### PR TITLE
Session continuity via sessionId chaining

### DIFF
--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -15,7 +15,7 @@ export interface Session {
   started_at: string | null;
   ended_at: string | null;
   message_count: number;
-  slug?: string;
+  parent_session_id?: string;
   file_path?: string;
   file_size?: number;
   file_mtime?: number;

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -15,6 +15,7 @@ export interface Session {
   started_at: string | null;
   ended_at: string | null;
   message_count: number;
+  slug?: string;
   file_path?: string;
   file_size?: number;
   file_mtime?: number;

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -5,9 +5,10 @@
 
   interface Props {
     session: Session;
+    continuationCount?: number;
   }
 
-  let { session }: Props = $props();
+  let { session, continuationCount = 1 }: Props = $props();
 
   let isActive = $derived(sessions.activeSessionId === session.id);
 
@@ -41,6 +42,9 @@
       <span class="session-project">{session.project}</span>
       <span class="session-time">{timeStr}</span>
       <span class="session-count">{session.message_count}</span>
+      {#if continuationCount > 1}
+        <span class="continuation-badge">x{continuationCount}</span>
+      {/if}
     </div>
   </div>
 </button>
@@ -116,5 +120,13 @@
 
   .session-count::before {
     content: "\2022 ";
+  }
+
+  .continuation-badge {
+    font-size: 9px;
+    font-weight: 600;
+    color: var(--accent-blue);
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 </style>

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -6,11 +6,22 @@
   interface Props {
     session: Session;
     continuationCount?: number;
+    groupSessionIds?: string[];
   }
 
-  let { session, continuationCount = 1 }: Props = $props();
+  let {
+    session,
+    continuationCount = 1,
+    groupSessionIds,
+  }: Props = $props();
 
-  let isActive = $derived(sessions.activeSessionId === session.id);
+  let isActive = $derived(
+    groupSessionIds
+      ? groupSessionIds.includes(
+          sessions.activeSessionId ?? "",
+        )
+      : sessions.activeSessionId === session.id,
+  );
 
   let agentColor = $derived(
     session.agent === "codex"

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -12,7 +12,8 @@
   let viewportHeight = $state(0);
   let scrollRaf: number | null = $state(null);
 
-  let totalCount = $derived(sessions.sessions.length);
+  let groups = $derived(sessions.groupedSessions);
+  let totalCount = $derived(groups.length);
 
   let startIndex = $derived(
     Math.max(
@@ -110,12 +111,18 @@
     style="height: {totalSize}px; width: 100%; position: relative;"
   >
     {#each virtualRows as row (row.key)}
-      {@const session = sessions.sessions[row.index]}
+      {@const group = groups[row.index]}
       <div
         style="position: absolute; top: 0; left: 0; width: 100%; height: {row.size}px; transform: translateY({row.start}px);"
       >
-        {#if session}
-          <SessionItem {session} />
+        {#if group}
+          {@const primary = group.sessions[group.sessions.length - 1]}
+          {#if primary}
+            <SessionItem
+              session={primary}
+              continuationCount={group.sessions.length}
+            />
+          {/if}
         {/if}
       </div>
     {/each}

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -116,11 +116,16 @@
         style="position: absolute; top: 0; left: 0; width: 100%; height: {row.size}px; transform: translateY({row.start}px);"
       >
         {#if group}
-          {@const primary = group.sessions[group.sessions.length - 1]}
+          {@const primary = group.sessions.find(
+            (s) => s.id === group.primarySessionId,
+          ) ?? group.sessions[0]}
           {#if primary}
             <SessionItem
               session={primary}
               continuationCount={group.sessions.length}
+              groupSessionIds={group.sessions.length > 1
+                ? group.sessions.map((s) => s.id)
+                : undefined}
             />
           {/if}
         {/if}

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -306,8 +306,18 @@ export function buildSessionGroups(
     }
     group.firstMessage =
       group.sessions[0]?.first_message ?? null;
+
+    let bestIdx = 0;
+    let bestEnd = group.sessions[0]?.ended_at ?? "";
+    for (let i = 1; i < group.sessions.length; i++) {
+      const end = group.sessions[i]?.ended_at ?? "";
+      if (end > bestEnd) {
+        bestEnd = end;
+        bestIdx = i;
+      }
+    }
     group.primarySessionId =
-      group.sessions[group.sessions.length - 1]!.id;
+      group.sessions[bestIdx]!.id;
   }
 
   return insertionOrder.map((k) => groupMap.get(k)!);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -259,6 +259,10 @@ function minString(
   return a < b ? a : b;
 }
 
+function recencyKey(s: Session): string {
+  return s.ended_at ?? s.started_at ?? s.created_at;
+}
+
 export function buildSessionGroups(
   sessions: Session[],
 ): SessionGroup[] {
@@ -308,11 +312,11 @@ export function buildSessionGroups(
       group.sessions[0]?.first_message ?? null;
 
     let bestIdx = 0;
-    let bestEnd = group.sessions[0]?.ended_at ?? "";
+    let bestKey = recencyKey(group.sessions[0]!);
     for (let i = 1; i < group.sessions.length; i++) {
-      const end = group.sessions[i]?.ended_at ?? "";
-      if (end > bestEnd) {
-        bestEnd = end;
+      const key = recencyKey(group.sessions[i]!);
+      if (key > bestKey) {
+        bestKey = key;
         bestIdx = i;
       }
     }

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -550,6 +550,50 @@ describe("buildSessionGroups", () => {
     expect(g.primarySessionId).toBe("s2");
   });
 
+  it("selects primary by ended_at not started_at", () => {
+    const sessions = [
+      makeSession({
+        id: "s1",
+        project: "proj",
+        slug: "abc",
+        started_at: "2024-01-01T00:00:00Z",
+        ended_at: "2024-01-01T05:00:00Z",
+      }),
+      makeSession({
+        id: "s2",
+        project: "proj",
+        slug: "abc",
+        started_at: "2024-01-02T00:00:00Z",
+        ended_at: "2024-01-02T01:00:00Z",
+      }),
+    ];
+
+    const groups = buildSessionGroups(sessions);
+    expect(groups[0]!.primarySessionId).toBe("s2");
+  });
+
+  it("selects primary by ended_at when started_at later", () => {
+    const sessions = [
+      makeSession({
+        id: "s1",
+        project: "proj",
+        slug: "abc",
+        started_at: "2024-01-02T00:00:00Z",
+        ended_at: "2024-01-02T01:00:00Z",
+      }),
+      makeSession({
+        id: "s2",
+        project: "proj",
+        slug: "abc",
+        started_at: "2024-01-01T00:00:00Z",
+        ended_at: "2024-01-03T00:00:00Z",
+      }),
+    ];
+
+    const groups = buildSessionGroups(sessions);
+    expect(groups[0]!.primarySessionId).toBe("s2");
+  });
+
   it("sorts sessions within group by startedAt asc", () => {
     const sessions = [
       makeSession({

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -209,10 +209,12 @@ func (db *DB) init() error {
 	); err != nil {
 		return fmt.Errorf("adding slug column: %w", err)
 	}
-	_, _ = db.writer.Exec(
+	if _, err := db.writer.Exec(
 		`CREATE INDEX IF NOT EXISTS idx_sessions_project_slug
 		 ON sessions(project, slug) WHERE slug IS NOT NULL`,
-	)
+	); err != nil {
+		return fmt.Errorf("creating slug index: %w", err)
+	}
 
 	return nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -222,19 +222,6 @@ func (db *DB) init() error {
 		)
 	}
 
-	// Force re-sync of Claude sessions that haven't been parsed
-	// for parent_session_id yet. Idempotent: on subsequent starts
-	// the WHERE matches 0 rows.
-	if _, err := db.writer.Exec(
-		`UPDATE sessions SET file_hash = NULL
-		 WHERE agent = 'claude'
-		   AND parent_session_id IS NULL`,
-	); err != nil {
-		return fmt.Errorf(
-			"clearing hashes for re-sync: %w", err,
-		)
-	}
-
 	return nil
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -202,6 +202,18 @@ func (db *DB) init() error {
 	); err != nil {
 		return fmt.Errorf("adding file_hash column: %w", err)
 	}
+
+	// Migration: add slug column for session continuity grouping.
+	if err := db.ensureColumn(
+		"sessions", "slug", "TEXT",
+	); err != nil {
+		return fmt.Errorf("adding slug column: %w", err)
+	}
+	_, _ = db.writer.Exec(
+		`CREATE INDEX IF NOT EXISTS idx_sessions_project_slug
+		 ON sessions(project, slug) WHERE slug IS NOT NULL`,
+	)
+
 	return nil
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -276,31 +276,33 @@ func TestSessionCRUD(t *testing.T) {
 	requireSessionGone(t, d, "nonexistent")
 }
 
-func TestSessionSlug(t *testing.T) {
+func TestSessionParentSessionID(t *testing.T) {
 	d := testDB(t)
 
-	t.Run("UpsertWithSlug", func(t *testing.T) {
-		insertSession(t, d, "slug-1", "proj", func(s *Session) {
-			s.Slug = Ptr("rippling-soaring-dijkstra")
+	t.Run("UpsertWithParent", func(t *testing.T) {
+		insertSession(t, d, "child-1", "proj", func(s *Session) {
+			s.ParentSessionID = Ptr("parent-uuid")
 		})
 
-		got := requireSessionExists(t, d, "slug-1")
-		if got.Slug == nil || *got.Slug != "rippling-soaring-dijkstra" {
-			t.Errorf("slug = %v, want %q",
-				got.Slug, "rippling-soaring-dijkstra")
+		got := requireSessionExists(t, d, "child-1")
+		if got.ParentSessionID == nil ||
+			*got.ParentSessionID != "parent-uuid" {
+			t.Errorf("parent_session_id = %v, want %q",
+				got.ParentSessionID, "parent-uuid")
 		}
 	})
 
-	t.Run("WithoutSlug", func(t *testing.T) {
-		insertSession(t, d, "slug-2", "proj")
+	t.Run("WithoutParent", func(t *testing.T) {
+		insertSession(t, d, "child-2", "proj")
 
-		got := requireSessionExists(t, d, "slug-2")
-		if got.Slug != nil {
-			t.Errorf("slug = %v, want nil", got.Slug)
+		got := requireSessionExists(t, d, "child-2")
+		if got.ParentSessionID != nil {
+			t.Errorf("parent_session_id = %v, want nil",
+				got.ParentSessionID)
 		}
 	})
 
-	t.Run("SlugInListSessions", func(t *testing.T) {
+	t.Run("ParentInListSessions", func(t *testing.T) {
 		page, err := d.ListSessions(
 			context.Background(),
 			filterWith(func(f *SessionFilter) {
@@ -312,22 +314,23 @@ func TestSessionSlug(t *testing.T) {
 		}
 		found := false
 		for _, s := range page.Sessions {
-			if s.ID == "slug-1" {
+			if s.ID == "child-1" {
 				found = true
-				if s.Slug == nil || *s.Slug != "rippling-soaring-dijkstra" {
-					t.Errorf("slug = %v, want %q",
-						s.Slug, "rippling-soaring-dijkstra")
+				if s.ParentSessionID == nil ||
+					*s.ParentSessionID != "parent-uuid" {
+					t.Errorf("parent_session_id = %v, want %q",
+						s.ParentSessionID, "parent-uuid")
 				}
 			}
 		}
 		if !found {
-			t.Error("slug-1 not found in list")
+			t.Error("child-1 not found in list")
 		}
 	})
 
-	t.Run("SlugInGetSessionFull", func(t *testing.T) {
+	t.Run("ParentInGetSessionFull", func(t *testing.T) {
 		got, err := d.GetSessionFull(
-			context.Background(), "slug-1",
+			context.Background(), "child-1",
 		)
 		if err != nil {
 			t.Fatalf("GetSessionFull: %v", err)
@@ -335,9 +338,10 @@ func TestSessionSlug(t *testing.T) {
 		if got == nil {
 			t.Fatal("session not found")
 		}
-		if got.Slug == nil || *got.Slug != "rippling-soaring-dijkstra" {
-			t.Errorf("slug = %v, want %q",
-				got.Slug, "rippling-soaring-dijkstra")
+		if got.ParentSessionID == nil ||
+			*got.ParentSessionID != "parent-uuid" {
+			t.Errorf("parent_session_id = %v, want %q",
+				got.ParentSessionID, "parent-uuid")
 		}
 	})
 }

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     file_size   INTEGER,
     file_mtime  INTEGER,
     file_hash   TEXT,
+    parent_session_id TEXT,
     created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
@@ -66,6 +67,10 @@ CREATE INDEX IF NOT EXISTS idx_messages_session_ordinal
     ON messages(session_id, ordinal);
 CREATE INDEX IF NOT EXISTS idx_messages_session_role
     ON messages(session_id, role);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_parent
+    ON sessions(parent_session_id)
+    WHERE parent_session_id IS NOT NULL;
 
 -- Analytics indexes
 CREATE INDEX IF NOT EXISTS idx_sessions_started

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -533,6 +533,11 @@ func (db *DB) FindPruneCandidates(
 		args = append(args, escapeLike(f.FirstMessage)+"%")
 	}
 
+	// Exclude sessions that are parents of other sessions.
+	where += ` AND NOT EXISTS (
+		SELECT 1 FROM sessions AS child
+		WHERE child.parent_session_id = sessions.id)`
+
 	query := "SELECT " + sessionPruneCols +
 		" FROM sessions WHERE " + where + `
 		ORDER BY COALESCE(

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -19,19 +19,19 @@ var ErrInvalidCursor = errors.New("invalid cursor")
 // (list, get). Keep in sync with scanSessionRow.
 const sessionBaseCols = `id, project, machine, agent,
 	first_message, started_at, ended_at,
-	message_count, created_at`
+	message_count, slug, created_at`
 
 // sessionPruneCols extends sessionBaseCols with file metadata
 // needed by FindPruneCandidates.
 const sessionPruneCols = `id, project, machine, agent,
 	first_message, started_at, ended_at,
-	message_count, file_path, file_size, created_at`
+	message_count, slug, file_path, file_size, created_at`
 
 // sessionFullCols includes all columns for a complete session record.
 const sessionFullCols = `id, project, machine, agent,
 	first_message, started_at, ended_at,
-	message_count, file_path, file_size, file_mtime, file_hash,
-	created_at`
+	message_count, slug, file_path, file_size, file_mtime,
+	file_hash, created_at`
 
 const (
 	// DefaultSessionLimit is the default number of sessions returned.
@@ -52,7 +52,7 @@ func scanSessionRow(rs rowScanner) (Session, error) {
 	err := rs.Scan(
 		&s.ID, &s.Project, &s.Machine, &s.Agent,
 		&s.FirstMessage, &s.StartedAt, &s.EndedAt,
-		&s.MessageCount, &s.CreatedAt,
+		&s.MessageCount, &s.Slug, &s.CreatedAt,
 	)
 	return s, err
 }
@@ -67,6 +67,7 @@ type Session struct {
 	StartedAt    *string `json:"started_at"`
 	EndedAt      *string `json:"ended_at"`
 	MessageCount int     `json:"message_count"`
+	Slug         *string `json:"slug,omitempty"`
 	FilePath     *string `json:"file_path,omitempty"`
 	FileSize     *int64  `json:"file_size,omitempty"`
 	FileMtime    *int64  `json:"file_mtime,omitempty"`
@@ -332,8 +333,8 @@ func (db *DB) GetSessionFull(
 	err := row.Scan(
 		&s.ID, &s.Project, &s.Machine, &s.Agent,
 		&s.FirstMessage, &s.StartedAt, &s.EndedAt,
-		&s.MessageCount, &s.FilePath, &s.FileSize, &s.FileMtime,
-		&s.FileHash, &s.CreatedAt,
+		&s.MessageCount, &s.Slug, &s.FilePath, &s.FileSize,
+		&s.FileMtime, &s.FileHash, &s.CreatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -352,9 +353,9 @@ func (db *DB) UpsertSession(s Session) error {
 	_, err := db.writer.Exec(`
 		INSERT INTO sessions (
 			id, project, machine, agent, first_message,
-			started_at, ended_at, message_count,
+			started_at, ended_at, message_count, slug,
 			file_path, file_size, file_mtime, file_hash
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project,
 			machine = excluded.machine,
@@ -363,12 +364,13 @@ func (db *DB) UpsertSession(s Session) error {
 			started_at = excluded.started_at,
 			ended_at = excluded.ended_at,
 			message_count = excluded.message_count,
+			slug = excluded.slug,
 			file_path = excluded.file_path,
 			file_size = excluded.file_size,
 			file_mtime = excluded.file_mtime,
 			file_hash = excluded.file_hash`,
 		s.ID, s.Project, s.Machine, s.Agent, s.FirstMessage,
-		s.StartedAt, s.EndedAt, s.MessageCount,
+		s.StartedAt, s.EndedAt, s.MessageCount, s.Slug,
 		s.FilePath, s.FileSize, s.FileMtime, s.FileHash)
 	if err != nil {
 		return fmt.Errorf("upserting session %s: %w", s.ID, err)
@@ -544,7 +546,7 @@ func (db *DB) FindPruneCandidates(
 		err := rows.Scan(
 			&s.ID, &s.Project, &s.Machine, &s.Agent,
 			&s.FirstMessage, &s.StartedAt, &s.EndedAt,
-			&s.MessageCount, &s.FilePath, &s.FileSize,
+			&s.MessageCount, &s.Slug, &s.FilePath, &s.FileSize,
 			&s.CreatedAt,
 		)
 		if err != nil {

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -36,6 +36,7 @@ func ParseClaudeSession(
 	var (
 		messages  []ParsedMessage
 		firstMsg  string
+		slug      string
 		startedAt time.Time
 		endedAt   time.Time
 		ordinal   int
@@ -76,6 +77,12 @@ func ParseClaudeSession(
 				startedAt = ts
 			}
 			endedAt = ts
+		}
+
+		if slug == "" {
+			if s := gjson.Get(line, "slug").Str; s != "" {
+				slug = s
+			}
 		}
 
 		entryType := gjson.Get(line, "type").Str
@@ -134,6 +141,7 @@ func ParseClaudeSession(
 		Project:      project,
 		Machine:      machine,
 		Agent:        AgentClaude,
+		Slug:         slug,
 		FirstMessage: firstMsg,
 		StartedAt:    startedAt,
 		EndedAt:      endedAt,

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -34,12 +34,13 @@ func ParseClaudeSession(
 	defer f.Close()
 
 	var (
-		messages  []ParsedMessage
-		firstMsg  string
-		slug      string
-		startedAt time.Time
-		endedAt   time.Time
-		ordinal   int
+		messages        []ParsedMessage
+		firstMsg        string
+		parentSessionID string
+		foundParentSID  bool
+		startedAt       time.Time
+		endedAt         time.Time
+		ordinal         int
 	)
 
 	scanner := bufio.NewScanner(f)
@@ -79,13 +80,17 @@ func ParseClaudeSession(
 			endedAt = ts
 		}
 
-		if slug == "" {
-			if s := gjson.Get(line, "slug").Str; s != "" {
-				slug = s
+		entryType := gjson.Get(line, "type").Str
+
+		if !foundParentSID &&
+			(entryType == "user" || entryType == "assistant") {
+			if sid := gjson.Get(line, "sessionId").Str; sid != "" {
+				foundParentSID = true
+				if sid != sessionID {
+					parentSessionID = sid
+				}
 			}
 		}
-
-		entryType := gjson.Get(line, "type").Str
 
 		if entryType == "user" || entryType == "assistant" {
 			// Tier 1: skip system-injected user entries by
@@ -137,15 +142,15 @@ func ParseClaudeSession(
 	}
 
 	sess := ParsedSession{
-		ID:           sessionID,
-		Project:      project,
-		Machine:      machine,
-		Agent:        AgentClaude,
-		Slug:         slug,
-		FirstMessage: firstMsg,
-		StartedAt:    startedAt,
-		EndedAt:      endedAt,
-		MessageCount: len(messages),
+		ID:              sessionID,
+		Project:         project,
+		Machine:         machine,
+		Agent:           AgentClaude,
+		ParentSessionID: parentSessionID,
+		FirstMessage:    firstMsg,
+		StartedAt:       startedAt,
+		EndedAt:         endedAt,
+		MessageCount:    len(messages),
 		File: FileInfo{
 			Path:  path,
 			Size:  info.Size(),

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -769,6 +769,49 @@ func TestParseClaudeSession(t *testing.T) {
 			},
 		},
 		{
+			name: "slug extracted from user record",
+			content: testjsonl.JoinJSONL(
+				testjsonl.ClaudeUserWithSlugJSON("hello", tsZero, "rippling-soaring-dijkstra"),
+				testjsonl.ClaudeAssistantJSON([]map[string]any{
+					{"type": "text", "text": "hi"},
+				}, tsZeroS1),
+			),
+			wantMsgCount: 2,
+			check: func(t *testing.T, sess ParsedSession, _ []ParsedMessage) {
+				t.Helper()
+				if sess.Slug != "rippling-soaring-dijkstra" {
+					t.Errorf("slug = %q, want %q",
+						sess.Slug, "rippling-soaring-dijkstra")
+				}
+			},
+		},
+		{
+			name: "no slug yields empty",
+			content: testjsonl.JoinJSONL(
+				testjsonl.ClaudeUserJSON("hello", tsZero),
+			),
+			wantMsgCount: 1,
+			check: func(t *testing.T, sess ParsedSession, _ []ParsedMessage) {
+				t.Helper()
+				if sess.Slug != "" {
+					t.Errorf("slug = %q, want empty", sess.Slug)
+				}
+			},
+		},
+		{
+			name: "slug extracted from non-user record",
+			content: `{"type":"system","timestamp":"` + tsZero + `","slug":"system-slug-test"}` + "\n" +
+				testjsonl.ClaudeUserJSON("hello", tsZeroS1) + "\n",
+			wantMsgCount: 1,
+			check: func(t *testing.T, sess ParsedSession, _ []ParsedMessage) {
+				t.Helper()
+				if sess.Slug != "system-slug-test" {
+					t.Errorf("slug = %q, want %q",
+						sess.Slug, "system-slug-test")
+				}
+			},
+		},
+		{
 			name: "assistant with system-like content not filtered",
 			content: testjsonl.JoinJSONL(
 				testjsonl.ClaudeUserJSON("hello", tsZero),

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -769,9 +769,11 @@ func TestParseClaudeSession(t *testing.T) {
 			},
 		},
 		{
-			name: "slug extracted from user record",
+			name: "sessionId != fileId sets ParentSessionID",
 			content: testjsonl.JoinJSONL(
-				testjsonl.ClaudeUserWithSlugJSON("hello", tsZero, "rippling-soaring-dijkstra"),
+				testjsonl.ClaudeUserWithSessionIDJSON(
+					"hello", tsZero, "parent-uuid",
+				),
 				testjsonl.ClaudeAssistantJSON([]map[string]any{
 					{"type": "text", "text": "hi"},
 				}, tsZeroS1),
@@ -779,35 +781,43 @@ func TestParseClaudeSession(t *testing.T) {
 			wantMsgCount: 2,
 			check: func(t *testing.T, sess ParsedSession, _ []ParsedMessage) {
 				t.Helper()
-				if sess.Slug != "rippling-soaring-dijkstra" {
-					t.Errorf("slug = %q, want %q",
-						sess.Slug, "rippling-soaring-dijkstra")
+				if sess.ParentSessionID != "parent-uuid" {
+					t.Errorf("ParentSessionID = %q, want %q",
+						sess.ParentSessionID, "parent-uuid")
 				}
 			},
 		},
 		{
-			name: "no slug yields empty",
+			name: "sessionId == fileId yields empty ParentSessionID",
+			content: testjsonl.JoinJSONL(
+				testjsonl.ClaudeUserWithSessionIDJSON(
+					"hello", tsZero, "test",
+				),
+			),
+			wantMsgCount: 1,
+			check: func(t *testing.T, sess ParsedSession, _ []ParsedMessage) {
+				t.Helper()
+				if sess.ParentSessionID != "" {
+					t.Errorf(
+						"ParentSessionID = %q, want empty",
+						sess.ParentSessionID,
+					)
+				}
+			},
+		},
+		{
+			name: "no sessionId field yields empty ParentSessionID",
 			content: testjsonl.JoinJSONL(
 				testjsonl.ClaudeUserJSON("hello", tsZero),
 			),
 			wantMsgCount: 1,
 			check: func(t *testing.T, sess ParsedSession, _ []ParsedMessage) {
 				t.Helper()
-				if sess.Slug != "" {
-					t.Errorf("slug = %q, want empty", sess.Slug)
-				}
-			},
-		},
-		{
-			name: "slug extracted from non-user record",
-			content: `{"type":"system","timestamp":"` + tsZero + `","slug":"system-slug-test"}` + "\n" +
-				testjsonl.ClaudeUserJSON("hello", tsZeroS1) + "\n",
-			wantMsgCount: 1,
-			check: func(t *testing.T, sess ParsedSession, _ []ParsedMessage) {
-				t.Helper()
-				if sess.Slug != "system-slug-test" {
-					t.Errorf("slug = %q, want %q",
-						sess.Slug, "system-slug-test")
+				if sess.ParentSessionID != "" {
+					t.Errorf(
+						"ParentSessionID = %q, want empty",
+						sess.ParentSessionID,
+					)
 				}
 			},
 		},

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -29,16 +29,16 @@ type FileInfo struct {
 
 // ParsedSession holds session metadata extracted from a JSONL file.
 type ParsedSession struct {
-	ID           string
-	Project      string
-	Machine      string
-	Agent        AgentType
-	Slug         string
-	FirstMessage string
-	StartedAt    time.Time
-	EndedAt      time.Time
-	MessageCount int
-	File         FileInfo
+	ID              string
+	Project         string
+	Machine         string
+	Agent           AgentType
+	ParentSessionID string
+	FirstMessage    string
+	StartedAt       time.Time
+	EndedAt         time.Time
+	MessageCount    int
+	File            FileInfo
 }
 
 // ParsedToolCall holds a single tool invocation extracted from

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -33,6 +33,7 @@ type ParsedSession struct {
 	Project      string
 	Machine      string
 	Agent        AgentType
+	Slug         string
 	FirstMessage string
 	StartedAt    time.Time
 	EndedAt      time.Time

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -525,6 +525,7 @@ func (e *Engine) writeBatch(batch []pendingWrite) {
 			Machine:      pw.sess.Machine,
 			Agent:        string(pw.sess.Agent),
 			MessageCount: pw.sess.MessageCount,
+			Slug:         strPtr(pw.sess.Slug),
 			FilePath:     strPtr(pw.sess.File.Path),
 			FileSize:     int64Ptr(pw.sess.File.Size),
 			FileMtime:    int64Ptr(pw.sess.File.Mtime),

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -520,16 +520,16 @@ type pendingWrite struct {
 func (e *Engine) writeBatch(batch []pendingWrite) {
 	for _, pw := range batch {
 		s := db.Session{
-			ID:           pw.sess.ID,
-			Project:      pw.sess.Project,
-			Machine:      pw.sess.Machine,
-			Agent:        string(pw.sess.Agent),
-			MessageCount: pw.sess.MessageCount,
-			Slug:         strPtr(pw.sess.Slug),
-			FilePath:     strPtr(pw.sess.File.Path),
-			FileSize:     int64Ptr(pw.sess.File.Size),
-			FileMtime:    int64Ptr(pw.sess.File.Mtime),
-			FileHash:     strPtr(pw.sess.File.Hash),
+			ID:              pw.sess.ID,
+			Project:         pw.sess.Project,
+			Machine:         pw.sess.Machine,
+			Agent:           string(pw.sess.Agent),
+			MessageCount:    pw.sess.MessageCount,
+			ParentSessionID: strPtr(pw.sess.ParentSessionID),
+			FilePath:        strPtr(pw.sess.File.Path),
+			FileSize:        int64Ptr(pw.sess.File.Size),
+			FileMtime:       int64Ptr(pw.sess.File.Mtime),
+			FileHash:        strPtr(pw.sess.File.Hash),
 		}
 		if pw.sess.FirstMessage != "" {
 			s.FirstMessage = &pw.sess.FirstMessage

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -824,6 +824,57 @@ func TestSyncPathsStatsUpdated(t *testing.T) {
 	}
 }
 
+func TestSyncPathsClaudeSlug(t *testing.T) {
+	env := setupTestEnv(t)
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithSlug(
+			tsZero, "Hello", "rippling-soaring-dijkstra",
+		).
+		AddClaudeAssistant(tsZeroS5, "Hi there!").
+		String()
+
+	path := env.writeClaudeSession(
+		t, "test-proj", "slug-test.jsonl", content,
+	)
+
+	env.engine.SyncPaths([]string{path})
+
+	assertSessionState(
+		t, env.db, "slug-test",
+		func(sess *db.Session) {
+			if sess.Slug == nil ||
+				*sess.Slug != "rippling-soaring-dijkstra" {
+				t.Errorf("slug = %v, want %q",
+					sess.Slug, "rippling-soaring-dijkstra")
+			}
+		},
+	)
+}
+
+func TestSyncPathsClaudeNoSlug(t *testing.T) {
+	env := setupTestEnv(t)
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "Hello").
+		String()
+
+	path := env.writeClaudeSession(
+		t, "test-proj", "no-slug-test.jsonl", content,
+	)
+
+	env.engine.SyncPaths([]string{path})
+
+	assertSessionState(
+		t, env.db, "no-slug-test",
+		func(sess *db.Session) {
+			if sess.Slug != nil {
+				t.Errorf("slug = %v, want nil", sess.Slug)
+			}
+		},
+	)
+}
+
 func TestSyncPathsClaudeRejectsNested(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -824,35 +824,35 @@ func TestSyncPathsStatsUpdated(t *testing.T) {
 	}
 }
 
-func TestSyncPathsClaudeSlug(t *testing.T) {
+func TestSyncPathsClaudeParentSessionID(t *testing.T) {
 	env := setupTestEnv(t)
 
 	content := testjsonl.NewSessionBuilder().
-		AddClaudeUserWithSlug(
-			tsZero, "Hello", "rippling-soaring-dijkstra",
+		AddClaudeUserWithSessionID(
+			tsZero, "Hello", "parent-uuid",
 		).
 		AddClaudeAssistant(tsZeroS5, "Hi there!").
 		String()
 
 	path := env.writeClaudeSession(
-		t, "test-proj", "slug-test.jsonl", content,
+		t, "test-proj", "child-test.jsonl", content,
 	)
 
 	env.engine.SyncPaths([]string{path})
 
 	assertSessionState(
-		t, env.db, "slug-test",
+		t, env.db, "child-test",
 		func(sess *db.Session) {
-			if sess.Slug == nil ||
-				*sess.Slug != "rippling-soaring-dijkstra" {
-				t.Errorf("slug = %v, want %q",
-					sess.Slug, "rippling-soaring-dijkstra")
+			if sess.ParentSessionID == nil ||
+				*sess.ParentSessionID != "parent-uuid" {
+				t.Errorf("parent_session_id = %v, want %q",
+					sess.ParentSessionID, "parent-uuid")
 			}
 		},
 	)
 }
 
-func TestSyncPathsClaudeNoSlug(t *testing.T) {
+func TestSyncPathsClaudeNoParentSessionID(t *testing.T) {
 	env := setupTestEnv(t)
 
 	content := testjsonl.NewSessionBuilder().
@@ -860,16 +860,17 @@ func TestSyncPathsClaudeNoSlug(t *testing.T) {
 		String()
 
 	path := env.writeClaudeSession(
-		t, "test-proj", "no-slug-test.jsonl", content,
+		t, "test-proj", "no-parent-test.jsonl", content,
 	)
 
 	env.engine.SyncPaths([]string{path})
 
 	assertSessionState(
-		t, env.db, "no-slug-test",
+		t, env.db, "no-parent-test",
 		func(sess *db.Session) {
-			if sess.Slug != nil {
-				t.Errorf("slug = %v, want nil", sess.Slug)
+			if sess.ParentSessionID != nil {
+				t.Errorf("parent_session_id = %v, want nil",
+					sess.ParentSessionID)
 			}
 		},
 	)

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -25,6 +25,25 @@ func ClaudeUserJSON(
 	return mustMarshal(m)
 }
 
+// ClaudeUserWithSlugJSON returns a Claude user message with
+// a slug field as a JSON string.
+func ClaudeUserWithSlugJSON(
+	content, timestamp, slug string, cwd ...string,
+) string {
+	m := map[string]any{
+		"type":      "user",
+		"timestamp": timestamp,
+		"slug":      slug,
+		"message": map[string]any{
+			"content": content,
+		},
+	}
+	if len(cwd) > 0 {
+		m["cwd"] = cwd[0]
+	}
+	return mustMarshal(m)
+}
+
 // ClaudeMetaUserJSON returns a Claude user message with
 // optional isMeta and isCompactSummary flags as a JSON string.
 func ClaudeMetaUserJSON(
@@ -200,6 +219,18 @@ func (b *SessionBuilder) AddClaudeUser(
 	timestamp, content string, cwd ...string,
 ) *SessionBuilder {
 	b.lines = append(b.lines, ClaudeUserJSON(content, timestamp, cwd...))
+	return b
+}
+
+// AddClaudeUserWithSlug appends a Claude user message line
+// with a slug field.
+func (b *SessionBuilder) AddClaudeUserWithSlug(
+	timestamp, content, slug string, cwd ...string,
+) *SessionBuilder {
+	b.lines = append(
+		b.lines,
+		ClaudeUserWithSlugJSON(content, timestamp, slug, cwd...),
+	)
 	return b
 }
 

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -25,15 +25,15 @@ func ClaudeUserJSON(
 	return mustMarshal(m)
 }
 
-// ClaudeUserWithSlugJSON returns a Claude user message with
-// a slug field as a JSON string.
-func ClaudeUserWithSlugJSON(
-	content, timestamp, slug string, cwd ...string,
+// ClaudeUserWithSessionIDJSON returns a Claude user message
+// with a sessionId field as a JSON string.
+func ClaudeUserWithSessionIDJSON(
+	content, timestamp, sessionID string, cwd ...string,
 ) string {
 	m := map[string]any{
 		"type":      "user",
 		"timestamp": timestamp,
-		"slug":      slug,
+		"sessionId": sessionID,
 		"message": map[string]any{
 			"content": content,
 		},
@@ -222,14 +222,16 @@ func (b *SessionBuilder) AddClaudeUser(
 	return b
 }
 
-// AddClaudeUserWithSlug appends a Claude user message line
-// with a slug field.
-func (b *SessionBuilder) AddClaudeUserWithSlug(
-	timestamp, content, slug string, cwd ...string,
+// AddClaudeUserWithSessionID appends a Claude user message
+// line with a sessionId field.
+func (b *SessionBuilder) AddClaudeUserWithSessionID(
+	timestamp, content, sessionID string, cwd ...string,
 ) *SessionBuilder {
 	b.lines = append(
 		b.lines,
-		ClaudeUserWithSlugJSON(content, timestamp, slug, cwd...),
+		ClaudeUserWithSessionIDJSON(
+			content, timestamp, sessionID, cwd...,
+		),
 	)
 	return b
 }


### PR DESCRIPTION
## Summary

- Group continuation sessions with their originals via `parent_session_id` chaining, extracted from Claude JSONL `sessionId` fields
- Frontend walks `parent_session_id` chains to find root sessions and groups all sessions sharing the same root
- Prune command excludes sessions that have children to avoid breaking continuity chains
- Old databases (missing `parent_session_id` column) are dropped and rebuilt from scratch on startup

## How it works

Claude JSONL files have a `sessionId` field on user/assistant records. For original sessions, `sessionId` matches the file's UUID. For continuations, it carries the parent file's UUID, forming a linked list (A -> B -> C). The parser extracts this and stores it as `parent_session_id`. The frontend walks the chain to find the root and groups all sessions sharing the same root.

## Test plan

- [x] `go vet ./... && go test -tags fts5 ./...` -- all pass
- [x] `cd frontend && npx vitest run` -- all 318 tests pass
- [ ] Manual: delete DB, restart agentsview, verify continuation sessions group under original with correct first message