### PR TITLE
fix: embed IANA timezone database for Windows support

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/wesm/agentsview/internal/config"
 	"github.com/wesm/agentsview/internal/db"

--- a/internal/server/analytics_test.go
+++ b/internal/server/analytics_test.go
@@ -84,6 +84,13 @@ func TestAnalyticsSummary(t *testing.T) {
 		// Should not error — defaults to last 30 days
 	})
 
+	t.Run("NonUTCTimezone", func(t *testing.T) {
+		w := te.get(t,
+			"/api/v1/analytics/summary"+
+				analyticsRange+"&timezone=America/New_York")
+		assertStatus(t, w, http.StatusOK)
+	})
+
 	t.Run("InvalidTimezone", func(t *testing.T) {
 		w := te.get(t,
 			"/api/v1/analytics/summary?timezone=Fake/Zone")


### PR DESCRIPTION
## Summary

- Import `time/tzdata` in `cmd/agentsview/main.go` to embed the IANA timezone database in the binary (~450KB)
- `time.LoadLocation` fails on Windows release builds (built with `-trimpath`) for any non-UTC timezone, breaking all analytics endpoints
- Add non-UTC timezone test case (`America/New_York`) to catch regressions

Closes #13

## Test plan
- [x] All Go tests pass (`CGO_ENABLED=1 go test -tags fts5 ./...`)
- [x] `NonUTCTimezone` test exercises `America/New_York` through the analytics handler
- [x] Windows CI already in test matrix (`windows-latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)