### PR TITLE
fix: skip oversized JSONL lines instead of failing the session

### DIFF
--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,6 +191,9 @@ func ExtractClaudeProjectHints(
 				return cwd, gitBranch
 			}
 		}
+	}
+	if err := lr.Err(); err != nil {
+		log.Printf("reading hints from %s: %v", path, err)
 	}
 	return cwd, gitBranch
 }

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -133,6 +133,11 @@ func ParseClaudeSession(
 		}
 	}
 
+	if err := lr.Err(); err != nil {
+		return ParsedSession{}, nil,
+			fmt.Errorf("reading %s: %w", path, err)
+	}
+
 	sess := ParsedSession{
 		ID:              sessionID,
 		Project:         project,

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -519,6 +519,11 @@ func ParseCodexSession(
 		}
 	}
 
+	if err := lr.Err(); err != nil {
+		return nil, nil,
+			fmt.Errorf("reading codex %s: %w", path, err)
+	}
+
 	sessionID := b.sessionID
 	if sessionID == "" {
 		sessionID = strings.TrimSuffix(

--- a/internal/parser/linereader.go
+++ b/internal/parser/linereader.go
@@ -7,11 +7,13 @@ import (
 
 // lineReader reads JSONL files line by line, skipping lines that
 // exceed maxLen rather than aborting. The buffer starts small and
-// grows on demand up to maxLen.
+// grows on demand up to maxLen. After iteration, call Err() to
+// check for I/O errors (as opposed to normal EOF).
 type lineReader struct {
 	r      *bufio.Reader
 	maxLen int
 	buf    []byte
+	err    error
 }
 
 func newLineReader(r io.Reader, maxLen int) *lineReader {
@@ -23,12 +25,15 @@ func newLineReader(r io.Reader, maxLen int) *lineReader {
 }
 
 // next returns the next line (without trailing newline) and true,
-// or ("", false) at EOF. Lines exceeding maxLen are silently
-// skipped.
+// or ("", false) at EOF or read error. After the loop, call Err()
+// to distinguish EOF from I/O failure.
 func (lr *lineReader) next() (string, bool) {
 	for {
 		line, err := lr.readLine()
 		if err != nil {
+			if err != io.EOF {
+				lr.err = err
+			}
 			return "", false
 		}
 		if line != "" {
@@ -36,6 +41,11 @@ func (lr *lineReader) next() (string, bool) {
 		}
 		// Empty line or skipped oversized line — continue.
 	}
+}
+
+// Err returns the first non-EOF read error encountered, or nil.
+func (lr *lineReader) Err() error {
+	return lr.err
 }
 
 // readLine reads a full line, returning "" for blank/oversized

--- a/internal/parser/linereader.go
+++ b/internal/parser/linereader.go
@@ -1,0 +1,80 @@
+package parser
+
+import (
+	"bufio"
+	"io"
+)
+
+// lineReader reads JSONL files line by line, skipping lines that
+// exceed maxLen rather than aborting. The buffer starts small and
+// grows on demand up to maxLen.
+type lineReader struct {
+	r      *bufio.Reader
+	maxLen int
+	buf    []byte
+}
+
+func newLineReader(r io.Reader, maxLen int) *lineReader {
+	return &lineReader{
+		r:      bufio.NewReaderSize(r, initialScanBufSize),
+		maxLen: maxLen,
+		buf:    make([]byte, 0, initialScanBufSize),
+	}
+}
+
+// next returns the next line (without trailing newline) and true,
+// or ("", false) at EOF. Lines exceeding maxLen are silently
+// skipped.
+func (lr *lineReader) next() (string, bool) {
+	for {
+		line, err := lr.readLine()
+		if err != nil {
+			return "", false
+		}
+		if line != "" {
+			return line, true
+		}
+		// Empty line or skipped oversized line — continue.
+	}
+}
+
+// readLine reads a full line, returning "" for blank/oversized
+// lines and a non-nil error only at EOF or read failure.
+func (lr *lineReader) readLine() (string, error) {
+	lr.buf = lr.buf[:0]
+	oversized := false
+
+	for {
+		chunk, isPrefix, err := lr.r.ReadLine()
+		if err != nil {
+			if len(lr.buf) > 0 && err == io.EOF {
+				break
+			}
+			return "", err
+		}
+
+		if oversized {
+			if !isPrefix {
+				return "", nil // done skipping
+			}
+			continue
+		}
+
+		lr.buf = append(lr.buf, chunk...)
+
+		if len(lr.buf) > lr.maxLen {
+			oversized = true
+			lr.buf = lr.buf[:0]
+			if !isPrefix {
+				return "", nil
+			}
+			continue
+		}
+
+		if !isPrefix {
+			break
+		}
+	}
+
+	return string(lr.buf), nil
+}


### PR DESCRIPTION
## Summary

- Replace `bufio.Scanner` with a custom `lineReader` that uses `bufio.Reader.ReadLine()` to skip lines exceeding 64MB instead of aborting the entire session parse
- Propagate I/O errors through `lineReader.Err()` (matching `bufio.Scanner` pattern) rather than silently swallowing them
- Replace all three scan sites (Claude parser, Claude hints extractor, Codex parser)

Closes #12

## Test plan

- [x] `TestLineReader` — normal lines, oversized skip, all oversized, empty input, blank lines, no trailing newline, exact limit, one over limit
- [x] `TestLineReaderIOError` — custom `io.Reader` that yields data then returns a non-EOF error; verifies lines are returned and `Err()` exposes the I/O error
- [x] `TestParseCodexSessionOversizedLineSkipped` — integration test placing an oversized line between normal JSONL entries
- [x] All Go tests pass (`CGO_ENABLED=1 go test -tags fts5 ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)