### PR TITLE
fix: sync performance, startup logging, and insights fixes

### DIFF
--- a/frontend/src/lib/stores/insights.svelte.ts
+++ b/frontend/src/lib/stores/insights.svelte.ts
@@ -62,9 +62,7 @@ class InsightsStore {
     const v = ++this.#version;
     this.loading = true;
     try {
-      const res = await listInsights({
-        project: this.project || undefined,
-      });
+      const res = await listInsights();
       if (this.#version === v) {
         this.items = res.insights;
         if (

--- a/frontend/src/lib/stores/insights.svelte.ts
+++ b/frontend/src/lib/stores/insights.svelte.ts
@@ -99,8 +99,6 @@ class InsightsStore {
 
   setProject(project: string) {
     this.project = project;
-    this.selectedId = null;
-    this.load();
   }
 
   setAgent(agent: AgentName) {

--- a/frontend/src/lib/stores/insights.test.ts
+++ b/frontend/src/lib/stores/insights.test.ts
@@ -59,9 +59,7 @@ describe("load", () => {
 
     await insights.load();
 
-    expect(api.listInsights).toHaveBeenCalledWith({
-      project: undefined,
-    });
+    expect(api.listInsights).toHaveBeenCalledWith();
     expect(insights.items).toHaveLength(2);
     expect(insights.loading).toBe(false);
   });
@@ -176,15 +174,11 @@ describe("date range mode switching", () => {
 });
 
 describe("setProject", () => {
-  it("updates project and reloads", async () => {
-    vi.mocked(api.listInsights).mockResolvedValueOnce({
-      insights: [],
-    });
-
+  it("updates project without reloading", () => {
     insights.setProject("my-app");
 
     expect(insights.project).toBe("my-app");
-    expect(api.listInsights).toHaveBeenCalled();
+    expect(api.listInsights).not.toHaveBeenCalled();
   });
 });
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1167,15 +1167,15 @@ func TestSessionFileInfo(t *testing.T) {
 		s.FileHash = Ptr("abc123def456")
 	})
 
-	gotSize, gotHash, ok := d.GetSessionFileInfo("s1")
+	gotSize, gotMtime, ok := d.GetSessionFileInfo("s1")
 	if !ok {
 		t.Fatal("expected ok")
 	}
 	if gotSize != 1024 {
 		t.Errorf("got size=%d, want 1024", gotSize)
 	}
-	if gotHash != "abc123def456" {
-		t.Errorf("got hash=%q, want %q", gotHash, "abc123def456")
+	if gotMtime != 1700000000 {
+		t.Errorf("got mtime=%d, want 1700000000", gotMtime)
 	}
 
 	_, _, ok = d.GetSessionFileInfo("nonexistent")

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -72,6 +72,10 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent
     ON sessions(parent_session_id)
     WHERE parent_session_id IS NOT NULL;
 
+CREATE INDEX IF NOT EXISTS idx_sessions_file_path
+    ON sessions(file_path)
+    WHERE file_path IS NOT NULL;
+
 -- Analytics indexes
 CREATE INDEX IF NOT EXISTS idx_sessions_started
     ON sessions(started_at);

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -408,7 +408,8 @@ func (db *DB) GetFileInfoByPath(
 	var s, m sql.NullInt64
 	err := db.reader.QueryRow(
 		"SELECT file_size, file_mtime FROM sessions"+
-			" WHERE file_path = ?",
+			" WHERE file_path = ?"+
+			" ORDER BY file_mtime DESC LIMIT 1",
 		path,
 	).Scan(&s, &m)
 	if err != nil || !s.Valid {

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -130,31 +130,32 @@ func generateClaude(
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
-		return Result{}, fmt.Errorf(
-			"claude CLI failed: %w\nstderr: %s",
-			err, stderr.String(),
-		)
-	}
+	runErr := cmd.Run()
 
 	var resp struct {
 		Result string `json:"result"`
 		Model  string `json:"model"`
 	}
-	if err := json.Unmarshal(
-		stdout.Bytes(), &resp,
-	); err != nil {
+	if json.Unmarshal(stdout.Bytes(), &resp) == nil &&
+		strings.TrimSpace(resp.Result) != "" {
+		return Result{
+			Content: resp.Result,
+			Agent:   "claude",
+			Model:   resp.Model,
+		}, nil
+	}
+
+	if runErr != nil {
 		return Result{}, fmt.Errorf(
-			"parsing claude output: %w\nraw: %s",
-			err, stdout.String(),
+			"claude CLI failed: %w\nstderr: %s",
+			runErr, stderr.String(),
 		)
 	}
 
-	return Result{
-		Content: resp.Result,
-		Agent:   "claude",
-		Model:   resp.Model,
-	}, nil
+	return Result{}, fmt.Errorf(
+		"claude returned empty result\nraw: %s",
+		stdout.String(),
+	)
 }
 
 // generateCodex invokes `codex exec` in read-only sandbox

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -132,6 +132,13 @@ func generateClaude(
 
 	runErr := cmd.Run()
 
+	// Honor context cancellation even if stdout has data.
+	if ctx.Err() != nil {
+		return Result{}, fmt.Errorf(
+			"claude CLI cancelled: %w", ctx.Err(),
+		)
+	}
+
 	var resp struct {
 		Result string `json:"result"`
 		Model  string `json:"model"`

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -388,3 +388,21 @@ func TestGenerateClaude_SalvageOnNonZeroExit(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateClaude_CancelledContext(t *testing.T) {
+	bin := fakeClaudeBin(
+		t, `{"result":"OK","model":"m1"}`, 0,
+	)
+	ctx, cancel := context.WithCancel(
+		context.Background(),
+	)
+	cancel() // cancel before invocation
+
+	_, err := generateClaude(ctx, bin, "test")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+	if !strings.Contains(err.Error(), "cancel") {
+		t.Errorf("error = %q, want cancel", err)
+	}
+}

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -1,6 +1,10 @@
 package insight
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -255,5 +259,115 @@ func TestValidAgents(t *testing.T) {
 	}
 	if ValidAgents["gpt"] {
 		t.Error("gpt should not be valid")
+	}
+}
+
+// fakeClaudeBin writes a shell script that prints the given
+// stdout and exits with the given code, ignoring all flags.
+func fakeClaudeBin(
+	t *testing.T, stdout string, exitCode int,
+) string {
+	t.Helper()
+	dir := t.TempDir()
+	dataFile := filepath.Join(dir, "stdout.txt")
+	if err := os.WriteFile(
+		dataFile, []byte(stdout), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "claude")
+	script := fmt.Sprintf(
+		"#!/bin/sh\ncat %s\nexit %d\n",
+		shellQuote(dataFile), exitCode,
+	)
+	if err := os.WriteFile(
+		bin, []byte(script), 0o755,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func TestGenerateClaude_SalvageOnNonZeroExit(t *testing.T) {
+	tests := []struct {
+		name       string
+		stdout     string
+		exitCode   int
+		wantResult string
+		wantErr    bool
+	}{
+		{
+			name:       "non-zero exit with valid result",
+			stdout:     `{"result":"# Analysis\nDone.","model":"m1"}`,
+			exitCode:   1,
+			wantResult: "# Analysis\nDone.",
+		},
+		{
+			name:     "non-zero exit with empty result",
+			stdout:   `{"result":"","model":"m1"}`,
+			exitCode: 1,
+			wantErr:  true,
+		},
+		{
+			name:     "non-zero exit with invalid JSON",
+			stdout:   `not json`,
+			exitCode: 1,
+			wantErr:  true,
+		},
+		{
+			name:     "non-zero exit with no stdout",
+			stdout:   "",
+			exitCode: 1,
+			wantErr:  true,
+		},
+		{
+			name:       "zero exit with valid result",
+			stdout:     `{"result":"OK","model":"m2"}`,
+			exitCode:   0,
+			wantResult: "OK",
+		},
+		{
+			name:     "zero exit with empty result",
+			stdout:   `{"result":"","model":"m2"}`,
+			exitCode: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bin := fakeClaudeBin(
+				t, tt.stdout, tt.exitCode,
+			)
+			result, err := generateClaude(
+				context.Background(), bin, "test",
+			)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Content != tt.wantResult {
+				t.Errorf(
+					"content = %q, want %q",
+					result.Content, tt.wantResult,
+				)
+			}
+			if result.Agent != "claude" {
+				t.Errorf(
+					"agent = %q, want claude",
+					result.Agent,
+				)
+			}
+		})
 	}
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -221,6 +221,7 @@ func (e *Engine) classifyOnePath(
 
 // SyncAll discovers and syncs all session files from all agents.
 func (e *Engine) SyncAll(onProgress ProgressFunc) SyncStats {
+	t0 := time.Now()
 	claude := DiscoverClaudeProjects(e.claudeDir)
 	codex := DiscoverCodexSessions(e.codexDir)
 	gemini := DiscoverGeminiSessions(e.geminiDir)
@@ -232,6 +233,12 @@ func (e *Engine) SyncAll(onProgress ProgressFunc) SyncStats {
 	all = append(all, claude...)
 	all = append(all, codex...)
 	all = append(all, gemini...)
+
+	log.Printf(
+		"discovered %d files (%d claude, %d codex, %d gemini) in %s",
+		len(all), len(claude), len(codex), len(gemini),
+		time.Since(t0).Round(time.Millisecond),
+	)
 
 	if onProgress != nil {
 		onProgress(Progress{

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -51,9 +51,11 @@ func NewWatcher(
 }
 
 // WatchRecursive walks a directory tree and adds all
-// subdirectories to the watch list.
-func (w *Watcher) WatchRecursive(root string) error {
-	return filepath.WalkDir(root,
+// subdirectories to the watch list. Returns the number
+// of directories added.
+func (w *Watcher) WatchRecursive(root string) (int, error) {
+	var count int
+	err := filepath.WalkDir(root,
 		func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return nil // skip inaccessible dirs
@@ -64,10 +66,13 @@ func (w *Watcher) WatchRecursive(root string) error {
 						"watcher: cannot watch %s: %v",
 						path, addErr,
 					)
+				} else {
+					count++
 				}
 			}
 			return nil
 		})
+	return count, err
 }
 
 // Start begins processing file events in a goroutine.

--- a/internal/sync/watcher_test.go
+++ b/internal/sync/watcher_test.go
@@ -24,7 +24,7 @@ func startTestWatcherNoCleanup(
 	if err != nil {
 		t.Fatalf("NewWatcher: %v", err)
 	}
-	if err := w.WatchRecursive(dir); err != nil {
+	if _, err := w.WatchRecursive(dir); err != nil {
 		t.Fatalf("WatchRecursive: %v", err)
 	}
 	w.Start()


### PR DESCRIPTION
## Summary

- **Sync performance**: Replace SHA-256 hash skip check with file_size + file_mtime comparison, add path-based DB lookup for codex/gemini files, and cache non-interactive session results. Reduces sync from ~14s to sub-second for unchanged sessions with 7000+ files.
- **Startup logging**: Add timing to each startup phase (discovery, sync, file watcher, total) so it's clear where time is spent.
- **Insights filtering**: Stop filtering insights list by project so global insights remain visible when a project is selected.
- **CLI failure recovery**: Try parsing claude CLI stdout before checking exit status, so insights are captured when the CLI exits non-zero but produced valid output.

## Test plan

- [ ] `CGO_ENABLED=1 go test -tags fts5 ./...` passes
- [ ] `npx tsc --noEmit` passes in frontend
- [ ] Start agentsview with large session count, verify timing logs appear and startup is faster on second run
- [ ] Generate insight with project filter active, verify global insights stay visible
- [ ] Verify insights still generate and save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)