### PR TITLE
fix: gate ctx.Err() check on runErr in salvage path

### DIFF
--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -132,8 +132,11 @@ func generateClaude(
 
 	runErr := cmd.Run()
 
-	// Honor context cancellation even if stdout has data.
-	if ctx.Err() != nil {
+	// Honor context cancellation over salvaging stdout, but
+	// only when the command actually failed. A successful
+	// cmd.Run with a race-y post-completion cancel should
+	// still return the valid result.
+	if runErr != nil && ctx.Err() != nil {
 		return Result{}, fmt.Errorf(
 			"claude CLI cancelled: %w", ctx.Err(),
 		)


### PR DESCRIPTION
## Summary
- Gate the cancellation check in `generateClaude` on `runErr != nil` so a successful `cmd.Run` followed by a post-completion context cancel doesn't discard a valid result

## Test plan
- [x] Existing `TestGenerateClaude_CancelledContext` passes (pre-cancelled context still errors)
- [x] `TestGenerateClaude_SalvageOnNonZeroExit` passes (salvage behavior preserved)
- [x] Full `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)