### PR TITLE
Fix app freeze on empty search results

### DIFF
--- a/frontend/src/lib/stores/search.svelte.ts
+++ b/frontend/src/lib/stores/search.svelte.ts
@@ -56,7 +56,7 @@ class SearchStore {
         { project: project || undefined, limit: 30 },
         { signal },
       );
-      this.results = res.results;
+      this.results = res.results ?? [];
     } catch (error: unknown) {
       if (error instanceof DOMException
         && error.name === "AbortError") {

--- a/internal/server/search.go
+++ b/internal/server/search.go
@@ -68,10 +68,14 @@ func (s *Server) handleSearch(
 		return
 	}
 
+	results := page.Results
+	if results == nil {
+		results = []db.SearchResult{}
+	}
 	writeJSON(w, http.StatusOK, searchResponse{
 		Query:   query,
-		Results: page.Results,
-		Count:   len(page.Results),
+		Results: results,
+		Count:   len(results),
 		Next:    page.NextCursor,
 	})
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -894,6 +894,26 @@ func TestSearch_DeadlineExceeded(t *testing.T) {
 	assertTimeoutRace(t, w)
 }
 
+func TestSearch_ZeroResults(t *testing.T) {
+	te := setup(t)
+	if !te.db.HasFTS() {
+		t.Skip("skipping search test: no FTS support")
+	}
+	te.seedSession(t, "s1", "my-app", 1)
+	te.seedMessages(t, "s1", 1)
+
+	w := te.get(t, "/api/v1/search?q=spamalot")
+	assertStatus(t, w, http.StatusOK)
+
+	resp := decode[searchResponse](t, w)
+	if resp.Results == nil {
+		t.Fatal("results must be [] not null")
+	}
+	if resp.Count != 0 {
+		t.Fatalf("expected count=0, got %d", resp.Count)
+	}
+}
+
 func TestSearch_NotAvailable(t *testing.T) {
 	te := setup(t)
 	// Simulate missing FTS by dropping the virtual table.


### PR DESCRIPTION
## Summary

- Fix command palette freeze when a search query returns zero results (e.g. "spamalot")
- Root cause: Go nil slice serializes as JSON `null`, not `[]`. The frontend crashed on `null.length`, breaking the component and its Escape handler.
- Server now coerces nil results to an empty slice before serialization
- Frontend adds `?? []` null-coalesce as defense in depth

## Test plan

- [x] New `TestSearch_ZeroResults` server test asserts results is `[]` not `null`
- [x] Existing search store tests pass
- [ ] Manual: open command palette, search for a term with no matches, verify "No results" shown and Escape works

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)