### PR TITLE
Improve Gemini project resolution, add hide-unknown filter, fix agent colors

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -323,7 +323,7 @@
   }
 
   .agent-gemini {
-    background: var(--accent-teal);
+    background: var(--accent-rose);
   }
 
   .agent-opencode {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -320,6 +320,14 @@
     background: var(--accent-amber);
   }
 
+  .agent-gemini {
+    background: var(--accent-cyan);
+  }
+
+  .agent-opencode {
+    background: var(--accent-purple);
+  }
+
   .session-time {
     font-size: 10px;
     color: var(--text-muted);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -323,7 +323,7 @@
   }
 
   .agent-gemini {
-    background: var(--accent-cyan);
+    background: var(--accent-teal);
   }
 
   .agent-opencode {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -187,6 +187,8 @@
                 class:agent-claude={session.agent === "claude"}
                 class:agent-codex={session.agent === "codex"}
                 class:agent-copilot={session.agent === "copilot"}
+                class:agent-gemini={session.agent === "gemini"}
+                class:agent-opencode={session.agent === "opencode"}
               >{session.agent}</span>
               {#if session.started_at}
                 <span class="session-time">

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -19,6 +19,7 @@
   --text-secondary: #555b6e;
   --text-muted: #878ea0;
   --accent-blue: #2563eb;
+  --accent-cyan: #0891b2;
   --accent-purple: #7c3aed;
   --accent-amber: #d97706;
   --accent-green: #059669;
@@ -56,6 +57,7 @@
   --text-secondary: #9ea5b4;
   --text-muted: #6c7385;
   --accent-blue: #60a5fa;
+  --accent-cyan: #22d3ee;
   --accent-purple: #a78bfa;
   --accent-amber: #fbbf24;
   --accent-green: #34d399;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -19,7 +19,7 @@
   --text-secondary: #555b6e;
   --text-muted: #878ea0;
   --accent-blue: #2563eb;
-  --accent-teal: #0d9488;
+  --accent-rose: #e11d48;
   --accent-purple: #7c3aed;
   --accent-amber: #d97706;
   --accent-green: #059669;
@@ -57,7 +57,7 @@
   --text-secondary: #9ea5b4;
   --text-muted: #6c7385;
   --accent-blue: #60a5fa;
-  --accent-teal: #2dd4bf;
+  --accent-rose: #fb7185;
   --accent-purple: #a78bfa;
   --accent-amber: #fbbf24;
   --accent-green: #34d399;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -19,7 +19,7 @@
   --text-secondary: #555b6e;
   --text-muted: #878ea0;
   --accent-blue: #2563eb;
-  --accent-cyan: #0891b2;
+  --accent-teal: #0d9488;
   --accent-purple: #7c3aed;
   --accent-amber: #d97706;
   --accent-green: #059669;
@@ -57,7 +57,7 @@
   --text-secondary: #9ea5b4;
   --text-muted: #6c7385;
   --accent-blue: #60a5fa;
-  --accent-cyan: #22d3ee;
+  --accent-teal: #2dd4bf;
   --accent-purple: #a78bfa;
   --accent-amber: #fbbf24;
   --accent-green: #34d399;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -89,6 +89,7 @@ function buildQuery(
 
 export interface ListSessionsParams {
   project?: string;
+  exclude_project?: string;
   machine?: string;
   agent?: string;
   date?: string;

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -94,6 +94,7 @@
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
+    max-width: 72px;
   }
 
   .agent-dot {
@@ -130,6 +131,9 @@
     text-transform: capitalize;
     letter-spacing: 0.01em;
     line-height: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .session-info {

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -47,11 +47,13 @@
   data-session-id={session.id}
   onclick={() => sessions.selectSession(session.id)}
 >
-  <span
-    class="agent-pill"
-    class:recently-active={recentlyActive}
-    style:background={agentColor}
-  >{session.agent}</span>
+  <div class="agent-indicator" style:--agent-c={agentColor}>
+    <span
+      class="agent-dot"
+      class:recently-active={recentlyActive}
+    ></span>
+    <span class="agent-label">{session.agent}</span>
+  </div>
   <div class="session-info">
     <div class="session-name">{displayName}</div>
     <div class="session-meta">
@@ -87,20 +89,22 @@
     border-left-color: var(--accent-blue);
   }
 
-  .agent-pill {
-    font-size: 8px;
-    font-weight: 600;
-    padding: 1px 5px;
-    border-radius: 6px;
-    color: white;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
+  .agent-indicator {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     flex-shrink: 0;
-    line-height: 1.4;
-    white-space: nowrap;
   }
 
-  .agent-pill.recently-active {
+  .agent-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--agent-c);
+    flex-shrink: 0;
+  }
+
+  .agent-dot.recently-active {
     animation: pulse-glow 3s ease-in-out infinite;
     will-change: box-shadow;
   }
@@ -117,6 +121,15 @@
         transparent
       );
     }
+  }
+
+  .agent-label {
+    font-size: 9px;
+    font-weight: 550;
+    color: var(--agent-c);
+    text-transform: capitalize;
+    letter-spacing: 0.01em;
+    line-height: 1;
   }
 
   .session-info {

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -47,11 +47,11 @@
   data-session-id={session.id}
   onclick={() => sessions.selectSession(session.id)}
 >
-  <div
-    class="agent-dot"
+  <span
+    class="agent-pill"
     class:recently-active={recentlyActive}
     style:background={agentColor}
-  ></div>
+  >{session.agent}</span>
   <div class="session-info">
     <div class="session-name">{displayName}</div>
     <div class="session-meta">
@@ -87,14 +87,20 @@
     border-left-color: var(--accent-blue);
   }
 
-  .agent-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
+  .agent-pill {
+    font-size: 8px;
+    font-weight: 600;
+    padding: 1px 5px;
+    border-radius: 6px;
+    color: white;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
     flex-shrink: 0;
+    line-height: 1.4;
+    white-space: nowrap;
   }
 
-  .agent-dot.recently-active {
+  .agent-pill.recently-active {
     animation: pulse-glow 3s ease-in-out infinite;
     will-change: box-shadow;
   }

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -22,6 +22,9 @@
   let isRecentlyActiveOn = $derived(
     sessions.filters.recentlyActive,
   );
+  let isHideUnknownOn = $derived(
+    sessions.filters.hideUnknownProject,
+  );
 
   let groups = $derived(sessions.groupedSessions);
   let totalCount = $derived(groups.length);
@@ -174,6 +177,23 @@
               class:on={isRecentlyActiveOn}
             ></span>
             Recently Active
+          </button>
+        </div>
+        <div class="filter-section">
+          <div class="filter-section-label">Project</div>
+          <button
+            class="filter-toggle"
+            class:active={isHideUnknownOn}
+            onclick={() =>
+              sessions.setHideUnknownProjectFilter(
+                !isHideUnknownOn,
+              )}
+          >
+            <span
+              class="toggle-check"
+              class:on={isHideUnknownOn}
+            ></span>
+            Hide unknown
           </button>
         </div>
         <div class="filter-section">

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -110,15 +110,21 @@ class SessionsStore {
       10,
     );
 
+    const hideUnknown =
+      params["exclude_project"] === "unknown";
+    let project = params["project"] ?? "";
+    if (hideUnknown && project === "unknown") {
+      project = "";
+    }
+
     this.filters = {
-      project: params["project"] ?? "",
+      project,
       agent: params["agent"] ?? "",
       date: params["date"] ?? "",
       dateFrom: params["date_from"] ?? "",
       dateTo: params["date_to"] ?? "",
       recentlyActive: params["active_since"] === "true",
-      hideUnknownProject:
-        params["exclude_project"] === "unknown",
+      hideUnknownProject: hideUnknown,
       minMessages: Number.isFinite(minMsgs) ? minMsgs : 0,
       maxMessages: Number.isFinite(maxMsgs) ? maxMsgs : 0,
       minUserMessages: Number.isFinite(minUserMsgs)

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -288,6 +288,9 @@ class SessionsStore {
 
   setHideUnknownProjectFilter(hide: boolean) {
     this.filters.hideUnknownProject = hide;
+    if (hide && this.filters.project === "unknown") {
+      this.filters.project = "";
+    }
     this.activeSessionId = null;
     this.resetPagination();
     this.load();

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -67,11 +67,14 @@ class SessionsStore {
 
   private get apiParams() {
     const f = this.filters;
+    // Don't exclude "unknown" when explicitly viewing it.
+    const exclude =
+      f.hideUnknownProject && f.project !== "unknown"
+        ? "unknown"
+        : undefined;
     return {
       project: f.project || undefined,
-      exclude_project: f.hideUnknownProject
-        ? "unknown"
-        : undefined,
+      exclude_project: exclude,
       agent: f.agent || undefined,
       date: f.date || undefined,
       date_from: f.dateFrom || undefined,

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -21,6 +21,7 @@ interface Filters {
   dateFrom: string;
   dateTo: string;
   recentlyActive: boolean;
+  hideUnknownProject: boolean;
   minMessages: number;
   maxMessages: number;
   minUserMessages: number;
@@ -34,6 +35,7 @@ function defaultFilters(): Filters {
     dateFrom: "",
     dateTo: "",
     recentlyActive: false,
+    hideUnknownProject: false,
     minMessages: 0,
     maxMessages: 0,
     minUserMessages: 0,
@@ -67,6 +69,9 @@ class SessionsStore {
     const f = this.filters;
     return {
       project: f.project || undefined,
+      exclude_project: f.hideUnknownProject
+        ? "unknown"
+        : undefined,
       agent: f.agent || undefined,
       date: f.date || undefined,
       date_from: f.dateFrom || undefined,
@@ -112,6 +117,8 @@ class SessionsStore {
       dateFrom: params["date_from"] ?? "",
       dateTo: params["date_to"] ?? "",
       recentlyActive: params["active_since"] === "true",
+      hideUnknownProject:
+        params["exclude_project"] === "unknown",
       minMessages: Number.isFinite(minMsgs) ? minMsgs : 0,
       maxMessages: Number.isFinite(maxMsgs) ? maxMsgs : 0,
       minUserMessages: Number.isFinite(minUserMsgs)
@@ -279,11 +286,19 @@ class SessionsStore {
     this.load();
   }
 
+  setHideUnknownProjectFilter(hide: boolean) {
+    this.filters.hideUnknownProject = hide;
+    this.activeSessionId = null;
+    this.resetPagination();
+    this.load();
+  }
+
   get hasActiveFilters(): boolean {
     const f = this.filters;
     return !!(
       f.agent ||
       f.recentlyActive ||
+      f.hideUnknownProject ||
       f.dateFrom ||
       f.dateTo ||
       f.date ||

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -455,6 +455,17 @@ describe("SessionsStore", () => {
       expect(sessions.hasActiveFilters).toBe(true);
     });
 
+    it("should suppress exclude_project when project is unknown", async () => {
+      sessions.filters.hideUnknownProject = true;
+      sessions.filters.project = "unknown";
+      await sessions.load();
+
+      expectListSessionsCalledWith({
+        project: "unknown",
+        exclude_project: undefined,
+      });
+    });
+
     it("should be cleared by clearSessionFilters", async () => {
       sessions.filters.hideUnknownProject = true;
       sessions.clearSessionFilters();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -441,6 +441,15 @@ describe("SessionsStore", () => {
       expect(sessions.filters.hideUnknownProject).toBe(false);
     });
 
+    it("should clear conflicting project=unknown in initFromParams", () => {
+      sessions.initFromParams({
+        project: "unknown",
+        exclude_project: "unknown",
+      });
+      expect(sessions.filters.project).toBe("");
+      expect(sessions.filters.hideUnknownProject).toBe(true);
+    });
+
     it("should be included in hasActiveFilters", () => {
       sessions.filters.hideUnknownProject = true;
       expect(sessions.hasActiveFilters).toBe(true);

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -25,17 +25,20 @@ describe("KNOWN_AGENTS", () => {
 
 describe("agentColor", () => {
   it("returns correct color for known agents", () => {
+    expect(agentColor("claude")).toBe(
+      "var(--accent-blue)",
+    );
     expect(agentColor("codex")).toBe(
       "var(--accent-green)",
     );
     expect(agentColor("copilot")).toBe(
       "var(--accent-amber)",
     );
+    expect(agentColor("gemini")).toBe(
+      "var(--accent-cyan)",
+    );
     expect(agentColor("opencode")).toBe(
       "var(--accent-purple)",
-    );
-    expect(agentColor("claude")).toBe(
-      "var(--accent-blue)",
     );
   });
 

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -35,7 +35,7 @@ describe("agentColor", () => {
       "var(--accent-amber)",
     );
     expect(agentColor("gemini")).toBe(
-      "var(--accent-cyan)",
+      "var(--accent-teal)",
     );
     expect(agentColor("opencode")).toBe(
       "var(--accent-purple)",

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -35,7 +35,7 @@ describe("agentColor", () => {
       "var(--accent-amber)",
     );
     expect(agentColor("gemini")).toBe(
-      "var(--accent-teal)",
+      "var(--accent-rose)",
     );
     expect(agentColor("opencode")).toBe(
       "var(--accent-purple)",

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -7,7 +7,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "claude", color: "var(--accent-blue)" },
   { name: "codex", color: "var(--accent-green)" },
   { name: "copilot", color: "var(--accent-amber)" },
-  { name: "gemini", color: "var(--accent-teal)" },
+  { name: "gemini", color: "var(--accent-rose)" },
   { name: "opencode", color: "var(--accent-purple)" },
 ];
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -7,7 +7,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "claude", color: "var(--accent-blue)" },
   { name: "codex", color: "var(--accent-green)" },
   { name: "copilot", color: "var(--accent-amber)" },
-  { name: "gemini", color: "var(--accent-cyan)" },
+  { name: "gemini", color: "var(--accent-teal)" },
   { name: "opencode", color: "var(--accent-purple)" },
 ];
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -7,7 +7,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "claude", color: "var(--accent-blue)" },
   { name: "codex", color: "var(--accent-green)" },
   { name: "copilot", color: "var(--accent-amber)" },
-  { name: "gemini", color: "var(--accent-blue)" },
+  { name: "gemini", color: "var(--accent-cyan)" },
   { name: "opencode", color: "var(--accent-purple)" },
 ];
 

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -201,6 +201,40 @@ func TestSessionFilterMinUserMessages(t *testing.T) {
 	}
 }
 
+func TestSessionFilterExcludeProject(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "known", "my_project", func(s *Session) {
+		s.MessageCount = 5
+	})
+	insertSession(t, d, "unknown1", "unknown", func(s *Session) {
+		s.MessageCount = 3
+	})
+	insertSession(t, d, "unknown2", "unknown", func(s *Session) {
+		s.MessageCount = 7
+	})
+
+	tests := []struct {
+		name           string
+		excludeProject string
+		want           int
+	}{
+		{"NoFilter", "", 3},
+		{"ExcludeUnknown", "unknown", 1},
+		{"ExcludeMyProject", "my_project", 2},
+		{"ExcludeNonexistent", "nope", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := filterWith(func(f *SessionFilter) {
+				f.ExcludeProject = tt.excludeProject
+			})
+			requireCount(t, d, f, tt.want)
+		})
+	}
+}
+
 func TestActiveSinceUsesEndedAtOverStartedAt(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -65,21 +65,21 @@ func scanSessionRow(rs rowScanner) (Session, error) {
 
 // Session represents a row in the sessions table.
 type Session struct {
-	ID              string  `json:"id"`
-	Project         string  `json:"project"`
-	Machine         string  `json:"machine"`
-	Agent           string  `json:"agent"`
-	FirstMessage    *string `json:"first_message"`
-	StartedAt       *string `json:"started_at"`
-	EndedAt         *string `json:"ended_at"`
+	ID               string  `json:"id"`
+	Project          string  `json:"project"`
+	Machine          string  `json:"machine"`
+	Agent            string  `json:"agent"`
+	FirstMessage     *string `json:"first_message"`
+	StartedAt        *string `json:"started_at"`
+	EndedAt          *string `json:"ended_at"`
 	MessageCount     int     `json:"message_count"`
 	UserMessageCount int     `json:"user_message_count"`
 	ParentSessionID  *string `json:"parent_session_id,omitempty"`
-	FilePath        *string `json:"file_path,omitempty"`
-	FileSize        *int64  `json:"file_size,omitempty"`
-	FileMtime       *int64  `json:"file_mtime,omitempty"`
-	FileHash        *string `json:"file_hash,omitempty"`
-	CreatedAt       string  `json:"created_at"`
+	FilePath         *string `json:"file_path,omitempty"`
+	FileSize         *int64  `json:"file_size,omitempty"`
+	FileMtime        *int64  `json:"file_mtime,omitempty"`
+	FileHash         *string `json:"file_hash,omitempty"`
+	CreatedAt        string  `json:"created_at"`
 }
 
 // SessionCursor is the opaque pagination token.
@@ -161,18 +161,19 @@ func (db *DB) DecodeCursor(s string) (SessionCursor, error) {
 
 // SessionFilter specifies how to query sessions.
 type SessionFilter struct {
-	Project     string
-	Machine     string
-	Agent       string
-	Date        string // exact date YYYY-MM-DD
-	DateFrom    string // range start (inclusive)
-	DateTo      string // range end (inclusive)
-	ActiveSince string // ISO-8601 timestamp; filters on most recent activity
-	MinMessages     int // message_count >= N (0 = no filter)
-	MaxMessages     int // message_count <= N (0 = no filter)
-	MinUserMessages int // user_message_count >= N (0 = no filter)
-	Cursor      string // opaque cursor from previous page
-	Limit       int
+	Project         string
+	ExcludeProject  string // exclude sessions with this project name
+	Machine         string
+	Agent           string
+	Date            string // exact date YYYY-MM-DD
+	DateFrom        string // range start (inclusive)
+	DateTo          string // range end (inclusive)
+	ActiveSince     string // ISO-8601 timestamp; filters on most recent activity
+	MinMessages     int    // message_count >= N (0 = no filter)
+	MaxMessages     int    // message_count <= N (0 = no filter)
+	MinUserMessages int    // user_message_count >= N (0 = no filter)
+	Cursor          string // opaque cursor from previous page
+	Limit           int
 }
 
 // SessionPage is a page of session results.
@@ -191,6 +192,10 @@ func buildSessionFilter(f SessionFilter) (string, []any) {
 	if f.Project != "" {
 		preds = append(preds, "project = ?")
 		args = append(args, f.Project)
+	}
+	if f.ExcludeProject != "" {
+		preds = append(preds, "project != ?")
+		args = append(args, f.ExcludeProject)
 	}
 	if f.Machine != "" {
 		preds = append(preds, "machine = ?")

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -31,14 +31,14 @@ type FileInfo struct {
 
 // ParsedSession holds session metadata extracted from a JSONL file.
 type ParsedSession struct {
-	ID              string
-	Project         string
-	Machine         string
-	Agent           AgentType
-	ParentSessionID string
-	FirstMessage    string
-	StartedAt       time.Time
-	EndedAt         time.Time
+	ID               string
+	Project          string
+	Machine          string
+	Agent            AgentType
+	ParentSessionID  string
+	FirstMessage     string
+	StartedAt        time.Time
+	EndedAt          time.Time
 	MessageCount     int
 	UserMessageCount int
 	File             FileInfo

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -57,6 +57,7 @@ func (s *Server) handleListSessions(
 
 	filter := db.SessionFilter{
 		Project:         q.Get("project"),
+		ExcludeProject:  q.Get("exclude_project"),
 		Machine:         q.Get("machine"),
 		Agent:           q.Get("agent"),
 		Date:            date,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -927,17 +927,17 @@ func (e *Engine) writeSessionFull(pw pendingWrite) {
 // toDBSession converts a pendingWrite to a db.Session.
 func toDBSession(pw pendingWrite) db.Session {
 	s := db.Session{
-		ID:              pw.sess.ID,
-		Project:         pw.sess.Project,
-		Machine:         pw.sess.Machine,
-		Agent:           string(pw.sess.Agent),
+		ID:               pw.sess.ID,
+		Project:          pw.sess.Project,
+		Machine:          pw.sess.Machine,
+		Agent:            string(pw.sess.Agent),
 		MessageCount:     pw.sess.MessageCount,
 		UserMessageCount: pw.sess.UserMessageCount,
 		ParentSessionID:  strPtr(pw.sess.ParentSessionID),
-		FilePath:        strPtr(pw.sess.File.Path),
-		FileSize:        int64Ptr(pw.sess.File.Size),
-		FileMtime:       int64Ptr(pw.sess.File.Mtime),
-		FileHash:        strPtr(pw.sess.File.Hash),
+		FilePath:         strPtr(pw.sess.File.Path),
+		FileSize:         int64Ptr(pw.sess.File.Size),
+		FileMtime:        int64Ptr(pw.sess.File.Mtime),
+		FileHash:         strPtr(pw.sess.File.Hash),
 	}
 	if pw.sess.FirstMessage != "" {
 		s.FirstMessage = &pw.sess.FirstMessage


### PR DESCRIPTION
## Summary

- **Read `trustedFolders.json`** alongside `projects.json` when building the Gemini hash-to-project map. `trustedFolders.json` persists longer than `projects.json`, recovering project names for orphaned SHA-256 hash directories that Gemini CLI has cleaned up.
- **Add `exclude_project` API filter** (`project != ?` SQL predicate) and a "Hide unknown" toggle in the sidebar filter dropdown, letting users hide sessions with unresolvable project names. Conflicting `project=unknown` + `exclude_project=unknown` is prevented centrally in `apiParams` -- explicit project selection always wins.
- **Fix Gemini/Claude color collision** (fixes #42). Both agents used `--accent-blue`. Gemini now uses `--accent-rose` (light: `#e11d48`, dark: `#fb7185`) for maximum distinction from all other agent colors.
- **Show agent name in session list.** Replace the plain dot indicator with a colored dot + agent name label (e.g. "Claude", "Gemini") in the agent's accent color. Width is capped with ellipsis truncation to prevent sidebar squeeze. Also adds missing `agent-gemini` and `agent-opencode` badge classes in the breadcrumb.

## Test plan

- [x] Go tests: `TestBuildGeminiProjectMapTrustedFolders`, `TestBuildGeminiProjectMapBothFiles`, `TestBuildGeminiProjectMapProjectsWin` verify trustedFolders.json reading and precedence
- [x] Go tests: `TestSessionFilterExcludeProject` covers exclude_project SQL filter (4 cases)
- [x] Frontend tests: 10 store tests cover API serialization, conflicting filter clearing (toggle, URL params, centralized apiParams guard), `hasActiveFilters`, and `clearSessionFilters`
- [x] Agent color test updated to assert Gemini uses `--accent-rose`
- [x] Vite build produces no warnings
- [x] All existing Go and frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)