### PR TITLE
Fix analytics message count discrepancy, add All range, update Gemini model

### DIFF
--- a/frontend/src/lib/components/analytics/DateRangePicker.svelte
+++ b/frontend/src/lib/components/analytics/DateRangePicker.svelte
@@ -31,7 +31,7 @@
     return localDateStr(new Date());
   }
 
-  const ALL_FROM = "2020-01-01";
+  const ALL_FROM = "1970-01-01";
 
   function applyPreset(days: number) {
     if (days === 0) {

--- a/frontend/src/lib/components/analytics/DateRangePicker.svelte
+++ b/frontend/src/lib/components/analytics/DateRangePicker.svelte
@@ -11,6 +11,7 @@
     { label: "30d", days: 30 },
     { label: "90d", days: 90 },
     { label: "1y", days: 365 },
+    { label: "All", days: 0 },
   ];
 
   function localDateStr(d: Date): string {
@@ -30,12 +31,19 @@
     return localDateStr(new Date());
   }
 
+  const ALL_FROM = "2020-01-01";
+
   function applyPreset(days: number) {
-    analytics.setDateRange(daysAgo(days), todayStr());
+    if (days === 0) {
+      analytics.setDateRange(ALL_FROM, todayStr());
+    } else {
+      analytics.setDateRange(daysAgo(days), todayStr());
+    }
   }
 
   function isActive(days: number): boolean {
-    return analytics.from === daysAgo(days) &&
+    const from = days === 0 ? ALL_FROM : daysAgo(days);
+    return analytics.from === from &&
       analytics.to === todayStr();
   }
 </script>

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -14,7 +14,7 @@ import (
 
 // geminiInsightModel is the model passed to the gemini CLI
 // for insight generation.
-const geminiInsightModel = "gemini-3-pro-preview"
+const geminiInsightModel = "gemini-3.1-pro-preview"
 
 // Result holds the output from an AI agent invocation.
 type Result struct {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1440,7 +1440,7 @@ func TestSyncSingleSessionPostFilterCounts(t *testing.T) {
 	// Corrupt stored counts and clear mtime so
 	// SyncSingleSession re-parses via writeSessionFull.
 	err := env.db.Update(func(tx *sql.Tx) error {
-		_, err := tx.Exec(
+		res, err := tx.Exec(
 			"UPDATE sessions"+
 				" SET message_count = 999,"+
 				" user_message_count = 999,"+
@@ -1448,7 +1448,16 @@ func TestSyncSingleSessionPostFilterCounts(t *testing.T) {
 				" WHERE id = ?",
 			"filter-single",
 		)
-		return err
+		if err != nil {
+			return err
+		}
+		n, _ := res.RowsAffected()
+		if n != 1 {
+			return fmt.Errorf(
+				"expected 1 row affected, got %d", n,
+			)
+		}
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("corrupt counts: %v", err)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1329,6 +1329,140 @@ func TestSyncEngineConcurrentSerialization(t *testing.T) {
 	wg.Wait()
 }
 
+// TestSyncEnginePostFilterCounts verifies that writeBatch
+// stores post-filter message counts (after pairAndFilter
+// removes empty user+tool_result messages), not the raw
+// parser counts.
+func TestSyncEnginePostFilterCounts(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Build a session with 4 raw messages:
+	//   1. user with content (kept)
+	//   2. assistant with tool_use (kept)
+	//   3. user with only tool_result, no text (filtered)
+	//   4. assistant with text (kept)
+	// Post-filter: 3 messages, 1 user message.
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "Read main.go").
+		AddRaw(testjsonl.ClaudeAssistantJSON(
+			[]map[string]any{{
+				"type": "tool_use",
+				"id":   "toolu_1",
+				"name": "Read",
+				"input": map[string]string{
+					"file_path": "main.go",
+				},
+			}},
+			tsEarlyS1,
+		)).
+		AddRaw(testjsonl.ClaudeToolResultUserJSON(
+			"toolu_1", "package main", tsEarlyS5,
+		)).
+		AddClaudeAssistant(tsEarlyS5, "Here it is.").
+		String()
+
+	env.writeClaudeSession(
+		t, "test-proj",
+		"filter-count.jsonl", content,
+	)
+
+	runSyncAndAssert(t, env.engine, 1, 0)
+
+	// Verify stored counts match post-filter values.
+	assertSessionState(
+		t, env.db, "filter-count",
+		func(sess *db.Session) {
+			if sess.MessageCount != 3 {
+				t.Errorf(
+					"MessageCount = %d, want 3"+
+						" (post-filter)",
+					sess.MessageCount,
+				)
+			}
+			if sess.UserMessageCount != 1 {
+				t.Errorf(
+					"UserMessageCount = %d, want 1",
+					sess.UserMessageCount,
+				)
+			}
+		},
+	)
+
+	// Verify actual message rows match the stored count.
+	msgs, err := env.db.GetAllMessages(
+		context.Background(), "filter-count",
+	)
+	if err != nil {
+		t.Fatalf("GetAllMessages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Errorf(
+			"stored message rows = %d, want 3",
+			len(msgs),
+		)
+	}
+}
+
+// TestSyncSingleSessionPostFilterCounts verifies that
+// writeSessionFull (used by SyncSingleSession) also stores
+// post-filter counts.
+func TestSyncSingleSessionPostFilterCounts(t *testing.T) {
+	env := setupTestEnv(t)
+
+	content2 := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "Read main.go").
+		AddRaw(testjsonl.ClaudeAssistantJSON(
+			[]map[string]any{{
+				"type": "tool_use",
+				"id":   "toolu_1",
+				"name": "Read",
+				"input": map[string]string{
+					"file_path": "main.go",
+				},
+			}},
+			tsEarlyS1,
+		)).
+		AddRaw(testjsonl.ClaudeToolResultUserJSON(
+			"toolu_1", "package main", tsEarlyS5,
+		)).
+		AddClaudeAssistant(tsEarlyS5, "Here it is.").
+		String()
+
+	env.writeClaudeSession(
+		t, "test-proj",
+		"filter-single.jsonl", content2,
+	)
+
+	// Use SyncAll first, then SyncSingleSession to exercise
+	// the writeSessionFull path.
+	env.engine.SyncAll(nil)
+
+	if err := env.engine.SyncSingleSession(
+		"filter-single",
+	); err != nil {
+		t.Fatalf("SyncSingleSession: %v", err)
+	}
+
+	assertSessionState(
+		t, env.db, "filter-single",
+		func(sess *db.Session) {
+			if sess.MessageCount != 3 {
+				t.Errorf(
+					"MessageCount = %d, want 3"+
+						" (post-filter)",
+					sess.MessageCount,
+				)
+			}
+			if sess.UserMessageCount != 1 {
+				t.Errorf(
+					"UserMessageCount = %d, want 1",
+					sess.UserMessageCount,
+				)
+			}
+		},
+	)
+}
+
 func TestSyncEngineMultiClaudeDir(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -136,6 +136,63 @@ func TestFilterEmptyMessages(t *testing.T) {
 	}
 }
 
+func TestPostFilterCounts(t *testing.T) {
+	tests := []struct {
+		name      string
+		msgs      []db.Message
+		wantTotal int
+		wantUser  int
+	}{
+		{
+			"mixed roles",
+			[]db.Message{
+				{Role: "user", Content: "hello"},
+				{Role: "assistant", Content: "hi"},
+				{Role: "user", Content: "thanks"},
+			},
+			3, 2,
+		},
+		{
+			"no user messages",
+			[]db.Message{
+				{Role: "assistant", Content: "hi"},
+			},
+			1, 0,
+		},
+		{
+			"empty slice",
+			nil,
+			0, 0,
+		},
+		{
+			"all user messages",
+			[]db.Message{
+				{Role: "user", Content: "a"},
+				{Role: "user", Content: "b"},
+			},
+			2, 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			total, user := postFilterCounts(tt.msgs)
+			if total != tt.wantTotal {
+				t.Errorf(
+					"total = %d, want %d",
+					total, tt.wantTotal,
+				)
+			}
+			if user != tt.wantUser {
+				t.Errorf(
+					"user = %d, want %d",
+					user, tt.wantUser,
+				)
+			}
+		})
+	}
+}
+
 func TestPairToolResults(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -65,6 +65,26 @@ func ClaudeMetaUserJSON(
 	return mustMarshal(m)
 }
 
+// ClaudeToolResultUserJSON returns a Claude user message
+// containing only a tool_result block (no text content).
+// These messages are filtered out by pairAndFilter.
+func ClaudeToolResultUserJSON(
+	toolUseID, resultContent, timestamp string,
+) string {
+	m := map[string]any{
+		"type":      "user",
+		"timestamp": timestamp,
+		"message": map[string]any{
+			"content": []map[string]any{{
+				"type":        "tool_result",
+				"tool_use_id": toolUseID,
+				"content":     resultContent,
+			}},
+		},
+	}
+	return mustMarshal(m)
+}
+
 // ClaudeAssistantJSON returns a Claude assistant message as a
 // JSON string.
 func ClaudeAssistantJSON(content any, timestamp string) string {


### PR DESCRIPTION
## Summary

- **Fix message count discrepancy**: `sessions.message_count` and `user_message_count` now reflect post-filter counts (after `pairAndFilter` removes empty user+tool_result messages), matching the status bar totals. Previously analytics showed inflated counts from pre-filter parser output.
- **Add "All" time range preset**: New preset in the analytics date picker sets the start date to `1970-01-01`, showing all sessions regardless of age.
- **Update Gemini insight model**: Changed `geminiInsightModel` from `gemini-3-pro-preview` to `gemini-3.1-pro-preview`.

> **Note:** Existing sessions will retain stale (inflated) counts until re-synced. Users who see a discrepancy between the analytics dashboard and the status bar should use the in-app resync button to reprocess all sessions. New and incrementally synced sessions will have correct counts automatically.

## Test plan

- [x] `postFilterCounts` unit test covers mixed roles, empty slice, all-user, no-user cases
- [x] `TestSyncEnginePostFilterCounts` integration test verifies `writeBatch` stores post-filter counts with tool_result filtering
- [x] `TestSyncSingleSessionPostFilterCounts` integration test verifies `writeSessionFull` path by corrupting DB counts and forcing reparse
- [x] Existing `TestGenerateGemini_ModelFlag` passes with updated model constant
- [x] All Go tests pass (`go test -tags fts5 ./internal/...`)
- [x] Frontend type check (`tsc --noEmit`) and tests (`vitest run`) pass
- [x] Frontend build (`vite build`) produces no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)