### PR TITLE
Fix Gemini thinking blocks, resync reliability, and startup UX

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -60,6 +60,27 @@ Key assumptions reviewers MUST account for:
     A full resync recovers any partial state. Do not flag non-atomic
     multi-session writes as a data corruption risk.
 
+11. TOCTOU ON LOCAL FILES: File operations on user-owned paths inside
+    ~/.agentsview/ (e.g. log truncation, config reads) do not need
+    TOCTOU protection. An attacker who can create symlinks or modify
+    files in the user's home directory already has equivalent access.
+    Do not flag Lstat-then-Truncate or similar patterns on local-only
+    user-owned paths as TOCTOU vulnerabilities.
+
+12. SCHEMA NOT NULL CONSTRAINTS: Before flagging SQL NULL handling
+    issues (e.g. NOT IN excluding NULLs), check the schema. The
+    sessions table defines `relationship_type TEXT NOT NULL DEFAULT ''`
+    (schema.sql), so NULL values cannot exist. The NOT IN clause works
+    correctly for non-NULL columns. Do not flag NULL filtering issues
+    without verifying the actual column constraints.
+
+13. VERIFY CONTROL FLOW BEFORE FLAGGING: When claiming a counter or
+    guard is incorrect, trace the actual control flow including early
+    returns, continue statements, and conditionals. For example, if
+    code has `if len(results) == 0 { continue }` before incrementing
+    a counter, the counter is NOT incremented for zero-result cases.
+    Read the code carefully before reporting logic errors.
+
 Do NOT flag issues that only apply to public-facing, multi-tenant,
 or network-exposed services. Focus on bugs, logic errors, data
 corruption risks, and code quality issues.

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -231,11 +231,15 @@ func setupLogFile(dataDir string) {
 }
 
 // truncateLogFile truncates the log file if it exceeds limit
-// bytes. Errors are silently ignored since logging is
+// bytes. Symlinks are skipped to avoid truncating unrelated
+// files. Errors are silently ignored since logging is
 // best-effort.
 func truncateLogFile(path string, limit int64) {
-	info, err := os.Stat(path)
-	if err != nil || info.Size() <= limit {
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 {
+		return
+	}
+	if info.Size() <= limit {
 		return
 	}
 	_ = os.Truncate(path, 0)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -136,6 +136,9 @@ func runServe(args []string) {
 	warnMissingDirs(cfg.ResolveGeminiDirs(), "gemini")
 	warnMissingDirs(cfg.ResolveOpenCodeDirs(), "opencode")
 
+	// Remove stale temp DB from a prior crashed resync.
+	cleanResyncTemp(cfg.DBPath)
+
 	engine := sync.NewEngine(
 		database,
 		cfg.ResolveClaudeDirs(),
@@ -253,6 +256,15 @@ func mustOpenDB(cfg config.Config) *db.DB {
 	}
 
 	return database
+}
+
+// cleanResyncTemp removes leftover temp database files from
+// a prior crashed resync.
+func cleanResyncTemp(dbPath string) {
+	tempPath := dbPath + "-resync"
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		os.Remove(tempPath + suffix)
+	}
 }
 
 func runInitialSync(engine *sync.Engine) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -165,8 +165,12 @@ func TestTruncateLogFileSymlink(t *testing.T) {
 
 	// Write a target file larger than the limit.
 	big := bytes.Repeat([]byte("x"), 1024)
-	os.WriteFile(target, big, 0o644)
-	os.Symlink(target, link)
+	if err := os.WriteFile(target, big, 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip("symlinks not supported:", err)
+	}
 
 	// Truncate via symlink: should be a no-op.
 	truncateLogFile(link, 512)

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"log"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -60,4 +65,94 @@ func TestMustLoadConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetupLogFile(t *testing.T) {
+	// Save and restore the global logger output.
+	origOutput := log.Writer()
+	t.Cleanup(func() { log.SetOutput(origOutput) })
+
+	dir := t.TempDir()
+	setupLogFile(dir)
+
+	// Log something and verify it reaches the file.
+	log.Print("test-log-message")
+
+	logPath := filepath.Join(dir, "debug.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	if !strings.Contains(string(data), "test-log-message") {
+		t.Errorf(
+			"log file missing message, got: %q", data,
+		)
+	}
+}
+
+func TestSetupLogFileOpenFailure(t *testing.T) {
+	origOutput := log.Writer()
+	t.Cleanup(func() { log.SetOutput(origOutput) })
+
+	// Capture log output to verify warning is emitted.
+	var buf bytes.Buffer
+	log.SetOutput(io.MultiWriter(origOutput, &buf))
+
+	// Pass a path that can't be opened (dir doesn't exist
+	// and we use a file as the "dir").
+	tmpFile := filepath.Join(t.TempDir(), "notadir")
+	os.WriteFile(tmpFile, []byte("x"), 0o644)
+
+	setupLogFile(tmpFile)
+
+	if !strings.Contains(buf.String(), "cannot open log file") {
+		t.Errorf(
+			"expected warning about log file, got: %q",
+			buf.String(),
+		)
+	}
+}
+
+func TestTruncateLogFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// Write a file larger than the limit.
+	big := bytes.Repeat([]byte("x"), 1024)
+	os.WriteFile(path, big, 0o644)
+
+	// Truncate with limit smaller than file size.
+	truncateLogFile(path, 512)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after truncate: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("size after truncate = %d, want 0", info.Size())
+	}
+}
+
+func TestTruncateLogFileUnderLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	content := []byte("small log content")
+	os.WriteFile(path, content, 0o644)
+
+	// File is under limit: should not be truncated.
+	truncateLogFile(path, 1024)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after truncate: %v", err)
+	}
+	if string(data) != string(content) {
+		t.Errorf("content changed: got %q", data)
+	}
+}
+
+func TestTruncateLogFileMissing(t *testing.T) {
+	// Non-existent file: should not panic.
+	truncateLogFile("/nonexistent/path/log.txt", 1024)
 }

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -169,7 +171,12 @@ func TestTruncateLogFileSymlink(t *testing.T) {
 		t.Fatalf("write target: %v", err)
 	}
 	if err := os.Symlink(target, link); err != nil {
-		t.Skip("symlinks not supported:", err)
+		if errors.Is(err, syscall.EPERM) ||
+			errors.Is(err, syscall.EACCES) ||
+			errors.Is(err, os.ErrPermission) {
+			t.Skip("symlinks not supported:", err)
+		}
+		t.Fatalf("symlink: %v", err)
 	}
 
 	// Truncate via symlink: should be a no-op.

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -173,7 +173,9 @@ func TestTruncateLogFileSymlink(t *testing.T) {
 	if err := os.Symlink(target, link); err != nil {
 		if errors.Is(err, syscall.EPERM) ||
 			errors.Is(err, syscall.EACCES) ||
-			errors.Is(err, os.ErrPermission) {
+			errors.Is(err, os.ErrPermission) ||
+			errors.Is(err, syscall.ENOSYS) ||
+			errors.Is(err, syscall.ENOTSUP) {
 			t.Skip("symlinks not supported:", err)
 		}
 		t.Fatalf("symlink: %v", err)

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -21,7 +21,7 @@ type sessionSpec struct {
 var specs = []sessionSpec{
 	{"project-alpha", "small-2", 2, 1},
 	{"project-alpha", "small-5", 5, 3},
-	{"project-beta", "mixed-content-6", 6, 3},
+	{"project-beta", "mixed-content-7", 7, 3},
 	{"project-beta", "medium-8", 8, 4},
 	{"project-beta", "medium-100", 100, 50},
 	{"project-gamma", "large-200", 200, 100},
@@ -97,7 +97,7 @@ func createSessionFixture(
 	}
 
 	var msgs []db.Message
-	if spec.suffix == "mixed-content-6" {
+	if spec.suffix == "mixed-content-7" {
 		msgs = generateMixedContentMessages(sessionID, startedAt)
 	} else {
 		msgs = generateMessages(
@@ -171,6 +171,12 @@ func generateMixedContentMessages(
 			role:       "assistant",
 			content:    "[Bash]\nls -la /src",
 			hasToolUse: true,
+		},
+		{
+			role: "assistant",
+			content: "[Thinking]\nGemini-style reasoning\n\n" +
+				"This is the visible response after thinking.",
+			hasThinking: true,
 		},
 		{
 			role:    "user",

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -174,7 +174,8 @@ func generateMixedContentMessages(
 		},
 		{
 			role: "assistant",
-			content: "[Thinking]\nGemini-style reasoning\n\n" +
+			content: "[Thinking]\nGemini-style reasoning\n" +
+				"[/Thinking]\n\n" +
 				"This is the visible response after thinking.",
 			hasThinking: true,
 		},

--- a/frontend/e2e/message-content.spec.ts
+++ b/frontend/e2e/message-content.spec.ts
@@ -182,15 +182,15 @@ test.describe("Mixed content rendering", () => {
     const sid = await selectSession(page, project, count);
     await expectSessionLoaded(page, sid, displayRows);
 
-    const thinkingBlock = page.locator(".thinking-block");
+    const thinkingBlock = page.locator(".thinking-block").first();
     await expect(thinkingBlock).toBeVisible();
 
     // Content should be hidden (collapsed by default)
-    const thinkingContent = page.locator(".thinking-content");
+    const thinkingContent = thinkingBlock.locator(".thinking-content");
     await expect(thinkingContent).not.toBeVisible();
 
     // Click to expand
-    const thinkingHeader = page.locator(".thinking-header");
+    const thinkingHeader = thinkingBlock.locator(".thinking-header");
     await thinkingHeader.click();
 
     // Content should now be visible

--- a/frontend/e2e/message-content.spec.ts
+++ b/frontend/e2e/message-content.spec.ts
@@ -8,10 +8,10 @@ const LOC = {
   row: ".virtual-row",
 } as const;
 
-const BETA_6 = {
+const BETA_7 = {
   project: "project-beta",
   count: 3, // user_message_count shown in sidebar
-  displayRows: 5,
+  displayRows: 6,
 };
 
 function getSessionItem(
@@ -85,7 +85,7 @@ test.describe("Mixed content rendering", () => {
   test("tool group renders for consecutive tool-only messages", async ({
     page,
   }) => {
-    const { project, count, displayRows } = BETA_6;
+    const { project, count, displayRows } = BETA_7;
     const sid = await selectSession(page, project, count);
     await expectSessionLoaded(page, sid, displayRows);
 
@@ -105,7 +105,7 @@ test.describe("Mixed content rendering", () => {
   test("tool block expands on click and text is selectable", async ({
     page,
   }) => {
-    const { project, count, displayRows } = BETA_6;
+    const { project, count, displayRows } = BETA_7;
     const sid = await selectSession(page, project, count);
     await expectSessionLoaded(page, sid, displayRows);
 
@@ -141,7 +141,7 @@ test.describe("Mixed content rendering", () => {
   test("text selection does not collapse tool block", async ({
     page,
   }) => {
-    const { project, count, displayRows } = BETA_6;
+    const { project, count, displayRows } = BETA_7;
     const sid = await selectSession(page, project, count);
     await expectSessionLoaded(page, sid, displayRows);
 
@@ -178,7 +178,7 @@ test.describe("Mixed content rendering", () => {
   test("thinking block is collapsed by default", async ({
     page,
   }) => {
-    const { project, count, displayRows } = BETA_6;
+    const { project, count, displayRows } = BETA_7;
     const sid = await selectSession(page, project, count);
     await expectSessionLoaded(page, sid, displayRows);
 
@@ -198,5 +198,46 @@ test.describe("Mixed content rendering", () => {
     await expect(thinkingContent).toContainText(
       "Let me analyze...",
     );
+  });
+
+  test("thinking+text message shows response text", async ({
+    page,
+  }) => {
+    const { project, count, displayRows } = BETA_7;
+    const sid = await selectSession(page, project, count);
+    await expectSessionLoaded(page, sid, displayRows);
+
+    // The response text after thinking should be visible
+    await expect(
+      page
+        .locator(LOC.row)
+        .filter({
+          hasText: "visible response after thinking",
+        }),
+    ).toBeVisible();
+  });
+
+  test("response text remains after toggling thinking off", async ({
+    page,
+  }) => {
+    const { project, count, displayRows } = BETA_7;
+    const sid = await selectSession(page, project, count);
+    await expectSessionLoaded(page, sid, displayRows);
+
+    // Toggle thinking off with keyboard shortcut
+    await page.keyboard.press("t");
+
+    // Thinking blocks should be hidden
+    const thinkingBlocks = page.locator(".thinking-block");
+    await expect(thinkingBlocks).toHaveCount(0);
+
+    // Response text should still be visible
+    await expect(
+      page
+        .locator(LOC.row)
+        .filter({
+          hasText: "visible response after thinking",
+        }),
+    ).toBeVisible();
   });
 });

--- a/frontend/e2e/session-count-consistency.spec.ts
+++ b/frontend/e2e/session-count-consistency.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+import { SessionsPage } from "./pages/sessions-page";
+
+test.describe("Session count consistency", () => {
+  let sp: SessionsPage;
+
+  test.beforeEach(async ({ page }) => {
+    sp = new SessionsPage(page);
+    await sp.goto();
+  });
+
+  test("session list, analytics summary, and status bar show the same count", async ({
+    page,
+  }) => {
+    // 1. Session list header count (e.g. "65 sessions")
+    const headerText = await sp.sessionListHeader.textContent();
+    const listMatch = headerText?.match(/(\d[\d,]*)\s+sessions/);
+    expect(listMatch, "session list header must show a count").toBeTruthy();
+    const listCount = parseInt(listMatch![1].replace(/,/g, ""), 10);
+
+    // 2. Status bar (bottom left) — uses /api/v1/stats
+    const statusBar = page.locator(".status-left");
+    await expect(statusBar).toContainText("sessions", { timeout: 5_000 });
+    const statusText = await statusBar.textContent();
+    const statsMatch = statusText?.match(/(\d[\d,]*)\s+sessions/);
+    expect(statsMatch, "status bar must show a session count").toBeTruthy();
+    const statsCount = parseInt(statsMatch![1].replace(/,/g, ""), 10);
+
+    // 3. Analytics summary card — uses /api/v1/analytics/summary
+    //    The analytics page is visible by default (no session selected).
+    const summaryCards = page.locator(".summary-cards");
+    await expect(summaryCards).toBeVisible({ timeout: 5_000 });
+
+    // Wait for the summary to finish loading.
+    const sessionsCard = summaryCards
+      .locator(".card")
+      .filter({ has: page.locator(".card-label", { hasText: "Sessions" }) });
+    await expect(
+      sessionsCard.locator(".card-value"),
+    ).not.toHaveText("--", { timeout: 10_000 });
+    // Also wait for skeletons to disappear.
+    await expect(
+      sessionsCard.locator(".skeleton-value"),
+    ).toHaveCount(0, { timeout: 5_000 });
+
+    const cardValue = await sessionsCard
+      .locator(".card-value")
+      .textContent();
+    const analyticsCount = parseInt(
+      cardValue?.replace(/,/g, "") ?? "0",
+      10,
+    );
+
+    // All three must be equal and non-zero.
+    expect(listCount, "session list count must be > 0").toBeGreaterThan(0);
+
+    expect(statsCount, `status bar (${statsCount}) != session list (${listCount})`).toBe(
+      listCount,
+    );
+    expect(
+      analyticsCount,
+      `analytics summary (${analyticsCount}) != session list (${listCount})`,
+    ).toBe(listCount);
+  });
+});

--- a/frontend/e2e/virtual-list.spec.ts
+++ b/frontend/e2e/virtual-list.spec.ts
@@ -81,9 +81,16 @@ test.describe("Virtual list behavior", () => {
 
     await sp.filterByProject("tiny");
 
+    // Wait for filtered results to render before checking
+    // scroll position — on CI the re-render can be slow.
+    await expect(sp.sessionListHeader).toContainText(
+      "1 sessions",
+      { timeout: 5_000 },
+    );
+
     await expect
       .poll(() => getScrollTop(sp.sessionListScroll), {
-        timeout: 2000,
+        timeout: 5_000,
       })
       .toBe(0);
   });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -202,7 +202,7 @@
                   })}
                 </span>
               {/if}
-              {#if session.agent === "claude" || session.agent === "codex"}
+              {#if session.id}
                 {@const rawId = sessionDisplayId(session.id)}
                 <button
                   class="session-id"

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -69,7 +69,7 @@ describe("triggerSync SSE parsing", () => {
   it("should parse CRLF-terminated SSE frames", async () => {
     const { handle, progress } = startSync([
       "event: progress\r\ndata: {\"phase\":\"scanning\",\"projects_total\":1,\"projects_done\":0,\"sessions_total\":0,\"sessions_done\":0,\"messages_indexed\":0}\r\n\r\n",
-      "event: done\r\ndata: {\"total_sessions\":5,\"synced\":3,\"skipped\":2}\r\n\r\n",
+      "event: done\r\ndata: {\"total_sessions\":5,\"synced\":3,\"skipped\":2,\"failed\":0}\r\n\r\n",
     ]);
 
     const stats = await handle.done;
@@ -83,7 +83,7 @@ describe("triggerSync SSE parsing", () => {
   it("should handle multi-line data: payloads", async () => {
     const { handle, progress } = startSync([
       'event: progress\ndata: {"phase":"scanning",\ndata: "projects_total":2,"projects_done":1,\ndata: "sessions_total":10,"sessions_done":5,"messages_indexed":50}\n\n',
-      'event: done\ndata: {"total_sessions":10,"synced":5,"skipped":5}\n\n',
+      'event: done\ndata: {"total_sessions":10,"synced":5,"skipped":5,"failed":0}\n\n',
     ]);
 
     await handle.done;
@@ -95,7 +95,7 @@ describe("triggerSync SSE parsing", () => {
 
   it("should process trailing frame on EOF", async () => {
     const { handle } = startSync([
-      'event: done\ndata: {"total_sessions":1,"synced":1,"skipped":0}',
+      'event: done\ndata: {"total_sessions":1,"synced":1,"skipped":0,"failed":0}',
     ]);
 
     const stats = await handle.done;
@@ -106,7 +106,7 @@ describe("triggerSync SSE parsing", () => {
 
   it("should trigger done once and stop processing after done", async () => {
     const { handle, progress } = startSync([
-      'event: done\ndata: {"total_sessions":1,"synced":1,"skipped":0}\n\n',
+      'event: done\ndata: {"total_sessions":1,"synced":1,"skipped":0,"failed":0}\n\n',
       'event: progress\ndata: {"phase":"extra","projects_total":0,"projects_done":0,"sessions_total":0,"sessions_done":0,"messages_indexed":0}\n\n',
     ]);
 
@@ -121,7 +121,7 @@ describe("triggerSync SSE parsing", () => {
 
   it("should handle data: without space after colon", async () => {
     const { handle } = startSync([
-      'event: done\ndata:{"total_sessions":3,"synced":2,"skipped":1}\n\n',
+      'event: done\ndata:{"total_sessions":3,"synced":2,"skipped":1,"failed":0}\n\n',
     ]);
 
     const stats = await handle.done;
@@ -145,7 +145,7 @@ describe("triggerSync SSE parsing", () => {
   it("should handle chunks split across frame boundaries", async () => {
     const { handle, progress } = startSync([
       'event: progress\ndata: {"phase":"scan',
-      'ning","projects_total":1,"projects_done":0,"sessions_total":0,"sessions_done":0,"messages_indexed":0}\n\nevent: done\ndata: {"total_sessions":1,"synced":1,"skipped":0}\n\n',
+      'ning","projects_total":1,"projects_done":0,"sessions_total":0,"sessions_done":0,"messages_indexed":0}\n\nevent: done\ndata: {"total_sessions":1,"synced":1,"skipped":0,"failed":0}\n\n',
     ]);
 
     await handle.done;

--- a/frontend/src/lib/api/types/sync.ts
+++ b/frontend/src/lib/api/types/sync.ts
@@ -14,6 +14,7 @@ export interface SyncStats {
   total_sessions: number;
   synced: number;
   skipped: number;
+  failed: number;
 }
 
 export interface SyncStatus {

--- a/frontend/src/lib/components/analytics/SummaryCards.svelte
+++ b/frontend/src/lib/components/analytics/SummaryCards.svelte
@@ -2,8 +2,6 @@
   import { analytics } from "../../stores/analytics.svelte.js";
 
   function formatNum(n: number): string {
-    if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
-    if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
     return n.toLocaleString();
   }
 

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -45,7 +45,7 @@
     if (!ui.showThinking) {
       msgs = msgs.filter(
         (m) => !(m.has_thinking && !m.content.replace(
-          /\[Thinking\]\n?[\s\S]*?(?:\n\[|\n\n\[|$)/g, "",
+          /\[Thinking\]\n?[\s\S]*?(?:\n\[|\n\n|$)/g, "",
         ).trim()),
       );
     }

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -45,7 +45,7 @@
     if (!ui.showThinking) {
       msgs = msgs.filter(
         (m) => !(m.has_thinking && !m.content.replace(
-          /\[Thinking\]\n?[\s\S]*?(?:\n\[|\n\n|$)/g, "",
+          /\[Thinking\]\n?[\s\S]*?(?:\n?\[\/Thinking\]|\n\[(?!\/Thinking\])|\n\n|$)/g, "",
         ).trim()),
       );
     }

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -44,9 +44,10 @@
     // Filter thinking-only messages
     if (!ui.showThinking) {
       msgs = msgs.filter(
-        (m) => !(m.has_thinking && !m.content.replace(
-          /\[Thinking\]\n?[\s\S]*?(?:\n?\[\/Thinking\]|\n\[(?!\/Thinking\])|\n\n|$)/g, "",
-        ).trim()),
+        (m) => !(m.has_thinking && !m.content
+          .replace(/\[Thinking\]\n?[\s\S]*?\n?\[\/Thinking\]/g, "")
+          .replace(/\[Thinking\]\n?[\s\S]*?(?:\n\[|\n\n|$)/g, "")
+          .trim()),
       );
     }
 

--- a/frontend/src/lib/components/modals/ResyncModal.svelte
+++ b/frontend/src/lib/components/modals/ResyncModal.svelte
@@ -117,20 +117,14 @@
       {:else if view === "done"}
         <div class="done-view">
           {#if sync.lastSyncStats}
-            <div class="stats-grid">
-              <span class="stat-label">Synced</span>
-              <span class="stat-value">
-                {sync.lastSyncStats.synced}
-              </span>
-              <span class="stat-label">Skipped</span>
-              <span class="stat-value">
-                {sync.lastSyncStats.skipped}
-              </span>
-              <span class="stat-label">Total</span>
-              <span class="stat-value">
-                {sync.lastSyncStats.total_sessions}
-              </span>
-            </div>
+            <p class="done-summary">
+              Sessions synced: {sync.lastSyncStats.synced}
+            </p>
+            {#if sync.lastSyncStats.failed > 0}
+              <p class="done-warning">
+                Failed: {sync.lastSyncStats.failed}
+              </p>
+            {/if}
           {/if}
           <div class="done-actions">
             <button
@@ -215,20 +209,15 @@
     gap: 16px;
   }
 
-  .stats-grid {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 4px 12px;
+  .done-summary {
     font-size: 12px;
-  }
-
-  .stat-label {
-    color: var(--text-muted);
-    font-weight: 500;
-  }
-
-  .stat-value {
     color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .done-warning {
+    font-size: 12px;
+    color: var(--accent-orange, #e09040);
     font-variant-numeric: tabular-nums;
   }
 

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -57,7 +57,7 @@ type Panel =
   | "topSessions";
 
 class AnalyticsStore {
-  from: string = $state(daysAgo(365));
+  from: string = $state("1970-01-01");
   to: string = $state(today());
   granularity: Granularity = $state("day");
   metric: HeatmapMetric = $state("messages");

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -21,6 +21,7 @@ vi.mock("../api/client.js", () => ({
 const MOCK_STATS: SyncStats = {
   synced: 5,
   skipped: 3,
+  failed: 0,
   total_sessions: 8,
 };
 

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -220,6 +220,33 @@ describe("parseContent - thinking blocks", () => {
     expect(textSegs).toHaveLength(1);
     expect(textSegs[0]!.content).toBe("Response");
   });
+
+  it("preserves blank lines inside marked thinking block", () => {
+    const text =
+      "[Thinking]\npara1\n\npara2\n[/Thinking]";
+    const segments = parseContent(text, false);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]!.type).toBe("thinking");
+    expect(segments[0]!.content).toContain("para1");
+    expect(segments[0]!.content).toContain("para2");
+  });
+
+  it("preserves bracket lines inside marked thinking", () => {
+    const text =
+      "[Thinking]\nI see [Read: foo] in the code\n" +
+      "[/Thinking]\n\nResponse";
+    const segments = parseContent(text, false);
+    const thinking = segments.filter(
+      (s) => s.type === "thinking",
+    );
+    expect(thinking).toHaveLength(1);
+    expect(thinking[0]!.content).toContain("[Read: foo]");
+    const textSegs = segments.filter(
+      (s) => s.type === "text",
+    );
+    expect(textSegs).toHaveLength(1);
+    expect(textSegs[0]!.content).toBe("Response");
+  });
 });
 
 describe("isToolOnly", () => {

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -139,6 +139,56 @@ describe("parseContent", () => {
   });
 });
 
+describe("parseContent - thinking blocks", () => {
+  it("separates thinking from following text at blank line", () => {
+    const text =
+      "[Thinking]\nsome thoughts\n\nHere is my response";
+    const segments = parseContent(text, false);
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({
+      type: "thinking",
+      content: "some thoughts",
+    });
+    expect(segments[1]).toMatchObject({
+      type: "text",
+      content: "Here is my response",
+    });
+  });
+
+  it("merges consecutive thinking blocks into one", () => {
+    const text =
+      "[Thinking]\nfirst thought\n[Thinking]\nsecond thought";
+    const segments = parseContent(text, false);
+    const thinking = segments.filter(
+      (s) => s.type === "thinking",
+    );
+    expect(thinking).toHaveLength(1);
+    expect(thinking[0]!.content).toContain("first thought");
+    expect(thinking[0]!.content).toContain("second thought");
+  });
+
+  it("does not merge thinking blocks separated by text", () => {
+    const text =
+      "[Thinking]\nthought one\n\nSome text\n[Thinking]\nthought two";
+    const segments = parseContent(text, false);
+    const thinking = segments.filter(
+      (s) => s.type === "thinking",
+    );
+    expect(thinking).toHaveLength(2);
+  });
+
+  it("shows response text when thinking is stripped", () => {
+    const text =
+      "[Thinking]\nanalysis\n\nThe answer is 42.";
+    const segments = parseContent(text, false);
+    const textSegs = segments.filter(
+      (s) => s.type === "text",
+    );
+    expect(textSegs).toHaveLength(1);
+    expect(textSegs[0]!.content).toBe("The answer is 42.");
+  });
+});
+
 describe("isToolOnly", () => {
   it("returns false for user messages", () => {
     const msg = makeMsg({ role: "user", content: "[Bash]\nhi" });

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -187,6 +187,39 @@ describe("parseContent - thinking blocks", () => {
     expect(textSegs).toHaveLength(1);
     expect(textSegs[0]!.content).toBe("The answer is 42.");
   });
+
+  it("uses [/Thinking] end marker to delimit content", () => {
+    const text =
+      "[Thinking]\nmy thoughts\n[/Thinking]\n\nResponse text";
+    const segments = parseContent(text, false);
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({
+      type: "thinking",
+      content: "my thoughts",
+    });
+    expect(segments[1]).toMatchObject({
+      type: "text",
+      content: "Response text",
+    });
+  });
+
+  it("handles end marker with no blank line before text", () => {
+    const text =
+      "[Thinking]\nthoughts\n[/Thinking]\n" +
+      "[Thinking]\nmore\n[/Thinking]\n\nResponse";
+    const segments = parseContent(text, false);
+    const thinking = segments.filter(
+      (s) => s.type === "thinking",
+    );
+    expect(thinking).toHaveLength(1);
+    expect(thinking[0]!.content).toContain("thoughts");
+    expect(thinking[0]!.content).toContain("more");
+    const textSegs = segments.filter(
+      (s) => s.type === "text",
+    );
+    expect(textSegs).toHaveLength(1);
+    expect(textSegs[0]!.content).toBe("Response");
+  });
 });
 
 describe("isToolOnly", () => {

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -17,7 +17,7 @@ export interface ContentSegment {
  * internal/server/export.go:403-412
  */
 const THINKING_RE =
-  /\[Thinking\]\n?([\s\S]*?)(?=\n\[|\n\n|$)/g;
+  /\[Thinking\]\n?([\s\S]*?)(?:\n?\[\/Thinking\]|(?=\n\[(?!\/Thinking\])|\n\n|$))/g;
 
 const TOOL_NAMES =
   "Tool|Read|Write|Edit|Bash|Glob|Grep|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Skill|" +

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -93,7 +93,10 @@ func (f AnalyticsFilter) utcRange() (string, string) {
 func (f AnalyticsFilter) buildWhere(
 	dateCol string,
 ) (string, []any) {
-	preds := []string{"message_count > 0"}
+	preds := []string{
+		"message_count > 0",
+		"relationship_type NOT IN ('subagent', 'fork')",
+	}
 	var args []any
 
 	utcFrom, utcTo := f.utcRange()

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -172,7 +172,7 @@ func (db *DB) filteredSessionIDs(
 		JOIN messages m ON m.session_id = s.id
 		WHERE ` + where + ` AND m.timestamp != ''`
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"querying filtered session IDs: %w", err,
@@ -312,7 +312,7 @@ func (db *DB) GetAnalyticsSummary(
 		FROM sessions WHERE ` + where +
 		` ORDER BY message_count ASC`
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return AnalyticsSummary{},
 			fmt.Errorf("querying analytics summary: %w", err)
@@ -498,7 +498,7 @@ func (db *DB) GetAnalyticsActivity(
 		WHERE ` + where + `
 		GROUP BY s.id, m.role, m.has_thinking`
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return ActivityResponse{},
 			fmt.Errorf("querying analytics activity: %w", err)
@@ -607,7 +607,7 @@ func (db *DB) mergeActivityToolCalls(
 		FROM tool_calls
 		WHERE session_id IN ` + ph + `
 		GROUP BY session_id`
-	rows, err := db.reader.QueryContext(ctx, q, args...)
+	rows, err := db.getReader().QueryContext(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf(
 			"querying activity tool_calls: %w", err,
@@ -680,7 +680,7 @@ func (db *DB) GetAnalyticsHeatmap(
 	query := `SELECT id, ` + dateCol + `, message_count
 		FROM sessions WHERE ` + where
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return HeatmapResponse{},
 			fmt.Errorf("querying analytics heatmap: %w", err)
@@ -840,7 +840,7 @@ func (db *DB) GetAnalyticsProjects(
 		FROM sessions WHERE ` + where +
 		` ORDER BY project, ` + dateCol
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return ProjectsAnalyticsResponse{},
 			fmt.Errorf("querying analytics projects: %w", err)
@@ -977,7 +977,7 @@ func (db *DB) GetAnalyticsHourOfWeek(
 		JOIN messages m ON m.session_id = s.id
 		WHERE ` + where + ` AND m.timestamp != ''`
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return HourOfWeekResponse{},
 			fmt.Errorf("querying hour-of-week: %w", err)
@@ -1156,7 +1156,7 @@ func (db *DB) GetAnalyticsSessionShape(
 	query := `SELECT ` + dateCol + `, started_at, ended_at,
 		message_count, id FROM sessions WHERE ` + where
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return SessionShapeResponse{},
 			fmt.Errorf("querying session shape: %w", err)
@@ -1246,7 +1246,7 @@ func (db *DB) queryAutonomyChunk(
 		WHERE session_id IN ` + ph + `
 		GROUP BY session_id`
 
-	rows, err := db.reader.QueryContext(ctx, q, args...)
+	rows, err := db.getReader().QueryContext(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("querying autonomy: %w", err)
 	}
@@ -1321,7 +1321,7 @@ func (db *DB) GetAnalyticsTools(
 	sessQ := `SELECT id, ` + dateCol + `, agent
 		FROM sessions WHERE ` + where
 
-	sessRows, err := db.reader.QueryContext(ctx, sessQ, args...)
+	sessRows, err := db.getReader().QueryContext(ctx, sessQ, args...)
 	if err != nil {
 		return ToolsAnalyticsResponse{},
 			fmt.Errorf("querying tool sessions: %w", err)
@@ -1379,7 +1379,7 @@ func (db *DB) GetAnalyticsTools(
 			q := `SELECT session_id, category
 				FROM tool_calls
 				WHERE session_id IN ` + ph
-			rows, qErr := db.reader.QueryContext(
+			rows, qErr := db.getReader().QueryContext(
 				ctx, q, chunkArgs...,
 			)
 			if qErr != nil {
@@ -1534,7 +1534,7 @@ func (db *DB) queryVelocityMsgs(
 		WHERE session_id IN ` + ph + `
 		ORDER BY session_id, ordinal`
 
-	rows, err := db.reader.QueryContext(ctx, q, args...)
+	rows, err := db.getReader().QueryContext(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf(
 			"querying velocity messages: %w", err,
@@ -1667,7 +1667,7 @@ func (db *DB) GetAnalyticsVelocity(
 	sessQuery := `SELECT id, ` + dateCol + `, agent,
 		message_count FROM sessions WHERE ` + where
 
-	sessRows, err := db.reader.QueryContext(
+	sessRows, err := db.getReader().QueryContext(
 		ctx, sessQuery, args...,
 	)
 	if err != nil {
@@ -1735,7 +1735,7 @@ func (db *DB) GetAnalyticsVelocity(
 				FROM tool_calls
 				WHERE session_id IN ` + ph + `
 				GROUP BY session_id`
-			rows, qErr := db.reader.QueryContext(
+			rows, qErr := db.getReader().QueryContext(
 				ctx, q, chunkArgs...,
 			)
 			if qErr != nil {
@@ -1981,7 +1981,7 @@ func (db *DB) GetAnalyticsTopSessions(
 		FROM sessions WHERE ` + where +
 		` ORDER BY ` + orderExpr + ` LIMIT 200`
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return TopSessionsResponse{},
 			fmt.Errorf("querying top sessions: %w", err)

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -96,7 +96,7 @@ func (db *DB) GetMessages(
 		ORDER BY ordinal %s
 		LIMIT ?`, selectMessageCols, op, dir)
 
-	rows, err := db.reader.QueryContext(
+	rows, err := db.getReader().QueryContext(
 		ctx, query, sessionID, from, limit,
 	)
 	if err != nil {
@@ -117,7 +117,7 @@ func (db *DB) GetMessages(
 func (db *DB) GetAllMessages(
 	ctx context.Context, sessionID string,
 ) ([]Message, error) {
-	rows, err := db.reader.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := db.getReader().QueryContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM messages
 		WHERE session_id = ?
@@ -148,7 +148,7 @@ func (db *DB) GetMinimap(
 func (db *DB) GetMinimapFrom(
 	ctx context.Context, sessionID string, from int,
 ) ([]MinimapEntry, error) {
-	rows, err := db.reader.QueryContext(ctx, `
+	rows, err := db.getReader().QueryContext(ctx, `
 		SELECT ordinal, role, content_length, has_thinking, has_tool_use
 		FROM messages
 		WHERE session_id = ? AND ordinal >= ?
@@ -302,7 +302,7 @@ func (db *DB) InsertMessages(msgs []Message) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	tx, err := db.writer.Begin()
+	tx, err := db.getWriter().Begin()
 	if err != nil {
 		return fmt.Errorf("beginning tx: %w", err)
 	}
@@ -324,7 +324,7 @@ func (db *DB) InsertMessages(msgs []Message) error {
 // or -1 if the session has no messages.
 func (db *DB) MaxOrdinal(sessionID string) int {
 	var n sql.NullInt64
-	err := db.reader.QueryRow(
+	err := db.getReader().QueryRow(
 		"SELECT MAX(ordinal) FROM messages"+
 			" WHERE session_id = ?",
 		sessionID,
@@ -354,7 +354,7 @@ func (db *DB) ReplaceSessionMessages(
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	tx, err := db.writer.Begin()
+	tx, err := db.getWriter().Begin()
 	if err != nil {
 		return fmt.Errorf("beginning tx: %w", err)
 	}
@@ -440,7 +440,7 @@ func (db *DB) attachToolCallsBatch(
 		ORDER BY id`,
 		strings.Join(placeholders, ","))
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("querying tool_calls: %w", err)
 	}
@@ -504,7 +504,7 @@ func scanMessages(rows *sql.Rows) ([]Message, error) {
 // MessageCount returns the number of messages for a session.
 func (db *DB) MessageCount(sessionID string) (int, error) {
 	var count int
-	err := db.reader.QueryRow(
+	err := db.getReader().QueryRow(
 		"SELECT COUNT(*) FROM messages WHERE session_id = ?",
 		sessionID,
 	).Scan(&count)
@@ -515,7 +515,7 @@ func (db *DB) MessageCount(sessionID string) (int, error) {
 func (db *DB) GetMessageByOrdinal(
 	sessionID string, ordinal int,
 ) (*Message, error) {
-	row := db.reader.QueryRow(fmt.Sprintf(`
+	row := db.getReader().QueryRow(fmt.Sprintf(`
 		SELECT %s
 		FROM messages
 		WHERE session_id = ? AND ordinal = ?`, selectMessageCols),

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -332,6 +332,45 @@ func (db *DB) DeleteSessionMessages(sessionID string) error {
 	return err
 }
 
+// DeleteMessagesForSessions bulk-deletes messages and tool_calls
+// for multiple sessions in a single transaction.
+func (db *DB) DeleteMessagesForSessions(
+	sessionIDs []string,
+) error {
+	if len(sessionIDs) == 0 {
+		return nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	tx, err := db.writer.Begin()
+	if err != nil {
+		return fmt.Errorf("beginning tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, id := range sessionIDs {
+		if _, err := tx.Exec(
+			"DELETE FROM tool_calls WHERE session_id = ?",
+			id,
+		); err != nil {
+			return fmt.Errorf(
+				"delete tool_calls for %s: %w", id, err,
+			)
+		}
+		if _, err := tx.Exec(
+			"DELETE FROM messages WHERE session_id = ?",
+			id,
+		); err != nil {
+			return fmt.Errorf(
+				"delete messages for %s: %w", id, err,
+			)
+		}
+	}
+
+	return tx.Commit()
+}
+
 // ReplaceSessionMessages deletes existing and inserts new messages
 // in a single transaction.
 func (db *DB) ReplaceSessionMessages(

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -322,25 +322,6 @@ func (db *DB) MaxOrdinal(sessionID string) int {
 	return int(n.Int64)
 }
 
-// MessageContentStats returns the message count and total
-// content length for a session. Used for cheap change detection
-// during resync to avoid expensive FTS5 delete+reinsert when
-// content hasn't changed.
-func (db *DB) MessageContentStats(
-	sessionID string,
-) (count, totalLen int) {
-	err := db.reader.QueryRow(
-		"SELECT COUNT(*),"+
-			" COALESCE(SUM(LENGTH(content)), 0)"+
-			" FROM messages WHERE session_id = ?",
-		sessionID,
-	).Scan(&count, &totalLen)
-	if err != nil {
-		return 0, 0
-	}
-	return
-}
-
 // DeleteSessionMessages removes all messages for a session.
 func (db *DB) DeleteSessionMessages(sessionID string) error {
 	db.mu.Lock()

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -322,6 +322,25 @@ func (db *DB) MaxOrdinal(sessionID string) int {
 	return int(n.Int64)
 }
 
+// MessageContentStats returns the message count and total
+// content length for a session. Used for cheap change detection
+// during resync to avoid expensive FTS5 delete+reinsert when
+// content hasn't changed.
+func (db *DB) MessageContentStats(
+	sessionID string,
+) (count, totalLen int) {
+	err := db.reader.QueryRow(
+		"SELECT COUNT(*),"+
+			" COALESCE(SUM(LENGTH(content)), 0)"+
+			" FROM messages WHERE session_id = ?",
+		sessionID,
+	).Scan(&count, &totalLen)
+	if err != nil {
+		return 0, 0
+	}
+	return
+}
+
 // DeleteSessionMessages removes all messages for a session.
 func (db *DB) DeleteSessionMessages(sessionID string) error {
 	db.mu.Lock()

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -70,7 +70,7 @@ func (db *DB) Search(
 	)
 	args = append(args, f.Limit+1, f.Cursor)
 
-	rows, err := db.reader.QueryContext(ctx, query, args...)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
 		return SearchPage{}, fmt.Errorf("searching: %w", err)
 	}

--- a/internal/db/skipped.go
+++ b/internal/db/skipped.go
@@ -5,7 +5,7 @@ import "fmt"
 // LoadSkippedFiles returns all persisted skip cache entries
 // as a map from file_path to file_mtime.
 func (db *DB) LoadSkippedFiles() (map[string]int64, error) {
-	rows, err := db.reader.Query(
+	rows, err := db.getReader().Query(
 		"SELECT file_path, file_mtime FROM skipped_files",
 	)
 	if err != nil {
@@ -38,7 +38,7 @@ func (db *DB) ReplaceSkippedFiles(
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	tx, err := db.writer.Begin()
+	tx, err := db.getWriter().Begin()
 	if err != nil {
 		return fmt.Errorf("begin: %w", err)
 	}
@@ -75,7 +75,7 @@ func (db *DB) ReplaceSkippedFiles(
 func (db *DB) DeleteSkippedFile(path string) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	_, err := db.writer.Exec(
+	_, err := db.getWriter().Exec(
 		"DELETE FROM skipped_files WHERE file_path = ?",
 		path,
 	)

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -18,6 +18,27 @@ type Stats struct {
 const rootSessionFilter = `message_count > 0
 	AND relationship_type NOT IN ('subagent', 'fork')`
 
+// FileBackedSessionCount returns the number of root sessions
+// synced from files (excludes OpenCode, which is DB-backed).
+// Used by ResyncAll to decide whether empty file discovery
+// should abort the swap.
+func (db *DB) FileBackedSessionCount(
+	ctx context.Context,
+) (int, error) {
+	var count int
+	err := db.getReader().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sessions
+		 WHERE agent != 'opencode'
+		 AND `+rootSessionFilter,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"counting file-backed sessions: %w", err,
+		)
+	}
+	return count, nil
+}
+
 // GetStats returns database statistics, counting only root
 // sessions with messages (matching the session list filter).
 func (db *DB) GetStats(ctx context.Context) (Stats, error) {

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -24,7 +24,7 @@ func (db *DB) GetStats(ctx context.Context) (Stats, error) {
 			(SELECT COUNT(DISTINCT machine) FROM sessions)`
 
 	var s Stats
-	err := db.reader.QueryRowContext(ctx, query).Scan(
+	err := db.getReader().QueryRowContext(ctx, query).Scan(
 		&s.SessionCount,
 		&s.MessageCount,
 		&s.ProjectCount,

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -119,7 +119,7 @@ Part 2`,
 			wantError: "rate limited",
 		},
 		{
-			name: "empty",
+			name:  "empty",
 			input: "",
 			want:  "",
 		},

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -25,12 +25,12 @@ func runClaudeParserTest(t *testing.T, fileName, content string) (ParsedSession,
 func TestParseClaudeSession_Basic(t *testing.T) {
 	content := loadFixture(t, "claude/valid_session.jsonl")
 	sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
-	
+
 	assertMessageCount(t, len(msgs), 4)
 	assertMessageCount(t, sess.MessageCount, 4)
 	assertSessionMeta(t, &sess, "test", "my_app", AgentClaude)
 	assert.Equal(t, "Fix the login bug", sess.FirstMessage)
-	
+
 	assertMessage(t, msgs[0], RoleUser, "")
 	assertMessage(t, msgs[1], RoleAssistant, "")
 	assert.True(t, msgs[1].HasToolUse)

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -22,7 +22,7 @@ func runCodexParserTest(t *testing.T, fileName, content string, includeExec bool
 func TestParseCodexSession_Basic(t *testing.T) {
 	content := loadFixture(t, "codex/standard_session.jsonl")
 	sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
-	
+
 	require.NotNil(t, sess)
 	assert.Equal(t, "codex:abc-123", sess.ID)
 	assert.Equal(t, 2, len(msgs))
@@ -52,22 +52,22 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 	t.Run("function calls", func(t *testing.T) {
 		content := loadFixture(t, "codex/function_calls.jsonl")
 		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
-		
+
 		require.NotNil(t, sess)
 		assert.Equal(t, "codex:fc-1", sess.ID)
 		assert.Equal(t, 3, len(msgs))
-		
+
 		assert.Equal(t, RoleUser, msgs[0].Role)
 		assert.False(t, msgs[0].HasToolUse)
-		
+
 		assert.Equal(t, RoleAssistant, msgs[1].Role)
 		assert.True(t, msgs[1].HasToolUse)
 		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{ToolName: "shell_command", Category: "Bash"}})
 		assert.Equal(t, "[Bash: Running tests]", msgs[1].Content)
-		
+
 		assert.True(t, msgs[2].HasToolUse)
 		assertToolCalls(t, msgs[2].ToolCalls, []ParsedToolCall{{ToolName: "apply_patch", Category: "Edit"}})
-		
+
 		for i, m := range msgs {
 			assert.Equal(t, i, m.Ordinal)
 		}
@@ -85,7 +85,7 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		want := "[Edit: internal/parser/codex.go (+1 more)]\ninternal/parser/codex.go\ninternal/parser/parser_test.go"
 		assert.Equal(t, want, msgs[1].Content)
 	})
-	
+
 	t.Run("write_stdin formats with session and chars", func(t *testing.T) {
 		content := loadFixture(t, "codex/fc_stdin.jsonl")
 		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)

--- a/internal/parser/content.go
+++ b/internal/parser/content.go
@@ -39,7 +39,8 @@ func ExtractTextContent(
 			thinking := block.Get("thinking").Str
 			if thinking != "" {
 				hasThinking = true
-				parts = append(parts, "[Thinking]\n"+thinking)
+				parts = append(parts,
+					"[Thinking]\n"+thinking+"\n[/Thinking]")
 			}
 		case "tool_use":
 			hasToolUse = true

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -153,7 +153,7 @@ func extractGeminiContent(
 				if subj != "" {
 					parts = append(parts,
 						fmt.Sprintf(
-							"[Thinking: %s]\n%s", subj, desc,
+							"[Thinking]\n%s\n%s", subj, desc,
 						),
 					)
 				} else {

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -138,12 +138,13 @@ func extractGeminiContent(
 				if subj != "" {
 					parts = append(parts,
 						fmt.Sprintf(
-							"[Thinking]\n%s\n%s", subj, desc,
+							"[Thinking]\n%s\n%s\n[/Thinking]",
+							subj, desc,
 						),
 					)
 				} else {
 					parts = append(parts,
-						"[Thinking]\n"+desc,
+						"[Thinking]\n"+desc+"\n[/Thinking]",
 					)
 				}
 			}

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -127,22 +127,7 @@ func extractGeminiContent(
 		hasToolUse  bool
 	)
 
-	// Extract main content (string or Part[] array)
-	content := msg.Get("content")
-	if content.Type == gjson.String {
-		if t := content.Str; t != "" {
-			parts = append(parts, t)
-		}
-	} else if content.IsArray() {
-		content.ForEach(func(_, part gjson.Result) bool {
-			if t := part.Get("text").Str; t != "" {
-				parts = append(parts, t)
-			}
-			return true
-		})
-	}
-
-	// Extract thoughts
+	// Extract thoughts (appear before content chronologically)
 	thoughts := msg.Get("thoughts")
 	if thoughts.IsArray() {
 		thoughts.ForEach(func(_, thought gjson.Result) bool {
@@ -161,6 +146,21 @@ func extractGeminiContent(
 						"[Thinking]\n"+desc,
 					)
 				}
+			}
+			return true
+		})
+	}
+
+	// Extract main content (string or Part[] array)
+	content := msg.Get("content")
+	if content.Type == gjson.String {
+		if t := content.Str; t != "" {
+			parts = append(parts, t)
+		}
+	} else if content.IsArray() {
+		content.ForEach(func(_, part gjson.Result) bool {
+			if t := part.Get("text").Str; t != "" {
+				parts = append(parts, t)
 			}
 			return true
 		})

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -183,7 +183,7 @@ func extractGeminiContent(
 		})
 	}
 
-	return strings.Join(parts, "\n"),
+	return strings.Join(parts, "\n\n"),
 		hasThinking, hasToolUse, parsed
 }
 

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -44,6 +44,12 @@ func TestParseGeminiSession_ToolCalls(t *testing.T) {
 		assert.True(t, msgs[1].HasThinking)
 		assert.True(t, strings.Contains(msgs[1].Content, "[Thinking]\nPlanning\n"))
 		assert.True(t, strings.Contains(msgs[1].Content, "[Read: main.go]"))
+		// Chronological: thinking before content before tool calls
+		thinkIdx := strings.Index(msgs[1].Content, "[Thinking]")
+		contentIdx := strings.Index(msgs[1].Content, "Let me read it.")
+		toolIdx := strings.Index(msgs[1].Content, "[Read:")
+		assert.Less(t, thinkIdx, contentIdx)
+		assert.Less(t, contentIdx, toolIdx)
 		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{ToolName: "read_file", Category: "Read"}})
 	})
 

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -42,7 +42,7 @@ func TestParseGeminiSession_ToolCalls(t *testing.T) {
 		assert.Equal(t, 2, len(msgs))
 		assert.True(t, msgs[1].HasToolUse)
 		assert.True(t, msgs[1].HasThinking)
-		assert.True(t, strings.Contains(msgs[1].Content, "[Thinking: Planning]"))
+		assert.True(t, strings.Contains(msgs[1].Content, "[Thinking]\nPlanning\n"))
 		assert.True(t, strings.Contains(msgs[1].Content, "[Read: main.go]"))
 		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{ToolName: "read_file", Category: "Read"}})
 	})

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -21,13 +21,13 @@ func runGeminiParserTest(t *testing.T, content string) (*ParsedSession, []Parsed
 func TestParseGeminiSession_Basic(t *testing.T) {
 	content := loadFixture(t, "gemini/standard_session.json")
 	sess, msgs := runGeminiParserTest(t, content)
-	
+
 	require.NotNil(t, sess)
 	assertMessageCount(t, len(msgs), 4)
 	assertMessageCount(t, sess.MessageCount, 4)
 	assertSessionMeta(t, sess, "gemini:sess-uuid-1", "my_project", AgentGemini)
 	assert.Equal(t, "Fix the login bug", sess.FirstMessage)
-	
+
 	assertMessage(t, msgs[0], RoleUser, "Fix the login bug")
 	assertMessage(t, msgs[1], RoleAssistant, "Looking at")
 	assert.Equal(t, 0, msgs[0].Ordinal)
@@ -38,7 +38,7 @@ func TestParseGeminiSession_ToolCalls(t *testing.T) {
 	t.Run("basic tool calls", func(t *testing.T) {
 		content := loadFixture(t, "gemini/tool_calls.json")
 		_, msgs := runGeminiParserTest(t, content)
-		
+
 		assert.Equal(t, 2, len(msgs))
 		assert.True(t, msgs[1].HasToolUse)
 		assert.True(t, msgs[1].HasThinking)
@@ -86,13 +86,13 @@ func TestParseGeminiSession_EdgeCases(t *testing.T) {
 		require.NotNil(t, sess)
 		assert.Equal(t, 303, len(sess.FirstMessage))
 	})
-	
+
 	t.Run("malformed JSON", func(t *testing.T) {
 		path := createTestFile(t, "session.json", "not valid json {{{")
 		_, _, err := ParseGeminiSession(path, "my_project", "local")
 		assert.Error(t, err)
 	})
-	
+
 	t.Run("missing file", func(t *testing.T) {
 		_, _, err := ParseGeminiSession("/nonexistent.json", "my_project", "local")
 		assert.Error(t, err)

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -43,6 +43,7 @@ func TestParseGeminiSession_ToolCalls(t *testing.T) {
 		assert.True(t, msgs[1].HasToolUse)
 		assert.True(t, msgs[1].HasThinking)
 		assert.True(t, strings.Contains(msgs[1].Content, "[Thinking]\nPlanning\n"))
+		assert.True(t, strings.Contains(msgs[1].Content, "[/Thinking]"))
 		assert.True(t, strings.Contains(msgs[1].Content, "[Read: main.go]"))
 		// Chronological: thinking before content before tool calls
 		thinkIdx := strings.Index(msgs[1].Content, "[Thinking]")

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -491,7 +491,8 @@ func buildOpenCodeMessage(
 			text := extractOpenCodeText(p.data)
 			if text != "" {
 				hasThinking = true
-				texts = append(texts, "[Thinking]\n"+text)
+				texts = append(texts,
+					"[Thinking]\n"+text+"\n[/Thinking]")
 			}
 		}
 		// skip step-start, step-finish, patch, etc.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -685,10 +685,6 @@ func TestIsClaudeSystemMessage(t *testing.T) {
 	}
 }
 
-
-
-
-
 func TestCodexUserMessageCount(t *testing.T) {
 	content := testjsonl.JoinJSONL(
 		testjsonl.CodexSessionMetaJSON(
@@ -893,13 +889,11 @@ func TestExtractClaudeProjectHints(t *testing.T) {
 	})
 }
 
-
-
 func TestFormatGeminiToolCall(t *testing.T) {
 	tests := []struct {
 		toolName string
-		json string
-		want string
+		json     string
+		want     string
 	}{
 		{
 			"read_file",

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -143,7 +143,7 @@ func TestExtractTextContent(t *testing.T) {
 		{
 			"thinking block",
 			`[{"type":"thinking","thinking":"Let me think..."}]`,
-			"[Thinking]\nLet me think...", true, false, nil,
+			"[Thinking]\nLet me think...\n[/Thinking]", true, false, nil,
 		},
 		{
 			"tool_use block",

--- a/internal/parser/testdata/gemini/thinking_only.json
+++ b/internal/parser/testdata/gemini/thinking_only.json
@@ -1,0 +1,33 @@
+{
+  "lastUpdated": "2024-01-01T10:00:05Z",
+  "messages": [
+    {
+      "content": "Explain how this works",
+      "id": "u1",
+      "timestamp": "2024-01-01T10:00:00Z",
+      "type": "user"
+    },
+    {
+      "content": "Here is how it works: the system reads the config file on startup.",
+      "id": "a1",
+      "model": "gemini-2.5-pro",
+      "thoughts": [
+        {
+          "description": "The user wants an explanation of the system.",
+          "subject": "Understanding request",
+          "timestamp": "2024-01-01T10:00:01Z"
+        },
+        {
+          "description": "I should describe the config loading flow.",
+          "subject": "Planning response",
+          "timestamp": "2024-01-01T10:00:02Z"
+        }
+      ],
+      "timestamp": "2024-01-01T10:00:05Z",
+      "type": "gemini"
+    }
+  ],
+  "projectHash": "abc123def456",
+  "sessionId": "sess-uuid-thinking",
+  "startTime": "2024-01-01T10:00:00Z"
+}

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -576,7 +576,7 @@ var (
 	codeBlockRe  = regexp.MustCompile("(?s)```(\\w*)\\n(.*?)```")
 	inlineCodeRe = regexp.MustCompile("`([^`]+)`")
 	thinkingRe   = regexp.MustCompile(
-		`(?s)\[Thinking\]\n?(.*?)(?:\n\[|\n\n\[|$)`)
+		`(?s)\[Thinking\]\n?(.*?)(?:\n\[|\n\n|$)`)
 	toolBlockRe = regexp.MustCompile(
 		`(?s)\[(Tool|Read|Write|Edit|Bash|Glob|Grep|Task|` +
 			`Question|Todo List|Entering Plan Mode|` +

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -576,7 +576,7 @@ var (
 	codeBlockRe  = regexp.MustCompile("(?s)```(\\w*)\\n(.*?)```")
 	inlineCodeRe = regexp.MustCompile("`([^`]+)`")
 	thinkingRe   = regexp.MustCompile(
-		`(?s)\[Thinking\]\n?(.*?)(?:\n\[|\n\n|$)`)
+		`(?s)\[Thinking\]\n?(.*?)(?:\n?\[/Thinking\]|\n\[|\n\n|$)`)
 	toolBlockRe = regexp.MustCompile(
 		`(?s)\[(Tool|Read|Write|Edit|Bash|Glob|Grep|Task|` +
 			`Question|Todo List|Entering Plan Mode|` +

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -359,8 +359,10 @@ func (e *Engine) ResyncAll(
 	// failed than succeeded (e.g. permission errors, disk
 	// issues). A few permanent parse failures are tolerated
 	// since those files were broken in the old DB too.
+	// Both Failed and FilesOK count files, so the comparison
+	// is unit-consistent.
 	abortSwap := (stats.Synced == 0 && stats.TotalSessions > 0) ||
-		(stats.Failed > 0 && stats.Failed > stats.Synced)
+		(stats.Failed > 0 && stats.Failed > stats.filesOK)
 	if abortSwap {
 		log.Printf(
 			"resync: aborting swap, %d synced / %d failed / %d total",
@@ -682,6 +684,7 @@ func (e *Engine) collectAndBatch(
 			continue
 		}
 		e.clearSkip(r.path)
+		stats.filesOK++
 
 		for _, pr := range r.results {
 			pending = append(pending, pendingWrite{

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -405,6 +405,13 @@ func (e *Engine) ResyncAll(
 		stats.Warnings = append(stats.Warnings,
 			"close before swap failed: "+err.Error(),
 		)
+		removeTempDB(tempPath)
+		// Connections may be partially closed; reopen to
+		// restore service before returning.
+		if rerr := origDB.Reopen(); rerr != nil {
+			log.Printf("resync: recovery reopen: %v", rerr)
+		}
+		return stats
 	}
 
 	// Remove WAL/SHM while connections are closed.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -31,7 +31,7 @@ type Engine struct {
 	geminiDirs    []string
 	opencodeDirs  []string
 	machine       string
-	syncMu        gosync.Mutex // serializes full sync runs
+	syncMu        gosync.Mutex // serializes all sync operations
 	mu            gosync.RWMutex
 	lastSync      time.Time
 	lastSyncStats SyncStats
@@ -355,6 +355,12 @@ func (e *Engine) ResyncAll(
 			"search index rebuild failed: "+err.Error(),
 		)
 	}
+
+	// Update cached stats so /api/v1/sync/status includes
+	// any warnings appended after syncAllLocked returned.
+	e.mu.Lock()
+	e.lastSyncStats = stats
+	e.mu.Unlock()
 
 	return stats
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -351,6 +351,9 @@ func (e *Engine) ResyncAll(
 	// 5. Recreate FTS table and rebuild index from content.
 	if err := e.db.RebuildFTS(); err != nil {
 		log.Printf("resync: rebuild fts: %v", err)
+		stats.Warnings = append(stats.Warnings,
+			"search index rebuild failed: "+err.Error(),
+		)
 	}
 
 	return stats

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -522,12 +522,6 @@ func (e *Engine) syncOneOpenCode(dir string) []pendingWrite {
 		})
 	}
 
-	if len(pending) > 0 {
-		log.Printf(
-			"sync: %d opencode session(s) updated",
-			len(pending),
-		)
-	}
 	return pending
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -394,6 +394,7 @@ func (e *Engine) ResyncAll(
 		stats.Warnings = append(stats.Warnings,
 			"close before swap failed: "+err.Error(),
 		)
+		newDB.Close()
 		removeTempDB(tempPath)
 		// Connections may be partially closed; reopen to
 		// restore service before returning.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -377,6 +377,7 @@ func (e *Engine) ResyncAll(
 	// files were broken in the old DB too.
 	emptyDiscovery := stats.filesDiscovered == 0 &&
 		stats.filesOK == 0 &&
+		stats.Synced == 0 &&
 		oldStats.SessionCount > 0
 	abortSwap := emptyDiscovery ||
 		(stats.Synced == 0 && stats.TotalSessions > 0) ||

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -100,6 +100,9 @@ func (e *Engine) SyncPaths(paths []string) {
 		return
 	}
 
+	e.syncMu.Lock()
+	defer e.syncMu.Unlock()
+
 	results := e.startWorkers(files)
 	stats := e.collectAndBatch(
 		results, len(files), nil, false,
@@ -1092,6 +1095,9 @@ func (e *Engine) FindSourceFile(sessionID string) string {
 // Unlike the bulk SyncAll path, this includes exec-originated
 // Codex sessions and uses the existing DB project as fallback.
 func (e *Engine) SyncSingleSession(sessionID string) error {
+	e.syncMu.Lock()
+	defer e.syncMu.Unlock()
+
 	if strings.HasPrefix(sessionID, "opencode:") {
 		return e.syncSingleOpenCode(sessionID)
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	gosync "sync"
 	"testing"
@@ -1777,6 +1778,13 @@ func TestResyncAllAbortsOnFailures(t *testing.T) {
 
 	env.engine.SyncAll(nil)
 	assertSessionMessageCount(t, env.db, "abort-test", 2)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod(0) does not prevent reads on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root can read mode-0 files")
+	}
 
 	// Make the file unreadable so the parser returns a hard
 	// error. This is deterministic: os.Open will fail with

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1695,16 +1695,20 @@ func TestResyncAllReplacesMessageContent(t *testing.T) {
 	}
 
 	// FTS search should work after resync (index was dropped
-	// and rebuilt).
-	page, err := env.db.Search(
-		context.Background(),
-		db.SearchFilter{Query: "explanation"},
-	)
-	if err != nil {
-		t.Fatalf("search after resync: %v", err)
-	}
-	if len(page.Results) == 0 {
-		t.Error("FTS search returned no results after resync")
+	// and rebuilt). Skip if FTS5 module is unavailable.
+	if env.db.HasFTS() {
+		page, err := env.db.Search(
+			context.Background(),
+			db.SearchFilter{Query: "explanation"},
+		)
+		if err != nil {
+			t.Fatalf("search after resync: %v", err)
+		}
+		if len(page.Results) == 0 {
+			t.Error(
+				"FTS search returned no results after resync",
+			)
+		}
 	}
 }
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1692,4 +1692,17 @@ func TestResyncAllReplacesMessageContent(t *testing.T) {
 			msgs[1].Content,
 		)
 	}
+
+	// FTS search should work after resync (index was dropped
+	// and rebuilt).
+	page, err := env.db.Search(
+		context.Background(),
+		db.SearchFilter{Query: "explanation"},
+	)
+	if err != nil {
+		t.Fatalf("search after resync: %v", err)
+	}
+	if len(page.Results) == 0 {
+		t.Error("FTS search returned no results after resync")
+	}
 }

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -31,9 +31,10 @@ type SyncResult struct {
 
 // SyncStats summarizes a full sync run.
 type SyncStats struct {
-	TotalSessions int `json:"total_sessions"`
-	Synced        int `json:"synced"`
-	Skipped       int `json:"skipped"`
+	TotalSessions int      `json:"total_sessions"`
+	Synced        int      `json:"synced"`
+	Skipped       int      `json:"skipped"`
+	Warnings      []string `json:"warnings,omitempty"`
 }
 
 // RecordSkip increments the skipped session counter.

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -31,10 +31,12 @@ type SyncResult struct {
 
 // SyncStats summarizes a full sync run.
 //
-// TotalSessions and Failed count discovered files. Synced counts
-// sessions (one file can produce multiple sessions via fork
-// detection). filesOK is an internal file-level counter used by
-// ResyncAll to compare against Failed on the same unit.
+// TotalSessions counts discovered files plus OpenCode sessions.
+// Synced counts sessions (one file can produce multiple via fork
+// detection; OpenCode adds sessions directly). Failed counts
+// files with hard parse/stat errors. filesOK counts files that
+// produced at least one session — used by ResyncAll to compare
+// against Failed on the same unit.
 type SyncStats struct {
 	TotalSessions int      `json:"total_sessions"`
 	Synced        int      `json:"synced"`

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -44,7 +44,8 @@ type SyncStats struct {
 	Failed        int      `json:"failed"`
 	Warnings      []string `json:"warnings,omitempty"`
 
-	filesOK int // unexported: file-level success counter
+	filesOK         int // unexported: file-level success counter
+	filesDiscovered int // file-based total, excludes OpenCode
 }
 
 // RecordSkip increments the skipped session counter.

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -34,6 +34,7 @@ type SyncStats struct {
 	TotalSessions int      `json:"total_sessions"`
 	Synced        int      `json:"synced"`
 	Skipped       int      `json:"skipped"`
+	Failed        int      `json:"failed"`
 	Warnings      []string `json:"warnings,omitempty"`
 }
 
@@ -45,6 +46,11 @@ func (s *SyncStats) RecordSkip() {
 // RecordSynced adds n to the synced session counter.
 func (s *SyncStats) RecordSynced(n int) {
 	s.Synced += n
+}
+
+// RecordFailed increments the hard-failure counter.
+func (s *SyncStats) RecordFailed() {
+	s.Failed++
 }
 
 // Percent returns the sync progress as a percentage (0–100).

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -30,12 +30,19 @@ type SyncResult struct {
 }
 
 // SyncStats summarizes a full sync run.
+//
+// TotalSessions and Failed count discovered files. Synced counts
+// sessions (one file can produce multiple sessions via fork
+// detection). filesOK is an internal file-level counter used by
+// ResyncAll to compare against Failed on the same unit.
 type SyncStats struct {
 	TotalSessions int      `json:"total_sessions"`
 	Synced        int      `json:"synced"`
 	Skipped       int      `json:"skipped"`
 	Failed        int      `json:"failed"`
 	Warnings      []string `json:"warnings,omitempty"`
+
+	filesOK int // unexported: file-level success counter
 }
 
 // RecordSkip increments the skipped session counter.

--- a/internal/sync/test_helpers_test.go
+++ b/internal/sync/test_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/wesm/agentsview/internal/db"
@@ -61,7 +62,9 @@ func assertSessionProject(t *testing.T, database *db.DB, sessionID string, want 
 func runSyncAndAssert(t *testing.T, engine *sync.Engine, want sync.SyncStats) sync.SyncStats {
 	t.Helper()
 	stats := engine.SyncAll(nil)
-	if diff := cmp.Diff(want, stats); diff != "" {
+	if diff := cmp.Diff(want, stats,
+		cmpopts.IgnoreUnexported(sync.SyncStats{}),
+	); diff != "" {
 		t.Fatalf("SyncAll() mismatch (-want +got):\n%s", diff)
 	}
 	return stats

--- a/scripts/e2e-server.sh
+++ b/scripts/e2e-server.sh
@@ -36,12 +36,16 @@ else
       -o "$SERVER" "$ROOT/cmd/agentsview"
 fi
 
-# Run server with test DB, no sync dirs, fixed port
+# Run server with test DB, no sync dirs, fixed port.
+# Every agent dir must point to EMPTY_DIR to prevent
+# the server from discovering real sessions on the host.
 echo "Starting e2e server on :8090..."
 AGENT_VIEWER_DATA_DIR="$TMPDIR" \
 CLAUDE_PROJECTS_DIR="$EMPTY_DIR" \
 CODEX_SESSIONS_DIR="$EMPTY_DIR" \
+COPILOT_DIR="$EMPTY_DIR" \
 GEMINI_DIR="$EMPTY_DIR" \
+OPENCODE_DIR="$EMPTY_DIR" \
 exec "$SERVER" \
   -port 8090 \
   -no-browser


### PR DESCRIPTION
## Summary

### Gemini thinking blocks
- **Two-pass thinking regex**: Split `THINKING_RE` into `THINKING_MARKED_RE` (for `[/Thinking]`-delimited blocks, matched first) and `THINKING_LEGACY_RE` (fallback). Prevents fallback delimiters from truncating marked blocks.
- **Thinking end markers**: All parsers (Claude, Gemini, OpenCode) emit `[/Thinking]` end markers.
- **Gemini thinking format**: Parts joined with `\n\n`, ordered chronologically (thinking, content, tools).
- **Merge consecutive thinking blocks**: Multiple Gemini thoughts collapse into a single collapsible block.
- **Thinking-only filter fix**: Messages with thinking + response text are no longer hidden by the `showThinking` toggle.

### Session count consistency
- **Aligned counts across views**: Session list, analytics summary, and status bar all use the same root-session filter (`message_count > 0 AND relationship_type NOT IN ('subagent', 'fork')`).
- **Full numbers in dashboard**: Removed K/M abbreviation, always shows full number with comma separators.
- **Default date range**: Analytics defaults to all-time instead of 1 year.
- **Go HTTP integration test**: `TestSessionCountConsistency` seeds mixed session types and asserts all three endpoints agree.
- **E2e Playwright test**: `session-count-consistency.spec.ts` verifies the same invariant through the full UI stack, asserting exact expected count.

### Resync reliability
- **Fresh database build**: `ResyncAll` builds a new DB from scratch and swaps atomically, instead of in-place mutation.
- **Atomic DB connections**: `atomic.Pointer[sql.DB]` for reader/writer so HTTP handlers don't race with connection swaps.
- **Windows-safe swap**: Close connections before rename to avoid mandatory file locking failures.
- **Empty-discovery guard**: Abort resync when file discovery returns zero but old DB has file-backed sessions. Uses `FileBackedSessionCount` (excludes OpenCode) so OpenCode-only datasets aren't blocked, while mixed-source data loss is prevented.
- **Insights preservation**: Abort swap when `CopyInsightsFrom` fails instead of silently dropping insights.
- **Failure tracking**: Abort when failures exceed successful syncs.
- **FTS rebuild**: Drop and rebuild FTS index during resync.
- **Sync serialization**: `SyncPaths` and `SyncSingleSession` serialized with `syncMu`.

### E2e test isolation
- All agent directories (Claude, Codex, Copilot, Gemini, OpenCode) point to empty dirs in e2e-server.sh, preventing real session data from leaking into tests.
- Test fixture seeds subagent, fork, and empty sessions alongside root sessions.

### Other
- **Session ID for all agents**: Gemini, OpenCode, and Copilot sessions show the copyable session ID.
- **Clean startup logging**: `log.Printf` goes to `~/.agentsview/debug.log` only. Missing directory warnings stay on stderr.
- **Debug log management**: Truncate `debug.log` on startup when >10MB.
- **Windows test fix**: Close log file before TempDir cleanup to avoid mandatory file locking.

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)