### PR TITLE
Fix CI failure: DB Reopen race and install test drift

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -365,14 +365,13 @@ func (db *DB) init() error {
 // retired pools left over from previous Reopen calls.
 func (db *DB) Close() error {
 	db.mu.Lock()
+	w := db.getWriter()
+	r := db.getReader()
 	retired := db.retired
 	db.retired = nil
 	db.mu.Unlock()
 
-	errs := []error{
-		db.getWriter().Close(),
-		db.getReader().Close(),
-	}
+	errs := []error{w.Close(), r.Close()}
 	for _, p := range retired {
 		errs = append(errs, p.Close())
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -431,7 +432,11 @@ func (db *DB) reopenLocked() error {
 	// retired for at least one full Reopen cycle, so all
 	// in-flight queries on them have long since completed.
 	for _, p := range db.retired {
-		_ = p.Close()
+		if err := p.Close(); err != nil {
+			log.Printf(
+				"warning: closing retired db pool: %v", err,
+			)
+		}
 	}
 	db.retired = db.retired[:0]
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -199,4 +199,7 @@ main() {
     echo "  agentsview update   # Check for and install updates"
 }
 
-main "$@"
+# Guard: only run main when executed directly, not when sourced.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -200,6 +200,8 @@ main() {
 }
 
 # Guard: only run main when executed directly, not when sourced.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# ${BASH_SOURCE[0]-} defaults to empty when piped via stdin
+# (curl ... | bash), which we treat as direct execution.
+if [[ "${BASH_SOURCE[0]-}" == "${0}" || -z "${BASH_SOURCE[0]-}" ]]; then
     main "$@"
 fi


### PR DESCRIPTION
## Summary

- **Fix DB Reopen race** (`internal/db/db.go`): `reopenLocked()` was closing old `*sql.DB` pools immediately after swapping atomic pointers, causing concurrent readers to hit `sql: database is closed`. Old pools are now retired into a list and closed in `DB.Close()`, eliminating the race deterministically.
- **Fix install test drift** (`scripts/install.sh`, `scripts/install_test.sh`): The test duplicated the grep/cut parsing logic from `install.sh`. Added a `BASH_SOURCE` guard to `install.sh` so the test can source it and call `get_latest_version` directly with a mocked `curl`. Also switched from `echo` to `printf` for reliable fixture piping.

## Test plan

- [x] `TestConcurrentReadsWhileReopen` passes 5x with `-count=5`
- [x] All `TestReopen*`, `TestCloseConnections`, `TestCloseRenameReopen` pass
- [x] Full `internal/db` test suite passes
- [x] `scripts/install_test.sh` passes (6/6)
- [x] `install.sh` syntax check passes (`bash -n`)
- [x] `go vet` and `go fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)