### PR TITLE
Add Cursor agent support with filter UI

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -62,9 +62,9 @@ func main() {
 func printUsage() {
 	fmt.Printf(`agentsview %s - local web viewer for AI agent sessions
 
-Syncs Claude Code, Codex, Copilot CLI, Gemini CLI, and OpenCode session
-data into SQLite, serves an analytics dashboard and session browser via
-a local web UI.
+Syncs Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, and Cursor
+session data into SQLite, serves an analytics dashboard and session
+browser via a local web UI.
 
 Usage:
   agentsview [flags]          Start the server (default command)
@@ -98,6 +98,7 @@ Environment variables:
   COPILOT_DIR             Copilot CLI directory
   GEMINI_DIR              Gemini CLI directory
   OPENCODE_DIR            OpenCode data directory
+  CURSOR_PROJECTS_DIR     Cursor projects directory
   AGENT_VIEWER_DATA_DIR   Data directory (database, config)
 
 Multiple directories:
@@ -159,6 +160,7 @@ func runServe(args []string) {
 		cfg.ResolveCopilotDirs(),
 		cfg.ResolveGeminiDirs(),
 		cfg.ResolveOpenCodeDirs(),
+		cfg.CursorProjectsDir,
 		"local",
 	)
 
@@ -362,6 +364,14 @@ func startFileWatcher(
 		geminiTmp := filepath.Join(d, "tmp")
 		if _, err := os.Stat(geminiTmp); err == nil {
 			roots = append(roots, watchRoot{d, geminiTmp})
+		}
+	}
+	if cfg.CursorProjectsDir != "" {
+		if _, err := os.Stat(cfg.CursorProjectsDir); err == nil {
+			roots = append(roots, watchRoot{
+				cfg.CursorProjectsDir,
+				cfg.CursorProjectsDir,
+			})
 		}
 	}
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -139,6 +139,7 @@
       sessions.initFromParams(params);
       sessions.load();
       sessions.loadProjects();
+      sessions.loadAgents();
     });
   });
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -23,6 +23,7 @@
   --accent-purple: #7c3aed;
   --accent-amber: #d97706;
   --accent-green: #059669;
+  --accent-black: #2d2d2d;
   --accent-red: #dc2626;
   --user-bg: #eef2ff;
   --assistant-bg: #faf9ff;
@@ -61,6 +62,7 @@
   --accent-purple: #a78bfa;
   --accent-amber: #fbbf24;
   --accent-green: #34d399;
+  --accent-black: #b0b0b0;
   --accent-red: #f87171;
   --user-bg: #111827;
   --assistant-bg: #141220;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -6,6 +6,7 @@ import type {
   SearchResponse,
   ProjectsResponse,
   MachinesResponse,
+  AgentsResponse,
   Stats,
   VersionInfo,
   SyncStatus,
@@ -43,38 +44,22 @@ export class ApiError extends Error {
   }
 }
 
-function apiErrorMessage(
-  status: number,
-  body: string,
-): string {
+function apiErrorMessage(status: number, body: string): string {
   return body.trim() || `API ${status}`;
 }
 
-async function fetchJSON<T>(
-  path: string,
-  init?: RequestInit,
-): Promise<T> {
+async function fetchJSON<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, init);
   if (!res.ok) {
     const body = await res.text();
-    throw new ApiError(
-      res.status,
-      apiErrorMessage(res.status, body),
-    );
+    throw new ApiError(res.status, apiErrorMessage(res.status, body));
   }
   return res.json() as Promise<T>;
 }
 
-type QueryValue =
-  | string
-  | number
-  | boolean
-  | undefined
-  | null;
+type QueryValue = string | number | boolean | undefined | null;
 
-function buildQuery(
-  params: Record<string, QueryValue>,
-): string {
+function buildQuery(params: Record<string, QueryValue>): string {
   const q = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (value !== undefined && value !== null && value !== "") {
@@ -109,10 +94,7 @@ export function listSessions(
   return fetchJSON(`/sessions${buildQuery({ ...params })}`);
 }
 
-export function getSession(
-  id: string,
-  init?: RequestInit,
-): Promise<Session> {
+export function getSession(id: string, init?: RequestInit): Promise<Session> {
   return fetchJSON(`/sessions/${id}`, init);
 }
 
@@ -163,10 +145,7 @@ export function search(
   if (!query) {
     throw new Error("search query must not be empty");
   }
-  return fetchJSON(
-    `/search${buildQuery({ q: query, ...params })}`,
-    init,
-  );
+  return fetchJSON(`/search${buildQuery({ q: query, ...params })}`, init);
 }
 
 /* Metadata */
@@ -177,6 +156,10 @@ export function getProjects(): Promise<ProjectsResponse> {
 
 export function getMachines(): Promise<MachinesResponse> {
   return fetchJSON("/machines");
+}
+
+export function getAgents(): Promise<AgentsResponse> {
+  return fetchJSON("/agents");
 }
 
 export function getStats(): Promise<Stats> {
@@ -318,9 +301,7 @@ export function watchSession(
   sessionId: string,
   onUpdate: () => void,
 ): EventSource {
-  const es = new EventSource(
-    `${BASE}/sessions/${sessionId}/watch`,
-  );
+  const es = new EventSource(`${BASE}/sessions/${sessionId}/watch`);
 
   es.addEventListener("session_updated", () => {
     onUpdate();
@@ -340,9 +321,7 @@ export function getExportUrl(sessionId: string): string {
 
 /* Publish / GitHub config */
 
-export function publishSession(
-  sessionId: string,
-): Promise<PublishResponse> {
+export function publishSession(sessionId: string): Promise<PublishResponse> {
   return fetchJSON(`/sessions/${sessionId}/publish`, {
     method: "POST",
   });
@@ -380,9 +359,7 @@ export interface AnalyticsParams {
 export function getAnalyticsSummary(
   params: AnalyticsParams,
 ): Promise<AnalyticsSummary> {
-  return fetchJSON(
-    `/analytics/summary${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/summary${buildQuery({ ...params })}`);
 }
 
 export function getAnalyticsActivity(
@@ -390,9 +367,7 @@ export function getAnalyticsActivity(
     granularity?: Granularity;
   },
 ): Promise<ActivityResponse> {
-  return fetchJSON(
-    `/analytics/activity${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/activity${buildQuery({ ...params })}`);
 }
 
 export function getAnalyticsHeatmap(
@@ -400,49 +375,37 @@ export function getAnalyticsHeatmap(
     metric?: HeatmapMetric;
   },
 ): Promise<HeatmapResponse> {
-  return fetchJSON(
-    `/analytics/heatmap${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/heatmap${buildQuery({ ...params })}`);
 }
 
 export function getAnalyticsProjects(
   params: AnalyticsParams,
 ): Promise<ProjectsAnalyticsResponse> {
-  return fetchJSON(
-    `/analytics/projects${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/projects${buildQuery({ ...params })}`);
 }
 
 export function getAnalyticsHourOfWeek(
   params: AnalyticsParams,
 ): Promise<HourOfWeekResponse> {
-  return fetchJSON(
-    `/analytics/hour-of-week${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/hour-of-week${buildQuery({ ...params })}`);
 }
 
 export function getAnalyticsSessionShape(
   params: AnalyticsParams,
 ): Promise<SessionShapeResponse> {
-  return fetchJSON(
-    `/analytics/sessions${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/sessions${buildQuery({ ...params })}`);
 }
 
 export function getAnalyticsVelocity(
   params: AnalyticsParams,
 ): Promise<VelocityResponse> {
-  return fetchJSON(
-    `/analytics/velocity${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/velocity${buildQuery({ ...params })}`);
 }
 
 export function getAnalyticsTools(
   params: AnalyticsParams,
 ): Promise<ToolsAnalyticsResponse> {
-  return fetchJSON(
-    `/analytics/tools${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/tools${buildQuery({ ...params })}`);
 }
 
 export function getAnalyticsTopSessions(
@@ -450,9 +413,7 @@ export function getAnalyticsTopSessions(
     metric?: TopSessionsMetric;
   },
 ): Promise<TopSessionsResponse> {
-  return fetchJSON(
-    `/analytics/top-sessions${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/analytics/top-sessions${buildQuery({ ...params })}`);
 }
 
 /* Insights */
@@ -465,9 +426,7 @@ export interface ListInsightsParams {
 export function listInsights(
   params: ListInsightsParams = {},
 ): Promise<InsightsResponse> {
-  return fetchJSON(
-    `/insights${buildQuery({ ...params })}`,
-  );
+  return fetchJSON(`/insights${buildQuery({ ...params })}`);
 }
 
 export function getInsight(id: number): Promise<Insight> {
@@ -480,10 +439,7 @@ export async function deleteInsight(id: number): Promise<void> {
   });
   if (!res.ok) {
     const body = await res.text();
-    throw new ApiError(
-      res.status,
-      apiErrorMessage(res.status, body),
-    );
+    throw new ApiError(res.status, apiErrorMessage(res.status, body));
   }
 }
 
@@ -507,9 +463,7 @@ export function generateInsight(
     });
 
     if (!res.ok || !res.body) {
-      throw new Error(
-        `Generate request failed: ${res.status}`,
-      );
+      throw new Error(`Generate request failed: ${res.status}`);
     }
 
     const reader = res.body.getReader();
@@ -523,9 +477,7 @@ export function generateInsight(
       buf += decoder.decode(value, { stream: true });
       buf = buf.replaceAll("\r\n", "\n");
 
-      const parsed = processInsightFrames(
-        buf, onStatus,
-      );
+      const parsed = processInsightFrames(buf, onStatus);
       if (parsed) {
         result = parsed;
         reader.cancel();
@@ -543,9 +495,7 @@ export function generateInsight(
     }
 
     if (!result) {
-      throw new Error(
-        "Generate stream ended without done event",
-      );
+      throw new Error("Generate stream ended without done event");
     }
 
     return result;

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -65,11 +65,7 @@ export interface Message {
 /** Matches Go MinimapEntry struct */
 export type MinimapEntry = Pick<
   Message,
-  | "ordinal"
-  | "role"
-  | "content_length"
-  | "has_thinking"
-  | "has_tool_use"
+  "ordinal" | "role" | "content_length" | "has_thinking" | "has_tool_use"
 >;
 
 /** Matches Go SearchResult struct in internal/db/search.go */
@@ -114,4 +110,14 @@ export interface ProjectsResponse {
 
 export interface MachinesResponse {
   machines: string[];
+}
+
+/** Matches Go AgentInfo struct */
+export interface AgentInfo {
+  name: string;
+  session_count: number;
+}
+
+export interface AgentsResponse {
+  agents: AgentInfo[];
 }

--- a/frontend/src/lib/components/analytics/ActiveFilters.svelte
+++ b/frontend/src/lib/components/analytics/ActiveFilters.svelte
@@ -151,6 +151,7 @@
       </button>
     {/if}
 
+
     {#if hasTime}
       <button
         class="filter-chip"

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -9,6 +9,12 @@
   const isMac = navigator.platform.toUpperCase().includes("MAC");
   const modKey = isMac ? "Cmd" : "Ctrl";
 
+  function handleAgentChange(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    sessions.setAgentFilter(select.value);
+  }
+
+
   function handleExport() {
     if (sessions.activeSessionId) {
       window.open(
@@ -48,6 +54,19 @@
       value={sessions.filters.project}
       onselect={(v) => sessions.setProjectFilter(v)}
     />
+
+    <select
+      class="project-select"
+      value={sessions.filters.agent}
+      onchange={handleAgentChange}
+    >
+      <option value="">All Agents</option>
+      {#each sessions.agents as agent}
+        <option value={agent.name}>
+          {agent.name} ({agent.session_count})
+        </option>
+      {/each}
+    </select>
 
     <button
       class="nav-btn"

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -287,8 +287,7 @@ class AnalyticsStore {
       }
     } catch (e) {
       if (this.versions[panel] === v) {
-        this.errors[panel] =
-          e instanceof Error ? e.message : "Failed to load";
+        this.errors[panel] = e instanceof Error ? e.message : "Failed to load";
       }
     } finally {
       if (this.versions[panel] === v) {
@@ -315,7 +314,9 @@ class AnalyticsStore {
     await this.executeFetch(
       "summary",
       () => getAnalyticsSummary(this.filterParams()),
-      (data) => { this.summary = data; },
+      (data) => {
+        this.summary = data;
+      },
     );
   }
 
@@ -325,22 +326,28 @@ class AnalyticsStore {
   async fetchActivity() {
     await this.executeFetch(
       "activity",
-      () => getAnalyticsActivity({
-        ...this.baseParams(),
-        granularity: this.granularity,
-      }),
-      (data) => { this.activity = data; },
+      () =>
+        getAnalyticsActivity({
+          ...this.baseParams(),
+          granularity: this.granularity,
+        }),
+      (data) => {
+        this.activity = data;
+      },
     );
   }
 
   async fetchHeatmap() {
     await this.executeFetch(
       "heatmap",
-      () => getAnalyticsHeatmap({
-        ...this.baseParams(),
-        metric: this.metric,
-      }),
-      (data) => { this.heatmap = data; },
+      () =>
+        getAnalyticsHeatmap({
+          ...this.baseParams(),
+          metric: this.metric,
+        }),
+      (data) => {
+        this.heatmap = data;
+      },
     );
   }
 
@@ -350,20 +357,20 @@ class AnalyticsStore {
   async fetchProjects() {
     await this.executeFetch(
       "projects",
-      () => getAnalyticsProjects(
-        this.filterParams({ includeProject: false }),
-      ),
-      (data) => { this.projects = data; },
+      () => getAnalyticsProjects(this.filterParams({ includeProject: false })),
+      (data) => {
+        this.projects = data;
+      },
     );
   }
 
   async fetchHourOfWeek() {
     await this.executeFetch(
       "hourOfWeek",
-      () => getAnalyticsHourOfWeek(
-        this.baseParams({ includeTime: false }),
-      ),
-      (data) => { this.hourOfWeek = data; },
+      () => getAnalyticsHourOfWeek(this.baseParams({ includeTime: false })),
+      (data) => {
+        this.hourOfWeek = data;
+      },
     );
   }
 
@@ -371,7 +378,9 @@ class AnalyticsStore {
     await this.executeFetch(
       "sessionShape",
       () => getAnalyticsSessionShape(this.filterParams()),
-      (data) => { this.sessionShape = data; },
+      (data) => {
+        this.sessionShape = data;
+      },
     );
   }
 
@@ -379,7 +388,9 @@ class AnalyticsStore {
     await this.executeFetch(
       "velocity",
       () => getAnalyticsVelocity(this.filterParams()),
-      (data) => { this.velocity = data; },
+      (data) => {
+        this.velocity = data;
+      },
     );
   }
 
@@ -387,18 +398,23 @@ class AnalyticsStore {
     await this.executeFetch(
       "tools",
       () => getAnalyticsTools(this.filterParams()),
-      (data) => { this.tools = data; },
+      (data) => {
+        this.tools = data;
+      },
     );
   }
 
   async fetchTopSessions() {
     await this.executeFetch(
       "topSessions",
-      () => getAnalyticsTopSessions({
-        ...this.filterParams(),
-        metric: this.topMetric,
-      }),
-      (data) => { this.topSessions = data; },
+      () =>
+        getAnalyticsTopSessions({
+          ...this.filterParams(),
+          metric: this.topMetric,
+        }),
+      (data) => {
+        this.topSessions = data;
+      },
     );
   }
 
@@ -440,15 +456,9 @@ class AnalyticsStore {
     this.fetchHeatmap();
   }
 
-  selectHourOfWeek(
-    dow: number | null,
-    hour: number | null,
-  ) {
+  selectHourOfWeek(dow: number | null, hour: number | null) {
     // Toggle off if clicking the same selection
-    if (
-      this.selectedDow === dow &&
-      this.selectedHour === hour
-    ) {
+    if (this.selectedDow === dow && this.selectedHour === hour) {
       this.selectedDow = null;
       this.selectedHour = null;
     } else {

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -13,6 +13,7 @@ describe("KNOWN_AGENTS", () => {
       "copilot",
       "gemini",
       "opencode",
+      "cursor",
     ]);
   });
 
@@ -39,6 +40,9 @@ describe("agentColor", () => {
     );
     expect(agentColor("opencode")).toBe(
       "var(--accent-purple)",
+    );
+    expect(agentColor("cursor")).toBe(
+      "var(--accent-black)",
     );
   });
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -9,6 +9,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "copilot", color: "var(--accent-amber)" },
   { name: "gemini", color: "var(--accent-rose)" },
   { name: "opencode", color: "var(--accent-purple)" },
+  { name: "cursor", color: "var(--accent-black)" },
 ];
 
 const agentColorMap = new Map(

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -280,6 +280,27 @@ describe("parseContent - inline code spans", () => {
     const segments = parseContent(text, true);
     expect(segments.every((s) => s.type === "text")).toBe(true);
   });
+
+  it("handles double-backtick span containing single backtick", () => {
+    const text = "Example: `` `[Thinking]` `` in docs.";
+    const segments = parseContent(text, true);
+    expect(segments.every((s) => s.type === "text")).toBe(true);
+  });
+
+  it("handles triple-backtick inline span", () => {
+    const text = "Use ``` [Bash] ``` as inline code.";
+    const segments = parseContent(text, true);
+    expect(segments.every((s) => s.type === "text")).toBe(true);
+  });
+
+  it("does not confuse fenced code blocks with inline spans", () => {
+    const text =
+      "```sh\necho [Bash]\n```\n\n[Bash]\n$ echo real";
+    const segments = parseContent(text, true);
+    const types = segments.map((s) => s.type);
+    expect(types).toContain("code");
+    expect(types).toContain("tool");
+  });
 });
 
 describe("isToolOnly", () => {

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -293,6 +293,12 @@ describe("parseContent - inline code spans", () => {
     expect(segments.every((s) => s.type === "text")).toBe(true);
   });
 
+  it("handles triple-backtick inline span at line start", () => {
+    const text = "``` [Bash] ```\nnext line";
+    const segments = parseContent(text, true);
+    expect(segments.every((s) => s.type === "text")).toBe(true);
+  });
+
   it("does not confuse fenced code blocks with inline spans", () => {
     const text =
       "```sh\necho [Bash]\n```\n\n[Bash]\n$ echo real";

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -249,6 +249,39 @@ describe("parseContent - thinking blocks", () => {
   });
 });
 
+describe("parseContent - inline code spans", () => {
+  it("does not match [Thinking] inside backtick code span", () => {
+    const text =
+      "handling of `[Thinking]`, `[Tool call]`, `[Tool result]`.";
+    const segments = parseContent(text, true);
+    expect(segments.every((s) => s.type === "text")).toBe(true);
+    expect(segments[0]!.content).toContain("`[Thinking]`");
+  });
+
+  it("does not match [Bash] inside backtick code span", () => {
+    const text = "Run `[Bash]` to execute commands.";
+    const segments = parseContent(text, true);
+    expect(segments.every((s) => s.type === "text")).toBe(true);
+    expect(segments[0]!.content).toContain("`[Bash]`");
+  });
+
+  it("still matches real markers outside code spans", () => {
+    const text =
+      "Mentioned `[Thinking]` in docs.\n[Bash]\n$ echo hi";
+    const segments = parseContent(text, true);
+    const types = segments.map((s) => s.type);
+    expect(types).toContain("text");
+    expect(types).toContain("tool");
+    expect(types).not.toContain("thinking");
+  });
+
+  it("handles double-backtick code spans", () => {
+    const text = "Use ``[Thinking]`` as a marker.";
+    const segments = parseContent(text, true);
+    expect(segments.every((s) => s.type === "text")).toBe(true);
+  });
+});
+
 describe("isToolOnly", () => {
   it("returns false for user messages", () => {
     const msg = makeMsg({ role: "user", content: "[Bash]\nhi" });

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -307,6 +307,14 @@ describe("parseContent - inline code spans", () => {
     expect(types).toContain("code");
     expect(types).toContain("tool");
   });
+
+  it("continues scanning after unmatched backtick run", () => {
+    const text =
+      "Some `` unmatched double then `[Thinking]` single";
+    const segments = parseContent(text, true);
+    expect(segments.every((s) => s.type === "text")).toBe(true);
+    expect(segments[0]!.content).toContain("`[Thinking]`");
+  });
 });
 
 describe("isToolOnly", () => {

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -113,7 +113,9 @@ function scanInlineCodeSpans(
         break;
       }
     }
-    if (!found) break;
+    // If no closing run found, i is already past the
+    // unmatched opening run — continue scanning for
+    // other valid spans of different lengths.
   }
   return spans;
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,19 +14,20 @@ import (
 
 // Config holds all application configuration.
 type Config struct {
-	Host             string        `json:"host"`
-	Port             int           `json:"port"`
-	NoBrowser        bool          `json:"no_browser"`
-	ClaudeProjectDir string        `json:"claude_project_dir"`
-	CodexSessionsDir string        `json:"codex_sessions_dir"`
-	CopilotDir       string        `json:"copilot_dir"`
-	GeminiDir        string        `json:"gemini_dir"`
-	OpenCodeDir      string        `json:"opencode_dir"`
-	DataDir          string        `json:"data_dir"`
-	DBPath           string        `json:"-"`
-	CursorSecret     string        `json:"cursor_secret"`
-	GithubToken      string        `json:"github_token,omitempty"`
-	WriteTimeout     time.Duration `json:"-"`
+	Host              string        `json:"host"`
+	Port              int           `json:"port"`
+	NoBrowser         bool          `json:"no_browser"`
+	ClaudeProjectDir  string        `json:"claude_project_dir"`
+	CodexSessionsDir  string        `json:"codex_sessions_dir"`
+	CopilotDir        string        `json:"copilot_dir"`
+	GeminiDir         string        `json:"gemini_dir"`
+	OpenCodeDir       string        `json:"opencode_dir"`
+	CursorProjectsDir string        `json:"cursor_projects_dir"`
+	DataDir           string        `json:"data_dir"`
+	DBPath            string        `json:"-"`
+	CursorSecret      string        `json:"cursor_secret"`
+	GithubToken       string        `json:"github_token,omitempty"`
+	WriteTimeout      time.Duration `json:"-"`
 
 	// Multi-directory support (from config.json).
 	// When set, these take precedence over the single-dir
@@ -49,16 +50,17 @@ func Default() (Config, error) {
 	}
 	dataDir := filepath.Join(home, ".agentsview")
 	return Config{
-		Host:             "127.0.0.1",
-		Port:             8080,
-		ClaudeProjectDir: filepath.Join(home, ".claude", "projects"),
-		CodexSessionsDir: filepath.Join(home, ".codex", "sessions"),
-		CopilotDir:       filepath.Join(home, ".copilot"),
-		GeminiDir:        filepath.Join(home, ".gemini"),
-		OpenCodeDir:      filepath.Join(home, ".local", "share", "opencode"),
-		DataDir:          dataDir,
-		DBPath:           filepath.Join(dataDir, "sessions.db"),
-		WriteTimeout:     30 * time.Second,
+		Host:              "127.0.0.1",
+		Port:              8080,
+		ClaudeProjectDir:  filepath.Join(home, ".claude", "projects"),
+		CodexSessionsDir:  filepath.Join(home, ".codex", "sessions"),
+		CopilotDir:        filepath.Join(home, ".copilot"),
+		GeminiDir:         filepath.Join(home, ".gemini"),
+		OpenCodeDir:       filepath.Join(home, ".local", "share", "opencode"),
+		CursorProjectsDir: filepath.Join(home, ".cursor", "projects"),
+		DataDir:           dataDir,
+		DBPath:            filepath.Join(dataDir, "sessions.db"),
+		WriteTimeout:      30 * time.Second,
 	}, nil
 }
 
@@ -205,6 +207,9 @@ func (c *Config) loadEnv() {
 	if v := os.Getenv("OPENCODE_DIR"); v != "" {
 		c.OpenCodeDir = v
 		c.OpenCodeDirs = []string{v}
+	}
+	if v := os.Getenv("CURSOR_PROJECTS_DIR"); v != "" {
+		c.CursorProjectsDir = v
 	}
 	if v := os.Getenv("AGENT_VIEWER_DATA_DIR"); v != "" {
 		c.DataDir = v

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2596,3 +2596,26 @@ func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
 		t.Errorf("got %d agents, want 2", len(agents))
 	}
 }
+
+func TestGetAgentsEmptyResultSerializesAsArray(t *testing.T) {
+	d := testDB(t)
+
+	agents, err := d.GetAgents(context.Background())
+	if err != nil {
+		t.Fatalf("GetAgents: %v", err)
+	}
+	if agents == nil {
+		t.Fatal("GetAgents returned nil, want empty slice")
+	}
+	if len(agents) != 0 {
+		t.Errorf("got %d agents, want 0", len(agents))
+	}
+
+	b, err := json.Marshal(agents)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if string(b) != "[]" {
+		t.Errorf("JSON = %s, want []", b)
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2570,3 +2570,29 @@ func TestCopyInsightsFrom(t *testing.T) {
 		)
 	}
 }
+
+func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
+	d := testDB(t)
+
+	// Insert sessions with various agent values.
+	insertSession(t, d, "s1", "proj",
+		func(s *Session) { s.Agent = "claude" })
+	insertSession(t, d, "s2", "proj",
+		func(s *Session) { s.Agent = "cursor" })
+	insertSession(t, d, "s3", "proj",
+		func(s *Session) { s.Agent = "" })
+
+	agents, err := d.GetAgents(context.Background())
+	if err != nil {
+		t.Fatalf("GetAgents: %v", err)
+	}
+
+	for _, a := range agents {
+		if a.Name == "" {
+			t.Error("GetAgents returned empty agent name")
+		}
+	}
+	if len(agents) != 2 {
+		t.Errorf("got %d agents, want 2", len(agents))
+	}
+}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -533,7 +533,7 @@ func (db *DB) GetAgents(
 	rows, err := db.getReader().QueryContext(ctx, `
 		SELECT agent, COUNT(*) as session_count
 		FROM sessions
-		WHERE message_count > 0
+		WHERE message_count > 0 AND agent <> ''
 		GROUP BY agent
 		ORDER BY agent`)
 	if err != nil {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -526,6 +526,38 @@ type ProjectInfo struct {
 	SessionCount int    `json:"session_count"`
 }
 
+// GetAgents returns distinct agent names with session counts.
+func (db *DB) GetAgents(
+	ctx context.Context,
+) ([]AgentInfo, error) {
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT agent, COUNT(*) as session_count
+		FROM sessions
+		WHERE message_count > 0
+		GROUP BY agent
+		ORDER BY agent`)
+	if err != nil {
+		return nil, fmt.Errorf("querying agents: %w", err)
+	}
+	defer rows.Close()
+
+	var agents []AgentInfo
+	for rows.Next() {
+		var a AgentInfo
+		if err := rows.Scan(&a.Name, &a.SessionCount); err != nil {
+			return nil, fmt.Errorf("scanning agent: %w", err)
+		}
+		agents = append(agents, a)
+	}
+	return agents, rows.Err()
+}
+
+// AgentInfo holds an agent name and its session count.
+type AgentInfo struct {
+	Name         string `json:"name"`
+	SessionCount int    `json:"session_count"`
+}
+
 // GetMachines returns distinct machine names.
 func (db *DB) GetMachines(
 	ctx context.Context,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -541,7 +541,7 @@ func (db *DB) GetAgents(
 	}
 	defer rows.Close()
 
-	var agents []AgentInfo
+	agents := []AgentInfo{}
 	for rows.Next() {
 		var a AgentInfo
 		if err := rows.Scan(&a.Name, &a.SessionCount); err != nil {

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -1,0 +1,327 @@
+package parser
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// maxCursorTranscriptSize is the maximum transcript file size
+// we'll read into memory. Cursor transcripts are typically
+// under 500 KB; 10 MB provides generous headroom.
+const maxCursorTranscriptSize = 10 << 20
+
+// ParseCursorSession parses a Cursor agent transcript file.
+// Transcripts are plain text with "user:" and "assistant:" role
+// markers, tool calls, and thinking blocks.
+func ParseCursorSession(
+	path, project, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	// Open with O_NOFOLLOW (Unix) to reject symlinks at the
+	// final path component, closing the TOCTOU window between
+	// discovery validation and file read.
+	f, err := openNoFollow(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	// Use Fstat on the open fd — this reflects the actual
+	// opened file, not whatever the path currently points to.
+	info, err := f.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf(
+			"skip %s: not a regular file", path,
+		)
+	}
+
+	// Use LimitReader to enforce the size cap even if the
+	// file grows after Fstat. Read one extra byte so we can
+	// detect truncation.
+	data, err := io.ReadAll(
+		io.LimitReader(f, maxCursorTranscriptSize+1),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if int64(len(data)) > maxCursorTranscriptSize {
+		return nil, nil, fmt.Errorf(
+			"skip %s: file too large (read %d bytes, max %d)",
+			path, len(data), maxCursorTranscriptSize,
+		)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	messages := parseCursorMessages(lines)
+	if len(messages) == 0 {
+		return nil, nil, nil
+	}
+
+	sessionID := "cursor:" + strings.TrimSuffix(
+		filepath.Base(path), ".txt",
+	)
+
+	var firstMessage string
+	for _, m := range messages {
+		if m.Role == RoleUser && m.Content != "" {
+			firstMessage = truncate(
+				strings.ReplaceAll(m.Content, "\n", " "), 300,
+			)
+			break
+		}
+	}
+
+	// Compute hash from the already-read data to avoid
+	// re-opening the file by path (which would be another
+	// TOCTOU opportunity).
+	hash := fmt.Sprintf("%x", sha256.Sum256(data))
+
+	mtime := info.ModTime()
+	sess := &ParsedSession{
+		ID:           sessionID,
+		Project:      project,
+		Machine:      machine,
+		Agent:        AgentCursor,
+		FirstMessage: firstMessage,
+		StartedAt:    mtime,
+		EndedAt:      mtime,
+		MessageCount: len(messages),
+		File: FileInfo{
+			Path:  path,
+			Size:  info.Size(),
+			Mtime: mtime.UnixNano(),
+			Hash:  hash,
+		},
+	}
+	return sess, messages, nil
+}
+
+// cursorBlock represents a raw block of lines between role
+// markers in a Cursor transcript.
+type cursorBlock struct {
+	role  RoleType
+	lines []string
+}
+
+// parseCursorMessages splits transcript lines on role markers
+// and converts each block into a ParsedMessage.
+func parseCursorMessages(lines []string) []ParsedMessage {
+	blocks := splitCursorBlocks(lines)
+	messages := make([]ParsedMessage, 0, len(blocks))
+
+	for i, block := range blocks {
+		content, hasThinking, toolCalls := extractCursorContent(
+			block.role, block.lines,
+		)
+		content = strings.TrimSpace(content)
+		if content == "" && len(toolCalls) == 0 {
+			continue
+		}
+
+		messages = append(messages, ParsedMessage{
+			Ordinal:       i,
+			Role:          block.role,
+			Content:       content,
+			Timestamp:     time.Time{},
+			HasThinking:   hasThinking,
+			HasToolUse:    len(toolCalls) > 0,
+			ContentLength: len(content),
+			ToolCalls:     toolCalls,
+		})
+	}
+
+	// Re-number ordinals to be contiguous after filtering
+	for i := range messages {
+		messages[i].Ordinal = i
+	}
+	return messages
+}
+
+// splitCursorBlocks splits lines into blocks delimited by
+// "user:" or "assistant:" on a line by itself.
+func splitCursorBlocks(lines []string) []cursorBlock {
+	var blocks []cursorBlock
+	var current *cursorBlock
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "user:" || trimmed == "assistant:" {
+			if current != nil {
+				blocks = append(blocks, *current)
+			}
+			role := RoleUser
+			if trimmed == "assistant:" {
+				role = RoleAssistant
+			}
+			current = &cursorBlock{role: role}
+			continue
+		}
+		if current != nil {
+			current.lines = append(current.lines, line)
+		}
+	}
+	if current != nil {
+		blocks = append(blocks, *current)
+	}
+	return blocks
+}
+
+// extractCursorContent processes lines for a single message
+// block, returning the visible text content, whether thinking
+// was present, and any tool calls found.
+func extractCursorContent(
+	role RoleType, lines []string,
+) (string, bool, []ParsedToolCall) {
+	if role == RoleUser {
+		content := extractUserQuery(lines)
+		return content, false, nil
+	}
+	return extractAssistantContent(lines)
+}
+
+// extractUserQuery extracts text from <user_query> tags.
+// Falls back to joining all lines if no tags are found.
+func extractUserQuery(lines []string) string {
+	text := strings.Join(lines, "\n")
+
+	start := strings.Index(text, "<user_query>")
+	end := strings.Index(text, "</user_query>")
+	if start >= 0 && end > start {
+		return strings.TrimSpace(
+			text[start+len("<user_query>") : end],
+		)
+	}
+
+	return strings.TrimSpace(text)
+}
+
+// extractAssistantContent parses assistant message lines for
+// visible text, thinking blocks, and tool calls.
+func extractAssistantContent(
+	lines []string,
+) (string, bool, []ParsedToolCall) {
+	var textParts []string
+	var toolCalls []ParsedToolCall
+	hasThinking := false
+
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		// Thinking block
+		if strings.HasPrefix(trimmed, "[Thinking]") {
+			hasThinking = true
+			i++
+			// Skip thinking content until next marker
+			for i < len(lines) {
+				t := strings.TrimSpace(lines[i])
+				if isAssistantMarker(t) {
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		// Tool call
+		if toolName, ok := strings.CutPrefix(
+			trimmed, "[Tool call] ",
+		); ok {
+			toolCalls = append(toolCalls, ParsedToolCall{
+				ToolName: toolName,
+				Category: NormalizeToolCategory(toolName),
+			})
+			i++
+			// Skip tool call parameters until next marker
+			for i < len(lines) {
+				t := strings.TrimSpace(lines[i])
+				if isAssistantMarker(t) {
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		// Tool result — skip the header and body
+		if strings.HasPrefix(trimmed, "[Tool result]") {
+			i++
+			for i < len(lines) {
+				t := strings.TrimSpace(lines[i])
+				if isAssistantMarker(t) {
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		// Regular text
+		textParts = append(textParts, line)
+		i++
+	}
+
+	content := strings.TrimSpace(strings.Join(textParts, "\n"))
+	return content, hasThinking, toolCalls
+}
+
+// isAssistantMarker returns true if the line is a structural
+// marker within an assistant block (thinking, tool call, or
+// tool result).
+func isAssistantMarker(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "[Thinking]") ||
+		strings.HasPrefix(trimmed, "[Tool call] ") ||
+		strings.HasPrefix(trimmed, "[Tool result]")
+}
+
+// DecodeCursorProjectDir extracts a clean project name from
+// a Cursor-style hyphenated directory name. Cursor encodes
+// absolute paths by replacing / and . with hyphens, e.g.
+// "Users-fiona-fan-Documents-mcp-cursor-analytics".
+func DecodeCursorProjectDir(dirName string) string {
+	if dirName == "" {
+		return ""
+	}
+
+	parts := strings.Split(dirName, "-")
+
+	// Find the last known parent directory marker.
+	// Everything after it is the project path.
+	markers := map[string]bool{
+		"Documents": true, "Code": true,
+		"code": true, "projects": true,
+		"repos": true, "src": true,
+		"work": true, "dev": true,
+	}
+
+	lastMarkerIdx := -1
+	for i, part := range parts {
+		if markers[part] {
+			lastMarkerIdx = i
+		}
+	}
+
+	if lastMarkerIdx >= 0 && lastMarkerIdx+1 < len(parts) {
+		result := strings.Join(
+			parts[lastMarkerIdx+1:], "-",
+		)
+		if result != "" {
+			return NormalizeName(result)
+		}
+	}
+
+	// Fallback: last two components
+	if len(parts) >= 2 {
+		return NormalizeName(
+			strings.Join(parts[len(parts)-2:], "-"),
+		)
+	}
+	return NormalizeName(dirName)
+}

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -219,10 +219,8 @@ func extractAssistantContent(
 		if strings.HasPrefix(trimmed, "[Thinking]") {
 			hasThinking = true
 			i++
-			// Skip thinking content until next marker
 			for i < len(lines) {
-				t := strings.TrimSpace(lines[i])
-				if isAssistantMarker(t) {
+				if isBlockBodyEnd(lines[i]) {
 					break
 				}
 				i++
@@ -239,10 +237,8 @@ func extractAssistantContent(
 				Category: NormalizeToolCategory(toolName),
 			})
 			i++
-			// Skip tool call parameters until next marker
 			for i < len(lines) {
-				t := strings.TrimSpace(lines[i])
-				if isAssistantMarker(t) {
+				if isBlockBodyEnd(lines[i]) {
 					break
 				}
 				i++
@@ -254,8 +250,7 @@ func extractAssistantContent(
 		if strings.HasPrefix(trimmed, "[Tool result]") {
 			i++
 			for i < len(lines) {
-				t := strings.TrimSpace(lines[i])
-				if isAssistantMarker(t) {
+				if isBlockBodyEnd(lines[i]) {
 					break
 				}
 				i++
@@ -279,6 +274,21 @@ func isAssistantMarker(trimmed string) bool {
 	return strings.HasPrefix(trimmed, "[Thinking]") ||
 		strings.HasPrefix(trimmed, "[Tool call] ") ||
 		strings.HasPrefix(trimmed, "[Tool result]")
+}
+
+// isBlockBodyEnd returns true if line signals the end of a
+// structured block body (thinking, tool call, or tool result).
+// Block bodies consist of indented or empty lines; a non-empty
+// line at the left margin is either a new marker or regular
+// assistant prose that should not be consumed.
+func isBlockBodyEnd(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if isAssistantMarker(trimmed) {
+		return true
+	}
+	// Non-empty line at left margin ends the block.
+	return trimmed != "" && len(line) > 0 && line[0] != ' ' &&
+		line[0] != '\t'
 }
 
 // DecodeCursorProjectDir extracts a clean project name from

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -1,0 +1,178 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestExtractAssistantContent(t *testing.T) {
+	tests := []struct {
+		name          string
+		lines         []string
+		wantText      string
+		wantThinking  bool
+		wantToolCount int
+	}{
+		{
+			name: "plain text",
+			lines: []string{
+				"Hello, how can I help?",
+			},
+			wantText: "Hello, how can I help?",
+		},
+		{
+			name: "thinking then text",
+			lines: []string{
+				"[Thinking]",
+				"  internal reasoning...",
+				"Here is my answer.",
+			},
+			wantText:     "Here is my answer.",
+			wantThinking: true,
+		},
+		{
+			name: "tool call then prose",
+			lines: []string{
+				"[Tool call] EditFile",
+				"  path=/tmp/foo.go",
+				"  content=bar",
+				"I edited the file for you.",
+			},
+			wantText:      "I edited the file for you.",
+			wantToolCount: 1,
+		},
+		{
+			name: "tool result then prose",
+			lines: []string{
+				"[Tool result]",
+				"  success: true",
+				"The operation completed.",
+			},
+			wantText: "The operation completed.",
+		},
+		{
+			name: "thinking, tool, prose sequence",
+			lines: []string{
+				"[Thinking]",
+				"  let me think...",
+				"[Tool call] Shell",
+				"  command=ls",
+				"[Tool result]",
+				"  file1.go",
+				"Here are the files I found.",
+			},
+			wantText:      "Here are the files I found.",
+			wantThinking:  true,
+			wantToolCount: 1,
+		},
+		{
+			name: "prose between markers",
+			lines: []string{
+				"First I'll check the file.",
+				"[Tool call] ReadFile",
+				"  path=main.go",
+				"[Tool result]",
+				"  package main",
+				"The file looks good.",
+				"[Tool call] Shell",
+				"  command=go build",
+				"Build succeeded.",
+			},
+			wantText: "First I'll check the file.\n" +
+				"The file looks good.\n" +
+				"Build succeeded.",
+			wantToolCount: 2,
+		},
+		{
+			name:  "empty lines",
+			lines: []string{},
+		},
+		{
+			name: "only markers no prose",
+			lines: []string{
+				"[Thinking]",
+				"  reasoning",
+				"[Tool call] Shell",
+				"  command=echo hi",
+			},
+			wantThinking:  true,
+			wantToolCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, hasThinking, toolCalls := extractAssistantContent(
+				tt.lines,
+			)
+			if text != tt.wantText {
+				t.Errorf(
+					"text = %q, want %q", text, tt.wantText,
+				)
+			}
+			if hasThinking != tt.wantThinking {
+				t.Errorf(
+					"hasThinking = %v, want %v",
+					hasThinking, tt.wantThinking,
+				)
+			}
+			if len(toolCalls) != tt.wantToolCount {
+				t.Errorf(
+					"tool call count = %d, want %d",
+					len(toolCalls), tt.wantToolCount,
+				)
+			}
+		})
+	}
+}
+
+func TestIsContainedIn_EdgeCases(t *testing.T) {
+	// isContainedIn is in sync/discovery.go; we test
+	// isBlockBodyEnd here since it's in cursor.go.
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"marker", "[Tool call] Shell", true},
+		{"indented", "  param=value", false},
+		{"tab indented", "\tparam=value", false},
+		{"empty", "", false},
+		{"left-margin prose", "Here is text.", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBlockBodyEnd(tt.line)
+			if got != tt.want {
+				t.Errorf(
+					"isBlockBodyEnd(%q) = %v, want %v",
+					tt.line, got, tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestDecodeCursorProjectDir(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{
+			"Users-fiona-Documents-project",
+			"project",
+		},
+		{
+			"Users-fiona-Documents-my-app",
+			"my_app",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := DecodeCursorProjectDir(tt.input)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -450,6 +450,19 @@ func TestDecodeCursorProjectDir(t *testing.T) {
 			"C-Users-user-dev-my-project",
 			"my_project",
 		},
+		// Multi-token usernames
+		{
+			"Users-john-doe-Documents-my-app",
+			"my_app",
+		},
+		{
+			"home-john-doe-projects-my-super-app",
+			"my_super_app",
+		},
+		{
+			"C-Users-jane-smith-dev-project",
+			"project",
+		},
 		// No recognized root — fallback to last two
 		{
 			"opt-builds-my-project",

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -209,6 +209,18 @@ func TestIsCursorJSONL(t *testing.T) {
 			strings.Repeat("\n", 100),
 			false,
 		},
+		{
+			"first line exceeds 4KB",
+			`{"role":"user","message":{"content":"` +
+				strings.Repeat("x", 5000) + `"}}`,
+			true,
+		},
+		{
+			"first non-empty line beyond 4KB of blanks",
+			strings.Repeat("\n", 5000) +
+				`{"role":"user","message":{"content":"hi"}}`,
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -473,6 +473,14 @@ func TestDecodeCursorProjectDir(t *testing.T) {
 			"C-Users-jane-dev-smith-projects-my-app",
 			"my_app",
 		},
+		// Ambiguous: "dev" could be a directory or part
+		// of the username. High-confidence "Documents"
+		// wins because marker-word usernames are rarer
+		// than real ~/Documents paths.
+		{
+			"Users-john-dev-my-Documents-app",
+			"app",
+		},
 		// No recognized root — fallback to last two
 		{
 			"opt-builds-my-project",

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -414,6 +414,35 @@ func TestDecodeCursorProjectDir(t *testing.T) {
 			"Users-fiona-Documents-my-app",
 			"my_app",
 		},
+		// Marker words inside project names must not
+		// cause truncation.
+		{
+			"Users-wesm-code-my-dev-tool",
+			"my_dev_tool",
+		},
+		{
+			"Users-wesm-code-work-bench",
+			"work_bench",
+		},
+		{
+			"Users-wesm-code-code-gen",
+			"code_gen",
+		},
+		// Linux home prefix
+		{
+			"home-user-projects-my-app",
+			"my_app",
+		},
+		// Windows prefix (drive letter)
+		{
+			"C-Users-user-dev-my-project",
+			"my_project",
+		},
+		// No recognized root — fallback to last two
+		{
+			"opt-builds-my-project",
+			"my_project",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -463,6 +463,16 @@ func TestDecodeCursorProjectDir(t *testing.T) {
 			"C-Users-jane-smith-dev-project",
 			"project",
 		},
+		// Username contains a low-confidence marker word;
+		// high-confidence marker later takes precedence.
+		{
+			"Users-john-code-doe-Documents-my-app",
+			"my_app",
+		},
+		{
+			"C-Users-jane-dev-smith-projects-my-app",
+			"my_app",
+		},
 		// No recognized root — fallback to last two
 		{
 			"opt-builds-my-project",

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -189,6 +189,12 @@ func TestIsCursorJSONL(t *testing.T) {
 			true,
 		},
 		{
+			"many leading blank lines",
+			strings.Repeat("\n", 50) +
+				`{"role":"user","message":{"content":"hi"}}`,
+			true,
+		},
+		{
 			"plain text",
 			"user:\nhello\nassistant:\nworld",
 			false,
@@ -196,6 +202,11 @@ func TestIsCursorJSONL(t *testing.T) {
 		{
 			"empty",
 			"",
+			false,
+		},
+		{
+			"only blank lines within scan limit",
+			strings.Repeat("\n", 100),
 			false,
 		},
 	}

--- a/internal/parser/open_nofollow_unix.go
+++ b/internal/parser/open_nofollow_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package parser
+
+import (
+	"os"
+	"syscall"
+)
+
+// openNoFollow opens a file for reading without following
+// symlinks at the final path component. On Unix systems this
+// uses O_NOFOLLOW which causes the open to fail with ELOOP if
+// the target is a symlink, closing the TOCTOU window between
+// discovery validation and file read.
+func openNoFollow(path string) (*os.File, error) {
+	return os.OpenFile(
+		path, os.O_RDONLY|syscall.O_NOFOLLOW, 0,
+	)
+}

--- a/internal/parser/open_nofollow_windows.go
+++ b/internal/parser/open_nofollow_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package parser
+
+import "os"
+
+// openNoFollow opens a file for reading. On Windows,
+// O_NOFOLLOW is not available so we fall back to a regular
+// open. The discovery-phase containment checks provide the
+// primary defense on this platform.
+func openNoFollow(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -63,6 +63,14 @@ func NormalizeToolCategory(rawName string) string {
 	case "report_intent":
 		return "Tool"
 
+	// Cursor tools
+	case "Shell":
+		return "Bash"
+	case "StrReplace":
+		return "Edit"
+	case "LS":
+		return "Read"
+
 	default:
 		return "Other"
 	}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -14,6 +14,7 @@ const (
 	AgentCopilot  AgentType = "copilot"
 	AgentGemini   AgentType = "gemini"
 	AgentOpenCode AgentType = "opencode"
+	AgentCursor   AgentType = "cursor"
 )
 
 // RelationshipType describes how a session relates to its parent.

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -253,3 +253,19 @@ func (s *Server) handleListMachines(
 		"machines": machines,
 	})
 }
+
+func (s *Server) handleListAgents(
+	w http.ResponseWriter, r *http.Request,
+) {
+	agents, err := s.db.GetAgents(r.Context())
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"agents": agents,
+	})
+}

--- a/internal/server/helpers_internal_test.go
+++ b/internal/server/helpers_internal_test.go
@@ -40,7 +40,7 @@ func testServer(
 		DBPath:       dbPath,
 		WriteTimeout: writeTimeout,
 	}
-	engine := sync.NewEngine(database, []string{dir}, nil, nil, nil, nil, "test")
+	engine := sync.NewEngine(database, []string{dir}, nil, nil, nil, nil, "", "test")
 	return New(cfg, database, engine, opts...)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -135,6 +135,7 @@ func (s *Server) routes() {
 	s.mux.Handle("GET /api/v1/search", s.withTimeout(s.handleSearch))
 	s.mux.Handle("GET /api/v1/projects", s.withTimeout(s.handleListProjects))
 	s.mux.Handle("GET /api/v1/machines", s.withTimeout(s.handleListMachines))
+	s.mux.Handle("GET /api/v1/agents", s.withTimeout(s.handleListAgents))
 	s.mux.Handle("GET /api/v1/stats", s.withTimeout(s.handleGetStats))
 	s.mux.Handle("GET /api/v1/version", s.withTimeout(s.handleGetVersion))
 	s.mux.HandleFunc("POST /api/v1/sync", s.handleTriggerSync)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -96,7 +96,7 @@ func setupWithServerOpts(
 		opt(&cfg)
 	}
 	engine := sync.NewEngine(
-		database, []string{claudeDir}, []string{codexDir}, nil, nil, nil, "test",
+		database, []string{claudeDir}, []string{codexDir}, nil, nil, nil, "", "test",
 	)
 	srv := server.New(cfg, database, engine, srvOpts...)
 
@@ -1440,7 +1440,7 @@ func TestWatchSession_Events(t *testing.T) {
 
 	engine := sync.NewEngine(
 		te.db, []string{te.claudeDir},
-		[]string{filepath.Join(te.dataDir, "codex")}, nil, nil, nil, "test",
+		[]string{filepath.Join(te.dataDir, "codex")}, nil, nil, nil, "", "test",
 	)
 	engine.SyncAll(nil)
 
@@ -1486,7 +1486,7 @@ func TestWatchSession_FileDisappearAndResolve(t *testing.T) {
 
 	engine := sync.NewEngine(
 		te.db, []string{te.claudeDir},
-		[]string{filepath.Join(te.dataDir, "codex")}, nil, nil, nil, "test",
+		[]string{filepath.Join(te.dataDir, "codex")}, nil, nil, nil, "", "test",
 	)
 	engine.SyncAll(nil)
 

--- a/internal/sync/discovery.go
+++ b/internal/sync/discovery.go
@@ -570,7 +570,9 @@ func FindCursorSourceFile(
 			continue
 		}
 		rel, err := filepath.Rel(resolvedRoot, resolved)
-		if err != nil || strings.HasPrefix(rel, "..") {
+		sep := string(filepath.Separator)
+		if err != nil || rel == ".." ||
+			strings.HasPrefix(rel, ".."+sep) {
 			continue
 		}
 		return candidate

--- a/internal/sync/discovery.go
+++ b/internal/sync/discovery.go
@@ -447,6 +447,137 @@ func confirmGeminiSessionID(
 	return parser.GeminiSessionID(data) == sessionID
 }
 
+// DiscoverCursorSessions finds all agent transcript files under
+// the Cursor projects dir (<projectsDir>/<project>/agent-transcripts/<uuid>.txt).
+// All discovered paths are validated to resolve within the
+// canonical projectsDir, preventing symlink escapes.
+func DiscoverCursorSessions(
+	projectsDir string,
+) []DiscoveredFile {
+	if projectsDir == "" {
+		return nil
+	}
+
+	// Canonicalize root once for containment checks.
+	resolvedRoot, err := filepath.EvalSymlinks(projectsDir)
+	if err != nil {
+		return nil
+	}
+
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return nil
+	}
+
+	var files []DiscoveredFile
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		// Reject symlinked project directory entries.
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		transcriptsDir := filepath.Join(
+			projectsDir, entry.Name(), "agent-transcripts",
+		)
+
+		// Verify the transcripts directory resolves within
+		// the canonical root. This catches symlinked
+		// agent-transcripts directories pointing outside.
+		resolvedDir, err := filepath.EvalSymlinks(
+			transcriptsDir,
+		)
+		if err != nil {
+			continue
+		}
+		if !isContainedIn(resolvedDir, resolvedRoot) {
+			continue
+		}
+
+		transcripts, err := os.ReadDir(transcriptsDir)
+		if err != nil {
+			continue
+		}
+
+		project := parser.DecodeCursorProjectDir(entry.Name())
+		if project == "" {
+			project = "unknown"
+		}
+
+		for _, sf := range transcripts {
+			if sf.IsDir() {
+				continue
+			}
+			if !strings.HasSuffix(sf.Name(), ".txt") {
+				continue
+			}
+			fullPath := filepath.Join(transcriptsDir, sf.Name())
+			if !isRegularFile(fullPath) {
+				continue
+			}
+			files = append(files, DiscoveredFile{
+				Path:    fullPath,
+				Project: project,
+				Agent:   parser.AgentCursor,
+			})
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// FindCursorSourceFile finds a Cursor transcript file by
+// session UUID. Searches all project directories for a
+// matching agent-transcripts/<uuid>.txt file.
+func FindCursorSourceFile(
+	projectsDir, sessionID string,
+) string {
+	if projectsDir == "" || !isValidSessionID(sessionID) {
+		return ""
+	}
+
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return ""
+	}
+
+	// Canonicalize the root so the containment check works
+	// even when CURSOR_PROJECTS_DIR is itself a symlink.
+	resolvedRoot, err := filepath.EvalSymlinks(projectsDir)
+	if err != nil {
+		return ""
+	}
+
+	target := sessionID + ".txt"
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(
+			projectsDir, entry.Name(),
+			"agent-transcripts", target,
+		)
+		if !isRegularFile(candidate) {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(resolvedRoot, resolved)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		return candidate
+	}
+	return ""
+}
+
 // geminiProjectsFile holds the structure of
 // ~/.gemini/projects.json.
 type geminiProjectsFile struct {
@@ -675,4 +806,26 @@ func FindCopilotSourceFile(
 	}
 
 	return ""
+}
+
+// isRegularFile returns true if path exists and is a regular
+// file (not a symlink, directory, or other special file).
+// Uses os.Lstat to avoid following symlinks.
+func isRegularFile(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}
+
+// isContainedIn returns true if child is a path strictly
+// under root. Both paths must be absolute / canonical (no
+// symlinks) for this to be reliable.
+func isContainedIn(child, root string) bool {
+	rel, err := filepath.Rel(root, child)
+	if err != nil {
+		return false
+	}
+	return !strings.HasPrefix(rel, "..")
 }

--- a/internal/sync/discovery.go
+++ b/internal/sync/discovery.go
@@ -827,5 +827,5 @@ func isContainedIn(child, root string) bool {
 	if err != nil {
 		return false
 	}
-	return !strings.HasPrefix(rel, "..")
+	return rel != "." && !strings.HasPrefix(rel, "..")
 }

--- a/internal/sync/discovery.go
+++ b/internal/sync/discovery.go
@@ -827,5 +827,6 @@ func isContainedIn(child, root string) bool {
 	if err != nil {
 		return false
 	}
-	return rel != "." && !strings.HasPrefix(rel, "..")
+	return rel != "." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/internal/sync/discovery.go
+++ b/internal/sync/discovery.go
@@ -827,6 +827,6 @@ func isContainedIn(child, root string) bool {
 	if err != nil {
 		return false
 	}
-	return rel != "." &&
+	return rel != "." && rel != ".." &&
 		!strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1132,7 +1132,9 @@ func validateCursorContainment(
 		return fmt.Errorf("resolve path: %w", err)
 	}
 	rel, err := filepath.Rel(resolvedRoot, resolvedPath)
-	if err != nil || strings.HasPrefix(rel, "..") {
+	sep := string(filepath.Separator)
+	if err != nil || rel == ".." ||
+		strings.HasPrefix(rel, ".."+sep) {
 		return fmt.Errorf(
 			"%s escapes %s", path, cursorDir,
 		)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -311,7 +311,7 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
-	// Cursor: <cursorDir>/<project>/agent-transcripts/<uuid>.txt
+	// Cursor: <cursorDir>/<project>/agent-transcripts/<uuid>.{txt,jsonl}
 	if e.cursorDir != "" {
 		if rel, ok := isUnder(e.cursorDir, path); ok {
 			parts := strings.Split(rel, sep)
@@ -321,7 +321,7 @@ func (e *Engine) classifyOnePath(
 			if parts[1] != "agent-transcripts" {
 				return DiscoveredFile{}, false
 			}
-			if !strings.HasSuffix(parts[2], ".txt") {
+			if !isCursorTranscriptExt(parts[2]) {
 				return DiscoveredFile{}, false
 			}
 			project := parser.DecodeCursorProjectDir(parts[0])
@@ -1073,9 +1073,7 @@ func (e *Engine) processGemini(
 func (e *Engine) processCursor(
 	file DiscoveredFile, info os.FileInfo,
 ) processResult {
-	sessionID := "cursor:" + strings.TrimSuffix(
-		info.Name(), ".txt",
-	)
+	sessionID := parser.CursorSessionID(file.Path)
 
 	if e.shouldSkipFile(sessionID, info) {
 		return processResult{skip: true}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1073,6 +1073,14 @@ func (e *Engine) processGemini(
 func (e *Engine) processCursor(
 	file DiscoveredFile, info os.FileInfo,
 ) processResult {
+	// Skip .txt if a sibling .jsonl exists — .jsonl is the
+	// richer format and takes precedence.
+	if stem, ok := strings.CutSuffix(file.Path, ".txt"); ok {
+		if isRegularFile(stem + ".jsonl") {
+			return processResult{skip: true}
+		}
+	}
+
 	sessionID := parser.CursorSessionID(file.Path)
 
 	if e.shouldSkipFile(sessionID, info) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -81,7 +81,7 @@ func setupTestEnv(t *testing.T, opts ...TestEnvOption) *testEnv {
 
 	env.engine = sync.NewEngine(
 		env.db, claudeDirs, codexDirs, nil,
-		[]string{env.geminiDir}, []string{env.opencodeDir}, "local",
+		[]string{env.geminiDir}, []string{env.opencodeDir}, "", "local",
 	)
 	return env
 }

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -995,3 +995,47 @@ func TestFindClaudeSourceFile_Symlink(t *testing.T) {
 		t.Errorf("expected path through symlink, got %q", got)
 	}
 }
+
+func TestIsContainedIn(t *testing.T) {
+	tests := []struct {
+		name        string
+		child, root string
+		want        bool
+	}{
+		{
+			name:  "child under root",
+			child: "/a/b/c",
+			root:  "/a/b",
+			want:  true,
+		},
+		{
+			name:  "same path",
+			child: "/a/b",
+			root:  "/a/b",
+			want:  false,
+		},
+		{
+			name:  "child outside root",
+			child: "/a/x",
+			root:  "/a/b",
+			want:  false,
+		},
+		{
+			name:  "traversal",
+			child: "/a/b/../x",
+			root:  "/a/b",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isContainedIn(tt.child, tt.root)
+			if got != tt.want {
+				t.Errorf(
+					"isContainedIn(%q, %q) = %v, want %v",
+					tt.child, tt.root, got, tt.want,
+				)
+			}
+		})
+	}
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1027,6 +1027,12 @@ func TestIsContainedIn(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "parent of root",
+			child: "/a",
+			root:  "/a/b",
+			want:  false,
+		},
+		{
 			name:  "dotdot-prefixed name",
 			child: "/a/b/..hidden",
 			root:  "/a/b",

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/wesm/agentsview/internal/parser"
 )
@@ -1166,37 +1165,21 @@ func TestFindCursorSourceFile(t *testing.T) {
 		}
 	})
 
-	t.Run("PrefersNewerWhenBothExist", func(t *testing.T) {
+	t.Run("PrefersJsonlWhenBothExist", func(t *testing.T) {
 		dir := t.TempDir()
 		setupFileSystem(t, dir, map[string]string{
 			filepath.Join(cursorTranscripts, "sess3.txt"):   "old",
 			filepath.Join(cursorTranscripts, "sess3.jsonl"): "new",
 		})
-		// Touch .jsonl to make it newer.
 		jsonlPath := filepath.Join(
 			dir, cursorTranscripts, "sess3.jsonl",
 		)
-		now := time.Now()
-		os.Chtimes(jsonlPath, now, now)
-		// Touch .txt to make it older.
-		txtPath := filepath.Join(
-			dir, cursorTranscripts, "sess3.txt",
-		)
-		past := now.Add(-time.Hour)
-		os.Chtimes(txtPath, past, past)
-
 		got := FindCursorSourceFile(dir, "sess3")
 		if got != jsonlPath {
-			t.Errorf("got %q, want %q (newer file)", got, jsonlPath)
-		}
-
-		// Reverse: make .txt newer.
-		os.Chtimes(txtPath, now, now)
-		os.Chtimes(jsonlPath, past, past)
-
-		got = FindCursorSourceFile(dir, "sess3")
-		if got != txtPath {
-			t.Errorf("got %q, want %q (newer file)", got, txtPath)
+			t.Errorf(
+				"got %q, want %q (.jsonl preferred)",
+				got, jsonlPath,
+			)
 		}
 	})
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1026,6 +1026,12 @@ func TestIsContainedIn(t *testing.T) {
 			root:  "/a/b",
 			want:  false,
 		},
+		{
+			name:  "dotdot-prefixed name",
+			child: "/a/b/..hidden",
+			root:  "/a/b",
+			want:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Supersedes #22 (squashed, rebased on main, with review fixes).

- Add Cursor as a supported agent type, syncing transcripts from `~/.cursor/projects/<project>/agent-transcripts/` with a dedicated parser, file discovery, and sync engine wiring
- Support both `.txt` (legacy plain-text) and `.jsonl` (Anthropic API message format) transcript files with automatic format detection
- Add `/api/v1/agents` endpoint and agent filter dropdown in the dashboard header to filter sessions by source
- Thread agent filter through analytics so all dashboard panels respect the selection
- Map Cursor tool names (Shell, StrReplace, LS) to normalized categories

### Parser and sync details

- Format detection: first non-empty line is checked for valid JSON to dispatch between JSONL and text parsers
- JSONL parser reuses `ExtractTextContent` for assistant messages (handles `text`, `thinking`, `tool_use`, `tool_result` blocks) and `extractUserQuery` for user messages (strips `<user_query>` tags)
- Discovery dedupes by basename when both `.txt` and `.jsonl` exist, preferring `.jsonl`
- `FindCursorSourceFile` picks the newest file by mtime when both extensions exist
- `DecodeCursorProjectDir` anchors marker matching to the home-directory position to avoid truncating project names containing marker words (e.g. `my-dev-tool`)
- `CursorSessionID` derives extension-agnostic session IDs

### Content parser fix

- Frontend content parser no longer false-matches `[Thinking]` / `[Bash]` markers inside inline code spans (backtick-quoted text in markdown)
- Replaced regex-based inline code detection with a CommonMark-compliant scanner supporting arbitrary backtick delimiter lengths
- Fenced code blocks at line start are correctly distinguished from inline triple-backtick spans

### Earlier review fixes

- Fix `extractAssistantContent` dropping visible prose after marker blocks (added `isBlockBodyEnd` heuristic)
- Fix `isContainedIn` rejecting `..`-prefixed child names and accepting `rel == "."`
- Exclude empty agent names from `GetAgents` query
- Return `[]` instead of `null` JSON when no agents match
- Use black accent color for Cursor agent

Co-authored-by: jfan-nux <jfan3@wellesley.edu>

Closes #22