### PR TITLE
Remove agent filter dropdown from header

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -9,12 +9,6 @@
   const isMac = navigator.platform.toUpperCase().includes("MAC");
   const modKey = isMac ? "Cmd" : "Ctrl";
 
-  function handleAgentChange(e: Event) {
-    const select = e.target as HTMLSelectElement;
-    sessions.setAgentFilter(select.value);
-  }
-
-
   function handleExport() {
     if (sessions.activeSessionId) {
       window.open(
@@ -54,19 +48,6 @@
       value={sessions.filters.project}
       onselect={(v) => sessions.setProjectFilter(v)}
     />
-
-    <select
-      class="project-select"
-      value={sessions.filters.agent}
-      onchange={handleAgentChange}
-    >
-      <option value="">All Agents</option>
-      {#each sessions.agents as agent}
-        <option value={agent.name}>
-          {agent.name} ({agent.session_count})
-        </option>
-      {/each}
-    </select>
 
     <button
       class="nav-btn"


### PR DESCRIPTION
## Summary

- Remove the native `<select>` agent filter dropdown from the header bar
- Agent filtering is already available in the session list filter controls, making the header dropdown redundant and visually inconsistent with the styled project typeahead

## Test plan

- [ ] Run `npm run check` in frontend/ -- 0 errors
- [ ] Verify the header no longer shows the agent dropdown
- [ ] Verify agent filtering still works via the session list filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)