### PR TITLE
feat: Codex tool call enrichment, non-destructive DB resync, dashboard date fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,7 @@ Instructions for autonomous coding agents working in this repository.
 
 - Do not revert user-authored or unrelated local changes unless explicitly requested.
 - Avoid destructive git commands unless explicitly requested.
+
+## Data Safety
+
+The SQLite database is a persistent archive. Never delete or recreate it to handle data version changes. Schema changes use ALTER TABLE; parser changes trigger a full resync (build fresh DB, sync files, copy orphaned sessions from old DB, atomic swap). Existing session data must be preserved even when source files no longer exist on disk.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ make vet        # go vet
 - Prefer stdlib over external dependencies
 - Tests should be fast and isolated
 - No emojis in code or output
+- **The database is a persistent archive** — never drop, truncate, or recreate the database to handle data version changes. Use non-destructive migrations (ALTER TABLE, UPDATE) and full resync (build fresh DB, copy orphaned data, swap) instead. Session data must survive even when the original source files are gone.
 
 ## Git Workflow
 

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -164,7 +164,11 @@ func runServe(args []string) {
 		Machine:   "local",
 	})
 
-	runInitialSync(engine)
+	if database.NeedsResync() {
+		runInitialResync(engine)
+	} else {
+		runInitialSync(engine)
+	}
 
 	stopWatcher, unwatchedDirs := startFileWatcher(cfg, engine)
 	defer stopWatcher()
@@ -298,10 +302,27 @@ func runInitialSync(engine *sync.Engine) {
 	fmt.Println("Running initial sync...")
 	t := time.Now()
 	stats := engine.SyncAll(printSyncProgress)
+	printSyncSummary(stats, t)
+}
+
+func runInitialResync(engine *sync.Engine) {
+	fmt.Println("Data version changed, running full resync...")
+	t := time.Now()
+	stats := engine.ResyncAll(printSyncProgress)
+	printSyncSummary(stats, t)
+}
+
+func printSyncSummary(stats sync.SyncStats, t time.Time) {
 	summary := fmt.Sprintf(
 		"\nSync complete: %d sessions synced",
 		stats.Synced,
 	)
+	if stats.OrphanedCopied > 0 {
+		summary += fmt.Sprintf(
+			", %d archived sessions preserved",
+			stats.OrphanedCopied,
+		)
+	}
 	if stats.Failed > 0 {
 		summary += fmt.Sprintf(", %d failed", stats.Failed)
 	}

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -147,6 +147,9 @@ func runServe(args []string) {
 	defer database.Close()
 
 	for _, def := range parser.Registry {
+		if !cfg.IsUserConfigured(def.Type) {
+			continue
+		}
 		warnMissingDirs(
 			cfg.ResolveDirs(def.Type),
 			string(def.Type),

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -310,6 +310,16 @@ func runInitialResync(engine *sync.Engine) {
 	t := time.Now()
 	stats := engine.ResyncAll(printSyncProgress)
 	printSyncSummary(stats, t)
+
+	// If resync was aborted (swap didn't happen), fall back
+	// to a normal incremental sync so the server starts with
+	// current file data rather than a potentially stale DB.
+	if len(stats.Warnings) > 0 {
+		fmt.Println("Resync incomplete, running incremental sync...")
+		t = time.Now()
+		fallback := engine.SyncAll(printSyncProgress)
+		printSyncSummary(fallback, t)
+	}
 }
 
 func printSyncSummary(stats sync.SyncStats, t time.Time) {
@@ -330,6 +340,9 @@ func printSyncSummary(stats sync.SyncStats, t time.Time) {
 		" in %s\n", time.Since(t).Round(time.Millisecond),
 	)
 	fmt.Print(summary)
+	for _, w := range stats.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
 }
 
 func printSyncProgress(p sync.Progress) {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -314,7 +314,7 @@ func runInitialResync(engine *sync.Engine) {
 	// If resync was aborted (swap didn't happen), fall back
 	// to a normal incremental sync so the server starts with
 	// current file data rather than a potentially stale DB.
-	if len(stats.Warnings) > 0 {
+	if stats.Aborted {
 		fmt.Println("Resync incomplete, running incremental sync...")
 		t = time.Now()
 		fallback := engine.SyncAll(printSyncProgress)

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -62,7 +62,10 @@ func main() {
 	}
 	defer database.Close()
 
-	base := time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC)
+	// Use a recent base date so fixture data stays within the
+	// default 1-year analytics window.
+	base := time.Now().UTC().AddDate(0, 0, -30).
+		Truncate(24 * time.Hour).Add(10 * time.Hour)
 
 	for i, spec := range specs {
 		if err := createSessionFixture(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -171,7 +171,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -212,7 +211,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1116,7 +1114,6 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -1327,7 +1324,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1712,7 +1708,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -1874,7 +1869,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2100,7 +2094,6 @@
       "integrity": "sha512-YkqERnF05g8KLdDZwZrF8/i1eSbj6Eoat8Jjr2IfruZz9StLuBqo8sfCSzjosNKd+ZrQ8DkKZDjpO5y3ht1Pow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2250,7 +2243,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2275,7 +2267,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/frontend/src/lib/api/types/analytics.ts
+++ b/frontend/src/lib/api/types/analytics.ts
@@ -55,6 +55,7 @@ export interface HeatmapResponse {
   metric: string;
   entries: HeatmapEntry[];
   levels: HeatmapLevels;
+  entries_from: string;
 }
 
 export interface ProjectAnalytics {

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -85,6 +85,7 @@ export interface Stats {
   message_count: number;
   project_count: number;
   machine_count: number;
+  earliest_session: string | null;
 }
 
 export interface MessagesResponse {

--- a/frontend/src/lib/api/types/sync.ts
+++ b/frontend/src/lib/api/types/sync.ts
@@ -17,6 +17,7 @@ export interface SyncStats {
   failed: number;
   orphaned_copied?: number;
   warnings?: string[];
+  aborted?: boolean;
 }
 
 export interface SyncStatus {

--- a/frontend/src/lib/api/types/sync.ts
+++ b/frontend/src/lib/api/types/sync.ts
@@ -15,6 +15,8 @@ export interface SyncStats {
   synced: number;
   skipped: number;
   failed: number;
+  orphaned_copied?: number;
+  warnings?: string[];
 }
 
 export interface SyncStatus {

--- a/frontend/src/lib/components/analytics/DateRangePicker.svelte
+++ b/frontend/src/lib/components/analytics/DateRangePicker.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { analytics } from "../../stores/analytics.svelte.js";
+  import { sync } from "../../stores/sync.svelte.js";
 
   interface Preset {
     label: string;
@@ -31,18 +32,24 @@
     return localDateStr(new Date());
   }
 
-  const ALL_FROM = "1970-01-01";
+  function allFrom(): string {
+    const ts = sync.stats?.earliest_session;
+    if (ts && ts.length >= 10) {
+      return ts.slice(0, 10);
+    }
+    return daysAgo(365);
+  }
 
   function applyPreset(days: number) {
     if (days === 0) {
-      analytics.setDateRange(ALL_FROM, todayStr());
+      analytics.setDateRange(allFrom(), todayStr());
     } else {
       analytics.setDateRange(daysAgo(days), todayStr());
     }
   }
 
   function isActive(days: number): boolean {
-    const from = days === 0 ? ALL_FROM : daysAgo(days);
+    const from = days === 0 ? allFrom() : daysAgo(days);
     return analytics.from === from &&
       analytics.to === todayStr();
   }

--- a/frontend/src/lib/components/analytics/Heatmap.svelte
+++ b/frontend/src/lib/components/analytics/Heatmap.svelte
@@ -157,6 +157,9 @@
       </button>
     </div>
   {:else if grid.cols.length > 0}
+    {#if analytics.heatmap?.entries_from && analytics.heatmap.entries_from > analytics.from}
+      <div class="clamp-note">Showing most recent year</div>
+    {/if}
     <div class="heatmap-scroll">
       <svg
         width={svgWidth}
@@ -320,6 +323,12 @@
     white-space: nowrap;
     pointer-events: none;
     z-index: 100;
+  }
+
+  .clamp-note {
+    color: var(--text-muted);
+    font-size: 10px;
+    margin-bottom: 4px;
   }
 
   .loading, .empty {

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -57,7 +57,7 @@ type Panel =
   | "topSessions";
 
 class AnalyticsStore {
-  from: string = $state("1970-01-01");
+  from: string = $state(daysAgo(365));
   to: string = $state(today());
   granularity: Granularity = $state("day");
   metric: HeatmapMetric = $state("messages");

--- a/frontend/src/lib/stores/analytics.test.ts
+++ b/frontend/src/lib/stores/analytics.test.ts
@@ -56,6 +56,7 @@ function makeHeatmap(): HeatmapResponse {
     metric: "messages",
     entries: [],
     levels: { l1: 1, l2: 5, l3: 10, l4: 20 },
+    entries_from: "2024-01-01",
   };
 }
 

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -35,6 +35,7 @@ function mockResyncSuccess(): void {
     message_count: 100,
     project_count: 3,
     machine_count: 1,
+    earliest_session: null,
   });
 }
 

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -528,6 +528,22 @@ describe("enrichSegments", () => {
     }
   });
 
+  it("replaces truncated Codex Bash content with full cmd", () => {
+    const firstLine = "cat > file.toml <<'EOF'";
+    const fullCmd = `${firstLine}\n[package]\nname = "foo"\nEOF`;
+    // Backend truncates to first line; regex sees [Bash]\n$ first-line
+    const segments = parseContent(`[exec_command]\n$ ${firstLine}`);
+
+    const tc: ToolCall = {
+      tool_name: "exec_command",
+      category: "Bash",
+      input_json: JSON.stringify({ cmd: fullCmd }),
+    };
+    const result = enrichSegments(segments, [tc]);
+    expect(result[0]!.content).toBe(`$ ${fullCmd}`);
+    expect(result[0]!.toolCall).toBe(tc);
+  });
+
   it("does not replace single-line Bash content", () => {
     const segments = parseContent("[Bash]\n$ echo hi");
     const tc: ToolCall = {

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -355,10 +355,10 @@ export function enrichSegments(
       tcIdx++;
       const enriched: ContentSegment = { ...seg, toolCall: tc };
 
-      if (tc.tool_name === "Bash" && tc.input_json) {
+      if (tc.category === "Bash" && tc.input_json) {
         try {
           const input = JSON.parse(tc.input_json);
-          const fullCmd = input.command;
+          const fullCmd = input.command ?? input.cmd;
           if (fullCmd && fullCmd.includes("\n")) {
             enriched.content = `$ ${fullCmd}`;
             // Absorb orphaned text segments from truncated command

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type dirSource int
 
 const (
 	dirDefault dirSource = iota
+	dirFile
 	dirEnv
 )
 
@@ -48,6 +49,15 @@ func (c *Config) ResolveDirs(
 	agent parser.AgentType,
 ) []string {
 	return c.AgentDirs[agent]
+}
+
+// IsUserConfigured reports whether the agent's directories
+// were explicitly set by the user (via env var or config file)
+// rather than populated from defaults.
+func (c *Config) IsUserConfigured(
+	agent parser.AgentType,
+) bool {
+	return c.agentDirSource[agent] != dirDefault
 }
 
 // Default returns a Config with default values.
@@ -168,6 +178,7 @@ func (c *Config) loadFile() error {
 		}
 		if len(dirs) > 0 {
 			c.AgentDirs[def.Type] = dirs
+			c.agentDirSource[def.Type] = dirFile
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -224,11 +224,12 @@ func TestLoadFile_ReadsDirArrays(t *testing.T) {
 
 func TestResolveDirs(t *testing.T) {
 	tests := []struct {
-		name          string
-		config        map[string]any
-		envValue      string
-		expectDefault bool
-		wantDirs      []string
+		name           string
+		config         map[string]any
+		envValue       string
+		expectDefault  bool
+		wantDirs       []string
+		wantUserConfig bool
 	}{
 		{
 			"DefaultOnly",
@@ -236,6 +237,7 @@ func TestResolveDirs(t *testing.T) {
 			"",
 			true,
 			nil,
+			false,
 		},
 		{
 			"ConfigOverrides",
@@ -245,6 +247,7 @@ func TestResolveDirs(t *testing.T) {
 			"",
 			false,
 			[]string{"/a", "/b"},
+			true,
 		},
 		{
 			"EnvOverrides",
@@ -254,6 +257,7 @@ func TestResolveDirs(t *testing.T) {
 			"/env/override",
 			false,
 			[]string{"/env/override"},
+			true,
 		},
 	}
 
@@ -291,6 +295,14 @@ func TestResolveDirs(t *testing.T) {
 						i, v, want[i],
 					)
 				}
+			}
+
+			got := cfg.IsUserConfigured(parser.AgentClaude)
+			if got != tt.wantUserConfig {
+				t.Errorf(
+					"IsUserConfigured = %v, want %v",
+					got, tt.wantUserConfig,
+				)
 			}
 		})
 	}

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -127,7 +127,7 @@ func (f AnalyticsFilter) buildWhere(
 
 	if f.ActiveSince != "" {
 		preds = append(preds,
-			"COALESCE(ended_at, started_at, created_at) >= ?")
+			"COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at) >= ?")
 		args = append(args, f.ActiveSince)
 	}
 
@@ -167,7 +167,7 @@ func (db *DB) filteredSessionIDs(
 	ctx context.Context, f AnalyticsFilter,
 ) (map[string]bool, error) {
 	loc := f.location()
-	dateCol := "COALESCE(s.started_at, s.created_at)"
+	dateCol := "COALESCE(NULLIF(s.started_at, ''), s.created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	query := `SELECT s.id, m.timestamp
@@ -297,7 +297,7 @@ func (db *DB) GetAnalyticsSummary(
 	ctx context.Context, f AnalyticsFilter,
 ) (AnalyticsSummary, error) {
 	loc := f.location()
-	dateCol := "COALESCE(started_at, created_at)"
+	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	var timeIDs map[string]bool
@@ -482,7 +482,7 @@ func (db *DB) GetAnalyticsActivity(
 		granularity = "day"
 	}
 	loc := f.location()
-	dateCol := "COALESCE(s.started_at, s.created_at)"
+	dateCol := "COALESCE(NULLIF(s.started_at, ''), s.created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	var timeIDs map[string]bool
@@ -669,7 +669,7 @@ func (db *DB) GetAnalyticsHeatmap(
 	}
 
 	loc := f.location()
-	dateCol := "COALESCE(started_at, created_at)"
+	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	var timeIDs map[string]bool
@@ -860,7 +860,7 @@ func (db *DB) GetAnalyticsProjects(
 	ctx context.Context, f AnalyticsFilter,
 ) (ProjectsAnalyticsResponse, error) {
 	loc := f.location()
-	dateCol := "COALESCE(started_at, created_at)"
+	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	var timeIDs map[string]bool
@@ -1006,7 +1006,7 @@ func (db *DB) GetAnalyticsHourOfWeek(
 	ctx context.Context, f AnalyticsFilter,
 ) (HourOfWeekResponse, error) {
 	loc := f.location()
-	dateCol := "COALESCE(s.started_at, s.created_at)"
+	dateCol := "COALESCE(NULLIF(s.started_at, ''), s.created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	query := `SELECT ` + dateCol + `, m.timestamp
@@ -1178,7 +1178,7 @@ func (db *DB) GetAnalyticsSessionShape(
 	ctx context.Context, f AnalyticsFilter,
 ) (SessionShapeResponse, error) {
 	loc := f.location()
-	dateCol := "COALESCE(started_at, created_at)"
+	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	var timeIDs map[string]bool
@@ -1342,7 +1342,7 @@ func (db *DB) GetAnalyticsTools(
 	ctx context.Context, f AnalyticsFilter,
 ) (ToolsAnalyticsResponse, error) {
 	loc := f.location()
-	dateCol := "COALESCE(started_at, created_at)"
+	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	var timeIDs map[string]bool
@@ -1688,7 +1688,7 @@ func (db *DB) GetAnalyticsVelocity(
 	ctx context.Context, f AnalyticsFilter,
 ) (VelocityResponse, error) {
 	loc := f.location()
-	dateCol := "COALESCE(started_at, created_at)"
+	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	var timeIDs map[string]bool
@@ -1988,7 +1988,7 @@ func (db *DB) GetAnalyticsTopSessions(
 		metric = "messages"
 	}
 	loc := f.location()
-	dateCol := "COALESCE(started_at, created_at)"
+	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
 	where, args := f.buildWhere(dateCol)
 
 	var timeIDs map[string]bool

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -722,10 +722,14 @@ func (db *DB) GetAnalyticsHeatmap(
 		source = daySessions
 	}
 
-	// Collect non-zero values for quartile computation
+	// Determine effective date range (clamped to MaxHeatmapDays)
+	entriesFrom := clampFrom(f.From, f.To)
+
+	// Collect non-zero values from the displayed range only,
+	// so outliers outside the window don't skew intensity.
 	var values []int
-	for _, v := range source {
-		if v > 0 {
+	for date, v := range source {
+		if v > 0 && date >= entriesFrom && date <= f.To {
 			values = append(values, v)
 		}
 	}
@@ -733,9 +737,9 @@ func (db *DB) GetAnalyticsHeatmap(
 
 	levels := computeQuartileLevels(values)
 
-	// Build entries for each day in range
-	entries, entriesFrom := buildDateEntries(
-		f.From, f.To, source, levels,
+	// Build entries for each day in the clamped range
+	entries := buildDateEntries(
+		entriesFrom, f.To, source, levels,
 	)
 
 	return HeatmapResponse{
@@ -782,30 +786,41 @@ func assignLevel(value int, levels HeatmapLevels) int {
 // the most recent MaxHeatmapDays from the end date.
 const MaxHeatmapDays = 366
 
+// clampFrom returns from clamped so that [from, to] spans at
+// most MaxHeatmapDays. If the range is already within bounds,
+// from is returned unchanged.
+func clampFrom(from, to string) string {
+	start, err := time.Parse("2006-01-02", from)
+	if err != nil {
+		return from
+	}
+	end, err := time.Parse("2006-01-02", to)
+	if err != nil {
+		return from
+	}
+	earliest := end.AddDate(0, 0, -(MaxHeatmapDays - 1))
+	if start.Before(earliest) {
+		return earliest.Format("2006-01-02")
+	}
+	return from
+}
+
 // buildDateEntries creates a HeatmapEntry for each day in
-// [from, to], clamping to at most maxHeatmapDays. Returns
-// the entries and the effective start date (which may differ
-// from the requested from when clamped).
+// [from, to]. The caller is responsible for clamping the
+// range via clampFrom before calling this function.
 func buildDateEntries(
 	from, to string,
 	values map[string]int,
 	levels HeatmapLevels,
-) ([]HeatmapEntry, string) {
+) []HeatmapEntry {
 	start, err := time.Parse("2006-01-02", from)
 	if err != nil {
-		return nil, from
+		return nil
 	}
 	end, err := time.Parse("2006-01-02", to)
 	if err != nil {
-		return nil, from
+		return nil
 	}
-
-	// Clamp to most recent MaxHeatmapDays
-	earliest := end.AddDate(0, 0, -(MaxHeatmapDays - 1))
-	if start.Before(earliest) {
-		start = earliest
-	}
-	effectiveFrom := start.Format("2006-01-02")
 
 	var entries []HeatmapEntry
 	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
@@ -817,7 +832,7 @@ func buildDateEntries(
 			Level: assignLevel(v, levels),
 		})
 	}
-	return entries, effectiveFrom
+	return entries
 }
 
 // --- Projects ---

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -653,9 +653,10 @@ type HeatmapLevels struct {
 
 // HeatmapResponse wraps the heatmap data.
 type HeatmapResponse struct {
-	Metric  string         `json:"metric"`
-	Entries []HeatmapEntry `json:"entries"`
-	Levels  HeatmapLevels  `json:"levels"`
+	Metric      string         `json:"metric"`
+	Entries     []HeatmapEntry `json:"entries"`
+	Levels      HeatmapLevels  `json:"levels"`
+	EntriesFrom string         `json:"entries_from"`
 }
 
 // GetAnalyticsHeatmap returns daily counts with intensity levels.
@@ -733,12 +734,15 @@ func (db *DB) GetAnalyticsHeatmap(
 	levels := computeQuartileLevels(values)
 
 	// Build entries for each day in range
-	entries := buildDateEntries(f.From, f.To, source, levels)
+	entries, entriesFrom := buildDateEntries(
+		f.From, f.To, source, levels,
+	)
 
 	return HeatmapResponse{
-		Metric:  metric,
-		Entries: entries,
-		Levels:  levels,
+		Metric:      metric,
+		Entries:     entries,
+		Levels:      levels,
+		EntriesFrom: entriesFrom,
 	}, nil
 }
 
@@ -773,20 +777,35 @@ func assignLevel(value int, levels HeatmapLevels) int {
 	return 4
 }
 
-// buildDateEntries creates a HeatmapEntry for each day in [from, to].
+// MaxHeatmapDays is the maximum number of day entries the
+// heatmap will return. Ranges exceeding this are clamped to
+// the most recent MaxHeatmapDays from the end date.
+const MaxHeatmapDays = 366
+
+// buildDateEntries creates a HeatmapEntry for each day in
+// [from, to], clamping to at most maxHeatmapDays. Returns
+// the entries and the effective start date (which may differ
+// from the requested from when clamped).
 func buildDateEntries(
 	from, to string,
 	values map[string]int,
 	levels HeatmapLevels,
-) []HeatmapEntry {
+) ([]HeatmapEntry, string) {
 	start, err := time.Parse("2006-01-02", from)
 	if err != nil {
-		return nil
+		return nil, from
 	}
 	end, err := time.Parse("2006-01-02", to)
 	if err != nil {
-		return nil
+		return nil, from
 	}
+
+	// Clamp to most recent MaxHeatmapDays
+	earliest := end.AddDate(0, 0, -(MaxHeatmapDays - 1))
+	if start.Before(earliest) {
+		start = earliest
+	}
+	effectiveFrom := start.Format("2006-01-02")
 
 	var entries []HeatmapEntry
 	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
@@ -798,7 +817,7 @@ func buildDateEntries(
 			Level: assignLevel(v, levels),
 		})
 	}
-	return entries
+	return entries, effectiveFrom
 }
 
 // --- Projects ---

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -352,12 +352,24 @@ func (db *DB) HasFTS() bool {
 }
 
 // setDataVersion stamps the current dataVersion into
-// user_version. Called by Open() only when data is current
-// (not stale), so the marker survives until ResyncAll
-// completes.
+// user_version, but never downgrades a higher version left
+// by a newer build. Called by Open() only when data is
+// current (not stale), so the marker survives until
+// ResyncAll completes.
 func (db *DB) setDataVersion() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
+
+	var current int
+	if err := db.getWriter().QueryRow(
+		"PRAGMA user_version",
+	).Scan(&current); err != nil {
+		return fmt.Errorf("reading data version: %w", err)
+	}
+	if current >= dataVersion {
+		return nil
+	}
+
 	_, err := db.getWriter().Exec(
 		fmt.Sprintf("PRAGMA user_version = %d", dataVersion),
 	)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -17,6 +17,13 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+// dataVersion tracks parser/schema changes that require a full
+// re-sync. Increment this when parsing logic changes in ways
+// that affect stored data (e.g. new fields extracted, content
+// formatting changes). Old databases with a lower user_version
+// are dropped and rebuilt on next startup.
+const dataVersion = 1
+
 //go:embed schema.sql
 var schemaSQL string
 
@@ -221,7 +228,18 @@ func needsRebuild(path string) (bool, error) {
 			"probing schema: %w", err,
 		)
 	}
-	return subagentColCount == 0, nil
+	if subagentColCount == 0 {
+		return true, nil
+	}
+
+	var version int
+	err = conn.QueryRow("PRAGMA user_version").Scan(&version)
+	if err != nil {
+		return false, fmt.Errorf(
+			"probing data version: %w", err,
+		)
+	}
+	return version < dataVersion, nil
 }
 
 func dropDatabase(path string) error {
@@ -327,6 +345,12 @@ func (db *DB) init() error {
 	w := db.getWriter()
 	if _, err := w.Exec(schemaSQL); err != nil {
 		return err
+	}
+
+	if _, err := w.Exec(
+		fmt.Sprintf("PRAGMA user_version = %d", dataVersion),
+	); err != nil {
+		return fmt.Errorf("setting data version: %w", err)
 	}
 
 	// Check if FTS table exists before trying to create it

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -17,11 +17,12 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-// dataVersion tracks parser/schema changes that require a full
+// dataVersion tracks parser changes that require a full
 // re-sync. Increment this when parsing logic changes in ways
 // that affect stored data (e.g. new fields extracted, content
 // formatting changes). Old databases with a lower user_version
-// are dropped and rebuilt on next startup.
+// trigger a non-destructive re-sync (mtime reset + skip cache
+// clear) so existing session data is preserved.
 const dataVersion = 1
 
 //go:embed schema.sql
@@ -56,11 +57,12 @@ END;
 // concurrent HTTP handler goroutines can safely read while
 // Reopen/CloseConnections swap the underlying *sql.DB.
 type DB struct {
-	path    string
-	writer  atomic.Pointer[sql.DB]
-	reader  atomic.Pointer[sql.DB]
-	mu      sync.Mutex // serializes writes
-	retired []*sql.DB  // old pools kept open for in-flight reads
+	path      string
+	writer    atomic.Pointer[sql.DB]
+	reader    atomic.Pointer[sql.DB]
+	mu        sync.Mutex // serializes writes
+	retired   []*sql.DB  // old pools kept open for in-flight reads
+	dataStale bool       // set by Open when user_version < dataVersion
 
 	cursorMu     sync.RWMutex
 	cursorSecret []byte
@@ -104,20 +106,22 @@ func makeDSN(path string, readOnly bool) string {
 // It configures WAL mode, mmap, and returns a DB with separate
 // writer and reader connections.
 //
-// If an existing database has an outdated schema, it is deleted
-// and recreated from scratch. Session data is re-synced from
-// the source files on the next sync cycle.
+// If an existing database has an outdated schema (missing
+// columns), it is deleted and recreated from scratch.
+// If the schema is current but the data version is stale,
+// the database is preserved and file mtimes are reset to
+// trigger a re-sync on the next cycle.
 func Open(path string) (*DB, error) {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating db directory: %w", err)
 	}
 
-	rebuild, err := needsRebuild(path)
+	schemaStale, dataStale, err := probeDatabase(path)
 	if err != nil {
 		return nil, fmt.Errorf("checking schema: %w", err)
 	}
-	if rebuild {
+	if schemaStale {
 		if err := dropDatabase(path); err != nil {
 			return nil, fmt.Errorf(
 				"rebuilding database: %w", err,
@@ -125,121 +129,118 @@ func Open(path string) (*DB, error) {
 		}
 	}
 
-	return openAndInit(path)
+	d, err := openAndInit(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if dataStale && !schemaStale {
+		d.dataStale = true
+		log.Printf(
+			"data version outdated; full resync required",
+		)
+	}
+
+	return d, nil
 }
 
-// needsRebuild checks whether an existing database has an
-// outdated schema that requires a full rebuild. Returns an
-// error on probe failures so callers can surface them.
-func needsRebuild(path string) (bool, error) {
+// probeDatabase checks an existing database for schema and
+// data staleness. Returns (schemaStale, dataStale, err).
+// schemaStale means required columns are missing and the DB
+// must be dropped and recreated. dataStale means the schema
+// is fine but user_version < dataVersion, requiring a
+// non-destructive re-sync.
+func probeDatabase(
+	path string,
+) (schemaStale, dataStale bool, err error) {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
-			return false, nil // no existing DB
+			return false, false, nil
 		}
-		return false, fmt.Errorf(
+		return false, false, fmt.Errorf(
 			"checking database file: %w", err,
 		)
 	}
 	conn, err := sql.Open("sqlite3", makeDSN(path, true))
 	if err != nil {
-		return false, fmt.Errorf(
+		return false, false, fmt.Errorf(
 			"probing schema: %w", err,
 		)
 	}
 	defer conn.Close()
 
-	var count int
-	err = conn.QueryRow(
-		`SELECT count(*) FROM pragma_table_info('sessions')
-		 WHERE name = 'parent_session_id'`,
-	).Scan(&count)
+	schema, err := needsSchemaRebuild(conn)
 	if err != nil {
-		return false, fmt.Errorf(
-			"probing schema: %w", err,
-		)
+		return false, false, err
 	}
-	if count == 0 {
-		return true, nil
+	if schema {
+		return true, false, nil
 	}
 
-	var insightCount int
-	err = conn.QueryRow(
-		`SELECT count(*) FROM pragma_table_info('insights')
-		 WHERE name = 'date_from'`,
-	).Scan(&insightCount)
+	data, err := needsDataResync(conn)
 	if err != nil {
-		return false, fmt.Errorf(
-			"probing schema: %w", err,
-		)
+		return false, false, err
 	}
-	if insightCount == 0 {
-		return true, nil
-	}
+	return false, data, nil
+}
 
-	var toolCount int
-	err = conn.QueryRow(
-		`SELECT count(*) FROM pragma_table_info('tool_calls')
-		 WHERE name = 'tool_use_id'`,
-	).Scan(&toolCount)
-	if err != nil {
-		return false, fmt.Errorf(
-			"probing schema: %w", err,
-		)
+// needsSchemaRebuild probes for required columns that may be
+// missing in databases created by older releases. If any are
+// absent, the DB must be dropped and recreated.
+func needsSchemaRebuild(conn *sql.DB) (bool, error) {
+	probes := []struct {
+		table  string
+		column string
+	}{
+		{"sessions", "parent_session_id"},
+		{"insights", "date_from"},
+		{"tool_calls", "tool_use_id"},
+		{"sessions", "user_message_count"},
+		{"sessions", "relationship_type"},
+		{"tool_calls", "subagent_session_id"},
 	}
-	if toolCount == 0 {
-		return true, nil
+	for _, p := range probes {
+		var count int
+		err := conn.QueryRow(fmt.Sprintf(
+			"SELECT count(*) FROM pragma_table_info('%s')"+
+				" WHERE name = '%s'",
+			p.table, p.column,
+		)).Scan(&count)
+		if err != nil {
+			return false, fmt.Errorf(
+				"probing schema (%s.%s): %w",
+				p.table, p.column, err,
+			)
+		}
+		if count == 0 {
+			return true, nil
+		}
 	}
+	return false, nil
+}
 
-	var umcCount int
-	err = conn.QueryRow(
-		`SELECT count(*) FROM pragma_table_info('sessions')
-		 WHERE name = 'user_message_count'`,
-	).Scan(&umcCount)
-	if err != nil {
-		return false, fmt.Errorf(
-			"probing schema: %w", err,
-		)
-	}
-	if umcCount == 0 {
-		return true, nil
-	}
-
-	var relTypeCount int
-	err = conn.QueryRow(
-		`SELECT count(*) FROM pragma_table_info('sessions')
-		 WHERE name = 'relationship_type'`,
-	).Scan(&relTypeCount)
-	if err != nil {
-		return false, fmt.Errorf(
-			"probing schema: %w", err,
-		)
-	}
-	if relTypeCount == 0 {
-		return true, nil
-	}
-
-	var subagentColCount int
-	err = conn.QueryRow(
-		`SELECT count(*) FROM pragma_table_info('tool_calls')
-		 WHERE name = 'subagent_session_id'`,
-	).Scan(&subagentColCount)
-	if err != nil {
-		return false, fmt.Errorf(
-			"probing schema: %w", err,
-		)
-	}
-	if subagentColCount == 0 {
-		return true, nil
-	}
-
+// needsDataResync checks whether user_version is behind the
+// current dataVersion, indicating parser changes that require
+// re-processing existing files.
+func needsDataResync(conn *sql.DB) (bool, error) {
 	var version int
-	err = conn.QueryRow("PRAGMA user_version").Scan(&version)
+	err := conn.QueryRow(
+		"PRAGMA user_version",
+	).Scan(&version)
 	if err != nil {
 		return false, fmt.Errorf(
 			"probing data version: %w", err,
 		)
 	}
 	return version < dataVersion, nil
+}
+
+// NeedsResync reports whether the database was opened with a
+// stale data version, indicating the caller should trigger a
+// full resync (build fresh DB, copy orphaned data, swap)
+// rather than an incremental sync.
+func (db *DB) NeedsResync() bool {
+	return db.dataStale
 }
 
 func dropDatabase(path string) error {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -139,6 +139,17 @@ func Open(path string) (*DB, error) {
 		log.Printf(
 			"data version outdated; full resync required",
 		)
+	} else {
+		// Only stamp user_version when data is current.
+		// When data is stale, preserve the old version so
+		// the "needs resync" state survives process restarts
+		// until ResyncAll completes successfully.
+		if err := d.setDataVersion(); err != nil {
+			d.Close()
+			return nil, fmt.Errorf(
+				"setting data version: %w", err,
+			)
+		}
 	}
 
 	return d, nil
@@ -340,18 +351,28 @@ func (db *DB) HasFTS() bool {
 	return err == nil
 }
 
+// setDataVersion stamps the current dataVersion into
+// user_version. Called by Open() only when data is current
+// (not stale), so the marker survives until ResyncAll
+// completes.
+func (db *DB) setDataVersion() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, err := db.getWriter().Exec(
+		fmt.Sprintf("PRAGMA user_version = %d", dataVersion),
+	)
+	if err != nil {
+		return fmt.Errorf("setting data version: %w", err)
+	}
+	return nil
+}
+
 func (db *DB) init() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	w := db.getWriter()
 	if _, err := w.Exec(schemaSQL); err != nil {
 		return err
-	}
-
-	if _, err := w.Exec(
-		fmt.Sprintf("PRAGMA user_version = %d", dataVersion),
-	); err != nil {
-		return fmt.Errorf("setting data version: %w", err)
 	}
 
 	// Check if FTS table exists before trying to create it

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -283,6 +283,58 @@ func TestOpenCreatesFile(t *testing.T) {
 	}
 }
 
+func TestOpenRebuildOnDataVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	// Create a valid DB (sets user_version = dataVersion).
+	d, err := Open(path)
+	requireNoError(t, err, "initial open")
+
+	// Insert a session so we can verify it gets dropped.
+	d.UpsertSession(Session{
+		ID:      "s1",
+		Project: "proj",
+		Machine: "local",
+		Agent:   "codex",
+	})
+	d.Close()
+
+	// Set user_version to 0 to simulate old data.
+	conn, err := sql.Open("sqlite3", path)
+	requireNoError(t, err, "raw open")
+	_, err = conn.Exec("PRAGMA user_version = 0")
+	requireNoError(t, err, "reset version")
+	conn.Close()
+
+	// Re-open: should detect stale version and rebuild.
+	d2, err := Open(path)
+	requireNoError(t, err, "reopen")
+	defer d2.Close()
+
+	// Session should be gone (DB was rebuilt).
+	page, err := d2.ListSessions(
+		context.Background(),
+		SessionFilter{Limit: 100},
+	)
+	requireNoError(t, err, "list sessions")
+	if len(page.Sessions) != 0 {
+		t.Fatalf("expected 0 sessions after rebuild, got %d",
+			len(page.Sessions))
+	}
+
+	// user_version should now be current.
+	var ver int
+	err = d2.getReader().QueryRow(
+		"PRAGMA user_version",
+	).Scan(&ver)
+	requireNoError(t, err, "read version")
+	if ver != dataVersion {
+		t.Fatalf("expected user_version=%d, got %d",
+			dataVersion, ver)
+	}
+}
+
 func TestOpenProbeErrorPropagates(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping: chmod semantics differ on Windows")

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -283,7 +283,7 @@ func TestOpenCreatesFile(t *testing.T) {
 	}
 }
 
-func TestOpenRebuildOnDataVersion(t *testing.T) {
+func TestOpenDataVersionBump_PreservesData(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.db")
 
@@ -291,40 +291,65 @@ func TestOpenRebuildOnDataVersion(t *testing.T) {
 	d, err := Open(path)
 	requireNoError(t, err, "initial open")
 
-	// Insert a session so we can verify it gets dropped.
 	err = d.UpsertSession(Session{
-		ID:      "s1",
-		Project: "proj",
-		Machine: "local",
-		Agent:   "codex",
+		ID:           "s1",
+		Project:      "proj",
+		Machine:      "local",
+		Agent:        "codex",
+		MessageCount: 1,
+		FileMtime:    Ptr(int64(12345)),
 	})
 	requireNoError(t, err, "insert session")
+	insertMessages(t, d,
+		userMsg("s1", 0, "hello"),
+		asstMsg("s1", 1, "world"),
+	)
+
+	// Add a skipped file entry.
+	err = d.ReplaceSkippedFiles(map[string]int64{
+		"/tmp/skip.jsonl": 99999,
+	})
+	requireNoError(t, err, "add skipped file")
 	d.Close()
 
-	// Set user_version to 0 to simulate old data.
+	// Set user_version to 0 to simulate stale data version.
 	conn, err := sql.Open("sqlite3", path)
 	requireNoError(t, err, "raw open")
 	_, err = conn.Exec("PRAGMA user_version = 0")
 	requireNoError(t, err, "reset version")
 	conn.Close()
 
-	// Re-open: should detect stale version and rebuild.
+	// Re-open: should detect stale version but preserve data.
 	d2, err := Open(path)
 	requireNoError(t, err, "reopen")
 	defer d2.Close()
 
-	// Session should be gone (DB was rebuilt).
+	// NeedsResync should be true.
+	if !d2.NeedsResync() {
+		t.Fatal("expected NeedsResync()=true after version bump")
+	}
+
+	// Session and messages must still exist.
 	page, err := d2.ListSessions(
 		context.Background(),
 		SessionFilter{Limit: 100},
 	)
 	requireNoError(t, err, "list sessions")
-	if len(page.Sessions) != 0 {
-		t.Fatalf("expected 0 sessions after rebuild, got %d",
+	if len(page.Sessions) != 1 {
+		t.Fatalf("expected 1 session preserved, got %d",
 			len(page.Sessions))
 	}
 
-	// user_version should now be current.
+	msgs, err := d2.GetMessages(
+		context.Background(), "s1", 0, 100, true,
+	)
+	requireNoError(t, err, "get messages")
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages preserved, got %d",
+			len(msgs))
+	}
+
+	// user_version should be updated to current.
 	var ver int
 	err = d2.getReader().QueryRow(
 		"PRAGMA user_version",
@@ -356,6 +381,10 @@ func TestOpenPreservesDataAtCurrentVersion(t *testing.T) {
 	d2, err := Open(path)
 	requireNoError(t, err, "reopen")
 	defer d2.Close()
+
+	if d2.NeedsResync() {
+		t.Fatal("expected NeedsResync()=false at current version")
+	}
 
 	page, err := d2.ListSessions(
 		context.Background(),
@@ -2677,6 +2706,196 @@ func TestCopyInsightsFrom(t *testing.T) {
 			"content = %q, want %q",
 			insights[0].Content, "test insight content",
 		)
+	}
+}
+
+func TestCopyOrphanedDataFrom(t *testing.T) {
+	dir := t.TempDir()
+
+	// Source (old) DB with two sessions: s1 and s2.
+	srcPath := filepath.Join(dir, "old.db")
+	srcDB, err := Open(srcPath)
+	requireNoError(t, err, "Open src")
+	insertSession(t, srcDB, "s1", "proj", func(s *Session) {
+		s.Agent = "claude"
+	})
+	insertSession(t, srcDB, "s2", "proj", func(s *Session) {
+		s.Agent = "codex"
+	})
+	insertMessages(t, srcDB,
+		userMsg("s1", 0, "hello from s1"),
+		asstMsg("s1", 1, "reply from s1"),
+		userMsg("s2", 0, "hello from s2"),
+	)
+	// Insert tool_calls for s1 via raw SQL since
+	// insertToolCallsTx is unexported.
+	_, err = srcDB.getWriter().Exec(`
+		INSERT INTO tool_calls
+			(message_id, session_id, tool_name, category)
+		SELECT id, session_id, 'Read', 'file'
+		FROM messages
+		WHERE session_id = 's1' AND ordinal = 1`,
+	)
+	requireNoError(t, err, "insert tool_call")
+	srcDB.Close()
+
+	// Destination (new) DB: only has s1 (re-synced from
+	// file). s2 is orphaned (file gone).
+	dstPath := filepath.Join(dir, "new.db")
+	dstDB, err := Open(dstPath)
+	requireNoError(t, err, "Open dst")
+	defer dstDB.Close()
+	insertSession(t, dstDB, "s1", "proj", func(s *Session) {
+		s.Agent = "claude"
+	})
+	insertMessages(t, dstDB,
+		userMsg("s1", 0, "hello from s1"),
+		asstMsg("s1", 1, "reply from s1"),
+	)
+
+	// Copy orphaned data from source.
+	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
+	requireNoError(t, err, "CopyOrphanedDataFrom")
+	if count != 1 {
+		t.Fatalf("expected 1 orphaned session, got %d", count)
+	}
+
+	// s2 should now exist in dst.
+	s, err := dstDB.GetSession(
+		context.Background(), "s2",
+	)
+	requireNoError(t, err, "GetSession s2")
+	if s == nil {
+		t.Fatal("orphaned session s2 not found in dst")
+	}
+	if s.Agent != "codex" {
+		t.Errorf("s2 agent = %q, want %q", s.Agent, "codex")
+	}
+
+	// s2 messages should be copied.
+	ctx := context.Background()
+	msgs, err := dstDB.GetMessages(ctx, "s2", 0, 100, true)
+	requireNoError(t, err, "GetMessages s2")
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message for s2, got %d",
+			len(msgs))
+	}
+	if msgs[0].Content != "hello from s2" {
+		t.Errorf("s2 message content = %q, want %q",
+			msgs[0].Content, "hello from s2")
+	}
+
+	// s1 should still exist and not be duplicated.
+	s1msgs, err := dstDB.GetMessages(ctx, "s1", 0, 100, true)
+	requireNoError(t, err, "GetMessages s1")
+	if len(s1msgs) != 2 {
+		t.Fatalf("expected 2 messages for s1, got %d",
+			len(s1msgs))
+	}
+
+	// Tool calls for s1 should NOT be copied (s1 exists in
+	// dst, so it's not orphaned). Only verify s2's tool_calls
+	// aren't present (s2 had no tool_calls on ordinal 0).
+	var tcCount int
+	err = dstDB.getReader().QueryRow(
+		"SELECT count(*) FROM tool_calls " +
+			"WHERE session_id = 's2'",
+	).Scan(&tcCount)
+	requireNoError(t, err, "count s2 tool_calls")
+	if tcCount != 0 {
+		t.Errorf("expected 0 tool_calls for s2, got %d",
+			tcCount)
+	}
+}
+
+func TestCopyOrphanedDataFrom_NoOrphans(t *testing.T) {
+	dir := t.TempDir()
+
+	srcPath := filepath.Join(dir, "old.db")
+	srcDB, err := Open(srcPath)
+	requireNoError(t, err, "Open src")
+	insertSession(t, srcDB, "s1", "proj")
+	srcDB.Close()
+
+	dstPath := filepath.Join(dir, "new.db")
+	dstDB, err := Open(dstPath)
+	requireNoError(t, err, "Open dst")
+	defer dstDB.Close()
+	insertSession(t, dstDB, "s1", "proj")
+
+	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
+	requireNoError(t, err, "CopyOrphanedDataFrom")
+	if count != 0 {
+		t.Fatalf("expected 0 orphaned sessions, got %d",
+			count)
+	}
+}
+
+func TestCopyOrphanedDataFrom_WithToolCalls(t *testing.T) {
+	dir := t.TempDir()
+
+	// Source DB with session s1 that has tool_calls.
+	srcPath := filepath.Join(dir, "old.db")
+	srcDB, err := Open(srcPath)
+	requireNoError(t, err, "Open src")
+	insertSession(t, srcDB, "s1", "proj")
+	insertMessages(t, srcDB,
+		userMsg("s1", 0, "hello"),
+		asstMsg("s1", 1, "used a tool"),
+	)
+	_, err = srcDB.getWriter().Exec(`
+		INSERT INTO tool_calls
+			(message_id, session_id, tool_name, category,
+			 tool_use_id)
+		SELECT id, session_id, 'Bash', 'command',
+			'tu_123'
+		FROM messages
+		WHERE session_id = 's1' AND ordinal = 1`,
+	)
+	requireNoError(t, err, "insert tool_call")
+	srcDB.Close()
+
+	// Empty destination DB.
+	dstPath := filepath.Join(dir, "new.db")
+	dstDB, err := Open(dstPath)
+	requireNoError(t, err, "Open dst")
+	defer dstDB.Close()
+
+	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
+	requireNoError(t, err, "CopyOrphanedDataFrom")
+	if count != 1 {
+		t.Fatalf("expected 1 orphaned, got %d", count)
+	}
+
+	// Verify tool_call was copied with correct message_id
+	// mapping.
+	var toolName, toolUseID string
+	var msgID int
+	err = dstDB.getReader().QueryRow(`
+		SELECT tc.message_id, tc.tool_name, tc.tool_use_id
+		FROM tool_calls tc
+		WHERE tc.session_id = 's1'`,
+	).Scan(&msgID, &toolName, &toolUseID)
+	requireNoError(t, err, "query tool_call")
+	if toolName != "Bash" {
+		t.Errorf("tool_name = %q, want %q", toolName, "Bash")
+	}
+	if toolUseID != "tu_123" {
+		t.Errorf(
+			"tool_use_id = %q, want %q",
+			toolUseID, "tu_123",
+		)
+	}
+
+	// Verify the message_id FK is valid.
+	var ordinal int
+	err = dstDB.getReader().QueryRow(
+		"SELECT ordinal FROM messages WHERE id = ?", msgID,
+	).Scan(&ordinal)
+	requireNoError(t, err, "verify FK")
+	if ordinal != 1 {
+		t.Errorf("tool_call message ordinal = %d, want 1",
+			ordinal)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -432,6 +432,44 @@ func TestOpenPreservesDataAtCurrentVersion(t *testing.T) {
 	}
 }
 
+func TestOpenDoesNotDowngradeUserVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	d, err := Open(path)
+	requireNoError(t, err, "initial open")
+
+	// Simulate a newer build by setting user_version higher
+	// than our dataVersion.
+	futureVersion := dataVersion + 10
+	_, err = d.getWriter().Exec(
+		fmt.Sprintf("PRAGMA user_version = %d", futureVersion),
+	)
+	requireNoError(t, err, "set future version")
+	d.Close()
+
+	// Reopen with current (lower) dataVersion.
+	d2, err := Open(path)
+	requireNoError(t, err, "reopen")
+	defer d2.Close()
+
+	var version int
+	err = d2.getWriter().QueryRow(
+		"PRAGMA user_version",
+	).Scan(&version)
+	requireNoError(t, err, "read version")
+
+	if version != futureVersion {
+		t.Errorf(
+			"user_version = %d, want %d (should not downgrade)",
+			version, futureVersion,
+		)
+	}
+	if d2.NeedsResync() {
+		t.Error("NeedsResync should be false for higher version")
+	}
+}
+
 func TestOpenProbeErrorPropagates(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping: chmod semantics differ on Windows")

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -349,15 +349,50 @@ func TestOpenDataVersionBump_PreservesData(t *testing.T) {
 			len(msgs))
 	}
 
-	// user_version should be updated to current.
+	// user_version must stay stale — it is only bumped
+	// after a successful ResyncAll, not at Open() time.
 	var ver int
 	err = d2.getReader().QueryRow(
 		"PRAGMA user_version",
 	).Scan(&ver)
 	requireNoError(t, err, "read version")
-	if ver != dataVersion {
-		t.Fatalf("expected user_version=%d, got %d",
-			dataVersion, ver)
+	if ver != 0 {
+		t.Fatalf("expected user_version=0 (stale), got %d",
+			ver)
+	}
+}
+
+func TestOpenDataVersionBump_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	// Create a DB and downgrade its version.
+	d, err := Open(path)
+	requireNoError(t, err, "initial open")
+	insertSession(t, d, "s1", "proj")
+	d.Close()
+
+	conn, err := sql.Open("sqlite3", path)
+	requireNoError(t, err, "raw open")
+	_, err = conn.Exec("PRAGMA user_version = 0")
+	requireNoError(t, err, "reset version")
+	conn.Close()
+
+	// First reopen: detects stale, does NOT bump version.
+	d2, err := Open(path)
+	requireNoError(t, err, "reopen 1")
+	if !d2.NeedsResync() {
+		t.Fatal("first reopen: expected NeedsResync=true")
+	}
+	d2.Close() // simulate process exit without resync
+
+	// Second reopen: must still detect stale because the
+	// version was not bumped.
+	d3, err := Open(path)
+	requireNoError(t, err, "reopen 2")
+	defer d3.Close()
+	if !d3.NeedsResync() {
+		t.Fatal("second reopen: expected NeedsResync=true")
 	}
 }
 
@@ -2896,6 +2931,55 @@ func TestCopyOrphanedDataFrom_WithToolCalls(t *testing.T) {
 	if ordinal != 1 {
 		t.Errorf("tool_call message ordinal = %d, want 1",
 			ordinal)
+	}
+}
+
+func TestCopyOrphanedDataFrom_AtomicOnFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create source DB with a session and messages.
+	srcPath := filepath.Join(dir, "old.db")
+	srcDB, err := Open(srcPath)
+	requireNoError(t, err, "Open src")
+	insertSession(t, srcDB, "s1", "proj")
+	insertMessages(t, srcDB, userMsg("s1", 0, "hello"))
+	srcDB.Close()
+
+	// Corrupt source: drop the messages table so the
+	// message-copy step fails.
+	raw, err := sql.Open("sqlite3", srcPath)
+	requireNoError(t, err, "raw open")
+	_, err = raw.Exec("PRAGMA foreign_keys = OFF")
+	requireNoError(t, err, "disable fk")
+	_, err = raw.Exec("DROP TABLE messages")
+	requireNoError(t, err, "drop messages")
+	raw.Close()
+
+	// Empty destination.
+	dstPath := filepath.Join(dir, "new.db")
+	dstDB, err := Open(dstPath)
+	requireNoError(t, err, "Open dst")
+	defer dstDB.Close()
+
+	// CopyOrphanedDataFrom should fail on the message
+	// copy step.
+	_, err = dstDB.CopyOrphanedDataFrom(srcPath)
+	if err == nil {
+		t.Fatal("expected error from corrupted source")
+	}
+
+	// The session insert must have been rolled back — no
+	// partial data in the destination.
+	page, err := dstDB.ListSessions(
+		context.Background(),
+		SessionFilter{Limit: 100},
+	)
+	requireNoError(t, err, "list sessions")
+	if len(page.Sessions) != 0 {
+		t.Fatalf(
+			"expected 0 sessions after failed copy, got %d",
+			len(page.Sessions),
+		)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -814,6 +814,53 @@ func TestListSessionsPaginationNoDuplicates(t *testing.T) {
 	}
 }
 
+func TestListSessionsPaginationEmptyTimestamps(t *testing.T) {
+	d := testDB(t)
+
+	// Mix of normal, NULL, and empty-string timestamps.
+	// Empty-string ended_at/started_at should sort by
+	// created_at, same as NULL.
+	insertSession(t, d, "s-normal", "proj", func(s *Session) {
+		s.EndedAt = Ptr("2024-06-01T12:00:00Z")
+		s.StartedAt = Ptr("2024-06-01T10:00:00Z")
+	})
+	insertSession(t, d, "s-empty-ended", "proj", func(s *Session) {
+		s.EndedAt = Ptr("")
+		s.StartedAt = Ptr("2024-05-01T10:00:00Z")
+	})
+	insertSession(t, d, "s-both-empty", "proj", func(s *Session) {
+		s.EndedAt = Ptr("")
+		s.StartedAt = Ptr("")
+	})
+	insertSession(t, d, "s-null-ts", "proj")
+
+	// Paginate 1 at a time to exercise cursor encoding.
+	seen := make(map[string]bool)
+	cursor := ""
+	for {
+		page, err := d.ListSessions(
+			context.Background(),
+			SessionFilter{Limit: 1, Cursor: cursor},
+		)
+		if err != nil {
+			t.Fatalf("ListSessions: %v", err)
+		}
+		for _, s := range page.Sessions {
+			if seen[s.ID] {
+				t.Errorf("duplicate session %s", s.ID)
+			}
+			seen[s.ID] = true
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	if len(seen) != 4 {
+		t.Errorf("saw %d sessions, want 4", len(seen))
+	}
+}
+
 func TestListSessionsProjectFilter(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1045,6 +1045,12 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 				" should fall back to created_at",
 		)
 	}
+	if *stats.EarliestSession == "" {
+		t.Fatal(
+			"earliest_session is empty string;" +
+				" NULLIF should have converted '' to NULL",
+		)
+	}
 
 	// Add a session with an explicit started_at that is
 	// older than the auto-generated created_at.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1013,6 +1013,44 @@ func TestStats(t *testing.T) {
 	}
 }
 
+func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
+	d := testDB(t)
+
+	// Session with no started_at — earliest should fall
+	// back to created_at instead of being nil.
+	insertSession(t, d, "s-no-start", "proj")
+	insertMessages(t, d, userMsg("s-no-start", 0, "hi"))
+
+	stats, err := d.GetStats(context.Background())
+	requireNoError(t, err, "GetStats")
+	if stats.EarliestSession == nil {
+		t.Fatal(
+			"earliest_session nil when started_at missing;" +
+				" should fall back to created_at",
+		)
+	}
+
+	// Add a session with an explicit started_at that is
+	// older than the auto-generated created_at.
+	old := "2020-01-01T00:00:00Z"
+	insertSession(t, d, "s-old", "proj", func(s *Session) {
+		s.StartedAt = &old
+	})
+	insertMessages(t, d, userMsg("s-old", 0, "hello"))
+
+	stats, err = d.GetStats(context.Background())
+	requireNoError(t, err, "GetStats with old session")
+	if stats.EarliestSession == nil {
+		t.Fatal("earliest_session nil")
+	}
+	if *stats.EarliestSession != old {
+		t.Errorf(
+			"earliest_session = %q, want %q",
+			*stats.EarliestSession, old,
+		)
+	}
+}
+
 func TestGetProjects(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -899,17 +899,32 @@ func TestCanceledContext(t *testing.T) {
 func TestStats(t *testing.T) {
 	d := testDB(t)
 
-	insertSession(t, d, "s1", "p1")
+	// Empty DB returns nil EarliestSession
+	stats, err := d.GetStats(context.Background())
+	requireNoError(t, err, "GetStats empty")
+	if stats.EarliestSession != nil {
+		t.Errorf(
+			"earliest_session = %v, want nil",
+			*stats.EarliestSession,
+		)
+	}
+
+	early := "2024-01-15T09:00:00Z"
+	late := "2024-06-01T14:00:00Z"
+	insertSession(t, d, "s1", "p1", func(s *Session) {
+		s.StartedAt = &late
+	})
 	insertSession(t, d, "s2", "p2", func(s *Session) {
 		s.Machine = "remote"
 		s.Agent = "codex"
+		s.StartedAt = &early
 	})
 	insertMessages(t, d,
 		userMsg("s1", 0, "hi"),
 		userMsg("s2", 0, "bye"),
 	)
 
-	stats, err := d.GetStats(context.Background())
+	stats, err = d.GetStats(context.Background())
 	requireNoError(t, err, "GetStats")
 	if stats.SessionCount != 2 {
 		t.Errorf("session_count = %d, want 2", stats.SessionCount)
@@ -922,6 +937,15 @@ func TestStats(t *testing.T) {
 	}
 	if stats.MachineCount != 2 {
 		t.Errorf("machine_count = %d, want 2", stats.MachineCount)
+	}
+	if stats.EarliestSession == nil {
+		t.Fatal("earliest_session is nil, want non-nil")
+	}
+	if *stats.EarliestSession != early {
+		t.Errorf(
+			"earliest_session = %q, want %q",
+			*stats.EarliestSession, early,
+		)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1016,16 +1016,32 @@ func TestStats(t *testing.T) {
 func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 	d := testDB(t)
 
-	// Session with no started_at — earliest should fall
+	// Session with NULL started_at — earliest should fall
 	// back to created_at instead of being nil.
-	insertSession(t, d, "s-no-start", "proj")
-	insertMessages(t, d, userMsg("s-no-start", 0, "hi"))
+	insertSession(t, d, "s-null-start", "proj")
+	insertMessages(t, d, userMsg("s-null-start", 0, "hi"))
 
 	stats, err := d.GetStats(context.Background())
-	requireNoError(t, err, "GetStats")
+	requireNoError(t, err, "GetStats null started_at")
 	if stats.EarliestSession == nil {
 		t.Fatal(
-			"earliest_session nil when started_at missing;" +
+			"earliest_session nil when started_at is NULL;" +
+				" should fall back to created_at",
+		)
+	}
+
+	// Session with empty-string started_at — NULLIF should
+	// treat it the same as NULL.
+	insertSession(t, d, "s-empty-start", "proj", func(s *Session) {
+		s.StartedAt = Ptr("")
+	})
+	insertMessages(t, d, userMsg("s-empty-start", 0, "hey"))
+
+	stats, err = d.GetStats(context.Background())
+	requireNoError(t, err, "GetStats empty started_at")
+	if stats.EarliestSession == nil {
+		t.Fatal(
+			"earliest_session nil when started_at is '';" +
 				" should fall back to created_at",
 		)
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -292,12 +292,13 @@ func TestOpenRebuildOnDataVersion(t *testing.T) {
 	requireNoError(t, err, "initial open")
 
 	// Insert a session so we can verify it gets dropped.
-	d.UpsertSession(Session{
+	err = d.UpsertSession(Session{
 		ID:      "s1",
 		Project: "proj",
 		Machine: "local",
 		Agent:   "codex",
 	})
+	requireNoError(t, err, "insert session")
 	d.Close()
 
 	// Set user_version to 0 to simulate old data.
@@ -332,6 +333,38 @@ func TestOpenRebuildOnDataVersion(t *testing.T) {
 	if ver != dataVersion {
 		t.Fatalf("expected user_version=%d, got %d",
 			dataVersion, ver)
+	}
+}
+
+func TestOpenPreservesDataAtCurrentVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	d, err := Open(path)
+	requireNoError(t, err, "initial open")
+	err = d.UpsertSession(Session{
+		ID:           "s1",
+		Project:      "proj",
+		Machine:      "local",
+		Agent:        "codex",
+		MessageCount: 1,
+	})
+	requireNoError(t, err, "insert session")
+	d.Close()
+
+	// Re-open without changing user_version: data survives.
+	d2, err := Open(path)
+	requireNoError(t, err, "reopen")
+	defer d2.Close()
+
+	page, err := d2.ListSessions(
+		context.Background(),
+		SessionFilter{Limit: 100},
+	)
+	requireNoError(t, err, "list sessions")
+	if len(page.Sessions) != 1 {
+		t.Fatalf("expected 1 session preserved, got %d",
+			len(page.Sessions))
 	}
 }
 

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -1,0 +1,155 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+)
+
+// CopyOrphanedDataFrom copies sessions (and their messages
+// and tool_calls) that exist in the source database but not
+// in this database. This preserves archived sessions whose
+// source files no longer exist on disk.
+//
+// The source database must not have active connections (call
+// CloseConnections on its DB handle first). Uses ATTACH
+// DATABASE on a pinned connection for atomicity.
+func (d *DB) CopyOrphanedDataFrom(
+	sourcePath string,
+) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	ctx := context.Background()
+	conn, err := d.getWriter().Conn(ctx)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"acquiring connection: %w", err,
+		)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(
+		ctx, "ATTACH DATABASE ? AS old_db", sourcePath,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"attaching source db: %w", err,
+		)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(
+			ctx, "DETACH DATABASE old_db",
+		)
+	}()
+
+	// Snapshot orphaned session IDs before any inserts
+	// change main.sessions.
+	if _, err := conn.ExecContext(ctx, `
+		CREATE TEMP TABLE _orphaned_ids AS
+		SELECT id FROM old_db.sessions
+		WHERE id NOT IN (SELECT id FROM main.sessions)`,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"identifying orphaned sessions: %w", err,
+		)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(
+			ctx,
+			"DROP TABLE IF EXISTS _orphaned_ids",
+		)
+	}()
+
+	var count int
+	if err := conn.QueryRowContext(ctx,
+		"SELECT count(*) FROM _orphaned_ids",
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf(
+			"counting orphaned sessions: %w", err,
+		)
+	}
+	if count == 0 {
+		return 0, nil
+	}
+
+	t := time.Now()
+
+	// Copy session rows.
+	if _, err := conn.ExecContext(ctx, `
+		INSERT OR IGNORE INTO sessions
+			(id, project, machine, agent, first_message,
+			 started_at, ended_at, message_count,
+			 user_message_count, file_path, file_size,
+			 file_mtime, file_hash, parent_session_id,
+			 relationship_type, created_at)
+		SELECT
+			id, project, machine, agent, first_message,
+			started_at, ended_at, message_count,
+			user_message_count, file_path, file_size,
+			file_mtime, file_hash, parent_session_id,
+			relationship_type, created_at
+		FROM old_db.sessions
+		WHERE id IN (SELECT id FROM _orphaned_ids)`,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"copying orphaned sessions: %w", err,
+		)
+	}
+
+	// Copy messages. Omit id to let auto-increment assign
+	// new IDs (old IDs may collide with freshly synced
+	// messages).
+	if _, err := conn.ExecContext(ctx, `
+		INSERT INTO messages
+			(session_id, ordinal, role, content,
+			 timestamp, has_thinking, has_tool_use,
+			 content_length)
+		SELECT
+			session_id, ordinal, role, content,
+			timestamp, has_thinking, has_tool_use,
+			content_length
+		FROM old_db.messages
+		WHERE session_id IN (
+			SELECT id FROM _orphaned_ids
+		)`,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"copying orphaned messages: %w", err,
+		)
+	}
+
+	// Copy tool_calls. Map old message_id to new
+	// message_id via the (session_id, ordinal) natural key.
+	if _, err := conn.ExecContext(ctx, `
+		INSERT INTO tool_calls
+			(message_id, session_id, tool_name, category,
+			 tool_use_id, input_json, skill_name,
+			 result_content_length, subagent_session_id)
+		SELECT
+			new_m.id, otc.session_id, otc.tool_name,
+			otc.category, otc.tool_use_id, otc.input_json,
+			otc.skill_name, otc.result_content_length,
+			otc.subagent_session_id
+		FROM old_db.tool_calls otc
+		JOIN old_db.messages old_m
+			ON old_m.id = otc.message_id
+		JOIN main.messages new_m
+			ON new_m.session_id = old_m.session_id
+			AND new_m.ordinal = old_m.ordinal
+		WHERE otc.session_id IN (
+			SELECT id FROM _orphaned_ids
+		)`,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"copying orphaned tool_calls: %w", err,
+		)
+	}
+
+	log.Printf(
+		"resync: copied %d orphaned sessions in %s",
+		count, time.Since(t).Round(time.Millisecond),
+	)
+
+	return count, nil
+}

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -75,8 +75,17 @@ func (d *DB) CopyOrphanedDataFrom(
 
 	t := time.Now()
 
+	// Use a transaction so all three inserts are atomic.
+	// Partial orphan copies would leave dangling sessions
+	// without messages or tool_calls.
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin orphan tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	// Copy session rows.
-	if _, err := conn.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 		INSERT OR IGNORE INTO sessions
 			(id, project, machine, agent, first_message,
 			 started_at, ended_at, message_count,
@@ -100,7 +109,7 @@ func (d *DB) CopyOrphanedDataFrom(
 	// Copy messages. Omit id to let auto-increment assign
 	// new IDs (old IDs may collide with freshly synced
 	// messages).
-	if _, err := conn.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
 			 timestamp, has_thinking, has_tool_use,
@@ -121,7 +130,7 @@ func (d *DB) CopyOrphanedDataFrom(
 
 	// Copy tool_calls. Map old message_id to new
 	// message_id via the (session_id, ordinal) natural key.
-	if _, err := conn.ExecContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO tool_calls
 			(message_id, session_id, tool_name, category,
 			 tool_use_id, input_json, skill_name,
@@ -143,6 +152,12 @@ func (d *DB) CopyOrphanedDataFrom(
 	); err != nil {
 		return 0, fmt.Errorf(
 			"copying orphaned tool_calls: %w", err,
+		)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf(
+			"committing orphaned data: %w", err,
 		)
 	}
 

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -12,6 +12,12 @@ import (
 // in this database. This preserves archived sessions whose
 // source files no longer exist on disk.
 //
+// Orphaned sessions are identified by ID-diff: any session
+// present in the source but absent from the target after a
+// full file sync. This correctly captures sessions whose
+// source files were deleted, moved, or otherwise lost —
+// exactly the set that would be dropped by a naive DB swap.
+//
 // The source database must not have active connections (call
 // CloseConnections on its DB handle first). Uses ATTACH
 // DATABASE on a pinned connection for atomicity.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -212,22 +212,22 @@ func buildSessionFilter(f SessionFilter) (string, []any) {
 	}
 	if f.Date != "" {
 		preds = append(preds,
-			"date(COALESCE(started_at, created_at)) = ?")
+			"date(COALESCE(NULLIF(started_at, ''), created_at)) = ?")
 		args = append(args, f.Date)
 	}
 	if f.DateFrom != "" {
 		preds = append(preds,
-			"date(COALESCE(started_at, created_at)) >= ?")
+			"date(COALESCE(NULLIF(started_at, ''), created_at)) >= ?")
 		args = append(args, f.DateFrom)
 	}
 	if f.DateTo != "" {
 		preds = append(preds,
-			"date(COALESCE(started_at, created_at)) <= ?")
+			"date(COALESCE(NULLIF(started_at, ''), created_at)) <= ?")
 		args = append(args, f.DateTo)
 	}
 	if f.ActiveSince != "" {
 		preds = append(preds,
-			"COALESCE(ended_at, started_at, created_at) >= ?")
+			"COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at) >= ?")
 		args = append(args, f.ActiveSince)
 	}
 	if f.MinMessages > 0 {
@@ -284,7 +284,7 @@ func (db *DB) ListSessions(
 	cursorWhere := where
 	if f.Cursor != "" {
 		cursorWhere += ` AND (
-				COALESCE(ended_at, started_at, created_at), id
+				COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at), id
 			) < (?, ?)`
 		cursorArgs = append(cursorArgs, cur.EndedAt, cur.ID)
 	}
@@ -644,7 +644,7 @@ func (db *DB) FindPruneCandidates(
 		args = append(args, *f.MaxMessages)
 	}
 	if f.Before != "" {
-		where += " AND COALESCE(ended_at, started_at, created_at) < ?"
+		where += " AND COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at) < ?"
 		args = append(args, f.Before)
 	}
 	if f.FirstMessage != "" {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -292,7 +292,9 @@ func (db *DB) ListSessions(
 	query := "SELECT " + sessionBaseCols +
 		" FROM sessions WHERE " + cursorWhere + `
 		ORDER BY COALESCE(
-			ended_at, started_at, created_at
+			NULLIF(ended_at, ''),
+			NULLIF(started_at, ''),
+			created_at
 		) DESC, id DESC
 		LIMIT ?`
 	cursorArgs = append(cursorArgs, f.Limit+1)
@@ -313,13 +315,12 @@ func (db *DB) ListSessions(
 	if len(sessions) > f.Limit {
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
-		ea := ""
-		if last.EndedAt != nil {
-			ea = *last.EndedAt
-		} else if last.StartedAt != nil {
+		ea := last.CreatedAt
+		if last.StartedAt != nil && *last.StartedAt != "" {
 			ea = *last.StartedAt
-		} else {
-			ea = last.CreatedAt
+		}
+		if last.EndedAt != nil && *last.EndedAt != "" {
+			ea = *last.EndedAt
 		}
 		page.NextCursor = db.EncodeCursor(ea, last.ID, total)
 	}
@@ -660,7 +661,9 @@ func (db *DB) FindPruneCandidates(
 	query := "SELECT " + sessionPruneCols +
 		" FROM sessions WHERE " + where + `
 		ORDER BY COALESCE(
-			ended_at, started_at, created_at
+			NULLIF(ended_at, ''),
+			NULLIF(started_at, ''),
+			created_at
 		) DESC`
 
 	rows, err := db.getReader().Query(query, args...)

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -53,7 +53,9 @@ func (db *DB) GetStats(ctx context.Context) (Stats, error) {
 			 WHERE ` + rootSessionFilter + `),
 			(SELECT COUNT(DISTINCT machine) FROM sessions
 			 WHERE ` + rootSessionFilter + `),
-			(SELECT MIN(started_at) FROM sessions
+			(SELECT MIN(COALESCE(
+				NULLIF(started_at, ''), created_at
+			 )) FROM sessions
 			 WHERE ` + rootSessionFilter + `)`
 
 	var s Stats

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -7,10 +7,11 @@ import (
 
 // Stats holds database-wide statistics.
 type Stats struct {
-	SessionCount int `json:"session_count"`
-	MessageCount int `json:"message_count"`
-	ProjectCount int `json:"project_count"`
-	MachineCount int `json:"machine_count"`
+	SessionCount    int     `json:"session_count"`
+	MessageCount    int     `json:"message_count"`
+	ProjectCount    int     `json:"project_count"`
+	MachineCount    int     `json:"machine_count"`
+	EarliestSession *string `json:"earliest_session"`
 }
 
 // rootSessionFilter is the WHERE clause shared by session list
@@ -51,6 +52,8 @@ func (db *DB) GetStats(ctx context.Context) (Stats, error) {
 			(SELECT COUNT(DISTINCT project) FROM sessions
 			 WHERE ` + rootSessionFilter + `),
 			(SELECT COUNT(DISTINCT machine) FROM sessions
+			 WHERE ` + rootSessionFilter + `),
+			(SELECT MIN(started_at) FROM sessions
 			 WHERE ` + rootSessionFilter + `)`
 
 	var s Stats
@@ -59,6 +62,7 @@ func (db *DB) GetStats(ctx context.Context) (Stats, error) {
 		&s.MessageCount,
 		&s.ProjectCount,
 		&s.MachineCount,
+		&s.EarliestSession,
 	)
 	if err != nil {
 		return Stats{}, fmt.Errorf("fetching stats: %w", err)

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -138,6 +138,7 @@ func (b *codexSessionBuilder) handleFunctionCall(
 	}
 
 	content := formatCodexFunctionCall(name, payload)
+	inputJSON := extractCodexInputJSON(payload)
 
 	b.messages = append(b.messages, ParsedMessage{
 		Ordinal:       b.ordinal,
@@ -147,8 +148,9 @@ func (b *codexSessionBuilder) handleFunctionCall(
 		HasToolUse:    true,
 		ContentLength: len(content),
 		ToolCalls: []ParsedToolCall{{
-			ToolName: name,
-			Category: NormalizeToolCategory(name),
+			ToolName:  name,
+			Category:  NormalizeToolCategory(name),
+			InputJSON: inputJSON,
 		}},
 	})
 	b.ordinal++
@@ -233,6 +235,38 @@ func parseCodexFunctionArgs(
 		}
 	}
 	return gjson.Result{}, ""
+}
+
+// extractCodexInputJSON returns the raw JSON string of the
+// function call arguments from the payload. It checks
+// "arguments" then "input", normalizing string-encoded JSON
+// to an object string.
+func extractCodexInputJSON(payload gjson.Result) string {
+	for _, key := range []string{"arguments", "input"} {
+		arg := payload.Get(key)
+		if !arg.Exists() {
+			continue
+		}
+
+		switch arg.Type {
+		case gjson.String:
+			s := strings.TrimSpace(arg.Str)
+			if s == "" {
+				continue
+			}
+			if gjson.Valid(s) {
+				return s
+			}
+			return arg.Str
+		default:
+			raw := strings.TrimSpace(arg.Raw)
+			if raw == "" || raw == "{}" || raw == "[]" {
+				continue
+			}
+			return arg.Raw
+		}
+	}
+	return ""
 }
 
 func formatCodexBashCall(

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -282,6 +282,10 @@ func formatCodexBashCall(
 
 	header := formatToolHeader("Bash", summary)
 	if cmd != "" {
+		firstLine, _, hasMore := strings.Cut(cmd, "\n")
+		if hasMore {
+			return header + "\n$ " + firstLine
+		}
 		return header + "\n$ " + cmd
 	}
 	if preview := codexArgPreview(args, rawArgs); preview != "" {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -255,6 +255,9 @@ func extractCodexInputJSON(payload gjson.Result) string {
 				continue
 			}
 			if gjson.Valid(s) {
+				if s == "{}" || s == "[]" {
+					continue
+				}
 				return s
 			}
 			return arg.Str

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -77,6 +77,7 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		content := loadFixture(t, "codex/fc_args_1.jsonl")
 		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
 		assert.Equal(t, "[Bash]\n$ rg --files", msgs[1].Content)
+		assert.Equal(t, `{"cmd":"rg --files","workdir":"/tmp"}`, msgs[1].ToolCalls[0].InputJSON)
 	})
 
 	t.Run("apply_patch arguments summarize edited files", func(t *testing.T) {
@@ -84,6 +85,8 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
 		want := "[Edit: internal/parser/codex.go (+1 more)]\ninternal/parser/codex.go\ninternal/parser/parser_test.go"
 		assert.Equal(t, want, msgs[1].Content)
+		assert.NotEmpty(t, msgs[1].ToolCalls[0].InputJSON)
+		assert.Contains(t, msgs[1].ToolCalls[0].InputJSON, "Begin Patch")
 	})
 
 	t.Run("write_stdin formats with session and chars", func(t *testing.T) {
@@ -172,6 +175,75 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		assert.Equal(t, "codex:fc-empty-arr", sess.ID)
 		assert.Equal(t, 2, len(msgs))
 		assert.Equal(t, "[Bash]\n$ echo hello", msgs[1].Content)
+	})
+}
+
+func TestParseCodexSession_InputJSON(t *testing.T) {
+	t.Run("object arguments populates InputJSON", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("ij-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "do it", tsEarlyS1),
+			testjsonl.CodexFunctionCallArgsJSON("shell_command", map[string]any{
+				"cmd": "ls -la",
+			}, tsEarlyS5),
+		)
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
+			ToolName:  "shell_command",
+			Category:  "Bash",
+			InputJSON: `{"cmd":"ls -la"}`,
+		}})
+	})
+
+	t.Run("string-encoded JSON arguments", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("ij-2", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "do it", tsEarlyS1),
+			testjsonl.CodexFunctionCallArgsJSON("exec_command",
+				`{"cmd":"rg foo","workdir":"/tmp"}`, tsEarlyS5),
+		)
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
+			ToolName:  "exec_command",
+			Category:  "Bash",
+			InputJSON: `{"cmd":"rg foo","workdir":"/tmp"}`,
+		}})
+	})
+
+	t.Run("non-JSON string arguments preserved", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("ij-3", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "do it", tsEarlyS1),
+			testjsonl.CodexFunctionCallArgsJSON("shell_command",
+				"echo hello world", tsEarlyS5),
+		)
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+		assert.Equal(t, "echo hello world", msgs[1].ToolCalls[0].InputJSON)
+	})
+
+	t.Run("input field used when arguments empty", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("ij-4", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "run", tsEarlyS1),
+			testjsonl.CodexFunctionCallFieldsJSON("exec_command",
+				map[string]any{}, `{"cmd":"echo hi"}`, tsEarlyS5),
+		)
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
+			ToolName:  "exec_command",
+			Category:  "Bash",
+			InputJSON: `{"cmd":"echo hi"}`,
+		}})
+	})
+
+	t.Run("no arguments yields empty InputJSON", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("ij-5", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "do it", tsEarlyS1),
+			testjsonl.CodexFunctionCallJSON("exec_command", "", tsEarlyS5),
+		)
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+		assert.Empty(t, msgs[1].ToolCalls[0].InputJSON)
 	})
 }
 

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -251,6 +251,21 @@ func TestParseCodexSession_InputJSON(t *testing.T) {
 		}})
 	})
 
+	t.Run("string-encoded empty JSON falls through to input", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("ij-str-empty", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "run", tsEarlyS1),
+			testjsonl.CodexFunctionCallFieldsJSON("exec_command",
+				`{}`, `{"cmd":"echo fallback"}`, tsEarlyS5),
+		)
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
+			ToolName:  "exec_command",
+			Category:  "Bash",
+			InputJSON: `{"cmd":"echo fallback"}`,
+		}})
+	})
+
 	t.Run("no arguments yields empty InputJSON", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
 			testjsonl.CodexSessionMetaJSON("ij-5", "/tmp", "user", tsEarly),

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -80,6 +80,21 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		assert.Equal(t, `{"cmd":"rg --files","workdir":"/tmp"}`, msgs[1].ToolCalls[0].InputJSON)
 	})
 
+	t.Run("multi-line command truncated to first line", func(t *testing.T) {
+		multiLineCmd := "cat > file.toml <<'EOF'\n[package]\nname = \"foo\"\nEOF"
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("fc-ml", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "create file", tsEarlyS1),
+			testjsonl.CodexFunctionCallArgsJSON("exec_command", map[string]any{
+				"cmd": multiLineCmd,
+			}, tsEarlyS5),
+		)
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+		assert.Equal(t, "[Bash]\n$ cat > file.toml <<'EOF'", msgs[1].Content)
+		assert.Contains(t, msgs[1].ToolCalls[0].InputJSON, "cmd")
+		assert.Contains(t, msgs[1].ToolCalls[0].InputJSON, "[package]")
+	})
+
 	t.Run("apply_patch arguments summarize edited files", func(t *testing.T) {
 		content := loadFixture(t, "codex/fc_args_2.jsonl")
 		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)

--- a/internal/server/analytics_test.go
+++ b/internal/server/analytics_test.go
@@ -475,6 +475,47 @@ func TestAnalyticsHeatmap(t *testing.T) {
 			)
 		}
 	})
+
+	t.Run("Levels_FromClampedWindow", func(t *testing.T) {
+		// Seed a historical outlier far outside the clamped
+		// window. Levels should be based only on displayed data.
+		oldDate := "2020-01-15T10:00:00Z"
+		te.seedSession(t, "old-outlier", "gamma", 500,
+			func(sess *db.Session) {
+				sess.Agent = "claude"
+				sess.StartedAt = &oldDate
+				sess.EndedAt = &oldDate
+			},
+		)
+		te.seedMessages(t, "old-outlier", 500)
+
+		// Request range covering both old and recent data
+		params := map[string]string{
+			"from": "2019-01-01",
+			"to":   "2024-06-03",
+		}
+		w := te.get(t, buildURL("heatmap", params))
+		assertStatus(t, w, http.StatusOK)
+
+		resp := decode[db.HeatmapResponse](t, w)
+
+		// The outlier at 2020-01-15 should be clamped out.
+		// Verify no entry has the outlier date.
+		for _, e := range resp.Entries {
+			if e.Date == "2020-01-15" {
+				t.Error("outlier date should be outside clamped window")
+			}
+		}
+
+		// Levels should reflect the recent data (max ~30 msgs),
+		// not the 500-message outlier.
+		if resp.Levels.L4 >= 500 {
+			t.Errorf(
+				"L4 = %d, should be << 500 (outlier leaked into levels)",
+				resp.Levels.L4,
+			)
+		}
+	})
 }
 
 func TestAnalyticsProjects(t *testing.T) {

--- a/internal/server/analytics_test.go
+++ b/internal/server/analytics_test.go
@@ -434,6 +434,47 @@ func TestAnalyticsHeatmap(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("ClampedRange", func(t *testing.T) {
+		// Request a range >366 days; entries should be clamped
+		params := map[string]string{
+			"from": "2022-01-01",
+			"to":   "2024-06-03",
+		}
+		w := te.get(t, buildURL("heatmap", params))
+		assertStatus(t, w, http.StatusOK)
+
+		resp := decode[db.HeatmapResponse](t, w)
+		if len(resp.Entries) > db.MaxHeatmapDays {
+			t.Errorf(
+				"len(Entries) = %d, want <= %d",
+				len(resp.Entries), db.MaxHeatmapDays,
+			)
+		}
+		if resp.EntriesFrom == "" {
+			t.Fatal("EntriesFrom is empty")
+		}
+		if resp.EntriesFrom <= "2022-01-01" {
+			t.Errorf(
+				"EntriesFrom = %q, want later than 2022-01-01",
+				resp.EntriesFrom,
+			)
+		}
+	})
+
+	t.Run("ShortRange_NoClamping", func(t *testing.T) {
+		// A 3-day range should not be clamped
+		w := te.get(t, buildURLWithRange("heatmap", nil))
+		assertStatus(t, w, http.StatusOK)
+
+		resp := decode[db.HeatmapResponse](t, w)
+		if resp.EntriesFrom != "2024-06-01" {
+			t.Errorf(
+				"EntriesFrom = %q, want %q",
+				resp.EntriesFrom, "2024-06-01",
+			)
+		}
+	})
 }
 
 func TestAnalyticsProjects(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -569,6 +569,21 @@ func (e *Engine) ResyncAll(
 		time.Since(tInsights).Round(time.Millisecond),
 	)
 
+	// Copy orphaned sessions (source files gone) from the
+	// old DB so archived data is preserved.
+	orphaned, err := newDB.CopyOrphanedDataFrom(origPath)
+	if err != nil {
+		log.Printf("resync: copy orphaned sessions: %v", err)
+		stats.Warnings = append(stats.Warnings,
+			"orphaned session copy failed: "+err.Error(),
+		)
+		// Non-fatal: proceed with swap. The freshly synced
+		// data is still valid; only archived sessions whose
+		// files are gone are lost.
+	} else {
+		stats.OrphanedCopied = orphaned
+	}
+
 	// 5. Close newDB and swap files, then reopen origDB.
 	newDB.Close()
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -486,6 +486,7 @@ func (e *Engine) ResyncAll(
 		log.Printf("resync: open temp db: %v", err)
 		restoreSkipCache()
 		stats := SyncStats{
+			Aborted: true,
 			Warnings: []string{
 				"resync failed: " + err.Error(),
 			},
@@ -523,6 +524,7 @@ func (e *Engine) ResyncAll(
 		newDB.Close()
 		removeTempDB(tempPath)
 		restoreSkipCache()
+		stats.Aborted = true
 		stats.Warnings = append(stats.Warnings, fmt.Sprintf(
 			"resync aborted: %d synced, %d failed",
 			stats.Synced, stats.Failed,
@@ -540,6 +542,7 @@ func (e *Engine) ResyncAll(
 	// after the copy.
 	if err := origDB.CloseConnections(); err != nil {
 		log.Printf("resync: close orig db: %v", err)
+		stats.Aborted = true
 		stats.Warnings = append(stats.Warnings,
 			"close before swap failed: "+err.Error(),
 		)
@@ -562,6 +565,7 @@ func (e *Engine) ResyncAll(
 	tInsights := time.Now()
 	if err := newDB.CopyInsightsFrom(origPath); err != nil {
 		log.Printf("resync: copy insights: %v", err)
+		stats.Aborted = true
 		stats.Warnings = append(stats.Warnings,
 			"insights copy failed, aborting swap: "+
 				err.Error(),
@@ -588,6 +592,7 @@ func (e *Engine) ResyncAll(
 	orphaned, err := newDB.CopyOrphanedDataFrom(origPath)
 	if err != nil {
 		log.Printf("resync: copy orphaned sessions: %v", err)
+		stats.Aborted = true
 		stats.Warnings = append(stats.Warnings,
 			"orphaned session copy failed, aborting swap: "+
 				err.Error(),
@@ -612,6 +617,7 @@ func (e *Engine) ResyncAll(
 
 	if err := os.Rename(tempPath, origPath); err != nil {
 		log.Printf("resync: rename temp db: %v", err)
+		stats.Aborted = true
 		stats.Warnings = append(stats.Warnings,
 			"resync swap failed: "+err.Error(),
 		)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -466,15 +466,25 @@ func (e *Engine) ResyncAll(
 	// Clean up stale temp DB from a prior crash.
 	removeTempDB(tempPath)
 
-	// 1. Clear in-memory skip cache.
+	// 1. Snapshot and clear in-memory skip cache. The
+	// snapshot is restored on early failure so behavior
+	// matches the persisted DB until the next restart.
 	e.skipMu.Lock()
+	savedSkipCache := e.skipCache
 	e.skipCache = make(map[string]int64)
 	e.skipMu.Unlock()
+
+	restoreSkipCache := func() {
+		e.skipMu.Lock()
+		e.skipCache = savedSkipCache
+		e.skipMu.Unlock()
+	}
 
 	// 2. Open a fresh DB at the temp path.
 	newDB, err := db.Open(tempPath)
 	if err != nil {
 		log.Printf("resync: open temp db: %v", err)
+		restoreSkipCache()
 		stats := SyncStats{
 			Warnings: []string{
 				"resync failed: " + err.Error(),
@@ -512,6 +522,7 @@ func (e *Engine) ResyncAll(
 		)
 		newDB.Close()
 		removeTempDB(tempPath)
+		restoreSkipCache()
 		stats.Warnings = append(stats.Warnings, fmt.Sprintf(
 			"resync aborted: %d synced, %d failed",
 			stats.Synced, stats.Failed,
@@ -534,6 +545,7 @@ func (e *Engine) ResyncAll(
 		)
 		newDB.Close()
 		removeTempDB(tempPath)
+		restoreSkipCache()
 		// Connections may be partially closed; reopen to
 		// restore service before returning.
 		if rerr := origDB.Reopen(); rerr != nil {
@@ -556,6 +568,7 @@ func (e *Engine) ResyncAll(
 		)
 		newDB.Close()
 		removeTempDB(tempPath)
+		restoreSkipCache()
 		if rerr := origDB.Reopen(); rerr != nil {
 			log.Printf("resync: recovery reopen: %v", rerr)
 		}
@@ -570,19 +583,27 @@ func (e *Engine) ResyncAll(
 	)
 
 	// Copy orphaned sessions (source files gone) from the
-	// old DB so archived data is preserved.
+	// old DB so archived data is preserved. Failure aborts
+	// the swap to avoid losing archived sessions.
 	orphaned, err := newDB.CopyOrphanedDataFrom(origPath)
 	if err != nil {
 		log.Printf("resync: copy orphaned sessions: %v", err)
 		stats.Warnings = append(stats.Warnings,
-			"orphaned session copy failed: "+err.Error(),
+			"orphaned session copy failed, aborting swap: "+
+				err.Error(),
 		)
-		// Non-fatal: proceed with swap. The freshly synced
-		// data is still valid; only archived sessions whose
-		// files are gone are lost.
-	} else {
-		stats.OrphanedCopied = orphaned
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		if rerr := origDB.Reopen(); rerr != nil {
+			log.Printf("resync: recovery reopen: %v", rerr)
+		}
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats
 	}
+	stats.OrphanedCopied = orphaned
 
 	// 5. Close newDB and swap files, then reopen origDB.
 	newDB.Close()
@@ -595,6 +616,7 @@ func (e *Engine) ResyncAll(
 			"resync swap failed: "+err.Error(),
 		)
 		removeTempDB(tempPath)
+		restoreSkipCache()
 		// Restore service even on rename failure.
 		if rerr := origDB.Reopen(); rerr != nil {
 			log.Printf("resync: recovery reopen: %v", rerr)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2019,6 +2019,10 @@ func TestResyncAllAbortsOnFailures(t *testing.T) {
 		t.Fatal("expected TotalSessions > 0")
 	}
 
+	if !stats.Aborted {
+		t.Error("expected Aborted = true")
+	}
+
 	hasAbortWarning := false
 	for _, w := range stats.Warnings {
 		if strings.Contains(w, "resync aborted") {
@@ -2177,6 +2181,9 @@ func TestResyncAllPostReopenAvailability(t *testing.T) {
 	stats := env.engine.ResyncAll(nil)
 	if stats.Synced != 1 {
 		t.Fatalf("resync: synced = %d, want 1", stats.Synced)
+	}
+	if stats.Aborted {
+		t.Error("unexpected Aborted = true on successful resync")
 	}
 	for _, w := range stats.Warnings {
 		t.Errorf("unexpected warning: %s", w)

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -38,11 +38,12 @@ type SyncResult struct {
 // produced at least one session — used by ResyncAll to compare
 // against Failed on the same unit.
 type SyncStats struct {
-	TotalSessions int      `json:"total_sessions"`
-	Synced        int      `json:"synced"`
-	Skipped       int      `json:"skipped"`
-	Failed        int      `json:"failed"`
-	Warnings      []string `json:"warnings,omitempty"`
+	TotalSessions  int      `json:"total_sessions"`
+	Synced         int      `json:"synced"`
+	Skipped        int      `json:"skipped"`
+	Failed         int      `json:"failed"`
+	OrphanedCopied int      `json:"orphaned_copied,omitempty"`
+	Warnings       []string `json:"warnings,omitempty"`
 
 	filesOK         int // unexported: file-level success counter
 	filesDiscovered int // file-based total, excludes OpenCode

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -44,6 +44,7 @@ type SyncStats struct {
 	Failed         int      `json:"failed"`
 	OrphanedCopied int      `json:"orphaned_copied,omitempty"`
 	Warnings       []string `json:"warnings,omitempty"`
+	Aborted        bool     `json:"aborted,omitempty"`
 
 	filesOK         int // unexported: file-level success counter
 	filesDiscovered int // file-based total, excludes OpenCode


### PR DESCRIPTION
## Summary

- **Codex tool calls**: Populate `InputJSON` for Codex function calls, truncate multi-line bash commands to first line in display, and enrich frontend segments using `category` (not `tool_name`) with `cmd` field support for Codex
- **Non-destructive data version resync**: When `dataVersion` advances, preserve existing session data instead of dropping the database. Startup triggers `ResyncAll` (build fresh DB, sync files, copy orphaned sessions + insights from old DB, atomic swap). Stale `user_version` marker survives process restarts until resync completes successfully
- **Orphaned session archival**: New `CopyOrphanedDataFrom` copies sessions, messages, and tool_calls (with message ID remapping) from the old DB for sessions whose source files no longer exist on disk. Runs inside a transaction for atomicity
- **Dashboard date defaults**: Default analytics range to 1 year instead of all-time. Clamp heatmap to 366 days max, compute intensity levels from clamped window only (historical outliers no longer skew colors). Add `earliest_session` to stats and `entries_from` to heatmap response
- **Suppress default-path warnings**: Skip directory-not-found warnings for agents the user hasn't explicitly configured (via env var or config file). Add `IsUserConfigured` to config
- **Archive safety docs**: Codify the persistent archive principle in CLAUDE.md and AGENTS.md

## Files changed

| Area | Files | What |
|------|-------|------|
| Codex parser | `internal/parser/codex.go`, `codex_parser_test.go` | Extract `InputJSON`, truncate multi-line commands |
| DB open/resync | `internal/db/db.go` | Split `needsRebuild` into schema vs data checks, defer `user_version` bump, expose `NeedsResync()` |
| Orphan copy | `internal/db/orphaned.go` (new) | `CopyOrphanedDataFrom` with transactional session+message+tool_call copy |
| Sync engine | `internal/sync/engine.go`, `progress.go` | Call orphan copy in `ResyncAll`, add `OrphanedCopied` stat |
| Startup | `cmd/agentsview/main.go` | Route to `ResyncAll` when `NeedsResync`, suppress default-path warnings |
| Analytics | `internal/db/analytics.go`, `stats.go` | Heatmap clamping, `earliest_session` stat |
| Config | `internal/config/config.go`, `config_test.go` | `IsUserConfigured`, `dirFile` source tracking |
| Frontend | `DateRangePicker.svelte`, `Heatmap.svelte`, `analytics.svelte.ts`, `content-parser.ts` | 1y default, clamp note, Codex bash enrichment via `category`+`cmd` |
| Docs | `CLAUDE.md`, `AGENTS.md` | Archive safety principle |

## Test plan

- [x] `go test ./internal/db/` — version bump preserves data, survives restart, orphan copy atomicity, tool_call remapping
- [x] `go test ./internal/sync/` — ResyncAll integration tests pass
- [x] `go test ./internal/parser/` — Codex InputJSON extraction, multi-line truncation
- [x] `go test ./internal/server/` — heatmap clamping, outlier isolation
- [x] `go test ./internal/config/` — IsUserConfigured
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)