### PR TITLE
feat: add desktop release packaging with auto-update

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,299 @@
+name: Desktop Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-macos:
+    name: Desktop Build (macOS)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
+        with:
+          node-version: "24"
+
+      - name: Install desktop dependencies
+        run: npm ci
+        working-directory: desktop
+
+      - name: Prepare sidecar
+        env:
+          AGENTSVIEW_VERSION: ${{ github.ref_name }}
+        run: npm run prepare-sidecar
+        working-directory: desktop
+
+      - name: Patch updater config for current repository
+        env:
+          AGENTSVIEW_UPDATER_PUBKEY: ${{ secrets.AGENTSVIEW_UPDATER_PUBKEY }}
+        run: |
+          sed -i.bak \
+            -e "s|wesm/agentsview|${GITHUB_REPOSITORY}|g" \
+            -e "s|NOT_SET|${AGENTSVIEW_UPDATER_PUBKEY}|g" \
+            desktop/src-tauri/tauri.conf.json
+          rm -f desktop/src-tauri/tauri.conf.json.bak
+
+      - name: Import signing certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASS="$(openssl rand -base64 32)"
+
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          echo "$APPLE_CERTIFICATE" | base64 -d > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm -f "$CERT_PATH"
+
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PASS" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
+
+      - name: Write API key
+        env:
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          KEY_DIR="$RUNNER_TEMP/apple-keys"
+          mkdir -p "$KEY_DIR"
+          echo "$APPLE_API_KEY_CONTENT" | base64 -d \
+            > "$KEY_DIR/AuthKey_${APPLE_API_KEY}.p8"
+          echo "APPLE_API_KEY_PATH=$KEY_DIR/AuthKey_${APPLE_API_KEY}.p8" \
+            >> "$GITHUB_ENV"
+
+      - name: Build DMG and updater bundle
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          AGENTSVIEW_UPDATER_PUBKEY: ${{ secrets.AGENTSVIEW_UPDATER_PUBKEY }}
+        run: npx tauri build
+        working-directory: desktop
+
+      - name: Collect build artifacts
+        run: |
+          mkdir -p staging
+          cp desktop/src-tauri/target/release/bundle/dmg/*.dmg staging/
+          cp desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz staging/
+          cp desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig staging/
+          ls -la staging/
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: agentsview-desktop-macos
+          path: staging/*
+          if-no-files-found: error
+
+      - name: Cleanup signing secrets
+        if: always()
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          rm -rf "$RUNNER_TEMP/apple-keys" 2>/dev/null || true
+
+  build-windows:
+    name: Desktop Build (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
+        with:
+          node-version: "24"
+
+      - name: Setup MinGW
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda  # v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: mingw-w64-x86_64-gcc
+          path-type: inherit
+
+      - name: Install desktop dependencies
+        run: npm ci
+        working-directory: desktop
+
+      - name: Prepare sidecar
+        shell: bash
+        env:
+          AGENTSVIEW_VERSION: ${{ github.ref_name }}
+        run: npm run prepare-sidecar
+        working-directory: desktop
+
+      - name: Patch updater config for current repository
+        shell: bash
+        env:
+          AGENTSVIEW_UPDATER_PUBKEY: ${{ secrets.AGENTSVIEW_UPDATER_PUBKEY }}
+        run: |
+          sed -i.bak \
+            -e "s|wesm/agentsview|${GITHUB_REPOSITORY}|g" \
+            -e "s|NOT_SET|${AGENTSVIEW_UPDATER_PUBKEY}|g" \
+            desktop/src-tauri/tauri.conf.json
+          rm -f desktop/src-tauri/tauri.conf.json.bak
+
+      - name: Build NSIS installer and updater bundle
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          AGENTSVIEW_UPDATER_PUBKEY: ${{ secrets.AGENTSVIEW_UPDATER_PUBKEY }}
+        run: npx tauri build --bundles nsis
+        working-directory: desktop
+
+      - name: Collect build artifacts
+        shell: bash
+        run: |
+          mkdir -p staging
+          cp desktop/src-tauri/target/release/bundle/nsis/*.exe staging/
+          cp desktop/src-tauri/target/release/bundle/nsis/*.nsis.zip staging/
+          cp desktop/src-tauri/target/release/bundle/nsis/*.nsis.zip.sig staging/
+          ls -la staging/
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: agentsview-desktop-windows
+          path: staging/*
+          if-no-files-found: error
+
+  release:
+    name: Upload Desktop Installers
+    needs: [build-macos, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          path: artifacts
+          pattern: agentsview-desktop-*
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum *.dmg *.exe *.tar.gz *.nsis.zip > SHA256SUMS-desktop 2>/dev/null || true
+          cat SHA256SUMS-desktop
+
+      - name: Generate updater manifest
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          TAG="updater"
+
+          MACOS_SIG=""
+          MACOS_URL=""
+          WINDOWS_SIG=""
+          WINDOWS_URL=""
+
+          for f in artifacts/*.app.tar.gz.sig; do
+            if [ -f "$f" ]; then
+              MACOS_SIG="$(cat "$f")"
+              MACOS_TARBALL="$(basename "${f%.sig}")"
+              MACOS_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${MACOS_TARBALL}"
+            fi
+          done
+
+          for f in artifacts/*.nsis.zip.sig; do
+            if [ -f "$f" ]; then
+              WINDOWS_SIG="$(cat "$f")"
+              NSIS_ZIP="$(basename "${f%.sig}")"
+              WINDOWS_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${NSIS_ZIP}"
+            fi
+          done
+
+          if [ -z "$MACOS_SIG" ] || [ -z "$MACOS_URL" ]; then
+            echo "error: missing macOS updater signature or URL" >&2
+            exit 1
+          fi
+          if [ -z "$WINDOWS_SIG" ] || [ -z "$WINDOWS_URL" ]; then
+            echo "error: missing Windows updater signature or URL" >&2
+            exit 1
+          fi
+
+          cat > artifacts/latest.json << MANIFEST
+          {
+            "version": "${VERSION}",
+            "pub_date": "${DATE}",
+            "platforms": {
+              "darwin-aarch64": {
+                "url": "${MACOS_URL}",
+                "signature": "${MACOS_SIG}"
+              },
+              "windows-x86_64": {
+                "url": "${WINDOWS_URL}",
+                "signature": "${WINDOWS_SIG}"
+              }
+            }
+          }
+          MANIFEST
+
+          echo "Generated latest.json:"
+          cat artifacts/latest.json
+
+      - name: Upload installers to versioned release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        with:
+          files: |
+            artifacts/*.dmg
+            artifacts/*.exe
+            artifacts/SHA256SUMS-desktop
+
+      - name: Upload updater artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Create or update the permanent 'updater' release
+          if ! gh release view updater --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create updater \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Auto-Updater Artifacts" \
+              --notes "Internal release used by the desktop auto-updater. Do not delete." \
+              --prerelease
+          fi
+          # Overwrite existing assets
+          gh release upload updater \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber \
+            artifacts/*.app.tar.gz \
+            artifacts/*.app.tar.gz.sig \
+            artifacts/*.nsis.zip \
+            artifacts/*.nsis.zip.sig \
+            artifacts/latest.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ make vet        # go vet
 - Tests should be fast and isolated
 - No emojis in code or output
 - **The database is a persistent archive** — never drop, truncate, or recreate the database to handle data version changes. Use non-destructive migrations (ALTER TABLE, UPDATE) and full resync (build fresh DB, copy orphaned data, swap) instead. Session data must survive even when the original source files are gone.
+- **Markdown formatting**: Use `mdformat --wrap 80` to format Markdown files. Requires the `mdformat-tables` plugin (`uv tool install mdformat --with mdformat-tables`).
 
 ## Git Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGS := -X main.version=$(VERSION) \
 LDFLAGS_RELEASE := $(LDFLAGS) -s -w
 DESKTOP_DIST_DIR := dist/desktop
 
-.PHONY: build build-release install frontend frontend-dev dev desktop-dev desktop-build desktop-macos-app desktop-windows-installer desktop-app test test-short e2e vet lint tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir help
+.PHONY: build build-release install frontend frontend-dev dev desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-app test test-short e2e vet lint tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -75,6 +75,22 @@ desktop-macos-app:
 	cp -R desktop/src-tauri/target/release/bundle/macos/AgentsView.app \
 		$(DESKTOP_DIST_DIR)/macos/AgentsView.app
 	@echo "macOS app bundle copied to $(DESKTOP_DIST_DIR)/macos/AgentsView.app"
+
+# Build macOS DMG installer
+desktop-macos-dmg:
+	cd desktop && npm install && npm run tauri:build:macos-dmg
+	mkdir -p $(DESKTOP_DIST_DIR)/macos
+	rm -f $(DESKTOP_DIST_DIR)/macos/*.dmg
+	@dmg_count=$$(find desktop/src-tauri/target/release/bundle/dmg \
+		-maxdepth 1 -type f -name '*.dmg' | wc -l | tr -d ' '); \
+	if [ "$$dmg_count" -eq 0 ]; then \
+		echo "error: no DMG installer found in bundle output" >&2; \
+		exit 1; \
+	fi; \
+	find desktop/src-tauri/target/release/bundle/dmg \
+		-maxdepth 1 -type f -name '*.dmg' \
+		-exec cp {} $(DESKTOP_DIST_DIR)/macos/ \;; \
+	echo "Copied $$dmg_count DMG installer(s) to $(DESKTOP_DIST_DIR)/macos/"
 
 # Build Windows NSIS installer bundle (.exe)
 # Run on Windows runner/host.
@@ -180,6 +196,7 @@ help:
 	@echo "  desktop-dev    - Run Tauri desktop wrapper in dev mode"
 	@echo "  desktop-build  - Build Tauri desktop app bundles"
 	@echo "  desktop-macos-app - Build macOS .app bundle only"
+	@echo "  desktop-macos-dmg - Build macOS DMG installer"
 	@echo "  desktop-windows-installer - Build Windows NSIS installer"
 	@echo "  desktop-app    - Alias for desktop-macos-app"
 	@echo ""

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -198,6 +198,7 @@ func runServe(args []string) {
 			Commit:    commit,
 			BuildDate: buildDate,
 		}),
+		server.WithDataDir(cfg.DataDir),
 	)
 
 	url := fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port)

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,6 +8,7 @@
     "tauri:dev": "npm run prepare-sidecar && tauri dev",
     "tauri:build": "npm run prepare-sidecar && tauri build",
     "tauri:build:macos-app": "npm run prepare-sidecar && tauri build --bundles app",
+    "tauri:build:macos-dmg": "npm run prepare-sidecar && tauri build --bundles dmg",
     "tauri:build:windows": "npm run prepare-sidecar && tauri build --bundles nsis",
     "tauri": "tauri"
   },

--- a/desktop/scripts/prepare-sidecar.sh
+++ b/desktop/scripts/prepare-sidecar.sh
@@ -47,6 +47,14 @@ map_go_target() {
 }
 
 resolve_version() {
+  # In CI, AGENTSVIEW_VERSION is set from the triggering tag ref
+  # to avoid git-describe picking the wrong tag when multiple
+  # tags point at the same commit.
+  if [ -n "${AGENTSVIEW_VERSION:-}" ]; then
+    echo "$AGENTSVIEW_VERSION"
+    return 0
+  fi
+
   local resolved
   resolved="$(git -C "$REPO_ROOT" describe --tags --always --dirty 2>/dev/null || true)"
   if [ -n "$resolved" ]; then
@@ -61,6 +69,50 @@ resolve_version() {
   fi
 
   echo "dev"
+}
+
+version_to_semver() {
+  local raw="$1"
+  # Strip leading 'v'
+  raw="${raw#v}"
+  # git-describe: 0.10.0-3-gabcdef -> 0.10.0-dev.3
+  if [[ "$raw" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g[0-9a-f]+(-dirty)?$ ]]; then
+    local base="${BASH_REMATCH[1]}"
+    local distance="${BASH_REMATCH[2]}"
+    echo "${base}-dev.${distance}"
+    return 0
+  fi
+  # Already semver, with optional prerelease suffix (possibly with -dirty).
+  # Identifiers are dot-separated, each non-empty, allowing [a-zA-Z0-9-].
+  if [[ "$raw" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*)?(-dirty)?$ ]]; then
+    echo "${raw%-dirty}"
+    return 0
+  fi
+  # Looks like a version (digits then dot) but isn't valid semver -- fail fast.
+  # Bare hex hashes starting with digits (e.g. 1abc234) fall through to
+  # the non-tag fallback below.
+  if [[ "$raw" =~ ^[0-9]+\. ]]; then
+    echo "error: malformed version tag: $raw" >&2
+    return 1
+  fi
+  # Non-tag fallback: bare hash, "dev", etc.
+  echo ""
+}
+
+patch_tauri_version() {
+  local version="$1"
+  local semver
+  semver="$(version_to_semver "$version")"
+  if [ -z "$semver" ]; then
+    echo "Skipping tauri.conf.json version patch (non-tag build: $version)"
+    return 0
+  fi
+  local conf="$TAURI_DIR/src-tauri/tauri.conf.json"
+  sed -i.bak \
+    "s/\"version\": \"[^\"]*\"/\"version\": \"$semver\"/" \
+    "$conf"
+  rm -f "$conf.bak"
+  echo "Patched tauri.conf.json version to $semver"
 }
 
 install_frontend_deps() {
@@ -103,6 +155,7 @@ main() {
 
   local version commit build_date ldflags tmp_dir build_bin
   version="$(resolve_version)"
+  patch_tauri_version "$version"
   commit="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
   build_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   ldflags="-X main.version=$version -X main.commit=$commit -X main.buildDate=$build_date -s -w"

--- a/desktop/scripts/test-prepare-sidecar.sh
+++ b/desktop/scripts/test-prepare-sidecar.sh
@@ -36,6 +36,10 @@ if [ -z "$resolved_version" ] || [ "$resolved_version" = "dev" ]; then
   exit 1
 fi
 
+# AGENTSVIEW_VERSION env var overrides git describe
+assert_eq "$(AGENTSVIEW_VERSION=v0.5.0-staging.1 resolve_version)" \
+  "v0.5.0-staging.1" "AGENTSVIEW_VERSION override"
+
 target="$(
   TAURI_ENV_TARGET_TRIPLE="tauri-priority-target" CARGO_BUILD_TARGET="cargo-target" \
     resolve_target_triple
@@ -47,5 +51,80 @@ target="$(
   CARGO_BUILD_TARGET="cargo-target" resolve_target_triple
 )"
 assert_eq "$target" "cargo-target" "Cargo target fallback"
+
+# version_to_semver tests
+assert_eq "$(version_to_semver "v0.10.0")" "0.10.0" \
+  "tagged release"
+assert_eq "$(version_to_semver "0.10.0")" "0.10.0" \
+  "tagged release without v prefix"
+assert_eq "$(version_to_semver "v0.10.0-3-gabcdef")" "0.10.0-dev.3" \
+  "git-describe with distance"
+assert_eq "$(version_to_semver "v1.2.3-15-g1234567")" "1.2.3-dev.15" \
+  "git-describe large distance"
+assert_eq "$(version_to_semver "v0.10.0-dirty")" "0.10.0" \
+  "dirty tag stripped"
+assert_eq "$(version_to_semver "v0.10.0-3-gabcdef-dirty")" "0.10.0-dev.3" \
+  "git-describe dirty with distance"
+# Non-tag inputs return empty (skip patching)
+assert_eq "$(version_to_semver "abc1234")" "" \
+  "bare hash returns empty"
+assert_eq "$(version_to_semver "1abc234")" "" \
+  "digit-leading hash returns empty"
+assert_eq "$(version_to_semver "9f0e1d2")" "" \
+  "digit-leading hex hash returns empty"
+assert_eq "$(version_to_semver "dev")" "" \
+  "dev string returns empty"
+
+# Prerelease tags accepted
+assert_eq "$(version_to_semver "v1.2.3-rc.1")" "1.2.3-rc.1" \
+  "prerelease tag"
+assert_eq "$(version_to_semver "v0.0.1-staging.1")" "0.0.1-staging.1" \
+  "staging prerelease tag"
+assert_eq "$(version_to_semver "v1.0.0-beta")" "1.0.0-beta" \
+  "simple prerelease tag"
+assert_eq "$(version_to_semver "v1.0.0-alpha.2-dirty")" "1.0.0-alpha.2" \
+  "prerelease tag dirty stripped"
+
+# Hyphens within identifiers
+assert_eq "$(version_to_semver "v1.0.0-rc-1")" "1.0.0-rc-1" \
+  "prerelease with hyphen in identifier"
+assert_eq "$(version_to_semver "v2.0.0-pre-alpha.3")" "2.0.0-pre-alpha.3" \
+  "prerelease with hyphenated identifier and dot"
+
+# Malformed prerelease rejected
+assert_fails "empty prerelease identifier rejected" \
+  version_to_semver "v1.0.0-.."
+assert_fails "trailing dot rejected" \
+  version_to_semver "v1.0.0-rc."
+
+# Malformed v-prefixed versions fail hard
+assert_fails "incomplete semver rejected" version_to_semver "v1.2"
+assert_fails "bare digits rejected" version_to_semver "1.2"
+
+# patch_tauri_version test (uses a temp copy)
+tmp_root="$(mktemp -d)"
+mkdir -p "$tmp_root/src-tauri"
+cp "$SCRIPT_DIR/../src-tauri/tauri.conf.json" "$tmp_root/src-tauri/tauri.conf.json"
+saved_tauri_dir="$TAURI_DIR"
+TAURI_DIR="$tmp_root"
+patch_tauri_version "v0.10.0" >/dev/null
+patched="$(grep '"version"' "$tmp_root/src-tauri/tauri.conf.json" | head -1)"
+assert_eq "$(echo "$patched" | tr -d ' ')" '"version":"0.10.0",' \
+  "patch_tauri_version applies correct version"
+
+# patch_tauri_version skips non-tag builds
+cp "$saved_tauri_dir/src-tauri/tauri.conf.json" "$tmp_root/src-tauri/tauri.conf.json"
+original="$(grep '"version"' "$tmp_root/src-tauri/tauri.conf.json" | head -1)"
+output="$(patch_tauri_version "abc1234")"
+after="$(grep '"version"' "$tmp_root/src-tauri/tauri.conf.json" | head -1)"
+assert_eq "$after" "$original" \
+  "patch_tauri_version skips patching for non-tag build"
+echo "$output" | grep -q "Skipping" || {
+  echo "assertion failed: expected skip message (got '$output')" >&2
+  exit 1
+}
+
+TAURI_DIR="$saved_tauri_dir"
+rm -rf "$tmp_root"
 
 echo "prepare-sidecar target mapping checks passed"

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -12,10 +12,15 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agentsview-desktop"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-opener",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -56,6 +61,146 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "atk"
@@ -135,6 +280,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -315,6 +473,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -499,6 +666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +733,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -658,6 +838,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +892,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +935,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -814,6 +1053,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1201,6 +1453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1534,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1680,7 +1954,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1767,6 +2044,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2051,6 +2334,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,10 +2415,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "os_pipe"
@@ -2133,6 +2444,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2161,6 +2486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,7 +2509,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2342,10 +2673,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -2371,6 +2719,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2602,6 +2964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,15 +3046,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2693,6 +3069,44 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2718,6 +3132,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +3217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2788,6 +3284,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3089,7 +3608,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3158,6 +3677,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3274,6 +3799,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3414,6 +3950,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,6 +4030,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -3655,6 +4286,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,7 +4456,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3866,6 +4519,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -3925,6 +4589,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4217,6 +4887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,6 +5123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4866,6 +5554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4886,6 +5584,67 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.14",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.14",
+ "zvariant",
 ]
 
 [[package]]
@@ -4930,6 +5689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4963,7 +5728,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.14",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.14",
+]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -15,4 +15,9 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
+tauri-plugin-opener = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-dialog = "2"
+serde_json = "1"
 tempfile = "3"
+tokio = { version = "1", features = ["time", "sync"] }

--- a/desktop/src-tauri/Entitlements.plist
+++ b/desktop/src-tauri/Entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  Hardened runtime entitlements for Tauri + WebKit.
+  allow-jit: required for WebKit JavaScriptCore JIT compilation.
+  allow-unsigned-executable-memory: required by WebKit JIT on macOS;
+    without it, the WebView fails to render in notarized builds.
+-->
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -13,16 +13,21 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use tauri::async_runtime::Receiver;
+use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::plugin::Builder as PluginBuilder;
-use tauri::{App, AppHandle, Manager, RunEvent, Url, WebviewWindow};
+use tauri::{App, AppHandle, Emitter, Manager, RunEvent, Url, WebviewWindow};
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
+use tauri_plugin_updater::UpdaterExt;
 
 const HOST: &str = "127.0.0.1";
 const PREFERRED_PORT: u16 = 8080;
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(125);
 const LOGIN_SHELL_ENV_TIMEOUT: Duration = Duration::from_secs(3);
+
 
 type DynError = Box<dyn Error>;
 type CommandRx = Receiver<CommandEvent>;
@@ -35,14 +40,39 @@ struct SidecarState {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let mut updater_builder = tauri_plugin_updater::Builder::new();
+    // Override the placeholder pubkey from tauri.conf.json with
+    // the real key when baked in at compile time via env var.
+    if let Some(pubkey) = option_env!("AGENTSVIEW_UPDATER_PUBKEY") {
+        if !pubkey.is_empty() {
+            updater_builder = updater_builder.pubkey(pubkey.to_string());
+        }
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_opener::init())
+        .plugin(updater_builder.build())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(init_navigation_guard_plugin())
         .manage(SidecarState::default())
-        .setup(launch_backend)
+        .setup(|app| {
+            launch_backend(app)?;
+            setup_menu(app)?;
+            schedule_auto_update_check(app.handle().clone());
+            Ok(())
+        })
         .build(tauri::generate_context!())
         .expect("failed to build tauri app")
         .run(|app_handle, event| {
+            if let RunEvent::MenuEvent(event) = &event {
+                if event.id().0 == "check_updates" {
+                    let handle = app_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        check_for_updates(&handle, false).await;
+                    });
+                }
+            }
             if matches!(event, RunEvent::ExitRequested { .. } | RunEvent::Exit) {
                 stop_backend(app_handle);
             }
@@ -94,8 +124,8 @@ fn init_navigation_guard_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlug
             if is_allowed_external_open_url(url) {
                 if let Err(err) = webview
                     .app_handle()
-                    .shell()
-                    .open(url.as_str().to_string(), None)
+                    .opener()
+                    .open_url(url.as_str(), Option::<&str>::None)
                 {
                     eprintln!("[agentsview] failed to open external URL in system browser: {err}");
                 }
@@ -369,7 +399,7 @@ where
 
     let drive = get("HOMEDRIVE", &mut lookup)?;
     let path = get("HOMEPATH", &mut lookup)?;
-    let mut combined = OsString::from(drive);
+    let mut combined = drive;
     combined.push(path);
     Some(PathBuf::from(combined))
 }
@@ -407,13 +437,14 @@ fn handle_sidecar_terminated(state: &SidecarState, startup_handled: &AtomicBool)
 
 fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow) {
     let startup_handled = Arc::new(AtomicBool::new(false));
+    let first_output = Arc::new(AtomicBool::new(false));
     let timeout_window = window.clone();
     let timeout_state = startup_handled.clone();
     thread::spawn(move || {
         thread::sleep(READY_TIMEOUT);
         if !timeout_state.load(Ordering::SeqCst) {
             let _ = timeout_window.eval(
-                "document.getElementById('status').textContent = 'AgentsView backend did not become ready in time.';",
+                "window.__setStatus('AgentsView backend did not become ready in time.');",
             );
         }
     });
@@ -426,12 +457,28 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow) {
                     let chunk = String::from_utf8_lossy(&chunk_bytes);
                     eprintln!("[agentsview] {}", chunk.trim_end());
                     if !startup_handled.load(Ordering::SeqCst) {
+                        if !first_output.swap(true, Ordering::SeqCst) {
+                            let _ = window.eval(
+                                "window.__setStage(1); \
+                                 window.__setStatus('Starting database and syncing sessions...');",
+                            );
+                        }
+                        if let Some(status) = extract_startup_status(chunk.as_ref()) {
+                            let escaped = status.replace('\\', "\\\\").replace('\'', "\\'");
+                            let _ = window.eval(
+                                format!("window.__setStatus('{escaped}');").as_str(),
+                            );
+                        }
                         if let Some(port) = parse_listening_port_from_stdout_buffer(
                             &mut stdout_buffer,
                             chunk.as_ref(),
                         ) {
-                            save_sidecar_port(&window.app_handle(), port);
+                            save_sidecar_port(window.app_handle(), port);
                             startup_handled.store(true, Ordering::SeqCst);
+                            let _ = window.eval(
+                                "window.__setStage(2); \
+                                 window.__setStatus('Connecting to interface...');",
+                            );
                             redirect_when_ready(window.clone(), port);
                         }
                     }
@@ -448,7 +495,8 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow) {
                     let state = window.app_handle().state::<SidecarState>();
                     if handle_sidecar_terminated(&state, startup_handled.as_ref()) {
                         let _ = window.eval(
-                            "document.getElementById('status').textContent = 'AgentsView backend exited before startup completed.';",
+                            "window.__setStatus(\
+                             'AgentsView backend exited before startup completed.');",
                         );
                     }
                     break;
@@ -467,8 +515,12 @@ fn main_window(app: &App) -> Result<WebviewWindow, DynError> {
         .ok_or_else(|| io::Error::other("missing main window").into())
 }
 
+fn desktop_redirect_url(port: u16) -> String {
+    format!("http://{HOST}:{port}?desktop=1")
+}
+
 fn redirect_when_ready(window: WebviewWindow, port: u16) {
-    let target_url = format!("http://{HOST}:{port}");
+    let target_url = desktop_redirect_url(port);
 
     thread::spawn(move || {
         if wait_for_server(port, READY_TIMEOUT) {
@@ -481,6 +533,23 @@ fn redirect_when_ready(window: WebviewWindow, port: u16) {
             "document.getElementById('status').textContent = 'AgentsView backend did not start within 30 seconds.';",
         );
     });
+}
+
+/// Extracts the latest human-readable status text from a stdout
+/// chunk during startup. The Go server uses `\r` for in-place
+/// progress updates and `\n` for line breaks.
+fn extract_startup_status(chunk: &str) -> Option<String> {
+    // Split on \r or \n, take the last non-empty segment.
+    let segment = chunk
+        .rsplit(['\r', '\n'])
+        .map(|s| s.trim())
+        .find(|s| !s.is_empty())?;
+    // Only forward lines that look like sync output, not
+    // arbitrary log noise.
+    if segment.contains("sessions") || segment.contains("ync") || segment.contains("atching") {
+        return Some(segment.to_string());
+    }
+    None
 }
 
 fn parse_listening_port(line: &str) -> Option<u16> {
@@ -512,6 +581,162 @@ fn parse_listening_port_from_stdout_buffer(buffer: &mut String, chunk: &str) -> 
     }
 
     None
+}
+
+fn setup_menu(app: &mut App) -> Result<(), DynError> {
+    let check_updates = MenuItemBuilder::with_id("check_updates", "Check for Updates...")
+        .build(app)?;
+
+    let app_submenu = SubmenuBuilder::new(app, "AgentsView")
+        .item(&check_updates)
+        .separator()
+        .quit()
+        .build()?;
+
+    let menu = MenuBuilder::new(app).item(&app_submenu).build()?;
+    app.set_menu(menu)?;
+    Ok(())
+}
+
+static UPDATE_CHECK_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+// Guard that clears UPDATE_CHECK_ACTIVE on drop, ensuring the
+// flag is reset regardless of which return path is taken.
+struct UpdateGuard;
+
+impl Drop for UpdateGuard {
+    fn drop(&mut self) {
+        UPDATE_CHECK_ACTIVE.store(false, Ordering::SeqCst);
+    }
+}
+
+fn schedule_auto_update_check(handle: AppHandle) {
+    let disabled = std::env::var("AGENTSVIEW_DESKTOP_AUTOUPDATE")
+        .map(|v| v == "0")
+        .unwrap_or(false);
+    if disabled {
+        return;
+    }
+
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        check_for_updates(&handle, true).await;
+    });
+}
+
+async fn check_for_updates(handle: &AppHandle, silent: bool) {
+    if UPDATE_CHECK_ACTIVE
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        if !silent {
+            handle
+                .dialog()
+                .message("An update check is already in progress.")
+                .title("Update Check")
+                .show(|_| {});
+        }
+        return;
+    }
+    let _guard = UpdateGuard;
+
+    let updater = match handle.updater() {
+        Ok(updater) => updater,
+        Err(err) => {
+            eprintln!("[agentsview] updater unavailable: {err}");
+            if !silent {
+                handle
+                    .dialog()
+                    .message("Could not check for updates. The updater is not configured.")
+                    .title("Update Check")
+                    .show(|_| {});
+            }
+            return;
+        }
+    };
+
+    let update = match updater.check().await {
+        Ok(update) => update,
+        Err(err) => {
+            eprintln!("[agentsview] update check failed: {err}");
+            if !silent {
+                handle
+                    .dialog()
+                    .message("Could not check for updates. Please try again later.")
+                    .title("Update Check")
+                    .show(|_| {});
+            }
+            return;
+        }
+    };
+
+    let Some(update) = update else {
+        if !silent {
+            handle
+                .dialog()
+                .message("You're running the latest version.")
+                .title("No Updates Available")
+                .show(|_| {});
+        }
+        return;
+    };
+
+    let version = update.version.clone();
+    let confirmed = dialog_confirm(
+        handle,
+        "Update Available",
+        &format!(
+            "Version {version} is available. \
+             Would you like to download and install it?"
+        ),
+    )
+    .await;
+
+    if !confirmed {
+        return;
+    }
+
+    if let Err(err) = update.download_and_install(|_, _| {}, || {}).await {
+        eprintln!("[agentsview] update install failed: {err}");
+        handle
+            .dialog()
+            .message(
+                "Failed to install the update. \
+                 Please try downloading manually from the releases page.",
+            )
+            .title("Update Failed")
+            .show(|_| {});
+        return;
+    }
+
+    let restart = dialog_confirm(
+        handle,
+        "Update Complete",
+        "Update installed. Restart now to apply?",
+    )
+    .await;
+
+    if restart {
+        let _ = handle.emit("restart", ());
+        handle.restart();
+    }
+}
+
+async fn dialog_confirm(
+    handle: &AppHandle,
+    title: &str,
+    message: &str,
+) -> bool {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    handle
+        .dialog()
+        .message(message)
+        .title(title)
+        .buttons(MessageDialogButtons::OkCancel)
+        .show(move |confirmed| {
+            let _ = tx.send(confirmed);
+        });
+    rx.await.unwrap_or(false)
 }
 
 fn stop_backend(app: &AppHandle) {
@@ -626,6 +851,41 @@ mod tests {
             parse_listening_port_from_stdout_buffer(&mut buf, "080 (started in 1.2s)\n"),
             Some(18080)
         );
+    }
+
+    #[test]
+    fn extract_startup_status_parses_progress_and_messages() {
+        // Carriage-return progress line
+        let chunk = "\r  25/100 sessions (25%) · 1250 messages";
+        assert_eq!(
+            extract_startup_status(chunk),
+            Some("25/100 sessions (25%) · 1250 messages".to_string())
+        );
+
+        // Multiple \r-delimited updates: takes the last one
+        let chunk = "\r  5/100 sessions (5%) · 25 messages\r  10/100 sessions (10%) · 50 messages";
+        assert_eq!(
+            extract_startup_status(chunk),
+            Some("10/100 sessions (10%) · 50 messages".to_string())
+        );
+
+        // Newline-delimited sync messages
+        assert_eq!(
+            extract_startup_status("Running initial sync...\n"),
+            Some("Running initial sync...".to_string())
+        );
+        assert_eq!(
+            extract_startup_status("Sync complete: 42 sessions synced in 125ms\n"),
+            Some("Sync complete: 42 sessions synced in 125ms".to_string())
+        );
+        assert_eq!(
+            extract_startup_status("Watching 50 directories for changes (12ms)\n"),
+            Some("Watching 50 directories for changes (12ms)".to_string())
+        );
+
+        // Unrelated output is ignored
+        assert_eq!(extract_startup_status("some random log line\n"), None);
+        assert_eq!(extract_startup_status(""), None);
     }
 
     #[test]
@@ -886,6 +1146,16 @@ mod tests {
             elapsed < Duration::from_secs(1),
             "timeout path took too long: {elapsed:?}"
         );
+    }
+
+    #[test]
+    fn desktop_redirect_url_includes_desktop_query_param() {
+        let url = desktop_redirect_url(18080);
+        assert_eq!(url, "http://127.0.0.1:18080?desktop=1");
+
+        let url2 = desktop_redirect_url(8080);
+        assert!(url2.contains("?desktop=1"));
+        assert!(url2.starts_with("http://127.0.0.1:8080"));
     }
 
     #[test]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -26,6 +26,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": "v1Compatible",
     "externalBin": [
       "binaries/agentsview"
     ],
@@ -35,6 +36,18 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "entitlements": "./Entitlements.plist",
+      "minimumSystemVersion": "11.0"
+    }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "NOT_SET",
+      "endpoints": [
+        "https://github.com/wesm/agentsview/releases/download/updater/latest.json"
+      ]
+    }
   }
 }

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -130,17 +130,50 @@
         width: 7px;
         height: 7px;
         border-radius: 999px;
+        flex-shrink: 0;
+      }
+
+      .stage[data-state="pending"] {
+        color: #8fa6c5;
+      }
+
+      .stage[data-state="pending"] .stage-dot {
+        background: #bccfe6;
+      }
+
+      .stage[data-state="active"] .stage-dot {
         background: var(--brand);
         box-shadow: 0 0 0 0 rgba(47, 124, 246, 0.35);
         animation: pulse 1.8s ease-in-out infinite;
       }
 
-      .stage:nth-child(2) .stage-dot {
-        animation-delay: 0.28s;
+      .stage[data-state="completed"] {
+        color: #2a6d3e;
       }
 
-      .stage:nth-child(3) .stage-dot {
-        animation-delay: 0.56s;
+      .stage[data-state="completed"] .stage-dot {
+        width: 14px;
+        height: 14px;
+        margin: -3.5px -3.5px;
+        background: #2a9d51;
+      }
+
+      .stage-check {
+        display: none;
+        width: 8px;
+        height: 8px;
+      }
+
+      .stage[data-state="completed"] .stage-check {
+        display: block;
+        position: absolute;
+      }
+
+      .stage-dot-wrap {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
 
       .foot {
@@ -217,13 +250,54 @@
         <div class="meter" aria-hidden="true"></div>
 
         <ul class="stage-list" aria-hidden="true">
-          <li class="stage"><span class="stage-dot"></span>Launching local service</li>
-          <li class="stage"><span class="stage-dot"></span>Connecting to session database</li>
-          <li class="stage"><span class="stage-dot"></span>Opening app shell</li>
+          <li class="stage" data-state="active">
+            <span class="stage-dot-wrap">
+              <span class="stage-dot"></span>
+              <svg class="stage-check" viewBox="0 0 8 8" fill="none">
+                <path d="M1.5 4L3.2 5.8L6.5 2.2" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+            Launching local service
+          </li>
+          <li class="stage" data-state="pending">
+            <span class="stage-dot-wrap">
+              <span class="stage-dot"></span>
+              <svg class="stage-check" viewBox="0 0 8 8" fill="none">
+                <path d="M1.5 4L3.2 5.8L6.5 2.2" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+            Connecting to session database
+          </li>
+          <li class="stage" data-state="pending">
+            <span class="stage-dot-wrap">
+              <span class="stage-dot"></span>
+              <svg class="stage-check" viewBox="0 0 8 8" fill="none">
+                <path d="M1.5 4L3.2 5.8L6.5 2.2" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </span>
+            Opening app shell
+          </li>
         </ul>
 
         <div class="foot">Everything stays local to this machine.</div>
       </div>
     </main>
+    <script>
+      window.__setStage = function(activeIndex) {
+        var stages = document.querySelectorAll('.stage');
+        for (var i = 0; i < stages.length; i++) {
+          if (i < activeIndex) {
+            stages[i].setAttribute('data-state', 'completed');
+          } else if (i === activeIndex) {
+            stages[i].setAttribute('data-state', 'active');
+          } else {
+            stages[i].setAttribute('data-state', 'pending');
+          }
+        }
+      };
+      window.__setStatus = function(text) {
+        document.getElementById('status').textContent = text;
+      };
+    </script>
   </body>
 </html>

--- a/docs/desktop-release-setup.md
+++ b/docs/desktop-release-setup.md
@@ -1,0 +1,547 @@
+# Desktop Release: Signing and Configuration Guide
+
+This document covers the one-time setup for desktop release signing (macOS
+notarization, Tauri update signing) and the GitHub secrets required by the
+`desktop-release.yml` workflow.
+
+## Overview
+
+The desktop release workflow (`.github/workflows/desktop-release.yml`) triggers
+on `v*` tag pushes and produces:
+
+- **macOS**: Signed and notarized `.dmg` installer + `.app.tar.gz` updater
+  bundle
+- **Windows**: `.exe` NSIS installer + `.nsis.zip` updater bundle
+- **Updater manifest**: `latest.json` with platform URLs and Ed25519 signatures
+
+Three separate credential sets are needed:
+
+| Credential Set                  | Purpose                       | Platforms       |
+| ------------------------------- | ----------------------------- | --------------- |
+| Apple Developer certificate     | Code signing                  | macOS           |
+| Apple App Store Connect API key | Notarization                  | macOS           |
+| Tauri signing key               | Update signature verification | macOS + Windows |
+
+## 1. Apple Developer Certificate (macOS code signing)
+
+Code signing proves the app was built by a known developer. macOS Gatekeeper
+blocks unsigned apps. The CI workflow imports this certificate into a temporary
+keychain, signs the `.app` bundle and DMG, then deletes the keychain.
+
+### Prerequisites
+
+- An [Apple Developer Program](https://developer.apple.com/programs/) membership
+  ($99/year, required for "Developer ID" certificates)
+- A Mac with Keychain Access (needed to generate the CSR and export the `.p12`)
+
+### Step 1: Create a Certificate Signing Request (CSR)
+
+1. Open **Keychain Access** (in `/Applications/Utilities/`)
+1. Menu bar: **Keychain Access > Certificate Assistant > Request a Certificate
+   from a Certificate Authority...**
+1. Fill in:
+   - **User Email Address**: your Apple ID email
+   - **Common Name**: your name (can be anything)
+   - **CA Email Address**: leave blank
+   - Select **Saved to disk**
+1. Click **Continue** and save the `.certSigningRequest` file
+
+### Step 2: Create the certificate on Apple's portal
+
+1. Go to
+   [developer.apple.com/account/resources/certificates/list](https://developer.apple.com/account/resources/certificates/list)
+1. Click the **+** button
+1. Under "Software", select **Developer ID Application** (this is for apps
+   distributed outside the App Store — do **not** choose "Mac App Distribution"
+   or "Apple Development")
+1. Click **Continue**, upload the `.certSigningRequest` file from step 1
+1. Click **Continue**, then **Download** to get the `.cer` file
+1. Double-click the `.cer` file to install it into Keychain Access
+
+### Step 3: Export as .p12
+
+The CI runner needs the certificate as a `.p12` file (which bundles the
+certificate and its private key).
+
+1. Open **Keychain Access**
+1. In the left sidebar, select **login** keychain, then **My Certificates**
+   category
+1. Find the certificate named `Developer ID Application: Your Name (TEAMID)` —
+   it should have a disclosure triangle showing a private key underneath
+1. Right-click the certificate (not the private key) > **Export "Developer ID
+   Application: ..."**
+1. Format: **Personal Information Exchange (.p12)**
+1. Set a strong password when prompted — you will need this for the
+   `APPLE_CERTIFICATE_PASSWORD` secret
+
+Base64-encode the `.p12` for storage as a GitHub secret:
+
+```bash
+base64 -i "Developer_ID_Application.p12" | pbcopy
+# The base64 string is now on your clipboard
+```
+
+The output is a long base64 string (typically 3000-5000 characters). It starts
+with something like `MIIKcQIBAzCCCjcGCS...`. This entire string goes into the
+`APPLE_CERTIFICATE` secret.
+
+### Step 4: Find your signing identity
+
+Run this to list available code signing identities:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+You should see output like:
+
+```
+  1) A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2 "Developer ID Application: Jane Smith (ABC123XYZ)"
+     1 valid identities found
+```
+
+The full quoted string — `Developer ID Application: Jane Smith (ABC123XYZ)` — is
+your signing identity. The 10-character code in parentheses is your Team ID.
+
+If you see multiple identities, use the one that matches the certificate you
+just created. If you see no identities, the certificate wasn't installed
+correctly — check that the `.cer` was imported and that the private key from the
+CSR is in the same keychain.
+
+### GitHub secrets for code signing
+
+| Secret                       | Example value                                      | Notes                                                             |
+| ---------------------------- | -------------------------------------------------- | ----------------------------------------------------------------- |
+| `APPLE_CERTIFICATE`          | `MIIKcQIBAzCCCjcGCS...` (long base64)              | The entire base64-encoded `.p12` file                             |
+| `APPLE_CERTIFICATE_PASSWORD` | `your-p12-export-password`                         | The password you set when exporting the `.p12`                    |
+| `APPLE_SIGNING_IDENTITY`     | `Developer ID Application: Jane Smith (ABC123XYZ)` | Exact string from `security find-identity`, including the Team ID |
+
+## 2. Apple App Store Connect API Key (notarization)
+
+Notarization sends the signed app to Apple's servers for automated malware
+scanning. After approval (usually 1-5 minutes), macOS recognizes the app as
+checked by Apple and won't show the "unidentified developer" warning. The CI
+workflow uses an App Store Connect API key to authenticate with Apple's notary
+service.
+
+### Step 1: Create the API key
+
+1. Go to
+   [appstoreconnect.apple.com/access/integrations/api](https://appstoreconnect.apple.com/access/integrations/api)
+   - If you haven't used the API before, you'll need to click **Request Access**
+     first
+1. Note the **Issuer ID** displayed at the top of the page. It looks like a
+   UUID:
+   ```
+   Issuer ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+   ```
+1. Click **Generate API Key** (or the **+** button)
+1. Name: `AgentsView Notarization` (or any descriptive name)
+1. Access: **Developer** (minimum role needed for notarization)
+1. Click **Generate**
+
+### Step 2: Download the key
+
+After generating, the key appears in the table with a **Download** link.
+
+**Download the `.p8` file immediately.** Apple only lets you download it once.
+If you lose it, you must revoke the key and create a new one.
+
+The downloaded file is named `AuthKey_XXXXXXXXXX.p8` where `XXXXXXXXXX` is the
+Key ID. For example: `AuthKey_ABC123DEF0.p8`.
+
+The Key ID is also shown in the "Key ID" column of the table. It is a
+10-character alphanumeric string like `ABC123DEF0`.
+
+### Step 3: Inspect what you have
+
+At this point you should have three pieces of information:
+
+```
+Issuer ID:  a1b2c3d4-e5f6-7890-abcd-ef1234567890    (from the top of the API keys page)
+Key ID:     ABC123DEF0                                 (from the table, also in the filename)
+Key file:   ~/Downloads/AuthKey_ABC123DEF0.p8          (the downloaded file)
+```
+
+The `.p8` file is a short PEM-encoded private key (about 300 bytes). It looks
+like:
+
+```
+-----BEGIN PRIVATE KEY-----
+MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg...
+(2-3 lines of base64)
+-----END PRIVATE KEY-----
+```
+
+### Step 4: Base64-encode the key file
+
+```bash
+base64 -i ~/Downloads/AuthKey_ABC123DEF0.p8 | pbcopy
+# The base64 string is now on your clipboard
+```
+
+The base64 output is relatively short (about 400 characters). This goes into
+`APPLE_API_KEY_CONTENT`.
+
+### GitHub secrets for notarization
+
+| Secret                  | Example value                          | Notes                                       |
+| ----------------------- | -------------------------------------- | ------------------------------------------- |
+| `APPLE_API_KEY_CONTENT` | `LS0tLS1CRUdJTiBQUk...` (base64)       | Base64-encoded `.p8` key file               |
+| `APPLE_API_KEY`         | `ABC123DEF0`                           | The 10-character Key ID (not the Issuer ID) |
+| `APPLE_API_ISSUER`      | `a1b2c3d4-e5f6-7890-abcd-ef1234567890` | UUID from the top of the API keys page      |
+
+### How the workflow uses these
+
+The workflow reconstructs the `.p8` file on the runner:
+
+```bash
+echo "$APPLE_API_KEY_CONTENT" | base64 --decode > AuthKey_${APPLE_API_KEY}.p8
+```
+
+Then Tauri's build process passes the key to Apple's notary service via
+`notarytool`. The `APPLE_API_ISSUER` and `APPLE_API_KEY` identify which key to
+use. If notarization succeeds, `tauri build` staples the notarization ticket to
+the DMG automatically.
+
+## 3. Tauri Update Signing Key (auto-updater)
+
+The Tauri updater uses Ed25519 signatures to verify that update bundles are
+authentic. A keypair is generated once; the private key signs bundles during CI,
+and the public key is compiled into the app binary.
+
+### Generate the keypair
+
+```bash
+npx @tauri-apps/cli signer generate -w ~/.tauri/agentsview.key
+```
+
+This creates two files:
+
+- `~/.tauri/agentsview.key` -- the private key (keep secret)
+- `~/.tauri/agentsview.key.pub` -- the public key
+
+The command will prompt for a password. You can leave it empty for an
+unencrypted key, or set one (you'll need to provide it as a GitHub secret).
+
+### Configure the public key
+
+The public key needs to go in **two** places:
+
+**Option A (recommended):** Add `AGENTSVIEW_UPDATER_PUBKEY` as a GitHub Actions
+secret containing the public key string. The release workflow passes it as an
+env var to both Tauri build steps, and the Rust code reads it at compile time
+via `option_env!("AGENTSVIEW_UPDATER_PUBKEY")` to override the placeholder in
+`tauri.conf.json`. The relevant workflow lines look like:
+
+```yaml
+env:
+  AGENTSVIEW_UPDATER_PUBKEY: ${{ secrets.AGENTSVIEW_UPDATER_PUBKEY }}
+  TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+  TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+```
+
+If this secret is missing or empty, the app compiles but the updater falls back
+to the `"NOT_SET"` placeholder and shows "updater is not configured" at runtime.
+
+**Option B:** Replace `"NOT_SET"` in `desktop/src-tauri/tauri.conf.json`
+directly:
+
+```json
+"plugins": {
+  "updater": {
+    "pubkey": "<paste contents of agentsview.key.pub here>",
+    "endpoints": [
+      "https://github.com/wesm/agentsview/releases/latest/download/latest.json"
+    ]
+  }
+}
+```
+
+### GitHub secrets
+
+| Secret                               | Value                                  |
+| ------------------------------------ | -------------------------------------- |
+| `TAURI_SIGNING_PRIVATE_KEY`          | Contents of `~/.tauri/agentsview.key`  |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password (empty string if unencrypted) |
+
+If using Option A for the public key:
+
+| Secret                      | Value                                     |
+| --------------------------- | ----------------------------------------- |
+| `AGENTSVIEW_UPDATER_PUBKEY` | Contents of `~/.tauri/agentsview.key.pub` |
+
+## Complete GitHub Secrets Reference
+
+All secrets are configured at **Settings > Secrets and variables > Actions** in
+the GitHub repository.
+
+| Secret                               | Used By        | Purpose                            |
+| ------------------------------------ | -------------- | ---------------------------------- |
+| `APPLE_CERTIFICATE`                  | macOS build    | Signing certificate (.p12, base64) |
+| `APPLE_CERTIFICATE_PASSWORD`         | macOS build    | Certificate password               |
+| `APPLE_SIGNING_IDENTITY`             | macOS build    | Certificate CN identity string     |
+| `APPLE_API_KEY_CONTENT`              | macOS build    | Notarization API key (.p8, base64) |
+| `APPLE_API_KEY`                      | macOS build    | API key ID                         |
+| `APPLE_API_ISSUER`                   | macOS build    | API issuer ID                      |
+| `TAURI_SIGNING_PRIVATE_KEY`          | Both platforms | Tauri updater signing key          |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Both platforms | Signing key password               |
+| `AGENTSVIEW_UPDATER_PUBKEY`          | Both platforms | Updater public key (Option A)      |
+
+## Key Rotation
+
+### Rotating the Apple certificate
+
+Apple Developer ID Application certificates are valid for 5 years. To rotate:
+
+1. Generate a new certificate following section 1 above
+1. Export as `.p12` and base64-encode
+1. Update `APPLE_CERTIFICATE` and `APPLE_CERTIFICATE_PASSWORD` in GitHub secrets
+1. Update `APPLE_SIGNING_IDENTITY` if the identity string changed
+1. The old certificate can be revoked in Apple Developer portal after confirming
+   new builds work
+
+### Rotating the Apple API key
+
+API keys don't expire, but can be revoked. To rotate:
+
+1. Generate a new key in App Store Connect
+1. Base64-encode the new `.p8` file
+1. Update `APPLE_API_KEY_CONTENT` and `APPLE_API_KEY` in GitHub secrets
+1. `APPLE_API_ISSUER` doesn't change (it's per-organization)
+1. Revoke the old key in App Store Connect
+
+### Rotating the Tauri signing key
+
+Changing the signing key means existing app installations cannot verify updates
+signed with the new key. Plan for this:
+
+1. Generate a new keypair:
+   `npx @tauri-apps/cli signer generate -w ~/.tauri/agentsview-v2.key`
+1. Update `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+   in GitHub secrets
+1. Update the public key in `tauri.conf.json` or `AGENTSVIEW_UPDATER_PUBKEY`
+1. Release a version with the new public key compiled in
+1. Users on older versions will see update verification fail and need to
+   download the new version manually from the GitHub releases page
+
+## Build Artifacts
+
+Each release produces these artifacts:
+
+| File                                      | Description                                  |
+| ----------------------------------------- | -------------------------------------------- |
+| `AgentsView_x.y.z_aarch64.dmg`            | macOS installer (signed + notarized)         |
+| `AgentsView.app.tar.gz`                   | macOS updater bundle                         |
+| `AgentsView.app.tar.gz.sig`               | macOS updater signature                      |
+| `AgentsView_x.y.z_x64-setup.exe`          | Windows NSIS installer                       |
+| `AgentsView_x.y.z_x64-setup.nsis.zip`     | Windows updater bundle                       |
+| `AgentsView_x.y.z_x64-setup.nsis.zip.sig` | Windows updater signature                    |
+| `latest.json`                             | Updater manifest (version, URLs, signatures) |
+| `SHA256SUMS-desktop`                      | Checksums for all desktop artifacts          |
+
+## Runtime Configuration
+
+These environment variables affect the desktop app at runtime (not build time):
+
+| Variable                                  | Default | Purpose                                                 |
+| ----------------------------------------- | ------- | ------------------------------------------------------- |
+| `AGENTSVIEW_DESKTOP_AUTOUPDATE`           | enabled | Set to `0` to disable automatic update check on startup |
+| `AGENTSVIEW_DESKTOP_SKIP_LOGIN_SHELL_ENV` | unset   | Set to skip inheriting login shell environment          |
+| `AGENTSVIEW_DESKTOP_PATH`                 | unset   | Override PATH passed to the Go backend sidecar          |
+
+Users can also set environment overrides in `~/.agentsview/desktop.env`
+(KEY=VALUE format, one per line).
+
+## Staging / Testing
+
+Test the full release pipeline on a personal fork before shipping to production.
+This covers code signing, notarization, updater artifacts, and the end-to-end
+update flow.
+
+### Fork setup
+
+1. Fork the repository on GitHub.
+
+1. Configure **all** secrets on the fork (Settings > Secrets and variables >
+   Actions). The Apple secrets are the same ones used in production — they are
+   tied to your Apple Developer account, not to a specific repository:
+
+   | Secret                               | Notes                                            |
+   | ------------------------------------ | ------------------------------------------------ |
+   | `APPLE_CERTIFICATE`                  | Same certificate works on any repo               |
+   | `APPLE_CERTIFICATE_PASSWORD`         |                                                  |
+   | `APPLE_SIGNING_IDENTITY`             |                                                  |
+   | `APPLE_API_KEY_CONTENT`              | Same API key works for any app                   |
+   | `APPLE_API_KEY`                      |                                                  |
+   | `APPLE_API_ISSUER`                   |                                                  |
+   | `TAURI_SIGNING_PRIVATE_KEY`          | Generate a **separate** test keypair (see below) |
+   | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` |                                                  |
+   | `AGENTSVIEW_UPDATER_PUBKEY`          | Public key from the test keypair                 |
+
+1. Generate a test Tauri signing keypair (do not reuse the production key):
+
+   ```bash
+   npx @tauri-apps/cli signer generate -w /tmp/staging-updater.key
+   # Use the contents of /tmp/staging-updater.key for TAURI_SIGNING_PRIVATE_KEY
+   # Use the contents of /tmp/staging-updater.key.pub for AGENTSVIEW_UPDATER_PUBKEY
+   ```
+
+No manual `tauri.conf.json` edits are needed. The workflow automatically patches
+the updater endpoint URL and `latest.json` download URLs to use the current
+repository (`$GITHUB_REPOSITORY`).
+
+### Test the CI pipeline
+
+Push the branch and a test tag to the fork:
+
+```bash
+git remote add staging git@github.com:YOUR_USER/agentsview.git
+git push staging tauri-packaging
+git tag v0.0.1-staging.1
+git push staging v0.0.1-staging.1
+```
+
+Watch the workflow run. Verify:
+
+- **macOS job**: Certificate import succeeds, code signing succeeds,
+  notarization completes (Apple returns "Accepted"), DMG and `.app.tar.gz` +
+  `.sig` are uploaded
+- **Windows job**: NSIS installer and `.nsis.zip` + `.sig` are uploaded
+- **Release job**: `latest.json` contains non-empty URLs and signatures for both
+  platforms, all artifacts appear on the GitHub Release page
+
+### Test the desktop update flow
+
+This requires two releases on the fork — an older version to install, and a
+newer version to update to.
+
+1. After `v0.0.1-staging.1` finishes building, download and install the macOS
+   DMG (or Windows installer).
+
+1. Make a small commit (e.g. edit a comment), then push a second tag. The second
+   tag **must** be on a different commit so the build produces a distinct
+   version:
+
+   ```bash
+   git commit --allow-empty -m "staging: bump for v0.0.2 test"
+   git tag v0.0.2-staging.1
+   git push staging tauri-packaging v0.0.2-staging.1
+   ```
+
+1. Wait for the workflow to complete and the release to publish.
+
+1. Launch the v0.0.1 app. Verify:
+
+   - **Auto-check**: Within a few seconds of startup, a native dialog should
+     appear offering to update to v0.0.2 (check stderr for `[agentsview]` log
+     lines if it doesn't)
+   - **Menu**: Click "AgentsView > Check for Updates..." — should show the
+     update dialog
+   - **Install**: Click OK to download and install, then confirm the restart
+     prompt
+   - **Post-restart**: The app should relaunch running v0.0.2
+
+1. Check "Check for Updates..." again — should now show "You're running the
+   latest version."
+
+### Test the Go endpoint and frontend
+
+No fork needed. Run locally with a low version number:
+
+```bash
+go build -tags fts5 \
+  -ldflags "-X main.version=v0.1.0" \
+  -o /tmp/agentsview-test ./cmd/agentsview
+/tmp/agentsview-test serve
+```
+
+Verify:
+
+- `GET /api/v1/update/check` returns `update_available: true` with the correct
+  latest version
+- The StatusBar shows "update available" — clicking it opens the UpdateModal
+- The modal displays current vs latest version and CLI instructions
+
+Repeat with `-X main.version=v99.99.99` (up-to-date) and `-X main.version=dev`
+(dev build) to confirm those paths show no update indicator.
+
+### Cleanup
+
+After testing, delete the test tags and releases from the fork:
+
+```bash
+git push staging --delete v0.0.1-staging.1 v0.0.2-staging.1
+git tag -d v0.0.1-staging.1 v0.0.2-staging.1
+```
+
+Delete the releases manually from the fork's GitHub Releases page.
+
+## Troubleshooting
+
+### Code signing: "no identity found" or "Developer ID Application" not found
+
+The `APPLE_SIGNING_IDENTITY` secret must exactly match the identity string from
+`security find-identity`. Common issues:
+
+- **Wrong certificate type**: "Mac Developer" or "Apple Development"
+  certificates don't work for distribution. You need "Developer ID Application".
+- **Typo in identity string**: Copy-paste the entire quoted string from
+  `security find-identity`, including the Team ID in parentheses.
+- **Certificate expired**: Developer ID Application certificates are valid for 5
+  years. Check expiry in Keychain Access or at
+  [developer.apple.com/account/resources/certificates](https://developer.apple.com/account/resources/certificates/list).
+- **Private key missing from .p12**: When exporting, make sure you export from
+  "My Certificates" (which bundles the private key), not from "Certificates"
+  (which exports only the public cert).
+
+### Code signing: "errSecInternalComponent" or "User interaction is not allowed"
+
+The keychain wasn't unlocked properly. This usually means the
+`APPLE_CERTIFICATE_PASSWORD` secret doesn't match the password used when
+exporting the `.p12`. Re-export with a known password and update the secret.
+
+### Notarization: "invalid credentials" or "authentication failed"
+
+Check each piece independently:
+
+1. **Is the API key revoked?** Check at
+   [appstoreconnect.apple.com/access/integrations/api](https://appstoreconnect.apple.com/access/integrations/api)
+1. **Is `APPLE_API_KEY` the Key ID (not the Issuer ID)?** The Key ID is the
+   10-character string like `ABC123DEF0`, not the UUID.
+1. **Is `APPLE_API_ISSUER` the Issuer ID (not the Key ID)?** The Issuer ID is
+   the UUID shown at the top of the API keys page.
+1. **Is `APPLE_API_KEY_CONTENT` correctly base64-encoded?** Decode and verify it
+   looks like a PEM private key:
+   ```bash
+   echo "$APPLE_API_KEY_CONTENT" | base64 --decode
+   # Should print:
+   # -----BEGIN PRIVATE KEY-----
+   # (2-3 lines of base64)
+   # -----END PRIVATE KEY-----
+   ```
+1. **Was the `.p8` file re-downloaded?** Apple only allows one download. If you
+   lost the original, revoke the key and create a new one.
+
+### Notarization: "package is invalid" or "the signature is invalid"
+
+The app was signed with the wrong certificate type, or the entitlements are
+incorrect. Verify:
+
+- The certificate is "Developer ID Application" (not "Apple Development" or "3rd
+  Party Mac Developer Application")
+- `desktop/src-tauri/Entitlements.plist` includes the hardened runtime
+  entitlements for WebKit JIT
+
+### "The updater is not configured"
+
+The `AGENTSVIEW_UPDATER_PUBKEY` env var was not set at compile time, or the
+pubkey in `tauri.conf.json` is still `"NOT_SET"`. Make sure the secret is
+configured in GitHub and that both build steps in `desktop-release.yml` pass it
+as an env var.
+
+### Update verification fails after key rotation
+
+Expected. Users on versions compiled with the old public key cannot verify
+signatures from the new private key. They must download the new version manually
+from the releases page.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import ShortcutsModal from "./lib/components/modals/ShortcutsModal.svelte";
   import PublishModal from "./lib/components/modals/PublishModal.svelte";
   import ResyncModal from "./lib/components/modals/ResyncModal.svelte";
+  import UpdateModal from "./lib/components/modals/UpdateModal.svelte";
   import AnalyticsPage from "./lib/components/analytics/AnalyticsPage.svelte";
   import InsightsPage from "./lib/components/insights/InsightsPage.svelte";
   import PinnedPage from "./lib/components/pinned/PinnedPage.svelte";
@@ -164,6 +165,7 @@
     sync.loadStatus();
     sync.loadStats();
     sync.loadVersion();
+    sync.checkForUpdate();
     sync.startPolling();
 
     const cleanup = registerShortcuts({ navigateMessage });
@@ -227,6 +229,10 @@
 
 {#if ui.activeModal === "resync"}
   <ResyncModal />
+{/if}
+
+{#if ui.activeModal === "update"}
+  <UpdateModal />
 {/if}
 
 {#if sessions.recentlyDeleted.length > 0}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -9,6 +9,7 @@ import type {
   AgentsResponse,
   Stats,
   VersionInfo,
+  UpdateCheck,
   SyncStatus,
   SyncProgress,
   SyncStats,
@@ -179,6 +180,10 @@ export function getStats(
 
 export function getVersion(): Promise<VersionInfo> {
   return fetchJSON("/version");
+}
+
+export function checkForUpdate(): Promise<UpdateCheck> {
+  return fetchJSON("/update/check");
 }
 
 /* Sync */

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -150,3 +150,11 @@ export interface PinsResponse {
 export interface TrashResponse {
   sessions: Session[];
 }
+
+/** Matches Go updateCheckResponse in internal/server/update.go */
+export interface UpdateCheck {
+  update_available: boolean;
+  current_version: string;
+  latest_version?: string;
+  is_dev_build?: boolean;
+}

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { sync } from "../../stores/sync.svelte.js";
+  import { ui } from "../../stores/ui.svelte.js";
   import { formatNumber, formatRelativeTime } from "../../utils/format.js";
 
   let progressText = $derived.by(() => {
@@ -30,6 +31,16 @@
   </div>
 
   <div class="status-right">
+    {#if sync.updateAvailable && !sync.isDesktop}
+      <button
+        class="update-available"
+        onclick={() => (ui.activeModal = "update")}
+        title="A new version is available: {sync.latestVersion}"
+      >
+        update available
+      </button>
+      <span class="sep">&middot;</span>
+    {/if}
     {#if sync.versionMismatch}
       <button
         class="version-warn"
@@ -85,6 +96,17 @@
 
   .sync-progress {
     color: var(--accent-green);
+  }
+
+  .update-available {
+    color: var(--accent-blue);
+    font-size: 10px;
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .update-available:hover {
+    text-decoration: underline;
   }
 
   .version-warn {

--- a/frontend/src/lib/components/modals/UpdateModal.svelte
+++ b/frontend/src/lib/components/modals/UpdateModal.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  import { ui } from "../../stores/ui.svelte.js";
+  import { sync } from "../../stores/sync.svelte.js";
+
+  function close() {
+    ui.activeModal = null;
+  }
+
+  function handleOverlayClick(e: MouseEvent) {
+    if (
+      (e.target as HTMLElement).classList.contains(
+        "modal-overlay",
+      )
+    ) {
+      close();
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      close();
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="modal-overlay"
+  onclick={handleOverlayClick}
+  onkeydown={handleKeydown}
+>
+  <div class="modal-panel update-panel">
+    <div class="modal-header">
+      <h3 class="modal-title">Software Update</h3>
+      <button class="modal-close" onclick={close}>
+        &times;
+      </button>
+    </div>
+
+    <div class="modal-body">
+      {#if sync.updateAvailable && sync.latestVersion}
+        <p class="update-text">
+          A new version is available:
+          <strong>{sync.latestVersion}</strong>
+        </p>
+        <p class="update-current">
+          You are running
+          {sync.serverVersion?.version ?? "unknown"}.
+        </p>
+        <p class="update-instructions">
+          Run <code>agentsview update</code> on the command
+          line to install.
+        </p>
+      {:else}
+        <p class="update-text">
+          You're running the latest version
+          ({sync.serverVersion?.version ?? "unknown"}).
+        </p>
+      {/if}
+      <div class="update-actions">
+        <button
+          class="modal-btn modal-btn-primary"
+          onclick={close}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .update-panel {
+    width: 400px;
+  }
+
+  .update-text {
+    font-size: 12px;
+    color: var(--text-primary);
+    line-height: 1.5;
+  }
+
+  .update-current {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin-top: 4px;
+  }
+
+  .update-instructions {
+    font-size: 12px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin-top: 8px;
+  }
+
+  .update-instructions code {
+    font-family: var(--font-mono);
+    background: var(--bg-inset);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 11px;
+  }
+
+  .update-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 16px;
+  }
+</style>

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -4,6 +4,7 @@ import type {
   SyncStats,
   Stats,
   VersionInfo,
+  UpdateCheck,
 } from "../api/types.js";
 
 const POLL_INTERVAL_MS = 10_000;
@@ -34,8 +35,13 @@ class SyncStore {
   stats: Stats | null = $state(null);
   serverVersion: VersionInfo | null = $state(null);
   versionMismatch: boolean = $state(false);
+  updateAvailable: boolean = $state(false);
+  latestVersion: string | null = $state(null);
   readonly buildCommit: string =
     import.meta.env.VITE_BUILD_COMMIT;
+  readonly isDesktop: boolean =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).has("desktop");
 
   private watchEventSource: EventSource | null = null;
   private pollTimer: ReturnType<typeof setInterval> | null =
@@ -101,6 +107,21 @@ class SyncStore {
       );
     } catch (error) {
       console.warn("Failed to load version info:", error);
+    }
+  }
+
+  async checkForUpdate() {
+    // Desktop app uses the native Tauri updater; the
+    // Go backend endpoint checks upstream releases which
+    // is irrelevant and potentially wrong for forks.
+    if (this.isDesktop) return;
+    try {
+      const result: UpdateCheck =
+        await api.checkForUpdate();
+      this.updateAvailable = result.update_available;
+      this.latestVersion = result.latest_version ?? null;
+    } catch (error) {
+      console.warn("Failed to check for updates:", error);
     }
   }
 

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -7,7 +7,7 @@ import {
 } from "vitest";
 import { commitsDisagree, sync } from "./sync.svelte.js";
 import * as api from "../api/client.js";
-import type { SyncStats } from "../api/types.js";
+import type { SyncStats, UpdateCheck } from "../api/types.js";
 
 vi.mock("../api/client.js", () => ({
   triggerSync: vi.fn(),
@@ -16,6 +16,7 @@ vi.mock("../api/client.js", () => ({
   getStats: vi.fn(),
   getVersion: vi.fn(),
   watchSession: vi.fn(),
+  checkForUpdate: vi.fn(),
 }));
 
 const MOCK_STATS: SyncStats = {
@@ -216,5 +217,67 @@ describe("SyncStore.triggerResync", () => {
     });
     expect(sync.syncing).toBe(false);
     expect(sync.lastSyncStats).toEqual(MOCK_STATS);
+  });
+});
+
+describe("SyncStore.checkForUpdate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const s = sync as unknown as Record<string, unknown>;
+    s.updateAvailable = false;
+    s.latestVersion = null;
+  });
+
+  it("skips API call when isDesktop is true", async () => {
+    const s = sync as unknown as Record<string, unknown>;
+    // Temporarily override isDesktop
+    const original = s.isDesktop;
+    Object.defineProperty(sync, "isDesktop", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    await sync.checkForUpdate();
+
+    expect(api.checkForUpdate).not.toHaveBeenCalled();
+    expect(sync.updateAvailable).toBe(false);
+
+    Object.defineProperty(sync, "isDesktop", {
+      value: original,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("calls API and sets state when not desktop", async () => {
+    const mockResult: UpdateCheck = {
+      update_available: true,
+      current_version: "v0.9.0",
+      latest_version: "v1.0.0",
+    };
+    vi.mocked(api.checkForUpdate).mockResolvedValue(
+      mockResult,
+    );
+
+    const s = sync as unknown as Record<string, unknown>;
+    const original = s.isDesktop;
+    Object.defineProperty(sync, "isDesktop", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+
+    await sync.checkForUpdate();
+
+    expect(api.checkForUpdate).toHaveBeenCalled();
+    expect(sync.updateAvailable).toBe(true);
+    expect(sync.latestVersion).toBe("v1.0.0");
+
+    Object.defineProperty(sync, "isDesktop", {
+      value: original,
+      writable: true,
+      configurable: true,
+    });
   });
 });

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -5,6 +5,7 @@ type ModalType =
   | "shortcuts"
   | "publish"
   | "resync"
+  | "update"
   | null;
 
 /** Block types that can be toggled visible/hidden. */

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	mux     *http.ServeMux
 	httpSrv *http.Server
 	version VersionInfo
+	dataDir string
 
 	generateStreamFunc insight.GenerateStreamFunc
 	spaFS              fs.FS
@@ -45,6 +46,11 @@ type Server struct {
 	// handler, used only by tests to guarantee handlers
 	// exceed a short timeout. Zero in production.
 	handlerDelay time.Duration
+
+	// updateCheckFn is the function called to check for
+	// updates. Defaults to update.CheckForUpdate; tests
+	// can override it via WithUpdateChecker.
+	updateCheckFn UpdateCheckFunc
 }
 
 // New creates a new Server.
@@ -79,6 +85,17 @@ type Option func(*Server)
 // WithVersion sets the build-time version metadata.
 func WithVersion(v VersionInfo) Option {
 	return func(s *Server) { s.version = v }
+}
+
+// WithDataDir sets the data directory used for update caching.
+func WithDataDir(dir string) Option {
+	return func(s *Server) { s.dataDir = dir }
+}
+
+// WithUpdateChecker overrides the update check function,
+// allowing tests to substitute a deterministic stub.
+func WithUpdateChecker(f UpdateCheckFunc) Option {
+	return func(s *Server) { s.updateCheckFn = f }
 }
 
 // WithGenerateFunc overrides the insight generation function,
@@ -171,6 +188,7 @@ func (s *Server) routes() {
 	s.mux.Handle(
 		"POST /api/v1/config/terminal", s.withTimeout(s.handleSetTerminalConfig),
 	)
+	s.mux.Handle("GET /api/v1/update/check", s.withTimeout(s.handleCheckUpdate))
 
 	s.mux.Handle("GET /api/v1/starred", s.withTimeout(s.handleListStarred))
 	s.mux.Handle("PUT /api/v1/sessions/{id}/star", s.withTimeout(s.handleStarSession))

--- a/internal/server/update.go
+++ b/internal/server/update.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/wesm/agentsview/internal/update"
+)
+
+// UpdateCheckFunc is the signature for functions that check for
+// available updates. The default is update.CheckForUpdate.
+type UpdateCheckFunc func(
+	currentVersion string,
+	forceCheck bool,
+	cacheDir string,
+) (*update.UpdateInfo, error)
+
+type updateCheckResponse struct {
+	UpdateAvailable bool   `json:"update_available"`
+	CurrentVersion  string `json:"current_version"`
+	LatestVersion   string `json:"latest_version,omitempty"`
+	IsDevBuild      bool   `json:"is_dev_build,omitempty"`
+}
+
+func (s *Server) handleCheckUpdate(
+	w http.ResponseWriter, _ *http.Request,
+) {
+	checkFn := s.updateCheckFn
+	if checkFn == nil {
+		checkFn = update.CheckForUpdate
+	}
+
+	info, err := checkFn(
+		s.version.Version, false, s.dataDir,
+	)
+	if err != nil {
+		writeJSON(w, http.StatusOK, updateCheckResponse{
+			CurrentVersion: s.version.Version,
+		})
+		return
+	}
+
+	if info == nil {
+		writeJSON(w, http.StatusOK, updateCheckResponse{
+			CurrentVersion: s.version.Version,
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, updateCheckResponse{
+		UpdateAvailable: !info.IsDevBuild,
+		CurrentVersion:  info.CurrentVersion,
+		LatestVersion:   info.LatestVersion,
+		IsDevBuild:      info.IsDevBuild,
+	})
+}

--- a/internal/server/update_test.go
+++ b/internal/server/update_test.go
@@ -1,0 +1,160 @@
+package server_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/server"
+	"github.com/wesm/agentsview/internal/update"
+)
+
+func stubChecker(
+	info *update.UpdateInfo, err error,
+) server.UpdateCheckFunc {
+	return func(string, bool, string) (*update.UpdateInfo, error) {
+		return info, err
+	}
+}
+
+func TestCheckUpdateUpToDate(t *testing.T) {
+	t.Parallel()
+
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithVersion(server.VersionInfo{
+			Version:   "v1.0.0",
+			Commit:    "abc123",
+			BuildDate: "2026-01-01",
+		}),
+		server.WithUpdateChecker(stubChecker(nil, nil)),
+	})
+
+	w := te.get(t, "/api/v1/update/check")
+	assertStatus(t, w, 200)
+
+	resp := decode[updateCheckResp](t, w)
+	if resp.CurrentVersion != "v1.0.0" {
+		t.Errorf(
+			"current_version = %q, want %q",
+			resp.CurrentVersion, "v1.0.0",
+		)
+	}
+	if resp.UpdateAvailable {
+		t.Error("expected update_available=false when up to date")
+	}
+}
+
+func TestCheckUpdateAvailable(t *testing.T) {
+	t.Parallel()
+
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithVersion(server.VersionInfo{
+			Version:   "v0.9.0",
+			Commit:    "abc123",
+			BuildDate: "2026-01-01",
+		}),
+		server.WithUpdateChecker(stubChecker(
+			&update.UpdateInfo{
+				CurrentVersion: "v0.9.0",
+				LatestVersion:  "v1.0.0",
+			},
+			nil,
+		)),
+	})
+
+	w := te.get(t, "/api/v1/update/check")
+	assertStatus(t, w, 200)
+
+	resp := decode[updateCheckResp](t, w)
+	if !resp.UpdateAvailable {
+		t.Error("expected update_available=true")
+	}
+	if resp.LatestVersion != "v1.0.0" {
+		t.Errorf(
+			"latest_version = %q, want %q",
+			resp.LatestVersion, "v1.0.0",
+		)
+	}
+	if resp.CurrentVersion != "v0.9.0" {
+		t.Errorf(
+			"current_version = %q, want %q",
+			resp.CurrentVersion, "v0.9.0",
+		)
+	}
+}
+
+func TestCheckUpdateDevBuild(t *testing.T) {
+	t.Parallel()
+
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithVersion(server.VersionInfo{
+			Version:   "dev",
+			Commit:    "unknown",
+			BuildDate: "",
+		}),
+		server.WithUpdateChecker(stubChecker(
+			&update.UpdateInfo{
+				CurrentVersion: "dev",
+				LatestVersion:  "v1.0.0",
+				IsDevBuild:     true,
+			},
+			nil,
+		)),
+	})
+
+	w := te.get(t, "/api/v1/update/check")
+	assertStatus(t, w, 200)
+
+	resp := decode[updateCheckResp](t, w)
+	if resp.UpdateAvailable {
+		t.Error(
+			"expected update_available=false for dev build",
+		)
+	}
+	if !resp.IsDevBuild {
+		t.Error("expected is_dev_build=true")
+	}
+	if resp.CurrentVersion != "dev" {
+		t.Errorf(
+			"current_version = %q, want %q",
+			resp.CurrentVersion, "dev",
+		)
+	}
+}
+
+func TestCheckUpdateError(t *testing.T) {
+	t.Parallel()
+
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithVersion(server.VersionInfo{
+			Version:   "v1.0.0",
+			Commit:    "abc123",
+			BuildDate: "2026-01-01",
+		}),
+		server.WithUpdateChecker(stubChecker(
+			nil, errors.New("network error"),
+		)),
+	})
+
+	w := te.get(t, "/api/v1/update/check")
+	assertStatus(t, w, 200)
+
+	resp := decode[updateCheckResp](t, w)
+	if resp.CurrentVersion != "v1.0.0" {
+		t.Errorf(
+			"current_version = %q, want %q",
+			resp.CurrentVersion, "v1.0.0",
+		)
+	}
+	if resp.UpdateAvailable {
+		t.Error(
+			"expected update_available=false on error",
+		)
+	}
+}
+
+type updateCheckResp struct {
+	UpdateAvailable bool   `json:"update_available"`
+	CurrentVersion  string `json:"current_version"`
+	LatestVersion   string `json:"latest_version"`
+	IsDevBuild      bool   `json:"is_dev_build"`
+}


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for building signed macOS DMG and Windows
  NSIS desktop installers on tag push
- Add Tauri updater plugin for in-app desktop updates with native dialogs
  and menu bar integration
- Add Go server update-check endpoint and frontend update notification UI
  for CLI/browser users
- Add sidecar build script with version resolution, semver patching, and
  cross-compilation support
- Add setup guide for Apple signing, notarization, and Tauri signing keys

## Desktop release CI (`.github/workflows/desktop-release.yml`)

Workflow triggered on `v*` tags with three jobs:

- **build-macos**: Imports Apple signing certificate into ephemeral
  keychain, writes App Store Connect API key, builds with full bundle
  targets (no `--bundles` flag) so the `.app` bundle exists for the
  updater `.tar.gz` to be derived from. Code signing and notarization
  included.
- **build-windows**: Sets up MinGW, builds with `--bundles nsis` (avoids
  MSI version format restrictions). `createUpdaterArtifacts: "v1Compatible"`
  generates `.nsis.zip` + `.sig` updater bundles.
- **release**: Downloads artifacts, generates `SHA256SUMS-desktop` and
  `latest.json` updater manifest. Uploads `.dmg` and `.exe` installers to
  the versioned release. Uploads updater bundles (`.app.tar.gz`, `.nsis.zip`,
  sigs, `latest.json`) to a permanent `updater` prerelease, keeping the
  user-facing release page clean.

The workflow patches `tauri.conf.json` at build time via `sed` to inject
the updater pubkey and correct the endpoint URL for the current repository
(fork-aware via `${GITHUB_REPOSITORY}`).

Build outputs are copied to a flat staging directory before
`upload-artifact` to avoid nested directory structures.

## Tauri configuration

- `bundle.createUpdaterArtifacts: "v1Compatible"` generates `.app.tar.gz`
  (macOS) and `.nsis.zip` (Windows) updater bundles alongside installers
- `plugins.updater.pubkey` set to `"NOT_SET"` placeholder, patched by CI
- Updater endpoint points to `releases/download/updater/latest.json`
  (the permanent updater prerelease)
- `Entitlements.plist`: Hardened runtime entitlements for WebKit JIT

## Tauri desktop updater (`desktop/src-tauri/src/lib.rs`)

- Registers `tauri-plugin-updater` and `tauri-plugin-dialog`
- `option_env!("AGENTSVIEW_UPDATER_PUBKEY")` compile-time override
- Menu bar "Check for Updates..." item
- Auto-check 5s after startup (disabled via
  `AGENTSVIEW_DESKTOP_AUTOUPDATE=0`)
- Native confirmation dialogs for download and restart
- `AtomicBool` guard prevents concurrent update checks
- Redirect URL includes `?desktop=1` for frontend context detection

## Go server update endpoint

- `GET /api/v1/update/check` handler with 1-hour cache
- `WithUpdateChecker()` and `WithDataDir()` server options for testing
- Four deterministic tests (no network access needed)

## Frontend update notification

- `UpdateModal.svelte`: current vs latest version with CLI instructions
- `StatusBar.svelte`: clickable "update available" indicator
- Skips update check in desktop mode (`?desktop=1`)
- Tests for desktop and non-desktop paths

## Test plan

- [x] Push test tag to fork, verify CI produces signed+notarized DMG,
  NSIS installer, updater artifacts, `latest.json`, and
  `SHA256SUMS-desktop`
- [x] Versioned release contains only `.dmg`, `.exe`, and checksums
- [x] Updater prerelease contains `.app.tar.gz`, `.nsis.zip`, sigs,
  and `latest.json`
- [ ] `make test` -- Go tests pass
- [ ] `bash desktop/scripts/test-prepare-sidecar.sh` -- sidecar tests
- [ ] `cd frontend && npx vitest run` -- frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)