### PR TITLE
feat: exclude single-turn sessions by default

### DIFF
--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -104,7 +104,7 @@ func runSync(args []string) {
 	}
 
 	fmt.Println()
-	stats, err := database.GetStats(context.Background())
+	stats, err := database.GetStats(context.Background(), false)
 	if err == nil {
 		fmt.Printf(
 			"Database: %d sessions, %d messages\n",

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -21,7 +21,7 @@ type sessionSpec struct {
 }
 
 var specs = []sessionSpec{
-	{"project-alpha", "small-2", 2, 1, "", ""},
+	{"project-alpha", "small-2", 2, 2, "", ""},
 	{"project-alpha", "small-5", 5, 3, "", ""},
 	{"project-beta", "mixed-content-7", 7, 3, "", ""},
 	{"project-beta", "medium-8", 8, 4, "", ""},

--- a/frontend/e2e/virtualizer.spec.ts
+++ b/frontend/e2e/virtualizer.spec.ts
@@ -15,7 +15,7 @@ const LOC = {
 
 const SESSIONS = {
   ALPHA_5: { project: "project-alpha", count: 3, displayRows: 5 },
-  ALPHA_2: { project: "project-alpha", count: 1, displayRows: 2 },
+  ALPHA_2: { project: "project-alpha", count: 2, displayRows: 2 },
   BETA_6: { project: "project-beta", count: 3, displayRows: 5 },
 };
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -86,6 +86,7 @@ export interface ListSessionsParams {
   min_messages?: number;
   max_messages?: number;
   min_user_messages?: number;
+  include_one_shot?: boolean;
   cursor?: string;
   limit?: number;
 }
@@ -152,16 +153,20 @@ export function search(
 
 /* Metadata */
 
-export function getProjects(): Promise<ProjectsResponse> {
-  return fetchJSON("/projects");
+export function getProjects(
+  params: { include_one_shot?: boolean } = {},
+): Promise<ProjectsResponse> {
+  return fetchJSON(`/projects${buildQuery({ ...params })}`);
 }
 
 export function getMachines(): Promise<MachinesResponse> {
   return fetchJSON("/machines");
 }
 
-export function getAgents(): Promise<AgentsResponse> {
-  return fetchJSON("/agents");
+export function getAgents(
+  params: { include_one_shot?: boolean } = {},
+): Promise<AgentsResponse> {
+  return fetchJSON(`/agents${buildQuery({ ...params })}`);
 }
 
 export function getStats(): Promise<Stats> {
@@ -395,6 +400,7 @@ export interface AnalyticsParams {
   dow?: number;
   hour?: number;
   min_user_messages?: number;
+  include_one_shot?: boolean;
   active_since?: string;
 }
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -159,8 +159,10 @@ export function getProjects(
   return fetchJSON(`/projects${buildQuery({ ...params })}`);
 }
 
-export function getMachines(): Promise<MachinesResponse> {
-  return fetchJSON("/machines");
+export function getMachines(
+  params: { include_one_shot?: boolean } = {},
+): Promise<MachinesResponse> {
+  return fetchJSON(`/machines${buildQuery({ ...params })}`);
 }
 
 export function getAgents(

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -171,8 +171,10 @@ export function getAgents(
   return fetchJSON(`/agents${buildQuery({ ...params })}`);
 }
 
-export function getStats(): Promise<Stats> {
-  return fetchJSON("/stats");
+export function getStats(
+  params: { include_one_shot?: boolean } = {},
+): Promise<Stats> {
+  return fetchJSON(`/stats${buildQuery({ ...params })}`);
 }
 
 export function getVersion(): Promise<VersionInfo> {

--- a/frontend/src/lib/components/analytics/ActiveFilters.svelte
+++ b/frontend/src/lib/components/analytics/ActiveFilters.svelte
@@ -39,6 +39,7 @@
     (analytics.project !== "" ? 1 : 0) +
     (analytics.agent !== "" ? 1 : 0) +
     (analytics.minUserMessages > 0 ? 1 : 0) +
+    (analytics.includeOneShot ? 1 : 0) +
     (analytics.recentlyActive ? 1 : 0) +
     (hasTime ? 1 : 0)
   );
@@ -151,6 +152,16 @@
       </button>
     {/if}
 
+    {#if analytics.includeOneShot}
+      <button
+        class="filter-chip"
+        onclick={() => analytics.clearIncludeOneShot()}
+        title="Clear single-turn filter"
+      >
+        Single-turn included
+        <span class="chip-x">&times;</span>
+      </button>
+    {/if}
 
     {#if hasTime}
       <button

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -56,6 +56,8 @@
     const headerRecentlyActive = sessions.filters.recentlyActive;
     const headerMinUserMessages =
       sessions.filters.minUserMessages;
+    const headerIncludeOneShot =
+      sessions.filters.includeOneShot;
 
     const curProject = untrack(() => analytics.project);
     const curAgent = untrack(() => analytics.agent);
@@ -64,6 +66,9 @@
     );
     const curMinUser = untrack(
       () => analytics.minUserMessages,
+    );
+    const curIncludeOneShot = untrack(
+      () => analytics.includeOneShot,
     );
 
     let changed = false;
@@ -86,6 +91,11 @@
       : 0;
     if (curMinUser !== minUserVal) {
       analytics.minUserMessages = minUserVal;
+      changed = true;
+    }
+
+    if (curIncludeOneShot !== headerIncludeOneShot) {
+      analytics.includeOneShot = headerIncludeOneShot;
       changed = true;
     }
 

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -17,7 +17,11 @@
   }
 
   function handleSessionClick(id: string) {
-    router.navigate("sessions");
+    const params: Record<string, string> = {};
+    if (analytics.includeOneShot) {
+      params["include_one_shot"] = "true";
+    }
+    router.navigate("sessions", params);
     sessions.selectSession(id);
   }
 </script>

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -21,8 +21,8 @@
     if (analytics.includeOneShot) {
       params["include_one_shot"] = "true";
     }
+    sessions.pendingNavTarget = id;
     router.navigate("sessions", params);
-    sessions.selectSession(id);
   }
 </script>
 

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -22,7 +22,10 @@
       params["include_one_shot"] = "true";
     }
     sessions.pendingNavTarget = id;
-    router.navigate("sessions", params);
+    if (!router.navigate("sessions", params)) {
+      sessions.pendingNavTarget = null;
+      sessions.selectSession(id);
+    }
   }
 </script>
 

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -51,6 +51,9 @@
   let isHideUnknownOn = $derived(
     sessions.filters.hideUnknownProject,
   );
+  let isIncludeOneShotOn = $derived(
+    sessions.filters.includeOneShot,
+  );
 
   let groups = $derived.by(() => {
     const all = sessions.groupedSessions;
@@ -272,6 +275,25 @@
               class:on={isRecentlyActiveOn}
             ></span>
             Recently Active
+          </button>
+        </div>
+        <div class="filter-section">
+          <div class="filter-section-label">
+            Session Type
+          </div>
+          <button
+            class="filter-toggle"
+            class:active={isIncludeOneShotOn}
+            onclick={() =>
+              sessions.setIncludeOneShotFilter(
+                !isIncludeOneShotOn,
+              )}
+          >
+            <span
+              class="toggle-check"
+              class:on={isIncludeOneShotOn}
+            ></span>
+            Include single-turn
           </button>
         </div>
         <div class="filter-section">

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -91,7 +91,7 @@
     buildDisplayItems(groups, agentSections, groupByAgent, collapsedAgents),
   );
 
-  let totalCount = $derived(groups.length);
+  let totalCount = $derived(sessions.total);
   let totalSize = $derived(computeTotalSize(displayItems));
 
   let visibleItems = $derived.by(() => {

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -91,7 +91,11 @@
     buildDisplayItems(groups, agentSections, groupByAgent, collapsedAgents),
   );
 
-  let totalCount = $derived(sessions.total);
+  let totalCount = $derived(
+    starred.filterOnly
+      ? groups.reduce((n, g) => n + g.sessions.length, 0)
+      : sessions.total,
+  );
   let totalSize = $derived(computeTotalSize(displayItems));
 
   let visibleItems = $derived.by(() => {

--- a/frontend/src/lib/components/sidebar/session-list-utils.test.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.test.ts
@@ -519,3 +519,83 @@ describe("DisplayItem id stability", () => {
     expect(sessionItem!.id).toBe("session:claude:c1-session-0");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Starred-only count derivation
+// ---------------------------------------------------------------------------
+
+describe("starred-only session count", () => {
+  // Mirrors the component logic:
+  //   starred.filterOnly
+  //     ? groups.reduce((n, g) => n + g.sessions.length, 0)
+  //     : sessions.total
+
+  function filterGroupsForStarred(
+    groups: SessionGroup[],
+    starredIds: Set<string>,
+  ): SessionGroup[] {
+    return groups
+      .map((g) => ({
+        ...g,
+        sessions: g.sessions.filter((s) =>
+          starredIds.has(s.id),
+        ),
+      }))
+      .filter((g) => g.sessions.length > 0);
+  }
+
+  it("counts individual sessions, not groups", () => {
+    // Two groups, each with 3 sessions.
+    const g1 = makeGroup("claude", 3, "c");
+    const g2 = makeGroup("gpt", 3, "g");
+    const groups = [g1, g2];
+
+    // Star 2 sessions from g1 and 1 from g2.
+    const starred = new Set([
+      "c-session-0",
+      "c-session-2",
+      "g-session-1",
+    ]);
+    const filtered = filterGroupsForStarred(groups, starred);
+
+    // Should be 3 sessions across 2 groups, not 2 (groups).
+    const count = filtered.reduce(
+      (n, g) => n + g.sessions.length,
+      0,
+    );
+    expect(count).toBe(3);
+    expect(filtered).toHaveLength(2);
+  });
+
+  it("excludes groups with no starred sessions", () => {
+    const g1 = makeGroup("claude", 2, "c");
+    const g2 = makeGroup("gpt", 2, "g");
+    const groups = [g1, g2];
+
+    // Star only sessions from g1.
+    const starred = new Set(["c-session-0"]);
+    const filtered = filterGroupsForStarred(groups, starred);
+
+    const count = filtered.reduce(
+      (n, g) => n + g.sessions.length,
+      0,
+    );
+    expect(count).toBe(1);
+    expect(filtered).toHaveLength(1);
+  });
+
+  it("returns zero when nothing is starred", () => {
+    const groups = [makeGroup("claude", 3, "c")];
+    const filtered = filterGroupsForStarred(
+      groups,
+      new Set(),
+    );
+
+    const count = filtered.reduce(
+      (n, g) => n + g.sessions.length,
+      0,
+    );
+    expect(count).toBe(0);
+    expect(filtered).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -65,6 +65,7 @@ class AnalyticsStore {
   project: string = $state("");
   agent: string = $state("");
   minUserMessages: number = $state(0);
+  includeOneShot: boolean = $state(false);
   recentlyActive: boolean = $state(false);
   selectedDow: number | null = $state(null);
   selectedHour: number | null = $state(null);
@@ -126,6 +127,7 @@ class AnalyticsStore {
       this.project !== "" ||
       this.agent !== "" ||
       this.minUserMessages > 0 ||
+      this.includeOneShot ||
       this.recentlyActive ||
       this.selectedDow !== null ||
       this.selectedHour !== null
@@ -137,13 +139,16 @@ class AnalyticsStore {
     this.project = "";
     this.agent = "";
     this.minUserMessages = 0;
+    this.includeOneShot = false;
     this.recentlyActive = false;
     this.selectedDow = null;
     this.selectedHour = null;
     sessions.filters.project = "";
     sessions.filters.agent = "";
     sessions.filters.minUserMessages = 0;
+    sessions.filters.includeOneShot = false;
     sessions.filters.recentlyActive = false;
+    sessions.invalidateFilterCaches();
     sessions.load();
     this.fetchAll();
   }
@@ -158,6 +163,14 @@ class AnalyticsStore {
   clearMinUserMessages() {
     this.minUserMessages = 0;
     sessions.filters.minUserMessages = 0;
+    sessions.load();
+    this.fetchAll();
+  }
+
+  clearIncludeOneShot() {
+    this.includeOneShot = false;
+    sessions.filters.includeOneShot = false;
+    sessions.invalidateFilterCaches();
     sessions.load();
     this.fetchAll();
   }
@@ -219,6 +232,9 @@ class AnalyticsStore {
     if (this.minUserMessages > 0) {
       p.min_user_messages = this.minUserMessages;
     }
+    if (this.includeOneShot) {
+      p.include_one_shot = true;
+    }
     if (this.recentlyActive) {
       p.active_since = new Date(
         Date.now() - 24 * 60 * 60 * 1000,
@@ -253,6 +269,9 @@ class AnalyticsStore {
       if (this.agent) p.agent = this.agent;
       if (this.minUserMessages > 0) {
         p.min_user_messages = this.minUserMessages;
+      }
+      if (this.includeOneShot) {
+        p.include_one_shot = true;
       }
       if (this.recentlyActive) {
         p.active_since = new Date(

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -69,14 +69,18 @@ export class RouterStore {
     );
   }
 
-  navigate(route: Route, params: Record<string, string> = {}) {
+  navigate(
+    route: Route,
+    params: Record<string, string> = {},
+  ): boolean {
     const qs = new URLSearchParams(params).toString();
     const hash = qs ? `#/${route}?${qs}` : `#/${route}`;
-    if (hash === window.location.hash) return;
+    if (hash === window.location.hash) return false;
     this.route = route;
     this.params = params;
     this.#lastHash = hash;
     window.location.hash = hash;
+    return true;
   }
 }
 

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -112,6 +112,34 @@ describe("RouterStore", () => {
     removeSpy.mockRestore();
   });
 
+  it("navigate returns true on hash change", () => {
+    window.location.hash = "";
+    store = new RouterStore();
+    const result = store.navigate("sessions", {
+      project: "foo",
+    });
+    expect(result).toBe(true);
+    expect(store.route).toBe("sessions");
+    expect(store.params).toEqual({ project: "foo" });
+  });
+
+  it("navigate returns false on same hash (no-op)", () => {
+    window.location.hash = "#/sessions";
+    store = new RouterStore();
+    const result = store.navigate("sessions");
+    expect(result).toBe(false);
+  });
+
+  it("navigate returns false when params match", () => {
+    window.location.hash =
+      "#/sessions?include_one_shot=true";
+    store = new RouterStore();
+    const result = store.navigate("sessions", {
+      include_one_shot: "true",
+    });
+    expect(result).toBe(false);
+  });
+
   it("does not accumulate listeners across instances", () => {
     const addSpy = vi.spyOn(window, "addEventListener");
     const removeSpy = vi.spyOn(

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -129,6 +129,10 @@ class SessionsStore {
       project = "";
     }
 
+    const prevOneShot = this.filters.includeOneShot;
+    const nextOneShot =
+      params["include_one_shot"] === "true";
+
     this.filters = {
       project,
       agent: params["agent"] ?? "",
@@ -142,9 +146,11 @@ class SessionsStore {
       minUserMessages: Number.isFinite(minUserMsgs)
         ? minUserMsgs
         : 0,
-      includeOneShot:
-        params["include_one_shot"] === "true",
+      includeOneShot: nextOneShot,
     };
+    if (prevOneShot !== nextOneShot) {
+      this.invalidateFilterCaches();
+    }
     if (this.pendingNavTarget) {
       this.activeSessionId = this.pendingNavTarget;
       this.pendingNavTarget = null;
@@ -336,8 +342,10 @@ class SessionsStore {
   }
 
   setProjectFilter(project: string) {
+    const wasOneShot = this.filters.includeOneShot;
     this.filters = { ...defaultFilters(), project, agent: this.filters.agent };
     this.activeSessionId = null;
+    if (wasOneShot) this.invalidateFilterCaches();
     this.load();
   }
 
@@ -395,8 +403,10 @@ class SessionsStore {
 
   clearSessionFilters() {
     const project = this.filters.project;
+    const wasOneShot = this.filters.includeOneShot;
     this.filters = { ...defaultFilters(), project };
     this.activeSessionId = null;
+    if (wasOneShot) this.invalidateFilterCaches();
     this.load();
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -25,6 +25,7 @@ interface Filters {
   minMessages: number;
   maxMessages: number;
   minUserMessages: number;
+  includeOneShot: boolean;
 }
 
 function defaultFilters(): Filters {
@@ -39,6 +40,7 @@ function defaultFilters(): Filters {
     minMessages: 0,
     maxMessages: 0,
     minUserMessages: 0,
+    includeOneShot: false,
   };
 }
 
@@ -96,6 +98,7 @@ class SessionsStore {
         f.maxMessages > 0 ? f.maxMessages : undefined,
       min_user_messages:
         f.minUserMessages > 0 ? f.minUserMessages : undefined,
+      include_one_shot: f.includeOneShot || undefined,
     };
   }
 
@@ -139,6 +142,8 @@ class SessionsStore {
       minUserMessages: Number.isFinite(minUserMsgs)
         ? minUserMsgs
         : 0,
+      includeOneShot:
+        params["include_one_shot"] === "true",
     };
     if (this.pendingNavTarget) {
       this.activeSessionId = this.pendingNavTarget;
@@ -256,7 +261,10 @@ class SessionsStore {
     const ver = this.projectsVersion;
     this.projectsPromise = (async () => {
       try {
-        const res = await api.getProjects();
+        const params = this.filters.includeOneShot
+          ? { include_one_shot: true as const }
+          : {};
+        const res = await api.getProjects(params);
         if (ver === this.projectsVersion) {
           this.projects = res.projects;
           this.projectsLoaded = true;
@@ -278,7 +286,10 @@ class SessionsStore {
     const ver = this.agentsVersion;
     this.agentsPromise = (async () => {
       try {
-        const res = await api.getAgents();
+        const params = this.filters.includeOneShot
+          ? { include_one_shot: true as const }
+          : {};
+        const res = await api.getAgents(params);
         if (ver === this.agentsVersion) {
           this.agents = res.agents;
           this.agentsLoaded = true;
@@ -361,6 +372,13 @@ class SessionsStore {
     this.load();
   }
 
+  setIncludeOneShotFilter(include: boolean) {
+    this.filters.includeOneShot = include;
+    this.activeSessionId = null;
+    this.invalidateFilterCaches();
+    this.load();
+  }
+
   get hasActiveFilters(): boolean {
     const f = this.filters;
     return !!(
@@ -370,7 +388,8 @@ class SessionsStore {
       f.dateFrom ||
       f.dateTo ||
       f.date ||
-      f.minUserMessages > 0
+      f.minUserMessages > 0 ||
+      f.includeOneShot
     );
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1,5 +1,6 @@
 import * as api from "../api/client.js";
 import type { Session, ProjectInfo, AgentInfo } from "../api/types.js";
+import { sync } from "./sync.svelte.js";
 
 const SESSION_PAGE_SIZE = 500;
 
@@ -450,6 +451,11 @@ class SessionsStore {
     this.agentsPromise = null;
     this.loadProjects();
     this.loadAgents();
+    sync.loadStats(
+      this.filters.includeOneShot
+        ? { include_one_shot: true }
+        : {},
+    );
   }
 
   /** Remove one or all entries from the undo toast list. */

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -40,6 +40,8 @@ class SyncStore {
   private watchEventSource: EventSource | null = null;
   private pollTimer: ReturnType<typeof setInterval> | null =
     null;
+  private lastStatsParams: { include_one_shot?: boolean } =
+    {};
 
   async loadStatus() {
     try {
@@ -70,9 +72,14 @@ class SyncStore {
     }
   }
 
-  async loadStats() {
+  async loadStats(
+    params?: { include_one_shot?: boolean },
+  ) {
+    if (params !== undefined) {
+      this.lastStatsParams = params;
+    }
     try {
-      this.stats = await api.getStats();
+      this.stats = await api.getStats(this.lastStatsParams);
     } catch (error) {
       console.warn("Failed to load sync stats:", error);
     }

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -42,6 +42,7 @@ class SyncStore {
     null;
   private lastStatsParams: { include_one_shot?: boolean } =
     {};
+  private statsVersion = 0;
 
   async loadStatus() {
     try {
@@ -78,8 +79,14 @@ class SyncStore {
     if (params !== undefined) {
       this.lastStatsParams = params;
     }
+    const version = ++this.statsVersion;
     try {
-      this.stats = await api.getStats(this.lastStatsParams);
+      const result = await api.getStats(
+        this.lastStatsParams,
+      );
+      if (this.statsVersion === version) {
+        this.stats = result;
+      }
     } catch (error) {
       console.warn("Failed to load sync stats:", error);
     }

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -80,6 +80,61 @@ describe("commitsDisagree", () => {
   );
 });
 
+describe("SyncStore.loadStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const s = sync as unknown as Record<string, unknown>;
+    s.stats = null;
+  });
+
+  it("discards stale response when a newer request exists", async () => {
+    const older = {
+      session_count: 10,
+      message_count: 50,
+      project_count: 2,
+      machine_count: 1,
+      earliest_session: null,
+    };
+    const newer = {
+      session_count: 5,
+      message_count: 30,
+      project_count: 1,
+      machine_count: 1,
+      earliest_session: null,
+    };
+
+    let resolveOlder!: (v: typeof older) => void;
+    let resolveNewer!: (v: typeof newer) => void;
+
+    vi.mocked(api.getStats)
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveOlder = r;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveNewer = r;
+        }),
+      );
+
+    // Start first request (include one-shot).
+    const p1 = sync.loadStats({ include_one_shot: true });
+    // Start second request (exclude one-shot) before first resolves.
+    const p2 = sync.loadStats({});
+
+    // Resolve newer first, then older.
+    resolveNewer(newer);
+    await p2;
+    expect(sync.stats).toEqual(newer);
+
+    // Now resolve the older request — it should be discarded.
+    resolveOlder(older);
+    await p1;
+    expect(sync.stats).toEqual(newer);
+  });
+});
+
 describe("SyncStore.triggerResync", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -51,6 +51,7 @@ type AnalyticsFilter struct {
 	DayOfWeek       *int   // nil = all, 0=Mon, 6=Sun (ISO)
 	Hour            *int   // nil = all, 0-23
 	MinUserMessages int    // user_message_count >= N
+	ExcludeOneShot  bool   // exclude sessions with user_message_count <= 1
 	ActiveSince     string // ISO timestamp cutoff
 }
 
@@ -124,6 +125,9 @@ func (f AnalyticsFilter) buildWhere(
 	if f.MinUserMessages > 0 {
 		preds = append(preds, "user_message_count >= ?")
 		args = append(args, f.MinUserMessages)
+	}
+	if f.ExcludeOneShot {
+		preds = append(preds, "user_message_count > 1")
 	}
 
 	if f.ActiveSince != "" {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1275,7 +1275,7 @@ func TestGetProjects(t *testing.T) {
 	})
 	insertSession(t, d, "s3", "alpha")
 
-	projects, err := d.GetProjects(context.Background())
+	projects, err := d.GetProjects(context.Background(), false)
 	requireNoError(t, err, "GetProjects")
 	if len(projects) != 2 {
 		t.Fatalf("got %d projects, want 2", len(projects))
@@ -3329,7 +3329,7 @@ func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
 	insertSession(t, d, "s3", "proj",
 		func(s *Session) { s.Agent = "" })
 
-	agents, err := d.GetAgents(context.Background())
+	agents, err := d.GetAgents(context.Background(), false)
 	if err != nil {
 		t.Fatalf("GetAgents: %v", err)
 	}
@@ -3347,7 +3347,7 @@ func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
 func TestGetAgentsEmptyResultSerializesAsArray(t *testing.T) {
 	d := testDB(t)
 
-	agents, err := d.GetAgents(context.Background())
+	agents, err := d.GetAgents(context.Background(), false)
 	if err != nil {
 		t.Fatalf("GetAgents: %v", err)
 	}
@@ -3886,13 +3886,13 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 	})
 
 	// Before trashing: both projects, agents, machines visible.
-	projects, err := d.GetProjects(ctx)
+	projects, err := d.GetProjects(ctx, false)
 	requireNoError(t, err, "GetProjects before trash")
 	if len(projects) != 2 {
 		t.Fatalf("projects before trash: got %d, want 2", len(projects))
 	}
 
-	agents, err := d.GetAgents(ctx)
+	agents, err := d.GetAgents(ctx, false)
 	requireNoError(t, err, "GetAgents before trash")
 	if len(agents) != 2 {
 		t.Fatalf("agents before trash: got %d, want 2", len(agents))
@@ -3907,7 +3907,7 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 	// Soft-delete s2: its project/agent/machine should disappear.
 	requireNoError(t, d.SoftDeleteSession("s2"), "soft delete s2")
 
-	projects, err = d.GetProjects(ctx)
+	projects, err = d.GetProjects(ctx, false)
 	requireNoError(t, err, "GetProjects after trash")
 	if len(projects) != 1 {
 		t.Errorf("projects after trash: got %d, want 1", len(projects))
@@ -3916,7 +3916,7 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 		t.Errorf("project name: got %q, want %q", projects[0].Name, "proj-a")
 	}
 
-	agents, err = d.GetAgents(ctx)
+	agents, err = d.GetAgents(ctx, false)
 	requireNoError(t, err, "GetAgents after trash")
 	if len(agents) != 1 {
 		t.Errorf("agents after trash: got %d, want 1", len(agents))

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1138,7 +1138,7 @@ func TestCanceledContext(t *testing.T) {
 			return err
 		}, false},
 		{"GetStats", func() error {
-			_, err := d.GetStats(ctx)
+			_, err := d.GetStats(ctx, false)
 			return err
 		}, false},
 	}
@@ -1157,7 +1157,7 @@ func TestStats(t *testing.T) {
 	d := testDB(t)
 
 	// Empty DB returns nil EarliestSession
-	stats, err := d.GetStats(context.Background())
+	stats, err := d.GetStats(context.Background(), false)
 	requireNoError(t, err, "GetStats empty")
 	if stats.EarliestSession != nil {
 		t.Errorf(
@@ -1181,7 +1181,7 @@ func TestStats(t *testing.T) {
 		userMsg("s2", 0, "bye"),
 	)
 
-	stats, err = d.GetStats(context.Background())
+	stats, err = d.GetStats(context.Background(), false)
 	requireNoError(t, err, "GetStats")
 	if stats.SessionCount != 2 {
 		t.Errorf("session_count = %d, want 2", stats.SessionCount)
@@ -1214,7 +1214,7 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 	insertSession(t, d, "s-null-start", "proj")
 	insertMessages(t, d, userMsg("s-null-start", 0, "hi"))
 
-	stats, err := d.GetStats(context.Background())
+	stats, err := d.GetStats(context.Background(), false)
 	requireNoError(t, err, "GetStats null started_at")
 	if stats.EarliestSession == nil {
 		t.Fatal(
@@ -1230,7 +1230,7 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 	})
 	insertMessages(t, d, userMsg("s-empty-start", 0, "hey"))
 
-	stats, err = d.GetStats(context.Background())
+	stats, err = d.GetStats(context.Background(), false)
 	requireNoError(t, err, "GetStats empty started_at")
 	if stats.EarliestSession == nil {
 		t.Fatal(
@@ -1253,7 +1253,7 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 	})
 	insertMessages(t, d, userMsg("s-old", 0, "hello"))
 
-	stats, err = d.GetStats(context.Background())
+	stats, err = d.GetStats(context.Background(), false)
 	requireNoError(t, err, "GetStats with old session")
 	if stats.EarliestSession == nil {
 		t.Fatal("earliest_session nil")
@@ -1640,7 +1640,7 @@ func TestDeleteSessions(t *testing.T) {
 		insertMessages(t, d, userMsg(id, 0, "msg for "+id))
 	}
 
-	stats, _ := d.GetStats(context.Background())
+	stats, _ := d.GetStats(context.Background(), false)
 	if stats.SessionCount != 3 {
 		t.Fatalf("initial sessions = %d, want 3", stats.SessionCount)
 	}
@@ -1667,7 +1667,7 @@ func TestDeleteSessions(t *testing.T) {
 		t.Errorf("s2 messages = %d, want 1", len(msgs))
 	}
 
-	stats, _ = d.GetStats(context.Background())
+	stats, _ = d.GetStats(context.Background(), false)
 	if stats.SessionCount != 1 {
 		t.Errorf("session_count = %d, want 1", stats.SessionCount)
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3898,7 +3898,7 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 		t.Fatalf("agents before trash: got %d, want 2", len(agents))
 	}
 
-	machines, err := d.GetMachines(ctx)
+	machines, err := d.GetMachines(ctx, false)
 	requireNoError(t, err, "GetMachines before trash")
 	if len(machines) != 2 {
 		t.Fatalf("machines before trash: got %d, want 2", len(machines))
@@ -3925,7 +3925,7 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 		t.Errorf("agent name: got %q, want %q", agents[0].Name, "claude")
 	}
 
-	machines, err = d.GetMachines(ctx)
+	machines, err = d.GetMachines(ctx, false)
 	requireNoError(t, err, "GetMachines after trash")
 	if len(machines) != 1 {
 		t.Errorf("machines after trash: got %d, want 1", len(machines))

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -296,3 +296,50 @@ func TestActiveSinceUsesEndedAtOverStartedAt(t *testing.T) {
 		})
 	}
 }
+
+func TestSessionFilterExcludeOneShot(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "zero", "proj", func(s *Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 0
+	})
+	insertSession(t, d, "one", "proj", func(s *Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "two", "proj", func(s *Session) {
+		s.MessageCount = 5
+		s.UserMessageCount = 2
+	})
+	insertSession(t, d, "ten", "proj", func(s *Session) {
+		s.MessageCount = 20
+		s.UserMessageCount = 10
+	})
+
+	tests := []struct {
+		name           string
+		excludeOneShot bool
+		want           []string
+	}{
+		{
+			"IncludeAll",
+			false,
+			[]string{"zero", "one", "two", "ten"},
+		},
+		{
+			"ExcludeOneShot",
+			true,
+			[]string{"two", "ten"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := SessionFilter{
+				ExcludeOneShot: tt.excludeOneShot,
+			}
+			requireSessions(t, d, f, tt.want)
+		})
+	}
+}

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 )
 
@@ -341,5 +342,80 @@ func TestSessionFilterExcludeOneShot(t *testing.T) {
 			}
 			requireSessions(t, d, f, tt.want)
 		})
+	}
+}
+
+func TestGetMachinesExcludeOneShot(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "s1", "proj", func(s *Session) {
+		s.Machine = "laptop"
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "s2", "proj", func(s *Session) {
+		s.Machine = "desktop"
+		s.UserMessageCount = 5
+	})
+
+	all, err := d.GetMachines(context.Background(), false)
+	requireNoError(t, err, "GetMachines includeAll")
+	if len(all) != 2 {
+		t.Fatalf("includeAll: got %d machines, want 2", len(all))
+	}
+
+	filtered, err := d.GetMachines(context.Background(), true)
+	requireNoError(t, err, "GetMachines excludeOneShot")
+	if len(filtered) != 1 {
+		t.Fatalf("excludeOneShot: got %d machines, want 1",
+			len(filtered))
+	}
+	if filtered[0] != "desktop" {
+		t.Errorf("excludeOneShot: got %q, want desktop",
+			filtered[0])
+	}
+}
+
+func TestGetStatsExcludeOneShot(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "s1", "proj1", func(s *Session) {
+		s.MessageCount = 5
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "s2", "proj2", func(s *Session) {
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+
+	// Include all.
+	stats, err := d.GetStats(context.Background(), false)
+	requireNoError(t, err, "GetStats includeAll")
+	if stats.SessionCount != 2 {
+		t.Errorf("includeAll: session_count = %d, want 2",
+			stats.SessionCount)
+	}
+	if stats.MessageCount != 15 {
+		t.Errorf("includeAll: message_count = %d, want 15",
+			stats.MessageCount)
+	}
+	if stats.ProjectCount != 2 {
+		t.Errorf("includeAll: project_count = %d, want 2",
+			stats.ProjectCount)
+	}
+
+	// Exclude one-shot.
+	stats, err = d.GetStats(context.Background(), true)
+	requireNoError(t, err, "GetStats excludeOneShot")
+	if stats.SessionCount != 1 {
+		t.Errorf("excludeOneShot: session_count = %d, want 1",
+			stats.SessionCount)
+	}
+	if stats.MessageCount != 10 {
+		t.Errorf("excludeOneShot: message_count = %d, want 10",
+			stats.MessageCount)
+	}
+	if stats.ProjectCount != 1 {
+		t.Errorf("excludeOneShot: project_count = %d, want 1",
+			stats.ProjectCount)
 	}
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -182,6 +182,7 @@ type SessionFilter struct {
 	MinMessages     int    // message_count >= N (0 = no filter)
 	MaxMessages     int    // message_count <= N (0 = no filter)
 	MinUserMessages int    // user_message_count >= N (0 = no filter)
+	ExcludeOneShot  bool   // exclude sessions with user_message_count <= 1
 	Cursor          string // opaque cursor from previous page
 	Limit           int
 }
@@ -250,6 +251,9 @@ func buildSessionFilter(f SessionFilter) (string, []any) {
 	if f.MinUserMessages > 0 {
 		preds = append(preds, "user_message_count >= ?")
 		args = append(args, f.MinUserMessages)
+	}
+	if f.ExcludeOneShot {
+		preds = append(preds, "user_message_count > 1")
 	}
 
 	return strings.Join(preds, " AND "), args
@@ -607,16 +611,18 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 
 // GetProjects returns project names with session counts.
 func (db *DB) GetProjects(
-	ctx context.Context,
+	ctx context.Context, excludeOneShot bool,
 ) ([]ProjectInfo, error) {
-	rows, err := db.getReader().QueryContext(ctx, `
-		SELECT project, COUNT(*) as session_count
+	q := `SELECT project, COUNT(*) as session_count
 		FROM sessions
 		WHERE message_count > 0
 		  AND relationship_type NOT IN ('subagent', 'fork')
-		  AND deleted_at IS NULL
-		GROUP BY project
-		ORDER BY project`)
+		  AND deleted_at IS NULL`
+	if excludeOneShot {
+		q += " AND user_message_count > 1"
+	}
+	q += " GROUP BY project ORDER BY project"
+	rows, err := db.getReader().QueryContext(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("querying projects: %w", err)
 	}
@@ -641,15 +647,17 @@ type ProjectInfo struct {
 
 // GetAgents returns distinct agent names with session counts.
 func (db *DB) GetAgents(
-	ctx context.Context,
+	ctx context.Context, excludeOneShot bool,
 ) ([]AgentInfo, error) {
-	rows, err := db.getReader().QueryContext(ctx, `
-		SELECT agent, COUNT(*) as session_count
+	q := `SELECT agent, COUNT(*) as session_count
 		FROM sessions
 		WHERE message_count > 0 AND agent <> ''
-		  AND deleted_at IS NULL
-		GROUP BY agent
-		ORDER BY agent`)
+		  AND deleted_at IS NULL`
+	if excludeOneShot {
+		q += " AND user_message_count > 1"
+	}
+	q += " GROUP BY agent ORDER BY agent"
+	rows, err := db.getReader().QueryContext(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("querying agents: %w", err)
 	}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -682,11 +682,14 @@ type AgentInfo struct {
 
 // GetMachines returns distinct machine names.
 func (db *DB) GetMachines(
-	ctx context.Context,
+	ctx context.Context, excludeOneShot bool,
 ) ([]string, error) {
-	rows, err := db.getReader().QueryContext(ctx,
-		"SELECT DISTINCT machine FROM sessions WHERE deleted_at IS NULL ORDER BY machine",
-	)
+	q := "SELECT DISTINCT machine FROM sessions WHERE deleted_at IS NULL"
+	if excludeOneShot {
+		q += " AND user_message_count > 1"
+	}
+	q += " ORDER BY machine"
+	rows, err := db.getReader().QueryContext(ctx, q)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -43,21 +43,28 @@ func (db *DB) FileBackedSessionCount(
 
 // GetStats returns database statistics, counting only root
 // sessions with messages (matching the session list filter).
-func (db *DB) GetStats(ctx context.Context) (Stats, error) {
-	const query = `
+func (db *DB) GetStats(
+	ctx context.Context, excludeOneShot bool,
+) (Stats, error) {
+	filter := rootSessionFilter
+	if excludeOneShot {
+		filter += " AND user_message_count > 1"
+	}
+	query := fmt.Sprintf(`
 		SELECT
 			(SELECT COUNT(*) FROM sessions
-			 WHERE ` + rootSessionFilter + `),
+			 WHERE %s),
 			(SELECT value FROM stats
 			 WHERE key = 'message_count'),
 			(SELECT COUNT(DISTINCT project) FROM sessions
-			 WHERE ` + rootSessionFilter + `),
+			 WHERE %s),
 			(SELECT COUNT(DISTINCT machine) FROM sessions
-			 WHERE ` + rootSessionFilter + `),
+			 WHERE %s),
 			(SELECT MIN(COALESCE(
 				NULLIF(started_at, ''), created_at
 			 )) FROM sessions
-			 WHERE ` + rootSessionFilter + `)`
+			 WHERE %s)`,
+		filter, filter, filter, filter)
 
 	var s Stats
 	err := db.getReader().QueryRowContext(ctx, query).Scan(

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -54,8 +54,8 @@ func (db *DB) GetStats(
 		SELECT
 			(SELECT COUNT(*) FROM sessions
 			 WHERE %s),
-			(SELECT value FROM stats
-			 WHERE key = 'message_count'),
+			(SELECT COALESCE(SUM(message_count), 0)
+			 FROM sessions WHERE %s),
 			(SELECT COUNT(DISTINCT project) FROM sessions
 			 WHERE %s),
 			(SELECT COUNT(DISTINCT machine) FROM sessions
@@ -64,7 +64,7 @@ func (db *DB) GetStats(
 				NULLIF(started_at, ''), created_at
 			 )) FROM sessions
 			 WHERE %s)`,
-		filter, filter, filter, filter)
+		filter, filter, filter, filter, filter)
 
 	var s Stats
 	err := db.getReader().QueryRowContext(ctx, query).Scan(

--- a/internal/server/analytics.go
+++ b/internal/server/analytics.go
@@ -107,6 +107,8 @@ func parseAnalyticsFilter(
 		return db.AnalyticsFilter{}, false
 	}
 
+	includeOneShot := q.Get("include_one_shot") == "true"
+
 	return db.AnalyticsFilter{
 		From:            from,
 		To:              to,
@@ -117,6 +119,7 @@ func parseAnalyticsFilter(
 		DayOfWeek:       dow,
 		Hour:            hour,
 		MinUserMessages: minUserMsgs,
+		ExcludeOneShot:  !includeOneShot,
 		ActiveSince:     activeSince,
 	}, true
 }

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -225,7 +225,8 @@ func (s *Server) handleGetStats(
 func (s *Server) handleListProjects(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	projects, err := s.db.GetProjects(r.Context())
+	excludeOneShot := r.URL.Query().Get("include_one_shot") != "true"
+	projects, err := s.db.GetProjects(r.Context(), excludeOneShot)
 	if err != nil {
 		if handleContextError(w, err) {
 			return
@@ -257,7 +258,8 @@ func (s *Server) handleListMachines(
 func (s *Server) handleListAgents(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	agents, err := s.db.GetAgents(r.Context())
+	excludeOneShot := r.URL.Query().Get("include_one_shot") != "true"
+	agents, err := s.db.GetAgents(r.Context(), excludeOneShot)
 	if err != nil {
 		if handleContextError(w, err) {
 			return

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -242,7 +242,8 @@ func (s *Server) handleListProjects(
 func (s *Server) handleListMachines(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	machines, err := s.db.GetMachines(r.Context())
+	excludeOneShot := r.URL.Query().Get("include_one_shot") != "true"
+	machines, err := s.db.GetMachines(r.Context(), excludeOneShot)
 	if err != nil {
 		if handleContextError(w, err) {
 			return

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -211,7 +211,8 @@ func (s *Server) handleSyncStatus(
 func (s *Server) handleGetStats(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	stats, err := s.db.GetStats(r.Context())
+	excludeOneShot := r.URL.Query().Get("include_one_shot") != "true"
+	stats, err := s.db.GetStats(r.Context(), excludeOneShot)
 	if err != nil {
 		if handleContextError(w, err) {
 			return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -289,6 +289,7 @@ func (te *testEnv) seedSession(
 	dbtest.SeedSession(t, te.db, id, project, func(s *db.Session) {
 		s.Machine = "test"
 		s.MessageCount = msgCount
+		s.UserMessageCount = max(msgCount, 2)
 		s.StartedAt = dbtest.Ptr(tsSeed)
 		s.EndedAt = dbtest.Ptr(tsSeedEnd)
 		s.FirstMessage = dbtest.Ptr("Hello world")
@@ -663,6 +664,43 @@ func TestListSessions_ExcludeProjectFilter(t *testing.T) {
 	if resp.Sessions[0].ID != "s1" {
 		t.Errorf("expected session s1, got %s",
 			resp.Sessions[0].ID)
+	}
+}
+
+func TestListSessions_ExcludeOneShotDefault(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "my-app", 5, func(s *db.Session) {
+		s.UserMessageCount = 1
+	})
+	te.seedSession(t, "s2", "my-app", 10, func(s *db.Session) {
+		s.UserMessageCount = 5
+	})
+	te.seedSession(t, "s3", "my-app", 3, func(s *db.Session) {
+		s.UserMessageCount = 0
+	})
+
+	// Default: exclude one-shot sessions.
+	w := te.get(t, "/api/v1/sessions")
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[sessionListResponse](t, w)
+	if len(resp.Sessions) != 1 {
+		t.Fatalf("default: expected 1 session, got %d",
+			len(resp.Sessions))
+	}
+	if resp.Sessions[0].ID != "s2" {
+		t.Errorf("default: expected s2, got %s",
+			resp.Sessions[0].ID)
+	}
+
+	// Explicit include_one_shot=true: include all.
+	w = te.get(t,
+		"/api/v1/sessions?include_one_shot=true",
+	)
+	assertStatus(t, w, http.StatusOK)
+	resp = decode[sessionListResponse](t, w)
+	if len(resp.Sessions) != 3 {
+		t.Fatalf("include: expected 3 sessions, got %d",
+			len(resp.Sessions))
 	}
 }
 
@@ -2197,7 +2235,9 @@ func TestResyncPreservesDataThroughSwap(t *testing.T) {
 	}
 
 	// Verify sessions are accessible before resync.
-	w := te.get(t, "/api/v1/sessions")
+	w := te.get(t,
+		"/api/v1/sessions?include_one_shot=true",
+	)
 	assertStatus(t, w, http.StatusOK)
 	before := decode[sessionListResponse](t, w)
 	if before.Total != 2 {
@@ -2224,7 +2264,9 @@ func TestResyncPreservesDataThroughSwap(t *testing.T) {
 	}
 
 	// Verify sessions survived the DB swap.
-	w = te.get(t, "/api/v1/sessions")
+	w = te.get(t,
+		"/api/v1/sessions?include_one_shot=true",
+	)
 	assertStatus(t, w, http.StatusOK)
 	after := decode[sessionListResponse](t, w)
 	if after.Total != 2 {
@@ -2250,7 +2292,9 @@ func TestResyncPreservesDataThroughSwap(t *testing.T) {
 	}
 
 	// Verify projects endpoint works (exercises reader pool).
-	projW := te.get(t, "/api/v1/projects")
+	projW := te.get(t,
+		"/api/v1/projects?include_one_shot=true",
+	)
 	assertStatus(t, projW, http.StatusOK)
 	projects := decode[projectListResponse](t, projW)
 	if len(projects.Projects) != 2 {
@@ -2349,7 +2393,9 @@ func TestResyncConcurrentReads(t *testing.T) {
 	// The real assertion: reads must succeed after resync
 	// completes. If the close->reopen cycle left the DB
 	// in a bad state, this will fail.
-	w := te.get(t, "/api/v1/sessions")
+	w := te.get(t,
+		"/api/v1/sessions?include_one_shot=true",
+	)
 	assertStatus(t, w, http.StatusOK)
 	resp := decode[sessionListResponse](t, w)
 	if resp.Total != 1 {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -579,6 +579,10 @@ type uploadResponse struct {
 	Messages  int    `json:"messages"`
 }
 
+type machineListResponse struct {
+	Machines []string `json:"machines"`
+}
+
 type syncResultResponse struct {
 	TotalSessions int `json:"total_sessions"`
 	Synced        int `json:"synced"`
@@ -1197,6 +1201,78 @@ func TestGetStats(t *testing.T) {
 	if resp.MessageCount != 5 {
 		t.Fatalf("expected 5 messages, got %d",
 			resp.MessageCount)
+	}
+}
+
+func TestGetStats_ExcludeOneShotDefault(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "my-app", 5, func(s *db.Session) {
+		s.UserMessageCount = 1
+	})
+	te.seedSession(t, "s2", "my-app", 10, func(s *db.Session) {
+		s.UserMessageCount = 5
+	})
+	te.seedMessages(t, "s1", 5)
+	te.seedMessages(t, "s2", 10)
+
+	// Default: exclude one-shot sessions.
+	w := te.get(t, "/api/v1/stats")
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[db.Stats](t, w)
+	if resp.SessionCount != 1 {
+		t.Errorf("default: session_count = %d, want 1",
+			resp.SessionCount)
+	}
+	if resp.MessageCount != 10 {
+		t.Errorf("default: message_count = %d, want 10",
+			resp.MessageCount)
+	}
+
+	// Explicit include: all sessions.
+	w = te.get(t, "/api/v1/stats?include_one_shot=true")
+	assertStatus(t, w, http.StatusOK)
+	resp = decode[db.Stats](t, w)
+	if resp.SessionCount != 2 {
+		t.Errorf("include: session_count = %d, want 2",
+			resp.SessionCount)
+	}
+	if resp.MessageCount != 15 {
+		t.Errorf("include: message_count = %d, want 15",
+			resp.MessageCount)
+	}
+}
+
+func TestListMachines_ExcludeOneShotDefault(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "my-app", 5, func(s *db.Session) {
+		s.Machine = "laptop"
+		s.UserMessageCount = 1
+	})
+	te.seedSession(t, "s2", "my-app", 10, func(s *db.Session) {
+		s.Machine = "desktop"
+		s.UserMessageCount = 5
+	})
+
+	// Default: exclude one-shot sessions.
+	w := te.get(t, "/api/v1/machines")
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[machineListResponse](t, w)
+	if len(resp.Machines) != 1 {
+		t.Fatalf("default: expected 1 machine, got %d",
+			len(resp.Machines))
+	}
+	if resp.Machines[0] != "desktop" {
+		t.Errorf("default: expected desktop, got %s",
+			resp.Machines[0])
+	}
+
+	// Explicit include: all machines.
+	w = te.get(t, "/api/v1/machines?include_one_shot=true")
+	assertStatus(t, w, http.StatusOK)
+	resp = decode[machineListResponse](t, w)
+	if len(resp.Machines) != 2 {
+		t.Fatalf("include: expected 2 machines, got %d",
+			len(resp.Machines))
 	}
 }
 

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -55,6 +55,8 @@ func (s *Server) handleListSessions(
 		return
 	}
 
+	includeOneShot := q.Get("include_one_shot") == "true"
+
 	filter := db.SessionFilter{
 		Project:         q.Get("project"),
 		ExcludeProject:  q.Get("exclude_project"),
@@ -67,6 +69,7 @@ func (s *Server) handleListSessions(
 		MinMessages:     minMsgs,
 		MaxMessages:     maxMsgs,
 		MinUserMessages: minUserMsgs,
+		ExcludeOneShot:  !includeOneShot,
 		Cursor:          q.Get("cursor"),
 		Limit:           limit,
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -271,7 +271,7 @@ func TestSyncEngineWorktreesShareProject(t *testing.T) {
 	assertSessionProject(t, env.db, "main-repo", "agentsview")
 	assertSessionProject(t, env.db, "worktree-repo", "agentsview")
 
-	projects, err := env.db.GetProjects(context.Background())
+	projects, err := env.db.GetProjects(context.Background(), false)
 	if err != nil {
 		t.Fatalf("GetProjects: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Sessions with `user_message_count <= 1` are now excluded from session lists, analytics, and sidebar project/agent counts by default
- New `include_one_shot` API query param opts in to showing them (`true` = include, absent = exclude)
- New "Include single-turn" toggle in the sidebar filter dropdown and "Single-turn included" chip in the analytics active filters bar
- Sidebar metadata caches (projects, agents) are invalidated when the one-shot filter changes, including through `initFromParams`, `setProjectFilter`, and `clearSessionFilters`
- TopSessions drill-down preserves the `include_one_shot` flag and uses `pendingNavTarget` to survive the route-change reset

## Test plan

- [x] `make test` -- all Go tests pass including new `TestSessionFilterExcludeOneShot` and `TestListSessions_ExcludeOneShotDefault`
- [x] `make vet` -- clean (aside from expected missing `dist/`)
- [x] Frontend `vitest run` -- 648 tests pass
- [x] Frontend `svelte-check` -- no new errors
- [ ] Manual: start server, verify session list excludes single-turn sessions by default
- [ ] Manual: toggle "Include single-turn", verify they appear and sidebar counts update
- [ ] Manual: click a top session in analytics with include-one-shot on, verify it opens in the sessions view

🤖 Generated with [Claude Code](https://claude.com/claude-code)