### PR TITLE
fix: align timestamps between message and tool group headers

### DIFF
--- a/frontend/src/lib/components/content/MessageContent.svelte
+++ b/frontend/src/lib/components/content/MessageContent.svelte
@@ -94,9 +94,6 @@
     >
       {isUser ? "User" : "Assistant"}
     </span>
-    <span class="timestamp">
-      {formatTimestamp(message.timestamp)}
-    </span>
     <button
       type="button"
       class="copy-btn"
@@ -128,6 +125,9 @@
     {#if pinFeedback}
       <span class="pin-feedback">{pinFeedback}</span>
     {/if}
+    <span class="timestamp">
+      {formatTimestamp(message.timestamp)}
+    </span>
   </div>
 
   <div class="message-body">

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -357,7 +357,8 @@
     font-weight: 700;
   }
 
-  .layout-compact :global(.timestamp) {
+  .layout-compact :global(.timestamp),
+  .layout-compact :global(.group-timestamp) {
     font-size: 10px;
   }
 

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -89,9 +89,6 @@
       </svg>
     </span>
     <span class="group-label">{label}</span>
-    <span class="group-timestamp">
-      {formatTimestamp(timestamp)}
-    </span>
     <button
       type="button"
       class="copy-btn"
@@ -109,6 +106,9 @@
         </svg>
       {/if}
     </button>
+    <span class="group-timestamp">
+      {formatTimestamp(timestamp)}
+    </span>
   </div>
 
   <div class="tool-group-body">


### PR DESCRIPTION
## Summary

- Move timestamps to be the last flex item in both `MessageContent` and `ToolCallGroup` headers so `margin-left: auto` pushes them to the same right edge regardless of how many action buttons precede them
- Add `.group-timestamp` to the compact layout font-size override in `MessageList` so both header types use 10px in compact mode

Closes #115

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (648 tests)
- [ ] Visually confirm message and tool group timestamps are horizontally aligned in both default and compact layouts
- [ ] Verify hover action buttons appear without shifting timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)