### PR TITLE
feat(resume): session resume dropdown with terminal launch and directory actions

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -336,6 +336,7 @@ export interface ResumeRequest {
   skip_permissions?: boolean;
   fork_session?: boolean;
   command_only?: boolean;
+  opener_id?: string;
 }
 
 export interface ResumeResponse {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -420,6 +420,14 @@ export async function bulkStarSessions(
   }
 }
 
+/* Session directory */
+
+export function getSessionDirectory(
+  sessionId: string,
+): Promise<{ path: string }> {
+  return fetchJSON(`/sessions/${sessionId}/directory`);
+}
+
 /* Openers — Conductor-style "Open in" */
 
 export interface Opener {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -330,6 +330,33 @@ export function getExportUrl(sessionId: string): string {
   return `${BASE}/sessions/${sessionId}/export`;
 }
 
+/* Resume in terminal */
+
+export interface ResumeRequest {
+  skip_permissions?: boolean;
+  fork_session?: boolean;
+  command_only?: boolean;
+}
+
+export interface ResumeResponse {
+  launched: boolean;
+  terminal?: string;
+  command: string;
+  cwd?: string;
+  error?: string;
+}
+
+export function resumeSession(
+  sessionId: string,
+  flags: ResumeRequest = {},
+): Promise<ResumeResponse> {
+  return fetchJSON(`/sessions/${sessionId}/resume`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(flags),
+  });
+}
+
 /* Publish / GitHub config */
 
 export function publishSession(sessionId: string): Promise<PublishResponse> {
@@ -390,6 +417,62 @@ export async function bulkStarSessions(
     const body = await res.text();
     throw new ApiError(res.status, apiErrorMessage(res.status, body));
   }
+}
+
+/* Openers — Conductor-style "Open in" */
+
+export interface Opener {
+  id: string;
+  name: string;
+  kind: "editor" | "terminal" | "files" | "action";
+  bin: string;
+}
+
+export interface OpenersResponse {
+  openers: Opener[];
+}
+
+export function listOpeners(): Promise<OpenersResponse> {
+  return fetchJSON("/openers");
+}
+
+export interface OpenResponse {
+  launched: boolean;
+  opener: string;
+  path: string;
+}
+
+export function openSession(
+  sessionId: string,
+  openerId: string,
+): Promise<OpenResponse> {
+  return fetchJSON(`/sessions/${sessionId}/open`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ opener_id: openerId }),
+  });
+}
+
+/* Terminal config */
+
+export interface TerminalConfig {
+  mode: "auto" | "custom" | "clipboard";
+  custom_bin?: string;
+  custom_args?: string;
+}
+
+export function getTerminalConfig(): Promise<TerminalConfig> {
+  return fetchJSON("/config/terminal");
+}
+
+export function setTerminalConfig(
+  cfg: TerminalConfig,
+): Promise<TerminalConfig> {
+  return fetchJSON("/config/terminal", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(cfg),
+  });
 }
 
 /* Analytics */

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -33,10 +33,20 @@
   let openers: Opener[] = $state([]);
   let openFeedback = $state("");
   let feedbackTimer: ReturnType<typeof setTimeout> | undefined;
+  let sessionDir = $state<string | null>(null);
 
   onMount(() => {
     listOpeners()
       .then((res) => { openers = res.openers; })
+      .catch(() => {});
+  });
+
+  $effect(() => {
+    sessionDir = null;
+    if (!session) return;
+    const id = session.id;
+    getSessionDirectory(id)
+      .then(({ path }) => { sessionDir = path; })
       .catch(() => {});
   });
 
@@ -158,15 +168,13 @@
   }
 
   async function handleCopyFilePath() {
-    if (!session) return;
     showOpenMenu = false;
-    try {
-      const { path } = await getSessionDirectory(session.id);
-      const ok = await copyToClipboard(path);
-      showFeedback(ok ? "Path copied!" : "Failed");
-    } catch {
+    if (!sessionDir) {
       showFeedback("No path available");
+      return;
     }
+    const ok = await copyToClipboard(sessionDir);
+    showFeedback(ok ? "Path copied!" : "Failed");
   }
 
   async function handleOpenIn(opener: Opener) {
@@ -224,9 +232,12 @@
     openers.filter((o) => o.kind === "files"),
   );
 
-  // Always show for any session — at minimum "Copy directory
-  // path" is available via the server-side resolution endpoint.
-  const showDropdown = $derived(!!session);
+  const showDropdown = $derived(
+    canResume ||
+    editorOpeners.length > 0 ||
+    fileOpeners.length > 0 ||
+    sessionDir !== null,
+  );
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -46,7 +46,9 @@
     if (!session) return;
     const id = session.id;
     getSessionDirectory(id)
-      .then(({ path }) => { sessionDir = path || null; })
+      .then(({ path }) => {
+        if (session?.id === id) sessionDir = path || null;
+      })
       .catch(() => {});
   });
 

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -159,24 +159,28 @@
   async function handleCopyFilePath() {
     if (!session) return;
     showOpenMenu = false;
-    try {
-      const resp = await resumeSession(
-        session.id, { command_only: true },
-      );
-      if (resp.cwd) {
-        const ok = await copyToClipboard(resp.cwd);
-        showFeedback(ok ? "Path copied!" : "Failed");
-        return;
-      }
-    } catch {
-      // Fall back to session project field.
-    }
+    // Use session.project directly if it's an absolute path.
     if (session.project?.startsWith("/")) {
       const ok = await copyToClipboard(session.project);
       showFeedback(ok ? "Path copied!" : "Failed");
-    } else {
-      showFeedback("No path available");
+      return;
     }
+    // Otherwise try the resume API for resolved cwd.
+    if (canResume) {
+      try {
+        const resp = await resumeSession(
+          session.id, { command_only: true },
+        );
+        if (resp.cwd) {
+          const ok = await copyToClipboard(resp.cwd);
+          showFeedback(ok ? "Path copied!" : "Failed");
+          return;
+        }
+      } catch {
+        // No cwd available.
+      }
+    }
+    showFeedback("No path available");
   }
 
   async function handleOpenIn(opener: Opener) {
@@ -187,6 +191,34 @@
       showFeedback(`Opened in ${opener.name}`);
     } catch {
       showFeedback("Failed to open");
+    }
+  }
+
+  async function handleResumeDefault() {
+    if (!session) return;
+    showOpenMenu = false;
+    try {
+      const resp = await resumeSession(session.id, {});
+      if (resp.launched) {
+        showFeedback(
+          `Resumed in ${resp.terminal ?? "terminal"}`,
+        );
+        return;
+      }
+      if (resp.command) {
+        const ok = await copyToClipboard(resp.command);
+        showFeedback(ok ? "Command copied!" : "Failed");
+        return;
+      }
+    } catch {
+      // Fall back to local command build.
+    }
+    const cmd = buildResumeCommand(session.agent, session.id);
+    if (cmd) {
+      const ok = await copyToClipboard(cmd);
+      showFeedback(ok ? "Command copied!" : "Failed");
+    } else {
+      showFeedback("Not supported");
     }
   }
 
@@ -204,6 +236,17 @@
 
   const fileOpeners = $derived(
     openers.filter((o) => o.kind === "files"),
+  );
+
+  const hasProjectDir = $derived(
+    session?.project?.startsWith("/") ?? false,
+  );
+
+  const showDropdown = $derived(
+    canResume ||
+    editorOpeners.length > 0 ||
+    fileOpeners.length > 0 ||
+    hasProjectDir,
   );
 
   function handleKeydown(e: KeyboardEvent) {
@@ -295,14 +338,14 @@
           )}
         </span>
       {/if}
-      {#if canResume}
+      {#if showDropdown}
         <span class="open-group">
           <button
             class="resume-btn"
             class:has-feedback={openFeedback !== ""}
             onclick={(e) => { e.stopPropagation(); showOpenMenu = !showOpenMenu; }}
-            title="Resume session in terminal"
-            aria-label="Resume session"
+            title={canResume ? "Resume session in terminal" : "Session actions"}
+            aria-label={canResume ? "Resume session" : "Session actions"}
           >
             {#if openFeedback}
               <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -310,7 +353,7 @@
               </svg>
               {openFeedback}
             {:else}
-              Resume
+              {canResume ? "Resume" : "Open"}
               <svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                 <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"/>
               </svg>
@@ -318,27 +361,35 @@
           </button>
           {#if showOpenMenu}
             <div class="open-menu">
-              {#each terminalOpeners as opener, i (opener.id)}
-                <button
-                  class="open-menu-item"
-                  onclick={() => handleResumeIn(opener)}
-                >
-                  <span class="open-menu-num">{i + 1}</span>
-                  <span class="open-menu-name">{opener.name}</span>
+              {#if canResume}
+                {#each terminalOpeners as opener, i (opener.id)}
+                  <button
+                    class="open-menu-item"
+                    onclick={() => handleResumeIn(opener)}
+                  >
+                    <span class="open-menu-num">{i + 1}</span>
+                    <span class="open-menu-name">{opener.name}</span>
+                  </button>
+                {/each}
+                <button class="open-menu-item" onclick={handleResumeDefault}>
+                  <span class="open-menu-num">
+                    <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v3.585a.746.746 0 010 .83v3.585a.747.747 0 010 .83v3.67A1.75 1.75 0 0114.25 16H1.75A1.75 1.75 0 010 14.25V1.75zM1.5 6.5v3h13v-3h-13zm0 4.5v3.25c0 .138.112.25.25.25h12.5a.25.25 0 00.25-.25V11h-13zm13-5.5v-3.25a.25.25 0 00-.25-.25H1.75a.25.25 0 00-.25.25V5.5h13z"/>
+                    </svg>
+                  </span>
+                  <span class="open-menu-name">Default terminal</span>
                 </button>
-              {/each}
-              {#if terminalOpeners.length > 0}
                 <div class="open-menu-divider"></div>
+                <button class="open-menu-item" onclick={handleCopyResumeCommand}>
+                  <span class="open-menu-num">
+                    <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
+                      <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
+                    </svg>
+                  </span>
+                  <span class="open-menu-name">Copy command</span>
+                </button>
               {/if}
-              <button class="open-menu-item" onclick={handleCopyResumeCommand}>
-                <span class="open-menu-num">
-                  <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
-                    <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
-                  </svg>
-                </span>
-                <span class="open-menu-name">Copy command</span>
-              </button>
               <button class="open-menu-item" onclick={handleCopyFilePath}>
                 <span class="open-menu-num">
                   <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
@@ -347,9 +398,6 @@
                 </span>
                 <span class="open-menu-name">Copy directory path</span>
               </button>
-              {#if terminalOpeners.length === 0}
-                <div class="open-menu-empty">No terminals detected</div>
-              {/if}
               {#if editorOpeners.length > 0 || fileOpeners.length > 0}
                 <div class="open-menu-divider"></div>
                 <div class="open-menu-section">Open in</div>

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -4,7 +4,6 @@
   import {
     resumeSession,
     listOpeners,
-    openSession,
     type Opener,
   } from "../../api/client.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
@@ -105,51 +104,18 @@
     feedbackTimer = setTimeout(() => { openFeedback = ""; }, 2000);
   }
 
-  async function handleOpen(opener: Opener) {
+  async function handleResumeIn(opener: Opener) {
     if (!session) return;
     showOpenMenu = false;
     try {
-      const resp = await openSession(session.id, opener.id);
+      const resp = await resumeSession(session.id, {
+        opener_id: opener.id,
+      });
       if (resp.launched) {
-        showFeedback(`Opened in ${opener.name}`);
-      }
-    } catch {
-      showFeedback("Failed to open");
-    }
-  }
-
-  async function handleCopyPath() {
-    if (!session) return;
-    showOpenMenu = false;
-    try {
-      const resp = await resumeSession(session.id, { command_only: true });
-      if (resp.cwd) {
-        const ok = await copyToClipboard(resp.cwd);
-        showFeedback(ok ? "Path copied!" : "Failed");
+        showFeedback(`Resumed in ${resp.terminal ?? opener.name}`);
         return;
       }
-    } catch {
-      // Fall through to project field.
-    }
-    const fallback = session.project || "";
-    if (fallback.startsWith("/")) {
-      const ok = await copyToClipboard(fallback);
-      showFeedback(ok ? "Path copied!" : "Failed");
-    } else {
-      showFeedback("No project path");
-    }
-  }
-
-  async function handleResumeInTerminal() {
-    if (!session) return;
-    showOpenMenu = false;
-    try {
-      const resp = await resumeSession(session.id);
-      if (resp.launched) {
-        showFeedback(`Launched in ${resp.terminal ?? "terminal"}`);
-        return;
-      }
-      // Launch not possible — copy command to clipboard instead.
+      // Launch failed — fall back to clipboard copy.
       if (resp.command) {
         const ok = await copyToClipboard(resp.command);
         showFeedback(ok ? "Command copied!" : "Failed");
@@ -193,10 +159,9 @@
     session ? supportsResume(session.agent) : false,
   );
 
-  // Group openers by kind for display order.
-  const fileOpeners = $derived(openers.filter((o) => o.kind === "files"));
-  const editorOpeners = $derived(openers.filter((o) => o.kind === "editor"));
-  const terminalOpeners = $derived(openers.filter((o) => o.kind === "terminal"));
+  const terminalOpeners = $derived(
+    openers.filter((o) => o.kind === "terminal"),
+  );
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
@@ -214,11 +179,10 @@
       // Number key shortcuts (1-9) for quick selection.
       const num = parseInt(e.key);
       if (num >= 1 && num <= 9) {
-        const all = [...fileOpeners, ...editorOpeners, ...terminalOpeners];
         const idx = num - 1;
-        if (idx < all.length) {
+        if (idx < terminalOpeners.length) {
           e.preventDefault();
-          handleOpen(all[idx]);
+          handleResumeIn(terminalOpeners[idx]);
         }
       }
     }
@@ -288,80 +252,57 @@
           )}
         </span>
       {/if}
-      <span class="open-group">
-        <button
-          class="open-btn"
-          class:has-feedback={openFeedback !== ""}
-          onclick={(e) => { e.stopPropagation(); showOpenMenu = !showOpenMenu; }}
-          title="Open project in..."
-          aria-label="Open project"
-        >
-          {#if openFeedback}
-            <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/>
-            </svg>
-            {openFeedback}
-          {:else}
-            Open
-            <svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"/>
-            </svg>
-          {/if}
-        </button>
-        {#if showOpenMenu}
-          {@const allOpeners = [...fileOpeners, ...editorOpeners, ...terminalOpeners]}
-          <div class="open-menu">
-            {#each allOpeners as opener, i (opener.id)}
-              <button
-                class="open-menu-item"
-                onclick={() => handleOpen(opener)}
-              >
-                <span class="open-menu-num">{i + 1}</span>
-                <span class="open-menu-name">{opener.name}</span>
-                <span class="open-menu-kind">{opener.kind}</span>
-              </button>
-            {/each}
-            {#if allOpeners.length > 0}
-              <div class="open-menu-divider"></div>
+      {#if canResume}
+        <span class="open-group">
+          <button
+            class="resume-btn"
+            class:has-feedback={openFeedback !== ""}
+            onclick={(e) => { e.stopPropagation(); showOpenMenu = !showOpenMenu; }}
+            title="Resume session in terminal"
+            aria-label="Resume session"
+          >
+            {#if openFeedback}
+              <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/>
+              </svg>
+              {openFeedback}
+            {:else}
+              Resume
+              <svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"/>
+              </svg>
             {/if}
-            {#if canResume}
-              <button class="open-menu-item" onclick={handleResumeInTerminal}>
-                <span class="open-menu-num">
-                  <!-- terminal icon -->
-                  <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0114.25 15H1.75A1.75 1.75 0 010 13.25V2.75zm1.75-.25a.25.25 0 00-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 00.25-.25V2.75a.25.25 0 00-.25-.25H1.75z"/>
-                    <path d="M3.17 5.47a.75.75 0 011.06 0L6.53 7.77a.75.75 0 010 1.06L4.23 11.13a.75.75 0 01-1.06-1.06L5.44 7.8 3.17 6.53a.75.75 0 010-1.06zM7 10.25a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5h-3.5a.75.75 0 01-.75-.75z"/>
-                  </svg>
-                </span>
-                <span class="open-menu-name">Resume in terminal</span>
-              </button>
+          </button>
+          {#if showOpenMenu}
+            <div class="open-menu">
+              {#each terminalOpeners as opener, i (opener.id)}
+                <button
+                  class="open-menu-item"
+                  onclick={() => handleResumeIn(opener)}
+                >
+                  <span class="open-menu-num">{i + 1}</span>
+                  <span class="open-menu-name">{opener.name}</span>
+                </button>
+              {/each}
+              {#if terminalOpeners.length > 0}
+                <div class="open-menu-divider"></div>
+              {/if}
               <button class="open-menu-item" onclick={handleCopyResumeCommand}>
                 <span class="open-menu-num">
-                  <!-- copy icon -->
                   <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
                     <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
                   </svg>
                 </span>
-                <span class="open-menu-name">Copy resume command</span>
+                <span class="open-menu-name">Copy command</span>
               </button>
-            {/if}
-            <button class="open-menu-item" onclick={handleCopyPath}>
-              <span class="open-menu-num">
-                <!-- copy icon -->
-                <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
-                  <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
-                </svg>
-              </span>
-              <span class="open-menu-name">Copy path</span>
-            </button>
-            {#if openers.length === 0}
-              <div class="open-menu-empty">No applications detected</div>
-            {/if}
-          </div>
-        {/if}
-      </span>
+              {#if terminalOpeners.length === 0}
+                <div class="open-menu-empty">No terminals detected</div>
+              {/if}
+            </div>
+          {/if}
+        </span>
+      {/if}
       {#if session.id}
         {@const rawId = sessionDisplayId(session.id)}
         <button
@@ -502,7 +443,7 @@
     flex-shrink: 0;
   }
 
-  .open-btn {
+  .resume-btn {
     display: flex;
     align-items: center;
     gap: 4px;
@@ -518,12 +459,12 @@
     transition: color 0.15s, background 0.15s;
   }
 
-  .open-btn:hover {
+  .resume-btn:hover {
     color: var(--text-secondary);
     background: var(--bg-surface-hover);
   }
 
-  .open-btn.has-feedback {
+  .resume-btn.has-feedback {
     color: var(--accent-green, #2ea043);
   }
 
@@ -572,15 +513,6 @@
   .open-menu-name {
     flex: 1;
     font-weight: 500;
-  }
-
-  .open-menu-kind {
-    font-size: 9px;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--text-muted);
-    opacity: 0.6;
   }
 
   .open-menu-divider {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -3,6 +3,7 @@
   import type { Session } from "../../api/types.js";
   import {
     resumeSession,
+    openSession,
     listOpeners,
     type Opener,
   } from "../../api/client.js";
@@ -155,12 +156,54 @@
     }
   }
 
+  async function handleCopyFilePath() {
+    if (!session) return;
+    showOpenMenu = false;
+    try {
+      const resp = await resumeSession(
+        session.id, { command_only: true },
+      );
+      if (resp.cwd) {
+        const ok = await copyToClipboard(resp.cwd);
+        showFeedback(ok ? "Path copied!" : "Failed");
+        return;
+      }
+    } catch {
+      // Fall back to session project field.
+    }
+    if (session.project?.startsWith("/")) {
+      const ok = await copyToClipboard(session.project);
+      showFeedback(ok ? "Path copied!" : "Failed");
+    } else {
+      showFeedback("No path available");
+    }
+  }
+
+  async function handleOpenIn(opener: Opener) {
+    if (!session) return;
+    showOpenMenu = false;
+    try {
+      await openSession(session.id, opener.id);
+      showFeedback(`Opened in ${opener.name}`);
+    } catch {
+      showFeedback("Failed to open");
+    }
+  }
+
   const canResume = $derived(
     session ? supportsResume(session.agent) : false,
   );
 
   const terminalOpeners = $derived(
     openers.filter((o) => o.kind === "terminal"),
+  );
+
+  const editorOpeners = $derived(
+    openers.filter((o) => o.kind === "editor"),
+  );
+
+  const fileOpeners = $derived(
+    openers.filter((o) => o.kind === "files"),
   );
 
   function handleKeydown(e: KeyboardEvent) {
@@ -182,7 +225,7 @@
         const idx = num - 1;
         if (idx < terminalOpeners.length) {
           e.preventDefault();
-          handleResumeIn(terminalOpeners[idx]);
+          handleResumeIn(terminalOpeners[idx]!);
         }
       }
     }
@@ -296,8 +339,47 @@
                 </span>
                 <span class="open-menu-name">Copy command</span>
               </button>
+              <button class="open-menu-item" onclick={handleCopyFilePath}>
+                <span class="open-menu-num">
+                  <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                    <path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6H9.75A1.75 1.75 0 018 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v9.086A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75z"/>
+                  </svg>
+                </span>
+                <span class="open-menu-name">Copy file path</span>
+              </button>
               {#if terminalOpeners.length === 0}
                 <div class="open-menu-empty">No terminals detected</div>
+              {/if}
+              {#if editorOpeners.length > 0 || fileOpeners.length > 0}
+                <div class="open-menu-divider"></div>
+                <div class="open-menu-section">Open in</div>
+                {#each editorOpeners as opener (opener.id)}
+                  <button
+                    class="open-menu-item"
+                    onclick={() => handleOpenIn(opener)}
+                  >
+                    <span class="open-menu-num">
+                      <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M4.708 5.578L2.061 8.224l2.647 2.646-.708.708L.94 8.578V7.87L4 4.87l.708.708zm7.292 0l2.647 2.646-2.647 2.646.708.708L15.768 8.578V7.87L12.708 4.87 12 5.578z"/>
+                        <path d="M5.708 13.578L9.258 2.578l.984.344-3.55 11-.984-.344z"/>
+                      </svg>
+                    </span>
+                    <span class="open-menu-name">{opener.name}</span>
+                  </button>
+                {/each}
+                {#each fileOpeners as opener (opener.id)}
+                  <button
+                    class="open-menu-item"
+                    onclick={() => handleOpenIn(opener)}
+                  >
+                    <span class="open-menu-num">
+                      <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                        <path d="M1.75 1A1.75 1.75 0 000 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0016 13.25v-8.5A1.75 1.75 0 0014.25 3H7.5a.25.25 0 01-.2-.1l-.9-1.2C6.07 1.26 5.55 1 5 1H1.75z"/>
+                      </svg>
+                    </span>
+                    <span class="open-menu-name">{opener.name}</span>
+                  </button>
+                {/each}
               {/if}
             </div>
           {/if}
@@ -519,6 +601,15 @@
     height: 1px;
     background: var(--border-muted);
     margin: 4px 0;
+  }
+
+  .open-menu-section {
+    padding: 4px 10px 2px;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
 
   .open-menu-empty {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -224,16 +224,9 @@
     openers.filter((o) => o.kind === "files"),
   );
 
-  const hasProjectDir = $derived(
-    session?.project?.startsWith("/") ?? false,
-  );
-
-  const showDropdown = $derived(
-    canResume ||
-    editorOpeners.length > 0 ||
-    fileOpeners.length > 0 ||
-    hasProjectDir,
-  );
+  // Always show for any session — at minimum "Copy directory
+  // path" is available via the server-side resolution endpoint.
+  const showDropdown = $derived(!!session);
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -4,6 +4,7 @@
   import {
     resumeSession,
     openSession,
+    getSessionDirectory,
     listOpeners,
     type Opener,
   } from "../../api/client.js";
@@ -159,28 +160,13 @@
   async function handleCopyFilePath() {
     if (!session) return;
     showOpenMenu = false;
-    // Use session.project directly if it's an absolute path.
-    if (session.project?.startsWith("/")) {
-      const ok = await copyToClipboard(session.project);
+    try {
+      const { path } = await getSessionDirectory(session.id);
+      const ok = await copyToClipboard(path);
       showFeedback(ok ? "Path copied!" : "Failed");
-      return;
+    } catch {
+      showFeedback("No path available");
     }
-    // Otherwise try the resume API for resolved cwd.
-    if (canResume) {
-      try {
-        const resp = await resumeSession(
-          session.id, { command_only: true },
-        );
-        if (resp.cwd) {
-          const ok = await copyToClipboard(resp.cwd);
-          showFeedback(ok ? "Path copied!" : "Failed");
-          return;
-        }
-      } catch {
-        // No cwd available.
-      }
-    }
-    showFeedback("No path available");
   }
 
   async function handleOpenIn(opener: Opener) {
@@ -660,12 +646,6 @@
     letter-spacing: 0.04em;
   }
 
-  .open-menu-empty {
-    padding: 8px 10px;
-    font-size: 11px;
-    color: var(--text-muted);
-    text-align: center;
-  }
 
   .session-id {
     font-size: 10px;

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -46,7 +46,7 @@
     if (!session) return;
     const id = session.id;
     getSessionDirectory(id)
-      .then(({ path }) => { sessionDir = path; })
+      .then(({ path }) => { sessionDir = path || null; })
       .catch(() => {});
   });
 

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -520,7 +520,7 @@
 
   .open-btn:hover {
     color: var(--text-secondary);
-    background: var(--bg-hover);
+    background: var(--bg-surface-hover);
   }
 
   .open-btn.has-feedback {
@@ -555,7 +555,7 @@
   }
 
   .open-menu-item:hover {
-    background: var(--bg-hover);
+    background: var(--bg-surface-hover);
   }
 
   .open-menu-num {
@@ -611,7 +611,7 @@
 
   .session-id:hover {
     color: var(--text-secondary);
-    background: var(--bg-hover);
+    background: var(--bg-surface-hover);
   }
 
   .actions-wrapper {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -345,7 +345,7 @@
                     <path fill-rule="evenodd" d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6H9.75A1.75 1.75 0 018 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v9.086A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75z"/>
                   </svg>
                 </span>
-                <span class="open-menu-name">Copy file path</span>
+                <span class="open-menu-name">Copy directory path</span>
               </button>
               {#if terminalOpeners.length === 0}
                 <div class="open-menu-empty">No terminals detected</div>

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -140,6 +140,33 @@
     }
   }
 
+  async function handleResumeInTerminal() {
+    if (!session) return;
+    showOpenMenu = false;
+    try {
+      const resp = await resumeSession(session.id);
+      if (resp.launched) {
+        showFeedback(`Launched in ${resp.terminal ?? "terminal"}`);
+        return;
+      }
+      // Launch not possible — copy command to clipboard instead.
+      if (resp.command) {
+        const ok = await copyToClipboard(resp.command);
+        showFeedback(ok ? "Command copied!" : "Failed");
+        return;
+      }
+    } catch {
+      // Fall back to local command build.
+    }
+    const cmd = buildResumeCommand(session.agent, session.id);
+    if (cmd) {
+      const ok = await copyToClipboard(cmd);
+      showFeedback(ok ? "Command copied!" : "Failed");
+    } else {
+      showFeedback("Not supported");
+    }
+  }
+
   async function handleCopyResumeCommand() {
     if (!session) return;
     showOpenMenu = false;
@@ -298,7 +325,7 @@
               <div class="open-menu-divider"></div>
             {/if}
             {#if canResume}
-              <button class="open-menu-item" onclick={handleCopyResumeCommand}>
+              <button class="open-menu-item" onclick={handleResumeInTerminal}>
                 <span class="open-menu-num">
                   <!-- terminal icon -->
                   <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
@@ -306,7 +333,17 @@
                     <path d="M3.17 5.47a.75.75 0 011.06 0L6.53 7.77a.75.75 0 010 1.06L4.23 11.13a.75.75 0 01-1.06-1.06L5.44 7.8 3.17 6.53a.75.75 0 010-1.06zM7 10.25a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5h-3.5a.75.75 0 01-.75-.75z"/>
                   </svg>
                 </span>
-                <span class="open-menu-name">Resume command</span>
+                <span class="open-menu-name">Resume in terminal</span>
+              </button>
+              <button class="open-menu-item" onclick={handleCopyResumeCommand}>
+                <span class="open-menu-num">
+                  <!-- copy icon -->
+                  <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
+                    <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
+                  </svg>
+                </span>
+                <span class="open-menu-name">Copy resume command</span>
               </button>
             {/if}
             <button class="open-menu-item" onclick={handleCopyPath}>

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -1,8 +1,19 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import type { Session } from "../../api/types.js";
+  import {
+    resumeSession,
+    listOpeners,
+    openSession,
+    type Opener,
+  } from "../../api/client.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
   import { agentColor } from "../../utils/agents.js";
   import { sessions } from "../../stores/sessions.svelte.js";
+  import {
+    supportsResume,
+    buildResumeCommand,
+  } from "../../utils/resume.js";
 
   interface Props {
     session: Session | undefined;
@@ -17,6 +28,16 @@
   let renameInput = $state<HTMLInputElement | null>(null);
   let menuBtnEl = $state<HTMLButtonElement | null>(null);
   let menuEl = $state<HTMLDivElement | null>(null);
+  let showOpenMenu = $state(false);
+  let openers: Opener[] = $state([]);
+  let openFeedback = $state("");
+  let feedbackTimer: ReturnType<typeof setTimeout> | undefined;
+
+  onMount(() => {
+    listOpeners()
+      .then((res) => { openers = res.openers; })
+      .catch(() => {});
+  });
 
   function sessionDisplayId(id: string): string {
     const idx = id.indexOf(":");
@@ -29,12 +50,12 @@
   ) {
     const ok = await copyToClipboard(rawId);
     if (!ok) return;
-
     copiedSessionId = sessionId;
     setTimeout(() => {
       if (copiedSessionId === sessionId) copiedSessionId = "";
     }, 1500);
   }
+
 
   function toggleMenu() {
     menuOpen = !menuOpen;
@@ -78,26 +99,119 @@
     }
   }
 
+  function showFeedback(msg: string) {
+    openFeedback = msg;
+    clearTimeout(feedbackTimer);
+    feedbackTimer = setTimeout(() => { openFeedback = ""; }, 2000);
+  }
+
+  async function handleOpen(opener: Opener) {
+    if (!session) return;
+    showOpenMenu = false;
+    try {
+      const resp = await openSession(session.id, opener.id);
+      if (resp.launched) {
+        showFeedback(`Opened in ${opener.name}`);
+      }
+    } catch {
+      showFeedback("Failed to open");
+    }
+  }
+
+  async function handleCopyPath() {
+    if (!session) return;
+    showOpenMenu = false;
+    try {
+      const resp = await resumeSession(session.id, { command_only: true });
+      if (resp.cwd) {
+        const ok = await copyToClipboard(resp.cwd);
+        showFeedback(ok ? "Path copied!" : "Failed");
+        return;
+      }
+    } catch {
+      // Fall through to project field.
+    }
+    const fallback = session.project || "";
+    if (fallback.startsWith("/")) {
+      const ok = await copyToClipboard(fallback);
+      showFeedback(ok ? "Path copied!" : "Failed");
+    } else {
+      showFeedback("No project path");
+    }
+  }
+
+  async function handleCopyResumeCommand() {
+    if (!session) return;
+    showOpenMenu = false;
+    try {
+      const resp = await resumeSession(session.id, { command_only: true });
+      if (resp.command) {
+        const ok = await copyToClipboard(resp.command);
+        showFeedback(ok ? "Command copied!" : "Failed");
+        return;
+      }
+    } catch {
+      // Fall back to local build.
+    }
+    const cmd = buildResumeCommand(session.agent, session.id);
+    if (cmd) {
+      const ok = await copyToClipboard(cmd);
+      showFeedback(ok ? "Command copied!" : "Failed");
+    } else {
+      showFeedback("Not supported");
+    }
+  }
+
+  const canResume = $derived(
+    session ? supportsResume(session.agent) : false,
+  );
+
+  // Group openers by kind for display order.
+  const fileOpeners = $derived(openers.filter((o) => o.kind === "files"));
+  const editorOpeners = $derived(openers.filter((o) => o.kind === "editor"));
+  const terminalOpeners = $derived(openers.filter((o) => o.kind === "terminal"));
+
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
       if (renaming) {
         cancelRename();
       } else if (menuOpen) {
         closeMenu();
+      } else if (showOpenMenu) {
+        showOpenMenu = false;
+        e.preventDefault();
+      }
+      return;
+    }
+    if (showOpenMenu) {
+      // Number key shortcuts (1-9) for quick selection.
+      const num = parseInt(e.key);
+      if (num >= 1 && num <= 9) {
+        const all = [...fileOpeners, ...editorOpeners, ...terminalOpeners];
+        const idx = num - 1;
+        if (idx < all.length) {
+          e.preventDefault();
+          handleOpen(all[idx]);
+        }
       }
     }
   }
 
   function handleClickOutside(e: MouseEvent) {
-    if (!menuOpen) return;
     const target = e.target as Node;
-    if (
-      menuEl?.contains(target) ||
-      menuBtnEl?.contains(target)
-    ) {
-      return;
+    // Close actions menu
+    if (menuOpen) {
+      if (
+        !menuEl?.contains(target) &&
+        !menuBtnEl?.contains(target)
+      ) {
+        closeMenu();
+      }
     }
-    closeMenu();
+    // Close open menu
+    if (!(target as HTMLElement).closest?.(".open-group")) {
+      showOpenMenu = false;
+    }
   }
 </script>
 
@@ -105,6 +219,7 @@
   onkeydown={handleKeydown}
   onclick={handleClickOutside}
 />
+
 
 <div class="session-breadcrumb">
   <button class="breadcrumb-link" onclick={onBack}>
@@ -146,6 +261,70 @@
           )}
         </span>
       {/if}
+      <span class="open-group">
+        <button
+          class="open-btn"
+          class:has-feedback={openFeedback !== ""}
+          onclick={(e) => { e.stopPropagation(); showOpenMenu = !showOpenMenu; }}
+          title="Open project in..."
+          aria-label="Open project"
+        >
+          {#if openFeedback}
+            <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/>
+            </svg>
+            {openFeedback}
+          {:else}
+            Open
+            <svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"/>
+            </svg>
+          {/if}
+        </button>
+        {#if showOpenMenu}
+          {@const allOpeners = [...fileOpeners, ...editorOpeners, ...terminalOpeners]}
+          <div class="open-menu">
+            {#each allOpeners as opener, i (opener.id)}
+              <button
+                class="open-menu-item"
+                onclick={() => handleOpen(opener)}
+              >
+                <span class="open-menu-num">{i + 1}</span>
+                <span class="open-menu-name">{opener.name}</span>
+                <span class="open-menu-kind">{opener.kind}</span>
+              </button>
+            {/each}
+            {#if allOpeners.length > 0}
+              <div class="open-menu-divider"></div>
+            {/if}
+            {#if canResume}
+              <button class="open-menu-item" onclick={handleCopyResumeCommand}>
+                <span class="open-menu-num">
+                  <!-- terminal icon -->
+                  <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0114.25 15H1.75A1.75 1.75 0 010 13.25V2.75zm1.75-.25a.25.25 0 00-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 00.25-.25V2.75a.25.25 0 00-.25-.25H1.75z"/>
+                    <path d="M3.17 5.47a.75.75 0 011.06 0L6.53 7.77a.75.75 0 010 1.06L4.23 11.13a.75.75 0 01-1.06-1.06L5.44 7.8 3.17 6.53a.75.75 0 010-1.06zM7 10.25a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5h-3.5a.75.75 0 01-.75-.75z"/>
+                  </svg>
+                </span>
+                <span class="open-menu-name">Resume command</span>
+              </button>
+            {/if}
+            <button class="open-menu-item" onclick={handleCopyPath}>
+              <span class="open-menu-num">
+                <!-- copy icon -->
+                <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"/>
+                  <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"/>
+                </svg>
+              </span>
+              <span class="open-menu-name">Copy path</span>
+            </button>
+            {#if openers.length === 0}
+              <div class="open-menu-empty">No applications detected</div>
+            {/if}
+          </div>
+        {/if}
+      </span>
       {#if session.id}
         {@const rawId = sessionDisplayId(session.id)}
         <button
@@ -277,6 +456,107 @@
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     flex-shrink: 0;
+  }
+
+  .open-group {
+    position: relative;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .open-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--text-muted);
+    padding: 1px 8px;
+    border-radius: 4px;
+    background: var(--bg-tertiary);
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .open-btn:hover {
+    color: var(--text-secondary);
+    background: var(--bg-hover);
+  }
+
+  .open-btn.has-feedback {
+    color: var(--accent-green, #2ea043);
+  }
+
+  .open-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-default);
+    border-radius: 8px;
+    padding: 4px;
+    min-width: 200px;
+    z-index: 100;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  }
+
+  .open-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 6px 10px;
+    font-size: 13px;
+    color: var(--text-primary);
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .open-menu-item:hover {
+    background: var(--bg-hover);
+  }
+
+  .open-menu-num {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .open-menu-name {
+    flex: 1;
+    font-weight: 500;
+  }
+
+  .open-menu-kind {
+    font-size: 9px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    opacity: 0.6;
+  }
+
+  .open-menu-divider {
+    height: 1px;
+    background: var(--border-muted);
+    margin: 4px 0;
+  }
+
+  .open-menu-empty {
+    padding: 8px 10px;
+    font-size: 11px;
+    color: var(--text-muted);
+    text-align: center;
   }
 
   .session-id {

--- a/frontend/src/lib/components/modals/ShortcutsModal.svelte
+++ b/frontend/src/lib/components/modals/ShortcutsModal.svelte
@@ -14,7 +14,7 @@
     { key: "s", action: "Star / unstar session" },
     { key: "e", action: "Export session" },
     { key: "p", action: "Publish to Gist" },
-    { key: "c", action: "Resume session in terminal" },
+    { key: "c", action: "Copy resume command" },
     { key: "?", action: "Show this modal" },
   ];
 

--- a/frontend/src/lib/components/modals/ShortcutsModal.svelte
+++ b/frontend/src/lib/components/modals/ShortcutsModal.svelte
@@ -14,6 +14,7 @@
     { key: "s", action: "Star / unstar session" },
     { key: "e", action: "Export session" },
     { key: "p", action: "Publish to Gist" },
+    { key: "c", action: "Resume session in terminal" },
     { key: "?", action: "Show this modal" },
   ];
 

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,7 +1,27 @@
 export async function copyToClipboard(text: string): Promise<boolean> {
+  // Try the modern Clipboard API first (requires secure context).
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to legacy method.
+    }
+  }
+
+  // Legacy fallback for non-secure contexts (HTTP over LAN, SSH tunnels).
   try {
-    await navigator.clipboard.writeText(text);
-    return true;
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.top = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
   } catch {
     return false;
   }

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -2,7 +2,12 @@ import { ui } from "../stores/ui.svelte.js";
 import { sessions } from "../stores/sessions.svelte.js";
 import { starred } from "../stores/starred.svelte.js";
 import { sync } from "../stores/sync.svelte.js";
-import { getExportUrl } from "../api/client.js";
+import {
+  getExportUrl,
+  resumeSession,
+} from "../api/client.js";
+import { supportsResume, buildResumeCommand } from "./resume.js";
+import { copyToClipboard } from "./clipboard.js";
 
 function isInputFocused(): boolean {
   const el = document.activeElement;
@@ -99,6 +104,26 @@ export function registerShortcuts(
       s: () => {
         if (sessions.activeSessionId) {
           starred.toggle(sessions.activeSessionId);
+        }
+      },
+      c: () => {
+        const session = sessions.activeSession;
+        if (session && supportsResume(session.agent)) {
+          // Copy resume command to clipboard. Use backend-built command
+          // (includes cd to project dir) with local fallback.
+          resumeSession(session.id, { command_only: true }).then((resp) => {
+            const cmd = resp.command || buildResumeCommand(
+              session.agent,
+              session.id,
+            );
+            if (cmd) copyToClipboard(cmd);
+          }).catch(() => {
+            const cmd = buildResumeCommand(
+              session.agent,
+              session.id,
+            );
+            if (cmd) copyToClipboard(cmd);
+          });
         }
       },
       "?": () => {

--- a/frontend/src/lib/utils/resume.test.ts
+++ b/frontend/src/lib/utils/resume.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildResumeCommand,
+  supportsResume,
+} from "./resume.js";
+
+describe("supportsResume", () => {
+  it("returns true for supported agents", () => {
+    expect(supportsResume("claude")).toBe(true);
+    expect(supportsResume("codex")).toBe(true);
+    expect(supportsResume("gemini")).toBe(true);
+    expect(supportsResume("opencode")).toBe(true);
+    expect(supportsResume("amp")).toBe(true);
+  });
+
+  it("returns false for unsupported agents", () => {
+    expect(supportsResume("copilot")).toBe(false);
+    expect(supportsResume("cursor")).toBe(false);
+    expect(supportsResume("vscode-copilot")).toBe(false);
+    expect(supportsResume("unknown")).toBe(false);
+  });
+
+  it("returns false for prototype properties", () => {
+    expect(supportsResume("toString")).toBe(false);
+    expect(supportsResume("constructor")).toBe(false);
+    expect(supportsResume("hasOwnProperty")).toBe(false);
+  });
+});
+
+describe("buildResumeCommand", () => {
+  it("generates claude resume command", () => {
+    expect(
+      buildResumeCommand("claude", "abc-123-def"),
+    ).toBe("claude --resume abc-123-def");
+  });
+
+  it("generates codex resume command", () => {
+    expect(
+      buildResumeCommand("codex", "codex:sess-1"),
+    ).toBe("codex resume sess-1");
+  });
+
+  it("generates gemini resume command", () => {
+    expect(
+      buildResumeCommand("gemini", "gemini:sess-2"),
+    ).toBe("gemini --resume sess-2");
+  });
+
+  it("generates opencode resume command", () => {
+    expect(
+      buildResumeCommand("opencode", "opencode:s3"),
+    ).toBe("opencode --session s3");
+  });
+
+  it("generates amp resume command", () => {
+    expect(
+      buildResumeCommand("amp", "amp:t-1"),
+    ).toBe("amp --resume t-1");
+  });
+
+  it("strips agent prefix from compound IDs", () => {
+    expect(
+      buildResumeCommand("codex", "codex:my-session-id"),
+    ).toBe("codex resume my-session-id");
+  });
+
+  it("handles plain IDs without prefix", () => {
+    expect(
+      buildResumeCommand("claude", "550e8400-e29b-41d4-a716-446655440000"),
+    ).toBe("claude --resume 550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("returns null for unsupported agents", () => {
+    expect(buildResumeCommand("copilot", "id")).toBeNull();
+    expect(buildResumeCommand("cursor", "id")).toBeNull();
+    expect(buildResumeCommand("unknown", "id")).toBeNull();
+  });
+
+  describe("claude flags", () => {
+    const id = "test-session";
+
+    it("adds --dangerously-skip-permissions", () => {
+      expect(
+        buildResumeCommand("claude", id, {
+          skipPermissions: true,
+        }),
+      ).toBe(
+        "claude --resume test-session --dangerously-skip-permissions",
+      );
+    });
+
+    it("adds --fork-session", () => {
+      expect(
+        buildResumeCommand("claude", id, {
+          forkSession: true,
+        }),
+      ).toBe("claude --resume test-session --fork-session");
+    });
+
+    it("adds --print", () => {
+      expect(
+        buildResumeCommand("claude", id, { print: true }),
+      ).toBe("claude --resume test-session --print");
+    });
+
+    it("combines multiple flags", () => {
+      expect(
+        buildResumeCommand("claude", id, {
+          skipPermissions: true,
+          forkSession: true,
+          print: true,
+        }),
+      ).toBe(
+        "claude --resume test-session --dangerously-skip-permissions --fork-session --print",
+      );
+    });
+
+    it("ignores flags for non-claude agents", () => {
+      expect(
+        buildResumeCommand("codex", "codex:s1", {
+          skipPermissions: true,
+        }),
+      ).toBe("codex resume s1");
+    });
+  });
+
+  it("single-quotes IDs with special characters", () => {
+    const cmd = buildResumeCommand(
+      "claude",
+      "id with spaces",
+    );
+    expect(cmd).toBe("claude --resume 'id with spaces'");
+  });
+
+  it("escapes single quotes in IDs using POSIX quoting", () => {
+    const cmd = buildResumeCommand(
+      "claude",
+      "it's a test",
+    );
+    expect(cmd).toBe(
+      "claude --resume 'it'\"'\"'s a test'",
+    );
+  });
+
+  it("quotes shell metacharacters safely", () => {
+    const cmd = buildResumeCommand(
+      "codex",
+      "codex:$(whoami)",
+    );
+    expect(cmd).toBe("codex resume '$(whoami)'");
+  });
+
+  it("quotes backtick injection attempts", () => {
+    const cmd = buildResumeCommand(
+      "gemini",
+      "gemini:`rm -rf /`",
+    );
+    expect(cmd).toBe("gemini --resume '`rm -rf /`'");
+  });
+
+  it("quotes $VAR expansion attempts", () => {
+    const cmd = buildResumeCommand(
+      "amp",
+      "amp:$HOME/evil",
+    );
+    expect(cmd).toBe("amp --resume '$HOME/evil'");
+  });
+});

--- a/frontend/src/lib/utils/resume.ts
+++ b/frontend/src/lib/utils/resume.ts
@@ -1,0 +1,81 @@
+/** Agent types that support CLI session resumption. */
+const RESUME_AGENTS: Record<
+  string,
+  (sessionId: string) => string
+> = Object.create(null);
+RESUME_AGENTS["claude"] = (id) =>
+  `claude --resume ${shellQuote(id)}`;
+RESUME_AGENTS["codex"] = (id) =>
+  `codex resume ${shellQuote(id)}`;
+RESUME_AGENTS["gemini"] = (id) =>
+  `gemini --resume ${shellQuote(id)}`;
+RESUME_AGENTS["opencode"] = (id) =>
+  `opencode --session ${shellQuote(id)}`;
+RESUME_AGENTS["amp"] = (id) =>
+  `amp --resume ${shellQuote(id)}`;
+
+/** Flags available for Claude Code resume. */
+export interface ClaudeResumeFlags {
+  skipPermissions?: boolean;
+  forkSession?: boolean;
+  print?: boolean;
+}
+
+/**
+ * POSIX-safe shell quoting using single quotes.
+ * Any embedded single quotes are escaped as '"'"'.
+ * Skips quoting for IDs that are purely alphanumeric + hyphens.
+ */
+function shellQuote(s: string): string {
+  if (/^[a-zA-Z0-9_][\w-]*$/.test(s)) return s;
+  return "'" + s.replace(/'/g, "'\"'\"'") + "'";
+}
+
+/**
+ * Strip the agent-type prefix from a compound session ID, but only
+ * when the prefix matches a known agent. Raw IDs that happen to
+ * contain ":" are left untouched.
+ */
+function stripIdPrefix(id: string, agent?: string): string {
+  if (agent) {
+    const prefix = agent + ":";
+    if (id.startsWith(prefix)) return id.slice(prefix.length);
+  }
+  return id;
+}
+
+/**
+ * Returns true if the given agent supports CLI session resumption.
+ */
+export function supportsResume(agent: string): boolean {
+  return Object.hasOwn(RESUME_AGENTS, agent);
+}
+
+/**
+ * Build a CLI command to resume the given session in a terminal.
+ *
+ * @param agent - The agent type (e.g. "claude", "codex", "gemini")
+ * @param sessionId - The session ID (may include agent prefix)
+ * @param flags - Optional Claude-specific resume flags
+ * @returns The shell command string, or null if the agent is not supported
+ */
+export function buildResumeCommand(
+  agent: string,
+  sessionId: string,
+  flags?: ClaudeResumeFlags,
+): string | null {
+  const builder = RESUME_AGENTS[agent];
+  if (!builder) return null;
+
+  const rawId = stripIdPrefix(sessionId, agent);
+  let cmd = builder(rawId);
+
+  if (agent === "claude" && flags) {
+    if (flags.skipPermissions)
+      cmd += " --dangerously-skip-permissions";
+    if (flags.forkSession) cmd += " --fork-session";
+    if (flags.print) cmd += " --print";
+  }
+
+  return cmd;
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/go-cmp v0.7.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mattn/go-sqlite3 v1.14.34
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
 github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,18 @@ import (
 	"github.com/wesm/agentsview/internal/parser"
 )
 
+// TerminalConfig holds terminal launch preferences.
+type TerminalConfig struct {
+	// Mode: "auto" (detect terminal), "custom" (use CustomBin),
+	// or "clipboard" (never launch, always copy).
+	Mode string `json:"mode"`
+	// CustomBin is the terminal binary path (used when Mode == "custom").
+	CustomBin string `json:"custom_bin,omitempty"`
+	// CustomArgs is a template for terminal args. Use {cmd} as
+	// placeholder for the resume command (e.g. "-- bash -c {cmd}").
+	CustomArgs string `json:"custom_args,omitempty"`
+}
+
 // Config holds all application configuration.
 type Config struct {
 	Host         string        `json:"host"`
@@ -24,6 +36,7 @@ type Config struct {
 	DBPath       string        `json:"-"`
 	CursorSecret string        `json:"cursor_secret"`
 	GithubToken  string        `json:"github_token,omitempty"`
+	Terminal     TerminalConfig `json:"terminal,omitempty"`
 	WriteTimeout time.Duration `json:"-"`
 
 	// AgentDirs maps each AgentType to its configured
@@ -141,9 +154,10 @@ func (c *Config) loadFile() error {
 	}
 
 	var file struct {
-		GithubToken                    string   `json:"github_token"`
-		CursorSecret                   string   `json:"cursor_secret"`
-		ResultContentBlockedCategories []string `json:"result_content_blocked_categories"`
+		GithubToken                    string         `json:"github_token"`
+		CursorSecret                   string         `json:"cursor_secret"`
+		ResultContentBlockedCategories []string       `json:"result_content_blocked_categories"`
+		Terminal                       TerminalConfig `json:"terminal"`
 	}
 	if err := json.Unmarshal(data, &file); err != nil {
 		return fmt.Errorf("parsing config: %w", err)
@@ -156,6 +170,9 @@ func (c *Config) loadFile() error {
 	}
 	if file.ResultContentBlockedCategories != nil {
 		c.ResultContentBlockedCategories = file.ResultContentBlockedCategories
+	}
+	if file.Terminal.Mode != "" {
+		c.Terminal = file.Terminal
 	}
 
 	// Parse config-file dir arrays for agents that have a
@@ -284,6 +301,39 @@ func ResolveDataDir() (string, error) {
 		cfg.DataDir = v
 	}
 	return cfg.DataDir, nil
+}
+
+// SaveTerminalConfig persists terminal settings to the config file.
+func (c *Config) SaveTerminalConfig(tc TerminalConfig) error {
+	if err := os.MkdirAll(c.DataDir, 0o700); err != nil {
+		return fmt.Errorf("creating data dir: %w", err)
+	}
+
+	existing := make(map[string]any)
+	data, err := os.ReadFile(c.configPath())
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading config file: %w", err)
+	}
+	if err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf(
+				"existing config is invalid, cannot update: %w",
+				err,
+			)
+		}
+	}
+
+	existing["terminal"] = tc
+	out, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := os.WriteFile(c.configPath(), out, 0o600); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	c.Terminal = tc
+	return nil
 }
 
 // SaveGithubToken persists the GitHub token to the config file.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -746,6 +746,7 @@ func TestSessionParentSessionID(t *testing.T) {
 		requireNoError(t, err, "GetSessionFull")
 		if got == nil {
 			t.Fatal("session not found")
+			return
 		}
 		if got.ParentSessionID == nil ||
 			*got.ParentSessionID != "parent-uuid" {
@@ -1767,6 +1768,7 @@ func TestGetSessionFull(t *testing.T) {
 		requireNoError(t, err, "GetSessionFull")
 		if got == nil {
 			t.Fatal("expected non-nil session")
+			return
 		}
 		want := &Session{
 			ID:           "full-1",
@@ -1797,6 +1799,7 @@ func TestGetSessionFull(t *testing.T) {
 		requireNoError(t, err, "GetSessionFull")
 		if got == nil {
 			t.Fatal("expected non-nil session")
+			return
 		}
 		want := &Session{
 			ID:           "full-2",
@@ -3137,6 +3140,7 @@ func TestCopyOrphanedDataFrom(t *testing.T) {
 	requireNoError(t, err, "GetSession s2")
 	if s == nil {
 		t.Fatal("orphaned session s2 not found in dst")
+		return
 	}
 	if s.Agent != "codex" {
 		t.Errorf("s2 agent = %q, want %q", s.Agent, "codex")

--- a/internal/db/insights_test.go
+++ b/internal/db/insights_test.go
@@ -40,6 +40,7 @@ func TestInsights_InsertAndGet(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected insight, got nil")
+		return
 	}
 
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Insight{}, "ID", "CreatedAt")); diff != "" {
@@ -73,6 +74,7 @@ func TestInsights_InsertDateRange(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected insight, got nil")
+		return
 	}
 
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Insight{}, "ID", "CreatedAt")); diff != "" {

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -265,6 +265,7 @@ func TestParseOpenCodeSession_SingleSession(t *testing.T) {
 	}
 	if sess == nil {
 		t.Fatal("expected non-nil session")
+		return
 	}
 
 	assertEq(t, "ID", sess.ID, "opencode:ses_abc")
@@ -344,6 +345,7 @@ func TestParseOpenCodeDB_ParentSession(t *testing.T) {
 	}
 	if child == nil {
 		t.Fatal("child session not found")
+		return
 	}
 	assertEq(t, "ParentSessionID", child.Session.ParentSessionID, "opencode:ses_parent")
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -924,6 +924,7 @@ func TestCodexUserMessageCount(t *testing.T) {
 	}
 	if sess == nil {
 		t.Fatal("session is nil")
+		return
 	}
 	if len(msgs) != 4 {
 		t.Fatalf("got %d messages, want 4", len(msgs))
@@ -1062,6 +1063,7 @@ func TestParseCodexSession_WorktreeBranchFallback(t *testing.T) {
 	}
 	if sess == nil {
 		t.Fatal("session is nil")
+		return
 	}
 	if sess.Project != "agentsview" {
 		t.Fatalf("project = %q, want %q", sess.Project, "agentsview")
@@ -1232,6 +1234,7 @@ func TestGeminiUserMessageCount(t *testing.T) {
 	}
 	if sess == nil {
 		t.Fatal("session is nil")
+		return
 	}
 	if len(msgs) != 4 {
 		t.Fatalf("got %d messages, want 4", len(msgs))

--- a/internal/parser/test_helpers_test.go
+++ b/internal/parser/test_helpers_test.go
@@ -38,6 +38,7 @@ func assertSessionMeta(t *testing.T, s *ParsedSession, wantID, wantProject strin
 	t.Helper()
 	if s == nil {
 		t.Fatal("session is nil")
+		return
 	}
 	if s.ID != wantID {
 		t.Errorf("session ID = %q, want %q", s.ID, wantID)

--- a/internal/parser/vscode_copilot_test.go
+++ b/internal/parser/vscode_copilot_test.go
@@ -142,6 +142,7 @@ func TestParseVSCodeCopilotSession(t *testing.T) {
 
 			if sess == nil {
 				t.Fatal("expected non-nil session")
+				return
 			}
 
 			if len(msgs) != tt.wantMessages {
@@ -240,6 +241,7 @@ func TestParseVSCodeCopilotSession_MixedTextAndTools(t *testing.T) {
 	}
 	if assistant == nil {
 		t.Fatal("no assistant message")
+		return
 	}
 
 	if !assistant.HasToolUse {
@@ -301,6 +303,7 @@ func TestParseVSCodeCopilotSession_TerminalToolData(t *testing.T) {
 	}
 	if assistant == nil {
 		t.Fatal("no assistant message")
+		return
 	}
 
 	if len(assistant.ToolCalls) != 1 {
@@ -660,6 +663,7 @@ func TestParseVSCodeCopilotSession_JSONL(t *testing.T) {
 
 			if sess == nil {
 				t.Fatal("expected non-nil session")
+				return
 			}
 
 			if len(msgs) != tt.wantMessages {

--- a/internal/server/openers.go
+++ b/internal/server/openers.go
@@ -168,7 +168,7 @@ func (s *Server) handleOpenSession(
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
-	if session == nil {
+	if session == nil || session.DeletedAt != nil {
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}

--- a/internal/server/openers.go
+++ b/internal/server/openers.go
@@ -39,12 +39,11 @@ var openerCandidates = []openerCandidate{
 	{"nemo", "Nemo", "files", []string{"nemo"}, ""},
 	{"pcmanfm", "PCManFM", "files", []string{"pcmanfm"}, ""},
 
-	// Editors / IDEs
+	// Editors / IDEs (GUI only — CLI editors like vim need a TTY)
 	{"cursor", "Cursor", "editor", []string{"cursor"}, ""},
 	{"vscode", "VS Code", "editor", []string{"code"}, ""},
 	{"zed", "Zed", "editor", []string{"zed"}, ""},
 	{"sublime", "Sublime Text", "editor", []string{"subl"}, ""},
-	{"vim", "Vim", "editor", []string{"nvim", "vim"}, ""},
 	{"emacs", "Emacs", "editor", []string{"emacs"}, ""},
 	{"intellij", "IntelliJ IDEA", "editor", []string{"idea"}, ""},
 	{"goland", "GoLand", "editor", []string{"goland"}, ""},
@@ -67,18 +66,18 @@ var darwinOpenerCandidates = []openerCandidate{
 	// File manager is always Finder on macOS — use "open" command
 	{"finder", "Finder", "files", []string{"open"}, ""},
 
-	// Editors
+	// Editors (GUI only — CLI editors like vim need a TTY)
 	{"cursor", "Cursor", "editor", []string{"cursor"}, ""},
 	{"vscode", "VS Code", "editor", []string{"code"}, ""},
 	{"zed", "Zed", "editor", []string{"zed"}, ""},
 	{"xcode", "Xcode", "editor", []string{"xed"}, ""},
 	{"sublime", "Sublime Text", "editor", []string{"subl"}, ""},
-	{"vim", "Vim", "editor", []string{"nvim", "vim"}, ""},
 
-	// Terminals — iTerm2 and Terminal.app are GUI-only; detect via app bundle.
-	{"ghostty", "Ghostty", "terminal", []string{"ghostty"}, ""},
+	// Terminals — Ghostty, iTerm2, kitty, and Terminal.app are macOS GUI
+	// apps; detect via app bundle path rather than LookPath.
+	{"ghostty", "Ghostty", "terminal", nil, "/Applications/Ghostty.app"},
 	{"iterm2", "iTerm2", "terminal", nil, "/Applications/iTerm.app"},
-	{"kitty", "kitty", "terminal", []string{"kitty"}, ""},
+	{"kitty", "kitty", "terminal", nil, "/Applications/kitty.app"},
 	{"alacritty", "Alacritty", "terminal", []string{"alacritty"}, ""},
 	{"wezterm", "WezTerm", "terminal", []string{"wezterm"}, ""},
 	{"terminal", "Terminal", "terminal", nil, "/System/Applications/Utilities/Terminal.app"},
@@ -254,6 +253,14 @@ func launchOpener(o Opener, dir string) error {
 func launchTerminalInDir(o Opener, dir string) *exec.Cmd {
 	if runtime.GOOS == "darwin" {
 		switch o.ID {
+		case "ghostty":
+			// Ghostty accepts --working-directory via CLI args passed
+			// through `open -a`. The -n flag opens a new instance.
+			return exec.Command("open", "-na", "Ghostty",
+				"--args", "--working-directory="+dir)
+		case "kitty":
+			return exec.Command("open", "-na", "kitty",
+				"--args", "-d", dir)
 		case "iterm2":
 			// Build shell command first, then AppleScript-escape the
 			// entire string once. shellQuote provides POSIX quoting for
@@ -277,9 +284,16 @@ func launchTerminalInDir(o Opener, dir string) *exec.Cmd {
 				escapeForAppleScript(shellCmd),
 			)
 			return exec.Command("osascript", "-e", script)
+		case "alacritty":
+			return exec.Command("open", "-na", "Alacritty",
+				"--args", "--working-directory", dir)
+		case "wezterm":
+			return exec.Command("open", "-na", "WezTerm",
+				"--args", "start", "--cwd", dir)
 		}
 	}
 
+	// Linux: launch via CLI binary directly.
 	switch o.ID {
 	case "kitty":
 		return exec.Command(o.Bin, "--directory", dir)
@@ -298,7 +312,6 @@ func launchTerminalInDir(o Opener, dir string) *exec.Cmd {
 	case "ghostty":
 		return exec.Command(o.Bin, "--working-directory="+dir)
 	default:
-		// generic: try --working-directory, fallback to cd
 		cmd := exec.Command(o.Bin)
 		cmd.Dir = dir
 		return cmd

--- a/internal/server/openers.go
+++ b/internal/server/openers.go
@@ -73,11 +73,12 @@ var darwinOpenerCandidates = []openerCandidate{
 	{"xcode", "Xcode", "editor", []string{"xed"}, ""},
 	{"sublime", "Sublime Text", "editor", []string{"subl"}, ""},
 
-	// Terminals — Ghostty, iTerm2, kitty, and Terminal.app are macOS GUI
-	// apps; detect via app bundle path rather than LookPath.
-	{"ghostty", "Ghostty", "terminal", nil, "/Applications/Ghostty.app"},
+	// Terminals — Ghostty, iTerm2, kitty, and Terminal.app are macOS
+	// GUI apps; detect via app bundle first, fall back to PATH binary
+	// for non-default installs (e.g. Homebrew formula).
+	{"ghostty", "Ghostty", "terminal", []string{"ghostty"}, "/Applications/Ghostty.app"},
 	{"iterm2", "iTerm2", "terminal", nil, "/Applications/iTerm.app"},
-	{"kitty", "kitty", "terminal", nil, "/Applications/kitty.app"},
+	{"kitty", "kitty", "terminal", []string{"kitty"}, "/Applications/kitty.app"},
 	{"alacritty", "Alacritty", "terminal", []string{"alacritty"}, ""},
 	{"wezterm", "WezTerm", "terminal", []string{"wezterm"}, ""},
 	{"terminal", "Terminal", "terminal", nil, "/System/Applications/Utilities/Terminal.app"},
@@ -250,23 +251,31 @@ func launchOpener(o Opener, dir string) error {
 	return nil
 }
 
+// isAppBundle returns true if the path looks like a macOS .app bundle.
+func isAppBundle(bin string) bool {
+	return strings.HasSuffix(bin, ".app")
+}
+
+// macExecCommand builds an exec.Cmd for macOS. If bin is an .app
+// bundle it wraps with `open -na`; otherwise executes the binary
+// directly. This keeps detection and launch consistent regardless
+// of whether the opener was found via app bundle or PATH.
+func macExecCommand(bin string, args ...string) *exec.Cmd {
+	if isAppBundle(bin) {
+		openArgs := []string{"-na", bin, "--args"}
+		openArgs = append(openArgs, args...)
+		return exec.Command("open", openArgs...)
+	}
+	return exec.Command(bin, args...)
+}
+
 func launchTerminalInDir(o Opener, dir string) *exec.Cmd {
 	if runtime.GOOS == "darwin" {
 		switch o.ID {
-		case "ghostty":
-			// Ghostty accepts --working-directory via CLI args passed
-			// through `open -a`. The -n flag opens a new instance.
-			return exec.Command("open", "-na", "Ghostty",
-				"--args", "--working-directory="+dir)
-		case "kitty":
-			return exec.Command("open", "-na", "kitty",
-				"--args", "-d", dir)
 		case "iterm2":
-			// Build shell command first, then AppleScript-escape the
-			// entire string once. shellQuote provides POSIX quoting for
-			// the directory, then escapeForAppleScript escapes the whole
-			// command for embedding in an AppleScript string literal.
-			shellCmd := fmt.Sprintf("cd %s && exec bash", shellQuote(dir))
+			shellCmd := fmt.Sprintf(
+				"cd %s && exec bash", shellQuote(dir),
+			)
 			script := fmt.Sprintf(
 				`tell application "iTerm"
 					create window with default profile command "%s"
@@ -284,12 +293,17 @@ func launchTerminalInDir(o Opener, dir string) *exec.Cmd {
 				escapeForAppleScript(shellCmd),
 			)
 			return exec.Command("osascript", "-e", script)
+		case "ghostty":
+			return macExecCommand(o.Bin,
+				"--working-directory="+dir)
+		case "kitty":
+			return macExecCommand(o.Bin, "-d", dir)
 		case "alacritty":
-			return exec.Command("open", "-na", "Alacritty",
-				"--args", "--working-directory", dir)
+			return macExecCommand(o.Bin,
+				"--working-directory", dir)
 		case "wezterm":
-			return exec.Command("open", "-na", "WezTerm",
-				"--args", "start", "--cwd", dir)
+			return macExecCommand(o.Bin,
+				"start", "--cwd", dir)
 		}
 	}
 
@@ -306,7 +320,8 @@ func launchTerminalInDir(o Opener, dir string) *exec.Cmd {
 	case "konsole":
 		return exec.Command(o.Bin, "--workdir", dir)
 	case "xfce4-terminal":
-		return exec.Command(o.Bin, "--default-working-directory="+dir)
+		return exec.Command(o.Bin,
+			"--default-working-directory="+dir)
 	case "tilix":
 		return exec.Command(o.Bin, "--working-directory="+dir)
 	case "ghostty":

--- a/internal/server/openers.go
+++ b/internal/server/openers.go
@@ -1,0 +1,301 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Opener represents an application that can open a project directory.
+type Opener struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Kind string `json:"kind"` // "editor", "terminal", "files", "action"
+	Bin  string `json:"bin"`
+}
+
+// openerCandidate is a binary we check for on PATH.
+type openerCandidate struct {
+	id   string
+	name string
+	kind string
+	bins []string // alternatives to try in order
+}
+
+// Linux + cross-platform candidates.
+var openerCandidates = []openerCandidate{
+	// File managers
+	{"nautilus", "Files", "files", []string{"nautilus"}},
+	{"dolphin", "Dolphin", "files", []string{"dolphin"}},
+	{"thunar", "Thunar", "files", []string{"thunar"}},
+	{"nemo", "Nemo", "files", []string{"nemo"}},
+	{"pcmanfm", "PCManFM", "files", []string{"pcmanfm"}},
+
+	// Editors / IDEs
+	{"cursor", "Cursor", "editor", []string{"cursor"}},
+	{"vscode", "VS Code", "editor", []string{"code"}},
+	{"zed", "Zed", "editor", []string{"zed"}},
+	{"sublime", "Sublime Text", "editor", []string{"subl"}},
+	{"vim", "Vim", "editor", []string{"nvim", "vim"}},
+	{"emacs", "Emacs", "editor", []string{"emacs"}},
+	{"intellij", "IntelliJ IDEA", "editor", []string{"idea"}},
+	{"goland", "GoLand", "editor", []string{"goland"}},
+	{"webstorm", "WebStorm", "editor", []string{"webstorm"}},
+
+	// Terminals
+	{"ghostty", "Ghostty", "terminal", []string{"ghostty"}},
+	{"kitty", "kitty", "terminal", []string{"kitty"}},
+	{"alacritty", "Alacritty", "terminal", []string{"alacritty"}},
+	{"wezterm", "WezTerm", "terminal", []string{"wezterm"}},
+	{"gnome-terminal", "GNOME Terminal", "terminal", []string{"gnome-terminal"}},
+	{"konsole", "Konsole", "terminal", []string{"konsole"}},
+	{"xfce4-terminal", "Xfce Terminal", "terminal", []string{"xfce4-terminal"}},
+	{"tilix", "Tilix", "terminal", []string{"tilix"}},
+	{"xterm", "xterm", "terminal", []string{"xterm"}},
+}
+
+// macOS-specific candidates.
+var darwinOpenerCandidates = []openerCandidate{
+	// File manager is always Finder on macOS — use "open" command
+	{"finder", "Finder", "files", []string{"open"}},
+
+	// Editors
+	{"cursor", "Cursor", "editor", []string{"cursor"}},
+	{"vscode", "VS Code", "editor", []string{"code"}},
+	{"zed", "Zed", "editor", []string{"zed"}},
+	{"xcode", "Xcode", "editor", []string{"xed"}},
+	{"sublime", "Sublime Text", "editor", []string{"subl"}},
+	{"vim", "Vim", "editor", []string{"nvim", "vim"}},
+
+	// Terminals
+	{"ghostty", "Ghostty", "terminal", []string{"ghostty"}},
+	{"iterm2", "iTerm2", "terminal", []string{"iterm2"}},
+	{"kitty", "kitty", "terminal", []string{"kitty"}},
+	{"alacritty", "Alacritty", "terminal", []string{"alacritty"}},
+	{"wezterm", "WezTerm", "terminal", []string{"wezterm"}},
+	{"terminal", "Terminal", "terminal", []string{"open"}}, // Terminal.app
+}
+
+// cachedOpeners stores detected openers with a TTL.
+var (
+	openerCache   []Opener
+	openerCacheMu sync.Mutex
+	openerCacheAt time.Time
+	openerCacheTTL = 60 * time.Second
+)
+
+func detectOpeners() []Opener {
+	openerCacheMu.Lock()
+	defer openerCacheMu.Unlock()
+
+	if time.Since(openerCacheAt) < openerCacheTTL && openerCache != nil {
+		return openerCache
+	}
+
+	candidates := openerCandidates
+	if runtime.GOOS == "darwin" {
+		candidates = darwinOpenerCandidates
+	}
+
+	var result []Opener
+	for _, c := range candidates {
+		for _, bin := range c.bins {
+			path, err := exec.LookPath(bin)
+			if err != nil {
+				continue
+			}
+			result = append(result, Opener{
+				ID:   c.id,
+				Name: c.name,
+				Kind: c.kind,
+				Bin:  path,
+			})
+			break // found one binary for this candidate
+		}
+	}
+
+	openerCache = result
+	openerCacheAt = time.Now()
+	return result
+}
+
+func (s *Server) handleListOpeners(
+	w http.ResponseWriter, _ *http.Request,
+) {
+	openers := detectOpeners()
+	if openers == nil {
+		openers = []Opener{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"openers": openers,
+	})
+}
+
+type openRequest struct {
+	OpenerID string `json:"opener_id"`
+}
+
+func (s *Server) handleOpenSession(
+	w http.ResponseWriter, r *http.Request,
+) {
+	sessionID := r.PathValue("id")
+	session, err := s.db.GetSession(r.Context(), sessionID)
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	var req openRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	// Find the project directory.
+	projectDir := resolveSessionDir(session)
+	if projectDir == "" {
+		writeError(w, http.StatusBadRequest, "session has no project directory")
+		return
+	}
+
+	// Find the opener.
+	openers := detectOpeners()
+	var opener *Opener
+	for i := range openers {
+		if openers[i].ID == req.OpenerID {
+			opener = &openers[i]
+			break
+		}
+	}
+	if opener == nil {
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("opener %q not found", req.OpenerID))
+		return
+	}
+
+	// Launch the opener with the project directory.
+	if err := launchOpener(*opener, projectDir); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to launch")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"launched": true,
+		"opener":   opener.Name,
+		"path":     projectDir,
+	})
+}
+
+func launchOpener(o Opener, dir string) error {
+	var cmd *exec.Cmd
+
+	switch o.Kind {
+	case "files":
+		if runtime.GOOS == "darwin" {
+			cmd = exec.Command("open", dir)
+		} else {
+			cmd = exec.Command(o.Bin, dir)
+		}
+	case "editor":
+		if runtime.GOOS == "darwin" && o.ID == "xcode" {
+			cmd = exec.Command(o.Bin, dir)
+		} else {
+			cmd = exec.Command(o.Bin, dir)
+		}
+	case "terminal":
+		cmd = launchTerminalInDir(o, dir)
+	default:
+		return fmt.Errorf("unsupported opener kind: %s", o.Kind)
+	}
+
+	if cmd == nil {
+		return fmt.Errorf("could not build command for opener %s", o.Name)
+	}
+
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() { _ = cmd.Wait() }()
+	return nil
+}
+
+func launchTerminalInDir(o Opener, dir string) *exec.Cmd {
+	if runtime.GOOS == "darwin" {
+		switch o.ID {
+		case "iterm2":
+			// Build shell command first, then AppleScript-escape the
+			// entire string once. shellQuote provides POSIX quoting for
+			// the directory, then escapeForAppleScript escapes the whole
+			// command for embedding in an AppleScript string literal.
+			shellCmd := fmt.Sprintf("cd %s && exec bash", shellQuote(dir))
+			script := fmt.Sprintf(
+				`tell application "iTerm"
+					create window with default profile command "%s"
+				end tell`,
+				escapeForAppleScript(shellCmd),
+			)
+			return exec.Command("osascript", "-e", script)
+		case "terminal":
+			shellCmd := fmt.Sprintf("cd %s", shellQuote(dir))
+			script := fmt.Sprintf(
+				`tell application "Terminal"
+					activate
+					do script "%s"
+				end tell`,
+				escapeForAppleScript(shellCmd),
+			)
+			return exec.Command("osascript", "-e", script)
+		}
+	}
+
+	switch o.ID {
+	case "kitty":
+		return exec.Command(o.Bin, "--directory", dir)
+	case "alacritty":
+		return exec.Command(o.Bin, "--working-directory", dir)
+	case "wezterm":
+		return exec.Command(o.Bin, "start", "--cwd", dir)
+	case "gnome-terminal":
+		return exec.Command(o.Bin, "--working-directory="+dir)
+	case "konsole":
+		return exec.Command(o.Bin, "--workdir", dir)
+	case "xfce4-terminal":
+		return exec.Command(o.Bin, "--default-working-directory="+dir)
+	case "tilix":
+		return exec.Command(o.Bin, "--working-directory="+dir)
+	case "ghostty":
+		return exec.Command(o.Bin, "--working-directory="+dir)
+	default:
+		// generic: try --working-directory, fallback to cd
+		cmd := exec.Command(o.Bin)
+		cmd.Dir = dir
+		return cmd
+	}
+}
+
+// escapeForAppleScript escapes a string for embedding inside an
+// AppleScript double-quoted string literal. Does NOT add outer quotes.
+func escapeForAppleScript(s string) string {
+	return strings.NewReplacer(
+		"\n", " ",
+		"\r", " ",
+		`\`, `\\`,
+		`"`, `\"`,
+	).Replace(s)
+}

--- a/internal/server/openers.go
+++ b/internal/server/openers.go
@@ -169,10 +169,6 @@ func (s *Server) handleGetSessionDir(
 		return
 	}
 	dir := resolveSessionDir(session)
-	if dir == "" {
-		writeError(w, http.StatusNotFound, "no directory found")
-		return
-	}
 	writeJSON(w, http.StatusOK, map[string]string{
 		"path": dir,
 	})

--- a/internal/server/openers.go
+++ b/internal/server/openers.go
@@ -152,6 +152,32 @@ func (s *Server) handleListOpeners(
 	})
 }
 
+func (s *Server) handleGetSessionDir(
+	w http.ResponseWriter, r *http.Request,
+) {
+	sessionID := r.PathValue("id")
+	session, err := s.db.GetSessionFull(r.Context(), sessionID)
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if session == nil || session.DeletedAt != nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	dir := resolveSessionDir(session)
+	if dir == "" {
+		writeError(w, http.StatusNotFound, "no directory found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{
+		"path": dir,
+	})
+}
+
 type openRequest struct {
 	OpenerID string `json:"opener_id"`
 }

--- a/internal/server/openers.go
+++ b/internal/server/openers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -19,73 +20,75 @@ type Opener struct {
 	Bin  string `json:"bin"`
 }
 
-// openerCandidate is a binary we check for on PATH.
+// openerCandidate is a binary we check for on PATH, or a macOS
+// app bundle we check for on disk.
 type openerCandidate struct {
-	id   string
-	name string
-	kind string
-	bins []string // alternatives to try in order
+	id      string
+	name    string
+	kind    string
+	bins    []string // alternatives to try via LookPath
+	appPath string   // macOS .app bundle path (checked via os.Stat)
 }
 
 // Linux + cross-platform candidates.
 var openerCandidates = []openerCandidate{
 	// File managers
-	{"nautilus", "Files", "files", []string{"nautilus"}},
-	{"dolphin", "Dolphin", "files", []string{"dolphin"}},
-	{"thunar", "Thunar", "files", []string{"thunar"}},
-	{"nemo", "Nemo", "files", []string{"nemo"}},
-	{"pcmanfm", "PCManFM", "files", []string{"pcmanfm"}},
+	{"nautilus", "Files", "files", []string{"nautilus"}, ""},
+	{"dolphin", "Dolphin", "files", []string{"dolphin"}, ""},
+	{"thunar", "Thunar", "files", []string{"thunar"}, ""},
+	{"nemo", "Nemo", "files", []string{"nemo"}, ""},
+	{"pcmanfm", "PCManFM", "files", []string{"pcmanfm"}, ""},
 
 	// Editors / IDEs
-	{"cursor", "Cursor", "editor", []string{"cursor"}},
-	{"vscode", "VS Code", "editor", []string{"code"}},
-	{"zed", "Zed", "editor", []string{"zed"}},
-	{"sublime", "Sublime Text", "editor", []string{"subl"}},
-	{"vim", "Vim", "editor", []string{"nvim", "vim"}},
-	{"emacs", "Emacs", "editor", []string{"emacs"}},
-	{"intellij", "IntelliJ IDEA", "editor", []string{"idea"}},
-	{"goland", "GoLand", "editor", []string{"goland"}},
-	{"webstorm", "WebStorm", "editor", []string{"webstorm"}},
+	{"cursor", "Cursor", "editor", []string{"cursor"}, ""},
+	{"vscode", "VS Code", "editor", []string{"code"}, ""},
+	{"zed", "Zed", "editor", []string{"zed"}, ""},
+	{"sublime", "Sublime Text", "editor", []string{"subl"}, ""},
+	{"vim", "Vim", "editor", []string{"nvim", "vim"}, ""},
+	{"emacs", "Emacs", "editor", []string{"emacs"}, ""},
+	{"intellij", "IntelliJ IDEA", "editor", []string{"idea"}, ""},
+	{"goland", "GoLand", "editor", []string{"goland"}, ""},
+	{"webstorm", "WebStorm", "editor", []string{"webstorm"}, ""},
 
 	// Terminals
-	{"ghostty", "Ghostty", "terminal", []string{"ghostty"}},
-	{"kitty", "kitty", "terminal", []string{"kitty"}},
-	{"alacritty", "Alacritty", "terminal", []string{"alacritty"}},
-	{"wezterm", "WezTerm", "terminal", []string{"wezterm"}},
-	{"gnome-terminal", "GNOME Terminal", "terminal", []string{"gnome-terminal"}},
-	{"konsole", "Konsole", "terminal", []string{"konsole"}},
-	{"xfce4-terminal", "Xfce Terminal", "terminal", []string{"xfce4-terminal"}},
-	{"tilix", "Tilix", "terminal", []string{"tilix"}},
-	{"xterm", "xterm", "terminal", []string{"xterm"}},
+	{"ghostty", "Ghostty", "terminal", []string{"ghostty"}, ""},
+	{"kitty", "kitty", "terminal", []string{"kitty"}, ""},
+	{"alacritty", "Alacritty", "terminal", []string{"alacritty"}, ""},
+	{"wezterm", "WezTerm", "terminal", []string{"wezterm"}, ""},
+	{"gnome-terminal", "GNOME Terminal", "terminal", []string{"gnome-terminal"}, ""},
+	{"konsole", "Konsole", "terminal", []string{"konsole"}, ""},
+	{"xfce4-terminal", "Xfce Terminal", "terminal", []string{"xfce4-terminal"}, ""},
+	{"tilix", "Tilix", "terminal", []string{"tilix"}, ""},
+	{"xterm", "xterm", "terminal", []string{"xterm"}, ""},
 }
 
 // macOS-specific candidates.
 var darwinOpenerCandidates = []openerCandidate{
 	// File manager is always Finder on macOS — use "open" command
-	{"finder", "Finder", "files", []string{"open"}},
+	{"finder", "Finder", "files", []string{"open"}, ""},
 
 	// Editors
-	{"cursor", "Cursor", "editor", []string{"cursor"}},
-	{"vscode", "VS Code", "editor", []string{"code"}},
-	{"zed", "Zed", "editor", []string{"zed"}},
-	{"xcode", "Xcode", "editor", []string{"xed"}},
-	{"sublime", "Sublime Text", "editor", []string{"subl"}},
-	{"vim", "Vim", "editor", []string{"nvim", "vim"}},
+	{"cursor", "Cursor", "editor", []string{"cursor"}, ""},
+	{"vscode", "VS Code", "editor", []string{"code"}, ""},
+	{"zed", "Zed", "editor", []string{"zed"}, ""},
+	{"xcode", "Xcode", "editor", []string{"xed"}, ""},
+	{"sublime", "Sublime Text", "editor", []string{"subl"}, ""},
+	{"vim", "Vim", "editor", []string{"nvim", "vim"}, ""},
 
-	// Terminals
-	{"ghostty", "Ghostty", "terminal", []string{"ghostty"}},
-	{"iterm2", "iTerm2", "terminal", []string{"iterm2"}},
-	{"kitty", "kitty", "terminal", []string{"kitty"}},
-	{"alacritty", "Alacritty", "terminal", []string{"alacritty"}},
-	{"wezterm", "WezTerm", "terminal", []string{"wezterm"}},
-	{"terminal", "Terminal", "terminal", []string{"open"}}, // Terminal.app
+	// Terminals — iTerm2 and Terminal.app are GUI-only; detect via app bundle.
+	{"ghostty", "Ghostty", "terminal", []string{"ghostty"}, ""},
+	{"iterm2", "iTerm2", "terminal", nil, "/Applications/iTerm.app"},
+	{"kitty", "kitty", "terminal", []string{"kitty"}, ""},
+	{"alacritty", "Alacritty", "terminal", []string{"alacritty"}, ""},
+	{"wezterm", "WezTerm", "terminal", []string{"wezterm"}, ""},
+	{"terminal", "Terminal", "terminal", nil, "/System/Applications/Utilities/Terminal.app"},
 }
 
 // cachedOpeners stores detected openers with a TTL.
 var (
-	openerCache   []Opener
-	openerCacheMu sync.Mutex
-	openerCacheAt time.Time
+	openerCache    []Opener
+	openerCacheMu  sync.Mutex
+	openerCacheAt  time.Time
 	openerCacheTTL = 60 * time.Second
 )
 
@@ -104,6 +107,19 @@ func detectOpeners() []Opener {
 
 	var result []Opener
 	for _, c := range candidates {
+		// Try app bundle path first (macOS GUI apps).
+		if c.appPath != "" {
+			if _, err := os.Stat(c.appPath); err == nil {
+				result = append(result, Opener{
+					ID:   c.id,
+					Name: c.name,
+					Kind: c.kind,
+					Bin:  c.appPath,
+				})
+				continue
+			}
+		}
+		// Fall back to PATH-based binary detection.
 		for _, bin := range c.bins {
 			path, err := exec.LookPath(bin)
 			if err != nil {
@@ -144,7 +160,7 @@ func (s *Server) handleOpenSession(
 	w http.ResponseWriter, r *http.Request,
 ) {
 	sessionID := r.PathValue("id")
-	session, err := s.db.GetSession(r.Context(), sessionID)
+	session, err := s.db.GetSessionFull(r.Context(), sessionID)
 	if err != nil {
 		if handleContextError(w, err) {
 			return

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -357,22 +357,22 @@ func (s *Server) handleSetTerminalConfig(
 		return
 	}
 
-	if tc.Mode == "custom" && tc.CustomArgs != "" &&
-		!strings.Contains(tc.CustomArgs, "{cmd}") {
-		writeError(w, http.StatusBadRequest,
-			`custom_args must contain the {cmd} placeholder so the `+
-				`resume command is passed to the terminal`)
-		return
-	}
-
-	// Validate that custom_args can be shell-split so users get
-	// immediate feedback about malformed quoting (e.g. unmatched
-	// quotes) instead of a silent save that fails later at resume.
-	if tc.CustomArgs != "" {
-		if _, splitErr := shlex.Split(tc.CustomArgs); splitErr != nil {
+	// Only validate custom_args when mode is "custom" — stale
+	// args from a previous config shouldn't block saving other modes.
+	if tc.Mode == "custom" {
+		if tc.CustomArgs != "" &&
+			!strings.Contains(tc.CustomArgs, "{cmd}") {
 			writeError(w, http.StatusBadRequest,
-				fmt.Sprintf("custom_args has invalid shell syntax: %v", splitErr))
+				`custom_args must contain the {cmd} placeholder so the `+
+					`resume command is passed to the terminal`)
 			return
+		}
+		if tc.CustomArgs != "" {
+			if _, splitErr := shlex.Split(tc.CustomArgs); splitErr != nil {
+				writeError(w, http.StatusBadRequest,
+					fmt.Sprintf("custom_args has invalid shell syntax: %v", splitErr))
+				return
+			}
 		}
 	}
 

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -81,7 +81,7 @@ func (s *Server) handleResumeSession(
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
-	if session == nil {
+	if session == nil || session.DeletedAt != nil {
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
@@ -160,7 +160,7 @@ func (s *Server) handleResumeSession(
 	}
 
 	// Detect and launch a terminal.
-	termBin, termArgs, termErr := detectTerminal(cmd, sessionDir, termCfg)
+	termBin, termArgs, termName, termErr := detectTerminal(cmd, sessionDir, termCfg)
 	if termErr != nil {
 		// Can't launch — return the command for clipboard fallback.
 		log.Printf("resume: terminal detection failed: %v", termErr)
@@ -199,7 +199,7 @@ func (s *Server) handleResumeSession(
 
 	writeJSON(w, http.StatusOK, resumeResponse{
 		Launched: true,
-		Terminal: termBin,
+		Terminal: termName,
 		Command:  cmd,
 		Cwd:      sessionDir,
 	})
@@ -227,25 +227,27 @@ func shellQuote(s string) string {
 }
 
 // detectTerminal finds a suitable terminal emulator and builds the
-// full argument list to launch the given command.
+// full argument list to launch the given command. Returns the
+// executable path, args, a user-facing display name, and any error.
 func detectTerminal(
 	cmd string, cwd string, tc config.TerminalConfig,
-) (bin string, args []string, err error) {
+) (bin string, args []string, name string, err error) {
 	// Custom terminal mode — use the user-configured binary + args.
 	if tc.Mode == "custom" && tc.CustomBin != "" {
 		path, lookErr := exec.LookPath(tc.CustomBin)
 		if lookErr != nil {
-			return "", nil, fmt.Errorf(
+			return "", nil, "", fmt.Errorf(
 				"custom terminal %q not found: %w",
 				tc.CustomBin, lookErr,
 			)
 		}
+		displayName := filepath.Base(tc.CustomBin)
 		if tc.CustomArgs != "" {
 			// Shell-aware split so that quoted args like
 			// --title "My Terminal" are kept together.
 			parts, splitErr := shlex.Split(tc.CustomArgs)
 			if splitErr != nil {
-				return "", nil, fmt.Errorf(
+				return "", nil, "", fmt.Errorf(
 					"parsing custom_args: %w", splitErr,
 				)
 			}
@@ -253,10 +255,10 @@ func detectTerminal(
 			for _, p := range parts {
 				a = append(a, strings.ReplaceAll(p, "{cmd}", cmd))
 			}
-			return path, a, nil
+			return path, a, displayName, nil
 		}
 		// No args template — default pattern.
-		return path, []string{"-e", "bash", "-c", cmd + "; exec bash"}, nil
+		return path, []string{"-e", "bash", "-c", cmd + "; exec bash"}, displayName, nil
 	}
 
 	switch runtime.GOOS {
@@ -265,7 +267,7 @@ func detectTerminal(
 	case "linux":
 		return detectTerminalLinux(cmd)
 	default:
-		return "", nil, fmt.Errorf(
+		return "", nil, "", fmt.Errorf(
 			"unsupported OS %q for terminal launch", runtime.GOOS,
 		)
 	}
@@ -273,7 +275,7 @@ func detectTerminal(
 
 func detectTerminalDarwin(
 	cmd string, cwd string,
-) (string, []string, error) {
+) (string, []string, string, error) {
 	// Check for iTerm2 first, then fall back to Terminal.app.
 	// Use osascript to tell the app to open a new window and run
 	// the command.
@@ -304,7 +306,7 @@ func detectTerminalDarwin(
 				end tell`,
 				safe,
 			)
-			return "osascript", []string{"-e", appleScript}, nil
+			return "osascript", []string{"-e", appleScript}, "iTerm2", nil
 		}
 		// Fall back to Terminal.app.
 		appleScript := fmt.Sprintf(
@@ -314,9 +316,9 @@ func detectTerminalDarwin(
 			end tell`,
 			safe,
 		)
-		return "osascript", []string{"-e", appleScript}, nil
+		return "osascript", []string{"-e", appleScript}, "Terminal", nil
 	}
-	return "", nil, fmt.Errorf("osascript not found on macOS")
+	return "", nil, "", fmt.Errorf("osascript not found on macOS")
 }
 
 func (s *Server) handleGetTerminalConfig(
@@ -434,7 +436,7 @@ func isDir(path string) bool {
 	return err == nil && info.IsDir()
 }
 
-func detectTerminalLinux(cmd string) (string, []string, error) {
+func detectTerminalLinux(cmd string) (string, []string, string, error) {
 	// Check $TERMINAL env var first. If it resolves, build args
 	// using the per-terminal template when the basename matches a
 	// known candidate, otherwise use a generic pattern.
@@ -442,7 +444,7 @@ func detectTerminalLinux(cmd string) (string, []string, error) {
 		if path, err := exec.LookPath(envTerm); err == nil {
 			base := filepath.Base(envTerm)
 			args := buildTerminalArgs(base, cmd)
-			return path, args, nil
+			return path, args, base, nil
 		}
 	}
 
@@ -452,10 +454,10 @@ func detectTerminalLinux(cmd string) (string, []string, error) {
 		if err != nil {
 			continue
 		}
-		return path, buildTerminalArgs(c.bin, cmd), nil
+		return path, buildTerminalArgs(c.bin, cmd), c.bin, nil
 	}
 
-	return "", nil, fmt.Errorf(
+	return "", nil, "", fmt.Errorf(
 		"no terminal emulator found; install kitty, alacritty, " +
 			"gnome-terminal, or set $TERMINAL",
 	)

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -1,0 +1,488 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"bufio"
+
+	"github.com/google/shlex"
+	"github.com/tidwall/gjson"
+	"github.com/wesm/agentsview/internal/config"
+	"github.com/wesm/agentsview/internal/db"
+)
+
+// resumeRequest is the JSON body for POST /api/v1/sessions/{id}/resume.
+type resumeRequest struct {
+	SkipPermissions bool `json:"skip_permissions"`
+	ForkSession     bool `json:"fork_session"`
+	CommandOnly     bool `json:"command_only"`
+}
+
+// resumeResponse is the JSON response for a resume request.
+type resumeResponse struct {
+	Launched bool   `json:"launched"`
+	Terminal string `json:"terminal,omitempty"`
+	Command  string `json:"command"`
+	Cwd      string `json:"cwd,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+// resumeAgents maps agent type strings to their resume command templates.
+// The %s placeholder is replaced with the (quoted) session ID.
+var resumeAgents = map[string]string{
+	"claude":   "claude --resume %s",
+	"codex":    "codex resume %s",
+	"gemini":   "gemini --resume %s",
+	"opencode": "opencode --session %s",
+	"amp":      "amp --resume %s",
+}
+
+// terminalCandidates lists terminal emulators to try on Linux, in
+// preference order. Each entry is {binary, args-before-command...}.
+// The resume command is appended after the last arg.
+var terminalCandidates = []struct {
+	bin  string
+	args []string
+}{
+	{"kitty", []string{"--"}},
+	{"alacritty", []string{"-e"}},
+	{"wezterm", []string{"start", "--"}},
+	{"gnome-terminal", []string{"--", "bash", "-c"}},
+	{"konsole", []string{"-e"}},
+	{"xfce4-terminal", []string{"-e"}},
+	{"tilix", []string{"-e"}},
+	{"xterm", []string{"-e"}},
+	{"x-terminal-emulator", []string{"-e"}},
+}
+
+func (s *Server) handleResumeSession(
+	w http.ResponseWriter, r *http.Request,
+) {
+	id := r.PathValue("id")
+
+	// Look up the session to get agent type.
+	session, err := s.db.GetSession(r.Context(), id)
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		log.Printf("resume: session lookup failed: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	// Check if this agent supports resumption.
+	tmpl, ok := resumeAgents[string(session.Agent)]
+	if !ok {
+		writeError(
+			w, http.StatusBadRequest,
+			fmt.Sprintf("agent %q does not support resume", session.Agent),
+		)
+		return
+	}
+
+	// Parse optional flags.
+	var req resumeRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+	}
+
+	// Strip agent prefix from compound ID only when it matches the
+	// expected agent (e.g. "codex:abc" → "abc"). Raw IDs that
+	// happen to contain ":" are left untouched.
+	prefix := string(session.Agent) + ":"
+	rawID := strings.TrimPrefix(id, prefix)
+
+	// Build the CLI command.
+	cmd := fmt.Sprintf(tmpl, shellQuote(rawID))
+	if string(session.Agent) == "claude" {
+		if req.SkipPermissions {
+			cmd += " --dangerously-skip-permissions"
+		}
+		if req.ForkSession {
+			cmd += " --fork-session"
+		}
+	}
+
+	// Resolve the project directory from the session file or
+	// project field for use in cd prefix and response metadata.
+	sessionDir := resolveSessionDir(session)
+
+	// Claude Code scopes sessions by the working directory the
+	// session was started from. Prepend cd <cwd> so the resume
+	// works from any terminal location. Only Claude uses this
+	// pattern — other agents handle directory scoping internally.
+	if string(session.Agent) == "claude" && sessionDir != "" {
+		cmd = fmt.Sprintf("cd %s && %s", shellQuote(sessionDir), cmd)
+	}
+
+	// If the caller only wants the command string (e.g. for
+	// clipboard copy), skip terminal detection and launch.
+	if req.CommandOnly {
+		writeJSON(w, http.StatusOK, resumeResponse{
+			Launched: false,
+			Command:  cmd,
+			Cwd:      sessionDir,
+		})
+		return
+	}
+
+	// Check terminal config.
+	s.mu.RLock()
+	termCfg := s.cfg.Terminal
+	s.mu.RUnlock()
+
+	if termCfg.Mode == "clipboard" {
+		// User explicitly chose clipboard-only mode.
+		writeJSON(w, http.StatusOK, resumeResponse{
+			Launched: false,
+			Command:  cmd,
+		})
+		return
+	}
+
+	// Detect and launch a terminal.
+	termBin, termArgs, termErr := detectTerminal(cmd, sessionDir, termCfg)
+	if termErr != nil {
+		// Can't launch — return the command for clipboard fallback.
+		log.Printf("resume: terminal detection failed: %v", termErr)
+		writeJSON(w, http.StatusOK, resumeResponse{
+			Launched: false,
+			Command:  cmd,
+			Cwd:      sessionDir,
+			Error:    "no_terminal_found",
+		})
+		return
+	}
+
+	// Fire and forget — we don't need the terminal process to
+	// complete before responding.
+	proc := exec.Command(termBin, termArgs...)
+	proc.Stdout = nil
+	proc.Stderr = nil
+	proc.Stdin = nil
+	if sessionDir != "" {
+		proc.Dir = sessionDir
+	}
+
+	if err := proc.Start(); err != nil {
+		log.Printf("resume: terminal start failed: %v", err)
+		writeJSON(w, http.StatusOK, resumeResponse{
+			Launched: false,
+			Command:  cmd,
+			Cwd:      sessionDir,
+			Error:    "terminal_launch_failed",
+		})
+		return
+	}
+
+	// Detach — don't wait for the terminal process.
+	go func() { _ = proc.Wait() }()
+
+	writeJSON(w, http.StatusOK, resumeResponse{
+		Launched: true,
+		Terminal: termBin,
+		Command:  cmd,
+		Cwd:      sessionDir,
+	})
+}
+
+// shellQuote applies POSIX single-quote escaping.
+func shellQuote(s string) string {
+	// Simple IDs: alphanumeric + hyphens need no quoting,
+	// but a leading '-' must always be quoted to prevent
+	// the value being interpreted as a CLI flag.
+	safe := len(s) == 0 || s[0] != '-'
+	if safe {
+		for _, c := range s {
+			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') &&
+				(c < '0' || c > '9') && c != '-' && c != '_' {
+				safe = false
+				break
+			}
+		}
+	}
+	if safe {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+// detectTerminal finds a suitable terminal emulator and builds the
+// full argument list to launch the given command.
+func detectTerminal(
+	cmd string, cwd string, tc config.TerminalConfig,
+) (bin string, args []string, err error) {
+	// Custom terminal mode — use the user-configured binary + args.
+	if tc.Mode == "custom" && tc.CustomBin != "" {
+		path, lookErr := exec.LookPath(tc.CustomBin)
+		if lookErr != nil {
+			return "", nil, fmt.Errorf(
+				"custom terminal %q not found: %w",
+				tc.CustomBin, lookErr,
+			)
+		}
+		if tc.CustomArgs != "" {
+			// Shell-aware split so that quoted args like
+			// --title "My Terminal" are kept together.
+			parts, splitErr := shlex.Split(tc.CustomArgs)
+			if splitErr != nil {
+				return "", nil, fmt.Errorf(
+					"parsing custom_args: %w", splitErr,
+				)
+			}
+			a := make([]string, 0, len(parts))
+			for _, p := range parts {
+				a = append(a, strings.ReplaceAll(p, "{cmd}", cmd))
+			}
+			return path, a, nil
+		}
+		// No args template — default pattern.
+		return path, []string{"-e", "bash", "-c", cmd + "; exec bash"}, nil
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return detectTerminalDarwin(cmd, cwd)
+	case "linux":
+		return detectTerminalLinux(cmd)
+	default:
+		return "", nil, fmt.Errorf(
+			"unsupported OS %q for terminal launch", runtime.GOOS,
+		)
+	}
+}
+
+func detectTerminalDarwin(
+	cmd string, cwd string,
+) (string, []string, error) {
+	// Check for iTerm2 first, then fall back to Terminal.app.
+	// Use osascript to tell the app to open a new window and run
+	// the command.
+	script := cmd
+	if cwd != "" {
+		if info, err := os.Stat(cwd); err == nil && info.IsDir() {
+			script = fmt.Sprintf("cd %s && %s", shellQuote(cwd), cmd)
+		}
+	}
+
+	// Try iTerm2 first.
+	if _, err := exec.LookPath("osascript"); err == nil {
+		// Sanitize for AppleScript: escape backslashes, then quotes,
+		// and reject newlines to prevent multi-line injection.
+		safe := strings.NewReplacer(
+			"\n", " ",
+			"\r", " ",
+			`\`, `\\`,
+			`"`, `\"`,
+		).Replace(script)
+
+		// Check if iTerm is installed.
+		iterm := "/Applications/iTerm.app"
+		if _, err := os.Stat(iterm); err == nil {
+			appleScript := fmt.Sprintf(
+				`tell application "iTerm"
+					create window with default profile command "%s"
+				end tell`,
+				safe,
+			)
+			return "osascript", []string{"-e", appleScript}, nil
+		}
+		// Fall back to Terminal.app.
+		appleScript := fmt.Sprintf(
+			`tell application "Terminal"
+				activate
+				do script "%s"
+			end tell`,
+			safe,
+		)
+		return "osascript", []string{"-e", appleScript}, nil
+	}
+	return "", nil, fmt.Errorf("osascript not found on macOS")
+}
+
+func (s *Server) handleGetTerminalConfig(
+	w http.ResponseWriter, _ *http.Request,
+) {
+	s.mu.RLock()
+	tc := s.cfg.Terminal
+	s.mu.RUnlock()
+	if tc.Mode == "" {
+		tc.Mode = "auto"
+	}
+	writeJSON(w, http.StatusOK, tc)
+}
+
+func (s *Server) handleSetTerminalConfig(
+	w http.ResponseWriter, r *http.Request,
+) {
+	var tc config.TerminalConfig
+	if err := json.NewDecoder(r.Body).Decode(&tc); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	switch tc.Mode {
+	case "auto", "custom", "clipboard":
+		// ok
+	default:
+		writeError(w, http.StatusBadRequest,
+			`mode must be "auto", "custom", or "clipboard"`)
+		return
+	}
+
+	if tc.Mode == "custom" && tc.CustomBin == "" {
+		writeError(w, http.StatusBadRequest,
+			`custom_bin is required when mode is "custom"`)
+		return
+	}
+
+	if tc.Mode == "custom" && tc.CustomArgs != "" &&
+		!strings.Contains(tc.CustomArgs, "{cmd}") {
+		writeError(w, http.StatusBadRequest,
+			`custom_args must contain the {cmd} placeholder so the `+
+				`resume command is passed to the terminal`)
+		return
+	}
+
+	// Validate that custom_args can be shell-split so users get
+	// immediate feedback about malformed quoting (e.g. unmatched
+	// quotes) instead of a silent save that fails later at resume.
+	if tc.CustomArgs != "" {
+		if _, splitErr := shlex.Split(tc.CustomArgs); splitErr != nil {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("custom_args has invalid shell syntax: %v", splitErr))
+			return
+		}
+	}
+
+	s.mu.Lock()
+	err := s.cfg.SaveTerminalConfig(tc)
+	s.mu.Unlock()
+	if err != nil {
+		log.Printf("save terminal config: %v", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, tc)
+}
+
+// readSessionCwd reads the first few lines of a session JSONL file
+// and extracts the "cwd" field. Claude Code stores the working
+// directory in early conversation entries; some agents (e.g. Codex)
+// store it under payload.cwd. Returns "" if not found.
+func readSessionCwd(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024)
+	for i := 0; i < 20 && scanner.Scan(); i++ {
+		line := scanner.Text()
+		if cwd := gjson.Get(line, "cwd").Str; cwd != "" {
+			return cwd
+		}
+		if cwd := gjson.Get(line, "payload.cwd").Str; cwd != "" {
+			return cwd
+		}
+	}
+	return ""
+}
+
+// resolveSessionDir determines the project directory for a session.
+// It tries the session file's embedded cwd first, then falls back to
+// the session's project field. Both candidates must be absolute paths
+// pointing to existing directories.
+func resolveSessionDir(session *db.Session) string {
+	if session.FilePath != nil {
+		if cwd := readSessionCwd(*session.FilePath); isDir(cwd) {
+			return cwd
+		}
+	}
+	if isDir(session.Project) {
+		return session.Project
+	}
+	return ""
+}
+
+func isDir(path string) bool {
+	if !filepath.IsAbs(path) {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func detectTerminalLinux(cmd string) (string, []string, error) {
+	// Check $TERMINAL env var first. If it resolves, build args
+	// using the per-terminal template when the basename matches a
+	// known candidate, otherwise use a generic pattern.
+	if envTerm := os.Getenv("TERMINAL"); envTerm != "" {
+		if path, err := exec.LookPath(envTerm); err == nil {
+			base := filepath.Base(envTerm)
+			args := buildTerminalArgs(base, cmd)
+			return path, args, nil
+		}
+	}
+
+	// Try each candidate in preference order.
+	for _, c := range terminalCandidates {
+		path, err := exec.LookPath(c.bin)
+		if err != nil {
+			continue
+		}
+		return path, buildTerminalArgs(c.bin, cmd), nil
+	}
+
+	return "", nil, fmt.Errorf(
+		"no terminal emulator found; install kitty, alacritty, " +
+			"gnome-terminal, or set $TERMINAL",
+	)
+}
+
+// buildTerminalArgs returns the argument list for launching a command
+// in a named terminal. The bin parameter is the terminal basename
+// (e.g. "kitty", "gnome-terminal"). Used by both $TERMINAL and the
+// auto-detection loop.
+func buildTerminalArgs(bin, cmd string) []string {
+	switch bin {
+	case "gnome-terminal":
+		return []string{"--", "bash", "-c", cmd + "; exec bash"}
+	case "kitty":
+		return []string{"--", "bash", "-c", cmd + "; exec bash"}
+	case "alacritty":
+		return []string{"-e", "bash", "-c", cmd + "; exec bash"}
+	case "wezterm":
+		return []string{"start", "--", "bash", "-c", cmd + "; exec bash"}
+	case "konsole":
+		return []string{"-e", "bash", "-c", cmd + "; exec bash"}
+	case "xfce4-terminal":
+		return []string{"-e", "bash -c '" + strings.ReplaceAll(cmd, "'", `'"'"'`) + "; exec bash'"}
+	case "tilix":
+		return []string{"-e", "bash -c '" + strings.ReplaceAll(cmd, "'", `'"'"'`) + "; exec bash'"}
+	case "xterm":
+		return []string{"-e", "bash", "-c", cmd + "; exec bash"}
+	default:
+		return []string{"-e", "bash", "-c", cmd + "; exec bash"}
+	}
+}

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -23,9 +23,10 @@ import (
 
 // resumeRequest is the JSON body for POST /api/v1/sessions/{id}/resume.
 type resumeRequest struct {
-	SkipPermissions bool `json:"skip_permissions"`
-	ForkSession     bool `json:"fork_session"`
-	CommandOnly     bool `json:"command_only"`
+	SkipPermissions bool   `json:"skip_permissions"`
+	ForkSession     bool   `json:"fork_session"`
+	CommandOnly     bool   `json:"command_only"`
+	OpenerID        string `json:"opener_id"`
 }
 
 // resumeResponse is the JSON response for a resume request.
@@ -139,6 +140,51 @@ func (s *Server) handleResumeSession(
 	if req.CommandOnly {
 		writeJSON(w, http.StatusOK, resumeResponse{
 			Launched: false,
+			Command:  cmd,
+			Cwd:      sessionDir,
+		})
+		return
+	}
+
+	// If the caller specified a terminal opener, use it directly.
+	if req.OpenerID != "" {
+		openers := detectOpeners()
+		var opener *Opener
+		for i := range openers {
+			if openers[i].ID == req.OpenerID {
+				opener = &openers[i]
+				break
+			}
+		}
+		if opener == nil {
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("opener %q not found", req.OpenerID))
+			return
+		}
+		proc := launchResumeInOpener(*opener, cmd, sessionDir)
+		if proc == nil {
+			writeJSON(w, http.StatusOK, resumeResponse{
+				Launched: false,
+				Command:  cmd,
+				Cwd:      sessionDir,
+				Error:    "unsupported_opener",
+			})
+			return
+		}
+		if err := proc.Start(); err != nil {
+			log.Printf("resume: opener start failed: %v", err)
+			writeJSON(w, http.StatusOK, resumeResponse{
+				Launched: false,
+				Command:  cmd,
+				Cwd:      sessionDir,
+				Error:    "terminal_launch_failed",
+			})
+			return
+		}
+		go func() { _ = proc.Wait() }()
+		writeJSON(w, http.StatusOK, resumeResponse{
+			Launched: true,
+			Terminal: opener.Name,
 			Command:  cmd,
 			Cwd:      sessionDir,
 		})
@@ -487,5 +533,101 @@ func buildTerminalArgs(bin, cmd string) []string {
 		return []string{"-e", "bash", "-c", cmd + "; exec bash"}
 	default:
 		return []string{"-e", "bash", "-c", cmd + "; exec bash"}
+	}
+}
+
+// launchResumeInOpener builds an exec.Cmd that runs a shell command
+// inside the terminal identified by the opener. Returns nil if the
+// opener kind is not "terminal" or the terminal is not supported.
+func launchResumeInOpener(
+	o Opener, cmd string, cwd string,
+) *exec.Cmd {
+	if o.Kind != "terminal" {
+		return nil
+	}
+
+	if runtime.GOOS == "darwin" {
+		return launchResumeDarwin(o, cmd, cwd)
+	}
+
+	// Linux: launch via CLI binary with per-terminal arg patterns.
+	// Wrap the resume command so the shell stays open after it exits.
+	args := buildTerminalArgs(o.ID, cmd+"; exec bash")
+	proc := exec.Command(o.Bin, args...)
+	if cwd != "" {
+		proc.Dir = cwd
+	}
+	proc.Stdout = nil
+	proc.Stderr = nil
+	proc.Stdin = nil
+	return proc
+}
+
+// launchResumeDarwin launches a resume command in a macOS terminal
+// app. Uses AppleScript for iTerm2/Terminal.app and `open -na` with
+// appropriate flags for others.
+func launchResumeDarwin(
+	o Opener, cmd string, cwd string,
+) *exec.Cmd {
+	// For AppleScript-based terminals, build a single shell command
+	// that cd's and then runs the resume command.
+	shellCmd := cmd
+	if cwd != "" {
+		shellCmd = fmt.Sprintf(
+			"cd %s && %s", shellQuote(cwd), cmd,
+		)
+	}
+	safe := escapeForAppleScript(shellCmd)
+
+	switch o.ID {
+	case "iterm2":
+		script := fmt.Sprintf(
+			`tell application "iTerm"
+				create window with default profile command "%s"
+			end tell`, safe,
+		)
+		return exec.Command("osascript", "-e", script)
+	case "terminal":
+		script := fmt.Sprintf(
+			`tell application "Terminal"
+				activate
+				do script "%s"
+			end tell`, safe,
+		)
+		return exec.Command("osascript", "-e", script)
+	case "ghostty":
+		args := []string{"-na", "Ghostty", "--args"}
+		if cwd != "" {
+			args = append(args, "--working-directory="+cwd)
+		}
+		args = append(args, "-e", "bash", "-c",
+			cmd+"; exec bash")
+		return exec.Command("open", args...)
+	case "kitty":
+		args := []string{"-na", "kitty", "--args"}
+		if cwd != "" {
+			args = append(args, "-d", cwd)
+		}
+		args = append(args, "bash", "-c", cmd+"; exec bash")
+		return exec.Command("open", args...)
+	case "alacritty":
+		args := []string{"-na", "Alacritty", "--args"}
+		if cwd != "" {
+			args = append(args, "--working-directory", cwd)
+		}
+		args = append(args, "-e", "bash", "-c",
+			cmd+"; exec bash")
+		return exec.Command("open", args...)
+	case "wezterm":
+		args := []string{"-na", "WezTerm", "--args",
+			"start"}
+		if cwd != "" {
+			args = append(args, "--cwd", cwd)
+		}
+		args = append(args, "--", "bash", "-c",
+			cmd+"; exec bash")
+		return exec.Command("open", args...)
+	default:
+		return nil
 	}
 }

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -596,37 +596,36 @@ func launchResumeDarwin(
 		)
 		return exec.Command("osascript", "-e", script)
 	case "ghostty":
-		args := []string{"-na", "Ghostty", "--args"}
+		var args []string
 		if cwd != "" {
 			args = append(args, "--working-directory="+cwd)
 		}
 		args = append(args, "-e", "bash", "-c",
 			cmd+"; exec bash")
-		return exec.Command("open", args...)
+		return macExecCommand(o.Bin, args...)
 	case "kitty":
-		args := []string{"-na", "kitty", "--args"}
+		var args []string
 		if cwd != "" {
 			args = append(args, "-d", cwd)
 		}
 		args = append(args, "bash", "-c", cmd+"; exec bash")
-		return exec.Command("open", args...)
+		return macExecCommand(o.Bin, args...)
 	case "alacritty":
-		args := []string{"-na", "Alacritty", "--args"}
+		var args []string
 		if cwd != "" {
 			args = append(args, "--working-directory", cwd)
 		}
 		args = append(args, "-e", "bash", "-c",
 			cmd+"; exec bash")
-		return exec.Command("open", args...)
+		return macExecCommand(o.Bin, args...)
 	case "wezterm":
-		args := []string{"-na", "WezTerm", "--args",
-			"start"}
+		args := []string{"start"}
 		if cwd != "" {
 			args = append(args, "--cwd", cwd)
 		}
 		args = append(args, "--", "bash", "-c",
 			cmd+"; exec bash")
-		return exec.Command("open", args...)
+		return macExecCommand(o.Bin, args...)
 	default:
 		return nil
 	}

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -444,21 +444,21 @@ func readSessionCwd(path string) string {
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
-	// Session files can have large JSON lines (tool results,
-	// base64 images). 2MB covers the vast majority of cases.
-	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
-	for i := 0; i < 20 && scanner.Scan(); i++ {
-		line := scanner.Text()
-		if cwd := gjson.Get(line, "cwd").Str; cwd != "" {
-			return cwd
+	reader := bufio.NewReader(f)
+	for range 20 {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			s := string(line)
+			if cwd := gjson.Get(s, "cwd").Str; cwd != "" {
+				return cwd
+			}
+			if cwd := gjson.Get(s, "payload.cwd").Str; cwd != "" {
+				return cwd
+			}
 		}
-		if cwd := gjson.Get(line, "payload.cwd").Str; cwd != "" {
-			return cwd
+		if err != nil {
+			break
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		log.Printf("readSessionCwd %s: %v", path, err)
 	}
 	return ""
 }
@@ -488,14 +488,22 @@ func isDir(path string) bool {
 }
 
 func detectTerminalLinux(cmd string) (string, []string, string, error) {
-	// Check $TERMINAL env var first. If it resolves, build args
-	// using the per-terminal template when the basename matches a
-	// known candidate, otherwise use a generic pattern.
+	// Check $TERMINAL env var first. The value may contain
+	// arguments (e.g. "kitty --single-instance"), so split it
+	// with a shell lexer and use the first token for LookPath.
 	if envTerm := os.Getenv("TERMINAL"); envTerm != "" {
-		if path, err := exec.LookPath(envTerm); err == nil {
-			base := filepath.Base(envTerm)
-			args := buildTerminalArgs(base, cmd)
-			return path, args, base, nil
+		parts, splitErr := shlex.Split(envTerm)
+		if splitErr == nil && len(parts) > 0 {
+			if path, err := exec.LookPath(parts[0]); err == nil {
+				base := filepath.Base(parts[0])
+				args := buildTerminalArgs(base, cmd)
+				// Prepend extra tokens from $TERMINAL before
+				// the template args (e.g. --single-instance).
+				if len(parts) > 1 {
+					args = append(parts[1:], args...)
+				}
+				return path, args, base, nil
+			}
 		}
 	}
 

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -70,8 +70,9 @@ func (s *Server) handleResumeSession(
 ) {
 	id := r.PathValue("id")
 
-	// Look up the session to get agent type.
-	session, err := s.db.GetSession(r.Context(), id)
+	// Look up the session with full file metadata so
+	// resolveSessionDir can read the session file for cwd.
+	session, err := s.db.GetSessionFull(r.Context(), id)
 	if err != nil {
 		if handleContextError(w, err) {
 			return

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -445,7 +445,9 @@ func readSessionCwd(path string) string {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024)
+	// Session files can have large JSON lines (tool results,
+	// base64 images). 2MB covers the vast majority of cases.
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
 	for i := 0; i < 20 && scanner.Scan(); i++ {
 		line := scanner.Text()
 		if cwd := gjson.Get(line, "cwd").Str; cwd != "" {
@@ -454,6 +456,9 @@ func readSessionCwd(path string) string {
 		if cwd := gjson.Get(line, "payload.cwd").Str; cwd != "" {
 			return cwd
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("readSessionCwd %s: %v", path, err)
 	}
 	return ""
 }

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -1,0 +1,225 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+func TestResumeSession(t *testing.T) {
+	te := setup(t)
+
+	// Seed a claude session with an absolute project path.
+	projectDir := t.TempDir()
+	te.seedSession(t, "sess-1", projectDir, 5, func(s *db.Session) {
+		s.Agent = "claude"
+	})
+
+	t.Run("command only", func(t *testing.T) {
+		w := te.post(t,
+			"/api/v1/sessions/sess-1/resume",
+			`{"command_only":true}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Launched bool   `json:"launched"`
+			Command  string `json:"command"`
+			Cwd      string `json:"cwd"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Launched {
+			t.Error("expected launched=false for command_only")
+		}
+		if resp.Command == "" {
+			t.Error("expected non-empty command")
+		}
+		if resp.Cwd != projectDir {
+			t.Errorf("cwd = %q, want %q", resp.Cwd, projectDir)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		w := te.post(t,
+			"/api/v1/sessions/nonexistent/resume",
+			`{"command_only":true}`,
+		)
+		assertStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("unsupported agent", func(t *testing.T) {
+		te.seedSession(t, "copilot-1", "/tmp", 3, func(s *db.Session) {
+			s.Agent = "copilot"
+		})
+		w := te.post(t,
+			"/api/v1/sessions/copilot-1/resume",
+			`{"command_only":true}`,
+		)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("deleted session rejected", func(t *testing.T) {
+		te.seedSession(t, "del-1", "/tmp", 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		if err := te.db.SoftDeleteSession("del-1"); err != nil {
+			t.Fatal(err)
+		}
+		w := te.post(t,
+			"/api/v1/sessions/del-1/resume",
+			`{"command_only":true}`,
+		)
+		assertStatus(t, w, http.StatusNotFound)
+	})
+}
+
+func TestGetSessionDirectory(t *testing.T) {
+	te := setup(t)
+
+	projectDir := t.TempDir()
+	te.seedSession(t, "dir-1", projectDir, 3)
+
+	t.Run("returns resolved directory", func(t *testing.T) {
+		w := te.get(t, "/api/v1/sessions/dir-1/directory")
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Path != projectDir {
+			t.Errorf("path = %q, want %q", resp.Path, projectDir)
+		}
+	})
+
+	t.Run("empty path for relative project", func(t *testing.T) {
+		te.seedSession(t, "dir-2", "my-repo", 3)
+		w := te.get(t, "/api/v1/sessions/dir-2/directory")
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Path != "" {
+			t.Errorf("path = %q, want empty", resp.Path)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		w := te.get(t, "/api/v1/sessions/nonexistent/directory")
+		assertStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("prefers session file cwd", func(t *testing.T) {
+		cwdDir := filepath.Join(t.TempDir(), "nested")
+		if err := os.Mkdir(cwdDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		sessionFile := filepath.Join(t.TempDir(), "session.jsonl")
+		cwdJSON, _ := json.Marshal(cwdDir)
+		content := `{"cwd":` + string(cwdJSON) + "}\n"
+		if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		te.seedSession(t, "dir-3", projectDir, 3, func(s *db.Session) {
+			s.FilePath = &sessionFile
+		})
+		w := te.get(t, "/api/v1/sessions/dir-3/directory")
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Path string `json:"path"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Path != cwdDir {
+			t.Errorf("path = %q, want %q", resp.Path, cwdDir)
+		}
+	})
+}
+
+func TestListOpeners(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, "/api/v1/openers")
+	assertStatus(t, w, http.StatusOK)
+
+	var resp struct {
+		Openers []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+			Kind string `json:"kind"`
+			Bin  string `json:"bin"`
+		} `json:"openers"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// The response should always be an array (possibly empty),
+	// never null.
+	if resp.Openers == nil {
+		t.Error("openers should be [] not null")
+	}
+}
+
+func TestGetTerminalConfig(t *testing.T) {
+	te := setup(t)
+
+	t.Run("default config", func(t *testing.T) {
+		w := te.get(t, "/api/v1/config/terminal")
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Mode string `json:"mode"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Mode != "auto" {
+			t.Errorf("mode = %q, want %q", resp.Mode, "auto")
+		}
+	})
+
+	t.Run("set and get", func(t *testing.T) {
+		w := te.post(t,
+			"/api/v1/config/terminal",
+			`{"mode":"clipboard"}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+
+		w = te.get(t, "/api/v1/config/terminal")
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Mode string `json:"mode"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Mode != "clipboard" {
+			t.Errorf("mode = %q, want %q", resp.Mode, "clipboard")
+		}
+	})
+
+	t.Run("invalid mode", func(t *testing.T) {
+		w := te.post(t,
+			"/api/v1/config/terminal",
+			`{"mode":"invalid"}`,
+		)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("custom requires bin", func(t *testing.T) {
+		w := te.post(t,
+			"/api/v1/config/terminal",
+			`{"mode":"custom","custom_bin":""}`,
+		)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+}

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -1,0 +1,45 @@
+package server
+
+import "testing"
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple uuid", "abc-123-def", "abc-123-def"},
+		{"alphanumeric", "session42", "session42"},
+		{"with colon", "a:b", "'a:b'"},
+		{"with spaces", "has space", "'has space'"},
+		{"with single quote", "it's", `'it'"'"'s'`},
+		{"command injection attempt", "$(whoami)", "'$(whoami)'"},
+		{"backtick injection", "`rm -rf /`", "'`rm -rf /`'"},
+		{"semicolon", "id;rm -rf /", "'id;rm -rf /'"},
+		{"pipe", "id|cat", "'id|cat'"},
+		{"empty passthrough", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shellQuote(tt.in)
+			if got != tt.want {
+				t.Errorf(
+					"shellQuote(%q) = %q, want %q",
+					tt.in, got, tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestDetectTerminalLinux_NoTerminal(t *testing.T) {
+	// When no terminal is installed, should return an error.
+	// This test validates the error path — on CI or servers
+	// without a display, no terminal emulator is typically
+	// available.
+	_, _, err := detectTerminalLinux("echo test")
+	// We just check it doesn't panic. The error may or may not
+	// occur depending on the environment.
+	_ = err
+}

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -44,7 +44,7 @@ func TestDetectTerminalLinux_NoTerminal(t *testing.T) {
 	// This test validates the error path — on CI or servers
 	// without a display, no terminal emulator is typically
 	// available.
-	_, _, err := detectTerminalLinux("echo test")
+	_, _, _, err := detectTerminalLinux("echo test")
 	// We just check it doesn't panic. The error may or may not
 	// occur depending on the environment.
 	_ = err

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -41,14 +41,38 @@ func TestShellQuote(t *testing.T) {
 }
 
 func TestDetectTerminalLinux_NoTerminal(t *testing.T) {
-	// When no terminal is installed, should return an error.
-	// This test validates the error path — on CI or servers
-	// without a display, no terminal emulator is typically
-	// available.
+	// Empty PATH and no $TERMINAL — no terminal should be found.
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("TERMINAL", "")
 	_, _, _, err := detectTerminalLinux("echo test")
-	// We just check it doesn't panic. The error may or may not
-	// occur depending on the environment.
-	_ = err
+	if err == nil {
+		t.Error("expected error with empty PATH, got nil")
+	}
+}
+
+func TestDetectTerminalLinux_EnvTerminal(t *testing.T) {
+	// Create a fake terminal binary on PATH.
+	binDir := t.TempDir()
+	fakeBin := filepath.Join(binDir, "myterm")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("TERMINAL", "myterm")
+
+	bin, args, name, err := detectTerminalLinux("echo hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != fakeBin {
+		t.Errorf("bin = %q, want %q", bin, fakeBin)
+	}
+	if name != "myterm" {
+		t.Errorf("name = %q, want %q", name, "myterm")
+	}
+	if len(args) == 0 {
+		t.Error("expected non-empty args")
+	}
 }
 
 func TestResolveSessionDir(t *testing.T) {

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -1,6 +1,12 @@
 package server
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+)
 
 func TestShellQuote(t *testing.T) {
 	tests := []struct {
@@ -42,4 +48,88 @@ func TestDetectTerminalLinux_NoTerminal(t *testing.T) {
 	// We just check it doesn't panic. The error may or may not
 	// occur depending on the environment.
 	_ = err
+}
+
+func TestResolveSessionDir(t *testing.T) {
+	// Create a real temp directory for the "absolute path" cases.
+	tmpDir := t.TempDir()
+
+	// Create a session file with a cwd field.
+	sessionFile := filepath.Join(tmpDir, "session.jsonl")
+	cwdDir := filepath.Join(tmpDir, "project")
+	if err := os.Mkdir(cwdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"cwd":"` + cwdDir + `"}` + "\n"
+	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		session *db.Session
+		want    string
+	}{
+		{
+			name: "absolute project path",
+			session: &db.Session{
+				Project: tmpDir,
+			},
+			want: tmpDir,
+		},
+		{
+			name: "relative project name returns empty",
+			session: &db.Session{
+				Project: "my-repo",
+			},
+			want: "",
+		},
+		{
+			name: "nil file_path with relative project",
+			session: &db.Session{
+				Project:  "my-repo",
+				FilePath: nil,
+			},
+			want: "",
+		},
+		{
+			name: "file_path with cwd in session file",
+			session: &db.Session{
+				Project:  "my-repo",
+				FilePath: &sessionFile,
+			},
+			want: cwdDir,
+		},
+		{
+			name: "file_path takes precedence over project",
+			session: &db.Session{
+				Project:  tmpDir,
+				FilePath: &sessionFile,
+			},
+			want: cwdDir,
+		},
+		{
+			name: "nonexistent file_path falls back to project",
+			session: func() *db.Session {
+				bad := "/nonexistent/session.jsonl"
+				return &db.Session{
+					Project:  tmpDir,
+					FilePath: &bad,
+				}
+			}(),
+			want: tmpDir,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveSessionDir(tt.session)
+			if got != tt.want {
+				t.Errorf(
+					"resolveSessionDir() = %q, want %q",
+					got, tt.want,
+				)
+			}
+		})
+	}
 }

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,7 +61,8 @@ func TestResolveSessionDir(t *testing.T) {
 	if err := os.Mkdir(cwdDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	content := `{"cwd":"` + cwdDir + `"}` + "\n"
+	cwdJSON, _ := json.Marshal(cwdDir)
+	content := `{"cwd":` + string(cwdJSON) + `}` + "\n"
 	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/wesm/agentsview/internal/db"
@@ -41,6 +43,9 @@ func TestShellQuote(t *testing.T) {
 }
 
 func TestDetectTerminalLinux_NoTerminal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Linux-only terminal detection")
+	}
 	// Empty PATH and no $TERMINAL — no terminal should be found.
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("TERMINAL", "")
@@ -51,6 +56,9 @@ func TestDetectTerminalLinux_NoTerminal(t *testing.T) {
 }
 
 func TestDetectTerminalLinux_EnvTerminal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Linux-only terminal detection")
+	}
 	// Create a fake terminal binary on PATH.
 	binDir := t.TempDir()
 	fakeBin := filepath.Join(binDir, "myterm")
@@ -72,6 +80,60 @@ func TestDetectTerminalLinux_EnvTerminal(t *testing.T) {
 	}
 	if len(args) == 0 {
 		t.Error("expected non-empty args")
+	}
+}
+
+func TestDetectTerminalLinux_EnvTerminalWithArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Linux-only terminal detection")
+	}
+	binDir := t.TempDir()
+	fakeBin := filepath.Join(binDir, "kitty")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("TERMINAL", "kitty --single-instance")
+
+	bin, args, name, err := detectTerminalLinux("echo hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != fakeBin {
+		t.Errorf("bin = %q, want %q", bin, fakeBin)
+	}
+	if name != "kitty" {
+		t.Errorf("name = %q, want %q", name, "kitty")
+	}
+	// Should have --single-instance prepended before template args.
+	if len(args) < 2 || args[0] != "--single-instance" {
+		t.Errorf("args = %v, want --single-instance as first arg", args)
+	}
+}
+
+func TestReadSessionCwd_LargeLine(t *testing.T) {
+	// Verify that readSessionCwd handles lines larger than the
+	// old 2MB scanner limit without losing the cwd field.
+	dir := t.TempDir()
+	cwdDir := filepath.Join(dir, "project")
+	if err := os.Mkdir(cwdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cwdJSON, _ := json.Marshal(cwdDir)
+	// Build a 3MB padding string to exceed the old scanner limit.
+	padding := strings.Repeat("x", 3*1024*1024)
+	line := `{"cwd":` + string(cwdJSON) +
+		`,"big":"` + padding + `"}` + "\n"
+
+	sessionFile := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(sessionFile, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readSessionCwd(sessionFile)
+	if got != cwdDir {
+		t.Errorf("readSessionCwd() = %q, want %q", got, cwdDir)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -134,6 +134,7 @@ func (s *Server) routes() {
 		"POST /api/v1/sessions/{id}/resume", s.withTimeout(s.handleResumeSession),
 	)
 	s.mux.Handle("GET /api/v1/openers", s.withTimeout(s.handleListOpeners))
+	s.mux.Handle("GET /api/v1/sessions/{id}/directory", s.withTimeout(s.handleGetSessionDir))
 	s.mux.Handle("POST /api/v1/sessions/{id}/open", s.withTimeout(s.handleOpenSession))
 	s.mux.Handle(
 		"POST /api/v1/sessions/upload", s.withTimeout(s.handleUploadSession),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -131,6 +131,11 @@ func (s *Server) routes() {
 		"POST /api/v1/sessions/{id}/publish", s.withTimeout(s.handlePublishSession),
 	)
 	s.mux.Handle(
+		"POST /api/v1/sessions/{id}/resume", s.withTimeout(s.handleResumeSession),
+	)
+	s.mux.Handle("GET /api/v1/openers", s.withTimeout(s.handleListOpeners))
+	s.mux.Handle("POST /api/v1/sessions/{id}/open", s.withTimeout(s.handleOpenSession))
+	s.mux.Handle(
 		"POST /api/v1/sessions/upload", s.withTimeout(s.handleUploadSession),
 	)
 	s.mux.Handle("GET /api/v1/analytics/summary", s.withTimeout(s.handleAnalyticsSummary))
@@ -160,6 +165,10 @@ func (s *Server) routes() {
 	s.mux.Handle("GET /api/v1/config/github", s.withTimeout(s.handleGetGithubConfig))
 	s.mux.Handle(
 		"POST /api/v1/config/github", s.withTimeout(s.handleSetGithubConfig),
+	)
+	s.mux.Handle("GET /api/v1/config/terminal", s.withTimeout(s.handleGetTerminalConfig))
+	s.mux.Handle(
+		"POST /api/v1/config/terminal", s.withTimeout(s.handleSetTerminalConfig),
 	)
 
 	s.mux.Handle("GET /api/v1/starred", s.withTimeout(s.handleListStarred))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1923,6 +1923,7 @@ func TestUploadSession(t *testing.T) {
 	}
 	if sess == nil {
 		t.Fatal("session not found in DB")
+		return
 	}
 	if sess.Project != "myproj" {
 		t.Errorf("stored project = %q", sess.Project)
@@ -1954,6 +1955,7 @@ func TestUploadSession_InfersRelationshipType(t *testing.T) {
 	}
 	if sess == nil {
 		t.Fatal("session not found in DB")
+		return
 	}
 	if sess.RelationshipType != "subagent" {
 		t.Errorf(

--- a/internal/sync/test_helpers_test.go
+++ b/internal/sync/test_helpers_test.go
@@ -35,6 +35,7 @@ func assertSessionState(t *testing.T, database *db.DB, sessionID string, check f
 	}
 	if sess == nil {
 		t.Fatalf("Session %q not found", sessionID)
+		return
 	}
 	if check != nil {
 		check(sess)
@@ -195,6 +196,7 @@ func (e *testEnv) updateSessionProject(
 	}
 	if sess == nil {
 		t.Fatalf("session %q not found", sessionID)
+		return
 	}
 	sess.Project = project
 	if err := e.db.UpsertSession(*sess); err != nil {

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -43,6 +43,7 @@ func TestPtr(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatalf("Ptr() returned nil, want %q", *tt.want)
+				return
 			}
 			if *got != *tt.want {
 				t.Errorf("Ptr() = %q, want %q", *got, *tt.want)


### PR DESCRIPTION
## Summary

Adds a session action dropdown to the breadcrumb bar that lets users resume sessions in a terminal, open the project directory in editors or file managers, and copy paths and commands to the clipboard.

### Backend

- **`POST /sessions/{id}/resume`** — Builds the agent-specific resume command (`claude --resume`, `codex resume`, etc.), optionally launches it in a detected or user-specified terminal. Supports `command_only` for clipboard copy, `opener_id` for launching in a specific terminal, and flags like `skip_permissions` and `fork_session` for Claude.
- **`GET /sessions/{id}/directory`** — Agent-agnostic directory resolution. Prefers the embedded `cwd` from the session file, falls back to the session's `project` field. Used by the frontend to determine dropdown visibility and copy the directory path.
- **`GET /openers`** — Detects installed applications (terminals, editors, file managers) via app bundle paths on macOS and `PATH` lookup on Linux. Results are cached with a 60s TTL.
- **`POST /sessions/{id}/open`** — Launches a detected opener with the session's resolved project directory.
- **Terminal config** (`GET/POST /config/terminal`) — Persisted `auto`, `custom`, or `clipboard` mode. Custom mode supports a user-specified binary and argument template with `{cmd}` placeholder.
- **macOS launch** uses `open -na <app>` for `.app` bundles and direct binary execution for PATH-detected installs, keeping detection and launch consistent. AppleScript for iTerm2 and Terminal.app.
- **Session directory resolution** reads the first 20 lines of the session JSONL file for an embedded `cwd` field, with fallback to the session's `project` field. Both must be absolute paths pointing to existing directories.

### Frontend

- **Resume dropdown** on the session breadcrumb bar, visible when the session has resume support, detected openers, or a resolvable directory:
  - Terminal openers (Ghostty, kitty, iTerm2, etc.) — launches the resume command directly
  - "Default terminal" — uses the server's auto-detect or custom terminal config
  - "Copy command" — copies the resume command to clipboard
  - "Copy directory path" — copies the resolved project directory
  - "Open in" section — detected editors (VS Code, Cursor, Zed, etc.) and file managers (Finder, etc.)
- **Keyboard shortcut** `c` copies the resume command to clipboard from the session detail view.
- **`resume.ts`** utility with per-agent command templates and POSIX shell quoting.
- **Dropdown visibility** is based on actual capabilities: cached server-side directory resolution, detected openers, and agent resume support. No dropdown renders for sessions with nothing actionable.

### Supported agents

| Agent | Resume command |
|-------|---------------|
| Claude | `claude --resume <id>` |
| Codex | `codex resume <id>` |
| Gemini | `gemini --resume <id>` |
| OpenCode | `opencode --session <id>` |
| Amp | `amp --resume <id>` |

### Detected terminals (macOS)

Ghostty, iTerm2, kitty, Alacritty, WezTerm, Terminal.app — detected via app bundle path with PATH binary fallback for non-default installs.

### Detected terminals (Linux)

Ghostty, kitty, Alacritty, WezTerm, GNOME Terminal, Konsole, Xfce Terminal, Tilix, xterm — detected via `PATH`. Respects `$TERMINAL` environment variable.