### PR TITLE
fix: add release metadata and About dialog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,12 @@ desktop-dev:
 desktop-build:
 	cd desktop && npm install && npm run tauri:build
 
-# Build only the macOS .app bundle (skip DMG packaging)
+# Build only the macOS .app bundle (skip DMG packaging).
+# Skips updater artifact signing when TAURI_SIGNING_PRIVATE_KEY
+# is not set so local builds succeed without release keys.
 desktop-macos-app:
-	cd desktop && npm install && npm run tauri:build:macos-app
+	cd desktop && npm install && npm run tauri:build:macos-app \
+		$(if $(TAURI_SIGNING_PRIVATE_KEY),,-- --config '{"bundle":{"createUpdaterArtifacts":false}}')
 	mkdir -p $(DESKTOP_DIST_DIR)/macos
 	rm -rf $(DESKTOP_DIST_DIR)/macos/AgentsView.app
 	cp -R desktop/src-tauri/target/release/bundle/macos/AgentsView.app \

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agentsview-desktop"
 version = "0.1.0"
 description = "AgentsView desktop wrapper"
-authors = ["agentsview contributors"]
+authors = ["Wes McKinney"]
 edition = "2021"
 
 [lib]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -66,6 +66,13 @@ pub fn run() {
         .expect("failed to build tauri app")
         .run(|app_handle, event| {
             if let RunEvent::MenuEvent(event) = &event {
+                if event.id().0 == "about" {
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        let _ = window.eval(
+                            "window.dispatchEvent(new CustomEvent('show-about'));",
+                        );
+                    }
+                }
                 if event.id().0 == "check_updates" {
                     let handle = app_handle.clone();
                     tauri::async_runtime::spawn(async move {
@@ -584,10 +591,14 @@ fn parse_listening_port_from_stdout_buffer(buffer: &mut String, chunk: &str) -> 
 }
 
 fn setup_menu(app: &mut App) -> Result<(), DynError> {
+    let about = MenuItemBuilder::with_id("about", "About AgentsView")
+        .build(app)?;
     let check_updates = MenuItemBuilder::with_id("check_updates", "Check for Updates...")
         .build(app)?;
 
     let app_submenu = SubmenuBuilder::new(app, "AgentsView")
+        .item(&about)
+        .separator()
         .item(&check_updates)
         .separator()
         .quit()

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -26,6 +26,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "copyright": "Copyright 2025 Wes McKinney",
+    "shortDescription": "Local viewer for AI agent sessions",
+    "longDescription": "AgentsView is a local web viewer for AI agent sessions including Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, and Amp.",
     "createUpdaterArtifacts": "v1Compatible",
     "externalBin": [
       "binaries/agentsview"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "copyright": "Copyright 2025 Wes McKinney",
+    "copyright": "Copyright 2026 Wes McKinney",
     "shortDescription": "Local viewer for AI agent sessions",
     "longDescription": "AgentsView is a local web viewer for AI agent sessions including Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, and Amp.",
     "createUpdaterArtifacts": "v1Compatible",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -162,6 +162,7 @@
   });
 
   function showAbout() {
+    if (ui.activeModal === "resync" && sync.syncing) return;
     ui.activeModal = "about";
   }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -7,6 +7,7 @@
   import SessionList from "./lib/components/sidebar/SessionList.svelte";
   import MessageList from "./lib/components/content/MessageList.svelte";
   import CommandPalette from "./lib/components/command-palette/CommandPalette.svelte";
+  import AboutModal from "./lib/components/modals/AboutModal.svelte";
   import ShortcutsModal from "./lib/components/modals/ShortcutsModal.svelte";
   import PublishModal from "./lib/components/modals/PublishModal.svelte";
   import ResyncModal from "./lib/components/modals/ResyncModal.svelte";
@@ -160,6 +161,10 @@
     });
   });
 
+  function showAbout() {
+    ui.activeModal = "about";
+  }
+
   onMount(() => {
     starred.load();
     sync.loadStatus();
@@ -168,9 +173,11 @@
     sync.checkForUpdate();
     sync.startPolling();
 
+    window.addEventListener("show-about", showAbout);
     const cleanup = registerShortcuts({ navigateMessage });
     return () => {
       cleanup();
+      window.removeEventListener("show-about", showAbout);
       sync.stopPolling();
       sync.unwatchSession();
     };
@@ -214,6 +221,10 @@
 {/if}
 
 <StatusBar />
+
+{#if ui.activeModal === "about"}
+  <AboutModal />
+{/if}
 
 {#if ui.activeModal === "commandPalette"}
   <CommandPalette />

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -61,9 +61,13 @@
       {#if sync.versionMismatch || progressText || sync.lastSync}
         <span class="sep">&middot;</span>
       {/if}
-      <span class="version" title="Build: {sync.serverVersion.commit}">
+      <button
+        class="version"
+        title="Build: {sync.serverVersion.commit}"
+        onclick={() => (ui.activeModal = "about")}
+      >
         {sync.serverVersion.version}
-      </span>
+      </button>
     {/if}
   </div>
 </footer>
@@ -122,5 +126,12 @@
 
   .version {
     font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .version:hover {
+    color: var(--text-secondary);
   }
 </style>

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -64,7 +64,10 @@
       <button
         class="version"
         title="Build: {sync.serverVersion.commit}"
-        onclick={() => (ui.activeModal = "about")}
+        onclick={() => {
+          if (ui.activeModal === "resync" && sync.syncing) return;
+          ui.activeModal = "about";
+        }}
       >
         {sync.serverVersion.version}
       </button>

--- a/frontend/src/lib/components/modals/AboutModal.svelte
+++ b/frontend/src/lib/components/modals/AboutModal.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { sync } from "../../stores/sync.svelte.js";
+  import { ui } from "../../stores/ui.svelte.js";
+
+  function handleOverlayClick(e: MouseEvent) {
+    if (
+      (e.target as HTMLElement).classList.contains(
+        "about-overlay",
+      )
+    ) {
+      ui.activeModal = null;
+    }
+  }
+
+  const buildDate = $derived.by(() => {
+    const raw = sync.serverVersion?.build_date;
+    if (!raw) return null;
+    try {
+      return new Date(raw).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+    } catch {
+      return raw;
+    }
+  });
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="about-overlay"
+  onclick={handleOverlayClick}
+  onkeydown={(e) => {
+    if (e.key === "Escape") ui.activeModal = null;
+  }}
+>
+  <div class="about-modal">
+    <div class="about-header">
+      <svg class="about-logo" width="40" height="40" viewBox="0 0 32 32" aria-hidden="true">
+        <rect width="32" height="32" rx="6" fill="var(--accent-blue, #3b82f6)"/>
+        <rect x="13" y="10" width="6" height="16" rx="2" fill="var(--bg-surface, #fff)"/>
+        <rect x="11" y="5" width="10" height="7" rx="2" fill="var(--bg-surface, #fff)"/>
+        <circle cx="18" cy="8.5" r="2" fill="var(--accent-blue, #3b82f6)"/>
+        <circle cx="18" cy="8.5" r="1" fill="#1d4ed8"/>
+      </svg>
+      <div class="about-name">AgentsView</div>
+      <button
+        class="close-btn"
+        onclick={() => ui.activeModal = null}
+      >
+        &times;
+      </button>
+    </div>
+
+    <div class="about-body">
+      <div class="about-row">
+        <span class="about-label">Author</span>
+        <span class="about-value">Wes McKinney</span>
+      </div>
+      {#if sync.serverVersion}
+        <div class="about-row">
+          <span class="about-label">Version</span>
+          <span class="about-value mono">
+            {sync.serverVersion.version}
+          </span>
+        </div>
+        <div class="about-row">
+          <span class="about-label">Commit</span>
+          <span class="about-value mono">
+            {sync.serverVersion.commit}
+          </span>
+        </div>
+        {#if buildDate}
+          <div class="about-row">
+            <span class="about-label">Build date</span>
+            <span class="about-value">{buildDate}</span>
+          </div>
+        {/if}
+      {/if}
+    </div>
+
+    <div class="about-footer">
+      Local viewer for AI agent sessions
+    </div>
+  </div>
+</div>
+
+<style>
+  .about-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay-bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+
+  .about-modal {
+    width: 320px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+  }
+
+  .about-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px 16px 12px;
+    position: relative;
+  }
+
+  .about-logo {
+    margin-bottom: 8px;
+  }
+
+  .about-name {
+    font-size: 15px;
+    font-weight: 650;
+    color: var(--text-primary);
+    letter-spacing: -0.01em;
+  }
+
+  .close-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    color: var(--text-muted);
+    border-radius: var(--radius-sm);
+  }
+
+  .close-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .about-body {
+    padding: 8px 20px 12px;
+  }
+
+  .about-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px 0;
+  }
+
+  .about-label {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  .about-value {
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .about-value.mono {
+    font-family: var(--font-mono);
+    font-size: 11px;
+  }
+
+  .about-footer {
+    padding: 10px 20px;
+    border-top: 1px solid var(--border-default);
+    font-size: 11px;
+    color: var(--text-muted);
+    text-align: center;
+  }
+</style>

--- a/frontend/src/lib/components/modals/AboutModal.svelte
+++ b/frontend/src/lib/components/modals/AboutModal.svelte
@@ -20,6 +20,7 @@
         year: "numeric",
         month: "long",
         day: "numeric",
+        timeZone: "UTC",
       });
     } catch {
       return raw;

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -1,6 +1,7 @@
 type Theme = "light" | "dark";
 export type MessageLayout = "default" | "compact" | "stream";
 type ModalType =
+  | "about"
   | "commandPalette"
   | "shortcuts"
   | "publish"


### PR DESCRIPTION
## Summary
- Add Windows executable metadata (copyright, description, author) to `tauri.conf.json` and `Cargo.toml` so the compiled `.exe` shows version, author, and description in file properties
- Add an About dialog accessible from the native AgentsView menu and by clicking the version number in the status bar, showing app name, author, version, commit, and build date
- Fix `make desktop-macos-app` failing without `TAURI_SIGNING_PRIVATE_KEY` by skipping updater artifact signing for local builds

Closes #124
Closes #129

## Test plan
- [ ] Run `make desktop-macos-app` without `TAURI_SIGNING_PRIVATE_KEY` — should succeed
- [ ] Open the built .app, verify About dialog opens from AgentsView menu
- [ ] Click version number in status bar — should open the same About dialog
- [ ] On Windows, check .exe file properties show version, author, and description
- [ ] Verify `make desktop-build` with `TAURI_SIGNING_PRIVATE_KEY` set still produces updater artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)