### PR TITLE
feat: incremental JSONL parsing for live session updates

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4124,15 +4124,6 @@ func TestGetSessionForIncremental(t *testing.T) {
 		if info.ID != "codex:inc-test" {
 			t.Errorf("ID = %q, want codex:inc-test", info.ID)
 		}
-		if info.Project != "my-project" {
-			t.Errorf("Project = %q", info.Project)
-		}
-		if info.FirstMessage != "hello world" {
-			t.Errorf("FirstMessage = %q", info.FirstMessage)
-		}
-		if info.StartedAt != "2024-01-15T10:00:00Z" {
-			t.Errorf("StartedAt = %q", info.StartedAt)
-		}
 		if info.FileSize != 4096 {
 			t.Errorf("FileSize = %d, want 4096", info.FileSize)
 		}
@@ -4151,4 +4142,94 @@ func TestGetSessionForIncremental(t *testing.T) {
 			t.Error("expected not found")
 		}
 	})
+
+	t.Run("multi_session_bails_out", func(t *testing.T) {
+		// Two sessions sharing the same file_path (Claude
+		// DAG fork) should prevent incremental parsing.
+		path := "/tmp/sessions/forked.jsonl"
+		for _, id := range []string{"fork-main", "fork-1"} {
+			requireNoError(t, d.UpsertSession(Session{
+				ID:       id,
+				Agent:    "claude",
+				FilePath: Ptr(path),
+				FileSize: Ptr(int64(8192)),
+			}), "upsert "+id)
+		}
+		_, ok := d.GetSessionForIncremental(path)
+		if ok {
+			t.Error(
+				"expected false for multi-session file",
+			)
+		}
+	})
+}
+
+func TestUpdateSessionIncremental(t *testing.T) {
+	d := testDB(t)
+
+	// Insert a session with all fields populated.
+	s := Session{
+		ID:               "inc-update",
+		Project:          "my-project",
+		Machine:          "test",
+		Agent:            "codex",
+		FirstMessage:     Ptr("hello"),
+		StartedAt:        Ptr("2024-01-15T10:00:00Z"),
+		MessageCount:     3,
+		UserMessageCount: 1,
+		ParentSessionID:  Ptr("parent-1"),
+		RelationshipType: "continuation",
+		FilePath:         Ptr("/tmp/sessions/update.jsonl"),
+		FileSize:         Ptr(int64(1024)),
+		FileMtime:        Ptr(int64(100)),
+		FileHash:         Ptr("abc123"),
+	}
+	requireNoError(t, d.UpsertSession(s), "upsert")
+
+	// Incremental update: bump counts and file metadata.
+	ended := "2024-01-15T10:30:00Z"
+	err := d.UpdateSessionIncremental(
+		"inc-update", &ended, 7, 3, 2048, 200,
+	)
+	requireNoError(t, err, "incremental update")
+
+	// Verify updated fields changed.
+	got, err := d.GetSessionFull(
+		context.Background(), "inc-update",
+	)
+	requireNoError(t, err, "get session")
+	if got.MessageCount != 7 {
+		t.Errorf("MessageCount = %d, want 7",
+			got.MessageCount)
+	}
+	if got.UserMessageCount != 3 {
+		t.Errorf("UserMessageCount = %d, want 3",
+			got.UserMessageCount)
+	}
+	if got.EndedAt == nil || *got.EndedAt != ended {
+		t.Errorf("EndedAt = %v, want %q", got.EndedAt, ended)
+	}
+	if got.FileSize == nil || *got.FileSize != 2048 {
+		t.Errorf("FileSize = %v, want 2048", got.FileSize)
+	}
+
+	// Verify preserved fields were NOT cleared.
+	if got.FirstMessage == nil || *got.FirstMessage != "hello" {
+		t.Errorf("FirstMessage cleared: %v", got.FirstMessage)
+	}
+	if got.Project != "my-project" {
+		t.Errorf("Project cleared: %q", got.Project)
+	}
+	if got.ParentSessionID == nil ||
+		*got.ParentSessionID != "parent-1" {
+		t.Errorf("ParentSessionID cleared: %v",
+			got.ParentSessionID)
+	}
+	if got.RelationshipType != "continuation" {
+		t.Errorf("RelationshipType cleared: %q",
+			got.RelationshipType)
+	}
+	if got.FileHash == nil || *got.FileHash != "abc123" {
+		t.Errorf("FileHash cleared: %v", got.FileHash)
+	}
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4094,3 +4094,61 @@ CREATE TABLE IF NOT EXISTS insights (
 	)
 	requireNoError(t, err, "writing deleted_at")
 }
+
+func TestGetSessionForIncremental(t *testing.T) {
+	d := testDB(t)
+
+	s := Session{
+		ID:               "codex:inc-test",
+		Project:          "my-project",
+		Machine:          "test",
+		Agent:            "codex",
+		FirstMessage:     Ptr("hello world"),
+		StartedAt:        Ptr("2024-01-15T10:00:00Z"),
+		EndedAt:          Ptr("2024-01-15T10:30:00Z"),
+		MessageCount:     5,
+		UserMessageCount: 2,
+		FilePath:         Ptr("/tmp/sessions/test.jsonl"),
+		FileSize:         Ptr(int64(4096)),
+		FileMtime:        Ptr(int64(999)),
+	}
+	requireNoError(t, d.UpsertSession(s), "upsert")
+
+	t.Run("found", func(t *testing.T) {
+		info, ok := d.GetSessionForIncremental(
+			"/tmp/sessions/test.jsonl",
+		)
+		if !ok {
+			t.Fatal("expected to find session")
+		}
+		if info.ID != "codex:inc-test" {
+			t.Errorf("ID = %q, want codex:inc-test", info.ID)
+		}
+		if info.Project != "my-project" {
+			t.Errorf("Project = %q", info.Project)
+		}
+		if info.FirstMessage != "hello world" {
+			t.Errorf("FirstMessage = %q", info.FirstMessage)
+		}
+		if info.StartedAt != "2024-01-15T10:00:00Z" {
+			t.Errorf("StartedAt = %q", info.StartedAt)
+		}
+		if info.FileSize != 4096 {
+			t.Errorf("FileSize = %d, want 4096", info.FileSize)
+		}
+		if info.MsgCount != 5 {
+			t.Errorf("MsgCount = %d, want 5", info.MsgCount)
+		}
+		if info.UserMsgCount != 2 {
+			t.Errorf("UserMsgCount = %d, want 2",
+				info.UserMsgCount)
+		}
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		_, ok := d.GetSessionForIncremental("/no/such/file")
+		if ok {
+			t.Error("expected not found")
+		}
+	})
+}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -591,45 +591,78 @@ func (db *DB) GetSessionMessageCount(
 // re-parsing of an append-only session file.
 type IncrementalInfo struct {
 	ID           string
-	Project      string
-	FirstMessage string
-	StartedAt    string
 	FileSize     int64
 	MsgCount     int
 	UserMsgCount int
 }
 
 // GetSessionForIncremental returns session state needed for
-// incremental parsing, looked up by file_path.
+// incremental parsing, looked up by file_path. Returns false
+// when the path is unknown or maps to multiple sessions (e.g.
+// Claude DAG forks), since incremental parsing cannot update
+// multiple sessions from a single append.
 func (db *DB) GetSessionForIncremental(
 	path string,
 ) (*IncrementalInfo, bool) {
-	var info IncrementalInfo
-	var fm, sa sql.NullString
-	var fs sql.NullInt64
+	// Bail out if the file maps to more than one session
+	// (Claude fork/subagent splits).
+	var count int
 	err := db.getReader().QueryRow(
-		`SELECT id, project, first_message, started_at,
-			file_size, message_count, user_message_count
-		 FROM sessions WHERE file_path = ?
-		 ORDER BY file_mtime DESC LIMIT 1`,
-		path,
-	).Scan(
-		&info.ID, &info.Project, &fm, &sa,
-		&fs, &info.MsgCount, &info.UserMsgCount,
-	)
-	if err != nil {
+		`SELECT COUNT(*) FROM sessions
+		 WHERE file_path = ?`, path,
+	).Scan(&count)
+	if err != nil || count != 1 {
 		return nil, false
 	}
-	if fm.Valid {
-		info.FirstMessage = fm.String
-	}
-	if sa.Valid {
-		info.StartedAt = sa.String
+
+	var info IncrementalInfo
+	var fs sql.NullInt64
+	err = db.getReader().QueryRow(
+		`SELECT id, file_size, message_count,
+			user_message_count
+		 FROM sessions WHERE file_path = ?`,
+		path,
+	).Scan(&info.ID, &fs, &info.MsgCount, &info.UserMsgCount)
+	if err != nil {
+		return nil, false
 	}
 	if fs.Valid {
 		info.FileSize = fs.Int64
 	}
 	return &info, true
+}
+
+// UpdateSessionIncremental updates only the fields that change
+// during an incremental append: ended_at, message_count,
+// user_message_count, file_size, and file_mtime. All other
+// columns (project, parent_session_id, file_hash, etc.) are
+// preserved.
+func (db *DB) UpdateSessionIncremental(
+	id string,
+	endedAt *string,
+	msgCount, userMsgCount int,
+	fileSize, fileMtime int64,
+) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	_, err := db.getWriter().Exec(`
+		UPDATE sessions SET
+			ended_at = COALESCE(?, ended_at),
+			message_count = ?,
+			user_message_count = ?,
+			file_size = ?,
+			file_mtime = ?
+		WHERE id = ?`,
+		endedAt, msgCount, userMsgCount,
+		fileSize, fileMtime, id,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"incremental update session %s: %w", id, err,
+		)
+	}
+	return nil
 }
 
 // GetFileInfoByPath returns file_size and file_mtime for a

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -587,6 +587,22 @@ func (db *DB) GetSessionMessageCount(
 	return count, true
 }
 
+// GetSessionVersion returns the message count and file mtime
+// for change detection in SSE watchers.
+func (db *DB) GetSessionVersion(
+	id string,
+) (count int, fileMtime int64, ok bool) {
+	err := db.getReader().QueryRow(
+		"SELECT message_count, COALESCE(file_mtime, 0)"+
+			" FROM sessions WHERE id = ?",
+		id,
+	).Scan(&count, &fileMtime)
+	if err != nil {
+		return 0, 0, false
+	}
+	return count, fileMtime, true
+}
+
 // IncrementalInfo holds the data needed for incremental
 // re-parsing of an append-only session file.
 type IncrementalInfo struct {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -572,6 +572,66 @@ func (db *DB) GetSessionFileInfo(
 	return s.Int64, m.Int64, true
 }
 
+// GetSessionMessageCount returns the message_count for a
+// session. Returns (0, false) when the session does not exist.
+func (db *DB) GetSessionMessageCount(
+	id string,
+) (count int, ok bool) {
+	err := db.getReader().QueryRow(
+		"SELECT message_count FROM sessions WHERE id = ?",
+		id,
+	).Scan(&count)
+	if err != nil {
+		return 0, false
+	}
+	return count, true
+}
+
+// IncrementalInfo holds the data needed for incremental
+// re-parsing of an append-only session file.
+type IncrementalInfo struct {
+	ID           string
+	Project      string
+	FirstMessage string
+	StartedAt    string
+	FileSize     int64
+	MsgCount     int
+	UserMsgCount int
+}
+
+// GetSessionForIncremental returns session state needed for
+// incremental parsing, looked up by file_path.
+func (db *DB) GetSessionForIncremental(
+	path string,
+) (*IncrementalInfo, bool) {
+	var info IncrementalInfo
+	var fm, sa sql.NullString
+	var fs sql.NullInt64
+	err := db.getReader().QueryRow(
+		`SELECT id, project, first_message, started_at,
+			file_size, message_count, user_message_count
+		 FROM sessions WHERE file_path = ?
+		 ORDER BY file_mtime DESC LIMIT 1`,
+		path,
+	).Scan(
+		&info.ID, &info.Project, &fm, &sa,
+		&fs, &info.MsgCount, &info.UserMsgCount,
+	)
+	if err != nil {
+		return nil, false
+	}
+	if fm.Valid {
+		info.FirstMessage = fm.String
+	}
+	if sa.Valid {
+		info.StartedAt = sa.String
+	}
+	if fs.Valid {
+		info.FileSize = fs.Int64
+	}
+	return &info, true
+}
+
 // GetFileInfoByPath returns file_size and file_mtime for a
 // session identified by file_path. Used for codex/gemini files
 // where the session ID requires parsing.

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -198,44 +198,62 @@ func ParseClaudeSession(
 // startOrdinal) and the latest timestamp. Fork detection is
 // skipped — new entries are processed linearly. Used for
 // incremental re-parsing of append-only session files.
+// ErrDAGDetected is returned by ParseClaudeSessionFrom when
+// appended lines contain uuid fields that require DAG-aware
+// fork detection, which incremental parsing cannot handle.
+var ErrDAGDetected = fmt.Errorf(
+	"incremental parse: DAG uuid detected",
+)
+
 func ParseClaudeSessionFrom(
 	path string,
 	offset int64,
 	startOrdinal int,
-) ([]ParsedMessage, time.Time, error) {
+) ([]ParsedMessage, time.Time, int64, error) {
 	var entries []dagEntry
 	lineIndex := startOrdinal
 
-	err := readJSONLFrom(path, offset, func(line string) {
-		entryType := gjson.Get(line, "type").Str
-		if entryType != "user" &&
-			entryType != "assistant" {
-			return
-		}
-		ts := extractTimestamp(line)
-		entries = append(entries, dagEntry{
-			entryType: entryType,
-			lineIndex: lineIndex,
-			line:      line,
-			timestamp: ts,
-		})
-		lineIndex++
-	})
+	consumed, err := readJSONLFrom(
+		path, offset, func(line string) {
+			entryType := gjson.Get(line, "type").Str
+			if entryType != "user" &&
+				entryType != "assistant" {
+				return
+			}
+			ts := extractTimestamp(line)
+			entries = append(entries, dagEntry{
+				uuid:      gjson.Get(line, "uuid").Str,
+				entryType: entryType,
+				lineIndex: lineIndex,
+				line:      line,
+				timestamp: ts,
+			})
+			lineIndex++
+		},
+	)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf(
+		return nil, time.Time{}, 0, fmt.Errorf(
 			"reading claude %s from offset %d: %w",
 			path, offset, err,
 		)
 	}
 
 	if len(entries) == 0 {
-		return nil, time.Time{}, nil
+		return nil, time.Time{}, consumed, nil
+	}
+
+	// If any appended line has a uuid, the file uses DAG
+	// structure and needs full fork detection.
+	for _, e := range entries {
+		if e.uuid != "" {
+			return nil, time.Time{}, 0, ErrDAGDetected
+		}
 	}
 
 	msgs, _, endedAt := extractMessagesFrom(
 		entries, startOrdinal,
 	)
-	return msgs, endedAt, nil
+	return msgs, endedAt, consumed, nil
 }
 
 // extractMessagesFrom is like extractMessages but uses a

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -210,11 +210,23 @@ func ParseClaudeSessionFrom(
 	offset int64,
 	startOrdinal int,
 ) ([]ParsedMessage, time.Time, int64, error) {
-	var entries []dagEntry
-	lineIndex := startOrdinal
+	var (
+		entries   []dagEntry
+		lineIndex = startOrdinal
+		// Track latest timestamp from all lines, including
+		// non-message events (progress, queue-operation) so
+		// callers can update ended_at even when no new
+		// messages are found.
+		latestTS time.Time
+	)
 
 	consumed, err := readJSONLFrom(
 		path, offset, func(line string) {
+			if ts := extractTimestamp(line); !ts.IsZero() {
+				if ts.After(latestTS) {
+					latestTS = ts
+				}
+			}
 			entryType := gjson.Get(line, "type").Str
 			if entryType != "user" &&
 				entryType != "assistant" {
@@ -240,7 +252,7 @@ func ParseClaudeSessionFrom(
 	}
 
 	if len(entries) == 0 {
-		return nil, time.Time{}, consumed, nil
+		return nil, latestTS, consumed, nil
 	}
 
 	// Detect forks: if any entry's parentUuid doesn't
@@ -253,6 +265,12 @@ func ParseClaudeSessionFrom(
 	msgs, _, endedAt := extractMessagesFrom(
 		entries, startOrdinal,
 	)
+	// Use the latest timestamp from all lines (including
+	// non-message events) if it's later than what
+	// extractMessagesFrom found.
+	if latestTS.After(endedAt) {
+		endedAt = latestTS
+	}
 	return msgs, endedAt, consumed, nil
 }
 

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -4,7 +4,6 @@ package parser
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -204,36 +203,15 @@ func ParseClaudeSessionFrom(
 	offset int64,
 	startOrdinal int,
 ) ([]ParsedMessage, time.Time, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, time.Time{},
-			fmt.Errorf("open %s: %w", path, err)
-	}
-	defer f.Close()
-
-	if _, err := f.Seek(offset, io.SeekStart); err != nil {
-		return nil, time.Time{},
-			fmt.Errorf("seek %s to %d: %w", path, offset, err)
-	}
-
-	lr := newLineReader(f, maxLineSize)
 	var entries []dagEntry
 	lineIndex := startOrdinal
 
-	for {
-		line, ok := lr.next()
-		if !ok {
-			break
-		}
-		if !gjson.Valid(line) {
-			continue
-		}
-
+	err := readJSONLFrom(path, offset, func(line string) {
 		entryType := gjson.Get(line, "type").Str
-		if entryType != "user" && entryType != "assistant" {
-			continue
+		if entryType != "user" &&
+			entryType != "assistant" {
+			return
 		}
-
 		ts := extractTimestamp(line)
 		entries = append(entries, dagEntry{
 			entryType: entryType,
@@ -242,9 +220,8 @@ func ParseClaudeSessionFrom(
 			timestamp: ts,
 		})
 		lineIndex++
-	}
-
-	if err := lr.Err(); err != nil {
+	})
+	if err != nil {
 		return nil, time.Time{}, fmt.Errorf(
 			"reading claude %s from offset %d: %w",
 			path, offset, err,

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -280,21 +280,16 @@ func ParseClaudeSessionFrom(
 // (each entry parenting the next) are safe for incremental
 // parsing; forks require full DAG processing.
 func hasDAGFork(entries []dagEntry) bool {
-	for i, e := range entries {
+	var lastUUID string
+	for _, e := range entries {
 		if e.uuid == "" {
 			continue // non-UUID entries are always linear
 		}
-		if i == 0 {
-			// First appended entry — its parentUuid
-			// points into the pre-existing data which we
-			// can't verify here, so accept it.
-			continue
-		}
-		prev := entries[i-1]
-		if prev.uuid != "" &&
-			e.parentUuid != prev.uuid {
+		if lastUUID != "" &&
+			e.parentUuid != lastUUID {
 			return true
 		}
+		lastUUID = e.uuid
 	}
 	return false
 }

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -222,11 +222,12 @@ func ParseClaudeSessionFrom(
 			}
 			ts := extractTimestamp(line)
 			entries = append(entries, dagEntry{
-				uuid:      gjson.Get(line, "uuid").Str,
-				entryType: entryType,
-				lineIndex: lineIndex,
-				line:      line,
-				timestamp: ts,
+				uuid:       gjson.Get(line, "uuid").Str,
+				parentUuid: gjson.Get(line, "parentUuid").Str,
+				entryType:  entryType,
+				lineIndex:  lineIndex,
+				line:       line,
+				timestamp:  ts,
 			})
 			lineIndex++
 		},
@@ -242,18 +243,42 @@ func ParseClaudeSessionFrom(
 		return nil, time.Time{}, consumed, nil
 	}
 
-	// If any appended line has a uuid, the file uses DAG
-	// structure and needs full fork detection.
-	for _, e := range entries {
-		if e.uuid != "" {
-			return nil, time.Time{}, 0, ErrDAGDetected
-		}
+	// Detect forks: if any entry's parentUuid doesn't
+	// match the previous entry's uuid, the appended data
+	// contains a branch that requires full DAG processing.
+	if hasDAGFork(entries) {
+		return nil, time.Time{}, 0, ErrDAGDetected
 	}
 
 	msgs, _, endedAt := extractMessagesFrom(
 		entries, startOrdinal,
 	)
 	return msgs, endedAt, consumed, nil
+}
+
+// hasDAGFork returns true if the entries contain a fork —
+// i.e. any entry whose parentUuid doesn't point to the
+// immediately preceding entry's uuid. Linear UUID chains
+// (each entry parenting the next) are safe for incremental
+// parsing; forks require full DAG processing.
+func hasDAGFork(entries []dagEntry) bool {
+	for i, e := range entries {
+		if e.uuid == "" {
+			continue // non-UUID entries are always linear
+		}
+		if i == 0 {
+			// First appended entry — its parentUuid
+			// points into the pre-existing data which we
+			// can't verify here, so accept it.
+			continue
+		}
+		prev := entries[i-1]
+		if prev.uuid != "" &&
+			e.parentUuid != prev.uuid {
+			return true
+		}
+	}
+	return false
 }
 
 // extractMessagesFrom is like extractMessages but uses a

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -4,6 +4,7 @@ package parser
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -190,6 +191,130 @@ func ParseClaudeSession(
 		parentSessionID, fileInfo, subagentMap,
 		globalStart, globalEnd,
 	)
+}
+
+// ParseClaudeSessionFrom parses only new lines from a Claude
+// JSONL file starting at the given byte offset. Returns only
+// the newly parsed messages (with ordinals starting at
+// startOrdinal) and the latest timestamp. Fork detection is
+// skipped — new entries are processed linearly. Used for
+// incremental re-parsing of append-only session files.
+func ParseClaudeSessionFrom(
+	path string,
+	offset int64,
+	startOrdinal int,
+) ([]ParsedMessage, time.Time, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, time.Time{},
+			fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, time.Time{},
+			fmt.Errorf("seek %s to %d: %w", path, offset, err)
+	}
+
+	lr := newLineReader(f, maxLineSize)
+	var entries []dagEntry
+	lineIndex := startOrdinal
+
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if !gjson.Valid(line) {
+			continue
+		}
+
+		entryType := gjson.Get(line, "type").Str
+		if entryType != "user" && entryType != "assistant" {
+			continue
+		}
+
+		ts := extractTimestamp(line)
+		entries = append(entries, dagEntry{
+			entryType: entryType,
+			lineIndex: lineIndex,
+			line:      line,
+			timestamp: ts,
+		})
+		lineIndex++
+	}
+
+	if err := lr.Err(); err != nil {
+		return nil, time.Time{}, fmt.Errorf(
+			"reading claude %s from offset %d: %w",
+			path, offset, err,
+		)
+	}
+
+	if len(entries) == 0 {
+		return nil, time.Time{}, nil
+	}
+
+	msgs, _, endedAt := extractMessagesFrom(
+		entries, startOrdinal,
+	)
+	return msgs, endedAt, nil
+}
+
+// extractMessagesFrom is like extractMessages but uses a
+// custom starting ordinal for incremental parsing.
+func extractMessagesFrom(
+	entries []dagEntry, startOrdinal int,
+) ([]ParsedMessage, time.Time, time.Time) {
+	var (
+		messages  []ParsedMessage
+		startedAt time.Time
+		endedAt   time.Time
+		ordinal   = startOrdinal
+	)
+
+	for _, e := range entries {
+		if !e.timestamp.IsZero() {
+			if startedAt.IsZero() {
+				startedAt = e.timestamp
+			}
+			endedAt = e.timestamp
+		}
+
+		if e.entryType == "user" {
+			if gjson.Get(e.line, "isMeta").Bool() ||
+				gjson.Get(e.line, "isCompactSummary").Bool() {
+				continue
+			}
+		}
+
+		content := gjson.Get(e.line, "message.content")
+		text, hasThinking, hasToolUse, tcs, trs :=
+			ExtractTextContent(content)
+		if strings.TrimSpace(text) == "" && len(trs) == 0 {
+			continue
+		}
+
+		if e.entryType == "user" &&
+			isClaudeSystemMessage(text) {
+			continue
+		}
+
+		messages = append(messages, ParsedMessage{
+			Ordinal:       ordinal,
+			Role:          RoleType(e.entryType),
+			Content:       text,
+			Timestamp:     e.timestamp,
+			HasThinking:   hasThinking,
+			HasToolUse:    hasToolUse,
+			ContentLength: len(text),
+			ToolCalls:     tcs,
+			ToolResults:   trs,
+		})
+		ordinal++
+	}
+
+	return messages, startedAt, endedAt
 }
 
 // parseLinear processes entries sequentially without DAG awareness.

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -236,7 +236,7 @@ func TestParseClaudeSessionFrom_Incremental(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	// Incremental parse from offset.
-	newMsgs, endedAt, err := ParseClaudeSessionFrom(
+	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
 		path, offset, 2,
 	)
 	require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestParseClaudeSessionFrom_SkipsNonMessages(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, err := ParseClaudeSessionFrom(
+	newMsgs, _, _, err := ParseClaudeSessionFrom(
 		path, offset, 1,
 	)
 	require.NoError(t, err)
@@ -307,12 +307,87 @@ func TestParseClaudeSessionFrom_NoNewData(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse from EOF — should return empty.
-	newMsgs, endedAt, err := ParseClaudeSessionFrom(
+	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
 		path, info.Size(), 1,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, newMsgs)
 	assert.True(t, endedAt.IsZero())
+}
+
+func TestParseClaudeSessionFrom_PartialLineAtEOF(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-partial.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Append a complete line + a partial (truncated) line.
+	complete := testjsonl.ClaudeAssistantJSON(
+		"complete", tsEarlyS5,
+	) + "\n"
+	partial := `{"type":"user","timestamp":"` + tsLate
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(complete + partial)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, consumed, err := ParseClaudeSessionFrom(
+		path, offset, 1,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(newMsgs))
+	assert.Equal(t, RoleAssistant, newMsgs[0].Role)
+
+	// consumed should cover only the complete line, not
+	// the partial one.
+	assert.Equal(t, int64(len(complete)), consumed)
+}
+
+func TestParseClaudeSessionFrom_DAGDetected(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-dag.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Append a line with a uuid field (DAG structure).
+	dagLine := `{"type":"user","uuid":"abc-123",` +
+		`"timestamp":"` + tsEarlyS5 +
+		`","message":{"content":"fork"}}` + "\n"
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(dagLine)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseClaudeSessionFrom(
+		path, offset, 1,
+	)
+	assert.ErrorIs(t, err, ErrDAGDetected)
 }
 
 func loadFixture(t *testing.T, name string) string {

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -398,6 +398,53 @@ func TestParseClaudeSessionFrom_DAGDetected(
 	assert.ErrorIs(t, err, ErrDAGDetected)
 }
 
+func TestParseClaudeSessionFrom_DAGAcrossNonUUID(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-dag-gap.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Append: UUID entry, then a non-UUID entry (no uuid
+	// field), then another UUID entry whose parentUuid
+	// doesn't match the first UUID entry. The non-UUID gap
+	// must not prevent fork detection.
+	line1 := `{"type":"user","uuid":"u1",` +
+		`"parentUuid":"pre",` +
+		`"timestamp":"` + tsEarlyS5 +
+		`","message":{"content":"a"}}` + "\n"
+	noUUID := `{"type":"user",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"content":"gap"}}` + "\n"
+	line2 := `{"type":"assistant","uuid":"u2",` +
+		`"parentUuid":"other",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"content":[` +
+		`{"type":"text","text":"b"}]}}` + "\n"
+
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(line1 + noUUID + line2)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseClaudeSessionFrom(
+		path, offset, 1,
+	)
+	assert.ErrorIs(t, err, ErrDAGDetected)
+}
+
 func TestParseClaudeSessionFrom_LinearUUID(
 	t *testing.T,
 ) {

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -372,15 +372,23 @@ func TestParseClaudeSessionFrom_DAGDetected(
 	require.NoError(t, err)
 	offset := info.Size()
 
-	// Append a line with a uuid field (DAG structure).
-	dagLine := `{"type":"user","uuid":"abc-123",` +
+	// Append two entries that form a fork: both have the
+	// same parentUuid but different uuids.
+	fork1 := `{"type":"user","uuid":"child-1",` +
+		`"parentUuid":"root-1",` +
 		`"timestamp":"` + tsEarlyS5 +
-		`","message":{"content":"fork"}}` + "\n"
+		`","message":{"content":"branch A"}}` + "\n"
+	fork2 := `{"type":"assistant","uuid":"child-2",` +
+		`"parentUuid":"root-1",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"content":[` +
+		`{"type":"text","text":"branch B"}]}}` + "\n"
+
 	f, err := os.OpenFile(
 		path, os.O_APPEND|os.O_WRONLY, 0o644,
 	)
 	require.NoError(t, err)
-	_, err = f.WriteString(dagLine)
+	_, err = f.WriteString(fork1 + fork2)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
@@ -388,6 +396,53 @@ func TestParseClaudeSessionFrom_DAGDetected(
 		path, offset, 1,
 	)
 	assert.ErrorIs(t, err, ErrDAGDetected)
+}
+
+func TestParseClaudeSessionFrom_LinearUUID(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-linear-uuid.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Append UUID-bearing entries that form a linear chain
+	// (each entry's parentUuid == previous entry's uuid).
+	// This should NOT trigger ErrDAGDetected.
+	line1 := `{"type":"user","uuid":"u1",` +
+		`"parentUuid":"pre-existing",` +
+		`"timestamp":"` + tsEarlyS5 +
+		`","message":{"content":"msg1"}}` + "\n"
+	line2 := `{"type":"assistant","uuid":"u2",` +
+		`"parentUuid":"u1",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"content":[` +
+		`{"type":"text","text":"reply"}]}}` + "\n"
+
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(line1 + line2)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
+		path, offset, 1,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(newMsgs))
+	assert.Equal(t, 1, newMsgs[0].Ordinal)
+	assert.Equal(t, 2, newMsgs[1].Ordinal)
+	assert.False(t, endedAt.IsZero())
 }
 
 func loadFixture(t *testing.T, name string) string {

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -198,6 +198,123 @@ func TestParseClaudeSession_ParentSessionID(t *testing.T) {
 	})
 }
 
+func TestParseClaudeSessionFrom_Incremental(t *testing.T) {
+	t.Parallel()
+
+	// Build initial content: user + assistant.
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello world", tsEarly),
+		testjsonl.ClaudeAssistantJSON("hi there", tsEarlyS1),
+	)
+
+	path := createTestFile(t, "inc-claude.jsonl", initial)
+
+	// Full parse to get baseline.
+	results, err := ParseClaudeSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	assert.Equal(t, 2, len(results[0].Messages))
+	assert.Equal(t, 0, results[0].Messages[0].Ordinal)
+	assert.Equal(t, 1, results[0].Messages[1].Ordinal)
+
+	// Record file size as the incremental offset.
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Append new messages.
+	appended := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("follow up", tsEarlyS5),
+		testjsonl.ClaudeAssistantJSON("got it", tsLate),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Incremental parse from offset.
+	newMsgs, endedAt, err := ParseClaudeSessionFrom(
+		path, offset, 2,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(newMsgs))
+
+	// Ordinals continue from startOrdinal=2.
+	assert.Equal(t, 2, newMsgs[0].Ordinal)
+	assert.Equal(t, RoleUser, newMsgs[0].Role)
+	assert.Contains(t, newMsgs[0].Content, "follow up")
+
+	assert.Equal(t, 3, newMsgs[1].Ordinal)
+	assert.Equal(t, RoleAssistant, newMsgs[1].Role)
+	assert.Contains(t, newMsgs[1].Content, "got it")
+
+	assert.False(t, endedAt.IsZero())
+}
+
+func TestParseClaudeSessionFrom_SkipsNonMessages(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Initial content with a "system" type line mixed in.
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-claude-skip.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Append a system line followed by a real message.
+	appended := `{"type":"system","timestamp":"` +
+		tsEarlyS5 + `","message":{}}` + "\n" +
+		testjsonl.ClaudeAssistantJSON("response", tsLate) +
+		"\n"
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, err := ParseClaudeSessionFrom(
+		path, offset, 1,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(newMsgs))
+	assert.Equal(t, RoleAssistant, newMsgs[0].Role)
+	assert.Equal(t, 1, newMsgs[0].Ordinal)
+}
+
+func TestParseClaudeSessionFrom_NoNewData(t *testing.T) {
+	t.Parallel()
+
+	content := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("only msg", tsEarly),
+	)
+	path := createTestFile(
+		t, "inc-claude-empty.jsonl", content,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	// Parse from EOF — should return empty.
+	newMsgs, endedAt, err := ParseClaudeSessionFrom(
+		path, info.Size(), 1,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, newMsgs)
+	assert.True(t, endedAt.IsZero())
+}
+
 func loadFixture(t *testing.T, name string) string {
 	t.Helper()
 	path := filepath.Join("testdata", name)

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -612,39 +611,19 @@ func ParseCodexSessionFrom(
 	startOrdinal int,
 	includeExec bool,
 ) ([]ParsedMessage, time.Time, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, time.Time{},
-			fmt.Errorf("open %s: %w", path, err)
-	}
-	defer f.Close()
-
-	if _, err := f.Seek(offset, io.SeekStart); err != nil {
-		return nil, time.Time{},
-			fmt.Errorf("seek %s to %d: %w", path, offset, err)
-	}
-
-	lr := newLineReader(f, maxLineSize)
 	b := newCodexSessionBuilder(includeExec)
 	b.ordinal = startOrdinal
 
-	for {
-		line, ok := lr.next()
-		if !ok {
-			break
-		}
-		if !gjson.Valid(line) {
-			continue
-		}
+	err := readJSONLFrom(path, offset, func(line string) {
 		// Skip session_meta — already processed in the
 		// initial full parse.
-		if gjson.Get(line, "type").Str == codexTypeSessionMeta {
-			continue
+		if gjson.Get(line, "type").Str ==
+			codexTypeSessionMeta {
+			return
 		}
 		b.processLine(line)
-	}
-
-	if err := lr.Err(); err != nil {
+	})
+	if err != nil {
 		return nil, time.Time{}, fmt.Errorf(
 			"reading codex %s from offset %d: %w",
 			path, offset, err,

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -610,27 +610,29 @@ func ParseCodexSessionFrom(
 	offset int64,
 	startOrdinal int,
 	includeExec bool,
-) ([]ParsedMessage, time.Time, error) {
+) ([]ParsedMessage, time.Time, int64, error) {
 	b := newCodexSessionBuilder(includeExec)
 	b.ordinal = startOrdinal
 
-	err := readJSONLFrom(path, offset, func(line string) {
-		// Skip session_meta — already processed in the
-		// initial full parse.
-		if gjson.Get(line, "type").Str ==
-			codexTypeSessionMeta {
-			return
-		}
-		b.processLine(line)
-	})
+	consumed, err := readJSONLFrom(
+		path, offset, func(line string) {
+			// Skip session_meta — already processed in
+			// the initial full parse.
+			if gjson.Get(line, "type").Str ==
+				codexTypeSessionMeta {
+				return
+			}
+			b.processLine(line)
+		},
+	)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf(
+		return nil, time.Time{}, 0, fmt.Errorf(
 			"reading codex %s from offset %d: %w",
 			path, offset, err,
 		)
 	}
 
-	return b.messages, b.endedAt, nil
+	return b.messages, b.endedAt, consumed, nil
 }
 
 func isCodexSystemMessage(content string) bool {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -598,6 +599,59 @@ func ParseCodexSession(
 	}
 
 	return sess, b.messages, nil
+}
+
+// ParseCodexSessionFrom parses only new lines from a Codex
+// JSONL file starting at the given byte offset. Returns only
+// the newly parsed messages (with ordinals starting at
+// startOrdinal) and the latest timestamp seen. Used for
+// incremental re-parsing of large append-only session files.
+func ParseCodexSessionFrom(
+	path string,
+	offset int64,
+	startOrdinal int,
+	includeExec bool,
+) ([]ParsedMessage, time.Time, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, time.Time{},
+			fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return nil, time.Time{},
+			fmt.Errorf("seek %s to %d: %w", path, offset, err)
+	}
+
+	lr := newLineReader(f, maxLineSize)
+	b := newCodexSessionBuilder(includeExec)
+	b.ordinal = startOrdinal
+
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if !gjson.Valid(line) {
+			continue
+		}
+		// Skip session_meta — already processed in the
+		// initial full parse.
+		if gjson.Get(line, "type").Str == codexTypeSessionMeta {
+			continue
+		}
+		b.processLine(line)
+	}
+
+	if err := lr.Err(); err != nil {
+		return nil, time.Time{}, fmt.Errorf(
+			"reading codex %s from offset %d: %w",
+			path, offset, err,
+		)
+	}
+
+	return b.messages, b.endedAt, nil
 }
 
 func isCodexSystemMessage(content string) bool {

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -374,7 +374,7 @@ func TestParseCodexSessionFrom_Incremental(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	// Incremental parse from the offset.
-	newMsgs, endedAt, err := ParseCodexSessionFrom(
+	newMsgs, endedAt, _, err := ParseCodexSessionFrom(
 		path, offset, 1, false,
 	)
 	require.NoError(t, err)
@@ -423,7 +423,7 @@ func TestParseCodexSessionFrom_SkipsSessionMeta(t *testing.T) {
 	f.WriteString(extra)
 	f.Close()
 
-	newMsgs, _, err := ParseCodexSessionFrom(
+	newMsgs, _, _, err := ParseCodexSessionFrom(
 		path, offset, 5, false,
 	)
 	require.NoError(t, err)
@@ -447,7 +447,7 @@ func TestParseCodexSessionFrom_NoNewData(t *testing.T) {
 	offset := info.Size()
 
 	// Parse from end of file — no new data.
-	newMsgs, endedAt, err := ParseCodexSessionFrom(
+	newMsgs, endedAt, _, err := ParseCodexSessionFrom(
 		path, offset, 10, false,
 	)
 	require.NoError(t, err)

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -326,4 +327,130 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 		assert.Equal(t, 1, len(msgs))
 		assert.Equal(t, "unknown", sess.Project)
 	})
+}
+
+func TestParseCodexSessionFrom_Incremental(t *testing.T) {
+	t.Parallel()
+
+	// Build initial content with session_meta + one message.
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"inc-1", "/projects/api",
+			"codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	)
+
+	path := createTestFile(t, "incremental.jsonl", initial)
+
+	// Full parse to get baseline.
+	sess, msgs, err := ParseCodexSession(path, "local", false)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "codex:inc-1", sess.ID)
+	assert.Equal(t, 1, len(msgs))
+	assert.Equal(t, 0, msgs[0].Ordinal)
+
+	// Record the file size as the incremental offset.
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Append new messages.
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON(
+			"assistant", "world", tsEarlyS5,
+		),
+		testjsonl.CodexMsgJSON(
+			"user", "thanks", tsLate,
+		),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Incremental parse from the offset.
+	newMsgs, endedAt, err := ParseCodexSessionFrom(
+		path, offset, 1, false,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(newMsgs))
+
+	// Ordinals start from startOrdinal=1.
+	assert.Equal(t, 1, newMsgs[0].Ordinal)
+	assert.Equal(t, RoleAssistant, newMsgs[0].Role)
+	assert.Contains(t, newMsgs[0].Content, "world")
+
+	assert.Equal(t, 2, newMsgs[1].Ordinal)
+	assert.Equal(t, RoleUser, newMsgs[1].Role)
+
+	// endedAt reflects the latest timestamp.
+	assert.False(t, endedAt.IsZero())
+}
+
+func TestParseCodexSessionFrom_SkipsSessionMeta(t *testing.T) {
+	t.Parallel()
+
+	// File where session_meta appears after the offset
+	// (shouldn't happen in practice but should be skipped).
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"meta-2", "/tmp", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "first", tsEarlyS1),
+	)
+	path := createTestFile(t, "meta-skip.jsonl", initial)
+
+	info, _ := os.Stat(path)
+	offset := info.Size()
+
+	// Append a duplicate session_meta + a message.
+	extra := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"meta-2", "/tmp", "codex_cli_rs", tsEarlyS5,
+		),
+		testjsonl.CodexMsgJSON(
+			"assistant", "reply", tsLate,
+		),
+	)
+	f, _ := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	f.WriteString(extra)
+	f.Close()
+
+	newMsgs, _, err := ParseCodexSessionFrom(
+		path, offset, 5, false,
+	)
+	require.NoError(t, err)
+	// Only the assistant message, not the session_meta.
+	assert.Equal(t, 1, len(newMsgs))
+	assert.Equal(t, 5, newMsgs[0].Ordinal)
+}
+
+func TestParseCodexSessionFrom_NoNewData(t *testing.T) {
+	t.Parallel()
+
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"empty-1", "/tmp", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hi", tsEarlyS1),
+	)
+	path := createTestFile(t, "no-new.jsonl", content)
+
+	info, _ := os.Stat(path)
+	offset := info.Size()
+
+	// Parse from end of file — no new data.
+	newMsgs, endedAt, err := ParseCodexSessionFrom(
+		path, offset, 10, false,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(newMsgs))
+	assert.True(t, endedAt.IsZero())
 }

--- a/internal/parser/linereader.go
+++ b/internal/parser/linereader.go
@@ -9,20 +9,36 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// countingReader wraps an io.Reader and counts bytes read.
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (cr *countingReader) Read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	cr.n += int64(n)
+	return n, err
+}
+
 // lineReader reads JSONL files line by line, skipping lines that
 // exceed maxLen rather than aborting. The buffer starts small and
 // grows on demand up to maxLen. After iteration, call Err() to
 // check for I/O errors (as opposed to normal EOF).
 type lineReader struct {
-	r      *bufio.Reader
-	maxLen int
-	buf    []byte
-	err    error
+	r         *bufio.Reader
+	cr        *countingReader
+	maxLen    int
+	buf       []byte
+	err       error
+	bytesRead int64 // total bytes consumed (from countingReader)
 }
 
 func newLineReader(r io.Reader, maxLen int) *lineReader {
+	cr := &countingReader{r: r}
 	return &lineReader{
-		r:      bufio.NewReaderSize(r, initialScanBufSize),
+		r:      bufio.NewReaderSize(cr, initialScanBufSize),
+		cr:     cr,
 		maxLen: maxLen,
 		buf:    make([]byte, 0, initialScanBufSize),
 	}
@@ -54,6 +70,15 @@ func (lr *lineReader) Err() error {
 
 // readLine reads a full line, returning "" for blank/oversized
 // lines and a non-nil error only at EOF or read failure.
+// updateBytesRead computes total bytes consumed by
+// subtracting any buffered-but-not-consumed data from the
+// countingReader total.
+func (lr *lineReader) updateBytesRead() {
+	if lr.cr != nil {
+		lr.bytesRead = lr.cr.n - int64(lr.r.Buffered())
+	}
+}
+
 func (lr *lineReader) readLine() (string, error) {
 	lr.buf = lr.buf[:0]
 	oversized := false
@@ -62,6 +87,7 @@ func (lr *lineReader) readLine() (string, error) {
 		chunk, isPrefix, err := lr.r.ReadLine()
 		if err != nil {
 			if len(lr.buf) > 0 && err == io.EOF {
+				lr.updateBytesRead()
 				break
 			}
 			return "", err
@@ -69,6 +95,7 @@ func (lr *lineReader) readLine() (string, error) {
 
 		if oversized {
 			if !isPrefix {
+				lr.updateBytesRead()
 				return "", nil // done skipping
 			}
 			continue
@@ -80,12 +107,14 @@ func (lr *lineReader) readLine() (string, error) {
 			oversized = true
 			lr.buf = lr.buf[:0]
 			if !isPrefix {
+				lr.updateBytesRead()
 				return "", nil
 			}
 			continue
 		}
 
 		if !isPrefix {
+			lr.updateBytesRead()
 			break
 		}
 	}
@@ -94,18 +123,22 @@ func (lr *lineReader) readLine() (string, error) {
 }
 
 // readJSONLFrom opens a JSONL file, seeks to offset, and
-// calls fn for each valid JSON line. Returns any I/O error.
+// calls fn for each valid JSON line. Returns the number of
+// bytes consumed (relative to offset) and any I/O error. The
+// returned byte count covers only complete lines, so callers
+// can use offset+consumed as a safe resume point even if the
+// file had a partially written line at EOF.
 func readJSONLFrom(
 	path string, offset int64, fn func(line string),
-) error {
+) (consumed int64, err error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("open %s: %w", path, err)
+		return 0, fmt.Errorf("open %s: %w", path, err)
 	}
 	defer f.Close()
 
 	if _, err := f.Seek(offset, io.SeekStart); err != nil {
-		return fmt.Errorf(
+		return 0, fmt.Errorf(
 			"seek %s to %d: %w", path, offset, err,
 		)
 	}
@@ -118,7 +151,10 @@ func readJSONLFrom(
 		}
 		if gjson.Valid(line) {
 			fn(line)
+			// Track offset through last valid JSON line
+			// so partial lines at EOF are not skipped.
+			consumed = lr.bytesRead
 		}
 	}
-	return lr.Err()
+	return consumed, lr.Err()
 }

--- a/internal/parser/linereader.go
+++ b/internal/parser/linereader.go
@@ -2,7 +2,11 @@ package parser
 
 import (
 	"bufio"
+	"fmt"
 	"io"
+	"os"
+
+	"github.com/tidwall/gjson"
 )
 
 // lineReader reads JSONL files line by line, skipping lines that
@@ -87,4 +91,34 @@ func (lr *lineReader) readLine() (string, error) {
 	}
 
 	return string(lr.buf), nil
+}
+
+// readJSONLFrom opens a JSONL file, seeks to offset, and
+// calls fn for each valid JSON line. Returns any I/O error.
+func readJSONLFrom(
+	path string, offset int64, fn func(line string),
+) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return fmt.Errorf(
+			"seek %s to %d: %w", path, offset, err,
+		)
+	}
+
+	lr := newLineReader(f, maxLineSize)
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if gjson.Valid(line) {
+			fn(line)
+		}
+	}
+	return lr.Err()
 }

--- a/internal/parser/linereader_test.go
+++ b/internal/parser/linereader_test.go
@@ -90,6 +90,54 @@ func TestLineReader(t *testing.T) {
 	}
 }
 
+func TestLineReaderBytesRead(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int64
+	}{
+		{
+			"complete lines",
+			"aaa\nbbb\n",
+			8, // 3+1+3+1
+		},
+		{
+			"no trailing newline",
+			"aaa\nbbb",
+			7, // 3+1+3 (no newline after bbb)
+		},
+		{
+			"empty",
+			"",
+			0,
+		},
+		{
+			"single line with newline",
+			"hello\n",
+			6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lr := newLineReader(
+				strings.NewReader(tt.input), 100,
+			)
+			for {
+				_, ok := lr.next()
+				if !ok {
+					break
+				}
+			}
+			if lr.bytesRead != tt.want {
+				t.Errorf(
+					"bytesRead = %d, want %d",
+					lr.bytesRead, tt.want,
+				)
+			}
+		})
+	}
+}
+
 func TestLineReaderIOError(t *testing.T) {
 	ioErr := errors.New("disk read failed")
 	r := io.MultiReader(

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -2,27 +2,49 @@ package server
 
 import (
 	"context"
-	"errors"
 	"log"
 	"net/http"
 	"os"
-	"syscall"
 	"time"
 
 	syncpkg "github.com/wesm/agentsview/internal/sync"
 )
 
+// statMtime returns the file's modification time in
+// nanoseconds, or 0 if the file cannot be stat'd.
+func statMtime(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.ModTime().UnixNano()
+}
+
 const (
-	// pollInterval is how often the file watcher checks for changes.
+	// pollInterval is how often the session monitor checks
+	// the database for changes.
 	pollInterval = 1500 * time.Millisecond
-	// heartbeatInterval is how often a keepalive is sent to the
-	// client. Expressed as a multiple of pollInterval (~30s).
+	// heartbeatInterval is how often a keepalive is sent to
+	// the client. Expressed as a multiple of pollInterval
+	// (~30s).
 	heartbeatTicks = 20
+	// syncFallbackDelay is how long to wait after detecting
+	// a file mtime change before attempting a direct sync.
+	// This gives the file watcher time to process the change
+	// through the normal SyncPaths pipeline.
+	syncFallbackDelay = 5 * time.Second
 )
 
-// sessionMonitor polls a session's source file for changes and
-// syncs on modification. It sends on the returned channel after
-// each successful sync. The channel is closed when ctx is done.
+// sessionMonitor polls the database for session changes and
+// signals the returned channel when the message count changes.
+// This is decoupled from file I/O — the file watcher handles
+// syncing files to the database, and this monitor detects the
+// resulting DB changes.
+//
+// As a fallback for sessions the file watcher skips (e.g.
+// codex_exec sessions), it also monitors the source file's
+// mtime and triggers a direct sync when the DB hasn't been
+// updated within syncFallbackDelay.
 func (s *Server) sessionMonitor(
 	ctx context.Context, sessionID string,
 ) <-chan struct{} {
@@ -30,12 +52,17 @@ func (s *Server) sessionMonitor(
 	go func() {
 		defer close(ch)
 
+		// Seed initial state from the database.
+		lastCount, _ := s.db.GetSessionMessageCount(
+			sessionID,
+		)
+
+		// Track file mtime for fallback sync.
 		sourcePath := s.engine.FindSourceFile(sessionID)
-		var lastMtime int64
+		var lastFileMtime int64
+		var fileMtimeChangedAt time.Time
 		if sourcePath != "" {
-			if info, err := os.Stat(sourcePath); err == nil {
-				lastMtime = info.ModTime().UnixNano()
-			}
+			lastFileMtime = statMtime(sourcePath)
 		}
 
 		ticker := time.NewTicker(pollInterval)
@@ -46,8 +73,12 @@ func (s *Server) sessionMonitor(
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				changed := s.checkAndSync(
-					sessionID, &sourcePath, &lastMtime,
+				changed := s.checkDBForChanges(
+					sessionID,
+					&lastCount,
+					&sourcePath,
+					&lastFileMtime,
+					&fileMtimeChangedAt,
 				)
 				if changed {
 					select {
@@ -62,66 +93,80 @@ func (s *Server) sessionMonitor(
 	return ch
 }
 
-// checkAndSync polls the source file and syncs if modified.
-// It updates sourcePath and lastMtime through the pointers.
-// Returns true if the session was synced successfully.
-func (s *Server) checkAndSync(
+// checkDBForChanges polls the database for a session's
+// message_count. If the count changed, it returns true.
+// As a fallback, it monitors file mtime and triggers a
+// direct sync when the watcher hasn't updated the DB.
+func (s *Server) checkDBForChanges(
 	sessionID string,
+	lastCount *int,
 	sourcePath *string,
-	lastMtime *int64,
+	lastFileMtime *int64,
+	fileMtimeChangedAt *time.Time,
 ) bool {
-	if *sourcePath != "" {
-		return s.syncIfModified(
-			sessionID, sourcePath, lastMtime,
-		)
+	// Primary: check if the DB has new data.
+	if count, ok := s.db.GetSessionMessageCount(
+		sessionID,
+	); ok && count != *lastCount {
+		*lastCount = count
+		// DB was updated; clear any pending fallback.
+		*fileMtimeChangedAt = time.Time{}
+		return true
 	}
-	// Try to re-resolve a previously unknown path
-	*sourcePath = s.engine.FindSourceFile(sessionID)
-	if *sourcePath == "" {
-		return false
-	}
-	info, err := os.Stat(*sourcePath)
-	if err != nil {
-		return false
-	}
-	*lastMtime = info.ModTime().UnixNano()
-	if err := s.engine.SyncSingleSession(sessionID); err != nil {
-		log.Printf("watch sync error: %v", err)
-		return false
-	}
-	return true
-}
 
-// syncIfModified checks whether the file at path has been
-// modified since lastMtime. If so, it syncs and updates
-// lastMtime. On not-exist or invalid-path stat errors, clear cache;
-// transient errors preserve cache so checkAndSync can re-try.
-// Returns true on a successful sync.
-func (s *Server) syncIfModified(
-	sessionID string,
-	sourcePath *string,
-	lastMtime *int64,
-) bool {
-	info, err := os.Stat(*sourcePath)
-	if err != nil {
-		// Clear cache if the file is gone or the path is invalid (e.g. ENOTDIR).
-		// Transient errors (like permission denied) preserve the cache.
-		if os.IsNotExist(err) || errors.Is(err, syscall.ENOTDIR) {
-			*sourcePath = ""
-			*lastMtime = 0
+	// Track file mtime for the fallback path.
+	if *sourcePath == "" {
+		*sourcePath = s.engine.FindSourceFile(sessionID)
+		if *sourcePath == "" {
+			return false
 		}
+		*lastFileMtime = statMtime(*sourcePath)
+		// Source file (re-)resolved — trigger fallback sync
+		// immediately since content likely differs from DB.
+		past := time.Now().Add(-syncFallbackDelay)
+		*fileMtimeChangedAt = past
+	}
+
+	mtime := statMtime(*sourcePath)
+	if mtime == 0 {
+		// File disappeared; try to re-resolve later.
+		*sourcePath = ""
+		*lastFileMtime = 0
+		*fileMtimeChangedAt = time.Time{}
 		return false
 	}
-	mtime := info.ModTime().UnixNano()
-	if mtime <= *lastMtime {
-		return false
+
+	if mtime != *lastFileMtime {
+		*lastFileMtime = mtime
+		if fileMtimeChangedAt.IsZero() {
+			now := time.Now()
+			*fileMtimeChangedAt = now
+		}
 	}
-	*lastMtime = mtime
-	if err := s.engine.SyncSingleSession(sessionID); err != nil {
-		log.Printf("watch sync error: %v", err)
-		return false
+
+	// Fallback: if the file changed but the DB hasn't been
+	// updated within syncFallbackDelay, trigger a direct
+	// sync. This handles sessions the watcher skips (e.g.
+	// codex_exec).
+	if !fileMtimeChangedAt.IsZero() &&
+		time.Since(*fileMtimeChangedAt) >= syncFallbackDelay {
+		*fileMtimeChangedAt = time.Time{}
+		if err := s.engine.SyncSingleSession(
+			sessionID,
+		); err != nil {
+			log.Printf("watch sync error: %v", err)
+			return false
+		}
+		// Re-check the DB after syncing.
+		if count, ok := s.db.GetSessionMessageCount(
+			sessionID,
+		); ok && count != *lastCount {
+			*lastCount = count
+			return true
+		}
 	}
-	return true
+
+	return false
 }
 
 func (s *Server) handleWatchSession(

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -53,7 +53,7 @@ func (s *Server) sessionMonitor(
 		defer close(ch)
 
 		// Seed initial state from the database.
-		lastCount, _ := s.db.GetSessionMessageCount(
+		lastCount, lastDBMtime, _ := s.db.GetSessionVersion(
 			sessionID,
 		)
 
@@ -76,6 +76,7 @@ func (s *Server) sessionMonitor(
 				changed := s.checkDBForChanges(
 					sessionID,
 					&lastCount,
+					&lastDBMtime,
 					&sourcePath,
 					&lastFileMtime,
 					&fileMtimeChangedAt,
@@ -94,21 +95,27 @@ func (s *Server) sessionMonitor(
 }
 
 // checkDBForChanges polls the database for a session's
-// message_count. If the count changed, it returns true.
-// As a fallback, it monitors file mtime and triggers a
-// direct sync when the watcher hasn't updated the DB.
+// message_count and file_mtime. If either changed, it
+// returns true. As a fallback, it monitors source file
+// mtime and triggers a direct sync when the watcher
+// hasn't updated the DB.
 func (s *Server) checkDBForChanges(
 	sessionID string,
 	lastCount *int,
+	lastDBMtime *int64,
 	sourcePath *string,
 	lastFileMtime *int64,
 	fileMtimeChangedAt *time.Time,
 ) bool {
-	// Primary: check if the DB has new data.
-	if count, ok := s.db.GetSessionMessageCount(
+	// Primary: check if the DB has new data (message count
+	// or file_mtime changed, covering both message appends
+	// and metadata-only updates like progress events).
+	if count, dbMtime, ok := s.db.GetSessionVersion(
 		sessionID,
-	); ok && count != *lastCount {
+	); ok && (count != *lastCount ||
+		dbMtime != *lastDBMtime) {
 		*lastCount = count
+		*lastDBMtime = dbMtime
 		// DB was updated; clear any pending fallback.
 		*fileMtimeChangedAt = time.Time{}
 		return true
@@ -158,10 +165,12 @@ func (s *Server) checkDBForChanges(
 			return false
 		}
 		// Re-check the DB after syncing.
-		if count, ok := s.db.GetSessionMessageCount(
+		if count, dbMtime, ok := s.db.GetSessionVersion(
 			sessionID,
-		); ok && count != *lastCount {
+		); ok && (count != *lastCount ||
+			dbMtime != *lastDBMtime) {
 			*lastCount = count
+			*lastDBMtime = dbMtime
 			return true
 		}
 	}

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -39,10 +39,12 @@ func TestCheckDBForChanges_FileDisappears(t *testing.T) {
 	var lastMtime int64 = 12345
 	var mchanged time.Time
 	var lastCount int
+	var lastDBMtime int64
 
 	changed := srv.checkDBForChanges(
 		"test-session",
 		&lastCount,
+		&lastDBMtime,
 		&path,
 		&lastMtime,
 		&mchanged,

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -3,108 +3,57 @@ package server
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
+	"time"
 )
 
-func skipIfNotUnix(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping: Unix permissions not reliable on Windows")
-	}
-	if os.Getuid() == 0 {
-		t.Skip("skipping: running as root bypasses permissions")
+func TestStatMtime_NonexistentFile(t *testing.T) {
+	t.Parallel()
+	got := statMtime(
+		filepath.Join(t.TempDir(), "no-such-file"),
+	)
+	if got != 0 {
+		t.Errorf("statMtime(nonexistent) = %d, want 0", got)
 	}
 }
 
-func assertCacheCleared(t *testing.T, sourcePath string, lastMtime int64) {
-	t.Helper()
-	if sourcePath != "" {
-		t.Errorf("expected sourcePath cleared, got %q", sourcePath)
+func TestStatMtime_ExistingFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(
+		path, []byte("data"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	got := statMtime(path)
+	if got == 0 {
+		t.Error("statMtime(existing) = 0, want nonzero")
+	}
+}
+
+func TestCheckDBForChanges_FileDisappears(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t, 5*time.Second)
+
+	path := filepath.Join(t.TempDir(), "gone.jsonl")
+	var lastMtime int64 = 12345
+	var mchanged time.Time
+	var lastCount int
+
+	changed := srv.checkDBForChanges(
+		"test-session",
+		&lastCount,
+		&path,
+		&lastMtime,
+		&mchanged,
+	)
+	if changed {
+		t.Error("expected no change signal")
+	}
+	if path != "" {
+		t.Errorf("sourcePath = %q, want empty", path)
 	}
 	if lastMtime != 0 {
-		t.Errorf("expected lastMtime cleared, got %d", lastMtime)
-	}
-}
-
-func assertCachePreserved(t *testing.T, sourcePath, wantPath string, lastMtime, wantMtime int64) {
-	t.Helper()
-	if sourcePath != wantPath {
-		t.Errorf("sourcePath = %q, want %q", sourcePath, wantPath)
-	}
-	if lastMtime != wantMtime {
-		t.Errorf("lastMtime = %d, want %d", lastMtime, wantMtime)
-	}
-}
-
-func makeUnreadableDir(t *testing.T) string {
-	t.Helper()
-	skipIfNotUnix(t)
-	tmpDir := t.TempDir()
-	subDir := filepath.Join(tmpDir, "subdir")
-	if err := os.Mkdir(subDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	target := filepath.Join(subDir, "target")
-	if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Chmod(subDir, 0o755) })
-	if err := os.Chmod(subDir, 0o000); err != nil {
-		t.Fatal(err)
-	}
-	return target
-}
-
-func TestSyncIfModified_CacheClearing(t *testing.T) {
-	t.Parallel()
-	srv := &Server{}
-
-	tests := []struct {
-		name        string
-		setupPath   func(t *testing.T) string
-		wantCleared bool
-	}{
-		{
-			name: "NotExist_ClearsCache",
-			setupPath: func(t *testing.T) string {
-				return filepath.Join(t.TempDir(), "nonexistent")
-			},
-			wantCleared: true,
-		},
-		{
-			name: "NotDir_ClearsCache",
-			setupPath: func(t *testing.T) string {
-				tmpDir := t.TempDir()
-				filePath := filepath.Join(tmpDir, "file")
-				if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
-					t.Fatal(err)
-				}
-				return filepath.Join(filePath, "child")
-			},
-			wantCleared: true,
-		},
-		{
-			name:        "PermissionDenied_KeepsCache",
-			setupPath:   makeUnreadableDir,
-			wantCleared: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			path := tt.setupPath(t)
-			sourcePath := path
-			var lastMtime int64 = 12345
-
-			srv.syncIfModified("s1", &sourcePath, &lastMtime)
-
-			if tt.wantCleared {
-				assertCacheCleared(t, sourcePath, lastMtime)
-			} else {
-				assertCachePreserved(t, sourcePath, path, lastMtime, 12345)
-			}
-		})
+		t.Errorf("lastMtime = %d, want 0", lastMtime)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -44,6 +44,7 @@ type testEnv struct {
 	srv       *server.Server
 	handler   http.Handler
 	db        *db.DB
+	engine    *sync.Engine
 	claudeDir string
 	dataDir   string
 }
@@ -151,6 +152,7 @@ func setupWithServerOpts(
 		srv:       srv,
 		handler:   wrappedHandler,
 		db:        database,
+		engine:    engine,
 		claudeDir: claudeDir,
 		dataDir:   dir,
 	}
@@ -2280,6 +2282,10 @@ func TestWatchSession_Events(t *testing.T) {
 		t.Fatalf("writing updated session file: %v", err)
 	}
 
+	// Sync the file to update the DB — in production the
+	// file watcher does this via SyncPaths.
+	engine.SyncPaths([]string{sessionPath})
+
 	te.waitForSSEEvent(t, w, "session_updated", 5*time.Second)
 	cancel()
 	<-done
@@ -2303,7 +2309,7 @@ func TestWatchSession_FileDisappearAndResolve(t *testing.T) {
 	engine.SyncAll(nil)
 
 	ctx, cancel := context.WithTimeout(
-		context.Background(), 10*time.Second,
+		context.Background(), 15*time.Second,
 	)
 	defer cancel()
 
@@ -2326,18 +2332,19 @@ func TestWatchSession_FileDisappearAndResolve(t *testing.T) {
 		t.Fatalf("removing session file: %v", err)
 	}
 
-	// Wait long enough for at least one poll tick to notice
-	// the missing file and clear the cached path.
+	// Wait for at least one poll tick to notice the missing
+	// file and clear the cached path.
 	time.Sleep(2 * time.Second)
 
 	// Recreate the file with updated content at a NEW location
-	// so we verify that FindSourceFile actually re-scans.
+	// so we verify that FindSourceFile re-scans and the
+	// fallback sync picks up the change.
 	updated := content + testjsonl.NewSessionBuilder().
 		AddClaudeAssistant(tsZeroS5, "recovered").
 		String()
 	te.writeProjectFile(t, "moved-proj", "vanish-sess.jsonl", updated)
 
-	te.waitForSSEEvent(t, w, "session_updated", 8*time.Second)
+	te.waitForSSEEvent(t, w, "session_updated", 12*time.Second)
 	cancel()
 	<-done
 }

--- a/internal/server/timeout_test.go
+++ b/internal/server/timeout_test.go
@@ -9,22 +9,27 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/wesm/agentsview/internal/testjsonl"
 )
 
 // TestServerTimeouts starts a real HTTP server and verifies that
 // streaming connections (SSE) are not closed prematurely by WriteTimeout.
 func TestServerTimeouts(t *testing.T) {
 	// Set a very short WriteTimeout to verify SSE is exempt.
-	// If SSE were subject to this timeout, the connection would close
-	// well before our 500ms wait below.
 	writeTimeout := 100 * time.Millisecond
-	sleepDuration := 500 * time.Millisecond // Must be > writeTimeout
+	sleepDuration := 500 * time.Millisecond
 
 	te := setup(t, withWriteTimeout(writeTimeout))
 
-	sessionPath := te.writeProjectFile(
-		t, "test-project", "watch-test.jsonl", `{"type":"user"}`,
+	initial := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2025-01-01T00:00:00Z", "initial message")
+	sessionPath := te.writeSessionFile(
+		t, "test-project", "watch-test.jsonl", initial,
 	)
+
+	// Seed the DB.
+	te.engine.SyncAll(nil)
 
 	baseURL := te.listenAndServe(t)
 
@@ -37,7 +42,9 @@ func TestServerTimeouts(t *testing.T) {
 	)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, url, nil,
+	)
 	if err != nil {
 		t.Fatalf("creating request: %v", err)
 	}
@@ -52,29 +59,41 @@ func TestServerTimeouts(t *testing.T) {
 		t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
 	}
 
-	// Trigger an update after 500ms (> WriteTimeout of 100ms).
-	// If the handler had a timeout, the body would be closed by now.
+	// Trigger an update after 500ms (> WriteTimeout).
 	errCh := make(chan error, 1)
 	go func() {
 		time.Sleep(sleepDuration)
-		f, err := os.OpenFile(sessionPath, os.O_APPEND|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(
+			sessionPath, os.O_APPEND|os.O_WRONLY, 0644,
+		)
 		if err != nil {
 			errCh <- fmt.Errorf("opening file: %w", err)
 			return
 		}
-		defer f.Close()
 
-		if _, err := f.WriteString("\n{\"type\":\"user\",\"content\":\"update\"}"); err != nil {
+		update := testjsonl.NewSessionBuilder().
+			AddClaudeAssistant(
+				"2025-01-01T00:00:05Z", "response",
+			)
+		if _, err := f.WriteString(update.String()); err != nil {
+			f.Close()
 			errCh <- fmt.Errorf("writing update: %w", err)
 			return
 		}
+		f.Close()
+
+		// Sync to update the DB — the session monitor polls
+		// DB changes, not file mtime.
+		te.engine.SyncPaths([]string{sessionPath})
 	}()
 
 	readCh := make(chan string)
 	go func() {
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), "session_updated") {
+			if strings.Contains(
+				scanner.Text(), "session_updated",
+			) {
 				readCh <- scanner.Text()
 				return
 			}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1035,7 +1035,7 @@ func (e *Engine) collectAndBatch(
 			}
 			continue
 		}
-		if len(r.results) == 0 {
+		if len(r.results) == 0 && r.incremental == nil {
 			e.cacheSkip(r.path, r.mtime)
 			progress.SessionsDone++
 			if onProgress != nil {
@@ -1046,12 +1046,19 @@ func (e *Engine) collectAndBatch(
 		e.clearSkip(r.path)
 		stats.filesOK++
 
-		for _, pr := range r.results {
-			pending = append(pending, pendingWrite{
-				sess:       pr.Session,
-				msgs:       pr.Messages,
-				appendOnly: r.appendOnly,
-			})
+		if r.incremental != nil {
+			e.writeIncremental(r.incremental)
+			stats.RecordSynced(1)
+			progress.MessagesIndexed += len(
+				r.incremental.msgs,
+			)
+		} else {
+			for _, pr := range r.results {
+				pending = append(pending, pendingWrite{
+					sess: pr.Session,
+					msgs: pr.Messages,
+				})
+			}
 		}
 
 		if len(pending) >= batchSize {
@@ -1080,12 +1087,25 @@ func (e *Engine) collectAndBatch(
 	return stats
 }
 
+// incrementalUpdate holds the delta produced by an
+// incremental JSONL parse, used to partially update the
+// session row without overwriting unrelated columns.
+type incrementalUpdate struct {
+	sessionID    string
+	msgs         []parser.ParsedMessage
+	endedAt      time.Time
+	msgCount     int // total (old + new)
+	userMsgCount int // total (old + new)
+	fileSize     int64
+	fileMtime    int64
+}
+
 type processResult struct {
-	results    []parser.ParseResult
-	skip       bool
-	mtime      int64
-	err        error
-	appendOnly bool // messages are new-only; append to DB
+	results     []parser.ParseResult
+	skip        bool
+	mtime       int64
+	err         error
+	incremental *incrementalUpdate
 }
 
 func (e *Engine) processFile(
@@ -1281,7 +1301,9 @@ type incrementalParseFunc func(
 // tryIncrementalJSONL attempts an incremental parse of an
 // append-only JSONL file by reading only bytes appended since
 // the last sync. Returns (result, true) on success, or
-// (zero, false) to fall through to a full parse.
+// (zero, false) to fall through to a full parse. Falls back
+// to full parse when the file maps to multiple DB sessions
+// (e.g. Claude DAG forks).
 func (e *Engine) tryIncrementalJSONL(
 	file parser.DiscoveredFile,
 	info os.FileInfo,
@@ -1318,30 +1340,7 @@ func (e *Engine) tryIncrementalJSONL(
 		return processResult{skip: true}, true
 	}
 
-	var startedAt time.Time
-	if inc.StartedAt != "" {
-		startedAt, _ = time.Parse(
-			time.RFC3339Nano, inc.StartedAt,
-		)
-	}
-
 	newUserCount := countUserMsgs(newMsgs)
-	sess := parser.ParsedSession{
-		ID:               inc.ID,
-		Project:          inc.Project,
-		Machine:          e.machine,
-		Agent:            agent,
-		FirstMessage:     inc.FirstMessage,
-		StartedAt:        startedAt,
-		EndedAt:          endedAt,
-		MessageCount:     inc.MsgCount + len(newMsgs),
-		UserMessageCount: inc.UserMsgCount + newUserCount,
-		File: parser.FileInfo{
-			Path:  file.Path,
-			Size:  currentSize,
-			Mtime: info.ModTime().UnixNano(),
-		},
-	}
 
 	log.Printf(
 		"incremental %s %s: %d new message(s) "+
@@ -1350,10 +1349,15 @@ func (e *Engine) tryIncrementalJSONL(
 	)
 
 	return processResult{
-		results: []parser.ParseResult{
-			{Session: sess, Messages: newMsgs},
+		incremental: &incrementalUpdate{
+			sessionID:    inc.ID,
+			msgs:         newMsgs,
+			endedAt:      endedAt,
+			msgCount:     inc.MsgCount + len(newMsgs),
+			userMsgCount: inc.UserMsgCount + newUserCount,
+			fileSize:     currentSize,
+			fileMtime:    info.ModTime().UnixNano(),
 		},
-		appendOnly: true,
 	}, true
 }
 
@@ -1712,34 +1716,23 @@ func (e *Engine) processIflow(
 }
 
 type pendingWrite struct {
-	sess       parser.ParsedSession
-	msgs       []parser.ParsedMessage
-	appendOnly bool // msgs are new-only; session counts are pre-set
+	sess parser.ParsedSession
+	msgs []parser.ParsedMessage
 }
 
 func (e *Engine) writeBatch(batch []pendingWrite) {
 	for _, pw := range batch {
 		msgs := toDBMessages(pw, e.blockedResultCategories)
 		s := toDBSession(pw)
-		if pw.appendOnly {
-			// For incremental appends, session counts are
-			// pre-calculated (old + new). Adjust for any
-			// messages removed by the blocked-category filter.
-			newTotal, newUser := postFilterCounts(msgs)
-			filtered := len(pw.msgs) - newTotal
-			s.MessageCount -= filtered
-			userFiltered := countUserMsgs(pw.msgs) - newUser
-			s.UserMessageCount -= userFiltered
-		} else {
-			s.MessageCount, s.UserMessageCount =
-				postFilterCounts(msgs)
-		}
+		s.MessageCount, s.UserMessageCount =
+			postFilterCounts(msgs)
 		if err := e.db.UpsertSession(s); err != nil {
 			if errors.Is(err, db.ErrSessionExcluded) {
-				// Cache as skipped so excluded files are not
-				// re-parsed on subsequent syncs.
 				if pw.sess.File.Path != "" {
-					e.cacheSkip(pw.sess.File.Path, pw.sess.File.Mtime)
+					e.cacheSkip(
+						pw.sess.File.Path,
+						pw.sess.File.Mtime,
+					)
 				}
 				continue
 			}
@@ -1748,6 +1741,45 @@ func (e *Engine) writeBatch(batch []pendingWrite) {
 		}
 		e.writeMessages(pw.sess.ID, msgs)
 	}
+}
+
+// writeIncremental appends new messages and partially updates
+// session metadata without overwriting columns that are not
+// recomputed during incremental parsing (e.g. file_hash,
+// parent_session_id, relationship_type).
+func (e *Engine) writeIncremental(inc *incrementalUpdate) {
+	dbMsgs := toDBMessages(
+		pendingWrite{msgs: inc.msgs},
+		e.blockedResultCategories,
+	)
+
+	// Adjust counts for blocked-category filtering.
+	newTotal, newUser := postFilterCounts(dbMsgs)
+	filtered := len(inc.msgs) - newTotal
+	msgCount := inc.msgCount - filtered
+	userFiltered := countUserMsgs(inc.msgs) - newUser
+	userMsgCount := inc.userMsgCount - userFiltered
+
+	var endedAt *string
+	if !inc.endedAt.IsZero() {
+		s := inc.endedAt.Format(time.RFC3339Nano)
+		endedAt = &s
+	}
+
+	err := e.db.UpdateSessionIncremental(
+		inc.sessionID, endedAt,
+		msgCount, userMsgCount,
+		inc.fileSize, inc.fileMtime,
+	)
+	if err != nil {
+		log.Printf(
+			"incremental update %s: %v",
+			inc.sessionID, err,
+		)
+		return
+	}
+
+	e.writeMessages(inc.sessionID, dbMsgs)
 }
 
 // writeMessages uses an incremental append when possible.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1293,10 +1293,12 @@ func (e *Engine) processClaude(
 // incrementalParseFunc reads new JSONL lines from a file
 // starting at the given byte offset with the given starting
 // ordinal. Returns parsed messages, the latest timestamp
-// (endedAt), and any error.
+// (endedAt), bytes consumed (relative to offset), and any
+// error. The consumed count covers only complete, valid JSON
+// lines so it can be used as a safe resume offset.
 type incrementalParseFunc func(
 	path string, offset int64, startOrdinal int,
-) ([]parser.ParsedMessage, time.Time, error)
+) ([]parser.ParsedMessage, time.Time, int64, error)
 
 // tryIncrementalJSONL attempts an incremental parse of an
 // append-only JSONL file by reading only bytes appended since
@@ -1325,7 +1327,7 @@ func (e *Engine) tryIncrementalJSONL(
 		return processResult{}, false
 	}
 
-	newMsgs, endedAt, err := parseFn(
+	newMsgs, endedAt, consumed, err := parseFn(
 		file.Path, inc.FileSize, maxOrd+1,
 	)
 	if err != nil {
@@ -1342,6 +1344,11 @@ func (e *Engine) tryIncrementalJSONL(
 
 	newUserCount := countUserMsgs(newMsgs)
 
+	// Use the offset through the last valid JSON line, not
+	// info.Size(), so partial lines at EOF are retried on
+	// the next sync.
+	newOffset := inc.FileSize + consumed
+
 	log.Printf(
 		"incremental %s %s: %d new message(s) "+
 			"from offset %d",
@@ -1355,7 +1362,7 @@ func (e *Engine) tryIncrementalJSONL(
 			endedAt:      endedAt,
 			msgCount:     inc.MsgCount + len(newMsgs),
 			userMsgCount: inc.UserMsgCount + newUserCount,
-			fileSize:     currentSize,
+			fileSize:     newOffset,
 			fileMtime:    info.ModTime().UnixNano(),
 		},
 	}, true
@@ -1374,7 +1381,7 @@ func (e *Engine) processCodex(
 	// that have already been synced.
 	codexParseFn := func(
 		path string, offset int64, startOrd int,
-	) ([]parser.ParsedMessage, time.Time, error) {
+	) ([]parser.ParsedMessage, time.Time, int64, error) {
 		return parser.ParseCodexSessionFrom(
 			path, offset, startOrd, false,
 		)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1746,7 +1746,9 @@ func (e *Engine) writeBatch(batch []pendingWrite) {
 			log.Printf("upsert session %s: %v", s.ID, err)
 			continue
 		}
-		e.writeMessages(pw.sess.ID, msgs)
+		if err := e.writeMessages(pw.sess.ID, msgs); err != nil {
+			log.Printf("%v", err)
+		}
 	}
 }
 
@@ -1776,10 +1778,17 @@ func (e *Engine) writeIncremental(inc *incrementalUpdate) {
 		endedAt = &s
 	}
 
-	// Write messages before advancing file_size so that a
-	// message insert failure doesn't leave the offset past
-	// unprocessed data.
-	e.writeMessages(inc.sessionID, dbMsgs)
+	// Write messages first — only advance file_size when
+	// the insert succeeds so a failure is retried.
+	if err := e.writeMessages(
+		inc.sessionID, dbMsgs,
+	); err != nil {
+		log.Printf(
+			"incremental messages %s: %v",
+			inc.sessionID, err,
+		)
+		return
+	}
 
 	err := e.db.UpdateSessionIncremental(
 		inc.sessionID, endedAt,
@@ -1801,18 +1810,18 @@ func (e *Engine) writeIncremental(inc *incrementalUpdate) {
 // delete+reinsert of existing content).
 func (e *Engine) writeMessages(
 	sessionID string, msgs []db.Message,
-) {
+) error {
 	maxOrd := e.db.MaxOrdinal(sessionID)
 
 	// No existing messages — insert all.
 	if maxOrd < 0 {
 		if err := e.db.InsertMessages(msgs); err != nil {
-			log.Printf(
-				"insert messages for %s: %v",
+			return fmt.Errorf(
+				"insert messages for %s: %w",
 				sessionID, err,
 			)
 		}
-		return
+		return nil
 	}
 
 	// Find new messages (ordinal > maxOrd).
@@ -1826,15 +1835,16 @@ func (e *Engine) writeMessages(
 	}
 
 	if delta == 0 {
-		return
+		return nil
 	}
 
 	if err := e.db.InsertMessages(msgs); err != nil {
-		log.Printf(
-			"append messages for %s: %v",
+		return fmt.Errorf(
+			"append messages for %s: %w",
 			sessionID, err,
 		)
 	}
+	return nil
 }
 
 // writeSessionFull upserts a session and does a full

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1346,11 +1346,14 @@ func (e *Engine) tryIncrementalJSONL(
 	if len(newMsgs) == 0 {
 		// No new messages, but advance the offset past
 		// non-message lines (progress events, metadata)
-		// so they aren't re-read on every sync.
+		// so they aren't re-read on every sync. Carry
+		// endedAt forward so session bounds stay current
+		// with non-message timestamps (e.g. progress).
 		if consumed > 0 {
 			return processResult{
 				incremental: &incrementalUpdate{
 					sessionID:    inc.ID,
+					endedAt:      endedAt,
 					msgCount:     inc.MsgCount,
 					userMsgCount: inc.UserMsgCount,
 					fileSize:     newOffset,
@@ -2072,6 +2075,13 @@ func (e *Engine) SyncSingleSession(sessionID string) error {
 		return res.err
 	}
 	if res.skip {
+		return nil
+	}
+
+	// Handle incremental updates from processFile (e.g.
+	// append-only JSONL that was already synced).
+	if res.incremental != nil {
+		e.writeIncremental(res.incremental)
 		return nil
 	}
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1749,7 +1749,10 @@ func (e *Engine) writeBatch(batch []pendingWrite) {
 // parent_session_id, relationship_type).
 func (e *Engine) writeIncremental(inc *incrementalUpdate) {
 	dbMsgs := toDBMessages(
-		pendingWrite{msgs: inc.msgs},
+		pendingWrite{
+			sess: parser.ParsedSession{ID: inc.sessionID},
+			msgs: inc.msgs,
+		},
 		e.blockedResultCategories,
 	)
 
@@ -1766,6 +1769,11 @@ func (e *Engine) writeIncremental(inc *incrementalUpdate) {
 		endedAt = &s
 	}
 
+	// Write messages before advancing file_size so that a
+	// message insert failure doesn't leave the offset past
+	// unprocessed data.
+	e.writeMessages(inc.sessionID, dbMsgs)
+
 	err := e.db.UpdateSessionIncremental(
 		inc.sessionID, endedAt,
 		msgCount, userMsgCount,
@@ -1776,10 +1784,7 @@ func (e *Engine) writeIncremental(inc *incrementalUpdate) {
 			"incremental update %s: %v",
 			inc.sessionID, err,
 		)
-		return
 	}
-
-	e.writeMessages(inc.sessionID, dbMsgs)
 }
 
 // writeMessages uses an incremental append when possible.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1338,16 +1338,30 @@ func (e *Engine) tryIncrementalJSONL(
 		return processResult{}, false
 	}
 
-	if len(newMsgs) == 0 {
-		return processResult{skip: true}, true
-	}
-
-	newUserCount := countUserMsgs(newMsgs)
-
 	// Use the offset through the last valid JSON line, not
 	// info.Size(), so partial lines at EOF are retried on
 	// the next sync.
 	newOffset := inc.FileSize + consumed
+
+	if len(newMsgs) == 0 {
+		// No new messages, but advance the offset past
+		// non-message lines (progress events, metadata)
+		// so they aren't re-read on every sync.
+		if consumed > 0 {
+			return processResult{
+				incremental: &incrementalUpdate{
+					sessionID:    inc.ID,
+					msgCount:     inc.MsgCount,
+					userMsgCount: inc.UserMsgCount,
+					fileSize:     newOffset,
+					fileMtime:    info.ModTime().UnixNano(),
+				},
+			}, true
+		}
+		return processResult{skip: true}, true
+	}
+
+	newUserCount := countUserMsgs(newMsgs)
 
 	log.Printf(
 		"incremental %s %s: %d new message(s) "+
@@ -1733,6 +1747,14 @@ func (e *Engine) writeBatch(batch []pendingWrite) {
 		s := toDBSession(pw)
 		s.MessageCount, s.UserMessageCount =
 			postFilterCounts(msgs)
+
+		// UpsertSession first: the session row must exist
+		// before messages can be inserted (FK constraint).
+		// This is safe because writeBatch runs full parses
+		// that always recompute all columns. For
+		// incremental updates (writeIncremental), messages
+		// are written first since the session already
+		// exists.
 		if err := e.db.UpsertSession(s); err != nil {
 			if errors.Is(err, db.ErrSessionExcluded) {
 				if pw.sess.File.Path != "" {
@@ -1746,8 +1768,12 @@ func (e *Engine) writeBatch(batch []pendingWrite) {
 			log.Printf("upsert session %s: %v", s.ID, err)
 			continue
 		}
-		if err := e.writeMessages(pw.sess.ID, msgs); err != nil {
+
+		if err := e.writeMessages(
+			pw.sess.ID, msgs,
+		); err != nil {
 			log.Printf("%v", err)
+			continue
 		}
 	}
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1231,8 +1231,9 @@ func (e *Engine) processClaude(
 
 	// Try incremental parse for append-only JSONL files
 	// that have already been synced.
-	if res, ok := e.tryIncrementalClaude(
-		file, info,
+	if res, ok := e.tryIncrementalJSONL(
+		file, info, parser.AgentClaude,
+		parser.ParseClaudeSessionFrom,
 	); ok {
 		return res
 	}
@@ -1269,12 +1270,23 @@ func (e *Engine) processClaude(
 	return processResult{results: results}
 }
 
-// tryIncrementalClaude attempts an incremental parse of a
-// Claude JSONL file by reading only bytes appended since the
-// last sync. Returns (result, true) on success, or
+// incrementalParseFunc reads new JSONL lines from a file
+// starting at the given byte offset with the given starting
+// ordinal. Returns parsed messages, the latest timestamp
+// (endedAt), and any error.
+type incrementalParseFunc func(
+	path string, offset int64, startOrdinal int,
+) ([]parser.ParsedMessage, time.Time, error)
+
+// tryIncrementalJSONL attempts an incremental parse of an
+// append-only JSONL file by reading only bytes appended since
+// the last sync. Returns (result, true) on success, or
 // (zero, false) to fall through to a full parse.
-func (e *Engine) tryIncrementalClaude(
-	file parser.DiscoveredFile, info os.FileInfo,
+func (e *Engine) tryIncrementalJSONL(
+	file parser.DiscoveredFile,
+	info os.FileInfo,
+	agent parser.AgentType,
+	parseFn incrementalParseFunc,
 ) (processResult, bool) {
 	inc, ok := e.db.GetSessionForIncremental(file.Path)
 	if !ok || inc.FileSize <= 0 {
@@ -1291,13 +1303,13 @@ func (e *Engine) tryIncrementalClaude(
 		return processResult{}, false
 	}
 
-	newMsgs, endedAt, err := parser.ParseClaudeSessionFrom(
+	newMsgs, endedAt, err := parseFn(
 		file.Path, inc.FileSize, maxOrd+1,
 	)
 	if err != nil {
 		log.Printf(
-			"incremental claude %s: %v (full parse)",
-			file.Path, err,
+			"incremental %s %s: %v (full parse)",
+			agent, file.Path, err,
 		)
 		return processResult{}, false
 	}
@@ -1318,7 +1330,7 @@ func (e *Engine) tryIncrementalClaude(
 		ID:               inc.ID,
 		Project:          inc.Project,
 		Machine:          e.machine,
-		Agent:            parser.AgentClaude,
+		Agent:            agent,
 		FirstMessage:     inc.FirstMessage,
 		StartedAt:        startedAt,
 		EndedAt:          endedAt,
@@ -1332,9 +1344,9 @@ func (e *Engine) tryIncrementalClaude(
 	}
 
 	log.Printf(
-		"incremental claude %s: %d new message(s) "+
+		"incremental %s %s: %d new message(s) "+
 			"from offset %d",
-		inc.ID, len(newMsgs), inc.FileSize,
+		agent, inc.ID, len(newMsgs), inc.FileSize,
 	)
 
 	return processResult{
@@ -1356,8 +1368,15 @@ func (e *Engine) processCodex(
 
 	// Try incremental parse for append-only JSONL files
 	// that have already been synced.
-	if res, ok := e.tryIncrementalCodex(
-		file, info,
+	codexParseFn := func(
+		path string, offset int64, startOrd int,
+	) ([]parser.ParsedMessage, time.Time, error) {
+		return parser.ParseCodexSessionFrom(
+			path, offset, startOrd, false,
+		)
+	}
+	if res, ok := e.tryIncrementalJSONL(
+		file, info, parser.AgentCodex, codexParseFn,
 	); ok {
 		return res
 	}
@@ -1382,83 +1401,6 @@ func (e *Engine) processCodex(
 			{Session: *sess, Messages: msgs},
 		},
 	}
-}
-
-// tryIncrementalCodex attempts an incremental parse of a
-// Codex JSONL file by reading only bytes appended since the
-// last sync. Returns (result, true) on success, or
-// (zero, false) to fall through to a full parse.
-func (e *Engine) tryIncrementalCodex(
-	file parser.DiscoveredFile, info os.FileInfo,
-) (processResult, bool) {
-	inc, ok := e.db.GetSessionForIncremental(file.Path)
-	if !ok || inc.FileSize <= 0 {
-		return processResult{}, false
-	}
-
-	currentSize := info.Size()
-	if currentSize <= inc.FileSize {
-		return processResult{}, false
-	}
-
-	maxOrd := e.db.MaxOrdinal(inc.ID)
-	if maxOrd < 0 {
-		return processResult{}, false
-	}
-
-	newMsgs, endedAt, err := parser.ParseCodexSessionFrom(
-		file.Path, inc.FileSize, maxOrd+1, false,
-	)
-	if err != nil {
-		log.Printf(
-			"incremental codex %s: %v (full parse)",
-			file.Path, err,
-		)
-		return processResult{}, false
-	}
-
-	if len(newMsgs) == 0 {
-		return processResult{skip: true}, true
-	}
-
-	// Parse startedAt back from DB string.
-	var startedAt time.Time
-	if inc.StartedAt != "" {
-		startedAt, _ = time.Parse(
-			time.RFC3339Nano, inc.StartedAt,
-		)
-	}
-
-	newUserCount := countUserMsgs(newMsgs)
-	sess := parser.ParsedSession{
-		ID:               inc.ID,
-		Project:          inc.Project,
-		Machine:          e.machine,
-		Agent:            parser.AgentCodex,
-		FirstMessage:     inc.FirstMessage,
-		StartedAt:        startedAt,
-		EndedAt:          endedAt,
-		MessageCount:     inc.MsgCount + len(newMsgs),
-		UserMessageCount: inc.UserMsgCount + newUserCount,
-		File: parser.FileInfo{
-			Path:  file.Path,
-			Size:  currentSize,
-			Mtime: info.ModTime().UnixNano(),
-		},
-	}
-
-	log.Printf(
-		"incremental codex %s: %d new message(s) "+
-			"from offset %d",
-		inc.ID, len(newMsgs), inc.FileSize,
-	)
-
-	return processResult{
-		results: []parser.ParseResult{
-			{Session: sess, Messages: newMsgs},
-		},
-		appendOnly: true,
-	}, true
 }
 
 func (e *Engine) processCopilot(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1049,6 +1049,8 @@ func (e *Engine) collectAndBatch(
 		if r.incremental != nil {
 			if err := e.writeIncremental(r.incremental); err != nil {
 				log.Printf("%v", err)
+				stats.RecordFailed()
+				continue
 			}
 			stats.RecordSynced(1)
 			progress.MessagesIndexed += len(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1047,7 +1047,9 @@ func (e *Engine) collectAndBatch(
 		stats.filesOK++
 
 		if r.incremental != nil {
-			e.writeIncremental(r.incremental)
+			if err := e.writeIncremental(r.incremental); err != nil {
+				log.Printf("%v", err)
+			}
 			stats.RecordSynced(1)
 			progress.MessagesIndexed += len(
 				r.incremental.msgs,
@@ -1785,7 +1787,9 @@ func (e *Engine) writeBatch(batch []pendingWrite) {
 // session metadata without overwriting columns that are not
 // recomputed during incremental parsing (e.g. file_hash,
 // parent_session_id, relationship_type).
-func (e *Engine) writeIncremental(inc *incrementalUpdate) {
+func (e *Engine) writeIncremental(
+	inc *incrementalUpdate,
+) error {
 	dbMsgs := toDBMessages(
 		pendingWrite{
 			sess: parser.ParsedSession{ID: inc.sessionID},
@@ -1812,24 +1816,23 @@ func (e *Engine) writeIncremental(inc *incrementalUpdate) {
 	if err := e.writeMessages(
 		inc.sessionID, dbMsgs,
 	); err != nil {
-		log.Printf(
-			"incremental messages %s: %v",
+		return fmt.Errorf(
+			"incremental messages %s: %w",
 			inc.sessionID, err,
 		)
-		return
 	}
 
-	err := e.db.UpdateSessionIncremental(
+	if err := e.db.UpdateSessionIncremental(
 		inc.sessionID, endedAt,
 		msgCount, userMsgCount,
 		inc.fileSize, inc.fileMtime,
-	)
-	if err != nil {
-		log.Printf(
-			"incremental update %s: %v",
+	); err != nil {
+		return fmt.Errorf(
+			"incremental update %s: %w",
 			inc.sessionID, err,
 		)
 	}
+	return nil
 }
 
 // writeMessages uses an incremental append when possible.
@@ -2081,8 +2084,7 @@ func (e *Engine) SyncSingleSession(sessionID string) error {
 	// Handle incremental updates from processFile (e.g.
 	// append-only JSONL that was already synced).
 	if res.incremental != nil {
-		e.writeIncremental(res.incremental)
-		return nil
+		return e.writeIncremental(res.incremental)
 	}
 
 	// For Codex, processFile uses includeExec=false which may

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1048,8 +1048,9 @@ func (e *Engine) collectAndBatch(
 
 		for _, pr := range r.results {
 			pending = append(pending, pendingWrite{
-				sess: pr.Session,
-				msgs: pr.Messages,
+				sess:       pr.Session,
+				msgs:       pr.Messages,
+				appendOnly: r.appendOnly,
 			})
 		}
 
@@ -1080,10 +1081,11 @@ func (e *Engine) collectAndBatch(
 }
 
 type processResult struct {
-	results []parser.ParseResult
-	skip    bool
-	mtime   int64
-	err     error
+	results    []parser.ParseResult
+	skip       bool
+	mtime      int64
+	err        error
+	appendOnly bool // messages are new-only; append to DB
 }
 
 func (e *Engine) processFile(
@@ -1227,6 +1229,14 @@ func (e *Engine) processClaude(
 		}
 	}
 
+	// Try incremental parse for append-only JSONL files
+	// that have already been synced.
+	if res, ok := e.tryIncrementalClaude(
+		file, info,
+	); ok {
+		return res
+	}
+
 	// Determine project name from cwd if possible
 	project := parser.GetProjectName(file.Project)
 	cwd, gitBranch := parser.ExtractClaudeProjectHints(
@@ -1259,6 +1269,82 @@ func (e *Engine) processClaude(
 	return processResult{results: results}
 }
 
+// tryIncrementalClaude attempts an incremental parse of a
+// Claude JSONL file by reading only bytes appended since the
+// last sync. Returns (result, true) on success, or
+// (zero, false) to fall through to a full parse.
+func (e *Engine) tryIncrementalClaude(
+	file parser.DiscoveredFile, info os.FileInfo,
+) (processResult, bool) {
+	inc, ok := e.db.GetSessionForIncremental(file.Path)
+	if !ok || inc.FileSize <= 0 {
+		return processResult{}, false
+	}
+
+	currentSize := info.Size()
+	if currentSize <= inc.FileSize {
+		return processResult{}, false
+	}
+
+	maxOrd := e.db.MaxOrdinal(inc.ID)
+	if maxOrd < 0 {
+		return processResult{}, false
+	}
+
+	newMsgs, endedAt, err := parser.ParseClaudeSessionFrom(
+		file.Path, inc.FileSize, maxOrd+1,
+	)
+	if err != nil {
+		log.Printf(
+			"incremental claude %s: %v (full parse)",
+			file.Path, err,
+		)
+		return processResult{}, false
+	}
+
+	if len(newMsgs) == 0 {
+		return processResult{skip: true}, true
+	}
+
+	var startedAt time.Time
+	if inc.StartedAt != "" {
+		startedAt, _ = time.Parse(
+			time.RFC3339Nano, inc.StartedAt,
+		)
+	}
+
+	newUserCount := countUserMsgs(newMsgs)
+	sess := parser.ParsedSession{
+		ID:               inc.ID,
+		Project:          inc.Project,
+		Machine:          e.machine,
+		Agent:            parser.AgentClaude,
+		FirstMessage:     inc.FirstMessage,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     inc.MsgCount + len(newMsgs),
+		UserMessageCount: inc.UserMsgCount + newUserCount,
+		File: parser.FileInfo{
+			Path:  file.Path,
+			Size:  currentSize,
+			Mtime: info.ModTime().UnixNano(),
+		},
+	}
+
+	log.Printf(
+		"incremental claude %s: %d new message(s) "+
+			"from offset %d",
+		inc.ID, len(newMsgs), inc.FileSize,
+	)
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: sess, Messages: newMsgs},
+		},
+		appendOnly: true,
+	}, true
+}
+
 func (e *Engine) processCodex(
 	file parser.DiscoveredFile, info os.FileInfo,
 ) processResult {
@@ -1266,6 +1352,14 @@ func (e *Engine) processCodex(
 	// Fast path: skip by file_path + mtime before parsing.
 	if e.shouldSkipByPath(file.Path, info) {
 		return processResult{skip: true}
+	}
+
+	// Try incremental parse for append-only JSONL files
+	// that have already been synced.
+	if res, ok := e.tryIncrementalCodex(
+		file, info,
+	); ok {
+		return res
 	}
 
 	sess, msgs, err := parser.ParseCodexSession(
@@ -1288,6 +1382,83 @@ func (e *Engine) processCodex(
 			{Session: *sess, Messages: msgs},
 		},
 	}
+}
+
+// tryIncrementalCodex attempts an incremental parse of a
+// Codex JSONL file by reading only bytes appended since the
+// last sync. Returns (result, true) on success, or
+// (zero, false) to fall through to a full parse.
+func (e *Engine) tryIncrementalCodex(
+	file parser.DiscoveredFile, info os.FileInfo,
+) (processResult, bool) {
+	inc, ok := e.db.GetSessionForIncremental(file.Path)
+	if !ok || inc.FileSize <= 0 {
+		return processResult{}, false
+	}
+
+	currentSize := info.Size()
+	if currentSize <= inc.FileSize {
+		return processResult{}, false
+	}
+
+	maxOrd := e.db.MaxOrdinal(inc.ID)
+	if maxOrd < 0 {
+		return processResult{}, false
+	}
+
+	newMsgs, endedAt, err := parser.ParseCodexSessionFrom(
+		file.Path, inc.FileSize, maxOrd+1, false,
+	)
+	if err != nil {
+		log.Printf(
+			"incremental codex %s: %v (full parse)",
+			file.Path, err,
+		)
+		return processResult{}, false
+	}
+
+	if len(newMsgs) == 0 {
+		return processResult{skip: true}, true
+	}
+
+	// Parse startedAt back from DB string.
+	var startedAt time.Time
+	if inc.StartedAt != "" {
+		startedAt, _ = time.Parse(
+			time.RFC3339Nano, inc.StartedAt,
+		)
+	}
+
+	newUserCount := countUserMsgs(newMsgs)
+	sess := parser.ParsedSession{
+		ID:               inc.ID,
+		Project:          inc.Project,
+		Machine:          e.machine,
+		Agent:            parser.AgentCodex,
+		FirstMessage:     inc.FirstMessage,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     inc.MsgCount + len(newMsgs),
+		UserMessageCount: inc.UserMsgCount + newUserCount,
+		File: parser.FileInfo{
+			Path:  file.Path,
+			Size:  currentSize,
+			Mtime: info.ModTime().UnixNano(),
+		},
+	}
+
+	log.Printf(
+		"incremental codex %s: %d new message(s) "+
+			"from offset %d",
+		inc.ID, len(newMsgs), inc.FileSize,
+	)
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: sess, Messages: newMsgs},
+		},
+		appendOnly: true,
+	}, true
 }
 
 func (e *Engine) processCopilot(
@@ -1599,16 +1770,28 @@ func (e *Engine) processIflow(
 }
 
 type pendingWrite struct {
-	sess parser.ParsedSession
-	msgs []parser.ParsedMessage
+	sess       parser.ParsedSession
+	msgs       []parser.ParsedMessage
+	appendOnly bool // msgs are new-only; session counts are pre-set
 }
 
 func (e *Engine) writeBatch(batch []pendingWrite) {
 	for _, pw := range batch {
 		msgs := toDBMessages(pw, e.blockedResultCategories)
 		s := toDBSession(pw)
-		s.MessageCount, s.UserMessageCount =
-			postFilterCounts(msgs)
+		if pw.appendOnly {
+			// For incremental appends, session counts are
+			// pre-calculated (old + new). Adjust for any
+			// messages removed by the blocked-category filter.
+			newTotal, newUser := postFilterCounts(msgs)
+			filtered := len(pw.msgs) - newTotal
+			s.MessageCount -= filtered
+			userFiltered := countUserMsgs(pw.msgs) - newUser
+			s.UserMessageCount -= userFiltered
+		} else {
+			s.MessageCount, s.UserMessageCount =
+				postFilterCounts(msgs)
+		}
 		if err := e.db.UpsertSession(s); err != nil {
 			if errors.Is(err, db.ErrSessionExcluded) {
 				// Cache as skipped so excluded files are not
@@ -1757,6 +1940,17 @@ func postFilterCounts(msgs []db.Message) (total, user int) {
 		}
 	}
 	return len(msgs), user
+}
+
+// countUserMsgs counts user messages in parsed messages.
+func countUserMsgs(msgs []parser.ParsedMessage) int {
+	n := 0
+	for _, m := range msgs {
+		if m.Role == parser.RoleUser {
+			n++
+		}
+	}
+	return n
 }
 
 func countMessages(batch []pendingWrite) int {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2843,3 +2843,148 @@ func TestPiSessionIntegration(t *testing.T) {
 		},
 	)
 }
+
+func TestIncrementalSync_ClaudeAppend(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Initial sync: one user message.
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsZero),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "inc-test.jsonl", initial,
+	)
+	env.engine.SyncAll(nil)
+
+	assertSessionMessageCount(t, env.db, "inc-test", 1)
+	assertMessageRoles(t, env.db, "inc-test", "user")
+	msgs := fetchMessages(t, env.db, "inc-test")
+	if msgs[0].SessionID != "inc-test" {
+		t.Fatalf(
+			"msgs[0].SessionID = %q, want inc-test",
+			msgs[0].SessionID,
+		)
+	}
+
+	// Verify metadata is set from full parse.
+	full, err := env.db.GetSessionFull(
+		context.Background(), "inc-test",
+	)
+	if err != nil {
+		t.Fatalf("GetSessionFull: %v", err)
+	}
+	if full.FileHash == nil || *full.FileHash == "" {
+		t.Fatal("file_hash not set after full parse")
+	}
+	origHash := *full.FileHash
+
+	// Append an assistant response.
+	appended := testjsonl.ClaudeAssistantJSON(
+		"world", tsZeroS5,
+	) + "\n"
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	_, err = f.WriteString(appended)
+	f.Close()
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	// SyncPaths triggers incremental parse.
+	env.engine.SyncPaths([]string{path})
+
+	// Session count updated.
+	assertSessionMessageCount(t, env.db, "inc-test", 2)
+	assertMessageRoles(
+		t, env.db, "inc-test", "user", "assistant",
+	)
+
+	// New message has correct session_id.
+	msgs = fetchMessages(t, env.db, "inc-test")
+	for i, m := range msgs {
+		if m.SessionID != "inc-test" {
+			t.Errorf(
+				"msgs[%d].SessionID = %q, want inc-test",
+				i, m.SessionID,
+			)
+		}
+	}
+
+	// Metadata preserved (file_hash not cleared).
+	updated, err := env.db.GetSessionFull(
+		context.Background(), "inc-test",
+	)
+	if err != nil {
+		t.Fatalf("GetSessionFull after incremental: %v", err)
+	}
+	if updated.FileHash == nil ||
+		*updated.FileHash != origHash {
+		t.Errorf(
+			"file_hash = %v, want %q (preserved)",
+			updated.FileHash, origHash,
+		)
+	}
+}
+
+func TestIncrementalSync_CodexAppend(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"inc-cx", "/tmp/proj",
+			"codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "01"),
+		"rollout-20240101-inc-cx.jsonl", initial,
+	)
+	env.engine.SyncAll(nil)
+
+	assertSessionMessageCount(
+		t, env.db, "codex:inc-cx", 1,
+	)
+
+	// Append new messages.
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON(
+			"assistant", "world", tsEarlyS5,
+		),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	_, err = f.WriteString(appended)
+	f.Close()
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	env.engine.SyncPaths([]string{path})
+
+	assertSessionMessageCount(
+		t, env.db, "codex:inc-cx", 2,
+	)
+	assertMessageRoles(
+		t, env.db, "codex:inc-cx", "user", "assistant",
+	)
+
+	// Verify session_id on all messages.
+	msgs := fetchMessages(t, env.db, "codex:inc-cx")
+	for i, m := range msgs {
+		if m.SessionID != "codex:inc-cx" {
+			t.Errorf(
+				"msgs[%d].SessionID = %q, want codex:inc-cx",
+				i, m.SessionID,
+			)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add byte-offset incremental parsing for JSONL session files (Codex and Claude)
- Switch SSE session monitor from file-mtime polling to DB-polling with file-mtime fallback
- Add partial-update DB path that preserves session metadata during incremental sync

## Changes

**Incremental JSONL parsing** — Instead of re-parsing entire files on every sync, the engine seeks to the last-known byte offset and only parses appended lines. Shared `readJSONLFrom` helper in `linereader.go` handles file I/O; each agent provides a per-line callback.

**SSE monitor rework** — `checkDBForChanges` polls `message_count` from the DB instead of doing direct file sync. File mtime changes trigger a fallback sync after a short delay. Decouples SSE responsiveness from `syncMu` contention.

**Partial session updates** — `UpdateSessionIncremental` only touches columns that change during append (`ended_at`, `message_count`, `user_message_count`, `file_size`, `file_mtime`), preserving `file_hash`, `parent_session_id`, `relationship_type`, etc.

**Safety guards:**
- Files mapping to multiple DB sessions (Claude DAG forks) fall back to full parse
- Appended lines with `uuid` fields trigger `ErrDAGDetected`, falling back to full parse with fork detection
- Byte offset tracks through last valid JSON line (via `countingReader`), not `info.Size()`, so partial lines at EOF are retried
- Message insert must succeed before `file_size`/`file_mtime` are advanced

## Test plan

- [ ] `TestIncrementalSync_ClaudeAppend` — full parse → append → SyncPaths, verifies session_id, counts, metadata preservation
- [ ] `TestIncrementalSync_CodexAppend` — same for Codex sessions
- [ ] `TestParseClaudeSessionFrom_Incremental` — offset-based parsing lifecycle
- [ ] `TestParseClaudeSessionFrom_PartialLineAtEOF` — consumed bytes exclude partial lines
- [ ] `TestParseClaudeSessionFrom_DAGDetected` — uuid fields trigger fallback
- [ ] `TestGetSessionForIncremental` — multi-session files rejected
- [ ] `TestUpdateSessionIncremental` — partial update preserves all other columns
- [ ] `TestLineReaderBytesRead` — byte counting with/without trailing newlines
- [ ] `TestWatchSession_Events` / `TestServerTimeouts` — SSE live updates work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)