### PR TITLE
fix: Windows Tauri desktop navigation and dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Go binaries
 /agentsview
+/agentsview.exe
 /agentsv
 /testfixture
 *.test.exe

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -151,8 +151,13 @@ fn is_allowed_navigation_url(url: &Url, backend_port: Option<u16>) -> bool {
     if url.scheme() == "tauri" && url.host_str() == Some("localhost") {
         return true;
     }
-    // Windows (WebView2): http://tauri.localhost or https://tauri.localhost
-    if matches!(url.scheme(), "http" | "https") && url.host_str() == Some("tauri.localhost") {
+    // Windows (WebView2): https://tauri.localhost (default origin).
+    // Restrict to https-only with no explicit port to avoid accepting
+    // spoofable http origins or unexpected ports.
+    if url.scheme() == "https"
+        && url.host_str() == Some("tauri.localhost")
+        && url.port().is_none()
+    {
         return true;
     }
     // Only allow navigation to the known sidecar port on
@@ -921,16 +926,21 @@ mod tests {
         assert!(is_allowed_navigation_url(&tauri_url, None));
         assert!(is_allowed_navigation_url(&tauri_url, Some(18080)));
 
-        // Windows (WebView2): http://tauri.localhost
-        let win_url =
-            Url::parse("http://tauri.localhost/index.html").expect("valid windows tauri url");
-        assert!(is_allowed_navigation_url(&win_url, None));
-        assert!(is_allowed_navigation_url(&win_url, Some(18080)));
-
-        // Windows with https
+        // Windows (WebView2): https://tauri.localhost (default origin)
         let win_https =
-            Url::parse("https://tauri.localhost/index.html").expect("valid windows https url");
+            Url::parse("https://tauri.localhost/index.html").expect("valid windows tauri url");
         assert!(is_allowed_navigation_url(&win_https, None));
+        assert!(is_allowed_navigation_url(&win_https, Some(18080)));
+
+        // Reject http://tauri.localhost (not the default WebView2 scheme)
+        let win_http =
+            Url::parse("http://tauri.localhost/index.html").expect("valid http tauri url");
+        assert!(!is_allowed_navigation_url(&win_http, None));
+
+        // Reject tauri.localhost with an explicit port
+        let win_port =
+            Url::parse("https://tauri.localhost:9999/").expect("valid tauri localhost with port");
+        assert!(!is_allowed_navigation_url(&win_port, None));
 
         let local_backend = Url::parse("http://127.0.0.1:18080/").expect("valid localhost url");
         assert!(is_allowed_navigation_url(&local_backend, Some(18080)));

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -151,10 +151,10 @@ fn is_allowed_navigation_url(url: &Url, backend_port: Option<u16>) -> bool {
     if url.scheme() == "tauri" && url.host_str() == Some("localhost") {
         return true;
     }
-    // Windows (WebView2): https://tauri.localhost (default origin).
-    // Restrict to https-only with no explicit port to avoid accepting
-    // spoofable http origins or unexpected ports.
-    if url.scheme() == "https"
+    // Windows (WebView2): http://tauri.localhost or https://tauri.localhost.
+    // WebView2 uses http by default for the custom localhost origin.
+    // Reject explicit ports to prevent spoofing via other local services.
+    if matches!(url.scheme(), "http" | "https")
         && url.host_str() == Some("tauri.localhost")
         && url.port().is_none()
     {
@@ -926,16 +926,16 @@ mod tests {
         assert!(is_allowed_navigation_url(&tauri_url, None));
         assert!(is_allowed_navigation_url(&tauri_url, Some(18080)));
 
-        // Windows (WebView2): https://tauri.localhost (default origin)
-        let win_https =
-            Url::parse("https://tauri.localhost/index.html").expect("valid windows tauri url");
-        assert!(is_allowed_navigation_url(&win_https, None));
-        assert!(is_allowed_navigation_url(&win_https, Some(18080)));
-
-        // Reject http://tauri.localhost (not the default WebView2 scheme)
+        // Windows (WebView2): http://tauri.localhost (default origin)
         let win_http =
-            Url::parse("http://tauri.localhost/index.html").expect("valid http tauri url");
-        assert!(!is_allowed_navigation_url(&win_http, None));
+            Url::parse("http://tauri.localhost/index.html").expect("valid windows tauri url");
+        assert!(is_allowed_navigation_url(&win_http, None));
+        assert!(is_allowed_navigation_url(&win_http, Some(18080)));
+
+        // Windows: https://tauri.localhost also allowed
+        let win_https =
+            Url::parse("https://tauri.localhost/index.html").expect("valid windows https url");
+        assert!(is_allowed_navigation_url(&win_https, None));
 
         // Reject tauri.localhost with an explicit port
         let win_port =

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -147,7 +147,12 @@ fn init_navigation_guard_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlug
 }
 
 fn is_allowed_navigation_url(url: &Url, backend_port: Option<u16>) -> bool {
+    // macOS/Linux: tauri://localhost
     if url.scheme() == "tauri" && url.host_str() == Some("localhost") {
+        return true;
+    }
+    // Windows (WebView2): http://tauri.localhost or https://tauri.localhost
+    if matches!(url.scheme(), "http" | "https") && url.host_str() == Some("tauri.localhost") {
         return true;
     }
     // Only allow navigation to the known sidecar port on
@@ -606,7 +611,7 @@ fn setup_menu(app: &mut App) -> Result<(), DynError> {
     let check_updates = MenuItemBuilder::with_id("check_updates", "Check for Updates...")
         .build(app)?;
 
-    let app_submenu = SubmenuBuilder::new(app, "AgentsView")
+    let app_submenu = SubmenuBuilder::new(app, "File")
         .item(&about)
         .separator()
         .item(&check_updates)
@@ -911,9 +916,21 @@ mod tests {
 
     #[test]
     fn is_allowed_navigation_url_allows_local_only() {
+        // macOS/Linux: tauri://localhost
         let tauri_url = Url::parse("tauri://localhost/index.html").expect("valid tauri url");
         assert!(is_allowed_navigation_url(&tauri_url, None));
         assert!(is_allowed_navigation_url(&tauri_url, Some(18080)));
+
+        // Windows (WebView2): http://tauri.localhost
+        let win_url =
+            Url::parse("http://tauri.localhost/index.html").expect("valid windows tauri url");
+        assert!(is_allowed_navigation_url(&win_url, None));
+        assert!(is_allowed_navigation_url(&win_url, Some(18080)));
+
+        // Windows with https
+        let win_https =
+            Url::parse("https://tauri.localhost/index.html").expect("valid windows https url");
+        assert!(is_allowed_navigation_url(&win_https, None));
 
         let local_backend = Url::parse("http://127.0.0.1:18080/").expect("valid localhost url");
         assert!(is_allowed_navigation_url(&local_backend, Some(18080)));

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentsView",
-  "version": "0.1.0",
+  "version": "0.12.1",
   "identifier": "io.agentsview.desktop",
   "build": {
     "frontendDist": "../ui"

--- a/scripts/desktop-dev.ps1
+++ b/scripts/desktop-dev.ps1
@@ -38,7 +38,12 @@ $DesktopDir = Join-Path $RepoRoot "desktop"
 $FrontendDir = Join-Path $RepoRoot "frontend"
 $EmbedDir = Join-Path $RepoRoot "internal\web\dist"
 $BinDir = Join-Path $DesktopDir "src-tauri\binaries"
-$Triple = "x86_64-pc-windows-msvc"
+# Detect Rust host triple for the sidecar binary name
+$Triple = (rustc -vV | Select-String "^host:").ToString().Split(" ", 2)[1].Trim()
+if (-not $Triple) {
+    Write-Error "Could not detect Rust host triple. Is rustc installed?"
+    exit 1
+}
 $SidecarBin = Join-Path $BinDir "agentsview-$Triple.exe"
 
 if (-not $SkipBuild) {

--- a/scripts/desktop-dev.ps1
+++ b/scripts/desktop-dev.ps1
@@ -16,6 +16,52 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function ConvertTo-Semver {
+    param([string]$Raw)
+    # Strip leading 'v'
+    $Raw = $Raw -replace '^v', ''
+    # git-describe: 0.10.0-3-gabcdef -> 0.10.0-dev.3
+    if ($Raw -match '^(\d+\.\d+\.\d+)-(\d+)-g[0-9a-f]+(-dirty)?$') {
+        return "$($Matches[1])-dev.$($Matches[2])"
+    }
+    # Already semver, with optional prerelease (strip -dirty)
+    if ($Raw -match '^\d+\.\d+\.\d+(-[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*)?(-dirty)?$') {
+        return ($Raw -replace '-dirty$', '')
+    }
+    # Looks like a version but isn't valid semver
+    if ($Raw -match '^\d+\.') {
+        Write-Error "Malformed version tag: $Raw"
+        exit 1
+    }
+    # Non-tag fallback (bare hash, "dev", etc.)
+    return ""
+}
+
+function Update-TauriVersion {
+    param([string]$Version, [string]$ConfPath)
+    $semver = ConvertTo-Semver $Version
+    if (-not $semver) {
+        Write-Host "Skipping tauri.conf.json version patch (non-tag build: $Version)"
+        return
+    }
+    $origPath = "$ConfPath.orig"
+    if (-not (Test-Path $origPath)) {
+        Copy-Item $ConfPath $origPath
+    }
+    $content = Get-Content $ConfPath -Raw
+    $content = $content -replace '"version":\s*"[^"]*"', "`"version`": `"$semver`""
+    Set-Content -Path $ConfPath -Value $content -NoNewline
+    Write-Host "Patched tauri.conf.json version to $semver" -ForegroundColor Green
+}
+
+function Restore-TauriVersion {
+    param([string]$ConfPath)
+    $origPath = "$ConfPath.orig"
+    if (Test-Path $origPath) {
+        Move-Item -Force $origPath $ConfPath
+    }
+}
+
 # Ensure fnm-managed Node.js is on PATH. fnm requires an `fnm env`
 # eval in each new PowerShell session; without it, node/npm are not
 # found even though fnm itself is on PATH via WinGet links.
@@ -88,6 +134,10 @@ if (-not $SkipBuild) {
     Copy-Item (Join-Path $RepoRoot "agentsview.exe") $SidecarBin -Force
 
     Write-Host "Sidecar ready: $SidecarBin" -ForegroundColor Green
+
+    # Patch tauri.conf.json version to match the git-derived version
+    $TauriConf = Join-Path $DesktopDir "src-tauri\tauri.conf.json"
+    Update-TauriVersion -Version $version -ConfPath $TauriConf
 } else {
     if (-not (Test-Path $SidecarBin)) {
         Write-Error "Sidecar binary not found at $SidecarBin. Run without -SkipBuild first."
@@ -101,10 +151,12 @@ if (-not $SkipBuild) {
 # built-in dev server opening a browser tab (port 1430) that shows a
 # stale "Preparing your workspace" page. The app manages its own
 # webview navigation from the splash screen to the Go backend.
+$TauriConf = Join-Path $DesktopDir "src-tauri\tauri.conf.json"
 Write-Host "Launching Tauri dev..." -ForegroundColor Cyan
 Push-Location (Join-Path $DesktopDir "src-tauri")
 try {
     cargo run
 } finally {
     Pop-Location
+    Restore-TauriVersion -ConfPath $TauriConf
 }

--- a/scripts/desktop-dev.ps1
+++ b/scripts/desktop-dev.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Build and launch the AgentsView Tauri desktop app in dev mode on Windows.
+
+.DESCRIPTION
+    Builds the frontend SPA, compiles the Go sidecar binary, copies it into
+    the Tauri binaries directory, and runs `cargo tauri dev`.
+
+.PARAMETER SkipBuild
+    Skip the frontend and Go sidecar build steps. Use this when iterating
+    on Rust/Tauri code only and the sidecar binary is already up to date.
+#>
+param(
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+# Ensure fnm-managed Node.js is on PATH. fnm requires an `fnm env`
+# eval in each new PowerShell session; without it, node/npm are not
+# found even though fnm itself is on PATH via WinGet links.
+if ((Get-Command fnm -ErrorAction SilentlyContinue) -and -not (Get-Command node -ErrorAction SilentlyContinue)) {
+    Write-Host "Activating fnm environment..." -ForegroundColor Yellow
+    fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression
+}
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if (-not (Test-Path "$RepoRoot\go.mod")) {
+    # Script may live at repo/scripts/ directly
+    $RepoRoot = Split-Path -Parent $PSScriptRoot
+}
+if (-not (Test-Path "$RepoRoot\go.mod")) {
+    Write-Error "Could not locate repository root (no go.mod found)"
+    exit 1
+}
+
+$DesktopDir = Join-Path $RepoRoot "desktop"
+$FrontendDir = Join-Path $RepoRoot "frontend"
+$EmbedDir = Join-Path $RepoRoot "internal\web\dist"
+$BinDir = Join-Path $DesktopDir "src-tauri\binaries"
+$Triple = "x86_64-pc-windows-msvc"
+$SidecarBin = Join-Path $BinDir "agentsview-$Triple.exe"
+
+if (-not $SkipBuild) {
+    # --- Build frontend ---
+    Write-Host "Building frontend..." -ForegroundColor Cyan
+    Push-Location $FrontendDir
+    try {
+        npm install
+        npm run build
+    } finally {
+        Pop-Location
+    }
+
+    # Copy frontend dist into Go embed directory
+    if (Test-Path $EmbedDir) {
+        Remove-Item -Recurse -Force $EmbedDir
+    }
+    Copy-Item -Recurse (Join-Path $FrontendDir "dist") $EmbedDir
+
+    # --- Build Go sidecar ---
+    Write-Host "Building Go sidecar..." -ForegroundColor Cyan
+
+    $version = git -C $RepoRoot describe --tags --always --dirty 2>$null
+    if (-not $version) { $version = "dev" }
+    $commit = git -C $RepoRoot rev-parse --short HEAD 2>$null
+    if (-not $commit) { $commit = "unknown" }
+    $buildDate = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $ldflags = "-X main.version=$version -X main.commit=$commit -X main.buildDate=$buildDate"
+
+    $env:CGO_ENABLED = "1"
+    Push-Location $RepoRoot
+    try {
+        go build -tags fts5 -ldflags $ldflags -o agentsview.exe ./cmd/agentsview
+    } finally {
+        Pop-Location
+    }
+
+    # Copy sidecar binary
+    if (-not (Test-Path $BinDir)) {
+        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+    }
+    Copy-Item (Join-Path $RepoRoot "agentsview.exe") $SidecarBin -Force
+
+    Write-Host "Sidecar ready: $SidecarBin" -ForegroundColor Green
+} else {
+    if (-not (Test-Path $SidecarBin)) {
+        Write-Error "Sidecar binary not found at $SidecarBin. Run without -SkipBuild first."
+        exit 1
+    }
+    Write-Host "Skipping build (using existing sidecar binary)" -ForegroundColor Yellow
+}
+
+# --- Launch Tauri dev ---
+# Use `cargo run` directly instead of `npx tauri dev` to avoid Tauri's
+# built-in dev server opening a browser tab (port 1430) that shows a
+# stale "Preparing your workspace" page. The app manages its own
+# webview navigation from the splash screen to the Go backend.
+Write-Host "Launching Tauri dev..." -ForegroundColor Cyan
+Push-Location (Join-Path $DesktopDir "src-tauri")
+try {
+    cargo run
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

Fixes the Tauri desktop app on Windows and adds a PowerShell dev workflow script.

### Navigation guard for Windows WebView2
- WebView2 uses `http://tauri.localhost` (not `tauri://localhost` like macOS/Linux) as the app origin. The navigation guard now allows both `http` and `https` on `tauri.localhost`, with an explicit port check to prevent spoofing via other local services.
- Tests cover the allowed origins and rejected cases (wrong port, wrong scheme for localhost backend).

### Menu bar rename
- Renamed the app menu submenu from "AgentsView" to "File" to eliminate the triple-"AgentsView" appearance on Windows (OS title bar + menu bar + app header).

### Version sync
- Bumped `tauri.conf.json` version from `0.1.0` to `0.12.1` to match the project release version.

### Windows dev workflow (`scripts/desktop-dev.ps1`)
- New PowerShell script for building and launching the Tauri desktop app on Windows without requiring `make` or bash.
- Auto-activates fnm if Node.js is not on PATH.
- Builds the frontend SPA, Go sidecar binary, and copies it to the Tauri binaries directory.
- Dynamically patches `tauri.conf.json` version from git tags (matching the bash `prepare-sidecar.sh` behavior) and restores it on exit.
- Detects the Rust host triple at runtime for correct sidecar binary naming (ARM64 support).
- Uses `cargo run` directly instead of `npx tauri dev` to avoid the Tauri dev server opening a stale browser tab on port 1430.
- Supports `-SkipBuild` flag for fast iteration on Rust/Tauri code only.

### Housekeeping
- Added `/agentsview.exe` to `.gitignore` for Windows build artifacts.

## Test plan
- [x] Tauri desktop app launches and navigates correctly on Windows 11
- [x] Splash screen transitions through stages to the main app UI
- [x] No stale browser tab opened on port 1430
- [x] Menu bar shows "File" instead of duplicate "AgentsView"
- [x] `desktop-dev.ps1` full build and `-SkipBuild` paths both work
- [x] Navigation guard rejects http://tauri.localhost:9999 and other spoofable URLs

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)