### PR TITLE
fix: add newline after download progress before verify step

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -177,6 +177,9 @@ func PerformUpdate(
 		return fmt.Errorf("download: %w", err)
 	}
 
+	if progressFn != nil {
+		fmt.Println()
+	}
 	fmt.Println("Verifying and installing...")
 	if err := installFromArchive(
 		archivePath, info.Checksum, downloadChecksum,


### PR DESCRIPTION
## Summary

- Adds a newline after the download progress line completes, so "Verifying and installing..." appears on its own line instead of being appended to the progress output.

Fixes #169

## Test plan

- [ ] Run `agentsview update` when an update is available and verify the output shows the download progress and "Verifying and installing..." on separate lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)