### PR TITLE
feat: Linux desktop build (AppImage)

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -26,6 +26,10 @@ jobs:
             os: windows-latest
             bundle: nsis
             bundle_dir: nsis
+          - platform: linux
+            os: ubuntu-22.04
+            bundle: appimage
+            bundle_dir: appimage
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -48,6 +52,15 @@ jobs:
           update: false
           install: mingw-w64-x86_64-gcc
           path-type: inherit
+
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libappindicator3-dev librsvg2-dev \
+            patchelf
 
       - name: Install desktop dependencies
         run: npm ci

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -2,6 +2,11 @@ name: Desktop Artifacts
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'desktop/**'
+      - '.github/workflows/desktop-artifacts.yml'
+      - '.github/workflows/desktop-release.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -71,12 +71,11 @@ jobs:
         run: npm ci
         working-directory: desktop
 
-      - name: Desktop smoke tests
+      - name: Desktop smoke tests (shell scripts)
         shell: bash
         run: |
           bash desktop/scripts/test-prepare-sidecar.sh
           bash desktop/scripts/test-startup-ui.sh
-          cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib
 
       - name: Build desktop bundle
         shell: bash
@@ -84,6 +83,10 @@ jobs:
           cd desktop
           npm run prepare-sidecar
           npx tauri build --bundles "${{ matrix.bundle }}"
+
+      - name: Desktop smoke tests (Rust unit tests)
+        shell: bash
+        run: cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib
 
       - name: Smoke check sidecar metadata
         shell: bash

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -5,8 +5,12 @@ on:
   pull_request:
     paths:
       - 'desktop/**'
-      - '.github/workflows/desktop-artifacts.yml'
-      - '.github/workflows/desktop-release.yml'
+      - 'frontend/**'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/desktop-*.yml'
 
 permissions:
   contents: read
@@ -82,7 +86,8 @@ jobs:
         run: |
           cd desktop
           npm run prepare-sidecar
-          npx tauri build --bundles "${{ matrix.bundle }}"
+          npx tauri build --bundles "${{ matrix.bundle }}" \
+            --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - name: Desktop smoke tests (Rust unit tests)
         shell: bash

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -191,9 +191,76 @@ jobs:
           path: staging/*
           if-no-files-found: error
 
+  build-linux:
+    name: Desktop Build (Linux)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: "24"
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libappindicator3-dev librsvg2-dev \
+            patchelf
+
+      - name: Install desktop dependencies
+        run: npm ci
+        working-directory: desktop
+
+      - name: Prepare sidecar
+        env:
+          AGENTSVIEW_VERSION: ${{ github.ref_name }}
+        run: npm run prepare-sidecar
+        working-directory: desktop
+
+      - name: Patch updater config for current repository
+        env:
+          AGENTSVIEW_UPDATER_PUBKEY: ${{ secrets.AGENTSVIEW_UPDATER_PUBKEY }}
+        run: |
+          sed -i.bak \
+            -e "s|wesm/agentsview|${GITHUB_REPOSITORY}|g" \
+            -e "s|NOT_SET|${AGENTSVIEW_UPDATER_PUBKEY}|g" \
+            desktop/src-tauri/tauri.conf.json
+          rm -f desktop/src-tauri/tauri.conf.json.bak
+
+      - name: Build AppImage and updater bundle
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          AGENTSVIEW_UPDATER_PUBKEY: ${{ secrets.AGENTSVIEW_UPDATER_PUBKEY }}
+        run: npx tauri build --bundles appimage
+        working-directory: desktop
+
+      - name: Collect build artifacts
+        run: |
+          mkdir -p staging
+          cp desktop/src-tauri/target/release/bundle/appimage/*.AppImage staging/
+          cp desktop/src-tauri/target/release/bundle/appimage/*.AppImage.tar.gz staging/
+          cp desktop/src-tauri/target/release/bundle/appimage/*.AppImage.tar.gz.sig staging/
+          ls -la staging/
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: agentsview-desktop-linux
+          path: staging/*
+          if-no-files-found: error
+
   release:
     name: Upload Desktop Installers
-    needs: [build-macos, build-windows]
+    needs: [build-macos, build-windows, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -207,7 +274,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum *.dmg *.exe *.tar.gz *.nsis.zip > SHA256SUMS-desktop 2>/dev/null || true
+          sha256sum *.dmg *.exe *.AppImage *.tar.gz *.nsis.zip > SHA256SUMS-desktop 2>/dev/null || true
           cat SHA256SUMS-desktop
 
       - name: Generate updater manifest
@@ -221,6 +288,8 @@ jobs:
           MACOS_URL=""
           WINDOWS_SIG=""
           WINDOWS_URL=""
+          LINUX_SIG=""
+          LINUX_URL=""
 
           for f in artifacts/*.app.tar.gz.sig; do
             if [ -f "$f" ]; then
@@ -238,12 +307,24 @@ jobs:
             fi
           done
 
+          for f in artifacts/*.AppImage.tar.gz.sig; do
+            if [ -f "$f" ]; then
+              LINUX_SIG="$(cat "$f")"
+              LINUX_TARBALL="$(basename "${f%.sig}")"
+              LINUX_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${LINUX_TARBALL}"
+            fi
+          done
+
           if [ -z "$MACOS_SIG" ] || [ -z "$MACOS_URL" ]; then
             echo "error: missing macOS updater signature or URL" >&2
             exit 1
           fi
           if [ -z "$WINDOWS_SIG" ] || [ -z "$WINDOWS_URL" ]; then
             echo "error: missing Windows updater signature or URL" >&2
+            exit 1
+          fi
+          if [ -z "$LINUX_SIG" ] || [ -z "$LINUX_URL" ]; then
+            echo "error: missing Linux updater signature or URL" >&2
             exit 1
           fi
 
@@ -259,6 +340,10 @@ jobs:
               "windows-x86_64": {
                 "url": "${WINDOWS_URL}",
                 "signature": "${WINDOWS_SIG}"
+              },
+              "linux-x86_64": {
+                "url": "${LINUX_URL}",
+                "signature": "${LINUX_SIG}"
               }
             }
           }
@@ -273,6 +358,7 @@ jobs:
           files: |
             artifacts/*.dmg
             artifacts/*.exe
+            artifacts/*.AppImage
             artifacts/SHA256SUMS-desktop
 
       - name: Upload updater artifacts
@@ -296,4 +382,6 @@ jobs:
             artifacts/*.app.tar.gz.sig \
             artifacts/*.nsis.zip \
             artifacts/*.nsis.zip.sig \
+            artifacts/*.AppImage.tar.gz \
+            artifacts/*.AppImage.tar.gz.sig \
             artifacts/latest.json

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGS := -X main.version=$(VERSION) \
 LDFLAGS_RELEASE := $(LDFLAGS) -s -w
 DESKTOP_DIST_DIR := dist/desktop
 
-.PHONY: build build-release install frontend frontend-dev dev desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-app test test-short e2e vet lint tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir help
+.PHONY: build build-release install frontend frontend-dev dev desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app test test-short e2e vet lint tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -112,6 +112,24 @@ desktop-windows-installer:
 		-exec cp {} $(DESKTOP_DIST_DIR)/windows/ \;; \
 	echo "Copied $$exe_count Windows installer(s) to $(DESKTOP_DIST_DIR)/windows/"
 
+# Build Linux AppImage bundle
+# Run on a Linux host.
+desktop-linux-appimage:
+	cd desktop && npm install && npm run tauri:build:linux \
+		$(if $(TAURI_SIGNING_PRIVATE_KEY),,-- --config '{"bundle":{"createUpdaterArtifacts":false}}')
+	mkdir -p $(DESKTOP_DIST_DIR)/linux
+	rm -f $(DESKTOP_DIST_DIR)/linux/*.AppImage
+	@ai_count=$$(find desktop/src-tauri/target/release/bundle/appimage \
+		-maxdepth 1 -type f -name '*.AppImage' | wc -l | tr -d ' '); \
+	if [ "$$ai_count" -eq 0 ]; then \
+		echo "error: no AppImage found in bundle output" >&2; \
+		exit 1; \
+	fi; \
+	find desktop/src-tauri/target/release/bundle/appimage \
+		-maxdepth 1 -type f -name '*.AppImage' \
+		-exec cp {} $(DESKTOP_DIST_DIR)/linux/ \;; \
+	echo "Copied $$ai_count AppImage(s) to $(DESKTOP_DIST_DIR)/linux/"
+
 # Backward-compatible alias (macOS .app)
 desktop-app: desktop-macos-app
 
@@ -201,6 +219,7 @@ help:
 	@echo "  desktop-macos-app - Build macOS .app bundle only"
 	@echo "  desktop-macos-dmg - Build macOS DMG installer"
 	@echo "  desktop-windows-installer - Build Windows NSIS installer"
+	@echo "  desktop-linux-appimage - Build Linux AppImage"
 	@echo "  desktop-app    - Alias for desktop-macos-app"
 	@echo ""
 	@echo "  test           - Run all tests"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,6 +10,7 @@
     "tauri:build:macos-app": "npm run prepare-sidecar && bash ./scripts/run-tauri.sh build --bundles app",
     "tauri:build:macos-dmg": "npm run prepare-sidecar && bash ./scripts/run-tauri.sh build --bundles dmg",
     "tauri:build:windows": "npm run prepare-sidecar && bash ./scripts/run-tauri.sh build --bundles nsis",
+    "tauri:build:linux": "npm run prepare-sidecar && bash ./scripts/run-tauri.sh build --bundles appimage",
     "tauri": "tauri"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Add Linux AppImage to the desktop build pipeline (artifacts + release workflows)
- Add `desktop-linux-appimage` Makefile target and `tauri:build:linux` npm script
- Trigger desktop artifacts build on PRs that touch desktop files or workflows
- Include Linux in release checksums, updater manifest (`linux-x86_64`), and artifact uploads
- Fix `cargo test` ordering in desktop-artifacts workflow (needs sidecar binary)

## Validated

Tested AppImage builds on x86_64 and aarch64 Ubuntu 24.04 hosts before writing the CI jobs.

CI builds x86_64 only (`ubuntu-22.04` for broad glibc compatibility).

System deps: `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libappindicator3-dev`, `librsvg2-dev`, `patchelf`.

## Test plan

- [ ] Desktop Artifacts workflow passes for all 3 platforms (macOS, Windows, Linux)
- [ ] Linux artifact uploaded successfully

Generated with [Claude Code](https://claude.com/claude-code)