### PR TITLE
fix: surface insight generation errors in the UI

### DIFF
--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -290,7 +290,7 @@
             role="button"
             tabindex="0"
             onclick={() => insights.selectTask(task.clientId)}
-            onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") insights.selectTask(task.clientId); }}
+            onkeydown={(e) => { if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) insights.selectTask(task.clientId); }}
           >
             <div class="task-indicator">
               {#if task.status === "generating"}

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -314,6 +314,7 @@
               {#if task.logs.length > 0}
                 <div
                   class="task-logs"
+                  class:task-logs-error={task.status === "error"}
                   role="log"
                   aria-live="polite"
                 >
@@ -839,6 +840,15 @@
     font-family: var(--font-mono);
     font-size: 10px;
     line-height: 1.4;
+  }
+
+  .task-logs-error {
+    max-height: 240px;
+    border-color: color-mix(
+      in srgb,
+      var(--accent-red) 30%,
+      var(--border-muted)
+    );
   }
 
   .task-log-line {

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -411,8 +411,10 @@
             </span>
             <button
               class="delete-btn"
-              onclick={() => insights.dismissTask(task.clientId)}
-              title="Dismiss"
+              onclick={() => task.status === "error"
+                ? insights.dismissTask(task.clientId)
+                : insights.cancelTask(task.clientId)}
+              title={task.status === "error" ? "Dismiss" : "Cancel"}
             >
               <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
                 <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/>

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -286,6 +286,11 @@
           <div
             class="task-item"
             class:task-error={task.status === "error"}
+            class:selected={insights.selectedTaskId === task.clientId}
+            role="button"
+            tabindex="0"
+            onclick={() => insights.selectTask(task.clientId)}
+            onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") insights.selectTask(task.clientId); }}
           >
             <div class="task-indicator">
               {#if task.status === "generating"}
@@ -311,31 +316,18 @@
               {:else}
                 <span class="task-phase">{task.phase}</span>
               {/if}
-              {#if task.logs.length > 0}
-                <div
-                  class="task-logs"
-                  class:task-logs-error={task.status === "error"}
-                  role="log"
-                  aria-live="polite"
-                >
-                  {#each task.logs as entry}
-                    <div
-                      class="task-log-line"
-                      class:log-stderr={entry.stream === "stderr"}
-                    >
-                      <span class="task-log-stream">{entry.stream}</span>
-                      <span class="task-log-text">{entry.line}</span>
-                    </div>
-                  {/each}
-                </div>
-              {/if}
             </div>
             <span class="task-agent">{task.agent}</span>
             <button
               class="task-dismiss"
-              onclick={() => task.status === "error"
-                ? insights.dismissTask(task.clientId)
-                : insights.cancelTask(task.clientId)}
+              onclick={(e) => {
+                e.stopPropagation();
+                if (task.status === "error") {
+                  insights.dismissTask(task.clientId);
+                } else {
+                  insights.cancelTask(task.clientId);
+                }
+              }}
               title={task.status === "error" ? "Dismiss" : "Cancel"}
             >
               <svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor">
@@ -401,7 +393,78 @@
   </div>
 
   <main class="content-panel">
-    {#if insights.selectedItem}
+    {#if insights.selectedTask}
+      {@const task = insights.selectedTask}
+      <div class="reading-area">
+        <header class="insight-header">
+          <div class="header-top">
+            <span
+              class="header-badge"
+              class:badge-red={task.status === "error"}
+              class:badge-blue={task.status !== "error"}
+            >
+              {task.status === "error" ? "Error" : "Generating"}
+            </span>
+            <span class="header-date">
+              {typeShort(task.type, task.dateFrom, task.dateTo)}
+              {formatDateRange(task.dateFrom, task.dateTo)}
+            </span>
+            <button
+              class="delete-btn"
+              onclick={() => insights.dismissTask(task.clientId)}
+              title="Dismiss"
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/>
+              </svg>
+            </button>
+          </div>
+          <div class="header-details">
+            {#if task.project}
+              <span class="detail-chip">{task.project}</span>
+            {:else}
+              <span class="detail-chip muted">global</span>
+            {/if}
+            <span class="detail-text">{task.agent}</span>
+          </div>
+        </header>
+        {#if task.status === "error" && task.error}
+          <div class="task-error-banner">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8.982 1.566a1.13 1.13 0 00-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 01-1.1 0L7.1 5.995A.905.905 0 018 5zm.002 6a1 1 0 110 2 1 1 0 010-2z"/>
+            </svg>
+            <span>{task.error}</span>
+          </div>
+        {/if}
+        {#if task.logs.length > 0}
+          <div class="task-detail-logs" role="log">
+            <div class="task-detail-logs-header">
+              Execution Log
+              <span class="log-count">{task.logs.length} lines</span>
+            </div>
+            <div class="task-detail-logs-body">
+              {#each task.logs as entry}
+                <div
+                  class="task-log-line"
+                  class:log-stderr={entry.stream === "stderr"}
+                >
+                  <span class="task-log-stream">{entry.stream}</span>
+                  <span class="task-log-text">{entry.line}</span>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {:else if task.status === "generating"}
+          <div class="content-generating" style="margin-top: 48px">
+            <div class="gen-orbit">
+              <span class="orbit-ring"></span>
+              <span class="orbit-dot"></span>
+            </div>
+            <span class="gen-label">Waiting for {task.agent}...</span>
+          </div>
+        {/if}
+      </div>
+    {:else if insights.selectedItem}
       <div class="reading-area">
         <header class="insight-header">
           <div class="header-top">
@@ -737,6 +800,24 @@
     min-height: 42px;
     padding: 8px 14px 10px;
     overflow: hidden;
+    width: 100%;
+    text-align: left;
+    border-left: 2px solid transparent;
+    transition: background 0.1s;
+    cursor: pointer;
+  }
+
+  .task-item:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .task-item.selected {
+    background: var(--bg-surface-hover);
+    border-left-color: var(--accent-blue);
+  }
+
+  .task-item.selected.task-error {
+    border-left-color: var(--accent-red);
   }
 
   .task-error {
@@ -828,33 +909,72 @@
     word-break: break-word;
   }
 
-  .task-logs {
-    width: 100%;
-    max-height: 132px;
-    overflow-y: auto;
-    margin-top: 2px;
-    padding: 4px 6px;
-    border: 1px solid var(--border-muted);
-    border-radius: 6px;
-    background: var(--bg-inset);
-    font-family: var(--font-mono);
-    font-size: 10px;
-    line-height: 1.4;
-  }
-
-  .task-logs-error {
-    max-height: 240px;
-    border-color: color-mix(
+  /* ── Task Detail (main pane) ── */
+  .task-error-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px 16px;
+    border-radius: var(--radius-md);
+    background: color-mix(
       in srgb,
-      var(--accent-red) 30%,
+      var(--accent-red) 8%,
+      var(--bg-inset)
+    );
+    border: 1px solid color-mix(
+      in srgb,
+      var(--accent-red) 25%,
       var(--border-muted)
     );
+    color: var(--accent-red);
+    font-size: 13px;
+    line-height: 1.5;
+    margin-bottom: 20px;
+  }
+
+  .task-error-banner svg {
+    flex-shrink: 0;
+    margin-top: 2px;
+    opacity: 0.8;
+  }
+
+  .task-detail-logs {
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+
+  .task-detail-logs-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 14px;
+    background: var(--bg-inset);
+    border-bottom: 1px solid var(--border-muted);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  .log-count {
+    font-weight: 400;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .task-detail-logs-body {
+    max-height: 50vh;
+    overflow-y: auto;
+    padding: 8px 14px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.5;
   }
 
   .task-log-line {
     display: grid;
-    grid-template-columns: 42px 1fr;
-    gap: 6px;
+    grid-template-columns: 48px 1fr;
+    gap: 8px;
     color: var(--text-secondary);
     white-space: pre-wrap;
     word-break: break-word;
@@ -863,6 +983,7 @@
   .task-log-stream {
     text-transform: uppercase;
     color: var(--text-muted);
+    font-size: 10px;
   }
 
   .task-log-text {
@@ -1086,6 +1207,10 @@
 
   .badge-purple {
     background: var(--accent-purple);
+  }
+
+  .badge-red {
+    background: var(--accent-red);
   }
 
   .header-date {

--- a/frontend/src/lib/stores/insights.svelte.ts
+++ b/frontend/src/lib/stores/insights.svelte.ts
@@ -43,6 +43,7 @@ class InsightsStore {
   agent: AgentName = $state("claude");
   items: Insight[] = $state([]);
   selectedId: number | null = $state(null);
+  selectedTaskId: string | null = $state(null);
   loading = $state(false);
   promptText: string = $state("");
   tasks: InsightTask[] = $state([]);
@@ -53,6 +54,13 @@ class InsightsStore {
   get selectedItem(): Insight | undefined {
     return this.items.find(
       (s) => s.id === this.selectedId,
+    );
+  }
+
+  get selectedTask(): InsightTask | undefined {
+    if (this.selectedTaskId === null) return undefined;
+    return this.tasks.find(
+      (t) => t.clientId === this.selectedTaskId,
     );
   }
 
@@ -111,6 +119,12 @@ class InsightsStore {
 
   select(id: number) {
     this.selectedId = id;
+    this.selectedTaskId = null;
+  }
+
+  selectTask(clientId: string) {
+    this.selectedTaskId = clientId;
+    this.selectedId = null;
   }
 
   generate() {
@@ -205,6 +219,8 @@ class InsightsStore {
             ? { ...t, status: "error" as const, error: msg }
             : t,
         );
+        this.selectedTaskId = clientId;
+        this.selectedId = null;
       });
   }
 
@@ -217,6 +233,9 @@ class InsightsStore {
     this.tasks = this.tasks.filter(
       (t) => t.clientId !== clientId,
     );
+    if (this.selectedTaskId === clientId) {
+      this.selectedTaskId = null;
+    }
   }
 
   async deleteItem(id: number) {

--- a/frontend/src/lib/stores/insights.test.ts
+++ b/frontend/src/lib/stores/insights.test.ts
@@ -44,6 +44,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   insights.items = [];
   insights.selectedId = null;
+  insights.selectedTaskId = null;
   insights.loading = false;
   insights.tasks = [];
   insights.promptText = "";
@@ -185,9 +186,20 @@ describe("setProject", () => {
 });
 
 describe("select", () => {
-  it("sets selectedId", () => {
+  it("sets selectedId and clears selectedTaskId", () => {
+    insights.selectedTaskId = "some-task";
     insights.select(42);
     expect(insights.selectedId).toBe(42);
+    expect(insights.selectedTaskId).toBeNull();
+  });
+});
+
+describe("selectTask", () => {
+  it("sets selectedTaskId and clears selectedId", () => {
+    insights.selectedId = 42;
+    insights.selectTask("task-123");
+    expect(insights.selectedTaskId).toBe("task-123");
+    expect(insights.selectedId).toBeNull();
   });
 });
 
@@ -268,7 +280,7 @@ describe("generate (multi-task)", () => {
     expect(insights.items[0]).toEqual(s2);
   });
 
-  it("sets error on task failure", async () => {
+  it("sets error on task failure and selects task", async () => {
     const mockHandle = {
       abort: vi.fn(),
       done: Promise.reject(new Error("CLI not found")),
@@ -283,6 +295,10 @@ describe("generate (multi-task)", () => {
     expect(insights.tasks).toHaveLength(1);
     expect(insights.tasks[0]!.status).toBe("error");
     expect(insights.tasks[0]!.error).toBe("CLI not found");
+    expect(insights.selectedTaskId).toBe(
+      insights.tasks[0]!.clientId,
+    );
+    expect(insights.selectedId).toBeNull();
   });
 
   it("captures streaming logs per task", async () => {

--- a/internal/server/insights.go
+++ b/internal/server/insights.go
@@ -133,8 +133,22 @@ type generateInsightRequest struct {
 	Agent    string `json:"agent"`
 }
 
-func insightGenerateClientMessage(agent string) string {
-	return fmt.Sprintf("%s generation failed", agent)
+func insightGenerateClientMessage(
+	agent string, err error,
+) string {
+	if err == nil {
+		return fmt.Sprintf("%s generation failed", agent)
+	}
+	msg := err.Error()
+	// Strip stderr dump after newline for the short
+	// client message; full details are in the log stream.
+	if idx := strings.Index(msg, "\nstderr:"); idx > 0 {
+		msg = msg[:idx]
+	}
+	if idx := strings.Index(msg, "\nraw:"); idx > 0 {
+		msg = msg[:idx]
+	}
+	return msg
 }
 
 func (s *Server) handleGenerateInsight(
@@ -350,7 +364,9 @@ func (s *Server) handleGenerateInsight(
 	if err != nil {
 		log.Printf("insight generate error: %v", err)
 		sendJSON("error", map[string]string{
-			"message": insightGenerateClientMessage(req.Agent),
+			"message": insightGenerateClientMessage(
+				req.Agent, err,
+			),
 		})
 		return
 	}

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -244,7 +244,7 @@ func TestGenerateInsight_ErrorMessageStripsRaw(t *testing.T) {
 	if !strings.Contains(body, "claude returned empty result") {
 		t.Fatalf("expected error detail in response, got: %s", body)
 	}
-	if strings.Contains(body, "raw:") {
+	if strings.Contains(body, `"type":"result"`) {
 		t.Fatalf("expected raw payload to be stripped from client message")
 	}
 }

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -198,7 +198,31 @@ func TestGenerateInsight_DefaultAgent(t *testing.T) {
 		`{"type":"daily_activity","date_from":"2025-01-15","date_to":"2025-01-15"}`)
 	assertStatus(t, w, http.StatusOK)
 	assertBodyContains(t, w, "event: error")
-	assertBodyContains(t, w, "claude generation failed")
+	assertBodyContains(t, w, "stub: no CLI")
+}
+
+func TestGenerateInsight_ErrorMessageStripsStderr(t *testing.T) {
+	stubGen := func(
+		_ context.Context, _, _ string,
+	) (insight.Result, error) {
+		return insight.Result{}, fmt.Errorf(
+			"claude CLI failed: exit status 1\nstderr: some debug output",
+		)
+	}
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithGenerateFunc(stubGen),
+	})
+
+	w := te.post(t, "/api/v1/insights/generate",
+		`{"type":"daily_activity","date_from":"2025-01-15","date_to":"2025-01-15"}`)
+	assertStatus(t, w, http.StatusOK)
+	body := w.Body.String()
+	if !strings.Contains(body, "claude CLI failed: exit status 1") {
+		t.Fatalf("expected error detail in response, got: %s", body)
+	}
+	if strings.Contains(body, "some debug output") {
+		t.Fatalf("expected stderr to be stripped from client message")
+	}
 }
 
 func TestGenerateInsight_InitialStatusWriteFailureSkipsGeneration(t *testing.T) {

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -225,6 +225,30 @@ func TestGenerateInsight_ErrorMessageStripsStderr(t *testing.T) {
 	}
 }
 
+func TestGenerateInsight_ErrorMessageStripsRaw(t *testing.T) {
+	stubGen := func(
+		_ context.Context, _, _ string,
+	) (insight.Result, error) {
+		return insight.Result{}, fmt.Errorf(
+			"claude returned empty result\nraw: {\"type\":\"result\",\"result\":\"\"}",
+		)
+	}
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithGenerateFunc(stubGen),
+	})
+
+	w := te.post(t, "/api/v1/insights/generate",
+		`{"type":"daily_activity","date_from":"2025-01-15","date_to":"2025-01-15"}`)
+	assertStatus(t, w, http.StatusOK)
+	body := w.Body.String()
+	if !strings.Contains(body, "claude returned empty result") {
+		t.Fatalf("expected error detail in response, got: %s", body)
+	}
+	if strings.Contains(body, "raw:") {
+		t.Fatalf("expected raw payload to be stripped from client message")
+	}
+}
+
 func TestGenerateInsight_InitialStatusWriteFailureSkipsGeneration(t *testing.T) {
 	var called atomic.Bool
 	te := setupWithServerOpts(t, []server.Option{


### PR DESCRIPTION
## Summary

- Send actual error details (e.g. "claude CLI not found", "gemini
  failed: exit status 1") to the client instead of the generic
  "X generation failed" message. Stderr dumps are stripped from the
  short message since they're already visible in the log stream.
- Show task error details and execution logs in the main content pane
  instead of cramming them into the narrow sidebar. On error, the
  failed task is auto-selected so the user immediately sees an error
  banner and full log output.
- Sidebar task items are now clickable to view their details in the
  main pane (both during generation and after errors).

<img width="1914" height="392" alt="image" src="https://github.com/user-attachments/assets/bca10e27-7cf3-414b-b610-f14757d9bb8a" />

Closes #175

Generated with [Claude Code](https://claude.com/claude-code)