### PR TITLE
fix(desktop): add Edit menu to enable Cmd-C/V/X keyboard shortcuts

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -622,7 +622,20 @@ fn setup_menu(app: &mut App) -> Result<(), DynError> {
 
     let app_submenu = builder.quit().build()?;
 
-    let menu = MenuBuilder::new(app).item(&app_submenu).build()?;
+    let edit_submenu = SubmenuBuilder::new(app, "Edit")
+        .undo()
+        .redo()
+        .separator()
+        .cut()
+        .copy()
+        .paste()
+        .select_all()
+        .build()?;
+
+    let menu = MenuBuilder::new(app)
+        .item(&app_submenu)
+        .item(&edit_submenu)
+        .build()?;
     app.set_menu(menu)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add an Edit submenu (Undo, Redo, Cut, Copy, Paste, Select All) to the Tauri app menu bar
- On macOS, standard editing shortcuts (Cmd-C/V/X/A/Z) are routed through the menu bar — without an Edit menu they were non-functional in the webview

## Test plan

- [ ] Build the desktop app and verify Cmd-C copies selected text
- [ ] Verify Cmd-V pastes, Cmd-X cuts, Cmd-A selects all
- [ ] Verify Cmd-Z/Cmd-Shift-Z undo/redo work in text fields
- [ ] Verify the existing File menu (About, Check for Updates, Hide, Quit) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)