### PR TITLE
fix: add -buildvcs=false to Linux container builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,7 @@ jobs:
 
   release:
     needs: [build-linux, build]
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -240,6 +241,7 @@ jobs:
 
   pypi:
     needs: [build-linux, build, release]
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -266,14 +268,18 @@ jobs:
             --version "$VERSION" \
             --input-dir artifacts \
             --output-dir wheels \
-            --readme README.md \
-            --require-all
+            --readme README.md
 
       - name: Smoke test wheel
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          pip install wheels/agentsview-${VERSION}-py3-none-manylinux_2_28_x86_64.whl
-          agentsview --version
+          WHEEL="wheels/agentsview-${VERSION}-py3-none-manylinux_2_28_x86_64.whl"
+          if [ -f "$WHEEL" ]; then
+            pip install "$WHEEL"
+            agentsview --version
+          else
+            echo "Linux x86_64 wheel not available, skipping smoke test"
+          fi
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
 
   pypi:
     needs: [build-linux, build, release]
-    if: ${{ !cancelled() && needs.release.result == 'success' }}
+    if: ${{ !cancelled() && needs.release.result == 'success' && needs.build-linux.result == 'success' }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -268,18 +268,14 @@ jobs:
             --version "$VERSION" \
             --input-dir artifacts \
             --output-dir wheels \
-            --readme README.md
+            --readme README.md \
+            --require-all
 
       - name: Smoke test wheel
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          WHEEL="wheels/agentsview-${VERSION}-py3-none-manylinux_2_28_x86_64.whl"
-          if [ -f "$WHEEL" ]; then
-            pip install "$WHEEL"
-            agentsview --version
-          else
-            echo "Linux x86_64 wheel not available, skipping smoke test"
-          fi
+          pip install wheels/agentsview-${VERSION}-py3-none-manylinux_2_28_x86_64.whl
+          agentsview --version
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,6 @@ jobs:
 
   release:
     needs: [build-linux, build]
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -241,7 +240,6 @@ jobs:
 
   pypi:
     needs: [build-linux, build, release]
-    if: ${{ !cancelled() && needs.release.result == 'success' && needs.build-linux.result == 'success' }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
           mkdir -p dist
           LDFLAGS="-s -w -X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}"
-          go build -tags fts5 -ldflags="$LDFLAGS" -trimpath \
+          go build -tags fts5 -buildvcs=false -ldflags="$LDFLAGS" -trimpath \
             -o dist/agentsview ./cmd/agentsview
 
           # Smoke test (native builds — no cross-compilation)


### PR DESCRIPTION
## Summary

- Add `-buildvcs=false` to the `go build` command in the `build-linux` job
- Fixes `error obtaining VCS status: exit status 128` when building inside manylinux Docker containers where git `safe.directory` is not configured
- Version info is already stamped via `-ldflags`, so VCS stamping is redundant

Failed run: https://github.com/wesm/agentsview/actions/runs/23521504471

## Test plan

- [ ] Tag v0.16.1 and verify both Linux builds succeed
- [ ] Verify wheels are published to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)