### PR TITLE
chore: normalize product name to Agentsview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,10 @@ desktop-macos-app:
 	cd desktop && npm install && npm run tauri:build:macos-app \
 		$(if $(TAURI_SIGNING_PRIVATE_KEY),,-- --config '{"bundle":{"createUpdaterArtifacts":false}}')
 	mkdir -p $(DESKTOP_DIST_DIR)/macos
-	rm -rf $(DESKTOP_DIST_DIR)/macos/AgentsView.app
-	cp -R desktop/src-tauri/target/release/bundle/macos/AgentsView.app \
-		$(DESKTOP_DIST_DIR)/macos/AgentsView.app
-	@echo "macOS app bundle copied to $(DESKTOP_DIST_DIR)/macos/AgentsView.app"
+	rm -rf $(DESKTOP_DIST_DIR)/macos/Agentsview.app
+	cp -R desktop/src-tauri/target/release/bundle/macos/Agentsview.app \
+		$(DESKTOP_DIST_DIR)/macos/Agentsview.app
+	@echo "macOS app bundle copied to $(DESKTOP_DIST_DIR)/macos/Agentsview.app"
 
 # Build macOS DMG installer
 desktop-macos-dmg:

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agentsview-desktop"
 version = "0.1.0"
-description = "AgentsView desktop wrapper"
+description = "Agentsview desktop wrapper"
 authors = ["Wes McKinney"]
 edition = "2021"
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -455,7 +455,7 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow) {
         thread::sleep(READY_TIMEOUT);
         if !timeout_state.load(Ordering::SeqCst) {
             let _ = timeout_window.eval(
-                "window.__setStatus('AgentsView backend did not become ready in time.');",
+                "window.__setStatus('Agentsview backend did not become ready in time.');",
             );
         }
     });
@@ -507,7 +507,7 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow) {
                     if handle_sidecar_terminated(&state, startup_handled.as_ref()) {
                         let _ = window.eval(
                             "window.__setStatus(\
-                             'AgentsView backend exited before startup completed.');",
+                             'Agentsview backend exited before startup completed.');",
                         );
                     }
                     break;
@@ -550,7 +550,7 @@ fn redirect_when_ready(window: WebviewWindow, port: u16) {
 
         let _ = window.eval(
             "document.getElementById('status').textContent = \
-             'AgentsView backend did not start within 30 seconds.';",
+             'Agentsview backend did not start within 30 seconds.';",
         );
     });
 }
@@ -604,7 +604,7 @@ fn parse_listening_port_from_stdout_buffer(buffer: &mut String, chunk: &str) -> 
 }
 
 fn setup_menu(app: &mut App) -> Result<(), DynError> {
-    let about = MenuItemBuilder::with_id("about", "About AgentsView")
+    let about = MenuItemBuilder::with_id("about", "About Agentsview")
         .build(app)?;
     let check_updates = MenuItemBuilder::with_id("check_updates", "Check for Updates...")
         .build(app)?;

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "AgentsView",
+  "productName": "Agentsview",
   "version": "0.12.1",
   "identifier": "io.agentsview.desktop",
   "build": {
@@ -10,7 +10,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "AgentsView",
+        "title": "Agentsview",
         "width": 1440,
         "height": 900,
         "minWidth": 1024,
@@ -28,7 +28,7 @@
     "targets": "all",
     "copyright": "Copyright 2026 Wes McKinney",
     "shortDescription": "Local viewer for AI agent sessions",
-    "longDescription": "AgentsView is a local web viewer for AI agent sessions including Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, and Amp.",
+    "longDescription": "Agentsview is a local web viewer for AI agent sessions including Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, and Amp.",
     "createUpdaterArtifacts": "v1Compatible",
     "externalBin": [
       "binaries/agentsview"

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AgentsView</title>
+    <title>Agentsview</title>
     <style>
       :root {
         color-scheme: light;
@@ -241,7 +241,7 @@
             <circle cx="18" cy="8.5" r="2" fill="var(--brand)" />
             <circle cx="18" cy="8.5" r="1" fill="var(--brand-deep)" />
           </svg>
-          <p class="brand-name">AgentsView Desktop</p>
+          <p class="brand-name">Agentsview Desktop</p>
         </div>
 
         <h1>Preparing your workspace</h1>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400..700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <title>AgentsView</title>
+    <title>Agentsview</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -129,7 +129,7 @@
         <circle cx="18" cy="8.5" r="2" fill="var(--accent-blue, #3b82f6)"/>
         <circle cx="18" cy="8.5" r="1" fill="#1d4ed8"/>
       </svg>
-      <span class="header-title">AgentsView</span>
+      <span class="header-title">Agentsview</span>
     </button>
 
     <ProjectTypeahead

--- a/frontend/src/lib/components/modals/AboutModal.svelte
+++ b/frontend/src/lib/components/modals/AboutModal.svelte
@@ -45,7 +45,7 @@
         <circle cx="18" cy="8.5" r="2" fill="var(--accent-blue, #3b82f6)"/>
         <circle cx="18" cy="8.5" r="1" fill="#1d4ed8"/>
       </svg>
-      <div class="about-name">AgentsView</div>
+      <div class="about-name">Agentsview</div>
       <button
         class="close-btn"
         onclick={() => ui.activeModal = null}

--- a/scripts/desktop-dev.ps1
+++ b/scripts/desktop-dev.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Build and launch the AgentsView Tauri desktop app in dev mode on Windows.
+    Build and launch the Agentsview Tauri desktop app in dev mode on Windows.
 
 .DESCRIPTION
     Builds the frontend SPA, compiles the Go sidecar binary, copies it into


### PR DESCRIPTION
## Summary

- Rename `AgentsView` -> `Agentsview` across all code, config, and UI files
- Covers frontend titles, desktop app config (Tauri), Makefile build paths, Rust status messages, and PowerShell script

## Not included

Docs (`docs/desktop-release-setup.md`, `desktop/README.md`) will be updated separately. Note that Tauri build artifact filenames will change (e.g. `Agentsview_x.y.z_aarch64.dmg`).

## Test plan

- [x] Grep confirms no remaining `AgentsView` outside docs
- [ ] Verify desktop app builds with new `productName`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>