### PR TITLE
Detect and filter automated roborev sessions

### DIFF
--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -117,7 +117,7 @@ func runLocalSync(
 	}
 
 	fmt.Println()
-	stats, err := database.GetStats(context.Background(), false)
+	stats, err := database.GetStats(context.Background(), false, false)
 	if err == nil {
 		fmt.Printf(
 			"Database: %d sessions, %d messages\n",

--- a/docs/superpowers/plans/2026-04-01-roborev-detection.md
+++ b/docs/superpowers/plans/2026-04-01-roborev-detection.md
@@ -1,0 +1,793 @@
+# Roborev Detection & Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect automated roborev review/fix sessions via
+first_message heuristics, hide them by default, and flip single-turn
+sessions to shown-by-default with a "Hide single-turn" toggle.
+
+**Architecture:** Add `is_automated` boolean column to the sessions
+table (SQLite + PG). Compute it from `first_message` during upsert
+using prefix-matching heuristics. Add `ExcludeAutomated` filter
+alongside existing `ExcludeOneShot`. Frontend flips single-turn
+default and adds automated toggle.
+
+**Tech Stack:** Go (SQLite, PostgreSQL), Svelte 5 (TypeScript)
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `internal/db/automated.go` | Detection heuristic function |
+| Create | `internal/db/automated_test.go` | Tests for detection |
+| Modify | `internal/db/schema.sql` | Add `is_automated` column |
+| Modify | `internal/db/db.go` | Add migration + backfill |
+| Modify | `internal/db/sessions.go` | Struct, cols, scan, upsert, filter |
+| Modify | `internal/db/analytics.go` | `ExcludeAutomated` in `AnalyticsFilter` |
+| Modify | `internal/db/stats.go` | `excludeAutomated` param on `GetStats` |
+| Modify | `internal/db/filter_test.go` | Filter tests for automated exclusion |
+| Modify | `internal/server/sessions.go` | `include_automated` API param |
+| Modify | `internal/server/analytics.go` | `include_automated` API param |
+| Modify | `internal/server/events.go` | `include_automated` on metadata endpoints |
+| Modify | `internal/server/server_test.go` | API tests |
+| Modify | `internal/postgres/schema.go` | PG DDL + migration |
+| Modify | `internal/postgres/sessions.go` | PG cols, scan, filter |
+| Modify | `internal/postgres/analytics.go` | PG analytics filter |
+| Modify | `internal/postgres/push.go` | Sync `is_automated` to PG |
+| Modify | `frontend/src/lib/stores/sessions.svelte.ts` | Filters + default flip |
+| Modify | `frontend/src/lib/stores/analytics.svelte.ts` | Analytics filter |
+| Modify | `frontend/src/lib/components/sidebar/SessionList.svelte` | Toggle UI |
+| Modify | `frontend/src/lib/components/analytics/ActiveFilters.svelte` | Filter chips |
+| Modify | `frontend/src/lib/api/client.ts` | API params |
+| Modify | `frontend/src/App.svelte` | URL sync |
+
+---
+
+### Task 1: Detection heuristic + tests
+
+**Files:**
+- Create: `internal/db/automated.go`
+- Create: `internal/db/automated_test.go`
+
+- [ ] **Step 1: Write tests for the detection heuristic**
+
+Create `internal/db/automated_test.go`:
+
+```go
+package db
+
+import "testing"
+
+func TestIsAutomatedSession(t *testing.T) {
+	tests := []struct {
+		name         string
+		firstMessage string
+		want         bool
+	}{
+		{
+			"EmptyMessage",
+			"",
+			false,
+		},
+		{
+			"NormalUserPrompt",
+			"fix the login bug",
+			false,
+		},
+		{
+			"RoborevReviewPrompt",
+			"You are a code reviewer. Review the code changes shown below.\n\n## Changes\n...",
+			true,
+		},
+		{
+			"RoborevReviewPromptExact",
+			"You are a code reviewer. Review the code changes shown below.",
+			true,
+		},
+		{
+			"RoborevFixPrompt",
+			"# Fix Request\n\nAn analysis was performed and produced the following findings:\n...",
+			true,
+		},
+		{
+			"RoborevFixPromptExact",
+			"# Fix Request",
+			true,
+		},
+		{
+			"SimilarButNotReview",
+			"You are a code reviewer but I need help",
+			false,
+		},
+		{
+			"FixInNormalContext",
+			"Fix the request handler",
+			false,
+		},
+		{
+			"NilSafeViaPointer",
+			"",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAutomatedSession(tt.firstMessage)
+			if got != tt.want {
+				t.Errorf(
+					"IsAutomatedSession(%q) = %v, want %v",
+					tt.firstMessage, got, tt.want,
+				)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/wesm/.superset/worktrees/agentsview/feat/roborev-detection && CGO_ENABLED=1 go test -tags fts5 ./internal/db/ -run TestIsAutomatedSession -v`
+Expected: FAIL — `IsAutomatedSession` not defined.
+
+- [ ] **Step 3: Implement detection function**
+
+Create `internal/db/automated.go`:
+
+```go
+package db
+
+import "strings"
+
+// automatedPrefixes are first_message prefixes that identify
+// automated (roborev) review and fix sessions. Matched
+// case-sensitively against the start of first_message.
+var automatedPrefixes = []string{
+	"You are a code reviewer. Review the code changes shown below.",
+	"# Fix Request\n",
+}
+
+// IsAutomatedSession returns true if the first message
+// matches a known automated review/fix prompt pattern.
+func IsAutomatedSession(firstMessage string) bool {
+	for _, prefix := range automatedPrefixes {
+		if strings.HasPrefix(firstMessage, prefix) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `CGO_ENABLED=1 go test -tags fts5 ./internal/db/ -run TestIsAutomatedSession -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/automated.go internal/db/automated_test.go
+git commit -m "feat: add IsAutomatedSession detection heuristic"
+```
+
+---
+
+### Task 2: Add `is_automated` column to SQLite
+
+**Files:**
+- Modify: `internal/db/schema.sql:2-26` (add column to CREATE TABLE)
+- Modify: `internal/db/db.go:264-372` (add migration + backfill)
+- Modify: `internal/db/sessions.go:26-52` (column lists)
+- Modify: `internal/db/sessions.go:68-80` (scanSessionRow)
+- Modify: `internal/db/sessions.go:83-107` (Session struct)
+- Modify: `internal/db/sessions.go:523-577` (UpsertSession)
+
+- [ ] **Step 1: Add column to schema.sql**
+
+Add `is_automated INTEGER NOT NULL DEFAULT 0` after `has_peak_context_tokens` (line 23) in `internal/db/schema.sql`.
+
+- [ ] **Step 2: Add migration + backfill in db.go**
+
+In `migrateColumns()`, add a new migration entry:
+
+```go
+{
+	"sessions", "is_automated",
+	"ALTER TABLE sessions ADD COLUMN is_automated INTEGER NOT NULL DEFAULT 0",
+},
+```
+
+After column migrations, add a backfill step that updates existing
+sessions:
+
+```go
+// Backfill is_automated for existing sessions.
+if err := db.backfillIsAutomatedLocked(w); err != nil {
+	return err
+}
+```
+
+Add the backfill function:
+
+```go
+func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
+	var count int
+	if err := w.QueryRow(
+		`SELECT count(*) FROM sessions
+		 WHERE is_automated = 0
+		   AND first_message IS NOT NULL
+		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
+		     OR first_message LIKE '# Fix Request' || X'0A' || '%')`,
+	).Scan(&count); err != nil {
+		return fmt.Errorf("probing automated backfill: %w", err)
+	}
+	if count == 0 {
+		return nil
+	}
+	_, err := w.Exec(
+		`UPDATE sessions SET is_automated = 1
+		 WHERE first_message IS NOT NULL
+		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
+		     OR first_message LIKE '# Fix Request' || X'0A' || '%')`,
+	)
+	if err != nil {
+		return fmt.Errorf("backfilling is_automated: %w", err)
+	}
+	log.Printf("migration: backfilled is_automated for %d sessions", count)
+	return nil
+}
+```
+
+- [ ] **Step 3: Add `IsAutomated` field to Session struct**
+
+In `internal/db/sessions.go`, add to Session struct (after
+`HasPeakContextTokens`):
+
+```go
+IsAutomated bool `json:"is_automated"`
+```
+
+- [ ] **Step 4: Update column lists**
+
+Update `sessionBaseCols` to include `is_automated` after
+`has_peak_context_tokens`:
+
+```go
+const sessionBaseCols = `id, project, machine, agent,
+	first_message, display_name, started_at, ended_at,
+	message_count, user_message_count,
+	parent_session_id, relationship_type,
+	total_output_tokens, peak_context_tokens,
+	has_total_output_tokens, has_peak_context_tokens,
+	is_automated,
+	deleted_at, created_at`
+```
+
+Similarly update `sessionPruneCols` and `sessionFullCols`.
+
+- [ ] **Step 5: Update scanSessionRow**
+
+Add `&s.IsAutomated` to the Scan call after `&s.HasPeakContextTokens`:
+
+```go
+func scanSessionRow(rs rowScanner) (Session, error) {
+	var s Session
+	err := rs.Scan(
+		&s.ID, &s.Project, &s.Machine, &s.Agent,
+		&s.FirstMessage, &s.DisplayName, &s.StartedAt, &s.EndedAt,
+		&s.MessageCount, &s.UserMessageCount,
+		&s.ParentSessionID, &s.RelationshipType,
+		&s.TotalOutputTokens, &s.PeakContextTokens,
+		&s.HasTotalOutputTokens, &s.HasPeakContextTokens,
+		&s.IsAutomated,
+		&s.DeletedAt, &s.CreatedAt,
+	)
+	return s, err
+}
+```
+
+Also update the two manual Scan calls in `GetSessionFull` and
+`ListSessionsModifiedBetween` — add `&s.IsAutomated` in the
+same position (after `&s.HasPeakContextTokens`).
+
+- [ ] **Step 6: Update UpsertSession to set is_automated**
+
+Add `is_automated` to the INSERT column list and the ON CONFLICT
+UPDATE set. Compute it from `FirstMessage`:
+
+```go
+isAutomated := false
+if s.FirstMessage != nil {
+	isAutomated = IsAutomatedSession(*s.FirstMessage)
+}
+```
+
+Add `is_automated` as a column in the INSERT and the ON CONFLICT
+DO UPDATE SET clause. Pass `isAutomated` as a bind parameter.
+
+- [ ] **Step 7: Also update scanPruneCandidate in FindPruneCandidates**
+
+The `FindPruneCandidates` function scans `sessionPruneCols` manually
+(not via `scanSessionRow`). Add `&s.IsAutomated` to that Scan in
+the correct position.
+
+- [ ] **Step 8: Run all tests**
+
+Run: `CGO_ENABLED=1 go test -tags fts5 ./internal/db/ -v`
+Expected: PASS (existing tests exercise UpsertSession, scan, etc.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/db/schema.sql internal/db/db.go internal/db/sessions.go
+git commit -m "feat: add is_automated column to sessions table"
+```
+
+---
+
+### Task 3: Add `ExcludeAutomated` filter to SQLite queries
+
+**Files:**
+- Modify: `internal/db/sessions.go:186-362` (SessionFilter, buildSessionFilter)
+- Modify: `internal/db/analytics.go:44-156` (AnalyticsFilter, buildWhere)
+- Modify: `internal/db/stats.go:46-66` (GetStats)
+- Modify: `internal/db/sessions.go:898-994` (GetProjects, GetAgents, GetMachines)
+
+- [ ] **Step 1: Write filter tests**
+
+Add to `internal/db/filter_test.go`:
+
+```go
+func TestSessionFilterExcludeAutomated(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "normal", "proj", func(s *Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "review", "proj", func(s *Session) {
+		fm := "You are a code reviewer. Review the code changes shown below.\n\n## Changes"
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "fix", "proj", func(s *Session) {
+		fm := "# Fix Request\nAn analysis was performed"
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "multi", "proj", func(s *Session) {
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+
+	tests := []struct {
+		name            string
+		excludeAutomated bool
+		want            []string
+	}{
+		{
+			"IncludeAll",
+			false,
+			[]string{"normal", "review", "fix", "multi"},
+		},
+		{
+			"ExcludeAutomated",
+			true,
+			[]string{"normal", "multi"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := SessionFilter{
+				ExcludeAutomated: tt.excludeAutomated,
+			}
+			requireSessions(t, d, f, tt.want)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `CGO_ENABLED=1 go test -tags fts5 ./internal/db/ -run TestSessionFilterExcludeAutomated -v`
+Expected: FAIL — `ExcludeAutomated` field not found.
+
+- [ ] **Step 3: Add `ExcludeAutomated` to SessionFilter**
+
+In `internal/db/sessions.go`, add to `SessionFilter`:
+
+```go
+ExcludeAutomated bool // exclude sessions where is_automated = 1
+```
+
+- [ ] **Step 4: Add filter predicate to buildSessionFilter**
+
+In `buildSessionFilter`, after the `ExcludeOneShot` handling block
+(around line 324), add:
+
+```go
+if f.ExcludeAutomated {
+	filterPreds = append(filterPreds, "is_automated = 0")
+}
+```
+
+No special `IncludeChildren` handling needed — automated sessions
+are never parents.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `CGO_ENABLED=1 go test -tags fts5 ./internal/db/ -run TestSessionFilterExcludeAutomated -v`
+Expected: PASS
+
+- [ ] **Step 6: Add `ExcludeAutomated` to AnalyticsFilter**
+
+In `internal/db/analytics.go`, add to `AnalyticsFilter`:
+
+```go
+ExcludeAutomated bool // exclude automated sessions
+```
+
+In `buildWhere`, after the `ExcludeOneShot` block (line 146-147),
+add:
+
+```go
+if f.ExcludeAutomated {
+	preds = append(preds, "is_automated = 0")
+}
+```
+
+- [ ] **Step 7: Update GetStats, GetProjects, GetAgents, GetMachines**
+
+Change their signature from `excludeOneShot bool` to accept a
+struct:
+
+```go
+type MetadataFilter struct {
+	ExcludeOneShot   bool
+	ExcludeAutomated bool
+}
+```
+
+Or simpler: add a second `bool` parameter `excludeAutomated` to
+each function and add the `AND is_automated = 0` predicate when
+true. Follow the existing `excludeOneShot` pattern.
+
+- [ ] **Step 8: Run all DB tests**
+
+Run: `CGO_ENABLED=1 go test -tags fts5 ./internal/db/ -v`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/db/sessions.go internal/db/analytics.go \
+       internal/db/stats.go internal/db/filter_test.go
+git commit -m "feat: add ExcludeAutomated filter to session queries"
+```
+
+---
+
+### Task 4: Update API handlers
+
+**Files:**
+- Modify: `internal/server/sessions.go:10-93` (handleListSessions)
+- Modify: `internal/server/analytics.go:49-125` (parseAnalyticsFilter)
+- Modify: `internal/server/events.go:319-378` (stats/projects/agents/machines handlers)
+
+- [ ] **Step 1: Add `include_automated` param to handleListSessions**
+
+In `internal/server/sessions.go`, after `includeOneShot` (line 58):
+
+```go
+includeAutomated := q.Get("include_automated") == "true"
+```
+
+Add to filter struct:
+
+```go
+ExcludeAutomated: !includeAutomated,
+```
+
+- [ ] **Step 2: Add `include_automated` param to parseAnalyticsFilter**
+
+In `internal/server/analytics.go`, after `includeOneShot` (line 110):
+
+```go
+includeAutomated := q.Get("include_automated") == "true"
+```
+
+Add to return struct:
+
+```go
+ExcludeAutomated: !includeAutomated,
+```
+
+- [ ] **Step 3: Add `include_automated` to metadata handlers**
+
+In `internal/server/events.go`, update `handleGetStats`,
+`handleListProjects`, `handleListMachines`, `handleListAgents`
+to parse `include_automated` and pass `excludeAutomated` alongside
+`excludeOneShot`.
+
+- [ ] **Step 4: Run server tests**
+
+Run: `CGO_ENABLED=1 go test -tags fts5 ./internal/server/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/sessions.go internal/server/analytics.go \
+       internal/server/events.go
+git commit -m "feat: add include_automated API parameter"
+```
+
+---
+
+### Task 5: Update PostgreSQL support
+
+**Files:**
+- Modify: `internal/postgres/schema.go:26-46` (coreDDL)
+- Modify: `internal/postgres/sessions.go:29-35` (pgSessionCols)
+- Modify: `internal/postgres/sessions.go:51-86` (scanPGSession)
+- Modify: `internal/postgres/sessions.go:113-239` (buildPGSessionFilter)
+- Modify: `internal/postgres/analytics.go:65-119` (buildAnalyticsWhere)
+- Modify: `internal/postgres/push.go:589-660` (pushSession)
+
+- [ ] **Step 1: Add column to PG DDL**
+
+In `internal/postgres/schema.go`, add to sessions table DDL
+(after `has_peak_context_tokens`):
+
+```sql
+is_automated BOOLEAN NOT NULL DEFAULT FALSE,
+```
+
+- [ ] **Step 2: Add schema migration**
+
+In the migration section of `schema.go` (wherever columns are
+added to existing tables), add an `ALTER TABLE sessions ADD COLUMN
+is_automated BOOLEAN NOT NULL DEFAULT FALSE` migration.
+
+- [ ] **Step 3: Update pgSessionCols and scanPGSession**
+
+Add `is_automated` to `pgSessionCols` after
+`has_peak_context_tokens`. Add `&s.IsAutomated` to the Scan call
+in `scanPGSession`.
+
+- [ ] **Step 4: Update buildPGSessionFilter**
+
+After the `ExcludeOneShot` block, add:
+
+```go
+if f.ExcludeAutomated {
+	filterPreds = append(filterPreds, "is_automated = FALSE")
+}
+```
+
+- [ ] **Step 5: Update buildAnalyticsWhere**
+
+After the `ExcludeOneShot` block, add:
+
+```go
+if f.ExcludeAutomated {
+	preds = append(preds,
+		"is_automated = FALSE")
+}
+```
+
+- [ ] **Step 6: Update pushSession**
+
+Add `is_automated` to the INSERT columns, values, ON CONFLICT
+UPDATE SET, and WHERE IS DISTINCT FROM clauses. Compute from
+`sess.FirstMessage`:
+
+```go
+isAutomated := false
+if sess.FirstMessage != nil {
+	isAutomated = db.IsAutomatedSession(*sess.FirstMessage)
+}
+```
+
+- [ ] **Step 7: Run PG compilation check**
+
+Run: `CGO_ENABLED=1 go build -tags fts5 ./internal/postgres/...`
+Expected: compiles cleanly (full PG tests require a running
+PostgreSQL instance).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/postgres/schema.go internal/postgres/sessions.go \
+       internal/postgres/analytics.go internal/postgres/push.go
+git commit -m "feat: add is_automated column to PostgreSQL schema"
+```
+
+---
+
+### Task 6: Frontend - flip defaults and add automated filter
+
+**Files:**
+- Modify: `frontend/src/lib/api/types/core.ts` (add `is_automated`)
+- Modify: `frontend/src/lib/api/client.ts` (add `include_automated` params)
+- Modify: `frontend/src/lib/stores/sessions.svelte.ts` (filter changes)
+- Modify: `frontend/src/lib/stores/analytics.svelte.ts` (filter changes)
+- Modify: `frontend/src/lib/components/sidebar/SessionList.svelte` (toggle UI)
+- Modify: `frontend/src/lib/components/analytics/ActiveFilters.svelte` (filter chips)
+- Modify: `frontend/src/App.svelte` (URL sync)
+
+- [ ] **Step 1: Add `is_automated` to TypeScript Session type**
+
+In `frontend/src/lib/api/types/core.ts`, add:
+
+```typescript
+is_automated: boolean;
+```
+
+- [ ] **Step 2: Add `include_automated` to API client**
+
+Update `getProjects`, `getMachines`, `getAgents`, `getStats` to
+accept `include_automated?: boolean` alongside `include_one_shot`.
+
+- [ ] **Step 3: Update sessions store**
+
+In `frontend/src/lib/stores/sessions.svelte.ts`:
+
+1. Add `includeAutomated: boolean` to `Filters` interface
+   (default `false`)
+2. Change `includeOneShot` default from `false` to `true`
+3. In `apiParams`, add `include_automated: f.includeAutomated ||
+   undefined`
+4. Update `hasActiveFilters`: replace `f.includeOneShot` with
+   `!f.includeOneShot` (since default is now true, NOT including
+   is the active filter). Add `f.includeAutomated`.
+5. Add `setIncludeAutomatedFilter(include: boolean)` method
+6. Update `clearSessionFilters` to reset both filters
+7. Update `invalidateFilterCaches` to pass both params
+8. Update `initFromParams` to parse `include_automated`
+9. Update `loadProjects`, `loadAgents`, `loadMachines` to pass
+   both filter params
+
+- [ ] **Step 4: Update analytics store**
+
+In `frontend/src/lib/stores/analytics.svelte.ts`:
+
+1. Add `includeAutomated: boolean = $state(false)`
+2. Update `params` getter to include `include_automated`
+3. Update `hasActiveFilters` with the same logic changes
+
+- [ ] **Step 5: Update SessionList filter toggles**
+
+In `frontend/src/lib/components/sidebar/SessionList.svelte`:
+
+1. Change "Include single-turn" toggle to "Hide single-turn"
+   with inverted logic (ON = `includeOneShot: false`)
+2. Add new "Include automated" toggle below it (ON =
+   `includeAutomated: true`)
+
+- [ ] **Step 6: Update ActiveFilters chips**
+
+In `frontend/src/lib/components/analytics/ActiveFilters.svelte`:
+
+1. Change "Single-turn included" chip to "Single-turn hidden"
+   (shown when `!includeOneShot`, since default is now true)
+2. Add "Automated included" chip (shown when
+   `includeAutomated`)
+
+- [ ] **Step 7: Update App.svelte URL sync**
+
+In `frontend/src/App.svelte`, add `include_automated` to the URL
+param sync (same pattern as `include_one_shot`). Since
+`includeOneShot` is now true by default, always include it in URL
+params when false: `if (!f.includeOneShot)
+p.include_one_shot = "false"`.
+
+Wait — for backwards compatibility, keep the existing URL param
+behavior: `include_one_shot=true` means include. The default now
+sends `include_one_shot=true` because the frontend default flipped.
+When user toggles "Hide single-turn", it stops sending the param
+(server default excludes).
+
+- [ ] **Step 8: Build frontend**
+
+Run: `cd frontend && npm run build`
+Expected: no TypeScript errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/lib/api/types/core.ts \
+       frontend/src/lib/api/client.ts \
+       frontend/src/lib/stores/sessions.svelte.ts \
+       frontend/src/lib/stores/analytics.svelte.ts \
+       frontend/src/lib/components/sidebar/SessionList.svelte \
+       frontend/src/lib/components/analytics/ActiveFilters.svelte \
+       frontend/src/App.svelte
+git commit -m "feat: flip single-turn default, add automated filter UI"
+```
+
+---
+
+### Task 7: Update server tests
+
+**Files:**
+- Modify: `internal/server/server_test.go`
+
+- [ ] **Step 1: Update existing tests that use `include_one_shot`**
+
+Several tests use `include_one_shot=true` to include single-turn
+sessions. These remain correct — the server-side default hasn't
+changed (server still excludes one-shot unless told otherwise).
+Only the frontend default changed.
+
+Add a test for the new `include_automated` parameter:
+
+```go
+// Verify include_automated=true shows automated sessions.
+// Create a session with a roborev first_message, verify it's
+// excluded by default and included with include_automated=true.
+```
+
+- [ ] **Step 2: Run all server tests**
+
+Run: `CGO_ENABLED=1 go test -tags fts5 ./internal/server/ -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/server/server_test.go
+git commit -m "test: add server tests for include_automated param"
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Run all Go tests**
+
+Run: `CGO_ENABLED=1 go test -tags fts5 ./... -v`
+Expected: PASS
+
+- [ ] **Step 2: Run lints**
+
+Run: `go vet ./... && go fmt ./...`
+Expected: clean
+
+- [ ] **Step 3: Build full binary**
+
+Run: `make build`
+Expected: builds successfully with embedded frontend
+
+- [ ] **Step 4: Commit any final fixes**
+
+---
+
+## Key Design Decisions
+
+1. **`is_automated` as stored column, not computed**: Allows
+   indexed filtering without per-row computation. Computed from
+   `first_message` during upsert; backfilled via SQL LIKE for
+   existing rows.
+
+2. **Server-side defaults unchanged**: The `include_one_shot`
+   API parameter behavior is preserved. Only the frontend
+   default flips from "exclude" to "include". This avoids
+   breaking API consumers.
+
+3. **No `dataVersion` bump needed**: The column is added via
+   migration + backfill. No need for a full resync since the
+   detection is based on existing `first_message` data.
+
+4. **Detection heuristics are prefix-based**: Simple
+   `strings.HasPrefix` matching against known prompt patterns.
+   Easy to extend by adding entries to `automatedPrefixes`.

--- a/frontend/e2e/virtual-list.spec.ts
+++ b/frontend/e2e/virtual-list.spec.ts
@@ -44,7 +44,7 @@ test.describe("Virtual list behavior", () => {
       ]),
     );
 
-    await page.route("**/api/v1/projects", async (route) => {
+    await page.route("**/api/v1/projects*", async (route) => {
       await route.fulfill({
         json: {
           projects: [

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -272,7 +272,8 @@
     if (f.minMessages > 0) p.min_messages = String(f.minMessages);
     if (f.maxMessages > 0) p.max_messages = String(f.maxMessages);
     if (f.minUserMessages > 0) p.min_user_messages = String(f.minUserMessages);
-    if (f.includeOneShot) p.include_one_shot = "true";
+    if (!f.includeOneShot) p.include_one_shot = "false";
+    if (f.includeAutomated) p.include_automated = "true";
     return p;
   }
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -233,26 +233,31 @@ export function searchSession(
 
 /* Metadata */
 
+interface MetadataParams {
+  include_one_shot?: boolean;
+  include_automated?: boolean;
+}
+
 export function getProjects(
-  params: { include_one_shot?: boolean } = {},
+  params: MetadataParams = {},
 ): Promise<ProjectsResponse> {
   return fetchJSON(`/projects${buildQuery({ ...params })}`);
 }
 
 export function getMachines(
-  params: { include_one_shot?: boolean } = {},
+  params: MetadataParams = {},
 ): Promise<MachinesResponse> {
   return fetchJSON(`/machines${buildQuery({ ...params })}`);
 }
 
 export function getAgents(
-  params: { include_one_shot?: boolean } = {},
+  params: MetadataParams = {},
 ): Promise<AgentsResponse> {
   return fetchJSON(`/agents${buildQuery({ ...params })}`);
 }
 
 export function getStats(
-  params: { include_one_shot?: boolean } = {},
+  params: MetadataParams = {},
 ): Promise<Stats> {
   return fetchJSON(`/stats${buildQuery({ ...params })}`);
 }
@@ -655,6 +660,7 @@ export interface AnalyticsParams {
   hour?: number;
   min_user_messages?: number;
   include_one_shot?: boolean;
+  include_automated?: boolean;
   active_since?: string;
 }
 

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -27,6 +27,7 @@ export interface Session {
   peak_context_tokens: number;
   has_total_output_tokens?: boolean;
   has_peak_context_tokens?: boolean;
+  is_automated: boolean;
   created_at: string;
 }
 

--- a/frontend/src/lib/components/analytics/ActiveFilters.svelte
+++ b/frontend/src/lib/components/analytics/ActiveFilters.svelte
@@ -173,10 +173,7 @@
     {#if analytics.includeAutomated}
       <button
         class="filter-chip"
-        onclick={() => {
-          analytics.includeAutomated = false;
-          analytics.fetchAll();
-        }}
+        onclick={() => analytics.clearIncludeAutomated()}
         title="Clear automated filter"
       >
         Automated included

--- a/frontend/src/lib/components/analytics/ActiveFilters.svelte
+++ b/frontend/src/lib/components/analytics/ActiveFilters.svelte
@@ -45,7 +45,8 @@
     (analytics.project !== "" ? 1 : 0) +
     selectedAgents.length +
     (analytics.minUserMessages > 0 ? 1 : 0) +
-    (analytics.includeOneShot ? 1 : 0) +
+    (!analytics.includeOneShot ? 1 : 0) +
+    (analytics.includeAutomated ? 1 : 0) +
     (analytics.recentlyActive ? 1 : 0) +
     (hasTime ? 1 : 0)
   );
@@ -158,13 +159,27 @@
       </button>
     {/if}
 
-    {#if analytics.includeOneShot}
+    {#if !analytics.includeOneShot}
       <button
         class="filter-chip"
         onclick={() => analytics.clearIncludeOneShot()}
         title="Clear single-turn filter"
       >
-        Single-turn included
+        Single-turn hidden
+        <span class="chip-x">&times;</span>
+      </button>
+    {/if}
+
+    {#if analytics.includeAutomated}
+      <button
+        class="filter-chip"
+        onclick={() => {
+          analytics.includeAutomated = false;
+          analytics.fetchAll();
+        }}
+        title="Clear automated filter"
+      >
+        Automated included
         <span class="chip-x">&times;</span>
       </button>
     {/if}

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -58,6 +58,8 @@
       sessions.filters.minUserMessages;
     const headerIncludeOneShot =
       sessions.filters.includeOneShot;
+    const headerIncludeAutomated =
+      sessions.filters.includeAutomated;
 
     const curProject = untrack(() => analytics.project);
     const curAgent = untrack(() => analytics.agent);
@@ -69,6 +71,9 @@
     );
     const curIncludeOneShot = untrack(
       () => analytics.includeOneShot,
+    );
+    const curIncludeAutomated = untrack(
+      () => analytics.includeAutomated,
     );
 
     let changed = false;
@@ -96,6 +101,11 @@
 
     if (curIncludeOneShot !== headerIncludeOneShot) {
       analytics.includeOneShot = headerIncludeOneShot;
+      changed = true;
+    }
+
+    if (curIncludeAutomated !== headerIncludeAutomated) {
+      analytics.includeAutomated = headerIncludeAutomated;
       changed = true;
     }
 

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -18,8 +18,16 @@
   }
 
   function handleSessionClick(id: string) {
+    let needInvalidate = false;
     if (analytics.includeOneShot && !sessions.filters.includeOneShot) {
       sessions.filters.includeOneShot = true;
+      needInvalidate = true;
+    }
+    if (analytics.includeAutomated && !sessions.filters.includeAutomated) {
+      sessions.filters.includeAutomated = true;
+      needInvalidate = true;
+    }
+    if (needInvalidate) {
       sessions.invalidateFilterCaches();
     }
     router.navigateToSession(id);

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -85,8 +85,11 @@
   let isHideUnknownOn = $derived(
     sessions.filters.hideUnknownProject,
   );
-  let isIncludeOneShotOn = $derived(
-    sessions.filters.includeOneShot,
+  let isHideSingleTurnOn = $derived(
+    !sessions.filters.includeOneShot,
+  );
+  let isIncludeAutomatedOn = $derived(
+    sessions.filters.includeAutomated,
   );
 
   let groups = $derived.by(() => {
@@ -455,17 +458,31 @@
           </div>
           <button
             class="filter-toggle"
-            class:active={isIncludeOneShotOn}
+            class:active={isHideSingleTurnOn}
             onclick={() =>
               sessions.setIncludeOneShotFilter(
-                !isIncludeOneShotOn,
+                isHideSingleTurnOn,
               )}
           >
             <span
               class="toggle-check"
-              class:on={isIncludeOneShotOn}
+              class:on={isHideSingleTurnOn}
             ></span>
-            Include single-turn
+            Hide single-turn
+          </button>
+          <button
+            class="filter-toggle"
+            class:active={isIncludeAutomatedOn}
+            onclick={() =>
+              sessions.setIncludeAutomatedFilter(
+                !isIncludeAutomatedOn,
+              )}
+          >
+            <span
+              class="toggle-check"
+              class:on={isIncludeAutomatedOn}
+            ></span>
+            Include automated reviews
           </button>
         </div>
         <div class="filter-section">

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -198,6 +198,15 @@ class AnalyticsStore {
     this.fetchAll();
   }
 
+  clearIncludeAutomated() {
+    this.includeAutomated = false;
+    sessions.filters.includeAutomated = false;
+    sessions.activeSessionId = null;
+    sessions.invalidateFilterCaches();
+    sessions.load();
+    this.fetchAll();
+  }
+
   clearRecentlyActive() {
     this.recentlyActive = false;
     sessions.filters.recentlyActive = false;

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -65,7 +65,8 @@ class AnalyticsStore {
   project: string = $state("");
   agent: string = $state("");
   minUserMessages: number = $state(0);
-  includeOneShot: boolean = $state(false);
+  includeOneShot: boolean = $state(true);
+  includeAutomated: boolean = $state(false);
   recentlyActive: boolean = $state(false);
   selectedDow: number | null = $state(null);
   selectedHour: number | null = $state(null);
@@ -127,7 +128,8 @@ class AnalyticsStore {
       this.project !== "" ||
       this.agent !== "" ||
       this.minUserMessages > 0 ||
-      this.includeOneShot ||
+      !this.includeOneShot ||
+      this.includeAutomated ||
       this.recentlyActive ||
       this.selectedDow !== null ||
       this.selectedHour !== null
@@ -139,14 +141,16 @@ class AnalyticsStore {
     this.project = "";
     this.agent = "";
     this.minUserMessages = 0;
-    this.includeOneShot = false;
+    this.includeOneShot = true;
+    this.includeAutomated = false;
     this.recentlyActive = false;
     this.selectedDow = null;
     this.selectedHour = null;
     sessions.filters.project = "";
     sessions.filters.agent = "";
     sessions.filters.minUserMessages = 0;
-    sessions.filters.includeOneShot = false;
+    sessions.filters.includeOneShot = true;
+    sessions.filters.includeAutomated = false;
     sessions.filters.recentlyActive = false;
     sessions.activeSessionId = null;
     sessions.invalidateFilterCaches();
@@ -186,8 +190,8 @@ class AnalyticsStore {
   }
 
   clearIncludeOneShot() {
-    this.includeOneShot = false;
-    sessions.filters.includeOneShot = false;
+    this.includeOneShot = true;
+    sessions.filters.includeOneShot = true;
     sessions.activeSessionId = null;
     sessions.invalidateFilterCaches();
     sessions.load();
@@ -256,6 +260,9 @@ class AnalyticsStore {
     if (this.includeOneShot) {
       p.include_one_shot = true;
     }
+    if (this.includeAutomated) {
+      p.include_automated = true;
+    }
     if (this.recentlyActive) {
       p.active_since = new Date(
         Date.now() - 24 * 60 * 60 * 1000,
@@ -293,6 +300,9 @@ class AnalyticsStore {
       }
       if (this.includeOneShot) {
         p.include_one_shot = true;
+      }
+      if (this.includeAutomated) {
+        p.include_automated = true;
       }
       if (this.recentlyActive) {
         p.active_since = new Date(

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -145,6 +145,7 @@ class SessionsStore {
     }
 
     const prevOneShot = this.filters.includeOneShot;
+    const prevAutomated = this.filters.includeAutomated;
     // Default is true (show single-turn); only false when
     // explicitly set to "false" in URL params.
     const oneShotParam = params["include_one_shot"];
@@ -170,7 +171,8 @@ class SessionsStore {
       includeOneShot: nextOneShot,
       includeAutomated: nextAutomated,
     };
-    if (prevOneShot !== nextOneShot) {
+    if (prevOneShot !== nextOneShot ||
+        prevAutomated !== nextAutomated) {
       this.invalidateFilterCaches();
     }
     this.setActiveSession(null);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -31,6 +31,7 @@ interface Filters {
   maxMessages: number;
   minUserMessages: number;
   includeOneShot: boolean;
+  includeAutomated: boolean;
 }
 
 function defaultFilters(): Filters {
@@ -46,7 +47,8 @@ function defaultFilters(): Filters {
     minMessages: 0,
     maxMessages: 0,
     minUserMessages: 0,
-    includeOneShot: false,
+    includeOneShot: true,
+    includeAutomated: false,
   };
 }
 
@@ -110,6 +112,7 @@ class SessionsStore {
       min_user_messages:
         f.minUserMessages > 0 ? f.minUserMessages : undefined,
       include_one_shot: f.includeOneShot || undefined,
+      include_automated: f.includeAutomated || undefined,
       include_children: true,
     };
   }
@@ -142,8 +145,13 @@ class SessionsStore {
     }
 
     const prevOneShot = this.filters.includeOneShot;
+    // Default is true (show single-turn); only false when
+    // explicitly set to "false" in URL params.
+    const oneShotParam = params["include_one_shot"];
     const nextOneShot =
-      params["include_one_shot"] === "true";
+      oneShotParam === undefined ? true : oneShotParam === "true";
+    const nextAutomated =
+      params["include_automated"] === "true";
 
     this.filters = {
       project,
@@ -160,6 +168,7 @@ class SessionsStore {
         ? minUserMsgs
         : 0,
       includeOneShot: nextOneShot,
+      includeAutomated: nextAutomated,
     };
     if (prevOneShot !== nextOneShot) {
       this.invalidateFilterCaches();
@@ -277,10 +286,7 @@ class SessionsStore {
     const ver = this.projectsVersion;
     this.projectsPromise = (async () => {
       try {
-        const params = this.filters.includeOneShot
-          ? { include_one_shot: true as const }
-          : {};
-        const res = await api.getProjects(params);
+        const res = await api.getProjects(this.metadataParams);
         if (ver === this.projectsVersion) {
           this.projects = res.projects;
           this.projectsLoaded = true;
@@ -302,10 +308,7 @@ class SessionsStore {
     const ver = this.agentsVersion;
     this.agentsPromise = (async () => {
       try {
-        const params = this.filters.includeOneShot
-          ? { include_one_shot: true as const }
-          : {};
-        const res = await api.getAgents(params);
+        const res = await api.getAgents(this.metadataParams);
         if (ver === this.agentsVersion) {
           this.agents = res.agents;
           this.agentsLoaded = true;
@@ -327,10 +330,7 @@ class SessionsStore {
     const ver = this.machinesVersion;
     this.machinesPromise = (async () => {
       try {
-        const params = this.filters.includeOneShot
-          ? { include_one_shot: true as const }
-          : {};
-        const res = await api.getMachines(params);
+        const res = await api.getMachines(this.metadataParams);
         if (ver === this.machinesVersion) {
           this.machines = res.machines;
           this.machinesLoaded = true;
@@ -451,10 +451,13 @@ class SessionsStore {
   }
 
   setProjectFilter(project: string) {
-    const wasOneShot = this.filters.includeOneShot;
-    this.filters = { ...defaultFilters(), project, agent: this.filters.agent };
+    const prev = this.filters;
+    this.filters = { ...defaultFilters(), project, agent: prev.agent };
     this.setActiveSession(null);
-    if (wasOneShot) this.invalidateFilterCaches();
+    if (prev.includeOneShot !== this.filters.includeOneShot ||
+        prev.includeAutomated !== this.filters.includeAutomated) {
+      this.invalidateFilterCaches();
+    }
     this.load();
   }
 
@@ -552,6 +555,13 @@ class SessionsStore {
     this.load();
   }
 
+  setIncludeAutomatedFilter(include: boolean) {
+    this.filters.includeAutomated = include;
+    this.setActiveSession(null);
+    this.invalidateFilterCaches();
+    this.load();
+  }
+
   get hasActiveFilters(): boolean {
     const f = this.filters;
     return !!(
@@ -563,16 +573,20 @@ class SessionsStore {
       f.dateTo ||
       f.date ||
       f.minUserMessages > 0 ||
-      f.includeOneShot
+      !f.includeOneShot ||
+      f.includeAutomated
     );
   }
 
   clearSessionFilters() {
     const project = this.filters.project;
     const wasOneShot = this.filters.includeOneShot;
+    const wasAutomated = this.filters.includeAutomated;
     this.filters = { ...defaultFilters(), project };
     this.setActiveSession(null);
-    if (wasOneShot) this.invalidateFilterCaches();
+    if (wasOneShot !== this.filters.includeOneShot || wasAutomated) {
+      this.invalidateFilterCaches();
+    }
     this.load();
   }
 
@@ -607,6 +621,13 @@ class SessionsStore {
     await this.load();
   }
 
+  private get metadataParams() {
+    return {
+      include_one_shot: this.filters.includeOneShot || undefined,
+      include_automated: this.filters.includeAutomated || undefined,
+    };
+  }
+
   invalidateFilterCaches() {
     this.projectsVersion++;
     this.projectsLoaded = false;
@@ -620,11 +641,7 @@ class SessionsStore {
     this.loadProjects();
     this.loadAgents();
     this.loadMachines();
-    sync.loadStats(
-      this.filters.includeOneShot
-        ? { include_one_shot: true }
-        : {},
-    );
+    sync.loadStats(this.metadataParams);
   }
 
   /** Remove one or all entries from the undo toast list. */

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -51,7 +51,7 @@ class SyncStore {
   private lastStatsParams: {
     include_one_shot?: boolean;
     include_automated?: boolean;
-  } = {};
+  } = { include_one_shot: true };
   private statsVersion = 0;
   private syncCompleteListeners: SyncCompleteListener[] = [];
   private statusHydrated = false;

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -48,8 +48,10 @@ class SyncStore {
   private watchEventSource: EventSource | null = null;
   private pollTimer: ReturnType<typeof setInterval> | null =
     null;
-  private lastStatsParams: { include_one_shot?: boolean } =
-    {};
+  private lastStatsParams: {
+    include_one_shot?: boolean;
+    include_automated?: boolean;
+  } = {};
   private statsVersion = 0;
   private syncCompleteListeners: SyncCompleteListener[] = [];
   private statusHydrated = false;
@@ -106,7 +108,10 @@ class SyncStore {
   }
 
   async loadStats(
-    params?: { include_one_shot?: boolean },
+    params?: {
+      include_one_shot?: boolean;
+      include_automated?: boolean;
+    },
   ) {
     if (params !== undefined) {
       this.lastStatsParams = params;

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -50,9 +50,10 @@ type AnalyticsFilter struct {
 	Timezone        string // IANA timezone for day bucketing
 	DayOfWeek       *int   // nil = all, 0=Mon, 6=Sun (ISO)
 	Hour            *int   // nil = all, 0-23
-	MinUserMessages int    // user_message_count >= N
-	ExcludeOneShot  bool   // exclude sessions with user_message_count <= 1
-	ActiveSince     string // ISO timestamp cutoff
+	MinUserMessages  int    // user_message_count >= N
+	ExcludeOneShot   bool   // exclude sessions with user_message_count <= 1
+	ExcludeAutomated bool   // exclude automated (roborev) sessions
+	ActiveSince      string // ISO timestamp cutoff
 }
 
 // location loads the timezone or returns UTC on error.
@@ -144,6 +145,9 @@ func (f AnalyticsFilter) buildWhere(
 	}
 	if f.ExcludeOneShot {
 		preds = append(preds, "user_message_count > 1")
+	}
+	if f.ExcludeAutomated {
+		preds = append(preds, "is_automated = 0")
 	}
 
 	if f.ActiveSince != "" {

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -144,7 +144,12 @@ func (f AnalyticsFilter) buildWhere(
 		args = append(args, f.MinUserMessages)
 	}
 	if f.ExcludeOneShot {
-		preds = append(preds, "user_message_count > 1")
+		if !f.ExcludeAutomated {
+			preds = append(preds,
+				"(user_message_count > 1 OR is_automated = 1)")
+		} else {
+			preds = append(preds, "user_message_count > 1")
+		}
 	}
 	if f.ExcludeAutomated {
 		preds = append(preds, "is_automated = 0")

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -4,14 +4,21 @@ import "strings"
 
 // automatedPrefixes are first_message prefixes that identify
 // automated (roborev) sessions. Matched case-sensitively.
+// Combined with the single-turn gate (user_message_count <= 1)
+// to avoid misclassifying interactive sessions.
 var automatedPrefixes = []string{
 	"You are a code reviewer.",
 	"You are a security code reviewer.",
 	"You are a design reviewer.",
 	"You are a code assistant. Your task is to address",
-	"## Analysis Request",
 	"You are a code review insights analyst.",
-	"# Fix Request\n",
+	"You are reviewing whether an implementation matches",
+	"You are a plan document reviewer.",
+	"You are a spec document reviewer.",
+	"You are summarizing a day of AI agent activity.",
+	"You are analyzing AI agent sessions.",
+	"## Analysis Request",
+	"# Fix Request",
 }
 
 // automatedSubstrings are patterns matched anywhere in the

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -5,9 +5,13 @@ import "strings"
 // automatedPrefixes are first_message prefixes that identify
 // automated (roborev) review and fix sessions. Matched
 // case-sensitively against the start of first_message.
+//
+// The review prefix is long enough to be unambiguous. The fix
+// prefix requires a trailing newline to avoid false positives
+// on user headings like "# Fix Request for login flow".
 var automatedPrefixes = []string{
 	"You are a code reviewer. Review the code changes shown below.",
-	"# Fix Request",
+	"# Fix Request\n",
 }
 
 // IsAutomatedSession returns true if the first message

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -1,0 +1,22 @@
+package db
+
+import "strings"
+
+// automatedPrefixes are first_message prefixes that identify
+// automated (roborev) review and fix sessions. Matched
+// case-sensitively against the start of first_message.
+var automatedPrefixes = []string{
+	"You are a code reviewer. Review the code changes shown below.",
+	"# Fix Request",
+}
+
+// IsAutomatedSession returns true if the first message
+// matches a known automated review/fix prompt pattern.
+func IsAutomatedSession(firstMessage string) bool {
+	for _, prefix := range automatedPrefixes {
+		if strings.HasPrefix(firstMessage, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -3,15 +3,22 @@ package db
 import "strings"
 
 // automatedPrefixes are first_message prefixes that identify
-// automated (roborev) review and fix sessions. Matched
-// case-sensitively against the start of first_message.
-//
-// The review prefix is long enough to be unambiguous. The fix
-// prefix requires a trailing newline to avoid false positives
-// on user headings like "# Fix Request for login flow".
+// automated (roborev) sessions. Matched case-sensitively.
 var automatedPrefixes = []string{
-	"You are a code reviewer. Review the code changes shown below.",
+	"You are a code reviewer.",
+	"You are a security code reviewer.",
+	"You are a design reviewer.",
+	"You are a code assistant. Your task is to address",
+	"## Analysis Request",
+	"You are a code review insights analyst.",
 	"# Fix Request\n",
+}
+
+// automatedSubstrings are patterns matched anywhere in the
+// first message. Used for catch-all markers embedded in
+// longer prompts.
+var automatedSubstrings = []string{
+	"invoked by roborev to perform this review",
 }
 
 // IsAutomatedSession returns true if the first message
@@ -19,6 +26,11 @@ var automatedPrefixes = []string{
 func IsAutomatedSession(firstMessage string) bool {
 	for _, prefix := range automatedPrefixes {
 		if strings.HasPrefix(firstMessage, prefix) {
+			return true
+		}
+	}
+	for _, sub := range automatedSubstrings {
+		if strings.Contains(firstMessage, sub) {
 			return true
 		}
 	}

--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -1,0 +1,107 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBackfillIsAutomatedBidirectional(t *testing.T) {
+	d := testDB(t)
+
+	// Seed a false negative: single-turn roborev session with
+	// is_automated = 0 (simulates pre-migration data).
+	insertSession(t, d, "missed", "proj", func(s *Session) {
+		fm := "You are a code reviewer. Review the code."
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	// Force is_automated to 0 to simulate pre-migration state.
+	_, err := d.getWriter().Exec(
+		"UPDATE sessions SET is_automated = 0 WHERE id = 'missed'",
+	)
+	requireNoError(t, err, "force missed to 0")
+
+	// Seed a stale false positive: multi-turn session that was
+	// previously marked automated under old broad rules.
+	insertSession(t, d, "stale", "proj", func(s *Session) {
+		fm := "# Fix Request for login flow"
+		s.FirstMessage = &fm
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+	_, err = d.getWriter().Exec(
+		"UPDATE sessions SET is_automated = 1 WHERE id = 'stale'",
+	)
+	requireNoError(t, err, "force stale to 1")
+
+	// Clear the marker so the backfill will run.
+	_, err = d.getWriter().Exec(
+		"DELETE FROM stats WHERE key = 'is_automated_backfill_v2'",
+	)
+	requireNoError(t, err, "clear marker")
+
+	// Run backfill.
+	d.mu.Lock()
+	err = d.backfillIsAutomatedLocked(d.getWriter())
+	d.mu.Unlock()
+	requireNoError(t, err, "first backfill run")
+
+	ctx := context.Background()
+
+	// False negative should now be set.
+	missed, err := d.GetSession(ctx, "missed")
+	requireNoError(t, err, "get missed")
+	if !missed.IsAutomated {
+		t.Error("missed session should be automated after backfill")
+	}
+
+	// Stale false positive should now be cleared.
+	stale, err := d.GetSession(ctx, "stale")
+	requireNoError(t, err, "get stale")
+	if stale.IsAutomated {
+		t.Error("stale session should not be automated after backfill")
+	}
+}
+
+func TestBackfillIsAutomatedMarkerIdempotent(t *testing.T) {
+	d := testDB(t)
+
+	// Seed a roborev session.
+	insertSession(t, d, "review", "proj", func(s *Session) {
+		fm := "You are a code reviewer. Review the code."
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+
+	// Clear the marker and run backfill.
+	_, err := d.getWriter().Exec(
+		"DELETE FROM stats WHERE key = 'is_automated_backfill_v2'",
+	)
+	requireNoError(t, err, "clear marker")
+
+	d.mu.Lock()
+	err = d.backfillIsAutomatedLocked(d.getWriter())
+	d.mu.Unlock()
+	requireNoError(t, err, "first run")
+
+	// Manually corrupt the session to verify second run is a no-op.
+	_, err = d.getWriter().Exec(
+		"UPDATE sessions SET is_automated = 0 WHERE id = 'review'",
+	)
+	requireNoError(t, err, "corrupt")
+
+	// Second run should be a no-op (marker present).
+	d.mu.Lock()
+	err = d.backfillIsAutomatedLocked(d.getWriter())
+	d.mu.Unlock()
+	requireNoError(t, err, "second run")
+
+	ctx := context.Background()
+	review, err := d.GetSession(ctx, "review")
+	requireNoError(t, err, "get review")
+	if review.IsAutomated {
+		t.Error("second run should be no-op; is_automated should still be 0")
+	}
+}

--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -37,7 +37,7 @@ func TestBackfillIsAutomatedBidirectional(t *testing.T) {
 
 	// Clear the marker so the backfill will run.
 	_, err = d.getWriter().Exec(
-		"DELETE FROM stats WHERE key = 'is_automated_backfill_v2'",
+		"DELETE FROM stats WHERE key = 'is_automated_backfill_v3'",
 	)
 	requireNoError(t, err, "clear marker")
 
@@ -77,7 +77,7 @@ func TestBackfillIsAutomatedMarkerIdempotent(t *testing.T) {
 
 	// Clear the marker and run backfill.
 	_, err := d.getWriter().Exec(
-		"DELETE FROM stats WHERE key = 'is_automated_backfill_v2'",
+		"DELETE FROM stats WHERE key = 'is_automated_backfill_v3'",
 	)
 	requireNoError(t, err, "clear marker")
 

--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -37,7 +37,7 @@ func TestBackfillIsAutomatedBidirectional(t *testing.T) {
 
 	// Clear the marker so the backfill will run.
 	_, err = d.getWriter().Exec(
-		"DELETE FROM stats WHERE key = 'is_automated_backfill_v3'",
+		"DELETE FROM stats WHERE key = 'is_automated_backfill_v1'",
 	)
 	requireNoError(t, err, "clear marker")
 
@@ -77,7 +77,7 @@ func TestBackfillIsAutomatedMarkerIdempotent(t *testing.T) {
 
 	// Clear the marker and run backfill.
 	_, err := d.getWriter().Exec(
-		"DELETE FROM stats WHERE key = 'is_automated_backfill_v3'",
+		"DELETE FROM stats WHERE key = 'is_automated_backfill_v1'",
 	)
 	requireNoError(t, err, "clear marker")
 

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -58,21 +58,50 @@ func TestIsAutomatedSession(t *testing.T) {
 			true,
 		},
 
-		// Legacy fix request
+		// Fix request (various formats)
 		{
-			"FixRequestWithBody",
+			"FixRequestWithNewline",
 			"# Fix Request\nAn analysis was performed.",
 			true,
 		},
 		{
-			"FixRequestNoNewline",
-			"# Fix Request",
-			false,
+			"FixRequestWithDoubleSpace",
+			"# Fix Request  An analysis was performed.",
+			true,
 		},
 		{
-			"FixRequestUserHeading",
-			"# Fix Request for login flow",
-			false,
+			"FixRequestExact",
+			"# Fix Request",
+			true,
+		},
+
+		// Spec / plan review
+		{
+			"SpecReview",
+			"You are reviewing whether an implementation matches its specification.",
+			true,
+		},
+		{
+			"PlanReview",
+			"You are a plan document reviewer. Verify this plan.",
+			true,
+		},
+		{
+			"SpecDocReview",
+			"You are a spec document reviewer. Read the spec.",
+			true,
+		},
+
+		// Insights
+		{
+			"DaySummary",
+			"You are summarizing a day of AI agent activity. Provide a summary.",
+			true,
+		},
+		{
+			"SessionAnalysis",
+			"You are analyzing AI agent sessions. Provide analysis.",
+			true,
 		},
 
 		// Catch-all substring

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -34,13 +34,18 @@ func TestIsAutomatedSession(t *testing.T) {
 			true,
 		},
 		{
-			"RoborevFixPromptExact",
+			"RoborevFixPromptExactNoNewline",
 			"# Fix Request",
-			true,
+			false,
 		},
 		{
 			"SimilarButNotReview",
 			"You are a code reviewer but I need help",
+			false,
+		},
+		{
+			"FixRequestWithSuffix",
+			"# Fix Request for login flow",
 			false,
 		},
 		{

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -1,0 +1,64 @@
+package db
+
+import "testing"
+
+func TestIsAutomatedSession(t *testing.T) {
+	tests := []struct {
+		name         string
+		firstMessage string
+		want         bool
+	}{
+		{
+			"EmptyMessage",
+			"",
+			false,
+		},
+		{
+			"NormalUserPrompt",
+			"fix the login bug",
+			false,
+		},
+		{
+			"RoborevReviewPrompt",
+			"You are a code reviewer. Review the code changes shown below.\n\n## Changes\n...",
+			true,
+		},
+		{
+			"RoborevReviewPromptExact",
+			"You are a code reviewer. Review the code changes shown below.",
+			true,
+		},
+		{
+			"RoborevFixPromptWithBody",
+			"# Fix Request\n\nAn analysis was performed and produced the following findings:\n...",
+			true,
+		},
+		{
+			"RoborevFixPromptExact",
+			"# Fix Request",
+			true,
+		},
+		{
+			"SimilarButNotReview",
+			"You are a code reviewer but I need help",
+			false,
+		},
+		{
+			"FixInNormalContext",
+			"Fix the request handler",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAutomatedSession(tt.firstMessage)
+			if got != tt.want {
+				t.Errorf(
+					"IsAutomatedSession(%q) = %v, want %v",
+					tt.firstMessage, got, tt.want,
+				)
+			}
+		})
+	}
+}

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -8,49 +8,94 @@ func TestIsAutomatedSession(t *testing.T) {
 		firstMessage string
 		want         bool
 	}{
+		{"EmptyMessage", "", false},
+		{"NormalUserPrompt", "fix the login bug", false},
+
+		// Code review
 		{
-			"EmptyMessage",
-			"",
-			false,
-		},
-		{
-			"NormalUserPrompt",
-			"fix the login bug",
-			false,
-		},
-		{
-			"RoborevReviewPrompt",
-			"You are a code reviewer. Review the code changes shown below.\n\n## Changes\n...",
+			"CodeReviewFull",
+			"You are a code reviewer. Review the code changes shown below.\n\n## Changes",
 			true,
 		},
 		{
-			"RoborevReviewPromptExact",
-			"You are a code reviewer. Review the code changes shown below.",
+			"CodeReviewShort",
+			"You are a code reviewer. Here is a diff.",
+			true,
+		},
+
+		// Security review
+		{
+			"SecurityReview",
+			"You are a security code reviewer. Analyze the following.",
+			true,
+		},
+
+		// Design review
+		{
+			"DesignReview",
+			"You are a design reviewer. Review the architectural changes.",
+			true,
+		},
+
+		// Fix (code assistant)
+		{
+			"CodeAssistantFix",
+			"You are a code assistant. Your task is to address the following findings.",
+			true,
+		},
+
+		// Analysis request
+		{
+			"AnalysisRequest",
+			"## Analysis Request\n\nPlease analyze the following code.",
+			true,
+		},
+
+		// Insights analyst
+		{
+			"InsightsAnalyst",
+			"You are a code review insights analyst. Summarize trends.",
+			true,
+		},
+
+		// Legacy fix request
+		{
+			"FixRequestWithBody",
+			"# Fix Request\nAn analysis was performed.",
 			true,
 		},
 		{
-			"RoborevFixPromptWithBody",
-			"# Fix Request\n\nAn analysis was performed and produced the following findings:\n...",
-			true,
-		},
-		{
-			"RoborevFixPromptExactNoNewline",
+			"FixRequestNoNewline",
 			"# Fix Request",
 			false,
 		},
+		{
+			"FixRequestUserHeading",
+			"# Fix Request for login flow",
+			false,
+		},
+
+		// Catch-all substring
+		{
+			"RoborevSubstringInMiddle",
+			"IMPORTANT: You are being invoked by roborev to perform this review directly.\n\nReview the diff.",
+			true,
+		},
+
+		// Negative cases
 		{
 			"SimilarButNotReview",
 			"You are a code reviewer but I need help",
 			false,
 		},
 		{
-			"FixRequestWithSuffix",
-			"# Fix Request for login flow",
+			"NormalFix",
+			"Fix the request handler",
 			false,
 		},
 		{
-			"FixInNormalContext",
-			"Fix the request handler",
+			"AnalysisInBody",
+			"Please do an ## Analysis Request of this code",
 			false,
 		},
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -385,7 +385,7 @@ func (db *DB) migrateColumns() error {
 // Guarded by a stats marker so it only runs once per pattern
 // version.
 func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
-	const marker = "is_automated_backfill_v2"
+	const marker = "is_automated_backfill_v3"
 	var done int
 	if err := w.QueryRow(
 		`SELECT count(*) FROM stats

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -389,7 +389,7 @@ func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
 		 WHERE is_automated = 0
 		   AND first_message IS NOT NULL
 		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
-		     OR first_message LIKE '# Fix Request%')`,
+		     OR first_message LIKE '# Fix Request' || X'0A' || '%')`,
 	).Scan(&count); err != nil {
 		return fmt.Errorf(
 			"probing automated backfill: %w", err,
@@ -402,7 +402,7 @@ func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
 		`UPDATE sessions SET is_automated = 1
 		 WHERE first_message IS NOT NULL
 		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
-		     OR first_message LIKE '# Fix Request%')`,
+		     OR first_message LIKE '# Fix Request' || X'0A' || '%')`,
 	)
 	if err != nil {
 		return fmt.Errorf(

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -327,6 +327,10 @@ func (db *DB) migrateColumns() error {
 			"sessions", "local_modified_at",
 			"ALTER TABLE sessions ADD COLUMN local_modified_at TEXT",
 		},
+		{
+			"sessions", "is_automated",
+			"ALTER TABLE sessions ADD COLUMN is_automated INTEGER NOT NULL DEFAULT 0",
+		},
 	}
 
 	for _, m := range migrations {
@@ -355,6 +359,10 @@ func (db *DB) migrateColumns() error {
 			)
 		}
 	}
+	if err := db.backfillIsAutomatedLocked(w); err != nil {
+		return err
+	}
+
 	runRepair, err := db.shouldRunTokenCoverageRepairLocked(w)
 	if err != nil {
 		return err
@@ -368,6 +376,43 @@ func (db *DB) migrateColumns() error {
 	if err := db.markTokenCoverageRepairDoneLocked(w); err != nil {
 		return err
 	}
+	return nil
+}
+
+// backfillIsAutomatedLocked sets is_automated = 1 for sessions
+// whose first_message matches known automated prompt patterns.
+// Uses SQL LIKE to avoid scanning every row in Go.
+func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
+	var count int
+	if err := w.QueryRow(
+		`SELECT count(*) FROM sessions
+		 WHERE is_automated = 0
+		   AND first_message IS NOT NULL
+		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
+		     OR first_message LIKE '# Fix Request%')`,
+	).Scan(&count); err != nil {
+		return fmt.Errorf(
+			"probing automated backfill: %w", err,
+		)
+	}
+	if count == 0 {
+		return nil
+	}
+	_, err := w.Exec(
+		`UPDATE sessions SET is_automated = 1
+		 WHERE first_message IS NOT NULL
+		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
+		     OR first_message LIKE '# Fix Request%')`,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"backfilling is_automated: %w", err,
+		)
+	}
+	log.Printf(
+		"migration: backfilled is_automated for %d sessions",
+		count,
+	)
 	return nil
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -385,7 +385,7 @@ func (db *DB) migrateColumns() error {
 // Guarded by a stats marker so it only runs once per pattern
 // version.
 func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
-	const marker = "is_automated_backfill_v3"
+	const marker = "is_automated_backfill_v1"
 	var done int
 	if err := w.QueryRow(
 		`SELECT count(*) FROM stats

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -379,16 +379,31 @@ func (db *DB) migrateColumns() error {
 	return nil
 }
 
-// backfillIsAutomatedLocked scans single-turn sessions and
-// sets is_automated = 1 for those whose first_message matches
-// a known roborev prompt pattern. Uses the Go detector so the
-// SQL doesn't need to duplicate every pattern.
+// backfillIsAutomatedLocked recomputes is_automated for all
+// sessions, correcting both false negatives (new patterns) and
+// stale false positives (patterns tightened since last run).
+// Guarded by a stats marker so it only runs once per pattern
+// version.
 func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
+	const marker = "is_automated_backfill_v2"
+	var done int
+	if err := w.QueryRow(
+		`SELECT count(*) FROM stats
+		 WHERE key = ? AND value != 0`, marker,
+	).Scan(&done); err != nil {
+		return fmt.Errorf(
+			"probing automated backfill marker: %w", err,
+		)
+	}
+	if done > 0 {
+		return nil
+	}
+
 	rows, err := w.Query(
-		`SELECT id, first_message FROM sessions
-		 WHERE is_automated = 0
-		   AND user_message_count <= 1
-		   AND first_message IS NOT NULL`,
+		`SELECT id, first_message, user_message_count,
+			is_automated
+		 FROM sessions
+		 WHERE first_message IS NOT NULL`,
 	)
 	if err != nil {
 		return fmt.Errorf(
@@ -397,37 +412,72 @@ func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
 	}
 	defer rows.Close()
 
-	var ids []string
+	var setIDs, clearIDs []string
 	for rows.Next() {
 		var id, fm string
-		if err := rows.Scan(&id, &fm); err != nil {
+		var umc int
+		var current bool
+		if err := rows.Scan(
+			&id, &fm, &umc, &current,
+		); err != nil {
 			return fmt.Errorf(
 				"scanning backfill candidate: %w", err,
 			)
 		}
-		if IsAutomatedSession(fm) {
-			ids = append(ids, id)
+		want := umc <= 1 && IsAutomatedSession(fm)
+		if want && !current {
+			setIDs = append(setIDs, id)
+		} else if !want && current {
+			clearIDs = append(clearIDs, id)
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
-	if len(ids) == 0 {
-		return nil
+
+	if err := batchUpdateAutomated(
+		w, setIDs, 1,
+	); err != nil {
+		return err
+	}
+	if err := batchUpdateAutomated(
+		w, clearIDs, 0,
+	); err != nil {
+		return err
 	}
 
+	if len(setIDs) > 0 || len(clearIDs) > 0 {
+		log.Printf(
+			"migration: recomputed is_automated"+
+				" (set %d, cleared %d)",
+			len(setIDs), len(clearIDs),
+		)
+	}
+
+	_, err = w.Exec(
+		`INSERT INTO stats (key, value) VALUES (?, 1)
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		marker,
+	)
+	return err
+}
+
+func batchUpdateAutomated(
+	w *sql.DB, ids []string, val int,
+) error {
 	const batchSize = 500
 	for i := 0; i < len(ids); i += batchSize {
 		end := min(i+batchSize, len(ids))
 		batch := ids[i:end]
-		args := make([]any, len(batch))
+		args := make([]any, len(batch)+1)
 		phs := make([]string, len(batch))
+		args[0] = val
 		for j, id := range batch {
-			args[j] = id
+			args[j+1] = id
 			phs[j] = "?"
 		}
 		_, err := w.Exec(
-			"UPDATE sessions SET is_automated = 1"+
+			"UPDATE sessions SET is_automated = ?"+
 				" WHERE id IN ("+
 				strings.Join(phs, ",")+
 				")",
@@ -435,14 +485,10 @@ func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
 		)
 		if err != nil {
 			return fmt.Errorf(
-				"backfilling is_automated: %w", err,
+				"updating is_automated: %w", err,
 			)
 		}
 	}
-	log.Printf(
-		"migration: backfilled is_automated for %d sessions",
-		len(ids),
-	)
 	return nil
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -379,39 +379,69 @@ func (db *DB) migrateColumns() error {
 	return nil
 }
 
-// backfillIsAutomatedLocked sets is_automated = 1 for sessions
-// whose first_message matches known automated prompt patterns.
-// Uses SQL LIKE to avoid scanning every row in Go.
+// backfillIsAutomatedLocked scans single-turn sessions and
+// sets is_automated = 1 for those whose first_message matches
+// a known roborev prompt pattern. Uses the Go detector so the
+// SQL doesn't need to duplicate every pattern.
 func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
-	var count int
-	if err := w.QueryRow(
-		`SELECT count(*) FROM sessions
+	rows, err := w.Query(
+		`SELECT id, first_message FROM sessions
 		 WHERE is_automated = 0
-		   AND first_message IS NOT NULL
-		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
-		     OR first_message LIKE '# Fix Request' || X'0A' || '%')`,
-	).Scan(&count); err != nil {
-		return fmt.Errorf(
-			"probing automated backfill: %w", err,
-		)
-	}
-	if count == 0 {
-		return nil
-	}
-	_, err := w.Exec(
-		`UPDATE sessions SET is_automated = 1
-		 WHERE first_message IS NOT NULL
-		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
-		     OR first_message LIKE '# Fix Request' || X'0A' || '%')`,
+		   AND user_message_count <= 1
+		   AND first_message IS NOT NULL`,
 	)
 	if err != nil {
 		return fmt.Errorf(
-			"backfilling is_automated: %w", err,
+			"querying automated backfill candidates: %w", err,
 		)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id, fm string
+		if err := rows.Scan(&id, &fm); err != nil {
+			return fmt.Errorf(
+				"scanning backfill candidate: %w", err,
+			)
+		}
+		if IsAutomatedSession(fm) {
+			ids = append(ids, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	const batchSize = 500
+	for i := 0; i < len(ids); i += batchSize {
+		end := min(i+batchSize, len(ids))
+		batch := ids[i:end]
+		args := make([]any, len(batch))
+		phs := make([]string, len(batch))
+		for j, id := range batch {
+			args[j] = id
+			phs[j] = "?"
+		}
+		_, err := w.Exec(
+			"UPDATE sessions SET is_automated = 1"+
+				" WHERE id IN ("+
+				strings.Join(phs, ",")+
+				")",
+			args...,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"backfilling is_automated: %w", err,
+			)
+		}
 	}
 	log.Printf(
 		"migration: backfilled is_automated for %d sessions",
-		count,
+		len(ids),
 	)
 	return nil
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1397,7 +1397,7 @@ func TestCanceledContext(t *testing.T) {
 			return err
 		}, false},
 		{"GetStats", func() error {
-			_, err := d.GetStats(ctx, false)
+			_, err := d.GetStats(ctx, false, false)
 			return err
 		}, false},
 	}
@@ -1416,7 +1416,7 @@ func TestStats(t *testing.T) {
 	d := testDB(t)
 
 	// Empty DB returns nil EarliestSession
-	stats, err := d.GetStats(context.Background(), false)
+	stats, err := d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats empty")
 	if stats.EarliestSession != nil {
 		t.Errorf(
@@ -1440,7 +1440,7 @@ func TestStats(t *testing.T) {
 		userMsg("s2", 0, "bye"),
 	)
 
-	stats, err = d.GetStats(context.Background(), false)
+	stats, err = d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats")
 	if stats.SessionCount != 2 {
 		t.Errorf("session_count = %d, want 2", stats.SessionCount)
@@ -1473,7 +1473,7 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 	insertSession(t, d, "s-null-start", "proj")
 	insertMessages(t, d, userMsg("s-null-start", 0, "hi"))
 
-	stats, err := d.GetStats(context.Background(), false)
+	stats, err := d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats null started_at")
 	if stats.EarliestSession == nil {
 		t.Fatal(
@@ -1489,7 +1489,7 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 	})
 	insertMessages(t, d, userMsg("s-empty-start", 0, "hey"))
 
-	stats, err = d.GetStats(context.Background(), false)
+	stats, err = d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats empty started_at")
 	if stats.EarliestSession == nil {
 		t.Fatal(
@@ -1512,7 +1512,7 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 	})
 	insertMessages(t, d, userMsg("s-old", 0, "hello"))
 
-	stats, err = d.GetStats(context.Background(), false)
+	stats, err = d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats with old session")
 	if stats.EarliestSession == nil {
 		t.Fatal("earliest_session nil")
@@ -1534,7 +1534,7 @@ func TestGetProjects(t *testing.T) {
 	})
 	insertSession(t, d, "s3", "alpha")
 
-	projects, err := d.GetProjects(context.Background(), false)
+	projects, err := d.GetProjects(context.Background(), false, false)
 	requireNoError(t, err, "GetProjects")
 	if len(projects) != 2 {
 		t.Fatalf("got %d projects, want 2", len(projects))
@@ -1936,7 +1936,7 @@ func TestDeleteSessions(t *testing.T) {
 		insertMessages(t, d, userMsg(id, 0, "msg for "+id))
 	}
 
-	stats, _ := d.GetStats(context.Background(), false)
+	stats, _ := d.GetStats(context.Background(), false, false)
 	if stats.SessionCount != 3 {
 		t.Fatalf("initial sessions = %d, want 3", stats.SessionCount)
 	}
@@ -1963,7 +1963,7 @@ func TestDeleteSessions(t *testing.T) {
 		t.Errorf("s2 messages = %d, want 1", len(msgs))
 	}
 
-	stats, _ = d.GetStats(context.Background(), false)
+	stats, _ = d.GetStats(context.Background(), false, false)
 	if stats.SessionCount != 1 {
 		t.Errorf("session_count = %d, want 1", stats.SessionCount)
 	}
@@ -3895,7 +3895,7 @@ func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
 	insertSession(t, d, "s3", "proj",
 		func(s *Session) { s.Agent = "" })
 
-	agents, err := d.GetAgents(context.Background(), false)
+	agents, err := d.GetAgents(context.Background(), false, false)
 	if err != nil {
 		t.Fatalf("GetAgents: %v", err)
 	}
@@ -3913,7 +3913,7 @@ func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
 func TestGetAgentsEmptyResultSerializesAsArray(t *testing.T) {
 	d := testDB(t)
 
-	agents, err := d.GetAgents(context.Background(), false)
+	agents, err := d.GetAgents(context.Background(), false, false)
 	if err != nil {
 		t.Fatalf("GetAgents: %v", err)
 	}
@@ -4452,19 +4452,19 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 	})
 
 	// Before trashing: both projects, agents, machines visible.
-	projects, err := d.GetProjects(ctx, false)
+	projects, err := d.GetProjects(ctx, false, false)
 	requireNoError(t, err, "GetProjects before trash")
 	if len(projects) != 2 {
 		t.Fatalf("projects before trash: got %d, want 2", len(projects))
 	}
 
-	agents, err := d.GetAgents(ctx, false)
+	agents, err := d.GetAgents(ctx, false, false)
 	requireNoError(t, err, "GetAgents before trash")
 	if len(agents) != 2 {
 		t.Fatalf("agents before trash: got %d, want 2", len(agents))
 	}
 
-	machines, err := d.GetMachines(ctx, false)
+	machines, err := d.GetMachines(ctx, false, false)
 	requireNoError(t, err, "GetMachines before trash")
 	if len(machines) != 2 {
 		t.Fatalf("machines before trash: got %d, want 2", len(machines))
@@ -4473,7 +4473,7 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 	// Soft-delete s2: its project/agent/machine should disappear.
 	requireNoError(t, d.SoftDeleteSession("s2"), "soft delete s2")
 
-	projects, err = d.GetProjects(ctx, false)
+	projects, err = d.GetProjects(ctx, false, false)
 	requireNoError(t, err, "GetProjects after trash")
 	if len(projects) != 1 {
 		t.Errorf("projects after trash: got %d, want 1", len(projects))
@@ -4482,7 +4482,7 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 		t.Errorf("project name: got %q, want %q", projects[0].Name, "proj-a")
 	}
 
-	agents, err = d.GetAgents(ctx, false)
+	agents, err = d.GetAgents(ctx, false, false)
 	requireNoError(t, err, "GetAgents after trash")
 	if len(agents) != 1 {
 		t.Errorf("agents after trash: got %d, want 1", len(agents))
@@ -4491,7 +4491,7 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 		t.Errorf("agent name: got %q, want %q", agents[0].Name, "claude")
 	}
 
-	machines, err = d.GetMachines(ctx, false)
+	machines, err = d.GetMachines(ctx, false, false)
 	requireNoError(t, err, "GetMachines after trash")
 	if len(machines) != 1 {
 		t.Errorf("machines after trash: got %d, want 1", len(machines))

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -772,6 +772,67 @@ func TestSessionFilterExcludeAutomated(t *testing.T) {
 	}
 }
 
+func TestExcludeOneShotWithIncludeAutomated(t *testing.T) {
+	d := testDB(t)
+
+	// Normal multi-turn session.
+	insertSession(t, d, "multi", "proj", func(s *Session) {
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+	// Normal single-turn session.
+	insertSession(t, d, "oneshot", "proj", func(s *Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	// Automated single-turn session.
+	insertSession(t, d, "review", "proj", func(s *Session) {
+		fm := "You are a code reviewer. Review the code."
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+
+	tests := []struct {
+		name             string
+		excludeOneShot   bool
+		excludeAutomated bool
+		want             []string
+	}{
+		{
+			"BothOff",
+			false, false,
+			[]string{"multi", "oneshot", "review"},
+		},
+		{
+			"ExcludeOneShotOnly",
+			true, false,
+			// Automated sessions survive one-shot exclusion.
+			[]string{"multi", "review"},
+		},
+		{
+			"ExcludeBoth",
+			true, true,
+			[]string{"multi"},
+		},
+		{
+			"ExcludeAutomatedOnly",
+			false, true,
+			[]string{"multi", "oneshot"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := SessionFilter{
+				ExcludeOneShot:   tt.excludeOneShot,
+				ExcludeAutomated: tt.excludeAutomated,
+			}
+			requireSessions(t, d, f, tt.want)
+		})
+	}
+}
+
 func TestIsAutomatedSetOnUpsert(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -658,13 +658,13 @@ func TestGetMachinesExcludeOneShot(t *testing.T) {
 		s.UserMessageCount = 5
 	})
 
-	all, err := d.GetMachines(context.Background(), false)
+	all, err := d.GetMachines(context.Background(), false, false)
 	requireNoError(t, err, "GetMachines includeAll")
 	if len(all) != 2 {
 		t.Fatalf("includeAll: got %d machines, want 2", len(all))
 	}
 
-	filtered, err := d.GetMachines(context.Background(), true)
+	filtered, err := d.GetMachines(context.Background(), true, false)
 	requireNoError(t, err, "GetMachines excludeOneShot")
 	if len(filtered) != 1 {
 		t.Fatalf("excludeOneShot: got %d machines, want 1",
@@ -689,7 +689,7 @@ func TestGetStatsExcludeOneShot(t *testing.T) {
 	})
 
 	// Include all.
-	stats, err := d.GetStats(context.Background(), false)
+	stats, err := d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats includeAll")
 	if stats.SessionCount != 2 {
 		t.Errorf("includeAll: session_count = %d, want 2",
@@ -705,7 +705,7 @@ func TestGetStatsExcludeOneShot(t *testing.T) {
 	}
 
 	// Exclude one-shot.
-	stats, err = d.GetStats(context.Background(), true)
+	stats, err = d.GetStats(context.Background(), true, false)
 	requireNoError(t, err, "GetStats excludeOneShot")
 	if stats.SessionCount != 1 {
 		t.Errorf("excludeOneShot: session_count = %d, want 1",
@@ -718,5 +718,87 @@ func TestGetStatsExcludeOneShot(t *testing.T) {
 	if stats.ProjectCount != 1 {
 		t.Errorf("excludeOneShot: project_count = %d, want 1",
 			stats.ProjectCount)
+	}
+}
+
+func TestSessionFilterExcludeAutomated(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "normal", "proj", func(s *Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "review", "proj", func(s *Session) {
+		fm := "You are a code reviewer. Review the code changes shown below.\n\n## Changes"
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "fix", "proj", func(s *Session) {
+		fm := "# Fix Request\nAn analysis was performed"
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "multi", "proj", func(s *Session) {
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+
+	tests := []struct {
+		name             string
+		excludeAutomated bool
+		want             []string
+	}{
+		{
+			"IncludeAll",
+			false,
+			[]string{"normal", "review", "fix", "multi"},
+		},
+		{
+			"ExcludeAutomated",
+			true,
+			[]string{"normal", "multi"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := SessionFilter{
+				ExcludeAutomated: tt.excludeAutomated,
+			}
+			requireSessions(t, d, f, tt.want)
+		})
+	}
+}
+
+func TestIsAutomatedSetOnUpsert(t *testing.T) {
+	d := testDB(t)
+
+	// Normal session.
+	insertSession(t, d, "normal", "proj", func(s *Session) {
+		fm := "fix the login bug"
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+	})
+
+	// Automated review session.
+	insertSession(t, d, "review", "proj", func(s *Session) {
+		fm := "You are a code reviewer. Review the code changes shown below."
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+	})
+
+	ctx := context.Background()
+	normal, err := d.GetSession(ctx, "normal")
+	requireNoError(t, err, "get normal")
+	if normal.IsAutomated {
+		t.Error("normal session should not be automated")
+	}
+
+	review, err := d.GetSession(ctx, "review")
+	requireNoError(t, err, "get review")
+	if !review.IsAutomated {
+		t.Error("review session should be automated")
 	}
 }

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -832,3 +832,34 @@ func TestIsAutomatedSetOnUpsert(t *testing.T) {
 		t.Error("single-turn roborev substring should be automated")
 	}
 }
+
+func TestIncrementalUpdateClearsAutomated(t *testing.T) {
+	d := testDB(t)
+
+	// Start as single-turn automated session.
+	fm := "You are a code reviewer. Review the code."
+	insertSession(t, d, "s1", "proj", func(s *Session) {
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+
+	ctx := context.Background()
+	s, err := d.GetSession(ctx, "s1")
+	requireNoError(t, err, "get before")
+	if !s.IsAutomated {
+		t.Fatal("should start as automated")
+	}
+
+	// Simulate a second user turn via incremental update.
+	err = d.UpdateSessionIncremental(
+		"s1", nil, 6, 2, 100, 12345, 0, 0, false, false,
+	)
+	requireNoError(t, err, "incremental update")
+
+	s, err = d.GetSession(ctx, "s1")
+	requireNoError(t, err, "get after")
+	if s.IsAutomated {
+		t.Error("should no longer be automated after second user turn")
+	}
+}

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -780,13 +780,31 @@ func TestIsAutomatedSetOnUpsert(t *testing.T) {
 		fm := "fix the login bug"
 		s.FirstMessage = &fm
 		s.MessageCount = 3
+		s.UserMessageCount = 1
 	})
 
-	// Automated review session.
+	// Single-turn automated review session.
 	insertSession(t, d, "review", "proj", func(s *Session) {
-		fm := "You are a code reviewer. Review the code changes shown below."
+		fm := "You are a code reviewer. Review the code."
 		s.FirstMessage = &fm
 		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+
+	// Multi-turn session with review prompt — NOT automated.
+	insertSession(t, d, "multi-review", "proj", func(s *Session) {
+		fm := "You are a code reviewer. Review the code."
+		s.FirstMessage = &fm
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+
+	// Single-turn with roborev substring marker.
+	insertSession(t, d, "roborev-sub", "proj", func(s *Session) {
+		fm := "IMPORTANT: You are being invoked by roborev to perform this review directly."
+		s.FirstMessage = &fm
+		s.MessageCount = 3
+		s.UserMessageCount = 1
 	})
 
 	ctx := context.Background()
@@ -799,6 +817,18 @@ func TestIsAutomatedSetOnUpsert(t *testing.T) {
 	review, err := d.GetSession(ctx, "review")
 	requireNoError(t, err, "get review")
 	if !review.IsAutomated {
-		t.Error("review session should be automated")
+		t.Error("single-turn review should be automated")
+	}
+
+	multi, err := d.GetSession(ctx, "multi-review")
+	requireNoError(t, err, "get multi-review")
+	if multi.IsAutomated {
+		t.Error("multi-turn review should not be automated")
+	}
+
+	sub, err := d.GetSession(ctx, "roborev-sub")
+	requireNoError(t, err, "get roborev-sub")
+	if !sub.IsAutomated {
+		t.Error("single-turn roborev substring should be automated")
 	}
 }

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     peak_context_tokens INTEGER NOT NULL DEFAULT 0,
     has_total_output_tokens INTEGER NOT NULL DEFAULT 0,
     has_peak_context_tokens INTEGER NOT NULL DEFAULT 0,
+    is_automated INTEGER NOT NULL DEFAULT 0,
     deleted_at  TEXT,
     created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -778,26 +778,17 @@ func (db *DB) UpdateSessionIncremental(
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	// Recompute is_automated: read stored first_message and
-	// apply the detector with the new user_message_count.
-	isAutomated := false
-	if userMsgCount <= 1 {
-		var fm sql.NullString
-		_ = db.getWriter().QueryRow(
-			"SELECT first_message FROM sessions WHERE id = ?",
-			id,
-		).Scan(&fm)
-		if fm.Valid {
-			isAutomated = IsAutomatedSession(fm.String)
-		}
-	}
-
+	// is_automated requires single-turn (user_message_count <= 1).
+	// When the count grows past 1, clear the flag in SQL without
+	// an extra SELECT. UpsertSession already sets the flag for new
+	// sessions, so the only incremental transition is clearing it.
 	_, err := db.getWriter().Exec(`
 		UPDATE sessions SET
 			ended_at = COALESCE(?, ended_at),
 			message_count = ?,
 			user_message_count = ?,
-			is_automated = ?,
+			is_automated = CASE WHEN ? > 1 THEN 0
+				ELSE is_automated END,
 			file_size = ?,
 			file_mtime = ?,
 			total_output_tokens = ?,
@@ -805,7 +796,7 @@ func (db *DB) UpdateSessionIncremental(
 			has_total_output_tokens = ?,
 			has_peak_context_tokens = ?
 		WHERE id = ?`,
-		endedAt, msgCount, userMsgCount, isAutomated,
+		endedAt, msgCount, userMsgCount, userMsgCount,
 		fileSize, fileMtime,
 		totalOutputTokens, peakContextTokens,
 		hasTotalOutputTokens, hasPeakContextTokens, id,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -29,6 +29,7 @@ const sessionBaseCols = `id, project, machine, agent,
 	parent_session_id, relationship_type,
 	total_output_tokens, peak_context_tokens,
 	has_total_output_tokens, has_peak_context_tokens,
+	is_automated,
 	deleted_at, created_at`
 
 // sessionPruneCols extends sessionBaseCols with file metadata
@@ -39,6 +40,7 @@ const sessionPruneCols = `id, project, machine, agent,
 	parent_session_id, relationship_type,
 	total_output_tokens, peak_context_tokens,
 	has_total_output_tokens, has_peak_context_tokens,
+	is_automated,
 	deleted_at, file_path, file_size, created_at`
 
 // sessionFullCols includes all columns for a complete session record.
@@ -48,6 +50,7 @@ const sessionFullCols = `id, project, machine, agent,
 	parent_session_id, relationship_type,
 	total_output_tokens, peak_context_tokens,
 	has_total_output_tokens, has_peak_context_tokens,
+	is_automated,
 	deleted_at, file_path, file_size, file_mtime,
 	file_hash, local_modified_at, created_at`
 
@@ -74,6 +77,7 @@ func scanSessionRow(rs rowScanner) (Session, error) {
 		&s.ParentSessionID, &s.RelationshipType,
 		&s.TotalOutputTokens, &s.PeakContextTokens,
 		&s.HasTotalOutputTokens, &s.HasPeakContextTokens,
+		&s.IsAutomated,
 		&s.DeletedAt, &s.CreatedAt,
 	)
 	return s, err
@@ -97,6 +101,7 @@ type Session struct {
 	PeakContextTokens    int     `json:"peak_context_tokens"`
 	HasTotalOutputTokens bool    `json:"has_total_output_tokens"`
 	HasPeakContextTokens bool    `json:"has_peak_context_tokens"`
+	IsAutomated          bool    `json:"is_automated"`
 	DeletedAt            *string `json:"deleted_at,omitempty"`
 	FilePath             *string `json:"file_path,omitempty"`
 	FileSize             *int64  `json:"file_size,omitempty"`
@@ -196,8 +201,9 @@ type SessionFilter struct {
 	MinMessages     int    // message_count >= N (0 = no filter)
 	MaxMessages     int    // message_count <= N (0 = no filter)
 	MinUserMessages int    // user_message_count >= N (0 = no filter)
-	ExcludeOneShot  bool   // exclude sessions with user_message_count <= 1
-	IncludeChildren bool   // include subagent sessions (for sidebar grouping)
+	ExcludeOneShot   bool   // exclude sessions with user_message_count <= 1
+	ExcludeAutomated bool   // exclude sessions where is_automated = 1
+	IncludeChildren  bool   // include subagent sessions (for sidebar grouping)
 	Cursor          string // opaque cursor from previous page
 	Limit           int
 }
@@ -321,6 +327,10 @@ func buildSessionFilter(f SessionFilter) (string, []any) {
 			filterPreds = append(filterPreds,
 				"user_message_count > 1")
 		}
+	}
+
+	if f.ExcludeAutomated {
+		filterPreds = append(filterPreds, "is_automated = 0")
 	}
 
 	// Simple case: no IncludeChildren or no user filters.
@@ -482,6 +492,7 @@ func (db *DB) GetSessionFull(
 		&s.ParentSessionID, &s.RelationshipType,
 		&s.TotalOutputTokens, &s.PeakContextTokens,
 		&s.HasTotalOutputTokens, &s.HasPeakContextTokens,
+		&s.IsAutomated,
 		&s.DeletedAt, &s.FilePath, &s.FileSize,
 		&s.FileMtime, &s.FileHash, &s.LocalModifiedAt, &s.CreatedAt,
 	)
@@ -534,6 +545,11 @@ func (db *DB) UpsertSession(s Session) error {
 		return ErrSessionExcluded
 	}
 
+	isAutomated := false
+	if s.FirstMessage != nil {
+		isAutomated = IsAutomatedSession(*s.FirstMessage)
+	}
+
 	_, err := db.getWriter().Exec(`
 		INSERT INTO sessions (
 			id, project, machine, agent, first_message,
@@ -542,8 +558,9 @@ func (db *DB) UpsertSession(s Session) error {
 			relationship_type,
 			total_output_tokens, peak_context_tokens,
 			has_total_output_tokens, has_peak_context_tokens,
+			is_automated,
 			file_path, file_size, file_mtime, file_hash
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project,
 			machine = excluded.machine,
@@ -559,6 +576,7 @@ func (db *DB) UpsertSession(s Session) error {
 			peak_context_tokens = excluded.peak_context_tokens,
 			has_total_output_tokens = excluded.has_total_output_tokens,
 			has_peak_context_tokens = excluded.has_peak_context_tokens,
+			is_automated = excluded.is_automated,
 			file_path = excluded.file_path,
 			file_size = excluded.file_size,
 			file_mtime = excluded.file_mtime,
@@ -569,6 +587,7 @@ func (db *DB) UpsertSession(s Session) error {
 		s.RelationshipType,
 		s.TotalOutputTokens, s.PeakContextTokens,
 		s.HasTotalOutputTokens, s.HasPeakContextTokens,
+		isAutomated,
 		s.FilePath, s.FileSize, s.FileMtime, s.FileHash)
 	if err != nil {
 		return fmt.Errorf("upserting session %s: %w", s.ID, err)
@@ -897,7 +916,8 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 
 // GetProjects returns project names with session counts.
 func (db *DB) GetProjects(
-	ctx context.Context, excludeOneShot bool,
+	ctx context.Context,
+	excludeOneShot, excludeAutomated bool,
 ) ([]ProjectInfo, error) {
 	q := `SELECT project, COUNT(*) as session_count
 		FROM sessions
@@ -906,6 +926,9 @@ func (db *DB) GetProjects(
 		  AND deleted_at IS NULL`
 	if excludeOneShot {
 		q += " AND user_message_count > 1"
+	}
+	if excludeAutomated {
+		q += " AND is_automated = 0"
 	}
 	q += " GROUP BY project ORDER BY project"
 	rows, err := db.getReader().QueryContext(ctx, q)
@@ -933,7 +956,8 @@ type ProjectInfo struct {
 
 // GetAgents returns distinct agent names with session counts.
 func (db *DB) GetAgents(
-	ctx context.Context, excludeOneShot bool,
+	ctx context.Context,
+	excludeOneShot, excludeAutomated bool,
 ) ([]AgentInfo, error) {
 	q := `SELECT agent, COUNT(*) as session_count
 		FROM sessions
@@ -942,6 +966,9 @@ func (db *DB) GetAgents(
 		  AND relationship_type NOT IN ('subagent', 'fork')`
 	if excludeOneShot {
 		q += " AND user_message_count > 1"
+	}
+	if excludeAutomated {
+		q += " AND is_automated = 0"
 	}
 	q += " GROUP BY agent ORDER BY agent"
 	rows, err := db.getReader().QueryContext(ctx, q)
@@ -969,11 +996,15 @@ type AgentInfo struct {
 
 // GetMachines returns distinct machine names.
 func (db *DB) GetMachines(
-	ctx context.Context, excludeOneShot bool,
+	ctx context.Context,
+	excludeOneShot, excludeAutomated bool,
 ) ([]string, error) {
 	q := "SELECT DISTINCT machine FROM sessions WHERE deleted_at IS NULL"
 	if excludeOneShot {
 		q += " AND user_message_count > 1"
+	}
+	if excludeAutomated {
+		q += " AND is_automated = 0"
 	}
 	q += " ORDER BY machine"
 	rows, err := db.getReader().QueryContext(ctx, q)
@@ -1094,6 +1125,7 @@ func (db *DB) FindPruneCandidates(
 			&s.ParentSessionID, &s.RelationshipType,
 			&s.TotalOutputTokens, &s.PeakContextTokens,
 			&s.HasTotalOutputTokens, &s.HasPeakContextTokens,
+			&s.IsAutomated,
 			&s.DeletedAt, &s.FilePath, &s.FileSize, &s.CreatedAt,
 		)
 		if err != nil {
@@ -1339,6 +1371,7 @@ func (db *DB) ListSessionsModifiedBetween(
 			&s.ParentSessionID, &s.RelationshipType,
 			&s.TotalOutputTokens, &s.PeakContextTokens,
 			&s.HasTotalOutputTokens, &s.HasPeakContextTokens,
+			&s.IsAutomated,
 			&s.DeletedAt, &s.FilePath, &s.FileSize,
 			&s.FileMtime, &s.FileHash, &s.LocalModifiedAt, &s.CreatedAt,
 		)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -319,13 +319,20 @@ func buildSessionFilter(f SessionFilter) (string, []any) {
 	// are almost always one-shot by nature and must not be
 	// excluded. The one-shot filter applies only to root
 	// sessions that match the filter directly.
+	// When ExcludeOneShot is true but automated sessions are
+	// included, exempt them from the one-shot filter — automated
+	// sessions are single-turn by definition, so a strict
+	// user_message_count > 1 predicate would always hide them.
 	oneShotPred := ""
 	if f.ExcludeOneShot {
+		pred := "user_message_count > 1"
+		if !f.ExcludeAutomated {
+			pred = "(user_message_count > 1 OR is_automated = 1)"
+		}
 		if f.IncludeChildren {
-			oneShotPred = "user_message_count > 1"
+			oneShotPred = pred
 		} else {
-			filterPreds = append(filterPreds,
-				"user_message_count > 1")
+			filterPreds = append(filterPreds, pred)
 		}
 	}
 
@@ -930,7 +937,11 @@ func (db *DB) GetProjects(
 		  AND relationship_type NOT IN ('subagent', 'fork')
 		  AND deleted_at IS NULL`
 	if excludeOneShot {
-		q += " AND user_message_count > 1"
+		if !excludeAutomated {
+			q += " AND (user_message_count > 1 OR is_automated = 1)"
+		} else {
+			q += " AND user_message_count > 1"
+		}
 	}
 	if excludeAutomated {
 		q += " AND is_automated = 0"
@@ -970,7 +981,11 @@ func (db *DB) GetAgents(
 		  AND deleted_at IS NULL
 		  AND relationship_type NOT IN ('subagent', 'fork')`
 	if excludeOneShot {
-		q += " AND user_message_count > 1"
+		if !excludeAutomated {
+			q += " AND (user_message_count > 1 OR is_automated = 1)"
+		} else {
+			q += " AND user_message_count > 1"
+		}
 	}
 	if excludeAutomated {
 		q += " AND is_automated = 0"
@@ -1006,7 +1021,11 @@ func (db *DB) GetMachines(
 ) ([]string, error) {
 	q := "SELECT DISTINCT machine FROM sessions WHERE deleted_at IS NULL"
 	if excludeOneShot {
-		q += " AND user_message_count > 1"
+		if !excludeAutomated {
+			q += " AND (user_message_count > 1 OR is_automated = 1)"
+		} else {
+			q += " AND user_message_count > 1"
+		}
 	}
 	if excludeAutomated {
 		q += " AND is_automated = 0"

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -778,11 +778,26 @@ func (db *DB) UpdateSessionIncremental(
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
+	// Recompute is_automated: read stored first_message and
+	// apply the detector with the new user_message_count.
+	isAutomated := false
+	if userMsgCount <= 1 {
+		var fm sql.NullString
+		_ = db.getWriter().QueryRow(
+			"SELECT first_message FROM sessions WHERE id = ?",
+			id,
+		).Scan(&fm)
+		if fm.Valid {
+			isAutomated = IsAutomatedSession(fm.String)
+		}
+	}
+
 	_, err := db.getWriter().Exec(`
 		UPDATE sessions SET
 			ended_at = COALESCE(?, ended_at),
 			message_count = ?,
 			user_message_count = ?,
+			is_automated = ?,
 			file_size = ?,
 			file_mtime = ?,
 			total_output_tokens = ?,
@@ -790,7 +805,7 @@ func (db *DB) UpdateSessionIncremental(
 			has_total_output_tokens = ?,
 			has_peak_context_tokens = ?
 		WHERE id = ?`,
-		endedAt, msgCount, userMsgCount,
+		endedAt, msgCount, userMsgCount, isAutomated,
 		fileSize, fileMtime,
 		totalOutputTokens, peakContextTokens,
 		hasTotalOutputTokens, hasPeakContextTokens, id,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -545,10 +545,9 @@ func (db *DB) UpsertSession(s Session) error {
 		return ErrSessionExcluded
 	}
 
-	isAutomated := false
-	if s.FirstMessage != nil {
-		isAutomated = IsAutomatedSession(*s.FirstMessage)
-	}
+	isAutomated := s.UserMessageCount <= 1 &&
+		s.FirstMessage != nil &&
+		IsAutomatedSession(*s.FirstMessage)
 
 	_, err := db.getWriter().Exec(`
 		INSERT INTO sessions (

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -44,11 +44,15 @@ func (db *DB) FileBackedSessionCount(
 // GetStats returns database statistics, counting only root
 // sessions with messages (matching the session list filter).
 func (db *DB) GetStats(
-	ctx context.Context, excludeOneShot bool,
+	ctx context.Context,
+	excludeOneShot, excludeAutomated bool,
 ) (Stats, error) {
 	filter := rootSessionFilter
 	if excludeOneShot {
 		filter += " AND user_message_count > 1"
+	}
+	if excludeAutomated {
+		filter += " AND is_automated = 0"
 	}
 	query := fmt.Sprintf(`
 		SELECT

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -49,7 +49,11 @@ func (db *DB) GetStats(
 ) (Stats, error) {
 	filter := rootSessionFilter
 	if excludeOneShot {
-		filter += " AND user_message_count > 1"
+		if !excludeAutomated {
+			filter += " AND (user_message_count > 1 OR is_automated = 1)"
+		} else {
+			filter += " AND user_message_count > 1"
+		}
 	}
 	if excludeAutomated {
 		filter += " AND is_automated = 0"

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -39,10 +39,10 @@ type Store interface {
 	GetSessionVersion(id string) (count int, fileMtime int64, ok bool)
 
 	// Metadata.
-	GetStats(ctx context.Context, excludeOneShot bool) (Stats, error)
-	GetProjects(ctx context.Context, excludeOneShot bool) ([]ProjectInfo, error)
-	GetAgents(ctx context.Context, excludeOneShot bool) ([]AgentInfo, error)
-	GetMachines(ctx context.Context, excludeOneShot bool) ([]string, error)
+	GetStats(ctx context.Context, excludeOneShot, excludeAutomated bool) (Stats, error)
+	GetProjects(ctx context.Context, excludeOneShot, excludeAutomated bool) ([]ProjectInfo, error)
+	GetAgents(ctx context.Context, excludeOneShot, excludeAutomated bool) ([]AgentInfo, error)
+	GetMachines(ctx context.Context, excludeOneShot, excludeAutomated bool) ([]string, error)
 
 	// Analytics.
 	GetAnalyticsSummary(ctx context.Context, f AnalyticsFilter) (AnalyticsSummary, error)

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -109,6 +109,9 @@ func buildAnalyticsWhere(
 	if f.ExcludeOneShot {
 		preds = append(preds, "user_message_count > 1")
 	}
+	if f.ExcludeAutomated {
+		preds = append(preds, "is_automated = FALSE")
+	}
 	if f.ActiveSince != "" {
 		preds = append(preds,
 			"COALESCE(ended_at, started_at, created_at)"+

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -107,7 +107,12 @@ func buildAnalyticsWhere(
 				pb.add(f.MinUserMessages))
 	}
 	if f.ExcludeOneShot {
-		preds = append(preds, "user_message_count > 1")
+		if !f.ExcludeAutomated {
+			preds = append(preds,
+				"(user_message_count > 1 OR is_automated = TRUE)")
+		} else {
+			preds = append(preds, "user_message_count > 1")
+		}
 	}
 	if f.ExcludeAutomated {
 		preds = append(preds, "is_automated = FALSE")

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -590,6 +590,10 @@ func (s *Sync) pushSession(
 	ctx context.Context, tx *sql.Tx, sess db.Session,
 ) error {
 	createdAt, _ := ParseSQLiteTimestamp(sess.CreatedAt)
+	isAutomated := false
+	if sess.FirstMessage != nil {
+		isAutomated = db.IsAutomatedSession(*sess.FirstMessage)
+	}
 	_, err := tx.ExecContext(ctx, `
 		INSERT INTO sessions (
 			id, machine, project, agent,
@@ -598,13 +602,14 @@ func (s *Sync) pushSession(
 			message_count, user_message_count,
 			total_output_tokens, peak_context_tokens,
 			has_total_output_tokens, has_peak_context_tokens,
+			is_automated,
 			parent_session_id, relationship_type,
 			updated_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6,
 			$7, $8, $9, $10,
 			$11, $12, $13, $14,
-			$15, $16, $17, $18, NOW()
+			$15, $16, $17, $18, $19, NOW()
 		)
 		ON CONFLICT (id) DO UPDATE SET
 			machine = EXCLUDED.machine,
@@ -622,6 +627,7 @@ func (s *Sync) pushSession(
 			peak_context_tokens = EXCLUDED.peak_context_tokens,
 			has_total_output_tokens = EXCLUDED.has_total_output_tokens,
 			has_peak_context_tokens = EXCLUDED.has_peak_context_tokens,
+			is_automated = EXCLUDED.is_automated,
 			parent_session_id = EXCLUDED.parent_session_id,
 			relationship_type = EXCLUDED.relationship_type,
 			updated_at = NOW()
@@ -640,6 +646,7 @@ func (s *Sync) pushSession(
 			OR sessions.peak_context_tokens IS DISTINCT FROM EXCLUDED.peak_context_tokens
 			OR sessions.has_total_output_tokens IS DISTINCT FROM EXCLUDED.has_total_output_tokens
 			OR sessions.has_peak_context_tokens IS DISTINCT FROM EXCLUDED.has_peak_context_tokens
+			OR sessions.is_automated IS DISTINCT FROM EXCLUDED.is_automated
 			OR sessions.parent_session_id IS DISTINCT FROM EXCLUDED.parent_session_id
 			OR sessions.relationship_type IS DISTINCT FROM EXCLUDED.relationship_type`,
 		sess.ID, s.machine,
@@ -654,6 +661,7 @@ func (s *Sync) pushSession(
 		sess.MessageCount, sess.UserMessageCount,
 		sess.TotalOutputTokens, sess.PeakContextTokens,
 		sess.HasTotalOutputTokens, sess.HasPeakContextTokens,
+		isAutomated,
 		nilStr(sess.ParentSessionID),
 		sess.RelationshipType,
 	)

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -590,10 +590,9 @@ func (s *Sync) pushSession(
 	ctx context.Context, tx *sql.Tx, sess db.Session,
 ) error {
 	createdAt, _ := ParseSQLiteTimestamp(sess.CreatedAt)
-	isAutomated := false
-	if sess.FirstMessage != nil {
-		isAutomated = db.IsAutomatedSession(*sess.FirstMessage)
-	}
+	isAutomated := sess.UserMessageCount <= 1 &&
+		sess.FirstMessage != nil &&
+		db.IsAutomatedSession(*sess.FirstMessage)
 	_, err := tx.ExecContext(ctx, `
 		INSERT INTO sessions (
 			id, machine, project, agent,

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -278,7 +278,7 @@ func EnsureSchema(
 	return nil
 }
 
-const isAutomatedBackfillMetadataKey = "is_automated_backfill_v2"
+const isAutomatedBackfillMetadataKey = "is_automated_backfill_v3"
 
 // backfillIsAutomatedPG recomputes is_automated for all PG
 // sessions, correcting both false negatives (new patterns) and

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -245,6 +246,7 @@ func EnsureSchema(
 		},
 	}
 	tokenCoverageColumnsAdded := false
+	isAutomatedAdded := false
 	for _, a := range alters {
 		added, err := ensureColumn(ctx, db, a.table, a.column, a.stmt)
 		if err != nil {
@@ -254,6 +256,13 @@ func EnsureSchema(
 		case "has_total_output_tokens", "has_peak_context_tokens",
 			"has_context_tokens", "has_output_tokens":
 			tokenCoverageColumnsAdded = tokenCoverageColumnsAdded || added
+		case "is_automated":
+			isAutomatedAdded = isAutomatedAdded || added
+		}
+	}
+	if isAutomatedAdded {
+		if err := backfillIsAutomatedPG(ctx, db); err != nil {
+			return err
 		}
 	}
 	runRepair, err := shouldRunTokenCoverageRepair(
@@ -270,6 +279,32 @@ func EnsureSchema(
 	}
 	if err := markTokenCoverageRepairDone(ctx, db); err != nil {
 		return err
+	}
+	return nil
+}
+
+// backfillIsAutomatedPG sets is_automated = TRUE for existing
+// PG sessions whose first_message matches roborev prompt
+// patterns. Only runs when the column was newly added.
+func backfillIsAutomatedPG(
+	ctx context.Context, pg *sql.DB,
+) error {
+	res, err := pg.ExecContext(ctx,
+		`UPDATE sessions SET is_automated = TRUE
+		 WHERE first_message IS NOT NULL
+		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
+		     OR first_message LIKE '# Fix Request' || E'\n' || '%')`)
+	if err != nil {
+		return fmt.Errorf(
+			"backfilling is_automated in PG: %w", err,
+		)
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		log.Printf(
+			"pg migration: backfilled is_automated for %d sessions",
+			n,
+		)
 	}
 	return nil
 }

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     peak_context_tokens INT NOT NULL DEFAULT 0,
     has_total_output_tokens BOOLEAN NOT NULL DEFAULT FALSE,
     has_peak_context_tokens BOOLEAN NOT NULL DEFAULT FALSE,
+    is_automated       BOOLEAN NOT NULL DEFAULT FALSE,
     updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -234,6 +235,13 @@ func EnsureSchema(
 			 ADD COLUMN IF NOT EXISTS call_index
 			 INT NOT NULL DEFAULT 0`,
 			"adding tool_calls.call_index",
+		},
+		{
+			"sessions", "is_automated",
+			`ALTER TABLE sessions
+			 ADD COLUMN IF NOT EXISTS is_automated
+			 BOOLEAN NOT NULL DEFAULT FALSE`,
+			"adding sessions.is_automated",
 		},
 	}
 	tokenCoverageColumnsAdded := false

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -278,7 +278,7 @@ func EnsureSchema(
 	return nil
 }
 
-const isAutomatedBackfillMetadataKey = "is_automated_backfill_v3"
+const isAutomatedBackfillMetadataKey = "is_automated_backfill_v1"
 
 // backfillIsAutomatedPG recomputes is_automated for all PG
 // sessions, correcting both false negatives (new patterns) and

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -246,7 +246,6 @@ func EnsureSchema(
 		},
 	}
 	tokenCoverageColumnsAdded := false
-	isAutomatedAdded := false
 	for _, a := range alters {
 		added, err := ensureColumn(ctx, db, a.table, a.column, a.stmt)
 		if err != nil {
@@ -256,14 +255,10 @@ func EnsureSchema(
 		case "has_total_output_tokens", "has_peak_context_tokens",
 			"has_context_tokens", "has_output_tokens":
 			tokenCoverageColumnsAdded = tokenCoverageColumnsAdded || added
-		case "is_automated":
-			isAutomatedAdded = isAutomatedAdded || added
 		}
 	}
-	if isAutomatedAdded {
-		if err := backfillIsAutomatedPG(ctx, db); err != nil {
-			return err
-		}
+	if err := backfillIsAutomatedPG(ctx, db); err != nil {
+		return err
 	}
 	runRepair, err := shouldRunTokenCoverageRepair(
 		ctx, db, tokenCoverageColumnsAdded,
@@ -283,19 +278,35 @@ func EnsureSchema(
 	return nil
 }
 
-// backfillIsAutomatedPG scans single-turn PG sessions and
-// sets is_automated = TRUE for those matching roborev prompt
-// patterns. Uses the Go detector so the SQL doesn't need to
-// duplicate every pattern. Only runs when the column is newly
-// added.
+const isAutomatedBackfillMetadataKey = "is_automated_backfill_v2"
+
+// backfillIsAutomatedPG recomputes is_automated for all PG
+// sessions, correcting both false negatives (new patterns) and
+// stale false positives (patterns tightened since last run).
+// Guarded by a sync_metadata marker so it only runs once per
+// pattern version.
 func backfillIsAutomatedPG(
 	ctx context.Context, pg *sql.DB,
 ) error {
+	var done int
+	if err := pg.QueryRowContext(ctx,
+		`SELECT count(*) FROM sync_metadata
+		 WHERE key = $1 AND value != ''`,
+		isAutomatedBackfillMetadataKey,
+	).Scan(&done); err != nil {
+		return fmt.Errorf(
+			"probing PG automated backfill marker: %w", err,
+		)
+	}
+	if done > 0 {
+		return nil
+	}
+
 	rows, err := pg.QueryContext(ctx,
-		`SELECT id, first_message FROM sessions
-		 WHERE is_automated = FALSE
-		   AND user_message_count <= 1
-		   AND first_message IS NOT NULL`)
+		`SELECT id, first_message, user_message_count,
+			is_automated
+		 FROM sessions
+		 WHERE first_message IS NOT NULL`)
 	if err != nil {
 		return fmt.Errorf(
 			"querying PG automated backfill candidates: %w",
@@ -304,39 +315,74 @@ func backfillIsAutomatedPG(
 	}
 	defer rows.Close()
 
-	var ids []string
+	var setIDs, clearIDs []string
 	for rows.Next() {
 		var id, fm string
-		if err := rows.Scan(&id, &fm); err != nil {
+		var umc int
+		var current bool
+		if err := rows.Scan(
+			&id, &fm, &umc, &current,
+		); err != nil {
 			return fmt.Errorf(
 				"scanning PG backfill candidate: %w", err,
 			)
 		}
-		if db.IsAutomatedSession(fm) {
-			ids = append(ids, id)
+		want := umc <= 1 && db.IsAutomatedSession(fm)
+		if want && !current {
+			setIDs = append(setIDs, id)
+		} else if !want && current {
+			clearIDs = append(clearIDs, id)
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
-	if len(ids) == 0 {
-		return nil
+
+	if err := batchUpdateAutomatedPG(
+		ctx, pg, setIDs, true,
+	); err != nil {
+		return err
+	}
+	if err := batchUpdateAutomatedPG(
+		ctx, pg, clearIDs, false,
+	); err != nil {
+		return err
 	}
 
-	// Batch update in chunks.
-	pb := &paramBuilder{}
+	if len(setIDs) > 0 || len(clearIDs) > 0 {
+		log.Printf(
+			"pg migration: recomputed is_automated"+
+				" (set %d, cleared %d)",
+			len(setIDs), len(clearIDs),
+		)
+	}
+
+	_, err = pg.ExecContext(ctx,
+		`INSERT INTO sync_metadata (key, value)
+		 VALUES ($1, '1')
+		 ON CONFLICT (key) DO UPDATE
+		 SET value = EXCLUDED.value`,
+		isAutomatedBackfillMetadataKey,
+	)
+	return err
+}
+
+func batchUpdateAutomatedPG(
+	ctx context.Context, pg *sql.DB,
+	ids []string, val bool,
+) error {
 	const batchSize = 500
 	for i := 0; i < len(ids); i += batchSize {
 		end := min(i+batchSize, len(ids))
 		batch := ids[i:end]
-		pb.n = 0
-		pb.args = pb.args[:0]
+		pb := &paramBuilder{}
+		valPh := pb.add(val)
 		phs := make([]string, len(batch))
 		for j, id := range batch {
 			phs[j] = pb.add(id)
 		}
 		_, err := pg.ExecContext(ctx,
-			"UPDATE sessions SET is_automated = TRUE"+
+			"UPDATE sessions SET is_automated = "+valPh+
 				" WHERE id IN ("+
 				strings.Join(phs, ",")+
 				")",
@@ -344,14 +390,10 @@ func backfillIsAutomatedPG(
 		)
 		if err != nil {
 			return fmt.Errorf(
-				"backfilling is_automated in PG: %w", err,
+				"updating is_automated in PG: %w", err,
 			)
 		}
 	}
-	log.Printf(
-		"pg migration: backfilled is_automated for %d sessions",
-		len(ids),
-	)
 	return nil
 }
 

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -283,29 +283,75 @@ func EnsureSchema(
 	return nil
 }
 
-// backfillIsAutomatedPG sets is_automated = TRUE for existing
-// PG sessions whose first_message matches roborev prompt
-// patterns. Only runs when the column was newly added.
+// backfillIsAutomatedPG scans single-turn PG sessions and
+// sets is_automated = TRUE for those matching roborev prompt
+// patterns. Uses the Go detector so the SQL doesn't need to
+// duplicate every pattern. Only runs when the column is newly
+// added.
 func backfillIsAutomatedPG(
 	ctx context.Context, pg *sql.DB,
 ) error {
-	res, err := pg.ExecContext(ctx,
-		`UPDATE sessions SET is_automated = TRUE
-		 WHERE first_message IS NOT NULL
-		   AND (first_message LIKE 'You are a code reviewer. Review the code changes shown below.%'
-		     OR first_message LIKE '# Fix Request' || E'\n' || '%')`)
+	rows, err := pg.QueryContext(ctx,
+		`SELECT id, first_message FROM sessions
+		 WHERE is_automated = FALSE
+		   AND user_message_count <= 1
+		   AND first_message IS NOT NULL`)
 	if err != nil {
 		return fmt.Errorf(
-			"backfilling is_automated in PG: %w", err,
+			"querying PG automated backfill candidates: %w",
+			err,
 		)
 	}
-	n, _ := res.RowsAffected()
-	if n > 0 {
-		log.Printf(
-			"pg migration: backfilled is_automated for %d sessions",
-			n,
-		)
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id, fm string
+		if err := rows.Scan(&id, &fm); err != nil {
+			return fmt.Errorf(
+				"scanning PG backfill candidate: %w", err,
+			)
+		}
+		if db.IsAutomatedSession(fm) {
+			ids = append(ids, id)
+		}
 	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	// Batch update in chunks.
+	pb := &paramBuilder{}
+	const batchSize = 500
+	for i := 0; i < len(ids); i += batchSize {
+		end := min(i+batchSize, len(ids))
+		batch := ids[i:end]
+		pb.n = 0
+		pb.args = pb.args[:0]
+		phs := make([]string, len(batch))
+		for j, id := range batch {
+			phs[j] = pb.add(id)
+		}
+		_, err := pg.ExecContext(ctx,
+			"UPDATE sessions SET is_automated = TRUE"+
+				" WHERE id IN ("+
+				strings.Join(phs, ",")+
+				")",
+			pb.args...,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"backfilling is_automated in PG: %w", err,
+			)
+		}
+	}
+	log.Printf(
+		"pg migration: backfilled is_automated for %d sessions",
+		len(ids),
+	)
 	return nil
 }
 

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -205,11 +205,14 @@ func buildPGSessionFilter(
 
 	oneShotPred := ""
 	if f.ExcludeOneShot {
+		pred := "user_message_count > 1"
+		if !f.ExcludeAutomated {
+			pred = "(user_message_count > 1 OR is_automated = TRUE)"
+		}
 		if f.IncludeChildren {
-			oneShotPred = "user_message_count > 1"
+			oneShotPred = pred
 		} else {
-			filterPreds = append(filterPreds,
-				"user_message_count > 1")
+			filterPreds = append(filterPreds, pred)
 		}
 	}
 
@@ -504,7 +507,11 @@ func (s *Store) GetStats(
 ) (db.Stats, error) {
 	filter := pgRootSessionFilter
 	if excludeOneShot {
-		filter += " AND user_message_count > 1"
+		if !excludeAutomated {
+			filter += " AND (user_message_count > 1 OR is_automated = TRUE)"
+		} else {
+			filter += " AND user_message_count > 1"
+		}
 	}
 	if excludeAutomated {
 		filter += " AND is_automated = FALSE"
@@ -555,7 +562,11 @@ func (s *Store) GetProjects(
 		  AND relationship_type NOT IN ('subagent', 'fork')
 		  AND deleted_at IS NULL`
 	if excludeOneShot {
-		q += " AND user_message_count > 1"
+		if !excludeAutomated {
+			q += " AND (user_message_count > 1 OR is_automated = TRUE)"
+		} else {
+			q += " AND user_message_count > 1"
+		}
 	}
 	if excludeAutomated {
 		q += " AND is_automated = FALSE"
@@ -595,7 +606,11 @@ func (s *Store) GetAgents(
 		  AND deleted_at IS NULL
 		  AND relationship_type NOT IN ('subagent', 'fork')`
 	if excludeOneShot {
-		q += " AND user_message_count > 1"
+		if !excludeAutomated {
+			q += " AND (user_message_count > 1 OR is_automated = TRUE)"
+		} else {
+			q += " AND user_message_count > 1"
+		}
 	}
 	if excludeAutomated {
 		q += " AND is_automated = FALSE"
@@ -632,7 +647,11 @@ func (s *Store) GetMachines(
 	q := `SELECT DISTINCT machine FROM sessions
 		WHERE deleted_at IS NULL`
 	if excludeOneShot {
-		q += " AND user_message_count > 1"
+		if !excludeAutomated {
+			q += " AND (user_message_count > 1 OR is_automated = TRUE)"
+		} else {
+			q += " AND user_message_count > 1"
+		}
 	}
 	if excludeAutomated {
 		q += " AND is_automated = FALSE"

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -32,6 +32,7 @@ const pgSessionCols = `id, project, machine, agent,
 	parent_session_id, relationship_type,
 	total_output_tokens, peak_context_tokens,
 	has_total_output_tokens, has_peak_context_tokens,
+	is_automated,
 	deleted_at`
 
 // paramBuilder generates numbered PostgreSQL placeholders.
@@ -62,6 +63,7 @@ func scanPGSession(
 		&s.ParentSessionID, &s.RelationshipType,
 		&s.TotalOutputTokens, &s.PeakContextTokens,
 		&s.HasTotalOutputTokens, &s.HasPeakContextTokens,
+		&s.IsAutomated,
 		&deletedAt,
 	)
 	if err != nil {
@@ -209,6 +211,11 @@ func buildPGSessionFilter(
 			filterPreds = append(filterPreds,
 				"user_message_count > 1")
 		}
+	}
+
+	if f.ExcludeAutomated {
+		filterPreds = append(filterPreds,
+			"is_automated = FALSE")
 	}
 
 	hasFilters := len(filterPreds) > 0 || oneShotPred != ""
@@ -492,11 +499,15 @@ func (s *Store) GetChildSessions(
 // GetStats returns database statistics, counting only root
 // sessions with messages.
 func (s *Store) GetStats(
-	ctx context.Context, excludeOneShot bool,
+	ctx context.Context,
+	excludeOneShot, excludeAutomated bool,
 ) (db.Stats, error) {
 	filter := pgRootSessionFilter
 	if excludeOneShot {
 		filter += " AND user_message_count > 1"
+	}
+	if excludeAutomated {
+		filter += " AND is_automated = FALSE"
 	}
 	query := fmt.Sprintf(`
 		SELECT
@@ -535,7 +546,8 @@ func (s *Store) GetStats(
 
 // GetProjects returns project names with session counts.
 func (s *Store) GetProjects(
-	ctx context.Context, excludeOneShot bool,
+	ctx context.Context,
+	excludeOneShot, excludeAutomated bool,
 ) ([]db.ProjectInfo, error) {
 	q := `SELECT project, COUNT(*) as session_count
 		FROM sessions
@@ -544,6 +556,9 @@ func (s *Store) GetProjects(
 		  AND deleted_at IS NULL`
 	if excludeOneShot {
 		q += " AND user_message_count > 1"
+	}
+	if excludeAutomated {
+		q += " AND is_automated = FALSE"
 	}
 	q += " GROUP BY project ORDER BY project"
 	rows, err := s.pg.QueryContext(ctx, q)
@@ -571,7 +586,8 @@ func (s *Store) GetProjects(
 
 // GetAgents returns distinct agent names with session counts.
 func (s *Store) GetAgents(
-	ctx context.Context, excludeOneShot bool,
+	ctx context.Context,
+	excludeOneShot, excludeAutomated bool,
 ) ([]db.AgentInfo, error) {
 	q := `SELECT agent, COUNT(*) as session_count
 		FROM sessions
@@ -580,6 +596,9 @@ func (s *Store) GetAgents(
 		  AND relationship_type NOT IN ('subagent', 'fork')`
 	if excludeOneShot {
 		q += " AND user_message_count > 1"
+	}
+	if excludeAutomated {
+		q += " AND is_automated = FALSE"
 	}
 	q += " GROUP BY agent ORDER BY agent"
 	rows, err := s.pg.QueryContext(ctx, q)
@@ -607,12 +626,16 @@ func (s *Store) GetAgents(
 
 // GetMachines returns distinct machine names.
 func (s *Store) GetMachines(
-	ctx context.Context, excludeOneShot bool,
+	ctx context.Context,
+	excludeOneShot, excludeAutomated bool,
 ) ([]string, error) {
 	q := `SELECT DISTINCT machine FROM sessions
 		WHERE deleted_at IS NULL`
 	if excludeOneShot {
 		q += " AND user_message_count > 1"
+	}
+	if excludeAutomated {
+		q += " AND is_automated = FALSE"
 	}
 	q += " ORDER BY machine"
 	rows, err := s.pg.QueryContext(ctx, q)

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -278,7 +278,7 @@ func TestStoreGetStats(t *testing.T) {
 	defer store.Close()
 
 	ctx := context.Background()
-	stats, err := store.GetStats(ctx, false)
+	stats, err := store.GetStats(ctx, false, false)
 	if err != nil {
 		t.Fatalf("GetStats: %v", err)
 	}

--- a/internal/server/analytics.go
+++ b/internal/server/analytics.go
@@ -108,19 +108,21 @@ func parseAnalyticsFilter(
 	}
 
 	includeOneShot := q.Get("include_one_shot") == "true"
+	includeAutomated := q.Get("include_automated") == "true"
 
 	return db.AnalyticsFilter{
-		From:            from,
-		To:              to,
-		Machine:         q.Get("machine"),
-		Project:         q.Get("project"),
-		Agent:           q.Get("agent"),
-		Timezone:        tz,
-		DayOfWeek:       dow,
-		Hour:            hour,
-		MinUserMessages: minUserMsgs,
-		ExcludeOneShot:  !includeOneShot,
-		ActiveSince:     activeSince,
+		From:             from,
+		To:               to,
+		Machine:          q.Get("machine"),
+		Project:          q.Get("project"),
+		Agent:            q.Get("agent"),
+		Timezone:         tz,
+		DayOfWeek:        dow,
+		Hour:             hour,
+		MinUserMessages:  minUserMsgs,
+		ExcludeOneShot:   !includeOneShot,
+		ExcludeAutomated: !includeAutomated,
+		ActiveSince:      activeSince,
 	}, true
 }
 

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -319,8 +319,10 @@ func (s *Server) handleSyncStatus(
 func (s *Server) handleGetStats(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	excludeOneShot := r.URL.Query().Get("include_one_shot") != "true"
-	stats, err := s.db.GetStats(r.Context(), excludeOneShot)
+	q := r.URL.Query()
+	excludeOneShot := q.Get("include_one_shot") != "true"
+	excludeAutomated := q.Get("include_automated") != "true"
+	stats, err := s.db.GetStats(r.Context(), excludeOneShot, excludeAutomated)
 	if err != nil {
 		if handleContextError(w, err) {
 			return
@@ -334,8 +336,10 @@ func (s *Server) handleGetStats(
 func (s *Server) handleListProjects(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	excludeOneShot := r.URL.Query().Get("include_one_shot") != "true"
-	projects, err := s.db.GetProjects(r.Context(), excludeOneShot)
+	q := r.URL.Query()
+	excludeOneShot := q.Get("include_one_shot") != "true"
+	excludeAutomated := q.Get("include_automated") != "true"
+	projects, err := s.db.GetProjects(r.Context(), excludeOneShot, excludeAutomated)
 	if err != nil {
 		if handleContextError(w, err) {
 			return
@@ -351,8 +355,10 @@ func (s *Server) handleListProjects(
 func (s *Server) handleListMachines(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	excludeOneShot := r.URL.Query().Get("include_one_shot") != "true"
-	machines, err := s.db.GetMachines(r.Context(), excludeOneShot)
+	q := r.URL.Query()
+	excludeOneShot := q.Get("include_one_shot") != "true"
+	excludeAutomated := q.Get("include_automated") != "true"
+	machines, err := s.db.GetMachines(r.Context(), excludeOneShot, excludeAutomated)
 	if err != nil {
 		if handleContextError(w, err) {
 			return
@@ -368,8 +374,10 @@ func (s *Server) handleListMachines(
 func (s *Server) handleListAgents(
 	w http.ResponseWriter, r *http.Request,
 ) {
-	excludeOneShot := r.URL.Query().Get("include_one_shot") != "true"
-	agents, err := s.db.GetAgents(r.Context(), excludeOneShot)
+	q := r.URL.Query()
+	excludeOneShot := q.Get("include_one_shot") != "true"
+	excludeAutomated := q.Get("include_automated") != "true"
+	agents, err := s.db.GetAgents(r.Context(), excludeOneShot, excludeAutomated)
 	if err != nil {
 		if handleContextError(w, err) {
 			return

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -56,24 +56,26 @@ func (s *Server) handleListSessions(
 	}
 
 	includeOneShot := q.Get("include_one_shot") == "true"
+	includeAutomated := q.Get("include_automated") == "true"
 	includeChildren := q.Get("include_children") == "true"
 
 	filter := db.SessionFilter{
-		Project:         q.Get("project"),
-		ExcludeProject:  q.Get("exclude_project"),
-		Machine:         q.Get("machine"),
-		Agent:           q.Get("agent"),
-		Date:            date,
-		DateFrom:        dateFrom,
-		DateTo:          dateTo,
-		ActiveSince:     activeSince,
-		MinMessages:     minMsgs,
-		MaxMessages:     maxMsgs,
-		MinUserMessages: minUserMsgs,
-		ExcludeOneShot:  !includeOneShot,
-		IncludeChildren: includeChildren,
-		Cursor:          q.Get("cursor"),
-		Limit:           limit,
+		Project:          q.Get("project"),
+		ExcludeProject:   q.Get("exclude_project"),
+		Machine:          q.Get("machine"),
+		Agent:            q.Get("agent"),
+		Date:             date,
+		DateFrom:         dateFrom,
+		DateTo:           dateTo,
+		ActiveSince:      activeSince,
+		MinMessages:      minMsgs,
+		MaxMessages:      maxMsgs,
+		MinUserMessages:  minUserMsgs,
+		ExcludeOneShot:   !includeOneShot,
+		ExcludeAutomated: !includeAutomated,
+		IncludeChildren:  includeChildren,
+		Cursor:           q.Get("cursor"),
+		Limit:            limit,
 	}
 
 	page, err := s.db.ListSessions(r.Context(), filter)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -275,7 +275,7 @@ func TestSyncEngineWorktreesShareProject(t *testing.T) {
 	assertSessionProject(t, env.db, "main-repo", "agentsview")
 	assertSessionProject(t, env.db, "worktree-repo", "agentsview")
 
-	projects, err := env.db.GetProjects(context.Background(), false)
+	projects, err := env.db.GetProjects(context.Background(), false, false)
 	if err != nil {
 		t.Fatalf("GetProjects: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `is_automated` boolean column to sessions table (SQLite + PG) that flags single-turn roborev review/fix/analysis sessions
- Detect 7 roborev prompt patterns (code review, security review, design review, code assistant fix, analysis request, insights analyst, catch-all "invoked by roborev" substring)
- Only flag sessions as automated when `user_message_count <= 1` — multi-turn sessions are interactive
- Hide automated sessions by default; add "Include automated reviews" filter toggle in sidebar and analytics
- Flip single-turn default: show single-turn sessions by default, with "Hide single-turn" toggle (replaces old "Include single-turn")
- Bidirectional migration backfill for both SQLite and PG, guarded by versioned markers

Closes #256

## Test plan

- [x] `IsAutomatedSession` unit tests cover all 7 patterns + negative cases
- [x] `TestSessionFilterExcludeAutomated` verifies SQL filter predicate
- [x] `TestIsAutomatedSetOnUpsert` verifies single-turn vs multi-turn distinction
- [x] `TestIncrementalUpdateClearsAutomated` verifies a session that gains a second user turn flips back to non-automated
- [x] All existing Go tests pass (`go test -tags fts5 -short ./...`)
- [x] Frontend builds cleanly
- [ ] Manual: verify sidebar shows single-turn sessions by default
- [ ] Manual: verify roborev sessions hidden by default, visible with toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)