### PR TITLE
feat: import Claude.ai and ChatGPT conversations

### DIFF
--- a/cmd/agentsview/import.go
+++ b/cmd/agentsview/import.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wesm/agentsview/internal/config"
+	"github.com/wesm/agentsview/internal/db"
+	"github.com/wesm/agentsview/internal/importer"
+)
+
+func runImport(args []string) {
+	fs := flag.NewFlagSet("import", flag.ContinueOnError)
+	importType := fs.String(
+		"type", "", "Import type: claude-ai, chatgpt",
+	)
+
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+
+	if *importType == "" || fs.NArg() == 0 {
+		fmt.Fprintln(os.Stderr,
+			"usage: agentsview import --type <type> <path>")
+		fmt.Fprintln(os.Stderr,
+			"  --type   claude-ai or chatgpt")
+		fmt.Fprintln(os.Stderr,
+			"  <path>   directory, .json, or .zip file")
+		os.Exit(1)
+	}
+
+	path := fs.Arg(0)
+
+	appCfg, err := config.LoadMinimal()
+	if err != nil {
+		log.Fatalf("loading config: %v", err)
+	}
+
+	database, err := db.Open(appCfg.DBPath)
+	if err != nil {
+		log.Fatalf("Error opening database: %v", err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+
+	// Handle zip files.
+	dir, cleanup, err := resolveImportSource(path)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	var stats importer.ImportStats
+
+	switch *importType {
+	case "claude-ai":
+		stats, err = runClaudeAIImport(ctx, database, dir)
+	case "chatgpt":
+		assetsDir := filepath.Join(appCfg.DataDir, "assets")
+		stats, err = runChatGPTImport(
+			ctx, database, dir, assetsDir,
+		)
+	default:
+		log.Fatalf(
+			"Unknown import type: %s (use claude-ai or chatgpt)",
+			*importType,
+		)
+	}
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr)
+		log.Fatalf("Import failed: %v", err)
+	}
+
+	printImportSummary(stats)
+
+	if stats.Errors > 0 {
+		os.Exit(1)
+	}
+}
+
+func runClaudeAIImport(
+	ctx context.Context, database *db.DB, path string,
+) (importer.ImportStats, error) {
+	jsonPath := path
+	info, err := os.Stat(path)
+	if err != nil {
+		return importer.ImportStats{}, err
+	}
+	if info.IsDir() {
+		jsonPath = filepath.Join(path, "conversations.json")
+	}
+
+	f, err := os.Open(jsonPath)
+	if err != nil {
+		return importer.ImportStats{},
+			fmt.Errorf("opening %s: %w", jsonPath, err)
+	}
+	defer f.Close()
+
+	return importer.ImportClaudeAI(
+		ctx, database, f, func(n int) {
+			fmt.Fprintf(
+				os.Stderr,
+				"\rImported %d conversations...", n,
+			)
+		},
+	)
+}
+
+func runChatGPTImport(
+	ctx context.Context, database *db.DB,
+	dir, assetsDir string,
+) (importer.ImportStats, error) {
+	return importer.ImportChatGPT(
+		ctx, database, dir, assetsDir,
+		func(processed int) {
+			fmt.Fprintf(
+				os.Stderr,
+				"\rProcessed %d conversations...",
+				processed,
+			)
+		},
+	)
+}
+
+func printImportSummary(stats importer.ImportStats) {
+	total := stats.Imported + stats.Updated + stats.Skipped
+	fmt.Fprintf(os.Stderr, "\rDone: %d processed", total)
+	var parts []string
+	if stats.Imported > 0 {
+		parts = append(
+			parts, fmt.Sprintf("%d new", stats.Imported),
+		)
+	}
+	if stats.Updated > 0 {
+		parts = append(
+			parts, fmt.Sprintf("%d updated", stats.Updated),
+		)
+	}
+	if stats.Skipped > 0 {
+		parts = append(
+			parts, fmt.Sprintf("%d skipped", stats.Skipped),
+		)
+	}
+	if len(parts) > 0 {
+		fmt.Fprintf(
+			os.Stderr, " (%s)", strings.Join(parts, ", "),
+		)
+	}
+	fmt.Fprintln(os.Stderr)
+	if stats.Errors > 0 {
+		fmt.Fprintf(os.Stderr, "  %d errors\n", stats.Errors)
+	}
+}
+
+// resolveImportSource handles zip extraction. If the path is
+// a .zip file, it extracts to a temp dir and returns the dir
+// path with a cleanup function. Otherwise returns the original
+// path with nil cleanup.
+func resolveImportSource(
+	path string,
+) (string, func(), error) {
+	if strings.HasSuffix(strings.ToLower(path), ".zip") {
+		return importer.ExtractZip(path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		return "", nil,
+			fmt.Errorf("cannot access %s: %w", path, err)
+	}
+	return path, nil, nil
+}

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -54,6 +54,9 @@ func main() {
 		case "token-use":
 			runTokenUse(os.Args[2:])
 			return
+		case "import":
+			runImport(os.Args[2:])
+			return
 		case "version", "--version", "-v":
 			fmt.Printf("agentsview %s (commit %s, built %s)\n",
 				version, commit, buildDate)
@@ -83,6 +86,8 @@ Usage:
   agentsview pg serve [flags] Serve from PostgreSQL (read-only)
   agentsview token-use <id>   Show token usage for a session (JSON)
   agentsview prune [flags]    Delete sessions matching filters
+  agentsview import --type <type> <path>
+                          Import conversations (claude-ai, chatgpt)
   agentsview update [flags]   Check for and install updates
   agentsview version          Show version information
   agentsview help             Show this help
@@ -214,27 +219,30 @@ func runServe(args []string) {
 	)
 	defer stop()
 
-	engine := sync.NewEngine(database, sync.EngineConfig{
-		AgentDirs:               cfg.AgentDirs,
-		Machine:                 "local",
-		BlockedResultCategories: cfg.ResultContentBlockedCategories,
-	})
+	var engine *sync.Engine
+	if !cfg.NoSync {
+		engine = sync.NewEngine(database, sync.EngineConfig{
+			AgentDirs:               cfg.AgentDirs,
+			Machine:                 "local",
+			BlockedResultCategories: cfg.ResultContentBlockedCategories,
+		})
 
-	if database.NeedsResync() {
-		runInitialResync(ctx, engine)
-	} else {
-		runInitialSync(ctx, engine)
-	}
-	if ctx.Err() != nil {
-		return
-	}
+		if database.NeedsResync() {
+			runInitialResync(ctx, engine)
+		} else {
+			runInitialSync(ctx, engine)
+		}
+		if ctx.Err() != nil {
+			return
+		}
 
-	stopWatcher, unwatchedDirs := startFileWatcher(cfg, engine)
-	defer stopWatcher()
+		stopWatcher, unwatchedDirs := startFileWatcher(cfg, engine)
+		defer stopWatcher()
 
-	go startPeriodicSync(engine)
-	if len(unwatchedDirs) > 0 {
-		go startUnwatchedPoll(engine)
+		go startPeriodicSync(engine)
+		if len(unwatchedDirs) > 0 {
+			go startUnwatchedPoll(engine)
+		}
 	}
 
 	// Auto-bind to 0.0.0.0 when remote access is enabled so the
@@ -314,6 +322,7 @@ func runServe(args []string) {
 			time.Since(start).Round(time.Millisecond),
 		)
 	}
+	fmt.Printf("Database: %s\n", cfg.DBPath)
 
 	if err := waitForServerRuntime(ctx, srv, rt); err != nil {
 		fatal("%v", err)

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -922,6 +922,46 @@ export async function emptyTrash(): Promise<{ deleted: number }> {
   return fetchJSON("/trash", { method: "DELETE" });
 }
 
+/* Import */
+
+export async function importClaudeAI(
+  file: File,
+): Promise<{ imported: number; updated: number; errors: number }> {
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch(
+    `${getBase()}/import/claude-ai`,
+    authHeaders({ method: "POST", body: form }),
+  );
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(
+      (err as { error?: string }).error
+      ?? `Import failed (${res.status})`,
+    );
+  }
+  return res.json();
+}
+
+export async function importChatGPT(
+  file: File,
+): Promise<{ imported: number; updated: number; skipped: number; errors: number }> {
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch(
+    `${getBase()}/import/chatgpt`,
+    authHeaders({ method: "POST", body: form }),
+  );
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(
+      (err as { error?: string }).error
+      ?? `Import failed (${res.status})`,
+    );
+  }
+  return res.json();
+}
+
 /* Pins */
 
 export function listPins(): Promise<PinsResponse> {

--- a/frontend/src/lib/components/import/ImportModal.svelte
+++ b/frontend/src/lib/components/import/ImportModal.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  import { importClaudeAI, importChatGPT } from "../../api/client.js";
+
+  interface Props {
+    open: boolean;
+    onclose: () => void;
+    onimported: () => void;
+  }
+
+  let { open = $bindable(), onclose, onimported }: Props = $props();
+
+  let fileInput: HTMLInputElement | undefined = $state();
+  let selectedFile: File | null = $state(null);
+  let provider: "claude-ai" | "chatgpt" = $state("claude-ai");
+  let importing = $state(false);
+  let result: {
+    imported: number;
+    updated: number;
+    skipped?: number;
+    errors: number;
+  } | null = $state(null);
+  let error: string | null = $state(null);
+
+  // Reset file selection when provider changes.
+  $effect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    provider;
+    selectedFile = null;
+    result = null;
+    error = null;
+    if (fileInput) fileInput.value = "";
+  });
+
+  function handleFileChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    selectedFile = input.files?.[0] ?? null;
+    result = null;
+    error = null;
+  }
+
+  async function handleImport() {
+    if (importing || !selectedFile) return;
+    importing = true;
+    error = null;
+    result = null;
+
+    try {
+      if (provider === "chatgpt") {
+        result = await importChatGPT(selectedFile);
+      } else {
+        const r = await importClaudeAI(selectedFile);
+        result = { ...r, skipped: 0 };
+      }
+      onimported();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Import failed";
+    } finally {
+      importing = false;
+    }
+  }
+
+  function handleClose() {
+    if (importing) return;
+    selectedFile = null;
+    result = null;
+    error = null;
+    open = false;
+    onclose();
+  }
+</script>
+
+{#if open}
+  <div class="modal-backdrop" role="presentation" onkeydown={(e) => e.key === "Escape" && handleClose()} onclick={handleClose}>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <!-- svelte-ignore a11y_interactive_supports_focus -->
+    <div class="modal" role="dialog" aria-modal="true" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.key === "Escape" && handleClose()}>
+      <h3>Import Conversations</h3>
+
+      <div class="provider-select">
+        <label>
+          <input type="radio" bind:group={provider} value="claude-ai" disabled={importing} />
+          Claude.ai
+        </label>
+        <label>
+          <input type="radio" bind:group={provider} value="chatgpt" disabled={importing} />
+          ChatGPT
+        </label>
+      </div>
+
+      <p class="instructions">
+        {#if provider === "claude-ai"}
+          Upload <code>conversations.json</code> or a <code>.zip</code> from a Claude.ai data export.
+        {:else}
+          Upload a <code>.zip</code> from a ChatGPT data export.
+        {/if}
+      </p>
+
+      <input
+        bind:this={fileInput}
+        type="file"
+        accept={provider === "claude-ai" ? ".json,.zip" : ".zip"}
+        onchange={handleFileChange}
+        disabled={importing}
+      />
+
+      {#if error}
+        <p class="error">{error}</p>
+      {/if}
+
+      {#if result}
+        <p class="success">
+          {result.imported + result.updated + (result.skipped ?? 0)} conversations processed
+          ({result.imported} new{#if result.updated > 0}, {result.updated} updated{/if}{#if (result.skipped ?? 0) > 0}, {result.skipped} skipped{/if})
+          {#if result.errors > 0}
+            , {result.errors} errors
+          {/if}
+        </p>
+      {/if}
+
+      <div class="actions">
+        <button onclick={handleClose} disabled={importing}>
+          {result ? "Close" : "Cancel"}
+        </button>
+        {#if !result}
+          <button
+            class="primary"
+            onclick={handleImport}
+            disabled={!selectedFile || importing}
+          >
+            {importing ? "Importing..." : "Import"}
+          </button>
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .modal {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 8px;
+    padding: 1.5rem;
+    max-width: 28rem;
+    width: 90%;
+  }
+
+  h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+  }
+
+  .provider-select {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .provider-select label {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+
+  .instructions {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin: 0 0 1rem;
+  }
+
+  code {
+    background: var(--bg-secondary);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    font-size: 0.85em;
+  }
+
+  input[type="file"] {
+    width: 100%;
+    margin-bottom: 1rem;
+  }
+
+  .error {
+    color: var(--accent-red, #e53e3e);
+    font-size: 0.85rem;
+    margin: 0 0 1rem;
+  }
+
+  .success {
+    color: var(--accent-green, #38a169);
+    font-size: 0.85rem;
+    margin: 0 0 1rem;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+  }
+
+  button {
+    padding: 0.4rem 1rem;
+    border: 1px solid var(--border-primary);
+    border-radius: 4px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+
+  button.primary {
+    background: var(--accent-blue);
+    color: white;
+    border-color: var(--accent-blue);
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -10,10 +10,12 @@
   import { router } from "../../stores/router.svelte.js";
   import { downloadExport } from "../../api/client.js";
   import ProjectTypeahead from "./ProjectTypeahead.svelte";
+  import ImportModal from "../import/ImportModal.svelte";
 
   const isMac = navigator.platform.toUpperCase().includes("MAC");
   const modKey = isMac ? "Cmd" : "Ctrl";
 
+  let showImportModal = $state(false);
   let showBlockFilter = $state(false);
   let showOverflow = $state(false);
   let filterBtnRef: HTMLButtonElement | undefined =
@@ -422,6 +424,18 @@
       </svg>
     </button>
 
+    <button
+      class="header-btn"
+      onclick={() => showImportModal = true}
+      title="Import conversations"
+      aria-label="Import conversations"
+    >
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+        <path d="M2.75 14A1.75 1.75 0 011 12.25v-2.5a.75.75 0 011.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0113.25 14H2.75z"/>
+        <path d="M11.78 4.72a.75.75 0 00-1.06 0L8.75 6.69V1.5a.75.75 0 00-1.5 0v5.19L5.28 4.72a.75.75 0 00-1.06 1.06l3.25 3.25a.75.75 0 001.06 0l3.25-3.25a.75.75 0 000-1.06z"/>
+      </svg>
+    </button>
+
     <span class="header-divider"></span>
 
     <button
@@ -462,6 +476,15 @@
     </button>
   </div>
 </header>
+
+<ImportModal
+  bind:open={showImportModal}
+  onclose={() => showImportModal = false}
+  onimported={() => {
+    sessions.invalidateFilterCaches();
+    sessions.load();
+  }}
+/>
 
 <style>
   .header {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -9,7 +9,7 @@
     type Opener,
   } from "../../api/client.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
-  import { agentColor } from "../../utils/agents.js";
+  import { agentColor, agentLabel } from "../../utils/agents.js";
   import { formatTokenUsage } from "../../utils/format.js";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { router } from "../../stores/router.svelte.js";
@@ -302,7 +302,7 @@
     canResume ||
     editorOpeners.length > 0 ||
     fileOpeners.length > 0 ||
-    sessionDir !== null,
+    (sessionDir !== null && !!session?.file_path),
   );
 
   function handleKeydown(e: KeyboardEvent) {
@@ -381,7 +381,7 @@
       <span
         class="agent-badge"
         style:background={agentColor(session.agent)}
-      >{session.agent}</span>
+      >{agentLabel(session.agent)}</span>
       {#if session.started_at}
         <span class="session-time">
           {new Date(session.started_at).toLocaleDateString(

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -3,7 +3,7 @@
   import { sessions, isRecentlyActive } from "../../stores/sessions.svelte.js";
   import { starred } from "../../stores/starred.svelte.js";
   import { formatRelativeTime, truncate } from "../../utils/format.js";
-  import { agentColor as getAgentColor } from "../../utils/agents.js";
+  import { agentColor as getAgentColor, agentLabel } from "../../utils/agents.js";
 
   interface Props {
     session: Session;
@@ -334,7 +334,7 @@
   {#if !compact && (!hideAgent || showMachine)}
     <div class="side-meta">
       {#if !hideAgent}
-        <span class="agent-tag" style:color={agentColor}>{session.agent}</span>
+        <span class="agent-tag" style:color={agentColor}>{agentLabel(session.agent)}</span>
       {/if}
       {#if showMachine}
         <span class="machine-tag" title={session.machine}>

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -26,6 +26,8 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   },
   { name: "iflow", color: "var(--accent-sky)", label: "iFlow" },
   { name: "kimi", color: "var(--accent-pink)", label: "Kimi" },
+  { name: "claude-ai", color: "var(--accent-violet)", label: "Claude.ai" },
+  { name: "chatgpt", color: "var(--accent-lime)", label: "ChatGPT" },
 ];
 
 const agentColorMap = new Map(

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -9,15 +9,33 @@ const parser = new Marked({
 
 const cache = new LRUCache<string, string>(6000);
 
+function getApiBase(): string {
+  const baseEl = document.querySelector("base[href]");
+  if (baseEl) {
+    const base = new URL(document.baseURI).pathname.replace(/\/$/, "");
+    return `${base}/api/v1`;
+  }
+  return "/api/v1";
+}
+
+function resolveAssetURLs(text: string): string {
+  return text.replace(
+    /asset:\/\/([^\s)]+)/g,
+    `${getApiBase()}/assets/$1`,
+  );
+}
+
 export function renderMarkdown(text: string): string {
   if (!text) return "";
 
   const cached = cache.get(text);
   if (cached !== undefined) return cached;
 
+  const resolved = resolveAssetURLs(text);
+
   // Trim trailing whitespace — with breaks:true, trailing
   // newlines become <br> tags that add invisible height.
-  const html = parser.parse(text.trimEnd()) as string;
+  const html = parser.parse(resolved.trimEnd()) as string;
   const safe = DOMPurify.sanitize(html);
 
   cache.set(text, safe);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,7 @@ type Config struct {
 	AuthToken            string         `json:"auth_token,omitempty" toml:"auth_token"`
 	RemoteAccess         bool           `json:"remote_access" toml:"remote_access"`
 	NoBrowser            bool           `json:"no_browser" toml:"no_browser"`
+	NoSync               bool           `json:"-" toml:"-"`
 	PG                   PGConfig       `json:"pg,omitempty" toml:"pg"`
 	WriteTimeout         time.Duration  `json:"-" toml:"-"`
 
@@ -534,6 +535,10 @@ func RegisterServeFlags(fs *flag.FlagSet) {
 		"no-browser", false,
 		"Don't open browser on startup",
 	)
+	fs.Bool(
+		"no-sync", false,
+		"Skip initial sync and disable background sync/file watching",
+	)
 }
 
 // applyFlags copies explicitly-set flags from fs into cfg.
@@ -569,6 +574,8 @@ func applyFlags(cfg *Config, fs *flag.FlagSet) {
 			cfg.Proxy.AllowedSubnets = splitFlagList(f.Value.String())
 		case "no-browser":
 			cfg.NoBrowser = f.Value.String() == "true"
+		case "no-sync":
+			cfg.NoSync = f.Value.String() == "true"
 		}
 	})
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -558,7 +558,7 @@ func (db *DB) UpsertSession(s Session) error {
 
 	_, err := db.getWriter().Exec(`
 		INSERT INTO sessions (
-			id, project, machine, agent, first_message,
+			id, project, machine, agent, first_message, display_name,
 			started_at, ended_at, message_count,
 			user_message_count, parent_session_id,
 			relationship_type,
@@ -566,7 +566,7 @@ func (db *DB) UpsertSession(s Session) error {
 			has_total_output_tokens, has_peak_context_tokens,
 			is_automated,
 			file_path, file_size, file_mtime, file_hash
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project,
 			machine = excluded.machine,
@@ -587,7 +587,7 @@ func (db *DB) UpsertSession(s Session) error {
 			file_size = excluded.file_size,
 			file_mtime = excluded.file_mtime,
 			file_hash = excluded.file_hash`,
-		s.ID, s.Project, s.Machine, s.Agent, s.FirstMessage,
+		s.ID, s.Project, s.Machine, s.Agent, s.FirstMessage, s.DisplayName,
 		s.StartedAt, s.EndedAt, s.MessageCount,
 		s.UserMessageCount, s.ParentSessionID,
 		s.RelationshipType,

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUpsertSession_DisplayNameInsertOnly(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	displayName := "My Chat Title"
+	err := d.UpsertSession(Session{
+		ID:           "claude-ai:dn-test",
+		Project:      "claude.ai",
+		Machine:      "local",
+		Agent:        "claude-ai",
+		DisplayName:  &displayName,
+		MessageCount: 1,
+	})
+	requireNoError(t, err, "UpsertSession insert")
+
+	// Verify display_name was set.
+	s, err := d.GetSession(ctx, "claude-ai:dn-test")
+	requireNoError(t, err, "GetSession after insert")
+	if s == nil {
+		t.Fatal("GetSession returned nil after insert")
+	}
+	if s.DisplayName == nil {
+		t.Fatal("DisplayName is nil after insert, want non-nil")
+	}
+	if *s.DisplayName != "My Chat Title" {
+		t.Errorf("DisplayName = %q, want %q", *s.DisplayName, "My Chat Title")
+	}
+
+	// Re-upsert with a different display_name.
+	newName := "Updated Title"
+	err = d.UpsertSession(Session{
+		ID:           "claude-ai:dn-test",
+		Project:      "claude.ai",
+		Machine:      "local",
+		Agent:        "claude-ai",
+		DisplayName:  &newName,
+		MessageCount: 2,
+	})
+	requireNoError(t, err, "UpsertSession update")
+
+	// display_name should NOT be overwritten by re-upsert.
+	s, err = d.GetSession(ctx, "claude-ai:dn-test")
+	requireNoError(t, err, "GetSession after re-upsert")
+	if s == nil {
+		t.Fatal("GetSession returned nil after re-upsert")
+	}
+	if s.DisplayName == nil {
+		t.Fatal("DisplayName is nil after re-upsert, want non-nil")
+	}
+	if *s.DisplayName != "My Chat Title" {
+		t.Errorf(
+			"DisplayName = %q after re-upsert, want %q (should be preserved)",
+			*s.DisplayName, "My Chat Title",
+		)
+	}
+	// But other fields should update.
+	if s.MessageCount != 2 {
+		t.Errorf("MessageCount = %d, want 2", s.MessageCount)
+	}
+}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -3,6 +3,9 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/wesm/agentsview/internal/parser"
 )
 
 // Stats holds database-wide statistics.
@@ -20,18 +23,37 @@ const rootSessionFilter = `message_count > 0
 	AND relationship_type NOT IN ('subagent', 'fork')
 	AND deleted_at IS NULL`
 
+func nonFileAgentPlaceholders() string {
+	agents := parser.NonFileBackedAgents()
+	placeholders := make([]string, len(agents))
+	for i := range agents {
+		placeholders[i] = "?"
+	}
+	return strings.Join(placeholders, ", ")
+}
+
+func nonFileAgentArgs() []any {
+	agents := parser.NonFileBackedAgents()
+	args := make([]any, len(agents))
+	for i, a := range agents {
+		args[i] = string(a)
+	}
+	return args
+}
+
 // FileBackedSessionCount returns the number of root sessions
-// synced from files (excludes OpenCode, which is DB-backed).
-// Used by ResyncAll to decide whether empty file discovery
-// should abort the swap.
+// synced from files (excludes non-file-backed agents like
+// OpenCode and Claude.ai). Used by ResyncAll to decide
+// whether empty file discovery should abort the swap.
 func (db *DB) FileBackedSessionCount(
 	ctx context.Context,
 ) (int, error) {
 	var count int
 	err := db.getReader().QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM sessions
-		 WHERE agent != 'opencode'
+		 WHERE agent NOT IN (`+nonFileAgentPlaceholders()+`)
 		 AND `+rootSessionFilter,
+		nonFileAgentArgs()...,
 	).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf(

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFileBackedSessionCount_ExcludesNonFileAgents(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	// Insert a claude-ai session (non-file-backed).
+	insertSession(t, d, "claude-ai:test-1", "claude.ai",
+		func(s *Session) { s.Agent = "claude-ai" })
+
+	// Insert an opencode session (non-file-backed).
+	insertSession(t, d, "opencode:test-1", "myproject",
+		func(s *Session) { s.Agent = "opencode" })
+
+	// Insert a claude session (file-backed).
+	insertSession(t, d, "test-file-session", "myproject")
+
+	count, err := d.FileBackedSessionCount(ctx)
+	requireNoError(t, err, "FileBackedSessionCount")
+	if count != 1 {
+		t.Errorf(
+			"FileBackedSessionCount = %d, want 1 "+
+				"(only claude session)", count,
+		)
+	}
+}

--- a/internal/importer/assets.go
+++ b/internal/importer/assets.go
@@ -1,0 +1,177 @@
+package importer
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// AssetIndex maps asset pointer prefixes to file paths on disk.
+type AssetIndex struct {
+	entries map[string]string
+}
+
+// BuildAssetIndex scans an export directory for image assets.
+// ChatGPT exports store images in three locations:
+//   - dalle-generations/ (DALL-E outputs)
+//   - user-*/ directories (user uploads via sediment://)
+//   - root directory as file-* (user uploads via file-service://)
+func BuildAssetIndex(exportDir string) AssetIndex {
+	idx := AssetIndex{entries: make(map[string]string)}
+
+	// DALL-E generated images.
+	dalleDir := filepath.Join(exportDir, "dalle-generations")
+	scanAssetDir(dalleDir, idx.entries)
+
+	// User uploads in user-*/ subdirectories.
+	matches, _ := filepath.Glob(filepath.Join(exportDir, "user-*"))
+	for _, m := range matches {
+		info, err := os.Stat(m)
+		if err == nil && info.IsDir() {
+			scanAssetDir(m, idx.entries)
+		}
+	}
+
+	// User uploads as loose file-* in the root directory.
+	scanAssetFiles(exportDir, idx.entries)
+
+	return idx
+}
+
+func scanAssetDir(dir string, entries map[string]string) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		name := f.Name()
+		prefix := extractAssetPrefix(name)
+		if prefix != "" {
+			entries[prefix] = filepath.Join(dir, name)
+		}
+	}
+}
+
+// scanAssetFiles indexes only file-* and file_* entries in a
+// directory. Used for the root dir where non-asset files exist.
+func scanAssetFiles(dir string, entries map[string]string) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		name := f.Name()
+		if !strings.HasPrefix(name, "file-") &&
+			!strings.HasPrefix(name, "file_") {
+			continue
+		}
+		prefix := extractAssetPrefix(name)
+		if prefix != "" {
+			entries[prefix] = filepath.Join(dir, name)
+		}
+	}
+}
+
+// extractAssetPrefix gets the stable prefix from filenames like
+// "file-abc123-aaaa-bbbb-cccc-dddddddddddd.webp"
+func extractAssetPrefix(name string) string {
+	base := strings.TrimSuffix(name, filepath.Ext(name))
+	// UUID is 36 chars at end, preceded by hyphen = 37 chars total
+	if len(base) > 37 && base[len(base)-37] == '-' {
+		return base[:len(base)-37]
+	}
+	return base
+}
+
+// Resolve maps an asset pointer URL to a file path.
+func (idx AssetIndex) Resolve(pointer string) (string, bool) {
+	var prefix string
+	switch {
+	case strings.HasPrefix(pointer, "file-service://"):
+		prefix = strings.TrimPrefix(pointer, "file-service://")
+	case strings.HasPrefix(pointer, "sediment://"):
+		prefix = strings.TrimPrefix(pointer, "sediment://")
+	default:
+		return "", false
+	}
+	path, ok := idx.entries[prefix]
+	return path, ok
+}
+
+// allowedImageExts is the set of passive image formats that
+// are safe to serve inline. Active content (svg, html, js) is
+// rejected to prevent stored XSS.
+var allowedImageExts = map[string]bool{
+	".png":  true,
+	".jpg":  true,
+	".jpeg": true,
+	".webp": true,
+	".gif":  true,
+}
+
+// CopyAsset copies a file to the assets directory using its
+// SHA-256 hash as the filename. Returns the asset:// reference.
+// Only passive image types are accepted; active content is
+// rejected.
+func CopyAsset(srcPath, assetsDir string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(srcPath))
+	if !allowedImageExts[ext] {
+		return "", fmt.Errorf(
+			"unsupported asset type: %s", ext,
+		)
+	}
+
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return "", fmt.Errorf("reading asset: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hashing asset: %w", err)
+	}
+
+	hash := fmt.Sprintf("%x", h.Sum(nil))
+	filename := hash + ext
+	destPath := filepath.Join(assetsDir, filename)
+
+	if _, err := os.Stat(destPath); err == nil {
+		return "asset://" + filename, nil
+	}
+
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating assets dir: %w", err)
+	}
+
+	// Re-read source for copy (we consumed it for hashing).
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return "", fmt.Errorf("reopening asset: %w", err)
+	}
+	defer src.Close()
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return "", fmt.Errorf("writing asset: %w", err)
+	}
+
+	if _, err := io.Copy(out, src); err != nil {
+		out.Close()
+		return "", fmt.Errorf("copying asset: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return "", fmt.Errorf("closing asset: %w", err)
+	}
+
+	return "asset://" + filename, nil
+}

--- a/internal/importer/assets_test.go
+++ b/internal/importer/assets_test.go
@@ -1,0 +1,62 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAssetIndex(t *testing.T) {
+	dir := t.TempDir()
+
+	dalleDir := filepath.Join(dir, "dalle-generations")
+	require.NoError(t, os.MkdirAll(dalleDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dalleDir, "file-abc123-aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee.webp"),
+		[]byte("fake image"), 0o644,
+	))
+
+	userDir := filepath.Join(dir, "user-xyz")
+	require.NoError(t, os.MkdirAll(userDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(userDir, "file_deadbeef-aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee.png"),
+		[]byte("fake upload"), 0o644,
+	))
+
+	idx := BuildAssetIndex(dir)
+
+	path, ok := idx.Resolve("file-service://file-abc123")
+	assert.True(t, ok)
+	assert.Contains(t, path, "file-abc123")
+
+	path, ok = idx.Resolve("sediment://file_deadbeef")
+	assert.True(t, ok)
+	assert.Contains(t, path, "file_deadbeef")
+
+	_, ok = idx.Resolve("file-service://file-unknown")
+	assert.False(t, ok)
+}
+
+func TestCopyAsset(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "source.webp")
+	require.NoError(t, os.WriteFile(src, []byte("image data"), 0o644))
+
+	assetsDir := filepath.Join(t.TempDir(), "assets")
+
+	ref, err := CopyAsset(src, assetsDir)
+	require.NoError(t, err)
+	assert.Contains(t, ref, "asset://")
+	assert.Contains(t, ref, ".webp")
+
+	// Second call should return same ref (dedup).
+	ref2, err := CopyAsset(src, assetsDir)
+	require.NoError(t, err)
+	assert.Equal(t, ref, ref2)
+
+	entries, err := os.ReadDir(assetsDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1,0 +1,322 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"time"
+
+	"github.com/wesm/agentsview/internal/db"
+	"github.com/wesm/agentsview/internal/parser"
+)
+
+// ImportStats reports the outcome of an import operation.
+type ImportStats struct {
+	Imported int `json:"imported"`
+	Updated  int `json:"updated"`
+	Skipped  int `json:"skipped"`
+	Errors   int `json:"errors"`
+}
+
+// ImportClaudeAI reads a Claude.ai conversations.json export
+// and upserts each conversation into the store. Existing
+// sessions are updated (messages replaced); user-renamed
+// display names are preserved. Excluded (deleted) sessions
+// are counted as skipped.
+func ImportClaudeAI(
+	ctx context.Context,
+	store db.Store,
+	r io.Reader,
+	onProgress func(imported int),
+) (ImportStats, error) {
+	var stats ImportStats
+
+	err := parser.ParseClaudeAIExport(r, func(
+		result parser.ParseResult,
+	) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		status, err := upsertConversation(ctx, store, result)
+		if err != nil {
+			stats.Errors++
+			log.Printf(
+				"import: skipping %s: %v",
+				result.Session.ID, err,
+			)
+			return nil
+		}
+
+		switch status {
+		case importNew:
+			stats.Imported++
+		case importUpdated:
+			stats.Updated++
+		case importSkipped:
+			stats.Skipped++
+		}
+
+		if onProgress != nil {
+			total := stats.Imported + stats.Updated + stats.Skipped
+			onProgress(total)
+		}
+
+		return nil
+	})
+
+	return stats, err
+}
+
+type importStatus int
+
+const (
+	importNew importStatus = iota
+	importUpdated
+	importSkipped
+)
+
+func upsertConversation(
+	ctx context.Context,
+	store db.Store,
+	result parser.ParseResult,
+) (importStatus, error) {
+	s := result.Session
+
+	existing, err := store.GetSession(ctx, s.ID)
+	if err != nil {
+		return importNew, fmt.Errorf("checking session: %w", err)
+	}
+	isNew := existing == nil
+
+	// Preserve user-renamed display_name on re-import.
+	displayName := strPtr(s.DisplayName)
+	if !isNew && existing.DisplayName != nil {
+		importName := strPtr(s.DisplayName)
+		nameChanged := importName == nil ||
+			*existing.DisplayName != *importName
+		if nameChanged {
+			displayName = existing.DisplayName
+		}
+	}
+
+	sess := db.Session{
+		ID:               s.ID,
+		Project:          s.Project,
+		Machine:          s.Machine,
+		Agent:            string(s.Agent),
+		FirstMessage:     strPtr(s.FirstMessage),
+		DisplayName:      displayName,
+		StartedAt:        timeStr(s.StartedAt),
+		EndedAt:          timeStr(s.EndedAt),
+		MessageCount:     s.MessageCount,
+		UserMessageCount: s.UserMessageCount,
+	}
+
+	if err := store.UpsertSession(sess); err != nil {
+		if errors.Is(err, db.ErrSessionExcluded) {
+			return importSkipped, nil
+		}
+		return importNew, fmt.Errorf("upserting session: %w", err)
+	}
+
+	msgs := make([]db.Message, len(result.Messages))
+	for i, m := range result.Messages {
+		msgs[i] = db.Message{
+			SessionID:     s.ID,
+			Ordinal:       m.Ordinal,
+			Role:          string(m.Role),
+			Content:       m.Content,
+			Timestamp:     m.Timestamp.UTC().Format(time.RFC3339Nano),
+			ContentLength: m.ContentLength,
+		}
+	}
+
+	if err := store.ReplaceSessionMessages(s.ID, msgs); err != nil {
+		return importNew, fmt.Errorf("replacing messages: %w", err)
+	}
+
+	if isNew {
+		return importNew, nil
+	}
+	return importUpdated, nil
+}
+
+// assetResolverAdapter bridges the importer's AssetIndex / CopyAsset
+// pair to the parser.AssetResolver interface.
+type assetResolverAdapter struct {
+	index     AssetIndex
+	assetsDir string
+}
+
+func (a *assetResolverAdapter) Resolve(
+	pointer string,
+) (string, bool) {
+	return a.index.Resolve(pointer)
+}
+
+func (a *assetResolverAdapter) Copy(
+	srcPath string,
+) (string, error) {
+	return CopyAsset(srcPath, a.assetsDir)
+}
+
+// ImportChatGPT reads a ChatGPT export directory (containing
+// conversations-*.json files) and imports each conversation into
+// the store. Existing sessions are skipped to preserve archived
+// data.
+func ImportChatGPT(
+	ctx context.Context,
+	store db.Store,
+	dir string,
+	assetsDir string,
+	onProgress func(processed int),
+) (ImportStats, error) {
+	var stats ImportStats
+
+	index := BuildAssetIndex(dir)
+	resolver := &assetResolverAdapter{
+		index:     index,
+		assetsDir: assetsDir,
+	}
+
+	err := parser.ParseChatGPTExport(dir, resolver,
+		func(result parser.ParseResult) error {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			s := result.Session
+
+			existing, err := store.GetSession(ctx, s.ID)
+			if err != nil {
+				stats.Errors++
+				log.Printf(
+					"import: skipping %s: %v", s.ID, err,
+				)
+				return nil
+			}
+			if existing != nil {
+				stats.Skipped++
+				if onProgress != nil {
+					onProgress(stats.Imported + stats.Skipped)
+				}
+				return nil
+			}
+
+			sess := db.Session{
+				ID:               s.ID,
+				Project:          s.Project,
+				Machine:          s.Machine,
+				Agent:            string(s.Agent),
+				FirstMessage:     strPtr(s.FirstMessage),
+				DisplayName:      strPtr(s.DisplayName),
+				StartedAt:        timeStr(s.StartedAt),
+				EndedAt:          timeStr(s.EndedAt),
+				MessageCount:     s.MessageCount,
+				UserMessageCount: s.UserMessageCount,
+			}
+
+			if err := store.UpsertSession(sess); err != nil {
+				if errors.Is(err, db.ErrSessionExcluded) {
+					stats.Skipped++
+					if onProgress != nil {
+						onProgress(stats.Imported + stats.Skipped)
+					}
+					return nil
+				}
+				stats.Errors++
+				log.Printf(
+					"import: skipping %s: %v", s.ID, err,
+				)
+				return nil
+			}
+
+			msgs := make([]db.Message, len(result.Messages))
+			for i, m := range result.Messages {
+				msgs[i] = db.Message{
+					SessionID: s.ID,
+					Ordinal:   m.Ordinal,
+					Role:      string(m.Role),
+					Content:   m.Content,
+					Timestamp: m.Timestamp.UTC().Format(
+						time.RFC3339Nano,
+					),
+					HasThinking:   m.HasThinking,
+					HasToolUse:    m.HasToolUse,
+					ContentLength: m.ContentLength,
+					IsSystem:      m.IsSystem,
+					Model:         m.Model,
+					ToolCalls: convertToolCalls(
+						s.ID, m.ToolCalls,
+					),
+				}
+			}
+
+			if err := store.ReplaceSessionMessages(
+				s.ID, msgs,
+			); err != nil {
+				stats.Errors++
+				log.Printf(
+					"import: skipping messages for %s: %v",
+					s.ID, err,
+				)
+				return nil
+			}
+
+			stats.Imported++
+			if onProgress != nil {
+				onProgress(stats.Imported + stats.Skipped)
+			}
+			return nil
+		},
+	)
+
+	return stats, err
+}
+
+func strPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func timeStr(t time.Time) *string {
+	if t.IsZero() {
+		return nil
+	}
+	s := t.UTC().Format(time.RFC3339Nano)
+	return &s
+}
+
+func convertToolCalls(
+	sessionID string, parsed []parser.ParsedToolCall,
+) []db.ToolCall {
+	if len(parsed) == 0 {
+		return nil
+	}
+	calls := make([]db.ToolCall, len(parsed))
+	for i, tc := range parsed {
+		calls[i] = db.ToolCall{
+			SessionID: sessionID,
+			ToolName:  tc.ToolName,
+			Category:  tc.Category,
+			ToolUseID: tc.ToolUseID,
+			InputJSON: tc.InputJSON,
+			SkillName: tc.SkillName,
+		}
+		// Map execution output from ResultEvents to
+		// ResultContent for display in the UI.
+		for _, ev := range tc.ResultEvents {
+			if ev.Content != "" {
+				calls[i].ResultContent = ev.Content
+				calls[i].ResultContentLength = len(ev.Content)
+				break
+			}
+		}
+	}
+	return calls
+}

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -1,0 +1,191 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+const testConversationsJSON = `[
+  {
+    "uuid": "import-test-001",
+    "name": "First Chat",
+    "summary": "",
+    "created_at": "2026-02-01T09:00:00.000000Z",
+    "updated_at": "2026-02-01T09:15:00.000000Z",
+    "account": {"uuid": "acct-1"},
+    "chat_messages": [
+      {
+        "uuid": "m1",
+        "text": "Hello",
+        "content": [{"type":"text","text":"Hello"}],
+        "sender": "human",
+        "created_at": "2026-02-01T09:00:00.000000Z",
+        "updated_at": "2026-02-01T09:00:00.000000Z",
+        "attachments": [],
+        "files": []
+      },
+      {
+        "uuid": "m2",
+        "text": "Hi there!",
+        "content": [{"type":"text","text":"Hi there!"}],
+        "sender": "assistant",
+        "created_at": "2026-02-01T09:00:05.000000Z",
+        "updated_at": "2026-02-01T09:00:05.000000Z",
+        "attachments": [],
+        "files": []
+      }
+    ]
+  }
+]`
+
+func testDB(t *testing.T) *db.DB {
+	t.Helper()
+	d, err := db.Open(t.TempDir() + "/test.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func TestImportClaudeAI(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	stats, err := ImportClaudeAI(
+		ctx, d, strings.NewReader(testConversationsJSON), nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Imported)
+	assert.Equal(t, 0, stats.Updated)
+
+	s, err := d.GetSession(ctx, "claude-ai:import-test-001")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, "claude.ai", s.Project)
+	assert.Equal(t, "claude-ai", s.Agent)
+	require.NotNil(t, s.DisplayName)
+	assert.Equal(t, "First Chat", *s.DisplayName)
+
+	msgs, err := d.GetAllMessages(ctx, "claude-ai:import-test-001")
+	require.NoError(t, err)
+	assert.Len(t, msgs, 2)
+}
+
+func TestImportClaudeAI_ReimportUpdatesMessages(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	_, err := ImportClaudeAI(
+		ctx, d, strings.NewReader(testConversationsJSON), nil,
+	)
+	require.NoError(t, err)
+
+	stats, err := ImportClaudeAI(
+		ctx, d, strings.NewReader(testConversationsJSON), nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.Imported)
+	assert.Equal(t, 1, stats.Updated)
+
+	msgs, err := d.GetAllMessages(
+		ctx, "claude-ai:import-test-001",
+	)
+	require.NoError(t, err)
+	assert.Len(t, msgs, 2)
+}
+
+func TestImportClaudeAI_PreservesDisplayNameOnReimport(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	_, err := ImportClaudeAI(
+		ctx, d, strings.NewReader(testConversationsJSON), nil,
+	)
+	require.NoError(t, err)
+
+	newName := "My Custom Name"
+	err = d.RenameSession(
+		"claude-ai:import-test-001", &newName,
+	)
+	require.NoError(t, err)
+
+	_, err = ImportClaudeAI(
+		ctx, d, strings.NewReader(testConversationsJSON), nil,
+	)
+	require.NoError(t, err)
+
+	s, err := d.GetSession(ctx, "claude-ai:import-test-001")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.NotNil(t, s.DisplayName)
+	assert.Equal(t, "My Custom Name", *s.DisplayName)
+}
+
+const testChatGPTConv = `[{
+  "id":"cg-1","conversation_id":"cg-1","title":"Test",
+  "create_time":1706745600.0,"update_time":1706745660.0,
+  "current_node":"n1","mapping":{
+    "r":{"id":"r","parent":null,"children":["n1"],
+         "message":null},
+    "n1":{"id":"n1","parent":"r","children":[],"message":{
+      "id":"m1","create_time":1706745600.0,
+      "author":{"role":"user","name":null,"metadata":{}},
+      "content":{"content_type":"text","parts":["Hello"]},
+      "status":"finished_successfully","metadata":{}}}
+  }
+}]`
+
+func TestImportChatGPT(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "conversations-000.json"),
+		[]byte(testChatGPTConv), 0o644,
+	))
+	assetsDir := filepath.Join(t.TempDir(), "assets")
+
+	stats, err := ImportChatGPT(
+		ctx, d, dir, assetsDir, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Imported)
+	assert.Equal(t, 0, stats.Skipped)
+
+	s, err := d.GetSession(ctx, "chatgpt:cg-1")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, "chatgpt.com", s.Project)
+}
+
+func TestImportChatGPT_SkipsExisting(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "conversations-000.json"),
+		[]byte(testChatGPTConv), 0o644,
+	))
+	assetsDir := filepath.Join(t.TempDir(), "assets")
+
+	_, err := ImportChatGPT(ctx, d, dir, assetsDir, nil)
+	require.NoError(t, err)
+
+	stats, err := ImportChatGPT(
+		ctx, d, dir, assetsDir, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.Imported)
+	assert.Equal(t, 1, stats.Skipped)
+}

--- a/internal/importer/zip.go
+++ b/internal/importer/zip.go
@@ -1,0 +1,71 @@
+package importer
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ExtractZip extracts a zip file to a temporary directory.
+// Returns the directory path and a cleanup function that
+// removes it. The caller must call cleanup when done.
+func ExtractZip(zipPath string) (string, func(), error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("opening zip %s: %w", zipPath, err)
+	}
+	defer r.Close()
+
+	dir, err := os.MkdirTemp("", "agentsview-import-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+	cleanup := func() { os.RemoveAll(dir) }
+
+	for _, f := range r.File {
+		if err := extractZipFile(dir, f); err != nil {
+			cleanup()
+			return "", nil, fmt.Errorf("extracting %s: %w", f.Name, err)
+		}
+	}
+
+	return dir, cleanup, nil
+}
+
+func extractZipFile(destDir string, f *zip.File) error {
+	dest := filepath.Join(destDir, f.Name)
+	if !strings.HasPrefix(
+		filepath.Clean(dest),
+		filepath.Clean(destDir)+string(os.PathSeparator),
+	) {
+		return fmt.Errorf("illegal path in zip: %s", f.Name)
+	}
+
+	if f.FileInfo().IsDir() {
+		return os.MkdirAll(dest, 0o755)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(out, rc); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/importer/zip_test.go
+++ b/internal/importer/zip_test.go
@@ -1,0 +1,52 @@
+package importer
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestZip(t *testing.T, files map[string]string) string {
+	t.Helper()
+	zipPath := filepath.Join(t.TempDir(), "test.zip")
+	f, err := os.Create(zipPath)
+	require.NoError(t, err)
+	w := zip.NewWriter(f)
+	for name, content := range files {
+		fw, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = fw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+	return zipPath
+}
+
+func TestExtractZip(t *testing.T) {
+	zipPath := createTestZip(t, map[string]string{
+		"conversations.json": `[{"uuid":"test"}]`,
+		"subdir/file.txt":    "hello",
+	})
+
+	dir, cleanup, err := ExtractZip(zipPath)
+	require.NoError(t, err)
+	defer cleanup()
+
+	data, err := os.ReadFile(filepath.Join(dir, "conversations.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "test")
+
+	data, err = os.ReadFile(filepath.Join(dir, "subdir", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(data))
+}
+
+func TestExtractZip_InvalidPath(t *testing.T) {
+	_, _, err := ExtractZip("/nonexistent.zip")
+	require.Error(t, err)
+}

--- a/internal/parser/chatgpt.go
+++ b/internal/parser/chatgpt.go
@@ -1,0 +1,518 @@
+// ABOUTME: Parses ChatGPT export archives (conversations-*.json)
+// ABOUTME: into structured session data with DAG linearization
+// ABOUTME: and content assembly for text, code, thinking, and tools.
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// AssetResolver resolves and copies image assets from exports.
+type AssetResolver interface {
+	Resolve(pointer string) (path string, ok bool)
+	Copy(srcPath string) (assetRef string, err error)
+}
+
+type chatGPTConversation struct {
+	ID          string                 `json:"conversation_id"`
+	RawID       string                 `json:"id"`
+	Title       string                 `json:"title"`
+	CreateTime  *float64               `json:"create_time"`
+	UpdateTime  *float64               `json:"update_time"`
+	CurrentNode string                 `json:"current_node"`
+	Mapping     map[string]chatGPTNode `json:"mapping"`
+}
+
+type chatGPTNode struct {
+	ID       string          `json:"id"`
+	Parent   *string         `json:"parent"`
+	Children []string        `json:"children"`
+	Message  *chatGPTMessage `json:"message"`
+}
+
+type chatGPTMessage struct {
+	ID         string         `json:"id"`
+	CreateTime *float64       `json:"create_time"`
+	Author     chatGPTAuthor  `json:"author"`
+	Content    chatGPTContent `json:"content"`
+	Status     string         `json:"status"`
+	Metadata   chatGPTMeta    `json:"metadata"`
+}
+
+type chatGPTAuthor struct {
+	Role string  `json:"role"`
+	Name *string `json:"name"`
+}
+
+type chatGPTContent struct {
+	ContentType string            `json:"content_type"`
+	Parts       []json.RawMessage `json:"parts"`
+	Text        string            `json:"text"`
+	Language    string            `json:"language"`
+	Thoughts    []chatGPTThought  `json:"thoughts"`
+	Title       string            `json:"title"`
+	URL         string            `json:"url"`
+}
+
+type chatGPTThought struct {
+	Content string `json:"content"`
+}
+
+type chatGPTMeta struct {
+	ModelSlug string `json:"model_slug"`
+}
+
+// ParseChatGPTExport reads all conversations-*.json files from dir
+// and calls onConversation for each non-empty conversation.
+func ParseChatGPTExport(
+	dir string,
+	assets AssetResolver,
+	onConversation func(ParseResult) error,
+) error {
+	// Support both numbered shards (conversations-000.json)
+	// and a single conversations.json file.
+	matches, err := filepath.Glob(
+		filepath.Join(dir, "conversations-*.json"),
+	)
+	if err != nil {
+		return fmt.Errorf("globbing conversations: %w", err)
+	}
+
+	single := filepath.Join(dir, "conversations.json")
+	if len(matches) == 0 {
+		if _, err := os.Stat(single); err == nil {
+			matches = []string{single}
+		}
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf(
+			"no conversation files found in %s", dir,
+		)
+	}
+
+	sort.Strings(matches)
+
+	for _, path := range matches {
+		if err := parseChatGPTFile(
+			path, assets, onConversation,
+		); err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+	}
+
+	return nil
+}
+
+func parseChatGPTFile(
+	path string,
+	assets AssetResolver,
+	onConversation func(ParseResult) error,
+) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	var convs []chatGPTConversation
+	if err := json.Unmarshal(data, &convs); err != nil {
+		return fmt.Errorf("decoding JSON: %w", err)
+	}
+
+	for _, conv := range convs {
+		if len(conv.Mapping) == 0 {
+			continue
+		}
+
+		result, ok := convertChatGPTConversation(conv, assets)
+		if !ok {
+			continue
+		}
+
+		if err := onConversation(result); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func convertChatGPTConversation(
+	conv chatGPTConversation,
+	assets AssetResolver,
+) (ParseResult, bool) {
+	// Fall back to id when conversation_id is empty.
+	convID := conv.ID
+	if convID == "" {
+		convID = conv.RawID
+	}
+	if convID == "" {
+		return ParseResult{}, false
+	}
+
+	nodes := linearizeDAG(conv.Mapping, conv.CurrentNode)
+
+	msgs, model := buildChatGPTMessages(nodes, assets)
+	if len(msgs) == 0 {
+		return ParseResult{}, false
+	}
+
+	var (
+		userCount int
+		firstMsg  string
+	)
+	for _, m := range msgs {
+		if m.Role == RoleUser && !m.IsSystem {
+			userCount++
+			if firstMsg == "" {
+				firstMsg = m.Content
+			}
+		}
+	}
+
+	// Backfill model onto assistant messages that lack one.
+	if model != "" {
+		for i := range msgs {
+			if msgs[i].Role == RoleAssistant &&
+				msgs[i].Model == "" {
+				msgs[i].Model = model
+			}
+		}
+	}
+
+	sess := ParsedSession{
+		ID:               "chatgpt:" + convID,
+		Project:          "chatgpt.com",
+		Machine:          "local",
+		Agent:            AgentChatGPT,
+		FirstMessage:     firstMsg,
+		DisplayName:      conv.Title,
+		StartedAt:        unixFloatToTime(conv.CreateTime),
+		EndedAt:          unixFloatToTime(conv.UpdateTime),
+		MessageCount:     len(msgs),
+		UserMessageCount: userCount,
+	}
+
+	return ParseResult{Session: sess, Messages: msgs}, true
+}
+
+// linearizeDAG walks parent pointers from currentNode to root,
+// then reverses to get chronological order.
+func linearizeDAG(
+	mapping map[string]chatGPTNode,
+	currentNode string,
+) []chatGPTNode {
+	if currentNode == "" {
+		return nil
+	}
+
+	var chain []chatGPTNode
+	nodeID := currentNode
+	for {
+		node, ok := mapping[nodeID]
+		if !ok {
+			break
+		}
+		chain = append(chain, node)
+		if node.Parent == nil || *node.Parent == "" {
+			break
+		}
+		nodeID = *node.Parent
+	}
+
+	// Reverse to chronological order.
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
+	}
+
+	return chain
+}
+
+// buildChatGPTMessages walks linearized nodes and produces
+// ParsedMessages. Tool nodes are attached to the preceding
+// assistant message. Returns messages and the last model seen.
+func buildChatGPTMessages(
+	nodes []chatGPTNode,
+	assets AssetResolver,
+) ([]ParsedMessage, string) {
+	var (
+		msgs       []ParsedMessage
+		lastModel  string
+		lastAsstID = -1
+		ordinal    int
+	)
+
+	for _, node := range nodes {
+		if node.Message == nil {
+			continue
+		}
+		msg := node.Message
+		role := msg.Author.Role
+		content := assembleContent(msg.Content, assets)
+
+		if msg.Metadata.ModelSlug != "" {
+			lastModel = msg.Metadata.ModelSlug
+		}
+
+		switch role {
+		case "user":
+			pm := ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleUser,
+				Content:       content,
+				Timestamp:     unixFloatToTime(msg.CreateTime),
+				ContentLength: len(content),
+			}
+			msgs = append(msgs, pm)
+			lastAsstID = -1
+			ordinal++
+
+		case "assistant":
+			hasThinking := msg.Content.ContentType == "thoughts"
+			pm := ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleAssistant,
+				Content:       content,
+				Timestamp:     unixFloatToTime(msg.CreateTime),
+				HasThinking:   hasThinking,
+				ContentLength: len(content),
+				Model:         msg.Metadata.ModelSlug,
+			}
+			msgs = append(msgs, pm)
+			lastAsstID = len(msgs) - 1
+			ordinal++
+
+		case "system":
+			pm := ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleAssistant,
+				Content:       content,
+				Timestamp:     unixFloatToTime(msg.CreateTime),
+				IsSystem:      true,
+				ContentLength: len(content),
+			}
+			msgs = append(msgs, pm)
+			lastAsstID = -1
+			ordinal++
+
+		case "tool":
+			attachToolToAssistant(
+				&msgs, lastAsstID, msg, content,
+			)
+		}
+	}
+
+	return msgs, lastModel
+}
+
+// attachToolToAssistant attaches a tool node's content to the
+// preceding assistant message as a ParsedToolCall.
+func attachToolToAssistant(
+	msgs *[]ParsedMessage,
+	asstIdx int,
+	msg *chatGPTMessage,
+	content string,
+) {
+	if asstIdx < 0 || asstIdx >= len(*msgs) {
+		return
+	}
+
+	ct := msg.Content.ContentType
+	asst := &(*msgs)[asstIdx]
+	asst.HasToolUse = true
+
+	switch ct {
+	case "code":
+		asst.ToolCalls = append(asst.ToolCalls, ParsedToolCall{
+			ToolName: "code_interpreter",
+			Category: NormalizeToolCategory("code_interpreter"),
+		})
+
+	case "execution_output":
+		// Pair with the last code_interpreter tool call.
+		if n := len(asst.ToolCalls); n > 0 {
+			tc := &asst.ToolCalls[n-1]
+			tc.ResultEvents = append(
+				tc.ResultEvents,
+				ParsedToolResultEvent{Content: content},
+			)
+		}
+
+	case "tether_quote", "tether_browsing_display":
+		asst.ToolCalls = append(asst.ToolCalls, ParsedToolCall{
+			ToolName: "web_search",
+			Category: NormalizeToolCategory("web_search"),
+		})
+
+	case "multimodal_text":
+		// DALL-E tool responses contain generated images as
+		// multimodal_text. Append the resolved image content
+		// to the assistant message.
+		if content != "" {
+			if asst.Content != "" {
+				asst.Content += "\n\n"
+			}
+			asst.Content += content
+			asst.ContentLength = len(asst.Content)
+		}
+	}
+}
+
+// assembleContent converts a chatGPTContent into a plain-text
+// string suitable for display. Unicode normalization is applied
+// only to prose content (text, thoughts, quotes, errors), not
+// to code blocks, execution output, or URLs.
+func assembleContent(
+	c chatGPTContent,
+	assets AssetResolver,
+) string {
+	switch c.ContentType {
+	case "text", "multimodal_text":
+		return assembleTextParts(c.Parts, assets)
+
+	case "code":
+		return "```" + c.Language + "\n" + c.Text + "\n```"
+
+	case "execution_output":
+		return "```\n" + c.Text + "\n```"
+
+	case "thoughts":
+		var parts []string
+		for _, t := range c.Thoughts {
+			if t.Content != "" {
+				parts = append(parts, normalizeUnicode(t.Content))
+			}
+		}
+		if len(parts) == 0 {
+			return ""
+		}
+		return "[Thinking]\n" +
+			strings.Join(parts, "\n") +
+			"\n[/Thinking]"
+
+	case "tether_quote":
+		line := "> " + normalizeUnicode(c.Text)
+		if c.Title != "" || c.URL != "" {
+			line += "\n> -- [" +
+				normalizeUnicode(c.Title) + "](" + c.URL + ")"
+		}
+		return line
+
+	case "reasoning_recap", "tether_browsing_display":
+		return ""
+
+	case "system_error":
+		return normalizeUnicode(c.Text)
+
+	default:
+		return assembleFallbackParts(c.Parts)
+	}
+}
+
+// assembleTextParts joins Parts from text/multimodal_text
+// content. Each part is either a JSON string or an object.
+func assembleTextParts(
+	parts []json.RawMessage,
+	assets AssetResolver,
+) string {
+	var out []string
+
+	for _, raw := range parts {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			if s != "" {
+				out = append(out, normalizeUnicode(s))
+			}
+			continue
+		}
+
+		// Try as an object with content_type field.
+		var obj struct {
+			ContentType  string `json:"content_type"`
+			AssetPointer string `json:"asset_pointer"`
+		}
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			continue
+		}
+
+		if obj.ContentType == "image_asset_pointer" {
+			out = append(out, resolveImageAsset(
+				obj.AssetPointer, assets,
+			))
+		}
+	}
+
+	return strings.Join(out, "\n")
+}
+
+// assembleFallbackParts tries to join parts as strings for
+// unknown content types.
+func assembleFallbackParts(parts []json.RawMessage) string {
+	var out []string
+	for _, raw := range parts {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// resolveImageAsset attempts to resolve and copy an image asset.
+func resolveImageAsset(
+	pointer string,
+	assets AssetResolver,
+) string {
+	if assets == nil {
+		return "[image unavailable]"
+	}
+
+	srcPath, ok := assets.Resolve(pointer)
+	if !ok {
+		return "[image unavailable]"
+	}
+
+	ref, err := assets.Copy(srcPath)
+	if err != nil {
+		return "[image unavailable]"
+	}
+
+	return "![image](" + ref + ")"
+}
+
+// normalizeUnicode replaces decorative Unicode characters with
+// their plain ASCII equivalents.
+var unicodeReplacer = strings.NewReplacer(
+	"\u275D", `"`, // HEAVY DOUBLE TURNED COMMA QUOTATION MARK ORNAMENT
+	"\u275E", `"`, // HEAVY DOUBLE COMMA QUOTATION MARK ORNAMENT
+	"\u275B", "'", // HEAVY SINGLE TURNED COMMA QUOTATION MARK ORNAMENT
+	"\u275C", "'", // HEAVY SINGLE COMMA QUOTATION MARK ORNAMENT
+	"\u201C", `"`, // LEFT DOUBLE QUOTATION MARK
+	"\u201D", `"`, // RIGHT DOUBLE QUOTATION MARK
+	"\u2018", "'", // LEFT SINGLE QUOTATION MARK
+	"\u2019", "'", // RIGHT SINGLE QUOTATION MARK
+	"\u2013", "-", // EN DASH
+	"\u2014", "--", // EM DASH
+	"\u2026", "...", // HORIZONTAL ELLIPSIS
+)
+
+func normalizeUnicode(s string) string {
+	return unicodeReplacer.Replace(s)
+}
+
+func unixFloatToTime(f *float64) time.Time {
+	if f == nil || *f == 0 {
+		return time.Time{}
+	}
+	sec := int64(*f)
+	nsec := int64((*f - float64(sec)) * 1e9)
+	return time.Unix(sec, nsec)
+}

--- a/internal/parser/chatgpt_test.go
+++ b/internal/parser/chatgpt_test.go
@@ -1,0 +1,773 @@
+package parser
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeChatGPTFixture(
+	t *testing.T, dir, filename, content string,
+) {
+	t.Helper()
+	err := os.WriteFile(
+		filepath.Join(dir, filename),
+		[]byte(content),
+		0o644,
+	)
+	require.NoError(t, err)
+}
+
+// Basic 3-message conversation: user, assistant, user.
+func TestParseChatGPTExport(t *testing.T) {
+	dir := t.TempDir()
+	writeChatGPTFixture(t, dir, "conversations-001.json", `[
+  {
+    "conversation_id": "abc-123",
+    "title": "Hello Chat",
+    "create_time": 1700000000.0,
+    "update_time": 1700000060.0,
+    "current_node": "node-3",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "parent": null,
+        "children": ["node-1"],
+        "message": null
+      },
+      "node-1": {
+        "id": "node-1",
+        "parent": "root",
+        "children": ["node-2"],
+        "message": {
+          "id": "msg-1",
+          "create_time": 1700000010.0,
+          "author": {"role": "user"},
+          "content": {
+            "content_type": "text",
+            "parts": ["What is Go?"]
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      },
+      "node-2": {
+        "id": "node-2",
+        "parent": "node-1",
+        "children": ["node-3"],
+        "message": {
+          "id": "msg-2",
+          "create_time": 1700000020.0,
+          "author": {"role": "assistant"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Go is a programming language."]
+          },
+          "status": "finished_successfully",
+          "metadata": {"model_slug": "gpt-4"}
+        }
+      },
+      "node-3": {
+        "id": "node-3",
+        "parent": "node-2",
+        "children": [],
+        "message": {
+          "id": "msg-3",
+          "create_time": 1700000050.0,
+          "author": {"role": "user"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Thanks!"]
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      }
+    }
+  }
+]`)
+
+	var results []ParseResult
+	err := ParseChatGPTExport(dir, nil, func(r ParseResult) error {
+		results = append(results, r)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	s := results[0].Session
+	assert.Equal(t, "chatgpt:abc-123", s.ID)
+	assert.Equal(t, "chatgpt.com", s.Project)
+	assert.Equal(t, "local", s.Machine)
+	assert.Equal(t, AgentChatGPT, s.Agent)
+	assert.Equal(t, "Hello Chat", s.DisplayName)
+	assert.Equal(t, "What is Go?", s.FirstMessage)
+	assert.Equal(t, 3, s.MessageCount)
+	assert.Equal(t, 2, s.UserMessageCount)
+
+	msgs := results[0].Messages
+	require.Len(t, msgs, 3)
+
+	assert.Equal(t, 0, msgs[0].Ordinal)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "What is Go?", msgs[0].Content)
+
+	assert.Equal(t, 1, msgs[1].Ordinal)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, "Go is a programming language.", msgs[1].Content)
+	assert.Equal(t, "gpt-4", msgs[1].Model)
+
+	assert.Equal(t, 2, msgs[2].Ordinal)
+	assert.Equal(t, RoleUser, msgs[2].Role)
+	assert.Equal(t, "Thanks!", msgs[2].Content)
+}
+
+// Tool nodes (code_interpreter + execution_output) should
+// be attached to the preceding assistant message.
+func TestParseChatGPTExport_ToolCalls(t *testing.T) {
+	dir := t.TempDir()
+	writeChatGPTFixture(t, dir, "conversations-001.json", `[
+  {
+    "conversation_id": "tool-conv",
+    "title": "Code Run",
+    "create_time": 1700000000.0,
+    "update_time": 1700000060.0,
+    "current_node": "node-4",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "parent": null,
+        "children": ["node-1"],
+        "message": null
+      },
+      "node-1": {
+        "id": "node-1",
+        "parent": "root",
+        "children": ["node-2"],
+        "message": {
+          "id": "msg-1",
+          "create_time": 1700000010.0,
+          "author": {"role": "user"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Run print(42)"]
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      },
+      "node-2": {
+        "id": "node-2",
+        "parent": "node-1",
+        "children": ["node-3"],
+        "message": {
+          "id": "msg-2",
+          "create_time": 1700000020.0,
+          "author": {"role": "assistant"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Let me run that for you."]
+          },
+          "status": "finished_successfully",
+          "metadata": {"model_slug": "gpt-4"}
+        }
+      },
+      "node-3": {
+        "id": "node-3",
+        "parent": "node-2",
+        "children": ["node-4"],
+        "message": {
+          "id": "msg-code",
+          "create_time": 1700000030.0,
+          "author": {"role": "tool", "name": "python"},
+          "content": {
+            "content_type": "code",
+            "text": "print(42)",
+            "language": "python"
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      },
+      "node-4": {
+        "id": "node-4",
+        "parent": "node-3",
+        "children": [],
+        "message": {
+          "id": "msg-output",
+          "create_time": 1700000035.0,
+          "author": {"role": "tool", "name": "python"},
+          "content": {
+            "content_type": "execution_output",
+            "text": "42"
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      }
+    }
+  }
+]`)
+
+	var results []ParseResult
+	err := ParseChatGPTExport(dir, nil, func(r ParseResult) error {
+		results = append(results, r)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	msgs := results[0].Messages
+	// Tool nodes are NOT separate messages.
+	require.Len(t, msgs, 2, "tool nodes should be attached, not separate")
+
+	asst := msgs[1]
+	assert.Equal(t, RoleAssistant, asst.Role)
+	assert.True(t, asst.HasToolUse)
+	require.Len(t, asst.ToolCalls, 1)
+	assert.Equal(t, "code_interpreter", asst.ToolCalls[0].ToolName)
+	assert.Equal(t, "Bash", asst.ToolCalls[0].Category)
+
+	// execution_output is paired as a result event.
+	require.Len(t, asst.ToolCalls[0].ResultEvents, 1)
+	assert.Contains(t, asst.ToolCalls[0].ResultEvents[0].Content, "42")
+}
+
+// Thoughts content type should produce [Thinking] blocks.
+func TestParseChatGPTExport_Thinking(t *testing.T) {
+	dir := t.TempDir()
+	writeChatGPTFixture(t, dir, "conversations-001.json", `[
+  {
+    "conversation_id": "think-conv",
+    "title": "Thinking Test",
+    "create_time": 1700000000.0,
+    "update_time": 1700000060.0,
+    "current_node": "node-2",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "parent": null,
+        "children": ["node-1"],
+        "message": null
+      },
+      "node-1": {
+        "id": "node-1",
+        "parent": "root",
+        "children": ["node-2"],
+        "message": {
+          "id": "msg-1",
+          "create_time": 1700000010.0,
+          "author": {"role": "user"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Explain recursion"]
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      },
+      "node-2": {
+        "id": "node-2",
+        "parent": "node-1",
+        "children": [],
+        "message": {
+          "id": "msg-2",
+          "create_time": 1700000020.0,
+          "author": {"role": "assistant"},
+          "content": {
+            "content_type": "thoughts",
+            "thoughts": [
+              {"content": "Let me think about recursion."},
+              {"content": "It is a function calling itself."}
+            ]
+          },
+          "status": "finished_successfully",
+          "metadata": {"model_slug": "o1-preview"}
+        }
+      }
+    }
+  }
+]`)
+
+	var results []ParseResult
+	err := ParseChatGPTExport(dir, nil, func(r ParseResult) error {
+		results = append(results, r)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	msgs := results[0].Messages
+	require.Len(t, msgs, 2)
+
+	asst := msgs[1]
+	assert.True(t, asst.HasThinking)
+	assert.Contains(t, asst.Content, "[Thinking]")
+	assert.Contains(t, asst.Content, "Let me think about recursion.")
+	assert.Contains(t, asst.Content, "It is a function calling itself.")
+	assert.Contains(t, asst.Content, "[/Thinking]")
+	assert.Equal(t, "o1-preview", asst.Model)
+}
+
+// System nodes should have IsSystem = true and count in
+// MessageCount.
+func TestParseChatGPTExport_SystemMessage(t *testing.T) {
+	dir := t.TempDir()
+	writeChatGPTFixture(t, dir, "conversations-001.json", `[
+  {
+    "conversation_id": "sys-conv",
+    "title": "System Test",
+    "create_time": 1700000000.0,
+    "update_time": 1700000060.0,
+    "current_node": "node-2",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "parent": null,
+        "children": ["node-sys"],
+        "message": null
+      },
+      "node-sys": {
+        "id": "node-sys",
+        "parent": "root",
+        "children": ["node-1"],
+        "message": {
+          "id": "msg-sys",
+          "create_time": 1700000005.0,
+          "author": {"role": "system"},
+          "content": {
+            "content_type": "text",
+            "parts": ["You are a helpful assistant."]
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      },
+      "node-1": {
+        "id": "node-1",
+        "parent": "node-sys",
+        "children": ["node-2"],
+        "message": {
+          "id": "msg-1",
+          "create_time": 1700000010.0,
+          "author": {"role": "user"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Hi"]
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      },
+      "node-2": {
+        "id": "node-2",
+        "parent": "node-1",
+        "children": [],
+        "message": {
+          "id": "msg-2",
+          "create_time": 1700000020.0,
+          "author": {"role": "assistant"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Hello!"]
+          },
+          "status": "finished_successfully",
+          "metadata": {"model_slug": "gpt-4"}
+        }
+      }
+    }
+  }
+]`)
+
+	var results []ParseResult
+	err := ParseChatGPTExport(dir, nil, func(r ParseResult) error {
+		results = append(results, r)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	s := results[0].Session
+	assert.Equal(t, 3, s.MessageCount)
+	assert.Equal(t, 1, s.UserMessageCount)
+
+	msgs := results[0].Messages
+	require.Len(t, msgs, 3)
+
+	assert.True(t, msgs[0].IsSystem)
+	assert.Equal(t, "You are a helpful assistant.", msgs[0].Content)
+	assert.False(t, msgs[1].IsSystem)
+	assert.Equal(t, RoleUser, msgs[1].Role)
+}
+
+// Empty directory should produce no results and no error.
+func TestParseChatGPTExport_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	err := ParseChatGPTExport(dir, nil, func(r ParseResult) error {
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no conversation files")
+}
+
+// Multiple conversation files should all be processed.
+func TestParseChatGPTExport_MultipleShards(t *testing.T) {
+	dir := t.TempDir()
+
+	shard := func(id, title string) string {
+		return `[{
+      "conversation_id": "` + id + `",
+      "title": "` + title + `",
+      "create_time": 1700000000.0,
+      "update_time": 1700000060.0,
+      "current_node": "node-1",
+      "mapping": {
+        "root": {
+          "id": "root",
+          "parent": null,
+          "children": ["node-1"],
+          "message": null
+        },
+        "node-1": {
+          "id": "node-1",
+          "parent": "root",
+          "children": [],
+          "message": {
+            "id": "msg-1",
+            "create_time": 1700000010.0,
+            "author": {"role": "user"},
+            "content": {
+              "content_type": "text",
+              "parts": ["Hello"]
+            },
+            "status": "finished_successfully",
+            "metadata": {}
+          }
+        }
+      }
+    }]`
+	}
+
+	writeChatGPTFixture(t, dir, "conversations-001.json",
+		shard("conv-a", "First"))
+	writeChatGPTFixture(t, dir, "conversations-002.json",
+		shard("conv-b", "Second"))
+
+	var results []ParseResult
+	err := ParseChatGPTExport(dir, nil, func(r ParseResult) error {
+		results = append(results, r)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "chatgpt:conv-a", results[0].Session.ID)
+	assert.Equal(t, "chatgpt:conv-b", results[1].Session.ID)
+}
+
+// Verify DAG linearization walks from current_node to root and
+// reverses.
+func TestLinearizeDAG(t *testing.T) {
+	parent := "root"
+	mapping := map[string]chatGPTNode{
+		"root": {
+			ID:       "root",
+			Parent:   nil,
+			Children: []string{"a"},
+		},
+		"a": {
+			ID:       "a",
+			Parent:   &parent,
+			Children: []string{"b"},
+		},
+		"b": {
+			ID:     "b",
+			Parent: strPtr("a"),
+		},
+	}
+
+	nodes := linearizeDAG(mapping, "b")
+	require.Len(t, nodes, 3)
+	assert.Equal(t, "root", nodes[0].ID)
+	assert.Equal(t, "a", nodes[1].ID)
+	assert.Equal(t, "b", nodes[2].ID)
+}
+
+func TestLinearizeDAG_EmptyCurrentNode(t *testing.T) {
+	nodes := linearizeDAG(map[string]chatGPTNode{}, "")
+	assert.Nil(t, nodes)
+}
+
+func TestLinearizeDAG_MissingNode(t *testing.T) {
+	nodes := linearizeDAG(map[string]chatGPTNode{}, "missing")
+	assert.Empty(t, nodes)
+}
+
+// Verify assembleContent handles all content types.
+func TestAssembleContent(t *testing.T) {
+	tests := []struct {
+		name string
+		c    chatGPTContent
+		want string
+	}{
+		{
+			name: "text with string parts",
+			c: chatGPTContent{
+				ContentType: "text",
+				Parts:       rawParts("Hello", "World"),
+			},
+			want: "Hello\nWorld",
+		},
+		{
+			name: "code block",
+			c: chatGPTContent{
+				ContentType: "code",
+				Text:        "print(42)",
+				Language:    "python",
+			},
+			want: "```python\nprint(42)\n```",
+		},
+		{
+			name: "execution_output",
+			c: chatGPTContent{
+				ContentType: "execution_output",
+				Text:        "42",
+			},
+			want: "```\n42\n```",
+		},
+		{
+			name: "thoughts",
+			c: chatGPTContent{
+				ContentType: "thoughts",
+				Thoughts: []chatGPTThought{
+					{Content: "thinking hard"},
+				},
+			},
+			want: "[Thinking]\nthinking hard\n[/Thinking]",
+		},
+		{
+			name: "tether_quote",
+			c: chatGPTContent{
+				ContentType: "tether_quote",
+				Text:        "some quote",
+				Title:       "Source",
+				URL:         "https://example.com",
+			},
+			want: "> some quote\n> -- [Source](https://example.com)",
+		},
+		{
+			name: "reasoning_recap is skipped",
+			c: chatGPTContent{
+				ContentType: "reasoning_recap",
+				Text:        "recap text",
+			},
+			want: "",
+		},
+		{
+			name: "tether_browsing_display is skipped",
+			c: chatGPTContent{
+				ContentType: "tether_browsing_display",
+			},
+			want: "",
+		},
+		{
+			name: "system_error",
+			c: chatGPTContent{
+				ContentType: "system_error",
+				Text:        "something went wrong",
+			},
+			want: "something went wrong",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := assembleContent(tt.c, nil)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Verify image asset resolution with a mock resolver.
+func TestAssembleContent_ImageAsset(t *testing.T) {
+	c := chatGPTContent{
+		ContentType: "multimodal_text",
+		Parts: []json.RawMessage{
+			json.RawMessage(`"Here is an image:"`),
+			json.RawMessage(`{
+				"content_type": "image_asset_pointer",
+				"asset_pointer": "file-service://file-abc123"
+			}`),
+		},
+	}
+
+	resolver := &mockAssetResolver{
+		files: map[string]string{
+			"file-service://file-abc123": "/tmp/img.png",
+		},
+		copyRef: "asset://abc123.png",
+	}
+
+	got := assembleContent(c, resolver)
+	assert.Contains(t, got, "Here is an image:")
+	assert.Contains(t, got, "![image](asset://abc123.png)")
+}
+
+// Nil resolver should produce [image unavailable].
+func TestAssembleContent_ImageAsset_NilResolver(t *testing.T) {
+	c := chatGPTContent{
+		ContentType: "multimodal_text",
+		Parts: []json.RawMessage{
+			json.RawMessage(`{
+				"content_type": "image_asset_pointer",
+				"asset_pointer": "file-service://file-abc123"
+			}`),
+		},
+	}
+
+	got := assembleContent(c, nil)
+	assert.Equal(t, "[image unavailable]", got)
+}
+
+func TestUnixFloatToTime(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.True(t, unixFloatToTime(nil).IsZero())
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		z := 0.0
+		assert.True(t, unixFloatToTime(&z).IsZero())
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		v := 1700000000.5
+		got := unixFloatToTime(&v)
+		assert.Equal(t, int64(1700000000), got.Unix())
+		assert.Equal(t, 500000000, got.Nanosecond())
+	})
+}
+
+// Conversation with web_search tool nodes.
+func TestParseChatGPTExport_WebSearch(t *testing.T) {
+	dir := t.TempDir()
+	writeChatGPTFixture(t, dir, "conversations-001.json", `[
+  {
+    "conversation_id": "web-conv",
+    "title": "Web Search",
+    "create_time": 1700000000.0,
+    "update_time": 1700000060.0,
+    "current_node": "node-3",
+    "mapping": {
+      "root": {
+        "id": "root",
+        "parent": null,
+        "children": ["node-1"],
+        "message": null
+      },
+      "node-1": {
+        "id": "node-1",
+        "parent": "root",
+        "children": ["node-2"],
+        "message": {
+          "id": "msg-1",
+          "create_time": 1700000010.0,
+          "author": {"role": "user"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Search for Go"]
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      },
+      "node-2": {
+        "id": "node-2",
+        "parent": "node-1",
+        "children": ["node-3"],
+        "message": {
+          "id": "msg-2",
+          "create_time": 1700000020.0,
+          "author": {"role": "assistant"},
+          "content": {
+            "content_type": "text",
+            "parts": ["Searching..."]
+          },
+          "status": "finished_successfully",
+          "metadata": {"model_slug": "gpt-4"}
+        }
+      },
+      "node-3": {
+        "id": "node-3",
+        "parent": "node-2",
+        "children": [],
+        "message": {
+          "id": "msg-browse",
+          "create_time": 1700000030.0,
+          "author": {"role": "tool"},
+          "content": {
+            "content_type": "tether_quote",
+            "text": "Go is great",
+            "title": "Go Blog",
+            "url": "https://go.dev/blog"
+          },
+          "status": "finished_successfully",
+          "metadata": {}
+        }
+      }
+    }
+  }
+]`)
+
+	var results []ParseResult
+	err := ParseChatGPTExport(dir, nil, func(r ParseResult) error {
+		results = append(results, r)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	msgs := results[0].Messages
+	require.Len(t, msgs, 2)
+
+	asst := msgs[1]
+	assert.True(t, asst.HasToolUse)
+	require.Len(t, asst.ToolCalls, 1)
+	assert.Equal(t, "web_search", asst.ToolCalls[0].ToolName)
+	assert.Equal(t, "Tool", asst.ToolCalls[0].Category)
+}
+
+// --- helpers ---
+
+// rawParts creates json.RawMessage slices from strings for
+// chatGPTContent.Parts test fixtures.
+func rawParts(ss ...string) []json.RawMessage {
+	var parts []json.RawMessage
+	for _, s := range ss {
+		b, _ := json.Marshal(s)
+		parts = append(parts, b)
+	}
+	return parts
+}
+
+func strPtr(s string) *string { return &s }
+
+type mockAssetResolver struct {
+	files   map[string]string
+	copyRef string
+}
+
+func (m *mockAssetResolver) Resolve(
+	pointer string,
+) (string, bool) {
+	p, ok := m.files[pointer]
+	return p, ok
+}
+
+func (m *mockAssetResolver) Copy(string) (string, error) {
+	return m.copyRef, nil
+}

--- a/internal/parser/claude_ai.go
+++ b/internal/parser/claude_ai.go
@@ -1,0 +1,173 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type claudeAIConversation struct {
+	UUID      string            `json:"uuid"`
+	Name      string            `json:"name"`
+	CreatedAt string            `json:"created_at"`
+	UpdatedAt string            `json:"updated_at"`
+	Messages  []claudeAIMessage `json:"chat_messages"`
+}
+
+type claudeAIMessage struct {
+	UUID      string              `json:"uuid"`
+	Text      string              `json:"text"`
+	Content   []claudeAIBlock     `json:"content"`
+	Sender    string              `json:"sender"`
+	CreatedAt string              `json:"created_at"`
+}
+
+// claudeAIBlock represents a content block within a message.
+// Block types: text, thinking, tool_use, tool_result,
+// voice_note, token_budget.
+type claudeAIBlock struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Thinking string `json:"thinking"`
+}
+
+// ParseClaudeAIExport streams a Claude.ai conversations.json
+// export and calls onConversation for each non-empty
+// conversation.
+func ParseClaudeAIExport(
+	r io.Reader,
+	onConversation func(ParseResult) error,
+) error {
+	dec := json.NewDecoder(r)
+
+	tok, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("reading opening token: %w", err)
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '[' {
+		return fmt.Errorf("expected JSON array, got %v", tok)
+	}
+
+	for dec.More() {
+		var conv claudeAIConversation
+		if err := dec.Decode(&conv); err != nil {
+			return fmt.Errorf("decoding conversation: %w", err)
+		}
+
+		if len(conv.Messages) == 0 {
+			continue
+		}
+
+		result, err := convertClaudeAIConversation(conv)
+		if err != nil {
+			return fmt.Errorf(
+				"converting conversation %s: %w",
+				conv.UUID, err,
+			)
+		}
+
+		if err := onConversation(result); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// assembleClaudeAIContent builds message content from content
+// blocks. Falls back to the top-level text field when no
+// content blocks have usable text.
+func assembleClaudeAIContent(
+	m claudeAIMessage,
+) (content string, hasThinking bool) {
+	if len(m.Content) == 0 {
+		return m.Text, false
+	}
+
+	var parts []string
+	for _, b := range m.Content {
+		switch b.Type {
+		case "text":
+			if b.Text != "" {
+				parts = append(parts, b.Text)
+			}
+		case "thinking":
+			if b.Thinking != "" {
+				hasThinking = true
+				parts = append(parts,
+					"[Thinking]\n"+b.Thinking+"\n[/Thinking]")
+			}
+		// tool_use, tool_result, voice_note, token_budget
+		// are metadata blocks — skip for display content.
+		}
+	}
+
+	if len(parts) == 0 {
+		return m.Text, hasThinking
+	}
+	return strings.Join(parts, "\n\n"), hasThinking
+}
+
+func convertClaudeAIConversation(
+	conv claudeAIConversation,
+) (ParseResult, error) {
+	startedAt, err := time.Parse(time.RFC3339Nano, conv.CreatedAt)
+	if err != nil {
+		return ParseResult{},
+			fmt.Errorf("parsing created_at: %w", err)
+	}
+
+	endedAt, err := time.Parse(time.RFC3339Nano, conv.UpdatedAt)
+	if err != nil {
+		return ParseResult{},
+			fmt.Errorf("parsing updated_at: %w", err)
+	}
+
+	var (
+		msgs             []ParsedMessage
+		userCount        int
+		firstUserMessage string
+	)
+
+	for i, m := range conv.Messages {
+		content, hasThinking := assembleClaudeAIContent(m)
+
+		role := RoleAssistant
+		if m.Sender == "human" {
+			role = RoleUser
+			userCount++
+			if firstUserMessage == "" {
+				firstUserMessage = content
+			}
+		}
+
+		ts, _ := time.Parse(time.RFC3339Nano, m.CreatedAt)
+
+		msgs = append(msgs, ParsedMessage{
+			Ordinal:       i,
+			Role:          role,
+			Content:       content,
+			Timestamp:     ts,
+			HasThinking:   hasThinking,
+			ContentLength: len(content),
+		})
+	}
+
+	return ParseResult{
+		Session: ParsedSession{
+			ID:               "claude-ai:" + conv.UUID,
+			Project:          "claude.ai",
+			Machine:          "local",
+			Agent:            AgentClaudeAI,
+			FirstMessage:     firstUserMessage,
+			DisplayName:      conv.Name,
+			StartedAt:        startedAt,
+			EndedAt:          endedAt,
+			MessageCount:     len(conv.Messages),
+			UserMessageCount: userCount,
+		},
+		Messages: msgs,
+	}, nil
+}

--- a/internal/parser/claude_ai_test.go
+++ b/internal/parser/claude_ai_test.go
@@ -1,0 +1,194 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testExportJSON = `[
+  {
+    "uuid": "conv-001",
+    "name": "Test Chat",
+    "summary": "A test conversation",
+    "created_at": "2026-01-15T10:00:00.000000Z",
+    "updated_at": "2026-01-15T10:30:00.000000Z",
+    "account": {"uuid": "acct-1"},
+    "chat_messages": [
+      {
+        "uuid": "msg-001",
+        "text": "Hello, how are you?",
+        "content": [{"type": "text", "text": "Hello, how are you?"}],
+        "sender": "human",
+        "created_at": "2026-01-15T10:00:00.000000Z",
+        "updated_at": "2026-01-15T10:00:00.000000Z",
+        "attachments": [],
+        "files": []
+      },
+      {
+        "uuid": "msg-002",
+        "text": "I'm doing well, thanks!",
+        "content": [{"type": "text", "text": "I'm doing well, thanks!"}],
+        "sender": "assistant",
+        "created_at": "2026-01-15T10:00:30.000000Z",
+        "updated_at": "2026-01-15T10:00:30.000000Z",
+        "attachments": [],
+        "files": []
+      }
+    ]
+  },
+  {
+    "uuid": "conv-002",
+    "name": "",
+    "summary": "",
+    "created_at": "2026-01-16T12:00:00.000000Z",
+    "updated_at": "2026-01-16T12:05:00.000000Z",
+    "account": {"uuid": "acct-1"},
+    "chat_messages": []
+  },
+  {
+    "uuid": "conv-003",
+    "name": "Second Chat",
+    "summary": "",
+    "created_at": "2026-01-17T08:00:00.000000Z",
+    "updated_at": "2026-01-17T08:10:00.000000Z",
+    "account": {"uuid": "acct-1"},
+    "chat_messages": [
+      {
+        "uuid": "msg-003",
+        "text": "What is Go?",
+        "content": [{"type": "text", "text": "What is Go?"}],
+        "sender": "human",
+        "created_at": "2026-01-17T08:00:00.000000Z",
+        "updated_at": "2026-01-17T08:00:00.000000Z",
+        "attachments": [],
+        "files": []
+      }
+    ]
+  }
+]`
+
+func TestParseClaudeAIExport(t *testing.T) {
+	var results []ParseResult
+	err := ParseClaudeAIExport(
+		strings.NewReader(testExportJSON),
+		func(r ParseResult) error {
+			results = append(results, r)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	// conv-002 has no messages, should be skipped.
+	require.Len(t, results, 2)
+
+	// First conversation.
+	s := results[0].Session
+	assert.Equal(t, "claude-ai:conv-001", s.ID)
+	assert.Equal(t, "claude.ai", s.Project)
+	assert.Equal(t, "local", s.Machine)
+	assert.Equal(t, AgentClaudeAI, s.Agent)
+	assert.Equal(t, "Hello, how are you?", s.FirstMessage)
+	assert.Equal(t, "Test Chat", s.DisplayName)
+	assert.Equal(t, 2, s.MessageCount)
+	assert.Equal(t, 1, s.UserMessageCount)
+	assert.Equal(t,
+		"2026-01-15T10:00:00.000000Z",
+		s.StartedAt.Format("2006-01-02T15:04:05.000000Z"),
+	)
+
+	msgs := results[0].Messages
+	require.Len(t, msgs, 2)
+	assert.Equal(t, 0, msgs[0].Ordinal)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Hello, how are you?", msgs[0].Content)
+	assert.Equal(t, 1, msgs[1].Ordinal)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+
+	// Third conversation (second result).
+	s2 := results[1].Session
+	assert.Equal(t, "claude-ai:conv-003", s2.ID)
+	assert.Equal(t, 1, s2.MessageCount)
+	assert.Equal(t, 1, s2.UserMessageCount)
+}
+
+func TestParseClaudeAIExport_ContentBlocks(t *testing.T) {
+	input := `[{
+		"uuid": "conv-blocks",
+		"name": "Block Test",
+		"created_at": "2026-01-20T10:00:00.000000Z",
+		"updated_at": "2026-01-20T10:05:00.000000Z",
+		"account": {"uuid": "acct-1"},
+		"chat_messages": [
+			{
+				"uuid": "m1",
+				"text": "This block is not supported on your current device yet.",
+				"content": [
+					{"type": "text", "text": "First part."},
+					{"type": "tool_use", "text": ""},
+					{"type": "tool_result", "text": ""},
+					{"type": "text", "text": "Second part."}
+				],
+				"sender": "assistant",
+				"created_at": "2026-01-20T10:00:00.000000Z"
+			},
+			{
+				"uuid": "m2",
+				"text": "",
+				"content": [
+					{"type": "thinking", "thinking": "deep thought"},
+					{"type": "text", "text": "The answer."}
+				],
+				"sender": "assistant",
+				"created_at": "2026-01-20T10:01:00.000000Z"
+			}
+		]
+	}]`
+
+	var results []ParseResult
+	err := ParseClaudeAIExport(
+		strings.NewReader(input),
+		func(r ParseResult) error {
+			results = append(results, r)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	msgs := results[0].Messages
+
+	// Message with tool_use/tool_result blocks should use
+	// text blocks, not the truncated top-level text.
+	assert.Equal(t, "First part.\n\nSecond part.", msgs[0].Content)
+	assert.False(t, msgs[0].HasThinking)
+
+	// Message with thinking block.
+	assert.Contains(t, msgs[1].Content, "[Thinking]")
+	assert.Contains(t, msgs[1].Content, "deep thought")
+	assert.Contains(t, msgs[1].Content, "The answer.")
+	assert.True(t, msgs[1].HasThinking)
+}
+
+func TestParseClaudeAIExport_EmptyArray(t *testing.T) {
+	var results []ParseResult
+	err := ParseClaudeAIExport(
+		strings.NewReader("[]"),
+		func(r ParseResult) error {
+			results = append(results, r)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestParseClaudeAIExport_InvalidJSON(t *testing.T) {
+	err := ParseClaudeAIExport(
+		strings.NewReader("{not json"),
+		func(r ParseResult) error { return nil },
+	)
+	require.Error(t, err)
+}

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -126,6 +126,10 @@ func NormalizeToolCategory(rawName string) string {
 	case "zencoder-rag-mcp__web_search":
 		return "Read"
 
+	// ChatGPT tools
+	case "code_interpreter":
+		return "Bash"
+
 	default:
 		// MCP tools may carry a server prefix (e.g.
 		// "Zencoder_subagent__ZencoderSubagent") or use

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -23,6 +23,8 @@ const (
 	AgentPi            AgentType = "pi"
 	AgentOpenClaw      AgentType = "openclaw"
 	AgentKimi          AgentType = "kimi"
+	AgentClaudeAI      AgentType = "claude-ai"
+	AgentChatGPT       AgentType = "chatgpt"
 )
 
 // AgentDef describes a supported coding agent's filesystem
@@ -207,6 +209,29 @@ var Registry = []AgentDef{
 		DiscoverFunc:   DiscoverKimiSessions,
 		FindSourceFunc: FindKimiSourceFile,
 	},
+	{
+		Type:        AgentClaudeAI,
+		DisplayName: "Claude.ai",
+		IDPrefix:    "claude-ai:",
+		FileBased:   false,
+	},
+	{
+		Type:        AgentChatGPT,
+		DisplayName: "ChatGPT",
+		IDPrefix:    "chatgpt:",
+		FileBased:   false,
+	},
+}
+
+// NonFileBackedAgents returns agent types where FileBased is false.
+func NonFileBackedAgents() []AgentType {
+	var agents []AgentType
+	for _, def := range Registry {
+		if !def.FileBased {
+			agents = append(agents, def.Type)
+		}
+	}
+	return agents
 }
 
 // AgentByType returns the AgentDef for the given type.
@@ -276,6 +301,7 @@ type ParsedSession struct {
 	RelationshipType RelationshipType
 	Cwd              string
 	FirstMessage     string
+	DisplayName      string
 	StartedAt        time.Time
 	EndedAt          time.Time
 	MessageCount     int

--- a/internal/server/assets.go
+++ b/internal/server/assets.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// safeImageTypes maps extensions to MIME types for passive
+// image formats. Active content (svg, html, js) is never
+// served inline to prevent stored XSS.
+var safeImageTypes = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".webp": "image/webp",
+	".gif":  "image/gif",
+}
+
+func (s *Server) handleGetAsset(
+	w http.ResponseWriter, r *http.Request,
+) {
+	filename := r.PathValue("filename")
+	if filename == "" {
+		writeError(w, http.StatusBadRequest, "missing filename")
+		return
+	}
+
+	if strings.Contains(filename, "..") ||
+		strings.Contains(filename, "/") ||
+		strings.Contains(filename, "\\") {
+		writeError(w, http.StatusBadRequest, "invalid filename")
+		return
+	}
+
+	ext := strings.ToLower(filepath.Ext(filename))
+	contentType, ok := safeImageTypes[ext]
+	if !ok {
+		writeError(w, http.StatusForbidden,
+			"unsupported asset type")
+		return
+	}
+
+	assetsDir := filepath.Join(s.cfg.DataDir, "assets")
+	filePath := filepath.Join(assetsDir, filename)
+
+	if _, err := os.Stat(filePath); err != nil {
+		writeError(w, http.StatusNotFound, "asset not found")
+		return
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Cache-Control",
+		"public, max-age=31536000, immutable")
+
+	http.ServeFile(w, r, filePath)
+}

--- a/internal/server/import.go
+++ b/internal/server/import.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wesm/agentsview/internal/importer"
+)
+
+func (s *Server) handleImportClaudeAI(
+	w http.ResponseWriter, r *http.Request,
+) {
+	if s.db.ReadOnly() {
+		writeError(w, http.StatusNotImplemented,
+			"import not available in read-only mode")
+		return
+	}
+
+	// 64 MB max memory for multipart parsing.
+	if err := r.ParseMultipartForm(64 << 20); err != nil {
+		writeError(w, http.StatusBadRequest,
+			"invalid multipart form")
+		return
+	}
+	if r.MultipartForm != nil {
+		defer func() { _ = r.MultipartForm.RemoveAll() }()
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, http.StatusBadRequest,
+			"missing 'file' field in form data")
+		return
+	}
+	defer file.Close()
+
+	var reader io.Reader = file
+
+	// Handle zip uploads.
+	if strings.HasSuffix(
+		strings.ToLower(header.Filename), ".zip",
+	) {
+		tmpFile, tmpErr := os.CreateTemp(
+			"", "claude-import-*.zip",
+		)
+		if tmpErr != nil {
+			writeError(w, http.StatusInternalServerError,
+				"failed to create temp file")
+			return
+		}
+		defer os.Remove(tmpFile.Name())
+
+		if _, tmpErr = io.Copy(tmpFile, file); tmpErr != nil {
+			tmpFile.Close()
+			writeError(w, http.StatusInternalServerError,
+				"failed to save upload")
+			return
+		}
+		tmpFile.Close()
+
+		dir, cleanup, extractErr := importer.ExtractZip(
+			tmpFile.Name(),
+		)
+		if extractErr != nil {
+			writeError(w, http.StatusBadRequest,
+				"failed to extract zip: "+extractErr.Error())
+			return
+		}
+		defer cleanup()
+
+		jsonPath := filepath.Join(dir, "conversations.json")
+		jsonFile, openErr := os.Open(jsonPath)
+		if openErr != nil {
+			writeError(w, http.StatusBadRequest,
+				"no conversations.json found in zip")
+			return
+		}
+		defer jsonFile.Close()
+		reader = jsonFile
+	}
+
+	stats, err := importer.ImportClaudeAI(
+		r.Context(), s.db, reader, nil,
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError,
+			"import failed: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, stats)
+}
+
+func (s *Server) handleImportChatGPT(
+	w http.ResponseWriter, r *http.Request,
+) {
+	if s.db.ReadOnly() {
+		writeError(w, http.StatusNotImplemented,
+			"import not available in read-only mode")
+		return
+	}
+
+	// 256 MB max memory for multipart parsing.
+	if err := r.ParseMultipartForm(256 << 20); err != nil {
+		writeError(w, http.StatusBadRequest,
+			"invalid multipart form")
+		return
+	}
+	if r.MultipartForm != nil {
+		defer func() { _ = r.MultipartForm.RemoveAll() }()
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, http.StatusBadRequest,
+			"missing 'file' field in form data")
+		return
+	}
+	defer file.Close()
+
+	if !strings.HasSuffix(
+		strings.ToLower(header.Filename), ".zip",
+	) {
+		writeError(w, http.StatusBadRequest,
+			"ChatGPT import requires a .zip file")
+		return
+	}
+
+	tmpFile, err := os.CreateTemp("", "chatgpt-import-*.zip")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError,
+			"failed to create temp file")
+		return
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err = io.Copy(tmpFile, file); err != nil {
+		tmpFile.Close()
+		writeError(w, http.StatusInternalServerError,
+			"failed to save upload")
+		return
+	}
+	tmpFile.Close()
+
+	dir, cleanup, err := importer.ExtractZip(tmpFile.Name())
+	if err != nil {
+		writeError(w, http.StatusBadRequest,
+			"failed to extract zip: "+err.Error())
+		return
+	}
+	defer cleanup()
+
+	assetsDir := filepath.Join(s.cfg.DataDir, "assets")
+	stats, err := importer.ImportChatGPT(
+		r.Context(), s.db, dir, assetsDir, nil,
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError,
+			"import failed: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, stats)
+}

--- a/internal/server/import_test.go
+++ b/internal/server/import_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wesm/agentsview/internal/importer"
+)
+
+func TestHandleImportClaudeAI(t *testing.T) {
+	srv := testServer(t, 5*time.Second)
+
+	conversations := `[
+      {
+        "uuid": "api-test-001",
+        "name": "API Test",
+        "summary": "",
+        "created_at": "2026-03-01T10:00:00.000000Z",
+        "updated_at": "2026-03-01T10:05:00.000000Z",
+        "account": {"uuid": "acct-1"},
+        "chat_messages": [
+          {
+            "uuid": "m1",
+            "text": "Test message",
+            "content": [{"type":"text","text":"Test message"}],
+            "sender": "human",
+            "created_at": "2026-03-01T10:00:00.000000Z",
+            "updated_at": "2026-03-01T10:00:00.000000Z",
+            "attachments": [],
+            "files": []
+          }
+        ]
+      }
+    ]`
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "conversations.json")
+	if err != nil {
+		t.Fatalf("creating form file: %v", err)
+	}
+	_, _ = part.Write([]byte(conversations))
+	writer.Close()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/import/claude-ai",
+		&body,
+	)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf(
+			"status = %d, want 200: %s",
+			rec.Code, rec.Body.String(),
+		)
+	}
+
+	var stats importer.ImportStats
+	if err := json.NewDecoder(rec.Body).Decode(&stats); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if stats.Imported != 1 {
+		t.Errorf("imported = %d, want 1", stats.Imported)
+	}
+	if stats.Updated != 0 {
+		t.Errorf("updated = %d, want 0", stats.Updated)
+	}
+}
+
+func TestHandleImportChatGPT_RequiresZip(t *testing.T) {
+	srv := testServer(t, 5*time.Second)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "data.json")
+	if err != nil {
+		t.Fatalf("creating form file: %v", err)
+	}
+	_, _ = part.Write([]byte("[]"))
+	writer.Close()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/import/chatgpt",
+		&body,
+	)
+	req.Header.Set(
+		"Content-Type", writer.FormDataContentType(),
+	)
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf(
+			"status = %d, want 400: %s",
+			rec.Code, rec.Body.String(),
+		)
+	}
+}
+
+func TestHandleImportClaudeAI_NoFile(t *testing.T) {
+	srv := testServer(t, 5*time.Second)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	writer.Close()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/import/claude-ai",
+		&body,
+	)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf(
+			"status = %d, want 400: %s",
+			rec.Code, rec.Body.String(),
+		)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -243,6 +243,22 @@ func (s *Server) routes() {
 	s.mux.Handle("GET /api/v1/sessions/{id}/pins", s.withTimeout(s.handleListSessionPins))
 	s.mux.Handle("POST /api/v1/sessions/{id}/messages/{messageId}/pin", s.withTimeout(s.handlePinMessage))
 	s.mux.Handle("DELETE /api/v1/sessions/{id}/messages/{messageId}/pin", s.withTimeout(s.handleUnpinMessage))
+	// Import: no timeout wrapper (large files may take longer).
+	s.mux.HandleFunc(
+		"POST /api/v1/import/claude-ai",
+		s.handleImportClaudeAI,
+	)
+	// ChatGPT import: no timeout wrapper.
+	s.mux.HandleFunc(
+		"POST /api/v1/import/chatgpt",
+		s.handleImportChatGPT,
+	)
+	// Assets: no timeout wrapper (static files).
+	s.mux.HandleFunc(
+		"GET /api/v1/assets/{filename}",
+		s.handleGetAsset,
+	)
+
 	// SPA fallback: serve embedded frontend
 	// Do not use timeout handler for static assets to avoid buffering.
 	s.mux.Handle("/", http.HandlerFunc(s.handleSPA))

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -34,6 +34,9 @@ func (s *Server) handleGetSettings(
 	s.mu.RLock()
 	dirs := make(map[string][]string)
 	for _, def := range parser.Registry {
+		if !def.FileBased && def.EnvVar == "" {
+			continue
+		}
 		d := s.cfg.AgentDirs[def.Type]
 		if d == nil {
 			d = []string{}


### PR DESCRIPTION
## Summary

- Add `agentsview import --type claude-ai|chatgpt <path>` CLI command to import conversations from data exports
- Add web UI import modal with provider selector (Claude.ai / ChatGPT)
- Add image asset storage and serving for ChatGPT DALL-E generations and user uploads
- Add `-no-sync` flag to serve imported-only databases without sync overhead

Closes #253, closes #254.

## What this enables

Users can export their data from claude.ai and chatgpt.com, import it into agentsview, and browse their historical conversations locally. This is especially useful for users who want to delete their accounts on these services but keep their conversation history.

## Architecture

**Two new parsers:**
- `internal/parser/claude_ai.go` -- streams `conversations.json`, maps sender/role, extracts display names
- `internal/parser/chatgpt.go` -- linearizes ChatGPT's DAG message tree via `current_node`, assembles 9 content types (text, code, thoughts, execution_output, tether_quote, multimodal_text, etc.), extracts tool calls, resolves image assets

**Import orchestrator** (`internal/importer/`):
- `importer.go` -- `ImportClaudeAI` (upsert + message replace dedup) and `ImportChatGPT` (skip-if-exists dedup to preserve archived DAG branches)
- `assets.go` -- content-addressable image storage (`$DATA_DIR/assets/<sha256>.<ext>`), asset index for `file-service://` and `sediment://` pointer resolution
- `zip.go` -- shared zip extraction with path traversal protection

**CLI** (`cmd/agentsview/import.go`):
- `--type` flag (required): `claude-ai` or `chatgpt`
- Accepts `.zip`, directory, or `.json` (Claude.ai only)
- Progress reporting, summary with new/updated/skipped counts

**API endpoints:**
- `POST /api/v1/import/claude-ai` -- accepts `.json` or `.zip`
- `POST /api/v1/import/chatgpt` -- accepts `.zip` only
- `GET /api/v1/assets/{filename}` -- serves imported images with immutable cache headers

**Frontend:**
- Import modal with Claude.ai / ChatGPT radio selector
- `agentLabel()` used in session list and breadcrumb for display names
- `asset://` URL resolution in markdown renderer
- File actions suppressed for imported sessions (no source files)

**Infrastructure fixes:**
- `FileBackedSessionCount` uses parser registry instead of hardcoding `opencode`
- `display_name` in `UpsertSession` INSERT (not UPDATE) preserves user renames
- Non-file-backed agents filtered from Agent Directories settings
- `ErrSessionExcluded` handled gracefully during import
- Unicode normalization scoped to prose only (not code/URLs)

Generated with [Claude Code](https://claude.com/claude-code)