### PR TITLE
fix: reduce WebView memory from content-parser caches

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -145,7 +145,12 @@
         );
         if (msg && !thinkingVisible) {
           const segs = enrichSegments(
-            parseContent(msg.content, msg.has_tool_use, msg.id),
+            parseContent(
+              msg.content,
+              msg.has_tool_use,
+              msg.id,
+              msg.content_length,
+            ),
             msg.tool_calls,
           );
           const hasThinkingSegment = segs.some(

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -145,7 +145,7 @@
         );
         if (msg && !thinkingVisible) {
           const segs = enrichSegments(
-            parseContent(msg.content, msg.has_tool_use),
+            parseContent(msg.content, msg.has_tool_use, msg.id),
             msg.tool_calls,
           );
           const hasThinkingSegment = segs.some(

--- a/frontend/src/lib/components/content/MessageContent.svelte
+++ b/frontend/src/lib/components/content/MessageContent.svelte
@@ -34,7 +34,12 @@
 
   let segments = $derived(
     enrichSegments(
-      parseContent(message.content, message.has_tool_use, message.id),
+      parseContent(
+        message.content,
+        message.has_tool_use,
+        message.id,
+        message.content_length,
+      ),
       message.tool_calls,
     ),
   );

--- a/frontend/src/lib/components/content/MessageContent.svelte
+++ b/frontend/src/lib/components/content/MessageContent.svelte
@@ -34,7 +34,7 @@
 
   let segments = $derived(
     enrichSegments(
-      parseContent(message.content, message.has_tool_use),
+      parseContent(message.content, message.has_tool_use, message.id),
       message.tool_calls,
     ),
   );

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -27,7 +27,12 @@
   let toolSegments = $derived(
     messages.flatMap((m) =>
       enrichSegments(
-        parseContent(m.content, m.has_tool_use, m.id),
+        parseContent(
+          m.content,
+          m.has_tool_use,
+          m.id,
+          m.content_length,
+        ),
         m.tool_calls,
       ).filter((s) => s.type === "tool"),
     ),

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -27,7 +27,7 @@
   let toolSegments = $derived(
     messages.flatMap((m) =>
       enrichSegments(
-        parseContent(m.content, m.has_tool_use),
+        parseContent(m.content, m.has_tool_use, m.id),
         m.tool_calls,
       ).filter((s) => s.type === "tool"),
     ),

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -439,6 +439,7 @@ class MessagesStore {
     signal: AbortSignal,
     messageCountHint?: number,
   ) {
+    clearContentCaches();
     this.loading = true;
     try {
       if (

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -1,5 +1,6 @@
 import * as api from "../api/client.js";
 import type { Message } from "../api/types.js";
+import { clearContentCaches } from "../utils/content-parser.js";
 import { computeMainModel } from "../utils/model.js";
 
 const MESSAGE_PAGE_SIZE = 1000;
@@ -121,6 +122,7 @@ class MessagesStore {
     this.abortController?.abort();
     this.abortController = null;
     this.messages = [];
+    clearContentCaches();
     this.sessionId = null;
     this.loading = false;
     this._stableMainModel = "";

--- a/frontend/src/lib/utils/cache.ts
+++ b/frontend/src/lib/utils/cache.ts
@@ -31,6 +31,10 @@ export class LRUCache<K, V> {
     this.map.set(key, value);
   }
 
+  clear(): void {
+    this.map.clear();
+  }
+
   get size(): number {
     return this.map.size;
   }

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -7,11 +7,13 @@ import {
 } from "./content-parser.js";
 import type { Message, ToolCall } from "../api/types.js";
 
+let nextId = 1;
+
 function makeMsg(
   overrides: Partial<Message> & { content: string },
 ): Message {
   const defaults: Message = {
-    id: 1,
+    id: nextId++,
     session_id: "s1",
     ordinal: 0,
     role: "assistant",

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -148,7 +148,7 @@ interface Match {
   segment: ContentSegment;
 }
 
-const toolOnlyCache = new LRUCache<number, boolean>(500);
+const toolOnlyCache = new LRUCache<string, boolean>(500);
 const segmentCache = new LRUCache<string, ContentSegment[]>(500);
 
 /** Clear both content-parser caches. Call on session switch
@@ -160,12 +160,13 @@ export function clearContentCaches(): void {
 
 /** Returns true if the message contains only tool calls (no text) */
 export function isToolOnly(msg: Message): boolean {
-  const cached = toolOnlyCache.get(msg.id);
+  const key = `${msg.id}:${msg.content_length}`;
+  const cached = toolOnlyCache.get(key);
   if (cached !== undefined) return cached;
 
   if (msg.role !== "assistant") return false;
   if (!msg.has_tool_use) {
-    toolOnlyCache.set(msg.id, false);
+    toolOnlyCache.set(key, false);
     return false;
   }
   const stripped = msg.content
@@ -174,7 +175,7 @@ export function isToolOnly(msg: Message): boolean {
     .replace(TOOL_RE, "")
     .trim();
   const result = stripped.length === 0;
-  toolOnlyCache.set(msg.id, result);
+  toolOnlyCache.set(key, result);
   return result;
 }
 
@@ -353,19 +354,21 @@ function mergeThinking(
 }
 
 /** Parse message content into typed segments.
- *  Pass messageId to enable LRU caching keyed by ID
- *  instead of by full text (avoids storing huge strings
- *  as Map keys). */
+ *  Pass messageId and contentLength to enable LRU caching
+ *  keyed by ID instead of by full text (avoids storing huge
+ *  strings as Map keys). contentLength ensures the cache
+ *  invalidates when message content grows during streaming. */
 export function parseContent(
   text: string,
   hasToolUse = true,
   messageId?: number,
+  contentLength?: number,
 ): ContentSegment[] {
   if (!text) return [];
 
   const cacheKey =
     messageId !== undefined
-      ? `${hasToolUse ? "t" : "n"}:${messageId}`
+      ? `${hasToolUse ? "t" : "n"}:${messageId}:${contentLength ?? text.length}`
       : undefined;
 
   if (cacheKey) {
@@ -504,7 +507,12 @@ export function hasVisibleSegments(
   const role: "user" | "assistant" =
     msg.role === "user" ? "user" : "assistant";
   const segs = enrichSegments(
-    parseContent(msg.content, msg.has_tool_use, msg.id),
+    parseContent(
+      msg.content,
+      msg.has_tool_use,
+      msg.id,
+      msg.content_length,
+    ),
     msg.tool_calls,
   );
   // Empty messages (e.g. initial assistant streaming state) should

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -148,19 +148,24 @@ interface Match {
   segment: ContentSegment;
 }
 
-const toolOnlyCache = new LRUCache<string, boolean>(12000);
-const segmentCache = new LRUCache<string, ContentSegment[]>(8000);
+const toolOnlyCache = new LRUCache<number, boolean>(500);
+const segmentCache = new LRUCache<string, ContentSegment[]>(500);
+
+/** Clear both content-parser caches. Call on session switch
+ *  to prevent cross-session memory accumulation. */
+export function clearContentCaches(): void {
+  toolOnlyCache.clear();
+  segmentCache.clear();
+}
 
 /** Returns true if the message contains only tool calls (no text) */
 export function isToolOnly(msg: Message): boolean {
-  const key =
-    `${msg.role}|${msg.has_tool_use ? 1 : 0}|${msg.content}`;
-  const cached = toolOnlyCache.get(key);
+  const cached = toolOnlyCache.get(msg.id);
   if (cached !== undefined) return cached;
 
   if (msg.role !== "assistant") return false;
   if (!msg.has_tool_use) {
-    toolOnlyCache.set(key, false);
+    toolOnlyCache.set(msg.id, false);
     return false;
   }
   const stripped = msg.content
@@ -169,7 +174,7 @@ export function isToolOnly(msg: Message): boolean {
     .replace(TOOL_RE, "")
     .trim();
   const result = stripped.length === 0;
-  toolOnlyCache.set(key, result);
+  toolOnlyCache.set(msg.id, result);
   return result;
 }
 
@@ -347,14 +352,26 @@ function mergeThinking(
   return result;
 }
 
-/** Parse message content into typed segments */
-export function parseContent(text: string, hasToolUse = true): ContentSegment[] {
+/** Parse message content into typed segments.
+ *  Pass messageId to enable LRU caching keyed by ID
+ *  instead of by full text (avoids storing huge strings
+ *  as Map keys). */
+export function parseContent(
+  text: string,
+  hasToolUse = true,
+  messageId?: number,
+): ContentSegment[] {
   if (!text) return [];
-  const cacheKey = hasToolUse
-    ? `tools\0${text}`
-    : `notools\0${text}`;
-  const cached = segmentCache.get(cacheKey);
-  if (cached) return cached;
+
+  const cacheKey =
+    messageId !== undefined
+      ? `${hasToolUse ? "t" : "n"}:${messageId}`
+      : undefined;
+
+  if (cacheKey) {
+    const cached = segmentCache.get(cacheKey);
+    if (cached) return cached;
+  }
 
   const matches = extractMatches(text, hasToolUse);
 
@@ -362,7 +379,7 @@ export function parseContent(text: string, hasToolUse = true): ContentSegment[] 
     const onlyText: ContentSegment[] = [
       { type: "text", content: text.trimEnd() },
     ];
-    segmentCache.set(cacheKey, onlyText);
+    if (cacheKey) segmentCache.set(cacheKey, onlyText);
     return onlyText;
   }
 
@@ -371,7 +388,7 @@ export function parseContent(text: string, hasToolUse = true): ContentSegment[] 
     buildSegments(text, deduped),
   );
 
-  segmentCache.set(cacheKey, segments);
+  if (cacheKey) segmentCache.set(cacheKey, segments);
   return segments;
 }
 
@@ -487,7 +504,7 @@ export function hasVisibleSegments(
   const role: "user" | "assistant" =
     msg.role === "user" ? "user" : "assistant";
   const segs = enrichSegments(
-    parseContent(msg.content, msg.has_tool_use),
+    parseContent(msg.content, msg.has_tool_use, msg.id),
     msg.tool_calls,
   );
   // Empty messages (e.g. initial assistant streaming state) should

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -160,7 +160,8 @@ export function clearContentCaches(): void {
 
 /** Returns true if the message contains only tool calls (no text) */
 export function isToolOnly(msg: Message): boolean {
-  const key = `${msg.id}:${msg.content_length}`;
+  const len = msg.content_length ?? msg.content.length;
+  const key = `${msg.id}:${len}:${msg.has_tool_use ? 1 : 0}`;
   const cached = toolOnlyCache.get(key);
   if (cached !== undefined) return cached;
 

--- a/frontend/src/lib/utils/display-items.test.ts
+++ b/frontend/src/lib/utils/display-items.test.ts
@@ -3,11 +3,13 @@ import { buildDisplayItems } from "./display-items.js";
 import { hasVisibleSegments } from "./content-parser.js";
 import type { Message } from "../api/types.js";
 
+let nextId = 1;
+
 function msg(
   overrides: Partial<Message> & { content: string },
 ): Message {
   return {
-    id: 1,
+    id: nextId++,
     session_id: "s1",
     ordinal: 0,
     role: "assistant",

--- a/frontend/src/lib/utils/transcript-mode.test.ts
+++ b/frontend/src/lib/utils/transcript-mode.test.ts
@@ -6,11 +6,13 @@ import {
   shouldAutoSwitchTranscriptModeToNormal,
 } from "./transcript-mode.js";
 
+let nextId = 1;
+
 function msg(
   overrides: Partial<Message> & { content: string },
 ): Message {
   return {
-    id: 1,
+    id: nextId++,
     session_id: "s1",
     ordinal: 0,
     role: "assistant",


### PR DESCRIPTION
## Summary

- Rekey `segmentCache` and `toolOnlyCache` in `content-parser.ts` by
  message ID instead of full message text. The old approach stored each
  message's content 2-3x in memory (as Map key + parsed segment values).
  With tool outputs averaging 10-100KB, the 8,000/12,000-entry caches
  alone could consume 500MB-1.5GB in the WebView process.
- Reduce cache capacity from 8,000/12,000 to 500 (sufficient for a
  virtual-scrolled viewport of ~30 visible items).
- Clear caches on session switch and full reload to prevent stale
  entries after DB rebuilds.
- Add `LRUCache.clear()` method.

## Test plan

- [x] All 882 frontend tests pass
- [x] TypeScript type-check passes (pre-existing errors only)
- [ ] Manual: open app, browse sessions, switch between sessions,
  verify memory stays reasonable in Activity Monitor
- [ ] Manual: trigger a resync while viewing a session, confirm
  content renders correctly afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)