### PR TITLE
feat: import modal UI redesign with progress streaming

### DIFF
--- a/cmd/agentsview/import.go
+++ b/cmd/agentsview/import.go
@@ -107,11 +107,20 @@ func runClaudeAIImport(
 	defer f.Close()
 
 	return importer.ImportClaudeAI(
-		ctx, database, f, func(n int) {
-			fmt.Fprintf(
-				os.Stderr,
-				"\rImported %d conversations...", n,
-			)
+		ctx, database, f, &importer.ImportCallbacks{
+			OnProgress: func(s importer.ImportStats) {
+				n := s.Imported + s.Updated + s.Skipped
+				fmt.Fprintf(
+					os.Stderr,
+					"\r%d conversations processed...", n,
+				)
+			},
+			OnIndexing: func() {
+				fmt.Fprintf(
+					os.Stderr,
+					"\rRebuilding search index...   ",
+				)
+			},
 		},
 	)
 }
@@ -122,12 +131,20 @@ func runChatGPTImport(
 ) (importer.ImportStats, error) {
 	return importer.ImportChatGPT(
 		ctx, database, dir, assetsDir,
-		func(processed int) {
-			fmt.Fprintf(
-				os.Stderr,
-				"\rProcessed %d conversations...",
-				processed,
-			)
+		&importer.ImportCallbacks{
+			OnProgress: func(s importer.ImportStats) {
+				n := s.Imported + s.Skipped
+				fmt.Fprintf(
+					os.Stderr,
+					"\r%d conversations processed...", n,
+				)
+			},
+			OnIndexing: func() {
+				fmt.Fprintf(
+					os.Stderr,
+					"\rRebuilding search index...   ",
+				)
+			},
 		},
 	)
 }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -994,9 +994,12 @@ export async function importClaudeAI(
 ): Promise<ImportStats> {
   const form = new FormData();
   form.append("file", file);
+  const init = authHeaders({ method: "POST", body: form });
+  const headers = new Headers(init.headers);
+  headers.set("Accept", "text/event-stream");
   const res = await fetch(
     `${getBase()}/import/claude-ai`,
-    authHeaders({ method: "POST", body: form }),
+    { ...init, headers },
   );
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
@@ -1017,9 +1020,12 @@ export async function importChatGPT(
 ): Promise<ImportStats> {
   const form = new FormData();
   form.append("file", file);
+  const init = authHeaders({ method: "POST", body: form });
+  const headers = new Headers(init.headers);
+  headers.set("Accept", "text/event-stream");
   const res = await fetch(
     `${getBase()}/import/chatgpt`,
-    authHeaders({ method: "POST", body: form }),
+    { ...init, headers },
   );
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -924,9 +924,74 @@ export async function emptyTrash(): Promise<{ deleted: number }> {
 
 /* Import */
 
+export interface ImportStats {
+  imported: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+}
+
+export interface ImportCallbacks {
+  onProgress?: (stats: ImportStats) => void;
+  onIndexing?: () => void;
+}
+
+async function readImportSSE(
+  res: Response,
+  cb?: ImportCallbacks,
+): Promise<ImportStats> {
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let result: ImportStats | null = null;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+
+    // Process complete SSE frames (double newline delimited).
+    let idx: number;
+    while ((idx = buf.indexOf("\n\n")) !== -1) {
+      const frame = buf.slice(0, idx);
+      buf = buf.slice(idx + 2);
+
+      let event = "";
+      let data = "";
+      for (const line of frame.split("\n")) {
+        if (line.startsWith("event: ")) event = line.slice(7);
+        else if (line.startsWith("data: ")) data = line.slice(6);
+      }
+      if (!event || !data) continue;
+
+      const parsed = JSON.parse(data);
+      switch (event) {
+        case "progress":
+          cb?.onProgress?.(parsed as ImportStats);
+          break;
+        case "indexing":
+          cb?.onIndexing?.();
+          break;
+        case "done":
+          result = parsed as ImportStats;
+          break;
+        case "error":
+          throw new Error(
+            (parsed as { error?: string }).error
+            ?? "Import failed",
+          );
+      }
+    }
+  }
+
+  if (!result) throw new Error("Import stream ended without result");
+  return result;
+}
+
 export async function importClaudeAI(
   file: File,
-): Promise<{ imported: number; updated: number; errors: number }> {
+  cb?: ImportCallbacks,
+): Promise<ImportStats> {
   const form = new FormData();
   form.append("file", file);
   const res = await fetch(
@@ -940,12 +1005,16 @@ export async function importClaudeAI(
       ?? `Import failed (${res.status})`,
     );
   }
+  if (res.headers.get("content-type")?.includes("text/event-stream")) {
+    return readImportSSE(res, cb);
+  }
   return res.json();
 }
 
 export async function importChatGPT(
   file: File,
-): Promise<{ imported: number; updated: number; skipped: number; errors: number }> {
+  cb?: ImportCallbacks,
+): Promise<ImportStats> {
   const form = new FormData();
   form.append("file", file);
   const res = await fetch(
@@ -958,6 +1027,9 @@ export async function importChatGPT(
       (err as { error?: string }).error
       ?? `Import failed (${res.status})`,
     );
+  }
+  if (res.headers.get("content-type")?.includes("text/event-stream")) {
+    return readImportSSE(res, cb);
   }
   return res.json();
 }

--- a/frontend/src/lib/components/import/ImportModal.svelte
+++ b/frontend/src/lib/components/import/ImportModal.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { importClaudeAI, importChatGPT } from "../../api/client.js";
+  import {
+    importClaudeAI,
+    importChatGPT,
+  } from "../../api/client.js";
 
   interface Props {
     open: boolean;
@@ -7,21 +10,50 @@
     onimported: () => void;
   }
 
-  let { open = $bindable(), onclose, onimported }: Props = $props();
+  let {
+    open = $bindable(),
+    onclose,
+    onimported,
+  }: Props = $props();
 
-  let fileInput: HTMLInputElement | undefined = $state();
-  let selectedFile: File | null = $state(null);
-  let provider: "claude-ai" | "chatgpt" = $state("claude-ai");
-  let importing = $state(false);
-  let result: {
+  type ImportResult = {
     imported: number;
     updated: number;
     skipped?: number;
     errors: number;
-  } | null = $state(null);
-  let error: string | null = $state(null);
+  };
 
-  // Reset file selection when provider changes.
+  let fileInput: HTMLInputElement | undefined = $state();
+  let selectedFile = $state<File | null>(null);
+  let provider: "claude-ai" | "chatgpt" =
+    $state("claude-ai");
+  let importing = $state(false);
+  let dragOver = $state(false);
+  let dragCount = $state(0);
+  let result = $state<ImportResult | null>(null);
+  let error = $state<string | null>(null);
+
+  const fileSize = $derived(
+    selectedFile
+      ? selectedFile.size < 1024 * 1024
+        ? `${(selectedFile.size / 1024).toFixed(1)} KB`
+        : `${(selectedFile.size / (1024 * 1024)).toFixed(1)} MB`
+      : "",
+  );
+
+  const accepted = $derived(
+    provider === "claude-ai" ? ".json,.zip" : ".zip",
+  );
+
+  const totalProcessed = $derived(
+    result
+      ? result.imported +
+          result.updated +
+          (result.skipped ?? 0)
+      : 0,
+  );
+
+  // Reset file when provider changes.
   $effect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     provider;
@@ -31,11 +63,66 @@
     if (fileInput) fileInput.value = "";
   });
 
+  function selectProvider(p: typeof provider) {
+    if (importing) return;
+    provider = p;
+  }
+
   function handleFileChange(e: Event) {
     const input = e.target as HTMLInputElement;
     selectedFile = input.files?.[0] ?? null;
     result = null;
     error = null;
+  }
+
+  function handleDragEnter(e: DragEvent) {
+    e.preventDefault();
+    dragCount++;
+    if (!importing) dragOver = true;
+  }
+
+  function handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+  }
+
+  function handleDragLeave() {
+    dragCount--;
+    if (dragCount <= 0) {
+      dragCount = 0;
+      dragOver = false;
+    }
+  }
+
+  function handleDrop(e: DragEvent) {
+    e.preventDefault();
+    dragCount = 0;
+    dragOver = false;
+    if (importing) return;
+
+    const file = e.dataTransfer?.files[0];
+    if (!file) return;
+
+    const ext =
+      file.name.toLowerCase().split(".").pop() ?? "";
+    const allowed =
+      provider === "claude-ai"
+        ? ["json", "zip"]
+        : ["zip"];
+    if (!allowed.includes(ext)) {
+      error =
+        `Expected ${allowed.map((s) => "." + s).join(" or ")} file`;
+      return;
+    }
+    selectedFile = file;
+    result = null;
+    error = null;
+  }
+
+  function clearFile() {
+    selectedFile = null;
+    error = null;
+    if (fileInput) fileInput.value = "";
   }
 
   async function handleImport() {
@@ -53,7 +140,10 @@
       }
       onimported();
     } catch (e) {
-      error = e instanceof Error ? e.message : "Import failed";
+      error =
+        e instanceof Error
+          ? e.message
+          : "Import failed";
     } finally {
       importing = false;
     }
@@ -64,71 +154,296 @@
     selectedFile = null;
     result = null;
     error = null;
+    dragOver = false;
+    dragCount = 0;
     open = false;
     onclose();
+  }
+
+  function handleReset() {
+    selectedFile = null;
+    result = null;
+    error = null;
+    if (fileInput) fileInput.value = "";
   }
 </script>
 
 {#if open}
-  <div class="modal-backdrop" role="presentation" onkeydown={(e) => e.key === "Escape" && handleClose()} onclick={handleClose}>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <!-- svelte-ignore a11y_interactive_supports_focus -->
-    <div class="modal" role="dialog" aria-modal="true" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.key === "Escape" && handleClose()}>
-      <h3>Import Conversations</h3>
-
-      <div class="provider-select">
-        <label>
-          <input type="radio" bind:group={provider} value="claude-ai" disabled={importing} />
-          Claude.ai
-        </label>
-        <label>
-          <input type="radio" bind:group={provider} value="chatgpt" disabled={importing} />
-          ChatGPT
-        </label>
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="modal-overlay"
+    onclick={(e) => {
+      if (
+        (e.target as HTMLElement).classList.contains(
+          "modal-overlay",
+        )
+      )
+        handleClose();
+    }}
+    onkeydown={(e) => {
+      if (e.key === "Escape") handleClose();
+    }}
+  >
+    <div
+      class="modal-panel import-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Import conversations"
+    >
+      <div class="modal-header">
+        <h3 class="modal-title">Import Conversations</h3>
+        <button
+          class="modal-close"
+          onclick={handleClose}
+          disabled={importing}
+          aria-label="Close"
+        >&times;</button>
       </div>
 
-      <p class="instructions">
-        {#if provider === "claude-ai"}
-          Upload <code>conversations.json</code> or a <code>.zip</code> from a Claude.ai data export.
+      <div class="modal-body">
+        {#if result}
+          <!-- ── Results ── -->
+          <div class="result-view">
+            <div class="result-check">
+              <svg
+                width="32"
+                height="32"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="var(--accent-green)"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M8 12l3 3 5-5"
+                  stroke="var(--accent-green)"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+
+            <p class="result-heading">
+              {totalProcessed}
+              conversation{totalProcessed !== 1
+                ? "s"
+                : ""}
+              processed
+            </p>
+
+            <div class="result-stats">
+              <div class="stat">
+                <span class="stat-num new">
+                  {result.imported}
+                </span>
+                <span class="stat-lbl">new</span>
+              </div>
+              <div class="stat">
+                <span class="stat-num updated">
+                  {result.updated}
+                </span>
+                <span class="stat-lbl">updated</span>
+              </div>
+              {#if (result.skipped ?? 0) > 0}
+                <div class="stat">
+                  <span class="stat-num skipped">
+                    {result.skipped}
+                  </span>
+                  <span class="stat-lbl">skipped</span>
+                </div>
+              {/if}
+              {#if result.errors > 0}
+                <div class="stat">
+                  <span class="stat-num errors">
+                    {result.errors}
+                  </span>
+                  <span class="stat-lbl">errors</span>
+                </div>
+              {/if}
+            </div>
+
+            <div class="result-actions">
+              <button
+                class="modal-btn"
+                onclick={handleReset}
+              >
+                Import more
+              </button>
+              <button
+                class="modal-btn modal-btn-primary"
+                onclick={handleClose}
+              >
+                Done
+              </button>
+            </div>
+          </div>
         {:else}
-          Upload a <code>.zip</code> from a ChatGPT data export.
-        {/if}
-      </p>
+          <!-- ── Provider selector ── -->
+          <div class="provider-strip">
+            <button
+              class="provider-pill"
+              class:selected={provider === "claude-ai"}
+              onclick={() => selectProvider("claude-ai")}
+              disabled={importing}
+            >
+              <span class="pdot claude"></span>
+              <span>Claude.ai</span>
+            </button>
+            <button
+              class="provider-pill"
+              class:selected={provider === "chatgpt"}
+              onclick={() => selectProvider("chatgpt")}
+              disabled={importing}
+            >
+              <span class="pdot chatgpt"></span>
+              <span>ChatGPT</span>
+            </button>
+          </div>
 
-      <input
-        bind:this={fileInput}
-        type="file"
-        accept={provider === "claude-ai" ? ".json,.zip" : ".zip"}
-        onchange={handleFileChange}
-        disabled={importing}
-      />
+          <p class="hint">
+            {#if provider === "claude-ai"}
+              Upload <code>conversations.json</code> or
+              the <code>.zip</code> from a Claude.ai data
+              export.
+            {:else}
+              Upload the <code>.zip</code> from a ChatGPT
+              data export.
+            {/if}
+          </p>
 
-      {#if error}
-        <p class="error">{error}</p>
-      {/if}
-
-      {#if result}
-        <p class="success">
-          {result.imported + result.updated + (result.skipped ?? 0)} conversations processed
-          ({result.imported} new{#if result.updated > 0}, {result.updated} updated{/if}{#if (result.skipped ?? 0) > 0}, {result.skipped} skipped{/if})
-          {#if result.errors > 0}
-            , {result.errors} errors
+          <!-- ── Drop zone ── -->
+          {#if importing}
+            <div class="zone zone-importing">
+              <div class="modal-spinner"></div>
+              <span class="importing-label">
+                Importing conversations...
+              </span>
+            </div>
+          {:else if selectedFile}
+            <div class="zone zone-file">
+              <div class="file-row">
+                <svg
+                  class="file-icon"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                >
+                  <path d="M4 0a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4.5L9.5 0H4zM9 1v3.5A1.5 1.5 0 0010.5 6H14v8a1 1 0 01-1 1H4a1 1 0 01-1-1V2a1 1 0 011-1h5z"/>
+                </svg>
+                <div class="file-meta">
+                  <span class="file-name">
+                    {selectedFile.name}
+                  </span>
+                  <span class="file-size">
+                    {fileSize}
+                  </span>
+                </div>
+                <button
+                  class="file-clear"
+                  onclick={clearFile}
+                  title="Remove file"
+                  aria-label="Remove file"
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                  >
+                    <path d="M4.646 4.646a.5.5 0 01.708 0L8 7.293l2.646-2.647a.5.5 0 01.708.708L8.707 8l2.647 2.646a.5.5 0 01-.708.708L8 8.707l-2.646 2.647a.5.5 0 01-.708-.708L7.293 8 4.646 5.354a.5.5 0 010-.708z"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+          {:else}
+            <div
+              class="zone zone-empty"
+              class:drag-over={dragOver}
+              role="button"
+              tabindex="0"
+              ondragenter={handleDragEnter}
+              ondragover={handleDragOver}
+              ondragleave={handleDragLeave}
+              ondrop={handleDrop}
+              onclick={() => fileInput?.click()}
+              onkeydown={(e) => {
+                if (
+                  e.key === "Enter" ||
+                  e.key === " "
+                ) {
+                  e.preventDefault();
+                  fileInput?.click();
+                }
+              }}
+            >
+              <svg
+                class="upload-icon"
+                width="28"
+                height="28"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+                <polyline points="17 8 12 3 7 8"/>
+                <line x1="12" y1="3" x2="12" y2="15"/>
+              </svg>
+              <span class="drop-label">
+                Drop your file here
+              </span>
+              <span class="drop-sub">
+                or click to browse
+              </span>
+            </div>
           {/if}
-        </p>
-      {/if}
 
-      <div class="actions">
-        <button onclick={handleClose} disabled={importing}>
-          {result ? "Close" : "Cancel"}
-        </button>
-        {#if !result}
-          <button
-            class="primary"
-            onclick={handleImport}
-            disabled={!selectedFile || importing}
-          >
-            {importing ? "Importing..." : "Import"}
-          </button>
+          <input
+            bind:this={fileInput}
+            type="file"
+            accept={accepted}
+            onchange={handleFileChange}
+            class="sr-only"
+          />
+
+          {#if error}
+            <div class="import-error">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+              >
+                <path d="M8.982 1.566a1.13 1.13 0 00-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 01-1.1 0L7.1 5.995A.905.905 0 018 5zm.002 6a1 1 0 110 2 1 1 0 010-2z"/>
+              </svg>
+              <span>{error}</span>
+            </div>
+          {/if}
+
+          <div class="import-actions">
+            <button
+              class="modal-btn"
+              onclick={handleClose}
+              disabled={importing}
+            >
+              Cancel
+            </button>
+            <button
+              class="modal-btn modal-btn-primary"
+              onclick={handleImport}
+              disabled={!selectedFile || importing}
+            >
+              Import
+            </button>
+          </div>
         {/if}
       </div>
     </div>
@@ -136,98 +451,381 @@
 {/if}
 
 <style>
-  .modal-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.5);
+  /* ── Panel ── */
+  .import-panel {
+    width: 460px;
+    max-width: 92vw;
+    animation: panel-in 0.2s ease-out;
+  }
+
+  @keyframes panel-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px) scale(0.98);
+    }
+  }
+
+  /* ── Provider strip ── */
+  .provider-strip {
+    display: flex;
+    gap: 1px;
+    background: var(--border-default);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    margin-bottom: 12px;
+  }
+
+  .provider-pill {
+    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    gap: 7px;
+    height: 34px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+    background: var(--bg-surface);
+    transition: color 0.12s, background 0.12s;
   }
 
-  .modal {
-    background: var(--bg-primary);
-    border: 1px solid var(--border-primary);
-    border-radius: 8px;
-    padding: 1.5rem;
-    max-width: 28rem;
-    width: 90%;
+  .provider-pill:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+    color: var(--text-secondary);
   }
 
-  h3 {
-    margin: 0 0 0.5rem;
-    font-size: 1rem;
+  .provider-pill.selected {
+    color: var(--text-primary);
+    font-weight: 600;
   }
 
-  .provider-select {
+  .pdot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    opacity: 0.35;
+    transition: opacity 0.15s;
+  }
+
+  .provider-pill.selected .pdot {
+    opacity: 1;
+  }
+
+  .pdot.claude {
+    background: var(--accent-coral);
+  }
+
+  .pdot.chatgpt {
+    background: var(--accent-green);
+  }
+
+  /* ── Hint ── */
+  .hint {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+    line-height: 1.5;
+  }
+
+  .hint code {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    background: var(--bg-inset);
+    padding: 1px 5px;
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+  }
+
+  /* ── Drop zone (shared) ── */
+  .zone {
     display: flex;
-    gap: 1rem;
-    margin-bottom: 1rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border-radius: var(--radius-lg);
+    margin-bottom: 12px;
+    transition:
+      border-color 0.15s,
+      background 0.15s,
+      box-shadow 0.15s;
   }
 
-  .provider-select label {
+  /* Empty: dashed border, invites interaction */
+  .zone-empty {
+    min-height: 140px;
+    padding: 24px;
+    border: 2px dashed var(--border-default);
+    cursor: pointer;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.03);
+  }
+
+  .zone-empty:hover {
+    border-color: var(--text-muted);
+    background: var(--bg-surface-hover);
+  }
+
+  .zone-empty:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 2px;
+  }
+
+  .zone-empty.drag-over {
+    border-color: var(--accent-blue);
+    border-style: solid;
+    background: color-mix(
+      in srgb,
+      var(--accent-blue) 6%,
+      transparent
+    );
+    box-shadow: 0 0 0 3px
+      color-mix(
+        in srgb,
+        var(--accent-blue) 12%,
+        transparent
+      );
+  }
+
+  .zone-empty.drag-over .upload-icon {
+    color: var(--accent-blue);
+    animation: icon-lift 0.35s ease-out;
+  }
+
+  @keyframes icon-lift {
+    0% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-3px);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+
+  .upload-icon {
+    color: var(--text-muted);
+    margin-bottom: 2px;
+    transition: color 0.15s;
+  }
+
+  .drop-label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  .drop-sub {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  /* File selected */
+  .zone-file {
+    border: 1px solid var(--border-default);
+    background: var(--bg-inset);
+    padding: 12px 16px;
+  }
+
+  .file-row {
     display: flex;
     align-items: center;
-    gap: 0.3rem;
-    font-size: 0.85rem;
-    cursor: pointer;
-  }
-
-  .instructions {
-    color: var(--text-secondary);
-    font-size: 0.85rem;
-    margin: 0 0 1rem;
-  }
-
-  code {
-    background: var(--bg-secondary);
-    padding: 0.1em 0.3em;
-    border-radius: 3px;
-    font-size: 0.85em;
-  }
-
-  input[type="file"] {
+    gap: 10px;
     width: 100%;
-    margin-bottom: 1rem;
   }
 
-  .error {
-    color: var(--accent-red, #e53e3e);
-    font-size: 0.85rem;
-    margin: 0 0 1rem;
+  .file-icon {
+    color: var(--text-muted);
+    flex-shrink: 0;
   }
 
-  .success {
-    color: var(--accent-green, #38a169);
-    font-size: 0.85rem;
-    margin: 0 0 1rem;
-  }
-
-  .actions {
+  .file-meta {
+    flex: 1;
+    min-width: 0;
     display: flex;
-    gap: 0.5rem;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .file-name {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .file-size {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .file-clear {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    flex-shrink: 0;
+    transition: background 0.08s, color 0.08s;
+  }
+
+  .file-clear:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  /* Importing state */
+  .zone-importing {
+    min-height: 140px;
+    padding: 24px;
+    border: 1px solid var(--border-muted);
+    background: var(--bg-inset);
+  }
+
+  .importing-label {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 4px;
+  }
+
+  /* ── Error ── */
+  .import-error {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 8px 12px;
+    border: 1px solid var(--accent-red);
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    color: var(--accent-red);
+    margin-bottom: 12px;
+    word-break: break-word;
+  }
+
+  .import-error svg {
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  /* ── Actions ── */
+  .import-actions {
+    display: flex;
+    gap: 8px;
     justify-content: flex-end;
   }
 
-  button {
-    padding: 0.4rem 1rem;
-    border: 1px solid var(--border-primary);
-    border-radius: 4px;
-    background: var(--bg-secondary);
+  /* ── Result view ── */
+  .result-view {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0 4px;
+  }
+
+  .result-check {
+    margin-bottom: 2px;
+    animation: check-pop 0.35s ease-out;
+  }
+
+  @keyframes check-pop {
+    0% {
+      opacity: 0;
+      transform: scale(0.6);
+    }
+    60% {
+      transform: scale(1.08);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .result-heading {
+    font-size: 14px;
+    font-weight: 600;
     color: var(--text-primary);
-    cursor: pointer;
-    font-size: 0.85rem;
   }
 
-  button.primary {
-    background: var(--accent-blue);
-    color: white;
-    border-color: var(--accent-blue);
+  .result-stats {
+    display: flex;
+    gap: 12px;
+    margin: 8px 0 4px;
   }
 
-  button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+  .stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    min-width: 56px;
+    padding: 8px 14px;
+    background: var(--bg-inset);
+    border-radius: var(--radius-md);
+    animation: stat-up 0.3s ease-out backwards;
+  }
+
+  .stat:nth-child(1) {
+    animation-delay: 0.05s;
+  }
+
+  .stat:nth-child(2) {
+    animation-delay: 0.12s;
+  }
+
+  .stat:nth-child(3) {
+    animation-delay: 0.19s;
+  }
+
+  .stat:nth-child(4) {
+    animation-delay: 0.26s;
+  }
+
+  @keyframes stat-up {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+  }
+
+  .stat-num {
+    font-size: 18px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat-num.new {
+    color: var(--accent-green);
+  }
+
+  .stat-num.updated {
+    color: var(--accent-blue);
+  }
+
+  .stat-num.skipped {
+    color: var(--accent-amber);
+  }
+
+  .stat-num.errors {
+    color: var(--accent-red);
+  }
+
+  .stat-lbl {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .result-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
   }
 </style>

--- a/frontend/src/lib/components/import/ImportModal.svelte
+++ b/frontend/src/lib/components/import/ImportModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import {
     importClaudeAI,
     importChatGPT,
@@ -53,14 +54,19 @@
       : 0,
   );
 
-  // Reset file when provider changes.
+  // Reset file when provider changes. The fileInput access
+  // must be untracked: when the result view replaces the
+  // upload view, bind:this sets fileInput to undefined,
+  // which would re-trigger this effect and wipe the results.
   $effect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     provider;
     selectedFile = null;
     result = null;
     error = null;
-    if (fileInput) fileInput.value = "";
+    untrack(() => {
+      if (fileInput) fileInput.value = "";
+    });
   });
 
   function selectProvider(p: typeof provider) {

--- a/frontend/src/lib/components/import/ImportModal.svelte
+++ b/frontend/src/lib/components/import/ImportModal.svelte
@@ -349,7 +349,8 @@
                 {@const n =
                   progressStats.imported +
                   progressStats.updated +
-                  progressStats.skipped}
+                  progressStats.skipped +
+                  progressStats.errors}
                 <span class="importing-label">
                   {n} conversation{n !== 1 ? "s" : ""}
                   processed...

--- a/frontend/src/lib/components/import/ImportModal.svelte
+++ b/frontend/src/lib/components/import/ImportModal.svelte
@@ -3,6 +3,7 @@
   import {
     importClaudeAI,
     importChatGPT,
+    type ImportStats,
   } from "../../api/client.js";
 
   interface Props {
@@ -20,7 +21,7 @@
   type ImportResult = {
     imported: number;
     updated: number;
-    skipped?: number;
+    skipped: number;
     errors: number;
   };
 
@@ -33,6 +34,10 @@
   let dragCount = $state(0);
   let result = $state<ImportResult | null>(null);
   let error = $state<string | null>(null);
+  let phase = $state<"importing" | "indexing">(
+    "importing",
+  );
+  let progressStats = $state<ImportStats | null>(null);
 
   const fileSize = $derived(
     selectedFile
@@ -50,7 +55,7 @@
     result
       ? result.imported +
           result.updated +
-          (result.skipped ?? 0)
+          result.skipped
       : 0,
   );
 
@@ -136,13 +141,23 @@
     importing = true;
     error = null;
     result = null;
+    phase = "importing";
+    progressStats = null;
+
+    const cb = {
+      onProgress: (stats: ImportStats) => {
+        progressStats = stats;
+      },
+      onIndexing: () => {
+        phase = "indexing";
+      },
+    };
 
     try {
       if (provider === "chatgpt") {
-        result = await importChatGPT(selectedFile);
+        result = await importChatGPT(selectedFile, cb);
       } else {
-        const r = await importClaudeAI(selectedFile);
-        result = { ...r, skipped: 0 };
+        result = await importClaudeAI(selectedFile, cb);
       }
       onimported();
     } catch (e) {
@@ -255,12 +270,12 @@
                 </span>
                 <span class="stat-lbl">updated</span>
               </div>
-              {#if (result.skipped ?? 0) > 0}
+              {#if result.skipped > 0}
                 <div class="stat">
                   <span class="stat-num skipped">
                     {result.skipped}
                   </span>
-                  <span class="stat-lbl">skipped</span>
+                  <span class="stat-lbl">unchanged</span>
                 </div>
               {/if}
               {#if result.errors > 0}
@@ -326,9 +341,24 @@
           {#if importing}
             <div class="zone zone-importing">
               <div class="modal-spinner"></div>
-              <span class="importing-label">
-                Importing conversations...
-              </span>
+              {#if phase === "indexing"}
+                <span class="importing-label">
+                  Rebuilding search index...
+                </span>
+              {:else if progressStats}
+                {@const n =
+                  progressStats.imported +
+                  progressStats.updated +
+                  progressStats.skipped}
+                <span class="importing-label">
+                  {n} conversation{n !== 1 ? "s" : ""}
+                  processed...
+                </span>
+              {:else}
+                <span class="importing-label">
+                  Importing conversations...
+                </span>
+              {/if}
             </div>
           {:else if selectedFile}
             <div class="zone zone-file">

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -425,15 +425,16 @@
     </button>
 
     <button
-      class="header-btn"
+      class="import-btn"
       onclick={() => showImportModal = true}
       title="Import conversations"
       aria-label="Import conversations"
     >
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
         <path d="M2.75 14A1.75 1.75 0 011 12.25v-2.5a.75.75 0 011.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0113.25 14H2.75z"/>
         <path d="M11.78 4.72a.75.75 0 00-1.06 0L8.75 6.69V1.5a.75.75 0 00-1.5 0v5.19L5.28 4.72a.75.75 0 00-1.06 1.06l3.25 3.25a.75.75 0 001.06 0l3.25-3.25a.75.75 0 000-1.06z"/>
       </svg>
+      <span class="import-label">Import</span>
     </button>
 
     <span class="header-divider"></span>
@@ -820,6 +821,26 @@
     animation: spin 1s linear infinite;
   }
 
+  /* ── Import button (icon + label) ── */
+  .import-btn {
+    height: 26px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 0 10px;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    white-space: nowrap;
+    transition: background 0.12s, color 0.12s;
+  }
+
+  .import-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
   .header-divider {
     width: 1px;
     height: 14px;
@@ -898,7 +919,8 @@
 
   /* 1024px: Hide nav button labels + search text/kbd */
   @media (max-width: 1023px) {
-    .nav-label {
+    .nav-label,
+    .import-label {
       display: none;
     }
 
@@ -980,7 +1002,8 @@
   @media (pointer: coarse) {
     .header-btn,
     .nav-btn,
-    .hamburger {
+    .hamburger,
+    .import-btn {
       min-width: 44px;
       min-height: 44px;
     }

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -42,14 +42,14 @@ func queryChunked(
 
 // AnalyticsFilter is the shared filter for all analytics queries.
 type AnalyticsFilter struct {
-	From            string // ISO date YYYY-MM-DD, inclusive
-	To              string // ISO date YYYY-MM-DD, inclusive
-	Machine         string // optional machine filter
-	Project         string // optional project filter
-	Agent           string // optional agent filter
-	Timezone        string // IANA timezone for day bucketing
-	DayOfWeek       *int   // nil = all, 0=Mon, 6=Sun (ISO)
-	Hour            *int   // nil = all, 0-23
+	From             string // ISO date YYYY-MM-DD, inclusive
+	To               string // ISO date YYYY-MM-DD, inclusive
+	Machine          string // optional machine filter
+	Project          string // optional project filter
+	Agent            string // optional agent filter
+	Timezone         string // IANA timezone for day bucketing
+	DayOfWeek        *int   // nil = all, 0=Mon, 6=Sun (ISO)
+	Hour             *int   // nil = all, 0-23
 	MinUserMessages  int    // user_message_count >= N
 	ExcludeOneShot   bool   // exclude sessions with user_message_count <= 1
 	ExcludeAutomated bool   // exclude automated (roborev) sessions

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -190,22 +190,22 @@ func (db *DB) DecodeCursor(s string) (SessionCursor, error) {
 
 // SessionFilter specifies how to query sessions.
 type SessionFilter struct {
-	Project         string
-	ExcludeProject  string // exclude sessions with this project name
-	Machine         string
-	Agent           string
-	Date            string // exact date YYYY-MM-DD
-	DateFrom        string // range start (inclusive)
-	DateTo          string // range end (inclusive)
-	ActiveSince     string // ISO-8601 timestamp; filters on most recent activity
-	MinMessages     int    // message_count >= N (0 = no filter)
-	MaxMessages     int    // message_count <= N (0 = no filter)
-	MinUserMessages int    // user_message_count >= N (0 = no filter)
+	Project          string
+	ExcludeProject   string // exclude sessions with this project name
+	Machine          string
+	Agent            string
+	Date             string // exact date YYYY-MM-DD
+	DateFrom         string // range start (inclusive)
+	DateTo           string // range end (inclusive)
+	ActiveSince      string // ISO-8601 timestamp; filters on most recent activity
+	MinMessages      int    // message_count >= N (0 = no filter)
+	MaxMessages      int    // message_count <= N (0 = no filter)
+	MinUserMessages  int    // user_message_count >= N (0 = no filter)
 	ExcludeOneShot   bool   // exclude sessions with user_message_count <= 1
 	ExcludeAutomated bool   // exclude sessions where is_automated = 1
 	IncludeChildren  bool   // include subagent sessions (for sidebar grouping)
-	Cursor          string // opaque cursor from previous page
-	Limit           int
+	Cursor           string // opaque cursor from previous page
+	Limit            int
 }
 
 // SessionPage is a page of session results.

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -80,16 +80,17 @@ func (f *lazyFTS) suspend() {
 	f.dropped = true
 }
 
-func (f *lazyFTS) restore() {
+func (f *lazyFTS) restore() error {
 	if f == nil || !f.dropped {
-		return
+		return nil
 	}
 	if f.onIndexing != nil {
 		f.onIndexing()
 	}
 	if err := f.sus.RebuildFTS(); err != nil {
-		log.Printf("import: rebuild FTS: %v", err)
+		return fmt.Errorf("rebuilding FTS index: %w", err)
 	}
+	return nil
 }
 
 // ImportClaudeAI reads a Claude.ai conversations.json export
@@ -102,11 +103,13 @@ func ImportClaudeAI(
 	store db.Store,
 	r io.Reader,
 	cb *ImportCallbacks,
-) (ImportStats, error) {
+) (stats ImportStats, retErr error) {
 	fts := newLazyFTS(store, cb.indexing)
-	defer fts.restore()
-
-	var stats ImportStats
+	defer func() {
+		if err := fts.restore(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	err := parser.ParseClaudeAIExport(r, func(
 		result parser.ParseResult,
@@ -140,7 +143,8 @@ func ImportClaudeAI(
 		return nil
 	})
 
-	return stats, err
+	retErr = err
+	return
 }
 
 type importStatus int
@@ -197,9 +201,14 @@ func upsertConversation(
 	}
 
 	// Skip expensive message replacement when the conversation
-	// has not changed since the last import.
+	// has not changed since the last import. Compare both
+	// message count and ended_at (source updated_at) to detect
+	// content/metadata changes even when count is unchanged.
 	if !isNew && existing.MessageCount == s.MessageCount {
-		return importSkipped, nil
+		newEnd := timeStr(s.EndedAt)
+		if ptrEqual(existing.EndedAt, newEnd) {
+			return importSkipped, nil
+		}
 	}
 
 	// Suspend FTS before first message-changing operation to
@@ -257,11 +266,13 @@ func ImportChatGPT(
 	dir string,
 	assetsDir string,
 	cb *ImportCallbacks,
-) (ImportStats, error) {
+) (stats ImportStats, retErr error) {
 	fts := newLazyFTS(store, cb.indexing)
-	defer fts.restore()
-
-	var stats ImportStats
+	defer func() {
+		if err := fts.restore(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	index := BuildAssetIndex(dir)
 	resolver := &assetResolverAdapter{
@@ -357,7 +368,18 @@ func ImportChatGPT(
 		},
 	)
 
-	return stats, err
+	retErr = err
+	return
+}
+
+func ptrEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 func strPtr(s string) *string {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -304,8 +304,6 @@ func ImportChatGPT(
 				return nil
 			}
 
-			fts.suspend()
-
 			sess := db.Session{
 				ID:               s.ID,
 				Project:          s.Project,
@@ -332,6 +330,8 @@ func ImportChatGPT(
 				cb.progress(stats)
 				return nil
 			}
+
+			fts.suspend()
 
 			msgs := make([]db.Message, len(result.Messages))
 			for i, m := range result.Messages {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -20,6 +20,27 @@ type ImportStats struct {
 	Errors   int `json:"errors"`
 }
 
+// ImportCallbacks provides optional progress reporting.
+type ImportCallbacks struct {
+	// OnProgress fires after each conversation with current
+	// cumulative stats.
+	OnProgress func(ImportStats)
+	// OnIndexing fires before the FTS index rebuild starts.
+	OnIndexing func()
+}
+
+func (c *ImportCallbacks) progress(s ImportStats) {
+	if c != nil && c.OnProgress != nil {
+		c.OnProgress(s)
+	}
+}
+
+func (c *ImportCallbacks) indexing() {
+	if c != nil && c.OnIndexing != nil {
+		c.OnIndexing()
+	}
+}
+
 // ftsSuspender is optionally implemented by stores that
 // support dropping and rebuilding FTS indexes.
 type ftsSuspender interface {
@@ -33,16 +54,19 @@ type ftsSuspender interface {
 // avoids the expensive FTS rebuild when re-importing an
 // unchanged archive.
 type lazyFTS struct {
-	sus     ftsSuspender
-	dropped bool
+	sus        ftsSuspender
+	dropped    bool
+	onIndexing func()
 }
 
-func newLazyFTS(store db.Store) *lazyFTS {
+func newLazyFTS(
+	store db.Store, onIndexing func(),
+) *lazyFTS {
 	s, ok := store.(ftsSuspender)
 	if !ok || !store.HasFTS() {
 		return nil
 	}
-	return &lazyFTS{sus: s}
+	return &lazyFTS{sus: s, onIndexing: onIndexing}
 }
 
 func (f *lazyFTS) suspend() {
@@ -60,6 +84,9 @@ func (f *lazyFTS) restore() {
 	if f == nil || !f.dropped {
 		return
 	}
+	if f.onIndexing != nil {
+		f.onIndexing()
+	}
 	if err := f.sus.RebuildFTS(); err != nil {
 		log.Printf("import: rebuild FTS: %v", err)
 	}
@@ -74,9 +101,9 @@ func ImportClaudeAI(
 	ctx context.Context,
 	store db.Store,
 	r io.Reader,
-	onProgress func(imported int),
+	cb *ImportCallbacks,
 ) (ImportStats, error) {
-	fts := newLazyFTS(store)
+	fts := newLazyFTS(store, cb.indexing)
 	defer fts.restore()
 
 	var stats ImportStats
@@ -109,11 +136,7 @@ func ImportClaudeAI(
 			stats.Skipped++
 		}
 
-		if onProgress != nil {
-			total := stats.Imported + stats.Updated + stats.Skipped
-			onProgress(total)
-		}
-
+		cb.progress(stats)
 		return nil
 	})
 
@@ -233,9 +256,9 @@ func ImportChatGPT(
 	store db.Store,
 	dir string,
 	assetsDir string,
-	onProgress func(processed int),
+	cb *ImportCallbacks,
 ) (ImportStats, error) {
-	fts := newLazyFTS(store)
+	fts := newLazyFTS(store, cb.indexing)
 	defer fts.restore()
 
 	var stats ImportStats
@@ -264,9 +287,7 @@ func ImportChatGPT(
 			}
 			if existing != nil {
 				stats.Skipped++
-				if onProgress != nil {
-					onProgress(stats.Imported + stats.Skipped)
-				}
+				cb.progress(stats)
 				return nil
 			}
 
@@ -288,9 +309,7 @@ func ImportChatGPT(
 			if err := store.UpsertSession(sess); err != nil {
 				if errors.Is(err, db.ErrSessionExcluded) {
 					stats.Skipped++
-					if onProgress != nil {
-						onProgress(stats.Imported + stats.Skipped)
-					}
+					cb.progress(stats)
 					return nil
 				}
 				stats.Errors++
@@ -333,9 +352,7 @@ func ImportChatGPT(
 			}
 
 			stats.Imported++
-			if onProgress != nil {
-				onProgress(stats.Imported + stats.Skipped)
-			}
+			cb.progress(stats)
 			return nil
 		},
 	)

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -21,30 +21,47 @@ type ImportStats struct {
 }
 
 // ftsSuspender is optionally implemented by stores that
-// support dropping and rebuilding FTS indexes. Suspending
-// FTS during bulk imports avoids per-row trigger overhead.
+// support dropping and rebuilding FTS indexes.
 type ftsSuspender interface {
 	DropFTS() error
 	RebuildFTS() error
 }
 
-// suspendFTS drops FTS triggers before a bulk import and
-// returns a function that rebuilds the index. If the store
-// does not support FTS or FTS is unavailable, the returned
-// function is a no-op.
-func suspendFTS(store db.Store) func() {
+// lazyFTS suspends FTS triggers on first call to suspend()
+// and rebuilds on restore(). If suspend() is never called
+// (no message work happened), restore() is a no-op. This
+// avoids the expensive FTS rebuild when re-importing an
+// unchanged archive.
+type lazyFTS struct {
+	sus     ftsSuspender
+	dropped bool
+}
+
+func newLazyFTS(store db.Store) *lazyFTS {
 	s, ok := store.(ftsSuspender)
 	if !ok || !store.HasFTS() {
-		return func() {}
+		return nil
 	}
-	if err := s.DropFTS(); err != nil {
+	return &lazyFTS{sus: s}
+}
+
+func (f *lazyFTS) suspend() {
+	if f == nil || f.dropped {
+		return
+	}
+	if err := f.sus.DropFTS(); err != nil {
 		log.Printf("import: drop FTS: %v", err)
-		return func() {}
+		return
 	}
-	return func() {
-		if err := s.RebuildFTS(); err != nil {
-			log.Printf("import: rebuild FTS: %v", err)
-		}
+	f.dropped = true
+}
+
+func (f *lazyFTS) restore() {
+	if f == nil || !f.dropped {
+		return
+	}
+	if err := f.sus.RebuildFTS(); err != nil {
+		log.Printf("import: rebuild FTS: %v", err)
 	}
 }
 
@@ -59,8 +76,8 @@ func ImportClaudeAI(
 	r io.Reader,
 	onProgress func(imported int),
 ) (ImportStats, error) {
-	restoreFTS := suspendFTS(store)
-	defer restoreFTS()
+	fts := newLazyFTS(store)
+	defer fts.restore()
 
 	var stats ImportStats
 
@@ -71,7 +88,9 @@ func ImportClaudeAI(
 			return ctx.Err()
 		}
 
-		status, err := upsertConversation(ctx, store, result)
+		status, err := upsertConversation(
+			ctx, store, result, fts,
+		)
 		if err != nil {
 			stats.Errors++
 			log.Printf(
@@ -113,6 +132,7 @@ func upsertConversation(
 	ctx context.Context,
 	store db.Store,
 	result parser.ParseResult,
+	fts *lazyFTS,
 ) (importStatus, error) {
 	s := result.Session
 
@@ -152,6 +172,16 @@ func upsertConversation(
 		}
 		return importNew, fmt.Errorf("upserting session: %w", err)
 	}
+
+	// Skip expensive message replacement when the conversation
+	// has not changed since the last import.
+	if !isNew && existing.MessageCount == s.MessageCount {
+		return importSkipped, nil
+	}
+
+	// Suspend FTS before first message-changing operation to
+	// avoid per-row trigger overhead during bulk work.
+	fts.suspend()
 
 	msgs := make([]db.Message, len(result.Messages))
 	for i, m := range result.Messages {
@@ -205,8 +235,8 @@ func ImportChatGPT(
 	assetsDir string,
 	onProgress func(processed int),
 ) (ImportStats, error) {
-	restoreFTS := suspendFTS(store)
-	defer restoreFTS()
+	fts := newLazyFTS(store)
+	defer fts.restore()
 
 	var stats ImportStats
 
@@ -239,6 +269,8 @@ func ImportChatGPT(
 				}
 				return nil
 			}
+
+			fts.suspend()
 
 			sess := db.Session{
 				ID:               s.ID,

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -127,6 +127,7 @@ func ImportClaudeAI(
 				"import: skipping %s: %v",
 				result.Session.ID, err,
 			)
+			cb.progress(stats)
 			return nil
 		}
 
@@ -294,6 +295,7 @@ func ImportChatGPT(
 				log.Printf(
 					"import: skipping %s: %v", s.ID, err,
 				)
+				cb.progress(stats)
 				return nil
 			}
 			if existing != nil {
@@ -327,6 +329,7 @@ func ImportChatGPT(
 				log.Printf(
 					"import: skipping %s: %v", s.ID, err,
 				)
+				cb.progress(stats)
 				return nil
 			}
 
@@ -359,6 +362,7 @@ func ImportChatGPT(
 					"import: skipping messages for %s: %v",
 					s.ID, err,
 				)
+				cb.progress(stats)
 				return nil
 			}
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -106,8 +106,8 @@ func ImportClaudeAI(
 ) (stats ImportStats, retErr error) {
 	fts := newLazyFTS(store, cb.indexing)
 	defer func() {
-		if err := fts.restore(); err != nil && retErr == nil {
-			retErr = err
+		if err := fts.restore(); err != nil {
+			retErr = errors.Join(retErr, err)
 		}
 	}()
 
@@ -269,8 +269,8 @@ func ImportChatGPT(
 ) (stats ImportStats, retErr error) {
 	fts := newLazyFTS(store, cb.indexing)
 	defer func() {
-		if err := fts.restore(); err != nil && retErr == nil {
-			retErr = err
+		if err := fts.restore(); err != nil {
+			retErr = errors.Join(retErr, err)
 		}
 	}()
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -20,6 +20,34 @@ type ImportStats struct {
 	Errors   int `json:"errors"`
 }
 
+// ftsSuspender is optionally implemented by stores that
+// support dropping and rebuilding FTS indexes. Suspending
+// FTS during bulk imports avoids per-row trigger overhead.
+type ftsSuspender interface {
+	DropFTS() error
+	RebuildFTS() error
+}
+
+// suspendFTS drops FTS triggers before a bulk import and
+// returns a function that rebuilds the index. If the store
+// does not support FTS or FTS is unavailable, the returned
+// function is a no-op.
+func suspendFTS(store db.Store) func() {
+	s, ok := store.(ftsSuspender)
+	if !ok || !store.HasFTS() {
+		return func() {}
+	}
+	if err := s.DropFTS(); err != nil {
+		log.Printf("import: drop FTS: %v", err)
+		return func() {}
+	}
+	return func() {
+		if err := s.RebuildFTS(); err != nil {
+			log.Printf("import: rebuild FTS: %v", err)
+		}
+	}
+}
+
 // ImportClaudeAI reads a Claude.ai conversations.json export
 // and upserts each conversation into the store. Existing
 // sessions are updated (messages replaced); user-renamed
@@ -31,6 +59,9 @@ func ImportClaudeAI(
 	r io.Reader,
 	onProgress func(imported int),
 ) (ImportStats, error) {
+	restoreFTS := suspendFTS(store)
+	defer restoreFTS()
+
 	var stats ImportStats
 
 	err := parser.ParseClaudeAIExport(r, func(
@@ -174,6 +205,9 @@ func ImportChatGPT(
 	assetsDir string,
 	onProgress func(processed int),
 ) (ImportStats, error) {
+	restoreFTS := suspendFTS(store)
+	defer restoreFTS()
+
 	var stats ImportStats
 
 	index := BuildAssetIndex(dir)

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -78,7 +78,7 @@ func TestImportClaudeAI(t *testing.T) {
 	assert.Len(t, msgs, 2)
 }
 
-func TestImportClaudeAI_ReimportUpdatesMessages(t *testing.T) {
+func TestImportClaudeAI_ReimportSkipsUnchanged(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
 
@@ -87,13 +87,17 @@ func TestImportClaudeAI_ReimportUpdatesMessages(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// Re-importing the same file skips conversations whose
+	// message count has not changed.
 	stats, err := ImportClaudeAI(
 		ctx, d, strings.NewReader(testConversationsJSON), nil,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 0, stats.Imported)
-	assert.Equal(t, 1, stats.Updated)
+	assert.Equal(t, 0, stats.Updated)
+	assert.Equal(t, 1, stats.Skipped)
 
+	// Messages are still intact.
 	msgs, err := d.GetAllMessages(
 		ctx, "claude-ai:import-test-001",
 	)

--- a/internal/parser/claude_ai.go
+++ b/internal/parser/claude_ai.go
@@ -17,11 +17,11 @@ type claudeAIConversation struct {
 }
 
 type claudeAIMessage struct {
-	UUID      string              `json:"uuid"`
-	Text      string              `json:"text"`
-	Content   []claudeAIBlock     `json:"content"`
-	Sender    string              `json:"sender"`
-	CreatedAt string              `json:"created_at"`
+	UUID      string          `json:"uuid"`
+	Text      string          `json:"text"`
+	Content   []claudeAIBlock `json:"content"`
+	Sender    string          `json:"sender"`
+	CreatedAt string          `json:"created_at"`
 }
 
 // claudeAIBlock represents a content block within a message.
@@ -99,8 +99,8 @@ func assembleClaudeAIContent(
 				parts = append(parts,
 					"[Thinking]\n"+b.Thinking+"\n[/Thinking]")
 			}
-		// tool_use, tool_result, voice_note, token_budget
-		// are metadata blocks — skip for display content.
+			// tool_use, tool_result, voice_note, token_budget
+			// are metadata blocks — skip for display content.
 		}
 	}
 

--- a/internal/server/import.go
+++ b/internal/server/import.go
@@ -12,6 +12,14 @@ import (
 	"github.com/wesm/agentsview/internal/importer"
 )
 
+// wantsSSE checks if the client opted into streaming via
+// the Accept header.
+func wantsSSE(r *http.Request) bool {
+	return strings.Contains(
+		r.Header.Get("Accept"), "text/event-stream",
+	)
+}
+
 // sseWriter wraps an http.ResponseWriter for streaming
 // Server-Sent Events. Each call to event() writes one SSE
 // frame and flushes immediately.
@@ -111,9 +119,7 @@ func (s *Server) handleImportClaudeAI(
 		reader = jsonFile
 	}
 
-	sse, ok := newSSEWriter(w)
-	if !ok {
-		// Fallback: run without streaming.
+	if !wantsSSE(r) {
 		stats, err := importer.ImportClaudeAI(
 			r.Context(), s.db, reader, nil,
 		)
@@ -123,6 +129,13 @@ func (s *Server) handleImportClaudeAI(
 			return
 		}
 		writeJSON(w, http.StatusOK, stats)
+		return
+	}
+
+	sse, ok := newSSEWriter(w)
+	if !ok {
+		writeError(w, http.StatusInternalServerError,
+			"streaming not supported")
 		return
 	}
 
@@ -208,8 +221,7 @@ func (s *Server) handleImportChatGPT(
 
 	assetsDir := filepath.Join(s.cfg.DataDir, "assets")
 
-	sse, ok := newSSEWriter(w)
-	if !ok {
+	if !wantsSSE(r) {
 		stats, err := importer.ImportChatGPT(
 			r.Context(), s.db, dir, assetsDir, nil,
 		)
@@ -219,6 +231,13 @@ func (s *Server) handleImportChatGPT(
 			return
 		}
 		writeJSON(w, http.StatusOK, stats)
+		return
+	}
+
+	sse, ok := newSSEWriter(w)
+	if !ok {
+		writeError(w, http.StatusInternalServerError,
+			"streaming not supported")
 		return
 	}
 

--- a/internal/server/import.go
+++ b/internal/server/import.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -9,6 +11,33 @@ import (
 
 	"github.com/wesm/agentsview/internal/importer"
 )
+
+// sseWriter wraps an http.ResponseWriter for streaming
+// Server-Sent Events. Each call to event() writes one SSE
+// frame and flushes immediately.
+type sseWriter struct {
+	w http.ResponseWriter
+	f http.Flusher
+}
+
+func newSSEWriter(
+	w http.ResponseWriter,
+) (*sseWriter, bool) {
+	f, ok := w.(http.Flusher)
+	if !ok {
+		return nil, false
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	return &sseWriter{w: w, f: f}, true
+}
+
+func (s *sseWriter) event(name string, data any) {
+	b, _ := json.Marshal(data)
+	fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", name, b)
+	s.f.Flush()
+}
 
 func (s *Server) handleImportClaudeAI(
 	w http.ResponseWriter, r *http.Request,
@@ -82,16 +111,40 @@ func (s *Server) handleImportClaudeAI(
 		reader = jsonFile
 	}
 
-	stats, err := importer.ImportClaudeAI(
-		r.Context(), s.db, reader, nil,
-	)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError,
-			"import failed: "+err.Error())
+	sse, ok := newSSEWriter(w)
+	if !ok {
+		// Fallback: run without streaming.
+		stats, err := importer.ImportClaudeAI(
+			r.Context(), s.db, reader, nil,
+		)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError,
+				"import failed: "+err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, stats)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, stats)
+	cb := &importer.ImportCallbacks{
+		OnProgress: func(stats importer.ImportStats) {
+			sse.event("progress", stats)
+		},
+		OnIndexing: func() {
+			sse.event("indexing", struct{}{})
+		},
+	}
+
+	stats, err := importer.ImportClaudeAI(
+		r.Context(), s.db, reader, cb,
+	)
+	if err != nil {
+		sse.event("error", map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+	sse.event("done", stats)
 }
 
 func (s *Server) handleImportChatGPT(
@@ -154,14 +207,38 @@ func (s *Server) handleImportChatGPT(
 	defer cleanup()
 
 	assetsDir := filepath.Join(s.cfg.DataDir, "assets")
-	stats, err := importer.ImportChatGPT(
-		r.Context(), s.db, dir, assetsDir, nil,
-	)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError,
-			"import failed: "+err.Error())
+
+	sse, ok := newSSEWriter(w)
+	if !ok {
+		stats, err := importer.ImportChatGPT(
+			r.Context(), s.db, dir, assetsDir, nil,
+		)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError,
+				"import failed: "+err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, stats)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, stats)
+	cb := &importer.ImportCallbacks{
+		OnProgress: func(stats importer.ImportStats) {
+			sse.event("progress", stats)
+		},
+		OnIndexing: func() {
+			sse.event("indexing", struct{}{})
+		},
+	}
+
+	stats, err := importer.ImportChatGPT(
+		r.Context(), s.db, dir, assetsDir, cb,
+	)
+	if err != nil {
+		sse.event("error", map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+	sse.event("done", stats)
 }

--- a/internal/server/import_test.go
+++ b/internal/server/import_test.go
@@ -6,11 +6,48 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/wesm/agentsview/internal/importer"
 )
+
+// parseSSEDone extracts the "done" event data from an SSE
+// response body and decodes it into the target.
+func parseSSEDone(t *testing.T, body string, v any) {
+	t.Helper()
+	for line := range strings.SplitSeq(body, "\n") {
+		if strings.HasPrefix(line, "data: ") {
+			data := line[len("data: "):]
+			// The last data line before EOF with event:done
+			// is the final stats. Try to decode each data
+			// line; keep the last successful decode.
+			if err := json.Unmarshal(
+				[]byte(data), v,
+			); err == nil {
+				continue
+			}
+		}
+	}
+	// Re-parse: find event:done specifically.
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if line == "event: done" && i+1 < len(lines) {
+			data := strings.TrimPrefix(lines[i+1], "data: ")
+			if err := json.Unmarshal(
+				[]byte(data), v,
+			); err != nil {
+				t.Fatalf(
+					"decoding SSE done event: %v\nbody: %s",
+					err, body,
+				)
+			}
+			return
+		}
+	}
+	t.Fatalf("no 'done' event in SSE response:\n%s", body)
+}
 
 func TestHandleImportClaudeAI(t *testing.T) {
 	srv := testServer(t, 5*time.Second)
@@ -65,7 +102,10 @@ func TestHandleImportClaudeAI(t *testing.T) {
 	}
 
 	var stats importer.ImportStats
-	if err := json.NewDecoder(rec.Body).Decode(&stats); err != nil {
+	ct := rec.Header().Get("Content-Type")
+	if strings.Contains(ct, "text/event-stream") {
+		parseSSEDone(t, rec.Body.String(), &stats)
+	} else if err := json.NewDecoder(rec.Body).Decode(&stats); err != nil {
 		t.Fatalf("decoding response: %v", err)
 	}
 	if stats.Imported != 1 {

--- a/internal/server/import_test.go
+++ b/internal/server/import_test.go
@@ -13,42 +13,6 @@ import (
 	"github.com/wesm/agentsview/internal/importer"
 )
 
-// parseSSEDone extracts the "done" event data from an SSE
-// response body and decodes it into the target.
-func parseSSEDone(t *testing.T, body string, v any) {
-	t.Helper()
-	for line := range strings.SplitSeq(body, "\n") {
-		if strings.HasPrefix(line, "data: ") {
-			data := line[len("data: "):]
-			// The last data line before EOF with event:done
-			// is the final stats. Try to decode each data
-			// line; keep the last successful decode.
-			if err := json.Unmarshal(
-				[]byte(data), v,
-			); err == nil {
-				continue
-			}
-		}
-	}
-	// Re-parse: find event:done specifically.
-	lines := strings.Split(body, "\n")
-	for i, line := range lines {
-		if line == "event: done" && i+1 < len(lines) {
-			data := strings.TrimPrefix(lines[i+1], "data: ")
-			if err := json.Unmarshal(
-				[]byte(data), v,
-			); err != nil {
-				t.Fatalf(
-					"decoding SSE done event: %v\nbody: %s",
-					err, body,
-				)
-			}
-			return
-		}
-	}
-	t.Fatalf("no 'done' event in SSE response:\n%s", body)
-}
-
 func TestHandleImportClaudeAI(t *testing.T) {
 	srv := testServer(t, 5*time.Second)
 
@@ -102,10 +66,7 @@ func TestHandleImportClaudeAI(t *testing.T) {
 	}
 
 	var stats importer.ImportStats
-	ct := rec.Header().Get("Content-Type")
-	if strings.Contains(ct, "text/event-stream") {
-		parseSSEDone(t, rec.Body.String(), &stats)
-	} else if err := json.NewDecoder(rec.Body).Decode(&stats); err != nil {
+	if err := json.NewDecoder(rec.Body).Decode(&stats); err != nil {
 		t.Fatalf("decoding response: %v", err)
 	}
 	if stats.Imported != 1 {
@@ -145,6 +106,79 @@ func TestHandleImportChatGPT_RequiresZip(t *testing.T) {
 			"status = %d, want 400: %s",
 			rec.Code, rec.Body.String(),
 		)
+	}
+}
+
+func TestHandleImportClaudeAI_SSE(t *testing.T) {
+	srv := testServer(t, 5*time.Second)
+
+	conversations := `[{
+      "uuid": "sse-test-001",
+      "name": "SSE Test",
+      "created_at": "2026-03-01T10:00:00.000000Z",
+      "updated_at": "2026-03-01T10:05:00.000000Z",
+      "chat_messages": [{
+        "uuid": "m1", "text": "hello", "sender": "human",
+        "content": [{"type":"text","text":"hello"}],
+        "created_at": "2026-03-01T10:00:00.000000Z"
+      }]
+    }]`
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile(
+		"file", "conversations.json",
+	)
+	if err != nil {
+		t.Fatalf("creating form file: %v", err)
+	}
+	_, _ = part.Write([]byte(conversations))
+	writer.Close()
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/import/claude-ai",
+		&body,
+	)
+	req.Header.Set(
+		"Content-Type", writer.FormDataContentType(),
+	)
+	req.Header.Set("Accept", "text/event-stream")
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf(
+			"status = %d, want 200: %s",
+			rec.Code, rec.Body.String(),
+		)
+	}
+
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/event-stream") {
+		t.Fatalf(
+			"Content-Type = %q, want text/event-stream", ct,
+		)
+	}
+
+	// Parse the done event from the SSE body.
+	var stats importer.ImportStats
+	lines := strings.Split(rec.Body.String(), "\n")
+	for i, line := range lines {
+		if line == "event: done" && i+1 < len(lines) {
+			data := strings.TrimPrefix(
+				lines[i+1], "data: ",
+			)
+			if err := json.Unmarshal(
+				[]byte(data), &stats,
+			); err != nil {
+				t.Fatalf("decoding done event: %v", err)
+			}
+		}
+	}
+	if stats.Imported != 1 {
+		t.Errorf("imported = %d, want 1", stats.Imported)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Redesign the import modal with drag-and-drop file upload, provider
  cards with brand-colored indicators, animated results display, and
  shared modal pattern alignment
- Add visible "Import" text label to the header button for
  discoverability
- Stream import progress via SSE so the UI shows live conversation
  count and "Rebuilding search index..." phase indicator
- Skip unchanged conversations on re-import (same message count =
  no work), making re-imports near-instant
- Lazy FTS suspension: only drop/rebuild the search index when
  messages actually change, avoiding expensive full-index rebuilds
  on no-op re-imports
- Fix Svelte 5 reactivity bug where `$effect` tracking `fileInput`
  via `bind:this` wiped import results immediately after display