### PR TITLE
feat: add project filtering for pg push

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -57,6 +57,9 @@ func main() {
 		case "import":
 			runImport(os.Args[2:])
 			return
+		case "projects":
+			runProjects(os.Args[2:])
+			return
 		case "version", "--version", "-v":
 			fmt.Printf("agentsview %s (commit %s, built %s)\n",
 				version, commit, buildDate)
@@ -88,6 +91,7 @@ Usage:
   agentsview prune [flags]    Delete sessions matching filters
   agentsview import --type <type> <path>
                           Import conversations (claude-ai, chatgpt)
+  agentsview projects [flags] List projects with session counts
   agentsview update [flags]   Check for and install updates
   agentsview version          Show version information
   agentsview help             Show this help
@@ -111,6 +115,8 @@ Sync flags:
 
 PG push flags:
   -full              Bypass per-message skip heuristic
+  -projects string   Comma-separated projects to push (inclusive)
+  -exclude-projects string  Comma-separated projects to exclude from push
 
 PG serve flags:
   -host string       Host to bind to (default "127.0.0.1")
@@ -123,6 +129,9 @@ Prune flags:
   -first-message str  Sessions whose first message starts with this text
   -dry-run            Show what would be pruned without deleting
   -yes                Skip confirmation prompt
+
+Projects flags:
+  -json              Output as JSON array
 
 Update flags:
   -check              Check for updates without installing

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -117,6 +117,7 @@ PG push flags:
   -full              Bypass per-message skip heuristic
   -projects string   Comma-separated projects to push (inclusive)
   -exclude-projects string  Comma-separated projects to exclude from push
+  -all-projects      Ignore configured project filters for this run
 
 PG serve flags:
   -host string       Host to bind to (default "127.0.0.1")

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -86,11 +86,6 @@ func runPGPush(args []string) {
 		projects = nil
 	}
 
-	// Validate mutual exclusivity (config values may conflict too).
-	if len(projects) > 0 && len(excludeProjects) > 0 {
-		fatal("pg push: projects and exclude_projects are mutually exclusive")
-	}
-
 	database, err := db.Open(appCfg.DBPath)
 	if err != nil {
 		fatal("opening database: %v", err)

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -117,7 +117,10 @@ func runPGPush(args []string) {
 	ps, err := postgres.New(
 		pgCfg.URL, pgCfg.Schema, database,
 		pgCfg.MachineName, pgCfg.AllowInsecure,
-		projects, excludeProjects,
+		postgres.SyncOptions{
+			Projects:        projects,
+			ExcludeProjects: excludeProjects,
+		},
 	)
 	if err != nil {
 		fatal("pg push: %v", err)
@@ -180,7 +183,7 @@ func runPGStatus(args []string) {
 	ps, err := postgres.New(
 		pgCfg.URL, pgCfg.Schema, database,
 		pgCfg.MachineName, pgCfg.AllowInsecure,
-		nil, nil,
+		postgres.SyncOptions{},
 	)
 	if err != nil {
 		fatal("pg status: %v", err)

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -42,8 +43,16 @@ func runPGPush(args []string) {
 	fs := flag.NewFlagSet("pg push", flag.ExitOnError)
 	full := fs.Bool("full", false,
 		"Force full local resync and PG push")
+	projectsFlag := fs.String("projects", "",
+		"Comma-separated list of projects to push (inclusive)")
+	excludeProjectsFlag := fs.String("exclude-projects", "",
+		"Comma-separated list of projects to exclude from push")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
+	}
+
+	if *projectsFlag != "" && *excludeProjectsFlag != "" {
+		fatal("pg push: --projects and --exclude-projects are mutually exclusive")
 	}
 
 	appCfg, err := config.LoadMinimal()
@@ -61,6 +70,25 @@ func runPGPush(args []string) {
 	}
 	if pgCfg.URL == "" {
 		fatal("pg push: url not configured")
+	}
+
+	// CLI flags override config values entirely. When either
+	// flag is set, clear both config-derived lists so a CLI
+	// include can override a config exclude (and vice versa).
+	projects := pgCfg.Projects
+	excludeProjects := pgCfg.ExcludeProjects
+	if *projectsFlag != "" {
+		projects = splitProjectList(*projectsFlag)
+		excludeProjects = nil
+	}
+	if *excludeProjectsFlag != "" {
+		excludeProjects = splitProjectList(*excludeProjectsFlag)
+		projects = nil
+	}
+
+	// Validate mutual exclusivity (config values may conflict too).
+	if len(projects) > 0 && len(excludeProjects) > 0 {
+		fatal("pg push: projects and exclude_projects are mutually exclusive")
 	}
 
 	database, err := db.Open(appCfg.DBPath)
@@ -89,6 +117,7 @@ func runPGPush(args []string) {
 	ps, err := postgres.New(
 		pgCfg.URL, pgCfg.Schema, database,
 		pgCfg.MachineName, pgCfg.AllowInsecure,
+		projects, excludeProjects,
 	)
 	if err != nil {
 		fatal("pg push: %v", err)
@@ -151,6 +180,7 @@ func runPGStatus(args []string) {
 	ps, err := postgres.New(
 		pgCfg.URL, pgCfg.Schema, database,
 		pgCfg.MachineName, pgCfg.AllowInsecure,
+		nil, nil,
 	)
 	if err != nil {
 		fatal("pg status: %v", err)
@@ -314,4 +344,18 @@ func runPGServe(args []string) {
 	if err := waitForServerRuntime(ctx, srv, rt); err != nil {
 		fatal("pg serve: %v", err)
 	}
+}
+
+// splitProjectList splits a comma-separated string into trimmed,
+// non-empty project names.
+func splitProjectList(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -86,6 +86,11 @@ func runPGPush(args []string) {
 		projects = nil
 	}
 
+	if len(projects) > 0 && len(excludeProjects) > 0 {
+		fatal("pg push: projects and exclude_projects " +
+			"are mutually exclusive")
+	}
+
 	database, err := db.Open(appCfg.DBPath)
 	if err != nil {
 		fatal("opening database: %v", err)

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -47,12 +47,20 @@ func runPGPush(args []string) {
 		"Comma-separated list of projects to push (inclusive)")
 	excludeProjectsFlag := fs.String("exclude-projects", "",
 		"Comma-separated list of projects to exclude from push")
+	allProjects := fs.Bool("all-projects", false,
+		"Ignore configured project filters for this run")
 	if err := fs.Parse(args); err != nil {
 		log.Fatalf("parsing flags: %v", err)
 	}
 
 	if *projectsFlag != "" && *excludeProjectsFlag != "" {
-		fatal("pg push: --projects and --exclude-projects are mutually exclusive")
+		fatal("pg push: --projects and --exclude-projects " +
+			"are mutually exclusive")
+	}
+	if *allProjects &&
+		(*projectsFlag != "" || *excludeProjectsFlag != "") {
+		fatal("pg push: --all-projects cannot be combined " +
+			"with --projects or --exclude-projects")
 	}
 
 	appCfg, err := config.LoadMinimal()
@@ -75,8 +83,13 @@ func runPGPush(args []string) {
 	// CLI flags override config values entirely. When either
 	// flag is set, clear both config-derived lists so a CLI
 	// include can override a config exclude (and vice versa).
+	// --all-projects clears both lists for an unfiltered push.
 	projects := pgCfg.Projects
 	excludeProjects := pgCfg.ExcludeProjects
+	if *allProjects {
+		projects = nil
+		excludeProjects = nil
+	}
 	if *projectsFlag != "" {
 		projects = splitProjectList(*projectsFlag)
 		excludeProjects = nil

--- a/cmd/agentsview/projects.go
+++ b/cmd/agentsview/projects.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/wesm/agentsview/internal/config"
+	"github.com/wesm/agentsview/internal/db"
+)
+
+func runProjects(args []string) {
+	fs := flag.NewFlagSet("projects", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false,
+		"Output as JSON array")
+	if err := fs.Parse(args); err != nil {
+		log.Fatalf("parsing flags: %v", err)
+	}
+
+	appCfg, err := config.LoadMinimal()
+	if err != nil {
+		log.Fatalf("loading config: %v", err)
+	}
+
+	database, err := db.Open(appCfg.DBPath)
+	if err != nil {
+		fatal("opening database: %v", err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	projects, err := database.GetProjects(ctx, false, false)
+	if err != nil {
+		fatal("listing projects: %v", err)
+	}
+
+	if *jsonOutput {
+		if projects == nil {
+			projects = []db.ProjectInfo{}
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(projects); err != nil {
+			fatal("encoding json: %v", err)
+		}
+		return
+	}
+
+	if len(projects) == 0 {
+		fmt.Println("No projects found.")
+		return
+	}
+
+	fmt.Printf("%-40s %s\n", "PROJECT", "SESSIONS")
+	for _, p := range projects {
+		name := p.Name
+		if name == "" {
+			name = "(none)"
+		}
+		fmt.Printf("%-40s %d\n", name, p.SessionCount)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,10 +56,12 @@ type ProxyConfig struct {
 
 // PGConfig holds PostgreSQL connection settings.
 type PGConfig struct {
-	URL           string `toml:"url" json:"url"`
-	Schema        string `toml:"schema" json:"schema"`
-	MachineName   string `toml:"machine_name" json:"machine_name"`
-	AllowInsecure bool   `toml:"allow_insecure" json:"allow_insecure"`
+	URL             string   `toml:"url" json:"url"`
+	Schema          string   `toml:"schema" json:"schema"`
+	MachineName     string   `toml:"machine_name" json:"machine_name"`
+	AllowInsecure   bool     `toml:"allow_insecure" json:"allow_insecure"`
+	Projects        []string `toml:"projects" json:"projects,omitempty"`
+	ExcludeProjects []string `toml:"exclude_projects" json:"exclude_projects,omitempty"`
 }
 
 // Config holds all application configuration.
@@ -351,6 +353,12 @@ func (c *Config) loadFile() error {
 	}
 	if file.PG.AllowInsecure {
 		c.PG.AllowInsecure = true
+	}
+	if file.PG.Projects != nil && c.PG.Projects == nil {
+		c.PG.Projects = file.PG.Projects
+	}
+	if file.PG.ExcludeProjects != nil && c.PG.ExcludeProjects == nil {
+		c.PG.ExcludeProjects = file.PG.ExcludeProjects
 	}
 
 	// Parse config-file dir arrays for agents that have a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -908,6 +908,12 @@ func (c *Config) ResolvePG() (PGConfig, error) {
 		}
 		pg.MachineName = h
 	}
+	if len(pg.Projects) > 0 && len(pg.ExcludeProjects) > 0 {
+		return pg, fmt.Errorf(
+			"pg.projects and pg.exclude_projects are " +
+				"mutually exclusive",
+		)
+	}
 	return pg, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -908,12 +908,6 @@ func (c *Config) ResolvePG() (PGConfig, error) {
 		}
 		pg.MachineName = h
 	}
-	if len(pg.Projects) > 0 && len(pg.ExcludeProjects) > 0 {
-		return pg, fmt.Errorf(
-			"pg.projects and pg.exclude_projects are " +
-				"mutually exclusive",
-		)
-	}
 	return pg, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -978,3 +978,22 @@ func TestResolvePG_ErrorsOnMissingBareEnvVar(t *testing.T) {
 		t.Errorf("error = %v, want mention of NONEXISTENT_PG_BARE_VAR", err)
 	}
 }
+
+func TestResolvePG_RejectsMutuallyExclusiveFilters(
+	t *testing.T,
+) {
+	cfg := Config{
+		PG: PGConfig{
+			URL:             "postgres://localhost/test",
+			Projects:        []string{"alpha"},
+			ExcludeProjects: []string{"beta"},
+		},
+	}
+	_, err := cfg.ResolvePG()
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive filters")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %v, want mutually exclusive", err)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -979,9 +979,11 @@ func TestResolvePG_ErrorsOnMissingBareEnvVar(t *testing.T) {
 	}
 }
 
-func TestResolvePG_RejectsMutuallyExclusiveFilters(
-	t *testing.T,
-) {
+// ResolvePG must not reject configs with both filter lists —
+// that's a push-specific concern validated in runPGPush after
+// CLI flags are merged. status and serve use ResolvePG too and
+// shouldn't fail on push-only filter conflicts.
+func TestResolvePG_AllowsBothFilterLists(t *testing.T) {
 	cfg := Config{
 		PG: PGConfig{
 			URL:             "postgres://localhost/test",
@@ -990,10 +992,10 @@ func TestResolvePG_RejectsMutuallyExclusiveFilters(
 		},
 	}
 	_, err := cfg.ResolvePG()
-	if err == nil {
-		t.Fatal("expected error for mutually exclusive filters")
-	}
-	if !strings.Contains(err.Error(), "mutually exclusive") {
-		t.Errorf("error = %v, want mutually exclusive", err)
+	if err != nil {
+		t.Fatalf(
+			"ResolvePG should not reject filter conflicts: %v",
+			err,
+		)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -815,6 +815,58 @@ func TestLoadFile_PGConfig(t *testing.T) {
 	}
 }
 
+func TestPGConfig_ProjectFilter(t *testing.T) {
+	dir := t.TempDir()
+	tomlPath := filepath.Join(dir, "config.toml")
+	os.WriteFile(tomlPath, []byte(`
+[pg]
+url = "postgres://localhost/test"
+projects = ["alpha", "beta"]
+`), 0o644)
+
+	cfg, err := Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.DataDir = dir
+	if err := cfg.loadFile(); err != nil {
+		t.Fatalf("loadFile: %v", err)
+	}
+
+	if len(cfg.PG.Projects) != 2 {
+		t.Fatalf("Projects = %v, want [alpha beta]", cfg.PG.Projects)
+	}
+	if cfg.PG.Projects[0] != "alpha" || cfg.PG.Projects[1] != "beta" {
+		t.Errorf("Projects = %v, want [alpha beta]", cfg.PG.Projects)
+	}
+}
+
+func TestPGConfig_ExcludeProjectFilter(t *testing.T) {
+	dir := t.TempDir()
+	tomlPath := filepath.Join(dir, "config.toml")
+	os.WriteFile(tomlPath, []byte(`
+[pg]
+url = "postgres://localhost/test"
+exclude_projects = ["gamma"]
+`), 0o644)
+
+	cfg, err := Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.DataDir = dir
+	if err := cfg.loadFile(); err != nil {
+		t.Fatalf("loadFile: %v", err)
+	}
+
+	if len(cfg.PG.ExcludeProjects) != 1 {
+		t.Fatalf("ExcludeProjects = %v, want [gamma]", cfg.PG.ExcludeProjects)
+	}
+	if cfg.PG.ExcludeProjects[0] != "gamma" {
+		t.Errorf("ExcludeProjects = %v, want [gamma]", cfg.PG.ExcludeProjects)
+	}
+}
+
 func TestResolvePG_Defaults(t *testing.T) {
 	cfg := Config{
 		PG: PGConfig{

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5421,7 +5421,7 @@ func TestListSessionsModifiedBetween(t *testing.T) {
 	}
 
 	// Query all.
-	all, err := d.ListSessionsModifiedBetween(ctx, "", "")
+	all, err := d.ListSessionsModifiedBetween(ctx, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("list all: %v", err)
 	}
@@ -5430,7 +5430,7 @@ func TestListSessionsModifiedBetween(t *testing.T) {
 	}
 
 	// Query with since.
-	since, err := d.ListSessionsModifiedBetween(ctx, "2026-03-11T00:00:00Z", "")
+	since, err := d.ListSessionsModifiedBetween(ctx, "2026-03-11T00:00:00Z", "", nil, nil)
 	if err != nil {
 		t.Fatalf("list since: %v", err)
 	}
@@ -5439,7 +5439,7 @@ func TestListSessionsModifiedBetween(t *testing.T) {
 	}
 
 	// Query with until.
-	until, err := d.ListSessionsModifiedBetween(ctx, "", "2026-03-11T12:00:00.000Z")
+	until, err := d.ListSessionsModifiedBetween(ctx, "", "2026-03-11T12:00:00.000Z", nil, nil)
 	if err != nil {
 		t.Fatalf("list until: %v", err)
 	}
@@ -5448,7 +5448,7 @@ func TestListSessionsModifiedBetween(t *testing.T) {
 	}
 
 	// Query with both.
-	between, err := d.ListSessionsModifiedBetween(ctx, "2026-03-10T12:00:00.000Z", "2026-03-11T12:00:00.000Z")
+	between, err := d.ListSessionsModifiedBetween(ctx, "2026-03-10T12:00:00.000Z", "2026-03-11T12:00:00.000Z", nil, nil)
 	if err != nil {
 		t.Fatalf("list between: %v", err)
 	}
@@ -5591,5 +5591,85 @@ func TestToolCallCountAndFingerprint(t *testing.T) {
 	}
 	if sum != 150 {
 		t.Errorf("sum = %d, want 150", sum)
+	}
+}
+
+func TestListSessionsModifiedBetween_ProjectFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	sessions := []Session{
+		{ID: "s1", Project: "alpha", Machine: "local", Agent: "claude", CreatedAt: "2026-03-10T12:00:00.000Z"},
+		{ID: "s2", Project: "beta", Machine: "local", Agent: "claude", CreatedAt: "2026-03-10T12:00:00.000Z"},
+		{ID: "s3", Project: "gamma", Machine: "local", Agent: "claude", CreatedAt: "2026-03-10T12:00:00.000Z"},
+	}
+	for _, s := range sessions {
+		if err := d.UpsertSession(s); err != nil {
+			t.Fatalf("upsert %s: %v", s.ID, err)
+		}
+	}
+	for _, s := range sessions {
+		_, err := d.getWriter().Exec(
+			"UPDATE sessions SET created_at = ? WHERE id = ?",
+			s.CreatedAt, s.ID,
+		)
+		if err != nil {
+			t.Fatalf("backdate %s: %v", s.ID, err)
+		}
+	}
+
+	tests := []struct {
+		name            string
+		projects        []string
+		excludeProjects []string
+		wantIDs         []string
+	}{
+		{
+			name:    "no filter returns all",
+			wantIDs: []string{"s1", "s2", "s3"},
+		},
+		{
+			name:     "include alpha only",
+			projects: []string{"alpha"},
+			wantIDs:  []string{"s1"},
+		},
+		{
+			name:     "include alpha and gamma",
+			projects: []string{"alpha", "gamma"},
+			wantIDs:  []string{"s1", "s3"},
+		},
+		{
+			name:            "exclude beta",
+			excludeProjects: []string{"beta"},
+			wantIDs:         []string{"s1", "s3"},
+		},
+		{
+			name:     "include nonexistent project",
+			projects: []string{"nope"},
+			wantIDs:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := d.ListSessionsModifiedBetween(
+				ctx, "", "", tt.projects, tt.excludeProjects,
+			)
+			if err != nil {
+				t.Fatalf("ListSessionsModifiedBetween: %v", err)
+			}
+			var gotIDs []string
+			for _, s := range got {
+				gotIDs = append(gotIDs, s.ID)
+			}
+			if len(gotIDs) != len(tt.wantIDs) {
+				t.Fatalf("got %v, want %v", gotIDs, tt.wantIDs)
+			}
+			for i, id := range tt.wantIDs {
+				if gotIDs[i] != id {
+					t.Errorf("got[%d] = %q, want %q", i, gotIDs[i], id)
+				}
+			}
+		})
 	}
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1330,6 +1330,7 @@ func (db *DB) DeleteSessions(ids []string) (int, error) {
 // in text timestamp fields are therefore truncated.
 func (db *DB) ListSessionsModifiedBetween(
 	ctx context.Context, since, until string,
+	projects, excludeProjects []string,
 ) ([]Session, error) {
 	query := "SELECT " + sessionFullCols + " FROM sessions"
 	var (
@@ -1370,6 +1371,22 @@ func (db *DB) ListSessionsModifiedBetween(
 			AND `+sqliteSyncTimestampExpr(colBestTimestamp)+` <= ?
 			AND `+sqliteSyncTimestampExpr(colCreatedAt)+` <= ?)`)
 		args = append(args, untilNano, untilText, untilText, untilText)
+	}
+	if len(projects) > 0 {
+		placeholders := make([]string, len(projects))
+		for i, p := range projects {
+			placeholders[i] = "?"
+			args = append(args, p)
+		}
+		where = append(where, "project IN ("+strings.Join(placeholders, ", ")+")")
+	}
+	if len(excludeProjects) > 0 {
+		placeholders := make([]string, len(excludeProjects))
+		for i, p := range excludeProjects {
+			placeholders[i] = "?"
+			args = append(args, p)
+		}
+		where = append(where, "project NOT IN ("+strings.Join(placeholders, ", ")+")")
 	}
 	if len(where) > 0 {
 		query += " WHERE " + strings.Join(where, " AND ")

--- a/internal/postgres/integration_test.go
+++ b/internal/postgres/integration_test.go
@@ -17,7 +17,7 @@ func TestPGConnectivity(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"connectivity-test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -50,7 +50,7 @@ func TestPGPushCycle(t *testing.T) {
 	local := testDB(t)
 	ps, err := New(
 		pgURL, "agentsview", local, "machine-a", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)

--- a/internal/postgres/integration_test.go
+++ b/internal/postgres/integration_test.go
@@ -17,6 +17,7 @@ func TestPGConnectivity(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"connectivity-test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -49,6 +50,7 @@ func TestPGPushCycle(t *testing.T) {
 	local := testDB(t)
 	ps, err := New(
 		pgURL, "agentsview", local, "machine-a", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -49,12 +49,11 @@ type PushResult struct {
 // unfiltered sessions to be skipped. Instead, filtered
 // pushes rely on fingerprints for incrementality: each run
 // re-queries all sessions since the last unfiltered push
-// and skips those whose fingerprint hasn't changed. This
-// means the query window grows between unfiltered pushes.
-// If filtered push is the normal operating mode (e.g. set
-// in config and running on a cron), run an occasional
-// unfiltered push to advance the watermark and bound the
-// query window.
+// and skips those whose fingerprint hasn't changed. The
+// query window grows between unfiltered pushes, but
+// fingerprint matching keeps the actual PG writes minimal.
+// Run an occasional unfiltered push (or use --all-projects)
+// to advance the watermark and bound the query window.
 //
 // Known limitation: sessions that are permanently deleted
 // from SQLite (via prune) are not propagated as deletions
@@ -226,17 +225,24 @@ func (s *Sync) Push(
 	})
 
 	if len(sessions) == 0 {
-		// Filtered pushes must not advance the global
-		// watermark but should still update fingerprints
-		// so repeated filtered runs stay incremental.
-		// Skip when lastPush is empty (--full/PG reset).
-		if s.isFiltered() && lastPush != "" {
+		if s.isFiltered() {
+			// Filtered pushes must not advance the global
+			// watermark but should still update fingerprints
+			// so repeated filtered runs stay incremental.
+			// Use cutoff as the boundary key when lastPush
+			// is empty (--full/PG reset) so that the next
+			// filtered run can match fingerprints.
+			boundaryKey := lastPush
+			if boundaryKey == "" {
+				boundaryKey = cutoff
+			}
 			if err := writePushBoundaryState(
-				s.local, lastPush, sessions, priorFingerprints,
+				s.local, boundaryKey, sessions,
+				priorFingerprints,
 			); err != nil {
 				return result, err
 			}
-		} else if !s.isFiltered() {
+		} else {
 			if err := finalizePushState(
 				s.local, cutoff, sessions, nil,
 			); err != nil {
@@ -288,18 +294,19 @@ func (s *Sync) Push(
 		// sessions so subsequent filtered runs stay
 		// incremental, but do not advance the global
 		// watermark past sessions from other projects.
-		// Only write fingerprints when a watermark exists;
-		// an empty watermark means --full or PG reset
-		// cleared the state, and writing fingerprints
-		// would create stale entries that survive a
-		// subsequent PG reset undetected.
-		if lastPush != "" {
-			if err := writePushBoundaryState(
-				s.local, lastPush, pushed,
-				priorFingerprints,
-			); err != nil {
-				return result, err
-			}
+		// Use cutoff as the boundary key when lastPush is
+		// empty (--full/PG reset) so the next filtered
+		// run can match fingerprints instead of
+		// re-pushing everything.
+		boundaryKey := lastPush
+		if boundaryKey == "" {
+			boundaryKey = cutoff
+		}
+		if err := writePushBoundaryState(
+			s.local, boundaryKey, pushed,
+			priorFingerprints,
+		); err != nil {
+			return result, err
 		}
 	} else {
 		// When all sessions succeeded, advance the watermark

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -81,21 +81,8 @@ func (s *Sync) Push(
 		// watermark and boundary state so the next
 		// unfiltered push also starts from scratch.
 		if s.isFiltered() {
-			if err := s.local.SetSyncState(
-				lastPushBoundaryStateKey, "",
-			); err != nil {
-				return result, fmt.Errorf(
-					"clearing boundary state: %w",
-					err,
-				)
-			}
-			if err := s.local.SetSyncState(
-				"last_push_at", "",
-			); err != nil {
-				return result, fmt.Errorf(
-					"clearing last_push_at: %w",
-					err,
-				)
+			if err := clearPushState(s.local); err != nil {
+				return result, err
 			}
 		}
 	}
@@ -127,29 +114,12 @@ func (s *Sync) Push(
 			); err != nil {
 				return result, err
 			}
-			// When running a filtered push against a
-			// reset PG, clear both the watermark and
-			// boundary state so the next unfiltered push
-			// also triggers a full sync for the remaining
-			// projects. Both must be cleared together to
-			// avoid stale fingerprints surviving a partial
-			// recovery.
+			// Filtered push against a reset PG: clear
+			// watermark and boundary state so the next
+			// unfiltered push also starts from scratch.
 			if s.isFiltered() {
-				if err := s.local.SetSyncState(
-					lastPushBoundaryStateKey, "",
-				); err != nil {
-					return result, fmt.Errorf(
-						"clearing boundary state: %w",
-						err,
-					)
-				}
-				if err := s.local.SetSyncState(
-					"last_push_at", "",
-				); err != nil {
-					return result, fmt.Errorf(
-						"clearing last_push_at: %w",
-						err,
-					)
+				if err := clearPushState(s.local); err != nil {
+					return result, err
 				}
 			}
 		}
@@ -465,6 +435,29 @@ func finalizePushState(
 	return writePushBoundaryState(
 		local, cutoff, sessions, priorFingerprints,
 	)
+}
+
+// clearPushState resets the watermark and boundary state so that
+// the next push starts from scratch. Used when a filtered push
+// runs --full or detects a PG reset, to avoid leaving stale
+// state that would cause the next unfiltered push to skip
+// sessions.
+func clearPushState(local syncStateStore) error {
+	if err := local.SetSyncState(
+		lastPushBoundaryStateKey, "",
+	); err != nil {
+		return fmt.Errorf(
+			"clearing boundary state: %w", err,
+		)
+	}
+	if err := local.SetSyncState(
+		"last_push_at", "",
+	); err != nil {
+		return fmt.Errorf(
+			"clearing last_push_at: %w", err,
+		)
+	}
+	return nil
 }
 
 func readBoundaryAndFingerprints(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -77,6 +77,27 @@ func (s *Sync) Push(
 		); err != nil {
 			return result, err
 		}
+		// When a filtered full push runs, clear persisted
+		// watermark and boundary state so the next
+		// unfiltered push also starts from scratch.
+		if s.isFiltered() {
+			if err := s.local.SetSyncState(
+				lastPushBoundaryStateKey, "",
+			); err != nil {
+				return result, fmt.Errorf(
+					"clearing boundary state: %w",
+					err,
+				)
+			}
+			if err := s.local.SetSyncState(
+				"last_push_at", "",
+			); err != nil {
+				return result, fmt.Errorf(
+					"clearing last_push_at: %w",
+					err,
+				)
+			}
+		}
 	}
 
 	// Coherence check: if the local watermark says we've
@@ -106,13 +127,38 @@ func (s *Sync) Push(
 			); err != nil {
 				return result, err
 			}
+			// When running a filtered push against a
+			// reset PG, clear both the watermark and
+			// boundary state so the next unfiltered push
+			// also triggers a full sync for the remaining
+			// projects. Both must be cleared together to
+			// avoid stale fingerprints surviving a partial
+			// recovery.
+			if s.isFiltered() {
+				if err := s.local.SetSyncState(
+					lastPushBoundaryStateKey, "",
+				); err != nil {
+					return result, fmt.Errorf(
+						"clearing boundary state: %w",
+						err,
+					)
+				}
+				if err := s.local.SetSyncState(
+					"last_push_at", "",
+				); err != nil {
+					return result, fmt.Errorf(
+						"clearing last_push_at: %w",
+						err,
+					)
+				}
+			}
 		}
 	}
 
 	cutoff := time.Now().UTC().Format(LocalSyncTimestampLayout)
 
 	allSessions, err := s.local.ListSessionsModifiedBetween(
-		ctx, lastPush, cutoff,
+		ctx, lastPush, cutoff, s.projects, s.excludeProjects,
 	)
 	if err != nil {
 		return result, fmt.Errorf(
@@ -152,7 +198,7 @@ func (s *Sync) Push(
 			)
 		}
 		boundarySessions, err := s.local.ListSessionsModifiedBetween(
-			ctx, windowStart, lastPush,
+			ctx, windowStart, lastPush, s.projects, s.excludeProjects,
 		)
 		if err != nil {
 			return result, fmt.Errorf(
@@ -196,10 +242,22 @@ func (s *Sync) Push(
 	})
 
 	if len(sessions) == 0 {
-		if err := finalizePushState(
-			s.local, cutoff, sessions, nil,
-		); err != nil {
-			return result, err
+		// Filtered pushes must not advance the global
+		// watermark but should still update fingerprints
+		// so repeated filtered runs stay incremental.
+		// Skip when lastPush is empty (--full/PG reset).
+		if s.isFiltered() && lastPush != "" {
+			if err := writePushBoundaryState(
+				s.local, lastPush, sessions, priorFingerprints,
+			); err != nil {
+				return result, err
+			}
+		} else if !s.isFiltered() {
+			if err := finalizePushState(
+				s.local, cutoff, sessions, nil,
+			); err != nil {
+				return result, err
+			}
 		}
 		result.Duration = time.Since(start)
 		return result, nil
@@ -241,22 +299,43 @@ func (s *Sync) Push(
 		}
 	}
 
-	// When all sessions succeeded, advance the watermark to
-	// cutoff. When some failed, keep the watermark at lastPush
-	// so the failed sessions (plus any already-pushed ones) are
-	// re-evaluated next time. Already-pushed sessions are
-	// fingerprint-matched and skipped cheaply.
-	finalizeCutoff := cutoff
-	var mergedFingerprints map[string]string
-	if result.Errors > 0 {
-		finalizeCutoff = lastPush
-		mergedFingerprints = priorFingerprints
-	}
-	if err := finalizePushState(
-		s.local, finalizeCutoff, pushed,
-		mergedFingerprints,
-	); err != nil {
-		return result, err
+	if s.isFiltered() {
+		// Filtered pushes update fingerprints for pushed
+		// sessions so subsequent filtered runs stay
+		// incremental, but do not advance the global
+		// watermark past sessions from other projects.
+		// Only write fingerprints when a watermark exists;
+		// an empty watermark means --full or PG reset
+		// cleared the state, and writing fingerprints
+		// would create stale entries that survive a
+		// subsequent PG reset undetected.
+		if lastPush != "" {
+			if err := writePushBoundaryState(
+				s.local, lastPush, pushed,
+				priorFingerprints,
+			); err != nil {
+				return result, err
+			}
+		}
+	} else {
+		// When all sessions succeeded, advance the watermark
+		// to cutoff. When some failed, keep the watermark at
+		// lastPush so the failed sessions (plus any
+		// already-pushed ones) are re-evaluated next time.
+		// Already-pushed sessions are fingerprint-matched and
+		// skipped cheaply.
+		finalizeCutoff := cutoff
+		var mergedFingerprints map[string]string
+		if result.Errors > 0 {
+			finalizeCutoff = lastPush
+			mergedFingerprints = priorFingerprints
+		}
+		if err := finalizePushState(
+			s.local, finalizeCutoff, pushed,
+			mergedFingerprints,
+		); err != nil {
+			return result, err
+		}
 	}
 
 	result.Duration = time.Since(start)

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -42,6 +42,20 @@ type PushResult struct {
 // bypassed and every candidate session's messages are
 // re-pushed unconditionally.
 //
+// When project filters are set (via SyncOptions), only
+// matching sessions are pushed. Filtered pushes do not
+// advance the global watermark (last_push_at) because the
+// watermark covers all projects — advancing it would cause
+// unfiltered sessions to be skipped. Instead, filtered
+// pushes rely on fingerprints for incrementality: each run
+// re-queries all sessions since the last unfiltered push
+// and skips those whose fingerprint hasn't changed. This
+// means the query window grows between unfiltered pushes.
+// If filtered push is the normal operating mode (e.g. set
+// in config and running on a cron), run an occasional
+// unfiltered push to advance the watermark and bound the
+// query window.
+//
 // Known limitation: sessions that are permanently deleted
 // from SQLite (via prune) are not propagated as deletions
 // to PG because the local rows no longer exist at push time.

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -41,6 +41,16 @@ type Sync struct {
 	schemaDone bool
 }
 
+// SyncOptions holds optional configuration for a Sync instance.
+type SyncOptions struct {
+	// Projects limits push scope to these project names.
+	// Mutually exclusive with ExcludeProjects.
+	Projects []string
+	// ExcludeProjects excludes these project names from push.
+	// Mutually exclusive with Projects.
+	ExcludeProjects []string
+}
+
 // New creates a Sync instance and verifies the PG connection.
 // The machine name must not be "local", which is reserved as the
 // SQLite sentinel for sessions that originated on this machine.
@@ -49,7 +59,7 @@ type Sync struct {
 func New(
 	pgURL, schema string, local *db.DB,
 	machine string, allowInsecure bool,
-	projects, excludeProjects []string,
+	opts SyncOptions,
 ) (*Sync, error) {
 	if pgURL == "" {
 		return nil, fmt.Errorf("postgres URL is required")
@@ -80,8 +90,8 @@ func New(
 		local:           local,
 		machine:         machine,
 		schema:          schema,
-		projects:        projects,
-		excludeProjects: excludeProjects,
+		projects:        opts.Projects,
+		excludeProjects: opts.ExcludeProjects,
 	}, nil
 }
 

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -30,6 +30,10 @@ type Sync struct {
 	machine string
 	schema  string
 
+	// Project filtering for push scope.
+	projects        []string
+	excludeProjects []string
+
 	closeOnce sync.Once
 	closeErr  error
 
@@ -45,6 +49,7 @@ type Sync struct {
 func New(
 	pgURL, schema string, local *db.DB,
 	machine string, allowInsecure bool,
+	projects, excludeProjects []string,
 ) (*Sync, error) {
 	if pgURL == "" {
 		return nil, fmt.Errorf("postgres URL is required")
@@ -71,11 +76,19 @@ func New(
 	}
 
 	return &Sync{
-		pg:      pg,
-		local:   local,
-		machine: machine,
-		schema:  schema,
+		pg:              pg,
+		local:           local,
+		machine:         machine,
+		schema:          schema,
+		projects:        projects,
+		excludeProjects: excludeProjects,
 	}, nil
+}
+
+// isFiltered reports whether push scope is restricted by
+// project include/exclude filters.
+func (s *Sync) isFiltered() bool {
+	return len(s.projects) > 0 || len(s.excludeProjects) > 0
 }
 
 // DB returns the underlying PostgreSQL connection pool.

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -44,7 +44,7 @@ func TestEnsureSchemaIdempotent(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -173,7 +173,7 @@ func TestPushSingleSession(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -273,7 +273,7 @@ func TestPushIdempotent(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -330,7 +330,7 @@ func TestPushWithToolCalls(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -417,7 +417,7 @@ func TestPushWithToolResultEvents(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -497,7 +497,7 @@ func TestStatus(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -536,7 +536,7 @@ func TestStatusMissingSchema(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -573,7 +573,7 @@ func TestNewRejectsMachineLocal(t *testing.T) {
 	local := testDB(t)
 	_, err := New(
 		pgURL, "agentsview", local, "local", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err == nil {
 		t.Fatal("expected error for machine=local")
@@ -585,7 +585,7 @@ func TestNewRejectsEmptyMachine(t *testing.T) {
 	local := testDB(t)
 	_, err := New(
 		pgURL, "agentsview", local, "", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err == nil {
 		t.Fatal("expected error for empty machine")
@@ -596,7 +596,7 @@ func TestNewRejectsEmptyURL(t *testing.T) {
 	local := testDB(t)
 	_, err := New(
 		"", "agentsview", local, "test", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err == nil {
 		t.Fatal("expected error for empty URL")
@@ -612,7 +612,7 @@ func TestPushUpdatedAtFormat(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -674,7 +674,7 @@ func TestPushBumpsUpdatedAtOnMessageRewrite(
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"machine-a", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -763,7 +763,7 @@ func TestPushFullBypassesHeuristic(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -835,7 +835,7 @@ func TestPushDetectsSchemaReset(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -918,7 +918,7 @@ func TestPushFullAfterSchemaDropRecreatesSchema(
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -973,7 +973,7 @@ func TestPushBatchesMultipleSessions(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -1076,7 +1076,7 @@ func TestPushBulkInsertManyMessages(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -1196,7 +1196,7 @@ func TestPushSimplePK(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
-		nil, nil,
+		SyncOptions{},
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -1494,6 +1494,27 @@ func TestPushFilteredFullIsIncremental(t *testing.T) {
 			r1.SessionsPushed)
 	}
 
+	// Filtered --full must not advance the global watermark.
+	wm, err := local.GetSyncState("last_push_at")
+	if err != nil {
+		t.Fatalf("reading watermark: %v", err)
+	}
+	if wm != "" {
+		t.Errorf("watermark after filtered --full = %q, "+
+			"want empty", wm)
+	}
+
+	// Boundary fingerprints must have been written.
+	bs, err := local.GetSyncState(
+		"last_push_boundary_state",
+	)
+	if err != nil {
+		t.Fatalf("reading boundary state: %v", err)
+	}
+	if bs == "" {
+		t.Fatal("boundary state empty after filtered --full")
+	}
+
 	// Second push (not --full) should be a no-op because
 	// fingerprints were persisted after the filtered --full.
 	r2, err := ps.Push(ctx, false)

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -1445,3 +1445,63 @@ func TestPushExcludeProject(t *testing.T) {
 		t.Errorf("project = %q, want alpha", pgProject)
 	}
 }
+
+func TestPushFilteredFullIsIncremental(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanPGSchema(t, pgURL)
+	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
+
+	local := testDB(t)
+
+	if err := local.UpsertSession(db.Session{
+		ID: "s1", Project: "alpha",
+		Machine: "local", Agent: "claude",
+		MessageCount: 1,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := local.InsertMessages([]db.Message{
+		{
+			SessionID: "s1", Ordinal: 0,
+			Role: "user", Content: "hello",
+		},
+	}); err != nil {
+		t.Fatalf("insert msg: %v", err)
+	}
+
+	ctx := context.Background()
+	ps, err := New(
+		pgURL, "agentsview", local,
+		"test-machine", true,
+		SyncOptions{Projects: []string{"alpha"}},
+	)
+	if err != nil {
+		t.Fatalf("creating sync: %v", err)
+	}
+	defer ps.Close()
+
+	if err := ps.EnsureSchema(ctx); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+
+	// First push with --full.
+	r1, err := ps.Push(ctx, true)
+	if err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+	if r1.SessionsPushed != 1 {
+		t.Fatalf("first push: sessions = %d, want 1",
+			r1.SessionsPushed)
+	}
+
+	// Second push (not --full) should be a no-op because
+	// fingerprints were persisted after the filtered --full.
+	r2, err := ps.Push(ctx, false)
+	if err != nil {
+		t.Fatalf("second push: %v", err)
+	}
+	if r2.SessionsPushed != 0 {
+		t.Errorf("second push: sessions = %d, want 0",
+			r2.SessionsPushed)
+	}
+}

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -1246,3 +1246,202 @@ func TestPushSimplePK(t *testing.T) {
 		)
 	}
 }
+
+func TestPushFilteredByProject(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanPGSchema(t, pgURL)
+	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
+
+	local := testDB(t)
+
+	// Seed three sessions across three projects.
+	for _, s := range []db.Session{
+		{
+			ID: "s-alpha", Project: "alpha",
+			Machine: "local", Agent: "claude",
+			MessageCount: 1,
+		},
+		{
+			ID: "s-beta", Project: "beta",
+			Machine: "local", Agent: "claude",
+			MessageCount: 1,
+		},
+		{
+			ID: "s-gamma", Project: "gamma",
+			Machine: "local", Agent: "claude",
+			MessageCount: 1,
+		},
+	} {
+		if err := local.UpsertSession(s); err != nil {
+			t.Fatalf("upsert %s: %v", s.ID, err)
+		}
+		if err := local.InsertMessages([]db.Message{
+			{
+				SessionID: s.ID, Ordinal: 0,
+				Role: "user", Content: "msg " + s.ID,
+			},
+		}); err != nil {
+			t.Fatalf("insert msg %s: %v", s.ID, err)
+		}
+	}
+
+	ctx := context.Background()
+
+	// Step 1: push with project filter = ["alpha"].
+	filtered, err := New(
+		pgURL, "agentsview", local,
+		"test-machine", true,
+		SyncOptions{Projects: []string{"alpha"}},
+	)
+	if err != nil {
+		t.Fatalf("creating filtered sync: %v", err)
+	}
+	defer filtered.Close()
+
+	if err := filtered.EnsureSchema(ctx); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+	r1, err := filtered.Push(ctx, false)
+	if err != nil {
+		t.Fatalf("filtered push: %v", err)
+	}
+	if r1.SessionsPushed != 1 {
+		t.Fatalf(
+			"filtered push: sessions = %d, want 1",
+			r1.SessionsPushed,
+		)
+	}
+
+	// Verify only alpha is in PG.
+	pgSessionCount := func(project string) int {
+		t.Helper()
+		var n int
+		err := filtered.pg.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM sessions "+
+				"WHERE project = $1",
+			project,
+		).Scan(&n)
+		if err != nil {
+			t.Fatalf("count %s: %v", project, err)
+		}
+		return n
+	}
+	if n := pgSessionCount("alpha"); n != 1 {
+		t.Errorf("alpha count = %d, want 1", n)
+	}
+	if n := pgSessionCount("beta"); n != 0 {
+		t.Errorf("beta count = %d, want 0", n)
+	}
+	if n := pgSessionCount("gamma"); n != 0 {
+		t.Errorf("gamma count = %d, want 0", n)
+	}
+
+	// Step 2: push unfiltered — beta and gamma should arrive.
+	unfiltered, err := New(
+		pgURL, "agentsview", local,
+		"test-machine", true,
+		SyncOptions{},
+	)
+	if err != nil {
+		t.Fatalf("creating unfiltered sync: %v", err)
+	}
+	defer unfiltered.Close()
+
+	r2, err := unfiltered.Push(ctx, false)
+	if err != nil {
+		t.Fatalf("unfiltered push: %v", err)
+	}
+	if r2.SessionsPushed < 2 {
+		t.Fatalf(
+			"unfiltered push: sessions = %d, want >= 2",
+			r2.SessionsPushed,
+		)
+	}
+
+	// Verify all three projects are in PG.
+	for _, p := range []string{"alpha", "beta", "gamma"} {
+		if n := pgSessionCount(p); n != 1 {
+			t.Errorf("%s count = %d, want 1", p, n)
+		}
+	}
+
+	// Step 3: second filtered push is a no-op (fingerprints
+	// match).
+	r3, err := filtered.Push(ctx, false)
+	if err != nil {
+		t.Fatalf("second filtered push: %v", err)
+	}
+	if r3.SessionsPushed != 0 {
+		t.Errorf(
+			"second filtered push: sessions = %d, want 0",
+			r3.SessionsPushed,
+		)
+	}
+}
+
+func TestPushExcludeProject(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanPGSchema(t, pgURL)
+	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
+
+	local := testDB(t)
+
+	for _, s := range []db.Session{
+		{
+			ID: "s-a", Project: "alpha",
+			Machine: "local", Agent: "claude",
+			MessageCount: 1,
+		},
+		{
+			ID: "s-b", Project: "beta",
+			Machine: "local", Agent: "claude",
+			MessageCount: 1,
+		},
+	} {
+		if err := local.UpsertSession(s); err != nil {
+			t.Fatalf("upsert %s: %v", s.ID, err)
+		}
+		if err := local.InsertMessages([]db.Message{
+			{
+				SessionID: s.ID, Ordinal: 0,
+				Role: "user", Content: "msg",
+			},
+		}); err != nil {
+			t.Fatalf("insert msg %s: %v", s.ID, err)
+		}
+	}
+
+	ctx := context.Background()
+
+	ps, err := New(
+		pgURL, "agentsview", local,
+		"test-machine", true,
+		SyncOptions{ExcludeProjects: []string{"beta"}},
+	)
+	if err != nil {
+		t.Fatalf("creating sync: %v", err)
+	}
+	defer ps.Close()
+
+	if err := ps.EnsureSchema(ctx); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+	r, err := ps.Push(ctx, false)
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if r.SessionsPushed != 1 {
+		t.Fatalf("sessions = %d, want 1", r.SessionsPushed)
+	}
+
+	var pgProject string
+	err = ps.pg.QueryRowContext(ctx,
+		"SELECT project FROM sessions LIMIT 1",
+	).Scan(&pgProject)
+	if err != nil {
+		t.Fatalf("query pg: %v", err)
+	}
+	if pgProject != "alpha" {
+		t.Errorf("project = %q, want alpha", pgProject)
+	}
+}

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -44,6 +44,7 @@ func TestEnsureSchemaIdempotent(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -172,6 +173,7 @@ func TestPushSingleSession(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -271,6 +273,7 @@ func TestPushIdempotent(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -327,6 +330,7 @@ func TestPushWithToolCalls(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -413,6 +417,7 @@ func TestPushWithToolResultEvents(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -492,6 +497,7 @@ func TestStatus(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -530,6 +536,7 @@ func TestStatusMissingSchema(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -566,6 +573,7 @@ func TestNewRejectsMachineLocal(t *testing.T) {
 	local := testDB(t)
 	_, err := New(
 		pgURL, "agentsview", local, "local", true,
+		nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error for machine=local")
@@ -577,6 +585,7 @@ func TestNewRejectsEmptyMachine(t *testing.T) {
 	local := testDB(t)
 	_, err := New(
 		pgURL, "agentsview", local, "", true,
+		nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error for empty machine")
@@ -587,6 +596,7 @@ func TestNewRejectsEmptyURL(t *testing.T) {
 	local := testDB(t)
 	_, err := New(
 		"", "agentsview", local, "test", true,
+		nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected error for empty URL")
@@ -602,6 +612,7 @@ func TestPushUpdatedAtFormat(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -663,6 +674,7 @@ func TestPushBumpsUpdatedAtOnMessageRewrite(
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"machine-a", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -751,6 +763,7 @@ func TestPushFullBypassesHeuristic(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -822,6 +835,7 @@ func TestPushDetectsSchemaReset(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -904,6 +918,7 @@ func TestPushFullAfterSchemaDropRecreatesSchema(
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -958,6 +973,7 @@ func TestPushBatchesMultipleSessions(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -1060,6 +1076,7 @@ func TestPushBulkInsertManyMessages(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
@@ -1179,6 +1196,7 @@ func TestPushSimplePK(t *testing.T) {
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"test-machine", true,
+		nil, nil,
 	)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)

--- a/internal/postgres/token_usage_pgtest_test.go
+++ b/internal/postgres/token_usage_pgtest_test.go
@@ -108,7 +108,7 @@ func TestPushTokenUsageToPostgres(t *testing.T) {
 	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
 
 	local := testDB(t)
-	ps, err := New(pgURL, "agentsview", local, "test-machine", true, nil, nil)
+	ps, err := New(pgURL, "agentsview", local, "test-machine", true, SyncOptions{})
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
 	}

--- a/internal/postgres/token_usage_pgtest_test.go
+++ b/internal/postgres/token_usage_pgtest_test.go
@@ -108,7 +108,7 @@ func TestPushTokenUsageToPostgres(t *testing.T) {
 	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
 
 	local := testDB(t)
-	ps, err := New(pgURL, "agentsview", local, "test-machine", true)
+	ps, err := New(pgURL, "agentsview", local, "test-machine", true, nil, nil)
 	if err != nil {
 		t.Fatalf("creating sync: %v", err)
 	}


### PR DESCRIPTION
## Summary

Add `--projects` and `--exclude-projects` flags to `pg push` for scoping which
projects are synced to PostgreSQL. Filters can also be set via config file
(`pg.projects` / `pg.exclude_projects`). CLI flags override config values.

- `agentsview pg push --projects=alpha,beta` — push only these projects
- `agentsview pg push --exclude-projects=gamma` — push everything except gamma
- `agentsview pg push --all-projects` — ignore configured filters for one run
- `agentsview projects [--json]` — list projects with session counts

Based on work by @tlmaloney in `tlmaloney/feat/project-filtering`. That branch
had the core feature working but needed cleanup. Changes from the original:

**Squashed commit history.** The original branch had 19 commits (5 feat + 12
sequential fix-on-fix patches + 2 spec docs that were added then removed).
Squashed into a single commit preserving Tom's authorship.

**API cleanup.** `postgres.New()` had grown to 7 positional params with the
addition of `projects, excludeProjects []string`. Introduced `SyncOptions`
struct, eliminating `nil, nil` noise across 20 test call sites.

**Deduplicated state clearing.** Two identical 15-line watermark+boundary reset
blocks in `push.go` extracted into `clearPushState()`.

**Fixed fingerprint persistence after filtered --full.** The original code
skipped writing fingerprints when `last_push_at` was empty (after `--full` or PG
reset), causing every subsequent filtered push to re-push all matching sessions.
Now always writes fingerprints for filtered pushes, using the current cutoff as
the boundary state key.

**Fixed config validation scope.** The original put mutual exclusivity validation
in `ResolvePG()`, which broke `pg status` and `pg serve` on configs with
conflicting filter fields they don't consume. Also prevented CLI flags from
overriding a conflicting config. Moved validation to `runPGPush` after CLI flag
merging.

**Added `--all-projects` flag.** If `config.toml` sets `projects = ["alpha"]`,
there was no CLI way to run an unfiltered push. The documented guidance to "run
an occasional unfiltered push" was impossible without editing the config file.

**Added PG integration tests.** The original had no pgtest coverage for filtered
push. Added `TestPushFilteredByProject`, `TestPushExcludeProject`, and
`TestPushFilteredFullIsIncremental`.

**Documented watermark tradeoff.** Filtered pushes don't advance the global
watermark, so the query window grows between unfiltered pushes. Fingerprint
matching keeps PG writes minimal, but the SQLite query cost increases. Documented
in the `Push` doc comment.

## Test plan

- [ ] `make test` passes (Go unit tests, CGO_ENABLED=1 -tags fts5)
- [ ] `make test-postgres` passes (PG integration tests including new filtered
  push tests)
- [ ] Manual: `agentsview projects` lists projects with session counts
- [ ] Manual: `agentsview pg push --projects=<name>` pushes only matching
  sessions
- [ ] Manual: `agentsview pg push --all-projects` ignores config filters
- [ ] `pg status` and `pg serve` work with conflicting filter config

🤖 Generated with [Claude Code](https://claude.com/claude-code)