### PR TITLE
perf(usage): faster usage daily, default to 30-day window

### DIFF
--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -52,6 +52,26 @@ func runUsage(args []string) {
 // full history when users usually want recent spend.
 const defaultUsageDays = 30
 
+// resolveDefaultSince returns the effective --since value,
+// applying a 30-day lookback only when the caller gave no
+// explicit range at all. If --until is set we leave --since
+// empty so "everything up to --until" still works; otherwise
+// a bare --until would produce From > To and empty results.
+func resolveDefaultSince(
+	since, until string, all bool, now time.Time, tz string,
+) string {
+	if since != "" || until != "" || all {
+		return since
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		loc = time.Local
+	}
+	return now.In(loc).
+		AddDate(0, 0, -(defaultUsageDays - 1)).
+		Format("2006-01-02")
+}
+
 func runUsageDaily(args []string) {
 	fs := flag.NewFlagSet("usage daily", flag.ExitOnError)
 	jsonOut := fs.Bool("json", false,
@@ -88,18 +108,9 @@ func runUsageDaily(args []string) {
 		tz = localTimezone()
 	}
 
-	// Apply default 30-day window if no explicit range and
-	// --all was not requested.
-	effectiveSince := *since
-	if effectiveSince == "" && !*all {
-		loc, err := time.LoadLocation(tz)
-		if err != nil {
-			loc = time.Local
-		}
-		effectiveSince = time.Now().In(loc).
-			AddDate(0, 0, -(defaultUsageDays - 1)).
-			Format("2006-01-02")
-	}
+	effectiveSince := resolveDefaultSince(
+		*since, *until, *all, time.Now(), tz,
+	)
 
 	filter := db.UsageFilter{
 		From:     effectiveSince,

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -46,6 +46,12 @@ func runUsage(args []string) {
 	}
 }
 
+// defaultUsageDays is the default lookback window for
+// `agentsview usage daily` when neither --since nor --all is
+// given. Matches ccusage's default and avoids scanning the
+// full history when users usually want recent spend.
+const defaultUsageDays = 30
+
 func runUsageDaily(args []string) {
 	fs := flag.NewFlagSet("usage daily", flag.ExitOnError)
 	jsonOut := fs.Bool("json", false,
@@ -54,6 +60,8 @@ func runUsageDaily(args []string) {
 		"Start date (YYYY-MM-DD)")
 	until := fs.String("until", "",
 		"End date (YYYY-MM-DD)")
+	all := fs.Bool("all", false,
+		"Include all history (overrides default 30-day window)")
 	agent := fs.String("agent", "",
 		"Filter by agent (claude, codex)")
 	breakdown := fs.Bool("breakdown", false,
@@ -80,8 +88,21 @@ func runUsageDaily(args []string) {
 		tz = localTimezone()
 	}
 
+	// Apply default 30-day window if no explicit range and
+	// --all was not requested.
+	effectiveSince := *since
+	if effectiveSince == "" && !*all {
+		loc, err := time.LoadLocation(tz)
+		if err != nil {
+			loc = time.Local
+		}
+		effectiveSince = time.Now().In(loc).
+			AddDate(0, 0, -(defaultUsageDays - 1)).
+			Format("2006-01-02")
+	}
+
 	filter := db.UsageFilter{
-		From:     *since,
+		From:     effectiveSince,
 		To:       *until,
 		Agent:    *agent,
 		Timezone: tz,
@@ -340,8 +361,9 @@ Commands:
 
 Daily flags:
   --json              Output as JSON
-  --since YYYY-MM-DD  Start date
+  --since YYYY-MM-DD  Start date (default: 30 days ago)
   --until YYYY-MM-DD  End date
+  --all               Include all history (overrides default window)
   --agent string      Filter by agent (claude, codex)
   --breakdown         Show per-model breakdown rows
   --offline           Use fallback pricing only

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -3,9 +3,61 @@ package main
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/wesm/agentsview/internal/db"
 )
+
+func TestResolveDefaultSince(t *testing.T) {
+	now := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	const utc = "UTC"
+
+	tests := []struct {
+		name  string
+		since string
+		until string
+		all   bool
+		want  string
+	}{
+		{
+			name: "no flags returns 30-day window",
+			want: "2024-05-17",
+		},
+		{
+			name:  "explicit since preserved",
+			since: "2024-01-01",
+			want:  "2024-01-01",
+		},
+		{
+			name: "all flag disables default",
+			all:  true,
+			want: "",
+		},
+		{
+			name:  "until without since does not backfill since",
+			until: "2024-01-31",
+			want:  "",
+		},
+		{
+			name:  "explicit range preserved",
+			since: "2024-01-01",
+			until: "2024-01-31",
+			want:  "2024-01-01",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveDefaultSince(
+				tc.since, tc.until, tc.all, now, utc,
+			)
+			if got != tc.want {
+				t.Errorf("resolveDefaultSince = %q, want %q",
+					got, tc.want)
+			}
+		})
+	}
+}
 
 func TestFormatDailyUsageJSON(t *testing.T) {
 	result := db.DailyUsageResult{

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -210,6 +210,14 @@ WHERE m.token_usage != ''
 			continue
 		}
 
+		// token_usage is written by our parsers and never by
+		// user input, so we trust it to be valid JSON. gjson
+		// is permissive enough that a truncated-tail row still
+		// yields its leading fields; a fully garbage row would
+		// return zeros, but that path is not reachable from
+		// any known parser. Skipping gjson.Valid here preserves
+		// the hot-path speedup (O(n) per row → not free on a
+		// 310k-row scan).
 		usage := gjson.Parse(tokenJSON)
 		inputTok := int(usage.Get("input_tokens").Int())
 		outputTok := int(usage.Get("output_tokens").Int())

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	"github.com/tidwall/gjson"
 )
 
 // UsageFilter controls the date range, agent, and timezone
@@ -65,6 +67,49 @@ type DailyUsageResult struct {
 	Totals UsageTotals       `json:"totals"`
 }
 
+// modelRates holds per-model pricing in rate-per-token form.
+type modelRates struct {
+	input         float64
+	output        float64
+	cacheCreation float64
+	cacheRead     float64
+}
+
+// loadPricingMap reads the model_pricing table into a map for
+// in-memory joins. This is much faster than a SQL LEFT JOIN
+// on every row of the daily usage scan, since the pricing
+// table is tiny (a few dozen rows) and lookups are O(1).
+func (db *DB) loadPricingMap(
+	ctx context.Context,
+) (map[string]modelRates, error) {
+	rows, err := db.getReader().QueryContext(ctx,
+		`SELECT model_pattern,
+			input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok
+		 FROM model_pricing`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]modelRates)
+	for rows.Next() {
+		var (
+			pattern string
+			rates   modelRates
+		)
+		if err := rows.Scan(
+			&pattern,
+			&rates.input, &rates.output,
+			&rates.cacheCreation, &rates.cacheRead,
+		); err != nil {
+			return nil, err
+		}
+		out[pattern] = rates
+	}
+	return out, rows.Err()
+}
+
 // paddedUTCBound pads a UTC timestamp by hours to cover timezone
 // offsets. Positive hours pad forward, negative pad backward.
 func paddedUTCBound(ts string, hours int) string {
@@ -76,28 +121,28 @@ func paddedUTCBound(ts string, hours int) string {
 }
 
 // GetDailyUsage returns token usage and cost aggregated by day.
-// It joins messages with sessions and model_pricing to compute
-// per-row costs, then buckets by local date.
+// It scans messages with non-empty token_usage JSON blobs,
+// parses them in Go (faster than SQLite's json_extract per row),
+// joins against an in-memory pricing map, and buckets by
+// local date.
 func (db *DB) GetDailyUsage(
 	ctx context.Context, f UsageFilter,
 ) (DailyUsageResult, error) {
 	loc := f.location()
 
+	pricing, err := db.loadPricingMap(ctx)
+	if err != nil {
+		return DailyUsageResult{},
+			fmt.Errorf("loading pricing: %w", err)
+	}
+
 	query := `
 SELECT
 	COALESCE(m.timestamp, s.started_at) as ts,
 	m.model,
-	COALESCE(json_extract(m.token_usage, '$.input_tokens'), 0),
-	COALESCE(json_extract(m.token_usage, '$.output_tokens'), 0),
-	COALESCE(json_extract(m.token_usage, '$.cache_creation_input_tokens'), 0),
-	COALESCE(json_extract(m.token_usage, '$.cache_read_input_tokens'), 0),
-	COALESCE(p.input_per_mtok, 0),
-	COALESCE(p.output_per_mtok, 0),
-	COALESCE(p.cache_creation_per_mtok, 0),
-	COALESCE(p.cache_read_per_mtok, 0)
+	m.token_usage
 FROM messages m
 JOIN sessions s ON m.session_id = s.id
-LEFT JOIN model_pricing p ON m.model = p.model_pattern
 WHERE m.token_usage != ''
 	AND m.model != ''
 	AND m.model != '<synthetic>'
@@ -146,21 +191,13 @@ WHERE m.token_usage != ''
 
 	accum := make(map[dateModelKey]*modelAccum)
 
+	var (
+		ts        string
+		model     string
+		tokenJSON string
+	)
 	for rows.Next() {
-		var (
-			ts                       string
-			model                    string
-			inputTok, outputTok      int
-			cacheCrTok, cacheRdTok   int
-			inputRate, outputRate    float64
-			cacheCrRate, cacheRdRate float64
-		)
-		if err := rows.Scan(
-			&ts, &model,
-			&inputTok, &outputTok, &cacheCrTok, &cacheRdTok,
-			&inputRate, &outputRate,
-			&cacheCrRate, &cacheRdRate,
-		); err != nil {
+		if err := rows.Scan(&ts, &model, &tokenJSON); err != nil {
 			return DailyUsageResult{},
 				fmt.Errorf("scanning daily usage row: %w", err)
 		}
@@ -173,10 +210,17 @@ WHERE m.token_usage != ''
 			continue
 		}
 
-		cost := (float64(inputTok)*inputRate +
-			float64(outputTok)*outputRate +
-			float64(cacheCrTok)*cacheCrRate +
-			float64(cacheRdTok)*cacheRdRate) / 1_000_000
+		usage := gjson.Parse(tokenJSON)
+		inputTok := int(usage.Get("input_tokens").Int())
+		outputTok := int(usage.Get("output_tokens").Int())
+		cacheCrTok := int(usage.Get("cache_creation_input_tokens").Int())
+		cacheRdTok := int(usage.Get("cache_read_input_tokens").Int())
+
+		rates := pricing[model]
+		cost := (float64(inputTok)*rates.input +
+			float64(outputTok)*rates.output +
+			float64(cacheCrTok)*rates.cacheCreation +
+			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
 
 		key := dateModelKey{date: date, model: model}
 		ma, ok := accum[key]

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -354,6 +354,70 @@ func TestGetDailyUsageNoPricing(t *testing.T) {
 	}
 }
 
+// TestGetDailyUsageTruncatedTokenJSON documents what happens when
+// a message lands in the DB with truncated token_usage — gjson is
+// permissive and still extracts the leading fields, so the valid
+// data is preserved. This is why we don't run gjson.Valid on the
+// hot aggregation path: the realistic corruption modes reachable
+// from our parsers don't produce silent zeros.
+func TestGetDailyUsageTruncatedTokenJSON(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "sess1", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+
+	insertMessages(t, d,
+		Message{
+			SessionID: "sess1", Ordinal: 0,
+			Role:      "assistant",
+			Timestamp: "2024-06-15T10:30:00Z",
+			Model:     "claude-sonnet-4-20250514",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":1000,"output_tokens":500}`),
+		},
+		Message{
+			SessionID: "sess1", Ordinal: 1,
+			Role:      "assistant",
+			Timestamp: "2024-06-15T10:31:00Z",
+			Model:     "claude-sonnet-4-20250514",
+			// Truncated mid-key. gjson still finds the two
+			// leading numeric fields and extracts them.
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":9999,"output_tokens":4242,"ca`),
+		},
+	)
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	})
+	requireNoError(t, err, "GetDailyUsage truncated")
+
+	if len(result.Daily) != 1 {
+		t.Fatalf("got %d daily entries, want 1",
+			len(result.Daily))
+	}
+	day := result.Daily[0]
+	// 1000 (valid row) + 9999 (truncated but still parseable)
+	if day.InputTokens != 10999 {
+		t.Errorf("InputTokens = %d, want 10999 "+
+			"(gjson should extract leading fields from truncated JSON)",
+			day.InputTokens)
+	}
+	if day.OutputTokens != 4742 {
+		t.Errorf("OutputTokens = %d, want 4742", day.OutputTokens)
+	}
+}
+
 func TestGetDailyUsageLongLivedSession(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
Two followups to #308.

## Summary
- **perf: parse `token_usage` in Go instead of SQLite's `json_extract`.** `GetDailyUsage` was running 1.2M `json_extract` calls per 310k-row scan. Switch to a single raw `token_usage` fetch + `gjson.Parse` in Go, and hoist the `model_pricing` LEFT JOIN into an in-memory map loaded once before the scan (the pricing table has <20 rows). Query drops from ~525ms to ~270ms on a 22k-session / 310k-message DB.
- **feat: default `usage daily` to last 30 days, add `--all` flag.** Running `usage daily` without a date range previously scanned full history. Most callers only care about recent spend, so default to a 30-day window and let users opt into full history with `--all`. The date filter also pushes down into the SQL `WHERE` clause.

Net effect on `agentsview usage daily --json --offline --no-sync`: 530ms → 320ms (40% faster). With quick sync enabled: 720ms → 550ms.

## Test plan
- [ ] `agentsview usage daily` returns last 30 days by default
- [ ] `agentsview usage daily --all` returns full history
- [ ] `agentsview usage daily --from=... --to=...` still honors explicit ranges
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)