### PR TITLE
chore: stop enumerating agent names in docs and help text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,17 +2,17 @@
 
 ## Project Overview
 
-agentsview is a local web viewer for AI agent sessions (Claude Code, Codex,
-Copilot CLI, Gemini CLI, OpenCode, Amp). It syncs session data from disk into
-SQLite (with FTS5 full-text search), serves a Svelte 5 SPA via an embedded Go
-HTTP server, and provides real-time updates via SSE.
+agentsview is a local web viewer for AI agent sessions. It syncs session data
+from disk into SQLite (with FTS5 full-text search), serves a Svelte 5 SPA via an
+embedded Go HTTP server, and provides real-time updates via SSE. See
+`internal/parser/types.go` for the full list of supported agents.
 
 ## Architecture
 
 ```
 CLI (agentsview) → Config → DB (SQLite/FTS5)
                   ↓              ↓
-              File Watcher → Sync Engine → Parser (Claude, Codex, Copilot, Gemini, OpenCode, Amp)
+              File Watcher → Sync Engine → Parsers (per agent)
                   ↓              ↓
               HTTP Server → REST API + SSE + Embedded SPA
                                  ↓
@@ -27,9 +27,8 @@ CLI (agentsview) → Config → DB (SQLite/FTS5)
 - **Sync**: File watcher + periodic sync (15min) for session directories
 - **PG Sync**: On-demand push sync from SQLite to PostgreSQL via `pg push`
 - **Frontend**: Svelte 5 SPA embedded in the Go binary at build time
-- **Config**: Env vars (`AGENT_VIEWER_DATA_DIR`, `CLAUDE_PROJECTS_DIR`,
-  `CODEX_SESSIONS_DIR`, `COPILOT_DIR`, `GEMINI_DIR`, `OPENCODE_DIR`, `AMP_DIR`)
-  and CLI flags
+- **Config**: `AGENT_VIEWER_DATA_DIR` plus per-agent directory overrides (see
+  `EnvVar` on each entry in `internal/parser/types.go`) and CLI flags
 
 ## Project Structure
 
@@ -39,8 +38,7 @@ CLI (agentsview) → Config → DB (SQLite/FTS5)
 - `internal/db/` - SQLite operations (sessions, messages, search, analytics)
 - `internal/postgres/` - PostgreSQL support: push sync, read-only store, schema,
   connection helpers
-- `internal/parser/` - Session file parsers (Claude, Codex, Copilot, Gemini,
-  OpenCode, Amp, content extraction)
+- `internal/parser/` - Per-agent session file parsers and content extraction
 - `internal/server/` - HTTP handlers, SSE, middleware, search, export
 - `internal/sync/` - Sync engine, file watcher, discovery, hashing
 - `internal/timeutil/` - Time parsing utilities
@@ -62,10 +60,8 @@ CLI (agentsview) → Config → DB (SQLite/FTS5)
 | `internal/db/sessions.go`        | Session CRUD queries                          |
 | `internal/db/search.go`          | FTS5 search queries                           |
 | `internal/sync/engine.go`        | Sync orchestration                            |
-| `internal/parser/claude.go`      | Claude Code session parser                    |
-| `internal/parser/codex.go`       | Codex session parser                          |
-| `internal/parser/copilot.go`     | Copilot CLI session parser                    |
-| `internal/parser/amp.go`         | Amp session parser                            |
+| `internal/parser/types.go`       | Agent registry (one `AgentDef` per agent)     |
+| `internal/parser/*.go`           | Per-agent session parsers                     |
 | `internal/postgres/connect.go`   | Connection setup, SSL checks, DSN helpers     |
 | `internal/postgres/schema.go`    | PG DDL, schema management                     |
 | `internal/postgres/push.go`      | Push logic, fingerprinting                    |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # agentsview
 
 A local-first desktop and web application for browsing, searching, and analyzing
-AI agent coding sessions. Supports Claude Code, Codex, OpenCode, and many
-other agents.
+AI agent coding sessions. Supports Claude Code, Codex, OpenCode, and more
+([full list](#supported-agents)).
 
 <p align="center">
   <img src="https://agentsview.io/screenshots/dashboard.png" alt="Analytics dashboard" width="720">
@@ -51,7 +51,7 @@ behavior, and track usage patterns over time.
 - **Full-text search** across all message content, instantly
 - **Analytics dashboard** with activity heatmaps, tool usage, velocity metrics,
   and project breakdowns
-- **Multi-agent support** for Claude Code, Codex, OpenCode, and many other agents
+- **Multi-agent support** — Claude Code, Codex, OpenCode, and more
   ([full list](#supported-agents))
 - **Live updates** via SSE as active sessions receive new messages
 - **Keyboard-first** navigation (vim-style `j`/`k`/`[`/`]`)
@@ -338,24 +338,24 @@ frontend/           Svelte 5 SPA (Vite, TypeScript)
 
 ## Supported Agents
 
-| Agent          | Session Directory                                  | Env Override          |
-| -------------- | -------------------------------------------------- | --------------------- |
-| Claude Code    | `~/.claude/projects/`                              | `CLAUDE_PROJECTS_DIR` |
-| Codex          | `~/.codex/sessions/`                               | `CODEX_SESSIONS_DIR`  |
-| Copilot        | `~/.copilot/`                                      | `COPILOT_DIR`         |
-| Gemini         | `~/.gemini/`                                       | `GEMINI_DIR`          |
-| OpenCode       | `~/.local/share/opencode/`                         | `OPENCODE_DIR`        |
+| Agent          | Session Directory                                  | Env Override                  |
+| -------------- | -------------------------------------------------- | ----------------------------- |
+| Claude Code    | `~/.claude/projects/`                              | `CLAUDE_PROJECTS_DIR`         |
+| Codex          | `~/.codex/sessions/`                               | `CODEX_SESSIONS_DIR`          |
+| Copilot        | `~/.copilot/`                                      | `COPILOT_DIR`                 |
+| Gemini         | `~/.gemini/`                                       | `GEMINI_DIR`                  |
+| OpenCode       | `~/.local/share/opencode/`                         | `OPENCODE_DIR`                |
 | OpenHands CLI  | `~/.openhands/conversations/`                      | `OPENHANDS_CONVERSATIONS_DIR` |
-| Cursor         | `~/.cursor/projects/`                              | `CURSOR_PROJECTS_DIR` |
-| Amp            | `~/.local/share/amp/threads/`                      | `AMP_DIR`             |
-| iFlow          | `~/.iflow/projects/`                               | `IFLOW_DIR`           |
-| VSCode Copilot | `~/Library/Application Support/Code/User/` (macOS) | `VSCODE_COPILOT_DIR`  |
-| Pi             | `~/.pi/agent/sessions/`                            | `PI_DIR`              |
-| OpenClaw       | `~/.openclaw/agents/`                              | `OPENCLAW_DIR`        |
-| Kimi           | `~/.kimi/sessions/`                                | `KIMI_DIR`            |
-| Kiro CLI       | `~/.kiro/sessions/cli/`                            | `KIRO_SESSIONS_DIR`   |
-| Kiro IDE       | `~/Library/Application Support/Kiro/` (macOS)      | `KIRO_IDE_DIR`        |
-| Cortex Code    | `~/.snowflake/cortex/conversations/`               | `CORTEX_DIR`          |
+| Cursor         | `~/.cursor/projects/`                              | `CURSOR_PROJECTS_DIR`         |
+| Amp            | `~/.local/share/amp/threads/`                      | `AMP_DIR`                     |
+| iFlow          | `~/.iflow/projects/`                               | `IFLOW_DIR`                   |
+| VSCode Copilot | `~/Library/Application Support/Code/User/` (macOS) | `VSCODE_COPILOT_DIR`          |
+| Pi             | `~/.pi/agent/sessions/`                            | `PI_DIR`                      |
+| OpenClaw       | `~/.openclaw/agents/`                              | `OPENCLAW_DIR`                |
+| Kimi           | `~/.kimi/sessions/`                                | `KIMI_DIR`                    |
+| Kiro CLI       | `~/.kiro/sessions/cli/`                            | `KIRO_SESSIONS_DIR`           |
+| Kiro IDE       | `~/Library/Application Support/Kiro/` (macOS)      | `KIRO_IDE_DIR`                |
+| Cortex Code    | `~/.snowflake/cortex/conversations/`               | `CORTEX_DIR`                  |
 
 ## Acknowledgements
 

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -79,9 +79,8 @@ func main() {
 func printUsage() {
 	fmt.Printf(`agentsview %s - local web viewer for AI agent sessions
 
-Syncs Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, OpenHands,
-Cursor, and Amp session data into SQLite, serves an analytics dashboard
-and session browser via a local web UI.
+Syncs session data from supported agents into SQLite and serves an
+analytics dashboard and session browser via a local web UI.
 
 Usage:
   agentsview [flags]          Start the server (default command)

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -83,7 +83,7 @@ func runUsageDaily(args []string) {
 	all := fs.Bool("all", false,
 		"Include all history (overrides default 30-day window)")
 	agent := fs.String("agent", "",
-		"Filter by agent (claude, codex)")
+		"Filter by agent name")
 	breakdown := fs.Bool("breakdown", false,
 		"Show per-model breakdown rows")
 	offline := fs.Bool("offline", false,
@@ -143,7 +143,7 @@ func runUsageDaily(args []string) {
 func runUsageStatusline(args []string) {
 	fs := flag.NewFlagSet("usage statusline", flag.ExitOnError)
 	agent := fs.String("agent", "",
-		"Filter by agent (claude, codex)")
+		"Filter by agent name")
 	offline := fs.Bool("offline", false,
 		"Use fallback pricing only")
 	noSync := fs.Bool("no-sync", false,
@@ -375,14 +375,14 @@ Daily flags:
   --since YYYY-MM-DD  Start date (default: 30 days ago)
   --until YYYY-MM-DD  End date
   --all               Include all history (overrides default window)
-  --agent string      Filter by agent (claude, codex)
+  --agent string      Filter by agent name
   --breakdown         Show per-model breakdown rows
   --offline           Use fallback pricing only
   --no-sync           Skip on-demand sync before querying
   --timezone string   IANA timezone for date bucketing
 
 Statusline flags:
-  --agent string      Filter by agent (claude, codex)
+  --agent string      Filter by agent name
   --offline           Use fallback pricing only
   --no-sync           Skip on-demand sync before querying
 `)

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
     "targets": "all",
     "copyright": "Copyright 2026 Wes McKinney",
     "shortDescription": "Local viewer for AI agent sessions",
-    "longDescription": "AgentsView is a local web viewer for AI agent sessions including Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, and Amp.",
+    "longDescription": "AgentsView is a local web viewer for AI agent coding sessions.",
     "createUpdaterArtifacts": "v1Compatible",
     "externalBin": [
       "binaries/agentsview"

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -28,14 +28,24 @@ type Result struct {
 	Model   string
 }
 
-// ValidAgents lists the supported agent names.
-var ValidAgents = map[string]bool{
-	"claude":  true,
-	"codex":   true,
-	"copilot": true,
-	"gemini":  true,
-	"kiro":    true,
+// ValidAgentNames lists the supported insight agent names in display
+// order. ValidAgents is a lookup set derived from it.
+var ValidAgentNames = []string{
+	"claude",
+	"codex",
+	"copilot",
+	"gemini",
+	"kiro",
 }
+
+// ValidAgents is the set of supported insight agent names.
+var ValidAgents = func() map[string]bool {
+	m := make(map[string]bool, len(ValidAgentNames))
+	for _, name := range ValidAgentNames {
+		m[name] = true
+	}
+	return m
+}()
 
 // GenerateFunc is the signature for insight generation,
 // allowing tests to substitute a stub.

--- a/internal/server/insights.go
+++ b/internal/server/insights.go
@@ -193,7 +193,8 @@ func (s *Server) handleGenerateInsight(
 	}
 	if !insight.ValidAgents[req.Agent] {
 		writeError(w, http.StatusBadRequest,
-			"invalid agent: must be claude, codex, copilot, or gemini")
+			"invalid agent: must be one of "+
+				strings.Join(insight.ValidAgentNames, ", "))
 		return
 	}
 


### PR DESCRIPTION
## Summary

Several spots listed specific agents (\"Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, Amp\" and friends) that went stale every time a new agent was added and kept getting rewritten by agent-adding PRs. Replace enumerated lists with generic phrasing or a pointer to the registry in `internal/parser/types.go`. In `README.md` the featured copy keeps the top three (Claude Code, Codex, OpenCode) followed by \"and more\" and a link to the full `#supported-agents` table.

Also fixes a latent bug in the insights API: the validation error at `internal/server/insights.go` listed four agents but `insight.ValidAgents` already contained five (`kiro`). Introduces `insight.ValidAgentNames` as the ordered source of truth and derives both the lookup set and the error message from it.

## Changes

- `cmd/agentsview/main.go` (`printUsage`): drop the agent list from the one-line description
- `cmd/agentsview/usage.go`: replace \"Filter by agent (claude, codex)\" with \"Filter by agent name\" in four places (flag help + help text)
- `CLAUDE.md`: drop agent lists from project overview, architecture diagram, env vars section, parser description, and key-files table
- `README.md`: keep \"Claude Code, Codex, OpenCode, and more\" with a link to the full table
- `desktop/src-tauri/tauri.conf.json`: generic `longDescription`
- `internal/insight/generate.go`: `ValidAgentNames` slice as single source of truth, `ValidAgents` map derived from it
- `internal/server/insights.go`: join `ValidAgentNames` in the validation error (previously hardcoded and stale)

## Test plan

- [x] \`go vet ./...\`
- [x] \`go test -tags fts5 -short ./internal/insight ./internal/server ./cmd/agentsview ./internal/parser ./internal/sync\`
- [x] \`mdformat --wrap 80 CLAUDE.md README.md\`