### PR TITLE
feat: token usage dashboard with filtering and drill-down

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,15 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+cmd = "./scripts/dev-backend-build.sh"
+bin = "./tmp/agentsview"
+delay = 500
+exclude_dir = ["frontend", "internal/web/dist", "tmp", "vendor", ".git", "dist", "desktop", "data", "sessions", "html", ".superpowers"]
+include_ext = ["go", "tpl", "tmpl", "html", "sql"]
+stop_on_error = true
+send_interrupt = true
+kill_delay = "500ms"
+
+[screen]
+clear_on_rebuild = true

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ internal/web/dist/
 coverage.out
 *.test
 
+# Air (live-reload dev server)
+/tmp/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,13 @@ LDFLAGS := -X main.version=$(VERSION) \
 LDFLAGS_RELEASE := $(LDFLAGS) -s -w
 DESKTOP_DIST_DIR := dist/desktop
 
-.PHONY: build build-release install frontend frontend-dev dev desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app test test-short test-postgres test-postgres-ci postgres-up postgres-down e2e vet lint lint-ci tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir help
+GOPATH_FIRST := $(shell go env GOPATH | cut -d: -f1)
+AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
+	elif [ -n "$$(go env GOBIN)" ] && [ -x "$$(go env GOBIN)/air" ]; then printf "%s" "$$(go env GOBIN)/air"; \
+	elif [ -x "$(GOPATH_FIRST)/bin/air" ]; then printf "%s" "$(GOPATH_FIRST)/bin/air"; \
+	fi)
+
+.PHONY: build build-release install frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app test test-short test-postgres test-postgres-ci postgres-up postgres-down e2e vet lint lint-ci tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -55,9 +61,21 @@ frontend:
 frontend-dev:
 	cd frontend && npm run dev
 
-# Run Go server in dev mode (no embedded frontend)
-dev: ensure-embed-dir
-	go run -tags fts5 -ldflags="$(LDFLAGS)" ./cmd/agentsview $(ARGS)
+# Ensure air is installed for backend live reload
+check-air:
+	@if [ -z "$(AIR_BIN)" ]; then \
+		echo "air not found. Install with: make air-install" >&2; \
+		exit 1; \
+	fi
+
+# Install air for backend live reload
+air-install:
+	go install github.com/air-verse/air@latest
+
+# Run Go server in dev mode with live reload (use with frontend-dev).
+# Edits to .go files trigger a rebuild + restart via air.
+dev: ensure-embed-dir check-air
+	"$(AIR_BIN)" -c .air.toml -- $(ARGS)
 
 # Run the Tauri desktop wrapper in development mode
 desktop-dev:
@@ -191,7 +209,7 @@ tidy:
 # Clean build artifacts
 clean:
 	rm -f agentsview agentsv
-	rm -rf internal/web/dist dist/
+	rm -rf internal/web/dist dist/ tmp/
 
 # Build release binary for current platform (CGO required for sqlite3)
 release: frontend
@@ -235,7 +253,8 @@ help:
 	@echo "  build-release  - Release build (optimized, stripped)"
 	@echo "  install        - Build and install to ~/.local/bin or GOPATH"
 	@echo ""
-	@echo "  dev            - Run Go server (use with frontend-dev)"
+	@echo "  dev            - Run Go server with live reload via air (use with frontend-dev)"
+	@echo "  air-install    - Install air for backend live reload"
 	@echo "  frontend       - Build frontend SPA"
 	@echo "  frontend-dev   - Run Vite dev server"
 	@echo "  desktop-dev    - Run Tauri desktop wrapper in dev mode"

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -176,10 +176,11 @@ func runUsageStatusline(args []string) {
 	}
 
 	if *agent != "" {
-		fmt.Printf("$%.2f today (%s)\n",
-			result.Totals.TotalCost, *agent)
+		fmt.Printf("%s today (%s)\n",
+			fmtCost(result.Totals.TotalCost), *agent)
 	} else {
-		fmt.Printf("$%.2f today\n", result.Totals.TotalCost)
+		fmt.Printf("%s today\n",
+			fmtCost(result.Totals.TotalCost))
 	}
 }
 

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -307,26 +307,26 @@ func printDailyTable(
 
 	for _, day := range result.Daily {
 		models := joinModels(day.ModelsUsed)
-		fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t$%.4f\t%s\n",
+		fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t%s\t%s\n",
 			day.Date,
 			day.InputTokens,
 			day.OutputTokens,
 			day.CacheCreationTokens,
 			day.CacheReadTokens,
-			day.TotalCost,
+			fmtCost(day.TotalCost),
 			models,
 		)
 
 		if breakdown {
 			for _, mb := range day.ModelBreakdowns {
 				fmt.Fprintf(w,
-					"  %s\t%d\t%d\t%d\t%d\t$%.4f\t\n",
+					"  %s\t%d\t%d\t%d\t%d\t%s\t\n",
 					mb.ModelName,
 					mb.InputTokens,
 					mb.OutputTokens,
 					mb.CacheCreationTokens,
 					mb.CacheReadTokens,
-					mb.Cost,
+					fmtCost(mb.Cost),
 				)
 			}
 		}
@@ -334,12 +334,12 @@ func printDailyTable(
 
 	fmt.Fprintln(w,
 		"----\t-----\t------\t--------\t--------\t----\t------")
-	fmt.Fprintf(w, "TOTAL\t%d\t%d\t%d\t%d\t$%.4f\t\n",
+	fmt.Fprintf(w, "TOTAL\t%d\t%d\t%d\t%d\t%s\t\n",
 		result.Totals.InputTokens,
 		result.Totals.OutputTokens,
 		result.Totals.CacheCreationTokens,
 		result.Totals.CacheReadTokens,
-		result.Totals.TotalCost,
+		fmtCost(result.Totals.TotalCost),
 	)
 
 	w.Flush()
@@ -348,6 +348,17 @@ func printDailyTable(
 // localTimezone returns the IANA name of the system's local timezone.
 func localTimezone() string {
 	return time.Now().Location().String()
+}
+
+// fmtCost formats a dollar amount with two decimal places,
+// matching conventional currency display. Non-zero values
+// under half a cent would otherwise round to "$0.00" and
+// read as "free", so they render as "<$0.01" instead.
+func fmtCost(v float64) string {
+	if v > 0 && v < 0.005 {
+		return "<$0.01"
+	}
+	return fmt.Sprintf("$%.2f", v)
 }
 
 func joinModels(models []string) string {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -8,6 +8,32 @@ import (
 	"github.com/wesm/agentsview/internal/db"
 )
 
+func TestFmtCost(t *testing.T) {
+	tests := []struct {
+		name string
+		in   float64
+		want string
+	}{
+		{"zero is $0.00", 0, "$0.00"},
+		{"under half a cent shows <$0.01", 0.001, "<$0.01"},
+		{"half a cent rounds up to $0.01", 0.005, "$0.01"},
+		{"typical cents", 0.45, "$0.45"},
+		{"dollars", 12.34, "$12.34"},
+		{"rounds to two decimals", 1.23456, "$1.23"},
+		{"large value", 1234.56, "$1234.56"},
+		// A negative input shouldn't hit the <$0.01 branch.
+		{"negative passes through", -0.42, "$-0.42"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fmtCost(tc.in); got != tc.want {
+				t.Errorf("fmtCost(%v) = %q, want %q",
+					tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestResolveDefaultSince(t *testing.T) {
 	now := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
 	const utc = "UTC"

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -148,13 +148,6 @@ func createSessionFixture(
 	if index%3 == 1 {
 		model = "claude-opus-4-20250514"
 	}
-	// Subagent and fork sessions must not appear in /usage
-	// aggregation. Skip seeding token_usage on their messages so
-	// the usage query's eligibility predicates (which match empty
-	// model as the disqualifier) filter them out.
-	if spec.relationshipType != "" {
-		model = ""
-	}
 
 	var msgs []db.Message
 	if spec.suffix == "mixed-content-7" {

--- a/cmd/testfixture/main.go
+++ b/cmd/testfixture/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -61,6 +62,26 @@ func main() {
 		log.Fatalf("opening db: %v", err)
 	}
 	defer database.Close()
+
+	// Seed model pricing for usage page e2e tests.
+	if err := database.UpsertModelPricing([]db.ModelPricing{
+		{
+			ModelPattern:         "claude-sonnet-4-20250514",
+			InputPerMTok:         3.0,
+			OutputPerMTok:        15.0,
+			CacheCreationPerMTok: 3.75,
+			CacheReadPerMTok:     0.30,
+		},
+		{
+			ModelPattern:         "claude-opus-4-20250514",
+			InputPerMTok:         15.0,
+			OutputPerMTok:        75.0,
+			CacheCreationPerMTok: 18.75,
+			CacheReadPerMTok:     1.50,
+		},
+	}); err != nil {
+		log.Fatalf("seeding model pricing: %v", err)
+	}
 
 	// Use a recent base date so fixture data stays within the
 	// default 1-year analytics window.
@@ -123,12 +144,26 @@ func createSessionFixture(
 		return nil
 	}
 
+	model := "claude-sonnet-4-20250514"
+	if index%3 == 1 {
+		model = "claude-opus-4-20250514"
+	}
+	// Subagent and fork sessions must not appear in /usage
+	// aggregation. Skip seeding token_usage on their messages so
+	// the usage query's eligibility predicates (which match empty
+	// model as the disqualifier) filter them out.
+	if spec.relationshipType != "" {
+		model = ""
+	}
+
 	var msgs []db.Message
 	if spec.suffix == "mixed-content-7" {
-		msgs = generateMixedContentMessages(sessionID, startedAt)
+		msgs = generateMixedContentMessages(
+			sessionID, startedAt, model,
+		)
 	} else {
 		msgs = generateMessages(
-			sessionID, spec.msgCount, startedAt,
+			sessionID, spec.msgCount, startedAt, model,
 		)
 	}
 	if err := database.InsertMessages(msgs); err != nil {
@@ -138,7 +173,8 @@ func createSessionFixture(
 }
 
 func generateMessages(
-	sessionID string, count int, start time.Time,
+	sessionID string, count int,
+	start time.Time, model string,
 ) []db.Message {
 	msgs := make([]db.Message, 0, count)
 	for i := range count {
@@ -150,7 +186,7 @@ func generateMessages(
 		ts := start.Add(time.Duration(i) * time.Minute)
 		content := generateContent(role, i, count)
 
-		msgs = append(msgs, db.Message{
+		msg := db.Message{
 			SessionID:     sessionID,
 			Ordinal:       i,
 			Role:          role,
@@ -159,13 +195,33 @@ func generateMessages(
 			HasThinking:   role == "assistant" && i%5 == 0,
 			HasToolUse:    role == "assistant" && i%3 == 0,
 			ContentLength: len(content),
-		})
+		}
+
+		if role == "assistant" && model != "" {
+			msg.Model = model
+			inputTok := 500 + (i*137)%2000
+			outputTok := 200 + (i*89)%800
+			cacheCr := 50 + (i*31)%200
+			cacheRd := 1000 + (i*53)%4000
+			msg.TokenUsage = json.RawMessage(
+				fmt.Sprintf(
+					`{"input_tokens":%d,`+
+						`"output_tokens":%d,`+
+						`"cache_creation_input_tokens":%d,`+
+						`"cache_read_input_tokens":%d}`,
+					inputTok, outputTok,
+					cacheCr, cacheRd,
+				),
+			)
+		}
+
+		msgs = append(msgs, msg)
 	}
 	return msgs
 }
 
 func generateMixedContentMessages(
-	sessionID string, start time.Time,
+	sessionID string, start time.Time, model string,
 ) []db.Message {
 	type spec struct {
 		role        string
@@ -215,7 +271,7 @@ func generateMixedContentMessages(
 	msgs := make([]db.Message, 0, len(specs))
 	for i, s := range specs {
 		ts := start.Add(time.Duration(i) * time.Minute)
-		msgs = append(msgs, db.Message{
+		msg := db.Message{
 			SessionID:     sessionID,
 			Ordinal:       i,
 			Role:          s.role,
@@ -224,7 +280,25 @@ func generateMixedContentMessages(
 			HasThinking:   s.hasThinking,
 			HasToolUse:    s.hasToolUse,
 			ContentLength: len(s.content),
-		})
+		}
+		if s.role == "assistant" && model != "" {
+			msg.Model = model
+			inputTok := 400 + (i*113)%1500
+			outputTok := 150 + (i*67)%600
+			cacheCr := 30 + (i*23)%150
+			cacheRd := 800 + (i*41)%3000
+			msg.TokenUsage = json.RawMessage(
+				fmt.Sprintf(
+					`{"input_tokens":%d,`+
+						`"output_tokens":%d,`+
+						`"cache_creation_input_tokens":%d,`+
+						`"cache_read_input_tokens":%d}`,
+					inputTok, outputTok,
+					cacheCr, cacheRd,
+				),
+			)
+		}
+		msgs = append(msgs, msg)
 	}
 	return msgs
 }

--- a/frontend/e2e/usage.spec.ts
+++ b/frontend/e2e/usage.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Usage page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/usage");
+    // Wait for the page shell to render.
+    await expect(
+      page.locator(".usage-page"),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows toolbar and summary cards with data", async ({
+    page,
+  }) => {
+    await expect(
+      page.locator(".page-title"),
+    ).toContainText("Usage");
+
+    // Summary cards should appear with at least one value.
+    await expect(
+      page.locator(".summary-cards"),
+    ).toBeVisible();
+    await expect(
+      page.locator(".card-value").first(),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows cost time series chart", async ({ page }) => {
+    // Wait for summary data to load.
+    await expect(
+      page.locator(".summary-cards .card-value").first(),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator(".chart-container"),
+    ).toBeVisible();
+    // SVG chart should render.
+    await expect(
+      page.locator(".chart-container svg"),
+    ).toBeVisible();
+  });
+
+  test("shows attribution panel with treemap", async ({
+    page,
+  }) => {
+    await expect(
+      page.locator(".summary-cards .card-value").first(),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator(".attribution-panel"),
+    ).toBeVisible();
+    // Treemap SVG should be rendered.
+    await expect(
+      page.locator(".treemap-container svg"),
+    ).toBeVisible();
+  });
+
+  test("filter dropdown opens and shows items", async ({
+    page,
+  }) => {
+    // Wait for data so filter items are populated.
+    await expect(
+      page.locator(".summary-cards .card-value").first(),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click the first filter dropdown (Project).
+    const trigger = page
+      .locator(".filter-dropdown .filter-trigger")
+      .first();
+    await trigger.click();
+
+    // Dropdown panel should appear with rows.
+    await expect(
+      page.locator(".dropdown-panel").first(),
+    ).toBeVisible();
+    await expect(
+      page.locator(".dropdown-row").first(),
+    ).toBeVisible();
+  });
+
+  test("excluding a project updates total cost", async ({
+    page,
+  }) => {
+    // Wait for data to load.
+    await expect(
+      page.locator(".summary-cards .card-value").first(),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Grab the initial total cost text.
+    const totalCostBefore = await page
+      .locator(".card.featured .card-value")
+      .textContent();
+
+    // Open the project filter and exclude the first item.
+    const trigger = page
+      .locator(".filter-dropdown .filter-trigger")
+      .first();
+    await trigger.click();
+    await page.locator(".dropdown-row").first().click();
+
+    // Close dropdown by clicking the page title.
+    await page.locator(".page-title").click();
+
+    // Total cost should change after refetch.
+    await expect(async () => {
+      const after = await page
+        .locator(".card.featured .card-value")
+        .textContent();
+      expect(after).not.toBe(totalCostBefore);
+    }).toPass({ timeout: 5_000 });
+  });
+
+  test("select all / deselect all buttons work", async ({
+    page,
+  }) => {
+    // Wait for data so items populate.
+    await expect(
+      page.locator(".summary-cards .card-value").first(),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Open the project filter.
+    const trigger = page
+      .locator(".filter-dropdown .filter-trigger")
+      .first();
+    await trigger.click();
+
+    // Click "Deselect all".
+    await page
+      .locator(".bulk-btn")
+      .filter({ hasText: "Deselect all" })
+      .first()
+      .click();
+
+    // Trigger label should show "None".
+    await expect(trigger).toContainText("None");
+
+    // Click "Select all".
+    await page
+      .locator(".bulk-btn")
+      .filter({ hasText: "Select all" })
+      .first()
+      .click();
+
+    // Trigger label should show "All".
+    await expect(trigger).toContainText("All");
+  });
+
+  test("top nav shows Usage button as active", async ({
+    page,
+  }) => {
+    const usageBtn = page.locator(
+      '.nav-btn[aria-label="Usage"]',
+    );
+    await expect(usageBtn).toBeVisible();
+    await expect(usageBtn).toHaveClass(/active/);
+  });
+
+  test("URL updates when filter changes", async ({ page }) => {
+    // Wait for data.
+    await expect(
+      page.locator(".summary-cards .card-value").first(),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Exclude a project.
+    const trigger = page
+      .locator(".filter-dropdown .filter-trigger")
+      .first();
+    await trigger.click();
+    await page.locator(".dropdown-row").first().click();
+    await page.locator(".page-title").click();
+
+    // URL should contain the exclude_project param.
+    await expect(page).toHaveURL(/exclude_project=/);
+  });
+});

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -16,6 +16,7 @@
   import UpdateModal from "./lib/components/modals/UpdateModal.svelte";
   import ConfirmDeleteModal from "./lib/components/modals/ConfirmDeleteModal.svelte";
   import AnalyticsPage from "./lib/components/analytics/AnalyticsPage.svelte";
+  import UsagePage from "./lib/components/usage/UsagePage.svelte";
   import InsightsPage from "./lib/components/insights/InsightsPage.svelte";
   import PinnedPage from "./lib/components/pinned/PinnedPage.svelte";
   import TrashPage from "./lib/components/trash/TrashPage.svelte";
@@ -369,7 +370,11 @@
 
 <AppHeader />
 
-{#if router.route === "insights"}
+{#if router.route === "usage"}
+  <div class="page-scroll">
+    <UsagePage />
+  </div>
+{:else if router.route === "insights"}
   <div class="page-scroll">
     <InsightsPage />
   </div>

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -32,6 +32,10 @@ import type {
   GenerateInsightRequest,
   PinsResponse,
   TrashResponse,
+  UsageSummaryResponse,
+  TopUsageSessionsResponse,
+  UsageParams,
+  UsageTopSessionsParams,
 } from "./types.js";
 import type { SessionActivityResponse } from "./types/session-activity.js";
 
@@ -1080,4 +1084,18 @@ export async function unpinMessage(
     const body = await res.text();
     throw new ApiError(res.status, apiErrorMessage(res.status, body));
   }
+}
+
+/* Usage */
+
+export function getUsageSummary(
+  params: UsageParams,
+): Promise<UsageSummaryResponse> {
+  return fetchJSON(`/usage/summary${buildQuery({ ...params })}`);
+}
+
+export function getUsageTopSessions(
+  params: UsageTopSessionsParams,
+): Promise<TopUsageSessionsResponse> {
+  return fetchJSON(`/usage/top-sessions${buildQuery({ ...params })}`);
 }

--- a/frontend/src/lib/api/types/index.ts
+++ b/frontend/src/lib/api/types/index.ts
@@ -4,3 +4,4 @@ export type * from "./analytics.js";
 export type * from "./github.js";
 export type * from "./insights.js";
 export type * from "./session-activity.js";
+export type * from "./usage.js";

--- a/frontend/src/lib/api/types/usage.ts
+++ b/frontend/src/lib/api/types/usage.ts
@@ -1,0 +1,140 @@
+/** Usage types — match Go structs in internal/server/usage.go
+ *  and internal/db/usage.go */
+
+export interface UsageTotals {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  totalCost: number;
+}
+
+export interface ModelBreakdown {
+  modelName: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}
+
+export interface ProjectBreakdown {
+  project: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}
+
+export interface AgentBreakdown {
+  agent: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}
+
+export interface DailyUsageEntry {
+  date: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  totalCost: number;
+  modelsUsed: string[];
+  modelBreakdowns?: ModelBreakdown[];
+  projectBreakdowns?: ProjectBreakdown[];
+  agentBreakdowns?: AgentBreakdown[];
+}
+
+export interface ProjectTotal {
+  project: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}
+
+export interface ModelTotal {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}
+
+export interface AgentTotal {
+  agent: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}
+
+export interface CacheStats {
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  uncachedInputTokens: number;
+  outputTokens: number;
+  hitRate: number;
+  savingsVsUncached: number;
+}
+
+export interface UsageSessionCounts {
+  total: number;
+  byProject: Record<string, number>;
+  byAgent: Record<string, number>;
+}
+
+export interface UsageComparison {
+  priorFrom: string;
+  priorTo: string;
+  priorTotalCost: number;
+  deltaPct: number;
+}
+
+export interface UsageSummaryResponse {
+  from: string;
+  to: string;
+  totals: UsageTotals;
+  daily: DailyUsageEntry[];
+  projectTotals: ProjectTotal[];
+  modelTotals: ModelTotal[];
+  agentTotals: AgentTotal[];
+  sessionCounts: UsageSessionCounts;
+  cacheStats: CacheStats;
+  comparison?: UsageComparison;
+}
+
+export interface TopSessionEntry {
+  sessionId: string;
+  displayName: string;
+  agent: string;
+  project: string;
+  startedAt: string;
+  totalTokens: number;
+  cost: number;
+}
+
+export type TopUsageSessionsResponse = TopSessionEntry[];
+
+export interface UsageParams {
+  from?: string;
+  to?: string;
+  project?: string;
+  agent?: string;
+  model?: string;
+  exclude_project?: string;
+  exclude_agent?: string;
+  exclude_model?: string;
+  timezone?: string;
+}
+
+export interface UsageTopSessionsParams extends UsageParams {
+  limit?: number;
+}

--- a/frontend/src/lib/components/analytics/SummaryCards.svelte
+++ b/frontend/src/lib/components/analytics/SummaryCards.svelte
@@ -5,12 +5,6 @@
     return n.toLocaleString();
   }
 
-  function formatOptionalNum(
-    n: number | null | undefined,
-  ): string {
-    return typeof n === "number" ? formatNum(n) : "—";
-  }
-
   function pct(n: number): string {
     return `${(n * 100).toFixed(1)}%`;
   }
@@ -31,20 +25,6 @@
       label: "Messages",
       value: () =>
         formatNum(analytics.summary?.total_messages ?? 0),
-    },
-    {
-      label: "Output Tokens",
-      value: () =>
-        formatOptionalNum(
-          analytics.summary?.total_output_tokens,
-        ),
-    },
-    {
-      label: "Reporting Sessions",
-      value: () =>
-        formatOptionalNum(
-          analytics.summary?.token_reporting_sessions,
-        ),
     },
     {
       label: "Projects",

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -18,6 +18,7 @@
   let showImportModal = $state(false);
   let showBlockFilter = $state(false);
   let showOverflow = $state(false);
+  let moreOpen = $state(false);
   let filterBtnRef: HTMLButtonElement | undefined =
     $state(undefined);
   let filterDropRef: HTMLDivElement | undefined =
@@ -25,6 +26,10 @@
   let overflowBtnRef: HTMLButtonElement | undefined =
     $state(undefined);
   let overflowDropRef: HTMLDivElement | undefined =
+    $state(undefined);
+  let moreBtnRef: HTMLButtonElement | undefined =
+    $state(undefined);
+  let moreDropRef: HTMLDivElement | undefined =
     $state(undefined);
 
   const BLOCK_LABELS: Record<BlockType, string> = {
@@ -98,6 +103,33 @@
         true,
       );
   });
+
+  // Close More dropdown on outside click or Escape
+  $effect(() => {
+    if (!moreOpen) return;
+    function onClickOutside(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        moreBtnRef?.contains(target) ||
+        moreDropRef?.contains(target)
+      )
+        return;
+      moreOpen = false;
+    }
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") moreOpen = false;
+    }
+    document.addEventListener("click", onClickOutside, true);
+    document.addEventListener("keydown", onKeydown);
+    return () => {
+      document.removeEventListener(
+        "click",
+        onClickOutside,
+        true,
+      );
+      document.removeEventListener("keydown", onKeydown);
+    };
+  });
 </script>
 
 <header class="header">
@@ -155,44 +187,51 @@
 
     <button
       class="nav-btn"
-      class:active={router.route === "pinned"}
-      onclick={() => router.navigate("pinned")}
-      title="Pinned Messages"
-      aria-label="Pinned"
+      class:active={router.route === "usage"}
+      onclick={() => router.navigate("usage")}
+      title="Token Usage"
+      aria-label="Usage"
     >
       <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-        <path d="M4.146.146A.5.5 0 014.5 0h7a.5.5 0 01.5.5c0 .68-.342 1.174-.646 1.479-.126.125-.25.224-.354.298v4.431l.078.048c.203.127.476.314.751.555C12.36 7.775 13 8.527 13 9.5a.5.5 0 01-.5.5H8.5v5.5a.5.5 0 01-1 0V10H3.5a.5.5 0 01-.5-.5c0-.973.64-1.725 1.17-2.189A6 6 0 015 6.708V2.277a3 3 0 01-.354-.298C4.342 1.674 4 1.179 4 .5a.5.5 0 01.146-.354z"/>
+        <path d="M1 2.5A1.5 1.5 0 012.5 1h3A1.5 1.5 0 017 2.5v3A1.5 1.5 0 015.5 7h-3A1.5 1.5 0 011 5.5v-3zM2.5 2a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5h-3zm6.5.5A1.5 1.5 0 0110.5 1h3A1.5 1.5 0 0115 2.5v3A1.5 1.5 0 0113.5 7h-3A1.5 1.5 0 019 5.5v-3zm1.5-.5a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5h-3zM1 10.5A1.5 1.5 0 012.5 9h3A1.5 1.5 0 017 10.5v3A1.5 1.5 0 015.5 15h-3A1.5 1.5 0 011 13.5v-3zm1.5-.5a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5h-3zm6.5.5A1.5 1.5 0 0110.5 9h3a1.5 1.5 0 011.5 1.5v3a1.5 1.5 0 01-1.5 1.5h-3A1.5 1.5 0 019 13.5v-3zm1.5-.5a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5h-3z"/>
       </svg>
-      <span class="nav-label">Pinned</span>
+      <span class="nav-label">Usage</span>
     </button>
 
-    <button
-      class="nav-btn"
-      class:active={router.route === "insights"}
-      onclick={() => router.navigate("insights")}
-      title="Insights"
-      aria-label="Insights"
-    >
-      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-        <path d="M14.5 3a.5.5 0 01.5.5v9a.5.5 0 01-.5.5h-13a.5.5 0 01-.5-.5v-9a.5.5 0 01.5-.5h13zm-13-1A1.5 1.5 0 000 3.5v9A1.5 1.5 0 001.5 14h13a1.5 1.5 0 001.5-1.5v-9A1.5 1.5 0 0014.5 2h-13z"/>
-        <path d="M3 5.5a.5.5 0 01.5-.5h9a.5.5 0 010 1h-9a.5.5 0 01-.5-.5zM3 8a.5.5 0 01.5-.5h9a.5.5 0 010 1h-9A.5.5 0 013 8zm0 2.5a.5.5 0 01.5-.5h6a.5.5 0 010 1h-6a.5.5 0 01-.5-.5z"/>
-      </svg>
-      <span class="nav-label">Insights</span>
-    </button>
-
-    <button
-      class="nav-btn"
-      class:active={router.route === "trash"}
-      onclick={() => router.navigate("trash")}
-      title="Trash"
-      aria-label="Trash"
-    >
-      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-        <path d="M5.5 5.5A.5.5 0 016 6v6a.5.5 0 01-1 0V6a.5.5 0 01.5-.5zm2.5 0a.5.5 0 01.5.5v6a.5.5 0 01-1 0V6a.5.5 0 01.5-.5zm3 .5a.5.5 0 00-1 0v6a.5.5 0 001 0V6z"/>
-        <path fill-rule="evenodd" d="M14.5 3a1 1 0 01-1 1H13v9a2 2 0 01-2 2H5a2 2 0 01-2-2V4h-.5a1 1 0 01-1-1V2a1 1 0 011-1H5.5l1-1h3l1 1h2.5a1 1 0 011 1v1zM4.118 4L4 4.059V13a1 1 0 001 1h6a1 1 0 001-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
-      </svg>
-      <span class="nav-label">Trash</span>
-    </button>
+    <div class="more-wrap">
+      <button
+        class="nav-btn"
+        class:active={router.route === "pinned" || router.route === "insights" || router.route === "trash" || moreOpen}
+        bind:this={moreBtnRef}
+        onclick={() => { moreOpen = !moreOpen; }}
+        aria-label="More navigation"
+        aria-expanded={moreOpen}
+      >
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M3 9.5a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm5 0a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm5 0a1.5 1.5 0 110-3 1.5 1.5 0 010 3z"/>
+        </svg>
+        <span class="nav-label">More</span>
+      </button>
+      {#if moreOpen}
+        <div class="more-dropdown" role="menu" bind:this={moreDropRef}>
+          <button class="more-item" role="menuitem"
+            class:active={router.route === "pinned"}
+            onclick={() => { router.navigate("pinned"); moreOpen = false; }}>
+            Pinned
+          </button>
+          <button class="more-item" role="menuitem"
+            class:active={router.route === "insights"}
+            onclick={() => { router.navigate("insights"); moreOpen = false; }}>
+            Insights
+          </button>
+          <button class="more-item" role="menuitem"
+            class:active={router.route === "trash"}
+            onclick={() => { router.navigate("trash"); moreOpen = false; }}>
+            Trash
+          </button>
+        </div>
+      {/if}
+    </div>
   </div>
 
   <button
@@ -560,6 +599,49 @@
       var(--accent-blue) 8%,
       transparent
     );
+  }
+
+  .more-wrap {
+    position: relative;
+  }
+
+  .more-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    min-width: 140px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    display: flex;
+    flex-direction: column;
+    padding: 4px;
+    z-index: 20;
+    animation: dropdown-in 0.12s ease-out;
+  }
+
+  .more-item {
+    padding: 6px 10px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    border-radius: var(--radius-sm);
+    text-align: left;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transition: background 0.08s, color 0.08s;
+  }
+
+  .more-item:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .more-item.active {
+    color: var(--text-primary);
+    font-weight: 500;
+    background: var(--bg-inset);
   }
 
   .search-hint {
@@ -939,7 +1021,8 @@
 
   /* 767px: Hide nav buttons and typeahead */
   @media (max-width: 767px) {
-    .header-left .nav-btn {
+    .header-left .nav-btn,
+    .header-left .more-wrap {
       display: none;
     }
 

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
@@ -303,6 +303,16 @@
       </button>
       <button
         class="mobile-nav-btn"
+        class:active={router.route === "usage"}
+        onclick={() => mobileNav("usage")}
+      >
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M1 2.5A1.5 1.5 0 012.5 1h3A1.5 1.5 0 017 2.5v3A1.5 1.5 0 015.5 7h-3A1.5 1.5 0 011 5.5v-3zM2.5 2a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5h-3zm6.5.5A1.5 1.5 0 0110.5 1h3A1.5 1.5 0 0115 2.5v3A1.5 1.5 0 0113.5 7h-3A1.5 1.5 0 019 5.5v-3zm1.5-.5a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5h-3zM1 10.5A1.5 1.5 0 012.5 9h3A1.5 1.5 0 017 10.5v3A1.5 1.5 0 015.5 15h-3A1.5 1.5 0 011 13.5v-3zm1.5-.5a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5h-3zm6.5.5A1.5 1.5 0 0110.5 9h3a1.5 1.5 0 011.5 1.5v3a1.5 1.5 0 01-1.5 1.5h-3A1.5 1.5 0 019 13.5v-3zm1.5-.5a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5h-3z"/>
+        </svg>
+        Usage
+      </button>
+      <button
+        class="mobile-nav-btn"
         class:active={router.route === "pinned"}
         onclick={() => mobileNav("pinned")}
       >

--- a/frontend/src/lib/components/usage/AttributionPanel.svelte
+++ b/frontend/src/lib/components/usage/AttributionPanel.svelte
@@ -151,65 +151,70 @@
     <div class="loading">Loading...</div>
   {:else if rows.length === 0}
     <div class="empty">No data for this period</div>
-  {:else if view === "treemap"}
-    <div class="treemap-layout">
-      <div class="treemap-main">
-        <Treemap
-          items={treemapItems}
-          height={260}
-          onSelect={handleSelect}
-        />
+  {:else}
+    <div class="hint">Click to hide from chart</div>
+    {#if view === "treemap"}
+      <div class="treemap-layout">
+        <div class="treemap-main">
+          <Treemap
+            items={treemapItems}
+            height={260}
+            onSelect={handleSelect}
+          />
+        </div>
+        <div class="side-rail">
+          {#each rows as row, i (row.id)}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="rail-row"
+              title="Click to hide {row.label}"
+              onclick={() => handleSelect(row.id)}
+            >
+              <span class="rail-rank">{i + 1}</span>
+              <span
+                class="rail-dot"
+                style="background: {row.color}"
+              ></span>
+              <span class="rail-label">{row.label}</span>
+              <span class="rail-cost">{fmtCost(row.cost)}</span>
+            </div>
+          {/each}
+        </div>
       </div>
-      <div class="side-rail">
+    {:else}
+      <div class="list-view">
         {#each rows as row, i (row.id)}
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
-            class="rail-row"
+            class="list-row"
+            title="Click to hide {row.label}"
             onclick={() => handleSelect(row.id)}
           >
-            <span class="rail-rank">{i + 1}</span>
+            <span class="list-rank">{i + 1}</span>
             <span
-              class="rail-dot"
+              class="list-dot"
               style="background: {row.color}"
             ></span>
-            <span class="rail-label">{row.label}</span>
-            <span class="rail-cost">{fmtCost(row.cost)}</span>
+            <div class="list-info">
+              <span class="list-label">{row.label}</span>
+              <div class="list-bar-track">
+                <div
+                  class="list-bar-fill"
+                  style="width: {Math.max(row.pct * 100, 1)}%;
+                         background: {row.color};"
+                ></div>
+              </div>
+            </div>
+            <span class="list-pct">
+              {(row.pct * 100).toFixed(1)}%
+            </span>
+            <span class="list-cost">{fmtCost(row.cost)}</span>
           </div>
         {/each}
       </div>
-    </div>
-  {:else}
-    <div class="list-view">
-      {#each rows as row, i (row.id)}
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-          class="list-row"
-          onclick={() => handleSelect(row.id)}
-        >
-          <span class="list-rank">{i + 1}</span>
-          <span
-            class="list-dot"
-            style="background: {row.color}"
-          ></span>
-          <div class="list-info">
-            <span class="list-label">{row.label}</span>
-            <div class="list-bar-track">
-              <div
-                class="list-bar-fill"
-                style="width: {Math.max(row.pct * 100, 1)}%;
-                       background: {row.color};"
-              ></div>
-            </div>
-          </div>
-          <span class="list-pct">
-            {(row.pct * 100).toFixed(1)}%
-          </span>
-          <span class="list-cost">{fmtCost(row.cost)}</span>
-        </div>
-      {/each}
-    </div>
+    {/if}
   {/if}
 </div>
 
@@ -423,6 +428,13 @@
     font-size: 12px;
     padding: 24px;
     text-align: center;
+  }
+
+  .hint {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+    font-style: italic;
   }
 
   @media (max-width: 600px) {

--- a/frontend/src/lib/components/usage/AttributionPanel.svelte
+++ b/frontend/src/lib/components/usage/AttributionPanel.svelte
@@ -1,0 +1,433 @@
+<script lang="ts">
+  import {
+    usage,
+    type GroupBy,
+    type AttributionView,
+  } from "../../stores/usage.svelte.js";
+  import { projectColor } from "../../utils/projectColor.js";
+  import Treemap from "./Treemap.svelte";
+
+  function fmtCost(v: number): string {
+    if (v >= 100) return `$${v.toFixed(0)}`;
+    return `$${v.toFixed(2)}`;
+  }
+
+  function fmtPct(v: number, total: number): string {
+    if (total <= 0) return "";
+    return `${((v / total) * 100).toFixed(1)}%`;
+  }
+
+  const groupBy = $derived(usage.toggles.attribution.groupBy);
+  const view = $derived(usage.toggles.attribution.view);
+
+  interface Row {
+    id: string;
+    label: string;
+    cost: number;
+    color: string;
+    pct: number;
+  }
+
+  const rows = $derived.by((): Row[] => {
+    const s = usage.summary;
+    if (!s) return [];
+
+    let items: Array<{
+      id: string;
+      label: string;
+      cost: number;
+    }> = [];
+
+    if (groupBy === "project") {
+      items = s.projectTotals.map((p) => ({
+        id: p.project,
+        label: p.project,
+        cost: p.cost,
+      }));
+    } else if (groupBy === "model") {
+      items = s.modelTotals.map((m) => ({
+        id: m.model,
+        label: m.model,
+        cost: m.cost,
+      }));
+    } else {
+      items = s.agentTotals.map((a) => ({
+        id: a.agent,
+        label: a.agent,
+        cost: a.cost,
+      }));
+    }
+
+    items.sort((a, b) => b.cost - a.cost);
+    const total = items.reduce((s, d) => s + d.cost, 0);
+
+    return items.map((d) => ({
+      id: d.id,
+      label: d.label,
+      cost: d.cost,
+      color: projectColor(d.id),
+      pct: total > 0 ? d.cost / total : 0,
+    }));
+  });
+
+  const treemapItems = $derived(
+    rows.map((r) => ({
+      id: r.id,
+      label: r.label,
+      value: r.cost,
+      color: r.color,
+      meta: fmtPct(r.cost, rows.reduce(
+        (s, d) => s + d.cost, 0,
+      )),
+    })),
+  );
+
+  function handleSelect(id: string) {
+    if (groupBy === "project") {
+      usage.toggleProject(id);
+    } else if (groupBy === "agent") {
+      usage.toggleAgent(id);
+    } else {
+      usage.toggleModel(id);
+    }
+  }
+
+  function handleGroupByChange(g: GroupBy) {
+    usage.setAttributionGroupBy(g);
+  }
+
+  function handleViewChange(v: AttributionView) {
+    usage.setAttributionView(v);
+  }
+</script>
+
+<div class="attribution-panel">
+  <div class="panel-header">
+    <h3 class="chart-title">Cost Attribution</h3>
+    <div class="toggles">
+      <div class="segment-toggle">
+        <button
+          class="toggle-btn"
+          class:active={groupBy === "project"}
+          onclick={() => handleGroupByChange("project")}
+        >
+          Project
+        </button>
+        <button
+          class="toggle-btn"
+          class:active={groupBy === "model"}
+          onclick={() => handleGroupByChange("model")}
+        >
+          Model
+        </button>
+        <button
+          class="toggle-btn"
+          class:active={groupBy === "agent"}
+          onclick={() => handleGroupByChange("agent")}
+        >
+          Agent
+        </button>
+      </div>
+      <div class="segment-toggle">
+        <button
+          class="toggle-btn"
+          class:active={view === "treemap"}
+          onclick={() => handleViewChange("treemap")}
+        >
+          Treemap
+        </button>
+        <button
+          class="toggle-btn"
+          class:active={view === "list"}
+          onclick={() => handleViewChange("list")}
+        >
+          List
+        </button>
+      </div>
+    </div>
+  </div>
+
+  {#if usage.loading.summary}
+    <div class="loading">Loading...</div>
+  {:else if rows.length === 0}
+    <div class="empty">No data for this period</div>
+  {:else if view === "treemap"}
+    <div class="treemap-layout">
+      <div class="treemap-main">
+        <Treemap
+          items={treemapItems}
+          height={260}
+          onSelect={handleSelect}
+        />
+      </div>
+      <div class="side-rail">
+        {#each rows as row, i (row.id)}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="rail-row"
+            onclick={() => handleSelect(row.id)}
+          >
+            <span class="rail-rank">{i + 1}</span>
+            <span
+              class="rail-dot"
+              style="background: {row.color}"
+            ></span>
+            <span class="rail-label">{row.label}</span>
+            <span class="rail-cost">{fmtCost(row.cost)}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {:else}
+    <div class="list-view">
+      {#each rows as row, i (row.id)}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="list-row"
+          onclick={() => handleSelect(row.id)}
+        >
+          <span class="list-rank">{i + 1}</span>
+          <span
+            class="list-dot"
+            style="background: {row.color}"
+          ></span>
+          <div class="list-info">
+            <span class="list-label">{row.label}</span>
+            <div class="list-bar-track">
+              <div
+                class="list-bar-fill"
+                style="width: {Math.max(row.pct * 100, 1)}%;
+                       background: {row.color};"
+              ></div>
+            </div>
+          </div>
+          <span class="list-pct">
+            {(row.pct * 100).toFixed(1)}%
+          </span>
+          <span class="list-cost">{fmtCost(row.cost)}</span>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .attribution-panel {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .chart-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .toggles {
+    display: flex;
+    gap: 8px;
+  }
+
+  .segment-toggle {
+    display: flex;
+    gap: 2px;
+    background: var(--bg-inset);
+    border-radius: var(--radius-sm);
+    padding: 1px;
+  }
+
+  .toggle-btn {
+    padding: 2px 8px;
+    font-size: 10px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s;
+  }
+
+  .toggle-btn.active {
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .toggle-btn:hover:not(.active) {
+    color: var(--text-secondary);
+  }
+
+  /* Treemap layout: main + side rail */
+  .treemap-layout {
+    display: grid;
+    grid-template-columns: 2.4fr 1fr;
+    gap: 12px;
+    min-height: 260px;
+  }
+
+  .treemap-main {
+    overflow: hidden;
+    border-radius: var(--radius-md);
+  }
+
+  .side-rail {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow-y: auto;
+    max-height: 280px;
+  }
+
+  .rail-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 4px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .rail-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .rail-rank {
+    width: 14px;
+    text-align: right;
+    font-size: 9px;
+    font-weight: 600;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .rail-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .rail-label {
+    flex: 1;
+    font-size: 10px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .rail-cost {
+    font-size: 10px;
+    font-weight: 500;
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  /* List view */
+  .list-view {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .list-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .list-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .list-rank {
+    width: 18px;
+    text-align: right;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .list-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .list-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .list-label {
+    font-size: 11px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .list-bar-track {
+    height: 4px;
+    background: var(--bg-inset);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .list-bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.3s ease;
+  }
+
+  .list-pct {
+    flex-shrink: 0;
+    min-width: 36px;
+    text-align: right;
+    font-size: 10px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+  }
+
+  .list-cost {
+    flex-shrink: 0;
+    min-width: 48px;
+    text-align: right;
+    font-size: 11px;
+    font-weight: 500;
+    font-family: var(--font-mono);
+    color: var(--accent-blue);
+  }
+
+  .loading, .empty {
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 24px;
+    text-align: center;
+  }
+
+  @media (max-width: 600px) {
+    .treemap-layout {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/usage/CacheEfficiencyPanel.svelte
+++ b/frontend/src/lib/components/usage/CacheEfficiencyPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { usage } from "../../stores/usage.svelte.js";
+  import { savingsState } from "../../utils/usageSavings.js";
 
   function fmtTokens(v: number): string {
     if (v >= 1_000_000_000) {
@@ -68,6 +69,7 @@
   const savings = $derived(
     usage.summary?.cacheStats?.savingsVsUncached ?? 0,
   );
+  const savingsLabel = $derived(savingsState(savings));
 </script>
 
 <div class="cache-panel">
@@ -96,9 +98,13 @@
       {/each}
     </div>
 
-    {#if savings > 0}
-      <div class="savings-callout">
+    {#if savingsLabel === "saved"}
+      <div class="savings-callout saved">
         {fmtCost(savings)} saved vs uncached
+      </div>
+    {:else if savingsLabel === "costlier"}
+      <div class="savings-callout costlier">
+        {fmtCost(Math.abs(savings))} more than uncached
       </div>
     {/if}
   {/if}
@@ -164,12 +170,22 @@
     margin-top: 12px;
     padding: 6px 10px;
     border-radius: var(--radius-sm);
+    font-size: 11px;
+    font-weight: 500;
+  }
+
+  .savings-callout.saved {
     background: color-mix(
       in srgb, var(--accent-green) 10%, transparent
     );
     color: var(--accent-green);
-    font-size: 11px;
-    font-weight: 500;
+  }
+
+  .savings-callout.costlier {
+    background: color-mix(
+      in srgb, var(--accent-amber) 12%, transparent
+    );
+    color: var(--accent-amber);
   }
 
   .loading, .empty {

--- a/frontend/src/lib/components/usage/CacheEfficiencyPanel.svelte
+++ b/frontend/src/lib/components/usage/CacheEfficiencyPanel.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import { usage } from "../../stores/usage.svelte.js";
+
+  function fmtTokens(v: number): string {
+    if (v >= 1_000_000_000) {
+      const g = Math.floor(v / 100_000_000) / 10;
+      return `${g}B`;
+    }
+    if (v >= 1_000_000) {
+      const m = Math.floor(v / 100_000) / 10;
+      return `${m}M`;
+    }
+    if (v >= 1_000) {
+      const k = Math.floor(v / 100) / 10;
+      return `${k}K`;
+    }
+    return String(v);
+  }
+
+  function fmtCost(v: number): string {
+    return `$${v.toFixed(2)}`;
+  }
+
+  interface Bar {
+    label: string;
+    value: number;
+    pct: number;
+    color: string;
+  }
+
+  const bars = $derived.by((): Bar[] => {
+    const cs = usage.summary?.cacheStats;
+    if (!cs) return [];
+    const total =
+      cs.cacheReadTokens +
+      cs.cacheCreationTokens +
+      cs.uncachedInputTokens +
+      cs.outputTokens;
+    if (total === 0) return [];
+    return [
+      {
+        label: "Cache Reads",
+        value: cs.cacheReadTokens,
+        pct: cs.cacheReadTokens / total,
+        color: "var(--accent-green)",
+      },
+      {
+        label: "Cache Writes",
+        value: cs.cacheCreationTokens,
+        pct: cs.cacheCreationTokens / total,
+        color: "var(--accent-teal)",
+      },
+      {
+        label: "Uncached Input",
+        value: cs.uncachedInputTokens,
+        pct: cs.uncachedInputTokens / total,
+        color: "var(--accent-amber)",
+      },
+      {
+        label: "Output",
+        value: cs.outputTokens,
+        pct: cs.outputTokens / total,
+        color: "var(--accent-blue)",
+      },
+    ];
+  });
+
+  const savings = $derived(
+    usage.summary?.cacheStats?.savingsVsUncached ?? 0,
+  );
+</script>
+
+<div class="cache-panel">
+  <h3 class="chart-title">Cache Efficiency</h3>
+
+  {#if usage.loading.summary}
+    <div class="loading">Loading...</div>
+  {:else if bars.length === 0}
+    <div class="empty">No token data</div>
+  {:else}
+    <div class="bar-list">
+      {#each bars as bar}
+        <div class="bar-row">
+          <span class="bar-label">{bar.label}</span>
+          <div class="bar-track">
+            <div
+              class="bar-fill"
+              style="width: {Math.max(bar.pct * 100, 1)}%;
+                     background: {bar.color};"
+            ></div>
+          </div>
+          <span class="bar-value">
+            {fmtTokens(bar.value)}
+          </span>
+        </div>
+      {/each}
+    </div>
+
+    {#if savings > 0}
+      <div class="savings-callout">
+        {fmtCost(savings)} saved vs uncached
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .cache-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .chart-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+  }
+
+  .bar-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .bar-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .bar-label {
+    flex-shrink: 0;
+    width: 100px;
+    font-size: 11px;
+    color: var(--text-secondary);
+  }
+
+  .bar-track {
+    flex: 1;
+    height: 12px;
+    background: var(--bg-inset);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .bar-fill {
+    height: 100%;
+    border-radius: var(--radius-sm);
+    transition: width 0.3s ease;
+  }
+
+  .bar-value {
+    flex-shrink: 0;
+    min-width: 48px;
+    text-align: right;
+    font-size: 10px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+  }
+
+  .savings-callout {
+    margin-top: 12px;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    background: color-mix(
+      in srgb, var(--accent-green) 10%, transparent
+    );
+    color: var(--accent-green);
+    font-size: 11px;
+    font-weight: 500;
+  }
+
+  .loading, .empty {
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 24px;
+    text-align: center;
+  }
+</style>

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -1,0 +1,484 @@
+<script lang="ts">
+  import { usage, type GroupBy } from "../../stores/usage.svelte.js";
+  import { projectColor } from "../../utils/projectColor.js";
+
+  const CHART_H = 180;
+  const X_LABEL_H = 20;
+  const Y_LABEL_W = 40;
+  const MAX_SERIES = 5;
+
+  const OTHER_COLOR = "var(--text-muted)";
+
+  let containerEl: HTMLDivElement | undefined = $state();
+  let containerWidth = $state(600);
+
+  $effect(() => {
+    if (!containerEl) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        containerWidth = Math.floor(entry.contentRect.width);
+      }
+    });
+    ro.observe(containerEl);
+    return () => ro.disconnect();
+  });
+
+  interface Point {
+    date: string;
+    values: Record<string, number>;
+  }
+
+  const groupBy = $derived(usage.toggles.timeSeries.groupBy);
+
+  const seriesData = $derived.by((): {
+    points: Point[];
+    keys: string[];
+    maxY: number;
+  } => {
+    const daily = usage.summary?.daily;
+    if (!daily || daily.length === 0) {
+      return { points: [], keys: [], maxY: 0 };
+    }
+
+    // Sum cost per key across the whole range to find top N.
+    const totals = new Map<string, number>();
+    for (const day of daily) {
+      if (groupBy === "project" && day.projectBreakdowns) {
+        for (const b of day.projectBreakdowns) {
+          totals.set(b.project,
+            (totals.get(b.project) ?? 0) + b.cost);
+        }
+      } else if (groupBy === "model" && day.modelBreakdowns) {
+        for (const b of day.modelBreakdowns) {
+          totals.set(b.modelName,
+            (totals.get(b.modelName) ?? 0) + b.cost);
+        }
+      } else if (groupBy === "agent" && day.agentBreakdowns) {
+        for (const b of day.agentBreakdowns) {
+          totals.set(b.agent,
+            (totals.get(b.agent) ?? 0) + b.cost);
+        }
+      }
+    }
+
+    // If only one key or few keys, no need for "Other".
+    if (totals.size === 0) {
+      const points = daily.map((d) => ({
+        date: d.date,
+        values: { total: d.totalCost },
+      }));
+      let maxY = 0;
+      for (const pt of points) {
+        if (pt.values.total > maxY) maxY = pt.values.total;
+      }
+      return { points, keys: ["total"], maxY: maxY || 1 };
+    }
+
+    // Pick top N by total cost, group the rest as "Other".
+    const ranked = [...totals.entries()]
+      .sort((a, b) => b[1] - a[1]);
+    const topKeys = new Set(
+      ranked.slice(0, MAX_SERIES).map(([k]) => k),
+    );
+    const hasOther = ranked.length > MAX_SERIES;
+
+    const points: Point[] = [];
+    for (const day of daily) {
+      const values: Record<string, number> = {};
+      let items: Array<{ key: string; cost: number }> = [];
+
+      if (groupBy === "project" && day.projectBreakdowns) {
+        items = day.projectBreakdowns.map((b) => ({
+          key: b.project, cost: b.cost,
+        }));
+      } else if (groupBy === "model" && day.modelBreakdowns) {
+        items = day.modelBreakdowns.map((b) => ({
+          key: b.modelName, cost: b.cost,
+        }));
+      } else if (groupBy === "agent" && day.agentBreakdowns) {
+        items = day.agentBreakdowns.map((b) => ({
+          key: b.agent, cost: b.cost,
+        }));
+      }
+
+      for (const { key, cost } of items) {
+        if (topKeys.has(key)) {
+          values[key] = (values[key] ?? 0) + cost;
+        } else {
+          values["__other__"] =
+            (values["__other__"] ?? 0) + cost;
+        }
+      }
+      points.push({ date: day.date, values });
+    }
+
+    // Build ordered key list: top N by cost desc, then
+    // __other__ (displayed as "Other" in legend/labels).
+    const keys = ranked
+      .slice(0, MAX_SERIES)
+      .map(([k]) => k);
+    if (hasOther) keys.push("__other__");
+
+    let maxY = 0;
+    for (const pt of points) {
+      let stack = 0;
+      for (const k of keys) {
+        stack += pt.values[k] ?? 0;
+      }
+      if (stack > maxY) maxY = stack;
+    }
+
+    return { points, keys, maxY: maxY || 1 };
+  });
+
+  const chartWidth = $derived(
+    Math.max(containerWidth - Y_LABEL_W - 8, 100),
+  );
+
+  const BAR_WIDTH = 40;
+
+  function buildPaths(
+    points: Point[],
+    keys: string[],
+    maxY: number,
+    w: number,
+    h: number,
+  ): Array<{ key: string; d: string; color: string }> {
+    if (points.length === 0) return [];
+
+    // Single data point: render stacked vertical bars instead
+    // of degenerate zero-width areas.
+    if (points.length === 1) {
+      const cx = Y_LABEL_W + w / 2;
+      const x0 = cx - BAR_WIDTH / 2;
+      const result: Array<{
+        key: string;
+        d: string;
+        color: string;
+      }> = [];
+      let baseline = 0;
+      for (const key of keys) {
+        const val = points[0]!.values[key] ?? 0;
+        const top = h - ((baseline + val) / maxY) * h;
+        const bot = h - (baseline / maxY) * h;
+        const d =
+          `M${x0},${bot}` +
+          `L${x0},${top}` +
+          `L${x0 + BAR_WIDTH},${top}` +
+          `L${x0 + BAR_WIDTH},${bot}Z`;
+        const color = key === "__other__"
+          ? "var(--text-muted)"
+          : projectColor(key);
+        result.push({ key, d, color });
+        baseline += val;
+      }
+      return result;
+    }
+
+    const xStep = w / Math.max(points.length - 1, 1);
+    const result: Array<{
+      key: string;
+      d: string;
+      color: string;
+    }> = [];
+
+    const baselines = new Float64Array(points.length);
+
+    for (const key of keys) {
+      let d = "";
+
+      for (let i = 0; i < points.length; i++) {
+        const x = Y_LABEL_W + i * xStep;
+        const val = points[i]!.values[key] ?? 0;
+        const top = h - ((baselines[i]! + val) / maxY) * h;
+        d += i === 0 ? `M${x},${top}` : `L${x},${top}`;
+      }
+
+      // Close area back along baseline
+      for (let i = points.length - 1; i >= 0; i--) {
+        const x = Y_LABEL_W + i * xStep;
+        const base = h - (baselines[i]! / maxY) * h;
+        d += `L${x},${base}`;
+      }
+      d += "Z";
+
+      const color = key === "__other__"
+        ? "var(--text-muted)"
+        : projectColor(key);
+      result.push({ key, d, color });
+
+      for (let i = 0; i < points.length; i++) {
+        baselines[i] += points[i]!.values[key] ?? 0;
+      }
+    }
+
+    return result;
+  }
+
+  const paths = $derived(
+    buildPaths(
+      seriesData.points,
+      seriesData.keys,
+      seriesData.maxY,
+      chartWidth,
+      CHART_H,
+    ),
+  );
+
+  function dateLabel(date: string): string {
+    const d = new Date(date + "T00:00:00");
+    return d.toLocaleDateString("en", {
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  const xLabels = $derived.by(() => {
+    const pts = seriesData.points;
+    if (pts.length <= 1) {
+      return pts.map((p, i) => ({ x: Y_LABEL_W, label: dateLabel(p.date), idx: i }));
+    }
+    const step = Math.max(
+      Math.floor(pts.length / 6),
+      1,
+    );
+    const xStep =
+      chartWidth / Math.max(pts.length - 1, 1);
+    const labels: Array<{
+      x: number;
+      label: string;
+      idx: number;
+    }> = [];
+    for (let i = 0; i < pts.length; i += step) {
+      labels.push({
+        x: Y_LABEL_W + i * xStep,
+        label: dateLabel(pts[i]!.date),
+        idx: i,
+      });
+    }
+    return labels;
+  });
+
+  function fmtYLabel(v: number): string {
+    if (v >= 100) return `$${v.toFixed(0)}`;
+    if (v >= 1) return `$${v.toFixed(1)}`;
+    return `$${v.toFixed(2)}`;
+  }
+
+  const yTicks = $derived.by(() => {
+    const max = seriesData.maxY;
+    if (max <= 0) return [];
+    const ticks: Array<{ y: number; label: string }> = [];
+    const count = 4;
+    for (let i = 0; i <= count; i++) {
+      const val = (max / count) * i;
+      ticks.push({
+        y: CHART_H - (val / max) * CHART_H,
+        label: fmtYLabel(val),
+      });
+    }
+    return ticks;
+  });
+
+  function handleGroupByChange(g: GroupBy) {
+    usage.setTimeSeriesGroupBy(g);
+  }
+</script>
+
+<div class="chart-container">
+  <div class="chart-header">
+    <h3 class="chart-title">Cost Over Time</h3>
+    <div class="segment-toggle">
+      <button
+        class="toggle-btn"
+        class:active={groupBy === "project"}
+        onclick={() => handleGroupByChange("project")}
+      >
+        Project
+      </button>
+      <button
+        class="toggle-btn"
+        class:active={groupBy === "model"}
+        onclick={() => handleGroupByChange("model")}
+      >
+        Model
+      </button>
+      <button
+        class="toggle-btn"
+        class:active={groupBy === "agent"}
+        onclick={() => handleGroupByChange("agent")}
+      >
+        Agent
+      </button>
+    </div>
+  </div>
+
+  {#if usage.loading.summary}
+    <div class="loading">Loading chart...</div>
+  {:else if seriesData.points.length === 0}
+    <div class="empty">No data for this period</div>
+  {:else}
+    <div class="chart-scroll" bind:this={containerEl}>
+      <svg
+        width="100%"
+        height={CHART_H + X_LABEL_H}
+        viewBox="0 0 {chartWidth + Y_LABEL_W + 8} {CHART_H + X_LABEL_H}"
+        preserveAspectRatio="xMidYMid meet"
+        class="chart-svg"
+      >
+        {#each yTicks as tick}
+          <line
+            x1={Y_LABEL_W}
+            y1={tick.y}
+            x2={chartWidth + Y_LABEL_W}
+            y2={tick.y}
+            class="grid-line"
+          />
+          <text
+            x={Y_LABEL_W - 4}
+            y={tick.y + 3}
+            class="y-label"
+            text-anchor="end"
+          >
+            {tick.label}
+          </text>
+        {/each}
+
+        {#each paths as p (p.key)}
+          <path d={p.d} fill={p.color} opacity="0.7" />
+        {/each}
+
+        {#each xLabels as lbl (lbl.idx)}
+          <text
+            x={lbl.x}
+            y={CHART_H + 14}
+            class="x-label"
+            text-anchor="middle"
+          >
+            {lbl.label}
+          </text>
+        {/each}
+      </svg>
+    </div>
+
+    {#if seriesData.keys.length > 1}
+      <div class="legend">
+        {#each seriesData.keys as key}
+          <span class="legend-item">
+            <span
+              class="legend-dot"
+              style="background: {key === '__other__' ? 'var(--text-muted)' : projectColor(key)}"
+            ></span>
+            {key === "__other__" ? "Other" : key}
+          </span>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .chart-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .chart-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+  }
+
+  .chart-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .segment-toggle {
+    display: flex;
+    gap: 2px;
+    background: var(--bg-inset);
+    border-radius: var(--radius-sm);
+    padding: 1px;
+  }
+
+  .toggle-btn {
+    padding: 2px 8px;
+    font-size: 10px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s;
+  }
+
+  .toggle-btn.active {
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .toggle-btn:hover:not(.active) {
+    color: var(--text-secondary);
+  }
+
+  .chart-scroll {
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .chart-svg {
+    display: block;
+  }
+
+  .grid-line {
+    stroke: var(--border-muted);
+    stroke-width: 1;
+    stroke-dasharray: 2 2;
+  }
+
+  .y-label {
+    font-size: 9px;
+    fill: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .x-label {
+    font-size: 9px;
+    fill: var(--text-muted);
+    font-family: var(--font-sans);
+  }
+
+  .legend {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+    padding-left: 40px;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+
+  .legend-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .loading, .empty {
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 24px;
+    text-align: center;
+  }
+</style>

--- a/frontend/src/lib/components/usage/FilterDropdown.svelte
+++ b/frontend/src/lib/components/usage/FilterDropdown.svelte
@@ -1,0 +1,373 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+
+  interface FilterItem {
+    name: string;
+    count?: number;
+  }
+
+  interface Props {
+    label: string;
+    items: FilterItem[];
+    /** Comma-separated list of EXCLUDED item names. */
+    excludedCsv: string;
+    onToggle: (name: string) => void;
+    onSelectAll?: () => void;
+    onDeselectAll?: () => void;
+    color?: (name: string) => string;
+  }
+
+  let {
+    label,
+    items,
+    excludedCsv,
+    onToggle,
+    onSelectAll,
+    onDeselectAll,
+    color,
+  }: Props = $props();
+
+  let open = $state(false);
+  let search = $state("");
+  let containerEl: HTMLDivElement | undefined = $state();
+
+  const excludedSet = $derived(
+    new Set(excludedCsv ? excludedCsv.split(",") : []),
+  );
+
+  const excludedCount = $derived(excludedSet.size);
+  const visibleCount = $derived(
+    items.length - excludedCount,
+  );
+
+  const buttonLabel = $derived.by(() => {
+    if (excludedCount === 0) return `${label}: All`;
+    if (visibleCount === 1) {
+      const visible = items.find(
+        (i) => !excludedSet.has(i.name),
+      );
+      if (visible) {
+        const maxLen = 20;
+        if (visible.name.length > maxLen) {
+          return `${label}: ${visible.name.slice(0, maxLen)}...`;
+        }
+        return `${label}: ${visible.name}`;
+      }
+    }
+    if (visibleCount === 0) return `${label}: None`;
+    return `${label}: ${excludedCount} hidden`;
+  });
+
+  const showSearch = $derived(items.length > 8);
+
+  const filtered = $derived(
+    search
+      ? items.filter((i) =>
+          i.name.toLowerCase().includes(
+            search.toLowerCase(),
+          ),
+        )
+      : items,
+  );
+
+  function handleClickOutside(e: MouseEvent) {
+    if (
+      containerEl &&
+      !containerEl.contains(e.target as Node)
+    ) {
+      open = false;
+      search = "";
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape" && open) {
+      open = false;
+      search = "";
+    }
+  }
+
+  onMount(() => {
+    document.addEventListener("click", handleClickOutside);
+    document.addEventListener("keydown", handleKeydown);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener(
+      "click",
+      handleClickOutside,
+    );
+    document.removeEventListener("keydown", handleKeydown);
+  });
+</script>
+
+<div class="filter-dropdown" bind:this={containerEl}>
+  <button
+    class="filter-trigger"
+    class:active={excludedCount > 0}
+    onclick={() => {
+      open = !open;
+      if (!open) search = "";
+    }}
+  >
+    <span class="trigger-label">{buttonLabel}</span>
+    <svg
+      class="chevron"
+      class:open
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="currentColor"
+    >
+      <path d="M2.5 3.5L5 6.5L7.5 3.5" />
+    </svg>
+  </button>
+
+  {#if open}
+    <div class="dropdown-panel">
+      {#if showSearch}
+        <input
+          class="dropdown-search"
+          type="text"
+          placeholder="Search..."
+          bind:value={search}
+        />
+      {/if}
+      <div class="bulk-actions">
+        <button
+          class="bulk-btn"
+          onclick={() => onSelectAll?.()}
+        >Select all</button>
+        <button
+          class="bulk-btn"
+          onclick={() => onDeselectAll?.()}
+        >Deselect all</button>
+      </div>
+      <div class="dropdown-list">
+        {#each filtered as item (item.name)}
+          {@const included = !excludedSet.has(item.name)}
+          <button
+            class="dropdown-row"
+            class:selected={included}
+            style:--item-color={color
+              ? color(item.name)
+              : "var(--accent-blue)"}
+            onclick={() => onToggle(item.name)}
+          >
+            <span
+              class="item-check"
+              class:on={included}
+            >
+              {#if included}
+                <svg
+                  width="8"
+                  height="8"
+                  viewBox="0 0 8 8"
+                  fill="currentColor"
+                >
+                  <path
+                    d="M1.5 4L3.2 5.8L6.5 2.2"
+                    fill="none"
+                    stroke="white"
+                    stroke-width="1.2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              {/if}
+            </span>
+            {#if color}
+              <span
+                class="color-dot"
+                style:background={color(item.name)}
+              ></span>
+            {/if}
+            <span class="item-name">{item.name}</span>
+            {#if item.count !== undefined}
+              <span class="item-count">{item.count}</span>
+            {/if}
+          </button>
+        {/each}
+        {#if filtered.length === 0}
+          <div class="dropdown-empty">No matches</div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .filter-dropdown {
+    position: relative;
+  }
+
+  .filter-trigger {
+    height: 26px;
+    padding: 0 8px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-inset);
+    color: var(--text-primary);
+    font-size: 11px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+    max-width: 200px;
+  }
+
+  .filter-trigger:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .filter-trigger.active {
+    border-color: var(--accent-blue);
+    background: color-mix(
+      in srgb,
+      var(--accent-blue) 8%,
+      var(--bg-inset)
+    );
+  }
+
+  .trigger-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .chevron {
+    flex-shrink: 0;
+    transition: transform 0.15s;
+  }
+
+  .chevron.open {
+    transform: rotate(180deg);
+  }
+
+  .dropdown-panel {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 100;
+    min-width: 180px;
+    max-width: 280px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+  }
+
+  .dropdown-search {
+    width: 100%;
+    padding: 6px 8px;
+    border: none;
+    border-bottom: 1px solid var(--border-muted);
+    background: var(--bg-inset);
+    color: var(--text-primary);
+    font-size: 11px;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .dropdown-search::placeholder {
+    color: var(--text-muted);
+  }
+
+  .bulk-actions {
+    display: flex;
+    gap: 4px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border-muted);
+  }
+
+  .bulk-btn {
+    font-size: 10px;
+    color: var(--accent-blue);
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: var(--radius-sm);
+  }
+
+  .bulk-btn:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .dropdown-list {
+    max-height: 240px;
+    overflow-y: auto;
+    padding: 2px 0;
+  }
+
+  .dropdown-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 4px 8px;
+    border: none;
+    background: none;
+    color: var(--text-primary);
+    font-size: 11px;
+    cursor: pointer;
+    text-align: left;
+    flex-shrink: 0;
+  }
+
+  .dropdown-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .dropdown-row.selected {
+    color: var(--item-color, var(--accent-blue));
+    font-weight: 500;
+    background: color-mix(
+      in srgb,
+      var(--item-color, var(--accent-blue)) 8%,
+      transparent
+    );
+  }
+
+  .item-check {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    border: 1px solid var(--border-muted);
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .item-check.on {
+    background: var(--item-color, var(--accent-blue));
+    border-color: var(--item-color, var(--accent-blue));
+  }
+
+  .color-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .item-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .item-count {
+    color: var(--text-muted);
+    font-size: 10px;
+    flex-shrink: 0;
+  }
+
+  .dropdown-empty {
+    padding: 8px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+</style>

--- a/frontend/src/lib/components/usage/TopSessionsTable.svelte
+++ b/frontend/src/lib/components/usage/TopSessionsTable.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+  import { usage } from "../../stores/usage.svelte.js";
+  import { router } from "../../stores/router.svelte.js";
+  import { formatTokenCount } from "../../utils/format.js";
+  import { formatAgentName, truncate } from "../../utils/format.js";
+
+  function fmtCost(v: number): string {
+    return `$${v.toFixed(2)}`;
+  }
+
+  function handleRowClick(sessionId: string) {
+    router.navigateToSession(sessionId);
+  }
+</script>
+
+<div class="top-sessions-container">
+  <h3 class="chart-title">Top Sessions by Cost</h3>
+
+  {#if usage.loading.topSessions}
+    <div class="loading">Loading top sessions...</div>
+  {:else if usage.errors.topSessions}
+    <div class="error">
+      {usage.errors.topSessions}
+      <button
+        class="retry-btn"
+        onclick={() => usage.fetchTopSessions()}
+      >
+        Retry
+      </button>
+    </div>
+  {:else if usage.topSessions && usage.topSessions.length > 0}
+    <div class="session-list">
+      {#each usage.topSessions as row, i (row.sessionId)}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="session-row"
+          onclick={() => handleRowClick(row.sessionId)}
+        >
+          <span class="rank">{i + 1}</span>
+          <div class="session-info">
+            <span class="session-label">
+              <span class="agent-pill">
+                {formatAgentName(row.agent)}
+              </span>
+              {truncate(row.displayName || row.sessionId.slice(0, 12), 40)}
+            </span>
+            <span class="session-project">
+              {row.project}
+            </span>
+          </div>
+          <span class="session-tokens">
+            {formatTokenCount(row.totalTokens)}
+          </span>
+          <span class="session-cost">
+            {fmtCost(row.cost)}
+          </span>
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <div class="empty">No sessions in range</div>
+  {/if}
+</div>
+
+<style>
+  .top-sessions-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .chart-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+  }
+
+  .session-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .session-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .session-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .rank {
+    flex-shrink: 0;
+    width: 18px;
+    text-align: right;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .session-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .session-label {
+    font-size: 11px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .agent-pill {
+    flex-shrink: 0;
+    font-size: 9px;
+    font-weight: 500;
+    padding: 1px 5px;
+    border-radius: 8px;
+    background: var(--bg-inset);
+    color: var(--text-muted);
+  }
+
+  .session-project {
+    font-size: 9px;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .session-tokens {
+    flex-shrink: 0;
+    font-size: 10px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    min-width: 36px;
+    text-align: right;
+  }
+
+  .session-cost {
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 500;
+    font-family: var(--font-mono);
+    color: var(--accent-blue);
+    min-width: 48px;
+    text-align: right;
+  }
+
+  .loading, .empty {
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 24px;
+    text-align: center;
+  }
+
+  .error {
+    color: var(--accent-red);
+    font-size: 12px;
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .retry-btn {
+    padding: 2px 8px;
+    border: 1px solid currentColor;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: inherit;
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/lib/components/usage/Treemap.svelte
+++ b/frontend/src/lib/components/usage/Treemap.svelte
@@ -108,10 +108,12 @@
       class="tile"
       tabindex="0"
       role="button"
+      aria-label="Hide {tile.label} from chart"
       onclick={() => onSelect?.(tile.id)}
       onkeydown={(e) => handleKey(e, tile.id)}
       clip-path="url(#{clipId})"
     >
+      <title>Click to hide {tile.label}</title>
       <rect
         x={tile.x}
         y={tile.y}

--- a/frontend/src/lib/components/usage/Treemap.svelte
+++ b/frontend/src/lib/components/usage/Treemap.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+  import { squarify } from "../../utils/treemap.js";
+
+  interface TreemapItem {
+    id: string;
+    label: string;
+    value: number;
+    color: string;
+    meta?: string;
+  }
+
+  interface Props {
+    items: TreemapItem[];
+    height?: number;
+    onSelect?: (id: string) => void;
+  }
+
+  const { items, height = 260, onSelect }: Props = $props();
+
+  let containerEl: HTMLDivElement | undefined = $state();
+  let width = $state(600);
+
+  $effect(() => {
+    if (!containerEl) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        width = Math.floor(entry.contentRect.width);
+      }
+    });
+    ro.observe(containerEl);
+    return () => ro.disconnect();
+  });
+
+  function formatCost(v: number): string {
+    if (v >= 100) return `$${v.toFixed(0)}`;
+    return `$${v.toFixed(2)}`;
+  }
+
+  interface Tile {
+    id: string;
+    label: string;
+    value: number;
+    color: string;
+    meta?: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+
+  const tiles = $derived.by((): Tile[] => {
+    if (items.length === 0 || width <= 0 || height <= 0) {
+      return [];
+    }
+    const input = items.map((d) => ({
+      id: d.id,
+      value: d.value,
+    }));
+    const layout = squarify(input, width, height);
+    const byId = new Map(items.map((d) => [d.id, d]));
+    return layout.map((t) => {
+      const src = byId.get(t.id)!;
+      return {
+        id: t.id,
+        label: src.label,
+        value: src.value,
+        color: src.color,
+        meta: src.meta,
+        x: t.x,
+        y: t.y,
+        width: t.width,
+        height: t.height,
+      };
+    });
+  });
+
+  function handleKey(e: KeyboardEvent, id: string) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelect?.(id);
+    }
+  }
+</script>
+
+<div class="treemap-container" bind:this={containerEl}>
+<svg
+  width="100%"
+  {height}
+  class="treemap"
+  viewBox="0 0 {width} {height}"
+  preserveAspectRatio="none"
+>
+  {#each tiles as tile, i (tile.id)}
+    {@const large = tile.width > 60 && tile.height > 40}
+    {@const medium = tile.width > 40 && tile.height > 20}
+    {@const clipId = `tile-clip-${i}`}
+    <clipPath id={clipId}>
+      <rect
+        x={tile.x}
+        y={tile.y}
+        width={tile.width}
+        height={tile.height}
+      />
+    </clipPath>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <g
+      class="tile"
+      tabindex="0"
+      role="button"
+      onclick={() => onSelect?.(tile.id)}
+      onkeydown={(e) => handleKey(e, tile.id)}
+      clip-path="url(#{clipId})"
+    >
+      <rect
+        x={tile.x}
+        y={tile.y}
+        width={tile.width}
+        height={tile.height}
+        rx="3"
+        fill={tile.color}
+      />
+      {#if large}
+        <text
+          x={tile.x + 6}
+          y={tile.y + 16}
+          class="tile-label"
+        >
+          {tile.label}
+        </text>
+        <text
+          x={tile.x + 6}
+          y={tile.y + 30}
+          class="tile-value"
+        >
+          {formatCost(tile.value)}
+        </text>
+        {#if tile.meta}
+          <text
+            x={tile.x + 6}
+            y={tile.y + 42}
+            class="tile-meta"
+          >
+            {tile.meta}
+          </text>
+        {/if}
+      {:else if medium}
+        <text
+          x={tile.x + 4}
+          y={tile.y + 14}
+          class="tile-label-sm"
+        >
+          {tile.label}
+        </text>
+      {/if}
+    </g>
+  {/each}
+</svg>
+</div>
+
+<style>
+  .treemap-container {
+    width: 100%;
+    min-height: 0;
+  }
+
+  .treemap {
+    display: block;
+  }
+
+  .tile {
+    cursor: pointer;
+  }
+
+  .tile:hover rect {
+    opacity: 0.92;
+  }
+
+  .tile:focus-visible {
+    outline: none;
+  }
+
+  .tile:focus-visible rect {
+    stroke: white;
+    stroke-width: 2;
+  }
+
+  .tile-label {
+    fill: white;
+    font-size: 11px;
+    font-weight: 600;
+    font-family: var(--font-sans);
+    pointer-events: none;
+  }
+
+  .tile-value {
+    fill: rgba(255, 255, 255, 0.85);
+    font-size: 11px;
+    font-weight: 500;
+    font-family: var(--font-mono);
+    pointer-events: none;
+  }
+
+  .tile-meta {
+    fill: rgba(255, 255, 255, 0.7);
+    font-size: 9px;
+    font-family: var(--font-sans);
+    pointer-events: none;
+  }
+
+  .tile-label-sm {
+    fill: white;
+    font-size: 9px;
+    font-weight: 500;
+    font-family: var(--font-sans);
+    pointer-events: none;
+  }
+</style>

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -1,0 +1,365 @@
+<script lang="ts">
+  import { onMount, onDestroy, untrack } from "svelte";
+  import { usage } from "../../stores/usage.svelte.js";
+  import { sessions } from "../../stores/sessions.svelte.js";
+  import { router } from "../../stores/router.svelte.js";
+  import { agentColor } from "../../utils/agents.js";
+  import UsageSummaryCards from "./UsageSummaryCards.svelte";
+  import CostTimeSeriesChart from "./CostTimeSeriesChart.svelte";
+  import AttributionPanel from "./AttributionPanel.svelte";
+  import TopSessionsTable from "./TopSessionsTable.svelte";
+  import CacheEfficiencyPanel from "./CacheEfficiencyPanel.svelte";
+  import FilterDropdown from "./FilterDropdown.svelte";
+
+  const REFRESH_MS = 5 * 60 * 1000;
+  let refreshTimer: ReturnType<typeof setInterval> | undefined;
+
+  const projectItems = $derived(
+    sessions.projects.map((p) => ({
+      name: p.name,
+      count: p.session_count,
+    })),
+  );
+
+  const agentItems = $derived(
+    sessions.agents.map((a) => ({
+      name: a.name,
+      count: a.session_count,
+    })),
+  );
+
+  // Track every model we've seen in any summary response — never
+  // remove one. Without this the model dropdown would lose excluded
+  // models (since modelTotals only contains non-excluded models) and
+  // the user would have no way to re-include them.
+  let knownModels: string[] = $state([]);
+
+  $effect(() => {
+    const fromSummary = (usage.summary?.modelTotals ?? [])
+      .map((m) => m.model);
+    if (fromSummary.length === 0) return;
+    untrack(() => {
+      const set = new Set(knownModels);
+      let changed = false;
+      for (const m of fromSummary) {
+        if (!set.has(m)) {
+          set.add(m);
+          changed = true;
+        }
+      }
+      if (changed) {
+        knownModels = [...set].sort();
+      }
+    });
+  });
+
+  const modelItems = $derived(
+    knownModels.map((m) => ({ name: m })),
+  );
+
+  // URL-init: seed store filters from URL params when landing
+  // on /usage or when the URL changes via back/forward nav.
+  // Uses explicit empty fallbacks so filters CLEAR when params
+  // disappear (e.g., navigating back from /usage?exclude_project=foo
+  // to /usage). On initial mount, onMount() calls fetchAll after
+  // this effect runs, so we skip the refetch on the first run.
+  let urlInitRan = false;
+  $effect(() => {
+    const route = router.route;
+    const params = router.params;
+    untrack(() => {
+      if (route !== "usage") return;
+      let changed = false;
+      // from/to: use defaults when missing (don't stomp the store
+      // with "" which would break date inputs).
+      if (params["from"] && params["from"] !== usage.from) {
+        usage.from = params["from"];
+        changed = true;
+      }
+      if (params["to"] && params["to"] !== usage.to) {
+        usage.to = params["to"];
+        changed = true;
+      }
+      // Exclude params: missing means "nothing excluded", so we
+      // MUST update to "" when the param disappears.
+      const newExProj = params["exclude_project"] ?? "";
+      if (newExProj !== usage.excludedProjects) {
+        usage.excludedProjects = newExProj;
+        changed = true;
+      }
+      const newExAgent = params["exclude_agent"] ?? "";
+      if (newExAgent !== usage.excludedAgents) {
+        usage.excludedAgents = newExAgent;
+        changed = true;
+      }
+      const newExModel = params["exclude_model"] ?? "";
+      if (newExModel !== usage.excludedModels) {
+        usage.excludedModels = newExModel;
+        changed = true;
+      }
+      if (changed && urlInitRan) {
+        usage.fetchAll();
+      }
+      urlInitRan = true;
+    });
+  });
+
+  // URL write-back: keep URL params in sync with filter state
+  // so users can share/bookmark the view.
+  $effect(() => {
+    const from = usage.from;
+    const to = usage.to;
+    const exProj = usage.excludedProjects;
+    const exAgent = usage.excludedAgents;
+    const exModel = usage.excludedModels;
+    untrack(() => {
+      if (router.route !== "usage") return;
+      const params: Record<string, string> = {};
+      if (from) params["from"] = from;
+      if (to) params["to"] = to;
+      if (exProj) params["exclude_project"] = exProj;
+      if (exAgent) params["exclude_agent"] = exAgent;
+      if (exModel) params["exclude_model"] = exModel;
+      router.replaceParams(params);
+    });
+  });
+
+  function handleFromChange(
+    e: Event & { currentTarget: HTMLInputElement },
+  ) {
+    const val = e.currentTarget.value;
+    if (val) usage.setDateRange(val, usage.to);
+  }
+
+  function handleToChange(
+    e: Event & { currentTarget: HTMLInputElement },
+  ) {
+    const val = e.currentTarget.value;
+    if (val) usage.setDateRange(usage.from, val);
+  }
+
+  onMount(() => {
+    usage.fetchAll();
+    refreshTimer = setInterval(
+      () => usage.fetchAll(),
+      REFRESH_MS,
+    );
+  });
+
+  onDestroy(() => {
+    if (refreshTimer !== undefined) {
+      clearInterval(refreshTimer);
+    }
+  });
+</script>
+
+<div class="usage-page">
+  <div class="usage-toolbar">
+    <h2 class="page-title">Usage</h2>
+
+    <div class="toolbar-controls">
+      <input
+        type="date"
+        class="date-input"
+        value={usage.from}
+        onchange={handleFromChange}
+      />
+      <span class="date-sep">to</span>
+      <input
+        type="date"
+        class="date-input"
+        value={usage.to}
+        onchange={handleToChange}
+      />
+
+      <FilterDropdown
+        label="Project"
+        items={projectItems}
+        excludedCsv={usage.excludedProjects}
+        onToggle={(name) => usage.toggleProject(name)}
+        onSelectAll={() => usage.selectAllProjects()}
+        onDeselectAll={() => usage.deselectAllProjects(projectItems.map(p => p.name))}
+      />
+
+      <FilterDropdown
+        label="Agent"
+        items={agentItems}
+        excludedCsv={usage.excludedAgents}
+        onToggle={(name) => usage.toggleAgent(name)}
+        onSelectAll={() => usage.selectAllAgents()}
+        onDeselectAll={() => usage.deselectAllAgents(agentItems.map(a => a.name))}
+        color={agentColor}
+      />
+
+      <FilterDropdown
+        label="Model"
+        items={modelItems}
+        excludedCsv={usage.excludedModels}
+        onToggle={(name) => usage.toggleModel(name)}
+        onSelectAll={() => usage.selectAllModels()}
+        onDeselectAll={() => usage.deselectAllModels(modelItems.map(m => m.name))}
+      />
+
+      <button
+        class="refresh-btn"
+        onclick={() => usage.fetchAll()}
+        title="Refresh"
+        aria-label="Refresh usage data"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+        >
+          <path d="M8 3a5 5 0 00-4.546 2.914.5.5 0 01-.908-.418A6 6 0 0114 8a.5.5 0 01-1 0 5 5 0 00-5-5zm4.546 7.086a.5.5 0 01.908.418A6 6 0 012 8a.5.5 0 011 0 5 5 0 005 5 5 5 0 004.546-2.914z" />
+        </svg>
+      </button>
+
+      {#if usage.hasActiveFilters}
+        <button
+          class="clear-filters"
+          onclick={() => usage.clearFilters()}
+        >
+          Clear filters
+        </button>
+      {/if}
+    </div>
+  </div>
+
+  <div class="usage-content">
+    <UsageSummaryCards />
+
+    <div class="chart-panel wide">
+      <CostTimeSeriesChart />
+    </div>
+
+    <div class="chart-panel wide">
+      <AttributionPanel />
+    </div>
+
+    <div class="bottom-grid">
+      <div class="chart-panel">
+        <TopSessionsTable />
+      </div>
+      <div class="chart-panel">
+        <CacheEfficiencyPanel />
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .usage-page {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .usage-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 16px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-muted);
+    flex-shrink: 0;
+  }
+
+  .page-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+  }
+
+  .toolbar-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    flex: 1;
+  }
+
+  .date-input {
+    height: 26px;
+    padding: 0 6px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-inset);
+    color: var(--text-primary);
+    font-size: 11px;
+    font-family: var(--font-mono);
+  }
+
+  .date-sep {
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+
+  .clear-filters {
+    height: 26px;
+    padding: 0 8px;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .clear-filters:hover {
+    color: var(--text-primary);
+  }
+
+  .refresh-btn {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .refresh-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .usage-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .chart-panel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    padding: 12px;
+    min-width: 0;
+  }
+
+  .chart-panel.wide {
+    width: 100%;
+  }
+
+  .bottom-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+
+  @media (max-width: 800px) {
+    .bottom-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -28,28 +28,45 @@
     })),
   );
 
-  // Track every model we've seen in any summary response — never
-  // remove one. Without this the model dropdown would lose excluded
-  // models (since modelTotals only contains non-excluded models) and
-  // the user would have no way to re-include them.
+  // Track every model we've seen in any summary response or
+  // excluded-model filter — never remove one. This keeps the model
+  // dropdown usable even when landing on a shared URL like
+  // /usage?exclude_model=claude-opus, which would otherwise never
+  // show that model in the dropdown (it's filtered out of
+  // modelTotals on every response) and leave the user unable to
+  // re-include it.
   let knownModels: string[] = $state([]);
 
+  function mergeIntoKnownModels(names: string[]): void {
+    if (names.length === 0) return;
+    const set = new Set(knownModels);
+    let changed = false;
+    for (const m of names) {
+      if (m && !set.has(m)) {
+        set.add(m);
+        changed = true;
+      }
+    }
+    if (changed) {
+      knownModels = [...set].sort();
+    }
+  }
+
+  // Seed from the filtered summary response.
   $effect(() => {
     const fromSummary = (usage.summary?.modelTotals ?? [])
       .map((m) => m.model);
-    if (fromSummary.length === 0) return;
+    untrack(() => mergeIntoKnownModels(fromSummary));
+  });
+
+  // Seed from the excluded-model filter so a shared URL like
+  // /usage?exclude_model=foo shows "foo" in the dropdown on first
+  // load, letting the user re-include it without clearing first.
+  $effect(() => {
+    const excluded = usage.excludedModels;
     untrack(() => {
-      const set = new Set(knownModels);
-      let changed = false;
-      for (const m of fromSummary) {
-        if (!set.has(m)) {
-          set.add(m);
-          changed = true;
-        }
-      }
-      if (changed) {
-        knownModels = [...set].sort();
-      }
+      if (!excluded) return;
+      mergeIntoKnownModels(excluded.split(","));
     });
   });
 

--- a/frontend/src/lib/components/usage/UsageSummaryCards.svelte
+++ b/frontend/src/lib/components/usage/UsageSummaryCards.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+  import { usage } from "../../stores/usage.svelte.js";
+
+  function fmtCost(v: number): string {
+    return `$${v.toFixed(2)}`;
+  }
+
+  function fmtTokens(v: number): string {
+    if (v >= 1_000_000_000) {
+      const g = Math.floor(v / 100_000_000) / 10;
+      return `${g}B`;
+    }
+    if (v >= 1_000_000) {
+      const m = Math.floor(v / 100_000) / 10;
+      return `${m}M`;
+    }
+    if (v >= 1_000) {
+      const k = Math.floor(v / 100) / 10;
+      return `${k}K`;
+    }
+    return String(v);
+  }
+
+  function fmtPct(v: number): string {
+    return `${(v * 100).toFixed(1)}%`;
+  }
+
+  const totalTokens = $derived.by(() => {
+    const s = usage.summary;
+    if (!s) return 0;
+    const t = s.totals;
+    return t.inputTokens + t.outputTokens
+      + t.cacheCreationTokens + t.cacheReadTokens;
+  });
+
+  const dailyBurn = $derived.by(() => {
+    const s = usage.summary;
+    if (!s || !s.daily || s.daily.length === 0) return 0;
+    return s.totals.totalCost / s.daily.length;
+  });
+
+  const peak = $derived.by(() => {
+    const s = usage.summary;
+    if (!s || !s.daily || s.daily.length === 0) {
+      return { date: "", cost: 0 };
+    }
+    let best = s.daily[0]!;
+    for (const d of s.daily) {
+      if (d.totalCost > best.totalCost) best = d;
+    }
+    return { date: best.date, cost: best.totalCost };
+  });
+
+  const activeDays = $derived(
+    usage.summary?.daily?.filter(
+      (d) => d.totalCost > 0,
+    ).length ?? 0,
+  );
+
+  const vsPrior = $derived.by(() => {
+    const c = usage.summary?.comparison;
+    if (!c) return null;
+    const sign = c.deltaPct >= 0 ? "+" : "";
+    return `${sign}${(c.deltaPct * 100).toFixed(0)}% vs prior`;
+  });
+
+  interface Card {
+    label: string;
+    value: () => string;
+    sub?: () => string;
+    featured?: boolean;
+  }
+
+  const cards: Card[] = [
+    {
+      label: "Total Cost",
+      value: () => fmtCost(usage.summary?.totals.totalCost ?? 0),
+      sub: () => vsPrior ?? "",
+      featured: true,
+    },
+    {
+      label: "Tokens",
+      value: () => fmtTokens(totalTokens),
+    },
+    {
+      label: "Daily Burn",
+      value: () => fmtCost(dailyBurn),
+      sub: () => "avg/day",
+    },
+    {
+      label: "Peak Day",
+      value: () => fmtCost(peak.cost),
+      sub: () => peak.date,
+    },
+    {
+      label: "Cache Hit",
+      value: () =>
+        fmtPct(usage.summary?.cacheStats.hitRate ?? 0),
+    },
+    {
+      label: "Projects",
+      value: () =>
+        String(
+          Object.keys(
+            usage.summary?.sessionCounts.byProject ?? {},
+          ).length,
+        ),
+    },
+    {
+      label: "Models",
+      value: () =>
+        String(usage.summary?.modelTotals.length ?? 0),
+    },
+    {
+      label: "Active Days",
+      value: () => String(activeDays),
+    },
+  ];
+</script>
+
+<div class="summary-cards">
+  {#each cards as card}
+    <div
+      class="card"
+      class:featured={card.featured}
+      class:loading={usage.loading.summary}
+    >
+      {#if usage.loading.summary}
+        <div class="skeleton-value"></div>
+        <div class="skeleton-label"></div>
+      {:else if usage.errors.summary}
+        <span class="card-value error">--</span>
+        <span class="card-label">{card.label}</span>
+      {:else}
+        <span class="card-value">{card.value()}</span>
+        <span class="card-label">{card.label}</span>
+        {#if card.sub}
+          {@const subtext = card.sub()}
+          {#if subtext}
+            <span class="card-sub">{subtext}</span>
+          {/if}
+        {/if}
+      {/if}
+    </div>
+  {/each}
+</div>
+
+{#if usage.errors.summary}
+  <div class="error-bar">
+    <span>{usage.errors.summary}</span>
+    <button
+      class="retry-btn"
+      onclick={() => usage.fetchSummary()}
+    >
+      Retry
+    </button>
+  </div>
+{/if}
+
+<style>
+  .summary-cards {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    flex: 1;
+    min-width: 120px;
+    padding: 12px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .card.featured {
+    border-width: 2px;
+    border-color: var(--accent-blue);
+  }
+
+  .card-value {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.2;
+  }
+
+  .card-value.error {
+    color: var(--text-muted);
+  }
+
+  .card-label {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .card-sub {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-top: 2px;
+  }
+
+  .skeleton-value {
+    width: 60px;
+    height: 20px;
+    background: var(--bg-inset);
+    border-radius: var(--radius-sm);
+  }
+
+  .skeleton-label {
+    width: 80px;
+    height: 12px;
+    background: var(--bg-inset);
+    border-radius: var(--radius-sm);
+  }
+
+  .error-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--bg-surface);
+    border: 1px solid var(--accent-red);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: var(--accent-red);
+  }
+
+  .retry-btn {
+    padding: 2px 8px;
+    border: 1px solid var(--accent-red);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: var(--accent-red);
+    cursor: pointer;
+  }
+
+  .retry-btn:hover {
+    background: var(--accent-red);
+    color: #fff;
+  }
+</style>

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -1,5 +1,6 @@
 export type Route =
   | "sessions"
+  | "usage"
   | "insights"
   | "pinned"
   | "trash"
@@ -7,6 +8,7 @@ export type Route =
 
 const VALID_ROUTES: ReadonlySet<string> = new Set<Route>([
   "sessions",
+  "usage",
   "insights",
   "pinned",
   "trash",

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -1,0 +1,289 @@
+import type {
+  UsageSummaryResponse,
+  TopUsageSessionsResponse,
+  UsageParams,
+} from "../api/types/usage.js";
+import {
+  getUsageSummary,
+  getUsageTopSessions,
+} from "../api/client.js";
+
+export type GroupBy = "project" | "model" | "agent";
+export type TimeSeriesView = "stacked-area" | "bars" | "lines";
+export type AttributionView = "treemap" | "list" | "bars";
+
+interface Toggles {
+  timeSeries: { groupBy: GroupBy; view: TimeSeriesView };
+  attribution: { groupBy: GroupBy; view: AttributionView };
+}
+
+const TOGGLES_KEY = "usage-toggles";
+
+function defaultToggles(): Toggles {
+  return {
+    timeSeries: { groupBy: "project", view: "stacked-area" },
+    attribution: { groupBy: "project", view: "treemap" },
+  };
+}
+
+function loadToggles(): Toggles {
+  try {
+    const raw = localStorage.getItem(TOGGLES_KEY);
+    if (raw) return JSON.parse(raw) as Toggles;
+  } catch {
+    // Corrupted localStorage — fall back to defaults.
+  }
+  return defaultToggles();
+}
+
+function saveToggles(t: Toggles): void {
+  try {
+    localStorage.setItem(TOGGLES_KEY, JSON.stringify(t));
+  } catch {
+    // localStorage full or unavailable — silently skip.
+  }
+}
+
+function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return localDateStr(d);
+}
+
+function today(): string {
+  return localDateStr(new Date());
+}
+
+type Endpoint = "summary" | "topSessions";
+
+class UsageStore {
+  from: string = $state(daysAgo(30));
+  to: string = $state(today());
+
+  // Excluded items (comma-separated strings). Default is
+  // empty = nothing excluded = show all. The UI shows all items
+  // as checked; clicking one unchecks it (excludes it).
+  // Sent directly to the backend as exclude_project / exclude_agent
+  // / exclude_model query params (NOT IN filtering).
+  excludedProjects: string = $state("");
+  excludedAgents: string = $state("");
+  excludedModels: string = $state("");
+
+  summary = $state<UsageSummaryResponse | null>(null);
+  topSessions = $state<TopUsageSessionsResponse | null>(null);
+
+  loading = $state({ summary: false, topSessions: false });
+  errors = $state<Record<Endpoint, string | null>>({
+    summary: null,
+    topSessions: null,
+  });
+
+  toggles: Toggles = $state(loadToggles());
+
+  private versions: Record<Endpoint, number> = {
+    summary: 0,
+    topSessions: 0,
+  };
+
+  private get timezone(): string {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+
+  private baseParams(): UsageParams {
+    const p: UsageParams = {
+      from: this.from,
+      to: this.to,
+      timezone: this.timezone,
+    };
+    if (this.excludedProjects) {
+      p.exclude_project = this.excludedProjects;
+    }
+    if (this.excludedAgents) {
+      p.exclude_agent = this.excludedAgents;
+    }
+    if (this.excludedModels) {
+      p.exclude_model = this.excludedModels;
+    }
+    return p;
+  }
+
+  setDateRange(from: string, to: string) {
+    this.from = from;
+    this.to = to;
+    this.fetchAll();
+  }
+
+  // Toggle an item's exclusion. Clicking an included item
+  // excludes it; clicking an excluded item re-includes it.
+  toggleProject(name: string): void {
+    this.excludedProjects = this.toggleCsv(
+      this.excludedProjects, name,
+    );
+    this.fetchAll();
+  }
+
+  toggleAgent(name: string): void {
+    this.excludedAgents = this.toggleCsv(
+      this.excludedAgents, name,
+    );
+    this.fetchAll();
+  }
+
+  toggleModel(name: string): void {
+    this.excludedModels = this.toggleCsv(
+      this.excludedModels, name,
+    );
+    this.fetchAll();
+  }
+
+  private toggleCsv(csv: string, name: string): string {
+    const current = csv ? csv.split(",") : [];
+    const idx = current.indexOf(name);
+    if (idx >= 0) {
+      current.splice(idx, 1);
+    } else {
+      current.push(name);
+    }
+    return current.join(",");
+  }
+
+  // An item is "excluded" if it appears in the excluded CSV.
+  // The UI shows a check for items NOT excluded (i.e., visible).
+  isProjectExcluded(name: string): boolean {
+    if (!this.excludedProjects) return false;
+    return this.excludedProjects.split(",").includes(name);
+  }
+
+  isAgentExcluded(name: string): boolean {
+    if (!this.excludedAgents) return false;
+    return this.excludedAgents.split(",").includes(name);
+  }
+
+  isModelExcluded(name: string): boolean {
+    if (!this.excludedModels) return false;
+    return this.excludedModels.split(",").includes(name);
+  }
+
+  selectAllProjects(): void {
+    this.excludedProjects = "";
+    this.fetchAll();
+  }
+
+  deselectAllProjects(all: string[]): void {
+    this.excludedProjects = all.join(",");
+    this.fetchAll();
+  }
+
+  selectAllAgents(): void {
+    this.excludedAgents = "";
+    this.fetchAll();
+  }
+
+  deselectAllAgents(all: string[]): void {
+    this.excludedAgents = all.join(",");
+    this.fetchAll();
+  }
+
+  selectAllModels(): void {
+    this.excludedModels = "";
+    this.fetchAll();
+  }
+
+  deselectAllModels(all: string[]): void {
+    this.excludedModels = all.join(",");
+    this.fetchAll();
+  }
+
+  clearFilters(): void {
+    this.excludedProjects = "";
+    this.excludedAgents = "";
+    this.excludedModels = "";
+    this.fetchAll();
+  }
+
+  get hasActiveFilters(): boolean {
+    return (
+      this.excludedProjects !== "" ||
+      this.excludedAgents !== "" ||
+      this.excludedModels !== ""
+    );
+  }
+
+  setTimeSeriesGroupBy(g: GroupBy) {
+    this.toggles.timeSeries.groupBy = g;
+    saveToggles(this.toggles);
+  }
+
+  setTimeSeriesView(v: TimeSeriesView) {
+    this.toggles.timeSeries.view = v;
+    saveToggles(this.toggles);
+  }
+
+  setAttributionGroupBy(g: GroupBy) {
+    this.toggles.attribution.groupBy = g;
+    saveToggles(this.toggles);
+  }
+
+  setAttributionView(v: AttributionView) {
+    this.toggles.attribution.view = v;
+    saveToggles(this.toggles);
+  }
+
+  async fetchAll() {
+    await Promise.all([
+      this.fetchSummary(),
+      this.fetchTopSessions(),
+    ]);
+  }
+
+  async fetchSummary() {
+    const v = ++this.versions.summary;
+    this.loading.summary = true;
+    this.errors.summary = null;
+    try {
+      const data = await getUsageSummary(this.baseParams());
+      if (this.versions.summary === v) {
+        this.summary = data;
+      }
+    } catch (e) {
+      if (this.versions.summary === v) {
+        this.errors.summary =
+          e instanceof Error ? e.message : "Failed to load";
+      }
+    } finally {
+      if (this.versions.summary === v) {
+        this.loading.summary = false;
+      }
+    }
+  }
+
+  async fetchTopSessions() {
+    const v = ++this.versions.topSessions;
+    this.loading.topSessions = true;
+    this.errors.topSessions = null;
+    try {
+      const data = await getUsageTopSessions(this.baseParams());
+      if (this.versions.topSessions === v) {
+        this.topSessions = data;
+      }
+    } catch (e) {
+      if (this.versions.topSessions === v) {
+        this.errors.topSessions =
+          e instanceof Error ? e.message : "Failed to load";
+      }
+    } finally {
+      if (this.versions.topSessions === v) {
+        this.loading.topSessions = false;
+      }
+    }
+  }
+}
+
+export const usage = new UsageStore();

--- a/frontend/src/lib/utils/projectColor.test.ts
+++ b/frontend/src/lib/utils/projectColor.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { projectColor, PROJECT_PALETTE } from "./projectColor.js";
+
+describe("projectColor", () => {
+  it("returns a palette color for any non-empty string", () => {
+    expect(PROJECT_PALETTE).toContain(projectColor("agentsview"));
+  });
+
+  it("is deterministic", () => {
+    expect(projectColor("agentsview")).toBe(projectColor("agentsview"));
+  });
+
+  it("maps empty input to the muted fallback", () => {
+    expect(projectColor("")).toBe("var(--text-muted)");
+  });
+
+  it("spreads different names across the palette", () => {
+    const names = [
+      "agentsview", "quokka", "arrow-rs", "side-quests",
+      "infrastructure", "blog", "experiments", "docs",
+      "dotfiles", "playground", "sandbox", "notes",
+    ];
+    const seen = new Set(names.map(projectColor));
+    expect(seen.size).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/frontend/src/lib/utils/projectColor.ts
+++ b/frontend/src/lib/utils/projectColor.ts
@@ -1,0 +1,29 @@
+export const PROJECT_PALETTE: readonly string[] = [
+  "var(--accent-blue)",
+  "var(--accent-purple)",
+  "var(--accent-amber)",
+  "var(--accent-teal)",
+  "var(--accent-rose)",
+  "var(--accent-green)",
+  "var(--accent-indigo)",
+  "var(--accent-orange)",
+  "var(--accent-sky)",
+  "var(--accent-pink)",
+  "var(--accent-coral)",
+  "var(--accent-lime)",
+] as const;
+
+const FALLBACK = "var(--text-muted)";
+
+function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+export function projectColor(name: string): string {
+  if (!name) return FALLBACK;
+  return PROJECT_PALETTE[djb2(name) % PROJECT_PALETTE.length]!;
+}

--- a/frontend/src/lib/utils/treemap.test.ts
+++ b/frontend/src/lib/utils/treemap.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { squarify, type TreemapTile } from "./treemap.js";
+
+describe("squarify", () => {
+  it("returns empty array for empty input", () => {
+    expect(squarify([], 400, 300)).toEqual([]);
+  });
+
+  it("returns single tile filling the full rect", () => {
+    const tiles = squarify(
+      [{ id: "a", value: 10 }], 400, 300,
+    );
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0]!.x).toBe(0);
+    expect(tiles[0]!.y).toBe(0);
+    expect(tiles[0]!.width).toBe(400);
+    expect(tiles[0]!.height).toBe(300);
+  });
+
+  it("tiles sum to full area within tolerance", () => {
+    const tiles = squarify(
+      [
+        { id: "a", value: 40 },
+        { id: "b", value: 30 },
+        { id: "c", value: 20 },
+        { id: "d", value: 10 },
+      ],
+      400,
+      300,
+    );
+    const totalArea = tiles.reduce(
+      (s, t) => s + t.width * t.height, 0,
+    );
+    expect(totalArea).toBeCloseTo(400 * 300, -1);
+  });
+
+  it("tiles do not overlap", () => {
+    const tiles = squarify(
+      [
+        { id: "a", value: 40 },
+        { id: "b", value: 30 },
+        { id: "c", value: 20 },
+        { id: "d", value: 10 },
+      ],
+      400,
+      300,
+    );
+    for (let i = 0; i < tiles.length; i++) {
+      for (let j = i + 1; j < tiles.length; j++) {
+        expect(tilesOverlap(tiles[i]!, tiles[j]!)).toBe(false);
+      }
+    }
+  });
+
+  it("filters out zero-value items", () => {
+    const tiles = squarify(
+      [
+        { id: "a", value: 10 },
+        { id: "b", value: 0 },
+        { id: "c", value: 5 },
+      ],
+      400,
+      300,
+    );
+    expect(tiles).toHaveLength(2);
+    const ids = tiles.map((t) => t.id);
+    expect(ids).toContain("a");
+    expect(ids).toContain("c");
+    expect(ids).not.toContain("b");
+  });
+});
+
+function tilesOverlap(a: TreemapTile, b: TreemapTile): boolean {
+  const EPS = 0.01;
+  const aRight = a.x + a.width;
+  const aBottom = a.y + a.height;
+  const bRight = b.x + b.width;
+  const bBottom = b.y + b.height;
+  return (
+    a.x < bRight - EPS &&
+    aRight > b.x + EPS &&
+    a.y < bBottom - EPS &&
+    aBottom > b.y + EPS
+  );
+}

--- a/frontend/src/lib/utils/treemap.ts
+++ b/frontend/src/lib/utils/treemap.ts
@@ -1,0 +1,146 @@
+export interface TreemapInput {
+  id: string;
+  value: number;
+}
+
+export interface TreemapTile {
+  id: string;
+  value: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Squarified treemap layout (Bruls/Huijsen/van Wijk 2000).
+ *
+ * Filters to positive values, sorts descending, scales so values
+ * sum to total area, then recursively lays out rows along the
+ * shorter edge using the worst-aspect-ratio heuristic.
+ */
+export function squarify(
+  input: readonly TreemapInput[],
+  width: number,
+  height: number,
+): TreemapTile[] {
+  const items = input
+    .filter((d) => d.value > 0)
+    .sort((a, b) => b.value - a.value);
+
+  if (items.length === 0 || width <= 0 || height <= 0) return [];
+
+  const totalValue = items.reduce((s, d) => s + d.value, 0);
+  const totalArea = width * height;
+  const scaled = items.map((d) => ({
+    id: d.id,
+    area: (d.value / totalValue) * totalArea,
+    value: d.value,
+  }));
+
+  const tiles: TreemapTile[] = [];
+  layoutRect(scaled, 0, 0, width, height, tiles);
+  return tiles;
+}
+
+interface ScaledItem {
+  id: string;
+  area: number;
+  value: number;
+}
+
+function worstRatio(
+  row: ScaledItem[],
+  sideLength: number,
+): number {
+  const rowArea = row.reduce((s, d) => s + d.area, 0);
+  let worst = 0;
+  for (const item of row) {
+    const w = rowArea / sideLength;
+    const h = item.area / w;
+    const ratio = Math.max(w / h, h / w);
+    if (ratio > worst) worst = ratio;
+  }
+  return worst;
+}
+
+function layoutRect(
+  items: ScaledItem[],
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  tiles: TreemapTile[],
+): void {
+  if (items.length === 0) return;
+
+  if (items.length === 1) {
+    const d = items[0]!;
+    tiles.push({
+      id: d.id,
+      value: d.value,
+      x,
+      y,
+      width: w,
+      height: h,
+    });
+    return;
+  }
+
+  const shortSide = Math.min(w, h);
+  const row: ScaledItem[] = [items[0]!];
+  let idx = 1;
+
+  while (idx < items.length) {
+    const candidate = [...row, items[idx]!];
+    if (worstRatio(candidate, shortSide) <=
+        worstRatio(row, shortSide)) {
+      row.push(items[idx]!);
+      idx++;
+    } else {
+      break;
+    }
+  }
+
+  const rowArea = row.reduce((s, d) => s + d.area, 0);
+  const horizontal = w >= h;
+  const rowSpan = rowArea / (horizontal ? h : w);
+
+  let offset = 0;
+  for (const item of row) {
+    const itemSpan = item.area / rowSpan;
+    if (horizontal) {
+      tiles.push({
+        id: item.id,
+        value: item.value,
+        x,
+        y: y + offset,
+        width: rowSpan,
+        height: itemSpan,
+      });
+    } else {
+      tiles.push({
+        id: item.id,
+        value: item.value,
+        x: x + offset,
+        y,
+        width: itemSpan,
+        height: rowSpan,
+      });
+    }
+    offset += itemSpan;
+  }
+
+  const remaining = items.slice(idx);
+  if (remaining.length > 0) {
+    if (horizontal) {
+      layoutRect(
+        remaining, x + rowSpan, y, w - rowSpan, h, tiles,
+      );
+    } else {
+      layoutRect(
+        remaining, x, y + rowSpan, w, h - rowSpan, tiles,
+      );
+    }
+  }
+}

--- a/frontend/src/lib/utils/usageSavings.test.ts
+++ b/frontend/src/lib/utils/usageSavings.test.ts
@@ -2,22 +2,35 @@ import { describe, it, expect } from "vitest";
 import { savingsState } from "./usageSavings.js";
 
 describe("savingsState", () => {
-  it("returns 'saved' for positive values", () => {
+  it("returns 'saved' for positive values >= half a cent", () => {
+    expect(savingsState(0.005)).toBe("saved");
     expect(savingsState(0.01)).toBe("saved");
     expect(savingsState(2.7)).toBe("saved");
     expect(savingsState(1_000_000)).toBe("saved");
   });
 
-  it("returns 'costlier' for negative values", () => {
+  it("returns 'costlier' for negative values <= -half a cent", () => {
     // Write-heavy workloads: creation premium > read discount.
+    expect(savingsState(-0.005)).toBe("costlier");
     expect(savingsState(-0.01)).toBe("costlier");
     expect(savingsState(-0.75)).toBe("costlier");
     expect(savingsState(-42)).toBe("costlier");
   });
 
   it("returns 'none' for exactly zero", () => {
-    // No cache activity, or exact break-even.
     expect(savingsState(0)).toBe("none");
     expect(savingsState(-0)).toBe("none");
   });
+
+  it(
+    "returns 'none' for sub-cent deltas that would render $0.00",
+    () => {
+      // These would format as "$0.00 more/saved than uncached"
+      // and look broken. Suppress the badge entirely instead.
+      expect(savingsState(0.001)).toBe("none");
+      expect(savingsState(0.004)).toBe("none");
+      expect(savingsState(-0.001)).toBe("none");
+      expect(savingsState(-0.004999)).toBe("none");
+    },
+  );
 });

--- a/frontend/src/lib/utils/usageSavings.test.ts
+++ b/frontend/src/lib/utils/usageSavings.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { savingsState } from "./usageSavings.js";
+
+describe("savingsState", () => {
+  it("returns 'saved' for positive values", () => {
+    expect(savingsState(0.01)).toBe("saved");
+    expect(savingsState(2.7)).toBe("saved");
+    expect(savingsState(1_000_000)).toBe("saved");
+  });
+
+  it("returns 'costlier' for negative values", () => {
+    // Write-heavy workloads: creation premium > read discount.
+    expect(savingsState(-0.01)).toBe("costlier");
+    expect(savingsState(-0.75)).toBe("costlier");
+    expect(savingsState(-42)).toBe("costlier");
+  });
+
+  it("returns 'none' for exactly zero", () => {
+    // No cache activity, or exact break-even.
+    expect(savingsState(0)).toBe("none");
+    expect(savingsState(-0)).toBe("none");
+  });
+});

--- a/frontend/src/lib/utils/usageSavings.ts
+++ b/frontend/src/lib/utils/usageSavings.ts
@@ -1,14 +1,21 @@
 export type SavingsState = "saved" | "costlier" | "none";
 
+// Values whose absolute magnitude rounds to $0.00 at two
+// decimals are treated as "none" so the UI doesn't render
+// a misleading "$0.00 more than uncached" badge for a
+// sub-cent delta.
+const DISPLAY_EPSILON = 0.005;
+
 // savingsState classifies a cache-savings dollar delta into
 // the three states the Cache Efficiency panel renders:
 //   - "saved"    : positive — cache reduced total cost
 //   - "costlier" : negative — cache creation premium outweighed
 //                  any read discount (common in write-only
 //                  workloads where cache_creation > input rate)
-//   - "none"     : exactly zero — no signal to show
+//   - "none"     : zero, or within half a cent of zero — no
+//                  signal worth showing at 2-decimal display
 export function savingsState(value: number): SavingsState {
+  if (Math.abs(value) < DISPLAY_EPSILON) return "none";
   if (value > 0) return "saved";
-  if (value < 0) return "costlier";
-  return "none";
+  return "costlier";
 }

--- a/frontend/src/lib/utils/usageSavings.ts
+++ b/frontend/src/lib/utils/usageSavings.ts
@@ -1,0 +1,14 @@
+export type SavingsState = "saved" | "costlier" | "none";
+
+// savingsState classifies a cache-savings dollar delta into
+// the three states the Cache Efficiency panel renders:
+//   - "saved"    : positive — cache reduced total cost
+//   - "costlier" : negative — cache creation premium outweighed
+//                  any read discount (common in write-only
+//                  workloads where cache_creation > input rate)
+//   - "none"     : exactly zero — no signal to show
+export function savingsState(value: number): SavingsState {
+  if (value > 0) return "saved";
+  if (value < 0) return "costlier";
+  return "none";
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -55,6 +55,11 @@ type Store interface {
 	GetAnalyticsVelocity(ctx context.Context, f AnalyticsFilter) (VelocityResponse, error)
 	GetAnalyticsTopSessions(ctx context.Context, f AnalyticsFilter, metric string) (TopSessionsResponse, error)
 
+	// Usage (token cost).
+	GetDailyUsage(ctx context.Context, f UsageFilter) (DailyUsageResult, error)
+	GetTopSessionsByCost(ctx context.Context, f UsageFilter, limit int) ([]TopSessionEntry, error)
+	GetUsageSessionCounts(ctx context.Context, f UsageFilter) (UsageSessionCounts, error)
+
 	// Stars (local-only; PG returns ErrReadOnly).
 	StarSession(sessionID string) (bool, error)
 	UnstarSession(sessionID string) error

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -708,6 +708,8 @@ SELECT
 	COALESCE(s.started_at, ''),
 	m.model,
 	m.token_usage,
+	m.claude_message_id,
+	m.claude_request_id,
 	COALESCE(m.timestamp, s.started_at) as ts
 FROM messages m
 JOIN sessions s ON m.session_id = s.id
@@ -726,6 +728,12 @@ WHERE ` + usageMessageEligibility
 		args = append(args, padded)
 	}
 	query, args = f.appendFilterClauses(query, args)
+	// Deterministic order so the dedup "winner" (the session
+	// that gets credit for a duplicate message.id + request.id
+	// pair) is stable across runs: earliest timestamp wins,
+	// then session_id, then message ordinal.
+	query += ` ORDER BY COALESCE(m.timestamp, s.started_at) ASC,
+		m.session_id ASC, m.ordinal ASC`
 
 	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
@@ -749,6 +757,14 @@ WHERE ` + usageMessageEligibility
 	// Track insertion order for stable iteration.
 	var order []string
 
+	// Dedup duplicate Claude messages across fork/subagent
+	// boundaries so per-session totals match the aggregate
+	// totals from GetDailyUsage. Same key and ordering rules.
+	type dedupKey struct {
+		msgID, reqID string
+	}
+	seen := make(map[dedupKey]struct{})
+
 	var (
 		sid         string
 		displayName string
@@ -757,12 +773,15 @@ WHERE ` + usageMessageEligibility
 		startedAt   string
 		model       string
 		tokenJSON   string
+		msgID       string
+		reqID       string
 		ts          string
 	)
 	for rows.Next() {
 		if err := rows.Scan(
 			&sid, &displayName, &agent, &project,
-			&startedAt, &model, &tokenJSON, &ts,
+			&startedAt, &model, &tokenJSON,
+			&msgID, &reqID, &ts,
 		); err != nil {
 			return nil,
 				fmt.Errorf("scanning top sessions row: %w", err)
@@ -775,6 +794,17 @@ WHERE ` + usageMessageEligibility
 		}
 		if f.To != "" && date > f.To {
 			continue
+		}
+
+		// Dedup AFTER the date filter, matching GetDailyUsage,
+		// so out-of-range rows pulled in by the ±14h padding
+		// don't claim a key and suppress the in-range duplicate.
+		if msgID != "" && reqID != "" {
+			key := dedupKey{msgID: msgID, reqID: reqID}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
 		}
 
 		usage := gjson.Parse(tokenJSON)

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -99,6 +99,14 @@ func (f UsageFilter) location() *time.Location {
 // reference this constant so the set of counted messages stays
 // identical across queries. Drift here is the bug that makes
 // sessionCounts and daily totals disagree.
+//
+// Note: this does NOT filter by s.relationship_type. Duplicate
+// messages across fork/subagent boundaries are handled by the
+// per-query claude_message_id + claude_request_id dedup in
+// GetDailyUsage, which is more precise than a blanket exclusion:
+// a fork session can legitimately contribute unique-keyed messages
+// that should still be counted (see
+// TestGetDailyUsage_DedupesByClaudeMessageAndRequestID).
 const usageMessageEligibility = `
     m.token_usage != ''
     AND m.model != ''

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -164,6 +164,14 @@ type UsageTotals struct {
 	CacheCreationTokens int     `json:"cacheCreationTokens"`
 	CacheReadTokens     int     `json:"cacheReadTokens"`
 	TotalCost           float64 `json:"totalCost"`
+	// CacheSavings is the net dollar delta vs an uncached run:
+	// cache reads save (input_rate - cache_read_rate) per token,
+	// cache creations cost (input_rate - cache_creation_rate)
+	// per token (usually negative because creation is billed
+	// above the input rate). Computed from per-model rates so
+	// mixed-model workloads get the right number, not a fixed
+	// Sonnet proxy.
+	CacheSavings float64 `json:"cacheSavings"`
 }
 
 // DailyUsageResult wraps the daily entries and totals.
@@ -317,6 +325,13 @@ WHERE ` + usageMessageEligibility
 	}
 	seen := make(map[dedupKey]struct{})
 
+	// totalSavings is the running sum of per-message cache
+	// savings using each row's actual per-model rates. We sum
+	// at the message level instead of deriving from totals
+	// later because the rate mix varies per workload and a
+	// single fallback rate would misreport mixed-model periods.
+	var totalSavings float64
+
 	var (
 		ts        string
 		model     string
@@ -385,6 +400,16 @@ WHERE ` + usageMessageEligibility
 			float64(outputTok)*rates.output +
 			float64(cacheCrTok)*rates.cacheCreation +
 			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
+
+		// Per-message cache delta: reads earn (input - cacheRead)
+		// per token, creations earn (input - cacheCreate) per
+		// token (usually negative). Zero-rate fallbacks fold
+		// through cleanly.
+		readDelta := float64(cacheRdTok) *
+			(rates.input - rates.cacheRead) / 1_000_000
+		crDelta := float64(cacheCrTok) *
+			(rates.input - rates.cacheCreation) / 1_000_000
+		totalSavings += readDelta + crDelta
 
 		key := accumKey{
 			date: date, project: project,
@@ -513,6 +538,7 @@ WHERE ` + usageMessageEligibility
 		if daily == nil {
 			daily = []DailyUsageEntry{}
 		}
+		totals.CacheSavings = totalSavings
 		return DailyUsageResult{
 			Daily:  daily,
 			Totals: totals,
@@ -664,6 +690,7 @@ WHERE ` + usageMessageEligibility
 		daily = []DailyUsageEntry{}
 	}
 
+	totals.CacheSavings = totalSavings
 	return DailyUsageResult{
 		Daily:  daily,
 		Totals: totals,
@@ -893,6 +920,8 @@ SELECT
 	s.id,
 	s.project,
 	s.agent,
+	m.claude_message_id,
+	m.claude_request_id,
 	COALESCE(m.timestamp, s.started_at) as ts
 FROM messages m
 JOIN sessions s ON m.session_id = s.id
@@ -911,6 +940,12 @@ WHERE ` + usageMessageEligibility
 		args = append(args, padded)
 	}
 	query, args = f.appendFilterClauses(query, args)
+	// Deterministic ordering so the Claude dedup winner — the
+	// session that "owns" a shared message — is stable across
+	// runs. Matches GetDailyUsage / GetTopSessionsByCost so all
+	// three queries agree on which session gets credit.
+	query += ` ORDER BY COALESCE(m.timestamp, s.started_at) ASC,
+		m.session_id ASC, m.ordinal ASC`
 
 	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {
@@ -930,15 +965,30 @@ WHERE ` + usageMessageEligibility
 	}
 	seen := make(map[string]sessInfo)
 
+	// Claude message dedup mirrors GetDailyUsage: if a session
+	// only qualifies because of messages that are duplicates of
+	// an earlier session's rows (fork/subagent replays), that
+	// session should NOT be counted. Otherwise sessionCounts
+	// would disagree with the deduped token totals — a fork
+	// with zero unique messages would inflate the count even
+	// though it contributes zero cost.
+	type dedupKey struct {
+		msgID, reqID string
+	}
+	dedup := make(map[dedupKey]struct{})
+
 	var (
 		sid     string
 		project string
 		agent   string
+		msgID   string
+		reqID   string
 		ts      string
 	)
 	for rows.Next() {
 		if err := rows.Scan(
-			&sid, &project, &agent, &ts,
+			&sid, &project, &agent,
+			&msgID, &reqID, &ts,
 		); err != nil {
 			return UsageSessionCounts{},
 				fmt.Errorf("scanning session counts: %w", err)
@@ -951,6 +1001,16 @@ WHERE ` + usageMessageEligibility
 		}
 		if f.To != "" && date > f.To {
 			continue
+		}
+
+		// Dedup AFTER the date filter, matching the other two
+		// queries so ±14h padding rows don't claim keys.
+		if msgID != "" && reqID != "" {
+			key := dedupKey{msgID: msgID, reqID: reqID}
+			if _, dup := dedup[key]; dup {
+				continue
+			}
+			dedup[key] = struct{}{}
 		}
 
 		if _, ok := seen[sid]; !ok {

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -12,10 +13,72 @@ import (
 // UsageFilter controls the date range, agent, and timezone
 // for daily usage aggregation queries.
 type UsageFilter struct {
-	From     string // YYYY-MM-DD, inclusive
-	To       string // YYYY-MM-DD, inclusive
-	Agent    string // "claude", "codex", or "" for all
-	Timezone string // IANA timezone, "" for UTC
+	From           string // YYYY-MM-DD, inclusive
+	To             string // YYYY-MM-DD, inclusive
+	Agent          string // "" for all; supports comma-separated
+	Project        string // "" for all; supports comma-separated
+	Model          string // "" for all; supports comma-separated
+	ExcludeProject string // comma-separated projects to exclude
+	ExcludeAgent   string // comma-separated agents to exclude
+	ExcludeModel   string // comma-separated models to exclude
+	Timezone       string // IANA timezone, "" for UTC
+	Breakdowns     bool   // populate Project/AgentBreakdowns per day
+}
+
+// appendFilterClauses appends WHERE clauses for all include and
+// exclude filters onto the given query and args. Reused by
+// GetDailyUsage, GetTopSessionsByCost, and GetUsageSessionCounts
+// so the filter contract stays in lockstep.
+func (f UsageFilter) appendFilterClauses(
+	query string, args []any,
+) (string, []any) {
+	appendCSV := func(
+		q string, a []any, col, csv string, include bool,
+	) (string, []any) {
+		if csv == "" {
+			return q, a
+		}
+		vals := strings.Split(csv, ",")
+		op := "IN"
+		if !include {
+			op = "NOT IN"
+		}
+		if len(vals) == 1 {
+			if include {
+				q += " AND " + col + " = ?"
+			} else {
+				q += " AND " + col + " != ?"
+			}
+			a = append(a, vals[0])
+		} else {
+			ph := make([]string, len(vals))
+			for i, v := range vals {
+				ph[i] = "?"
+				a = append(a, v)
+			}
+			q += " AND " + col + " " + op +
+				" (" + strings.Join(ph, ",") + ")"
+		}
+		return q, a
+	}
+
+	// Include filters.
+	query, args = appendCSV(
+		query, args, "s.agent", f.Agent, true)
+	query, args = appendCSV(
+		query, args, "s.project", f.Project, true)
+	query, args = appendCSV(
+		query, args, "m.model", f.Model, true)
+
+	// Exclude filters.
+	query, args = appendCSV(
+		query, args, "s.project", f.ExcludeProject, false)
+	query, args = appendCSV(
+		query, args, "s.agent", f.ExcludeAgent, false)
+	query, args = appendCSV(
+		query, args, "m.model", f.ExcludeModel, false)
+
+	return query, args
 }
 
 // location loads the timezone or returns the system local timezone.
@@ -30,21 +93,55 @@ func (f UsageFilter) location() *time.Location {
 	return loc
 }
 
+// usageMessageEligibility is the WHERE-clause fragment that selects
+// messages eligible for usage / cost aggregation. Every usage query
+// (GetDailyUsage, GetUsageSessionCounts, GetTopSessionsByCost) MUST
+// reference this constant so the set of counted messages stays
+// identical across queries. Drift here is the bug that makes
+// sessionCounts and daily totals disagree.
+const usageMessageEligibility = `
+    m.token_usage != ''
+    AND m.model != ''
+    AND m.model != '<synthetic>'
+    AND s.deleted_at IS NULL`
+
 // DailyUsageEntry holds token counts and cost for one day.
 type DailyUsageEntry struct {
-	Date                string           `json:"date"`
-	InputTokens         int              `json:"inputTokens"`
-	OutputTokens        int              `json:"outputTokens"`
-	CacheCreationTokens int              `json:"cacheCreationTokens"`
-	CacheReadTokens     int              `json:"cacheReadTokens"`
-	TotalCost           float64          `json:"totalCost"`
-	ModelsUsed          []string         `json:"modelsUsed"`
-	ModelBreakdowns     []ModelBreakdown `json:"modelBreakdowns,omitempty"`
+	Date                string             `json:"date"`
+	InputTokens         int                `json:"inputTokens"`
+	OutputTokens        int                `json:"outputTokens"`
+	CacheCreationTokens int                `json:"cacheCreationTokens"`
+	CacheReadTokens     int                `json:"cacheReadTokens"`
+	TotalCost           float64            `json:"totalCost"`
+	ModelsUsed          []string           `json:"modelsUsed"`
+	ModelBreakdowns     []ModelBreakdown   `json:"modelBreakdowns,omitempty"`
+	ProjectBreakdowns   []ProjectBreakdown `json:"projectBreakdowns,omitempty"`
+	AgentBreakdowns     []AgentBreakdown   `json:"agentBreakdowns,omitempty"`
 }
 
 // ModelBreakdown holds per-model token and cost breakdown.
 type ModelBreakdown struct {
 	ModelName           string  `json:"modelName"`
+	InputTokens         int     `json:"inputTokens"`
+	OutputTokens        int     `json:"outputTokens"`
+	CacheCreationTokens int     `json:"cacheCreationTokens"`
+	CacheReadTokens     int     `json:"cacheReadTokens"`
+	Cost                float64 `json:"cost"`
+}
+
+// ProjectBreakdown is the per-project slice of a day's usage.
+type ProjectBreakdown struct {
+	Project             string  `json:"project"`
+	InputTokens         int     `json:"inputTokens"`
+	OutputTokens        int     `json:"outputTokens"`
+	CacheCreationTokens int     `json:"cacheCreationTokens"`
+	CacheReadTokens     int     `json:"cacheReadTokens"`
+	Cost                float64 `json:"cost"`
+}
+
+// AgentBreakdown is the per-agent slice of a day's usage.
+type AgentBreakdown struct {
+	Agent               string  `json:"agent"`
 	InputTokens         int     `json:"inputTokens"`
 	OutputTokens        int     `json:"outputTokens"`
 	CacheCreationTokens int     `json:"cacheCreationTokens"`
@@ -136,7 +233,22 @@ func (db *DB) GetDailyUsage(
 			fmt.Errorf("loading pricing: %w", err)
 	}
 
-	query := `
+	var query string
+	if f.Breakdowns {
+		query = `
+SELECT
+	COALESCE(m.timestamp, s.started_at) as ts,
+	m.model,
+	m.token_usage,
+	m.claude_message_id,
+	m.claude_request_id,
+	s.project,
+	s.agent
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE ` + usageMessageEligibility
+	} else {
+		query = `
 SELECT
 	COALESCE(m.timestamp, s.started_at) as ts,
 	m.model,
@@ -145,10 +257,8 @@ SELECT
 	m.claude_request_id
 FROM messages m
 JOIN sessions s ON m.session_id = s.id
-WHERE m.token_usage != ''
-	AND m.model != ''
-	AND m.model != '<synthetic>'
-	AND s.deleted_at IS NULL`
+WHERE ` + usageMessageEligibility
+	}
 
 	var args []any
 
@@ -166,10 +276,7 @@ WHERE m.token_usage != ''
 		query += " AND COALESCE(m.timestamp, s.started_at) <= ?"
 		args = append(args, padded)
 	}
-	if f.Agent != "" {
-		query += " AND s.agent = ?"
-		args = append(args, f.Agent)
-	}
+	query, args = f.appendFilterClauses(query, args)
 	query += ` ORDER BY COALESCE(m.timestamp, s.started_at) ASC,
 		m.session_id ASC, m.ordinal ASC`
 
@@ -180,12 +287,14 @@ WHERE m.token_usage != ''
 	}
 	defer rows.Close()
 
-	// dateModel key for per-(date, model) accumulation
-	type dateModelKey struct {
-		date  string
-		model string
+	// 4-tuple key for per-(date, project, agent, model) accumulation.
+	type accumKey struct {
+		date    string
+		project string
+		agent   string
+		model   string
 	}
-	type modelAccum struct {
+	type bucket struct {
 		inputTok  int
 		outputTok int
 		cacheCr   int
@@ -193,7 +302,7 @@ WHERE m.token_usage != ''
 		cost      float64
 	}
 
-	accum := make(map[dateModelKey]*modelAccum)
+	accum := make(map[accumKey]*bucket)
 
 	type dedupKey struct {
 		msgID, reqID string
@@ -206,11 +315,26 @@ WHERE m.token_usage != ''
 		tokenJSON string
 		msgID     string
 		reqID     string
+		project   string
+		agent     string
 	)
 	for rows.Next() {
-		if err := rows.Scan(&ts, &model, &tokenJSON, &msgID, &reqID); err != nil {
+		var scanErr error
+		if f.Breakdowns {
+			scanErr = rows.Scan(
+				&ts, &model, &tokenJSON,
+				&msgID, &reqID,
+				&project, &agent,
+			)
+		} else {
+			scanErr = rows.Scan(
+				&ts, &model, &tokenJSON,
+				&msgID, &reqID,
+			)
+		}
+		if scanErr != nil {
 			return DailyUsageResult{},
-				fmt.Errorf("scanning daily usage row: %w", err)
+				fmt.Errorf("scanning daily usage row: %w", scanErr)
 		}
 
 		date := localDate(ts, loc)
@@ -238,13 +362,15 @@ WHERE m.token_usage != ''
 		// yields its leading fields; a fully garbage row would
 		// return zeros, but that path is not reachable from
 		// any known parser. Skipping gjson.Valid here preserves
-		// the hot-path speedup (O(n) per row → not free on a
+		// the hot-path speedup (O(n) per row -> not free on a
 		// 310k-row scan).
 		usage := gjson.Parse(tokenJSON)
 		inputTok := int(usage.Get("input_tokens").Int())
 		outputTok := int(usage.Get("output_tokens").Int())
-		cacheCrTok := int(usage.Get("cache_creation_input_tokens").Int())
-		cacheRdTok := int(usage.Get("cache_read_input_tokens").Int())
+		cacheCrTok := int(
+			usage.Get("cache_creation_input_tokens").Int())
+		cacheRdTok := int(
+			usage.Get("cache_read_input_tokens").Int())
 
 		rates := pricing[model]
 		cost := (float64(inputTok)*rates.input +
@@ -252,38 +378,181 @@ WHERE m.token_usage != ''
 			float64(cacheCrTok)*rates.cacheCreation +
 			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
 
-		key := dateModelKey{date: date, model: model}
-		ma, ok := accum[key]
-		if !ok {
-			ma = &modelAccum{}
-			accum[key] = ma
+		key := accumKey{
+			date: date, project: project,
+			agent: agent, model: model,
 		}
-		ma.inputTok += inputTok
-		ma.outputTok += outputTok
-		ma.cacheCr += cacheCrTok
-		ma.cacheRd += cacheRdTok
-		ma.cost += cost
+		b, ok := accum[key]
+		if !ok {
+			b = &bucket{}
+			accum[key] = b
+		}
+		b.inputTok += inputTok
+		b.outputTok += outputTok
+		b.cacheCr += cacheCrTok
+		b.cacheRd += cacheRdTok
+		b.cost += cost
 	}
 	if err := rows.Err(); err != nil {
 		return DailyUsageResult{},
 			fmt.Errorf("iterating daily usage rows: %w", err)
 	}
 
-	// Group by date
-	type dayData struct {
-		models map[string]*modelAccum
-	}
-	days := make(map[string]*dayData)
-	for key, ma := range accum {
-		dd, ok := days[key.date]
-		if !ok {
-			dd = &dayData{models: make(map[string]*modelAccum)}
-			days[key.date] = dd
+	// Two paths: without breakdowns (CLI, fast) and with breakdowns
+	// (web UI). The fast path uses the original (date, model)
+	// grouping with no extra column reads. The breakdown path adds
+	// project/agent dimensions and builds three decomposition slices.
+
+	if !f.Breakdowns {
+		// Fast path: group by (date, model) only.
+		type dateModelKey struct {
+			date  string
+			model string
 		}
-		dd.models[key.model] = ma
+		type modelAccum struct {
+			inputTok  int
+			outputTok int
+			cacheCr   int
+			cacheRd   int
+			cost      float64
+		}
+		dm := make(map[dateModelKey]*modelAccum)
+		for key, b := range accum {
+			dmk := dateModelKey{date: key.date, model: key.model}
+			ma, ok := dm[dmk]
+			if !ok {
+				ma = &modelAccum{}
+				dm[dmk] = ma
+			}
+			ma.inputTok += b.inputTok
+			ma.outputTok += b.outputTok
+			ma.cacheCr += b.cacheCr
+			ma.cacheRd += b.cacheRd
+			ma.cost += b.cost
+		}
+
+		type dayData struct {
+			models map[string]*modelAccum
+		}
+		days := make(map[string]*dayData)
+		for key, ma := range dm {
+			dd, ok := days[key.date]
+			if !ok {
+				dd = &dayData{
+					models: make(map[string]*modelAccum),
+				}
+				days[key.date] = dd
+			}
+			dd.models[key.model] = ma
+		}
+
+		dateKeys := make([]string, 0, len(days))
+		for d := range days {
+			dateKeys = append(dateKeys, d)
+		}
+		sort.Strings(dateKeys)
+
+		daily := make([]DailyUsageEntry, 0, len(dateKeys))
+		var totals UsageTotals
+
+		for _, date := range dateKeys {
+			dd := days[date]
+			var entry DailyUsageEntry
+			entry.Date = date
+
+			modelNames := make([]string, 0, len(dd.models))
+			for m := range dd.models {
+				modelNames = append(modelNames, m)
+			}
+			sort.Slice(modelNames, func(i, j int) bool {
+				ci := dd.models[modelNames[i]].cost
+				cj := dd.models[modelNames[j]].cost
+				if ci != cj {
+					return ci > cj
+				}
+				return modelNames[i] < modelNames[j]
+			})
+			entry.ModelsUsed = modelNames
+			mbd := make(
+				[]ModelBreakdown, 0, len(modelNames),
+			)
+			for _, m := range modelNames {
+				ma := dd.models[m]
+				entry.InputTokens += ma.inputTok
+				entry.OutputTokens += ma.outputTok
+				entry.CacheCreationTokens += ma.cacheCr
+				entry.CacheReadTokens += ma.cacheRd
+				entry.TotalCost += ma.cost
+				mbd = append(mbd, ModelBreakdown{
+					ModelName:           m,
+					InputTokens:         ma.inputTok,
+					OutputTokens:        ma.outputTok,
+					CacheCreationTokens: ma.cacheCr,
+					CacheReadTokens:     ma.cacheRd,
+					Cost:                ma.cost,
+				})
+			}
+			entry.ModelBreakdowns = mbd
+			daily = append(daily, entry)
+
+			totals.InputTokens += entry.InputTokens
+			totals.OutputTokens += entry.OutputTokens
+			totals.CacheCreationTokens += entry.CacheCreationTokens
+			totals.CacheReadTokens += entry.CacheReadTokens
+			totals.TotalCost += entry.TotalCost
+		}
+
+		if daily == nil {
+			daily = []DailyUsageEntry{}
+		}
+		return DailyUsageResult{
+			Daily:  daily,
+			Totals: totals,
+		}, nil
 	}
 
-	// Sort dates ascending
+	// Breakdown path: single walk builds model/project/agent maps.
+	type dayMaps struct {
+		models   map[string]bucket
+		projects map[string]bucket
+		agents   map[string]bucket
+	}
+	days := make(map[string]*dayMaps, 64)
+	for key, b := range accum {
+		dm, ok := days[key.date]
+		if !ok {
+			dm = &dayMaps{
+				models:   make(map[string]bucket, 4),
+				projects: make(map[string]bucket, 8),
+				agents:   make(map[string]bucket, 4),
+			}
+			days[key.date] = dm
+		}
+		cur := dm.models[key.model]
+		cur.inputTok += b.inputTok
+		cur.outputTok += b.outputTok
+		cur.cacheCr += b.cacheCr
+		cur.cacheRd += b.cacheRd
+		cur.cost += b.cost
+		dm.models[key.model] = cur
+
+		cur = dm.projects[key.project]
+		cur.inputTok += b.inputTok
+		cur.outputTok += b.outputTok
+		cur.cacheCr += b.cacheCr
+		cur.cacheRd += b.cacheRd
+		cur.cost += b.cost
+		dm.projects[key.project] = cur
+
+		cur = dm.agents[key.agent]
+		cur.inputTok += b.inputTok
+		cur.outputTok += b.outputTok
+		cur.cacheCr += b.cacheCr
+		cur.cacheRd += b.cacheRd
+		cur.cost += b.cost
+		dm.agents[key.agent] = cur
+	}
+
 	dateKeys := make([]string, 0, len(days))
 	for d := range days {
 		dateKeys = append(dateKeys, d)
@@ -294,45 +563,86 @@ WHERE m.token_usage != ''
 	var totals UsageTotals
 
 	for _, date := range dateKeys {
-		dd := days[date]
-
+		dm := days[date]
 		var entry DailyUsageEntry
 		entry.Date = date
 
-		// Sort models by cost descending
-		modelNames := make([]string, 0, len(dd.models))
-		for m := range dd.models {
+		modelNames := make([]string, 0, len(dm.models))
+		for m := range dm.models {
 			modelNames = append(modelNames, m)
 		}
 		sort.Slice(modelNames, func(i, j int) bool {
-			return dd.models[modelNames[i]].cost >
-				dd.models[modelNames[j]].cost
+			ci := dm.models[modelNames[i]].cost
+			cj := dm.models[modelNames[j]].cost
+			if ci != cj {
+				return ci > cj
+			}
+			return modelNames[i] < modelNames[j]
 		})
-
 		entry.ModelsUsed = modelNames
-		breakdowns := make(
+		mbd := make(
 			[]ModelBreakdown, 0, len(modelNames),
 		)
-
-		for _, model := range modelNames {
-			ma := dd.models[model]
-			entry.InputTokens += ma.inputTok
-			entry.OutputTokens += ma.outputTok
-			entry.CacheCreationTokens += ma.cacheCr
-			entry.CacheReadTokens += ma.cacheRd
-			entry.TotalCost += ma.cost
-
-			breakdowns = append(breakdowns, ModelBreakdown{
-				ModelName:           model,
-				InputTokens:         ma.inputTok,
-				OutputTokens:        ma.outputTok,
-				CacheCreationTokens: ma.cacheCr,
-				CacheReadTokens:     ma.cacheRd,
-				Cost:                ma.cost,
+		for _, m := range modelNames {
+			b := dm.models[m]
+			entry.InputTokens += b.inputTok
+			entry.OutputTokens += b.outputTok
+			entry.CacheCreationTokens += b.cacheCr
+			entry.CacheReadTokens += b.cacheRd
+			entry.TotalCost += b.cost
+			mbd = append(mbd, ModelBreakdown{
+				ModelName:           m,
+				InputTokens:         b.inputTok,
+				OutputTokens:        b.outputTok,
+				CacheCreationTokens: b.cacheCr,
+				CacheReadTokens:     b.cacheRd,
+				Cost:                b.cost,
 			})
 		}
+		entry.ModelBreakdowns = mbd
 
-		entry.ModelBreakdowns = breakdowns
+		pbd := make(
+			[]ProjectBreakdown, 0, len(dm.projects),
+		)
+		for p, b := range dm.projects {
+			pbd = append(pbd, ProjectBreakdown{
+				Project:             p,
+				InputTokens:         b.inputTok,
+				OutputTokens:        b.outputTok,
+				CacheCreationTokens: b.cacheCr,
+				CacheReadTokens:     b.cacheRd,
+				Cost:                b.cost,
+			})
+		}
+		sort.Slice(pbd, func(i, j int) bool {
+			if pbd[i].Cost != pbd[j].Cost {
+				return pbd[i].Cost > pbd[j].Cost
+			}
+			return pbd[i].Project < pbd[j].Project
+		})
+		entry.ProjectBreakdowns = pbd
+
+		abd := make(
+			[]AgentBreakdown, 0, len(dm.agents),
+		)
+		for a, b := range dm.agents {
+			abd = append(abd, AgentBreakdown{
+				Agent:               a,
+				InputTokens:         b.inputTok,
+				OutputTokens:        b.outputTok,
+				CacheCreationTokens: b.cacheCr,
+				CacheReadTokens:     b.cacheRd,
+				Cost:                b.cost,
+			})
+		}
+		sort.Slice(abd, func(i, j int) bool {
+			if abd[i].Cost != abd[j].Cost {
+				return abd[i].Cost > abd[j].Cost
+			}
+			return abd[i].Agent < abd[j].Agent
+		})
+		entry.AgentBreakdowns = abd
+
 		daily = append(daily, entry)
 
 		totals.InputTokens += entry.InputTokens
@@ -350,4 +660,282 @@ WHERE m.token_usage != ''
 		Daily:  daily,
 		Totals: totals,
 	}, nil
+}
+
+// TopSessionEntry is one row in the "top sessions by cost" result.
+type TopSessionEntry struct {
+	SessionID   string  `json:"sessionId"`
+	DisplayName string  `json:"displayName"`
+	Agent       string  `json:"agent"`
+	Project     string  `json:"project"`
+	StartedAt   string  `json:"startedAt"`
+	TotalTokens int     `json:"totalTokens"`
+	Cost        float64 `json:"cost"`
+}
+
+// GetTopSessionsByCost returns sessions ranked by total cost
+// over the filter range. Default limit 20, max 100.
+func (db *DB) GetTopSessionsByCost(
+	ctx context.Context, f UsageFilter, limit int,
+) ([]TopSessionEntry, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	pricing, err := db.loadPricingMap(ctx)
+	if err != nil {
+		return nil,
+			fmt.Errorf("loading pricing: %w", err)
+	}
+
+	query := `
+SELECT
+	s.id,
+	COALESCE(s.display_name, s.id),
+	s.agent,
+	s.project,
+	COALESCE(s.started_at, ''),
+	m.model,
+	m.token_usage,
+	COALESCE(m.timestamp, s.started_at) as ts
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE ` + usageMessageEligibility
+
+	var args []any
+
+	if f.From != "" {
+		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
+		query += " AND COALESCE(m.timestamp, s.started_at) >= ?"
+		args = append(args, padded)
+	}
+	if f.To != "" {
+		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
+		query += " AND COALESCE(m.timestamp, s.started_at) <= ?"
+		args = append(args, padded)
+	}
+	query, args = f.appendFilterClauses(query, args)
+
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil,
+			fmt.Errorf("querying top sessions: %w", err)
+	}
+	defer rows.Close()
+
+	loc := f.location()
+
+	type sessAccum struct {
+		displayName string
+		agent       string
+		project     string
+		startedAt   string
+		totalTokens int
+		cost        float64
+	}
+
+	accum := make(map[string]*sessAccum)
+	// Track insertion order for stable iteration.
+	var order []string
+
+	var (
+		sid         string
+		displayName string
+		agent       string
+		project     string
+		startedAt   string
+		model       string
+		tokenJSON   string
+		ts          string
+	)
+	for rows.Next() {
+		if err := rows.Scan(
+			&sid, &displayName, &agent, &project,
+			&startedAt, &model, &tokenJSON, &ts,
+		); err != nil {
+			return nil,
+				fmt.Errorf("scanning top sessions row: %w", err)
+		}
+
+		// Post-query date filter (same as GetDailyUsage).
+		date := localDate(ts, loc)
+		if f.From != "" && date < f.From {
+			continue
+		}
+		if f.To != "" && date > f.To {
+			continue
+		}
+
+		usage := gjson.Parse(tokenJSON)
+		inputTok := int(usage.Get("input_tokens").Int())
+		outputTok := int(usage.Get("output_tokens").Int())
+		cacheCrTok := int(
+			usage.Get("cache_creation_input_tokens").Int())
+		cacheRdTok := int(
+			usage.Get("cache_read_input_tokens").Int())
+
+		rates := pricing[model]
+		cost := (float64(inputTok)*rates.input +
+			float64(outputTok)*rates.output +
+			float64(cacheCrTok)*rates.cacheCreation +
+			float64(cacheRdTok)*rates.cacheRead) / 1_000_000
+
+		sa, ok := accum[sid]
+		if !ok {
+			sa = &sessAccum{
+				displayName: displayName,
+				agent:       agent,
+				project:     project,
+				startedAt:   startedAt,
+			}
+			accum[sid] = sa
+			order = append(order, sid)
+		}
+		sa.totalTokens += inputTok + outputTok +
+			cacheCrTok + cacheRdTok
+		sa.cost += cost
+	}
+	if err := rows.Err(); err != nil {
+		return nil,
+			fmt.Errorf("iterating top sessions rows: %w", err)
+	}
+
+	result := make([]TopSessionEntry, 0, len(order))
+	for _, id := range order {
+		sa := accum[id]
+		result = append(result, TopSessionEntry{
+			SessionID:   id,
+			DisplayName: sa.displayName,
+			Agent:       sa.agent,
+			Project:     sa.project,
+			StartedAt:   sa.startedAt,
+			TotalTokens: sa.totalTokens,
+			Cost:        sa.cost,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Cost != result[j].Cost {
+			return result[i].Cost > result[j].Cost
+		}
+		return result[i].SessionID < result[j].SessionID
+	})
+
+	if len(result) > limit {
+		result = result[:limit]
+	}
+
+	return result, nil
+}
+
+// UsageSessionCounts holds distinct session counts grouped by
+// project and agent over a filter range.
+type UsageSessionCounts struct {
+	Total     int            `json:"total"`
+	ByProject map[string]int `json:"byProject"`
+	ByAgent   map[string]int `json:"byAgent"`
+}
+
+// GetUsageSessionCounts returns distinct session counts grouped
+// by project and agent. Sessions spanning multiple days count
+// once. Soft-deleted sessions are excluded via
+// usageMessageEligibility.
+//
+// Like GetDailyUsage and GetTopSessionsByCost, this query pads
+// the UTC bounds by +/-14h and applies a post-query localDate
+// filter so timezone-boundary messages are counted correctly.
+func (db *DB) GetUsageSessionCounts(
+	ctx context.Context, f UsageFilter,
+) (UsageSessionCounts, error) {
+	query := `
+SELECT
+	s.id,
+	s.project,
+	s.agent,
+	COALESCE(m.timestamp, s.started_at) as ts
+FROM messages m
+JOIN sessions s ON m.session_id = s.id
+WHERE ` + usageMessageEligibility
+
+	var args []any
+
+	if f.From != "" {
+		padded := paddedUTCBound(f.From+"T00:00:00Z", -14)
+		query += " AND COALESCE(m.timestamp, s.started_at) >= ?"
+		args = append(args, padded)
+	}
+	if f.To != "" {
+		padded := paddedUTCBound(f.To+"T23:59:59Z", 14)
+		query += " AND COALESCE(m.timestamp, s.started_at) <= ?"
+		args = append(args, padded)
+	}
+	query, args = f.appendFilterClauses(query, args)
+
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
+	if err != nil {
+		return UsageSessionCounts{},
+			fmt.Errorf("querying session counts: %w", err)
+	}
+	defer rows.Close()
+
+	loc := f.location()
+
+	// Track which sessions pass the localDate filter via a
+	// set of seen session IDs. Each session is counted once
+	// regardless of how many qualifying messages it has.
+	type sessInfo struct {
+		project string
+		agent   string
+	}
+	seen := make(map[string]sessInfo)
+
+	var (
+		sid     string
+		project string
+		agent   string
+		ts      string
+	)
+	for rows.Next() {
+		if err := rows.Scan(
+			&sid, &project, &agent, &ts,
+		); err != nil {
+			return UsageSessionCounts{},
+				fmt.Errorf("scanning session counts: %w", err)
+		}
+
+		// Post-query date filter (same as GetDailyUsage).
+		date := localDate(ts, loc)
+		if f.From != "" && date < f.From {
+			continue
+		}
+		if f.To != "" && date > f.To {
+			continue
+		}
+
+		if _, ok := seen[sid]; !ok {
+			seen[sid] = sessInfo{
+				project: project,
+				agent:   agent,
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return UsageSessionCounts{},
+			fmt.Errorf("iterating session counts: %w", err)
+	}
+
+	out := UsageSessionCounts{
+		Total:     len(seen),
+		ByProject: make(map[string]int),
+		ByAgent:   make(map[string]int),
+	}
+	for _, info := range seen {
+		out.ByProject[info.project]++
+		out.ByAgent[info.agent]++
+	}
+
+	return out, nil
 }

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -1054,6 +1054,117 @@ func TestGetTopSessionsByCost(t *testing.T) {
 	}
 }
 
+// TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID
+// mirrors TestGetDailyUsage_DedupesByClaudeMessageAndRequestID
+// for the top-sessions query: a parent session and a forked
+// session that both replay the same Claude message should only
+// count that message once in the per-session totals. The
+// earliest-timestamp session wins the credit.
+func TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:         "claude-sonnet",
+		InputPerMTok:         3.0,
+		OutputPerMTok:        15.0,
+		CacheCreationPerMTok: 3.75,
+		CacheReadPerMTok:     0.30,
+	}}), "UpsertModelPricing")
+
+	// Parent session starts first.
+	insertSession(t, d, "s-parent", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	// Forked session starts a minute later.
+	insertSession(t, d, "s-fork", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:01:00Z")
+		s.ParentSessionID = Ptr("s-parent")
+		s.RelationshipType = "fork"
+	})
+
+	shared := json.RawMessage(
+		`{"input_tokens":1000,"output_tokens":500,` +
+			`"cache_creation_input_tokens":200,` +
+			`"cache_read_input_tokens":3000}`)
+	unique := json.RawMessage(
+		`{"input_tokens":10,"output_tokens":20,` +
+			`"cache_creation_input_tokens":0,` +
+			`"cache_read_input_tokens":0}`)
+
+	// The shared message exists on both sessions with the same
+	// Claude IDs; the parent's timestamp is earlier so it should
+	// win the dedup.
+	insertMessages(t, d, Message{
+		SessionID: "s-parent", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:02:00Z",
+		Model: "claude-sonnet", TokenUsage: shared,
+		ClaudeMessageID: "msg_dup", ClaudeRequestID: "req_dup",
+	})
+	insertMessages(t, d, Message{
+		SessionID: "s-fork", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:03:00Z",
+		Model: "claude-sonnet", TokenUsage: shared,
+		ClaudeMessageID: "msg_dup", ClaudeRequestID: "req_dup",
+	})
+	// Plus a unique fork-only message so the fork still appears.
+	insertMessages(t, d, Message{
+		SessionID: "s-fork", Ordinal: 1,
+		Role: "assistant", Timestamp: "2024-06-15T10:04:00Z",
+		Model: "claude-sonnet", TokenUsage: unique,
+		ClaudeMessageID: "msg_uniq", ClaudeRequestID: "req_uniq",
+	})
+
+	top, err := d.GetTopSessionsByCost(ctx, UsageFilter{
+		From: "2024-06-15", To: "2024-06-15", Timezone: "UTC",
+	}, 20)
+	requireNoError(t, err, "GetTopSessionsByCost")
+
+	if len(top) != 2 {
+		t.Fatalf("got %d entries, want 2", len(top))
+	}
+
+	byID := map[string]TopSessionEntry{}
+	for _, e := range top {
+		byID[e.SessionID] = e
+	}
+
+	parent, ok := byID["s-parent"]
+	if !ok {
+		t.Fatal("s-parent missing from top sessions")
+	}
+	// Parent owns shared: 1000+500+200+3000 = 4700 tokens.
+	if parent.TotalTokens != 4700 {
+		t.Errorf("parent.TotalTokens = %d, want 4700",
+			parent.TotalTokens)
+	}
+
+	fork, ok := byID["s-fork"]
+	if !ok {
+		t.Fatal("s-fork missing from top sessions")
+	}
+	// Fork should only own the unique message: 10+20 = 30
+	// tokens. If the dedup were missing, the shared row would
+	// be counted again and this would jump to 4730.
+	if fork.TotalTokens != 30 {
+		t.Errorf("fork.TotalTokens = %d, want 30 "+
+			"(shared message should be deduped)",
+			fork.TotalTokens)
+	}
+
+	// Total across both entries must equal the undeduped
+	// message sum: parent 4700 + fork 30 = 4730.
+	total := parent.TotalTokens + fork.TotalTokens
+	if total != 4730 {
+		t.Errorf("sum of per-session totals = %d, want 4730",
+			total)
+	}
+}
+
 func TestGetTopSessionsByCostLimit(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"math"
+	"strconv"
 	"testing"
+	"time"
 )
 
 func TestGetDailyUsageEmpty(t *testing.T) {
@@ -589,5 +591,952 @@ func TestGetDailyUsageLongLivedSession(t *testing.T) {
 	if result.Daily[0].InputTokens != 2000 {
 		t.Errorf("InputTokens = %d, want 2000",
 			result.Daily[0].InputTokens)
+	}
+}
+
+func TestGetDailyUsageProjectFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "sess-a", "proj-a", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:  "sess-a",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2024-06-15T10:30:00Z",
+		Model:      "claude-sonnet",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	insertSession(t, d, "sess-b", "proj-b", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:  "sess-b",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2024-06-15T10:30:00Z",
+		Model:      "claude-sonnet",
+		TokenUsage: json.RawMessage(`{"input_tokens":2000,"output_tokens":1000}`),
+	})
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From:    "2024-06-01",
+		To:      "2024-06-30",
+		Project: "proj-a",
+	})
+	requireNoError(t, err, "GetDailyUsage project filter")
+
+	if len(result.Daily) != 1 {
+		t.Fatalf("got %d daily entries, want 1",
+			len(result.Daily))
+	}
+	day := result.Daily[0]
+	if day.InputTokens != 1000 {
+		t.Errorf("InputTokens = %d, want 1000 (proj-a only)",
+			day.InputTokens)
+	}
+	if result.Totals.InputTokens != 1000 {
+		t.Errorf("Totals.InputTokens = %d, want 1000",
+			result.Totals.InputTokens)
+	}
+}
+
+func TestGetDailyUsageModelFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{
+		{ModelPattern: "claude-sonnet", InputPerMTok: 3.0,
+			OutputPerMTok: 15.0},
+		{ModelPattern: "gpt-5", InputPerMTok: 2.5,
+			OutputPerMTok: 10.0},
+	}), "UpsertModelPricing")
+
+	insertSession(t, d, "sess1", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d,
+		Message{
+			SessionID:  "sess1",
+			Ordinal:    0,
+			Role:       "assistant",
+			Timestamp:  "2024-06-15T10:30:00Z",
+			Model:      "claude-sonnet",
+			TokenUsage: json.RawMessage(`{"input_tokens":2000,"output_tokens":800}`),
+		},
+		Message{
+			SessionID:  "sess1",
+			Ordinal:    1,
+			Role:       "assistant",
+			Timestamp:  "2024-06-15T10:31:00Z",
+			Model:      "gpt-5",
+			TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+		},
+	)
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From:  "2024-06-01",
+		To:    "2024-06-30",
+		Model: "gpt-5",
+	})
+	requireNoError(t, err, "GetDailyUsage model filter")
+
+	if len(result.Daily) != 1 {
+		t.Fatalf("got %d daily entries, want 1",
+			len(result.Daily))
+	}
+	day := result.Daily[0]
+	if day.InputTokens != 1000 {
+		t.Errorf("InputTokens = %d, want 1000 (gpt-5 only)",
+			day.InputTokens)
+	}
+	if len(day.ModelsUsed) != 1 || day.ModelsUsed[0] != "gpt-5" {
+		t.Errorf("ModelsUsed = %v, want [gpt-5]",
+			day.ModelsUsed)
+	}
+}
+
+func TestGetDailyUsageProjectBreakdowns(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "sess-a", "proj-a", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:  "sess-a",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2024-06-15T10:30:00Z",
+		Model:      "claude-sonnet",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	insertSession(t, d, "sess-b", "proj-b", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:  "sess-b",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2024-06-15T10:30:00Z",
+		Model:      "claude-sonnet",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From:       "2024-06-01",
+		To:         "2024-06-30",
+		Breakdowns: true,
+	})
+	requireNoError(t, err, "GetDailyUsage project breakdowns")
+
+	if len(result.Daily) != 1 {
+		t.Fatalf("got %d daily entries, want 1",
+			len(result.Daily))
+	}
+	day := result.Daily[0]
+	if len(day.ProjectBreakdowns) != 2 {
+		t.Fatalf("ProjectBreakdowns len = %d, want 2",
+			len(day.ProjectBreakdowns))
+	}
+
+	projMap := make(map[string]ProjectBreakdown)
+	var projCostSum float64
+	for _, pb := range day.ProjectBreakdowns {
+		projMap[pb.Project] = pb
+		projCostSum += pb.Cost
+	}
+	for _, name := range []string{"proj-a", "proj-b"} {
+		pb, ok := projMap[name]
+		if !ok {
+			t.Errorf("missing ProjectBreakdown for %s", name)
+			continue
+		}
+		if pb.InputTokens != 1000 {
+			t.Errorf("%s InputTokens = %d, want 1000",
+				name, pb.InputTokens)
+		}
+	}
+	if math.Abs(projCostSum-day.TotalCost) > 1e-9 {
+		t.Errorf("sum(ProjectBreakdowns.Cost) = %v, "+
+			"want TotalCost = %v", projCostSum, day.TotalCost)
+	}
+}
+
+func TestGetDailyUsageAgentBreakdowns(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "sess-claude", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:  "sess-claude",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2024-06-15T10:30:00Z",
+		Model:      "claude-sonnet",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	insertSession(t, d, "sess-codex", "proj1", func(s *Session) {
+		s.Agent = "codex"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:  "sess-codex",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2024-06-15T10:30:00Z",
+		Model:      "claude-sonnet",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From:       "2024-06-01",
+		To:         "2024-06-30",
+		Breakdowns: true,
+	})
+	requireNoError(t, err, "GetDailyUsage agent breakdowns")
+
+	if len(result.Daily) != 1 {
+		t.Fatalf("got %d daily entries, want 1",
+			len(result.Daily))
+	}
+	day := result.Daily[0]
+	if len(day.AgentBreakdowns) != 2 {
+		t.Fatalf("AgentBreakdowns len = %d, want 2",
+			len(day.AgentBreakdowns))
+	}
+
+	agentMap := make(map[string]AgentBreakdown)
+	var agentCostSum float64
+	for _, ab := range day.AgentBreakdowns {
+		agentMap[ab.Agent] = ab
+		agentCostSum += ab.Cost
+	}
+	for _, name := range []string{"claude", "codex"} {
+		ab, ok := agentMap[name]
+		if !ok {
+			t.Errorf("missing AgentBreakdown for %s", name)
+			continue
+		}
+		if ab.InputTokens != 1000 {
+			t.Errorf("%s InputTokens = %d, want 1000",
+				name, ab.InputTokens)
+		}
+	}
+	if math.Abs(agentCostSum-day.TotalCost) > 1e-9 {
+		t.Errorf("sum(AgentBreakdowns.Cost) = %v, "+
+			"want TotalCost = %v", agentCostSum, day.TotalCost)
+	}
+}
+
+func TestGetDailyUsageBreakdownInvariant(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{
+		{ModelPattern: "model-a", InputPerMTok: 2.0,
+			OutputPerMTok: 10.0},
+		{ModelPattern: "model-b", InputPerMTok: 4.0,
+			OutputPerMTok: 20.0},
+	}), "UpsertModelPricing")
+
+	// 2 projects x 2 agents = 4 sessions, each with 2 messages
+	// from different models.
+	type combo struct {
+		project string
+		agent   string
+	}
+	combos := []combo{
+		{"proj-a", "claude"},
+		{"proj-a", "codex"},
+		{"proj-b", "claude"},
+		{"proj-b", "codex"},
+	}
+	for i, c := range combos {
+		sid := "sess-" + strconv.Itoa(i)
+		insertSession(t, d, sid, c.project, func(s *Session) {
+			s.Agent = c.agent
+			s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		})
+		insertMessages(t, d,
+			Message{
+				SessionID:  sid,
+				Ordinal:    0,
+				Role:       "assistant",
+				Timestamp:  "2024-06-15T10:30:00Z",
+				Model:      "model-a",
+				TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+			},
+			Message{
+				SessionID:  sid,
+				Ordinal:    1,
+				Role:       "assistant",
+				Timestamp:  "2024-06-15T10:31:00Z",
+				Model:      "model-b",
+				TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+			},
+		)
+	}
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From:       "2024-06-01",
+		To:         "2024-06-30",
+		Breakdowns: true,
+	})
+	requireNoError(t, err, "GetDailyUsage breakdown invariant")
+
+	if len(result.Daily) != 1 {
+		t.Fatalf("got %d daily entries, want 1",
+			len(result.Daily))
+	}
+	day := result.Daily[0]
+
+	var modelCostSum float64
+	for _, mb := range day.ModelBreakdowns {
+		modelCostSum += mb.Cost
+	}
+	var projectCostSum float64
+	for _, pb := range day.ProjectBreakdowns {
+		projectCostSum += pb.Cost
+	}
+	var agentCostSum float64
+	for _, ab := range day.AgentBreakdowns {
+		agentCostSum += ab.Cost
+	}
+
+	if math.Abs(modelCostSum-day.TotalCost) > 1e-9 {
+		t.Errorf("sum(ModelBreakdowns.Cost) = %v, "+
+			"want TotalCost = %v", modelCostSum, day.TotalCost)
+	}
+	if math.Abs(projectCostSum-day.TotalCost) > 1e-9 {
+		t.Errorf("sum(ProjectBreakdowns.Cost) = %v, "+
+			"want TotalCost = %v", projectCostSum, day.TotalCost)
+	}
+	if math.Abs(agentCostSum-day.TotalCost) > 1e-9 {
+		t.Errorf("sum(AgentBreakdowns.Cost) = %v, "+
+			"want TotalCost = %v", agentCostSum, day.TotalCost)
+	}
+	if math.Abs(modelCostSum-projectCostSum) > 1e-9 {
+		t.Errorf("model cost sum %v != project cost sum %v",
+			modelCostSum, projectCostSum)
+	}
+	if math.Abs(modelCostSum-agentCostSum) > 1e-9 {
+		t.Errorf("model cost sum %v != agent cost sum %v",
+			modelCostSum, agentCostSum)
+	}
+}
+
+// BenchmarkGetDailyUsage measures the hot-path scan over a realistic
+// synthetic dataset. The baseline number (captured against the commit
+// that introduces this benchmark) is the non-regression budget for all
+// subsequent changes to GetDailyUsage: new code must land within +10%.
+//
+// See docs/specs/2026-04-12-token-usage-ui-design.md for the full
+// non-destructive benchmark procedure.
+func TestGetTopSessionsByCost(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:         "claude-sonnet",
+		InputPerMTok:         3.0,
+		OutputPerMTok:        15.0,
+		CacheCreationPerMTok: 3.75,
+		CacheReadPerMTok:     0.30,
+	}}), "UpsertModelPricing")
+
+	// Expensive session
+	insertSession(t, d, "sBig", "proj-a", func(s *Session) {
+		s.Agent = "claude"
+		s.DisplayName = Ptr("Big Session")
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "sBig", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:30:00Z",
+		Model: "claude-sonnet",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":5000,"output_tokens":2000,` +
+				`"cache_creation_input_tokens":1000,` +
+				`"cache_read_input_tokens":3000}`),
+	})
+
+	// Cheap session
+	insertSession(t, d, "sSmall", "proj-b", func(s *Session) {
+		s.Agent = "codex"
+		s.DisplayName = Ptr("Small Session")
+		s.StartedAt = Ptr("2024-06-15T11:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "sSmall", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T11:30:00Z",
+		Model: "claude-sonnet",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":100,"output_tokens":50,` +
+				`"cache_creation_input_tokens":10,` +
+				`"cache_read_input_tokens":20}`),
+	})
+
+	top, err := d.GetTopSessionsByCost(ctx, UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	}, 20)
+	requireNoError(t, err, "GetTopSessionsByCost")
+
+	if len(top) != 2 {
+		t.Fatalf("got %d entries, want 2", len(top))
+	}
+
+	// Ordered cost desc — sBig first
+	if top[0].SessionID != "sBig" {
+		t.Errorf("top[0].SessionID = %q, want sBig",
+			top[0].SessionID)
+	}
+	if top[0].DisplayName != "Big Session" {
+		t.Errorf("top[0].DisplayName = %q, want Big Session",
+			top[0].DisplayName)
+	}
+	if top[0].Project != "proj-a" {
+		t.Errorf("top[0].Project = %q, want proj-a",
+			top[0].Project)
+	}
+	if top[0].Agent != "claude" {
+		t.Errorf("top[0].Agent = %q, want claude",
+			top[0].Agent)
+	}
+	// TotalTokens = 5000 + 2000 + 1000 + 3000 = 11000
+	if top[0].TotalTokens != 11000 {
+		t.Errorf("top[0].TotalTokens = %d, want 11000",
+			top[0].TotalTokens)
+	}
+	if top[0].Cost <= 0 {
+		t.Errorf("top[0].Cost = %v, want > 0", top[0].Cost)
+	}
+
+	if top[1].SessionID != "sSmall" {
+		t.Errorf("top[1].SessionID = %q, want sSmall",
+			top[1].SessionID)
+	}
+	if top[0].Cost <= top[1].Cost {
+		t.Errorf("top[0].Cost (%v) should be > top[1].Cost (%v)",
+			top[0].Cost, top[1].Cost)
+	}
+}
+
+func TestGetTopSessionsByCostLimit(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	for i := range 5 {
+		sid := "sess-" + strconv.Itoa(i)
+		insertSession(t, d, sid, "proj", func(s *Session) {
+			s.Agent = "claude"
+			s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+		})
+		insertMessages(t, d, Message{
+			SessionID: sid, Ordinal: 0,
+			Role: "assistant", Timestamp: "2024-06-15T10:30:00Z",
+			Model: "claude-sonnet",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":1000,"output_tokens":500}`),
+		})
+	}
+
+	top, err := d.GetTopSessionsByCost(ctx, UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	}, 3)
+	requireNoError(t, err, "GetTopSessionsByCost limit")
+
+	if len(top) != 3 {
+		t.Fatalf("got %d entries, want 3", len(top))
+	}
+}
+
+func TestGetUsageSessionCounts(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	// s1: proj-a / claude — TWO messages across TWO days
+	insertSession(t, d, "s1", "proj-a", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d,
+		Message{
+			SessionID: "s1", Ordinal: 0,
+			Role: "assistant", Timestamp: "2024-06-15T10:30:00Z",
+			Model: "claude-sonnet",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":100,"output_tokens":50}`),
+		},
+		Message{
+			SessionID: "s1", Ordinal: 1,
+			Role: "assistant", Timestamp: "2024-06-16T10:30:00Z",
+			Model: "claude-sonnet",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":200,"output_tokens":100}`),
+		},
+	)
+
+	// s2: proj-a / codex
+	insertSession(t, d, "s2", "proj-a", func(s *Session) {
+		s.Agent = "codex"
+		s.StartedAt = Ptr("2024-06-15T11:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "s2", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T11:30:00Z",
+		Model: "claude-sonnet",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":100,"output_tokens":50}`),
+	})
+
+	// s3: proj-b / claude
+	insertSession(t, d, "s3", "proj-b", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T12:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "s3", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T12:30:00Z",
+		Model: "claude-sonnet",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":100,"output_tokens":50}`),
+	})
+
+	counts, err := d.GetUsageSessionCounts(ctx, UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	})
+	requireNoError(t, err, "GetUsageSessionCounts")
+
+	if counts.Total != 3 {
+		t.Errorf("Total = %d, want 3", counts.Total)
+	}
+	if counts.ByProject["proj-a"] != 2 {
+		t.Errorf("ByProject[proj-a] = %d, want 2",
+			counts.ByProject["proj-a"])
+	}
+	if counts.ByProject["proj-b"] != 1 {
+		t.Errorf("ByProject[proj-b] = %d, want 1",
+			counts.ByProject["proj-b"])
+	}
+	if counts.ByAgent["claude"] != 2 {
+		t.Errorf("ByAgent[claude] = %d, want 2",
+			counts.ByAgent["claude"])
+	}
+	if counts.ByAgent["codex"] != 1 {
+		t.Errorf("ByAgent[codex] = %d, want 1",
+			counts.ByAgent["codex"])
+	}
+}
+
+// TestUsageQueryEligibilityParity seeds messages that fail each
+// disqualification predicate and asserts all three usage queries
+// ignore them. Guardrail against drift between usage queries.
+func TestUsageQueryEligibilityParity(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	// Good session — should be visible to all queries.
+	insertSession(t, d, "good", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "good", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:30:00Z",
+		Model: "claude-sonnet",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	// Bad: empty token_usage
+	insertSession(t, d, "bad-empty", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "bad-empty", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:30:00Z",
+		Model:      "claude-sonnet",
+		TokenUsage: json.RawMessage(""),
+	})
+
+	// Bad: synthetic model
+	insertSession(t, d, "bad-synth", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "bad-synth", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:30:00Z",
+		Model: "<synthetic>",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":999,"output_tokens":999}`),
+	})
+
+	// Bad: soft-deleted session
+	insertSession(t, d, "bad-deleted", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "bad-deleted", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:30:00Z",
+		Model: "claude-sonnet",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":999,"output_tokens":999}`),
+	})
+	requireNoError(t,
+		d.SoftDeleteSession("bad-deleted"),
+		"SoftDeleteSession")
+
+	filter := UsageFilter{
+		From:       "2024-06-01",
+		To:         "2024-06-30",
+		Breakdowns: true,
+	}
+
+	// GetDailyUsage
+	daily, err := d.GetDailyUsage(ctx, filter)
+	requireNoError(t, err, "GetDailyUsage parity")
+	if daily.Totals.InputTokens != 1000 {
+		t.Errorf("GetDailyUsage InputTokens = %d, want 1000",
+			daily.Totals.InputTokens)
+	}
+
+	// GetUsageSessionCounts
+	counts, err := d.GetUsageSessionCounts(ctx, filter)
+	requireNoError(t, err, "GetUsageSessionCounts parity")
+	if counts.Total != 1 {
+		t.Errorf("GetUsageSessionCounts Total = %d, want 1",
+			counts.Total)
+	}
+
+	// GetTopSessionsByCost
+	top, err := d.GetTopSessionsByCost(ctx, filter, 20)
+	requireNoError(t, err, "GetTopSessionsByCost parity")
+	if len(top) != 1 {
+		t.Fatalf("GetTopSessionsByCost len = %d, want 1",
+			len(top))
+	}
+	if top[0].SessionID != "good" {
+		t.Errorf("GetTopSessionsByCost[0].SessionID = %q, "+
+			"want good", top[0].SessionID)
+	}
+}
+
+// TestExcludeProjectFilter verifies that ExcludeProject removes
+// matching projects from all three usage queries.
+func TestExcludeProjectFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "sA", "proj-a", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertSession(t, d, "sB", "proj-b", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertSession(t, d, "sC", "proj-c", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+
+	usage := `{"input_tokens":1000,"output_tokens":500}`
+	insertMessages(t, d,
+		Message{SessionID: "sA", Ordinal: 0, Role: "assistant",
+			Timestamp: "2024-06-15T10:30:00Z", Model: "claude-sonnet",
+			TokenUsage: json.RawMessage(usage)},
+		Message{SessionID: "sB", Ordinal: 0, Role: "assistant",
+			Timestamp: "2024-06-15T10:30:00Z", Model: "claude-sonnet",
+			TokenUsage: json.RawMessage(usage)},
+		Message{SessionID: "sC", Ordinal: 0, Role: "assistant",
+			Timestamp: "2024-06-15T10:30:00Z", Model: "claude-sonnet",
+			TokenUsage: json.RawMessage(usage)},
+	)
+
+	base := UsageFilter{From: "2024-06-01", To: "2024-06-30"}
+
+	// Exclude one project.
+	f1 := base
+	f1.ExcludeProject = "proj-b"
+	daily, err := d.GetDailyUsage(ctx, f1)
+	requireNoError(t, err, "GetDailyUsage exclude one")
+	if daily.Totals.InputTokens != 2000 {
+		t.Errorf("exclude proj-b: InputTokens = %d, want 2000",
+			daily.Totals.InputTokens)
+	}
+
+	// Exclude two projects (comma-separated).
+	f2 := base
+	f2.ExcludeProject = "proj-a,proj-c"
+	daily, err = d.GetDailyUsage(ctx, f2)
+	requireNoError(t, err, "GetDailyUsage exclude two")
+	if daily.Totals.InputTokens != 1000 {
+		t.Errorf("exclude a+c: InputTokens = %d, want 1000",
+			daily.Totals.InputTokens)
+	}
+
+	// GetTopSessionsByCost with exclude.
+	top, err := d.GetTopSessionsByCost(ctx, f1, 10)
+	requireNoError(t, err, "GetTopSessionsByCost exclude")
+	if len(top) != 2 {
+		t.Fatalf("exclude proj-b: top len = %d, want 2", len(top))
+	}
+	for _, ts := range top {
+		if ts.Project == "proj-b" {
+			t.Errorf("excluded proj-b still in top sessions")
+		}
+	}
+
+	// GetUsageSessionCounts with exclude.
+	counts, err := d.GetUsageSessionCounts(ctx, f1)
+	requireNoError(t, err, "GetUsageSessionCounts exclude")
+	if counts.Total != 2 {
+		t.Errorf("exclude proj-b: Total = %d, want 2", counts.Total)
+	}
+	if counts.ByProject["proj-b"] != 0 {
+		t.Errorf("excluded proj-b count = %d, want 0",
+			counts.ByProject["proj-b"])
+	}
+}
+
+// TestExcludeAgentFilter verifies ExcludeAgent on GetDailyUsage.
+func TestExcludeAgentFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "s1", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertSession(t, d, "s2", "proj", func(s *Session) {
+		s.Agent = "codex"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+
+	usage := `{"input_tokens":1000,"output_tokens":500}`
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "assistant",
+			Timestamp: "2024-06-15T10:30:00Z", Model: "claude-sonnet",
+			TokenUsage: json.RawMessage(usage)},
+		Message{SessionID: "s2", Ordinal: 0, Role: "assistant",
+			Timestamp: "2024-06-15T10:30:00Z", Model: "claude-sonnet",
+			TokenUsage: json.RawMessage(usage)},
+	)
+
+	f := UsageFilter{
+		From:         "2024-06-01",
+		To:           "2024-06-30",
+		ExcludeAgent: "codex",
+	}
+	daily, err := d.GetDailyUsage(ctx, f)
+	requireNoError(t, err, "GetDailyUsage exclude agent")
+	if daily.Totals.InputTokens != 1000 {
+		t.Errorf("exclude codex: InputTokens = %d, want 1000",
+			daily.Totals.InputTokens)
+	}
+}
+
+// TestExcludeModelFilter verifies ExcludeModel on GetDailyUsage.
+func TestExcludeModelFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{
+		{ModelPattern: "sonnet", InputPerMTok: 3.0,
+			OutputPerMTok: 15.0},
+		{ModelPattern: "opus", InputPerMTok: 15.0,
+			OutputPerMTok: 75.0},
+	}), "UpsertModelPricing")
+
+	insertSession(t, d, "s1", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "assistant",
+			Timestamp: "2024-06-15T10:30:00Z", Model: "sonnet",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":1000,"output_tokens":500}`)},
+		Message{SessionID: "s1", Ordinal: 1, Role: "assistant",
+			Timestamp: "2024-06-15T11:30:00Z", Model: "opus",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":1000,"output_tokens":500}`)},
+	)
+
+	f := UsageFilter{
+		From:         "2024-06-01",
+		To:           "2024-06-30",
+		ExcludeModel: "opus",
+	}
+	daily, err := d.GetDailyUsage(ctx, f)
+	requireNoError(t, err, "GetDailyUsage exclude model")
+	if daily.Totals.InputTokens != 1000 {
+		t.Errorf("exclude opus: InputTokens = %d, want 1000",
+			daily.Totals.InputTokens)
+	}
+	if len(daily.Daily) != 1 {
+		t.Fatalf("daily len = %d, want 1", len(daily.Daily))
+	}
+	for _, mb := range daily.Daily[0].ModelBreakdowns {
+		if mb.ModelName == "opus" {
+			t.Errorf("excluded model opus still in breakdowns")
+		}
+	}
+}
+
+func BenchmarkGetDailyUsage(b *testing.B) {
+	d := testDB(&testing.T{})
+	ctx := context.Background()
+
+	if err := d.UpsertModelPricing([]ModelPricing{
+		{ModelPattern: "claude-sonnet-4-20250514",
+			InputPerMTok: 3.0, OutputPerMTok: 15.0,
+			CacheCreationPerMTok: 3.75, CacheReadPerMTok: 0.30},
+		{ModelPattern: "claude-opus-4-20250514",
+			InputPerMTok: 15.0, OutputPerMTok: 75.0,
+			CacheCreationPerMTok: 18.75, CacheReadPerMTok: 1.50},
+		{ModelPattern: "gpt-5",
+			InputPerMTok: 2.5, OutputPerMTok: 10.0,
+			CacheCreationPerMTok: 2.5, CacheReadPerMTok: 0.25},
+		{ModelPattern: "gemini-2.5-pro",
+			InputPerMTok: 1.25, OutputPerMTok: 5.0,
+			CacheCreationPerMTok: 1.25, CacheReadPerMTok: 0.125},
+	}); err != nil {
+		b.Fatalf("UpsertModelPricing: %v", err)
+	}
+
+	projects := []string{
+		"agentsview", "quokka", "arrow-rs", "side-quests",
+		"infrastructure", "blog", "experiments", "docs",
+		"dotfiles", "playground",
+	}
+	agents := []string{"claude", "codex", "openhands"}
+	models := []string{
+		"claude-sonnet-4-20250514",
+		"claude-opus-4-20250514",
+		"gpt-5",
+		"gemini-2.5-pro",
+	}
+
+	// 500 sessions × 200 messages each = 100k rows.
+	const sessionCount = 500
+	const msgsPerSession = 200
+
+	tokenUsage := `{"input_tokens":1200,"output_tokens":480,` +
+		`"cache_creation_input_tokens":300,` +
+		`"cache_read_input_tokens":2400}`
+
+	// Pre-parse the anchor timestamp once; the seed loop offsets from it.
+	startTime, err := time.Parse(time.RFC3339, "2024-06-01T00:00:00Z")
+	if err != nil {
+		b.Fatalf("parsing start time: %v", err)
+	}
+
+	for i := range sessionCount {
+		id := "bench-sess-" + strconv.Itoa(i)
+		project := projects[i%len(projects)]
+		agent := agents[i%len(agents)]
+		// Spread sessions across a 60-day window.
+		dayOffset := i % 60
+		s := Session{
+			ID:           id,
+			Project:      project,
+			Machine:      defaultMachine,
+			Agent:        agent,
+			MessageCount: msgsPerSession,
+			StartedAt:    Ptr(startTime.Format(time.RFC3339)),
+		}
+		if err := d.UpsertSession(s); err != nil {
+			b.Fatalf("UpsertSession: %v", err)
+		}
+		msgs := make([]Message, msgsPerSession)
+		for j := range msgsPerSession {
+			msgs[j] = Message{
+				SessionID:  id,
+				Ordinal:    j,
+				Role:       "assistant",
+				Timestamp:  startTime.AddDate(0, 0, dayOffset).Format(time.RFC3339),
+				Model:      models[(i+j)%len(models)],
+				TokenUsage: json.RawMessage(tokenUsage),
+			}
+		}
+		if err := d.InsertMessages(msgs); err != nil {
+			b.Fatalf("InsertMessages: %v", err)
+		}
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := d.GetDailyUsage(ctx, UsageFilter{
+			From: "2024-06-01",
+			To:   "2024-08-01",
+		})
+		if err != nil {
+			b.Fatalf("GetDailyUsage: %v", err)
+		}
 	}
 }

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -126,6 +126,96 @@ func TestGetDailyUsageWithData(t *testing.T) {
 	}
 }
 
+// TestGetDailyUsage_CacheSavingsUsesPerModelRates pins down
+// that totals.CacheSavings is computed from each row's actual
+// per-model pricing, not a hard-coded proxy. A hard-coded
+// Sonnet rate would misreport an Opus-heavy workload because
+// Opus rates are roughly 5x Sonnet on both sides.
+func TestGetDailyUsage_CacheSavingsUsesPerModelRates(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{
+		{
+			ModelPattern:         "claude-opus-4-6",
+			InputPerMTok:         15.0,
+			OutputPerMTok:        75.0,
+			CacheCreationPerMTok: 18.75,
+			CacheReadPerMTok:     1.50,
+		},
+		{
+			ModelPattern:         "claude-sonnet-4-20250514",
+			InputPerMTok:         3.0,
+			OutputPerMTok:        15.0,
+			CacheCreationPerMTok: 3.75,
+			CacheReadPerMTok:     0.30,
+		},
+	}), "UpsertModelPricing")
+
+	// Same 1M/1M mix of cache read + cache creation tokens
+	// on both models so the per-model rate difference is the
+	// only thing that can move the result.
+	tokens := json.RawMessage(
+		`{"input_tokens":0,"output_tokens":0,` +
+			`"cache_creation_input_tokens":1000000,` +
+			`"cache_read_input_tokens":1000000}`)
+
+	insertSession(t, d, "s-opus", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "s-opus", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:30:00Z",
+		Model: "claude-opus-4-6", TokenUsage: tokens,
+	})
+
+	insertSession(t, d, "s-sonnet", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:05:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "s-sonnet", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:35:00Z",
+		Model: "claude-sonnet-4-20250514", TokenUsage: tokens,
+	})
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From: "2024-06-01", To: "2024-06-30",
+	})
+	requireNoError(t, err, "GetDailyUsage")
+
+	// Opus per-token delta: read earns (15 - 1.50) = 13.50,
+	// creation earns (15 - 18.75) = -3.75.
+	// Opus savings on 1M + 1M = 13.50 + (-3.75) = 9.75.
+	// Sonnet per-token delta: read earns (3 - 0.30) = 2.70,
+	// creation earns (3 - 3.75) = -0.75.
+	// Sonnet savings on 1M + 1M = 2.70 + (-0.75) = 1.95.
+	// Net total savings = 9.75 + 1.95 = 11.70.
+	wantSavings := 11.70
+	if math.Abs(
+		result.Totals.CacheSavings-wantSavings,
+	) > 1e-9 {
+		t.Errorf(
+			"Totals.CacheSavings = %v, want %v",
+			result.Totals.CacheSavings, wantSavings,
+		)
+	}
+
+	// Falsification: if the code had used Sonnet rates for
+	// both rows the total would be 2 * 1.95 = 3.90, which
+	// differs from wantSavings by >$7. Assert we're nowhere
+	// near that value so a regression to a single-rate path
+	// trips the test.
+	if math.Abs(result.Totals.CacheSavings-3.90) < 0.1 {
+		t.Errorf(
+			"CacheSavings = %v looks like single-rate path; "+
+				"expected per-model math",
+			result.Totals.CacheSavings,
+		)
+	}
+}
+
 func TestGetDailyUsageAgentFilter(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
@@ -1277,6 +1367,78 @@ func TestGetUsageSessionCounts(t *testing.T) {
 	if counts.ByAgent["codex"] != 1 {
 		t.Errorf("ByAgent[codex] = %d, want 1",
 			counts.ByAgent["codex"])
+	}
+}
+
+// TestGetUsageSessionCounts_DedupesByClaudeMessageAndRequestID
+// mirrors the dedup regression coverage on the other two usage
+// queries. A fork session whose only qualifying messages are
+// replays of its parent's (same claude_message_id +
+// claude_request_id) contributes zero cost after dedup in
+// GetDailyUsage, so it must also NOT be counted in
+// GetUsageSessionCounts — otherwise the summary cards disagree
+// with the charts.
+func TestGetUsageSessionCounts_DedupesByClaudeMessageAndRequestID(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	// Parent starts first.
+	insertSession(t, d, "s-parent", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:00:00Z")
+	})
+	// Fork starts a minute later.
+	insertSession(t, d, "s-fork", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2024-06-15T10:01:00Z")
+		s.ParentSessionID = Ptr("s-parent")
+		s.RelationshipType = "fork"
+	})
+
+	shared := json.RawMessage(
+		`{"input_tokens":100,"output_tokens":50}`)
+
+	// Parent has one unique message.
+	insertMessages(t, d, Message{
+		SessionID: "s-parent", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:02:00Z",
+		Model: "claude-sonnet", TokenUsage: shared,
+		ClaudeMessageID: "msg_dup", ClaudeRequestID: "req_dup",
+	})
+	// Fork's ONLY qualifying message is a replay of the parent
+	// row — same claude IDs. After dedup the fork contributes
+	// nothing and must not be counted.
+	insertMessages(t, d, Message{
+		SessionID: "s-fork", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:03:00Z",
+		Model: "claude-sonnet", TokenUsage: shared,
+		ClaudeMessageID: "msg_dup", ClaudeRequestID: "req_dup",
+	})
+
+	counts, err := d.GetUsageSessionCounts(ctx, UsageFilter{
+		From: "2024-06-15", To: "2024-06-15", Timezone: "UTC",
+	})
+	requireNoError(t, err, "GetUsageSessionCounts")
+
+	if counts.Total != 1 {
+		t.Errorf(
+			"Total = %d, want 1 (fork should dedup out)",
+			counts.Total,
+		)
+	}
+	if counts.ByProject["proj"] != 1 {
+		t.Errorf(
+			"ByProject[proj] = %d, want 1",
+			counts.ByProject["proj"],
+		)
+	}
+	if counts.ByAgent["claude"] != 1 {
+		t.Errorf(
+			"ByAgent[claude] = %d, want 1",
+			counts.ByAgent["claude"],
+		)
 	}
 }
 

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -69,32 +69,32 @@ func (s *Store) GetSessionVersion(
 
 // ------------------------------------------------------------
 // Usage stubs (not yet implemented for PG)
+//
+// These return db.ErrReadOnly so the usage HTTP handlers can map
+// them to 501 Not Implemented. Returning empty results silently
+// would look like "no usage data" on a fully populated PG
+// deployment, which is far worse than an explicit error.
 // ------------------------------------------------------------
 
 // GetDailyUsage is not implemented for PG.
 func (s *Store) GetDailyUsage(
 	_ context.Context, _ db.UsageFilter,
 ) (db.DailyUsageResult, error) {
-	return db.DailyUsageResult{
-		Daily: []db.DailyUsageEntry{},
-	}, nil
+	return db.DailyUsageResult{}, db.ErrReadOnly
 }
 
 // GetTopSessionsByCost is not implemented for PG.
 func (s *Store) GetTopSessionsByCost(
 	_ context.Context, _ db.UsageFilter, _ int,
 ) ([]db.TopSessionEntry, error) {
-	return []db.TopSessionEntry{}, nil
+	return nil, db.ErrReadOnly
 }
 
 // GetUsageSessionCounts is not implemented for PG.
 func (s *Store) GetUsageSessionCounts(
 	_ context.Context, _ db.UsageFilter,
 ) (db.UsageSessionCounts, error) {
-	return db.UsageSessionCounts{
-		ByProject: make(map[string]int),
-		ByAgent:   make(map[string]int),
-	}, nil
+	return db.UsageSessionCounts{}, db.ErrReadOnly
 }
 
 // ------------------------------------------------------------

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -68,6 +68,36 @@ func (s *Store) GetSessionVersion(
 }
 
 // ------------------------------------------------------------
+// Usage stubs (not yet implemented for PG)
+// ------------------------------------------------------------
+
+// GetDailyUsage is not implemented for PG.
+func (s *Store) GetDailyUsage(
+	_ context.Context, _ db.UsageFilter,
+) (db.DailyUsageResult, error) {
+	return db.DailyUsageResult{
+		Daily: []db.DailyUsageEntry{},
+	}, nil
+}
+
+// GetTopSessionsByCost is not implemented for PG.
+func (s *Store) GetTopSessionsByCost(
+	_ context.Context, _ db.UsageFilter, _ int,
+) ([]db.TopSessionEntry, error) {
+	return []db.TopSessionEntry{}, nil
+}
+
+// GetUsageSessionCounts is not implemented for PG.
+func (s *Store) GetUsageSessionCounts(
+	_ context.Context, _ db.UsageFilter,
+) (db.UsageSessionCounts, error) {
+	return db.UsageSessionCounts{
+		ByProject: make(map[string]int),
+		ByAgent:   make(map[string]int),
+	}, nil
+}
+
+// ------------------------------------------------------------
 // Write stubs (all return db.ErrReadOnly)
 // ------------------------------------------------------------
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -198,6 +198,11 @@ func (s *Server) routes() {
 	s.mux.Handle("GET /api/v1/analytics/tools", s.withTimeout(s.handleAnalyticsTools))
 	s.mux.Handle("GET /api/v1/analytics/top-sessions", s.withTimeout(s.handleAnalyticsTopSessions))
 
+	s.mux.Handle("GET /api/v1/usage/summary",
+		s.withTimeout(s.handleUsageSummary))
+	s.mux.Handle("GET /api/v1/usage/top-sessions",
+		s.withTimeout(s.handleUsageTopSessions))
+
 	s.mux.Handle("GET /api/v1/insights", s.withTimeout(s.handleListInsights))
 	s.mux.Handle("GET /api/v1/insights/{id}", s.withTimeout(s.handleGetInsight))
 	s.mux.Handle("DELETE /api/v1/insights/{id}", s.withTimeout(s.handleDeleteInsight))

--- a/internal/server/usage.go
+++ b/internal/server/usage.go
@@ -217,10 +217,11 @@ func foldAgentTotals(
 }
 
 // computeCacheStats derives cache hit/miss metrics from totals.
-// SavingsVsUncached is approximate: it uses a flat $3.00/MTok
-// average input rate because the handler doesn't have per-model
-// cache-read token counts. Good enough for a v1 ballpark; a
-// future iteration can compute weighted rates from breakdowns.
+// SavingsVsUncached is approximate: it uses Anthropic Sonnet
+// rates as a proxy because the handler doesn't have per-model
+// breakdowns of cache-read/creation tokens. Good enough for a
+// v1 ballpark; a future iteration can compute weighted rates
+// from per-model breakdowns.
 func computeCacheStats(t db.UsageTotals) CacheStats {
 	uncached := max(t.InputTokens-t.CacheReadTokens-
 		t.CacheCreationTokens, 0)
@@ -235,21 +236,25 @@ func computeCacheStats(t db.UsageTotals) CacheStats {
 		cs.HitRate = float64(t.CacheReadTokens) /
 			float64(denominator)
 	}
-	// SavingsVsUncached is the absolute dollar delta between
-	// what the cache-read tokens would have cost at the full
-	// input rate and what they actually cost at the cache-read
-	// rate. v1 approximates both rates with Anthropic Sonnet
-	// pricing ($3/MTok input, $0.30/MTok cache-read) — good
-	// enough for the headline; revisit if users want precision.
+	// SavingsVsUncached is the net dollar delta vs a world
+	// without the cache: cache reads save (input - cacheRead)
+	// per token, but cache creations cost extra because
+	// creation is billed above the input rate. On Sonnet:
+	// $3.00/MTok input, $0.30/MTok cache-read, $3.75/MTok
+	// cache-create — so a creation token is actually -$0.75
+	// "savings". Write-heavy workloads with no reads end up
+	// with a negative value, which is correct: the cache
+	// made them more expensive.
 	const (
-		inputRatePerMTok     = 3.0
-		cacheReadRatePerMTok = 0.30
+		inputRatePerMTok         = 3.0
+		cacheReadRatePerMTok     = 0.30
+		cacheCreationRatePerMTok = 3.75
 	)
-	cacheReadFullCost := float64(t.CacheReadTokens) *
-		inputRatePerMTok / 1_000_000
-	cacheReadActualCost := float64(t.CacheReadTokens) *
-		cacheReadRatePerMTok / 1_000_000
-	cs.SavingsVsUncached = cacheReadFullCost - cacheReadActualCost
+	readDelta := float64(t.CacheReadTokens) *
+		(inputRatePerMTok - cacheReadRatePerMTok) / 1_000_000
+	creationDelta := float64(t.CacheCreationTokens) *
+		(inputRatePerMTok - cacheCreationRatePerMTok) / 1_000_000
+	cs.SavingsVsUncached = readDelta + creationDelta
 	return cs
 }
 

--- a/internal/server/usage.go
+++ b/internal/server/usage.go
@@ -223,12 +223,14 @@ func foldAgentTotals(
 // v1 ballpark; a future iteration can compute weighted rates
 // from per-model breakdowns.
 func computeCacheStats(t db.UsageTotals) CacheStats {
-	uncached := max(t.InputTokens-t.CacheReadTokens-
-		t.CacheCreationTokens, 0)
+	// Anthropic reports input_tokens as the NON-cached portion
+	// of the input (cache_read and cache_creation are separate
+	// fields), so UncachedInputTokens is just t.InputTokens
+	// directly — no subtraction.
 	cs := CacheStats{
 		CacheReadTokens:     t.CacheReadTokens,
 		CacheCreationTokens: t.CacheCreationTokens,
-		UncachedInputTokens: uncached,
+		UncachedInputTokens: t.InputTokens,
 		OutputTokens:        t.OutputTokens,
 	}
 	denominator := t.CacheReadTokens + t.InputTokens
@@ -322,6 +324,9 @@ func (s *Server) handleUsageSummary(
 		if handleContextError(w, err) {
 			return
 		}
+		if handleReadOnly(w, err) {
+			return
+		}
 		log.Printf("usage summary error: %v", err)
 		writeError(w, http.StatusInternalServerError,
 			"internal server error")
@@ -336,6 +341,9 @@ func (s *Server) handleUsageSummary(
 	)
 	if err != nil {
 		if handleContextError(w, err) {
+			return
+		}
+		if handleReadOnly(w, err) {
 			return
 		}
 		log.Printf("usage session counts error: %v", err)
@@ -397,6 +405,9 @@ func (s *Server) handleUsageTopSessions(
 	)
 	if err != nil {
 		if handleContextError(w, err) {
+			return
+		}
+		if handleReadOnly(w, err) {
 			return
 		}
 		log.Printf("usage top sessions error: %v", err)

--- a/internal/server/usage.go
+++ b/internal/server/usage.go
@@ -1,0 +1,395 @@
+package server
+
+import (
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+// ProjectTotal holds range-wide token and cost totals per project.
+type ProjectTotal struct {
+	Project             string  `json:"project"`
+	InputTokens         int     `json:"inputTokens"`
+	OutputTokens        int     `json:"outputTokens"`
+	CacheCreationTokens int     `json:"cacheCreationTokens"`
+	CacheReadTokens     int     `json:"cacheReadTokens"`
+	Cost                float64 `json:"cost"`
+}
+
+// ModelTotal holds range-wide token and cost totals per model.
+type ModelTotal struct {
+	Model               string  `json:"model"`
+	InputTokens         int     `json:"inputTokens"`
+	OutputTokens        int     `json:"outputTokens"`
+	CacheCreationTokens int     `json:"cacheCreationTokens"`
+	CacheReadTokens     int     `json:"cacheReadTokens"`
+	Cost                float64 `json:"cost"`
+}
+
+// AgentTotal holds range-wide token and cost totals per agent.
+type AgentTotal struct {
+	Agent               string  `json:"agent"`
+	InputTokens         int     `json:"inputTokens"`
+	OutputTokens        int     `json:"outputTokens"`
+	CacheCreationTokens int     `json:"cacheCreationTokens"`
+	CacheReadTokens     int     `json:"cacheReadTokens"`
+	Cost                float64 `json:"cost"`
+}
+
+// CacheStats summarizes cache hit/miss for the period.
+type CacheStats struct {
+	CacheReadTokens     int     `json:"cacheReadTokens"`
+	CacheCreationTokens int     `json:"cacheCreationTokens"`
+	UncachedInputTokens int     `json:"uncachedInputTokens"`
+	OutputTokens        int     `json:"outputTokens"`
+	HitRate             float64 `json:"hitRate"`
+	SavingsVsUncached   float64 `json:"savingsVsUncached"`
+}
+
+// Comparison holds the prior-period cost comparison.
+type Comparison struct {
+	PriorFrom      string  `json:"priorFrom"`
+	PriorTo        string  `json:"priorTo"`
+	PriorTotalCost float64 `json:"priorTotalCost"`
+	DeltaPct       float64 `json:"deltaPct"`
+}
+
+// UsageSummaryResponse is the JSON shape for
+// GET /api/v1/usage/summary.
+type UsageSummaryResponse struct {
+	From          string                `json:"from"`
+	To            string                `json:"to"`
+	Totals        db.UsageTotals        `json:"totals"`
+	Daily         []db.DailyUsageEntry  `json:"daily"`
+	ProjectTotals []ProjectTotal        `json:"projectTotals"`
+	ModelTotals   []ModelTotal          `json:"modelTotals"`
+	AgentTotals   []AgentTotal          `json:"agentTotals"`
+	SessionCounts db.UsageSessionCounts `json:"sessionCounts"`
+	CacheStats    CacheStats            `json:"cacheStats"`
+	Comparison    *Comparison           `json:"comparison,omitempty"`
+}
+
+// parseUsageFilter extracts usage filter params from a request.
+// Returns the filter and true on success; writes an error
+// response and returns false on failure.
+func parseUsageFilter(
+	w http.ResponseWriter, r *http.Request,
+) (db.UsageFilter, bool) {
+	q := r.URL.Query()
+	tz := q.Get("timezone")
+	if tz == "" {
+		tz = "UTC"
+	}
+	if _, err := time.LoadLocation(tz); err != nil {
+		writeError(w, http.StatusBadRequest,
+			"invalid timezone: "+tz)
+		return db.UsageFilter{}, false
+	}
+
+	from, to := defaultDateRange(q.Get("from"), q.Get("to"))
+
+	if !isValidDate(from) || !isValidDate(to) {
+		writeError(w, http.StatusBadRequest,
+			"invalid date format: use YYYY-MM-DD")
+		return db.UsageFilter{}, false
+	}
+	if from > to {
+		writeError(w, http.StatusBadRequest,
+			"from must not be after to")
+		return db.UsageFilter{}, false
+	}
+
+	return db.UsageFilter{
+		From:           from,
+		To:             to,
+		Agent:          q.Get("agent"),
+		Project:        q.Get("project"),
+		ExcludeProject: q.Get("exclude_project"),
+		ExcludeAgent:   q.Get("exclude_agent"),
+		ExcludeModel:   q.Get("exclude_model"),
+		Model:          q.Get("model"),
+		Timezone:       tz,
+		Breakdowns:     true,
+	}, true
+}
+
+// foldProjectTotals sums daily project breakdowns into
+// range-wide totals sorted by cost descending.
+func foldProjectTotals(
+	daily []db.DailyUsageEntry,
+) []ProjectTotal {
+	m := make(map[string]*ProjectTotal)
+	for _, d := range daily {
+		for _, pb := range d.ProjectBreakdowns {
+			pt, ok := m[pb.Project]
+			if !ok {
+				pt = &ProjectTotal{Project: pb.Project}
+				m[pb.Project] = pt
+			}
+			pt.InputTokens += pb.InputTokens
+			pt.OutputTokens += pb.OutputTokens
+			pt.CacheCreationTokens += pb.CacheCreationTokens
+			pt.CacheReadTokens += pb.CacheReadTokens
+			pt.Cost += pb.Cost
+		}
+	}
+	out := make([]ProjectTotal, 0, len(m))
+	for _, v := range m {
+		out = append(out, *v)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Cost != out[j].Cost {
+			return out[i].Cost > out[j].Cost
+		}
+		return out[i].Project < out[j].Project
+	})
+	return out
+}
+
+// foldModelTotals sums daily model breakdowns into range-wide
+// totals sorted by cost descending.
+func foldModelTotals(
+	daily []db.DailyUsageEntry,
+) []ModelTotal {
+	m := make(map[string]*ModelTotal)
+	for _, d := range daily {
+		for _, mb := range d.ModelBreakdowns {
+			mt, ok := m[mb.ModelName]
+			if !ok {
+				mt = &ModelTotal{Model: mb.ModelName}
+				m[mb.ModelName] = mt
+			}
+			mt.InputTokens += mb.InputTokens
+			mt.OutputTokens += mb.OutputTokens
+			mt.CacheCreationTokens += mb.CacheCreationTokens
+			mt.CacheReadTokens += mb.CacheReadTokens
+			mt.Cost += mb.Cost
+		}
+	}
+	out := make([]ModelTotal, 0, len(m))
+	for _, v := range m {
+		out = append(out, *v)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Cost != out[j].Cost {
+			return out[i].Cost > out[j].Cost
+		}
+		return out[i].Model < out[j].Model
+	})
+	return out
+}
+
+// foldAgentTotals sums daily agent breakdowns into range-wide
+// totals sorted by cost descending.
+func foldAgentTotals(
+	daily []db.DailyUsageEntry,
+) []AgentTotal {
+	m := make(map[string]*AgentTotal)
+	for _, d := range daily {
+		for _, ab := range d.AgentBreakdowns {
+			at, ok := m[ab.Agent]
+			if !ok {
+				at = &AgentTotal{Agent: ab.Agent}
+				m[ab.Agent] = at
+			}
+			at.InputTokens += ab.InputTokens
+			at.OutputTokens += ab.OutputTokens
+			at.CacheCreationTokens += ab.CacheCreationTokens
+			at.CacheReadTokens += ab.CacheReadTokens
+			at.Cost += ab.Cost
+		}
+	}
+	out := make([]AgentTotal, 0, len(m))
+	for _, v := range m {
+		out = append(out, *v)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Cost != out[j].Cost {
+			return out[i].Cost > out[j].Cost
+		}
+		return out[i].Agent < out[j].Agent
+	})
+	return out
+}
+
+// computeCacheStats derives cache hit/miss metrics from totals.
+// SavingsVsUncached is approximate: it uses a flat $3.00/MTok
+// average input rate because the handler doesn't have per-model
+// cache-read token counts. Good enough for a v1 ballpark; a
+// future iteration can compute weighted rates from breakdowns.
+func computeCacheStats(t db.UsageTotals) CacheStats {
+	uncached := max(t.InputTokens-t.CacheReadTokens-
+		t.CacheCreationTokens, 0)
+	cs := CacheStats{
+		CacheReadTokens:     t.CacheReadTokens,
+		CacheCreationTokens: t.CacheCreationTokens,
+		UncachedInputTokens: uncached,
+		OutputTokens:        t.OutputTokens,
+	}
+	denominator := t.CacheReadTokens + t.InputTokens
+	if denominator > 0 {
+		cs.HitRate = float64(t.CacheReadTokens) /
+			float64(denominator)
+	}
+	// Rough savings estimate: $3.00/MTok average input rate.
+	const avgInputRate = 3.0
+	allInputTokens := t.InputTokens + t.CacheReadTokens +
+		t.CacheCreationTokens
+	uncachedCost := float64(allInputTokens) *
+		avgInputRate / 1_000_000
+	if uncachedCost > 0 {
+		cs.SavingsVsUncached = 1.0 - t.TotalCost/uncachedCost
+	}
+	return cs
+}
+
+// computeComparison runs a prior-period query and computes
+// the cost delta. Best-effort: logs and returns nil on error.
+func (s *Server) computeComparison(
+	r *http.Request, f db.UsageFilter, currentCost float64,
+) *Comparison {
+	fromT, err := time.Parse("2006-01-02", f.From)
+	if err != nil {
+		return nil
+	}
+	toT, err := time.Parse("2006-01-02", f.To)
+	if err != nil {
+		return nil
+	}
+	days := int(toT.Sub(fromT).Hours()/24) + 1
+	priorTo := fromT.AddDate(0, 0, -1)
+	priorFrom := priorTo.AddDate(0, 0, -(days - 1))
+
+	priorFilter := db.UsageFilter{
+		From:       priorFrom.Format("2006-01-02"),
+		To:         priorTo.Format("2006-01-02"),
+		Agent:      f.Agent,
+		Project:    f.Project,
+		Model:      f.Model,
+		Timezone:   f.Timezone,
+		Breakdowns: false,
+	}
+	priorResult, err := s.db.GetDailyUsage(
+		r.Context(), priorFilter,
+	)
+	if err != nil {
+		log.Printf("usage comparison error: %v", err)
+		return nil
+	}
+
+	c := &Comparison{
+		PriorFrom:      priorFilter.From,
+		PriorTo:        priorFilter.To,
+		PriorTotalCost: priorResult.Totals.TotalCost,
+	}
+	if c.PriorTotalCost > 0 {
+		c.DeltaPct = (currentCost - c.PriorTotalCost) /
+			c.PriorTotalCost
+	}
+	return c
+}
+
+func (s *Server) handleUsageSummary(
+	w http.ResponseWriter, r *http.Request,
+) {
+	f, ok := parseUsageFilter(w, r)
+	if !ok {
+		return
+	}
+
+	ctx := r.Context()
+
+	result, err := s.db.GetDailyUsage(ctx, f)
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		log.Printf("usage summary error: %v", err)
+		writeError(w, http.StatusInternalServerError,
+			"internal server error")
+		return
+	}
+
+	// Session counts don't use breakdowns.
+	scFilter := f
+	scFilter.Breakdowns = false
+	sessionCounts, err := s.db.GetUsageSessionCounts(
+		ctx, scFilter,
+	)
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		log.Printf("usage session counts error: %v", err)
+		writeError(w, http.StatusInternalServerError,
+			"internal server error")
+		return
+	}
+
+	cacheStats := computeCacheStats(result.Totals)
+
+	comparison := s.computeComparison(
+		r, f, result.Totals.TotalCost,
+	)
+
+	resp := UsageSummaryResponse{
+		From:          f.From,
+		To:            f.To,
+		Totals:        result.Totals,
+		Daily:         result.Daily,
+		ProjectTotals: foldProjectTotals(result.Daily),
+		ModelTotals:   foldModelTotals(result.Daily),
+		AgentTotals:   foldAgentTotals(result.Daily),
+		SessionCounts: sessionCounts,
+		CacheStats:    cacheStats,
+		Comparison:    comparison,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleUsageTopSessions(
+	w http.ResponseWriter, r *http.Request,
+) {
+	f, ok := parseUsageFilter(w, r)
+	if !ok {
+		return
+	}
+	f.Breakdowns = false
+
+	limit := 20
+	if s := r.URL.Query().Get("limit"); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			writeError(w, http.StatusBadRequest,
+				"invalid limit parameter")
+			return
+		}
+		limit = v
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	entries, err := s.db.GetTopSessionsByCost(
+		r.Context(), f, limit,
+	)
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		log.Printf("usage top sessions error: %v", err)
+		writeError(w, http.StatusInternalServerError,
+			"internal server error")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, entries)
+}

--- a/internal/server/usage.go
+++ b/internal/server/usage.go
@@ -217,11 +217,11 @@ func foldAgentTotals(
 }
 
 // computeCacheStats derives cache hit/miss metrics from totals.
-// SavingsVsUncached is approximate: it uses Anthropic Sonnet
-// rates as a proxy because the handler doesn't have per-model
-// breakdowns of cache-read/creation tokens. Good enough for a
-// v1 ballpark; a future iteration can compute weighted rates
-// from per-model breakdowns.
+// SavingsVsUncached passes through totals.CacheSavings, which
+// the DB layer computes per-message using each row's actual
+// per-model rates — so mixed-model periods (e.g. Opus + Sonnet)
+// report the right net delta instead of a single hard-coded
+// proxy rate.
 func computeCacheStats(t db.UsageTotals) CacheStats {
 	// Anthropic reports input_tokens as the NON-cached portion
 	// of the input (cache_read and cache_creation are separate
@@ -232,31 +232,13 @@ func computeCacheStats(t db.UsageTotals) CacheStats {
 		CacheCreationTokens: t.CacheCreationTokens,
 		UncachedInputTokens: t.InputTokens,
 		OutputTokens:        t.OutputTokens,
+		SavingsVsUncached:   t.CacheSavings,
 	}
 	denominator := t.CacheReadTokens + t.InputTokens
 	if denominator > 0 {
 		cs.HitRate = float64(t.CacheReadTokens) /
 			float64(denominator)
 	}
-	// SavingsVsUncached is the net dollar delta vs a world
-	// without the cache: cache reads save (input - cacheRead)
-	// per token, but cache creations cost extra because
-	// creation is billed above the input rate. On Sonnet:
-	// $3.00/MTok input, $0.30/MTok cache-read, $3.75/MTok
-	// cache-create — so a creation token is actually -$0.75
-	// "savings". Write-heavy workloads with no reads end up
-	// with a negative value, which is correct: the cache
-	// made them more expensive.
-	const (
-		inputRatePerMTok         = 3.0
-		cacheReadRatePerMTok     = 0.30
-		cacheCreationRatePerMTok = 3.75
-	)
-	readDelta := float64(t.CacheReadTokens) *
-		(inputRatePerMTok - cacheReadRatePerMTok) / 1_000_000
-	creationDelta := float64(t.CacheCreationTokens) *
-		(inputRatePerMTok - cacheCreationRatePerMTok) / 1_000_000
-	cs.SavingsVsUncached = readDelta + creationDelta
 	return cs
 }
 

--- a/internal/server/usage.go
+++ b/internal/server/usage.go
@@ -235,15 +235,21 @@ func computeCacheStats(t db.UsageTotals) CacheStats {
 		cs.HitRate = float64(t.CacheReadTokens) /
 			float64(denominator)
 	}
-	// Rough savings estimate: $3.00/MTok average input rate.
-	const avgInputRate = 3.0
-	allInputTokens := t.InputTokens + t.CacheReadTokens +
-		t.CacheCreationTokens
-	uncachedCost := float64(allInputTokens) *
-		avgInputRate / 1_000_000
-	if uncachedCost > 0 {
-		cs.SavingsVsUncached = 1.0 - t.TotalCost/uncachedCost
-	}
+	// SavingsVsUncached is the absolute dollar delta between
+	// what the cache-read tokens would have cost at the full
+	// input rate and what they actually cost at the cache-read
+	// rate. v1 approximates both rates with Anthropic Sonnet
+	// pricing ($3/MTok input, $0.30/MTok cache-read) — good
+	// enough for the headline; revisit if users want precision.
+	const (
+		inputRatePerMTok     = 3.0
+		cacheReadRatePerMTok = 0.30
+	)
+	cacheReadFullCost := float64(t.CacheReadTokens) *
+		inputRatePerMTok / 1_000_000
+	cacheReadActualCost := float64(t.CacheReadTokens) *
+		cacheReadRatePerMTok / 1_000_000
+	cs.SavingsVsUncached = cacheReadFullCost - cacheReadActualCost
 	return cs
 }
 
@@ -265,13 +271,16 @@ func (s *Server) computeComparison(
 	priorFrom := priorTo.AddDate(0, 0, -(days - 1))
 
 	priorFilter := db.UsageFilter{
-		From:       priorFrom.Format("2006-01-02"),
-		To:         priorTo.Format("2006-01-02"),
-		Agent:      f.Agent,
-		Project:    f.Project,
-		Model:      f.Model,
-		Timezone:   f.Timezone,
-		Breakdowns: false,
+		From:           priorFrom.Format("2006-01-02"),
+		To:             priorTo.Format("2006-01-02"),
+		Agent:          f.Agent,
+		Project:        f.Project,
+		Model:          f.Model,
+		ExcludeProject: f.ExcludeProject,
+		ExcludeAgent:   f.ExcludeAgent,
+		ExcludeModel:   f.ExcludeModel,
+		Timezone:       f.Timezone,
+		Breakdowns:     false,
 	}
 	priorResult, err := s.db.GetDailyUsage(
 		r.Context(), priorFilter,

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"math"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+// approxEqual returns true if a and b are within eps (for
+// float comparisons that have rounding from division).
+func approxEqual(a, b, eps float64) bool {
+	return math.Abs(a-b) <= eps
+}
+
+func TestComputeCacheStats_ReadOnlySavings(t *testing.T) {
+	// 1M cache-read tokens, no creations. Discount per token
+	// is (3.00 - 0.30) / 1M = $2.70 total.
+	cs := computeCacheStats(db.UsageTotals{
+		InputTokens:     1_000_000,
+		CacheReadTokens: 1_000_000,
+	})
+	if !approxEqual(cs.SavingsVsUncached, 2.70, 1e-9) {
+		t.Errorf("SavingsVsUncached = %v, want ~2.70",
+			cs.SavingsVsUncached)
+	}
+}
+
+func TestComputeCacheStats_CreationOnlyIsNegative(t *testing.T) {
+	// 1M cache-creation tokens, no reads. Premium is
+	// (3.00 - 3.75) / 1M = -$0.75. The cache costs more than
+	// an uncached run; savings must be negative.
+	cs := computeCacheStats(db.UsageTotals{
+		InputTokens:         1_000_000,
+		CacheCreationTokens: 1_000_000,
+	})
+	if cs.SavingsVsUncached >= 0 {
+		t.Errorf("SavingsVsUncached = %v, want < 0",
+			cs.SavingsVsUncached)
+	}
+	if !approxEqual(cs.SavingsVsUncached, -0.75, 1e-9) {
+		t.Errorf("SavingsVsUncached = %v, want ~-0.75",
+			cs.SavingsVsUncached)
+	}
+}
+
+func TestComputeCacheStats_MixedReadsAndCreations(t *testing.T) {
+	// 2M reads save 2 * 2.70 = $5.40.
+	// 1M creations cost 1 * 0.75 = -$0.75.
+	// Net = $4.65.
+	cs := computeCacheStats(db.UsageTotals{
+		InputTokens:         3_000_000,
+		CacheReadTokens:     2_000_000,
+		CacheCreationTokens: 1_000_000,
+	})
+	if !approxEqual(cs.SavingsVsUncached, 4.65, 1e-9) {
+		t.Errorf("SavingsVsUncached = %v, want ~4.65",
+			cs.SavingsVsUncached)
+	}
+}
+
+func TestComputeCacheStats_ZeroTotalsIsZero(t *testing.T) {
+	cs := computeCacheStats(db.UsageTotals{})
+	if cs.SavingsVsUncached != 0 {
+		t.Errorf("SavingsVsUncached = %v, want 0",
+			cs.SavingsVsUncached)
+	}
+	if cs.HitRate != 0 {
+		t.Errorf("HitRate = %v, want 0", cs.HitRate)
+	}
+}
+
+func TestComputeCacheStats_HitRate(t *testing.T) {
+	// 800 cache reads, 200 uncached inputs -> 0.80 hit rate.
+	// (The HitRate denominator in this code is
+	// cacheRead + input where input already includes reads.)
+	cs := computeCacheStats(db.UsageTotals{
+		InputTokens:     200,
+		CacheReadTokens: 800,
+	})
+	// denom = 800 + 200 = 1000; hit = 800/1000 = 0.80.
+	if !approxEqual(cs.HitRate, 0.80, 1e-9) {
+		t.Errorf("HitRate = %v, want ~0.80", cs.HitRate)
+	}
+}
+
+func TestComputeCacheStats_UncachedInputNonNegative(t *testing.T) {
+	// Pathological case where cache tokens exceed total
+	// input (can happen because the tallies come from
+	// different JSON fields). UncachedInputTokens must clamp
+	// to 0, not go negative.
+	cs := computeCacheStats(db.UsageTotals{
+		InputTokens:         100,
+		CacheReadTokens:     200,
+		CacheCreationTokens: 50,
+	})
+	if cs.UncachedInputTokens != 0 {
+		t.Errorf("UncachedInputTokens = %d, want 0",
+			cs.UncachedInputTokens)
+	}
+}

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -84,18 +84,29 @@ func TestComputeCacheStats_HitRate(t *testing.T) {
 	}
 }
 
-func TestComputeCacheStats_UncachedInputNonNegative(t *testing.T) {
-	// Pathological case where cache tokens exceed total
-	// input (can happen because the tallies come from
-	// different JSON fields). UncachedInputTokens must clamp
-	// to 0, not go negative.
+func TestComputeCacheStats_UncachedPassesInputThrough(t *testing.T) {
+	// Anthropic's input_tokens field is the NON-cached portion
+	// of the input; cache_read and cache_creation are tracked
+	// separately. UncachedInputTokens must therefore equal
+	// InputTokens directly — not input minus the cache buckets,
+	// which would double-subtract and wrongly drive the value
+	// toward zero for any cached workload.
 	cs := computeCacheStats(db.UsageTotals{
 		InputTokens:         100,
 		CacheReadTokens:     200,
 		CacheCreationTokens: 50,
 	})
-	if cs.UncachedInputTokens != 0 {
-		t.Errorf("UncachedInputTokens = %d, want 0",
+	if cs.UncachedInputTokens != 100 {
+		t.Errorf("UncachedInputTokens = %d, want 100",
 			cs.UncachedInputTokens)
+	}
+	// And the cache buckets are reported verbatim alongside it.
+	if cs.CacheReadTokens != 200 {
+		t.Errorf("CacheReadTokens = %d, want 200",
+			cs.CacheReadTokens)
+	}
+	if cs.CacheCreationTokens != 50 {
+		t.Errorf("CacheCreationTokens = %d, want 50",
+			cs.CacheCreationTokens)
 	}
 }

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -13,49 +13,32 @@ func approxEqual(a, b, eps float64) bool {
 	return math.Abs(a-b) <= eps
 }
 
-func TestComputeCacheStats_ReadOnlySavings(t *testing.T) {
-	// 1M cache-read tokens, no creations. Discount per token
-	// is (3.00 - 0.30) / 1M = $2.70 total.
-	cs := computeCacheStats(db.UsageTotals{
-		InputTokens:     1_000_000,
-		CacheReadTokens: 1_000_000,
-	})
-	if !approxEqual(cs.SavingsVsUncached, 2.70, 1e-9) {
-		t.Errorf("SavingsVsUncached = %v, want ~2.70",
-			cs.SavingsVsUncached)
+func TestComputeCacheStats_SavingsPassThrough(t *testing.T) {
+	// SavingsVsUncached is now computed per-model in the DB
+	// layer; computeCacheStats just forwards totals.CacheSavings.
+	// Verify the pass-through at the positive, negative, and
+	// zero boundaries so a future refactor that drops the field
+	// trips a test.
+	cases := []struct {
+		name string
+		in   float64
+	}{
+		{"positive", 4.65},
+		{"negative", -0.75},
+		{"zero", 0},
 	}
-}
-
-func TestComputeCacheStats_CreationOnlyIsNegative(t *testing.T) {
-	// 1M cache-creation tokens, no reads. Premium is
-	// (3.00 - 3.75) / 1M = -$0.75. The cache costs more than
-	// an uncached run; savings must be negative.
-	cs := computeCacheStats(db.UsageTotals{
-		InputTokens:         1_000_000,
-		CacheCreationTokens: 1_000_000,
-	})
-	if cs.SavingsVsUncached >= 0 {
-		t.Errorf("SavingsVsUncached = %v, want < 0",
-			cs.SavingsVsUncached)
-	}
-	if !approxEqual(cs.SavingsVsUncached, -0.75, 1e-9) {
-		t.Errorf("SavingsVsUncached = %v, want ~-0.75",
-			cs.SavingsVsUncached)
-	}
-}
-
-func TestComputeCacheStats_MixedReadsAndCreations(t *testing.T) {
-	// 2M reads save 2 * 2.70 = $5.40.
-	// 1M creations cost 1 * 0.75 = -$0.75.
-	// Net = $4.65.
-	cs := computeCacheStats(db.UsageTotals{
-		InputTokens:         3_000_000,
-		CacheReadTokens:     2_000_000,
-		CacheCreationTokens: 1_000_000,
-	})
-	if !approxEqual(cs.SavingsVsUncached, 4.65, 1e-9) {
-		t.Errorf("SavingsVsUncached = %v, want ~4.65",
-			cs.SavingsVsUncached)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := computeCacheStats(db.UsageTotals{
+				CacheSavings: tc.in,
+			})
+			if !approxEqual(cs.SavingsVsUncached, tc.in, 1e-9) {
+				t.Errorf(
+					"SavingsVsUncached = %v, want %v",
+					cs.SavingsVsUncached, tc.in,
+				)
+			}
+		})
 	}
 }
 
@@ -73,7 +56,8 @@ func TestComputeCacheStats_ZeroTotalsIsZero(t *testing.T) {
 func TestComputeCacheStats_HitRate(t *testing.T) {
 	// 800 cache reads, 200 uncached inputs -> 0.80 hit rate.
 	// (The HitRate denominator in this code is
-	// cacheRead + input where input already includes reads.)
+	// cacheRead + input where input is already the uncached
+	// portion — see the pass-through test below.)
 	cs := computeCacheStats(db.UsageTotals{
 		InputTokens:     200,
 		CacheReadTokens: 800,

--- a/internal/server/usage_readonly_internal_test.go
+++ b/internal/server/usage_readonly_internal_test.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+// readOnlyUsageSpy stubs the Store interface and returns
+// db.ErrReadOnly from the three usage queries. It lets us
+// verify the handlers map the sentinel error to 501 Not
+// Implemented without spinning up a real PG instance.
+type readOnlyUsageSpy struct {
+	db.Store
+}
+
+func (readOnlyUsageSpy) GetDailyUsage(
+	_ context.Context, _ db.UsageFilter,
+) (db.DailyUsageResult, error) {
+	return db.DailyUsageResult{}, db.ErrReadOnly
+}
+
+func (readOnlyUsageSpy) GetTopSessionsByCost(
+	_ context.Context, _ db.UsageFilter, _ int,
+) ([]db.TopSessionEntry, error) {
+	return nil, db.ErrReadOnly
+}
+
+func (readOnlyUsageSpy) GetUsageSessionCounts(
+	_ context.Context, _ db.UsageFilter,
+) (db.UsageSessionCounts, error) {
+	return db.UsageSessionCounts{}, db.ErrReadOnly
+}
+
+// TestUsageHandlers_ReturnNotImplementedOnReadOnlyStore locks
+// in the Postgres-backend contract: when the underlying Store
+// reports a usage query as unavailable (db.ErrReadOnly), both
+// usage HTTP endpoints must surface 501 Not Implemented rather
+// than silently returning an empty body, which would look like
+// "no usage data" to the user.
+func TestUsageHandlers_ReturnNotImplementedOnReadOnlyStore(
+	t *testing.T,
+) {
+	s := &Server{db: readOnlyUsageSpy{}}
+
+	cases := []struct {
+		name    string
+		path    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{
+			name: "summary",
+			path: "/api/v1/usage/summary?" +
+				"from=2024-06-01&to=2024-06-03",
+			handler: s.handleUsageSummary,
+		},
+		{
+			name: "top-sessions",
+			path: "/api/v1/usage/top-sessions?" +
+				"from=2024-06-01&to=2024-06-03",
+			handler: s.handleUsageTopSessions,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(
+				http.MethodGet, tc.path, nil,
+			)
+			w := httptest.NewRecorder()
+			tc.handler(w, req)
+			if w.Code != http.StatusNotImplemented {
+				t.Errorf(
+					"status = %d, want 501; body=%s",
+					w.Code, w.Body.String(),
+				)
+			}
+		})
+	}
+}

--- a/internal/server/usage_test.go
+++ b/internal/server/usage_test.go
@@ -1,0 +1,238 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+	"github.com/wesm/agentsview/internal/dbtest"
+	"github.com/wesm/agentsview/internal/server"
+)
+
+// tokenUsageJSON is a valid token_usage blob for test messages.
+var tokenUsageJSON = json.RawMessage(
+	`{"input_tokens":100,"output_tokens":50,` +
+		`"cache_creation_input_tokens":10,` +
+		`"cache_read_input_tokens":20}`,
+)
+
+func TestParseUsageFilterDefaults(t *testing.T) {
+	te := setup(t)
+
+	// No params at all -> defaults should kick in.
+	w := te.get(t, "/api/v1/usage/summary")
+	assertStatus(t, w, http.StatusOK)
+
+	resp := decode[server.UsageSummaryResponse](t, w)
+	if resp.From == "" {
+		t.Error("From is empty, expected defaulted value")
+	}
+	if resp.To == "" {
+		t.Error("To is empty, expected defaulted value")
+	}
+	// from should be ~30 days before to.
+	if resp.From >= resp.To {
+		t.Errorf("From %q >= To %q", resp.From, resp.To)
+	}
+}
+
+func TestParseUsageFilterExplicit(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, buildPathURL("/api/v1/usage/summary",
+		map[string]string{
+			"from":     "2024-06-01",
+			"to":       "2024-06-15",
+			"timezone": "America/New_York",
+			"project":  "myproj",
+			"agent":    "claude",
+			"model":    "claude-sonnet-4-20250514",
+		}))
+	assertStatus(t, w, http.StatusOK)
+
+	resp := decode[server.UsageSummaryResponse](t, w)
+	if resp.From != "2024-06-01" {
+		t.Errorf("From = %q, want 2024-06-01", resp.From)
+	}
+	if resp.To != "2024-06-15" {
+		t.Errorf("To = %q, want 2024-06-15", resp.To)
+	}
+}
+
+func TestParseUsageFilterInvalidDate(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, buildPathURL("/api/v1/usage/summary",
+		map[string]string{"from": "yesterday"}))
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// seedUsageEnv populates sessions with token_usage data for
+// usage endpoint testing.
+func seedUsageEnv(t *testing.T, te *testEnv) {
+	t.Helper()
+
+	type entry struct {
+		id, project, agent, started string
+		msgs                        int
+	}
+	entries := []entry{
+		{"u1", "alpha", "claude", "2024-06-01T09:00:00Z", 4},
+		{"u2", "beta", "codex", "2024-06-02T10:00:00Z", 4},
+	}
+
+	for _, e := range entries {
+		te.seedSession(t, e.id, e.project, e.msgs,
+			func(sess *db.Session) {
+				sess.Agent = e.agent
+				sess.StartedAt = &e.started
+				sess.EndedAt = &e.started
+				sess.FirstMessage = dbtest.Ptr("Usage test")
+			},
+		)
+		started := e.started
+		te.seedMessages(t, e.id, e.msgs,
+			func(i int, m *db.Message) {
+				m.Timestamp = started
+				if m.Role == "assistant" {
+					m.Model = "claude-sonnet-4-20250514"
+					m.TokenUsage = tokenUsageJSON
+				}
+			},
+		)
+	}
+}
+
+func TestHandleUsageSummaryJSONShape(t *testing.T) {
+	te := setup(t)
+	seedUsageEnv(t, te)
+
+	w := te.get(t, buildPathURL("/api/v1/usage/summary",
+		map[string]string{
+			"from":     "2024-06-01",
+			"to":       "2024-06-03",
+			"timezone": "UTC",
+		}))
+	assertStatus(t, w, http.StatusOK)
+
+	// Verify all expected top-level keys exist.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(
+		w.Body.Bytes(), &raw,
+	); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	required := []string{
+		"from", "to", "totals", "daily",
+		"projectTotals", "modelTotals", "agentTotals",
+		"sessionCounts", "cacheStats",
+	}
+	for _, key := range required {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing key %q in response", key)
+		}
+	}
+
+	resp := decode[server.UsageSummaryResponse](t, w)
+	if len(resp.Daily) == 0 {
+		t.Error("Daily is empty, expected entries")
+	}
+	if len(resp.ProjectTotals) == 0 {
+		t.Error("ProjectTotals is empty")
+	}
+	if len(resp.ModelTotals) == 0 {
+		t.Error("ModelTotals is empty")
+	}
+	if len(resp.AgentTotals) == 0 {
+		t.Error("AgentTotals is empty")
+	}
+}
+
+func TestHandleUsageTopSessionsEmpty(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, buildPathURL(
+		"/api/v1/usage/top-sessions",
+		map[string]string{
+			"from":     "2024-06-01",
+			"to":       "2024-06-03",
+			"timezone": "UTC",
+		}))
+	assertStatus(t, w, http.StatusOK)
+
+	var entries []db.TopSessionEntry
+	if err := json.Unmarshal(
+		w.Body.Bytes(), &entries,
+	); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entries == nil {
+		t.Error("expected non-null JSON array")
+	}
+}
+
+func TestHandleUsageTopSessionsLimit(t *testing.T) {
+	te := setup(t)
+	seedUsageEnv(t, te)
+
+	w := te.get(t, buildPathURL(
+		"/api/v1/usage/top-sessions",
+		map[string]string{
+			"from":     "2024-06-01",
+			"to":       "2024-06-03",
+			"timezone": "UTC",
+			"limit":    "1",
+		}))
+	assertStatus(t, w, http.StatusOK)
+
+	var entries []db.TopSessionEntry
+	if err := json.Unmarshal(
+		w.Body.Bytes(), &entries,
+	); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) > 1 {
+		t.Errorf("len(entries) = %d, want <= 1",
+			len(entries))
+	}
+}
+
+// TestUsageSummaryErrorRedaction verifies internal errors
+// don't leak DB details.
+func TestUsageSummaryErrorRedaction(t *testing.T) {
+	te := setup(t)
+	te.db.Close()
+
+	w := te.get(t, buildPathURL("/api/v1/usage/summary",
+		map[string]string{
+			"from": "2024-06-01",
+			"to":   "2024-06-03",
+		}))
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+// Verify the route is actually registered by checking we
+// don't get a 404 for usage endpoints.
+func TestUsageRoutesRegistered(t *testing.T) {
+	te := setup(t)
+
+	endpoints := []string{
+		"/api/v1/usage/summary",
+		"/api/v1/usage/top-sessions",
+	}
+	for _, ep := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			req := httptest.NewRequest(
+				http.MethodGet, ep, nil,
+			)
+			w := httptest.NewRecorder()
+			te.handler.ServeHTTP(w, req)
+			if w.Code == http.StatusNotFound {
+				t.Errorf("%s returned 404", ep)
+			}
+		})
+	}
+}

--- a/scripts/dev-backend-build.sh
+++ b/scripts/dev-backend-build.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Build helper invoked by air on every Go file change. Keeps the
+# build command in one place so air config stays minimal.
+
+set -eu
+
+mkdir -p tmp
+
+# Ensure the embed dir exists even if frontend hasn't been built,
+# so go:embed doesn't complain during backend-only dev.
+mkdir -p internal/web/dist
+[ -n "$(ls internal/web/dist/ 2>/dev/null)" ] \
+  || echo ok > internal/web/dist/stub.html
+
+VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
+COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+LDFLAGS="-X main.version=${VERSION} \
+         -X main.commit=${COMMIT} \
+         -X main.buildDate=${BUILD_DATE}"
+
+CGO_ENABLED=1 go build -tags fts5 -ldflags="${LDFLAGS}" \
+  -o ./tmp/agentsview ./cmd/agentsview


### PR DESCRIPTION
## Summary

Adds a new `/usage` view with an interactive token usage dashboard: eight summary cards, stacked-area cost-over-time chart, treemap-led attribution panel, top sessions table, and cache efficiency panel. Every panel is filterable by date range, project, agent, and model (multi-select with exclude semantics + select/deselect all). Drill-down on treemap tiles toggles the matching filter. Toggle state persists to localStorage; filters persist to the URL for shareable links.

- **Backend:** extends `GetDailyUsage` with project/agent/model breakdowns and filters (both include and NOT IN exclude), adds `GetTopSessionsByCost` and `GetUsageSessionCounts` queries, and exposes `/api/v1/usage/summary` + `/api/v1/usage/top-sessions`. All three queries share a `usageMessageEligibility` WHERE-clause fragment so the filter contract stays in lockstep (covered by a parity test). The `Breakdowns` flag gates the extra SELECT columns so the CLI hot path stays within +10% of its benchmark baseline (+3.7% measured).
- **Frontend:** new `UsagePage.svelte` with 7 Svelte 5 components, a `UsageStore` that mirrors the analytics store pattern, a reusable `FilterDropdown` with checkbox-list multi-select, a `projectColor` hash util, and a squarified treemap layout (Bruls/Huijsen/van Wijk 2000). Both the time-series chart and the treemap are responsive via `ResizeObserver`. The stacked area caps at top 5 series and rolls the rest into a single "Other" band.
- **Nav:** Usage added as a primary nav item; Pinned/Insights/Trash collapsed into a "More ▾" dropdown to keep the header uncluttered.
- **Cleanup:** Output Tokens and Reporting Sessions cards removed from the sessions dashboard since that data now has a dedicated home.
- **Dev experience:** `make dev` switched to `air` for Go backend live-reload (previously `go run` held a snapshot of source at startup, which caused stale-backend confusion during development).

## Test plan

- [ ] `make test` passes
- [ ] `CGO_ENABLED=1 go test -tags fts5 -bench BenchmarkGetDailyUsage -benchtime=5s ./internal/db/` lands within +10% of the baseline recorded in the benchmark commit (71.7ms)
- [ ] `cd frontend && npm run build` completes cleanly
- [ ] `cd frontend && npx vitest run src/lib/utils/projectColor.test.ts src/lib/utils/treemap.test.ts` — all green
- [ ] `make e2e` runs `frontend/e2e/usage.spec.ts` against the test fixture — all green
- [ ] Manual smoke: load `/usage` against a real DB, verify summary cards populate, flip group-by toggles between Project/Model/Agent, exclude a project via the filter dropdown and confirm charts update, click a treemap tile to drill in, use the Deselect all button
- [ ] Navigate back from a filtered state and confirm the filter clears
- [ ] Verify light/dark theme both look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)