### PR TITLE
fix(usage): track cost for opencode and pi; sync codex exec sessions

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -261,9 +261,13 @@ func runServe(args []string) {
 	}
 
 	// Seed model_pricing after any resync swap so the new DB
-	// file (which doesn't carry pricing across the swap) gets
-	// populated before the dashboard starts answering requests.
-	go seedPricingIfEmpty(database)
+	// file (which doesn't carry pricing across the swap) is
+	// populated before the dashboard starts answering
+	// requests. Synchronous so the first usage page load does
+	// not observe an empty table; the count check is a no-op
+	// after the initial seed, and ensurePricing falls back to
+	// hardcoded rates if the network fetch fails.
+	seedPricingIfEmpty(database)
 
 	// Auto-bind to 0.0.0.0 when remote access is enabled so the
 	// server is reachable from the network. Only override if the

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -260,6 +260,11 @@ func runServe(args []string) {
 		}
 	}
 
+	// Seed model_pricing after any resync swap so the new DB
+	// file (which doesn't carry pricing across the swap) gets
+	// populated before the dashboard starts answering requests.
+	go seedPricingIfEmpty(database)
+
 	// Auto-bind to 0.0.0.0 when remote access is enabled so the
 	// server is reachable from the network. Only override if the
 	// user hasn't explicitly set --host via the CLI flag.

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -261,6 +261,25 @@ func ensureFreshData(
 	engine.SyncAllSince(ctx, since, func(sync.Progress) {})
 }
 
+// seedPricingIfEmpty populates the model_pricing table on first
+// run when the server starts. Without this, a fresh install that
+// only ever opens the web dashboard sees $0 across the board
+// because no CLI command has fetched LiteLLM rates yet. It is
+// safe to call repeatedly: it only fetches when the table is
+// empty so curated rates from a prior `agentsview usage` run
+// are never overwritten.
+func seedPricingIfEmpty(database *db.DB) {
+	n, err := database.CountModelPricing()
+	if err != nil {
+		log.Printf("pricing seed: %v", err)
+		return
+	}
+	if n > 0 {
+		return
+	}
+	ensurePricing(database, false)
+}
+
 func ensurePricing(database *db.DB, offline bool) {
 	var prices []pricing.ModelPricing
 

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -262,12 +262,21 @@ func ensureFreshData(
 }
 
 // seedPricingIfEmpty populates the model_pricing table on first
-// run when the server starts. Without this, a fresh install that
-// only ever opens the web dashboard sees $0 across the board
-// because no CLI command has fetched LiteLLM rates yet. It is
-// safe to call repeatedly: it only fetches when the table is
-// empty so curated rates from a prior `agentsview usage` run
-// are never overwritten.
+// run when the server starts. Without this, a fresh install
+// that only ever opens the web dashboard sees $0 across the
+// board because no CLI command has fetched LiteLLM rates yet.
+// It is safe to call repeatedly: it only seeds when the table
+// is empty so curated rates from a prior `agentsview usage`
+// run are never overwritten.
+//
+// The seed runs in two stages:
+//
+//  1. Synchronous upsert of the hardcoded fallback rates so the
+//     dashboard and any startup-waiting CLI probes observe a
+//     populated table as soon as the server accepts requests.
+//  2. Background LiteLLM refresh so the full multi-provider
+//     catalog lands shortly after startup without holding the
+//     listen socket behind a 30-second HTTP timeout.
 func seedPricingIfEmpty(database *db.DB) {
 	n, err := database.CountModelPricing()
 	if err != nil {
@@ -277,7 +286,23 @@ func seedPricingIfEmpty(database *db.DB) {
 	if n > 0 {
 		return
 	}
-	ensurePricing(database, false)
+	upsertPricing(database, pricing.FallbackPricing())
+	go refreshPricingFromLiteLLM(database)
+}
+
+// refreshPricingFromLiteLLM fetches the upstream LiteLLM
+// catalog and upserts it over whatever is in the table. Called
+// from a goroutine after the synchronous fallback seed so a
+// slow or failing fetch never blocks server startup.
+func refreshPricingFromLiteLLM(database *db.DB) {
+	prices, err := pricing.FetchLiteLLMPricing()
+	if err != nil {
+		log.Printf(
+			"pricing refresh: litellm fetch failed: %v", err,
+		)
+		return
+	}
+	upsertPricing(database, prices)
 }
 
 func ensurePricing(database *db.DB, offline bool) {
@@ -296,6 +321,16 @@ func ensurePricing(database *db.DB, offline bool) {
 		}
 	}
 
+	upsertPricing(database, prices)
+}
+
+// upsertPricing copies pricing rows into the db.ModelPricing
+// shape and upserts them. Shared by ensurePricing (CLI),
+// seedPricingIfEmpty (sync fallback), and
+// refreshPricingFromLiteLLM (async refresh).
+func upsertPricing(
+	database *db.DB, prices []pricing.ModelPricing,
+) {
 	dbPrices := make([]db.ModelPricing, len(prices))
 	for i, p := range prices {
 		dbPrices[i] = db.ModelPricing{
@@ -306,10 +341,8 @@ func ensurePricing(database *db.DB, offline bool) {
 			CacheReadPerMTok:     p.CacheReadPerMTok,
 		}
 	}
-
 	if err := database.UpsertModelPricing(dbPrices); err != nil {
-		fmt.Fprintf(os.Stderr,
-			"warning: could not update pricing: %v\n", err)
+		log.Printf("pricing upsert: %v", err)
 	}
 }
 

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -5,6 +5,10 @@
   const CHART_H = 180;
   const X_LABEL_H = 20;
   const Y_LABEL_W = 40;
+  // Reserved headroom at the top of the plot area so the
+  // maximum bar, its grid line, and the top y-axis label's
+  // ascenders do not clip against the SVG viewBox edge.
+  const TOP_PAD = 10;
   const MAX_SERIES = 5;
 
   const OTHER_COLOR = "var(--text-muted)";
@@ -138,6 +142,35 @@
 
   const BAR_WIDTH = 40;
 
+  // niceCeil rounds v up to the next "nice" round number
+  // (1, 2, 2.5, 5, 10 × 10^n) so the y-axis top tick is a
+  // readable value instead of an arbitrary data max. Combined
+  // with TOP_PAD this is what gives the chart its headroom.
+  function niceCeil(v: number): number {
+    if (!Number.isFinite(v) || v <= 0) return 1;
+    const exp = Math.floor(Math.log10(v));
+    const base = Math.pow(10, exp);
+    const normalized = v / base;
+    let nice: number;
+    if (normalized <= 1) nice = 1;
+    else if (normalized <= 2) nice = 2;
+    else if (normalized <= 2.5) nice = 2.5;
+    else if (normalized <= 5) nice = 5;
+    else nice = 10;
+    return nice * base;
+  }
+
+  const niceMax = $derived(niceCeil(seriesData.maxY));
+
+  // scaleY maps a data value in [0, niceMax] onto the plot
+  // area [TOP_PAD, h], inverted so 0 is at the bottom. Kept
+  // as a function so both buildPaths and yTicks use identical
+  // math and the top tick lines up with the highest bar.
+  function scaleY(val: number, max: number, h: number): number {
+    const plotH = h - TOP_PAD;
+    return h - (val / max) * plotH;
+  }
+
   function buildPaths(
     points: Point[],
     keys: string[],
@@ -160,8 +193,8 @@
       let baseline = 0;
       for (const key of keys) {
         const val = points[0]!.values[key] ?? 0;
-        const top = h - ((baseline + val) / maxY) * h;
-        const bot = h - (baseline / maxY) * h;
+        const top = scaleY(baseline + val, maxY, h);
+        const bot = scaleY(baseline, maxY, h);
         const d =
           `M${x0},${bot}` +
           `L${x0},${top}` +
@@ -191,14 +224,14 @@
       for (let i = 0; i < points.length; i++) {
         const x = Y_LABEL_W + i * xStep;
         const val = points[i]!.values[key] ?? 0;
-        const top = h - ((baselines[i]! + val) / maxY) * h;
+        const top = scaleY(baselines[i]! + val, maxY, h);
         d += i === 0 ? `M${x},${top}` : `L${x},${top}`;
       }
 
       // Close area back along baseline
       for (let i = points.length - 1; i >= 0; i--) {
         const x = Y_LABEL_W + i * xStep;
-        const base = h - (baselines[i]! / maxY) * h;
+        const base = scaleY(baselines[i]!, maxY, h);
         d += `L${x},${base}`;
       }
       d += "Z";
@@ -220,7 +253,7 @@
     buildPaths(
       seriesData.points,
       seriesData.keys,
-      seriesData.maxY,
+      niceMax,
       chartWidth,
       CHART_H,
     ),
@@ -267,14 +300,13 @@
   }
 
   const yTicks = $derived.by(() => {
-    const max = seriesData.maxY;
-    if (max <= 0) return [];
+    if (niceMax <= 0) return [];
     const ticks: Array<{ y: number; label: string }> = [];
     const count = 4;
     for (let i = 0; i <= count; i++) {
-      const val = (max / count) * i;
+      const val = (niceMax / count) * i;
       ticks.push({
-        y: CHART_H - (val / max) * CHART_H,
+        y: scaleY(val, niceMax, CHART_H),
         label: fmtYLabel(val),
       });
     }

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -142,25 +142,35 @@
 
   const BAR_WIDTH = 40;
 
-  // niceCeil rounds v up to the next "nice" round number
-  // (1, 2, 2.5, 5, 10 × 10^n) so the y-axis top tick is a
-  // readable value instead of an arbitrary data max. Combined
-  // with TOP_PAD this is what gives the chart its headroom.
-  function niceCeil(v: number): number {
-    if (!Number.isFinite(v) || v <= 0) return 1;
-    const exp = Math.floor(Math.log10(v));
+  // TICK_TARGET is the number of y-axis intervals we aim
+  // for. niceScale picks a step from the 1/2/5 × 10ⁿ set so
+  // the chosen max is always an integer multiple of the step
+  // and every tick lands on a round value. Actual interval
+  // count may come out as target ± 1 depending on where maxY
+  // falls.
+  const TICK_TARGET = 5;
+
+  function niceScale(
+    maxY: number,
+  ): { step: number; max: number } {
+    if (!Number.isFinite(maxY) || maxY <= 0) {
+      return { step: 0.25, max: 1 };
+    }
+    const rough = maxY / TICK_TARGET;
+    const exp = Math.floor(Math.log10(rough));
     const base = Math.pow(10, exp);
-    const normalized = v / base;
-    let nice: number;
-    if (normalized <= 1) nice = 1;
-    else if (normalized <= 2) nice = 2;
-    else if (normalized <= 2.5) nice = 2.5;
-    else if (normalized <= 5) nice = 5;
-    else nice = 10;
-    return nice * base;
+    const normalized = rough / base;
+    let mult: number;
+    if (normalized <= 1) mult = 1;
+    else if (normalized <= 2) mult = 2;
+    else if (normalized <= 5) mult = 5;
+    else mult = 10;
+    const step = mult * base;
+    const max = Math.ceil(maxY / step) * step;
+    return { step, max };
   }
 
-  const niceMax = $derived(niceCeil(seriesData.maxY));
+  const scale = $derived(niceScale(seriesData.maxY));
 
   // scaleY maps a data value in [0, niceMax] onto the plot
   // area [TOP_PAD, h], inverted so 0 is at the bottom. Kept
@@ -253,7 +263,7 @@
     buildPaths(
       seriesData.points,
       seriesData.keys,
-      niceMax,
+      scale.max,
       chartWidth,
       CHART_H,
     ),
@@ -300,13 +310,17 @@
   }
 
   const yTicks = $derived.by(() => {
-    if (niceMax <= 0) return [];
+    const { step, max } = scale;
+    if (max <= 0 || step <= 0) return [];
     const ticks: Array<{ y: number; label: string }> = [];
-    const count = 4;
+    // Step-driven loop so every tick is an integer multiple
+    // of step and the top tick equals max exactly. Rounding
+    // guards against floating-point drift on sub-unit steps.
+    const count = Math.round(max / step);
     for (let i = 0; i <= count; i++) {
-      const val = (niceMax / count) * i;
+      const val = step * i;
       ticks.push({
-        y: scaleY(val, niceMax, CHART_H),
+        y: scaleY(val, max, CHART_H),
         label: fmtYLabel(val),
       });
     }

--- a/frontend/src/lib/components/usage/UsageSummaryCards.svelte
+++ b/frontend/src/lib/components/usage/UsageSummaryCards.svelte
@@ -25,12 +25,18 @@
     return `${(v * 100).toFixed(1)}%`;
   }
 
-  const totalTokens = $derived.by(() => {
-    const s = usage.summary;
-    if (!s) return 0;
-    const t = s.totals;
-    return t.inputTokens + t.outputTokens
-      + t.cacheCreationTokens + t.cacheReadTokens;
+  const inputTokens = $derived(
+    usage.summary?.totals.inputTokens ?? 0,
+  );
+
+  const outputTokens = $derived(
+    usage.summary?.totals.outputTokens ?? 0,
+  );
+
+  const cachedTokens = $derived.by(() => {
+    const t = usage.summary?.totals;
+    if (!t) return 0;
+    return t.cacheCreationTokens + t.cacheReadTokens;
   });
 
   const dailyBurn = $derived.by(() => {
@@ -79,8 +85,14 @@
       featured: true,
     },
     {
-      label: "Tokens",
-      value: () => fmtTokens(totalTokens),
+      label: "Input Tokens",
+      value: () => fmtTokens(inputTokens),
+      sub: () =>
+        cachedTokens > 0 ? `+${fmtTokens(cachedTokens)} cached` : "",
+    },
+    {
+      label: "Output Tokens",
+      value: () => fmtTokens(outputTokens),
     },
     {
       label: "Daily Burn",

--- a/frontend/src/lib/components/usage/UsageSummaryCards.svelte
+++ b/frontend/src/lib/components/usage/UsageSummaryCards.svelte
@@ -33,11 +33,15 @@
     usage.summary?.totals.outputTokens ?? 0,
   );
 
-  const cachedTokens = $derived.by(() => {
-    const t = usage.summary?.totals;
-    if (!t) return 0;
-    return t.cacheCreationTokens + t.cacheReadTokens;
-  });
+  // "cached" here means input tokens that were actually
+  // served from cache, i.e. cacheReadTokens. Cache-creation
+  // tokens are cache writes — fresh input paying the
+  // cache-write surcharge rather than being replayed from
+  // cache — so folding them in would overstate cache usage
+  // on workloads that only warm the cache.
+  const cachedTokens = $derived(
+    usage.summary?.totals.cacheReadTokens ?? 0,
+  );
 
   const dailyBurn = $derived.by(() => {
     const s = usage.summary;

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -25,7 +25,12 @@ import (
 // formatting changes). Old databases with a lower user_version
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
-const dataVersion = 9
+//
+// Bumped to 10: opencode and pi parsers now extract per-message
+// model id and token usage so the cost dashboard attributes
+// non-Claude/Codex sessions correctly. Existing rows have empty
+// model and token_usage and need a reparse to backfill.
+const dataVersion = 10
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/pricing.go
+++ b/internal/db/pricing.go
@@ -63,6 +63,20 @@ func (db *DB) UpsertModelPricing(
 	return tx.Commit()
 }
 
+// CountModelPricing returns the number of rows in model_pricing.
+// Used by the server to decide whether to seed pricing on
+// startup so a fresh install does not silently report $0 cost.
+func (db *DB) CountModelPricing() (int, error) {
+	var n int
+	err := db.getReader().QueryRow(
+		`SELECT count(*) FROM model_pricing`,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("counting model_pricing: %w", err)
+	}
+	return n, nil
+}
+
 // GetModelPricing returns pricing for an exact model match.
 // Returns nil, nil if not found.
 func (db *DB) GetModelPricing(

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1017,9 +1017,15 @@ func extractCodexContent(payload gjson.Result) string {
 	return strings.Join(texts, "\n")
 }
 
-// IsCodexExecSessionFile reports whether the first non-empty
-// session_meta line in a Codex JSONL file has
-// originator=="codex_exec".
+// IsCodexExecSessionFile reports whether any session_meta
+// line in a Codex JSONL file has originator=="codex_exec".
+// The pre-bulk-sync parser called handleSessionMeta on every
+// session_meta line and flagged the whole session as exec if
+// any of them carried that originator, so a one-shot check
+// of only the first session_meta would miss files that were
+// originally skipped because a later session_meta set the
+// originator. Scan all session_meta lines to match the old
+// skip condition exactly.
 func IsCodexExecSessionFile(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
@@ -1037,8 +1043,10 @@ func IsCodexExecSessionFile(path string) bool {
 		if gjson.Get(line, "type").Str != codexTypeSessionMeta {
 			continue
 		}
-		return gjson.Get(line, "payload.originator").Str ==
-			codexOriginatorExec
+		if gjson.Get(line, "payload.originator").Str ==
+			codexOriginatorExec {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,7 +38,6 @@ type codexSessionBuilder struct {
 	sessionID            string
 	project              string
 	ordinal              int
-	includeExec          bool
 	currentModel         string
 	callNames            map[string]string
 	callRefs             map[string]codexToolCallRef
@@ -63,11 +63,10 @@ type codexPendingEvent struct {
 }
 
 func newCodexSessionBuilder(
-	includeExec bool,
+	_ bool,
 ) *codexSessionBuilder {
 	return &codexSessionBuilder{
 		project:              "unknown",
-		includeExec:          includeExec,
 		callNames:            make(map[string]string),
 		callRefs:             make(map[string]codexToolCallRef),
 		agentSpawnCalls:      make(map[string]string),
@@ -78,8 +77,6 @@ func newCodexSessionBuilder(
 }
 
 // processLine handles a single non-empty, valid JSON line.
-// Returns (skip=true) if the session should be discarded
-// (e.g. non-interactive codex_exec).
 func (b *codexSessionBuilder) processLine(
 	line string,
 ) (skip bool) {
@@ -125,10 +122,6 @@ func (b *codexSessionBuilder) handleSessionMeta(
 		}
 	}
 
-	if !b.includeExec &&
-		payload.Get("originator").Str == codexOriginatorExec {
-		return true
-	}
 	return false
 }
 
@@ -1024,9 +1017,36 @@ func extractCodexContent(payload gjson.Result) string {
 	return strings.Join(texts, "\n")
 }
 
+// IsCodexExecSessionFile reports whether the first non-empty
+// session_meta line in a Codex JSONL file has
+// originator=="codex_exec".
+func IsCodexExecSessionFile(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 64*1024), maxLineSize)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || !gjson.Valid(line) {
+			continue
+		}
+		if gjson.Get(line, "type").Str != codexTypeSessionMeta {
+			continue
+		}
+		return gjson.Get(line, "payload.originator").Str ==
+			codexOriginatorExec
+	}
+	return false
+}
+
 // ParseCodexSession parses a Codex JSONL session file.
-// Returns nil session if the session is non-interactive and
-// includeExec is false.
+// The includeExec parameter is retained for backward
+// compatibility; exec-originated sessions are now always
+// parsed and imported.
 func ParseCodexSession(
 	path, machine string, includeExec bool,
 ) (*ParsedSession, []ParsedMessage, error) {

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -53,9 +53,11 @@ func TestParseCodexSession_ExecOriginator(t *testing.T) {
 		testjsonl.CodexMsgJSON("user", "test", tsEarlyS1),
 	)
 
-	t.Run("skips exec originator", func(t *testing.T) {
-		sess, _ := runCodexParserTest(t, "test.jsonl", execContent, false)
-		assert.Nil(t, sess)
+	t.Run("includes exec originator by default", func(t *testing.T) {
+		sess, msgs := runCodexParserTest(t, "test.jsonl", execContent, false)
+		require.NotNil(t, sess)
+		assert.Equal(t, "codex:abc", sess.ID)
+		assert.Equal(t, 1, len(msgs))
 	})
 
 	t.Run("includes exec when requested", func(t *testing.T) {

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -487,6 +487,11 @@ func buildOpenCodeSession(
 // `cache.{read,write}` shape; this maps them onto the
 // agentsview-native `cache_{read,creation}_input_tokens` keys
 // that internal/db/usage.go expects.
+//
+// A present `tokens` object is treated as authoritative: even
+// when every counter is zero (e.g. an errored request) the
+// normalized usage is written and coverage flags are set, so
+// downstream rollups distinguish "known zero" from "unknown".
 func applyOpenCodeTokenUsage(
 	pm *ParsedMessage, md openCodeMessageData,
 ) {
@@ -497,10 +502,6 @@ func applyOpenCodeTokenUsage(
 		return
 	}
 	t := md.Tokens
-	if t.Input == 0 && t.Output == 0 &&
-		t.Cache.Read == 0 && t.Cache.Write == 0 {
-		return
-	}
 
 	normalized := map[string]int{
 		"input_tokens":                t.Input,
@@ -514,9 +515,9 @@ func applyOpenCodeTokenUsage(
 	}
 	pm.TokenUsage = j
 	pm.OutputTokens = t.Output
-	pm.HasOutputTokens = t.Output > 0
+	pm.HasOutputTokens = true
 	pm.ContextTokens = t.Input + t.Cache.Read + t.Cache.Write
-	pm.HasContextTokens = pm.ContextTokens > 0
+	pm.HasContextTokens = true
 }
 
 // openCodeDefaultTitleRe matches the exact placeholder format

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -271,9 +271,29 @@ type openCodeMessageRow struct {
 }
 
 // openCodeMessageData holds the fields we extract from the
-// message data JSON blob.
+// message data JSON blob. Assistant rows additionally carry the
+// model id and per-message token counts that drive cost
+// calculation in the usage dashboard.
 type openCodeMessageData struct {
-	Role string `json:"role"`
+	Role    string                 `json:"role"`
+	ModelID string                 `json:"modelID"`
+	Tokens  *openCodeMessageTokens `json:"tokens,omitempty"`
+}
+
+// openCodeMessageTokens mirrors the OpenCode `tokens` object.
+// Reasoning tokens are recorded by OpenCode but are already
+// counted inside `output` for billing purposes, so they are
+// kept only as metadata and not added to output_tokens.
+type openCodeMessageTokens struct {
+	Input     int                  `json:"input"`
+	Output    int                  `json:"output"`
+	Reasoning int                  `json:"reasoning"`
+	Cache     openCodeMessageCache `json:"cache"`
+}
+
+type openCodeMessageCache struct {
+	Read  int `json:"read"`
+	Write int `json:"write"`
 }
 
 // openCodePartRow is a row from the opencode part table.
@@ -398,6 +418,7 @@ func buildOpenCodeSession(
 		pm := buildOpenCodeMessage(
 			ordinal, role, m.timeCreated, msgParts,
 		)
+		applyOpenCodeTokenUsage(&pm, md)
 		if strings.TrimSpace(pm.Content) == "" &&
 			!pm.HasToolUse {
 			continue
@@ -455,7 +476,47 @@ func buildOpenCodeSession(
 		},
 	}
 
+	accumulateMessageTokenUsage(sess, parsed)
+
 	return sess, parsed, nil
+}
+
+// applyOpenCodeTokenUsage copies the assistant message's model
+// id and per-message token counts into pm so the usage dashboard
+// can attribute cost. OpenCode's token field names use a nested
+// `cache.{read,write}` shape; this maps them onto the
+// agentsview-native `cache_{read,creation}_input_tokens` keys
+// that internal/db/usage.go expects.
+func applyOpenCodeTokenUsage(
+	pm *ParsedMessage, md openCodeMessageData,
+) {
+	if md.ModelID != "" {
+		pm.Model = md.ModelID
+	}
+	if md.Tokens == nil {
+		return
+	}
+	t := md.Tokens
+	if t.Input == 0 && t.Output == 0 &&
+		t.Cache.Read == 0 && t.Cache.Write == 0 {
+		return
+	}
+
+	normalized := map[string]int{
+		"input_tokens":                t.Input,
+		"output_tokens":               t.Output,
+		"cache_read_input_tokens":     t.Cache.Read,
+		"cache_creation_input_tokens": t.Cache.Write,
+	}
+	j, err := json.Marshal(normalized)
+	if err != nil {
+		return
+	}
+	pm.TokenUsage = j
+	pm.OutputTokens = t.Output
+	pm.HasOutputTokens = t.Output > 0
+	pm.ContextTokens = t.Input + t.Cache.Read + t.Cache.Write
+	pm.HasContextTokens = pm.ContextTokens > 0
 }
 
 // openCodeDefaultTitleRe matches the exact placeholder format

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/tidwall/gjson"
 )
 
 // OpenCodeSession bundles a parsed session with its messages.
@@ -270,30 +272,13 @@ type openCodeMessageRow struct {
 	timeCreated int64
 }
 
-// openCodeMessageData holds the fields we extract from the
-// message data JSON blob. Assistant rows additionally carry the
-// model id and per-message token counts that drive cost
-// calculation in the usage dashboard.
+// openCodeMessageData holds the scalar fields we extract from
+// the message data JSON blob. Token usage lives under `tokens`
+// and is read separately via gjson so the parser can
+// distinguish explicit zero fields from absent ones.
 type openCodeMessageData struct {
-	Role    string                 `json:"role"`
-	ModelID string                 `json:"modelID"`
-	Tokens  *openCodeMessageTokens `json:"tokens,omitempty"`
-}
-
-// openCodeMessageTokens mirrors the OpenCode `tokens` object.
-// Reasoning tokens are recorded by OpenCode but are already
-// counted inside `output` for billing purposes, so they are
-// kept only as metadata and not added to output_tokens.
-type openCodeMessageTokens struct {
-	Input     int                  `json:"input"`
-	Output    int                  `json:"output"`
-	Reasoning int                  `json:"reasoning"`
-	Cache     openCodeMessageCache `json:"cache"`
-}
-
-type openCodeMessageCache struct {
-	Read  int `json:"read"`
-	Write int `json:"write"`
+	Role    string `json:"role"`
+	ModelID string `json:"modelID"`
 }
 
 // openCodePartRow is a row from the opencode part table.
@@ -418,7 +403,7 @@ func buildOpenCodeSession(
 		pm := buildOpenCodeMessage(
 			ordinal, role, m.timeCreated, msgParts,
 		)
-		applyOpenCodeTokenUsage(&pm, md)
+		applyOpenCodeTokenUsage(&pm, md, m.data)
 		if strings.TrimSpace(pm.Content) == "" &&
 			!pm.HasToolUse {
 			continue
@@ -482,42 +467,59 @@ func buildOpenCodeSession(
 }
 
 // applyOpenCodeTokenUsage copies the assistant message's model
-// id and per-message token counts into pm so the usage dashboard
-// can attribute cost. OpenCode's token field names use a nested
-// `cache.{read,write}` shape; this maps them onto the
-// agentsview-native `cache_{read,creation}_input_tokens` keys
-// that internal/db/usage.go expects.
+// id and per-message token counts into pm so the usage
+// dashboard can attribute cost. OpenCode's token field names
+// use a nested `cache.{read,write}` shape; this maps them onto
+// the agentsview-native `cache_{read,creation}_input_tokens`
+// keys that internal/db/usage.go expects.
 //
-// A present `tokens` object is treated as authoritative: even
-// when every counter is zero (e.g. an errored request) the
-// normalized usage is written and coverage flags are set, so
-// downstream rollups distinguish "known zero" from "unknown".
+// Coverage semantics match the claude parser contract: a field
+// that is present at zero is preserved as "known zero" and
+// sets its coverage flag, while a tokens object with no
+// recognized fields (empty `{}` or a foreign schema) leaves
+// TokenUsage empty so the usage query filter skips the row.
 func applyOpenCodeTokenUsage(
-	pm *ParsedMessage, md openCodeMessageData,
+	pm *ParsedMessage, md openCodeMessageData, dataRaw string,
 ) {
 	if md.ModelID != "" {
 		pm.Model = md.ModelID
 	}
-	if md.Tokens == nil {
+	tokens := gjson.Get(dataRaw, "tokens")
+	if !tokens.Exists() {
 		return
 	}
-	t := md.Tokens
+
+	inputField := tokens.Get("input")
+	outputField := tokens.Get("output")
+	cacheReadField := tokens.Get("cache.read")
+	cacheWriteField := tokens.Get("cache.write")
+
+	if !inputField.Exists() && !outputField.Exists() &&
+		!cacheReadField.Exists() && !cacheWriteField.Exists() {
+		return
+	}
+
+	input := int(inputField.Int())
+	output := int(outputField.Int())
+	cacheRead := int(cacheReadField.Int())
+	cacheCreate := int(cacheWriteField.Int())
 
 	normalized := map[string]int{
-		"input_tokens":                t.Input,
-		"output_tokens":               t.Output,
-		"cache_read_input_tokens":     t.Cache.Read,
-		"cache_creation_input_tokens": t.Cache.Write,
+		"input_tokens":                input,
+		"output_tokens":               output,
+		"cache_read_input_tokens":     cacheRead,
+		"cache_creation_input_tokens": cacheCreate,
 	}
 	j, err := json.Marshal(normalized)
 	if err != nil {
 		return
 	}
 	pm.TokenUsage = j
-	pm.OutputTokens = t.Output
-	pm.HasOutputTokens = true
-	pm.ContextTokens = t.Input + t.Cache.Read + t.Cache.Write
-	pm.HasContextTokens = true
+	pm.OutputTokens = output
+	pm.HasOutputTokens = outputField.Exists()
+	pm.ContextTokens = input + cacheRead + cacheCreate
+	pm.HasContextTokens = inputField.Exists() ||
+		cacheReadField.Exists() || cacheWriteField.Exists()
 }
 
 // openCodeDefaultTitleRe matches the exact placeholder format

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -546,6 +546,78 @@ func TestParseOpenCodeDB_TokenUsage(t *testing.T) {
 		s.Session.PeakContextTokens, 12470) // 1 + 500 + 11969
 }
 
+// TestParseOpenCodeDB_ZeroTokens verifies that an explicit
+// tokens block with every counter set to zero is preserved as
+// "known zero" rather than collapsed to "unknown". The
+// normalized token_usage row is still written and both
+// coverage flags are set, so downstream rollups can
+// distinguish an errored request from a missing usage blob.
+func TestParseOpenCodeDB_ZeroTokens(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", "/tmp/proj")
+	seeder.AddSession("ses_zero", "prj_1", "", "Zero",
+		1700000000000, 1700000010000)
+
+	seeder.AddMessage("msg_u", "ses_zero",
+		1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("prt_u", "msg_u", "ses_zero",
+		1700000000000, 1700000000000,
+		`{"type":"text","text":"hi"}`)
+
+	// Errored assistant request: OpenCode still records the
+	// tokens object with every field set to zero. Non-empty
+	// content keeps the row out of the "empty message" filter
+	// so the usage extraction path is actually exercised.
+	seeder.AddMessage("msg_a", "ses_zero",
+		1700000005000, 1700000005000,
+		`{"role":"assistant","modelID":"gpt-5.2-chat-latest",`+
+			`"providerID":"openai","cost":0,`+
+			`"tokens":{"input":0,"output":0,"reasoning":0,`+
+			`"cache":{"read":0,"write":0}}}`)
+	seeder.AddPart("prt_a", "msg_a", "ses_zero",
+		1700000005000, 1700000005000,
+		`{"type":"text","text":"sorry, request failed"}`)
+
+	sessions, err := ParseOpenCodeDB(dbPath, "m")
+	if err != nil {
+		t.Fatalf("ParseOpenCodeDB: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions len = %d, want 1", len(sessions))
+	}
+
+	var asst *ParsedMessage
+	for i := range sessions[0].Messages {
+		if sessions[0].Messages[i].Role == RoleAssistant {
+			asst = &sessions[0].Messages[i]
+			break
+		}
+	}
+	if asst == nil {
+		t.Fatal("missing assistant message")
+	}
+	assertEq(t, "Model", asst.Model, "gpt-5.2-chat-latest")
+	if len(asst.TokenUsage) == 0 {
+		t.Fatal("TokenUsage empty; want zero-valued JSON preserved")
+	}
+	var got map[string]int
+	if err := json.Unmarshal(asst.TokenUsage, &got); err != nil {
+		t.Fatalf("unmarshal TokenUsage: %v", err)
+	}
+	assertEq(t, "input_tokens", got["input_tokens"], 0)
+	assertEq(t, "output_tokens", got["output_tokens"], 0)
+	assertEq(t, "cache_read_input_tokens",
+		got["cache_read_input_tokens"], 0)
+	assertEq(t, "cache_creation_input_tokens",
+		got["cache_creation_input_tokens"], 0)
+	assertEq(t, "HasOutputTokens", asst.HasOutputTokens, true)
+	assertEq(t, "HasContextTokens", asst.HasContextTokens, true)
+	assertEq(t, "OutputTokens", asst.OutputTokens, 0)
+	assertEq(t, "ContextTokens", asst.ContextTokens, 0)
+}
+
 // TestParseOpenCodeDB_NoTokenUsage verifies that assistant
 // messages with no tokens block (e.g. errored requests) leave
 // TokenUsage empty so they are filtered out by the usage query.

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -423,4 +424,173 @@ func TestListOpenCodeSessionMeta_NonexistentDB(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assertEq(t, "metas len", len(metas), 0)
+}
+
+// TestParseOpenCodeDB_TokenUsage verifies that an assistant
+// message with modelID and tokens populates ParsedMessage.Model
+// and TokenUsage in the agentsview-native key shape, and that
+// session totals roll up. Without this fix the usage dashboard
+// reports $0 for every OpenCode session.
+func TestParseOpenCodeDB_TokenUsage(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", "/home/user/code/myapp")
+	seeder.AddSession("ses_usage", "prj_1", "", "Usage Test",
+		1700000000000, 1700000060000)
+
+	seeder.AddMessage("msg_user", "ses_usage",
+		1700000000000, 1700000000000,
+		`{"role":"user"}`)
+	seeder.AddPart("prt_user", "msg_user", "ses_usage",
+		1700000000000, 1700000000000,
+		`{"type":"text","text":"hi"}`)
+
+	// Assistant message with full token blob: input, output,
+	// cache.read, cache.write. Mirrors the real OpenCode shape
+	// for OpenAI and Anthropic providers.
+	assistantData := `{"role":"assistant","modelID":"gpt-5.2-codex",` +
+		`"providerID":"openai","cost":0.0186375,` +
+		`"tokens":{"input":10370,"output":35,"reasoning":0,` +
+		`"cache":{"read":0,"write":0}}}`
+	seeder.AddMessage("msg_asst", "ses_usage",
+		1700000010000, 1700000010000, assistantData)
+	seeder.AddPart("prt_asst", "msg_asst", "ses_usage",
+		1700000010000, 1700000010000,
+		`{"type":"text","text":"answer"}`)
+
+	// Second assistant with cache read+write to verify the
+	// nested cache.{read,write} fields map onto the
+	// cache_{read,creation}_input_tokens keys.
+	cacheData := `{"role":"assistant","modelID":"claude-sonnet-4-20250514",` +
+		`"providerID":"anthropic","cost":0.04641675,` +
+		`"tokens":{"input":1,"output":102,"reasoning":0,` +
+		`"cache":{"read":500,"write":11969}}}`
+	seeder.AddMessage("msg_asst2", "ses_usage",
+		1700000020000, 1700000020000, cacheData)
+	seeder.AddPart("prt_asst2", "msg_asst2", "ses_usage",
+		1700000020000, 1700000020000,
+		`{"type":"text","text":"answer2"}`)
+
+	sessions, err := ParseOpenCodeDB(dbPath, "testmachine")
+	if err != nil {
+		t.Fatalf("ParseOpenCodeDB: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions len = %d, want 1", len(sessions))
+	}
+	s := sessions[0]
+
+	var asst1, asst2 *ParsedMessage
+	for i := range s.Messages {
+		m := &s.Messages[i]
+		if m.Role != RoleAssistant {
+			continue
+		}
+		switch m.Model {
+		case "gpt-5.2-codex":
+			asst1 = m
+		case "claude-sonnet-4-20250514":
+			asst2 = m
+		}
+	}
+	if asst1 == nil {
+		t.Fatal("missing gpt-5.2-codex assistant message")
+	}
+	if asst2 == nil {
+		t.Fatal("missing claude-sonnet assistant message")
+	}
+
+	checkUsage := func(name string, m *ParsedMessage,
+		wantIn, wantOut, wantCacheRead, wantCacheCreate int) {
+		t.Helper()
+		if len(m.TokenUsage) == 0 {
+			t.Fatalf("%s: TokenUsage empty", name)
+		}
+		var got map[string]int
+		if err := json.Unmarshal(m.TokenUsage, &got); err != nil {
+			t.Fatalf("%s: unmarshal TokenUsage: %v", name, err)
+		}
+		assertEq(t, name+" input_tokens",
+			got["input_tokens"], wantIn)
+		assertEq(t, name+" output_tokens",
+			got["output_tokens"], wantOut)
+		assertEq(t, name+" cache_read_input_tokens",
+			got["cache_read_input_tokens"], wantCacheRead)
+		assertEq(t, name+" cache_creation_input_tokens",
+			got["cache_creation_input_tokens"], wantCacheCreate)
+		assertEq(t, name+" OutputTokens",
+			m.OutputTokens, wantOut)
+		assertEq(t, name+" HasOutputTokens",
+			m.HasOutputTokens, wantOut > 0)
+		wantCtx := wantIn + wantCacheRead + wantCacheCreate
+		assertEq(t, name+" ContextTokens",
+			m.ContextTokens, wantCtx)
+		assertEq(t, name+" HasContextTokens",
+			m.HasContextTokens, wantCtx > 0)
+	}
+
+	checkUsage("gpt", asst1, 10370, 35, 0, 0)
+	checkUsage("claude", asst2, 1, 102, 500, 11969)
+
+	// Session-level rollups via accumulateMessageTokenUsage.
+	if !s.Session.HasTotalOutputTokens {
+		t.Fatal("session HasTotalOutputTokens=false, want true")
+	}
+	assertEq(t, "TotalOutputTokens",
+		s.Session.TotalOutputTokens, 137) // 35 + 102
+	if !s.Session.HasPeakContextTokens {
+		t.Fatal("session HasPeakContextTokens=false, want true")
+	}
+	assertEq(t, "PeakContextTokens",
+		s.Session.PeakContextTokens, 12470) // 1 + 500 + 11969
+}
+
+// TestParseOpenCodeDB_NoTokenUsage verifies that assistant
+// messages with no tokens block (e.g. errored requests) leave
+// TokenUsage empty so they are filtered out by the usage query.
+func TestParseOpenCodeDB_NoTokenUsage(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", "/tmp/proj")
+	seeder.AddSession("ses_err", "prj_1", "", "Errored",
+		1700000000000, 1700000010000)
+
+	seeder.AddMessage("msg_u", "ses_err",
+		1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("prt_u", "msg_u", "ses_err",
+		1700000000000, 1700000000000,
+		`{"type":"text","text":"hi"}`)
+
+	// No tokens block at all (errored request).
+	seeder.AddMessage("msg_a", "ses_err",
+		1700000005000, 1700000005000,
+		`{"role":"assistant","modelID":"gpt-5.4","providerID":"openai"}`)
+	seeder.AddPart("prt_a", "msg_a", "ses_err",
+		1700000005000, 1700000005000,
+		`{"type":"text","text":"oops"}`)
+
+	sessions, err := ParseOpenCodeDB(dbPath, "m")
+	if err != nil {
+		t.Fatalf("ParseOpenCodeDB: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions len = %d, want 1", len(sessions))
+	}
+
+	var asst *ParsedMessage
+	for i := range sessions[0].Messages {
+		if sessions[0].Messages[i].Role == RoleAssistant {
+			asst = &sessions[0].Messages[i]
+			break
+		}
+	}
+	if asst == nil {
+		t.Fatal("missing assistant message")
+	}
+	assertEq(t, "Model", asst.Model, "gpt-5.4")
+	if len(asst.TokenUsage) != 0 {
+		t.Fatalf("TokenUsage = %q, want empty", string(asst.TokenUsage))
+	}
 }

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -546,6 +546,73 @@ func TestParseOpenCodeDB_TokenUsage(t *testing.T) {
 		s.Session.PeakContextTokens, 12470) // 1 + 500 + 11969
 }
 
+// TestParseOpenCodeDB_UnknownTokensShape verifies that a
+// present but unrecognized `tokens` object (empty {} or a
+// foreign schema) leaves TokenUsage empty so the usage query
+// filter skips the row, rather than fabricating a zero-valued
+// record that pollutes the dashboard.
+func TestParseOpenCodeDB_UnknownTokensShape(t *testing.T) {
+	cases := []struct {
+		name      string
+		tokensRaw string
+	}{
+		{"empty object", `{}`},
+		{"foreign keys only", `{"totalTokens":42,"promptCount":3}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath, seeder, db := newTestDB(t)
+			defer db.Close()
+
+			seeder.AddProject("prj_1", "/tmp/proj")
+			seeder.AddSession("ses_u", "prj_1", "", "Unknown",
+				1700000000000, 1700000010000)
+			seeder.AddMessage("msg_u", "ses_u",
+				1700000000000, 1700000000000, `{"role":"user"}`)
+			seeder.AddPart("prt_u", "msg_u", "ses_u",
+				1700000000000, 1700000000000,
+				`{"type":"text","text":"hi"}`)
+
+			data := `{"role":"assistant","modelID":"gpt-5.4",` +
+				`"providerID":"openai","tokens":` + tc.tokensRaw + `}`
+			seeder.AddMessage("msg_a", "ses_u",
+				1700000005000, 1700000005000, data)
+			seeder.AddPart("prt_a", "msg_a", "ses_u",
+				1700000005000, 1700000005000,
+				`{"type":"text","text":"answer"}`)
+
+			sessions, err := ParseOpenCodeDB(dbPath, "m")
+			if err != nil {
+				t.Fatalf("ParseOpenCodeDB: %v", err)
+			}
+			if len(sessions) != 1 {
+				t.Fatalf("sessions len = %d, want 1", len(sessions))
+			}
+
+			var asst *ParsedMessage
+			for i := range sessions[0].Messages {
+				if sessions[0].Messages[i].Role == RoleAssistant {
+					asst = &sessions[0].Messages[i]
+					break
+				}
+			}
+			if asst == nil {
+				t.Fatal("missing assistant message")
+			}
+			assertEq(t, "Model", asst.Model, "gpt-5.4")
+			if len(asst.TokenUsage) != 0 {
+				t.Fatalf("TokenUsage = %q, want empty",
+					string(asst.TokenUsage))
+			}
+			assertEq(t, "HasOutputTokens",
+				asst.HasOutputTokens, false)
+			assertEq(t, "HasContextTokens",
+				asst.HasContextTokens, false)
+		})
+	}
+}
+
 // TestParseOpenCodeDB_ZeroTokens verifies that an explicit
 // tokens block with every counter set to zero is preserved as
 // "known zero" rather than collapsed to "unknown". The

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -324,6 +324,13 @@ func parsePiAssistantMessage(
 // Cache fields are read from both the nested cache.{read,write}
 // shape (OpenCode-style) and the flat cacheRead/cacheCreation
 // shape (Anthropic-style) so both transports work.
+//
+// A present `usage` object is treated as authoritative and its
+// raw counters are normalized even when every value is zero.
+// Coverage flags follow field presence rather than nonzero
+// values, matching the claude parser contract so an explicit
+// zero from an errored request is not conflated with missing
+// usage metadata.
 func applyPiTokenUsage(
 	pm *ParsedMessage, line, fallbackModel string,
 ) {
@@ -338,20 +345,21 @@ func applyPiTokenUsage(
 		return
 	}
 
-	input := int(usage.Get("input").Int())
-	output := int(usage.Get("output").Int())
-	cacheRead := int(usage.Get("cache.read").Int())
-	if cacheRead == 0 {
-		cacheRead = int(usage.Get("cacheRead").Int())
+	inputField := usage.Get("input")
+	outputField := usage.Get("output")
+	cacheReadField := usage.Get("cache.read")
+	if !cacheReadField.Exists() {
+		cacheReadField = usage.Get("cacheRead")
 	}
-	cacheCreate := int(usage.Get("cache.write").Int())
-	if cacheCreate == 0 {
-		cacheCreate = int(usage.Get("cacheCreation").Int())
+	cacheWriteField := usage.Get("cache.write")
+	if !cacheWriteField.Exists() {
+		cacheWriteField = usage.Get("cacheCreation")
 	}
 
-	if input == 0 && output == 0 && cacheRead == 0 && cacheCreate == 0 {
-		return
-	}
+	input := int(inputField.Int())
+	output := int(outputField.Int())
+	cacheRead := int(cacheReadField.Int())
+	cacheCreate := int(cacheWriteField.Int())
 
 	normalized := map[string]int{
 		"input_tokens":                input,
@@ -365,9 +373,10 @@ func applyPiTokenUsage(
 	}
 	pm.TokenUsage = j
 	pm.OutputTokens = output
-	pm.HasOutputTokens = output > 0
+	pm.HasOutputTokens = outputField.Exists()
 	pm.ContextTokens = input + cacheRead + cacheCreate
-	pm.HasContextTokens = pm.ContextTokens > 0
+	pm.HasContextTokens = inputField.Exists() ||
+		cacheReadField.Exists() || cacheWriteField.Exists()
 }
 
 // parsePiToolResultMessage parses a message entry with role="toolResult".

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -85,6 +85,7 @@ func ParsePiSession(
 		firstMessage string
 		ordinal      int
 		userCount    int
+		currentModel string
 	)
 
 	for {
@@ -127,9 +128,12 @@ func ParsePiSession(
 				userCount++
 
 			case "assistant":
-				msg := parsePiAssistantMessage(line, ordinal)
+				msg := parsePiAssistantMessage(line, ordinal, currentModel)
 				if msg == nil {
 					continue
+				}
+				if msg.Model != "" {
+					currentModel = msg.Model
 				}
 				messages = append(messages, *msg)
 				ordinal++
@@ -146,7 +150,12 @@ func ParsePiSession(
 				// skip silently
 			}
 
-		case "model_change", "compaction":
+		case "model_change":
+			if id := gjson.Get(line, "modelId").Str; id != "" {
+				currentModel = id
+			}
+
+		case "compaction":
 			continue
 
 		default:
@@ -196,6 +205,8 @@ func ParsePiSession(
 		},
 	}
 
+	accumulateMessageTokenUsage(sess, messages)
+
 	return sess, messages, nil
 }
 
@@ -232,8 +243,12 @@ func parsePiUserMessage(line string, ordinal int) *ParsedMessage {
 }
 
 // parsePiAssistantMessage parses a message entry with role="assistant".
-// Returns nil if the entry is malformed.
-func parsePiAssistantMessage(line string, ordinal int) *ParsedMessage {
+// Returns nil if the entry is malformed. fallbackModel is the most
+// recent model id seen (from a prior assistant message or
+// model_change entry), used when this message has no inline model.
+func parsePiAssistantMessage(
+	line string, ordinal int, fallbackModel string,
+) *ParsedMessage {
 	var (
 		parts       []string
 		toolCalls   []ParsedToolCall
@@ -288,7 +303,7 @@ func parsePiAssistantMessage(line string, ordinal int) *ParsedMessage {
 	content := strings.Join(parts, "\n")
 	ts := piTimestamp(line)
 
-	return &ParsedMessage{
+	pm := &ParsedMessage{
 		Ordinal:       ordinal,
 		Role:          RoleAssistant,
 		Content:       content,
@@ -298,6 +313,61 @@ func parsePiAssistantMessage(line string, ordinal int) *ParsedMessage {
 		ContentLength: len(content),
 		ToolCalls:     toolCalls,
 	}
+	applyPiTokenUsage(pm, line, fallbackModel)
+	return pm
+}
+
+// applyPiTokenUsage extracts the assistant message's model and
+// per-message token counts from a Pi JSONL line. Pi records
+// usage as a flat object under message.usage with provider-
+// agnostic input/output keys plus optional cache breakdowns.
+// Cache fields are read from both the nested cache.{read,write}
+// shape (OpenCode-style) and the flat cacheRead/cacheCreation
+// shape (Anthropic-style) so both transports work.
+func applyPiTokenUsage(
+	pm *ParsedMessage, line, fallbackModel string,
+) {
+	if model := gjson.Get(line, "message.model").Str; model != "" {
+		pm.Model = model
+	} else if fallbackModel != "" {
+		pm.Model = fallbackModel
+	}
+
+	usage := gjson.Get(line, "message.usage")
+	if !usage.Exists() {
+		return
+	}
+
+	input := int(usage.Get("input").Int())
+	output := int(usage.Get("output").Int())
+	cacheRead := int(usage.Get("cache.read").Int())
+	if cacheRead == 0 {
+		cacheRead = int(usage.Get("cacheRead").Int())
+	}
+	cacheCreate := int(usage.Get("cache.write").Int())
+	if cacheCreate == 0 {
+		cacheCreate = int(usage.Get("cacheCreation").Int())
+	}
+
+	if input == 0 && output == 0 && cacheRead == 0 && cacheCreate == 0 {
+		return
+	}
+
+	normalized := map[string]int{
+		"input_tokens":                input,
+		"output_tokens":               output,
+		"cache_read_input_tokens":     cacheRead,
+		"cache_creation_input_tokens": cacheCreate,
+	}
+	j, err := json.Marshal(normalized)
+	if err != nil {
+		return
+	}
+	pm.TokenUsage = j
+	pm.OutputTokens = output
+	pm.HasOutputTokens = output > 0
+	pm.ContextTokens = input + cacheRead + cacheCreate
+	pm.HasContextTokens = pm.ContextTokens > 0
 }
 
 // parsePiToolResultMessage parses a message entry with role="toolResult".

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -325,12 +325,11 @@ func parsePiAssistantMessage(
 // shape (OpenCode-style) and the flat cacheRead/cacheCreation
 // shape (Anthropic-style) so both transports work.
 //
-// A present `usage` object is treated as authoritative and its
-// raw counters are normalized even when every value is zero.
-// Coverage flags follow field presence rather than nonzero
-// values, matching the claude parser contract so an explicit
-// zero from an errored request is not conflated with missing
-// usage metadata.
+// Coverage semantics match the claude parser contract: a field
+// present at zero is preserved as "known zero" and sets its
+// coverage flag, while a usage object with no recognized
+// fields (empty `{}` or a foreign schema) leaves TokenUsage
+// empty so the usage query filter skips the row.
 func applyPiTokenUsage(
 	pm *ParsedMessage, line, fallbackModel string,
 ) {
@@ -354,6 +353,11 @@ func applyPiTokenUsage(
 	cacheWriteField := usage.Get("cache.write")
 	if !cacheWriteField.Exists() {
 		cacheWriteField = usage.Get("cacheCreation")
+	}
+
+	if !inputField.Exists() && !outputField.Exists() &&
+		!cacheReadField.Exists() && !cacheWriteField.Exists() {
+		return
 	}
 
 	input := int(inputField.Int())

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -607,6 +607,38 @@ func TestParsePiSession_ModelFromModelChange(t *testing.T) {
 		"token usage extracted from message.usage")
 }
 
+// TestParsePiSession_ZeroUsage verifies that an explicit usage
+// block with every counter at zero is preserved as "known
+// zero" rather than collapsed to "unknown". The normalized
+// token_usage is still written and coverage flags follow field
+// presence, matching the claude parser contract and letting
+// downstream rollups distinguish an errored request from a
+// missing usage blob.
+func TestParsePiSession_ZeroUsage(t *testing.T) {
+	header := `{"type":"session","id":"zu-sess","timestamp":"2025-01-01T10:00:00Z","cwd":"/tmp"}` + "\n"
+	asst := `{"type":"message","id":"a1","timestamp":"2025-01-01T10:00:01Z","message":{"role":"assistant","content":"oops","model":"gpt-5.4","usage":{"input":0,"output":0}}}`
+
+	_, msgs := runPiParserTest(t, header+asst)
+	require.Len(t, msgs, 1)
+	m := msgs[0]
+
+	assert.Equal(t, "gpt-5.4", m.Model)
+	require.NotEmpty(t, m.TokenUsage,
+		"zero-valued usage object must still write token_usage")
+
+	assert.Equal(t, int64(0),
+		gjson.GetBytes(m.TokenUsage, "input_tokens").Int())
+	assert.Equal(t, int64(0),
+		gjson.GetBytes(m.TokenUsage, "output_tokens").Int())
+
+	assert.True(t, m.HasOutputTokens,
+		"output field present => HasOutputTokens true even at zero")
+	assert.True(t, m.HasContextTokens,
+		"input field present => HasContextTokens true even at zero")
+	assert.Equal(t, 0, m.OutputTokens)
+	assert.Equal(t, 0, m.ContextTokens)
+}
+
 // TestParsePiSession_NoUsageNoTokenUsage verifies that messages
 // without a usage block do not write an empty token_usage row,
 // since the eligibility filter requires token_usage != ”.

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // runPiParserTest creates a temp file with the given JSONL content and
@@ -527,4 +528,96 @@ func TestParsePiSession_ErrorCases(t *testing.T) {
 		assert.Equal(t, "pi:ws-sess", sess.ID)
 		assert.Len(t, msgs, 1)
 	})
+}
+
+// TestParsePiSession_TokenUsageFromFixture verifies that assistant
+// messages in the standard pi fixture get Model and TokenUsage
+// populated from the inline message.model and message.usage fields.
+// Without this, the usage dashboard reports $0 for pi sessions.
+func TestParsePiSession_TokenUsageFromFixture(t *testing.T) {
+	fixturePath := createTestFile(
+		t, "pi-session.jsonl",
+		loadFixture(t, "pi/session.jsonl"),
+	)
+	sess, msgs, err := ParsePiSession(fixturePath, "", "local")
+	require.NoError(t, err)
+
+	var assistants []ParsedMessage
+	for _, m := range msgs {
+		if m.Role == RoleAssistant {
+			assistants = append(assistants, m)
+		}
+	}
+	require.GreaterOrEqual(t, len(assistants), 2,
+		"fixture has at least two assistant messages")
+
+	for i, m := range assistants {
+		assert.Equal(t, "claude-opus-4-5", m.Model,
+			"assistant[%d] model populated from message.model", i)
+		require.NotEmpty(t, m.TokenUsage,
+			"assistant[%d] TokenUsage populated from message.usage", i)
+	}
+
+	// Fixture: entry-2 input=100,output=50; entry-7 input=200,output=10.
+	wantInputs := []int64{100, 200}
+	wantOutputs := []int64{50, 10}
+	for i, m := range assistants[:2] {
+		gotIn := gjson.GetBytes(m.TokenUsage, "input_tokens").Int()
+		gotOut := gjson.GetBytes(m.TokenUsage, "output_tokens").Int()
+		assert.Equal(t, wantInputs[i], gotIn,
+			"assistant[%d] input_tokens", i)
+		assert.Equal(t, wantOutputs[i], gotOut,
+			"assistant[%d] output_tokens", i)
+	}
+
+	// Session totals roll up from per-message HasOutputTokens.
+	assert.True(t, sess.HasTotalOutputTokens,
+		"session has rolled up output tokens")
+	assert.Equal(t, 60, sess.TotalOutputTokens,
+		"session TotalOutputTokens = 50 + 10")
+	assert.True(t, sess.HasPeakContextTokens,
+		"session has rolled up context tokens")
+	assert.Equal(t, 200, sess.PeakContextTokens,
+		"session PeakContextTokens = max(100, 200)")
+}
+
+// TestParsePiSession_ModelFromModelChange verifies that when an
+// assistant message has no inline model field, the parser falls
+// back to the most recent model_change entry's modelId.
+func TestParsePiSession_ModelFromModelChange(t *testing.T) {
+	header := `{"type":"session","id":"mc-sess","timestamp":"2025-01-01T10:00:00Z","cwd":"/tmp"}` + "\n"
+	mc := `{"type":"model_change","id":"mc1","timestamp":"2025-01-01T10:00:00.5Z","provider":"openai","modelId":"gpt-5.4"}` + "\n"
+	user := `{"type":"message","id":"u1","timestamp":"2025-01-01T10:00:01Z","message":{"role":"user","content":"hi"}}` + "\n"
+	// Assistant without inline model — should inherit from model_change.
+	asst := `{"type":"message","id":"a1","timestamp":"2025-01-01T10:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input":10,"output":5}}}`
+
+	_, msgs := runPiParserTest(t, header+mc+user+asst)
+
+	var asstMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].Role == RoleAssistant {
+			asstMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, asstMsg, "assistant message present")
+	assert.Equal(t, "gpt-5.4", asstMsg.Model,
+		"assistant model inherited from prior model_change")
+	require.NotEmpty(t, asstMsg.TokenUsage,
+		"token usage extracted from message.usage")
+}
+
+// TestParsePiSession_NoUsageNoTokenUsage verifies that messages
+// without a usage block do not write an empty token_usage row,
+// since the eligibility filter requires token_usage != ”.
+func TestParsePiSession_NoUsageNoTokenUsage(t *testing.T) {
+	header := `{"type":"session","id":"nu-sess","timestamp":"2025-01-01T10:00:00Z","cwd":"/tmp"}` + "\n"
+	asst := `{"type":"message","id":"a1","timestamp":"2025-01-01T10:00:01Z","message":{"role":"assistant","content":"hello","model":"claude-opus-4-5"}}`
+
+	_, msgs := runPiParserTest(t, header+asst)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "claude-opus-4-5", msgs[0].Model,
+		"model still populated even when usage missing")
+	assert.Empty(t, msgs[0].TokenUsage,
+		"token usage left empty when message.usage absent")
 }

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -607,6 +607,39 @@ func TestParsePiSession_ModelFromModelChange(t *testing.T) {
 		"token usage extracted from message.usage")
 }
 
+// TestParsePiSession_UnknownUsageShape verifies that a present
+// but unrecognized usage object (empty {} or a foreign schema
+// with none of the keys we know about) leaves TokenUsage empty
+// so the usage query filter skips the row, rather than
+// fabricating a zero-valued record.
+func TestParsePiSession_UnknownUsageShape(t *testing.T) {
+	header := `{"type":"session","id":"uu-sess","timestamp":"2025-01-01T10:00:00Z","cwd":"/tmp"}` + "\n"
+
+	cases := []struct {
+		name     string
+		usageRaw string
+	}{
+		{"empty object", `{}`},
+		{"foreign keys only", `{"totalTokens":42,"promptCount":3}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			asst := `{"type":"message","id":"a1","timestamp":"2025-01-01T10:00:01Z","message":{"role":"assistant","content":"hi","model":"gpt-5.4","usage":` + tc.usageRaw + `}}`
+			_, msgs := runPiParserTest(t, header+asst)
+			require.Len(t, msgs, 1)
+			m := msgs[0]
+
+			assert.Equal(t, "gpt-5.4", m.Model,
+				"model still populated from message.model")
+			assert.Empty(t, m.TokenUsage,
+				"unrecognized usage shape must leave TokenUsage empty")
+			assert.False(t, m.HasOutputTokens)
+			assert.False(t, m.HasContextTokens)
+		})
+	}
+}
+
 // TestParsePiSession_ZeroUsage verifies that an explicit usage
 // block with every counter at zero is preserved as "known
 // zero" rather than collapsed to "unknown". The normalized

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -41,10 +41,10 @@ const (
 // syncing files to the database, and this monitor detects the
 // resulting DB changes.
 //
-// As a fallback for sessions the file watcher skips (e.g.
-// codex_exec sessions), it also monitors the source file's
-// mtime and triggers a direct sync when the DB hasn't been
-// updated within syncFallbackDelay.
+// As a fallback when file watching or incremental sync misses
+// a DB update, it also monitors the source file's mtime and
+// triggers a direct sync when the DB hasn't been updated
+// within syncFallbackDelay.
 func (s *Server) sessionMonitor(
 	ctx context.Context, sessionID string,
 ) <-chan struct{} {
@@ -190,8 +190,7 @@ func (s *Server) checkDBForChanges(
 
 	// Fallback: if the file changed but the DB hasn't been
 	// updated within syncFallbackDelay, trigger a direct
-	// sync. This handles sessions the watcher skips (e.g.
-	// codex_exec).
+	// sync.
 	if !fileMtimeChangedAt.IsZero() &&
 		time.Since(*fileMtimeChangedAt) >= syncFallbackDelay {
 		*fileMtimeChangedAt = time.Time{}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -93,6 +93,14 @@ func NewEngine(
 // pass so subsequent process starts do not re-scan files.
 // New skip entries for real parse errors on exec files are
 // untouched here and honored normally on later syncs.
+//
+// The cleanup builds a rebuilt snapshot and writes it through
+// the atomic ReplaceSkippedFiles, then only mutates the
+// in-memory map and records the done flag after the persist
+// succeeds. A partial failure leaves both the DB and the
+// in-memory cache in their prior state so the migration is
+// retried on the next startup rather than being falsely
+// marked complete.
 func migrateLegacyCodexExecSkips(
 	database *db.DB, skipCache map[string]int64,
 ) {
@@ -105,22 +113,34 @@ func migrateLegacyCodexExecSkips(
 		return
 	}
 
-	removed := 0
-	for path := range skipCache {
-		if !strings.HasSuffix(path, ".jsonl") {
+	cleaned := make(map[string]int64, len(skipCache))
+	var legacy []string
+	for path, mtime := range skipCache {
+		if strings.HasSuffix(path, ".jsonl") &&
+			parser.IsCodexExecSessionFile(path) {
+			legacy = append(legacy, path)
 			continue
 		}
-		if !parser.IsCodexExecSessionFile(path) {
-			continue
-		}
-		delete(skipCache, path)
-		if err := database.DeleteSkippedFile(path); err != nil {
+		cleaned[path] = mtime
+	}
+
+	if len(legacy) > 0 {
+		if err := database.ReplaceSkippedFiles(
+			cleaned,
+		); err != nil {
 			log.Printf(
-				"codex exec migration: delete %s: %v",
-				path, err,
+				"codex exec migration: persist cleaned skip cache: %v",
+				err,
 			)
+			return
 		}
-		removed++
+		for _, p := range legacy {
+			delete(skipCache, p)
+		}
+		log.Printf(
+			"codex exec legacy migration: cleared %d skip entries",
+			len(legacy),
+		)
 	}
 
 	if err := database.SetSyncState(
@@ -128,13 +148,6 @@ func migrateLegacyCodexExecSkips(
 	); err != nil {
 		log.Printf(
 			"codex exec migration: set flag: %v", err,
-		)
-		return
-	}
-	if removed > 0 {
-		log.Printf(
-			"codex exec legacy migration: cleared %d skip entries",
-			removed,
 		)
 	}
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1475,7 +1475,15 @@ func (e *Engine) processFile(
 	cachedMtime, cached := e.skipCache[file.Path]
 	e.skipMu.RUnlock()
 	if cached && cachedMtime == mtime {
-		return processResult{skip: true, mtime: mtime}
+		// Older agentsview builds cached codex_exec files as
+		// non-interactive. Re-check and unskip those files so
+		// the new bulk-sync behavior can import them.
+		if file.Agent == parser.AgentCodex &&
+			parser.IsCodexExecSessionFile(file.Path) {
+			e.clearSkip(file.Path)
+		} else {
+			return processResult{skip: true, mtime: mtime}
+		}
 	}
 
 	var res processResult
@@ -1807,9 +1815,6 @@ func (e *Engine) processCodex(
 	)
 	if err != nil {
 		return processResult{err: err}
-	}
-	if sess == nil {
-		return processResult{} // non-interactive
 	}
 
 	hash, err := ComputeFileHash(file.Path)
@@ -2670,9 +2675,8 @@ func (e *Engine) FindSourceFile(sessionID string) string {
 	return ""
 }
 
-// SyncSingleSession re-syncs a single session by its ID.
-// Unlike the bulk SyncAll path, this includes exec-originated
-// Codex sessions and uses the existing DB project as fallback.
+// SyncSingleSession re-syncs a single session by its ID and
+// uses the existing DB project as fallback where applicable.
 func (e *Engine) SyncSingleSession(sessionID string) error {
 	e.syncMu.Lock()
 	defer e.syncMu.Unlock()
@@ -2704,9 +2708,7 @@ func (e *Engine) SyncSingleSession(sessionID string) error {
 	// during a bulk SyncAll.
 	e.clearSkip(path)
 
-	// Reuse processFile for stat and DB-skip logic. For
-	// Claude this is the full pipeline; for Codex we need
-	// includeExec=true so we call the parser directly.
+	// Reuse processFile for stat and DB-skip logic.
 	file := parser.DiscoveredFile{
 		Path:  path,
 		Agent: agent,
@@ -2771,23 +2773,6 @@ func (e *Engine) SyncSingleSession(sessionID string) error {
 		return e.writeIncremental(res.incremental)
 	}
 
-	// For Codex, processFile uses includeExec=false which may
-	// return empty results for exec-originated sessions. Re-parse
-	// with includeExec=true when that happens.
-	if len(res.results) == 0 && agent == parser.AgentCodex {
-		execRes := e.processCodexIncludeExec(file)
-		if execRes.err != nil {
-			if res.mtime != 0 {
-				e.cacheSkip(path, res.mtime)
-			}
-			return execRes.err
-		}
-		if len(execRes.results) == 0 {
-			return nil
-		}
-		res.results = execRes.results
-	}
-
 	if len(res.results) == 0 {
 		return nil
 	}
@@ -2809,30 +2794,6 @@ func (e *Engine) SyncSingleSession(sessionID string) error {
 	}
 
 	return nil
-}
-
-// processCodexIncludeExec re-parses a Codex session with
-// exec-originated sessions included.
-func (e *Engine) processCodexIncludeExec(
-	file parser.DiscoveredFile,
-) processResult {
-	sess, msgs, err := parser.ParseCodexSession(
-		file.Path, e.machine, true,
-	)
-	if err != nil {
-		return processResult{err: err}
-	}
-	if sess == nil {
-		return processResult{}
-	}
-	if h, herr := ComputeFileHash(file.Path); herr == nil {
-		sess.File.Hash = h
-	}
-	return processResult{
-		results: []parser.ParseResult{
-			{Session: *sess, Messages: msgs},
-		},
-	}
 }
 
 // syncSingleOpenCode re-syncs a single OpenCode session.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -50,9 +50,16 @@ type Engine struct {
 	skipCache map[string]int64
 }
 
+// codexExecMigrationKey is the pg_sync_state flag that
+// records whether the one-time cleanup of legacy codex_exec
+// skip cache entries has already run on this database.
+const codexExecMigrationKey = "codex_exec_legacy_migration_v1"
+
 // NewEngine creates a sync engine. It pre-populates the
 // in-memory skip cache from the database so that files
-// skipped in a prior run are not re-parsed on startup.
+// skipped in a prior run are not re-parsed on startup, and
+// migrates legacy codex_exec skip entries on first run under
+// the new bulk-sync behavior.
 func NewEngine(
 	database *db.DB, cfg EngineConfig,
 ) *Engine {
@@ -62,6 +69,8 @@ func NewEngine(
 	} else {
 		log.Printf("loading skip cache: %v", err)
 	}
+
+	migrateLegacyCodexExecSkips(database, skipCache)
 
 	dirs := make(map[parser.AgentType][]string, len(cfg.AgentDirs))
 	for k, v := range cfg.AgentDirs {
@@ -74,6 +83,59 @@ func NewEngine(
 		machine:                 cfg.Machine,
 		blockedResultCategories: blockedCategorySet(cfg.BlockedResultCategories),
 		skipCache:               skipCache,
+	}
+}
+
+// migrateLegacyCodexExecSkips removes skip cache entries
+// created by older agentsview builds that excluded Codex exec
+// sessions from bulk sync. The scrub runs once per database:
+// a `pg_sync_state` flag is set after the first successful
+// pass so subsequent process starts do not re-scan files.
+// New skip entries for real parse errors on exec files are
+// untouched here and honored normally on later syncs.
+func migrateLegacyCodexExecSkips(
+	database *db.DB, skipCache map[string]int64,
+) {
+	done, err := database.GetSyncState(codexExecMigrationKey)
+	if err != nil {
+		log.Printf("codex exec migration: %v", err)
+		return
+	}
+	if done != "" {
+		return
+	}
+
+	removed := 0
+	for path := range skipCache {
+		if !strings.HasSuffix(path, ".jsonl") {
+			continue
+		}
+		if !parser.IsCodexExecSessionFile(path) {
+			continue
+		}
+		delete(skipCache, path)
+		if err := database.DeleteSkippedFile(path); err != nil {
+			log.Printf(
+				"codex exec migration: delete %s: %v",
+				path, err,
+			)
+		}
+		removed++
+	}
+
+	if err := database.SetSyncState(
+		codexExecMigrationKey, "done",
+	); err != nil {
+		log.Printf(
+			"codex exec migration: set flag: %v", err,
+		)
+		return
+	}
+	if removed > 0 {
+		log.Printf(
+			"codex exec legacy migration: cleared %d skip entries",
+			removed,
+		)
 	}
 }
 
@@ -1471,19 +1533,16 @@ func (e *Engine) processFile(
 
 	// Skip files cached from a previous sync (parse errors
 	// or non-interactive sessions) whose mtime is unchanged.
+	// Legacy codex_exec entries from pre-bulk-sync builds are
+	// scrubbed once at engine construction by
+	// migrateLegacyCodexExecSkips, so this check can treat
+	// the skip cache as authoritative without per-file
+	// re-validation.
 	e.skipMu.RLock()
 	cachedMtime, cached := e.skipCache[file.Path]
 	e.skipMu.RUnlock()
 	if cached && cachedMtime == mtime {
-		// Older agentsview builds cached codex_exec files as
-		// non-interactive. Re-check and unskip those files so
-		// the new bulk-sync behavior can import them.
-		if file.Agent == parser.AgentCodex &&
-			parser.IsCodexExecSessionFile(file.Path) {
-			e.clearSkip(file.Path)
-		} else {
-			return processResult{skip: true, mtime: mtime}
-		}
+		return processResult{skip: true, mtime: mtime}
 	}
 
 	var res processResult

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -657,6 +657,77 @@ func TestSyncAllImportsCodexExecFromLegacySkipCache(
 	)
 }
 
+// TestCodexExecMigrationIdempotent verifies that once the
+// codex exec skip cache migration has run, subsequent engine
+// starts do not re-scan or remove entries — even those that
+// point at codex_exec files, which legitimately get cached
+// post-migration when the parser fails on them. The flag in
+// pg_sync_state is the gate; without it a broken exec file
+// would be reopened on every startup.
+func TestCodexExecMigrationIdempotent(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// setupTestEnv already built an engine that set the
+	// migration flag against an empty skip cache. Write a
+	// codex exec file and seed it into the skip cache to
+	// mimic a fresh parse-error cache entry made by a
+	// post-migration sync.
+	uuid := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			tsEarly, uuid,
+			"/home/user/code/api", "codex_exec",
+		).
+		AddCodexMessage(tsEarlyS1, "user", "run ls").
+		String()
+
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "15"),
+		"rollout-20240115-"+uuid+".jsonl", content,
+	)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat codex session: %v", err)
+	}
+
+	if err := env.db.ReplaceSkippedFiles(map[string]int64{
+		path: info.ModTime().UnixNano(),
+	}); err != nil {
+		t.Fatalf("seed skipped files: %v", err)
+	}
+
+	// Rebuild the engine without resetting the migration
+	// flag. The migration must be a no-op: the seeded entry
+	// stays in the DB and the engine respects it on sync.
+	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude:   {env.claudeDir},
+			parser.AgentCodex:    {env.codexDir},
+			parser.AgentCursor:   {env.cursorDir},
+			parser.AgentGemini:   {env.geminiDir},
+			parser.AgentOpenCode: {env.opencodeDir},
+			parser.AgentIflow:    {env.iflowDir},
+			parser.AgentAmp:      {env.ampDir},
+			parser.AgentPi:       {env.piDir},
+		},
+		Machine: "local",
+	})
+
+	env.engine.SyncAll(context.Background(), nil)
+
+	loaded, err := env.db.LoadSkippedFiles()
+	if err != nil {
+		t.Fatalf("load skipped files: %v", err)
+	}
+	if _, ok := loaded[path]; !ok {
+		t.Fatalf(
+			"post-migration skip entry for %s was cleared; "+
+				"migration must be idempotent",
+			path,
+		)
+	}
+}
+
 func TestSyncEngineTombstoneClearOnMtimeChange(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -619,6 +619,17 @@ func TestSyncAllImportsCodexExecFromLegacySkipCache(
 		t.Fatalf("seed skipped files: %v", err)
 	}
 
+	// setupTestEnv already built an engine, which ran the
+	// codex exec migration against an empty skip cache and
+	// flipped the flag to "done". Reset the flag so the new
+	// engine below observes a legacy skip entry and scrubs
+	// it, matching the production upgrade path.
+	if err := env.db.SetSyncState(
+		sync.CodexExecMigrationKey, "",
+	); err != nil {
+		t.Fatalf("reset migration flag: %v", err)
+	}
+
 	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude:   {env.claudeDir},

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -554,14 +554,14 @@ func TestSyncSingleSessionHashCodex(t *testing.T) {
 	env.assertResyncRoundTrip(t, sessionID)
 }
 
-func TestSyncSingleSessionCodexExecBypassesCache(
+func TestSyncAllImportsCodexExec(
 	t *testing.T,
 ) {
 	env := setupTestEnv(t)
 
 	uuid := "e5f6a7b8-5678-9012-cdef-123456789012"
-	// Exec-originated session: SyncAll skips these, but
-	// SyncSingleSession should still find them.
+	// Exec-originated sessions should be imported during the
+	// normal bulk sync path.
 	content := testjsonl.NewSessionBuilder().
 		AddCodexMeta(
 			tsEarly, uuid,
@@ -576,21 +576,64 @@ func TestSyncSingleSessionCodexExecBypassesCache(
 		"rollout-20240115-"+uuid+".jsonl", content,
 	)
 
-	// SyncAll skips exec-originated sessions (nil result).
 	env.engine.SyncAll(context.Background(), nil)
-	sess, _ := env.db.GetSession(
-		context.Background(), "codex:"+uuid,
+
+	assertSessionState(
+		t, env.db, "codex:"+uuid,
+		func(sess *db.Session) {
+			if sess.Agent != "codex" {
+				t.Errorf("agent = %q, want codex",
+					sess.Agent)
+			}
+		},
 	)
-	if sess != nil {
-		t.Fatal("exec session should not appear after SyncAll")
+}
+
+func TestSyncAllImportsCodexExecFromLegacySkipCache(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	uuid := "f6a7b8c9-6789-0123-def0-234567890123"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			tsEarly, uuid,
+			"/home/user/code/api", "codex_exec",
+		).
+		AddCodexMessage(tsEarlyS1, "user", "run ls").
+		AddCodexMessage(tsEarlyS5, "assistant", "done").
+		String()
+
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "15"),
+		"rollout-20240115-"+uuid+".jsonl", content,
+	)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat codex session: %v", err)
 	}
 
-	// SyncSingleSession should bypass the skip cache and
-	// parse with includeExec=true.
-	err := env.engine.SyncSingleSession("codex:" + uuid)
-	if err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
+	if err := env.db.ReplaceSkippedFiles(map[string]int64{
+		path: info.ModTime().UnixNano(),
+	}); err != nil {
+		t.Fatalf("seed skipped files: %v", err)
 	}
+
+	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude:   {env.claudeDir},
+			parser.AgentCodex:    {env.codexDir},
+			parser.AgentCursor:   {env.cursorDir},
+			parser.AgentGemini:   {env.geminiDir},
+			parser.AgentOpenCode: {env.opencodeDir},
+			parser.AgentIflow:    {env.iflowDir},
+			parser.AgentAmp:      {env.ampDir},
+			parser.AgentPi:       {env.piDir},
+		},
+		Machine: "local",
+	})
+
+	env.engine.SyncAll(context.Background(), nil)
 
 	assertSessionState(
 		t, env.db, "codex:"+uuid,

--- a/internal/sync/export_test.go
+++ b/internal/sync/export_test.go
@@ -1,0 +1,6 @@
+package sync
+
+// CodexExecMigrationKey exposes the pg_sync_state key used to
+// gate the one-time codex_exec skip cache migration so tests
+// can reset it between engine instantiations.
+const CodexExecMigrationKey = codexExecMigrationKey


### PR DESCRIPTION
## Summary

The usage dashboard reported $0 for users running OpenAI models through opencode and pi. Their parsers did not store a per-message model id or token usage, so the usage query filter (`m.model != '' AND m.token_usage != ''` in `internal/db/usage.go:110-114`) excluded every row. Fresh web-only installs also saw $0 across all agents because `model_pricing` was only populated by the `agentsview usage` CLI. This PR also folds in a codex exec import fix so users get both under the single resync triggered by the data version bump.

## Changes

**opencode parser** — extracts `modelID` and `tokens.{input,output,cache.{read,write}}` from the assistant message data blob via gjson. Gates on at least one recognized field so foreign or empty `tokens` objects do not fabricate a zero row. Coverage flags follow field presence, preserving explicit zero usage from errored requests.

**pi parser** — extracts `message.model` and `message.usage.{input,output,cacheRead,cacheCreation}` from assistant entries, falls back to the most recent `model_change.modelId` when a message has no inline model. Same field-gating and zero-preservation rules.

**Session rollups** — both parsers now call `accumulateMessageTokenUsage` so `HasTotalOutputTokens`, `TotalOutputTokens`, and `PeakContextTokens` populate alongside Claude and Codex.

**Codex exec sessions in bulk sync** — `internal/parser/codex.go` drops the `includeExec` filter that skipped sessions with `originator=="codex_exec"` during bulk sync. `internal/sync/engine.go` and `internal/server/events.go` stop threading the flag through; `internal/parser/codex.go` exposes `IsCodexExecSessionFile` for discovery. Non-interactive codex exec sessions are now imported alongside interactive ones.

**Data version** — `dataVersion` bumps to 10 so existing databases reparse opencode, pi, and codex rows to pick up both the new usage fields and the previously skipped codex exec sessions in a single resync.

**Pricing seed on startup** — `seedPricingIfEmpty` upserts `pricing.FallbackPricing()` synchronously then refreshes from LiteLLM in a background goroutine. Fresh installs and resync swaps never observe an empty `model_pricing` table, and the server never blocks startup behind the 30s LiteLLM HTTP timeout. A follow-up to bundle a full LiteLLM snapshot as the offline fallback is tracked in #315.

**Cost Over Time chart** — reserves `TOP_PAD=10` headroom in the plot area and rounds the y-axis maximum up to the next `1/2/2.5/5/10 × 10ⁿ` step via `niceCeil`. The tallest bar and the top y-axis label ascenders no longer clip against the SVG viewBox edge, and tick labels land on round numbers.