### PR TITLE
fix(usage): seed codex model from turn_context on incremental parse

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -26,11 +26,12 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 10: opencode and pi parsers now extract per-message
-// model id and token usage so the cost dashboard attributes
-// non-Claude/Codex sessions correctly. Existing rows have empty
-// model and token_usage and need a reparse to backfill.
-const dataVersion = 10
+// Bumped to 11: codex incremental parser was not seeding
+// currentModel from prior turn_context lines, causing all
+// incrementally parsed messages to store an empty model
+// string. The usage query filters these out, so codex cost
+// tracking froze after the initial full parse.
+const dataVersion = 11
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -721,6 +721,7 @@ type IncrementalInfo struct {
 	PeakContextTokens    int
 	HasTotalOutputTokens bool
 	HasPeakContextTokens bool
+	LastModel            string
 }
 
 // GetSessionForIncremental returns session state needed for
@@ -744,23 +745,33 @@ func (db *DB) GetSessionForIncremental(
 
 	var info IncrementalInfo
 	var fs sql.NullInt64
+	var lastModel sql.NullString
 	err = db.getReader().QueryRow(
-		`SELECT id, file_size, message_count,
-			user_message_count,
-			total_output_tokens, peak_context_tokens,
-			has_total_output_tokens, has_peak_context_tokens
-		 FROM sessions WHERE file_path = ?`,
+		`SELECT s.id, s.file_size, s.message_count,
+			s.user_message_count,
+			s.total_output_tokens, s.peak_context_tokens,
+			s.has_total_output_tokens,
+			s.has_peak_context_tokens,
+			(SELECT m.model FROM messages m
+			 WHERE m.session_id = s.id
+			   AND m.model != ''
+			 ORDER BY m.ordinal DESC LIMIT 1)
+		 FROM sessions s WHERE s.file_path = ?`,
 		path,
 	).Scan(
 		&info.ID, &fs, &info.MsgCount, &info.UserMsgCount,
 		&info.TotalOutputTokens, &info.PeakContextTokens,
 		&info.HasTotalOutputTokens, &info.HasPeakContextTokens,
+		&lastModel,
 	)
 	if err != nil {
 		return nil, false
 	}
 	if fs.Valid {
 		info.FileSize = fs.Int64
+	}
+	if lastModel.Valid {
+		info.LastModel = lastModel.String
 	}
 	info.HasTotalOutputTokens =
 		info.HasTotalOutputTokens || info.TotalOutputTokens != 0

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -721,7 +721,6 @@ type IncrementalInfo struct {
 	PeakContextTokens    int
 	HasTotalOutputTokens bool
 	HasPeakContextTokens bool
-	LastModel            string
 }
 
 // GetSessionForIncremental returns session state needed for
@@ -745,33 +744,23 @@ func (db *DB) GetSessionForIncremental(
 
 	var info IncrementalInfo
 	var fs sql.NullInt64
-	var lastModel sql.NullString
 	err = db.getReader().QueryRow(
-		`SELECT s.id, s.file_size, s.message_count,
-			s.user_message_count,
-			s.total_output_tokens, s.peak_context_tokens,
-			s.has_total_output_tokens,
-			s.has_peak_context_tokens,
-			(SELECT m.model FROM messages m
-			 WHERE m.session_id = s.id
-			   AND m.model != ''
-			 ORDER BY m.ordinal DESC LIMIT 1)
-		 FROM sessions s WHERE s.file_path = ?`,
+		`SELECT id, file_size, message_count,
+			user_message_count,
+			total_output_tokens, peak_context_tokens,
+			has_total_output_tokens, has_peak_context_tokens
+		 FROM sessions WHERE file_path = ?`,
 		path,
 	).Scan(
 		&info.ID, &fs, &info.MsgCount, &info.UserMsgCount,
 		&info.TotalOutputTokens, &info.PeakContextTokens,
 		&info.HasTotalOutputTokens, &info.HasPeakContextTokens,
-		&lastModel,
 	)
 	if err != nil {
 		return nil, false
 	}
 	if fs.Valid {
 		info.FileSize = fs.Int64
-	}
-	if lastModel.Valid {
-		info.LastModel = lastModel.String
 	}
 	info.HasTotalOutputTokens =
 		info.HasTotalOutputTokens || info.TotalOutputTokens != 0

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -1130,6 +1131,40 @@ func ParseCodexSession(
 	return sess, b.messages, nil
 }
 
+// readCodexModelAtOffset scans a Codex JSONL file from the
+// start up to the given byte offset and returns the model
+// from the most recent turn_context entry. Returns "" when
+// no turn_context is found before the offset. Used to seed
+// currentModel for incremental parses that resume past turn
+// boundaries.
+func readCodexModelAtOffset(
+	path string, offset int64,
+) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	lr := newLineReader(
+		io.LimitReader(f, offset), maxLineSize,
+	)
+	var model string
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if gjson.Get(line, "type").Str != codexTypeTurnContext {
+			continue
+		}
+		if m := gjson.Get(line, "payload.model").Str; m != "" {
+			model = m
+		}
+	}
+	return model
+}
+
 // ParseCodexSessionFrom parses only new lines from a Codex
 // JSONL file starting at the given byte offset. Returns only
 // the newly parsed messages (with ordinals starting at
@@ -1143,6 +1178,7 @@ func ParseCodexSessionFrom(
 ) ([]ParsedMessage, time.Time, int64, error) {
 	b := newCodexSessionBuilder(includeExec)
 	b.ordinal = startOrdinal
+	b.currentModel = readCodexModelAtOffset(path, offset)
 	var fallbackErr error
 
 	consumed, err := readJSONLFrom(

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1137,6 +1137,12 @@ func ParseCodexSession(
 // no turn_context is found before the offset. Used to seed
 // currentModel for incremental parses that resume past turn
 // boundaries.
+// readCodexModelAtOffset scans a Codex JSONL file from the
+// start up to the given byte offset and returns the model
+// from the most recent turn_context entry. Mirrors the full
+// parser: every turn_context unconditionally overwrites the
+// model, including empty strings. Returns "" when no
+// turn_context is found before the offset.
 func readCodexModelAtOffset(
 	path string, offset int64,
 ) string {
@@ -1158,9 +1164,7 @@ func readCodexModelAtOffset(
 		if gjson.Get(line, "type").Str != codexTypeTurnContext {
 			continue
 		}
-		if m := gjson.Get(line, "payload.model").Str; m != "" {
-			model = m
-		}
+		model = gjson.Get(line, "payload.model").Str
 	}
 	return model
 }
@@ -1170,15 +1174,27 @@ func readCodexModelAtOffset(
 // the newly parsed messages (with ordinals starting at
 // startOrdinal) and the latest timestamp seen. Used for
 // incremental re-parsing of large append-only session files.
+//
+// lastModel seeds the builder's currentModel so that messages
+// appearing before the first turn_context in the new chunk
+// inherit the correct model. Callers should pass the value
+// from IncrementalInfo.LastModel (fast DB lookup). When
+// lastModel is empty, the function falls back to a file
+// pre-scan via readCodexModelAtOffset.
 func ParseCodexSessionFrom(
 	path string,
 	offset int64,
 	startOrdinal int,
 	includeExec bool,
+	lastModel string,
 ) ([]ParsedMessage, time.Time, int64, error) {
 	b := newCodexSessionBuilder(includeExec)
 	b.ordinal = startOrdinal
-	b.currentModel = readCodexModelAtOffset(path, offset)
+	if lastModel != "" {
+		b.currentModel = lastModel
+	} else {
+		b.currentModel = readCodexModelAtOffset(path, offset)
+	}
 	var fallbackErr error
 
 	consumed, err := readJSONLFrom(

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1161,6 +1161,9 @@ func readCodexModelAtOffset(
 		if !ok {
 			break
 		}
+		if !gjson.Valid(line) {
+			continue
+		}
 		if gjson.Get(line, "type").Str != codexTypeTurnContext {
 			continue
 		}

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1174,27 +1174,15 @@ func readCodexModelAtOffset(
 // the newly parsed messages (with ordinals starting at
 // startOrdinal) and the latest timestamp seen. Used for
 // incremental re-parsing of large append-only session files.
-//
-// lastModel seeds the builder's currentModel so that messages
-// appearing before the first turn_context in the new chunk
-// inherit the correct model. Callers should pass the value
-// from IncrementalInfo.LastModel (fast DB lookup). When
-// lastModel is empty, the function falls back to a file
-// pre-scan via readCodexModelAtOffset.
 func ParseCodexSessionFrom(
 	path string,
 	offset int64,
 	startOrdinal int,
 	includeExec bool,
-	lastModel string,
 ) ([]ParsedMessage, time.Time, int64, error) {
 	b := newCodexSessionBuilder(includeExec)
 	b.ordinal = startOrdinal
-	if lastModel != "" {
-		b.currentModel = lastModel
-	} else {
-		b.currentModel = readCodexModelAtOffset(path, offset)
-	}
+	b.currentModel = readCodexModelAtOffset(path, offset)
 	var fallbackErr error
 
 	consumed, err := readJSONLFrom(

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1063,7 +1063,7 @@ func TestParseCodexSessionFrom_Incremental(t *testing.T) {
 
 	// Incremental parse from the offset.
 	newMsgs, endedAt, _, err := ParseCodexSessionFrom(
-		path, offset, 1, false,
+		path, offset, 1, false, "",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(newMsgs))
@@ -1112,7 +1112,7 @@ func TestParseCodexSessionFrom_SkipsSessionMeta(t *testing.T) {
 	f.Close()
 
 	newMsgs, _, _, err := ParseCodexSessionFrom(
-		path, offset, 5, false,
+		path, offset, 5, false, "",
 	)
 	require.NoError(t, err)
 	// Only the assistant message, not the session_meta.
@@ -1136,7 +1136,7 @@ func TestParseCodexSessionFrom_NoNewData(t *testing.T) {
 
 	// Parse from end of file — no new data.
 	newMsgs, endedAt, _, err := ParseCodexSessionFrom(
-		path, offset, 10, false,
+		path, offset, 10, false, "",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(newMsgs))
@@ -1168,7 +1168,7 @@ func TestParseCodexSessionFrom_SubagentOutputRequiresFullParse(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseCodexSessionFrom(path, offset, 2, false)
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 2, false, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "full parse")
 }
@@ -1206,7 +1206,7 @@ func TestParseCodexSessionFrom_WaitCallRequiresFullParse(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseCodexSessionFrom(path, offset, 4, false)
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 4, false, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "full parse")
 }
@@ -1232,7 +1232,7 @@ func TestParseCodexSessionFrom_SystemMessageDoesNotRequireFullParse(t *testing.T
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
+	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false, "")
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(newMsgs))
 	assert.False(t, endedAt.IsZero())
@@ -1263,7 +1263,7 @@ func TestParseCodexSessionFrom_RunningNotificationRequiresFullParse(t *testing.T
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseCodexSessionFrom(path, offset, 1, false)
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 1, false, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "full parse")
 }
@@ -1289,7 +1289,7 @@ func TestParseCodexSessionFrom_NonSubagentFunctionOutputDoesNotRequireFullParse(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
+	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false, "")
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(newMsgs))
 	assert.False(t, endedAt.IsZero())
@@ -1331,14 +1331,24 @@ func TestParseCodexSessionFrom_SeedsModelFromTurnContext(
 	require.NoError(t, err)
 	require.NoError(t, f2.Close())
 
+	// File-scan fallback path (lastModel="").
 	newMsgs2, _, _, err := ParseCodexSessionFrom(
-		path, offset, 2, false,
+		path, offset, 2, false, "",
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(newMsgs2))
 	assert.Equal(t, "gpt-5.4", newMsgs2[0].Model,
-		"incremental parse should seed model from "+
+		"file-scan fallback should seed model from "+
 			"prior turn_context")
+
+	// DB-first path (lastModel provided by caller).
+	newMsgs3, _, _, err := ParseCodexSessionFrom(
+		path, offset, 2, false, "gpt-5.4",
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(newMsgs3))
+	assert.Equal(t, "gpt-5.4", newMsgs3[0].Model,
+		"DB-provided lastModel should seed model")
 }
 
 func TestReadCodexModelAtOffset(t *testing.T) {

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1294,3 +1294,88 @@ func TestParseCodexSessionFrom_NonSubagentFunctionOutputDoesNotRequireFullParse(
 	assert.Equal(t, 0, len(newMsgs))
 	assert.False(t, endedAt.IsZero())
 }
+
+func TestParseCodexSessionFrom_SeedsModelFromTurnContext(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"model-seed", "/tmp", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextJSON(
+			"gpt-5.4", tsEarlyS1,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS5),
+		testjsonl.CodexMsgJSON(
+			"assistant", "hi there", tsLate,
+		),
+	)
+	path := createTestFile(t, "model-seed.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON(
+			"assistant", "second reply", tsLateS5,
+		),
+	)
+	f2, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f2.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f2.Close())
+
+	newMsgs2, _, _, err := ParseCodexSessionFrom(
+		path, offset, 2, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(newMsgs2))
+	assert.Equal(t, "gpt-5.4", newMsgs2[0].Model,
+		"incremental parse should seed model from "+
+			"prior turn_context")
+}
+
+func TestReadCodexModelAtOffset(t *testing.T) {
+	t.Parallel()
+
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"model-at-offset", "/tmp",
+			"codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextJSON(
+			"gpt-5", tsEarlyS1,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS5),
+		testjsonl.CodexTurnContextJSON(
+			"gpt-5.4", tsLate,
+		),
+		testjsonl.CodexMsgJSON("user", "bye", tsLateS5),
+	)
+	path := createTestFile(
+		t, "model-at-offset.jsonl", content,
+	)
+
+	t.Run("full file returns last model", func(t *testing.T) {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		got := readCodexModelAtOffset(path, info.Size())
+		assert.Equal(t, "gpt-5.4", got)
+	})
+
+	t.Run("zero offset returns empty", func(t *testing.T) {
+		got := readCodexModelAtOffset(path, 0)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("nonexistent file returns empty", func(t *testing.T) {
+		got := readCodexModelAtOffset("/no/such/file", 100)
+		assert.Equal(t, "", got)
+	})
+}

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1341,6 +1341,101 @@ func TestParseCodexSessionFrom_SeedsModelFromTurnContext(
 			"prior turn_context via file scan")
 }
 
+func TestParseCodexSessionFrom_SeedsBoundaryAfterTurnContext(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Offset lands immediately after a turn_context with no
+	// following message — the exact sync boundary edge case.
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"tc-boundary", "/tmp", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextJSON(
+			"gpt-5.4", tsEarlyS1,
+		),
+	)
+	path := createTestFile(
+		t, "tc-boundary.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS5),
+		testjsonl.CodexMsgJSON(
+			"assistant", "world", tsLate,
+		),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := ParseCodexSessionFrom(
+		path, offset, 0, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(newMsgs))
+	assert.Equal(t, "gpt-5.4", newMsgs[0].Model,
+		"user message after turn_context boundary")
+	assert.Equal(t, "gpt-5.4", newMsgs[1].Model,
+		"assistant message after turn_context boundary")
+}
+
+func TestParseCodexSessionFrom_EmptyModelReset(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// turn_context clears model to "" — incremental parse
+	// must honor the reset, not retain the old model.
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"model-reset", "/tmp", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextJSON(
+			"gpt-5.4", tsEarlyS1,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS5),
+		testjsonl.CodexTurnContextJSON("", tsLate),
+	)
+	path := createTestFile(
+		t, "model-reset.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON(
+			"assistant", "after reset", tsLateS5,
+		),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := ParseCodexSessionFrom(
+		path, offset, 2, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(newMsgs))
+	assert.Equal(t, "", newMsgs[0].Model,
+		"empty-model turn_context should reset model")
+}
+
 func TestReadCodexModelAtOffset(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1436,6 +1436,35 @@ func TestParseCodexSessionFrom_EmptyModelReset(
 		"empty-model turn_context should reset model")
 }
 
+func TestReadCodexModelAtOffset_SkipsInvalidJSON(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Truncated turn_context between a valid one and the
+	// offset — must not override the valid model.
+	validTC := testjsonl.CodexTurnContextJSON(
+		"gpt-5.4", tsEarlyS1,
+	)
+	truncated := `{"type":"turn_context","payload":{"model":"wrong`
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"invalid-json", "/tmp",
+			"codex_cli_rs", tsEarly,
+		),
+	) + validTC + "\n" + truncated + "\n"
+
+	path := createTestFile(
+		t, "invalid-tc.jsonl", content,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	got := readCodexModelAtOffset(path, info.Size())
+	assert.Equal(t, "gpt-5.4", got,
+		"truncated turn_context should be skipped")
+}
+
 func TestReadCodexModelAtOffset(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1063,7 +1063,7 @@ func TestParseCodexSessionFrom_Incremental(t *testing.T) {
 
 	// Incremental parse from the offset.
 	newMsgs, endedAt, _, err := ParseCodexSessionFrom(
-		path, offset, 1, false, "",
+		path, offset, 1, false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(newMsgs))
@@ -1112,7 +1112,7 @@ func TestParseCodexSessionFrom_SkipsSessionMeta(t *testing.T) {
 	f.Close()
 
 	newMsgs, _, _, err := ParseCodexSessionFrom(
-		path, offset, 5, false, "",
+		path, offset, 5, false,
 	)
 	require.NoError(t, err)
 	// Only the assistant message, not the session_meta.
@@ -1136,7 +1136,7 @@ func TestParseCodexSessionFrom_NoNewData(t *testing.T) {
 
 	// Parse from end of file — no new data.
 	newMsgs, endedAt, _, err := ParseCodexSessionFrom(
-		path, offset, 10, false, "",
+		path, offset, 10, false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(newMsgs))
@@ -1168,7 +1168,7 @@ func TestParseCodexSessionFrom_SubagentOutputRequiresFullParse(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseCodexSessionFrom(path, offset, 2, false, "")
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 2, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "full parse")
 }
@@ -1206,7 +1206,7 @@ func TestParseCodexSessionFrom_WaitCallRequiresFullParse(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseCodexSessionFrom(path, offset, 4, false, "")
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 4, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "full parse")
 }
@@ -1232,7 +1232,7 @@ func TestParseCodexSessionFrom_SystemMessageDoesNotRequireFullParse(t *testing.T
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false, "")
+	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(newMsgs))
 	assert.False(t, endedAt.IsZero())
@@ -1263,7 +1263,7 @@ func TestParseCodexSessionFrom_RunningNotificationRequiresFullParse(t *testing.T
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseCodexSessionFrom(path, offset, 1, false, "")
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 1, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "full parse")
 }
@@ -1289,7 +1289,7 @@ func TestParseCodexSessionFrom_NonSubagentFunctionOutputDoesNotRequireFullParse(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false, "")
+	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(newMsgs))
 	assert.False(t, endedAt.IsZero())
@@ -1331,24 +1331,14 @@ func TestParseCodexSessionFrom_SeedsModelFromTurnContext(
 	require.NoError(t, err)
 	require.NoError(t, f2.Close())
 
-	// File-scan fallback path (lastModel="").
 	newMsgs2, _, _, err := ParseCodexSessionFrom(
-		path, offset, 2, false, "",
+		path, offset, 2, false,
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(newMsgs2))
 	assert.Equal(t, "gpt-5.4", newMsgs2[0].Model,
-		"file-scan fallback should seed model from "+
-			"prior turn_context")
-
-	// DB-first path (lastModel provided by caller).
-	newMsgs3, _, _, err := ParseCodexSessionFrom(
-		path, offset, 2, false, "gpt-5.4",
-	)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(newMsgs3))
-	assert.Equal(t, "gpt-5.4", newMsgs3[0].Model,
-		"DB-provided lastModel should seed model")
+		"incremental parse should seed model from "+
+			"prior turn_context via file scan")
 }
 
 func TestReadCodexModelAtOffset(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1867,13 +1867,20 @@ func (e *Engine) processCodex(
 		return processResult{skip: true}
 	}
 
-	// Try incremental parse for append-only JSONL files
-	// that have already been synced.
+	// Pre-fetch the last known model so the incremental
+	// closure can seed it without a file re-scan.
+	var lastModel string
+	if inc, ok := e.db.GetSessionForIncremental(
+		file.Path,
+	); ok {
+		lastModel = inc.LastModel
+	}
+
 	codexParseFn := func(
 		path string, offset int64, startOrd int,
 	) ([]parser.ParsedMessage, time.Time, int64, error) {
 		return parser.ParseCodexSessionFrom(
-			path, offset, startOrd, false,
+			path, offset, startOrd, false, lastModel,
 		)
 	}
 	if res, ok := e.tryIncrementalJSONL(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1867,20 +1867,11 @@ func (e *Engine) processCodex(
 		return processResult{skip: true}
 	}
 
-	// Pre-fetch the last known model so the incremental
-	// closure can seed it without a file re-scan.
-	var lastModel string
-	if inc, ok := e.db.GetSessionForIncremental(
-		file.Path,
-	); ok {
-		lastModel = inc.LastModel
-	}
-
 	codexParseFn := func(
 		path string, offset int64, startOrd int,
 	) ([]parser.ParsedMessage, time.Time, int64, error) {
 		return parser.ParseCodexSessionFrom(
-			path, offset, startOrd, false, lastModel,
+			path, offset, startOrd, false,
 		)
 	}
 	if res, ok := e.tryIncrementalJSONL(


### PR DESCRIPTION
## Summary

- Codex incremental parser (`ParseCodexSessionFrom`) created a fresh builder with `currentModel=""`, so messages parsed after the initial full sync got `model=""` and were excluded by the usage query's `m.model != ''` filter -- freezing codex cost tracking
- Add `readCodexModelAtOffset` to pre-scan the file up to the resume offset for the most recent `turn_context` model, seeding the builder before processing new lines
- Bump `dataVersion` to 11 so existing databases reparse codex sessions and backfill the missing model field

## Test plan

- [x] `TestParseCodexSessionFrom_SeedsModelFromTurnContext` -- verifies incremental messages inherit model from prior turn_context
- [x] `TestReadCodexModelAtOffset` -- verifies helper returns correct model at various offsets
- [x] All existing codex parser tests pass
- [ ] Manual: restart agentsview, confirm resync runs and codex usage updates past the previous frozen value

Generated with [Claude Code](https://claude.com/claude-code)