### PR TITLE
fix: recognize "helpful assistant" prefix as automated session

### DIFF
--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -19,6 +19,7 @@ var automatedPrefixes = []string{
 	"You are analyzing AI agent sessions.",
 	"## Analysis Request",
 	"# Fix Request",
+	"You are a helpful assistant working on a software project.",
 }
 
 // automatedSubstrings are patterns matched anywhere in the

--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -37,7 +37,7 @@ func TestBackfillIsAutomatedBidirectional(t *testing.T) {
 
 	// Clear the marker so the backfill will run.
 	_, err = d.getWriter().Exec(
-		"DELETE FROM stats WHERE key = 'is_automated_backfill_v1'",
+		"DELETE FROM stats WHERE key = 'is_automated_backfill_v2'",
 	)
 	requireNoError(t, err, "clear marker")
 
@@ -77,7 +77,7 @@ func TestBackfillIsAutomatedMarkerIdempotent(t *testing.T) {
 
 	// Clear the marker and run backfill.
 	_, err := d.getWriter().Exec(
-		"DELETE FROM stats WHERE key = 'is_automated_backfill_v1'",
+		"DELETE FROM stats WHERE key = 'is_automated_backfill_v2'",
 	)
 	requireNoError(t, err, "clear marker")
 

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -104,6 +104,13 @@ func TestIsAutomatedSession(t *testing.T) {
 			true,
 		},
 
+		// Helpful assistant analysis
+		{
+			"HelpfulAssistantAnalysis",
+			"You are a helpful assistant working on a software project. Analyze the following sessions.",
+			true,
+		},
+
 		// Catch-all substring
 		{
 			"RoborevSubstringInMiddle",

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -412,7 +412,7 @@ func (db *DB) migrateColumns() error {
 // Guarded by a stats marker so it only runs once per pattern
 // version.
 func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
-	const marker = "is_automated_backfill_v1"
+	const marker = "is_automated_backfill_v2"
 	var done int
 	if err := w.QueryRow(
 		`SELECT count(*) FROM stats

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -294,7 +294,7 @@ func EnsureSchema(
 	return nil
 }
 
-const isAutomatedBackfillMetadataKey = "is_automated_backfill_v1"
+const isAutomatedBackfillMetadataKey = "is_automated_backfill_v2"
 
 // backfillIsAutomatedPG recomputes is_automated for all PG
 // sessions, correcting both false negatives (new patterns) and

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -36,8 +36,8 @@ func (f fakeFileInfo) Mode() os.FileMode { return 0 }
 func (f fakeFileInfo) ModTime() time.Time {
 	return time.Unix(0, f.mtime)
 }
-func (f fakeFileInfo) IsDir() bool      { return false }
-func (f fakeFileInfo) Sys() any         { return nil }
+func (f fakeFileInfo) IsDir() bool { return false }
+func (f fakeFileInfo) Sys() any    { return nil }
 
 func TestFilterEmptyMessages(t *testing.T) {
 	tests := []struct {
@@ -716,12 +716,12 @@ func TestApplyRemoteRewrites(t *testing.T) {
 					},
 				},
 			},
-			wantSessID:  "host~abc",
-			wantParent:  strPtr("host~parent-1"),
+			wantSessID:   "host~abc",
+			wantParent:   strPtr("host~parent-1"),
 			wantFilePath: strPtr("/tmp/file"),
-			wantMsgSess: "host~abc",
-			wantSubs:    []string{"host~sub-1", ""},
-			wantEvSubs:  []string{"host~ev-1", ""},
+			wantMsgSess:  "host~abc",
+			wantSubs:     []string{"host~sub-1", ""},
+			wantEvSubs:   []string{"host~ev-1", ""},
 		},
 		{
 			name:   "path rewriter applied",


### PR DESCRIPTION
## Summary

- Add "You are a helpful assistant working on a software project." to `automatedPrefixes` so analysis tasks using this prompt pattern are classified as automated
- Bump backfill marker from v1 to v2 so existing sessions in both SQLite and PostgreSQL get re-scanned on next startup