### PR TITLE
fix: token-use accepts raw session IDs

### DIFF
--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/wesm/agentsview/internal/config"
@@ -17,6 +18,95 @@ import (
 	"github.com/wesm/agentsview/internal/sync"
 )
 
+// Exit codes for the token-use subcommand.
+const (
+	tokenUseExitOK            = 0
+	tokenUseExitErr           = 1
+	tokenUseExitNotFound      = 2
+	tokenUseExitNoTokenData   = 3
+	tokenUseResolveMatchLimit = 2
+)
+
+// resolveRawSessionID translates a user-supplied session ID into
+// the canonical form stored in sessions.id. Callers may pass
+// either a prefixed ID ("codex:<uuid>") or a bare raw ID as
+// emitted by the underlying agent. Resolution order:
+//
+//  1. Input already contains ':' -> returned unchanged (trust the
+//     caller; preserves exact-match contract for prefixed IDs).
+//  2. DB lookup: exact match OR suffix match against ":<input>";
+//     exact match wins, otherwise most-recent suffix match wins
+//     (rare ambiguity is reported to stderr).
+//  3. Disk probe: iterate file-based agents and check their
+//     FindSourceFunc for any configured directory; first hit
+//     yields "<prefix><input>".
+//  4. No match anywhere: returned unchanged with known=false.
+//
+// known reports whether resolution found evidence for the ID.
+// When false, the caller should skip on-demand sync because it
+// cannot produce meaningful output.
+func resolveRawSessionID(
+	ctx context.Context,
+	database *db.DB,
+	agentDirs map[parser.AgentType][]string,
+	input string,
+) (resolved string, known bool) {
+	if strings.Contains(input, ":") {
+		return input, true
+	}
+
+	matches, err := database.FindSessionIDsByRawSuffix(
+		ctx, input, tokenUseResolveMatchLimit,
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"warning: session id lookup failed: %v\n", err)
+	}
+	if len(matches) > 0 {
+		for _, m := range matches {
+			if m == input {
+				return m, true
+			}
+		}
+		if len(matches) > 1 {
+			fmt.Fprintf(os.Stderr,
+				"warning: ambiguous session id %q matches "+
+					"multiple sessions, using most recent (%s)\n",
+				input, matches[0],
+			)
+		}
+		return matches[0], true
+	}
+
+	for _, def := range parser.Registry {
+		if !def.FileBased || def.FindSourceFunc == nil {
+			continue
+		}
+		for _, dir := range agentDirs[def.Type] {
+			if def.FindSourceFunc(dir, input) != "" {
+				return def.IDPrefix + input, true
+			}
+		}
+	}
+
+	return input, false
+}
+
+// tokenUseExitCode classifies a session record into an exit code:
+// 0 when token metrics are present, 2 when the session is not in
+// the DB, and 3 when the session exists but has no token data
+// yet (e.g. the parser hasn't ingested it or the agent never
+// emitted usage metadata).
+func tokenUseExitCode(sess *db.Session) int {
+	if sess == nil {
+		return tokenUseExitNotFound
+	}
+	if sess.HasTotalOutputTokens || sess.HasPeakContextTokens {
+		return tokenUseExitOK
+	}
+	return tokenUseExitNoTokenData
+}
+
 // tokenUseOutput is the JSON structure written to stdout.
 // This format is experimental and may change.
 type tokenUseOutput struct {
@@ -25,6 +115,7 @@ type tokenUseOutput struct {
 	Project           string `json:"project"`
 	TotalOutputTokens int    `json:"total_output_tokens"`
 	PeakContextTokens int    `json:"peak_context_tokens"`
+	HasTokenData      bool   `json:"has_token_data"`
 	ServerRunning     bool   `json:"server_running"`
 }
 
@@ -37,23 +128,26 @@ func runTokenUse(args []string) {
 	if len(args) != 1 {
 		fmt.Fprintln(os.Stderr,
 			"usage: agentsview token-use <session-id>")
-		os.Exit(1)
+		os.Exit(tokenUseExitErr)
 	}
 
-	if err := tokenUse(args[0]); err != nil {
+	code, err := tokenUse(args[0])
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		os.Exit(tokenUseExitErr)
 	}
+	os.Exit(code)
 }
 
-func tokenUse(sessionID string) error {
+func tokenUse(sessionID string) (int, error) {
 	appCfg, err := config.LoadMinimal()
 	if err != nil {
-		return fmt.Errorf("loading config: %w", err)
+		return tokenUseExitErr, fmt.Errorf("loading config: %w", err)
 	}
 
 	if err := os.MkdirAll(appCfg.DataDir, 0o755); err != nil {
-		return fmt.Errorf("creating data dir: %w", err)
+		return tokenUseExitErr,
+			fmt.Errorf("creating data dir: %w", err)
 	}
 
 	serverActive := server.IsServerActive(appCfg.DataDir)
@@ -102,7 +196,8 @@ func tokenUse(sessionID string) error {
 
 	database, err := db.Open(appCfg.DBPath)
 	if err != nil {
-		return fmt.Errorf("opening database: %w", err)
+		return tokenUseExitErr,
+			fmt.Errorf("opening database: %w", err)
 	}
 	defer database.Close()
 
@@ -111,12 +206,17 @@ func tokenUse(sessionID string) error {
 			appCfg.CursorSecret,
 		)
 		if decErr != nil {
-			return fmt.Errorf(
+			return tokenUseExitErr, fmt.Errorf(
 				"invalid cursor secret: %w", decErr,
 			)
 		}
 		database.SetCursorSecret(secret)
 	}
+
+	ctx := context.Background()
+	resolvedID, known := resolveRawSessionID(
+		ctx, database, appCfg.AgentDirs, sessionID,
+	)
 
 	// If no server is managing the DB, do an on-demand sync
 	// for this session so the data is fresh. Re-check right
@@ -150,14 +250,17 @@ func tokenUse(sessionID string) error {
 			// active but slow. Read DB as-is.
 		}
 	}
-	if !serverActive {
+	// Skip sync entirely when we have no evidence of the
+	// session (known=false) — SyncSingleSession would just
+	// log a misleading "source file not found" warning.
+	if !serverActive && known {
 		engine := sync.NewEngine(database, sync.EngineConfig{
 			AgentDirs:               appCfg.AgentDirs,
 			Machine:                 "local",
 			BlockedResultCategories: appCfg.ResultContentBlockedCategories,
 		})
 		if syncErr := engine.SyncSingleSession(
-			sessionID,
+			resolvedID,
 		); syncErr != nil {
 			// Not fatal: session may already be in the DB
 			// from a previous sync, or may not exist at all.
@@ -166,19 +269,20 @@ func tokenUse(sessionID string) error {
 		}
 	}
 
-	sess, err := database.GetSession(
-		context.Background(), sessionID,
-	)
+	sess, err := database.GetSession(ctx, resolvedID)
 	if err != nil {
-		return fmt.Errorf("querying session: %w", err)
+		return tokenUseExitErr,
+			fmt.Errorf("querying session: %w", err)
 	}
 	if sess == nil {
-		return fmt.Errorf("session not found: %s", sessionID)
+		fmt.Fprintf(os.Stderr,
+			"session not found: %s\n", sessionID)
+		return tokenUseExitNotFound, nil
 	}
 
 	agent := sess.Agent
 	if agent == "" {
-		if def, ok := parser.AgentByPrefix(sessionID); ok {
+		if def, ok := parser.AgentByPrefix(sess.ID); ok {
 			agent = string(def.Type)
 		}
 	}
@@ -189,10 +293,15 @@ func tokenUse(sessionID string) error {
 		Project:           sess.Project,
 		TotalOutputTokens: sess.TotalOutputTokens,
 		PeakContextTokens: sess.PeakContextTokens,
-		ServerRunning:     serverActive,
+		HasTokenData: sess.HasTotalOutputTokens ||
+			sess.HasPeakContextTokens,
+		ServerRunning: serverActive,
 	}
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	return enc.Encode(out)
+	if err := enc.Encode(out); err != nil {
+		return tokenUseExitErr, err
+	}
+	return tokenUseExitCode(sess), nil
 }

--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -27,13 +27,36 @@ const (
 	tokenUseResolveMatchLimit = 2
 )
 
+// isCanonicalSessionID reports whether id is already in the
+// canonical form stored in sessions.id: either a host-prefixed
+// remote ID ("host~<id>") or an ID beginning with a registered
+// agent prefix ("codex:", "kimi:", ...). A bare input with no
+// recognised prefix is treated as a raw ID even when it contains
+// ':' because agents like Kimi and OpenClaw emit colon-bearing
+// raw IDs.
+func isCanonicalSessionID(id string) bool {
+	host, rawID := parser.StripHostPrefix(id)
+	if host != "" {
+		return true
+	}
+	for _, def := range parser.Registry {
+		if def.IDPrefix != "" &&
+			strings.HasPrefix(rawID, def.IDPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveRawSessionID translates a user-supplied session ID into
 // the canonical form stored in sessions.id. Callers may pass
-// either a prefixed ID ("codex:<uuid>") or a bare raw ID as
-// emitted by the underlying agent. Resolution order:
+// either a canonical ID ("codex:<uuid>") or a bare raw ID as
+// emitted by the underlying agent — including raw IDs that
+// contain colons themselves (Kimi: "<project-hash>:<session-uuid>",
+// OpenClaw: "<agentId>:<sessionId>"). Resolution order:
 //
-//  1. Input already contains ':' -> returned unchanged (trust the
-//     caller; preserves exact-match contract for prefixed IDs).
+//  1. Input already carries a canonical prefix (host~... or
+//     <agent>:...) -> returned unchanged.
 //  2. DB lookup: exact match OR suffix match against ":<input>";
 //     exact match wins, otherwise most-recent suffix match wins
 //     (rare ambiguity is reported to stderr).
@@ -51,7 +74,7 @@ func resolveRawSessionID(
 	agentDirs map[parser.AgentType][]string,
 	input string,
 ) (resolved string, known bool) {
-	if strings.Contains(input, ":") {
+	if isCanonicalSessionID(input) {
 		return input, true
 	}
 

--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -27,43 +27,31 @@ const (
 	tokenUseResolveMatchLimit = 2
 )
 
-// isCanonicalSessionID reports whether id is already in the
-// canonical form stored in sessions.id: either a host-prefixed
-// remote ID ("host~<id>") or an ID beginning with a registered
-// agent prefix ("codex:", "kimi:", ...). A bare input with no
-// recognised prefix is treated as a raw ID even when it contains
-// ':' because agents like Kimi and OpenClaw emit colon-bearing
-// raw IDs.
-func isCanonicalSessionID(id string) bool {
-	host, rawID := parser.StripHostPrefix(id)
-	if host != "" {
-		return true
-	}
-	for _, def := range parser.Registry {
-		if def.IDPrefix != "" &&
-			strings.HasPrefix(rawID, def.IDPrefix) {
-			return true
-		}
-	}
-	return false
-}
-
 // resolveRawSessionID translates a user-supplied session ID into
 // the canonical form stored in sessions.id. Callers may pass
 // either a canonical ID ("codex:<uuid>") or a bare raw ID as
 // emitted by the underlying agent — including raw IDs that
-// contain colons themselves (Kimi: "<project-hash>:<session-uuid>",
-// OpenClaw: "<agentId>:<sessionId>"). Resolution order:
+// themselves contain colons (Kimi: "<project-hash>:<session-uuid>",
+// OpenClaw: "<agentId>:<sessionId>", legacy Kiro IDE).
 //
-//  1. Input already carries a canonical prefix (host~... or
-//     <agent>:...) -> returned unchanged.
-//  2. DB lookup: exact match OR suffix match against ":<input>";
-//     exact match wins, otherwise most-recent suffix match wins
-//     (rare ambiguity is reported to stderr).
-//  3. Disk probe: iterate file-based agents and check their
-//     FindSourceFunc for any configured directory; first hit
-//     yields "<prefix><input>".
-//  4. No match anywhere: returned unchanged with known=false.
+// Resolution order (short-circuit only on host-prefixed IDs, which
+// are unambiguously remote; any other input — even one that begins
+// with a registered prefix — flows through DB and disk probes
+// because the first colon-delimited component can legitimately be
+// part of a raw ID):
+//
+//  1. Host-prefixed input -> returned unchanged.
+//  2. DB lookup: exact row (if any) sorts ahead of suffix matches
+//     in SQL; suffix matches come back in most-recent order. If
+//     multiple suffix matches exist without an exact row, the
+//     most recent wins and an ambiguity warning is emitted.
+//  3. Canonical disk probe: when input begins with a registered
+//     agent prefix, strip the prefix and call that agent's
+//     FindSourceFunc so a truly canonical-but-unsynced ID on disk
+//     still resolves.
+//  4. Raw disk probe: call every file-based agent's FindSourceFunc
+//     with the raw input; the first hit yields "<prefix><input>".
+//  5. No match anywhere: returned unchanged with known=false.
 //
 // known reports whether resolution found evidence for the ID.
 // When false, the caller should skip on-demand sync because it
@@ -74,7 +62,7 @@ func resolveRawSessionID(
 	agentDirs map[parser.AgentType][]string,
 	input string,
 ) (resolved string, known bool) {
-	if isCanonicalSessionID(input) {
+	if host, _ := parser.StripHostPrefix(input); host != "" {
 		return input, true
 	}
 
@@ -86,10 +74,8 @@ func resolveRawSessionID(
 			"warning: session id lookup failed: %v\n", err)
 	}
 	if len(matches) > 0 {
-		for _, m := range matches {
-			if m == input {
-				return m, true
-			}
+		if matches[0] == input {
+			return input, true
 		}
 		if len(matches) > 1 {
 			fmt.Fprintf(os.Stderr,
@@ -101,6 +87,31 @@ func resolveRawSessionID(
 		return matches[0], true
 	}
 
+	// Canonical disk probe: if the input starts with a known
+	// agent prefix, trust that interpretation first and strip
+	// before calling FindSourceFunc (which rejects IDs with
+	// colons via IsValidSessionID).
+	for _, def := range parser.Registry {
+		if def.IDPrefix == "" || !def.FileBased ||
+			def.FindSourceFunc == nil {
+			continue
+		}
+		if !strings.HasPrefix(input, def.IDPrefix) {
+			continue
+		}
+		bareID := strings.TrimPrefix(input, def.IDPrefix)
+		for _, dir := range agentDirs[def.Type] {
+			if def.FindSourceFunc(dir, bareID) != "" {
+				return input, true
+			}
+		}
+	}
+
+	// Raw disk probe: treat input as a raw agent ID. Agents
+	// whose raw IDs cannot contain ':' (most of them) reject
+	// the input via IsValidSessionID; agents that accept
+	// colon-bearing raw IDs (Kimi, OpenClaw, Kiro IDE) may
+	// match.
 	for _, def := range parser.Registry {
 		if !def.FileBased || def.FindSourceFunc == nil {
 			continue

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+	"github.com/wesm/agentsview/internal/parser"
+)
+
+// newTestDB opens a fresh SQLite DB in a temp dir for a single test.
+func newTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// upsertSession inserts a session with minimal required fields.
+func upsertSession(
+	t *testing.T, d *db.DB, id, agent, startedAt string,
+) {
+	t.Helper()
+	s := db.Session{
+		ID:           id,
+		Project:      "test-project",
+		Machine:      "local",
+		Agent:        agent,
+		MessageCount: 1,
+	}
+	if startedAt != "" {
+		s.StartedAt = &startedAt
+	}
+	if err := d.UpsertSession(s); err != nil {
+		t.Fatalf("upsert %s: %v", id, err)
+	}
+}
+
+func TestResolveSessionID_PrefixedInput_ReturnedUnchanged(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Even when the DB has no matching row, a prefixed input
+	// must be returned unchanged (exact-match contract).
+	input := "codex:019d5490-fe31-7e62-838c-8ba4193f245d"
+	got, known := resolveRawSessionID(ctx, d, nil, input)
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
+	if !known {
+		t.Errorf("known = false, want true (prefixed input trusted)")
+	}
+}
+
+func TestResolveSessionID_BareClaudeUUID_ExactMatch(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Claude sessions have no prefix; the bare UUID is the
+	// canonical ID stored in sessions.id.
+	id := "11111111-1111-1111-1111-111111111111"
+	upsertSession(t, d, id, "claude", "2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, id)
+	if got != id {
+		t.Errorf("got %q, want %q", got, id)
+	}
+	if !known {
+		t.Errorf("known = false, want true (DB match)")
+	}
+}
+
+func TestResolveSessionID_BareCodexUUID_ResolvesToPrefixed(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	bare := "019d5490-fe31-7e62-838c-8ba4193f245d"
+	stored := "codex:" + bare
+	upsertSession(t, d, stored, "codex", "2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, bare)
+	if got != stored {
+		t.Errorf("got %q, want %q", got, stored)
+	}
+	if !known {
+		t.Errorf("known = false, want true (DB match)")
+	}
+}
+
+func TestResolveSessionID_Ambiguous_MostRecentWins(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	bare := "22222222-2222-2222-2222-222222222222"
+	// Older codex session.
+	upsertSession(t, d, "codex:"+bare, "codex", "2026-04-16T10:00:00Z")
+	// Newer amp session with same raw UUID.
+	upsertSession(t, d, "amp:"+bare, "amp", "2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, bare)
+	if got != "amp:"+bare {
+		t.Errorf("got %q, want amp:%s (most recent)", got, bare)
+	}
+	if !known {
+		t.Errorf("known = false, want true")
+	}
+}
+
+func TestResolveSessionID_NotInDB_FoundOnDisk(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Create a codex session file on disk: the probe path
+	// should resolve a bare raw UUID to the prefixed form.
+	codexDir := filepath.Join(t.TempDir(), "codex-sessions")
+	bare := "33333333-3333-3333-3333-333333333333"
+	dayDir := filepath.Join(codexDir, "2026", "04", "17")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fname := "rollout-2026-04-17T10-00-00-" + bare + ".jsonl"
+	fpath := filepath.Join(dayDir, fname)
+	if err := os.WriteFile(fpath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	agentDirs := map[parser.AgentType][]string{
+		parser.AgentCodex: {codexDir},
+	}
+	got, known := resolveRawSessionID(ctx, d, agentDirs, bare)
+	if got != "codex:"+bare {
+		t.Errorf("got %q, want codex:%s (disk probe)", got, bare)
+	}
+	if !known {
+		t.Errorf("known = false, want true (disk probe found match)")
+	}
+}
+
+func TestResolveSessionID_NotFoundAnywhere_PassThrough(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	bare := "44444444-4444-4444-4444-444444444444"
+	got, known := resolveRawSessionID(ctx, d, nil, bare)
+	if got != bare {
+		t.Errorf("got %q, want %q (pass-through)", got, bare)
+	}
+	if known {
+		t.Errorf("known = true, want false (nothing found)")
+	}
+}
+
+func TestResolveSessionID_BareClaudeAndPrefixedSameUUID_ClaudeExactWins(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Edge: a bare Claude UUID that ALSO exists as a prefixed
+	// session (e.g. codex:<same-uuid>). The Claude row is an
+	// exact match and should win over the suffix match.
+	bare := "55555555-5555-5555-5555-555555555555"
+	upsertSession(t, d, bare, "claude", "2026-04-16T10:00:00Z")
+	upsertSession(t, d, "codex:"+bare, "codex", "2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, bare)
+	if got != bare {
+		t.Errorf("got %q, want %q (exact claude match)", got, bare)
+	}
+	if !known {
+		t.Errorf("known = false, want true")
+	}
+}
+
+func TestTokenUseExitCode_Found(t *testing.T) {
+	sess := &db.Session{
+		ID:                   "codex:xxx",
+		HasTotalOutputTokens: true,
+		TotalOutputTokens:    100,
+	}
+	if got := tokenUseExitCode(sess); got != 0 {
+		t.Errorf("got %d, want 0", got)
+	}
+}
+
+func TestTokenUseExitCode_NoData(t *testing.T) {
+	sess := &db.Session{ID: "codex:xxx"}
+	if got := tokenUseExitCode(sess); got != 3 {
+		t.Errorf("got %d, want 3", got)
+	}
+}
+
+func TestTokenUseExitCode_NotFound(t *testing.T) {
+	if got := tokenUseExitCode(nil); got != 2 {
+		t.Errorf("got %d, want 2", got)
+	}
+}
+
+func TestTokenUseExitCode_PeakContextOnly(t *testing.T) {
+	// Having only peak_context token data is still "has data".
+	sess := &db.Session{
+		ID:                   "claude:xxx",
+		HasPeakContextTokens: true,
+		PeakContextTokens:    50000,
+	}
+	if got := tokenUseExitCode(sess); got != 0 {
+		t.Errorf("got %d, want 0", got)
+	}
+}

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -176,6 +176,86 @@ func TestResolveSessionID_BareClaudeAndPrefixedSameUUID_ClaudeExactWins(t *testi
 	}
 }
 
+func TestResolveSessionID_KimiRawID_ResolvesToPrefixed(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Kimi raw IDs have the shape "<project-hash>:<session-uuid>".
+	// The stored canonical form prepends "kimi:".
+	raw := "proj-hash-abc:66666666-6666-6666-6666-666666666666"
+	stored := "kimi:" + raw
+	upsertSession(t, d, stored, "kimi", "2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, raw)
+	if got != stored {
+		t.Errorf("got %q, want %q (kimi raw ID resolves)", got, stored)
+	}
+	if !known {
+		t.Errorf("known = false, want true")
+	}
+}
+
+func TestResolveSessionID_OpenClawRawID_ResolvesToPrefixed(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// OpenClaw raw IDs have the shape "<agentId>:<sessionId>".
+	raw := "main:abc-123"
+	stored := "openclaw:" + raw
+	upsertSession(t, d, stored, "openclaw", "2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, raw)
+	if got != stored {
+		t.Errorf("got %q, want %q (openclaw raw ID resolves)",
+			got, stored)
+	}
+	if !known {
+		t.Errorf("known = false, want true")
+	}
+}
+
+func TestResolveSessionID_CanonicalKimiID_ReturnedUnchanged(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// A fully canonical Kimi ID contains two colons; it must
+	// be returned as-is (the "kimi:" prefix is the signal).
+	input := "kimi:proj-abc:77777777-7777-7777-7777-777777777777"
+	got, known := resolveRawSessionID(ctx, d, nil, input)
+	if got != input {
+		t.Errorf("got %q, want %q (canonical)", got, input)
+	}
+	if !known {
+		t.Errorf("known = false, want true (canonical prefix)")
+	}
+}
+
+func TestResolveSessionID_UnderscoreID_NoFalseMatch(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Underscore is a LIKE wildcard in SQLite. If the query
+	// uses LIKE naively, a raw id "20260403_aaa" would match
+	// rows whose id ends with ":20260403Xaaa" (X = any char).
+	// Insert a decoy that would only match under naive LIKE
+	// semantics, plus a true match, and assert the true match
+	// wins.
+	raw := "20260403_aaa"
+	decoy := "codex:20260403Xaaa"
+	real := "codex:" + raw
+	upsertSession(t, d, decoy, "codex", "2026-04-16T10:00:00Z")
+	upsertSession(t, d, real, "codex", "2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, raw)
+	if got != real {
+		t.Errorf("got %q, want %q (underscore is literal)",
+			got, real)
+	}
+	if !known {
+		t.Errorf("known = false, want true")
+	}
+}
+
 func TestTokenUseExitCode_Found(t *testing.T) {
 	sess := &db.Session{
 		ID:                   "codex:xxx",

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -42,19 +42,38 @@ func upsertSession(
 	}
 }
 
-func TestResolveSessionID_PrefixedInput_ReturnedUnchanged(t *testing.T) {
+func TestResolveSessionID_PrefixedInput_NoEvidence_UnchangedNotKnown(t *testing.T) {
 	d := newTestDB(t)
 	ctx := context.Background()
 
-	// Even when the DB has no matching row, a prefixed input
-	// must be returned unchanged (exact-match contract).
+	// A prefixed input with no DB row and no disk evidence is
+	// returned unchanged so downstream lookup/error messages
+	// use what the caller typed, but known=false so the caller
+	// skips the on-demand sync that would only warn about a
+	// missing source file.
 	input := "codex:019d5490-fe31-7e62-838c-8ba4193f245d"
 	got, known := resolveRawSessionID(ctx, d, nil, input)
 	if got != input {
 		t.Errorf("got %q, want %q", got, input)
 	}
+	if known {
+		t.Errorf("known = true, want false (no evidence)")
+	}
+}
+
+func TestResolveSessionID_HostPrefixedInput_ReturnedUnchanged(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Host-prefixed IDs are unambiguously canonical remote IDs;
+	// resolution short-circuits without touching DB or disk.
+	input := "other-host~codex:abc-123"
+	got, known := resolveRawSessionID(ctx, d, nil, input)
+	if got != input {
+		t.Errorf("got %q, want %q", got, input)
+	}
 	if !known {
-		t.Errorf("known = false, want true (prefixed input trusted)")
+		t.Errorf("known = false, want true (host-prefixed)")
 	}
 }
 
@@ -176,6 +195,31 @@ func TestResolveSessionID_BareClaudeAndPrefixedSameUUID_ClaudeExactWins(t *testi
 	}
 }
 
+func TestResolveSessionID_ExactMatchWinsOverNewerCollisions(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Bare Claude session is the exact match but older than
+	// multiple prefixed sessions sharing the same suffix. The
+	// exact row must always win, even if a LIMIT on the suffix
+	// query would exclude it by recency.
+	bare := "88888888-8888-8888-8888-888888888888"
+	upsertSession(t, d, bare, "claude", "2026-04-10T10:00:00Z")
+	upsertSession(t, d, "codex:"+bare, "codex",
+		"2026-04-15T10:00:00Z")
+	upsertSession(t, d, "amp:"+bare, "amp",
+		"2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, bare)
+	if got != bare {
+		t.Errorf("got %q, want %q (exact match must beat "+
+			"newer suffix collisions)", got, bare)
+	}
+	if !known {
+		t.Errorf("known = false, want true")
+	}
+}
+
 func TestResolveSessionID_KimiRawID_ResolvesToPrefixed(t *testing.T) {
 	d := newTestDB(t)
 	ctx := context.Background()
@@ -214,19 +258,82 @@ func TestResolveSessionID_OpenClawRawID_ResolvesToPrefixed(t *testing.T) {
 	}
 }
 
-func TestResolveSessionID_CanonicalKimiID_ReturnedUnchanged(t *testing.T) {
+func TestResolveSessionID_CanonicalKimiID_ResolvesWhenInDB(t *testing.T) {
 	d := newTestDB(t)
 	ctx := context.Background()
 
-	// A fully canonical Kimi ID contains two colons; it must
-	// be returned as-is (the "kimi:" prefix is the signal).
+	// A canonical Kimi ID already in the DB resolves via the
+	// exact-match branch. A canonical ID with no DB row and no
+	// disk evidence falls through to known=false so no
+	// misleading sync warning is emitted.
 	input := "kimi:proj-abc:77777777-7777-7777-7777-777777777777"
+	upsertSession(t, d, input, "kimi", "2026-04-17T10:00:00Z")
+
 	got, known := resolveRawSessionID(ctx, d, nil, input)
 	if got != input {
-		t.Errorf("got %q, want %q (canonical)", got, input)
+		t.Errorf("got %q, want %q (exact DB match)", got, input)
 	}
 	if !known {
-		t.Errorf("known = false, want true (canonical prefix)")
+		t.Errorf("known = false, want true (exact DB match)")
+	}
+}
+
+func TestResolveSessionID_CanonicalCodexID_OnDiskNotInDB(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// Canonical "codex:<uuid>" not yet synced but present on
+	// disk must resolve via the canonical disk probe — which
+	// strips the prefix before calling FindSourceFunc (the
+	// underlying finder rejects colon-bearing IDs).
+	codexDir := filepath.Join(t.TempDir(), "codex-sessions")
+	uuid := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	dayDir := filepath.Join(codexDir, "2026", "04", "17")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fname := "rollout-2026-04-17T10-00-00-" + uuid + ".jsonl"
+	if err := os.WriteFile(
+		filepath.Join(dayDir, fname), []byte("{}\n"), 0o644,
+	); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	agentDirs := map[parser.AgentType][]string{
+		parser.AgentCodex: {codexDir},
+	}
+	input := "codex:" + uuid
+	got, known := resolveRawSessionID(ctx, d, agentDirs, input)
+	if got != input {
+		t.Errorf("got %q, want %q (canonical on disk)", got, input)
+	}
+	if !known {
+		t.Errorf("known = false, want true (canonical disk probe)")
+	}
+}
+
+func TestResolveSessionID_RawOpenClawCollidesWithCodexPrefix(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	// OpenClaw permits arbitrary alphanumeric-dash-underscore
+	// agent IDs, so a user may have one literally named "codex".
+	// The raw OpenClaw ID "codex:abc-123" is stored as
+	// "openclaw:codex:abc-123". Passing the raw form must not
+	// be short-circuited as a canonical Codex ID — DB suffix
+	// resolution must take precedence.
+	raw := "codex:abc-123"
+	stored := "openclaw:" + raw
+	upsertSession(t, d, stored, "openclaw",
+		"2026-04-17T10:00:00Z")
+
+	got, known := resolveRawSessionID(ctx, d, nil, raw)
+	if got != stored {
+		t.Errorf("got %q, want %q (raw openclaw must beat "+
+			"canonical-prefix short-circuit)", got, stored)
+	}
+	if !known {
+		t.Errorf("known = false, want true")
 	}
 }
 

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -862,11 +862,12 @@ func (db *DB) FindSessionIDsByPartial(
 
 // FindSessionIDsByRawSuffix returns up to limit session IDs whose
 // stored id is either the exact raw input or the raw input
-// preceded by an agent prefix (e.g. "codex:<uuid>"). Unlike the
-// substring match of FindSessionIDsByPartial, this only matches
-// when raw is the final ID component, mirroring how agents emit
-// their own thread/session IDs. Results are sorted by most
-// recently active first. Excludes soft-deleted sessions.
+// preceded by an agent prefix (e.g. "codex:<uuid>"). The suffix
+// comparison uses SUBSTR rather than LIKE so that SQL wildcard
+// characters ('_' and '%') present in session IDs (which permit
+// underscores) are compared literally instead of matching any
+// character. Results are sorted by most recently active first.
+// Excludes soft-deleted sessions.
 func (db *DB) FindSessionIDsByRawSuffix(
 	ctx context.Context, raw string, limit int,
 ) ([]string, error) {
@@ -878,7 +879,8 @@ func (db *DB) FindSessionIDsByRawSuffix(
 	}
 	rows, err := db.getReader().QueryContext(ctx,
 		`SELECT id FROM sessions
-		 WHERE (id = ?1 OR id LIKE '%:' || ?1)
+		 WHERE (id = ?1
+		        OR SUBSTR(id, -(LENGTH(?1) + 1)) = ':' || ?1)
 		   AND deleted_at IS NULL
 		 ORDER BY COALESCE(
 		     NULLIF(ended_at, ''),

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -860,6 +860,54 @@ func (db *DB) FindSessionIDsByPartial(
 	return ids, rows.Err()
 }
 
+// FindSessionIDsByRawSuffix returns up to limit session IDs whose
+// stored id is either the exact raw input or the raw input
+// preceded by an agent prefix (e.g. "codex:<uuid>"). Unlike the
+// substring match of FindSessionIDsByPartial, this only matches
+// when raw is the final ID component, mirroring how agents emit
+// their own thread/session IDs. Results are sorted by most
+// recently active first. Excludes soft-deleted sessions.
+func (db *DB) FindSessionIDsByRawSuffix(
+	ctx context.Context, raw string, limit int,
+) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	rows, err := db.getReader().QueryContext(ctx,
+		`SELECT id FROM sessions
+		 WHERE (id = ?1 OR id LIKE '%:' || ?1)
+		   AND deleted_at IS NULL
+		 ORDER BY COALESCE(
+		     NULLIF(ended_at, ''),
+		     NULLIF(started_at, ''),
+		     created_at
+		 ) DESC
+		 LIMIT ?2`,
+		raw, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"finding sessions by raw suffix %q: %w",
+			raw, err,
+		)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf(
+				"scanning session id: %w", err,
+			)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // GetSessionDataVersion returns the data_version for a session.
 // Returns 0 when the session does not exist.
 func (db *DB) GetSessionDataVersion(id string) int {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -882,11 +882,12 @@ func (db *DB) FindSessionIDsByRawSuffix(
 		 WHERE (id = ?1
 		        OR SUBSTR(id, -(LENGTH(?1) + 1)) = ':' || ?1)
 		   AND deleted_at IS NULL
-		 ORDER BY COALESCE(
-		     NULLIF(ended_at, ''),
-		     NULLIF(started_at, ''),
-		     created_at
-		 ) DESC
+		 ORDER BY (id = ?1) DESC,
+		          COALESCE(
+		              NULLIF(ended_at, ''),
+		              NULLIF(started_at, ''),
+		              created_at
+		          ) DESC
 		 LIMIT ?2`,
 		raw, limit,
 	)


### PR DESCRIPTION
## Summary

`agentsview token-use <id>` now accepts the raw session/thread ID emitted by an agent (e.g. codex `thread_id`, claude `session_id`) instead of requiring the internally-namespaced form (`codex:<uuid>`, `kimi:<proj>:<uuid>`, etc.). The raw-ID path is what integrators naturally have on hand; requiring the prefix leaked an agentsview storage detail and caused `roborev` to silently drop token data for ~938/940 codex review jobs.

The CLI resolves the input in three stages:

1. Canonical inputs (`host~…` or any registered agent prefix) pass through unchanged.
2. DB lookup matches either the exact `sessions.id` or a suffix of the form `:<input>`, using `SUBSTR` comparison so underscores/percent in raw IDs are not treated as SQL wildcards. Most-recent wins on ambiguity, with a stderr warning.
3. Disk probe iterates file-based agents and resolves via each `FindSourceFunc`; first hit yields `<prefix><input>`.

When resolution finds no evidence of the ID, the on-demand sync is skipped so the previous misleading `warning: sync failed: source file not found for <id>` no longer fires.

Exit codes now distinguish outcomes:

| code | meaning |
|------|---------|
| 0 | session has token data |
| 1 | error (bad args, DB open, etc.) |
| 2 | session not found |
| 3 | session known but no token data yet |

JSON output gains `has_token_data` so callers can branch without reading the exit code.