### PR TITLE
fix(parser): skip git-root walk for foreign-OS cwds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/mod v0.35.0
+	golang.org/x/sync v0.17.0
 	golang.org/x/term v0.35.0
 )
 
@@ -28,7 +29,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -7,7 +7,10 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // osStat is indirected through a var so tests can intercept stat
@@ -260,27 +263,47 @@ func isForeignOSPath(cwd, cleaned string, winPath bool) bool {
 	return false
 }
 
+// autofsProbeTTL bounds how long a probe result (positive or
+// negative) is trusted. Long enough that a bulk sync pays for
+// one probe per unique prefix user; short enough that a long-
+// running server rediscovers a mount that came up after startup.
+const autofsProbeTTL = 60 * time.Second
+
+// nowFn is indirected so TTL-expiry tests can advance the clock.
+var nowFn = time.Now
+
+type autofsProbeEntry struct {
+	resolves bool
+	expires  time.Time
+}
+
 // autofsProbes memoises whether the first path component under an
-// autofs prefix actually resolves locally. The cache is keyed by
-// the probed path (e.g. "/home/wes"), so a bulk sync whose cwds
-// all share a single <prefix>/<user> pays one stat overall rather
-// than one per session.
+// autofs prefix resolves locally. Keyed by the probed path
+// (e.g. "/home/wes"), so a bulk sync whose cwds all share a
+// single <prefix>/<user> pays one probe rather than one per
+// session.
+//
+// Writes go through autofsProbeSF to collapse concurrent misses
+// for the same key into a single osStat call — critical because
+// sync workers probe in parallel.
 var (
-	autofsProbesMu sync.RWMutex
-	autofsProbes   = map[string]bool{}
+	autofsProbesMu sync.Mutex
+	autofsProbes   = map[string]autofsProbeEntry{}
+	autofsProbeSF  singleflight.Group
 )
 
-// resetAutofsProbes clears the probe cache. Intended for tests
-// that need deterministic probe counts.
+// resetAutofsProbes clears the cache and in-flight probes.
+// Intended for tests that need deterministic probe counts.
 func resetAutofsProbes() {
 	autofsProbesMu.Lock()
-	autofsProbes = map[string]bool{}
+	autofsProbes = map[string]autofsProbeEntry{}
 	autofsProbesMu.Unlock()
+	autofsProbeSF = singleflight.Group{}
 }
 
 // autofsFirstLevelResolves probes whether <prefix>/<first-comp>
-// exists as a real filesystem entry on this host. The result is
-// cached per probed path.
+// exists as a real filesystem entry. Results are cached for
+// autofsProbeTTL and concurrent misses share a single probe.
 func autofsFirstLevelResolves(prefix, cleaned string) bool {
 	rest := cleaned[len(prefix):]
 	if i := strings.IndexByte(rest, '/'); i >= 0 {
@@ -288,20 +311,42 @@ func autofsFirstLevelResolves(prefix, cleaned string) bool {
 	}
 	key := prefix + rest
 
-	autofsProbesMu.RLock()
-	resolves, ok := autofsProbes[key]
-	autofsProbesMu.RUnlock()
-	if ok {
+	if resolves, ok := lookupAutofsProbe(key); ok {
 		return resolves
 	}
 
-	_, err := osStat(key)
-	resolves = err == nil
+	v, _, _ := autofsProbeSF.Do(key, func() (any, error) {
+		// Re-check inside the singleflight slot: a prior
+		// caller for the same key may have just populated
+		// the cache while we were waiting for the slot.
+		if resolves, ok := lookupAutofsProbe(key); ok {
+			return resolves, nil
+		}
+		_, err := osStat(key)
+		resolves := err == nil
+		storeAutofsProbe(key, resolves)
+		return resolves, nil
+	})
+	return v.(bool)
+}
 
+func lookupAutofsProbe(key string) (bool, bool) {
 	autofsProbesMu.Lock()
-	autofsProbes[key] = resolves
+	defer autofsProbesMu.Unlock()
+	entry, ok := autofsProbes[key]
+	if !ok || !nowFn().Before(entry.expires) {
+		return false, false
+	}
+	return entry.resolves, true
+}
+
+func storeAutofsProbe(key string, resolves bool) {
+	autofsProbesMu.Lock()
+	autofsProbes[key] = autofsProbeEntry{
+		resolves: resolves,
+		expires:  nowFn().Add(autofsProbeTTL),
+	}
 	autofsProbesMu.Unlock()
-	return resolves
 }
 
 // looksLikeWindowsPath returns true when cwd appears to use

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -156,53 +157,75 @@ func projectFromWorktreeLayout(path string) string {
 	return ""
 }
 
-// autoMasterPath is indirected so tests can substitute a fixture.
-var autoMasterPath = "/etc/auto_master"
+// autofsMountSource is indirected so tests can supply fixture
+// output in lieu of running mount(8).
+var autofsMountSource = runMountCommand
 
-// autofsPrefixes holds path prefixes that the local autofs config
-// manages, each with a trailing separator so strings.HasPrefix
-// gives component-boundary matches. Populated at package init on
-// darwin; other platforms leave it empty.
+func runMountCommand() ([]byte, error) {
+	return exec.Command("/sbin/mount").Output()
+}
+
+// autofsPrefixes holds path prefixes that autofs is actively
+// managing on this host, each with a trailing separator so
+// strings.HasPrefix gives component-boundary matches. Populated
+// at package init on darwin from the live mount table; other
+// platforms leave it empty.
 //
 // Why we care: os.Stat into an autofs-managed prefix triggers
 // automountd. For the default /home entry macOS resolves the map
 // via /usr/libexec/od_user_homes, which asks opendirectoryd to
 // enumerate every user record. Bulk remote-sync runs whose
 // session cwds all share a /home/<user>/... prefix therefore peg
-// opendirectoryd and automountd at hundreds of percent CPU. The
-// git-root walker skips paths that fall inside these prefixes.
+// opendirectoryd and automountd at hundreds of percent CPU.
 //
-// Discovering the prefix set from auto_master (rather than
-// hardcoding /home) means a host with a real filesystem at /home
-// — and no autofs entry — still gets full git-root resolution.
+// Sourcing the prefix set from mount(8) (rather than parsing
+// /etc/auto_master directly) captures prefixes pulled in via
+// +auto_master directory-service includes, which never appear
+// in the local config file.
 var autofsPrefixes = detectAutofsPrefixes()
 
-// detectAutofsPrefixes reads auto_master and returns the mount
-// points declared as autofs prefixes. Returns nil on non-darwin
-// hosts or when the file is absent/unreadable.
+// detectAutofsPrefixes returns the autofs-managed path prefixes
+// reported by the running mount table. Non-darwin hosts and
+// exec failures both return nil.
 func detectAutofsPrefixes() []string {
 	if runtime.GOOS != "darwin" {
 		return nil
 	}
-	data, err := os.ReadFile(autoMasterPath)
+	data, err := autofsMountSource()
 	if err != nil {
 		return nil
 	}
+	return parseMountOutputForAutofs(data)
+}
+
+// parseMountOutputForAutofs extracts the mount points of autofs
+// filesystems from mount(8) output. Typical macOS lines look
+// like:
+//
+//	map auto_home on /System/Volumes/Data/home (autofs, automounted, nobrowse)
+//	server.example:/export on /corp/home (autofs, nobrowse)
+//
+// macOS presents the Data volume at / via an APFS firmlink, so
+// /System/Volumes/Data is stripped to match the path form that
+// client code observes.
+func parseMountOutputForAutofs(data []byte) []string {
 	var out []string
 	for line := range strings.SplitSeq(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
+		if !strings.Contains(line, "(autofs") {
 			continue
 		}
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
+		_, after, ok := strings.Cut(line, " on ")
+		if !ok {
 			continue
 		}
-		mount := fields[0]
-		// Skip +include directives (e.g. +auto_master) and the
-		// direct-map marker /- — neither corresponds to a prefix
-		// we could match with strings.HasPrefix.
-		if !strings.HasPrefix(mount, "/") || mount == "/-" {
+		rest := after
+		parenIdx := strings.LastIndex(rest, " (")
+		if parenIdx < 0 {
+			continue
+		}
+		mount := strings.TrimSpace(rest[:parenIdx])
+		mount = strings.TrimPrefix(mount, "/System/Volumes/Data")
+		if mount == "" || mount == "/" {
 			continue
 		}
 		out = append(out, strings.TrimRight(mount, "/")+"/")

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -8,6 +8,11 @@ import (
 	"unicode"
 )
 
+// osStat is indirected through a var so tests can intercept stat
+// calls from the git-root walker. Production code always uses
+// os.Stat via this binding.
+var osStat = os.Stat
+
 var projectMarkers = []string{
 	"code", "projects", "repos", "src", "work", "dev",
 }
@@ -84,14 +89,14 @@ func ExtractProjectFromCwdWithBranch(
 	}
 	cleaned := filepath.Clean(norm)
 
-	// On non-Windows, a converted Windows path like "C:/Users/..."
-	// is treated as relative by filepath and would cause
-	// findGitRepoRoot to walk up from the process CWD. Skip git
-	// root detection only for foreign Windows paths on POSIX;
-	// on actual Windows hosts, drive-letter paths are native and
-	// git root detection must still run.
-	foreignWinPath := winPath && runtime.GOOS != "windows"
-	if !foreignWinPath {
+	// Skip the git-root walk when cwd uses a path convention
+	// foreign to the running OS. There is no local directory to
+	// find, and on macOS walking under /home/* triggers autofs
+	// (auto_home -> /usr/libexec/od_user_homes), which cascades
+	// into opendirectoryd lookups across every user record —
+	// pathological when bulk-processing remote sessions whose
+	// cwds all share a /home/<user>/... prefix.
+	if !isForeignOSPath(cwd, winPath) {
 		if root := findGitRepoRoot(cleaned); root != "" {
 			name := filepath.Base(root)
 			if isInvalidPathBase(name) {
@@ -152,6 +157,28 @@ func projectFromWorktreeLayout(path string) string {
 	return ""
 }
 
+// isForeignOSPath reports whether cwd uses a path convention that
+// cannot correspond to a local filesystem location on the running
+// OS. Walking such a path with os.Stat is both futile and, on
+// macOS, actively harmful: /home is an autofs mount point whose
+// map resolver (/usr/libexec/od_user_homes) enumerates every user
+// record through opendirectoryd, so bulk probes from remote-sync
+// runs peg opendirectoryd and automountd at many hundred percent
+// CPU. Windows-style paths on POSIX were the original case; the
+// cross-OS home-prefix cases cover the autofs storm symmetrically.
+func isForeignOSPath(cwd string, winPath bool) bool {
+	if winPath {
+		return runtime.GOOS != "windows"
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return strings.HasPrefix(cwd, "/home/")
+	case "linux":
+		return strings.HasPrefix(cwd, "/Users/")
+	}
+	return false
+}
+
 // looksLikeWindowsPath returns true when cwd appears to use
 // Windows path conventions: a drive letter (e.g. "C:\...") or a
 // UNC prefix ("\\server\..."). On POSIX, backslash is a legal
@@ -191,7 +218,7 @@ func findGitRepoRoot(cwd string) string {
 
 	dir := cwd
 	cwdMissing := false
-	if info, err := os.Stat(dir); err == nil {
+	if info, err := osStat(dir); err == nil {
 		if !info.IsDir() {
 			dir = filepath.Dir(dir)
 		}
@@ -212,7 +239,7 @@ func findGitRepoRoot(cwd string) string {
 	if cwdMissing {
 		sibDir := dir
 		for {
-			if _, err := os.Stat(sibDir); err == nil {
+			if _, err := osStat(sibDir); err == nil {
 				break
 			}
 			parent := filepath.Dir(sibDir)
@@ -228,7 +255,7 @@ func findGitRepoRoot(cwd string) string {
 
 	for {
 		gitPath := filepath.Join(dir, ".git")
-		info, err := os.Stat(gitPath)
+		info, err := osStat(gitPath)
 		if err == nil {
 			if info.IsDir() {
 				return dir
@@ -259,7 +286,7 @@ func findGitRepoRoot(cwd string) string {
 func repoRootFromSiblings(dir, cwd string) string {
 	// If dir is itself a repo or worktree, let the normal
 	// upward walk handle it.
-	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+	if _, err := osStat(filepath.Join(dir, ".git")); err == nil {
 		return ""
 	}
 	entries, err := os.ReadDir(dir)
@@ -282,7 +309,7 @@ func repoRootFromSiblings(dir, cwd string) string {
 			continue
 		}
 		gitPath := filepath.Join(dir, entry.Name(), ".git")
-		info, err := os.Stat(gitPath)
+		info, err := osStat(gitPath)
 		if err != nil {
 			continue
 		}

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"unicode"
 )
 
@@ -89,14 +90,12 @@ func ExtractProjectFromCwdWithBranch(
 	}
 	cleaned := filepath.Clean(norm)
 
-	// Skip the git-root walk when cwd uses a path convention
-	// foreign to the running OS. There is no local directory to
-	// find, and on macOS walking under /home/* triggers autofs
-	// (auto_home -> /usr/libexec/od_user_homes), which cascades
-	// into opendirectoryd lookups across every user record —
-	// pathological when bulk-processing remote sessions whose
-	// cwds all share a /home/<user>/... prefix.
-	if !isForeignOSPath(cwd, winPath) {
+	// Skip the git-root walk when the cwd cannot resolve to a
+	// real local filesystem location. On macOS a bulk walk under
+	// an unbacked autofs prefix cascades through automountd into
+	// opendirectoryd (/usr/libexec/od_user_homes), so we probe
+	// the prefix once before walking.
+	if !isForeignOSPath(cwd, cleaned, winPath) {
 		if root := findGitRepoRoot(cleaned); root != "" {
 			name := filepath.Base(root)
 			if isInvalidPathBase(name) {
@@ -212,27 +211,74 @@ func detectAutofsPrefixes() []string {
 }
 
 // isForeignOSPath reports whether cwd should bypass the local
-// git-root walk. Two cases qualify:
+// git-root walk.
 //
 //   - Windows-convention paths on POSIX hosts (drive letters, UNC
 //     prefixes) cannot exist as real filesystem locations.
-//   - Paths under a locally-configured autofs prefix: walking them
-//     triggers automountd, which on macOS cascades into
-//     opendirectoryd enumeration of every user record.
+//   - Paths under a local autofs prefix whose first component does
+//     not resolve: walking them on macOS triggers automountd per
+//     ancestor, and auto_home's resolver asks opendirectoryd to
+//     enumerate every user record — a hundred-percent-CPU storm
+//     under bulk remote sync.
 //
-// The autofs set is discovered from /etc/auto_master, so hosts
-// that have replaced the default /home autofs entry with a real
-// mount are not misclassified.
-func isForeignOSPath(cwd string, winPath bool) bool {
+// An autofs prefix that does resolve (e.g. an enterprise NFS-backed
+// /home) falls through to the walk so repository roots are still
+// found.
+func isForeignOSPath(cwd, cleaned string, winPath bool) bool {
 	if winPath {
 		return runtime.GOOS != "windows"
 	}
 	for _, prefix := range autofsPrefixes {
-		if strings.HasPrefix(cwd, prefix) {
-			return true
+		if !strings.HasPrefix(cleaned, prefix) {
+			continue
 		}
+		return !autofsFirstLevelResolves(prefix, cleaned)
 	}
 	return false
+}
+
+// autofsProbes memoises whether the first path component under an
+// autofs prefix actually resolves locally. The cache is keyed by
+// the probed path (e.g. "/home/wes"), so a bulk sync whose cwds
+// all share a single <prefix>/<user> pays one stat overall rather
+// than one per session.
+var (
+	autofsProbesMu sync.RWMutex
+	autofsProbes   = map[string]bool{}
+)
+
+// resetAutofsProbes clears the probe cache. Intended for tests
+// that need deterministic probe counts.
+func resetAutofsProbes() {
+	autofsProbesMu.Lock()
+	autofsProbes = map[string]bool{}
+	autofsProbesMu.Unlock()
+}
+
+// autofsFirstLevelResolves probes whether <prefix>/<first-comp>
+// exists as a real filesystem entry on this host. The result is
+// cached per probed path.
+func autofsFirstLevelResolves(prefix, cleaned string) bool {
+	rest := cleaned[len(prefix):]
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		rest = rest[:i]
+	}
+	key := prefix + rest
+
+	autofsProbesMu.RLock()
+	resolves, ok := autofsProbes[key]
+	autofsProbesMu.RUnlock()
+	if ok {
+		return resolves
+	}
+
+	_, err := osStat(key)
+	resolves = err == nil
+
+	autofsProbesMu.Lock()
+	autofsProbes[key] = resolves
+	autofsProbesMu.Unlock()
+	return resolves
 }
 
 // looksLikeWindowsPath returns true when cwd appears to use

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -157,24 +157,80 @@ func projectFromWorktreeLayout(path string) string {
 	return ""
 }
 
-// isForeignOSPath reports whether cwd uses a path convention that
-// cannot correspond to a local filesystem location on the running
-// OS. Walking such a path with os.Stat is both futile and, on
-// macOS, actively harmful: /home is an autofs mount point whose
-// map resolver (/usr/libexec/od_user_homes) enumerates every user
-// record through opendirectoryd, so bulk probes from remote-sync
-// runs peg opendirectoryd and automountd at many hundred percent
-// CPU. Windows-style paths on POSIX were the original case; the
-// cross-OS home-prefix cases cover the autofs storm symmetrically.
+// autoMasterPath is indirected so tests can substitute a fixture.
+var autoMasterPath = "/etc/auto_master"
+
+// autofsPrefixes holds path prefixes that the local autofs config
+// manages, each with a trailing separator so strings.HasPrefix
+// gives component-boundary matches. Populated at package init on
+// darwin; other platforms leave it empty.
+//
+// Why we care: os.Stat into an autofs-managed prefix triggers
+// automountd. For the default /home entry macOS resolves the map
+// via /usr/libexec/od_user_homes, which asks opendirectoryd to
+// enumerate every user record. Bulk remote-sync runs whose
+// session cwds all share a /home/<user>/... prefix therefore peg
+// opendirectoryd and automountd at hundreds of percent CPU. The
+// git-root walker skips paths that fall inside these prefixes.
+//
+// Discovering the prefix set from auto_master (rather than
+// hardcoding /home) means a host with a real filesystem at /home
+// — and no autofs entry — still gets full git-root resolution.
+var autofsPrefixes = detectAutofsPrefixes()
+
+// detectAutofsPrefixes reads auto_master and returns the mount
+// points declared as autofs prefixes. Returns nil on non-darwin
+// hosts or when the file is absent/unreadable.
+func detectAutofsPrefixes() []string {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	data, err := os.ReadFile(autoMasterPath)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		mount := fields[0]
+		// Skip +include directives (e.g. +auto_master) and the
+		// direct-map marker /- — neither corresponds to a prefix
+		// we could match with strings.HasPrefix.
+		if !strings.HasPrefix(mount, "/") || mount == "/-" {
+			continue
+		}
+		out = append(out, strings.TrimRight(mount, "/")+"/")
+	}
+	return out
+}
+
+// isForeignOSPath reports whether cwd should bypass the local
+// git-root walk. Two cases qualify:
+//
+//   - Windows-convention paths on POSIX hosts (drive letters, UNC
+//     prefixes) cannot exist as real filesystem locations.
+//   - Paths under a locally-configured autofs prefix: walking them
+//     triggers automountd, which on macOS cascades into
+//     opendirectoryd enumeration of every user record.
+//
+// The autofs set is discovered from /etc/auto_master, so hosts
+// that have replaced the default /home autofs entry with a real
+// mount are not misclassified.
 func isForeignOSPath(cwd string, winPath bool) bool {
 	if winPath {
 		return runtime.GOOS != "windows"
 	}
-	switch runtime.GOOS {
-	case "darwin":
-		return strings.HasPrefix(cwd, "/home/")
-	case "linux":
-		return strings.HasPrefix(cwd, "/Users/")
+	for _, prefix := range autofsPrefixes {
+		if strings.HasPrefix(cwd, prefix) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/parser/project_foreign_test.go
+++ b/internal/parser/project_foreign_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // autofsTestsSupported reports whether the running OS uses POSIX
@@ -238,6 +240,107 @@ func TestDetectAutofsPrefixes(t *testing.T) {
 	want := []string{"/home/", "/Network/Servers/"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("detectAutofsPrefixes() = %v, want %v", got, want)
+	}
+}
+
+// TestExtractProjectFromCwd_AutofsConcurrent_SingleProbe exercises
+// the single-flight guarantee: N goroutines hitting the same
+// unresolved autofs prefix must share a single probe, not race
+// each other into N duplicate automount attempts.
+func TestExtractProjectFromCwd_AutofsConcurrent_SingleProbe(t *testing.T) {
+	if !autofsTestsSupported() {
+		t.Skip("autofs tests require POSIX path separators")
+	}
+	origPrefixes := autofsPrefixes
+	defer func() { autofsPrefixes = origPrefixes }()
+	autofsPrefixes = []string{"/home/"}
+	resetAutofsProbes()
+
+	// Hold osStat open so later callers have a chance to pile
+	// up against the first one. Without single-flight all of
+	// them will issue their own stat before the cache populates.
+	release := make(chan struct{})
+	orig := osStat
+	defer func() { osStat = orig }()
+	var count atomic.Int64
+	osStat = func(path string) (os.FileInfo, error) {
+		count.Add(1)
+		<-release
+		return nil, os.ErrNotExist
+	}
+
+	const workers = 16
+	var started sync.WaitGroup
+	var done sync.WaitGroup
+	started.Add(workers)
+	done.Add(workers)
+	for range workers {
+		go func() {
+			defer done.Done()
+			started.Done()
+			_ = ExtractProjectFromCwdWithBranch(
+				"/home/wes/code/proj", "")
+		}()
+	}
+	started.Wait()
+	// Give the workers a moment to actually enter the probe.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	done.Wait()
+
+	if n := count.Load(); n != 1 {
+		t.Errorf("concurrent probes issued %d osStat calls; "+
+			"expected exactly 1 under %d-way concurrency",
+			n, workers)
+	}
+}
+
+// TestExtractProjectFromCwd_AutofsProbe_TTLExpires guards against
+// permanently caching a negative probe result. A path that was
+// unreachable at first access should be re-probed after the TTL
+// so a later-appearing mount (e.g. delayed NFS availability on a
+// long-running server) can start resolving to its repository
+// root.
+func TestExtractProjectFromCwd_AutofsProbe_TTLExpires(t *testing.T) {
+	if !autofsTestsSupported() {
+		t.Skip("autofs tests require POSIX path separators")
+	}
+	origPrefixes := autofsPrefixes
+	defer func() { autofsPrefixes = origPrefixes }()
+	autofsPrefixes = []string{"/home/"}
+	resetAutofsProbes()
+
+	origNow := nowFn
+	defer func() { nowFn = origNow }()
+	current := time.Now()
+	nowFn = func() time.Time { return current }
+
+	orig := osStat
+	defer func() { osStat = orig }()
+	var count atomic.Int64
+	osStat = func(path string) (os.FileInfo, error) {
+		count.Add(1)
+		return nil, os.ErrNotExist
+	}
+
+	cwd := "/home/wes/code/proj"
+	_ = ExtractProjectFromCwdWithBranch(cwd, "")
+	if n := count.Load(); n != 1 {
+		t.Fatalf("first call: expected 1 osStat, got %d", n)
+	}
+
+	// Within TTL — cached, no new probe.
+	current = current.Add(autofsProbeTTL / 2)
+	_ = ExtractProjectFromCwdWithBranch(cwd, "")
+	if n := count.Load(); n != 1 {
+		t.Fatalf("within TTL: expected still 1 osStat, got %d", n)
+	}
+
+	// Past TTL — re-probe.
+	current = current.Add(autofsProbeTTL + time.Second)
+	_ = ExtractProjectFromCwdWithBranch(cwd, "")
+	if n := count.Load(); n != 2 {
+		t.Errorf("past TTL: expected 2 osStat calls, got %d", n)
 	}
 }
 

--- a/internal/parser/project_foreign_test.go
+++ b/internal/parser/project_foreign_test.go
@@ -1,13 +1,22 @@
 package parser
 
 import (
+	"errors"
 	"os"
-	"path/filepath"
 	"reflect"
 	"runtime"
 	"sync/atomic"
 	"testing"
 )
+
+// autofsTestsSupported reports whether the running OS uses POSIX
+// path separators, which the autofs prefix matching depends on.
+// Windows-normalised paths (\home\...) would not match the /home/
+// prefix form autofs reports, and Windows has no autofs in the
+// first place, so these tests are skipped there.
+func autofsTestsSupported() bool {
+	return runtime.GOOS != "windows"
+}
 
 // TestExtractProjectFromCwd_AutofsUnresolved_SkipsWalk verifies
 // that a cwd under an autofs prefix whose first component does
@@ -16,6 +25,9 @@ import (
 // full git-root walk. Without the skip, statting every ancestor
 // hammers automountd/opendirectoryd via /usr/libexec/od_user_homes.
 func TestExtractProjectFromCwd_AutofsUnresolved_SkipsWalk(t *testing.T) {
+	if !autofsTestsSupported() {
+		t.Skip("autofs tests require POSIX path separators")
+	}
 	origPrefixes := autofsPrefixes
 	defer func() { autofsPrefixes = origPrefixes }()
 	autofsPrefixes = []string{"/home/"}
@@ -46,6 +58,9 @@ func TestExtractProjectFromCwd_AutofsUnresolved_SkipsWalk(t *testing.T) {
 // that a bulk sync with many cwds under the same autofs first
 // component pays for only one stat across the batch.
 func TestExtractProjectFromCwd_AutofsUnresolved_ProbeCached(t *testing.T) {
+	if !autofsTestsSupported() {
+		t.Skip("autofs tests require POSIX path separators")
+	}
 	origPrefixes := autofsPrefixes
 	defer func() { autofsPrefixes = origPrefixes }()
 	autofsPrefixes = []string{"/home/"}
@@ -78,6 +93,9 @@ func TestExtractProjectFromCwd_AutofsUnresolved_ProbeCached(t *testing.T) {
 // still resolve projects to their repository roots. A resolving
 // probe lets the git-root walk proceed normally.
 func TestExtractProjectFromCwd_AutofsResolved_Walks(t *testing.T) {
+	if !autofsTestsSupported() {
+		t.Skip("autofs tests require POSIX path separators")
+	}
 	origPrefixes := autofsPrefixes
 	defer func() { autofsPrefixes = origPrefixes }()
 	autofsPrefixes = []string{"/home/"}
@@ -114,9 +132,13 @@ func TestExtractProjectFromCwd_AutofsResolved_Walks(t *testing.T) {
 // paths outside any autofs-managed prefix still trigger the
 // git-root walk.
 func TestExtractProjectFromCwd_NativePath_StillWalks(t *testing.T) {
+	if !autofsTestsSupported() {
+		t.Skip("autofs tests require POSIX path separators")
+	}
 	origPrefixes := autofsPrefixes
 	defer func() { autofsPrefixes = origPrefixes }()
 	autofsPrefixes = []string{"/home/"}
+	resetAutofsProbes()
 
 	orig := osStat
 	defer func() { osStat = orig }()
@@ -139,9 +161,13 @@ func TestExtractProjectFromCwd_NativePath_StillWalks(t *testing.T) {
 // mounted at /home (no autofs entry) should still get git-root
 // resolution, not a basename-only fallback.
 func TestExtractProjectFromCwd_HomePathWithoutAutofs_StillWalks(t *testing.T) {
+	if !autofsTestsSupported() {
+		t.Skip("autofs tests require POSIX path separators")
+	}
 	origPrefixes := autofsPrefixes
 	defer func() { autofsPrefixes = origPrefixes }()
 	autofsPrefixes = nil
+	resetAutofsProbes()
 
 	orig := osStat
 	defer func() { osStat = orig }()
@@ -159,27 +185,47 @@ func TestExtractProjectFromCwd_HomePathWithoutAutofs_StillWalks(t *testing.T) {
 	}
 }
 
-// TestDetectAutofsPrefixes verifies that /etc/auto_master is parsed
-// into the prefix set. Only darwin is expected to populate this;
-// other platforms return an empty list.
-func TestDetectAutofsPrefixes(t *testing.T) {
-	origPath := autoMasterPath
-	defer func() { autoMasterPath = origPath }()
-
-	tmp := t.TempDir()
-	fixture := filepath.Join(tmp, "auto_master")
-	content := "#\n" +
-		"# Automounter master map\n" +
-		"#\n" +
-		"+auto_master\n" +
-		"#/net           -hosts    -nobrowse\n" +
-		"/home           auto_home -nobrowse,hidefromfinder\n" +
-		"/Network/Servers -fstab\n" +
-		"/-              -static\n"
-	if err := os.WriteFile(fixture, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
+// TestParseMountOutputForAutofs exercises the pure mount-output
+// parser. It runs on every platform because it operates on the
+// string form of `mount`'s output.
+func TestParseMountOutputForAutofs(t *testing.T) {
+	// Representative macOS output mixing real filesystems with
+	// autofs entries; includes the /System/Volumes/Data firmlink
+	// prefix that must be stripped.
+	input := []byte(`/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+devfs on /dev (devfs, local, nobrowse)
+/dev/disk3s6 on /System/Volumes/VM (apfs, local, noexec, journaled, nobrowse, sealed)
+map auto_home on /System/Volumes/Data/home (autofs, automounted, nobrowse)
+map -hosts on /System/Volumes/Data/net (autofs, automounted, nobrowse)
+map -fstab on /System/Volumes/Data/Network/Servers (autofs, automounted, nobrowse)
+server.example:/export on /corp/home (autofs, nobrowse)
+`)
+	got := parseMountOutputForAutofs(input)
+	want := []string{
+		"/home/",
+		"/net/",
+		"/Network/Servers/",
+		"/corp/home/",
 	}
-	autoMasterPath = fixture
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseMountOutputForAutofs() = %v, want %v",
+			got, want)
+	}
+}
+
+// TestDetectAutofsPrefixes uses the injectable mount source so the
+// end-to-end detection path runs without actually invoking mount(8).
+func TestDetectAutofsPrefixes(t *testing.T) {
+	origSrc := autofsMountSource
+	defer func() { autofsMountSource = origSrc }()
+	autofsMountSource = func() ([]byte, error) {
+		return []byte(
+			"map auto_home on /System/Volumes/Data/home " +
+				"(autofs, automounted, nobrowse)\n" +
+				"map -fstab on /System/Volumes/Data/Network/Servers " +
+				"(autofs, automounted, nobrowse)\n",
+		), nil
+	}
 
 	got := detectAutofsPrefixes()
 	if runtime.GOOS != "darwin" {
@@ -189,23 +235,23 @@ func TestDetectAutofsPrefixes(t *testing.T) {
 		}
 		return
 	}
-
 	want := []string{"/home/", "/Network/Servers/"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("detectAutofsPrefixes() = %v, want %v", got, want)
 	}
 }
 
-// TestDetectAutofsPrefixes_MissingFile confirms that a missing
-// auto_master file (unusual but possible) yields an empty list
-// rather than crashing.
-func TestDetectAutofsPrefixes_MissingFile(t *testing.T) {
-	origPath := autoMasterPath
-	defer func() { autoMasterPath = origPath }()
-	autoMasterPath = filepath.Join(t.TempDir(), "does-not-exist")
-
+// TestDetectAutofsPrefixes_MountFails confirms that a mount(8)
+// failure degrades to nil rather than crashing or blocking the
+// git-root walk on unrelated paths.
+func TestDetectAutofsPrefixes_MountFails(t *testing.T) {
+	origSrc := autofsMountSource
+	defer func() { autofsMountSource = origSrc }()
+	autofsMountSource = func() ([]byte, error) {
+		return nil, errors.New("mock mount failure")
+	}
 	if got := detectAutofsPrefixes(); got != nil {
-		t.Errorf("detectAutofsPrefixes() with missing file = %v, want nil",
-			got)
+		t.Errorf("detectAutofsPrefixes() with mount failure = %v, "+
+			"want nil", got)
 	}
 }

--- a/internal/parser/project_foreign_test.go
+++ b/internal/parser/project_foreign_test.go
@@ -2,32 +2,24 @@ package parser
 
 import (
 	"os"
+	"path/filepath"
+	"reflect"
 	"runtime"
 	"sync/atomic"
 	"testing"
 )
 
 // TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk verifies that
-// a cwd using a path convention foreign to the running OS does not
+// a cwd falling inside a locally-configured autofs prefix does not
 // trigger any filesystem stat calls. On macOS, statting under /home
 // fires autofs, which cascades into opendirectoryd/automountd
 // lookups via /usr/libexec/od_user_homes. At bulk-remote-sync scale
 // this pegs both daemons at 100s of % CPU, so the git-root walk
-// must be skipped for paths that can't correspond to a local
-// filesystem location anyway.
+// must be skipped for such paths.
 func TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk(t *testing.T) {
-	var cwd, want string
-	switch runtime.GOOS {
-	case "darwin":
-		cwd = "/home/wes/code/example-project"
-		want = "example_project"
-	case "linux":
-		cwd = "/Users/wes/code/example-project"
-		want = "example_project"
-	default:
-		t.Skipf("test only applies to darwin/linux, got %s",
-			runtime.GOOS)
-	}
+	origPrefixes := autofsPrefixes
+	defer func() { autofsPrefixes = origPrefixes }()
+	autofsPrefixes = []string{"/home/"}
 
 	orig := osStat
 	defer func() { osStat = orig }()
@@ -37,32 +29,27 @@ func TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk(t *testing.T) {
 		return orig(path)
 	}
 
+	cwd := "/home/wes/code/example-project"
+	want := "example_project"
 	got := ExtractProjectFromCwdWithBranch(cwd, "")
 	if got != want {
 		t.Errorf("ExtractProjectFromCwdWithBranch(%q) = %q, want %q",
 			cwd, got, want)
 	}
 	if n := count.Load(); n != 0 {
-		t.Errorf("osStat called %d times for foreign cwd %q; "+
+		t.Errorf("osStat called %d times for autofs-managed cwd %q; "+
 			"expected 0 (git-root walk should be skipped)",
 			n, cwd)
 	}
 }
 
-// TestExtractProjectFromCwd_NativePath_StillWalks confirms the
-// skip is path-specific: a native-prefix cwd still triggers the
-// git-root walk so ExtractProjectFromCwd can find real repos.
+// TestExtractProjectFromCwd_NativePath_StillWalks confirms that
+// paths outside any autofs-managed prefix still trigger the
+// git-root walk.
 func TestExtractProjectFromCwd_NativePath_StillWalks(t *testing.T) {
-	var cwd string
-	switch runtime.GOOS {
-	case "darwin":
-		cwd = "/Users/nobody-agentsview-test/code/example"
-	case "linux":
-		cwd = "/home/nobody-agentsview-test/code/example"
-	default:
-		t.Skipf("test only applies to darwin/linux, got %s",
-			runtime.GOOS)
-	}
+	origPrefixes := autofsPrefixes
+	defer func() { autofsPrefixes = origPrefixes }()
+	autofsPrefixes = []string{"/home/"}
 
 	orig := osStat
 	defer func() { osStat = orig }()
@@ -72,10 +59,86 @@ func TestExtractProjectFromCwd_NativePath_StillWalks(t *testing.T) {
 		return orig(path)
 	}
 
+	cwd := "/Users/nobody-agentsview-test/code/example"
 	_ = ExtractProjectFromCwdWithBranch(cwd, "")
 	if count.Load() == 0 {
-		t.Errorf("osStat never called for native cwd %q; "+
-			"git-root walk should run for local-style paths",
-			cwd)
+		t.Errorf("osStat never called for %q; "+
+			"git-root walk should run for non-autofs paths", cwd)
+	}
+}
+
+// TestExtractProjectFromCwd_HomePathWithoutAutofs_StillWalks covers
+// the edge case flagged in review: a user with a real filesystem
+// mounted at /home (no autofs entry) should still get git-root
+// resolution, not a basename-only fallback.
+func TestExtractProjectFromCwd_HomePathWithoutAutofs_StillWalks(t *testing.T) {
+	origPrefixes := autofsPrefixes
+	defer func() { autofsPrefixes = origPrefixes }()
+	autofsPrefixes = nil
+
+	orig := osStat
+	defer func() { osStat = orig }()
+	var count atomic.Int64
+	osStat = func(path string) (os.FileInfo, error) {
+		count.Add(1)
+		return orig(path)
+	}
+
+	cwd := "/home/nobody-agentsview-test/code/example"
+	_ = ExtractProjectFromCwdWithBranch(cwd, "")
+	if count.Load() == 0 {
+		t.Errorf("osStat never called for /home path with empty " +
+			"autofs config; walk must proceed for a real mount")
+	}
+}
+
+// TestDetectAutofsPrefixes verifies that /etc/auto_master is parsed
+// into the prefix set. Only darwin is expected to populate this;
+// other platforms return an empty list.
+func TestDetectAutofsPrefixes(t *testing.T) {
+	origPath := autoMasterPath
+	defer func() { autoMasterPath = origPath }()
+
+	tmp := t.TempDir()
+	fixture := filepath.Join(tmp, "auto_master")
+	content := "#\n" +
+		"# Automounter master map\n" +
+		"#\n" +
+		"+auto_master\n" +
+		"#/net           -hosts    -nobrowse\n" +
+		"/home           auto_home -nobrowse,hidefromfinder\n" +
+		"/Network/Servers -fstab\n" +
+		"/-              -static\n"
+	if err := os.WriteFile(fixture, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	autoMasterPath = fixture
+
+	got := detectAutofsPrefixes()
+	if runtime.GOOS != "darwin" {
+		if got != nil {
+			t.Errorf("detectAutofsPrefixes() = %v on %s, want nil",
+				got, runtime.GOOS)
+		}
+		return
+	}
+
+	want := []string{"/home/", "/Network/Servers/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("detectAutofsPrefixes() = %v, want %v", got, want)
+	}
+}
+
+// TestDetectAutofsPrefixes_MissingFile confirms that a missing
+// auto_master file (unusual but possible) yields an empty list
+// rather than crashing.
+func TestDetectAutofsPrefixes_MissingFile(t *testing.T) {
+	origPath := autoMasterPath
+	defer func() { autoMasterPath = origPath }()
+	autoMasterPath = filepath.Join(t.TempDir(), "does-not-exist")
+
+	if got := detectAutofsPrefixes(); got != nil {
+		t.Errorf("detectAutofsPrefixes() with missing file = %v, want nil",
+			got)
 	}
 }

--- a/internal/parser/project_foreign_test.go
+++ b/internal/parser/project_foreign_test.go
@@ -9,24 +9,24 @@ import (
 	"testing"
 )
 
-// TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk verifies that
-// a cwd falling inside a locally-configured autofs prefix does not
-// trigger any filesystem stat calls. On macOS, statting under /home
-// fires autofs, which cascades into opendirectoryd/automountd
-// lookups via /usr/libexec/od_user_homes. At bulk-remote-sync scale
-// this pegs both daemons at 100s of % CPU, so the git-root walk
-// must be skipped for such paths.
-func TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk(t *testing.T) {
+// TestExtractProjectFromCwd_AutofsUnresolved_SkipsWalk verifies
+// that a cwd under an autofs prefix whose first component does
+// not resolve locally (the classic "Linux cwd on a macOS box"
+// case) pays for exactly one stat — the probe — and skips the
+// full git-root walk. Without the skip, statting every ancestor
+// hammers automountd/opendirectoryd via /usr/libexec/od_user_homes.
+func TestExtractProjectFromCwd_AutofsUnresolved_SkipsWalk(t *testing.T) {
 	origPrefixes := autofsPrefixes
 	defer func() { autofsPrefixes = origPrefixes }()
 	autofsPrefixes = []string{"/home/"}
+	resetAutofsProbes()
 
 	orig := osStat
 	defer func() { osStat = orig }()
 	var count atomic.Int64
 	osStat = func(path string) (os.FileInfo, error) {
 		count.Add(1)
-		return orig(path)
+		return nil, os.ErrNotExist
 	}
 
 	cwd := "/home/wes/code/example-project"
@@ -36,10 +36,77 @@ func TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk(t *testing.T) {
 		t.Errorf("ExtractProjectFromCwdWithBranch(%q) = %q, want %q",
 			cwd, got, want)
 	}
-	if n := count.Load(); n != 0 {
-		t.Errorf("osStat called %d times for autofs-managed cwd %q; "+
-			"expected 0 (git-root walk should be skipped)",
-			n, cwd)
+	if n := count.Load(); n != 1 {
+		t.Errorf("osStat called %d times for unresolved autofs cwd "+
+			"%q; expected 1 (probe only, walk skipped)", n, cwd)
+	}
+}
+
+// TestExtractProjectFromCwd_AutofsUnresolved_ProbeCached checks
+// that a bulk sync with many cwds under the same autofs first
+// component pays for only one stat across the batch.
+func TestExtractProjectFromCwd_AutofsUnresolved_ProbeCached(t *testing.T) {
+	origPrefixes := autofsPrefixes
+	defer func() { autofsPrefixes = origPrefixes }()
+	autofsPrefixes = []string{"/home/"}
+	resetAutofsProbes()
+
+	orig := osStat
+	defer func() { osStat = orig }()
+	var count atomic.Int64
+	osStat = func(path string) (os.FileInfo, error) {
+		count.Add(1)
+		return nil, os.ErrNotExist
+	}
+
+	for _, cwd := range []string{
+		"/home/wes/code/proj-a",
+		"/home/wes/code/proj-b",
+		"/home/wes/code/nested/proj-c/src",
+	} {
+		_ = ExtractProjectFromCwdWithBranch(cwd, "")
+	}
+	if n := count.Load(); n != 1 {
+		t.Errorf("osStat called %d times across 3 cwds sharing "+
+			"/home/wes; expected 1 (cached probe)", n)
+	}
+}
+
+// TestExtractProjectFromCwd_AutofsResolved_Walks is the regression
+// guard for the reviewer's concern: enterprise hosts where an
+// autofs prefix has a real backing (e.g. NFS-mounted /home) must
+// still resolve projects to their repository roots. A resolving
+// probe lets the git-root walk proceed normally.
+func TestExtractProjectFromCwd_AutofsResolved_Walks(t *testing.T) {
+	origPrefixes := autofsPrefixes
+	defer func() { autofsPrefixes = origPrefixes }()
+	autofsPrefixes = []string{"/home/"}
+	resetAutofsProbes()
+
+	// Use a real directory's FileInfo so IsDir() answers true
+	// when the probe "resolves".
+	realDir := t.TempDir()
+	realInfo, err := os.Stat(realDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig := osStat
+	defer func() { osStat = orig }()
+	var count atomic.Int64
+	osStat = func(path string) (os.FileInfo, error) {
+		count.Add(1)
+		if path == "/home/wes" {
+			return realInfo, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	cwd := "/home/wes/code/example"
+	_ = ExtractProjectFromCwdWithBranch(cwd, "")
+	if n := count.Load(); n < 2 {
+		t.Errorf("with resolving autofs probe, expected the walk "+
+			"to stat multiple paths (probe + walk); got %d", n)
 	}
 }
 

--- a/internal/parser/project_foreign_test.go
+++ b/internal/parser/project_foreign_test.go
@@ -1,0 +1,81 @@
+package parser
+
+import (
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+)
+
+// TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk verifies that
+// a cwd using a path convention foreign to the running OS does not
+// trigger any filesystem stat calls. On macOS, statting under /home
+// fires autofs, which cascades into opendirectoryd/automountd
+// lookups via /usr/libexec/od_user_homes. At bulk-remote-sync scale
+// this pegs both daemons at 100s of % CPU, so the git-root walk
+// must be skipped for paths that can't correspond to a local
+// filesystem location anyway.
+func TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk(t *testing.T) {
+	var cwd, want string
+	switch runtime.GOOS {
+	case "darwin":
+		cwd = "/home/wes/code/example-project"
+		want = "example_project"
+	case "linux":
+		cwd = "/Users/wes/code/example-project"
+		want = "example_project"
+	default:
+		t.Skipf("test only applies to darwin/linux, got %s",
+			runtime.GOOS)
+	}
+
+	orig := osStat
+	defer func() { osStat = orig }()
+	var count atomic.Int64
+	osStat = func(path string) (os.FileInfo, error) {
+		count.Add(1)
+		return orig(path)
+	}
+
+	got := ExtractProjectFromCwdWithBranch(cwd, "")
+	if got != want {
+		t.Errorf("ExtractProjectFromCwdWithBranch(%q) = %q, want %q",
+			cwd, got, want)
+	}
+	if n := count.Load(); n != 0 {
+		t.Errorf("osStat called %d times for foreign cwd %q; "+
+			"expected 0 (git-root walk should be skipped)",
+			n, cwd)
+	}
+}
+
+// TestExtractProjectFromCwd_NativePath_StillWalks confirms the
+// skip is path-specific: a native-prefix cwd still triggers the
+// git-root walk so ExtractProjectFromCwd can find real repos.
+func TestExtractProjectFromCwd_NativePath_StillWalks(t *testing.T) {
+	var cwd string
+	switch runtime.GOOS {
+	case "darwin":
+		cwd = "/Users/nobody-agentsview-test/code/example"
+	case "linux":
+		cwd = "/home/nobody-agentsview-test/code/example"
+	default:
+		t.Skipf("test only applies to darwin/linux, got %s",
+			runtime.GOOS)
+	}
+
+	orig := osStat
+	defer func() { osStat = orig }()
+	var count atomic.Int64
+	osStat = func(path string) (os.FileInfo, error) {
+		count.Add(1)
+		return orig(path)
+	}
+
+	_ = ExtractProjectFromCwdWithBranch(cwd, "")
+	if count.Load() == 0 {
+		t.Errorf("osStat never called for native cwd %q; "+
+			"git-root walk should run for local-style paths",
+			cwd)
+	}
+}


### PR DESCRIPTION
## Summary

- `ExtractProjectFromCwdWithBranch` fed every cwd from session content into `findGitRepoRoot`, which walks upward statting each ancestor for `.git`.
- For sessions synced from a Linux host the cwd is `/home/<user>/...`. On macOS those paths sit under an autofs mount point (`/etc/auto_master` -> `/etc/auto_home` -> `+/usr/libexec/od_user_homes`), so each stat triggers `automountd` to ask `opendirectoryd` to enumerate every user record. Under `agentsview sync --host` this pegged `opendirectoryd` and `automountd` at 300%+ / 100%+ CPU for the duration of the sync.
- Generalise the existing `foreignWinPath` short-circuit in `ExtractProjectFromCwdWithBranch` into `isForeignOSPath`, which now also treats `/home/*` as foreign on darwin and `/Users/*` on linux. For those cwds the git-root walk is skipped and the function falls through to the worktree-layout / basename fallback.
- Route the walker's `os.Stat` calls through a package-level `osStat` var so tests can assert no stat calls happen on foreign paths.

## Test plan

- [x] `go test ./...` (all packages green)
- [x] `go vet ./...` clean
- [x] `make lint` reports 0 issues
- [x] New `TestExtractProjectFromCwd_ForeignPath_SkipsStatWalk` fails before the fix (9 stat calls, ~80ms of autofs on darwin) and passes after (0 stat calls)
- [x] New `TestExtractProjectFromCwd_NativePath_StillWalks` guards against over-skipping by confirming the walk still runs for `/Users/*` on darwin / `/home/*` on linux
- [x] Existing `TestExtractProjectFromCwd` / `TestExtractProjectFromCwd_Git` / `TestExtractProjectFromCwdWithBranch` suites still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)