### PR TITLE
feat(cli)!: require explicit serve subcommand to start server

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,6 +4,7 @@ tmp_dir = "tmp"
 [build]
 cmd = "./scripts/dev-backend-build.sh"
 bin = "./tmp/agentsview"
+args_bin = ["serve"]
 delay = 500
 exclude_dir = ["frontend", "internal/web/dist", "tmp", "vendor", ".git", "dist", "desktop", "data", "sessions", "html", ".superpowers"]
 include_ext = ["go", "tpl", "tmpl", "html", "sql"]

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ dev-snapshot: build
 	else \
 		echo "Reusing existing snapshot at $(SNAPSHOT_ABS)/sessions.db"; \
 	fi
-	AGENT_VIEWER_DATA_DIR="$(SNAPSHOT_ABS)" ./agentsview --port 0
+	AGENT_VIEWER_DATA_DIR="$(SNAPSHOT_ABS)" ./agentsview serve --port 0
 
 # Ensure air is installed for backend live reload
 check-air:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or download the **desktop app** (macOS / Windows) from
 ## Quick Start
 
 ```bash
-agentsview                 # start server, open web UI
+agentsview serve           # start server, open web UI
 agentsview usage daily     # print daily cost summary
 ```
 

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -34,7 +34,7 @@ func newRootCommand() *cobra.Command {
 				printVersion(cmd.OutOrStdout())
 				return
 			}
-			runServe(mustLoadConfig(cmd))
+			_ = cmd.Help()
 		},
 	}
 	root.AddGroup(
@@ -46,7 +46,6 @@ func newRootCommand() *cobra.Command {
 	root.SetCompletionCommandGroupID(groupMeta)
 	root.SetHelpCommandGroupID(groupMeta)
 
-	config.RegisterServePFlags(root.Flags())
 	root.Flags().BoolVarP(
 		&showVersion,
 		"version",

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -41,11 +41,34 @@ func TestRootHelpShowsKeySectionsAndCommands(t *testing.T) {
 		"usage daily            Daily cost summary",
 		"completion             Generate the autocompletion script for the specified shell",
 		"Flags:",
-		"--host string",
-		"--port int",
+		"--version",
 	} {
 		if !strings.Contains(help, want) {
 			t.Fatalf("help missing %q\n%s", want, help)
+		}
+	}
+	for _, unwanted := range []string{
+		"--host string",
+		"--port int",
+	} {
+		if strings.Contains(help, unwanted) {
+			t.Fatalf("root help should not include serve flag %q\n%s", unwanted, help)
+		}
+	}
+}
+
+func TestRootNoArgsShowsHelp(t *testing.T) {
+	out, err := executeCommand(newRootCommand())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{
+		"Usage:\n  agentsview [flags]\n  agentsview <command> [flags]",
+		"Core Commands:",
+		"serve                  Start server",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q\n%s", want, out)
 		}
 	}
 }

--- a/scripts/e2e-server.sh
+++ b/scripts/e2e-server.sh
@@ -52,6 +52,6 @@ IFLOW_DIR="$EMPTY_DIR" \
 VSCODE_COPILOT_DIR="$EMPTY_DIR" \
 PI_DIR="$EMPTY_DIR" \
 OPENCLAW_DIR="$EMPTY_DIR" \
-exec "$SERVER" \
+exec "$SERVER" serve \
   --port 8090 \
   --no-browser

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -225,7 +225,7 @@ function Install-Agentsview {
         }
 
         Write-Host "Get started:"
-        Write-Host "  agentsview          # Start the server and open browser"
+        Write-Host "  agentsview serve    # Start the server and open browser"
         Write-Host "  agentsview update   # Check for and install updates"
 
     } finally {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -195,7 +195,7 @@ main() {
     fi
 
     echo "Get started:"
-    echo "  agentsview          # Start the server and open browser"
+    echo "  agentsview serve    # Start the server and open browser"
     echo "  agentsview update   # Check for and install updates"
 }
 


### PR DESCRIPTION
## Summary

Bare `agentsview` now prints help instead of auto-launching the server. This matches conventional CLI behavior (git, docker, kubectl) where the top-level command shows usage when invoked without a subcommand.

- `--version`/`-v` still works at the root.
- Serve flags (`--host`, `--port`, etc.) are no longer registered on the root command, so `agentsview --port 9090` returns "unknown flag"; use `agentsview serve --port 9090` instead.
- `make dev` (`.air.toml`) and `make dev-snapshot` invoke `serve` explicitly.
- README quickstart updated.
- Tauri sidecar already invoked `serve` explicitly, so the desktop app is unaffected.