### PR TITLE
fix(parser): subtract cached tokens from codex input_tokens

### DIFF
--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -184,6 +184,14 @@ func ensureFreshData(
 
 	ctx := context.Background()
 
+	// Silence engine worker log.Printf lines (e.g. "db:
+	// InsertMessages (N msgs)") for both branches so --json and
+	// statusline output stay clean. Progress goes to stderr
+	// below to stay out of stdout-bound payloads.
+	origLog := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(origLog)
+
 	if database.NeedsResync() {
 		engine := sync.NewEngine(database, sync.EngineConfig{
 			AgentDirs: appCfg.AgentDirs,
@@ -191,7 +199,9 @@ func ensureFreshData(
 		})
 		fmt.Fprintln(os.Stderr,
 			"Data version changed, running full resync...")
-		engine.ResyncAll(ctx, nil)
+		t := time.Now()
+		stats := engine.ResyncAll(ctx, printSyncProgressStderr)
+		printSyncSummaryStderr(stats, t)
 		return
 	}
 
@@ -213,16 +223,45 @@ func ensureFreshData(
 		since = since.Add(-quickSyncMargin)
 	}
 
-	// Silence engine progress and incremental-parse logging
-	// so --json and statusline output stay clean. The engine
-	// emits unconditional log.Printf calls from worker paths
-	// that aren't gated by a verbose flag, so redirect the
-	// global logger for the duration of the sync.
-	origLog := log.Writer()
-	log.SetOutput(io.Discard)
-	defer log.SetOutput(origLog)
-
 	engine.SyncAllSince(ctx, since, func(sync.Progress) {})
+}
+
+// printSyncProgressStderr mirrors printSyncProgress but writes
+// to stderr so it does not pollute stdout-bound JSON or
+// statusline output from the usage commands.
+func printSyncProgressStderr(p sync.Progress) {
+	if p.SessionsTotal > 0 {
+		fmt.Fprintf(os.Stderr,
+			"\r  %d/%d sessions (%.0f%%) · %d messages",
+			p.SessionsDone, p.SessionsTotal,
+			p.Percent(), p.MessagesIndexed,
+		)
+	}
+}
+
+// printSyncSummaryStderr mirrors printSyncSummary but writes to
+// stderr, for the same reason as printSyncProgressStderr.
+func printSyncSummaryStderr(stats sync.SyncStats, t time.Time) {
+	summary := fmt.Sprintf(
+		"\nSync complete: %d sessions synced",
+		stats.Synced,
+	)
+	if stats.OrphanedCopied > 0 {
+		summary += fmt.Sprintf(
+			", %d archived sessions preserved",
+			stats.OrphanedCopied,
+		)
+	}
+	if stats.Failed > 0 {
+		summary += fmt.Sprintf(", %d failed", stats.Failed)
+	}
+	summary += fmt.Sprintf(
+		" in %s\n", time.Since(t).Round(time.Millisecond),
+	)
+	fmt.Fprint(os.Stderr, summary)
+	for _, w := range stats.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
 }
 
 // seedPricing ensures fallback rates are present in

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -26,11 +26,12 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 14: thinking_text column + promoted system
-// subtypes (continuation, resume, interrupted,
-// task_notification, stop_hook) surfaced as first-class
-// system messages instead of being silently skipped.
-const dataVersion = 14
+// Bumped to 15: Codex parser now subtracts cached_input_tokens
+// from input_tokens before storing, matching the Anthropic
+// convention that downstream cost and usage queries assume.
+// Prior rows double-counted cached tokens at the full input
+// rate; re-parsing rewrites token_usage and context_tokens.
+const dataVersion = 15
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -201,21 +201,29 @@ func (b *codexSessionBuilder) handleEventMsg(
 }
 
 // applyCodexTokenUsage normalizes Codex token usage fields
-// into the format expected by the usage query:
+// into the Anthropic-style shape expected by the usage and cost
+// queries. Codex reports input_tokens as the full input count
+// (cached portion included), while the downstream cost formula
+// treats input_tokens as the uncached remainder and bills
+// cache_read_input_tokens separately. Subtracting cached here
+// prevents double-counting the cached portion at the full input
+// rate.
 //
-//	input_tokens        → input_tokens
-//	output_tokens       → output_tokens
-//	cached_input_tokens → cache_read_input_tokens
+//	input_tokens - cached_input_tokens → input_tokens  (uncached)
+//	output_tokens                      → output_tokens
+//	cached_input_tokens                → cache_read_input_tokens
 func (b *codexSessionBuilder) applyCodexTokenUsage(
 	msg *ParsedMessage, raw string,
 ) {
 	usage := gjson.Parse(raw)
-	input := int(usage.Get("input_tokens").Int())
+	totalInput := int(usage.Get("input_tokens").Int())
 	cached := int(usage.Get("cached_input_tokens").Int())
 	output := int(usage.Get("output_tokens").Int())
 
+	uncached := max(totalInput-cached, 0)
+
 	normalized := map[string]int{
-		"input_tokens":            input,
+		"input_tokens":            uncached,
 		"output_tokens":           output,
 		"cache_read_input_tokens": cached,
 	}
@@ -226,8 +234,8 @@ func (b *codexSessionBuilder) applyCodexTokenUsage(
 	msg.TokenUsage = j
 	msg.OutputTokens = output
 	msg.HasOutputTokens = output > 0
-	msg.ContextTokens = input + cached
-	msg.HasContextTokens = input > 0 || cached > 0
+	msg.ContextTokens = uncached + cached
+	msg.HasContextTokens = totalInput > 0 || cached > 0
 }
 
 func (b *codexSessionBuilder) handleFunctionCall(

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -868,13 +868,16 @@ func TestParseCodexSession_TokenUsage(t *testing.T) {
 		// User message has no usage.
 		assert.Empty(t, msgs[0].TokenUsage)
 
-		// Assistant message has normalized usage.
+		// Assistant message has normalized usage. Codex reports
+		// input_tokens=10000 as the full input (cached included);
+		// after normalization the stored input_tokens is the
+		// uncached remainder (10000-6000=4000).
 		assert.NotEmpty(t, msgs[1].TokenUsage)
-		assert.Contains(t, string(msgs[1].TokenUsage), `"input_tokens":10000`)
+		assert.Contains(t, string(msgs[1].TokenUsage), `"input_tokens":4000`)
 		assert.Contains(t, string(msgs[1].TokenUsage), `"output_tokens":500`)
 		assert.Contains(t, string(msgs[1].TokenUsage), `"cache_read_input_tokens":6000`)
 		assert.Equal(t, 500, msgs[1].OutputTokens)
-		assert.Equal(t, 16000, msgs[1].ContextTokens) // 10000+6000
+		assert.Equal(t, 10000, msgs[1].ContextTokens) // 4000+6000
 		assert.True(t, msgs[1].HasOutputTokens)
 		assert.True(t, msgs[1].HasContextTokens)
 
@@ -882,7 +885,7 @@ func TestParseCodexSession_TokenUsage(t *testing.T) {
 		assert.True(t, sess.HasTotalOutputTokens)
 		assert.Equal(t, 500, sess.TotalOutputTokens)
 		assert.True(t, sess.HasPeakContextTokens)
-		assert.Equal(t, 16000, sess.PeakContextTokens)
+		assert.Equal(t, 10000, sess.PeakContextTokens)
 	})
 
 	t.Run("duplicate token_count events deduplicated", func(t *testing.T) {
@@ -916,17 +919,17 @@ func TestParseCodexSession_TokenUsage(t *testing.T) {
 		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
 		require.Len(t, msgs, 4)
 
-		// First assistant msg.
+		// First assistant msg (10000 total, 6000 cached).
 		assert.Equal(t, 500, msgs[1].OutputTokens)
-		assert.Equal(t, 16000, msgs[1].ContextTokens)
+		assert.Equal(t, 10000, msgs[1].ContextTokens)
 
-		// Second assistant msg.
+		// Second assistant msg (20000 total, 12000 cached).
 		assert.Equal(t, 800, msgs[3].OutputTokens)
-		assert.Equal(t, 32000, msgs[3].ContextTokens)
+		assert.Equal(t, 20000, msgs[3].ContextTokens)
 
 		// Session totals.
 		assert.Equal(t, 1300, sess.TotalOutputTokens)
-		assert.Equal(t, 32000, sess.PeakContextTokens)
+		assert.Equal(t, 20000, sess.PeakContextTokens)
 	})
 
 	t.Run("multiple API calls in one turn", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Codex reports `input_tokens` as the full input count with `cached_input_tokens` as a subset. The parser stored this raw total under the Anthropic field name `input_tokens`, which the cost formula in `internal/db/usage.go` treats as the uncached remainder. The cached portion was therefore billed at the full input rate in addition to the `cache_read` rate, inflating reported codex cost by roughly 5x on cache-heavy sessions.

The parser now stores `input_tokens - cached_input_tokens` as the uncached input, keeps the cached subset under `cache_read_input_tokens`, and sets `context_tokens` to the true context size. `dataVersion` is bumped to 15 so existing databases re-parse codex files on next sync and rewrite the buggy rows.