### PR TITLE
fix(frontend): swap sidebar sessions atomically after multi-page load

### DIFF
--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -266,26 +266,18 @@ class SessionsStore {
         });
         if (this.loadVersion !== version) return;
 
-        if (page.sessions.length === 0) {
-          this.sessions = loaded;
-          this.nextCursor = null;
-          this.total = loaded.length;
-          break;
-        }
-
+        if (page.sessions.length === 0) break;
         loaded = [...loaded, ...page.sessions];
-        this.sessions = loaded;
-        // Keep total aligned with loaded rows to avoid blank
-        // virtual space while we fetch remaining pages.
-        this.total = loaded.length;
-
         cursor = page.next_cursor ?? undefined;
-        this.nextCursor = cursor ?? null;
-        if (!cursor) {
-          this.total = loaded.length;
-          break;
-        }
+        if (!cursor) break;
       }
+
+      // Swap atomically once all pages have loaded. Updating
+      // this.sessions and this.total after each page causes the
+      // sidebar session count to visibly tick up as pages arrive.
+      this.sessions = loaded;
+      this.nextCursor = null;
+      this.total = loaded.length;
     } catch {
       // Restore previous state so a transient failure
       // doesn't wipe the visible session list.

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -458,6 +458,67 @@ describe("SessionsStore", () => {
       expect(sessions.nextCursor).toBeNull();
     });
 
+    it("swaps sessions atomically after all pages load", async () => {
+      // Pre-populate with a list representing a prior load,
+      // then trigger a multi-page reload. The visible count
+      // must not tick up as pages arrive — old data stays,
+      // then the new data replaces it in one step.
+      sessions.sessions = [
+        makeSession({ id: "old-a" }),
+        makeSession({ id: "old-b" }),
+        makeSession({ id: "old-c" }),
+      ];
+      sessions.total = 3;
+
+      let resolvePage2: ((v: {
+        sessions: Session[];
+        total: number;
+        next_cursor?: string;
+      }) => void) | null = null;
+      const page2Promise = new Promise<{
+        sessions: Session[];
+        total: number;
+        next_cursor?: string;
+      }>((resolve) => {
+        resolvePage2 = resolve;
+      });
+
+      vi.mocked(api.listSessions)
+        .mockResolvedValueOnce({
+          sessions: [makeSession({ id: "new-1" })],
+          total: 2,
+          next_cursor: "c1",
+        })
+        .mockReturnValueOnce(page2Promise);
+
+      const loadPromise = sessions.load();
+
+      // Flush the first page fetch without resolving the second.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Old sessions are still visible while pagination is in flight.
+      expect(sessions.sessions.map((s) => s.id)).toEqual([
+        "old-a",
+        "old-b",
+        "old-c",
+      ]);
+      expect(sessions.total).toBe(3);
+
+      resolvePage2!({
+        sessions: [makeSession({ id: "new-2" })],
+        total: 2,
+      });
+      await loadPromise;
+
+      expect(sessions.sessions.map((s) => s.id)).toEqual([
+        "new-1",
+        "new-2",
+      ]);
+      expect(sessions.total).toBe(2);
+      expect(sessions.nextCursor).toBeNull();
+    });
+
     it("should omit min/max when 0 in loadMore", async () => {
       sessions.nextCursor = "cur2";
 


### PR DESCRIPTION
## Summary

The sidebar session count appeared to "animate" during live refreshes because `load()` in `sessions.svelte.ts` reassigned `this.sessions` and `this.total` after every paginated page arrived. With a page size of 500, a 1,500-session workspace saw the count jump `500 → 1000 → 1500` on each refresh. Combined with the 10-second sync poll and SSE-driven refetches, this produced a distracting ticker in the sidebar header every 10–15 seconds.

Pages are now accumulated into a local array and `this.sessions`, `this.nextCursor`, `this.total` are swapped once at the end, so the count updates in a single step. Existing sessions stay visible during the fetch, so users don't see a blank list mid-refresh.

Added a regression test that defers a later page's resolution and asserts the previous sessions remain visible until the full load completes.