### PR TITLE
perf(server): coalesce SSE emits to cap dashboard refetch rate

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -98,7 +98,7 @@ func runServe(cfg config.Config) {
 	)
 	defer stop()
 
-	broadcaster := server.NewBroadcaster()
+	broadcaster := server.NewBroadcaster(cfg.EventsCoalesceInterval)
 
 	var engine *sync.Engine
 	if !cfg.NoSync {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -346,8 +346,10 @@ func (c *Config) loadFile() error {
 		RemoteAccess                   bool           `toml:"remote_access"`
 		DisableUpdateCheck             bool           `toml:"disable_update_check"`
 		PG                             PGConfig       `toml:"pg"`
+		EventsCoalesceInterval         time.Duration  `toml:"events_coalesce_interval"`
 	}
-	if _, err := toml.DecodeFile(path, &file); err != nil {
+	meta, err := toml.DecodeFile(path, &file)
+	if err != nil {
 		return fmt.Errorf("parsing config: %w", err)
 	}
 	if file.GithubToken != "" {
@@ -401,6 +403,12 @@ func (c *Config) loadFile() error {
 	}
 	if file.PG.ExcludeProjects != nil && c.PG.ExcludeProjects == nil {
 		c.PG.ExcludeProjects = file.PG.ExcludeProjects
+	}
+	// IsDefined distinguishes "unset" (leave default 10s) from an
+	// explicit "0s" (disable coalescing). Checking != 0 would silently
+	// ignore the latter.
+	if meta.IsDefined("events_coalesce_interval") {
+		c.EventsCoalesceInterval = file.EventsCoalesceInterval
 	}
 
 	// Parse config-file dir arrays for agents that have a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,13 @@ type Config struct {
 
 	ResultContentBlockedCategories []string `json:"result_content_blocked_categories,omitempty" toml:"result_content_blocked_categories"`
 
+	// EventsCoalesceInterval is the minimum wall-clock time between
+	// SSE data_changed broadcasts to connected clients. Emits that
+	// arrive within this window after a prior broadcast are coalesced
+	// into a single trailing broadcast, bounding dashboard refetch
+	// work during bursts of sync activity. Zero disables coalescing.
+	EventsCoalesceInterval time.Duration `json:"events_coalesce_interval,omitempty" toml:"events_coalesce_interval"`
+
 	// HostExplicit is true when the user passed --host on the CLI.
 	// Used to prevent auto-bind to 0.0.0.0 when the user
 	// explicitly requested a specific host.
@@ -158,6 +165,7 @@ func Default() (Config, error) {
 		agentDirSource:                 agentDirSource,
 		WatchExcludePatterns:           []string{".git", "node_modules", "__pycache__", ".venv", "venv", "vendor", ".next"},
 		ResultContentBlockedCategories: []string{"Read", "Glob"},
+		EventsCoalesceInterval:         10 * time.Second,
 	}, nil
 }
 
@@ -599,6 +607,10 @@ func RegisterServeFlags(fs *flag.FlagSet) {
 		"require-auth", false,
 		"Require a bearer token for all API requests",
 	)
+	fs.Duration(
+		"events-coalesce-interval", 10*time.Second,
+		"Minimum interval between SSE data_changed broadcasts (0 disables coalescing)",
+	)
 }
 
 // RegisterServePFlags registers serve-command flags on fs.
@@ -659,6 +671,10 @@ func RegisterServePFlags(fs *pflag.FlagSet) {
 		"require-auth", false,
 		"Require a bearer token for all API requests",
 	)
+	fs.Duration(
+		"events-coalesce-interval", 10*time.Second,
+		"Minimum interval between SSE data_changed broadcasts (0 disables coalescing)",
+	)
 }
 
 // applyFlags copies explicitly-set flags from fs into cfg.
@@ -714,6 +730,10 @@ func applyFlagValue(cfg *Config, name, value string) {
 		cfg.DisableUpdateCheck = value == "true"
 	case "require-auth":
 		cfg.RequireAuth = value == "true"
+	case "events-coalesce-interval":
+		if d, err := time.ParseDuration(value); err == nil {
+			cfg.EventsCoalesceInterval = d
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/pflag"
@@ -749,6 +750,52 @@ func TestLoadFile_ResultContentBlockedCategories(t *testing.T) {
 						i, v, tt.want[i],
 					)
 				}
+			}
+		})
+	}
+}
+
+func TestLoadFile_EventsCoalesceInterval(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]any
+		want   time.Duration
+	}{
+		{
+			"NoConfigFileUsesDefault",
+			map[string]any{},
+			10 * time.Second,
+		},
+		{
+			"ConfigFileOverrides",
+			map[string]any{
+				"events_coalesce_interval": "5s",
+			},
+			5 * time.Second,
+		},
+		{
+			"ConfigFileExplicitZeroDisables",
+			map[string]any{
+				"events_coalesce_interval": "0s",
+			},
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := setupTestEnv(t)
+			writeConfig(t, dir, tt.config)
+
+			cfg, err := LoadMinimal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.EventsCoalesceInterval != tt.want {
+				t.Errorf(
+					"EventsCoalesceInterval = %v, want %v",
+					cfg.EventsCoalesceInterval, tt.want,
+				)
 			}
 		})
 	}

--- a/internal/server/broadcaster.go
+++ b/internal/server/broadcaster.go
@@ -1,11 +1,21 @@
 package server
 
-import gosync "sync"
+import (
+	gosync "sync"
+	"time"
+)
 
 // broadcasterBufferCap is the per-subscriber buffer size. A slow
 // client can fall this many events behind before the broadcaster
 // starts dropping events on its channel.
 const broadcasterBufferCap = 8
+
+// broadcasterEmitInterval is the minimum wall-clock time between
+// broadcasts to subscribers. Emits that arrive within this window
+// after a prior broadcast are coalesced into a single trailing
+// broadcast that fires once the window elapses. Bounds dashboard
+// refetch work when many agents are actively writing files.
+const broadcasterEmitInterval = 10 * time.Second
 
 // Event is a refresh signal sent by the sync engine after a pass
 // that wrote data. Scope is advisory — subscribers may filter on
@@ -16,24 +26,86 @@ type Event struct {
 
 // Broadcaster fans out Event values from the sync engine to all
 // connected SSE clients. It implements sync.Emitter.
+//
+// Broadcasts are rate-limited with leading+trailing edge semantics:
+// the first emit in a quiet period fires immediately, further emits
+// within minInterval are coalesced into a single trailing broadcast
+// carrying the most recent scope. This keeps first-write latency
+// low while capping refetch work during sustained sync bursts.
 type Broadcaster struct {
-	mu   gosync.Mutex
-	subs map[chan Event]struct{}
+	mu          gosync.Mutex
+	subs        map[chan Event]struct{}
+	minInterval time.Duration
+	lastEmit    time.Time
+	pending     *Event
+	timer       *time.Timer
 }
 
-// NewBroadcaster creates an empty broadcaster.
+// NewBroadcaster creates an empty broadcaster with the production
+// rate-limit interval.
 func NewBroadcaster() *Broadcaster {
-	return &Broadcaster{subs: make(map[chan Event]struct{})}
+	return newBroadcasterWithInterval(broadcasterEmitInterval)
 }
 
-// Emit sends an event to every current subscriber. Delivery is
-// non-blocking: if a subscriber's buffer is full, the event is
-// dropped for that subscriber. The engine never blocks on slow
-// clients.
+// newBroadcasterWithInterval lets tests use a short window (or
+// disable rate limiting with 0) without exposing the tuning knob
+// to production callers.
+func newBroadcasterWithInterval(d time.Duration) *Broadcaster {
+	return &Broadcaster{
+		subs:        make(map[chan Event]struct{}),
+		minInterval: d,
+	}
+}
+
+// Emit delivers scope to every subscriber, subject to rate limiting.
+// The first emit after a quiet gap of at least minInterval fans out
+// immediately; emits within the window update the pending scope and
+// schedule one trailing broadcast when the window ends.
+//
+// Delivery is non-blocking: if a subscriber's buffer is full, the
+// event is dropped for that subscriber. The engine never blocks on
+// slow clients.
 func (b *Broadcaster) Emit(scope string) {
-	ev := Event{Scope: scope}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	now := time.Now()
+	if b.minInterval == 0 || b.lastEmit.IsZero() ||
+		now.Sub(b.lastEmit) >= b.minInterval {
+		b.lastEmit = now
+		b.broadcastLocked(Event{Scope: scope})
+		return
+	}
+
+	b.pending = &Event{Scope: scope}
+	if b.timer == nil {
+		wait := b.minInterval - now.Sub(b.lastEmit)
+		b.timer = time.AfterFunc(wait, b.flushTrailing)
+	}
+}
+
+// flushTrailing is invoked by the trailing-edge timer. It delivers
+// the most recent coalesced scope (if any) and clears the timer so
+// future emits can schedule a new one.
+func (b *Broadcaster) flushTrailing() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.timer = nil
+	if b.pending == nil {
+		return
+	}
+	ev := *b.pending
+	b.pending = nil
+	b.lastEmit = time.Now()
+	b.broadcastLocked(ev)
+}
+
+// broadcastLocked sends ev to every subscriber using a non-blocking
+// select so a full buffer drops the event for that subscriber only.
+// Must be called with b.mu held; holding the lock is safe because
+// sends never block.
+func (b *Broadcaster) broadcastLocked(ev Event) {
 	for ch := range b.subs {
 		select {
 		case ch <- ev:

--- a/internal/server/broadcaster.go
+++ b/internal/server/broadcaster.go
@@ -39,6 +39,17 @@ type Broadcaster struct {
 	lastEmit    time.Time
 	pending     *Event
 	timer       *time.Timer
+	// timerGen increments each time a leading-edge broadcast
+	// invalidates the trailing state. A flushTrailing callback
+	// captures the generation at schedule time and returns early
+	// if the current generation no longer matches. Without this
+	// token, a callback whose timer already fired but was still
+	// waiting for b.mu could acquire the lock after a leading
+	// emit and a subsequent rate-limited emit had installed a
+	// new pending+timer, then consume that newer pending as if
+	// it were its own and broadcast it immediately — violating
+	// the rate limit and orphaning the newly scheduled timer.
+	timerGen uint64
 }
 
 // NewBroadcaster creates an empty broadcaster with the production
@@ -72,18 +83,19 @@ func (b *Broadcaster) Emit(scope string) {
 	now := time.Now()
 	if b.minInterval == 0 || b.lastEmit.IsZero() ||
 		now.Sub(b.lastEmit) >= b.minInterval {
-		// Leading edge. Cancel any trailing state left over from the
-		// prior window: without this, a timer whose goroutine had
-		// already fired and was waiting on b.mu could acquire it
-		// after this call and deliver a stale coalesced event. Stop
-		// prevents unfired timers from running; clearing pending
-		// makes flushTrailing a no-op for timers whose goroutine
-		// already started.
+		// Leading edge. Invalidate any in-flight trailing state:
+		// bumping timerGen makes a flushTrailing callback whose
+		// timer already fired (but was still waiting for b.mu)
+		// return without touching state. Clearing pending and
+		// stopping the timer handle the common cases where the
+		// callback has not yet started; the generation token
+		// covers the narrower race where it has.
 		b.pending = nil
 		if b.timer != nil {
 			b.timer.Stop()
 			b.timer = nil
 		}
+		b.timerGen++
 		b.lastEmit = now
 		b.broadcastLocked(Event{Scope: scope})
 		return
@@ -91,18 +103,27 @@ func (b *Broadcaster) Emit(scope string) {
 
 	b.pending = &Event{Scope: scope}
 	if b.timer == nil {
+		gen := b.timerGen
 		wait := b.minInterval - now.Sub(b.lastEmit)
-		b.timer = time.AfterFunc(wait, b.flushTrailing)
+		b.timer = time.AfterFunc(wait, func() {
+			b.flushTrailing(gen)
+		})
 	}
 }
 
 // flushTrailing is invoked by the trailing-edge timer. It delivers
 // the most recent coalesced scope (if any) and clears the timer so
-// future emits can schedule a new one.
-func (b *Broadcaster) flushTrailing() {
+// future emits can schedule a new one. gen is the generation the
+// timer captured at schedule time; a mismatch means a leading-edge
+// broadcast has since invalidated this callback, so it returns
+// without touching any state.
+func (b *Broadcaster) flushTrailing(gen uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	if gen != b.timerGen {
+		return
+	}
 	b.timer = nil
 	if b.pending == nil {
 		return

--- a/internal/server/broadcaster.go
+++ b/internal/server/broadcaster.go
@@ -72,6 +72,18 @@ func (b *Broadcaster) Emit(scope string) {
 	now := time.Now()
 	if b.minInterval == 0 || b.lastEmit.IsZero() ||
 		now.Sub(b.lastEmit) >= b.minInterval {
+		// Leading edge. Cancel any trailing state left over from the
+		// prior window: without this, a timer whose goroutine had
+		// already fired and was waiting on b.mu could acquire it
+		// after this call and deliver a stale coalesced event. Stop
+		// prevents unfired timers from running; clearing pending
+		// makes flushTrailing a no-op for timers whose goroutine
+		// already started.
+		b.pending = nil
+		if b.timer != nil {
+			b.timer.Stop()
+			b.timer = nil
+		}
 		b.lastEmit = now
 		b.broadcastLocked(Event{Scope: scope})
 		return

--- a/internal/server/broadcaster.go
+++ b/internal/server/broadcaster.go
@@ -10,13 +10,6 @@ import (
 // starts dropping events on its channel.
 const broadcasterBufferCap = 8
 
-// broadcasterEmitInterval is the minimum wall-clock time between
-// broadcasts to subscribers. Emits that arrive within this window
-// after a prior broadcast are coalesced into a single trailing
-// broadcast that fires once the window elapses. Bounds dashboard
-// refetch work when many agents are actively writing files.
-const broadcasterEmitInterval = 10 * time.Second
-
 // Event is a refresh signal sent by the sync engine after a pass
 // that wrote data. Scope is advisory — subscribers may filter on
 // it but are free to treat it as "refetch now".
@@ -52,19 +45,14 @@ type Broadcaster struct {
 	timerGen uint64
 }
 
-// NewBroadcaster creates an empty broadcaster with the production
-// rate-limit interval.
-func NewBroadcaster() *Broadcaster {
-	return newBroadcasterWithInterval(broadcasterEmitInterval)
-}
-
-// newBroadcasterWithInterval lets tests use a short window (or
-// disable rate limiting with 0) without exposing the tuning knob
-// to production callers.
-func newBroadcasterWithInterval(d time.Duration) *Broadcaster {
+// NewBroadcaster creates an empty broadcaster. minInterval is the
+// minimum wall-clock time between broadcasts; zero (or any
+// non-positive value) disables coalescing so every Emit fans out
+// immediately.
+func NewBroadcaster(minInterval time.Duration) *Broadcaster {
 	return &Broadcaster{
 		subs:        make(map[chan Event]struct{}),
-		minInterval: d,
+		minInterval: minInterval,
 	}
 }
 

--- a/internal/server/broadcaster_test.go
+++ b/internal/server/broadcaster_test.go
@@ -211,6 +211,69 @@ func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
 	}
 }
 
+func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.T) {
+	// Narrow race: a trailing callback whose timer already fired is
+	// waiting for b.mu; a leading-edge Emit runs first and a follow-up
+	// rate-limited Emit installs a new pending+timer. Without a
+	// generation token, the stale callback clobbers b.timer and
+	// broadcasts the newer pending event immediately, violating the
+	// rate limit.
+	const interval = 50 * time.Millisecond
+	b := newBroadcasterWithInterval(interval)
+	sub, unsub := b.Subscribe()
+	defer unsub()
+
+	b.Emit("a")
+	<-sub
+
+	// Rate-limited emit schedules a timer; capture the generation
+	// the scheduled callback will check against when it runs.
+	b.Emit("b")
+	b.mu.Lock()
+	staleGen := b.timerGen
+	b.mu.Unlock()
+
+	// Force the next Emit into the leading branch, invalidating the
+	// prior timer's generation.
+	b.mu.Lock()
+	b.lastEmit = time.Now().Add(-2 * interval)
+	b.mu.Unlock()
+	b.Emit("c")
+	<-sub
+
+	// Rate-limited emit after the leading edge installs a fresh
+	// pending+timer under the new generation.
+	b.Emit("d")
+
+	// Simulate the stale callback from the "b" timer finally acquiring
+	// the lock after being blocked. With the generation check it must
+	// return without touching state; without it, the stale callback
+	// would clear b.timer and broadcast "d" prematurely.
+	b.flushTrailing(staleGen)
+
+	// No premature broadcast in the window right after the stale
+	// callback supposedly ran.
+	select {
+	case ev := <-sub:
+		t.Fatalf("stale callback consumed newer pending: %v", ev)
+	case <-time.After(interval / 2):
+	}
+
+	// The new timer scheduled for "d" must still be live and deliver
+	// "d" on its original schedule. A bug that lets the stale callback
+	// null out b.timer would orphan the new timer here — in which case
+	// the callback still fires, finds pending == nil, and no event
+	// arrives.
+	select {
+	case ev := <-sub:
+		if ev.Scope != "d" {
+			t.Errorf("got scope %q, want d", ev.Scope)
+		}
+	case <-time.After(interval * 3):
+		t.Fatal("new trailing timer did not fire with pending scope")
+	}
+}
+
 func TestBroadcaster_EmitAfterIntervalBroadcastsImmediately(t *testing.T) {
 	const interval = 50 * time.Millisecond
 	b := newBroadcasterWithInterval(interval)

--- a/internal/server/broadcaster_test.go
+++ b/internal/server/broadcaster_test.go
@@ -28,7 +28,10 @@ func TestBroadcaster_EmitFansOutToAllSubscribers(t *testing.T) {
 }
 
 func TestBroadcaster_EmitIsNonBlockingOnSlowSubscriber(t *testing.T) {
-	b := NewBroadcaster()
+	// Disable rate limiting so every Emit attempts a broadcast, which
+	// is what exercises the non-blocking select-default path against
+	// a slow subscriber.
+	b := newBroadcasterWithInterval(0)
 	slow, unsub := b.Subscribe()
 	defer unsub()
 
@@ -81,7 +84,9 @@ func TestBroadcaster_UnsubscribeStopsDelivery(t *testing.T) {
 }
 
 func TestBroadcaster_ConcurrentSubscribeAndEmit(t *testing.T) {
-	b := NewBroadcaster()
+	// Disable rate limiting so each subscriber's Emit reliably
+	// produces a broadcast during the race.
+	b := newBroadcasterWithInterval(0)
 	var wg sync.WaitGroup
 	for range 20 {
 		wg.Go(func() {
@@ -96,4 +101,87 @@ func TestBroadcaster_ConcurrentSubscribeAndEmit(t *testing.T) {
 		})
 	}
 	wg.Wait()
+}
+
+func TestBroadcaster_LeadingEdgeEmitsImmediately(t *testing.T) {
+	b := newBroadcasterWithInterval(time.Second)
+	sub, unsub := b.Subscribe()
+	defer unsub()
+
+	b.Emit("messages")
+
+	select {
+	case ev := <-sub:
+		if ev.Scope != "messages" {
+			t.Errorf("got scope %q, want %q", ev.Scope, "messages")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("first emit did not broadcast immediately")
+	}
+}
+
+func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
+	const interval = 100 * time.Millisecond
+	b := newBroadcasterWithInterval(interval)
+	sub, unsub := b.Subscribe()
+	defer unsub()
+
+	// Leading-edge broadcast drains the first emit.
+	b.Emit("sessions")
+	select {
+	case <-sub:
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("leading-edge emit did not broadcast immediately")
+	}
+
+	// Bursts within the window are coalesced; no broadcast yet.
+	b.Emit("messages")
+	b.Emit("sync")
+	b.Emit("sessions")
+
+	select {
+	case ev := <-sub:
+		t.Fatalf("got early broadcast during rate-limit window: %v", ev)
+	case <-time.After(interval / 2):
+	}
+
+	// After the window elapses a single trailing broadcast arrives
+	// carrying the most recent scope.
+	select {
+	case ev := <-sub:
+		if ev.Scope != "sessions" {
+			t.Errorf("trailing scope %q, want %q", ev.Scope, "sessions")
+		}
+	case <-time.After(interval * 3):
+		t.Fatal("trailing broadcast never arrived")
+	}
+
+	// The three coalesced emits produce exactly one trailing broadcast.
+	select {
+	case ev := <-sub:
+		t.Fatalf("got duplicate broadcast after trailing fire: %v", ev)
+	case <-time.After(interval):
+	}
+}
+
+func TestBroadcaster_EmitAfterIntervalBroadcastsImmediately(t *testing.T) {
+	const interval = 50 * time.Millisecond
+	b := newBroadcasterWithInterval(interval)
+	sub, unsub := b.Subscribe()
+	defer unsub()
+
+	b.Emit("first")
+	<-sub
+
+	time.Sleep(interval * 2)
+
+	b.Emit("second")
+	select {
+	case ev := <-sub:
+		if ev.Scope != "second" {
+			t.Errorf("got scope %q, want %q", ev.Scope, "second")
+		}
+	case <-time.After(interval):
+		t.Fatal("emit after quiet interval did not broadcast immediately")
+	}
 }

--- a/internal/server/broadcaster_test.go
+++ b/internal/server/broadcaster_test.go
@@ -164,6 +164,53 @@ func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
 	}
 }
 
+func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
+	const interval = 50 * time.Millisecond
+	b := newBroadcasterWithInterval(interval)
+	sub, unsub := b.Subscribe()
+	defer unsub()
+
+	// Leading broadcast fills the window.
+	b.Emit("a")
+	select {
+	case <-sub:
+	case <-time.After(interval):
+		t.Fatal("leading emit did not broadcast")
+	}
+
+	// Rate-limited emit schedules a trailing broadcast of "b".
+	b.Emit("b")
+
+	// Simulate the race: another Emit arrives just after the window
+	// boundary but before the in-flight trailing timer can acquire
+	// the lock. Backdating lastEmit forces the next Emit to take the
+	// leading branch while pending is still set and the timer is
+	// still armed.
+	b.mu.Lock()
+	b.lastEmit = time.Now().Add(-2 * interval)
+	b.mu.Unlock()
+
+	b.Emit("c")
+	select {
+	case ev := <-sub:
+		if ev.Scope != "c" {
+			t.Errorf("leading broadcast scope %q, want %q", ev.Scope, "c")
+		}
+	case <-time.After(interval):
+		t.Fatal("second leading emit did not broadcast")
+	}
+
+	// The pre-existing trailing timer for "b" may still fire. If the
+	// leading branch did not cancel pending/timer, flushTrailing
+	// would now deliver a stale "b" broadcast. Wait past the
+	// original deadline and assert no extra event arrives.
+	select {
+	case ev := <-sub:
+		t.Fatalf("stale trailing broadcast after leading edge: %v", ev)
+	case <-time.After(2 * interval):
+	}
+}
+
 func TestBroadcaster_EmitAfterIntervalBroadcastsImmediately(t *testing.T) {
 	const interval = 50 * time.Millisecond
 	b := newBroadcasterWithInterval(interval)

--- a/internal/server/broadcaster_test.go
+++ b/internal/server/broadcaster_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBroadcaster_EmitFansOutToAllSubscribers(t *testing.T) {
-	b := NewBroadcaster()
+	b := NewBroadcaster(10 * time.Second)
 	sub1, unsub1 := b.Subscribe()
 	defer unsub1()
 	sub2, unsub2 := b.Subscribe()
@@ -31,7 +31,7 @@ func TestBroadcaster_EmitIsNonBlockingOnSlowSubscriber(t *testing.T) {
 	// Disable rate limiting so every Emit attempts a broadcast, which
 	// is what exercises the non-blocking select-default path against
 	// a slow subscriber.
-	b := newBroadcasterWithInterval(0)
+	b := NewBroadcaster(0)
 	slow, unsub := b.Subscribe()
 	defer unsub()
 
@@ -66,7 +66,7 @@ func TestBroadcaster_EmitIsNonBlockingOnSlowSubscriber(t *testing.T) {
 }
 
 func TestBroadcaster_UnsubscribeStopsDelivery(t *testing.T) {
-	b := NewBroadcaster()
+	b := NewBroadcaster(10 * time.Second)
 	sub, unsub := b.Subscribe()
 	unsub()
 
@@ -86,7 +86,7 @@ func TestBroadcaster_UnsubscribeStopsDelivery(t *testing.T) {
 func TestBroadcaster_ConcurrentSubscribeAndEmit(t *testing.T) {
 	// Disable rate limiting so each subscriber's Emit reliably
 	// produces a broadcast during the race.
-	b := newBroadcasterWithInterval(0)
+	b := NewBroadcaster(0)
 	var wg sync.WaitGroup
 	for range 20 {
 		wg.Go(func() {
@@ -104,7 +104,7 @@ func TestBroadcaster_ConcurrentSubscribeAndEmit(t *testing.T) {
 }
 
 func TestBroadcaster_LeadingEdgeEmitsImmediately(t *testing.T) {
-	b := newBroadcasterWithInterval(time.Second)
+	b := NewBroadcaster(time.Second)
 	sub, unsub := b.Subscribe()
 	defer unsub()
 
@@ -122,7 +122,7 @@ func TestBroadcaster_LeadingEdgeEmitsImmediately(t *testing.T) {
 
 func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
 	const interval = 100 * time.Millisecond
-	b := newBroadcasterWithInterval(interval)
+	b := NewBroadcaster(interval)
 	sub, unsub := b.Subscribe()
 	defer unsub()
 
@@ -166,7 +166,7 @@ func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
 
 func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
 	const interval = 50 * time.Millisecond
-	b := newBroadcasterWithInterval(interval)
+	b := NewBroadcaster(interval)
 	sub, unsub := b.Subscribe()
 	defer unsub()
 
@@ -219,7 +219,7 @@ func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.
 	// broadcasts the newer pending event immediately, violating the
 	// rate limit.
 	const interval = 50 * time.Millisecond
-	b := newBroadcasterWithInterval(interval)
+	b := NewBroadcaster(interval)
 	sub, unsub := b.Subscribe()
 	defer unsub()
 
@@ -276,7 +276,7 @@ func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.
 
 func TestBroadcaster_EmitAfterIntervalBroadcastsImmediately(t *testing.T) {
 	const interval = 50 * time.Millisecond
-	b := newBroadcasterWithInterval(interval)
+	b := NewBroadcaster(interval)
 	sub, unsub := b.Subscribe()
 	defer unsub()
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -113,7 +113,8 @@ func setupWithServerOpts(
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	broadcaster := server.NewBroadcaster()
+	// Disable coalescing in tests so emits fan out deterministically.
+	broadcaster := server.NewBroadcaster(0)
 	engineCfg := sync.EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude: {claudeDir},


### PR DESCRIPTION
## Summary

After #351, the sync engine emits a `data_changed` SSE event after every `SyncPaths` pass that wrote data. When agents are actively writing session files, the file watcher flushes every ~500ms–1s and each flush produces an emit. Every dashboard subscriber (sidebar session list, Analytics `fetchAll` with 10 parallel aggregations, Usage `fetchAll`) refetches on each event, cut only by a 300ms trailing-edge debounce on the frontend. The result is a sustained ~1/s cadence of analytics/sessions queries — versus the pre-SSE 5-minute poll — consuming CPU on the agentsview process while agents work.

This change rate-limits at `server.Broadcaster` with leading + trailing edge coalescing. The first emit after a quiet gap of at least 10 seconds broadcasts immediately; emits within the window update a pending event and schedule a single trailing broadcast that fires when the window ends. Subscribers now see at most one broadcast per 10 seconds. First-write latency stays low, and dashboards still refresh ~30× faster than the pre-SSE poll.

Trailing-timer state is versioned with a `timerGen` counter. A leading-edge broadcast bumps the generation; each `time.AfterFunc` callback captures the generation at schedule time and returns early on mismatch, so a timer whose goroutine already fired but was still waiting for the lock cannot consume a newer pending event installed by a follow-up emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)