### PR TITLE
refactor(config): rename AGENT_VIEWER_DATA_DIR to AGENTSVIEW_DATA_DIR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ CLI (agentsview) → Config → DB (SQLite/FTS5)
 - **Sync**: File watcher + periodic sync (15min) for session directories
 - **PG Sync**: On-demand push sync from SQLite to PostgreSQL via `pg push`
 - **Frontend**: Svelte 5 SPA embedded in the Go binary at build time
-- **Config**: `AGENT_VIEWER_DATA_DIR` plus per-agent directory overrides (see
+- **Config**: `AGENTSVIEW_DATA_DIR` plus per-agent directory overrides (see
   `EnvVar` on each entry in `internal/parser/types.go`) and CLI flags
 
 ## Project Structure

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ dev-snapshot: build
 	else \
 		echo "Reusing existing snapshot at $(SNAPSHOT_ABS)/sessions.db"; \
 	fi
-	AGENT_VIEWER_DATA_DIR="$(SNAPSHOT_ABS)" ./agentsview serve --port 0
+	AGENTSVIEW_DATA_DIR="$(SNAPSHOT_ABS)" ./agentsview serve --port 0
 
 # Ensure air is installed for backend live reload
 check-air:

--- a/cmd/agentsview/classifier_test.go
+++ b/cmd/agentsview/classifier_test.go
@@ -20,7 +20,7 @@ import (
 func classifierTestEnv(t *testing.T, prefixes []string) string {
 	t.Helper()
 	dir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dir)
 
 	tomlBuf := &bytes.Buffer{}
 	tomlBuf.WriteString("[automated]\nprefixes = [")

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -432,7 +432,7 @@ func writeRootHelp(w io.Writer, root *cobra.Command) {
 	fmt.Fprintln(w, "  CURSOR_PROJECTS_DIR     Cursor projects directory")
 	fmt.Fprintln(w, "  IFLOW_DIR               iFlow projects directory")
 	fmt.Fprintln(w, "  AMP_DIR                 Amp threads directory")
-	fmt.Fprintln(w, "  AGENT_VIEWER_DATA_DIR   Data directory (database, config)")
+	fmt.Fprintln(w, "  AGENTSVIEW_DATA_DIR     Data directory (database, config)")
 	fmt.Fprintln(w, "  AGENTSVIEW_PG_URL       PostgreSQL connection URL for sync")
 	fmt.Fprintln(w, "  AGENTSVIEW_PG_MACHINE   Machine name for PG sync")
 	fmt.Fprintln(w, "  AGENTSVIEW_PG_SCHEMA    PG schema name (default \"agentsview\")")

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -52,7 +52,7 @@ func TestMustLoadConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("AGENT_VIEWER_DATA_DIR", t.TempDir())
+			t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
 			cmd := newServeCommand()
 			if err := cmd.Flags().Parse(tt.args); err != nil {
 				t.Fatalf("Parse: %v", err)

--- a/cmd/agentsview/pg_test.go
+++ b/cmd/agentsview/pg_test.go
@@ -21,7 +21,7 @@ func loadPGServeConfigForTest(t *testing.T, args ...string) (config.Config, stri
 
 func TestLoadPGServeConfigDoesNotInheritServeProxySettings(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	err := os.WriteFile(filepath.Join(dataDir, "config.toml"), []byte(`
 public_url = "https://viewer.example.test"
@@ -68,7 +68,7 @@ url = "postgres://user:pass@db.example.test:5432/agentsview?sslmode=require"
 
 func TestLoadPGServeConfigIgnoresInvalidPersistedServeSettings(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	err := os.WriteFile(filepath.Join(dataDir, "config.toml"), []byte(`
 public_url = "not a url"
@@ -99,7 +99,7 @@ url = "postgres://user:pass@db.example.test:5432/agentsview?sslmode=require"
 }
 
 func TestPGServeConfigAcceptsManagedCaddyFlags(t *testing.T) {
-	t.Setenv("AGENT_VIEWER_DATA_DIR", t.TempDir())
+	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
 
 	cfg, basePath, err := loadPGServeConfigForTest(t,
 		"--host", "127.0.0.1",
@@ -189,7 +189,7 @@ func TestRunPGServeRejectsInvalidManagedCaddyConfigBeforePGSetup(t *testing.T) {
 	cmd.Env = append(
 		os.Environ(),
 		"AGENTSVIEW_RUN_PG_SERVE_HELPER=1",
-		"AGENT_VIEWER_DATA_DIR="+dataDir,
+		"AGENTSVIEW_DATA_DIR="+dataDir,
 	)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
@@ -210,7 +210,7 @@ func TestRunPGServeNonLoopbackWithoutProxyFallsThroughToPGConfig(t *testing.T) {
 	cmd.Env = append(
 		os.Environ(),
 		"AGENTSVIEW_RUN_PG_SERVE_HELPER=1",
-		"AGENT_VIEWER_DATA_DIR="+dataDir,
+		"AGENTSVIEW_DATA_DIR="+dataDir,
 	)
 	out, err := cmd.CombinedOutput()
 	if err == nil {

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -82,7 +82,7 @@ func seedSessionWithOpts(
 
 func TestSessionGet_JSON(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-1", "proj")
 
 	out, err := executeCommand(newRootCommand(),
@@ -98,7 +98,7 @@ func TestSessionGet_JSON(t *testing.T) {
 
 func TestSessionGet_NotFound(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	_, err := executeCommand(newRootCommand(),
 		"session", "get", "missing", "--format", "json")
@@ -109,7 +109,7 @@ func TestSessionGet_NotFound(t *testing.T) {
 
 func TestSessionGet_Human(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-2", "proj")
 
 	out, err := executeCommand(newRootCommand(),
@@ -127,7 +127,7 @@ func TestSessionGet_Human(t *testing.T) {
 // retries the lookup with each registered IDPrefix.
 func TestSessionGet_BareIDFindsPrefixed(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	bareID := "019da6a6-8c67-7c23-b102-ef48502852d0"
 	seedSessionWithOpts(t, dataDir, "codex:"+bareID, "proj",
 		func(s *db.Session) { s.Agent = "codex" })
@@ -144,7 +144,7 @@ func TestSessionGet_BareIDFindsPrefixed(t *testing.T) {
 
 func TestSessionList_JSONShape(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-a", "proj")
 	seedSession(t, dataDir, "s-b", "proj")
 
@@ -165,7 +165,7 @@ func TestSessionList_JSONShape(t *testing.T) {
 
 func TestSessionList_FilterByProject(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-a", "p1")
 	seedSession(t, dataDir, "s-b", "p2")
 
@@ -189,7 +189,7 @@ func TestSessionList_FilterByProject(t *testing.T) {
 // that converts the int flag into a *int on ListFilter.
 func TestSessionList_MinToolFailuresZero(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSessionWithOpts(t, dataDir, "s-a", "proj",
 		func(s *db.Session) { s.ToolFailureSignalCount = 0 })
 
@@ -239,7 +239,7 @@ func seedMessages(t *testing.T, dataDir, sessionID string, n int) {
 
 func TestSessionMessages_JSONShape(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-msgs", "proj")
 	seedMessages(t, dataDir, "s-msgs", 3)
 
@@ -260,7 +260,7 @@ func TestSessionMessages_JSONShape(t *testing.T) {
 
 func TestSessionMessages_FromLimit(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-msgs", "proj")
 	seedMessages(t, dataDir, "s-msgs", 5)
 
@@ -282,7 +282,7 @@ func TestSessionMessages_FromLimit(t *testing.T) {
 
 func TestSessionMessages_DirectionDesc(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-msgs", "proj")
 	seedMessages(t, dataDir, "s-msgs", 4)
 
@@ -342,7 +342,7 @@ func seedMessagesWithToolCalls(
 
 func TestSessionToolCalls_JSONShape(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-tc", "proj")
 	seedMessagesWithToolCalls(t, dataDir, "s-tc", 2)
 
@@ -364,7 +364,7 @@ func TestSessionToolCalls_JSONShape(t *testing.T) {
 
 func TestSessionToolCalls_HumanTable(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-tc2", "proj")
 	seedMessagesWithToolCalls(t, dataDir, "s-tc2", 2)
 
@@ -383,7 +383,7 @@ func TestSessionToolCalls_HumanTable(t *testing.T) {
 
 func TestSessionExport_StreamsFromDisk(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	src := filepath.Join(t.TempDir(), "session.jsonl")
 	body := "{\"type\":\"user\",\"content\":\"hello\"}\n" +
@@ -401,7 +401,7 @@ func TestSessionExport_StreamsFromDisk(t *testing.T) {
 
 func TestSessionExport_FailsWhenSourceMissing(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	nonExistent := filepath.Join(t.TempDir(), "gone.jsonl")
 	seedSessionWithOpts(t, dataDir, "s-1", "proj",
@@ -415,7 +415,7 @@ func TestSessionExport_FailsWhenSourceMissing(t *testing.T) {
 
 func TestSessionExport_FailsWhenNotInLocalArchive(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	_, err := executeCommand(newRootCommand(),
 		"session", "export", "unknown-id")
@@ -430,7 +430,7 @@ func TestSessionExport_FailsWhenNotInLocalArchive(t *testing.T) {
 // for scripts that expected JSON output.
 func TestSessionExport_RejectsFormatFlag(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	_, err := executeCommand(newRootCommand(),
 		"session", "export", "some-id", "--format", "json")
@@ -447,7 +447,7 @@ func TestSessionExport_RejectsFormatFlag(t *testing.T) {
 // sync.Engine as in the default newService path).
 func TestSessionSync_UnknownID_ReportsNoFilePath(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	_, err := executeCommand(newRootCommand(),
 		"session", "sync", "missing-id")
@@ -466,7 +466,7 @@ func TestSessionSync_UnknownID_ReportsNoFilePath(t *testing.T) {
 // real HTTP handler.
 func TestSessionSync_AgainstReadOnlyDaemon_Refuses(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	_, port := freeTCPListener(t)
 	_, err := server.WriteStateFile(
@@ -489,7 +489,7 @@ func TestSessionSync_AgainstReadOnlyDaemon_Refuses(t *testing.T) {
 // SQLite write ownership.
 func TestSessionSync_WhenDaemonActiveButUnreachable_Refuses(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	// Bind then immediately close so the port is guaranteed
 	// free and no TCP listener is accepting.
@@ -524,7 +524,7 @@ func TestSessionSync_WhenDaemonActiveButUnreachable_Refuses(t *testing.T) {
 // returns synchronously would complete in single-digit ms.
 func TestSessionWatch_ExitsOnCancel(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	seedSession(t, dataDir, "s-watch", "proj")
 
 	root := newRootCommand()
@@ -585,7 +585,7 @@ func TestSessionWatch_ExitsOnCancel(t *testing.T) {
 // footgun for automation scripts.
 func TestSessionWatch_UnknownID_FailsFast(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
 	_, err := executeCommand(newRootCommand(),
 		"session", "watch", "unknown-id")

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -261,7 +261,7 @@ var updateGolden = flag.Bool(
 //	go test ./cmd/agentsview -run TestStatsGolden -update
 func TestStatsGolden(t *testing.T) {
 	dataDir := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	// TZ is stripped by --timezone=UTC but the environment can
 	// still leak into date parsing on some platforms; pin it too.
 	t.Setenv("TZ", "UTC")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -537,6 +537,16 @@ func (c *Config) writeConfigMap(m map[string]any) error {
 	return nil
 }
 
+// dataDirFromEnv returns the data directory from the environment, preferring
+// AGENTSVIEW_DATA_DIR and falling back to the legacy AGENT_VIEWER_DATA_DIR.
+// Returns "" when neither is set.
+func dataDirFromEnv() string {
+	if v := os.Getenv("AGENTSVIEW_DATA_DIR"); v != "" {
+		return v
+	}
+	return os.Getenv("AGENT_VIEWER_DATA_DIR")
+}
+
 func (c *Config) loadEnv() {
 	for _, def := range parser.Registry {
 		if v := os.Getenv(def.EnvVar); v != "" {
@@ -544,7 +554,7 @@ func (c *Config) loadEnv() {
 			c.agentDirSource[def.Type] = dirEnv
 		}
 	}
-	if v := os.Getenv("AGENT_VIEWER_DATA_DIR"); v != "" {
+	if v := dataDirFromEnv(); v != "" {
 		c.DataDir = v
 	}
 	if v := os.Getenv("AGENTSVIEW_PG_URL"); v != "" {
@@ -1052,7 +1062,7 @@ func ResolveDataDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if v := os.Getenv("AGENT_VIEWER_DATA_DIR"); v != "" {
+	if v := dataDirFromEnv(); v != "" {
 		cfg.DataDir = v
 	}
 	return cfg.DataDir, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,7 +48,7 @@ func setupTestEnv(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 
-	t.Setenv("AGENT_VIEWER_DATA_DIR", dir)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dir)
 	return dir
 }
 
@@ -593,7 +593,7 @@ func TestResolveDataDir_DefaultAndEnvOverride(t *testing.T) {
 
 	// With env override, should return the override
 	custom := t.TempDir()
-	t.Setenv("AGENT_VIEWER_DATA_DIR", custom)
+	t.Setenv("AGENTSVIEW_DATA_DIR", custom)
 	dir, err = ResolveDataDir()
 	if err != nil {
 		t.Fatal(err)
@@ -601,6 +601,37 @@ func TestResolveDataDir_DefaultAndEnvOverride(t *testing.T) {
 	if dir != custom {
 		t.Errorf("ResolveDataDir = %q, want %q", dir, custom)
 	}
+}
+
+// TestDataDir_LegacyEnvFallback verifies that the legacy AGENT_VIEWER_DATA_DIR
+// env var still takes effect when the canonical AGENTSVIEW_DATA_DIR is unset,
+// and that the canonical name wins when both are set.
+func TestDataDir_LegacyEnvFallback(t *testing.T) {
+	t.Run("legacy used when canonical unset", func(t *testing.T) {
+		legacy := t.TempDir()
+		t.Setenv("AGENT_VIEWER_DATA_DIR", legacy)
+		dir, err := ResolveDataDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dir != legacy {
+			t.Errorf("ResolveDataDir = %q, want %q", dir, legacy)
+		}
+	})
+
+	t.Run("canonical wins over legacy", func(t *testing.T) {
+		legacy := t.TempDir()
+		canonical := t.TempDir()
+		t.Setenv("AGENT_VIEWER_DATA_DIR", legacy)
+		t.Setenv("AGENTSVIEW_DATA_DIR", canonical)
+		dir, err := ResolveDataDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dir != canonical {
+			t.Errorf("ResolveDataDir = %q, want %q (canonical should win)", dir, canonical)
+		}
+	})
 }
 
 func TestEnvOverridesConfigFile(t *testing.T) {

--- a/scripts/e2e-server.sh
+++ b/scripts/e2e-server.sh
@@ -43,7 +43,7 @@ fi
 # Every agent dir must point to EMPTY_DIR to prevent
 # the server from discovering real sessions on the host.
 echo "Starting e2e server on :8090..."
-AGENT_VIEWER_DATA_DIR="$TMPDIR" \
+AGENTSVIEW_DATA_DIR="$TMPDIR" \
 CLAUDE_PROJECTS_DIR="$EMPTY_DIR" \
 CODEX_SESSIONS_DIR="$EMPTY_DIR" \
 COPILOT_DIR="$EMPTY_DIR" \


### PR DESCRIPTION
## Summary

- Align the data directory env var with the other `AGENTSVIEW_*` vars (`PG_URL`, `PG_SCHEMA`, `PG_MACHINE`, `DISABLE_UPDATE_CHECK`).
- Legacy `AGENT_VIEWER_DATA_DIR` is still honored as a silent fallback when the canonical name is unset; the canonical name wins when both are set.
- Updated CLI help, `Makefile`, `scripts/e2e-server.sh`, `CLAUDE.md`, and all tests to use the canonical name.