### PR TITLE
Add Trends term frequency charts

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -17,6 +17,7 @@
   import ConfirmDeleteModal from "./lib/components/modals/ConfirmDeleteModal.svelte";
   import AnalyticsPage from "./lib/components/analytics/AnalyticsPage.svelte";
   import UsagePage from "./lib/components/usage/UsagePage.svelte";
+  import TrendsPage from "./lib/components/trends/TrendsPage.svelte";
   import InsightsPage from "./lib/components/insights/InsightsPage.svelte";
   import PinnedPage from "./lib/components/pinned/PinnedPage.svelte";
   import TrashPage from "./lib/components/trash/TrashPage.svelte";
@@ -392,6 +393,10 @@
 {#if router.route === "usage"}
   <div class="page-scroll">
     <UsagePage />
+  </div>
+{:else if router.route === "trends"}
+  <div class="page-scroll">
+    <TrendsPage />
   </div>
 {:else if router.route === "insights"}
   <div class="page-scroll">

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -7,6 +7,7 @@ import {
   getAnalyticsActivity,
   getAnalyticsHeatmap,
   getAnalyticsTopSessions,
+  getTrendsTerms,
   watchEvents,
   WATCH_EVENTS_MAX_CONSECUTIVE_ERRORS,
   watchSession,
@@ -663,6 +664,42 @@ describe("query serialization", () => {
       expect(lastUrl()).toBe(
         "/api/v1/analytics/top-sessions?from=2024-01-01",
       );
+    });
+  });
+
+  describe("trends query serialization", () => {
+    it("serializes trends repeated term params", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          granularity: "week",
+          from: "2024-06-01",
+          to: "2024-06-30",
+          message_count: 0,
+          buckets: [],
+          series: [],
+        }),
+      });
+
+      await getTrendsTerms({
+        from: "2024-06-01",
+        to: "2024-06-30",
+        timezone: "UTC",
+        granularity: "week",
+        terms: ["load bearing | load-bearing", "seam"],
+      });
+
+      const [path, query = ""] = lastUrl().split("?");
+      expect(path).toBe("/api/v1/trends/terms");
+      const params = new URLSearchParams(query);
+      expect(params.get("from")).toBe("2024-06-01");
+      expect(params.get("to")).toBe("2024-06-30");
+      expect(params.get("timezone")).toBe("UTC");
+      expect(params.get("granularity")).toBe("week");
+      expect(params.getAll("term")).toEqual([
+        "load bearing | load-bearing",
+        "seam",
+      ]);
     });
   });
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -28,6 +28,8 @@ import type {
   Granularity,
   HeatmapMetric,
   TopSessionsMetric,
+  TrendsGranularity,
+  TrendsTermsResponse,
   Insight,
   InsightsResponse,
   GenerateInsightRequest,
@@ -880,6 +882,38 @@ export function getAnalyticsSignals(
   return fetchJSON(
     `/analytics/signals${buildQuery({ ...params })}`,
   );
+}
+
+export interface TrendsTermsParams extends AnalyticsParams {
+  granularity?: TrendsGranularity;
+  terms: string[];
+}
+
+function buildTrendsTermsQuery(params: TrendsTermsParams): string {
+  const q = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (
+      key === "terms" ||
+      value === undefined ||
+      value === null ||
+      value === ""
+    ) {
+      continue;
+    }
+    // Match buildQuery semantics: 0 and false are valid query values.
+    q.set(key, String(value));
+  }
+  for (const term of params.terms) {
+    if (term.trim()) q.append("term", term);
+  }
+  const qs = q.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export function getTrendsTerms(
+  params: TrendsTermsParams,
+): Promise<TrendsTermsResponse> {
+  return fetchJSON(`/trends/terms${buildTrendsTermsQuery(params)}`);
 }
 
 /* Insights */

--- a/frontend/src/lib/api/types/analytics.ts
+++ b/frontend/src/lib/api/types/analytics.ts
@@ -1,6 +1,7 @@
 /** Analytics types — match Go structs in internal/db/analytics.go */
 
 export type Granularity = "day" | "week" | "month";
+export type TrendsGranularity = "day" | "week" | "month";
 export type HeatmapMetric =
   | "messages"
   | "sessions"
@@ -226,4 +227,30 @@ export interface SignalsAnalyticsResponse {
   trend: SignalsTrendBucket[];
   by_agent: SignalsAgentRow[];
   by_project: SignalsProjectRow[];
+}
+
+export interface TrendsBucket {
+  date: string;
+  message_count: number;
+}
+
+export interface TrendsPoint {
+  date: string;
+  count: number;
+}
+
+export interface TrendsSeries {
+  term: string;
+  variants: string[];
+  total: number;
+  points: TrendsPoint[];
+}
+
+export interface TrendsTermsResponse {
+  granularity: TrendsGranularity;
+  from: string;
+  to: string;
+  message_count: number;
+  buckets: TrendsBucket[];
+  series: TrendsSeries[];
 }

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -252,7 +252,7 @@
     <div class="more-wrap">
       <button
         class="nav-btn"
-        class:active={router.route === "pinned" || router.route === "insights" || router.route === "trash" || moreOpen}
+        class:active={router.route === "trends" || router.route === "pinned" || router.route === "insights" || router.route === "trash" || moreOpen}
         bind:this={moreBtnRef}
         onclick={() => { moreOpen = !moreOpen; }}
         aria-label="More navigation"
@@ -265,6 +265,11 @@
       </button>
       {#if moreOpen}
         <div class="more-dropdown" role="menu" bind:this={moreDropRef}>
+          <button class="more-item" role="menuitem"
+            class:active={router.route === "trends"}
+            onclick={() => { router.navigate("trends"); moreOpen = false; }}>
+            Trends
+          </button>
           <button class="more-item" role="menuitem"
             class:active={router.route === "pinned"}
             onclick={() => { router.navigate("pinned"); moreOpen = false; }}>

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
@@ -313,6 +313,17 @@
       </button>
       <button
         class="mobile-nav-btn"
+        class:active={router.route === "trends"}
+        onclick={() => mobileNav("trends")}
+      >
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M2 13.5a.5.5 0 01-.5-.5V2a.5.5 0 011 0v10.5H14a.5.5 0 010 1H2z"/>
+          <path d="M3.35 10.35a.5.5 0 010-.7l2.5-2.5a.5.5 0 01.7 0L8.5 9.09l3.15-4.44a.5.5 0 01.82.58l-3.5 4.94a.5.5 0 01-.76.06L6.2 8.21l-2.15 2.14a.5.5 0 01-.7 0z"/>
+        </svg>
+        Trends
+      </button>
+      <button
+        class="mobile-nav-btn"
         class:active={router.route === "pinned"}
         onclick={() => mobileNav("pinned")}
       >
@@ -488,24 +499,25 @@
     }
 
     .mobile-nav {
-      display: flex;
-      gap: 2px;
-      padding: 8px 8px 0;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 6px;
+      padding: 8px;
       border-bottom: 1px solid var(--border-muted);
       flex-shrink: 0;
     }
 
     .mobile-nav-btn {
-      flex: 1;
       display: flex;
       align-items: center;
       justify-content: center;
       gap: 4px;
-      padding: 6px 0;
+      min-width: 0;
+      padding: 6px 4px;
       font-size: 11px;
       font-weight: 500;
       color: var(--text-muted);
-      border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+      border-radius: var(--radius-sm);
       white-space: nowrap;
       transition: background 0.12s, color 0.12s;
     }

--- a/frontend/src/lib/components/trends/TermTable.svelte
+++ b/frontend/src/lib/components/trends/TermTable.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import type { TrendsSeries } from "../../api/types.js";
+
+  interface Props {
+    series: TrendsSeries[];
+    colorFor: (term: string, index: number) => string;
+    activeTerm: string | null;
+    normalized: boolean;
+    messageCount: number;
+    onHover: (term: string | null) => void;
+  }
+
+  let {
+    series,
+    colorFor,
+    activeTerm,
+    normalized,
+    messageCount,
+    onHover,
+  }: Props = $props();
+
+  function displayTotal(item: TrendsSeries): number {
+    if (!normalized) return item.total;
+    if (messageCount <= 0) return 0;
+    return (item.total / messageCount) * 1000;
+  }
+
+  function formatMetric(value: number): string {
+    if (!normalized) return Math.round(value).toLocaleString();
+    return value.toLocaleString(undefined, {
+      maximumFractionDigits: value < 10 ? 2 : 1,
+    });
+  }
+</script>
+
+<div class="term-table-wrap">
+  <table class="term-table">
+    <thead>
+      <tr>
+        <th>Term</th>
+        <th class="count-col">{normalized ? "Per 1k messages" : "Count"}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each series as item, index}
+        <tr
+          class:dimmed={activeTerm !== null && activeTerm !== item.term}
+          onmouseenter={() => onHover(item.term)}
+          onmouseleave={() => onHover(null)}
+        >
+          <td>
+            <div class="term-name">
+              <span
+                class="swatch"
+                style:background={colorFor(item.term, index)}
+              ></span>
+              <span>{item.term}</span>
+            </div>
+            {#if item.variants.length > 1}
+              <div class="variants">
+                {item.variants.join(" | ")}
+              </div>
+            {/if}
+          </td>
+          <td class="count-col">{formatMetric(displayTotal(item))}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .term-table-wrap {
+    overflow: auto;
+    border: 1px solid var(--border-default);
+    border-radius: 8px;
+    background: var(--bg-surface);
+  }
+
+  .term-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+
+  th {
+    padding: 9px 10px;
+    color: var(--text-muted);
+    font-weight: 600;
+    text-align: left;
+    border-bottom: 1px solid var(--border-muted);
+  }
+
+  td {
+    padding: 10px;
+    border-bottom: 1px solid var(--border-muted);
+    vertical-align: top;
+  }
+
+  tr:last-child td {
+    border-bottom: 0;
+  }
+
+  tbody tr {
+    transition: opacity 120ms ease, background 120ms ease;
+  }
+
+  tbody tr:hover {
+    background: var(--bg-hover);
+  }
+
+  tr.dimmed {
+    opacity: 0.45;
+  }
+
+  .term-name {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  .swatch {
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    flex: 0 0 auto;
+  }
+
+  .variants {
+    margin-top: 3px;
+    padding-left: 17px;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.35;
+    word-break: break-word;
+  }
+
+  .count-col {
+    width: 96px;
+    text-align: right;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/frontend/src/lib/components/trends/TrendsLineChart.svelte
+++ b/frontend/src/lib/components/trends/TrendsLineChart.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+  import type {
+    TrendsBucket,
+    TrendsSeries,
+  } from "../../api/types.js";
+
+  interface Props {
+    buckets: TrendsBucket[];
+    series: TrendsSeries[];
+    colorFor: (term: string, index: number) => string;
+    activeTerm: string | null;
+    normalized: boolean;
+    onHover: (term: string | null) => void;
+  }
+
+  let {
+    buckets,
+    series,
+    colorFor,
+    activeTerm,
+    normalized,
+    onHover,
+  }: Props = $props();
+
+  const HEIGHT = 300;
+  const LEFT = 52;
+  const RIGHT = 12;
+  const TOP = 28;
+  const BOTTOM = 34;
+  const TICK_TARGET = 5;
+
+  let containerEl: HTMLDivElement | undefined = $state();
+  let containerWidth = $state(720);
+
+  $effect(() => {
+    if (!containerEl) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        containerWidth = Math.floor(entry.contentRect.width);
+      }
+    });
+    ro.observe(containerEl);
+    return () => ro.disconnect();
+  });
+
+  const width = $derived(Math.max(containerWidth, 320));
+  const plotW = $derived(Math.max(width - LEFT - RIGHT, 1));
+  const plotH = HEIGHT - TOP - BOTTOM;
+  const maxCount = $derived.by(() => {
+    let max = 0;
+    for (const item of series) {
+      for (let i = 0; i < item.points.length; i++) {
+        const value = pointValue(item.points[i]!.count, i);
+        if (value > max) max = value;
+      }
+    }
+    return max;
+  });
+  const hasData = $derived(series.some((item) => item.total > 0));
+  const metricLabel = $derived(
+    normalized ? "Occurrences / 1k messages" : "Occurrences",
+  );
+
+  function niceScale(maxY: number): { step: number; max: number } {
+    if (!Number.isFinite(maxY) || maxY <= 0) {
+      return { step: 1, max: 5 };
+    }
+    const rough = maxY / TICK_TARGET;
+    const exp = Math.floor(Math.log10(rough));
+    const base = Math.pow(10, exp);
+    const normalized = rough / base;
+    let mult: number;
+    if (normalized <= 1) mult = 1;
+    else if (normalized <= 2) mult = 2;
+    else if (normalized <= 5) mult = 5;
+    else mult = 10;
+    const step = Math.max(1, mult * base);
+    return { step, max: Math.max(step, Math.ceil(maxY / step) * step) };
+  }
+
+  const scale = $derived(niceScale(maxCount));
+  const yTicks = $derived.by(() => {
+    const out: number[] = [];
+    for (let v = 0; v <= scale.max; v += scale.step) {
+      out.push(v);
+    }
+    if (out[out.length - 1] !== scale.max) out.push(scale.max);
+    return out;
+  });
+
+  function xFor(index: number): number {
+    if (buckets.length <= 1) return LEFT + plotW / 2;
+    return LEFT + (index / (buckets.length - 1)) * plotW;
+  }
+
+  function yFor(count: number): number {
+    return TOP + plotH - (count / scale.max) * plotH;
+  }
+
+  function pointValue(count: number, index: number): number {
+    if (!normalized) return count;
+    const denom = buckets[index]?.message_count ?? 0;
+    if (denom <= 0) return 0;
+    return (count / denom) * 1000;
+  }
+
+  function formatMetric(value: number): string {
+    if (!normalized) return Math.round(value).toLocaleString();
+    return value.toLocaleString(undefined, {
+      maximumFractionDigits: value < 10 ? 2 : 1,
+    });
+  }
+
+  function pathFor(item: TrendsSeries): string {
+    return item.points
+      .map((point, index) => {
+        const cmd = index === 0 ? "M" : "L";
+        return `${cmd}${xFor(index)},${yFor(pointValue(point.count, index))}`;
+      })
+      .join("");
+  }
+
+  function labelFor(date: string): string {
+    const [, month, day] = date.split("-");
+    return `${month}/${day}`;
+  }
+
+  function showXLabel(index: number): boolean {
+    const maxLabels = width < 520 ? 4 : 7;
+    const step = Math.max(1, Math.ceil(buckets.length / maxLabels));
+    return index === 0 || index === buckets.length - 1 || index % step === 0;
+  }
+</script>
+
+<div class="chart-wrap" bind:this={containerEl}>
+  {#if buckets.length === 0 || series.length === 0}
+    <div class="empty">No trend data</div>
+  {:else}
+    <svg
+      class="chart"
+      viewBox={`0 0 ${width} ${HEIGHT}`}
+      role="img"
+      aria-label={normalized
+        ? "Term occurrence trends per 1,000 messages"
+        : "Term occurrence trends"}
+    >
+      <text class="y-title" x={LEFT} y="12">
+        {metricLabel}
+      </text>
+
+      {#each yTicks as tick}
+        {@const y = yFor(tick)}
+        <line
+          class="grid"
+          x1={LEFT}
+          x2={width - RIGHT}
+          y1={y}
+          y2={y}
+        />
+        <text class="y-label" x={LEFT - 8} y={y + 4}>
+          {formatMetric(tick)}
+        </text>
+      {/each}
+
+      {#each buckets as bucket, index}
+        {#if showXLabel(index)}
+          <text class="x-label" x={xFor(index)} y={HEIGHT - 8}>
+            {labelFor(bucket.date)}
+          </text>
+        {/if}
+      {/each}
+
+      {#each series as item, index}
+        {@const d = pathFor(item)}
+        {@const muted = activeTerm !== null && activeTerm !== item.term}
+        <path
+          d={d}
+          role="presentation"
+          fill="none"
+          stroke="transparent"
+          stroke-width="16"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          onmouseenter={() => onHover(item.term)}
+          onmouseleave={() => onHover(null)}
+        />
+        <path
+          d={d}
+          fill="none"
+          stroke={colorFor(item.term, index)}
+          stroke-width={activeTerm === item.term ? 3 : 2}
+          stroke-opacity={muted ? 0.24 : 1}
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        {#if activeTerm === item.term}
+          {#each item.points as point, pointIndex}
+            <circle
+              cx={xFor(pointIndex)}
+              cy={yFor(pointValue(point.count, pointIndex))}
+              r="3"
+              fill={colorFor(item.term, index)}
+            />
+          {/each}
+        {/if}
+      {/each}
+
+      {#if !hasData}
+        <text class="empty-svg" x={width / 2} y={HEIGHT / 2}>
+          No occurrences in this range
+        </text>
+      {/if}
+    </svg>
+  {/if}
+</div>
+
+<style>
+  .chart-wrap {
+    width: 100%;
+    min-height: 300px;
+    border: 1px solid var(--border-default);
+    border-radius: 8px;
+    background: var(--bg-surface);
+    overflow: hidden;
+  }
+
+  .chart {
+    display: block;
+    width: 100%;
+    height: 300px;
+  }
+
+  .grid {
+    stroke: var(--border-muted);
+    stroke-width: 1;
+  }
+
+  .y-label {
+    fill: var(--text-muted);
+    font-size: 10px;
+    text-anchor: end;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .y-title {
+    fill: var(--text-muted);
+    font-size: 10px;
+    font-weight: 600;
+    text-anchor: start;
+  }
+
+  .x-label {
+    fill: var(--text-muted);
+    font-size: 10px;
+    text-anchor: middle;
+  }
+
+  .empty,
+  .empty-svg {
+    color: var(--text-muted);
+    fill: var(--text-muted);
+    font-size: 12px;
+    text-anchor: middle;
+  }
+
+  .empty {
+    height: 300px;
+    display: grid;
+    place-items: center;
+  }
+</style>

--- a/frontend/src/lib/components/trends/TrendsPage.svelte
+++ b/frontend/src/lib/components/trends/TrendsPage.svelte
@@ -1,0 +1,478 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { trends } from "../../stores/trends.svelte.js";
+  import { getBasePath } from "../../stores/router.svelte.js";
+  import type { TrendsGranularity } from "../../api/types.js";
+  import TermTable from "./TermTable.svelte";
+  import TrendsLineChart from "./TrendsLineChart.svelte";
+
+  const TREND_PALETTE = [
+    "var(--trend-blue)",
+    "var(--trend-gold)",
+    "var(--trend-purple)",
+    "var(--trend-green)",
+    "var(--trend-magenta)",
+    "var(--trend-slate)",
+    "var(--trend-red)",
+    "var(--trend-cyan)",
+    "var(--trend-brown)",
+    "var(--trend-lime)",
+    "var(--trend-indigo)",
+    "var(--trend-black)",
+  ] as const;
+
+  let activeTerm: string | null = $state(null);
+
+  function colorFor(_term: string, index: number): string {
+    return TREND_PALETTE[index % TREND_PALETTE.length]!;
+  }
+
+  function isGranularity(value: string | null): value is TrendsGranularity {
+    return value === "day" || value === "week" || value === "month";
+  }
+
+  function applyQueryParams() {
+    const q = new URLSearchParams(window.location.search);
+    const from = q.get("from");
+    const to = q.get("to");
+    const granularity = q.get("granularity");
+    const normalized = q.get("normalized");
+    const terms = q.getAll("term").map((s) => s.trim()).filter(Boolean);
+    if (from) trends.from = from;
+    if (to) trends.to = to;
+    if (isGranularity(granularity)) trends.granularity = granularity;
+    trends.normalized = normalized === "true";
+    if (terms.length > 0) trends.termText = terms.join("\n");
+  }
+
+  function writeUrl() {
+    const q = new URLSearchParams();
+    const current = new URLSearchParams(window.location.search);
+    if (current.has("desktop")) {
+      q.set("desktop", current.get("desktop") ?? "");
+    }
+    q.set("from", trends.from);
+    q.set("to", trends.to);
+    q.set("granularity", trends.granularity);
+    if (trends.normalized) {
+      q.set("normalized", "true");
+    }
+    for (const term of trends.terms) {
+      q.append("term", term);
+    }
+    const basePath = getBasePath();
+    const qs = q.toString();
+    const url = `${basePath}/trends${qs ? `?${qs}` : ""}`;
+    window.history.replaceState(null, "", url);
+  }
+
+  async function refresh() {
+    writeUrl();
+    await trends.fetchTerms();
+  }
+
+  async function setFromDate(event: Event) {
+    trends.from = (event.currentTarget as HTMLInputElement).value;
+    await refresh();
+  }
+
+  async function setToDate(event: Event) {
+    trends.to = (event.currentTarget as HTMLInputElement).value;
+    await refresh();
+  }
+
+  function setNormalized(event: Event) {
+    trends.normalized = (event.currentTarget as HTMLInputElement).checked;
+    writeUrl();
+  }
+
+  async function resetTerms() {
+    await trends.resetTerms();
+    writeUrl();
+  }
+
+  async function setGranularity(value: TrendsGranularity) {
+    trends.granularity = value;
+    await refresh();
+  }
+
+  onMount(() => {
+    applyQueryParams();
+    writeUrl();
+    trends.fetchTerms();
+  });
+</script>
+
+<section class="trends-page">
+  <div class="page-head">
+    <div>
+      <h1>Trends</h1>
+      <p>{trends.response?.from ?? trends.from} to {trends.response?.to ?? trends.to}</p>
+    </div>
+    <div class="head-actions">
+      <button class="secondary" onclick={resetTerms}>Reset</button>
+      <button class="primary" onclick={refresh} disabled={trends.loading.terms}>
+        {trends.loading.terms ? "Refreshing" : "Refresh"}
+      </button>
+    </div>
+  </div>
+
+  <div class="toolbar">
+    <label>
+      <span>From</span>
+      <input type="date" bind:value={trends.from} onchange={setFromDate} />
+    </label>
+    <label>
+      <span>To</span>
+      <input type="date" bind:value={trends.to} onchange={setToDate} />
+    </label>
+    <div class="granularity" aria-label="Granularity">
+      {#each ["day", "week", "month"] as value}
+        <button
+          class:active={trends.granularity === value}
+          onclick={() => setGranularity(value as TrendsGranularity)}
+        >
+          {value}
+        </button>
+      {/each}
+    </div>
+    <label class="normalize-toggle">
+      <input
+        type="checkbox"
+        bind:checked={trends.normalized}
+        onchange={setNormalized}
+      />
+      <span>Normalize by number of messages</span>
+    </label>
+  </div>
+
+  <div class="content-grid">
+    <div class="query-panel">
+      <label class="terms-label" for="trend-terms">
+        <span>Terms</span>
+        <span class="terms-hint">one per line</span>
+      </label>
+      <textarea
+        id="trend-terms"
+        bind:value={trends.termText}
+        rows="9"
+        spellcheck="false"
+      ></textarea>
+      {#if trends.errors.terms}
+        <div class="error">{trends.errors.terms}</div>
+      {/if}
+    </div>
+
+    <div class="chart-panel" aria-busy={trends.loading.terms}>
+      <TrendsLineChart
+        buckets={trends.response?.buckets ?? []}
+        series={trends.response?.series ?? []}
+        {colorFor}
+        {activeTerm}
+        normalized={trends.normalized}
+        onHover={(term) => (activeTerm = term)}
+      />
+      {#if trends.loading.terms}
+        <div class="loading-overlay" role="status" aria-live="polite">
+          <span class="loading-spinner" aria-hidden="true"></span>
+          <span>Computing trends...</span>
+        </div>
+      {/if}
+    </div>
+
+    <div class="table-panel">
+      <TermTable
+        series={trends.response?.series ?? []}
+        {colorFor}
+        {activeTerm}
+        normalized={trends.normalized}
+        messageCount={trends.response?.message_count ?? 0}
+        onHover={(term) => (activeTerm = term)}
+      />
+    </div>
+  </div>
+</section>
+
+<style>
+  .trends-page {
+    --trend-blue: #2563eb;
+    --trend-gold: #d97706;
+    --trend-purple: #7c3aed;
+    --trend-green: #059669;
+    --trend-magenta: #db2777;
+    --trend-slate: #475569;
+    --trend-red: #dc2626;
+    --trend-cyan: #0891b2;
+    --trend-brown: #92400e;
+    --trend-lime: #65a30d;
+    --trend-indigo: #4338ca;
+    --trend-black: #111827;
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 22px;
+    color: var(--text-primary);
+  }
+
+  :global(:root.dark) .trends-page {
+    --trend-blue: #60a5fa;
+    --trend-gold: #fbbf24;
+    --trend-purple: #c084fc;
+    --trend-green: #4ade80;
+    --trend-magenta: #f472b6;
+    --trend-slate: #cbd5e1;
+    --trend-red: #f87171;
+    --trend-cyan: #22d3ee;
+    --trend-brown: #fb923c;
+    --trend-lime: #a3e635;
+    --trend-indigo: #818cf8;
+    --trend-black: #f8fafc;
+  }
+
+  .page-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 24px;
+    line-height: 1.2;
+    font-weight: 650;
+    letter-spacing: 0;
+  }
+
+  p {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .head-actions,
+  .toolbar,
+  .granularity {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  button,
+  input,
+  textarea {
+    font: inherit;
+  }
+
+  button {
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+
+  button:hover:not(:disabled) {
+    background: var(--bg-hover);
+  }
+
+  button:disabled {
+    opacity: 0.65;
+    cursor: default;
+  }
+
+  .primary,
+  .secondary {
+    height: 32px;
+    padding: 0 12px;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .primary {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+    color: white;
+  }
+
+  .primary:hover:not(:disabled) {
+    filter: brightness(0.95);
+    background: var(--accent-blue);
+  }
+
+  .toolbar {
+    flex-wrap: wrap;
+    padding: 12px 0 18px;
+    border-top: 1px solid var(--border-muted);
+  }
+
+  label {
+    display: grid;
+    gap: 5px;
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  input,
+  textarea {
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    background: var(--bg-surface);
+    color: var(--text-primary);
+  }
+
+  input {
+    height: 32px;
+    padding: 0 8px;
+    font-size: 12px;
+  }
+
+  .granularity {
+    align-self: end;
+    height: 32px;
+    padding: 2px;
+    border: 1px solid var(--border-default);
+    border-radius: 7px;
+    background: var(--bg-surface);
+  }
+
+  .granularity button {
+    height: 26px;
+    min-width: 54px;
+    padding: 0 10px;
+    border: 0;
+    background: transparent;
+    color: var(--text-muted);
+    text-transform: capitalize;
+    font-size: 12px;
+  }
+
+  .granularity button.active {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  .normalize-toggle {
+    align-self: end;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 500;
+  }
+
+  .normalize-toggle input {
+    width: 14px;
+    height: 14px;
+    padding: 0;
+  }
+
+  .content-grid {
+    display: grid;
+    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+    grid-template-areas:
+      "query chart"
+      "table chart";
+    gap: 14px;
+    align-items: start;
+  }
+
+  .query-panel {
+    grid-area: query;
+  }
+
+  .chart-panel {
+    grid-area: chart;
+    min-width: 0;
+    position: relative;
+  }
+
+  .table-panel {
+    grid-area: table;
+  }
+
+  .terms-label {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+
+  .terms-hint {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 500;
+  }
+
+  textarea {
+    width: 100%;
+    min-height: 188px;
+    padding: 10px;
+    resize: vertical;
+    line-height: 1.45;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px;
+  }
+
+  .error {
+    margin-top: 8px;
+    color: var(--accent-rose);
+    font-size: 12px;
+    line-height: 1.35;
+  }
+
+  .loading-overlay {
+    position: absolute;
+    inset: 1px;
+    display: grid;
+    place-items: center;
+    gap: 8px;
+    border-radius: 8px;
+    background: color-mix(
+      in srgb,
+      var(--bg-surface) 78%,
+      transparent
+    );
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 600;
+    pointer-events: none;
+  }
+
+  .loading-spinner {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--border-default);
+    border-top-color: var(--accent-blue);
+    border-radius: 999px;
+    animation: trends-spin 800ms linear infinite;
+  }
+
+  @keyframes trends-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (max-width: 820px) {
+    .trends-page {
+      padding: 16px;
+    }
+
+    .page-head {
+      flex-direction: column;
+    }
+
+    .content-grid {
+      grid-template-columns: 1fr;
+      grid-template-areas:
+        "query"
+        "chart"
+        "table";
+    }
+  }
+</style>

--- a/frontend/src/lib/components/trends/TrendsPage.test.ts
+++ b/frontend/src/lib/components/trends/TrendsPage.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { mount, tick, unmount } from "svelte";
+import { trends } from "../../stores/trends.svelte.js";
+import type { TrendsTermsResponse } from "../../api/types.js";
+
+const mocks = vi.hoisted(() => ({
+  getTrendsTerms: vi.fn(),
+}));
+
+vi.mock("../../api/client.js", () => ({
+  getTrendsTerms: mocks.getTrendsTerms,
+}));
+
+// @ts-ignore
+import TrendsPage from "./TrendsPage.svelte";
+
+function makeResponse(
+  from = "2024-01-01",
+  to = "2024-01-31",
+): TrendsTermsResponse {
+  return {
+    granularity: "week",
+    from,
+    to,
+    message_count: 0,
+    buckets: [],
+    series: [],
+  };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await tick();
+}
+
+describe("TrendsPage", () => {
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    mocks.getTrendsTerms.mockImplementation((params) =>
+      Promise.resolve(makeResponse(params.from, params.to)),
+    );
+    trends.from = "2024-01-01";
+    trends.to = "2024-01-31";
+    trends.granularity = "week";
+    trends.termText = "seam";
+    trends.response = null;
+    trends.loading.terms = false;
+    trends.errors.terms = null;
+    window.history.replaceState(null, "", "/trends");
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = undefined;
+    }
+    document.body.innerHTML = "";
+    window.history.replaceState(null, "", "/");
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes with the changed date value", async () => {
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    const fromInput = document.querySelector<HTMLInputElement>(
+      'input[type="date"]',
+    );
+    expect(fromInput).not.toBeNull();
+
+    fromInput!.value = "2024-01-10";
+    fromInput!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushPromises();
+
+    expect(mocks.getTrendsTerms).toHaveBeenLastCalledWith(
+      expect.objectContaining({ from: "2024-01-10" }),
+    );
+    expect(window.location.search).toContain("from=2024-01-10");
+  });
+
+  it("shows the terms entry format hint", async () => {
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain("one per line");
+  });
+
+  it("shows chart loading status while trends are computing", async () => {
+    let resolveFetch:
+      | ((response: TrendsTermsResponse) => void)
+      | undefined;
+    mocks.getTrendsTerms.mockReturnValueOnce(
+      new Promise<TrendsTermsResponse>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    component = mount(TrendsPage, { target: document.body });
+    await tick();
+
+    const status = document.querySelector<HTMLElement>(
+      '[role="status"]',
+    );
+    expect(status).not.toBeNull();
+    expect(status!.textContent).toContain("Computing trends");
+
+    resolveFetch!(makeResponse());
+    await flushPromises();
+
+    expect(document.body.textContent).not.toContain(
+      "Computing trends",
+    );
+  });
+
+  it("surfaces explicit refresh errors after initial data loads", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    mocks.getTrendsTerms.mockRejectedValueOnce(
+      new Error("at least one trend term is required"),
+    );
+    const textarea = document.querySelector<HTMLTextAreaElement>(
+      "#trend-terms",
+    );
+    expect(textarea).not.toBeNull();
+    textarea!.value = "";
+    textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const refreshButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.trim() === "Refresh");
+    expect(refreshButton).not.toBeNull();
+    refreshButton!.click();
+    await flushPromises();
+
+    expect(document.body.textContent).toContain(
+      "at least one trend term is required",
+    );
+    warn.mockRestore();
+  });
+
+  it("toggles normalized term totals", async () => {
+    mocks.getTrendsTerms.mockResolvedValueOnce({
+      granularity: "week",
+      from: "2024-01-01",
+      to: "2024-01-31",
+      message_count: 20,
+      buckets: [{ date: "2024-01-01", message_count: 20 }],
+      series: [
+        {
+          term: "seam",
+          variants: ["seam"],
+          total: 2,
+          points: [{ date: "2024-01-01", count: 2 }],
+        },
+      ],
+    });
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain("Count");
+    expect(document.body.textContent).toContain("2");
+
+    const checkbox = document.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    expect(checkbox).not.toBeNull();
+    checkbox!.click();
+    await tick();
+
+    expect(document.body.textContent).toContain("Per 1k messages");
+    expect(document.body.textContent).toContain("100");
+  });
+
+  it("labels normalization by number of messages", async () => {
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain(
+      "Normalize by number of messages",
+    );
+  });
+
+  it("shows a y-axis metric label", async () => {
+    mocks.getTrendsTerms.mockResolvedValueOnce({
+      granularity: "week",
+      from: "2024-01-01",
+      to: "2024-01-31",
+      message_count: 20,
+      buckets: [{ date: "2024-01-01", message_count: 20 }],
+      series: [
+        {
+          term: "seam",
+          variants: ["seam"],
+          total: 2,
+          points: [{ date: "2024-01-01", count: 2 }],
+        },
+      ],
+    });
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain("Occurrences");
+  });
+
+  it("uses the dedicated trends palette for seven terms", async () => {
+    mocks.getTrendsTerms.mockResolvedValueOnce({
+      granularity: "week",
+      from: "2024-01-01",
+      to: "2024-01-31",
+      message_count: 70,
+      buckets: [{ date: "2024-01-01", message_count: 70 }],
+      series: Array.from({ length: 7 }, (_, i) => ({
+        term: `term-${i + 1}`,
+        variants: [`term-${i + 1}`],
+        total: i + 1,
+        points: [{ date: "2024-01-01", count: i + 1 }],
+      })),
+    });
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    const swatches = Array.from(
+      document.querySelectorAll<HTMLElement>(".swatch"),
+    );
+    const styles = swatches.map((el) => el.getAttribute("style") ?? "");
+    expect(styles.slice(0, 7)).toEqual([
+      "background: var(--trend-blue);",
+      "background: var(--trend-gold);",
+      "background: var(--trend-purple);",
+      "background: var(--trend-green);",
+      "background: var(--trend-magenta);",
+      "background: var(--trend-slate);",
+      "background: var(--trend-red);",
+    ]);
+  });
+});

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -1,6 +1,7 @@
 export type Route =
   | "sessions"
   | "usage"
+  | "trends"
   | "insights"
   | "pinned"
   | "trash"
@@ -9,6 +10,7 @@ export type Route =
 const VALID_ROUTES: ReadonlySet<string> = new Set<Route>([
   "sessions",
   "usage",
+  "trends",
   "insights",
   "pinned",
   "trash",

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -63,6 +63,8 @@ describe("parsePath", () => {
 
   it("parses page routes", () => {
     for (const route of [
+      "usage",
+      "trends",
       "insights",
       "pinned",
       "trash",
@@ -146,6 +148,14 @@ describe("RouterStore", () => {
     expect(spy).toHaveBeenCalled();
     expect(store.route).toBe("insights");
     spy.mockRestore();
+  });
+
+  it("navigate updates URL to /trends", () => {
+    setURL("/");
+    store = new RouterStore();
+    store.navigate("trends");
+    expect(window.location.pathname).toBe("/trends");
+    expect(store.route).toBe("trends");
   });
 
   it("navigate returns false on same URL (no-op)", () => {

--- a/frontend/src/lib/stores/trends.svelte.ts
+++ b/frontend/src/lib/stores/trends.svelte.ts
@@ -1,0 +1,91 @@
+import type {
+  TrendsGranularity,
+  TrendsTermsResponse,
+} from "../api/types.js";
+import {
+  getTrendsTerms,
+  type TrendsTermsParams,
+} from "../api/client.js";
+import { daysAgo, today } from "../utils/dates.js";
+
+const DEFAULT_TERMS =
+  "load bearing | load-bearing\nseam\nblast radius";
+
+class TrendsStore {
+  from: string = $state(daysAgo(365));
+  to: string = $state(today());
+  granularity: TrendsGranularity = $state("week");
+  normalized: boolean = $state(false);
+  termText: string = $state(DEFAULT_TERMS);
+  response: TrendsTermsResponse | null = $state(null);
+  loading = $state({ terms: false });
+  errors = $state<{ terms: string | null }>({ terms: null });
+  private version = 0;
+
+  get timezone(): string {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+
+  get terms(): string[] {
+    return this.termText
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  private params(): TrendsTermsParams {
+    return {
+      from: this.from,
+      to: this.to,
+      timezone: this.timezone,
+      granularity: this.granularity,
+      terms: this.terms,
+    };
+  }
+
+  async fetchTerms(): Promise<void> {
+    const v = ++this.version;
+    const isFirstLoad = this.response === null;
+    this.loading.terms = true;
+    this.errors.terms = null;
+    try {
+      const data = await getTrendsTerms(this.params());
+      if (this.version === v) {
+        this.response = data;
+        this.errors.terms = null;
+      }
+    } catch (e) {
+      if (this.version === v) {
+        this.errors.terms =
+          e instanceof Error ? e.message : "Failed to load";
+        if (isFirstLoad) {
+          this.response = null;
+        } else {
+          console.warn("trends.terms refetch failed:", e);
+        }
+      }
+    } finally {
+      if (this.version === v) {
+        this.loading.terms = false;
+      }
+    }
+  }
+
+  async setDateRange(from: string, to: string): Promise<void> {
+    this.from = from;
+    this.to = to;
+    await this.fetchTerms();
+  }
+
+  async setGranularity(g: TrendsGranularity): Promise<void> {
+    this.granularity = g;
+    await this.fetchTerms();
+  }
+
+  async resetTerms(): Promise<void> {
+    this.termText = DEFAULT_TERMS;
+    await this.fetchTerms();
+  }
+}
+
+export const trends = new TrendsStore();

--- a/frontend/src/lib/stores/trends.test.ts
+++ b/frontend/src/lib/stores/trends.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { trends } from "./trends.svelte.js";
+import * as api from "../api/client.js";
+import type { TrendsTermsResponse } from "../api/types.js";
+
+vi.mock("../api/client.js", () => ({
+  getTrendsTerms: vi.fn(),
+}));
+
+function makeResponse(): TrendsTermsResponse {
+  return {
+    granularity: "week",
+    from: "2024-01-01",
+    to: "2024-01-31",
+    message_count: 0,
+    buckets: [],
+    series: [],
+  };
+}
+
+function resetStore() {
+  trends.from = "2024-01-01";
+  trends.to = "2024-01-31";
+  trends.granularity = "week";
+  trends.normalized = false;
+  trends.termText = "load bearing | load-bearing\nseam";
+  trends.response = null;
+  trends.loading.terms = false;
+  trends.errors.terms = null;
+}
+
+beforeEach(() => {
+  resetStore();
+  vi.clearAllMocks();
+  vi.mocked(api.getTrendsTerms).mockResolvedValue(makeResponse());
+});
+
+describe("TrendsStore.fetchTerms", () => {
+  it("fetches default terms with timezone and date range", async () => {
+    await trends.fetchTerms();
+
+    expect(api.getTrendsTerms).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "2024-01-01",
+        to: "2024-01-31",
+        granularity: "week",
+        terms: ["load bearing | load-bearing", "seam"],
+        timezone: expect.any(String),
+      }),
+    );
+    expect(trends.response?.granularity).toBe("week");
+  });
+
+  it("removes blank term lines", async () => {
+    trends.termText = "seam\n\n  \nblast radius";
+
+    await trends.fetchTerms();
+
+    expect(api.getTrendsTerms).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terms: ["seam", "blast radius"],
+      }),
+    );
+  });
+
+  it("sets first-load error state", async () => {
+    vi.mocked(api.getTrendsTerms).mockRejectedValue(new Error("boom"));
+
+    await trends.fetchTerms();
+
+    expect(trends.response).toBeNull();
+    expect(trends.loading.terms).toBe(false);
+    expect(trends.errors.terms).toBe("boom");
+  });
+
+  it("keeps existing response and surfaces refetch errors", async () => {
+    const existing = makeResponse();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    trends.response = existing;
+    vi.mocked(api.getTrendsTerms).mockRejectedValue(new Error("boom"));
+
+    await trends.fetchTerms();
+
+    expect(trends.response).toEqual(existing);
+    expect(trends.loading.terms).toBe(false);
+    expect(trends.errors.terms).toBe("boom");
+    expect(warn).toHaveBeenCalledWith(
+      "trends.terms refetch failed:",
+      expect.any(Error),
+    );
+    warn.mockRestore();
+  });
+
+  it("setGranularity refetches with the new granularity", async () => {
+    await trends.setGranularity("month");
+
+    expect(api.getTrendsTerms).toHaveBeenCalledWith(
+      expect.objectContaining({ granularity: "month" }),
+    );
+  });
+});

--- a/frontend/src/lib/utils/dates.test.ts
+++ b/frontend/src/lib/utils/dates.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { daysAgo, localDateStr, today } from "./dates.js";
+
+describe("date helpers", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("formats local dates as YYYY-MM-DD", () => {
+    expect(localDateStr(new Date(2024, 5, 7))).toBe("2024-06-07");
+  });
+
+  it("computes today and daysAgo from local time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 5, 10, 12, 0, 0));
+    expect(today()).toBe("2024-06-10");
+    expect(daysAgo(7)).toBe("2024-06-03");
+  });
+});

--- a/frontend/src/lib/utils/dates.ts
+++ b/frontend/src/lib/utils/dates.ts
@@ -1,0 +1,16 @@
+export function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return localDateStr(d);
+}
+
+export function today(): string {
+  return localDateStr(new Date());
+}

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -116,6 +116,21 @@ func (f AnalyticsFilter) utcRange() (string, string) {
 func (f AnalyticsFilter) buildWhere(
 	dateCol string,
 ) (string, []any) {
+	return f.buildWhereWithDate(dateCol, true)
+}
+
+// buildWhereWithoutDate returns common analytics predicates
+// without adding session date bounds. Callers that evaluate
+// date windows against message timestamps should use this to
+// avoid pre-filtering by the parent session timestamp.
+func (f AnalyticsFilter) buildWhereWithoutDate() (string, []any) {
+	return f.buildWhereWithDate("", false)
+}
+
+func (f AnalyticsFilter) buildWhereWithDate(
+	dateCol string,
+	includeDate bool,
+) (string, []any) {
 	preds := []string{
 		"message_count > 0",
 		"relationship_type NOT IN ('subagent', 'fork')",
@@ -123,11 +138,13 @@ func (f AnalyticsFilter) buildWhere(
 	}
 	var args []any
 
-	utcFrom, utcTo := f.utcRange()
-	preds = append(preds, dateCol+" >= ?")
-	args = append(args, utcFrom)
-	preds = append(preds, dateCol+" <= ?")
-	args = append(args, utcTo)
+	if includeDate {
+		utcFrom, utcTo := f.utcRange()
+		preds = append(preds, dateCol+" >= ?")
+		args = append(args, utcFrom)
+		preds = append(preds, dateCol+" <= ?")
+		args = append(args, utcTo)
+	}
 
 	if f.Machine != "" {
 		preds = append(preds, "machine = ?")

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -55,6 +55,7 @@ type Store interface {
 	GetAnalyticsVelocity(ctx context.Context, f AnalyticsFilter) (VelocityResponse, error)
 	GetAnalyticsTopSessions(ctx context.Context, f AnalyticsFilter, metric string) (TopSessionsResponse, error)
 	GetAnalyticsSignals(ctx context.Context, f AnalyticsFilter) (SignalsAnalyticsResponse, error)
+	GetTrendsTerms(ctx context.Context, f AnalyticsFilter, terms []TrendTermInput, granularity string) (TrendsTermsResponse, error)
 
 	// Usage (token cost).
 	GetDailyUsage(ctx context.Context, f UsageFilter) (DailyUsageResult, error)

--- a/internal/db/trends.go
+++ b/internal/db/trends.go
@@ -1,0 +1,454 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	MaxTrendTerms        = 12
+	MaxTrendTermVariants = 8
+)
+
+type TrendTermInput struct {
+	Term     string   `json:"term"`
+	Variants []string `json:"variants"`
+	Matchers []string `json:"-"`
+}
+
+type TrendBucket struct {
+	Date         string `json:"date"`
+	MessageCount int    `json:"message_count"`
+}
+
+type TrendPoint struct {
+	Date  string `json:"date"`
+	Count int    `json:"count"`
+}
+
+type TrendSeries struct {
+	Term     string       `json:"term"`
+	Variants []string     `json:"variants"`
+	Total    int          `json:"total"`
+	Points   []TrendPoint `json:"points"`
+}
+
+type TrendsTermsResponse struct {
+	Granularity  string        `json:"granularity"`
+	From         string        `json:"from"`
+	To           string        `json:"to"`
+	MessageCount int           `json:"message_count"`
+	Buckets      []TrendBucket `json:"buckets"`
+	Series       []TrendSeries `json:"series"`
+}
+
+func (db *DB) GetTrendsTerms(
+	ctx context.Context,
+	f AnalyticsFilter,
+	terms []TrendTermInput,
+	granularity string,
+) (TrendsTermsResponse, error) {
+	if granularity == "" {
+		granularity = "week"
+	}
+	loc := f.location()
+	buckets := TrendBucketRange(f.From, f.To, granularity)
+	bucketIndex := trendBucketIndex(buckets)
+	counts := make([][]int, len(terms))
+	for i := range counts {
+		counts[i] = make([]int, len(buckets))
+	}
+	messageCounts := make([]int, len(buckets))
+
+	sessionFilter := f
+	sessionFilter.From = ""
+	sessionFilter.To = ""
+	dateCol := "COALESCE(NULLIF(s.started_at, ''), s.created_at)"
+	where, args := sessionFilter.buildWhere(dateCol)
+	query := `SELECT m.content, COALESCE(m.timestamp, ''),
+			COALESCE(s.started_at, ''), s.created_at
+		FROM sessions s
+		JOIN messages m ON m.session_id = s.id
+		WHERE ` + where + `
+			AND m.role IN ('user', 'assistant')
+			AND m.is_system = 0
+			AND ` + SystemPrefixSQL("m.content", "m.role")
+
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
+	if err != nil {
+		return TrendsTermsResponse{}, fmt.Errorf("querying trends terms: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var content, msgTS, startedAt, createdAt string
+		if err := rows.Scan(
+			&content, &msgTS, &startedAt, &createdAt,
+		); err != nil {
+			return TrendsTermsResponse{}, fmt.Errorf("scanning trends term row: %w", err)
+		}
+		msgTime, ok := trendMessageLocalTime(msgTS, startedAt, createdAt, loc)
+		if !ok {
+			continue
+		}
+		if f.HasTimeFilter() && !f.matchesTimeFilter(msgTime) {
+			continue
+		}
+		msgDate := msgTime.Format("2006-01-02")
+		if !inDateRange(msgDate, f.From, f.To) {
+			continue
+		}
+		bucketDate := trendBucketDate(msgTime, loc, granularity)
+		bucket, ok := bucketIndex[bucketDate]
+		if !ok {
+			continue
+		}
+		messageCounts[bucket]++
+		for i, term := range terms {
+			count := countTrendOccurrences(content, term)
+			if count > 0 {
+				counts[i][bucket] += count
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return TrendsTermsResponse{}, fmt.Errorf("iterating trends term rows: %w", err)
+	}
+
+	return BuildTrendsTermsResponse(
+		f.From, f.To, granularity, buckets, terms, counts, messageCounts,
+	), nil
+}
+
+func ParseTrendTerms(values []string) ([]TrendTermInput, error) {
+	terms := make([]TrendTermInput, 0, min(len(values), MaxTrendTerms))
+	for _, value := range values {
+		variants := parseTrendTermVariants(value)
+		if len(variants) == 0 {
+			continue
+		}
+		if len(variants) > MaxTrendTermVariants {
+			return nil, fmt.Errorf("trend terms can have at most %d variants", MaxTrendTermVariants)
+		}
+		matchers := make([]string, 0, len(variants)*3)
+		for _, variant := range variants {
+			matchers = append(matchers, variant)
+			if plural, ok := simpleTrendPlural(variant); ok {
+				matchers = append(matchers, plural)
+			}
+			matchers = append(matchers, simpleSilentEStemMatchers(variant)...)
+		}
+		matchers = dedupeCaseFolded(matchers)
+		terms = append(terms, TrendTermInput{
+			Term:     variants[0],
+			Variants: variants,
+			Matchers: matchers,
+		})
+	}
+	if len(terms) == 0 {
+		return nil, fmt.Errorf("at least one trend term is required")
+	}
+	if len(terms) > MaxTrendTerms {
+		return nil, fmt.Errorf("trend query supports at most %d terms", MaxTrendTerms)
+	}
+	return terms, nil
+}
+
+func parseTrendTermVariants(value string) []string {
+	parts := strings.Split(value, "|")
+	variants := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		variant := strings.TrimSpace(part)
+		if variant == "" {
+			continue
+		}
+		key := strings.ToLower(variant)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		variants = append(variants, variant)
+	}
+	return variants
+}
+
+func simpleTrendPlural(value string) (string, bool) {
+	if value == "" || strings.ContainsAny(value, " \t\n\r") {
+		return "", false
+	}
+	if strings.HasSuffix(strings.ToLower(value), "s") {
+		return "", false
+	}
+	return value + "s", true
+}
+
+func simpleSilentEStemMatchers(value string) []string {
+	if len(value) < 3 || !isSingleWordMatcher(value) {
+		return nil
+	}
+	lower := strings.ToLower(value)
+	if !strings.HasSuffix(lower, "c") ||
+		strings.HasSuffix(lower, "e") ||
+		strings.HasSuffix(lower, "s") {
+		return nil
+	}
+	withE := value + "e"
+	return []string{
+		withE,
+		withE + "s",
+		withE + "d",
+		value + "ing",
+	}
+}
+
+func dedupeCaseFolded(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+type matchSpan struct {
+	start int
+	end   int
+}
+
+func countTrendOccurrences(text string, term TrendTermInput) int {
+	return CountTrendOccurrences(text, term)
+}
+
+func CountTrendOccurrences(text string, term TrendTermInput) int {
+	spans := make([]matchSpan, 0)
+	for _, matcher := range term.Matchers {
+		matcher = strings.TrimSpace(matcher)
+		if matcher == "" {
+			continue
+		}
+		wordBounded := isSingleWordMatcher(matcher)
+		spans = append(spans, collectTrendSpans(text, matcher, wordBounded)...)
+	}
+	return mergeCountSpans(spans)
+}
+
+func collectTrendSpans(text string, matcher string, wordBounded bool) []matchSpan {
+	needle := strings.ToLower(matcher)
+	haystack := strings.ToLower(text)
+	if needle == "" || haystack == "" {
+		return nil
+	}
+	spans := make([]matchSpan, 0)
+	for offset := 0; offset < len(haystack); {
+		idx := strings.Index(haystack[offset:], needle)
+		if idx < 0 {
+			break
+		}
+		start := offset + idx
+		end := start + len(needle)
+		if !wordBounded || hasWordBoundaries(haystack, start, end) {
+			spans = append(spans, matchSpan{start: start, end: end})
+		}
+		offset = start + 1
+	}
+	return spans
+}
+
+func isSingleWordMatcher(matcher string) bool {
+	if matcher == "" {
+		return false
+	}
+	for i := 0; i < len(matcher); i++ {
+		if !isWordByte(matcher[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasWordBoundaries(text string, start, end int) bool {
+	if start > 0 && isWordByte(text[start-1]) {
+		return false
+	}
+	if end < len(text) && isWordByte(text[end]) {
+		return false
+	}
+	return true
+}
+
+func isWordByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') ||
+		b == '_'
+}
+
+func mergeCountSpans(spans []matchSpan) int {
+	if len(spans) == 0 {
+		return 0
+	}
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start == spans[j].start {
+			return spans[i].end < spans[j].end
+		}
+		return spans[i].start < spans[j].start
+	})
+	count := 0
+	mergedEnd := -1
+	for _, span := range spans {
+		if span.start >= mergedEnd {
+			count++
+			mergedEnd = span.end
+			continue
+		}
+		if span.end > mergedEnd {
+			mergedEnd = span.end
+		}
+	}
+	return count
+}
+
+func trendMessageLocalTime(
+	messageTS string,
+	startedAt string,
+	createdAt string,
+	loc *time.Location,
+) (time.Time, bool) {
+	for _, ts := range []string{messageTS, startedAt, createdAt} {
+		if t, ok := localTime(ts, loc); ok {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func trendBucketDate(t time.Time, loc *time.Location, granularity string) string {
+	return TrendBucketDate(t, loc, granularity)
+}
+
+func TrendBucketDate(t time.Time, loc *time.Location, granularity string) string {
+	local := t.In(loc)
+	switch granularity {
+	case "week":
+		weekday := int(local.Weekday())
+		if weekday == 0 {
+			weekday = 7
+		}
+		start := local.AddDate(0, 0, -(weekday - 1))
+		return time.Date(
+			start.Year(), start.Month(), start.Day(),
+			0, 0, 0, 0, loc,
+		).Format("2006-01-02")
+	case "month":
+		return time.Date(
+			local.Year(), local.Month(), 1,
+			0, 0, 0, 0, loc,
+		).Format("2006-01-02")
+	default:
+		return local.Format("2006-01-02")
+	}
+}
+
+func TrendBucketRange(from, to, granularity string) []TrendBucket {
+	if from == "" || to == "" {
+		return nil
+	}
+	start, err := time.Parse("2006-01-02", from)
+	if err != nil {
+		return nil
+	}
+	end, err := time.Parse("2006-01-02", to)
+	if err != nil {
+		return nil
+	}
+	startDate := trendBucketDate(start, time.UTC, granularity)
+	endDate := trendBucketDate(end, time.UTC, granularity)
+	cur, err := time.Parse("2006-01-02", startDate)
+	if err != nil {
+		return nil
+	}
+	last, err := time.Parse("2006-01-02", endDate)
+	if err != nil {
+		return nil
+	}
+	buckets := make([]TrendBucket, 0)
+	for !cur.After(last) {
+		buckets = append(buckets, TrendBucket{Date: cur.Format("2006-01-02")})
+		switch granularity {
+		case "month":
+			cur = cur.AddDate(0, 1, 0)
+		case "week":
+			cur = cur.AddDate(0, 0, 7)
+		default:
+			cur = cur.AddDate(0, 0, 1)
+		}
+	}
+	return buckets
+}
+
+func trendBucketIndex(buckets []TrendBucket) map[string]int {
+	index := make(map[string]int, len(buckets))
+	for i, bucket := range buckets {
+		index[bucket.Date] = i
+	}
+	return index
+}
+
+func BuildTrendsTermsResponse(
+	from string,
+	to string,
+	granularity string,
+	buckets []TrendBucket,
+	terms []TrendTermInput,
+	counts [][]int,
+	messageCounts []int,
+) TrendsTermsResponse {
+	outBuckets := make([]TrendBucket, len(buckets))
+	totalMessages := 0
+	for i, bucket := range buckets {
+		outBuckets[i] = bucket
+		if i < len(messageCounts) {
+			outBuckets[i].MessageCount = messageCounts[i]
+			totalMessages += messageCounts[i]
+		}
+	}
+	series := make([]TrendSeries, len(terms))
+	for i, term := range terms {
+		points := make([]TrendPoint, len(buckets))
+		total := 0
+		for j, bucket := range buckets {
+			count := 0
+			if i < len(counts) && j < len(counts[i]) {
+				count = counts[i][j]
+			}
+			total += count
+			points[j] = TrendPoint{
+				Date:  bucket.Date,
+				Count: count,
+			}
+		}
+		series[i] = TrendSeries{
+			Term:     term.Term,
+			Variants: append([]string(nil), term.Variants...),
+			Total:    total,
+			Points:   points,
+		}
+	}
+	return TrendsTermsResponse{
+		Granularity:  granularity,
+		From:         from,
+		To:           to,
+		MessageCount: totalMessages,
+		Buckets:      outBuckets,
+		Series:       series,
+	}
+}

--- a/internal/db/trends.go
+++ b/internal/db/trends.go
@@ -66,8 +66,9 @@ func (db *DB) GetTrendsTerms(
 	sessionFilter := f
 	sessionFilter.From = ""
 	sessionFilter.To = ""
-	dateCol := "COALESCE(NULLIF(s.started_at, ''), s.created_at)"
-	where, args := sessionFilter.buildWhere(dateCol)
+	sessionFilter.DayOfWeek = nil
+	sessionFilter.Hour = nil
+	where, args := sessionFilter.buildWhereWithoutDate()
 	query := `SELECT m.content, COALESCE(m.timestamp, ''),
 			COALESCE(s.started_at, ''), s.created_at
 		FROM sessions s

--- a/internal/db/trends_test.go
+++ b/internal/db/trends_test.go
@@ -1,0 +1,357 @@
+package db
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseTrendTerms(t *testing.T) {
+	got, err := ParseTrendTerms([]string{
+		" load bearing | load-bearing ",
+		"seam",
+		"seam | Seam | seams",
+		"slic",
+	})
+	if err != nil {
+		t.Fatalf("ParseTrendTerms: %v", err)
+	}
+	if got[0].Term != "load bearing" {
+		t.Fatalf("term label = %q", got[0].Term)
+	}
+	if want := []string{"load bearing", "load-bearing"}; !slices.Equal(got[0].Variants, want) {
+		t.Fatalf("variants = %#v, want %#v", got[0].Variants, want)
+	}
+	if want := []string{"seam", "seams"}; !slices.Equal(got[1].Matchers, want) {
+		t.Fatalf("matchers = %#v, want %#v", got[1].Matchers, want)
+	}
+	if got[2].Term != "seam" {
+		t.Fatalf("deduped term label = %q", got[2].Term)
+	}
+	if want := []string{"seam", "seams"}; !slices.Equal(got[2].Variants, want) {
+		t.Fatalf("deduped variants = %#v, want %#v", got[2].Variants, want)
+	}
+	if want := []string{"slic", "slics", "slice", "slices", "sliced", "slicing"}; !slices.Equal(got[3].Matchers, want) {
+		t.Fatalf("stem matchers = %#v, want %#v", got[3].Matchers, want)
+	}
+}
+
+func TestParseTrendTermsValidation(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		if _, err := ParseTrendTerms(nil); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("empty rows dropped before limit", func(t *testing.T) {
+		got, err := ParseTrendTerms([]string{"", "  ", "seam"})
+		if err != nil {
+			t.Fatalf("ParseTrendTerms: %v", err)
+		}
+		if len(got) != 1 || got[0].Term != "seam" {
+			t.Fatalf("terms = %#v, want only seam", got)
+		}
+	})
+
+	t.Run("more than 12 terms", func(t *testing.T) {
+		values := make([]string, MaxTrendTerms+1)
+		for i := range values {
+			values[i] = "term"
+		}
+		_, err := ParseTrendTerms(values)
+		if err == nil || !strings.Contains(err.Error(), "at most 12") {
+			t.Fatalf("error = %v, want max terms", err)
+		}
+	})
+
+	t.Run("more than 8 variants after dedupe", func(t *testing.T) {
+		_, err := ParseTrendTerms([]string{"a|b|c|d|e|f|g|h|i"})
+		if err == nil || !strings.Contains(err.Error(), "at most 8") {
+			t.Fatalf("error = %v, want max variants", err)
+		}
+	})
+
+	t.Run("variant limit after dedupe", func(t *testing.T) {
+		got, err := ParseTrendTerms([]string{"a|A|b|c|d|e|f|g|h"})
+		if err != nil {
+			t.Fatalf("ParseTrendTerms: %v", err)
+		}
+		if len(got[0].Variants) != MaxTrendTermVariants {
+			t.Fatalf("variant count = %d, want %d", len(got[0].Variants), MaxTrendTermVariants)
+		}
+	})
+}
+
+func TestCountTrendOccurrences(t *testing.T) {
+	term := TrendTermInput{
+		Term:     "seam",
+		Variants: []string{"seam"},
+		Matchers: []string{"seam", "seams"},
+	}
+	cases := []struct {
+		name string
+		text string
+		want int
+	}{
+		{"case insensitive", "Seam seam SEAMS", 3},
+		{"word boundary", "seamless seam seams", 2},
+		{"overlap plural", "seams", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countTrendOccurrences(tc.text, term); got != tc.want {
+				t.Fatalf("count = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountTrendOccurrencesSilentEStem(t *testing.T) {
+	terms, err := ParseTrendTerms([]string{"slic"})
+	if err != nil {
+		t.Fatalf("ParseTrendTerms: %v", err)
+	}
+	got := countTrendOccurrences(
+		"slice slices sliced slicing slicer sliced-up",
+		terms[0],
+	)
+	if got != 5 {
+		t.Fatalf("count = %d, want 5", got)
+	}
+}
+
+func TestCountTrendOccurrencesPhrases(t *testing.T) {
+	term := TrendTermInput{
+		Term:     "load bearing",
+		Variants: []string{"load bearing", "load-bearing"},
+		Matchers: []string{"load bearing", "load-bearing"},
+	}
+	got := countTrendOccurrences("Load bearing and load-bearing", term)
+	if got != 2 {
+		t.Fatalf("count = %d, want 2", got)
+	}
+}
+
+func TestTrendBucketDate(t *testing.T) {
+	loc := time.UTC
+	cases := []struct {
+		gran string
+		ts   string
+		want string
+	}{
+		{"day", "2024-06-05T12:00:00Z", "2024-06-05"},
+		{"week", "2024-06-05T12:00:00Z", "2024-06-03"},
+		{"month", "2024-06-05T12:00:00Z", "2024-06-01"},
+	}
+	for _, tc := range cases {
+		parsed, _ := time.Parse(time.RFC3339, tc.ts)
+		if got := trendBucketDate(parsed, loc, tc.gran); got != tc.want {
+			t.Fatalf("%s got %s want %s", tc.gran, got, tc.want)
+		}
+	}
+}
+
+func TestGetTrendsTermsSQLite(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	start := "2024-06-01T09:00:00Z"
+	insertSession(t, d, "s1", "proj-a", func(s *Session) {
+		s.StartedAt = &start
+		s.CreatedAt = start
+		s.MessageCount = 3
+		s.UserMessageCount = 2
+	})
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "load bearing seam", Timestamp: "2024-06-01T09:00:00Z", ContentLength: 17},
+		Message{SessionID: "s1", Ordinal: 1, Role: "assistant", Content: "load-bearing seams seam", Timestamp: "2024-06-08T09:00:00Z", ContentLength: 23},
+		Message{SessionID: "s1", Ordinal: 2, Role: "user", Content: "seam system", Timestamp: "2024-06-08T09:00:00Z", ContentLength: 11, IsSystem: true},
+	)
+	terms, err := ParseTrendTerms([]string{"load bearing | load-bearing", "seam"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
+		From: "2024-06-01", To: "2024-06-09", Timezone: "UTC",
+	}, terms, "week")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if want := []string{"2024-05-27", "2024-06-03"}; !slices.Equal(trendBucketDates(got.Buckets), want) {
+		t.Fatalf("bucket dates = %#v, want %#v", trendBucketDates(got.Buckets), want)
+	}
+	if want := []int{1, 1}; !slices.Equal(trendBucketMessageCounts(got.Buckets), want) {
+		t.Fatalf("bucket message counts = %#v, want %#v", trendBucketMessageCounts(got.Buckets), want)
+	}
+	if got.MessageCount != 2 {
+		t.Fatalf("message count = %d, want 2", got.MessageCount)
+	}
+	byTerm := trendSeriesByTerm(got.Series)
+	if got := byTerm["load bearing"].Total; got != 2 {
+		t.Fatalf("load bearing total = %d, want 2", got)
+	}
+	if got := byTerm["seam"].Total; got != 3 {
+		t.Fatalf("seam total = %d, want 3", got)
+	}
+	if want := []int{1, 1}; !slices.Equal(trendPointCounts(byTerm["load bearing"].Points), want) {
+		t.Fatalf("load bearing points = %#v, want %#v", trendPointCounts(byTerm["load bearing"].Points), want)
+	}
+	if want := []int{1, 2}; !slices.Equal(trendPointCounts(byTerm["seam"].Points), want) {
+		t.Fatalf("seam points = %#v, want %#v", trendPointCounts(byTerm["seam"].Points), want)
+	}
+}
+
+func TestGetTrendsTermsSQLiteProjectFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	start := "2024-06-01T09:00:00Z"
+	insertSession(t, d, "s1", "proj-a", func(s *Session) {
+		s.StartedAt = &start
+		s.CreatedAt = start
+		s.MessageCount = 1
+		s.UserMessageCount = 1
+	})
+	insertSession(t, d, "s2", "proj-b", func(s *Session) {
+		s.StartedAt = &start
+		s.CreatedAt = start
+		s.MessageCount = 1
+		s.UserMessageCount = 1
+	})
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "seam", Timestamp: start, ContentLength: 4},
+		Message{SessionID: "s2", Ordinal: 0, Role: "user", Content: "seam", Timestamp: start, ContentLength: 4},
+	)
+	terms, err := ParseTrendTerms([]string{"seam"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
+		From: "2024-06-01", To: "2024-06-01", Timezone: "UTC", Project: "proj-a",
+	}, terms, "day")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
+		t.Fatalf("project-filtered total = %d, want 1", got)
+	}
+}
+
+func TestGetTrendsTermsSQLiteUsesMessageTimestampRange(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	start := "2024-05-01T09:00:00Z"
+	created := "2024-05-01T08:00:00Z"
+	insertSession(t, d, "s1", "proj-a", func(s *Session) {
+		s.StartedAt = &start
+		s.CreatedAt = created
+		s.MessageCount = 1
+		s.UserMessageCount = 1
+	})
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "seam", Timestamp: "2024-06-05T09:00:00Z", ContentLength: 4},
+	)
+	terms, err := ParseTrendTerms([]string{"seam"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
+		From: "2024-06-05", To: "2024-06-05", Timezone: "UTC",
+	}, terms, "day")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
+		t.Fatalf("message timestamp total = %d, want 1", got)
+	}
+}
+
+func TestGetTrendsTermsSQLiteTimestampFallback(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	start := "2024-06-05T09:00:00Z"
+	created := "2024-06-04T08:00:00Z"
+	insertSession(t, d, "s1", "proj-a", func(s *Session) {
+		s.StartedAt = &start
+		s.CreatedAt = created
+		s.MessageCount = 1
+		s.UserMessageCount = 1
+	})
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "seam", Timestamp: "not-a-time", ContentLength: 4},
+	)
+	terms, err := ParseTrendTerms([]string{"seam"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
+		From: "2024-06-05", To: "2024-06-05", Timezone: "UTC",
+	}, terms, "day")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
+		t.Fatalf("fallback timestamp total = %d, want 1", got)
+	}
+}
+
+func TestGetTrendsTermsSQLiteExcludesLegacySystemPrefixes(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	start := "2024-06-01T09:00:00Z"
+	insertSession(t, d, "s1", "proj-a", func(s *Session) {
+		s.StartedAt = &start
+		s.CreatedAt = start
+		s.MessageCount = 2
+		s.UserMessageCount = 2
+	})
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: SystemMsgPrefixes[0] + " seam", Timestamp: start, ContentLength: 40},
+		Message{SessionID: "s1", Ordinal: 1, Role: "user", Content: "seam", Timestamp: start, ContentLength: 4},
+	)
+	terms, err := ParseTrendTerms([]string{"seam"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
+		From: "2024-06-01", To: "2024-06-01", Timezone: "UTC",
+	}, terms, "day")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
+		t.Fatalf("system-prefix-filtered total = %d, want 1", got)
+	}
+}
+
+func trendBucketDates(buckets []TrendBucket) []string {
+	dates := make([]string, len(buckets))
+	for i, bucket := range buckets {
+		dates[i] = bucket.Date
+	}
+	return dates
+}
+
+func trendBucketMessageCounts(buckets []TrendBucket) []int {
+	counts := make([]int, len(buckets))
+	for i, bucket := range buckets {
+		counts[i] = bucket.MessageCount
+	}
+	return counts
+}
+
+func trendSeriesByTerm(series []TrendSeries) map[string]TrendSeries {
+	byTerm := make(map[string]TrendSeries, len(series))
+	for _, entry := range series {
+		byTerm[entry.Term] = entry
+	}
+	return byTerm
+}
+
+func trendPointCounts(points []TrendPoint) []int {
+	counts := make([]int, len(points))
+	for i, point := range points {
+		counts[i] = point.Count
+	}
+	return counts
+}

--- a/internal/db/trends_test.go
+++ b/internal/db/trends_test.go
@@ -266,6 +266,67 @@ func TestGetTrendsTermsSQLiteUsesMessageTimestampRange(t *testing.T) {
 	}
 }
 
+func TestGetTrendsTermsSQLiteDoesNotFilterBySessionTimestamp(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	start := "not-a-time"
+	insertSession(t, d, "s1", "proj-a", func(s *Session) {
+		s.StartedAt = &start
+		s.MessageCount = 1
+		s.UserMessageCount = 1
+	})
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "seam", Timestamp: "2024-06-05T09:00:00Z", ContentLength: 4},
+	)
+	terms, err := ParseTrendTerms([]string{"seam"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
+		From: "2024-06-05", To: "2024-06-05", Timezone: "UTC",
+	}, terms, "day")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
+		t.Fatalf("message timestamp total = %d, want 1", got)
+	}
+}
+
+func TestGetTrendsTermsSQLiteAppliesDayAndHourToMessageTimestamp(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	start := "2024-06-04T08:00:00Z"
+	insertSession(t, d, "s1", "proj-a", func(s *Session) {
+		s.StartedAt = &start
+		s.MessageCount = 2
+		s.UserMessageCount = 2
+	})
+	insertMessages(t, d,
+		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "seam", Timestamp: "2024-06-05T09:00:00Z", ContentLength: 4},
+		Message{SessionID: "s1", Ordinal: 1, Role: "user", Content: "seam", Timestamp: "2024-06-05T10:00:00Z", ContentLength: 4},
+	)
+	terms, err := ParseTrendTerms([]string{"seam"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dow := 2
+	hour := 9
+	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
+		From:      "2024-06-05",
+		To:        "2024-06-05",
+		Timezone:  "UTC",
+		DayOfWeek: &dow,
+		Hour:      &hour,
+	}, terms, "day")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
+		t.Fatalf("hour-filtered message total = %d, want 1", got)
+	}
+}
+
 func TestGetTrendsTermsSQLiteTimestampFallback(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -97,16 +97,38 @@ func buildAnalyticsWhere(
 	dateCol string,
 	pb *paramBuilder,
 ) string {
+	return buildAnalyticsWhereWithDate(f, dateCol, pb, true)
+}
+
+// buildAnalyticsWhereWithoutDate returns common analytics
+// predicates without adding session date bounds. Trends uses
+// this because date, day, and hour filters are evaluated
+// against message timestamps instead of session timestamps.
+func buildAnalyticsWhereWithoutDate(
+	f db.AnalyticsFilter,
+	pb *paramBuilder,
+) string {
+	return buildAnalyticsWhereWithDate(f, "", pb, false)
+}
+
+func buildAnalyticsWhereWithDate(
+	f db.AnalyticsFilter,
+	dateCol string,
+	pb *paramBuilder,
+	includeDate bool,
+) string {
 	preds := []string{
 		"message_count > 0",
 		"relationship_type NOT IN ('subagent', 'fork')",
 		"deleted_at IS NULL",
 	}
-	utcFrom, utcTo := analyticsUTCRange(f)
-	preds = append(preds,
-		dateCol+" >= "+pb.add(utcFrom)+"::timestamptz")
-	preds = append(preds,
-		dateCol+" <= "+pb.add(utcTo)+"::timestamptz")
+	if includeDate {
+		utcFrom, utcTo := analyticsUTCRange(f)
+		preds = append(preds,
+			dateCol+" >= "+pb.add(utcFrom)+"::timestamptz")
+		preds = append(preds,
+			dateCol+" <= "+pb.add(utcTo)+"::timestamptz")
+	}
 	if f.Machine != "" {
 		preds = append(preds,
 			"machine = "+pb.add(f.Machine))

--- a/internal/postgres/trends.go
+++ b/internal/postgres/trends.go
@@ -1,0 +1,118 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+func (s *Store) GetTrendsTerms(
+	ctx context.Context,
+	f db.AnalyticsFilter,
+	terms []db.TrendTermInput,
+	granularity string,
+) (db.TrendsTermsResponse, error) {
+	if granularity == "" {
+		granularity = "week"
+	}
+	loc := analyticsLocation(f)
+	buckets := db.TrendBucketRange(f.From, f.To, granularity)
+	bucketIndex := trendBucketIndex(buckets)
+	counts := make([][]int, len(terms))
+	for i := range counts {
+		counts[i] = make([]int, len(buckets))
+	}
+	messageCounts := make([]int, len(buckets))
+
+	sessionFilter := f
+	sessionFilter.From = ""
+	sessionFilter.To = ""
+	pb := &paramBuilder{}
+	where := buildAnalyticsWhere(
+		sessionFilter,
+		"COALESCE(s.started_at, s.created_at)",
+		pb,
+	)
+	query := `SELECT m.content,
+			COALESCE(TO_CHAR(m.timestamp AT TIME ZONE 'UTC',
+				'YYYY-MM-DD"T"HH24:MI:SS"Z"'), ''),
+			COALESCE(TO_CHAR(s.started_at AT TIME ZONE 'UTC',
+				'YYYY-MM-DD"T"HH24:MI:SS"Z"'), ''),
+			COALESCE(TO_CHAR(s.created_at AT TIME ZONE 'UTC',
+				'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '')
+		FROM sessions s
+		JOIN messages m ON m.session_id = s.id
+		WHERE ` + where + `
+			AND m.role IN ('user', 'assistant')
+			AND m.is_system = FALSE
+			AND ` + db.SystemPrefixSQL("m.content", "m.role")
+
+	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+	if err != nil {
+		return db.TrendsTermsResponse{}, fmt.Errorf("querying trends terms: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var content, msgTS, startedAt, createdAt string
+		if err := rows.Scan(
+			&content, &msgTS, &startedAt, &createdAt,
+		); err != nil {
+			return db.TrendsTermsResponse{}, fmt.Errorf("scanning trends term row: %w", err)
+		}
+		msgTime, ok := trendMessageLocalTime(msgTS, startedAt, createdAt, loc)
+		if !ok {
+			continue
+		}
+		if f.HasTimeFilter() && !matchesTimeFilter(f, msgTime) {
+			continue
+		}
+		msgDate := msgTime.Format("2006-01-02")
+		if !inDateRange(msgDate, f.From, f.To) {
+			continue
+		}
+		bucketDate := db.TrendBucketDate(msgTime, loc, granularity)
+		bucket, ok := bucketIndex[bucketDate]
+		if !ok {
+			continue
+		}
+		messageCounts[bucket]++
+		for i, term := range terms {
+			count := db.CountTrendOccurrences(content, term)
+			if count > 0 {
+				counts[i][bucket] += count
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return db.TrendsTermsResponse{}, fmt.Errorf("iterating trends term rows: %w", err)
+	}
+
+	return db.BuildTrendsTermsResponse(
+		f.From, f.To, granularity, buckets, terms, counts, messageCounts,
+	), nil
+}
+
+func trendMessageLocalTime(
+	messageTS string,
+	startedAt string,
+	createdAt string,
+	loc *time.Location,
+) (time.Time, bool) {
+	for _, ts := range []string{messageTS, startedAt, createdAt} {
+		if t, ok := localTime(ts, loc); ok {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func trendBucketIndex(buckets []db.TrendBucket) map[string]int {
+	index := make(map[string]int, len(buckets))
+	for i, bucket := range buckets {
+		index[bucket.Date] = i
+	}
+	return index
+}

--- a/internal/postgres/trends.go
+++ b/internal/postgres/trends.go
@@ -29,12 +29,10 @@ func (s *Store) GetTrendsTerms(
 	sessionFilter := f
 	sessionFilter.From = ""
 	sessionFilter.To = ""
+	sessionFilter.DayOfWeek = nil
+	sessionFilter.Hour = nil
 	pb := &paramBuilder{}
-	where := buildAnalyticsWhere(
-		sessionFilter,
-		"COALESCE(s.started_at, s.created_at)",
-		pb,
-	)
+	where := buildAnalyticsWhereWithoutDate(sessionFilter, pb)
 	query := `SELECT m.content,
 			COALESCE(TO_CHAR(m.timestamp AT TIME ZONE 'UTC',
 				'YYYY-MM-DD"T"HH24:MI:SS"Z"'), ''),

--- a/internal/postgres/trends_pgtest_test.go
+++ b/internal/postgres/trends_pgtest_test.go
@@ -1,0 +1,107 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+func TestStoreGetTrendsTerms(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_trends_terms_test")
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES (
+			'trends-pg-001', 'test-machine', 'alpha', 'claude',
+			'2024-06-01T09:00:00Z'::timestamptz,
+			'2024-06-01T10:00:00Z'::timestamptz,
+			3, 2
+		)`)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, is_system
+		) VALUES
+			('trends-pg-001', 0, 'user', 'load bearing seam',
+			 '2024-06-01T09:00:00Z'::timestamptz, 17, FALSE),
+			('trends-pg-001', 1, 'assistant', 'load-bearing seams seam',
+			 '2024-06-08T09:00:00Z'::timestamptz, 23, FALSE),
+			('trends-pg-001', 2, 'user', 'seam system',
+			 '2024-06-08T09:00:00Z'::timestamptz, 11, TRUE)`)
+	if err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+	terms, err := db.ParseTrendTerms([]string{"load bearing | load-bearing", "seam"})
+	if err != nil {
+		t.Fatalf("ParseTrendTerms: %v", err)
+	}
+	got, err := store.GetTrendsTerms(ctx, db.AnalyticsFilter{
+		From: "2024-06-01", To: "2024-06-09", Timezone: "UTC",
+	}, terms, "week")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if want := []string{"2024-05-27", "2024-06-03"}; !slices.Equal(trendBucketDates(got.Buckets), want) {
+		t.Fatalf("bucket dates = %#v, want %#v", trendBucketDates(got.Buckets), want)
+	}
+	if want := []int{1, 1}; !slices.Equal(trendBucketMessageCounts(got.Buckets), want) {
+		t.Fatalf("bucket message counts = %#v, want %#v", trendBucketMessageCounts(got.Buckets), want)
+	}
+	if got.MessageCount != 2 {
+		t.Fatalf("message count = %d, want 2", got.MessageCount)
+	}
+	byTerm := trendSeriesByTerm(got.Series)
+	if got := byTerm["load bearing"].Total; got != 2 {
+		t.Fatalf("load bearing total = %d, want 2", got)
+	}
+	if got := byTerm["seam"].Total; got != 3 {
+		t.Fatalf("seam total = %d, want 3", got)
+	}
+	if want := []int{1, 1}; !slices.Equal(trendPointCounts(byTerm["load bearing"].Points), want) {
+		t.Fatalf("load bearing points = %#v, want %#v", trendPointCounts(byTerm["load bearing"].Points), want)
+	}
+	if want := []int{1, 2}; !slices.Equal(trendPointCounts(byTerm["seam"].Points), want) {
+		t.Fatalf("seam points = %#v, want %#v", trendPointCounts(byTerm["seam"].Points), want)
+	}
+}
+
+func trendBucketDates(buckets []db.TrendBucket) []string {
+	dates := make([]string, len(buckets))
+	for i, bucket := range buckets {
+		dates[i] = bucket.Date
+	}
+	return dates
+}
+
+func trendBucketMessageCounts(buckets []db.TrendBucket) []int {
+	counts := make([]int, len(buckets))
+	for i, bucket := range buckets {
+		counts[i] = bucket.MessageCount
+	}
+	return counts
+}
+
+func trendSeriesByTerm(series []db.TrendSeries) map[string]db.TrendSeries {
+	byTerm := make(map[string]db.TrendSeries, len(series))
+	for _, entry := range series {
+		byTerm[entry.Term] = entry
+	}
+	return byTerm
+}
+
+func trendPointCounts(points []db.TrendPoint) []int {
+	counts := make([]int, len(points))
+	for i, point := range points {
+		counts[i] = point.Count
+	}
+	return counts
+}

--- a/internal/postgres/trends_pgtest_test.go
+++ b/internal/postgres/trends_pgtest_test.go
@@ -74,6 +74,57 @@ func TestStoreGetTrendsTerms(t *testing.T) {
 	}
 }
 
+func TestStoreGetTrendsTermsUsesMessageTimestampFilters(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_trends_terms_message_filters_test")
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES (
+			'trends-pg-message-filters-001', 'test-machine',
+			'alpha', 'claude',
+			'2024-06-04T08:00:00Z'::timestamptz, 2, 2
+		)`)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, is_system
+		) VALUES
+			('trends-pg-message-filters-001', 0, 'user', 'seam',
+			 '2024-06-05T09:00:00Z'::timestamptz, 4, FALSE),
+			('trends-pg-message-filters-001', 1, 'user', 'seam',
+			 '2024-06-05T10:00:00Z'::timestamptz, 4, FALSE)`)
+	if err != nil {
+		t.Fatalf("insert messages: %v", err)
+	}
+	terms, err := db.ParseTrendTerms([]string{"seam"})
+	if err != nil {
+		t.Fatalf("ParseTrendTerms: %v", err)
+	}
+	dow := 2
+	hour := 9
+	got, err := store.GetTrendsTerms(ctx, db.AnalyticsFilter{
+		From:      "2024-06-05",
+		To:        "2024-06-05",
+		Timezone:  "UTC",
+		DayOfWeek: &dow,
+		Hour:      &hour,
+	}, terms, "day")
+	if err != nil {
+		t.Fatalf("GetTrendsTerms: %v", err)
+	}
+	if got.MessageCount != 1 {
+		t.Fatalf("message count = %d, want 1", got.MessageCount)
+	}
+	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
+		t.Fatalf("message timestamp filtered total = %d, want 1", got)
+	}
+}
+
 func trendBucketDates(buckets []db.TrendBucket) []string {
 	dates := make([]string, len(buckets))
 	for i, bucket := range buckets {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -234,6 +234,7 @@ func (s *Server) routes() {
 	s.mux.Handle("GET /api/v1/analytics/tools", s.withTimeout(s.handleAnalyticsTools))
 	s.mux.Handle("GET /api/v1/analytics/top-sessions", s.withTimeout(s.handleAnalyticsTopSessions))
 	s.mux.Handle("GET /api/v1/analytics/signals", s.withTimeout(s.handleAnalyticsSignals))
+	s.mux.Handle("GET /api/v1/trends/terms", s.withTimeout(s.handleTrendsTerms))
 
 	s.mux.Handle("GET /api/v1/usage/summary",
 		s.withTimeout(s.handleUsageSummary))

--- a/internal/server/trends.go
+++ b/internal/server/trends.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+func (s *Server) handleTrendsTerms(
+	w http.ResponseWriter, r *http.Request,
+) {
+	f, ok := parseAnalyticsFilter(w, r)
+	if !ok {
+		return
+	}
+
+	granularity := r.URL.Query().Get("granularity")
+	if granularity == "" {
+		granularity = "week"
+	}
+	switch granularity {
+	case "day", "week", "month":
+	default:
+		writeError(w, http.StatusBadRequest,
+			"invalid granularity: must be day, week, or month")
+		return
+	}
+
+	terms, err := db.ParseTrendTerms(r.URL.Query()["term"])
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	result, err := s.db.GetTrendsTerms(
+		r.Context(), f, terms, granularity,
+	)
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		log.Printf("trends terms error: %v", err)
+		writeError(w, http.StatusInternalServerError,
+			"internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}

--- a/internal/server/trends_test.go
+++ b/internal/server/trends_test.go
@@ -1,0 +1,126 @@
+package server_test
+
+import (
+	"net/http"
+	"net/url"
+	"slices"
+	"testing"
+
+	"github.com/wesm/agentsview/internal/db"
+)
+
+func TestTrendsTermsEndpoint(t *testing.T) {
+	te := setup(t)
+	start := "2024-06-01T09:00:00Z"
+	te.seedSession(t, "s1", "alpha", 2, func(s *db.Session) {
+		s.StartedAt = &start
+		s.EndedAt = &start
+	})
+	te.seedMessages(t, "s1", 2, func(i int, m *db.Message) {
+		m.Timestamp = "2024-06-01T09:00:00Z"
+		if i == 0 {
+			m.Content = "load bearing seam"
+		}
+		if i == 1 {
+			m.Content = "load-bearing seams"
+		}
+		m.ContentLength = len(m.Content)
+	})
+
+	w := te.get(t, trendsURL(url.Values{
+		"from":        {"2024-06-01"},
+		"to":          {"2024-06-02"},
+		"timezone":    {"UTC"},
+		"granularity": {"week"},
+		"term":        {"load bearing | load-bearing", "seam"},
+	}))
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[db.TrendsTermsResponse](t, w)
+	if want := []string{"2024-05-27"}; !slices.Equal(trendBucketDates(resp.Buckets), want) {
+		t.Fatalf("bucket dates = %#v, want %#v", trendBucketDates(resp.Buckets), want)
+	}
+	byTerm := trendSeriesByTerm(resp.Series)
+	if got := byTerm["load bearing"].Total; got != 2 {
+		t.Fatalf("load bearing total = %d, want 2", got)
+	}
+	if got := byTerm["seam"].Total; got != 2 {
+		t.Fatalf("seam total = %d, want 2", got)
+	}
+}
+
+func TestTrendsTermsValidation(t *testing.T) {
+	te := setup(t)
+
+	t.Run("missing term", func(t *testing.T) {
+		w := te.get(t, trendsURL(url.Values{
+			"from": {"2024-06-01"},
+			"to":   {"2024-06-02"},
+		}))
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("invalid granularity", func(t *testing.T) {
+		w := te.get(t, trendsURL(url.Values{
+			"from":        {"2024-06-01"},
+			"to":          {"2024-06-02"},
+			"granularity": {"hour"},
+			"term":        {"seam"},
+		}))
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+}
+
+func TestTrendsTermsProjectFilter(t *testing.T) {
+	te := setup(t)
+	start := "2024-06-01T09:00:00Z"
+	for _, seeded := range []struct {
+		id      string
+		project string
+	}{
+		{"s1", "alpha"},
+		{"s2", "beta"},
+	} {
+		te.seedSession(t, seeded.id, seeded.project, 1, func(s *db.Session) {
+			s.StartedAt = &start
+			s.EndedAt = &start
+		})
+		te.seedMessages(t, seeded.id, 1, func(_ int, m *db.Message) {
+			m.Timestamp = start
+			m.Content = "seam"
+			m.ContentLength = len(m.Content)
+		})
+	}
+
+	w := te.get(t, trendsURL(url.Values{
+		"from":     {"2024-06-01"},
+		"to":       {"2024-06-01"},
+		"timezone": {"UTC"},
+		"project":  {"alpha"},
+		"term":     {"seam"},
+	}))
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[db.TrendsTermsResponse](t, w)
+	if got := trendSeriesByTerm(resp.Series)["seam"].Total; got != 1 {
+		t.Fatalf("project-filtered total = %d, want 1", got)
+	}
+}
+
+func trendsURL(q url.Values) string {
+	return "/api/v1/trends/terms?" + q.Encode()
+}
+
+func trendBucketDates(buckets []db.TrendBucket) []string {
+	dates := make([]string, len(buckets))
+	for i, bucket := range buckets {
+		dates[i] = bucket.Date
+	}
+	return dates
+}
+
+func trendSeriesByTerm(series []db.TrendSeries) map[string]db.TrendSeries {
+	byTerm := make(map[string]db.TrendSeries, len(series))
+	for _, entry := range series {
+		byTerm[entry.Term] = entry
+	}
+	return byTerm
+}


### PR DESCRIPTION
## Summary
- Add a Trends page for ad hoc term-frequency line charts over session history.
- Add backend term parsing/counting and SQLite/PostgreSQL/API support for repeated term queries.
- Add normalization, refresh/loading states, term totals, and distinct chart colors for the Trends UI.