### PR TITLE
fix(update): atomic binary swap to avoid partial state during update

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -285,34 +285,60 @@ func installFromArchiveTo(
 }
 
 // installBinaryTo replaces the binary at dstPath with the one
-// at srcPath using a rename-then-copy pattern that works on
-// all platforms including Windows.
+// at srcPath. The new binary is staged in a sibling tmp file
+// with the executable mode bit set, then atomically renamed
+// into place. This avoids a window in which a consumer running
+// agentsview concurrently with the update would observe a
+// partial or non-executable file at dstPath.
 func installBinaryTo(srcPath, dstPath string) error {
 	backupPath := dstPath + ".old"
+	tmpPath := dstPath + ".new"
 
-	// Remove stale backup from a previous update.
+	// Clean up leftovers from a prior failed update so they
+	// don't interfere with the renames below.
 	os.Remove(backupPath)
+	os.Remove(tmpPath)
 
+	installed := false
+	defer func() {
+		if !installed {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	// Stage the new binary at tmpPath with executable mode set
+	// BEFORE touching the live binary at dstPath.
+	if err := copyFile(srcPath, tmpPath); err != nil {
+		return fmt.Errorf("install: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0o755); err != nil {
+		return fmt.Errorf("chmod: %w", err)
+	}
+
+	// Move the existing binary aside before installing. Windows
+	// requires this because os.Rename cannot replace a running
+	// binary; on Unix it provides a rollback target.
+	haveExisting := false
 	if _, err := os.Stat(dstPath); err == nil {
 		if err := os.Rename(dstPath, backupPath); err != nil {
 			return fmt.Errorf("backup: %w", err)
 		}
+		haveExisting = true
 	}
 
-	if err := copyFile(srcPath, dstPath); err != nil {
-		if restoreErr := os.Rename(backupPath, dstPath); restoreErr != nil {
-			return fmt.Errorf(
-				"install: %w (rollback also failed: %v)",
-				err, restoreErr,
-			)
+	if err := os.Rename(tmpPath, dstPath); err != nil {
+		if haveExisting {
+			if rbErr := os.Rename(backupPath, dstPath); rbErr != nil {
+				return fmt.Errorf(
+					"install: %w (rollback also failed: %v)",
+					err, rbErr,
+				)
+			}
 		}
 		return fmt.Errorf("install: %w", err)
 	}
 
-	if err := os.Chmod(dstPath, 0o755); err != nil {
-		return fmt.Errorf("chmod: %w", err)
-	}
-
+	installed = true
 	os.Remove(backupPath)
 	return nil
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -286,10 +286,14 @@ func installFromArchiveTo(
 
 // installBinaryTo replaces the binary at dstPath with the one
 // at srcPath. The new binary is staged in a sibling tmp file
-// with the executable mode bit set, then atomically renamed
-// into place. This avoids a window in which a consumer running
-// agentsview concurrently with the update would observe a
-// partial or non-executable file at dstPath.
+// with the executable mode bit set, then renamed into place.
+//
+// On Unix os.Rename atomically replaces dstPath in a single
+// syscall, so concurrent readers always see one of the two
+// binaries — never a missing or partial file. On Windows the
+// existing binary must be moved aside first because os.Rename
+// cannot replace a running executable; this leaves dstPath
+// briefly missing between the two renames.
 func installBinaryTo(srcPath, dstPath string) error {
 	backupPath := dstPath + ".old"
 	tmpPath := dstPath + ".new"
@@ -315,19 +319,17 @@ func installBinaryTo(srcPath, dstPath string) error {
 		return fmt.Errorf("chmod: %w", err)
 	}
 
-	// Move the existing binary aside before installing. Windows
-	// requires this because os.Rename cannot replace a running
-	// binary; on Unix it provides a rollback target.
-	haveExisting := false
-	if _, err := os.Stat(dstPath); err == nil {
-		if err := os.Rename(dstPath, backupPath); err != nil {
-			return fmt.Errorf("backup: %w", err)
+	movedAside := false
+	if runtime.GOOS == "windows" {
+		aside, err := movePreviousAside(dstPath, backupPath)
+		if err != nil {
+			return err
 		}
-		haveExisting = true
+		movedAside = aside
 	}
 
 	if err := os.Rename(tmpPath, dstPath); err != nil {
-		if haveExisting {
+		if movedAside {
 			if rbErr := os.Rename(backupPath, dstPath); rbErr != nil {
 				return fmt.Errorf(
 					"install: %w (rollback also failed: %v)",
@@ -341,6 +343,19 @@ func installBinaryTo(srcPath, dstPath string) error {
 	installed = true
 	os.Remove(backupPath)
 	return nil
+}
+
+// movePreviousAside renames an existing dstPath to backupPath.
+// Used on Windows where os.Rename cannot replace a running
+// executable. Returns true if dstPath was moved.
+func movePreviousAside(dstPath, backupPath string) (bool, error) {
+	if _, err := os.Stat(dstPath); err != nil {
+		return false, nil
+	}
+	if err := os.Rename(dstPath, backupPath); err != nil {
+		return false, fmt.Errorf("backup: %w", err)
+	}
+	return true, nil
 }
 
 func fetchLatestRelease() (*Release, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -140,6 +141,95 @@ func TestExtractTarGz(t *testing.T) {
 	}
 	if string(content) != "binary-content" {
 		t.Errorf("got %q, want %q", content, "binary-content")
+	}
+}
+
+func TestInstallBinaryToSetsExecutableMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode bits not meaningful on Windows")
+	}
+
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "agentsview")
+	dstPath := filepath.Join(dstDir, "agentsview")
+
+	if err := os.WriteFile(srcPath, []byte("binary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installBinaryTo(srcPath, dstPath); err != nil {
+		t.Fatalf("installBinaryTo: %v", err)
+	}
+
+	info, err := os.Stat(dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Errorf("dstPath mode = %o, want 0755", got)
+	}
+}
+
+func TestInstallBinaryToPreservesOnSourceMissing(t *testing.T) {
+	dstDir := t.TempDir()
+	dstPath := filepath.Join(dstDir, "agentsview")
+
+	if err := os.WriteFile(
+		dstPath, []byte("original"), 0o755,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	missingSrc := filepath.Join(t.TempDir(), "does-not-exist")
+
+	if err := installBinaryTo(missingSrc, dstPath); err == nil {
+		t.Fatal("expected error from missing source")
+	}
+
+	got, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("dstPath should still exist: %v", err)
+	}
+	if string(got) != "original" {
+		t.Errorf("dstPath content = %q, want %q", got, "original")
+	}
+
+	if _, err := os.Stat(dstPath + ".new"); !os.IsNotExist(err) {
+		t.Error("staging .new file should not be left behind")
+	}
+	if _, err := os.Stat(dstPath + ".old"); !os.IsNotExist(err) {
+		t.Error("backup .old file should not be left behind")
+	}
+}
+
+func TestInstallBinaryToRemovesStaleStagingFile(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "agentsview")
+	dstPath := filepath.Join(dstDir, "agentsview")
+
+	if err := os.WriteFile(srcPath, []byte("new-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dstPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stagingPath := dstPath + ".new"
+	if err := os.WriteFile(
+		stagingPath, []byte("stale-staging"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installBinaryTo(srcPath, dstPath); err != nil {
+		t.Fatalf("installBinaryTo: %v", err)
+	}
+
+	if _, err := os.Stat(stagingPath); !os.IsNotExist(err) {
+		t.Errorf(
+			"stale staging file should be removed, got err=%v", err,
+		)
 	}
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"testing"
 )
 
@@ -200,6 +201,77 @@ func TestInstallBinaryToPreservesOnSourceMissing(t *testing.T) {
 	}
 	if _, err := os.Stat(dstPath + ".old"); !os.IsNotExist(err) {
 		t.Error("backup .old file should not be left behind")
+	}
+}
+
+func TestInstallBinaryToNeverMissingDuringUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip(
+			"Windows must rename the running binary aside; " +
+				"a brief missing window is unavoidable",
+		)
+	}
+
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "agentsview")
+	dstPath := filepath.Join(dstDir, "agentsview")
+
+	if err := os.WriteFile(srcPath, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dstPath, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var observations, missing atomic.Uint64
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, err := os.Stat(dstPath); err != nil &&
+				os.IsNotExist(err) {
+				missing.Add(1)
+			}
+			observations.Add(1)
+		}
+	}()
+
+	const iterations = 1000
+	for i := range iterations {
+		if err := installBinaryTo(srcPath, dstPath); err != nil {
+			close(stop)
+			<-done
+			t.Fatalf("install iteration %d: %v", i, err)
+		}
+	}
+
+	close(stop)
+	<-done
+
+	t.Logf(
+		"iterations=%d observations=%d missing=%d",
+		iterations, observations.Load(), missing.Load(),
+	)
+
+	if observations.Load() < 1000 {
+		t.Skipf(
+			"observer ran only %d times, test inconclusive",
+			observations.Load(),
+		)
+	}
+	if missing.Load() > 0 {
+		t.Errorf(
+			"dstPath observed missing %d times during install",
+			missing.Load(),
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

`installBinaryTo` previously wrote the new binary directly to `dstPath` and `chmod`'d it afterward, leaving a multi-hundred-millisecond window in which `dstPath` existed but was either partially written or had mode 0644. Consumers running `agentsview` concurrently with the update (e.g. vibepulse) could spawn against a truncated or non-executable file and surface errors that persisted in the menu bar until the next scheduled refresh.

The new binary is now staged at `dstPath + ".new"` with the executable bit set, then atomically renamed into place. The existing binary is still moved to `.old` first so Windows can replace its running executable. Stale `.new` and `.old` artifacts from any prior failed update are cleaned up on entry, and the staging file is removed on any error path via defer.