### PR TITLE
ci: retry msys2/setup-msys2 once on transient failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,17 @@ jobs:
 
       - name: Setup MinGW (Windows)
         if: runner.os == 'Windows'
+        id: setup_mingw
+        continue-on-error: true
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: mingw-w64-x86_64-gcc
+          path-type: inherit
+
+      - name: Setup MinGW (Windows, retry on transient failure)
+        if: runner.os == 'Windows' && steps.setup_mingw.outcome == 'failure'
         uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2
         with:
           msystem: MINGW64

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -161,6 +161,17 @@ jobs:
           node-version: "24"
 
       - name: Setup MinGW
+        id: setup_mingw
+        continue-on-error: true
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2
+        with:
+          msystem: MINGW64
+          update: false
+          install: mingw-w64-x86_64-gcc
+          path-type: inherit
+
+      - name: Setup MinGW (retry on transient failure)
+        if: steps.setup_mingw.outcome == 'failure'
         uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2
         with:
           msystem: MINGW64


### PR DESCRIPTION
## Summary

The Windows job in the v0.25.0 desktop release ([run 24920832890](https://github.com/wesm/agentsview/actions/runs/24920832890)) failed at `Setup MinGW`: the MSYS2 download terminated ~0.26s after `Downloading MSYS2...` with no error in the log. CI on the exact same revision succeeded with the identical step a minute earlier, and a re-run of the failed job also succeeded — so the failure was a transient network/mirror flake.

Because `desktop-release.yml` is triggered by a tag push, a flake here blocks the whole release (see #400).

This wraps the `msys2/setup-msys2` step in both `desktop-release.yml` and `ci.yml` with a single retry:

- First attempt: `continue-on-error: true`, captures `outcome` via a step `id`.
- Second attempt: only runs `if: steps.setup_mingw.outcome == 'failure'`.

No new action dependency. The weekly `msys2-update-check.yml` workflow still surfaces persistent toolchain drift.