### PR TITLE
fix(parser): surface Claude queued_command attachments

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,11 +27,14 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 19: Copilot parser now filters synthetic skill
-// context user messages (source "skill-*" or content
-// starting with "<skill-context"), so full resync drops
-// injected skill definitions from stored transcripts and
-// first_message.
+// Bumped to 20: Claude parser now surfaces queued_command
+// attachment entries (user messages typed mid-tool-call) as
+// real user messages with source_subtype="queued_command".
+// Sessions previously parsed by older versions had these
+// dropped, so a full resync is required to recover them.
+//
+// (19: Copilot parser now filters synthetic skill context
+// user messages.)
 //
 // (18: Claude parser now skips /clear and /effort
 // command envelopes when computing first_message, so sessions
@@ -41,7 +44,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 19
+const dataVersion = 20
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -43,6 +43,17 @@ type dagEntry struct {
 	timestamp  time.Time
 }
 
+// claudeQueuedCommand is a user message Claude Code persisted as
+// type=attachment with attachment.type=queued_command — i.e. a
+// prompt the user typed while a tool call was still running.
+// These records have no uuid/parentUuid, so we collect them out
+// of band and splice them into the message stream by timestamp
+// after DAG processing completes.
+type claudeQueuedCommand struct {
+	prompt    string
+	timestamp time.Time
+}
+
 // ParseClaudeSession parses a Claude Code JSONL session file.
 // Returns one or more ParseResult structs (multiple when forks
 // are detected in the uuid/parentUuid DAG).
@@ -65,6 +76,7 @@ func ParseClaudeSession(
 	// First pass: collect all valid lines with metadata.
 	var (
 		entries         = make([]dagEntry, 0)
+		queuedCommands  []claudeQueuedCommand
 		hasAnyUUID      bool
 		allHaveUUID     bool
 		parentSessionID string
@@ -147,6 +159,16 @@ func ParseClaudeSession(
 				if tuid != "" && agentID != "" {
 					subagentMap[tuid] = "agent-" + agentID
 				}
+			}
+			continue
+		}
+
+		// Collect queued_command attachments — user messages
+		// the user typed mid-tool-call. Other attachment types
+		// (e.g. task_reminder) are intentionally dropped.
+		if entryType == "attachment" {
+			if qc, ok := extractQueuedCommand(line); ok {
+				queuedCommands = append(queuedCommands, qc)
 			}
 			continue
 		}
@@ -234,21 +256,37 @@ func ParseClaudeSession(
 		isTruncated:     isTruncated,
 	}
 
+	var (
+		results  []ParseResult
+		parseErr error
+	)
 	// If all user/assistant entries have uuids, use DAG-aware processing.
 	if hasAnyUUID && allHaveUUID {
-		return parseDAG(
+		results, parseErr = parseDAG(
+			entries, sessionID, project, machine,
+			parentSessionID, fileInfo, subagentMap,
+			globalStart, globalEnd, meta,
+		)
+	} else {
+		// Fall back to linear processing.
+		results, parseErr = parseLinear(
 			entries, sessionID, project, machine,
 			parentSessionID, fileInfo, subagentMap,
 			globalStart, globalEnd, meta,
 		)
 	}
+	if parseErr != nil {
+		return nil, parseErr
+	}
 
-	// Fall back to linear processing.
-	return parseLinear(
-		entries, sessionID, project, machine,
-		parentSessionID, fileInfo, subagentMap,
-		globalStart, globalEnd, meta,
-	)
+	// Splice queued_command attachments into the main session
+	// by timestamp. Attachments have no uuid/parentUuid and so
+	// can't participate in DAG fork detection; they belong to
+	// the original conversation timeline (results[0]).
+	if len(queuedCommands) > 0 && len(results) > 0 {
+		results[0] = applyQueuedCommands(results[0], queuedCommands)
+	}
+	return results, nil
 }
 
 // ParseClaudeSessionFrom parses only new lines from a Claude
@@ -270,8 +308,9 @@ func ParseClaudeSessionFrom(
 	startOrdinal int,
 ) ([]ParsedMessage, time.Time, int64, error) {
 	var (
-		entries   []dagEntry
-		lineIndex = startOrdinal
+		entries        []dagEntry
+		queuedCommands []claudeQueuedCommand
+		lineIndex      = startOrdinal
 		// Track latest timestamp from all lines, including
 		// non-message events (progress, queue-operation) so
 		// callers can update ended_at even when no new
@@ -287,6 +326,12 @@ func ParseClaudeSessionFrom(
 				}
 			}
 			entryType := gjson.Get(line, "type").Str
+			if entryType == "attachment" {
+				if qc, ok := extractQueuedCommand(line); ok {
+					queuedCommands = append(queuedCommands, qc)
+				}
+				return
+			}
 			if entryType != "user" &&
 				entryType != "assistant" {
 				return
@@ -310,7 +355,7 @@ func ParseClaudeSessionFrom(
 		)
 	}
 
-	if len(entries) == 0 {
+	if len(entries) == 0 && len(queuedCommands) == 0 {
 		return nil, latestTS, consumed, nil
 	}
 
@@ -324,6 +369,16 @@ func ParseClaudeSessionFrom(
 	msgs, _, endedAt := extractMessagesFrom(
 		entries, startOrdinal,
 	)
+	if len(queuedCommands) > 0 {
+		msgs = mergeQueuedCommands(
+			msgs, queuedCommands, startOrdinal,
+		)
+		for _, qc := range queuedCommands {
+			if qc.timestamp.After(endedAt) {
+				endedAt = qc.timestamp
+			}
+		}
+	}
 	// Use the latest timestamp from all lines (including
 	// non-message events) if it's later than what
 	// extractMessagesFrom found.
@@ -716,6 +771,119 @@ func parseDAG(
 	}
 
 	return results, nil
+}
+
+// extractQueuedCommand parses a Claude Code attachment entry and
+// returns the queued_command prompt if present. Other attachment
+// types (e.g. task_reminder) return ok=false. Whitespace-only or
+// empty prompts also return false to match the parser's general
+// "skip empty user content" behavior.
+func extractQueuedCommand(line string) (claudeQueuedCommand, bool) {
+	if gjson.Get(line, "attachment.type").Str != "queued_command" {
+		return claudeQueuedCommand{}, false
+	}
+	prompt := gjson.Get(line, "attachment.prompt").Str
+	if strings.TrimSpace(prompt) == "" {
+		return claudeQueuedCommand{}, false
+	}
+	return claudeQueuedCommand{
+		prompt:    prompt,
+		timestamp: extractTimestamp(line),
+	}, true
+}
+
+// applyQueuedCommands splices queued_command attachments into a
+// ParseResult by timestamp, renumbers ordinals, and refreshes
+// derived session counts. Token aggregates are unchanged because
+// queued_command entries have no usage data. Callers must ensure
+// queued is non-empty.
+func applyQueuedCommands(
+	r ParseResult, queued []claudeQueuedCommand,
+) ParseResult {
+	merged := mergeQueuedCommands(r.Messages, queued, 0)
+	firstMsg, userCount := firstMessageAndUserCount(merged)
+	r.Session.FirstMessage = firstMsg
+	r.Session.UserMessageCount = userCount
+	r.Session.MessageCount = len(merged)
+	for _, qc := range queued {
+		if qc.timestamp.After(r.Session.EndedAt) {
+			r.Session.EndedAt = qc.timestamp
+		}
+		if !qc.timestamp.IsZero() &&
+			(r.Session.StartedAt.IsZero() ||
+				qc.timestamp.Before(r.Session.StartedAt)) {
+			r.Session.StartedAt = qc.timestamp
+		}
+	}
+	r.Messages = merged
+	return r
+}
+
+// mergeQueuedCommands merges queued_command entries into messages
+// in timestamp order and renumbers ordinals starting at the given
+// offset. Both inputs are assumed to already be in chronological
+// order. Equal timestamps preserve the original message before the
+// queued command (queued commands always follow the entry that
+// triggered the tool call).
+func mergeQueuedCommands(
+	messages []ParsedMessage,
+	queued []claudeQueuedCommand,
+	startOrdinal int,
+) []ParsedMessage {
+	out := make([]ParsedMessage, 0, len(messages)+len(queued))
+	i, j := 0, 0
+	for i < len(messages) && j < len(queued) {
+		if queuedBefore(queued[j], messages[i]) {
+			out = append(out, queuedCommandMessage(queued[j]))
+			j++
+		} else {
+			out = append(out, messages[i])
+			i++
+		}
+	}
+	for ; i < len(messages); i++ {
+		out = append(out, messages[i])
+	}
+	for ; j < len(queued); j++ {
+		out = append(out, queuedCommandMessage(queued[j]))
+	}
+	for k := range out {
+		out[k].Ordinal = startOrdinal + k
+	}
+	return out
+}
+
+// queuedBefore reports whether a queued_command should sort before
+// a regular message. Zero timestamps on either side are treated
+// conservatively: a zero-timestamp message keeps its original
+// position relative to queued items.
+func queuedBefore(
+	q claudeQueuedCommand, m ParsedMessage,
+) bool {
+	if q.timestamp.IsZero() {
+		return false
+	}
+	if m.Timestamp.IsZero() {
+		return false
+	}
+	return q.timestamp.Before(m.Timestamp)
+}
+
+// queuedCommandMessage builds a ParsedMessage from a collected
+// queued_command attachment. Role stays user (the user typed
+// this) and IsSystem is false so it counts as a real user turn;
+// SourceSubtype lets the UI distinguish it from inline prompts.
+func queuedCommandMessage(
+	q claudeQueuedCommand,
+) ParsedMessage {
+	return ParsedMessage{
+		Role:          RoleUser,
+		Content:       q.prompt,
+		Timestamp:     q.timestamp,
+		ContentLength: len(q.prompt),
+		SourceType:    "user",
+		SourceSubtype: "queued_command",
+	}
 }
 
 // collapseStreamingDuplicates removes consecutive assistant entries

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -258,6 +258,118 @@ func TestParseClaudeSession_SkippedMessages(t *testing.T) {
 	})
 }
 
+func TestParseClaudeSession_QueuedCommand(t *testing.T) {
+	t.Run("surfaces as user message between turns", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("first request", tsZero),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "starting work"},
+			}, tsZeroS1),
+			testjsonl.ClaudeQueuedCommandJSON(
+				"hold on, also do X", tsZeroS2,
+			),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "OK doing X too"},
+			}, "2024-01-01T00:00:03Z"),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		require.Len(t, msgs, 4)
+		assert.Equal(t, 4, sess.MessageCount)
+		// Original first user + queued command both count.
+		assert.Equal(t, 2, sess.UserMessageCount)
+		assert.Equal(t, "first request", sess.FirstMessage)
+
+		assert.Equal(t, RoleUser, msgs[0].Role)
+		assert.Equal(t, "first request", msgs[0].Content)
+
+		assert.Equal(t, RoleAssistant, msgs[1].Role)
+
+		assert.Equal(t, RoleUser, msgs[2].Role)
+		assert.Equal(t, "hold on, also do X", msgs[2].Content)
+		assert.False(t, msgs[2].IsSystem)
+		assert.Equal(t, "user", msgs[2].SourceType)
+		assert.Equal(t, "queued_command", msgs[2].SourceSubtype)
+
+		assert.Equal(t, RoleAssistant, msgs[3].Role)
+
+		for i, m := range msgs {
+			assert.Equal(t, i, m.Ordinal,
+				"ordinal mismatch at %d", i)
+		}
+	})
+
+	t.Run("becomes first message when session opens with one", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeQueuedCommandJSON(
+				"queued opener", tsZero,
+			),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "ok"},
+			}, tsZeroS1),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		require.Len(t, msgs, 2)
+		assert.Equal(t, 1, sess.UserMessageCount)
+		assert.Equal(t, "queued opener", sess.FirstMessage)
+		assert.Equal(t, "queued_command", msgs[0].SourceSubtype)
+	})
+
+	t.Run("empty prompt is skipped", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("hi", tsZero),
+			testjsonl.ClaudeQueuedCommandJSON("   ", tsZeroS1),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "ok"},
+			}, tsZeroS2),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		assert.Equal(t, 2, sess.MessageCount)
+		require.Len(t, msgs, 2)
+	})
+
+	t.Run("non-queued attachment types are dropped", func(t *testing.T) {
+		taskReminder := `{"type":"attachment","timestamp":"` +
+			tsZeroS1 + `","attachment":{"type":"task_reminder",` +
+			`"content":"reminder"}}`
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("hi", tsZero),
+			taskReminder,
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "ok"},
+			}, tsZeroS2),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		assert.Equal(t, 2, sess.MessageCount)
+		require.Len(t, msgs, 2)
+	})
+
+	t.Run("works in DAG sessions with uuids on real entries", func(t *testing.T) {
+		// Real entries form a uuid chain; the attachment has
+		// no uuid but must still surface as a user message.
+		userLine := `{"type":"user","uuid":"u1","timestamp":"` +
+			tsZero + `","message":{"content":"hi"}}`
+		assistant1 := `{"type":"assistant","uuid":"a1",` +
+			`"parentUuid":"u1","timestamp":"` + tsZeroS1 +
+			`","message":{"content":[{"type":"text",` +
+			`"text":"work"}]}}`
+		attachment := testjsonl.ClaudeQueuedCommandJSON(
+			"also do X", tsZeroS2,
+		)
+		assistant2 := `{"type":"assistant","uuid":"a2",` +
+			`"parentUuid":"a1","timestamp":` +
+			`"2024-01-01T00:00:03Z","message":{"content":[` +
+			`{"type":"text","text":"done"}]}}`
+		content := testjsonl.JoinJSONL(
+			userLine, assistant1, attachment, assistant2,
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		require.Len(t, msgs, 4)
+		assert.Equal(t, "also do X", msgs[2].Content)
+		assert.Equal(t, "queued_command", msgs[2].SourceSubtype)
+		assert.Equal(t, 2, sess.UserMessageCount)
+	})
+}
+
 func TestParseClaudeSession_ParentSessionID(t *testing.T) {
 	t.Run("sessionId != fileId sets ParentSessionID", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
@@ -341,6 +453,46 @@ func TestParseClaudeSessionFrom_Incremental(t *testing.T) {
 	assert.Contains(t, newMsgs[1].Content, "got it")
 
 	assert.False(t, endedAt.IsZero())
+}
+
+func TestParseClaudeSessionFrom_QueuedCommand(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+		testjsonl.ClaudeAssistantJSON("hi", tsEarlyS1),
+	)
+	path := createTestFile(t, "inc-queued.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Append: queued command + assistant turn.
+	appended := testjsonl.JoinJSONL(
+		testjsonl.ClaudeQueuedCommandJSON("plus do X", tsEarlyS5),
+		testjsonl.ClaudeAssistantJSON("done", tsLate),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 2)
+	require.NoError(t, err)
+	require.Len(t, newMsgs, 2)
+
+	// queued_command first (earlier timestamp), then assistant.
+	assert.Equal(t, RoleUser, newMsgs[0].Role)
+	assert.Equal(t, "plus do X", newMsgs[0].Content)
+	assert.Equal(t, "queued_command", newMsgs[0].SourceSubtype)
+	assert.Equal(t, 2, newMsgs[0].Ordinal)
+
+	assert.Equal(t, RoleAssistant, newMsgs[1].Role)
+	assert.Equal(t, 3, newMsgs[1].Ordinal)
 }
 
 func TestParseClaudeSessionFrom_SkipsNonMessages(

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -3724,6 +3724,108 @@ func TestResyncAllReplacesMessageContent(t *testing.T) {
 	}
 }
 
+// TestResyncAllSurfacesQueuedCommands locks in that bumping
+// dataVersion (which forces a full resync) recovers Claude
+// queued_command attachments dropped by older parser versions.
+// Old DBs synced before the parser fix have no row for the
+// mid-flight user message; ResyncAll must replay the file and
+// reinstate it.
+func TestResyncAllSurfacesQueuedCommands(t *testing.T) {
+	env := setupTestEnv(t)
+
+	content := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsEarly),
+		testjsonl.ClaudeAssistantJSON([]map[string]any{
+			{"type": "text", "text": "starting"},
+		}, tsEarlyS1),
+		testjsonl.ClaudeQueuedCommandJSON(
+			"also do X", "2024-01-01T10:00:02Z",
+		),
+		testjsonl.ClaudeAssistantJSON([]map[string]any{
+			{"type": "text", "text": "done"},
+		}, tsEarlyS5),
+	)
+
+	env.writeClaudeSession(
+		t, "test-proj", "queued-resync.jsonl", content,
+	)
+
+	// Initial sync uses the current parser, which surfaces the
+	// queued_command as message ordinal 2.
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	const sessionID = "queued-resync"
+	msgs := fetchMessages(t, env.db, sessionID)
+	if len(msgs) != 4 {
+		t.Fatalf("initial sync: got %d messages, want 4", len(msgs))
+	}
+
+	// Simulate an old-parser DB by removing the queued_command
+	// row directly. Older versions of the parser would never
+	// have stored it.
+	err := env.db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"DELETE FROM messages WHERE session_id = ?"+
+				" AND source_subtype = 'queued_command'",
+			sessionID,
+		)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("delete queued_command row: %v", err)
+	}
+	msgs = fetchMessages(t, env.db, sessionID)
+	if len(msgs) != 3 {
+		t.Fatalf("after stale simulation: got %d, want 3",
+			len(msgs))
+	}
+
+	// SyncAll must NOT recover the dropped row: the source
+	// file is unchanged on disk, so the engine skips it.
+	stats := env.engine.SyncAll(context.Background(), nil)
+	if stats.Skipped != 1 {
+		t.Fatalf("SyncAll: expected Skipped=1, got %d",
+			stats.Skipped)
+	}
+	msgs = fetchMessages(t, env.db, sessionID)
+	if len(msgs) != 3 {
+		t.Fatalf("after SyncAll: got %d, want 3", len(msgs))
+	}
+
+	// ResyncAll re-parses every session from scratch and the
+	// queued_command reappears.
+	env.engine.ResyncAll(context.Background(), nil)
+
+	msgs = fetchMessages(t, env.db, sessionID)
+	if len(msgs) != 4 {
+		t.Fatalf("after ResyncAll: got %d, want 4", len(msgs))
+	}
+
+	var queued *db.Message
+	for i := range msgs {
+		if msgs[i].SourceSubtype == "queued_command" {
+			queued = &msgs[i]
+			break
+		}
+	}
+	if queued == nil {
+		t.Fatal("ResyncAll did not restore queued_command row")
+	}
+	if queued.Content != "also do X" {
+		t.Errorf("queued_command content = %q, want %q",
+			queued.Content, "also do X")
+	}
+	if queued.Role != "user" {
+		t.Errorf("queued_command role = %q, want user",
+			queued.Role)
+	}
+	if queued.IsSystem {
+		t.Error("queued_command should not be is_system=true")
+	}
+}
+
 func TestResyncAllPreservesInsights(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -98,6 +98,24 @@ func ClaudeAssistantJSON(content any, timestamp string) string {
 	return mustMarshal(m)
 }
 
+// ClaudeQueuedCommandJSON returns a Claude attachment entry of
+// type queued_command — a user message typed and submitted while
+// Claude Code was mid-tool-call.
+func ClaudeQueuedCommandJSON(
+	prompt, timestamp string,
+) string {
+	m := map[string]any{
+		"type":      "attachment",
+		"timestamp": timestamp,
+		"attachment": map[string]any{
+			"type":        "queued_command",
+			"commandMode": "prompt",
+			"prompt":      prompt,
+		},
+	}
+	return mustMarshal(m)
+}
+
 // ClaudeSnapshotJSON returns a Claude snapshot message as a
 // JSON string.
 func ClaudeSnapshotJSON(timestamp string) string {


### PR DESCRIPTION
## Summary

Closes #401.

The Claude parser dropped `type:"attachment"` entries with `attachment.type:"queued_command"` — the JSONL records Claude Code writes when a user submits a message while a tool call is still running. The parser's entry-type whitelist only admitted `user` and `assistant`, so the user's prompt never made it into the transcript even though Claude visibly acted on it.

The parser now collects `queued_command` attachments out of band (they have no uuid/parentUuid and would otherwise force linear fallback or get pruned by the DAG fork heuristic) and splices them into the main session by timestamp. They surface as `role=user`, `is_system=false`, `source_type=user`, `source_subtype=queued_command`, with ordinals renumbered and session counts (`first_message`, `user_message_count`, `message_count`, start/end bounds) refreshed. Other attachment types (e.g. `task_reminder`) and empty/whitespace prompts are still dropped.

`dataVersion` is bumped from 19 to 20 so existing databases re-parse their sessions on next startup and recover the mid-flight messages they previously missed.