### PR TITLE
Improve full resync performance

### DIFF
--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -41,6 +41,13 @@ const (
 	// Keep query parameter counts conservative so large sessions
 	// do not exceed SQLite variable limits when hydrating tool calls.
 	attachToolCallBatchSize = 500
+
+	// Keep multi-row INSERT statements below SQLite's historic
+	// 999-variable limit so binaries built against older SQLite
+	// versions still work.
+	messageInsertRowsPerStmt         = 39 // 25 params per row
+	toolCallInsertRowsPerStmt        = 90 // 10 params per row
+	toolResultEventInsertRowsPerStmt = 80 // 12 params per row
 )
 
 // ToolCall represents a single tool invocation stored in
@@ -195,42 +202,141 @@ func (db *DB) GetAllMessages(
 func insertMessagesTx(
 	tx *sql.Tx, msgs []Message,
 ) ([]int64, error) {
-	stmt, err := tx.Prepare(fmt.Sprintf(`
-		INSERT INTO messages (%s)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, insertMessageCols))
-	if err != nil {
-		return nil, fmt.Errorf("preparing insert: %w", err)
-	}
-	defer stmt.Close()
-
 	ids := make([]int64, len(msgs))
-	for i, m := range msgs {
-		res, err := stmt.Exec(
-			m.SessionID, m.Ordinal, m.Role, m.Content,
-			m.ThinkingText,
-			m.Timestamp, m.HasThinking, m.HasToolUse,
-			m.ContentLength, m.IsSystem,
-			m.Model, string(m.TokenUsage),
-			m.ContextTokens, m.OutputTokens,
-			m.HasContextTokens, m.HasOutputTokens,
-			m.ClaudeMessageID, m.ClaudeRequestID,
-			m.SourceType, m.SourceSubtype, m.SourceUUID,
-			m.SourceParentUUID, m.IsSidechain, m.IsCompactBoundary,
+	nextID, err := nextMessageIDTx(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	for start := 0; start < len(msgs); start += messageInsertRowsPerStmt {
+		end := min(start+messageInsertRowsPerStmt, len(msgs))
+		batch := msgs[start:end]
+		args := make([]any, 0, len(batch)*25)
+		for i, m := range batch {
+			id := nextID + int64(start+i)
+			ids[start+i] = id
+			args = append(args,
+				id,
+				m.SessionID, m.Ordinal, m.Role, m.Content,
+				m.ThinkingText,
+				m.Timestamp, m.HasThinking, m.HasToolUse,
+				m.ContentLength, m.IsSystem,
+				m.Model, string(m.TokenUsage),
+				m.ContextTokens, m.OutputTokens,
+				m.HasContextTokens, m.HasOutputTokens,
+				m.ClaudeMessageID, m.ClaudeRequestID,
+				m.SourceType, m.SourceSubtype, m.SourceUUID,
+				m.SourceParentUUID, m.IsSidechain, m.IsCompactBoundary,
+			)
+		}
+		query := fmt.Sprintf(
+			"INSERT INTO messages (id, %s) VALUES %s",
+			insertMessageCols,
+			multiRowPlaceholders(len(batch), 25),
 		)
-		if err != nil {
+		if _, err := tx.Exec(query, args...); err != nil {
+			first := batch[0].Ordinal
+			last := batch[len(batch)-1].Ordinal
 			return nil, fmt.Errorf(
-				"inserting message ord=%d: %w", m.Ordinal, err,
+				"inserting messages ord=%d..%d: %w",
+				first, last, err,
 			)
 		}
-		id, err := res.LastInsertId()
-		if err != nil {
-			return nil, fmt.Errorf(
-				"last insert id ord=%d: %w", m.Ordinal, err,
-			)
-		}
-		ids[i] = id
 	}
 	return ids, nil
+}
+
+func nextMessageIDTx(tx *sql.Tx) (int64, error) {
+	var n sql.NullInt64
+	if err := tx.QueryRow("SELECT MAX(id) FROM messages").Scan(&n); err != nil {
+		return 0, fmt.Errorf("reading next message id: %w", err)
+	}
+	if !n.Valid {
+		return 1, nil
+	}
+	return n.Int64 + 1, nil
+}
+
+func multiRowPlaceholders(rows, cols int) string {
+	var b strings.Builder
+	for i := range rows {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteByte('(')
+		for j := range cols {
+			if j > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteByte('?')
+		}
+		b.WriteByte(')')
+	}
+	return b.String()
+}
+
+func insertToolCallsChunkTx(
+	tx *sql.Tx, calls []ToolCall,
+) error {
+	args := make([]any, 0, len(calls)*10)
+	for _, tc := range calls {
+		args = append(args,
+			tc.MessageID, tc.SessionID,
+			tc.ToolName, tc.Category,
+			nilIfEmpty(tc.ToolUseID),
+			nilIfEmpty(tc.InputJSON),
+			nilIfEmpty(tc.SkillName),
+			nilIfZero(tc.ResultContentLength),
+			nilIfEmpty(tc.ResultContent),
+			nilIfEmpty(tc.SubagentSessionID),
+		)
+	}
+	query := `
+		INSERT INTO tool_calls
+			(message_id, session_id, tool_name, category,
+			 tool_use_id, input_json, skill_name,
+			 result_content_length, result_content, subagent_session_id)
+		VALUES ` + multiRowPlaceholders(len(calls), 10)
+	if _, err := tx.Exec(query, args...); err != nil {
+		return fmt.Errorf(
+			"inserting tool_calls batch (%d rows): %w",
+			len(calls), err,
+		)
+	}
+	return nil
+}
+
+func insertToolResultEventsChunkTx(
+	tx *sql.Tx, rows []toolResultEventRow,
+) error {
+	args := make([]any, 0, len(rows)*12)
+	for _, r := range rows {
+		args = append(args,
+			r.SessionID, r.MessageOrdinal, r.CallIndex,
+			nilIfEmpty(r.Event.ToolUseID),
+			nilIfEmpty(r.Event.AgentID),
+			nilIfEmpty(r.Event.SubagentSessionID),
+			r.Event.Source, r.Event.Status,
+			r.Event.Content,
+			r.Event.ContentLength,
+			nilIfEmpty(r.Event.Timestamp),
+			r.Event.EventIndex,
+		)
+	}
+	query := `
+		INSERT INTO tool_result_events
+			(session_id, tool_call_message_ordinal, call_index,
+			 tool_use_id, agent_id, subagent_session_id,
+			 source, status, content, content_length,
+			 timestamp, event_index)
+		VALUES ` + multiRowPlaceholders(len(rows), 12)
+	if _, err := tx.Exec(query, args...); err != nil {
+		return fmt.Errorf(
+			"inserting tool_result_events batch (%d rows): %w",
+			len(rows), err,
+		)
+	}
+	return nil
 }
 
 func nilIfEmpty(s string) any {
@@ -252,34 +358,10 @@ func nilIfZero(n int) any {
 func insertToolCallsTx(
 	tx *sql.Tx, calls []ToolCall,
 ) error {
-	if len(calls) == 0 {
-		return nil
-	}
-	stmt, err := tx.Prepare(`
-		INSERT INTO tool_calls
-			(message_id, session_id, tool_name, category,
-			 tool_use_id, input_json, skill_name,
-			 result_content_length, result_content, subagent_session_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return fmt.Errorf("preparing tool_calls insert: %w", err)
-	}
-	defer stmt.Close()
-
-	for _, tc := range calls {
-		if _, err := stmt.Exec(
-			tc.MessageID, tc.SessionID,
-			tc.ToolName, tc.Category,
-			nilIfEmpty(tc.ToolUseID),
-			nilIfEmpty(tc.InputJSON),
-			nilIfEmpty(tc.SkillName),
-			nilIfZero(tc.ResultContentLength),
-			nilIfEmpty(tc.ResultContent),
-			nilIfEmpty(tc.SubagentSessionID),
-		); err != nil {
-			return fmt.Errorf(
-				"inserting tool_call %q: %w", tc.ToolName, err,
-			)
+	for start := 0; start < len(calls); start += toolCallInsertRowsPerStmt {
+		end := min(start+toolCallInsertRowsPerStmt, len(calls))
+		if err := insertToolCallsChunkTx(tx, calls[start:end]); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -288,37 +370,10 @@ func insertToolCallsTx(
 func insertToolResultEventsTx(
 	tx *sql.Tx, rows []toolResultEventRow,
 ) error {
-	if len(rows) == 0 {
-		return nil
-	}
-	stmt, err := tx.Prepare(`
-		INSERT INTO tool_result_events
-			(session_id, tool_call_message_ordinal, call_index,
-			 tool_use_id, agent_id, subagent_session_id,
-			 source, status, content, content_length,
-			 timestamp, event_index)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return fmt.Errorf("preparing tool_result_events insert: %w", err)
-	}
-	defer stmt.Close()
-
-	for _, r := range rows {
-		if _, err := stmt.Exec(
-			r.SessionID, r.MessageOrdinal, r.CallIndex,
-			nilIfEmpty(r.Event.ToolUseID),
-			nilIfEmpty(r.Event.AgentID),
-			nilIfEmpty(r.Event.SubagentSessionID),
-			r.Event.Source, r.Event.Status,
-			r.Event.Content,
-			r.Event.ContentLength,
-			nilIfEmpty(r.Event.Timestamp),
-			r.Event.EventIndex,
-		); err != nil {
-			return fmt.Errorf(
-				"inserting tool_result_event %q/%q: %w",
-				r.Event.Source, r.Event.Status, err,
-			)
+	for start := 0; start < len(rows); start += toolResultEventInsertRowsPerStmt {
+		end := min(start+toolResultEventInsertRowsPerStmt, len(rows))
+		if err := insertToolResultEventsChunkTx(tx, rows[start:end]); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -192,7 +192,7 @@ func (db *DB) GetAllMessages(
 // insertMessagesTx batch-inserts messages within an existing
 // transaction. Returns a slice of message IDs parallel to the
 // input msgs slice. The caller must hold db.mu.
-func (db *DB) insertMessagesTx(
+func insertMessagesTx(
 	tx *sql.Tx, msgs []Message,
 ) ([]int64, error) {
 	stmt, err := tx.Prepare(fmt.Sprintf(`
@@ -350,7 +350,7 @@ func (db *DB) InsertMessages(msgs []Message) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	ids, err := db.insertMessagesTx(tx, msgs)
+	ids, err := insertMessagesTx(tx, msgs)
 	if err != nil {
 		return err
 	}
@@ -515,7 +515,7 @@ func (db *DB) ReplaceSessionMessages(
 	}
 
 	if len(msgs) > 0 {
-		ids, err := db.insertMessagesTx(tx, msgs)
+		ids, err := insertMessagesTx(tx, msgs)
 		if err != nil {
 			return err
 		}

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -36,6 +36,143 @@ func TestInsertAndGetMessage_ThinkingText(t *testing.T) {
 	}
 }
 
+func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
+	d := testDB(t)
+
+	requireNoError(t, d.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"INSERT INTO excluded_sessions (id) VALUES (?)",
+			"excluded",
+		)
+		return err
+	}), "seed excluded session")
+
+	health := 95
+	grade := "A"
+	result, err := d.WriteSessionBatch([]SessionBatchWrite{
+		{
+			Session: Session{
+				ID:               "good",
+				Project:          "proj",
+				Machine:          defaultMachine,
+				Agent:            defaultAgent,
+				FirstMessage:     Ptr("hello"),
+				MessageCount:     2,
+				UserMessageCount: 1,
+			},
+			Messages: []Message{
+				userMsg("good", 0, "hello"),
+				{
+					SessionID:     "good",
+					Ordinal:       1,
+					Role:          "assistant",
+					Content:       "answer",
+					ContentLength: 6,
+					ToolCalls: []ToolCall{{
+						ToolName:  "Read",
+						Category:  "Read",
+						ToolUseID: "toolu_1",
+					}},
+				},
+			},
+			Signals: SessionSignalUpdate{
+				Outcome:           "success",
+				OutcomeConfidence: "high",
+				EndedWithRole:     "assistant",
+				HealthScore:       &health,
+				HealthGrade:       &grade,
+				HasToolCalls:      true,
+			},
+			DataVersion: CurrentDataVersion(),
+		},
+		{
+			Session: Session{
+				ID:               "bad",
+				Project:          "proj",
+				Machine:          defaultMachine,
+				Agent:            defaultAgent,
+				MessageCount:     1,
+				UserMessageCount: 1,
+			},
+			Messages: []Message{
+				userMsg("missing-session", 0, "broken"),
+			},
+			DataVersion: CurrentDataVersion(),
+		},
+		{
+			Session: Session{
+				ID:               "excluded",
+				Project:          "proj",
+				Machine:          defaultMachine,
+				Agent:            defaultAgent,
+				MessageCount:     1,
+				UserMessageCount: 1,
+			},
+			Messages: []Message{
+				userMsg("excluded", 0, "deleted"),
+			},
+			DataVersion: CurrentDataVersion(),
+		},
+	})
+	requireNoError(t, err, "WriteSessionBatch")
+	if result.WrittenSessions != 1 {
+		t.Fatalf("WrittenSessions = %d, want 1", result.WrittenSessions)
+	}
+	if result.WrittenMessages != 2 {
+		t.Fatalf("WrittenMessages = %d, want 2", result.WrittenMessages)
+	}
+	if result.FailedSessions != 1 {
+		t.Fatalf("FailedSessions = %d, want 1", result.FailedSessions)
+	}
+	if result.ExcludedSessions != 1 {
+		t.Fatalf("ExcludedSessions = %d, want 1", result.ExcludedSessions)
+	}
+
+	sess, err := d.GetSessionFull(context.Background(), "good")
+	requireNoError(t, err, "GetSessionFull good")
+	if sess == nil {
+		t.Fatal("good session not found")
+	}
+	if sess.DataVersion != CurrentDataVersion() {
+		t.Errorf(
+			"DataVersion = %d, want %d",
+			sess.DataVersion, CurrentDataVersion(),
+		)
+	}
+	if sess.Outcome != "success" || sess.OutcomeConfidence != "high" {
+		t.Errorf(
+			"signals = %q/%q, want success/high",
+			sess.Outcome, sess.OutcomeConfidence,
+		)
+	}
+	if !sess.HasToolCalls {
+		t.Error("HasToolCalls = false, want true")
+	}
+
+	msgs, err := d.GetAllMessages(context.Background(), "good")
+	requireNoError(t, err, "GetAllMessages good")
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2", len(msgs))
+	}
+	if len(msgs[1].ToolCalls) != 1 {
+		t.Fatalf(
+			"assistant tool calls = %d, want 1",
+			len(msgs[1].ToolCalls),
+		)
+	}
+
+	bad, err := d.GetSessionFull(context.Background(), "bad")
+	requireNoError(t, err, "GetSessionFull bad")
+	if bad != nil {
+		t.Fatal("bad session should have rolled back")
+	}
+	excluded, err := d.GetSessionFull(context.Background(), "excluded")
+	requireNoError(t, err, "GetSessionFull excluded")
+	if excluded != nil {
+		t.Fatal("excluded session should not be written")
+	}
+}
+
 func TestMigration_ThinkingTextColumn(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.db")

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -1,0 +1,283 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// SessionBatchWrite is one full session rewrite for a bulk
+// rebuild. Callers must provide a complete session row, the
+// complete message set to store, the computed signal values,
+// and the data version to stamp after messages are written.
+type SessionBatchWrite struct {
+	Session         Session
+	Messages        []Message
+	Signals         SessionSignalUpdate
+	DataVersion     int
+	ReplaceMessages bool
+}
+
+// SessionBatchResult summarizes a WriteSessionBatch call.
+type SessionBatchResult struct {
+	WrittenSessions  int
+	WrittenMessages  int
+	ExcludedSessions int
+	ExcludedIDs      []string
+	FailedSessions   int
+	Errors           []error
+}
+
+// WriteSessionBatch writes multiple complete sessions inside
+// one transaction. Each session is wrapped in a savepoint so a
+// single bad row rolls back only that session and does not
+// poison the rest of the batch.
+//
+// This is intended for full-resync temp databases, where there
+// are no user pins to preserve yet. Use ReplaceSessionMessages
+// for ordinary single-session replacement on a live database.
+func (db *DB) WriteSessionBatch(
+	writes []SessionBatchWrite,
+) (SessionBatchResult, error) {
+	var result SessionBatchResult
+	if len(writes) == 0 {
+		return result, nil
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return result, fmt.Errorf("beginning batch tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i, write := range writes {
+		savepoint := fmt.Sprintf("session_batch_%d", i)
+		if _, err := tx.Exec("SAVEPOINT " + savepoint); err != nil {
+			return result, fmt.Errorf(
+				"creating savepoint %s: %w", savepoint, err,
+			)
+		}
+
+		messagesWritten, err := writeOneSessionBatchTx(tx, write)
+		switch {
+		case err == nil:
+			if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
+				return result, fmt.Errorf(
+					"releasing savepoint %s: %w",
+					savepoint, err,
+				)
+			}
+			result.WrittenSessions++
+			result.WrittenMessages += messagesWritten
+		case errors.Is(err, ErrSessionExcluded):
+			if rerr := rollbackSavepoint(tx, savepoint); rerr != nil {
+				return result, rerr
+			}
+			result.ExcludedSessions++
+			result.ExcludedIDs = append(
+				result.ExcludedIDs,
+				write.Session.ID,
+			)
+		default:
+			if rerr := rollbackSavepoint(tx, savepoint); rerr != nil {
+				return result, rerr
+			}
+			result.FailedSessions++
+			result.Errors = append(result.Errors, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return result, fmt.Errorf("committing batch tx: %w", err)
+	}
+	return result, nil
+}
+
+func rollbackSavepoint(tx *sql.Tx, savepoint string) error {
+	if _, err := tx.Exec("ROLLBACK TO SAVEPOINT " + savepoint); err != nil {
+		return fmt.Errorf(
+			"rolling back savepoint %s: %w", savepoint, err,
+		)
+	}
+	if _, err := tx.Exec("RELEASE SAVEPOINT " + savepoint); err != nil {
+		return fmt.Errorf(
+			"releasing rolled back savepoint %s: %w",
+			savepoint, err,
+		)
+	}
+	return nil
+}
+
+func writeOneSessionBatchTx(
+	tx *sql.Tx, write SessionBatchWrite,
+) (int, error) {
+	var excluded int
+	err := tx.QueryRow(
+		"SELECT 1 FROM excluded_sessions WHERE id = ?",
+		write.Session.ID,
+	).Scan(&excluded)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf(
+			"checking exclusion for %s: %w",
+			write.Session.ID, err,
+		)
+	}
+	if excluded == 1 {
+		return 0, ErrSessionExcluded
+	}
+
+	if _, err := tx.Exec(
+		upsertSessionSQL,
+		upsertSessionArgs(write.Session)...,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"upserting session %s: %w",
+			write.Session.ID, err,
+		)
+	}
+
+	msgs := write.Messages
+	if write.ReplaceMessages {
+		if err := deleteSessionMessagesTx(tx, write.Session.ID); err != nil {
+			return 0, err
+		}
+	} else {
+		maxOrd, err := maxOrdinalTx(tx, write.Session.ID)
+		if err != nil {
+			return 0, err
+		}
+		msgs = messagesAfterOrdinal(msgs, maxOrd)
+	}
+
+	if len(msgs) > 0 {
+		ids, err := insertMessagesTx(tx, msgs)
+		if err != nil {
+			return 0, err
+		}
+		toolCalls := resolveToolCalls(msgs, ids)
+		if err := insertToolCallsTx(tx, toolCalls); err != nil {
+			return 0, err
+		}
+		events := resolveToolResultEvents(msgs)
+		if err := insertToolResultEventsTx(tx, events); err != nil {
+			return 0, err
+		}
+	}
+
+	if write.DataVersion > 0 {
+		if _, err := tx.Exec(
+			`UPDATE sessions SET
+				data_version = ?,
+				local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+			 WHERE id = ?`,
+			write.DataVersion, write.Session.ID,
+		); err != nil {
+			return 0, fmt.Errorf(
+				"setting data_version for %s: %w",
+				write.Session.ID, err,
+			)
+		}
+	}
+
+	if _, err := tx.Exec(`
+		UPDATE sessions SET
+			tool_failure_signal_count = ?,
+			tool_retry_count = ?,
+			edit_churn_count = ?,
+			consecutive_failure_max = ?,
+			outcome = ?,
+			outcome_confidence = ?,
+			ended_with_role = ?,
+			final_failure_streak = ?,
+			signals_pending_since = ?,
+			compaction_count = ?,
+			mid_task_compaction_count = ?,
+			context_pressure_max = ?,
+			health_score = ?,
+			health_grade = ?,
+			has_tool_calls = ?,
+			has_context_data = ?,
+			local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		WHERE id = ?`,
+		write.Signals.ToolFailureSignalCount,
+		write.Signals.ToolRetryCount,
+		write.Signals.EditChurnCount,
+		write.Signals.ConsecutiveFailureMax,
+		write.Signals.Outcome,
+		write.Signals.OutcomeConfidence,
+		write.Signals.EndedWithRole,
+		write.Signals.FinalFailureStreak,
+		write.Signals.SignalsPendingSince,
+		write.Signals.CompactionCount,
+		write.Signals.MidTaskCompactionCount,
+		write.Signals.ContextPressureMax,
+		write.Signals.HealthScore,
+		write.Signals.HealthGrade,
+		write.Signals.HasToolCalls,
+		write.Signals.HasContextData,
+		write.Session.ID,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"updating session signals for %s: %w",
+			write.Session.ID, err,
+		)
+	}
+
+	return len(msgs), nil
+}
+
+func deleteSessionMessagesTx(tx *sql.Tx, sessionID string) error {
+	if _, err := tx.Exec(
+		"DELETE FROM tool_calls WHERE session_id = ?",
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("deleting old tool_calls: %w", err)
+	}
+	if _, err := tx.Exec(
+		"DELETE FROM tool_result_events WHERE session_id = ?",
+		sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"deleting old tool_result_events: %w", err,
+		)
+	}
+	if _, err := tx.Exec(
+		"DELETE FROM messages WHERE session_id = ?",
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("deleting old messages: %w", err)
+	}
+	return nil
+}
+
+func maxOrdinalTx(tx *sql.Tx, sessionID string) (int, error) {
+	var n sql.NullInt64
+	err := tx.QueryRow(
+		"SELECT MAX(ordinal) FROM messages WHERE session_id = ?",
+		sessionID,
+	).Scan(&n)
+	if err != nil {
+		return -1, fmt.Errorf(
+			"reading max ordinal for %s: %w", sessionID, err,
+		)
+	}
+	if !n.Valid {
+		return -1, nil
+	}
+	return int(n.Int64), nil
+}
+
+func messagesAfterOrdinal(msgs []Message, maxOrd int) []Message {
+	if maxOrd < 0 {
+		return msgs
+	}
+	for i, m := range msgs {
+		if m.Ordinal > maxOrd {
+			return msgs[i:]
+		}
+	}
+	return nil
+}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -666,35 +666,7 @@ func (db *DB) PurgeExcludedSessions() error {
 	return err
 }
 
-// UpsertSession inserts or updates a session.
-// Sessions that were permanently deleted (in excluded_sessions)
-// are silently skipped.
-func (db *DB) UpsertSession(s Session) error {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-
-	// Check exclusion under the write lock to avoid a race with
-	// concurrent DeleteSession/EmptyTrash.
-	var excluded int
-	_ = db.getWriter().QueryRow(
-		"SELECT 1 FROM excluded_sessions WHERE id = ?", s.ID,
-	).Scan(&excluded)
-	if excluded == 1 {
-		return ErrSessionExcluded
-	}
-
-	isAutomated := s.UserMessageCount <= 1 &&
-		s.FirstMessage != nil &&
-		IsAutomatedSession(*s.FirstMessage)
-
-	// data_version is intentionally NOT advanced here. The
-	// caller must call SetSessionDataVersion only after the
-	// associated message rewrite succeeds, so a transient
-	// failure to write messages doesn't mark the file as
-	// up-to-date and starve the rewrite on the next sync.
-	// New rows are seeded with 0 (the default) and bumped to
-	// the current version once their messages land.
-	_, err := db.getWriter().Exec(`
+const upsertSessionSQL = `
 		INSERT INTO sessions (
 			id, project, machine, agent, first_message, display_name,
 			started_at, ended_at, message_count,
@@ -736,19 +708,59 @@ func (db *DB) UpsertSession(s Session) error {
 			file_mtime = excluded.file_mtime,
 			file_inode = excluded.file_inode,
 			file_device = excluded.file_device,
-			file_hash = excluded.file_hash`,
+			file_hash = excluded.file_hash`
+
+func sessionIsAutomated(s Session) bool {
+	return s.UserMessageCount <= 1 &&
+		s.FirstMessage != nil &&
+		IsAutomatedSession(*s.FirstMessage)
+}
+
+func upsertSessionArgs(s Session) []any {
+	return []any{
 		s.ID, s.Project, s.Machine, s.Agent, s.FirstMessage, s.DisplayName,
 		s.StartedAt, s.EndedAt, s.MessageCount,
 		s.UserMessageCount, s.ParentSessionID,
 		s.RelationshipType,
 		s.TotalOutputTokens, s.PeakContextTokens,
 		s.HasTotalOutputTokens, s.HasPeakContextTokens,
-		isAutomated,
+		sessionIsAutomated(s),
 		s.Cwd, s.GitBranch, s.SourceSessionID,
 		s.SourceVersion, s.ParserMalformedLines,
 		s.IsTruncated,
 		s.FilePath, s.FileSize, s.FileMtime,
-		s.FileInode, s.FileDevice, s.FileHash)
+		s.FileInode, s.FileDevice, s.FileHash,
+	}
+}
+
+// UpsertSession inserts or updates a session.
+// Sessions that were permanently deleted (in excluded_sessions)
+// are silently skipped.
+func (db *DB) UpsertSession(s Session) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	// Check exclusion under the write lock to avoid a race with
+	// concurrent DeleteSession/EmptyTrash.
+	var excluded int
+	_ = db.getWriter().QueryRow(
+		"SELECT 1 FROM excluded_sessions WHERE id = ?", s.ID,
+	).Scan(&excluded)
+	if excluded == 1 {
+		return ErrSessionExcluded
+	}
+
+	// data_version is intentionally NOT advanced here. The
+	// caller must call SetSessionDataVersion only after the
+	// associated message rewrite succeeds, so a transient
+	// failure to write messages doesn't mark the file as
+	// up-to-date and starve the rewrite on the next sync.
+	// New rows are seeded with 0 (the default) and bumped to
+	// the current version once their messages land.
+	_, err := db.getWriter().Exec(
+		upsertSessionSQL,
+		upsertSessionArgs(s)...,
+	)
 	if err != nil {
 		return fmt.Errorf("upserting session %s: %w", s.ID, err)
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -25,6 +25,13 @@ const (
 	maxWorkers = 8
 )
 
+type syncWriteMode int
+
+const (
+	syncWriteDefault syncWriteMode = iota
+	syncWriteBulk
+)
+
 var errSessionPreserved = errors.New("session preserved")
 
 // Emitter is notified after a sync pass writes data. Implementations
@@ -261,6 +268,7 @@ func (e *Engine) SyncPaths(paths []string) {
 	results := e.startWorkers(context.Background(), files)
 	stats = e.collectAndBatch(
 		context.Background(), results, len(files), nil,
+		syncWriteDefault,
 	)
 	e.persistSkipCache()
 
@@ -1007,7 +1015,9 @@ func (e *Engine) ResyncAll(
 	// 3. Point engine at newDB and sync into it.
 	e.openCodeArchiveStore = origDB
 	e.db = newDB
-	stats = e.syncAllLocked(ctx, onProgress, time.Time{})
+	stats = e.syncAllLocked(
+		ctx, onProgress, time.Time{}, syncWriteBulk,
+	)
 	e.db = origDB // restore immediately
 	e.openCodeArchiveStore = nil
 
@@ -1278,7 +1288,9 @@ func (e *Engine) SyncAll(
 		}
 	}()
 	defer e.syncMu.Unlock()
-	stats = e.syncAllLocked(ctx, onProgress, time.Time{})
+	stats = e.syncAllLocked(
+		ctx, onProgress, time.Time{}, syncWriteDefault,
+	)
 	return
 }
 
@@ -1299,12 +1311,15 @@ func (e *Engine) SyncAllSince(
 		}
 	}()
 	defer e.syncMu.Unlock()
-	stats = e.syncAllLocked(ctx, onProgress, since)
+	stats = e.syncAllLocked(
+		ctx, onProgress, since, syncWriteDefault,
+	)
 	return
 }
 
 func (e *Engine) syncAllLocked(
 	ctx context.Context, onProgress ProgressFunc, since time.Time,
+	writeMode syncWriteMode,
 ) SyncStats {
 	if ctx.Err() != nil {
 		return SyncStats{Aborted: true}
@@ -1361,7 +1376,7 @@ func (e *Engine) syncAllLocked(
 	tWorkers := time.Now()
 	results := e.startWorkers(ctx, all)
 	stats := e.collectAndBatch(
-		ctx, results, len(all), onProgress,
+		ctx, results, len(all), onProgress, writeMode,
 	)
 	if verbose {
 		log.Printf(
@@ -1391,18 +1406,28 @@ func (e *Engine) syncAllLocked(
 		stats.TotalSessions += len(ocPending)
 		tWrite := time.Now()
 		var ocWritten int
-		for _, pw := range ocPending {
-			if ctx.Err() != nil {
-				break
-			}
-			switch err := e.writeSessionFull(pw); {
-			case err == nil:
-				ocWritten++
-			case errors.Is(err, db.ErrSessionExcluded),
-				errors.Is(err, errSessionPreserved):
-				// Intentional skip, not a failure.
-			default:
+		if writeMode == syncWriteBulk {
+			var failedWrites int
+			ocWritten, _, failedWrites = e.writeBatch(
+				ocPending, writeMode, true,
+			)
+			for range failedWrites {
 				stats.RecordFailed()
+			}
+		} else {
+			for _, pw := range ocPending {
+				if ctx.Err() != nil {
+					break
+				}
+				switch err := e.writeSessionFull(pw); {
+				case err == nil:
+					ocWritten++
+				case errors.Is(err, db.ErrSessionExcluded),
+					errors.Is(err, errSessionPreserved):
+					// Intentional skip, not a failure.
+				default:
+					stats.RecordFailed()
+				}
 			}
 		}
 		stats.RecordSynced(ocWritten)
@@ -1433,18 +1458,28 @@ func (e *Engine) syncAllLocked(
 		stats.TotalSessions += len(warpPending)
 		tWrite := time.Now()
 		var warpWritten int
-		for _, pw := range warpPending {
-			if ctx.Err() != nil {
-				break
-			}
-			switch err := e.writeSessionFull(pw); {
-			case err == nil:
-				warpWritten++
-			case errors.Is(err, db.ErrSessionExcluded),
-				errors.Is(err, errSessionPreserved):
-				// Intentional skip, not a failure.
-			default:
+		if writeMode == syncWriteBulk {
+			var failedWrites int
+			warpWritten, _, failedWrites = e.writeBatch(
+				warpPending, writeMode, true,
+			)
+			for range failedWrites {
 				stats.RecordFailed()
+			}
+		} else {
+			for _, pw := range warpPending {
+				if ctx.Err() != nil {
+					break
+				}
+				switch err := e.writeSessionFull(pw); {
+				case err == nil:
+					warpWritten++
+				case errors.Is(err, db.ErrSessionExcluded),
+					errors.Is(err, errSessionPreserved):
+					// Intentional skip, not a failure.
+				default:
+					stats.RecordFailed()
+				}
 			}
 		}
 		stats.RecordSynced(warpWritten)
@@ -1687,6 +1722,7 @@ func (e *Engine) collectAndBatch(
 	ctx context.Context,
 	results <-chan syncJob, total int,
 	onProgress ProgressFunc,
+	writeMode syncWriteMode,
 ) SyncStats {
 	var stats SyncStats
 	stats.TotalSessions = total
@@ -1768,9 +1804,12 @@ func (e *Engine) collectAndBatch(
 		}
 
 		if len(pending) >= batchSize {
-			writtenSessions, writtenMessages :=
-				e.writeBatch(pending)
+			writtenSessions, writtenMessages, failedWrites :=
+				e.writeBatch(pending, writeMode, false)
 			stats.RecordSynced(writtenSessions)
+			for range failedWrites {
+				stats.RecordFailed()
+			}
 			progress.MessagesIndexed += writtenMessages
 			pending = pending[:0]
 		}
@@ -1783,9 +1822,12 @@ func (e *Engine) collectAndBatch(
 
 flush:
 	if len(pending) > 0 {
-		writtenSessions, writtenMessages :=
-			e.writeBatch(pending)
+		writtenSessions, writtenMessages, failedWrites :=
+			e.writeBatch(pending, writeMode, false)
 		stats.RecordSynced(writtenSessions)
+		for range failedWrites {
+			stats.RecordFailed()
+		}
 		progress.MessagesIndexed += writtenMessages
 	}
 
@@ -3110,14 +3152,18 @@ type pendingWrite struct {
 
 func (e *Engine) writeBatch(
 	batch []pendingWrite,
-) (writtenSessions, writtenMessages int) {
+	writeMode syncWriteMode,
+	forceReplace bool,
+) (writtenSessions, writtenMessages, failedSessions int) {
+	if writeMode == syncWriteBulk {
+		return e.writeBatchBulk(batch, forceReplace)
+	}
+
 	for _, pw := range batch {
-		msgs := toDBMessages(pw, e.blockedResultCategories)
-		s := toDBSession(pw)
-		s.MessageCount, s.UserMessageCount =
-			postFilterCounts(msgs)
-		e.applyRemoteRewrites(&s, msgs)
-		s.IsAutomated = isAutomatedFromSession(s)
+		s, msgs, ok := e.prepareSessionWrite(pw)
+		if !ok {
+			continue
+		}
 
 		// Detect stale parser version BEFORE UpsertSession
 		// overwrites it. Existing message rows from an
@@ -3129,12 +3175,6 @@ func (e *Engine) writeBatch(
 		if existing := e.db.GetSessionDataVersion(s.ID); existing > 0 &&
 			existing < db.CurrentDataVersion() {
 			stale = true
-		}
-		if e.shouldPreserveOpenCodeArchive(
-			pw.sess.Agent, pw.sess.File.Path, s.ID,
-			pw.sess.File.Mtime, derefString(s.FileHash), msgs,
-		) {
-			continue
 		}
 
 		// UpsertSession first: the session row must exist
@@ -3155,10 +3195,11 @@ func (e *Engine) writeBatch(
 				continue
 			}
 			log.Printf("upsert session %s: %v", s.ID, err)
+			failedSessions++
 			continue
 		}
 
-		replaceMessages := stale ||
+		replaceMessages := forceReplace || stale ||
 			pw.sess.Agent == parser.AgentOpenCode
 
 		var werr error
@@ -3172,6 +3213,7 @@ func (e *Engine) writeBatch(
 				"write messages for %s: %v",
 				s.ID, werr,
 			)
+			failedSessions++
 			continue
 		}
 
@@ -3199,7 +3241,80 @@ func (e *Engine) writeBatch(
 		writtenSessions++
 		writtenMessages += len(msgs)
 	}
-	return writtenSessions, writtenMessages
+	return writtenSessions, writtenMessages, failedSessions
+}
+
+func (e *Engine) prepareSessionWrite(
+	pw pendingWrite,
+) (db.Session, []db.Message, bool) {
+	msgs := toDBMessages(pw, e.blockedResultCategories)
+	s := toDBSession(pw)
+	s.MessageCount, s.UserMessageCount =
+		postFilterCounts(msgs)
+	e.applyRemoteRewrites(&s, msgs)
+	s.IsAutomated = isAutomatedFromSession(s)
+
+	if e.shouldPreserveOpenCodeArchive(
+		pw.sess.Agent, pw.sess.File.Path, s.ID,
+		pw.sess.File.Mtime, derefString(s.FileHash), msgs,
+	) {
+		return db.Session{}, nil, false
+	}
+	return s, msgs, true
+}
+
+type batchSourceFile struct {
+	path  string
+	mtime int64
+}
+
+func (e *Engine) writeBatchBulk(
+	batch []pendingWrite, forceReplace bool,
+) (writtenSessions, writtenMessages, failedSessions int) {
+	writes := make([]db.SessionBatchWrite, 0, len(batch))
+	sources := make(map[string]batchSourceFile, len(batch))
+
+	for _, pw := range batch {
+		s, msgs, ok := e.prepareSessionWrite(pw)
+		if !ok {
+			continue
+		}
+		replaceMessages := forceReplace ||
+			pw.sess.Agent == parser.AgentOpenCode
+		writes = append(writes, db.SessionBatchWrite{
+			Session:         s,
+			Messages:        msgs,
+			Signals:         computeSignalsFromMessages(s, msgs),
+			DataVersion:     db.CurrentDataVersion(),
+			ReplaceMessages: replaceMessages,
+		})
+		if pw.sess.File.Path != "" {
+			sources[s.ID] = batchSourceFile{
+				path:  pw.sess.File.Path,
+				mtime: pw.sess.File.Mtime,
+			}
+		}
+	}
+	if len(writes) == 0 {
+		return 0, 0, 0
+	}
+
+	result, err := e.db.WriteSessionBatch(writes)
+	if err != nil {
+		log.Printf("write session batch: %v", err)
+		return 0, 0, len(writes)
+	}
+	for _, id := range result.ExcludedIDs {
+		if source, ok := sources[id]; ok && source.path != "" {
+			e.cacheSkip(source.path, source.mtime)
+		}
+	}
+	for _, err := range result.Errors {
+		log.Printf("write session batch: %v", err)
+	}
+	return result.WrittenSessions,
+		result.WrittenMessages,
+		result.FailedSessions
 }
 
 // writeIncremental appends new messages and partially updates

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1012,6 +1012,36 @@ func (e *Engine) ResyncAll(
 		// Non-fatal: worst case, deleted sessions reappear.
 	}
 
+	// The temp DB is not swapped into production until the end,
+	// so avoid per-row FTS trigger work during the bulk load and
+	// rebuild the index once all message rows are final.
+	ftsDropped := false
+	if newDB.HasFTS() {
+		tFTS := time.Now()
+		if err := newDB.DropFTS(); err != nil {
+			log.Printf("resync: drop temp fts: %v", err)
+			newDB.Close()
+			removeTempDB(tempPath)
+			restoreSkipCache()
+			stats = SyncStats{
+				Aborted: true,
+				Warnings: []string{
+					"resync failed: drop temp fts: " +
+						err.Error(),
+				},
+			}
+			e.mu.Lock()
+			e.lastSyncStats = stats
+			e.mu.Unlock()
+			return
+		}
+		ftsDropped = true
+		log.Printf(
+			"resync: drop temp fts: %s",
+			time.Since(tFTS).Round(time.Millisecond),
+		)
+	}
+
 	// 3. Point engine at newDB and sync into it.
 	e.openCodeArchiveStore = origDB
 	e.db = newDB
@@ -1177,6 +1207,32 @@ func (e *Engine) ResyncAll(
 	// pre-resync classification until the next algorithm bump.
 	if err := newDB.ForceBackfillIsAutomated(); err != nil {
 		log.Printf("resync: reclassify is_automated: %v", err)
+	}
+
+	if ftsDropped {
+		tFTS := time.Now()
+		if err := newDB.RebuildFTS(); err != nil {
+			log.Printf("resync: rebuild fts: %v", err)
+			stats.Aborted = true
+			stats.Warnings = append(stats.Warnings,
+				"fts rebuild failed, aborting swap: "+
+					err.Error(),
+			)
+			newDB.Close()
+			removeTempDB(tempPath)
+			restoreSkipCache()
+			if rerr := origDB.Reopen(); rerr != nil {
+				log.Printf("resync: recovery reopen: %v", rerr)
+			}
+			e.mu.Lock()
+			e.lastSyncStats = stats
+			e.mu.Unlock()
+			return stats
+		}
+		log.Printf(
+			"resync: rebuild fts: %s",
+			time.Since(tFTS).Round(time.Millisecond),
+		)
 	}
 
 	// 5. Close newDB and swap files, then reopen origDB.
@@ -1683,12 +1739,14 @@ func (e *Engine) startWorkers(
 	files []parser.DiscoveredFile,
 ) <-chan syncJob {
 	workers := min(max(runtime.NumCPU(), 2), maxWorkers)
+	buffer := max(workers*2, 1)
 
-	jobs := make(chan parser.DiscoveredFile, len(files))
-	results := make(chan syncJob, len(files))
+	jobs := make(chan parser.DiscoveredFile, buffer)
+	results := make(chan syncJob, buffer)
 
+	var wg gosync.WaitGroup
 	for range workers {
-		go func() {
+		wg.Go(func() {
 			for file := range jobs {
 				if ctx.Err() != nil {
 					results <- syncJob{
@@ -1704,13 +1762,17 @@ func (e *Engine) startWorkers(
 					path:          file.Path,
 				}
 			}
-		}()
+		})
 	}
 
-	for _, f := range files {
-		jobs <- f
-	}
-	close(jobs)
+	go func() {
+		for _, f := range files {
+			jobs <- f
+		}
+		close(jobs)
+		wg.Wait()
+		close(results)
+	}()
 	return results
 }
 


### PR DESCRIPTION
## Summary
- Batch full-resync session writes in larger SQLite transactions with per-session savepoints.
- Use multi-row inserts for messages, tool calls, and tool result events.
- Bound the parser/write pipeline and rebuild FTS once on the temp DB before the atomic swap.

## Performance Notes
- Profiling showed the remaining bottleneck is SQLite write/index work, especially b-tree inserts, pwrite, WAL/checkpoint work, and FTS5 merge/flush.
- On the 26.7k-session throwaway sync workload, wall clock improved from about 1m17s to about 34s.
- Peak footprint on that workload was about 879 MB.

## Test Plan
- [x] go test -tags fts5 ./... -count=1
- [x] go vet -tags fts5 ./...
- [x] commit hooks: golangci-lint, NilAway