### PR TITLE
Better call duration bars and faster load for large sessions

### DIFF
--- a/frontend/src/lib/components/content/CallRow.svelte
+++ b/frontend/src/lib/components/content/CallRow.svelte
@@ -159,7 +159,7 @@
   }
   .call .cbar-wrap {
     height: 9px;
-    background: #1f1f1f;
+    background: transparent;
     border-radius: 1px;
     position: relative;
     overflow: hidden;

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -132,15 +132,27 @@
   // everything else is relative to it, so call-vs-call comparisons are
   // legible even in long sessions where any single call is a tiny
   // fraction of total wall-clock. Parallel siblings (duration_ms ==
-  // null) fall back to the parent turn's duration.
+  // null) use the parent turn's duration both when computing the max
+  // and when scaling each row, so a turn whose only signal lives at
+  // the group level still contributes meaningfully.
+  //
+  // The max is memoized per SessionTiming reference: callBarPct runs
+  // once per rendered row, and recomputing the max each time would
+  // be O(n²) across the call list.
+  const maxCallMsCache = new WeakMap<SessionTiming, number>();
+
   function maxCallMs(t: SessionTiming): number {
+    const cached = maxCallMsCache.get(t);
+    if (cached !== undefined) return cached;
     let max = 0;
     for (const turn of t.turns) {
+      const turnFallback = turn.duration_ms ?? 0;
       for (const call of turn.calls) {
-        const d = call.duration_ms ?? 0;
+        const d = call.duration_ms ?? turnFallback;
         if (d > max) max = d;
       }
     }
+    maxCallMsCache.set(t, max);
     return max;
   }
 

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -127,19 +127,34 @@
     if (turn) ui.scrollToOrdinal(turn.ordinal);
   }
 
-  // Bar width for one call, scaled against the supplied session's
-  // total wall-clock duration. Solo calls render at their own
-  // duration; parallel siblings (duration_ms == null) fall back to
-  // the parent turn's duration so they fill the same fraction as
-  // the group header.
+  // Bar width for one call, scaled against the longest call duration
+  // in the supplied session's scope. The slowest call fills the bar;
+  // everything else is relative to it, so call-vs-call comparisons are
+  // legible even in long sessions where any single call is a tiny
+  // fraction of total wall-clock. Parallel siblings (duration_ms ==
+  // null) fall back to the parent turn's duration.
+  function maxCallMs(t: SessionTiming): number {
+    let max = 0;
+    for (const turn of t.turns) {
+      for (const call of turn.calls) {
+        const d = call.duration_ms ?? 0;
+        if (d > max) max = d;
+      }
+    }
+    return max;
+  }
+
   function callBarPct(c: CallTiming, t: SessionTiming): number {
-    if (t.total_duration_ms <= 0) return 0;
+    const maxMs = maxCallMs(t);
+    if (maxMs <= 0) return 0;
     let dur = c.duration_ms;
     if (dur == null) {
       const turn = t.turns.find((tt) => tt.calls.includes(c));
       dur = turn?.duration_ms ?? 0;
     }
-    return Math.min(100, (dur / t.total_duration_ms) * 100);
+    if (dur <= 0) return 0;
+    const pct = (dur / maxMs) * 100;
+    return Math.min(100, Math.max(pct, 4));
   }
 
   function turnHeaderBarPct(

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -4,7 +4,7 @@ import { clearContentCaches } from "../utils/content-parser.js";
 import { computeMainModel } from "../utils/model.js";
 
 const MESSAGE_PAGE_SIZE = 1000;
-const FULL_SESSION_MESSAGE_THRESHOLD = 20_000;
+const FULL_SESSION_MESSAGE_THRESHOLD = 3_000;
 
 interface FetchPageOptions {
   from: number;


### PR DESCRIPTION
## Summary

- Scale call duration bars in the Calls list relative to the longest call in scope, not total session duration. The slowest call fills the bar; everything else is proportional, so call-vs-call comparison is legible even in long sessions where any one call is a tiny fraction of total wall-clock. Floor at 4% so very short calls remain visible.
- Drop the dark track behind the fill in `CallRow`. With near-zero fills it read as a redaction strip; transparent track keeps the colored fill as the only signal.
- Lower `FULL_SESSION_MESSAGE_THRESHOLD` in the messages store from 20,000 to 3,000. Sessions past that count now take the progressive load path (one fetch of the most-recent 1000, older pages lazy-loaded on scroll) instead of fetching every page on open and triggering full reactive rebuilds between each.