### PR TITLE
fix(desktop): disable WebKit DMABUF renderer on Linux

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -39,6 +39,15 @@ struct SidecarState {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // WebKitGTK 2.40+ DMABUF renderer aborts on some Linux EGL
+    // setups (NVIDIA, headless, certain Wayland sessions); fall
+    // back to the legacy compositing path unless the user opted
+    // out by setting the variable explicitly.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     let mut updater_builder = tauri_plugin_updater::Builder::new();
     // Override the placeholder pubkey from tauri.conf.json with
     // the real key when baked in at compile time via env var.


### PR DESCRIPTION
## Summary

Sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` at the top of `run()` on Linux when the variable is unset, so WebKitGTK falls back to its legacy compositing path instead of trying to bring up the DMABUF/EGL renderer.

WebKitGTK 2.40+ defaults to a DMABUF-based renderer that calls `g_error()` and aborts the process when EGL initialization returns `BAD_PARAMETER` — a known failure mode on certain NVIDIA proprietary driver combinations, headless/containerized environments, and some Wayland sessions. Field reports show the AppImage hitting `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...` immediately after the sidecar comes up, which then causes Tauri to SIGKILL the sidecar on its way out.

A user who needs the new renderer can still opt back in by exporting `WEBKIT_DISABLE_DMABUF_RENDERER=0` before launch.

This is a stopgap for Linux specifically; it does not affect macOS or Windows.