### PR TITLE
fix(stats): make git outcome metrics opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,18 @@ Features:
 
 ## Session Stats
 
-`agentsview stats` emits window-scoped analytics over recorded sessions:
-totals, archetypes (automation vs. quick/standard/deep/marathon), distributions
-for session duration, user-message count, peak context, and tools-per-turn, plus
+`agentsview stats` emits window-scoped analytics over recorded sessions: totals,
+archetypes (automation vs. quick/standard/deep/marathon), distributions for
+session duration, user-message count, peak context, and tools-per-turn, plus
 cache economics, tool/model/agent mix, and a temporal hourly breakdown. The
 `--format json` output follows a versioned v1 schema (`schema_version: 1`)
 suitable for downstream consumers.
+
+By default, `stats` only reads the local SQLite archive. Git-derived outcome
+metrics are opt-in because they can be slow or brittle on large/missing repos:
+use `--include-git-outcomes` for commits/LOC/files changed, and
+`--include-github-outcomes` for GitHub PR counts via `gh` (this also enables git
+outcomes).
 
 ```bash
 # Human-readable summary over the last 28 days
@@ -127,6 +133,9 @@ agentsview stats --format json --since 2026-04-01 --until 2026-04-15
 
 # Restrict to one agent and inspect the schema
 agentsview stats --format json --agent claude | jq '.schema_version'
+
+# Include expensive local git outcome metrics explicitly
+agentsview stats --include-git-outcomes
 ```
 
 ## Session Browser

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -23,8 +23,9 @@ import (
 
 func newStatsCommand() *cobra.Command {
 	var (
-		since, until, agent, timezone    string
-		includeProjects, excludeProjects []string
+		since, until, agent, timezone         string
+		includeProjects, excludeProjects      []string
+		includeGitOutcomes, includeGHOutcomes bool
 	)
 	cmd := &cobra.Command{
 		Use:          "stats",
@@ -48,14 +49,23 @@ func newStatsCommand() *cobra.Command {
 			if agentFilter == "all" {
 				agentFilter = ""
 			}
+			if includeGHOutcomes {
+				includeGitOutcomes = true
+			}
+			var ghToken string
+			if includeGHOutcomes {
+				ghToken = resolveGitHubToken(cmd.Context())
+			}
 			stats, err := svc.Stats(cmd.Context(), service.StatsFilter{
-				Since:           since,
-				Until:           until,
-				Agent:           agentFilter,
-				IncludeProjects: includeProjects,
-				ExcludeProjects: excludeProjects,
-				Timezone:        timezone,
-				GHToken:         resolveGitHubToken(cmd.Context()),
+				Since:                 since,
+				Until:                 until,
+				Agent:                 agentFilter,
+				IncludeProjects:       includeProjects,
+				ExcludeProjects:       excludeProjects,
+				Timezone:              timezone,
+				IncludeGitOutcomes:    includeGitOutcomes,
+				IncludeGitHubOutcomes: includeGHOutcomes,
+				GHToken:               ghToken,
 			})
 			if err != nil {
 				return err
@@ -72,6 +82,7 @@ func newStatsCommand() *cobra.Command {
 	registerStatsFlags(cmd,
 		&since, &until, &agent, &timezone,
 		&includeProjects, &excludeProjects,
+		&includeGitOutcomes, &includeGHOutcomes,
 	)
 	return cmd
 }
@@ -107,6 +118,7 @@ func registerStatsFlags(
 	cmd *cobra.Command,
 	since, until, agent, timezone *string,
 	includeProjects, excludeProjects *[]string,
+	includeGitOutcomes, includeGHOutcomes *bool,
 ) {
 	f := cmd.Flags()
 	f.StringVar(since, "since", "28d",
@@ -121,6 +133,10 @@ func registerStatsFlags(
 		"Exclude these projects (repeatable)")
 	f.StringVar(timezone, "timezone", "",
 		"Timezone for temporal (default: local system timezone)")
+	f.BoolVar(includeGitOutcomes, "include-git-outcomes", false,
+		"Include git-derived outcome stats (commits, LOC, files)")
+	f.BoolVar(includeGHOutcomes, "include-github-outcomes", false,
+		"Include GitHub PR outcome stats via gh (implies --include-git-outcomes)")
 }
 
 // openStatsService opens a SessionService scoped to the local SQLite

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -233,6 +233,18 @@ func TestFmtInt64(t *testing.T) {
 	}
 }
 
+func TestStatsCommand_OutcomeFlagsRegistered(t *testing.T) {
+	cmd := newStatsCommand()
+	for _, name := range []string{
+		"include-git-outcomes",
+		"include-github-outcomes",
+	} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("missing --%s flag", name)
+		}
+	}
+}
+
 // updateGolden toggles regeneration of stats_golden.json.
 // Pass `go test ./cmd/agentsview -run TestStatsGolden -update`
 // after intentionally changing the fixture or the stats pipeline.

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -19,13 +19,15 @@ import (
 // StatsFilter mirrors the service-layer StatsFilter but lives in db
 // because db functions take typed filters without cross-package deps.
 type StatsFilter struct {
-	Since           string
-	Until           string
-	Agent           string
-	IncludeProjects []string
-	ExcludeProjects []string
-	Timezone        string
-	GHToken         string
+	Since                 string
+	Until                 string
+	Agent                 string
+	IncludeProjects       []string
+	ExcludeProjects       []string
+	Timezone              string
+	IncludeGitOutcomes    bool
+	IncludeGitHubOutcomes bool
+	GHToken               string
 }
 
 // GetSessionStats computes the v1 session-stats JSON response.
@@ -105,8 +107,10 @@ func (db *DB) GetSessionStats(
 		return nil, fmt.Errorf("computing adoption: %w", err)
 	}
 
-	if err := db.computeOutcomeStats(ctx, stats, f, from, to, rows); err != nil {
-		return nil, fmt.Errorf("computing outcome stats: %w", err)
+	if f.IncludeGitOutcomes || f.IncludeGitHubOutcomes {
+		if err := db.computeOutcomeStats(ctx, stats, f, from, to, rows); err != nil {
+			return nil, fmt.Errorf("computing outcome stats: %w", err)
+		}
 	}
 
 	return stats, nil

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -2787,6 +2787,30 @@ func statsCommitFile(
 	statsRunGit(t, repo, env, "commit", "-q", "-m", message)
 }
 
+// TestGetSessionStats_OutcomeStats_DefaultDisabled verifies that plain
+// stats runs do not touch git-derived outcome aggregation, even when
+// sessions carry cwd values inside a real repository.
+func TestGetSessionStats_OutcomeStats_DefaultDisabled(t *testing.T) {
+	skipIfNoGit(t)
+	d := testDB(t)
+	ctx := context.Background()
+
+	repo := statsInitRepo(t)
+	statsCommitFile(t, repo, "a.txt", "a1\n", "c1")
+	insertSessionFixture(t, d, sessionFixture{
+		id: "os-default", agent: "claude", userMsgs: 5,
+		startedAt: hoursAgo(5), cwd: repo,
+	})
+
+	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
+	if err != nil {
+		t.Fatalf("GetSessionStats: %v", err)
+	}
+	if stats.OutcomeStats != nil {
+		t.Fatalf("OutcomeStats: got %+v want nil", stats.OutcomeStats)
+	}
+}
+
 // TestGetSessionStats_OutcomeStats_Happy seeds sessions whose cwd
 // points inside a real fixture repo and asserts that the outcome_stats
 // section surfaces the author-filtered commit totals. PRsOpened /
@@ -2823,7 +2847,9 @@ func TestGetSessionStats_OutcomeStats_Happy(t *testing.T) {
 		startedAt: hoursAgo(4), cwd: sub,
 	})
 
-	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
+	stats, err := d.GetSessionStats(ctx, StatsFilter{
+		Since: "28d", IncludeGitOutcomes: true,
+	})
 	if err != nil {
 		t.Fatalf("GetSessionStats: %v", err)
 	}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -373,12 +373,14 @@ func (b *directBackend) Stats(
 		return nil, db.ErrReadOnly
 	}
 	return b.local.GetSessionStats(ctx, db.StatsFilter{
-		Since:           f.Since,
-		Until:           f.Until,
-		Agent:           f.Agent,
-		IncludeProjects: f.IncludeProjects,
-		ExcludeProjects: f.ExcludeProjects,
-		Timezone:        f.Timezone,
-		GHToken:         f.GHToken,
+		Since:                 f.Since,
+		Until:                 f.Until,
+		Agent:                 f.Agent,
+		IncludeProjects:       f.IncludeProjects,
+		ExcludeProjects:       f.ExcludeProjects,
+		Timezone:              f.Timezone,
+		IncludeGitOutcomes:    f.IncludeGitOutcomes,
+		IncludeGitHubOutcomes: f.IncludeGitHubOutcomes,
+		GHToken:               f.GHToken,
 	})
 }

--- a/internal/service/stats_types.go
+++ b/internal/service/stats_types.go
@@ -5,13 +5,15 @@ import "github.com/wesm/agentsview/internal/db"
 
 // StatsFilter mirrors the session-stats CLI flag set.
 type StatsFilter struct {
-	Since           string   `json:"since,omitempty"`
-	Until           string   `json:"until,omitempty"`
-	Agent           string   `json:"agent,omitempty"`
-	IncludeProjects []string `json:"include_projects,omitempty"`
-	ExcludeProjects []string `json:"exclude_projects,omitempty"`
-	Timezone        string   `json:"timezone,omitempty"`
-	GHToken         string   `json:"-"`
+	Since                 string   `json:"since,omitempty"`
+	Until                 string   `json:"until,omitempty"`
+	Agent                 string   `json:"agent,omitempty"`
+	IncludeProjects       []string `json:"include_projects,omitempty"`
+	ExcludeProjects       []string `json:"exclude_projects,omitempty"`
+	Timezone              string   `json:"timezone,omitempty"`
+	IncludeGitOutcomes    bool     `json:"include_git_outcomes,omitempty"`
+	IncludeGitHubOutcomes bool     `json:"include_github_outcomes,omitempty"`
+	GHToken               string   `json:"-"`
 }
 
 // SessionStats is the transport-neutral response type; currently just


### PR DESCRIPTION
## Summary

- `agentsview stats` no longer computes git-derived outcome metrics (commits, LOC, files changed) by default. Outcome aggregation walked every session's cwd and shelled out to `git`, which is slow on large repos and brittle when the cwd has moved or the repo is unavailable.
- Adds `--include-git-outcomes` to opt back into local git outcome metrics, and `--include-github-outcomes` to additionally include GitHub PR counts via `gh` (implies `--include-git-outcomes`). The `GHToken` is only resolved when GitHub outcomes are requested.
- `StatsFilter` (CLI, service, and db layers) gains `IncludeGitOutcomes` and `IncludeGitHubOutcomes` booleans, threaded end-to-end. README documents the new flags.