### PR TITLE
feat(frontend): preview common tool inputs on collapsed tool header

### DIFF
--- a/frontend/src/lib/components/content/ToolBlock.svelte
+++ b/frontend/src/lib/components/content/ToolBlock.svelte
@@ -121,6 +121,29 @@
   });
 
   let previewLine = $derived.by(() => {
+    // Tool-specific summaries take precedence over the first line of
+    // content, which for these tools is a generic header (e.g.
+    // "[Todo List]") that hides the meaningful info.
+    const toolName = toolCall?.tool_name;
+    if (toolName === "TodoWrite") {
+      const todos = inputParams?.todos;
+      if (Array.isArray(todos) && todos.length) {
+        const target =
+          todos.find((t) => t?.status === "in_progress") ??
+          todos[todos.length - 1];
+        const text = target?.content ? String(target.content) : "";
+        if (text) return `→ ${text}`.slice(0, 100);
+      }
+    } else if (toolName === "TaskCreate" && inputParams?.subject) {
+      return String(inputParams.subject).slice(0, 100);
+    } else if (toolName === "TaskUpdate") {
+      const parts: string[] = [];
+      if (inputParams?.taskId != null) parts.push(`#${inputParams.taskId}`);
+      if (inputParams?.status) parts.push(String(inputParams.status));
+      if (inputParams?.subject) parts.push(String(inputParams.subject));
+      if (parts.length) return parts.join(" · ").slice(0, 100);
+    }
+
     const line = content.split("\n")[0]?.slice(0, 100) ?? "";
     if (line) return line;
     // For Bash tools, surface the command in the collapsed header so

--- a/frontend/src/lib/components/content/ToolBlock.svelte
+++ b/frontend/src/lib/components/content/ToolBlock.svelte
@@ -142,6 +142,26 @@
       if (inputParams?.status) parts.push(String(inputParams.status));
       if (inputParams?.subject) parts.push(String(inputParams.subject));
       if (parts.length) return parts.join(" · ").slice(0, 100);
+    } else if (toolName === "Skill" || toolName === "skill") {
+      const skill = inputParams?.skill ?? inputParams?.name;
+      if (skill) return String(skill).slice(0, 100);
+    } else if (toolName === "ToolSearch") {
+      const query = inputParams?.query;
+      if (query) {
+        const firstLine = String(query).split("\n")[0] ?? "";
+        return firstLine.slice(0, 100);
+      }
+    } else if (
+      toolName === "Task" ||
+      toolName === "Agent" ||
+      toolCall?.category === "Task" ||
+      (toolName?.includes("subagent") ?? false)
+    ) {
+      const desc = inputParams?.description ?? inputParams?.prompt;
+      if (desc) {
+        const firstLine = String(desc).split("\n")[0] ?? "";
+        return firstLine.slice(0, 100);
+      }
     }
 
     const line = content.split("\n")[0]?.slice(0, 100) ?? "";

--- a/frontend/src/lib/components/content/ToolBlock.test.ts
+++ b/frontend/src/lib/components/content/ToolBlock.test.ts
@@ -572,4 +572,122 @@ describe("ToolBlock collapsed preview", () => {
     const preview = document.querySelector(".tool-header .tool-preview");
     expect(preview!.textContent).toBe("#29 · completed");
   });
+
+  it("shows skill name for Skill tool", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "Skill",
+      input_json: JSON.stringify({ skill: "roborev-review-branch" }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "Skill", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("roborev-review-branch");
+  });
+
+  it("shows skill name from name field for lowercase skill tool", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "skill",
+      input_json: JSON.stringify({ name: "my-skill" }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "skill", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("my-skill");
+  });
+
+  it("shows query for ToolSearch", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "ToolSearch",
+      input_json: JSON.stringify({
+        query: "select:TaskOutput,TaskGet",
+        max_results: 2,
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "ToolSearch", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("select:TaskOutput,TaskGet");
+  });
+
+  it("shows description for Task tool", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "Task",
+      input_json: JSON.stringify({
+        subagent_type: "Explore",
+        description: "Explore agentsview project",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "Task", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("Explore agentsview project");
+  });
+
+  it("falls back to prompt when description is missing for Task", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "Task",
+      input_json: JSON.stringify({
+        subagent_type: "Explore",
+        prompt: "Find the foo function\nand return its location",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "Task", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("Find the foo function");
+  });
+
+  it("uses Task preview for Agent tool", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "Agent",
+      input_json: JSON.stringify({
+        description: "Audit ship readiness",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "Agent", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("Audit ship readiness");
+  });
+
+  it("uses Task preview for subagent-style tool names", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "Zencoder_subagent__ZencoderSubagent",
+      input_json: JSON.stringify({
+        description: "Run subagent task",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "subagent", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("Run subagent task");
+  });
 });

--- a/frontend/src/lib/components/content/ToolBlock.test.ts
+++ b/frontend/src/lib/components/content/ToolBlock.test.ts
@@ -452,4 +452,124 @@ describe("ToolBlock collapsed preview", () => {
     const preview = document.querySelector(".tool-header .tool-preview");
     expect(preview!.textContent).toBe("$ from content");
   });
+
+  it("shows in-progress todo content for TodoWrite", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "TodoWrite",
+      input_json: JSON.stringify({
+        todos: [
+          { content: "first done task", status: "completed" },
+          { content: "current work", status: "in_progress" },
+          { content: "future task", status: "pending" },
+        ],
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "TodoWrite", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview).not.toBeNull();
+    expect(preview!.textContent).toBe("→ current work");
+  });
+
+  it("falls back to last todo when none are in-progress", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "TodoWrite",
+      input_json: JSON.stringify({
+        todos: [
+          { content: "task one", status: "completed" },
+          { content: "task two", status: "completed" },
+        ],
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "TodoWrite", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("→ task two");
+  });
+
+  it("prefers TodoWrite synthesis over content first line", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "TodoWrite",
+      input_json: JSON.stringify({
+        todos: [{ content: "do thing", status: "in_progress" }],
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: {
+        content: "[Todo List]\n  → do thing",
+        label: "TodoWrite",
+        toolCall,
+      },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("→ do thing");
+  });
+
+  it("shows subject for TaskCreate", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "TaskCreate",
+      input_json: JSON.stringify({
+        subject: "Rebuild Companies list table columns",
+        description: "long description here",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "TaskCreate", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("Rebuild Companies list table columns");
+  });
+
+  it("shows task id, status, and subject for TaskUpdate", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "TaskUpdate",
+      input_json: JSON.stringify({
+        taskId: 29,
+        status: "in_progress",
+        subject: "Rebuild Companies list table columns",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "TaskUpdate", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe(
+      "#29 · in_progress · Rebuild Companies list table columns",
+    );
+  });
+
+  it("shows just task id and status for TaskUpdate without subject", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "TaskUpdate",
+      input_json: JSON.stringify({
+        taskId: 29,
+        status: "completed",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "TaskUpdate", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("#29 · completed");
+  });
 });


### PR DESCRIPTION
## Summary

Synthesize collapsed-header previews from input params for tools whose first line of `content` is a generic header that hides the useful info. Previews take precedence over `content.split("\n")[0]`.

- `TodoWrite` → `→ <in-progress todo content>` (falls back to the last todo)
- `TaskCreate` → `<subject>`
- `TaskUpdate` → `#<taskId> · <status>` (appends ` · <subject>` when present)
- `Skill` / `skill` → skill name from `skill` or `name`
- `ToolSearch` → first line of `query`
- `Task` / `Agent` / `*subagent*` (also `category === "Task"`) → `description` (falls back to first line of `prompt`)