### PR TITLE
fix(piebald): progress accounting, fork validation, generic CLI help

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -413,9 +413,8 @@ func printVersion(w io.Writer) {
 
 func writeRootHelp(w io.Writer, root *cobra.Command) {
 	fmt.Fprintf(w, "agentsview %s - local web viewer for AI agent sessions\n\n", version)
-	fmt.Fprintln(w, "Syncs Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode,")
-	fmt.Fprintln(w, "Cursor, Amp, and Piebald session data into SQLite, serves analytics,")
-	fmt.Fprintln(w, "and exposes session browser via local web UI.")
+	fmt.Fprintln(w, "Syncs session data from supported AI coding agents into SQLite,")
+	fmt.Fprintln(w, "serves analytics, and exposes a session browser via local web UI.")
 	fmt.Fprintln(w)
 	renderRootUsage(w, root)
 	fmt.Fprintln(w)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1498,6 +1498,7 @@ func (e *Engine) syncAllLocked(
 		for _, pw := range pending {
 			dbProgress.MessagesIndexed += len(pw.msgs)
 		}
+		stats.messagesIndexed = dbProgress.MessagesIndexed
 		onProgress(dbProgress)
 	}
 
@@ -4253,7 +4254,8 @@ func (e *Engine) FindSourceFile(sessionID string) string {
 				if dbPath == "" {
 					continue
 				}
-				if _, _, err := parser.ParsePiebaldSession(dbPath, chatID, e.machine); err == nil {
+				results, err := parser.ParsePiebaldSessionResults(dbPath, chatID, e.machine)
+				if err == nil && piebaldResultsContain(results, sessionID) {
 					return dbPath
 				}
 			}
@@ -4341,10 +4343,24 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 				if err != nil {
 					continue
 				}
+				var mtime int64
 				for _, meta := range metas {
 					if meta.SessionID == chatID {
-						return meta.FileMtime
+						mtime = meta.FileMtime
+						break
 					}
+				}
+				if mtime == 0 {
+					continue
+				}
+				// Base chat IDs are confirmed by meta. Fork IDs
+				// need a parse to verify the requested fork exists.
+				if chatID == rawSessionID {
+					return mtime
+				}
+				results, err := parser.ParsePiebaldSessionResults(dbPath, chatID, e.machine)
+				if err == nil && piebaldResultsContain(results, sessionID) {
+					return mtime
 				}
 			}
 		}
@@ -4982,7 +4998,7 @@ func (e *Engine) syncSinglePiebald(
 			lastErr = err
 			continue
 		}
-		if len(results) == 0 {
+		if !piebaldResultsContain(results, sessionID) {
 			continue
 		}
 		for _, result := range results {
@@ -5005,6 +5021,18 @@ func (e *Engine) syncSinglePiebald(
 		return fmt.Errorf("piebald session %s: %w", sessionID, lastErr)
 	}
 	return fmt.Errorf("piebald session %s not found", sessionID)
+}
+
+// piebaldResultsContain reports whether any parsed result has the given
+// session ID. Used to verify a requested fork session was actually
+// produced by the parser before treating a base-chat lookup as a hit.
+func piebaldResultsContain(results []parser.ParseResult, sessionID string) bool {
+	for _, r := range results {
+		if r.Session.ID == sessionID {
+			return true
+		}
+	}
+	return false
 }
 
 func strPtr(s string) *string {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -499,6 +499,15 @@ func TestSyncEngineProgressEmitsPhaseDoneOnce(t *testing.T) {
 	if last.SessionsDone != last.SessionsTotal || last.SessionsTotal != 2 {
 		t.Fatalf("final progress = %d/%d, want 2/2", last.SessionsDone, last.SessionsTotal)
 	}
+	var peakMessages int
+	for _, e := range events {
+		if e.MessagesIndexed > peakMessages {
+			peakMessages = e.MessagesIndexed
+		}
+	}
+	if last.MessagesIndexed < peakMessages {
+		t.Fatalf("final MessagesIndexed = %d regressed from peak %d", last.MessagesIndexed, peakMessages)
+	}
 }
 
 func TestSyncEngineProgressDoneCatchesResyncDBBackedWork(t *testing.T) {

--- a/internal/sync/piebald_integration_test.go
+++ b/internal/sync/piebald_integration_test.go
@@ -209,6 +209,22 @@ func TestSyncSingleSessionPiebaldFork(t *testing.T) {
 	}
 }
 
+func TestSyncSingleSessionPiebaldUnknownFork(t *testing.T) {
+	env := setupTestEnv(t)
+	piebald := createPiebaldDB(t, env.piebaldDir)
+	piebald.addChatWithFork(t, 42)
+
+	if err := env.engine.SyncSingleSession("piebald:42-999"); err == nil {
+		t.Fatal("SyncSingleSession(piebald:42-999) returned nil; want not-found error")
+	}
+	if src := env.engine.FindSourceFile("piebald:42-999"); src != "" {
+		t.Fatalf("FindSourceFile(piebald:42-999) = %q, want empty", src)
+	}
+	if mtime := env.engine.SourceMtime("piebald:42-999"); mtime != 0 {
+		t.Fatalf("SourceMtime(piebald:42-999) = %d, want 0", mtime)
+	}
+}
+
 func TestSyncEnginePiebaldBulkSync(t *testing.T) {
 	env := setupTestEnv(t)
 	piebald := createPiebaldDB(t, env.piebaldDir)


### PR DESCRIPTION
## Summary

Follow-up fixes to #478 surfaced by post-merge review:

- **Progress accounting** — `stats.messagesIndexed` was tracking only the file-backed total, so the terminal `PhaseDone` callback regressed `MessagesIndexed` to the file-only count after Piebald/OpenCode/Warp/Forge work. Now updated inside `advanceDBProgress` so the cumulative count holds.
- **Fork ID validation** — `syncSinglePiebald`, `FindSource`, and `SourceMtime` strip the `-<row>` suffix from fork IDs to look up the base chat, but didn't verify the requested fork actually exists. Stale or typoed IDs like `piebald:42-999` could silently succeed or return mtimes for non-existent sessions. They now require an exact `Session.ID` match in the parsed results.
- **CLI help** — drop the hard-coded agent list from `agentsview --help`. The list went stale every time a new agent was added (most recently Piebald); the README's supported-agents table and per-agent env vars below stay authoritative.