### PR TITLE
test: harden temp dir cleanup for Windows SQLite locks

### DIFF
--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -5,7 +5,9 @@ package dbtest
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/wesm/agentsview/internal/db"
 )
@@ -32,11 +34,43 @@ func WriteTestFile(
 	}
 }
 
+// MkdirTempWithCleanup creates a temporary directory and registers
+// a cleanup that retries os.RemoveAll on Windows where SQLite WAL
+// and mmap'd database files can remain briefly locked after the
+// owning *sql.DB has been closed. A runtime.GC() runs first so
+// any finalizer-driven stmt cleanup in mattn/go-sqlite3 releases
+// its file handles before the directory removal is attempted.
+func MkdirTempWithCleanup(t *testing.T, pattern string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", pattern)
+	if err != nil {
+		t.Fatalf("creating temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		runtime.GC()
+		var removeErr error
+		sleep := 25 * time.Millisecond
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			removeErr = os.RemoveAll(dir)
+			if removeErr == nil {
+				return
+			}
+			time.Sleep(sleep)
+			if sleep < 500*time.Millisecond {
+				sleep *= 2
+			}
+		}
+		t.Errorf("removing temp dir %s: %v", dir, removeErr)
+	})
+	return dir
+}
+
 // OpenTestDB creates a temporary SQLite database for testing.
 // The database is automatically closed when the test completes.
 func OpenTestDB(t *testing.T) *db.DB {
 	t.Helper()
-	dir := t.TempDir()
+	dir := MkdirTempWithCleanup(t, "agentsview-dbtest-*")
 	path := filepath.Join(dir, "test.db")
 	d, err := db.Open(path)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -231,22 +231,7 @@ func setupPGMode(t *testing.T) *testEnv {
 
 func tempDirWithRetryCleanup(t *testing.T) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("", "agentsview-server-test-*")
-	if err != nil {
-		t.Fatalf("creating temp dir: %v", err)
-	}
-	t.Cleanup(func() {
-		var removeErr error
-		for range 20 {
-			removeErr = os.RemoveAll(dir)
-			if removeErr == nil {
-				return
-			}
-			time.Sleep(50 * time.Millisecond)
-		}
-		t.Errorf("removing temp dir %s: %v", dir, removeErr)
-	})
-	return dir
+	return dbtest.MkdirTempWithCleanup(t, "agentsview-server-test-*")
 }
 
 func (te *testEnv) writeProjectFile(


### PR DESCRIPTION
## Summary

- On Windows, SQLite WAL and mmap'd database files can remain briefly locked after `*sql.DB.Close()` returns, especially when a query was interrupted by context cancellation. The previous 1-second retry budget in `tempDirWithRetryCleanup` was not always sufficient on slow CI VMs, and `dbtest.OpenTestDB` used bare `t.TempDir()` with no retry at all -- making `TestSearch_CanceledContext` and `TestHTTPBackend_Watch_CancelClosesChannel` flaky on `windows-latest`.
- Add a shared `dbtest.MkdirTempWithCleanup` helper that runs `runtime.GC()` first (so `mattn/go-sqlite3` stmt finalizers release mmap regions) and retries `os.RemoveAll` with exponential backoff up to 10 seconds.
- Route both `OpenTestDB` and `server_test.go`'s `tempDirWithRetryCleanup` through the new helper.