### PR TITLE
fix: allow remote server connections through CSP connect-src

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' http://127.0.0.1:* http://localhost:*; script-src 'self' http://127.0.0.1:* http://localhost:*; connect-src 'self' http://127.0.0.1:* http://localhost:* ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: http://127.0.0.1:* http://localhost:*; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com http://127.0.0.1:* http://localhost:*; font-src 'self' data: https://fonts.gstatic.com http://127.0.0.1:* http://localhost:*; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+      "csp": "default-src 'self' http://127.0.0.1:* http://localhost:*; script-src 'self' http://127.0.0.1:* http://localhost:*; connect-src 'self' http: https: ws: wss:; img-src 'self' data: http://127.0.0.1:* http://localhost:*; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com http://127.0.0.1:* http://localhost:*; font-src 'self' data: https://fonts.gstatic.com http://127.0.0.1:* http://localhost:*; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
     }
   },
   "bundle": {

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { sync } from "../../stores/sync.svelte.js";
   import { ui } from "../../stores/ui.svelte.js";
+  import { router } from "../../stores/router.svelte.js";
   import {
     formatNumber,
     formatRelativeTime,
@@ -59,6 +60,16 @@
   </div>
 
   <div class="status-right">
+    {#if sync.remoteUnreachable}
+      <button
+        class="remote-warn"
+        onclick={() => router.navigate("settings")}
+        title="Can't reach the remote server. Open settings to check the URL, token, or disconnect."
+      >
+        remote server unreachable
+      </button>
+      <span class="sep">&middot;</span>
+    {/if}
     {#if sync.isDesktop}
       <div class="zoom-controls">
         <button
@@ -182,6 +193,17 @@
   }
 
   .version-warn:hover {
+    text-decoration: underline;
+  }
+
+  .remote-warn {
+    color: var(--accent-red);
+    font-size: 10px;
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .remote-warn:hover {
     text-decoration: underline;
   }
 

--- a/frontend/src/lib/components/layout/StatusBar.test.ts
+++ b/frontend/src/lib/components/layout/StatusBar.test.ts
@@ -22,6 +22,7 @@ describe("StatusBar", () => {
     sync.stats = null;
     sync.serverVersion = null;
     sync.versionMismatch = false;
+    sync.remoteUnreachable = false;
   });
 
   afterEach(() => {
@@ -31,6 +32,7 @@ describe("StatusBar", () => {
     sync.stats = null;
     sync.serverVersion = null;
     sync.versionMismatch = false;
+    sync.remoteUnreachable = false;
     sync.progress = null;
     sync.syncing = false;
   });
@@ -64,6 +66,25 @@ describe("StatusBar", () => {
 
     expect(document.body.textContent).toContain(
       "synced 1m ago",
+    );
+
+    unmount(component);
+  });
+
+  it("shows a remote-unreachable indicator only when flagged", async () => {
+    sync.remoteUnreachable = true;
+    const component = mount(StatusBar, {
+      target: document.body,
+    });
+    await tick();
+    expect(document.body.textContent).toContain(
+      "remote server unreachable",
+    );
+
+    sync.remoteUnreachable = false;
+    await tick();
+    expect(document.body.textContent).not.toContain(
+      "remote server unreachable",
     );
 
     unmount(component);

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -38,6 +38,10 @@ class SyncStore {
   stats: Stats | null = $state(null);
   serverVersion: VersionInfo | null = $state(null);
   versionMismatch: boolean = $state(false);
+  // True when connected to a remote server that the browser cannot
+  // reach (network error, CSP block, or the server being down).
+  // Surfaced in the status bar so the failure is not silent.
+  remoteUnreachable: boolean = $state(false);
   updateAvailable: boolean = $state(false);
   latestVersion: string | null = $state(null);
   readonly buildCommit: string =
@@ -69,9 +73,21 @@ class SyncStore {
     }
   }
 
+  /** Record whether the backend responded. Only flags a failure
+   * when a remote server is configured — local failures are handled
+   * by the visibility health check, which reloads the page. */
+  private markRemoteReachable(reachable: boolean) {
+    if (reachable) {
+      this.remoteUnreachable = false;
+    } else if (api.isRemoteConnection()) {
+      this.remoteUnreachable = true;
+    }
+  }
+
   async loadStatus() {
     try {
       const status = await api.getSyncStatus();
+      this.markRemoteReachable(true);
       const newLastSync = status.last_sync || null;
       const isInitial = !this.statusHydrated;
       this.statusHydrated = true;
@@ -88,6 +104,7 @@ class SyncStore {
         this.notifySyncComplete();
       }
     } catch (error) {
+      this.markRemoteReachable(false);
       this.pendingHydration = false;
       console.warn("Failed to load sync status:", error);
     }
@@ -133,11 +150,13 @@ class SyncStore {
   async loadVersion() {
     try {
       this.serverVersion = await api.getVersion();
+      this.markRemoteReachable(true);
       this.versionMismatch = commitsDisagree(
         this.buildCommit,
         this.serverVersion.commit,
       );
     } catch (error) {
+      this.markRemoteReachable(false);
       console.warn("Failed to load version info:", error);
     }
   }

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -17,6 +17,7 @@ vi.mock("../api/client.js", () => ({
   getVersion: vi.fn(),
   watchSession: vi.fn(),
   checkForUpdate: vi.fn(),
+  isRemoteConnection: vi.fn(),
 }));
 
 const MOCK_STATS: SyncStats = {
@@ -287,5 +288,50 @@ describe("SyncStore.checkForUpdate", () => {
       writable: true,
       configurable: true,
     });
+  });
+});
+
+describe("SyncStore.remoteUnreachable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const s = sync as unknown as Record<string, unknown>;
+    s.remoteUnreachable = false;
+    s.statusHydrated = false;
+  });
+
+  it("flags unreachable when a remote load fails", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    vi.mocked(api.getSyncStatus).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+
+    await sync.loadStatus();
+
+    expect(sync.remoteUnreachable).toBe(true);
+  });
+
+  it("clears the flag when a remote load succeeds", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    const s = sync as unknown as Record<string, unknown>;
+    s.remoteUnreachable = true;
+    vi.mocked(api.getSyncStatus).mockResolvedValue({
+      last_sync: "",
+      stats: MOCK_STATS,
+    });
+
+    await sync.loadStatus();
+
+    expect(sync.remoteUnreachable).toBe(false);
+  });
+
+  it("does not flag unreachable for local connections", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(false);
+    vi.mocked(api.getSyncStatus).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+
+    await sync.loadStatus();
+
+    expect(sync.remoteUnreachable).toBe(false);
   });
 });

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -156,117 +156,90 @@ func TestMiddlewareTimeout(t *testing.T) {
 	}
 }
 
+// parseCSP splits a Content-Security-Policy string into a map of
+// directive name -> source list.
+func parseCSP(csp string) map[string]string {
+	out := map[string]string{}
+	for part := range strings.SplitSeq(csp, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		name, sources, _ := strings.Cut(part, " ")
+		out[name] = strings.TrimSpace(sources)
+	}
+	return out
+}
+
 func TestCSPMiddlewareSetsHeaderOnNonAPIRoutes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		path          string
-		host          string
-		port          int
-		publicOrigins []string
-		bindAllIPs    map[string]bool
-		wantCSP       bool
-		wantParts     []string
-		wantAbsent    []string // substrings that must NOT appear
+		name     string
+		path     string
+		host     string
+		port     int
+		basePath string
+		wantCSP  bool
+		// wantDirectives maps a directive name to its exact expected
+		// source list. Resource directives stay pinned to the server
+		// origin; connect-src is widened to any http/https/ws/wss.
+		wantDirectives map[string]string
 	}{
 		{
-			name:    "SPA_root_gets_CSP_with_pinned_origin",
+			name:    "SPA root pins origin and widens connect-src",
 			path:    "/",
 			host:    "127.0.0.1",
 			port:    8081,
 			wantCSP: true,
-			wantParts: []string{
-				"script-src 'self' http://127.0.0.1:8081",
-				"default-src 'self' http://127.0.0.1:8081",
-				"connect-src 'self' http://127.0.0.1:8081",
-				"ws://127.0.0.1:8081",
-				"style-src 'self' http://127.0.0.1:8081 'unsafe-inline' https://fonts.googleapis.com",
-				"font-src 'self' http://127.0.0.1:8081 data: https://fonts.gstatic.com",
-				"frame-ancestors 'none'",
+			wantDirectives: map[string]string{
+				"default-src":     "'self' http://127.0.0.1:8081",
+				"script-src":      "'self' http://127.0.0.1:8081",
+				"connect-src":     "'self' http: https: ws: wss:",
+				"img-src":         "'self' http://127.0.0.1:8081 data:",
+				"style-src":       "'self' http://127.0.0.1:8081 'unsafe-inline' https://fonts.googleapis.com",
+				"font-src":        "'self' http://127.0.0.1:8081 data: https://fonts.gstatic.com",
+				"object-src":      "'none'",
+				"base-uri":        "'none'",
+				"frame-ancestors": "'none'",
 			},
 		},
 		{
-			name:    "SPA_subpath_gets_CSP",
+			name:    "IPv6 loopback brackets pinned origin",
 			path:    "/sessions/abc",
-			host:    "127.0.0.1",
+			host:    "::1",
 			port:    9090,
 			wantCSP: true,
-			wantParts: []string{
-				"http://127.0.0.1:9090",
-				"ws://127.0.0.1:9090",
+			wantDirectives: map[string]string{
+				"script-src":  "'self' http://[::1]:9090",
+				"connect-src": "'self' http: https: ws: wss:",
 			},
 		},
 		{
-			name:    "API_route_no_CSP",
+			name:     "base path relaxes base-uri to self",
+			path:     "/app/",
+			host:     "127.0.0.1",
+			port:     8081,
+			basePath: "/app",
+			wantCSP:  true,
+			wantDirectives: map[string]string{
+				"connect-src": "'self' http: https: ws: wss:",
+				"base-uri":    "'self'",
+			},
+		},
+		{
+			name:    "API route gets no CSP",
 			path:    "/api/v1/sessions",
 			host:    "127.0.0.1",
 			port:    8081,
 			wantCSP: false,
 		},
 		{
-			name:    "API_subpath_no_CSP",
+			name:    "API subpath gets no CSP",
 			path:    "/api/v1/stats",
 			host:    "127.0.0.1",
 			port:    8081,
 			wantCSP: false,
-		},
-		{
-			name:    "IPv6_loopback_brackets",
-			path:    "/",
-			host:    "::1",
-			port:    8081,
-			wantCSP: true,
-			wantParts: []string{
-				"script-src 'self' http://[::1]:8081",
-				"connect-src",
-				"ws://[::1]:8081",
-				"http://127.0.0.1:8081",
-			},
-		},
-		{
-			name: "BindAll_connect_src_includes_LAN_IPs",
-			path: "/",
-			host: "0.0.0.0",
-			port: 8080,
-			bindAllIPs: map[string]bool{
-				"127.0.0.1":   true,
-				"::1":         true,
-				"192.168.1.5": true,
-			},
-			wantCSP: true,
-			wantParts: []string{
-				// Pinned origin in all directives
-				"script-src 'self' http://0.0.0.0:8080",
-				// LAN IPs in connect-src
-				"http://192.168.1.5:8080",
-				"ws://192.168.1.5:8080",
-				"http://127.0.0.1:8080",
-				"http://localhost:8080",
-			},
-			wantAbsent: []string{
-				// LAN IPs must NOT be in script-src
-				"script-src 'self' http://0.0.0.0:8080 http://192",
-			},
-		},
-		{
-			name:          "PublicOrigin_in_connect_src_only",
-			path:          "/",
-			host:          "127.0.0.1",
-			port:          8081,
-			publicOrigins: []string{"https://view.example.com"},
-			wantCSP:       true,
-			wantParts: []string{
-				// Pinned origin in script-src
-				"script-src 'self' http://127.0.0.1:8081",
-				// Public origin in connect-src
-				"https://view.example.com",
-				"wss://view.example.com",
-			},
-			wantAbsent: []string{
-				// Public origin must NOT be in script-src
-				"script-src 'self' http://127.0.0.1:8081 https://view",
-			},
 		},
 	}
 
@@ -276,37 +249,64 @@ func TestCSPMiddlewareSetsHeaderOnNonAPIRoutes(t *testing.T) {
 			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
-			handler := cspMiddleware(tt.host, tt.port, tt.publicOrigins, tt.bindAllIPs, "", inner)
+			handler := cspMiddleware(tt.host, tt.port, tt.basePath, inner)
 
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			w := httptest.NewRecorder()
 			handler.ServeHTTP(w, req)
 
 			csp := w.Header().Get("Content-Security-Policy")
-			if tt.wantCSP {
-				if csp == "" {
-					t.Fatal("expected CSP header, got empty")
-				}
-				for _, part := range tt.wantParts {
-					if !strings.Contains(csp, part) {
-						t.Errorf("CSP missing %q; got %q", part, csp)
-					}
-				}
-				for _, absent := range tt.wantAbsent {
-					if strings.Contains(csp, absent) {
-						t.Errorf("CSP should not contain %q; got %q", absent, csp)
-					}
-				}
-				xfo := w.Header().Get("X-Frame-Options")
-				if xfo != "DENY" {
-					t.Errorf("expected X-Frame-Options DENY, got %q", xfo)
-				}
-			} else {
+			if !tt.wantCSP {
 				if csp != "" {
 					t.Errorf("expected no CSP header on API route, got %q", csp)
 				}
+				return
+			}
+			if csp == "" {
+				t.Fatal("expected CSP header, got empty")
+			}
+			got := parseCSP(csp)
+			for name, want := range tt.wantDirectives {
+				if got[name] != want {
+					t.Errorf("directive %s = %q, want %q", name, got[name], want)
+				}
+			}
+			if xfo := w.Header().Get("X-Frame-Options"); xfo != "DENY" {
+				t.Errorf("X-Frame-Options = %q, want DENY", xfo)
 			}
 		})
+	}
+}
+
+// TestBuildCSPPolicyWidensConnectSrcOnly is a regression test for the
+// CSP that blocked the "Connect to Remote Server" feature. The SPA
+// points fetch/SSE/WebSocket at an arbitrary remote origin stored
+// client-side (frontend/src/lib/api/client.ts), so connect-src must
+// permit any http/https/ws/wss origin — while every directive that
+// gates code or resource loading stays pinned to the server origin.
+func TestBuildCSPPolicyWidensConnectSrcOnly(t *testing.T) {
+	t.Parallel()
+
+	directives := parseCSP(buildCSPPolicy("127.0.0.1", 8081, ""))
+
+	if got := directives["connect-src"]; got != "'self' http: https: ws: wss:" {
+		t.Errorf("connect-src = %q, want it widened to any http/https/ws/wss origin", got)
+	}
+
+	// Scheme-source wildcards must not leak into the directives that
+	// gate code/resource loading, or the widening would defeat the
+	// remaining CSP protection.
+	locked := []string{"default-src", "script-src", "img-src", "style-src", "font-src"}
+	schemeWildcards := map[string]bool{
+		"http:": true, "https:": true, "ws:": true, "wss:": true,
+	}
+	for _, name := range locked {
+		for field := range strings.FieldsSeq(directives[name]) {
+			if schemeWildcards[field] {
+				t.Errorf("directive %s must stay pinned but allows %q (full: %q)",
+					name, field, directives[name])
+			}
+		}
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -448,7 +448,7 @@ func (s *Server) Handler() http.Handler {
 	if bindAll {
 		bindAllIPs = localInterfaceIPs()
 	}
-	h := cspMiddleware(s.cfg.Host, s.cfg.Port, s.cfg.PublicOrigins, bindAllIPs, s.basePath,
+	h := cspMiddleware(s.cfg.Host, s.cfg.Port, s.basePath,
 		s.authMiddleware(
 			hostCheckMiddleware(
 				allowedHosts, bindAll, s.cfg.Port, bindAllIPs,
@@ -488,8 +488,8 @@ func (s *Server) Handler() http.Handler {
 // responses. The policy pins the exact host:port origin so that
 // even if Tauri's compile-time CSP uses a wildcard port, the
 // intersection narrows to the actual runtime port.
-func cspMiddleware(host string, port int, publicOrigins []string, bindAllIPs map[string]bool, basePath string, next http.Handler) http.Handler {
-	policy := buildCSPPolicy(host, port, publicOrigins, bindAllIPs, basePath)
+func cspMiddleware(host string, port int, basePath string, next http.Handler) http.Handler {
+	policy := buildCSPPolicy(host, port, basePath)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/api/") {
 			w.Header().Set("Content-Security-Policy", policy)
@@ -500,77 +500,29 @@ func cspMiddleware(host string, port int, publicOrigins []string, bindAllIPs map
 }
 
 // buildCSPPolicy constructs the Content-Security-Policy string.
-// It uses the same loopback/bind-all logic as buildAllowedOrigins
-// to handle IPv6 bracketing, 0.0.0.0/:: normalization, and
-// public origins (proxy/TLS).
 //
-// The server's own origin (host:port) is included explicitly in
-// all directives because WebKitGTK in a Tauri webview may not
-// resolve 'self' to the Go server origin after navigating from
-// tauri://localhost. Public origins and LAN IPs are restricted
-// to connect-src only to limit the script execution surface.
-func buildCSPPolicy(host string, port int, publicOrigins []string, bindAllIPs map[string]bool, basePath string) string {
+// The server's own origin (host:port) is pinned in the resource
+// directives (default/script/img/style/font) because WebKitGTK in a
+// Tauri webview may not resolve 'self' to the Go server origin after
+// navigating from tauri://localhost.
+//
+// connect-src is intentionally widened to any http/https/ws/wss
+// origin. The "Connect to Remote Server" feature (see
+// frontend/src/lib/api/client.ts) lets the user point the SPA at an
+// arbitrary remote agentsview API origin stored client-side, which
+// this server cannot know when the policy is built. This mirrors the
+// backend, where authenticated remote requests already bypass the
+// host-check and CORS restrictions (see isRemoteAuth in auth.go and
+// corsMiddleware). Security tradeoff: a broad connect-src means that
+// if an XSS ever executed in the app, exfiltration would be easier;
+// the other directives stay pinned so script execution remains gated
+// to 'self'.
+func buildCSPPolicy(host string, port int, basePath string) string {
 	// serverOrigin is the pinned http origin for the configured
-	// host:port, used in all directives so resources load
+	// host:port, used in the resource directives so resources load
 	// correctly regardless of how the webview resolves 'self'.
 	serverOrigin := "http://" + net.JoinHostPort(host, strconv.Itoa(port))
-
-	// connectSrcs collects additional origins for connect-src
-	// (fetch, SSE, WebSocket) — loopback variants, LAN IPs,
-	// and public/proxy origins.
-	connectHTTP := []string{}
-	connectWS := []string{}
-
-	addConnectOrigin := func(h string) {
-		for _, o := range httpOrigin(h, port) {
-			connectHTTP = append(connectHTTP, o)
-			connectWS = append(connectWS, strings.Replace(o, "http://", "ws://", 1))
-		}
-	}
-
-	// Mirror buildAllowedOrigins: when binding to loopback,
-	// include the other loopback variant. When binding to all
-	// interfaces, include all loopback origins plus every
-	// concrete interface IP.
-	switch host {
-	case "127.0.0.1":
-		addConnectOrigin("localhost")
-	case "localhost":
-		addConnectOrigin("127.0.0.1")
-	case "0.0.0.0", "::":
-		addConnectOrigin("127.0.0.1")
-		addConnectOrigin("localhost")
-		addConnectOrigin("::1")
-		for ip := range bindAllIPs {
-			if ip != "127.0.0.1" && ip != "::1" {
-				addConnectOrigin(ip)
-			}
-		}
-	case "::1":
-		addConnectOrigin("127.0.0.1")
-		addConnectOrigin("localhost")
-	}
-
-	for _, origin := range publicOrigins {
-		connectHTTP = append(connectHTTP, origin)
-		connectWS = append(connectWS,
-			strings.NewReplacer(
-				"https://", "wss://",
-				"http://", "ws://",
-			).Replace(origin),
-		)
-	}
-
-	// resource-src: 'self' + pinned server origin (for all resource types)
 	resourceSrc := "'self' " + serverOrigin
-
-	// connect-src: resource-src + loopback/LAN/public origins + ws variants
-	connectParts := []string{resourceSrc}
-	wsOrigin := "ws://" + net.JoinHostPort(host, strconv.Itoa(port))
-	connectParts = append(connectParts, wsOrigin)
-	connectParts = append(connectParts, connectHTTP...)
-	connectParts = append(connectParts, connectWS...)
-	connectSrc := strings.Join(connectParts, " ")
 
 	baseURI := "'none'"
 	if basePath != "" {
@@ -580,14 +532,14 @@ func buildCSPPolicy(host string, port int, publicOrigins []string, bindAllIPs ma
 	return fmt.Sprintf(
 		"default-src %[1]s; "+
 			"script-src %[1]s; "+
-			"connect-src %[2]s; "+
+			"connect-src 'self' http: https: ws: wss:; "+
 			"img-src %[1]s data:; "+
 			"style-src %[1]s 'unsafe-inline' https://fonts.googleapis.com; "+
 			"font-src %[1]s data: https://fonts.gstatic.com; "+
 			"object-src 'none'; "+
-			"base-uri %[3]s; "+
+			"base-uri %[2]s; "+
 			"frame-ancestors 'none'",
-		resourceSrc, connectSrc, baseURI,
+		resourceSrc, baseURI,
 	)
 }
 


### PR DESCRIPTION
The "Connect to Remote Server" feature points the SPA's fetch, SSE, and WebSocket calls at a user-supplied remote origin stored client-side. The page-serving instance emitted a `connect-src` pinned to its own host:port, loopback variants, LAN IPs, and public origins, so the browser blocked every request to the remote — the server cannot know the client-side URL when the policy is built. The Tauri config had the same loopback-only restriction.

`connect-src` is now widened to any `http`/`https`/`ws`/`wss` origin in both the Go CSP builder and the Tauri config, while every other directive stays pinned to the server origin so script execution remains gated to `'self'`. This matches the backend, where authenticated remote requests already bypass the host-check and CORS restrictions.

Remote connection failures now surface as a status-bar indicator instead of being swallowed in `console.warn`.

The widened `connect-src` is an intentional tradeoff documented in `buildCSPPolicy`: if an XSS executed in the app, a broad `connect-src` would make exfiltration easier; the remaining directives keep script execution locked to `'self'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
