### PR TITLE
fix: restore server timeutil import

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	_ "embed"
@@ -148,8 +149,9 @@ type DB struct {
 	writer    atomic.Pointer[sql.DB]
 	reader    atomic.Pointer[sql.DB]
 	mu        sync.Mutex // serializes writes
-	retired   []*sql.DB  // old pools kept open for in-flight reads
-	dataStale bool       // set by Open when user_version < dataVersion
+	connMu    sync.RWMutex
+	retired   []*sql.DB // old pools kept open for in-flight reads
+	dataStale bool      // set by Open when user_version < dataVersion
 
 	cursorMu     sync.RWMutex
 	cursorSecret []byte
@@ -157,8 +159,58 @@ type DB struct {
 	customPricing map[string]config.CustomModelRate
 }
 
-// getReader returns the current read-only connection pool.
-func (db *DB) getReader() *sql.DB { return db.reader.Load() }
+type readerHandle struct {
+	owner *DB
+}
+
+func (r *readerHandle) current() *sql.DB {
+	return r.owner.reader.Load()
+}
+
+func (r *readerHandle) Exec(
+	query string, args ...any,
+) (sql.Result, error) {
+	r.owner.connMu.RLock()
+	defer r.owner.connMu.RUnlock()
+	return r.current().Exec(query, args...)
+}
+
+func (r *readerHandle) Query(
+	query string, args ...any,
+) (*sql.Rows, error) {
+	r.owner.connMu.RLock()
+	defer r.owner.connMu.RUnlock()
+	return r.current().Query(query, args...)
+}
+
+func (r *readerHandle) QueryContext(
+	ctx context.Context, query string, args ...any,
+) (*sql.Rows, error) {
+	r.owner.connMu.RLock()
+	defer r.owner.connMu.RUnlock()
+	return r.current().QueryContext(ctx, query, args...)
+}
+
+func (r *readerHandle) QueryRow(
+	query string, args ...any,
+) *sql.Row {
+	r.owner.connMu.RLock()
+	defer r.owner.connMu.RUnlock()
+	return r.current().QueryRow(query, args...)
+}
+
+func (r *readerHandle) QueryRowContext(
+	ctx context.Context, query string, args ...any,
+) *sql.Row {
+	r.owner.connMu.RLock()
+	defer r.owner.connMu.RUnlock()
+	return r.current().QueryRowContext(ctx, query, args...)
+}
+
+// getReader returns a guarded facade for the current read-only connection pool.
+func (db *DB) getReader() *readerHandle { return &readerHandle{owner: db} }
+
+func (db *DB) rawReader() *sql.DB { return db.reader.Load() }
 
 // getWriter returns the current write connection.
 func (db *DB) getWriter() *sql.DB { return db.writer.Load() }
@@ -1373,10 +1425,12 @@ func (db *DB) init() error {
 // retired pools left over from previous Reopen calls.
 func (db *DB) Close() error {
 	db.mu.Lock()
+	db.connMu.Lock()
 	w := db.getWriter()
-	r := db.getReader()
+	r := db.rawReader()
 	retired := db.retired
 	db.retired = nil
+	db.connMu.Unlock()
 	db.mu.Unlock()
 
 	errs := []error{w.Close(), r.Close()}
@@ -1393,10 +1447,12 @@ func (db *DB) Close() error {
 func (db *DB) CloseConnections() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
+	db.connMu.Lock()
+	defer db.connMu.Unlock()
 
 	errs := []error{
 		db.getWriter().Close(),
-		db.getReader().Close(),
+		db.rawReader().Close(),
 	}
 	for _, p := range db.retired {
 		errs = append(errs, p.Close())
@@ -1435,9 +1491,13 @@ func (db *DB) reopenLocked() error {
 	}
 	reader.SetMaxOpenConns(4)
 
-	// Close pools from any previous reopen. They have been
-	// retired for at least one full Reopen cycle, so all
-	// in-flight queries on them have long since completed.
+	db.connMu.Lock()
+	defer db.connMu.Unlock()
+
+	// Close pools from any previous reopen. The connection guard
+	// prevents new queries from starting on handles that are about
+	// to be closed; database/sql waits for queries already started
+	// on those pools to finish.
 	for _, p := range db.retired {
 		if err := p.Close(); err != nil {
 			log.Printf(
@@ -1479,7 +1539,7 @@ func (db *DB) Update(fn func(tx *sql.Tx) error) error {
 
 // Reader returns the read-only connection pool.
 func (db *DB) Reader() *sql.DB {
-	return db.getReader()
+	return db.rawReader()
 }
 
 // GetSyncState reads a value from the pg_sync_state table.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1507,21 +1507,7 @@ func (db *DB) reopenLocked() error {
 	reader.SetMaxOpenConns(4)
 
 	db.connMu.Lock()
-	defer db.connMu.Unlock()
-
-	// Close pools from any previous reopen. The connection guard
-	// prevents new queries from starting on handles that are about
-	// to be closed; database/sql waits for queries already started
-	// on those pools to finish.
-	for _, p := range db.retired {
-		if err := p.Close(); err != nil {
-			log.Printf(
-				"warning: closing retired db pool: %v", err,
-			)
-		}
-	}
-	db.retired = db.retired[:0]
-
+	retired := append([]*sql.DB(nil), db.retired...)
 	oldWriter := db.writer.Swap(writer)
 	oldReader := db.reader.Swap(reader)
 
@@ -1529,7 +1515,19 @@ func (db *DB) reopenLocked() error {
 	// loaded the old pointer before the swap may still have
 	// in-flight queries; these pools will be closed on the
 	// next Reopen, CloseConnections, or Close call.
-	db.retired = append(db.retired, oldWriter, oldReader)
+	db.retired = []*sql.DB{oldWriter, oldReader}
+	db.connMu.Unlock()
+
+	// Close pools from earlier reopens outside connMu. database/sql
+	// may wait for active rows to finish, and that wait must not
+	// block new reads from acquiring the guarded current reader.
+	for _, p := range retired {
+		if err := p.Close(); err != nil {
+			log.Printf(
+				"warning: closing retired db pool: %v", err,
+			)
+		}
+	}
 	return nil
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -159,6 +159,21 @@ type DB struct {
 	customPricing map[string]config.CustomModelRate
 }
 
+// Reader exposes guarded read-only query operations. It intentionally does
+// not expose the underlying *sql.DB so callers cannot retain a raw pool across
+// Reopen.
+type Reader interface {
+	Exec(query string, args ...any) (sql.Result, error)
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryContext(
+		ctx context.Context, query string, args ...any,
+	) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+	QueryRowContext(
+		ctx context.Context, query string, args ...any,
+	) *sql.Row
+}
+
 type readerHandle struct {
 	owner *DB
 }
@@ -1537,9 +1552,9 @@ func (db *DB) Update(fn func(tx *sql.Tx) error) error {
 	return tx.Commit()
 }
 
-// Reader returns the read-only connection pool.
-func (db *DB) Reader() *sql.DB {
-	return db.rawReader()
+// Reader returns guarded read-only query access.
+func (db *DB) Reader() Reader {
+	return db.getReader()
 }
 
 // GetSyncState reads a value from the pg_sync_state table.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3564,6 +3564,29 @@ func TestConcurrentReadsWhileReopen(t *testing.T) {
 	}
 }
 
+func TestReaderHandleAcquiredBeforeReopenStaysUsable(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	reader := d.getReader()
+	for range 2 {
+		if err := d.Reopen(); err != nil {
+			t.Fatalf("Reopen: %v", err)
+		}
+	}
+
+	var id string
+	err := reader.QueryRow(
+		"SELECT id FROM sessions WHERE id = ?", "s1",
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("query with pre-reopen reader handle: %v", err)
+	}
+	if id != "s1" {
+		t.Fatalf("id = %q, want s1", id)
+	}
+}
+
 func TestRepeatedReopenBoundsRetiredPools(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "s1", "proj")

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -16,9 +17,92 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+const blockingCloseDriverName = "agentsview-blocking-close"
+
+var (
+	registerBlockingCloseDriverOnce sync.Once
+	blockingCloseDriverStates       sync.Map
+)
+
+type blockingCloseState struct {
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce sync.Once
+}
+
+type blockingCloseDriver struct{}
+
+func (blockingCloseDriver) Open(name string) (driver.Conn, error) {
+	state, ok := blockingCloseDriverStates.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("missing blocking close state for %q", name)
+	}
+	return &blockingCloseConn{
+		state: state.(*blockingCloseState),
+	}, nil
+}
+
+type blockingCloseConn struct {
+	state *blockingCloseState
+}
+
+func (c *blockingCloseConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (c *blockingCloseConn) Close() error {
+	c.state.startedOnce.Do(func() {
+		close(c.state.started)
+	})
+	<-c.state.release
+	return nil
+}
+
+func (c *blockingCloseConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("begin not implemented")
+}
+
+func openBlockingCloseDB(
+	t *testing.T,
+) (*sql.DB, <-chan struct{}, func()) {
+	t.Helper()
+
+	registerBlockingCloseDriverOnce.Do(func() {
+		sql.Register(blockingCloseDriverName, blockingCloseDriver{})
+	})
+
+	dsn := fmt.Sprintf("%s/%p", t.Name(), t)
+	state := &blockingCloseState{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	blockingCloseDriverStates.Store(dsn, state)
+
+	pool, err := sql.Open(blockingCloseDriverName, dsn)
+	if err != nil {
+		t.Fatalf("opening blocking close pool: %v", err)
+	}
+	pool.SetMaxOpenConns(1)
+	if err := pool.PingContext(context.Background()); err != nil {
+		t.Fatalf("priming blocking close pool: %v", err)
+	}
+
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(state.release)
+			blockingCloseDriverStates.Delete(dsn)
+		})
+	}
+	t.Cleanup(release)
+
+	return pool, state.started, release
+}
 
 // filterWith returns a SessionFilter with Limit defaulted to 100.
 func filterWith(fn func(*SessionFilter)) SessionFilter {
@@ -3584,6 +3668,49 @@ func TestExportedReaderAcquiredBeforeReopenStaysUsable(t *testing.T) {
 	}
 	if id != "s1" {
 		t.Fatalf("id = %q, want s1", id)
+	}
+}
+
+func TestReopenDoesNotBlockNewReadsWhileClosingRetiredPool(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	blockingPool, closeStarted, releaseClose := openBlockingCloseDB(t)
+	d.connMu.Lock()
+	d.retired = append(d.retired, blockingPool)
+	d.connMu.Unlock()
+
+	reopenDone := make(chan error, 1)
+	go func() {
+		reopenDone <- d.Reopen()
+	}()
+
+	select {
+	case <-closeStarted:
+	case err := <-reopenDone:
+		t.Fatalf("Reopen finished before blocking close: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reopen did not start closing retired pool")
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := d.GetSession(context.Background(), "s1")
+		readDone <- err
+	}()
+
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("new read while closing retired pool: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("new read blocked while Reopen closed a retired pool")
+	}
+
+	releaseClose()
+	if err := <-reopenDone; err != nil {
+		t.Fatalf("Reopen: %v", err)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3564,11 +3564,11 @@ func TestConcurrentReadsWhileReopen(t *testing.T) {
 	}
 }
 
-func TestReaderHandleAcquiredBeforeReopenStaysUsable(t *testing.T) {
+func TestExportedReaderAcquiredBeforeReopenStaysUsable(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "s1", "proj")
 
-	reader := d.getReader()
+	reader := d.Reader()
 	for range 2 {
 		if err := d.Reopen(); err != nil {
 			t.Fatalf("Reopen: %v", err)

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -7,6 +7,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/service"
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 func (s *Server) handleListSessions(


### PR DESCRIPTION
## Summary
- Restore the missing internal/timeutil import used by the sidebar session index handler.
- Fixes the Go compile failure that broke CI, Docker, CLI release, and desktop release jobs for v0.30.0.

## Evidence
The failed release run reported:
```
internal/server/sessions.go:121:18: undefined: timeutil
internal/server/sessions.go:134:27: undefined: timeutil
```

Normal CI for the same merge commit also caught the same failure in lint, Go tests, coverage, and e2e pre-build.

## Verification
- `go test ./...`
- `git diff --check`
- commit hooks: golangci-lint, NilAway

## Release notes
After merge, recreate the v0.30.0 tag from the fixed main commit. A raw RC tag currently is not a draft-only dry run: the existing tag workflows would publish Docker images, GitHub release assets, desktop updater assets, and attempt the production PyPI publish path.