### PR TITLE
fix: refresh pricing from LiteLLM when session usage hits unpriced models

### DIFF
--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -336,6 +336,28 @@ func sessionUsageData(sessionID string) (*sessionUsageOutput, int, error) {
 		fmt.Fprintf(os.Stderr, "session not found: %s\n", sessionID)
 		return nil, tokenUseExitNotFound, nil
 	}
+	// If the session uses models the local pricing catalog
+	// doesn't know about, try a one-off LiteLLM refresh and
+	// re-query — newly released models often hit this until
+	// the user next runs `agentsview serve`. Skip when a
+	// server is active (it owns pricing writes) or the
+	// cooldown hasn't elapsed.
+	if len(u.UnpricedModels) > 0 && !serverActive {
+		refreshed, refErr := refreshPricingIfStale(
+			database, pricing.FetchLiteLLMPricing,
+			pricingRefreshCooldown, time.Now(),
+		)
+		if refErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: pricing refresh failed: %v\n", refErr)
+		} else if refreshed {
+			if u2, e := database.GetSessionUsage(
+				ctx, resolvedID,
+			); e == nil && u2 != nil {
+				u = u2
+			}
+		}
+	}
 	if u.Agent == "" {
 		if def, ok := parser.AgentByPrefix(u.SessionID); ok {
 			u.Agent = string(def.Type)

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -316,6 +316,61 @@ func refreshPricingFromLiteLLM(database *db.DB) {
 	}
 }
 
+// pricingRefreshMetaKey marks the last time the CLI tried to
+// refresh model_pricing from LiteLLM. Cooldown is enforced
+// against this value, win or fail, so a repeatedly-failing
+// fetch (offline, DNS broken) does not block every CLI call.
+const pricingRefreshMetaKey = "_litellm_last_attempt"
+
+// pricingRefreshCooldown is the minimum interval between
+// CLI-triggered LiteLLM fetches. Short enough that a newly
+// released model gets priced within hours of the user noticing,
+// long enough that statusline-style repeated CLI invocations
+// don't hammer LiteLLM when a session uses a truly unpriced
+// model (e.g. a local Ollama model).
+const pricingRefreshCooldown = time.Hour
+
+// refreshPricingIfStale fetches the LiteLLM pricing catalog
+// and upserts it when the last attempt is older than cooldown
+// (or has never run). The fetcher is injectable for tests so
+// the cooldown logic can be exercised without network. Returns
+// true when an upsert succeeded; callers can re-query pricing
+// after a true result. Errors from the fetch are returned so
+// the caller can emit a warning; cooldown is recorded before
+// the fetch so a persistent failure won't retry every call.
+func refreshPricingIfStale(
+	database *db.DB,
+	fetch func() ([]pricing.ModelPricing, error),
+	cooldown time.Duration,
+	now time.Time,
+) (bool, error) {
+	stored, err := database.GetPricingMeta(pricingRefreshMetaKey)
+	if err != nil {
+		return false, fmt.Errorf(
+			"reading pricing refresh meta: %w", err)
+	}
+	if stored != "" {
+		last, perr := time.Parse(time.RFC3339, stored)
+		if perr == nil && now.Sub(last) < cooldown {
+			return false, nil
+		}
+	}
+	if err := database.SetPricingMeta(
+		pricingRefreshMetaKey, now.UTC().Format(time.RFC3339),
+	); err != nil {
+		return false, fmt.Errorf(
+			"recording pricing refresh attempt: %w", err)
+	}
+	prices, err := fetch()
+	if err != nil {
+		return false, err
+	}
+	if err := upsertPricing(database, prices); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func ensurePricing(database *db.DB, offline bool) {
 	var prices []pricing.ModelPricing
 

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/pricing"
 )
 
 func TestFmtCost(t *testing.T) {
@@ -169,5 +171,157 @@ func TestFormatDailyUsageJSON(t *testing.T) {
 		if _, ok := totals[f]; !ok {
 			t.Errorf("missing field %q in totals", f)
 		}
+	}
+}
+
+func TestRefreshPricingIfStale_FreshAttemptSkipsFetch(t *testing.T) {
+	d := newTestDB(t)
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+
+	// Last attempt 10 minutes ago, cooldown 1 hour: skip.
+	prev := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	if err := d.SetPricingMeta(
+		pricingRefreshMetaKey, prev,
+	); err != nil {
+		t.Fatalf("seed meta: %v", err)
+	}
+
+	called := false
+	refreshed, err := refreshPricingIfStale(
+		d, func() ([]pricing.ModelPricing, error) {
+			called = true
+			return nil, nil
+		}, time.Hour, now,
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if refreshed {
+		t.Error("refreshed = true, want false within cooldown")
+	}
+	if called {
+		t.Error("fetch should not run within cooldown")
+	}
+
+	// Meta value preserved (we did not overwrite it).
+	got, err := d.GetPricingMeta(pricingRefreshMetaKey)
+	if err != nil {
+		t.Fatalf("get meta: %v", err)
+	}
+	if got != prev {
+		t.Errorf("meta = %q, want %q (unchanged)", got, prev)
+	}
+}
+
+func TestRefreshPricingIfStale_StaleTriggersFetch(t *testing.T) {
+	d := newTestDB(t)
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+
+	// Last attempt 2 hours ago, cooldown 1 hour: refresh.
+	prev := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	if err := d.SetPricingMeta(
+		pricingRefreshMetaKey, prev,
+	); err != nil {
+		t.Fatalf("seed meta: %v", err)
+	}
+
+	refreshed, err := refreshPricingIfStale(
+		d, func() ([]pricing.ModelPricing, error) {
+			return []pricing.ModelPricing{{
+				ModelPattern:  "gpt-5.5",
+				InputPerMTok:  1.25,
+				OutputPerMTok: 10.0,
+			}}, nil
+		}, time.Hour, now,
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !refreshed {
+		t.Fatal("refreshed = false, want true after cooldown")
+	}
+
+	// Pricing row written.
+	p, err := d.GetModelPricing("gpt-5.5")
+	if err != nil {
+		t.Fatalf("get pricing: %v", err)
+	}
+	if p == nil || p.OutputPerMTok != 10.0 {
+		t.Errorf("gpt-5.5 row missing or wrong: %+v", p)
+	}
+
+	// Meta updated to now.
+	got, err := d.GetPricingMeta(pricingRefreshMetaKey)
+	if err != nil {
+		t.Fatalf("get meta: %v", err)
+	}
+	if got != now.Format(time.RFC3339) {
+		t.Errorf("meta = %q, want %q", got, now.Format(time.RFC3339))
+	}
+}
+
+func TestRefreshPricingIfStale_NeverAttemptedTriggersFetch(t *testing.T) {
+	d := newTestDB(t)
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+
+	called := false
+	refreshed, err := refreshPricingIfStale(
+		d, func() ([]pricing.ModelPricing, error) {
+			called = true
+			return nil, nil
+		}, time.Hour, now,
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !called {
+		t.Error("fetch should run when meta empty")
+	}
+	if !refreshed {
+		t.Error("refreshed = false, want true on first attempt")
+	}
+}
+
+func TestRefreshPricingIfStale_FetchFailureRecordsAttempt(t *testing.T) {
+	d := newTestDB(t)
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+
+	wantErr := errors.New("network down")
+	refreshed, err := refreshPricingIfStale(
+		d, func() ([]pricing.ModelPricing, error) {
+			return nil, wantErr
+		}, time.Hour, now,
+	)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want network down", err)
+	}
+	if refreshed {
+		t.Error("refreshed = true, want false on fetch failure")
+	}
+
+	// Cooldown still recorded so a persistent failure doesn't
+	// retry on every CLI call.
+	got, err := d.GetPricingMeta(pricingRefreshMetaKey)
+	if err != nil {
+		t.Fatalf("get meta: %v", err)
+	}
+	if got != now.Format(time.RFC3339) {
+		t.Errorf("meta = %q, want %q (recorded on failure)",
+			got, now.Format(time.RFC3339))
+	}
+
+	// A second call within cooldown skips the fetch entirely.
+	called := false
+	_, err = refreshPricingIfStale(
+		d, func() ([]pricing.ModelPricing, error) {
+			called = true
+			return nil, nil
+		}, time.Hour, now.Add(time.Minute),
+	)
+	if err != nil {
+		t.Fatalf("second call err: %v", err)
+	}
+	if called {
+		t.Error("second call should be suppressed by cooldown")
 	}
 }


### PR DESCRIPTION
## Summary

`agentsview session usage <id>` reported `Cost: n/a (unpriced: <model>)` for sessions that used a newly released model (e.g. `gpt-5.5`), even though LiteLLM had the rate. Running `agentsview serve` once made the same command print a cost — because the server's background `refreshPricingFromLiteLLM` populated the row. The CLI path only seeded `pricing.FallbackPricing()`, never the live catalog.

When `GetSessionUsage` returns `UnpricedModels` and no server is active, the CLI now triggers a one-shot LiteLLM fetch, upserts the catalog, and re-queries. A 1-hour cooldown stored in a `PricingMeta` sentinel row (`_litellm_last_attempt`) prevents repeated CLI invocations — or persistent fetch failures (offline, DNS broken) — from pinging LiteLLM on every call.

The cooldown is recorded before the fetch so a failing fetch still updates the timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)