### PR TITLE
test: migrate Go test suite to testify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ html/
 
 # Antigravity CLI session dir created when AGY runs inside this repo
 .antigravitycli/
+.kata.local.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,15 @@ Instructions for autonomous coding agents working in this repository.
 - Run relevant tests before committing when practical.
 - If tests cannot be run, state that clearly in the handoff.
 
+## Test Style
+
+- Go tests use `github.com/stretchr/testify` for assertions. Use `require.X`
+  when a failed check should abort the test (setup, nil receivers, length checks
+  before indexing) and `assert.X` for independent checks that should keep
+  running. Don't write `if got != want { t.Fatalf(...) }` in new tests.
+- Domain-specific helpers are fine, but they must use testify internally rather
+  than stdlib comparisons.
+
 ## Safety
 
 - Do not revert user-authored or unrelated local changes unless explicitly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,13 @@ container (see `.github/workflows/ci.yml`, `integration` job).
 ### Test Guidelines
 
 - Table-driven tests for Go code
+- **Use `testify` (`require` + `assert`) for assertions in Go tests.** Reach for
+  `require.X` when a failed check should stop the test (setup errors, nil
+  receivers, length mismatches before indexing) and `assert.X` for independent
+  checks that should keep running. Don't hand-roll
+  `if got != want { t.Fatalf(...) }` in new tests. Custom domain helpers (e.g.
+  `assertSessionMeta`) are fine, but they should be built on top of testify, not
+  stdlib comparisons.
 - Use `testDB(t)` helper for database tests
 - Frontend: colocated `*.test.ts` files, Playwright specs in `frontend/e2e/`
 - All tests use `t.TempDir()` for temp directories

--- a/cmd/agentsview/classifier_test.go
+++ b/cmd/agentsview/classifier_test.go
@@ -7,10 +7,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 )
@@ -31,12 +32,10 @@ func classifierTestEnv(t *testing.T, prefixes []string) string {
 		tomlBuf.WriteString("\"" + p + "\"")
 	}
 	tomlBuf.WriteString("]\n")
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "config.toml"),
 		tomlBuf.Bytes(), 0o600,
-	); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	), "write config")
 
 	t.Cleanup(func() { db.SetUserAutomationPrefixes(nil) })
 	return dir
@@ -47,9 +46,7 @@ func classifierTestEnv(t *testing.T, prefixes []string) string {
 func seedHash(t *testing.T, cfg config.Config) {
 	t.Helper()
 	d, err := db.Open(cfg.DBPath)
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
+	require.NoError(t, err, "open db")
 	defer d.Close()
 	// Opening already runs backfill; the hash is now stored.
 	_ = d
@@ -63,9 +60,7 @@ func seedHash(t *testing.T, cfg config.Config) {
 func readStoredHash(t *testing.T, dbPath string) string {
 	t.Helper()
 	conn, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("open raw sqlite: %v", err)
-	}
+	require.NoError(t, err, "open raw sqlite")
 	defer conn.Close()
 	var v string
 	err = conn.QueryRow(
@@ -75,34 +70,26 @@ func readStoredHash(t *testing.T, dbPath string) string {
 	if errors.Is(err, sql.ErrNoRows) {
 		return ""
 	}
-	if err != nil {
-		t.Fatalf("query stats: %v", err)
-	}
+	require.NoError(t, err, "query stats")
 	return v
 }
 
 func TestClassifierRebuildClearsSQLiteHash(t *testing.T) {
 	dir := classifierTestEnv(t, []string{"You are analyzing an essay"})
 	cfg, err := config.LoadMinimal()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
+	require.NoError(t, err, "load")
 	cfg.DBPath = filepath.Join(dir, "sessions.db")
 	applyClassifierConfig(cfg)
 	seedHash(t, cfg)
-	if got := readStoredHash(t, cfg.DBPath); got == "" {
-		t.Fatalf("precondition: expected stored hash, got empty")
-	}
+	require.NotEmpty(t, readStoredHash(t, cfg.DBPath),
+		"precondition: expected stored hash, got empty")
 
-	if err := runClassifierRebuild(
+	require.NoError(t, runClassifierRebuild(
 		context.Background(), cfg, &bytes.Buffer{},
-	); err != nil {
-		t.Fatalf("rebuild: %v", err)
-	}
+	), "rebuild")
 
-	if got := readStoredHash(t, cfg.DBPath); got != "" {
-		t.Errorf("expected hash cleared, got %q", got)
-	}
+	assert.Empty(t, readStoredHash(t, cfg.DBPath),
+		"expected hash cleared")
 }
 
 func TestClassifierRebuildPrintsLoadedPrefixes(t *testing.T) {
@@ -112,67 +99,49 @@ func TestClassifierRebuildPrintsLoadedPrefixes(t *testing.T) {
 	}
 	dir := classifierTestEnv(t, prefixes)
 	cfg, err := config.LoadMinimal()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
+	require.NoError(t, err, "load")
 	cfg.DBPath = filepath.Join(dir, "sessions.db")
 	applyClassifierConfig(cfg)
 	seedHash(t, cfg)
 
 	out := &bytes.Buffer{}
-	if err := runClassifierRebuild(
+	require.NoError(t, runClassifierRebuild(
 		context.Background(), cfg, out,
-	); err != nil {
-		t.Fatalf("rebuild: %v", err)
-	}
+	), "rebuild")
 	got := out.String()
 	for _, p := range prefixes {
-		if !strings.Contains(got, p) {
-			t.Errorf("output missing %q:\n%s", p, got)
-		}
+		assert.Contains(t, got, p, "output missing %q", p)
 	}
-	if !strings.Contains(got, "loaded 2 user automation prefix") {
-		t.Errorf("output missing count line:\n%s", got)
-	}
-	if !strings.Contains(got, "restart") {
-		t.Errorf("output missing restart reminder:\n%s", got)
-	}
+	assert.Contains(t, got, "loaded 2 user automation prefix",
+		"output missing count line")
+	assert.Contains(t, got, "restart",
+		"output missing restart reminder")
 }
 
 func TestClassifierRebuildRefusesOnHTTPTransport(t *testing.T) {
 	dir := classifierTestEnv(t, nil)
 	cfg, err := config.LoadMinimal()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
+	require.NoError(t, err, "load")
 	cfg.DBPath = filepath.Join(dir, "sessions.db")
 
 	tr := transport{Mode: transportHTTP, URL: "http://127.0.0.1:8080"}
 	err = guardClassifierRebuild(tr)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "daemon") {
-		t.Errorf("error should mention daemon, got: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon",
+		"error should mention daemon")
 }
 
 func TestClassifierRebuildRefusesOnDirectReadOnly(t *testing.T) {
 	tr := transport{Mode: transportDirect, DirectReadOnly: true}
 	err := guardClassifierRebuild(tr)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "daemon") {
-		t.Errorf("error should mention daemon, got: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon",
+		"error should mention daemon")
 }
 
 func TestClassifierRebuildAllowsDirectWritable(t *testing.T) {
 	tr := transport{Mode: transportDirect, DirectReadOnly: false}
-	if err := guardClassifierRebuild(tr); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	assert.NoError(t, guardClassifierRebuild(tr))
 }
 
 // TestClassifierRebuildHardFailsOnPGUnreachable confirms
@@ -182,9 +151,7 @@ func TestClassifierRebuildAllowsDirectWritable(t *testing.T) {
 func TestClassifierRebuildHardFailsOnPGUnreachable(t *testing.T) {
 	dir := classifierTestEnv(t, nil)
 	cfg, err := config.LoadMinimal()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
+	require.NoError(t, err, "load")
 	cfg.DBPath = filepath.Join(dir, "sessions.db")
 	// Point at a deliberately-unreachable PG URL. Use port 1
 	// (commonly closed) so Open returns quickly without
@@ -197,23 +164,16 @@ func TestClassifierRebuildHardFailsOnPGUnreachable(t *testing.T) {
 	err = runClassifierRebuild(
 		context.Background(), cfg, &bytes.Buffer{},
 	)
-	if err == nil {
-		t.Fatal("expected error for unreachable PG, got nil")
-	}
-	if !strings.Contains(err.Error(), "PG") &&
-		!strings.Contains(err.Error(), "pg") {
-		t.Errorf("error should mention PG, got: %v", err)
-	}
+	require.Error(t, err, "expected error for unreachable PG")
+	assert.True(t,
+		bytes.Contains([]byte(err.Error()), []byte("PG")) ||
+			bytes.Contains([]byte(err.Error()), []byte("pg")),
+		"error should mention PG, got: %v", err)
 	// Lock the spec contract: the error must surface the
 	// 'pg push --full' remediation hint so a future refactor
 	// can't silently drop it.
-	if !strings.Contains(err.Error(), "pg push --full") {
-		t.Errorf(
-			"error should mention 'pg push --full' "+
-				"remediation, got: %v",
-			err,
-		)
-	}
+	assert.Contains(t, err.Error(), "pg push --full",
+		"error should mention 'pg push --full' remediation")
 }
 
 // TestClassifierRebuildSkipsPGWhenNotConfigured verifies the
@@ -223,19 +183,15 @@ func TestClassifierRebuildHardFailsOnPGUnreachable(t *testing.T) {
 func TestClassifierRebuildSkipsPGWhenNotConfigured(t *testing.T) {
 	dir := classifierTestEnv(t, nil)
 	cfg, err := config.LoadMinimal()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
+	require.NoError(t, err, "load")
 	cfg.DBPath = filepath.Join(dir, "sessions.db")
 	cfg.PG.URL = ""
 	applyClassifierConfig(cfg)
 	seedHash(t, cfg)
 
-	if err := runClassifierRebuild(
+	require.NoError(t, runClassifierRebuild(
 		context.Background(), cfg, &bytes.Buffer{},
-	); err != nil {
-		t.Fatalf("unexpected error when PG unconfigured: %v", err)
-	}
+	), "unexpected error when PG unconfigured")
 }
 
 // TestClassifierCommandIsHidden pins the UX decision that the
@@ -244,7 +200,6 @@ func TestClassifierRebuildSkipsPGWhenNotConfigured(t *testing.T) {
 // this group is a recovery hatch.
 func TestClassifierCommandIsHidden(t *testing.T) {
 	cmd := newClassifierCommand()
-	if !cmd.Hidden {
-		t.Errorf("classifier command should be Hidden=true; got false")
-	}
+	assert.True(t, cmd.Hidden,
+		"classifier command should be Hidden=true; got false")
 }

--- a/cmd/agentsview/classifier_wiring_test.go
+++ b/cmd/agentsview/classifier_wiring_test.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // triggerCalls names the qualified function calls that read
@@ -37,9 +39,7 @@ const wiringHelper = "applyClassifierConfig"
 // db package singleton.
 func TestEveryStoreOpenPathIsWired(t *testing.T) {
 	entries, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("listing cmd/agentsview: %v", err)
-	}
+	require.NoError(t, err, "listing cmd/agentsview")
 
 	fset := token.NewFileSet()
 	var violations []string
@@ -53,9 +53,7 @@ func TestEveryStoreOpenPathIsWired(t *testing.T) {
 			fset, filepath.Join(".", name), nil,
 			parser.ParseComments,
 		)
-		if err != nil {
-			t.Fatalf("parsing %s: %v", name, err)
-		}
+		require.NoError(t, err, "parsing %s", name)
 		violations = append(
 			violations, scanFile(fset, f)...,
 		)

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -3,11 +3,11 @@ package main
 import (
 	"bytes"
 	"os"
-	"slices"
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func executeCommand(root *cobra.Command, args ...string) (string, error) {
@@ -27,9 +27,7 @@ func executeCommandC(root *cobra.Command, args ...string) (*cobra.Command, strin
 
 func TestRootHelpShowsKeySectionsAndCommands(t *testing.T) {
 	help, err := executeCommand(newRootCommand(), "--help")
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
+	require.NoError(t, err, "Execute")
 	for _, want := range []string{
 		"Usage:\n  agentsview [flags]\n  agentsview <command> [flags]",
 		"Core Commands:",
@@ -43,41 +41,32 @@ func TestRootHelpShowsKeySectionsAndCommands(t *testing.T) {
 		"Flags:",
 		"--version",
 	} {
-		if !strings.Contains(help, want) {
-			t.Fatalf("help missing %q\n%s", want, help)
-		}
+		assert.Contains(t, help, want, "help missing %q", want)
 	}
 	for _, unwanted := range []string{
 		"--host string",
 		"--port int",
 	} {
-		if strings.Contains(help, unwanted) {
-			t.Fatalf("root help should not include serve flag %q\n%s", unwanted, help)
-		}
+		assert.NotContains(t, help, unwanted,
+			"root help should not include serve flag %q", unwanted)
 	}
 }
 
 func TestRootNoArgsShowsHelp(t *testing.T) {
 	out, err := executeCommand(newRootCommand())
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
+	require.NoError(t, err, "Execute")
 	for _, want := range []string{
 		"Usage:\n  agentsview [flags]\n  agentsview <command> [flags]",
 		"Core Commands:",
 		"serve                  Start server",
 	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("output missing %q\n%s", want, out)
-		}
+		assert.Contains(t, out, want, "output missing %q", want)
 	}
 }
 
 func TestRootHelpKeepsSummaryClean(t *testing.T) {
 	help, err := executeCommand(newRootCommand(), "--help")
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
+	require.NoError(t, err, "Execute")
 	for _, unwanted := range []string{
 		"agentsview serve [flags]",
 		"\nCommands:\n",
@@ -86,9 +75,8 @@ func TestRootHelpKeepsSummaryClean(t *testing.T) {
 		"completion powershell",
 		"completion zsh",
 	} {
-		if strings.Contains(help, unwanted) {
-			t.Fatalf("root help should not include %q\n%s", unwanted, help)
-		}
+		assert.NotContains(t, help, unwanted,
+			"root help should not include %q", unwanted)
 	}
 }
 
@@ -105,36 +93,26 @@ func TestNormalizeFlagHelpWidth(t *testing.T) {
 		{in: 220, want: 160},
 	}
 	for _, tt := range tests {
-		if got := normalizeFlagHelpWidth(tt.in); got != tt.want {
-			t.Fatalf("normalizeFlagHelpWidth(%d) = %d, want %d", tt.in, got, tt.want)
-		}
+		assert.Equal(t, tt.want, normalizeFlagHelpWidth(tt.in),
+			"normalizeFlagHelpWidth(%d)", tt.in)
 	}
 }
 
 func TestFlagHelpWidthFallback(t *testing.T) {
-	if got := flagHelpWidth(&bytes.Buffer{}); got != 80 {
-		t.Fatalf("flagHelpWidth(buffer) = %d, want 80", got)
-	}
+	assert.Equal(t, 80, flagHelpWidth(&bytes.Buffer{}),
+		"flagHelpWidth(buffer)")
 
 	f, err := os.CreateTemp(t.TempDir(), "help-width")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
+	require.NoError(t, err, "CreateTemp")
 	defer f.Close()
 
-	if got := flagHelpWidth(f); got != 80 {
-		t.Fatalf("flagHelpWidth(file) = %d, want 80", got)
-	}
+	assert.Equal(t, 80, flagHelpWidth(f), "flagHelpWidth(file)")
 }
 
 func TestRootVersionFlag(t *testing.T) {
 	got, err := executeCommand(newRootCommand(), "--version")
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !strings.Contains(got, "agentsview ") {
-		t.Fatalf("version output = %q", got)
-	}
+	require.NoError(t, err, "Execute")
+	assert.Contains(t, got, "agentsview ", "version output = %q", got)
 }
 
 func TestNormalizeLegacyLongFlags(t *testing.T) {
@@ -155,17 +133,13 @@ func TestNormalizeLegacyLongFlags(t *testing.T) {
 		"--",
 		"-port", "1000",
 	}
-	if !slices.Equal(got, want) {
-		t.Fatalf("normalized = %#v, want %#v", got, want)
-	}
+	assert.Equal(t, want, got)
 	wantRewrites := []string{
 		"-host -> --host",
 		"-port -> --port",
 		"-full -> --full",
 	}
-	if !slices.Equal(rewrites, wantRewrites) {
-		t.Fatalf("rewrites = %#v, want %#v", rewrites, wantRewrites)
-	}
+	assert.Equal(t, wantRewrites, rewrites)
 }
 
 func TestNormalizeLegacyLongFlagsSkipsShortFlagsAndNumbers(t *testing.T) {
@@ -178,12 +152,8 @@ func TestNormalizeLegacyLongFlagsSkipsShortFlagsAndNumbers(t *testing.T) {
 		"--port", "9090",
 	}, flags)
 	want := []string{"-h", "-v", "-1", "-abc", "--port", "9090"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("normalized = %#v, want %#v", got, want)
-	}
-	if len(rewrites) != 0 {
-		t.Fatalf("rewrites = %#v, want none", rewrites)
-	}
+	assert.Equal(t, want, got)
+	assert.Empty(t, rewrites)
 }
 
 func TestLegacyLongFlagWarning(t *testing.T) {
@@ -192,21 +162,16 @@ func TestLegacyLongFlagWarning(t *testing.T) {
 		"-port -> --port",
 	})
 	want := "warning: deprecated single-dash long flags detected; use GNU-style long flags instead: -host -> --host, -port -> --port\n"
-	if got != want {
-		t.Fatalf("warning = %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestExecuteCLIWithLegacyFlagCompatWarnsOnce(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	if err := executeCLIWithLegacyFlagCompat([]string{"-version"}, &stdout, &stderr); err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !strings.Contains(stdout.String(), "agentsview ") {
-		t.Fatalf("version output = %q", stdout.String())
-	}
+	require.NoError(t,
+		executeCLIWithLegacyFlagCompat([]string{"-version"}, &stdout, &stderr),
+		"Execute")
+	assert.Contains(t, stdout.String(), "agentsview ",
+		"version output = %q", stdout.String())
 	want := "warning: deprecated single-dash long flags detected; use GNU-style long flags instead: -version -> --version\n"
-	if stderr.String() != want {
-		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
-	}
+	assert.Equal(t, want, stderr.String())
 }

--- a/cmd/agentsview/health_test.go
+++ b/cmd/agentsview/health_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -23,10 +24,7 @@ func TestGradeCell(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := gradeCell(tc.in); got != tc.want {
-				t.Errorf("gradeCell = %q, want %q",
-					got, tc.want)
-			}
+			assert.Equal(t, tc.want, gradeCell(tc.in))
 		})
 	}
 }
@@ -43,22 +41,15 @@ func TestFormatPressure(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := formatPressure(tc.in); got != tc.want {
-				t.Errorf("formatPressure = %q, want %q",
-					got, tc.want)
-			}
+			assert.Equal(t, tc.want, formatPressure(tc.in))
 		})
 	}
 }
 
 func TestFormatScore(t *testing.T) {
 	score := 87
-	if got := formatScore(nil); got != "" {
-		t.Errorf("nil score = %q, want empty", got)
-	}
-	if got := formatScore(&score); got != " (score 87)" {
-		t.Errorf("score = %q, want ' (score 87)'", got)
-	}
+	assert.Empty(t, formatScore(nil), "nil score should be empty")
+	assert.Equal(t, " (score 87)", formatScore(&score))
 }
 
 func TestFormatConfidence(t *testing.T) {
@@ -88,11 +79,7 @@ func TestFormatConfidence(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := formatConfidence(tc.conf, tc.endedWith)
-			if got != tc.want {
-				t.Errorf("formatConfidence = %q, want %q",
-					got, tc.want)
-			}
+			assert.Equal(t, tc.want, formatConfidence(tc.conf, tc.endedWith))
 		})
 	}
 }
@@ -117,10 +104,8 @@ func TestShortDate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := shortDate(tc.in); got != tc.want {
-				t.Errorf("shortDate(%q) = %q, want %q",
-					tc.in, got, tc.want)
-			}
+			assert.Equal(t, tc.want, shortDate(tc.in),
+				"shortDate(%q)", tc.in)
 		})
 	}
 }
@@ -139,10 +124,8 @@ func TestTruncate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := truncate(tc.in, tc.n); got != tc.want {
-				t.Errorf("truncate(%q, %d) = %q, want %q",
-					tc.in, tc.n, got, tc.want)
-			}
+			assert.Equal(t, tc.want, truncate(tc.in, tc.n),
+				"truncate(%q, %d)", tc.in, tc.n)
 		})
 	}
 }
@@ -159,10 +142,8 @@ func TestShortID(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := shortID(tc.in); got != tc.want {
-				t.Errorf("shortID(%q) = %q, want %q",
-					tc.in, got, tc.want)
-			}
+			assert.Equal(t, tc.want, shortID(tc.in),
+				"shortID(%q)", tc.in)
 		})
 	}
 }
@@ -204,10 +185,7 @@ func TestPrintHealthList(t *testing.T) {
 		"roborev", "codex", "D", "failed",
 		"abc12345", "def67890",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q\n--- output ---\n%s",
-				want, out)
-		}
+		assert.Contains(t, out, want, "output missing %q", want)
 	}
 }
 
@@ -258,30 +236,22 @@ func TestPrintHealthDetail(t *testing.T) {
 		"Compactions:          1",
 		"Context pressure:     45%",
 	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q\n--- output ---\n%s",
-				want, out)
-		}
+		assert.Contains(t, out, want, "output missing %q", want)
 	}
 }
 
 func TestResolveSessionID(t *testing.T) {
 	dir := t.TempDir()
 	database, err := db.Open(filepath.Join(dir, "test.db"))
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
+	require.NoError(t, err, "open db")
 	t.Cleanup(func() { database.Close() })
 
 	upsert := func(id string) {
 		t.Helper()
-		err := database.UpsertSession(db.Session{
+		require.NoError(t, database.UpsertSession(db.Session{
 			ID: id, Project: "p", Machine: "m",
 			Agent: "claude", MessageCount: 1,
-		})
-		if err != nil {
-			t.Fatalf("upsert %q: %v", id, err)
-		}
+		}), "upsert %q", id)
 	}
 
 	// "abcdef12" is both a full session ID and the short-ID
@@ -301,46 +271,30 @@ func TestResolveSessionID(t *testing.T) {
 
 	t.Run("unique substring resolves", func(t *testing.T) {
 		got, err := resolveSessionID(ctx, database, "unique")
-		if err != nil {
-			t.Fatalf("resolveSessionID: %v", err)
-		}
-		if got != "unique-session-id" {
-			t.Errorf("got %q, want unique-session-id", got)
-		}
+		require.NoError(t, err, "resolveSessionID")
+		assert.Equal(t, "unique-session-id", got)
 	})
 
 	t.Run("exact full id matching another short id is ambiguous",
 		func(t *testing.T) {
 			_, err := resolveSessionID(ctx, database, "abcdef12")
-			if err == nil {
-				t.Fatal("expected ambiguity error, got nil")
-			}
-			if !strings.Contains(err.Error(), "ambiguous") {
-				t.Errorf("error %q lacks 'ambiguous'",
-					err.Error())
-			}
+			require.Error(t, err, "expected ambiguity error")
+			assert.Contains(t, err.Error(), "ambiguous",
+				"error lacks 'ambiguous'")
 		})
 
 	t.Run("no match returns empty", func(t *testing.T) {
 		got, err := resolveSessionID(ctx, database, "zzznope")
-		if err != nil {
-			t.Fatalf("resolveSessionID: %v", err)
-		}
-		if got != "" {
-			t.Errorf("got %q, want empty", got)
-		}
+		require.NoError(t, err, "resolveSessionID")
+		assert.Empty(t, got)
 	})
 
 	t.Run("unique full id resolves", func(t *testing.T) {
 		got, err := resolveSessionID(
 			ctx, database, "abcdef1234567890",
 		)
-		if err != nil {
-			t.Fatalf("resolveSessionID: %v", err)
-		}
-		if got != "abcdef1234567890" {
-			t.Errorf("got %q, want abcdef1234567890", got)
-		}
+		require.NoError(t, err, "resolveSessionID")
+		assert.Equal(t, "abcdef1234567890", got)
 	})
 
 	t.Run("exact id contained in host-prefixed id resolves",
@@ -348,15 +302,8 @@ func TestResolveSessionID(t *testing.T) {
 			got, err := resolveSessionID(
 				ctx, database, "local-uuid-aaaa-bbbb",
 			)
-			if err != nil {
-				t.Fatalf("resolveSessionID: %v", err)
-			}
-			if got != "local-uuid-aaaa-bbbb" {
-				t.Errorf(
-					"got %q, want local-uuid-aaaa-bbbb",
-					got,
-				)
-			}
+			require.NoError(t, err, "resolveSessionID")
+			assert.Equal(t, "local-uuid-aaaa-bbbb", got)
 		})
 }
 
@@ -369,21 +316,16 @@ func TestResolveSessionID(t *testing.T) {
 func TestResolveSessionIDCollisionBeyondTopFew(t *testing.T) {
 	dir := t.TempDir()
 	database, err := db.Open(filepath.Join(dir, "test.db"))
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
+	require.NoError(t, err, "open db")
 	t.Cleanup(func() { database.Close() })
 
 	upsert := func(id string, started string) {
 		t.Helper()
-		err := database.UpsertSession(db.Session{
+		require.NoError(t, database.UpsertSession(db.Session{
 			ID: id, Project: "p", Machine: "m",
 			Agent: "claude", MessageCount: 1,
 			StartedAt: &started,
-		})
-		if err != nil {
-			t.Fatalf("upsert %q: %v", id, err)
-		}
+		}), "upsert %q", id)
 	}
 
 	// shortID() truncates the segment after the last "~" to
@@ -411,12 +353,9 @@ func TestResolveSessionIDCollisionBeyondTopFew(t *testing.T) {
 
 	ctx := context.Background()
 	_, err = resolveSessionID(ctx, database, partial)
-	if err == nil {
-		t.Fatal("expected ambiguity error, got nil")
-	}
-	if !strings.Contains(err.Error(), "ambiguous") {
-		t.Errorf("error %q lacks 'ambiguous'", err.Error())
-	}
+	require.Error(t, err, "expected ambiguity error")
+	assert.Contains(t, err.Error(), "ambiguous",
+		"error lacks 'ambiguous'")
 }
 
 func parseLocalDate(t *testing.T, ts string) string {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -7,10 +7,11 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/sync"
 )
@@ -54,31 +55,17 @@ func TestMustLoadConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
 			cmd := newServeCommand()
-			if err := cmd.Flags().Parse(tt.args); err != nil {
-				t.Fatalf("Parse: %v", err)
-			}
+			require.NoError(t, cmd.Flags().Parse(tt.args), "Parse")
 			cfg := mustLoadConfig(cmd)
 
-			if cfg.Host != tt.wantHost {
-				t.Errorf("Host = %q, want %q", cfg.Host, tt.wantHost)
-			}
-			if cfg.Port != tt.wantPort {
-				t.Errorf("Port = %d, want %d", cfg.Port, tt.wantPort)
-			}
-			if cfg.PublicURL != tt.wantPublicURL {
-				t.Errorf("PublicURL = %q, want %q", cfg.PublicURL, tt.wantPublicURL)
-			}
-			if cfg.Proxy.Mode != tt.wantProxyMode {
-				t.Errorf("Proxy.Mode = %q, want %q", cfg.Proxy.Mode, tt.wantProxyMode)
-			}
+			assert.Equal(t, tt.wantHost, cfg.Host)
+			assert.Equal(t, tt.wantPort, cfg.Port)
+			assert.Equal(t, tt.wantPublicURL, cfg.PublicURL)
+			assert.Equal(t, tt.wantProxyMode, cfg.Proxy.Mode)
 
-			if cfg.DataDir == "" {
-				t.Error("DataDir should be set")
-			}
+			assert.NotEmpty(t, cfg.DataDir, "DataDir should be set")
 			wantDBPath := filepath.Join(cfg.DataDir, "sessions.db")
-			if cfg.DBPath != wantDBPath {
-				t.Errorf("DBPath = %q, want %q", cfg.DBPath, wantDBPath)
-			}
+			assert.Equal(t, wantDBPath, cfg.DBPath)
 		})
 	}
 }
@@ -99,18 +86,12 @@ func TestPrepareServeRuntimeConfigPortZeroUsesAssignedPort(t *testing.T) {
 			},
 		)
 	})
-	if err != nil {
-		t.Fatalf("prepareServeRuntimeConfig: %v", err)
-	}
-	if cfg.Port == 0 {
-		t.Fatal("Port remained literal 0")
-	}
-	if strings.Contains(out, "Port 0 in use") {
-		t.Fatalf("unexpected literal port 0 fallback message: %q", out)
-	}
-	if !strings.Contains(out, "Using available port") {
-		t.Fatalf("missing ephemeral port message: %q", out)
-	}
+	require.NoError(t, err, "prepareServeRuntimeConfig")
+	assert.NotZero(t, cfg.Port, "Port remained literal 0")
+	assert.NotContains(t, out, "Port 0 in use",
+		"unexpected literal port 0 fallback message")
+	assert.Contains(t, out, "Using available port",
+		"missing ephemeral port message")
 }
 
 func captureStdout(t *testing.T, fn func()) string {
@@ -118,9 +99,7 @@ func captureStdout(t *testing.T, fn func()) string {
 
 	orig := os.Stdout
 	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
+	require.NoError(t, err, "pipe")
 	os.Stdout = w
 	t.Cleanup(func() {
 		os.Stdout = orig
@@ -128,18 +107,12 @@ func captureStdout(t *testing.T, fn func()) string {
 
 	fn()
 
-	if err := w.Close(); err != nil {
-		t.Fatalf("close stdout pipe writer: %v", err)
-	}
+	require.NoError(t, w.Close(), "close stdout pipe writer")
 	os.Stdout = orig
 
 	data, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read stdout pipe: %v", err)
-	}
-	if err := r.Close(); err != nil {
-		t.Fatalf("close stdout pipe reader: %v", err)
-	}
+	require.NoError(t, err, "read stdout pipe")
+	require.NoError(t, r.Close(), "close stdout pipe reader")
 	return string(data)
 }
 
@@ -164,14 +137,9 @@ func TestSetupLogFile(t *testing.T) {
 
 	logPath := filepath.Join(dir, "debug.log")
 	data, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("reading log file: %v", err)
-	}
-	if !strings.Contains(string(data), "test-log-message") {
-		t.Errorf(
-			"log file missing message, got: %q", data,
-		)
-	}
+	require.NoError(t, err, "reading log file")
+	assert.Contains(t, string(data), "test-log-message",
+		"log file missing message")
 }
 
 func TestSetupLogFileOpenFailure(t *testing.T) {
@@ -189,12 +157,8 @@ func TestSetupLogFileOpenFailure(t *testing.T) {
 
 	setupLogFile(tmpFile)
 
-	if !strings.Contains(buf.String(), "cannot open log file") {
-		t.Errorf(
-			"expected warning about log file, got: %q",
-			buf.String(),
-		)
-	}
+	assert.Contains(t, buf.String(), "cannot open log file",
+		"expected warning about log file")
 }
 
 func TestTruncateLogFile(t *testing.T) {
@@ -209,12 +173,8 @@ func TestTruncateLogFile(t *testing.T) {
 	truncateLogFile(path, 512)
 
 	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat after truncate: %v", err)
-	}
-	if info.Size() != 0 {
-		t.Errorf("size after truncate = %d, want 0", info.Size())
-	}
+	require.NoError(t, err, "stat after truncate")
+	assert.Equal(t, int64(0), info.Size())
 }
 
 func TestTruncateLogFileUnderLimit(t *testing.T) {
@@ -228,12 +188,8 @@ func TestTruncateLogFileUnderLimit(t *testing.T) {
 	truncateLogFile(path, 1024)
 
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read after truncate: %v", err)
-	}
-	if string(data) != string(content) {
-		t.Errorf("content changed: got %q", data)
-	}
+	require.NoError(t, err, "read after truncate")
+	assert.Equal(t, string(content), string(data), "content changed")
 }
 
 func TestTruncateLogFileMissing(t *testing.T) {
@@ -249,9 +205,7 @@ func TestTruncateLogFileSymlink(t *testing.T) {
 
 	// Write a target file larger than the limit.
 	big := bytes.Repeat([]byte("x"), 1024)
-	if err := os.WriteFile(target, big, 0o644); err != nil {
-		t.Fatalf("write target: %v", err)
-	}
+	require.NoError(t, os.WriteFile(target, big, 0o644), "write target")
 	if err := os.Symlink(target, link); err != nil {
 		if errors.Is(err, syscall.EPERM) ||
 			errors.Is(err, syscall.EACCES) ||
@@ -267,15 +221,8 @@ func TestTruncateLogFileSymlink(t *testing.T) {
 	truncateLogFile(link, 512)
 
 	data, err := os.ReadFile(target)
-	if err != nil {
-		t.Fatalf("read target: %v", err)
-	}
-	if len(data) != 1024 {
-		t.Errorf(
-			"symlink target was truncated: size=%d, want 1024",
-			len(data),
-		)
-	}
+	require.NoError(t, err, "read target")
+	assert.Len(t, data, 1024, "symlink target was truncated")
 }
 
 func TestResyncCoversSignals(t *testing.T) {
@@ -316,12 +263,7 @@ func TestResyncCoversSignals(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := resyncCoversSignals(tc.stats, tc.fellBack)
-			if got != tc.want {
-				t.Errorf(
-					"resyncCoversSignals = %v, want %v",
-					got, tc.want,
-				)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/cmd/agentsview/managed_caddy_test.go
+++ b/cmd/agentsview/managed_caddy_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -18,21 +20,15 @@ func TestBrowserURLUsesPublicURL(t *testing.T) {
 		Port:      8080,
 		PublicURL: "https://viewer.example.test",
 	}
-	if got := browserURL(cfg); got != "https://viewer.example.test" {
-		t.Fatalf("browserURL = %q, want %q", got, "https://viewer.example.test")
-	}
+	assert.Equal(t, "https://viewer.example.test", browserURL(cfg))
 }
 
 func TestValidateServeConfigManagedCaddyAllowsHTTPS(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, "viewer.crt")
 	keyPath := filepath.Join(dir, "viewer.key")
-	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(certPath, []byte("cert"), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, []byte("key"), 0o600))
 
 	cfg := config.Config{
 		Host:      "127.0.0.1",
@@ -46,9 +42,7 @@ func TestValidateServeConfigManagedCaddyAllowsHTTPS(t *testing.T) {
 			AllowedSubnets: []string{"10.0.0.0/16"},
 		},
 	}
-	if err := validateServeConfig(cfg); err != nil {
-		t.Fatalf("validateServeConfig returned error: %v", err)
-	}
+	assert.NoError(t, validateServeConfig(cfg))
 }
 
 func TestValidateServeConfigManagedCaddyRejectsNonLoopbackHost(t *testing.T) {
@@ -62,24 +56,16 @@ func TestValidateServeConfigManagedCaddyRejectsNonLoopbackHost(t *testing.T) {
 		},
 	}
 	err := validateServeConfig(cfg)
-	if err == nil {
-		t.Fatal("expected error for non-loopback backend host")
-	}
-	if !strings.Contains(err.Error(), "loopback backend host") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err, "expected error for non-loopback backend host")
+	assert.Contains(t, err.Error(), "loopback backend host")
 }
 
 func TestValidateServeConfigManagedCaddyRequiresAllowlistForNonLoopbackBind(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, "viewer.crt")
 	keyPath := filepath.Join(dir, "viewer.key")
-	if err := os.WriteFile(certPath, []byte("cert"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(certPath, []byte("cert"), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, []byte("key"), 0o600))
 
 	cfg := config.Config{
 		Host:      "127.0.0.1",
@@ -94,12 +80,8 @@ func TestValidateServeConfigManagedCaddyRequiresAllowlistForNonLoopbackBind(t *t
 		},
 	}
 	err := validateServeConfig(cfg)
-	if err == nil {
-		t.Fatal("expected non-loopback bind allowlist error")
-	}
-	if !strings.Contains(err.Error(), "allowed_subnet") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err, "expected non-loopback bind allowlist error")
+	assert.Contains(t, err.Error(), "allowed_subnet")
 }
 
 func TestValidateServeConfigManagedCaddyRejectsHTTPWithTLS(t *testing.T) {
@@ -115,12 +97,8 @@ func TestValidateServeConfigManagedCaddyRejectsHTTPWithTLS(t *testing.T) {
 		},
 	}
 	err := validateServeConfig(cfg)
-	if err == nil {
-		t.Fatal("expected HTTP-with-TLS error")
-	}
-	if !strings.Contains(err.Error(), "HTTP mode") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err, "expected HTTP-with-TLS error")
+	assert.Contains(t, err.Error(), "HTTP mode")
 }
 
 func TestBuildManagedCaddyfileIncludesAllowlistAndTLS(t *testing.T) {
@@ -143,9 +121,8 @@ func TestBuildManagedCaddyfileIncludesAllowlistAndTLS(t *testing.T) {
 		"tls \"/tmp/viewer.crt\" \"/tmp/viewer.key\"",
 		"reverse_proxy 127.0.0.1:8080",
 	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("generated caddyfile missing %q:\n%s", want, got)
-		}
+		assert.Contains(t, got, want,
+			"generated caddyfile missing %q", want)
 	}
 }
 
@@ -155,21 +132,16 @@ func TestManagedCaddyConfigPathNamespacesMode(t *testing.T) {
 	gotServe := managedCaddyConfigPath(dataDir, "serve")
 	gotPG := managedCaddyConfigPath(dataDir, "pg-serve")
 
-	if gotServe == gotPG {
-		t.Fatal("managed caddy paths must differ by mode")
-	}
-	if !strings.HasSuffix(
+	assert.NotEqual(t, gotServe, gotPG,
+		"managed caddy paths must differ by mode")
+	assert.True(t, strings.HasSuffix(
 		gotServe,
 		filepath.Join("managed-caddy", "serve", "Caddyfile"),
-	) {
-		t.Fatalf("serve path = %q", gotServe)
-	}
-	if !strings.HasSuffix(
+	), "serve path = %q", gotServe)
+	assert.True(t, strings.HasSuffix(
 		gotPG,
 		filepath.Join("managed-caddy", "pg-serve", "Caddyfile"),
-	) {
-		t.Fatalf("pg path = %q", gotPG)
-	}
+	), "pg path = %q", gotPG)
 }
 
 func TestPrepareManagedCaddyConfigForPGServeUsesNamespacedPathAndBackend(t *testing.T) {
@@ -190,18 +162,12 @@ func TestPrepareManagedCaddyConfigForPGServeUsesNamespacedPathAndBackend(t *test
 		"pg-serve",
 		"127.0.0.1:18080",
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasSuffix(
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(
 		path,
 		filepath.Join("managed-caddy", "pg-serve", "Caddyfile"),
-	) {
-		t.Fatalf("path = %q", path)
-	}
-	if !strings.Contains(content, "reverse_proxy 127.0.0.1:18080") {
-		t.Fatalf("content = %s", content)
-	}
+	), "path = %q", path)
+	assert.Contains(t, content, "reverse_proxy 127.0.0.1:18080")
 }
 
 func TestRewriteConfiguredPublicURLPort_RewritesMatchingExplicitPort(t *testing.T) {
@@ -211,18 +177,11 @@ func TestRewriteConfiguredPublicURLPort_RewritesMatchingExplicitPort(t *testing.
 		8004,
 		8005,
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !changed {
-		t.Fatal("expected public URL rewrite")
-	}
-	if updatedURL != "http://viewer.example.test:8005" {
-		t.Fatalf("updatedURL = %q, want %q", updatedURL, "http://viewer.example.test:8005")
-	}
-	if got := strings.Join(updatedOrigins, ","); got != "http://viewer.example.test:8005" {
-		t.Fatalf("updatedOrigins = %q, want %q", got, "http://viewer.example.test:8005")
-	}
+	require.NoError(t, err)
+	assert.True(t, changed, "expected public URL rewrite")
+	assert.Equal(t, "http://viewer.example.test:8005", updatedURL)
+	assert.Equal(t, "http://viewer.example.test:8005",
+		strings.Join(updatedOrigins, ","))
 }
 
 func TestRewriteConfiguredPublicURLPort_PreservesExternalProxyPort(t *testing.T) {
@@ -232,18 +191,11 @@ func TestRewriteConfiguredPublicURLPort_PreservesExternalProxyPort(t *testing.T)
 		8080,
 		8081,
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if changed {
-		t.Fatal("expected public URL to remain unchanged")
-	}
-	if updatedURL != "https://viewer.example.test" {
-		t.Fatalf("updatedURL = %q, want %q", updatedURL, "https://viewer.example.test")
-	}
-	if got := strings.Join(updatedOrigins, ","); got != "https://viewer.example.test" {
-		t.Fatalf("updatedOrigins = %q, want %q", got, "https://viewer.example.test")
-	}
+	require.NoError(t, err)
+	assert.False(t, changed, "expected public URL to remain unchanged")
+	assert.Equal(t, "https://viewer.example.test", updatedURL)
+	assert.Equal(t, "https://viewer.example.test",
+		strings.Join(updatedOrigins, ","))
 }
 
 func TestReadinessProbeHost(t *testing.T) {
@@ -255,9 +207,8 @@ func TestReadinessProbeHost(t *testing.T) {
 		"10.0.60.2": "10.0.60.2",
 	}
 	for input, want := range tests {
-		if got := readinessProbeHost(input); got != want {
-			t.Fatalf("readinessProbeHost(%q) = %q, want %q", input, got, want)
-		}
+		assert.Equal(t, want, readinessProbeHost(input),
+			"readinessProbeHost(%q)", input)
 	}
 }
 
@@ -271,9 +222,8 @@ func TestWaitForLocalPortReturnsEarlyOnErrorChannel(t *testing.T) {
 		5*time.Second,
 		errCh,
 	)
-	if err == nil || !strings.Contains(err.Error(), "backend failed") {
-		t.Fatalf("expected backend failure, got %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backend failed")
 }
 
 func TestWaitForLocalPortHonorsContextCancellation(t *testing.T) {
@@ -286,9 +236,7 @@ func TestWaitForLocalPortHonorsContextCancellation(t *testing.T) {
 		5*time.Second,
 		nil,
 	)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context cancellation, got %v", err)
-	}
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestWaitForLocalPortPrefersContextCancellationOverError(t *testing.T) {
@@ -303,7 +251,5 @@ func TestWaitForLocalPortPrefersContextCancellationOverError(t *testing.T) {
 		5*time.Second,
 		errCh,
 	)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context cancellation, got %v", err)
-	}
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/cmd/agentsview/pg_test.go
+++ b/cmd/agentsview/pg_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -38,32 +40,16 @@ allowed_subnets = ["10.0.0.0/16"]
 [pg]
 url = "postgres://user:pass@db.example.test:5432/agentsview?sslmode=require"
 `), 0o600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cfg, _, err := loadPGServeConfigForTest(t)
-	if err != nil {
-		t.Fatalf("loadPGServeConfigForTest: %v", err)
-	}
-	if cfg.PG.URL == "" {
-		t.Fatal("expected PG URL")
-	}
-	if cfg.PublicURL != "" {
-		t.Fatalf("PublicURL = %q, want empty", cfg.PublicURL)
-	}
-	if len(cfg.PublicOrigins) != 0 {
-		t.Fatalf("PublicOrigins = %v, want empty", cfg.PublicOrigins)
-	}
-	if cfg.Proxy.Mode != "" {
-		t.Fatalf("Proxy.Mode = %q, want empty", cfg.Proxy.Mode)
-	}
-	if cfg.Host != "127.0.0.1" {
-		t.Fatalf("Host = %q, want %q", cfg.Host, "127.0.0.1")
-	}
-	if cfg.Port != 8080 {
-		t.Fatalf("Port = %d, want %d", cfg.Port, 8080)
-	}
+	require.NoError(t, err, "loadPGServeConfigForTest")
+	require.NotEmpty(t, cfg.PG.URL, "expected PG URL")
+	assert.Empty(t, cfg.PublicURL, "PublicURL should be empty")
+	assert.Empty(t, cfg.PublicOrigins, "PublicOrigins should be empty")
+	assert.Empty(t, cfg.Proxy.Mode, "Proxy.Mode should be empty")
+	assert.Equal(t, "127.0.0.1", cfg.Host)
+	assert.Equal(t, 8080, cfg.Port)
 }
 
 func TestLoadPGServeConfigIgnoresInvalidPersistedServeSettings(t *testing.T) {
@@ -79,23 +65,13 @@ mode = "bogus"
 [pg]
 url = "postgres://user:pass@db.example.test:5432/agentsview?sslmode=require"
 `), 0o600)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cfg, _, err := loadPGServeConfigForTest(t)
-	if err != nil {
-		t.Fatalf("loadPGServeConfigForTest: %v", err)
-	}
-	if cfg.PG.URL == "" {
-		t.Fatal("expected PG URL")
-	}
-	if cfg.PublicURL != "" {
-		t.Fatalf("PublicURL = %q, want empty", cfg.PublicURL)
-	}
-	if cfg.Proxy.Mode != "" {
-		t.Fatalf("Proxy.Mode = %q, want empty", cfg.Proxy.Mode)
-	}
+	require.NoError(t, err, "loadPGServeConfigForTest")
+	require.NotEmpty(t, cfg.PG.URL, "expected PG URL")
+	assert.Empty(t, cfg.PublicURL, "PublicURL should be empty")
+	assert.Empty(t, cfg.Proxy.Mode, "Proxy.Mode should be empty")
 }
 
 func TestPGServeConfigAcceptsManagedCaddyFlags(t *testing.T) {
@@ -114,67 +90,20 @@ func TestPGServeConfigAcceptsManagedCaddyFlags(t *testing.T) {
 		"--tls-key", "/tmp/viewer.key",
 		"--allowed-subnet", "10.0.0.0/16",
 	)
-	if err != nil {
-		t.Fatalf("loadPGServeConfigForTest: %v", err)
-	}
-	if cfg.Proxy.Mode != "caddy" {
-		t.Fatalf(
-			"Proxy.Mode = %q, want %q",
-			cfg.Proxy.Mode,
-			"caddy",
-		)
-	}
-	if cfg.PublicURL != "https://viewer.example.test:8443" {
-		t.Fatalf("PublicURL = %q", cfg.PublicURL)
-	}
-	if got := strings.Join(cfg.PublicOrigins, ","); got != "https://app.example.test,https://viewer.example.test:8443" {
-		t.Fatalf(
-			"PublicOrigins = %q, want %q",
-			got,
-			"https://app.example.test,https://viewer.example.test:8443",
-		)
-	}
-	if cfg.Proxy.Bin != "/usr/local/bin/caddy" {
-		t.Fatalf(
-			"Proxy.Bin = %q, want %q",
-			cfg.Proxy.Bin,
-			"/usr/local/bin/caddy",
-		)
-	}
-	if cfg.Proxy.BindHost != "0.0.0.0" {
-		t.Fatalf(
-			"Proxy.BindHost = %q, want %q",
-			cfg.Proxy.BindHost,
-			"0.0.0.0",
-		)
-	}
-	if cfg.Proxy.PublicPort != 8443 {
-		t.Fatalf("Proxy.PublicPort = %d, want %d", cfg.Proxy.PublicPort, 8443)
-	}
-	if cfg.Proxy.TLSCert != "/tmp/viewer.crt" {
-		t.Fatalf(
-			"Proxy.TLSCert = %q, want %q",
-			cfg.Proxy.TLSCert,
-			"/tmp/viewer.crt",
-		)
-	}
-	if cfg.Proxy.TLSKey != "/tmp/viewer.key" {
-		t.Fatalf(
-			"Proxy.TLSKey = %q, want %q",
-			cfg.Proxy.TLSKey,
-			"/tmp/viewer.key",
-		)
-	}
-	if got := strings.Join(cfg.Proxy.AllowedSubnets, ","); got != "10.0.0.0/16" {
-		t.Fatalf(
-			"Proxy.AllowedSubnets = %q, want %q",
-			got,
-			"10.0.0.0/16",
-		)
-	}
-	if basePath != "" {
-		t.Fatalf("basePath = %q, want empty", basePath)
-	}
+	require.NoError(t, err, "loadPGServeConfigForTest")
+	assert.Equal(t, "caddy", cfg.Proxy.Mode)
+	assert.Equal(t, "https://viewer.example.test:8443", cfg.PublicURL)
+	assert.Equal(t,
+		"https://app.example.test,https://viewer.example.test:8443",
+		strings.Join(cfg.PublicOrigins, ","))
+	assert.Equal(t, "/usr/local/bin/caddy", cfg.Proxy.Bin)
+	assert.Equal(t, "0.0.0.0", cfg.Proxy.BindHost)
+	assert.Equal(t, 8443, cfg.Proxy.PublicPort)
+	assert.Equal(t, "/tmp/viewer.crt", cfg.Proxy.TLSCert)
+	assert.Equal(t, "/tmp/viewer.key", cfg.Proxy.TLSKey)
+	assert.Equal(t, "10.0.0.0/16",
+		strings.Join(cfg.Proxy.AllowedSubnets, ","))
+	assert.Empty(t, basePath, "basePath should be empty")
 }
 
 func TestRunPGServeRejectsInvalidManagedCaddyConfigBeforePGSetup(t *testing.T) {
@@ -192,12 +121,8 @@ func TestRunPGServeRejectsInvalidManagedCaddyConfigBeforePGSetup(t *testing.T) {
 		"AGENTSVIEW_DATA_DIR="+dataDir,
 	)
 	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("runPGServe unexpectedly succeeded")
-	}
-	if !strings.Contains(string(out), "loopback backend host") {
-		t.Fatalf("output = %s", out)
-	}
+	require.Error(t, err, "runPGServe unexpectedly succeeded")
+	assert.Contains(t, string(out), "loopback backend host")
 }
 
 func TestRunPGServeNonLoopbackWithoutProxyFallsThroughToPGConfig(t *testing.T) {
@@ -213,16 +138,11 @@ func TestRunPGServeNonLoopbackWithoutProxyFallsThroughToPGConfig(t *testing.T) {
 		"AGENTSVIEW_DATA_DIR="+dataDir,
 	)
 	out, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatal("runPGServe unexpectedly succeeded")
-	}
+	require.Error(t, err, "runPGServe unexpectedly succeeded")
 	output := string(out)
-	if strings.Contains(output, "invalid serve config") {
-		t.Fatalf("unexpected serve validation failure: %s", output)
-	}
-	if !strings.Contains(output, "pg serve: url not configured") {
-		t.Fatalf("output = %s", output)
-	}
+	assert.NotContains(t, output, "invalid serve config",
+		"unexpected serve validation failure")
+	assert.Contains(t, output, "pg serve: url not configured")
 }
 
 func TestRunPGServeHelperProcess(t *testing.T) {
@@ -238,17 +158,11 @@ func TestRunPGServeHelperProcess(t *testing.T) {
 			break
 		}
 	}
-	if sep == -1 {
-		t.Fatal("missing argument separator")
-	}
+	require.NotEqual(t, -1, sep, "missing argument separator")
 
 	cmd := newPGServeCommand()
-	if err := cmd.Flags().Parse(args[sep+1:]); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, cmd.Flags().Parse(args[sep+1:]))
 	cfg, basePath, err := loadPGServeConfig(cmd)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	runPGServe(cfg, basePath)
 }

--- a/cmd/agentsview/prune_test.go
+++ b/cmd/agentsview/prune_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 )
@@ -32,15 +33,9 @@ func TestParsePruneFlags(t *testing.T) {
 			args: []string{"--project", "myapp"},
 			check: func(t *testing.T, cfg PruneConfig) {
 				t.Helper()
-				if cfg.Filter.Project != "myapp" {
-					t.Errorf(
-						"Project = %q, want %q",
-						cfg.Filter.Project, "myapp",
-					)
-				}
-				if cfg.DryRun || cfg.Yes {
-					t.Error("unexpected flag defaults")
-				}
+				assert.Equal(t, "myapp", cfg.Filter.Project)
+				assert.False(t, cfg.DryRun, "DryRun default")
+				assert.False(t, cfg.Yes, "Yes default")
 			},
 		},
 		{
@@ -55,29 +50,13 @@ func TestParsePruneFlags(t *testing.T) {
 			},
 			check: func(t *testing.T, cfg PruneConfig) {
 				t.Helper()
-				if cfg.Filter.Project != "p" {
-					t.Errorf("Project = %q", cfg.Filter.Project)
-				}
-				if cfg.Filter.MaxMessages == nil || *cfg.Filter.MaxMessages != 5 {
-					t.Errorf(
-						"MaxMessages = %v", cfg.Filter.MaxMessages,
-					)
-				}
-				if cfg.Filter.Before != "2024-01-01" {
-					t.Errorf("Before = %q", cfg.Filter.Before)
-				}
-				if cfg.Filter.FirstMessage != "hello" {
-					t.Errorf(
-						"FirstMessage = %q",
-						cfg.Filter.FirstMessage,
-					)
-				}
-				if !cfg.DryRun {
-					t.Error("DryRun should be true")
-				}
-				if !cfg.Yes {
-					t.Error("Yes should be true")
-				}
+				assert.Equal(t, "p", cfg.Filter.Project)
+				require.NotNil(t, cfg.Filter.MaxMessages)
+				assert.Equal(t, 5, *cfg.Filter.MaxMessages)
+				assert.Equal(t, "2024-01-01", cfg.Filter.Before)
+				assert.Equal(t, "hello", cfg.Filter.FirstMessage)
+				assert.True(t, cfg.DryRun, "DryRun should be true")
+				assert.True(t, cfg.Yes, "Yes should be true")
 			},
 		},
 		{
@@ -96,19 +75,12 @@ func TestParsePruneFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := parsePruneFlags(tt.args)
 			if tt.wantErr != "" {
-				if err == nil {
-					t.Fatalf("expected error containing %q",
-						tt.wantErr)
-				}
-				if !strings.Contains(err.Error(), tt.wantErr) {
-					t.Fatalf("error %q missing %q",
-						err, tt.wantErr)
-				}
+				require.Error(t, err,
+					"expected error containing %q", tt.wantErr)
+				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			if tt.check != nil {
 				tt.check(t, cfg)
 			}
@@ -118,11 +90,7 @@ func TestParsePruneFlags(t *testing.T) {
 
 func TestParsePruneFlagsHelp(t *testing.T) {
 	_, err := parsePruneFlags([]string{"--help"})
-	if !errors.Is(err, flag.ErrHelp) {
-		t.Fatalf(
-			"expected flag.ErrHelp, got %v", err,
-		)
-	}
+	require.ErrorIs(t, err, flag.ErrHelp)
 }
 
 func TestPrunerEmptyFilterReturnsError(t *testing.T) {
@@ -134,15 +102,9 @@ func TestPrunerEmptyFilterReturnsError(t *testing.T) {
 	}
 
 	err := pruner.Prune(cfg)
-	if err == nil {
-		t.Fatal("expected error for empty filter")
-	}
-	if !strings.Contains(err.Error(), "at least one filter") {
-		t.Errorf(
-			"error %q should mention filter requirement",
-			err,
-		)
-	}
+	require.Error(t, err, "expected error for empty filter")
+	assert.Contains(t, err.Error(), "at least one filter",
+		"error should mention filter requirement")
 }
 
 func TestConfirm(t *testing.T) {
@@ -165,12 +127,9 @@ func TestConfirm(t *testing.T) {
 			in := strings.NewReader(tt.input)
 			out := &bytes.Buffer{}
 			got := confirm(in, out, "Delete?")
-			if got != tt.want {
-				t.Errorf("confirm() = %v, want %v", got, tt.want)
-			}
-			if !strings.Contains(out.String(), "[y/N]") {
-				t.Error("prompt missing [y/N]")
-			}
+			assert.Equal(t, tt.want, got)
+			assert.Contains(t, out.String(), "[y/N]",
+				"prompt missing [y/N]")
 		})
 	}
 }
@@ -192,9 +151,7 @@ By project:
   projA                                    2
   projB                                    1
 `
-	if out != want {
-		t.Errorf("writeSummary() mismatch\nwant:\n%s\ngot:\n%s", want, out)
-	}
+	assert.Equal(t, want, out, "writeSummary() mismatch")
 }
 
 func TestFormatBytes(t *testing.T) {
@@ -213,13 +170,8 @@ func TestFormatBytes(t *testing.T) {
 	for _, tt := range tests {
 		name := fmt.Sprintf("%d_bytes", tt.input)
 		t.Run(name, func(t *testing.T) {
-			got := formatBytes(tt.input)
-			if got != tt.want {
-				t.Errorf(
-					"formatBytes(%d) = %q, want %q",
-					tt.input, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, formatBytes(tt.input),
+				"formatBytes(%d)", tt.input)
 		})
 	}
 }
@@ -264,16 +216,11 @@ func TestPrunerMaxMessagesCountsUserOnly(t *testing.T) {
 		DryRun: true,
 	}
 
-	if err := pruner.Prune(cfg); err != nil {
-		t.Fatalf("Prune: %v", err)
-	}
+	require.NoError(t, pruner.Prune(cfg), "Prune")
 
 	out := buf.String()
-	if !strings.Contains(out, "Found 1 sessions") {
-		t.Errorf(
-			"expected 1 match (oneshot only), got: %s", out,
-		)
-	}
+	assert.Contains(t, out, "Found 1 sessions",
+		"expected 1 match (oneshot only)")
 }
 
 func TestPruner_PruneScenarios(t *testing.T) {
@@ -327,25 +274,23 @@ func TestPruner_PruneScenarios(t *testing.T) {
 			})
 
 			pruner, buf := newTestPruner(t, d, tt.input)
-			if err := pruner.Prune(tt.cfg); err != nil {
-				t.Fatalf("Prune: %v", err)
-			}
+			require.NoError(t, pruner.Prune(tt.cfg), "Prune")
 
 			out := buf.String()
 			for _, want := range tt.wantOutput {
-				if !strings.Contains(out, want) {
-					t.Errorf("expected output containing %q, got: %s", want, out)
-				}
+				assert.Contains(t, out, want,
+					"expected output containing %q", want)
 			}
-			if tt.cfg.Yes && strings.Contains(out, "[y/N]") {
-				t.Error("should not prompt when --yes is set")
+			if tt.cfg.Yes {
+				assert.NotContains(t, out, "[y/N]",
+					"should not prompt when --yes is set")
 			}
 
 			s, _ := d.GetSession(context.Background(), "s1")
-			if tt.wantKept && s == nil {
-				t.Error("session was deleted unexpectedly")
-			} else if !tt.wantKept && s != nil {
-				t.Error("session still exists")
+			if tt.wantKept {
+				assert.NotNil(t, s, "session was deleted unexpectedly")
+			} else {
+				assert.Nil(t, s, "session still exists")
 			}
 		})
 	}
@@ -354,36 +299,26 @@ func TestPruner_PruneScenarios(t *testing.T) {
 func TestDeleteFilesRemovesFiles(t *testing.T) {
 	dir := t.TempDir()
 	subdir := filepath.Join(dir, "session1")
-	if err := os.MkdirAll(subdir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
 
 	f := filepath.Join(subdir, "data.jsonl")
-	if err := os.WriteFile(f, []byte("test data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(f, []byte("test data"), 0o644))
 
 	sessions := []db.Session{
 		{ID: "s1", FilePath: new(f)},
 	}
 
 	removed, reclaimed := deleteFiles(sessions)
-	if removed != 1 {
-		t.Errorf("removed = %d, want 1", removed)
-	}
-	if reclaimed != 9 {
-		t.Errorf("reclaimed = %d, want 9", reclaimed)
-	}
+	assert.Equal(t, 1, removed)
+	assert.Equal(t, int64(9), reclaimed)
 
 	// File should be gone.
-	if _, err := os.Stat(f); !os.IsNotExist(err) {
-		t.Error("file still exists")
-	}
+	_, err := os.Stat(f)
+	assert.True(t, os.IsNotExist(err), "file still exists")
 
 	// Empty parent dir should be removed.
-	if _, err := os.Stat(subdir); !os.IsNotExist(err) {
-		t.Error("empty parent dir still exists")
-	}
+	_, err = os.Stat(subdir)
+	assert.True(t, os.IsNotExist(err), "empty parent dir still exists")
 }
 
 func TestDeleteFilesMissingFile(t *testing.T) {
@@ -392,12 +327,8 @@ func TestDeleteFilesMissingFile(t *testing.T) {
 	}
 
 	removed, reclaimed := deleteFiles(sessions)
-	if removed != 0 {
-		t.Errorf("removed = %d, want 0", removed)
-	}
-	if reclaimed != 0 {
-		t.Errorf("reclaimed = %d, want 0", reclaimed)
-	}
+	assert.Equal(t, 0, removed)
+	assert.Equal(t, int64(0), reclaimed)
 }
 
 func TestDeleteFilesNilPath(t *testing.T) {
@@ -406,12 +337,8 @@ func TestDeleteFilesNilPath(t *testing.T) {
 	}
 
 	removed, reclaimed := deleteFiles(sessions)
-	if removed != 0 {
-		t.Errorf("removed = %d, want 0", removed)
-	}
-	if reclaimed != 0 {
-		t.Errorf("reclaimed = %d, want 0", reclaimed)
-	}
+	assert.Equal(t, 0, removed)
+	assert.Equal(t, int64(0), reclaimed)
 }
 
 func newTestPruner(t *testing.T, d *db.DB, input string) (*Pruner, *bytes.Buffer) {

--- a/cmd/agentsview/secrets_test.go
+++ b/cmd/agentsview/secrets_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/service"
 )
@@ -18,9 +20,8 @@ func TestNewSecretsListCommandFlags(t *testing.T) {
 	cmd.SetArgs([]string{"--confidence", "bogus", "--reveal", "--limit", "5"})
 	for _, name := range []string{"project", "agent", "rule", "confidence",
 		"reveal", "limit", "cursor", "date-from", "date-to"} {
-		if cmd.Flags().Lookup(name) == nil {
-			t.Errorf("secrets list missing --%s flag", name)
-		}
+		assert.NotNil(t, cmd.Flags().Lookup(name),
+			"secrets list missing --%s flag", name)
 	}
 }
 
@@ -28,9 +29,8 @@ func TestNewSecretsScanCommandFlags(t *testing.T) {
 	cmd := newSecretsScanCommand()
 	for _, name := range []string{"backfill", "project", "agent",
 		"date-from", "date-to"} {
-		if cmd.Flags().Lookup(name) == nil {
-			t.Errorf("secrets scan missing --%s flag", name)
-		}
+		assert.NotNil(t, cmd.Flags().Lookup(name),
+			"secrets scan missing --%s flag", name)
 	}
 }
 
@@ -54,36 +54,30 @@ func TestSecretsScan_DirectMode_Scans(t *testing.T) {
 	seedSession(t, dataDir, "leaky", "proj")
 
 	d, err := db.Open(filepath.Join(dataDir, "sessions.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	secret := syntheticAWSAccessKey(t.Name())
-	if err := d.InsertMessages([]db.Message{{
+	require.NoError(t, d.InsertMessages([]db.Message{{
 		SessionID: "leaky", Ordinal: 0, Role: "user",
 		Content: "my key " + secret + " here",
-	}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Close(); err != nil {
-		t.Fatal(err)
-	}
+	}}))
+	require.NoError(t, d.Close())
 
 	out, err := executeCommand(newRootCommand(),
 		"secrets", "scan", "--backfill", "--format", "json")
-	if err != nil {
-		t.Fatalf("secrets scan failed (engine not plumbed?): %v", err)
-	}
+	require.NoError(t, err, "secrets scan failed (engine not plumbed?)")
 	var got struct {
 		Scanned       int `json:"scanned"`
 		WithSecrets   int `json:"with_secrets"`
 		TotalFindings int `json:"total_findings"`
 	}
-	if jerr := json.Unmarshal([]byte(out), &got); jerr != nil {
-		t.Fatalf("scan output not JSON: %q (%v)", out, jerr)
-	}
-	if got.Scanned < 1 || got.WithSecrets < 1 || got.TotalFindings < 1 {
-		t.Errorf("expected the seeded secret to be found, got %+v", got)
-	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"scan output not JSON: %q", out)
+	assert.GreaterOrEqual(t, got.Scanned, 1,
+		"expected the seeded secret to be found, got %+v", got)
+	assert.GreaterOrEqual(t, got.WithSecrets, 1,
+		"expected the seeded secret to be found, got %+v", got)
+	assert.GreaterOrEqual(t, got.TotalFindings, 1,
+		"expected the seeded secret to be found, got %+v", got)
 }
 
 func TestSecretsScan_DirectMode_DeniesAgentsviewFixtures(t *testing.T) {
@@ -92,39 +86,30 @@ func TestSecretsScan_DirectMode_DeniesAgentsviewFixtures(t *testing.T) {
 	seedSession(t, dataDir, "fixture", "proj")
 
 	d, err := db.Open(filepath.Join(dataDir, "sessions.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	secret := strings.Join([]string{
 		"ghp_", "M7qL8r", "P2sT5u", "V9wX3y",
 		"Z6aB1c", "D4eF7g", "H0iJ2k",
 	}, "")
-	if err := d.InsertMessages([]db.Message{{
+	require.NoError(t, d.InsertMessages([]db.Message{{
 		SessionID: "fixture", Ordinal: 0, Role: "user",
 		Content: "fixture token " + secret,
-	}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Close(); err != nil {
-		t.Fatal(err)
-	}
+	}}))
+	require.NoError(t, d.Close())
 
 	out, err := executeCommand(newRootCommand(),
 		"secrets", "scan", "--backfill", "--format", "json")
-	if err != nil {
-		t.Fatalf("secrets scan failed: %v", err)
-	}
+	require.NoError(t, err, "secrets scan failed")
 	var got struct {
 		Scanned       int `json:"scanned"`
 		WithSecrets   int `json:"with_secrets"`
 		TotalFindings int `json:"total_findings"`
 	}
-	if jerr := json.Unmarshal([]byte(out), &got); jerr != nil {
-		t.Fatalf("scan output not JSON: %q (%v)", out, jerr)
-	}
-	if got.Scanned != 1 || got.WithSecrets != 0 || got.TotalFindings != 0 {
-		t.Errorf("fixture should be suppressed, got %+v", got)
-	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"scan output not JSON: %q", out)
+	assert.Equal(t, 1, got.Scanned, "fixture should be suppressed, got %+v", got)
+	assert.Equal(t, 0, got.WithSecrets, "fixture should be suppressed, got %+v", got)
+	assert.Equal(t, 0, got.TotalFindings, "fixture should be suppressed, got %+v", got)
 }
 
 func TestPrintSecretFindingsHuman(t *testing.T) {
@@ -132,10 +117,7 @@ func TestPrintSecretFindingsHuman(t *testing.T) {
 	res := &service.SecretFindingList{
 		Findings: []db.SecretFindingRow{},
 	}
-	if err := printSecretFindingsHuman(&buf, res); err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(buf.String(), "(no findings)") {
-		t.Errorf("empty list should print (no findings): %q", buf.String())
-	}
+	require.NoError(t, printSecretFindingsHuman(&buf, res))
+	assert.Contains(t, buf.String(), "(no findings)",
+		"empty list should print (no findings)")
 }

--- a/cmd/agentsview/session_get_test.go
+++ b/cmd/agentsview/session_get_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/service"
 )
 
@@ -13,13 +14,10 @@ func TestPrintSessionDetailShowsSecretLeak(t *testing.T) {
 	d.ID = "s1"
 	d.SecretLeakCount = 3
 	var buf bytes.Buffer
-	if err := printSessionDetailHuman(&buf, d); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, printSessionDetailHuman(&buf, d))
 	out := buf.String()
-	if !strings.Contains(out, "Secrets") || !strings.Contains(out, "3") {
-		t.Errorf("detail output missing secret leak count:\n%s", out)
-	}
+	assert.Contains(t, out, "Secrets")
+	assert.Contains(t, out, "3")
 }
 
 func TestPrintSessionDetailHidesZeroSecretLeak(t *testing.T) {
@@ -27,10 +25,7 @@ func TestPrintSessionDetailHidesZeroSecretLeak(t *testing.T) {
 	d.ID = "s1"
 	d.SecretLeakCount = 0
 	var buf bytes.Buffer
-	if err := printSessionDetailHuman(&buf, d); err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(buf.String(), "Secrets") {
-		t.Errorf("clean session should not show a Secrets line:\n%s", buf.String())
-	}
+	require.NoError(t, printSessionDetailHuman(&buf, d))
+	assert.NotContains(t, buf.String(), "Secrets",
+		"clean session should not show a Secrets line")
 }

--- a/cmd/agentsview/session_search_test.go
+++ b/cmd/agentsview/session_search_test.go
@@ -1,24 +1,24 @@
 package main
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSessionSearchFlagValidation(t *testing.T) {
 	cmd := newSessionSearchCommand()
 	cmd.SetArgs([]string{"needle", "--regex", "--fts"})
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
-		t.Fatalf("expected mutual-exclusion error, got %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestSessionSearchFTSWithToolSource(t *testing.T) {
 	cmd := newSessionSearchCommand()
 	cmd.SetArgs([]string{"needle", "--fts", "--in", "tool_result"})
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "messages only") {
-		t.Fatalf("expected fts+tool rejection, got %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messages only")
 }

--- a/cmd/agentsview/session_usage_test.go
+++ b/cmd/agentsview/session_usage_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -17,16 +19,10 @@ func TestRenderSessionUsageHuman_WithCost(t *testing.T) {
 		},
 	}
 	var b strings.Builder
-	if err := renderSessionUsageHuman(&b, out); err != nil {
-		t.Fatalf("render: %v", err)
-	}
+	require.NoError(t, renderSessionUsageHuman(&b, out))
 	s := b.String()
-	if !strings.Contains(s, "~$0.42") {
-		t.Errorf("output missing cost:\n%s", s)
-	}
-	if !strings.Contains(s, "claude-opus-4-6") {
-		t.Errorf("output missing model:\n%s", s)
-	}
+	assert.Contains(t, s, "~$0.42", "output missing cost")
+	assert.Contains(t, s, "claude-opus-4-6", "output missing model")
 }
 
 func TestRenderSessionUsageHuman_NoCostNoModels(t *testing.T) {
@@ -37,16 +33,11 @@ func TestRenderSessionUsageHuman_NoCostNoModels(t *testing.T) {
 		},
 	}
 	var b strings.Builder
-	if err := renderSessionUsageHuman(&b, out); err != nil {
-		t.Fatalf("render: %v", err)
-	}
+	require.NoError(t, renderSessionUsageHuman(&b, out))
 	s := b.String()
-	if !strings.Contains(s, "n/a") {
-		t.Errorf("expected bare 'n/a' cost line:\n%s", s)
-	}
-	if strings.Contains(s, "unpriced") {
-		t.Errorf("should not mention unpriced when none:\n%s", s)
-	}
+	assert.Contains(t, s, "n/a", "expected bare 'n/a' cost line")
+	assert.NotContains(t, s, "unpriced",
+		"should not mention unpriced when none")
 }
 
 func TestRenderSessionUsageHuman_NoCost(t *testing.T) {
@@ -58,14 +49,9 @@ func TestRenderSessionUsageHuman_NoCost(t *testing.T) {
 		},
 	}
 	var b strings.Builder
-	if err := renderSessionUsageHuman(&b, out); err != nil {
-		t.Fatalf("render: %v", err)
-	}
+	require.NoError(t, renderSessionUsageHuman(&b, out))
 	s := b.String()
-	if strings.Contains(s, "$") {
-		t.Errorf("no-cost output should not contain '$':\n%s", s)
-	}
-	if !strings.Contains(s, "local-llama-99") {
-		t.Errorf("output should note unpriced model:\n%s", s)
-	}
+	assert.NotContains(t, s, "$", "no-cost output should not contain '$'")
+	assert.Contains(t, s, "local-llama-99",
+		"output should note unpriced model")
 }

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -139,13 +139,10 @@ func TestPrintStatsHuman_Populated(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := printStatsHuman(&buf, stats); err != nil {
-		t.Fatalf("printStatsHuman: %v", err)
-	}
+	require.NoError(t, printStatsHuman(&buf, stats), "printStatsHuman")
 	out := buf.String()
-	if len(out) < 200 {
-		t.Fatalf("output suspiciously short (%d bytes):\n%s", len(out), out)
-	}
+	require.GreaterOrEqual(t, len(out), 200,
+		"output suspiciously short (%d bytes):\n%s", len(out), out)
 
 	// Guard every major section header so accidental drops are caught.
 	wants := []string{
@@ -164,15 +161,13 @@ func TestPrintStatsHuman_Populated(t *testing.T) {
 		"Outcomes",
 	}
 	for _, w := range wants {
-		if !strings.Contains(out, w) {
-			t.Errorf("missing section heading %q in output:\n%s", w, out)
-		}
+		assert.Contains(t, out, w,
+			"missing section heading %q in output", w)
 	}
 
 	// Thousands separators must be applied to large counts.
-	if !strings.Contains(out, "11,905") {
-		t.Errorf("expected thousands separator for 11,905, got:\n%s", out)
-	}
+	assert.Contains(t, out, "11,905",
+		"expected thousands separator for 11,905")
 }
 
 // TestPrintStatsHuman_Empty guards the zero-session short
@@ -193,21 +188,16 @@ func TestPrintStatsHuman_Empty(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := printStatsHuman(&buf, stats); err != nil {
-		t.Fatalf("printStatsHuman: %v", err)
-	}
+	require.NoError(t, printStatsHuman(&buf, stats), "printStatsHuman")
 	out := buf.String()
-	if !strings.Contains(out, "no sessions") {
-		t.Errorf("expected zero-session placeholder in output:\n%s", out)
-	}
+	assert.Contains(t, out, "no sessions",
+		"expected zero-session placeholder in output")
 	// No optional section headers should appear.
 	for _, banned := range []string{
 		"Archetypes", "Velocity", "Cache economics", "Outcomes",
 	} {
-		if strings.Contains(out, banned) {
-			t.Errorf("section %q must not appear for empty window:\n%s",
-				banned, out)
-		}
+		assert.NotContains(t, out, banned,
+			"section %q must not appear for empty window", banned)
 	}
 }
 
@@ -227,9 +217,8 @@ func TestFmtInt64(t *testing.T) {
 		{-1234, "-1,234"},
 	}
 	for _, c := range cases {
-		if got := fmtInt64(c.in); got != c.want {
-			t.Errorf("fmtInt64(%d) = %q, want %q", c.in, got, c.want)
-		}
+		assert.Equal(t, c.want, fmtInt64(c.in),
+			"fmtInt64(%d)", c.in)
 	}
 }
 
@@ -239,9 +228,8 @@ func TestStatsCommand_OutcomeFlagsRegistered(t *testing.T) {
 		"include-git-outcomes",
 		"include-github-outcomes",
 	} {
-		if cmd.Flags().Lookup(name) == nil {
-			t.Fatalf("missing --%s flag", name)
-		}
+		assert.NotNil(t, cmd.Flags().Lookup(name),
+			"missing --%s flag", name)
 	}
 }
 
@@ -286,14 +274,11 @@ func TestStatsGolden(t *testing.T) {
 		"--until", "2026-04-15",
 		"--timezone", "UTC",
 	)
-	if err != nil {
-		t.Fatalf("stats: %v\noutput:\n%s", err, out)
-	}
+	require.NoError(t, err, "stats output:\n%s", out)
 
 	var got map[string]any
-	if err := json.Unmarshal([]byte(out), &got); err != nil {
-		t.Fatalf("unmarshal stats output: %v\noutput:\n%s", err, out)
-	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"unmarshal stats output, output:\n%s", out)
 	delete(got, "generated_at")
 
 	goldenPath := filepath.Join(
@@ -301,35 +286,25 @@ func TestStatsGolden(t *testing.T) {
 	)
 	if *updateGolden {
 		buf, err := json.MarshalIndent(got, "", "  ")
-		if err != nil {
-			t.Fatalf("marshal golden: %v", err)
-		}
+		require.NoError(t, err, "marshal golden")
 		buf = append(buf, '\n')
-		if err := os.MkdirAll(
+		require.NoError(t, os.MkdirAll(
 			filepath.Dir(goldenPath), 0o755,
-		); err != nil {
-			t.Fatalf("mkdir testdata: %v", err)
-		}
-		if err := os.WriteFile(
+		), "mkdir testdata")
+		require.NoError(t, os.WriteFile(
 			goldenPath, buf, 0o644,
-		); err != nil {
-			t.Fatalf("write golden: %v", err)
-		}
+		), "write golden")
 		t.Logf("rewrote %s (%d bytes)", goldenPath, len(buf))
 		return
 	}
 
 	raw, err := os.ReadFile(goldenPath)
-	if err != nil {
-		t.Fatalf("read golden: %v (run with -update to generate)", err)
-	}
+	require.NoError(t, err, "read golden (run with -update to generate)")
 	var want map[string]any
-	if err := json.Unmarshal(raw, &want); err != nil {
-		t.Fatalf("unmarshal golden: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(raw, &want), "unmarshal golden")
 	delete(want, "generated_at")
 
-	if !reflect.DeepEqual(got, want) {
+	if !assert.Equal(t, want, got) {
 		gotBuf, _ := json.MarshalIndent(got, "", "  ")
 		wantBuf, _ := json.MarshalIndent(want, "", "  ")
 		t.Fatalf(
@@ -363,12 +338,10 @@ func TestStatsGolden(t *testing.T) {
 func buildGoldenFixtureDB(t *testing.T, dbPath string) {
 	t.Helper()
 	d, err := db.Open(dbPath)
-	if err != nil {
-		t.Fatalf("open fixture db: %v", err)
-	}
+	require.NoError(t, err, "open fixture db")
 	t.Cleanup(func() { d.Close() })
 
-	if err := d.UpsertModelPricing([]db.ModelPricing{
+	require.NoError(t, d.UpsertModelPricing([]db.ModelPricing{
 		{
 			ModelPattern:         "claude-sonnet-4-20250514",
 			InputPerMTok:         3.0,
@@ -383,9 +356,7 @@ func buildGoldenFixtureDB(t *testing.T, dbPath string) {
 			CacheCreationPerMTok: 18.75,
 			CacheReadPerMTok:     1.50,
 		},
-	}); err != nil {
-		t.Fatalf("seed pricing: %v", err)
-	}
+	}), "seed pricing")
 
 	for _, spec := range goldenFixtureSessions {
 		seedGoldenSession(t, d, spec)
@@ -539,9 +510,7 @@ func seedGoldenSession(
 		TotalOutputTokens:    totalOutput,
 		HasTotalOutputTokens: totalOutput > 0,
 	}
-	if err := d.UpsertSession(session); err != nil {
-		t.Fatalf("upsert %s: %v", spec.id, err)
-	}
+	require.NoError(t, d.UpsertSession(session), "upsert %s", spec.id)
 
 	if spec.outcome != "" || spec.healthGrade != "" ||
 		spec.retryCount > 0 || spec.editChurn > 0 ||
@@ -551,22 +520,19 @@ func seedGoldenSession(
 			g := spec.healthGrade
 			grade = &g
 		}
-		if err := d.UpdateSessionSignals(spec.id, db.SessionSignalUpdate{
+		require.NoError(t, d.UpdateSessionSignals(spec.id, db.SessionSignalUpdate{
 			Outcome:         spec.outcome,
 			HealthGrade:     grade,
 			ToolRetryCount:  spec.retryCount,
 			EditChurnCount:  spec.editChurn,
 			CompactionCount: spec.compactions,
-		}); err != nil {
-			t.Fatalf("update signals %s: %v", spec.id, err)
-		}
+		}), "update signals %s", spec.id)
 	}
 
 	msgs := buildGoldenMessages(spec)
 	if len(msgs) > 0 {
-		if err := d.InsertMessages(msgs); err != nil {
-			t.Fatalf("insert messages %s: %v", spec.id, err)
-		}
+		require.NoError(t, d.InsertMessages(msgs),
+			"insert messages %s", spec.id)
 	}
 }
 

--- a/cmd/agentsview/terminal_sanitize_test.go
+++ b/cmd/agentsview/terminal_sanitize_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSanitizeTerminal(t *testing.T) {
@@ -91,19 +93,13 @@ func TestSanitizeTerminal(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := sanitizeTerminal(tc.in)
-			if got != tc.want {
-				t.Errorf(
-					"sanitizeTerminal(%q) = %q, want %q",
-					tc.in, got, tc.want,
-				)
-			}
+			assert.Equal(t, tc.want, got,
+				"sanitizeTerminal(%q)", tc.in)
 			// Post-condition: no ESC byte or NUL in output.
-			if strings.ContainsRune(got, 0x1b) {
-				t.Errorf("output still contains ESC: %q", got)
-			}
-			if strings.ContainsRune(got, 0) {
-				t.Errorf("output still contains NUL: %q", got)
-			}
+			assert.False(t, strings.ContainsRune(got, 0x1b),
+				"output still contains ESC: %q", got)
+			assert.False(t, strings.ContainsRune(got, 0),
+				"output still contains NUL: %q", got)
 		})
 	}
 }

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 )
@@ -15,9 +17,7 @@ func newTestDB(t *testing.T) *db.DB {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "test.db")
 	d, err := db.Open(path)
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
+	require.NoError(t, err, "opening test db")
 	t.Cleanup(func() { d.Close() })
 	return d
 }
@@ -37,9 +37,7 @@ func upsertSession(
 	if startedAt != "" {
 		s.StartedAt = &startedAt
 	}
-	if err := d.UpsertSession(s); err != nil {
-		t.Fatalf("upsert %s: %v", id, err)
-	}
+	require.NoError(t, d.UpsertSession(s), "upsert %s", id)
 }
 
 func TestResolveSessionID_PrefixedInput_NoEvidence_UnchangedNotKnown(t *testing.T) {
@@ -53,12 +51,8 @@ func TestResolveSessionID_PrefixedInput_NoEvidence_UnchangedNotKnown(t *testing.
 	// missing source file.
 	input := "codex:019d5490-fe31-7e62-838c-8ba4193f245d"
 	got, known := resolveRawSessionID(ctx, d, nil, input)
-	if got != input {
-		t.Errorf("got %q, want %q", got, input)
-	}
-	if known {
-		t.Errorf("known = true, want false (no evidence)")
-	}
+	assert.Equal(t, input, got)
+	assert.False(t, known, "known should be false (no evidence)")
 }
 
 func TestResolveSessionID_HostPrefixedInput_ReturnedUnchanged(t *testing.T) {
@@ -69,12 +63,8 @@ func TestResolveSessionID_HostPrefixedInput_ReturnedUnchanged(t *testing.T) {
 	// resolution short-circuits without touching DB or disk.
 	input := "other-host~codex:abc-123"
 	got, known := resolveRawSessionID(ctx, d, nil, input)
-	if got != input {
-		t.Errorf("got %q, want %q", got, input)
-	}
-	if !known {
-		t.Errorf("known = false, want true (host-prefixed)")
-	}
+	assert.Equal(t, input, got)
+	assert.True(t, known, "known should be true (host-prefixed)")
 }
 
 func TestResolveSessionID_BareClaudeUUID_ExactMatch(t *testing.T) {
@@ -87,12 +77,8 @@ func TestResolveSessionID_BareClaudeUUID_ExactMatch(t *testing.T) {
 	upsertSession(t, d, id, "claude", "2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, id)
-	if got != id {
-		t.Errorf("got %q, want %q", got, id)
-	}
-	if !known {
-		t.Errorf("known = false, want true (DB match)")
-	}
+	assert.Equal(t, id, got)
+	assert.True(t, known, "known should be true (DB match)")
 }
 
 func TestResolveSessionID_BareCodexUUID_ResolvesToPrefixed(t *testing.T) {
@@ -104,12 +90,8 @@ func TestResolveSessionID_BareCodexUUID_ResolvesToPrefixed(t *testing.T) {
 	upsertSession(t, d, stored, "codex", "2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, bare)
-	if got != stored {
-		t.Errorf("got %q, want %q", got, stored)
-	}
-	if !known {
-		t.Errorf("known = false, want true (DB match)")
-	}
+	assert.Equal(t, stored, got)
+	assert.True(t, known, "known should be true (DB match)")
 }
 
 func TestResolveSessionID_Ambiguous_MostRecentWins(t *testing.T) {
@@ -123,12 +105,8 @@ func TestResolveSessionID_Ambiguous_MostRecentWins(t *testing.T) {
 	upsertSession(t, d, "amp:"+bare, "amp", "2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, bare)
-	if got != "amp:"+bare {
-		t.Errorf("got %q, want amp:%s (most recent)", got, bare)
-	}
-	if !known {
-		t.Errorf("known = false, want true")
-	}
+	assert.Equal(t, "amp:"+bare, got, "most recent should win")
+	assert.True(t, known)
 }
 
 func TestResolveSessionID_NotInDB_FoundOnDisk(t *testing.T) {
@@ -140,25 +118,17 @@ func TestResolveSessionID_NotInDB_FoundOnDisk(t *testing.T) {
 	codexDir := filepath.Join(t.TempDir(), "codex-sessions")
 	bare := "33333333-3333-3333-3333-333333333333"
 	dayDir := filepath.Join(codexDir, "2026", "04", "17")
-	if err := os.MkdirAll(dayDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(dayDir, 0o755), "mkdir")
 	fname := "rollout-2026-04-17T10-00-00-" + bare + ".jsonl"
 	fpath := filepath.Join(dayDir, fname)
-	if err := os.WriteFile(fpath, []byte("{}\n"), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	require.NoError(t, os.WriteFile(fpath, []byte("{}\n"), 0o644), "write")
 
 	agentDirs := map[parser.AgentType][]string{
 		parser.AgentCodex: {codexDir},
 	}
 	got, known := resolveRawSessionID(ctx, d, agentDirs, bare)
-	if got != "codex:"+bare {
-		t.Errorf("got %q, want codex:%s (disk probe)", got, bare)
-	}
-	if !known {
-		t.Errorf("known = false, want true (disk probe found match)")
-	}
+	assert.Equal(t, "codex:"+bare, got, "disk probe")
+	assert.True(t, known, "disk probe found match")
 }
 
 func TestResolveSessionID_NotFoundAnywhere_PassThrough(t *testing.T) {
@@ -167,12 +137,8 @@ func TestResolveSessionID_NotFoundAnywhere_PassThrough(t *testing.T) {
 
 	bare := "44444444-4444-4444-4444-444444444444"
 	got, known := resolveRawSessionID(ctx, d, nil, bare)
-	if got != bare {
-		t.Errorf("got %q, want %q (pass-through)", got, bare)
-	}
-	if known {
-		t.Errorf("known = true, want false (nothing found)")
-	}
+	assert.Equal(t, bare, got, "pass-through")
+	assert.False(t, known, "known should be false (nothing found)")
 }
 
 func TestResolveSessionID_BareClaudeAndPrefixedSameUUID_ClaudeExactWins(t *testing.T) {
@@ -187,12 +153,8 @@ func TestResolveSessionID_BareClaudeAndPrefixedSameUUID_ClaudeExactWins(t *testi
 	upsertSession(t, d, "codex:"+bare, "codex", "2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, bare)
-	if got != bare {
-		t.Errorf("got %q, want %q (exact claude match)", got, bare)
-	}
-	if !known {
-		t.Errorf("known = false, want true")
-	}
+	assert.Equal(t, bare, got, "exact claude match")
+	assert.True(t, known)
 }
 
 func TestResolveSessionID_ExactMatchWinsOverNewerCollisions(t *testing.T) {
@@ -211,13 +173,9 @@ func TestResolveSessionID_ExactMatchWinsOverNewerCollisions(t *testing.T) {
 		"2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, bare)
-	if got != bare {
-		t.Errorf("got %q, want %q (exact match must beat "+
-			"newer suffix collisions)", got, bare)
-	}
-	if !known {
-		t.Errorf("known = false, want true")
-	}
+	assert.Equal(t, bare, got,
+		"exact match must beat newer suffix collisions")
+	assert.True(t, known)
 }
 
 func TestResolveSessionID_KimiRawID_ResolvesToPrefixed(t *testing.T) {
@@ -231,12 +189,8 @@ func TestResolveSessionID_KimiRawID_ResolvesToPrefixed(t *testing.T) {
 	upsertSession(t, d, stored, "kimi", "2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, raw)
-	if got != stored {
-		t.Errorf("got %q, want %q (kimi raw ID resolves)", got, stored)
-	}
-	if !known {
-		t.Errorf("known = false, want true")
-	}
+	assert.Equal(t, stored, got, "kimi raw ID resolves")
+	assert.True(t, known)
 }
 
 func TestResolveSessionID_OpenClawRawID_ResolvesToPrefixed(t *testing.T) {
@@ -249,13 +203,8 @@ func TestResolveSessionID_OpenClawRawID_ResolvesToPrefixed(t *testing.T) {
 	upsertSession(t, d, stored, "openclaw", "2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, raw)
-	if got != stored {
-		t.Errorf("got %q, want %q (openclaw raw ID resolves)",
-			got, stored)
-	}
-	if !known {
-		t.Errorf("known = false, want true")
-	}
+	assert.Equal(t, stored, got, "openclaw raw ID resolves")
+	assert.True(t, known)
 }
 
 func TestResolveSessionID_CanonicalKimiID_ResolvesWhenInDB(t *testing.T) {
@@ -270,12 +219,8 @@ func TestResolveSessionID_CanonicalKimiID_ResolvesWhenInDB(t *testing.T) {
 	upsertSession(t, d, input, "kimi", "2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, input)
-	if got != input {
-		t.Errorf("got %q, want %q (exact DB match)", got, input)
-	}
-	if !known {
-		t.Errorf("known = false, want true (exact DB match)")
-	}
+	assert.Equal(t, input, got, "exact DB match")
+	assert.True(t, known, "exact DB match")
 }
 
 func TestResolveSessionID_CanonicalCodexID_OnDiskNotInDB(t *testing.T) {
@@ -289,27 +234,19 @@ func TestResolveSessionID_CanonicalCodexID_OnDiskNotInDB(t *testing.T) {
 	codexDir := filepath.Join(t.TempDir(), "codex-sessions")
 	uuid := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	dayDir := filepath.Join(codexDir, "2026", "04", "17")
-	if err := os.MkdirAll(dayDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(dayDir, 0o755), "mkdir")
 	fname := "rollout-2026-04-17T10-00-00-" + uuid + ".jsonl"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dayDir, fname), []byte("{}\n"), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	), "write")
 
 	agentDirs := map[parser.AgentType][]string{
 		parser.AgentCodex: {codexDir},
 	}
 	input := "codex:" + uuid
 	got, known := resolveRawSessionID(ctx, d, agentDirs, input)
-	if got != input {
-		t.Errorf("got %q, want %q (canonical on disk)", got, input)
-	}
-	if !known {
-		t.Errorf("known = false, want true (canonical disk probe)")
-	}
+	assert.Equal(t, input, got, "canonical on disk")
+	assert.True(t, known, "canonical disk probe")
 }
 
 func TestResolveSessionID_RawOpenClawCollidesWithCodexPrefix(t *testing.T) {
@@ -328,13 +265,9 @@ func TestResolveSessionID_RawOpenClawCollidesWithCodexPrefix(t *testing.T) {
 		"2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, raw)
-	if got != stored {
-		t.Errorf("got %q, want %q (raw openclaw must beat "+
-			"canonical-prefix short-circuit)", got, stored)
-	}
-	if !known {
-		t.Errorf("known = false, want true")
-	}
+	assert.Equal(t, stored, got,
+		"raw openclaw must beat canonical-prefix short-circuit")
+	assert.True(t, known)
 }
 
 func TestResolveSessionID_UnderscoreID_NoFalseMatch(t *testing.T) {
@@ -354,39 +287,26 @@ func TestResolveSessionID_UnderscoreID_NoFalseMatch(t *testing.T) {
 	upsertSession(t, d, real, "codex", "2026-04-17T10:00:00Z")
 
 	got, known := resolveRawSessionID(ctx, d, nil, raw)
-	if got != real {
-		t.Errorf("got %q, want %q (underscore is literal)",
-			got, real)
-	}
-	if !known {
-		t.Errorf("known = false, want true")
-	}
+	assert.Equal(t, real, got, "underscore is literal")
+	assert.True(t, known)
 }
 
 func TestUsageExitCode_TokenData(t *testing.T) {
 	u := &db.SessionUsage{HasTokenData: true}
-	if got := usageExitCode(u); got != tokenUseExitOK {
-		t.Errorf("got %d, want %d", got, tokenUseExitOK)
-	}
+	assert.Equal(t, tokenUseExitOK, usageExitCode(u))
 }
 
 func TestUsageExitCode_CostOnly(t *testing.T) {
 	u := &db.SessionUsage{HasTokenData: false, HasCost: true}
-	if got := usageExitCode(u); got != tokenUseExitOK {
-		t.Errorf("got %d, want %d (cost-only must not be exit 3)",
-			got, tokenUseExitOK)
-	}
+	assert.Equal(t, tokenUseExitOK, usageExitCode(u),
+		"cost-only must not be exit 3")
 }
 
 func TestUsageExitCode_NoData(t *testing.T) {
 	u := &db.SessionUsage{}
-	if got := usageExitCode(u); got != tokenUseExitNoTokenData {
-		t.Errorf("got %d, want %d", got, tokenUseExitNoTokenData)
-	}
+	assert.Equal(t, tokenUseExitNoTokenData, usageExitCode(u))
 }
 
 func TestUsageExitCode_NotFound(t *testing.T) {
-	if got := usageExitCode(nil); got != tokenUseExitNotFound {
-		t.Errorf("got %d, want %d", got, tokenUseExitNotFound)
-	}
+	assert.Equal(t, tokenUseExitNotFound, usageExitCode(nil))
 }

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -26,10 +28,8 @@ func TestFmtCost(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := fmtCost(tc.in); got != tc.want {
-				t.Errorf("fmtCost(%v) = %q, want %q",
-					tc.in, got, tc.want)
-			}
+			assert.Equal(t, tc.want, fmtCost(tc.in),
+				"fmtCost(%v)", tc.in)
 		})
 	}
 }
@@ -77,10 +77,7 @@ func TestResolveDefaultSince(t *testing.T) {
 			got := resolveDefaultSince(
 				tc.since, tc.until, tc.all, now, utc,
 			)
-			if got != tc.want {
-				t.Errorf("resolveDefaultSince = %q, want %q",
-					got, tc.want)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -118,30 +115,20 @@ func TestFormatDailyUsageJSON(t *testing.T) {
 	}
 
 	out, err := json.Marshal(result)
-	if err != nil {
-		t.Fatalf("json.Marshal failed: %v", err)
-	}
+	require.NoError(t, err, "json.Marshal failed")
 
 	var decoded map[string]json.RawMessage
-	if err := json.Unmarshal(out, &decoded); err != nil {
-		t.Fatalf("json.Unmarshal failed: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(out, &decoded),
+		"json.Unmarshal failed")
 
-	if _, ok := decoded["daily"]; !ok {
-		t.Error("missing 'daily' key in JSON output")
-	}
-	if _, ok := decoded["totals"]; !ok {
-		t.Error("missing 'totals' key in JSON output")
-	}
+	assert.Contains(t, decoded, "daily", "missing 'daily' key in JSON output")
+	assert.Contains(t, decoded, "totals", "missing 'totals' key in JSON output")
 
 	// Verify daily array has expected entry
 	var daily []map[string]json.RawMessage
-	if err := json.Unmarshal(decoded["daily"], &daily); err != nil {
-		t.Fatalf("parsing daily array: %v", err)
-	}
-	if len(daily) != 1 {
-		t.Fatalf("daily length = %d, want 1", len(daily))
-	}
+	require.NoError(t, json.Unmarshal(decoded["daily"], &daily),
+		"parsing daily array")
+	require.Len(t, daily, 1, "daily length")
 
 	// Check expected fields exist in daily entry
 	wantFields := []string{
@@ -150,24 +137,21 @@ func TestFormatDailyUsageJSON(t *testing.T) {
 		"totalCost", "modelsUsed", "modelBreakdowns",
 	}
 	for _, f := range wantFields {
-		if _, ok := daily[0][f]; !ok {
-			t.Errorf("missing field %q in daily entry", f)
-		}
+		assert.Contains(t, daily[0], f,
+			"missing field %q in daily entry", f)
 	}
 
 	// Verify totals fields
 	var totals map[string]json.RawMessage
-	if err := json.Unmarshal(decoded["totals"], &totals); err != nil {
-		t.Fatalf("parsing totals: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(decoded["totals"], &totals),
+		"parsing totals")
 	totalFields := []string{
 		"inputTokens", "outputTokens",
 		"cacheCreationTokens", "cacheReadTokens",
 		"totalCost",
 	}
 	for _, f := range totalFields {
-		if _, ok := totals[f]; !ok {
-			t.Errorf("missing field %q in totals", f)
-		}
+		assert.Contains(t, totals, f,
+			"missing field %q in totals", f)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -36,12 +37,8 @@ func skipIfNotUnix(t *testing.T) {
 func writeConfig(t *testing.T, dir string, data any) {
 	t.Helper()
 	var buf bytes.Buffer
-	if err := toml.NewEncoder(&buf).Encode(data); err != nil {
-		t.Fatalf("marshal config: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, configFileName), buf.Bytes(), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	require.NoError(t, toml.NewEncoder(&buf).Encode(data), "marshal config")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, configFileName), buf.Bytes(), 0o600), "write config")
 }
 
 func setupTestEnv(t *testing.T) string {
@@ -81,116 +78,65 @@ binary = "/opt/agents/claude"
 [agent.gemini]
 binary = "/usr/local/bin/gemini"
 `)
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, data, 0o600), "write config")
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatalf("LoadMinimal: %v", err)
-	}
+	require.NoError(t, err)
 
-	if cfg.Agent["claude"].Binary != "/opt/agents/claude" {
-		t.Fatalf("claude binary = %q", cfg.Agent["claude"].Binary)
-	}
-	if cfg.Agent["gemini"].Binary != "/usr/local/bin/gemini" {
-		t.Fatalf("gemini binary = %q", cfg.Agent["gemini"].Binary)
-	}
+	assert.Equal(t, "/opt/agents/claude", cfg.Agent["claude"].Binary)
+	assert.Equal(t, "/usr/local/bin/gemini", cfg.Agent["gemini"].Binary)
 }
 
 func TestDefault_IncludesCodexArchivedSessionsDir(t *testing.T) {
 	cfg, err := Default()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	dirs := cfg.ResolveDirs(parser.AgentCodex)
-	if len(dirs) != 2 {
-		t.Fatalf("len(codex dirs) = %d, want 2", len(dirs))
-	}
-	if !strings.HasSuffix(dirs[0], filepath.Join(".codex", "sessions")) {
-		t.Fatalf("dirs[0] = %q", dirs[0])
-	}
-	if !strings.HasSuffix(dirs[1], filepath.Join(".codex", "archived_sessions")) {
-		t.Fatalf("dirs[1] = %q", dirs[1])
-	}
+	require.Len(t, dirs, 2)
+	assert.True(t, strings.HasSuffix(dirs[0], filepath.Join(".codex", "sessions")), "dirs[0] = %q", dirs[0])
+	assert.True(t, strings.HasSuffix(dirs[1], filepath.Join(".codex", "archived_sessions")), "dirs[1] = %q", dirs[1])
 }
 
 func TestLoadEnv_OverridesDataDir(t *testing.T) {
 	custom := setupTestEnv(t)
 
 	cfg, err := Default()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cfg.loadEnv()
 
-	if cfg.DataDir != custom {
-		t.Errorf(
-			"DataDir = %q, want %q", cfg.DataDir, custom,
-		)
-	}
+	assert.Equal(t, custom, cfg.DataDir)
 }
 
 func TestLoad_AppliesExplicitFlags(t *testing.T) {
 	cfg, err := loadConfigFromFlags(t, "-host", "0.0.0.0", "-port", "9090")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.Host != "0.0.0.0" {
-		t.Errorf("Host = %q, want %q", cfg.Host, "0.0.0.0")
-	}
-	if cfg.Port != 9090 {
-		t.Errorf("Port = %d, want %d", cfg.Port, 9090)
-	}
+	assert.Equal(t, "0.0.0.0", cfg.Host)
+	assert.Equal(t, 9090, cfg.Port)
 }
 
 func TestLoad_DefaultsWithoutFlags(t *testing.T) {
 	cfg, err := loadConfigFromFlags(t)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.Host != "127.0.0.1" {
-		t.Errorf(
-			"Host = %q, want default %q",
-			cfg.Host, "127.0.0.1",
-		)
-	}
-	if cfg.Port != 8080 {
-		t.Errorf(
-			"Port = %d, want default %d", cfg.Port, 8080,
-		)
-	}
-	if len(cfg.PublicOrigins) != 0 {
-		t.Errorf("PublicOrigins = %v, want none", cfg.PublicOrigins)
-	}
+	assert.Equal(t, "127.0.0.1", cfg.Host)
+	assert.Equal(t, 8080, cfg.Port)
+	assert.Empty(t, cfg.PublicOrigins)
 }
 
 func TestLoadPFlags_AppliesExplicitFlags(t *testing.T) {
 	cfg, err := loadConfigFromPFlags(t, "--host", "0.0.0.0", "--port", "9090")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.Host != "0.0.0.0" {
-		t.Errorf("Host = %q, want %q", cfg.Host, "0.0.0.0")
-	}
-	if cfg.Port != 9090 {
-		t.Errorf("Port = %d, want %d", cfg.Port, 9090)
-	}
+	assert.Equal(t, "0.0.0.0", cfg.Host)
+	assert.Equal(t, 9090, cfg.Port)
 }
 
 func TestLoad_NilFlagSet(t *testing.T) {
 	cfg, err := Load(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.Host != "127.0.0.1" {
-		t.Errorf("Host = %q, want %q", cfg.Host, "127.0.0.1")
-	}
+	assert.Equal(t, "127.0.0.1", cfg.Host)
 }
 
 func TestLoad_PublicOriginFlagOverridesConfigFile(t *testing.T) {
@@ -204,15 +150,10 @@ func TestLoad_PublicOriginFlagOverridesConfigFile(t *testing.T) {
 		"-public-origin", "https://viewer.example.test/",
 		"-public-origin", "http://viewer.example.test:8004",
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	got := strings.Join(cfg.PublicOrigins, ",")
-	want := "https://viewer.example.test,http://viewer.example.test:8004"
-	if got != want {
-		t.Fatalf("PublicOrigins = %q, want %q", got, want)
-	}
+	assert.Equal(t, "https://viewer.example.test,http://viewer.example.test:8004", got)
 }
 
 func TestLoad_PublicOriginsFromConfigFile(t *testing.T) {
@@ -225,15 +166,10 @@ func TestLoad_PublicOriginsFromConfigFile(t *testing.T) {
 	})
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	got := strings.Join(cfg.PublicOrigins, ",")
-	want := "https://viewer.example.test,http://viewer.example.test:8004"
-	if got != want {
-		t.Fatalf("PublicOrigins = %q, want %q", got, want)
-	}
+	assert.Equal(t, "https://viewer.example.test,http://viewer.example.test:8004", got)
 }
 
 func TestLoad_PublicOriginsRejectInvalid(t *testing.T) {
@@ -243,12 +179,8 @@ func TestLoad_PublicOriginsRejectInvalid(t *testing.T) {
 	})
 
 	_, err := LoadMinimal()
-	if err == nil {
-		t.Fatal("expected invalid public origin error")
-	}
-	if !strings.Contains(err.Error(), "invalid public origins") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err, "expected invalid public origin error")
+	assert.Contains(t, err.Error(), "invalid public origins")
 }
 
 func TestLoad_PublicURLMergedIntoOrigins(t *testing.T) {
@@ -258,16 +190,10 @@ func TestLoad_PublicURLMergedIntoOrigins(t *testing.T) {
 	})
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.PublicURL != "https://viewer.example.test" {
-		t.Fatalf("PublicURL = %q, want %q", cfg.PublicURL, "https://viewer.example.test")
-	}
-	if got := strings.Join(cfg.PublicOrigins, ","); got != "https://viewer.example.test" {
-		t.Fatalf("PublicOrigins = %q, want %q", got, "https://viewer.example.test")
-	}
+	assert.Equal(t, "https://viewer.example.test", cfg.PublicURL)
+	assert.Equal(t, "https://viewer.example.test", strings.Join(cfg.PublicOrigins, ","))
 }
 
 func TestLoad_ProxyConfigFromFile(t *testing.T) {
@@ -285,28 +211,14 @@ func TestLoad_ProxyConfigFromFile(t *testing.T) {
 	})
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.Proxy.Mode != "caddy" {
-		t.Fatalf("Proxy.Mode = %q, want %q", cfg.Proxy.Mode, "caddy")
-	}
-	if cfg.Proxy.Bin != "caddy" {
-		t.Fatalf("Proxy.Bin = %q, want %q", cfg.Proxy.Bin, "caddy")
-	}
-	if cfg.Proxy.BindHost != "10.0.60.2" {
-		t.Fatalf("BindHost = %q, want %q", cfg.Proxy.BindHost, "10.0.60.2")
-	}
-	if cfg.Proxy.PublicPort != 9443 {
-		t.Fatalf("PublicPort = %d, want %d", cfg.Proxy.PublicPort, 9443)
-	}
-	if cfg.PublicURL != "https://viewer.example.test:9443" {
-		t.Fatalf("PublicURL = %q, want %q", cfg.PublicURL, "https://viewer.example.test:9443")
-	}
-	if got := strings.Join(cfg.Proxy.AllowedSubnets, ","); got != "10.1.0.0/16,192.168.1.0/24" {
-		t.Fatalf("AllowedSubnets = %q, want %q", got, "10.1.0.0/16,192.168.1.0/24")
-	}
+	assert.Equal(t, "caddy", cfg.Proxy.Mode)
+	assert.Equal(t, "caddy", cfg.Proxy.Bin)
+	assert.Equal(t, "10.0.60.2", cfg.Proxy.BindHost)
+	assert.Equal(t, 9443, cfg.Proxy.PublicPort)
+	assert.Equal(t, "https://viewer.example.test:9443", cfg.PublicURL)
+	assert.Equal(t, "10.1.0.0/16,192.168.1.0/24", strings.Join(cfg.Proxy.AllowedSubnets, ","))
 }
 
 func TestLoad_ProxyFlags(t *testing.T) {
@@ -321,25 +233,13 @@ func TestLoad_ProxyFlags(t *testing.T) {
 		"-allowed-subnet", "10.0/16",
 		"-allowed-subnet", "192.168.0.0/24",
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.PublicURL != "https://viewer.example.test:9443" {
-		t.Fatalf("PublicURL = %q, want %q", cfg.PublicURL, "https://viewer.example.test:9443")
-	}
-	if cfg.Proxy.Mode != "caddy" {
-		t.Fatalf("Proxy.Mode = %q, want %q", cfg.Proxy.Mode, "caddy")
-	}
-	if cfg.Proxy.BindHost != "0.0.0.0" {
-		t.Fatalf("BindHost = %q, want %q", cfg.Proxy.BindHost, "0.0.0.0")
-	}
-	if cfg.Proxy.PublicPort != 9443 {
-		t.Fatalf("PublicPort = %d, want %d", cfg.Proxy.PublicPort, 9443)
-	}
-	if got := strings.Join(cfg.Proxy.AllowedSubnets, ","); got != "10.0.0.0/16,192.168.0.0/24" {
-		t.Fatalf("AllowedSubnets = %q, want %q", got, "10.0.0.0/16,192.168.0.0/24")
-	}
+	assert.Equal(t, "https://viewer.example.test:9443", cfg.PublicURL)
+	assert.Equal(t, "caddy", cfg.Proxy.Mode)
+	assert.Equal(t, "0.0.0.0", cfg.Proxy.BindHost)
+	assert.Equal(t, 9443, cfg.Proxy.PublicPort)
+	assert.Equal(t, "10.0.0.0/16,192.168.0.0/24", strings.Join(cfg.Proxy.AllowedSubnets, ","))
 }
 
 func TestLoad_ManagedCaddyDefaultsPublicPortAndBindHost(t *testing.T) {
@@ -348,19 +248,11 @@ func TestLoad_ManagedCaddyDefaultsPublicPortAndBindHost(t *testing.T) {
 		"-public-url", "https://viewer.example.test",
 		"-proxy", "caddy",
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.PublicURL != "https://viewer.example.test:8443" {
-		t.Fatalf("PublicURL = %q, want %q", cfg.PublicURL, "https://viewer.example.test:8443")
-	}
-	if cfg.Proxy.BindHost != "127.0.0.1" {
-		t.Fatalf("BindHost = %q, want %q", cfg.Proxy.BindHost, "127.0.0.1")
-	}
-	if cfg.Proxy.PublicPort != 0 {
-		t.Fatalf("PublicPort = %d, want %d", cfg.Proxy.PublicPort, 0)
-	}
+	assert.Equal(t, "https://viewer.example.test:8443", cfg.PublicURL)
+	assert.Equal(t, "127.0.0.1", cfg.Proxy.BindHost)
+	assert.Equal(t, 0, cfg.Proxy.PublicPort)
 }
 
 func TestLoad_ManagedCaddyRejectsConflictingPublicPort(t *testing.T) {
@@ -370,12 +262,8 @@ func TestLoad_ManagedCaddyRejectsConflictingPublicPort(t *testing.T) {
 		"-proxy", "caddy",
 		"-public-port", "8443",
 	)
-	if err == nil {
-		t.Fatal("expected public port conflict error")
-	}
-	if !strings.Contains(err.Error(), "conflicts with configured public port") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err, "expected public port conflict error")
+	assert.Contains(t, err.Error(), "conflicts with configured public port")
 }
 
 func TestLoad_ManagedCaddyRejectsPublicURLPath(t *testing.T) {
@@ -384,12 +272,8 @@ func TestLoad_ManagedCaddyRejectsPublicURLPath(t *testing.T) {
 		"-public-url", "https://viewer.example.test/path",
 		"-proxy", "caddy",
 	)
-	if err == nil {
-		t.Fatal("expected public URL path error")
-	}
-	if !strings.Contains(err.Error(), "must not include a path") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err, "expected public URL path error")
+	assert.Contains(t, err.Error(), "must not include a path")
 }
 
 func TestLoad_ManagedCaddyNormalizesExplicitDefaultPorts(t *testing.T) {
@@ -398,24 +282,16 @@ func TestLoad_ManagedCaddyNormalizesExplicitDefaultPorts(t *testing.T) {
 		"-public-url", "https://viewer.example.test:443",
 		"-proxy", "caddy",
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.PublicURL != "https://viewer.example.test" {
-		t.Fatalf("PublicURL = %q, want %q", cfg.PublicURL, "https://viewer.example.test")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "https://viewer.example.test", cfg.PublicURL)
 
 	cfg, err = loadConfigFromFlags(
 		t,
 		"-public-url", "http://viewer.example.test:80",
 		"-proxy", "caddy",
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.PublicURL != "http://viewer.example.test" {
-		t.Fatalf("PublicURL = %q, want %q", cfg.PublicURL, "http://viewer.example.test")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "http://viewer.example.test", cfg.PublicURL)
 }
 
 func TestLoad_AllowedSubnetsRejectInvalid(t *testing.T) {
@@ -428,12 +304,8 @@ func TestLoad_AllowedSubnetsRejectInvalid(t *testing.T) {
 	})
 
 	_, err := LoadMinimal()
-	if err == nil {
-		t.Fatal("expected invalid allowed subnets error")
-	}
-	if !strings.Contains(err.Error(), "invalid allowed subnets") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.Error(t, err, "expected invalid allowed subnets error")
+	assert.Contains(t, err.Error(), "invalid allowed subnets")
 }
 
 func TestSaveGithubToken_RejectsCorruptConfig(t *testing.T) {
@@ -442,16 +314,10 @@ func TestSaveGithubToken_RejectsCorruptConfig(t *testing.T) {
 
 	// Write invalid TOML to config file
 	path := filepath.Join(tmp, configFileName)
-	if err := os.WriteFile(
-		path, []byte("[invalid toml = ="), 0o600,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("[invalid toml = ="), 0o600))
 
 	err := cfg.SaveGithubToken("tok")
-	if err == nil {
-		t.Fatal("expected error for corrupt config")
-	}
+	require.Error(t, err, "expected error for corrupt config")
 }
 
 func TestSaveGithubToken_ReturnsErrorOnReadFailure(t *testing.T) {
@@ -462,19 +328,11 @@ func TestSaveGithubToken_ReturnsErrorOnReadFailure(t *testing.T) {
 
 	// Create a config file that is not readable
 	path := filepath.Join(tmp, configFileName)
-	if err := os.WriteFile(
-		path, []byte("k = \"v\"\n"), 0o000,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("k = \"v\"\n"), 0o000))
 
 	err := cfg.SaveGithubToken("tok")
-	if err == nil {
-		t.Fatal("expected error for unreadable config file")
-	}
-	if !strings.Contains(err.Error(), "reading config file") {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.Error(t, err, "expected error for unreadable config file")
+	assert.Contains(t, err.Error(), "reading config file")
 }
 
 func TestSaveGithubToken_PreservesExistingKeys(t *testing.T) {
@@ -484,30 +342,15 @@ func TestSaveGithubToken_PreservesExistingKeys(t *testing.T) {
 	existing := map[string]any{"custom_key": "value"}
 	writeConfig(t, tmp, existing)
 
-	if err := cfg.SaveGithubToken("new-token"); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, cfg.SaveGithubToken("new-token"))
 
 	got, err := os.ReadFile(filepath.Join(tmp, configFileName))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	var result map[string]any
-	if _, err := toml.Decode(string(got), &result); err != nil {
-		t.Fatal(err)
-	}
-	if result["custom_key"] != "value" {
-		t.Errorf(
-			"custom_key = %v, want %q",
-			result["custom_key"], "value",
-		)
-	}
-	if result["github_token"] != "new-token" {
-		t.Errorf(
-			"github_token = %v, want %q",
-			result["github_token"], "new-token",
-		)
-	}
+	_, err = toml.Decode(string(got), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "value", result["custom_key"])
+	assert.Equal(t, "new-token", result["github_token"])
 }
 
 func TestLoadFile_ReadsDirArrays(t *testing.T) {
@@ -518,25 +361,15 @@ func TestLoadFile_ReadsDirArrays(t *testing.T) {
 	})
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	claudeDirs := cfg.ResolveDirs(parser.AgentClaude)
-	if len(claudeDirs) != 2 {
-		t.Fatalf(
-			"claude dirs len = %d, want 2",
-			len(claudeDirs),
-		)
-	}
-	if claudeDirs[0] != "/path/one" ||
-		claudeDirs[1] != "/path/two" {
-		t.Errorf("claude dirs = %v", claudeDirs)
-	}
+	require.Len(t, claudeDirs, 2)
+	assert.Equal(t, "/path/one", claudeDirs[0])
+	assert.Equal(t, "/path/two", claudeDirs[1])
 	codexDirs := cfg.ResolveDirs(parser.AgentCodex)
-	if len(codexDirs) != 1 || codexDirs[0] != "/codex/a" {
-		t.Errorf("codex dirs = %v", codexDirs)
-	}
+	require.Len(t, codexDirs, 1)
+	assert.Equal(t, "/codex/a", codexDirs[0])
 }
 
 func TestResolveDirs(t *testing.T) {
@@ -587,9 +420,7 @@ func TestResolveDirs(t *testing.T) {
 			}
 
 			cfg, err := LoadMinimal()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			dirs := cfg.ResolveDirs(parser.AgentClaude)
 
@@ -599,28 +430,8 @@ func TestResolveDirs(t *testing.T) {
 				want = cfg.AgentDirs[parser.AgentClaude]
 			}
 
-			if len(dirs) != len(want) {
-				t.Fatalf(
-					"got %d dirs, want %d",
-					len(dirs), len(want),
-				)
-			}
-			for i, v := range dirs {
-				if v != want[i] {
-					t.Errorf(
-						"dirs[%d] = %q, want %q",
-						i, v, want[i],
-					)
-				}
-			}
-
-			got := cfg.IsUserConfigured(parser.AgentClaude)
-			if got != tt.wantUserConfig {
-				t.Errorf(
-					"IsUserConfigured = %v, want %v",
-					got, tt.wantUserConfig,
-				)
-			}
+			assert.Equal(t, want, dirs)
+			assert.Equal(t, tt.wantUserConfig, cfg.IsUserConfigured(parser.AgentClaude))
 		})
 	}
 }
@@ -628,23 +439,15 @@ func TestResolveDirs(t *testing.T) {
 func TestResolveDataDir_DefaultAndEnvOverride(t *testing.T) {
 	// Without env override, should return default
 	dir, err := ResolveDataDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dir == "" {
-		t.Error("ResolveDataDir returned empty string")
-	}
+	require.NoError(t, err)
+	assert.NotEmpty(t, dir, "ResolveDataDir returned empty string")
 
 	// With env override, should return the override
 	custom := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", custom)
 	dir, err = ResolveDataDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if dir != custom {
-		t.Errorf("ResolveDataDir = %q, want %q", dir, custom)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, custom, dir)
 }
 
 // TestDataDir_LegacyEnvFallback verifies that the legacy AGENT_VIEWER_DATA_DIR
@@ -655,12 +458,8 @@ func TestDataDir_LegacyEnvFallback(t *testing.T) {
 		legacy := t.TempDir()
 		t.Setenv("AGENT_VIEWER_DATA_DIR", legacy)
 		dir, err := ResolveDataDir()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if dir != legacy {
-			t.Errorf("ResolveDataDir = %q, want %q", dir, legacy)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, legacy, dir)
 	})
 
 	t.Run("canonical wins over legacy", func(t *testing.T) {
@@ -669,12 +468,8 @@ func TestDataDir_LegacyEnvFallback(t *testing.T) {
 		t.Setenv("AGENT_VIEWER_DATA_DIR", legacy)
 		t.Setenv("AGENTSVIEW_DATA_DIR", canonical)
 		dir, err := ResolveDataDir()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if dir != canonical {
-			t.Errorf("ResolveDataDir = %q, want %q (canonical should win)", dir, canonical)
-		}
+		require.NoError(t, err)
+		assert.Equal(t, canonical, dir, "canonical should win")
 	})
 }
 
@@ -686,16 +481,10 @@ func TestEnvOverridesConfigFile(t *testing.T) {
 	t.Setenv("CODEX_SESSIONS_DIR", "/from/env")
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	dirs := cfg.ResolveDirs(parser.AgentCodex)
-	if len(dirs) != 1 || dirs[0] != "/from/env" {
-		t.Errorf(
-			"codex dirs = %v, want [/from/env]", dirs,
-		)
-	}
+	assert.Equal(t, []string{"/from/env"}, dirs)
 }
 
 func TestLoadFile_MalformedDirValueLogsWarning(t *testing.T) {
@@ -714,59 +503,26 @@ func TestLoadFile_MalformedDirValueLogsWarning(t *testing.T) {
 	t.Cleanup(func() { log.SetOutput(prev) })
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// The malformed key should trigger a warning.
 	logged := buf.String()
-	if !strings.Contains(logged, "claude_project_dirs") {
-		t.Errorf(
-			"expected warning mentioning config key, got: %q",
-			logged,
-		)
-	}
-	if !strings.Contains(logged, "expected string array") {
-		t.Errorf(
-			"expected warning about type, got: %q",
-			logged,
-		)
-	}
+	assert.Contains(t, logged, "claude_project_dirs")
+	assert.Contains(t, logged, "expected string array")
 
 	// ResolveDirs should return the default (malformed value
 	// was not applied).
 	dirs := cfg.ResolveDirs(parser.AgentClaude)
 	home, _ := os.UserHomeDir()
 	defaultDir := filepath.Join(home, ".claude", "projects")
-	if len(dirs) != 1 || dirs[0] != defaultDir {
-		t.Errorf(
-			"claude dirs = %v, want default [%s]",
-			dirs, defaultDir,
-		)
-	}
+	assert.Equal(t, []string{defaultDir}, dirs)
 }
 
 func TestDefault_ResultContentBlockedCategories(t *testing.T) {
 	cfg, err := Default()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	want := []string{"Read", "Glob"}
-	if len(cfg.ResultContentBlockedCategories) != len(want) {
-		t.Fatalf(
-			"ResultContentBlockedCategories len = %d, want %d",
-			len(cfg.ResultContentBlockedCategories), len(want),
-		)
-	}
-	for i, v := range cfg.ResultContentBlockedCategories {
-		if v != want[i] {
-			t.Errorf(
-				"ResultContentBlockedCategories[%d] = %q, want %q",
-				i, v, want[i],
-			)
-		}
-	}
+	assert.Equal(t, []string{"Read", "Glob"}, cfg.ResultContentBlockedCategories)
 }
 
 func TestLoadFile_ResultContentBlockedCategories(t *testing.T) {
@@ -809,24 +565,9 @@ func TestLoadFile_ResultContentBlockedCategories(t *testing.T) {
 			writeConfig(t, dir, tt.config)
 
 			cfg, err := LoadMinimal()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if len(cfg.ResultContentBlockedCategories) != len(tt.want) {
-				t.Fatalf(
-					"ResultContentBlockedCategories len = %d, want %d",
-					len(cfg.ResultContentBlockedCategories), len(tt.want),
-				)
-			}
-			for i, v := range cfg.ResultContentBlockedCategories {
-				if v != tt.want[i] {
-					t.Errorf(
-						"ResultContentBlockedCategories[%d] = %q, want %q",
-						i, v, tt.want[i],
-					)
-				}
-			}
+			assert.Equal(t, tt.want, cfg.ResultContentBlockedCategories)
 		})
 	}
 }
@@ -864,15 +605,8 @@ func TestLoadFile_EventsCoalesceInterval(t *testing.T) {
 			writeConfig(t, dir, tt.config)
 
 			cfg, err := LoadMinimal()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if cfg.EventsCoalesceInterval != tt.want {
-				t.Errorf(
-					"EventsCoalesceInterval = %v, want %v",
-					cfg.EventsCoalesceInterval, tt.want,
-				)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.EventsCoalesceInterval)
 		})
 	}
 }
@@ -941,24 +675,10 @@ func TestLoadFile_PGConfig(t *testing.T) {
 			}
 
 			cfg, err := LoadMinimal()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if cfg.PG.URL != tt.want.URL {
-				t.Errorf(
-					"URL = %q, want %q",
-					cfg.PG.URL,
-					tt.want.URL,
-				)
-			}
-			if cfg.PG.MachineName != tt.want.MachineName {
-				t.Errorf(
-					"MachineName = %q, want %q",
-					cfg.PG.MachineName,
-					tt.want.MachineName,
-				)
-			}
+			assert.Equal(t, tt.want.URL, cfg.PG.URL)
+			assert.Equal(t, tt.want.MachineName, cfg.PG.MachineName)
 		})
 	}
 }
@@ -973,20 +693,13 @@ projects = ["alpha", "beta"]
 `), 0o644)
 
 	cfg, err := Default()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cfg.DataDir = dir
-	if err := cfg.loadFile(); err != nil {
-		t.Fatalf("loadFile: %v", err)
-	}
+	require.NoError(t, cfg.loadFile(), "loadFile")
 
-	if len(cfg.PG.Projects) != 2 {
-		t.Fatalf("Projects = %v, want [alpha beta]", cfg.PG.Projects)
-	}
-	if cfg.PG.Projects[0] != "alpha" || cfg.PG.Projects[1] != "beta" {
-		t.Errorf("Projects = %v, want [alpha beta]", cfg.PG.Projects)
-	}
+	require.Len(t, cfg.PG.Projects, 2)
+	assert.Equal(t, "alpha", cfg.PG.Projects[0])
+	assert.Equal(t, "beta", cfg.PG.Projects[1])
 }
 
 func TestPGConfig_ExcludeProjectFilter(t *testing.T) {
@@ -999,20 +712,12 @@ exclude_projects = ["gamma"]
 `), 0o644)
 
 	cfg, err := Default()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cfg.DataDir = dir
-	if err := cfg.loadFile(); err != nil {
-		t.Fatalf("loadFile: %v", err)
-	}
+	require.NoError(t, cfg.loadFile(), "loadFile")
 
-	if len(cfg.PG.ExcludeProjects) != 1 {
-		t.Fatalf("ExcludeProjects = %v, want [gamma]", cfg.PG.ExcludeProjects)
-	}
-	if cfg.PG.ExcludeProjects[0] != "gamma" {
-		t.Errorf("ExcludeProjects = %v, want [gamma]", cfg.PG.ExcludeProjects)
-	}
+	require.Len(t, cfg.PG.ExcludeProjects, 1)
+	assert.Equal(t, "gamma", cfg.PG.ExcludeProjects[0])
 }
 
 func TestResolvePG_Defaults(t *testing.T) {
@@ -1022,16 +727,10 @@ func TestResolvePG_Defaults(t *testing.T) {
 		},
 	}
 	resolved, err := cfg.ResolvePG()
-	if err != nil {
-		t.Fatalf("ResolvePG: %v", err)
-	}
+	require.NoError(t, err, "ResolvePG")
 
-	if resolved.Schema != "agentsview" {
-		t.Errorf("Schema = %q, want agentsview", resolved.Schema)
-	}
-	if resolved.MachineName == "" {
-		t.Error("MachineName should default to hostname")
-	}
+	assert.Equal(t, "agentsview", resolved.Schema)
+	assert.NotEmpty(t, resolved.MachineName, "MachineName should default to hostname")
 }
 
 func TestResolvePG_ExpandsEnvVars(t *testing.T) {
@@ -1045,14 +744,9 @@ func TestResolvePG_ExpandsEnvVars(t *testing.T) {
 	}
 
 	resolved, err := cfg.ResolvePG()
-	if err != nil {
-		t.Fatalf("ResolvePG: %v", err)
-	}
+	require.NoError(t, err, "ResolvePG")
 
-	want := "postgres://localhost/test?password=env-secret"
-	if resolved.URL != want {
-		t.Fatalf("URL = %q, want %q", resolved.URL, want)
-	}
+	assert.Equal(t, "postgres://localhost/test?password=env-secret", resolved.URL)
 }
 
 func TestResolvePG_ExpandsBareEnvOnlyForWholeValue(t *testing.T) {
@@ -1065,14 +759,9 @@ func TestResolvePG_ExpandsBareEnvOnlyForWholeValue(t *testing.T) {
 	}
 
 	resolved, err := cfg.ResolvePG()
-	if err != nil {
-		t.Fatalf("ResolvePG: %v", err)
-	}
+	require.NoError(t, err, "ResolvePG")
 
-	want := "postgres://localhost/test"
-	if resolved.URL != want {
-		t.Fatalf("URL = %q, want %q", resolved.URL, want)
-	}
+	assert.Equal(t, "postgres://localhost/test", resolved.URL)
 }
 
 func TestResolvePG_PreservesLiteralDollarSequencesInURL(t *testing.T) {
@@ -1085,14 +774,9 @@ func TestResolvePG_PreservesLiteralDollarSequencesInURL(t *testing.T) {
 	}
 
 	resolved, err := cfg.ResolvePG()
-	if err != nil {
-		t.Fatalf("ResolvePG: %v", err)
-	}
+	require.NoError(t, err, "ResolvePG")
 
-	want := "postgres://user:pa$word@localhost/db?application_name=$client&password=env-secret"
-	if resolved.URL != want {
-		t.Fatalf("URL = %q, want %q", resolved.URL, want)
-	}
+	assert.Equal(t, "postgres://user:pa$word@localhost/db?application_name=$client&password=env-secret", resolved.URL)
 }
 
 func TestResolvePG_ErrorsOnMissingEnvVar(t *testing.T) {
@@ -1103,12 +787,8 @@ func TestResolvePG_ErrorsOnMissingEnvVar(t *testing.T) {
 	}
 
 	_, err := cfg.ResolvePG()
-	if err == nil {
-		t.Fatal("expected error for unset env var")
-	}
-	if !strings.Contains(err.Error(), "NONEXISTENT_PG_VAR") {
-		t.Errorf("error = %v, want mention of NONEXISTENT_PG_VAR", err)
-	}
+	require.Error(t, err, "expected error for unset env var")
+	assert.Contains(t, err.Error(), "NONEXISTENT_PG_VAR")
 }
 
 func TestResolvePG_ErrorsOnMissingBareEnvVar(t *testing.T) {
@@ -1119,12 +799,8 @@ func TestResolvePG_ErrorsOnMissingBareEnvVar(t *testing.T) {
 	}
 
 	_, err := cfg.ResolvePG()
-	if err == nil {
-		t.Fatal("expected error for unset bare env var")
-	}
-	if !strings.Contains(err.Error(), "NONEXISTENT_PG_BARE_VAR") {
-		t.Errorf("error = %v, want mention of NONEXISTENT_PG_BARE_VAR", err)
-	}
+	require.Error(t, err, "expected error for unset bare env var")
+	assert.Contains(t, err.Error(), "NONEXISTENT_PG_BARE_VAR")
 }
 
 // ResolvePG must not reject configs with both filter lists —
@@ -1140,12 +816,7 @@ func TestResolvePG_AllowsBothFilterLists(t *testing.T) {
 		},
 	}
 	_, err := cfg.ResolvePG()
-	if err != nil {
-		t.Fatalf(
-			"ResolvePG should not reject filter conflicts: %v",
-			err,
-		)
-	}
+	require.NoError(t, err, "ResolvePG should not reject filter conflicts")
 }
 
 func TestAutomatedPrefixesRoundTrip(t *testing.T) {
@@ -1161,19 +832,14 @@ func TestAutomatedPrefixesRoundTrip(t *testing.T) {
 		},
 	})
 	cfg, err := loadConfigFromPFlags(t)
-	if err != nil {
-		t.Fatalf("loading config: %v", err)
-	}
-	got := cfg.Automated.Prefixes
+	require.NoError(t, err, "loading config")
 	want := []string{
 		"You are analyzing an essay",
 		"You are grading quotes",
 		"  ",
 		"You are analyzing an essay",
 	}
-	if !slices.Equal(got, want) {
-		t.Errorf("prefixes = %q, want %q", got, want)
-	}
+	assert.Equal(t, want, cfg.Automated.Prefixes)
 }
 
 func TestAutomatedPrefixesAbsentIsNil(t *testing.T) {
@@ -1182,12 +848,8 @@ func TestAutomatedPrefixesAbsentIsNil(t *testing.T) {
 		"public_url": "http://example.com",
 	})
 	cfg, err := loadConfigFromPFlags(t)
-	if err != nil {
-		t.Fatalf("loading config: %v", err)
-	}
-	if cfg.Automated.Prefixes != nil {
-		t.Errorf("expected nil, got %v", cfg.Automated.Prefixes)
-	}
+	require.NoError(t, err, "loading config")
+	assert.Nil(t, cfg.Automated.Prefixes)
 }
 
 func TestLoadFile_CustomModelPricing(t *testing.T) {
@@ -1233,29 +895,21 @@ func TestLoadFile_CustomModelPricing(t *testing.T) {
 			writeConfig(t, dir, tt.data)
 
 			cfg, err := LoadMinimal()
-			if err != nil {
-				t.Fatalf("LoadMinimal: %v", err)
-			}
+			require.NoError(t, err, "LoadMinimal")
 
 			if len(tt.want) == 0 {
-				if len(cfg.CustomModelPricing) != 0 {
-					t.Fatalf("expected nil/empty, got %v", cfg.CustomModelPricing)
-				}
+				assert.Empty(t, cfg.CustomModelPricing)
 				return
 			}
 
-			if len(cfg.CustomModelPricing) != len(tt.want) {
-				t.Fatalf("got %d entries, want %d", len(cfg.CustomModelPricing), len(tt.want))
-			}
+			require.Len(t, cfg.CustomModelPricing, len(tt.want))
 			for model, wantRate := range tt.want {
 				got, ok := cfg.CustomModelPricing[model]
 				if !ok {
 					t.Errorf("missing model %q", model)
 					continue
 				}
-				if got != wantRate {
-					t.Errorf("model %q = %+v, want %+v", model, got, wantRate)
-				}
+				assert.Equal(t, wantRate, got, "model %q", model)
 			}
 		})
 	}

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -6,16 +6,17 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func readConfigFile(t *testing.T, dir string) Config {
 	t.Helper()
 	var fileCfg Config
-	if _, err := toml.DecodeFile(
+	_, err := toml.DecodeFile(
 		filepath.Join(dir, configFileName), &fileCfg,
-	); err != nil {
-		t.Fatalf("parsing config file: %v", err)
-	}
+	)
+	require.NoError(t, err, "parsing config file")
 	return fileCfg
 }
 
@@ -24,106 +25,59 @@ func TestCursorSecret_GeneratedAndPersisted(t *testing.T) {
 
 	// First load: should generate a secret
 	cfg1, err := LoadMinimal()
-	if err != nil {
-		t.Fatalf("first load failed: %v", err)
-	}
-	if cfg1.CursorSecret == "" {
-		t.Fatal("cursor secret was not generated")
-	}
-	if cfg1.DataDir != dir {
-		t.Fatalf(
-			"DataDir = %q, want %q", cfg1.DataDir, dir,
-		)
-	}
+	require.NoError(t, err, "first load failed")
+	require.NotEmpty(t, cfg1.CursorSecret, "cursor secret was not generated")
+	require.Equal(t, dir, cfg1.DataDir)
 
 	// Verify file existence and content
 	fileCfg := readConfigFile(t, dir)
 
-	if fileCfg.CursorSecret != cfg1.CursorSecret {
-		t.Errorf(
-			"file secret = %q, want %q",
-			fileCfg.CursorSecret, cfg1.CursorSecret,
-		)
-	}
+	assert.Equal(t, cfg1.CursorSecret, fileCfg.CursorSecret)
 
 	// Second load: should read the same secret
 	cfg2, err := LoadMinimal()
-	if err != nil {
-		t.Fatalf("second load failed: %v", err)
-	}
-	if cfg2.CursorSecret != cfg1.CursorSecret {
-		t.Errorf(
-			"second load got %q, want %q",
-			cfg2.CursorSecret, cfg1.CursorSecret,
-		)
-	}
+	require.NoError(t, err, "second load failed")
+	assert.Equal(t, cfg1.CursorSecret, cfg2.CursorSecret)
 }
 
 func TestCursorSecret_RegeneratedIfMissing(t *testing.T) {
 	dir := setupTestEnv(t)
 
 	initialContent := "cursor_secret = \"\"\n"
-	if err := os.WriteFile(filepath.Join(dir, configFileName), []byte(initialContent), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, configFileName), []byte(initialContent), 0o600))
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatalf("load failed: %v", err)
-	}
-	if cfg.CursorSecret == "" {
-		t.Fatal("cursor secret should have been regenerated")
-	}
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg.CursorSecret, "cursor secret should have been regenerated")
 
 	// Verify it was updated in the file
 	fileCfg := readConfigFile(t, dir)
-	if fileCfg.CursorSecret == "" {
-		t.Error("cursor secret was not updated in the file")
-	}
+	assert.NotEmpty(t, fileCfg.CursorSecret, "cursor secret was not updated in the file")
 }
 
 func TestCursorSecret_LoadErrorOnInvalidConfig(t *testing.T) {
 	dir := setupTestEnv(t)
 
-	if err := os.WriteFile(filepath.Join(dir, configFileName), []byte("[invalid toml = ="), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, configFileName), []byte("[invalid toml = ="), 0o600))
 
 	_, err := LoadMinimal()
-	if err == nil {
-		t.Fatal("expected error loading invalid config")
-	}
+	require.Error(t, err, "expected error loading invalid config")
 }
 
 func TestCursorSecret_PreservesOtherFields(t *testing.T) {
 	dir := setupTestEnv(t)
 
-	if err := os.WriteFile(filepath.Join(dir, configFileName), []byte("github_token = \"my-token\"\n"), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, configFileName), []byte("github_token = \"my-token\"\n"), 0o600))
 
 	cfg, err := LoadMinimal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if cfg.CursorSecret == "" {
-		t.Error("cursor secret not generated")
-	}
-	if cfg.GithubToken != "my-token" {
-		t.Errorf(
-			"github_token = %q, want %q",
-			cfg.GithubToken, "my-token",
-		)
-	}
+	assert.NotEmpty(t, cfg.CursorSecret, "cursor secret not generated")
+	assert.Equal(t, "my-token", cfg.GithubToken)
 
 	// Verify file content has both
 	fileCfg := readConfigFile(t, dir)
 
-	if fileCfg.CursorSecret == "" {
-		t.Error("cursor_secret missing in file")
-	}
-	if fileCfg.GithubToken != "my-token" {
-		t.Error("github_token lost/changed in file")
-	}
+	assert.NotEmpty(t, fileCfg.CursorSecret, "cursor_secret missing in file")
+	assert.Equal(t, "my-token", fileCfg.GithubToken, "github_token lost/changed in file")
 }

--- a/internal/db/activity_test.go
+++ b/internal/db/activity_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetSessionActivity(t *testing.T) {
@@ -14,9 +17,7 @@ func TestGetSessionActivity(t *testing.T) {
 		Agent:     "claude",
 		StartedAt: new("2026-03-26T10:00:00Z"),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Insert messages spanning ~29 minutes.
 	msgs := []Message{
@@ -30,172 +31,110 @@ func TestGetSessionActivity(t *testing.T) {
 		// System message — should be excluded from counts.
 		{SessionID: sid, Ordinal: 6, Role: "user", Content: "This session is being continued from a previous conversation.", Timestamp: "2026-03-26T10:29:30Z", ContentLength: 60, IsSystem: true},
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.InsertMessages(msgs))
 
 	resp, err := d.GetSessionActivity(context.Background(), sid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// 29 min span => 1min buckets (snapInterval(1740) = 60).
-	if resp.IntervalSeconds != 60 {
-		t.Errorf("interval = %d, want 60", resp.IntervalSeconds)
-	}
+	assert.Equal(t, int64(60), resp.IntervalSeconds, "interval")
 
 	// System message should still count toward total (7 total messages).
-	if resp.TotalMessages != 7 {
-		t.Errorf("total = %d, want 7", resp.TotalMessages)
-	}
+	assert.Equal(t, 7, resp.TotalMessages, "total")
 
 	// Should have 30 buckets (min 0 to min 29).
-	if len(resp.Buckets) < 28 {
-		t.Errorf("bucket count = %d, want >= 28", len(resp.Buckets))
-	}
+	assert.GreaterOrEqual(t, len(resp.Buckets), 28, "bucket count")
 
 	// First bucket (10:00-10:01) should have user=1, assistant=1.
 	first := resp.Buckets[0]
-	if first.UserCount != 1 || first.AssistantCount != 1 {
-		t.Errorf("first bucket: user=%d asst=%d, want 1,1", first.UserCount, first.AssistantCount)
-	}
-	if first.FirstOrdinal == nil || *first.FirstOrdinal != 0 {
-		t.Errorf("first bucket first_ordinal: got %v, want 0", first.FirstOrdinal)
-	}
+	assert.Equal(t, 1, first.UserCount, "first bucket user")
+	assert.Equal(t, 1, first.AssistantCount, "first bucket asst")
+	require.NotNil(t, first.FirstOrdinal, "first bucket first_ordinal")
+	assert.Equal(t, 0, *first.FirstOrdinal, "first bucket first_ordinal")
 
 	// Middle empty bucket should have nil FirstOrdinal.
 	mid := resp.Buckets[15]
-	if mid.UserCount != 0 || mid.AssistantCount != 0 {
-		t.Errorf("mid bucket: user=%d asst=%d, want 0,0", mid.UserCount, mid.AssistantCount)
-	}
-	if mid.FirstOrdinal != nil {
-		t.Errorf("mid bucket first_ordinal: got %v, want nil", mid.FirstOrdinal)
-	}
+	assert.Equal(t, 0, mid.UserCount, "mid bucket user")
+	assert.Equal(t, 0, mid.AssistantCount, "mid bucket asst")
+	assert.Nil(t, mid.FirstOrdinal, "mid bucket first_ordinal")
 }
 
 func TestGetSessionActivity_NoMessages(t *testing.T) {
 	d := testDB(t)
 	sid := "test-empty"
 
-	err := d.UpsertSession(Session{ID: sid, Agent: "claude"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.UpsertSession(Session{ID: sid, Agent: "claude"}))
 
 	resp, err := d.GetSessionActivity(context.Background(), sid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(resp.Buckets) != 0 {
-		t.Errorf("buckets = %d, want 0", len(resp.Buckets))
-	}
+	require.NoError(t, err)
+	assert.Empty(t, resp.Buckets, "buckets")
 }
 
 func TestGetSessionActivity_NullTimestamps(t *testing.T) {
 	d := testDB(t)
 	sid := "test-null-ts"
 
-	err := d.UpsertSession(Session{ID: sid, Agent: "claude"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.UpsertSession(Session{ID: sid, Agent: "claude"}))
 
 	msgs := []Message{
 		{SessionID: sid, Ordinal: 0, Role: "user", Content: "hi", ContentLength: 2},
 		{SessionID: sid, Ordinal: 1, Role: "assistant", Content: "hello", ContentLength: 5},
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.InsertMessages(msgs))
 
 	resp, err := d.GetSessionActivity(context.Background(), sid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(resp.Buckets) != 0 {
-		t.Errorf("buckets = %d, want 0", len(resp.Buckets))
-	}
-	if resp.TotalMessages != 2 {
-		t.Errorf("total = %d, want 2", resp.TotalMessages)
-	}
+	require.NoError(t, err)
+	assert.Empty(t, resp.Buckets, "buckets")
+	assert.Equal(t, 2, resp.TotalMessages, "total")
 }
 
 func TestGetSessionActivity_SingleMessage(t *testing.T) {
 	d := testDB(t)
 	sid := "test-single"
 
-	err := d.UpsertSession(Session{ID: sid, Agent: "claude"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.UpsertSession(Session{ID: sid, Agent: "claude"}))
 
 	msgs := []Message{
 		{SessionID: sid, Ordinal: 0, Role: "user", Content: "hi", Timestamp: "2026-03-26T10:00:00Z", ContentLength: 2},
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.InsertMessages(msgs))
 
 	resp, err := d.GetSessionActivity(context.Background(), sid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(resp.Buckets) != 1 {
-		t.Fatalf("buckets = %d, want 1", len(resp.Buckets))
-	}
-	if resp.Buckets[0].UserCount != 1 {
-		t.Errorf("user count = %d, want 1", resp.Buckets[0].UserCount)
-	}
+	require.NoError(t, err)
+	require.Len(t, resp.Buckets, 1, "buckets")
+	assert.Equal(t, 1, resp.Buckets[0].UserCount, "user count")
 }
 
 func TestGetSessionActivity_MalformedTimestamps(t *testing.T) {
 	d := testDB(t)
 	sid := "test-malformed-ts"
 
-	err := d.UpsertSession(Session{ID: sid, Agent: "claude"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.UpsertSession(Session{ID: sid, Agent: "claude"}))
 
 	msgs := []Message{
 		{SessionID: sid, Ordinal: 0, Role: "user", Content: "hi", Timestamp: "2026-03-26T10:00:00Z", ContentLength: 2},
 		{SessionID: sid, Ordinal: 1, Role: "assistant", Content: "hello", Timestamp: "not-a-timestamp", ContentLength: 5},
 		{SessionID: sid, Ordinal: 2, Role: "user", Content: "bye", Timestamp: "2026-03-26T10:00:30Z", ContentLength: 3},
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.InsertMessages(msgs))
 
 	resp, err := d.GetSessionActivity(context.Background(), sid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Malformed timestamp excluded from buckets; valid ones bucketed.
-	if len(resp.Buckets) < 1 {
-		t.Fatal("expected at least 1 bucket")
-	}
+	require.NotEmpty(t, resp.Buckets, "expected at least 1 bucket")
 	// Both valid user messages (ord 0 and 2) are within 30s,
 	// so they land in the same bucket.
-	if resp.Buckets[0].UserCount != 2 || resp.Buckets[0].AssistantCount != 0 {
-		t.Errorf(
-			"first bucket: user=%d asst=%d, want 2,0",
-			resp.Buckets[0].UserCount, resp.Buckets[0].AssistantCount,
-		)
-	}
-	if resp.TotalMessages != 3 {
-		t.Errorf("total = %d, want 3", resp.TotalMessages)
-	}
+	assert.Equal(t, 2, resp.Buckets[0].UserCount, "first bucket user")
+	assert.Equal(t, 0, resp.Buckets[0].AssistantCount, "first bucket asst")
+	assert.Equal(t, 3, resp.TotalMessages, "total")
 }
 
 func TestGetSessionActivity_FractionalTimestamps(t *testing.T) {
 	d := testDB(t)
 	sid := "test-frac-ts"
 
-	err := d.UpsertSession(Session{ID: sid, Agent: "claude"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.UpsertSession(Session{ID: sid, Agent: "claude"}))
 
 	// Two messages within the same 60s bucket but with fractional
 	// timestamps that would be mis-bucketed by whole-second truncation.
@@ -206,42 +145,23 @@ func TestGetSessionActivity_FractionalTimestamps(t *testing.T) {
 		// This message is in the next bucket (60.1s after the anchor).
 		{SessionID: sid, Ordinal: 2, Role: "user", Content: "c", Timestamp: "2026-03-26T10:01:01.000Z", ContentLength: 1},
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, d.InsertMessages(msgs))
 
 	resp, err := d.GetSessionActivity(context.Background(), sid)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if resp.IntervalSeconds != 60 {
-		t.Fatalf("interval = %d, want 60", resp.IntervalSeconds)
-	}
+	require.Equal(t, int64(60), resp.IntervalSeconds, "interval")
 
 	// First bucket should have both fractional-second messages.
-	if len(resp.Buckets) < 1 {
-		t.Fatal("expected at least 1 bucket")
-	}
+	require.NotEmpty(t, resp.Buckets, "expected at least 1 bucket")
 	first := resp.Buckets[0]
-	if first.UserCount != 1 || first.AssistantCount != 1 {
-		t.Errorf(
-			"first bucket: user=%d asst=%d, want 1,1",
-			first.UserCount, first.AssistantCount,
-		)
-	}
+	assert.Equal(t, 1, first.UserCount, "first bucket user")
+	assert.Equal(t, 1, first.AssistantCount, "first bucket asst")
 
 	// Second bucket should have the third message.
-	if len(resp.Buckets) < 2 {
-		t.Fatal("expected at least 2 buckets")
-	}
+	require.GreaterOrEqual(t, len(resp.Buckets), 2, "expected at least 2 buckets")
 	second := resp.Buckets[1]
-	if second.UserCount != 1 {
-		t.Errorf(
-			"second bucket user=%d, want 1",
-			second.UserCount,
-		)
-	}
+	assert.Equal(t, 1, second.UserCount, "second bucket user")
 }
 
 func TestSnapInterval(t *testing.T) {
@@ -272,12 +192,7 @@ func TestSnapInterval(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := SnapInterval(tt.duration)
-			if got != tt.want {
-				t.Errorf(
-					"SnapInterval(%d) = %d, want %d",
-					tt.duration, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got, "SnapInterval(%d)", tt.duration)
 		})
 	}
 }

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -3,7 +3,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -174,13 +173,9 @@ func TestGetAnalyticsSummary(t *testing.T) {
 		// P90 index = int(5*0.9) = 4 → value 30
 		assert.Equal(t, 30, s.P90Messages, "P90Messages")
 
-		if s.Agents["claude"] == nil {
-			t.Fatal("expected claude agent entry")
-		}
+		require.NotNil(t, s.Agents["claude"], "expected claude agent entry")
 		assert.Equal(t, 4, s.Agents["claude"].Sessions, "claude sessions")
-		if s.Agents["codex"] == nil {
-			t.Fatal("expected codex agent entry")
-		}
+		require.NotNil(t, s.Agents["codex"], "expected codex agent entry")
 		assert.Equal(t, 1, s.Agents["codex"].Sessions, "codex sessions")
 	})
 
@@ -314,10 +309,10 @@ func TestGetAnalyticsHeatmap(t *testing.T) {
 		resp := mustHeatmap(t, d, ctx, baseFilter(), "messages")
 		// All entries should have levels 0-4
 		for _, e := range resp.Entries {
-			if e.Level < 0 || e.Level > 4 {
-				t.Errorf("date %s level = %d, want 0-4",
-					e.Date, e.Level)
-			}
+			assert.GreaterOrEqual(t, e.Level, 0,
+				"date %s level", e.Date)
+			assert.LessOrEqual(t, e.Level, 4,
+				"date %s level", e.Date)
 		}
 	})
 
@@ -328,19 +323,9 @@ func TestGetAnalyticsHeatmap(t *testing.T) {
 		resp := mustHeatmap(
 			t, d, ctx, baseFilter(), "output_tokens",
 		)
-		if resp.Metric != "output_tokens" {
-			t.Errorf(
-				"Metric = %q, want output_tokens",
-				resp.Metric,
-			)
-		}
-		if len(resp.Entries) != 0 {
-			t.Errorf(
-				"len(Entries) = %d, want 0 "+
-					"(no sessions report token coverage)",
-				len(resp.Entries),
-			)
-		}
+		assert.Equal(t, "output_tokens", resp.Metric, "Metric")
+		assert.Empty(t, resp.Entries,
+			"len(Entries) want 0 (no sessions report token coverage)")
 	})
 
 	t.Run("EmptyRange", func(t *testing.T) {
@@ -349,12 +334,8 @@ func TestGetAnalyticsHeatmap(t *testing.T) {
 		resp := mustHeatmap(t, d, ctx, f, "messages")
 		require.Len(t, resp.Entries, 3, "len(Entries) =")
 		for _, e := range resp.Entries {
-			if e.Value != 0 {
-				t.Errorf("date %s value = %d, want 0", e.Date, e.Value)
-			}
-			if e.Level != 0 {
-				t.Errorf("date %s level = %d, want 0", e.Date, e.Level)
-			}
+			assert.Equal(t, 0, e.Value, "date %s value", e.Date)
+			assert.Equal(t, 0, e.Level, "date %s level", e.Date)
 		}
 	})
 }
@@ -417,12 +398,8 @@ func TestMedianInt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := medianInt(tt.sorted, len(tt.sorted))
-			if got != tt.want {
-				t.Errorf(
-					"medianInt(%v) = %d, want %d",
-					tt.sorted, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got,
+				"medianInt(%v)", tt.sorted)
 		})
 	}
 }
@@ -445,12 +422,8 @@ func TestLocalDate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := localDate(tt.ts, utc)
-			if got != tt.want {
-				t.Errorf(
-					"localDate(%q) = %q, want %q",
-					tt.ts, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got,
+				"localDate(%q)", tt.ts)
 		})
 	}
 }
@@ -479,12 +452,8 @@ func TestMostActiveTieBreak(t *testing.T) {
 	s := mustSummary(t, d, ctx, f)
 
 	// Alphabetically, "alpha" < "zebra"
-	if s.MostActive != "alpha" {
-		t.Errorf(
-			"MostActive = %q, want alphabetically first (alpha)",
-			s.MostActive,
-		)
-	}
+	assert.Equal(t, "alpha", s.MostActive,
+		"MostActive want alphabetically first (alpha)")
 }
 
 func TestEvenCountMedianInSummary(t *testing.T) {
@@ -510,11 +479,7 @@ func TestEvenCountMedianInSummary(t *testing.T) {
 	s := mustSummary(t, d, ctx, f)
 
 	// Sorted: [5, 10, 20, 30] → median = (10+20)/2 = 15
-	if s.MedianMessages != 15 {
-		t.Errorf(
-			"MedianMessages = %d, want 15", s.MedianMessages,
-		)
-	}
+	assert.Equal(t, 15, s.MedianMessages, "MedianMessages")
 }
 
 func TestAnalyticsTimezone(t *testing.T) {
@@ -631,12 +596,7 @@ func TestConcentrationTopThree(t *testing.T) {
 			Timezone: "UTC",
 		}
 		s := mustSummary(t, d, ctx, f)
-		if s.Concentration != 1.0 {
-			t.Errorf(
-				"Concentration = %f, want 1.0",
-				s.Concentration,
-			)
-		}
+		assert.Equal(t, 1.0, s.Concentration, "Concentration")
 	})
 
 	t.Run("TwoProjects", func(t *testing.T) {
@@ -658,12 +618,7 @@ func TestConcentrationTopThree(t *testing.T) {
 		}
 		s := mustSummary(t, d, ctx, f)
 		// Both in top 3 → concentration = 1.0
-		if s.Concentration != 1.0 {
-			t.Errorf(
-				"Concentration = %f, want 1.0",
-				s.Concentration,
-			)
-		}
+		assert.Equal(t, 1.0, s.Concentration, "Concentration")
 	})
 
 	t.Run("FourProjects", func(t *testing.T) {
@@ -691,12 +646,7 @@ func TestConcentrationTopThree(t *testing.T) {
 		}
 		s := mustSummary(t, d, ctx, f)
 		// Top 3: 40+30+20 = 90, total = 100
-		if s.Concentration != 0.9 {
-			t.Errorf(
-				"Concentration = %f, want 0.9",
-				s.Concentration,
-			)
-		}
+		assert.Equal(t, 0.9, s.Concentration, "Concentration")
 	})
 }
 
@@ -709,12 +659,9 @@ func TestGetAnalyticsHourOfWeek(t *testing.T) {
 		require.NoError(t, err, "GetAnalyticsHourOfWeek")
 		assert.Len(t, resp.Cells, 168, "len(Cells)")
 		for _, c := range resp.Cells {
-			if c.Messages != 0 {
-				t.Errorf(
-					"day=%d hour=%d messages=%d, want 0",
-					c.DayOfWeek, c.Hour, c.Messages,
-				)
-			}
+			assert.Equal(t, 0, c.Messages,
+				"day=%d hour=%d messages",
+				c.DayOfWeek, c.Hour)
 		}
 	})
 
@@ -772,20 +719,12 @@ func TestGetAnalyticsHourOfWeek(t *testing.T) {
 		// 23:00 UTC Sat → 04:00 Sun in UTC+5
 		// Sunday = ISO day 6
 		sunH4 := findHOWCell(resp.Cells, 6, 4)
-		if sunH4 != 1 {
-			t.Errorf(
-				"Sun 04:00 PKT = %d, want 1", sunH4,
-			)
-		}
+		assert.Equal(t, 1, sunH4, "Sun 04:00 PKT")
 		// 09:00 UTC Sat → 14:00 Sat in UTC+5
 		// 09:30 UTC Sat → 14:30 Sat in UTC+5
 		// Both fall in hour 14
 		satH14 := findHOWCell(resp.Cells, 5, 14)
-		if satH14 != 2 {
-			t.Errorf(
-				"Sat 14:xx PKT = %d, want 2", satH14,
-			)
-		}
+		assert.Equal(t, 2, satH14, "Sat 14:xx PKT")
 	})
 }
 
@@ -871,12 +810,7 @@ func TestGetAnalyticsSessionShape(t *testing.T) {
 		for _, b := range resp.DurationDistribution {
 			totalDur += b.Count
 		}
-		if totalDur != 1 {
-			t.Errorf(
-				"total duration entries = %d, want 1",
-				totalDur,
-			)
-		}
+		assert.Equal(t, 1, totalDur, "total duration entries")
 	})
 
 	t.Run("Autonomy", func(t *testing.T) {
@@ -912,9 +846,7 @@ func bucketMap(
 
 func assertEq[T comparable](t *testing.T, name string, got, want T) {
 	t.Helper()
-	if got != want {
-		t.Errorf("%s = %v, want %v", name, got, want)
-	}
+	assert.Equal(t, want, got, name)
 }
 
 type testClock struct {
@@ -1004,9 +936,8 @@ func TestGetAnalyticsVelocity_Metrics(t *testing.T) {
 		require.NoError(t, err, "GetAnalyticsVelocity")
 		// Active time: 5 gaps of 10s = 50s ≈ 0.833 min
 		// 6 msgs / 0.833 = ~7.2 msgs/min
-		if resp.Overall.MsgsPerActiveMin < 7.0 || resp.Overall.MsgsPerActiveMin > 7.5 {
-			t.Errorf("MsgsPerActiveMin = %f, want ~7.2", resp.Overall.MsgsPerActiveMin)
-		}
+		assert.InDelta(t, 7.2, resp.Overall.MsgsPerActiveMin, 0.3,
+			"MsgsPerActiveMin want ~7.2")
 	})
 
 	t.Run("ByAgent", func(t *testing.T) {
@@ -1167,9 +1098,8 @@ func TestGetAnalyticsVelocity_ToolUsage(t *testing.T) {
 		)
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
 		require.NoError(t, err, "GetAnalyticsVelocity")
-		if len(resp.ByAgent) < 2 {
-			t.Fatalf("ByAgent has %d entries, want >= 2", len(resp.ByAgent))
-		}
+		require.GreaterOrEqual(t, len(resp.ByAgent), 2,
+			"ByAgent entries want >= 2")
 		agentMap := make(map[string]VelocityBreakdown)
 		for _, b := range resp.ByAgent {
 			agentMap[b.Label] = b
@@ -1219,20 +1149,14 @@ func TestVelocityChunkedQuery(t *testing.T) {
 
 	// Velocity must not fail even with >500 sessions
 	resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-	if err != nil {
-		t.Fatalf("GetAnalyticsVelocity with %d sessions: %v",
-			n, err)
-	}
+	require.NoError(t, err,
+		"GetAnalyticsVelocity with %d sessions", n)
 	assert.Equal(t, n, resp.ByComplexity[0].Sessions, "sessions")
 
 	// SessionShape must not fail either
 	shape, err := d.GetAnalyticsSessionShape(ctx, baseFilter())
-	if err != nil {
-		t.Fatalf(
-			"GetAnalyticsSessionShape with %d sessions: %v",
-			n, err,
-		)
-	}
+	require.NoError(t, err,
+		"GetAnalyticsSessionShape with %d sessions", n)
 	assert.Equal(t, n, shape.Count, "Count")
 }
 
@@ -1252,10 +1176,9 @@ func TestPercentileFloat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := percentileFloat(tt.sorted, tt.pct)
-			if got != tt.want {
-				t.Errorf("percentileFloat(%v, %f) = %f, want %f",
-					tt.sorted, tt.pct, got, tt.want)
-			}
+			assert.Equal(t, tt.want, got,
+				"percentileFloat(%v, %f)",
+				tt.sorted, tt.pct)
 		})
 	}
 }
@@ -1410,9 +1333,7 @@ func TestActivityToolAndThinkingCounts(t *testing.T) {
 	insertMessages(t, d, u, a1, a2)
 
 	resp := mustActivity(t, d, ctx, baseFilter(), "day")
-	if len(resp.Series) == 0 {
-		t.Fatal("expected non-empty series")
-	}
+	require.NotEmpty(t, resp.Series, "expected non-empty series")
 
 	entry := resp.Series[0]
 	assert.Equal(t, 1, entry.ThinkingMessages, "ThinkingMessages")
@@ -1439,10 +1360,8 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 			ctx, baseFilter(), "messages",
 		)
 		require.NoError(t, err, "GetAnalyticsTopSessions")
-		if len(resp.Sessions) != stats.TotalSessions {
-			t.Fatalf("len(Sessions) = %d, want %d",
-				len(resp.Sessions), stats.TotalSessions)
-		}
+		require.Len(t, resp.Sessions, stats.TotalSessions,
+			"len(Sessions)")
 		// First should be the session with most messages (b1=30)
 		assert.Equal(t, 30, resp.Sessions[0].MessageCount, "top session messages")
 		assert.Equal(t, "project-beta", resp.Sessions[0].Project, "top session project")
@@ -1456,15 +1375,12 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		assert.Equal(t, "duration", resp.Metric, "Metric")
 		// All seeded sessions have 1h duration except a1
 		// which runs from 09:00 to midyear
-		if len(resp.Sessions) == 0 {
-			t.Fatal("expected non-empty sessions")
-		}
+		require.NotEmpty(t, resp.Sessions,
+			"expected non-empty sessions")
 		// All sessions should have positive duration
 		for _, s := range resp.Sessions {
-			if s.DurationMin <= 0 {
-				t.Errorf("session %s duration = %f, want > 0",
-					s.ID, s.DurationMin)
-			}
+			assert.Greater(t, s.DurationMin, 0.0,
+				"session %s duration", s.ID)
 		}
 	})
 
@@ -1543,20 +1459,12 @@ func TestAnalyticsTerminationFilter(t *testing.T) {
 					"COALESCE(NULLIF(started_at, ''), created_at)",
 				)
 				if tc.want == "" {
-					if strings.Contains(where, "termination_status") {
-						t.Errorf(
-							"empty termination produced predicate: %s",
-							where,
-						)
-					}
+					assert.NotContains(t, where, "termination_status",
+						"empty termination produced predicate")
 					return
 				}
-				if !strings.Contains(where, tc.want) {
-					t.Errorf(
-						"buildWhere(%q) missing %q in: %s",
-						tc.termination, tc.want, where,
-					)
-				}
+				assert.Contains(t, where, tc.want,
+					"buildWhere(%q)", tc.termination)
 			})
 		}
 	})
@@ -1607,10 +1515,8 @@ func TestAnalyticsTerminationFilter(t *testing.T) {
 			resp, err := d.GetAnalyticsTopSessions(
 				ctx, f, "messages",
 			)
-			if err != nil {
-				t.Fatalf("GetAnalyticsTopSessions(%q): %v",
-					termination, err)
-			}
+			require.NoError(t, err,
+				"GetAnalyticsTopSessions(%q)", termination)
 			ids := make([]string, len(resp.Sessions))
 			for i, s := range resp.Sessions {
 				ids[i] = s.ID
@@ -1641,23 +1547,16 @@ func TestAnalyticsTerminationFilter(t *testing.T) {
 				ctx, f, "messages",
 			)
 			require.NoError(t, err, "GetAnalyticsTopSessions")
-			if len(resp.Sessions) == 0 {
-				t.Fatal("expected sessions, got 0")
-			}
+			require.NotEmpty(t, resp.Sessions,
+				"expected sessions, got 0")
 			for _, s := range resp.Sessions {
-				if s.TerminationStatus == nil {
-					t.Errorf(
-						"session %s TerminationStatus = nil, want clean",
-						s.ID,
-					)
+				if !assert.NotNil(t, s.TerminationStatus,
+					"session %s TerminationStatus want clean",
+					s.ID) {
 					continue
 				}
-				if *s.TerminationStatus != "clean" {
-					t.Errorf(
-						"session %s TerminationStatus = %q, want clean",
-						s.ID, *s.TerminationStatus,
-					)
-				}
+				assert.Equal(t, "clean", *s.TerminationStatus,
+					"session %s TerminationStatus", s.ID)
 			}
 		})
 
@@ -1868,7 +1767,8 @@ func TestAutonomyExcludesSystemMessages(t *testing.T) {
 			return // found the expected bucket
 		}
 	}
-	t.Errorf("expected autonomy bucket '1-2' with count 1, got %v",
+	assert.Failf(t, "missing autonomy bucket",
+		"expected autonomy bucket '1-2' with count 1, got %v",
 		resp.AutonomyDistribution)
 }
 
@@ -1992,9 +1892,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 	t.Run("AvgHealthScore", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
 		require.NoError(t, err, "GetAnalyticsSignals")
-		if resp.AvgHealthScore == nil {
-			t.Fatal("AvgHealthScore is nil")
-		}
+		require.NotNil(t, resp.AvgHealthScore, "AvgHealthScore")
 		// (85 + 45) / 2 = 65.0
 		assertEq(t, "AvgHealthScore",
 			*resp.AvgHealthScore, 65.0)
@@ -2123,10 +2021,8 @@ func TestLocalTime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ok := localTime(tt.ts, time.UTC)
-			if ok != tt.valid {
-				t.Errorf("localTime(%q) ok = %v, want %v",
-					tt.ts, ok, tt.valid)
-			}
+			assert.Equal(t, tt.valid, ok,
+				"localTime(%q) ok", tt.ts)
 		})
 	}
 }

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type seedStats struct {
@@ -111,9 +114,7 @@ func mustSummary(
 ) AnalyticsSummary {
 	t.Helper()
 	s, err := d.GetAnalyticsSummary(ctx, f)
-	if err != nil {
-		t.Fatalf("GetAnalyticsSummary: %v", err)
-	}
+	require.NoError(t, err, "GetAnalyticsSummary")
 	return s
 }
 
@@ -123,9 +124,7 @@ func mustActivity(
 ) ActivityResponse {
 	t.Helper()
 	r, err := d.GetAnalyticsActivity(ctx, f, gran)
-	if err != nil {
-		t.Fatalf("GetAnalyticsActivity: %v", err)
-	}
+	require.NoError(t, err, "GetAnalyticsActivity")
 	return r
 }
 
@@ -135,9 +134,7 @@ func mustHeatmap(
 ) HeatmapResponse {
 	t.Helper()
 	r, err := d.GetAnalyticsHeatmap(ctx, f, metric)
-	if err != nil {
-		t.Fatalf("GetAnalyticsHeatmap: %v", err)
-	}
+	require.NoError(t, err, "GetAnalyticsHeatmap")
 	return r
 }
 
@@ -147,9 +144,7 @@ func mustProjects(
 ) ProjectsAnalyticsResponse {
 	t.Helper()
 	r, err := d.GetAnalyticsProjects(ctx, f)
-	if err != nil {
-		t.Fatalf("GetAnalyticsProjects: %v", err)
-	}
+	require.NoError(t, err, "GetAnalyticsProjects")
 	return r
 }
 
@@ -159,58 +154,34 @@ func TestGetAnalyticsSummary(t *testing.T) {
 
 	t.Run("EmptyDB", func(t *testing.T) {
 		s := mustSummary(t, d, ctx, baseFilter())
-		if s.TotalSessions != 0 {
-			t.Errorf("TotalSessions = %d, want 0", s.TotalSessions)
-		}
+		assert.Equal(t, 0, s.TotalSessions, "TotalSessions")
 	})
 
 	stats := seedAnalyticsData(t, d)
 
 	t.Run("FullRange", func(t *testing.T) {
 		s := mustSummary(t, d, ctx, baseFilter())
-		if s.TotalSessions != stats.TotalSessions {
-			t.Errorf("TotalSessions = %d, want %d", s.TotalSessions, stats.TotalSessions)
-		}
-		if s.TotalMessages != stats.TotalMessages {
-			t.Errorf("TotalMessages = %d, want %d", s.TotalMessages, stats.TotalMessages)
-		}
-		if s.ActiveProjects != stats.ActiveProjects {
-			t.Errorf("ActiveProjects = %d, want %d", s.ActiveProjects, stats.ActiveProjects)
-		}
-		if s.ActiveDays != stats.ActiveDays {
-			t.Errorf("ActiveDays = %d, want %d", s.ActiveDays, stats.ActiveDays)
-		}
-		if s.MostActive != "project-beta" {
-			t.Errorf("MostActive = %q, want project-beta", s.MostActive)
-		}
+		assert.Equal(t, stats.TotalSessions, s.TotalSessions, "TotalSessions")
+		assert.Equal(t, stats.TotalMessages, s.TotalMessages, "TotalMessages")
+		assert.Equal(t, stats.ActiveProjects, s.ActiveProjects, "ActiveProjects")
+		assert.Equal(t, stats.ActiveDays, s.ActiveDays, "ActiveDays")
+		assert.Equal(t, "project-beta", s.MostActive, "MostActive")
 		// 2 projects, both in top 3 → concentration = 1.0
-		if s.Concentration != 1.0 {
-			t.Errorf("Concentration = %f, want 1.0", s.Concentration)
-		}
+		assert.Equal(t, 1.0, s.Concentration, "Concentration")
 
 		// Sorted message counts: [5, 10, 15, 20, 30]
-		if s.MedianMessages != 15 {
-			t.Errorf("MedianMessages = %d, want 15", s.MedianMessages)
-		}
+		assert.Equal(t, 15, s.MedianMessages, "MedianMessages")
 		// P90 index = int(5*0.9) = 4 → value 30
-		if s.P90Messages != 30 {
-			t.Errorf("P90Messages = %d, want 30", s.P90Messages)
-		}
+		assert.Equal(t, 30, s.P90Messages, "P90Messages")
 
 		if s.Agents["claude"] == nil {
 			t.Fatal("expected claude agent entry")
 		}
-		if s.Agents["claude"].Sessions != 4 {
-			t.Errorf("claude sessions = %d, want 4",
-				s.Agents["claude"].Sessions)
-		}
+		assert.Equal(t, 4, s.Agents["claude"].Sessions, "claude sessions")
 		if s.Agents["codex"] == nil {
 			t.Fatal("expected codex agent entry")
 		}
-		if s.Agents["codex"].Sessions != 1 {
-			t.Errorf("codex sessions = %d, want 1",
-				s.Agents["codex"].Sessions)
-		}
+		assert.Equal(t, 1, s.Agents["codex"].Sessions, "codex sessions")
 	})
 
 	t.Run("DateSubset", func(t *testing.T) {
@@ -220,25 +191,19 @@ func TestGetAnalyticsSummary(t *testing.T) {
 			Timezone: "UTC",
 		}
 		s := mustSummary(t, d, ctx, f)
-		if s.TotalSessions != 2 {
-			t.Errorf("TotalSessions = %d, want 2", s.TotalSessions)
-		}
+		assert.Equal(t, 2, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("MachineFilter", func(t *testing.T) {
 		f := baseFilter()
 		f.Machine = "nonexistent"
 		s := mustSummary(t, d, ctx, f)
-		if s.TotalSessions != 0 {
-			t.Errorf("TotalSessions = %d, want 0", s.TotalSessions)
-		}
+		assert.Equal(t, 0, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("EmptyDateRange", func(t *testing.T) {
 		s := mustSummary(t, d, ctx, emptyFilter())
-		if s.TotalSessions != 0 {
-			t.Errorf("TotalSessions = %d, want 0", s.TotalSessions)
-		}
+		assert.Equal(t, 0, s.TotalSessions, "TotalSessions")
 	})
 }
 
@@ -265,9 +230,7 @@ func TestAnalyticsFilterMachineMultiSelect(t *testing.T) {
 	f := baseFilter()
 	f.Machine = "laptop,server"
 	s := mustSummary(t, d, ctx, f)
-	if s.TotalSessions != 2 {
-		t.Fatalf("TotalSessions = %d, want 2", s.TotalSessions)
-	}
+	require.Equal(t, 2, s.TotalSessions, "TotalSessions")
 }
 
 func TestGetAnalyticsActivity(t *testing.T) {
@@ -277,36 +240,23 @@ func TestGetAnalyticsActivity(t *testing.T) {
 
 	t.Run("DayGranularity", func(t *testing.T) {
 		resp := mustActivity(t, d, ctx, baseFilter(), "day")
-		if resp.Granularity != "day" {
-			t.Errorf("Granularity = %q, want day", resp.Granularity)
-		}
-		if len(resp.Series) != stats.ActiveDays {
-			t.Fatalf("len(Series) = %d, want %d", len(resp.Series), stats.ActiveDays)
-		}
+		assert.Equal(t, "day", resp.Granularity, "Granularity")
+		require.Len(t, resp.Series, stats.ActiveDays, "len(Series)")
 		// Day 1: 2 sessions (a1, a2)
-		if resp.Series[0].Sessions != 2 {
-			t.Errorf("Day1 sessions = %d, want 2",
-				resp.Series[0].Sessions)
-		}
+		assert.Equal(t, 2, resp.Series[0].Sessions, "Day1 sessions")
 	})
 
 	t.Run("WeekGranularity", func(t *testing.T) {
 		resp := mustActivity(t, d, ctx, baseFilter(), "week")
 		// 2024-06-01 is Saturday, 2024-06-03 is Monday
 		// So we expect 2 weeks: week of May 27 and week of Jun 3
-		if len(resp.Series) != 2 {
-			t.Errorf("len(Series) = %d, want 2", len(resp.Series))
-		}
+		assert.Equal(t, 2, len(resp.Series), "len(Series)")
 	})
 
 	t.Run("MonthGranularity", func(t *testing.T) {
 		resp := mustActivity(t, d, ctx, baseFilter(), "month")
-		if len(resp.Series) != 1 {
-			t.Errorf("len(Series) = %d, want 1", len(resp.Series))
-		}
-		if resp.Series[0].Sessions != stats.TotalSessions {
-			t.Errorf("month sessions = %d, want %d", resp.Series[0].Sessions, stats.TotalSessions)
-		}
+		assert.Equal(t, 1, len(resp.Series), "len(Series)")
+		assert.Equal(t, stats.TotalSessions, resp.Series[0].Sessions, "month sessions")
 	})
 
 	t.Run("HasRoleCounts", func(t *testing.T) {
@@ -317,15 +267,9 @@ func TestGetAnalyticsActivity(t *testing.T) {
 			totalUser += e.UserMessages
 			totalAsst += e.AssistantMessages
 		}
-		if totalUser+totalAsst != stats.TotalMessages {
-			t.Errorf("total messages = %d, want %d", totalUser+totalAsst, stats.TotalMessages)
-		}
-		if totalUser != stats.TotalUserMessages {
-			t.Errorf("total user messages = %d, want %d", totalUser, stats.TotalUserMessages)
-		}
-		if totalAsst != stats.TotalAssistantMessages {
-			t.Errorf("total assistant messages = %d, want %d", totalAsst, stats.TotalAssistantMessages)
-		}
+		assert.Equal(t, stats.TotalMessages, totalUser+totalAsst, "total messages")
+		assert.Equal(t, stats.TotalUserMessages, totalUser, "total user messages")
+		assert.Equal(t, stats.TotalAssistantMessages, totalAsst, "total assistant messages")
 	})
 }
 
@@ -336,53 +280,34 @@ func TestGetAnalyticsHeatmap(t *testing.T) {
 
 	t.Run("MessageMetric", func(t *testing.T) {
 		resp := mustHeatmap(t, d, ctx, baseFilter(), "messages")
-		if resp.Metric != "messages" {
-			t.Errorf("Metric = %q, want messages", resp.Metric)
-		}
+		assert.Equal(t, "messages", resp.Metric, "Metric")
 		// 3 days in range: Jun 1, 2, 3
-		if len(resp.Entries) != stats.ActiveDays {
-			t.Fatalf("len(Entries) = %d, want %d", len(resp.Entries), stats.ActiveDays)
-		}
+		require.Len(t, resp.Entries, stats.ActiveDays, "len(Entries)")
 
 		totalMessages := 0
 		for _, e := range resp.Entries {
 			totalMessages += e.Value
 		}
-		if totalMessages != stats.TotalMessages {
-			t.Errorf("total messages across heatmap = %d, want %d", totalMessages, stats.TotalMessages)
-		}
+		assert.Equal(t, stats.TotalMessages, totalMessages, "total messages across heatmap")
 
 		// Jun 1: 10+20=30, Jun 2: 30+15=45, Jun 3: 5
-		if resp.Entries[0].Value != 30 {
-			t.Errorf("Jun1 value = %d, want 30", resp.Entries[0].Value)
-		}
-		if resp.Entries[1].Value != 45 {
-			t.Errorf("Jun2 value = %d, want 45", resp.Entries[1].Value)
-		}
-		if resp.Entries[2].Value != 5 {
-			t.Errorf("Jun3 value = %d, want 5", resp.Entries[2].Value)
-		}
+		assert.Equal(t, 30, resp.Entries[0].Value, "Jun1 value")
+		assert.Equal(t, 45, resp.Entries[1].Value, "Jun2 value")
+		assert.Equal(t, 5, resp.Entries[2].Value, "Jun3 value")
 	})
 
 	t.Run("SessionMetric", func(t *testing.T) {
 		resp := mustHeatmap(t, d, ctx, baseFilter(), "sessions")
-		if resp.Metric != "sessions" {
-			t.Errorf("Metric = %q, want sessions", resp.Metric)
-		}
+		assert.Equal(t, "sessions", resp.Metric, "Metric")
 
 		totalSessions := 0
 		for _, e := range resp.Entries {
 			totalSessions += e.Value
 		}
-		if totalSessions != stats.TotalSessions {
-			t.Errorf("total sessions across heatmap = %d, want %d", totalSessions, stats.TotalSessions)
-		}
+		assert.Equal(t, stats.TotalSessions, totalSessions, "total sessions across heatmap")
 
 		// Jun 1: 2, Jun 2: 2, Jun 3: 1
-		if resp.Entries[0].Value != 2 {
-			t.Errorf("Jun1 sessions = %d, want 2",
-				resp.Entries[0].Value)
-		}
+		assert.Equal(t, 2, resp.Entries[0].Value, "Jun1 sessions")
 	})
 
 	t.Run("LevelsAssigned", func(t *testing.T) {
@@ -422,9 +347,7 @@ func TestGetAnalyticsHeatmap(t *testing.T) {
 		f := emptyFilter()
 		f.To = "2020-01-03"
 		resp := mustHeatmap(t, d, ctx, f, "messages")
-		if len(resp.Entries) != 3 {
-			t.Fatalf("len(Entries) = %d, want 3", len(resp.Entries))
-		}
+		require.Len(t, resp.Entries, 3, "len(Entries) =")
 		for _, e := range resp.Entries {
 			if e.Value != 0 {
 				t.Errorf("date %s value = %d, want 0", e.Date, e.Value)
@@ -443,65 +366,38 @@ func TestGetAnalyticsProjects(t *testing.T) {
 
 	t.Run("FullRange", func(t *testing.T) {
 		resp := mustProjects(t, d, ctx, baseFilter())
-		if len(resp.Projects) != stats.ActiveProjects {
-			t.Fatalf("len(Projects) = %d, want %d", len(resp.Projects), stats.ActiveProjects)
-		}
+		require.Len(t, resp.Projects, stats.ActiveProjects, "len(Projects)")
 
 		totalMessages := 0
 		for _, p := range resp.Projects {
 			totalMessages += p.Messages
 		}
-		if totalMessages != stats.TotalMessages {
-			t.Errorf("total messages across projects = %d, want %d", totalMessages, stats.TotalMessages)
-		}
+		assert.Equal(t, stats.TotalMessages, totalMessages, "total messages across projects")
 
 		// Sorted by message count desc: beta (45) > alpha (35)
-		if resp.Projects[0].Name != "project-beta" {
-			t.Errorf("first project = %q, want project-beta",
-				resp.Projects[0].Name)
-		}
-		if resp.Projects[0].Messages != 45 {
-			t.Errorf("beta messages = %d, want 45",
-				resp.Projects[0].Messages)
-		}
-		if resp.Projects[1].Name != "project-alpha" {
-			t.Errorf("second project = %q, want project-alpha",
-				resp.Projects[1].Name)
-		}
-		if resp.Projects[1].Sessions != 3 {
-			t.Errorf("alpha sessions = %d, want 3",
-				resp.Projects[1].Sessions)
-		}
+		assert.Equal(t, "project-beta", resp.Projects[0].Name, "first project")
+		assert.Equal(t, 45, resp.Projects[0].Messages, "beta messages")
+		assert.Equal(t, "project-alpha", resp.Projects[1].Name, "second project")
+		assert.Equal(t, 3, resp.Projects[1].Sessions, "alpha sessions")
 	})
 
 	t.Run("AgentBreakdown", func(t *testing.T) {
 		resp := mustProjects(t, d, ctx, baseFilter())
 		alpha := resp.Projects[1]
-		if alpha.Agents["claude"] != 2 {
-			t.Errorf("alpha claude = %d, want 2",
-				alpha.Agents["claude"])
-		}
-		if alpha.Agents["codex"] != 1 {
-			t.Errorf("alpha codex = %d, want 1",
-				alpha.Agents["codex"])
-		}
+		assert.Equal(t, 2, alpha.Agents["claude"], "alpha claude")
+		assert.Equal(t, 1, alpha.Agents["codex"], "alpha codex")
 	})
 
 	t.Run("MedianMessages", func(t *testing.T) {
 		resp := mustProjects(t, d, ctx, baseFilter())
 		// Alpha counts sorted: [5, 10, 20], median = 10
 		alpha := resp.Projects[1]
-		if alpha.MedianMessages != 10 {
-			t.Errorf("alpha median = %d, want 10",
-				alpha.MedianMessages)
-		}
+		assert.Equal(t, 10, alpha.MedianMessages, "alpha median")
 	})
 
 	t.Run("EmptyRange", func(t *testing.T) {
 		resp := mustProjects(t, d, ctx, emptyFilter())
-		if len(resp.Projects) != 0 {
-			t.Errorf("len(Projects) = %d, want 0", len(resp.Projects))
-		}
+		assert.Equal(t, 0, len(resp.Projects), "len(Projects)")
 	})
 }
 
@@ -641,14 +537,8 @@ func TestAnalyticsTimezone(t *testing.T) {
 		}
 		resp := mustHeatmap(t, d, ctx, f, "messages")
 		// In UTC, this is Jun 1
-		if resp.Entries[0].Value != 10 {
-			t.Errorf("Jun1 UTC value = %d, want 10",
-				resp.Entries[0].Value)
-		}
-		if resp.Entries[1].Value != 0 {
-			t.Errorf("Jun2 UTC value = %d, want 0",
-				resp.Entries[1].Value)
-		}
+		assert.Equal(t, 10, resp.Entries[0].Value, "Jun1 UTC value")
+		assert.Equal(t, 0, resp.Entries[1].Value, "Jun2 UTC value")
 	})
 
 	t.Run("PlusFiveBucket", func(t *testing.T) {
@@ -659,14 +549,8 @@ func TestAnalyticsTimezone(t *testing.T) {
 		}
 		resp := mustHeatmap(t, d, ctx, f, "messages")
 		// In UTC+5, 23:00Z = 04:00 Jun 2
-		if resp.Entries[0].Value != 0 {
-			t.Errorf("Jun1 PKT value = %d, want 0",
-				resp.Entries[0].Value)
-		}
-		if resp.Entries[1].Value != 10 {
-			t.Errorf("Jun2 PKT value = %d, want 10",
-				resp.Entries[1].Value)
-		}
+		assert.Equal(t, 0, resp.Entries[0].Value, "Jun1 PKT value")
+		assert.Equal(t, 10, resp.Entries[1].Value, "Jun2 PKT value")
 	})
 }
 
@@ -822,13 +706,8 @@ func TestGetAnalyticsHourOfWeek(t *testing.T) {
 
 	t.Run("EmptyDB", func(t *testing.T) {
 		resp, err := d.GetAnalyticsHourOfWeek(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsHourOfWeek: %v", err)
-		}
-		if len(resp.Cells) != 168 {
-			t.Errorf("len(Cells) = %d, want 168",
-				len(resp.Cells))
-		}
+		require.NoError(t, err, "GetAnalyticsHourOfWeek")
+		assert.Len(t, resp.Cells, 168, "len(Cells)")
 		for _, c := range resp.Cells {
 			if c.Messages != 0 {
 				t.Errorf(
@@ -873,19 +752,13 @@ func TestGetAnalyticsHourOfWeek(t *testing.T) {
 
 	t.Run("UTCBucketing", func(t *testing.T) {
 		resp, err := d.GetAnalyticsHourOfWeek(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsHourOfWeek: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsHourOfWeek")
 		// Saturday = ISO day 5 (Mon=0)
 		// hour 9: 2 messages (user@09:00 + assistant@09:30)
 		satH9 := findHOWCell(resp.Cells, 5, 9)
-		if satH9 != 2 {
-			t.Errorf("Sat 09:xx = %d, want 2", satH9)
-		}
+		assert.Equal(t, 2, satH9, "Sat 09:xx")
 		satH23 := findHOWCell(resp.Cells, 5, 23)
-		if satH23 != 1 {
-			t.Errorf("Sat 23:00 = %d, want 1", satH23)
-		}
+		assert.Equal(t, 1, satH23, "Sat 23:00")
 	})
 
 	t.Run("TimezoneShift", func(t *testing.T) {
@@ -895,9 +768,7 @@ func TestGetAnalyticsHourOfWeek(t *testing.T) {
 			Timezone: "Asia/Karachi", // UTC+5
 		}
 		resp, err := d.GetAnalyticsHourOfWeek(ctx, f)
-		if err != nil {
-			t.Fatalf("GetAnalyticsHourOfWeek: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsHourOfWeek")
 		// 23:00 UTC Sat → 04:00 Sun in UTC+5
 		// Sunday = ISO day 6
 		sunH4 := findHOWCell(resp.Cells, 6, 4)
@@ -935,12 +806,8 @@ func TestGetAnalyticsSessionShape(t *testing.T) {
 		resp, err := d.GetAnalyticsSessionShape(
 			ctx, baseFilter(),
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsSessionShape: %v", err)
-		}
-		if resp.Count != 0 {
-			t.Errorf("Count = %d, want 0", resp.Count)
-		}
+		require.NoError(t, err, "GetAnalyticsSessionShape")
+		assert.Equal(t, 0, resp.Count, "Count")
 	})
 
 	// Session with 10 messages, 1h duration
@@ -989,27 +856,17 @@ func TestGetAnalyticsSessionShape(t *testing.T) {
 		resp, err := d.GetAnalyticsSessionShape(
 			ctx, baseFilter(),
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsSessionShape: %v", err)
-		}
-		if resp.Count != 2 {
-			t.Errorf("Count = %d, want 2", resp.Count)
-		}
+		require.NoError(t, err, "GetAnalyticsSessionShape")
+		assert.Equal(t, 2, resp.Count, "Count")
 
 		// Length: 10 → "6-15", 25 → "16-30"
 		lenMap := bucketMap(resp.LengthDistribution)
-		if lenMap["6-15"] != 1 {
-			t.Errorf("6-15 = %d, want 1", lenMap["6-15"])
-		}
-		if lenMap["16-30"] != 1 {
-			t.Errorf("16-30 = %d, want 1", lenMap["16-30"])
-		}
+		assert.Equal(t, 1, lenMap["6-15"], "6-15")
+		assert.Equal(t, 1, lenMap["16-30"], "16-30")
 
 		// Duration: only ss1 has both start/end (60m → "1-2h")
 		durMap := bucketMap(resp.DurationDistribution)
-		if durMap["1-2h"] != 1 {
-			t.Errorf("1-2h = %d, want 1", durMap["1-2h"])
-		}
+		assert.Equal(t, 1, durMap["1-2h"], "1-2h")
 		totalDur := 0
 		for _, b := range resp.DurationDistribution {
 			totalDur += b.Count
@@ -1026,30 +883,20 @@ func TestGetAnalyticsSessionShape(t *testing.T) {
 		resp, err := d.GetAnalyticsSessionShape(
 			ctx, baseFilter(),
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsSessionShape: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSessionShape")
 		// ss1: 5 user, 5 assistant w/ tool → ratio 5/5=1.0 → "1-2"
 		// ss2: 13 user, 0 tool → ratio 0/13=0 → "<0.5"
 		autoMap := bucketMap(resp.AutonomyDistribution)
-		if autoMap["1-2"] != 1 {
-			t.Errorf("1-2 = %d, want 1", autoMap["1-2"])
-		}
-		if autoMap["<0.5"] != 1 {
-			t.Errorf("<0.5 = %d, want 1", autoMap["<0.5"])
-		}
+		assert.Equal(t, 1, autoMap["1-2"], "1-2")
+		assert.Equal(t, 1, autoMap["<0.5"], "<0.5")
 	})
 
 	t.Run("EmptyRange", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSessionShape(
 			ctx, emptyFilter(),
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsSessionShape: %v", err)
-		}
-		if resp.Count != 0 {
-			t.Errorf("Count = %d, want 0", resp.Count)
-		}
+		require.NoError(t, err, "GetAnalyticsSessionShape")
+		assert.Equal(t, 0, resp.Count, "Count")
 	})
 }
 
@@ -1131,9 +978,7 @@ func TestGetAnalyticsVelocity_Metrics(t *testing.T) {
 
 	t.Run("EmptyDB", func(t *testing.T) {
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "len(ByAgent)", len(resp.ByAgent), 0)
 	})
 
@@ -1144,25 +989,19 @@ func TestGetAnalyticsVelocity_Metrics(t *testing.T) {
 
 	t.Run("TurnCycle", func(t *testing.T) {
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "TurnCycle P50", resp.Overall.TurnCycleSec.P50, 10.0)
 	})
 
 	t.Run("FirstResponse", func(t *testing.T) {
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "FirstResponse P50", resp.Overall.FirstResponseSec.P50, 10.0)
 	})
 
 	t.Run("Throughput", func(t *testing.T) {
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		// Active time: 5 gaps of 10s = 50s ≈ 0.833 min
 		// 6 msgs / 0.833 = ~7.2 msgs/min
 		if resp.Overall.MsgsPerActiveMin < 7.0 || resp.Overall.MsgsPerActiveMin > 7.5 {
@@ -1172,9 +1011,7 @@ func TestGetAnalyticsVelocity_Metrics(t *testing.T) {
 
 	t.Run("ByAgent", func(t *testing.T) {
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "len(ByAgent)", len(resp.ByAgent), 1)
 		assertEq(t, "ByAgent[0].Label", resp.ByAgent[0].Label, "claude")
 		assertEq(t, "ByAgent[0].Sessions", resp.ByAgent[0].Sessions, 1)
@@ -1182,9 +1019,7 @@ func TestGetAnalyticsVelocity_Metrics(t *testing.T) {
 
 	t.Run("ByComplexity", func(t *testing.T) {
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "len(ByComplexity)", len(resp.ByComplexity), 1)
 		assertEq(t, "ByComplexity[0].Label", resp.ByComplexity[0].Label, "1-15")
 	})
@@ -1199,9 +1034,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 			0, 45 * time.Minute,
 		})
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "TurnCycle P50", resp.Overall.TurnCycleSec.P50, 0.0)
 	})
 
@@ -1217,9 +1050,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 			Message{SessionID: "v3", Ordinal: 1, Role: "assistant", Content: "a", ContentLength: 1, Timestamp: ""},
 		)
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "TurnCycle P50", resp.Overall.TurnCycleSec.P50, 0.0)
 	})
 
@@ -1236,9 +1067,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 			Message{SessionID: "v4", Ordinal: 2, Role: "assistant", Content: "hello", ContentLength: 5, Timestamp: "2024-06-01T09:00:20Z"},
 		)
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "FirstResponse P50", resp.Overall.FirstResponseSec.P50, 10.0)
 	})
 
@@ -1255,9 +1084,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 			Message{SessionID: "v5", Ordinal: 2, Role: "assistant", Content: "answer", ContentLength: 6, Timestamp: "2024-06-01T09:00:20Z"},
 		)
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "FirstResponse P50", resp.Overall.FirstResponseSec.P50, 20.0)
 	})
 
@@ -1273,9 +1100,7 @@ func TestGetAnalyticsVelocity_EdgeCases(t *testing.T) {
 			Message{SessionID: "v6", Ordinal: 1, Role: "assistant", Content: "hi", ContentLength: 2, Timestamp: "2024-06-01T09:00:10Z"},
 		)
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "FirstResponse P50", resp.Overall.FirstResponseSec.P50, 0.0)
 	})
 }
@@ -1305,9 +1130,7 @@ func TestGetAnalyticsVelocity_ToolUsage(t *testing.T) {
 			},
 		)
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "ToolCallsPerActiveMin", resp.Overall.ToolCallsPerActiveMin, 6.0)
 	})
 
@@ -1343,9 +1166,7 @@ func TestGetAnalyticsVelocity_ToolUsage(t *testing.T) {
 			},
 		)
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		if len(resp.ByAgent) < 2 {
 			t.Fatalf("ByAgent has %d entries, want >= 2", len(resp.ByAgent))
 		}
@@ -1363,9 +1184,7 @@ func TestGetAnalyticsVelocity_ToolUsage(t *testing.T) {
 			0, 10 * time.Second,
 		})
 		resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsVelocity: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsVelocity")
 		assertEq(t, "ToolCallsPerActiveMin", resp.Overall.ToolCallsPerActiveMin, 0.0)
 	})
 }
@@ -1404,10 +1223,7 @@ func TestVelocityChunkedQuery(t *testing.T) {
 		t.Fatalf("GetAnalyticsVelocity with %d sessions: %v",
 			n, err)
 	}
-	if resp.ByComplexity[0].Sessions != n {
-		t.Errorf("sessions = %d, want %d",
-			resp.ByComplexity[0].Sessions, n)
-	}
+	assert.Equal(t, n, resp.ByComplexity[0].Sessions, "sessions")
 
 	// SessionShape must not fail either
 	shape, err := d.GetAnalyticsSessionShape(ctx, baseFilter())
@@ -1417,9 +1233,7 @@ func TestVelocityChunkedQuery(t *testing.T) {
 			n, err,
 		)
 	}
-	if shape.Count != n {
-		t.Errorf("Count = %d, want %d", shape.Count, n)
-	}
+	assert.Equal(t, n, shape.Count, "Count")
 }
 
 func TestPercentileFloat(t *testing.T) {
@@ -1452,17 +1266,9 @@ func TestGetAnalyticsTools(t *testing.T) {
 
 	t.Run("EmptyDB", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsTools: %v", err)
-		}
-		if resp.TotalCalls != 0 {
-			t.Errorf("TotalCalls = %d, want 0",
-				resp.TotalCalls)
-		}
-		if len(resp.ByCategory) != 0 {
-			t.Errorf("len(ByCategory) = %d, want 0",
-				len(resp.ByCategory))
-		}
+		require.NoError(t, err, "GetAnalyticsTools")
+		assert.Equal(t, 0, resp.TotalCalls, "TotalCalls")
+		assert.Len(t, resp.ByCategory, 0, "len(ByCategory)")
 	})
 
 	// Seed sessions with tool_calls.
@@ -1504,130 +1310,73 @@ func TestGetAnalyticsTools(t *testing.T) {
 
 	t.Run("TotalCalls", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsTools: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsTools")
 		// 2 Read + 1 Bash + 1 Edit + 1 Read + 1 Grep = 6
-		if resp.TotalCalls != 6 {
-			t.Errorf("TotalCalls = %d, want 6",
-				resp.TotalCalls)
-		}
+		assert.Equal(t, 6, resp.TotalCalls, "TotalCalls")
 	})
 
 	t.Run("ByCategory", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsTools: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsTools")
 		catMap := make(map[string]int)
 		for _, c := range resp.ByCategory {
 			catMap[c.Category] = c.Count
 		}
-		if catMap["Read"] != 3 {
-			t.Errorf("Read = %d, want 3", catMap["Read"])
-		}
-		if catMap["Bash"] != 1 {
-			t.Errorf("Bash = %d, want 1", catMap["Bash"])
-		}
-		if catMap["Edit"] != 1 {
-			t.Errorf("Edit = %d, want 1", catMap["Edit"])
-		}
-		if catMap["Grep"] != 1 {
-			t.Errorf("Grep = %d, want 1", catMap["Grep"])
-		}
+		assert.Equal(t, 3, catMap["Read"], "Read")
+		assert.Equal(t, 1, catMap["Bash"], "Bash")
+		assert.Equal(t, 1, catMap["Edit"], "Edit")
+		assert.Equal(t, 1, catMap["Grep"], "Grep")
 		// Sorted by count desc: Read first
-		if resp.ByCategory[0].Category != "Read" {
-			t.Errorf("first category = %q, want Read",
-				resp.ByCategory[0].Category)
-		}
+		assert.Equal(t, "Read", resp.ByCategory[0].Category, "first category")
 	})
 
 	t.Run("ByCategoryPct", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsTools: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsTools")
 		// Read: 3/6 = 50%
-		if resp.ByCategory[0].Pct != 50.0 {
-			t.Errorf("Read pct = %f, want 50.0",
-				resp.ByCategory[0].Pct)
-		}
+		assert.Equal(t, 50.0, resp.ByCategory[0].Pct, "Read pct")
 	})
 
 	t.Run("ByAgent", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsTools: %v", err)
-		}
-		if len(resp.ByAgent) != 2 {
-			t.Fatalf("len(ByAgent) = %d, want 2",
-				len(resp.ByAgent))
-		}
+		require.NoError(t, err, "GetAnalyticsTools")
+		require.Len(t, resp.ByAgent, 2, "len(ByAgent)")
 		// Alphabetical: claude, codex
-		if resp.ByAgent[0].Agent != "claude" {
-			t.Errorf("first agent = %q, want claude",
-				resp.ByAgent[0].Agent)
-		}
-		if resp.ByAgent[0].Total != 4 {
-			t.Errorf("claude total = %d, want 4",
-				resp.ByAgent[0].Total)
-		}
-		if resp.ByAgent[1].Agent != "codex" {
-			t.Errorf("second agent = %q, want codex",
-				resp.ByAgent[1].Agent)
-		}
-		if resp.ByAgent[1].Total != 2 {
-			t.Errorf("codex total = %d, want 2",
-				resp.ByAgent[1].Total)
-		}
+		assert.Equal(t, "claude", resp.ByAgent[0].Agent, "first agent")
+		assert.Equal(t, 4, resp.ByAgent[0].Total, "claude total")
+		assert.Equal(t, "codex", resp.ByAgent[1].Agent, "second agent")
+		assert.Equal(t, 2, resp.ByAgent[1].Total, "codex total")
 	})
 
 	t.Run("Trend", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsTools: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsTools")
 		// 2024-06-01 is Saturday, 2024-06-02 is Sunday.
 		// Both in same ISO week (May 27 week start).
 		// But 2024-06-03 is Monday, different week.
 		// So trend should have 1 entry (week of May 27).
-		if len(resp.Trend) != 1 {
-			t.Fatalf("len(Trend) = %d, want 1",
-				len(resp.Trend))
-		}
+		require.Len(t, resp.Trend, 1, "len(Trend)")
 		total := 0
 		for _, v := range resp.Trend[0].ByCat {
 			total += v
 		}
-		if total != 6 {
-			t.Errorf("week total = %d, want 6", total)
-		}
+		assert.Equal(t, 6, total, "week total")
 	})
 
 	t.Run("ProjectFilter", func(t *testing.T) {
 		f := baseFilter()
 		f.Project = "alpha"
 		resp, err := d.GetAnalyticsTools(ctx, f)
-		if err != nil {
-			t.Fatalf("GetAnalyticsTools: %v", err)
-		}
-		if resp.TotalCalls != 4 {
-			t.Errorf("TotalCalls = %d, want 4",
-				resp.TotalCalls)
-		}
+		require.NoError(t, err, "GetAnalyticsTools")
+		assert.Equal(t, 4, resp.TotalCalls, "TotalCalls")
 	})
 
 	t.Run("EmptyDateRange", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(
 			ctx, emptyFilter(),
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsTools: %v", err)
-		}
-		if resp.TotalCalls != 0 {
-			t.Errorf("TotalCalls = %d, want 0",
-				resp.TotalCalls)
-		}
+		require.NoError(t, err, "GetAnalyticsTools")
+		assert.Equal(t, 0, resp.TotalCalls, "TotalCalls")
 	})
 }
 
@@ -1666,14 +1415,8 @@ func TestActivityToolAndThinkingCounts(t *testing.T) {
 	}
 
 	entry := resp.Series[0]
-	if entry.ThinkingMessages != 1 {
-		t.Errorf("ThinkingMessages = %d, want 1",
-			entry.ThinkingMessages)
-	}
-	if entry.ToolCalls != 2 {
-		t.Errorf("ToolCalls = %d, want 2",
-			entry.ToolCalls)
-	}
+	assert.Equal(t, 1, entry.ThinkingMessages, "ThinkingMessages")
+	assert.Equal(t, 2, entry.ToolCalls, "ToolCalls")
 }
 
 func TestGetAnalyticsTopSessions(t *testing.T) {
@@ -1684,17 +1427,9 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "messages",
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsTopSessions: %v", err)
-		}
-		if len(resp.Sessions) != 0 {
-			t.Errorf("len(Sessions) = %d, want 0",
-				len(resp.Sessions))
-		}
-		if resp.Metric != "messages" {
-			t.Errorf("Metric = %q, want messages",
-				resp.Metric)
-		}
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		assert.Len(t, resp.Sessions, 0, "len(Sessions)")
+		assert.Equal(t, "messages", resp.Metric, "Metric")
 	})
 
 	stats := seedAnalyticsData(t, d)
@@ -1703,35 +1438,22 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "messages",
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsTopSessions: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsTopSessions")
 		if len(resp.Sessions) != stats.TotalSessions {
 			t.Fatalf("len(Sessions) = %d, want %d",
 				len(resp.Sessions), stats.TotalSessions)
 		}
 		// First should be the session with most messages (b1=30)
-		if resp.Sessions[0].MessageCount != 30 {
-			t.Errorf("top session messages = %d, want 30",
-				resp.Sessions[0].MessageCount)
-		}
-		if resp.Sessions[0].Project != "project-beta" {
-			t.Errorf("top session project = %q, want project-beta",
-				resp.Sessions[0].Project)
-		}
+		assert.Equal(t, 30, resp.Sessions[0].MessageCount, "top session messages")
+		assert.Equal(t, "project-beta", resp.Sessions[0].Project, "top session project")
 	})
 
 	t.Run("ByDuration", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "duration",
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsTopSessions: %v", err)
-		}
-		if resp.Metric != "duration" {
-			t.Errorf("Metric = %q, want duration",
-				resp.Metric)
-		}
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		assert.Equal(t, "duration", resp.Metric, "Metric")
 		// All seeded sessions have 1h duration except a1
 		// which runs from 09:00 to midyear
 		if len(resp.Sessions) == 0 {
@@ -1750,13 +1472,8 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "",
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsTopSessions: %v", err)
-		}
-		if resp.Metric != "messages" {
-			t.Errorf("Metric = %q, want messages",
-				resp.Metric)
-		}
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		assert.Equal(t, "messages", resp.Metric, "Metric")
 	})
 
 	t.Run("ProjectFilter", func(t *testing.T) {
@@ -1765,18 +1482,10 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, f, "messages",
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsTopSessions: %v", err)
-		}
-		if len(resp.Sessions) != 3 {
-			t.Errorf("len(Sessions) = %d, want 3",
-				len(resp.Sessions))
-		}
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		assert.Len(t, resp.Sessions, 3, "len(Sessions)")
 		for _, s := range resp.Sessions {
-			if s.Project != "project-alpha" {
-				t.Errorf("session project = %q, want project-alpha",
-					s.Project)
-			}
+			assert.Equal(t, "project-alpha", s.Project, "session project")
 		}
 	})
 
@@ -1784,13 +1493,8 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, emptyFilter(), "messages",
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsTopSessions: %v", err)
-		}
-		if len(resp.Sessions) != 0 {
-			t.Errorf("len(Sessions) = %d, want 0",
-				len(resp.Sessions))
-		}
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		assert.Len(t, resp.Sessions, 0, "len(Sessions)")
 	})
 }
 
@@ -1803,20 +1507,14 @@ func TestBuildWhereProjectFilter(t *testing.T) {
 		f := baseFilter()
 		f.Project = "project-alpha"
 		s := mustSummary(t, d, ctx, f)
-		if s.TotalSessions != 3 {
-			t.Errorf("TotalSessions = %d, want 3",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 3, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("SummaryWithNonexistentProject", func(t *testing.T) {
 		f := baseFilter()
 		f.Project = "nonexistent"
 		s := mustSummary(t, d, ctx, f)
-		if s.TotalSessions != 0 {
-			t.Errorf("TotalSessions = %d, want 0",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 0, s.TotalSessions, "TotalSessions")
 	})
 }
 
@@ -1942,9 +1640,7 @@ func TestAnalyticsTerminationFilter(t *testing.T) {
 			resp, err := d.GetAnalyticsTopSessions(
 				ctx, f, "messages",
 			)
-			if err != nil {
-				t.Fatalf("GetAnalyticsTopSessions: %v", err)
-			}
+			require.NoError(t, err, "GetAnalyticsTopSessions")
 			if len(resp.Sessions) == 0 {
 				t.Fatal("expected sessions, got 0")
 			}
@@ -1969,10 +1665,7 @@ func TestAnalyticsTerminationFilter(t *testing.T) {
 			f := baseFilter()
 			f.Termination = "unclean"
 			s := mustSummary(t, d, ctx, f)
-			if s.TotalSessions != 2 {
-				t.Errorf("TotalSessions = %d, want 2",
-					s.TotalSessions)
-			}
+			assert.Equal(t, 2, s.TotalSessions, "TotalSessions")
 		})
 	})
 }
@@ -2039,10 +1732,7 @@ func TestTimeFilter(t *testing.T) {
 		ff.Hour = &hour
 		s := mustSummary(t, d, ctx, ff)
 		// tf1 and tf3 have messages at hour 9
-		if s.TotalSessions != 2 {
-			t.Errorf("TotalSessions = %d, want 2",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 2, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("FilterByDow", func(t *testing.T) {
@@ -2051,10 +1741,7 @@ func TestTimeFilter(t *testing.T) {
 		ff.DayOfWeek = &dow
 		s := mustSummary(t, d, ctx, ff)
 		// tf1 and tf2 are on Saturday
-		if s.TotalSessions != 2 {
-			t.Errorf("TotalSessions = %d, want 2",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 2, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("FilterByDowAndHour", func(t *testing.T) {
@@ -2065,19 +1752,13 @@ func TestTimeFilter(t *testing.T) {
 		ff.Hour = &hour
 		s := mustSummary(t, d, ctx, ff)
 		// Only tf2 has messages on Saturday at hour 14
-		if s.TotalSessions != 1 {
-			t.Errorf("TotalSessions = %d, want 1",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 1, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("NoTimeFilter", func(t *testing.T) {
 		s := mustSummary(t, d, ctx, f)
 		// All 3 sessions
-		if s.TotalSessions != 3 {
-			t.Errorf("TotalSessions = %d, want 3",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 3, s.TotalSessions, "TotalSessions")
 	})
 }
 
@@ -2113,30 +1794,21 @@ func TestAnalyticsFilterAgentAndMinUserMessages(
 
 	t.Run("NoFilters", func(t *testing.T) {
 		s := mustSummary(t, d, ctx, f)
-		if s.TotalSessions != 3 {
-			t.Errorf("TotalSessions = %d, want 3",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 3, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("AgentOnly", func(t *testing.T) {
 		af := f
 		af.Agent = "claude"
 		s := mustSummary(t, d, ctx, af)
-		if s.TotalSessions != 2 {
-			t.Errorf("TotalSessions = %d, want 2",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 2, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("MinUserMessagesOnly", func(t *testing.T) {
 		af := f
 		af.MinUserMessages = 5
 		s := mustSummary(t, d, ctx, af)
-		if s.TotalSessions != 2 {
-			t.Errorf("TotalSessions = %d, want 2",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 2, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("AgentAndMinUserMessages", func(t *testing.T) {
@@ -2144,20 +1816,14 @@ func TestAnalyticsFilterAgentAndMinUserMessages(
 		af.Agent = "claude"
 		af.MinUserMessages = 2
 		s := mustSummary(t, d, ctx, af)
-		if s.TotalSessions != 1 {
-			t.Errorf("TotalSessions = %d, want 1",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 1, s.TotalSessions, "TotalSessions")
 	})
 
 	t.Run("ActiveSince", func(t *testing.T) {
 		af := f
 		af.ActiveSince = "2024-06-01T13:00:00Z"
 		s := mustSummary(t, d, ctx, af)
-		if s.TotalSessions != 1 {
-			t.Errorf("TotalSessions = %d, want 1",
-				s.TotalSessions)
-		}
+		assert.Equal(t, 1, s.TotalSessions, "TotalSessions")
 	})
 }
 
@@ -2238,22 +1904,12 @@ func TestActivityExcludesSystemUserMessages(t *testing.T) {
 	)
 	requireNoError(t, err, "GetAnalyticsActivity")
 
-	if len(resp.Series) != 1 {
-		t.Fatalf("got %d entries, want 1", len(resp.Series))
-	}
+	require.Len(t, resp.Series, 1, "len")
 	entry := resp.Series[0]
 	// 3 total messages but only 1 real user message
-	if entry.Messages != 3 {
-		t.Errorf("Messages = %d, want 3", entry.Messages)
-	}
-	if entry.UserMessages != 1 {
-		t.Errorf("UserMessages = %d, want 1 (system excluded)",
-			entry.UserMessages)
-	}
-	if entry.AssistantMessages != 1 {
-		t.Errorf("AssistantMessages = %d, want 1",
-			entry.AssistantMessages)
-	}
+	assert.Equal(t, 3, entry.Messages, "Messages")
+	assert.Equal(t, 1, entry.UserMessages, "UserMessages")
+	assert.Equal(t, 1, entry.AssistantMessages, "AssistantMessages")
 }
 
 func TestGetAnalyticsSignals(t *testing.T) {
@@ -2262,9 +1918,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("EmptyDB", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		assertEq(t, "ScoredSessions", resp.ScoredSessions, 0)
 		assertEq(t, "UnscoredSessions",
 			resp.UnscoredSessions, 0)
@@ -2322,9 +1976,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("ScoredVsUnscored", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		assertEq(t, "ScoredSessions", resp.ScoredSessions, 2)
 		assertEq(t, "UnscoredSessions",
 			resp.UnscoredSessions, 1)
@@ -2332,18 +1984,14 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("GradeDistribution", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		assertEq(t, "grade B", resp.GradeDistribution["B"], 1)
 		assertEq(t, "grade D", resp.GradeDistribution["D"], 1)
 	})
 
 	t.Run("AvgHealthScore", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		if resp.AvgHealthScore == nil {
 			t.Fatal("AvgHealthScore is nil")
 		}
@@ -2354,9 +2002,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("OutcomeDistribution", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		assertEq(t, "completed",
 			resp.OutcomeDistribution["completed"], 1)
 		assertEq(t, "errored",
@@ -2367,9 +2013,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("ToolHealth", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		// 2 + 5 + 0 = 7
 		assertEq(t, "TotalFailureSignals",
 			resp.ToolHealth.TotalFailureSignals, 7)
@@ -2386,9 +2030,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("ContextHealth", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		// sig1 (1) and sig3 (3) have compaction > 0
 		assertEq(t, "SessionsWithCompaction",
 			resp.ContextHealth.SessionsWithCompaction, 2)
@@ -2402,9 +2044,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("Trend", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		// 2 dates: 2024-06-01 (2 sessions), 2024-06-02 (1)
 		assertEq(t, "len(Trend)", len(resp.Trend), 2)
 		// Sorted by date
@@ -2424,9 +2064,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("ByAgent", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		// 2 agents: claude (2 sessions), codex (1)
 		assertEq(t, "len(ByAgent)", len(resp.ByAgent), 2)
 		// Alphabetical: claude first
@@ -2440,9 +2078,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 
 	t.Run("ByProject", func(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(ctx, baseFilter())
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		// 2 projects: alpha (2), beta (1)
 		// Sorted by session count desc
 		assertEq(t, "len(ByProject)", len(resp.ByProject), 2)
@@ -2456,9 +2092,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 		f := baseFilter()
 		f.Project = "beta"
 		resp, err := d.GetAnalyticsSignals(ctx, f)
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		assertEq(t, "ScoredSessions", resp.ScoredSessions, 0)
 		assertEq(t, "UnscoredSessions",
 			resp.UnscoredSessions, 1)
@@ -2469,9 +2103,7 @@ func TestGetAnalyticsSignals(t *testing.T) {
 		resp, err := d.GetAnalyticsSignals(
 			ctx, emptyFilter(),
 		)
-		if err != nil {
-			t.Fatalf("GetAnalyticsSignals: %v", err)
-		}
+		require.NoError(t, err, "GetAnalyticsSignals")
 		assertEq(t, "ScoredSessions", resp.ScoredSessions, 0)
 	})
 }

--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBackfillIsAutomatedBidirectional(t *testing.T) {
@@ -22,7 +25,7 @@ func TestBackfillIsAutomatedBidirectional(t *testing.T) {
 	_, err := d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'missed'",
 	)
-	requireNoError(t, err, "force missed to 0")
+	require.NoError(t, err, "force missed to 0")
 
 	// Seed a stale false positive: multi-turn session that was
 	// previously marked automated under old broad rules.
@@ -35,36 +38,32 @@ func TestBackfillIsAutomatedBidirectional(t *testing.T) {
 	_, err = d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 1 WHERE id = 'stale'",
 	)
-	requireNoError(t, err, "force stale to 1")
+	require.NoError(t, err, "force stale to 1")
 
 	// Clear the marker so the backfill will run.
 	_, err = d.getWriter().Exec(
 		"DELETE FROM stats WHERE key = ?",
 		ClassifierHashKey,
 	)
-	requireNoError(t, err, "clear marker")
+	require.NoError(t, err, "clear marker")
 
 	// Run backfill.
 	d.mu.Lock()
 	err = d.backfillIsAutomatedLocked(d.getWriter())
 	d.mu.Unlock()
-	requireNoError(t, err, "first backfill run")
+	require.NoError(t, err, "first backfill run")
 
 	ctx := context.Background()
 
 	// False negative should now be set.
 	missed, err := d.GetSession(ctx, "missed")
-	requireNoError(t, err, "get missed")
-	if !missed.IsAutomated {
-		t.Error("missed session should be automated after backfill")
-	}
+	require.NoError(t, err, "get missed")
+	assert.True(t, missed.IsAutomated, "missed session should be automated after backfill")
 
 	// Stale false positive should now be cleared.
 	stale, err := d.GetSession(ctx, "stale")
-	requireNoError(t, err, "get stale")
-	if stale.IsAutomated {
-		t.Error("stale session should not be automated after backfill")
-	}
+	require.NoError(t, err, "get stale")
+	assert.False(t, stale.IsAutomated, "stale session should not be automated after backfill")
 }
 
 func TestBackfillIsAutomatedMarkerDoesNotHideCorruption(t *testing.T) {
@@ -83,12 +82,12 @@ func TestBackfillIsAutomatedMarkerDoesNotHideCorruption(t *testing.T) {
 		"DELETE FROM stats WHERE key = ?",
 		ClassifierHashKey,
 	)
-	requireNoError(t, err, "clear marker")
+	require.NoError(t, err, "clear marker")
 
 	d.mu.Lock()
 	err = d.backfillIsAutomatedLocked(d.getWriter())
 	d.mu.Unlock()
-	requireNoError(t, err, "first run")
+	require.NoError(t, err, "first run")
 
 	// Manually corrupt the session. Matching classifier hashes
 	// cannot be trusted as a complete integrity marker because
@@ -96,21 +95,20 @@ func TestBackfillIsAutomatedMarkerDoesNotHideCorruption(t *testing.T) {
 	_, err = d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'review'",
 	)
-	requireNoError(t, err, "corrupt")
+	require.NoError(t, err, "corrupt")
 
 	// Second run should repair the inconsistent row even though
 	// the current hash is already stored.
 	d.mu.Lock()
 	err = d.backfillIsAutomatedLocked(d.getWriter())
 	d.mu.Unlock()
-	requireNoError(t, err, "second run")
+	require.NoError(t, err, "second run")
 
 	ctx := context.Background()
 	review, err := d.GetSession(ctx, "review")
-	requireNoError(t, err, "get review")
-	if !review.IsAutomated {
-		t.Error("second run should repair stale is_automated=0")
-	}
+	require.NoError(t, err, "get review")
+	assert.True(t, review.IsAutomated,
+		"second run should repair stale is_automated=0")
 }
 
 func TestBackfillIsAutomatedRepairsFalseNegativeWithMatchingHash(t *testing.T) {
@@ -127,30 +125,29 @@ func TestBackfillIsAutomatedRepairsFalseNegativeWithMatchingHash(t *testing.T) {
 	_, err := d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'stale-hash'",
 	)
-	requireNoError(t, err, "force stale is_automated=0")
+	require.NoError(t, err, "force stale is_automated=0")
 	_, err = d.getWriter().Exec(
 		`INSERT INTO stats (key, value) VALUES (?, ?)
 		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
 		ClassifierHashKey, ClassifierHash(),
 	)
-	requireNoError(t, err, "stamp current classifier hash")
+	require.NoError(t, err, "stamp current classifier hash")
 
 	d.mu.Lock()
 	err = d.backfillIsAutomatedLocked(d.getWriter())
 	d.mu.Unlock()
-	requireNoError(t, err, "backfill")
+	require.NoError(t, err, "backfill")
 
 	got, err := d.GetSession(ctx, "stale-hash")
-	requireNoError(t, err, "get stale-hash")
-	if !got.IsAutomated {
-		t.Fatal("matching classifier hash must not hide stale is_automated=0")
-	}
+	require.NoError(t, err, "get stale-hash")
+	assert.True(t, got.IsAutomated,
+		"matching classifier hash must not hide stale is_automated=0")
 }
 
 func TestOpenRepairsAutomatedFalseNegativeWithMatchingHash(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.db")
 	d, err := Open(path)
-	requireNoError(t, err, "open")
+	require.NoError(t, err, "open")
 
 	insertSession(t, d, "reload-stale", "proj", func(s *Session) {
 		fm := "You are combining multiple code review outputs into a single GitHub PR comment. Rules follow."
@@ -161,24 +158,23 @@ func TestOpenRepairsAutomatedFalseNegativeWithMatchingHash(t *testing.T) {
 	_, err = d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'reload-stale'",
 	)
-	requireNoError(t, err, "force stale is_automated=0")
+	require.NoError(t, err, "force stale is_automated=0")
 	_, err = d.getWriter().Exec(
 		`INSERT INTO stats (key, value) VALUES (?, ?)
 		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
 		ClassifierHashKey, ClassifierHash(),
 	)
-	requireNoError(t, err, "stamp current classifier hash")
-	requireNoError(t, d.Close(), "close")
+	require.NoError(t, err, "stamp current classifier hash")
+	require.NoError(t, d.Close(), "close")
 
 	reopened, err := Open(path)
-	requireNoError(t, err, "reopen")
+	require.NoError(t, err, "reopen")
 	defer reopened.Close()
 
 	got, err := reopened.GetSession(context.Background(), "reload-stale")
-	requireNoError(t, err, "get reload-stale")
-	if !got.IsAutomated {
-		t.Fatal("Open must repair stale is_automated=0 despite matching hash")
-	}
+	require.NoError(t, err, "get reload-stale")
+	assert.True(t, got.IsAutomated,
+		"Open must repair stale is_automated=0 despite matching hash")
 }
 
 // TestIncrementalUpdateReclassifiesOnPatternChange covers the
@@ -202,19 +198,18 @@ func TestIncrementalUpdateReclassifiesOnPatternChange(t *testing.T) {
 	_, err := d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'changelog-inc'",
 	)
-	requireNoError(t, err, "force stale is_automated=0")
+	require.NoError(t, err, "force stale is_automated=0")
 
 	// Incremental update with umc still <= 1.
 	err = d.UpdateSessionIncremental(
 		"changelog-inc", nil, 2, 1, 1024, 100, 0, 0, false, false,
 	)
-	requireNoError(t, err, "incremental update")
+	require.NoError(t, err, "incremental update")
 
 	got, err := d.GetSession(ctx, "changelog-inc")
-	requireNoError(t, err, "get changelog-inc")
-	if !got.IsAutomated {
-		t.Error("is_automated should be re-set after incremental update")
-	}
+	require.NoError(t, err, "get changelog-inc")
+	assert.True(t, got.IsAutomated,
+		"is_automated should be re-set after incremental update")
 }
 
 // TestIncrementalUpdateClearsWhenCountGrows covers the existing
@@ -232,22 +227,20 @@ func TestIncrementalUpdateClearsWhenCountGrows(t *testing.T) {
 	})
 	// After UpsertSession the row is correctly is_automated=1.
 	pre, err := d.GetSession(ctx, "grew-past-one")
-	requireNoError(t, err, "get pre")
-	if !pre.IsAutomated {
-		t.Fatalf("precondition: expected is_automated=1 after upsert")
-	}
+	require.NoError(t, err, "get pre")
+	require.True(t, pre.IsAutomated,
+		"precondition: expected is_automated=1 after upsert")
 
 	// Incremental update pushes umc > 1 — must clear.
 	err = d.UpdateSessionIncremental(
 		"grew-past-one", nil, 7, 3, 2048, 200, 0, 0, false, false,
 	)
-	requireNoError(t, err, "incremental update")
+	require.NoError(t, err, "incremental update")
 
 	got, err := d.GetSession(ctx, "grew-past-one")
-	requireNoError(t, err, "get grew-past-one")
-	if got.IsAutomated {
-		t.Error("is_automated should be cleared when umc grows > 1")
-	}
+	require.NoError(t, err, "get grew-past-one")
+	assert.False(t, got.IsAutomated,
+		"is_automated should be cleared when umc grows > 1")
 }
 
 // TestIncrementalUpdateLeavesNonMatching covers a non-automated
@@ -267,13 +260,12 @@ func TestIncrementalUpdateLeavesNonMatching(t *testing.T) {
 	err := d.UpdateSessionIncremental(
 		"normal-single", nil, 2, 1, 1024, 100, 0, 0, false, false,
 	)
-	requireNoError(t, err, "incremental update")
+	require.NoError(t, err, "incremental update")
 
 	got, err := d.GetSession(ctx, "normal-single")
-	requireNoError(t, err, "get normal-single")
-	if got.IsAutomated {
-		t.Error("is_automated should stay 0 for non-matching first_message")
-	}
+	require.NoError(t, err, "get normal-single")
+	assert.False(t, got.IsAutomated,
+		"is_automated should stay 0 for non-matching first_message")
 }
 
 // TestIncrementalUpdateClearsTerminationStatus verifies that an
@@ -295,26 +287,21 @@ func TestIncrementalUpdateClearsTerminationStatus(t *testing.T) {
 	})
 
 	pre, err := d.GetSession(ctx, "stale-term")
-	requireNoError(t, err, "get pre")
-	if pre.TerminationStatus == nil ||
-		*pre.TerminationStatus != "tool_call_pending" {
-		t.Fatalf("precondition: expected tool_call_pending, got %v",
-			pre.TerminationStatus)
-	}
+	require.NoError(t, err, "get pre")
+	require.NotNil(t, pre.TerminationStatus,
+		"precondition: expected tool_call_pending")
+	require.Equal(t, "tool_call_pending", *pre.TerminationStatus,
+		"precondition: expected tool_call_pending")
 
 	err = d.UpdateSessionIncremental(
 		"stale-term", nil, 4, 2, 2048, 200, 0, 0, false, false,
 	)
-	requireNoError(t, err, "incremental update")
+	require.NoError(t, err, "incremental update")
 
 	got, err := d.GetSession(ctx, "stale-term")
-	requireNoError(t, err, "get stale-term")
-	if got.TerminationStatus != nil {
-		t.Errorf(
-			"termination_status should be NULL after incremental update, got %q",
-			*got.TerminationStatus,
-		)
-	}
+	require.NoError(t, err, "get stale-term")
+	assert.Nil(t, got.TerminationStatus,
+		"termination_status should be NULL after incremental update")
 }
 
 func TestBackfillIsAutomatedBumpsLocalModifiedAt(t *testing.T) {
@@ -333,11 +320,11 @@ func TestBackfillIsAutomatedBumpsLocalModifiedAt(t *testing.T) {
 	_, err := d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'to-flip'",
 	)
-	requireNoError(t, err, "force to-flip to 0")
+	require.NoError(t, err, "force to-flip to 0")
 
 	// Snapshot local_modified_at before the backfill.
 	before, err := d.GetSessionFull(ctx, "to-flip")
-	requireNoError(t, err, "get to-flip before")
+	require.NoError(t, err, "get to-flip before")
 	var beforeLM string
 	if before.LocalModifiedAt != nil {
 		beforeLM = *before.LocalModifiedAt
@@ -353,27 +340,22 @@ func TestBackfillIsAutomatedBumpsLocalModifiedAt(t *testing.T) {
 		"DELETE FROM stats WHERE key = ?",
 		ClassifierHashKey,
 	)
-	requireNoError(t, err, "clear marker")
+	require.NoError(t, err, "clear marker")
 
 	d.mu.Lock()
 	err = d.backfillIsAutomatedLocked(d.getWriter())
 	d.mu.Unlock()
-	requireNoError(t, err, "backfill run")
+	require.NoError(t, err, "backfill run")
 
 	after, err := d.GetSessionFull(ctx, "to-flip")
-	requireNoError(t, err, "get to-flip after")
-	if !after.IsAutomated {
-		t.Fatal("to-flip should be automated after backfill")
-	}
-	if after.LocalModifiedAt == nil || *after.LocalModifiedAt == "" {
-		t.Fatal("local_modified_at not set after backfill")
-	}
-	if *after.LocalModifiedAt <= beforeLM {
-		t.Errorf(
-			"local_modified_at not bumped: before=%q after=%q",
-			beforeLM, *after.LocalModifiedAt,
-		)
-	}
+	require.NoError(t, err, "get to-flip after")
+	require.True(t, after.IsAutomated, "to-flip should be automated after backfill")
+	require.NotNil(t, after.LocalModifiedAt,
+		"local_modified_at not set after backfill")
+	require.NotEmpty(t, *after.LocalModifiedAt,
+		"local_modified_at not set after backfill")
+	assert.Greater(t, *after.LocalModifiedAt, beforeLM,
+		"local_modified_at not bumped")
 }
 
 // TestBackfillIsAutomatedRerunsOnHashChange verifies that a
@@ -395,10 +377,9 @@ func TestBackfillIsAutomatedRerunsOnHashChange(t *testing.T) {
 	})
 	ctx := context.Background()
 	pre, err := d.GetSession(ctx, "essay")
-	requireNoError(t, err, "get essay before")
-	if pre.IsAutomated {
-		t.Fatalf("precondition: essay should be is_automated=0")
-	}
+	require.NoError(t, err, "get essay before")
+	require.False(t, pre.IsAutomated,
+		"precondition: essay should be is_automated=0")
 
 	// Add a user prefix and re-run backfill. The new hash
 	// should not equal the stored hash, so the backfill
@@ -407,13 +388,12 @@ func TestBackfillIsAutomatedRerunsOnHashChange(t *testing.T) {
 	d.mu.Lock()
 	err = d.backfillIsAutomatedLocked(d.getWriter())
 	d.mu.Unlock()
-	requireNoError(t, err, "backfill after prefix add")
+	require.NoError(t, err, "backfill after prefix add")
 
 	got, err := d.GetSession(ctx, "essay")
-	requireNoError(t, err, "get essay after")
-	if !got.IsAutomated {
-		t.Error("essay should be is_automated=1 after user prefix added")
-	}
+	require.NoError(t, err, "get essay after")
+	assert.True(t, got.IsAutomated,
+		"essay should be is_automated=1 after user prefix added")
 
 	// A second backfill (no further classifier change) still
 	// repairs inconsistent rows; the stored hash is not a
@@ -421,16 +401,15 @@ func TestBackfillIsAutomatedRerunsOnHashChange(t *testing.T) {
 	_, err = d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'essay'",
 	)
-	requireNoError(t, err, "force back to 0")
+	require.NoError(t, err, "force back to 0")
 	d.mu.Lock()
 	err = d.backfillIsAutomatedLocked(d.getWriter())
 	d.mu.Unlock()
-	requireNoError(t, err, "second backfill")
+	require.NoError(t, err, "second backfill")
 	got, err = d.GetSession(ctx, "essay")
-	requireNoError(t, err, "get essay second")
-	if !got.IsAutomated {
-		t.Error("second backfill must repair stale flag when hash unchanged")
-	}
+	require.NoError(t, err, "get essay second")
+	assert.True(t, got.IsAutomated,
+		"second backfill must repair stale flag when hash unchanged")
 }
 
 // TestBackfillFixesOrphanCopyClassificationGap reproduces
@@ -456,7 +435,7 @@ func TestBackfillFixesOrphanCopyClassificationGap(t *testing.T) {
 	// 1. Old DB with a misclassified single-turn roborev session.
 	srcPath := filepath.Join(dir, "old.db")
 	srcDB, err := Open(srcPath)
-	requireNoError(t, err, "Open src")
+	require.NoError(t, err, "Open src")
 	insertSession(t, srcDB, "stale-orphan", "proj", func(s *Session) {
 		fm := "You are a code reviewer. Review the code."
 		s.FirstMessage = &fm
@@ -466,44 +445,37 @@ func TestBackfillFixesOrphanCopyClassificationGap(t *testing.T) {
 	_, err = srcDB.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'stale-orphan'",
 	)
-	requireNoError(t, err, "force orphan to is_automated=0")
+	require.NoError(t, err, "force orphan to is_automated=0")
 	srcDB.Close()
 
 	// 2. Fresh dst DB (Open's at-Open backfill ran on an empty
 	// table and stamped the current classifier hash).
 	dstPath := filepath.Join(dir, "new.db")
 	dstDB, err := Open(dstPath)
-	requireNoError(t, err, "Open dst")
+	require.NoError(t, err, "Open dst")
 	defer dstDB.Close()
 
 	// 3. Copy orphan rows (mirrors ResyncAll line ~954).
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
-	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphan, got %d", count)
-	}
+	require.NoError(t, err, "CopyOrphanedDataFrom")
+	require.Equal(t, 1, count, "expected 1 orphan")
 
 	ctx := context.Background()
 	got, err := dstDB.GetSession(ctx, "stale-orphan")
-	requireNoError(t, err, "get orphan after copy")
-	if got.IsAutomated {
-		t.Fatal("precondition: orphan row should carry stale is_automated=0")
-	}
+	require.NoError(t, err, "get orphan after copy")
+	require.False(t, got.IsAutomated,
+		"precondition: orphan row should carry stale is_automated=0")
 
 	// 4. A regular backfill must still repair the row even
 	// though the stored classifier hash already matches.
 	dstDB.mu.Lock()
 	err = dstDB.backfillIsAutomatedLocked(dstDB.getWriter())
 	dstDB.mu.Unlock()
-	requireNoError(t, err, "backfill")
+	require.NoError(t, err, "backfill")
 	got, err = dstDB.GetSession(ctx, "stale-orphan")
-	requireNoError(t, err, "get orphan after backfill")
-	if !got.IsAutomated {
-		t.Error(
-			"backfill must reclassify orphan-copied " +
-				"rows so they don't keep stale is_automated values",
-		)
-	}
+	require.NoError(t, err, "get orphan after backfill")
+	assert.True(t, got.IsAutomated,
+		"backfill must reclassify orphan-copied rows so they don't keep stale is_automated values")
 }
 
 // TestForceBackfillIsAutomatedRunsDespiteMatchingHash verifies
@@ -531,7 +503,7 @@ func TestForceBackfillIsAutomatedRunsDespiteMatchingHash(t *testing.T) {
 	_, err := d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 0 WHERE id = 'stuck'",
 	)
-	requireNoError(t, err, "force stuck to 0")
+	require.NoError(t, err, "force stuck to 0")
 
 	// Stamp the current hash so a *plain* backfill would
 	// short-circuit (mirrors ResyncAll's temp DB state after
@@ -541,17 +513,16 @@ func TestForceBackfillIsAutomatedRunsDespiteMatchingHash(t *testing.T) {
 		 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
 		ClassifierHashKey, ClassifierHash(),
 	)
-	requireNoError(t, err, "stamp current hash")
+	require.NoError(t, err, "stamp current hash")
 
 	// The force path must reclassify regardless of the stored
 	// hash and re-stamp the current classifier hash.
-	requireNoError(t, d.ForceBackfillIsAutomated(), "force backfill")
+	require.NoError(t, d.ForceBackfillIsAutomated(), "force backfill")
 
 	got, err := d.GetSession(ctx, "stuck")
-	requireNoError(t, err, "get stuck after force")
-	if !got.IsAutomated {
-		t.Error("ForceBackfillIsAutomated must flip stuck to is_automated=1")
-	}
+	require.NoError(t, err, "get stuck after force")
+	assert.True(t, got.IsAutomated,
+		"ForceBackfillIsAutomated must flip stuck to is_automated=1")
 
 	// And the hash must be re-stamped after the force run so
 	// subsequent Opens don't re-do the work.
@@ -560,11 +531,7 @@ func TestForceBackfillIsAutomatedRunsDespiteMatchingHash(t *testing.T) {
 		`SELECT value FROM stats WHERE key = ?`,
 		ClassifierHashKey,
 	).Scan(&stored)
-	requireNoError(t, err, "read hash after force")
-	if stored != ClassifierHash() {
-		t.Errorf(
-			"stored hash not refreshed after force: got %q want %q",
-			stored, ClassifierHash(),
-		)
-	}
+	require.NoError(t, err, "read hash after force")
+	assert.Equal(t, ClassifierHash(), stored,
+		"stored hash not refreshed after force")
 }

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -1,9 +1,10 @@
 package db
 
 import (
-	"slices"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsAutomatedSession(t *testing.T) {
@@ -297,12 +298,8 @@ func TestIsAutomatedSession(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := IsAutomatedSession(tt.firstMessage)
-			if got != tt.want {
-				t.Errorf(
-					"IsAutomatedSession(%q) = %v, want %v",
-					tt.firstMessage, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got,
+				"IsAutomatedSession(%q)", tt.firstMessage)
 		})
 	}
 }
@@ -336,10 +333,8 @@ func TestNormalizeUserPrefixes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := normalizeUserPrefixes(tt.in)
-			if !slices.Equal(got, tt.want) {
-				t.Errorf("normalizeUserPrefixes(%q) = %q, want %q",
-					tt.in, got, tt.want)
-			}
+			assert.Equal(t, tt.want, got,
+				"normalizeUserPrefixes(%q)", tt.in)
 		})
 	}
 }
@@ -380,10 +375,8 @@ func TestIsAutomatedSessionWithUserPrefixes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := IsAutomatedSession(tt.firstMessage)
-			if got != tt.want {
-				t.Errorf("IsAutomatedSession(%q) = %v, want %v",
-					tt.firstMessage, got, tt.want)
-			}
+			assert.Equal(t, tt.want, got,
+				"IsAutomatedSession(%q)", tt.firstMessage)
 		})
 	}
 }
@@ -396,7 +389,9 @@ func TestUserAutomationPrefixesReturnsCopy(t *testing.T) {
 		got[0] = "MUTATED"
 	}
 	again := UserAutomationPrefixes()
-	if len(again) == 0 || again[0] != "alpha" {
-		t.Errorf("singleton mutated through returned slice: got %q", again)
+	assert.NotEmpty(t, again, "singleton mutated through returned slice")
+	if len(again) > 0 {
+		assert.Equal(t, "alpha", again[0],
+			"singleton mutated through returned slice")
 	}
 }

--- a/internal/db/classifier_hash_test.go
+++ b/internal/db/classifier_hash_test.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClassifierHashStable(t *testing.T) {
@@ -9,9 +11,7 @@ func TestClassifierHashStable(t *testing.T) {
 	SetUserAutomationPrefixes([]string{"foo", "bar"})
 	a := ClassifierHash()
 	b := ClassifierHash()
-	if a != b {
-		t.Errorf("hash unstable: %s vs %s", a, b)
-	}
+	assert.Equal(t, a, b, "hash unstable")
 }
 
 func TestClassifierHashChangesWithUserPrefixes(t *testing.T) {
@@ -20,9 +20,8 @@ func TestClassifierHashChangesWithUserPrefixes(t *testing.T) {
 	base := ClassifierHash()
 	SetUserAutomationPrefixes([]string{"You are analyzing an essay"})
 	with := ClassifierHash()
-	if base == with {
-		t.Errorf("hash did not change when user prefixes changed: %s", base)
-	}
+	assert.NotEqual(t, base, with,
+		"hash did not change when user prefixes changed")
 }
 
 func TestClassifierHashOrderIndependent(t *testing.T) {
@@ -31,9 +30,7 @@ func TestClassifierHashOrderIndependent(t *testing.T) {
 	a := ClassifierHash()
 	SetUserAutomationPrefixes([]string{"gamma", "alpha", "beta"})
 	b := ClassifierHash()
-	if a != b {
-		t.Errorf("hash not order-independent: %s vs %s", a, b)
-	}
+	assert.Equal(t, a, b, "hash not order-independent")
 }
 
 // TestClassifierHashTagSeparation guards against the case
@@ -45,12 +42,8 @@ func TestClassifierHashTagSeparation(t *testing.T) {
 	got := ClassifierHash()
 	SetUserAutomationPrefixes(nil)
 	bareBuiltins := ClassifierHash()
-	if got == bareBuiltins {
-		t.Errorf(
-			"user prefix 'Warmup' collided with built-in exact-match 'Warmup': %s",
-			got,
-		)
-	}
+	assert.NotEqual(t, got, bareBuiltins,
+		"user prefix 'Warmup' collided with built-in exact-match 'Warmup'")
 }
 
 // TestClassifierHashCurrentAlgoVersion is a forced-bump
@@ -61,14 +54,8 @@ func TestClassifierHashTagSeparation(t *testing.T) {
 // the test must be updated to match. The check exists to
 // surface accidental version-constant edits during review.
 func TestClassifierHashCurrentAlgoVersion(t *testing.T) {
-	if classifierAlgorithmVersion != 2 {
-		t.Fatalf(
-			"classifierAlgorithmVersion changed to %d; "+
-				"update this test and confirm matching "+
-				"semantics actually changed (not just "+
-				"pattern edits, which the hash already "+
-				"detects)",
-			classifierAlgorithmVersion,
-		)
-	}
+	assert.Equal(t, 2, classifierAlgorithmVersion,
+		"classifierAlgorithmVersion changed; update this test and confirm "+
+			"matching semantics actually changed (not just pattern edits, "+
+			"which the hash already detects)")
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -351,9 +351,8 @@ func TestOpenCreatesFile(t *testing.T) {
 	requireNoError(t, err, "Open")
 	defer d.Close()
 
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("db file not created: %v", err)
-	}
+	_, err = os.Stat(path)
+	require.NoError(t, err, "db file not created")
 }
 
 func TestOpenDataVersionBump_PreservesData(t *testing.T) {
@@ -398,9 +397,8 @@ func TestOpenDataVersionBump_PreservesData(t *testing.T) {
 	defer d2.Close()
 
 	// NeedsResync should be true.
-	if !d2.NeedsResync() {
-		t.Fatal("expected NeedsResync()=true after version bump")
-	}
+	require.True(t, d2.NeedsResync(),
+		"expected NeedsResync()=true after version bump")
 
 	// Session and messages must still exist.
 	page, err := d2.ListSessions(
@@ -423,10 +421,7 @@ func TestOpenDataVersionBump_PreservesData(t *testing.T) {
 		"PRAGMA user_version",
 	).Scan(&ver)
 	requireNoError(t, err, "read version")
-	if ver != 0 {
-		t.Fatalf("expected user_version=0 (stale), got %d",
-			ver)
-	}
+	require.Equal(t, 0, ver, "expected user_version=0 (stale)")
 }
 
 func TestOpenDataVersionBump_SurvivesRestart(t *testing.T) {
@@ -448,9 +443,8 @@ func TestOpenDataVersionBump_SurvivesRestart(t *testing.T) {
 	// First reopen: detects stale, does NOT bump version.
 	d2, err := Open(path)
 	requireNoError(t, err, "reopen 1")
-	if !d2.NeedsResync() {
-		t.Fatal("first reopen: expected NeedsResync=true")
-	}
+	require.True(t, d2.NeedsResync(),
+		"first reopen: expected NeedsResync=true")
 	d2.Close() // simulate process exit without resync
 
 	// Second reopen: must still detect stale because the
@@ -458,9 +452,8 @@ func TestOpenDataVersionBump_SurvivesRestart(t *testing.T) {
 	d3, err := Open(path)
 	requireNoError(t, err, "reopen 2")
 	defer d3.Close()
-	if !d3.NeedsResync() {
-		t.Fatal("second reopen: expected NeedsResync=true")
-	}
+	require.True(t, d3.NeedsResync(),
+		"second reopen: expected NeedsResync=true")
 }
 
 func TestMigration_ResultContentColumn(t *testing.T) {
@@ -514,9 +507,8 @@ func TestMigration_ResultContentColumn(t *testing.T) {
 			` WHERE name = 'result_content'`,
 	).Scan(&count)
 	requireNoError(t, err, "verify column removed")
-	if count != 0 {
-		t.Fatal("expected result_content column to be absent")
-	}
+	require.Equal(t, 0, count,
+		"expected result_content column to be absent")
 	var tcCount int
 	err = conn.QueryRow(
 		`SELECT count(*) FROM tool_calls`,
@@ -536,9 +528,8 @@ func TestMigration_ResultContentColumn(t *testing.T) {
 			` WHERE name = 'result_content'`,
 	).Scan(&count)
 	requireNoError(t, err, "verify column added")
-	if count != 1 {
-		t.Fatal("expected result_content column after migration")
-	}
+	require.Equal(t, 1, count,
+		"expected result_content column after migration")
 
 	// Verify tool_calls row preserved with fields intact.
 	msgs, err := d2.GetMessages(
@@ -578,9 +569,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		 WHERE type = 'table' AND name = 'tool_result_events'`,
 	).Scan(&count)
 	requireNoError(t, err, "verify table removed")
-	if count != 0 {
-		t.Fatal("expected tool_result_events table to be absent")
-	}
+	require.Equal(t, 0, count,
+		"expected tool_result_events table to be absent")
 	requireNoError(t, conn.Close(), "close legacy db")
 
 	d2, err := Open(path)
@@ -588,18 +578,16 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 	defer d2.Close()
 
 	requireSessionExists(t, d2, "s1")
-	if !d2.NeedsResync() {
-		t.Fatal("expected NeedsResync()=true after data version bump")
-	}
+	require.True(t, d2.NeedsResync(),
+		"expected NeedsResync()=true after data version bump")
 
 	err = d2.getReader().QueryRow(
 		`SELECT count(*) FROM sqlite_master
 		 WHERE type = 'table' AND name = 'tool_result_events'`,
 	).Scan(&count)
 	requireNoError(t, err, "verify table exists")
-	if count != 1 {
-		t.Fatal("expected tool_result_events table after reopen")
-	}
+	require.Equal(t, 1, count,
+		"expected tool_result_events table after reopen")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
@@ -682,9 +670,8 @@ func TestOpenPreservesDataAtCurrentVersion(t *testing.T) {
 	requireNoError(t, err, "reopen")
 	defer d2.Close()
 
-	if d2.NeedsResync() {
-		t.Fatal("expected NeedsResync()=false at current version")
-	}
+	require.False(t, d2.NeedsResync(),
+		"expected NeedsResync()=false at current version")
 
 	page, err := d2.ListSessions(
 		context.Background(),
@@ -721,15 +708,10 @@ func TestOpenDoesNotDowngradeUserVersion(t *testing.T) {
 	).Scan(&version)
 	requireNoError(t, err, "read version")
 
-	if version != futureVersion {
-		t.Errorf(
-			"user_version = %d, want %d (should not downgrade)",
-			version, futureVersion,
-		)
-	}
-	if d2.NeedsResync() {
-		t.Error("NeedsResync should be false for higher version")
-	}
+	assert.Equal(t, futureVersion, version,
+		"user_version should not downgrade")
+	assert.False(t, d2.NeedsResync(),
+		"NeedsResync should be false for higher version")
 }
 
 func TestOpenProbeErrorPropagates(t *testing.T) {
@@ -743,9 +725,7 @@ func TestOpenProbeErrorPropagates(t *testing.T) {
 	t.Run("StatPermissionError", func(t *testing.T) {
 		dir := t.TempDir()
 		sub := filepath.Join(dir, "sub")
-		if err := os.Mkdir(sub, 0o755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Mkdir(sub, 0o755))
 		path := filepath.Join(sub, "test.db")
 
 		d, err := Open(path)
@@ -760,18 +740,11 @@ func TestOpenProbeErrorPropagates(t *testing.T) {
 		t.Cleanup(func() { os.Chmod(sub, 0o755) })
 
 		_, err = Open(path)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-		if !errors.Is(err, fs.ErrPermission) {
-			t.Errorf("expected permission error, got: %v",
-				err)
-		}
-		if !strings.Contains(err.Error(),
-			"checking schema") {
-			t.Errorf("expected 'checking schema' wrapper: %v",
-				err)
-		}
+		require.Error(t, err, "expected error")
+		assert.ErrorIs(t, err, fs.ErrPermission,
+			"expected permission error")
+		assert.Contains(t, err.Error(), "checking schema",
+			"expected 'checking schema' wrapper")
 	})
 
 	t.Run("ProbeReadError", func(t *testing.T) {
@@ -790,15 +763,11 @@ func TestOpenProbeErrorPropagates(t *testing.T) {
 		t.Cleanup(func() { os.Chmod(path, 0o644) })
 
 		_, err = Open(path)
-		if err == nil {
-			t.Fatal("expected error")
-		}
-		if !strings.Contains(err.Error(),
-			"checking schema") &&
-			!strings.Contains(err.Error(),
-				"probing schema") {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.Error(t, err, "expected error")
+		assert.True(t,
+			strings.Contains(err.Error(), "checking schema") ||
+				strings.Contains(err.Error(), "probing schema"),
+			"unexpected error: %v", err)
 	})
 }
 
@@ -843,11 +812,9 @@ func TestSessionParentSessionID(t *testing.T) {
 		})
 
 		got := requireSessionExists(t, d, "child-1")
-		if got.ParentSessionID == nil ||
-			*got.ParentSessionID != "parent-uuid" {
-			t.Errorf("parent_session_id = %v, want %q",
-				got.ParentSessionID, "parent-uuid")
-		}
+		require.NotNil(t, got.ParentSessionID, "parent_session_id")
+		assert.Equal(t, "parent-uuid", *got.ParentSessionID,
+			"parent_session_id")
 	})
 
 	t.Run("WithoutParent", func(t *testing.T) {
@@ -869,10 +836,10 @@ func TestSessionParentSessionID(t *testing.T) {
 		for _, s := range page.Sessions {
 			if s.ID == "child-1" {
 				found = true
-				if s.ParentSessionID == nil ||
-					*s.ParentSessionID != "parent-uuid" {
-					t.Errorf("parent_session_id = %v, want %q",
-						s.ParentSessionID, "parent-uuid")
+				if assert.NotNil(t, s.ParentSessionID,
+					"parent_session_id want %q", "parent-uuid") {
+					assert.Equal(t, "parent-uuid",
+						*s.ParentSessionID, "parent_session_id")
 				}
 			}
 		}
@@ -884,15 +851,11 @@ func TestSessionParentSessionID(t *testing.T) {
 			context.Background(), "child-1",
 		)
 		requireNoError(t, err, "GetSessionFull")
-		if got == nil {
-			t.Fatal("session not found")
-			return
-		}
-		if got.ParentSessionID == nil ||
-			*got.ParentSessionID != "parent-uuid" {
-			t.Errorf("parent_session_id = %v, want %q",
-				got.ParentSessionID, "parent-uuid")
-		}
+		require.NotNil(t, got, "session not found")
+		require.NotNil(t, got.ParentSessionID,
+			"parent_session_id want %q", "parent-uuid")
+		assert.Equal(t, "parent-uuid", *got.ParentSessionID,
+			"parent_session_id")
 	})
 }
 
@@ -952,10 +915,8 @@ func TestGetChildSessions(t *testing.T) {
 		// Ordered by started_at ascending.
 		wantIDs := []string{"child-sub", "child-cont", "child-fork"}
 		for i, want := range wantIDs {
-			if children[i].ID != want {
-				t.Errorf("children[%d].ID = %q, want %q",
-					i, children[i].ID, want)
-			}
+			assert.Equal(t, want, children[i].ID,
+				"children[%d].ID", i)
 		}
 	})
 
@@ -1004,9 +965,7 @@ func TestListSessions(t *testing.T) {
 	)
 	requireNoError(t, err, "ListSessions limit")
 	assert.Len(t, page.Sessions, 2, "len")
-	if page.NextCursor == "" {
-		t.Error("expected next cursor")
-	}
+	assert.NotEmpty(t, page.NextCursor, "expected next cursor")
 
 	requireCount(t, d, SessionFilter{
 		Limit:  10,
@@ -1042,14 +1001,11 @@ func TestListSessionsPaginationNoDuplicates(t *testing.T) {
 			context.Background(),
 			SessionFilter{Limit: 2, Cursor: cursor},
 		)
-		if err != nil {
-			t.Fatalf("ListSessions page %d: %v", pages, err)
-		}
+		require.NoError(t, err, "ListSessions page %d", pages)
 		for _, s := range page.Sessions {
-			if seen[s.ID] {
-				t.Errorf("duplicate session %s on page %d",
-					s.ID, pages)
-			}
+			assert.False(t, seen[s.ID],
+				"duplicate session %s on page %d",
+				s.ID, pages)
 			seen[s.ID] = true
 		}
 		pages++
@@ -1091,9 +1047,7 @@ func TestListSessionsPaginationEmptyTimestamps(t *testing.T) {
 		)
 		require.NoError(t, err, "ListSessions")
 		for _, s := range page.Sessions {
-			if seen[s.ID] {
-				t.Errorf("duplicate session %s", s.ID)
-			}
+			assert.False(t, seen[s.ID], "duplicate session %s", s.ID)
 			seen[s.ID] = true
 		}
 		if page.NextCursor == "" {
@@ -1150,15 +1104,12 @@ func TestListSessionsMachineMultiSelect(t *testing.T) {
 	for _, session := range page.Sessions {
 		got[session.Machine] = true
 	}
-	if !got["local"] {
-		t.Fatalf("machines = %v, want local included", got)
-	}
-	if !got["other"] {
-		t.Fatalf("machines = %v, want other included", got)
-	}
-	if got["remote"] {
-		t.Fatalf("machines = %v, want remote excluded", got)
-	}
+	require.True(t, got["local"],
+		"machines = %v, want local included", got)
+	require.True(t, got["other"],
+		"machines = %v, want other included", got)
+	require.False(t, got["remote"],
+		"machines = %v, want remote excluded", got)
 }
 
 func TestMessageCRUD(t *testing.T) {
@@ -1178,12 +1129,8 @@ func TestMessageCRUD(t *testing.T) {
 	got, err := d.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
 	require.Len(t, got, 4, "len")
-	if got[0].Content != "Hello" {
-		t.Errorf("first message = %q", got[0].Content)
-	}
-	if got[3].Timestamp != "" {
-		t.Errorf("expected empty timestamp, got %q", got[3].Timestamp)
-	}
+	assert.Equal(t, "Hello", got[0].Content, "first message")
+	assert.Empty(t, got[3].Timestamp, "expected empty timestamp")
 
 	// Paginated
 	got, err = d.GetMessages(context.Background(), "s1", 1, 2, true)
@@ -1205,12 +1152,10 @@ func TestReplaceSessionMessages(t *testing.T) {
 
 	insertMessages(t, d, userMsg("s1", 0, "old"))
 
-	if err := d.ReplaceSessionMessages("s1", []Message{
+	require.NoError(t, d.ReplaceSessionMessages("s1", []Message{
 		userMsg("s1", 0, "new1"),
 		asstMsg("s1", 1, "new2"),
-	}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	}), "ReplaceSessionMessages")
 
 	got, _ := d.GetAllMessages(context.Background(), "s1")
 	require.Len(t, got, 2, "len")
@@ -1237,12 +1182,10 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 
 	// Pin ordinal-0 with a note and ordinal-2 with no note.
 	note := "important"
-	if _, err := d.PinMessage("s1", msgs[0].ID, &note); err != nil {
-		t.Fatalf("PinMessage ord=0: %v", err)
-	}
-	if _, err := d.PinMessage("s1", msgs[2].ID, nil); err != nil {
-		t.Fatalf("PinMessage ord=2: %v", err)
-	}
+	_, err = d.PinMessage("s1", msgs[0].ID, &note)
+	require.NoError(t, err, "PinMessage ord=0")
+	_, err = d.PinMessage("s1", msgs[2].ID, nil)
+	require.NoError(t, err, "PinMessage ord=2")
 
 	// Record created_at before replace so we can verify it is preserved.
 	prePins, err := d.ListPinnedMessages(ctx, "s1", "")
@@ -1254,13 +1197,11 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 
 	// Full replace (simulates a resync of an OpenCode or
 	// explicitly re-synced session).
-	if err := d.ReplaceSessionMessages("s1", []Message{
+	require.NoError(t, d.ReplaceSessionMessages("s1", []Message{
 		userMsg("s1", 0, "msg0-updated"),
 		asstMsg("s1", 1, "msg1-updated"),
 		userMsg("s1", 2, "msg2-updated"),
-	}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	}), "ReplaceSessionMessages")
 
 	newMsgs, err := d.GetAllMessages(ctx, "s1")
 	require.NoError(t, err, "GetAllMessages after replace")
@@ -1279,8 +1220,8 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 	p0, ok := byOrdinal[0]
 	require.True(t, ok, "pin for ordinal 0 missing after replace")
 	assert.Equal(t, newMsgs[0].ID, p0.MessageID, "ord=0 pin message_id")
-	if p0.Note == nil || *p0.Note != note {
-		t.Errorf("ord=0 pin note = %v, want %q", p0.Note, note)
+	if assert.NotNil(t, p0.Note, "ord=0 pin note want %q", note) {
+		assert.Equal(t, note, *p0.Note, "ord=0 pin note")
 	}
 	assert.Equal(t, pinCreatedAt[0], p0.CreatedAt, "ord=0 pin created_at")
 
@@ -1309,17 +1250,14 @@ func TestReplaceSessionMessagesDropsPinsForRemovedOrdinals(t *testing.T) {
 	require.NoError(t, err, "GetAllMessages")
 	// Pin both messages.
 	for _, m := range msgs {
-		if _, err := d.PinMessage("s1", m.ID, nil); err != nil {
-			t.Fatalf("PinMessage: %v", err)
-		}
+		_, err := d.PinMessage("s1", m.ID, nil)
+		require.NoError(t, err, "PinMessage")
 	}
 
 	// Replace with only ordinal-0 (ordinal-1 is gone).
-	if err := d.ReplaceSessionMessages("s1", []Message{
+	require.NoError(t, d.ReplaceSessionMessages("s1", []Message{
 		userMsg("s1", 0, "msg0-updated"),
-	}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	}), "ReplaceSessionMessages")
 
 	pins, err := d.ListPinnedMessages(ctx, "s1", "")
 	require.NoError(t, err, "ListPinnedMessages")
@@ -1354,14 +1292,13 @@ func TestReplaceSessionMessagesPinSourceUUIDFollowsRow(t *testing.T) {
 	msgs, err := d.GetAllMessages(ctx, "s1")
 	require.NoError(t, err, "GetAllMessages")
 	note := "important"
-	if _, err := d.PinMessage("s1", msgs[1].ID, &note); err != nil {
-		t.Fatalf("PinMessage: %v", err)
-	}
+	_, err = d.PinMessage("s1", msgs[1].ID, &note)
+	require.NoError(t, err, "PinMessage")
 
 	// Rewrite: a compact-boundary row is now ordinal 1, pushing
 	// "answer" to ordinal 2. The pin should follow uuid-answer
 	// to its new ordinal, not stay on ordinal 1 (the boundary).
-	if err := d.ReplaceSessionMessages("s1", []Message{
+	require.NoError(t, d.ReplaceSessionMessages("s1", []Message{
 		{
 			SessionID: "s1", Ordinal: 0, Role: "user",
 			Content: "first", Timestamp: tsZero,
@@ -1378,21 +1315,15 @@ func TestReplaceSessionMessagesPinSourceUUIDFollowsRow(t *testing.T) {
 			Content: "answer", Timestamp: tsZero,
 			SourceUUID: "uuid-answer",
 		},
-	}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	}), "ReplaceSessionMessages")
 
 	pins, err := d.ListPinnedMessages(ctx, "s1", "")
 	require.NoError(t, err, "ListPinnedMessages")
 	require.Len(t, pins, 1, "want 1 pin")
-	if pins[0].Ordinal != 2 {
-		t.Errorf(
-			"pin ordinal = %d, want 2 (followed source_uuid)",
-			pins[0].Ordinal,
-		)
-	}
-	if pins[0].Note == nil || *pins[0].Note != note {
-		t.Errorf("pin note = %v, want %q", pins[0].Note, note)
+	assert.Equal(t, 2, pins[0].Ordinal,
+		"pin ordinal want 2 (followed source_uuid)")
+	if assert.NotNil(t, pins[0].Note, "pin note want %q", note) {
+		assert.Equal(t, note, *pins[0].Note, "pin note")
 	}
 }
 
@@ -1412,17 +1343,14 @@ func TestReplaceSessionMessagesPinFallsBackToOrdinal(t *testing.T) {
 
 	msgs, err := d.GetAllMessages(ctx, "s1")
 	require.NoError(t, err, "GetAllMessages")
-	if _, err := d.PinMessage("s1", msgs[1].ID, nil); err != nil {
-		t.Fatalf("PinMessage: %v", err)
-	}
+	_, err = d.PinMessage("s1", msgs[1].ID, nil)
+	require.NoError(t, err, "PinMessage")
 
 	// Replace with the same ordinals (and still no source_uuid).
-	if err := d.ReplaceSessionMessages("s1", []Message{
+	require.NoError(t, d.ReplaceSessionMessages("s1", []Message{
 		userMsg("s1", 0, "msg0-v2"),
 		asstMsg("s1", 1, "msg1-v2"),
-	}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	}), "ReplaceSessionMessages")
 
 	pins, err := d.ListPinnedMessages(ctx, "s1", "")
 	require.NoError(t, err, "ListPinnedMessages")
@@ -1482,10 +1410,10 @@ func TestLinkSubagentSessionsOverridesContinuation(t *testing.T) {
 	sess, err := d.GetSession(context.Background(), "child")
 	requireNoError(t, err, "GetSession")
 	assert.Equal(t, "subagent", sess.RelationshipType, "relationship_type")
-	if sess.ParentSessionID == nil ||
-		*sess.ParentSessionID != "parent" {
-		t.Errorf("parent_session_id = %v, want 'parent'",
-			sess.ParentSessionID)
+	if assert.NotNil(t, sess.ParentSessionID,
+		"parent_session_id want 'parent'") {
+		assert.Equal(t, "parent", *sess.ParentSessionID,
+			"parent_session_id")
 	}
 }
 
@@ -1505,12 +1433,10 @@ func TestIsSystemPersisted(t *testing.T) {
 	msgs, err := d.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
 	require.Len(t, msgs, 2, "len")
-	if msgs[0].IsSystem {
-		t.Error("msgs[0].IsSystem = true, want false")
-	}
-	if !msgs[1].IsSystem {
-		t.Error("msgs[1].IsSystem = false, want true")
-	}
+	assert.False(t, msgs[0].IsSystem,
+		"msgs[0].IsSystem want false")
+	assert.True(t, msgs[1].IsSystem,
+		"msgs[1].IsSystem want true")
 }
 
 func TestSearchBasic(t *testing.T) {
@@ -1533,9 +1459,7 @@ func TestSearchBasic(t *testing.T) {
 	})
 	requireNoError(t, err, "Search")
 	require.Len(t, page.Results, 1, "len")
-	if page.Results[0].SessionID != "s1" {
-		t.Errorf("session_id = %q", page.Results[0].SessionID)
-	}
+	assert.Equal(t, "s1", page.Results[0].SessionID, "session_id")
 }
 
 func TestSearchExcludesSystemMessages(t *testing.T) {
@@ -1614,12 +1538,7 @@ func TestStats(t *testing.T) {
 	// Empty DB returns nil EarliestSession
 	stats, err := d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats empty")
-	if stats.EarliestSession != nil {
-		t.Errorf(
-			"earliest_session = %v, want nil",
-			*stats.EarliestSession,
-		)
-	}
+	assert.Nil(t, stats.EarliestSession, "earliest_session")
 
 	early := "2024-01-15T09:00:00Z"
 	late := "2024-06-01T14:00:00Z"
@@ -1642,15 +1561,10 @@ func TestStats(t *testing.T) {
 	assert.Equal(t, 2, stats.MessageCount, "message_count")
 	assert.Equal(t, 2, stats.ProjectCount, "project_count")
 	assert.Equal(t, 2, stats.MachineCount, "machine_count")
-	if stats.EarliestSession == nil {
-		t.Fatal("earliest_session is nil, want non-nil")
-	}
-	if *stats.EarliestSession != early {
-		t.Errorf(
-			"earliest_session = %q, want %q",
-			*stats.EarliestSession, early,
-		)
-	}
+	require.NotNil(t, stats.EarliestSession,
+		"earliest_session is nil, want non-nil")
+	assert.Equal(t, early, *stats.EarliestSession,
+		"earliest_session")
 }
 
 func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
@@ -1663,12 +1577,9 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 
 	stats, err := d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats null started_at")
-	if stats.EarliestSession == nil {
-		t.Fatal(
-			"earliest_session nil when started_at is NULL;" +
-				" should fall back to created_at",
-		)
-	}
+	require.NotNil(t, stats.EarliestSession,
+		"earliest_session nil when started_at is NULL; "+
+			"should fall back to created_at")
 
 	// Session with empty-string started_at — NULLIF should
 	// treat it the same as NULL.
@@ -1679,18 +1590,12 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 
 	stats, err = d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats empty started_at")
-	if stats.EarliestSession == nil {
-		t.Fatal(
-			"earliest_session nil when started_at is '';" +
-				" should fall back to created_at",
-		)
-	}
-	if *stats.EarliestSession == "" {
-		t.Fatal(
-			"earliest_session is empty string;" +
-				" NULLIF should have converted '' to NULL",
-		)
-	}
+	require.NotNil(t, stats.EarliestSession,
+		"earliest_session nil when started_at is ''; "+
+			"should fall back to created_at")
+	require.NotEmpty(t, *stats.EarliestSession,
+		"earliest_session is empty string; "+
+			"NULLIF should have converted '' to NULL")
 
 	// Add a session with an explicit started_at that is
 	// older than the auto-generated created_at.
@@ -1702,15 +1607,8 @@ func TestStatsEarliestFallsBackToCreatedAt(t *testing.T) {
 
 	stats, err = d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats with old session")
-	if stats.EarliestSession == nil {
-		t.Fatal("earliest_session nil")
-	}
-	if *stats.EarliestSession != old {
-		t.Errorf(
-			"earliest_session = %q, want %q",
-			*stats.EarliestSession, old,
-		)
-	}
+	require.NotNil(t, stats.EarliestSession, "earliest_session nil")
+	assert.Equal(t, old, *stats.EarliestSession, "earliest_session")
 }
 
 func TestGetProjects(t *testing.T) {
@@ -1725,9 +1623,10 @@ func TestGetProjects(t *testing.T) {
 	projects, err := d.GetProjects(context.Background(), false, false)
 	requireNoError(t, err, "GetProjects")
 	require.Len(t, projects, 2, "len")
-	if projects[0].Name != "alpha" || projects[0].SessionCount != 2 {
-		t.Errorf("alpha: %+v", projects[0])
-	}
+	assert.Equal(t, "alpha", projects[0].Name,
+		"alpha: %+v", projects[0])
+	assert.Equal(t, 2, projects[0].SessionCount,
+		"alpha: %+v", projects[0])
 }
 
 // setupPruneData inserts the standard sessions used by the prune
@@ -1864,9 +1763,7 @@ func TestFindPruneCandidates(t *testing.T) {
 		})
 		requireNoError(t, err, "FindPruneCandidates")
 		require.Len(t, got, 1, "len")
-		if got[0].ID != "s1" {
-			t.Errorf("got ID %q, want s1", got[0].ID)
-		}
+		assert.Equal(t, "s1", got[0].ID, "got ID")
 	})
 
 	// File metadata returned correctly.
@@ -1881,12 +1778,10 @@ func TestFindPruneCandidates(t *testing.T) {
 		})
 		requireNoError(t, err, "FindPruneCandidates")
 		require.Len(t, got, 1, "len")
-		if got[0].FilePath == nil || *got[0].FilePath != fp {
-			t.Errorf("file_path = %v, want %q", got[0].FilePath, fp)
-		}
-		if got[0].FileSize == nil || *got[0].FileSize != 4096 {
-			t.Errorf("file_size = %v, want 4096", got[0].FileSize)
-		}
+		require.NotNil(t, got[0].FilePath, "file_path")
+		assert.Equal(t, fp, *got[0].FilePath, "file_path")
+		require.NotNil(t, got[0].FileSize, "file_size")
+		assert.Equal(t, int64(4096), *got[0].FileSize, "file_size")
 	})
 }
 
@@ -1926,15 +1821,10 @@ func TestFindPruneCandidatesExcludesParents(t *testing.T) {
 	ids := collectIDs(got)
 
 	// Parent should be excluded; child and standalone eligible.
-	if len(got) != 2 {
-		t.Fatalf("got %d candidates %v, want 2",
-			len(got), ids)
-	}
+	require.Len(t, got, 2, "got candidates %v", ids)
 	for _, s := range got {
-		if s.ID == "parent1" {
-			t.Errorf("parent1 should be excluded, "+
-				"got candidates: %v", ids)
-		}
+		assert.NotEqual(t, "parent1", s.ID,
+			"parent1 should be excluded, got candidates: %v", ids)
 	}
 }
 
@@ -1999,13 +1889,11 @@ func TestFindPruneCandidatesLikeEscaping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := d.FindPruneCandidates(tt.filter)
 			requireNoError(t, err, "FindPruneCandidates")
-			if len(got) != tt.wantN {
-				t.Fatalf("got %v, want %d results",
-					collectIDs(got), tt.wantN)
-			}
-			if tt.wantOnly != "" && got[0].ID != tt.wantOnly {
-				t.Errorf("got %v, want [%s]",
-					collectIDs(got), tt.wantOnly)
+			require.Len(t, got, tt.wantN,
+				"got %v", collectIDs(got))
+			if tt.wantOnly != "" {
+				assert.Equal(t, tt.wantOnly, got[0].ID,
+					"got %v", collectIDs(got))
 			}
 		})
 	}
@@ -2064,9 +1952,7 @@ func TestFindPruneCandidatesMaxMessagesSentinel(t *testing.T) {
 	got, err := d.FindPruneCandidates(PruneFilter{MaxMessages: new(0)})
 	requireNoError(t, err, "FindPruneCandidates MaxMessages=0")
 	require.Len(t, got, 1, "MaxMessages 0:")
-	if got[0].ID != "m1" {
-		t.Errorf("MaxMessages 0: got %q, want m1", got[0].ID)
-	}
+	assert.Equal(t, "m1", got[0].ID, "MaxMessages 0")
 }
 
 func TestFindPruneCandidatesIgnoresSystemMessages(t *testing.T) {
@@ -2089,9 +1975,7 @@ func TestFindPruneCandidatesIgnoresSystemMessages(t *testing.T) {
 	)
 	requireNoError(t, err, "FindPruneCandidates")
 	require.Len(t, got, 1, "expected 1 result")
-	if got[0].ID != "zen1" {
-		t.Errorf("got %q, want zen1", got[0].ID)
-	}
+	assert.Equal(t, "zen1", got[0].ID, "got")
 
 	// MaxMessages=0 should NOT include zen1 (it has 1 real
 	// user message).
@@ -2132,15 +2016,12 @@ func TestDeleteSessions(t *testing.T) {
 	assert.Equal(t, 1, stats.MessageCount, "message_count")
 
 	// Deleted sessions must be excluded.
-	if !d.IsSessionExcluded("s1") {
-		t.Error("s1 should be excluded after DeleteSessions")
-	}
-	if !d.IsSessionExcluded("s3") {
-		t.Error("s3 should be excluded after DeleteSessions")
-	}
-	if d.IsSessionExcluded("s2") {
-		t.Error("s2 should not be excluded (not deleted)")
-	}
+	assert.True(t, d.IsSessionExcluded("s1"),
+		"s1 should be excluded after DeleteSessions")
+	assert.True(t, d.IsSessionExcluded("s3"),
+		"s3 should be excluded after DeleteSessions")
+	assert.False(t, d.IsSessionExcluded("s2"),
+		"s2 should not be excluded (not deleted)")
 
 	deleted, err = d.DeleteSessions(nil)
 	requireNoError(t, err, "DeleteSessions empty")
@@ -2152,9 +2033,8 @@ func TestDeleteSessionNonExistentNoGhostExclusion(t *testing.T) {
 
 	// Deleting a non-existent ID should not create an exclusion.
 	requireNoError(t, d.DeleteSession("bogus"), "DeleteSession bogus")
-	if d.IsSessionExcluded("bogus") {
-		t.Error("bogus should not be excluded (no row deleted)")
-	}
+	assert.False(t, d.IsSessionExcluded("bogus"),
+		"bogus should not be excluded (no row deleted)")
 }
 
 func TestDeleteSessionsMixedBatchNoGhostExclusion(t *testing.T) {
@@ -2165,12 +2045,10 @@ func TestDeleteSessionsMixedBatchNoGhostExclusion(t *testing.T) {
 	deleted, err := d.DeleteSessions([]string{"real", "bogus"})
 	requireNoError(t, err, "DeleteSessions mixed")
 	assert.Equal(t, 1, deleted, "deleted")
-	if !d.IsSessionExcluded("real") {
-		t.Error("real should be excluded after bulk delete")
-	}
-	if d.IsSessionExcluded("bogus") {
-		t.Error("bogus should not be excluded (never existed)")
-	}
+	assert.True(t, d.IsSessionExcluded("real"),
+		"real should be excluded after bulk delete")
+	assert.False(t, d.IsSessionExcluded("bogus"),
+		"bogus should not be excluded (never existed)")
 }
 
 func TestSessionFileInfo(t *testing.T) {
@@ -2209,10 +2087,7 @@ func TestGetSessionFull(t *testing.T) {
 
 		got, err := d.GetSessionFull(ctx, "full-1")
 		requireNoError(t, err, "GetSessionFull")
-		if got == nil {
-			t.Fatal("expected non-nil session")
-			return
-		}
+		require.NotNil(t, got, "expected non-nil session")
 		want := &Session{
 			ID:                "full-1",
 			Project:           "proj",
@@ -2242,10 +2117,7 @@ func TestGetSessionFull(t *testing.T) {
 
 		got, err := d.GetSessionFull(ctx, "full-2")
 		requireNoError(t, err, "GetSessionFull")
-		if got == nil {
-			t.Fatal("expected non-nil session")
-			return
-		}
+		require.NotNil(t, got, "expected non-nil session")
 		want := &Session{
 			ID:                "full-2",
 			Project:           "proj",
@@ -2264,9 +2136,7 @@ func TestGetSessionFull(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		got, err := d.GetSessionFull(ctx, "nonexistent")
 		requireNoError(t, err, "GetSessionFull")
-		if got != nil {
-			t.Errorf("expected nil session, got %+v", got)
-		}
+		assert.Nil(t, got, "expected nil session")
 	})
 }
 
@@ -2275,12 +2145,8 @@ func TestCursorEncodeDecode(t *testing.T) {
 	encoded := d.EncodeCursor(tsZero, "session-1")
 	cur, err := d.DecodeCursor(encoded)
 	requireNoError(t, err, "DecodeCursor")
-	if cur.EndedAt != tsZero {
-		t.Errorf("EndedAt = %q", cur.EndedAt)
-	}
-	if cur.ID != "session-1" {
-		t.Errorf("ID = %q", cur.ID)
-	}
+	assert.Equal(t, tsZero, cur.EndedAt, "EndedAt")
+	assert.Equal(t, "session-1", cur.ID, "ID")
 
 	encodedWithTotal := d.EncodeCursor(
 		tsZero,
@@ -2319,12 +2185,9 @@ func TestCursorTampering(t *testing.T) {
 
 	// 4. Decode should fail signature check
 	_, err = d.DecodeCursor(tamperedCursor)
-	if err == nil {
-		t.Fatal("expected error for tampered cursor, got nil")
-	}
-	if !strings.Contains(err.Error(), "signature mismatch") {
-		t.Errorf("expected signature mismatch error, got: %v", err)
-	}
+	require.Error(t, err, "expected error for tampered cursor, got nil")
+	assert.Contains(t, err.Error(), "signature mismatch",
+		"expected signature mismatch error")
 }
 
 func TestLegacyCursor(t *testing.T) {
@@ -2381,12 +2244,9 @@ func TestCursorSecretConcurrency(t *testing.T) {
 					// Decode may fail if secret rotated
 					// between encode and decode; that's OK.
 					_, err := d.DecodeCursor(encoded)
-					if err != nil &&
-						!errors.Is(err, ErrInvalidCursor) {
-						t.Errorf(
-							"unexpected DecodeCursor error: %v",
-							err,
-						)
+					if err != nil {
+						assert.ErrorIs(t, err, ErrInvalidCursor,
+							"unexpected DecodeCursor error")
 					}
 				}
 			}
@@ -2410,12 +2270,8 @@ func TestSetCursorSecretDefensiveCopy(t *testing.T) {
 	}
 
 	_, err := d.DecodeCursor(encoded)
-	if err != nil {
-		t.Fatalf(
-			"DecodeCursor failed after caller mutated secret: %v",
-			err,
-		)
-	}
+	require.NoError(t, err,
+		"DecodeCursor failed after caller mutated secret")
 }
 
 func TestDeleteSession(t *testing.T) {
@@ -2487,21 +2343,22 @@ func TestMigrationRace(t *testing.T) {
 	for range 2 {
 		if err := <-errCh; err != nil {
 			msg := err.Error()
-			if strings.Contains(msg, "database is locked") ||
+			isLockErr := strings.Contains(msg, "database is locked") ||
 				strings.Contains(msg, "database schema is locked") ||
 				strings.Contains(msg, "SQLITE_BUSY") ||
-				strings.Contains(msg, "SQLITE_LOCKED") {
+				strings.Contains(msg, "SQLITE_LOCKED")
+			if isLockErr {
 				t.Logf("concurrent Open lock contention: %v", err)
 			} else {
-				t.Errorf("unexpected concurrent Open error: %v", err)
+				assert.Fail(t,
+					"unexpected concurrent Open error",
+					err.Error())
 			}
 		} else {
 			successes++
 		}
 	}
-	if successes == 0 {
-		t.Fatal("both concurrent Opens failed")
-	}
+	require.NotEqual(t, 0, successes, "both concurrent Opens failed")
 
 	// 3. Verify schema is intact
 	dbCheck, err := Open(path)
@@ -2511,9 +2368,7 @@ func TestMigrationRace(t *testing.T) {
 	_, err = dbCheck.getWriter().Exec(
 		"SELECT parent_session_id FROM sessions LIMIT 1",
 	)
-	if err != nil {
-		t.Errorf("parent_session_id column missing: %v", err)
-	}
+	assert.NoError(t, err, "parent_session_id column missing")
 }
 
 func TestToolCallsInsertedWithMessages(t *testing.T) {
@@ -2544,27 +2399,26 @@ func TestToolCallsInsertedWithMessages(t *testing.T) {
 	var calls []ToolCall
 	for rows.Next() {
 		var tc ToolCall
-		if err := rows.Scan(
+		require.NoError(t, rows.Scan(
 			&tc.MessageID, &tc.SessionID,
 			&tc.ToolName, &tc.Category,
-		); err != nil {
-			t.Fatalf("scan tool_call: %v", err)
-		}
+		), "scan tool_call")
 		calls = append(calls, tc)
 	}
 	err = rows.Err()
 	require.NoError(t, err, "rows.Err")
 
 	require.Len(t, calls, 2, "len")
-	if calls[0].ToolName != "Read" || calls[0].Category != "Read" {
-		t.Errorf("calls[0] = %+v", calls[0])
-	}
-	if calls[1].ToolName != "Grep" || calls[1].Category != "Grep" {
-		t.Errorf("calls[1] = %+v", calls[1])
-	}
-	if calls[0].MessageID == 0 {
-		t.Error("message_id should be non-zero")
-	}
+	assert.Equal(t, "Read", calls[0].ToolName,
+		"calls[0]: %+v", calls[0])
+	assert.Equal(t, "Read", calls[0].Category,
+		"calls[0]: %+v", calls[0])
+	assert.Equal(t, "Grep", calls[1].ToolName,
+		"calls[1]: %+v", calls[1])
+	assert.Equal(t, "Grep", calls[1].Category,
+		"calls[1]: %+v", calls[1])
+	assert.NotEqual(t, int64(0), calls[0].MessageID,
+		"message_id should be non-zero")
 	assert.Equal(t, "s1", calls[0].SessionID, "session_id")
 }
 
@@ -2584,12 +2438,10 @@ func TestToolCallsCascadeOnSessionDelete(t *testing.T) {
 	require.NoError(t, err, "DeleteSession")
 
 	var count int
-	if err := d.Reader().QueryRow(
+	require.NoError(t, d.Reader().QueryRow(
 		"SELECT COUNT(*) FROM tool_calls WHERE session_id = ?",
 		"s1",
-	).Scan(&count); err != nil {
-		t.Fatalf("count tool_calls: %v", err)
-	}
+	).Scan(&count), "count tool_calls")
 	assert.Equal(t, 0, count, "tool_calls count")
 }
 
@@ -2708,12 +2560,10 @@ func TestToolCallsNoToolCalls(t *testing.T) {
 	insertMessages(t, d, userMsg("s1", 0, "hello"))
 
 	var count int
-	if err := d.Reader().QueryRow(
+	require.NoError(t, d.Reader().QueryRow(
 		"SELECT COUNT(*) FROM tool_calls WHERE session_id = ?",
 		"s1",
-	).Scan(&count); err != nil {
-		t.Fatalf("count: %v", err)
-	}
+	).Scan(&count), "count")
 	assert.Equal(t, 0, count, "tool_calls count")
 }
 
@@ -2753,11 +2603,9 @@ func TestToolCallsMixedSessionsOverlappingOrdinals(t *testing.T) {
 	var got []row
 	for rows.Next() {
 		var r row
-		if err := rows.Scan(
+		require.NoError(t, rows.Scan(
 			&r.toolName, &r.tcSession, &r.msgSession,
-		); err != nil {
-			t.Fatalf("scan: %v", err)
-		}
+		), "scan")
 		got = append(got, r)
 	}
 	err = rows.Err()
@@ -2765,29 +2613,22 @@ func TestToolCallsMixedSessionsOverlappingOrdinals(t *testing.T) {
 
 	require.Len(t, got, 2, "len")
 	// Bash should be linked to s2
-	if got[0].toolName != "Bash" ||
-		got[0].tcSession != "s2" ||
-		got[0].msgSession != "s2" {
-		t.Errorf("Bash row = %+v", got[0])
-	}
+	assert.Equal(t, "Bash", got[0].toolName, "Bash toolName")
+	assert.Equal(t, "s2", got[0].tcSession, "Bash tcSession")
+	assert.Equal(t, "s2", got[0].msgSession, "Bash msgSession")
 	// Read should be linked to s1
-	if got[1].toolName != "Read" ||
-		got[1].tcSession != "s1" ||
-		got[1].msgSession != "s1" {
-		t.Errorf("Read row = %+v", got[1])
-	}
+	assert.Equal(t, "Read", got[1].toolName, "Read toolName")
+	assert.Equal(t, "s1", got[1].tcSession, "Read tcSession")
+	assert.Equal(t, "s1", got[1].msgSession, "Read msgSession")
 }
 
 func TestResolveToolCallsPanicsOnLengthMismatch(t *testing.T) {
 	defer func() {
 		r := recover()
-		if r == nil {
-			t.Fatal("expected panic, got none")
-		}
+		require.NotNil(t, r, "expected panic, got none")
 		msg, ok := r.(string)
-		if !ok || !strings.Contains(msg, "resolveToolCalls") {
-			t.Errorf("unexpected panic value: %v", r)
-		}
+		assert.True(t, ok && strings.Contains(msg, "resolveToolCalls"),
+			"unexpected panic value: %v", r)
 	}()
 
 	msgs := []Message{
@@ -2825,15 +2666,12 @@ func TestToolCallNewColumns(t *testing.T) {
         FROM tool_calls WHERE session_id = 's1'
     `).Scan(&toolUseID, &inputJSON, &resultLen)
 	requireNoError(t, err, "query tool_calls")
-	if !toolUseID.Valid || toolUseID.String != "toolu_abc" {
-		t.Errorf("tool_use_id = %v, want toolu_abc", toolUseID)
-	}
-	if !inputJSON.Valid || inputJSON.String != `{"file_path":"main.go"}` {
-		t.Errorf("input_json = %v", inputJSON)
-	}
-	if !resultLen.Valid || resultLen.Int64 != 500 {
-		t.Errorf("result_content_length = %v, want 500", resultLen)
-	}
+	require.True(t, toolUseID.Valid, "tool_use_id valid")
+	assert.Equal(t, "toolu_abc", toolUseID.String, "tool_use_id")
+	require.True(t, inputJSON.Valid, "input_json valid")
+	assert.Equal(t, `{"file_path":"main.go"}`, inputJSON.String, "input_json")
+	require.True(t, resultLen.Valid, "result_content_length valid")
+	assert.Equal(t, int64(500), resultLen.Int64, "result_content_length")
 }
 
 func TestToolCallSkillName(t *testing.T) {
@@ -2861,9 +2699,8 @@ func TestToolCallSkillName(t *testing.T) {
         SELECT skill_name FROM tool_calls WHERE session_id = 's1'
     `).Scan(&skillName)
 	requireNoError(t, err, "query")
-	if !skillName.Valid || skillName.String != "superpowers:brainstorming" {
-		t.Errorf("skill_name = %v, want superpowers:brainstorming", skillName)
-	}
+	require.True(t, skillName.Valid, "skill_name valid")
+	assert.Equal(t, "superpowers:brainstorming", skillName.String, "skill_name")
 }
 
 func TestGetMessagesReturnsToolCalls(t *testing.T) {
@@ -2895,15 +2732,10 @@ func TestGetMessagesReturnsToolCalls(t *testing.T) {
 	require.Len(t, msgs, 1, "len")
 	require.Len(t, msgs[0].ToolCalls, 1, "got")
 	tc := msgs[0].ToolCalls[0]
-	if tc.ToolName != "Skill" {
-		t.Errorf("ToolName = %q", tc.ToolName)
-	}
-	if tc.SkillName != "superpowers:brainstorming" {
-		t.Errorf("SkillName = %q", tc.SkillName)
-	}
-	if tc.InputJSON != `{"skill":"superpowers:brainstorming"}` {
-		t.Errorf("InputJSON = %q", tc.InputJSON)
-	}
+	assert.Equal(t, "Skill", tc.ToolName, "ToolName")
+	assert.Equal(t, "superpowers:brainstorming", tc.SkillName, "SkillName")
+	assert.Equal(t, `{"skill":"superpowers:brainstorming"}`,
+		tc.InputJSON, "InputJSON")
 	assert.Equal(t, 42, tc.ResultContentLength, "ResultContentLength =")
 }
 
@@ -2937,13 +2769,11 @@ func TestToolCallResultContent(t *testing.T) {
 		context.Background(), "sess-rc", 0, 10, true,
 	)
 	require.NoError(t, err, "get")
-	if len(retrieved) != 1 || len(retrieved[0].ToolCalls) != 1 {
-		t.Fatalf("expected 1 msg with 1 tool call")
-	}
+	require.Len(t, retrieved, 1, "expected 1 msg")
+	require.Len(t, retrieved[0].ToolCalls, 1, "expected 1 tool call")
 	tc := retrieved[0].ToolCalls[0]
-	if tc.ResultContent != "[main abc1234] Add feature\n 1 file changed" {
-		t.Errorf("ResultContent = %q", tc.ResultContent)
-	}
+	assert.Equal(t, "[main abc1234] Add feature\n 1 file changed",
+		tc.ResultContent, "ResultContent")
 }
 
 func TestGetAllMessagesReturnsToolCallsAcrossBatches(t *testing.T) {
@@ -2977,15 +2807,11 @@ func TestGetAllMessagesReturnsToolCallsAcrossBatches(t *testing.T) {
 	require.Len(t, got, total, "got")
 
 	for i := range total {
-		if len(got[i].ToolCalls) != 1 {
-			t.Fatalf("msg %d: got %d tool_calls, want 1",
-				i, len(got[i].ToolCalls))
-		}
-		if got[i].ToolCalls[0].ToolUseID != fmt.Sprintf("toolu_%d", i) {
-			t.Fatalf("msg %d: tool_use_id = %q, want %q",
-				i, got[i].ToolCalls[0].ToolUseID,
-				fmt.Sprintf("toolu_%d", i))
-		}
+		require.Len(t, got[i].ToolCalls, 1,
+			"msg %d: tool_calls", i)
+		require.Equal(t, fmt.Sprintf("toolu_%d", i),
+			got[i].ToolCalls[0].ToolUseID,
+			"msg %d: tool_use_id", i)
 	}
 }
 
@@ -3016,10 +2842,9 @@ func TestToolCallSubagentSessionID(t *testing.T) {
 		FROM tool_calls WHERE session_id = 's1'
 	`).Scan(&subagentID)
 	requireNoError(t, err, "query tool_calls")
-	if !subagentID.Valid || subagentID.String != "agent-abc123" {
-		t.Errorf("subagent_session_id = %v, want agent-abc123",
-			subagentID)
-	}
+	require.True(t, subagentID.Valid, "subagent_session_id valid")
+	assert.Equal(t, "agent-abc123", subagentID.String,
+		"subagent_session_id")
 
 	// Verify via GetMessages that it round-trips
 	msgs, err := d.GetMessages(
@@ -3055,10 +2880,9 @@ func TestToolCallSubagentSessionID(t *testing.T) {
 		FROM tool_calls WHERE session_id = 's2'
 	`).Scan(&nullSubagent)
 	requireNoError(t, err, "query tool_calls s2")
-	if nullSubagent.Valid {
-		t.Errorf("expected NULL subagent_session_id for s2, got %q",
-			nullSubagent.String)
-	}
+	assert.False(t, nullSubagent.Valid,
+		"expected NULL subagent_session_id for s2, got %q",
+		nullSubagent.String)
 }
 
 func TestFTSBackfill(t *testing.T) {
@@ -3074,14 +2898,12 @@ func TestFTSBackfill(t *testing.T) {
 	requireNoError(t, err, "Open 1")
 	// Use writer directly to ensure it happens
 	w := d1.getWriter()
-	if _, err := w.Exec("DROP TABLE IF EXISTS messages_fts"); err != nil {
-		t.Fatalf("dropping fts: %v", err)
-	}
+	_, err = w.Exec("DROP TABLE IF EXISTS messages_fts")
+	require.NoError(t, err, "dropping fts")
 	// Also drop triggers, otherwise inserts will fail
 	for _, tr := range []string{"messages_ai", "messages_ad", "messages_au"} {
-		if _, err := w.Exec("DROP TRIGGER IF EXISTS " + tr); err != nil {
-			t.Fatalf("dropping trigger %s: %v", tr, err)
-		}
+		_, err := w.Exec("DROP TRIGGER IF EXISTS " + tr)
+		require.NoError(t, err, "dropping trigger %s", tr)
 	}
 
 	// 2. Insert messages while FTS is missing
@@ -3096,9 +2918,7 @@ func TestFTSBackfill(t *testing.T) {
 	requireNoError(t, err, "Open 2")
 	defer d2.Close()
 
-	if !d2.HasFTS() {
-		t.Fatal("FTS should be available after re-open")
-	}
+	require.True(t, d2.HasFTS(), "FTS should be available after re-open")
 
 	// 4. Verify search finds the message
 	page, err := d2.Search(context.Background(), SearchFilter{
@@ -3117,9 +2937,7 @@ func TestPath(t *testing.T) {
 	requireNoError(t, err, "Open")
 	defer d.Close()
 
-	if got := d.Path(); got != path {
-		t.Errorf("Path() = %q, want %q", got, path)
-	}
+	assert.Equal(t, path, d.Path(), "Path()")
 }
 
 func TestReopen(t *testing.T) {
@@ -3142,9 +2960,9 @@ func TestReopen(t *testing.T) {
 
 	msgs, err := d.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
-	if len(msgs) != 1 || msgs[0].Content != "hello" {
-		t.Errorf("messages = %v, want [hello]", msgs)
-	}
+	require.Len(t, msgs, 1, "messages = %v, want [hello]", msgs)
+	assert.Equal(t, "hello", msgs[0].Content,
+		"messages = %v, want [hello]", msgs)
 
 	// Writes should work after reopen.
 	insertSession(t, d, "s2", "proj2")
@@ -3202,9 +3020,7 @@ func TestCloseConnections(t *testing.T) {
 
 	// Queries should fail after close.
 	_, err = d.GetSession(context.Background(), "s1")
-	if err == nil {
-		t.Error("expected error querying after CloseConnections")
-	}
+	assert.Error(t, err, "expected error querying after CloseConnections")
 
 	// Reopen should restore service.
 	err = d.Reopen()
@@ -3213,9 +3029,7 @@ func TestCloseConnections(t *testing.T) {
 	// Queries should work again.
 	s, err := d.GetSession(context.Background(), "s1")
 	require.NoError(t, err, "GetSession after Reopen")
-	if s == nil {
-		t.Error("session s1 missing after Reopen")
-	}
+	assert.NotNil(t, s, "session s1 missing after Reopen")
 }
 
 func TestCloseRenameReopen(t *testing.T) {
@@ -3270,9 +3084,7 @@ func TestCloseRecoveryOnRenameFail(t *testing.T) {
 	// Simulate rename failure (temp file doesn't exist).
 	nonexistent := filepath.Join(dir, "no-such-file.db")
 	renameErr := os.Rename(nonexistent, origPath)
-	if renameErr == nil {
-		t.Fatal("expected rename to fail")
-	}
+	require.Error(t, renameErr, "expected rename to fail")
 
 	// Recovery: reopen original to restore service.
 	err = origDB.Reopen()
@@ -3281,9 +3093,7 @@ func TestCloseRecoveryOnRenameFail(t *testing.T) {
 	// Data should still be accessible.
 	s, err := origDB.GetSession(context.Background(), "s1")
 	require.NoError(t, err, "GetSession after recovery")
-	if s == nil {
-		t.Error("session s1 missing after recovery Reopen")
-	}
+	assert.NotNil(t, s, "session s1 missing after recovery Reopen")
 }
 
 func TestConcurrentReadsWhileReopen(t *testing.T) {
@@ -3323,9 +3133,8 @@ func TestConcurrentReadsWhileReopen(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	if n := readErrors.Load(); n > 0 {
-		t.Errorf("got %d concurrent read errors", n)
-	}
+	assert.Equal(t, int64(0), readErrors.Load(),
+		"got %d concurrent read errors", readErrors.Load())
 }
 
 func TestExportedReaderAcquiredBeforeReopenStaysUsable(t *testing.T) {
@@ -3363,9 +3172,10 @@ func TestReopenDoesNotBlockNewReadsWhileClosingRetiredPool(t *testing.T) {
 	select {
 	case <-closeStarted:
 	case err := <-reopenDone:
-		t.Fatalf("Reopen finished before blocking close: %v", err)
+		require.Failf(t, "Reopen finished early",
+			"Reopen finished before blocking close: %v", err)
 	case <-time.After(2 * time.Second):
-		t.Fatal("Reopen did not start closing retired pool")
+		require.Fail(t, "Reopen did not start closing retired pool")
 	}
 
 	readDone := make(chan error, 1)
@@ -3378,7 +3188,8 @@ func TestReopenDoesNotBlockNewReadsWhileClosingRetiredPool(t *testing.T) {
 	case err := <-readDone:
 		require.NoError(t, err, "new read while closing retired pool")
 	case <-time.After(200 * time.Millisecond):
-		t.Fatal("new read blocked while Reopen closed a retired pool")
+		require.Fail(t,
+			"new read blocked while Reopen closed a retired pool")
 	}
 
 	releaseClose()
@@ -3403,16 +3214,13 @@ func TestRepeatedReopenBoundsRetiredPools(t *testing.T) {
 	d.mu.Lock()
 	n := len(d.retired)
 	d.mu.Unlock()
-	if n > 2 {
-		t.Errorf("retired pool count = %d, want <= 2", n)
-	}
+	assert.LessOrEqual(t, n, 2,
+		"retired pool count = %d, want <= 2", n)
 
 	// Data should still be readable.
 	s, err := d.GetSession(context.Background(), "s1")
 	require.NoError(t, err, "GetSession")
-	if s == nil {
-		t.Error("session s1 missing after repeated Reopen")
-	}
+	assert.NotNil(t, s, "session s1 missing after repeated Reopen")
 }
 
 func TestCloseAfterCloseConnectionsReopen(t *testing.T) {
@@ -3465,12 +3273,7 @@ func TestCopyInsightsFrom(t *testing.T) {
 	)
 	requireNoError(t, err, "ListInsights")
 	require.Len(t, insights, 1, "len")
-	if insights[0].Content != "test insight content" {
-		t.Errorf(
-			"content = %q, want %q",
-			insights[0].Content, "test insight content",
-		)
-	}
+	assert.Equal(t, "test insight content", insights[0].Content, "content")
 }
 
 func TestCopyOrphanedDataFrom(t *testing.T) {
@@ -3527,10 +3330,7 @@ func TestCopyOrphanedDataFrom(t *testing.T) {
 		context.Background(), "s2",
 	)
 	requireNoError(t, err, "GetSession s2")
-	if s == nil {
-		t.Fatal("orphaned session s2 not found in dst")
-		return
-	}
+	require.NotNil(t, s, "orphaned session s2 not found in dst")
 	assert.Equal(t, "codex", s.Agent, "s2 agent")
 
 	// s2 messages should be copied.
@@ -3554,10 +3354,8 @@ func TestCopyOrphanedDataFrom(t *testing.T) {
 			"WHERE session_id = 's2'",
 	).Scan(&tcCount)
 	requireNoError(t, err, "count s2 tool_calls")
-	if tcCount != 0 {
-		t.Errorf("expected 0 tool_calls for s2, got %d",
-			tcCount)
-	}
+	assert.Equal(t, 0, tcCount,
+		"expected 0 tool_calls for s2, got %d", tcCount)
 }
 
 func TestCopyOrphanedDataFrom_NoOrphans(t *testing.T) {
@@ -3577,10 +3375,8 @@ func TestCopyOrphanedDataFrom_NoOrphans(t *testing.T) {
 
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
 	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 0 {
-		t.Fatalf("expected 0 orphaned sessions, got %d",
-			count)
-	}
+	require.Equal(t, 0, count,
+		"expected 0 orphaned sessions, got %d", count)
 }
 
 func TestCopyOrphanedDataFrom_WithToolCalls(t *testing.T) {
@@ -3628,12 +3424,7 @@ func TestCopyOrphanedDataFrom_WithToolCalls(t *testing.T) {
 	).Scan(&msgID, &toolName, &toolUseID)
 	requireNoError(t, err, "query tool_call")
 	assert.Equal(t, "Bash", toolName, "tool_name")
-	if toolUseID != "tu_123" {
-		t.Errorf(
-			"tool_use_id = %q, want %q",
-			toolUseID, "tu_123",
-		)
-	}
+	assert.Equal(t, "tu_123", toolUseID, "tool_use_id")
 
 	// Verify the message_id FK is valid.
 	var ordinal int
@@ -3696,12 +3487,8 @@ func TestCopyOrphanedDataFrom_WithToolResultEvents(t *testing.T) {
 	require.Equal(t, "Finished successfully", tc.ResultContent, "result_content")
 	require.Len(t, tc.ResultEvents, 1, "result events len =")
 	require.Equal(t, "wait_output", tc.ResultEvents[0].Source, "event source")
-	if tc.ResultEvents[0].SubagentSessionID != "codex:agent-1" {
-		t.Fatalf(
-			"subagent_session_id = %q, want %q",
-			tc.ResultEvents[0].SubagentSessionID, "codex:agent-1",
-		)
-	}
+	require.Equal(t, "codex:agent-1",
+		tc.ResultEvents[0].SubagentSessionID, "subagent_session_id")
 }
 
 func TestCopyTrashedDataFromPreservesPins(t *testing.T) {
@@ -3720,9 +3507,8 @@ func TestCopyTrashedDataFromPreservesPins(t *testing.T) {
 	requireNoError(t, err, "GetAllMessages src")
 	note := "important"
 	pinID, err := srcDB.PinMessage("s1", srcMsgs[0].ID, &note)
-	if err != nil || pinID == 0 {
-		t.Fatalf("PinMessage src: id=%d err=%v", pinID, err)
-	}
+	require.NoError(t, err, "PinMessage src: id=%d", pinID)
+	require.NotZero(t, pinID, "PinMessage src returned id=0")
 	requireNoError(t, srcDB.SoftDeleteSession("s1"), "SoftDelete src")
 	srcDB.Close()
 
@@ -3739,9 +3525,8 @@ func TestCopyTrashedDataFromPreservesPins(t *testing.T) {
 	requireNoError(t, err, "ListPinnedMessages")
 	require.Len(t, pins, 1, "pins copied =")
 	require.Equal(t, 0, pins[0].Ordinal, "pin ordinal")
-	if pins[0].Note == nil || *pins[0].Note != note {
-		t.Fatalf("pin note = %v, want %q", pins[0].Note, note)
-	}
+	require.NotNil(t, pins[0].Note, "pin note nil")
+	require.Equal(t, note, *pins[0].Note, "pin note")
 
 	var messageContent string
 	requireNoError(t, dstDB.getReader().QueryRow(
@@ -3781,9 +3566,7 @@ func TestCopyOrphanedDataFrom_AtomicOnFailure(t *testing.T) {
 	// CopyOrphanedDataFrom should fail on the message
 	// copy step.
 	_, err = dstDB.CopyOrphanedDataFrom(srcPath)
-	if err == nil {
-		t.Fatal("expected error from corrupted source")
-	}
+	require.Error(t, err, "expected error from corrupted source")
 
 	// The session insert must have been rolled back — no
 	// partial data in the destination.
@@ -3792,12 +3575,9 @@ func TestCopyOrphanedDataFrom_AtomicOnFailure(t *testing.T) {
 		SessionFilter{Limit: 100},
 	)
 	requireNoError(t, err, "list sessions")
-	if len(page.Sessions) != 0 {
-		t.Fatalf(
-			"expected 0 sessions after failed copy, got %d",
-			len(page.Sessions),
-		)
-	}
+	require.Empty(t, page.Sessions,
+		"expected 0 sessions after failed copy, got %d",
+		len(page.Sessions))
 }
 
 func TestCopyOrphanedDataFrom_IsSystem(t *testing.T) {
@@ -3829,12 +3609,8 @@ func TestCopyOrphanedDataFrom_IsSystem(t *testing.T) {
 	)
 	requireNoError(t, err, "GetMessages")
 	require.Len(t, msgs, 2, "expected 2 messages")
-	if !msgs[0].IsSystem {
-		t.Error("ordinal 0: is_system should be true")
-	}
-	if msgs[1].IsSystem {
-		t.Error("ordinal 1: is_system should be false")
-	}
+	assert.True(t, msgs[0].IsSystem, "ordinal 0: is_system should be true")
+	assert.False(t, msgs[1].IsSystem, "ordinal 1: is_system should be false")
 }
 
 func TestCopyOrphanedDataFrom_LegacyNoIsSystem(t *testing.T) {
@@ -3902,9 +3678,7 @@ func TestCopyOrphanedDataFrom_LegacyNoIsSystem(t *testing.T) {
 	)
 	requireNoError(t, err, "GetMessages")
 	require.Len(t, msgs, 1, "expected 1 message")
-	if msgs[0].IsSystem {
-		t.Error("is_system should default to false")
-	}
+	assert.False(t, msgs[0].IsSystem, "is_system should default to false")
 }
 
 func TestCopyOrphanedDataFrom_TokenMetadata(t *testing.T) {
@@ -3946,9 +3720,7 @@ func TestCopyOrphanedDataFrom_TokenMetadata(t *testing.T) {
 	ctx := context.Background()
 	s, err := dstDB.GetSession(ctx, "s1")
 	requireNoError(t, err, "GetSession s1")
-	if s == nil {
-		t.Fatal("orphaned session s1 not found")
-	}
+	require.NotNil(t, s, "orphaned session s1 not found")
 	assert.Equal(t, 5000, s.TotalOutputTokens, "TotalOutputTokens")
 	assert.Equal(t, 120000, s.PeakContextTokens, "PeakContextTokens")
 	assert.True(t, s.HasTotalOutputTokens, "HasTotalOutputTokens should be true")
@@ -3964,9 +3736,7 @@ func TestCopyOrphanedDataFrom_TokenMetadata(t *testing.T) {
 	assert.Equal(t, 500, m.OutputTokens, "OutputTokens")
 	assert.True(t, m.HasContextTokens, "HasContextTokens should be true")
 	assert.True(t, m.HasOutputTokens, "HasOutputTokens should be true")
-	if len(m.TokenUsage) == 0 {
-		t.Error("TokenUsage should be preserved")
-	}
+	assert.NotEmpty(t, m.TokenUsage, "TokenUsage should be preserved")
 }
 
 func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
@@ -3984,9 +3754,7 @@ func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
 	require.NoError(t, err, "GetAgents")
 
 	for _, a := range agents {
-		if a.Name == "" {
-			t.Error("GetAgents returned empty agent name")
-		}
+		assert.NotEmpty(t, a.Name, "GetAgents returned empty agent name")
 	}
 	assert.Len(t, agents, 2, "len")
 }
@@ -3996,16 +3764,12 @@ func TestGetAgentsEmptyResultSerializesAsArray(t *testing.T) {
 
 	agents, err := d.GetAgents(context.Background(), false, false)
 	require.NoError(t, err, "GetAgents")
-	if agents == nil {
-		t.Fatal("GetAgents returned nil, want empty slice")
-	}
-	assert.Len(t, agents, 0, "len")
+	require.NotNil(t, agents, "GetAgents returned nil, want empty slice")
+	assert.Empty(t, agents, "len")
 
 	b, err := json.Marshal(agents)
 	require.NoError(t, err, "json.Marshal")
-	if string(b) != "[]" {
-		t.Errorf("JSON = %s, want []", b)
-	}
+	assert.Equal(t, "[]", string(b), "JSON")
 }
 
 func TestStarSession(t *testing.T) {
@@ -4015,9 +3779,8 @@ func TestStarSession(t *testing.T) {
 
 	// Star existing session.
 	ok, err := d.StarSession("s1")
-	if err != nil || !ok {
-		t.Fatalf("StarSession: ok=%v err=%v", ok, err)
-	}
+	require.NoError(t, err, "StarSession")
+	require.True(t, ok, "StarSession should succeed for existing session")
 
 	// Idempotent re-star — should still return true (session exists).
 	ok, err = d.StarSession("s1")
@@ -4028,18 +3791,14 @@ func TestStarSession(t *testing.T) {
 	// Listed.
 	ids, err := d.ListStarredSessionIDs(ctx)
 	require.NoError(t, err, "ListStarredSessionIDs")
-	if len(ids) != 1 || ids[0] != "s1" {
-		t.Errorf("listed = %v, want [s1]", ids)
-	}
+	assert.Equal(t, []string{"s1"}, ids, "listed = %v, want [s1]", ids)
 
 	// Unstar.
 	err = d.UnstarSession("s1")
 	require.NoError(t, err, "UnstarSession")
 	ids, err = d.ListStarredSessionIDs(ctx)
 	require.NoError(t, err, "ListStarredSessionIDs after unstar")
-	if len(ids) != 0 {
-		t.Errorf("listed after unstar = %v, want []", ids)
-	}
+	assert.Empty(t, ids, "listed after unstar = %v, want []", ids)
 
 	// Star non-existent session returns false (no FK error).
 	ok, err = d.StarSession("nonexistent")
@@ -4087,9 +3846,8 @@ func TestRestoreSession(t *testing.T) {
 		f := filterWith(func(f *SessionFilter) {})
 		page, err := d.ListSessions(ctx, f)
 		requireNoError(t, err, "ListSessions")
-		if len(page.Sessions) != 0 {
-			t.Fatal("soft-deleted session should not appear in list")
-		}
+		require.Empty(t, page.Sessions,
+			"soft-deleted session should not appear in list")
 
 		// Should appear in trash list.
 		trashed, err := d.ListTrashedSessions(ctx)
@@ -4103,9 +3861,8 @@ func TestRestoreSession(t *testing.T) {
 		// Should appear in list again.
 		page, err = d.ListSessions(ctx, f)
 		requireNoError(t, err, "ListSessions")
-		if len(page.Sessions) != 1 {
-			t.Fatal("restored session should appear in list")
-		}
+		require.Len(t, page.Sessions, 1,
+			"restored session should appear in list")
 	})
 }
 
@@ -4121,17 +3878,15 @@ func TestDeleteSessionExcludes(t *testing.T) {
 	requireSessionGone(t, d, "s1")
 
 	// Session should be excluded.
-	if !d.IsSessionExcluded("s1") {
-		t.Error("session should be excluded after permanent delete")
-	}
+	assert.True(t, d.IsSessionExcluded("s1"),
+		"session should be excluded after permanent delete")
 
 	// UpsertSession should return ErrSessionExcluded.
 	err = d.UpsertSession(Session{
 		ID: "s1", Project: "p", Machine: "m", Agent: "claude",
 	})
-	if !errors.Is(err, ErrSessionExcluded) {
-		t.Fatalf("UpsertSession = %v, want ErrSessionExcluded", err)
-	}
+	require.ErrorIs(t, err, ErrSessionExcluded,
+		"UpsertSession = %v, want ErrSessionExcluded", err)
 	requireSessionGone(t, d, "s1")
 }
 
@@ -4144,9 +3899,8 @@ func TestUpsertSessionTrashedReturnsErrSessionTrashed(t *testing.T) {
 	err := d.UpsertSession(Session{
 		ID: "s1", Project: "p", Machine: "m", Agent: "claude",
 	})
-	if !errors.Is(err, ErrSessionTrashed) {
-		t.Fatalf("UpsertSession = %v, want ErrSessionTrashed", err)
-	}
+	require.ErrorIs(t, err, ErrSessionTrashed,
+		"UpsertSession = %v, want ErrSessionTrashed", err)
 }
 
 func TestEmptyTrashExcludes(t *testing.T) {
@@ -4164,32 +3918,24 @@ func TestEmptyTrashExcludes(t *testing.T) {
 	assert.Equal(t, 2, n, "EmptyTrash deleted")
 
 	// Both should be excluded.
-	if !d.IsSessionExcluded("s1") {
-		t.Error("s1 should be excluded")
-	}
-	if !d.IsSessionExcluded("s2") {
-		t.Error("s2 should be excluded")
-	}
+	assert.True(t, d.IsSessionExcluded("s1"), "s1 should be excluded")
+	assert.True(t, d.IsSessionExcluded("s2"), "s2 should be excluded")
 
 	// s3 should NOT be excluded.
-	if d.IsSessionExcluded("s3") {
-		t.Error("s3 should not be excluded")
-	}
+	assert.False(t, d.IsSessionExcluded("s3"),
+		"s3 should not be excluded")
 
 	// Re-upsert should return ErrSessionExcluded.
 	err = d.UpsertSession(Session{
 		ID: "s1", Project: "p", Machine: "m", Agent: "claude",
 	})
-	if !errors.Is(err, ErrSessionExcluded) {
-		t.Fatalf("UpsertSession s1 = %v, want ErrSessionExcluded", err)
-	}
+	require.ErrorIs(t, err, ErrSessionExcluded,
+		"UpsertSession s1 = %v, want ErrSessionExcluded", err)
 	requireSessionGone(t, d, "s1")
 
 	// s3 should still be upsertable.
 	s, _ := d.GetSession(context.Background(), "s3")
-	if s == nil {
-		t.Error("s3 should still be visible")
-	}
+	assert.NotNil(t, s, "s3 should still be visible")
 }
 
 func TestCopyExcludedSessionsFrom(t *testing.T) {
@@ -4202,9 +3948,8 @@ func TestCopyExcludedSessionsFrom(t *testing.T) {
 
 	insertSession(t, srcDB, "s1", "p")
 	requireNoError(t, srcDB.DeleteSession("s1"), "DeleteSession")
-	if !srcDB.IsSessionExcluded("s1") {
-		t.Fatal("s1 should be excluded in src")
-	}
+	require.True(t, srcDB.IsSessionExcluded("s1"),
+		"s1 should be excluded in src")
 	srcDB.Close()
 
 	// Destination DB (empty, simulates fresh resync DB).
@@ -4218,17 +3963,15 @@ func TestCopyExcludedSessionsFrom(t *testing.T) {
 	require.NoError(t, err, "CopyExcludedSessionsFrom")
 
 	// s1 should be excluded in destination.
-	if !dstDB.IsSessionExcluded("s1") {
-		t.Error("s1 should be excluded in dst after copy")
-	}
+	assert.True(t, dstDB.IsSessionExcluded("s1"),
+		"s1 should be excluded in dst after copy")
 
 	// Upserting s1 should be rejected.
 	err = dstDB.UpsertSession(Session{
 		ID: "s1", Project: "p", Machine: "m", Agent: "claude",
 	})
-	if !errors.Is(err, ErrSessionExcluded) {
-		t.Errorf("UpsertSession = %v, want ErrSessionExcluded", err)
-	}
+	assert.ErrorIs(t, err, ErrSessionExcluded,
+		"UpsertSession = %v, want ErrSessionExcluded", err)
 }
 
 func TestCopySessionMetadataFrom(t *testing.T) {
@@ -4249,15 +3992,13 @@ func TestCopySessionMetadataFrom(t *testing.T) {
 	requireNoError(t, srcDB.SoftDeleteSession("s1"), "SoftDelete")
 	// Pin message ordinal 1.
 	pinID, err := srcDB.PinMessage("s1", 1, nil)
-	if err != nil || pinID == 0 {
-		t.Fatalf("PinMessage in src: id=%d err=%v", pinID, err)
-	}
+	require.NoError(t, err, "PinMessage in src: id=%d", pinID)
+	require.NotZero(t, pinID, "PinMessage in src returned id=0")
 	// Star the session.
-	if _, err := srcDB.getWriter().Exec(
+	_, err = srcDB.getWriter().Exec(
 		"INSERT INTO starred_sessions (session_id) VALUES (?)", "s1",
-	); err != nil {
-		t.Fatalf("star session in src: %v", err)
-	}
+	)
+	require.NoError(t, err, "star session in src")
 	srcDB.Close()
 
 	// Destination DB: same session re-synced (no user metadata).
@@ -4274,12 +4015,8 @@ func TestCopySessionMetadataFrom(t *testing.T) {
 	// Before copy: no metadata, no pins.
 	s, err := dstDB.GetSession(ctx, "s1")
 	requireNoError(t, err, "GetSession before")
-	if s.DisplayName != nil {
-		t.Errorf("display_name before = %v, want nil", *s.DisplayName)
-	}
-	if s.DeletedAt != nil {
-		t.Errorf("deleted_at before = %v, want nil", *s.DeletedAt)
-	}
+	assert.Nil(t, s.DisplayName, "display_name before")
+	assert.Nil(t, s.DeletedAt, "deleted_at before")
 	pins, err := dstDB.ListPinnedMessages(ctx, "s1", "")
 	requireNoError(t, err, "ListPins before")
 	assert.Equal(t, 0, len(pins), "pins before")
@@ -4298,15 +4035,10 @@ func TestCopySessionMetadataFrom(t *testing.T) {
 	// GetSession (which filters deleted_at IS NULL) returns nil.
 	sf, err := dstDB.GetSessionFull(ctx, "s1")
 	requireNoError(t, err, "GetSessionFull after")
-	if sf == nil {
-		t.Fatal("session should exist after metadata copy")
-	}
-	if sf.DisplayName == nil || *sf.DisplayName != dn {
-		t.Errorf("display_name = %v, want %q", sf.DisplayName, dn)
-	}
-	if sf.DeletedAt == nil {
-		t.Error("deleted_at should be set after copy")
-	}
+	require.NotNil(t, sf, "session should exist after metadata copy")
+	require.NotNil(t, sf.DisplayName, "display_name nil")
+	assert.Equal(t, dn, *sf.DisplayName, "display_name")
+	assert.NotNil(t, sf.DeletedAt, "deleted_at should be set after copy")
 	pins, err = dstDB.ListPinnedMessages(ctx, "s1", "")
 	requireNoError(t, err, "ListPins after")
 	require.Len(t, pins, 1, "pins after =")
@@ -4342,15 +4074,10 @@ func TestCopySessionMetadataCopiesFromSource(t *testing.T) {
 
 	sf, err := dstDB.GetSessionFull(ctx, "s1")
 	requireNoError(t, err, "GetSessionFull")
-	if sf == nil {
-		t.Fatal("session should exist")
-	}
-	if sf.DisplayName == nil || *sf.DisplayName != name {
-		t.Errorf("display_name = %v, want %q", sf.DisplayName, name)
-	}
-	if sf.DeletedAt == nil {
-		t.Error("deleted_at should be set from source")
-	}
+	require.NotNil(t, sf, "session should exist")
+	require.NotNil(t, sf.DisplayName, "display_name nil")
+	assert.Equal(t, name, *sf.DisplayName, "display_name")
+	assert.NotNil(t, sf.DeletedAt, "deleted_at should be set from source")
 }
 
 func TestCopySessionMetadataPreservesWorktreeProjectMappings(t *testing.T) {
@@ -4386,9 +4113,7 @@ func TestCopySessionMetadataPreservesWorktreeProjectMappings(t *testing.T) {
 
 	got, err := dstDB.ListWorktreeProjectMappings(ctx, "laptop")
 	requireNoError(t, err, "ListWorktreeProjectMappings")
-	if len(got) != 2 {
-		t.Fatalf("mapping count = %d, want 2: %+v", len(got), got)
-	}
+	require.Len(t, got, 2, "mapping count = %d, want 2: %+v", len(got), got)
 	projects := map[string]string{}
 	for _, m := range got {
 		projects[m.PathPrefix] = m.Project
@@ -4421,21 +4146,13 @@ func TestCopySessionMetadataPreservesClears(t *testing.T) {
 
 	sf, err := dstDB.GetSessionFull(ctx, "s1")
 	requireNoError(t, err, "GetSessionFull")
-	if sf == nil {
-		t.Fatal("session should exist")
-	}
-	if sf.DisplayName != nil {
-		t.Errorf(
-			"display_name = %v, want nil (clear preserved)",
-			sf.DisplayName,
-		)
-	}
-	if sf.DeletedAt != nil {
-		t.Errorf(
-			"deleted_at = %v, want nil (restore preserved)",
-			sf.DeletedAt,
-		)
-	}
+	require.NotNil(t, sf, "session should exist")
+	assert.Nil(t, sf.DisplayName,
+		"display_name = %v, want nil (clear preserved)",
+		sf.DisplayName)
+	assert.Nil(t, sf.DeletedAt,
+		"deleted_at = %v, want nil (restore preserved)",
+		sf.DeletedAt)
 }
 
 func TestPinMessageIdempotent(t *testing.T) {
@@ -4445,27 +4162,23 @@ func TestPinMessageIdempotent(t *testing.T) {
 
 	// First pin should succeed.
 	id1, err := d.PinMessage("s1", 1, nil)
-	if err != nil || id1 == 0 {
-		t.Fatalf("first PinMessage: id=%d err=%v", id1, err)
-	}
+	require.NoError(t, err, "first PinMessage: id=%d", id1)
+	require.NotZero(t, id1, "first PinMessage returned id=0")
 
 	// Idempotent re-pin with same note must not return 0.
 	id2, err := d.PinMessage("s1", 1, nil)
 	require.NoError(t, err, "idempotent PinMessage err")
-	if id2 == 0 {
-		t.Fatal("idempotent PinMessage returned id=0; should return existing id")
-	}
-	if id2 != id1 {
-		t.Errorf("idempotent PinMessage id=%d, want %d", id2, id1)
-	}
+	require.NotZero(t, id2,
+		"idempotent PinMessage returned id=0; should return existing id")
+	assert.Equal(t, id1, id2,
+		"idempotent PinMessage id=%d, want %d", id2, id1)
 
 	// Re-pin with different note should succeed and return same id.
 	note := "important"
 	id2b, err := d.PinMessage("s1", 1, &note)
 	require.NoError(t, err, "re-pin with note err")
-	if id2b != id1 {
-		t.Errorf("re-pin with note id=%d, want %d", id2b, id1)
-	}
+	assert.Equal(t, id1, id2b,
+		"re-pin with note id=%d, want %d", id2b, id1)
 
 	// Pin with wrong session should return 0.
 	id3, err := d.PinMessage("nonexistent", 1, nil)
@@ -4492,14 +4205,11 @@ func TestDeleteSessionIfTrashed(t *testing.T) {
 	ctx := context.Background()
 	s, err := d.GetSessionFull(ctx, "s1")
 	require.NoError(t, err, "GetSessionFull after delete")
-	if s != nil {
-		t.Error("session should be nil after permanent delete")
-	}
+	assert.Nil(t, s, "session should be nil after permanent delete")
 
 	// Session should be excluded.
-	if !d.IsSessionExcluded("s1") {
-		t.Error("session should be in excluded_sessions")
-	}
+	assert.True(t, d.IsSessionExcluded("s1"),
+		"session should be in excluded_sessions")
 
 	// Non-existent session should return 0.
 	n, err = d.DeleteSessionIfTrashed("nonexistent")
@@ -4538,24 +4248,18 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 
 	projects, err = d.GetProjects(ctx, false, false)
 	requireNoError(t, err, "GetProjects after trash")
-	assert.Len(t, projects, 1, "projects after trash:")
-	if projects[0].Name != "proj-a" {
-		t.Errorf("project name: got %q, want %q", projects[0].Name, "proj-a")
-	}
+	require.Len(t, projects, 1, "projects after trash:")
+	assert.Equal(t, "proj-a", projects[0].Name, "project name")
 
 	agents, err = d.GetAgents(ctx, false, false)
 	requireNoError(t, err, "GetAgents after trash")
-	assert.Len(t, agents, 1, "agents after trash:")
-	if agents[0].Name != "claude" {
-		t.Errorf("agent name: got %q, want %q", agents[0].Name, "claude")
-	}
+	require.Len(t, agents, 1, "agents after trash:")
+	assert.Equal(t, "claude", agents[0].Name, "agent name")
 
 	machines, err = d.GetMachines(ctx, false, false)
 	requireNoError(t, err, "GetMachines after trash")
-	assert.Len(t, machines, 1, "machines after trash:")
-	if machines[0] != "laptop" {
-		t.Errorf("machine: got %q, want %q", machines[0], "laptop")
-	}
+	require.Len(t, machines, 1, "machines after trash:")
+	assert.Equal(t, "laptop", machines[0], "machine")
 }
 
 func TestGetSessionExcludesTrashed(t *testing.T) {
@@ -4567,24 +4271,19 @@ func TestGetSessionExcludesTrashed(t *testing.T) {
 	// Before trashing: GetSession returns the session.
 	s, err := d.GetSession(ctx, "s1")
 	requireNoError(t, err, "GetSession before trash")
-	if s == nil {
-		t.Fatal("session should exist before trash")
-	}
+	require.NotNil(t, s, "session should exist before trash")
 
 	// After trashing: GetSession returns nil.
 	requireNoError(t, d.SoftDeleteSession("s1"), "soft delete")
 	s, err = d.GetSession(ctx, "s1")
 	requireNoError(t, err, "GetSession after trash")
-	if s != nil {
-		t.Error("GetSession should return nil for trashed session")
-	}
+	assert.Nil(t, s, "GetSession should return nil for trashed session")
 
 	// GetSessionFull still returns it.
 	sf, err := d.GetSessionFull(ctx, "s1")
 	requireNoError(t, err, "GetSessionFull after trash")
-	if sf == nil {
-		t.Error("GetSessionFull should still return trashed session")
-	}
+	assert.NotNil(t, sf,
+		"GetSessionFull should still return trashed session")
 }
 
 func TestOpenMigratesColumnsWithoutDrop(t *testing.T) {
@@ -4693,9 +4392,7 @@ CREATE TABLE IF NOT EXISTS insights (
 	ctx := context.Background()
 	s, err := d.GetSession(ctx, "keep-me")
 	requireNoError(t, err, "GetSession after migration")
-	if s == nil {
-		t.Fatal("session lost during migration")
-	}
+	require.NotNil(t, s, "session lost during migration")
 	assert.Equal(t, "myproj", s.Project, "project")
 	assert.Equal(t, 3, s.MessageCount, "message_count")
 
@@ -4824,29 +4521,23 @@ CREATE TABLE IF NOT EXISTS tool_calls (
 	ctx := context.Background()
 	nonzero, err := d.GetSession(ctx, "legacy-nonzero")
 	requireNoError(t, err, "GetSession legacy-nonzero")
-	if nonzero == nil {
-		t.Fatal("legacy-nonzero missing")
-	}
+	require.NotNil(t, nonzero, "legacy-nonzero missing")
 	assert.True(t, nonzero.HasTotalOutputTokens, "legacy-nonzero HasTotalOutputTokens = false, want true")
 	assert.True(t, nonzero.HasPeakContextTokens, "legacy-nonzero HasPeakContextTokens = false, want true")
 
 	zero, err := d.GetSession(ctx, "legacy-zero")
 	requireNoError(t, err, "GetSession legacy-zero")
-	if zero == nil {
-		t.Fatal("legacy-zero missing")
-	}
+	require.NotNil(t, zero, "legacy-zero missing")
 	assert.True(t, zero.HasTotalOutputTokens, "legacy-zero HasTotalOutputTokens = false, want true")
 	assert.True(t, zero.HasPeakContextTokens, "legacy-zero HasPeakContextTokens = false, want true")
 
 	msgs, err := d.GetMessages(ctx, "legacy-zero", 0, 10, true)
 	requireNoError(t, err, "GetMessages legacy-zero")
 	require.Len(t, msgs, 1, "legacy-zero messages =")
-	if !msgs[0].HasContextTokens {
-		t.Error("legacy-zero message HasContextTokens = false, want true")
-	}
-	if !msgs[0].HasOutputTokens {
-		t.Error("legacy-zero message HasOutputTokens = false, want true")
-	}
+	assert.True(t, msgs[0].HasContextTokens,
+		"legacy-zero message HasContextTokens = false, want true")
+	assert.True(t, msgs[0].HasOutputTokens,
+		"legacy-zero message HasOutputTokens = false, want true")
 }
 
 func TestOpenRepairsLegacyCurrentSchemaTokenCoverageOnce(t *testing.T) {
@@ -4892,21 +4583,17 @@ func TestOpenRepairsLegacyCurrentSchemaTokenCoverageOnce(t *testing.T) {
 	ctx := context.Background()
 	sess, err := d.GetSession(ctx, "current")
 	requireNoError(t, err, "GetSession current")
-	if sess == nil {
-		t.Fatal("current session missing")
-	}
+	require.NotNil(t, sess, "current session missing")
 	assert.True(t, sess.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
 	assert.True(t, sess.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 
 	msgs, err := d.GetMessages(ctx, "current", 0, 10, true)
 	requireNoError(t, err, "GetMessages current")
 	require.Len(t, msgs, 1, "messages len =")
-	if !msgs[0].HasContextTokens {
-		t.Error("HasContextTokens = false, want true")
-	}
-	if !msgs[0].HasOutputTokens {
-		t.Error("HasOutputTokens = false, want true")
-	}
+	assert.True(t, msgs[0].HasContextTokens,
+		"HasContextTokens = false, want true")
+	assert.True(t, msgs[0].HasOutputTokens,
+		"HasOutputTokens = false, want true")
 	_, err = d.getWriter().Exec(
 		`UPDATE sessions
 		 SET has_total_output_tokens = 0,
@@ -4934,21 +4621,17 @@ func TestOpenRepairsLegacyCurrentSchemaTokenCoverageOnce(t *testing.T) {
 
 	sess, err = d.GetSession(ctx, "current")
 	requireNoError(t, err, "GetSession current after marker")
-	if sess == nil {
-		t.Fatal("current session missing after marker")
-	}
+	require.NotNil(t, sess, "current session missing after marker")
 	assert.False(t, sess.HasTotalOutputTokens, "HasTotalOutputTokens = true after marker, want false")
 	assert.False(t, sess.HasPeakContextTokens, "HasPeakContextTokens = true after marker, want false")
 
 	msgs, err = d.GetMessages(ctx, "current", 0, 10, true)
 	requireNoError(t, err, "GetMessages current after marker")
 	require.Len(t, msgs, 1, "messages len after marker =")
-	if msgs[0].HasContextTokens {
-		t.Error("HasContextTokens = true after marker, want false")
-	}
-	if msgs[0].HasOutputTokens {
-		t.Error("HasOutputTokens = true after marker, want false")
-	}
+	assert.False(t, msgs[0].HasContextTokens,
+		"HasContextTokens = true after marker, want false")
+	assert.False(t, msgs[0].HasOutputTokens,
+		"HasOutputTokens = true after marker, want false")
 }
 
 func TestBackfillMessageTokenCoverageSkipsRowsWithoutTokenSignals(
@@ -5072,11 +4755,8 @@ func TestGetSessionForIncremental(t *testing.T) {
 			}), "upsert "+id)
 		}
 		_, ok := d.GetSessionForIncremental(path)
-		if ok {
-			t.Error(
-				"expected false for multi-session file",
-			)
-		}
+		assert.False(t, ok,
+			"expected false for multi-session file")
 	})
 
 	t.Run("legacy_false_flags_repaired", func(t *testing.T) {
@@ -5109,9 +4789,7 @@ func TestGetSessionForIncremental(t *testing.T) {
 
 		got, err := d.GetSessionFull(context.Background(), info.ID)
 		requireNoError(t, err, "GetSessionFull legacy")
-		if got == nil {
-			t.Fatal("legacy session missing after incremental")
-		}
+		require.NotNil(t, got, "legacy session missing after incremental")
 		assert.True(t, got.HasTotalOutputTokens, "stored HasTotalOutputTokens = false, want true")
 		assert.True(t, got.HasPeakContextTokens, "stored HasPeakContextTokens = false, want true")
 	})
@@ -5157,36 +4835,26 @@ func TestUpdateSessionIncremental(t *testing.T) {
 	requireNoError(t, err, "get session")
 	assert.Equal(t, 7, got.MessageCount, "MessageCount")
 	assert.Equal(t, 3, got.UserMessageCount, "UserMessageCount")
-	if got.EndedAt == nil || *got.EndedAt != ended {
-		t.Errorf("EndedAt = %v, want %q", got.EndedAt, ended)
-	}
-	if got.FileSize == nil || *got.FileSize != 2048 {
-		t.Errorf("FileSize = %v, want 2048", got.FileSize)
-	}
+	require.NotNil(t, got.EndedAt, "EndedAt nil")
+	assert.Equal(t, ended, *got.EndedAt, "EndedAt")
+	require.NotNil(t, got.FileSize, "FileSize nil")
+	assert.Equal(t, int64(2048), *got.FileSize, "FileSize")
 	assert.Equal(t, 500, got.TotalOutputTokens, "TotalOutputTokens")
 	assert.Equal(t, 1600, got.PeakContextTokens, "PeakContextTokens")
 	assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
 	assert.True(t, got.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 
 	// Verify preserved fields were NOT cleared.
-	if got.FirstMessage == nil || *got.FirstMessage != "hello" {
-		t.Errorf("FirstMessage cleared: %v", got.FirstMessage)
-	}
-	if got.Project != "my-project" {
-		t.Errorf("Project cleared: %q", got.Project)
-	}
-	if got.ParentSessionID == nil ||
-		*got.ParentSessionID != "parent-1" {
-		t.Errorf("ParentSessionID cleared: %v",
-			got.ParentSessionID)
-	}
-	if got.RelationshipType != "continuation" {
-		t.Errorf("RelationshipType cleared: %q",
-			got.RelationshipType)
-	}
-	if got.FileHash == nil || *got.FileHash != "abc123" {
-		t.Errorf("FileHash cleared: %v", got.FileHash)
-	}
+	require.NotNil(t, got.FirstMessage, "FirstMessage cleared")
+	assert.Equal(t, "hello", *got.FirstMessage, "FirstMessage")
+	assert.Equal(t, "my-project", got.Project, "Project cleared")
+	require.NotNil(t, got.ParentSessionID,
+		"ParentSessionID cleared")
+	assert.Equal(t, "parent-1", *got.ParentSessionID, "ParentSessionID")
+	assert.Equal(t, "continuation", got.RelationshipType,
+		"RelationshipType cleared")
+	require.NotNil(t, got.FileHash, "FileHash cleared")
+	assert.Equal(t, "abc123", *got.FileHash, "FileHash")
 }
 
 func TestSyncState_GetSetRoundtrip(t *testing.T) {
@@ -5223,9 +4891,8 @@ func TestListSessionsModifiedBetween(t *testing.T) {
 		{ID: "s3", Project: "p", Machine: "local", Agent: "claude", CreatedAt: "2026-03-12T12:00:00.000Z"},
 	}
 	for _, s := range sessions {
-		if err := d.UpsertSession(s); err != nil {
-			t.Fatalf("upsert %s: %v", s.ID, err)
-		}
+		require.NoError(t, d.UpsertSession(s),
+			"upsert %s", s.ID)
 	}
 
 	// Backdate created_at for deterministic test results.
@@ -5234,9 +4901,7 @@ func TestListSessionsModifiedBetween(t *testing.T) {
 			"UPDATE sessions SET created_at = ? WHERE id = ?",
 			s.CreatedAt, s.ID,
 		)
-		if err != nil {
-			t.Fatalf("backdate %s: %v", s.ID, err)
-		}
+		require.NoError(t, err, "backdate %s", s.ID)
 	}
 
 	// Query all.
@@ -5266,12 +4931,10 @@ func TestMessageContentFingerprint(t *testing.T) {
 	sess := Session{ID: "fp-sess", Project: "p", Machine: "local", Agent: "claude"}
 	err := d.UpsertSession(sess)
 	require.NoError(t, err, "upsert")
-	if err := d.InsertMessages([]Message{
+	require.NoError(t, d.InsertMessages([]Message{
 		{SessionID: "fp-sess", Ordinal: 0, Role: "user", Content: "hello", ContentLength: 5},
 		{SessionID: "fp-sess", Ordinal: 1, Role: "assistant", Content: "hi there!", ContentLength: 9},
-	}); err != nil {
-		t.Fatalf("insert: %v", err)
-	}
+	}), "insert")
 
 	sum, max, min, err := d.MessageContentFingerprint("fp-sess")
 	require.NoError(t, err, "fingerprint")
@@ -5286,13 +4949,11 @@ func TestSystemMessageFingerprint(t *testing.T) {
 	err := d.UpsertSession(sess)
 	require.NoError(t, err, "upsert")
 	// System ordinals: 0 and 2 → "0,2".
-	if err := d.InsertMessages([]Message{
+	require.NoError(t, d.InsertMessages([]Message{
 		{SessionID: "sys-fp", Ordinal: 0, Role: "user", Content: "sys", ContentLength: 3, IsSystem: true},
 		{SessionID: "sys-fp", Ordinal: 1, Role: "assistant", Content: "hi", ContentLength: 2},
 		{SessionID: "sys-fp", Ordinal: 2, Role: "user", Content: "sys2", ContentLength: 4, IsSystem: true},
-	}); err != nil {
-		t.Fatalf("insert: %v", err)
-	}
+	}), "insert")
 
 	fp, err := d.SystemMessageFingerprint("sys-fp")
 	require.NoError(t, err, "SystemMessageFingerprint")
@@ -5312,9 +4973,7 @@ func TestSystemMessageFingerprint(t *testing.T) {
 		{"fp-126", []int{1, 2, 6}, "1,2,6"},
 	} {
 		s := Session{ID: tc.id, Project: "p", Machine: "local", Agent: "claude"}
-		if err := d.UpsertSession(s); err != nil {
-			t.Fatalf("upsert %s: %v", tc.id, err)
-		}
+		require.NoError(t, d.UpsertSession(s), "upsert %s", tc.id)
 		maxOrd := 0
 		for _, o := range tc.ordinals {
 			if o > maxOrd {
@@ -5333,16 +4992,11 @@ func TestSystemMessageFingerprint(t *testing.T) {
 				IsSystem: systemSet[i],
 			}
 		}
-		if err := d.InsertMessages(msgs); err != nil {
-			t.Fatalf("insert %s: %v", tc.id, err)
-		}
+		require.NoError(t, d.InsertMessages(msgs),
+			"insert %s", tc.id)
 		got, err := d.SystemMessageFingerprint(tc.id)
-		if err != nil {
-			t.Fatalf("SystemMessageFingerprint %s: %v", tc.id, err)
-		}
-		if got != tc.want {
-			t.Errorf("%s: got %q, want %q", tc.id, got, tc.want)
-		}
+		require.NoError(t, err, "SystemMessageFingerprint %s", tc.id)
+		assert.Equal(t, tc.want, got, "%s", tc.id)
 	}
 }
 
@@ -5351,7 +5005,7 @@ func TestToolCallCountAndFingerprint(t *testing.T) {
 	sess := Session{ID: "tc-sess", Project: "p", Machine: "local", Agent: "claude"}
 	err := d.UpsertSession(sess)
 	require.NoError(t, err, "upsert")
-	if err := d.InsertMessages([]Message{
+	require.NoError(t, d.InsertMessages([]Message{
 		{
 			SessionID: "tc-sess", Ordinal: 0, Role: "assistant", Content: "tool",
 			ToolCalls: []ToolCall{
@@ -5359,9 +5013,7 @@ func TestToolCallCountAndFingerprint(t *testing.T) {
 				{ToolName: "Write", Category: "Write", ResultContentLength: 50},
 			},
 		},
-	}); err != nil {
-		t.Fatalf("insert: %v", err)
-	}
+	}), "insert")
 
 	count, err := d.ToolCallCount("tc-sess")
 	require.NoError(t, err, "count")
@@ -5382,18 +5034,15 @@ func TestListSessionsModifiedBetween_ProjectFilter(t *testing.T) {
 		{ID: "s3", Project: "gamma", Machine: "local", Agent: "claude", CreatedAt: "2026-03-10T12:00:00.000Z"},
 	}
 	for _, s := range sessions {
-		if err := d.UpsertSession(s); err != nil {
-			t.Fatalf("upsert %s: %v", s.ID, err)
-		}
+		require.NoError(t, d.UpsertSession(s),
+			"upsert %s", s.ID)
 	}
 	for _, s := range sessions {
 		_, err := d.getWriter().Exec(
 			"UPDATE sessions SET created_at = ? WHERE id = ?",
 			s.CreatedAt, s.ID,
 		)
-		if err != nil {
-			t.Fatalf("backdate %s: %v", s.ID, err)
-		}
+		require.NoError(t, err, "backdate %s", s.ID)
 	}
 
 	tests := []struct {
@@ -5438,13 +5087,11 @@ func TestListSessionsModifiedBetween_ProjectFilter(t *testing.T) {
 			for _, s := range got {
 				gotIDs = append(gotIDs, s.ID)
 			}
-			if len(gotIDs) != len(tt.wantIDs) {
-				t.Fatalf("got %v, want %v", gotIDs, tt.wantIDs)
-			}
+			require.Len(t, gotIDs, len(tt.wantIDs),
+				"got %v, want %v", gotIDs, tt.wantIDs)
 			for i, id := range tt.wantIDs {
-				if gotIDs[i] != id {
-					t.Errorf("got[%d] = %q, want %q", i, gotIDs[i], id)
-				}
+				assert.Equal(t, id, gotIDs[i],
+					"got[%d] = %q, want %q", i, gotIDs[i], id)
 			}
 		})
 	}
@@ -5460,11 +5107,8 @@ func TestSessionsHasTerminationStatusColumn(t *testing.T) {
 	).Scan(&count)
 	requireNoError(t, err, "probing termination_status column")
 
-	if count != 1 {
-		t.Fatalf(
-			"expected 1 termination_status column, got %d", count,
-		)
-	}
+	require.Equal(t, 1, count,
+		"expected 1 termination_status column, got %d", count)
 }
 
 func TestSessionsTerminationStatusIndex(t *testing.T) {
@@ -5477,12 +5121,9 @@ func TestSessionsTerminationStatusIndex(t *testing.T) {
 	).Scan(&count)
 	requireNoError(t, err, "probing idx_sessions_termination_status")
 
-	if count != 1 {
-		t.Fatalf(
-			"expected idx_sessions_termination_status to exist, got count=%d",
-			count,
-		)
-	}
+	require.Equal(t, 1, count,
+		"expected idx_sessions_termination_status to exist, got count=%d",
+		count)
 }
 
 // TestMigration_TerminationStatusColumn simulates upgrading from a
@@ -5516,17 +5157,15 @@ func TestMigration_TerminationStatusColumn(t *testing.T) {
 		 WHERE name = 'termination_status'`,
 	).Scan(&count)
 	requireNoError(t, err, "verify column removed")
-	if count != 0 {
-		t.Fatal("expected termination_status column to be absent")
-	}
+	require.Equal(t, 0, count,
+		"expected termination_status column to be absent")
 	err = conn.QueryRow(
 		`SELECT count(*) FROM sqlite_master
 		 WHERE type='index' AND name='idx_sessions_termination_status'`,
 	).Scan(&count)
 	requireNoError(t, err, "verify index removed")
-	if count != 0 {
-		t.Fatal("expected termination_status index to be absent")
-	}
+	require.Equal(t, 0, count,
+		"expected termination_status index to be absent")
 	var sessCount int
 	err = conn.QueryRow(`SELECT count(*) FROM sessions`).Scan(&sessCount)
 	requireNoError(t, err, "count sessions pre-migration")
@@ -5548,26 +5187,27 @@ func TestMigration_TerminationStatusColumn(t *testing.T) {
 		 WHERE name = 'termination_status'`,
 	).Scan(&count)
 	requireNoError(t, err, "verify column added")
-	if count != 1 {
-		t.Fatal("expected termination_status column after migration")
-	}
+	require.Equal(t, 1, count,
+		"expected termination_status column after migration")
 	err = d2.getReader().QueryRow(
 		`SELECT count(*) FROM sqlite_master
 		 WHERE type='index' AND name='idx_sessions_termination_status'`,
 	).Scan(&count)
 	requireNoError(t, err, "verify index added")
-	if count != 1 {
-		t.Fatal("expected termination_status index after migration")
-	}
+	require.Equal(t, 1, count,
+		"expected termination_status index after migration")
 
 	sessions, err := d2.ListSessions(context.Background(), SessionFilter{})
 	requireNoError(t, err, "list sessions")
-	if len(sessions.Sessions) != 1 || sessions.Sessions[0].ID != "s1" {
-		t.Fatalf("expected 1 session 's1' after migration, got %v",
-			sessions.Sessions)
-	}
+	require.Len(t, sessions.Sessions, 1,
+		"expected 1 session 's1' after migration, got %v",
+		sessions.Sessions)
+	require.Equal(t, "s1", sessions.Sessions[0].ID,
+		"expected session id 's1' after migration, got %v",
+		sessions.Sessions)
 	if sessions.Sessions[0].TerminationStatus != nil {
-		t.Errorf("expected NULL termination_status after migration, got %q",
+		assert.Failf(t, "termination_status not NULL",
+			"expected NULL termination_status after migration, got %q",
 			*sessions.Sessions[0].TerminationStatus)
 	}
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const blockingCloseDriverName = "agentsview-blocking-close"
@@ -84,13 +86,10 @@ func openBlockingCloseDB(
 	blockingCloseDriverStates.Store(dsn, state)
 
 	pool, err := sql.Open(blockingCloseDriverName, dsn)
-	if err != nil {
-		t.Fatalf("opening blocking close pool: %v", err)
-	}
+	require.NoError(t, err, "opening blocking close pool")
 	pool.SetMaxOpenConns(1)
-	if err := pool.PingContext(context.Background()); err != nil {
-		t.Fatalf("priming blocking close pool: %v", err)
-	}
+	require.NoError(t, pool.PingContext(context.Background()),
+		"priming blocking close pool")
 
 	var releaseOnce sync.Once
 	release := func() {
@@ -135,10 +134,8 @@ func requireCount(
 	page, err := d.ListSessions(
 		context.Background(), f,
 	)
-	requireNoError(t, err, "ListSessions")
-	if got := len(page.Sessions); got != want {
-		t.Errorf("got %d sessions, want %d", got, want)
-	}
+	require.NoError(t, err, "ListSessions")
+	assert.Len(t, page.Sessions, want, "session count")
 }
 
 // requireSessions lists sessions with filter and asserts the exact IDs returned.
@@ -149,7 +146,7 @@ func requireSessions(
 	page, err := d.ListSessions(
 		context.Background(), f,
 	)
-	requireNoError(t, err, "ListSessions")
+	require.NoError(t, err, "ListSessions")
 
 	gotIDs := collectIDs(page.Sessions)
 	wantSorted := make([]string, len(wantIDs))
@@ -165,12 +162,12 @@ func requireSessions(
 	}
 }
 
-// requireNoError fails the test if err is not nil.
+// requireNoError fails the test if err is not nil. Wraps testify's
+// require.NoError to preserve the legacy helper signature used throughout
+// the package.
 func requireNoError(t *testing.T, err error, msg string) {
 	t.Helper()
-	if err != nil {
-		t.Fatalf("%s: %v", msg, err)
-	}
+	require.NoError(t, err, msg)
 }
 
 // requireErrContains fails if err is nil or doesn't contain
@@ -179,13 +176,9 @@ func requireErrContains(
 	t *testing.T, err error, substr string,
 ) {
 	t.Helper()
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), substr) {
-		t.Errorf("error %q does not contain %q",
-			err.Error(), substr)
-	}
+	require.Error(t, err, "expected error, got nil")
+	assert.Contains(t, err.Error(), substr,
+		"error %q does not contain %q", err.Error(), substr)
 }
 
 const (
@@ -205,7 +198,7 @@ func testDB(t *testing.T) *DB {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.db")
 	d, err := Open(path)
-	requireNoError(t, err, "opening test db")
+	require.NoError(t, err, "opening test db")
 	t.Cleanup(func() { d.Close() })
 	return d
 }
@@ -232,9 +225,7 @@ func insertSession(
 	for _, opt := range opts {
 		opt(&s)
 	}
-	if err := d.UpsertSession(s); err != nil {
-		t.Fatalf("insertSession %s: %v", id, err)
-	}
+	require.NoError(t, d.UpsertSession(s), "insertSession %s", id)
 }
 
 // updateSignals is a helper that updates session signal columns
@@ -243,18 +234,15 @@ func updateSignals(
 	t *testing.T, d *DB, id string, u SessionSignalUpdate,
 ) {
 	t.Helper()
-	if err := d.UpdateSessionSignals(id, u); err != nil {
-		t.Fatalf("updateSignals %s: %v", id, err)
-	}
+	require.NoError(t, d.UpdateSessionSignals(id, u),
+		"updateSignals %s", id)
 }
 
 // insertMessages is a helper that inserts messages and fails
 // the test on error.
 func insertMessages(t *testing.T, d *DB, msgs ...Message) {
 	t.Helper()
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatalf("insertMessages: %v", err)
-	}
+	require.NoError(t, d.InsertMessages(msgs), "insertMessages")
 }
 
 // userMsg creates a user message with the given content.
@@ -327,12 +315,8 @@ func canceledCtx() context.Context {
 // requireCanceledErr asserts that err is context.Canceled.
 func requireCanceledErr(t *testing.T, err error) {
 	t.Helper()
-	if err == nil {
-		t.Fatal("expected error from canceled context")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got: %v", err)
-	}
+	require.ErrorIs(t, err, context.Canceled,
+		"expected context.Canceled")
 }
 
 // requireFTS skips the test if FTS is not available.
@@ -347,12 +331,8 @@ func requireFTS(t *testing.T, d *DB) {
 func requireSessionExists(t *testing.T, d *DB, id string) *Session {
 	t.Helper()
 	s, err := d.GetSession(context.Background(), id)
-	if err != nil {
-		t.Fatalf("GetSession %q: %v", id, err)
-	}
-	if s == nil {
-		t.Fatalf("session %q should exist", id)
-	}
+	require.NoError(t, err, "GetSession %q", id)
+	require.NotNil(t, s, "session %q should exist", id)
 	return s
 }
 
@@ -360,12 +340,8 @@ func requireSessionExists(t *testing.T, d *DB, id string) *Session {
 func requireSessionGone(t *testing.T, d *DB, id string) {
 	t.Helper()
 	s, err := d.GetSession(context.Background(), id)
-	if err != nil {
-		t.Fatalf("GetSession %q: %v", id, err)
-	}
-	if s != nil {
-		t.Fatalf("session %q should be gone", id)
-	}
+	require.NoError(t, err, "GetSession %q", id)
+	require.Nil(t, s, "session %q should be gone", id)
 }
 
 func TestOpenCreatesFile(t *testing.T) {
@@ -432,19 +408,13 @@ func TestOpenDataVersionBump_PreservesData(t *testing.T) {
 		SessionFilter{Limit: 100},
 	)
 	requireNoError(t, err, "list sessions")
-	if len(page.Sessions) != 1 {
-		t.Fatalf("expected 1 session preserved, got %d",
-			len(page.Sessions))
-	}
+	require.Len(t, page.Sessions, 1, "expected 1 session preserved, got")
 
 	msgs, err := d2.GetMessages(
 		context.Background(), "s1", 0, 100, true,
 	)
 	requireNoError(t, err, "get messages")
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages preserved, got %d",
-			len(msgs))
-	}
+	require.Len(t, msgs, 2, "expected 2 messages preserved, got")
 
 	// user_version must stay stale — it is only bumped
 	// after a successful ResyncAll, not at Open() time.
@@ -552,9 +522,7 @@ func TestMigration_ResultContentColumn(t *testing.T) {
 		`SELECT count(*) FROM tool_calls`,
 	).Scan(&tcCount)
 	requireNoError(t, err, "count tool_calls pre-migration")
-	if tcCount != 1 {
-		t.Fatalf("expected 1 tool_call row, got %d", tcCount)
-	}
+	require.Equal(t, 1, tcCount, "expected 1 tool_call row, got")
 	conn.Close()
 
 	// Reopen with Open() — migration should add the column.
@@ -577,28 +545,13 @@ func TestMigration_ResultContentColumn(t *testing.T) {
 		context.Background(), "s1", 0, 100, true,
 	)
 	requireNoError(t, err, "get messages")
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
-	if len(msgs[1].ToolCalls) != 1 {
-		t.Fatalf("expected 1 tool call, got %d",
-			len(msgs[1].ToolCalls))
-	}
+	require.Len(t, msgs, 2, "expected 2 messages")
+	require.Len(t, msgs[1].ToolCalls, 1, "expected 1 tool call, got")
 	tc := msgs[1].ToolCalls[0]
-	if tc.ToolName != "Read" {
-		t.Errorf("ToolName = %q, want Read", tc.ToolName)
-	}
-	if tc.ToolUseID != "tu1" {
-		t.Errorf("ToolUseID = %q, want tu1", tc.ToolUseID)
-	}
-	if tc.ResultContentLength != 42 {
-		t.Errorf("ResultContentLength = %d, want 42",
-			tc.ResultContentLength)
-	}
-	if tc.ResultContent != "" {
-		t.Errorf("ResultContent = %q, want empty (NULL)",
-			tc.ResultContent)
-	}
+	assert.Equal(t, "Read", tc.ToolName, "ToolName")
+	assert.Equal(t, "tu1", tc.ToolUseID, "ToolUseID")
+	assert.Equal(t, 42, tc.ResultContentLength, "ResultContentLength")
+	assert.Equal(t, "", tc.ResultContent, "ResultContent")
 }
 
 func TestMigration_ToolResultEventsTable(t *testing.T) {
@@ -700,22 +653,12 @@ func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 
 	msgs, err := d.GetMessages(context.Background(), "s-events", 0, 100, true)
 	requireNoError(t, err, "GetMessages")
-	if len(msgs) != 1 {
-		t.Fatalf("got %d messages, want 1", len(msgs))
-	}
-	if len(msgs[0].ToolCalls) != 1 {
-		t.Fatalf("got %d tool_calls, want 1", len(msgs[0].ToolCalls))
-	}
+	require.Len(t, msgs, 1, "len")
+	require.Len(t, msgs[0].ToolCalls, 1, "len")
 	tc := msgs[0].ToolCalls[0]
-	if len(tc.ResultEvents) != 2 {
-		t.Fatalf("got %d result events, want 2", len(tc.ResultEvents))
-	}
-	if tc.ResultEvents[0].AgentID != "agent-1" {
-		t.Errorf("result event 0 agent_id = %q, want %q", tc.ResultEvents[0].AgentID, "agent-1")
-	}
-	if tc.ResultEvents[1].Source != "subagent_notification" {
-		t.Errorf("result event 1 source = %q, want %q", tc.ResultEvents[1].Source, "subagent_notification")
-	}
+	require.Len(t, tc.ResultEvents, 2, "len")
+	assert.Equal(t, "agent-1", tc.ResultEvents[0].AgentID, "result event 0 agent_id")
+	assert.Equal(t, "subagent_notification", tc.ResultEvents[1].Source, "result event 1 source")
 }
 
 func TestOpenPreservesDataAtCurrentVersion(t *testing.T) {
@@ -748,10 +691,7 @@ func TestOpenPreservesDataAtCurrentVersion(t *testing.T) {
 		SessionFilter{Limit: 100},
 	)
 	requireNoError(t, err, "list sessions")
-	if len(page.Sessions) != 1 {
-		t.Fatalf("expected 1 session preserved, got %d",
-			len(page.Sessions))
-	}
+	require.Len(t, page.Sessions, 1, "expected 1 session preserved, got")
 }
 
 func TestOpenDoesNotDowngradeUserVersion(t *testing.T) {
@@ -876,28 +816,19 @@ func TestSessionCRUD(t *testing.T) {
 		MessageCount: 5,
 	}
 
-	if err := d.UpsertSession(s); err != nil {
-		t.Fatalf("UpsertSession: %v", err)
-	}
+	err := d.UpsertSession(s)
+	require.NoError(t, err, "UpsertSession")
 
 	got := requireSessionExists(t, d, "test-session-1")
-	if got.Project != "my_project" {
-		t.Errorf("project = %q, want %q", got.Project, "my_project")
-	}
-	if got.MessageCount != 5 {
-		t.Errorf("message_count = %d, want 5", got.MessageCount)
-	}
+	assert.Equal(t, "my_project", got.Project, "project")
+	assert.Equal(t, 5, got.MessageCount, "message_count")
 
 	// Update
 	s.MessageCount = 10
-	if err := d.UpsertSession(s); err != nil {
-		t.Fatalf("UpsertSession update: %v", err)
-	}
+	err = d.UpsertSession(s)
+	require.NoError(t, err, "UpsertSession update")
 	got = requireSessionExists(t, d, "test-session-1")
-	if got.MessageCount != 10 {
-		t.Errorf("after update: message_count = %d, want 10",
-			got.MessageCount)
-	}
+	assert.Equal(t, 10, got.MessageCount, "after update: message_count")
 
 	// Get nonexistent
 	requireSessionGone(t, d, "nonexistent")
@@ -923,10 +854,7 @@ func TestSessionParentSessionID(t *testing.T) {
 		insertSession(t, d, "child-2", "proj")
 
 		got := requireSessionExists(t, d, "child-2")
-		if got.ParentSessionID != nil {
-			t.Errorf("parent_session_id = %v, want nil",
-				got.ParentSessionID)
-		}
+		assert.Nil(t, got.ParentSessionID, "parent_session_id")
 	})
 
 	t.Run("ParentInListSessions", func(t *testing.T) {
@@ -948,9 +876,7 @@ func TestSessionParentSessionID(t *testing.T) {
 				}
 			}
 		}
-		if !found {
-			t.Error("child-1 not found in list")
-		}
+		assert.True(t, found, "child-1 not found in list")
 	})
 
 	t.Run("ParentInGetSessionFull", func(t *testing.T) {
@@ -1022,9 +948,7 @@ func TestGetChildSessions(t *testing.T) {
 			context.Background(), "parent-1",
 		)
 		requireNoError(t, err, "GetChildSessions")
-		if len(children) != 3 {
-			t.Fatalf("expected 3 visible children, got %d", len(children))
-		}
+		require.Len(t, children, 3, "expected 3 visible children")
 		// Ordered by started_at ascending.
 		wantIDs := []string{"child-sub", "child-cont", "child-fork"}
 		for i, want := range wantIDs {
@@ -1040,9 +964,7 @@ func TestGetChildSessions(t *testing.T) {
 			context.Background(), "unrelated",
 		)
 		requireNoError(t, err, "GetChildSessions")
-		if len(children) != 0 {
-			t.Fatalf("expected 0 children, got %d", len(children))
-		}
+		require.Len(t, children, 0, "expected 0 children")
 	})
 
 	t.Run("NonexistentParent", func(t *testing.T) {
@@ -1050,9 +972,7 @@ func TestGetChildSessions(t *testing.T) {
 			context.Background(), "no-such-parent",
 		)
 		requireNoError(t, err, "GetChildSessions")
-		if len(children) != 0 {
-			t.Fatalf("expected 0 children, got %d", len(children))
-		}
+		require.Len(t, children, 0, "expected 0 children")
 	})
 
 	t.Run("CanceledContext", func(t *testing.T) {
@@ -1083,9 +1003,7 @@ func TestListSessions(t *testing.T) {
 		context.Background(), SessionFilter{Limit: 2},
 	)
 	requireNoError(t, err, "ListSessions limit")
-	if len(page.Sessions) != 2 {
-		t.Errorf("got %d sessions, want 2", len(page.Sessions))
-	}
+	assert.Len(t, page.Sessions, 2, "len")
 	if page.NextCursor == "" {
 		t.Error("expected next cursor")
 	}
@@ -1140,9 +1058,7 @@ func TestListSessionsPaginationNoDuplicates(t *testing.T) {
 		}
 		cursor = page.NextCursor
 	}
-	if len(seen) != 5 {
-		t.Errorf("saw %d sessions, want 5", len(seen))
-	}
+	assert.Len(t, seen, 5, "saw")
 }
 
 func TestListSessionsPaginationEmptyTimestamps(t *testing.T) {
@@ -1173,9 +1089,7 @@ func TestListSessionsPaginationEmptyTimestamps(t *testing.T) {
 			context.Background(),
 			SessionFilter{Limit: 1, Cursor: cursor},
 		)
-		if err != nil {
-			t.Fatalf("ListSessions: %v", err)
-		}
+		require.NoError(t, err, "ListSessions")
 		for _, s := range page.Sessions {
 			if seen[s.ID] {
 				t.Errorf("duplicate session %s", s.ID)
@@ -1187,9 +1101,7 @@ func TestListSessionsPaginationEmptyTimestamps(t *testing.T) {
 		}
 		cursor = page.NextCursor
 	}
-	if len(seen) != 4 {
-		t.Errorf("saw %d sessions, want 4", len(seen))
-	}
+	assert.Len(t, seen, 4, "saw")
 }
 
 func TestListSessionsProjectFilter(t *testing.T) {
@@ -1232,9 +1144,7 @@ func TestListSessionsMachineMultiSelect(t *testing.T) {
 		},
 	)
 	requireNoError(t, err, "ListSessions")
-	if page.Total != 2 {
-		t.Fatalf("total = %d, want 2", page.Total)
-	}
+	require.Equal(t, 2, page.Total, "total")
 
 	got := map[string]bool{}
 	for _, session := range page.Sessions {
@@ -1267,9 +1177,7 @@ func TestMessageCRUD(t *testing.T) {
 
 	got, err := d.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
-	if len(got) != 4 {
-		t.Fatalf("got %d messages, want 4", len(got))
-	}
+	require.Len(t, got, 4, "len")
 	if got[0].Content != "Hello" {
 		t.Errorf("first message = %q", got[0].Content)
 	}
@@ -1280,22 +1188,14 @@ func TestMessageCRUD(t *testing.T) {
 	// Paginated
 	got, err = d.GetMessages(context.Background(), "s1", 1, 2, true)
 	requireNoError(t, err, "GetMessages")
-	if len(got) != 2 {
-		t.Fatalf("got %d messages, want 2", len(got))
-	}
-	if got[0].Ordinal != 1 {
-		t.Errorf("first ordinal = %d, want 1", got[0].Ordinal)
-	}
+	require.Len(t, got, 2, "len")
+	assert.Equal(t, 1, got[0].Ordinal, "first ordinal")
 
 	// Descending
 	got, err = d.GetMessages(context.Background(), "s1", 2, 10, false)
 	requireNoError(t, err, "GetMessages desc")
-	if len(got) != 3 {
-		t.Fatalf("got %d, want 3", len(got))
-	}
-	if got[0].Ordinal != 2 {
-		t.Errorf("desc first ordinal = %d, want 2", got[0].Ordinal)
-	}
+	require.Len(t, got, 3, "len")
+	assert.Equal(t, 2, got[0].Ordinal, "desc first ordinal")
 }
 
 func TestReplaceSessionMessages(t *testing.T) {
@@ -1313,12 +1213,8 @@ func TestReplaceSessionMessages(t *testing.T) {
 	}
 
 	got, _ := d.GetAllMessages(context.Background(), "s1")
-	if len(got) != 2 {
-		t.Fatalf("got %d messages, want 2", len(got))
-	}
-	if got[0].Content != "new1" {
-		t.Errorf("content = %q, want %q", got[0].Content, "new1")
-	}
+	require.Len(t, got, 2, "len")
+	assert.Equal(t, "new1", got[0].Content, "content")
 }
 
 // TestReplaceSessionMessagesPreservesPins verifies that pinned
@@ -1337,9 +1233,7 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 	)
 
 	msgs, err := d.GetAllMessages(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetAllMessages: %v", err)
-	}
+	require.NoError(t, err, "GetAllMessages")
 
 	// Pin ordinal-0 with a note and ordinal-2 with no note.
 	note := "important"
@@ -1352,9 +1246,7 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 
 	// Record created_at before replace so we can verify it is preserved.
 	prePins, err := d.ListPinnedMessages(ctx, "s1", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages before replace: %v", err)
-	}
+	require.NoError(t, err, "ListPinnedMessages before replace")
 	pinCreatedAt := make(map[int]string) // ordinal → created_at
 	for _, p := range prePins {
 		pinCreatedAt[p.Ordinal] = p.CreatedAt
@@ -1371,20 +1263,12 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 	}
 
 	newMsgs, err := d.GetAllMessages(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetAllMessages after replace: %v", err)
-	}
-	if len(newMsgs) != 3 {
-		t.Fatalf("want 3 messages after replace, got %d", len(newMsgs))
-	}
+	require.NoError(t, err, "GetAllMessages after replace")
+	require.Len(t, newMsgs, 3, "want 3 messages after replace")
 
 	pins, err := d.ListPinnedMessages(ctx, "s1", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages: %v", err)
-	}
-	if len(pins) != 2 {
-		t.Fatalf("want 2 pins after replace, got %d", len(pins))
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 2, "want 2 pins after replace")
 
 	byOrdinal := make(map[int]PinnedMessage)
 	for _, p := range pins {
@@ -1393,37 +1277,19 @@ func TestReplaceSessionMessagesPreservesPins(t *testing.T) {
 
 	// Ordinal-0: note preserved, message_id updated, created_at preserved.
 	p0, ok := byOrdinal[0]
-	if !ok {
-		t.Fatal("pin for ordinal 0 missing after replace")
-	}
-	if p0.MessageID != newMsgs[0].ID {
-		t.Errorf("ord=0 pin message_id = %d, want %d",
-			p0.MessageID, newMsgs[0].ID)
-	}
+	require.True(t, ok, "pin for ordinal 0 missing after replace")
+	assert.Equal(t, newMsgs[0].ID, p0.MessageID, "ord=0 pin message_id")
 	if p0.Note == nil || *p0.Note != note {
 		t.Errorf("ord=0 pin note = %v, want %q", p0.Note, note)
 	}
-	if p0.CreatedAt != pinCreatedAt[0] {
-		t.Errorf("ord=0 pin created_at = %q, want %q",
-			p0.CreatedAt, pinCreatedAt[0])
-	}
+	assert.Equal(t, pinCreatedAt[0], p0.CreatedAt, "ord=0 pin created_at")
 
 	// Ordinal-2: nil note preserved, message_id updated.
 	p2, ok := byOrdinal[2]
-	if !ok {
-		t.Fatal("pin for ordinal 2 missing after replace")
-	}
-	if p2.MessageID != newMsgs[2].ID {
-		t.Errorf("ord=2 pin message_id = %d, want %d",
-			p2.MessageID, newMsgs[2].ID)
-	}
-	if p2.Note != nil {
-		t.Errorf("ord=2 pin note = %v, want nil", p2.Note)
-	}
-	if p2.CreatedAt != pinCreatedAt[2] {
-		t.Errorf("ord=2 pin created_at = %q, want %q",
-			p2.CreatedAt, pinCreatedAt[2])
-	}
+	require.True(t, ok, "pin for ordinal 2 missing after replace")
+	assert.Equal(t, newMsgs[2].ID, p2.MessageID, "ord=2 pin message_id")
+	assert.Nil(t, p2.Note, "ord=2 pin note")
+	assert.Equal(t, pinCreatedAt[2], p2.CreatedAt, "ord=2 pin created_at")
 }
 
 // TestReplaceSessionMessagesDropsPinsForRemovedOrdinals verifies that
@@ -1440,9 +1306,7 @@ func TestReplaceSessionMessagesDropsPinsForRemovedOrdinals(t *testing.T) {
 	)
 
 	msgs, err := d.GetAllMessages(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetAllMessages: %v", err)
-	}
+	require.NoError(t, err, "GetAllMessages")
 	// Pin both messages.
 	for _, m := range msgs {
 		if _, err := d.PinMessage("s1", m.ID, nil); err != nil {
@@ -1458,18 +1322,10 @@ func TestReplaceSessionMessagesDropsPinsForRemovedOrdinals(t *testing.T) {
 	}
 
 	pins, err := d.ListPinnedMessages(ctx, "s1", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages: %v", err)
-	}
-	if len(pins) != 1 {
-		t.Fatalf("want 1 pin (ordinal-1 dropped), got %d", len(pins))
-	}
-	if pins[0].Ordinal != 0 {
-		t.Errorf("surviving pin ordinal = %d, want 0", pins[0].Ordinal)
-	}
-	if pins[0].Note != nil {
-		t.Errorf("surviving pin note = %v, want nil", pins[0].Note)
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 1, "want 1 pin (ordinal-1 dropped)")
+	assert.Equal(t, 0, pins[0].Ordinal, "surviving pin ordinal")
+	assert.Nil(t, pins[0].Note, "surviving pin note")
 }
 
 // TestReplaceSessionMessagesPinSourceUUIDFollowsRow verifies that a
@@ -1496,9 +1352,7 @@ func TestReplaceSessionMessagesPinSourceUUIDFollowsRow(t *testing.T) {
 	)
 
 	msgs, err := d.GetAllMessages(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetAllMessages: %v", err)
-	}
+	require.NoError(t, err, "GetAllMessages")
 	note := "important"
 	if _, err := d.PinMessage("s1", msgs[1].ID, &note); err != nil {
 		t.Fatalf("PinMessage: %v", err)
@@ -1529,12 +1383,8 @@ func TestReplaceSessionMessagesPinSourceUUIDFollowsRow(t *testing.T) {
 	}
 
 	pins, err := d.ListPinnedMessages(ctx, "s1", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages: %v", err)
-	}
-	if len(pins) != 1 {
-		t.Fatalf("want 1 pin, got %d", len(pins))
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 1, "want 1 pin")
 	if pins[0].Ordinal != 2 {
 		t.Errorf(
 			"pin ordinal = %d, want 2 (followed source_uuid)",
@@ -1561,9 +1411,7 @@ func TestReplaceSessionMessagesPinFallsBackToOrdinal(t *testing.T) {
 	)
 
 	msgs, err := d.GetAllMessages(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetAllMessages: %v", err)
-	}
+	require.NoError(t, err, "GetAllMessages")
 	if _, err := d.PinMessage("s1", msgs[1].ID, nil); err != nil {
 		t.Fatalf("PinMessage: %v", err)
 	}
@@ -1577,15 +1425,9 @@ func TestReplaceSessionMessagesPinFallsBackToOrdinal(t *testing.T) {
 	}
 
 	pins, err := d.ListPinnedMessages(ctx, "s1", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages: %v", err)
-	}
-	if len(pins) != 1 {
-		t.Fatalf("want 1 pin, got %d", len(pins))
-	}
-	if pins[0].Ordinal != 1 {
-		t.Errorf("pin ordinal = %d, want 1", pins[0].Ordinal)
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 1, "want 1 pin")
+	assert.Equal(t, 1, pins[0].Ordinal, "pin ordinal")
 }
 
 func TestGetSessionFilePath(t *testing.T) {
@@ -1597,16 +1439,11 @@ func TestGetSessionFilePath(t *testing.T) {
 	})
 
 	got := d.GetSessionFilePath("zencoder:abc")
-	if got != fp {
-		t.Errorf("GetSessionFilePath = %q, want %q", got, fp)
-	}
+	assert.Equal(t, fp, got, "GetSessionFilePath")
 
 	// Non-existent session returns empty.
 	got = d.GetSessionFilePath("zencoder:nonexistent")
-	if got != "" {
-		t.Errorf("GetSessionFilePath(missing) = %q, want empty",
-			got)
-	}
+	assert.Equal(t, "", got, "GetSessionFilePath(missing)")
 }
 
 func TestLinkSubagentSessionsOverridesContinuation(t *testing.T) {
@@ -1639,16 +1476,12 @@ func TestLinkSubagentSessionsOverridesContinuation(t *testing.T) {
 	insertMessages(t, d, m)
 
 	// Link should override continuation -> subagent.
-	if err := d.LinkSubagentSessions(); err != nil {
-		t.Fatalf("LinkSubagentSessions: %v", err)
-	}
+	err := d.LinkSubagentSessions()
+	require.NoError(t, err, "LinkSubagentSessions")
 
 	sess, err := d.GetSession(context.Background(), "child")
 	requireNoError(t, err, "GetSession")
-	if sess.RelationshipType != "subagent" {
-		t.Errorf("relationship_type = %q, want 'subagent'",
-			sess.RelationshipType)
-	}
+	assert.Equal(t, "subagent", sess.RelationshipType, "relationship_type")
 	if sess.ParentSessionID == nil ||
 		*sess.ParentSessionID != "parent" {
 		t.Errorf("parent_session_id = %v, want 'parent'",
@@ -1671,9 +1504,7 @@ func TestIsSystemPersisted(t *testing.T) {
 
 	msgs, err := d.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
-	if len(msgs) != 2 {
-		t.Fatalf("got %d messages, want 2", len(msgs))
-	}
+	require.Len(t, msgs, 2, "len")
 	if msgs[0].IsSystem {
 		t.Error("msgs[0].IsSystem = true, want false")
 	}
@@ -1701,9 +1532,7 @@ func TestSearchBasic(t *testing.T) {
 		Limit: 10,
 	})
 	requireNoError(t, err, "Search")
-	if len(page.Results) != 1 {
-		t.Fatalf("got %d results, want 1", len(page.Results))
-	}
+	require.Len(t, page.Results, 1, "len")
 	if page.Results[0].SessionID != "s1" {
 		t.Errorf("session_id = %q", page.Results[0].SessionID)
 	}
@@ -1730,13 +1559,8 @@ func TestSearchExcludesSystemMessages(t *testing.T) {
 	})
 	requireNoError(t, err, "Search")
 	// Only the non-system message should appear
-	if len(page.Results) != 1 {
-		t.Fatalf("got %d results, want 1 (system msg excluded)",
-			len(page.Results))
-	}
-	if page.Results[0].Ordinal != 0 {
-		t.Errorf("ordinal = %d, want 0", page.Results[0].Ordinal)
-	}
+	require.Len(t, page.Results, 1, "got")
+	assert.Equal(t, 0, page.Results[0].Ordinal, "ordinal")
 }
 
 func TestCanceledContext(t *testing.T) {
@@ -1814,18 +1638,10 @@ func TestStats(t *testing.T) {
 
 	stats, err = d.GetStats(context.Background(), false, false)
 	requireNoError(t, err, "GetStats")
-	if stats.SessionCount != 2 {
-		t.Errorf("session_count = %d, want 2", stats.SessionCount)
-	}
-	if stats.MessageCount != 2 {
-		t.Errorf("message_count = %d, want 2", stats.MessageCount)
-	}
-	if stats.ProjectCount != 2 {
-		t.Errorf("project_count = %d, want 2", stats.ProjectCount)
-	}
-	if stats.MachineCount != 2 {
-		t.Errorf("machine_count = %d, want 2", stats.MachineCount)
-	}
+	assert.Equal(t, 2, stats.SessionCount, "session_count")
+	assert.Equal(t, 2, stats.MessageCount, "message_count")
+	assert.Equal(t, 2, stats.ProjectCount, "project_count")
+	assert.Equal(t, 2, stats.MachineCount, "machine_count")
 	if stats.EarliestSession == nil {
 		t.Fatal("earliest_session is nil, want non-nil")
 	}
@@ -1908,9 +1724,7 @@ func TestGetProjects(t *testing.T) {
 
 	projects, err := d.GetProjects(context.Background(), false, false)
 	requireNoError(t, err, "GetProjects")
-	if len(projects) != 2 {
-		t.Fatalf("got %d projects, want 2", len(projects))
-	}
+	require.Len(t, projects, 2, "len")
 	if projects[0].Name != "alpha" || projects[0].SessionCount != 2 {
 		t.Errorf("alpha: %+v", projects[0])
 	}
@@ -2049,9 +1863,7 @@ func TestFindPruneCandidates(t *testing.T) {
 			Before: "2024-02-01",
 		})
 		requireNoError(t, err, "FindPruneCandidates")
-		if len(got) != 1 {
-			t.Fatalf("got %d, want 1", len(got))
-		}
+		require.Len(t, got, 1, "len")
 		if got[0].ID != "s1" {
 			t.Errorf("got ID %q, want s1", got[0].ID)
 		}
@@ -2068,9 +1880,7 @@ func TestFindPruneCandidates(t *testing.T) {
 			Project: "test",
 		})
 		requireNoError(t, err, "FindPruneCandidates")
-		if len(got) != 1 {
-			t.Fatalf("got %d, want 1", len(got))
-		}
+		require.Len(t, got, 1, "len")
 		if got[0].FilePath == nil || *got[0].FilePath != fp {
 			t.Errorf("file_path = %v, want %q", got[0].FilePath, fp)
 		}
@@ -2246,18 +2056,14 @@ func TestFindPruneCandidatesMaxMessagesSentinel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := d.FindPruneCandidates(tt.filter)
 			requireNoError(t, err, "FindPruneCandidates")
-			if len(got) != tt.want {
-				t.Errorf("got %d, want %d", len(got), tt.want)
-			}
+			assert.Len(t, got, tt.want, "got")
 		})
 	}
 
 	// Additional check: MaxMessages=0 returns m1 specifically.
 	got, err := d.FindPruneCandidates(PruneFilter{MaxMessages: new(0)})
 	requireNoError(t, err, "FindPruneCandidates MaxMessages=0")
-	if len(got) != 1 {
-		t.Fatalf("MaxMessages 0: got %d results, want 1", len(got))
-	}
+	require.Len(t, got, 1, "MaxMessages 0:")
 	if got[0].ID != "m1" {
 		t.Errorf("MaxMessages 0: got %q, want m1", got[0].ID)
 	}
@@ -2282,9 +2088,7 @@ func TestFindPruneCandidatesIgnoresSystemMessages(t *testing.T) {
 		PruneFilter{MaxMessages: new(1)},
 	)
 	requireNoError(t, err, "FindPruneCandidates")
-	if len(got) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(got))
-	}
+	require.Len(t, got, 1, "expected 1 result")
 	if got[0].ID != "zen1" {
 		t.Errorf("got %q, want zen1", got[0].ID)
 	}
@@ -2295,9 +2099,7 @@ func TestFindPruneCandidatesIgnoresSystemMessages(t *testing.T) {
 		PruneFilter{MaxMessages: new(0)},
 	)
 	requireNoError(t, err, "FindPruneCandidates")
-	if len(got) != 0 {
-		t.Fatalf("expected 0 results, got %d", len(got))
-	}
+	require.Len(t, got, 0, "expected 0 results")
 }
 
 func TestDeleteSessions(t *testing.T) {
@@ -2309,39 +2111,25 @@ func TestDeleteSessions(t *testing.T) {
 	}
 
 	stats, _ := d.GetStats(context.Background(), false, false)
-	if stats.SessionCount != 3 {
-		t.Fatalf("initial sessions = %d, want 3", stats.SessionCount)
-	}
-	if stats.MessageCount != 3 {
-		t.Fatalf("initial messages = %d, want 3", stats.MessageCount)
-	}
+	require.Equal(t, 3, stats.SessionCount, "initial sessions")
+	require.Equal(t, 3, stats.MessageCount, "initial messages")
 
 	deleted, err := d.DeleteSessions([]string{"s1", "s3"})
 	requireNoError(t, err, "DeleteSessions")
-	if deleted != 2 {
-		t.Errorf("deleted = %d, want 2", deleted)
-	}
+	assert.Equal(t, 2, deleted, "deleted")
 
 	requireSessionGone(t, d, "s1")
 	requireSessionExists(t, d, "s2")
 	requireSessionGone(t, d, "s3")
 
 	msgs, _ := d.GetAllMessages(context.Background(), "s1")
-	if len(msgs) != 0 {
-		t.Errorf("s1 messages = %d, want 0", len(msgs))
-	}
+	assert.Equal(t, 0, len(msgs), "s1 messages")
 	msgs, _ = d.GetAllMessages(context.Background(), "s2")
-	if len(msgs) != 1 {
-		t.Errorf("s2 messages = %d, want 1", len(msgs))
-	}
+	assert.Equal(t, 1, len(msgs), "s2 messages")
 
 	stats, _ = d.GetStats(context.Background(), false, false)
-	if stats.SessionCount != 1 {
-		t.Errorf("session_count = %d, want 1", stats.SessionCount)
-	}
-	if stats.MessageCount != 1 {
-		t.Errorf("message_count = %d, want 1", stats.MessageCount)
-	}
+	assert.Equal(t, 1, stats.SessionCount, "session_count")
+	assert.Equal(t, 1, stats.MessageCount, "message_count")
 
 	// Deleted sessions must be excluded.
 	if !d.IsSessionExcluded("s1") {
@@ -2356,9 +2144,7 @@ func TestDeleteSessions(t *testing.T) {
 
 	deleted, err = d.DeleteSessions(nil)
 	requireNoError(t, err, "DeleteSessions empty")
-	if deleted != 0 {
-		t.Errorf("deleted empty = %d, want 0", deleted)
-	}
+	assert.Equal(t, 0, deleted, "deleted empty")
 }
 
 func TestDeleteSessionNonExistentNoGhostExclusion(t *testing.T) {
@@ -2378,9 +2164,7 @@ func TestDeleteSessionsMixedBatchNoGhostExclusion(t *testing.T) {
 
 	deleted, err := d.DeleteSessions([]string{"real", "bogus"})
 	requireNoError(t, err, "DeleteSessions mixed")
-	if deleted != 1 {
-		t.Errorf("deleted = %d, want 1", deleted)
-	}
+	assert.Equal(t, 1, deleted, "deleted")
 	if !d.IsSessionExcluded("real") {
 		t.Error("real should be excluded after bulk delete")
 	}
@@ -2399,20 +2183,12 @@ func TestSessionFileInfo(t *testing.T) {
 	})
 
 	gotSize, gotMtime, ok := d.GetSessionFileInfo("s1")
-	if !ok {
-		t.Fatal("expected ok")
-	}
-	if gotSize != 1024 {
-		t.Errorf("got size=%d, want 1024", gotSize)
-	}
-	if gotMtime != 1700000000 {
-		t.Errorf("got mtime=%d, want 1700000000", gotMtime)
-	}
+	require.True(t, ok, "expected ok")
+	assert.Equal(t, int64(1024), gotSize, "got size=")
+	assert.Equal(t, int64(1700000000), gotMtime, "got mtime=")
 
 	_, _, ok = d.GetSessionFileInfo("nonexistent")
-	if ok {
-		t.Error("expected !ok for nonexistent")
-	}
+	assert.False(t, ok, "expected !ok for nonexistent")
 }
 
 func TestGetSessionFull(t *testing.T) {
@@ -2513,9 +2289,7 @@ func TestCursorEncodeDecode(t *testing.T) {
 	)
 	cur, err = d.DecodeCursor(encodedWithTotal)
 	requireNoError(t, err, "DecodeCursor with total")
-	if cur.Total != 123 {
-		t.Errorf("Total = %d, want 123", cur.Total)
-	}
+	assert.Equal(t, 123, cur.Total, "Total")
 }
 
 func TestCursorTampering(t *testing.T) {
@@ -2524,9 +2298,7 @@ func TestCursorTampering(t *testing.T) {
 	original := d.EncodeCursor(tsZero, "s1", 100)
 
 	parts := strings.Split(original, ".")
-	if len(parts) != 2 {
-		t.Fatalf("expected 2 parts (payload.sig), got %d", len(parts))
-	}
+	require.Len(t, parts, 2, "expected 2 parts (payload.sig)")
 
 	payload := parts[0]
 	sig := parts[1]
@@ -2535,9 +2307,8 @@ func TestCursorTampering(t *testing.T) {
 	data, err := base64.RawURLEncoding.DecodeString(payload)
 	requireNoError(t, err, "DecodeString payload")
 	var c SessionCursor
-	if err := json.Unmarshal(data, &c); err != nil {
-		t.Fatalf("Unmarshal payload: %v", err)
-	}
+	err = json.Unmarshal(data, &c)
+	require.NoError(t, err, "Unmarshal payload")
 	c.Total = 999
 	tamperedData, err := json.Marshal(c)
 	requireNoError(t, err, "Marshal tampered")
@@ -2573,13 +2344,9 @@ func TestLegacyCursor(t *testing.T) {
 	requireNoError(t, err, "DecodeCursor legacy")
 
 	// Verify ID/EndedAt are preserved
-	if got.ID != "s1" {
-		t.Errorf("ID = %q, want s1", got.ID)
-	}
+	assert.Equal(t, "s1", got.ID, "ID")
 	// Verify Total is ZEROED out
-	if got.Total != 0 {
-		t.Errorf("Total = %d, want 0 (untrusted legacy)", got.Total)
-	}
+	assert.Equal(t, 0, got.Total, "Total")
 }
 
 func TestCursorSecretConcurrency(t *testing.T) {
@@ -2657,17 +2424,13 @@ func TestDeleteSession(t *testing.T) {
 	insertSession(t, d, "s1", "p")
 	insertMessages(t, d, userMsg("s1", 0, "test"))
 
-	if err := d.DeleteSession("s1"); err != nil {
-		t.Fatalf("DeleteSession: %v", err)
-	}
+	err := d.DeleteSession("s1")
+	require.NoError(t, err, "DeleteSession")
 
 	requireSessionGone(t, d, "s1")
 
 	msgs, _ := d.GetAllMessages(context.Background(), "s1")
-	if len(msgs) != 0 {
-		t.Errorf("expected 0 messages after cascade, got %d",
-			len(msgs))
-	}
+	assert.Len(t, msgs, 0, "expected 0 messages after cascade, got")
 }
 
 func TestMigrationRace(t *testing.T) {
@@ -2789,13 +2552,10 @@ func TestToolCallsInsertedWithMessages(t *testing.T) {
 		}
 		calls = append(calls, tc)
 	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("rows.Err: %v", err)
-	}
+	err = rows.Err()
+	require.NoError(t, err, "rows.Err")
 
-	if len(calls) != 2 {
-		t.Fatalf("got %d tool_calls, want 2", len(calls))
-	}
+	require.Len(t, calls, 2, "len")
 	if calls[0].ToolName != "Read" || calls[0].Category != "Read" {
 		t.Errorf("calls[0] = %+v", calls[0])
 	}
@@ -2805,9 +2565,7 @@ func TestToolCallsInsertedWithMessages(t *testing.T) {
 	if calls[0].MessageID == 0 {
 		t.Error("message_id should be non-zero")
 	}
-	if calls[0].SessionID != "s1" {
-		t.Errorf("session_id = %q, want s1", calls[0].SessionID)
-	}
+	assert.Equal(t, "s1", calls[0].SessionID, "session_id")
 }
 
 func TestToolCallsCascadeOnSessionDelete(t *testing.T) {
@@ -2822,9 +2580,8 @@ func TestToolCallsCascadeOnSessionDelete(t *testing.T) {
 	}
 	insertMessages(t, d, m)
 
-	if err := d.DeleteSession("s1"); err != nil {
-		t.Fatalf("DeleteSession: %v", err)
-	}
+	err := d.DeleteSession("s1")
+	require.NoError(t, err, "DeleteSession")
 
 	var count int
 	if err := d.Reader().QueryRow(
@@ -2833,9 +2590,7 @@ func TestToolCallsCascadeOnSessionDelete(t *testing.T) {
 	).Scan(&count); err != nil {
 		t.Fatalf("count tool_calls: %v", err)
 	}
-	if count != 0 {
-		t.Errorf("tool_calls count = %d, want 0", count)
-	}
+	assert.Equal(t, 0, count, "tool_calls count")
 }
 
 func TestReplaceSessionMessagesReplacesToolCalls(t *testing.T) {
@@ -2857,9 +2612,8 @@ func TestReplaceSessionMessagesReplacesToolCalls(t *testing.T) {
 		{SessionID: "s1", ToolName: "Bash", Category: "Bash"},
 		{SessionID: "s1", ToolName: "Write", Category: "Write"},
 	}
-	if err := d.ReplaceSessionMessages("s1", []Message{m2}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	err := d.ReplaceSessionMessages("s1", []Message{m2})
+	require.NoError(t, err, "ReplaceSessionMessages")
 
 	var names []string
 	rows, err := d.Reader().Query(
@@ -2869,24 +2623,16 @@ func TestReplaceSessionMessagesReplacesToolCalls(t *testing.T) {
 	defer rows.Close()
 	for rows.Next() {
 		var name string
-		if err := rows.Scan(&name); err != nil {
-			t.Fatalf("scan: %v", err)
-		}
+		err := rows.Scan(&name)
+		require.NoError(t, err, "scan")
 		names = append(names, name)
 	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("rows.Err: %v", err)
-	}
+	err = rows.Err()
+	require.NoError(t, err, "rows.Err")
 
-	if len(names) != 2 {
-		t.Fatalf("got %d tool_calls, want 2", len(names))
-	}
-	if names[0] != "Bash" {
-		t.Errorf("names[0] = %q, want Bash", names[0])
-	}
-	if names[1] != "Write" {
-		t.Errorf("names[1] = %q, want Write", names[1])
-	}
+	require.Len(t, names, 2, "len")
+	assert.Equal(t, "Bash", names[0], "names[0]")
+	assert.Equal(t, "Write", names[1], "names[1]")
 }
 
 func TestReplaceSessionMessagesReplacesToolResultEvents(t *testing.T) {
@@ -2934,28 +2680,17 @@ func TestReplaceSessionMessagesReplacesToolResultEvents(t *testing.T) {
 			EventIndex:    0,
 		}},
 	}}
-	if err := d.ReplaceSessionMessages("s1", []Message{m2}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	err := d.ReplaceSessionMessages("s1", []Message{m2})
+	require.NoError(t, err, "ReplaceSessionMessages")
 
 	msgs, err := d.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
-	if len(msgs) != 1 {
-		t.Fatalf("messages len = %d, want 1", len(msgs))
-	}
-	if len(msgs[0].ToolCalls) != 1 {
-		t.Fatalf("tool calls len = %d, want 1", len(msgs[0].ToolCalls))
-	}
+	require.Len(t, msgs, 1, "messages len =")
+	require.Len(t, msgs[0].ToolCalls, 1, "tool calls len =")
 	tc := msgs[0].ToolCalls[0]
-	if tc.ResultContent != "new result" {
-		t.Fatalf("result_content = %q, want %q", tc.ResultContent, "new result")
-	}
-	if len(tc.ResultEvents) != 1 {
-		t.Fatalf("result events len = %d, want 1", len(tc.ResultEvents))
-	}
-	if tc.ResultEvents[0].Content != "new result" {
-		t.Fatalf("event content = %q, want %q", tc.ResultEvents[0].Content, "new result")
-	}
+	require.Equal(t, "new result", tc.ResultContent, "result_content")
+	require.Len(t, tc.ResultEvents, 1, "result events len =")
+	require.Equal(t, "new result", tc.ResultEvents[0].Content, "event content")
 
 	var count int
 	err = d.Reader().QueryRow(
@@ -2963,9 +2698,7 @@ func TestReplaceSessionMessagesReplacesToolResultEvents(t *testing.T) {
 		"s1",
 	).Scan(&count)
 	requireNoError(t, err, "count tool_result_events")
-	if count != 1 {
-		t.Fatalf("tool_result_events count = %d, want 1", count)
-	}
+	require.Equal(t, 1, count, "tool_result_events count")
 }
 
 func TestToolCallsNoToolCalls(t *testing.T) {
@@ -2981,9 +2714,7 @@ func TestToolCallsNoToolCalls(t *testing.T) {
 	).Scan(&count); err != nil {
 		t.Fatalf("count: %v", err)
 	}
-	if count != 0 {
-		t.Errorf("tool_calls count = %d, want 0", count)
-	}
+	assert.Equal(t, 0, count, "tool_calls count")
 }
 
 func TestToolCallsMixedSessionsOverlappingOrdinals(t *testing.T) {
@@ -3029,13 +2760,10 @@ func TestToolCallsMixedSessionsOverlappingOrdinals(t *testing.T) {
 		}
 		got = append(got, r)
 	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("rows.Err: %v", err)
-	}
+	err = rows.Err()
+	require.NoError(t, err, "rows.Err")
 
-	if len(got) != 2 {
-		t.Fatalf("got %d tool_calls, want 2", len(got))
-	}
+	require.Len(t, got, 2, "len")
 	// Bash should be linked to s2
 	if got[0].toolName != "Bash" ||
 		got[0].tcSession != "s2" ||
@@ -3164,13 +2892,8 @@ func TestGetMessagesReturnsToolCalls(t *testing.T) {
 		context.Background(), "s1", 0, 100, true,
 	)
 	requireNoError(t, err, "GetMessages")
-	if len(msgs) != 1 {
-		t.Fatalf("got %d messages, want 1", len(msgs))
-	}
-	if len(msgs[0].ToolCalls) != 1 {
-		t.Fatalf("got %d tool_calls, want 1",
-			len(msgs[0].ToolCalls))
-	}
+	require.Len(t, msgs, 1, "len")
+	require.Len(t, msgs[0].ToolCalls, 1, "got")
 	tc := msgs[0].ToolCalls[0]
 	if tc.ToolName != "Skill" {
 		t.Errorf("ToolName = %q", tc.ToolName)
@@ -3181,9 +2904,7 @@ func TestGetMessagesReturnsToolCalls(t *testing.T) {
 	if tc.InputJSON != `{"skill":"superpowers:brainstorming"}` {
 		t.Errorf("InputJSON = %q", tc.InputJSON)
 	}
-	if tc.ResultContentLength != 42 {
-		t.Errorf("ResultContentLength = %d", tc.ResultContentLength)
-	}
+	assert.Equal(t, 42, tc.ResultContentLength, "ResultContentLength =")
 }
 
 func TestToolCallResultContent(t *testing.T) {
@@ -3191,9 +2912,8 @@ func TestToolCallResultContent(t *testing.T) {
 	sess := Session{
 		ID: "sess-rc", Project: "p", Machine: "m", Agent: "claude",
 	}
-	if err := database.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert: %v", err)
-	}
+	err := database.UpsertSession(sess)
+	require.NoError(t, err, "upsert")
 	msgs := []Message{
 		{
 			SessionID: "sess-rc",
@@ -3211,15 +2931,12 @@ func TestToolCallResultContent(t *testing.T) {
 			},
 		},
 	}
-	if err := database.InsertMessages(msgs); err != nil {
-		t.Fatalf("insert: %v", err)
-	}
+	err = database.InsertMessages(msgs)
+	require.NoError(t, err, "insert")
 	retrieved, err := database.GetMessages(
 		context.Background(), "sess-rc", 0, 10, true,
 	)
-	if err != nil {
-		t.Fatalf("get: %v", err)
-	}
+	require.NoError(t, err, "get")
 	if len(retrieved) != 1 || len(retrieved[0].ToolCalls) != 1 {
 		t.Fatalf("expected 1 msg with 1 tool call")
 	}
@@ -3257,9 +2974,7 @@ func TestGetAllMessagesReturnsToolCallsAcrossBatches(t *testing.T) {
 
 	got, err := d.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
-	if len(got) != total {
-		t.Fatalf("got %d messages, want %d", len(got), total)
-	}
+	require.Len(t, got, total, "got")
 
 	for i := range total {
 		if len(got[i].ToolCalls) != 1 {
@@ -3311,18 +3026,10 @@ func TestToolCallSubagentSessionID(t *testing.T) {
 		context.Background(), "s1", 0, 100, true,
 	)
 	requireNoError(t, err, "GetMessages")
-	if len(msgs) != 1 {
-		t.Fatalf("got %d messages, want 1", len(msgs))
-	}
-	if len(msgs[0].ToolCalls) != 1 {
-		t.Fatalf("got %d tool_calls, want 1",
-			len(msgs[0].ToolCalls))
-	}
+	require.Len(t, msgs, 1, "len")
+	require.Len(t, msgs[0].ToolCalls, 1, "got")
 	tc := msgs[0].ToolCalls[0]
-	if tc.SubagentSessionID != "agent-abc123" {
-		t.Errorf("SubagentSessionID = %q, want %q",
-			tc.SubagentSessionID, "agent-abc123")
-	}
+	assert.Equal(t, "agent-abc123", tc.SubagentSessionID, "SubagentSessionID")
 
 	// Verify empty SubagentSessionID stores as NULL
 	insertSession(t, d, "s2", "proj")
@@ -3381,9 +3088,8 @@ func TestFTSBackfill(t *testing.T) {
 	insertSession(t, d1, "s1", "proj")
 	insertMessages(t, d1, userMsg("s1", 0, "unique_keyword"))
 
-	if err := d1.Close(); err != nil {
-		t.Fatalf("Close 1: %v", err)
-	}
+	err = d1.Close()
+	require.NoError(t, err, "Close 1")
 
 	// 3. Re-open. This should detect missing FTS, create it, and backfill.
 	d2, err := Open(path)
@@ -3400,12 +3106,8 @@ func TestFTSBackfill(t *testing.T) {
 		Limit: 1,
 	})
 	requireNoError(t, err, "Search")
-	if len(page.Results) != 1 {
-		t.Fatalf("got %d results, want 1", len(page.Results))
-	}
-	if page.Results[0].SessionID != "s1" {
-		t.Errorf("result session_id = %q, want s1", page.Results[0].SessionID)
-	}
+	require.Len(t, page.Results, 1, "len")
+	assert.Equal(t, "s1", page.Results[0].SessionID, "result session_id")
 }
 
 func TestPath(t *testing.T) {
@@ -3431,15 +3133,12 @@ func TestReopen(t *testing.T) {
 	insertSession(t, d, "s1", "proj")
 	insertMessages(t, d, userMsg("s1", 0, "hello"))
 
-	if err := d.Reopen(); err != nil {
-		t.Fatalf("Reopen: %v", err)
-	}
+	err = d.Reopen()
+	require.NoError(t, err, "Reopen")
 
 	// Data should still be accessible after reopen.
 	got := requireSessionExists(t, d, "s1")
-	if got.Project != "proj" {
-		t.Errorf("project = %q, want proj", got.Project)
-	}
+	assert.Equal(t, "proj", got.Project, "project")
 
 	msgs, err := d.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
@@ -3470,32 +3169,27 @@ func TestReopenAfterSwap(t *testing.T) {
 	tempDB.Close()
 
 	// Close connections before rename (Windows-safe flow).
-	if err := origDB.CloseConnections(); err != nil {
-		t.Fatalf("CloseConnections: %v", err)
-	}
+	err = origDB.CloseConnections()
+	require.NoError(t, err, "CloseConnections")
 
 	// Remove WAL/SHM while connections are closed.
 	os.Remove(origPath + "-wal")
 	os.Remove(origPath + "-shm")
 
 	// Swap: rename temp over original.
-	if err := os.Rename(tempPath, origPath); err != nil {
-		t.Fatalf("rename: %v", err)
-	}
+	err = os.Rename(tempPath, origPath)
+	require.NoError(t, err, "rename")
 	os.Remove(tempPath + "-wal")
 	os.Remove(tempPath + "-shm")
 
 	// Reopen to pick up the new file.
-	if err := origDB.Reopen(); err != nil {
-		t.Fatalf("Reopen: %v", err)
-	}
+	err = origDB.Reopen()
+	require.NoError(t, err, "Reopen")
 
 	// Original DB handle should now see the new data.
 	requireSessionGone(t, origDB, "old-session")
 	got := requireSessionExists(t, origDB, "new-session")
-	if got.Project != "new-proj" {
-		t.Errorf("project = %q, want new-proj", got.Project)
-	}
+	assert.Equal(t, "new-proj", got.Project, "project")
 }
 
 func TestCloseConnections(t *testing.T) {
@@ -3503,26 +3197,22 @@ func TestCloseConnections(t *testing.T) {
 	insertSession(t, d, "s1", "proj")
 
 	// Close connections.
-	if err := d.CloseConnections(); err != nil {
-		t.Fatalf("CloseConnections: %v", err)
-	}
+	err := d.CloseConnections()
+	require.NoError(t, err, "CloseConnections")
 
 	// Queries should fail after close.
-	_, err := d.GetSession(context.Background(), "s1")
+	_, err = d.GetSession(context.Background(), "s1")
 	if err == nil {
 		t.Error("expected error querying after CloseConnections")
 	}
 
 	// Reopen should restore service.
-	if err := d.Reopen(); err != nil {
-		t.Fatalf("Reopen: %v", err)
-	}
+	err = d.Reopen()
+	require.NoError(t, err, "Reopen")
 
 	// Queries should work again.
 	s, err := d.GetSession(context.Background(), "s1")
-	if err != nil {
-		t.Fatalf("GetSession after Reopen: %v", err)
-	}
+	require.NoError(t, err, "GetSession after Reopen")
 	if s == nil {
 		t.Error("session s1 missing after Reopen")
 	}
@@ -3547,26 +3237,21 @@ func TestCloseRenameReopen(t *testing.T) {
 
 	// Simulate the ResyncAll sequence:
 	// close -> removeWAL -> rename -> reopen
-	if err := origDB.CloseConnections(); err != nil {
-		t.Fatalf("CloseConnections: %v", err)
-	}
+	err = origDB.CloseConnections()
+	require.NoError(t, err, "CloseConnections")
 	for _, p := range []string{origPath, tempPath} {
 		os.Remove(p + "-wal")
 		os.Remove(p + "-shm")
 	}
-	if err := os.Rename(tempPath, origPath); err != nil {
-		t.Fatalf("rename: %v", err)
-	}
-	if err := origDB.Reopen(); err != nil {
-		t.Fatalf("Reopen: %v", err)
-	}
+	err = os.Rename(tempPath, origPath)
+	require.NoError(t, err, "rename")
+	err = origDB.Reopen()
+	require.NoError(t, err, "Reopen")
 
 	// Verify swap succeeded.
 	requireSessionGone(t, origDB, "old")
 	got := requireSessionExists(t, origDB, "new")
-	if got.Project != "new-proj" {
-		t.Errorf("project = %q, want new-proj", got.Project)
-	}
+	assert.Equal(t, "new-proj", got.Project, "project")
 }
 
 func TestCloseRecoveryOnRenameFail(t *testing.T) {
@@ -3579,9 +3264,8 @@ func TestCloseRecoveryOnRenameFail(t *testing.T) {
 	insertSession(t, origDB, "s1", "proj")
 
 	// Close connections as ResyncAll would.
-	if err := origDB.CloseConnections(); err != nil {
-		t.Fatalf("CloseConnections: %v", err)
-	}
+	err = origDB.CloseConnections()
+	require.NoError(t, err, "CloseConnections")
 
 	// Simulate rename failure (temp file doesn't exist).
 	nonexistent := filepath.Join(dir, "no-such-file.db")
@@ -3591,15 +3275,12 @@ func TestCloseRecoveryOnRenameFail(t *testing.T) {
 	}
 
 	// Recovery: reopen original to restore service.
-	if err := origDB.Reopen(); err != nil {
-		t.Fatalf("recovery Reopen: %v", err)
-	}
+	err = origDB.Reopen()
+	require.NoError(t, err, "recovery Reopen")
 
 	// Data should still be accessible.
 	s, err := origDB.GetSession(context.Background(), "s1")
-	if err != nil {
-		t.Fatalf("GetSession after recovery: %v", err)
-	}
+	require.NoError(t, err, "GetSession after recovery")
 	if s == nil {
 		t.Error("session s1 missing after recovery Reopen")
 	}
@@ -3635,9 +3316,8 @@ func TestConcurrentReadsWhileReopen(t *testing.T) {
 
 	// Reopen while readers are active.
 	for range 5 {
-		if err := d.Reopen(); err != nil {
-			t.Fatalf("Reopen: %v", err)
-		}
+		err := d.Reopen()
+		require.NoError(t, err, "Reopen")
 	}
 
 	cancel()
@@ -3654,21 +3334,16 @@ func TestExportedReaderAcquiredBeforeReopenStaysUsable(t *testing.T) {
 
 	reader := d.Reader()
 	for range 2 {
-		if err := d.Reopen(); err != nil {
-			t.Fatalf("Reopen: %v", err)
-		}
+		err := d.Reopen()
+		require.NoError(t, err, "Reopen")
 	}
 
 	var id string
 	err := reader.QueryRow(
 		"SELECT id FROM sessions WHERE id = ?", "s1",
 	).Scan(&id)
-	if err != nil {
-		t.Fatalf("query with pre-reopen reader handle: %v", err)
-	}
-	if id != "s1" {
-		t.Fatalf("id = %q, want s1", id)
-	}
+	require.NoError(t, err, "query with pre-reopen reader handle")
+	require.Equal(t, "s1", id, "id")
 }
 
 func TestReopenDoesNotBlockNewReadsWhileClosingRetiredPool(t *testing.T) {
@@ -3701,17 +3376,14 @@ func TestReopenDoesNotBlockNewReadsWhileClosingRetiredPool(t *testing.T) {
 
 	select {
 	case err := <-readDone:
-		if err != nil {
-			t.Fatalf("new read while closing retired pool: %v", err)
-		}
+		require.NoError(t, err, "new read while closing retired pool")
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("new read blocked while Reopen closed a retired pool")
 	}
 
 	releaseClose()
-	if err := <-reopenDone; err != nil {
-		t.Fatalf("Reopen: %v", err)
-	}
+	err := <-reopenDone
+	require.NoError(t, err, "Reopen")
 }
 
 func TestRepeatedReopenBoundsRetiredPools(t *testing.T) {
@@ -3722,9 +3394,8 @@ func TestRepeatedReopenBoundsRetiredPools(t *testing.T) {
 	// should be closed by subsequent reopens, keeping only
 	// the most recent pair alive.
 	for range 20 {
-		if err := d.Reopen(); err != nil {
-			t.Fatalf("Reopen: %v", err)
-		}
+		err := d.Reopen()
+		require.NoError(t, err, "Reopen")
 	}
 
 	// After 20 reopens the retired slice should hold at most
@@ -3738,9 +3409,7 @@ func TestRepeatedReopenBoundsRetiredPools(t *testing.T) {
 
 	// Data should still be readable.
 	s, err := d.GetSession(context.Background(), "s1")
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
+	require.NoError(t, err, "GetSession")
 	if s == nil {
 		t.Error("session s1 missing after repeated Reopen")
 	}
@@ -3751,19 +3420,16 @@ func TestCloseAfterCloseConnectionsReopen(t *testing.T) {
 	insertSession(t, d, "s1", "proj")
 
 	// CloseConnections + Reopen is the normal resync lifecycle.
-	if err := d.CloseConnections(); err != nil {
-		t.Fatalf("CloseConnections: %v", err)
-	}
-	if err := d.Reopen(); err != nil {
-		t.Fatalf("Reopen: %v", err)
-	}
+	err := d.CloseConnections()
+	require.NoError(t, err, "CloseConnections")
+	err = d.Reopen()
+	require.NoError(t, err, "Reopen")
 
 	// Close should succeed without "database is closed" errors
 	// from double-closing the pools that CloseConnections
 	// already closed.
-	if err := d.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
+	err = d.Close()
+	require.NoError(t, err, "Close")
 }
 
 func TestCopyInsightsFrom(t *testing.T) {
@@ -3790,18 +3456,15 @@ func TestCopyInsightsFrom(t *testing.T) {
 	defer dstDB.Close()
 
 	// Copy insights from source.
-	if err := dstDB.CopyInsightsFrom(srcPath); err != nil {
-		t.Fatalf("CopyInsightsFrom: %v", err)
-	}
+	err = dstDB.CopyInsightsFrom(srcPath)
+	require.NoError(t, err, "CopyInsightsFrom")
 
 	// Verify insights were copied.
 	insights, err := dstDB.ListInsights(
 		context.Background(), InsightFilter{},
 	)
 	requireNoError(t, err, "ListInsights")
-	if len(insights) != 1 {
-		t.Fatalf("got %d insights, want 1", len(insights))
-	}
+	require.Len(t, insights, 1, "len")
 	if insights[0].Content != "test insight content" {
 		t.Errorf(
 			"content = %q, want %q",
@@ -3857,9 +3520,7 @@ func TestCopyOrphanedDataFrom(t *testing.T) {
 	// Copy orphaned data from source.
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
 	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphaned session, got %d", count)
-	}
+	require.Equal(t, 1, count, "expected 1 orphaned session, got")
 
 	// s2 should now exist in dst.
 	s, err := dstDB.GetSession(
@@ -3870,30 +3531,19 @@ func TestCopyOrphanedDataFrom(t *testing.T) {
 		t.Fatal("orphaned session s2 not found in dst")
 		return
 	}
-	if s.Agent != "codex" {
-		t.Errorf("s2 agent = %q, want %q", s.Agent, "codex")
-	}
+	assert.Equal(t, "codex", s.Agent, "s2 agent")
 
 	// s2 messages should be copied.
 	ctx := context.Background()
 	msgs, err := dstDB.GetMessages(ctx, "s2", 0, 100, true)
 	requireNoError(t, err, "GetMessages s2")
-	if len(msgs) != 1 {
-		t.Fatalf("expected 1 message for s2, got %d",
-			len(msgs))
-	}
-	if msgs[0].Content != "hello from s2" {
-		t.Errorf("s2 message content = %q, want %q",
-			msgs[0].Content, "hello from s2")
-	}
+	require.Len(t, msgs, 1, "expected 1 message for s2, got")
+	assert.Equal(t, "hello from s2", msgs[0].Content, "s2 message content")
 
 	// s1 should still exist and not be duplicated.
 	s1msgs, err := dstDB.GetMessages(ctx, "s1", 0, 100, true)
 	requireNoError(t, err, "GetMessages s1")
-	if len(s1msgs) != 2 {
-		t.Fatalf("expected 2 messages for s1, got %d",
-			len(s1msgs))
-	}
+	require.Len(t, s1msgs, 2, "expected 2 messages for s1, got")
 
 	// Tool calls for s1 should NOT be copied (s1 exists in
 	// dst, so it's not orphaned). Only verify s2's tool_calls
@@ -3965,9 +3615,7 @@ func TestCopyOrphanedDataFrom_WithToolCalls(t *testing.T) {
 
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
 	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphaned, got %d", count)
-	}
+	require.Equal(t, 1, count, "expected 1 orphaned, got")
 
 	// Verify tool_call was copied with correct message_id
 	// mapping.
@@ -3979,9 +3627,7 @@ func TestCopyOrphanedDataFrom_WithToolCalls(t *testing.T) {
 		WHERE tc.session_id = 's1'`,
 	).Scan(&msgID, &toolName, &toolUseID)
 	requireNoError(t, err, "query tool_call")
-	if toolName != "Bash" {
-		t.Errorf("tool_name = %q, want %q", toolName, "Bash")
-	}
+	assert.Equal(t, "Bash", toolName, "tool_name")
 	if toolUseID != "tu_123" {
 		t.Errorf(
 			"tool_use_id = %q, want %q",
@@ -3995,10 +3641,7 @@ func TestCopyOrphanedDataFrom_WithToolCalls(t *testing.T) {
 		"SELECT ordinal FROM messages WHERE id = ?", msgID,
 	).Scan(&ordinal)
 	requireNoError(t, err, "verify FK")
-	if ordinal != 1 {
-		t.Errorf("tool_call message ordinal = %d, want 1",
-			ordinal)
-	}
+	assert.Equal(t, 1, ordinal, "tool_call message ordinal")
 }
 
 func TestCopyOrphanedDataFrom_WithToolResultEvents(t *testing.T) {
@@ -4043,28 +3686,16 @@ func TestCopyOrphanedDataFrom_WithToolResultEvents(t *testing.T) {
 
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
 	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphaned, got %d", count)
-	}
+	require.Equal(t, 1, count, "expected 1 orphaned, got")
 
 	msgs, err := dstDB.GetAllMessages(context.Background(), "s1")
 	requireNoError(t, err, "GetAllMessages")
-	if len(msgs) != 2 {
-		t.Fatalf("messages len = %d, want 2", len(msgs))
-	}
-	if len(msgs[1].ToolCalls) != 1 {
-		t.Fatalf("tool calls len = %d, want 1", len(msgs[1].ToolCalls))
-	}
+	require.Len(t, msgs, 2, "messages len =")
+	require.Len(t, msgs[1].ToolCalls, 1, "tool calls len =")
 	tc := msgs[1].ToolCalls[0]
-	if tc.ResultContent != "Finished successfully" {
-		t.Fatalf("result_content = %q, want %q", tc.ResultContent, "Finished successfully")
-	}
-	if len(tc.ResultEvents) != 1 {
-		t.Fatalf("result events len = %d, want 1", len(tc.ResultEvents))
-	}
-	if tc.ResultEvents[0].Source != "wait_output" {
-		t.Fatalf("event source = %q, want %q", tc.ResultEvents[0].Source, "wait_output")
-	}
+	require.Equal(t, "Finished successfully", tc.ResultContent, "result_content")
+	require.Len(t, tc.ResultEvents, 1, "result events len =")
+	require.Equal(t, "wait_output", tc.ResultEvents[0].Source, "event source")
 	if tc.ResultEvents[0].SubagentSessionID != "codex:agent-1" {
 		t.Fatalf(
 			"subagent_session_id = %q, want %q",
@@ -4102,18 +3733,12 @@ func TestCopyTrashedDataFromPreservesPins(t *testing.T) {
 
 	count, err := dstDB.CopyTrashedDataFrom(srcPath)
 	requireNoError(t, err, "CopyTrashedDataFrom")
-	if count != 1 {
-		t.Fatalf("copied trashed sessions = %d, want 1", count)
-	}
+	require.Equal(t, 1, count, "copied trashed sessions")
 
 	pins, err := dstDB.ListPinnedMessages(ctx, "s1", "")
 	requireNoError(t, err, "ListPinnedMessages")
-	if len(pins) != 1 {
-		t.Fatalf("pins copied = %d, want 1", len(pins))
-	}
-	if pins[0].Ordinal != 0 {
-		t.Fatalf("pin ordinal = %d, want 0", pins[0].Ordinal)
-	}
+	require.Len(t, pins, 1, "pins copied =")
+	require.Equal(t, 0, pins[0].Ordinal, "pin ordinal")
 	if pins[0].Note == nil || *pins[0].Note != note {
 		t.Fatalf("pin note = %v, want %q", pins[0].Note, note)
 	}
@@ -4123,10 +3748,7 @@ func TestCopyTrashedDataFromPreservesPins(t *testing.T) {
 		"SELECT content FROM messages WHERE id = ?",
 		pins[0].MessageID,
 	).Scan(&messageContent), "query pinned message")
-	if messageContent != "keep this pinned" {
-		t.Fatalf("pinned content = %q, want %q",
-			messageContent, "keep this pinned")
-	}
+	require.Equal(t, "keep this pinned", messageContent, "pinned content")
 }
 
 func TestCopyOrphanedDataFrom_AtomicOnFailure(t *testing.T) {
@@ -4199,18 +3821,14 @@ func TestCopyOrphanedDataFrom_IsSystem(t *testing.T) {
 
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
 	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphaned, got %d", count)
-	}
+	require.Equal(t, 1, count, "expected 1 orphaned, got")
 
 	// Verify is_system was preserved.
 	msgs, err := dstDB.GetMessages(
 		context.Background(), "s1", 0, 100, true,
 	)
 	requireNoError(t, err, "GetMessages")
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.Len(t, msgs, 2, "expected 2 messages")
 	if !msgs[0].IsSystem {
 		t.Error("ordinal 0: is_system should be true")
 	}
@@ -4275,9 +3893,7 @@ func TestCopyOrphanedDataFrom_LegacyNoIsSystem(t *testing.T) {
 
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
 	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphaned, got %d", count)
-	}
+	require.Equal(t, 1, count, "expected 1 orphaned, got")
 
 	// Message should be copied with is_system defaulting to
 	// false.
@@ -4285,9 +3901,7 @@ func TestCopyOrphanedDataFrom_LegacyNoIsSystem(t *testing.T) {
 		context.Background(), "s1", 0, 100, true,
 	)
 	requireNoError(t, err, "GetMessages")
-	if len(msgs) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(msgs))
-	}
+	require.Len(t, msgs, 1, "expected 1 message")
 	if msgs[0].IsSystem {
 		t.Error("is_system should default to false")
 	}
@@ -4326,9 +3940,7 @@ func TestCopyOrphanedDataFrom_TokenMetadata(t *testing.T) {
 
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
 	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphaned, got %d", count)
-	}
+	require.Equal(t, 1, count, "expected 1 orphaned, got")
 
 	// Session token metadata must survive the copy.
 	ctx := context.Background()
@@ -4337,46 +3949,21 @@ func TestCopyOrphanedDataFrom_TokenMetadata(t *testing.T) {
 	if s == nil {
 		t.Fatal("orphaned session s1 not found")
 	}
-	if s.TotalOutputTokens != 5000 {
-		t.Errorf("TotalOutputTokens = %d, want 5000",
-			s.TotalOutputTokens)
-	}
-	if s.PeakContextTokens != 120000 {
-		t.Errorf("PeakContextTokens = %d, want 120000",
-			s.PeakContextTokens)
-	}
-	if !s.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens should be true")
-	}
-	if !s.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens should be true")
-	}
+	assert.Equal(t, 5000, s.TotalOutputTokens, "TotalOutputTokens")
+	assert.Equal(t, 120000, s.PeakContextTokens, "PeakContextTokens")
+	assert.True(t, s.HasTotalOutputTokens, "HasTotalOutputTokens should be true")
+	assert.True(t, s.HasPeakContextTokens, "HasPeakContextTokens should be true")
 
 	// Message token metadata must survive the copy.
 	msgs, err := dstDB.GetMessages(ctx, "s1", 0, 100, true)
 	requireNoError(t, err, "GetMessages s1")
-	if len(msgs) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(msgs))
-	}
+	require.Len(t, msgs, 1, "expected 1 message")
 	m := msgs[0]
-	if m.Model != "claude-opus-4-20250514" {
-		t.Errorf("Model = %q, want claude-opus-4-20250514",
-			m.Model)
-	}
-	if m.ContextTokens != 80000 {
-		t.Errorf("ContextTokens = %d, want 80000",
-			m.ContextTokens)
-	}
-	if m.OutputTokens != 500 {
-		t.Errorf("OutputTokens = %d, want 500",
-			m.OutputTokens)
-	}
-	if !m.HasContextTokens {
-		t.Error("HasContextTokens should be true")
-	}
-	if !m.HasOutputTokens {
-		t.Error("HasOutputTokens should be true")
-	}
+	assert.Equal(t, "claude-opus-4-20250514", m.Model, "Model")
+	assert.Equal(t, 80000, m.ContextTokens, "ContextTokens")
+	assert.Equal(t, 500, m.OutputTokens, "OutputTokens")
+	assert.True(t, m.HasContextTokens, "HasContextTokens should be true")
+	assert.True(t, m.HasOutputTokens, "HasOutputTokens should be true")
 	if len(m.TokenUsage) == 0 {
 		t.Error("TokenUsage should be preserved")
 	}
@@ -4394,38 +3981,28 @@ func TestGetAgentsExcludesEmptyAgent(t *testing.T) {
 		func(s *Session) { s.Agent = "" })
 
 	agents, err := d.GetAgents(context.Background(), false, false)
-	if err != nil {
-		t.Fatalf("GetAgents: %v", err)
-	}
+	require.NoError(t, err, "GetAgents")
 
 	for _, a := range agents {
 		if a.Name == "" {
 			t.Error("GetAgents returned empty agent name")
 		}
 	}
-	if len(agents) != 2 {
-		t.Errorf("got %d agents, want 2", len(agents))
-	}
+	assert.Len(t, agents, 2, "len")
 }
 
 func TestGetAgentsEmptyResultSerializesAsArray(t *testing.T) {
 	d := testDB(t)
 
 	agents, err := d.GetAgents(context.Background(), false, false)
-	if err != nil {
-		t.Fatalf("GetAgents: %v", err)
-	}
+	require.NoError(t, err, "GetAgents")
 	if agents == nil {
 		t.Fatal("GetAgents returned nil, want empty slice")
 	}
-	if len(agents) != 0 {
-		t.Errorf("got %d agents, want 0", len(agents))
-	}
+	assert.Len(t, agents, 0, "len")
 
 	b, err := json.Marshal(agents)
-	if err != nil {
-		t.Fatalf("json.Marshal: %v", err)
-	}
+	require.NoError(t, err, "json.Marshal")
 	if string(b) != "[]" {
 		t.Errorf("JSON = %s, want []", b)
 	}
@@ -4444,43 +4021,30 @@ func TestStarSession(t *testing.T) {
 
 	// Idempotent re-star — should still return true (session exists).
 	ok, err = d.StarSession("s1")
-	if err != nil {
-		t.Fatalf("re-star: %v", err)
-	}
-	if !ok {
-		t.Error("re-star should return true (session exists, already starred)")
-	}
+	require.NoError(t, err, "re-star")
+	assert.True(t, ok, "re-star should return true (session exists, already starred)")
 	// This is acceptable — the session is already starred.
 
 	// Listed.
 	ids, err := d.ListStarredSessionIDs(ctx)
-	if err != nil {
-		t.Fatalf("ListStarredSessionIDs: %v", err)
-	}
+	require.NoError(t, err, "ListStarredSessionIDs")
 	if len(ids) != 1 || ids[0] != "s1" {
 		t.Errorf("listed = %v, want [s1]", ids)
 	}
 
 	// Unstar.
-	if err := d.UnstarSession("s1"); err != nil {
-		t.Fatalf("UnstarSession: %v", err)
-	}
+	err = d.UnstarSession("s1")
+	require.NoError(t, err, "UnstarSession")
 	ids, err = d.ListStarredSessionIDs(ctx)
-	if err != nil {
-		t.Fatalf("ListStarredSessionIDs after unstar: %v", err)
-	}
+	require.NoError(t, err, "ListStarredSessionIDs after unstar")
 	if len(ids) != 0 {
 		t.Errorf("listed after unstar = %v, want []", ids)
 	}
 
 	// Star non-existent session returns false (no FK error).
 	ok, err = d.StarSession("nonexistent")
-	if err != nil {
-		t.Fatalf("StarSession nonexistent: %v", err)
-	}
-	if ok {
-		t.Error("StarSession should return false for non-existent session")
-	}
+	require.NoError(t, err, "StarSession nonexistent")
+	assert.False(t, ok, "StarSession should return false for non-existent session")
 }
 
 func TestBulkStarSessions(t *testing.T) {
@@ -4491,17 +4055,11 @@ func TestBulkStarSessions(t *testing.T) {
 
 	// Bulk star with mix of valid and invalid IDs.
 	err := d.BulkStarSessions([]string{"s1", "s2", "nonexistent"})
-	if err != nil {
-		t.Fatalf("BulkStarSessions: %v", err)
-	}
+	require.NoError(t, err, "BulkStarSessions")
 
 	ids, err := d.ListStarredSessionIDs(ctx)
-	if err != nil {
-		t.Fatalf("ListStarredSessionIDs: %v", err)
-	}
-	if len(ids) != 2 {
-		t.Errorf("listed = %d, want 2", len(ids))
-	}
+	require.NoError(t, err, "ListStarredSessionIDs")
+	assert.Equal(t, 2, len(ids), "listed")
 }
 
 func TestRestoreSession(t *testing.T) {
@@ -4513,17 +4071,13 @@ func TestRestoreSession(t *testing.T) {
 	t.Run("restore non-trashed returns 0", func(t *testing.T) {
 		n, err := d.RestoreSession("s1")
 		requireNoError(t, err, "RestoreSession")
-		if n != 0 {
-			t.Errorf("rows affected = %d, want 0", n)
-		}
+		assert.Equal(t, int64(0), n, "rows affected")
 	})
 
 	t.Run("restore non-existent returns 0", func(t *testing.T) {
 		n, err := d.RestoreSession("no-such-session")
 		requireNoError(t, err, "RestoreSession")
-		if n != 0 {
-			t.Errorf("rows affected = %d, want 0", n)
-		}
+		assert.Equal(t, int64(0), n, "rows affected")
 	})
 
 	t.Run("restore trashed returns 1", func(t *testing.T) {
@@ -4540,15 +4094,11 @@ func TestRestoreSession(t *testing.T) {
 		// Should appear in trash list.
 		trashed, err := d.ListTrashedSessions(ctx)
 		requireNoError(t, err, "ListTrashedSessions")
-		if len(trashed) != 1 {
-			t.Fatalf("trash count = %d, want 1", len(trashed))
-		}
+		require.Len(t, trashed, 1, "trash count =")
 
 		n, err := d.RestoreSession("s1")
 		requireNoError(t, err, "RestoreSession")
-		if n != 1 {
-			t.Errorf("rows affected = %d, want 1", n)
-		}
+		assert.Equal(t, int64(1), n, "rows affected")
 
 		// Should appear in list again.
 		page, err = d.ListSessions(ctx, f)
@@ -4564,9 +4114,8 @@ func TestDeleteSessionExcludes(t *testing.T) {
 
 	insertSession(t, d, "s1", "p")
 
-	if err := d.DeleteSession("s1"); err != nil {
-		t.Fatalf("DeleteSession: %v", err)
-	}
+	err := d.DeleteSession("s1")
+	require.NoError(t, err, "DeleteSession")
 
 	// Session should be gone.
 	requireSessionGone(t, d, "s1")
@@ -4577,7 +4126,7 @@ func TestDeleteSessionExcludes(t *testing.T) {
 	}
 
 	// UpsertSession should return ErrSessionExcluded.
-	err := d.UpsertSession(Session{
+	err = d.UpsertSession(Session{
 		ID: "s1", Project: "p", Machine: "m", Agent: "claude",
 	})
 	if !errors.Is(err, ErrSessionExcluded) {
@@ -4612,9 +4161,7 @@ func TestEmptyTrashExcludes(t *testing.T) {
 
 	n, err := d.EmptyTrash()
 	requireNoError(t, err, "EmptyTrash")
-	if n != 2 {
-		t.Errorf("EmptyTrash deleted = %d, want 2", n)
-	}
+	assert.Equal(t, 2, n, "EmptyTrash deleted")
 
 	// Both should be excluded.
 	if !d.IsSessionExcluded("s1") {
@@ -4667,9 +4214,8 @@ func TestCopyExcludedSessionsFrom(t *testing.T) {
 	defer dstDB.Close()
 
 	// Copy excluded sessions.
-	if err := dstDB.CopyExcludedSessionsFrom(srcPath); err != nil {
-		t.Fatalf("CopyExcludedSessionsFrom: %v", err)
-	}
+	err = dstDB.CopyExcludedSessionsFrom(srcPath)
+	require.NoError(t, err, "CopyExcludedSessionsFrom")
 
 	// s1 should be excluded in destination.
 	if !dstDB.IsSessionExcluded("s1") {
@@ -4736,21 +4282,16 @@ func TestCopySessionMetadataFrom(t *testing.T) {
 	}
 	pins, err := dstDB.ListPinnedMessages(ctx, "s1", "")
 	requireNoError(t, err, "ListPins before")
-	if len(pins) != 0 {
-		t.Errorf("pins before = %d, want 0", len(pins))
-	}
+	assert.Equal(t, 0, len(pins), "pins before")
 	var starCount int
 	requireNoError(t, dstDB.getReader().QueryRow(
 		"SELECT count(*) FROM starred_sessions WHERE session_id = ?", "s1",
 	).Scan(&starCount), "count stars before")
-	if starCount != 0 {
-		t.Errorf("stars before = %d, want 0", starCount)
-	}
+	assert.Equal(t, 0, starCount, "stars before")
 
 	// Copy metadata.
-	if err := dstDB.CopySessionMetadataFrom(srcPath); err != nil {
-		t.Fatalf("CopySessionMetadataFrom: %v", err)
-	}
+	err = dstDB.CopySessionMetadataFrom(srcPath)
+	require.NoError(t, err, "CopySessionMetadataFrom")
 
 	// After copy: metadata, pin, and star should be merged.
 	// Use GetSessionFull because deleted_at was copied, so
@@ -4768,18 +4309,12 @@ func TestCopySessionMetadataFrom(t *testing.T) {
 	}
 	pins, err = dstDB.ListPinnedMessages(ctx, "s1", "")
 	requireNoError(t, err, "ListPins after")
-	if len(pins) != 1 {
-		t.Fatalf("pins after = %d, want 1", len(pins))
-	}
-	if pins[0].Ordinal != 1 {
-		t.Errorf("pin ordinal = %d, want 1", pins[0].Ordinal)
-	}
+	require.Len(t, pins, 1, "pins after =")
+	assert.Equal(t, 1, pins[0].Ordinal, "pin ordinal")
 	requireNoError(t, dstDB.getReader().QueryRow(
 		"SELECT count(*) FROM starred_sessions WHERE session_id = ?", "s1",
 	).Scan(&starCount), "count stars after")
-	if starCount != 1 {
-		t.Errorf("stars after = %d, want 1", starCount)
-	}
+	assert.Equal(t, 1, starCount, "stars after")
 }
 
 func TestCopySessionMetadataCopiesFromSource(t *testing.T) {
@@ -4858,12 +4393,8 @@ func TestCopySessionMetadataPreservesWorktreeProjectMappings(t *testing.T) {
 	for _, m := range got {
 		projects[m.PathPrefix] = m.Project
 	}
-	if projects[srcPrefix] != "src_repo" {
-		t.Fatalf("source mapping project = %q, want src_repo", projects[srcPrefix])
-	}
-	if projects[dstPrefix] != "src_conflict" {
-		t.Fatalf("destination mapping project = %q, want src_conflict", projects[dstPrefix])
-	}
+	require.Equal(t, "src_repo", projects[srcPrefix], "source mapping project")
+	require.Equal(t, "src_conflict", projects[dstPrefix], "destination mapping project")
 }
 
 func TestCopySessionMetadataPreservesClears(t *testing.T) {
@@ -4920,9 +4451,7 @@ func TestPinMessageIdempotent(t *testing.T) {
 
 	// Idempotent re-pin with same note must not return 0.
 	id2, err := d.PinMessage("s1", 1, nil)
-	if err != nil {
-		t.Fatalf("idempotent PinMessage err: %v", err)
-	}
+	require.NoError(t, err, "idempotent PinMessage err")
 	if id2 == 0 {
 		t.Fatal("idempotent PinMessage returned id=0; should return existing id")
 	}
@@ -4933,21 +4462,15 @@ func TestPinMessageIdempotent(t *testing.T) {
 	// Re-pin with different note should succeed and return same id.
 	note := "important"
 	id2b, err := d.PinMessage("s1", 1, &note)
-	if err != nil {
-		t.Fatalf("re-pin with note err: %v", err)
-	}
+	require.NoError(t, err, "re-pin with note err")
 	if id2b != id1 {
 		t.Errorf("re-pin with note id=%d, want %d", id2b, id1)
 	}
 
 	// Pin with wrong session should return 0.
 	id3, err := d.PinMessage("nonexistent", 1, nil)
-	if err != nil {
-		t.Fatalf("wrong-session PinMessage err: %v", err)
-	}
-	if id3 != 0 {
-		t.Errorf("wrong-session PinMessage id=%d, want 0", id3)
-	}
+	require.NoError(t, err, "wrong-session PinMessage err")
+	assert.Equal(t, int64(0), id3, "wrong-session PinMessage id=")
 }
 
 func TestDeleteSessionIfTrashed(t *testing.T) {
@@ -4956,29 +4479,19 @@ func TestDeleteSessionIfTrashed(t *testing.T) {
 
 	// Delete a non-trashed session should return 0.
 	n, err := d.DeleteSessionIfTrashed("s1")
-	if err != nil {
-		t.Fatalf("DeleteSessionIfTrashed non-trashed: %v", err)
-	}
-	if n != 0 {
-		t.Errorf("non-trashed: rows=%d, want 0", n)
-	}
+	require.NoError(t, err, "DeleteSessionIfTrashed non-trashed")
+	assert.Equal(t, int64(0), n, "non-trashed: rows=")
 
 	// Soft-delete, then permanent delete should succeed.
 	requireNoError(t, d.SoftDeleteSession("s1"), "soft delete")
 	n, err = d.DeleteSessionIfTrashed("s1")
-	if err != nil {
-		t.Fatalf("DeleteSessionIfTrashed trashed: %v", err)
-	}
-	if n != 1 {
-		t.Errorf("trashed: rows=%d, want 1", n)
-	}
+	require.NoError(t, err, "DeleteSessionIfTrashed trashed")
+	assert.Equal(t, int64(1), n, "trashed: rows=")
 
 	// Session should be gone.
 	ctx := context.Background()
 	s, err := d.GetSessionFull(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetSessionFull after delete: %v", err)
-	}
+	require.NoError(t, err, "GetSessionFull after delete")
 	if s != nil {
 		t.Error("session should be nil after permanent delete")
 	}
@@ -4990,12 +4503,8 @@ func TestDeleteSessionIfTrashed(t *testing.T) {
 
 	// Non-existent session should return 0.
 	n, err = d.DeleteSessionIfTrashed("nonexistent")
-	if err != nil {
-		t.Fatalf("DeleteSessionIfTrashed nonexistent: %v", err)
-	}
-	if n != 0 {
-		t.Errorf("nonexistent: rows=%d, want 0", n)
-	}
+	require.NoError(t, err, "DeleteSessionIfTrashed nonexistent")
+	assert.Equal(t, int64(0), n, "nonexistent: rows=")
 }
 
 func TestMetadataQueriesExcludeTrashed(t *testing.T) {
@@ -5014,48 +4523,36 @@ func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 	// Before trashing: both projects, agents, machines visible.
 	projects, err := d.GetProjects(ctx, false, false)
 	requireNoError(t, err, "GetProjects before trash")
-	if len(projects) != 2 {
-		t.Fatalf("projects before trash: got %d, want 2", len(projects))
-	}
+	require.Len(t, projects, 2, "projects before trash:")
 
 	agents, err := d.GetAgents(ctx, false, false)
 	requireNoError(t, err, "GetAgents before trash")
-	if len(agents) != 2 {
-		t.Fatalf("agents before trash: got %d, want 2", len(agents))
-	}
+	require.Len(t, agents, 2, "agents before trash:")
 
 	machines, err := d.GetMachines(ctx, false, false)
 	requireNoError(t, err, "GetMachines before trash")
-	if len(machines) != 2 {
-		t.Fatalf("machines before trash: got %d, want 2", len(machines))
-	}
+	require.Len(t, machines, 2, "machines before trash:")
 
 	// Soft-delete s2: its project/agent/machine should disappear.
 	requireNoError(t, d.SoftDeleteSession("s2"), "soft delete s2")
 
 	projects, err = d.GetProjects(ctx, false, false)
 	requireNoError(t, err, "GetProjects after trash")
-	if len(projects) != 1 {
-		t.Errorf("projects after trash: got %d, want 1", len(projects))
-	}
+	assert.Len(t, projects, 1, "projects after trash:")
 	if projects[0].Name != "proj-a" {
 		t.Errorf("project name: got %q, want %q", projects[0].Name, "proj-a")
 	}
 
 	agents, err = d.GetAgents(ctx, false, false)
 	requireNoError(t, err, "GetAgents after trash")
-	if len(agents) != 1 {
-		t.Errorf("agents after trash: got %d, want 1", len(agents))
-	}
+	assert.Len(t, agents, 1, "agents after trash:")
 	if agents[0].Name != "claude" {
 		t.Errorf("agent name: got %q, want %q", agents[0].Name, "claude")
 	}
 
 	machines, err = d.GetMachines(ctx, false, false)
 	requireNoError(t, err, "GetMachines after trash")
-	if len(machines) != 1 {
-		t.Errorf("machines after trash: got %d, want 1", len(machines))
-	}
+	assert.Len(t, machines, 1, "machines after trash:")
 	if machines[0] != "laptop" {
 		t.Errorf("machine: got %q, want %q", machines[0], "laptop")
 	}
@@ -5199,12 +4696,8 @@ CREATE TABLE IF NOT EXISTS insights (
 	if s == nil {
 		t.Fatal("session lost during migration")
 	}
-	if s.Project != "myproj" {
-		t.Errorf("project = %q, want myproj", s.Project)
-	}
-	if s.MessageCount != 3 {
-		t.Errorf("message_count = %d, want 3", s.MessageCount)
-	}
+	assert.Equal(t, "myproj", s.Project, "project")
+	assert.Equal(t, 3, s.MessageCount, "message_count")
 
 	// New columns must exist and be usable.
 	_, err = d.getWriter().Exec(
@@ -5334,30 +4827,20 @@ CREATE TABLE IF NOT EXISTS tool_calls (
 	if nonzero == nil {
 		t.Fatal("legacy-nonzero missing")
 	}
-	if !nonzero.HasTotalOutputTokens {
-		t.Error("legacy-nonzero HasTotalOutputTokens = false, want true")
-	}
-	if !nonzero.HasPeakContextTokens {
-		t.Error("legacy-nonzero HasPeakContextTokens = false, want true")
-	}
+	assert.True(t, nonzero.HasTotalOutputTokens, "legacy-nonzero HasTotalOutputTokens = false, want true")
+	assert.True(t, nonzero.HasPeakContextTokens, "legacy-nonzero HasPeakContextTokens = false, want true")
 
 	zero, err := d.GetSession(ctx, "legacy-zero")
 	requireNoError(t, err, "GetSession legacy-zero")
 	if zero == nil {
 		t.Fatal("legacy-zero missing")
 	}
-	if !zero.HasTotalOutputTokens {
-		t.Error("legacy-zero HasTotalOutputTokens = false, want true")
-	}
-	if !zero.HasPeakContextTokens {
-		t.Error("legacy-zero HasPeakContextTokens = false, want true")
-	}
+	assert.True(t, zero.HasTotalOutputTokens, "legacy-zero HasTotalOutputTokens = false, want true")
+	assert.True(t, zero.HasPeakContextTokens, "legacy-zero HasPeakContextTokens = false, want true")
 
 	msgs, err := d.GetMessages(ctx, "legacy-zero", 0, 10, true)
 	requireNoError(t, err, "GetMessages legacy-zero")
-	if len(msgs) != 1 {
-		t.Fatalf("legacy-zero messages = %d, want 1", len(msgs))
-	}
+	require.Len(t, msgs, 1, "legacy-zero messages =")
 	if !msgs[0].HasContextTokens {
 		t.Error("legacy-zero message HasContextTokens = false, want true")
 	}
@@ -5412,18 +4895,12 @@ func TestOpenRepairsLegacyCurrentSchemaTokenCoverageOnce(t *testing.T) {
 	if sess == nil {
 		t.Fatal("current session missing")
 	}
-	if !sess.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = false, want true")
-	}
-	if !sess.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = false, want true")
-	}
+	assert.True(t, sess.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
+	assert.True(t, sess.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 
 	msgs, err := d.GetMessages(ctx, "current", 0, 10, true)
 	requireNoError(t, err, "GetMessages current")
-	if len(msgs) != 1 {
-		t.Fatalf("messages len = %d, want 1", len(msgs))
-	}
+	require.Len(t, msgs, 1, "messages len =")
 	if !msgs[0].HasContextTokens {
 		t.Error("HasContextTokens = false, want true")
 	}
@@ -5460,18 +4937,12 @@ func TestOpenRepairsLegacyCurrentSchemaTokenCoverageOnce(t *testing.T) {
 	if sess == nil {
 		t.Fatal("current session missing after marker")
 	}
-	if sess.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = true after marker, want false")
-	}
-	if sess.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = true after marker, want false")
-	}
+	assert.False(t, sess.HasTotalOutputTokens, "HasTotalOutputTokens = true after marker, want false")
+	assert.False(t, sess.HasPeakContextTokens, "HasPeakContextTokens = true after marker, want false")
 
 	msgs, err = d.GetMessages(ctx, "current", 0, 10, true)
 	requireNoError(t, err, "GetMessages current after marker")
-	if len(msgs) != 1 {
-		t.Fatalf("messages len after marker = %d, want 1", len(msgs))
-	}
+	require.Len(t, msgs, 1, "messages len after marker =")
 	if msgs[0].HasContextTokens {
 		t.Error("HasContextTokens = true after marker, want false")
 	}
@@ -5507,9 +4978,7 @@ func TestBackfillMessageTokenCoverageSkipsRowsWithoutTokenSignals(
 		d.getWriter(),
 	)
 	requireNoError(t, err, "messageTokenCoverageBackfillCandidatesLocked")
-	if len(candidates) != 0 {
-		t.Fatalf("candidate count = %d, want 0", len(candidates))
-	}
+	require.Len(t, candidates, 0, "candidate count =")
 }
 
 func TestOpenBackfillSessionTokenCoverageSkipsMessageScanWithoutCandidates(
@@ -5544,9 +5013,7 @@ func TestOpenBackfillSessionTokenCoverageSkipsMessageScanWithoutCandidates(
 		d.getWriter(),
 	)
 	requireNoError(t, err, "backfillSessionTokenCoverageLocked")
-	if updates != 0 {
-		t.Fatalf("updates = %d, want 0", updates)
-	}
+	require.Equal(t, 0, updates, "updates")
 }
 
 func TestGetSessionForIncremental(t *testing.T) {
@@ -5576,43 +5043,20 @@ func TestGetSessionForIncremental(t *testing.T) {
 		info, ok := d.GetSessionForIncremental(
 			"/tmp/sessions/test.jsonl",
 		)
-		if !ok {
-			t.Fatal("expected to find session")
-		}
-		if info.ID != "codex:inc-test" {
-			t.Errorf("ID = %q, want codex:inc-test", info.ID)
-		}
-		if info.FileSize != 4096 {
-			t.Errorf("FileSize = %d, want 4096", info.FileSize)
-		}
-		if info.MsgCount != 5 {
-			t.Errorf("MsgCount = %d, want 5", info.MsgCount)
-		}
-		if info.UserMsgCount != 2 {
-			t.Errorf("UserMsgCount = %d, want 2",
-				info.UserMsgCount)
-		}
-		if info.TotalOutputTokens != 500 {
-			t.Errorf("TotalOutputTokens = %d, want 500",
-				info.TotalOutputTokens)
-		}
-		if info.PeakContextTokens != 1500 {
-			t.Errorf("PeakContextTokens = %d, want 1500",
-				info.PeakContextTokens)
-		}
-		if !info.HasTotalOutputTokens {
-			t.Error("HasTotalOutputTokens = false, want true")
-		}
-		if !info.HasPeakContextTokens {
-			t.Error("HasPeakContextTokens = false, want true")
-		}
+		require.True(t, ok, "expected to find session")
+		assert.Equal(t, "codex:inc-test", info.ID, "ID")
+		assert.Equal(t, int64(4096), info.FileSize, "FileSize")
+		assert.Equal(t, 5, info.MsgCount, "MsgCount")
+		assert.Equal(t, 2, info.UserMsgCount, "UserMsgCount")
+		assert.Equal(t, 500, info.TotalOutputTokens, "TotalOutputTokens")
+		assert.Equal(t, 1500, info.PeakContextTokens, "PeakContextTokens")
+		assert.True(t, info.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
+		assert.True(t, info.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 	})
 
 	t.Run("not_found", func(t *testing.T) {
 		_, ok := d.GetSessionForIncremental("/no/such/file")
-		if ok {
-			t.Error("expected not found")
-		}
+		assert.False(t, ok, "expected not found")
 	})
 
 	t.Run("multi_session_bails_out", func(t *testing.T) {
@@ -5651,15 +5095,9 @@ func TestGetSessionForIncremental(t *testing.T) {
 		requireNoError(t, err, "insert legacy false flags")
 
 		info, ok := d.GetSessionForIncremental(path)
-		if !ok {
-			t.Fatal("expected legacy session for incremental")
-		}
-		if !info.HasTotalOutputTokens {
-			t.Error("HasTotalOutputTokens = false, want true")
-		}
-		if !info.HasPeakContextTokens {
-			t.Error("HasPeakContextTokens = false, want true")
-		}
+		require.True(t, ok, "expected legacy session for incremental")
+		assert.True(t, info.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
+		assert.True(t, info.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 
 		err = d.UpdateSessionIncremental(
 			info.ID, nil, info.MsgCount+1, info.UserMsgCount,
@@ -5674,12 +5112,8 @@ func TestGetSessionForIncremental(t *testing.T) {
 		if got == nil {
 			t.Fatal("legacy session missing after incremental")
 		}
-		if !got.HasTotalOutputTokens {
-			t.Error("stored HasTotalOutputTokens = false, want true")
-		}
-		if !got.HasPeakContextTokens {
-			t.Error("stored HasPeakContextTokens = false, want true")
-		}
+		assert.True(t, got.HasTotalOutputTokens, "stored HasTotalOutputTokens = false, want true")
+		assert.True(t, got.HasPeakContextTokens, "stored HasPeakContextTokens = false, want true")
 	})
 }
 
@@ -5721,34 +5155,18 @@ func TestUpdateSessionIncremental(t *testing.T) {
 		context.Background(), "inc-update",
 	)
 	requireNoError(t, err, "get session")
-	if got.MessageCount != 7 {
-		t.Errorf("MessageCount = %d, want 7",
-			got.MessageCount)
-	}
-	if got.UserMessageCount != 3 {
-		t.Errorf("UserMessageCount = %d, want 3",
-			got.UserMessageCount)
-	}
+	assert.Equal(t, 7, got.MessageCount, "MessageCount")
+	assert.Equal(t, 3, got.UserMessageCount, "UserMessageCount")
 	if got.EndedAt == nil || *got.EndedAt != ended {
 		t.Errorf("EndedAt = %v, want %q", got.EndedAt, ended)
 	}
 	if got.FileSize == nil || *got.FileSize != 2048 {
 		t.Errorf("FileSize = %v, want 2048", got.FileSize)
 	}
-	if got.TotalOutputTokens != 500 {
-		t.Errorf("TotalOutputTokens = %d, want 500",
-			got.TotalOutputTokens)
-	}
-	if got.PeakContextTokens != 1600 {
-		t.Errorf("PeakContextTokens = %d, want 1600",
-			got.PeakContextTokens)
-	}
-	if !got.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = false, want true")
-	}
-	if !got.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = false, want true")
-	}
+	assert.Equal(t, 500, got.TotalOutputTokens, "TotalOutputTokens")
+	assert.Equal(t, 1600, got.PeakContextTokens, "PeakContextTokens")
+	assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
+	assert.True(t, got.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 
 	// Verify preserved fields were NOT cleared.
 	if got.FirstMessage == nil || *got.FirstMessage != "hello" {
@@ -5777,29 +5195,21 @@ func TestSyncState_GetSetRoundtrip(t *testing.T) {
 	// Initially empty.
 	val, err := d.GetSyncState("last_push_at")
 	requireNoError(t, err, "get initial")
-	if val != "" {
-		t.Fatalf("initial value = %q, want empty", val)
-	}
+	require.Equal(t, "", val, "initial value")
 
 	// Set and read back.
-	if err := d.SetSyncState("last_push_at", "2026-03-11T12:00:00.000Z"); err != nil {
-		t.Fatalf("set: %v", err)
-	}
+	err = d.SetSyncState("last_push_at", "2026-03-11T12:00:00.000Z")
+	require.NoError(t, err, "set")
 	val, err = d.GetSyncState("last_push_at")
 	requireNoError(t, err, "get after set")
-	if val != "2026-03-11T12:00:00.000Z" {
-		t.Fatalf("value = %q, want 2026-03-11T12:00:00.000Z", val)
-	}
+	require.Equal(t, "2026-03-11T12:00:00.000Z", val, "value")
 
 	// Update.
-	if err := d.SetSyncState("last_push_at", "2026-03-11T13:00:00.000Z"); err != nil {
-		t.Fatalf("update: %v", err)
-	}
+	err = d.SetSyncState("last_push_at", "2026-03-11T13:00:00.000Z")
+	require.NoError(t, err, "update")
 	val, err = d.GetSyncState("last_push_at")
 	requireNoError(t, err, "get after update")
-	if val != "2026-03-11T13:00:00.000Z" {
-		t.Fatalf("value = %q, want 2026-03-11T13:00:00.000Z", val)
-	}
+	require.Equal(t, "2026-03-11T13:00:00.000Z", val, "value")
 }
 
 func TestListSessionsModifiedBetween(t *testing.T) {
@@ -5831,50 +5241,31 @@ func TestListSessionsModifiedBetween(t *testing.T) {
 
 	// Query all.
 	all, err := d.ListSessionsModifiedBetween(ctx, "", "", nil, nil)
-	if err != nil {
-		t.Fatalf("list all: %v", err)
-	}
-	if len(all) != 3 {
-		t.Fatalf("list all = %d, want 3", len(all))
-	}
+	require.NoError(t, err, "list all")
+	require.Len(t, all, 3, "list all =")
 
 	// Query with since.
 	since, err := d.ListSessionsModifiedBetween(ctx, "2026-03-11T00:00:00Z", "", nil, nil)
-	if err != nil {
-		t.Fatalf("list since: %v", err)
-	}
-	if len(since) != 2 {
-		t.Fatalf("list since = %d, want 2", len(since))
-	}
+	require.NoError(t, err, "list since")
+	require.Len(t, since, 2, "list since =")
 
 	// Query with until.
 	until, err := d.ListSessionsModifiedBetween(ctx, "", "2026-03-11T12:00:00.000Z", nil, nil)
-	if err != nil {
-		t.Fatalf("list until: %v", err)
-	}
-	if len(until) != 2 {
-		t.Fatalf("list until = %d, want 2", len(until))
-	}
+	require.NoError(t, err, "list until")
+	require.Len(t, until, 2, "list until =")
 
 	// Query with both.
 	between, err := d.ListSessionsModifiedBetween(ctx, "2026-03-10T12:00:00.000Z", "2026-03-11T12:00:00.000Z", nil, nil)
-	if err != nil {
-		t.Fatalf("list between: %v", err)
-	}
-	if len(between) != 1 {
-		t.Fatalf("list between = %d, want 1 (s2 only)", len(between))
-	}
-	if between[0].ID != "s2" {
-		t.Errorf("between[0].ID = %q, want s2", between[0].ID)
-	}
+	require.NoError(t, err, "list between")
+	require.Len(t, between, 1, "list between =")
+	assert.Equal(t, "s2", between[0].ID, "between[0].ID")
 }
 
 func TestMessageContentFingerprint(t *testing.T) {
 	d := testDB(t)
 	sess := Session{ID: "fp-sess", Project: "p", Machine: "local", Agent: "claude"}
-	if err := d.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert: %v", err)
-	}
+	err := d.UpsertSession(sess)
+	require.NoError(t, err, "upsert")
 	if err := d.InsertMessages([]Message{
 		{SessionID: "fp-sess", Ordinal: 0, Role: "user", Content: "hello", ContentLength: 5},
 		{SessionID: "fp-sess", Ordinal: 1, Role: "assistant", Content: "hi there!", ContentLength: 9},
@@ -5883,26 +5274,17 @@ func TestMessageContentFingerprint(t *testing.T) {
 	}
 
 	sum, max, min, err := d.MessageContentFingerprint("fp-sess")
-	if err != nil {
-		t.Fatalf("fingerprint: %v", err)
-	}
-	if sum != 14 {
-		t.Errorf("sum = %d, want 14", sum)
-	}
-	if max != 9 {
-		t.Errorf("max = %d, want 9", max)
-	}
-	if min != 5 {
-		t.Errorf("min = %d, want 5", min)
-	}
+	require.NoError(t, err, "fingerprint")
+	assert.Equal(t, int64(14), sum, "sum")
+	assert.Equal(t, int64(9), max, "max")
+	assert.Equal(t, int64(5), min, "min")
 }
 
 func TestSystemMessageFingerprint(t *testing.T) {
 	d := testDB(t)
 	sess := Session{ID: "sys-fp", Project: "p", Machine: "local", Agent: "claude"}
-	if err := d.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert: %v", err)
-	}
+	err := d.UpsertSession(sess)
+	require.NoError(t, err, "upsert")
 	// System ordinals: 0 and 2 → "0,2".
 	if err := d.InsertMessages([]Message{
 		{SessionID: "sys-fp", Ordinal: 0, Role: "user", Content: "sys", ContentLength: 3, IsSystem: true},
@@ -5913,12 +5295,8 @@ func TestSystemMessageFingerprint(t *testing.T) {
 	}
 
 	fp, err := d.SystemMessageFingerprint("sys-fp")
-	if err != nil {
-		t.Fatalf("SystemMessageFingerprint: %v", err)
-	}
-	if fp != "0,2" {
-		t.Errorf("fingerprint = %q, want %q", fp, "0,2")
-	}
+	require.NoError(t, err, "SystemMessageFingerprint")
+	assert.Equal(t, "0,2", fp, "fingerprint")
 
 	// Regression: {0,3} and {1,2} both produce sum=3 and sum-of-squares differs,
 	// but {0,4,5} and {1,2,6} (sum=9, sumSq=41) collide under the two-component
@@ -5971,9 +5349,8 @@ func TestSystemMessageFingerprint(t *testing.T) {
 func TestToolCallCountAndFingerprint(t *testing.T) {
 	d := testDB(t)
 	sess := Session{ID: "tc-sess", Project: "p", Machine: "local", Agent: "claude"}
-	if err := d.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert: %v", err)
-	}
+	err := d.UpsertSession(sess)
+	require.NoError(t, err, "upsert")
 	if err := d.InsertMessages([]Message{
 		{
 			SessionID: "tc-sess", Ordinal: 0, Role: "assistant", Content: "tool",
@@ -5987,20 +5364,12 @@ func TestToolCallCountAndFingerprint(t *testing.T) {
 	}
 
 	count, err := d.ToolCallCount("tc-sess")
-	if err != nil {
-		t.Fatalf("count: %v", err)
-	}
-	if count != 2 {
-		t.Errorf("count = %d, want 2", count)
-	}
+	require.NoError(t, err, "count")
+	assert.Equal(t, 2, count, "count")
 
 	sum, err := d.ToolCallContentFingerprint("tc-sess")
-	if err != nil {
-		t.Fatalf("fingerprint: %v", err)
-	}
-	if sum != 150 {
-		t.Errorf("sum = %d, want 150", sum)
-	}
+	require.NoError(t, err, "fingerprint")
+	assert.Equal(t, int64(150), sum, "sum")
 }
 
 func TestListSessionsModifiedBetween_ProjectFilter(t *testing.T) {
@@ -6064,9 +5433,7 @@ func TestListSessionsModifiedBetween_ProjectFilter(t *testing.T) {
 			got, err := d.ListSessionsModifiedBetween(
 				ctx, "", "", tt.projects, tt.excludeProjects,
 			)
-			if err != nil {
-				t.Fatalf("ListSessionsModifiedBetween: %v", err)
-			}
+			require.NoError(t, err, "ListSessionsModifiedBetween")
 			var gotIDs []string
 			for _, s := range got {
 				gotIDs = append(gotIDs, s.ID)
@@ -6163,9 +5530,7 @@ func TestMigration_TerminationStatusColumn(t *testing.T) {
 	var sessCount int
 	err = conn.QueryRow(`SELECT count(*) FROM sessions`).Scan(&sessCount)
 	requireNoError(t, err, "count sessions pre-migration")
-	if sessCount != 1 {
-		t.Fatalf("expected 1 session row, got %d", sessCount)
-	}
+	require.Equal(t, 1, sessCount, "expected 1 session row, got")
 
 	// Force the migration path: bump user_version down so Open()
 	// re-runs the ADD COLUMN / CREATE INDEX steps.

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPruneFilterZeroValue(t *testing.T) {
 	f := PruneFilter{}
 
-	if f.HasFilters() {
-		t.Error("HasFilters() returned true for zero value")
-	}
+	assert.False(t, f.HasFilters(),
+		"HasFilters() returned true for zero value")
 
 	d := testDB(t)
 
@@ -843,21 +844,13 @@ func TestGetMachinesExcludeOneShot(t *testing.T) {
 	})
 
 	all, err := d.GetMachines(context.Background(), false, false)
-	requireNoError(t, err, "GetMachines includeAll")
-	if len(all) != 2 {
-		t.Fatalf("includeAll: got %d machines, want 2", len(all))
-	}
+	require.NoError(t, err, "GetMachines includeAll")
+	require.Len(t, all, 2, "includeAll machines")
 
 	filtered, err := d.GetMachines(context.Background(), true, false)
-	requireNoError(t, err, "GetMachines excludeOneShot")
-	if len(filtered) != 1 {
-		t.Fatalf("excludeOneShot: got %d machines, want 1",
-			len(filtered))
-	}
-	if filtered[0] != "desktop" {
-		t.Errorf("excludeOneShot: got %q, want desktop",
-			filtered[0])
-	}
+	require.NoError(t, err, "GetMachines excludeOneShot")
+	require.Len(t, filtered, 1, "excludeOneShot machines")
+	assert.Equal(t, "desktop", filtered[0], "excludeOneShot machine")
 }
 
 func TestGetStatsExcludeOneShot(t *testing.T) {
@@ -874,35 +867,17 @@ func TestGetStatsExcludeOneShot(t *testing.T) {
 
 	// Include all.
 	stats, err := d.GetStats(context.Background(), false, false)
-	requireNoError(t, err, "GetStats includeAll")
-	if stats.SessionCount != 2 {
-		t.Errorf("includeAll: session_count = %d, want 2",
-			stats.SessionCount)
-	}
-	if stats.MessageCount != 15 {
-		t.Errorf("includeAll: message_count = %d, want 15",
-			stats.MessageCount)
-	}
-	if stats.ProjectCount != 2 {
-		t.Errorf("includeAll: project_count = %d, want 2",
-			stats.ProjectCount)
-	}
+	require.NoError(t, err, "GetStats includeAll")
+	assert.Equal(t, 2, stats.SessionCount, "includeAll: session_count")
+	assert.Equal(t, 15, stats.MessageCount, "includeAll: message_count")
+	assert.Equal(t, 2, stats.ProjectCount, "includeAll: project_count")
 
 	// Exclude one-shot.
 	stats, err = d.GetStats(context.Background(), true, false)
-	requireNoError(t, err, "GetStats excludeOneShot")
-	if stats.SessionCount != 1 {
-		t.Errorf("excludeOneShot: session_count = %d, want 1",
-			stats.SessionCount)
-	}
-	if stats.MessageCount != 10 {
-		t.Errorf("excludeOneShot: message_count = %d, want 10",
-			stats.MessageCount)
-	}
-	if stats.ProjectCount != 1 {
-		t.Errorf("excludeOneShot: project_count = %d, want 1",
-			stats.ProjectCount)
-	}
+	require.NoError(t, err, "GetStats excludeOneShot")
+	assert.Equal(t, 1, stats.SessionCount, "excludeOneShot: session_count")
+	assert.Equal(t, 10, stats.MessageCount, "excludeOneShot: message_count")
+	assert.Equal(t, 1, stats.ProjectCount, "excludeOneShot: project_count")
 }
 
 func TestSessionFilterExcludeAutomated(t *testing.T) {
@@ -1036,9 +1011,7 @@ func TestSidebarSessionIndexExcludeAutomated(t *testing.T) {
 	})
 	requireNoError(t, err, "GetSidebarSessionIndex")
 	requireSidebarIndexIDs(t, index.Sessions, []string{"normal"})
-	if index.Total != 1 {
-		t.Fatalf("total = %d, want 1", index.Total)
-	}
+	require.Equal(t, 1, index.Total, "total")
 }
 
 func TestSidebarSessionIndexIncludeAutomated(t *testing.T) {
@@ -1060,9 +1033,7 @@ func TestSidebarSessionIndexIncludeAutomated(t *testing.T) {
 	})
 	requireNoError(t, err, "GetSidebarSessionIndex")
 	requireSidebarIndexIDs(t, index.Sessions, []string{"normal", "review"})
-	if index.Total != 2 {
-		t.Fatalf("total = %d, want 2", index.Total)
-	}
+	require.Equal(t, 2, index.Total, "total")
 }
 
 func TestSidebarSessionIndexExcludeOneShotWithAutomatedIncluded(t *testing.T) {
@@ -1137,15 +1108,10 @@ func TestSidebarSessionIndexReturnsDisplayName(t *testing.T) {
 	})
 
 	index, err := d.GetSidebarSessionIndex(context.Background(), SessionFilter{})
-	requireNoError(t, err, "GetSidebarSessionIndex")
-	if len(index.Sessions) != 1 {
-		t.Fatalf("sessions = %d, want 1", len(index.Sessions))
-	}
-	if index.Sessions[0].DisplayName == nil ||
-		*index.Sessions[0].DisplayName != displayName {
-		t.Fatalf("display_name = %v, want %q",
-			index.Sessions[0].DisplayName, displayName)
-	}
+	require.NoError(t, err, "GetSidebarSessionIndex")
+	require.Len(t, index.Sessions, 1)
+	require.NotNil(t, index.Sessions[0].DisplayName, "display_name")
+	assert.Equal(t, displayName, *index.Sessions[0].DisplayName, "display_name")
 }
 
 func TestSidebarSessionIndexComputesIsTeammate(t *testing.T) {
@@ -1166,12 +1132,10 @@ func TestSidebarSessionIndexComputesIsTeammate(t *testing.T) {
 	requireNoError(t, err, "GetSidebarSessionIndex")
 
 	rows := sidebarIndexByID(index.Sessions)
-	if !rows["teammate"].IsTeammate {
-		t.Fatal("teammate IsTeammate = false, want true")
-	}
-	if rows["normal"].IsTeammate {
-		t.Fatal("normal IsTeammate = true, want false")
-	}
+	require.True(t, rows["teammate"].IsTeammate,
+		"teammate IsTeammate = false, want true")
+	require.False(t, rows["normal"].IsTeammate,
+		"normal IsTeammate = true, want false")
 }
 
 func requireSidebarIndexIDs(
@@ -1190,9 +1154,8 @@ func requireSidebarIndexIDs(
 	copy(gotSorted, gotIDs)
 	slices.Sort(gotSorted)
 
-	if diff := cmp.Diff(wantSorted, gotSorted); diff != "" {
-		t.Errorf("sidebar index sessions mismatch (-want +got):\n%s", diff)
-	}
+	diff := cmp.Diff(wantSorted, gotSorted)
+	assert.Empty(t, diff, "sidebar index sessions mismatch (-want +got)")
 }
 
 func sidebarIndexByID(
@@ -1242,28 +1205,24 @@ func TestIsAutomatedSetOnUpsert(t *testing.T) {
 
 	ctx := context.Background()
 	normal, err := d.GetSession(ctx, "normal")
-	requireNoError(t, err, "get normal")
-	if normal.IsAutomated {
-		t.Error("normal session should not be automated")
-	}
+	require.NoError(t, err, "get normal")
+	assert.False(t, normal.IsAutomated,
+		"normal session should not be automated")
 
 	review, err := d.GetSession(ctx, "review")
-	requireNoError(t, err, "get review")
-	if !review.IsAutomated {
-		t.Error("single-turn review should be automated")
-	}
+	require.NoError(t, err, "get review")
+	assert.True(t, review.IsAutomated,
+		"single-turn review should be automated")
 
 	multi, err := d.GetSession(ctx, "multi-review")
-	requireNoError(t, err, "get multi-review")
-	if multi.IsAutomated {
-		t.Error("multi-turn review should not be automated")
-	}
+	require.NoError(t, err, "get multi-review")
+	assert.False(t, multi.IsAutomated,
+		"multi-turn review should not be automated")
 
 	sub, err := d.GetSession(ctx, "roborev-sub")
-	requireNoError(t, err, "get roborev-sub")
-	if !sub.IsAutomated {
-		t.Error("single-turn roborev substring should be automated")
-	}
+	require.NoError(t, err, "get roborev-sub")
+	assert.True(t, sub.IsAutomated,
+		"single-turn roborev substring should be automated")
 }
 
 func TestListSessionsHasSecret(t *testing.T) {
@@ -1275,39 +1234,30 @@ func TestListSessionsHasSecret(t *testing.T) {
 	// secret_leak_count is owned solely by the findings path; UpsertSession
 	// (used by insertSession) does NOT persist it, so set it via the findings
 	// API rather than the Session mutator.
-	if err := d.ReplaceSessionSecretFindings("leaky", nil, 3, "v"); err != nil {
-		t.Fatalf("ReplaceSessionSecretFindings: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionSecretFindings("leaky", nil, 3, "v"),
+		"ReplaceSessionSecretFindings")
 	insertSession(t, d, "clean", "proj", func(s *Session) {
 		s.MessageCount = 2
 		s.UserMessageCount = 2
 	})
 	page, err := d.ListSessions(context.Background(), SessionFilter{HasSecret: true})
-	if err != nil {
-		t.Fatalf("ListSessions: %v", err)
-	}
-	if len(page.Sessions) != 1 || page.Sessions[0].ID != "leaky" {
-		t.Fatalf("HasSecret filter = %+v, want only leaky", page.Sessions)
-	}
+	require.NoError(t, err, "ListSessions")
+	require.Len(t, page.Sessions, 1, "HasSecret filter")
+	require.Equal(t, "leaky", page.Sessions[0].ID, "HasSecret filter")
 
 	insertSession(t, d, "stale", "proj", func(s *Session) {
 		s.MessageCount = 2
 		s.UserMessageCount = 2
 	})
-	if err := d.ReplaceSessionSecretFindings("stale", nil, 2, "old-rules"); err != nil {
-		t.Fatalf("ReplaceSessionSecretFindings stale: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionSecretFindings("stale", nil, 2, "old-rules"),
+		"ReplaceSessionSecretFindings stale")
 	current, err := d.ListSessions(context.Background(), SessionFilter{
 		HasSecret:            true,
 		SecretsRulesVersions: []string{"v"},
 	})
-	if err != nil {
-		t.Fatalf("ListSessions current rules: %v", err)
-	}
-	if len(current.Sessions) != 1 || current.Sessions[0].ID != "leaky" {
-		t.Fatalf("versioned HasSecret filter = %+v, want only leaky",
-			current.Sessions)
-	}
+	require.NoError(t, err, "ListSessions current rules")
+	require.Len(t, current.Sessions, 1, "versioned HasSecret filter")
+	require.Equal(t, "leaky", current.Sessions[0].ID, "versioned HasSecret filter")
 }
 
 func TestIncrementalUpdateClearsAutomated(t *testing.T) {
@@ -1323,20 +1273,17 @@ func TestIncrementalUpdateClearsAutomated(t *testing.T) {
 
 	ctx := context.Background()
 	s, err := d.GetSession(ctx, "s1")
-	requireNoError(t, err, "get before")
-	if !s.IsAutomated {
-		t.Fatal("should start as automated")
-	}
+	require.NoError(t, err, "get before")
+	require.True(t, s.IsAutomated, "should start as automated")
 
 	// Simulate a second user turn via incremental update.
 	err = d.UpdateSessionIncremental(
 		"s1", nil, 6, 2, 100, 12345, 0, 0, false, false,
 	)
-	requireNoError(t, err, "incremental update")
+	require.NoError(t, err, "incremental update")
 
 	s, err = d.GetSession(ctx, "s1")
-	requireNoError(t, err, "get after")
-	if s.IsAutomated {
-		t.Error("should no longer be automated after second user turn")
-	}
+	require.NoError(t, err, "get after")
+	assert.False(t, s.IsAutomated,
+		"should no longer be automated after second user turn")
 }

--- a/internal/db/git/cache_test.go
+++ b/internal/db/git/cache_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // cacheSchema matches the `git_cache` DDL in internal/db/schema.sql. We keep
@@ -30,13 +32,10 @@ func newCacheDB(t *testing.T) *sql.DB {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "cache.db")
 	db, err := sql.Open("sqlite3", path)
-	if err != nil {
-		t.Fatalf("sql.Open: %v", err)
-	}
+	require.NoError(t, err, "sql.Open")
 	t.Cleanup(func() { _ = db.Close() })
-	if _, err := db.Exec(cacheSchema); err != nil {
-		t.Fatalf("init git_cache schema: %v", err)
-	}
+	_, err = db.Exec(cacheSchema)
+	require.NoError(t, err, "init git_cache schema")
 	return db
 }
 
@@ -52,27 +51,18 @@ func TestCache_GetOrCompute_FirstCallInvokesCompute(t *testing.T) {
 			return []byte(`{"commits":3}`), nil
 		},
 	)
-	if err != nil {
-		t.Fatalf("GetOrCompute: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("compute called %d times, want 1", calls)
-	}
-	if string(got) != `{"commits":3}` {
-		t.Fatalf("payload = %q, want %q", got, `{"commits":3}`)
-	}
+	require.NoError(t, err, "GetOrCompute")
+	assert.Equal(t, 1, calls, "compute call count")
+	assert.Equal(t, `{"commits":3}`, string(got), "payload")
 
 	// Verify the row landed in git_cache with the expected kind.
 	var kind, payload string
 	err = db.QueryRow(
 		`SELECT kind, payload FROM git_cache WHERE cache_key = ?`, "k1",
 	).Scan(&kind, &payload)
-	if err != nil {
-		t.Fatalf("row not persisted: %v", err)
-	}
-	if kind != "log" || payload != `{"commits":3}` {
-		t.Fatalf("row = (%q, %q), want (log, {...})", kind, payload)
-	}
+	require.NoError(t, err, "row not persisted")
+	assert.Equal(t, "log", kind, "row kind")
+	assert.Equal(t, `{"commits":3}`, payload, "row payload")
 }
 
 func TestCache_GetOrCompute_WithinTTLReturnsCached(t *testing.T) {
@@ -85,27 +75,18 @@ func TestCache_GetOrCompute_WithinTTLReturnsCached(t *testing.T) {
 		return []byte(`{"n":1}`), nil
 	}
 
-	if _, err := cache.GetOrCompute(
+	_, err := cache.GetOrCompute(
 		context.Background(), "k1", "log", time.Hour, compute,
-	); err != nil {
-		t.Fatalf("first GetOrCompute: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("after first call, calls = %d, want 1", calls)
-	}
+	)
+	require.NoError(t, err, "first GetOrCompute")
+	require.Equal(t, 1, calls, "after first call")
 
 	got, err := cache.GetOrCompute(
 		context.Background(), "k1", "log", time.Hour, compute,
 	)
-	if err != nil {
-		t.Fatalf("second GetOrCompute: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("compute called again within TTL: calls = %d, want 1", calls)
-	}
-	if string(got) != `{"n":1}` {
-		t.Fatalf("cached payload = %q, want %q", got, `{"n":1}`)
-	}
+	require.NoError(t, err, "second GetOrCompute")
+	assert.Equal(t, 1, calls, "compute called again within TTL")
+	assert.Equal(t, `{"n":1}`, string(got), "cached payload")
 }
 
 func TestCache_GetOrCompute_PastTTLRecomputes(t *testing.T) {
@@ -120,31 +101,23 @@ func TestCache_GetOrCompute_PastTTLRecomputes(t *testing.T) {
 
 	// Seed the cache with a timestamp well in the past so the second call
 	// sees an expired row.
-	if _, err := cache.GetOrCompute(
+	_, err := cache.GetOrCompute(
 		context.Background(), "k1", "log", time.Hour, compute,
-	); err != nil {
-		t.Fatalf("first GetOrCompute: %v", err)
-	}
+	)
+	require.NoError(t, err, "first GetOrCompute")
 	oldTime := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano)
-	if _, err := db.Exec(
+	_, err = db.Exec(
 		`UPDATE git_cache SET computed_at = ? WHERE cache_key = ?`,
 		oldTime, "k1",
-	); err != nil {
-		t.Fatalf("backdating row: %v", err)
-	}
+	)
+	require.NoError(t, err, "backdating row")
 
 	got, err := cache.GetOrCompute(
 		context.Background(), "k1", "log", time.Hour, compute,
 	)
-	if err != nil {
-		t.Fatalf("second GetOrCompute: %v", err)
-	}
-	if calls != 2 {
-		t.Fatalf("compute invocations = %d, want 2 (past TTL)", calls)
-	}
-	if string(got) != `{"call":2}` {
-		t.Fatalf("payload = %q, want recomputed %q", got, `{"call":2}`)
-	}
+	require.NoError(t, err, "second GetOrCompute")
+	assert.Equal(t, 2, calls, "compute invocations (past TTL)")
+	assert.Equal(t, `{"call":2}`, string(got), "recomputed payload")
 }
 
 func TestCache_GetOrCompute_ErrorDoesNotWriteRow(t *testing.T) {
@@ -156,29 +129,21 @@ func TestCache_GetOrCompute_ErrorDoesNotWriteRow(t *testing.T) {
 		context.Background(), "k1", "log", time.Hour,
 		func() ([]byte, error) { return nil, boom },
 	)
-	if !errors.Is(err, boom) {
-		t.Fatalf("err = %v, want wrap of %v", err, boom)
-	}
+	require.ErrorIs(t, err, boom)
 
 	var n int
-	if err := db.QueryRow(
+	err = db.QueryRow(
 		`SELECT count(*) FROM git_cache WHERE cache_key = ?`, "k1",
-	).Scan(&n); err != nil {
-		t.Fatalf("count: %v", err)
-	}
-	if n != 0 {
-		t.Fatalf("row count after error = %d, want 0", n)
-	}
+	).Scan(&n)
+	require.NoError(t, err, "count")
+	assert.Zero(t, n, "row count after error")
 }
 
 func TestCacheKey_DeterministicAndSensitiveToEachField(t *testing.T) {
 	base := CacheKey("log", "/r", "a@x", "2026-01-01", "2026-02-01")
-	if base == "" {
-		t.Fatal("CacheKey returned empty string")
-	}
-	if got := CacheKey("log", "/r", "a@x", "2026-01-01", "2026-02-01"); got != base {
-		t.Fatalf("CacheKey non-deterministic: %q vs %q", got, base)
-	}
+	require.NotEmpty(t, base, "CacheKey returned empty string")
+	assert.Equal(t, base, CacheKey("log", "/r", "a@x", "2026-01-01", "2026-02-01"),
+		"CacheKey non-deterministic")
 
 	cases := []struct {
 		name                     string
@@ -193,9 +158,8 @@ func TestCacheKey_DeterministicAndSensitiveToEachField(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got := CacheKey(c.kind, c.repo, c.author, c.s, c.u)
-			if got == base {
-				t.Fatalf("CacheKey did not change when %s differed: %q", c.name, got)
-			}
+			assert.NotEqual(t, base, got,
+				"CacheKey did not change when %s differed", c.name)
 		})
 	}
 }

--- a/internal/db/git/log_test.go
+++ b/internal/db/git/log_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // skipIfNoGit lets CI environments without git on PATH pass cleanly instead
@@ -26,9 +29,7 @@ func gitRun(t *testing.T, repo string, env []string, args ...string) {
 	cmd.Dir = repo
 	cmd.Env = append(os.Environ(), env...)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
-	}
+	require.NoError(t, err, "git %s: %s", strings.Join(args, " "), out)
 }
 
 // initRepo creates a fresh repo at t.TempDir() with a deterministic default
@@ -49,12 +50,9 @@ func initRepo(t *testing.T) string {
 func writeFile(t *testing.T, repo, relpath string, content []byte) {
 	t.Helper()
 	p := filepath.Join(repo, relpath)
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
-	}
-	if err := os.WriteFile(p, content, 0o644); err != nil {
-		t.Fatalf("write %s: %v", p, err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755),
+		"mkdir %s", filepath.Dir(p))
+	require.NoError(t, os.WriteFile(p, content, 0o644), "write %s", p)
 }
 
 // commitAs stages all changes and commits with an explicit author identity.
@@ -98,9 +96,7 @@ func TestAggregateLog_CountsCommitsLOCAndFiles(t *testing.T) {
 		repo, "test@example.com",
 		"1970-01-01T00:00:00Z", "2099-01-01T00:00:00Z",
 	)
-	if err != nil {
-		t.Fatalf("AggregateLog: %v", err)
-	}
+	require.NoError(t, err, "AggregateLog")
 
 	// Expected totals for test@example.com across the three commits. Values
 	// reflect git's diff for each commit; verified manually via
@@ -115,9 +111,7 @@ func TestAggregateLog_CountsCommitsLOCAndFiles(t *testing.T) {
 		LOCRemoved:   1,
 		FilesChanged: 4,
 	}
-	if got != want {
-		t.Fatalf("AggregateLog = %+v, want %+v", got, want)
-	}
+	assert.Equal(t, want, got, "AggregateLog")
 }
 
 func TestAggregateLog_EmptyWindowReturnsZero(t *testing.T) {
@@ -133,12 +127,8 @@ func TestAggregateLog_EmptyWindowReturnsZero(t *testing.T) {
 		repo, "test@example.com",
 		"1970-01-01T00:00:00Z", "1970-01-02T00:00:00Z",
 	)
-	if err != nil {
-		t.Fatalf("AggregateLog: %v", err)
-	}
-	if got != (LogResult{}) {
-		t.Fatalf("AggregateLog = %+v, want zero value", got)
-	}
+	require.NoError(t, err, "AggregateLog")
+	assert.Equal(t, LogResult{}, got, "AggregateLog")
 }
 
 func TestAggregateLog_UnknownAuthorReturnsZero(t *testing.T) {
@@ -153,12 +143,8 @@ func TestAggregateLog_UnknownAuthorReturnsZero(t *testing.T) {
 		repo, "nobody@example.invalid",
 		"1970-01-01T00:00:00Z", "2099-01-01T00:00:00Z",
 	)
-	if err != nil {
-		t.Fatalf("AggregateLog: %v", err)
-	}
-	if got != (LogResult{}) {
-		t.Fatalf("AggregateLog = %+v, want zero value", got)
-	}
+	require.NoError(t, err, "AggregateLog")
+	assert.Equal(t, LogResult{}, got, "AggregateLog")
 }
 
 func TestAggregateLog_BadRepoReturnsError(t *testing.T) {
@@ -171,9 +157,7 @@ func TestAggregateLog_BadRepoReturnsError(t *testing.T) {
 		notARepo, "test@example.com",
 		"1970-01-01T00:00:00Z", "2099-01-01T00:00:00Z",
 	)
-	if err == nil {
-		t.Fatalf("AggregateLog on non-repo: expected error, got nil")
-	}
+	require.Error(t, err, "AggregateLog on non-repo")
 }
 
 // TestAggregateLog_EmptyRepoReturnsZero covers the "git init but no
@@ -190,12 +174,8 @@ func TestAggregateLog_EmptyRepoReturnsZero(t *testing.T) {
 		repo, "test@example.com",
 		"1970-01-01T00:00:00Z", "2099-01-01T00:00:00Z",
 	)
-	if err != nil {
-		t.Fatalf("AggregateLog on empty repo: got error %v, want nil", err)
-	}
-	if got != (LogResult{}) {
-		t.Fatalf("AggregateLog on empty repo = %+v, want zero", got)
-	}
+	require.NoError(t, err, "AggregateLog on empty repo")
+	assert.Equal(t, LogResult{}, got, "AggregateLog on empty repo")
 }
 
 func TestAuthorEmail_LocalConfig(t *testing.T) {
@@ -205,9 +185,7 @@ func TestAuthorEmail_LocalConfig(t *testing.T) {
 	gitRun(t, repo, nil, "config", "user.email", "local@example.com")
 
 	got := AuthorEmail(repo)
-	if got != "local@example.com" {
-		t.Fatalf("AuthorEmail = %q, want %q", got, "local@example.com")
-	}
+	assert.Equal(t, "local@example.com", got, "AuthorEmail")
 }
 
 func TestAuthorEmail_FallsBackToGlobal(t *testing.T) {
@@ -228,9 +206,8 @@ func TestAuthorEmail_FallsBackToGlobal(t *testing.T) {
 		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
 		"GIT_CONFIG_GLOBAL="+globalCfg,
 	)
-	if out, err := setGlobal.CombinedOutput(); err != nil {
-		t.Fatalf("seed global config: %v\n%s", err, out)
-	}
+	out, err := setGlobal.CombinedOutput()
+	require.NoError(t, err, "seed global config: %s", out)
 
 	repo := t.TempDir()
 	// Init with no local user.email — `AuthorEmail` must fall through to global.
@@ -241,14 +218,11 @@ func TestAuthorEmail_FallsBackToGlobal(t *testing.T) {
 		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
 		"GIT_CONFIG_GLOBAL="+globalCfg,
 	)
-	if out, err := initCmd.CombinedOutput(); err != nil {
-		t.Fatalf("git init: %v\n%s", err, out)
-	}
+	out, err = initCmd.CombinedOutput()
+	require.NoError(t, err, "git init: %s", out)
 
 	got := AuthorEmail(repo)
-	if got != "global@example.com" {
-		t.Fatalf("AuthorEmail (global fallback) = %q, want %q", got, "global@example.com")
-	}
+	assert.Equal(t, "global@example.com", got, "AuthorEmail (global fallback)")
 }
 
 func TestParseNumstat_SkipsBinaryLOCButCountsFile(t *testing.T) {
@@ -273,7 +247,5 @@ func TestParseNumstat_SkipsBinaryLOCButCountsFile(t *testing.T) {
 		LOCRemoved:   1,
 		FilesChanged: 4,
 	}
-	if got != want {
-		t.Fatalf("parseNumstat = %+v, want %+v", got, want)
-	}
+	assert.Equal(t, want, got, "parseNumstat")
 }

--- a/internal/db/git/pr_test.go
+++ b/internal/db/git/pr_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // writeGhStub drops a shell script named "gh" into dir that picks its canned
@@ -24,13 +27,9 @@ func writeGhStub(t *testing.T, body string) string {
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gh")
-	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
-		t.Fatalf("write gh stub: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o755), "write gh stub")
 	// On some filesystems WriteFile's mode is masked; ensure +x explicitly.
-	if err := os.Chmod(path, 0o755); err != nil {
-		t.Fatalf("chmod gh stub: %v", err)
-	}
+	require.NoError(t, os.Chmod(path, 0o755), "chmod gh stub")
 	return dir
 }
 
@@ -57,16 +56,10 @@ esac
 		"2026-01-01", "2026-02-01",
 		"fake-token",
 	)
-	if err != nil {
-		t.Fatalf("AggregatePRs: %v", err)
-	}
-	if got == nil {
-		t.Fatalf("AggregatePRs returned nil result with non-empty token")
-	}
+	require.NoError(t, err, "AggregatePRs")
+	require.NotNil(t, got, "AggregatePRs returned nil result with non-empty token")
 	want := PRResult{Opened: 3, Merged: 2}
-	if *got != want {
-		t.Fatalf("AggregatePRs = %+v, want %+v", *got, want)
-	}
+	assert.Equal(t, want, *got, "AggregatePRs")
 }
 
 func TestAggregatePRs_EmptyTokenShortCircuits(t *testing.T) {
@@ -84,12 +77,8 @@ exit 97
 		"2026-01-01", "2026-02-01",
 		"",
 	)
-	if err != nil {
-		t.Fatalf("AggregatePRs (empty token): %v", err)
-	}
-	if got != nil {
-		t.Fatalf("AggregatePRs (empty token) = %+v, want nil", got)
-	}
+	require.NoError(t, err, "AggregatePRs (empty token)")
+	assert.Nil(t, got, "AggregatePRs (empty token)")
 }
 
 func TestAggregatePRs_ExecFailurePropagates(t *testing.T) {
@@ -106,9 +95,7 @@ exit 1
 		"2026-01-01", "2026-02-01",
 		"fake-token",
 	)
-	if err == nil {
-		t.Fatalf("AggregatePRs: expected error from failing gh, got nil")
-	}
+	require.Error(t, err, "AggregatePRs expected error from failing gh")
 }
 
 func TestAggregatePRs_EmptyArrayCountsZero(t *testing.T) {
@@ -124,16 +111,10 @@ echo '[]'
 		"2026-01-01", "2026-02-01",
 		"fake-token",
 	)
-	if err != nil {
-		t.Fatalf("AggregatePRs: %v", err)
-	}
-	if got == nil {
-		t.Fatalf("AggregatePRs returned nil with non-empty token")
-	}
+	require.NoError(t, err, "AggregatePRs")
+	require.NotNil(t, got, "AggregatePRs returned nil with non-empty token")
 	want := PRResult{Opened: 0, Merged: 0}
-	if *got != want {
-		t.Fatalf("AggregatePRs = %+v, want %+v", *got, want)
-	}
+	assert.Equal(t, want, *got, "AggregatePRs")
 }
 
 func TestAggregatePRs_BadJSONIsError(t *testing.T) {
@@ -149,9 +130,7 @@ echo 'not json at all'
 		"2026-01-01", "2026-02-01",
 		"fake-token",
 	)
-	if err == nil {
-		t.Fatalf("AggregatePRs: expected parse error, got nil")
-	}
+	require.Error(t, err, "AggregatePRs expected parse error")
 }
 
 func TestAggregatePRs_InjectsGHTokenIntoEnv(t *testing.T) {
@@ -173,14 +152,8 @@ echo '[]'
 		"2026-01-01", "2026-02-01",
 		"injected-token-123",
 	)
-	if err != nil {
-		t.Fatalf("AggregatePRs: %v", err)
-	}
+	require.NoError(t, err, "AggregatePRs")
 	got, err := os.ReadFile(sideChannel)
-	if err != nil {
-		t.Fatalf("read side channel: %v", err)
-	}
-	if string(got) != "injected-token-123" {
-		t.Fatalf("GH_TOKEN in env = %q, want %q", got, "injected-token-123")
-	}
+	require.NoError(t, err, "read side channel")
+	assert.Equal(t, "injected-token-123", string(got), "GH_TOKEN in env")
 }

--- a/internal/db/git/repos_test.go
+++ b/internal/db/git/repos_test.go
@@ -3,9 +3,11 @@ package git
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // initBareRepo runs `git init -b main` at root and configures a
@@ -25,9 +27,7 @@ func initBareRepo(t *testing.T) string {
 func mkdirIn(t *testing.T, root, rel string) string {
 	t.Helper()
 	p := filepath.Join(root, rel)
-	if err := os.MkdirAll(p, 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", p, err)
-	}
+	require.NoError(t, os.MkdirAll(p, 0o755), "mkdir %s", p)
 	return p
 }
 
@@ -56,9 +56,7 @@ func TestDiscoverRepos_FindsRootAndFiltersMissing(t *testing.T) {
 
 	got := DiscoverRepos([]string{sub, outside})
 	want := []string{repoA}
-	if !reflect.DeepEqual(canonAll(got), canonAll(want)) {
-		t.Fatalf("DiscoverRepos = %v, want %v", got, want)
-	}
+	assert.Equal(t, canonAll(want), canonAll(got), "DiscoverRepos")
 }
 
 func TestDiscoverRepos_Dedup(t *testing.T) {
@@ -68,26 +66,18 @@ func TestDiscoverRepos_Dedup(t *testing.T) {
 	sub2 := mkdirIn(t, repoA, "sub2/deeper")
 
 	got := DiscoverRepos([]string{sub1, sub2, repoA})
-	if len(got) != 1 {
-		t.Fatalf("DiscoverRepos = %v, want exactly one entry "+
-			"(dedup)", got)
-	}
-	if !reflect.DeepEqual(canonAll(got), canonAll([]string{repoA})) {
-		t.Fatalf("DiscoverRepos = %v, want %v", got, repoA)
-	}
+	require.Len(t, got, 1, "want exactly one entry (dedup)")
+	assert.Equal(t, canonAll([]string{repoA}), canonAll(got),
+		"DiscoverRepos")
 }
 
 func TestDiscoverRepos_EmptyInputReturnsEmptySlice(t *testing.T) {
 	got := DiscoverRepos(nil)
-	if got == nil || len(got) != 0 {
-		t.Fatalf("DiscoverRepos(nil) = %v, want non-nil empty slice",
-			got)
-	}
+	require.NotNil(t, got, "DiscoverRepos(nil)")
+	assert.Empty(t, got, "DiscoverRepos(nil) should be empty slice")
 	got = DiscoverRepos([]string{})
-	if got == nil || len(got) != 0 {
-		t.Fatalf("DiscoverRepos([]) = %v, want non-nil empty slice",
-			got)
-	}
+	require.NotNil(t, got, "DiscoverRepos([])")
+	assert.Empty(t, got, "DiscoverRepos([]) should be empty slice")
 }
 
 // TestDiscoverRepos_LinkedWorktreeResolves covers the regression flagged
@@ -109,16 +99,11 @@ func TestDiscoverRepos_LinkedWorktreeResolves(t *testing.T) {
 	)
 
 	got := DiscoverRepos([]string{worktreeRoot})
-	if len(got) != 1 {
-		t.Fatalf("DiscoverRepos = %v, want one worktree root", got)
-	}
-	if !reflect.DeepEqual(
-		canonAll(got),
+	require.Len(t, got, 1, "want one worktree root")
+	assert.Equal(t,
 		canonAll([]string{worktreeRoot}),
-	) {
-		t.Fatalf("DiscoverRepos = %v, want %v "+
-			"(worktree path)", got, worktreeRoot)
-	}
+		canonAll(got),
+		"DiscoverRepos (worktree path)")
 }
 
 // TestDiscoverRepos_MissingCwdSkipped confirms that a cwd whose path is
@@ -129,7 +114,5 @@ func TestDiscoverRepos_MissingCwdSkipped(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "no", "such", "path")
 
 	got := DiscoverRepos([]string{missing})
-	if len(got) != 0 {
-		t.Fatalf("DiscoverRepos = %v, want empty (missing path)", got)
-	}
+	assert.Empty(t, got, "DiscoverRepos missing path")
 }

--- a/internal/db/insights_test.go
+++ b/internal/db/insights_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInsights_InsertAndGet(t *testing.T) {
@@ -25,28 +27,16 @@ func TestInsights_InsertAndGet(t *testing.T) {
 	}
 
 	id, err := d.InsertInsight(*want)
-	if err != nil {
-		t.Fatalf("InsertInsight: %v", err)
-	}
-	if id <= 0 {
-		t.Fatalf("expected positive ID, got %d", id)
-	}
+	require.NoError(t, err, "InsertInsight")
+	require.Positive(t, id, "expected positive ID")
 
 	got, err := d.GetInsight(ctx, id)
-	if err != nil {
-		t.Fatalf("GetInsight: %v", err)
-	}
-	if got == nil {
-		t.Fatal("expected insight, got nil")
-		return
-	}
+	require.NoError(t, err, "GetInsight")
+	require.NotNil(t, got, "expected insight")
 
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Insight{}, "ID", "CreatedAt")); diff != "" {
-		t.Errorf("Insight mismatch (-want +got):\n%s", diff)
-	}
-	if got.CreatedAt == "" {
-		t.Error("expected created_at to be set")
-	}
+	diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Insight{}, "ID", "CreatedAt"))
+	assert.Empty(t, diff, "Insight mismatch (-want +got)")
+	assert.NotEmpty(t, got.CreatedAt, "expected created_at to be set")
 }
 
 func TestInsights_InsertDateRange(t *testing.T) {
@@ -62,22 +52,14 @@ func TestInsights_InsertDateRange(t *testing.T) {
 	}
 
 	id, err := d.InsertInsight(*want)
-	if err != nil {
-		t.Fatalf("InsertInsight: %v", err)
-	}
+	require.NoError(t, err, "InsertInsight")
 
 	got, err := d.GetInsight(ctx, id)
-	if err != nil {
-		t.Fatalf("GetInsight: %v", err)
-	}
-	if got == nil {
-		t.Fatal("expected insight, got nil")
-		return
-	}
+	require.NoError(t, err, "GetInsight")
+	require.NotNil(t, got, "expected insight")
 
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Insight{}, "ID", "CreatedAt")); diff != "" {
-		t.Errorf("Insight mismatch (-want +got):\n%s", diff)
-	}
+	diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Insight{}, "ID", "CreatedAt"))
+	assert.Empty(t, diff, "Insight mismatch (-want +got)")
 }
 
 func TestInsights_GetNonexistent(t *testing.T) {
@@ -85,12 +67,8 @@ func TestInsights_GetNonexistent(t *testing.T) {
 	ctx := context.Background()
 
 	got, err := d.GetInsight(ctx, 99999)
-	if err != nil {
-		t.Fatalf("GetInsight: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("expected nil, got %+v", got)
-	}
+	require.NoError(t, err, "GetInsight")
+	assert.Nil(t, got, "expected nil")
 }
 
 func TestListInsights(t *testing.T) {
@@ -106,9 +84,7 @@ func TestListInsights(t *testing.T) {
 		var ids []int64
 		for _, s := range entries {
 			id, err := d.InsertInsight(s)
-			if err != nil {
-				t.Fatalf("InsertInsight: %v", err)
-			}
+			require.NoError(t, err, "InsertInsight")
 			ids = append(ids, id)
 		}
 		return ids
@@ -126,13 +102,9 @@ func TestListInsights(t *testing.T) {
 			filter: InsightFilter{},
 			verify: func(t *testing.T, got []Insight, _ []int64) {
 				wantContent := []string{"Day 2 app-a", "Analysis", "Day 1 app-b", "Day 1 app-a"}
-				if len(got) != len(wantContent) {
-					t.Fatalf("got %d insights, want %d", len(got), len(wantContent))
-				}
+				require.Len(t, got, len(wantContent))
 				for i, want := range wantContent {
-					if got[i].Content != want {
-						t.Errorf("got[%d].Content = %q, want %q", i, got[i].Content, want)
-					}
+					assert.Equal(t, want, got[i].Content, "got[%d].Content", i)
 				}
 			},
 		},
@@ -142,13 +114,9 @@ func TestListInsights(t *testing.T) {
 			filter: InsightFilter{Type: "daily_activity"},
 			verify: func(t *testing.T, got []Insight, _ []int64) {
 				wantContent := []string{"Day 2 app-a", "Day 1 app-b", "Day 1 app-a"}
-				if len(got) != len(wantContent) {
-					t.Fatalf("got %d insights, want %d", len(got), len(wantContent))
-				}
+				require.Len(t, got, len(wantContent))
 				for i, want := range wantContent {
-					if got[i].Content != want {
-						t.Errorf("got[%d].Content = %q, want %q", i, got[i].Content, want)
-					}
+					assert.Equal(t, want, got[i].Content, "got[%d].Content", i)
 				}
 			},
 		},
@@ -158,13 +126,9 @@ func TestListInsights(t *testing.T) {
 			filter: InsightFilter{Project: "app-a"},
 			verify: func(t *testing.T, got []Insight, _ []int64) {
 				wantContent := []string{"Day 2 app-a", "Day 1 app-a"}
-				if len(got) != len(wantContent) {
-					t.Fatalf("got %d insights, want %d", len(got), len(wantContent))
-				}
+				require.Len(t, got, len(wantContent))
 				for i, want := range wantContent {
-					if got[i].Content != want {
-						t.Errorf("got[%d].Content = %q, want %q", i, got[i].Content, want)
-					}
+					assert.Equal(t, want, got[i].Content, "got[%d].Content", i)
 				}
 			},
 		},
@@ -174,13 +138,9 @@ func TestListInsights(t *testing.T) {
 			filter: InsightFilter{GlobalOnly: true},
 			verify: func(t *testing.T, got []Insight, _ []int64) {
 				wantContent := []string{"Analysis"}
-				if len(got) != len(wantContent) {
-					t.Fatalf("got %d insights, want %d", len(got), len(wantContent))
-				}
+				require.Len(t, got, len(wantContent))
 				for i, want := range wantContent {
-					if got[i].Content != want {
-						t.Errorf("got[%d].Content = %q, want %q", i, got[i].Content, want)
-					}
+					assert.Equal(t, want, got[i].Content, "got[%d].Content", i)
 				}
 			},
 		},
@@ -189,9 +149,7 @@ func TestListInsights(t *testing.T) {
 			seed:   seedFiltersData,
 			filter: InsightFilter{Type: "agent_analysis", Project: "nonexistent"},
 			verify: func(t *testing.T, got []Insight, _ []int64) {
-				if len(got) != 0 {
-					t.Fatalf("got %d insights, want 0", len(got))
-				}
+				assert.Empty(t, got, "got insights")
 			},
 		},
 		{
@@ -204,24 +162,16 @@ func TestListInsights(t *testing.T) {
 						DateFrom: "2025-01-15", DateTo: "2025-01-15",
 						Agent: "claude", Content: content,
 					})
-					if err != nil {
-						t.Fatalf("InsertInsight: %v", err)
-					}
+					require.NoError(t, err, "InsertInsight")
 					ids = append(ids, id)
 				}
 				return ids
 			},
 			filter: InsightFilter{},
 			verify: func(t *testing.T, got []Insight, ids []int64) {
-				if len(got) != 3 {
-					t.Fatalf("got %d insights, want 3", len(got))
-				}
-				if got[0].ID != ids[2] {
-					t.Errorf("first id = %d, want %d", got[0].ID, ids[2])
-				}
-				if got[2].ID != ids[0] {
-					t.Errorf("last id = %d, want %d", got[2].ID, ids[0])
-				}
+				require.Len(t, got, 3)
+				assert.Equal(t, ids[2], got[0].ID, "first id")
+				assert.Equal(t, ids[0], got[2].ID, "last id")
 			},
 		},
 		{
@@ -237,9 +187,7 @@ func TestListInsights(t *testing.T) {
 						Agent:    "claude",
 						Content:  fmt.Sprintf("insight %d", i),
 					})
-					if err != nil {
-						t.Fatalf("InsertInsight %d: %v", i, err)
-					}
+					require.NoError(t, err, "InsertInsight %d", i)
 					ids = append(ids, id)
 				}
 				return ids
@@ -247,20 +195,15 @@ func TestListInsights(t *testing.T) {
 			filter: InsightFilter{},
 			verify: func(t *testing.T, got []Insight, ids []int64) {
 				const total = 502
-				if len(got) != 500 {
-					t.Fatalf("got %d insights, want 500 (capped)", len(got))
-				}
+				require.Len(t, got, 500, "capped at 500")
 
 				// Newest (id 502) should be first.
 				newestID := ids[total-1]
-				if got[0].ID != newestID {
-					t.Errorf("first ID = %d, want %d (newest)", got[0].ID, newestID)
-				}
+				assert.Equal(t, newestID, got[0].ID, "first ID (newest)")
 				// Oldest retained should be id 3 (skipping 1 and 2).
 				oldestRetainedID := ids[total-500]
-				if got[499].ID != oldestRetainedID {
-					t.Errorf("last ID = %d, want %d (oldest retained)", got[499].ID, oldestRetainedID)
-				}
+				assert.Equal(t, oldestRetainedID, got[499].ID,
+					"last ID (oldest retained)")
 			},
 		},
 	}
@@ -270,9 +213,7 @@ func TestListInsights(t *testing.T) {
 			d := testDB(t)
 			ids := tt.seed(t, d)
 			got, err := d.ListInsights(ctx, tt.filter)
-			if err != nil {
-				t.Fatalf("ListInsights: %v", err)
-			}
+			require.NoError(t, err, "ListInsights")
 			tt.verify(t, got, ids)
 		})
 	}
@@ -287,19 +228,11 @@ func TestInsights_Delete(t *testing.T) {
 		DateFrom: "2025-01-15", DateTo: "2025-01-15",
 		Agent: "claude", Content: "to be deleted",
 	})
-	if err != nil {
-		t.Fatalf("InsertInsight: %v", err)
-	}
+	require.NoError(t, err, "InsertInsight")
 
-	if err := d.DeleteInsight(id); err != nil {
-		t.Fatalf("DeleteInsight: %v", err)
-	}
+	require.NoError(t, d.DeleteInsight(id), "DeleteInsight")
 
 	got, err := d.GetInsight(ctx, id)
-	if err != nil {
-		t.Fatalf("GetInsight after delete: %v", err)
-	}
-	if got != nil {
-		t.Fatal("expected nil after delete")
-	}
+	require.NoError(t, err, "GetInsight after delete")
+	assert.Nil(t, got, "expected nil after delete")
 }

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInsertAndGetMessage_ThinkingText(t *testing.T) {
@@ -24,35 +27,28 @@ func TestInsertAndGetMessage_ThinkingText(t *testing.T) {
 	})
 
 	got, err := d.GetAllMessages(context.Background(), sessionID)
-	requireNoError(t, err, "GetAllMessages")
-	if len(got) != 1 {
-		t.Fatalf("GetAllMessages returned %d messages, want 1", len(got))
-	}
-	if got[0].ThinkingText != "I am pondering" {
-		t.Errorf(
-			"ThinkingText = %q, want %q",
-			got[0].ThinkingText, "I am pondering",
-		)
-	}
+	require.NoError(t, err, "GetAllMessages")
+	require.Len(t, got, 1)
+	assert.Equal(t, "I am pondering", got[0].ThinkingText, "ThinkingText")
 }
 
 func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 	d := testDB(t)
 
-	requireNoError(t, d.Update(func(tx *sql.Tx) error {
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
 		_, err := tx.Exec(
 			"INSERT INTO excluded_sessions (id) VALUES (?)",
 			"excluded",
 		)
 		return err
 	}), "seed excluded session")
-	requireNoError(t, d.UpsertSession(Session{
+	require.NoError(t, d.UpsertSession(Session{
 		ID:      "trashed",
 		Project: "proj",
 		Machine: defaultMachine,
 		Agent:   defaultAgent,
 	}), "seed trashed session")
-	requireNoError(t, d.SoftDeleteSession("trashed"), "soft delete session")
+	require.NoError(t, d.SoftDeleteSession("trashed"), "soft delete session")
 
 	health := 95
 	grade := "A"
@@ -135,68 +131,35 @@ func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 			DataVersion: CurrentDataVersion(),
 		},
 	})
-	requireNoError(t, err, "WriteSessionBatch")
-	if result.WrittenSessions != 1 {
-		t.Fatalf("WrittenSessions = %d, want 1", result.WrittenSessions)
-	}
-	if result.WrittenMessages != 2 {
-		t.Fatalf("WrittenMessages = %d, want 2", result.WrittenMessages)
-	}
-	if result.FailedSessions != 1 {
-		t.Fatalf("FailedSessions = %d, want 1", result.FailedSessions)
-	}
-	if result.ExcludedSessions != 2 {
-		t.Fatalf("ExcludedSessions = %d, want 2", result.ExcludedSessions)
-	}
+	require.NoError(t, err, "WriteSessionBatch")
+	require.Equal(t, 1, result.WrittenSessions, "WrittenSessions")
+	require.Equal(t, 2, result.WrittenMessages, "WrittenMessages")
+	require.Equal(t, 1, result.FailedSessions, "FailedSessions")
+	require.Equal(t, 2, result.ExcludedSessions, "ExcludedSessions")
 
 	sess, err := d.GetSessionFull(context.Background(), "good")
-	requireNoError(t, err, "GetSessionFull good")
-	if sess == nil {
-		t.Fatal("good session not found")
-	}
-	if sess.DataVersion != CurrentDataVersion() {
-		t.Errorf(
-			"DataVersion = %d, want %d",
-			sess.DataVersion, CurrentDataVersion(),
-		)
-	}
-	if sess.Outcome != "success" || sess.OutcomeConfidence != "high" {
-		t.Errorf(
-			"signals = %q/%q, want success/high",
-			sess.Outcome, sess.OutcomeConfidence,
-		)
-	}
-	if !sess.HasToolCalls {
-		t.Error("HasToolCalls = false, want true")
-	}
+	require.NoError(t, err, "GetSessionFull good")
+	require.NotNil(t, sess, "good session not found")
+	assert.Equal(t, CurrentDataVersion(), sess.DataVersion, "DataVersion")
+	assert.Equal(t, "success", sess.Outcome, "Outcome")
+	assert.Equal(t, "high", sess.OutcomeConfidence, "OutcomeConfidence")
+	assert.True(t, sess.HasToolCalls, "HasToolCalls")
 	trashed, err := d.GetSessionFull(context.Background(), "trashed")
-	requireNoError(t, err, "GetSessionFull trashed")
-	if trashed == nil || trashed.DeletedAt == nil {
-		t.Fatal("trashed session was not preserved in trash")
-	}
+	require.NoError(t, err, "GetSessionFull trashed")
+	require.NotNil(t, trashed, "trashed session was not preserved in trash")
+	assert.NotNil(t, trashed.DeletedAt, "trashed session was not preserved in trash")
 
 	msgs, err := d.GetAllMessages(context.Background(), "good")
-	requireNoError(t, err, "GetAllMessages good")
-	if len(msgs) != 2 {
-		t.Fatalf("got %d messages, want 2", len(msgs))
-	}
-	if len(msgs[1].ToolCalls) != 1 {
-		t.Fatalf(
-			"assistant tool calls = %d, want 1",
-			len(msgs[1].ToolCalls),
-		)
-	}
+	require.NoError(t, err, "GetAllMessages good")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1, "assistant tool calls")
 
 	bad, err := d.GetSessionFull(context.Background(), "bad")
-	requireNoError(t, err, "GetSessionFull bad")
-	if bad != nil {
-		t.Fatal("bad session should have rolled back")
-	}
+	require.NoError(t, err, "GetSessionFull bad")
+	assert.Nil(t, bad, "bad session should have rolled back")
 	excluded, err := d.GetSessionFull(context.Background(), "excluded")
-	requireNoError(t, err, "GetSessionFull excluded")
-	if excluded != nil {
-		t.Fatal("excluded session should not be written")
-	}
+	require.NoError(t, err, "GetSessionFull excluded")
+	assert.Nil(t, excluded, "excluded session should not be written")
 }
 
 func TestMigration_ThinkingTextColumn(t *testing.T) {
@@ -206,7 +169,7 @@ func TestMigration_ThinkingTextColumn(t *testing.T) {
 	// Create a DB with the current schema then drop the
 	// thinking_text column to simulate a pre-migration DB.
 	d, err := Open(path)
-	requireNoError(t, err, "initial open")
+	require.NoError(t, err, "initial open")
 	insertSession(t, d, "s1", "proj")
 	insertMessages(t, d,
 		userMsg("s1", 0, "hello"),
@@ -223,11 +186,11 @@ func TestMigration_ThinkingTextColumn(t *testing.T) {
 	// Remove thinking_text via ALTER TABLE DROP COLUMN
 	// (SQLite 3.35+) to simulate a legacy schema.
 	conn, err := sql.Open("sqlite3", path)
-	requireNoError(t, err, "raw open")
+	require.NoError(t, err, "raw open")
 	_, err = conn.Exec(
 		`ALTER TABLE messages DROP COLUMN thinking_text`,
 	)
-	requireNoError(t, err, "drop thinking_text column")
+	require.NoError(t, err, "drop thinking_text column")
 
 	// Verify column is gone.
 	var count int
@@ -235,10 +198,8 @@ func TestMigration_ThinkingTextColumn(t *testing.T) {
 		`SELECT count(*) FROM pragma_table_info('messages')` +
 			` WHERE name = 'thinking_text'`,
 	).Scan(&count)
-	requireNoError(t, err, "verify column removed")
-	if count != 0 {
-		t.Fatal("expected thinking_text column to be absent")
-	}
+	require.NoError(t, err, "verify column removed")
+	require.Zero(t, count, "expected thinking_text column to be absent")
 
 	// Insert a legacy row with an explicit column list that
 	// cannot reference thinking_text (column doesn't exist yet).
@@ -264,12 +225,12 @@ func TestMigration_ThinkingTextColumn(t *testing.T) {
 			'', 0,
 			0
 		)`)
-	requireNoError(t, err, "insert legacy row")
+	require.NoError(t, err, "insert legacy row")
 	conn.Close()
 
 	// Reopen with Open() — migration should add the column.
 	d2, err := Open(path)
-	requireNoError(t, err, "reopen after migration")
+	require.NoError(t, err, "reopen after migration")
 	defer d2.Close()
 
 	// Verify column exists.
@@ -277,24 +238,15 @@ func TestMigration_ThinkingTextColumn(t *testing.T) {
 		`SELECT count(*) FROM pragma_table_info('messages')` +
 			` WHERE name = 'thinking_text'`,
 	).Scan(&count)
-	requireNoError(t, err, "verify column added")
-	if count != 1 {
-		t.Fatal("expected thinking_text column after migration")
-	}
+	require.NoError(t, err, "verify column added")
+	require.Equal(t, 1, count, "expected thinking_text column after migration")
 
 	// Verify all rows survive and the legacy row defaults to "".
 	msgs, err := d2.GetAllMessages(context.Background(), "s1")
-	requireNoError(t, err, "get messages")
-	if len(msgs) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err, "get messages")
+	require.Len(t, msgs, 3)
 	for _, m := range msgs {
-		if m.ThinkingText != "" {
-			t.Errorf(
-				"ord=%d ThinkingText = %q, want %q (default)",
-				m.Ordinal, m.ThinkingText, "",
-			)
-		}
+		assert.Empty(t, m.ThinkingText, "ord=%d ThinkingText", m.Ordinal)
 	}
 
 	// Insert a new message with ThinkingText and verify round-trip.
@@ -306,16 +258,9 @@ func TestMigration_ThinkingTextColumn(t *testing.T) {
 		ThinkingText: "x",
 	})
 	msgs, err = d2.GetAllMessages(context.Background(), "s1")
-	requireNoError(t, err, "get messages after insert")
-	if len(msgs) != 4 {
-		t.Fatalf("expected 4 messages, got %d", len(msgs))
-	}
-	if msgs[3].ThinkingText != "x" {
-		t.Errorf(
-			"ThinkingText = %q, want %q",
-			msgs[3].ThinkingText, "x",
-		)
-	}
+	require.NoError(t, err, "get messages after insert")
+	require.Len(t, msgs, 4)
+	assert.Equal(t, "x", msgs[3].ThinkingText, "ThinkingText")
 }
 
 // TestReplaceSessionMessages_LargeSession is a perf regression test
@@ -364,26 +309,16 @@ func TestReplaceSessionMessages_LargeSession(t *testing.T) {
 		repl = append(repl, userMsg(sessionID, i, "after"))
 	}
 	start := time.Now()
-	if err := d.ReplaceSessionMessages(sessionID, repl); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages(sessionID, repl),
+		"ReplaceSessionMessages")
 	elapsed := time.Since(start)
-	if elapsed > 10*time.Second {
-		t.Fatalf(
-			"ReplaceSessionMessages took %s, want < 10s "+
-				"(per-row FTS trigger regression?)",
-			elapsed.Round(time.Millisecond),
-		)
-	}
+	require.LessOrEqual(t, elapsed, 10*time.Second,
+		"ReplaceSessionMessages took %s, want < 10s (per-row FTS trigger regression?)",
+		elapsed.Round(time.Millisecond))
 
 	got, err := d.GetAllMessages(context.Background(), sessionID)
-	requireNoError(t, err, "GetAllMessages after replace")
-	if len(got) != len(repl) {
-		t.Fatalf(
-			"after replace got %d messages, want %d",
-			len(got), len(repl),
-		)
-	}
+	require.NoError(t, err, "GetAllMessages after replace")
+	require.Len(t, got, len(repl), "after replace")
 
 	// Verify the FTS index was actually scrubbed: count rows in
 	// messages_fts that join back to the (now-deleted) original
@@ -395,11 +330,7 @@ func TestReplaceSessionMessages_LargeSession(t *testing.T) {
 		`SELECT count(*) FROM messages_fts
 		 WHERE messages_fts MATCH 'xxx'`,
 	).Scan(&leaked)
-	requireNoError(t, err, "fts leak check")
-	if leaked != 0 {
-		t.Fatalf(
-			"FTS still contains %d rows matching 'xxx' from deleted blob",
-			leaked,
-		)
-	}
+	require.NoError(t, err, "fts leak check")
+	assert.Zero(t, leaked,
+		"FTS still contains rows matching 'xxx' from deleted blob")
 }

--- a/internal/db/pins_test.go
+++ b/internal/db/pins_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // pinFirstMessage pins the first message of a session and returns
@@ -11,15 +14,11 @@ func pinFirstMessage(t *testing.T, d *DB, sessionID string) int64 {
 	t.Helper()
 	ctx := context.Background()
 	msgs, err := d.GetMessages(ctx, sessionID, 0, 1, true)
-	requireNoError(t, err, "GetMessages")
-	if len(msgs) == 0 {
-		t.Fatalf("no messages in session %s", sessionID)
-	}
+	require.NoError(t, err, "GetMessages")
+	require.NotEmpty(t, msgs, "no messages in session %s", sessionID)
 	id, err := d.PinMessage(sessionID, msgs[0].ID, nil)
-	requireNoError(t, err, "PinMessage")
-	if id == 0 {
-		t.Fatalf("PinMessage returned 0 for session %s msg %d", sessionID, msgs[0].ID)
-	}
+	require.NoError(t, err, "PinMessage")
+	require.NotZero(t, id, "PinMessage returned 0 for session %s msg %d", sessionID, msgs[0].ID)
 	return msgs[0].ID
 }
 
@@ -35,10 +34,8 @@ func TestListPinnedMessages_NoFilter(t *testing.T) {
 	pinFirstMessage(t, d, "s2")
 
 	pins, err := d.ListPinnedMessages(ctx, "", "")
-	requireNoError(t, err, "ListPinnedMessages no filter")
-	if len(pins) != 2 {
-		t.Fatalf("got %d pins, want 2", len(pins))
-	}
+	require.NoError(t, err, "ListPinnedMessages no filter")
+	require.Len(t, pins, 2)
 }
 
 func TestListPinnedMessages_ProjectFilter(t *testing.T) {
@@ -67,16 +64,13 @@ func TestListPinnedMessages_ProjectFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("project="+tc.project, func(t *testing.T) {
 			pins, err := d.ListPinnedMessages(ctx, "", tc.project)
-			requireNoError(t, err, "ListPinnedMessages")
-			if len(pins) != tc.wantCount {
-				t.Errorf("got %d pins, want %d", len(pins), tc.wantCount)
-			}
+			require.NoError(t, err, "ListPinnedMessages")
+			assert.Len(t, pins, tc.wantCount)
 			// Verify project metadata on returned pins matches filter.
 			for _, p := range pins {
-				if tc.project != "" && p.SessionProject != nil &&
-					*p.SessionProject != tc.project {
-					t.Errorf("pin session_project = %q, want %q",
-						*p.SessionProject, tc.project)
+				if tc.project != "" && p.SessionProject != nil {
+					assert.Equal(t, tc.project, *p.SessionProject,
+						"pin session_project")
 				}
 			}
 		})
@@ -99,16 +93,13 @@ func TestListPinnedMessages_ProjectFilterExcludesTrashed(t *testing.T) {
 		"UPDATE sessions SET deleted_at = ? WHERE id = ?",
 		tsZeroS1, "trashed",
 	)
-	requireNoError(t, err, "soft-delete session")
+	require.NoError(t, err, "soft-delete session")
 
 	pins, err := d.ListPinnedMessages(ctx, "", "alpha")
-	requireNoError(t, err, "ListPinnedMessages")
-	if len(pins) != 1 {
-		t.Fatalf("got %d pins, want 1 (trashed session excluded)", len(pins))
-	}
-	if pins[0].SessionID != "live" {
-		t.Errorf("expected pin from live session, got session_id %q", pins[0].SessionID)
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 1, "trashed session excluded")
+	assert.Equal(t, "live", pins[0].SessionID,
+		"expected pin from live session")
 }
 
 func TestListPinnedMessages_SessionFilterIgnoresProject(t *testing.T) {
@@ -121,8 +112,6 @@ func TestListPinnedMessages_SessionFilterIgnoresProject(t *testing.T) {
 
 	// project param is ignored when sessionID is set.
 	pins, err := d.ListPinnedMessages(ctx, "s1", "beta")
-	requireNoError(t, err, "ListPinnedMessages by session")
-	if len(pins) != 1 {
-		t.Fatalf("got %d pins, want 1", len(pins))
-	}
+	require.NoError(t, err, "ListPinnedMessages by session")
+	require.Len(t, pins, 1)
 }

--- a/internal/db/pricing_test.go
+++ b/internal/db/pricing_test.go
@@ -2,6 +2,9 @@ package db
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMigrationCreatesModelPricingTable(t *testing.T) {
@@ -11,11 +14,9 @@ func TestMigrationCreatesModelPricingTable(t *testing.T) {
 	err := d.getReader().QueryRow(
 		`SELECT count(*) FROM pragma_table_info('model_pricing')`,
 	).Scan(&count)
-	requireNoError(t, err, "pragma_table_info")
+	require.NoError(t, err, "pragma_table_info")
 
-	if count == 0 {
-		t.Fatal("model_pricing table not created by schema")
-	}
+	assert.NotZero(t, count, "model_pricing table not created by schema")
 }
 
 func TestUpsertModelPricing(t *testing.T) {
@@ -32,37 +33,18 @@ func TestUpsertModelPricing(t *testing.T) {
 	}
 
 	err := d.UpsertModelPricing(prices)
-	requireNoError(t, err, "UpsertModelPricing")
+	require.NoError(t, err, "UpsertModelPricing")
 
 	got, err := d.GetModelPricing("claude-sonnet-4")
-	requireNoError(t, err, "GetModelPricing")
+	require.NoError(t, err, "GetModelPricing")
+	require.NotNil(t, got, "expected pricing")
 
-	if got == nil {
-		t.Fatal("expected pricing, got nil")
-	}
-	if got.ModelPattern != "claude-sonnet-4" {
-		t.Errorf("ModelPattern = %q, want %q",
-			got.ModelPattern, "claude-sonnet-4")
-	}
-	if got.InputPerMTok != 3.0 {
-		t.Errorf("InputPerMTok = %v, want 3.0",
-			got.InputPerMTok)
-	}
-	if got.OutputPerMTok != 15.0 {
-		t.Errorf("OutputPerMTok = %v, want 15.0",
-			got.OutputPerMTok)
-	}
-	if got.CacheCreationPerMTok != 3.75 {
-		t.Errorf("CacheCreationPerMTok = %v, want 3.75",
-			got.CacheCreationPerMTok)
-	}
-	if got.CacheReadPerMTok != 0.30 {
-		t.Errorf("CacheReadPerMTok = %v, want 0.30",
-			got.CacheReadPerMTok)
-	}
-	if got.UpdatedAt == "" {
-		t.Error("expected UpdatedAt to be set")
-	}
+	assert.Equal(t, "claude-sonnet-4", got.ModelPattern)
+	assert.Equal(t, 3.0, got.InputPerMTok)
+	assert.Equal(t, 15.0, got.OutputPerMTok)
+	assert.Equal(t, 3.75, got.CacheCreationPerMTok)
+	assert.Equal(t, 0.30, got.CacheReadPerMTok)
+	assert.NotEmpty(t, got.UpdatedAt, "expected UpdatedAt to be set")
 }
 
 func TestUpsertModelPricingOverwrites(t *testing.T) {
@@ -78,7 +60,7 @@ func TestUpsertModelPricingOverwrites(t *testing.T) {
 		},
 	}
 	err := d.UpsertModelPricing(initial)
-	requireNoError(t, err, "UpsertModelPricing initial")
+	require.NoError(t, err, "UpsertModelPricing initial")
 
 	updated := []ModelPricing{
 		{
@@ -90,30 +72,16 @@ func TestUpsertModelPricingOverwrites(t *testing.T) {
 		},
 	}
 	err = d.UpsertModelPricing(updated)
-	requireNoError(t, err, "UpsertModelPricing updated")
+	require.NoError(t, err, "UpsertModelPricing updated")
 
 	got, err := d.GetModelPricing("claude-opus-4")
-	requireNoError(t, err, "GetModelPricing after update")
+	require.NoError(t, err, "GetModelPricing after update")
+	require.NotNil(t, got, "expected pricing")
 
-	if got == nil {
-		t.Fatal("expected pricing, got nil")
-	}
-	if got.InputPerMTok != 10.0 {
-		t.Errorf("InputPerMTok = %v, want 10.0",
-			got.InputPerMTok)
-	}
-	if got.OutputPerMTok != 50.0 {
-		t.Errorf("OutputPerMTok = %v, want 50.0",
-			got.OutputPerMTok)
-	}
-	if got.CacheCreationPerMTok != 12.50 {
-		t.Errorf("CacheCreationPerMTok = %v, want 12.50",
-			got.CacheCreationPerMTok)
-	}
-	if got.CacheReadPerMTok != 1.00 {
-		t.Errorf("CacheReadPerMTok = %v, want 1.00",
-			got.CacheReadPerMTok)
-	}
+	assert.Equal(t, 10.0, got.InputPerMTok)
+	assert.Equal(t, 50.0, got.OutputPerMTok)
+	assert.Equal(t, 12.50, got.CacheCreationPerMTok)
+	assert.Equal(t, 1.00, got.CacheReadPerMTok)
 }
 
 func TestPricingMeta(t *testing.T) {
@@ -121,36 +89,31 @@ func TestPricingMeta(t *testing.T) {
 
 	// Initially empty.
 	got, err := d.GetPricingMeta("_fallback_version")
-	requireNoError(t, err, "GetPricingMeta empty")
-	if got != "" {
-		t.Fatalf("expected empty, got %q", got)
-	}
+	require.NoError(t, err, "GetPricingMeta empty")
+	require.Empty(t, got)
 
 	// Set and read back.
-	requireNoError(t,
+	require.NoError(t,
 		d.SetPricingMeta("_fallback_version", "v1"),
 		"SetPricingMeta v1")
 	got, err = d.GetPricingMeta("_fallback_version")
-	requireNoError(t, err, "GetPricingMeta v1")
-	if got != "v1" {
-		t.Fatalf("expected %q, got %q", "v1", got)
-	}
+	require.NoError(t, err, "GetPricingMeta v1")
+	require.Equal(t, "v1", got)
 
 	// Update overwrites.
-	requireNoError(t,
+	require.NoError(t,
 		d.SetPricingMeta("_fallback_version", "v2"),
 		"SetPricingMeta v2")
 	got, err = d.GetPricingMeta("_fallback_version")
-	requireNoError(t, err, "GetPricingMeta v2")
-	if got != "v2" {
-		t.Fatalf("expected %q, got %q", "v2", got)
-	}
+	require.NoError(t, err, "GetPricingMeta v2")
+	require.Equal(t, "v2", got)
 
 	// Sentinel row does not interfere with model lookups.
 	p, err := d.GetModelPricing("_fallback_version")
-	requireNoError(t, err, "GetModelPricing sentinel")
-	if p != nil && p.InputPerMTok != 0 {
-		t.Errorf("sentinel should have zero pricing, got %+v", p)
+	require.NoError(t, err, "GetModelPricing sentinel")
+	if p != nil {
+		assert.Zero(t, p.InputPerMTok,
+			"sentinel should have zero pricing, got %+v", p)
 	}
 }
 
@@ -158,26 +121,21 @@ func TestGetModelPricingNotFound(t *testing.T) {
 	d := testDB(t)
 
 	got, err := d.GetModelPricing("nonexistent-model")
-	requireNoError(t, err, "GetModelPricing not found")
-
-	if got != nil {
-		t.Fatalf("expected nil, got %+v", got)
-	}
+	require.NoError(t, err, "GetModelPricing not found")
+	assert.Nil(t, got, "expected nil")
 }
 
 func TestInsertMissingModelPricing_DoesNotOverwrite(t *testing.T) {
 	d := testDB(t)
 
 	// Seed an existing row (simulating a LiteLLM rate already present).
-	if err := d.UpsertModelPricing([]ModelPricing{{
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
 		ModelPattern:         "claude-opus-4-6",
 		InputPerMTok:         5.0,
 		OutputPerMTok:        25.0,
 		CacheCreationPerMTok: 6.25,
 		CacheReadPerMTok:     0.5,
-	}}); err != nil {
-		t.Fatalf("UpsertModelPricing: %v", err)
-	}
+	}}), "UpsertModelPricing")
 
 	// Insert-missing with a DIFFERENT rate for the same pattern, plus a
 	// brand-new pattern.
@@ -185,18 +143,16 @@ func TestInsertMissingModelPricing_DoesNotOverwrite(t *testing.T) {
 		{ModelPattern: "claude-opus-4-6", InputPerMTok: 999.0, OutputPerMTok: 999.0},
 		{ModelPattern: "gpt-5.4", InputPerMTok: 2.5, OutputPerMTok: 15.0},
 	})
-	requireNoError(t, err, "InsertMissingModelPricing")
+	require.NoError(t, err, "InsertMissingModelPricing")
 
 	// Existing row is untouched.
 	opus, err := d.GetModelPricing("claude-opus-4-6")
-	requireNoError(t, err, "GetModelPricing opus")
-	if opus == nil || opus.InputPerMTok != 5.0 {
-		t.Fatalf("opus InputPerMTok = %v, want 5.0 (not overwritten)", opus)
-	}
+	require.NoError(t, err, "GetModelPricing opus")
+	require.NotNil(t, opus)
+	assert.Equal(t, 5.0, opus.InputPerMTok, "opus InputPerMTok not overwritten")
 	// New row was inserted.
 	gpt, err := d.GetModelPricing("gpt-5.4")
-	requireNoError(t, err, "GetModelPricing gpt")
-	if gpt == nil || gpt.InputPerMTok != 2.5 {
-		t.Fatalf("gpt-5.4 InputPerMTok = %v, want 2.5 (inserted)", gpt)
-	}
+	require.NoError(t, err, "GetModelPricing gpt")
+	require.NotNil(t, gpt)
+	assert.Equal(t, 2.5, gpt.InputPerMTok, "gpt-5.4 InputPerMTok inserted")
 }

--- a/internal/db/remote_skipped_test.go
+++ b/internal/db/remote_skipped_test.go
@@ -4,6 +4,9 @@ import (
 	"maps"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/dbtest"
 )
 
@@ -11,12 +14,8 @@ func TestRemoteSkippedFiles_InitiallyEmpty(t *testing.T) {
 	d := dbtest.OpenTestDB(t)
 
 	loaded, err := d.LoadRemoteSkippedFiles("devbox1")
-	if err != nil {
-		t.Fatalf("LoadRemoteSkippedFiles: %v", err)
-	}
-	if len(loaded) != 0 {
-		t.Fatalf("expected empty, got %d entries", len(loaded))
-	}
+	require.NoError(t, err, "LoadRemoteSkippedFiles")
+	require.Empty(t, loaded)
 }
 
 func TestRemoteSkippedFiles_RoundTrip(t *testing.T) {
@@ -27,19 +26,12 @@ func TestRemoteSkippedFiles_RoundTrip(t *testing.T) {
 		"/home/user/.claude/sessions/b.jsonl": 2000,
 		"/home/user/.claude/sessions/c.jsonl": 3000,
 	}
-	if err := d.ReplaceRemoteSkippedFiles(
-		"devbox1", entries,
-	); err != nil {
-		t.Fatalf("ReplaceRemoteSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceRemoteSkippedFiles("devbox1", entries))
 
 	loaded, err := d.LoadRemoteSkippedFiles("devbox1")
-	if err != nil {
-		t.Fatalf("LoadRemoteSkippedFiles: %v", err)
-	}
-	if !maps.Equal(loaded, entries) {
-		t.Errorf("loaded %v, want %v", loaded, entries)
-	}
+	require.NoError(t, err, "LoadRemoteSkippedFiles")
+	assert.True(t, maps.Equal(loaded, entries),
+		"loaded %v, want %v", loaded, entries)
 }
 
 func TestRemoteSkippedFiles_HostIsolation(t *testing.T) {
@@ -49,32 +41,18 @@ func TestRemoteSkippedFiles_HostIsolation(t *testing.T) {
 		"/a.jsonl": 100,
 		"/b.jsonl": 200,
 	}
-	if err := d.ReplaceRemoteSkippedFiles(
-		"devbox1", entries,
-	); err != nil {
-		t.Fatalf("ReplaceRemoteSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceRemoteSkippedFiles("devbox1", entries))
 
 	// Different host should return empty.
 	loaded, err := d.LoadRemoteSkippedFiles("devbox2")
-	if err != nil {
-		t.Fatalf("LoadRemoteSkippedFiles devbox2: %v", err)
-	}
-	if len(loaded) != 0 {
-		t.Fatalf(
-			"devbox2: expected empty, got %d entries",
-			len(loaded),
-		)
-	}
+	require.NoError(t, err, "LoadRemoteSkippedFiles devbox2")
+	require.Empty(t, loaded, "devbox2 should be empty")
 
 	// Original host still has its entries.
 	loaded, err = d.LoadRemoteSkippedFiles("devbox1")
-	if err != nil {
-		t.Fatalf("LoadRemoteSkippedFiles devbox1: %v", err)
-	}
-	if !maps.Equal(loaded, entries) {
-		t.Errorf("devbox1: loaded %v, want %v", loaded, entries)
-	}
+	require.NoError(t, err, "LoadRemoteSkippedFiles devbox1")
+	assert.True(t, maps.Equal(loaded, entries),
+		"devbox1: loaded %v, want %v", loaded, entries)
 }
 
 func TestRemoteSkippedFiles_ReplaceOverwrites(t *testing.T) {
@@ -84,35 +62,18 @@ func TestRemoteSkippedFiles_ReplaceOverwrites(t *testing.T) {
 		"/a.jsonl": 100,
 		"/b.jsonl": 200,
 	}
-	if err := d.ReplaceRemoteSkippedFiles(
-		"devbox1", first,
-	); err != nil {
-		t.Fatalf("ReplaceRemoteSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceRemoteSkippedFiles("devbox1", first))
 
 	// Replace with different entries.
 	second := map[string]int64{
 		"/c.jsonl": 300,
 	}
-	if err := d.ReplaceRemoteSkippedFiles(
-		"devbox1", second,
-	); err != nil {
-		t.Fatalf("ReplaceRemoteSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceRemoteSkippedFiles("devbox1", second))
 
 	loaded, err := d.LoadRemoteSkippedFiles("devbox1")
-	if err != nil {
-		t.Fatalf("LoadRemoteSkippedFiles: %v", err)
-	}
-	if len(loaded) != 1 {
-		t.Fatalf("got %d entries, want 1", len(loaded))
-	}
-	if loaded["/c.jsonl"] != 300 {
-		t.Errorf(
-			"loaded[/c.jsonl] = %d, want 300",
-			loaded["/c.jsonl"],
-		)
-	}
+	require.NoError(t, err, "LoadRemoteSkippedFiles")
+	require.Len(t, loaded, 1)
+	assert.Equal(t, int64(300), loaded["/c.jsonl"])
 }
 
 func TestRemoteSkippedFiles_ReplaceDoesNotAffectOtherHosts(
@@ -123,41 +84,19 @@ func TestRemoteSkippedFiles_ReplaceDoesNotAffectOtherHosts(
 	host1 := map[string]int64{"/a.jsonl": 100}
 	host2 := map[string]int64{"/b.jsonl": 200}
 
-	if err := d.ReplaceRemoteSkippedFiles(
-		"devbox1", host1,
-	); err != nil {
-		t.Fatalf("ReplaceRemoteSkippedFiles devbox1: %v", err)
-	}
-	if err := d.ReplaceRemoteSkippedFiles(
-		"devbox2", host2,
-	); err != nil {
-		t.Fatalf("ReplaceRemoteSkippedFiles devbox2: %v", err)
-	}
+	require.NoError(t, d.ReplaceRemoteSkippedFiles("devbox1", host1))
+	require.NoError(t, d.ReplaceRemoteSkippedFiles("devbox2", host2))
 
 	// Replace devbox1 with empty — devbox2 unaffected.
-	if err := d.ReplaceRemoteSkippedFiles(
-		"devbox1", map[string]int64{},
-	); err != nil {
-		t.Fatalf("ReplaceRemoteSkippedFiles empty: %v", err)
-	}
+	require.NoError(t,
+		d.ReplaceRemoteSkippedFiles("devbox1", map[string]int64{}))
 
 	loaded1, err := d.LoadRemoteSkippedFiles("devbox1")
-	if err != nil {
-		t.Fatalf("LoadRemoteSkippedFiles devbox1: %v", err)
-	}
-	if len(loaded1) != 0 {
-		t.Fatalf(
-			"devbox1: got %d entries, want 0", len(loaded1),
-		)
-	}
+	require.NoError(t, err, "LoadRemoteSkippedFiles devbox1")
+	require.Empty(t, loaded1, "devbox1 should be empty")
 
 	loaded2, err := d.LoadRemoteSkippedFiles("devbox2")
-	if err != nil {
-		t.Fatalf("LoadRemoteSkippedFiles devbox2: %v", err)
-	}
-	if !maps.Equal(loaded2, host2) {
-		t.Errorf(
-			"devbox2: loaded %v, want %v", loaded2, host2,
-		)
-	}
+	require.NoError(t, err, "LoadRemoteSkippedFiles devbox2")
+	assert.True(t, maps.Equal(loaded2, host2),
+		"devbox2: loaded %v, want %v", loaded2, host2)
 }

--- a/internal/db/search_content_test.go
+++ b/internal/db/search_content_test.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // seedSearchSession inserts one session with the given messages
@@ -25,9 +28,7 @@ func seedSearchSession(t *testing.T, d *DB, id, project string, msgs [][2]string
 			Content: rc[1], Timestamp: "2026-05-20T12:00:0" + itoa(i) + "Z",
 		})
 	}
-	if err := d.ReplaceSessionMessages(id, out); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages(id, out), "ReplaceSessionMessages")
 }
 
 func TestSearchContentSubstringMessages(t *testing.T) {
@@ -40,22 +41,14 @@ func TestSearchContentSubstringMessages(t *testing.T) {
 		Pattern: "database_url", Mode: "substring",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 {
-		t.Fatalf("got %d matches, want 1: %+v", len(got.Matches), got.Matches)
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1, "matches")
 	m := got.Matches[0]
-	if m.SessionID != "s1" || m.Location != "message" || m.Ordinal != 0 {
-		t.Errorf("unexpected match: %+v", m)
-	}
-	if m.Role != "user" {
-		t.Errorf("Role = %q, want user", m.Role)
-	}
-	if !contains(m.Snippet, "DATABASE_URL") {
-		t.Errorf("snippet missing matched text: %q", m.Snippet)
-	}
+	assert.Equal(t, "s1", m.SessionID, "SessionID")
+	assert.Equal(t, "message", m.Location, "Location")
+	assert.Equal(t, 0, m.Ordinal, "Ordinal")
+	assert.Equal(t, "user", m.Role, "Role")
+	assert.Contains(t, m.Snippet, "DATABASE_URL", "snippet")
 }
 
 // TestSearchContentRedactsStraddlingSecret pins the default (non-reveal)
@@ -76,41 +69,19 @@ func TestSearchContentRedactsStraddlingSecret(t *testing.T) {
 		Sources: []string{"messages"}, Limit: 50,
 	}
 	got, err := d.SearchContent(context.Background(), base)
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 {
-		t.Fatalf("got %d matches, want 1", len(got.Matches))
-	}
-	if strings.Contains(got.Matches[0].Snippet, "SECRETKEYMATERIAL") {
-		t.Errorf("default snippet leaked key material: %q", got.Matches[0].Snippet)
-	}
-	if !contains(got.Matches[0].Snippet, "attached key") {
-		t.Errorf("snippet lost the matched context: %q", got.Matches[0].Snippet)
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1)
+	assert.NotContains(t, got.Matches[0].Snippet, "SECRETKEYMATERIAL",
+		"default snippet leaked key material")
+	assert.Contains(t, got.Matches[0].Snippet, "attached key",
+		"snippet lost the matched context")
 
 	// Reveal opts out of redaction (localhost-gated upstream): raw bytes show.
 	base.RevealSecrets = true
 	rev, err := d.SearchContent(context.Background(), base)
-	if err != nil {
-		t.Fatalf("SearchContent reveal: %v", err)
-	}
-	if !strings.Contains(rev.Matches[0].Snippet, "SECRETKEYMATERIAL") {
-		t.Errorf("reveal snippet should show raw bytes: %q", rev.Matches[0].Snippet)
-	}
-}
-
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (indexOf(s, sub) >= 0)
-}
-
-func indexOf(s, sub string) int {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
+	require.NoError(t, err, "SearchContent reveal")
+	assert.Contains(t, rev.Matches[0].Snippet, "SECRETKEYMATERIAL",
+		"reveal snippet should show raw bytes")
 }
 
 // TestCaseInsensitiveIndexUnicodeOffset pins that the returned offset indexes
@@ -118,12 +89,11 @@ func indexOf(s, sub string) int {
 // bytes but lowercases to one ('k'), so a ToLower-based index would report a
 // byte offset shifted left of the real match position.
 func TestCaseInsensitiveIndexUnicodeOffset(t *testing.T) {
-	body := strings.Repeat("K", 5) + "match here"
+	body := strings.Repeat("K", 5) + "match here"
 	got := CaseInsensitiveIndex(body, "MATCH")
 	want := strings.Index(body, "match") // real offset into the original string
-	if got != want {
-		t.Errorf("CaseInsensitiveIndex = %d, want %d (offset into original body)", got, want)
-	}
+	assert.Equal(t, want, got,
+		"CaseInsensitiveIndex offset into original body")
 }
 
 // TestSubstringSnippetUnicodeOffset guards against the snippet panic and
@@ -135,9 +105,7 @@ func TestSubstringSnippetUnicodeOffset(t *testing.T) {
 	body := strings.Repeat("Ⱥ", 100) + pat + " trailing context here"
 	f := ContentSearchFilter{Pattern: pat, Mode: "substring"}
 	got := f.substringSnippet(body) // must not panic
-	if !strings.Contains(got, pat) {
-		t.Errorf("snippet did not center on the match: %q", got)
-	}
+	assert.Contains(t, got, pat, "snippet did not center on the match")
 }
 
 func TestSearchContentToolIO(t *testing.T) {
@@ -155,28 +123,25 @@ func TestSearchContentToolIO(t *testing.T) {
 			ResultContent: "AWS_SECRET=topsecretvalue123",
 		}},
 	}}
-	if err := d.ReplaceSessionMessages("s2", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages("s2", msgs),
+		"ReplaceSessionMessages")
 	// match in tool input
 	in, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "printenv", Mode: "substring",
 		Sources: []string{"tool_input"}, Limit: 50,
 	})
-	if err != nil || len(in.Matches) != 1 || in.Matches[0].Location != "tool_input" {
-		t.Fatalf("tool_input search: %+v err=%v", in.Matches, err)
-	}
-	if in.Matches[0].ToolName != "Bash" {
-		t.Errorf("ToolName = %q, want Bash", in.Matches[0].ToolName)
-	}
+	require.NoError(t, err, "tool_input search")
+	require.Len(t, in.Matches, 1, "tool_input search")
+	require.Equal(t, "tool_input", in.Matches[0].Location, "Location")
+	assert.Equal(t, "Bash", in.Matches[0].ToolName, "ToolName")
 	// match in tool result
 	res, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "topsecretvalue", Mode: "substring",
 		Sources: []string{"tool_result"}, Limit: 50,
 	})
-	if err != nil || len(res.Matches) != 1 || res.Matches[0].Location != "tool_result" {
-		t.Fatalf("tool_result search: %+v err=%v", res.Matches, err)
-	}
+	require.NoError(t, err, "tool_result search")
+	require.Len(t, res.Matches, 1, "tool_result search")
+	assert.Equal(t, "tool_result", res.Matches[0].Location, "Location")
 }
 
 // TestSearchContentEmptyToolUseIDNotSuppressed guards the tool-result dedup:
@@ -206,9 +171,8 @@ func TestSearchContentEmptyToolUseIDNotSuppressed(t *testing.T) {
 			},
 		},
 	}}
-	if err := d.ReplaceSessionMessages("empti", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages("empti", msgs),
+		"ReplaceSessionMessages")
 	// ReplaceSessionMessages routes empty ToolUseID through nilIfEmpty so
 	// it lands as NULL. NULL = NULL is false in SQL, so the dedup bug we
 	// want to pin (an empty string matching another empty string) only
@@ -219,34 +183,27 @@ func TestSearchContentEmptyToolUseIDNotSuppressed(t *testing.T) {
 		"UPDATE tool_calls SET tool_use_id = '' WHERE session_id = 'empti'",
 		"UPDATE tool_result_events SET tool_use_id = '' WHERE session_id = 'empti'",
 	} {
-		if _, err := d.getWriter().Exec(sql); err != nil {
-			t.Fatalf("force empty tool_use_id: %v", err)
-		}
+		_, err := d.getWriter().Exec(sql)
+		require.NoError(t, err, "force empty tool_use_id")
 	}
 	for _, mode := range []string{"substring", "regex"} {
 		got, err := d.SearchContent(context.Background(), ContentSearchFilter{
 			Pattern: "FINDA", Mode: mode,
 			Sources: []string{"tool_result"}, Limit: 50,
 		})
-		if err != nil {
-			t.Fatalf("SearchContent %s: %v", mode, err)
-		}
-		if len(got.Matches) != 1 || got.Matches[0].Location != "tool_result" {
-			t.Fatalf("%s: empty-ID result_content suppressed: got %+v, want 1 tool_result",
-				mode, got.Matches)
-		}
+		require.NoError(t, err, "SearchContent %s", mode)
+		require.Len(t, got.Matches, 1,
+			"%s: empty-ID result_content suppressed", mode)
+		assert.Equal(t, "tool_result", got.Matches[0].Location,
+			"%s: want 1 tool_result", mode)
 	}
 	// The event-delivered result is still searchable via the events branch.
 	ev, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "FINDB", Mode: "substring",
 		Sources: []string{"tool_result"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent events: %v", err)
-	}
-	if len(ev.Matches) != 1 {
-		t.Errorf("event content not found: got %+v", ev.Matches)
-	}
+	require.NoError(t, err, "SearchContent events")
+	assert.Len(t, ev.Matches, 1, "event content not found")
 }
 
 // TestSearchContentPaginationStableAcrossTies seeds one message ordinal that
@@ -270,9 +227,8 @@ func TestSearchContentPaginationStableAcrossTies(t *testing.T) {
 			ResultContent: "FINDME in result",
 		}},
 	}}
-	if err := d.ReplaceSessionMessages("tie", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages("tie", msgs),
+		"ReplaceSessionMessages")
 	base := ContentSearchFilter{
 		Pattern: "FINDME", Mode: "substring",
 		Sources: []string{"messages", "tool_input", "tool_result"},
@@ -280,18 +236,12 @@ func TestSearchContentPaginationStableAcrossTies(t *testing.T) {
 	full := base
 	full.Limit = 50
 	all, err := d.SearchContent(context.Background(), full)
-	if err != nil {
-		t.Fatalf("SearchContent full: %v", err)
-	}
-	if len(all.Matches) != 3 {
-		t.Fatalf("want 3 tied matches, got %d: %+v", len(all.Matches), all.Matches)
-	}
+	require.NoError(t, err, "SearchContent full")
+	require.Len(t, all.Matches, 3, "tied matches")
 	// The tie-break orders the three sources deterministically by source rank.
 	wantOrder := []string{"message", "tool_input", "tool_result"}
 	for i, loc := range wantOrder {
-		if all.Matches[i].Location != loc {
-			t.Errorf("match %d Location = %q, want %q", i, all.Matches[i].Location, loc)
-		}
+		assert.Equal(t, loc, all.Matches[i].Location, "match %d Location", i)
 	}
 	// Page one row at a time; the sequence must equal the single-page order.
 	var paged []ContentMatch
@@ -300,23 +250,18 @@ func TestSearchContentPaginationStableAcrossTies(t *testing.T) {
 		p.Limit = 1
 		p.Cursor = cursor
 		page, err := d.SearchContent(context.Background(), p)
-		if err != nil {
-			t.Fatalf("SearchContent page at cursor %d: %v", cursor, err)
-		}
+		require.NoError(t, err, "SearchContent page at cursor %d", cursor)
 		paged = append(paged, page.Matches...)
 		if page.NextCursor == 0 {
 			break
 		}
 		cursor = page.NextCursor
 	}
-	if len(paged) != len(all.Matches) {
-		t.Fatalf("paged %d rows, want %d (duplicates or gaps)", len(paged), len(all.Matches))
-	}
+	require.Len(t, paged, len(all.Matches),
+		"paged rows (duplicates or gaps)")
 	for i := range all.Matches {
-		if paged[i].Location != all.Matches[i].Location {
-			t.Errorf("row %d: paged Location %q != single-page %q",
-				i, paged[i].Location, all.Matches[i].Location)
-		}
+		assert.Equal(t, all.Matches[i].Location, paged[i].Location,
+			"row %d: paged Location != single-page", i)
 	}
 }
 
@@ -330,12 +275,9 @@ func TestSearchContentRegex(t *testing.T) {
 		Pattern: `AKIA[0-9A-Z]{16}`, Mode: "regex",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent regex: %v", err)
-	}
-	if len(got.Matches) != 1 || got.Matches[0].Ordinal != 0 {
-		t.Fatalf("regex match = %+v, want 1 at ordinal 0", got.Matches)
-	}
+	require.NoError(t, err, "SearchContent regex")
+	require.Len(t, got.Matches, 1, "regex match")
+	assert.Equal(t, 0, got.Matches[0].Ordinal, "regex match ordinal")
 }
 
 func TestSearchContentUnknownSource(t *testing.T) {
@@ -343,9 +285,7 @@ func TestSearchContentUnknownSource(t *testing.T) {
 	_, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "x", Mode: "substring", Sources: []string{"messages", "bogus"},
 	})
-	if err == nil {
-		t.Fatal("expected error for unknown source name")
-	}
+	require.Error(t, err, "expected error for unknown source name")
 }
 
 func TestSearchContentRegexInvalid(t *testing.T) {
@@ -353,9 +293,7 @@ func TestSearchContentRegexInvalid(t *testing.T) {
 	_, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: `(unclosed`, Mode: "regex", Sources: []string{"messages"},
 	})
-	if err == nil {
-		t.Fatal("expected error for invalid regex")
-	}
+	require.Error(t, err, "expected error for invalid regex")
 }
 
 func TestSearchContentFTS(t *testing.T) {
@@ -370,12 +308,9 @@ func TestSearchContentFTS(t *testing.T) {
 		Pattern: "optimize", Mode: "fts",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent fts: %v", err)
-	}
-	if len(got.Matches) != 1 || got.Matches[0].Location != "message" {
-		t.Fatalf("fts match = %+v, want 1 message", got.Matches)
-	}
+	require.NoError(t, err, "SearchContent fts")
+	require.Len(t, got.Matches, 1, "fts match")
+	assert.Equal(t, "message", got.Matches[0].Location, "fts match Location")
 }
 
 func TestSearchContentFTSInvalidQuery(t *testing.T) {
@@ -393,9 +328,8 @@ func TestSearchContentFTSInvalidQuery(t *testing.T) {
 		Sources: []string{"messages"}, Limit: 50,
 	})
 	var inputErr *SearchInputError
-	if !errors.As(err, &inputErr) {
-		t.Fatalf("malformed FTS query error = %v, want *SearchInputError", err)
-	}
+	require.True(t, errors.As(err, &inputErr),
+		"malformed FTS query error = %v, want *SearchInputError", err)
 }
 
 func TestSearchContentFTSUnavailable(t *testing.T) {
@@ -406,20 +340,16 @@ func TestSearchContentFTSUnavailable(t *testing.T) {
 	// Drop the FTS table so HasFTS reports unavailable; the FTS search must
 	// then fail with an internal (non-input) error rather than being
 	// misclassified as an invalid user query (HTTP 400).
-	if _, err := d.getWriter().Exec("DROP TABLE IF EXISTS messages_fts"); err != nil {
-		t.Fatalf("drop messages_fts: %v", err)
-	}
-	_, err := d.SearchContent(context.Background(), ContentSearchFilter{
+	_, err := d.getWriter().Exec("DROP TABLE IF EXISTS messages_fts")
+	require.NoError(t, err, "drop messages_fts")
+	_, err = d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "x", Mode: "fts",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err == nil {
-		t.Fatal("expected error when FTS is unavailable")
-	}
+	require.Error(t, err, "expected error when FTS is unavailable")
 	var inputErr *SearchInputError
-	if errors.As(err, &inputErr) {
-		t.Errorf("FTS-unavailable misclassified as input error: %v", err)
-	}
+	assert.False(t, errors.As(err, &inputErr),
+		"FTS-unavailable misclassified as input error: %v", err)
 }
 
 func TestSearchContentExcludeSystem(t *testing.T) {
@@ -435,28 +365,20 @@ func TestSearchContentExcludeSystem(t *testing.T) {
 			Content: "ordinary message holding NEEDLE", IsSystem: true,
 			Timestamp: "2026-05-20T12:00:00Z"},
 	}
-	if err := d.ReplaceSessionMessages("s3", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages("s3", msgs),
+		"ReplaceSessionMessages")
 	withSys, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent with system: %v", err)
-	}
-	if len(withSys.Matches) != 1 {
-		t.Errorf("default should include system messages: got %d", len(withSys.Matches))
-	}
+	require.NoError(t, err, "SearchContent with system")
+	assert.Len(t, withSys.Matches, 1, "default should include system messages")
 	noSys, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"},
 		ExcludeSystem: true, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent exclude system: %v", err)
-	}
-	if len(noSys.Matches) != 0 {
-		t.Errorf("ExcludeSystem should drop system messages: got %d", len(noSys.Matches))
-	}
+	require.NoError(t, err, "SearchContent exclude system")
+	assert.Empty(t, noSys.Matches,
+		"ExcludeSystem should drop system messages")
 }
 
 func TestSearchContentExcludesAutomatedByDefault(t *testing.T) {
@@ -475,28 +397,21 @@ func TestSearchContentExcludesAutomatedByDefault(t *testing.T) {
 		SessionID: "auto", Ordinal: 0, Role: "user",
 		Content: "automated NEEDLE run", Timestamp: "2026-05-20T12:00:00Z",
 	}}
-	if err := d.ReplaceSessionMessages("auto", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages("auto", msgs),
+		"ReplaceSessionMessages")
 	def, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(def.Matches) != 0 {
-		t.Errorf("automated session should be excluded by default: got %d", len(def.Matches))
-	}
+	require.NoError(t, err, "SearchContent")
+	assert.Empty(t, def.Matches,
+		"automated session should be excluded by default")
 	inc, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"},
 		IncludeAutomated: true, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent include: %v", err)
-	}
-	if len(inc.Matches) != 1 {
-		t.Errorf("IncludeAutomated should include the session: got %d", len(inc.Matches))
-	}
+	require.NoError(t, err, "SearchContent include")
+	assert.Len(t, inc.Matches, 1,
+		"IncludeAutomated should include the session")
 }
 
 func TestSearchContentExcludesOneShotByDefault(t *testing.T) {
@@ -510,28 +425,21 @@ func TestSearchContentExcludesOneShotByDefault(t *testing.T) {
 		SessionID: "one", Ordinal: 0, Role: "user",
 		Content: "leaked NEEDLE token", Timestamp: "2026-05-20T12:00:00Z",
 	}}
-	if err := d.ReplaceSessionMessages("one", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages("one", msgs),
+		"ReplaceSessionMessages")
 	def, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(def.Matches) != 0 {
-		t.Errorf("one-shot session should be excluded by default: got %d", len(def.Matches))
-	}
+	require.NoError(t, err, "SearchContent")
+	assert.Empty(t, def.Matches,
+		"one-shot session should be excluded by default")
 	inc, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"},
 		IncludeOneShot: true, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent include: %v", err)
-	}
-	if len(inc.Matches) != 1 {
-		t.Errorf("IncludeOneShot should include the session: got %d", len(inc.Matches))
-	}
+	require.NoError(t, err, "SearchContent include")
+	assert.Len(t, inc.Matches, 1,
+		"IncludeOneShot should include the session")
 }
 
 func TestSearchContentToolResultDedup(t *testing.T) {
@@ -555,22 +463,16 @@ func TestSearchContentToolResultDedup(t *testing.T) {
 			}},
 		}},
 	}}
-	if err := d.ReplaceSessionMessages("dup", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages("dup", msgs),
+		"ReplaceSessionMessages")
 	got, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "DUPNEEDLE", Mode: "substring",
 		Sources: []string{"tool_result"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 {
-		t.Fatalf("canonical dedup: got %d matches, want 1: %+v", len(got.Matches), got.Matches)
-	}
-	if !contains(got.Matches[0].Snippet, "event") {
-		t.Errorf("expected the event content to win, got snippet %q", got.Matches[0].Snippet)
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1, "canonical dedup")
+	assert.Contains(t, got.Matches[0].Snippet, "event",
+		"expected the event content to win")
 }
 
 func TestSearchContentCursorPagination(t *testing.T) {
@@ -583,24 +485,16 @@ func TestSearchContentCursorPagination(t *testing.T) {
 	first, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"}, Limit: 2,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent page1: %v", err)
-	}
-	if len(first.Matches) != 2 || first.NextCursor != 2 {
-		t.Fatalf("page1: got %d matches, cursor %d; want 2 and 2",
-			len(first.Matches), first.NextCursor)
-	}
+	require.NoError(t, err, "SearchContent page1")
+	require.Len(t, first.Matches, 2, "page1 matches")
+	require.Equal(t, 2, first.NextCursor, "page1 cursor")
 	second, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "NEEDLE", Mode: "substring", Sources: []string{"messages"},
 		Limit: 2, Cursor: first.NextCursor,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent page2: %v", err)
-	}
-	if len(second.Matches) != 1 || second.NextCursor != 0 {
-		t.Fatalf("page2: got %d matches, cursor %d; want 1 and 0",
-			len(second.Matches), second.NextCursor)
-	}
+	require.NoError(t, err, "SearchContent page2")
+	require.Len(t, second.Matches, 1, "page2 matches")
+	require.Equal(t, 0, second.NextCursor, "page2 cursor")
 }
 
 func TestSearchContentMultiSourceWithProjectFilter(t *testing.T) {
@@ -619,25 +513,19 @@ func TestSearchContentMultiSourceWithProjectFilter(t *testing.T) {
 				InputJSON: `{"command":"FINDME"}`, ResultContent: "out FINDME",
 			}},
 		}}
-		if err := d.ReplaceSessionMessages(id, msgs); err != nil {
-			t.Fatalf("ReplaceSessionMessages %s: %v", id, err)
-		}
+		require.NoError(t, d.ReplaceSessionMessages(id, msgs),
+			"ReplaceSessionMessages %s", id)
 	}
 	got, err := d.SearchContent(context.Background(), ContentSearchFilter{
 		Pattern: "FINDME", Mode: "substring",
 		Sources: []string{"messages", "tool_input", "tool_result"},
 		Project: "alpha", Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) == 0 {
-		t.Fatal("expected matches in project alpha")
-	}
+	require.NoError(t, err, "SearchContent")
+	require.NotEmpty(t, got.Matches, "expected matches in project alpha")
 	for _, m := range got.Matches {
-		if m.SessionID != "a" || m.Project != "alpha" {
-			t.Errorf("project filter leaked match from %q (project %q)", m.SessionID, m.Project)
-		}
+		assert.Equal(t, "a", m.SessionID, "session leaked")
+		assert.Equal(t, "alpha", m.Project, "project leaked")
 	}
 }
 
@@ -655,16 +543,10 @@ func TestSnippetWindowRuneBoundaries(t *testing.T) {
 	// radius 3 lands mid-rune on both sides, so the partial padding runes are
 	// trimmed back to a boundary, leaving one whole rune of padding each side.
 	got := window(3)
-	if got != "éMATCHü" {
-		t.Errorf("mid-rune radius = %q, want éMATCHü", got)
-	}
+	assert.Equal(t, "éMATCHü", got, "mid-rune radius")
 	// radius 4 lands exactly on rune boundaries, so aligned padding is kept.
-	if aligned := window(4); aligned != "ééMATCHüü" {
-		t.Errorf("boundary-aligned radius = %q, want ééMATCHüü", aligned)
-	}
-	if !utf8.ValidString(got) {
-		t.Errorf("snippet not valid UTF-8: %q", got)
-	}
+	assert.Equal(t, "ééMATCHüü", window(4), "boundary-aligned radius")
+	assert.True(t, utf8.ValidString(got), "snippet not valid UTF-8: %q", got)
 }
 
 func TestFTSSnippetCentersOnPhrase(t *testing.T) {
@@ -676,16 +558,14 @@ func TestFTSSnippetCentersOnPhrase(t *testing.T) {
 
 	t.Run("phrase present centers on phrase", func(t *testing.T) {
 		f := ContentSearchFilter{Pattern: `"error handler"`, Mode: "fts"}
-		if snip := f.ftsSnippet(body); !strings.Contains(snip, "error handler") {
-			t.Errorf("snippet did not center on the phrase: %q", snip)
-		}
+		assert.Contains(t, f.ftsSnippet(body), "error handler",
+			"snippet did not center on the phrase")
 	})
 	t.Run("phrase absent falls back to first token", func(t *testing.T) {
 		// No contiguous "error handler" substring, so centering falls back to
 		// the first token "error", windowing its early occurrence.
 		f := ContentSearchFilter{Pattern: `"error nonexistent"`, Mode: "fts"}
-		if snip := f.ftsSnippet(body); !strings.Contains(snip, "error in the early") {
-			t.Errorf("fallback snippet not centered on first token: %q", snip)
-		}
+		assert.Contains(t, f.ftsSnippet(body), "error in the early",
+			"fallback snippet not centered on first token")
 	})
 }

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSearch(t *testing.T) {
@@ -95,76 +98,46 @@ func TestSearch(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "alpha", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
+		require.NoError(t, err, "Search")
 		// s1 and s2 each have alpha matches; s3 is excluded (system msg)
-		if len(page.Results) != 2 {
-			t.Errorf("got %d results, want 2 (one per session)", len(page.Results))
-		}
+		assert.Len(t, page.Results, 2, "one per session")
 	})
 
 	t.Run("agent field populated from sessions join", func(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "alpha beta", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) == 0 {
-			t.Fatal("expected at least one result")
-		}
-		if page.Results[0].Agent == "" {
-			t.Error("Agent field is empty, want populated")
-		}
-		if page.Results[0].Agent != "claude" {
-			t.Errorf("Agent = %q, want %q", page.Results[0].Agent, "claude")
-		}
+		require.NoError(t, err, "Search")
+		require.NotEmpty(t, page.Results, "expected at least one result")
+		assert.NotEmpty(t, page.Results[0].Agent, "Agent field empty")
+		assert.Equal(t, "claude", page.Results[0].Agent, "Agent")
 	})
 
 	t.Run("session_ended_at populated from COALESCE(ended_at, started_at)", func(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "alpha beta", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) == 0 {
-			t.Fatal("expected at least one result")
-		}
-		if page.Results[0].SessionEndedAt == "" {
-			t.Error("SessionEndedAt is empty, want populated")
-		}
+		require.NoError(t, err, "Search")
+		require.NotEmpty(t, page.Results, "expected at least one result")
+		assert.NotEmpty(t, page.Results[0].SessionEndedAt, "SessionEndedAt")
 	})
 
 	t.Run("sort recency: newer session appears first", func(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "alpha", Limit: 10, Sort: "recency",
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) < 2 {
-			t.Fatalf("want >= 2 results, got %d", len(page.Results))
-		}
+		require.NoError(t, err, "Search")
+		require.GreaterOrEqual(t, len(page.Results), 2, "want >= 2 results")
 		// s2 has ended_at 2024-01-02, s1 has 2024-01-01 — s2 must be first
-		if page.Results[0].SessionID != "s2" {
-			t.Errorf("recency sort: first result = %q, want %q",
-				page.Results[0].SessionID, "s2")
-		}
+		assert.Equal(t, "s2", page.Results[0].SessionID, "recency sort: first result")
 	})
 
 	t.Run("system messages excluded from results", func(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "system hidden", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 0 {
-			t.Errorf("got %d results for system-only session, want 0",
-				len(page.Results))
-		}
+		require.NoError(t, err, "Search")
+		assert.Empty(t, page.Results, "system-only session results")
 	})
 
 	t.Run("name branch excludes system-only sessions via display_name", func(t *testing.T) {
@@ -173,13 +146,9 @@ func TestSearch(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "sysonlydnterm", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 0 {
-			t.Errorf("got %d results for system-only session via display_name, want 0",
-				len(page.Results))
-		}
+		require.NoError(t, err, "Search")
+		assert.Empty(t, page.Results,
+			"system-only session via display_name")
 	})
 
 	t.Run("name branch excludes system-only sessions via first_message", func(t *testing.T) {
@@ -188,13 +157,9 @@ func TestSearch(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "sysonlyfmterm", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 0 {
-			t.Errorf("got %d results for system-only session via first_message, want 0",
-				len(page.Results))
-		}
+		require.NoError(t, err, "Search")
+		assert.Empty(t, page.Results,
+			"system-only session via first_message")
 	})
 
 	t.Run("name branch excludes prefix-only sessions", func(t *testing.T) {
@@ -204,13 +169,8 @@ func TestSearch(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "prefixonlydnterm", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 0 {
-			t.Errorf("got %d results for prefix-only session, want 0",
-				len(page.Results))
-		}
+		require.NoError(t, err, "Search")
+		assert.Empty(t, page.Results, "prefix-only session")
 	})
 
 	t.Run("invalid sort value defaults to relevance (SQL injection guard)", func(t *testing.T) {
@@ -218,9 +178,7 @@ func TestSearch(t *testing.T) {
 		_, err := d.Search(context.Background(), SearchFilter{
 			Query: "alpha", Limit: 10, Sort: "'; DROP TABLE sessions; --",
 		})
-		if err != nil {
-			t.Errorf("invalid Sort caused error: %v", err)
-		}
+		assert.NoError(t, err, "invalid Sort caused error")
 	})
 
 	t.Run("pagination at session level", func(t *testing.T) {
@@ -228,15 +186,9 @@ func TestSearch(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "alpha", Limit: 1,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 1 {
-			t.Errorf("got %d results with limit=1, want 1", len(page.Results))
-		}
-		if page.NextCursor == 0 {
-			t.Error("NextCursor = 0, want non-zero (more results exist)")
-		}
+		require.NoError(t, err, "Search")
+		assert.Len(t, page.Results, 1, "limit=1 results")
+		assert.NotZero(t, page.NextCursor, "NextCursor (more results exist)")
 	})
 
 	t.Run("multi-word FTS query matches session name via plain text", func(t *testing.T) {
@@ -247,27 +199,18 @@ func TestSearch(t *testing.T) {
 			s.Agent = "claude"
 			s.StartedAt = new("2024-01-06T10:00:00Z")
 		})
-		if err := d.RenameSession("s6", new("unique phrase session")); err != nil {
-			t.Fatalf("RenameSession: %v", err)
-		}
+		require.NoError(t, d.RenameSession("s6", new("unique phrase session")),
+			"RenameSession")
 		insertMessages(t, d, userMsg("s6", 0, "no match here"))
 
 		// Simulate prepareFTSQuery wrapping: multi-word queries get quoted.
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: `"unique phrase"`, Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 1 {
-			t.Fatalf("got %d results for quoted query, want 1", len(page.Results))
-		}
-		if page.Results[0].SessionID != "s6" {
-			t.Errorf("got session %q, want s6", page.Results[0].SessionID)
-		}
-		if page.Results[0].Ordinal != -1 {
-			t.Errorf("ordinal = %d, want -1 (name-only match)", page.Results[0].Ordinal)
-		}
+		require.NoError(t, err, "Search")
+		require.Len(t, page.Results, 1, "quoted query results")
+		assert.Equal(t, "s6", page.Results[0].SessionID, "session")
+		assert.Equal(t, -1, page.Results[0].Ordinal, "ordinal (name-only match)")
 	})
 
 	t.Run("session name match via display_name", func(t *testing.T) {
@@ -276,44 +219,29 @@ func TestSearch(t *testing.T) {
 			s.Agent = "claude"
 			s.StartedAt = new("2024-01-04T10:00:00Z")
 		})
-		if err := d.RenameSession("s4", new("my uniquename session")); err != nil {
-			t.Fatalf("RenameSession: %v", err)
-		}
+		require.NoError(t, d.RenameSession("s4", new("my uniquename session")),
+			"RenameSession")
 		// message that does NOT contain "uniquename"
 		insertMessages(t, d, userMsg("s4", 0, "hello world"))
 
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "uniquename", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 1 {
-			t.Fatalf("got %d results, want 1", len(page.Results))
-		}
-		if page.Results[0].SessionID != "s4" {
-			t.Errorf("got session %q, want s4", page.Results[0].SessionID)
-		}
-		if page.Results[0].Ordinal != -1 {
-			t.Errorf("ordinal = %d, want -1 (name-only match)", page.Results[0].Ordinal)
-		}
+		require.NoError(t, err, "Search")
+		require.Len(t, page.Results, 1)
+		assert.Equal(t, "s4", page.Results[0].SessionID, "session")
+		assert.Equal(t, -1, page.Results[0].Ordinal, "ordinal (name-only match)")
 	})
 
 	t.Run("name field populated on message-content match", func(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "alpha", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) == 0 {
-			t.Fatal("expected results")
-		}
+		require.NoError(t, err, "Search")
+		require.NotEmpty(t, page.Results, "expected results")
 		// s1 and s2 have no display_name — name should fall back to first_message
 		for _, r := range page.Results {
-			if r.Name == "" {
-				t.Errorf("result %q has empty Name", r.SessionID)
-			}
+			assert.NotEmpty(t, r.Name, "result %q has empty Name", r.SessionID)
 		}
 	})
 
@@ -324,32 +252,22 @@ func TestSearch(t *testing.T) {
 			s.FirstMessage = new("firstmsgonlyterm present here")
 			s.StartedAt = new("2024-01-07T10:00:00Z")
 		})
-		if err := d.RenameSession("s7", new("unrelated display name")); err != nil {
-			t.Fatalf("RenameSession: %v", err)
-		}
+		require.NoError(t, d.RenameSession("s7", new("unrelated display name")),
+			"RenameSession")
 		// message that does NOT contain the search term
 		insertMessages(t, d, userMsg("s7", 0, "no match content"))
 
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "firstmsgonlyterm", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 1 {
-			t.Fatalf("got %d results, want 1", len(page.Results))
-		}
+		require.NoError(t, err, "Search")
+		require.Len(t, page.Results, 1)
 		r := page.Results[0]
-		if r.SessionID != "s7" {
-			t.Errorf("got session %q, want s7", r.SessionID)
-		}
-		if r.Ordinal != -1 {
-			t.Errorf("ordinal = %d, want -1 (name-only match)", r.Ordinal)
-		}
+		assert.Equal(t, "s7", r.SessionID, "session")
+		assert.Equal(t, -1, r.Ordinal, "ordinal (name-only match)")
 		// Snippet must be the first_message (the matching field), not display_name
-		if r.Snippet != "firstmsgonlyterm present here" {
-			t.Errorf("snippet = %q, want first_message text", r.Snippet)
-		}
+		assert.Equal(t, "firstmsgonlyterm present here", r.Snippet,
+			"snippet should be first_message")
 	})
 
 	t.Run("no duplicate when session matches both name and content", func(t *testing.T) {
@@ -358,28 +276,24 @@ func TestSearch(t *testing.T) {
 			s.Agent = "claude"
 			s.StartedAt = new("2024-01-05T10:00:00Z")
 		})
-		if err := d.RenameSession("s5", new("doublehit session")); err != nil {
-			t.Fatalf("RenameSession: %v", err)
-		}
+		require.NoError(t, d.RenameSession("s5", new("doublehit session")),
+			"RenameSession")
 		insertMessages(t, d, userMsg("s5", 0, "doublehit in message too"))
 
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "doublehit", Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
+		require.NoError(t, err, "Search")
 		seen := map[string]int{}
 		for _, r := range page.Results {
 			seen[r.SessionID]++
 		}
-		if seen["s5"] != 1 {
-			t.Errorf("s5 appears %d times, want 1", seen["s5"])
-		}
+		assert.Equal(t, 1, seen["s5"], "s5 occurrences")
 		// When matched by both, FTS branch wins — ordinal should not be -1
 		for _, r := range page.Results {
-			if r.SessionID == "s5" && r.Ordinal == -1 {
-				t.Error("expected real ordinal (message match), got -1")
+			if r.SessionID == "s5" {
+				assert.NotEqual(t, -1, r.Ordinal,
+					"expected real ordinal (message match)")
 			}
 		}
 	})
@@ -397,12 +311,8 @@ func TestSearchEmptyQueryGuard(t *testing.T) {
 
 	for _, q := range []string{"", `""`} {
 		page, err := d.Search(context.Background(), SearchFilter{Query: q, Limit: 10})
-		if err != nil {
-			t.Fatalf("Search(%q): unexpected error: %v", q, err)
-		}
-		if len(page.Results) != 0 {
-			t.Errorf("Search(%q): got %d results, want 0", q, len(page.Results))
-		}
+		require.NoError(t, err, "Search(%q)", q)
+		assert.Empty(t, page.Results, "Search(%q) results", q)
 	}
 }
 
@@ -434,11 +344,10 @@ func TestSearchDeduplicationManyMessages(t *testing.T) {
 	// insert additional matching messages in a separate batch. This creates a
 	// second segment, reproducing the multi-segment state that caused the outer
 	// JOIN to return duplicate rows before the MATCH clause was added.
-	if _, err := d.getWriter().Exec(
+	_, err := d.getWriter().Exec(
 		"INSERT INTO messages_fts(messages_fts) VALUES('optimize')",
-	); err != nil {
-		t.Fatalf("fts optimize: %v", err)
-	}
+	)
+	require.NoError(t, err, "fts optimize")
 	extra := make([]Message, 20)
 	for i := range extra {
 		extra[i] = userMsg("s1", n+i,
@@ -449,12 +358,9 @@ func TestSearchDeduplicationManyMessages(t *testing.T) {
 	page, err := d.Search(context.Background(), SearchFilter{
 		Query: "needle", Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) != 1 {
-		t.Errorf("got %d results for single session with %d matching messages, want 1",
-			len(page.Results), n)
+	require.NoError(t, err, "Search")
+	if !assert.Len(t, page.Results, 1,
+		"single session with %d matching messages", n) {
 		for i, r := range page.Results {
 			t.Logf("  result[%d]: session_id=%q ordinal=%d", i, r.SessionID, r.Ordinal)
 		}
@@ -483,16 +389,10 @@ func TestSearchTieBreak(t *testing.T) {
 	page, err := d.Search(context.Background(), SearchFilter{
 		Query: "tiebreak unique phrase alpha", Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) != 1 {
-		t.Fatalf("got %d results, want 1", len(page.Results))
-	}
-	if page.Results[0].Ordinal != 0 {
-		t.Errorf("tie-break: ordinal = %d, want 0 (lower ordinal wins)",
-			page.Results[0].Ordinal)
-	}
+	require.NoError(t, err, "Search")
+	require.Len(t, page.Results, 1)
+	assert.Equal(t, 0, page.Results[0].Ordinal,
+		"tie-break: lower ordinal wins")
 }
 
 func TestSearchSession(t *testing.T) {
@@ -687,20 +587,12 @@ func TestSearchSession(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := d.SearchSession(context.Background(), tt.sessionID, tt.query)
-			if err != nil {
-				t.Fatalf("SearchSession(%q, %q): unexpected error: %v", tt.sessionID, tt.query, err)
-			}
+			require.NoError(t, err, "SearchSession(%q, %q)", tt.sessionID, tt.query)
 			if got == nil {
 				got = []int{}
 			}
-			if len(got) != len(tt.want) {
-				t.Fatalf("SearchSession(%q, %q) = %v, want %v", tt.sessionID, tt.query, got, tt.want)
-			}
-			for i, ord := range got {
-				if ord != tt.want[i] {
-					t.Errorf("ordinal[%d] = %d, want %d", i, ord, tt.want[i])
-				}
-			}
+			assert.Equal(t, tt.want, got,
+				"SearchSession(%q, %q)", tt.sessionID, tt.query)
 		})
 	}
 }
@@ -731,26 +623,18 @@ func TestSearchPaginationStability(t *testing.T) {
 			Limit:  1,
 			Cursor: cursor,
 		})
-		if err != nil {
-			t.Fatalf("page %d: %v", i, err)
-		}
-		if len(page.Results) != 1 {
-			t.Fatalf("page %d: got %d results, want 1",
-				i, len(page.Results))
-		}
+		require.NoError(t, err, "page %d", i)
+		require.Len(t, page.Results, 1, "page %d", i)
 		allIDs = append(allIDs, page.Results[0].SessionID)
 		cursor = page.NextCursor
 	}
 
 	// Verify no duplicates and ascending session_id order (tie-breaker).
 	for i := 1; i < len(allIDs); i++ {
-		if allIDs[i] == allIDs[i-1] {
-			t.Errorf("duplicate session at pages %d-%d: %s",
-				i-1, i, allIDs[i])
-		}
-		if allIDs[i] < allIDs[i-1] {
-			t.Errorf("unstable order: page %d=%s, page %d=%s",
-				i-1, allIDs[i-1], i, allIDs[i])
-		}
+		assert.NotEqual(t, allIDs[i-1], allIDs[i],
+			"duplicate session at pages %d-%d: %s", i-1, i, allIDs[i])
+		assert.GreaterOrEqual(t, allIDs[i], allIDs[i-1],
+			"unstable order: page %d=%s, page %d=%s",
+			i-1, allIDs[i-1], i, allIDs[i])
 	}
 }

--- a/internal/db/secret_findings_test.go
+++ b/internal/db/secret_findings_test.go
@@ -4,30 +4,27 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSecretFindingsSchemaExists(t *testing.T) {
 	d := testDB(t)
 	r := d.getReader()
 	var n int
-	if err := r.QueryRow(
+	err := r.QueryRow(
 		`SELECT count(*) FROM sqlite_master
-		 WHERE type='table' AND name='secret_findings'`).Scan(&n); err != nil {
-		t.Fatalf("probe: %v", err)
-	}
-	if n != 1 {
-		t.Fatalf("secret_findings table missing")
-	}
+		 WHERE type='table' AND name='secret_findings'`).Scan(&n)
+	require.NoError(t, err, "probe")
+	require.Equal(t, 1, n, "secret_findings table missing")
 	for _, col := range []string{"secret_leak_count", "secrets_rules_version"} {
 		var cnt int
-		if err := r.QueryRow(
+		err := r.QueryRow(
 			`SELECT count(*) FROM pragma_table_info('sessions') WHERE name=?`,
-			col).Scan(&cnt); err != nil {
-			t.Fatalf("probe col %s: %v", col, err)
-		}
-		if cnt != 1 {
-			t.Errorf("sessions.%s missing", col)
-		}
+			col).Scan(&cnt)
+		require.NoError(t, err, "probe col %s", col)
+		assert.Equal(t, 1, cnt, "sessions.%s missing", col)
 	}
 }
 
@@ -37,14 +34,11 @@ func TestSecretFindingsSchemaExists(t *testing.T) {
 func TestHasSecretPartialIndexExists(t *testing.T) {
 	d := testDB(t)
 	var n int
-	if err := d.getReader().QueryRow(
+	err := d.getReader().QueryRow(
 		`SELECT count(*) FROM sqlite_master
-		 WHERE type='index' AND name='idx_sessions_has_secret'`).Scan(&n); err != nil {
-		t.Fatalf("probe index: %v", err)
-	}
-	if n != 1 {
-		t.Fatal("idx_sessions_has_secret partial index missing")
-	}
+		 WHERE type='index' AND name='idx_sessions_has_secret'`).Scan(&n)
+	require.NoError(t, err, "probe index")
+	assert.Equal(t, 1, n, "idx_sessions_has_secret partial index missing")
 }
 
 func TestReplaceSessionSecretFindings(t *testing.T) {
@@ -58,34 +52,24 @@ func TestReplaceSessionSecretFindings(t *testing.T) {
 			LocationKind: "tool_result", MessageOrdinal: 1, CallIndex: Ptr(0),
 			MatchStart: 0, MatchEnd: 24, MatchIndex: 0, RedactedMatch: "…abcd"},
 	}
-	if err := d.ReplaceSessionSecretFindings(
-		"s1", findings, 1, "rulesv1"); err != nil {
-		t.Fatalf("ReplaceSessionSecretFindings: %v", err)
-	}
+	require.NoError(t,
+		d.ReplaceSessionSecretFindings("s1", findings, 1, "rulesv1"),
+		"ReplaceSessionSecretFindings")
 	got, err := d.SessionSecretFindings(context.Background(), "s1")
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if len(got) != 2 {
-		t.Fatalf("got %d findings, want 2", len(got))
-	}
+	require.NoError(t, err, "read")
+	require.Len(t, got, 2)
 	// A message finding has no call/event index (NULL round-trips to nil); a
 	// tool finding with CallIndex 0 must read back as a non-nil pointer to 0,
 	// not collapse to nil (the NULL-vs-zero trap for nullable ints).
-	if got[0].CallIndex != nil || got[0].EventIndex != nil {
-		t.Errorf("message finding indices = %v/%v, want nil/nil",
-			got[0].CallIndex, got[0].EventIndex)
-	}
-	if got[1].CallIndex == nil || *got[1].CallIndex != 0 {
-		t.Errorf("tool finding CallIndex = %v, want non-nil 0", got[1].CallIndex)
-	}
-	if err := d.ReplaceSessionSecretFindings("s1", findings[:1], 1, "rulesv1"); err != nil {
-		t.Fatalf("re-replace: %v", err)
-	}
+	assert.Nil(t, got[0].CallIndex, "message finding CallIndex")
+	assert.Nil(t, got[0].EventIndex, "message finding EventIndex")
+	require.NotNil(t, got[1].CallIndex, "tool finding CallIndex")
+	assert.Equal(t, 0, *got[1].CallIndex, "tool finding CallIndex")
+	require.NoError(t,
+		d.ReplaceSessionSecretFindings("s1", findings[:1], 1, "rulesv1"),
+		"re-replace")
 	got, _ = d.SessionSecretFindings(context.Background(), "s1")
-	if len(got) != 1 {
-		t.Fatalf("replace not idempotent: got %d, want 1", len(got))
-	}
+	require.Len(t, got, 1, "replace not idempotent")
 }
 
 // TestReplaceSessionMessagesResetsSecretState verifies that replacing a
@@ -98,46 +82,33 @@ func TestReplaceSessionMessagesResetsSecretState(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
 	insertSession(t, d, "s1", "proj")
-	if err := d.ReplaceSessionMessages("s1", []Message{
+	require.NoError(t, d.ReplaceSessionMessages("s1", []Message{
 		{SessionID: "s1", Ordinal: 0, Role: "user", Content: "key AKIA7QHWN2DKR4FYPLJM"},
-	}); err != nil {
-		t.Fatalf("seed messages: %v", err)
-	}
+	}), "seed messages")
 	findings := []SecretFinding{{
 		SessionID: "s1", RuleName: "aws-access-key", Confidence: "definite",
 		LocationKind: "message", MessageOrdinal: 0, MatchStart: 4, MatchEnd: 24,
 		MatchIndex: 0, RedactedMatch: "AKIA…MPLE",
 	}}
-	if err := d.ReplaceSessionSecretFindings("s1", findings, 1, "rulesvX"); err != nil {
-		t.Fatalf("seed findings: %v", err)
-	}
+	require.NoError(t,
+		d.ReplaceSessionSecretFindings("s1", findings, 1, "rulesvX"),
+		"seed findings")
 
-	if err := d.ReplaceSessionMessages("s1", []Message{
+	require.NoError(t, d.ReplaceSessionMessages("s1", []Message{
 		{SessionID: "s1", Ordinal: 0, Role: "user", Content: "nothing secret here"},
-	}); err != nil {
-		t.Fatalf("replace messages: %v", err)
-	}
+	}), "replace messages")
 
 	got, err := d.SessionSecretFindings(ctx, "s1")
-	if err != nil {
-		t.Fatalf("read findings: %v", err)
-	}
-	if len(got) != 0 {
-		t.Errorf("stale findings survived message replace: %+v", got)
-	}
+	require.NoError(t, err, "read findings")
+	assert.Empty(t, got, "stale findings survived message replace")
 	var leak int
 	var ver string
-	if err := d.getReader().QueryRow(
+	err = d.getReader().QueryRow(
 		"SELECT secret_leak_count, secrets_rules_version FROM sessions WHERE id = 's1'",
-	).Scan(&leak, &ver); err != nil {
-		t.Fatalf("read scan state: %v", err)
-	}
-	if leak != 0 {
-		t.Errorf("secret_leak_count = %d, want 0 after content replace", leak)
-	}
-	if ver != "" {
-		t.Errorf("secrets_rules_version = %q, want empty (forces backfill rescan)", ver)
-	}
+	).Scan(&leak, &ver)
+	require.NoError(t, err, "read scan state")
+	assert.Equal(t, 0, leak, "secret_leak_count after content replace")
+	assert.Empty(t, ver, "secrets_rules_version (forces backfill rescan)")
 }
 
 func TestOrphanCopyPreservesSecretFindings(t *testing.T) {
@@ -146,7 +117,7 @@ func TestOrphanCopyPreservesSecretFindings(t *testing.T) {
 
 	srcPath := filepath.Join(dir, "old.db")
 	srcDB, err := Open(srcPath)
-	requireNoError(t, err, "Open src")
+	require.NoError(t, err, "Open src")
 	insertSession(t, srcDB, "s1", "proj")
 	insertMessages(t, srcDB,
 		userMsg("s1", 0, "hello"),
@@ -165,58 +136,42 @@ func TestOrphanCopyPreservesSecretFindings(t *testing.T) {
 			RedactedMatch:  "AKIA…MPLE",
 		},
 	}, 1, "rulesv1")
-	requireNoError(t, err, "ReplaceSessionSecretFindings src")
+	require.NoError(t, err, "ReplaceSessionSecretFindings src")
 	// Stamp a distinctive past created_at so the copy can be shown to preserve
 	// it rather than regenerating from the destination default.
 	_, err = srcDB.getWriter().Exec(
 		"UPDATE secret_findings SET created_at = ? WHERE session_id = 's1'",
 		"2020-01-01T00:00:00.000Z")
-	requireNoError(t, err, "stamp created_at")
+	require.NoError(t, err, "stamp created_at")
 	srcDB.Close()
 
 	dstPath := filepath.Join(dir, "new.db")
 	dstDB, err := Open(dstPath)
-	requireNoError(t, err, "Open dst")
+	require.NoError(t, err, "Open dst")
 	defer dstDB.Close()
 
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
-	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphaned session, got %d", count)
-	}
+	require.NoError(t, err, "CopyOrphanedDataFrom")
+	require.Equal(t, 1, count, "expected 1 orphaned session")
 
 	s, err := dstDB.GetSession(ctx, "s1")
-	requireNoError(t, err, "GetSession")
-	if s == nil {
-		t.Fatal("session s1 not found in dst")
-	}
-	if s.SecretLeakCount != 1 {
-		t.Errorf("SecretLeakCount = %d, want 1", s.SecretLeakCount)
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, s, "session s1 not found in dst")
+	assert.Equal(t, 1, s.SecretLeakCount, "SecretLeakCount")
 
 	findings, err := dstDB.SessionSecretFindings(ctx, "s1")
-	requireNoError(t, err, "SessionSecretFindings")
-	if len(findings) != 1 {
-		t.Fatalf("findings count = %d, want 1", len(findings))
-	}
+	require.NoError(t, err, "SessionSecretFindings")
+	require.Len(t, findings, 1)
 	f := findings[0]
-	if f.RuleName != "aws-access-key" {
-		t.Errorf("RuleName = %q, want %q", f.RuleName, "aws-access-key")
-	}
-	if f.LocationKind != "message" {
-		t.Errorf("LocationKind = %q, want %q", f.LocationKind, "message")
-	}
-	if f.RedactedMatch != "AKIA…MPLE" {
-		t.Errorf("RedactedMatch = %q, want %q", f.RedactedMatch, "AKIA…MPLE")
-	}
+	assert.Equal(t, "aws-access-key", f.RuleName, "RuleName")
+	assert.Equal(t, "message", f.LocationKind, "LocationKind")
+	assert.Equal(t, "AKIA…MPLE", f.RedactedMatch, "RedactedMatch")
 
 	var createdAt string
-	requireNoError(t, dstDB.getReader().QueryRow(
+	require.NoError(t, dstDB.getReader().QueryRow(
 		"SELECT created_at FROM secret_findings WHERE session_id = 's1'",
 	).Scan(&createdAt), "query copied created_at")
-	if createdAt != "2020-01-01T00:00:00.000Z" {
-		t.Errorf("created_at = %q, want preserved 2020-01-01T00:00:00.000Z", createdAt)
-	}
+	assert.Equal(t, "2020-01-01T00:00:00.000Z", createdAt, "preserved created_at")
 }
 
 func TestListSecretFindings(t *testing.T) {
@@ -235,34 +190,24 @@ func TestListSecretFindings(t *testing.T) {
 	}, 0, "v1")
 
 	all, err := d.ListSecretFindings(context.Background(), SecretFindingFilter{Limit: 50})
-	if err != nil {
-		t.Fatalf("ListSecretFindings: %v", err)
-	}
-	if len(all.Findings) != 2 {
-		t.Fatalf("got %d, want 2", len(all.Findings))
-	}
+	require.NoError(t, err, "ListSecretFindings")
+	require.Len(t, all.Findings, 2)
 	// project filter
 	alpha, _ := d.ListSecretFindings(context.Background(),
 		SecretFindingFilter{Project: "alpha", Limit: 50})
-	if len(alpha.Findings) != 1 || alpha.Findings[0].SessionID != "s1" {
-		t.Fatalf("project filter = %+v", alpha.Findings)
-	}
+	require.Len(t, alpha.Findings, 1, "project filter")
+	assert.Equal(t, "s1", alpha.Findings[0].SessionID, "project filter")
 	// confidence filter
 	def, _ := d.ListSecretFindings(context.Background(),
 		SecretFindingFilter{Confidence: "definite", Limit: 50})
-	if len(def.Findings) != 1 || def.Findings[0].RuleName != "aws-access-key" {
-		t.Fatalf("confidence filter = %+v", def.Findings)
-	}
+	require.Len(t, def.Findings, 1, "confidence filter")
+	assert.Equal(t, "aws-access-key", def.Findings[0].RuleName, "confidence filter")
 	current, _ := d.ListSecretFindings(context.Background(),
 		SecretFindingFilter{RulesVersions: []string{"v1"}, Limit: 50})
-	if len(current.Findings) != 2 {
-		t.Fatalf("rules version filter current = %+v", current.Findings)
-	}
+	assert.Len(t, current.Findings, 2, "rules version filter current")
 	stale, _ := d.ListSecretFindings(context.Background(),
 		SecretFindingFilter{RulesVersions: []string{"v2"}, Limit: 50})
-	if len(stale.Findings) != 0 {
-		t.Fatalf("rules version filter stale = %+v", stale.Findings)
-	}
+	assert.Empty(t, stale.Findings, "rules version filter stale")
 }
 
 // TestListSecretFindingsPagination walks pages with a small limit and asserts
@@ -280,35 +225,28 @@ func TestListSecretFindingsPagination(t *testing.T) {
 			RedactedMatch: "AKIA…",
 		})
 	}
-	if err := d.ReplaceSessionSecretFindings("s1", findings, 5, "v1"); err != nil {
-		t.Fatalf("ReplaceSessionSecretFindings: %v", err)
-	}
+	require.NoError(t,
+		d.ReplaceSessionSecretFindings("s1", findings, 5, "v1"),
+		"ReplaceSessionSecretFindings")
 	seen := map[int]int{}
 	cursor, pages := 0, 0
 	for {
 		page, err := d.ListSecretFindings(context.Background(),
 			SecretFindingFilter{Limit: 2, Cursor: cursor})
-		if err != nil {
-			t.Fatalf("page at cursor %d: %v", cursor, err)
-		}
+		require.NoError(t, err, "page at cursor %d", cursor)
 		for _, f := range page.Findings {
 			seen[f.MatchStart]++
 		}
-		if pages++; pages > 10 {
-			t.Fatal("pagination did not terminate")
-		}
+		pages++
+		require.LessOrEqual(t, pages, 10, "pagination did not terminate")
 		if page.NextCursor == 0 {
 			break
 		}
 		cursor = page.NextCursor
 	}
-	if len(seen) != 5 {
-		t.Fatalf("saw %d distinct findings across pages, want 5", len(seen))
-	}
+	require.Len(t, seen, 5, "distinct findings across pages")
 	for start, n := range seen {
-		if n != 1 {
-			t.Errorf("finding at MatchStart=%d seen %d times, want 1", start, n)
-		}
+		assert.Equal(t, 1, n, "finding at MatchStart=%d seen %d times", start, n)
 	}
 }
 
@@ -326,36 +264,28 @@ func TestListSecretFindingsDateFilter(t *testing.T) {
 		s.StartedAt = Ptr("")
 	})
 	// Pin the empty session's created_at so the assertions are deterministic.
-	if _, err := d.getWriter().Exec(
+	_, err := d.getWriter().Exec(
 		"UPDATE sessions SET created_at = ? WHERE id = 'empty'",
-		"2026-05-10T00:00:00Z"); err != nil {
-		t.Fatalf("stamp created_at: %v", err)
-	}
+		"2026-05-10T00:00:00Z")
+	require.NoError(t, err, "stamp created_at")
 	for _, id := range []string{"dated", "empty"} {
-		if err := d.ReplaceSessionSecretFindings(id, []SecretFinding{{
+		require.NoError(t, d.ReplaceSessionSecretFindings(id, []SecretFinding{{
 			SessionID: id, RuleName: "aws-access-key", Confidence: "definite",
 			LocationKind: "message", MessageOrdinal: 0, MatchStart: 0,
 			MatchEnd: 20, MatchIndex: 0, RedactedMatch: "AKIA…MPLE",
-		}}, 1, "v1"); err != nil {
-			t.Fatalf("ReplaceSessionSecretFindings %s: %v", id, err)
-		}
+		}}, 1, "v1"), "ReplaceSessionSecretFindings %s", id)
 	}
 	// Wide range includes both; the empty started_at falls back to created_at.
 	wide, err := d.ListSecretFindings(context.Background(),
 		SecretFindingFilter{DateFrom: "2000-01-01", Limit: 50})
-	if err != nil {
-		t.Fatalf("wide: %v", err)
-	}
-	if len(wide.Findings) != 2 {
-		t.Fatalf("DateFrom 2000-01-01 = %d findings, want 2 (empty must fall "+
-			"back to created_at)", len(wide.Findings))
-	}
+	require.NoError(t, err, "wide")
+	assert.Len(t, wide.Findings, 2,
+		"DateFrom 2000-01-01 (empty must fall back to created_at)")
 	// Range covering only the dated session (empty's created_at is in May).
 	mar, _ := d.ListSecretFindings(context.Background(),
 		SecretFindingFilter{DateFrom: "2026-03-01", DateTo: "2026-03-31", Limit: 50})
-	if len(mar.Findings) != 1 || mar.Findings[0].SessionID != "dated" {
-		t.Fatalf("March range = %+v, want only dated", mar.Findings)
-	}
+	require.Len(t, mar.Findings, 1, "March range")
+	assert.Equal(t, "dated", mar.Findings[0].SessionID, "March range")
 }
 
 // TestUpdateSessionSignalsPreservesSecretColumns verifies a signals-only
@@ -366,43 +296,29 @@ func TestUpdateSessionSignalsPreservesSecretColumns(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
 	insertSession(t, d, "s1", "proj")
-	if err := d.ReplaceSessionSecretFindings("s1", []SecretFinding{{
+	require.NoError(t, d.ReplaceSessionSecretFindings("s1", []SecretFinding{{
 		SessionID: "s1", RuleName: "aws-access-key", Confidence: "definite",
 		LocationKind: "message", MessageOrdinal: 0, MatchStart: 0, MatchEnd: 20,
 		MatchIndex: 0, RedactedMatch: "AKIA…MPLE",
-	}}, 1, "rulesv1"); err != nil {
-		t.Fatalf("ReplaceSessionSecretFindings: %v", err)
-	}
+	}}, 1, "rulesv1"), "ReplaceSessionSecretFindings")
 	// A signals-only recompute carries zero secret fields; it must not reset
 	// the secret summary while findings still exist.
-	if err := d.UpdateSessionSignals(
+	require.NoError(t, d.UpdateSessionSignals(
 		"s1", SessionSignalUpdate{Outcome: "success"},
-	); err != nil {
-		t.Fatalf("UpdateSessionSignals: %v", err)
-	}
+	), "UpdateSessionSignals")
 	s, err := d.GetSession(ctx, "s1")
-	if err != nil || s == nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if s.SecretLeakCount != 1 {
-		t.Errorf("SecretLeakCount = %d, want preserved 1", s.SecretLeakCount)
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, s, "GetSession")
+	assert.Equal(t, 1, s.SecretLeakCount, "SecretLeakCount preserved")
 	findings, err := d.SessionSecretFindings(ctx, "s1")
-	if err != nil {
-		t.Fatalf("SessionSecretFindings: %v", err)
-	}
-	if len(findings) != 1 {
-		t.Errorf("findings = %d, want preserved 1", len(findings))
-	}
+	require.NoError(t, err, "SessionSecretFindings")
+	assert.Len(t, findings, 1, "findings preserved")
 	var rv string
-	if err := d.getReader().QueryRow(
+	err = d.getReader().QueryRow(
 		"SELECT secrets_rules_version FROM sessions WHERE id = 's1'",
-	).Scan(&rv); err != nil {
-		t.Fatalf("query secrets_rules_version: %v", err)
-	}
-	if rv != "rulesv1" {
-		t.Errorf("secrets_rules_version = %q, want preserved rulesv1", rv)
-	}
+	).Scan(&rv)
+	require.NoError(t, err, "query secrets_rules_version")
+	assert.Equal(t, "rulesv1", rv, "secrets_rules_version preserved")
 }
 
 func TestSecretScanCandidates(t *testing.T) {
@@ -411,30 +327,21 @@ func TestSecretScanCandidates(t *testing.T) {
 	insertSession(t, d, "stale", "proj", func(s *Session) { s.MessageCount = 1 })
 	insertSession(t, d, "empty", "proj", func(s *Session) { s.MessageCount = 0 })
 	// Mark "scanned" at the current version; the others stay at "".
-	if err := d.ReplaceSessionSecretFindings("scanned", nil, 0, "vCur"); err != nil {
-		t.Fatalf("mark scanned: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionSecretFindings("scanned", nil, 0, "vCur"),
+		"mark scanned")
 	ctx := context.Background()
 	stale, err := d.SecretScanCandidates(ctx, SecretScanCandidateFilter{
 		CurrentVersion: "vCur", OnlyStale: true,
 	})
-	if err != nil {
-		t.Fatalf("SecretScanCandidates stale: %v", err)
-	}
+	require.NoError(t, err, "SecretScanCandidates stale")
 	// Only "stale" qualifies: "scanned" is current, "empty" has no messages.
-	if len(stale) != 1 || stale[0] != "stale" {
-		t.Fatalf("OnlyStale candidates = %v, want [stale]", stale)
-	}
+	require.Equal(t, []string{"stale"}, stale, "OnlyStale candidates")
 	all, err := d.SecretScanCandidates(ctx, SecretScanCandidateFilter{
 		CurrentVersion: "vCur", OnlyStale: false,
 	})
-	if err != nil {
-		t.Fatalf("SecretScanCandidates forced: %v", err)
-	}
+	require.NoError(t, err, "SecretScanCandidates forced")
 	// Forced rescan ignores version but still requires messages.
-	if len(all) != 2 {
-		t.Fatalf("forced candidates = %v, want 2 (scanned+stale)", all)
-	}
+	require.Len(t, all, 2, "forced candidates (scanned+stale)")
 }
 
 func TestSecretFindingSource(t *testing.T) {
@@ -459,9 +366,8 @@ func TestSecretFindingSource(t *testing.T) {
 			},
 		},
 	}}
-	if err := d.ReplaceSessionMessages("s1", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages("s1", msgs),
+		"ReplaceSessionMessages")
 	ctx := context.Background()
 	cases := []struct {
 		name string
@@ -493,12 +399,9 @@ func TestSecretFindingSource(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, ok, err := d.SecretFindingSource(ctx, tc.f)
-			if err != nil {
-				t.Fatalf("SecretFindingSource: %v", err)
-			}
-			if ok != tc.ok || got != tc.want {
-				t.Errorf("got (%q, %v), want (%q, %v)", got, ok, tc.want, tc.ok)
-			}
+			require.NoError(t, err, "SecretFindingSource")
+			assert.Equal(t, tc.ok, ok, "ok")
+			assert.Equal(t, tc.want, got, "got")
 		})
 	}
 }
@@ -515,7 +418,7 @@ func TestOrphanCopyPreservesToolCallIndex(t *testing.T) {
 	// --- Source DB: one session, one assistant message, two tool calls ---
 	srcPath := filepath.Join(dir, "old.db")
 	srcDB, err := Open(srcPath)
-	requireNoError(t, err, "Open src")
+	require.NoError(t, err, "Open src")
 
 	insertSession(t, srcDB, "s1", "proj")
 	msgs := []Message{{
@@ -539,9 +442,8 @@ func TestOrphanCopyPreservesToolCallIndex(t *testing.T) {
 			},
 		},
 	}}
-	if err := srcDB.ReplaceSessionMessages("s1", msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	require.NoError(t, srcDB.ReplaceSessionMessages("s1", msgs),
+		"ReplaceSessionMessages")
 
 	// Finding at call_index=1 (second tool call), tool_result location.
 	finding := SecretFinding{
@@ -556,47 +458,35 @@ func TestOrphanCopyPreservesToolCallIndex(t *testing.T) {
 		MatchIndex:     0,
 		RedactedMatch:  "AKIA…MPLE",
 	}
-	if err := srcDB.ReplaceSessionSecretFindings(
+	require.NoError(t, srcDB.ReplaceSessionSecretFindings(
 		"s1", []SecretFinding{finding}, 1, "rulesv1",
-	); err != nil {
-		t.Fatalf("ReplaceSessionSecretFindings: %v", err)
-	}
+	), "ReplaceSessionSecretFindings")
 	srcDB.Close()
 
 	// --- Destination DB: copy orphaned data ---
 	dstPath := filepath.Join(dir, "new.db")
 	dstDB, err := Open(dstPath)
-	requireNoError(t, err, "Open dst")
+	require.NoError(t, err, "Open dst")
 	defer dstDB.Close()
 
 	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
-	requireNoError(t, err, "CopyOrphanedDataFrom")
-	if count != 1 {
-		t.Fatalf("expected 1 orphaned session, got %d", count)
-	}
+	require.NoError(t, err, "CopyOrphanedDataFrom")
+	require.Equal(t, 1, count, "expected 1 orphaned session")
 
 	// --- Verify: call_index=1 must resolve to the SECOND tool call ---
 	findings, err := dstDB.SessionSecretFindings(ctx, "s1")
-	requireNoError(t, err, "SessionSecretFindings")
-	if len(findings) != 1 {
-		t.Fatalf("findings count = %d, want 1", len(findings))
-	}
+	require.NoError(t, err, "SessionSecretFindings")
+	require.Len(t, findings, 1)
 	f := findings[0]
-	if f.CallIndex == nil || *f.CallIndex != 1 {
-		t.Fatalf("CallIndex = %v, want non-nil 1", f.CallIndex)
-	}
+	require.NotNil(t, f.CallIndex, "CallIndex")
+	require.Equal(t, 1, *f.CallIndex, "CallIndex")
 
 	got, ok, err := dstDB.SecretFindingSource(ctx, f)
-	requireNoError(t, err, "SecretFindingSource")
-	if !ok {
-		t.Fatal("SecretFindingSource returned ok=false; " +
-			"tool call order corrupted during orphan copy")
-	}
+	require.NoError(t, err, "SecretFindingSource")
+	require.True(t, ok, "SecretFindingSource returned ok=false; "+
+		"tool call order corrupted during orphan copy")
 	const wantContent = "AKIA7QHWN2DKR4FYPLJM"
-	if got != wantContent {
-		t.Errorf("SecretFindingSource = %q, want %q\n"+
-			"(call_index=1 resolved to wrong tool call; "+
-			"ORDER BY otc.id may be missing from orphan copy)",
-			got, wantContent)
-	}
+	assert.Equal(t, wantContent, got,
+		"SecretFindingSource (call_index=1 resolved to wrong tool call; "+
+			"ORDER BY otc.id may be missing from orphan copy)")
 }

--- a/internal/db/session_content_test.go
+++ b/internal/db/session_content_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReplaceSessionContentAtomic(t *testing.T) {
@@ -18,19 +21,11 @@ func TestReplaceSessionContentAtomic(t *testing.T) {
 		LocationKind: "message", MessageOrdinal: 0, MatchStart: 4, MatchEnd: 24,
 		MatchIndex: 0, RedactedMatch: "AKIA…MPLE", RulesVersion: "rulesv1",
 	}}
-	if err := d.ReplaceSessionContent("s1", msgs, signals, findings); err != nil {
-		t.Fatalf("ReplaceSessionContent: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionContent("s1", msgs, signals, findings))
 	got, _ := d.GetAllMessages(context.Background(), "s1")
-	if len(got) != 1 {
-		t.Fatalf("messages: got %d, want 1", len(got))
-	}
+	require.Len(t, got, 1)
 	f, _ := d.SessionSecretFindings(context.Background(), "s1")
-	if len(f) != 1 {
-		t.Fatalf("findings: got %d, want 1", len(f))
-	}
+	require.Len(t, f, 1)
 	s, _ := d.GetSession(context.Background(), "s1")
-	if s.SecretLeakCount != 1 {
-		t.Errorf("SecretLeakCount = %d, want 1", s.SecretLeakCount)
-	}
+	assert.Equal(t, 1, s.SecretLeakCount)
 }

--- a/internal/db/session_stats_buckets_test.go
+++ b/internal/db/session_stats_buckets_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAssignBucketDurationEdges(t *testing.T) {
@@ -16,9 +19,7 @@ func TestAssignBucketDurationEdges(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := assignBucket(durationMinutesEdges, c.v)
-		if got != c.want {
-			t.Errorf("durationMinutes v=%v: got %d, want %d", c.v, got, c.want)
-		}
+		assert.Equal(t, c.want, got, "durationMinutes v=%v", c.v)
 	}
 }
 
@@ -36,24 +37,17 @@ func TestAssignBucketUserMessagesAll(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := assignBucket(userMessagesEdgesAll, c.v)
-		if got != c.want {
-			t.Errorf("user_messages scope_all v=%v: got %d, want %d", c.v, got, c.want)
-		}
+		assert.Equal(t, c.want, got, "user_messages scope_all v=%v", c.v)
 	}
 }
 
 func TestBuildEmptyBucketsTopIsUnbounded(t *testing.T) {
 	b := buildEmptyBuckets(durationMinutesEdges)
-	if len(b) != 6 {
-		t.Fatalf("want 6 buckets, got %d", len(b))
-	}
+	require.Len(t, b, 6)
 	top := b[len(b)-1]
-	if top.Edge[1] != nil {
-		t.Errorf("top bucket hi should be nil (JSON null), got %v", *top.Edge[1])
-	}
-	if math.IsInf(*top.Edge[0], 1) {
-		t.Errorf("top bucket lo should be finite, got +Inf")
-	}
+	assert.Nil(t, top.Edge[1], "top bucket hi should be nil (JSON null)")
+	assert.False(t, math.IsInf(*top.Edge[0], 1),
+		"top bucket lo should be finite, got +Inf")
 }
 
 // TestEdgeListsShape pins every v1 edge list to the spec's bucket counts
@@ -74,18 +68,13 @@ func TestEdgeListsShape(t *testing.T) {
 		{"cacheHitRatio", cacheHitRatioEdges, 5, false}, // inclusive of 1.0 via 1.000001
 	}
 	for _, c := range cases {
-		if got := len(c.edges) - 1; got != c.wantBuckets {
-			t.Errorf("%s: want %d buckets, got %d", c.name, c.wantBuckets, got)
-		}
+		assert.Equal(t, c.wantBuckets, len(c.edges)-1, "%s: buckets", c.name)
 		for i := 1; i < len(c.edges); i++ {
-			if !(c.edges[i] > c.edges[i-1]) {
-				t.Errorf("%s: edges must be strictly increasing; edges[%d]=%v <= edges[%d]=%v",
-					c.name, i, c.edges[i], i-1, c.edges[i-1])
-			}
+			assert.Greater(t, c.edges[i], c.edges[i-1],
+				"%s: edges must be strictly increasing; edges[%d]=%v <= edges[%d]=%v",
+				c.name, i, c.edges[i], i-1, c.edges[i-1])
 		}
 		topIsInf := math.IsInf(c.edges[len(c.edges)-1], 1)
-		if topIsInf != c.wantTopInf {
-			t.Errorf("%s: top edge +Inf = %v, want %v", c.name, topIsInf, c.wantTopInf)
-		}
+		assert.Equal(t, c.wantTopInf, topIsInf, "%s: top edge +Inf", c.name)
 	}
 }

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -71,16 +71,12 @@ func Test_insertSessionFixture_isAutomated_patch(t *testing.T) {
 	})
 
 	var autoFlag, humanFlag int
-	if err := d.getReader().QueryRow(
+	require.NoError(t, d.getReader().QueryRow(
 		"SELECT is_automated FROM sessions WHERE id = ?", "auto-1",
-	).Scan(&autoFlag); err != nil {
-		t.Fatalf("read auto-1: %v", err)
-	}
-	if err := d.getReader().QueryRow(
+	).Scan(&autoFlag), "read auto-1")
+	require.NoError(t, d.getReader().QueryRow(
 		"SELECT is_automated FROM sessions WHERE id = ?", "human-1",
-	).Scan(&humanFlag); err != nil {
-		t.Fatalf("read human-1: %v", err)
-	}
+	).Scan(&humanFlag), "read human-1")
 	require.Equal(t, 1, autoFlag, "auto-1 is_automated")
 	require.Equal(t, 0, humanFlag, "human-1 is_automated")
 }
@@ -135,12 +131,9 @@ func insertSessionFixture(t *testing.T, d *DB, f sessionFixture) {
 	endedAt := f.endedAt
 	if endedAt == "" && f.durationMin > 0 && f.startedAt != "" {
 		start, err := time.Parse(time.RFC3339, f.startedAt)
-		if err != nil {
-			t.Fatalf(
-				"insertSessionFixture %s: parsing startedAt %q: %v",
-				f.id, f.startedAt, err,
-			)
-		}
+		require.NoError(t, err,
+			"insertSessionFixture %s: parsing startedAt %q",
+			f.id, f.startedAt)
 		dur := time.Duration(f.durationMin * float64(time.Minute))
 		endedAt = start.Add(dur).UTC().Format(time.RFC3339Nano)
 	}
@@ -179,13 +172,12 @@ func insertSessionFixture(t *testing.T, d *DB, f sessionFixture) {
 	if f.isAutomated {
 		want = 1
 	}
-	if _, err := d.getWriter().Exec(
+	_, err := d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = ? WHERE id = ?",
 		want, f.id,
-	); err != nil {
-		t.Fatalf("insertSessionFixture %s: patch is_automated: %v",
-			f.id, err)
-	}
+	)
+	require.NoError(t, err,
+		"insertSessionFixture %s: patch is_automated", f.id)
 }
 
 // seedAssistantActivity inserts `turns` assistant messages and
@@ -209,10 +201,8 @@ func seedAssistantActivity(
 	for i := range n {
 		msgs = append(msgs, asstMsg(sessionID, i+1, "reply"))
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatalf("seedAssistantActivity %s: InsertMessages: %v",
-			sessionID, err)
-	}
+	require.NoError(t, d.InsertMessages(msgs),
+		"seedAssistantActivity %s: InsertMessages", sessionID)
 	if toolCalls == 0 {
 		return
 	}
@@ -221,28 +211,17 @@ func seedAssistantActivity(
 	// INSERT ... SELECT ordinal to find the message_id.
 	for i := range toolCalls {
 		ord := (i % n) + 1
-		if _, err := d.getWriter().Exec(`
+		_, err := d.getWriter().Exec(`
 			INSERT INTO tool_calls
 				(message_id, session_id, tool_name, category)
 			SELECT id, session_id, 'Read', 'file'
 			FROM messages
 			WHERE session_id = ? AND ordinal = ?`,
 			sessionID, ord,
-		); err != nil {
-			t.Fatalf("seedAssistantActivity %s: tool_call: %v",
-				sessionID, err)
-		}
+		)
+		require.NoError(t, err,
+			"seedAssistantActivity %s: tool_call", sessionID)
 	}
-}
-
-// floatsClose reports whether a and b are within eps of each other.
-// Used by stats tests that compare arithmetic means.
-func floatsClose(a, b, eps float64) bool {
-	d := a - b
-	if d < 0 {
-		d = -d
-	}
-	return d <= eps
 }
 
 // seedToolCallsByCategory inserts one assistant message per entry in
@@ -260,23 +239,20 @@ func seedToolCallsByCategory(
 	for i, cat := range categories {
 		msgs = append(msgs, asstMsg(sessionID, i+1, "reply-"+cat))
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatalf("seedToolCallsByCategory %s: InsertMessages: %v",
-			sessionID, err)
-	}
+	require.NoError(t, d.InsertMessages(msgs),
+		"seedToolCallsByCategory %s: InsertMessages", sessionID)
 	for i, cat := range categories {
 		ord := i + 1
-		if _, err := d.getWriter().Exec(`
+		_, err := d.getWriter().Exec(`
 			INSERT INTO tool_calls
 				(message_id, session_id, tool_name, category)
 			SELECT id, session_id, ?, ?
 			FROM messages
 			WHERE session_id = ? AND ordinal = ?`,
 			cat, cat, sessionID, ord,
-		); err != nil {
-			t.Fatalf("seedToolCallsByCategory %s: %q: %v",
-				sessionID, cat, err)
-		}
+		)
+		require.NoError(t, err,
+			"seedToolCallsByCategory %s: %q", sessionID, cat)
 	}
 }
 
@@ -310,10 +286,8 @@ func seedModelMessages(
 		)
 		msgs = append(msgs, m)
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatalf("seedModelMessages %s: InsertMessages: %v",
-			sessionID, err)
-	}
+	require.NoError(t, d.InsertMessages(msgs),
+		"seedModelMessages %s: InsertMessages", sessionID)
 }
 
 func TestSessionShapeLabel(t *testing.T) {
@@ -337,12 +311,8 @@ func TestSessionShapeLabel(t *testing.T) {
 	}
 	for _, c := range cases {
 		got := sessionShapeLabel(c.userMsgs)
-		if got != c.want {
-			t.Errorf(
-				"sessionShapeLabel(%d): got %q, want %q",
-				c.userMsgs, got, c.want,
-			)
-		}
+		assert.Equal(t, c.want, got,
+			"sessionShapeLabel(%d)", c.userMsgs)
 	}
 }
 
@@ -352,23 +322,21 @@ func TestPickMaxLabel_TiesBreakByPriority(t *testing.T) {
 	priority := []string{
 		"automation", "marathon", "deep", "standard", "quick",
 	}
-	if got := pickMaxLabel(counts, priority); got != "automation" {
-		t.Errorf("tie break: got %q want automation", got)
-	}
+	assert.Equal(t, "automation", pickMaxLabel(counts, priority),
+		"tie break")
 	// PrimaryHuman excludes automation; marathon should win a 1/1/1
 	// tie over deep/standard/quick.
 	humanCounts := map[string]int{
 		"quick": 1, "standard": 1, "deep": 1, "marathon": 1,
 	}
 	humanPriority := []string{"marathon", "deep", "standard", "quick"}
-	if got := pickMaxLabel(humanCounts, humanPriority); got != "marathon" {
-		t.Errorf("human tie break: got %q want marathon", got)
-	}
+	assert.Equal(t, "marathon",
+		pickMaxLabel(humanCounts, humanPriority),
+		"human tie break")
 	// Strictly greater wins regardless of priority.
 	c2 := map[string]int{"quick": 5, "deep": 2}
-	if got := pickMaxLabel(c2, priority); got != "quick" {
-		t.Errorf("strict max: got %q want quick", got)
-	}
+	assert.Equal(t, "quick", pickMaxLabel(c2, priority),
+		"strict max")
 }
 
 func TestGetSessionStats_TotalsAndArchetypes(t *testing.T) {
@@ -396,91 +364,54 @@ func TestGetSessionStats_TotalsAndArchetypes(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 
 	assert.Equal(t, 1, stats.SchemaVersion, "schema_version: got")
-	if stats.Totals.SessionsAll != 5 {
-		t.Errorf("sessions_all: got %d want 5",
-			stats.Totals.SessionsAll)
-	}
-	if stats.Totals.SessionsAutomation != 2 {
-		t.Errorf("sessions_automation: got %d want 2",
-			stats.Totals.SessionsAutomation)
-	}
-	if stats.Totals.SessionsHuman != 3 {
-		t.Errorf("sessions_human: got %d want 3",
-			stats.Totals.SessionsHuman)
-	}
+	assert.Equal(t, 5, stats.Totals.SessionsAll, "sessions_all")
+	assert.Equal(t, 2, stats.Totals.SessionsAutomation,
+		"sessions_automation")
+	assert.Equal(t, 3, stats.Totals.SessionsHuman, "sessions_human")
 	// Invariant: human + automation must equal all.
-	if stats.Totals.SessionsHuman+stats.Totals.SessionsAutomation !=
-		stats.Totals.SessionsAll {
-		t.Errorf(
-			"invariant: human (%d) + automation (%d) != all (%d)",
-			stats.Totals.SessionsHuman,
-			stats.Totals.SessionsAutomation,
-			stats.Totals.SessionsAll,
-		)
-	}
-	if got := stats.Totals.UserMessagesTotal; got != 0+1+20+40+100 {
-		t.Errorf("user_messages_total: got %d want 161", got)
-	}
+	assert.Equal(t, stats.Totals.SessionsAll,
+		stats.Totals.SessionsHuman+stats.Totals.SessionsAutomation,
+		"invariant: human (%d) + automation (%d) != all (%d)",
+		stats.Totals.SessionsHuman,
+		stats.Totals.SessionsAutomation,
+		stats.Totals.SessionsAll)
+	assert.Equal(t, 161, stats.Totals.UserMessagesTotal,
+		"user_messages_total")
 
-	if stats.Archetypes.Automation != 2 {
-		t.Errorf("archetypes.automation: got %d want 2",
-			stats.Archetypes.Automation)
-	}
-	if stats.Archetypes.Quick != 0 {
-		t.Errorf("archetypes.quick: got %d want 0",
-			stats.Archetypes.Quick)
-	}
-	if stats.Archetypes.Standard != 0 {
-		t.Errorf("archetypes.standard: got %d want 0",
-			stats.Archetypes.Standard)
-	}
-	if stats.Archetypes.Deep != 2 {
-		t.Errorf("archetypes.deep: got %d want 2",
-			stats.Archetypes.Deep)
-	}
-	if stats.Archetypes.Marathon != 1 {
-		t.Errorf("archetypes.marathon: got %d want 1",
-			stats.Archetypes.Marathon)
-	}
+	assert.Equal(t, 2, stats.Archetypes.Automation,
+		"archetypes.automation")
+	assert.Equal(t, 0, stats.Archetypes.Quick, "archetypes.quick")
+	assert.Equal(t, 0, stats.Archetypes.Standard,
+		"archetypes.standard")
+	assert.Equal(t, 2, stats.Archetypes.Deep, "archetypes.deep")
+	assert.Equal(t, 1, stats.Archetypes.Marathon,
+		"archetypes.marathon")
 	// 2 automation, 2 deep — tie broken by priority: automation first.
-	if stats.Archetypes.Primary != "automation" {
-		t.Errorf("archetypes.primary: got %q want automation",
-			stats.Archetypes.Primary)
-	}
+	assert.Equal(t, "automation", stats.Archetypes.Primary,
+		"archetypes.primary")
 	// Human subset: 2 deep, 1 marathon. Deep wins.
-	if stats.Archetypes.PrimaryHuman != "deep" {
-		t.Errorf("archetypes.primary_human: got %q want deep",
-			stats.Archetypes.PrimaryHuman)
-	}
+	assert.Equal(t, "deep", stats.Archetypes.PrimaryHuman,
+		"archetypes.primary_human")
 
 	// Window bookkeeping: Since = now-28d, Until = now, days = 28.
 	assert.Equal(t, 28, stats.Window.Days, "window.days: got")
-	if stats.Window.Since == "" || stats.Window.Until == "" {
-		t.Errorf("window bounds empty: since=%q until=%q",
-			stats.Window.Since, stats.Window.Until)
-	}
-	if _, err := time.Parse(time.RFC3339, stats.Window.Since); err != nil {
-		t.Errorf("window.since not RFC3339: %v", err)
-	}
-	if _, err := time.Parse(time.RFC3339, stats.Window.Until); err != nil {
-		t.Errorf("window.until not RFC3339: %v", err)
-	}
+	assert.NotEmpty(t, stats.Window.Since,
+		"window.since (until=%q)", stats.Window.Until)
+	assert.NotEmpty(t, stats.Window.Until,
+		"window.until (since=%q)", stats.Window.Since)
+	_, errSince := time.Parse(time.RFC3339, stats.Window.Since)
+	assert.NoError(t, errSince, "window.since not RFC3339")
+	_, errUntil := time.Parse(time.RFC3339, stats.Window.Until)
+	assert.NoError(t, errUntil, "window.until not RFC3339")
 
 	// Filters echo the inputs and default Agent to "all".
-	if stats.Filters.Agent != "all" {
-		t.Errorf("filters.agent: got %q want all", stats.Filters.Agent)
-	}
-	if stats.Filters.Timezone != "UTC" {
-		t.Errorf("filters.timezone: got %q want UTC",
-			stats.Filters.Timezone)
-	}
-	if stats.Filters.ProjectsExcluded == nil {
-		t.Errorf("filters.projects_excluded must be non-nil slice")
-	}
+	assert.Equal(t, "all", stats.Filters.Agent, "filters.agent")
+	assert.Equal(t, "UTC", stats.Filters.Timezone,
+		"filters.timezone")
+	assert.NotNil(t, stats.Filters.ProjectsExcluded,
+		"filters.projects_excluded must be non-nil slice")
 
-	if stats.GeneratedAt == "" {
-		t.Errorf("generated_at empty")
-	}
+	assert.NotEmpty(t, stats.GeneratedAt, "generated_at")
 }
 
 func Test_computeTotalsAndArchetypes_flagAuthority(t *testing.T) {
@@ -524,23 +455,15 @@ func TestGetSessionStats_FilterByAgent(t *testing.T) {
 
 	all, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats all")
-	if all.Totals.SessionsAll != 2 {
-		t.Errorf("all agents: got %d want 2",
-			all.Totals.SessionsAll)
-	}
+	assert.Equal(t, 2, all.Totals.SessionsAll, "all agents")
 
 	onlyClaude, err := d.GetSessionStats(
 		ctx, StatsFilter{Since: "28d", Agent: "claude"},
 	)
 	require.NoError(t, err, "GetSessionStats claude")
-	if onlyClaude.Totals.SessionsAll != 1 {
-		t.Errorf("agent=claude: got %d want 1",
-			onlyClaude.Totals.SessionsAll)
-	}
-	if onlyClaude.Filters.Agent != "claude" {
-		t.Errorf("agent filter echoed: got %q want claude",
-			onlyClaude.Filters.Agent)
-	}
+	assert.Equal(t, 1, onlyClaude.Totals.SessionsAll, "agent=claude")
+	assert.Equal(t, "claude", onlyClaude.Filters.Agent,
+		"agent filter echoed")
 }
 
 func TestGetSessionStats_FilterByProject(t *testing.T) {
@@ -561,20 +484,16 @@ func TestGetSessionStats_FilterByProject(t *testing.T) {
 		IncludeProjects: []string{"alpha"},
 	})
 	require.NoError(t, err, "include alpha")
-	if includeAlpha.Totals.SessionsAll != 2 {
-		t.Errorf("include=alpha: got %d want 2",
-			includeAlpha.Totals.SessionsAll)
-	}
+	assert.Equal(t, 2, includeAlpha.Totals.SessionsAll,
+		"include=alpha")
 
 	excludeAlpha, err := d.GetSessionStats(ctx, StatsFilter{
 		Since:           "28d",
 		ExcludeProjects: []string{"alpha"},
 	})
 	require.NoError(t, err, "exclude alpha")
-	if excludeAlpha.Totals.SessionsAll != 2 {
-		t.Errorf("exclude=alpha: got %d want 2 (beta + gamma)",
-			excludeAlpha.Totals.SessionsAll)
-	}
+	assert.Equal(t, 2, excludeAlpha.Totals.SessionsAll,
+		"exclude=alpha want 2 (beta + gamma)")
 }
 
 func TestWindowBounds(t *testing.T) {
@@ -585,13 +504,11 @@ func TestWindowBounds(t *testing.T) {
 		from, to, days, err := windowBounds(StatsFilter{}, now)
 		require.NoError(t, err, "windowBounds")
 		assert.Equal(t, 28, days, "days: got")
-		if !to.Equal(now) {
-			t.Errorf("until: got %v want %v", to, now)
-		}
+		assert.True(t, to.Equal(now),
+			"until: got %v want %v", to, now)
 		wantFrom := now.Add(-28 * 24 * time.Hour)
-		if !from.Equal(wantFrom) {
-			t.Errorf("since: got %v want %v", from, wantFrom)
-		}
+		assert.True(t, from.Equal(wantFrom),
+			"since: got %v want %v", from, wantFrom)
 	})
 
 	t.Run("Nd duration", func(t *testing.T) {
@@ -607,9 +524,7 @@ func TestWindowBounds(t *testing.T) {
 			StatsFilter{Since: "48h"}, now,
 		)
 		require.NoError(t, err, "windowBounds")
-		if got := to.Sub(from); got != 48*time.Hour {
-			t.Errorf("span: got %v want 48h", got)
-		}
+		assert.Equal(t, 48*time.Hour, to.Sub(from), "span")
 	})
 
 	t.Run("bare date", func(t *testing.T) {
@@ -617,17 +532,19 @@ func TestWindowBounds(t *testing.T) {
 			StatsFilter{Since: "2026-04-01"}, now,
 		)
 		require.NoError(t, err, "windowBounds")
-		if from.Year() != 2026 || from.Month() != 4 || from.Day() != 1 {
-			t.Errorf("since parsed: got %v want 2026-04-01", from)
-		}
+		assert.Equal(t, 2026, from.Year(),
+			"since parsed: got %v want 2026-04-01", from)
+		assert.Equal(t, time.April, from.Month(),
+			"since parsed: got %v want 2026-04-01", from)
+		assert.Equal(t, 1, from.Day(),
+			"since parsed: got %v want 2026-04-01", from)
 	})
 
 	t.Run("invalid since", func(t *testing.T) {
-		if _, _, _, err := windowBounds(
+		_, _, _, err := windowBounds(
 			StatsFilter{Since: "bogus"}, now,
-		); err == nil {
-			t.Error("expected error for invalid Since")
-		}
+		)
+		assert.Error(t, err, "expected error for invalid Since")
 	})
 }
 
@@ -675,110 +592,85 @@ func TestGetSessionStats_Distributions(t *testing.T) {
 	// 25→bucket3, 120→bucket5 (top).
 	gotAll := stats.Distributions.DurationMinutes.ScopeAll.Buckets
 	wantCountsAll := []int{2, 0, 1, 1, 0, 1}
-	if len(gotAll) != len(wantCountsAll) {
-		t.Fatalf("duration scope_all: got %d buckets, want %d",
-			len(gotAll), len(wantCountsAll))
-	}
+	require.Len(t, gotAll, len(wantCountsAll),
+		"duration scope_all buckets")
 	for i, w := range wantCountsAll {
-		if gotAll[i].Count != w {
-			t.Errorf("duration scope_all bucket %d: got %d want %d",
-				i, gotAll[i].Count, w)
-		}
+		assert.Equal(t, w, gotAll[i].Count,
+			"duration scope_all bucket %d", i)
 	}
 	// duration scope_human (c,d,e): bucket2=1, bucket3=1, bucket5=1.
 	gotHuman := stats.Distributions.DurationMinutes.ScopeHuman.Buckets
 	wantCountsHuman := []int{0, 0, 1, 1, 0, 1}
-	if len(gotHuman) != len(wantCountsHuman) {
-		t.Fatalf("duration scope_human: got %d buckets, want %d",
-			len(gotHuman), len(wantCountsHuman))
-	}
+	require.Len(t, gotHuman, len(wantCountsHuman),
+		"duration scope_human buckets")
 	for i, w := range wantCountsHuman {
-		if gotHuman[i].Count != w {
-			t.Errorf("duration scope_human bucket %d: got %d want %d",
-				i, gotHuman[i].Count, w)
-		}
+		assert.Equal(t, w, gotHuman[i].Count,
+			"duration scope_human bucket %d", i)
 	}
 
 	// Means (arithmetic over included sessions).
 	wantAllMean := (0.5 + 0.9 + 10 + 25 + 120) / 5.0
 	gotAllMean := stats.Distributions.DurationMinutes.ScopeAll.Mean
-	if !floatsClose(gotAllMean, wantAllMean, 0.01) {
-		t.Errorf("duration scope_all mean: got %v want %v",
-			gotAllMean, wantAllMean)
-	}
+	assert.InDelta(t, wantAllMean, gotAllMean, 0.01,
+		"duration scope_all mean")
 	wantHumanMean := (10.0 + 25.0 + 120.0) / 3.0
 	gotHumanMean := stats.Distributions.DurationMinutes.ScopeHuman.Mean
-	if !floatsClose(gotHumanMean, wantHumanMean, 0.01) {
-		t.Errorf("duration scope_human mean: got %v want %v",
-			gotHumanMean, wantHumanMean)
-	}
+	assert.InDelta(t, wantHumanMean, gotHumanMean, 0.01,
+		"duration scope_human mean")
 
 	// user_messages scope_all uses userMessagesEdgesAll
 	// ([0,2),[2,6),[6,16),[16,31),[31,51),[51,inf)):
 	// 0→0, 1→0, 3→1, 10→2, 30→3.
 	gotUM := stats.Distributions.UserMessages.ScopeAll.Buckets
 	wantUM := []int{2, 1, 1, 1, 0, 0}
-	if len(gotUM) != len(wantUM) {
-		t.Fatalf("user_messages scope_all: got %d buckets, want %d",
-			len(gotUM), len(wantUM))
-	}
+	require.Len(t, gotUM, len(wantUM),
+		"user_messages scope_all buckets")
 	for i, w := range wantUM {
-		if gotUM[i].Count != w {
-			t.Errorf("user_messages scope_all bucket %d: got %d want %d",
-				i, gotUM[i].Count, w)
-		}
+		assert.Equal(t, w, gotUM[i].Count,
+			"user_messages scope_all bucket %d", i)
 	}
 	// user_messages scope_human uses userMessagesEdgesHuman (5 buckets,
 	// dropping the automation band): 3→0, 10→1, 30→2.
 	gotUMH := stats.Distributions.UserMessages.ScopeHuman.Buckets
 	wantUMH := []int{1, 1, 1, 0, 0}
-	if len(gotUMH) != len(wantUMH) {
-		t.Fatalf("user_messages scope_human: got %d buckets, want %d",
-			len(gotUMH), len(wantUMH))
-	}
+	require.Len(t, gotUMH, len(wantUMH),
+		"user_messages scope_human buckets")
 	for i, w := range wantUMH {
-		if gotUMH[i].Count != w {
-			t.Errorf("user_messages scope_human bucket %d: got %d want %d",
-				i, gotUMH[i].Count, w)
-		}
+		assert.Equal(t, w, gotUMH[i].Count,
+			"user_messages scope_human bucket %d", i)
 	}
 
 	// peak_context scope_all: 2k→0, 8k→0, 25k→1, 60k→2, 150k→4.
 	gotPCAll := stats.Distributions.PeakContextTokens.ScopeAll.Buckets
 	wantPCAll := []int{2, 1, 1, 0, 1, 0}
 	for i, w := range wantPCAll {
-		if gotPCAll[i].Count != w {
-			t.Errorf("peak_context scope_all bucket %d: got %d want %d",
-				i, gotPCAll[i].Count, w)
-		}
+		assert.Equal(t, w, gotPCAll[i].Count,
+			"peak_context scope_all bucket %d", i)
 	}
 	// peak_context scope_human (c,d,e): 25k→1, 60k→2, 150k→4.
 	gotPC := stats.Distributions.PeakContextTokens.ScopeHuman.Buckets
-	if gotPC[1].Count != 1 || gotPC[2].Count != 1 || gotPC[4].Count != 1 {
-		t.Errorf("peak_context scope_human: %+v", gotPC)
-	}
-	if !stats.Distributions.PeakContextTokens.ClaudeOnly {
-		t.Errorf("peak_context.claude_only: got false want true")
-	}
-	if stats.Distributions.PeakContextTokens.NullCount != 0 {
-		t.Errorf("peak_context.null_count: got %d want 0",
-			stats.Distributions.PeakContextTokens.NullCount)
-	}
+	assert.Equal(t, 1, gotPC[1].Count,
+		"peak_context scope_human: %+v", gotPC)
+	assert.Equal(t, 1, gotPC[2].Count,
+		"peak_context scope_human: %+v", gotPC)
+	assert.Equal(t, 1, gotPC[4].Count,
+		"peak_context scope_human: %+v", gotPC)
+	assert.True(t, stats.Distributions.PeakContextTokens.ClaudeOnly,
+		"peak_context.claude_only")
+	assert.Equal(t, 0,
+		stats.Distributions.PeakContextTokens.NullCount,
+		"peak_context.null_count")
 
 	// tools_per_turn: a skipped (assistantTurns==0),
 	// b=1/1=1, c=6/3=2, d=15/10=1.5, e=30/30=1.
 	// toolsPerTurnEdges = [0,1,2,4,7,11,+Inf].
 	gotTPT := stats.Distributions.ToolsPerTurn.ScopeAll.Buckets
 	wantTPT := []int{0, 3, 1, 0, 0, 0}
-	if len(gotTPT) != len(wantTPT) {
-		t.Fatalf("tools_per_turn scope_all: got %d buckets, want %d",
-			len(gotTPT), len(wantTPT))
-	}
+	require.Len(t, gotTPT, len(wantTPT),
+		"tools_per_turn scope_all buckets")
 	for i, w := range wantTPT {
-		if gotTPT[i].Count != w {
-			t.Errorf("tools_per_turn scope_all bucket %d: got %d want %d",
-				i, gotTPT[i].Count, w)
-		}
+		assert.Equal(t, w, gotTPT[i].Count,
+			"tools_per_turn scope_all bucket %d", i)
 	}
 }
 
@@ -799,21 +691,16 @@ func Test_computeDistributions_scopeHuman_flag(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 	// scope_all has both rows — mean ~= 16.5.
 	allMean := got.Distributions.DurationMinutes.ScopeAll.Mean
-	if allMean < 15 || allMean > 18 {
-		t.Fatalf("scope_all duration mean = %.2f, want ~16.5", allMean)
-	}
+	require.InDelta(t, 16.5, allMean, 1.5,
+		"scope_all duration mean")
 	// scope_human has only the non-automated short session — mean ~= 3.
 	humanMean := got.Distributions.DurationMinutes.ScopeHuman.Mean
-	if humanMean < 2 || humanMean > 4 {
-		t.Fatalf("scope_human duration mean = %.2f, want ~3 (short-human only)",
-			humanMean)
-	}
+	require.InDelta(t, 3.0, humanMean, 1.0,
+		"scope_human duration mean (short-human only)")
 
 	humanUserMessages := got.Distributions.UserMessages.ScopeHuman
-	if humanUserMessages.Mean != 0 {
-		t.Fatalf("scope_human user_messages mean = %.2f, want 0 (<2 filtered)",
-			humanUserMessages.Mean)
-	}
+	require.Equal(t, 0.0, humanUserMessages.Mean,
+		"scope_human user_messages mean want 0 (<2 filtered)")
 	bucketedHumanMessages := 0
 	for _, bucket := range humanUserMessages.Buckets {
 		bucketedHumanMessages += bucket.Count
@@ -855,18 +742,15 @@ func TestGetSessionStats_Distributions_NullPeakContext(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 
 	pc := stats.Distributions.PeakContextTokens
-	if pc.NullCount != 1 {
-		t.Errorf("null_count: got %d want 1 "+
-			"(only np1; codex cx1 must not count)", pc.NullCount)
-	}
+	assert.Equal(t, 1, pc.NullCount,
+		"null_count want 1 (only np1; codex cx1 must not count)")
 	total := 0
 	for _, b := range pc.ScopeAll.Buckets {
 		total += b.Count
 	}
-	if total != 1 {
-		t.Errorf("scope_all bucket total: got %d want 1 "+
-			"(the one Claude session with hasPeakContext=true)", total)
-	}
+	assert.Equal(t, 1, total,
+		"scope_all bucket total want 1 "+
+			"(the one Claude session with hasPeakContext=true)")
 }
 
 // seedVelocityMessages inserts len(offsetsSec) messages for sessionID,
@@ -880,10 +764,9 @@ func seedVelocityMessages(
 ) {
 	t.Helper()
 	start, err := time.Parse(time.RFC3339, startedAt)
-	if err != nil {
-		t.Fatalf("seedVelocityMessages %s: parse startedAt %q: %v",
-			sessionID, startedAt, err)
-	}
+	require.NoError(t, err,
+		"seedVelocityMessages %s: parse startedAt %q",
+		sessionID, startedAt)
 	msgs := make([]Message, 0, len(offsetsSec))
 	for i, off := range offsetsSec {
 		role := "user"
@@ -901,10 +784,8 @@ func seedVelocityMessages(
 			Timestamp:     ts,
 		})
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatalf("seedVelocityMessages %s: InsertMessages: %v",
-			sessionID, err)
-	}
+	require.NoError(t, d.InsertMessages(msgs),
+		"seedVelocityMessages %s: InsertMessages", sessionID)
 }
 
 func TestGetSessionStats_Velocity(t *testing.T) {
@@ -949,38 +830,26 @@ func TestGetSessionStats_Velocity(t *testing.T) {
 	// percentileFloat: P50 idx=int(5*0.5)=2 → 15, P90 idx=4 → 30.
 	// Mean = (5+10+15+20+30)/5 = 16.
 	tc := stats.Velocity.TurnCycleSeconds
-	if tc.P50 != 15.0 {
-		t.Errorf("TurnCycleSeconds.P50: got %v want 15", tc.P50)
-	}
-	if tc.P90 != 30.0 {
-		t.Errorf("TurnCycleSeconds.P90: got %v want 30", tc.P90)
-	}
-	if !floatsClose(tc.Mean, 16.0, 0.001) {
-		t.Errorf("TurnCycleSeconds.Mean: got %v want 16", tc.Mean)
-	}
+	assert.Equal(t, 15.0, tc.P50, "TurnCycleSeconds.P50")
+	assert.Equal(t, 30.0, tc.P90, "TurnCycleSeconds.P90")
+	assert.InDelta(t, 16.0, tc.Mean, 0.001,
+		"TurnCycleSeconds.Mean")
 
 	// First response seconds, sorted = [10,30].
 	// percentileFloat: P50 idx=int(2*0.5)=1 → 30, P90 idx=1 → 30.
 	// Mean = (10+30)/2 = 20.
 	fr := stats.Velocity.FirstResponseSeconds
-	if fr.P50 != 30.0 {
-		t.Errorf("FirstResponseSeconds.P50: got %v want 30", fr.P50)
-	}
-	if fr.P90 != 30.0 {
-		t.Errorf("FirstResponseSeconds.P90: got %v want 30", fr.P90)
-	}
-	if !floatsClose(fr.Mean, 20.0, 0.001) {
-		t.Errorf("FirstResponseSeconds.Mean: got %v want 20", fr.Mean)
-	}
+	assert.Equal(t, 30.0, fr.P50, "FirstResponseSeconds.P50")
+	assert.Equal(t, 30.0, fr.P90, "FirstResponseSeconds.P90")
+	assert.InDelta(t, 20.0, fr.Mean, 0.001,
+		"FirstResponseSeconds.Mean")
 
 	// MessagesPerActiveHour: active seconds=130, messages=10.
 	// activeMinutes = 130/60, per-hour = 10 / (activeMinutes/60)
 	//               = 10 * 60 / (130/60) = 36000/130 ≈ 276.923.
 	want := 36000.0 / 130.0
-	if !floatsClose(stats.Velocity.MessagesPerActiveHour, want, 0.01) {
-		t.Errorf("MessagesPerActiveHour: got %v want %v",
-			stats.Velocity.MessagesPerActiveHour, want)
-	}
+	assert.InDelta(t, want, stats.Velocity.MessagesPerActiveHour,
+		0.01, "MessagesPerActiveHour")
 }
 
 // Empty case: no sessions at all. The velocity accumulator stays zeroed
@@ -993,17 +862,15 @@ func TestGetSessionStats_Velocity_Empty(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 
 	tc := stats.Velocity.TurnCycleSeconds
-	if tc.P50 != 0 || tc.P90 != 0 || tc.Mean != 0 {
-		t.Errorf("TurnCycleSeconds: got %+v want all zero", tc)
-	}
+	assert.Equal(t, 0.0, tc.P50, "TurnCycleSeconds.P50 want zero: %+v", tc)
+	assert.Equal(t, 0.0, tc.P90, "TurnCycleSeconds.P90 want zero: %+v", tc)
+	assert.Equal(t, 0.0, tc.Mean, "TurnCycleSeconds.Mean want zero: %+v", tc)
 	fr := stats.Velocity.FirstResponseSeconds
-	if fr.P50 != 0 || fr.P90 != 0 || fr.Mean != 0 {
-		t.Errorf("FirstResponseSeconds: got %+v want all zero", fr)
-	}
-	if stats.Velocity.MessagesPerActiveHour != 0 {
-		t.Errorf("MessagesPerActiveHour: got %v want 0",
-			stats.Velocity.MessagesPerActiveHour)
-	}
+	assert.Equal(t, 0.0, fr.P50, "FirstResponseSeconds.P50 want zero: %+v", fr)
+	assert.Equal(t, 0.0, fr.P90, "FirstResponseSeconds.P90 want zero: %+v", fr)
+	assert.Equal(t, 0.0, fr.Mean, "FirstResponseSeconds.Mean want zero: %+v", fr)
+	assert.Equal(t, 0.0, stats.Velocity.MessagesPerActiveHour,
+		"MessagesPerActiveHour")
 }
 
 // Single session with one user→assistant turn. One sample point feeds
@@ -1028,32 +895,20 @@ func TestGetSessionStats_Velocity_SingleTurn(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 
 	tc := stats.Velocity.TurnCycleSeconds
-	if tc.P50 != 60.0 || tc.P90 != 60.0 {
-		t.Errorf("TurnCycleSeconds: got p50=%v p90=%v want both 60",
-			tc.P50, tc.P90)
-	}
-	if !floatsClose(tc.Mean, 60.0, 0.001) {
-		t.Errorf("TurnCycleSeconds.Mean: got %v want 60", tc.Mean)
-	}
+	assert.Equal(t, 60.0, tc.P50, "TurnCycleSeconds.P50")
+	assert.Equal(t, 60.0, tc.P90, "TurnCycleSeconds.P90")
+	assert.InDelta(t, 60.0, tc.Mean, 0.001,
+		"TurnCycleSeconds.Mean")
 	fr := stats.Velocity.FirstResponseSeconds
-	if fr.P50 != 60.0 || fr.P90 != 60.0 {
-		t.Errorf("FirstResponseSeconds: got p50=%v p90=%v want both 60",
-			fr.P50, fr.P90)
-	}
-	if !floatsClose(fr.Mean, 60.0, 0.001) {
-		t.Errorf("FirstResponseSeconds.Mean: got %v want 60", fr.Mean)
-	}
-	if stats.Velocity.MessagesPerActiveHour <= 0 {
-		t.Errorf("MessagesPerActiveHour: got %v want > 0",
-			stats.Velocity.MessagesPerActiveHour)
-	}
+	assert.Equal(t, 60.0, fr.P50, "FirstResponseSeconds.P50")
+	assert.Equal(t, 60.0, fr.P90, "FirstResponseSeconds.P90")
+	assert.InDelta(t, 60.0, fr.Mean, 0.001,
+		"FirstResponseSeconds.Mean")
+	assert.Greater(t, stats.Velocity.MessagesPerActiveHour, 0.0,
+		"MessagesPerActiveHour want > 0")
 	want := 120.0
-	if !floatsClose(
-		stats.Velocity.MessagesPerActiveHour, want, 0.001,
-	) {
-		t.Errorf("MessagesPerActiveHour: got %v want %v",
-			stats.Velocity.MessagesPerActiveHour, want)
-	}
+	assert.InDelta(t, want, stats.Velocity.MessagesPerActiveHour,
+		0.001, "MessagesPerActiveHour")
 }
 
 // Zero-active-minutes boundary: two messages share a timestamp so the
@@ -1075,10 +930,8 @@ func TestGetSessionStats_Velocity_ZeroActive(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
 
-	if stats.Velocity.MessagesPerActiveHour != 0 {
-		t.Errorf("MessagesPerActiveHour: got %v want 0",
-			stats.Velocity.MessagesPerActiveHour)
-	}
+	assert.Equal(t, 0.0, stats.Velocity.MessagesPerActiveHour,
+		"MessagesPerActiveHour")
 }
 
 func TestGetSessionStats_ToolMixAndModelMix(t *testing.T) {
@@ -1136,35 +989,24 @@ func TestGetSessionStats_ToolMixAndModelMix(t *testing.T) {
 		"Grep": 1,
 	}
 	gotCats := stats.ToolMix.ByCategory
-	if len(gotCats) != len(wantCats) {
-		t.Errorf("ToolMix.ByCategory len: got %d want %d (got=%v)",
-			len(gotCats), len(wantCats), gotCats)
-	}
+	assert.Len(t, gotCats, len(wantCats),
+		"ToolMix.ByCategory len (got=%v)", gotCats)
 	for cat, want := range wantCats {
-		if gotCats[cat] != want {
-			t.Errorf("ToolMix.ByCategory[%q]: got %d want %d",
-				cat, gotCats[cat], want)
-		}
+		assert.Equal(t, want, gotCats[cat],
+			"ToolMix.ByCategory[%q]", cat)
 	}
-	if stats.ToolMix.TotalCalls != 6 {
-		t.Errorf("ToolMix.TotalCalls: got %d want 6",
-			stats.ToolMix.TotalCalls)
-	}
+	assert.Equal(t, 6, stats.ToolMix.TotalCalls, "ToolMix.TotalCalls")
 
 	wantTokens := map[string]int64{
 		"claude-opus-4-7":   3000,
 		"claude-sonnet-4-6": 500,
 	}
 	gotTokens := stats.ModelMix.ByTokens
-	if len(gotTokens) != len(wantTokens) {
-		t.Errorf("ModelMix.ByTokens len: got %d want %d (got=%v)",
-			len(gotTokens), len(wantTokens), gotTokens)
-	}
+	assert.Len(t, gotTokens, len(wantTokens),
+		"ModelMix.ByTokens len (got=%v)", gotTokens)
 	for model, want := range wantTokens {
-		if gotTokens[model] != want {
-			t.Errorf("ModelMix.ByTokens[%q]: got %d want %d",
-				model, gotTokens[model], want)
-		}
+		assert.Equal(t, want, gotTokens[model],
+			"ModelMix.ByTokens[%q]", model)
 	}
 }
 
@@ -1224,33 +1066,24 @@ func TestGetSessionStats_ToolMixAndModelMix_Filters(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 
 	// Only in1's 2 tool_calls survive.
-	if stats.ToolMix.TotalCalls != 2 {
-		t.Errorf("ToolMix.TotalCalls: got %d want 2",
-			stats.ToolMix.TotalCalls)
-	}
-	if stats.ToolMix.ByCategory["Bash"] != 1 ||
-		stats.ToolMix.ByCategory["Read"] != 1 {
-		t.Errorf("ToolMix.ByCategory: got %v want Bash=1 Read=1",
-			stats.ToolMix.ByCategory)
-	}
-	if stats.ToolMix.ByCategory["Edit"] != 0 {
-		t.Errorf("out-of-window Edit leaked: got %d",
-			stats.ToolMix.ByCategory["Edit"])
-	}
-	if stats.ToolMix.ByCategory["Grep"] != 0 {
-		t.Errorf("wrong-agent Grep leaked: got %d",
-			stats.ToolMix.ByCategory["Grep"])
-	}
+	assert.Equal(t, 2, stats.ToolMix.TotalCalls, "ToolMix.TotalCalls")
+	assert.Equal(t, 1, stats.ToolMix.ByCategory["Bash"],
+		"ToolMix.ByCategory: want Bash=1 Read=1, got %v",
+		stats.ToolMix.ByCategory)
+	assert.Equal(t, 1, stats.ToolMix.ByCategory["Read"],
+		"ToolMix.ByCategory: want Bash=1 Read=1, got %v",
+		stats.ToolMix.ByCategory)
+	assert.Equal(t, 0, stats.ToolMix.ByCategory["Edit"],
+		"out-of-window Edit leaked")
+	assert.Equal(t, 0, stats.ToolMix.ByCategory["Grep"],
+		"wrong-agent Grep leaked")
 
 	// Only in1's 800 tokens survive.
-	if got := stats.ModelMix.ByTokens["claude-opus-4-7"]; got != 800 {
-		t.Errorf("ModelMix.ByTokens[claude-opus-4-7]: got %d want 800",
-			got)
-	}
-	if _, ok := stats.ModelMix.ByTokens["codex-gpt-5"]; ok {
-		t.Errorf("wrong-agent model leaked: %v",
-			stats.ModelMix.ByTokens)
-	}
+	assert.Equal(t, int64(800),
+		stats.ModelMix.ByTokens["claude-opus-4-7"],
+		"ModelMix.ByTokens[claude-opus-4-7]")
+	assert.NotContains(t, stats.ModelMix.ByTokens, "codex-gpt-5",
+		"wrong-agent model leaked")
 }
 
 // Empty-window case: no sessions → both mixes must serialize as empty
@@ -1261,16 +1094,12 @@ func TestGetSessionStats_ToolMixAndModelMix_Empty(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.ToolMix.ByCategory == nil {
-		t.Errorf("ToolMix.ByCategory: got nil want non-nil map")
-	}
-	if stats.ToolMix.TotalCalls != 0 {
-		t.Errorf("ToolMix.TotalCalls: got %d want 0",
-			stats.ToolMix.TotalCalls)
-	}
-	if stats.ModelMix.ByTokens == nil {
-		t.Errorf("ModelMix.ByTokens: got nil want non-nil map")
-	}
+	assert.NotNil(t, stats.ToolMix.ByCategory,
+		"ToolMix.ByCategory: want non-nil map")
+	assert.Equal(t, 0, stats.ToolMix.TotalCalls,
+		"ToolMix.TotalCalls")
+	assert.NotNil(t, stats.ModelMix.ByTokens,
+		"ModelMix.ByTokens: want non-nil map")
 }
 
 // AgentPortfolio aggregates session, message, and output-token counts
@@ -1328,36 +1157,26 @@ func TestGetSessionStats_AgentPortfolio(t *testing.T) {
 
 	ap := stats.AgentPortfolio
 	wantSessions := map[string]int{"claude": 3, "codex": 2, "cursor": 1}
-	if len(ap.BySessions) != len(wantSessions) {
-		t.Errorf("BySessions len: got %d want %d (got=%v)",
-			len(ap.BySessions), len(wantSessions), ap.BySessions)
-	}
+	assert.Len(t, ap.BySessions, len(wantSessions),
+		"BySessions len (got=%v)", ap.BySessions)
 	for k, v := range wantSessions {
-		if ap.BySessions[k] != v {
-			t.Errorf("BySessions[%q]: got %d want %d",
-				k, ap.BySessions[k], v)
-		}
+		assert.Equal(t, v, ap.BySessions[k],
+			"BySessions[%q]", k)
 	}
 
 	wantMessages := map[string]int{"claude": 22, "codex": 9, "cursor": 4}
 	for k, v := range wantMessages {
-		if ap.ByMessages[k] != v {
-			t.Errorf("ByMessages[%q]: got %d want %d",
-				k, ap.ByMessages[k], v)
-		}
+		assert.Equal(t, v, ap.ByMessages[k],
+			"ByMessages[%q]", k)
 	}
 
 	wantTokens := map[string]int64{"claude": 600, "codex": 150, "cursor": 80}
 	for k, v := range wantTokens {
-		if ap.ByTokens[k] != v {
-			t.Errorf("ByTokens[%q]: got %d want %d",
-				k, ap.ByTokens[k], v)
-		}
+		assert.Equal(t, v, ap.ByTokens[k],
+			"ByTokens[%q]", k)
 	}
 
-	if ap.Primary != "claude" {
-		t.Errorf("Primary: got %q want claude", ap.Primary)
-	}
+	assert.Equal(t, "claude", ap.Primary, "Primary")
 }
 
 // Tie-break: two agents at equal session counts must resolve to the
@@ -1389,16 +1208,14 @@ func TestGetSessionStats_AgentPortfolio_TieBreak(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.AgentPortfolio.BySessions["claude"] != 2 ||
-		stats.AgentPortfolio.BySessions["codex"] != 2 {
-		t.Fatalf("precondition: claude/codex must tie at 2 (got %v)",
-			stats.AgentPortfolio.BySessions)
-	}
-	if stats.AgentPortfolio.Primary != "claude" {
-		t.Errorf("Primary under tie: got %q want claude "+
-			"(alphabetical tie-break)",
-			stats.AgentPortfolio.Primary)
-	}
+	require.Equal(t, 2, stats.AgentPortfolio.BySessions["claude"],
+		"precondition: claude/codex must tie at 2 (got %v)",
+		stats.AgentPortfolio.BySessions)
+	require.Equal(t, 2, stats.AgentPortfolio.BySessions["codex"],
+		"precondition: claude/codex must tie at 2 (got %v)",
+		stats.AgentPortfolio.BySessions)
+	assert.Equal(t, "claude", stats.AgentPortfolio.Primary,
+		"Primary under tie want claude (alphabetical tie-break)")
 }
 
 // Empty-window case: AgentPortfolio maps must be non-nil (JSON encodes
@@ -1410,38 +1227,32 @@ func TestGetSessionStats_AgentPortfolio_Empty(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
 	ap := stats.AgentPortfolio
-	if ap.BySessions == nil {
-		t.Errorf("BySessions: got nil want non-nil map")
-	}
-	if ap.ByMessages == nil {
-		t.Errorf("ByMessages: got nil want non-nil map")
-	}
-	if ap.ByTokens == nil {
-		t.Errorf("ByTokens: got nil want non-nil map")
-	}
-	if ap.BySessionsHuman == nil {
-		t.Errorf("BySessionsHuman: got nil want non-nil map")
-	}
-	if ap.ByMessagesHuman == nil {
-		t.Errorf("ByMessagesHuman: got nil want non-nil map")
-	}
-	if ap.ByTokensHuman == nil {
-		t.Errorf("ByTokensHuman: got nil want non-nil map")
-	}
-	if len(ap.BySessions) != 0 || len(ap.ByMessages) != 0 ||
-		len(ap.ByTokens) != 0 {
-		t.Errorf("empty window: got non-empty maps %+v", ap)
-	}
-	if len(ap.BySessionsHuman) != 0 || len(ap.ByMessagesHuman) != 0 ||
-		len(ap.ByTokensHuman) != 0 {
-		t.Errorf("empty window: got non-empty human maps %+v", ap)
-	}
-	if ap.Primary != "" {
-		t.Errorf("Primary: got %q want empty", ap.Primary)
-	}
-	if ap.PrimaryHuman != "" {
-		t.Errorf("PrimaryHuman: got %q want empty", ap.PrimaryHuman)
-	}
+	assert.NotNil(t, ap.BySessions,
+		"BySessions: want non-nil map")
+	assert.NotNil(t, ap.ByMessages,
+		"ByMessages: want non-nil map")
+	assert.NotNil(t, ap.ByTokens,
+		"ByTokens: want non-nil map")
+	assert.NotNil(t, ap.BySessionsHuman,
+		"BySessionsHuman: want non-nil map")
+	assert.NotNil(t, ap.ByMessagesHuman,
+		"ByMessagesHuman: want non-nil map")
+	assert.NotNil(t, ap.ByTokensHuman,
+		"ByTokensHuman: want non-nil map")
+	assert.Empty(t, ap.BySessions,
+		"empty window: got non-empty maps %+v", ap)
+	assert.Empty(t, ap.ByMessages,
+		"empty window: got non-empty maps %+v", ap)
+	assert.Empty(t, ap.ByTokens,
+		"empty window: got non-empty maps %+v", ap)
+	assert.Empty(t, ap.BySessionsHuman,
+		"empty window: got non-empty human maps %+v", ap)
+	assert.Empty(t, ap.ByMessagesHuman,
+		"empty window: got non-empty human maps %+v", ap)
+	assert.Empty(t, ap.ByTokensHuman,
+		"empty window: got non-empty human maps %+v", ap)
+	assert.Empty(t, ap.Primary, "Primary")
+	assert.Empty(t, ap.PrimaryHuman, "PrimaryHuman")
 }
 
 func Test_computeAgentPortfolio_humanScoped(t *testing.T) {
@@ -1467,23 +1278,22 @@ func Test_computeAgentPortfolio_humanScoped(t *testing.T) {
 	ap := got.AgentPortfolio
 
 	// All-sessions view: every agent present.
-	if ap.BySessions["claude"] != 1 || ap.BySessions["codex"] != 1 ||
-		ap.BySessions["gemini"] != 1 {
-		t.Fatalf("BySessions = %v, want claude=1,codex=1,gemini=1",
-			ap.BySessions)
-	}
+	require.Equal(t, 1, ap.BySessions["claude"],
+		"BySessions = %v, want claude=1,codex=1,gemini=1", ap.BySessions)
+	require.Equal(t, 1, ap.BySessions["codex"],
+		"BySessions = %v, want claude=1,codex=1,gemini=1", ap.BySessions)
+	require.Equal(t, 1, ap.BySessions["gemini"],
+		"BySessions = %v, want claude=1,codex=1,gemini=1", ap.BySessions)
 	// primary ties on count; lexicographic min wins → claude.
 	require.Equal(t, "claude", ap.Primary, "Primary")
 
 	// Human-scoped view: only claude.
-	if _, ok := ap.BySessionsHuman["codex"]; ok {
-		t.Fatalf("BySessionsHuman must exclude codex: %v",
-			ap.BySessionsHuman)
-	}
-	if _, ok := ap.BySessionsHuman["gemini"]; ok {
-		t.Fatalf("BySessionsHuman must exclude gemini: %v",
-			ap.BySessionsHuman)
-	}
+	require.NotContains(t, ap.BySessionsHuman, "codex",
+		"BySessionsHuman must exclude codex: %v",
+		ap.BySessionsHuman)
+	require.NotContains(t, ap.BySessionsHuman, "gemini",
+		"BySessionsHuman must exclude gemini: %v",
+		ap.BySessionsHuman)
 	require.Equal(t, 1, ap.BySessionsHuman["claude"], "BySessionsHuman[claude]")
 	require.Equal(t, int64(100), ap.ByTokensHuman["claude"], "ByTokensHuman[claude]")
 	require.Equal(t, "claude", ap.PrimaryHuman, "PrimaryHuman")
@@ -1519,10 +1329,8 @@ func seedCacheEconomicsMessage(
 	m.OutputTokens = b.output
 	m.HasOutputTokens = true
 	m.TokenUsage = json.RawMessage(payload)
-	if err := d.InsertMessages([]Message{m}); err != nil {
-		t.Fatalf("seedCacheEconomicsMessage %s ord=%d: %v",
-			sessionID, ordinal, err)
-	}
+	require.NoError(t, d.InsertMessages([]Message{m}),
+		"seedCacheEconomicsMessage %s ord=%d", sessionID, ordinal)
 }
 
 // TestGetSessionStats_CacheEconomics exercises the cache-economics
@@ -1535,7 +1343,7 @@ func TestGetSessionStats_CacheEconomics(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
 
-	if err := d.UpsertModelPricing([]ModelPricing{
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{
 		{
 			ModelPattern:         "claude-opus-4-7",
 			InputPerMTok:         15.0,
@@ -1550,9 +1358,7 @@ func TestGetSessionStats_CacheEconomics(t *testing.T) {
 			CacheCreationPerMTok: 3.75,
 			CacheReadPerMTok:     0.3,
 		},
-	}); err != nil {
-		t.Fatalf("UpsertModelPricing: %v", err)
-	}
+	}), "UpsertModelPricing")
 
 	// ce1 (opus): ratio = 9000 / (1000+9000+100) = 9000/10100 ≈ 0.8911
 	// → cacheHitRatioEdges bucket 3 ([0.75, 0.95)).
@@ -1606,32 +1412,22 @@ func TestGetSessionStats_CacheEconomics(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 
 	ce := stats.CacheEconomics
-	if ce == nil {
-		t.Fatalf("CacheEconomics: got nil, want populated")
-	}
-	if !ce.ClaudeOnly {
-		t.Errorf("ClaudeOnly: got false, want true")
-	}
+	require.NotNil(t, ce, "CacheEconomics: want populated")
+	assert.True(t, ce.ClaudeOnly, "ClaudeOnly")
 
 	// Overall = sum(cache_read) / sum(denominator) (weighted mean).
 	// = (9000 + 3000 + 100) / (10100 + 3550 + 200)
 	// = 12100 / 13850 ≈ 0.873646.
 	wantOverall := 12100.0 / 13850.0
-	if !floatsClose(ce.CacheHitRatio.Overall, wantOverall, 1e-6) {
-		t.Errorf("CacheHitRatio.Overall: got %v want %v",
-			ce.CacheHitRatio.Overall, wantOverall)
-	}
+	assert.InDelta(t, wantOverall, ce.CacheHitRatio.Overall, 1e-6,
+		"CacheHitRatio.Overall")
 
 	wantBuckets := []int{0, 0, 1, 2, 0}
-	if len(ce.CacheHitRatio.Buckets) != len(wantBuckets) {
-		t.Fatalf("CacheHitRatio.Buckets: got %d buckets want %d",
-			len(ce.CacheHitRatio.Buckets), len(wantBuckets))
-	}
+	require.Len(t, ce.CacheHitRatio.Buckets, len(wantBuckets),
+		"CacheHitRatio.Buckets")
 	for i, w := range wantBuckets {
-		if ce.CacheHitRatio.Buckets[i].Count != w {
-			t.Errorf("CacheHitRatio.Buckets[%d]: got %d want %d",
-				i, ce.CacheHitRatio.Buckets[i].Count, w)
-		}
+		assert.Equal(t, w, ce.CacheHitRatio.Buckets[i].Count,
+			"CacheHitRatio.Buckets[%d]", i)
 	}
 
 	// Per-message cost (rates in $/MTok, so divide by 1e6):
@@ -1642,10 +1438,7 @@ func TestGetSessionStats_CacheEconomics(t *testing.T) {
 	//   ce3 opus = (100*15 + 50*75 + 0 + 100*1.5)/1e6
 	//           = (1500 + 3750 + 150)/1e6 = 0.0054
 	wantSpent := 0.067875 + 0.0055875 + 0.0054
-	if !floatsClose(ce.DollarsSpent, wantSpent, 1e-9) {
-		t.Errorf("DollarsSpent: got %v want %v",
-			ce.DollarsSpent, wantSpent)
-	}
+	assert.InDelta(t, wantSpent, ce.DollarsSpent, 1e-9, "DollarsSpent")
 
 	// cost_without_cache reprices input + cache_creation + cache_read
 	// at the input rate, keeping output unchanged. cache_creation
@@ -1660,10 +1453,8 @@ func TestGetSessionStats_CacheEconomics(t *testing.T) {
 	//           = (3000 + 3750)/1e6 = 0.00675
 	wantWithoutCache := 0.189 + 0.01365 + 0.00675
 	wantSavings := wantWithoutCache - wantSpent
-	if !floatsClose(ce.DollarsSavedVsUncached, wantSavings, 1e-9) {
-		t.Errorf("DollarsSavedVsUncached: got %v want %v",
-			ce.DollarsSavedVsUncached, wantSavings)
-	}
+	assert.InDelta(t, wantSavings, ce.DollarsSavedVsUncached, 1e-9,
+		"DollarsSavedVsUncached")
 }
 
 // TestGetSessionStats_CacheEconomics_NoClaude verifies that the
@@ -1677,13 +1468,11 @@ func TestGetSessionStats_CacheEconomics_NoClaude(t *testing.T) {
 
 	// Pricing is present so the nil result isn't an artifact of a
 	// missing pricing map.
-	if err := d.UpsertModelPricing([]ModelPricing{{
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
 		ModelPattern: "claude-sonnet-4-6",
 		InputPerMTok: 3.0, OutputPerMTok: 15.0,
 		CacheCreationPerMTok: 3.75, CacheReadPerMTok: 0.3,
-	}}); err != nil {
-		t.Fatalf("UpsertModelPricing: %v", err)
-	}
+	}}), "UpsertModelPricing")
 
 	insertSessionFixture(t, d, sessionFixture{
 		id: "cx1", agent: "codex", userMsgs: 3,
@@ -1694,10 +1483,7 @@ func TestGetSessionStats_CacheEconomics_NoClaude(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.CacheEconomics != nil {
-		t.Errorf("CacheEconomics: got %+v want nil",
-			stats.CacheEconomics)
-	}
+	assert.Nil(t, stats.CacheEconomics, "CacheEconomics")
 }
 
 // TestGetSessionStats_CacheEconomics_ZeroDenominatorSkipped seeds one
@@ -1709,13 +1495,11 @@ func TestGetSessionStats_CacheEconomics_ZeroDenominatorSkipped(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
 
-	if err := d.UpsertModelPricing([]ModelPricing{{
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
 		ModelPattern: "claude-opus-4-7",
 		InputPerMTok: 15.0, OutputPerMTok: 75.0,
 		CacheCreationPerMTok: 18.75, CacheReadPerMTok: 1.5,
-	}}); err != nil {
-		t.Fatalf("UpsertModelPricing: %v", err)
-	}
+	}}), "UpsertModelPricing")
 
 	// Session with a contributing denominator.
 	insertSessionFixture(t, d, sessionFixture{
@@ -1739,27 +1523,19 @@ func TestGetSessionStats_CacheEconomics_ZeroDenominatorSkipped(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
 	ce := stats.CacheEconomics
-	if ce == nil {
-		t.Fatalf("CacheEconomics: got nil want populated")
-	}
+	require.NotNil(t, ce, "CacheEconomics: want populated")
 	// Only "ok" contributes: ratio = 300 / (100+300) = 0.75 → bucket 3.
 	total := 0
 	for _, b := range ce.CacheHitRatio.Buckets {
 		total += b.Count
 	}
-	if total != 1 {
-		t.Errorf("histogram total: got %d want 1 (zero-denom skipped)",
-			total)
-	}
-	if ce.CacheHitRatio.Buckets[3].Count != 1 {
-		t.Errorf("bucket 3 [0.75,0.95): got %d want 1",
-			ce.CacheHitRatio.Buckets[3].Count)
-	}
+	assert.Equal(t, 1, total,
+		"histogram total want 1 (zero-denom skipped)")
+	assert.Equal(t, 1, ce.CacheHitRatio.Buckets[3].Count,
+		"bucket 3 [0.75,0.95)")
 	// Overall = 300/400 = 0.75 exactly (zero-denom session excluded
 	// from both numerator and denominator).
-	if !floatsClose(ce.CacheHitRatio.Overall, 0.75, 1e-9) {
-		t.Errorf("Overall: got %v want 0.75", ce.CacheHitRatio.Overall)
-	}
+	assert.InDelta(t, 0.75, ce.CacheHitRatio.Overall, 1e-9, "Overall")
 }
 
 func TestPickPrimaryAgent(t *testing.T) {
@@ -1803,10 +1579,8 @@ func TestPickPrimaryAgent(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := pickPrimaryAgent(c.input); got != c.want {
-				t.Errorf("pickPrimaryAgent(%v): got %q want %q",
-					c.input, got, c.want)
-			}
+			assert.Equal(t, c.want, pickPrimaryAgent(c.input),
+				"pickPrimaryAgent(%v)", c.input)
 		})
 	}
 }
@@ -1876,47 +1650,31 @@ func TestGetSessionStats_Temporal_HourlyGrouping(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
 	hours := stats.Temporal.HourlyUTC
-	if len(hours) != 3 {
-		t.Fatalf("hourly_utc: got %d entries want 3 (%+v)",
-			len(hours), hours)
-	}
+	require.Len(t, hours, 3,
+		"hourly_utc want 3 entries: %+v", hours)
 
 	// Entries must be sorted by TS ascending.
 	for i := 1; i < len(hours); i++ {
-		if hours[i-1].TS >= hours[i].TS {
-			t.Errorf("hourly_utc not ascending: %q >= %q",
-				hours[i-1].TS, hours[i].TS)
-		}
+		assert.Less(t, hours[i-1].TS, hours[i].TS,
+			"hourly_utc not ascending")
 	}
 
 	// H-5: 2 user messages, 1 distinct session.
-	if e := findHourlyUTC(hours, utcHourBoundary(5)); e == nil {
-		t.Errorf("missing hour entry %q", utcHourBoundary(5))
-	} else {
-		if e.UserMessages != 2 {
-			t.Errorf("H-5 user_messages: got %d want 2",
-				e.UserMessages)
-		}
+	if e := findHourlyUTC(hours, utcHourBoundary(5)); assert.NotNilf(t, e,
+		"missing hour entry %q", utcHourBoundary(5)) {
+		assert.Equal(t, 2, e.UserMessages, "H-5 user_messages")
 		assert.Equal(t, 1, e.Sessions, "H-5 sessions: got")
 	}
 	// H-4: 1 user message, 1 session.
-	if e := findHourlyUTC(hours, utcHourBoundary(4)); e == nil {
-		t.Errorf("missing hour entry %q", utcHourBoundary(4))
-	} else {
-		if e.UserMessages != 1 {
-			t.Errorf("H-4 user_messages: got %d want 1",
-				e.UserMessages)
-		}
+	if e := findHourlyUTC(hours, utcHourBoundary(4)); assert.NotNilf(t, e,
+		"missing hour entry %q", utcHourBoundary(4)) {
+		assert.Equal(t, 1, e.UserMessages, "H-4 user_messages")
 		assert.Equal(t, 1, e.Sessions, "H-4 sessions: got")
 	}
 	// H-3: 2 user messages from 2 distinct sessions.
-	if e := findHourlyUTC(hours, utcHourBoundary(3)); e == nil {
-		t.Errorf("missing hour entry %q", utcHourBoundary(3))
-	} else {
-		if e.UserMessages != 2 {
-			t.Errorf("H-3 user_messages: got %d want 2",
-				e.UserMessages)
-		}
+	if e := findHourlyUTC(hours, utcHourBoundary(3)); assert.NotNilf(t, e,
+		"missing hour entry %q", utcHourBoundary(3)) {
+		assert.Equal(t, 2, e.UserMessages, "H-3 user_messages")
 		assert.Equal(t, 2, e.Sessions, "H-3 sessions: got")
 	}
 }
@@ -1948,21 +1706,18 @@ func TestGetSessionStats_Temporal_MidnightBoundary(t *testing.T) {
 		Format("2006-01-02T15:00:00Z")
 	afterTS := after.Truncate(time.Hour).
 		Format("2006-01-02T15:00:00Z")
-	if beforeTS == afterTS {
-		t.Fatalf("test setup: before %q and after %q collapsed to "+
+	require.NotEqual(t, afterTS, beforeTS,
+		"test setup: before %q and after %q collapsed to "+
 			"the same hour", beforeTS, afterTS)
+	if e := findHourlyUTC(stats.Temporal.HourlyUTC, beforeTS); assert.NotNilf(t, e,
+		"missing before-midnight hour %q", beforeTS) {
+		assert.Equal(t, 1, e.UserMessages,
+			"before-midnight user_messages")
 	}
-	if e := findHourlyUTC(stats.Temporal.HourlyUTC, beforeTS); e == nil {
-		t.Errorf("missing before-midnight hour %q", beforeTS)
-	} else if e.UserMessages != 1 {
-		t.Errorf("before-midnight user_messages: got %d want 1",
-			e.UserMessages)
-	}
-	if e := findHourlyUTC(stats.Temporal.HourlyUTC, afterTS); e == nil {
-		t.Errorf("missing after-midnight hour %q", afterTS)
-	} else if e.UserMessages != 1 {
-		t.Errorf("after-midnight user_messages: got %d want 1",
-			e.UserMessages)
+	if e := findHourlyUTC(stats.Temporal.HourlyUTC, afterTS); assert.NotNilf(t, e,
+		"missing after-midnight hour %q", afterTS) {
+		assert.Equal(t, 1, e.UserMessages,
+			"after-midnight user_messages")
 	}
 }
 
@@ -1992,15 +1747,10 @@ func TestGetSessionStats_Temporal_OutOfWindowExcluded(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "2d"})
 	require.NoError(t, err, "GetSessionStats")
 	// Exactly one hour bucket, with a single user message (from "in").
-	if len(stats.Temporal.HourlyUTC) != 1 {
-		t.Fatalf("hourly_utc: got %d entries want 1 (%+v)",
-			len(stats.Temporal.HourlyUTC), stats.Temporal.HourlyUTC)
-	}
+	require.Len(t, stats.Temporal.HourlyUTC, 1,
+		"hourly_utc want 1 entry: %+v", stats.Temporal.HourlyUTC)
 	got := stats.Temporal.HourlyUTC[0]
-	if got.UserMessages != 1 {
-		t.Errorf("in-window user_messages: got %d want 1",
-			got.UserMessages)
-	}
+	assert.Equal(t, 1, got.UserMessages, "in-window user_messages")
 	assert.Equal(t, 1, got.Sessions, "in-window sessions: got")
 }
 
@@ -2025,29 +1775,15 @@ func TestGetSessionStats_Temporal_SessionsDistinctPerHour(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 	if e := findHourlyUTC(
 		stats.Temporal.HourlyUTC, utcHourBoundary(6),
-	); e == nil {
-		t.Fatalf("missing H-6 entry")
-	} else {
-		if e.UserMessages != 3 {
-			t.Errorf("H-6 user_messages: got %d want 3",
-				e.UserMessages)
-		}
-		if e.Sessions != 1 {
-			t.Errorf(
-				"H-6 sessions (same session 3 msgs): got %d want 1",
-				e.Sessions,
-			)
-		}
+	); assert.NotNil(t, e, "missing H-6 entry") {
+		assert.Equal(t, 3, e.UserMessages, "H-6 user_messages")
+		assert.Equal(t, 1, e.Sessions,
+			"H-6 sessions (same session 3 msgs)")
 	}
 	if e := findHourlyUTC(
 		stats.Temporal.HourlyUTC, utcHourBoundary(5),
-	); e == nil {
-		t.Fatalf("missing H-5 entry")
-	} else {
-		if e.UserMessages != 1 {
-			t.Errorf("H-5 user_messages: got %d want 1",
-				e.UserMessages)
-		}
+	); assert.NotNil(t, e, "missing H-5 entry") {
+		assert.Equal(t, 1, e.UserMessages, "H-5 user_messages")
 		assert.Equal(t, 1, e.Sessions, "H-5 sessions: got")
 	}
 }
@@ -2058,23 +1794,17 @@ func TestGetSessionStats_Temporal_EmptyWindowEmptySlice(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.Temporal.HourlyUTC == nil {
-		t.Errorf(
-			"hourly_utc must be a non-nil empty slice, got nil",
-		)
-	}
+	assert.NotNil(t, stats.Temporal.HourlyUTC,
+		"hourly_utc must be a non-nil empty slice, got nil")
 	assert.Len(t, stats.Temporal.HourlyUTC, 0, "hourly_utc: got len")
 	// Reporter timezone should still be populated (claim in the spec).
-	if stats.Temporal.ReporterTimezone == "" {
-		t.Errorf("reporter_timezone must be populated even when " +
+	assert.NotEmpty(t, stats.Temporal.ReporterTimezone,
+		"reporter_timezone must be populated even when "+
 			"hourly_utc is empty")
-	}
 	// JSON encoding must emit [] not null.
 	raw, err := json.Marshal(stats.Temporal.HourlyUTC)
 	require.NoError(t, err, "json.Marshal")
-	if string(raw) != "[]" {
-		t.Errorf("hourly_utc JSON: got %s want []", string(raw))
-	}
+	assert.Equal(t, "[]", string(raw), "hourly_utc JSON")
 }
 
 func TestGetSessionStats_Temporal_ReporterTimezone_FilterWins(t *testing.T) {
@@ -2086,10 +1816,8 @@ func TestGetSessionStats_Temporal_ReporterTimezone_FilterWins(t *testing.T) {
 		Timezone: "America/New_York",
 	})
 	require.NoError(t, err, "GetSessionStats")
-	if got := stats.Temporal.ReporterTimezone; got != "America/New_York" {
-		t.Errorf("reporter_timezone: got %q want America/New_York",
-			got)
-	}
+	assert.Equal(t, "America/New_York", stats.Temporal.ReporterTimezone,
+		"reporter_timezone")
 }
 
 func TestReporterTimezone_Precedence(t *testing.T) {
@@ -2105,28 +1833,20 @@ func TestReporterTimezone_Precedence(t *testing.T) {
 	// Filter wins over env.
 	err := os.Setenv("TZ", "Europe/Berlin")
 	require.NoError(t, err, "set TZ")
-	if got := reporterTimezone(
-		StatsFilter{Timezone: "Asia/Tokyo"},
-	); got != "Asia/Tokyo" {
-		t.Errorf("filter wins: got %q want Asia/Tokyo", got)
-	}
+	assert.Equal(t, "Asia/Tokyo",
+		reporterTimezone(StatsFilter{Timezone: "Asia/Tokyo"}),
+		"filter wins")
 
 	// No filter → env wins.
-	if got := reporterTimezone(StatsFilter{}); got != "Europe/Berlin" {
-		t.Errorf("env wins: got %q want Europe/Berlin", got)
-	}
+	assert.Equal(t, "Europe/Berlin",
+		reporterTimezone(StatsFilter{}), "env wins")
 
 	// No filter, no env → time.Local fallback.
 	err = os.Unsetenv("TZ")
 	require.NoError(t, err, "unset TZ")
 	got := reporterTimezone(StatsFilter{})
-	if got == "" {
-		t.Errorf("time.Local fallback: got empty string")
-	}
-	if got != time.Local.String() {
-		t.Errorf("time.Local fallback: got %q want %q",
-			got, time.Local.String())
-	}
+	assert.NotEmpty(t, got, "time.Local fallback: got empty string")
+	assert.Equal(t, time.Local.String(), got, "time.Local fallback")
 }
 
 func TestGetSessionStats_Temporal_FilterByAgentFlowsThrough(t *testing.T) {
@@ -2154,19 +1874,10 @@ func TestGetSessionStats_Temporal_FilterByAgentFlowsThrough(t *testing.T) {
 	require.NoError(t, err, "GetSessionStats")
 	if e := findHourlyUTC(
 		stats.Temporal.HourlyUTC, utcHourBoundary(3),
-	); e == nil {
-		t.Fatalf("missing H-3 entry")
-	} else {
-		if e.UserMessages != 1 {
-			t.Errorf(
-				"filter=claude user_messages: got %d want 1",
-				e.UserMessages,
-			)
-		}
-		if e.Sessions != 1 {
-			t.Errorf("filter=claude sessions: got %d want 1",
-				e.Sessions)
-		}
+	); assert.NotNil(t, e, "missing H-3 entry") {
+		assert.Equal(t, 1, e.UserMessages,
+			"filter=claude user_messages")
+		assert.Equal(t, 1, e.Sessions, "filter=claude sessions")
 	}
 }
 
@@ -2186,13 +1897,8 @@ func TestGetSessionStats_Temporal_IgnoresAssistantMessages(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if len(stats.Temporal.HourlyUTC) != 0 {
-		t.Errorf(
-			"hourly_utc should be empty when only assistant msgs, "+
-				"got %+v",
-			stats.Temporal.HourlyUTC,
-		)
-	}
+	assert.Empty(t, stats.Temporal.HourlyUTC,
+		"hourly_utc should be empty when only assistant msgs")
 }
 
 func TestGetSessionStats_Temporal_SkipsEmptyTimestamps(t *testing.T) {
@@ -2212,16 +1918,10 @@ func TestGetSessionStats_Temporal_SkipsEmptyTimestamps(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if len(stats.Temporal.HourlyUTC) != 1 {
-		t.Fatalf(
-			"hourly_utc: got %d entries want 1 (%+v)",
-			len(stats.Temporal.HourlyUTC), stats.Temporal.HourlyUTC,
-		)
-	}
-	if got := stats.Temporal.HourlyUTC[0]; got.UserMessages != 1 {
-		t.Errorf("user_messages: got %d want 1 (blank skipped)",
-			got.UserMessages)
-	}
+	require.Len(t, stats.Temporal.HourlyUTC, 1,
+		"hourly_utc want 1 entry: %+v", stats.Temporal.HourlyUTC)
+	assert.Equal(t, 1, stats.Temporal.HourlyUTC[0].UserMessages,
+		"user_messages want 1 (blank skipped)")
 }
 
 // TestGetSessionStats_Outcomes_Happy seeds five Claude sessions spanning
@@ -2305,50 +2005,34 @@ func TestGetSessionStats_Outcomes_Happy(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
 	out := stats.Outcomes
-	if out == nil {
-		t.Fatalf("Outcomes: got nil want populated")
-	}
-	if !out.ClaudeOnly {
-		t.Errorf("ClaudeOnly: got false want true")
-	}
+	require.NotNil(t, out, "Outcomes: want populated")
+	assert.True(t, out.ClaudeOnly, "ClaudeOnly")
 	// Two "completed" -> Success.
 	assert.Equal(t, 2, out.Success, "Success: got")
 	// One "abandoned" + one "errored" -> Failure.
 	assert.Equal(t, 2, out.Failure, "Failure: got")
 	// One explicit "unknown" -> Unknown.
 	assert.Equal(t, 1, out.Unknown, "Unknown: got")
-	if out.GradeDistribution == nil {
-		t.Fatalf("GradeDistribution: got nil want non-nil")
-	}
+	require.NotNil(t, out.GradeDistribution,
+		"GradeDistribution: want non-nil")
 	wantGrades := map[string]int{"A": 1, "B": 1, "C": 1, "D": 1}
-	if len(out.GradeDistribution) != len(wantGrades) {
-		t.Errorf("GradeDistribution size: got %d want %d (%+v)",
-			len(out.GradeDistribution), len(wantGrades),
-			out.GradeDistribution)
-	}
+	assert.Len(t, out.GradeDistribution, len(wantGrades),
+		"GradeDistribution size (%+v)", out.GradeDistribution)
 	for grade, want := range wantGrades {
-		if got := out.GradeDistribution[grade]; got != want {
-			t.Errorf("GradeDistribution[%q]: got %d want %d",
-				grade, got, want)
-		}
+		assert.Equal(t, want, out.GradeDistribution[grade],
+			"GradeDistribution[%q]", grade)
 	}
-	if _, hasEmpty := out.GradeDistribution[""]; hasEmpty {
-		t.Errorf("GradeDistribution: empty-string key present (%+v)",
-			out.GradeDistribution)
-	}
+	assert.NotContains(t, out.GradeDistribution, "",
+		"GradeDistribution: empty-string key present (%+v)",
+		out.GradeDistribution)
 	// ToolRetryRate = (1+0+3+2+1) / (2+4+6+8+5) = 7/25 = 0.28
-	if !floatsClose(out.ToolRetryRate, 0.28, 1e-9) {
-		t.Errorf("ToolRetryRate: got %v want 0.28", out.ToolRetryRate)
-	}
+	assert.InDelta(t, 0.28, out.ToolRetryRate, 1e-9,
+		"ToolRetryRate")
 	// CompactionsPerSession = (3+1+0+2+4) / 5 = 10/5 = 2.0
-	if !floatsClose(out.CompactionsPerSession, 2.0, 1e-9) {
-		t.Errorf("CompactionsPerSession: got %v want 2.0",
-			out.CompactionsPerSession)
-	}
+	assert.InDelta(t, 2.0, out.CompactionsPerSession, 1e-9,
+		"CompactionsPerSession")
 	// AvgEditChurn = (5+0+4+6+0) / 5 = 15/5 = 3.0
-	if !floatsClose(out.AvgEditChurn, 3.0, 1e-9) {
-		t.Errorf("AvgEditChurn: got %v want 3.0", out.AvgEditChurn)
-	}
+	assert.InDelta(t, 3.0, out.AvgEditChurn, 1e-9, "AvgEditChurn")
 }
 
 // TestGetSessionStats_Outcomes_NoClaude verifies that Outcomes stays
@@ -2370,9 +2054,7 @@ func TestGetSessionStats_Outcomes_NoClaude(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.Outcomes != nil {
-		t.Errorf("Outcomes: got %+v want nil", stats.Outcomes)
-	}
+	assert.Nil(t, stats.Outcomes, "Outcomes")
 }
 
 // TestGetSessionStats_Outcomes_NoGrade verifies that a Claude session
@@ -2394,20 +2076,12 @@ func TestGetSessionStats_Outcomes_NoGrade(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
 	out := stats.Outcomes
-	if out == nil {
-		t.Fatalf("Outcomes: got nil want populated")
-	}
-	if out.GradeDistribution == nil {
-		t.Errorf("GradeDistribution: got nil want empty map")
-	}
-	if len(out.GradeDistribution) != 0 {
-		t.Errorf("GradeDistribution: got %+v want empty",
-			out.GradeDistribution)
-	}
-	if out.ToolRetryRate != 0 {
-		t.Errorf("ToolRetryRate: got %v want 0 (no tools)",
-			out.ToolRetryRate)
-	}
+	require.NotNil(t, out, "Outcomes: want populated")
+	assert.NotNil(t, out.GradeDistribution,
+		"GradeDistribution: want empty map")
+	assert.Empty(t, out.GradeDistribution, "GradeDistribution")
+	assert.Equal(t, 0.0, out.ToolRetryRate,
+		"ToolRetryRate want 0 (no tools)")
 	assert.Equal(t, 1, out.Success, "Success: got")
 }
 
@@ -2426,27 +2100,24 @@ func seedToolCallsByName(
 	for i, c := range calls {
 		msgs = append(msgs, asstMsg(sessionID, i+1, "reply-"+c.toolName))
 	}
-	if err := d.InsertMessages(msgs); err != nil {
-		t.Fatalf("seedToolCallsByName %s: InsertMessages: %v",
-			sessionID, err)
-	}
+	require.NoError(t, d.InsertMessages(msgs),
+		"seedToolCallsByName %s: InsertMessages", sessionID)
 	for i, c := range calls {
 		ord := i + 1
 		var skill any
 		if c.skillName != "" {
 			skill = c.skillName
 		}
-		if _, err := d.getWriter().Exec(`
+		_, err := d.getWriter().Exec(`
 			INSERT INTO tool_calls
 				(message_id, session_id, tool_name, category, skill_name)
 			SELECT id, session_id, ?, ?, ?
 			FROM messages
 			WHERE session_id = ? AND ordinal = ?`,
 			c.toolName, c.toolName, skill, sessionID, ord,
-		); err != nil {
-			t.Fatalf("seedToolCallsByName %s: %q: %v",
-				sessionID, c.toolName, err)
-		}
+		)
+		require.NoError(t, err,
+			"seedToolCallsByName %s: %q", sessionID, c.toolName)
 	}
 }
 
@@ -2528,24 +2199,17 @@ func TestGetSessionStats_Adoption_Happy(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
 	ad := stats.Adoption
-	if ad == nil {
-		t.Fatalf("Adoption: got nil want populated")
-	}
-	if !ad.ClaudeOnly {
-		t.Errorf("ClaudeOnly: got false want true")
-	}
+	require.NotNil(t, ad, "Adoption: want populated")
+	assert.True(t, ad.ClaudeOnly, "ClaudeOnly")
 	// 2 of 4 Claude sessions have ExitPlanMode -> 0.5.
-	if !floatsClose(ad.PlanModeRate, 0.5, 1e-9) {
-		t.Errorf("PlanModeRate: got %v want 0.5", ad.PlanModeRate)
-	}
-	if ad.PlanModeRate < 0 || ad.PlanModeRate > 1 {
-		t.Errorf("PlanModeRate out of [0,1]: got %v", ad.PlanModeRate)
-	}
+	assert.InDelta(t, 0.5, ad.PlanModeRate, 1e-9, "PlanModeRate")
+	assert.GreaterOrEqual(t, ad.PlanModeRate, 0.0,
+		"PlanModeRate out of [0,1]")
+	assert.LessOrEqual(t, ad.PlanModeRate, 1.0,
+		"PlanModeRate out of [0,1]")
 	// 3 Task calls across 4 Claude sessions -> 0.75.
-	if !floatsClose(ad.SubagentsPerSession, 0.75, 1e-9) {
-		t.Errorf("SubagentsPerSession: got %v want 0.75",
-			ad.SubagentsPerSession)
-	}
+	assert.InDelta(t, 0.75, ad.SubagentsPerSession, 1e-9,
+		"SubagentsPerSession")
 	// {"brainstorm","writing-plans","brainstorm"} -> 2 distinct.
 	assert.Equal(t, 2, ad.DistinctSkills, "DistinctSkills: got")
 }
@@ -2570,9 +2234,7 @@ func TestGetSessionStats_Adoption_NoClaude(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.Adoption != nil {
-		t.Errorf("Adoption: got %+v want nil", stats.Adoption)
-	}
+	assert.Nil(t, stats.Adoption, "Adoption")
 }
 
 // skipIfNoGit lets CI environments without git on PATH pass cleanly
@@ -2596,10 +2258,8 @@ func statsRunGit(t *testing.T, repo string, env []string, args ...string) {
 	cmd.Dir = repo
 	cmd.Env = append(os.Environ(), env...)
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %s: %v\n%s",
-			strings.Join(args, " "), err, out)
-	}
+	require.NoError(t, err, "git %s\n%s",
+		strings.Join(args, " "), out)
 }
 
 // statsInitRepo creates a fresh git repo under t.TempDir() with a
@@ -2624,12 +2284,10 @@ func statsCommitFile(
 ) {
 	t.Helper()
 	p := filepath.Join(repo, relpath)
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
-	}
-	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
-		t.Fatalf("write %s: %v", p, err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755),
+		"mkdir %s", filepath.Dir(p))
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o644),
+		"write %s", p)
 	env := []string{
 		"GIT_AUTHOR_NAME=Test User",
 		"GIT_AUTHOR_EMAIL=test@example.com",
@@ -2657,9 +2315,7 @@ func TestGetSessionStats_OutcomeStats_DefaultDisabled(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.OutcomeStats != nil {
-		t.Fatalf("OutcomeStats: got %+v want nil", stats.OutcomeStats)
-	}
+	require.Nil(t, stats.OutcomeStats, "OutcomeStats")
 }
 
 // TestGetSessionStats_OutcomeStats_Happy seeds sessions whose cwd
@@ -2702,23 +2358,15 @@ func TestGetSessionStats_OutcomeStats_Happy(t *testing.T) {
 	})
 	require.NoError(t, err, "GetSessionStats")
 	out := stats.OutcomeStats
-	if out == nil {
-		t.Fatalf("OutcomeStats: got nil want populated")
-	}
+	require.NotNil(t, out, "OutcomeStats: want populated")
 	assert.Equal(t, 1, out.ReposActive, "ReposActive: got")
 	assert.Equal(t, 3, out.Commits, "Commits: got")
 	assert.Equal(t, 9, out.LOCAdded, "LOCAdded: got")
 	assert.Equal(t, 0, out.LOCRemoved, "LOCRemoved: got")
 	// Each commit touches one file: c1 a.txt, c2 a.txt, c3 b.txt -> 3.
 	assert.Equal(t, 3, out.FilesChanged, "FilesChanged: got")
-	if out.PRsOpened != nil {
-		t.Errorf("PRsOpened: got %v want nil (no GHToken)",
-			*out.PRsOpened)
-	}
-	if out.PRsMerged != nil {
-		t.Errorf("PRsMerged: got %v want nil (no GHToken)",
-			*out.PRsMerged)
-	}
+	assert.Nil(t, out.PRsOpened, "PRsOpened want nil (no GHToken)")
+	assert.Nil(t, out.PRsMerged, "PRsMerged want nil (no GHToken)")
 }
 
 // TestGetSessionStats_OutcomeStats_NoCwd verifies that sessions without
@@ -2738,10 +2386,7 @@ func TestGetSessionStats_OutcomeStats_NoCwd(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.OutcomeStats != nil {
-		t.Errorf("OutcomeStats: got %+v want nil",
-			stats.OutcomeStats)
-	}
+	assert.Nil(t, stats.OutcomeStats, "OutcomeStats")
 }
 
 // TestGetSessionStats_OutcomeStats_CwdOutsideRepo verifies that a cwd
@@ -2763,8 +2408,5 @@ func TestGetSessionStats_OutcomeStats_CwdOutsideRepo(t *testing.T) {
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
 	require.NoError(t, err, "GetSessionStats")
-	if stats.OutcomeStats != nil {
-		t.Errorf("OutcomeStats: got %+v want nil",
-			stats.OutcomeStats)
-	}
+	assert.Nil(t, stats.OutcomeStats, "OutcomeStats")
 }

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // itoa is a thin alias for strconv.Itoa kept short so seedModelMessages'
@@ -78,12 +81,8 @@ func Test_insertSessionFixture_isAutomated_patch(t *testing.T) {
 	).Scan(&humanFlag); err != nil {
 		t.Fatalf("read human-1: %v", err)
 	}
-	if autoFlag != 1 {
-		t.Fatalf("auto-1 is_automated = %d, want 1", autoFlag)
-	}
-	if humanFlag != 0 {
-		t.Fatalf("human-1 is_automated = %d, want 0", humanFlag)
-	}
+	require.Equal(t, 1, autoFlag, "auto-1 is_automated")
+	require.Equal(t, 0, humanFlag, "human-1 is_automated")
 }
 
 func Test_loadSessionsInWindow_isAutomated(t *testing.T) {
@@ -101,19 +100,13 @@ func Test_loadSessionsInWindow_isAutomated(t *testing.T) {
 	from := time.Now().Add(-24 * time.Hour)
 	to := time.Now().Add(1 * time.Hour)
 	rows, err := d.loadSessionsInWindow(ctx, StatsFilter{}, from, to)
-	if err != nil {
-		t.Fatalf("loadSessionsInWindow: %v", err)
-	}
+	require.NoError(t, err, "loadSessionsInWindow")
 	byID := map[string]bool{}
 	for _, r := range rows {
 		byID[r.id] = r.isAutomated
 	}
-	if got, want := byID["auto"], true; got != want {
-		t.Fatalf("auto.isAutomated = %v, want %v", got, want)
-	}
-	if got, want := byID["human"], false; got != want {
-		t.Fatalf("human.isAutomated = %v, want %v", got, want)
-	}
+	require.Equal(t, true, byID["auto"], "auto.isAutomated")
+	require.Equal(t, false, byID["human"], "human.isAutomated")
 }
 
 // insertSessionFixture inserts a sessionFixture via the standard
@@ -400,13 +393,9 @@ func TestGetSessionStats_TotalsAndArchetypes(t *testing.T) {
 	}
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
-	if stats.SchemaVersion != 1 {
-		t.Errorf("schema_version: got %d want 1", stats.SchemaVersion)
-	}
+	assert.Equal(t, 1, stats.SchemaVersion, "schema_version: got")
 	if stats.Totals.SessionsAll != 5 {
 		t.Errorf("sessions_all: got %d want 5",
 			stats.Totals.SessionsAll)
@@ -465,9 +454,7 @@ func TestGetSessionStats_TotalsAndArchetypes(t *testing.T) {
 	}
 
 	// Window bookkeeping: Since = now-28d, Until = now, days = 28.
-	if stats.Window.Days != 28 {
-		t.Errorf("window.days: got %d want 28", stats.Window.Days)
-	}
+	assert.Equal(t, 28, stats.Window.Days, "window.days: got")
 	if stats.Window.Since == "" || stats.Window.Until == "" {
 		t.Errorf("window bounds empty: since=%q until=%q",
 			stats.Window.Since, stats.Window.Until)
@@ -515,23 +502,11 @@ func Test_computeTotalsAndArchetypes_flagAuthority(t *testing.T) {
 	})
 
 	got, err := d.GetSessionStats(t.Context(), StatsFilter{Since: "1d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
-	if got.Totals.SessionsHuman != 1 {
-		t.Fatalf("SessionsHuman = %d, want 1", got.Totals.SessionsHuman)
-	}
-	if got.Totals.SessionsAutomation != 1 {
-		t.Fatalf("SessionsAutomation = %d, want 1",
-			got.Totals.SessionsAutomation)
-	}
-	if got.Archetypes.Quick != 1 {
-		t.Fatalf("Archetypes.Quick = %d, want 1 (short non-automated)",
-			got.Archetypes.Quick)
-	}
-	if got.Archetypes.Automation != 1 {
-		t.Fatalf("Archetypes.Automation = %d, want 1", got.Archetypes.Automation)
-	}
+	require.NoError(t, err, "GetSessionStats")
+	require.Equal(t, 1, got.Totals.SessionsHuman, "SessionsHuman")
+	require.Equal(t, 1, got.Totals.SessionsAutomation, "SessionsAutomation")
+	require.Equal(t, 1, got.Archetypes.Quick, "Archetypes.Quick")
+	require.Equal(t, 1, got.Archetypes.Automation, "Archetypes.Automation")
 }
 
 func TestGetSessionStats_FilterByAgent(t *testing.T) {
@@ -548,9 +523,7 @@ func TestGetSessionStats_FilterByAgent(t *testing.T) {
 	})
 
 	all, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats all: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats all")
 	if all.Totals.SessionsAll != 2 {
 		t.Errorf("all agents: got %d want 2",
 			all.Totals.SessionsAll)
@@ -559,9 +532,7 @@ func TestGetSessionStats_FilterByAgent(t *testing.T) {
 	onlyClaude, err := d.GetSessionStats(
 		ctx, StatsFilter{Since: "28d", Agent: "claude"},
 	)
-	if err != nil {
-		t.Fatalf("GetSessionStats claude: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats claude")
 	if onlyClaude.Totals.SessionsAll != 1 {
 		t.Errorf("agent=claude: got %d want 1",
 			onlyClaude.Totals.SessionsAll)
@@ -589,9 +560,7 @@ func TestGetSessionStats_FilterByProject(t *testing.T) {
 		Since:           "28d",
 		IncludeProjects: []string{"alpha"},
 	})
-	if err != nil {
-		t.Fatalf("include alpha: %v", err)
-	}
+	require.NoError(t, err, "include alpha")
 	if includeAlpha.Totals.SessionsAll != 2 {
 		t.Errorf("include=alpha: got %d want 2",
 			includeAlpha.Totals.SessionsAll)
@@ -601,9 +570,7 @@ func TestGetSessionStats_FilterByProject(t *testing.T) {
 		Since:           "28d",
 		ExcludeProjects: []string{"alpha"},
 	})
-	if err != nil {
-		t.Fatalf("exclude alpha: %v", err)
-	}
+	require.NoError(t, err, "exclude alpha")
 	if excludeAlpha.Totals.SessionsAll != 2 {
 		t.Errorf("exclude=alpha: got %d want 2 (beta + gamma)",
 			excludeAlpha.Totals.SessionsAll)
@@ -616,12 +583,8 @@ func TestWindowBounds(t *testing.T) {
 
 	t.Run("default 28d", func(t *testing.T) {
 		from, to, days, err := windowBounds(StatsFilter{}, now)
-		if err != nil {
-			t.Fatalf("windowBounds: %v", err)
-		}
-		if days != 28 {
-			t.Errorf("days: got %d want 28", days)
-		}
+		require.NoError(t, err, "windowBounds")
+		assert.Equal(t, 28, days, "days: got")
 		if !to.Equal(now) {
 			t.Errorf("until: got %v want %v", to, now)
 		}
@@ -635,21 +598,15 @@ func TestWindowBounds(t *testing.T) {
 		_, _, days, err := windowBounds(
 			StatsFilter{Since: "7d"}, now,
 		)
-		if err != nil {
-			t.Fatalf("windowBounds: %v", err)
-		}
-		if days != 7 {
-			t.Errorf("days: got %d want 7", days)
-		}
+		require.NoError(t, err, "windowBounds")
+		assert.Equal(t, 7, days, "days: got")
 	})
 
 	t.Run("Nh duration", func(t *testing.T) {
 		from, to, _, err := windowBounds(
 			StatsFilter{Since: "48h"}, now,
 		)
-		if err != nil {
-			t.Fatalf("windowBounds: %v", err)
-		}
+		require.NoError(t, err, "windowBounds")
 		if got := to.Sub(from); got != 48*time.Hour {
 			t.Errorf("span: got %v want 48h", got)
 		}
@@ -659,9 +616,7 @@ func TestWindowBounds(t *testing.T) {
 		from, _, _, err := windowBounds(
 			StatsFilter{Since: "2026-04-01"}, now,
 		)
-		if err != nil {
-			t.Fatalf("windowBounds: %v", err)
-		}
+		require.NoError(t, err, "windowBounds")
 		if from.Year() != 2026 || from.Month() != 4 || from.Day() != 1 {
 			t.Errorf("since parsed: got %v want 2026-04-01", from)
 		}
@@ -714,9 +669,7 @@ func TestGetSessionStats_Distributions(t *testing.T) {
 	}
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	// duration scope_all: 0.5→bucket0, 0.9→bucket0, 10→bucket2,
 	// 25→bucket3, 120→bucket5 (top).
@@ -843,9 +796,7 @@ func Test_computeDistributions_scopeHuman_flag(t *testing.T) {
 	})
 
 	got, err := d.GetSessionStats(t.Context(), StatsFilter{Since: "1d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	// scope_all has both rows — mean ~= 16.5.
 	allMean := got.Distributions.DurationMinutes.ScopeAll.Mean
 	if allMean < 15 || allMean > 18 {
@@ -867,10 +818,7 @@ func Test_computeDistributions_scopeHuman_flag(t *testing.T) {
 	for _, bucket := range humanUserMessages.Buckets {
 		bucketedHumanMessages += bucket.Count
 	}
-	if bucketedHumanMessages != 0 {
-		t.Fatalf("scope_human user_messages bucket total = %d, want 0 (<2 filtered)",
-			bucketedHumanMessages)
-	}
+	require.Equal(t, 0, bucketedHumanMessages, "scope_human user_messages bucket total")
 }
 
 func TestGetSessionStats_Distributions_NullPeakContext(t *testing.T) {
@@ -904,9 +852,7 @@ func TestGetSessionStats_Distributions_NullPeakContext(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	pc := stats.Distributions.PeakContextTokens
 	if pc.NullCount != 1 {
@@ -997,9 +943,7 @@ func TestGetSessionStats_Velocity(t *testing.T) {
 		[]int{0, 30, 60, 80})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	// Turn cycle seconds, sorted = [5,10,15,20,30].
 	// percentileFloat: P50 idx=int(5*0.5)=2 → 15, P90 idx=4 → 30.
@@ -1046,9 +990,7 @@ func TestGetSessionStats_Velocity_Empty(t *testing.T) {
 	ctx := context.Background()
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	tc := stats.Velocity.TurnCycleSeconds
 	if tc.P50 != 0 || tc.P90 != 0 || tc.Mean != 0 {
@@ -1083,9 +1025,7 @@ func TestGetSessionStats_Velocity_SingleTurn(t *testing.T) {
 	seedVelocityMessages(t, d, "s1", start, []int{0, 60})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	tc := stats.Velocity.TurnCycleSeconds
 	if tc.P50 != 60.0 || tc.P90 != 60.0 {
@@ -1133,9 +1073,7 @@ func TestGetSessionStats_Velocity_ZeroActive(t *testing.T) {
 	seedVelocityMessages(t, d, "z1", start, []int{0, 0})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	if stats.Velocity.MessagesPerActiveHour != 0 {
 		t.Errorf("MessagesPerActiveHour: got %v want 0",
@@ -1189,9 +1127,7 @@ func TestGetSessionStats_ToolMixAndModelMix(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	wantCats := map[string]int{
 		"Bash": 3,
@@ -1285,9 +1221,7 @@ func TestGetSessionStats_ToolMixAndModelMix_Filters(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{
 		Since: "28d", Agent: "claude",
 	})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	// Only in1's 2 tool_calls survive.
 	if stats.ToolMix.TotalCalls != 2 {
@@ -1326,9 +1260,7 @@ func TestGetSessionStats_ToolMixAndModelMix_Empty(t *testing.T) {
 	ctx := context.Background()
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.ToolMix.ByCategory == nil {
 		t.Errorf("ToolMix.ByCategory: got nil want non-nil map")
 	}
@@ -1392,9 +1324,7 @@ func TestGetSessionStats_AgentPortfolio(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	ap := stats.AgentPortfolio
 	wantSessions := map[string]int{"claude": 3, "codex": 2, "cursor": 1}
@@ -1458,9 +1388,7 @@ func TestGetSessionStats_AgentPortfolio_TieBreak(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.AgentPortfolio.BySessions["claude"] != 2 ||
 		stats.AgentPortfolio.BySessions["codex"] != 2 {
 		t.Fatalf("precondition: claude/codex must tie at 2 (got %v)",
@@ -1480,9 +1408,7 @@ func TestGetSessionStats_AgentPortfolio_Empty(t *testing.T) {
 	ctx := context.Background()
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	ap := stats.AgentPortfolio
 	if ap.BySessions == nil {
 		t.Errorf("BySessions: got nil want non-nil map")
@@ -1537,9 +1463,7 @@ func Test_computeAgentPortfolio_humanScoped(t *testing.T) {
 	})
 
 	got, err := d.GetSessionStats(t.Context(), StatsFilter{Since: "1d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	ap := got.AgentPortfolio
 
 	// All-sessions view: every agent present.
@@ -1549,9 +1473,7 @@ func Test_computeAgentPortfolio_humanScoped(t *testing.T) {
 			ap.BySessions)
 	}
 	// primary ties on count; lexicographic min wins → claude.
-	if ap.Primary != "claude" {
-		t.Fatalf("Primary = %q, want claude", ap.Primary)
-	}
+	require.Equal(t, "claude", ap.Primary, "Primary")
 
 	// Human-scoped view: only claude.
 	if _, ok := ap.BySessionsHuman["codex"]; ok {
@@ -1562,17 +1484,9 @@ func Test_computeAgentPortfolio_humanScoped(t *testing.T) {
 		t.Fatalf("BySessionsHuman must exclude gemini: %v",
 			ap.BySessionsHuman)
 	}
-	if ap.BySessionsHuman["claude"] != 1 {
-		t.Fatalf("BySessionsHuman[claude] = %d, want 1",
-			ap.BySessionsHuman["claude"])
-	}
-	if ap.ByTokensHuman["claude"] != 100 {
-		t.Fatalf("ByTokensHuman[claude] = %d, want 100",
-			ap.ByTokensHuman["claude"])
-	}
-	if ap.PrimaryHuman != "claude" {
-		t.Fatalf("PrimaryHuman = %q, want claude", ap.PrimaryHuman)
-	}
+	require.Equal(t, 1, ap.BySessionsHuman["claude"], "BySessionsHuman[claude]")
+	require.Equal(t, int64(100), ap.ByTokensHuman["claude"], "ByTokensHuman[claude]")
+	require.Equal(t, "claude", ap.PrimaryHuman, "PrimaryHuman")
 }
 
 // cacheTokenBreakdown names the four token dimensions the cache
@@ -1689,9 +1603,7 @@ func TestGetSessionStats_CacheEconomics(t *testing.T) {
 		})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 
 	ce := stats.CacheEconomics
 	if ce == nil {
@@ -1781,9 +1693,7 @@ func TestGetSessionStats_CacheEconomics_NoClaude(t *testing.T) {
 		cacheTokenBreakdown{input: 1000, output: 500})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.CacheEconomics != nil {
 		t.Errorf("CacheEconomics: got %+v want nil",
 			stats.CacheEconomics)
@@ -1827,9 +1737,7 @@ func TestGetSessionStats_CacheEconomics_ZeroDenominatorSkipped(t *testing.T) {
 		cacheTokenBreakdown{input: 0, output: 10, cacheRead: 0})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	ce := stats.CacheEconomics
 	if ce == nil {
 		t.Fatalf("CacheEconomics: got nil want populated")
@@ -1966,9 +1874,7 @@ func TestGetSessionStats_Temporal_HourlyGrouping(t *testing.T) {
 	)
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	hours := stats.Temporal.HourlyUTC
 	if len(hours) != 3 {
 		t.Fatalf("hourly_utc: got %d entries want 3 (%+v)",
@@ -1991,9 +1897,7 @@ func TestGetSessionStats_Temporal_HourlyGrouping(t *testing.T) {
 			t.Errorf("H-5 user_messages: got %d want 2",
 				e.UserMessages)
 		}
-		if e.Sessions != 1 {
-			t.Errorf("H-5 sessions: got %d want 1", e.Sessions)
-		}
+		assert.Equal(t, 1, e.Sessions, "H-5 sessions: got")
 	}
 	// H-4: 1 user message, 1 session.
 	if e := findHourlyUTC(hours, utcHourBoundary(4)); e == nil {
@@ -2003,9 +1907,7 @@ func TestGetSessionStats_Temporal_HourlyGrouping(t *testing.T) {
 			t.Errorf("H-4 user_messages: got %d want 1",
 				e.UserMessages)
 		}
-		if e.Sessions != 1 {
-			t.Errorf("H-4 sessions: got %d want 1", e.Sessions)
-		}
+		assert.Equal(t, 1, e.Sessions, "H-4 sessions: got")
 	}
 	// H-3: 2 user messages from 2 distinct sessions.
 	if e := findHourlyUTC(hours, utcHourBoundary(3)); e == nil {
@@ -2015,9 +1917,7 @@ func TestGetSessionStats_Temporal_HourlyGrouping(t *testing.T) {
 			t.Errorf("H-3 user_messages: got %d want 2",
 				e.UserMessages)
 		}
-		if e.Sessions != 2 {
-			t.Errorf("H-3 sessions: got %d want 2", e.Sessions)
-		}
+		assert.Equal(t, 2, e.Sessions, "H-3 sessions: got")
 	}
 }
 
@@ -2043,9 +1943,7 @@ func TestGetSessionStats_Temporal_MidnightBoundary(t *testing.T) {
 	)
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	beforeTS := before.Truncate(time.Hour).
 		Format("2006-01-02T15:00:00Z")
 	afterTS := after.Truncate(time.Hour).
@@ -2092,9 +1990,7 @@ func TestGetSessionStats_Temporal_OutOfWindowExcluded(t *testing.T) {
 	)
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "2d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	// Exactly one hour bucket, with a single user message (from "in").
 	if len(stats.Temporal.HourlyUTC) != 1 {
 		t.Fatalf("hourly_utc: got %d entries want 1 (%+v)",
@@ -2105,9 +2001,7 @@ func TestGetSessionStats_Temporal_OutOfWindowExcluded(t *testing.T) {
 		t.Errorf("in-window user_messages: got %d want 1",
 			got.UserMessages)
 	}
-	if got.Sessions != 1 {
-		t.Errorf("in-window sessions: got %d want 1", got.Sessions)
-	}
+	assert.Equal(t, 1, got.Sessions, "in-window sessions: got")
 }
 
 func TestGetSessionStats_Temporal_SessionsDistinctPerHour(t *testing.T) {
@@ -2128,9 +2022,7 @@ func TestGetSessionStats_Temporal_SessionsDistinctPerHour(t *testing.T) {
 	)
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if e := findHourlyUTC(
 		stats.Temporal.HourlyUTC, utcHourBoundary(6),
 	); e == nil {
@@ -2156,9 +2048,7 @@ func TestGetSessionStats_Temporal_SessionsDistinctPerHour(t *testing.T) {
 			t.Errorf("H-5 user_messages: got %d want 1",
 				e.UserMessages)
 		}
-		if e.Sessions != 1 {
-			t.Errorf("H-5 sessions: got %d want 1", e.Sessions)
-		}
+		assert.Equal(t, 1, e.Sessions, "H-5 sessions: got")
 	}
 }
 
@@ -2167,18 +2057,13 @@ func TestGetSessionStats_Temporal_EmptyWindowEmptySlice(t *testing.T) {
 	ctx := context.Background()
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.Temporal.HourlyUTC == nil {
 		t.Errorf(
 			"hourly_utc must be a non-nil empty slice, got nil",
 		)
 	}
-	if len(stats.Temporal.HourlyUTC) != 0 {
-		t.Errorf("hourly_utc: got len %d want 0",
-			len(stats.Temporal.HourlyUTC))
-	}
+	assert.Len(t, stats.Temporal.HourlyUTC, 0, "hourly_utc: got len")
 	// Reporter timezone should still be populated (claim in the spec).
 	if stats.Temporal.ReporterTimezone == "" {
 		t.Errorf("reporter_timezone must be populated even when " +
@@ -2186,9 +2071,7 @@ func TestGetSessionStats_Temporal_EmptyWindowEmptySlice(t *testing.T) {
 	}
 	// JSON encoding must emit [] not null.
 	raw, err := json.Marshal(stats.Temporal.HourlyUTC)
-	if err != nil {
-		t.Fatalf("json.Marshal: %v", err)
-	}
+	require.NoError(t, err, "json.Marshal")
 	if string(raw) != "[]" {
 		t.Errorf("hourly_utc JSON: got %s want []", string(raw))
 	}
@@ -2202,9 +2085,7 @@ func TestGetSessionStats_Temporal_ReporterTimezone_FilterWins(t *testing.T) {
 		Since:    "28d",
 		Timezone: "America/New_York",
 	})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if got := stats.Temporal.ReporterTimezone; got != "America/New_York" {
 		t.Errorf("reporter_timezone: got %q want America/New_York",
 			got)
@@ -2222,9 +2103,8 @@ func TestReporterTimezone_Precedence(t *testing.T) {
 	})
 
 	// Filter wins over env.
-	if err := os.Setenv("TZ", "Europe/Berlin"); err != nil {
-		t.Fatalf("set TZ: %v", err)
-	}
+	err := os.Setenv("TZ", "Europe/Berlin")
+	require.NoError(t, err, "set TZ")
 	if got := reporterTimezone(
 		StatsFilter{Timezone: "Asia/Tokyo"},
 	); got != "Asia/Tokyo" {
@@ -2237,9 +2117,8 @@ func TestReporterTimezone_Precedence(t *testing.T) {
 	}
 
 	// No filter, no env → time.Local fallback.
-	if err := os.Unsetenv("TZ"); err != nil {
-		t.Fatalf("unset TZ: %v", err)
-	}
+	err = os.Unsetenv("TZ")
+	require.NoError(t, err, "unset TZ")
 	got := reporterTimezone(StatsFilter{})
 	if got == "" {
 		t.Errorf("time.Local fallback: got empty string")
@@ -2272,9 +2151,7 @@ func TestGetSessionStats_Temporal_FilterByAgentFlowsThrough(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{
 		Since: "28d", Agent: "claude",
 	})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if e := findHourlyUTC(
 		stats.Temporal.HourlyUTC, utcHourBoundary(3),
 	); e == nil {
@@ -2308,9 +2185,7 @@ func TestGetSessionStats_Temporal_IgnoresAssistantMessages(t *testing.T) {
 	)
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if len(stats.Temporal.HourlyUTC) != 0 {
 		t.Errorf(
 			"hourly_utc should be empty when only assistant msgs, "+
@@ -2336,9 +2211,7 @@ func TestGetSessionStats_Temporal_SkipsEmptyTimestamps(t *testing.T) {
 	)
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if len(stats.Temporal.HourlyUTC) != 1 {
 		t.Fatalf(
 			"hourly_utc: got %d entries want 1 (%+v)",
@@ -2430,9 +2303,7 @@ func TestGetSessionStats_Outcomes_Happy(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	out := stats.Outcomes
 	if out == nil {
 		t.Fatalf("Outcomes: got nil want populated")
@@ -2441,17 +2312,11 @@ func TestGetSessionStats_Outcomes_Happy(t *testing.T) {
 		t.Errorf("ClaudeOnly: got false want true")
 	}
 	// Two "completed" -> Success.
-	if out.Success != 2 {
-		t.Errorf("Success: got %d want 2", out.Success)
-	}
+	assert.Equal(t, 2, out.Success, "Success: got")
 	// One "abandoned" + one "errored" -> Failure.
-	if out.Failure != 2 {
-		t.Errorf("Failure: got %d want 2", out.Failure)
-	}
+	assert.Equal(t, 2, out.Failure, "Failure: got")
 	// One explicit "unknown" -> Unknown.
-	if out.Unknown != 1 {
-		t.Errorf("Unknown: got %d want 1", out.Unknown)
-	}
+	assert.Equal(t, 1, out.Unknown, "Unknown: got")
 	if out.GradeDistribution == nil {
 		t.Fatalf("GradeDistribution: got nil want non-nil")
 	}
@@ -2504,9 +2369,7 @@ func TestGetSessionStats_Outcomes_NoClaude(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.Outcomes != nil {
 		t.Errorf("Outcomes: got %+v want nil", stats.Outcomes)
 	}
@@ -2529,9 +2392,7 @@ func TestGetSessionStats_Outcomes_NoGrade(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	out := stats.Outcomes
 	if out == nil {
 		t.Fatalf("Outcomes: got nil want populated")
@@ -2547,9 +2408,7 @@ func TestGetSessionStats_Outcomes_NoGrade(t *testing.T) {
 		t.Errorf("ToolRetryRate: got %v want 0 (no tools)",
 			out.ToolRetryRate)
 	}
-	if out.Success != 1 {
-		t.Errorf("Success: got %d want 1", out.Success)
-	}
+	assert.Equal(t, 1, out.Success, "Success: got")
 }
 
 // seedToolCallsByName inserts one assistant message per entry in calls and
@@ -2667,9 +2526,7 @@ func TestGetSessionStats_Adoption_Happy(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	ad := stats.Adoption
 	if ad == nil {
 		t.Fatalf("Adoption: got nil want populated")
@@ -2690,9 +2547,7 @@ func TestGetSessionStats_Adoption_Happy(t *testing.T) {
 			ad.SubagentsPerSession)
 	}
 	// {"brainstorm","writing-plans","brainstorm"} -> 2 distinct.
-	if ad.DistinctSkills != 2 {
-		t.Errorf("DistinctSkills: got %d want 2", ad.DistinctSkills)
-	}
+	assert.Equal(t, 2, ad.DistinctSkills, "DistinctSkills: got")
 }
 
 // TestGetSessionStats_Adoption_NoClaude verifies that Adoption stays
@@ -2714,9 +2569,7 @@ func TestGetSessionStats_Adoption_NoClaude(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.Adoption != nil {
 		t.Errorf("Adoption: got %+v want nil", stats.Adoption)
 	}
@@ -2803,9 +2656,7 @@ func TestGetSessionStats_OutcomeStats_DefaultDisabled(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.OutcomeStats != nil {
 		t.Fatalf("OutcomeStats: got %+v want nil", stats.OutcomeStats)
 	}
@@ -2835,9 +2686,8 @@ func TestGetSessionStats_OutcomeStats_Happy(t *testing.T) {
 	// one in a subdirectory. Both should collapse to the same repo and
 	// counted once in ReposActive.
 	sub := filepath.Join(repo, "subdir")
-	if err := os.MkdirAll(sub, 0o755); err != nil {
-		t.Fatalf("mkdir sub: %v", err)
-	}
+	err := os.MkdirAll(sub, 0o755)
+	require.NoError(t, err, "mkdir sub")
 	insertSessionFixture(t, d, sessionFixture{
 		id: "os1", agent: "claude", userMsgs: 5,
 		startedAt: hoursAgo(5), cwd: repo,
@@ -2850,29 +2700,17 @@ func TestGetSessionStats_OutcomeStats_Happy(t *testing.T) {
 	stats, err := d.GetSessionStats(ctx, StatsFilter{
 		Since: "28d", IncludeGitOutcomes: true,
 	})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	out := stats.OutcomeStats
 	if out == nil {
 		t.Fatalf("OutcomeStats: got nil want populated")
 	}
-	if out.ReposActive != 1 {
-		t.Errorf("ReposActive: got %d want 1", out.ReposActive)
-	}
-	if out.Commits != 3 {
-		t.Errorf("Commits: got %d want 3", out.Commits)
-	}
-	if out.LOCAdded != 9 {
-		t.Errorf("LOCAdded: got %d want 9", out.LOCAdded)
-	}
-	if out.LOCRemoved != 0 {
-		t.Errorf("LOCRemoved: got %d want 0", out.LOCRemoved)
-	}
+	assert.Equal(t, 1, out.ReposActive, "ReposActive: got")
+	assert.Equal(t, 3, out.Commits, "Commits: got")
+	assert.Equal(t, 9, out.LOCAdded, "LOCAdded: got")
+	assert.Equal(t, 0, out.LOCRemoved, "LOCRemoved: got")
 	// Each commit touches one file: c1 a.txt, c2 a.txt, c3 b.txt -> 3.
-	if out.FilesChanged != 3 {
-		t.Errorf("FilesChanged: got %d want 3", out.FilesChanged)
-	}
+	assert.Equal(t, 3, out.FilesChanged, "FilesChanged: got")
 	if out.PRsOpened != nil {
 		t.Errorf("PRsOpened: got %v want nil (no GHToken)",
 			*out.PRsOpened)
@@ -2899,9 +2737,7 @@ func TestGetSessionStats_OutcomeStats_NoCwd(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.OutcomeStats != nil {
 		t.Errorf("OutcomeStats: got %+v want nil",
 			stats.OutcomeStats)
@@ -2926,9 +2762,7 @@ func TestGetSessionStats_OutcomeStats_CwdOutsideRepo(t *testing.T) {
 	})
 
 	stats, err := d.GetSessionStats(ctx, StatsFilter{Since: "28d"})
-	if err != nil {
-		t.Fatalf("GetSessionStats: %v", err)
-	}
+	require.NoError(t, err, "GetSessionStats")
 	if stats.OutcomeStats != nil {
 		t.Errorf("OutcomeStats: got %+v want nil",
 			stats.OutcomeStats)

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindSessionIDsByPartial(t *testing.T) {
@@ -15,37 +18,20 @@ func TestFindSessionIDsByPartial(t *testing.T) {
 	ctx := context.Background()
 
 	got, err := d.FindSessionIDsByPartial(ctx, "abcdef", 5)
-	if err != nil {
-		t.Fatalf("FindSessionIDsByPartial: %v", err)
-	}
-	if len(got) != 2 {
-		t.Fatalf("abcdef matches = %v, want 2", got)
-	}
+	require.NoError(t, err, "FindSessionIDsByPartial")
+	assert.Len(t, got, 2, "abcdef matches")
 
 	got, err = d.FindSessionIDsByPartial(ctx, "fedcba", 5)
-	if err != nil {
-		t.Fatalf("FindSessionIDsByPartial: %v", err)
-	}
-	if len(got) != 1 || got[0] != "fedcba-5555" {
-		t.Fatalf("fedcba matches = %v, want [fedcba-5555]",
-			got)
-	}
+	require.NoError(t, err, "FindSessionIDsByPartial")
+	assert.Equal(t, []string{"fedcba-5555"}, got, "fedcba matches")
 
 	got, err = d.FindSessionIDsByPartial(ctx, "nope", 5)
-	if err != nil {
-		t.Fatalf("FindSessionIDsByPartial: %v", err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("nope matches = %v, want empty", got)
-	}
+	require.NoError(t, err, "FindSessionIDsByPartial")
+	assert.Empty(t, got, "nope matches")
 
 	got, err = d.FindSessionIDsByPartial(ctx, "", 5)
-	if err != nil {
-		t.Fatalf("FindSessionIDsByPartial: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("empty input = %v, want nil", got)
-	}
+	require.NoError(t, err, "FindSessionIDsByPartial")
+	assert.Nil(t, got, "empty input")
 }
 
 func TestListSessions_OutcomeFilter(t *testing.T) {
@@ -70,9 +56,7 @@ func TestListSessions_OutcomeFilter(t *testing.T) {
 		err := d.UpdateSessionSignals(tc.id, SessionSignalUpdate{
 			Outcome: tc.outcome,
 		})
-		if err != nil {
-			t.Fatalf("UpdateSessionSignals %s: %v", tc.id, err)
-		}
+		require.NoError(t, err, "UpdateSessionSignals %s", tc.id)
 	}
 
 	// Single outcome.
@@ -109,9 +93,7 @@ func TestListSessions_HealthGradeFilter(t *testing.T) {
 			HealthGrade: new(tc.grade),
 			HealthScore: new(tc.score),
 		})
-		if err != nil {
-			t.Fatalf("UpdateSessionSignals %s: %v", tc.id, err)
-		}
+		require.NoError(t, err, "UpdateSessionSignals %s", tc.id)
 	}
 
 	requireSessions(t, d, filterWith(func(f *SessionFilter) {
@@ -143,9 +125,7 @@ func TestListSessions_MinToolFailuresFilter(t *testing.T) {
 		err := d.UpdateSessionSignals(tc.id, SessionSignalUpdate{
 			ToolFailureSignalCount: tc.failures,
 		})
-		if err != nil {
-			t.Fatalf("UpdateSessionSignals %s: %v", tc.id, err)
-		}
+		require.NoError(t, err, "UpdateSessionSignals %s", tc.id)
 	}
 
 	requireSessions(t, d, filterWith(func(f *SessionFilter) {
@@ -175,20 +155,14 @@ func TestUpsertSession_DisplayNameInsertOnly(t *testing.T) {
 		DisplayName:  &displayName,
 		MessageCount: 1,
 	})
-	requireNoError(t, err, "UpsertSession insert")
+	require.NoError(t, err, "UpsertSession insert")
 
 	// Verify display_name was set.
 	s, err := d.GetSession(ctx, "claude-ai:dn-test")
-	requireNoError(t, err, "GetSession after insert")
-	if s == nil {
-		t.Fatal("GetSession returned nil after insert")
-	}
-	if s.DisplayName == nil {
-		t.Fatal("DisplayName is nil after insert, want non-nil")
-	}
-	if *s.DisplayName != "My Chat Title" {
-		t.Errorf("DisplayName = %q, want %q", *s.DisplayName, "My Chat Title")
-	}
+	require.NoError(t, err, "GetSession after insert")
+	require.NotNil(t, s, "GetSession returned nil after insert")
+	require.NotNil(t, s.DisplayName, "DisplayName is nil after insert")
+	assert.Equal(t, "My Chat Title", *s.DisplayName, "DisplayName")
 
 	// Re-upsert with a different display_name.
 	newName := "Updated Title"
@@ -200,27 +174,17 @@ func TestUpsertSession_DisplayNameInsertOnly(t *testing.T) {
 		DisplayName:  &newName,
 		MessageCount: 2,
 	})
-	requireNoError(t, err, "UpsertSession update")
+	require.NoError(t, err, "UpsertSession update")
 
 	// display_name should NOT be overwritten by re-upsert.
 	s, err = d.GetSession(ctx, "claude-ai:dn-test")
-	requireNoError(t, err, "GetSession after re-upsert")
-	if s == nil {
-		t.Fatal("GetSession returned nil after re-upsert")
-	}
-	if s.DisplayName == nil {
-		t.Fatal("DisplayName is nil after re-upsert, want non-nil")
-	}
-	if *s.DisplayName != "My Chat Title" {
-		t.Errorf(
-			"DisplayName = %q after re-upsert, want %q (should be preserved)",
-			*s.DisplayName, "My Chat Title",
-		)
-	}
+	require.NoError(t, err, "GetSession after re-upsert")
+	require.NotNil(t, s, "GetSession returned nil after re-upsert")
+	require.NotNil(t, s.DisplayName, "DisplayName is nil after re-upsert")
+	assert.Equal(t, "My Chat Title", *s.DisplayName,
+		"DisplayName should be preserved")
 	// But other fields should update.
-	if s.MessageCount != 2 {
-		t.Errorf("MessageCount = %d, want 2", s.MessageCount)
-	}
+	assert.Equal(t, 2, s.MessageCount, "MessageCount")
 }
 
 // TestUpsertSessionDoesNotAdvanceDataVersion guards the
@@ -235,59 +199,39 @@ func TestUpsertSessionDoesNotAdvanceDataVersion(t *testing.T) {
 
 	// New session: data_version stays 0 even when the
 	// caller passes a non-zero value on the struct.
-	if err := d.UpsertSession(Session{
+	require.NoError(t, d.UpsertSession(Session{
 		ID:           "dv-1",
 		Project:      "p",
 		Machine:      "m",
 		Agent:        "claude",
 		MessageCount: 1,
 		DataVersion:  CurrentDataVersion(),
-	}); err != nil {
-		t.Fatalf("UpsertSession (insert): %v", err)
-	}
-	if got := d.GetSessionDataVersion("dv-1"); got != 0 {
-		t.Errorf(
-			"after insert, data_version = %d, want 0", got,
-		)
-	}
+	}), "UpsertSession (insert)")
+	assert.Equal(t, 0, d.GetSessionDataVersion("dv-1"),
+		"after insert, data_version")
 
 	// Stamp a current value to simulate a successful write.
-	if err := d.SetSessionDataVersion(
+	require.NoError(t, d.SetSessionDataVersion(
 		"dv-1", CurrentDataVersion(),
-	); err != nil {
-		t.Fatalf("SetSessionDataVersion: %v", err)
-	}
-	if got := d.GetSessionDataVersion("dv-1"); got !=
-		CurrentDataVersion() {
-		t.Errorf(
-			"after Set, data_version = %d, want %d",
-			got, CurrentDataVersion(),
-		)
-	}
+	), "SetSessionDataVersion")
+	assert.Equal(t, CurrentDataVersion(), d.GetSessionDataVersion("dv-1"),
+		"after Set, data_version")
 
 	// Re-upserting (e.g. as part of an incremental sync)
 	// must NOT clobber the stamped version with the
 	// struct's value (here 0), and must NOT replace it
 	// with a future "current" value before the rewrite
 	// succeeds.
-	if err := d.UpsertSession(Session{
+	require.NoError(t, d.UpsertSession(Session{
 		ID:           "dv-1",
 		Project:      "p",
 		Machine:      "m",
 		Agent:        "claude",
 		MessageCount: 5,
 		DataVersion:  0,
-	}); err != nil {
-		t.Fatalf("UpsertSession (update): %v", err)
-	}
-	if got := d.GetSessionDataVersion("dv-1"); got !=
-		CurrentDataVersion() {
-		t.Errorf(
-			"after re-upsert, data_version = %d, want %d "+
-				"(must be preserved across UpsertSession)",
-			got, CurrentDataVersion(),
-		)
-	}
+	}), "UpsertSession (update)")
+	assert.Equal(t, CurrentDataVersion(), d.GetSessionDataVersion("dv-1"),
+		"after re-upsert, data_version (must be preserved across UpsertSession)")
 }
 
 func TestUpsertSessionTerminationStatus(t *testing.T) {
@@ -318,29 +262,17 @@ func TestUpsertSessionTerminationStatus(t *testing.T) {
 				UserMessageCount:  1,
 				TerminationStatus: tc.val,
 			}
-			if err := d.UpsertSession(s); err != nil {
-				t.Fatalf("upsert: %v", err)
-			}
+			require.NoError(t, d.UpsertSession(s), "upsert")
 
 			got, err := d.GetSession(ctx, id)
-			if err != nil {
-				t.Fatalf("get: %v", err)
-			}
-			if got == nil {
-				t.Fatal("session not found")
-			}
+			require.NoError(t, err, "get")
+			require.NotNil(t, got, "session not found")
 
-			if (got.TerminationStatus == nil) != (tc.val == nil) {
-				t.Fatalf(
-					"nil mismatch: got=%v want=%v",
-					got.TerminationStatus, tc.val,
-				)
-			}
-			if got.TerminationStatus != nil && *got.TerminationStatus != *tc.val {
-				t.Fatalf(
-					"value mismatch: got=%q want=%q",
-					*got.TerminationStatus, *tc.val,
-				)
+			if tc.val == nil {
+				assert.Nil(t, got.TerminationStatus, "nil mismatch")
+			} else {
+				require.NotNil(t, got.TerminationStatus, "nil mismatch")
+				assert.Equal(t, *tc.val, *got.TerminationStatus, "value mismatch")
 			}
 		})
 	}
@@ -372,9 +304,7 @@ func TestListSessionsTerminationFilter(t *testing.T) {
 			UserMessageCount:  2,
 			TerminationStatus: term,
 		}
-		if err := d.UpsertSession(s); err != nil {
-			t.Fatalf("upsert %s: %v", id, err)
-		}
+		require.NoError(t, d.UpsertSession(s), "upsert %s", id)
 	}
 
 	// Active (< 10 min idle): regardless of termination_status,
@@ -395,9 +325,7 @@ func TestListSessionsTerminationFilter(t *testing.T) {
 
 	collect := func(f SessionFilter) []string {
 		page, err := d.ListSessions(ctx, f)
-		if err != nil {
-			t.Fatalf("list: %v", err)
-		}
+		require.NoError(t, err, "list")
 		ids := make([]string, len(page.Sessions))
 		for i, s := range page.Sessions {
 			ids[i] = s.ID
@@ -460,21 +388,5 @@ func TestListSessionsTerminationFilter(t *testing.T) {
 // elements regardless of order.
 func assertStringSetsEqual(t *testing.T, got, want []string) {
 	t.Helper()
-	if len(got) != len(want) {
-		t.Fatalf("len mismatch: got=%d want=%d (got=%v want=%v)",
-			len(got), len(want), got, want)
-	}
-	seen := make(map[string]int)
-	for _, s := range want {
-		seen[s]++
-	}
-	for _, s := range got {
-		seen[s]--
-	}
-	for s, n := range seen {
-		if n != 0 {
-			t.Fatalf("set mismatch on %q: leftover=%d (got=%v want=%v)",
-				s, n, got, want)
-		}
-	}
+	assert.ElementsMatch(t, want, got)
 }

--- a/internal/db/signals_test.go
+++ b/internal/db/signals_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateSessionSignals(t *testing.T) {
@@ -30,57 +33,30 @@ func TestUpdateSessionSignals(t *testing.T) {
 		HealthScore:            new(72),
 		HealthGrade:            new("B"),
 	}
-	if err := d.UpdateSessionSignals("sig-1", update); err != nil {
-		t.Fatalf("UpdateSessionSignals: %v", err)
-	}
+	require.NoError(t, d.UpdateSessionSignals("sig-1", update),
+		"UpdateSessionSignals")
 
 	got, err := d.GetSessionFull(ctx, "sig-1")
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if got == nil {
-		t.Fatal("session not found after update")
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, got, "session not found after update")
 
-	checks := []struct {
-		name string
-		got  any
-		want any
-	}{
-		{"ToolFailureSignalCount", got.ToolFailureSignalCount, 3},
-		{"ToolRetryCount", got.ToolRetryCount, 2},
-		{"EditChurnCount", got.EditChurnCount, 1},
-		{"ConsecutiveFailureMax", got.ConsecutiveFailureMax, 4},
-		{"Outcome", got.Outcome, "completed"},
-		{"OutcomeConfidence", got.OutcomeConfidence, "high"},
-		{"EndedWithRole", got.EndedWithRole, "assistant"},
-		{"FinalFailureStreak", got.FinalFailureStreak, 0},
-		{"CompactionCount", got.CompactionCount, 2},
-	}
-	for _, c := range checks {
-		if c.got != c.want {
-			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
-		}
-	}
+	assert.Equal(t, 3, got.ToolFailureSignalCount, "ToolFailureSignalCount")
+	assert.Equal(t, 2, got.ToolRetryCount, "ToolRetryCount")
+	assert.Equal(t, 1, got.EditChurnCount, "EditChurnCount")
+	assert.Equal(t, 4, got.ConsecutiveFailureMax, "ConsecutiveFailureMax")
+	assert.Equal(t, "completed", got.Outcome, "Outcome")
+	assert.Equal(t, "high", got.OutcomeConfidence, "OutcomeConfidence")
+	assert.Equal(t, "assistant", got.EndedWithRole, "EndedWithRole")
+	assert.Equal(t, 0, got.FinalFailureStreak, "FinalFailureStreak")
+	assert.Equal(t, 2, got.CompactionCount, "CompactionCount")
 
-	if got.SignalsPendingSince != nil {
-		t.Errorf(
-			"SignalsPendingSince = %v, want nil",
-			*got.SignalsPendingSince,
-		)
-	}
-	if got.ContextPressureMax == nil || *got.ContextPressureMax != 0.85 {
-		t.Errorf(
-			"ContextPressureMax = %v, want 0.85",
-			got.ContextPressureMax,
-		)
-	}
-	if got.HealthScore == nil || *got.HealthScore != 72 {
-		t.Errorf("HealthScore = %v, want 72", got.HealthScore)
-	}
-	if got.HealthGrade == nil || *got.HealthGrade != "B" {
-		t.Errorf("HealthGrade = %v, want B", got.HealthGrade)
-	}
+	assert.Nil(t, got.SignalsPendingSince, "SignalsPendingSince")
+	require.NotNil(t, got.ContextPressureMax, "ContextPressureMax")
+	assert.Equal(t, 0.85, *got.ContextPressureMax, "ContextPressureMax")
+	require.NotNil(t, got.HealthScore, "HealthScore")
+	assert.Equal(t, 72, *got.HealthScore, "HealthScore")
+	require.NotNil(t, got.HealthGrade, "HealthGrade")
+	assert.Equal(t, "B", *got.HealthGrade, "HealthGrade")
 
 	// Update again with pending since set and nullable fields
 	// cleared.
@@ -90,50 +66,26 @@ func TestUpdateSessionSignals(t *testing.T) {
 		OutcomeConfidence:   "low",
 		SignalsPendingSince: &pending,
 	}
-	if err := d.UpdateSessionSignals("sig-1", update2); err != nil {
-		t.Fatalf("UpdateSessionSignals (2nd): %v", err)
-	}
+	require.NoError(t, d.UpdateSessionSignals("sig-1", update2),
+		"UpdateSessionSignals (2nd)")
 
 	got2, err := d.GetSessionFull(ctx, "sig-1")
-	if err != nil {
-		t.Fatalf("GetSessionFull (2nd): %v", err)
-	}
+	require.NoError(t, err, "GetSessionFull (2nd)")
 
 	// Verify signals_pending_since is loaded by GetSessionFull
 	// (was previously absent from the column lists).
-	if got2.SignalsPendingSince == nil ||
-		*got2.SignalsPendingSince != pending {
-		t.Errorf(
-			"SignalsPendingSince = %v, want %q",
-			got2.SignalsPendingSince, pending,
-		)
-	}
+	require.NotNil(t, got2.SignalsPendingSince, "SignalsPendingSince")
+	assert.Equal(t, pending, *got2.SignalsPendingSince, "SignalsPendingSince")
 
 	pendingIDs, err := d.PendingSignalSessions(
 		ctx, "2024-07-01T00:00:00Z",
 	)
-	if err != nil {
-		t.Fatalf("PendingSignalSessions: %v", err)
-	}
-	if len(pendingIDs) != 1 || pendingIDs[0] != "sig-1" {
-		t.Errorf(
-			"PendingSignalSessions = %v, want [sig-1]",
-			pendingIDs,
-		)
-	}
+	require.NoError(t, err, "PendingSignalSessions")
+	assert.Equal(t, []string{"sig-1"}, pendingIDs, "PendingSignalSessions")
 
-	if got2.ContextPressureMax != nil {
-		t.Errorf(
-			"ContextPressureMax = %v, want nil",
-			*got2.ContextPressureMax,
-		)
-	}
-	if got2.HealthScore != nil {
-		t.Errorf("HealthScore = %v, want nil", *got2.HealthScore)
-	}
-	if got2.HealthGrade != nil {
-		t.Errorf("HealthGrade = %v, want nil", *got2.HealthGrade)
-	}
+	assert.Nil(t, got2.ContextPressureMax, "ContextPressureMax")
+	assert.Nil(t, got2.HealthScore, "HealthScore")
+	assert.Nil(t, got2.HealthGrade, "HealthGrade")
 }
 
 // TestUpdateSessionSignalsBumpsLocalModifiedAt ensures that
@@ -150,12 +102,8 @@ func TestUpdateSessionSignalsBumpsLocalModifiedAt(t *testing.T) {
 
 	// Snapshot local_modified_at after the initial upsert.
 	beforeRow, err := d.GetSessionFull(ctx, "lm-1")
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if beforeRow == nil {
-		t.Fatal("session not found before update")
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, beforeRow, "session not found before update")
 	before := ""
 	if beforeRow.LocalModifiedAt != nil {
 		before = *beforeRow.LocalModifiedAt
@@ -165,29 +113,21 @@ func TestUpdateSessionSignalsBumpsLocalModifiedAt(t *testing.T) {
 	// Sleep a few ms so a re-set produces a strictly later value.
 	time.Sleep(5 * time.Millisecond)
 
-	if err := d.UpdateSessionSignals("lm-1", SessionSignalUpdate{
+	require.NoError(t, d.UpdateSessionSignals("lm-1", SessionSignalUpdate{
 		ToolFailureSignalCount: 1,
 		Outcome:                "completed",
 		OutcomeConfidence:      "high",
 		EndedWithRole:          "assistant",
-	}); err != nil {
-		t.Fatalf("UpdateSessionSignals: %v", err)
-	}
+	}), "UpdateSessionSignals")
 
 	afterRow, err := d.GetSessionFull(ctx, "lm-1")
-	if err != nil {
-		t.Fatalf("GetSessionFull (after): %v", err)
-	}
-	if afterRow.LocalModifiedAt == nil ||
-		*afterRow.LocalModifiedAt == "" {
-		t.Fatal("local_modified_at not set after signal update")
-	}
-	if *afterRow.LocalModifiedAt <= before {
-		t.Errorf(
-			"local_modified_at not bumped: before=%q after=%q",
-			before, *afterRow.LocalModifiedAt,
-		)
-	}
+	require.NoError(t, err, "GetSessionFull (after)")
+	require.NotNil(t, afterRow.LocalModifiedAt,
+		"local_modified_at not set after signal update")
+	require.NotEmpty(t, *afterRow.LocalModifiedAt,
+		"local_modified_at not set after signal update")
+	assert.Greater(t, *afterRow.LocalModifiedAt, before,
+		"local_modified_at not bumped")
 }
 
 func TestPendingSignalSessions(t *testing.T) {
@@ -203,9 +143,8 @@ func TestPendingSignalSessions(t *testing.T) {
 		OutcomeConfidence:   "low",
 		SignalsPendingSince: new("2024-06-01T10:00:00Z"),
 	}
-	if err := d.UpdateSessionSignals("ps-old", old); err != nil {
-		t.Fatalf("UpdateSessionSignals ps-old: %v", err)
-	}
+	require.NoError(t, d.UpdateSessionSignals("ps-old", old),
+		"UpdateSessionSignals ps-old")
 
 	// Session with pending_since after cutoff -- should NOT match.
 	insertSession(t, d, "ps-new", "proj")
@@ -214,23 +153,16 @@ func TestPendingSignalSessions(t *testing.T) {
 		OutcomeConfidence:   "low",
 		SignalsPendingSince: new("2024-06-01T14:00:00Z"),
 	}
-	if err := d.UpdateSessionSignals("ps-new", newer); err != nil {
-		t.Fatalf("UpdateSessionSignals ps-new: %v", err)
-	}
+	require.NoError(t, d.UpdateSessionSignals("ps-new", newer),
+		"UpdateSessionSignals ps-new")
 
 	// Session with no pending_since -- should NOT match.
 	insertSession(t, d, "ps-none", "proj")
 
 	ids, err := d.PendingSignalSessions(ctx, cutoff)
-	if err != nil {
-		t.Fatalf("PendingSignalSessions: %v", err)
-	}
-	if len(ids) != 1 {
-		t.Fatalf("got %d IDs, want 1", len(ids))
-	}
-	if ids[0] != "ps-old" {
-		t.Errorf("got ID %q, want ps-old", ids[0])
-	}
+	require.NoError(t, err, "PendingSignalSessions")
+	require.Len(t, ids, 1)
+	assert.Equal(t, "ps-old", ids[0])
 }
 
 // TestBackfillSignalsMarkerOnlyOnSuccess guards the
@@ -257,9 +189,7 @@ func TestBackfillSignalsMarkerOnlyOnSuccess(t *testing.T) {
 			return nil
 		},
 	)
-	if err == nil {
-		t.Fatal("expected error from partial backfill, got nil")
-	}
+	require.Error(t, err, "expected error from partial backfill")
 
 	// Marker check: a second BackfillSignals call must NOT
 	// short-circuit since the marker is unset.
@@ -271,16 +201,9 @@ func TestBackfillSignalsMarkerOnlyOnSuccess(t *testing.T) {
 			return nil
 		},
 	)
-	if err != nil {
-		t.Fatalf("retry: %v", err)
-	}
-	if calls != 3 {
-		t.Errorf(
-			"second backfill saw %d sessions, want 3 "+
-				"(marker should not be set after partial run)",
-			calls,
-		)
-	}
+	require.NoError(t, err, "retry")
+	assert.Equal(t, 3, calls,
+		"second backfill should see all sessions (marker not set after partial run)")
 
 	// Now the marker should be set; a third call short-circuits.
 	calls = 0
@@ -291,14 +214,7 @@ func TestBackfillSignalsMarkerOnlyOnSuccess(t *testing.T) {
 			return nil
 		},
 	)
-	if err != nil {
-		t.Fatalf("third call: %v", err)
-	}
-	if calls != 0 {
-		t.Errorf(
-			"third backfill saw %d sessions, want 0 "+
-				"(marker should be set after clean run)",
-			calls,
-		)
-	}
+	require.NoError(t, err, "third call")
+	assert.Equal(t, 0, calls,
+		"third backfill should see 0 sessions (marker set after clean run)")
 }

--- a/internal/db/skipped_test.go
+++ b/internal/db/skipped_test.go
@@ -4,6 +4,9 @@ import (
 	"maps"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/dbtest"
 )
 
@@ -12,12 +15,8 @@ func TestSkippedFiles_RoundTrip(t *testing.T) {
 
 	// Initially empty.
 	loaded, err := d.LoadSkippedFiles()
-	if err != nil {
-		t.Fatalf("LoadSkippedFiles: %v", err)
-	}
-	if len(loaded) != 0 {
-		t.Fatalf("expected empty, got %d entries", len(loaded))
-	}
+	require.NoError(t, err, "LoadSkippedFiles")
+	require.Empty(t, loaded)
 
 	// Persist some entries.
 	entries := map[string]int64{
@@ -25,18 +24,13 @@ func TestSkippedFiles_RoundTrip(t *testing.T) {
 		"/d/e/f.jsonl": 200,
 		"/g/h/i.jsonl": 300,
 	}
-	if err := d.ReplaceSkippedFiles(entries); err != nil {
-		t.Fatalf("ReplaceSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceSkippedFiles(entries))
 
 	// Load them back.
 	loaded, err = d.LoadSkippedFiles()
-	if err != nil {
-		t.Fatalf("LoadSkippedFiles: %v", err)
-	}
-	if !maps.Equal(loaded, entries) {
-		t.Errorf("loaded map %v, want %v", loaded, entries)
-	}
+	require.NoError(t, err, "LoadSkippedFiles")
+	assert.True(t, maps.Equal(loaded, entries),
+		"loaded map %v, want %v", loaded, entries)
 }
 
 func TestSkippedFiles_ReplaceOverwrites(t *testing.T) {
@@ -46,28 +40,18 @@ func TestSkippedFiles_ReplaceOverwrites(t *testing.T) {
 		"/a.jsonl": 100,
 		"/b.jsonl": 200,
 	}
-	if err := d.ReplaceSkippedFiles(first); err != nil {
-		t.Fatalf("ReplaceSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceSkippedFiles(first))
 
 	// Replace with different entries.
 	second := map[string]int64{
 		"/c.jsonl": 300,
 	}
-	if err := d.ReplaceSkippedFiles(second); err != nil {
-		t.Fatalf("ReplaceSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceSkippedFiles(second))
 
 	loaded, err := d.LoadSkippedFiles()
-	if err != nil {
-		t.Fatalf("LoadSkippedFiles: %v", err)
-	}
-	if len(loaded) != 1 {
-		t.Fatalf("got %d entries, want 1", len(loaded))
-	}
-	if loaded["/c.jsonl"] != 300 {
-		t.Errorf("loaded[/c.jsonl] = %d, want 300", loaded["/c.jsonl"])
-	}
+	require.NoError(t, err, "LoadSkippedFiles")
+	require.Len(t, loaded, 1)
+	assert.Equal(t, int64(300), loaded["/c.jsonl"])
 }
 
 func TestSkippedFiles_DeleteSingle(t *testing.T) {
@@ -77,56 +61,35 @@ func TestSkippedFiles_DeleteSingle(t *testing.T) {
 		"/a.jsonl": 100,
 		"/b.jsonl": 200,
 	}
-	if err := d.ReplaceSkippedFiles(entries); err != nil {
-		t.Fatalf("ReplaceSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceSkippedFiles(entries))
 
-	if err := d.DeleteSkippedFile("/a.jsonl"); err != nil {
-		t.Fatalf("DeleteSkippedFile: %v", err)
-	}
+	require.NoError(t, d.DeleteSkippedFile("/a.jsonl"))
 
 	loaded, err := d.LoadSkippedFiles()
-	if err != nil {
-		t.Fatalf("LoadSkippedFiles: %v", err)
-	}
-	if len(loaded) != 1 {
-		t.Fatalf("got %d entries, want 1", len(loaded))
-	}
-	if _, ok := loaded["/a.jsonl"]; ok {
-		t.Error("/a.jsonl should have been deleted")
-	}
-	if loaded["/b.jsonl"] != 200 {
-		t.Errorf("loaded[/b.jsonl] = %d, want 200", loaded["/b.jsonl"])
-	}
+	require.NoError(t, err, "LoadSkippedFiles")
+	require.Len(t, loaded, 1)
+	_, ok := loaded["/a.jsonl"]
+	assert.False(t, ok, "/a.jsonl should have been deleted")
+	assert.Equal(t, int64(200), loaded["/b.jsonl"])
 }
 
 func TestSkippedFiles_DeleteNonexistent(t *testing.T) {
 	d := dbtest.OpenTestDB(t)
 
 	// Should not error.
-	if err := d.DeleteSkippedFile("/nope"); err != nil {
-		t.Fatalf("DeleteSkippedFile: %v", err)
-	}
+	require.NoError(t, d.DeleteSkippedFile("/nope"))
 }
 
 func TestSkippedFiles_EmptyReplace(t *testing.T) {
 	d := dbtest.OpenTestDB(t)
 
 	entries := map[string]int64{"/a.jsonl": 100}
-	if err := d.ReplaceSkippedFiles(entries); err != nil {
-		t.Fatalf("ReplaceSkippedFiles: %v", err)
-	}
+	require.NoError(t, d.ReplaceSkippedFiles(entries))
 
 	// Replace with empty map clears the table.
-	if err := d.ReplaceSkippedFiles(map[string]int64{}); err != nil {
-		t.Fatalf("ReplaceSkippedFiles empty: %v", err)
-	}
+	require.NoError(t, d.ReplaceSkippedFiles(map[string]int64{}))
 
 	loaded, err := d.LoadSkippedFiles()
-	if err != nil {
-		t.Fatalf("LoadSkippedFiles: %v", err)
-	}
-	if len(loaded) != 0 {
-		t.Fatalf("got %d entries, want 0", len(loaded))
-	}
+	require.NoError(t, err, "LoadSkippedFiles")
+	require.Empty(t, loaded)
 }

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFileBackedSessionCount_ExcludesNonFileAgents(
@@ -23,11 +26,7 @@ func TestFileBackedSessionCount_ExcludesNonFileAgents(
 	insertSession(t, d, "test-file-session", "myproject")
 
 	count, err := d.FileBackedSessionCount(ctx)
-	requireNoError(t, err, "FileBackedSessionCount")
-	if count != 1 {
-		t.Errorf(
-			"FileBackedSessionCount = %d, want 1 "+
-				"(only claude session)", count,
-		)
-	}
+	require.NoError(t, err, "FileBackedSessionCount")
+	assert.Equal(t, 1, count,
+		"FileBackedSessionCount should be 1 (only claude session)")
 }

--- a/internal/db/timing_test.go
+++ b/internal/db/timing_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetSessionTiming_Solo(t *testing.T) {
@@ -23,31 +26,15 @@ func TestGetSessionTiming_Solo(t *testing.T) {
 		"ok", "2026-04-26T10:00:30Z", false)
 
 	got, err := d.GetSessionTiming(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got.TurnCount != 1 {
-		t.Errorf("TurnCount = %d, want 1", got.TurnCount)
-	}
-	if got.ToolCallCount != 1 {
-		t.Errorf("ToolCallCount = %d, want 1", got.ToolCallCount)
-	}
-	if got.Running {
-		t.Errorf("Running = true, want false")
-	}
-	if len(got.Turns) != 1 {
-		t.Fatalf("len(Turns) = %d, want 1", len(got.Turns))
-	}
-	if got.Turns[0].DurationMs == nil ||
-		*got.Turns[0].DurationMs != 29_000 {
-		t.Errorf("turn duration = %v, want 29000",
-			got.Turns[0].DurationMs)
-	}
-	if got.Turns[0].Calls[0].DurationMs == nil ||
-		*got.Turns[0].Calls[0].DurationMs != 29_000 {
-		t.Errorf("call duration = %v, want 29000",
-			got.Turns[0].Calls[0].DurationMs)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.Equal(t, 1, got.TurnCount, "TurnCount")
+	assert.Equal(t, 1, got.ToolCallCount, "ToolCallCount")
+	assert.False(t, got.Running, "Running")
+	require.Len(t, got.Turns, 1, "len(Turns)")
+	require.NotNil(t, got.Turns[0].DurationMs, "turn duration")
+	assert.Equal(t, int64(29_000), *got.Turns[0].DurationMs, "turn duration")
+	require.NotNil(t, got.Turns[0].Calls[0].DurationMs, "call duration")
+	assert.Equal(t, int64(29_000), *got.Turns[0].Calls[0].DurationMs, "call duration")
 }
 
 func TestGetSessionTiming_LastMessageFallsBackToSessionEnd(t *testing.T) {
@@ -64,24 +51,14 @@ func TestGetSessionTiming_LastMessageFallsBackToSessionEnd(t *testing.T) {
 		"tu_1", "Bash", "Bash", "")
 
 	got, err := d.GetSessionTiming(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got.Turns[0].DurationMs == nil {
-		t.Fatalf("turn duration = nil, want 20000 " +
-			"(fallback to ended_at)")
-	}
-	if *got.Turns[0].DurationMs != 20_000 {
-		t.Errorf("turn duration = %d, want 20000 "+
-			"(fallback to ended_at)",
-			*got.Turns[0].DurationMs)
-	}
-	if got.Turns[0].Calls[0].DurationMs == nil ||
-		*got.Turns[0].Calls[0].DurationMs != 20_000 {
-		t.Errorf("call duration = %v, want 20000 "+
-			"(solo non-subagent inherits turn duration)",
-			got.Turns[0].Calls[0].DurationMs)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	require.NotNil(t, got.Turns[0].DurationMs,
+		"turn duration nil, want 20000 (fallback to ended_at)")
+	assert.Equal(t, int64(20_000), *got.Turns[0].DurationMs,
+		"turn duration (fallback to ended_at)")
+	require.NotNil(t, got.Turns[0].Calls[0].DurationMs, "call duration")
+	assert.Equal(t, int64(20_000), *got.Turns[0].Calls[0].DurationMs,
+		"call duration (solo non-subagent inherits turn duration)")
 }
 
 func TestGetSessionTiming_RunningSessionLastTurnNull(t *testing.T) {
@@ -98,16 +75,9 @@ func TestGetSessionTiming_RunningSessionLastTurnNull(t *testing.T) {
 		"tu_1", "Bash", "Bash", "")
 
 	got, err := d.GetSessionTiming(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if !got.Running {
-		t.Errorf("Running = false, want true")
-	}
-	if got.Turns[0].DurationMs != nil {
-		t.Errorf("turn duration = %v, want nil (running)",
-			*got.Turns[0].DurationMs)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.True(t, got.Running, "Running")
+	assert.Nil(t, got.Turns[0].DurationMs, "turn duration (running)")
 }
 
 func TestGetSessionTiming_NonMonotonicTimestampClampsNull(t *testing.T) {
@@ -126,13 +96,8 @@ func TestGetSessionTiming_NonMonotonicTimestampClampsNull(t *testing.T) {
 		"ok", "2026-04-26T10:00:00Z", false)
 
 	got, err := d.GetSessionTiming(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got.Turns[0].DurationMs != nil {
-		t.Errorf("turn duration = %v, want nil (clamp)",
-			*got.Turns[0].DurationMs)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.Nil(t, got.Turns[0].DurationMs, "turn duration (clamp)")
 }
 
 func TestGetSessionTiming_NoToolUseHasNoTurnDuration(t *testing.T) {
@@ -147,12 +112,8 @@ func TestGetSessionTiming_NoToolUseHasNoTurnDuration(t *testing.T) {
 		"hi back", "2026-04-26T10:00:01Z", false)
 
 	got, err := d.GetSessionTiming(ctx, "s1")
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got.TurnCount != 0 {
-		t.Errorf("TurnCount = %d, want 0", got.TurnCount)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.Equal(t, 0, got.TurnCount, "TurnCount")
 }
 
 func TestGetSessionTiming_MarshalsEmptyCollectionsAsArrays(t *testing.T) {
@@ -167,15 +128,9 @@ func TestGetSessionTiming_MarshalsEmptyCollectionsAsArrays(t *testing.T) {
 		"hi back", "2026-04-26T10:00:01Z", false)
 
 	noTool, err := d.GetSessionTiming(ctx, "notool")
-	if err != nil {
-		t.Fatalf("GetSessionTiming(notool): %v", err)
-	}
-	if noTool.ByCategory == nil {
-		t.Fatal("ByCategory is nil, want empty slice")
-	}
-	if noTool.Turns == nil {
-		t.Fatal("Turns is nil, want empty slice")
-	}
+	require.NoError(t, err, "GetSessionTiming(notool)")
+	require.NotNil(t, noTool.ByCategory, "ByCategory is nil, want empty slice")
+	require.NotNil(t, noTool.Turns, "Turns is nil, want empty slice")
 
 	timingInsertSession(t, d, "missing-calls",
 		"2026-04-26T10:00:00Z", "2026-04-26T10:00:30Z")
@@ -187,29 +142,20 @@ func TestGetSessionTiming_MarshalsEmptyCollectionsAsArrays(t *testing.T) {
 		"done", "2026-04-26T10:00:30Z", false)
 
 	missingCalls, err := d.GetSessionTiming(ctx, "missing-calls")
-	if err != nil {
-		t.Fatalf("GetSessionTiming(missing-calls): %v", err)
-	}
-	if len(missingCalls.Turns) != 1 {
-		t.Fatalf("len(Turns) = %d, want 1", len(missingCalls.Turns))
-	}
-	if missingCalls.Turns[0].Calls == nil {
-		t.Fatal("Turn Calls is nil, want empty slice")
-	}
+	require.NoError(t, err, "GetSessionTiming(missing-calls)")
+	require.Len(t, missingCalls.Turns, 1, "len(Turns)")
+	require.NotNil(t, missingCalls.Turns[0].Calls,
+		"Turn Calls is nil, want empty slice")
 
 	payload, err := json.Marshal(missingCalls)
-	if err != nil {
-		t.Fatalf("Marshal timing: %v", err)
-	}
+	require.NoError(t, err, "Marshal timing")
 	body := string(payload)
 	for _, field := range []string{
 		`"by_category":null`,
 		`"turns":null`,
 		`"calls":null`,
 	} {
-		if strings.Contains(body, field) {
-			t.Fatalf("timing JSON contains %s: %s", field, body)
-		}
+		assert.NotContains(t, body, field, "timing JSON contains %s", field)
 	}
 }
 
@@ -232,16 +178,11 @@ func TestGetSessionTiming_SubagentExactDuration(t *testing.T) {
 		"done", "2026-04-26T10:02:16Z", false)
 
 	got, err := d.GetSessionTiming(ctx, "parent")
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
+	require.NoError(t, err, "GetSessionTiming")
 	dms := got.Turns[0].Calls[0].DurationMs
-	if dms == nil || *dms != 134_000 {
-		t.Errorf("subagent duration = %v, want 134000", dms)
-	}
-	if got.SubagentCount != 1 {
-		t.Errorf("SubagentCount = %d, want 1", got.SubagentCount)
-	}
+	require.NotNil(t, dms, "subagent duration")
+	assert.Equal(t, int64(134_000), *dms, "subagent duration")
+	assert.Equal(t, 1, got.SubagentCount, "SubagentCount")
 }
 
 func TestGetSessionTiming_MissingSessionReturnsNil(t *testing.T) {
@@ -249,12 +190,8 @@ func TestGetSessionTiming_MissingSessionReturnsNil(t *testing.T) {
 	ctx := context.Background()
 
 	got, err := d.GetSessionTiming(ctx, "no-such")
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got != nil {
-		t.Errorf("GetSessionTiming = %v, want nil", got)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.Nil(t, got, "GetSessionTiming")
 }
 
 func TestMakeInputPreview(t *testing.T) {
@@ -335,9 +272,7 @@ func TestMakeInputPreview(t *testing.T) {
 			got := makeInputPreview(
 				tc.category, tc.toolName, tc.inputJSON,
 			)
-			if got != tc.want {
-				t.Errorf("got %q, want %q", got, tc.want)
-			}
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }
@@ -360,9 +295,7 @@ func timingInsertSession(t *testing.T, d *DB, id, started, ended string) {
 			 started_at, ended_at)
 		VALUES (?, '', 'local', 'claude', 1, ?, ?)
 	`, id, started, endedAt)
-	if err != nil {
-		t.Fatalf("timingInsertSession %s: %v", id, err)
-	}
+	require.NoError(t, err, "timingInsertSession %s", id)
 }
 
 func timingInsertMessage(
@@ -381,10 +314,7 @@ func timingInsertMessage(
 			 has_tool_use)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`, sessionID, ordinal, role, content, ts, flag)
-	if err != nil {
-		t.Fatalf("timingInsertMessage %s/%d: %v",
-			sessionID, ordinal, err)
-	}
+	require.NoError(t, err, "timingInsertMessage %s/%d", sessionID, ordinal)
 }
 
 func timingMsgID(
@@ -397,10 +327,7 @@ func timingMsgID(
 		 WHERE session_id = ? AND ordinal = ?`,
 		sessionID, ordinal,
 	).Scan(&id)
-	if err != nil {
-		t.Fatalf("timingMsgID %s/%d: %v",
-			sessionID, ordinal, err)
-	}
+	require.NoError(t, err, "timingMsgID %s/%d", sessionID, ordinal)
 	return id
 }
 
@@ -420,8 +347,5 @@ func timingInsertToolCall(
 			 category, input_json, subagent_session_id)
 		VALUES (?, ?, ?, ?, ?, '{}', ?)
 	`, sessionID, messageID, toolUseID, toolName, category, sub)
-	if err != nil {
-		t.Fatalf("timingInsertToolCall %s/%d: %v",
-			sessionID, messageID, err)
-	}
+	require.NoError(t, err, "timingInsertToolCall %s/%d", sessionID, messageID)
 }

--- a/internal/db/token_coverage_unit_test.go
+++ b/internal/db/token_coverage_unit_test.go
@@ -1,6 +1,11 @@
 package db
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestComputeSessionCoverageUpdates(t *testing.T) {
 	tests := []struct {
@@ -53,22 +58,11 @@ func TestComputeSessionCoverageUpdates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ComputeSessionCoverageUpdates(tc.candidates, tc.msgCoverage)
 
-			if len(got) != len(tc.want) {
-				t.Fatalf("len(got) = %d, want %d; got = %v",
-					len(got), len(tc.want), got)
-			}
+			require.Len(t, got, len(tc.want), "len mismatch; got = %v", got)
 			for i, w := range tc.want {
-				if got[i].ID != w.ID {
-					t.Errorf("[%d] ID = %q, want %q", i, got[i].ID, w.ID)
-				}
-				if got[i].HasTotal != w.HasTotal {
-					t.Errorf("[%d] HasTotal = %v, want %v",
-						i, got[i].HasTotal, w.HasTotal)
-				}
-				if got[i].HasPeak != w.HasPeak {
-					t.Errorf("[%d] HasPeak = %v, want %v",
-						i, got[i].HasPeak, w.HasPeak)
-				}
+				assert.Equal(t, w.ID, got[i].ID, "[%d] ID", i)
+				assert.Equal(t, w.HasTotal, got[i].HasTotal, "[%d] HasTotal", i)
+				assert.Equal(t, w.HasPeak, got[i].HasPeak, "[%d] HasPeak", i)
 			}
 		})
 	}

--- a/internal/db/token_usage_test.go
+++ b/internal/db/token_usage_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMigrationAddsTokenColumns(t *testing.T) {
@@ -24,10 +27,8 @@ func TestMigrationAddsTokenColumns(t *testing.T) {
 			"SELECT count(*) FROM pragma_table_info('messages')"+
 				" WHERE name = ?", col,
 		).Scan(&count)
-		requireNoError(t, err, "probing messages."+col)
-		if count != 1 {
-			t.Errorf("expected messages.%s to exist", col)
-		}
+		require.NoError(t, err, "probing messages.%s", col)
+		assert.Equal(t, 1, count, "expected messages.%s to exist", col)
 	}
 
 	// Verify session token columns exist.
@@ -40,10 +41,8 @@ func TestMigrationAddsTokenColumns(t *testing.T) {
 			"SELECT count(*) FROM pragma_table_info('sessions')"+
 				" WHERE name = ?", col,
 		).Scan(&count)
-		requireNoError(t, err, "probing sessions."+col)
-		if count != 1 {
-			t.Errorf("expected sessions.%s to exist", col)
-		}
+		require.NoError(t, err, "probing sessions.%s", col)
+		assert.Equal(t, 1, count, "expected sessions.%s to exist", col)
 	}
 }
 
@@ -52,12 +51,12 @@ func TestMigrationIdempotent(t *testing.T) {
 	path := filepath.Join(dir, "test.db")
 
 	d1, err := Open(path)
-	requireNoError(t, err, "first open")
+	require.NoError(t, err, "first open")
 	d1.Close()
 
 	// Re-open should not fail even though columns already exist.
 	d2, err := Open(path)
-	requireNoError(t, err, "second open")
+	require.NoError(t, err, "second open")
 	d2.Close()
 }
 
@@ -98,47 +97,23 @@ func TestInsertAndGetMessagesTokenUsage(t *testing.T) {
 	insertMessages(t, d, msgs...)
 
 	got, err := d.GetMessages(ctx, "s1", 0, 100, true)
-	requireNoError(t, err, "GetMessages")
+	require.NoError(t, err, "GetMessages")
 
-	if len(got) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(got))
-	}
+	require.Len(t, got, 2)
 
 	// Verify first message fields.
-	if got[0].Model != "claude-sonnet-4-20250514" {
-		t.Errorf("msg[0].Model = %q, want %q",
-			got[0].Model, "claude-sonnet-4-20250514")
-	}
-	if string(got[0].TokenUsage) != `{"input":100,"output":0}` {
-		t.Errorf("msg[0].TokenUsage = %q, want %q",
-			string(got[0].TokenUsage), `{"input":100,"output":0}`)
-	}
-	if got[0].ContextTokens != 500 {
-		t.Errorf("msg[0].ContextTokens = %d, want 500",
-			got[0].ContextTokens)
-	}
-	if !got[0].HasContextTokens {
-		t.Error("msg[0].HasContextTokens = false, want true")
-	}
-	if !got[0].HasOutputTokens {
-		t.Error("msg[0].HasOutputTokens = false, want true")
-	}
+	assert.Equal(t, "claude-sonnet-4-20250514", got[0].Model, "msg[0].Model")
+	assert.Equal(t, `{"input":100,"output":0}`, string(got[0].TokenUsage),
+		"msg[0].TokenUsage")
+	assert.Equal(t, 500, got[0].ContextTokens, "msg[0].ContextTokens")
+	assert.True(t, got[0].HasContextTokens, "msg[0].HasContextTokens")
+	assert.True(t, got[0].HasOutputTokens, "msg[0].HasOutputTokens")
 
 	// Verify second message fields.
-	if got[1].OutputTokens != 200 {
-		t.Errorf("msg[1].OutputTokens = %d, want 200",
-			got[1].OutputTokens)
-	}
-	if got[1].ContextTokens != 600 {
-		t.Errorf("msg[1].ContextTokens = %d, want 600",
-			got[1].ContextTokens)
-	}
-	if !got[1].HasContextTokens {
-		t.Error("msg[1].HasContextTokens = false, want true")
-	}
-	if !got[1].HasOutputTokens {
-		t.Error("msg[1].HasOutputTokens = false, want true")
-	}
+	assert.Equal(t, 200, got[1].OutputTokens, "msg[1].OutputTokens")
+	assert.Equal(t, 600, got[1].ContextTokens, "msg[1].ContextTokens")
+	assert.True(t, got[1].HasContextTokens, "msg[1].HasContextTokens")
+	assert.True(t, got[1].HasOutputTokens, "msg[1].HasOutputTokens")
 }
 
 func TestGetAllMessagesTokenUsage(t *testing.T) {
@@ -159,20 +134,12 @@ func TestGetAllMessagesTokenUsage(t *testing.T) {
 	})
 
 	got, err := d.GetAllMessages(ctx, "s1")
-	requireNoError(t, err, "GetAllMessages")
+	require.NoError(t, err, "GetAllMessages")
 
-	if len(got) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(got))
-	}
-	if got[0].Model != "gpt-4o" {
-		t.Errorf("Model = %q, want %q", got[0].Model, "gpt-4o")
-	}
-	if got[0].OutputTokens != 150 {
-		t.Errorf("OutputTokens = %d, want 150", got[0].OutputTokens)
-	}
-	if got[0].ContextTokens != 300 {
-		t.Errorf("ContextTokens = %d, want 300", got[0].ContextTokens)
-	}
+	require.Len(t, got, 1)
+	assert.Equal(t, "gpt-4o", got[0].Model, "Model")
+	assert.Equal(t, 150, got[0].OutputTokens, "OutputTokens")
+	assert.Equal(t, 300, got[0].ContextTokens, "ContextTokens")
 }
 
 func TestGetMessageByOrdinalTokenUsage(t *testing.T) {
@@ -192,25 +159,12 @@ func TestGetMessageByOrdinalTokenUsage(t *testing.T) {
 	})
 
 	m, err := d.GetMessageByOrdinal("s1", 0)
-	requireNoError(t, err, "GetMessageByOrdinal")
-	if m == nil {
-		t.Fatal("expected message, got nil")
-	}
-	if m.Model != "claude-sonnet-4-20250514" {
-		t.Errorf("Model = %q, want %q",
-			m.Model, "claude-sonnet-4-20250514")
-	}
-	if string(m.TokenUsage) != `{"cache_read":42}` {
-		t.Errorf("TokenUsage = %q, want %q",
-			string(m.TokenUsage), `{"cache_read":42}`)
-	}
-	if m.ContextTokens != 250 {
-		t.Errorf("ContextTokens = %d, want 250",
-			m.ContextTokens)
-	}
-	if m.OutputTokens != 99 {
-		t.Errorf("OutputTokens = %d, want 99", m.OutputTokens)
-	}
+	require.NoError(t, err, "GetMessageByOrdinal")
+	require.NotNil(t, m, "expected message")
+	assert.Equal(t, "claude-sonnet-4-20250514", m.Model, "Model")
+	assert.Equal(t, `{"cache_read":42}`, string(m.TokenUsage), "TokenUsage")
+	assert.Equal(t, 250, m.ContextTokens, "ContextTokens")
+	assert.Equal(t, 99, m.OutputTokens, "OutputTokens")
 }
 
 func TestUpsertSessionTokenUsage(t *testing.T) {
@@ -228,49 +182,27 @@ func TestUpsertSessionTokenUsage(t *testing.T) {
 		HasTotalOutputTokens: true,
 		HasPeakContextTokens: true,
 	}
-	requireNoError(t, d.UpsertSession(s), "upsert")
+	require.NoError(t, d.UpsertSession(s), "upsert")
 
 	got, err := d.GetSession(ctx, "s1")
-	requireNoError(t, err, "GetSession")
-	if got == nil {
-		t.Fatal("expected session, got nil")
-	}
-	if got.TotalOutputTokens != 2000 {
-		t.Errorf("TotalOutputTokens = %d, want 2000",
-			got.TotalOutputTokens)
-	}
-	if got.PeakContextTokens != 8000 {
-		t.Errorf("PeakContextTokens = %d, want 8000",
-			got.PeakContextTokens)
-	}
-	if !got.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = false, want true")
-	}
-	if !got.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = false, want true")
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, got, "expected session")
+	assert.Equal(t, 2000, got.TotalOutputTokens, "TotalOutputTokens")
+	assert.Equal(t, 8000, got.PeakContextTokens, "PeakContextTokens")
+	assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens")
+	assert.True(t, got.HasPeakContextTokens, "HasPeakContextTokens")
 
 	// Update with new token values.
 	s.TotalOutputTokens = 2500
 	s.PeakContextTokens = 9000
-	requireNoError(t, d.UpsertSession(s), "upsert update")
+	require.NoError(t, d.UpsertSession(s), "upsert update")
 
 	got, err = d.GetSession(ctx, "s1")
-	requireNoError(t, err, "GetSession after update")
-	if got.TotalOutputTokens != 2500 {
-		t.Errorf("TotalOutputTokens after update = %d, want 2500",
-			got.TotalOutputTokens)
-	}
-	if got.PeakContextTokens != 9000 {
-		t.Errorf("PeakContextTokens after update = %d, want 9000",
-			got.PeakContextTokens)
-	}
-	if !got.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens after update = false, want true")
-	}
-	if !got.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens after update = false, want true")
-	}
+	require.NoError(t, err, "GetSession after update")
+	assert.Equal(t, 2500, got.TotalOutputTokens, "TotalOutputTokens after update")
+	assert.Equal(t, 9000, got.PeakContextTokens, "PeakContextTokens after update")
+	assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens after update")
+	assert.True(t, got.HasPeakContextTokens, "HasPeakContextTokens after update")
 }
 
 func TestSessionTokenUsageDefaultsToZero(t *testing.T) {
@@ -281,24 +213,12 @@ func TestSessionTokenUsageDefaultsToZero(t *testing.T) {
 	insertSession(t, d, "s1", "proj")
 
 	got, err := d.GetSession(ctx, "s1")
-	requireNoError(t, err, "GetSession")
-	if got == nil {
-		t.Fatal("expected session, got nil")
-	}
-	if got.TotalOutputTokens != 0 {
-		t.Errorf("TotalOutputTokens = %d, want 0",
-			got.TotalOutputTokens)
-	}
-	if got.PeakContextTokens != 0 {
-		t.Errorf("PeakContextTokens = %d, want 0",
-			got.PeakContextTokens)
-	}
-	if got.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = true, want false")
-	}
-	if got.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = true, want false")
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, got, "expected session")
+	assert.Equal(t, 0, got.TotalOutputTokens, "TotalOutputTokens")
+	assert.Equal(t, 0, got.PeakContextTokens, "PeakContextTokens")
+	assert.False(t, got.HasTotalOutputTokens, "HasTotalOutputTokens")
+	assert.False(t, got.HasPeakContextTokens, "HasPeakContextTokens")
 }
 
 func TestMessageTokenUsageDefaultsToZero(t *testing.T) {
@@ -310,31 +230,14 @@ func TestMessageTokenUsageDefaultsToZero(t *testing.T) {
 	insertMessages(t, d, userMsg("s1", 0, "hello"))
 
 	got, err := d.GetMessages(ctx, "s1", 0, 100, true)
-	requireNoError(t, err, "GetMessages")
-	if len(got) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(got))
-	}
-	if got[0].Model != "" {
-		t.Errorf("Model = %q, want empty", got[0].Model)
-	}
-	if len(got[0].TokenUsage) != 0 {
-		t.Errorf("TokenUsage = %q, want empty",
-			string(got[0].TokenUsage))
-	}
-	if got[0].ContextTokens != 0 {
-		t.Errorf("ContextTokens = %d, want 0",
-			got[0].ContextTokens)
-	}
-	if got[0].OutputTokens != 0 {
-		t.Errorf("OutputTokens = %d, want 0",
-			got[0].OutputTokens)
-	}
-	if got[0].HasContextTokens {
-		t.Error("HasContextTokens = true, want false")
-	}
-	if got[0].HasOutputTokens {
-		t.Error("HasOutputTokens = true, want false")
-	}
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, got, 1)
+	assert.Empty(t, got[0].Model, "Model")
+	assert.Empty(t, got[0].TokenUsage, "TokenUsage")
+	assert.Equal(t, 0, got[0].ContextTokens, "ContextTokens")
+	assert.Equal(t, 0, got[0].OutputTokens, "OutputTokens")
+	assert.False(t, got[0].HasContextTokens, "HasContextTokens")
+	assert.False(t, got[0].HasOutputTokens, "HasOutputTokens")
 }
 
 func TestGetSessionFullTokenUsage(t *testing.T) {
@@ -350,21 +253,13 @@ func TestGetSessionFullTokenUsage(t *testing.T) {
 		TotalOutputTokens: 600,
 		PeakContextTokens: 4000,
 	}
-	requireNoError(t, d.UpsertSession(s), "upsert")
+	require.NoError(t, d.UpsertSession(s), "upsert")
 
 	got, err := d.GetSessionFull(ctx, "s1")
-	requireNoError(t, err, "GetSessionFull")
-	if got == nil {
-		t.Fatal("expected session, got nil")
-	}
-	if got.TotalOutputTokens != 600 {
-		t.Errorf("TotalOutputTokens = %d, want 600",
-			got.TotalOutputTokens)
-	}
-	if got.PeakContextTokens != 4000 {
-		t.Errorf("PeakContextTokens = %d, want 4000",
-			got.PeakContextTokens)
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, got, "expected session")
+	assert.Equal(t, 600, got.TotalOutputTokens, "TotalOutputTokens")
+	assert.Equal(t, 4000, got.PeakContextTokens, "PeakContextTokens")
 }
 
 func TestReplaceSessionMessagesTokenUsage(t *testing.T) {
@@ -395,38 +290,21 @@ func TestReplaceSessionMessagesTokenUsage(t *testing.T) {
 		HasContextTokens: true,
 		HasOutputTokens:  true,
 	}}
-	requireNoError(t,
+	require.NoError(t,
 		d.ReplaceSessionMessages("s1", newMsgs),
 		"ReplaceSessionMessages",
 	)
 
 	got, err := d.GetMessages(ctx, "s1", 0, 100, true)
-	requireNoError(t, err, "GetMessages after replace")
-	if len(got) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(got))
-	}
-	if got[0].Model != "claude-sonnet-4-20250514" {
-		t.Errorf("Model = %q, want %q",
-			got[0].Model, "claude-sonnet-4-20250514")
-	}
-	if string(got[0].TokenUsage) != `{"input":999,"output":888}` {
-		t.Errorf("TokenUsage = %q, want %q",
-			string(got[0].TokenUsage), `{"input":999,"output":888}`)
-	}
-	if got[0].ContextTokens != 700 {
-		t.Errorf("ContextTokens = %d, want 700",
-			got[0].ContextTokens)
-	}
-	if got[0].OutputTokens != 888 {
-		t.Errorf("OutputTokens = %d, want 888",
-			got[0].OutputTokens)
-	}
-	if !got[0].HasContextTokens {
-		t.Error("HasContextTokens = false, want true")
-	}
-	if !got[0].HasOutputTokens {
-		t.Error("HasOutputTokens = false, want true")
-	}
+	require.NoError(t, err, "GetMessages after replace")
+	require.Len(t, got, 1)
+	assert.Equal(t, "claude-sonnet-4-20250514", got[0].Model, "Model")
+	assert.Equal(t, `{"input":999,"output":888}`, string(got[0].TokenUsage),
+		"TokenUsage")
+	assert.Equal(t, 700, got[0].ContextTokens, "ContextTokens")
+	assert.Equal(t, 888, got[0].OutputTokens, "OutputTokens")
+	assert.True(t, got[0].HasContextTokens, "HasContextTokens")
+	assert.True(t, got[0].HasOutputTokens, "HasOutputTokens")
 }
 
 func TestListSessionsTokenUsage(t *testing.T) {
@@ -444,29 +322,16 @@ func TestListSessionsTokenUsage(t *testing.T) {
 		HasTotalOutputTokens: true,
 		HasPeakContextTokens: true,
 	}
-	requireNoError(t, d.UpsertSession(s), "upsert")
+	require.NoError(t, d.UpsertSession(s), "upsert")
 
 	page, err := d.ListSessions(ctx, SessionFilter{})
-	requireNoError(t, err, "ListSessions")
-	if len(page.Sessions) != 1 {
-		t.Fatalf("expected 1 session, got %d",
-			len(page.Sessions))
-	}
+	require.NoError(t, err, "ListSessions")
+	require.Len(t, page.Sessions, 1)
 	got := page.Sessions[0]
-	if got.TotalOutputTokens != 222 {
-		t.Errorf("TotalOutputTokens = %d, want 222",
-			got.TotalOutputTokens)
-	}
-	if got.PeakContextTokens != 5000 {
-		t.Errorf("PeakContextTokens = %d, want 5000",
-			got.PeakContextTokens)
-	}
-	if !got.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = false, want true")
-	}
-	if !got.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = false, want true")
-	}
+	assert.Equal(t, 222, got.TotalOutputTokens, "TotalOutputTokens")
+	assert.Equal(t, 5000, got.PeakContextTokens, "PeakContextTokens")
+	assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens")
+	assert.True(t, got.HasPeakContextTokens, "HasPeakContextTokens")
 }
 
 func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
@@ -488,7 +353,7 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 		FileSize:             new(int64(2048)),
 		FileMtime:            new(int64(100)),
 	}
-	requireNoError(t, d.UpsertSession(s), "upsert")
+	require.NoError(t, d.UpsertSession(s), "upsert")
 
 	t.Run("metadata-only update preserves tokens", func(t *testing.T) {
 		// Simulate a no-new-messages incremental update that
@@ -499,28 +364,14 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 			"inc-tokens", &ended, 5, 2, 4096, 200,
 			1000, 8000, true, true,
 		)
-		requireNoError(t, err, "incremental update")
+		require.NoError(t, err, "incremental update")
 
 		got, err := d.GetSessionFull(ctx, "inc-tokens")
-		requireNoError(t, err, "get session")
-		if got.TotalOutputTokens != 1000 {
-			t.Errorf(
-				"TotalOutputTokens = %d, want 1000",
-				got.TotalOutputTokens,
-			)
-		}
-		if got.PeakContextTokens != 8000 {
-			t.Errorf(
-				"PeakContextTokens = %d, want 8000",
-				got.PeakContextTokens,
-			)
-		}
-		if !got.HasTotalOutputTokens {
-			t.Error("HasTotalOutputTokens = false, want true")
-		}
-		if !got.HasPeakContextTokens {
-			t.Error("HasPeakContextTokens = false, want true")
-		}
+		require.NoError(t, err, "get session")
+		assert.Equal(t, 1000, got.TotalOutputTokens, "TotalOutputTokens")
+		assert.Equal(t, 8000, got.PeakContextTokens, "PeakContextTokens")
+		assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens")
+		assert.True(t, got.HasPeakContextTokens, "HasPeakContextTokens")
 	})
 
 	t.Run("update with new messages advances tokens", func(t *testing.T) {
@@ -529,28 +380,14 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 			"inc-tokens", &ended, 8, 3, 8192, 300,
 			1500, 9000, true, true,
 		)
-		requireNoError(t, err, "incremental update")
+		require.NoError(t, err, "incremental update")
 
 		got, err := d.GetSessionFull(ctx, "inc-tokens")
-		requireNoError(t, err, "get session")
-		if got.TotalOutputTokens != 1500 {
-			t.Errorf(
-				"TotalOutputTokens = %d, want 1500",
-				got.TotalOutputTokens,
-			)
-		}
-		if got.PeakContextTokens != 9000 {
-			t.Errorf(
-				"PeakContextTokens = %d, want 9000",
-				got.PeakContextTokens,
-			)
-		}
-		if !got.HasTotalOutputTokens {
-			t.Error("HasTotalOutputTokens = false, want true")
-		}
-		if !got.HasPeakContextTokens {
-			t.Error("HasPeakContextTokens = false, want true")
-		}
+		require.NoError(t, err, "get session")
+		assert.Equal(t, 1500, got.TotalOutputTokens, "TotalOutputTokens")
+		assert.Equal(t, 9000, got.PeakContextTokens, "PeakContextTokens")
+		assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens")
+		assert.True(t, got.HasPeakContextTokens, "HasPeakContextTokens")
 	})
 
 	t.Run("idempotent retry does not inflate tokens", func(t *testing.T) {
@@ -561,22 +398,13 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 			"inc-tokens", &ended, 8, 3, 8192, 300,
 			1500, 9000, true, true,
 		)
-		requireNoError(t, err, "retry update")
+		require.NoError(t, err, "retry update")
 
 		got, err := d.GetSessionFull(ctx, "inc-tokens")
-		requireNoError(t, err, "get session")
-		if got.TotalOutputTokens != 1500 {
-			t.Errorf(
-				"TotalOutputTokens = %d, want 1500"+
-					" (retry inflated)",
-				got.TotalOutputTokens,
-			)
-		}
-		if !got.HasTotalOutputTokens {
-			t.Error("HasTotalOutputTokens = false, want true")
-		}
-		if !got.HasPeakContextTokens {
-			t.Error("HasPeakContextTokens = false, want true")
-		}
+		require.NoError(t, err, "get session")
+		assert.Equal(t, 1500, got.TotalOutputTokens,
+			"TotalOutputTokens (retry inflated)")
+		assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens")
+		assert.True(t, got.HasPeakContextTokens, "HasPeakContextTokens")
 	})
 }

--- a/internal/db/trends_test.go
+++ b/internal/db/trends_test.go
@@ -2,10 +2,11 @@ package db
 
 import (
 	"context"
-	"slices"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseTrendTerms(t *testing.T) {
@@ -15,44 +16,27 @@ func TestParseTrendTerms(t *testing.T) {
 		"seam | Seam | seams",
 		"slic",
 	})
-	if err != nil {
-		t.Fatalf("ParseTrendTerms: %v", err)
-	}
-	if got[0].Term != "load bearing" {
-		t.Fatalf("term label = %q", got[0].Term)
-	}
-	if want := []string{"load bearing", "load-bearing"}; !slices.Equal(got[0].Variants, want) {
-		t.Fatalf("variants = %#v, want %#v", got[0].Variants, want)
-	}
-	if want := []string{"seam", "seams"}; !slices.Equal(got[1].Matchers, want) {
-		t.Fatalf("matchers = %#v, want %#v", got[1].Matchers, want)
-	}
-	if got[2].Term != "seam" {
-		t.Fatalf("deduped term label = %q", got[2].Term)
-	}
-	if want := []string{"seam", "seams"}; !slices.Equal(got[2].Variants, want) {
-		t.Fatalf("deduped variants = %#v, want %#v", got[2].Variants, want)
-	}
-	if want := []string{"slic", "slics", "slice", "slices", "sliced", "slicing"}; !slices.Equal(got[3].Matchers, want) {
-		t.Fatalf("stem matchers = %#v, want %#v", got[3].Matchers, want)
-	}
+	require.NoError(t, err, "ParseTrendTerms")
+	assert.Equal(t, "load bearing", got[0].Term, "term label")
+	assert.Equal(t, []string{"load bearing", "load-bearing"}, got[0].Variants, "variants")
+	assert.Equal(t, []string{"seam", "seams"}, got[1].Matchers, "matchers")
+	assert.Equal(t, "seam", got[2].Term, "deduped term label")
+	assert.Equal(t, []string{"seam", "seams"}, got[2].Variants, "deduped variants")
+	assert.Equal(t, []string{"slic", "slics", "slice", "slices", "sliced", "slicing"},
+		got[3].Matchers, "stem matchers")
 }
 
 func TestParseTrendTermsValidation(t *testing.T) {
 	t.Run("empty input", func(t *testing.T) {
-		if _, err := ParseTrendTerms(nil); err == nil {
-			t.Fatal("expected error")
-		}
+		_, err := ParseTrendTerms(nil)
+		require.Error(t, err)
 	})
 
 	t.Run("empty rows dropped before limit", func(t *testing.T) {
 		got, err := ParseTrendTerms([]string{"", "  ", "seam"})
-		if err != nil {
-			t.Fatalf("ParseTrendTerms: %v", err)
-		}
-		if len(got) != 1 || got[0].Term != "seam" {
-			t.Fatalf("terms = %#v, want only seam", got)
-		}
+		require.NoError(t, err, "ParseTrendTerms")
+		require.Len(t, got, 1, "terms")
+		assert.Equal(t, "seam", got[0].Term)
 	})
 
 	t.Run("more than 12 terms", func(t *testing.T) {
@@ -61,26 +45,20 @@ func TestParseTrendTermsValidation(t *testing.T) {
 			values[i] = "term"
 		}
 		_, err := ParseTrendTerms(values)
-		if err == nil || !strings.Contains(err.Error(), "at most 12") {
-			t.Fatalf("error = %v, want max terms", err)
-		}
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at most 12", "want max terms")
 	})
 
 	t.Run("more than 8 variants after dedupe", func(t *testing.T) {
 		_, err := ParseTrendTerms([]string{"a|b|c|d|e|f|g|h|i"})
-		if err == nil || !strings.Contains(err.Error(), "at most 8") {
-			t.Fatalf("error = %v, want max variants", err)
-		}
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at most 8", "want max variants")
 	})
 
 	t.Run("variant limit after dedupe", func(t *testing.T) {
 		got, err := ParseTrendTerms([]string{"a|A|b|c|d|e|f|g|h"})
-		if err != nil {
-			t.Fatalf("ParseTrendTerms: %v", err)
-		}
-		if len(got[0].Variants) != MaxTrendTermVariants {
-			t.Fatalf("variant count = %d, want %d", len(got[0].Variants), MaxTrendTermVariants)
-		}
+		require.NoError(t, err, "ParseTrendTerms")
+		assert.Len(t, got[0].Variants, MaxTrendTermVariants, "variant count")
 	})
 }
 
@@ -101,25 +79,19 @@ func TestCountTrendOccurrences(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := countTrendOccurrences(tc.text, term); got != tc.want {
-				t.Fatalf("count = %d, want %d", got, tc.want)
-			}
+			assert.Equal(t, tc.want, countTrendOccurrences(tc.text, term))
 		})
 	}
 }
 
 func TestCountTrendOccurrencesSilentEStem(t *testing.T) {
 	terms, err := ParseTrendTerms([]string{"slic"})
-	if err != nil {
-		t.Fatalf("ParseTrendTerms: %v", err)
-	}
+	require.NoError(t, err, "ParseTrendTerms")
 	got := countTrendOccurrences(
 		"slice slices sliced slicing slicer sliced-up",
 		terms[0],
 	)
-	if got != 5 {
-		t.Fatalf("count = %d, want 5", got)
-	}
+	assert.Equal(t, 5, got)
 }
 
 func TestCountTrendOccurrencesPhrases(t *testing.T) {
@@ -129,9 +101,7 @@ func TestCountTrendOccurrencesPhrases(t *testing.T) {
 		Matchers: []string{"load bearing", "load-bearing"},
 	}
 	got := countTrendOccurrences("Load bearing and load-bearing", term)
-	if got != 2 {
-		t.Fatalf("count = %d, want 2", got)
-	}
+	assert.Equal(t, 2, got)
 }
 
 func TestTrendBucketDate(t *testing.T) {
@@ -147,9 +117,7 @@ func TestTrendBucketDate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		parsed, _ := time.Parse(time.RFC3339, tc.ts)
-		if got := trendBucketDate(parsed, loc, tc.gran); got != tc.want {
-			t.Fatalf("%s got %s want %s", tc.gran, got, tc.want)
-		}
+		assert.Equal(t, tc.want, trendBucketDate(parsed, loc, tc.gran), tc.gran)
 	}
 }
 
@@ -169,37 +137,23 @@ func TestGetTrendsTermsSQLite(t *testing.T) {
 		Message{SessionID: "s1", Ordinal: 2, Role: "user", Content: "seam system", Timestamp: "2024-06-08T09:00:00Z", ContentLength: 11, IsSystem: true},
 	)
 	terms, err := ParseTrendTerms([]string{"load bearing | load-bearing", "seam"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
 		From: "2024-06-01", To: "2024-06-09", Timezone: "UTC",
 	}, terms, "week")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if want := []string{"2024-05-27", "2024-06-03"}; !slices.Equal(trendBucketDates(got.Buckets), want) {
-		t.Fatalf("bucket dates = %#v, want %#v", trendBucketDates(got.Buckets), want)
-	}
-	if want := []int{1, 1}; !slices.Equal(trendBucketMessageCounts(got.Buckets), want) {
-		t.Fatalf("bucket message counts = %#v, want %#v", trendBucketMessageCounts(got.Buckets), want)
-	}
-	if got.MessageCount != 2 {
-		t.Fatalf("message count = %d, want 2", got.MessageCount)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, []string{"2024-05-27", "2024-06-03"},
+		trendBucketDates(got.Buckets), "bucket dates")
+	assert.Equal(t, []int{1, 1}, trendBucketMessageCounts(got.Buckets),
+		"bucket message counts")
+	assert.Equal(t, 2, got.MessageCount, "message count")
 	byTerm := trendSeriesByTerm(got.Series)
-	if got := byTerm["load bearing"].Total; got != 2 {
-		t.Fatalf("load bearing total = %d, want 2", got)
-	}
-	if got := byTerm["seam"].Total; got != 3 {
-		t.Fatalf("seam total = %d, want 3", got)
-	}
-	if want := []int{1, 1}; !slices.Equal(trendPointCounts(byTerm["load bearing"].Points), want) {
-		t.Fatalf("load bearing points = %#v, want %#v", trendPointCounts(byTerm["load bearing"].Points), want)
-	}
-	if want := []int{1, 2}; !slices.Equal(trendPointCounts(byTerm["seam"].Points), want) {
-		t.Fatalf("seam points = %#v, want %#v", trendPointCounts(byTerm["seam"].Points), want)
-	}
+	assert.Equal(t, 2, byTerm["load bearing"].Total, "load bearing total")
+	assert.Equal(t, 3, byTerm["seam"].Total, "seam total")
+	assert.Equal(t, []int{1, 1}, trendPointCounts(byTerm["load bearing"].Points),
+		"load bearing points")
+	assert.Equal(t, []int{1, 2}, trendPointCounts(byTerm["seam"].Points),
+		"seam points")
 }
 
 func TestGetTrendsTermsSQLiteProjectFilter(t *testing.T) {
@@ -223,18 +177,13 @@ func TestGetTrendsTermsSQLiteProjectFilter(t *testing.T) {
 		Message{SessionID: "s2", Ordinal: 0, Role: "user", Content: "seam", Timestamp: start, ContentLength: 4},
 	)
 	terms, err := ParseTrendTerms([]string{"seam"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
 		From: "2024-06-01", To: "2024-06-01", Timezone: "UTC", Project: "proj-a",
 	}, terms, "day")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
-		t.Fatalf("project-filtered total = %d, want 1", got)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, 1, trendSeriesByTerm(got.Series)["seam"].Total,
+		"project-filtered total")
 }
 
 func TestGetTrendsTermsSQLiteUsesMessageTimestampRange(t *testing.T) {
@@ -252,18 +201,13 @@ func TestGetTrendsTermsSQLiteUsesMessageTimestampRange(t *testing.T) {
 		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "seam", Timestamp: "2024-06-05T09:00:00Z", ContentLength: 4},
 	)
 	terms, err := ParseTrendTerms([]string{"seam"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
 		From: "2024-06-05", To: "2024-06-05", Timezone: "UTC",
 	}, terms, "day")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
-		t.Fatalf("message timestamp total = %d, want 1", got)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, 1, trendSeriesByTerm(got.Series)["seam"].Total,
+		"message timestamp total")
 }
 
 func TestGetTrendsTermsSQLiteDoesNotFilterBySessionTimestamp(t *testing.T) {
@@ -279,18 +223,13 @@ func TestGetTrendsTermsSQLiteDoesNotFilterBySessionTimestamp(t *testing.T) {
 		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "seam", Timestamp: "2024-06-05T09:00:00Z", ContentLength: 4},
 	)
 	terms, err := ParseTrendTerms([]string{"seam"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
 		From: "2024-06-05", To: "2024-06-05", Timezone: "UTC",
 	}, terms, "day")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
-		t.Fatalf("message timestamp total = %d, want 1", got)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, 1, trendSeriesByTerm(got.Series)["seam"].Total,
+		"message timestamp total")
 }
 
 func TestGetTrendsTermsSQLiteAppliesDayAndHourToMessageTimestamp(t *testing.T) {
@@ -307,9 +246,7 @@ func TestGetTrendsTermsSQLiteAppliesDayAndHourToMessageTimestamp(t *testing.T) {
 		Message{SessionID: "s1", Ordinal: 1, Role: "user", Content: "seam", Timestamp: "2024-06-05T10:00:00Z", ContentLength: 4},
 	)
 	terms, err := ParseTrendTerms([]string{"seam"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	dow := 2
 	hour := 9
 	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
@@ -319,12 +256,9 @@ func TestGetTrendsTermsSQLiteAppliesDayAndHourToMessageTimestamp(t *testing.T) {
 		DayOfWeek: &dow,
 		Hour:      &hour,
 	}, terms, "day")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
-		t.Fatalf("hour-filtered message total = %d, want 1", got)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, 1, trendSeriesByTerm(got.Series)["seam"].Total,
+		"hour-filtered message total")
 }
 
 func TestGetTrendsTermsSQLiteTimestampFallback(t *testing.T) {
@@ -342,18 +276,13 @@ func TestGetTrendsTermsSQLiteTimestampFallback(t *testing.T) {
 		Message{SessionID: "s1", Ordinal: 0, Role: "user", Content: "seam", Timestamp: "not-a-time", ContentLength: 4},
 	)
 	terms, err := ParseTrendTerms([]string{"seam"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
 		From: "2024-06-05", To: "2024-06-05", Timezone: "UTC",
 	}, terms, "day")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
-		t.Fatalf("fallback timestamp total = %d, want 1", got)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, 1, trendSeriesByTerm(got.Series)["seam"].Total,
+		"fallback timestamp total")
 }
 
 func TestGetTrendsTermsSQLiteExcludesLegacySystemPrefixes(t *testing.T) {
@@ -371,18 +300,13 @@ func TestGetTrendsTermsSQLiteExcludesLegacySystemPrefixes(t *testing.T) {
 		Message{SessionID: "s1", Ordinal: 1, Role: "user", Content: "seam", Timestamp: start, ContentLength: 4},
 	)
 	terms, err := ParseTrendTerms([]string{"seam"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	got, err := d.GetTrendsTerms(ctx, AnalyticsFilter{
 		From: "2024-06-01", To: "2024-06-01", Timezone: "UTC",
 	}, terms, "day")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
-		t.Fatalf("system-prefix-filtered total = %d, want 1", got)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, 1, trendSeriesByTerm(got.Series)["seam"].Total,
+		"system-prefix-filtered total")
 }
 
 func trendBucketDates(buckets []TrendBucket) []string {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -24,9 +24,7 @@ func TestGetDailyUsageEmpty(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage empty")
 
-	if result.Daily == nil {
-		t.Fatal("Daily should be non-nil empty slice")
-	}
+	require.NotNil(t, result.Daily, "Daily should be non-nil empty slice")
 	assert.Len(t, result.Daily, 0, "got")
 	assert.Equal(t, 0.0, result.Totals.TotalCost, "TotalCost")
 }
@@ -65,27 +63,25 @@ func TestUsageEventsReplaceAndList(t *testing.T) {
 	got, err := d.GetUsageEvents(ctx, "hermes:event")
 	require.NoError(t, err, "GetUsageEvents")
 	require.Len(t, got, 1, "len")
-	if got[0].InputTokens != 100 ||
-		got[0].OutputTokens != 50 ||
-		got[0].CacheCreationInputTokens != 7 ||
-		got[0].CacheReadInputTokens != 11 ||
-		got[0].ReasoningTokens != 13 {
-		t.Fatalf("token fields not round-tripped: %#v", got[0])
-	}
-	if got[0].MessageOrdinal == nil || *got[0].MessageOrdinal != 3 {
-		t.Fatalf("MessageOrdinal = %#v, want 3", got[0].MessageOrdinal)
-	}
-	if got[0].CostUSD == nil || *got[0].CostUSD != cost {
-		t.Fatalf("CostUSD = %#v, want %v", got[0].CostUSD, cost)
-	}
-	if got[0].DedupKey != "session:hermes:event" {
-		t.Fatalf("DedupKey = %q", got[0].DedupKey)
-	}
+	require.Equal(t, 100, got[0].InputTokens,
+		"InputTokens (token fields not round-tripped: %#v)", got[0])
+	require.Equal(t, 50, got[0].OutputTokens,
+		"OutputTokens (token fields not round-tripped: %#v)", got[0])
+	require.Equal(t, 7, got[0].CacheCreationInputTokens,
+		"CacheCreationInputTokens (token fields not round-tripped: %#v)", got[0])
+	require.Equal(t, 11, got[0].CacheReadInputTokens,
+		"CacheReadInputTokens (token fields not round-tripped: %#v)", got[0])
+	require.Equal(t, 13, got[0].ReasoningTokens,
+		"ReasoningTokens (token fields not round-tripped: %#v)", got[0])
+	require.NotNil(t, got[0].MessageOrdinal, "MessageOrdinal want 3")
+	require.Equal(t, 3, *got[0].MessageOrdinal, "MessageOrdinal")
+	require.NotNil(t, got[0].CostUSD, "CostUSD want %v", cost)
+	require.Equal(t, cost, *got[0].CostUSD, "CostUSD")
+	require.Equal(t, "session:hermes:event", got[0].DedupKey, "DedupKey")
 	fps, err := d.UsageEventFingerprints([]string{"hermes:event", "missing"})
 	require.NoError(t, err, "UsageEventFingerprints")
-	if fps["hermes:event"] == "" {
-		t.Fatal("expected non-empty usage event fingerprint")
-	}
+	require.NotEmpty(t, fps["hermes:event"],
+		"expected non-empty usage event fingerprint")
 	require.Equal(t, "", fps["missing"], "missing fingerprint")
 
 	err = d.ReplaceSessionUsageEvents("hermes:event", nil)
@@ -149,23 +145,15 @@ func TestGetDailyUsageWithData(t *testing.T) {
 	//      = 11340 / 1_000_000
 	//      = 0.01134
 	wantCost := 0.01134
-	if math.Abs(day.TotalCost-wantCost) > 1e-9 {
-		t.Errorf("TotalCost = %v, want %v",
-			day.TotalCost, wantCost)
-	}
+	assert.InDelta(t, wantCost, day.TotalCost, 1e-9, "TotalCost")
 
-	if len(day.ModelsUsed) != 1 ||
-		day.ModelsUsed[0] != "claude-sonnet-4-20250514" {
-		t.Errorf("ModelsUsed = %v, want [claude-sonnet-4-20250514]",
-			day.ModelsUsed)
-	}
+	assert.Equal(t, []string{"claude-sonnet-4-20250514"},
+		day.ModelsUsed, "ModelsUsed")
 
 	// Totals should match single day
 	assert.Equal(t, 1000, result.Totals.InputTokens, "Totals.InputTokens")
-	if math.Abs(result.Totals.TotalCost-wantCost) > 1e-9 {
-		t.Errorf("Totals.TotalCost = %v, want %v",
-			result.Totals.TotalCost, wantCost)
-	}
+	assert.InDelta(t, wantCost, result.Totals.TotalCost, 1e-9,
+		"Totals.TotalCost")
 }
 
 func TestUsageQueriesUnionMessageAndUsageEvents(t *testing.T) {
@@ -229,16 +217,15 @@ func TestUsageQueriesUnionMessageAndUsageEvents(t *testing.T) {
 	}
 	daily, err := d.GetDailyUsage(ctx, filter)
 	requireNoError(t, err, "GetDailyUsage")
-	if daily.Totals.InputTokens != 450 ||
-		daily.Totals.OutputTokens != 115 ||
-		daily.Totals.CacheReadTokens != 20 {
-		t.Fatalf("daily totals = %#v", daily.Totals)
-	}
+	require.Equal(t, 450, daily.Totals.InputTokens,
+		"daily totals: %#v", daily.Totals)
+	require.Equal(t, 115, daily.Totals.OutputTokens,
+		"daily totals: %#v", daily.Totals)
+	require.Equal(t, 20, daily.Totals.CacheReadTokens,
+		"daily totals: %#v", daily.Totals)
 	require.Len(t, daily.Daily, 1, "daily entries =")
-	if len(daily.Daily[0].AgentBreakdowns) != 2 {
-		t.Fatalf("agent breakdowns = %#v",
-			daily.Daily[0].AgentBreakdowns)
-	}
+	require.Len(t, daily.Daily[0].AgentBreakdowns, 2,
+		"agent breakdowns: %#v", daily.Daily[0].AgentBreakdowns)
 
 	top, err := d.GetTopSessionsByCost(ctx, filter, 10)
 	requireNoError(t, err, "GetTopSessionsByCost")
@@ -246,25 +233,20 @@ func TestUsageQueriesUnionMessageAndUsageEvents(t *testing.T) {
 	for _, entry := range top {
 		topByID[entry.SessionID] = entry
 	}
-	if topByID["claude:msg"].TotalTokens != 140 {
-		t.Fatalf("claude top tokens = %#v", topByID["claude:msg"])
-	}
-	if topByID["hermes:event"].TotalTokens != 390 {
-		t.Fatalf("hermes top tokens = %#v", topByID["hermes:event"])
-	}
-	if topByID["hermes:event-2"].TotalTokens != 55 {
-		t.Fatalf("second hermes top tokens = %#v", topByID["hermes:event-2"])
-	}
+	require.Equal(t, 140, topByID["claude:msg"].TotalTokens,
+		"claude top tokens: %#v", topByID["claude:msg"])
+	require.Equal(t, 390, topByID["hermes:event"].TotalTokens,
+		"hermes top tokens: %#v", topByID["hermes:event"])
+	require.Equal(t, 55, topByID["hermes:event-2"].TotalTokens,
+		"second hermes top tokens: %#v", topByID["hermes:event-2"])
 
 	counts, err := d.GetUsageSessionCounts(ctx, filter)
 	requireNoError(t, err, "GetUsageSessionCounts")
-	if counts.Total != 3 ||
-		counts.ByAgent["claude"] != 1 ||
-		counts.ByAgent["hermes"] != 2 ||
-		counts.ByProject["proj-a"] != 1 ||
-		counts.ByProject["proj-b"] != 2 {
-		t.Fatalf("counts = %#v", counts)
-	}
+	require.Equal(t, 3, counts.Total, "counts: %#v", counts)
+	require.Equal(t, 1, counts.ByAgent["claude"], "counts: %#v", counts)
+	require.Equal(t, 2, counts.ByAgent["hermes"], "counts: %#v", counts)
+	require.Equal(t, 1, counts.ByProject["proj-a"], "counts: %#v", counts)
+	require.Equal(t, 2, counts.ByProject["proj-b"], "counts: %#v", counts)
 }
 
 // TestGetDailyUsage_CacheSavingsUsesPerModelRates pins down
@@ -334,27 +316,16 @@ func TestGetDailyUsage_CacheSavingsUsesPerModelRates(t *testing.T) {
 	// Sonnet savings on 1M + 1M = 2.70 + (-0.75) = 1.95.
 	// Net total savings = 9.75 + 1.95 = 11.70.
 	wantSavings := 11.70
-	if math.Abs(
-		result.Totals.CacheSavings-wantSavings,
-	) > 1e-9 {
-		t.Errorf(
-			"Totals.CacheSavings = %v, want %v",
-			result.Totals.CacheSavings, wantSavings,
-		)
-	}
+	assert.InDelta(t, wantSavings, result.Totals.CacheSavings, 1e-9,
+		"Totals.CacheSavings")
 
 	// Falsification: if the code had used Sonnet rates for
 	// both rows the total would be 2 * 1.95 = 3.90, which
 	// differs from wantSavings by >$7. Assert we're nowhere
 	// near that value so a regression to a single-rate path
 	// trips the test.
-	if math.Abs(result.Totals.CacheSavings-3.90) < 0.1 {
-		t.Errorf(
-			"CacheSavings = %v looks like single-rate path; "+
-				"expected per-model math",
-			result.Totals.CacheSavings,
-		)
-	}
+	assert.Greater(t, math.Abs(result.Totals.CacheSavings-3.90), 0.1,
+		"CacheSavings looks like single-rate path; expected per-model math")
 }
 
 func TestGetDailyUsageAgentFilter(t *testing.T) {
@@ -499,10 +470,8 @@ func TestGetDailyUsageMultipleDaysAndModels(t *testing.T) {
 	//             day2 model-a = (300*2+150*10)/1e6 = 0.0021
 	//             total = 0.0056
 	wantTotalCost := 0.0056
-	if math.Abs(result.Totals.TotalCost-wantTotalCost) > 1e-9 {
-		t.Errorf("Totals.TotalCost = %v, want %v",
-			result.Totals.TotalCost, wantTotalCost)
-	}
+	assert.InDelta(t, wantTotalCost, result.Totals.TotalCost, 1e-9,
+		"Totals.TotalCost")
 }
 
 func TestGetDailyUsageNoPricing(t *testing.T) {
@@ -534,11 +503,8 @@ func TestGetDailyUsageNoPricing(t *testing.T) {
 	assert.Equal(t, 500, day.InputTokens, "InputTokens")
 	assert.Equal(t, 250, day.OutputTokens, "OutputTokens")
 	assert.Equal(t, 0.0, day.TotalCost, "TotalCost")
-	if len(day.ModelsUsed) != 1 ||
-		day.ModelsUsed[0] != "unknown-model" {
-		t.Errorf("ModelsUsed = %v, want [unknown-model]",
-			day.ModelsUsed)
-	}
+	assert.Equal(t, []string{"unknown-model"}, day.ModelsUsed,
+		"ModelsUsed")
 }
 
 // TestGetDailyUsageTruncatedTokenJSON documents what happens when
@@ -592,31 +558,26 @@ func TestGetDailyUsageTruncatedTokenJSON(t *testing.T) {
 	require.Len(t, result.Daily, 1, "got")
 	day := result.Daily[0]
 	// 1000 (valid row) + 9999 (truncated but still parseable)
-	if day.InputTokens != 10999 {
-		t.Errorf("InputTokens = %d, want 10999 "+
-			"(gjson should extract leading fields from truncated JSON)",
-			day.InputTokens)
-	}
+	assert.Equal(t, 10999, day.InputTokens,
+		"InputTokens want 10999 "+
+			"(gjson should extract leading fields from truncated JSON)")
 	assert.Equal(t, 4742, day.OutputTokens, "OutputTokens")
 }
 
 func TestGetDailyUsage_DedupesByClaudeMessageAndRequestID(t *testing.T) {
 	d := testDB(t)
-	if err := d.UpsertModelPricing([]ModelPricing{{
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
 		ModelPattern:         "claude-opus-4-6",
 		InputPerMTok:         15.0,
 		OutputPerMTok:        75.0,
 		CacheCreationPerMTok: 18.75,
 		CacheReadPerMTok:     1.50,
-	}}); err != nil {
-		t.Fatalf("seed pricing: %v", err)
-	}
+	}}), "seed pricing")
 
 	mustExec := func(q string, args ...any) {
 		t.Helper()
-		if _, err := d.getWriter().Exec(q, args...); err != nil {
-			t.Fatalf("exec %q: %v", q, err)
-		}
+		_, err := d.getWriter().Exec(q, args...)
+		require.NoError(t, err, "exec %q", q)
 	}
 	mustExec(`INSERT INTO sessions (id, project, machine, agent, started_at, ended_at)
 	          VALUES (?, ?, 'local', 'claude', ?, ?)`,
@@ -659,18 +620,15 @@ func TestGetDailyUsage_DedupesByClaudeMessageAndRequestID(t *testing.T) {
 
 func TestGetDailyUsage_MissingDedupKeysCountedEveryTime(t *testing.T) {
 	d := testDB(t)
-	if err := d.UpsertModelPricing([]ModelPricing{{
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
 		ModelPattern:  "claude-opus-4-6",
 		OutputPerMTok: 75.0,
-	}}); err != nil {
-		t.Fatalf("seed pricing: %v", err)
-	}
+	}}), "seed pricing")
 
 	mustExec := func(q string, args ...any) {
 		t.Helper()
-		if _, err := d.getWriter().Exec(q, args...); err != nil {
-			t.Fatalf("exec %q: %v", q, err)
-		}
+		_, err := d.getWriter().Exec(q, args...)
+		require.NoError(t, err, "exec %q", q)
 	}
 	mustExec(`INSERT INTO sessions (id, project, machine, agent, started_at, ended_at)
 	          VALUES ('s1', 'proj', 'local', 'claude', ?, ?)`,
@@ -691,9 +649,10 @@ func TestGetDailyUsage_MissingDedupKeysCountedEveryTime(t *testing.T) {
 		From: "2026-04-10", To: "2026-04-10", Timezone: "UTC",
 	})
 	require.NoError(t, err, "GetDailyUsage")
-	if len(result.Daily) != 1 || result.Daily[0].OutputTokens != 20 {
-		t.Errorf("output = %v, want 20 (both no-key rows counted)", result.Daily)
-	}
+	require.Len(t, result.Daily, 1,
+		"output want 20 (both no-key rows counted): %v", result.Daily)
+	assert.Equal(t, 20, result.Daily[0].OutputTokens,
+		"output want 20 (both no-key rows counted): %v", result.Daily)
 }
 
 func TestGetDailyUsageLongLivedSession(t *testing.T) {
@@ -848,10 +807,7 @@ func TestGetDailyUsageModelFilter(t *testing.T) {
 	require.Len(t, result.Daily, 1, "got")
 	day := result.Daily[0]
 	assert.Equal(t, 1000, day.InputTokens, "InputTokens")
-	if len(day.ModelsUsed) != 1 || day.ModelsUsed[0] != "gpt-5" {
-		t.Errorf("ModelsUsed = %v, want [gpt-5]",
-			day.ModelsUsed)
-	}
+	assert.Equal(t, []string{"gpt-5"}, day.ModelsUsed, "ModelsUsed")
 }
 
 func TestGetDailyUsageProjectBreakdowns(t *testing.T) {
@@ -909,19 +865,15 @@ func TestGetDailyUsageProjectBreakdowns(t *testing.T) {
 	}
 	for _, name := range []string{"proj-a", "proj-b"} {
 		pb, ok := projMap[name]
-		if !ok {
-			t.Errorf("missing ProjectBreakdown for %s", name)
+		if !assert.Truef(t, ok,
+			"missing ProjectBreakdown for %s", name) {
 			continue
 		}
-		if pb.InputTokens != 1000 {
-			t.Errorf("%s InputTokens = %d, want 1000",
-				name, pb.InputTokens)
-		}
+		assert.Equal(t, 1000, pb.InputTokens,
+			"%s InputTokens", name)
 	}
-	if math.Abs(projCostSum-day.TotalCost) > 1e-9 {
-		t.Errorf("sum(ProjectBreakdowns.Cost) = %v, "+
-			"want TotalCost = %v", projCostSum, day.TotalCost)
-	}
+	assert.InDelta(t, day.TotalCost, projCostSum, 1e-9,
+		"sum(ProjectBreakdowns.Cost) want TotalCost")
 }
 
 func TestGetDailyUsageAgentBreakdowns(t *testing.T) {
@@ -979,19 +931,15 @@ func TestGetDailyUsageAgentBreakdowns(t *testing.T) {
 	}
 	for _, name := range []string{"claude", "codex"} {
 		ab, ok := agentMap[name]
-		if !ok {
-			t.Errorf("missing AgentBreakdown for %s", name)
+		if !assert.Truef(t, ok,
+			"missing AgentBreakdown for %s", name) {
 			continue
 		}
-		if ab.InputTokens != 1000 {
-			t.Errorf("%s InputTokens = %d, want 1000",
-				name, ab.InputTokens)
-		}
+		assert.Equal(t, 1000, ab.InputTokens,
+			"%s InputTokens", name)
 	}
-	if math.Abs(agentCostSum-day.TotalCost) > 1e-9 {
-		t.Errorf("sum(AgentBreakdowns.Cost) = %v, "+
-			"want TotalCost = %v", agentCostSum, day.TotalCost)
-	}
+	assert.InDelta(t, day.TotalCost, agentCostSum, 1e-9,
+		"sum(AgentBreakdowns.Cost) want TotalCost")
 }
 
 func TestGetDailyUsageBreakdownInvariant(t *testing.T) {
@@ -1066,26 +1014,16 @@ func TestGetDailyUsageBreakdownInvariant(t *testing.T) {
 		agentCostSum += ab.Cost
 	}
 
-	if math.Abs(modelCostSum-day.TotalCost) > 1e-9 {
-		t.Errorf("sum(ModelBreakdowns.Cost) = %v, "+
-			"want TotalCost = %v", modelCostSum, day.TotalCost)
-	}
-	if math.Abs(projectCostSum-day.TotalCost) > 1e-9 {
-		t.Errorf("sum(ProjectBreakdowns.Cost) = %v, "+
-			"want TotalCost = %v", projectCostSum, day.TotalCost)
-	}
-	if math.Abs(agentCostSum-day.TotalCost) > 1e-9 {
-		t.Errorf("sum(AgentBreakdowns.Cost) = %v, "+
-			"want TotalCost = %v", agentCostSum, day.TotalCost)
-	}
-	if math.Abs(modelCostSum-projectCostSum) > 1e-9 {
-		t.Errorf("model cost sum %v != project cost sum %v",
-			modelCostSum, projectCostSum)
-	}
-	if math.Abs(modelCostSum-agentCostSum) > 1e-9 {
-		t.Errorf("model cost sum %v != agent cost sum %v",
-			modelCostSum, agentCostSum)
-	}
+	assert.InDelta(t, day.TotalCost, modelCostSum, 1e-9,
+		"sum(ModelBreakdowns.Cost) want TotalCost")
+	assert.InDelta(t, day.TotalCost, projectCostSum, 1e-9,
+		"sum(ProjectBreakdowns.Cost) want TotalCost")
+	assert.InDelta(t, day.TotalCost, agentCostSum, 1e-9,
+		"sum(AgentBreakdowns.Cost) want TotalCost")
+	assert.InDelta(t, projectCostSum, modelCostSum, 1e-9,
+		"model cost sum != project cost sum")
+	assert.InDelta(t, agentCostSum, modelCostSum, 1e-9,
+		"model cost sum != agent cost sum")
 }
 
 // BenchmarkGetDailyUsage measures the hot-path scan over a realistic
@@ -1154,15 +1092,11 @@ func TestGetTopSessionsByCost(t *testing.T) {
 	assert.Equal(t, "claude", top[0].Agent, "top[0].Agent")
 	// TotalTokens = 5000 + 2000 + 1000 + 3000 = 11000
 	assert.Equal(t, 11000, top[0].TotalTokens, "top[0].TotalTokens")
-	if top[0].Cost <= 0 {
-		t.Errorf("top[0].Cost = %v, want > 0", top[0].Cost)
-	}
+	assert.Greater(t, top[0].Cost, 0.0, "top[0].Cost want > 0")
 
 	assert.Equal(t, "sSmall", top[1].SessionID, "top[1].SessionID")
-	if top[0].Cost <= top[1].Cost {
-		t.Errorf("top[0].Cost (%v) should be > top[1].Cost (%v)",
-			top[0].Cost, top[1].Cost)
-	}
+	assert.Greater(t, top[0].Cost, top[1].Cost,
+		"top[0].Cost should be > top[1].Cost")
 }
 
 func TestGetTopSessionsByCost_DisplayNameFallback(t *testing.T) {
@@ -1248,22 +1182,14 @@ func TestGetTopSessionsByCost_DisplayNameFallback(t *testing.T) {
 		byID[e.SessionID] = e
 	}
 
-	if got := byID["s-dn"].DisplayName; got != "My Custom Name" {
-		t.Errorf("s-dn DisplayName = %q, want %q",
-			got, "My Custom Name")
-	}
-	if got := byID["s-fm"].DisplayName; got != "fix the login bug" {
-		t.Errorf("s-fm DisplayName = %q, want %q",
-			got, "fix the login bug")
-	}
-	if got := byID["s-proj"].DisplayName; got != "my-project" {
-		t.Errorf("s-proj DisplayName = %q, want %q",
-			got, "my-project")
-	}
-	if got := byID["s-id"].DisplayName; got != "s-id" {
-		t.Errorf("s-id DisplayName = %q, want %q",
-			got, "s-id")
-	}
+	assert.Equal(t, "My Custom Name", byID["s-dn"].DisplayName,
+		"s-dn DisplayName")
+	assert.Equal(t, "fix the login bug", byID["s-fm"].DisplayName,
+		"s-fm DisplayName")
+	assert.Equal(t, "my-project", byID["s-proj"].DisplayName,
+		"s-proj DisplayName")
+	assert.Equal(t, "s-id", byID["s-id"].DisplayName,
+		"s-id DisplayName")
 }
 
 // TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID
@@ -1353,11 +1279,9 @@ func TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID(
 	// Fork should only own the unique message: 10+20 = 30
 	// tokens. If the dedup were missing, the shared row would
 	// be counted again and this would jump to 4730.
-	if fork.TotalTokens != 30 {
-		t.Errorf("fork.TotalTokens = %d, want 30 "+
-			"(shared message should be deduped)",
-			fork.TotalTokens)
-	}
+	assert.Equal(t, 30, fork.TotalTokens,
+		"fork.TotalTokens want 30 "+
+			"(shared message should be deduped)")
 
 	// Total across both entries must equal the undeduped
 	// message sum: parent 4700 + fork 30 = 4730.
@@ -1516,24 +1440,10 @@ func TestGetUsageSessionCounts_DedupesByClaudeMessageAndRequestID(
 	})
 	requireNoError(t, err, "GetUsageSessionCounts")
 
-	if counts.Total != 1 {
-		t.Errorf(
-			"Total = %d, want 1 (fork should dedup out)",
-			counts.Total,
-		)
-	}
-	if counts.ByProject["proj"] != 1 {
-		t.Errorf(
-			"ByProject[proj] = %d, want 1",
-			counts.ByProject["proj"],
-		)
-	}
-	if counts.ByAgent["claude"] != 1 {
-		t.Errorf(
-			"ByAgent[claude] = %d, want 1",
-			counts.ByAgent["claude"],
-		)
-	}
+	assert.Equal(t, 1, counts.Total,
+		"Total want 1 (fork should dedup out)")
+	assert.Equal(t, 1, counts.ByProject["proj"], "ByProject[proj]")
+	assert.Equal(t, 1, counts.ByAgent["claude"], "ByAgent[claude]")
 }
 
 // TestUsageQueryEligibilityParity seeds messages that fail each
@@ -1623,10 +1533,8 @@ func TestUsageQueryEligibilityParity(t *testing.T) {
 	top, err := d.GetTopSessionsByCost(ctx, filter, 20)
 	requireNoError(t, err, "GetTopSessionsByCost parity")
 	require.Len(t, top, 1, "GetTopSessionsByCost len")
-	if top[0].SessionID != "good" {
-		t.Errorf("GetTopSessionsByCost[0].SessionID = %q, "+
-			"want good", top[0].SessionID)
-	}
+	assert.Equal(t, "good", top[0].SessionID,
+		"GetTopSessionsByCost[0].SessionID")
 }
 
 // TestExcludeProjectFilter verifies that ExcludeProject removes
@@ -1688,9 +1596,8 @@ func TestExcludeProjectFilter(t *testing.T) {
 	requireNoError(t, err, "GetTopSessionsByCost exclude")
 	require.Len(t, top, 2, "exclude proj-b: top len =")
 	for _, ts := range top {
-		if ts.Project == "proj-b" {
-			t.Errorf("excluded proj-b still in top sessions")
-		}
+		assert.NotEqual(t, "proj-b", ts.Project,
+			"excluded proj-b still in top sessions")
 	}
 
 	// GetUsageSessionCounts with exclude.
@@ -1749,12 +1656,11 @@ func TestUsageSessionFilters(t *testing.T) {
 		s.UserMessageCount = 3
 		s.StartedAt = new("2024-06-15T10:00:00Z")
 	})
-	if _, err := d.getWriter().Exec(
+	_, err := d.getWriter().Exec(
 		"UPDATE sessions SET is_automated = 1 WHERE id = ?",
 		"usage-filter-automated",
-	); err != nil {
-		t.Fatalf("patch automated fixture: %v", err)
-	}
+	)
+	require.NoError(t, err, "patch automated fixture")
 
 	for _, sid := range []string{
 		"usage-filter-keep",
@@ -1788,9 +1694,10 @@ func TestUsageSessionFilters(t *testing.T) {
 
 	top, err := d.GetTopSessionsByCost(ctx, filter, 10)
 	requireNoError(t, err, "GetTopSessionsByCost session filters")
-	if len(top) != 1 || top[0].SessionID != "usage-filter-keep" {
-		t.Fatalf("top sessions = %+v, want only usage-filter-keep", top)
-	}
+	require.Len(t, top, 1,
+		"top sessions want only usage-filter-keep: %+v", top)
+	require.Equal(t, "usage-filter-keep", top[0].SessionID,
+		"top sessions want only usage-filter-keep: %+v", top)
 
 	counts, err := d.GetUsageSessionCounts(ctx, filter)
 	requireNoError(t, err, "GetUsageSessionCounts session filters")
@@ -1850,10 +1757,10 @@ func TestUsageExcludeOneShotUsesUserMessageCount(t *testing.T) {
 
 	top, err := d.GetTopSessionsByCost(ctx, filter, 10)
 	requireNoError(t, err, "GetTopSessionsByCost exclude one-shot")
-	if len(top) != 1 || top[0].SessionID != "usage-two-user-messages" {
-		t.Fatalf("top sessions = %+v, want only usage-two-user-messages",
-			top)
-	}
+	require.Len(t, top, 1,
+		"top sessions want only usage-two-user-messages: %+v", top)
+	require.Equal(t, "usage-two-user-messages", top[0].SessionID,
+		"top sessions want only usage-two-user-messages: %+v", top)
 
 	counts, err := d.GetUsageSessionCounts(ctx, filter)
 	requireNoError(t, err, "GetUsageSessionCounts exclude one-shot")
@@ -1938,9 +1845,8 @@ func TestExcludeModelFilter(t *testing.T) {
 	assert.Equal(t, 1000, daily.Totals.InputTokens, "exclude opus: InputTokens")
 	require.Len(t, daily.Daily, 1, "daily len =")
 	for _, mb := range daily.Daily[0].ModelBreakdowns {
-		if mb.ModelName == "opus" {
-			t.Errorf("excluded model opus still in breakdowns")
-		}
+		assert.NotEqual(t, "opus", mb.ModelName,
+			"excluded model opus still in breakdowns")
 	}
 }
 
@@ -2118,22 +2024,19 @@ func TestGetDailyUsage_PricingPrecedence(t *testing.T) {
 			})
 			requireNoError(t, err, "GetDailyUsage")
 
-			if math.Abs(result.Totals.TotalCost-tt.wantCost) > 0.01 {
-				t.Errorf("TotalCost = %.4f, want %.4f", result.Totals.TotalCost, tt.wantCost)
-			}
+			assert.InDelta(t, tt.wantCost, result.Totals.TotalCost, 0.01,
+				"TotalCost")
 		})
 	}
 }
 
 func seedOpusPricing(t *testing.T, d *DB) {
 	t.Helper()
-	if err := d.UpsertModelPricing([]ModelPricing{{
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
 		ModelPattern: "claude-opus-4-6",
 		InputPerMTok: 5.0, OutputPerMTok: 25.0,
 		CacheCreationPerMTok: 6.25, CacheReadPerMTok: 0.5,
-	}}); err != nil {
-		t.Fatalf("UpsertModelPricing: %v", err)
-	}
+	}}), "UpsertModelPricing")
 }
 
 func TestGetSessionUsage_PricedModel(t *testing.T) {
@@ -2158,23 +2061,15 @@ func TestGetSessionUsage_PricedModel(t *testing.T) {
 
 	u, err := d.GetSessionUsage(ctx, "claude:s1")
 	requireNoError(t, err, "GetSessionUsage")
-	if u == nil {
-		t.Fatal("usage is nil")
-	}
+	require.NotNil(t, u, "usage is nil")
 	require.True(t, u.HasCost, "HasCost = false, want true")
-	if math.Abs(u.CostUSD-0.0175) > 1e-9 {
-		t.Errorf("CostUSD = %v, want 0.0175", u.CostUSD)
-	}
-	if u.TotalOutputTokens != 500 || u.PeakContextTokens != 1200 {
-		t.Errorf("token fields = %d/%d, want 500/1200",
-			u.TotalOutputTokens, u.PeakContextTokens)
-	}
-	if len(u.Models) != 1 || u.Models[0] != "claude-opus-4-6" {
-		t.Errorf("Models = %v, want [claude-opus-4-6]", u.Models)
-	}
-	if len(u.UnpricedModels) != 0 {
-		t.Errorf("UnpricedModels = %v, want empty", u.UnpricedModels)
-	}
+	assert.InDelta(t, 0.0175, u.CostUSD, 1e-9, "CostUSD")
+	assert.Equal(t, 500, u.TotalOutputTokens,
+		"TotalOutputTokens want 500")
+	assert.Equal(t, 1200, u.PeakContextTokens,
+		"PeakContextTokens want 1200")
+	assert.Equal(t, []string{"claude-opus-4-6"}, u.Models, "Models")
+	assert.Empty(t, u.UnpricedModels, "UnpricedModels")
 }
 
 func TestGetSessionUsage_UnpricedModel(t *testing.T) {
@@ -2197,9 +2092,8 @@ func TestGetSessionUsage_UnpricedModel(t *testing.T) {
 	requireNoError(t, err, "GetSessionUsage")
 	assert.False(t, u.HasCost, "HasCost = true, want false (unpriced)")
 	assert.Equal(t, 0.0, u.CostUSD, "CostUSD")
-	if len(u.UnpricedModels) != 1 || u.UnpricedModels[0] != "local-llama-99" {
-		t.Errorf("UnpricedModels = %v, want [local-llama-99]", u.UnpricedModels)
-	}
+	assert.Equal(t, []string{"local-llama-99"}, u.UnpricedModels,
+		"UnpricedModels")
 }
 
 func TestGetSessionUsage_MixedPricedUnpriced(t *testing.T) {
@@ -2229,9 +2123,8 @@ func TestGetSessionUsage_MixedPricedUnpriced(t *testing.T) {
 	requireNoError(t, err, "GetSessionUsage")
 	assert.False(t, u.HasCost, "HasCost = true, want false (mixed)")
 	assert.Equal(t, 0.0, u.CostUSD, "CostUSD")
-	if len(u.UnpricedModels) != 1 || u.UnpricedModels[0] != "local-llama-99" {
-		t.Errorf("UnpricedModels = %v, want [local-llama-99]", u.UnpricedModels)
-	}
+	assert.Equal(t, []string{"local-llama-99"}, u.UnpricedModels,
+		"UnpricedModels")
 }
 
 func TestGetSessionUsage_ExplicitCostOnly(t *testing.T) {
@@ -2242,24 +2135,18 @@ func TestGetSessionUsage_ExplicitCostOnly(t *testing.T) {
 		s.StartedAt = new("2026-05-20T10:00:00Z")
 	})
 	cost := 0.02
-	if err := d.ReplaceSessionUsageEvents("hermes:s4", []UsageEvent{{
+	require.NoError(t, d.ReplaceSessionUsageEvents("hermes:s4", []UsageEvent{{
 		SessionID: "hermes:s4", Source: "session", Model: "gpt-5.4",
 		InputTokens: 100, OutputTokens: 50,
 		CostUSD: &cost, CostStatus: "estimated", CostSource: "hermes",
 		OccurredAt: "2026-05-20T10:05:00Z", DedupKey: "session:hermes:s4",
-	}}); err != nil {
-		t.Fatalf("ReplaceSessionUsageEvents: %v", err)
-	}
+	}}), "ReplaceSessionUsageEvents")
 
 	u, err := d.GetSessionUsage(ctx, "hermes:s4")
 	requireNoError(t, err, "GetSessionUsage")
 	assert.True(t, u.HasCost, "HasCost = false, want true (explicit cost)")
-	if math.Abs(u.CostUSD-0.02) > 1e-9 {
-		t.Errorf("CostUSD = %v, want 0.02", u.CostUSD)
-	}
-	if len(u.Models) != 1 || u.Models[0] != "gpt-5.4" {
-		t.Errorf("Models = %v, want [gpt-5.4]", u.Models)
-	}
+	assert.InDelta(t, 0.02, u.CostUSD, 1e-9, "CostUSD")
+	assert.Equal(t, []string{"gpt-5.4"}, u.Models, "Models")
 }
 
 func TestGetSessionUsage_DedupesDuplicateClaudeRows(t *testing.T) {
@@ -2289,9 +2176,7 @@ func TestGetSessionUsage_DedupesDuplicateClaudeRows(t *testing.T) {
 	u, err := d.GetSessionUsage(ctx, "claude:s6")
 	requireNoError(t, err, "GetSessionUsage")
 	// One row priced at 1000*5/1e6 + 500*25/1e6 = 0.0175; deduped, not 0.035.
-	if math.Abs(u.CostUSD-0.0175) > 1e-9 {
-		t.Errorf("CostUSD = %v, want 0.0175 (deduped)", u.CostUSD)
-	}
+	assert.InDelta(t, 0.0175, u.CostUSD, 1e-9, "CostUSD want 0.0175 (deduped)")
 	assert.True(t, u.HasCost, "HasCost = false, want true")
 }
 
@@ -2309,18 +2194,14 @@ func TestGetSessionUsage_NoTokenRowsKeepsMetadata(t *testing.T) {
 
 	u, err := d.GetSessionUsage(ctx, "claude:s5")
 	requireNoError(t, err, "GetSessionUsage")
-	if u == nil {
-		t.Fatal("usage is nil")
-	}
-	if u.TotalOutputTokens != 700 || u.PeakContextTokens != 3000 {
-		t.Errorf("tokens = %d/%d, want 700/3000",
-			u.TotalOutputTokens, u.PeakContextTokens)
-	}
+	require.NotNil(t, u, "usage is nil")
+	assert.Equal(t, 700, u.TotalOutputTokens,
+		"TotalOutputTokens want 700")
+	assert.Equal(t, 3000, u.PeakContextTokens,
+		"PeakContextTokens want 3000")
 	assert.True(t, u.HasTokenData, "HasTokenData = false, want true")
 	assert.False(t, u.HasCost, "HasCost = true, want false (no cost rows)")
-	if u.Models == nil {
-		t.Error("Models = nil, want non-nil empty slice")
-	}
+	assert.NotNil(t, u.Models, "Models = nil, want non-nil empty slice")
 }
 
 func TestGetSessionUsage_NotFound(t *testing.T) {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -24,14 +27,8 @@ func TestGetDailyUsageEmpty(t *testing.T) {
 	if result.Daily == nil {
 		t.Fatal("Daily should be non-nil empty slice")
 	}
-	if len(result.Daily) != 0 {
-		t.Errorf("got %d daily entries, want 0",
-			len(result.Daily))
-	}
-	if result.Totals.TotalCost != 0 {
-		t.Errorf("TotalCost = %v, want 0",
-			result.Totals.TotalCost)
-	}
+	assert.Len(t, result.Daily, 0, "got")
+	assert.Equal(t, 0.0, result.Totals.TotalCost, "TotalCost")
 }
 
 func TestUsageEventsReplaceAndList(t *testing.T) {
@@ -62,17 +59,12 @@ func TestUsageEventsReplaceAndList(t *testing.T) {
 		OccurredAt:               "2026-05-14T10:05:00Z",
 		DedupKey:                 "session:hermes:event",
 	}}
-	if err := d.ReplaceSessionUsageEvents("hermes:event", events); err != nil {
-		t.Fatalf("ReplaceSessionUsageEvents: %v", err)
-	}
+	err := d.ReplaceSessionUsageEvents("hermes:event", events)
+	require.NoError(t, err, "ReplaceSessionUsageEvents")
 
 	got, err := d.GetUsageEvents(ctx, "hermes:event")
-	if err != nil {
-		t.Fatalf("GetUsageEvents: %v", err)
-	}
-	if len(got) != 1 {
-		t.Fatalf("got %d events, want 1", len(got))
-	}
+	require.NoError(t, err, "GetUsageEvents")
+	require.Len(t, got, 1, "len")
 	if got[0].InputTokens != 100 ||
 		got[0].OutputTokens != 50 ||
 		got[0].CacheCreationInputTokens != 7 ||
@@ -90,26 +82,17 @@ func TestUsageEventsReplaceAndList(t *testing.T) {
 		t.Fatalf("DedupKey = %q", got[0].DedupKey)
 	}
 	fps, err := d.UsageEventFingerprints([]string{"hermes:event", "missing"})
-	if err != nil {
-		t.Fatalf("UsageEventFingerprints: %v", err)
-	}
+	require.NoError(t, err, "UsageEventFingerprints")
 	if fps["hermes:event"] == "" {
 		t.Fatal("expected non-empty usage event fingerprint")
 	}
-	if fps["missing"] != "" {
-		t.Fatalf("missing fingerprint = %q, want empty", fps["missing"])
-	}
+	require.Equal(t, "", fps["missing"], "missing fingerprint")
 
-	if err := d.ReplaceSessionUsageEvents("hermes:event", nil); err != nil {
-		t.Fatalf("ReplaceSessionUsageEvents clear: %v", err)
-	}
+	err = d.ReplaceSessionUsageEvents("hermes:event", nil)
+	require.NoError(t, err, "ReplaceSessionUsageEvents clear")
 	got, err = d.GetUsageEvents(ctx, "hermes:event")
-	if err != nil {
-		t.Fatalf("GetUsageEvents after clear: %v", err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("usage events after clear = %d, want 0", len(got))
-	}
+	require.NoError(t, err, "GetUsageEvents after clear")
+	require.Len(t, got, 0, "usage events after clear =")
 }
 
 func TestGetDailyUsageWithData(t *testing.T) {
@@ -152,32 +135,14 @@ func TestGetDailyUsageWithData(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 
 	day := result.Daily[0]
-	if day.Date != "2024-06-15" {
-		t.Errorf("Date = %q, want %q",
-			day.Date, "2024-06-15")
-	}
-	if day.InputTokens != 1000 {
-		t.Errorf("InputTokens = %d, want 1000",
-			day.InputTokens)
-	}
-	if day.OutputTokens != 500 {
-		t.Errorf("OutputTokens = %d, want 500",
-			day.OutputTokens)
-	}
-	if day.CacheCreationTokens != 200 {
-		t.Errorf("CacheCreationTokens = %d, want 200",
-			day.CacheCreationTokens)
-	}
-	if day.CacheReadTokens != 300 {
-		t.Errorf("CacheReadTokens = %d, want 300",
-			day.CacheReadTokens)
-	}
+	assert.Equal(t, "2024-06-15", day.Date, "Date")
+	assert.Equal(t, 1000, day.InputTokens, "InputTokens")
+	assert.Equal(t, 500, day.OutputTokens, "OutputTokens")
+	assert.Equal(t, 200, day.CacheCreationTokens, "CacheCreationTokens")
+	assert.Equal(t, 300, day.CacheReadTokens, "CacheReadTokens")
 
 	// Cost = (1000*3.0 + 500*15.0 + 200*3.75 + 300*0.30) / 1_000_000
 	//      = (3000 + 7500 + 750 + 90) / 1_000_000
@@ -196,10 +161,7 @@ func TestGetDailyUsageWithData(t *testing.T) {
 	}
 
 	// Totals should match single day
-	if result.Totals.InputTokens != 1000 {
-		t.Errorf("Totals.InputTokens = %d, want 1000",
-			result.Totals.InputTokens)
-	}
+	assert.Equal(t, 1000, result.Totals.InputTokens, "Totals.InputTokens")
 	if math.Abs(result.Totals.TotalCost-wantCost) > 1e-9 {
 		t.Errorf("Totals.TotalCost = %v, want %v",
 			result.Totals.TotalCost, wantCost)
@@ -272,9 +234,7 @@ func TestUsageQueriesUnionMessageAndUsageEvents(t *testing.T) {
 		daily.Totals.CacheReadTokens != 20 {
 		t.Fatalf("daily totals = %#v", daily.Totals)
 	}
-	if len(daily.Daily) != 1 {
-		t.Fatalf("daily entries = %d, want 1", len(daily.Daily))
-	}
+	require.Len(t, daily.Daily, 1, "daily entries =")
 	if len(daily.Daily[0].AgentBreakdowns) != 2 {
 		t.Fatalf("agent breakdowns = %#v",
 			daily.Daily[0].AgentBreakdowns)
@@ -445,20 +405,11 @@ func TestGetDailyUsageAgentFilter(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage agent filter")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 
 	day := result.Daily[0]
-	if day.InputTokens != 1000 {
-		t.Errorf("InputTokens = %d, want 1000 (claude only)",
-			day.InputTokens)
-	}
-	if day.OutputTokens != 500 {
-		t.Errorf("OutputTokens = %d, want 500 (claude only)",
-			day.OutputTokens)
-	}
+	assert.Equal(t, 1000, day.InputTokens, "InputTokens")
+	assert.Equal(t, 500, day.OutputTokens, "OutputTokens")
 }
 
 func TestGetDailyUsageMultipleDaysAndModels(t *testing.T) {
@@ -523,50 +474,25 @@ func TestGetDailyUsageMultipleDaysAndModels(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage multi")
 
-	if len(result.Daily) != 2 {
-		t.Fatalf("got %d daily entries, want 2",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 2, "got")
 
 	// Day 1: check totals
 	d1 := result.Daily[0]
-	if d1.Date != "2024-06-10" {
-		t.Errorf("day1 Date = %q, want 2024-06-10", d1.Date)
-	}
-	if d1.InputTokens != 300 {
-		t.Errorf("day1 InputTokens = %d, want 300",
-			d1.InputTokens)
-	}
-	if d1.OutputTokens != 150 {
-		t.Errorf("day1 OutputTokens = %d, want 150",
-			d1.OutputTokens)
-	}
-	if len(d1.ModelsUsed) != 2 {
-		t.Errorf("day1 ModelsUsed count = %d, want 2",
-			len(d1.ModelsUsed))
-	}
+	assert.Equal(t, "2024-06-10", d1.Date, "day1 Date")
+	assert.Equal(t, 300, d1.InputTokens, "day1 InputTokens")
+	assert.Equal(t, 150, d1.OutputTokens, "day1 OutputTokens")
+	assert.Len(t, d1.ModelsUsed, 2, "day1 ModelsUsed count")
 
 	// Day 2
 	d2 := result.Daily[1]
-	if d2.Date != "2024-06-11" {
-		t.Errorf("day2 Date = %q, want 2024-06-11", d2.Date)
-	}
-	if d2.InputTokens != 300 {
-		t.Errorf("day2 InputTokens = %d, want 300",
-			d2.InputTokens)
-	}
+	assert.Equal(t, "2024-06-11", d2.Date, "day2 Date")
+	assert.Equal(t, 300, d2.InputTokens, "day2 InputTokens")
 
 	// Totals should sum both days
 	wantTotalInput := 600
-	if result.Totals.InputTokens != wantTotalInput {
-		t.Errorf("Totals.InputTokens = %d, want %d",
-			result.Totals.InputTokens, wantTotalInput)
-	}
+	assert.Equal(t, wantTotalInput, result.Totals.InputTokens, "Totals.InputTokens")
 	wantTotalOutput := 300
-	if result.Totals.OutputTokens != wantTotalOutput {
-		t.Errorf("Totals.OutputTokens = %d, want %d",
-			result.Totals.OutputTokens, wantTotalOutput)
-	}
+	assert.Equal(t, wantTotalOutput, result.Totals.OutputTokens, "Totals.OutputTokens")
 
 	// Cost check: day1 model-a = (100*2+50*10)/1e6 = 0.0007
 	//             day1 model-b = (200*4+100*20)/1e6 = 0.0028
@@ -602,24 +528,12 @@ func TestGetDailyUsageNoPricing(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage no pricing")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 
 	day := result.Daily[0]
-	if day.InputTokens != 500 {
-		t.Errorf("InputTokens = %d, want 500",
-			day.InputTokens)
-	}
-	if day.OutputTokens != 250 {
-		t.Errorf("OutputTokens = %d, want 250",
-			day.OutputTokens)
-	}
-	if day.TotalCost != 0 {
-		t.Errorf("TotalCost = %v, want 0 (no pricing)",
-			day.TotalCost)
-	}
+	assert.Equal(t, 500, day.InputTokens, "InputTokens")
+	assert.Equal(t, 250, day.OutputTokens, "OutputTokens")
+	assert.Equal(t, 0.0, day.TotalCost, "TotalCost")
 	if len(day.ModelsUsed) != 1 ||
 		day.ModelsUsed[0] != "unknown-model" {
 		t.Errorf("ModelsUsed = %v, want [unknown-model]",
@@ -675,10 +589,7 @@ func TestGetDailyUsageTruncatedTokenJSON(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage truncated")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 	day := result.Daily[0]
 	// 1000 (valid row) + 9999 (truncated but still parseable)
 	if day.InputTokens != 10999 {
@@ -686,9 +597,7 @@ func TestGetDailyUsageTruncatedTokenJSON(t *testing.T) {
 			"(gjson should extract leading fields from truncated JSON)",
 			day.InputTokens)
 	}
-	if day.OutputTokens != 4742 {
-		t.Errorf("OutputTokens = %d, want 4742", day.OutputTokens)
-	}
+	assert.Equal(t, 4742, day.OutputTokens, "OutputTokens")
 }
 
 func TestGetDailyUsage_DedupesByClaudeMessageAndRequestID(t *testing.T) {
@@ -739,25 +648,13 @@ func TestGetDailyUsage_DedupesByClaudeMessageAndRequestID(t *testing.T) {
 	result, err := d.GetDailyUsage(context.Background(), UsageFilter{
 		From: "2026-04-10", To: "2026-04-10", Timezone: "UTC",
 	})
-	if err != nil {
-		t.Fatalf("GetDailyUsage: %v", err)
-	}
-	if len(result.Daily) != 1 {
-		t.Fatalf("daily entries = %d, want 1", len(result.Daily))
-	}
+	require.NoError(t, err, "GetDailyUsage")
+	require.Len(t, result.Daily, 1, "daily entries =")
 	day := result.Daily[0]
-	if day.InputTokens != 120 {
-		t.Errorf("input = %d, want 120", day.InputTokens)
-	}
-	if day.OutputTokens != 580 {
-		t.Errorf("output = %d, want 580", day.OutputTokens)
-	}
-	if day.CacheCreationTokens != 1200 {
-		t.Errorf("cache_cr = %d, want 1200", day.CacheCreationTokens)
-	}
-	if day.CacheReadTokens != 55000 {
-		t.Errorf("cache_rd = %d, want 55000", day.CacheReadTokens)
-	}
+	assert.Equal(t, 120, day.InputTokens, "input")
+	assert.Equal(t, 580, day.OutputTokens, "output")
+	assert.Equal(t, 1200, day.CacheCreationTokens, "cache_cr")
+	assert.Equal(t, 55000, day.CacheReadTokens, "cache_rd")
 }
 
 func TestGetDailyUsage_MissingDedupKeysCountedEveryTime(t *testing.T) {
@@ -793,9 +690,7 @@ func TestGetDailyUsage_MissingDedupKeysCountedEveryTime(t *testing.T) {
 	result, err := d.GetDailyUsage(context.Background(), UsageFilter{
 		From: "2026-04-10", To: "2026-04-10", Timezone: "UTC",
 	})
-	if err != nil {
-		t.Fatalf("GetDailyUsage: %v", err)
-	}
+	require.NoError(t, err, "GetDailyUsage")
 	if len(result.Daily) != 1 || result.Daily[0].OutputTokens != 20 {
 		t.Errorf("output = %v, want 20 (both no-key rows counted)", result.Daily)
 	}
@@ -856,13 +751,8 @@ func TestGetDailyUsageLongLivedSession(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage long-lived")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("expected 1 day, got %d", len(result.Daily))
-	}
-	if result.Daily[0].InputTokens != 2000 {
-		t.Errorf("InputTokens = %d, want 2000",
-			result.Daily[0].InputTokens)
-	}
+	require.Len(t, result.Daily, 1, "expected 1 day")
+	assert.Equal(t, 2000, result.Daily[0].InputTokens, "InputTokens")
 }
 
 func TestGetDailyUsageProjectFilter(t *testing.T) {
@@ -908,19 +798,10 @@ func TestGetDailyUsageProjectFilter(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage project filter")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 	day := result.Daily[0]
-	if day.InputTokens != 1000 {
-		t.Errorf("InputTokens = %d, want 1000 (proj-a only)",
-			day.InputTokens)
-	}
-	if result.Totals.InputTokens != 1000 {
-		t.Errorf("Totals.InputTokens = %d, want 1000",
-			result.Totals.InputTokens)
-	}
+	assert.Equal(t, 1000, day.InputTokens, "InputTokens")
+	assert.Equal(t, 1000, result.Totals.InputTokens, "Totals.InputTokens")
 }
 
 func TestGetDailyUsageModelFilter(t *testing.T) {
@@ -964,15 +845,9 @@ func TestGetDailyUsageModelFilter(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage model filter")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 	day := result.Daily[0]
-	if day.InputTokens != 1000 {
-		t.Errorf("InputTokens = %d, want 1000 (gpt-5 only)",
-			day.InputTokens)
-	}
+	assert.Equal(t, 1000, day.InputTokens, "InputTokens")
 	if len(day.ModelsUsed) != 1 || day.ModelsUsed[0] != "gpt-5" {
 		t.Errorf("ModelsUsed = %v, want [gpt-5]",
 			day.ModelsUsed)
@@ -1022,15 +897,9 @@ func TestGetDailyUsageProjectBreakdowns(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage project breakdowns")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 	day := result.Daily[0]
-	if len(day.ProjectBreakdowns) != 2 {
-		t.Fatalf("ProjectBreakdowns len = %d, want 2",
-			len(day.ProjectBreakdowns))
-	}
+	require.Len(t, day.ProjectBreakdowns, 2, "ProjectBreakdowns len")
 
 	projMap := make(map[string]ProjectBreakdown)
 	var projCostSum float64
@@ -1098,15 +967,9 @@ func TestGetDailyUsageAgentBreakdowns(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage agent breakdowns")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 	day := result.Daily[0]
-	if len(day.AgentBreakdowns) != 2 {
-		t.Fatalf("AgentBreakdowns len = %d, want 2",
-			len(day.AgentBreakdowns))
-	}
+	require.Len(t, day.AgentBreakdowns, 2, "AgentBreakdowns len")
 
 	agentMap := make(map[string]AgentBreakdown)
 	var agentCostSum float64
@@ -1187,10 +1050,7 @@ func TestGetDailyUsageBreakdownInvariant(t *testing.T) {
 	})
 	requireNoError(t, err, "GetDailyUsage breakdown invariant")
 
-	if len(result.Daily) != 1 {
-		t.Fatalf("got %d daily entries, want 1",
-			len(result.Daily))
-	}
+	require.Len(t, result.Daily, 1, "got")
 	day := result.Daily[0]
 
 	var modelCostSum float64
@@ -1285,40 +1145,20 @@ func TestGetTopSessionsByCost(t *testing.T) {
 	}, 20)
 	requireNoError(t, err, "GetTopSessionsByCost")
 
-	if len(top) != 2 {
-		t.Fatalf("got %d entries, want 2", len(top))
-	}
+	require.Len(t, top, 2, "len")
 
 	// Ordered cost desc — sBig first
-	if top[0].SessionID != "sBig" {
-		t.Errorf("top[0].SessionID = %q, want sBig",
-			top[0].SessionID)
-	}
-	if top[0].DisplayName != "Big Session" {
-		t.Errorf("top[0].DisplayName = %q, want Big Session",
-			top[0].DisplayName)
-	}
-	if top[0].Project != "proj-a" {
-		t.Errorf("top[0].Project = %q, want proj-a",
-			top[0].Project)
-	}
-	if top[0].Agent != "claude" {
-		t.Errorf("top[0].Agent = %q, want claude",
-			top[0].Agent)
-	}
+	assert.Equal(t, "sBig", top[0].SessionID, "top[0].SessionID")
+	assert.Equal(t, "Big Session", top[0].DisplayName, "top[0].DisplayName")
+	assert.Equal(t, "proj-a", top[0].Project, "top[0].Project")
+	assert.Equal(t, "claude", top[0].Agent, "top[0].Agent")
 	// TotalTokens = 5000 + 2000 + 1000 + 3000 = 11000
-	if top[0].TotalTokens != 11000 {
-		t.Errorf("top[0].TotalTokens = %d, want 11000",
-			top[0].TotalTokens)
-	}
+	assert.Equal(t, 11000, top[0].TotalTokens, "top[0].TotalTokens")
 	if top[0].Cost <= 0 {
 		t.Errorf("top[0].Cost = %v, want > 0", top[0].Cost)
 	}
 
-	if top[1].SessionID != "sSmall" {
-		t.Errorf("top[1].SessionID = %q, want sSmall",
-			top[1].SessionID)
-	}
+	assert.Equal(t, "sSmall", top[1].SessionID, "top[1].SessionID")
 	if top[0].Cost <= top[1].Cost {
 		t.Errorf("top[0].Cost (%v) should be > top[1].Cost (%v)",
 			top[0].Cost, top[1].Cost)
@@ -1399,9 +1239,7 @@ func TestGetTopSessionsByCost_DisplayNameFallback(t *testing.T) {
 	}, 20)
 	requireNoError(t, err, "GetTopSessionsByCost fallback")
 
-	if len(top) != 4 {
-		t.Fatalf("got %d entries, want 4", len(top))
-	}
+	require.Len(t, top, 4, "len")
 
 	// Build a map for easy lookup (order is by cost, all equal
 	// here so secondary sort is by session ID).
@@ -1498,9 +1336,7 @@ func TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID(
 	}, 20)
 	requireNoError(t, err, "GetTopSessionsByCost")
 
-	if len(top) != 2 {
-		t.Fatalf("got %d entries, want 2", len(top))
-	}
+	require.Len(t, top, 2, "len")
 
 	byID := map[string]TopSessionEntry{}
 	for _, e := range top {
@@ -1508,19 +1344,12 @@ func TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID(
 	}
 
 	parent, ok := byID["s-parent"]
-	if !ok {
-		t.Fatal("s-parent missing from top sessions")
-	}
+	require.True(t, ok, "s-parent missing from top sessions")
 	// Parent owns shared: 1000+500+200+3000 = 4700 tokens.
-	if parent.TotalTokens != 4700 {
-		t.Errorf("parent.TotalTokens = %d, want 4700",
-			parent.TotalTokens)
-	}
+	assert.Equal(t, 4700, parent.TotalTokens, "parent.TotalTokens")
 
 	fork, ok := byID["s-fork"]
-	if !ok {
-		t.Fatal("s-fork missing from top sessions")
-	}
+	require.True(t, ok, "s-fork missing from top sessions")
 	// Fork should only own the unique message: 10+20 = 30
 	// tokens. If the dedup were missing, the shared row would
 	// be counted again and this would jump to 4730.
@@ -1533,10 +1362,7 @@ func TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID(
 	// Total across both entries must equal the undeduped
 	// message sum: parent 4700 + fork 30 = 4730.
 	total := parent.TotalTokens + fork.TotalTokens
-	if total != 4730 {
-		t.Errorf("sum of per-session totals = %d, want 4730",
-			total)
-	}
+	assert.Equal(t, 4730, total, "sum of per-session totals")
 }
 
 func TestGetTopSessionsByCostLimit(t *testing.T) {
@@ -1570,9 +1396,7 @@ func TestGetTopSessionsByCostLimit(t *testing.T) {
 	}, 3)
 	requireNoError(t, err, "GetTopSessionsByCost limit")
 
-	if len(top) != 3 {
-		t.Fatalf("got %d entries, want 3", len(top))
-	}
+	require.Len(t, top, 3, "len")
 }
 
 func TestGetUsageSessionCounts(t *testing.T) {
@@ -1633,25 +1457,11 @@ func TestGetUsageSessionCounts(t *testing.T) {
 	})
 	requireNoError(t, err, "GetUsageSessionCounts")
 
-	if counts.Total != 3 {
-		t.Errorf("Total = %d, want 3", counts.Total)
-	}
-	if counts.ByProject["proj-a"] != 2 {
-		t.Errorf("ByProject[proj-a] = %d, want 2",
-			counts.ByProject["proj-a"])
-	}
-	if counts.ByProject["proj-b"] != 1 {
-		t.Errorf("ByProject[proj-b] = %d, want 1",
-			counts.ByProject["proj-b"])
-	}
-	if counts.ByAgent["claude"] != 2 {
-		t.Errorf("ByAgent[claude] = %d, want 2",
-			counts.ByAgent["claude"])
-	}
-	if counts.ByAgent["codex"] != 1 {
-		t.Errorf("ByAgent[codex] = %d, want 1",
-			counts.ByAgent["codex"])
-	}
+	assert.Equal(t, 3, counts.Total, "Total")
+	assert.Equal(t, 2, counts.ByProject["proj-a"], "ByProject[proj-a]")
+	assert.Equal(t, 1, counts.ByProject["proj-b"], "ByProject[proj-b]")
+	assert.Equal(t, 2, counts.ByAgent["claude"], "ByAgent[claude]")
+	assert.Equal(t, 1, counts.ByAgent["codex"], "ByAgent[codex]")
 }
 
 // TestGetUsageSessionCounts_DedupesByClaudeMessageAndRequestID
@@ -1802,26 +1612,17 @@ func TestUsageQueryEligibilityParity(t *testing.T) {
 	// GetDailyUsage
 	daily, err := d.GetDailyUsage(ctx, filter)
 	requireNoError(t, err, "GetDailyUsage parity")
-	if daily.Totals.InputTokens != 1000 {
-		t.Errorf("GetDailyUsage InputTokens = %d, want 1000",
-			daily.Totals.InputTokens)
-	}
+	assert.Equal(t, 1000, daily.Totals.InputTokens, "GetDailyUsage InputTokens")
 
 	// GetUsageSessionCounts
 	counts, err := d.GetUsageSessionCounts(ctx, filter)
 	requireNoError(t, err, "GetUsageSessionCounts parity")
-	if counts.Total != 1 {
-		t.Errorf("GetUsageSessionCounts Total = %d, want 1",
-			counts.Total)
-	}
+	assert.Equal(t, 1, counts.Total, "GetUsageSessionCounts Total")
 
 	// GetTopSessionsByCost
 	top, err := d.GetTopSessionsByCost(ctx, filter, 20)
 	requireNoError(t, err, "GetTopSessionsByCost parity")
-	if len(top) != 1 {
-		t.Fatalf("GetTopSessionsByCost len = %d, want 1",
-			len(top))
-	}
+	require.Len(t, top, 1, "GetTopSessionsByCost len")
 	if top[0].SessionID != "good" {
 		t.Errorf("GetTopSessionsByCost[0].SessionID = %q, "+
 			"want good", top[0].SessionID)
@@ -1873,27 +1674,19 @@ func TestExcludeProjectFilter(t *testing.T) {
 	f1.ExcludeProject = "proj-b"
 	daily, err := d.GetDailyUsage(ctx, f1)
 	requireNoError(t, err, "GetDailyUsage exclude one")
-	if daily.Totals.InputTokens != 2000 {
-		t.Errorf("exclude proj-b: InputTokens = %d, want 2000",
-			daily.Totals.InputTokens)
-	}
+	assert.Equal(t, 2000, daily.Totals.InputTokens, "exclude proj-b: InputTokens")
 
 	// Exclude two projects (comma-separated).
 	f2 := base
 	f2.ExcludeProject = "proj-a,proj-c"
 	daily, err = d.GetDailyUsage(ctx, f2)
 	requireNoError(t, err, "GetDailyUsage exclude two")
-	if daily.Totals.InputTokens != 1000 {
-		t.Errorf("exclude a+c: InputTokens = %d, want 1000",
-			daily.Totals.InputTokens)
-	}
+	assert.Equal(t, 1000, daily.Totals.InputTokens, "exclude a+c: InputTokens")
 
 	// GetTopSessionsByCost with exclude.
 	top, err := d.GetTopSessionsByCost(ctx, f1, 10)
 	requireNoError(t, err, "GetTopSessionsByCost exclude")
-	if len(top) != 2 {
-		t.Fatalf("exclude proj-b: top len = %d, want 2", len(top))
-	}
+	require.Len(t, top, 2, "exclude proj-b: top len =")
 	for _, ts := range top {
 		if ts.Project == "proj-b" {
 			t.Errorf("excluded proj-b still in top sessions")
@@ -1903,13 +1696,8 @@ func TestExcludeProjectFilter(t *testing.T) {
 	// GetUsageSessionCounts with exclude.
 	counts, err := d.GetUsageSessionCounts(ctx, f1)
 	requireNoError(t, err, "GetUsageSessionCounts exclude")
-	if counts.Total != 2 {
-		t.Errorf("exclude proj-b: Total = %d, want 2", counts.Total)
-	}
-	if counts.ByProject["proj-b"] != 0 {
-		t.Errorf("excluded proj-b count = %d, want 0",
-			counts.ByProject["proj-b"])
-	}
+	assert.Equal(t, 2, counts.Total, "exclude proj-b: Total")
+	assert.Equal(t, 0, counts.ByProject["proj-b"], "excluded proj-b count")
 }
 
 func TestUsageSessionFilters(t *testing.T) {
@@ -1996,10 +1784,7 @@ func TestUsageSessionFilters(t *testing.T) {
 
 	daily, err := d.GetDailyUsage(ctx, filter)
 	requireNoError(t, err, "GetDailyUsage session filters")
-	if daily.Totals.InputTokens != 1000 {
-		t.Errorf("InputTokens = %d, want 1000",
-			daily.Totals.InputTokens)
-	}
+	assert.Equal(t, 1000, daily.Totals.InputTokens, "InputTokens")
 
 	top, err := d.GetTopSessionsByCost(ctx, filter, 10)
 	requireNoError(t, err, "GetTopSessionsByCost session filters")
@@ -2009,9 +1794,7 @@ func TestUsageSessionFilters(t *testing.T) {
 
 	counts, err := d.GetUsageSessionCounts(ctx, filter)
 	requireNoError(t, err, "GetUsageSessionCounts session filters")
-	if counts.Total != 1 {
-		t.Errorf("counts.Total = %d, want 1", counts.Total)
-	}
+	assert.Equal(t, 1, counts.Total, "counts.Total")
 }
 
 func TestUsageExcludeOneShotUsesUserMessageCount(t *testing.T) {
@@ -2063,10 +1846,7 @@ func TestUsageExcludeOneShotUsesUserMessageCount(t *testing.T) {
 
 	daily, err := d.GetDailyUsage(ctx, filter)
 	requireNoError(t, err, "GetDailyUsage exclude one-shot")
-	if daily.Totals.InputTokens != 1000 {
-		t.Errorf("InputTokens = %d, want 1000",
-			daily.Totals.InputTokens)
-	}
+	assert.Equal(t, 1000, daily.Totals.InputTokens, "InputTokens")
 
 	top, err := d.GetTopSessionsByCost(ctx, filter, 10)
 	requireNoError(t, err, "GetTopSessionsByCost exclude one-shot")
@@ -2077,9 +1857,7 @@ func TestUsageExcludeOneShotUsesUserMessageCount(t *testing.T) {
 
 	counts, err := d.GetUsageSessionCounts(ctx, filter)
 	requireNoError(t, err, "GetUsageSessionCounts exclude one-shot")
-	if counts.Total != 1 {
-		t.Errorf("counts.Total = %d, want 1", counts.Total)
-	}
+	assert.Equal(t, 1, counts.Total, "counts.Total")
 }
 
 // TestExcludeAgentFilter verifies ExcludeAgent on GetDailyUsage.
@@ -2119,10 +1897,7 @@ func TestExcludeAgentFilter(t *testing.T) {
 	}
 	daily, err := d.GetDailyUsage(ctx, f)
 	requireNoError(t, err, "GetDailyUsage exclude agent")
-	if daily.Totals.InputTokens != 1000 {
-		t.Errorf("exclude codex: InputTokens = %d, want 1000",
-			daily.Totals.InputTokens)
-	}
+	assert.Equal(t, 1000, daily.Totals.InputTokens, "exclude codex: InputTokens")
 }
 
 // TestExcludeModelFilter verifies ExcludeModel on GetDailyUsage.
@@ -2160,13 +1935,8 @@ func TestExcludeModelFilter(t *testing.T) {
 	}
 	daily, err := d.GetDailyUsage(ctx, f)
 	requireNoError(t, err, "GetDailyUsage exclude model")
-	if daily.Totals.InputTokens != 1000 {
-		t.Errorf("exclude opus: InputTokens = %d, want 1000",
-			daily.Totals.InputTokens)
-	}
-	if len(daily.Daily) != 1 {
-		t.Fatalf("daily len = %d, want 1", len(daily.Daily))
-	}
+	assert.Equal(t, 1000, daily.Totals.InputTokens, "exclude opus: InputTokens")
+	require.Len(t, daily.Daily, 1, "daily len =")
 	for _, mb := range daily.Daily[0].ModelBreakdowns {
 		if mb.ModelName == "opus" {
 			t.Errorf("excluded model opus still in breakdowns")
@@ -2391,9 +2161,7 @@ func TestGetSessionUsage_PricedModel(t *testing.T) {
 	if u == nil {
 		t.Fatal("usage is nil")
 	}
-	if !u.HasCost {
-		t.Fatal("HasCost = false, want true")
-	}
+	require.True(t, u.HasCost, "HasCost = false, want true")
 	if math.Abs(u.CostUSD-0.0175) > 1e-9 {
 		t.Errorf("CostUSD = %v, want 0.0175", u.CostUSD)
 	}
@@ -2427,12 +2195,8 @@ func TestGetSessionUsage_UnpricedModel(t *testing.T) {
 
 	u, err := d.GetSessionUsage(ctx, "claude:s2")
 	requireNoError(t, err, "GetSessionUsage")
-	if u.HasCost {
-		t.Error("HasCost = true, want false (unpriced)")
-	}
-	if u.CostUSD != 0 {
-		t.Errorf("CostUSD = %v, want 0 (partial suppressed)", u.CostUSD)
-	}
+	assert.False(t, u.HasCost, "HasCost = true, want false (unpriced)")
+	assert.Equal(t, 0.0, u.CostUSD, "CostUSD")
 	if len(u.UnpricedModels) != 1 || u.UnpricedModels[0] != "local-llama-99" {
 		t.Errorf("UnpricedModels = %v, want [local-llama-99]", u.UnpricedModels)
 	}
@@ -2463,12 +2227,8 @@ func TestGetSessionUsage_MixedPricedUnpriced(t *testing.T) {
 
 	u, err := d.GetSessionUsage(ctx, "claude:s3")
 	requireNoError(t, err, "GetSessionUsage")
-	if u.HasCost {
-		t.Error("HasCost = true, want false (mixed)")
-	}
-	if u.CostUSD != 0 {
-		t.Errorf("CostUSD = %v, want 0 (partial suppressed)", u.CostUSD)
-	}
+	assert.False(t, u.HasCost, "HasCost = true, want false (mixed)")
+	assert.Equal(t, 0.0, u.CostUSD, "CostUSD")
 	if len(u.UnpricedModels) != 1 || u.UnpricedModels[0] != "local-llama-99" {
 		t.Errorf("UnpricedModels = %v, want [local-llama-99]", u.UnpricedModels)
 	}
@@ -2493,9 +2253,7 @@ func TestGetSessionUsage_ExplicitCostOnly(t *testing.T) {
 
 	u, err := d.GetSessionUsage(ctx, "hermes:s4")
 	requireNoError(t, err, "GetSessionUsage")
-	if !u.HasCost {
-		t.Error("HasCost = false, want true (explicit cost)")
-	}
+	assert.True(t, u.HasCost, "HasCost = false, want true (explicit cost)")
 	if math.Abs(u.CostUSD-0.02) > 1e-9 {
 		t.Errorf("CostUSD = %v, want 0.02", u.CostUSD)
 	}
@@ -2534,9 +2292,7 @@ func TestGetSessionUsage_DedupesDuplicateClaudeRows(t *testing.T) {
 	if math.Abs(u.CostUSD-0.0175) > 1e-9 {
 		t.Errorf("CostUSD = %v, want 0.0175 (deduped)", u.CostUSD)
 	}
-	if !u.HasCost {
-		t.Error("HasCost = false, want true")
-	}
+	assert.True(t, u.HasCost, "HasCost = false, want true")
 }
 
 func TestGetSessionUsage_NoTokenRowsKeepsMetadata(t *testing.T) {
@@ -2560,12 +2316,8 @@ func TestGetSessionUsage_NoTokenRowsKeepsMetadata(t *testing.T) {
 		t.Errorf("tokens = %d/%d, want 700/3000",
 			u.TotalOutputTokens, u.PeakContextTokens)
 	}
-	if !u.HasTokenData {
-		t.Error("HasTokenData = false, want true")
-	}
-	if u.HasCost {
-		t.Error("HasCost = true, want false (no cost rows)")
-	}
+	assert.True(t, u.HasTokenData, "HasTokenData = false, want true")
+	assert.False(t, u.HasCost, "HasCost = true, want false (no cost rows)")
 	if u.Models == nil {
 		t.Error("Models = nil, want non-nil empty slice")
 	}
@@ -2575,7 +2327,5 @@ func TestGetSessionUsage_NotFound(t *testing.T) {
 	d := testDB(t)
 	u, err := d.GetSessionUsage(context.Background(), "nope:x")
 	requireNoError(t, err, "GetSessionUsage")
-	if u != nil {
-		t.Errorf("usage = %v, want nil", u)
-	}
+	assert.Nil(t, u, "usage")
 }

--- a/internal/db/worktree_mappings_test.go
+++ b/internal/db/worktree_mappings_test.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWorktreeProjectMappingsCRUDNormalizesAndScopesByMachine(t *testing.T) {
@@ -18,28 +20,19 @@ func TestWorktreeProjectMappingsCRUDNormalizesAndScopesByMachine(t *testing.T) {
 		Project:    "my-app",
 		Enabled:    true,
 	})
-	requireNoError(t, err, "create mapping")
-	if m.Machine != "laptop" {
-		t.Fatalf("machine = %q, want laptop", m.Machine)
-	}
-	if m.PathPrefix != prefix {
-		t.Fatalf("path_prefix = %q, want %q", m.PathPrefix, prefix)
-	}
-	if m.Project != "my_app" {
-		t.Fatalf("project = %q, want my_app", m.Project)
-	}
+	require.NoError(t, err, "create mapping")
+	assert.Equal(t, "laptop", m.Machine, "machine")
+	assert.Equal(t, prefix, m.PathPrefix, "path_prefix")
+	assert.Equal(t, "my_app", m.Project, "project")
 
 	got, err := d.ListWorktreeProjectMappings(ctx, "laptop")
-	requireNoError(t, err, "list laptop mappings")
-	if len(got) != 1 || got[0].ID != m.ID {
-		t.Fatalf("laptop mappings = %+v, want created mapping", got)
-	}
+	require.NoError(t, err, "list laptop mappings")
+	require.Len(t, got, 1, "laptop mappings")
+	assert.Equal(t, m.ID, got[0].ID, "laptop mapping ID")
 
 	other, err := d.ListWorktreeProjectMappings(ctx, "server")
-	requireNoError(t, err, "list server mappings")
-	if len(other) != 0 {
-		t.Fatalf("server mappings = %+v, want none", other)
-	}
+	require.NoError(t, err, "list server mappings")
+	assert.Empty(t, other, "server mappings")
 }
 
 func TestWorktreeProjectMappingsRejectInvalidAndDuplicateRows(t *testing.T) {
@@ -50,26 +43,20 @@ func TestWorktreeProjectMappingsRejectInvalidAndDuplicateRows(t *testing.T) {
 	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: " ", Project: "repo", Enabled: true,
 	})
-	if err == nil {
-		t.Fatal("empty path prefix accepted")
-	}
+	require.Error(t, err, "empty path prefix accepted")
 	_, err = d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: prefix, Project: " ", Enabled: true,
 	})
-	if err == nil {
-		t.Fatal("empty project accepted")
-	}
+	require.Error(t, err, "empty project accepted")
 
 	_, err = d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
 	})
-	requireNoError(t, err, "create first mapping")
+	require.NoError(t, err, "create first mapping")
 	_, err = d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: prefix, Project: "repo2", Enabled: true,
 	})
-	if !errors.Is(err, ErrWorktreeMappingDuplicate) {
-		t.Fatalf("duplicate error = %v, want ErrWorktreeMappingDuplicate", err)
-	}
+	require.ErrorIs(t, err, ErrWorktreeMappingDuplicate)
 }
 
 func TestResolveWorktreeProjectMappingUsesLongestPrefixAndBoundaries(t *testing.T) {
@@ -82,31 +69,28 @@ func TestResolveWorktreeProjectMappingUsesLongestPrefixAndBoundaries(t *testing.
 	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: broad, Project: "repo", Enabled: true,
 	})
-	requireNoError(t, err, "create broad mapping")
+	require.NoError(t, err, "create broad mapping")
 	_, err = d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: nested, Project: "special-repo", Enabled: true,
 	})
-	requireNoError(t, err, "create nested mapping")
+	require.NoError(t, err, "create nested mapping")
 
 	project, ok, err := d.ResolveWorktreeProjectMapping(ctx, "laptop",
 		filepath.Join(nested, "feat", "thing"), "leaf")
-	requireNoError(t, err, "resolve nested")
-	if !ok || project != "special_repo" {
-		t.Fatalf("nested resolve = (%q,%v), want (special_repo,true)", project, ok)
-	}
+	require.NoError(t, err, "resolve nested")
+	assert.True(t, ok, "nested resolve")
+	assert.Equal(t, "special_repo", project, "nested resolve")
 
 	project, ok, err = d.ResolveWorktreeProjectMapping(ctx, "laptop",
 		filepath.Join(broad, "feat", "thing"), "leaf")
-	requireNoError(t, err, "resolve broad")
-	if !ok || project != "repo" {
-		t.Fatalf("broad resolve = (%q,%v), want (repo,true)", project, ok)
-	}
+	require.NoError(t, err, "resolve broad")
+	assert.True(t, ok, "broad resolve")
+	assert.Equal(t, "repo", project, "broad resolve")
 
 	_, ok, err = d.ResolveWorktreeProjectMapping(ctx, "laptop", broad+"-other", "leaf")
-	requireNoError(t, err, "resolve boundary miss")
-	if ok {
-		t.Fatal("path with shared string prefix matched across component boundary")
-	}
+	require.NoError(t, err, "resolve boundary miss")
+	assert.False(t, ok,
+		"path with shared string prefix matched across component boundary")
 
 	project, ok = ResolveWorktreeProjectFromMappings(
 		[]WorktreeProjectMapping{
@@ -116,9 +100,8 @@ func TestResolveWorktreeProjectMappingUsesLongestPrefixAndBoundaries(t *testing.
 		filepath.Join(nested, "feat", "thing"),
 		"leaf",
 	)
-	if !ok || project != "special_repo" {
-		t.Fatalf("unsorted resolve = (%q,%v), want (special_repo,true)", project, ok)
-	}
+	assert.True(t, ok, "unsorted resolve")
+	assert.Equal(t, "special_repo", project, "unsorted resolve")
 }
 
 func TestResolveWorktreeProjectMappingMatchesRootPrefix(t *testing.T) {
@@ -131,14 +114,13 @@ func TestResolveWorktreeProjectMappingMatchesRootPrefix(t *testing.T) {
 		Project:    "root-project",
 		Enabled:    true,
 	})
-	requireNoError(t, err, "create root mapping")
+	require.NoError(t, err, "create root mapping")
 
 	project, ok, err := d.ResolveWorktreeProjectMapping(ctx, "laptop",
 		filepath.Join(string(filepath.Separator), "tmp", "worktree"), "leaf")
-	requireNoError(t, err, "resolve root")
-	if !ok || project != "root_project" {
-		t.Fatalf("root resolve = (%q,%v), want (root_project,true)", project, ok)
-	}
+	require.NoError(t, err, "resolve root")
+	assert.True(t, ok, "root resolve")
+	assert.Equal(t, "root_project", project, "root resolve")
 }
 
 func TestApplyWorktreeProjectMappingsUpdatesOnlyCurrentMachineAndEnabledRows(t *testing.T) {
@@ -151,31 +133,30 @@ func TestApplyWorktreeProjectMappingsUpdatesOnlyCurrentMachineAndEnabledRows(t *
 	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
 	})
-	requireNoError(t, err, "create enabled mapping")
+	require.NoError(t, err, "create enabled mapping")
 	_, err = d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: disabledPrefix, Project: "disabled", Enabled: false,
 	})
-	requireNoError(t, err, "create disabled mapping")
+	require.NoError(t, err, "create disabled mapping")
 
 	insert := func(id, machine, project, cwd string) {
 		t.Helper()
 		err := d.UpsertSession(Session{
 			ID: id, Project: project, Machine: machine, Agent: "claude", Cwd: cwd,
 		})
-		requireNoError(t, err, "insert "+id)
+		require.NoError(t, err, "insert %s", id)
 	}
 	insert("match", "laptop", "leaf", filepath.Join(prefix, "feat", "thing"))
 	insert("same-project", "laptop", "repo", filepath.Join(prefix, "bugfix"))
 	insert("other-machine", "server", "leaf", filepath.Join(prefix, "feat", "thing"))
 	insert("disabled", "laptop", "leaf", filepath.Join(disabledPrefix, "feat"))
 	insert("trashed", "laptop", "leaf", filepath.Join(prefix, "trashed"))
-	requireNoError(t, d.SoftDeleteSession("trashed"), "trash session")
+	require.NoError(t, d.SoftDeleteSession("trashed"), "trash session")
 
 	result, err := d.ApplyWorktreeProjectMappings(ctx, "laptop")
-	requireNoError(t, err, "apply mappings")
-	if result.MatchedSessions != 2 || result.UpdatedSessions != 1 {
-		t.Fatalf("apply result = %+v, want matched=2 updated=1", result)
-	}
+	require.NoError(t, err, "apply mappings")
+	assert.Equal(t, 2, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 1, result.UpdatedSessions, "updated sessions")
 	assertSessionProject(t, d, "match", "repo")
 	assertSessionProject(t, d, "same-project", "repo")
 	assertSessionProject(t, d, "other-machine", "leaf")
@@ -191,32 +172,25 @@ func TestApplyWorktreeProjectMappingsBumpsLocalModifiedAt(t *testing.T) {
 	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
 	})
-	requireNoError(t, err, "create mapping")
-	requireNoError(t, d.UpsertSession(Session{
+	require.NoError(t, err, "create mapping")
+	require.NoError(t, d.UpsertSession(Session{
 		ID: "match", Project: "leaf", Machine: "laptop", Agent: "claude",
 		Cwd: filepath.Join(prefix, "feat"),
 	}), "insert match")
 
 	before, err := d.GetSessionFull(ctx, "match")
-	requireNoError(t, err, "GetSessionFull before")
-	if before.LocalModifiedAt != nil {
-		t.Fatalf("local_modified_at before = %v, want nil", *before.LocalModifiedAt)
-	}
+	require.NoError(t, err, "GetSessionFull before")
+	require.Nil(t, before.LocalModifiedAt, "local_modified_at before")
 
 	result, err := d.ApplyWorktreeProjectMappings(ctx, "laptop")
-	requireNoError(t, err, "apply mappings")
-	if result.UpdatedSessions != 1 {
-		t.Fatalf("updated sessions = %d, want 1", result.UpdatedSessions)
-	}
+	require.NoError(t, err, "apply mappings")
+	require.Equal(t, 1, result.UpdatedSessions, "updated sessions")
 
 	after, err := d.GetSessionFull(ctx, "match")
-	requireNoError(t, err, "GetSessionFull after")
-	if after.Project != "repo" {
-		t.Fatalf("project = %q, want repo", after.Project)
-	}
-	if after.LocalModifiedAt == nil || *after.LocalModifiedAt == "" {
-		t.Fatalf("local_modified_at after = %v, want timestamp", after.LocalModifiedAt)
-	}
+	require.NoError(t, err, "GetSessionFull after")
+	assert.Equal(t, "repo", after.Project, "project")
+	require.NotNil(t, after.LocalModifiedAt, "local_modified_at after")
+	assert.NotEmpty(t, *after.LocalModifiedAt, "local_modified_at after")
 }
 
 func TestApplyWorktreeProjectMappingsToSessionUsesCurrentSessionState(
@@ -231,19 +205,19 @@ func TestApplyWorktreeProjectMappingsToSessionUsesCurrentSessionState(
 	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: stalePrefix, Project: "stale-repo", Enabled: true,
 	})
-	requireNoError(t, err, "create stale mapping")
+	require.NoError(t, err, "create stale mapping")
 	_, err = d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: currentPrefix, Project: "current-repo", Enabled: true,
 	})
-	requireNoError(t, err, "create current mapping")
+	require.NoError(t, err, "create current mapping")
 
 	staleCwd := filepath.Join(stalePrefix, "feat")
 	currentCwd := filepath.Join(currentPrefix, "feat")
-	requireNoError(t, d.UpsertSession(Session{
+	require.NoError(t, d.UpsertSession(Session{
 		ID: "match", Project: "leaf", Machine: "laptop", Agent: "claude",
 		Cwd: staleCwd,
 	}), "insert stale match")
-	requireNoError(t, d.UpsertSession(Session{
+	require.NoError(t, d.UpsertSession(Session{
 		ID: "match", Project: "other_leaf", Machine: "laptop", Agent: "claude",
 		Cwd: currentCwd,
 	}), "move session before apply")
@@ -251,10 +225,8 @@ func TestApplyWorktreeProjectMappingsToSessionUsesCurrentSessionState(
 	updated, err := d.ApplyWorktreeProjectMappingToSession(
 		ctx, "laptop", "match", staleCwd, "leaf",
 	)
-	requireNoError(t, err, "ApplyWorktreeProjectMappingToSession")
-	if !updated {
-		t.Fatal("updated = false, want true")
-	}
+	require.NoError(t, err, "ApplyWorktreeProjectMappingToSession")
+	require.True(t, updated, "updated")
 	assertSessionProject(t, d, "match", "current_repo")
 }
 
@@ -268,43 +240,33 @@ func TestApplyWorktreeProjectMappingToSessionFromSyncDoesNotBumpLocalModifiedAt(
 	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
 		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
 	})
-	requireNoError(t, err, "create mapping")
-	requireNoError(t, d.UpsertSession(Session{
+	require.NoError(t, err, "create mapping")
+	require.NoError(t, d.UpsertSession(Session{
 		ID: "match", Project: "leaf", Machine: "laptop", Agent: "claude",
 		Cwd: filepath.Join(prefix, "feat"),
 	}), "insert match")
 
 	before, err := d.GetSessionFull(ctx, "match")
-	requireNoError(t, err, "GetSessionFull before")
-	if before.LocalModifiedAt != nil {
-		t.Fatalf("local_modified_at before = %v, want nil", before.LocalModifiedAt)
-	}
+	require.NoError(t, err, "GetSessionFull before")
+	require.Nil(t, before.LocalModifiedAt, "local_modified_at before")
 
 	updated, err := d.ApplyWorktreeProjectMappingToSessionFromSync(
 		ctx, "laptop", "match", before.Cwd, before.Project,
 	)
-	requireNoError(t, err, "ApplyWorktreeProjectMappingToSessionFromSync")
-	if !updated {
-		t.Fatal("updated = false, want true")
-	}
+	require.NoError(t, err, "ApplyWorktreeProjectMappingToSessionFromSync")
+	require.True(t, updated, "updated")
 
 	after, err := d.GetSessionFull(ctx, "match")
-	requireNoError(t, err, "GetSessionFull after")
-	if after.Project != "repo" {
-		t.Fatalf("project = %q, want repo", after.Project)
-	}
-	if after.LocalModifiedAt != nil {
-		t.Fatalf("local_modified_at after = %v, want nil", after.LocalModifiedAt)
-	}
+	require.NoError(t, err, "GetSessionFull after")
+	assert.Equal(t, "repo", after.Project, "project")
+	assert.Nil(t, after.LocalModifiedAt, "local_modified_at after")
 }
 
 func assertSessionProject(t *testing.T, d *DB, id, want string) {
 	t.Helper()
 	got, err := d.GetSession(context.Background(), id)
-	requireNoError(t, err, "GetSession "+id)
-	if got.Project != want {
-		t.Fatalf("session %s project = %q, want %q", id, got.Project, want)
-	}
+	require.NoError(t, err, "GetSession %s", id)
+	assert.Equal(t, want, got.Project, "session %s project", id)
 }
 
 func TestWorktreeProjectMappingsFinalMetadataCopyRefreshesStalePrecopy(
@@ -315,7 +277,7 @@ func TestWorktreeProjectMappingsFinalMetadataCopyRefreshesStalePrecopy(
 
 	srcPath := filepath.Join(dir, "src.db")
 	srcDB, err := Open(srcPath)
-	requireNoError(t, err, "Open src")
+	require.NoError(t, err, "Open src")
 	defer srcDB.Close()
 
 	prefix := filepath.Join(dir, "app.worktrees")
@@ -328,14 +290,14 @@ func TestWorktreeProjectMappingsFinalMetadataCopyRefreshesStalePrecopy(
 			Enabled:    true,
 		},
 	)
-	requireNoError(t, err, "CreateWorktreeProjectMapping src")
+	require.NoError(t, err, "CreateWorktreeProjectMapping src")
 
 	dstPath := filepath.Join(dir, "dst.db")
 	dstDB, err := Open(dstPath)
-	requireNoError(t, err, "Open dst")
+	require.NoError(t, err, "Open dst")
 	defer dstDB.Close()
 
-	requireNoError(
+	require.NoError(
 		t,
 		dstDB.CopyWorktreeProjectMappingsFrom(srcPath),
 		"CopyWorktreeProjectMappingsFrom",
@@ -351,8 +313,8 @@ func TestWorktreeProjectMappingsFinalMetadataCopyRefreshesStalePrecopy(
 			Enabled:    false,
 		},
 	)
-	requireNoError(t, err, "UpdateWorktreeProjectMapping src")
-	requireNoError(t, srcDB.CloseConnections(), "CloseConnections src")
+	require.NoError(t, err, "UpdateWorktreeProjectMapping src")
+	require.NoError(t, srcDB.CloseConnections(), "CloseConnections src")
 
 	_, err = dstDB.getWriter().ExecContext(ctx, `
 		UPDATE worktree_project_mappings
@@ -361,25 +323,19 @@ func TestWorktreeProjectMappingsFinalMetadataCopyRefreshesStalePrecopy(
 		"laptop",
 		prefix,
 	)
-	requireNoError(t, err, "force dst updated_at ahead")
+	require.NoError(t, err, "force dst updated_at ahead")
 
-	requireNoError(
+	require.NoError(
 		t,
 		dstDB.CopySessionMetadataFrom(srcPath),
 		"CopySessionMetadataFrom",
 	)
 
 	got, err := dstDB.ListWorktreeProjectMappings(ctx, "laptop")
-	requireNoError(t, err, "ListWorktreeProjectMappings")
-	if len(got) != 1 {
-		t.Fatalf("mapping count = %d, want 1: %+v", len(got), got)
-	}
-	if got[0].Project != "new_project" {
-		t.Fatalf("project = %q, want new_project", got[0].Project)
-	}
-	if got[0].Enabled {
-		t.Fatal("mapping should reflect disabled source row")
-	}
+	require.NoError(t, err, "ListWorktreeProjectMappings")
+	require.Len(t, got, 1, "mapping count")
+	assert.Equal(t, "new_project", got[0].Project, "project")
+	assert.False(t, got[0].Enabled, "mapping should reflect disabled source row")
 }
 
 func TestWorktreeProjectMappingsFinalMetadataCopyRemovesDeletedPrecopy(
@@ -390,7 +346,7 @@ func TestWorktreeProjectMappingsFinalMetadataCopyRemovesDeletedPrecopy(
 
 	srcPath := filepath.Join(dir, "src.db")
 	srcDB, err := Open(srcPath)
-	requireNoError(t, err, "Open src")
+	require.NoError(t, err, "Open src")
 	defer srcDB.Close()
 
 	prefix := filepath.Join(dir, "app.worktrees")
@@ -403,46 +359,42 @@ func TestWorktreeProjectMappingsFinalMetadataCopyRemovesDeletedPrecopy(
 			Enabled:    true,
 		},
 	)
-	requireNoError(t, err, "CreateWorktreeProjectMapping src")
+	require.NoError(t, err, "CreateWorktreeProjectMapping src")
 
 	dstPath := filepath.Join(dir, "dst.db")
 	dstDB, err := Open(dstPath)
-	requireNoError(t, err, "Open dst")
+	require.NoError(t, err, "Open dst")
 	defer dstDB.Close()
 
-	requireNoError(
+	require.NoError(
 		t,
 		dstDB.CopyWorktreeProjectMappingsFrom(srcPath),
 		"CopyWorktreeProjectMappingsFrom",
 	)
 
-	requireNoError(
+	require.NoError(
 		t,
 		srcDB.DeleteWorktreeProjectMapping(
 			ctx, "laptop", sourceMapping.ID,
 		),
 		"DeleteWorktreeProjectMapping src",
 	)
-	requireNoError(t, srcDB.CloseConnections(), "CloseConnections src")
+	require.NoError(t, srcDB.CloseConnections(), "CloseConnections src")
 
-	requireNoError(
+	require.NoError(
 		t,
 		dstDB.CopySessionMetadataFrom(srcPath),
 		"CopySessionMetadataFrom",
 	)
 
 	got, err := dstDB.ListWorktreeProjectMappings(ctx, "laptop")
-	requireNoError(t, err, "ListWorktreeProjectMappings")
-	if len(got) != 0 {
-		t.Fatalf("mapping count = %d, want 0: %+v", len(got), got)
-	}
+	require.NoError(t, err, "ListWorktreeProjectMappings")
+	assert.Empty(t, got, "mapping count")
 }
 
 func assertFullSessionProject(t *testing.T, d *DB, id, want string) {
 	t.Helper()
 	got, err := d.GetSessionFull(context.Background(), id)
-	requireNoError(t, err, "GetSessionFull "+id)
-	if got.Project != want {
-		t.Fatalf("session %s project = %q, want %q", id, got.Project, want)
-	}
+	require.NoError(t, err, "GetSessionFull %s", id)
+	assert.Equal(t, want, got.Project, "session %s project", id)
 }

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -8,6 +8,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseCodexStream(t *testing.T) {
@@ -65,17 +68,12 @@ Second`,
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := parseCodexStream(strings.NewReader(tt.input), nil)
 			if tt.wantError != "" {
-				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
-					t.Fatalf("expected error containing %q, got %v", tt.wantError, err)
-				}
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if result != tt.want {
-				t.Errorf("got %q, want %q", result, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }
@@ -129,17 +127,12 @@ Part 2`,
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := parseStreamJSON(strings.NewReader(tt.input), nil)
 			if tt.wantError != "" {
-				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
-					t.Fatalf("expected error containing %q, got %v", tt.wantError, err)
-				}
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if result != tt.want {
-				t.Errorf("got %q, want %q", result, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }
@@ -157,21 +150,11 @@ func TestCollectStreamLines_LargeLine(t *testing.T) {
 	)
 	text := <-done
 
-	if len(got) != 2 {
-		t.Fatalf("got %d log events, want 2", len(got))
-	}
-	if got[0].Stream != "stderr" || len(got[0].Line) != len(longLine) {
-		t.Fatalf(
-			"first event mismatch: stream=%q len=%d",
-			got[0].Stream, len(got[0].Line),
-		)
-	}
-	if got[1].Line != "small-line" {
-		t.Fatalf("second line = %q, want %q", got[1].Line, "small-line")
-	}
-	if !strings.Contains(text, "small-line") {
-		t.Fatalf("joined text missing expected line: %q", text)
-	}
+	require.Len(t, got, 2)
+	assert.Equal(t, "stderr", got[0].Stream)
+	assert.Len(t, got[0].Line, len(longLine))
+	assert.Equal(t, "small-line", got[1].Line)
+	assert.Contains(t, text, "small-line")
 }
 
 func TestAgentEnv(t *testing.T) {
@@ -186,30 +169,18 @@ func TestAgentEnv(t *testing.T) {
 	}
 
 	// Full env is passed through — no filtering.
-	if envMap["ANTHROPIC_API_KEY"] != "sk-secret" {
-		t.Error("ANTHROPIC_API_KEY should be preserved")
-	}
-	if envMap["CUSTOM_VAR"] != "custom-val" {
-		t.Error("CUSTOM_VAR should be preserved")
-	}
-	if v, ok := envMap["CLAUDE_NO_SOUND"]; !ok || v != "1" {
-		t.Errorf(
-			"CLAUDE_NO_SOUND should be 1, got %q", v,
-		)
-	}
+	assert.Equal(t, "sk-secret", envMap["ANTHROPIC_API_KEY"], "ANTHROPIC_API_KEY should be preserved")
+	assert.Equal(t, "custom-val", envMap["CUSTOM_VAR"], "CUSTOM_VAR should be preserved")
+	assert.Equal(t, "1", envMap["CLAUDE_NO_SOUND"])
 }
 
 func TestValidAgents(t *testing.T) {
 	for _, agent := range []string{
 		"claude", "codex", "copilot", "gemini", "kiro",
 	} {
-		if !ValidAgents[agent] {
-			t.Errorf("%s should be valid", agent)
-		}
+		assert.True(t, ValidAgents[agent], "%s should be valid", agent)
 	}
-	if ValidAgents["gpt"] {
-		t.Error("gpt should not be valid")
-	}
+	assert.False(t, ValidAgents["gpt"], "gpt should not be valid")
 }
 
 func createMockBinary(
@@ -218,9 +189,7 @@ func createMockBinary(
 	t.Helper()
 	dir := t.TempDir()
 	dataFile := filepath.Join(dir, "stdout.txt")
-	if err := os.WriteFile(dataFile, []byte(stdout), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(dataFile, []byte(stdout), 0o644))
 
 	if writeArgs {
 		argsFile = filepath.Join(dir, "args.txt")
@@ -234,9 +203,7 @@ func createMockBinary(
 		} else {
 			script = fmt.Sprintf("@type %q\r\n@exit /b %d\r\n", dataFile, exitCode)
 		}
-		if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
 		return bin, argsFile
 	}
 
@@ -247,9 +214,7 @@ func createMockBinary(
 	} else {
 		script = fmt.Sprintf("#!/bin/sh\ncat %s\nexit %d\n", shellQuote(dataFile), exitCode)
 	}
-	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
 	return bin, argsFile
 }
 
@@ -284,12 +249,8 @@ func TestGenerateStreamWithOptions_UsesConfiguredBinary(t *testing.T) {
 			},
 		},
 	)
-	if err != nil {
-		t.Fatalf("GenerateStreamWithOptions: %v", err)
-	}
-	if result.Content != "OK" {
-		t.Fatalf("Content = %q, want OK", result.Content)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "OK", result.Content)
 }
 
 func TestGenerateClaude_CLIFlags(t *testing.T) {
@@ -305,17 +266,11 @@ func TestGenerateClaude_CLIFlags(t *testing.T) {
 	result, err := generateClaude(
 		context.Background(), bin, "test prompt", nil,
 	)
-	if err != nil {
-		t.Fatalf("generateClaude: %v", err)
-	}
-	if result.Content != "OK" {
-		t.Errorf("Content = %q, want OK", result.Content)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "OK", result.Content)
 
 	argsData, err := os.ReadFile(argsFile)
-	if err != nil {
-		t.Fatalf("reading args: %v", err)
-	}
+	require.NoError(t, err, "reading args")
 	args := strings.Split(
 		strings.TrimSpace(string(argsData)), "\n",
 	)
@@ -329,11 +284,7 @@ func TestGenerateClaude_CLIFlags(t *testing.T) {
 		"--no-session-persistence",
 		"--tools",
 	} {
-		if !strings.Contains(joined, want) {
-			t.Errorf(
-				"args %q missing %q", joined, want,
-			)
-		}
+		assert.Contains(t, joined, want)
 	}
 }
 
@@ -351,17 +302,11 @@ func TestGenerateCodex_CLIFlags(t *testing.T) {
 	result, err := generateCodex(
 		context.Background(), bin, "test prompt", nil,
 	)
-	if err != nil {
-		t.Fatalf("generateCodex: %v", err)
-	}
-	if result.Content != "OK" {
-		t.Errorf("Content = %q, want OK", result.Content)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "OK", result.Content)
 
 	argsData, err := os.ReadFile(argsFile)
-	if err != nil {
-		t.Fatalf("reading args: %v", err)
-	}
+	require.NoError(t, err, "reading args")
 	args := strings.Split(
 		strings.TrimSpace(string(argsData)), "\n",
 	)
@@ -373,17 +318,7 @@ func TestGenerateCodex_CLIFlags(t *testing.T) {
 		"--ephemeral",
 		"-",
 	}
-	if len(args) != len(wantArgs) {
-		t.Fatalf("args = %v, want %v", args, wantArgs)
-	}
-	for i, want := range wantArgs {
-		if args[i] != want {
-			t.Errorf(
-				"arg[%d] = %q, want %q",
-				i, args[i], want,
-			)
-		}
-	}
+	assert.Equal(t, wantArgs, args)
 }
 
 func TestGenerateCopilot_CLIFlags(t *testing.T) {
@@ -398,23 +333,12 @@ func TestGenerateCopilot_CLIFlags(t *testing.T) {
 	result, err := generateCopilot(
 		context.Background(), bin, "test prompt", nil,
 	)
-	if err != nil {
-		t.Fatalf("generateCopilot: %v", err)
-	}
-	if result.Content != "Hello from copilot" {
-		t.Errorf(
-			"Content = %q, want %q",
-			result.Content, "Hello from copilot",
-		)
-	}
-	if result.Agent != "copilot" {
-		t.Errorf("Agent = %q, want copilot", result.Agent)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "Hello from copilot", result.Content)
+	assert.Equal(t, "copilot", result.Agent)
 
 	argsData, err := os.ReadFile(argsFile)
-	if err != nil {
-		t.Fatalf("reading args: %v", err)
-	}
+	require.NoError(t, err, "reading args")
 	args := strings.Split(
 		strings.TrimSpace(string(argsData)), "\n",
 	)
@@ -426,17 +350,7 @@ func TestGenerateCopilot_CLIFlags(t *testing.T) {
 		"--no-ask-user",
 		"--disable-builtin-mcps",
 	}
-	if len(args) != len(wantArgs) {
-		t.Fatalf("args = %v, want %v", args, wantArgs)
-	}
-	for i, want := range wantArgs {
-		if args[i] != want {
-			t.Errorf(
-				"arg[%d] = %q, want %q",
-				i, args[i], want,
-			)
-		}
-	}
+	assert.Equal(t, wantArgs, args)
 }
 
 func TestGenerateCopilot_EmptyResult(t *testing.T) {
@@ -451,12 +365,8 @@ func TestGenerateCopilot_EmptyResult(t *testing.T) {
 	_, err := generateCopilot(
 		context.Background(), bin, "test", nil,
 	)
-	if err == nil {
-		t.Fatal("expected error for empty result")
-	}
-	if !strings.Contains(err.Error(), "empty result") {
-		t.Errorf("error = %q, want empty result", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty result")
 }
 
 func TestGenerateCopilot_PreservesBlankLines(t *testing.T) {
@@ -472,14 +382,8 @@ func TestGenerateCopilot_PreservesBlankLines(t *testing.T) {
 	result, err := generateCopilot(
 		context.Background(), bin, "test", nil,
 	)
-	if err != nil {
-		t.Fatalf("generateCopilot: %v", err)
-	}
-	if !strings.Contains(result.Content, "\n\n") {
-		t.Errorf(
-			"blank lines lost: %q", result.Content,
-		)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, result.Content, "\n\n", "blank lines lost")
 }
 
 func TestGenerateClaude_SalvageOnNonZeroExit(t *testing.T) {
@@ -538,26 +442,12 @@ func TestGenerateClaude_SalvageOnNonZeroExit(t *testing.T) {
 			)
 
 			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
+				require.Error(t, err)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if result.Content != tt.wantResult {
-				t.Errorf(
-					"content = %q, want %q",
-					result.Content, tt.wantResult,
-				)
-			}
-			if result.Agent != "claude" {
-				t.Errorf(
-					"agent = %q, want claude",
-					result.Agent,
-				)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResult, result.Content)
+			assert.Equal(t, "claude", result.Agent)
 		})
 	}
 }
@@ -585,27 +475,15 @@ func TestGenerateGemini_ModelFlag(t *testing.T) {
 	result, err := generateGemini(
 		context.Background(), bin, "test prompt", nil,
 	)
-	if err != nil {
-		t.Fatalf("generateGemini: %v", err)
-	}
+	require.NoError(t, err)
 
-	if result.Content != "# Analysis" {
-		t.Errorf("Content = %q, want %q",
-			result.Content, "# Analysis")
-	}
-	if result.Agent != "gemini" {
-		t.Errorf("Agent = %q, want gemini", result.Agent)
-	}
-	if result.Model != geminiInsightModel {
-		t.Errorf("Model = %q, want %q",
-			result.Model, geminiInsightModel)
-	}
+	assert.Equal(t, "# Analysis", result.Content)
+	assert.Equal(t, "gemini", result.Agent)
+	assert.Equal(t, geminiInsightModel, result.Model)
 
 	// Verify the CLI was invoked with --model flag.
 	argsData, err := os.ReadFile(argsFile)
-	if err != nil {
-		t.Fatalf("reading args: %v", err)
-	}
+	require.NoError(t, err, "reading args")
 	args := strings.Split(
 		strings.TrimSpace(string(argsData)), "\n",
 	)
@@ -615,15 +493,7 @@ func TestGenerateGemini_ModelFlag(t *testing.T) {
 		"--output-format", "stream-json",
 		"--sandbox",
 	}
-	if len(args) != len(wantArgs) {
-		t.Fatalf("args = %v, want %v", args, wantArgs)
-	}
-	for i, want := range wantArgs {
-		if args[i] != want {
-			t.Errorf("arg[%d] = %q, want %q",
-				i, args[i], want)
-		}
-	}
+	assert.Equal(t, wantArgs, args)
 }
 
 func TestGenerateClaude_CancelledContext(t *testing.T) {
@@ -638,12 +508,8 @@ func TestGenerateClaude_CancelledContext(t *testing.T) {
 	cancel()
 
 	_, err := generateClaude(ctx, bin, "test", nil)
-	if err == nil {
-		t.Fatal("expected error for cancelled context")
-	}
-	if !strings.Contains(err.Error(), "cancel") {
-		t.Errorf("error = %q, want cancel", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancel")
 }
 
 func TestGenerateClaude_SuccessNotDiscarded(t *testing.T) {
@@ -656,12 +522,8 @@ func TestGenerateClaude_SuccessNotDiscarded(t *testing.T) {
 	result, err := generateClaude(
 		context.Background(), bin, "test", nil,
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.Content != "OK" {
-		t.Errorf("content = %q, want OK", result.Content)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "OK", result.Content)
 }
 
 func TestParseCLIResult(t *testing.T) {
@@ -705,12 +567,8 @@ func TestParseCLIResult(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result, model := parseCLIResult([]byte(tc.input))
-			if result != tc.wantResult {
-				t.Errorf("result: got %q, want %q", result, tc.wantResult)
-			}
-			if model != tc.wantModel {
-				t.Errorf("model: got %q, want %q", model, tc.wantModel)
-			}
+			assert.Equal(t, tc.wantResult, result)
+			assert.Equal(t, tc.wantModel, model)
 		})
 	}
 }
@@ -727,12 +585,8 @@ func TestGenerateClaude_TruncatesLargeStdoutLogEvent(t *testing.T) {
 		"test",
 		func(ev LogEvent) { logs = append(logs, ev) },
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.Content != largeResult {
-		t.Fatalf("result content was truncated unexpectedly")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, largeResult, result.Content, "result content was truncated unexpectedly")
 
 	var stdoutLog string
 	for _, ev := range logs {
@@ -741,13 +595,7 @@ func TestGenerateClaude_TruncatesLargeStdoutLogEvent(t *testing.T) {
 			break
 		}
 	}
-	if stdoutLog == "" {
-		t.Fatalf("expected stdout log event")
-	}
-	if !strings.Contains(stdoutLog, "[truncated ") {
-		t.Fatalf("expected truncation marker in stdout log, got %q", stdoutLog)
-	}
-	if len(stdoutLog) >= len(stdout) {
-		t.Fatalf("expected truncated stdout log to be smaller than raw payload")
-	}
+	require.NotEmpty(t, stdoutLog, "expected stdout log event")
+	assert.Contains(t, stdoutLog, "[truncated ", "expected truncation marker in stdout log")
+	assert.Less(t, len(stdoutLog), len(stdout), "expected truncated stdout log to be smaller than raw payload")
 }

--- a/internal/insight/prompt_test.go
+++ b/internal/insight/prompt_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 )
@@ -120,9 +122,7 @@ func TestBuildPrompt(t *testing.T) {
 			wantContains: []string{"omitted"},
 			checkPrompt: func(t *testing.T, prompt string) {
 				count := strings.Count(prompt, "### Session")
-				if count != 50 {
-					t.Errorf("got %d sessions in prompt, want 50", count)
-				}
+				assert.Equal(t, 50, count, "got %d sessions in prompt, want 50", count)
 			},
 		},
 		{
@@ -207,19 +207,13 @@ func TestBuildPrompt(t *testing.T) {
 			}
 
 			prompt, err := BuildPrompt(ctx, d, tt.req)
-			if err != nil {
-				t.Fatalf("BuildPrompt: %v", err)
-			}
+			require.NoError(t, err)
 
 			for _, want := range tt.wantContains {
-				if !strings.Contains(prompt, want) {
-					t.Errorf("prompt missing %q", want)
-				}
+				assert.Contains(t, prompt, want)
 			}
 			for _, notWant := range tt.wantNot {
-				if strings.Contains(prompt, notWant) {
-					t.Errorf("prompt unexpectedly contains %q", notWant)
-				}
+				assert.NotContains(t, prompt, notWant)
 			}
 			if tt.checkPrompt != nil {
 				tt.checkPrompt(t, prompt)

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ---- protobuf wire walker -------------------------------------
@@ -65,35 +67,26 @@ func TestAgProtoParseAndExtract(t *testing.T) {
 	})
 
 	fields, err := agProtoParse(payload)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if len(fields) != 3 {
-		t.Fatalf("got %d fields, want 3", len(fields))
-	}
+	require.NoError(t, err, "parse")
+	require.Len(t, fields, 3)
 
 	// Field 17 should be a UTF-8 string with no nested decoding.
 	got, _ := agProtoFind(fields, 17)
 	s, ok := agProtoString(got)
-	if !ok || s != "Hi, what's up next?" {
-		t.Fatalf("field 17: got %q ok=%v", s, ok)
-	}
+	require.True(t, ok, "field 17 string ok")
+	assert.Equal(t, "Hi, what's up next?", s, "field 17")
 
 	// Field 5 should have nested fields parsed as a Timestamp.
 	tsf, _ := agProtoFind(fields, 5)
-	if tsf.Nested == nil {
-		t.Fatalf("field 5 not parsed as nested")
-	}
+	require.NotNil(t, tsf.Nested, "field 5 not parsed as nested")
 	sec, nanos, ok := agProtoTimestamp(tsf.Nested)
-	if !ok || sec != 1779326586 || nanos != 12345 {
-		t.Fatalf("timestamp: sec=%d nanos=%d ok=%v",
-			sec, nanos, ok)
-	}
+	require.True(t, ok, "timestamp ok")
+	assert.Equal(t, int64(1779326586), sec, "timestamp sec")
+	assert.Equal(t, int32(12345), nanos, "timestamp nanos")
 
 	strs := agProtoCollectStrings(fields, 5)
-	if len(strs) != 1 || strs[0] != "Hi, what's up next?" {
-		t.Fatalf("collect strings: %#v", strs)
-	}
+	require.Len(t, strs, 1)
+	assert.Equal(t, "Hi, what's up next?", strs[0])
 }
 
 // TestAgProtoLengthOverflow feeds a length-delimited field whose
@@ -120,9 +113,8 @@ func TestAgProtoLengthOverflow(t *testing.T) {
 			t.Fatalf("agProtoParse panicked: %v", r)
 		}
 	}()
-	if _, err := agProtoParse(payload); err == nil {
-		t.Fatalf("expected error for oversized length, got nil")
-	}
+	_, err := agProtoParse(payload)
+	require.Error(t, err, "expected error for oversized length")
 }
 
 // TestAgProtoLooksLikePrefix exercises the prefix-tolerant
@@ -134,9 +126,7 @@ func TestAgProtoLooksLikePrefix(t *testing.T) {
 		{num: 1, wire: pbWireVarint, varint: 42},
 		{num: 2, wire: pbWireBytes, bytes: []byte("hello there")},
 	})
-	if !agProtoLooksLikePrefix(complete) {
-		t.Fatalf("complete message rejected")
-	}
+	require.True(t, agProtoLooksLikePrefix(complete), "complete message rejected")
 
 	// Append a length-delimited field whose declared length runs
 	// past the end of the buffer — agProtoParse rejects this, but
@@ -146,20 +136,13 @@ func TestAgProtoLooksLikePrefix(t *testing.T) {
 		// tag for field 3, wire 2; length 100; only 3 actual bytes
 		0x1A, 0x64, 0x41, 0x42, 0x43,
 	)
-	if agProtoLooksLikePrefix(truncated) != true {
-		t.Fatalf("truncated tail rejected; want accepted")
-	}
-	if _, err := agProtoParse(truncated); err == nil {
-		t.Fatalf("agProtoParse should still reject truncated tail")
-	}
+	assert.True(t, agProtoLooksLikePrefix(truncated), "truncated tail rejected")
+	_, err := agProtoParse(truncated)
+	require.Error(t, err, "agProtoParse should still reject truncated tail")
 
 	// Pure garbage with zero clean fields → reject.
-	if agProtoLooksLikePrefix([]byte{0x00, 0x00, 0x00}) {
-		t.Fatalf("zero-field-number garbage accepted")
-	}
-	if agProtoLooksLikePrefix(nil) {
-		t.Fatalf("empty input accepted")
-	}
+	assert.False(t, agProtoLooksLikePrefix([]byte{0x00, 0x00, 0x00}), "zero-field-number garbage accepted")
+	assert.False(t, agProtoLooksLikePrefix(nil), "empty input accepted")
 }
 
 func TestEarliestAntigravityTimestamp(t *testing.T) {
@@ -175,13 +158,9 @@ func TestEarliestAntigravityTimestamp(t *testing.T) {
 		{num: 4, wire: pbWireBytes, bytes: older},
 	})
 	fields, err := agProtoParse(payload)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err, "parse")
 	got := earliestAntigravityTimestamp(fields)
-	if got.Unix() != 1700000000 {
-		t.Fatalf("got %d, want 1700000000", got.Unix())
-	}
+	assert.Equal(t, int64(1700000000), got.Unix())
 }
 
 // ---- CLI parser -----------------------------------------------
@@ -217,57 +196,29 @@ func TestAntigravityCLIDiscoverAndParse(t *testing.T) {
 
 	// Discovery should return the .pb with the right project.
 	files := DiscoverAntigravityCLISessions(root)
-	if len(files) != 1 {
-		t.Fatalf("discover: got %d files, want 1", len(files))
-	}
-	if files[0].Project != "/tmp/proj" {
-		t.Fatalf("project: got %q want /tmp/proj", files[0].Project)
-	}
+	require.Len(t, files, 1, "discover")
+	assert.Equal(t, "/tmp/proj", files[0].Project, "project")
 
 	// Find by id should locate the same .pb.
-	if got := FindAntigravityCLISourceFile(root, id); got !=
-		files[0].Path {
-		t.Fatalf("find: got %q want %q", got, files[0].Path)
-	}
+	assert.Equal(t, files[0].Path, FindAntigravityCLISourceFile(root, id), "find")
 
 	sess, msgs, err := ParseAntigravityCLISession(
 		files[0].Path, files[0].Project, "test-machine",
 	)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if sess.ID != "antigravity-cli:"+id {
-		t.Fatalf("session id: %q", sess.ID)
-	}
+	require.NoError(t, err, "parse")
+	assert.Equal(t, "antigravity-cli:"+id, sess.ID)
 	// One user message from history + one assistant from brain.
-	if len(msgs) != 2 {
-		t.Fatalf("msgs: got %d want 2", len(msgs))
-	}
-	if msgs[0].Role != RoleUser ||
-		!strings.Contains(msgs[0].Content, "hello world") {
-		t.Fatalf("msg0: %+v", msgs[0])
-	}
-	if msgs[1].Role != RoleAssistant ||
-		!strings.Contains(msgs[1].Content, "step one") ||
-		!strings.Contains(msgs[1].Content, "Top task summary") {
-		t.Fatalf("msg1: %+v", msgs[1])
-	}
-	if sess.MessageCount != 2 || sess.UserMessageCount != 1 {
-		t.Fatalf(
-			"counts: msg=%d user=%d",
-			sess.MessageCount, sess.UserMessageCount,
-		)
-	}
-	if sess.FirstMessage != "hello world" {
-		t.Fatalf("first message: %q", sess.FirstMessage)
-	}
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Contains(t, msgs[0].Content, "hello world")
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Contains(t, msgs[1].Content, "step one")
+	assert.Contains(t, msgs[1].Content, "Top task summary")
+	assert.Equal(t, 2, sess.MessageCount)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, "hello world", sess.FirstMessage)
 	// StartedAt is the user message timestamp (epoch ms).
-	if sess.StartedAt.UnixMilli() != 1779000000000 {
-		t.Fatalf(
-			"startedAt: %d want 1779000000000",
-			sess.StartedAt.UnixMilli(),
-		)
-	}
+	assert.Equal(t, int64(1779000000000), sess.StartedAt.UnixMilli())
 }
 
 func TestAntigravityCLIDiscoverIgnoresJunk(t *testing.T) {
@@ -282,9 +233,7 @@ func TestAntigravityCLIDiscoverIgnoresJunk(t *testing.T) {
 	mustWrite(t,
 		filepath.Join(root, "conversations", "bad.name.pb"),
 		[]byte("x"))
-	if files := DiscoverAntigravityCLISessions(root); len(files) != 0 {
-		t.Fatalf("expected 0 files, got %d", len(files))
-	}
+	assert.Empty(t, DiscoverAntigravityCLISessions(root))
 }
 
 // ---- IDE parser -----------------------------------------------
@@ -311,49 +260,34 @@ func TestAntigravityIDEDiscoverAndParse(t *testing.T) {
 		[]byte(`{"summary":"Plan summary","updatedAt":"2026-05-20T22:47:27Z"}`))
 
 	files := DiscoverAntigravitySessions(root)
-	if len(files) != 1 || files[0].Path != dbPath {
-		t.Fatalf("discover: %#v", files)
-	}
-	if got := FindAntigravitySourceFile(root, id); got != dbPath {
-		t.Fatalf("find: got %q want %q", got, dbPath)
-	}
+	require.Len(t, files, 1)
+	assert.Equal(t, dbPath, files[0].Path)
+	assert.Equal(t, dbPath, FindAntigravitySourceFile(root, id))
 
 	sess, msgs, err := ParseAntigravitySession(
 		dbPath, "", "test-machine",
 	)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if sess.ID != "antigravity:"+id {
-		t.Fatalf("session id: %q", sess.ID)
-	}
+	require.NoError(t, err, "parse")
+	assert.Equal(t, "antigravity:"+id, sess.ID)
 	// 2 step rows + 1 brain artifact = 3 messages
-	if len(msgs) != 3 {
-		t.Fatalf("msgs: %d", len(msgs))
-	}
+	require.Len(t, msgs, 3)
 	// step_type=14 should be flagged as user
 	var sawUser, sawAssistant bool
 	for _, m := range msgs {
 		if m.Role == RoleUser {
 			sawUser = true
-			if !strings.Contains(m.Content, "user prompt text") {
-				t.Fatalf("user msg content: %q", m.Content)
-			}
+			assert.Contains(t, m.Content, "user prompt text")
 		}
 		if m.Role == RoleAssistant &&
 			strings.Contains(m.Content, "Plan summary") {
 			sawAssistant = true
 		}
 	}
-	if !sawUser || !sawAssistant {
-		t.Fatalf("missing role(s): user=%v assistant=%v",
-			sawUser, sawAssistant)
-	}
+	assert.True(t, sawUser, "missing user role")
+	assert.True(t, sawAssistant, "missing assistant role")
 	// Annotation overrides endedAt to 2026-05-20T... =
 	// 1779326586
-	if sess.EndedAt.Unix() != 1779326586 {
-		t.Fatalf("endedAt: %d", sess.EndedAt.Unix())
-	}
+	assert.Equal(t, int64(1779326586), sess.EndedAt.Unix())
 }
 
 // ---- crypto: key loading --------------------------------------
@@ -379,32 +313,22 @@ func TestDecryptAesGCMRoundTrip(t *testing.T) {
 	plaintext := []byte("hello antigravity gcm world")
 
 	block, err := aes.NewCipher(key)
-	if err != nil {
-		t.Fatalf("new cipher: %v", err)
-	}
+	require.NoError(t, err, "new cipher")
 	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		t.Fatalf("new gcm: %v", err)
-	}
+	require.NoError(t, err, "new gcm")
 	nonce := bytes.Repeat([]byte{0x01}, 12)
 	ct := gcm.Seal(nil, nonce, plaintext, nil)
 	data := append(append([]byte{}, nonce...), ct...)
 
 	got := decryptAesGCM(data, key, 0)
-	if !bytes.Equal(got, plaintext) {
-		t.Fatalf("decrypt: got %q want %q", got, plaintext)
-	}
+	assert.True(t, bytes.Equal(got, plaintext), "decrypt: got %q want %q", got, plaintext)
 
 	// Wrong key → nil (auth tag fails).
 	bad := bytes.Repeat([]byte{0x43}, 32)
-	if out := decryptAesGCM(data, bad, 0); out != nil {
-		t.Fatalf("wrong key should fail, got %q", out)
-	}
+	assert.Nil(t, decryptAesGCM(data, bad, 0), "wrong key should fail")
 
 	// Too-short input → nil, not panic.
-	if out := decryptAesGCM([]byte{0x00}, key, 0); out != nil {
-		t.Fatalf("short input should return nil, got %q", out)
-	}
+	assert.Nil(t, decryptAesGCM([]byte{0x00}, key, 0), "short input should return nil")
 }
 
 // TestDecryptAesGCMSkip confirms the leading-bytes skip works as
@@ -423,9 +347,7 @@ func TestDecryptAesGCMSkip(t *testing.T) {
 	data = append(data, ct...)
 
 	got := decryptAesGCM(data, key, len(prefix))
-	if !bytes.Equal(got, plaintext) {
-		t.Fatalf("decrypt with skip: got %q want %q", got, plaintext)
-	}
+	assert.True(t, bytes.Equal(got, plaintext), "decrypt with skip: got %q want %q", got, plaintext)
 }
 
 func TestStripPKCS7(t *testing.T) {
@@ -470,9 +392,7 @@ func TestStripPKCS7(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := stripPKCS7(tc.in); !bytes.Equal(got, tc.want) {
-				t.Fatalf("got %v want %v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, stripPKCS7(tc.in))
 		})
 	}
 }
@@ -496,9 +416,7 @@ func TestAntigravityCLIDiscoverImplicit(t *testing.T) {
 		[]byte("x"))
 
 	files := DiscoverAntigravityCLISessions(root)
-	if len(files) != 2 {
-		t.Fatalf("got %d files, want 2 (one per subdir)", len(files))
-	}
+	require.Len(t, files, 2, "got files, want 2 (one per subdir)")
 	var sawConv, sawImpl bool
 	for _, f := range files {
 		switch filepath.Base(filepath.Dir(f.Path)) {
@@ -508,28 +426,22 @@ func TestAntigravityCLIDiscoverImplicit(t *testing.T) {
 			sawImpl = true
 		}
 	}
-	if !sawConv || !sawImpl {
-		t.Fatalf("missing subdir: conv=%v impl=%v",
-			sawConv, sawImpl)
-	}
+	assert.True(t, sawConv, "missing conv subdir")
+	assert.True(t, sawImpl, "missing impl subdir")
 
 	// FindAntigravityCLISourceFile routes implicit-tagged ids to
 	// the implicit/ subdir; bare ids resolve under conversations/.
 	wantImpl := filepath.Join("implicit", implID+".pb")
-	if got := FindAntigravityCLISourceFile(
-		root, "implicit-"+implID,
-	); got == "" || !strings.HasSuffix(got, wantImpl) {
-		t.Fatalf("find implicit: %q", got)
-	}
+	gotImpl := FindAntigravityCLISourceFile(root, "implicit-"+implID)
+	require.NotEmpty(t, gotImpl)
+	assert.True(t, strings.HasSuffix(gotImpl, wantImpl), "find implicit: %q", gotImpl)
 	wantConv := filepath.Join("conversations", convID+".pb")
-	if got := FindAntigravityCLISourceFile(root, convID); got == "" ||
-		!strings.HasSuffix(got, wantConv) {
-		t.Fatalf("find conv: %q", got)
-	}
+	gotConv := FindAntigravityCLISourceFile(root, convID)
+	require.NotEmpty(t, gotConv)
+	assert.True(t, strings.HasSuffix(gotConv, wantConv), "find conv: %q", gotConv)
 	// A bare implicit-only UUID must NOT resolve under conversations/.
-	if got := FindAntigravityCLISourceFile(root, implID); got != "" {
-		t.Fatalf("bare implicit id should not resolve: %q", got)
-	}
+	assert.Empty(t, FindAntigravityCLISourceFile(root, implID),
+		"bare implicit id should not resolve")
 }
 
 // TestAntigravityCLIImplicitSessionIDDistinct ensures a UUID that
@@ -547,33 +459,16 @@ func TestAntigravityCLIImplicitSessionIDDistinct(t *testing.T) {
 	mustWrite(t, implPath, []byte("x"))
 
 	convSess, _, err := ParseAntigravityCLISession(convPath, "", "m")
-	if err != nil {
-		t.Fatalf("parse conv: %v", err)
-	}
+	require.NoError(t, err, "parse conv")
 	implSess, _, err := ParseAntigravityCLISession(implPath, "", "m")
-	if err != nil {
-		t.Fatalf("parse impl: %v", err)
-	}
-	if convSess.ID == implSess.ID {
-		t.Fatalf("session ids collide: conv=%q impl=%q",
-			convSess.ID, implSess.ID)
-	}
-	if convSess.ID != "antigravity-cli:"+id {
-		t.Fatalf("conv id: %q", convSess.ID)
-	}
-	if implSess.ID != "antigravity-cli:implicit-"+id {
-		t.Fatalf("impl id: %q", implSess.ID)
-	}
+	require.NoError(t, err, "parse impl")
+	assert.NotEqual(t, implSess.ID, convSess.ID, "session ids collide")
+	assert.Equal(t, "antigravity-cli:"+id, convSess.ID, "conv id")
+	assert.Equal(t, "antigravity-cli:implicit-"+id, implSess.ID, "impl id")
 
 	// Round-trip: each storage id resolves back to its own file.
-	if got := FindAntigravityCLISourceFile(root, id); got != convPath {
-		t.Fatalf("round-trip conv: %q", got)
-	}
-	if got := FindAntigravityCLISourceFile(
-		root, "implicit-"+id,
-	); got != implPath {
-		t.Fatalf("round-trip impl: %q", got)
-	}
+	assert.Equal(t, convPath, FindAntigravityCLISourceFile(root, id), "round-trip conv")
+	assert.Equal(t, implPath, FindAntigravityCLISourceFile(root, "implicit-"+id), "round-trip impl")
 }
 
 func TestBuildAntigravityProjectMapRobust(t *testing.T) {
@@ -581,9 +476,7 @@ func TestBuildAntigravityProjectMapRobust(t *testing.T) {
 	path := filepath.Join(root, "history.jsonl")
 
 	// Missing file → empty map, no error.
-	if m := buildAntigravityProjectMap(path); len(m) != 0 {
-		t.Fatalf("missing file: got %d entries", len(m))
-	}
+	assert.Empty(t, buildAntigravityProjectMap(path), "missing file")
 
 	// Mix of valid rows, blank lines, garbage, and rows missing
 	// one of the two required fields. Only the valid rows survive.
@@ -596,31 +489,23 @@ func TestBuildAntigravityProjectMapRobust(t *testing.T) {
 			`{"conversationId":"id-3","workspace":"/tmp/c"}`+"\n",
 	))
 	m := buildAntigravityProjectMap(path)
-	if len(m) != 2 {
-		t.Fatalf("got %d entries, want 2: %#v", len(m), m)
-	}
-	if m["id-1"] != "/tmp/a" || m["id-3"] != "/tmp/c" {
-		t.Fatalf("unexpected map: %#v", m)
-	}
-	if _, ok := m["id-2"]; ok {
-		t.Fatalf("id-2 had no workspace, should be absent")
-	}
+	require.Len(t, m, 2, "map entries")
+	assert.Equal(t, "/tmp/a", m["id-1"])
+	assert.Equal(t, "/tmp/c", m["id-3"])
+	_, ok := m["id-2"]
+	assert.False(t, ok, "id-2 had no workspace, should be absent")
 }
 
 // ---- helpers --------------------------------------------------
 
 func mustMkdir(t *testing.T, p string) {
 	t.Helper()
-	if err := os.MkdirAll(p, 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", p, err)
-	}
+	require.NoError(t, os.MkdirAll(p, 0o755), "mkdir %s", p)
 }
 
 func mustWrite(t *testing.T, p string, b []byte) {
 	t.Helper()
-	if err := os.WriteFile(p, b, 0o644); err != nil {
-		t.Fatalf("write %s: %v", p, err)
-	}
+	require.NoError(t, os.WriteFile(p, b, 0o644), "write %s", p)
 }
 
 // createAntigravityTestDB writes a minimal antigravity IDE
@@ -629,9 +514,7 @@ func mustWrite(t *testing.T, p string, b []byte) {
 func createAntigravityTestDB(t *testing.T, path string) {
 	t.Helper()
 	db, err := sql.Open("sqlite3", path)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
+	require.NoError(t, err, "open")
 	defer db.Close()
 	mustExec(t, db, `CREATE TABLE trajectory_meta (
 		trajectory_id text, cascade_id text,
@@ -684,9 +567,8 @@ func mustExec(
 	t *testing.T, db *sql.DB, q string, args ...any,
 ) {
 	t.Helper()
-	if _, err := db.Exec(q, args...); err != nil {
-		t.Fatalf("exec %q: %v", q, err)
-	}
+	_, err := db.Exec(q, args...)
+	require.NoError(t, err, "exec %q", q)
 }
 
 // silence unused warning on time import in case the file is

--- a/internal/parser/claude_subagent_test.go
+++ b/internal/parser/claude_subagent_test.go
@@ -5,6 +5,8 @@ package parser
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // parseAndGetToolCalls is a helper function that takes test lines, runs the parser,
@@ -14,12 +16,8 @@ func parseAndGetToolCalls(t *testing.T, filename string, lines []string) []Parse
 	content := strings.Join(lines, "\n")
 	path := createTestFile(t, filename, content)
 	results, err := ParseClaudeSession(path, "proj", "local")
-	if err != nil {
-		t.Fatalf("ParseClaudeSession: %v", err)
-	}
-	if len(results) == 0 {
-		t.Fatal("no results")
-	}
+	require.NoError(t, err, "ParseClaudeSession")
+	require.NotEmpty(t, results, "no results")
 
 	var toolCalls []ParsedToolCall
 	for _, msg := range results[0].Messages {

--- a/internal/parser/copilot_test.go
+++ b/internal/parser/copilot_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // writeCopilotJSONL writes JSONL lines to a temp file and
@@ -16,11 +19,9 @@ func writeCopilotJSONL(
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test-session.jsonl")
 	content := strings.Join(lines, "\n") + "\n"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		path, []byte(content), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 	return path
 }
 
@@ -28,23 +29,15 @@ func writeCopilotJSONL(
 func parseAndValidateHelper(t *testing.T, path string, machine string, wantMsgs int) (*ParsedSession, []ParsedMessage) {
 	t.Helper()
 	sess, msgs, err := ParseCopilotSession(path, machine)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected non-nil session")
-	}
-	if len(msgs) != wantMsgs {
-		t.Fatalf("got %d messages, want %d", len(msgs), wantMsgs)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, sess, "expected non-nil session")
+	require.Len(t, msgs, wantMsgs)
 	return sess, msgs
 }
 
 func assertEqual[T comparable](t *testing.T, want, got T, name string) {
 	t.Helper()
-	if want != got {
-		t.Errorf("%s = %v, want %v", name, got, want)
-	}
+	assert.Equal(t, want, got, name)
 }
 
 func TestParseCopilotSession_Basic(t *testing.T) {
@@ -81,9 +74,7 @@ func TestParseCopilotSession_ToolCalls(t *testing.T) {
 
 	// Check tool call message.
 	tcMsg := msgs[1]
-	if !tcMsg.HasToolUse {
-		t.Error("expected HasToolUse on tool call message")
-	}
+	assert.True(t, tcMsg.HasToolUse, "expected HasToolUse on tool call message")
 	assertToolCalls(t, tcMsg.ToolCalls, []ParsedToolCall{{
 		ToolName:  "view",
 		Category:  "Read",
@@ -141,21 +132,13 @@ func TestParseCopilotSession_Reasoning(t *testing.T) {
 	_, msgs := parseAndValidateHelper(t, path, "m", 2)
 
 	ast := msgs[1]
-	if !ast.HasThinking {
-		t.Error("expected HasThinking on assistant message with reasoningText")
-	}
-	if !strings.Contains(ast.Content, "[Thinking]\nLet me think about this carefully...\n[/Thinking]") {
-		t.Errorf("expected thinking block in content, got: %q", ast.Content)
-	}
-	if !strings.Contains(ast.Content, "Here is my analysis.") {
-		t.Errorf("expected visible content after thinking block, got: %q", ast.Content)
-	}
+	assert.True(t, ast.HasThinking, "expected HasThinking on assistant message with reasoningText")
+	assert.Contains(t, ast.Content, "[Thinking]\nLet me think about this carefully...\n[/Thinking]")
+	assert.Contains(t, ast.Content, "Here is my analysis.")
 	// Thinking block must precede the visible content.
 	thinkIdx := strings.Index(ast.Content, "[Thinking]")
 	visibleIdx := strings.Index(ast.Content, "Here is my analysis.")
-	if thinkIdx >= visibleIdx {
-		t.Errorf("thinking block should appear before visible content")
-	}
+	assert.Less(t, thinkIdx, visibleIdx, "thinking block should appear before visible content")
 }
 
 func TestParseCopilotSession_ReasoningOnly(t *testing.T) {
@@ -170,12 +153,8 @@ func TestParseCopilotSession_ReasoningOnly(t *testing.T) {
 	_, msgs := parseAndValidateHelper(t, path, "m", 2)
 
 	ast := msgs[1]
-	if !ast.HasThinking {
-		t.Error("expected HasThinking")
-	}
-	if !strings.Contains(ast.Content, "[Thinking]\nPondering the question...\n[/Thinking]") {
-		t.Errorf("expected thinking block in content, got: %q", ast.Content)
-	}
+	assert.True(t, ast.HasThinking, "expected HasThinking")
+	assert.Contains(t, ast.Content, "[Thinking]\nPondering the question...\n[/Thinking]")
 }
 
 func TestParseCopilotSession_AssistantReasoningEvent(t *testing.T) {
@@ -187,17 +166,13 @@ func TestParseCopilotSession_AssistantReasoningEvent(t *testing.T) {
 	)
 
 	_, msgs := parseAndValidateHelper(t, path, "m", 2)
-	if !msgs[1].HasThinking {
-		t.Error("expected HasThinking set by assistant.reasoning event")
-	}
+	assert.True(t, msgs[1].HasThinking, "expected HasThinking set by assistant.reasoning event")
 }
 
 func TestParseCopilotSession_DirectoryFormat(t *testing.T) {
 	dir := t.TempDir()
 	sessDir := filepath.Join(dir, "abc-456")
-	if err := os.MkdirAll(sessDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0o755))
 
 	content := strings.Join([]string{
 		`{"type":"session.start","data":{"sessionId":"abc-456"},"timestamp":"2025-01-15T10:00:00Z"}`,
@@ -206,11 +181,9 @@ func TestParseCopilotSession_DirectoryFormat(t *testing.T) {
 	}, "\n") + "\n"
 
 	path := filepath.Join(sessDir, "events.jsonl")
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		path, []byte(content), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	sess, _ := parseAndValidateHelper(t, path, "m", 2)
 	assertEqual(t, "copilot:abc-456", sess.ID, "session ID")
@@ -230,24 +203,18 @@ func writeDirSession(
 	t.Helper()
 	dir := t.TempDir()
 	sessDir := filepath.Join(dir, sessID)
-	if err := os.MkdirAll(sessDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0o755))
 	eventsPath := filepath.Join(sessDir, "events.jsonl")
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		eventsPath,
 		[]byte(strings.Join(events, "\n")+"\n"),
 		0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 	if workspaceYAML != "" {
 		yamlPath := filepath.Join(sessDir, "workspace.yaml")
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			yamlPath, []byte(workspaceYAML), 0o644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 	return eventsPath
 }
@@ -353,20 +320,14 @@ func TestParseCopilotSession_WorkspaceNameTruncated(t *testing.T) {
 	sess, _ := parseAndValidateHelper(t, path, "m", 2)
 
 	// truncate(s, 300) returns at most 303 bytes (300 runes + "...").
-	if len(sess.FirstMessage) > 303 {
-		t.Errorf("FirstMessage not truncated: len=%d", len(sess.FirstMessage))
-	}
-	if len(sess.FirstMessage) == len(longName) {
-		t.Error("FirstMessage was not truncated at all")
-	}
+	assert.LessOrEqual(t, len(sess.FirstMessage), 303, "FirstMessage not truncated")
+	assert.NotEqual(t, len(longName), len(sess.FirstMessage), "FirstMessage was not truncated at all")
 }
 
 func TestParseCopilotSession_DirectoryFormatFallbackID(t *testing.T) {
 	dir := t.TempDir()
 	sessDir := filepath.Join(dir, "def-789")
-	if err := os.MkdirAll(sessDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0o755))
 
 	// No session.start event, so ID comes from dir name.
 	content := strings.Join([]string{
@@ -375,11 +336,9 @@ func TestParseCopilotSession_DirectoryFormatFallbackID(t *testing.T) {
 	}, "\n") + "\n"
 
 	path := filepath.Join(sessDir, "events.jsonl")
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		path, []byte(content), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	sess, _ := parseAndValidateHelper(t, path, "m", 2)
 	assertEqual(t, "copilot:def-789", sess.ID, "session ID")
@@ -391,30 +350,18 @@ func TestParseCopilotSession_EmptySession(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseCopilotSession(path, "m")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if sess != nil {
-		t.Errorf("expected nil session for empty, got %+v", sess)
-	}
-	if msgs != nil {
-		t.Errorf("expected nil messages for empty, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	assert.Nil(t, sess, "expected nil session for empty")
+	assert.Nil(t, msgs, "expected nil messages for empty")
 }
 
 func TestParseCopilotSession_NonexistentFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nonexistent.jsonl")
 
 	sess, msgs, err := ParseCopilotSession(path, "m")
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
-	}
-	if sess != nil {
-		t.Error("expected nil session for nonexistent file")
-	}
-	if msgs != nil {
-		t.Error("expected nil messages for nonexistent file")
-	}
+	require.NoError(t, err, "expected nil error")
+	assert.Nil(t, sess, "expected nil session for nonexistent file")
+	assert.Nil(t, msgs, "expected nil messages for nonexistent file")
 }
 
 func TestParseCopilotSession_ObjectArguments(t *testing.T) {

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -3,6 +3,9 @@ package parser
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractAssistantContent(t *testing.T) {
@@ -105,23 +108,9 @@ func TestExtractAssistantContent(t *testing.T) {
 			text, hasThinking, toolCalls := extractAssistantContent(
 				tt.lines,
 			)
-			if text != tt.wantText {
-				t.Errorf(
-					"text = %q, want %q", text, tt.wantText,
-				)
-			}
-			if hasThinking != tt.wantThinking {
-				t.Errorf(
-					"hasThinking = %v, want %v",
-					hasThinking, tt.wantThinking,
-				)
-			}
-			if len(toolCalls) != tt.wantToolCount {
-				t.Errorf(
-					"tool call count = %d, want %d",
-					len(toolCalls), tt.wantToolCount,
-				)
-			}
+			assert.Equal(t, tt.wantText, text, "text")
+			assert.Equal(t, tt.wantThinking, hasThinking, "hasThinking")
+			assert.Len(t, toolCalls, tt.wantToolCount, "tool call count")
 		})
 	}
 }
@@ -143,12 +132,7 @@ func TestIsContainedIn_EdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isBlockBodyEnd(tt.line)
-			if got != tt.want {
-				t.Errorf(
-					"isBlockBodyEnd(%q) = %v, want %v",
-					tt.line, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got, "isBlockBodyEnd(%q)", tt.line)
 		})
 	}
 }
@@ -165,9 +149,7 @@ func TestCursorSessionID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
 			got := CursorSessionID(tt.path)
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -225,9 +207,7 @@ func TestIsCursorJSONL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isCursorJSONL(tt.data)
-			if got != tt.want {
-				t.Errorf("got %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -349,64 +329,29 @@ func TestParseCursorJSONL(t *testing.T) {
 			data := strings.Join(tt.lines, "\n")
 			msgs := parseCursorJSONL(data)
 
-			if len(msgs) != tt.wantCount {
-				t.Fatalf(
-					"message count = %d, want %d",
-					len(msgs), tt.wantCount,
-				)
-			}
+			require.Len(t, msgs, tt.wantCount, "message count")
 			if tt.wantCount == 0 {
 				return
 			}
 
 			first := msgs[0]
-			if first.Role != tt.wantFirstRole {
-				t.Errorf(
-					"first role = %q, want %q",
-					first.Role, tt.wantFirstRole,
-				)
-			}
-			if tt.wantFirstContent != "" &&
-				first.Content != tt.wantFirstContent {
-				t.Errorf(
-					"first content = %q, want %q",
-					first.Content, tt.wantFirstContent,
-				)
+			assert.Equal(t, tt.wantFirstRole, first.Role, "first role")
+			if tt.wantFirstContent != "" {
+				assert.Equal(t, tt.wantFirstContent, first.Content, "first content")
 			}
 
 			// Check assistant properties on last message
 			if tt.wantThinking || tt.wantToolUse ||
 				tt.wantToolCount > 0 {
 				last := msgs[len(msgs)-1]
-				if last.HasThinking != tt.wantThinking {
-					t.Errorf(
-						"hasThinking = %v, want %v",
-						last.HasThinking, tt.wantThinking,
-					)
-				}
-				if last.HasToolUse != tt.wantToolUse {
-					t.Errorf(
-						"hasToolUse = %v, want %v",
-						last.HasToolUse, tt.wantToolUse,
-					)
-				}
-				if len(last.ToolCalls) != tt.wantToolCount {
-					t.Errorf(
-						"tool count = %d, want %d",
-						len(last.ToolCalls),
-						tt.wantToolCount,
-					)
-				}
+				assert.Equal(t, tt.wantThinking, last.HasThinking, "hasThinking")
+				assert.Equal(t, tt.wantToolUse, last.HasToolUse, "hasToolUse")
+				assert.Len(t, last.ToolCalls, tt.wantToolCount, "tool count")
 			}
 
 			// Verify ordinals are contiguous
 			for i, m := range msgs {
-				if m.Ordinal != i {
-					t.Errorf(
-						"ordinal[%d] = %d, want %d",
-						i, m.Ordinal, i,
-					)
-				}
+				assert.Equal(t, i, m.Ordinal, "ordinal[%d]", i)
 			}
 		})
 	}
@@ -490,9 +435,7 @@ func TestDecodeCursorProjectDir(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			got := DecodeCursorProjectDir(tt.input)
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -19,12 +22,10 @@ func setupFileSystem(t *testing.T, dir string, files map[string]string) {
 	for path, content := range files {
 		fullPath := filepath.Join(dir, path)
 
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", filepath.Dir(fullPath), err)
-		}
-		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
-			t.Fatalf("write %s: %v", fullPath, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755),
+			"mkdir %s", filepath.Dir(fullPath))
+		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o644),
+			"write %s", fullPath)
 	}
 }
 
@@ -41,26 +42,18 @@ func assertDiscoveredFiles(t *testing.T, got []DiscoveredFile, wantFilenames []s
 	for _, f := range got {
 		base := filepath.Base(f.Path)
 		gotMap[base] = true
-		if f.Agent != wantAgent {
-			t.Errorf("file %q: agent = %q, want %q", base, f.Agent, wantAgent)
-		}
+		assert.Equalf(t, wantAgent, f.Agent, "file %q: agent", base)
 	}
 
-	if len(got) != len(want) {
-		t.Errorf("got %d files total, want %d", len(got), len(want))
-	}
+	assert.Equal(t, len(want), len(got), "files total")
 
 	for file := range want {
-		if !gotMap[file] {
-			t.Errorf("missing expected file: %q", file)
-		}
+		assert.Truef(t, gotMap[file], "missing expected file: %q", file)
 	}
 
 	// Check for unexpected files
 	for file := range gotMap {
-		if !want[file] {
-			t.Errorf("got unexpected file: %q", file)
-		}
+		assert.Truef(t, want[file], "got unexpected file: %q", file)
 	}
 }
 
@@ -115,10 +108,8 @@ func TestDiscoverClaudeProjects(t *testing.T) {
 
 			if tt.name == "Subagents" {
 				for _, f := range files {
-					if f.Project != "project-a" {
-						t.Errorf("file %q: project = %q, want %q",
-							filepath.Base(f.Path), f.Project, "project-a")
-					}
+					assert.Equalf(t, "project-a", f.Project,
+						"file %q: project", filepath.Base(f.Path))
 				}
 			}
 		})
@@ -127,9 +118,7 @@ func TestDiscoverClaudeProjects(t *testing.T) {
 	t.Run("Nonexistent", func(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "does-not-exist")
 		files := DiscoverClaudeProjects(dir)
-		if files != nil {
-			t.Errorf("expected nil, got %d files", len(files))
-		}
+		assert.Nil(t, files, "expected nil")
 	})
 }
 
@@ -219,9 +208,7 @@ func TestDiscoverAmpSessions(t *testing.T) {
 	t.Run("Nonexistent", func(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "does-not-exist")
 		files := DiscoverAmpSessions(dir)
-		if files != nil {
-			t.Errorf("expected nil, got %d files", len(files))
-		}
+		assert.Nil(t, files, "expected nil")
 	})
 }
 
@@ -269,9 +256,7 @@ func TestFindClaudeSourceFile(t *testing.T) {
 				want = filepath.Join(dir, tt.wantFile)
 			}
 
-			if got != want {
-				t.Errorf("got %q, want %q", got, want)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 
@@ -280,9 +265,7 @@ func TestFindClaudeSourceFile(t *testing.T) {
 		tests := []string{"", "../etc/passwd", "a/b", "a b"}
 		for _, id := range tests {
 			got := FindClaudeSourceFile(dir, id)
-			if got != "" {
-				t.Errorf("FindClaudeSourceFile(%q) = %q, want empty", id, got)
-			}
+			assert.Emptyf(t, got, "FindClaudeSourceFile(%q)", id)
 		}
 	})
 }
@@ -298,9 +281,7 @@ func TestFindAmpSourceFile(t *testing.T) {
 			dir, "T-019ca26f-aaaa-bbbb-cccc-dddddddddddd",
 		)
 		want := filepath.Join(dir, rel)
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("Nonexistent", func(t *testing.T) {
@@ -308,9 +289,7 @@ func TestFindAmpSourceFile(t *testing.T) {
 		got := FindAmpSourceFile(
 			dir, "T-019ca26f-aaaa-bbbb-cccc-dddddddddddd",
 		)
-		if got != "" {
-			t.Errorf("expected empty, got %q", got)
-		}
+		assert.Empty(t, got, "expected empty")
 	})
 
 	t.Run("Validation", func(t *testing.T) {
@@ -324,12 +303,7 @@ func TestFindAmpSourceFile(t *testing.T) {
 		}
 		for _, id := range tests {
 			got := FindAmpSourceFile(dir, id)
-			if got != "" {
-				t.Errorf(
-					"FindAmpSourceFile(%q) = %q, want empty",
-					id, got,
-				)
-			}
+			assert.Emptyf(t, got, "FindAmpSourceFile(%q)", id)
 		}
 	})
 }
@@ -386,9 +360,7 @@ func TestFindCodexSourceFile(t *testing.T) {
 				want = filepath.Join(dir, tt.wantFile)
 			}
 
-			if got != want {
-				t.Errorf("got %q, want %q", got, want)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 }
@@ -423,10 +395,7 @@ func TestExtractUUIDFromRollout(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.filename, func(t *testing.T) {
 			got := extractUUIDFromRollout(tt.filename)
-			if got != tt.want {
-				t.Errorf("extractUUID(%q) = %q, want %q",
-					tt.filename, got, tt.want)
-			}
+			assert.Equalf(t, tt.want, got, "extractUUID(%q)", tt.filename)
 		})
 	}
 }
@@ -448,10 +417,7 @@ func TestIsValidSessionID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.id, func(t *testing.T) {
 			got := IsValidSessionID(tt.id)
-			if got != tt.want {
-				t.Errorf("IsValidSessionID(%q) = %v, want %v",
-					tt.id, got, tt.want)
-			}
+			assert.Equalf(t, tt.want, got, "IsValidSessionID(%q)", tt.id)
 		})
 	}
 }
@@ -472,10 +438,7 @@ func TestIsDigits(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.s, func(t *testing.T) {
 			got := IsDigits(tt.s)
-			if got != tt.want {
-				t.Errorf("IsDigits(%q) = %v, want %v",
-					tt.s, got, tt.want)
-			}
+			assert.Equalf(t, tt.want, got, "IsDigits(%q)", tt.s)
 		})
 	}
 }
@@ -537,9 +500,7 @@ func TestDiscoverGeminiSessions(t *testing.T) {
 
 			files := DiscoverGeminiSessions(dir)
 
-			if len(files) != len(tt.wantFiles) {
-				t.Fatalf("got %d files, want %d", len(files), len(tt.wantFiles))
-			}
+			require.Len(t, files, len(tt.wantFiles), "files count")
 
 			wantMap := make(map[string]bool)
 			for _, p := range tt.wantFiles {
@@ -547,39 +508,28 @@ func TestDiscoverGeminiSessions(t *testing.T) {
 			}
 
 			for _, f := range files {
-				if f.Agent != AgentGemini {
-					t.Errorf("agent = %q, want %q", f.Agent, AgentGemini)
-				}
-				if !wantMap[f.Path] {
-					t.Errorf("unexpected file discovered: %q", f.Path)
-				}
+				assert.Equal(t, AgentGemini, f.Agent, "agent")
+				assert.Truef(t, wantMap[f.Path],
+					"unexpected file discovered: %q", f.Path)
 			}
 		})
 	}
 
 	t.Run("EmptyChatDir", func(t *testing.T) {
 		dir := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(dir, "tmp", "hash1", geminiChatsDir), 0o755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "tmp", "hash1", geminiChatsDir), 0o755), "mkdir")
 		files := DiscoverGeminiSessions(dir)
-		if files != nil {
-			t.Errorf("expected nil, got %d files", len(files))
-		}
+		assert.Nil(t, files, "expected nil")
 	})
 
 	t.Run("Nonexistent", func(t *testing.T) {
 		files := DiscoverGeminiSessions(filepath.Join(t.TempDir(), "does-not-exist"))
-		if files != nil {
-			t.Errorf("expected nil, got %d files", len(files))
-		}
+		assert.Nil(t, files, "expected nil")
 	})
 
 	t.Run("EmptyDir", func(t *testing.T) {
 		files := DiscoverGeminiSessions("")
-		if files != nil {
-			t.Errorf("expected nil, got %d files", len(files))
-		}
+		assert.Nil(t, files, "expected nil")
 	})
 }
 
@@ -627,9 +577,7 @@ func TestFindGeminiSourceFile(t *testing.T) {
 				want = filepath.Join(dir, tt.wantFile)
 			}
 
-			if got != want {
-				t.Errorf("got %q, want %q", got, want)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 
@@ -637,59 +585,41 @@ func TestFindGeminiSourceFile(t *testing.T) {
 		dir := t.TempDir()
 		for _, id := range []string{"", "a", "abc", "1234567"} {
 			got := FindGeminiSourceFile(dir, id)
-			if got != "" {
-				t.Errorf("FindGeminiSourceFile(%q) = %q, want empty", id, got)
-			}
+			assert.Emptyf(t, got, "FindGeminiSourceFile(%q)", id)
 		}
 	})
 
 	t.Run("EmptyDir", func(t *testing.T) {
 		got := FindGeminiSourceFile("", "b0a4eadd-cb99-4165-94d9-64cad5a66d24")
-		if got != "" {
-			t.Errorf("expected empty, got %q", got)
-		}
+		assert.Empty(t, got, "expected empty")
 	})
 }
 
 func TestGeminiPathHash(t *testing.T) {
 	hash := geminiPathHash("/Users/alice/code/sample-repo")
-	if len(hash) != 64 {
-		t.Errorf("hash length = %d, want 64", len(hash))
-	}
-	if geminiPathHash("/Users/alice/code/sample-repo") != hash {
-		t.Error("hash not deterministic")
-	}
+	assert.Len(t, hash, 64, "hash length")
+	assert.Equal(t, hash, geminiPathHash("/Users/alice/code/sample-repo"),
+		"hash not deterministic")
 }
 
 func TestBuildGeminiProjectMap(t *testing.T) {
 	dir := t.TempDir()
 	projectsJSON := `{"projects":{"/Users/alice/code/my-app":"my-app"}}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "projects.json"),
 		[]byte(projectsJSON), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	), "write")
 
 	m := BuildGeminiProjectMap(dir)
 
 	hash := geminiPathHash("/Users/alice/code/my-app")
-	if m[hash] != "my_app" {
-		t.Errorf("project for hash = %q, want %q",
-			m[hash], "my_app")
-	}
-
-	if m["my-app"] != "my_app" {
-		t.Errorf("project for name = %q, want %q",
-			m["my-app"], "my_app")
-	}
+	assert.Equal(t, "my_app", m[hash], "project for hash")
+	assert.Equal(t, "my_app", m["my-app"], "project for name")
 }
 
 func TestBuildGeminiProjectMapMissingFile(t *testing.T) {
 	m := BuildGeminiProjectMap(t.TempDir())
-	if len(m) != 0 {
-		t.Errorf("expected empty map, got %d entries", len(m))
-	}
+	assert.Empty(t, m, "expected empty map")
 }
 
 func TestResolveGeminiProject(t *testing.T) {
@@ -736,9 +666,7 @@ func TestResolveGeminiProject(t *testing.T) {
 			got := ResolveGeminiProject(
 				tt.dirName, projectMap,
 			)
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -747,89 +675,62 @@ func TestBuildGeminiProjectMapTrustedFolders(t *testing.T) {
 	dir := t.TempDir()
 
 	tfJSON := `{"trustedFolders":["/Users/alice/code/my-app","/Users/alice/code/other"]}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "trustedFolders.json"),
 		[]byte(tfJSON), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	), "write")
 
 	m := BuildGeminiProjectMap(dir)
 
 	hash1 := geminiPathHash("/Users/alice/code/my-app")
-	if m[hash1] != "my_app" {
-		t.Errorf("hash for my-app = %q, want %q",
-			m[hash1], "my_app")
-	}
+	assert.Equal(t, "my_app", m[hash1], "hash for my-app")
 	hash2 := geminiPathHash("/Users/alice/code/other")
-	if m[hash2] != "other" {
-		t.Errorf("hash for other = %q, want %q",
-			m[hash2], "other")
-	}
+	assert.Equal(t, "other", m[hash2], "hash for other")
 }
 
 func TestBuildGeminiProjectMapBothFiles(t *testing.T) {
 	dir := t.TempDir()
 
 	pJSON := `{"projects":{"/Users/alice/code/proj-a":"proj-a"}}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "projects.json"),
 		[]byte(pJSON), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	), "write")
 
 	tfJSON := `{"trustedFolders":["/Users/alice/code/proj-b"]}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "trustedFolders.json"),
 		[]byte(tfJSON), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	), "write")
 
 	m := BuildGeminiProjectMap(dir)
 
 	hashA := geminiPathHash("/Users/alice/code/proj-a")
-	if m[hashA] != "proj_a" {
-		t.Errorf("proj-a hash = %q, want %q",
-			m[hashA], "proj_a")
-	}
+	assert.Equal(t, "proj_a", m[hashA], "proj-a hash")
 	hashB := geminiPathHash("/Users/alice/code/proj-b")
-	if m[hashB] != "proj_b" {
-		t.Errorf("proj-b hash = %q, want %q",
-			m[hashB], "proj_b")
-	}
+	assert.Equal(t, "proj_b", m[hashB], "proj-b hash")
 }
 
 func TestBuildGeminiProjectMapProjectsWin(t *testing.T) {
 	dir := t.TempDir()
 
 	pJSON := `{"projects":{"/Users/alice/code/my-app":"my-app"}}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "projects.json"),
 		[]byte(pJSON), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	), "write")
 
 	tfJSON := `{"trustedFolders":["/Users/alice/code/my-app"]}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "trustedFolders.json"),
 		[]byte(tfJSON), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	), "write")
 
 	m := BuildGeminiProjectMap(dir)
 
 	hash := geminiPathHash("/Users/alice/code/my-app")
-	if m[hash] != "my_app" {
-		t.Errorf("hash = %q, want %q", m[hash], "my_app")
-	}
-	if m["my-app"] != "my_app" {
-		t.Errorf("name key = %q, want %q",
-			m["my-app"], "my_app")
-	}
+	assert.Equal(t, "my_app", m[hash], "hash")
+	assert.Equal(t, "my_app", m["my-app"], "name key")
 }
 
 // --- Copilot discovery tests ---
@@ -909,9 +810,7 @@ func TestDiscoverCopilotSessions(t *testing.T) {
 
 			files := DiscoverCopilotSessions(dir)
 
-			if len(files) != len(tt.wantFiles) {
-				t.Fatalf("got %d files, want %d", len(files), len(tt.wantFiles))
-			}
+			require.Len(t, files, len(tt.wantFiles), "files count")
 
 			wantMap := make(map[string]bool)
 			for _, p := range tt.wantFiles {
@@ -919,28 +818,21 @@ func TestDiscoverCopilotSessions(t *testing.T) {
 			}
 
 			for _, f := range files {
-				if f.Agent != AgentCopilot {
-					t.Errorf("agent = %q, want %q", f.Agent, AgentCopilot)
-				}
-				if !wantMap[f.Path] {
-					t.Errorf("unexpected file discovered: %q", f.Path)
-				}
+				assert.Equal(t, AgentCopilot, f.Agent, "agent")
+				assert.Truef(t, wantMap[f.Path],
+					"unexpected file discovered: %q", f.Path)
 			}
 		})
 	}
 
 	t.Run("EmptyDir", func(t *testing.T) {
 		files := DiscoverCopilotSessions("")
-		if files != nil {
-			t.Errorf("expected nil, got %d files", len(files))
-		}
+		assert.Nil(t, files, "expected nil")
 	})
 
 	t.Run("Nonexistent", func(t *testing.T) {
 		files := DiscoverCopilotSessions(filepath.Join(t.TempDir(), "does-not-exist"))
-		if files != nil {
-			t.Errorf("expected nil, got %d files", len(files))
-		}
+		assert.Nil(t, files, "expected nil")
 	})
 }
 
@@ -991,9 +883,7 @@ func TestFindCopilotSourceFile(t *testing.T) {
 				want = filepath.Join(dir, tt.wantFile)
 			}
 
-			if got != want {
-				t.Errorf("got %q, want %q", got, want)
-			}
+			assert.Equal(t, want, got)
 		})
 	}
 
@@ -1001,17 +891,13 @@ func TestFindCopilotSourceFile(t *testing.T) {
 		dir := t.TempDir()
 		for _, id := range []string{"", "../etc/passwd", "a/b", "a b"} {
 			got := FindCopilotSourceFile(dir, id)
-			if got != "" {
-				t.Errorf("FindCopilotSourceFile(%q) = %q, want empty", id, got)
-			}
+			assert.Emptyf(t, got, "FindCopilotSourceFile(%q)", id)
 		}
 	})
 
 	t.Run("EmptyDir", func(t *testing.T) {
 		got := FindCopilotSourceFile("", "abc-123")
-		if got != "" {
-			t.Errorf("expected empty, got %q", got)
-		}
+		assert.Empty(t, got, "expected empty")
 	})
 }
 
@@ -1021,16 +907,10 @@ func TestIsDirOrSymlink(t *testing.T) {
 	dir := t.TempDir()
 
 	realDir := filepath.Join(dir, "real-dir")
-	if err := os.MkdirAll(realDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(realDir, 0o755), "mkdir")
 
 	realFile := filepath.Join(dir, "file.txt")
-	if err := os.WriteFile(
-		realFile, []byte("hi"), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	require.NoError(t, os.WriteFile(realFile, []byte("hi"), 0o644), "write")
 
 	if err := os.Symlink(
 		realDir, filepath.Join(dir, "link-to-dir"),
@@ -1038,23 +918,17 @@ func TestIsDirOrSymlink(t *testing.T) {
 		t.Skipf("symlink not supported: %v", err)
 	}
 
-	if err := os.Symlink(
+	require.NoError(t, os.Symlink(
 		realFile, filepath.Join(dir, "link-to-file"),
-	); err != nil {
-		t.Fatalf("symlink: %v", err)
-	}
+	), "symlink")
 
-	if err := os.Symlink(
+	require.NoError(t, os.Symlink(
 		filepath.Join(dir, "gone"),
 		filepath.Join(dir, "broken"),
-	); err != nil {
-		t.Fatalf("symlink: %v", err)
-	}
+	), "symlink")
 
 	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("readdir: %v", err)
-	}
+	require.NoError(t, err, "readdir")
 
 	want := map[string]bool{
 		"real-dir":     true,
@@ -1070,25 +944,18 @@ func TestIsDirOrSymlink(t *testing.T) {
 			continue
 		}
 		got := isDirOrSymlink(e, dir)
-		if got != expected {
-			t.Errorf("isDirOrSymlink(%q) = %v, want %v",
-				e.Name(), got, expected)
-		}
+		assert.Equalf(t, expected, got, "isDirOrSymlink(%q)", e.Name())
 	}
 }
 
 func TestFindClaudeSourceFile_Symlink(t *testing.T) {
 	externalDir := t.TempDir()
 	realDir := filepath.Join(externalDir, "real-project")
-	if err := os.MkdirAll(realDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(
+	require.NoError(t, os.MkdirAll(realDir, 0o755), "mkdir")
+	require.NoError(t, os.WriteFile(
 		filepath.Join(realDir, "sess-abc.jsonl"),
 		[]byte("{}"), 0o644,
-	); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	), "write")
 
 	searchDir := t.TempDir()
 	linkDir := filepath.Join(searchDir, "linked-project")
@@ -1097,12 +964,9 @@ func TestFindClaudeSourceFile_Symlink(t *testing.T) {
 	}
 
 	got := FindClaudeSourceFile(searchDir, "sess-abc")
-	if got == "" {
-		t.Fatal("expected to find session via symlink")
-	}
-	if filepath.Dir(got) != linkDir {
-		t.Errorf("expected path through symlink, got %q", got)
-	}
+	require.NotEmpty(t, got, "expected to find session via symlink")
+	assert.Equal(t, linkDir, filepath.Dir(got),
+		"expected path through symlink")
 }
 
 func TestIsContainedIn(t *testing.T) {
@@ -1151,12 +1015,8 @@ func TestIsContainedIn(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isContainedIn(tt.child, tt.root)
-			if got != tt.want {
-				t.Errorf(
-					"isContainedIn(%q, %q) = %v, want %v",
-					tt.child, tt.root, got, tt.want,
-				)
-			}
+			assert.Equalf(t, tt.want, got,
+				"isContainedIn(%q, %q)", tt.child, tt.root)
 		})
 	}
 }
@@ -1208,19 +1068,9 @@ func TestDiscoverCursorSessions(t *testing.T) {
 			dir := t.TempDir()
 			setupFileSystem(t, dir, tt.files)
 			files := DiscoverCursorSessions(dir)
-			if len(files) != tt.wantCount {
-				t.Fatalf(
-					"got %d files, want %d",
-					len(files), tt.wantCount,
-				)
-			}
+			require.Len(t, files, tt.wantCount, "files count")
 			for _, f := range files {
-				if f.Agent != AgentCursor {
-					t.Errorf(
-						"agent = %q, want %q",
-						f.Agent, AgentCursor,
-					)
-				}
+				assert.Equal(t, AgentCursor, f.Agent, "agent")
 			}
 		})
 	}
@@ -1291,19 +1141,9 @@ func TestDiscoverCursorSessions_NestedLayout(t *testing.T) {
 			dir := t.TempDir()
 			setupFileSystem(t, dir, tt.files)
 			files := DiscoverCursorSessions(dir)
-			if len(files) != tt.wantCount {
-				t.Fatalf(
-					"got %d files, want %d",
-					len(files), tt.wantCount,
-				)
-			}
+			require.Len(t, files, tt.wantCount, "files count")
 			for _, f := range files {
-				if f.Agent != AgentCursor {
-					t.Errorf(
-						"agent = %q, want %q",
-						f.Agent, AgentCursor,
-					)
-				}
+				assert.Equal(t, AgentCursor, f.Agent, "agent")
 			}
 		})
 	}
@@ -1319,14 +1159,9 @@ func TestDiscoverCursorSessions_DedupPrefersJsonl(t *testing.T) {
 		filepath.Join(transcripts, "sess.jsonl"): `{"role":"user"}`,
 	})
 	files := DiscoverCursorSessions(dir)
-	if len(files) != 1 {
-		t.Fatalf("got %d files, want 1", len(files))
-	}
-	if !strings.HasSuffix(files[0].Path, ".jsonl") {
-		t.Errorf(
-			"expected .jsonl path, got %q", files[0].Path,
-		)
-	}
+	require.Len(t, files, 1, "files count")
+	assert.True(t, strings.HasSuffix(files[0].Path, ".jsonl"),
+		"expected .jsonl path, got %q", files[0].Path)
 }
 
 func TestParseCursorTranscriptRelPath(t *testing.T) {
@@ -1385,15 +1220,8 @@ func TestParseCursorTranscriptRelPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotProject, gotOK := ParseCursorTranscriptRelPath(tt.rel)
-			if gotOK != tt.wantOK {
-				t.Fatalf("ok = %v, want %v", gotOK, tt.wantOK)
-			}
-			if gotProject != tt.wantProject {
-				t.Errorf(
-					"project = %q, want %q",
-					gotProject, tt.wantProject,
-				)
-			}
+			require.Equal(t, tt.wantOK, gotOK, "ok")
+			assert.Equal(t, tt.wantProject, gotProject, "project")
 		})
 	}
 }
@@ -1409,9 +1237,7 @@ func TestFindCursorSourceFile(t *testing.T) {
 			filepath.Join(cursorTranscripts, "sess1.txt"): "data",
 		})
 		got := FindCursorSourceFile(dir, "sess1")
-		if got == "" {
-			t.Fatal("expected to find .txt file")
-		}
+		assert.NotEmpty(t, got, "expected to find .txt file")
 	})
 
 	t.Run("FindsJsonl", func(t *testing.T) {
@@ -1420,9 +1246,7 @@ func TestFindCursorSourceFile(t *testing.T) {
 			filepath.Join(cursorTranscripts, "sess2.jsonl"): "{}",
 		})
 		got := FindCursorSourceFile(dir, "sess2")
-		if got == "" {
-			t.Fatal("expected to find .jsonl file")
-		}
+		assert.NotEmpty(t, got, "expected to find .jsonl file")
 	})
 
 	t.Run("PrefersJsonlWhenBothExist", func(t *testing.T) {
@@ -1435,12 +1259,7 @@ func TestFindCursorSourceFile(t *testing.T) {
 			dir, cursorTranscripts, "sess3.jsonl",
 		)
 		got := FindCursorSourceFile(dir, "sess3")
-		if got != jsonlPath {
-			t.Errorf(
-				"got %q, want %q (.jsonl preferred)",
-				got, jsonlPath,
-			)
-		}
+		assert.Equal(t, jsonlPath, got, "(.jsonl preferred)")
 	})
 
 	t.Run("FindsNestedJsonl", func(t *testing.T) {
@@ -1449,12 +1268,9 @@ func TestFindCursorSourceFile(t *testing.T) {
 			filepath.Join(cursorTranscripts, "sess4", "sess4.jsonl"): "{}",
 		})
 		got := FindCursorSourceFile(dir, "sess4")
-		if got == "" {
-			t.Fatal("expected to find nested .jsonl file")
-		}
-		if !strings.HasSuffix(got, filepath.Join("sess4", "sess4.jsonl")) {
-			t.Errorf("unexpected path %q", got)
-		}
+		require.NotEmpty(t, got, "expected to find nested .jsonl file")
+		assert.True(t, strings.HasSuffix(got, filepath.Join("sess4", "sess4.jsonl")),
+			"unexpected path %q", got)
 	})
 
 	t.Run("PrefersJsonlOverNestedTxt", func(t *testing.T) {
@@ -1464,31 +1280,25 @@ func TestFindCursorSourceFile(t *testing.T) {
 			filepath.Join(cursorTranscripts, "sess5", "sess5.jsonl"): "new",
 		})
 		got := FindCursorSourceFile(dir, "sess5")
-		if !strings.HasSuffix(got, "sess5.jsonl") {
-			t.Errorf("expected .jsonl path, got %q", got)
-		}
+		assert.True(t, strings.HasSuffix(got, "sess5.jsonl"),
+			"expected .jsonl path, got %q", got)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
 		dir := t.TempDir()
 		got := FindCursorSourceFile(dir, "nonexistent")
-		if got != "" {
-			t.Errorf("expected empty, got %q", got)
-		}
+		assert.Empty(t, got, "expected empty")
 	})
 }
 
 func TestIsPiSessionFile(t *testing.T) {
 	t.Run("ValidSession", func(t *testing.T) {
 		f, err := os.CreateTemp(t.TempDir(), "pi-*.jsonl")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, _ = f.WriteString(`{"type":"session","id":"abc"}` + "\n")
 		f.Close()
-		if !IsPiSessionFile(f.Name()) {
-			t.Error("expected true for valid session file")
-		}
+		assert.True(t, IsPiSessionFile(f.Name()),
+			"expected true for valid session file")
 	})
 
 	t.Run("LongHeaderLine", func(t *testing.T) {
@@ -1496,48 +1306,36 @@ func TestIsPiSessionFile(t *testing.T) {
 		padding := strings.Repeat("x", 2*1024*1024)
 		line := `{"type":"session","id":"abc","pad":"` + padding + `"}` + "\n"
 		f, err := os.CreateTemp(t.TempDir(), "pi-*.jsonl")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, _ = f.WriteString(line)
 		f.Close()
-		if !IsPiSessionFile(f.Name()) {
-			t.Error("expected true for session file with long header line (>1 MiB)")
-		}
+		assert.True(t, IsPiSessionFile(f.Name()),
+			"expected true for session file with long header line (>1 MiB)")
 	})
 
 	t.Run("LeadingBlankLines", func(t *testing.T) {
 		f, err := os.CreateTemp(t.TempDir(), "pi-*.jsonl")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, _ = f.WriteString("\n\n" + `{"type":"session","id":"abc"}` + "\n")
 		f.Close()
-		if !IsPiSessionFile(f.Name()) {
-			t.Error("expected true for session file with leading blank lines")
-		}
+		assert.True(t, IsPiSessionFile(f.Name()),
+			"expected true for session file with leading blank lines")
 	})
 
 	t.Run("NonSessionJSON", func(t *testing.T) {
 		f, err := os.CreateTemp(t.TempDir(), "pi-*.jsonl")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, _ = f.WriteString(`{"type":"message","id":"abc"}` + "\n")
 		f.Close()
-		if IsPiSessionFile(f.Name()) {
-			t.Error("expected false for non-session JSON")
-		}
+		assert.False(t, IsPiSessionFile(f.Name()),
+			"expected false for non-session JSON")
 	})
 
 	t.Run("EmptyFile", func(t *testing.T) {
 		f, err := os.CreateTemp(t.TempDir(), "pi-*.jsonl")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		f.Close()
-		if IsPiSessionFile(f.Name()) {
-			t.Error("expected false for empty file")
-		}
+		assert.False(t, IsPiSessionFile(f.Name()),
+			"expected false for empty file")
 	})
 }

--- a/internal/parser/forge_test.go
+++ b/internal/parser/forge_test.go
@@ -4,6 +4,9 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const forgeSchema = `
@@ -39,21 +42,16 @@ func (s *ForgeSeeder) AddConversation(
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		conversationID, title, workspaceID, context, createdAt, updatedAt, metrics,
 	)
-	if err != nil {
-		s.t.Fatalf("add conversation: %v", err)
-	}
+	require.NoError(s.t, err, "add conversation")
 }
 
 func newForgeTestDB(t *testing.T) (string, *ForgeSeeder, *sql.DB) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), ".forge.db")
 	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("open test db: %v", err)
-	}
-	if _, err := db.Exec(forgeSchema); err != nil {
-		t.Fatalf("create schema: %v", err)
-	}
+	require.NoError(t, err, "open test db")
+	_, err = db.Exec(forgeSchema)
+	require.NoError(t, err, "create schema")
 	seeder := &ForgeSeeder{db: db, t: t}
 	return dbPath, seeder, db
 }
@@ -169,9 +167,7 @@ func TestParseForgeDB_StandardConversation(t *testing.T) {
 	seedForgeConversation(t, seeder)
 
 	sessions, err := ParseForgeDB(dbPath, "testmachine")
-	if err != nil {
-		t.Fatalf("ParseForgeDB: %v", err)
-	}
+	require.NoError(t, err, "ParseForgeDB")
 
 	assertEq(t, "sessions len", len(sessions), 1)
 	s := sessions[0]
@@ -205,12 +201,8 @@ func TestParseForgeSession_SingleConversation(t *testing.T) {
 	seedForgeConversation(t, seeder)
 
 	sess, msgs, err := ParseForgeSession(dbPath, "conv-001", "testmachine")
-	if err != nil {
-		t.Fatalf("ParseForgeSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected non-nil session")
-	}
+	require.NoError(t, err, "ParseForgeSession")
+	require.NotNil(t, sess, "expected non-nil session")
 
 	assertEq(t, "ID", sess.ID, "forge:conv-001")
 	assertEq(t, "Agent", sess.Agent, AgentForge)
@@ -228,16 +220,12 @@ func TestListForgeSessionMeta(t *testing.T) {
 	seedForgeConversation(t, seeder)
 
 	metas, err := ListForgeSessionMeta(dbPath)
-	if err != nil {
-		t.Fatalf("ListForgeSessionMeta: %v", err)
-	}
+	require.NoError(t, err, "ListForgeSessionMeta")
 
 	assertEq(t, "metas len", len(metas), 1)
 	assertEq(t, "SessionID", metas[0].SessionID, "conv-001")
 	assertEq(t, "VirtualPath", metas[0].VirtualPath, dbPath+"#conv-001")
-	if metas[0].FileMtime == 0 {
-		t.Error("expected non-zero FileMtime")
-	}
+	assert.NotZero(t, metas[0].FileMtime, "expected non-zero FileMtime")
 }
 
 func TestCollectForgeToolCalls_TaskSubagentIDPrefixed(t *testing.T) {
@@ -279,15 +267,9 @@ func TestCollectForgeToolCalls_TaskSubagentIDPrefixed(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseForgeSession(dbPath, "parent-conv", "m")
-	if err != nil {
-		t.Fatalf("ParseForgeSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected non-nil session")
-	}
-	if len(msgs) == 0 {
-		t.Fatal("expected messages")
-	}
+	require.NoError(t, err, "ParseForgeSession")
+	require.NotNil(t, sess, "expected non-nil session")
+	require.NotEmpty(t, msgs, "expected messages")
 	var taskCall *ParsedToolCall
 	for i := range msgs {
 		for j := range msgs[i].ToolCalls {
@@ -296,9 +278,7 @@ func TestCollectForgeToolCalls_TaskSubagentIDPrefixed(t *testing.T) {
 			}
 		}
 	}
-	if taskCall == nil {
-		t.Fatal("expected task tool call")
-	}
+	require.NotNil(t, taskCall, "expected task tool call")
 	assertEq(t, "SubagentSessionID", taskCall.SubagentSessionID, "forge:child-conv-001")
 }
 
@@ -362,20 +342,15 @@ func TestForgeTokenFallbacks(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		s := sessions[0].Session
 		assertEq(t, "HasTotalOutputTokens", s.HasTotalOutputTokens, true)
 		assertEq(t, "TotalOutputTokens", s.TotalOutputTokens, 25) // 10+15
 		assertEq(t, "HasPeakContextTokens", s.HasPeakContextTokens, true)
-		if s.PeakContextTokens != 110 && s.PeakContextTokens != 70 {
-			// Peak is max(50+20=70, 80+30=110) = 110
-			t.Errorf("PeakContextTokens = %d, want 110", s.PeakContextTokens)
-		}
+		// Peak is max(50+20=70, 80+30=110) = 110
+		assert.Contains(t, []int{110, 70}, s.PeakContextTokens,
+			"PeakContextTokens = %d, want 110", s.PeakContextTokens)
 	})
 
 	// Case 2: metrics has only output_tokens (no input, no cached).
@@ -413,12 +388,8 @@ func TestForgeTokenFallbacks(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		s := sessions[0].Session
 		assertEq(t, "HasTotalOutputTokens", s.HasTotalOutputTokens, true)
 		assertEq(t, "TotalOutputTokens", s.TotalOutputTokens, 42)
@@ -456,16 +427,10 @@ func TestForgeTokenFallbacks(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		msgs := sessions[0].Messages
-		if len(msgs) == 0 {
-			t.Fatal("want at least 1 message")
-		}
+		require.NotEmpty(t, msgs, "want at least 1 message")
 		assertEq(t, "HasContextTokens", msgs[0].HasContextTokens, true)
 		assertEq(t, "ContextTokens", msgs[0].ContextTokens, 60) // only prompt, no cached
 	})
@@ -496,16 +461,10 @@ func TestForgeTokenFallbacks(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		msgs := sessions[0].Messages
-		if len(msgs) == 0 {
-			t.Fatal("want at least 1 message")
-		}
+		require.NotEmpty(t, msgs, "want at least 1 message")
 		m := msgs[0]
 		assertEq(t, "HasContextTokens", m.HasContextTokens, false)
 		assertEq(t, "HasOutputTokens", m.HasOutputTokens, false)
@@ -556,12 +515,8 @@ func TestForgeDegenerate(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		// Only the user message; empty assistant was skipped.
 		assertEq(t, "messages len", len(sessions[0].Messages), 1)
 		assertEq(t, "role", sessions[0].Messages[0].Role, RoleUser)
@@ -602,12 +557,8 @@ func TestForgeDegenerate(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		// Only the user message; tool result with empty call_id was skipped.
 		assertEq(t, "messages len", len(sessions[0].Messages), 1)
 	})
@@ -639,12 +590,8 @@ func TestForgeDegenerate(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		msgs := sessions[0].Messages
 		assertEq(t, "messages len", len(msgs), 1)
 		assertEq(t, "content", msgs[0].Content, "raw text fallback")
@@ -682,12 +629,8 @@ func TestForgeCwdEdgeCases(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		s := sessions[0].Session
 		assertEq(t, "Cwd", s.Cwd, "")
 		assertEq(t, "Project", s.Project, ExtractProjectFromCwd(""))
@@ -728,12 +671,8 @@ func TestForgeCwdEdgeCases(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		assertEq(t, "Cwd", sessions[0].Session.Cwd, "")
 	})
 
@@ -772,12 +711,8 @@ func TestForgeCwdEdgeCases(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		assertEq(t, "Cwd", sessions[0].Session.Cwd, "")
 	})
 
@@ -807,12 +742,8 @@ func TestForgeCwdEdgeCases(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		s := sessions[0].Session
 		assertEq(t, "Cwd", s.Cwd, "/home/mj/dev/projects/myapp")
 		assertEq(t, "Project", s.Project, "myapp")
@@ -839,11 +770,12 @@ func TestParseForgeTimestamp(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.input, func(t *testing.T) {
 			got := parseForgeTimestamp(tc.input)
-			if tc.empty && !got.IsZero() {
-				t.Errorf("parseForgeTimestamp(%q) = %v, want zero", tc.input, got)
-			}
-			if !tc.empty && got.IsZero() {
-				t.Errorf("parseForgeTimestamp(%q) returned zero time", tc.input)
+			if tc.empty {
+				assert.True(t, got.IsZero(),
+					"parseForgeTimestamp(%q) = %v, want zero", tc.input, got)
+			} else {
+				assert.False(t, got.IsZero(),
+					"parseForgeTimestamp(%q) returned zero time", tc.input)
 			}
 		})
 	}
@@ -879,24 +811,16 @@ func TestForgeEndedAtFallback(t *testing.T) {
 		"",
 	)
 	// Override to NULL updated_at.
-	if _, err := db.Exec("UPDATE conversations SET updated_at = NULL WHERE conversation_id = 'ended-fallback'"); err != nil {
-		t.Fatalf("update: %v", err)
-	}
+	_, err := db.Exec("UPDATE conversations SET updated_at = NULL WHERE conversation_id = 'ended-fallback'")
+	require.NoError(t, err, "update")
 
 	sessions, err := ParseForgeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseForgeDB: %v", err)
-	}
-	if len(sessions) != 1 {
-		t.Fatalf("want 1 session, got %d", len(sessions))
-	}
+	require.NoError(t, err, "ParseForgeDB")
+	require.Len(t, sessions, 1)
 	s := sessions[0].Session
-	if s.EndedAt.IsZero() {
-		t.Error("EndedAt is zero, want fallback to StartedAt")
-	}
-	if !s.StartedAt.Equal(s.EndedAt) {
-		t.Errorf("EndedAt = %v, want StartedAt = %v", s.EndedAt, s.StartedAt)
-	}
+	assert.False(t, s.EndedAt.IsZero(), "EndedAt is zero, want fallback to StartedAt")
+	assert.True(t, s.StartedAt.Equal(s.EndedAt),
+		"EndedAt = %v, want StartedAt = %v", s.EndedAt, s.StartedAt)
 }
 
 // ---------------------------------------------------------------------------
@@ -941,21 +865,12 @@ func TestForgeToolOutputText(t *testing.T) {
 		)
 
 		sessions, err := ParseForgeDB(dbPath, "m")
-		if err != nil {
-			t.Fatalf("ParseForgeDB: %v", err)
-		}
-		if len(sessions) != 1 {
-			t.Fatalf("want 1 session, got %d", len(sessions))
-		}
+		require.NoError(t, err, "ParseForgeDB")
+		require.Len(t, sessions, 1)
 		msgs := sessions[0].Messages
-		if len(msgs) < 2 {
-			t.Fatalf("want at least 2 messages, got %d", len(msgs))
-		}
+		require.GreaterOrEqual(t, len(msgs), 2, "want at least 2 messages")
 		// Second message is the tool result (role=user with ToolResults)
-		tr := msgs[1].ToolResults
-		if len(tr) == 0 {
-			t.Fatal("expected tool result")
-		}
+		require.NotEmpty(t, msgs[1].ToolResults, "expected tool result")
 	})
 }
 
@@ -1022,12 +937,8 @@ func TestForgeSkillToolName(t *testing.T) {
 			)
 
 			sessions, err := ParseForgeDB(dbPath, "m")
-			if err != nil {
-				t.Fatalf("ParseForgeDB: %v", err)
-			}
-			if len(sessions) != 1 {
-				t.Fatalf("want 1 session, got %d", len(sessions))
-			}
+			require.NoError(t, err, "ParseForgeDB")
+			require.Len(t, sessions, 1)
 			var skillCall *ParsedToolCall
 			for i := range sessions[0].Messages {
 				for j := range sessions[0].Messages[i].ToolCalls {
@@ -1036,9 +947,7 @@ func TestForgeSkillToolName(t *testing.T) {
 					}
 				}
 			}
-			if skillCall == nil {
-				t.Fatal("expected skill tool call")
-			}
+			require.NotNil(t, skillCall, "expected skill tool call")
 			assertEq(t, "SkillName", skillCall.SkillName, tc.wantSkill)
 		})
 	}
@@ -1086,17 +995,11 @@ func TestForgeReasoningNoText(t *testing.T) {
 	)
 
 	sessions, err := ParseForgeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseForgeDB: %v", err)
-	}
-	if len(sessions) != 1 {
-		t.Fatalf("want 1 session, got %d", len(sessions))
-	}
+	require.NoError(t, err, "ParseForgeDB")
+	require.Len(t, sessions, 1)
 	msgs := sessions[0].Messages
 	// User + assistant
-	if len(msgs) < 2 {
-		t.Fatalf("want at least 2 messages, got %d", len(msgs))
-	}
+	require.GreaterOrEqual(t, len(msgs), 2, "want at least 2 messages")
 	asst := msgs[1]
 	assertEq(t, "HasThinking", asst.HasThinking, false)
 }

--- a/internal/parser/fork_test.go
+++ b/internal/parser/fork_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
@@ -13,12 +15,8 @@ func parseTestContent(t *testing.T, name, content string, expectedLen int) []Par
 	t.Helper()
 	path := createTestFile(t, name, content)
 	results, err := ParseClaudeSession(path, "proj", "local")
-	if err != nil {
-		t.Fatalf("ParseClaudeSession: %v", err)
-	}
-	if len(results) != expectedLen {
-		t.Fatalf("got %d results, want %d", len(results), expectedLen)
-	}
+	require.NoError(t, err, "ParseClaudeSession")
+	require.Len(t, results, expectedLen)
 	return results
 }
 
@@ -83,26 +81,15 @@ func TestForkDetection_LargeGapFork(t *testing.T) {
 	main := results[0]
 	assertSessionMeta(t, &main.Session, "fork", "proj", AgentClaude)
 	assertMessageCount(t, len(main.Messages), 10)
-	if main.Session.ParentSessionID != "" {
-		t.Errorf("main ParentSessionID = %q, want empty", main.Session.ParentSessionID)
-	}
+	assert.Empty(t, main.Session.ParentSessionID, "main ParentSessionID")
 
 	// Fork session: entries on fork branch (i,j)
 	fork := results[1]
-	wantForkID := "fork-i"
-	if fork.Session.ID != wantForkID {
-		t.Errorf("fork session ID = %q, want %q", fork.Session.ID, wantForkID)
-	}
+	assert.Equal(t, "fork-i", fork.Session.ID, "fork session ID")
 	assertMessageCount(t, len(fork.Messages), 2)
-	if fork.Session.ParentSessionID != "fork" {
-		t.Errorf("fork ParentSessionID = %q, want %q", fork.Session.ParentSessionID, "fork")
-	}
-	if fork.Session.RelationshipType != RelFork {
-		t.Errorf("fork RelationshipType = %q, want %q", fork.Session.RelationshipType, RelFork)
-	}
-	if fork.Session.FirstMessage != "fork q1" {
-		t.Errorf("fork FirstMessage = %q, want %q", fork.Session.FirstMessage, "fork q1")
-	}
+	assert.Equal(t, "fork", fork.Session.ParentSessionID, "fork ParentSessionID")
+	assert.Equal(t, RelFork, fork.Session.RelationshipType, "fork RelationshipType")
+	assert.Equal(t, "fork q1", fork.Session.FirstMessage, "fork FirstMessage")
 }
 
 func TestForkDetection_SmallGapRetry(t *testing.T) {
@@ -201,41 +188,20 @@ func TestForkDetection_NestedFork(t *testing.T) {
 
 	// Nested fork from n (discovered first during depth-first walk): w,x = 2 messages
 	nested := results[1]
-	if nested.Session.ID != "nested-fork-w" {
-		t.Errorf("nested ID = %q, want %q", nested.Session.ID, "nested-fork-w")
-	}
+	assert.Equal(t, "nested-fork-w", nested.Session.ID, "nested ID")
 	assertMessageCount(t, len(nested.Messages), 2)
-	if nested.Session.RelationshipType != RelFork {
-		t.Errorf("nested RelationshipType = %q, want %q", nested.Session.RelationshipType, RelFork)
-	}
+	assert.Equal(t, RelFork, nested.Session.RelationshipType, "nested RelationshipType")
 	// Nested fork's parent should be the fork branch it split
 	// from, not the root session.
-	wantNestedParent := "nested-fork-m"
-	if nested.Session.ParentSessionID != wantNestedParent {
-		t.Errorf(
-			"nested ParentSessionID = %q, want %q",
-			nested.Session.ParentSessionID,
-			wantNestedParent,
-		)
-	}
+	assert.Equal(t, "nested-fork-m", nested.Session.ParentSessionID, "nested ParentSessionID")
 
 	// Fork from b: m,n,o,p,q,r,s,tt,u,v = 10 messages
 	fork := results[2]
-	if fork.Session.ID != "nested-fork-m" {
-		t.Errorf("fork ID = %q, want %q", fork.Session.ID, "nested-fork-m")
-	}
+	assert.Equal(t, "nested-fork-m", fork.Session.ID, "fork ID")
 	assertMessageCount(t, len(fork.Messages), 10)
-	if fork.Session.RelationshipType != RelFork {
-		t.Errorf("fork RelationshipType = %q, want %q", fork.Session.RelationshipType, RelFork)
-	}
+	assert.Equal(t, RelFork, fork.Session.RelationshipType, "fork RelationshipType")
 	// Fork from b's parent should be the root session.
-	if fork.Session.ParentSessionID != "nested-fork" {
-		t.Errorf(
-			"fork ParentSessionID = %q, want %q",
-			fork.Session.ParentSessionID,
-			"nested-fork",
-		)
-	}
+	assert.Equal(t, "nested-fork", fork.Session.ParentSessionID, "fork ParentSessionID")
 }
 
 func TestForkDetection_MultipleRoots(t *testing.T) {
@@ -296,10 +262,7 @@ func TestSessionBoundsIncludeNonMessageEvents(t *testing.T) {
 	results := parseTestContent(t, "queue-ts.jsonl", content, 1)
 
 	sess := results[0].Session
-	wantEnd := "2024-01-01T11:00:00Z"
-	if got := formatTime(sess.EndedAt); got != wantEnd {
-		t.Errorf("EndedAt = %q, want %q", got, wantEnd)
-	}
+	assert.Equal(t, "2024-01-01T11:00:00Z", formatTime(sess.EndedAt), "EndedAt")
 }
 
 func TestSessionBoundsStartedAtFromLeadingEvent(t *testing.T) {
@@ -317,10 +280,7 @@ func TestSessionBoundsStartedAtFromLeadingEvent(t *testing.T) {
 	results := parseTestContent(t, "early-queue.jsonl", content, 1)
 
 	sess := results[0].Session
-	wantStart := "2024-01-01T09:00:00Z"
-	if got := formatTime(sess.StartedAt); got != wantStart {
-		t.Errorf("StartedAt = %q, want %q", got, wantStart)
-	}
+	assert.Equal(t, "2024-01-01T09:00:00Z", formatTime(sess.StartedAt), "StartedAt")
 }
 
 func TestForkDetection_NestedForkCountsFullSubtree(t *testing.T) {
@@ -385,13 +345,8 @@ func TestForkDetection_NestedForkCountsFullSubtree(t *testing.T) {
 	// first child has <= 3 user turns — here "e" is a dead
 	// end with 0 user turns so the nested fork follows "f").
 	main := results[0]
-	if main.Session.MessageCount < 8 {
-		t.Errorf(
-			"main MessageCount = %d, want >= 8 "+
-				"(first child subtree should not be discarded)",
-			main.Session.MessageCount,
-		)
-	}
+	assert.GreaterOrEqual(t, main.Session.MessageCount, 8,
+		"main MessageCount (first child subtree should not be discarded)")
 
 	// The trivial "retry" branch should be the fork.
 	fork := results[1]
@@ -427,20 +382,8 @@ func TestSessionBoundsDAGMainWidenedNotFork(t *testing.T) {
 	results := parseTestContent(t, "dag-queue.jsonl", content, 2)
 
 	// Main session EndedAt should be widened to queue timestamp.
-	mainEnd := formatTime(results[0].Session.EndedAt)
-	if mainEnd != "2024-01-01T12:00:00Z" {
-		t.Errorf(
-			"main EndedAt = %q, want 2024-01-01T12:00:00Z",
-			mainEnd,
-		)
-	}
+	assert.Equal(t, "2024-01-01T12:00:00Z", formatTime(results[0].Session.EndedAt), "main EndedAt")
 
 	// Fork session EndedAt should NOT be widened.
-	forkEnd := formatTime(results[1].Session.EndedAt)
-	if forkEnd != "2024-01-01T10:01:01Z" {
-		t.Errorf(
-			"fork EndedAt = %q, want 2024-01-01T10:01:01Z",
-			forkEnd,
-		)
-	}
+	assert.Equal(t, "2024-01-01T10:01:01Z", formatTime(results[1].Session.EndedAt), "fork EndedAt")
 }

--- a/internal/parser/iflow_parser_test.go
+++ b/internal/parser/iflow_parser_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseIflowSession(t *testing.T) {
@@ -32,54 +35,24 @@ func TestParseIflowSession(t *testing.T) {
 				"local",
 			)
 
-			if err != nil {
-				t.Fatalf("ParseIflowSession error: %v", err)
-			}
-
-			if len(results) == 0 {
-				t.Fatal("expected at least one result")
-			}
+			require.NoError(t, err, "ParseIflowSession error")
+			require.NotEmpty(t, results, "expected at least one result")
 
 			session := results[0].Session
-			if session.ID != tt.expectID {
-				t.Errorf("expected ID %s, got %s", tt.expectID, session.ID)
-			}
-
-			if session.Agent != AgentIflow {
-				t.Errorf("expected agent %s, got %s", AgentIflow, session.Agent)
-			}
-
-			if session.Project != "test-project" {
-				t.Errorf("expected project test-project, got %s", session.Project)
-			}
-
-			if session.MessageCount != tt.expectMessageCount {
-				t.Errorf("expected %d messages, got %d", tt.expectMessageCount, session.MessageCount)
-			}
-
-			if len(results[0].Messages) != tt.expectMessageCount {
-				t.Errorf("expected %d parsed messages, got %d", tt.expectMessageCount, len(results[0].Messages))
-			}
-
-			if session.FirstMessage != tt.expectFirstMessage {
-				t.Errorf("expected first message %q, got %q", tt.expectFirstMessage, session.FirstMessage)
-			}
+			assert.Equal(t, tt.expectID, session.ID, "ID")
+			assert.Equal(t, AgentIflow, session.Agent, "agent")
+			assert.Equal(t, "test-project", session.Project, "project")
+			assert.Equal(t, tt.expectMessageCount, session.MessageCount, "message count")
+			assert.Len(t, results[0].Messages, tt.expectMessageCount, "parsed messages")
+			assert.Equal(t, tt.expectFirstMessage, session.FirstMessage, "first message")
 
 			// Check that timestamps are parsed
-			if session.StartedAt.IsZero() {
-				t.Error("expected non-zero StartedAt")
-			}
-			if session.EndedAt.IsZero() {
-				t.Error("expected non-zero EndedAt")
-			}
+			assert.False(t, session.StartedAt.IsZero(), "expected non-zero StartedAt")
+			assert.False(t, session.EndedAt.IsZero(), "expected non-zero EndedAt")
 
 			// Check that file info is populated
-			if session.File.Path == "" {
-				t.Error("expected non-empty file path")
-			}
-			if session.File.Size == 0 {
-				t.Error("expected non-zero file size")
-			}
+			assert.NotEmpty(t, session.File.Path, "expected non-empty file path")
+			assert.NotZero(t, session.File.Size, "expected non-zero file size")
 		})
 	}
 }
@@ -88,14 +61,10 @@ func TestExtractIflowProjectHints(t *testing.T) {
 	cwd, gitBranch := ExtractIflowProjectHints("testdata/iflow/session-5de701fc-7454-4858-a249-95cac4fd3b51.jsonl")
 
 	// Expected values from the test file
-	if cwd != "C:\\exp\\docker-image-retagger" {
-		t.Errorf("expected cwd C:\\exp\\docker-image-retagger, got %s", cwd)
-	}
+	assert.Equal(t, "C:\\exp\\docker-image-retagger", cwd, "cwd")
 
 	// gitBranch is null in this test file
-	if gitBranch != "" {
-		t.Errorf("expected empty gitBranch, got %s", gitBranch)
-	}
+	assert.Empty(t, gitBranch, "gitBranch")
 }
 
 func TestIflowSystemMessageFiltering(t *testing.T) {
@@ -105,22 +74,17 @@ func TestIflowSystemMessageFiltering(t *testing.T) {
 		"local",
 	)
 
-	if err != nil {
-		t.Fatalf("ParseIflowSession error: %v", err)
-	}
-
-	if len(results) == 0 {
-		t.Fatal("expected at least one result")
-	}
+	require.NoError(t, err, "ParseIflowSession error")
+	require.NotEmpty(t, results, "expected at least one result")
 
 	messages := results[0].Messages
 
 	// Verify that user messages have content
 	for _, msg := range messages {
 		if msg.Role == RoleUser {
-			if msg.Content == "" && len(msg.ToolResults) == 0 {
-				t.Errorf("user message at ordinal %d should have content or tool results", msg.Ordinal)
-			}
+			hasContent := msg.Content != "" || len(msg.ToolResults) > 0
+			assert.True(t, hasContent,
+				"user message at ordinal %d should have content or tool results", msg.Ordinal)
 		}
 	}
 }
@@ -132,13 +96,8 @@ func TestIflowToolCallParsing(t *testing.T) {
 		"local",
 	)
 
-	if err != nil {
-		t.Fatalf("ParseIflowSession error: %v", err)
-	}
-
-	if len(results) == 0 {
-		t.Fatal("expected at least one result")
-	}
+	require.NoError(t, err, "ParseIflowSession error")
+	require.NotEmpty(t, results, "expected at least one result")
 
 	messages := results[0].Messages
 
@@ -148,12 +107,8 @@ func TestIflowToolCallParsing(t *testing.T) {
 	hasToolUse := false
 	hasToolResult := false
 	for _, msg := range messages {
-		if msg.Role != RoleUser && msg.Role != RoleAssistant {
-			t.Errorf("unexpected role: %s", msg.Role)
-		}
-		if msg.Ordinal < 0 {
-			t.Errorf("invalid ordinal: %d", msg.Ordinal)
-		}
+		assert.Contains(t, []RoleType{RoleUser, RoleAssistant}, msg.Role, "unexpected role")
+		assert.GreaterOrEqual(t, msg.Ordinal, 0, "invalid ordinal")
 		if len(msg.ToolCalls) > 0 {
 			hasToolUse = true
 		}
@@ -161,12 +116,8 @@ func TestIflowToolCallParsing(t *testing.T) {
 			hasToolResult = true
 		}
 	}
-	if !hasToolUse {
-		t.Error("expected at least one message with tool calls")
-	}
-	if !hasToolResult {
-		t.Error("expected at least one message with tool results")
-	}
+	assert.True(t, hasToolUse, "expected at least one message with tool calls")
+	assert.True(t, hasToolResult, "expected at least one message with tool results")
 }
 
 func TestIflowBurstMerge(t *testing.T) {
@@ -176,12 +127,8 @@ func TestIflowBurstMerge(t *testing.T) {
 		"local",
 	)
 
-	if err != nil {
-		t.Fatalf("ParseIflowSession error: %v", err)
-	}
-	if len(results) == 0 {
-		t.Fatal("expected at least one result")
-	}
+	require.NoError(t, err, "ParseIflowSession error")
+	require.NotEmpty(t, results, "expected at least one result")
 
 	messages := results[0].Messages
 
@@ -189,23 +136,12 @@ func TestIflowBurstMerge(t *testing.T) {
 	// streaming burst from lines 1-4 of the fixture. It must
 	// retain the explanatory text from the first snapshot and
 	// all three unique read_file tool calls.
-	if len(messages) < 2 {
-		t.Fatal("expected at least 2 messages")
-	}
+	require.GreaterOrEqual(t, len(messages), 2, "expected at least 2 messages")
 
 	first := messages[1]
-	if first.Role != RoleAssistant {
-		t.Fatalf("expected assistant at ordinal 1, got %s", first.Role)
-	}
-	if !strings.Contains(first.Content, "DOCKER_API_VERSION") {
-		t.Error("first assistant burst lost explanatory text")
-	}
-	if len(first.ToolCalls) != 3 {
-		t.Errorf(
-			"expected 3 tool calls in first burst, got %d",
-			len(first.ToolCalls),
-		)
-	}
+	require.Equal(t, RoleAssistant, first.Role, "expected assistant at ordinal 1")
+	assert.Contains(t, first.Content, "DOCKER_API_VERSION", "first assistant burst lost explanatory text")
+	assert.Len(t, first.ToolCalls, 3, "expected 3 tool calls in first burst")
 
 	// Verify every tool_result in the session has a matching
 	// tool_call somewhere, confirming no orphaned results.
@@ -220,9 +156,7 @@ func TestIflowBurstMerge(t *testing.T) {
 		}
 	}
 	for id := range resultIDs {
-		if !callIDs[id] {
-			t.Errorf("orphaned tool_result %s has no tool_call", id)
-		}
+		assert.Truef(t, callIDs[id], "orphaned tool_result %s has no tool_call", id)
 	}
 }
 
@@ -275,18 +209,10 @@ func TestIflowBurstBoundary(t *testing.T) {
 
 	// All three entries must survive: the user entry between
 	// the two assistant entries prevents burst merging.
-	if len(result) != 3 {
-		t.Fatalf("expected 3 entries, got %d", len(result))
-	}
-	if result[0].uuid != "a1" {
-		t.Errorf("expected a1, got %s", result[0].uuid)
-	}
-	if result[1].uuid != "u1" {
-		t.Errorf("expected u1, got %s", result[1].uuid)
-	}
-	if result[2].uuid != "a2" {
-		t.Errorf("expected a2, got %s", result[2].uuid)
-	}
+	require.Len(t, result, 3, "expected 3 entries")
+	assert.Equal(t, "a1", result[0].uuid)
+	assert.Equal(t, "u1", result[1].uuid)
+	assert.Equal(t, "a2", result[2].uuid)
 
 	// Also test: different-parent assistant between snapshots.
 	entries2 := []dagEntryIflow{
@@ -323,12 +249,7 @@ func TestIflowBurstBoundary(t *testing.T) {
 	}
 
 	result2 := deduplicateIflowEntries(entries2)
-	if len(result2) != 3 {
-		t.Fatalf(
-			"expected 3 entries with interleaved parent, got %d",
-			len(result2),
-		)
-	}
+	require.Len(t, result2, 3, "expected 3 entries with interleaved parent")
 
 	// Third case: a non-user/assistant event (e.g. system) was
 	// filtered out before deduplication runs, so entries are
@@ -358,12 +279,7 @@ func TestIflowBurstBoundary(t *testing.T) {
 	}
 
 	result3 := deduplicateIflowEntries(entries3)
-	if len(result3) != 2 {
-		t.Fatalf(
-			"expected 2 entries with filtered-event gap, got %d",
-			len(result3),
-		)
-	}
+	require.Len(t, result3, 2, "expected 2 entries with filtered-event gap")
 }
 
 func TestIflowTimestampParsing(t *testing.T) {
@@ -373,38 +289,23 @@ func TestIflowTimestampParsing(t *testing.T) {
 		"local",
 	)
 
-	if err != nil {
-		t.Fatalf("ParseIflowSession error: %v", err)
-	}
-
-	if len(results) == 0 {
-		t.Fatal("expected at least one result")
-	}
+	require.NoError(t, err, "ParseIflowSession error")
+	require.NotEmpty(t, results, "expected at least one result")
 
 	session := results[0].Session
 
 	// Verify timestamps are in reasonable range
-	if !session.StartedAt.Before(time.Now()) {
-		t.Error("expected StartedAt to be in the past")
-	}
-
-	if !session.EndedAt.Before(time.Now()) {
-		t.Error("expected EndedAt to be in the past")
-	}
-
-	if session.StartedAt.After(session.EndedAt) {
-		t.Error("expected StartedAt to be before EndedAt")
-	}
+	assert.True(t, session.StartedAt.Before(time.Now()), "expected StartedAt to be in the past")
+	assert.True(t, session.EndedAt.Before(time.Now()), "expected EndedAt to be in the past")
+	assert.False(t, session.StartedAt.After(session.EndedAt), "expected StartedAt to be before EndedAt")
 
 	// Verify message timestamps
 	for _, msg := range results[0].Messages {
 		if !msg.Timestamp.IsZero() {
-			if msg.Timestamp.Before(session.StartedAt) {
-				t.Errorf("message timestamp before session start: %v < %v", msg.Timestamp, session.StartedAt)
-			}
-			if msg.Timestamp.After(session.EndedAt) {
-				t.Errorf("message timestamp after session end: %v > %v", msg.Timestamp, session.EndedAt)
-			}
+			assert.Falsef(t, msg.Timestamp.Before(session.StartedAt),
+				"message timestamp before session start: %v < %v", msg.Timestamp, session.StartedAt)
+			assert.Falsef(t, msg.Timestamp.After(session.EndedAt),
+				"message timestamp after session end: %v > %v", msg.Timestamp, session.EndedAt)
 		}
 	}
 }
@@ -432,9 +333,7 @@ func TestIflowSessionIDExtraction(t *testing.T) {
 				sessionID = trimmed
 			}
 
-			if sessionID != tt.expectID {
-				t.Errorf("expected ID %s, got %s", tt.expectID, sessionID)
-			}
+			assert.Equal(t, tt.expectID, sessionID, "ID")
 		})
 	}
 }

--- a/internal/parser/kiro_sqlite_test.go
+++ b/internal/parser/kiro_sqlite_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const kiroSQLiteSchema = `
@@ -24,13 +26,10 @@ func newKiroSQLiteTestDB(t *testing.T) (string, *sql.DB) {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), kiroSQLiteDBName)
 	db, err := sql.Open("sqlite3", path)
-	if err != nil {
-		t.Fatalf("open kiro sqlite test db: %v", err)
-	}
+	require.NoError(t, err, "open kiro sqlite test db")
 	t.Cleanup(func() { db.Close() })
-	if _, err := db.Exec(kiroSQLiteSchema); err != nil {
-		t.Fatalf("create kiro sqlite schema: %v", err)
-	}
+	_, err = db.Exec(kiroSQLiteSchema)
+	require.NoError(t, err, "create kiro sqlite schema")
 	return path, db
 }
 
@@ -39,9 +38,7 @@ func readKiroFixture(t *testing.T, name string) string {
 	data, err := os.ReadFile(filepath.Join(
 		"testdata", "kiro_sqlite", name,
 	))
-	if err != nil {
-		t.Fatalf("read fixture %s: %v", name, err)
-	}
+	require.NoError(t, err, "read fixture %s", name)
 	return string(data)
 }
 
@@ -50,14 +47,13 @@ func seedKiroSQLiteSession(
 	createdAt, updatedAt int64,
 ) {
 	t.Helper()
-	if _, err := db.Exec(
+	_, err := db.Exec(
 		`INSERT INTO conversations_v2
 			(key, conversation_id, value, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?)`,
 		key, id, payload, createdAt, updatedAt,
-	); err != nil {
-		t.Fatalf("seed kiro sqlite session: %v", err)
-	}
+	)
+	require.NoError(t, err, "seed kiro sqlite session")
 }
 
 func TestParseKiroSQLiteSession(t *testing.T) {
@@ -71,31 +67,27 @@ func TestParseKiroSQLiteSession(t *testing.T) {
 	sess, msgs, err := ParseKiroSQLiteSession(
 		dbPath, "sqlite-session", "test-machine",
 	)
-	if err != nil {
-		t.Fatalf("ParseKiroSQLiteSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected session")
-	}
-	assertEq(t, "ID", sess.ID, "kiro:sqlite-session")
-	assertEq(t, "Agent", sess.Agent, AgentKiro)
-	assertEq(t, "Machine", sess.Machine, "test-machine")
-	assertEq(t, "Project", sess.Project, "kiro_app")
-	assertEq(t, "Cwd", sess.Cwd, "/home/user/code/kiro-app")
-	assertEq(t, "FirstMessage", sess.FirstMessage, "Build the Kiro parser")
-	assertEq(t, "MessageCount", sess.MessageCount, 4)
-	assertEq(t, "UserMessageCount", sess.UserMessageCount, 2)
-	assertEq(t, "File.Path", sess.File.Path, dbPath+"#sqlite-session")
-	assertEq(t, "File.Mtime", sess.File.Mtime, int64(1779012030000)*1_000_000)
+	require.NoError(t, err, "ParseKiroSQLiteSession")
+	require.NotNil(t, sess, "expected session")
+	assert.Equal(t, "kiro:sqlite-session", sess.ID, "ID")
+	assert.Equal(t, AgentKiro, sess.Agent, "Agent")
+	assert.Equal(t, "test-machine", sess.Machine, "Machine")
+	assert.Equal(t, "kiro_app", sess.Project, "Project")
+	assert.Equal(t, "/home/user/code/kiro-app", sess.Cwd, "Cwd")
+	assert.Equal(t, "Build the Kiro parser", sess.FirstMessage, "FirstMessage")
+	assert.Equal(t, 4, sess.MessageCount, "MessageCount")
+	assert.Equal(t, 2, sess.UserMessageCount, "UserMessageCount")
+	assert.Equal(t, dbPath+"#sqlite-session", sess.File.Path, "File.Path")
+	assert.Equal(t, int64(1779012030000)*1_000_000, sess.File.Mtime, "File.Mtime")
 
-	assertEq(t, "messages len", len(msgs), 4)
-	assertEq(t, "msg[0].Role", msgs[0].Role, RoleUser)
-	assertEq(t, "msg[0].Content", msgs[0].Content, "Build the Kiro parser")
-	assertEq(t, "msg[1].Role", msgs[1].Role, RoleAssistant)
-	assertEq(t, "msg[1].Content", msgs[1].Content, "I can do that.")
-	assertEq(t, "msg[3].HasToolUse", msgs[3].HasToolUse, true)
-	assertEq(t, "msg[3].ToolCalls len", len(msgs[3].ToolCalls), 1)
-	assertEq(t, "msg[3].ToolName", msgs[3].ToolCalls[0].ToolName, "execute_bash")
+	require.Len(t, msgs, 4, "messages len")
+	assert.Equal(t, RoleUser, msgs[0].Role, "msg[0].Role")
+	assert.Equal(t, "Build the Kiro parser", msgs[0].Content, "msg[0].Content")
+	assert.Equal(t, RoleAssistant, msgs[1].Role, "msg[1].Role")
+	assert.Equal(t, "I can do that.", msgs[1].Content, "msg[1].Content")
+	assert.True(t, msgs[3].HasToolUse, "msg[3].HasToolUse")
+	require.Len(t, msgs[3].ToolCalls, 1, "msg[3].ToolCalls len")
+	assert.Equal(t, "execute_bash", msgs[3].ToolCalls[0].ToolName, "msg[3].ToolName")
 }
 
 func TestListKiroSQLiteSessionMetaUsesNewestLogicalRow(t *testing.T) {
@@ -111,11 +103,9 @@ func TestListKiroSQLiteSessionMetaUsesNewestLogicalRow(t *testing.T) {
 	)
 
 	metas, err := ListKiroSQLiteSessionMeta(dbPath)
-	if err != nil {
-		t.Fatalf("ListKiroSQLiteSessionMeta: %v", err)
-	}
-	assertEq(t, "metas len", len(metas), 1)
-	assertEq(t, "meta mtime", metas[0].FileMtime, int64(9_000_000))
+	require.NoError(t, err, "ListKiroSQLiteSessionMeta")
+	require.Len(t, metas, 1, "metas len")
+	assert.Equal(t, int64(9_000_000), metas[0].FileMtime, "meta mtime")
 }
 
 func TestKiroSQLiteSourceMtime(t *testing.T) {
@@ -128,10 +118,8 @@ func TestKiroSQLiteSourceMtime(t *testing.T) {
 	mtime, err := KiroSQLiteSourceMtime(
 		KiroSQLiteVirtualPath(dbPath, "sqlite-session"),
 	)
-	if err != nil {
-		t.Fatalf("KiroSQLiteSourceMtime: %v", err)
-	}
-	assertEq(t, "mtime", mtime, int64(7_000_000))
+	require.NoError(t, err, "KiroSQLiteSourceMtime")
+	assert.Equal(t, int64(7_000_000), mtime, "mtime")
 }
 
 func TestParseKiroSQLiteVirtualPath(t *testing.T) {
@@ -157,11 +145,9 @@ func TestParseKiroSQLiteVirtualPath(t *testing.T) {
 			gotDB, gotID, ok := ParseKiroSQLiteVirtualPath(
 				KiroSQLiteVirtualPath(tt.dbPath, tt.sessionID),
 			)
-			if !ok {
-				t.Fatal("expected virtual path to parse")
-			}
-			assertEq(t, "dbPath", gotDB, tt.dbPath)
-			assertEq(t, "sessionID", gotID, tt.sessionID)
+			require.True(t, ok, "expected virtual path to parse")
+			assert.Equal(t, tt.dbPath, gotDB, "dbPath")
+			assert.Equal(t, tt.sessionID, gotID, "sessionID")
 		})
 	}
 }
@@ -173,9 +159,8 @@ func TestParseKiroSQLiteSessionRejectsMalformedPayload(t *testing.T) {
 		readKiroFixture(t, "malformed_payload.txt"),
 		1, 2,
 	)
-	if _, _, err := ParseKiroSQLiteSession(
+	_, _, err := ParseKiroSQLiteSession(
 		dbPath, "broken-session", "test-machine",
-	); err == nil {
-		t.Fatal("expected malformed payload error")
-	}
+	)
+	require.Error(t, err, "expected malformed payload error")
 }

--- a/internal/parser/linereader_test.go
+++ b/internal/parser/linereader_test.go
@@ -3,10 +3,12 @@ package parser
 import (
 	"errors"
 	"io"
-	"slices"
 	"strings"
 	"testing"
 	"testing/iotest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLineReader(t *testing.T) {
@@ -80,12 +82,8 @@ func TestLineReader(t *testing.T) {
 				}
 				got = append(got, line)
 			}
-			if err := lr.Err(); err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if !slices.Equal(got, tt.want) {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			assert.NoError(t, lr.Err())
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -128,12 +126,7 @@ func TestLineReaderBytesRead(t *testing.T) {
 					break
 				}
 			}
-			if lr.bytesRead != tt.want {
-				t.Errorf(
-					"bytesRead = %d, want %d",
-					lr.bytesRead, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, lr.bytesRead)
 		})
 	}
 }
@@ -155,13 +148,7 @@ func TestLineReaderIOError(t *testing.T) {
 		got = append(got, line)
 	}
 
-	if len(got) != 2 {
-		t.Fatalf("got %d lines, want 2: %v", len(got), got)
-	}
-	if lr.Err() == nil {
-		t.Fatal("expected non-nil Err() after I/O failure")
-	}
-	if !errors.Is(lr.Err(), ioErr) {
-		t.Fatalf("Err() = %v, want %v", lr.Err(), ioErr)
-	}
+	require.Len(t, got, 2)
+	require.Error(t, lr.Err(), "expected non-nil Err() after I/O failure")
+	require.ErrorIs(t, lr.Err(), ioErr)
 }

--- a/internal/parser/openclaw_test.go
+++ b/internal/parser/openclaw_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // writeOpenClawTestFile creates a test JSONL file inside an
@@ -16,9 +19,7 @@ func writeOpenClawTestFile(
 	t.Helper()
 	root := t.TempDir()
 	sessDir := filepath.Join(root, agentID, "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 	path = filepath.Join(sessDir, "test-session.jsonl")
 	var b strings.Builder
 	for _, line := range lines {
@@ -26,9 +27,7 @@ func writeOpenClawTestFile(
 		b.WriteByte('\n')
 	}
 	content := b.String()
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
 	return path, root
 }
 
@@ -41,41 +40,18 @@ func TestParseOpenClawSession_Basic(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseOpenClawSession(path, "", "test-machine")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess == nil {
-		t.Fatal("expected session, got nil")
-		return
-	}
+	require.NoError(t, err)
+	require.NotNil(t, sess, "expected session, got nil")
 
-	if sess.ID != "openclaw:main:abc-123" {
-		t.Errorf("expected ID openclaw:main:abc-123, got %s", sess.ID)
-	}
-	if sess.Agent != AgentOpenClaw {
-		t.Errorf("expected agent openclaw, got %s", sess.Agent)
-	}
-	if sess.Machine != "test-machine" {
-		t.Errorf("expected machine test-machine, got %s", sess.Machine)
-	}
-	if sess.Project != "project" {
-		t.Errorf("expected project 'project', got %s", sess.Project)
-	}
-	if sess.FirstMessage != "Hello, how are you?" {
-		t.Errorf("expected first message 'Hello, how are you?', got %s", sess.FirstMessage)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
-	if msgs[0].Role != RoleUser {
-		t.Errorf("expected first role user, got %s", msgs[0].Role)
-	}
-	if msgs[1].Role != RoleAssistant {
-		t.Errorf("expected second role assistant, got %s", msgs[1].Role)
-	}
-	if sess.UserMessageCount != 1 {
-		t.Errorf("expected 1 user message, got %d", sess.UserMessageCount)
-	}
+	assert.Equal(t, "openclaw:main:abc-123", sess.ID, "expected ID openclaw:main:abc-123, got %s")
+	assert.Equal(t, AgentOpenClaw, sess.Agent, "expected agent openclaw, got %s")
+	assert.Equal(t, "test-machine", sess.Machine, "expected machine test-machine, got %s")
+	assert.Equal(t, "project", sess.Project, "expected project 'project', got %s")
+	assert.Equal(t, "Hello, how are you?", sess.FirstMessage, "expected first message 'Hello, how are you?', got %s")
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
+	assert.Equal(t, RoleUser, msgs[0].Role, "expected first role user, got %s")
+	assert.Equal(t, RoleAssistant, msgs[1].Role, "expected second role assistant, got %s")
+	assert.Equal(t, 1, sess.UserMessageCount, "expected 1 user message, got %d")
 }
 
 func TestParseOpenClawSession_Thinking(t *testing.T) {
@@ -86,15 +62,9 @@ func TestParseOpenClawSession_Thinking(t *testing.T) {
 	)
 
 	_, msgs, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
-	if !msgs[1].HasThinking {
-		t.Error("expected HasThinking=true for assistant message")
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
+	assert.True(t, msgs[1].HasThinking, "expected HasThinking=true for assistant message")
 }
 
 func TestParseOpenClawSession_ToolResult(t *testing.T) {
@@ -107,45 +77,23 @@ func TestParseOpenClawSession_ToolResult(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 4 {
-		t.Fatalf("expected 4 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 4, len(msgs), "expected 4 messages, got %d")
 	// Assistant with tool_use
-	if !msgs[1].HasToolUse {
-		t.Error("expected HasToolUse=true for tool-use message")
-	}
-	if len(msgs[1].ToolCalls) != 1 {
-		t.Fatalf("expected 1 tool call, got %d", len(msgs[1].ToolCalls))
-	}
-	if msgs[1].ToolCalls[0].ToolName != "read" {
-		t.Errorf("expected tool name 'read', got %s", msgs[1].ToolCalls[0].ToolName)
-	}
-	if msgs[1].ToolCalls[0].Category != "Read" {
-		t.Errorf("expected category 'Read', got %s", msgs[1].ToolCalls[0].Category)
-	}
+	assert.True(t, msgs[1].HasToolUse, "expected HasToolUse=true for tool-use message")
+	require.Equal(t, 1, len(msgs[1].ToolCalls), "expected 1 tool call, got %d")
+	assert.Equal(t, "read", msgs[1].ToolCalls[0].ToolName, "expected tool name 'read', got %s")
+	assert.Equal(t, "Read", msgs[1].ToolCalls[0].Category, "expected category 'Read', got %s")
 
 	// Tool result mapped to user role
-	if msgs[2].Role != RoleUser {
-		t.Errorf("expected tool result as user role, got %s", msgs[2].Role)
-	}
-	if len(msgs[2].ToolResults) != 1 {
-		t.Fatalf("expected 1 tool result, got %d", len(msgs[2].ToolResults))
-	}
-	if msgs[2].ToolResults[0].ToolUseID != "tu1" {
-		t.Errorf("expected tool use ID 'tu1', got %s", msgs[2].ToolResults[0].ToolUseID)
-	}
-	if sess.MessageCount != 4 {
-		t.Errorf("expected 4 messages, got %d", sess.MessageCount)
-	}
+	assert.Equal(t, RoleUser, msgs[2].Role, "expected tool result as user role, got %s")
+	require.Equal(t, 1, len(msgs[2].ToolResults), "expected 1 tool result, got %d")
+	assert.Equal(t, "tu1", msgs[2].ToolResults[0].ToolUseID, "expected tool use ID 'tu1', got %s")
+	assert.Equal(t, 4, sess.MessageCount, "expected 4 messages, got %d")
 
 	// UserMessageCount should only count the real user message,
 	// not the synthetic tool-result message.
-	if sess.UserMessageCount != 1 {
-		t.Errorf("expected UserMessageCount 1 (tool results excluded), got %d", sess.UserMessageCount)
-	}
+	assert.Equal(t, 1, sess.UserMessageCount, "expected UserMessageCount 1 (tool results excluded), got %d")
 }
 
 func TestParseOpenClawSession_OrphanToolResult(t *testing.T) {
@@ -159,24 +107,14 @@ func TestParseOpenClawSession_OrphanToolResult(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// 3 messages: user, assistant (tool_use), assistant (text).
 	// The orphan toolResult is skipped entirely.
-	if len(msgs) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(msgs))
-	}
-	if sess.MessageCount != 3 {
-		t.Errorf("MessageCount = %d, want 3", sess.MessageCount)
-	}
-	if sess.UserMessageCount != 1 {
-		t.Errorf("UserMessageCount = %d, want 1", sess.UserMessageCount)
-	}
+	require.Equal(t, 3, len(msgs), "expected 3 messages, got %d")
+	assert.Equal(t, 3, sess.MessageCount, "MessageCount = %d, want 3")
+	assert.Equal(t, 1, sess.UserMessageCount, "UserMessageCount = %d, want 1")
 	for _, m := range msgs {
-		if m.Role == RoleUser && m.Content == "" {
-			t.Error("blank user message leaked through")
-		}
+		assert.False(t, m.Role == RoleUser && m.Content == "", "blank user message leaked through")
 	}
 }
 
@@ -186,12 +124,8 @@ func TestParseOpenClawSession_EmptyFile(t *testing.T) {
 	)
 
 	sess, _, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess != nil {
-		t.Error("expected nil session for file with no messages")
-	}
+	require.NoError(t, err)
+	assert.Nil(t, sess, "expected nil session for file with no messages")
 }
 
 func TestParseOpenClawSession_AssistantUsage(t *testing.T) {
@@ -206,39 +140,21 @@ func TestParseOpenClawSession_AssistantUsage(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
 
 	a := msgs[1]
-	if a.Role != RoleAssistant {
-		t.Fatalf("expected assistant role, got %s", a.Role)
-	}
-	if a.Model != "claude-sonnet-4-6" {
-		t.Errorf("Model = %q, want claude-sonnet-4-6", a.Model)
-	}
-	if a.OutputTokens != 91 {
-		t.Errorf("OutputTokens = %d, want 91", a.OutputTokens)
-	}
-	if !a.HasOutputTokens {
-		t.Error("HasOutputTokens = false, want true")
-	}
+	require.Equal(t, RoleAssistant, a.Role, "expected assistant role, got %s")
+	assert.Equal(t, "claude-sonnet-4-6", a.Model, "Model = %q, want claude-sonnet-4-6")
+	assert.Equal(t, 91, a.OutputTokens, "OutputTokens = %d, want 91")
+	assert.True(t, a.HasOutputTokens, "HasOutputTokens = false, want true")
 	// ContextTokens = input + cacheRead + cacheWrite.
-	if a.ContextTokens != 9615 {
-		t.Errorf("ContextTokens = %d, want 9615", a.ContextTokens)
-	}
-	if !a.HasContextTokens {
-		t.Error("HasContextTokens = false, want true")
-	}
+	assert.Equal(t, 9615, a.ContextTokens, "ContextTokens = %d, want 9615")
+	assert.True(t, a.HasContextTokens, "HasContextTokens = false, want true")
 	// TokenUsage must be normalized to Anthropic-style keys so
 	// downstream usage aggregation (internal/db/usage.go) can
 	// read input_tokens/output_tokens/cache_*_input_tokens.
-	if len(a.TokenUsage) == 0 {
-		t.Fatal("TokenUsage empty, want normalized JSON")
-	}
+	require.False(t, len(a.TokenUsage) == 0, "TokenUsage empty, want normalized JSON")
 	tu := string(a.TokenUsage)
 	for _, want := range []string{
 		`"input_tokens":3`,
@@ -246,26 +162,14 @@ func TestParseOpenClawSession_AssistantUsage(t *testing.T) {
 		`"cache_read_input_tokens":0`,
 		`"cache_creation_input_tokens":9612`,
 	} {
-		if !strings.Contains(tu, want) {
-			t.Errorf("TokenUsage %q missing %q", tu, want)
-		}
+		assert.Contains(t, tu, want)
 	}
 
 	// Session-level rollup must reflect the per-message totals.
-	if !sess.HasTotalOutputTokens {
-		t.Error("sess.HasTotalOutputTokens = false, want true")
-	}
-	if sess.TotalOutputTokens != 91 {
-		t.Errorf("TotalOutputTokens = %d, want 91",
-			sess.TotalOutputTokens)
-	}
-	if !sess.HasPeakContextTokens {
-		t.Error("sess.HasPeakContextTokens = false, want true")
-	}
-	if sess.PeakContextTokens != 9615 {
-		t.Errorf("PeakContextTokens = %d, want 9615",
-			sess.PeakContextTokens)
-	}
+	assert.True(t, sess.HasTotalOutputTokens, "sess.HasTotalOutputTokens = false, want true")
+	assert.Equal(t, 91, sess.TotalOutputTokens, "TotalOutputTokens")
+	assert.True(t, sess.HasPeakContextTokens, "sess.HasPeakContextTokens = false, want true")
+	assert.Equal(t, 9615, sess.PeakContextTokens, "PeakContextTokens")
 }
 
 func TestParseOpenClawSession_AssistantUsageWithoutCost(t *testing.T) {
@@ -279,30 +183,15 @@ func TestParseOpenClawSession_AssistantUsageWithoutCost(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
 
 	a := msgs[1]
-	if a.Model != "claude-haiku-4-5" {
-		t.Errorf("Model = %q, want claude-haiku-4-5", a.Model)
-	}
-	if a.OutputTokens != 17 {
-		t.Errorf("OutputTokens = %d, want 17", a.OutputTokens)
-	}
-	if a.ContextTokens != 42 {
-		t.Errorf("ContextTokens = %d, want 42", a.ContextTokens)
-	}
-	if len(a.TokenUsage) == 0 {
-		t.Error("TokenUsage empty, want normalized JSON")
-	}
-	if sess.TotalOutputTokens != 17 {
-		t.Errorf("TotalOutputTokens = %d, want 17",
-			sess.TotalOutputTokens)
-	}
+	assert.Equal(t, "claude-haiku-4-5", a.Model, "Model = %q, want claude-haiku-4-5")
+	assert.Equal(t, 17, a.OutputTokens, "OutputTokens = %d, want 17")
+	assert.Equal(t, 42, a.ContextTokens, "ContextTokens = %d, want 42")
+	assert.False(t, len(a.TokenUsage) == 0, "TokenUsage empty, want normalized JSON")
+	assert.Equal(t, 17, sess.TotalOutputTokens, "TotalOutputTokens")
 }
 
 func TestParseOpenClawSession_PartialUsage(t *testing.T) {
@@ -318,29 +207,17 @@ func TestParseOpenClawSession_PartialUsage(t *testing.T) {
 	)
 
 	_, msgs, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
 
 	a := msgs[1]
-	if a.HasContextTokens {
-		t.Error("HasContextTokens = true, want false")
-	}
-	if !a.HasOutputTokens {
-		t.Error("HasOutputTokens = false, want true")
-	}
+	assert.False(t, a.HasContextTokens, "HasContextTokens = true, want false")
+	assert.True(t, a.HasOutputTokens, "HasOutputTokens = false, want true")
 
 	hasCtx, hasOut := a.TokenPresence()
-	if hasCtx {
-		t.Error("TokenPresence ctx = true, want false " +
-			"(parser flags must take precedence over JSON keys)")
-	}
-	if !hasOut {
-		t.Error("TokenPresence out = false, want true")
-	}
+	assert.False(t, hasCtx,
+		"TokenPresence ctx = true, want false (parser flags must take precedence over JSON keys)")
+	assert.True(t, hasOut, "TokenPresence out = false, want true")
 }
 
 func TestParseOpenClawSession_NoUsage(t *testing.T) {
@@ -353,18 +230,12 @@ func TestParseOpenClawSession_NoUsage(t *testing.T) {
 	)
 
 	_, msgs, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
 
 	hasCtx, hasOut := msgs[1].TokenPresence()
-	if hasCtx || hasOut {
-		t.Errorf("TokenPresence = (%v, %v), want (false, false)",
-			hasCtx, hasOut)
-	}
+	assert.False(t, hasCtx, "TokenPresence ctx")
+	assert.False(t, hasOut, "TokenPresence out")
 }
 
 func TestParseOpenClawSession_Compaction(t *testing.T) {
@@ -376,16 +247,10 @@ func TestParseOpenClawSession_Compaction(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseOpenClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess == nil {
-		t.Fatal("expected session, got nil")
-	}
+	require.NoError(t, err)
+	require.False(t, sess == nil, "expected session, got nil")
 	// Compaction should be skipped, only messages remain.
-	if len(msgs) != 2 {
-		t.Errorf("expected 2 messages (compaction skipped), got %d", len(msgs))
-	}
+	assert.Equal(t, 2, len(msgs), "expected 2 messages (compaction skipped), got %d")
 }
 
 func TestParseOpenClawSession_AgentIDInSessionID(t *testing.T) {
@@ -401,23 +266,14 @@ func TestParseOpenClawSession_AgentIDInSessionID(t *testing.T) {
 	)
 
 	sessA, _, err := ParseOpenClawSession(pathA, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sessB, _, err := ParseOpenClawSession(pathB, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if sessA.ID == sessB.ID {
-		t.Errorf("expected different session IDs for different agents, both got %s", sessA.ID)
-	}
-	if sessA.ID != "openclaw:alpha:same-id" {
-		t.Errorf("expected openclaw:alpha:same-id, got %s", sessA.ID)
-	}
-	if sessB.ID != "openclaw:beta:same-id" {
-		t.Errorf("expected openclaw:beta:same-id, got %s", sessB.ID)
-	}
+	assert.NotEqualf(t, sessB.ID, sessA.ID,
+		"expected different session IDs for different agents, both got %s", sessA.ID)
+	assert.Equal(t, "openclaw:alpha:same-id", sessA.ID, "expected openclaw:alpha:same-id, got %s")
+	assert.Equal(t, "openclaw:beta:same-id", sessB.ID, "expected openclaw:beta:same-id, got %s")
 }
 
 func TestIsOpenClawSessionFile(t *testing.T) {
@@ -435,23 +291,19 @@ func TestIsOpenClawSessionFile(t *testing.T) {
 		"sessions.json",
 	}
 	for _, name := range accepted {
-		if !IsOpenClawSessionFile(name) {
-			t.Errorf("expected %q to be accepted", name)
-		}
+		assert.Truef(t, IsOpenClawSessionFile(name),
+			"expected %q to be accepted", name)
 	}
 	for _, name := range rejected {
-		if IsOpenClawSessionFile(name) {
-			t.Errorf("expected %q to be rejected", name)
-		}
+		assert.Falsef(t, IsOpenClawSessionFile(name),
+			"expected %q to be rejected", name)
 	}
 }
 
 func TestBestOpenClawEntry_CrossSuffix(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// reset is newer (March) than deleted (January), even though
 	// "deleted" > "reset" would be wrong lexicographically within
@@ -459,20 +311,14 @@ func TestBestOpenClawEntry_CrossSuffix(t *testing.T) {
 	older := "abc.jsonl.deleted.2026-01-15T00-00-00.000Z"
 	newer := "abc.jsonl.reset.2026-03-01T00-00-00.000Z"
 	for _, name := range []string{older, newer} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name), []byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	files := DiscoverOpenClawSessions(root)
-	if len(files) != 1 {
-		t.Fatalf("expected 1 (deduplicated), got %d", len(files))
-	}
-	if filepath.Base(files[0].Path) != newer {
-		t.Errorf("expected %q, got %q", newer, filepath.Base(files[0].Path))
-	}
+	require.Equal(t, 1, len(files), "expected 1 (deduplicated), got %d")
+	assert.Equal(t, newer, filepath.Base(files[0].Path), "expected %q, got %q")
 }
 
 func TestDiscoverOpenClawSessions(t *testing.T) {
@@ -483,41 +329,25 @@ func TestDiscoverOpenClawSessions(t *testing.T) {
 	root := t.TempDir()
 
 	mainSessions := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(mainSessions, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(mainSessions, "sess1.jsonl"), []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(mainSessions, "sessions.json"), []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(mainSessions, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(mainSessions, "sess1.jsonl"), []byte("{}"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(mainSessions, "sessions.json"), []byte("{}"), 0644))
 
 	claudeSessions := filepath.Join(root, "claude", "sessions")
-	if err := os.MkdirAll(claudeSessions, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeSessions, "sess2.jsonl"), []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(claudeSessions, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeSessions, "sess2.jsonl"), []byte("{}"), 0644))
 
 	files := DiscoverOpenClawSessions(root)
-	if len(files) != 2 {
-		t.Fatalf("expected 2 session files, got %d", len(files))
-	}
+	require.Equal(t, 2, len(files), "expected 2 session files, got %d")
 	for _, f := range files {
-		if f.Agent != AgentOpenClaw {
-			t.Errorf("expected agent openclaw, got %s", f.Agent)
-		}
+		assert.Equal(t, AgentOpenClaw, f.Agent, "expected agent openclaw, got %s")
 	}
 }
 
 func TestDiscoverOpenClawSessions_DeduplicatesArchived(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Active file and two archived files for the same session.
 	for _, name := range []string{
@@ -525,192 +355,137 @@ func TestDiscoverOpenClawSessions_DeduplicatesArchived(t *testing.T) {
 		"abc.jsonl.deleted.2026-02-19T08-59-24.951Z",
 		"abc.jsonl.reset.2026-02-17T09-39-39.691Z",
 	} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name),
 			[]byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	files := DiscoverOpenClawSessions(root)
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file (deduplicated), got %d", len(files))
-	}
+	require.Equal(t, 1, len(files), "expected 1 file (deduplicated), got %d")
 	// Active file should win.
-	if !strings.HasSuffix(files[0].Path, "abc.jsonl") {
-		t.Errorf(
-			"expected active .jsonl to win, got %s",
-			filepath.Base(files[0].Path),
-		)
-	}
+	assert.Truef(t, strings.HasSuffix(files[0].Path, "abc.jsonl"),
+		"expected active .jsonl to win, got %s",
+		filepath.Base(files[0].Path))
 }
 
 func TestDiscoverOpenClawSessions_ArchiveOnlyPicksNewest(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Two archived files, no active — newest filename wins.
 	for _, name := range []string{
 		"xyz.jsonl.deleted.2026-01-01T00-00-00.000Z",
 		"xyz.jsonl.deleted.2026-03-01T00-00-00.000Z",
 	} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name),
 			[]byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	files := DiscoverOpenClawSessions(root)
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file (deduplicated), got %d", len(files))
-	}
+	require.Equal(t, 1, len(files), "expected 1 file (deduplicated), got %d")
 	want := "xyz.jsonl.deleted.2026-03-01T00-00-00.000Z"
-	if filepath.Base(files[0].Path) != want {
-		t.Errorf("expected newest archive %q, got %q",
-			want, filepath.Base(files[0].Path))
-	}
+	assert.Equal(t, want, filepath.Base(files[0].Path), "expected newest archive")
 }
 
 func TestDiscoverOpenClawSessions_DifferentSessionsNotDeduped(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Two different session IDs — should not be deduplicated.
 	for _, name := range []string{
 		"aaa.jsonl",
 		"bbb.jsonl.deleted.2026-01-01T00-00-00.000Z",
 	} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name),
 			[]byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	files := DiscoverOpenClawSessions(root)
-	if len(files) != 2 {
-		t.Fatalf("expected 2 files (different sessions), got %d",
-			len(files))
-	}
+	require.Len(t, files, 2, "expected 2 files (different sessions)")
 }
 
 func TestFindOpenClawSourceFile(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 	target := filepath.Join(sessDir, "abc-123.jsonl")
-	if err := os.WriteFile(target, []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(target, []byte("{}"), 0644))
 
 	// Raw ID is now "agentId:sessionId".
 	found := FindOpenClawSourceFile(root, "main:abc-123")
-	if found != target {
-		t.Errorf("expected %s, got %s", target, found)
-	}
+	assert.Equal(t, target, found, "expected %s, got %s")
 
 	// Non-existent session.
 	notFound := FindOpenClawSourceFile(root, "main:nonexistent")
-	if notFound != "" {
-		t.Errorf("expected empty string, got %s", notFound)
-	}
+	assert.Equal(t, "", notFound, "expected empty string, got %s")
 
 	// Non-existent agent.
 	notFound2 := FindOpenClawSourceFile(root, "other:abc-123")
-	if notFound2 != "" {
-		t.Errorf("expected empty string, got %s", notFound2)
-	}
+	assert.Equal(t, "", notFound2, "expected empty string, got %s")
 
 	// Invalid format (no colon separator).
 	notFound3 := FindOpenClawSourceFile(root, "abc-123")
-	if notFound3 != "" {
-		t.Errorf("expected empty string for bare ID, got %s", notFound3)
-	}
+	assert.Equal(t, "", notFound3, "expected empty string for bare ID, got %s")
 }
 
 func TestFindOpenClawSourceFile_ArchiveOnly(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Only archived files exist — no active .jsonl.
 	archived := "def-456.jsonl.deleted.2026-02-19T08-59-24.951Z"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(sessDir, archived),
 		[]byte("{}"), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	found := FindOpenClawSourceFile(root, "main:def-456")
 	want := filepath.Join(sessDir, archived)
-	if found != want {
-		t.Errorf("expected %s, got %s", want, found)
-	}
+	assert.Equal(t, want, found, "expected %s, got %s")
 }
 
 func TestFindOpenClawSourceFile_PrefersActiveOverArchive(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Both active and archived files exist.
 	active := filepath.Join(sessDir, "ghi-789.jsonl")
-	if err := os.WriteFile(active, []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(active, []byte("{}"), 0644))
 	archived := "ghi-789.jsonl.deleted.2026-02-19T00-00-00.000Z"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(sessDir, archived),
 		[]byte("{}"), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	found := FindOpenClawSourceFile(root, "main:ghi-789")
-	if found != active {
-		t.Errorf("expected active file %s, got %s", active, found)
-	}
+	assert.Equal(t, active, found, "expected active file %s, got %s")
 }
 
 func TestFindOpenClawSourceFile_ArchiveOnlyNewest(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Two archived files — newest should be chosen.
 	old := "jkl.jsonl.deleted.2026-01-01T00-00-00.000Z"
 	newest := "jkl.jsonl.deleted.2026-03-01T00-00-00.000Z"
 	for _, name := range []string{old, newest} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name),
 			[]byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	found := FindOpenClawSourceFile(root, "main:jkl")
 	want := filepath.Join(sessDir, newest)
-	if found != want {
-		t.Errorf("expected newest archive %s, got %s", want, found)
-	}
+	assert.Equal(t, want, found, "expected newest archive %s, got %s")
 }

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // openCodeSchema matches the real OpenCode database schema.
@@ -52,9 +54,7 @@ CREATE TABLE part (
 
 func assertEq[T comparable](t *testing.T, name string, got, want T) {
 	t.Helper()
-	if got != want {
-		t.Errorf("%s = %v, want %v", name, got, want)
-	}
+	assert.Equal(t, want, got, name)
 }
 
 type OpenCodeSeeder struct {
@@ -65,9 +65,7 @@ type OpenCodeSeeder struct {
 func (s *OpenCodeSeeder) AddProject(id, worktree string) {
 	s.t.Helper()
 	_, err := s.db.Exec(`INSERT INTO project (id, worktree) VALUES (?, ?)`, id, worktree)
-	if err != nil {
-		s.t.Fatalf("add project: %v", err)
-	}
+	require.NoError(s.t, err, "add project")
 }
 
 func (s *OpenCodeSeeder) AddSession(id, projectID, parentID, title string, timeCreated, timeUpdated int64) {
@@ -83,40 +81,31 @@ func (s *OpenCodeSeeder) AddSession(id, projectID, parentID, title string, timeC
 
 	_, err := s.db.Exec(`INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)`,
 		id, projectID, pID, tStr, timeCreated, timeUpdated)
-	if err != nil {
-		s.t.Fatalf("add session: %v", err)
-	}
+	require.NoError(s.t, err, "add session")
 }
 
 func (s *OpenCodeSeeder) AddMessage(id, sessionID string, timeCreated, timeUpdated int64, data string) {
 	s.t.Helper()
 	_, err := s.db.Exec(`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)`,
 		id, sessionID, timeCreated, timeUpdated, data)
-	if err != nil {
-		s.t.Fatalf("add message: %v", err)
-	}
+	require.NoError(s.t, err, "add message")
 }
 
 func (s *OpenCodeSeeder) AddPart(id, messageID, sessionID string, timeCreated, timeUpdated int64, data string) {
 	s.t.Helper()
 	_, err := s.db.Exec(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)`,
 		id, messageID, sessionID, timeCreated, timeUpdated, data)
-	if err != nil {
-		s.t.Fatalf("add part: %v", err)
-	}
+	require.NoError(s.t, err, "add part")
 }
 
 func newTestDB(t *testing.T) (string, *OpenCodeSeeder, *sql.DB) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "opencode.db")
 	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("open test db: %v", err)
-	}
+	require.NoError(t, err, "open test db")
 
-	if _, err := db.Exec(openCodeSchema); err != nil {
-		t.Fatalf("create schema: %v", err)
-	}
+	_, err = db.Exec(openCodeSchema)
+	require.NoError(t, err, "create schema")
 
 	seeder := &OpenCodeSeeder{db: db, t: t}
 	return dbPath, seeder, db
@@ -130,28 +119,23 @@ func newTestDB(t *testing.T) (string, *OpenCodeSeeder, *sql.DB) {
 func seedHybridSQLiteDB(t *testing.T, dbPath, sessionID string) {
 	t.Helper()
 	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("open hybrid db: %v", err)
-	}
+	require.NoError(t, err, "open hybrid db")
 	t.Cleanup(func() { db.Close() })
-	if _, err := db.Exec(openCodeSchema); err != nil {
-		t.Fatalf("create hybrid schema: %v", err)
-	}
-	if _, err := db.Exec(
+	_, err = db.Exec(openCodeSchema)
+	require.NoError(t, err, "create hybrid schema")
+	_, err = db.Exec(
 		`INSERT INTO project (id, worktree)
 		 VALUES (?, ?)`,
 		"prj_seed", "/tmp/seed",
-	); err != nil {
-		t.Fatalf("seed project: %v", err)
-	}
-	if _, err := db.Exec(
+	)
+	require.NoError(t, err, "seed project")
+	_, err = db.Exec(
 		`INSERT INTO session
 			(id, project_id, time_created, time_updated)
 		 VALUES (?, ?, ?, ?)`,
 		sessionID, "prj_seed", int64(1), int64(2),
-	); err != nil {
-		t.Fatalf("seed session: %v", err)
-	}
+	)
+	require.NoError(t, err, "seed session")
 }
 
 func seedStandardSession(t *testing.T, seeder *OpenCodeSeeder) {
@@ -170,16 +154,11 @@ func writeOpenCodeStorageFile(
 	t *testing.T, path string, data any,
 ) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755),
+		"mkdir %s", filepath.Dir(path))
 	raw, err := json.Marshal(data)
-	if err != nil {
-		t.Fatalf("marshal %s: %v", path, err)
-	}
-	if err := os.WriteFile(path, raw, 0o644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
+	require.NoError(t, err, "marshal %s", path)
+	require.NoError(t, os.WriteFile(path, raw, 0o644), "write %s", path)
 }
 
 func TestParseOpenCodeDB_StandardSession(t *testing.T) {
@@ -188,9 +167,7 @@ func TestParseOpenCodeDB_StandardSession(t *testing.T) {
 	seedStandardSession(t, seeder)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "testmachine")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
 
 	assertEq(t, "sessions len", len(sessions), 1)
 
@@ -303,12 +280,8 @@ func TestParseOpenCodeFile_StorageSession(t *testing.T) {
 	sess, msgs, err := ParseOpenCodeFile(
 		sessionPath, "testmachine",
 	)
-	if err != nil {
-		t.Fatalf("ParseOpenCodeFile: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected non-nil session")
-	}
+	require.NoError(t, err, "ParseOpenCodeFile")
+	require.NotNil(t, sess, "expected non-nil session")
 
 	assertEq(t, "ID", sess.ID, "opencode:ses_storage")
 	assertEq(t, "Agent", sess.Agent, AgentOpenCode)
@@ -363,16 +336,12 @@ func TestParseOpenCodeFile_StorageSessionInvalidChildFails(
 			"created": 1700000000000,
 		},
 	})
-	if err := os.MkdirAll(filepath.Join(
+	require.NoError(t, os.MkdirAll(filepath.Join(
 		root, "storage", "message", "ses_storage",
-	), 0o755); err != nil {
-		t.Fatalf("mkdir invalid message dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(
+	), 0o755), "mkdir invalid message dir")
+	require.NoError(t, os.WriteFile(filepath.Join(
 		root, "storage", "message", "ses_storage", "msg_bad.json",
-	), []byte(`{"id":"msg_bad"`), 0o644); err != nil {
-		t.Fatalf("write invalid message: %v", err)
-	}
+	), []byte(`{"id":"msg_bad"`), 0o644), "write invalid message")
 	writeOpenCodeStorageFile(t, filepath.Join(
 		root, "storage", "part", "msg_1", "prt_1.json",
 	), map[string]any{
@@ -385,29 +354,19 @@ func TestParseOpenCodeFile_StorageSessionInvalidChildFails(
 			"created": 1700000000000,
 		},
 	})
-	if err := os.MkdirAll(filepath.Join(
+	require.NoError(t, os.MkdirAll(filepath.Join(
 		root, "storage", "part", "msg_1",
-	), 0o755); err != nil {
-		t.Fatalf("mkdir invalid part dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(
+	), 0o755), "mkdir invalid part dir")
+	require.NoError(t, os.WriteFile(filepath.Join(
 		root, "storage", "part", "msg_1", "prt_bad.json",
-	), []byte(`{"id":"prt_bad"`), 0o644); err != nil {
-		t.Fatalf("write invalid part: %v", err)
-	}
+	), []byte(`{"id":"prt_bad"`), 0o644), "write invalid part")
 
 	sess, msgs, err := ParseOpenCodeFile(
 		sessionPath, "testmachine",
 	)
-	if err == nil {
-		t.Fatal("expected ParseOpenCodeFile error")
-	}
-	if sess != nil {
-		t.Fatalf("session = %#v, want nil", sess)
-	}
-	if msgs != nil {
-		t.Fatalf("msgs = %#v, want nil", msgs)
-	}
+	require.Error(t, err, "expected ParseOpenCodeFile error")
+	assert.Nil(t, sess, "session, want nil")
+	assert.Nil(t, msgs, "msgs, want nil")
 }
 
 func TestParseOpenCodeFile_MissingPartDirAllowed(t *testing.T) {
@@ -439,15 +398,9 @@ func TestParseOpenCodeFile_MissingPartDirAllowed(t *testing.T) {
 	sess, msgs, err := ParseOpenCodeFile(
 		sessionPath, "testmachine",
 	)
-	if err != nil {
-		t.Fatalf("ParseOpenCodeFile: %v", err)
-	}
-	if sess != nil {
-		t.Fatalf("session = %#v, want nil", sess)
-	}
-	if msgs != nil {
-		t.Fatalf("msgs = %#v, want nil", msgs)
-	}
+	require.NoError(t, err, "ParseOpenCodeFile")
+	assert.Nil(t, sess, "session, want nil")
+	assert.Nil(t, msgs, "msgs, want nil")
 }
 
 func TestParseOpenCodeFile_StorageMessageMissingIDFails(t *testing.T) {
@@ -477,15 +430,9 @@ func TestParseOpenCodeFile_StorageMessageMissingIDFails(t *testing.T) {
 	sess, msgs, err := ParseOpenCodeFile(
 		sessionPath, "testmachine",
 	)
-	if err == nil {
-		t.Fatal("expected ParseOpenCodeFile error")
-	}
-	if sess != nil {
-		t.Fatalf("session = %#v, want nil", sess)
-	}
-	if msgs != nil {
-		t.Fatalf("msgs = %#v, want nil", msgs)
-	}
+	require.Error(t, err, "expected ParseOpenCodeFile error")
+	assert.Nil(t, sess, "session, want nil")
+	assert.Nil(t, msgs, "msgs, want nil")
 }
 
 func TestParseOpenCodeFile_StoragePartMissingIDFails(t *testing.T) {
@@ -526,15 +473,9 @@ func TestParseOpenCodeFile_StoragePartMissingIDFails(t *testing.T) {
 	sess, msgs, err := ParseOpenCodeFile(
 		sessionPath, "testmachine",
 	)
-	if err == nil {
-		t.Fatal("expected ParseOpenCodeFile error")
-	}
-	if sess != nil {
-		t.Fatalf("session = %#v, want nil", sess)
-	}
-	if msgs != nil {
-		t.Fatalf("msgs = %#v, want nil", msgs)
-	}
+	require.Error(t, err, "expected ParseOpenCodeFile error")
+	assert.Nil(t, sess, "session, want nil")
+	assert.Nil(t, msgs, "msgs, want nil")
 }
 
 func TestParseOpenCodeFile_StoragePartOrderingUsesStartTime(
@@ -589,12 +530,8 @@ func TestParseOpenCodeFile_StoragePartOrderingUsesStartTime(
 	})
 
 	_, msgs, err := ParseOpenCodeFile(sessionPath, "testmachine")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeFile: %v", err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("messages len = %d, want 1", len(msgs))
-	}
+	require.NoError(t, err, "ParseOpenCodeFile")
+	require.Len(t, msgs, 1, "messages len")
 	assertEq(t, "msg[0].Content", msgs[0].Content, "first\nsecond")
 }
 
@@ -652,12 +589,8 @@ func TestParseOpenCodeFile_StoragePartOrderingPrefersStartOverCreated(
 	})
 
 	_, msgs, err := ParseOpenCodeFile(sessionPath, "testmachine")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeFile: %v", err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("messages len = %d, want 1", len(msgs))
-	}
+	require.NoError(t, err, "ParseOpenCodeFile")
+	require.Len(t, msgs, 1, "messages len")
 	assertEq(t, "msg[0].Content", msgs[0].Content, "first\nsecond")
 }
 
@@ -719,15 +652,9 @@ func TestParseOpenCodeFile_StorageStepFinishTokens(t *testing.T) {
 	})
 
 	sess, msgs, err := ParseOpenCodeFile(sessionPath, "testmachine")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeFile: %v", err)
-	}
-	if sess == nil || len(msgs) != 1 {
-		t.Fatalf(
-			"got session=%#v messages=%d, want one parsed session",
-			sess, len(msgs),
-		)
-	}
+	require.NoError(t, err, "ParseOpenCodeFile")
+	require.NotNil(t, sess, "want one parsed session")
+	require.Len(t, msgs, 1, "messages")
 
 	assertEq(t, "msg[0].Model", msgs[0].Model, "gpt-5.2-codex")
 	assertEq(t, "msg[0].HasOutputTokens", msgs[0].HasOutputTokens, true)
@@ -772,9 +699,7 @@ func TestParseOpenCodeDB_TitleFallback(t *testing.T) {
 		`{"type":"text","text":"Refactor the auth module"}`)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
 	assertEq(t, "sessions len", len(sessions), 2)
 
 	for _, s := range sessions {
@@ -807,9 +732,7 @@ func TestParseOpenCodeDB_ToolParts(t *testing.T) {
 	seeder.AddPart("prt_txt", "msg_a", "ses_tools", 1700000012000, 1700000012000, `{"type":"text","text":"Here is the file content."}`)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
 
 	assertEq(t, "sessions len", len(sessions), 1)
 
@@ -836,9 +759,7 @@ func TestParseOpenCodeDB_EmptySession(t *testing.T) {
 	seeder.AddSession("ses_empty", "prj_1", "", "", 1700000000000, 1700000000000)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
 
 	assertEq(t, "sessions len", len(sessions), 0)
 }
@@ -847,12 +768,8 @@ func TestParseOpenCodeDB_NonexistentDB(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "nonexistent.db")
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
-	}
-	if sessions != nil {
-		t.Errorf("expected nil sessions, got %d", len(sessions))
-	}
+	require.NoError(t, err, "expected nil error")
+	assert.Nil(t, sessions, "expected nil sessions")
 }
 
 func TestParseOpenCodeDB_ProjectFromWorktree(t *testing.T) {
@@ -862,9 +779,7 @@ func TestParseOpenCodeDB_ProjectFromWorktree(t *testing.T) {
 	// Create a temp dir that looks like a git repo so
 	// ExtractProjectFromCwd resolves it.
 	repoDir := filepath.Join(t.TempDir(), "my-project")
-	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755))
 
 	seeder.AddProject("prj_git", repoDir)
 	seeder.AddSession("ses_git", "prj_git", "", "", 1700000000000, 1700000010000)
@@ -872,9 +787,7 @@ func TestParseOpenCodeDB_ProjectFromWorktree(t *testing.T) {
 	seeder.AddPart("prt_1", "msg_1", "ses_git", 1700000000000, 1700000000000, `{"type":"text","text":"hello"}`)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
 	assertEq(t, "sessions len", len(sessions), 1)
 
 	assertEq(t, "Project", sessions[0].Session.Project, "my_project")
@@ -886,13 +799,8 @@ func TestParseOpenCodeSession_SingleSession(t *testing.T) {
 	seedStandardSession(t, seeder)
 
 	sess, msgs, err := ParseOpenCodeSession(dbPath, "ses_abc", "testmachine")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected non-nil session")
-		return
-	}
+	require.NoError(t, err, "ParseOpenCodeSession")
+	require.NotNil(t, sess, "expected non-nil session")
 
 	assertEq(t, "ID", sess.ID, "opencode:ses_abc")
 	assertEq(t, "messages len", len(msgs), 2)
@@ -926,9 +834,7 @@ func TestParseOpenCodeDB_OrdinalContinuity(t *testing.T) {
 	seeder.AddPart("prt_5", "msg_5", "ses_ord", 1700000040000, 1700000040000, `{"type":"text","text":"follow up"}`)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
 	assertEq(t, "sessions len", len(sessions), 1)
 
 	msgs := sessions[0].Messages
@@ -959,9 +865,7 @@ func TestParseOpenCodeDB_ParentSession(t *testing.T) {
 	seeder.AddPart("prt_c", "msg_c", "ses_child", 1700000020000, 1700000020000, `{"type":"text","text":"child msg"}`)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
 
 	var child *OpenCodeSession
 	for i := range sessions {
@@ -969,10 +873,7 @@ func TestParseOpenCodeDB_ParentSession(t *testing.T) {
 			child = &sessions[i]
 		}
 	}
-	if child == nil {
-		t.Fatal("child session not found")
-		return
-	}
+	require.NotNil(t, child, "child session not found")
 	assertEq(t, "ParentSessionID", child.Session.ParentSessionID, "opencode:ses_parent")
 }
 
@@ -982,9 +883,7 @@ func TestListOpenCodeSessionMeta(t *testing.T) {
 	seedStandardSession(t, seeder)
 
 	metas, err := ListOpenCodeSessionMeta(dbPath)
-	if err != nil {
-		t.Fatalf("ListOpenCodeSessionMeta: %v", err)
-	}
+	require.NoError(t, err, "ListOpenCodeSessionMeta")
 	assertEq(t, "metas len", len(metas), 1)
 
 	m := metas[0]
@@ -1000,9 +899,7 @@ func TestListOpenCodeSessionMeta(t *testing.T) {
 func TestListOpenCodeSessionMeta_NonexistentDB(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "nope.db")
 	metas, err := ListOpenCodeSessionMeta(dbPath)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err, "unexpected error")
 	assertEq(t, "metas len", len(metas), 0)
 }
 
@@ -1053,12 +950,8 @@ func TestParseOpenCodeDB_TokenUsage(t *testing.T) {
 		`{"type":"text","text":"answer2"}`)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "testmachine")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
-	if len(sessions) != 1 {
-		t.Fatalf("sessions len = %d, want 1", len(sessions))
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
 	s := sessions[0]
 
 	var asst1, asst2 *ParsedMessage
@@ -1074,23 +967,16 @@ func TestParseOpenCodeDB_TokenUsage(t *testing.T) {
 			asst2 = m
 		}
 	}
-	if asst1 == nil {
-		t.Fatal("missing gpt-5.2-codex assistant message")
-	}
-	if asst2 == nil {
-		t.Fatal("missing claude-sonnet assistant message")
-	}
+	require.NotNil(t, asst1, "missing gpt-5.2-codex assistant message")
+	require.NotNil(t, asst2, "missing claude-sonnet assistant message")
 
 	checkUsage := func(name string, m *ParsedMessage,
 		wantIn, wantOut, wantCacheRead, wantCacheCreate int) {
 		t.Helper()
-		if len(m.TokenUsage) == 0 {
-			t.Fatalf("%s: TokenUsage empty", name)
-		}
+		require.NotEmpty(t, m.TokenUsage, "%s: TokenUsage empty", name)
 		var got map[string]int
-		if err := json.Unmarshal(m.TokenUsage, &got); err != nil {
-			t.Fatalf("%s: unmarshal TokenUsage: %v", name, err)
-		}
+		require.NoError(t, json.Unmarshal(m.TokenUsage, &got),
+			"%s: unmarshal TokenUsage", name)
 		assertEq(t, name+" input_tokens",
 			got["input_tokens"], wantIn)
 		assertEq(t, name+" output_tokens",
@@ -1114,14 +1000,10 @@ func TestParseOpenCodeDB_TokenUsage(t *testing.T) {
 	checkUsage("claude", asst2, 1, 102, 500, 11969)
 
 	// Session-level rollups via accumulateMessageTokenUsage.
-	if !s.Session.HasTotalOutputTokens {
-		t.Fatal("session HasTotalOutputTokens=false, want true")
-	}
+	assert.True(t, s.Session.HasTotalOutputTokens, "session HasTotalOutputTokens")
 	assertEq(t, "TotalOutputTokens",
 		s.Session.TotalOutputTokens, 137) // 35 + 102
-	if !s.Session.HasPeakContextTokens {
-		t.Fatal("session HasPeakContextTokens=false, want true")
-	}
+	assert.True(t, s.Session.HasPeakContextTokens, "session HasPeakContextTokens")
 	assertEq(t, "PeakContextTokens",
 		s.Session.PeakContextTokens, 12470) // 1 + 500 + 11969
 }
@@ -1163,12 +1045,8 @@ func TestParseOpenCodeDB_UnknownTokensShape(t *testing.T) {
 				`{"type":"text","text":"answer"}`)
 
 			sessions, err := ParseOpenCodeDB(dbPath, "m")
-			if err != nil {
-				t.Fatalf("ParseOpenCodeDB: %v", err)
-			}
-			if len(sessions) != 1 {
-				t.Fatalf("sessions len = %d, want 1", len(sessions))
-			}
+			require.NoError(t, err, "ParseOpenCodeDB")
+			require.Len(t, sessions, 1, "sessions len")
 
 			var asst *ParsedMessage
 			for i := range sessions[0].Messages {
@@ -1177,14 +1055,10 @@ func TestParseOpenCodeDB_UnknownTokensShape(t *testing.T) {
 					break
 				}
 			}
-			if asst == nil {
-				t.Fatal("missing assistant message")
-			}
+			require.NotNil(t, asst, "missing assistant message")
 			assertEq(t, "Model", asst.Model, "gpt-5.4")
-			if len(asst.TokenUsage) != 0 {
-				t.Fatalf("TokenUsage = %q, want empty",
-					string(asst.TokenUsage))
-			}
+			assert.Empty(t, asst.TokenUsage,
+				"TokenUsage = %q, want empty", string(asst.TokenUsage))
 			assertEq(t, "HasOutputTokens",
 				asst.HasOutputTokens, false)
 			assertEq(t, "HasContextTokens",
@@ -1228,12 +1102,8 @@ func TestParseOpenCodeDB_ZeroTokens(t *testing.T) {
 		`{"type":"text","text":"sorry, request failed"}`)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
-	if len(sessions) != 1 {
-		t.Fatalf("sessions len = %d, want 1", len(sessions))
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
 
 	var asst *ParsedMessage
 	for i := range sessions[0].Messages {
@@ -1242,17 +1112,11 @@ func TestParseOpenCodeDB_ZeroTokens(t *testing.T) {
 			break
 		}
 	}
-	if asst == nil {
-		t.Fatal("missing assistant message")
-	}
+	require.NotNil(t, asst, "missing assistant message")
 	assertEq(t, "Model", asst.Model, "gpt-5.2-chat-latest")
-	if len(asst.TokenUsage) == 0 {
-		t.Fatal("TokenUsage empty; want zero-valued JSON preserved")
-	}
+	require.NotEmpty(t, asst.TokenUsage, "TokenUsage empty; want zero-valued JSON preserved")
 	var got map[string]int
-	if err := json.Unmarshal(asst.TokenUsage, &got); err != nil {
-		t.Fatalf("unmarshal TokenUsage: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(asst.TokenUsage, &got), "unmarshal TokenUsage")
 	assertEq(t, "input_tokens", got["input_tokens"], 0)
 	assertEq(t, "output_tokens", got["output_tokens"], 0)
 	assertEq(t, "cache_read_input_tokens",
@@ -1291,12 +1155,8 @@ func TestParseOpenCodeDB_NoTokenUsage(t *testing.T) {
 		`{"type":"text","text":"oops"}`)
 
 	sessions, err := ParseOpenCodeDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseOpenCodeDB: %v", err)
-	}
-	if len(sessions) != 1 {
-		t.Fatalf("sessions len = %d, want 1", len(sessions))
-	}
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
 
 	var asst *ParsedMessage
 	for i := range sessions[0].Messages {
@@ -1305,13 +1165,9 @@ func TestParseOpenCodeDB_NoTokenUsage(t *testing.T) {
 			break
 		}
 	}
-	if asst == nil {
-		t.Fatal("missing assistant message")
-	}
+	require.NotNil(t, asst, "missing assistant message")
 	assertEq(t, "Model", asst.Model, "gpt-5.4")
-	if len(asst.TokenUsage) != 0 {
-		t.Fatalf("TokenUsage = %q, want empty", string(asst.TokenUsage))
-	}
+	assert.Empty(t, asst.TokenUsage, "TokenUsage = %q, want empty", string(asst.TokenUsage))
 }
 
 func TestOpenCodeStorageFingerprintMissingDetectsContentRewrite(
@@ -1348,9 +1204,6 @@ func TestOpenCodeStorageFingerprintMissingDetectsContentRewrite(
 		},
 	)
 
-	if !OpenCodeStorageFingerprintMissing(
-		stored, current,
-	) {
-		t.Fatal("expected content rewrite to invalidate fingerprint")
-	}
+	assert.True(t, OpenCodeStorageFingerprintMissing(stored, current),
+		"expected content rewrite to invalidate fingerprint")
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/tidwall/gjson"
 	"go.kenn.io/agentsview/internal/testjsonl"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetProjectName(t *testing.T) {
@@ -46,10 +49,7 @@ func TestGetProjectName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetProjectName(tt.dir)
-			if got != tt.want {
-				t.Errorf("GetProjectName(%q) = %q, want %q",
-					tt.dir, got, tt.want)
-			}
+			assert.Equalf(t, tt.want, got, "GetProjectName(%q)", tt.dir)
 		})
 	}
 }
@@ -87,10 +87,7 @@ func TestExtractProjectFromCwd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.cwd, func(t *testing.T) {
 			got := ExtractProjectFromCwd(tt.cwd)
-			if got != tt.want {
-				t.Errorf("ExtractProjectFromCwd(%q) = %q, want %q",
-					tt.cwd, got, tt.want)
-			}
+			assert.Equalf(t, tt.want, got, "ExtractProjectFromCwd(%q)", tt.cwd)
 		})
 	}
 }
@@ -115,10 +112,7 @@ func TestNeedsProjectReparse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.project, func(t *testing.T) {
 			got := NeedsProjectReparse(tt.project)
-			if got != tt.want {
-				t.Errorf("NeedsProjectReparse(%q) = %v, want %v",
-					tt.project, got, tt.want)
-			}
+			assert.Equalf(t, tt.want, got, "NeedsProjectReparse(%q)", tt.project)
 		})
 	}
 }
@@ -215,17 +209,9 @@ func TestExtractTextContent(t *testing.T) {
 			result := gjson.Parse(tt.json)
 			text, _, hasThinking, hasToolUse, tcs, _ :=
 				ExtractTextContent(result)
-			if text != tt.wantText {
-				t.Errorf("text = %q, want %q", text, tt.wantText)
-			}
-			if hasThinking != tt.wantThink {
-				t.Errorf("hasThinking = %v, want %v",
-					hasThinking, tt.wantThink)
-			}
-			if hasToolUse != tt.wantToolUse {
-				t.Errorf("hasToolUse = %v, want %v",
-					hasToolUse, tt.wantToolUse)
-			}
+			assert.Equal(t, tt.wantText, text, "text")
+			assert.Equal(t, tt.wantThink, hasThinking, "hasThinking")
+			assert.Equal(t, tt.wantToolUse, hasToolUse, "hasToolUse")
 			assertToolCalls(t, tcs, tt.wantToolCalls)
 		})
 	}
@@ -239,38 +225,18 @@ func TestExtractTextContent_AmpSkillNameExtraction(t *testing.T) {
 	text, _, hasThinking, hasToolUse, toolCalls, toolResults :=
 		ExtractTextContent(result)
 
-	if text != "[Skill: walkthrough]" {
-		t.Fatalf("text = %q, want %q", text, "[Skill: walkthrough]")
-	}
-	if hasThinking {
-		t.Fatalf("hasThinking = %v, want false", hasThinking)
-	}
-	if !hasToolUse {
-		t.Fatalf("hasToolUse = %v, want true", hasToolUse)
-	}
-	if len(toolResults) != 0 {
-		t.Fatalf("len(toolResults) = %d, want 0", len(toolResults))
-	}
-	if len(toolCalls) != 1 {
-		t.Fatalf("len(toolCalls) = %d, want 1", len(toolCalls))
-	}
+	require.Equal(t, "[Skill: walkthrough]", text, "text")
+	require.False(t, hasThinking, "hasThinking")
+	require.True(t, hasToolUse, "hasToolUse")
+	require.Empty(t, toolResults, "toolResults")
+	require.Len(t, toolCalls, 1, "toolCalls")
 
 	got := toolCalls[0]
-	if got.ToolUseID != "toolu_amp_skill" {
-		t.Fatalf("ToolUseID = %q, want %q", got.ToolUseID, "toolu_amp_skill")
-	}
-	if got.ToolName != "skill" {
-		t.Fatalf("ToolName = %q, want %q", got.ToolName, "skill")
-	}
-	if got.Category != "Tool" {
-		t.Fatalf("Category = %q, want %q", got.Category, "Tool")
-	}
-	if got.SkillName != "walkthrough" {
-		t.Fatalf("SkillName = %q, want %q", got.SkillName, "walkthrough")
-	}
-	if got.InputJSON != `{"name":"walkthrough"}` {
-		t.Fatalf("InputJSON = %q, want %q", got.InputJSON, `{"name":"walkthrough"}`)
-	}
+	assert.Equal(t, "toolu_amp_skill", got.ToolUseID, "ToolUseID")
+	assert.Equal(t, "skill", got.ToolName, "ToolName")
+	assert.Equal(t, "Tool", got.Category, "Category")
+	assert.Equal(t, "walkthrough", got.SkillName, "SkillName")
+	assert.Equal(t, `{"name":"walkthrough"}`, got.InputJSON, "InputJSON")
 }
 
 func TestExtractToolResults(t *testing.T) {
@@ -307,23 +273,14 @@ func TestExtractToolResults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := gjson.Parse(tt.json)
 			_, _, _, _, _, trs := ExtractTextContent(result)
-			if len(trs) != len(tt.wantResults) {
-				t.Fatalf("tool_results count = %d, want %d",
-					len(trs), len(tt.wantResults))
-			}
+			require.Len(t, trs, len(tt.wantResults), "tool_results count")
 			for i := range tt.wantResults {
-				if trs[i].ToolUseID != tt.wantResults[i].ToolUseID {
-					t.Errorf("[%d].ToolUseID = %q, want %q",
-						i, trs[i].ToolUseID, tt.wantResults[i].ToolUseID)
-				}
-				if trs[i].ContentLength != tt.wantResults[i].ContentLength {
-					t.Errorf("[%d].ContentLength = %d, want %d",
-						i, trs[i].ContentLength, tt.wantResults[i].ContentLength)
-				}
-				if trs[i].ContentRaw != tt.wantResults[i].ContentRaw {
-					t.Errorf("[%d].ContentRaw = %q, want %q",
-						i, trs[i].ContentRaw, tt.wantResults[i].ContentRaw)
-				}
+				assert.Equalf(t, tt.wantResults[i].ToolUseID, trs[i].ToolUseID,
+					"[%d].ToolUseID", i)
+				assert.Equalf(t, tt.wantResults[i].ContentLength, trs[i].ContentLength,
+					"[%d].ContentLength", i)
+				assert.Equalf(t, tt.wantResults[i].ContentRaw, trs[i].ContentRaw,
+					"[%d].ContentRaw", i)
 			}
 		})
 	}
@@ -354,9 +311,7 @@ func TestDecodeContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DecodeContent(tt.raw)
-			if got != tt.want {
-				t.Errorf("DecodeContent(%q) = %q, want %q", tt.raw, got, tt.want)
-			}
+			assert.Equalf(t, tt.want, got, "DecodeContent(%q)", tt.raw)
 		})
 	}
 }
@@ -369,25 +324,12 @@ func TestExtractTextContent_IflowToolResult(t *testing.T) {
 		"content":{"responseParts":{"functionResponse":{"response":{"output":"result text"}}}}
 	}]`
 	_, _, _, _, _, trs := ExtractTextContent(gjson.Parse(content))
-	if len(trs) != 1 {
-		t.Fatalf("expected 1 tool result, got %d", len(trs))
-	}
+	require.Len(t, trs, 1, "expected 1 tool result")
 	tr := trs[0]
-	if tr.ToolUseID != "tu_123" {
-		t.Errorf("ToolUseID = %q, want %q", tr.ToolUseID, "tu_123")
-	}
-	if tr.ContentLength != len("result text") {
-		t.Errorf(
-			"ContentLength = %d, want %d",
-			tr.ContentLength, len("result text"),
-		)
-	}
+	assert.Equal(t, "tu_123", tr.ToolUseID, "ToolUseID")
+	assert.Equal(t, len("result text"), tr.ContentLength, "ContentLength")
 	decoded := DecodeContent(tr.ContentRaw)
-	if decoded != "result text" {
-		t.Errorf(
-			"DecodeContent = %q, want %q", decoded, "result text",
-		)
-	}
+	assert.Equal(t, "result text", decoded, "DecodeContent")
 
 	// Object without nested output: both length and decode
 	// should be zero/empty.
@@ -397,15 +339,9 @@ func TestExtractTextContent_IflowToolResult(t *testing.T) {
 		"content":{"other":"data"}
 	}]`
 	_, _, _, _, _, trs2 := ExtractTextContent(gjson.Parse(noOutput))
-	if len(trs2) != 1 {
-		t.Fatalf("expected 1 tool result, got %d", len(trs2))
-	}
-	if trs2[0].ContentLength != 0 {
-		t.Errorf("ContentLength = %d, want 0", trs2[0].ContentLength)
-	}
-	if d := DecodeContent(trs2[0].ContentRaw); d != "" {
-		t.Errorf("DecodeContent = %q, want empty", d)
-	}
+	require.Len(t, trs2, 1, "expected 1 tool result")
+	assert.Zero(t, trs2[0].ContentLength, "ContentLength")
+	assert.Empty(t, DecodeContent(trs2[0].ContentRaw), "DecodeContent")
 }
 
 func TestFormatToolUseVariants(t *testing.T) {
@@ -671,9 +607,7 @@ func TestFormatToolUseVariants(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			block := gjson.Parse(tt.json)
 			got := formatToolUse(block)
-			if got != tt.want {
-				t.Errorf("formatToolUse = %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got, "formatToolUse")
 		})
 	}
 }
@@ -766,31 +700,15 @@ func TestParseTimestamp(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseTimestamp(tt.input)
 			if tt.wantOK {
-				if got.IsZero() {
-					t.Fatalf(
-						"parseTimestamp(%q) = zero, want %v",
-						tt.input, tt.wantUTC,
-					)
-				}
-				if !got.Equal(tt.wantUTC) {
-					t.Errorf(
-						"parseTimestamp(%q) = %v, want %v",
-						tt.input, got, tt.wantUTC,
-					)
-				}
-				if got.Location() != time.UTC {
-					t.Errorf(
-						"parseTimestamp(%q) location = %v, want UTC",
-						tt.input, got.Location(),
-					)
-				}
+				require.Falsef(t, got.IsZero(),
+					"parseTimestamp(%q) = zero, want %v", tt.input, tt.wantUTC)
+				assert.Truef(t, got.Equal(tt.wantUTC),
+					"parseTimestamp(%q) = %v, want %v", tt.input, got, tt.wantUTC)
+				assert.Equalf(t, time.UTC, got.Location(),
+					"parseTimestamp(%q) location", tt.input)
 			} else {
-				if !got.IsZero() {
-					t.Errorf(
-						"parseTimestamp(%q) = %v, want zero",
-						tt.input, got,
-					)
-				}
+				assert.Truef(t, got.IsZero(),
+					"parseTimestamp(%q) = %v, want zero", tt.input, got)
 			}
 		})
 	}
@@ -808,9 +726,7 @@ func TestClaudeSessionTimestampSemantics(t *testing.T) {
 		assertTimestamp(t, sess.StartedAt, wantTS)
 		assertTimestamp(t, sess.EndedAt, wantTS)
 
-		if len(msgs) != 1 {
-			t.Fatalf("got %d messages, want 1", len(msgs))
-		}
+		require.Len(t, msgs, 1, "messages")
 		assertTimestamp(t, msgs[0].Timestamp, wantTS)
 	})
 
@@ -824,9 +740,7 @@ func TestClaudeSessionTimestampSemantics(t *testing.T) {
 		)
 		assertTimestamp(t, sess.StartedAt, wantUTC)
 
-		if len(msgs) != 1 {
-			t.Fatalf("got %d messages, want 1", len(msgs))
-		}
+		require.Len(t, msgs, 1, "messages")
 		assertTimestamp(t, msgs[0].Timestamp, wantUTC)
 	})
 
@@ -836,9 +750,7 @@ func TestClaudeSessionTimestampSemantics(t *testing.T) {
 			t, "ts-bad.jsonl", content, "proj",
 		)
 		assertZeroTimestamp(t, sess.StartedAt, "StartedAt")
-		if len(msgs) != 1 {
-			t.Fatalf("got %d messages, want 1", len(msgs))
-		}
+		require.Len(t, msgs, 1, "messages")
 		assertZeroTimestamp(t, msgs[0].Timestamp, "msg timestamp")
 	})
 
@@ -852,9 +764,7 @@ func TestClaudeSessionTimestampSemantics(t *testing.T) {
 
 		wantTS := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
 		assertTimestamp(t, sess.StartedAt, wantTS)
-		if len(msgs) != 1 {
-			t.Fatalf("got %d messages, want 1", len(msgs))
-		}
+		require.Len(t, msgs, 1, "messages")
 		assertTimestamp(t, msgs[0].Timestamp, wantTS)
 		assertLogEmpty(t, buf)
 	})
@@ -882,16 +792,13 @@ func TestClaudeSessionTimestampSemantics(t *testing.T) {
 		_, err := ParseClaudeSession(
 			path, "proj", "local",
 		)
-		if err != nil {
-			t.Fatalf("ParseClaudeSession: %v", err)
-		}
+		require.NoError(t, err, "ParseClaudeSession")
 
 		assertLogContains(t, buf,
 			"unparseable timestamp", "x...",
 		)
-		if buf.Len() > 1000 {
-			t.Errorf("log output too long: %d bytes", buf.Len())
-		}
+		assert.LessOrEqualf(t, buf.Len(), 1000,
+			"log output too long: %d bytes", buf.Len())
 		assertLogNotContains(t, buf, longInvalid)
 	})
 }
@@ -901,11 +808,7 @@ func createTestFile(
 ) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)
-	if err := os.WriteFile(
-		path, []byte(content), 0o644,
-	); err != nil {
-		t.Fatalf("create %s: %v", name, err)
-	}
+	require.NoErrorf(t, os.WriteFile(path, []byte(content), 0o644), "create %s", name)
 	return path
 }
 
@@ -965,12 +868,8 @@ func TestIsClaudeSystemMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isClaudeSystemMessage(tt.content)
-			if got != tt.want {
-				t.Errorf(
-					"isClaudeSystemMessage(%q) = %v, want %v",
-					tt.content, got, tt.want,
-				)
-			}
+			assert.Equalf(t, tt.want, got,
+				"isClaudeSystemMessage(%q)", tt.content)
 		})
 	}
 }
@@ -1047,18 +946,10 @@ func TestExtractCommandText(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := extractCommandText(tt.content)
-			if ok != tt.ok {
-				t.Errorf(
-					"extractCommandText(%q) ok = %v, want %v",
-					tt.content, ok, tt.ok,
-				)
-			}
-			if got != tt.want {
-				t.Errorf(
-					"extractCommandText(%q) = %q, want %q",
-					tt.content, got, tt.want,
-				)
-			}
+			assert.Equalf(t, tt.ok, ok,
+				"extractCommandText(%q) ok", tt.content)
+			assert.Equalf(t, tt.want, got,
+				"extractCommandText(%q)", tt.content)
 		})
 	}
 }
@@ -1078,21 +969,11 @@ func TestCodexUserMessageCount(t *testing.T) {
 
 	path := createTestFile(t, "codex-umc.jsonl", content)
 	sess, msgs, err := ParseCodexSession(path, "local", false)
-	if err != nil {
-		t.Fatalf("ParseCodexSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("session is nil")
-		return
-	}
-	if len(msgs) != 4 {
-		t.Fatalf("got %d messages, want 4", len(msgs))
-	}
+	require.NoError(t, err, "ParseCodexSession")
+	require.NotNil(t, sess, "session")
+	require.Len(t, msgs, 4, "messages")
 	// 2 user messages with real text content.
-	if sess.UserMessageCount != 2 {
-		t.Errorf("UserMessageCount = %d, want 2",
-			sess.UserMessageCount)
-	}
+	assert.Equal(t, 2, sess.UserMessageCount, "UserMessageCount")
 }
 
 func TestCodexSessionTimestampSemantics(t *testing.T) {
@@ -1104,14 +985,10 @@ func TestCodexSessionTimestampSemantics(t *testing.T) {
 		sess, msgs, err := ParseCodexSession(
 			path, "local", false,
 		)
-		if err != nil {
-			t.Fatalf("ParseCodexSession: %v", err)
-		}
+		require.NoError(t, err, "ParseCodexSession")
 
 		assertZeroTimestamp(t, sess.StartedAt, "StartedAt")
-		if len(msgs) != 1 {
-			t.Fatalf("got %d messages, want 1", len(msgs))
-		}
+		require.Len(t, msgs, 1, "messages")
 		assertZeroTimestamp(t, msgs[0].Timestamp, "msg timestamp")
 		assertLogContains(t, buf,
 			"unparseable timestamp", "garbage",
@@ -1127,9 +1004,7 @@ func TestCodexSessionTimestampSemantics(t *testing.T) {
 		_, _, err := ParseCodexSession(
 			path, "local", false,
 		)
-		if err != nil {
-			t.Fatalf("ParseCodexSession: %v", err)
-		}
+		require.NoError(t, err, "ParseCodexSession")
 
 		assertLogContains(t, buf,
 			"unparseable timestamp", "...",
@@ -1162,16 +1037,9 @@ func TestParseCodexSessionOversizedLineSkipped(t *testing.T) {
 	sess, msgs, err := ParseCodexSession(
 		path, "local", false,
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("session is nil")
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("got %d messages, want 2 (oversized skipped)",
-			len(msgs))
-	}
+	require.NoError(t, err, "unexpected error")
+	require.NotNil(t, sess, "session")
+	require.Len(t, msgs, 2, "messages (oversized skipped)")
 }
 
 func TestExtractCwdFromSession(t *testing.T) {
@@ -1196,18 +1064,13 @@ func TestExtractCwdFromSession(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			path := createTestFile(t, "test.jsonl", tt.content)
 			got := ExtractCwdFromSession(path)
-			if got != tt.want {
-				t.Errorf("ExtractCwdFromSession = %q, want %q",
-					got, tt.want)
-			}
+			assert.Equal(t, tt.want, got, "ExtractCwdFromSession")
 		})
 	}
 
 	t.Run("missing file", func(t *testing.T) {
 		got := ExtractCwdFromSession("/nonexistent/path.jsonl")
-		if got != "" {
-			t.Errorf("ExtractCwdFromSession = %q, want empty", got)
-		}
+		assert.Empty(t, got, "ExtractCwdFromSession")
 	})
 }
 
@@ -1217,16 +1080,9 @@ func TestParseCodexSession_WorktreeBranchFallback(t *testing.T) {
 	path := createTestFile(t, "codex-worktree.jsonl", content)
 
 	sess, _, err := ParseCodexSession(path, "local", false)
-	if err != nil {
-		t.Fatalf("ParseCodexSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("session is nil")
-		return
-	}
-	if sess.Project != "agentsview" {
-		t.Fatalf("project = %q, want %q", sess.Project, "agentsview")
-	}
+	require.NoError(t, err, "ParseCodexSession")
+	require.NotNil(t, sess, "session")
+	assert.Equal(t, "agentsview", sess.Project, "project")
 }
 
 func TestExtractClaudeProjectHints(t *testing.T) {
@@ -1235,13 +1091,8 @@ func TestExtractClaudeProjectHints(t *testing.T) {
 		path := createTestFile(t, "hints.jsonl", content)
 
 		cwd, branch := ExtractClaudeProjectHints(path)
-		if cwd != "/Users/alice/code/my-app-worktree-fix" {
-			t.Fatalf("cwd = %q, want %q",
-				cwd, "/Users/alice/code/my-app-worktree-fix")
-		}
-		if branch != "worktree-fix" {
-			t.Fatalf("branch = %q, want %q", branch, "worktree-fix")
-		}
+		require.Equal(t, "/Users/alice/code/my-app-worktree-fix", cwd, "cwd")
+		require.Equal(t, "worktree-fix", branch, "branch")
 	})
 
 	t.Run("missing branch still returns cwd", func(t *testing.T) {
@@ -1249,23 +1100,16 @@ func TestExtractClaudeProjectHints(t *testing.T) {
 		path := createTestFile(t, "hints-nobranch.jsonl", content)
 
 		cwd, branch := ExtractClaudeProjectHints(path)
-		if cwd != "/Users/alice/code/my-app" {
-			t.Fatalf("cwd = %q, want %q",
-				cwd, "/Users/alice/code/my-app")
-		}
-		if branch != "" {
-			t.Fatalf("branch = %q, want empty", branch)
-		}
+		require.Equal(t, "/Users/alice/code/my-app", cwd, "cwd")
+		require.Empty(t, branch, "branch")
 	})
 
 	t.Run("missing file", func(t *testing.T) {
 		cwd, branch := ExtractClaudeProjectHints(
 			"/nonexistent/path.jsonl",
 		)
-		if cwd != "" || branch != "" {
-			t.Fatalf("got cwd=%q branch=%q, want both empty",
-				cwd, branch)
-		}
+		require.Empty(t, cwd, "cwd")
+		require.Empty(t, branch, "branch")
 	})
 }
 
@@ -1360,10 +1204,7 @@ func TestFormatGeminiToolCall(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			tc := gjson.Parse(tt.json)
 			got := formatGeminiToolCall(tc)
-			if got != tt.want {
-				t.Errorf("formatGeminiToolCall = %q, want %q",
-					got, tt.want)
-			}
+			assert.Equal(t, tt.want, got, "formatGeminiToolCall")
 		})
 	}
 }
@@ -1388,38 +1229,22 @@ func TestGeminiUserMessageCount(t *testing.T) {
 	sess, msgs, err := ParseGeminiSession(
 		path, "my_project", "local",
 	)
-	if err != nil {
-		t.Fatalf("ParseGeminiSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("session is nil")
-		return
-	}
-	if len(msgs) != 4 {
-		t.Fatalf("got %d messages, want 4", len(msgs))
-	}
-	if sess.UserMessageCount != 2 {
-		t.Errorf("UserMessageCount = %d, want 2",
-			sess.UserMessageCount)
-	}
+	require.NoError(t, err, "ParseGeminiSession")
+	require.NotNil(t, sess, "session")
+	require.Len(t, msgs, 4, "messages")
+	assert.Equal(t, 2, sess.UserMessageCount, "UserMessageCount")
 }
 
 func TestGeminiSessionID(t *testing.T) {
 	data := []byte(`{"sessionId":"abc-123","messages":[]}`)
 	got := GeminiSessionID(data)
-	if got != "abc-123" {
-		t.Errorf("GeminiSessionID = %q, want %q", got, "abc-123")
-	}
+	assert.Equal(t, "abc-123", got, "GeminiSessionID")
 
 	got = GeminiSessionID([]byte("{\"sessionId\":\"jsonl-123\"}\n{\"type\":\"user\"}\n"))
-	if got != "jsonl-123" {
-		t.Errorf("GeminiSessionID JSONL = %q, want %q", got, "jsonl-123")
-	}
+	assert.Equal(t, "jsonl-123", got, "GeminiSessionID JSONL")
 
 	got = GeminiSessionID([]byte(`{}`))
-	if got != "" {
-		t.Errorf("GeminiSessionID empty = %q, want empty", got)
-	}
+	assert.Empty(t, got, "GeminiSessionID empty")
 }
 
 func TestClaudeUserMessageCount(t *testing.T) {
@@ -1477,25 +1302,12 @@ func TestClaudeUserMessageCount(t *testing.T) {
 			results, err := ParseClaudeSession(
 				path, "test-proj", "local",
 			)
-			if err != nil {
-				t.Fatalf("ParseClaudeSession: %v", err)
-			}
-			if len(results) == 0 {
-				t.Fatal("ParseClaudeSession returned no results")
-			}
+			require.NoError(t, err, "ParseClaudeSession")
+			require.NotEmpty(t, results, "ParseClaudeSession returned no results")
 			sess := results[0].Session
 			msgs := results[0].Messages
-			if len(msgs) != tt.wantMsgCount {
-				t.Fatalf("message count = %d, want %d",
-					len(msgs), tt.wantMsgCount)
-			}
-			if sess.UserMessageCount != tt.wantUserCount {
-				t.Errorf(
-					"UserMessageCount = %d, want %d",
-					sess.UserMessageCount,
-					tt.wantUserCount,
-				)
-			}
+			require.Len(t, msgs, tt.wantMsgCount, "message count")
+			assert.Equal(t, tt.wantUserCount, sess.UserMessageCount, "UserMessageCount")
 		})
 	}
 }
@@ -1509,30 +1321,16 @@ func TestParseClaudeToolResults(t *testing.T) {
 	path := createTestFile(t, "tool-results.jsonl", content)
 
 	results, err := ParseClaudeSession(path, "test-project", "local")
-	if err != nil {
-		t.Fatalf("ParseClaudeSession: %v", err)
-	}
-	if len(results) == 0 {
-		t.Fatal("ParseClaudeSession returned no results")
-	}
+	require.NoError(t, err, "ParseClaudeSession")
+	require.NotEmpty(t, results, "ParseClaudeSession returned no results")
 	msgs := results[0].Messages
 
 	// Should have 2 messages: assistant tool_use + user tool_result
-	if len(msgs) != 2 {
-		t.Fatalf("got %d messages, want 2", len(msgs))
-	}
+	require.Len(t, msgs, 2, "messages")
 
 	// User message should have ToolResults populated
 	userMsg := msgs[1]
-	if len(userMsg.ToolResults) != 1 {
-		t.Fatalf("ToolResults count = %d, want 1", len(userMsg.ToolResults))
-	}
-	if userMsg.ToolResults[0].ToolUseID != "toolu_abc" {
-		t.Errorf("ToolUseID = %q, want toolu_abc",
-			userMsg.ToolResults[0].ToolUseID)
-	}
-	if userMsg.ToolResults[0].ContentLength != 27 {
-		t.Errorf("ContentLength = %d, want 27",
-			userMsg.ToolResults[0].ContentLength)
-	}
+	require.Len(t, userMsg.ToolResults, 1, "ToolResults count")
+	assert.Equal(t, "toolu_abc", userMsg.ToolResults[0].ToolUseID, "ToolUseID")
+	assert.Equal(t, 27, userMsg.ToolResults[0].ContentLength, "ContentLength")
 }

--- a/internal/parser/piebald_test.go
+++ b/internal/parser/piebald_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -13,9 +15,7 @@ func newPiebaldTestDB(t *testing.T) string {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "app.db")
 	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("open test db: %v", err)
-	}
+	require.NoError(t, err, "open test db")
 	defer db.Close()
 	stmts := []string{
 		`CREATE TABLE projects (
@@ -85,9 +85,8 @@ func newPiebaldTestDB(t *testing.T) string {
 		)`,
 	}
 	for _, stmt := range stmts {
-		if _, err := db.Exec(stmt); err != nil {
-			t.Fatalf("exec schema: %v", err)
-		}
+		_, err := db.Exec(stmt)
+		require.NoError(t, err, "exec schema")
 	}
 	return dbPath
 }
@@ -95,13 +94,10 @@ func newPiebaldTestDB(t *testing.T) string {
 func execPiebaldTestSQL(t *testing.T, dbPath, stmt string, args ...any) {
 	t.Helper()
 	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("open test db: %v", err)
-	}
+	require.NoError(t, err, "open test db")
 	defer db.Close()
-	if _, err := db.Exec(stmt, args...); err != nil {
-		t.Fatalf("exec %q: %v", stmt, err)
-	}
+	_, err = db.Exec(stmt, args...)
+	require.NoError(t, err, "exec %q", stmt)
 }
 
 func seedPiebaldTextPart(t *testing.T, dbPath string, partID, msgID int64, idx int, text string, thinking bool) {
@@ -142,14 +138,10 @@ func seedPiebaldSubagentToolPart(t *testing.T, dbPath string, partID, msgID int6
 
 func TestFindPiebaldDBPath(t *testing.T) {
 	dir := t.TempDir()
-	if got := FindPiebaldDBPath(dir); got != "" {
-		t.Fatalf("empty dir path = %q, want empty", got)
-	}
+	assert.Empty(t, FindPiebaldDBPath(dir), "empty dir path")
 	dbPath := filepath.Join(dir, "app.db")
 	execPiebaldTestSQL(t, dbPath, `CREATE TABLE x (id INTEGER)`)
-	if got := FindPiebaldDBPath(dir); got != dbPath {
-		t.Fatalf("FindPiebaldDBPath = %q, want %q", got, dbPath)
-	}
+	assert.Equal(t, dbPath, FindPiebaldDBPath(dir))
 }
 
 func TestParsePiebaldSessionBasic(t *testing.T) {
@@ -172,42 +164,28 @@ func TestParsePiebaldSessionBasic(t *testing.T) {
 	seedPiebaldTextPart(t, dbPath, 201, 101, 0, "I fixed it", false)
 
 	sess, msgs, err := ParsePiebaldSession(dbPath, "42", "machine")
-	if err != nil {
-		t.Fatalf("ParsePiebaldSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected session")
-	}
-	if sess.ID != "piebald:42" || sess.Agent != AgentPiebald || sess.Project != "app" {
-		t.Fatalf("bad session meta: %#v", sess)
-	}
-	if sess.Cwd != "/repo/app" || sess.GitBranch != "main" || sess.FirstMessage != "Please fix this" {
-		t.Fatalf("bad session details: %#v", sess)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("messages len = %d, want 2", len(msgs))
-	}
-	if msgs[0].Role != RoleUser || msgs[0].Content != "Please fix this" {
-		t.Fatalf("bad first message: %#v", msgs[0])
-	}
-	if msgs[1].Role != RoleAssistant || msgs[1].Content != "I fixed it" || msgs[1].Model != "claude-test" {
-		t.Fatalf("bad assistant message: %#v", msgs[1])
-	}
-	if !msgs[1].HasContextTokens || msgs[1].ContextTokens != 15 || !msgs[1].HasOutputTokens || msgs[1].OutputTokens != 20 {
-		t.Fatalf("bad token usage: %#v", msgs[1])
-	}
-	if len(msgs[1].TokenUsage) == 0 {
-		t.Fatal("TokenUsage empty, want normalized usage JSON")
-	}
-	if got := gjson.GetBytes(msgs[1].TokenUsage, "input_tokens").Int(); got != 10 {
-		t.Fatalf("input_tokens = %d, want 10", got)
-	}
-	if got := gjson.GetBytes(msgs[1].TokenUsage, "output_tokens").Int(); got != 20 {
-		t.Fatalf("output_tokens = %d, want 20", got)
-	}
-	if got := gjson.GetBytes(msgs[1].TokenUsage, "cache_read_input_tokens").Int(); got != 5 {
-		t.Fatalf("cache_read_input_tokens = %d, want 5", got)
-	}
+	require.NoError(t, err, "ParsePiebaldSession")
+	require.NotNil(t, sess, "expected session")
+	assert.Equal(t, "piebald:42", sess.ID)
+	assert.Equal(t, AgentPiebald, sess.Agent)
+	assert.Equal(t, "app", sess.Project)
+	assert.Equal(t, "/repo/app", sess.Cwd)
+	assert.Equal(t, "main", sess.GitBranch)
+	assert.Equal(t, "Please fix this", sess.FirstMessage)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Please fix this", msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, "I fixed it", msgs[1].Content)
+	assert.Equal(t, "claude-test", msgs[1].Model)
+	assert.True(t, msgs[1].HasContextTokens)
+	assert.Equal(t, 15, msgs[1].ContextTokens)
+	assert.True(t, msgs[1].HasOutputTokens)
+	assert.Equal(t, 20, msgs[1].OutputTokens)
+	require.NotEmpty(t, msgs[1].TokenUsage, "TokenUsage empty")
+	assert.Equal(t, int64(10), gjson.GetBytes(msgs[1].TokenUsage, "input_tokens").Int(), "input_tokens")
+	assert.Equal(t, int64(20), gjson.GetBytes(msgs[1].TokenUsage, "output_tokens").Int(), "output_tokens")
+	assert.Equal(t, int64(5), gjson.GetBytes(msgs[1].TokenUsage, "cache_read_input_tokens").Int(), "cache_read_input_tokens")
 }
 
 func TestParsePiebaldSessionToolCall(t *testing.T) {
@@ -221,22 +199,16 @@ func TestParsePiebaldSessionToolCall(t *testing.T) {
 	seedPiebaldToolPart(t, dbPath, 700, 70, 0)
 
 	sess, msgs, err := ParsePiebaldSession(dbPath, "7", "machine")
-	if err != nil {
-		t.Fatalf("ParsePiebaldSession: %v", err)
-	}
-	if sess == nil || len(msgs) != 1 {
-		t.Fatalf("session/messages = %#v %d", sess, len(msgs))
-	}
-	if len(msgs[0].ToolCalls) != 1 {
-		t.Fatalf("tool calls = %d, want 1", len(msgs[0].ToolCalls))
-	}
+	require.NoError(t, err, "ParsePiebaldSession")
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].ToolCalls, 1)
 	call := msgs[0].ToolCalls[0]
-	if call.ToolUseID != "toolu_1" || call.ToolName != "Read" || call.Category != "Read" {
-		t.Fatalf("bad tool call: %#v", call)
-	}
-	if len(msgs[0].ToolResults) != 1 || msgs[0].ToolResults[0].ContentLength != len("file contents") {
-		t.Fatalf("bad tool result: %#v", msgs[0].ToolResults)
-	}
+	assert.Equal(t, "toolu_1", call.ToolUseID)
+	assert.Equal(t, "Read", call.ToolName)
+	assert.Equal(t, "Read", call.Category)
+	require.Len(t, msgs[0].ToolResults, 1)
+	assert.Equal(t, len("file contents"), msgs[0].ToolResults[0].ContentLength)
 }
 
 func TestParsePiebaldSessionSubagentToolCall(t *testing.T) {
@@ -251,22 +223,14 @@ func TestParsePiebaldSessionSubagentToolCall(t *testing.T) {
 	seedPiebaldSubagentToolPart(t, dbPath, 700, 70, 0, 99)
 
 	sess, msgs, err := ParsePiebaldSession(dbPath, "7", "machine")
-	if err != nil {
-		t.Fatalf("ParsePiebaldSession: %v", err)
-	}
-	if sess == nil || len(msgs) != 1 {
-		t.Fatalf("session/messages = %#v %d", sess, len(msgs))
-	}
-	if len(msgs[0].ToolCalls) != 1 {
-		t.Fatalf("tool calls = %d, want 1", len(msgs[0].ToolCalls))
-	}
+	require.NoError(t, err, "ParsePiebaldSession")
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].ToolCalls, 1)
 	call := msgs[0].ToolCalls[0]
-	if call.ToolName != "LaunchSubagent" || call.Category != "Task" {
-		t.Fatalf("bad subagent tool category: %#v", call)
-	}
-	if call.SubagentSessionID != "piebald:99" {
-		t.Fatalf("SubagentSessionID = %q, want piebald:99", call.SubagentSessionID)
-	}
+	assert.Equal(t, "LaunchSubagent", call.ToolName)
+	assert.Equal(t, "Task", call.Category)
+	assert.Equal(t, "piebald:99", call.SubagentSessionID)
 }
 
 func TestParsePiebaldSessionResultsSplitsForks(t *testing.T) {
@@ -290,29 +254,21 @@ func TestParsePiebaldSessionResultsSplitsForks(t *testing.T) {
 	seedPiebaldTextPart(t, dbPath, 2001, 201, 0, "fork answer", false)
 
 	results, err := ParsePiebaldSessionResults(dbPath, "42", "machine")
-	if err != nil {
-		t.Fatalf("ParsePiebaldSessionResults: %v", err)
-	}
-	if len(results) != 2 {
-		t.Fatalf("results len = %d, want 2", len(results))
-	}
+	require.NoError(t, err, "ParsePiebaldSessionResults")
+	require.Len(t, results, 2)
 	main := results[0]
-	if main.Session.ID != "piebald:42" || main.Session.ParentSessionID != "" || main.Session.RelationshipType != RelNone {
-		t.Fatalf("bad main session: %#v", main.Session)
-	}
-	if len(main.Messages) != 4 || main.Messages[2].Content != "main followup" {
-		t.Fatalf("bad main messages: %#v", main.Messages)
-	}
+	assert.Equal(t, "piebald:42", main.Session.ID)
+	assert.Empty(t, main.Session.ParentSessionID)
+	assert.Equal(t, RelNone, main.Session.RelationshipType)
+	require.Len(t, main.Messages, 4)
+	assert.Equal(t, "main followup", main.Messages[2].Content)
 	fork := results[1]
-	if fork.Session.ID != "piebald:42-200" {
-		t.Fatalf("fork session ID = %q, want piebald:42-200", fork.Session.ID)
-	}
-	if fork.Session.ParentSessionID != "piebald:42" || fork.Session.RelationshipType != RelFork {
-		t.Fatalf("bad fork relationship: %#v", fork.Session)
-	}
-	if len(fork.Messages) != 2 || fork.Messages[0].Content != "fork question" || fork.Messages[0].Ordinal != 0 {
-		t.Fatalf("bad fork messages: %#v", fork.Messages)
-	}
+	assert.Equal(t, "piebald:42-200", fork.Session.ID)
+	assert.Equal(t, "piebald:42", fork.Session.ParentSessionID)
+	assert.Equal(t, RelFork, fork.Session.RelationshipType)
+	require.Len(t, fork.Messages, 2)
+	assert.Equal(t, "fork question", fork.Messages[0].Content)
+	assert.Equal(t, 0, fork.Messages[0].Ordinal)
 }
 
 func TestParsePiebaldSessionResultsHandlesNestedForks(t *testing.T) {
@@ -355,12 +311,8 @@ func TestParsePiebaldSessionResultsHandlesNestedForks(t *testing.T) {
 	seedPiebaldTextPart(t, dbPath, 1301, 301, 0, "nested fork answer", false)
 
 	results, err := ParsePiebaldSessionResults(dbPath, "42", "machine")
-	if err != nil {
-		t.Fatalf("ParsePiebaldSessionResults: %v", err)
-	}
-	if len(results) != 3 {
-		t.Fatalf("results len = %d, want 3 (main + outer fork + nested fork)", len(results))
-	}
+	require.NoError(t, err, "ParsePiebaldSessionResults")
+	require.Len(t, results, 3, "main + outer fork + nested fork")
 
 	byID := make(map[string]ParseResult, len(results))
 	for _, r := range results {
@@ -368,37 +320,22 @@ func TestParsePiebaldSessionResultsHandlesNestedForks(t *testing.T) {
 	}
 
 	main, ok := byID["piebald:42"]
-	if !ok {
-		t.Fatal("missing main session piebald:42")
-	}
-	if main.Session.RelationshipType != RelNone || main.Session.ParentSessionID != "" {
-		t.Fatalf("bad main relationship: %#v", main.Session)
-	}
-	if len(main.Messages) != 4 {
-		t.Fatalf("main messages = %d, want 4", len(main.Messages))
-	}
+	require.True(t, ok, "missing main session piebald:42")
+	assert.Equal(t, RelNone, main.Session.RelationshipType)
+	assert.Empty(t, main.Session.ParentSessionID)
+	assert.Len(t, main.Messages, 4)
 
 	outer, ok := byID["piebald:42-200"]
-	if !ok {
-		t.Fatal("missing outer fork session piebald:42-200")
-	}
-	if outer.Session.RelationshipType != RelFork || outer.Session.ParentSessionID != "piebald:42" {
-		t.Fatalf("bad outer fork relationship: %#v", outer.Session)
-	}
-	if len(outer.Messages) != 4 {
-		t.Fatalf("outer fork messages = %d, want 4", len(outer.Messages))
-	}
+	require.True(t, ok, "missing outer fork session piebald:42-200")
+	assert.Equal(t, RelFork, outer.Session.RelationshipType)
+	assert.Equal(t, "piebald:42", outer.Session.ParentSessionID)
+	assert.Len(t, outer.Messages, 4)
 
 	nested, ok := byID["piebald:42-300"]
-	if !ok {
-		t.Fatal("missing nested fork session piebald:42-300 (lost by append/walk evaluation order bug)")
-	}
-	if nested.Session.RelationshipType != RelFork || nested.Session.ParentSessionID != "piebald:42-200" {
-		t.Fatalf("bad nested fork relationship: %#v", nested.Session)
-	}
-	if len(nested.Messages) != 2 {
-		t.Fatalf("nested fork messages = %d, want 2", len(nested.Messages))
-	}
+	require.True(t, ok, "missing nested fork session piebald:42-300 (lost by append/walk evaluation order bug)")
+	assert.Equal(t, RelFork, nested.Session.RelationshipType)
+	assert.Equal(t, "piebald:42-200", nested.Session.ParentSessionID)
+	assert.Len(t, nested.Messages, 2)
 }
 
 func TestListPiebaldSessionMetaSkipsDeletedAndEmpty(t *testing.T) {
@@ -409,10 +346,8 @@ func TestListPiebaldSessionMetaSkipsDeletedAndEmpty(t *testing.T) {
 		        (2, 'empty', '2026-05-01T10:00:00Z', '2026-05-01T10:01:00Z', 0, 0),
 		        (3, 'deleted', '2026-05-01T10:00:00Z', '2026-05-01T10:01:00Z', 1, 1)`)
 	metas, err := ListPiebaldSessionMeta(dbPath)
-	if err != nil {
-		t.Fatalf("ListPiebaldSessionMeta: %v", err)
-	}
-	if len(metas) != 1 || metas[0].SessionID != "1" || metas[0].VirtualPath != dbPath+"#1" {
-		t.Fatalf("metas = %#v", metas)
-	}
+	require.NoError(t, err, "ListPiebaldSessionMeta")
+	require.Len(t, metas, 1)
+	assert.Equal(t, "1", metas[0].SessionID)
+	assert.Equal(t, dbPath+"#1", metas[0].VirtualPath)
 }

--- a/internal/parser/positron_test.go
+++ b/internal/parser/positron_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParsePositronSession(t *testing.T) {
@@ -53,61 +56,34 @@ func TestParsePositronSession(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	sessionPath := filepath.Join(tmpDir, "test-session.json")
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		sessionPath, []byte(sessionJSON), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	sess, msgs, err := ParsePositronSession(
 		sessionPath, "test-project", "test-machine",
 	)
-	if err != nil {
-		t.Fatalf("ParsePositronSession failed: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected session, got nil")
-	}
+	require.NoError(t, err, "ParsePositronSession failed")
+	require.NotNil(t, sess, "expected session, got nil")
 
 	// Verify session metadata
-	if sess.Agent != AgentPositron {
-		t.Errorf("agent = %v, want %v", sess.Agent, AgentPositron)
-	}
-	if sess.ID != "positron:test-session-123" {
-		t.Errorf("ID = %v, want positron:test-session-123", sess.ID)
-	}
-	if sess.Project != "test-project" {
-		t.Errorf("project = %v, want test-project", sess.Project)
-	}
-	if sess.FirstMessage != "Hello, help me with R code" {
-		t.Errorf(
-			"firstMessage = %v, want 'Hello, help me with R code'",
-			sess.FirstMessage,
-		)
-	}
+	assert.Equal(t, AgentPositron, sess.Agent)
+	assert.Equal(t, "positron:test-session-123", sess.ID)
+	assert.Equal(t, "test-project", sess.Project)
+	assert.Equal(t, "Hello, help me with R code", sess.FirstMessage)
 
 	// Verify messages
-	if len(msgs) != 4 {
-		t.Fatalf("len(msgs) = %d, want 4", len(msgs))
-	}
+	require.Len(t, msgs, 4)
 
 	// First user message
-	if msgs[0].Role != RoleUser {
-		t.Errorf("msgs[0].Role = %v, want user", msgs[0].Role)
-	}
-	if msgs[0].Content != "Hello, help me with R code" {
-		t.Errorf("msgs[0].Content = %v", msgs[0].Content)
-	}
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Hello, help me with R code", msgs[0].Content)
 
 	// First assistant response
-	if msgs[1].Role != RoleAssistant {
-		t.Errorf("msgs[1].Role = %v, want assistant", msgs[1].Role)
-	}
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
 
 	// Second assistant should have tool use
-	if !msgs[3].HasToolUse {
-		t.Error("msgs[3] should have tool use")
-	}
+	assert.True(t, msgs[3].HasToolUse, "msgs[3] should have tool use")
 }
 
 func TestDiscoverPositronSessions(t *testing.T) {
@@ -120,19 +96,15 @@ func TestDiscoverPositronSessions(t *testing.T) {
 		tmpDir, "workspaceStorage", "abc123hash",
 	)
 	chatDir := filepath.Join(hashDir, "chatSessions")
-	if err := os.MkdirAll(chatDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(chatDir, 0755))
 
 	// Create workspace.json
 	wsJSON := `{"folder": "file:///Users/test/myproject"}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(hashDir, "workspace.json"),
 		[]byte(wsJSON),
 		0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	// Create session files
 	sessionJSON := `{"version": 3, "requests": []}`
@@ -140,36 +112,26 @@ func TestDiscoverPositronSessions(t *testing.T) {
 		"session-1.json",
 		"session-2.jsonl",
 	} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(chatDir, name),
 			[]byte(sessionJSON),
 			0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	// Create a non-session file that should be ignored
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(chatDir, "readme.txt"),
 		[]byte("ignore me"),
 		0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	files := DiscoverPositronSessions(tmpDir)
-	if len(files) != 2 {
-		t.Fatalf("len(files) = %d, want 2", len(files))
-	}
+	require.Len(t, files, 2)
 
 	for _, f := range files {
-		if f.Agent != AgentPositron {
-			t.Errorf("agent = %v, want positron", f.Agent)
-		}
-		if f.Project != "myproject" {
-			t.Errorf("project = %v, want myproject", f.Project)
-		}
+		assert.Equal(t, AgentPositron, f.Agent)
+		assert.Equal(t, "myproject", f.Project)
 	}
 }
 
@@ -181,27 +143,19 @@ func TestFindPositronSourceFile(t *testing.T) {
 		tmpDir, "workspaceStorage", "abc123hash",
 	)
 	chatDir := filepath.Join(hashDir, "chatSessions")
-	if err := os.MkdirAll(chatDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(chatDir, 0755))
 
 	// Create session file
 	sessionPath := filepath.Join(chatDir, "test-uuid.json")
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		sessionPath, []byte(`{}`), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	// Test finding existing session
 	found := FindPositronSourceFile(tmpDir, "test-uuid")
-	if found != sessionPath {
-		t.Errorf("found = %v, want %v", found, sessionPath)
-	}
+	assert.Equal(t, sessionPath, found)
 
 	// Test finding non-existent session
 	notFound := FindPositronSourceFile(tmpDir, "nonexistent")
-	if notFound != "" {
-		t.Errorf("expected empty string, got %v", notFound)
-	}
+	assert.Empty(t, notFound)
 }

--- a/internal/parser/project_foreign_test.go
+++ b/internal/parser/project_foreign_test.go
@@ -3,12 +3,14 @@ package parser
 import (
 	"errors"
 	"os"
-	"reflect"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // autofsTestsSupported reports whether the running OS uses POSIX
@@ -44,16 +46,12 @@ func TestExtractProjectFromCwd_AutofsUnresolved_SkipsWalk(t *testing.T) {
 	}
 
 	cwd := "/home/wes/code/example-project"
-	want := "example_project"
 	got := ExtractProjectFromCwdWithBranch(cwd, "")
-	if got != want {
-		t.Errorf("ExtractProjectFromCwdWithBranch(%q) = %q, want %q",
-			cwd, got, want)
-	}
-	if n := count.Load(); n != 1 {
-		t.Errorf("osStat called %d times for unresolved autofs cwd "+
-			"%q; expected 1 (probe only, walk skipped)", n, cwd)
-	}
+	assert.Equal(t, "example_project", got,
+		"ExtractProjectFromCwdWithBranch(%q)", cwd)
+	assert.Equal(t, int64(1), count.Load(),
+		"osStat call count for unresolved autofs cwd "+
+			"%q; expected 1 (probe only, walk skipped)", cwd)
 }
 
 // TestExtractProjectFromCwd_AutofsUnresolved_ProbeCached checks
@@ -83,10 +81,8 @@ func TestExtractProjectFromCwd_AutofsUnresolved_ProbeCached(t *testing.T) {
 	} {
 		_ = ExtractProjectFromCwdWithBranch(cwd, "")
 	}
-	if n := count.Load(); n != 1 {
-		t.Errorf("osStat called %d times across 3 cwds sharing "+
-			"/home/wes; expected 1 (cached probe)", n)
-	}
+	assert.Equal(t, int64(1), count.Load(),
+		"osStat calls across 3 cwds sharing /home/wes; expected 1 (cached probe)")
 }
 
 // TestExtractProjectFromCwd_AutofsResolved_Walks is the regression
@@ -107,9 +103,7 @@ func TestExtractProjectFromCwd_AutofsResolved_Walks(t *testing.T) {
 	// when the probe "resolves".
 	realDir := t.TempDir()
 	realInfo, err := os.Stat(realDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	orig := osStat
 	defer func() { osStat = orig }()
@@ -124,10 +118,9 @@ func TestExtractProjectFromCwd_AutofsResolved_Walks(t *testing.T) {
 
 	cwd := "/home/wes/code/example"
 	_ = ExtractProjectFromCwdWithBranch(cwd, "")
-	if n := count.Load(); n < 2 {
-		t.Errorf("with resolving autofs probe, expected the walk "+
-			"to stat multiple paths (probe + walk); got %d", n)
-	}
+	assert.GreaterOrEqual(t, count.Load(), int64(2),
+		"with resolving autofs probe, expected the walk "+
+			"to stat multiple paths (probe + walk)")
 }
 
 // TestExtractProjectFromCwd_NativePath_StillWalks confirms that
@@ -152,10 +145,9 @@ func TestExtractProjectFromCwd_NativePath_StillWalks(t *testing.T) {
 
 	cwd := "/Users/nobody-agentsview-test/code/example"
 	_ = ExtractProjectFromCwdWithBranch(cwd, "")
-	if count.Load() == 0 {
-		t.Errorf("osStat never called for %q; "+
+	assert.NotZero(t, count.Load(),
+		"osStat never called for %q; "+
 			"git-root walk should run for non-autofs paths", cwd)
-	}
 }
 
 // TestExtractProjectFromCwd_HomePathWithoutAutofs_StillWalks covers
@@ -181,10 +173,9 @@ func TestExtractProjectFromCwd_HomePathWithoutAutofs_StillWalks(t *testing.T) {
 
 	cwd := "/home/nobody-agentsview-test/code/example"
 	_ = ExtractProjectFromCwdWithBranch(cwd, "")
-	if count.Load() == 0 {
-		t.Errorf("osStat never called for /home path with empty " +
+	assert.NotZero(t, count.Load(),
+		"osStat never called for /home path with empty "+
 			"autofs config; walk must proceed for a real mount")
-	}
 }
 
 // TestParseMountOutputForAutofs exercises the pure mount-output
@@ -209,10 +200,7 @@ server.example:/export on /corp/home (autofs, nobrowse)
 		"/Network/Servers/",
 		"/corp/home/",
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("parseMountOutputForAutofs() = %v, want %v",
-			got, want)
-	}
+	assert.Equal(t, want, got, "parseMountOutputForAutofs()")
 }
 
 // TestDetectAutofsPrefixes uses the injectable mount source so the
@@ -231,16 +219,11 @@ func TestDetectAutofsPrefixes(t *testing.T) {
 
 	got := detectAutofsPrefixes()
 	if runtime.GOOS != "darwin" {
-		if got != nil {
-			t.Errorf("detectAutofsPrefixes() = %v on %s, want nil",
-				got, runtime.GOOS)
-		}
+		assert.Nil(t, got, "detectAutofsPrefixes() on %s", runtime.GOOS)
 		return
 	}
 	want := []string{"/home/", "/Network/Servers/"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("detectAutofsPrefixes() = %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got, "detectAutofsPrefixes()")
 }
 
 // TestExtractProjectFromCwd_AutofsConcurrent_SingleProbe exercises
@@ -288,11 +271,9 @@ func TestExtractProjectFromCwd_AutofsConcurrent_SingleProbe(t *testing.T) {
 	close(release)
 	done.Wait()
 
-	if n := count.Load(); n != 1 {
-		t.Errorf("concurrent probes issued %d osStat calls; "+
-			"expected exactly 1 under %d-way concurrency",
-			n, workers)
-	}
+	assert.Equal(t, int64(1), count.Load(),
+		"concurrent probes issued osStat calls; "+
+			"expected exactly 1 under %d-way concurrency", workers)
 }
 
 // TestExtractProjectFromCwd_AutofsProbe_TTLExpires guards against
@@ -325,23 +306,17 @@ func TestExtractProjectFromCwd_AutofsProbe_TTLExpires(t *testing.T) {
 
 	cwd := "/home/wes/code/proj"
 	_ = ExtractProjectFromCwdWithBranch(cwd, "")
-	if n := count.Load(); n != 1 {
-		t.Fatalf("first call: expected 1 osStat, got %d", n)
-	}
+	require.Equal(t, int64(1), count.Load(), "first call")
 
 	// Within TTL — cached, no new probe.
 	current = current.Add(autofsProbeTTL / 2)
 	_ = ExtractProjectFromCwdWithBranch(cwd, "")
-	if n := count.Load(); n != 1 {
-		t.Fatalf("within TTL: expected still 1 osStat, got %d", n)
-	}
+	require.Equal(t, int64(1), count.Load(), "within TTL")
 
 	// Past TTL — re-probe.
 	current = current.Add(autofsProbeTTL + time.Second)
 	_ = ExtractProjectFromCwdWithBranch(cwd, "")
-	if n := count.Load(); n != 2 {
-		t.Errorf("past TTL: expected 2 osStat calls, got %d", n)
-	}
+	assert.Equal(t, int64(2), count.Load(), "past TTL")
 }
 
 // TestDetectAutofsPrefixes_MountFails confirms that a mount(8)
@@ -353,8 +328,5 @@ func TestDetectAutofsPrefixes_MountFails(t *testing.T) {
 	autofsMountSource = func() ([]byte, error) {
 		return nil, errors.New("mock mount failure")
 	}
-	if got := detectAutofsPrefixes(); got != nil {
-		t.Errorf("detectAutofsPrefixes() with mount failure = %v, "+
-			"want nil", got)
-	}
+	assert.Nil(t, detectAutofsPrefixes(), "detectAutofsPrefixes() with mount failure")
 }

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractProjectFromCwd_Git(t *testing.T) {
@@ -68,10 +71,8 @@ func TestExtractProjectFromCwd_Git(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			root := t.TempDir()
 			cwd := tt.setup(t, root)
-			got := ExtractProjectFromCwd(cwd)
-			if got != tt.want {
-				t.Fatalf("ExtractProjectFromCwd(%q) = %q, want %q", cwd, got, tt.want)
-			}
+			assert.Equal(t, tt.want, ExtractProjectFromCwd(cwd),
+				"ExtractProjectFromCwd(%q)", cwd)
 		})
 	}
 }
@@ -100,13 +101,8 @@ func TestExtractProjectFromCwd_DeletedNestedWorktree(t *testing.T) {
 	// The deleted worktree path — not created on disk.
 	deleted := filepath.Join(container, "tauri-packaging")
 
-	got := ExtractProjectFromCwd(deleted)
-	if got != "my_project" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "my_project",
-		)
-	}
+	assert.Equal(t, "my_project", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_DeletedNestedWorktreeNoCommondir(
@@ -134,13 +130,8 @@ func TestExtractProjectFromCwd_DeletedNestedWorktreeNoCommondir(
 
 	deleted := filepath.Join(container, "tauri-packaging")
 
-	got := ExtractProjectFromCwd(deleted)
-	if got != "my_project" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "my_project",
-		)
-	}
+	assert.Equal(t, "my_project", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_DeletedNestedWorktreeDeep(
@@ -174,13 +165,8 @@ func TestExtractProjectFromCwd_DeletedNestedWorktreeDeep(
 		container, "tauri-packaging", "cmd", "server",
 	)
 
-	got := ExtractProjectFromCwd(deep)
-	if got != "my_project" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deep, got, "my_project",
-		)
-	}
+	assert.Equal(t, "my_project", ExtractProjectFromCwd(deep),
+		"ExtractProjectFromCwd(%q)", deep)
 }
 
 func TestExtractProjectFromCwd_SubmoduleSiblingIgnored(
@@ -211,14 +197,9 @@ func TestExtractProjectFromCwd_SubmoduleSiblingIgnored(
 
 	deleted := filepath.Join(container, "deleted-branch")
 
-	got := ExtractProjectFromCwd(deleted)
 	// No worktree sibling found, falls back to basename.
-	if got != "deleted_branch" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "deleted_branch",
-		)
-	}
+	assert.Equal(t, "deleted_branch", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_UnrelatedSiblingWorktree(
@@ -261,14 +242,9 @@ func TestExtractProjectFromCwd_UnrelatedSiblingWorktree(
 
 	deleted := filepath.Join(container, "deleted-thing")
 
-	got := ExtractProjectFromCwd(deleted)
 	// Siblings disagree, falls back to basename.
-	if got != "deleted_thing" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "deleted_thing",
-		)
-	}
+	assert.Equal(t, "deleted_thing", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_AncestorHasGitDir(
@@ -285,13 +261,8 @@ func TestExtractProjectFromCwd_AncestorHasGitDir(
 	// A deleted path inside the repo.
 	deleted := filepath.Join(repo, "deleted-subdir", "file")
 
-	got := ExtractProjectFromCwd(deleted)
-	if got != "my_repo" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "my_repo",
-		)
-	}
+	assert.Equal(t, "my_repo", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_RepoSiblingWithWorktree(
@@ -323,15 +294,10 @@ func TestExtractProjectFromCwd_RepoSiblingWithWorktree(
 
 	deleted := filepath.Join(root, "container", "deleted-dir")
 
-	got := ExtractProjectFromCwd(deleted)
 	// Container has a normal repo child, not a worktree-only
 	// container. Falls back to basename.
-	if got != "deleted_dir" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "deleted_dir",
-		)
-	}
+	assert.Equal(t, "deleted_dir", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_MainRepoWithOwnWorktrees(
@@ -361,14 +327,9 @@ func TestExtractProjectFromCwd_MainRepoWithOwnWorktrees(
 		root, "container", "my-project-hotfix",
 	)
 
-	got := ExtractProjectFromCwd(deleted)
 	// Main repo and worktree agree on same root.
-	if got != "my_project" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "my_project",
-		)
-	}
+	assert.Equal(t, "my_project", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_DeletedSiblingOfNormalRepo(
@@ -386,13 +347,8 @@ func TestExtractProjectFromCwd_DeletedSiblingOfNormalRepo(
 	// Deleted path — just a former directory, not a worktree.
 	deleted := filepath.Join(container, "scratch-old")
 
-	got := ExtractProjectFromCwd(deleted)
-	if got != "scratch_old" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "scratch_old",
-		)
-	}
+	assert.Equal(t, "scratch_old", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_UnrelatedDeletedNextToWorktreeRepo(
@@ -411,13 +367,8 @@ func TestExtractProjectFromCwd_UnrelatedDeletedNextToWorktreeRepo(
 	// Deleted path that is NOT a worktree of this repo.
 	deleted := filepath.Join(container, "scratch-old")
 
-	got := ExtractProjectFromCwd(deleted)
-	if got != "scratch_old" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "scratch_old",
-		)
-	}
+	assert.Equal(t, "scratch_old", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwd_DeletedOnlyWorktreeNextToMain(
@@ -437,13 +388,8 @@ func TestExtractProjectFromCwd_DeletedOnlyWorktreeNextToMain(
 	// Deleted worktree — not created on disk.
 	deleted := filepath.Join(container, "feature")
 
-	got := ExtractProjectFromCwd(deleted)
-	if got != "my_project" {
-		t.Fatalf(
-			"ExtractProjectFromCwd(%q) = %q, want %q",
-			deleted, got, "my_project",
-		)
-	}
+	assert.Equal(t, "my_project", ExtractProjectFromCwd(deleted),
+		"ExtractProjectFromCwd(%q)", deleted)
 }
 
 func TestExtractProjectFromCwdWithBranch_NestedWorktree(
@@ -474,15 +420,9 @@ func TestExtractProjectFromCwdWithBranch_NestedWorktree(
 	// Deleted worktree where branch name = directory name.
 	deleted := filepath.Join(container, "tauri-packaging")
 
-	got := ExtractProjectFromCwdWithBranch(
-		deleted, "tauri-packaging",
-	)
-	if got != "agentsview" {
-		t.Fatalf(
-			"ExtractProjectFromCwdWithBranch(%q, %q) = %q, want %q",
-			deleted, "tauri-packaging", got, "agentsview",
-		)
-	}
+	assert.Equal(t, "agentsview",
+		ExtractProjectFromCwdWithBranch(deleted, "tauri-packaging"),
+		"ExtractProjectFromCwdWithBranch(%q, %q)", deleted, "tauri-packaging")
 }
 
 func TestExtractProjectFromCwdWithBranch(t *testing.T) {
@@ -574,10 +514,9 @@ func TestExtractProjectFromCwdWithBranch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ExtractProjectFromCwdWithBranch(tt.cwd, tt.branch)
-			if got != tt.want {
-				t.Fatalf("ExtractProjectFromCwdWithBranch(%q, %q) = %q, want %q", tt.cwd, tt.branch, got, tt.want)
-			}
+			assert.Equal(t, tt.want,
+				ExtractProjectFromCwdWithBranch(tt.cwd, tt.branch),
+				"ExtractProjectFromCwdWithBranch(%q, %q)", tt.cwd, tt.branch)
 		})
 	}
 }
@@ -590,15 +529,9 @@ func TestForeignWindowsPathSkipsGitRoot(t *testing.T) {
 	// On non-Windows, a Windows-style path like C:\repo\subdir
 	// should NOT trigger findGitRepoRoot (which would walk the
 	// process CWD). It should fall back to the basename.
-	got := ExtractProjectFromCwdWithBranch(
-		`C:\Users\dev\projects\my-app`, "",
-	)
-	if got != "my_app" {
-		t.Errorf(
-			"foreign Windows path: got %q, want %q",
-			got, "my_app",
-		)
-	}
+	assert.Equal(t, "my_app",
+		ExtractProjectFromCwdWithBranch(`C:\Users\dev\projects\my-app`, ""),
+		"foreign Windows path")
 }
 
 func TestNativeWindowsPathUsesGitRoot(t *testing.T) {
@@ -614,25 +547,17 @@ func TestNativeWindowsPathUsesGitRoot(t *testing.T) {
 	mustMkdirAll(t, filepath.Join(repo, ".git"))
 	mustMkdirAll(t, subdir)
 
-	got := ExtractProjectFromCwd(subdir)
-	if got != "my_repo" {
-		t.Errorf(
-			"native Windows git path: got %q, want %q",
-			got, "my_repo",
-		)
-	}
+	assert.Equal(t, "my_repo", ExtractProjectFromCwd(subdir),
+		"native Windows git path")
 }
 
 func mustMkdirAll(t *testing.T, path string) {
 	t.Helper()
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		t.Fatalf("MkdirAll(%q): %v", path, err)
-	}
+	require.NoError(t, os.MkdirAll(path, 0o755), "MkdirAll(%q)", path)
 }
 
 func mustWriteFile(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("WriteFile(%q): %v", path, err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644),
+		"WriteFile(%q)", path)
 }

--- a/internal/parser/qclaw_test.go
+++ b/internal/parser/qclaw_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // writeQClawTestFile creates a test JSONL file inside an
@@ -16,9 +19,7 @@ func writeQClawTestFile(
 	t.Helper()
 	root := t.TempDir()
 	sessDir := filepath.Join(root, agentID, "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 	path = filepath.Join(sessDir, "test-session.jsonl")
 	var b strings.Builder
 	for _, line := range lines {
@@ -26,9 +27,7 @@ func writeQClawTestFile(
 		b.WriteByte('\n')
 	}
 	content := b.String()
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
 	return path, root
 }
 
@@ -41,41 +40,18 @@ func TestParseQClawSession_Basic(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseQClawSession(path, "", "test-machine")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess == nil {
-		t.Fatal("expected session, got nil")
-		return
-	}
+	require.NoError(t, err)
+	require.NotNil(t, sess, "expected session, got nil")
 
-	if sess.ID != "qclaw:main:abc-123" {
-		t.Errorf("expected ID qclaw:main:abc-123, got %s", sess.ID)
-	}
-	if sess.Agent != AgentQClaw {
-		t.Errorf("expected agent qclaw, got %s", sess.Agent)
-	}
-	if sess.Machine != "test-machine" {
-		t.Errorf("expected machine test-machine, got %s", sess.Machine)
-	}
-	if sess.Project != "project" {
-		t.Errorf("expected project 'project', got %s", sess.Project)
-	}
-	if sess.FirstMessage != "Hello, how are you?" {
-		t.Errorf("expected first message 'Hello, how are you?', got %s", sess.FirstMessage)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
-	if msgs[0].Role != RoleUser {
-		t.Errorf("expected first role user, got %s", msgs[0].Role)
-	}
-	if msgs[1].Role != RoleAssistant {
-		t.Errorf("expected second role assistant, got %s", msgs[1].Role)
-	}
-	if sess.UserMessageCount != 1 {
-		t.Errorf("expected 1 user message, got %d", sess.UserMessageCount)
-	}
+	assert.Equal(t, "qclaw:main:abc-123", sess.ID, "expected ID qclaw:main:abc-123, got %s")
+	assert.Equal(t, AgentQClaw, sess.Agent, "expected agent qclaw, got %s")
+	assert.Equal(t, "test-machine", sess.Machine, "expected machine test-machine, got %s")
+	assert.Equal(t, "project", sess.Project, "expected project 'project', got %s")
+	assert.Equal(t, "Hello, how are you?", sess.FirstMessage, "expected first message 'Hello, how are you?', got %s")
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
+	assert.Equal(t, RoleUser, msgs[0].Role, "expected first role user, got %s")
+	assert.Equal(t, RoleAssistant, msgs[1].Role, "expected second role assistant, got %s")
+	assert.Equal(t, 1, sess.UserMessageCount, "expected 1 user message, got %d")
 }
 
 func TestParseQClawSession_Thinking(t *testing.T) {
@@ -86,15 +62,9 @@ func TestParseQClawSession_Thinking(t *testing.T) {
 	)
 
 	_, msgs, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
-	if !msgs[1].HasThinking {
-		t.Error("expected HasThinking=true for assistant message")
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
+	assert.True(t, msgs[1].HasThinking, "expected HasThinking=true for assistant message")
 }
 
 func TestParseQClawSession_ToolResult(t *testing.T) {
@@ -107,49 +77,25 @@ func TestParseQClawSession_ToolResult(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 4 {
-		t.Fatalf("expected 4 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 4, len(msgs), "expected 4 messages, got %d")
 	// Assistant with tool_use
-	if !msgs[1].HasToolUse {
-		t.Error("expected HasToolUse=true for tool-use message")
-	}
-	if len(msgs[1].ToolCalls) != 1 {
-		t.Fatalf("expected 1 tool call, got %d", len(msgs[1].ToolCalls))
-	}
-	if msgs[1].ToolCalls[0].ToolName != "read" {
-		t.Errorf("expected tool name 'read', got %s", msgs[1].ToolCalls[0].ToolName)
-	}
-	if msgs[1].ToolCalls[0].Category != "Read" {
-		t.Errorf("expected category 'Read', got %s", msgs[1].ToolCalls[0].Category)
-	}
+	assert.True(t, msgs[1].HasToolUse, "expected HasToolUse=true for tool-use message")
+	require.Equal(t, 1, len(msgs[1].ToolCalls), "expected 1 tool call, got %d")
+	assert.Equal(t, "read", msgs[1].ToolCalls[0].ToolName, "expected tool name 'read', got %s")
+	assert.Equal(t, "Read", msgs[1].ToolCalls[0].Category, "expected category 'Read', got %s")
 
 	// Tool result mapped to user role
-	if msgs[2].Role != RoleUser {
-		t.Errorf("expected tool result as user role, got %s", msgs[2].Role)
-	}
-	if len(msgs[2].ToolResults) != 1 {
-		t.Fatalf("expected 1 tool result, got %d", len(msgs[2].ToolResults))
-	}
-	if msgs[2].ToolResults[0].ToolUseID != "tu1" {
-		t.Errorf("expected tool use ID 'tu1', got %s", msgs[2].ToolResults[0].ToolUseID)
-	}
+	assert.Equal(t, RoleUser, msgs[2].Role, "expected tool result as user role, got %s")
+	require.Equal(t, 1, len(msgs[2].ToolResults), "expected 1 tool result, got %d")
+	assert.Equal(t, "tu1", msgs[2].ToolResults[0].ToolUseID, "expected tool use ID 'tu1', got %s")
 	resultContent := DecodeContent(msgs[2].ToolResults[0].ContentRaw)
-	if resultContent != "127.0.0.1 localhost" {
-		t.Errorf("expected decoded tool result content, got %q", resultContent)
-	}
-	if sess.MessageCount != 4 {
-		t.Errorf("expected 4 messages, got %d", sess.MessageCount)
-	}
+	assert.Equal(t, "127.0.0.1 localhost", resultContent, "expected decoded tool result content, got %q")
+	assert.Equal(t, 4, sess.MessageCount, "expected 4 messages, got %d")
 
 	// UserMessageCount should only count the real user message,
 	// not the synthetic tool-result message.
-	if sess.UserMessageCount != 1 {
-		t.Errorf("expected UserMessageCount 1 (tool results excluded), got %d", sess.UserMessageCount)
-	}
+	assert.Equal(t, 1, sess.UserMessageCount, "expected UserMessageCount 1 (tool results excluded), got %d")
 }
 
 func TestParseQClawSession_OrphanToolResult(t *testing.T) {
@@ -163,24 +109,14 @@ func TestParseQClawSession_OrphanToolResult(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// 3 messages: user, assistant (tool_use), assistant (text).
 	// The orphan toolResult is skipped entirely.
-	if len(msgs) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(msgs))
-	}
-	if sess.MessageCount != 3 {
-		t.Errorf("MessageCount = %d, want 3", sess.MessageCount)
-	}
-	if sess.UserMessageCount != 1 {
-		t.Errorf("UserMessageCount = %d, want 1", sess.UserMessageCount)
-	}
+	require.Equal(t, 3, len(msgs), "expected 3 messages, got %d")
+	assert.Equal(t, 3, sess.MessageCount, "MessageCount = %d, want 3")
+	assert.Equal(t, 1, sess.UserMessageCount, "UserMessageCount = %d, want 1")
 	for _, m := range msgs {
-		if m.Role == RoleUser && m.Content == "" {
-			t.Error("blank user message leaked through")
-		}
+		assert.False(t, m.Role == RoleUser && m.Content == "", "blank user message leaked through")
 	}
 }
 
@@ -190,12 +126,8 @@ func TestParseQClawSession_EmptyFile(t *testing.T) {
 	)
 
 	sess, _, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess != nil {
-		t.Error("expected nil session for file with no messages")
-	}
+	require.NoError(t, err)
+	assert.Nil(t, sess, "expected nil session for file with no messages")
 }
 
 func TestParseQClawSession_AssistantUsage(t *testing.T) {
@@ -210,39 +142,21 @@ func TestParseQClawSession_AssistantUsage(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
 
 	a := msgs[1]
-	if a.Role != RoleAssistant {
-		t.Fatalf("expected assistant role, got %s", a.Role)
-	}
-	if a.Model != "claude-sonnet-4-6" {
-		t.Errorf("Model = %q, want claude-sonnet-4-6", a.Model)
-	}
-	if a.OutputTokens != 91 {
-		t.Errorf("OutputTokens = %d, want 91", a.OutputTokens)
-	}
-	if !a.HasOutputTokens {
-		t.Error("HasOutputTokens = false, want true")
-	}
+	require.Equal(t, RoleAssistant, a.Role, "expected assistant role, got %s")
+	assert.Equal(t, "claude-sonnet-4-6", a.Model, "Model = %q, want claude-sonnet-4-6")
+	assert.Equal(t, 91, a.OutputTokens, "OutputTokens = %d, want 91")
+	assert.True(t, a.HasOutputTokens, "HasOutputTokens = false, want true")
 	// ContextTokens = input + cacheRead + cacheWrite.
-	if a.ContextTokens != 9615 {
-		t.Errorf("ContextTokens = %d, want 9615", a.ContextTokens)
-	}
-	if !a.HasContextTokens {
-		t.Error("HasContextTokens = false, want true")
-	}
+	assert.Equal(t, 9615, a.ContextTokens, "ContextTokens = %d, want 9615")
+	assert.True(t, a.HasContextTokens, "HasContextTokens = false, want true")
 	// TokenUsage must be normalized to Anthropic-style keys so
 	// downstream usage aggregation (internal/db/usage.go) can
 	// read input_tokens/output_tokens/cache_*_input_tokens.
-	if len(a.TokenUsage) == 0 {
-		t.Fatal("TokenUsage empty, want normalized JSON")
-	}
+	require.False(t, len(a.TokenUsage) == 0, "TokenUsage empty, want normalized JSON")
 	tu := string(a.TokenUsage)
 	for _, want := range []string{
 		`"input_tokens":3`,
@@ -250,26 +164,14 @@ func TestParseQClawSession_AssistantUsage(t *testing.T) {
 		`"cache_read_input_tokens":0`,
 		`"cache_creation_input_tokens":9612`,
 	} {
-		if !strings.Contains(tu, want) {
-			t.Errorf("TokenUsage %q missing %q", tu, want)
-		}
+		assert.Contains(t, tu, want)
 	}
 
 	// Session-level rollup must reflect the per-message totals.
-	if !sess.HasTotalOutputTokens {
-		t.Error("sess.HasTotalOutputTokens = false, want true")
-	}
-	if sess.TotalOutputTokens != 91 {
-		t.Errorf("TotalOutputTokens = %d, want 91",
-			sess.TotalOutputTokens)
-	}
-	if !sess.HasPeakContextTokens {
-		t.Error("sess.HasPeakContextTokens = false, want true")
-	}
-	if sess.PeakContextTokens != 9615 {
-		t.Errorf("PeakContextTokens = %d, want 9615",
-			sess.PeakContextTokens)
-	}
+	assert.True(t, sess.HasTotalOutputTokens, "sess.HasTotalOutputTokens = false, want true")
+	assert.Equal(t, 91, sess.TotalOutputTokens, "TotalOutputTokens")
+	assert.True(t, sess.HasPeakContextTokens, "sess.HasPeakContextTokens = false, want true")
+	assert.Equal(t, 9615, sess.PeakContextTokens, "PeakContextTokens")
 }
 
 func TestParseQClawSession_AssistantUsageWithoutCost(t *testing.T) {
@@ -283,30 +185,15 @@ func TestParseQClawSession_AssistantUsageWithoutCost(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
 
 	a := msgs[1]
-	if a.Model != "claude-haiku-4-5" {
-		t.Errorf("Model = %q, want claude-haiku-4-5", a.Model)
-	}
-	if a.OutputTokens != 17 {
-		t.Errorf("OutputTokens = %d, want 17", a.OutputTokens)
-	}
-	if a.ContextTokens != 42 {
-		t.Errorf("ContextTokens = %d, want 42", a.ContextTokens)
-	}
-	if len(a.TokenUsage) == 0 {
-		t.Error("TokenUsage empty, want normalized JSON")
-	}
-	if sess.TotalOutputTokens != 17 {
-		t.Errorf("TotalOutputTokens = %d, want 17",
-			sess.TotalOutputTokens)
-	}
+	assert.Equal(t, "claude-haiku-4-5", a.Model, "Model = %q, want claude-haiku-4-5")
+	assert.Equal(t, 17, a.OutputTokens, "OutputTokens = %d, want 17")
+	assert.Equal(t, 42, a.ContextTokens, "ContextTokens = %d, want 42")
+	assert.False(t, len(a.TokenUsage) == 0, "TokenUsage empty, want normalized JSON")
+	assert.Equal(t, 17, sess.TotalOutputTokens, "TotalOutputTokens")
 }
 
 func TestParseQClawSession_PartialUsage(t *testing.T) {
@@ -322,29 +209,17 @@ func TestParseQClawSession_PartialUsage(t *testing.T) {
 	)
 
 	_, msgs, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
 
 	a := msgs[1]
-	if a.HasContextTokens {
-		t.Error("HasContextTokens = true, want false")
-	}
-	if !a.HasOutputTokens {
-		t.Error("HasOutputTokens = false, want true")
-	}
+	assert.False(t, a.HasContextTokens, "HasContextTokens = true, want false")
+	assert.True(t, a.HasOutputTokens, "HasOutputTokens = false, want true")
 
 	hasCtx, hasOut := a.TokenPresence()
-	if hasCtx {
-		t.Error("TokenPresence ctx = true, want false " +
-			"(parser flags must take precedence over JSON keys)")
-	}
-	if !hasOut {
-		t.Error("TokenPresence out = false, want true")
-	}
+	assert.False(t, hasCtx,
+		"TokenPresence ctx = true, want false (parser flags must take precedence over JSON keys)")
+	assert.True(t, hasOut, "TokenPresence out = false, want true")
 }
 
 func TestParseQClawSession_NoUsage(t *testing.T) {
@@ -357,18 +232,12 @@ func TestParseQClawSession_NoUsage(t *testing.T) {
 	)
 
 	_, msgs, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs), "expected 2 messages, got %d")
 
 	hasCtx, hasOut := msgs[1].TokenPresence()
-	if hasCtx || hasOut {
-		t.Errorf("TokenPresence = (%v, %v), want (false, false)",
-			hasCtx, hasOut)
-	}
+	assert.False(t, hasCtx, "TokenPresence ctx")
+	assert.False(t, hasOut, "TokenPresence out")
 }
 
 func TestParseQClawSession_Compaction(t *testing.T) {
@@ -380,16 +249,10 @@ func TestParseQClawSession_Compaction(t *testing.T) {
 	)
 
 	sess, msgs, err := ParseQClawSession(path, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess == nil {
-		t.Fatal("expected session, got nil")
-	}
+	require.NoError(t, err)
+	require.False(t, sess == nil, "expected session, got nil")
 	// Compaction should be skipped, only messages remain.
-	if len(msgs) != 2 {
-		t.Errorf("expected 2 messages (compaction skipped), got %d", len(msgs))
-	}
+	assert.Equal(t, 2, len(msgs), "expected 2 messages (compaction skipped), got %d")
 }
 
 func TestParseQClawSession_AgentIDInSessionID(t *testing.T) {
@@ -405,23 +268,14 @@ func TestParseQClawSession_AgentIDInSessionID(t *testing.T) {
 	)
 
 	sessA, _, err := ParseQClawSession(pathA, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	sessB, _, err := ParseQClawSession(pathB, "", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if sessA.ID == sessB.ID {
-		t.Errorf("expected different session IDs for different agents, both got %s", sessA.ID)
-	}
-	if sessA.ID != "qclaw:alpha:same-id" {
-		t.Errorf("expected qclaw:alpha:same-id, got %s", sessA.ID)
-	}
-	if sessB.ID != "qclaw:beta:same-id" {
-		t.Errorf("expected qclaw:beta:same-id, got %s", sessB.ID)
-	}
+	assert.NotEqualf(t, sessB.ID, sessA.ID,
+		"expected different session IDs for different agents, both got %s", sessA.ID)
+	assert.Equal(t, "qclaw:alpha:same-id", sessA.ID, "expected qclaw:alpha:same-id, got %s")
+	assert.Equal(t, "qclaw:beta:same-id", sessB.ID, "expected qclaw:beta:same-id, got %s")
 }
 
 func TestIsQClawSessionFile(t *testing.T) {
@@ -439,23 +293,19 @@ func TestIsQClawSessionFile(t *testing.T) {
 		"sessions.json",
 	}
 	for _, name := range accepted {
-		if !IsQClawSessionFile(name) {
-			t.Errorf("expected %q to be accepted", name)
-		}
+		assert.Truef(t, IsQClawSessionFile(name),
+			"expected %q to be accepted", name)
 	}
 	for _, name := range rejected {
-		if IsQClawSessionFile(name) {
-			t.Errorf("expected %q to be rejected", name)
-		}
+		assert.Falsef(t, IsQClawSessionFile(name),
+			"expected %q to be rejected", name)
 	}
 }
 
 func TestBestQClawEntry_CrossSuffix(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// reset is newer (March) than deleted (January), even though
 	// "deleted" > "reset" would be wrong lexicographically within
@@ -463,20 +313,14 @@ func TestBestQClawEntry_CrossSuffix(t *testing.T) {
 	older := "abc.jsonl.deleted.2026-01-15T00-00-00.000Z"
 	newer := "abc.jsonl.reset.2026-03-01T00-00-00.000Z"
 	for _, name := range []string{older, newer} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name), []byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	files := DiscoverQClawSessions(root)
-	if len(files) != 1 {
-		t.Fatalf("expected 1 (deduplicated), got %d", len(files))
-	}
-	if filepath.Base(files[0].Path) != newer {
-		t.Errorf("expected %q, got %q", newer, filepath.Base(files[0].Path))
-	}
+	require.Equal(t, 1, len(files), "expected 1 (deduplicated), got %d")
+	assert.Equal(t, newer, filepath.Base(files[0].Path), "expected %q, got %q")
 }
 
 func TestDiscoverQClawSessions(t *testing.T) {
@@ -487,41 +331,25 @@ func TestDiscoverQClawSessions(t *testing.T) {
 	root := t.TempDir()
 
 	mainSessions := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(mainSessions, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(mainSessions, "sess1.jsonl"), []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(mainSessions, "sessions.json"), []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(mainSessions, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(mainSessions, "sess1.jsonl"), []byte("{}"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(mainSessions, "sessions.json"), []byte("{}"), 0644))
 
 	claudeSessions := filepath.Join(root, "claude", "sessions")
-	if err := os.MkdirAll(claudeSessions, 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeSessions, "sess2.jsonl"), []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(claudeSessions, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeSessions, "sess2.jsonl"), []byte("{}"), 0644))
 
 	files := DiscoverQClawSessions(root)
-	if len(files) != 2 {
-		t.Fatalf("expected 2 session files, got %d", len(files))
-	}
+	require.Equal(t, 2, len(files), "expected 2 session files, got %d")
 	for _, f := range files {
-		if f.Agent != AgentQClaw {
-			t.Errorf("expected agent qclaw, got %s", f.Agent)
-		}
+		assert.Equal(t, AgentQClaw, f.Agent, "expected agent qclaw, got %s")
 	}
 }
 
 func TestDiscoverQClawSessions_DeduplicatesArchived(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Active file and two archived files for the same session.
 	for _, name := range []string{
@@ -529,192 +357,137 @@ func TestDiscoverQClawSessions_DeduplicatesArchived(t *testing.T) {
 		"abc.jsonl.deleted.2026-02-19T08-59-24.951Z",
 		"abc.jsonl.reset.2026-02-17T09-39-39.691Z",
 	} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name),
 			[]byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	files := DiscoverQClawSessions(root)
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file (deduplicated), got %d", len(files))
-	}
+	require.Equal(t, 1, len(files), "expected 1 file (deduplicated), got %d")
 	// Active file should win.
-	if !strings.HasSuffix(files[0].Path, "abc.jsonl") {
-		t.Errorf(
-			"expected active .jsonl to win, got %s",
-			filepath.Base(files[0].Path),
-		)
-	}
+	assert.Truef(t, strings.HasSuffix(files[0].Path, "abc.jsonl"),
+		"expected active .jsonl to win, got %s",
+		filepath.Base(files[0].Path))
 }
 
 func TestDiscoverQClawSessions_ArchiveOnlyPicksNewest(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Two archived files, no active — newest filename wins.
 	for _, name := range []string{
 		"xyz.jsonl.deleted.2026-01-01T00-00-00.000Z",
 		"xyz.jsonl.deleted.2026-03-01T00-00-00.000Z",
 	} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name),
 			[]byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	files := DiscoverQClawSessions(root)
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file (deduplicated), got %d", len(files))
-	}
+	require.Equal(t, 1, len(files), "expected 1 file (deduplicated), got %d")
 	want := "xyz.jsonl.deleted.2026-03-01T00-00-00.000Z"
-	if filepath.Base(files[0].Path) != want {
-		t.Errorf("expected newest archive %q, got %q",
-			want, filepath.Base(files[0].Path))
-	}
+	assert.Equal(t, want, filepath.Base(files[0].Path), "expected newest archive")
 }
 
 func TestDiscoverQClawSessions_DifferentSessionsNotDeduped(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Two different session IDs — should not be deduplicated.
 	for _, name := range []string{
 		"aaa.jsonl",
 		"bbb.jsonl.deleted.2026-01-01T00-00-00.000Z",
 	} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name),
 			[]byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	files := DiscoverQClawSessions(root)
-	if len(files) != 2 {
-		t.Fatalf("expected 2 files (different sessions), got %d",
-			len(files))
-	}
+	require.Len(t, files, 2, "expected 2 files (different sessions)")
 }
 
 func TestFindQClawSourceFile(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 	target := filepath.Join(sessDir, "abc-123.jsonl")
-	if err := os.WriteFile(target, []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(target, []byte("{}"), 0644))
 
 	// Raw ID is now "agentId:sessionId".
 	found := FindQClawSourceFile(root, "main:abc-123")
-	if found != target {
-		t.Errorf("expected %s, got %s", target, found)
-	}
+	assert.Equal(t, target, found, "expected %s, got %s")
 
 	// Non-existent session.
 	notFound := FindQClawSourceFile(root, "main:nonexistent")
-	if notFound != "" {
-		t.Errorf("expected empty string, got %s", notFound)
-	}
+	assert.Equal(t, "", notFound, "expected empty string, got %s")
 
 	// Non-existent agent.
 	notFound2 := FindQClawSourceFile(root, "other:abc-123")
-	if notFound2 != "" {
-		t.Errorf("expected empty string, got %s", notFound2)
-	}
+	assert.Equal(t, "", notFound2, "expected empty string, got %s")
 
 	// Invalid format (no colon separator).
 	notFound3 := FindQClawSourceFile(root, "abc-123")
-	if notFound3 != "" {
-		t.Errorf("expected empty string for bare ID, got %s", notFound3)
-	}
+	assert.Equal(t, "", notFound3, "expected empty string for bare ID, got %s")
 }
 
 func TestFindQClawSourceFile_ArchiveOnly(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Only archived files exist — no active .jsonl.
 	archived := "def-456.jsonl.deleted.2026-02-19T08-59-24.951Z"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(sessDir, archived),
 		[]byte("{}"), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	found := FindQClawSourceFile(root, "main:def-456")
 	want := filepath.Join(sessDir, archived)
-	if found != want {
-		t.Errorf("expected %s, got %s", want, found)
-	}
+	assert.Equal(t, want, found, "expected %s, got %s")
 }
 
 func TestFindQClawSourceFile_PrefersActiveOverArchive(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Both active and archived files exist.
 	active := filepath.Join(sessDir, "ghi-789.jsonl")
-	if err := os.WriteFile(active, []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(active, []byte("{}"), 0644))
 	archived := "ghi-789.jsonl.deleted.2026-02-19T00-00-00.000Z"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(sessDir, archived),
 		[]byte("{}"), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	found := FindQClawSourceFile(root, "main:ghi-789")
-	if found != active {
-		t.Errorf("expected active file %s, got %s", active, found)
-	}
+	assert.Equal(t, active, found, "expected active file %s, got %s")
 }
 
 func TestFindQClawSourceFile_ArchiveOnlyNewest(t *testing.T) {
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "main", "sessions")
-	if err := os.MkdirAll(sessDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(sessDir, 0755))
 
 	// Two archived files — newest should be chosen.
 	old := "jkl.jsonl.deleted.2026-01-01T00-00-00.000Z"
 	newest := "jkl.jsonl.deleted.2026-03-01T00-00-00.000Z"
 	for _, name := range []string{old, newest} {
-		if err := os.WriteFile(
+		require.NoError(t, os.WriteFile(
 			filepath.Join(sessDir, name),
 			[]byte("{}"), 0644,
-		); err != nil {
-			t.Fatal(err)
-		}
+		))
 	}
 
 	found := FindQClawSourceFile(root, "main:jkl")
 	want := filepath.Join(sessDir, newest)
-	if found != want {
-		t.Errorf("expected newest archive %s, got %s", want, found)
-	}
+	assert.Equal(t, want, found, "expected newest archive %s, got %s")
 }

--- a/internal/parser/taxonomy_test.go
+++ b/internal/parser/taxonomy_test.go
@@ -1,6 +1,10 @@
 package parser
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestNormalizeToolCategory(t *testing.T) {
 	tests := []struct {
@@ -111,12 +115,8 @@ func TestNormalizeToolCategory(t *testing.T) {
 		}
 		t.Run(testName, func(t *testing.T) {
 			got := NormalizeToolCategory(tt.toolName)
-			if got != tt.want {
-				t.Errorf(
-					"NormalizeToolCategory(%q) = %q, want %q",
-					tt.toolName, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got,
+				"NormalizeToolCategory(%q)", tt.toolName)
 		})
 	}
 }

--- a/internal/parser/test_helpers_test.go
+++ b/internal/parser/test_helpers_test.go
@@ -2,10 +2,14 @@ package parser
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Timestamp constants for test data.
@@ -36,52 +40,35 @@ func generateLargeString(size int) string {
 
 func assertSessionMeta(t *testing.T, s *ParsedSession, wantID, wantProject string, wantAgent AgentType) {
 	t.Helper()
-	if s == nil {
-		t.Fatal("session is nil")
-		return
-	}
-	if s.ID != wantID {
-		t.Errorf("session ID = %q, want %q", s.ID, wantID)
-	}
-	if s.Project != wantProject {
-		t.Errorf("project = %q, want %q", s.Project, wantProject)
-	}
-	if s.Agent != wantAgent {
-		t.Errorf("agent = %q, want %q", s.Agent, wantAgent)
-	}
+	require.NotNil(t, s, "session is nil")
+	assert.Equal(t, wantID, s.ID, "session ID")
+	assert.Equal(t, wantProject, s.Project, "project")
+	assert.Equal(t, wantAgent, s.Agent, "agent")
 }
 
 func assertMessage(t *testing.T, m ParsedMessage, wantRole RoleType, wantContentSnippet string) {
 	t.Helper()
-	if m.Role != wantRole {
-		t.Errorf("role = %q, want %q", m.Role, wantRole)
-	}
-	if wantContentSnippet != "" && !strings.Contains(m.Content, wantContentSnippet) {
-		t.Errorf("content missing snippet %q, got %q", wantContentSnippet, m.Content)
+	assert.Equal(t, wantRole, m.Role, "role")
+	if wantContentSnippet != "" {
+		assert.Contains(t, m.Content, wantContentSnippet)
 	}
 }
 
 func assertMessageCount(t *testing.T, count, want int) {
 	t.Helper()
-	if count != want {
-		t.Fatalf("message count = %d, want %d", count, want)
-	}
+	require.Equal(t, want, count, "message count")
 }
 
 func assertTimestamp(t *testing.T, got time.Time, want time.Time) {
 	t.Helper()
-	if !got.Equal(want) {
-		t.Errorf("timestamp = %v, want %v", got, want)
-	}
+	assert.True(t, got.Equal(want), "timestamp = %v, want %v", got, want)
 }
 
 func assertZeroTimestamp(
 	t *testing.T, ts time.Time, label string,
 ) {
 	t.Helper()
-	if !ts.IsZero() {
-		t.Errorf("%s = %v, want zero", label, ts)
-	}
+	assert.True(t, ts.IsZero(), "%s = %v, want zero", label, ts)
 }
 
 // captureLog redirects log output to a buffer for the
@@ -100,14 +87,8 @@ func assertLogContains(
 ) {
 	t.Helper()
 	got := buf.String()
-	var missing []string
 	for _, s := range substrs {
-		if !strings.Contains(got, s) {
-			missing = append(missing, s)
-		}
-	}
-	if len(missing) > 0 {
-		t.Errorf("log missing substrings %q. Full log:\n%s", missing, got)
+		assert.Contains(t, got, s, "log missing substring %q", s)
 	}
 }
 
@@ -116,32 +97,19 @@ func assertLogNotContains(
 ) {
 	t.Helper()
 	got := buf.String()
-	var unexpected []string
 	for _, s := range substrs {
-		if strings.Contains(got, s) {
-			unexpected = append(unexpected, s)
-		}
-	}
-	if len(unexpected) > 0 {
-		t.Errorf("log should not contain substrings %q. Full log:\n%s", unexpected, got)
+		assert.NotContains(t, got, s, "log should not contain substring %q", s)
 	}
 }
 
 func assertLogEmpty(t *testing.T, buf *bytes.Buffer) {
 	t.Helper()
-	if buf.Len() > 0 {
-		t.Errorf(
-			"expected no log output, got: %q",
-			buf.String(),
-		)
-	}
+	assert.Zero(t, buf.Len(), "expected no log output, got: %q", buf.String())
 }
 
 func assertToolCallField(t *testing.T, i int, field, got, want string) {
 	t.Helper()
-	if got != want {
-		t.Errorf("tool_calls[%d].%s = %q, want %q", i, field, got, want)
-	}
+	assert.Equal(t, want, got, fmt.Sprintf("tool_calls[%d].%s", i, field))
 }
 
 func assertToolCall(t *testing.T, i int, got, want ParsedToolCall) {
@@ -164,9 +132,7 @@ func assertToolCalls(
 	t *testing.T, got, want []ParsedToolCall,
 ) {
 	t.Helper()
-	if len(got) != len(want) {
-		t.Errorf("tool calls count = %d, want %d",
-			len(got), len(want))
+	if !assert.Equal(t, len(want), len(got), "tool calls count") {
 		return
 	}
 	for i := range want {
@@ -182,11 +148,7 @@ func parseClaudeTestFile(
 	results, err := ParseClaudeSession(
 		path, project, "local",
 	)
-	if err != nil {
-		t.Fatalf("ParseClaudeSession: %v", err)
-	}
-	if len(results) == 0 {
-		t.Fatal("ParseClaudeSession returned no results")
-	}
+	require.NoError(t, err, "ParseClaudeSession")
+	require.NotEmpty(t, results, "ParseClaudeSession returned no results")
 	return results[0].Session, results[0].Messages
 }

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -6,6 +6,9 @@ import (
 	"runtime"
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInferTokenPresence(t *testing.T) {
@@ -120,12 +123,8 @@ func TestInferTokenPresence(t *testing.T) {
 				tt.hasContext,
 				tt.hasOutput,
 			)
-			if gotCtx != tt.wantCtx || gotOut != tt.wantOut {
-				t.Errorf(
-					"InferTokenPresence() = (%v, %v), want (%v, %v)",
-					gotCtx, gotOut, tt.wantCtx, tt.wantOut,
-				)
-			}
+			assert.Equal(t, tt.wantCtx, gotCtx, "InferTokenPresence context")
+			assert.Equal(t, tt.wantOut, gotOut, "InferTokenPresence output")
 		})
 	}
 }
@@ -149,17 +148,9 @@ func TestAgentByType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		def, ok := AgentByType(tt.input)
-		if ok != tt.want {
-			t.Errorf(
-				"AgentByType(%q) ok = %v, want %v",
-				tt.input, ok, tt.want,
-			)
-		}
-		if ok && def.Type != tt.input {
-			t.Errorf(
-				"AgentByType(%q).Type = %q",
-				tt.input, def.Type,
-			)
+		assert.Equalf(t, tt.want, ok, "AgentByType(%q) ok", tt.input)
+		if ok {
+			assert.Equalf(t, tt.input, def.Type, "AgentByType(%q).Type", tt.input)
 		}
 	}
 }
@@ -247,17 +238,10 @@ func TestAgentByPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			def, ok := AgentByPrefix(tt.sessionID)
-			if ok != tt.wantOK {
-				t.Fatalf(
-					"AgentByPrefix(%q) ok = %v, want %v",
-					tt.sessionID, ok, tt.wantOK,
-				)
-			}
-			if ok && def.Type != tt.wantType {
-				t.Errorf(
-					"AgentByPrefix(%q).Type = %q, want %q",
-					tt.sessionID, def.Type, tt.wantType,
-				)
+			require.Equalf(t, tt.wantOK, ok, "AgentByPrefix(%q) ok", tt.sessionID)
+			if ok {
+				assert.Equalf(t, tt.wantType, def.Type,
+					"AgentByPrefix(%q).Type", tt.sessionID)
 			}
 		})
 	}
@@ -296,11 +280,8 @@ func TestRegistryCompleteness(t *testing.T) {
 	}
 
 	for _, at := range allTypes {
-		if !registered[at] {
-			t.Errorf(
-				"AgentType %q missing from Registry", at,
-			)
-		}
+		assert.Truef(t, registered[at],
+			"AgentType %q missing from Registry", at)
 	}
 }
 
@@ -384,16 +365,10 @@ func TestInferRelationshipTypes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			InferRelationshipTypes(tt.inputs)
-			if len(tt.inputs) != len(tt.want) {
-				t.Fatalf("len(inputs) = %d, want %d", len(tt.inputs), len(tt.want))
-			}
+			require.Len(t, tt.inputs, len(tt.want), "inputs len")
 			for i, r := range tt.inputs {
-				if r.Session.RelationshipType != tt.want[i] {
-					t.Errorf(
-						"inputs[%d].RelationshipType = %q, want %q",
-						i, r.Session.RelationshipType, tt.want[i],
-					)
-				}
+				assert.Equalf(t, tt.want[i], r.Session.RelationshipType,
+					"inputs[%d].RelationshipType", i)
 			}
 		})
 	}
@@ -404,56 +379,37 @@ func TestFileBasedAgentsHaveConfigKey(t *testing.T) {
 		if !def.FileBased {
 			continue
 		}
-		if def.ConfigKey == "" {
-			t.Errorf(
-				"file-based agent %q (%s) has empty ConfigKey",
-				def.DisplayName, def.Type,
-			)
-		}
+		assert.NotEmptyf(t, def.ConfigKey,
+			"file-based agent %q (%s) has empty ConfigKey",
+			def.DisplayName, def.Type)
 	}
 }
 
 func TestOpenCodeRegistryEntry(t *testing.T) {
 	def, ok := AgentByType(AgentOpenCode)
-	if !ok {
-		t.Fatalf("AgentOpenCode missing from Registry")
-	}
-	if !def.FileBased {
-		t.Fatalf("OpenCode FileBased = false, want true")
-	}
-	if def.DiscoverFunc == nil {
-		t.Fatalf("OpenCode DiscoverFunc = nil")
-	}
-	if def.FindSourceFunc == nil {
-		t.Fatalf("OpenCode FindSourceFunc = nil")
-	}
-	if got, want := def.WatchSubdirs, []string{
+	require.True(t, ok, "AgentOpenCode missing from Registry")
+	require.True(t, def.FileBased, "OpenCode FileBased")
+	require.NotNil(t, def.DiscoverFunc, "OpenCode DiscoverFunc")
+	require.NotNil(t, def.FindSourceFunc, "OpenCode FindSourceFunc")
+	want := []string{
 		"storage/session",
 		"storage/message",
 		"storage/part",
-	}; !slices.Equal(got, want) {
-		t.Fatalf("OpenCode WatchSubdirs = %v, want %v", got, want)
 	}
+	require.Truef(t, slices.Equal(def.WatchSubdirs, want),
+		"OpenCode WatchSubdirs = %v, want %v", def.WatchSubdirs, want)
 }
 
 func TestResolveOpenCodeSourcePrefersStorage(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := filepath.Join(root, "storage", "session", "global")
-	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-		t.Fatalf("mkdir session dir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir session dir")
 	dbPath := filepath.Join(root, "opencode.db")
-	if err := os.WriteFile(dbPath, []byte("x"), 0o644); err != nil {
-		t.Fatalf("write db marker: %v", err)
-	}
+	require.NoError(t, os.WriteFile(dbPath, []byte("x"), 0o644), "write db marker")
 
 	got := ResolveOpenCodeSource(root)
-	if got.Mode != OpenCodeSourceStorage {
-		t.Fatalf("Mode = %v, want %v", got.Mode, OpenCodeSourceStorage)
-	}
-	if got.SessionRoot != filepath.Join(root, "storage", "session") {
-		t.Fatalf("SessionRoot = %q", got.SessionRoot)
-	}
+	require.Equal(t, OpenCodeSourceStorage, got.Mode, "Mode")
+	require.Equal(t, filepath.Join(root, "storage", "session"), got.SessionRoot, "SessionRoot")
 }
 
 func TestResolveOpenCodeSourceFallsBackToSQLiteOnBrokenStoragePath(
@@ -461,21 +417,13 @@ func TestResolveOpenCodeSourceFallsBackToSQLiteOnBrokenStoragePath(
 ) {
 	root := t.TempDir()
 	storagePath := filepath.Join(root, "storage")
-	if err := os.WriteFile(storagePath, []byte("x"), 0o644); err != nil {
-		t.Fatalf("write storage marker: %v", err)
-	}
+	require.NoError(t, os.WriteFile(storagePath, []byte("x"), 0o644), "write storage marker")
 	dbPath := filepath.Join(root, "opencode.db")
-	if err := os.WriteFile(dbPath, []byte("x"), 0o644); err != nil {
-		t.Fatalf("write db marker: %v", err)
-	}
+	require.NoError(t, os.WriteFile(dbPath, []byte("x"), 0o644), "write db marker")
 
 	got := ResolveOpenCodeSource(root)
-	if got.Mode != OpenCodeSourceSQLite {
-		t.Fatalf("Mode = %v, want %v", got.Mode, OpenCodeSourceSQLite)
-	}
-	if got.DBPath != dbPath {
-		t.Fatalf("DBPath = %q, want %q", got.DBPath, dbPath)
-	}
+	require.Equal(t, OpenCodeSourceSQLite, got.Mode, "Mode")
+	require.Equal(t, dbPath, got.DBPath, "DBPath")
 }
 
 func TestResolveOpenCodeSourceKeepsStorageAuthoritativeWhenUnreadable(
@@ -486,115 +434,71 @@ func TestResolveOpenCodeSourceKeepsStorageAuthoritativeWhenUnreadable(
 	}
 	root := t.TempDir()
 	sessionDir := filepath.Join(root, "storage", "session", "global")
-	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
-		t.Fatalf("mkdir session dir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir session dir")
 	storageRoot := filepath.Join(root, "storage")
-	if err := os.Chmod(storageRoot, 0o000); err != nil {
-		t.Fatalf("chmod storage root: %v", err)
-	}
+	require.NoError(t, os.Chmod(storageRoot, 0o000), "chmod storage root")
 	defer func() {
 		_ = os.Chmod(storageRoot, 0o755)
 	}()
 	dbPath := filepath.Join(root, "opencode.db")
-	if err := os.WriteFile(dbPath, []byte("x"), 0o644); err != nil {
-		t.Fatalf("write db marker: %v", err)
-	}
+	require.NoError(t, os.WriteFile(dbPath, []byte("x"), 0o644), "write db marker")
 
 	got := ResolveOpenCodeSource(root)
-	if got.Mode != OpenCodeSourceStorage {
-		t.Fatalf("Mode = %v, want %v", got.Mode, OpenCodeSourceStorage)
-	}
-	if got.SessionRoot != filepath.Join(root, "storage", "session") {
-		t.Fatalf("SessionRoot = %q", got.SessionRoot)
-	}
+	require.Equal(t, OpenCodeSourceStorage, got.Mode, "Mode")
+	require.Equal(t, filepath.Join(root, "storage", "session"), got.SessionRoot, "SessionRoot")
 }
 
 func TestDiscoverOpenCodeSessions(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "storage", "session", "global")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(dir, 0o755), "mkdir")
 	path := filepath.Join(dir, "ses_test.json")
 	data := []byte(`{"id":"ses_test","directory":"/home/user/code/my-app"}`)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatalf("write session: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, data, 0o644), "write session")
 
 	got := DiscoverOpenCodeSessions(root)
-	if len(got) != 1 {
-		t.Fatalf("len = %d, want 1", len(got))
-	}
-	if got[0].Path != path {
-		t.Fatalf("Path = %q, want %q", got[0].Path, path)
-	}
-	if got[0].Project != "my_app" {
-		t.Fatalf("Project = %q, want %q", got[0].Project, "my_app")
-	}
-	if got[0].Agent != AgentOpenCode {
-		t.Fatalf("Agent = %q, want %q", got[0].Agent, AgentOpenCode)
-	}
+	require.Len(t, got, 1, "len")
+	require.Equal(t, path, got[0].Path, "Path")
+	require.Equal(t, "my_app", got[0].Project, "Project")
+	require.Equal(t, AgentOpenCode, got[0].Agent, "Agent")
 }
 
 func TestDiscoverOpenCodeSessionsIgnoresNestedJSON(t *testing.T) {
 	root := t.TempDir()
 	dir := filepath.Join(root, "storage", "session", "global")
-	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0o755), "mkdir")
 	path := filepath.Join(dir, "ses_test.json")
-	if err := os.WriteFile(path, []byte(`{"id":"ses_test"}`), 0o644); err != nil {
-		t.Fatalf("write session: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "nested", "meta.json"), []byte(`{"id":"meta"}`), 0o644); err != nil {
-		t.Fatalf("write nested json: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(`{"id":"ses_test"}`), 0o644), "write session")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "nested", "meta.json"), []byte(`{"id":"meta"}`), 0o644), "write nested json")
 
 	got := DiscoverOpenCodeSessions(root)
-	if len(got) != 1 {
-		t.Fatalf("len = %d, want 1", len(got))
-	}
-	if got[0].Path != path {
-		t.Fatalf("Path = %q, want %q", got[0].Path, path)
-	}
+	require.Len(t, got, 1, "len")
+	require.Equal(t, path, got[0].Path, "Path")
 }
 
 func TestFindOpenCodeSourceFilePrefersStorage(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "storage", "session", "global", "ses_123.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(path, []byte(`{"id":"ses_123"}`), 0o644); err != nil {
-		t.Fatalf("write session: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "opencode.db"), []byte("x"), 0o644); err != nil {
-		t.Fatalf("write db marker: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "mkdir")
+	require.NoError(t, os.WriteFile(path, []byte(`{"id":"ses_123"}`), 0o644), "write session")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "opencode.db"), []byte("x"), 0o644), "write db marker")
 
 	got := FindOpenCodeSourceFile(root, "ses_123")
-	if got != path {
-		t.Fatalf("FindOpenCodeSourceFile() = %q, want %q", got, path)
-	}
+	require.Equal(t, path, got, "FindOpenCodeSourceFile()")
 }
 
 func TestFindOpenCodeSourceFileFallsBackToSQLiteInHybridRoot(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "storage", "session", "global"),
 		0o755,
-	); err != nil {
-		t.Fatalf("mkdir session dir: %v", err)
-	}
+	), "mkdir session dir")
 	dbPath := filepath.Join(root, "opencode.db")
 	seedHybridSQLiteDB(t, dbPath, "ses_456")
 
 	got := FindOpenCodeSourceFile(root, "ses_456")
 	want := OpenCodeSQLiteVirtualPath(dbPath, "ses_456")
-	if got != want {
-		t.Fatalf("FindOpenCodeSourceFile() = %q, want %q", got, want)
-	}
+	require.Equal(t, want, got, "FindOpenCodeSourceFile()")
 }
 
 // TestFindOpenCodeSourceFileReturnsEmptyWhenSessionMissing covers
@@ -604,18 +508,15 @@ func TestFindOpenCodeSourceFileFallsBackToSQLiteInHybridRoot(t *testing.T) {
 // where the session actually lives.
 func TestFindOpenCodeSourceFileReturnsEmptyWhenSessionMissing(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "storage", "session", "global"),
 		0o755,
-	); err != nil {
-		t.Fatalf("mkdir session dir: %v", err)
-	}
+	), "mkdir session dir")
 	dbPath := filepath.Join(root, "opencode.db")
 	seedHybridSQLiteDB(t, dbPath, "ses_unrelated")
 
-	if got := FindOpenCodeSourceFile(root, "ses_missing"); got != "" {
-		t.Fatalf("FindOpenCodeSourceFile() = %q, want empty", got)
-	}
+	got := FindOpenCodeSourceFile(root, "ses_missing")
+	assert.Empty(t, got, "FindOpenCodeSourceFile()")
 }
 
 func TestFindOpenCodeSourceFilePureSQLiteOnlyForExistingSession(t *testing.T) {
@@ -623,42 +524,30 @@ func TestFindOpenCodeSourceFilePureSQLiteOnlyForExistingSession(t *testing.T) {
 	dbPath := filepath.Join(root, "opencode.db")
 	seedHybridSQLiteDB(t, dbPath, "ses_present")
 
-	if got := FindOpenCodeSourceFile(root, "ses_present"); got !=
-		OpenCodeSQLiteVirtualPath(dbPath, "ses_present") {
-		t.Fatalf(
-			"FindOpenCodeSourceFile(present) = %q, want virtual path",
-			got,
-		)
-	}
-	if got := FindOpenCodeSourceFile(root, "ses_absent"); got != "" {
-		t.Fatalf(
-			"FindOpenCodeSourceFile(absent) = %q, want empty", got,
-		)
-	}
+	got := FindOpenCodeSourceFile(root, "ses_present")
+	assert.Equal(t,
+		OpenCodeSQLiteVirtualPath(dbPath, "ses_present"),
+		got, "FindOpenCodeSourceFile(present)")
+	got = FindOpenCodeSourceFile(root, "ses_absent")
+	assert.Empty(t, got, "FindOpenCodeSourceFile(absent)")
 }
 
 func TestOpenCodeStorageSessionIDsCollectsJSONFiles(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := filepath.Join(root, "storage", "session")
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(sessionDir, "global"), 0o755,
-	); err != nil {
-		t.Fatalf("mkdir global: %v", err)
-	}
-	if err := os.MkdirAll(
+	), "mkdir global")
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(sessionDir, "proj-x"), 0o755,
-	); err != nil {
-		t.Fatalf("mkdir proj-x: %v", err)
-	}
+	), "mkdir proj-x")
 	for _, p := range []string{
 		filepath.Join(sessionDir, "global", "ses_a.json"),
 		filepath.Join(sessionDir, "global", "ses_b.json"),
 		filepath.Join(sessionDir, "proj-x", "ses_c.json"),
 		filepath.Join(sessionDir, "global", "skip.txt"),
 	} {
-		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
-			t.Fatalf("write %s: %v", p, err)
-		}
+		require.NoErrorf(t, os.WriteFile(p, []byte("{}"), 0o644), "write %s", p)
 	}
 
 	got := OpenCodeStorageSessionIDs(root)
@@ -667,63 +556,49 @@ func TestOpenCodeStorageSessionIDsCollectsJSONFiles(t *testing.T) {
 		"ses_b": {},
 		"ses_c": {},
 	}
-	if len(got) != len(want) {
-		t.Fatalf("got %d ids, want %d: %v", len(got), len(want), got)
-	}
+	require.Lenf(t, got, len(want), "got %v, want %v", got, want)
 	for id := range want {
-		if _, ok := got[id]; !ok {
-			t.Errorf("missing %q in result %v", id, got)
-		}
+		_, ok := got[id]
+		assert.Truef(t, ok, "missing %q in result %v", id, got)
 	}
 }
 
 func TestOpenCodeStorageSessionIDsNilForNonStorageRoot(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(root, "opencode.db"), []byte("x"), 0o644,
-	); err != nil {
-		t.Fatalf("write db marker: %v", err)
-	}
-	if got := OpenCodeStorageSessionIDs(root); got != nil {
-		t.Fatalf("got %v, want nil for SQLite-only root", got)
-	}
+	), "write db marker")
+	got := OpenCodeStorageSessionIDs(root)
+	assert.Nil(t, got, "want nil for SQLite-only root")
 }
 
 func TestResolveOpenCodeWatchRootsStorage(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "storage", "session", "global"),
 		0o755,
-	); err != nil {
-		t.Fatalf("mkdir session dir: %v", err)
-	}
+	), "mkdir session dir")
 
 	got := ResolveOpenCodeWatchRoots(root)
 	want := []string{filepath.Join(root, "storage")}
-	if !slices.Equal(got, want) {
-		t.Fatalf("ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
-	}
+	assert.Truef(t, slices.Equal(got, want),
+		"ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
 }
 
 func TestResolveOpenCodeWatchRootsHybrid(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "storage", "session", "global"),
 		0o755,
-	); err != nil {
-		t.Fatalf("mkdir session dir: %v", err)
-	}
-	if err := os.WriteFile(
+	), "mkdir session dir")
+	require.NoError(t, os.WriteFile(
 		filepath.Join(root, "opencode.db"), []byte("x"), 0o644,
-	); err != nil {
-		t.Fatalf("write db marker: %v", err)
-	}
+	), "write db marker")
 
 	got := ResolveOpenCodeWatchRoots(root)
 	want := []string{root}
-	if !slices.Equal(got, want) {
-		t.Fatalf("ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
-	}
+	assert.Truef(t, slices.Equal(got, want),
+		"ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
 }
 
 // A fresh opencode install may only have storage/session at startup;
@@ -732,65 +607,52 @@ func TestResolveOpenCodeWatchRootsHybrid(t *testing.T) {
 // Create handler picks up those lazy subdirs without a restart.
 func TestResolveOpenCodeWatchRootsStorageMissingSubdirs(t *testing.T) {
 	root := t.TempDir()
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "storage", "session"),
 		0o755,
-	); err != nil {
-		t.Fatalf("mkdir session dir: %v", err)
-	}
+	), "mkdir session dir")
 
 	got := ResolveOpenCodeWatchRoots(root)
 	want := []string{filepath.Join(root, "storage")}
-	if !slices.Equal(got, want) {
-		t.Fatalf("ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
-	}
+	assert.Truef(t, slices.Equal(got, want),
+		"ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
 }
 
 func TestResolveOpenCodeWatchRootsSQLite(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(root, "opencode.db"), []byte("x"), 0o644,
-	); err != nil {
-		t.Fatalf("write db marker: %v", err)
-	}
+	), "write db marker")
 
 	got := ResolveOpenCodeWatchRoots(root)
 	want := []string{root}
-	if !slices.Equal(got, want) {
-		t.Fatalf("ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
-	}
+	assert.Truef(t, slices.Equal(got, want),
+		"ResolveOpenCodeWatchRoots() = %v, want %v", got, want)
 }
 
 func TestResolveOpenCodeWatchRootsMissingRoot(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "missing")
 	got := ResolveOpenCodeWatchRoots(root)
-	if got != nil {
-		t.Fatalf("ResolveOpenCodeWatchRoots() = %v, want nil", got)
-	}
+	assert.Nil(t, got, "ResolveOpenCodeWatchRoots()")
 }
 
 func TestParseOpenCodeSQLiteVirtualPath(t *testing.T) {
 	dbPath := filepath.Join("/tmp", "opencode.db")
 	virtual := OpenCodeSQLiteVirtualPath(dbPath, "ses_123")
 	gotDB, gotSessionID, ok := ParseOpenCodeSQLiteVirtualPath(virtual)
-	if !ok {
-		t.Fatal("expected virtual path to parse")
-	}
-	if gotDB != dbPath || gotSessionID != "ses_123" {
-		t.Fatalf("ParseOpenCodeSQLiteVirtualPath() = (%q, %q), want (%q, %q)", gotDB, gotSessionID, dbPath, "ses_123")
-	}
+	require.True(t, ok, "expected virtual path to parse")
+	assert.Equal(t, dbPath, gotDB, "db path")
+	assert.Equal(t, "ses_123", gotSessionID, "session ID")
 	hashDBPath := filepath.Join("/tmp", "opencode#dev", "opencode.db")
 	hashVirtual := OpenCodeSQLiteVirtualPath(hashDBPath, "ses_456")
 	gotDB, gotSessionID, ok = ParseOpenCodeSQLiteVirtualPath(hashVirtual)
-	if !ok {
-		t.Fatal("expected virtual path with # in db path to parse")
-	}
-	if gotDB != hashDBPath || gotSessionID != "ses_456" {
-		t.Fatalf("ParseOpenCodeSQLiteVirtualPath() with # in db path = (%q, %q), want (%q, %q)", gotDB, gotSessionID, hashDBPath, "ses_456")
-	}
-	if _, _, ok := ParseOpenCodeSQLiteVirtualPath("/tmp/project#dir/storage/session/global/ses_123.json"); ok {
-		t.Fatal("expected real storage path with # to be rejected")
-	}
+	require.True(t, ok, "expected virtual path with # in db path to parse")
+	assert.Equal(t, hashDBPath, gotDB, "db path with #")
+	assert.Equal(t, "ses_456", gotSessionID, "session ID with #")
+	_, _, ok = ParseOpenCodeSQLiteVirtualPath(
+		"/tmp/project#dir/storage/session/global/ses_123.json",
+	)
+	assert.False(t, ok, "expected real storage path with # to be rejected")
 }
 
 func TestStripHostPrefix(t *testing.T) {
@@ -846,18 +708,8 @@ func TestStripHostPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			host, raw := StripHostPrefix(tt.id)
-			if host != tt.wantHost {
-				t.Errorf(
-					"StripHostPrefix(%q) host = %q, want %q",
-					tt.id, host, tt.wantHost,
-				)
-			}
-			if raw != tt.wantRaw {
-				t.Errorf(
-					"StripHostPrefix(%q) raw = %q, want %q",
-					tt.id, raw, tt.wantRaw,
-				)
-			}
+			assert.Equalf(t, tt.wantHost, host, "StripHostPrefix(%q) host", tt.id)
+			assert.Equalf(t, tt.wantRaw, raw, "StripHostPrefix(%q) raw", tt.id)
 		})
 	}
 }
@@ -915,17 +767,10 @@ func TestAgentByPrefixRemote(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			def, ok := AgentByPrefix(tt.sessionID)
-			if ok != tt.wantOK {
-				t.Fatalf(
-					"AgentByPrefix(%q) ok = %v, want %v",
-					tt.sessionID, ok, tt.wantOK,
-				)
-			}
-			if ok && def.Type != tt.wantType {
-				t.Errorf(
-					"AgentByPrefix(%q).Type = %q, want %q",
-					tt.sessionID, def.Type, tt.wantType,
-				)
+			require.Equalf(t, tt.wantOK, ok, "AgentByPrefix(%q) ok", tt.sessionID)
+			if ok {
+				assert.Equalf(t, tt.wantType, def.Type,
+					"AgentByPrefix(%q).Type", tt.sessionID)
 			}
 		})
 	}
@@ -933,9 +778,7 @@ func TestAgentByPrefixRemote(t *testing.T) {
 
 func TestVSCodeCopilotDefaultDirs(t *testing.T) {
 	def, ok := AgentByType(AgentVSCodeCopilot)
-	if !ok {
-		t.Fatal("AgentVSCodeCopilot not in Registry")
-	}
+	require.True(t, ok, "AgentVSCodeCopilot not in Registry")
 
 	required := []string{
 		// Windows
@@ -952,8 +795,7 @@ func TestVSCodeCopilotDefaultDirs(t *testing.T) {
 		".config/VSCodium/User",
 	}
 	for _, path := range required {
-		if !slices.Contains(def.DefaultDirs, path) {
-			t.Errorf("missing default dir: %s", path)
-		}
+		assert.Truef(t, slices.Contains(def.DefaultDirs, path),
+			"missing default dir: %s", path)
 	}
 }

--- a/internal/parser/vscode_copilot_test.go
+++ b/internal/parser/vscode_copilot_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseVSCodeCopilotSession(t *testing.T) {
@@ -120,59 +123,33 @@ func TestParseVSCodeCopilotSession(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			path := filepath.Join(dir, "test-session.json")
-			if err := os.WriteFile(
+			require.NoError(t, os.WriteFile(
 				path, []byte(tt.json), 0644,
-			); err != nil {
-				t.Fatal(err)
-			}
+			))
 
 			sess, msgs, err := ParseVSCodeCopilotSession(
 				path, "testproject", "local",
 			)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
 			if tt.wantNil {
-				if sess != nil {
-					t.Fatal("expected nil session")
-				}
+				assert.Nil(t, sess, "expected nil session")
 				return
 			}
 
-			if sess == nil {
-				t.Fatal("expected non-nil session")
-				return
+			require.NotNil(t, sess, "expected non-nil session")
+
+			assert.Len(t, msgs, tt.wantMessages, "messages")
+
+			if tt.wantTitle != "" {
+				assert.Equal(t, tt.wantTitle, sess.FirstMessage, "first message")
 			}
 
-			if len(msgs) != tt.wantMessages {
-				t.Errorf(
-					"messages: got %d, want %d",
-					len(msgs), tt.wantMessages,
-				)
+			if tt.wantAgent != "" {
+				assert.Equal(t, tt.wantAgent, sess.Agent, "agent")
 			}
 
-			if tt.wantTitle != "" &&
-				sess.FirstMessage != tt.wantTitle {
-				t.Errorf(
-					"first message: got %q, want %q",
-					sess.FirstMessage, tt.wantTitle,
-				)
-			}
-
-			if tt.wantAgent != "" && sess.Agent != tt.wantAgent {
-				t.Errorf(
-					"agent: got %q, want %q",
-					sess.Agent, tt.wantAgent,
-				)
-			}
-
-			if sess.Project != "testproject" {
-				t.Errorf(
-					"project: got %q, want %q",
-					sess.Project, "testproject",
-				)
-			}
+			assert.Equal(t, "testproject", sess.Project, "project")
 
 			if tt.wantToolUse {
 				found := false
@@ -182,9 +159,7 @@ func TestParseVSCodeCopilotSession(t *testing.T) {
 						break
 					}
 				}
-				if !found {
-					t.Error("expected tool use in messages")
-				}
+				assert.True(t, found, "expected tool use in messages")
 			}
 		})
 	}
@@ -194,12 +169,9 @@ func TestParseVSCodeCopilotSession_NonExistent(t *testing.T) {
 	sess, msgs, err := ParseVSCodeCopilotSession(
 		"/nonexistent/path.json", "proj", "local",
 	)
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
-	}
-	if sess != nil || msgs != nil {
-		t.Fatal("expected nil for non-existent file")
-	}
+	require.NoError(t, err, "expected nil error")
+	assert.Nil(t, sess, "expected nil session for non-existent file")
+	assert.Nil(t, msgs, "expected nil messages for non-existent file")
 }
 
 func TestParseVSCodeCopilotSession_MixedTextAndTools(t *testing.T) {
@@ -222,14 +194,10 @@ func TestParseVSCodeCopilotSession_MixedTextAndTools(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.json")
-	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(data), 0644))
 
 	_, msgs, err := ParseVSCodeCopilotSession(path, "proj", "local")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Find assistant message
 	var assistant *ParsedMessage
@@ -239,31 +207,18 @@ func TestParseVSCodeCopilotSession_MixedTextAndTools(t *testing.T) {
 			break
 		}
 	}
-	if assistant == nil {
-		t.Fatal("no assistant message")
-		return
-	}
+	require.NotNil(t, assistant, "no assistant message")
 
-	if !assistant.HasToolUse {
-		t.Error("expected HasToolUse=true")
-	}
+	assert.True(t, assistant.HasToolUse, "expected HasToolUse=true")
 
 	// Content should include both tool markers and text
-	if len(assistant.Content) == 0 {
-		t.Error("expected non-empty content")
-	}
+	assert.NotEmpty(t, assistant.Content, "expected non-empty content")
 
 	// Tool calls should have InputJSON populated
-	if len(assistant.ToolCalls) != 1 {
-		t.Fatalf("got %d tool calls, want 1", len(assistant.ToolCalls))
-	}
+	require.Len(t, assistant.ToolCalls, 1)
 	tc := assistant.ToolCalls[0]
-	if tc.InputJSON == "" {
-		t.Error("expected non-empty InputJSON")
-	}
-	if tc.Category != "Read" {
-		t.Errorf("category: got %q, want %q", tc.Category, "Read")
-	}
+	assert.NotEmpty(t, tc.InputJSON, "expected non-empty InputJSON")
+	assert.Equal(t, "Read", tc.Category, "category")
 }
 
 func TestParseVSCodeCopilotSession_TerminalToolData(t *testing.T) {
@@ -285,14 +240,10 @@ func TestParseVSCodeCopilotSession_TerminalToolData(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.json")
-	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(data), 0644))
 
 	_, msgs, err := ParseVSCodeCopilotSession(path, "proj", "local")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	var assistant *ParsedMessage
 	for i := range msgs {
@@ -301,43 +252,16 @@ func TestParseVSCodeCopilotSession_TerminalToolData(t *testing.T) {
 			break
 		}
 	}
-	if assistant == nil {
-		t.Fatal("no assistant message")
-		return
-	}
+	require.NotNil(t, assistant, "no assistant message")
 
-	if len(assistant.ToolCalls) != 1 {
-		t.Fatalf("got %d tool calls, want 1", len(assistant.ToolCalls))
-	}
+	require.Len(t, assistant.ToolCalls, 1)
 	tc := assistant.ToolCalls[0]
-	if tc.Category != "Bash" {
-		t.Errorf("category: got %q, want %q", tc.Category, "Bash")
-	}
-	if tc.InputJSON == "" {
-		t.Error("expected non-empty InputJSON")
-	}
+	assert.Equal(t, "Bash", tc.Category, "category")
+	assert.NotEmpty(t, tc.InputJSON, "expected non-empty InputJSON")
 
 	// Content should include the command
-	if !containsStr(assistant.Content, "npm test") {
-		t.Errorf("content should contain command, got: %s", assistant.Content)
-	}
-}
-
-func containsStr(haystack, needle string) bool {
-	return len(haystack) >= len(needle) &&
-		(haystack == needle ||
-			len(haystack) > len(needle) &&
-				(haystack[:len(needle)] == needle ||
-					containsSubstring(haystack, needle)))
-}
-
-func containsSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
+	assert.Contains(t, assistant.Content, "npm test",
+		"content should contain command, got: %s", assistant.Content)
 }
 
 func TestExtractProjectFromURI(t *testing.T) {
@@ -352,13 +276,8 @@ func TestExtractProjectFromURI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.uri, func(t *testing.T) {
-			got := extractProjectFromURI(tt.uri)
-			if got != tt.want {
-				t.Errorf(
-					"extractProjectFromURI(%q) = %q, want %q",
-					tt.uri, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, extractProjectFromURI(tt.uri),
+				"extractProjectFromURI(%q)", tt.uri)
 		})
 	}
 }
@@ -368,23 +287,15 @@ func TestReadVSCodeWorkspaceManifest(t *testing.T) {
 
 	// Valid workspace.json
 	content := `{"folder":"file:///Users/dev/projects/agentsview"}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "workspace.json"),
 		[]byte(content), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
-	project := ReadVSCodeWorkspaceManifest(dir)
-	if project != "agentsview" {
-		t.Errorf("got %q, want %q", project, "agentsview")
-	}
+	assert.Equal(t, "agentsview", ReadVSCodeWorkspaceManifest(dir))
 
 	// Non-existent dir
-	project = ReadVSCodeWorkspaceManifest("/nonexistent")
-	if project != "" {
-		t.Errorf("expected empty, got %q", project)
-	}
+	assert.Empty(t, ReadVSCodeWorkspaceManifest("/nonexistent"))
 }
 
 func TestDiscoverVSCodeCopilotSessions(t *testing.T) {
@@ -395,49 +306,31 @@ func TestDiscoverVSCodeCopilotSessions(t *testing.T) {
 	chatDir := filepath.Join(
 		root, "workspaceStorage", hash, "chatSessions",
 	)
-	if err := os.MkdirAll(chatDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(chatDir, 0755))
 
 	// workspace.json
 	wsJSON := `{"folder":"file:///Users/dev/projects/myproject"}`
 	wsPath := filepath.Join(
 		root, "workspaceStorage", hash, "workspace.json",
 	)
-	if err := os.WriteFile(
-		wsPath, []byte(wsJSON), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(wsPath, []byte(wsJSON), 0644))
 
 	// Chat session file
 	sessionJSON := `{"version":3,"sessionId":"sess1","requests":[{"requestId":"r1","message":{"text":"hi"},"response":[{"value":"hello"}],"timestamp":1755340000000}]}`
 	sessPath := filepath.Join(chatDir, "sess1.json")
-	if err := os.WriteFile(
-		sessPath, []byte(sessionJSON), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(sessPath, []byte(sessionJSON), 0644))
 
 	// globalStorage/emptyWindowChatSessions
 	globalDir := filepath.Join(
 		root, "globalStorage", "emptyWindowChatSessions",
 	)
-	if err := os.MkdirAll(globalDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(globalDir, 0755))
 	globalPath := filepath.Join(globalDir, "global-sess.json")
-	if err := os.WriteFile(
-		globalPath, []byte(sessionJSON), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(globalPath, []byte(sessionJSON), 0644))
 
 	files := DiscoverVSCodeCopilotSessions(root)
 
-	if len(files) != 2 {
-		t.Fatalf("got %d files, want 2", len(files))
-	}
+	require.Len(t, files, 2)
 
 	// Check workspace session
 	var wsFile, globalFile DiscoveredFile
@@ -450,17 +343,10 @@ func TestDiscoverVSCodeCopilotSessions(t *testing.T) {
 		}
 	}
 
-	if wsFile.Path == "" {
-		t.Error("missing workspace session file")
-	}
-	if wsFile.Agent != AgentVSCodeCopilot {
-		t.Errorf("agent: got %q, want %q",
-			wsFile.Agent, AgentVSCodeCopilot)
-	}
+	assert.NotEmpty(t, wsFile.Path, "missing workspace session file")
+	assert.Equal(t, AgentVSCodeCopilot, wsFile.Agent, "agent")
 
-	if globalFile.Path == "" {
-		t.Error("missing global session file")
-	}
+	assert.NotEmpty(t, globalFile.Path, "missing global session file")
 }
 
 func TestNormalizeVSCodeToolName(t *testing.T) {
@@ -488,10 +374,7 @@ func TestNormalizeVSCodeToolName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := normalizeVSCodeToolName(tt.input)
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, normalizeVSCodeToolName(tt.input))
 		})
 	}
 }
@@ -550,26 +433,16 @@ func TestExtractVSCopilotInputJSON(t *testing.T) {
 			got := extractVSCopilotInputJSON(inv, past, td)
 
 			if tt.wantKey == "" {
-				if got != "" {
-					t.Errorf("expected empty, got %q", got)
-				}
+				assert.Empty(t, got, "expected empty")
 				return
 			}
 
 			var m map[string]any
-			if err := json.Unmarshal(
-				[]byte(got), &m,
-			); err != nil {
-				t.Fatalf("invalid JSON: %v", err)
-			}
+			err := json.Unmarshal([]byte(got), &m)
+			require.NoError(t, err, "invalid JSON")
 			val, ok := m[tt.wantKey].(string)
-			if !ok || val != tt.wantVal {
-				t.Errorf(
-					"got %q=%q, want %q=%q",
-					tt.wantKey, val,
-					tt.wantKey, tt.wantVal,
-				)
-			}
+			assert.True(t, ok, "value not a string")
+			assert.Equal(t, tt.wantVal, val, "value for key %q", tt.wantKey)
 		})
 	}
 }
@@ -641,52 +514,29 @@ func TestParseVSCodeCopilotSession_JSONL(t *testing.T) {
 			path := filepath.Join(dir, "test-session.jsonl")
 
 			content := strings.Join(tt.lines, "\n") + "\n"
-			if err := os.WriteFile(
+			require.NoError(t, os.WriteFile(
 				path, []byte(content), 0644,
-			); err != nil {
-				t.Fatal(err)
-			}
+			))
 
 			sess, msgs, err := ParseVSCodeCopilotSession(
 				path, "testproject", "local",
 			)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
 			if tt.wantNil {
-				if sess != nil {
-					t.Fatal("expected nil session")
-				}
+				assert.Nil(t, sess, "expected nil session")
 				return
 			}
 
-			if sess == nil {
-				t.Fatal("expected non-nil session")
-				return
+			require.NotNil(t, sess, "expected non-nil session")
+
+			assert.Len(t, msgs, tt.wantMessages, "messages")
+
+			if tt.wantTitle != "" {
+				assert.Equal(t, tt.wantTitle, sess.FirstMessage, "first message")
 			}
 
-			if len(msgs) != tt.wantMessages {
-				t.Errorf(
-					"messages: got %d, want %d",
-					len(msgs), tt.wantMessages,
-				)
-			}
-
-			if tt.wantTitle != "" &&
-				sess.FirstMessage != tt.wantTitle {
-				t.Errorf(
-					"first message: got %q, want %q",
-					sess.FirstMessage, tt.wantTitle,
-				)
-			}
-
-			if sess.Agent != AgentVSCodeCopilot {
-				t.Errorf(
-					"agent: got %q, want %q",
-					sess.Agent, AgentVSCodeCopilot,
-				)
-			}
+			assert.Equal(t, AgentVSCodeCopilot, sess.Agent, "agent")
 
 			if tt.wantToolUse {
 				found := false
@@ -696,9 +546,7 @@ func TestParseVSCodeCopilotSession_JSONL(t *testing.T) {
 						break
 					}
 				}
-				if !found {
-					t.Error("expected tool use in messages")
-				}
+				assert.True(t, found, "expected tool use in messages")
 			}
 		})
 	}
@@ -718,12 +566,8 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 			check: func(t *testing.T, data []byte) {
 				var m map[string]any
-				if err := json.Unmarshal(data, &m); err != nil {
-					t.Fatal(err)
-				}
-				if m["sessionId"] != "s1" {
-					t.Errorf("sessionId: got %v", m["sessionId"])
-				}
+				require.NoError(t, json.Unmarshal(data, &m))
+				assert.Equal(t, "s1", m["sessionId"], "sessionId")
 			},
 		},
 		{
@@ -734,13 +578,9 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 			check: func(t *testing.T, data []byte) {
 				var m map[string]any
-				if err := json.Unmarshal(data, &m); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, json.Unmarshal(data, &m))
 				a := m["a"].(map[string]any)
-				if a["b"] != "new" {
-					t.Errorf("got %v, want new", a["b"])
-				}
+				assert.Equal(t, "new", a["b"])
 			},
 		},
 		{
@@ -751,16 +591,10 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 			check: func(t *testing.T, data []byte) {
 				var m map[string]any
-				if err := json.Unmarshal(data, &m); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, json.Unmarshal(data, &m))
 				items := m["items"].([]any)
-				if len(items) != 3 {
-					t.Fatalf("len: got %d, want 3", len(items))
-				}
-				if items[2] != "c" {
-					t.Errorf("items[2]: got %v", items[2])
-				}
+				require.Len(t, items, 3, "len")
+				assert.Equal(t, "c", items[2], "items[2]")
 			},
 		},
 		{
@@ -771,16 +605,10 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 			check: func(t *testing.T, data []byte) {
 				var m map[string]any
-				if err := json.Unmarshal(data, &m); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, json.Unmarshal(data, &m))
 				items := m["items"].([]any)
-				if len(items) != 3 {
-					t.Fatalf("len: got %d, want 3", len(items))
-				}
-				if items[0] != "a" || items[1] != "b" || items[2] != "c" {
-					t.Errorf("items: got %v", items)
-				}
+				require.Len(t, items, 3, "len")
+				assert.Equal(t, []any{"a", "b", "c"}, items, "items")
 			},
 		},
 		{
@@ -791,19 +619,11 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 			check: func(t *testing.T, data []byte) {
 				var m map[string]any
-				if err := json.Unmarshal(data, &m); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, json.Unmarshal(data, &m))
 				items := m["items"].([]any)
-				if len(items) != 3 {
-					t.Fatalf("len: got %d, want 3",
-						len(items))
-				}
+				require.Len(t, items, 3, "len")
 				// Negative index clamped to 0: inserted at front
-				if items[0] != "z" {
-					t.Errorf("items[0]: got %v, want z",
-						items[0])
-				}
+				assert.Equal(t, "z", items[0], "items[0]")
 			},
 		},
 		{
@@ -814,15 +634,10 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 			check: func(t *testing.T, data []byte) {
 				var m map[string]any
-				if err := json.Unmarshal(data, &m); err != nil {
-					t.Fatal(err)
-				}
-				if _, ok := m["b"]; ok {
-					t.Error("expected b to be deleted")
-				}
-				if m["a"] != "keep" {
-					t.Errorf("a: got %v", m["a"])
-				}
+				require.NoError(t, json.Unmarshal(data, &m))
+				_, ok := m["b"]
+				assert.False(t, ok, "expected b to be deleted")
+				assert.Equal(t, "keep", m["a"], "a")
 			},
 		},
 		{
@@ -833,22 +648,16 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 			check: func(t *testing.T, data []byte) {
 				var m map[string]any
-				if err := json.Unmarshal(data, &m); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, json.Unmarshal(data, &m))
 				arr := m["arr"].([]any)
-				if arr[1] != "Y" {
-					t.Errorf("arr[1]: got %v", arr[1])
-				}
+				assert.Equal(t, "Y", arr[1], "arr[1]")
 			},
 		},
 		{
 			name:  "empty file returns nil",
 			lines: []string{},
 			check: func(t *testing.T, data []byte) {
-				if data != nil {
-					t.Errorf("expected nil, got %s", data)
-				}
+				assert.Nil(t, data, "expected nil")
 			},
 		},
 	}
@@ -859,22 +668,16 @@ func TestReconstructJSONL(t *testing.T) {
 			path := filepath.Join(dir, "test.jsonl")
 
 			content := strings.Join(tt.lines, "\n") + "\n"
-			if err := os.WriteFile(
+			require.NoError(t, os.WriteFile(
 				path, []byte(content), 0644,
-			); err != nil {
-				t.Fatal(err)
-			}
+			))
 
 			data, err := reconstructJSONL(path)
 			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error")
-				}
+				require.Error(t, err, "expected error")
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 			tt.check(t, data)
 		})
 	}
@@ -887,67 +690,52 @@ func TestDiscoverVSCodeCopilot_JSONLDedup(t *testing.T) {
 	chatDir := filepath.Join(
 		root, "workspaceStorage", hash, "chatSessions",
 	)
-	if err := os.MkdirAll(chatDir, 0755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(chatDir, 0755))
 
 	wsJSON := `{"folder":"file:///Users/dev/projects/myproject"}`
 	wsPath := filepath.Join(
 		root, "workspaceStorage", hash, "workspace.json",
 	)
-	if err := os.WriteFile(
-		wsPath, []byte(wsJSON), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(wsPath, []byte(wsJSON), 0644))
 
 	// Session with both .json and .jsonl - jsonl should win
 	sessionJSON := `{"version":3,"sessionId":"dup1","requests":[{"requestId":"r1","message":{"text":"hi"},"response":[{"value":"hello"}],"timestamp":1755340000000}]}`
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(chatDir, "dup1.json"),
 		[]byte(sessionJSON), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 	jsonlContent := `{"kind":0,"v":{"version":3,"sessionId":"dup1","creationDate":1755340000000,"requests":[{"requestId":"r1","timestamp":1755340000000,"message":{"text":"hi"},"response":[{"value":"hello"}]}]}}` + "\n"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(chatDir, "dup1.jsonl"),
 		[]byte(jsonlContent), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	// Session with only .jsonl
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(chatDir, "only-jsonl.jsonl"),
 		[]byte(jsonlContent), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	// Session with only .json
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		filepath.Join(chatDir, "only-json.json"),
 		[]byte(sessionJSON), 0644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	files := DiscoverVSCodeCopilotSessions(root)
 
 	// Should get 3 files: dup1.jsonl, only-jsonl.jsonl, only-json.json
-	if len(files) != 3 {
+	if !assert.Len(t, files, 3, "expected 3 files") {
 		for _, f := range files {
 			t.Logf("  %s", f.Path)
 		}
-		t.Fatalf("got %d files, want 3", len(files))
+		t.FailNow()
 	}
 
 	// Verify dup1.json was excluded (dup1.jsonl present)
 	for _, f := range files {
-		if filepath.Base(f.Path) == "dup1.json" {
-			t.Error("dup1.json should be excluded when dup1.jsonl exists")
-		}
+		assert.NotEqual(t, "dup1.json", filepath.Base(f.Path),
+			"dup1.json should be excluded when dup1.jsonl exists")
 	}
 }
 
@@ -960,14 +748,8 @@ func TestFindVSCodeCopilotSourceFile(t *testing.T) {
 		dir, "workspaceStorage", "hash1", "chatSessions",
 	)
 	sessionPath := filepath.Join(chatDir, uuid+".json")
-	if err := os.MkdirAll(chatDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(
-		sessionPath, []byte("{}"), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(chatDir, 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte("{}"), 0o644))
 
 	tests := []struct {
 		name string
@@ -988,9 +770,7 @@ func TestFindVSCodeCopilotSourceFile(t *testing.T) {
 			got := FindVSCodeCopilotSourceFile(
 				tt.dir, tt.id,
 			)
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/parser/warp_test.go
+++ b/internal/parser/warp_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // warpSchema matches the relevant tables from Warp's SQLite database.
@@ -50,9 +52,7 @@ func (s *WarpSeeder) AddConversation(
 		 VALUES (?, ?, ?)`,
 		conversationID, conversationData, lastModified,
 	)
-	if err != nil {
-		s.t.Fatalf("add conversation: %v", err)
-	}
+	require.NoError(s.t, err, "add conversation")
 }
 
 func (s *WarpSeeder) AddExchange(
@@ -68,21 +68,16 @@ func (s *WarpSeeder) AddExchange(
 		exchangeID, conversationID, startTS, input,
 		workingDir, outputStatus, modelID,
 	)
-	if err != nil {
-		s.t.Fatalf("add exchange: %v", err)
-	}
+	require.NoError(s.t, err, "add exchange")
 }
 
 func newWarpTestDB(t *testing.T) (string, *WarpSeeder, *sql.DB) {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "warp.sqlite")
 	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatalf("open test db: %v", err)
-	}
-	if _, err := db.Exec(warpSchema); err != nil {
-		t.Fatalf("create schema: %v", err)
-	}
+	require.NoError(t, err, "open test db")
+	_, err = db.Exec(warpSchema)
+	require.NoError(t, err, "create schema")
 	seeder := &WarpSeeder{db: db, t: t}
 	return dbPath, seeder, db
 }
@@ -149,31 +144,24 @@ func TestParseWarpDB_StandardConversation(t *testing.T) {
 	seedWarpConversation(t, seeder)
 
 	sessions, err := ParseWarpDB(dbPath, "testmachine")
-	if err != nil {
-		t.Fatalf("ParseWarpDB: %v", err)
-	}
+	require.NoError(t, err, "ParseWarpDB")
 
-	assertEq(t, "sessions len", len(sessions), 1)
+	require.Len(t, sessions, 1, "sessions len")
 
 	s := sessions[0]
-	assertEq(t, "ID", s.Session.ID, "warp:conv-001")
-	assertEq(t, "Agent", s.Session.Agent, AgentWarp)
-	assertEq(t, "Machine", s.Session.Machine, "testmachine")
-	assertEq(t, "Project", s.Session.Project, "myproject")
-	assertEq(t, "UserMessageCount", s.Session.UserMessageCount, 2)
-	assertEq(t, "FirstMessage",
-		s.Session.FirstMessage,
-		"Fix the JSON parsing bug in parser.go",
-	)
+	assert.Equal(t, "warp:conv-001", s.Session.ID, "ID")
+	assert.Equal(t, AgentWarp, s.Session.Agent, "Agent")
+	assert.Equal(t, "testmachine", s.Session.Machine, "Machine")
+	assert.Equal(t, "myproject", s.Session.Project, "Project")
+	assert.Equal(t, 2, s.Session.UserMessageCount, "UserMessageCount")
+	assert.Equal(t, "Fix the JSON parsing bug in parser.go", s.Session.FirstMessage, "FirstMessage")
 
 	wantPath := dbPath + "#conv-001"
-	assertEq(t, "File.Path", s.Session.File.Path, wantPath)
+	assert.Equal(t, wantPath, s.Session.File.Path, "File.Path")
 
 	// Token usage from conversation_data
-	assertEq(t, "HasTotalOutputTokens",
-		s.Session.HasTotalOutputTokens, true)
-	assertEq(t, "TotalOutputTokens",
-		s.Session.TotalOutputTokens, 100000)
+	assert.True(t, s.Session.HasTotalOutputTokens, "HasTotalOutputTokens")
+	assert.Equal(t, 100000, s.Session.TotalOutputTokens, "TotalOutputTokens")
 
 	// Check user messages
 	var userMsgs, toolMsgs int
@@ -185,9 +173,9 @@ func TestParseWarpDB_StandardConversation(t *testing.T) {
 			toolMsgs++
 		}
 	}
-	assertEq(t, "userMsgs", userMsgs, 2)
+	assert.Equal(t, 2, userMsgs, "userMsgs")
 	// 3 run_command + 2 read_files + 1 grep + 1 apply_file_diff = 7
-	assertEq(t, "toolMsgs", toolMsgs, 7)
+	assert.Equal(t, 7, toolMsgs, "toolMsgs")
 }
 
 func TestParseWarpSession_SingleConversation(t *testing.T) {
@@ -198,24 +186,18 @@ func TestParseWarpSession_SingleConversation(t *testing.T) {
 	sess, msgs, err := ParseWarpSession(
 		dbPath, "conv-001", "testmachine",
 	)
-	if err != nil {
-		t.Fatalf("ParseWarpSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected non-nil session")
-	}
+	require.NoError(t, err, "ParseWarpSession")
+	require.NotNil(t, sess, "expected non-nil session")
 
-	assertEq(t, "ID", sess.ID, "warp:conv-001")
-	assertEq(t, "Agent", sess.Agent, AgentWarp)
+	assert.Equal(t, "warp:conv-001", sess.ID, "ID")
+	assert.Equal(t, AgentWarp, sess.Agent, "Agent")
 
 	// First user message
-	assertEq(t, "msgs[0].Role", msgs[0].Role, RoleUser)
-	assertEq(t, "msgs[0].Content", msgs[0].Content,
-		"Fix the JSON parsing bug in parser.go")
+	assert.Equal(t, RoleUser, msgs[0].Role, "msgs[0].Role")
+	assert.Equal(t, "Fix the JSON parsing bug in parser.go", msgs[0].Content, "msgs[0].Content")
 	// Second user message
-	assertEq(t, "msgs[1].Role", msgs[1].Role, RoleUser)
-	assertEq(t, "msgs[1].Content", msgs[1].Content,
-		"Now add a test for that fix")
+	assert.Equal(t, RoleUser, msgs[1].Role, "msgs[1].Role")
+	assert.Equal(t, "Now add a test for that fix", msgs[1].Content, "msgs[1].Content")
 }
 
 func TestListWarpSessionMeta(t *testing.T) {
@@ -224,17 +206,12 @@ func TestListWarpSessionMeta(t *testing.T) {
 	seedWarpConversation(t, seeder)
 
 	metas, err := ListWarpSessionMeta(dbPath)
-	if err != nil {
-		t.Fatalf("ListWarpSessionMeta: %v", err)
-	}
+	require.NoError(t, err, "ListWarpSessionMeta")
 
-	assertEq(t, "metas len", len(metas), 1)
-	assertEq(t, "SessionID", metas[0].SessionID, "conv-001")
-	assertEq(t, "VirtualPath",
-		metas[0].VirtualPath, dbPath+"#conv-001")
-	if metas[0].FileMtime == 0 {
-		t.Error("expected non-zero FileMtime")
-	}
+	require.Len(t, metas, 1, "metas len")
+	assert.Equal(t, "conv-001", metas[0].SessionID, "SessionID")
+	assert.Equal(t, dbPath+"#conv-001", metas[0].VirtualPath, "VirtualPath")
+	assert.NotZero(t, metas[0].FileMtime, "expected non-zero FileMtime")
 }
 
 func TestParseWarpDB_EmptyConversation(t *testing.T) {
@@ -246,10 +223,8 @@ func TestParseWarpDB_EmptyConversation(t *testing.T) {
 	)
 
 	sessions, err := ParseWarpDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseWarpDB: %v", err)
-	}
-	assertEq(t, "sessions len", len(sessions), 0)
+	require.NoError(t, err, "ParseWarpDB")
+	assert.Empty(t, sessions, "sessions len")
 }
 
 func TestParseWarpDB_NoQueryText(t *testing.T) {
@@ -267,22 +242,16 @@ func TestParseWarpDB_NoQueryText(t *testing.T) {
 	)
 
 	sessions, err := ParseWarpDB(dbPath, "m")
-	if err != nil {
-		t.Fatalf("ParseWarpDB: %v", err)
-	}
-	assertEq(t, "sessions len", len(sessions), 0)
+	require.NoError(t, err, "ParseWarpDB")
+	assert.Empty(t, sessions, "sessions len")
 }
 
 func TestParseWarpDB_NonExistent(t *testing.T) {
 	sessions, err := ParseWarpDB(
 		"/nonexistent/warp.sqlite", "m",
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if sessions != nil {
-		t.Error("expected nil sessions for non-existent db")
-	}
+	require.NoError(t, err)
+	assert.Nil(t, sessions, "expected nil sessions for non-existent db")
 }
 
 func TestExtractWarpQueryText(t *testing.T) {
@@ -301,7 +270,7 @@ func TestExtractWarpQueryText(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := extractWarpQueryText(tc.input)
-			assertEq(t, "text", got, tc.want)
+			assert.Equal(t, tc.want, got, "text")
 		})
 	}
 }
@@ -319,12 +288,9 @@ func TestParseWarpTimestamp(t *testing.T) {
 	for _, tc := range tests {
 		ts := parseWarpTimestamp(tc.input)
 		if tc.year == 0 {
-			if !ts.IsZero() {
-				t.Errorf("expected zero time for %q", tc.input)
-			}
-		} else if ts.Year() != tc.year {
-			t.Errorf("year = %d, want %d for %q",
-				ts.Year(), tc.year, tc.input)
+			assert.True(t, ts.IsZero(), "expected zero time for %q", tc.input)
+		} else {
+			assert.Equal(t, tc.year, ts.Year(), "year for %q", tc.input)
 		}
 	}
 }
@@ -335,19 +301,15 @@ func TestFindWarpDBPath(t *testing.T) {
 	dbPath := filepath.Join(dir, "warp.sqlite")
 
 	// Before creating the file
-	assertEq(t, "not found", FindWarpDBPath(dir), "")
+	assert.Empty(t, FindWarpDBPath(dir), "not found")
 
 	// Create the file (sql.Open is lazy; Ping forces creation)
 	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.Ping(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, db.Ping())
 	db.Close()
 
-	assertEq(t, "found", FindWarpDBPath(dir), dbPath)
+	assert.Equal(t, dbPath, FindWarpDBPath(dir), "found")
 }
 
 func TestParseWarpConversationMeta(t *testing.T) {
@@ -376,17 +338,17 @@ func TestParseWarpConversationMeta(t *testing.T) {
 	}`
 
 	meta := parseWarpConversationMeta(data)
-	assertEq(t, "totalTokens", meta.totalTokens, 1700)
-	assertEq(t, "RunCommand", meta.toolStats.RunCommand, 5)
-	assertEq(t, "ReadFiles", meta.toolStats.ReadFiles, 3)
-	assertEq(t, "Grep", meta.toolStats.Grep, 2)
-	assertEq(t, "ApplyFileDiff", meta.toolStats.ApplyFileDiff, 1)
+	assert.Equal(t, 1700, meta.totalTokens, "totalTokens")
+	assert.Equal(t, 5, meta.toolStats.RunCommand, "RunCommand")
+	assert.Equal(t, 3, meta.toolStats.ReadFiles, "ReadFiles")
+	assert.Equal(t, 2, meta.toolStats.Grep, "Grep")
+	assert.Equal(t, 1, meta.toolStats.ApplyFileDiff, "ApplyFileDiff")
 }
 
 func TestParseWarpConversationMeta_Empty(t *testing.T) {
 	meta := parseWarpConversationMeta("{}")
-	assertEq(t, "totalTokens", meta.totalTokens, 0)
-	assertEq(t, "RunCommand", meta.toolStats.RunCommand, 0)
+	assert.Equal(t, 0, meta.totalTokens, "totalTokens")
+	assert.Equal(t, 0, meta.toolStats.RunCommand, "RunCommand")
 }
 
 func TestSynthesizeWarpToolMessages(t *testing.T) {
@@ -403,24 +365,17 @@ func TestSynthesizeWarpToolMessages(t *testing.T) {
 		"auto", &ordinal,
 	)
 
-	assertEq(t, "msgs len", len(msgs), 3) // 2 + 1
-	assertEq(t, "ordinal after", ordinal, 3)
+	require.Len(t, msgs, 3, "msgs len") // 2 + 1
+	assert.Equal(t, 3, ordinal, "ordinal after")
 
 	// All should be assistant messages with tool use
 	for _, m := range msgs {
-		assertEq(t, "Role", m.Role, RoleAssistant)
-		if !m.HasToolUse {
-			t.Error("expected HasToolUse=true")
-		}
-		if len(m.ToolCalls) != 1 {
-			t.Errorf("expected 1 tool call, got %d",
-				len(m.ToolCalls))
-		}
+		assert.Equal(t, RoleAssistant, m.Role, "Role")
+		assert.True(t, m.HasToolUse, "expected HasToolUse=true")
+		assert.Len(t, m.ToolCalls, 1)
 	}
 
 	// Check categories
-	assertEq(t, "tc[0].Category",
-		msgs[0].ToolCalls[0].Category, "Bash")
-	assertEq(t, "tc[2].Category",
-		msgs[2].ToolCalls[0].Category, "Read")
+	assert.Equal(t, "Bash", msgs[0].ToolCalls[0].Category, "tc[0].Category")
+	assert.Equal(t, "Read", msgs[2].ToolCalls[0].Category, "tc[2].Category")
 }

--- a/internal/parser/workbuddy_test.go
+++ b/internal/parser/workbuddy_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -15,315 +17,197 @@ func TestDiscoverWorkBuddySessions(t *testing.T) {
 	subPath := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
 	toolPath := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111", "tool-results", "tool_123.txt")
 	for _, path := range []string{mainPath, subPath, toolPath} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", path, err)
-		}
-		if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
-			t.Fatalf("WriteFile(%q): %v", path, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "MkdirAll(%q)", path)
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644), "WriteFile(%q)", path)
 	}
 
 	files := DiscoverWorkBuddySessions(root)
-	if len(files) != 2 {
-		t.Fatalf("len(files) = %d, want 2", len(files))
-	}
-	if files[0].Path != mainPath || files[0].Project != "proj" || files[0].Agent != AgentWorkBuddy {
-		t.Fatalf("files[0] = %+v", files[0])
-	}
-	if files[1].Path != subPath || files[1].Project != "proj" || files[1].Agent != AgentWorkBuddy {
-		t.Fatalf("files[1] = %+v", files[1])
-	}
+	require.Len(t, files, 2)
+	assert.Equal(t, mainPath, files[0].Path)
+	assert.Equal(t, "proj", files[0].Project)
+	assert.Equal(t, AgentWorkBuddy, files[0].Agent)
+	assert.Equal(t, subPath, files[1].Path)
+	assert.Equal(t, "proj", files[1].Project)
+	assert.Equal(t, AgentWorkBuddy, files[1].Agent)
 }
 
 func TestParseWorkBuddySession(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "proj", "11111111-1111-4111-8111-111111111111.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	content := `{"id":"u1","timestamp":1778749186168,"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}],"sessionId":"11111111-1111-4111-8111-111111111111","cwd":"/tmp/proj"}
 {"id":"a1","timestamp":1778749187168,"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}],"sessionId":"11111111-1111-4111-8111-111111111111","providerData":{"model":"gpt-5.5","usage":{"inputTokens":20,"outputTokens":4,"cacheReadInputTokens":5}}}
 {"id":"fc1","timestamp":1778749188168,"type":"function_call","name":"Bash","callId":"call_1","arguments":"{\"command\":\"pwd\"}","providerData":{"model":"gpt-5.5","usage":{"inputTokens":10,"outputTokens":3,"cacheReadInputTokens":2}}}
 {"id":"fr1","timestamp":1778749189168,"type":"function_call_result","name":"Bash","callId":"call_1","output":{"type":"text","text":"/tmp/proj"}}
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	sess, msgs, err := ParseWorkBuddySession(path, "proj", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess == nil {
-		t.Fatal("session nil")
-	}
-	if sess.ID != "workbuddy:11111111-1111-4111-8111-111111111111" {
-		t.Fatalf("ID = %q", sess.ID)
-	}
-	if sess.Project != "proj" {
-		t.Fatalf("Project = %q", sess.Project)
-	}
-	if sess.Cwd != "/tmp/proj" || sess.FirstMessage != "hello" || sess.UserMessageCount != 1 {
-		t.Fatalf("session = %+v", sess)
-	}
-	if !sess.HasTotalOutputTokens || sess.TotalOutputTokens != 7 {
-		t.Fatalf("TotalOutputTokens = %d known=%v", sess.TotalOutputTokens, sess.HasTotalOutputTokens)
-	}
-	if len(msgs) != 4 {
-		t.Fatalf("len(msgs) = %d", len(msgs))
-	}
-	if gjson.GetBytes(msgs[1].TokenUsage, "input_tokens").Int() != 20 {
-		t.Fatalf("assistant message TokenUsage = %s", string(msgs[1].TokenUsage))
-	}
-	if msgs[2].Role != RoleAssistant || !msgs[2].HasToolUse || msgs[2].ToolCalls[0].ToolName != "Bash" {
-		t.Fatalf("tool call msg = %+v", msgs[2])
-	}
-	if msgs[2].ToolCalls[0].InputJSON != `{"command":"pwd"}` {
-		t.Fatalf("InputJSON = %q", msgs[2].ToolCalls[0].InputJSON)
-	}
-	if gjson.GetBytes(msgs[2].TokenUsage, "input_tokens").Int() != 10 {
-		t.Fatalf("TokenUsage = %s", string(msgs[2].TokenUsage))
-	}
-	if msgs[3].Role != RoleUser || msgs[3].ToolResults[0].ToolUseID != "call_1" {
-		t.Fatalf("tool result msg = %+v", msgs[3])
-	}
+	require.NoError(t, err)
+	require.NotNil(t, sess, "session nil")
+	assert.Equal(t, "workbuddy:11111111-1111-4111-8111-111111111111", sess.ID)
+	assert.Equal(t, "proj", sess.Project)
+	assert.Equal(t, "/tmp/proj", sess.Cwd)
+	assert.Equal(t, "hello", sess.FirstMessage)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 7, sess.TotalOutputTokens)
+	require.Len(t, msgs, 4)
+	assert.Equal(t, int64(20), gjson.GetBytes(msgs[1].TokenUsage, "input_tokens").Int(),
+		"assistant message TokenUsage = %s", string(msgs[1].TokenUsage))
+	assert.Equal(t, RoleAssistant, msgs[2].Role)
+	assert.True(t, msgs[2].HasToolUse)
+	require.NotEmpty(t, msgs[2].ToolCalls)
+	assert.Equal(t, "Bash", msgs[2].ToolCalls[0].ToolName)
+	assert.Equal(t, `{"command":"pwd"}`, msgs[2].ToolCalls[0].InputJSON)
+	assert.Equal(t, int64(10), gjson.GetBytes(msgs[2].TokenUsage, "input_tokens").Int(),
+		"TokenUsage = %s", string(msgs[2].TokenUsage))
+	assert.Equal(t, RoleUser, msgs[3].Role)
+	require.NotEmpty(t, msgs[3].ToolResults)
+	assert.Equal(t, "call_1", msgs[3].ToolResults[0].ToolUseID)
 }
 
 func TestParseWorkBuddySessionDoesNotDoubleCountOpenAICachedTokens(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "proj", "11111111-1111-4111-8111-111111111111.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	content := `{"id":"a1","timestamp":1778749187168,"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}],"sessionId":"11111111-1111-4111-8111-111111111111","providerData":{"model":"gpt-5.5","rawUsage":{"prompt_tokens":20,"completion_tokens":4,"prompt_tokens_details":{"cached_tokens":5}}}}
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	sess, msgs, err := ParseWorkBuddySession(path, "proj", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess == nil {
-		t.Fatal("session nil")
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("len(msgs) = %d", len(msgs))
-	}
-	if !msgs[0].HasContextTokens || msgs[0].ContextTokens != 20 {
-		t.Fatalf("ContextTokens = %d known=%v", msgs[0].ContextTokens, msgs[0].HasContextTokens)
-	}
-	if got := gjson.GetBytes(msgs[0].TokenUsage, "input_tokens").Int(); got != 15 {
-		t.Fatalf("input_tokens = %d, want 15; usage=%s", got, string(msgs[0].TokenUsage))
-	}
-	if got := gjson.GetBytes(msgs[0].TokenUsage, "cache_read_input_tokens").Int(); got != 5 {
-		t.Fatalf("cache_read_input_tokens = %d, want 5; usage=%s", got, string(msgs[0].TokenUsage))
-	}
+	require.NoError(t, err)
+	require.NotNil(t, sess, "session nil")
+	require.Len(t, msgs, 1)
+	assert.True(t, msgs[0].HasContextTokens)
+	assert.Equal(t, 20, msgs[0].ContextTokens)
+	assert.Equal(t, int64(15), gjson.GetBytes(msgs[0].TokenUsage, "input_tokens").Int(),
+		"input_tokens; usage=%s", string(msgs[0].TokenUsage))
+	assert.Equal(t, int64(5), gjson.GetBytes(msgs[0].TokenUsage, "cache_read_input_tokens").Int(),
+		"cache_read_input_tokens; usage=%s", string(msgs[0].TokenUsage))
 }
 
 func TestParseWorkBuddySessionUsesCwdProjectAndFileSessionID(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "stored-project", "22222222-2222-4222-8222-222222222222.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	// A non-git working directory under a controlled temp root so
 	// ExtractProjectFromCwd falls through to the basename and applies
 	// NormalizeName (hyphen -> underscore) deterministically.
 	cwd := filepath.Join(tmp, "code", "cwd-project")
-	if err := os.MkdirAll(cwd, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(cwd, 0o755))
 	content := fmt.Sprintf(`{"timestamp":1778749186168,"type":"message","role":"user","content":[{"text":"hello"}],"sessionId":"11111111-1111-4111-8111-111111111111","cwd":%q}
 `, cwd)
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	sess, _, err := ParseWorkBuddySession(path, "stored-project", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess.ID != "workbuddy:22222222-2222-4222-8222-222222222222" {
-		t.Fatalf("ID = %q", sess.ID)
-	}
-	if sess.Project != "cwd_project" {
-		t.Fatalf("Project = %q, want cwd_project", sess.Project)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "workbuddy:22222222-2222-4222-8222-222222222222", sess.ID)
+	assert.Equal(t, "cwd_project", sess.Project)
 }
 
 func TestParseWorkBuddySessionNormalizesWindowsCwdProject(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "stored", "33333333-3333-4333-8333-333333333333.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	content := `{"timestamp":1778749186168,"type":"message","role":"user","content":[{"text":"hi"}],"sessionId":"33333333-3333-4333-8333-333333333333","cwd":"C:\\Users\\alice\\projects\\report-builder"}
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	sess, _, err := ParseWorkBuddySession(path, "stored", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess.Project != "report_builder" {
-		t.Fatalf("Project = %q, want report_builder", sess.Project)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "report_builder", sess.Project)
 }
 
 func TestParseWorkBuddySessionFallsBackToDiscoveredProjectWhenCwdHasNoProject(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "discovered-proj", "44444444-4444-4444-8444-444444444444.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	content := `{"timestamp":1778749186168,"type":"message","role":"user","content":[{"text":"hi"}],"sessionId":"44444444-4444-4444-8444-444444444444","cwd":"/"}
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	sess, _, err := ParseWorkBuddySession(path, "discovered-proj", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess.Project != "discovered-proj" {
-		t.Fatalf("Project = %q, want discovered-proj", sess.Project)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "discovered-proj", sess.Project)
 }
 
 func TestParseWorkBuddySessionOmitsAbsentTokenUsageKeys(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "proj", "11111111-1111-4111-8111-111111111111.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	content := `{"id":"a1","timestamp":1778749187168,"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}],"sessionId":"11111111-1111-4111-8111-111111111111","providerData":{"model":"gpt-5.5","usage":{"inputTokens":20}}}
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	_, msgs, err := ParseWorkBuddySession(path, "proj", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("len(msgs) = %d", len(msgs))
-	}
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
 	m := msgs[0]
-	if m.HasOutputTokens {
-		t.Fatalf("HasOutputTokens = true, want false; usage=%s", string(m.TokenUsage))
-	}
-	if gjson.GetBytes(m.TokenUsage, "output_tokens").Exists() {
-		t.Fatalf("output_tokens key present, want absent; usage=%s", string(m.TokenUsage))
-	}
-	if got := gjson.GetBytes(m.TokenUsage, "input_tokens").Int(); got != 20 {
-		t.Fatalf("input_tokens = %d, want 20; usage=%s", got, string(m.TokenUsage))
-	}
+	assert.False(t, m.HasOutputTokens, "HasOutputTokens; usage=%s", string(m.TokenUsage))
+	assert.False(t, gjson.GetBytes(m.TokenUsage, "output_tokens").Exists(),
+		"output_tokens key present; usage=%s", string(m.TokenUsage))
+	assert.Equal(t, int64(20), gjson.GetBytes(m.TokenUsage, "input_tokens").Int(),
+		"input_tokens; usage=%s", string(m.TokenUsage))
 	// The DB coverage backfill re-derives presence from JSON keys, so
 	// an absent output field must not be inferred as output coverage.
 	_, hasOutput := InferTokenPresence(m.TokenUsage, m.ContextTokens, m.OutputTokens, false, false)
-	if hasOutput {
-		t.Fatalf("InferTokenPresence inferred output coverage for input-only usage; usage=%s", string(m.TokenUsage))
-	}
+	assert.False(t, hasOutput, "InferTokenPresence inferred output coverage for input-only usage; usage=%s", string(m.TokenUsage))
 }
 
 func TestParseWorkBuddySubagentSession(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "proj", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	content := `{"timestamp":1778749186168,"type":"message","role":"user","content":[{"text":"sub task"}],"cwd":"/tmp/cwd-project"}
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	sess, _, err := ParseWorkBuddySession(path, "proj", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess.ID != "workbuddy:11111111-1111-4111-8111-111111111111:subagent:agent-123" {
-		t.Fatalf("ID = %q", sess.ID)
-	}
-	if sess.ParentSessionID != "workbuddy:11111111-1111-4111-8111-111111111111" || sess.RelationshipType != RelSubagent {
-		t.Fatalf("relationship = %q parent=%q", sess.RelationshipType, sess.ParentSessionID)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "workbuddy:11111111-1111-4111-8111-111111111111:subagent:agent-123", sess.ID)
+	assert.Equal(t, "workbuddy:11111111-1111-4111-8111-111111111111", sess.ParentSessionID)
+	assert.Equal(t, RelSubagent, sess.RelationshipType)
 }
 
 func TestFindWorkBuddySourceFile(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
 	got := FindWorkBuddySourceFile(root, "workbuddy:11111111-1111-4111-8111-111111111111")
-	if got != path {
-		t.Fatalf("got %q, want %q", got, path)
-	}
+	assert.Equal(t, path, got)
 }
 
 func TestFindWorkBuddySourceFileRejectsInvalidSubagentID(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
 
 	got := FindWorkBuddySourceFile(root, "workbuddy:11111111-1111-4111-8111-111111111111:subagent:../agent-123")
-	if got != "" {
-		t.Fatalf("got %q, want empty path", got)
-	}
+	assert.Empty(t, got, "want empty path")
 }
 
 func TestParseWorkBuddyProjectNamedSubagentsIsNotSubagent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "subagents", "11111111-1111-4111-8111-111111111111.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	content := `{"timestamp":1778749186168,"type":"message","role":"user","content":[{"text":"hello"}]}
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	sess, _, err := ParseWorkBuddySession(path, "subagents", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if sess.ID != "workbuddy:11111111-1111-4111-8111-111111111111" {
-		t.Fatalf("ID = %q", sess.ID)
-	}
-	if sess.ParentSessionID != "" || sess.RelationshipType != RelNone {
-		t.Fatalf("relationship = %q parent=%q", sess.RelationshipType, sess.ParentSessionID)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "workbuddy:11111111-1111-4111-8111-111111111111", sess.ID)
+	assert.Empty(t, sess.ParentSessionID)
+	assert.Equal(t, RelNone, sess.RelationshipType)
 }
 
 func TestParseWorkBuddySessionDecodesObjectToolResultText(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "proj", "11111111-1111-4111-8111-111111111111.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	content := `{"id":"fr1","timestamp":1778749189168,"type":"function_call_result","name":"Bash","callId":"call_1","output":{"type":"text","text":"/tmp/proj"}}
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	_, msgs, err := ParseWorkBuddySession(path, "proj", "local")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(msgs) != 1 || len(msgs[0].ToolResults) != 1 {
-		t.Fatalf("messages = %+v", msgs)
-	}
-	if got := DecodeContent(msgs[0].ToolResults[0].ContentRaw); got != "/tmp/proj" {
-		t.Fatalf("DecodeContent = %q, want %q; ContentRaw=%s",
-			got, "/tmp/proj", msgs[0].ToolResults[0].ContentRaw)
-	}
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].ToolResults, 1)
+	assert.Equal(t, "/tmp/proj", DecodeContent(msgs[0].ToolResults[0].ContentRaw),
+		"ContentRaw=%s", msgs[0].ToolResults[0].ContentRaw)
 }

--- a/internal/postgres/analytics_autonomy_pgtest_test.go
+++ b/internal/postgres/analytics_autonomy_pgtest_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -30,15 +33,11 @@ func TestStoreGetAnalyticsSessionShape_AutonomyExcludesSystemUsers(
 		"autonomy-test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := time.Now().UTC().Add(-1 * time.Hour).
 		Format(time.RFC3339)
@@ -52,9 +51,7 @@ func TestStoreGetAnalyticsSessionShape_AutonomyExcludesSystemUsers(
 		StartedAt:    &started,
 		MessageCount: 8,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
 
 	msgs := []db.Message{
 		{
@@ -86,51 +83,35 @@ func TestStoreGetAnalyticsSessionShape_AutonomyExcludesSystemUsers(
 			Content:    "tool call",
 		})
 	}
-	if err := local.InsertMessages(msgs); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, local.InsertMessages(msgs), "insert messages")
 
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("push: %v", err)
-	}
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "push")
 
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	resp, err := store.GetAnalyticsSessionShape(
 		ctx, db.AnalyticsFilter{},
 	)
-	if err != nil {
-		t.Fatalf("GetAnalyticsSessionShape: %v", err)
-	}
+	require.NoError(t, err, "GetAnalyticsSessionShape")
 
 	// Promoted system rows must be excluded: ratio = 4/1 = 4.0 → "2-5".
 	// Regression case (counts all role='user'): 4/4 = 1.0 → "1-2".
 	want := map[string]int{"2-5": 1}
 	for label, got := range mapAutonomy(resp.AutonomyDistribution) {
-		if got != want[label] {
-			t.Errorf(
-				"AutonomyDistribution[%q] = %d, want %d (full: %+v)",
-				label, got, want[label], resp.AutonomyDistribution,
-			)
-		}
+		assert.Equal(t, want[label], got,
+			"AutonomyDistribution[%q] (full: %+v)",
+			label, resp.AutonomyDistribution)
 	}
-	if resp.AutonomyDistribution == nil ||
-		bucketCount(resp.AutonomyDistribution, "1-2") != 0 {
-		t.Errorf(
-			"expected zero sessions in '1-2' bucket; got %+v",
-			resp.AutonomyDistribution,
-		)
-	}
-	if bucketCount(resp.AutonomyDistribution, "2-5") != 1 {
-		t.Errorf(
-			"expected 1 session in '2-5' bucket; got %+v",
-			resp.AutonomyDistribution,
-		)
-	}
+	require.NotNil(t, resp.AutonomyDistribution)
+	assert.Equal(t, 0, bucketCount(resp.AutonomyDistribution, "1-2"),
+		"expected zero sessions in '1-2' bucket; got %+v",
+		resp.AutonomyDistribution)
+	assert.Equal(t, 1, bucketCount(resp.AutonomyDistribution, "2-5"),
+		"expected 1 session in '2-5' bucket; got %+v",
+		resp.AutonomyDistribution)
 }
 
 // mapAutonomy and bucketCount flatten the bucket slice so the

--- a/internal/postgres/analytics_pgtest_test.go
+++ b/internal/postgres/analytics_pgtest_test.go
@@ -3,6 +3,9 @@ package postgres
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -13,11 +16,10 @@ func TestRankTopSessions_DurationSort(t *testing.T) {
 		{ID: "c", DurationMin: 20.0},
 	}
 	got := rankTopSessions(sessions, true)
-	if got[0].ID != "b" || got[1].ID != "c" ||
-		got[2].ID != "a" {
-		t.Errorf("expected b,c,a order, got %s,%s,%s",
-			got[0].ID, got[1].ID, got[2].ID)
-	}
+	require.Len(t, got, 3)
+	assert.Equal(t, "b", got[0].ID)
+	assert.Equal(t, "c", got[1].ID)
+	assert.Equal(t, "a", got[2].ID)
 }
 
 func TestRankTopSessions_DurationTieBreaker(t *testing.T) {
@@ -27,12 +29,10 @@ func TestRankTopSessions_DurationTieBreaker(t *testing.T) {
 		{ID: "m", DurationMin: 5.0},
 	}
 	got := rankTopSessions(sessions, true)
-	if got[0].ID != "a" || got[1].ID != "m" ||
-		got[2].ID != "z" {
-		t.Errorf(
-			"expected a,m,z tie-break order, got %s,%s,%s",
-			got[0].ID, got[1].ID, got[2].ID)
-	}
+	require.Len(t, got, 3)
+	assert.Equal(t, "a", got[0].ID)
+	assert.Equal(t, "m", got[1].ID)
+	assert.Equal(t, "z", got[2].ID)
 }
 
 func TestRankTopSessions_NearTiePrecision(t *testing.T) {
@@ -41,15 +41,10 @@ func TestRankTopSessions_NearTiePrecision(t *testing.T) {
 		{ID: "b", DurationMin: 10.06},
 	}
 	got := rankTopSessions(sessions, true)
-	if got[0].ID != "b" {
-		t.Errorf("expected b first (10.06 > 10.04), got %s",
-			got[0].ID)
-	}
-	if got[0].DurationMin != 10.1 ||
-		got[1].DurationMin != 10.0 {
-		t.Errorf("expected rounded 10.1, 10.0; got %.1f, %.1f",
-			got[0].DurationMin, got[1].DurationMin)
-	}
+	require.Len(t, got, 2)
+	assert.Equal(t, "b", got[0].ID, "10.06 > 10.04")
+	assert.Equal(t, 10.1, got[0].DurationMin)
+	assert.Equal(t, 10.0, got[1].DurationMin)
 }
 
 func TestRankTopSessions_TruncatesTo10(t *testing.T) {
@@ -61,14 +56,8 @@ func TestRankTopSessions_TruncatesTo10(t *testing.T) {
 		}
 	}
 	got := rankTopSessions(sessions, true)
-	if len(got) != 10 {
-		t.Errorf("expected 10 sessions, got %d", len(got))
-	}
-	if got[0].DurationMin != 14.0 {
-		t.Errorf(
-			"expected first session duration 14.0, got %.1f",
-			got[0].DurationMin)
-	}
+	require.Len(t, got, 10)
+	assert.Equal(t, 14.0, got[0].DurationMin)
 }
 
 func TestRankTopSessions_NoSortForMessages(t *testing.T) {
@@ -78,23 +67,16 @@ func TestRankTopSessions_NoSortForMessages(t *testing.T) {
 		{ID: "b", MessageCount: 20},
 	}
 	got := rankTopSessions(sessions, false)
-	if got[0].ID != "c" || got[1].ID != "a" ||
-		got[2].ID != "b" {
-		t.Errorf(
-			"expected preserved order c,a,b, got %s,%s,%s",
-			got[0].ID, got[1].ID, got[2].ID)
-	}
+	require.Len(t, got, 3)
+	assert.Equal(t, "c", got[0].ID)
+	assert.Equal(t, "a", got[1].ID)
+	assert.Equal(t, "b", got[2].ID)
 }
 
 func TestRankTopSessions_NilInput(t *testing.T) {
 	got := rankTopSessions(nil, true)
-	if got == nil {
-		t.Error("expected non-nil empty slice, got nil")
-	}
-	if len(got) != 0 {
-		t.Errorf("expected empty slice, got %d elements",
-			len(got))
-	}
+	require.NotNil(t, got, "expected non-nil empty slice")
+	assert.Empty(t, got)
 }
 
 func TestRankTopSessions_RoundsForDisplay(t *testing.T) {
@@ -103,12 +85,7 @@ func TestRankTopSessions_RoundsForDisplay(t *testing.T) {
 		{ID: "b", DurationMin: 12.351},
 	}
 	got := rankTopSessions(sessions, true)
-	if got[0].DurationMin != 12.4 {
-		t.Errorf("expected 12.4, got %v",
-			got[0].DurationMin)
-	}
-	if got[1].DurationMin != 12.3 {
-		t.Errorf("expected 12.3, got %v",
-			got[1].DurationMin)
-	}
+	require.Len(t, got, 2)
+	assert.Equal(t, 12.4, got[0].DurationMin)
+	assert.Equal(t, 12.3, got[1].DurationMin)
 }

--- a/internal/postgres/analytics_signals_pgtest_test.go
+++ b/internal/postgres/analytics_signals_pgtest_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -26,15 +29,11 @@ func TestStoreGetAnalyticsSignals(t *testing.T) {
 		"signals-test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	score := 90
 	grade := "A"
@@ -53,10 +52,9 @@ func TestStoreGetAnalyticsSignals(t *testing.T) {
 			StartedAt:    &started,
 			MessageCount: 4,
 		}
-		if err := local.UpsertSession(sess); err != nil {
-			t.Fatalf("upsert %s: %v", id, err)
-		}
-		if err := local.UpdateSessionSignals(
+		require.NoError(t, local.UpsertSession(sess),
+			"upsert %s", id)
+		require.NoError(t, local.UpdateSessionSignals(
 			id,
 			db.SessionSignalUpdate{
 				Outcome:                "completed",
@@ -71,19 +69,14 @@ func TestStoreGetAnalyticsSignals(t *testing.T) {
 				HealthScore:            &score,
 				HealthGrade:            &grade,
 			},
-		); err != nil {
-			t.Fatalf("UpdateSessionSignals %s: %v", id, err)
-		}
+		), "UpdateSessionSignals %s", id)
 	}
 
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("push: %v", err)
-	}
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "push")
 
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	// Empty AnalyticsFilter must be accepted -- exercises the
@@ -92,56 +85,19 @@ func TestStoreGetAnalyticsSignals(t *testing.T) {
 	resp, err := store.GetAnalyticsSignals(
 		ctx, db.AnalyticsFilter{},
 	)
-	if err != nil {
-		t.Fatalf("GetAnalyticsSignals: %v", err)
-	}
+	require.NoError(t, err, "GetAnalyticsSignals")
 
-	if resp.ScoredSessions != 2 {
-		t.Errorf(
-			"ScoredSessions = %d, want 2",
-			resp.ScoredSessions,
-		)
-	}
-	if resp.GradeDistribution["A"] != 2 {
-		t.Errorf(
-			"GradeDistribution[A] = %d, want 2",
-			resp.GradeDistribution["A"],
-		)
-	}
-	if resp.OutcomeDistribution["completed"] != 2 {
-		t.Errorf(
-			"OutcomeDistribution[completed] = %d, want 2",
-			resp.OutcomeDistribution["completed"],
-		)
-	}
-	if resp.AvgHealthScore == nil ||
-		*resp.AvgHealthScore != 90 {
-		t.Errorf(
-			"AvgHealthScore = %v, want 90", resp.AvgHealthScore,
-		)
-	}
-	if resp.ContextHealth.MidTaskCompactionCount != 2 {
-		t.Errorf(
-			"MidTaskCompactionCount = %d, want 2",
-			resp.ContextHealth.MidTaskCompactionCount,
-		)
-	}
-	if resp.ToolHealth.TotalFailureSignals != 2 {
-		t.Errorf(
-			"TotalFailureSignals = %d, want 2",
-			resp.ToolHealth.TotalFailureSignals,
-		)
-	}
-	if len(resp.ByAgent) != 1 ||
-		resp.ByAgent[0].Agent != "claude" ||
-		resp.ByAgent[0].SessionCount != 2 {
-		t.Errorf("ByAgent = %+v, want [claude / 2]", resp.ByAgent)
-	}
-	if len(resp.ByProject) != 1 ||
-		resp.ByProject[0].Project != "proj" ||
-		resp.ByProject[0].SessionCount != 2 {
-		t.Errorf(
-			"ByProject = %+v, want [proj / 2]", resp.ByProject,
-		)
-	}
+	assert.Equal(t, 2, resp.ScoredSessions)
+	assert.Equal(t, 2, resp.GradeDistribution["A"])
+	assert.Equal(t, 2, resp.OutcomeDistribution["completed"])
+	require.NotNil(t, resp.AvgHealthScore)
+	assert.Equal(t, 90.0, *resp.AvgHealthScore)
+	assert.Equal(t, 2, resp.ContextHealth.MidTaskCompactionCount)
+	assert.Equal(t, 2, resp.ToolHealth.TotalFailureSignals)
+	require.Len(t, resp.ByAgent, 1)
+	assert.Equal(t, "claude", resp.ByAgent[0].Agent)
+	assert.Equal(t, 2, resp.ByAgent[0].SessionCount)
+	require.Len(t, resp.ByProject, 1)
+	assert.Equal(t, "proj", resp.ByProject[0].Project)
+	assert.Equal(t, 2, resp.ByProject[0].SessionCount)
 }

--- a/internal/postgres/automated_pgtest_test.go
+++ b/internal/postgres/automated_pgtest_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -29,7 +32,7 @@ func TestPushSessionTrustsLocalIsAutomated(t *testing.T) {
 	// sets is_automated=1 on the SQLite row.
 	db.SetUserAutomationPrefixes([]string{"You are analyzing an essay"})
 	fm := "You are analyzing an essay about epistemology."
-	if err := local.UpsertSession(db.Session{
+	require.NoError(t, local.UpsertSession(db.Session{
 		ID:               "essay-1",
 		Project:          "proj",
 		Machine:          "local",
@@ -38,9 +41,7 @@ func TestPushSessionTrustsLocalIsAutomated(t *testing.T) {
 		MessageCount:     2,
 		UserMessageCount: 1,
 		CreatedAt:        time.Now().UTC().Format(time.RFC3339Nano),
-	}); err != nil {
-		t.Fatalf("upsert: %v", err)
-	}
+	}), "upsert")
 
 	// Clear the user prefix so a recompute in pushSession
 	// would now classify this row as is_automated=0. If
@@ -52,9 +53,7 @@ func TestPushSessionTrustsLocalIsAutomated(t *testing.T) {
 		"trust-test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx, cancel := context.WithTimeout(
@@ -62,23 +61,17 @@ func TestPushSessionTrustsLocalIsAutomated(t *testing.T) {
 	)
 	defer cancel()
 
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("push: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "push")
 
 	var got bool
-	if err := ps.DB().QueryRowContext(ctx,
+	require.NoError(t, ps.DB().QueryRowContext(ctx,
 		`SELECT is_automated FROM sessions WHERE id = $1`,
 		"essay-1",
-	).Scan(&got); err != nil {
-		t.Fatalf("query pg: %v", err)
-	}
-	if !got {
-		t.Error("pushSession recomputed is_automated; expected to trust local value")
-	}
+	).Scan(&got), "query pg")
+	assert.True(t, got,
+		"pushSession recomputed is_automated; expected to trust local value")
 }
 
 // TestBackfillIsAutomatedPGRerunsOnHashChange exercises the
@@ -93,7 +86,7 @@ func TestBackfillIsAutomatedPGRerunsOnHashChange(t *testing.T) {
 
 	local := testDB(t)
 	fm := "You are analyzing an essay about epistemology."
-	if err := local.UpsertSession(db.Session{
+	require.NoError(t, local.UpsertSession(db.Session{
 		ID:               "essay-pg",
 		Project:          "proj",
 		Machine:          "local",
@@ -102,18 +95,14 @@ func TestBackfillIsAutomatedPGRerunsOnHashChange(t *testing.T) {
 		MessageCount:     2,
 		UserMessageCount: 1,
 		CreatedAt:        time.Now().UTC().Format(time.RFC3339Nano),
-	}); err != nil {
-		t.Fatalf("upsert: %v", err)
-	}
+	}), "upsert")
 
 	ps, err := New(
 		pgURL, "agentsview", local,
 		"backfill-test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx, cancel := context.WithTimeout(
@@ -121,42 +110,31 @@ func TestBackfillIsAutomatedPGRerunsOnHashChange(t *testing.T) {
 	)
 	defer cancel()
 
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("push: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "push")
 
 	// Confirm the PG row starts as is_automated=false.
 	var pre bool
-	if err := ps.DB().QueryRowContext(ctx,
+	require.NoError(t, ps.DB().QueryRowContext(ctx,
 		`SELECT is_automated FROM sessions WHERE id = $1`,
 		"essay-pg",
-	).Scan(&pre); err != nil {
-		t.Fatalf("query pre: %v", err)
-	}
-	if pre {
-		t.Fatalf("precondition: PG row should be is_automated=false")
-	}
+	).Scan(&pre), "query pre")
+	require.False(t, pre, "precondition: PG row should be is_automated=false")
 
 	// Add a user prefix so the classifier hash changes,
 	// then re-run the PG backfill directly (bypassing
 	// Sync.EnsureSchema's memo so the second pass actually
 	// executes). The matching row should flip to true.
 	db.SetUserAutomationPrefixes([]string{"You are analyzing an essay"})
-	if err := backfillIsAutomatedPG(ctx, ps.DB()); err != nil {
-		t.Fatalf("backfill after prefix add: %v", err)
-	}
+	require.NoError(t, backfillIsAutomatedPG(ctx, ps.DB()),
+		"backfill after prefix add")
 
 	var got bool
-	if err := ps.DB().QueryRowContext(ctx,
+	require.NoError(t, ps.DB().QueryRowContext(ctx,
 		`SELECT is_automated FROM sessions WHERE id = $1`,
 		"essay-pg",
-	).Scan(&got); err != nil {
-		t.Fatalf("query post: %v", err)
-	}
-	if !got {
-		t.Error("PG row should be is_automated=true after backfill on hash change")
-	}
+	).Scan(&got), "query post")
+	assert.True(t, got,
+		"PG row should be is_automated=true after backfill on hash change")
 }

--- a/internal/postgres/connect_test.go
+++ b/internal/postgres/connect_test.go
@@ -1,6 +1,10 @@
 package postgres
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestCheckSSL(t *testing.T) {
 	tests := []struct {
@@ -87,12 +91,7 @@ func TestCheckSSL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := CheckSSL(tt.dsn)
-			if (err != nil) != tt.wantErr {
-				t.Errorf(
-					"CheckSSL() error = %v, wantErr %v",
-					err, tt.wantErr,
-				)
-			}
+			assert.Equal(t, tt.wantErr, err != nil, "err = %v", err)
 		})
 	}
 }
@@ -121,13 +120,7 @@ func TestRedactDSN(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := RedactDSN(tt.dsn)
-			if got != tt.want {
-				t.Errorf(
-					"RedactDSN() = %q, want %q",
-					got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, RedactDSN(tt.dsn))
 		})
 	}
 }
@@ -147,12 +140,7 @@ func TestIsLoopback(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.host, func(t *testing.T) {
-			if got := isLoopback(tt.host); got != tt.want {
-				t.Errorf(
-					"isLoopback(%q) = %v, want %v",
-					tt.host, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, isLoopback(tt.host))
 		})
 	}
 }
@@ -174,18 +162,8 @@ func TestQuoteIdentifier(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := quoteIdentifier(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf(
-					"quoteIdentifier() err = %v, wantErr %v",
-					err, tt.wantErr,
-				)
-			}
-			if got != tt.want {
-				t.Errorf(
-					"quoteIdentifier() = %q, want %q",
-					got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.wantErr, err != nil, "err = %v", err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/postgres/curation_pgtest_test.go
+++ b/internal/postgres/curation_pgtest_test.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -14,9 +17,7 @@ func TestStoreStarsAndPins(t *testing.T) {
 
 	const schema = "agentsview_curation_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 	defer func() {
 		_, _ = pg.ExecContext(
@@ -26,14 +27,9 @@ func TestStoreStarsAndPins(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	if _, err := pg.ExecContext(
-		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
-	); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
 	_, err = pg.ExecContext(ctx, `
 		INSERT INTO sessions
@@ -49,9 +45,7 @@ func TestStoreStarsAndPins(t *testing.T) {
 			('cur-pin-1', 'machine-a', 'proj-curation',
 			 'claude', 'pin source',
 			 '2026-05-01T00:02:00Z'::timestamptz, 2, 1)`)
-	if err != nil {
-		t.Fatalf("insert sessions: %v", err)
-	}
+	require.NoError(t, err, "insert sessions")
 	_, err = pg.ExecContext(ctx, `
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp,
@@ -63,132 +57,72 @@ func TestStoreStarsAndPins(t *testing.T) {
 			('cur-pin-1', 1, 'assistant', 'answer',
 			 '2026-05-01T00:02:01Z'::timestamptz, 6,
 			 'uuid-answer')`)
-	if err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, err, "insert messages")
 
 	store, err := NewStore(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ok, err := store.StarSession("cur-star-1")
-	if err != nil || !ok {
-		t.Fatalf("StarSession existing: ok=%v err=%v", ok, err)
-	}
+	require.NoError(t, err, "StarSession existing")
+	require.True(t, ok, "StarSession existing")
 	ok, err = store.StarSession("missing")
-	if err != nil {
-		t.Fatalf("StarSession missing: %v", err)
-	}
-	if ok {
-		t.Fatal("StarSession missing = true, want false")
-	}
-	if err := store.BulkStarSessions(
+	require.NoError(t, err, "StarSession missing")
+	assert.False(t, ok, "StarSession missing")
+	require.NoError(t, store.BulkStarSessions(
 		[]string{"cur-star-2", "missing"},
-	); err != nil {
-		t.Fatalf("BulkStarSessions: %v", err)
-	}
+	), "BulkStarSessions")
 
 	ids, err := store.ListStarredSessionIDs(ctx)
-	if err != nil {
-		t.Fatalf("ListStarredSessionIDs: %v", err)
-	}
+	require.NoError(t, err, "ListStarredSessionIDs")
 	wantStars := map[string]bool{
 		"cur-star-1": true,
 		"cur-star-2": true,
 	}
-	if len(ids) != len(wantStars) {
-		t.Fatalf("starred ids = %v, want both stars", ids)
-	}
+	require.Len(t, ids, len(wantStars), "starred ids = %v", ids)
 	for _, id := range ids {
-		if !wantStars[id] {
-			t.Fatalf("unexpected starred id %q in %v", id, ids)
-		}
+		assert.True(t, wantStars[id], "unexpected starred id %q in %v", id, ids)
 	}
-	if err := store.UnstarSession("cur-star-1"); err != nil {
-		t.Fatalf("UnstarSession: %v", err)
-	}
+	require.NoError(t, store.UnstarSession("cur-star-1"), "UnstarSession")
 	ids, err = store.ListStarredSessionIDs(ctx)
-	if err != nil {
-		t.Fatalf("ListStarredSessionIDs after unstar: %v", err)
-	}
-	if len(ids) != 1 || ids[0] != "cur-star-2" {
-		t.Fatalf("starred ids after unstar = %v, want cur-star-2", ids)
-	}
+	require.NoError(t, err, "ListStarredSessionIDs after unstar")
+	require.Len(t, ids, 1)
+	assert.Equal(t, "cur-star-2", ids[0])
 
 	note := "keep this"
 	pinID, err := store.PinMessage("cur-pin-1", 1, &note)
-	if err != nil {
-		t.Fatalf("PinMessage: %v", err)
-	}
-	if pinID == 0 {
-		t.Fatal("PinMessage returned 0, want row id")
-	}
+	require.NoError(t, err, "PinMessage")
+	require.NotZero(t, pinID, "PinMessage returned 0, want row id")
 	updatedNote := "updated"
 	pinID2, err := store.PinMessage("cur-pin-1", 1, &updatedNote)
-	if err != nil {
-		t.Fatalf("PinMessage update: %v", err)
-	}
-	if pinID2 != pinID {
-		t.Fatalf("updated pin id = %d, want %d", pinID2, pinID)
-	}
+	require.NoError(t, err, "PinMessage update")
+	assert.Equal(t, pinID, pinID2)
 	missingPin, err := store.PinMessage("cur-pin-1", 99, nil)
-	if err != nil {
-		t.Fatalf("PinMessage missing message: %v", err)
-	}
-	if missingPin != 0 {
-		t.Fatalf("missing pin id = %d, want 0", missingPin)
-	}
+	require.NoError(t, err, "PinMessage missing message")
+	assert.Zero(t, missingPin)
 
 	pins, err := store.ListPinnedMessages(ctx, "cur-pin-1", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages session: %v", err)
-	}
-	if len(pins) != 1 {
-		t.Fatalf("session pins = %d, want 1", len(pins))
-	}
-	if pins[0].MessageID != 1 || pins[0].Ordinal != 1 {
-		t.Fatalf(
-			"pin message/ordinal = %d/%d, want 1/1",
-			pins[0].MessageID, pins[0].Ordinal,
-		)
-	}
-	if pins[0].Note == nil || *pins[0].Note != updatedNote {
-		t.Fatalf("pin note = %v, want %q", pins[0].Note, updatedNote)
-	}
+	require.NoError(t, err, "ListPinnedMessages session")
+	require.Len(t, pins, 1)
+	assert.Equal(t, int64(1), pins[0].MessageID)
+	assert.Equal(t, 1, pins[0].Ordinal)
+	require.NotNil(t, pins[0].Note)
+	assert.Equal(t, updatedNote, *pins[0].Note)
 
 	allPins, err := store.ListPinnedMessages(ctx, "", "proj-curation")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages all: %v", err)
-	}
-	if len(allPins) != 1 {
-		t.Fatalf("all pins = %d, want 1", len(allPins))
-	}
-	if allPins[0].Content == nil || *allPins[0].Content != "answer" {
-		t.Fatalf("pin content = %v, want answer", allPins[0].Content)
-	}
-	if allPins[0].Role == nil || *allPins[0].Role != "assistant" {
-		t.Fatalf("pin role = %v, want assistant", allPins[0].Role)
-	}
-	if allPins[0].SessionProject == nil ||
-		*allPins[0].SessionProject != "proj-curation" {
-		t.Fatalf(
-			"pin project = %v, want proj-curation",
-			allPins[0].SessionProject,
-		)
-	}
+	require.NoError(t, err, "ListPinnedMessages all")
+	require.Len(t, allPins, 1)
+	require.NotNil(t, allPins[0].Content)
+	assert.Equal(t, "answer", *allPins[0].Content)
+	require.NotNil(t, allPins[0].Role)
+	assert.Equal(t, "assistant", *allPins[0].Role)
+	require.NotNil(t, allPins[0].SessionProject)
+	assert.Equal(t, "proj-curation", *allPins[0].SessionProject)
 
-	if err := store.UnpinMessage("cur-pin-1", 1); err != nil {
-		t.Fatalf("UnpinMessage: %v", err)
-	}
+	require.NoError(t, store.UnpinMessage("cur-pin-1", 1), "UnpinMessage")
 	pins, err = store.ListPinnedMessages(ctx, "cur-pin-1", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages after unpin: %v", err)
-	}
-	if len(pins) != 0 {
-		t.Fatalf("pins after unpin = %d, want 0", len(pins))
-	}
+	require.NoError(t, err, "ListPinnedMessages after unpin")
+	assert.Empty(t, pins)
 }
 
 func TestPushPreservesMultiplePGPinsBySourceUUID(t *testing.T) {
@@ -202,15 +136,11 @@ func TestPushPreservesMultiplePGPinsBySourceUUID(t *testing.T) {
 		"curation-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("New sync: %v", err)
-	}
+	require.NoError(t, err, "New sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "EnsureSchema")
 
 	sess := db.Session{
 		ID:           "pg-pin-rewrite",
@@ -220,10 +150,8 @@ func TestPushPreservesMultiplePGPinsBySourceUUID(t *testing.T) {
 		MessageCount: 3,
 		CreatedAt:    "2026-05-01T00:00:00Z",
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("UpsertSession first: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{
+	require.NoError(t, local.UpsertSession(sess), "UpsertSession first")
+	require.NoError(t, local.InsertMessages([]db.Message{
 		{
 			SessionID:  "pg-pin-rewrite",
 			Ordinal:    0,
@@ -245,37 +173,24 @@ func TestPushPreservesMultiplePGPinsBySourceUUID(t *testing.T) {
 			Content:    "answer two",
 			SourceUUID: "uuid-answer-two",
 		},
-	}); err != nil {
-		t.Fatalf("InsertMessages first: %v", err)
-	}
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("Push first: %v", err)
-	}
+	}), "InsertMessages first")
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "Push first")
 
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	noteOne := "important one"
-	if _, err := store.PinMessage(
-		"pg-pin-rewrite", 1, &noteOne,
-	); err != nil {
-		t.Fatalf("PinMessage one: %v", err)
-	}
+	_, err = store.PinMessage("pg-pin-rewrite", 1, &noteOne)
+	require.NoError(t, err, "PinMessage one")
 	noteTwo := "important two"
-	if _, err := store.PinMessage(
-		"pg-pin-rewrite", 2, &noteTwo,
-	); err != nil {
-		t.Fatalf("PinMessage two: %v", err)
-	}
+	_, err = store.PinMessage("pg-pin-rewrite", 2, &noteTwo)
+	require.NoError(t, err, "PinMessage two")
 
 	sess.MessageCount = 4
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("UpsertSession second: %v", err)
-	}
-	if err := local.ReplaceSessionMessages(
+	require.NoError(t, local.UpsertSession(sess), "UpsertSession second")
+	require.NoError(t, local.ReplaceSessionMessages(
 		"pg-pin-rewrite",
 		[]db.Message{
 			{
@@ -308,45 +223,28 @@ func TestPushPreservesMultiplePGPinsBySourceUUID(t *testing.T) {
 				SourceUUID: "uuid-answer-two",
 			},
 		},
-	); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	), "ReplaceSessionMessages")
 
-	if _, err := ps.Push(ctx, true, nil); err != nil {
-		t.Fatalf("Push rewrite: %v", err)
-	}
+	_, err = ps.Push(ctx, true, nil)
+	require.NoError(t, err, "Push rewrite")
 
 	pins, err := store.ListPinnedMessages(ctx, "pg-pin-rewrite", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages: %v", err)
-	}
-	if len(pins) != 2 {
-		t.Fatalf("pins = %d, want 2", len(pins))
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 2)
 
 	byNote := map[string]db.PinnedMessage{}
 	for _, pin := range pins {
-		if pin.Note == nil {
-			t.Fatalf("pin note = nil, want populated note")
-		}
+		require.NotNil(t, pin.Note, "pin note should be populated")
 		byNote[*pin.Note] = pin
 	}
-	if pin, ok := byNote[noteOne]; !ok {
-		t.Fatalf("pin for %q missing: %v", noteOne, pins)
-	} else if pin.MessageID != 2 || pin.Ordinal != 2 {
-		t.Fatalf(
-			"pin one message/ordinal = %d/%d, want 2/2",
-			pin.MessageID, pin.Ordinal,
-		)
-	}
-	if pin, ok := byNote[noteTwo]; !ok {
-		t.Fatalf("pin for %q missing: %v", noteTwo, pins)
-	} else if pin.MessageID != 3 || pin.Ordinal != 3 {
-		t.Fatalf(
-			"pin two message/ordinal = %d/%d, want 3/3",
-			pin.MessageID, pin.Ordinal,
-		)
-	}
+	pin, ok := byNote[noteOne]
+	require.True(t, ok, "pin for %q missing: %v", noteOne, pins)
+	assert.Equal(t, int64(2), pin.MessageID)
+	assert.Equal(t, 2, pin.Ordinal)
+	pin, ok = byNote[noteTwo]
+	require.True(t, ok, "pin for %q missing: %v", noteTwo, pins)
+	assert.Equal(t, int64(3), pin.MessageID)
+	assert.Equal(t, 3, pin.Ordinal)
 }
 
 func TestReconcilePinnedMessagesPrefersCurrentTargetPin(t *testing.T) {
@@ -354,9 +252,7 @@ func TestReconcilePinnedMessagesPrefersCurrentTargetPin(t *testing.T) {
 
 	const schema = "agentsview_pin_duplicate_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 	defer func() {
 		_, _ = pg.ExecContext(
@@ -366,27 +262,20 @@ func TestReconcilePinnedMessagesPrefersCurrentTargetPin(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	if _, err := pg.ExecContext(
-		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
-	); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
-	if _, err := pg.ExecContext(ctx, `
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, message_count, user_message_count)
 		VALUES
 			('pg-pin-duplicate', 'machine-a', 'proj-curation',
 			 'codex', 'duplicate source repair',
-			 '2026-05-01T00:00:00Z'::timestamptz, 3, 1)`,
-	); err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
-	if _, err := pg.ExecContext(ctx, `
+			 '2026-05-01T00:00:00Z'::timestamptz, 3, 1)`)
+	require.NoError(t, err, "insert session")
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp,
 			 content_length, source_uuid)
@@ -399,11 +288,9 @@ func TestReconcilePinnedMessagesPrefersCurrentTargetPin(t *testing.T) {
 			 'uuid-boundary'),
 			('pg-pin-duplicate', 2, 'assistant', 'answer',
 			 '2026-05-01T00:00:02Z'::timestamptz, 6,
-			 'uuid-answer')`,
-	); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
-	if _, err := pg.ExecContext(ctx, `
+			 'uuid-answer')`)
+	require.NoError(t, err, "insert messages")
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO pinned_messages
 			(session_id, message_id, ordinal, source_uuid,
 			 note, created_at)
@@ -413,47 +300,30 @@ func TestReconcilePinnedMessagesPrefersCurrentTargetPin(t *testing.T) {
 			 '2026-05-01T00:01:00Z'::timestamptz),
 			('pg-pin-duplicate', 2, 2, 'uuid-answer',
 			 'current note',
-			 '2026-05-01T00:02:00Z'::timestamptz)`,
-	); err != nil {
-		t.Fatalf("insert pins: %v", err)
-	}
+			 '2026-05-01T00:02:00Z'::timestamptz)`)
+	require.NoError(t, err, "insert pins")
 
 	tx, err := pg.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("begin tx: %v", err)
-	}
+	require.NoError(t, err, "begin tx")
 	if err := reconcilePinnedMessages(
 		ctx, tx, "pg-pin-duplicate",
 	); err != nil {
 		_ = tx.Rollback()
 		t.Fatalf("reconcilePinnedMessages: %v", err)
 	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("commit tx: %v", err)
-	}
+	require.NoError(t, tx.Commit(), "commit tx")
 
 	store, err := NewStore(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	pins, err := store.ListPinnedMessages(ctx, "pg-pin-duplicate", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages: %v", err)
-	}
-	if len(pins) != 1 {
-		t.Fatalf("pins = %d, want 1: %v", len(pins), pins)
-	}
-	if pins[0].MessageID != 2 || pins[0].Ordinal != 2 {
-		t.Fatalf(
-			"pin message/ordinal = %d/%d, want 2/2",
-			pins[0].MessageID, pins[0].Ordinal,
-		)
-	}
-	if pins[0].Note == nil || *pins[0].Note != "current note" {
-		t.Fatalf("pin note = %v, want current note", pins[0].Note)
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 1, "pins = %v", pins)
+	assert.Equal(t, int64(2), pins[0].MessageID)
+	assert.Equal(t, 2, pins[0].Ordinal)
+	require.NotNil(t, pins[0].Note)
+	assert.Equal(t, "current note", *pins[0].Note)
 }
 
 // TestReconcilePinnedMessagesPrunesPinWhenSourceUUIDGone covers the
@@ -466,9 +336,7 @@ func TestReconcilePinnedMessagesPrunesPinWhenSourceUUIDGone(t *testing.T) {
 
 	const schema = "agentsview_pin_source_gone_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 	defer func() {
 		_, _ = pg.ExecContext(
@@ -478,27 +346,20 @@ func TestReconcilePinnedMessagesPrunesPinWhenSourceUUIDGone(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	if _, err := pg.ExecContext(
-		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
-	); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
-	if _, err := pg.ExecContext(ctx, `
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, message_count, user_message_count)
 		VALUES
 			('pg-pin-source-gone', 'machine-a', 'proj-curation',
 			 'codex', 'source uuid gone',
-			 '2026-05-01T00:00:00Z'::timestamptz, 2, 1)`,
-	); err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
-	if _, err := pg.ExecContext(ctx, `
+			 '2026-05-01T00:00:00Z'::timestamptz, 2, 1)`)
+	require.NoError(t, err, "insert session")
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp,
 			 content_length, source_uuid)
@@ -508,52 +369,36 @@ func TestReconcilePinnedMessagesPrunesPinWhenSourceUUIDGone(t *testing.T) {
 			 'uuid-question'),
 			('pg-pin-source-gone', 1, 'assistant', 'new answer',
 			 '2026-05-01T00:00:01Z'::timestamptz, 10,
-			 'uuid-new-answer')`,
-	); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
-	if _, err := pg.ExecContext(ctx, `
+			 'uuid-new-answer')`)
+	require.NoError(t, err, "insert messages")
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO pinned_messages
 			(session_id, message_id, ordinal, source_uuid,
 			 note, created_at)
 		VALUES
 			('pg-pin-source-gone', 1, 1, 'uuid-gone-forever',
 			 'stale pin',
-			 '2026-05-01T00:01:00Z'::timestamptz)`,
-	); err != nil {
-		t.Fatalf("insert pin: %v", err)
-	}
+			 '2026-05-01T00:01:00Z'::timestamptz)`)
+	require.NoError(t, err, "insert pin")
 
 	tx, err := pg.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("begin tx: %v", err)
-	}
+	require.NoError(t, err, "begin tx")
 	if err := reconcilePinnedMessages(
 		ctx, tx, "pg-pin-source-gone",
 	); err != nil {
 		_ = tx.Rollback()
 		t.Fatalf("reconcilePinnedMessages: %v", err)
 	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("commit tx: %v", err)
-	}
+	require.NoError(t, tx.Commit(), "commit tx")
 
 	store, err := NewStore(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	pins, err := store.ListPinnedMessages(ctx, "pg-pin-source-gone", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages: %v", err)
-	}
-	if len(pins) != 0 {
-		t.Fatalf(
-			"pins = %d, want 0 (stale source_uuid should be pruned): %v",
-			len(pins), pins,
-		)
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	assert.Empty(t, pins,
+		"stale source_uuid should be pruned: %v", pins)
 }
 
 // TestReconcilePinnedMessagesKeepsPinOnLaterDuplicateSourceUUID
@@ -566,9 +411,7 @@ func TestReconcilePinnedMessagesKeepsPinOnLaterDuplicateSourceUUID(t *testing.T)
 
 	const schema = "agentsview_pin_dup_uuid_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 	defer func() {
 		_, _ = pg.ExecContext(
@@ -578,27 +421,20 @@ func TestReconcilePinnedMessagesKeepsPinOnLaterDuplicateSourceUUID(t *testing.T)
 	}()
 
 	ctx := context.Background()
-	if _, err := pg.ExecContext(
-		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
-	); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
-	if _, err := pg.ExecContext(ctx, `
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, message_count, user_message_count)
 		VALUES
 			('pg-pin-dup-uuid', 'machine-a', 'proj-curation',
 			 'claude', 'duplicate source uuid',
-			 '2026-05-01T00:00:00Z'::timestamptz, 3, 1)`,
-	); err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
-	if _, err := pg.ExecContext(ctx, `
+			 '2026-05-01T00:00:00Z'::timestamptz, 3, 1)`)
+	require.NoError(t, err, "insert session")
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp,
 			 content_length, source_uuid)
@@ -611,56 +447,39 @@ func TestReconcilePinnedMessagesKeepsPinOnLaterDuplicateSourceUUID(t *testing.T)
 			 'uuid-shared'),
 			('pg-pin-dup-uuid', 2, 'assistant', 'second answer',
 			 '2026-05-01T00:00:02Z'::timestamptz, 13,
-			 'uuid-shared')`,
-	); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
-	if _, err := pg.ExecContext(ctx, `
+			 'uuid-shared')`)
+	require.NoError(t, err, "insert messages")
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO pinned_messages
 			(session_id, message_id, ordinal, source_uuid,
 			 note, created_at)
 		VALUES
 			('pg-pin-dup-uuid', 2, 2, 'uuid-shared',
 			 'pin on later duplicate',
-			 '2026-05-01T00:01:00Z'::timestamptz)`,
-	); err != nil {
-		t.Fatalf("insert pin: %v", err)
-	}
+			 '2026-05-01T00:01:00Z'::timestamptz)`)
+	require.NoError(t, err, "insert pin")
 
 	tx, err := pg.BeginTx(ctx, nil)
-	if err != nil {
-		t.Fatalf("begin tx: %v", err)
-	}
+	require.NoError(t, err, "begin tx")
 	if err := reconcilePinnedMessages(
 		ctx, tx, "pg-pin-dup-uuid",
 	); err != nil {
 		_ = tx.Rollback()
 		t.Fatalf("reconcilePinnedMessages: %v", err)
 	}
-	if err := tx.Commit(); err != nil {
-		t.Fatalf("commit tx: %v", err)
-	}
+	require.NoError(t, tx.Commit(), "commit tx")
 
 	store, err := NewStore(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	pins, err := store.ListPinnedMessages(ctx, "pg-pin-dup-uuid", "")
-	if err != nil {
-		t.Fatalf("ListPinnedMessages: %v", err)
-	}
-	if len(pins) != 1 {
-		t.Fatalf("pins = %d, want 1: %v", len(pins), pins)
-	}
-	if pins[0].MessageID != 2 || pins[0].Ordinal != 2 {
-		t.Fatalf(
-			"pin message/ordinal = %d/%d, want 2/2 (must not "+
-				"relocate to lower-ordinal duplicate)",
-			pins[0].MessageID, pins[0].Ordinal,
-		)
-	}
+	require.NoError(t, err, "ListPinnedMessages")
+	require.Len(t, pins, 1, "pins = %v", pins)
+	assert.Equal(t, int64(2), pins[0].MessageID,
+		"must not relocate to lower-ordinal duplicate")
+	assert.Equal(t, 2, pins[0].Ordinal,
+		"must not relocate to lower-ordinal duplicate")
 }
 
 // TestPinMessageRepinRefreshesSourceUUID covers re-pinning the same
@@ -672,9 +491,7 @@ func TestPinMessageRepinRefreshesSourceUUID(t *testing.T) {
 
 	const schema = "agentsview_pin_repin_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 	defer func() {
 		_, _ = pg.ExecContext(
@@ -684,27 +501,20 @@ func TestPinMessageRepinRefreshesSourceUUID(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	if _, err := pg.ExecContext(
-		ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`,
-	); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
-	if _, err := pg.ExecContext(ctx, `
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, message_count, user_message_count)
 		VALUES
 			('pg-pin-repin', 'machine-a', 'proj-curation',
 			 'claude', 'repin refreshes uuid',
-			 '2026-05-01T00:00:00Z'::timestamptz, 2, 1)`,
-	); err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
-	if _, err := pg.ExecContext(ctx, `
+			 '2026-05-01T00:00:00Z'::timestamptz, 2, 1)`)
+	require.NoError(t, err, "insert session")
+	_, err = pg.ExecContext(ctx, `
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp,
 			 content_length, source_uuid)
@@ -714,80 +524,52 @@ func TestPinMessageRepinRefreshesSourceUUID(t *testing.T) {
 			 'uuid-question'),
 			('pg-pin-repin', 1, 'assistant', 'original',
 			 '2026-05-01T00:00:01Z'::timestamptz, 8,
-			 'uuid-original')`,
-	); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+			 'uuid-original')`)
+	require.NoError(t, err, "insert messages")
 
 	store, err := NewStore(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	originalNote := "first"
-	if _, err := store.PinMessage("pg-pin-repin", 1, &originalNote); err != nil {
-		t.Fatalf("PinMessage initial: %v", err)
-	}
+	_, err = store.PinMessage("pg-pin-repin", 1, &originalNote)
+	require.NoError(t, err, "PinMessage initial")
 	var initialSourceUUID, initialCreatedAt string
-	if err := pg.QueryRowContext(ctx, `
+	require.NoError(t, pg.QueryRowContext(ctx, `
 		SELECT source_uuid, created_at::text
 		FROM pinned_messages
 		WHERE session_id = $1 AND message_id = $2`,
 		"pg-pin-repin", 1,
-	).Scan(&initialSourceUUID, &initialCreatedAt); err != nil {
-		t.Fatalf("query initial pin: %v", err)
-	}
-	if initialSourceUUID != "uuid-original" {
-		t.Fatalf(
-			"initial source_uuid = %q, want uuid-original",
-			initialSourceUUID,
-		)
-	}
+	).Scan(&initialSourceUUID, &initialCreatedAt), "query initial pin")
+	assert.Equal(t, "uuid-original", initialSourceUUID)
 
 	// Simulate a session rewrite that replaces the message at
 	// ordinal 1 with a different message (different source_uuid)
 	// while reusing the ordinal.
-	if _, err := pg.ExecContext(ctx, `
+	_, err = pg.ExecContext(ctx, `
 		UPDATE messages
 		SET source_uuid = 'uuid-replacement',
 			content = 'replaced'
 		WHERE session_id = $1 AND ordinal = $2`,
 		"pg-pin-repin", 1,
-	); err != nil {
-		t.Fatalf("update message source_uuid: %v", err)
-	}
+	)
+	require.NoError(t, err, "update message source_uuid")
 
 	updatedNote := "second"
-	if _, err := store.PinMessage("pg-pin-repin", 1, &updatedNote); err != nil {
-		t.Fatalf("PinMessage repin: %v", err)
-	}
+	_, err = store.PinMessage("pg-pin-repin", 1, &updatedNote)
+	require.NoError(t, err, "PinMessage repin")
 
 	var gotSourceUUID, gotCreatedAt string
 	var gotNote *string
-	if err := pg.QueryRowContext(ctx, `
+	require.NoError(t, pg.QueryRowContext(ctx, `
 		SELECT source_uuid, note, created_at::text
 		FROM pinned_messages
 		WHERE session_id = $1 AND message_id = $2`,
 		"pg-pin-repin", 1,
-	).Scan(&gotSourceUUID, &gotNote, &gotCreatedAt); err != nil {
-		t.Fatalf("query repinned pin: %v", err)
-	}
-	if gotSourceUUID != "uuid-replacement" {
-		t.Fatalf(
-			"after repin source_uuid = %q, want uuid-replacement "+
-				"(stale source_uuid would steer the next reconciliation "+
-				"away from the current message)",
-			gotSourceUUID,
-		)
-	}
-	if gotNote == nil || *gotNote != updatedNote {
-		t.Fatalf("after repin note = %v, want %q", gotNote, updatedNote)
-	}
-	if gotCreatedAt != initialCreatedAt {
-		t.Fatalf(
-			"after repin created_at = %q, want %q (must be preserved)",
-			gotCreatedAt, initialCreatedAt,
-		)
-	}
+	).Scan(&gotSourceUUID, &gotNote, &gotCreatedAt), "query repinned pin")
+	assert.Equal(t, "uuid-replacement", gotSourceUUID,
+		"stale source_uuid would steer the next reconciliation away from the current message")
+	require.NotNil(t, gotNote)
+	assert.Equal(t, updatedNote, *gotNote)
+	assert.Equal(t, initialCreatedAt, gotCreatedAt, "created_at must be preserved")
 }

--- a/internal/postgres/integration_test.go
+++ b/internal/postgres/integration_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -23,15 +26,11 @@ func TestPGPushSecrets(t *testing.T) {
 		pgURL, "agentsview", local, "machine-secrets", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	// Seed a session with a message.
 	started := time.Now().UTC().Format(time.RFC3339)
@@ -45,17 +44,13 @@ func TestPGPushSecrets(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{{
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{{
 		SessionID: "secrets-sess-001",
 		Ordinal:   0,
 		Role:      "user",
 		Content:   firstMsg,
-	}}); err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	}}), "insert message")
 
 	// Add a secret finding to the session.
 	findings := []db.SecretFinding{
@@ -72,29 +67,18 @@ func TestPGPushSecrets(t *testing.T) {
 			RulesVersion:   "v1.0",
 		},
 	}
-	if err := local.ReplaceSessionSecretFindings(
+	require.NoError(t, local.ReplaceSessionSecretFindings(
 		"secrets-sess-001", findings, 1, "v1.0",
-	); err != nil {
-		t.Fatalf("replace secret findings: %v", err)
-	}
+	), "replace secret findings")
 
 	// Push to PG.
 	pushResult, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("push: %v", err)
-	}
-	if pushResult.SessionsPushed != 1 {
-		t.Fatalf(
-			"pushed %d sessions; want 1",
-			pushResult.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "push")
+	require.Equal(t, 1, pushResult.SessionsPushed)
 
 	// Open a read Store and verify via ListSessions + ListSecretFindings.
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("opening store: %v", err)
-	}
+	require.NoError(t, err, "opening store")
 	defer store.Close()
 
 	// ListSessions with HasSecret=true must return the session with
@@ -102,77 +86,33 @@ func TestPGPushSecrets(t *testing.T) {
 	page, err := store.ListSessions(ctx, db.SessionFilter{
 		HasSecret: true, Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("ListSessions HasSecret: %v", err)
-	}
-	if len(page.Sessions) != 1 {
-		t.Fatalf(
-			"ListSessions HasSecret returned %d sessions; want 1",
-			len(page.Sessions),
-		)
-	}
-	if page.Sessions[0].SecretLeakCount != 1 {
-		t.Errorf(
-			"SecretLeakCount = %d; want 1",
-			page.Sessions[0].SecretLeakCount,
-		)
-	}
+	require.NoError(t, err, "ListSessions HasSecret")
+	require.Len(t, page.Sessions, 1)
+	assert.Equal(t, 1, page.Sessions[0].SecretLeakCount)
 
 	// ListSecretFindings must return the pushed finding with
 	// Project and Agent populated.
 	fpage, err := store.ListSecretFindings(ctx, db.SecretFindingFilter{
 		Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("ListSecretFindings: %v", err)
-	}
-	if len(fpage.Findings) != 1 {
-		t.Fatalf(
-			"ListSecretFindings returned %d findings; want 1",
-			len(fpage.Findings),
-		)
-	}
+	require.NoError(t, err, "ListSecretFindings")
+	require.Len(t, fpage.Findings, 1)
 	f := fpage.Findings[0]
-	if f.RuleName != "aws-access-key" {
-		t.Errorf("RuleName = %q; want aws-access-key", f.RuleName)
-	}
-	if f.Project != "secrets-project" {
-		t.Errorf("Project = %q; want secrets-project", f.Project)
-	}
-	if f.Agent != "claude" {
-		t.Errorf("Agent = %q; want claude", f.Agent)
-	}
-	if f.RedactedMatch != "AKIA[REDACTED]" {
-		t.Errorf(
-			"RedactedMatch = %q; want AKIA[REDACTED]",
-			f.RedactedMatch,
-		)
-	}
+	assert.Equal(t, "aws-access-key", f.RuleName)
+	assert.Equal(t, "secrets-project", f.Project)
+	assert.Equal(t, "claude", f.Agent)
+	assert.Equal(t, "AKIA[REDACTED]", f.RedactedMatch)
 
 	// Second push with no changes must be a no-op (fingerprint
 	// unchanged) and must not duplicate findings.
 	r2, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("second push: %v", err)
-	}
-	if r2.SessionsPushed != 0 {
-		t.Errorf(
-			"second push sessions = %d; want 0 (no-op)",
-			r2.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "second push")
+	assert.Equal(t, 0, r2.SessionsPushed, "second push should be no-op")
 	fpage2, err := store.ListSecretFindings(ctx, db.SecretFindingFilter{
 		Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("ListSecretFindings after re-push: %v", err)
-	}
-	if len(fpage2.Findings) != 1 {
-		t.Errorf(
-			"findings after re-push = %d; want 1 (no duplicate)",
-			len(fpage2.Findings),
-		)
-	}
+	require.NoError(t, err, "ListSecretFindings after re-push")
+	assert.Len(t, fpage2.Findings, 1, "no duplicate findings after re-push")
 }
 
 // TestPushSecretFindingsReportsChange verifies pushSecretFindings reports
@@ -188,15 +128,11 @@ func TestPushSecretFindingsReportsChange(t *testing.T) {
 		pgURL, "agentsview", local, "machine-findings-change", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	// Seed a session (no findings yet) and push it so the PG row exists
 	// for the secret_findings foreign key.
@@ -212,36 +148,27 @@ func TestPushSecretFindingsReportsChange(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{{
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{{
 		SessionID: sessID,
 		Ordinal:   0,
 		Role:      "user",
 		Content:   firstMsg,
-	}}); err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("seed push: %v", err)
-	}
+	}}), "insert message")
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "seed push")
 
 	// pushOnce runs pushSecretFindings in its own transaction and returns
 	// whether it reported a change.
 	pushOnce := func() bool {
 		tx, err := ps.pg.BeginTx(ctx, nil)
-		if err != nil {
-			t.Fatalf("begin tx: %v", err)
-		}
+		require.NoError(t, err, "begin tx")
 		changed, err := ps.pushSecretFindings(ctx, tx, sessID)
 		if err != nil {
 			_ = tx.Rollback()
 			t.Fatalf("pushSecretFindings: %v", err)
 		}
-		if err := tx.Commit(); err != nil {
-			t.Fatalf("commit tx: %v", err)
-		}
+		require.NoError(t, tx.Commit(), "commit tx")
 		return changed
 	}
 
@@ -259,40 +186,26 @@ func TestPushSecretFindingsReportsChange(t *testing.T) {
 	}
 
 	// No PG rows, no local findings: nothing changes.
-	if pushOnce() {
-		t.Error("empty -> empty reported a change; want false")
-	}
+	assert.False(t, pushOnce(), "empty -> empty reported a change")
 
 	// Local gains a finding: the insert is a change.
-	if err := local.ReplaceSessionSecretFindings(
+	require.NoError(t, local.ReplaceSessionSecretFindings(
 		sessID, []db.SecretFinding{finding}, 1, "v1.0",
-	); err != nil {
-		t.Fatalf("seed finding: %v", err)
-	}
-	if !pushOnce() {
-		t.Error("insert reported no change; want true")
-	}
+	), "seed finding")
+	assert.True(t, pushOnce(), "insert should report change")
 
 	// Re-pushing the same finding still rewrites rows (delete + insert),
 	// which counts as a change.
-	if !pushOnce() {
-		t.Error("rewrite reported no change; want true")
-	}
+	assert.True(t, pushOnce(), "rewrite should report change")
 
 	// Clearing local findings deletes the PG row: that is a change.
-	if err := local.ReplaceSessionSecretFindings(
+	require.NoError(t, local.ReplaceSessionSecretFindings(
 		sessID, nil, 0, "v1.0",
-	); err != nil {
-		t.Fatalf("clear findings: %v", err)
-	}
-	if !pushOnce() {
-		t.Error("delete reported no change; want true")
-	}
+	), "clear findings")
+	assert.True(t, pushOnce(), "delete should report change")
 
 	// Back to empty on both sides: nothing changes.
-	if pushOnce() {
-		t.Error("post-clear empty -> empty reported a change; want false")
-	}
+	assert.False(t, pushOnce(), "post-clear empty -> empty reported a change")
 }
 
 func TestPGConnectivity(t *testing.T) {
@@ -304,9 +217,7 @@ func TestPGConnectivity(t *testing.T) {
 		"connectivity-test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx, cancel := context.WithTimeout(
@@ -314,14 +225,10 @@ func TestPGConnectivity(t *testing.T) {
 	)
 	defer cancel()
 
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	status, err := ps.Status(ctx)
-	if err != nil {
-		t.Fatalf("get status: %v", err)
-	}
+	require.NoError(t, err, "get status")
 
 	t.Logf("PG Sync Status: %+v", status)
 }
@@ -337,15 +244,11 @@ func TestPGPushCycle(t *testing.T) {
 		pgURL, "agentsview", local, "machine-a", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := time.Now().UTC().Format(time.RFC3339)
 	firstMsg := "hello from pg"
@@ -358,45 +261,21 @@ func TestPGPushCycle(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{{
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{{
 		SessionID: "pg-sess-001",
 		Ordinal:   0,
 		Role:      "user",
 		Content:   firstMsg,
-	}}); err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	}}), "insert message")
 
 	pushResult, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("push: %v", err)
-	}
-	if pushResult.SessionsPushed != 1 ||
-		pushResult.MessagesPushed != 1 {
-		t.Fatalf(
-			"pushed %d sessions, %d messages; want 1/1",
-			pushResult.SessionsPushed,
-			pushResult.MessagesPushed,
-		)
-	}
+	require.NoError(t, err, "push")
+	require.Equal(t, 1, pushResult.SessionsPushed)
+	require.Equal(t, 1, pushResult.MessagesPushed)
 
 	status, err := ps.Status(ctx)
-	if err != nil {
-		t.Fatalf("status: %v", err)
-	}
-	if status.PGSessions != 1 {
-		t.Errorf(
-			"pg sessions = %d, want 1",
-			status.PGSessions,
-		)
-	}
-	if status.PGMessages != 1 {
-		t.Errorf(
-			"pg messages = %d, want 1",
-			status.PGMessages,
-		)
-	}
+	require.NoError(t, err, "status")
+	assert.Equal(t, 1, status.PGSessions)
+	assert.Equal(t, 1, status.PGMessages)
 }

--- a/internal/postgres/messages_pgtest_test.go
+++ b/internal/postgres/messages_pgtest_test.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -14,9 +17,7 @@ func TestStoreSearchILIKE(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -24,19 +25,11 @@ func TestStoreSearchILIKE(t *testing.T) {
 		Query: "hello",
 		Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) == 0 {
-		t.Error("expected at least 1 search result")
-	}
+	require.NoError(t, err, "Search")
+	assert.NotEmpty(t, page.Results, "expected at least 1 search result")
 	for _, r := range page.Results {
-		if r.Agent == "" {
-			t.Error("Agent field is empty, want populated")
-		}
-		if r.SessionEndedAt == "" {
-			t.Error("SessionEndedAt is empty, want populated")
-		}
+		assert.NotEmpty(t, r.Agent, "Agent field is empty")
+		assert.NotEmpty(t, r.SessionEndedAt, "SessionEndedAt is empty")
 	}
 }
 
@@ -47,9 +40,7 @@ func TestPGSearchDeduplication(t *testing.T) {
 	// store-test-001 has 2 messages; searching "hello" only matches ordinal 0.
 	// With session grouping, should return exactly 1 result.
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -57,12 +48,8 @@ func TestPGSearchDeduplication(t *testing.T) {
 		Query: "hello",
 		Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) != 1 {
-		t.Errorf("got %d results, want 1 (deduplicated to session)", len(page.Results))
-	}
+	require.NoError(t, err, "Search")
+	assert.Len(t, page.Results, 1, "deduplicated to session")
 }
 
 func TestPGSearchRecencySort(t *testing.T) {
@@ -71,9 +58,7 @@ func TestPGSearchRecencySort(t *testing.T) {
 
 	// Open a write connection to insert additional test data.
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// Insert a newer session that also matches "hello".
@@ -91,9 +76,7 @@ func TestPGSearchRecencySort(t *testing.T) {
 			 1, 1)
 		ON CONFLICT (id) DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting newer session: %v", err)
-	}
+	require.NoError(t, err, "inserting newer session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
@@ -104,14 +87,10 @@ func TestPGSearchRecencySort(t *testing.T) {
 			 '2026-04-01T10:00:00Z'::timestamptz, 17)
 		ON CONFLICT DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting newer message: %v", err)
-	}
+	require.NoError(t, err, "inserting newer message")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -120,17 +99,10 @@ func TestPGSearchRecencySort(t *testing.T) {
 		Limit: 10,
 		Sort:  "recency",
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) < 2 {
-		t.Fatalf("want >= 2 results, got %d", len(page.Results))
-	}
+	require.NoError(t, err, "Search")
+	require.GreaterOrEqual(t, len(page.Results), 2)
 	// recency-test-002 has ended_at 2026-04-01, store-test-001 has 2026-03-12
-	if page.Results[0].SessionID != "recency-test-002" {
-		t.Errorf("recency sort: first result = %q, want %q",
-			page.Results[0].SessionID, "recency-test-002")
-	}
+	assert.Equal(t, "recency-test-002", page.Results[0].SessionID)
 }
 
 func TestPGSearchRelevanceSort(t *testing.T) {
@@ -138,9 +110,7 @@ func TestPGSearchRelevanceSort(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// Insert two sessions:
@@ -166,9 +136,7 @@ func TestPGSearchRelevanceSort(t *testing.T) {
 			 1, 1)
 		ON CONFLICT (id) DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting sessions: %v", err)
-	}
+	require.NoError(t, err, "inserting sessions")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp, content_length)
@@ -181,14 +149,10 @@ func TestPGSearchRelevanceSort(t *testing.T) {
 			 '2025-01-02T10:00:00Z'::timestamptz, 73)
 		ON CONFLICT DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting messages: %v", err)
-	}
+	require.NoError(t, err, "inserting messages")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -197,18 +161,11 @@ func TestPGSearchRelevanceSort(t *testing.T) {
 		Limit: 10,
 		Sort:  "relevance",
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) < 2 {
-		t.Fatalf("want >= 2 results, got %d", len(page.Results))
-	}
+	require.NoError(t, err, "Search")
+	require.GreaterOrEqual(t, len(page.Results), 2)
 	// relevance-early has match at position 1; relevance-late has it after 50 chars
 	// relevance sort = match_pos ASC, so relevance-early must come first
-	if page.Results[0].SessionID != "relevance-early" {
-		t.Errorf("relevance sort: first result = %q, want %q",
-			page.Results[0].SessionID, "relevance-early")
-	}
+	assert.Equal(t, "relevance-early", page.Results[0].SessionID)
 }
 
 func TestPGSearchNullTimestampSorting(t *testing.T) {
@@ -216,9 +173,7 @@ func TestPGSearchNullTimestampSorting(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// Insert a session with NULL ended_at and started_at.
@@ -233,9 +188,7 @@ func TestPGSearchNullTimestampSorting(t *testing.T) {
 			 1, 1)
 		ON CONFLICT (id) DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting null-ts session: %v", err)
-	}
+	require.NoError(t, err, "inserting null-ts session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
@@ -246,9 +199,7 @@ func TestPGSearchNullTimestampSorting(t *testing.T) {
 			 '2026-01-01T00:00:00Z'::timestamptz, 21)
 		ON CONFLICT DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting null-ts message: %v", err)
-	}
+	require.NoError(t, err, "inserting null-ts message")
 
 	// Insert a session with real timestamps.
 	_, err = pg.Exec(`
@@ -265,9 +216,7 @@ func TestPGSearchNullTimestampSorting(t *testing.T) {
 			 1, 1)
 		ON CONFLICT (id) DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting real-ts session: %v", err)
-	}
+	require.NoError(t, err, "inserting real-ts session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
@@ -278,14 +227,10 @@ func TestPGSearchNullTimestampSorting(t *testing.T) {
 			 '2026-03-10T10:00:00Z'::timestamptz, 21)
 		ON CONFLICT DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting real-ts message: %v", err)
-	}
+	require.NoError(t, err, "inserting real-ts message")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -296,15 +241,10 @@ func TestPGSearchNullTimestampSorting(t *testing.T) {
 		Limit: 10,
 		Sort:  "recency",
 	})
-	if err != nil {
-		t.Fatalf("recency search: %v", err)
-	}
-	if len(page.Results) < 2 {
-		t.Fatalf("want >= 2 results, got %d", len(page.Results))
-	}
-	if page.Results[0].SessionID == "null-ts-001" {
-		t.Error("recency: NULL-timestamp session appeared first, want last")
-	}
+	require.NoError(t, err, "recency search")
+	require.GreaterOrEqual(t, len(page.Results), 2)
+	assert.NotEqual(t, "null-ts-001", page.Results[0].SessionID,
+		"recency: NULL-timestamp session appeared first, want last")
 
 	// Test relevance sort: both have same match_pos, so
 	// session_ended_at DESC is the tie-breaker — NULL must not win.
@@ -313,15 +253,10 @@ func TestPGSearchNullTimestampSorting(t *testing.T) {
 		Limit: 10,
 		Sort:  "relevance",
 	})
-	if err != nil {
-		t.Fatalf("relevance search: %v", err)
-	}
-	if len(page.Results) < 2 {
-		t.Fatalf("want >= 2 results, got %d", len(page.Results))
-	}
-	if page.Results[0].SessionID == "null-ts-001" {
-		t.Error("relevance: NULL-timestamp session appeared first, want last")
-	}
+	require.NoError(t, err, "relevance search")
+	require.GreaterOrEqual(t, len(page.Results), 2)
+	assert.NotEqual(t, "null-ts-001", page.Results[0].SessionID,
+		"relevance: NULL-timestamp session appeared first, want last")
 }
 
 func TestPGSearchSystemMessageExcluded(t *testing.T) {
@@ -329,9 +264,7 @@ func TestPGSearchSystemMessageExcluded(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// Insert a session whose only matching message is a system message.
@@ -351,9 +284,7 @@ func TestPGSearchSystemMessageExcluded(t *testing.T) {
 			 1, 0)
 		ON CONFLICT (id) DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting session: %v", err)
-	}
+	require.NoError(t, err, "inserting session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
@@ -364,14 +295,10 @@ func TestPGSearchSystemMessageExcluded(t *testing.T) {
 			 '2026-03-01T10:00:00Z'::timestamptz, 19, TRUE)
 		ON CONFLICT DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting system message: %v", err)
-	}
+	require.NoError(t, err, "inserting system message")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -379,13 +306,9 @@ func TestPGSearchSystemMessageExcluded(t *testing.T) {
 		Query: "sysonly unique",
 		Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) != 0 {
-		t.Errorf("got %d results for system-only session, want 0",
-			len(page.Results))
-	}
+	require.NoError(t, err, "Search")
+	assert.Empty(t, page.Results,
+		"system-only session should not appear in search results")
 }
 
 // TestPGSearchNameBranchExcludesSystemOnlySessions verifies that a
@@ -397,9 +320,7 @@ func TestPGSearchNameBranchExcludesSystemOnlySessions(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// Session with only display_name matching, system messages only.
@@ -418,9 +339,7 @@ func TestPGSearchNameBranchExcludesSystemOnlySessions(t *testing.T) {
 			 1, 0)
 		ON CONFLICT (id) DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting dn session: %v", err)
-	}
+	require.NoError(t, err, "inserting dn session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
@@ -431,9 +350,7 @@ func TestPGSearchNameBranchExcludesSystemOnlySessions(t *testing.T) {
 			 '2026-03-10T10:00:00Z'::timestamptz, 19, TRUE)
 		ON CONFLICT DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting dn system message: %v", err)
-	}
+	require.NoError(t, err, "inserting dn system message")
 
 	// Session with only first_message matching, system messages only.
 	_, err = pg.Exec(`
@@ -450,9 +367,7 @@ func TestPGSearchNameBranchExcludesSystemOnlySessions(t *testing.T) {
 			 1, 0)
 		ON CONFLICT (id) DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting fm session: %v", err)
-	}
+	require.NoError(t, err, "inserting fm session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
@@ -463,14 +378,10 @@ func TestPGSearchNameBranchExcludesSystemOnlySessions(t *testing.T) {
 			 '2026-03-11T10:00:00Z'::timestamptz, 19, TRUE)
 		ON CONFLICT DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting fm system message: %v", err)
-	}
+	require.NoError(t, err, "inserting fm system message")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -480,13 +391,9 @@ func TestPGSearchNameBranchExcludesSystemOnlySessions(t *testing.T) {
 			Query: "pgdnguardterm",
 			Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 0 {
-			t.Errorf("got %d results for system-only session via display_name, want 0",
-				len(page.Results))
-		}
+		require.NoError(t, err, "Search")
+		assert.Empty(t, page.Results,
+			"system-only session via display_name should not appear")
 	})
 
 	t.Run("first_message path", func(t *testing.T) {
@@ -494,13 +401,9 @@ func TestPGSearchNameBranchExcludesSystemOnlySessions(t *testing.T) {
 			Query: "pgfmguardterm",
 			Limit: 10,
 		})
-		if err != nil {
-			t.Fatalf("Search: %v", err)
-		}
-		if len(page.Results) != 0 {
-			t.Errorf("got %d results for system-only session via first_message, want 0",
-				len(page.Results))
-		}
+		require.NoError(t, err, "Search")
+		assert.Empty(t, page.Results,
+			"system-only session via first_message should not appear")
 	})
 }
 
@@ -512,9 +415,7 @@ func TestPGSearchSessionExcludesSystemMessages(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// Insert a session with one regular and one system message, both
@@ -530,9 +431,7 @@ func TestPGSearchSessionExcludesSystemMessages(t *testing.T) {
 			 NOW(), 2, 1)
 		ON CONFLICT (id) DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting session: %v", err)
-	}
+	require.NoError(t, err, "inserting session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
@@ -546,28 +445,18 @@ func TestPGSearchSessionExcludesSystemMessages(t *testing.T) {
 			 NOW(), 29, TRUE)
 		ON CONFLICT DO NOTHING
 	`)
-	if err != nil {
-		t.Fatalf("inserting messages: %v", err)
-	}
+	require.NoError(t, err, "inserting messages")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
 	ordinals, err := store.SearchSession(ctx, "sess-syssearch", "syssearch")
-	if err != nil {
-		t.Fatalf("SearchSession: %v", err)
-	}
-	if len(ordinals) != 1 {
-		t.Fatalf("got %d ordinals, want 1 (session search excludes system messages): %v",
-			len(ordinals), ordinals)
-	}
-	if ordinals[0] != 0 {
-		t.Errorf("got ordinals %v, want [0]", ordinals)
-	}
+	require.NoError(t, err, "SearchSession")
+	require.Len(t, ordinals, 1,
+		"session search excludes system messages: %v", ordinals)
+	assert.Equal(t, 0, ordinals[0])
 }
 
 func TestPGSearchSessionNameMatch(t *testing.T) {
@@ -575,9 +464,7 @@ func TestPGSearchSessionNameMatch(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// Insert session with display_name containing unique search term,
@@ -591,9 +478,7 @@ func TestPGSearchSessionNameMatch(t *testing.T) {
 			 'first msg text', 'uniquedisplayterm session',
 			 '2026-03-15T10:00:00Z'::timestamptz, 1, 1)
 		ON CONFLICT (id) DO NOTHING`)
-	if err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
+	require.NoError(t, err, "insert session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp, content_length)
@@ -601,35 +486,21 @@ func TestPGSearchSessionNameMatch(t *testing.T) {
 			('name-match-001', 0, 'user', 'no match here',
 			 '2026-03-15T10:00:00Z'::timestamptz, 13)
 		ON CONFLICT DO NOTHING`)
-	if err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	require.NoError(t, err, "insert message")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	page, err := store.Search(context.Background(), db.SearchFilter{
 		Query: "uniquedisplayterm", Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) != 1 {
-		t.Fatalf("got %d results, want 1", len(page.Results))
-	}
+	require.NoError(t, err, "Search")
+	require.Len(t, page.Results, 1)
 	r := page.Results[0]
-	if r.SessionID != "name-match-001" {
-		t.Errorf("got session %q, want name-match-001", r.SessionID)
-	}
-	if r.Ordinal != -1 {
-		t.Errorf("ordinal = %d, want -1 (name-only match)", r.Ordinal)
-	}
-	if r.Name == "" {
-		t.Error("Name field is empty")
-	}
+	assert.Equal(t, "name-match-001", r.SessionID)
+	assert.Equal(t, -1, r.Ordinal, "name-only match")
+	assert.NotEmpty(t, r.Name, "Name field is empty")
 }
 
 func TestPGSearchRecencyNameOnlyBeatsOlderContent(t *testing.T) {
@@ -637,9 +508,7 @@ func TestPGSearchRecencyNameOnlyBeatsOlderContent(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// older-content-001: message matches "recencytestterm", older timestamp
@@ -654,15 +523,11 @@ func TestPGSearchRecencyNameOnlyBeatsOlderContent(t *testing.T) {
 			('newer-name-recency', 'test-machine', 'test-project', 'claude',
 			 'first msg', '2026-01-02T10:00:00Z'::timestamptz, 1, 1)
 		ON CONFLICT (id) DO NOTHING`)
-	if err != nil {
-		t.Fatalf("insert sessions: %v", err)
-	}
+	require.NoError(t, err, "insert sessions")
 	_, err = pg.Exec(`
 		UPDATE sessions SET display_name = 'recencytestterm session'
 		WHERE id = 'newer-name-recency'`)
-	if err != nil {
-		t.Fatalf("set display_name: %v", err)
-	}
+	require.NoError(t, err, "set display_name")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp, content_length)
@@ -672,30 +537,20 @@ func TestPGSearchRecencyNameOnlyBeatsOlderContent(t *testing.T) {
 			('newer-name-recency', 0, 'user', 'no match here',
 			 '2026-01-02T10:00:00Z'::timestamptz, 13)
 		ON CONFLICT DO NOTHING`)
-	if err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, err, "insert messages")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	page, err := store.Search(context.Background(), db.SearchFilter{
 		Query: "recencytestterm", Limit: 10, Sort: "recency",
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) < 2 {
-		t.Fatalf("got %d results, want >= 2", len(page.Results))
-	}
+	require.NoError(t, err, "Search")
+	require.GreaterOrEqual(t, len(page.Results), 2)
 	// Recency mode: newer session (name-only) must appear before older content match.
-	if page.Results[0].SessionID != "newer-name-recency" {
-		t.Errorf("recency sort: first result = %q, want newer-name-recency (name-only but newer)",
-			page.Results[0].SessionID)
-	}
+	assert.Equal(t, "newer-name-recency", page.Results[0].SessionID,
+		"name-only but newer should win")
 }
 
 // TestPGSearchSnippetMatchingField verifies that when a session has a
@@ -707,9 +562,7 @@ func TestPGSearchSnippetMatchingField(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	// Session: display_name is set to something unrelated; only first_message
@@ -723,9 +576,7 @@ func TestPGSearchSnippetMatchingField(t *testing.T) {
 			 'snippetfieldterm in first message', 'unrelated display name',
 			 '2026-03-16T10:00:00Z'::timestamptz, 1, 1)
 		ON CONFLICT (id) DO NOTHING`)
-	if err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
+	require.NoError(t, err, "insert session")
 	// Message that does NOT contain the search term.
 	_, err = pg.Exec(`
 		INSERT INTO messages
@@ -734,36 +585,22 @@ func TestPGSearchSnippetMatchingField(t *testing.T) {
 			('snippet-field-001', 0, 'user', 'no match here',
 			 '2026-03-16T10:00:00Z'::timestamptz, 13)
 		ON CONFLICT DO NOTHING`)
-	if err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	require.NoError(t, err, "insert message")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	page, err := store.Search(context.Background(), db.SearchFilter{
 		Query: "snippetfieldterm", Limit: 10,
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) != 1 {
-		t.Fatalf("got %d results, want 1", len(page.Results))
-	}
+	require.NoError(t, err, "Search")
+	require.Len(t, page.Results, 1)
 	r := page.Results[0]
-	if r.SessionID != "snippet-field-001" {
-		t.Errorf("got session %q, want snippet-field-001", r.SessionID)
-	}
-	if r.Ordinal != -1 {
-		t.Errorf("ordinal = %d, want -1 (name-only match)", r.Ordinal)
-	}
+	assert.Equal(t, "snippet-field-001", r.SessionID)
+	assert.Equal(t, -1, r.Ordinal, "name-only match")
 	// Snippet must be first_message (the matching field), not display_name.
-	if r.Snippet != "snippetfieldterm in first message" {
-		t.Errorf("snippet = %q, want first_message text", r.Snippet)
-	}
+	assert.Equal(t, "snippetfieldterm in first message", r.Snippet)
 }
 
 // TestGetMessagesIsSystemField verifies that GetMessages and GetAllMessages
@@ -773,18 +610,13 @@ func TestGetMessagesIsSystemField(t *testing.T) {
 
 	const schema = "agentsview_is_system_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	ctx := context.Background()
-	if _, err := pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
 	_, err = pg.Exec(`
 		INSERT INTO sessions
@@ -794,9 +626,7 @@ func TestGetMessagesIsSystemField(t *testing.T) {
 			('is-system-001', 'test-machine', 'test-project', 'claude',
 			 'hello', '2026-03-16T10:00:00Z'::timestamptz, 2, 1)
 		ON CONFLICT (id) DO NOTHING`)
-	if err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
+	require.NoError(t, err, "insert session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content, timestamp, content_length, is_system)
@@ -806,45 +636,25 @@ func TestGetMessagesIsSystemField(t *testing.T) {
 			('is-system-001', 1, 'user', 'system message',
 			 '2026-03-16T10:00:01Z'::timestamptz, 14, TRUE)
 		ON CONFLICT DO NOTHING`)
-	if err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, err, "insert messages")
 
 	store, err := NewStore(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	// GetMessages
 	msgs, err := store.GetMessages(ctx, "is-system-001", 0, 10, true)
-	if err != nil {
-		t.Fatalf("GetMessages: %v", err)
-	}
-	if len(msgs) != 2 {
-		t.Fatalf("GetMessages: got %d messages, want 2", len(msgs))
-	}
-	if msgs[0].IsSystem {
-		t.Errorf("GetMessages: msgs[0].IsSystem = true, want false")
-	}
-	if !msgs[1].IsSystem {
-		t.Errorf("GetMessages: msgs[1].IsSystem = false, want true")
-	}
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, msgs, 2)
+	assert.False(t, msgs[0].IsSystem)
+	assert.True(t, msgs[1].IsSystem)
 
 	// GetAllMessages
 	all, err := store.GetAllMessages(ctx, "is-system-001")
-	if err != nil {
-		t.Fatalf("GetAllMessages: %v", err)
-	}
-	if len(all) != 2 {
-		t.Fatalf("GetAllMessages: got %d messages, want 2", len(all))
-	}
-	if all[0].IsSystem {
-		t.Errorf("GetAllMessages: all[0].IsSystem = true, want false")
-	}
-	if !all[1].IsSystem {
-		t.Errorf("GetAllMessages: all[1].IsSystem = false, want true")
-	}
+	require.NoError(t, err, "GetAllMessages")
+	require.Len(t, all, 2)
+	assert.False(t, all[0].IsSystem)
+	assert.True(t, all[1].IsSystem)
 }
 
 // TestGetMessagesIDPopulated regresses #439: scanPGMessages must
@@ -861,30 +671,23 @@ func TestGetMessagesIDPopulated(t *testing.T) {
 
 	const schema = "agentsview_msg_id_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	ctx := context.Background()
-	if _, err := pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
-	if _, err := pg.Exec(`
+	_, err = pg.Exec(`
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, message_count, user_message_count)
 		VALUES
 			('msg-id-001', 'test-machine', 'test-project', 'claude',
-			 'hello', '2026-03-16T10:00:00Z'::timestamptz, 4, 2)`,
-	); err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
-	if _, err := pg.Exec(`
+			 'hello', '2026-03-16T10:00:00Z'::timestamptz, 4, 2)`)
+	require.NoError(t, err, "insert session")
+	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
 			 timestamp, content_length, has_tool_use)
@@ -896,46 +699,35 @@ func TestGetMessagesIDPopulated(t *testing.T) {
 			('msg-id-001', 2, 'user', 'third',
 			 '2026-03-16T10:00:02Z'::timestamptz, 5, FALSE),
 			('msg-id-001', 3, 'assistant', 'fourth',
-			 '2026-03-16T10:00:03Z'::timestamptz, 6, TRUE)`,
-	); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+			 '2026-03-16T10:00:03Z'::timestamptz, 6, TRUE)`)
+	require.NoError(t, err, "insert messages")
 
 	store, err := NewStore(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	check := func(t *testing.T, label string, msgs []db.Message) {
 		t.Helper()
-		if len(msgs) != 4 {
-			t.Fatalf("%s: got %d messages, want 4", label, len(msgs))
-		}
+		require.Len(t, msgs, 4, label)
 		seen := map[int64]int{}
 		for i, m := range msgs {
-			if prev, ok := seen[m.ID]; ok {
-				t.Errorf("%s: msgs[%d].ID == msgs[%d].ID == %d (duplicate keys would crash Svelte each, regression of #439)",
-					label, prev, i, m.ID)
-			}
+			prev, ok := seen[m.ID]
+			assert.False(t, ok,
+				"%s: msgs[%d].ID == msgs[%d].ID == %d (regression of #439)",
+				label, prev, i, m.ID)
 			seen[m.ID] = i
-			if m.ID != int64(m.Ordinal) {
-				t.Errorf("%s: msgs[%d].ID = %d, want int64(ordinal=%d) for parity with TurnRow.MessageID",
-					label, i, m.ID, m.Ordinal)
-			}
+			assert.Equal(t, int64(m.Ordinal), m.ID,
+				"%s: msgs[%d].ID = %d, want int64(ordinal=%d)",
+				label, i, m.ID, m.Ordinal)
 		}
 	}
 
 	msgs, err := store.GetMessages(ctx, "msg-id-001", 0, 100, true)
-	if err != nil {
-		t.Fatalf("GetMessages: %v", err)
-	}
+	require.NoError(t, err, "GetMessages")
 	check(t, "GetMessages", msgs)
 
 	all, err := store.GetAllMessages(ctx, "msg-id-001")
-	if err != nil {
-		t.Fatalf("GetAllMessages: %v", err)
-	}
+	require.NoError(t, err, "GetAllMessages")
 	check(t, "GetAllMessages", all)
 
 	// Cross-check: every TurnRow.MessageID must correspond to a message
@@ -945,24 +737,17 @@ func TestGetMessagesIDPopulated(t *testing.T) {
 	// MessageID has no matching message means the join will silently
 	// drop timing data.
 	timing, err := store.GetSessionTiming(ctx, "msg-id-001")
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if timing == nil {
-		t.Fatal("GetSessionTiming returned nil")
-	}
-	if len(timing.Turns) == 0 {
-		t.Fatal("GetSessionTiming.Turns empty; cannot verify cross-check")
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	require.NotNil(t, timing, "GetSessionTiming returned nil")
+	require.NotEmpty(t, timing.Turns, "GetSessionTiming.Turns empty")
 	msgIDs := map[int64]bool{}
 	for _, m := range msgs {
 		msgIDs[m.ID] = true
 	}
 	for _, turn := range timing.Turns {
-		if !msgIDs[turn.MessageID] {
-			t.Errorf("turn.MessageID=%d has no matching message.ID; "+
+		assert.True(t, msgIDs[turn.MessageID],
+			"turn.MessageID=%d has no matching message.ID; "+
 				"frontend turnByMessage join will drop this turn",
-				turn.MessageID)
-		}
+			turn.MessageID)
 	}
 }

--- a/internal/postgres/pricing_pgtest_test.go
+++ b/internal/postgres/pricing_pgtest_test.go
@@ -4,8 +4,10 @@ package postgres
 
 import (
 	"context"
-	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/config"
 )
@@ -20,39 +22,24 @@ func TestLoadPricingMapAppliesCustomWhenTableMissing(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	if _, err := store.DB().ExecContext(
-		ctx, `DROP TABLE model_pricing`,
-	); err != nil {
-		t.Fatalf("drop model_pricing: %v", err)
-	}
+	_, err := store.DB().ExecContext(ctx, `DROP TABLE model_pricing`)
+	require.NoError(t, err, "drop model_pricing")
 
 	store.SetCustomPricing(map[string]config.CustomModelRate{
 		"acme-ultra-2.1": {Input: 9.0, Output: 18.0},
 	})
 
 	out, err := store.loadPricingMap(ctx)
-	if err != nil {
-		t.Fatalf("loadPricingMap: %v", err)
-	}
+	require.NoError(t, err, "loadPricingMap")
 
 	got, ok := out["acme-ultra-2.1"]
-	if !ok {
-		t.Fatalf("custom model missing from pricing map")
-	}
-	if math.Abs(got.input-9.0) > 0.001 {
-		t.Errorf("input = %.4f, want 9.0", got.input)
-	}
-	if math.Abs(got.output-18.0) > 0.001 {
-		t.Errorf("output = %.4f, want 18.0", got.output)
-	}
+	require.True(t, ok, "custom model missing from pricing map")
+	assert.InDelta(t, 9.0, got.input, 0.001)
+	assert.InDelta(t, 18.0, got.output, 0.001)
 
 	// Fallback pricing must still populate the map so real models
 	// continue to resolve when custom_model_pricing only covers a
 	// subset.
-	if len(out) < 2 {
-		t.Errorf(
-			"pricing map only has %d entries, expected fallback + custom",
-			len(out),
-		)
-	}
+	assert.GreaterOrEqual(t, len(out), 2,
+		"pricing map should have fallback + custom entries")
 }

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -1,8 +1,10 @@
 package postgres
 
 import (
-	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
@@ -51,12 +53,8 @@ func TestCustomPricingOverridesPricingMap(t *testing.T) {
 			out := pricingRowsToMap(tt.dbPrices)
 			s.applyCustomPricing(out)
 			got, ok := out[tt.model]
-			if !ok {
-				t.Fatalf("model %q not in map", tt.model)
-			}
-			if math.Abs(got.input-tt.wantInput) > 0.001 {
-				t.Errorf("input = %.4f, want %.4f", got.input, tt.wantInput)
-			}
+			require.True(t, ok, "model %q not in map", tt.model)
+			assert.InDelta(t, tt.wantInput, got.input, 0.001)
 		})
 	}
 }

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -27,26 +30,19 @@ func TestPushSystemFingerprintCollisionRegression(t *testing.T) {
 
 	const schema = "agentsview_push_sysfingerprint_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	ctx := context.Background()
-	if _, err := pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
 	// Local SQLite DB.
 	localDB, err := db.Open(
 		filepath.Join(t.TempDir(), "local.db"),
 	)
-	if err != nil {
-		t.Fatalf("db.Open: %v", err)
-	}
+	require.NoError(t, err, "db.Open")
 	defer localDB.Close()
 
 	sync := &Sync{
@@ -67,9 +63,7 @@ func TestPushSystemFingerprintCollisionRegression(t *testing.T) {
 		MessageCount: 7,
 		CreatedAt:    "2026-01-01T00:00:00Z",
 	}
-	if err := localDB.UpsertSession(sess); err != nil {
-		t.Fatalf("UpsertSession: %v", err)
-	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
 
 	// First set: system ordinals {0,4,5}.
 	firstSet := map[int]bool{0: true, 4: true, 5: true}
@@ -84,15 +78,11 @@ func TestPushSystemFingerprintCollisionRegression(t *testing.T) {
 			IsSystem:      firstSet[i],
 		}
 	}
-	if err := localDB.InsertMessages(msgs); err != nil {
-		t.Fatalf("InsertMessages (first set): %v", err)
-	}
+	require.NoError(t, localDB.InsertMessages(msgs), "InsertMessages (first set)")
 
 	// First push.
 	_, err = sync.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("Push (first): %v", err)
-	}
+	require.NoError(t, err, "Push (first)")
 
 	// Verify PG reflects system ordinals {0,4,5}.
 	checkIsSystem(t, pg, sessID, firstSet, 7)
@@ -104,27 +94,22 @@ func TestPushSystemFingerprintCollisionRegression(t *testing.T) {
 	for i := range 7 {
 		msgs[i].IsSystem = secondSet[i]
 	}
-	if err := localDB.ReplaceSessionMessages(sessID, msgs); err != nil {
-		t.Fatalf("ReplaceSessionMessages (second set): %v", err)
-	}
+	require.NoError(t, localDB.ReplaceSessionMessages(sessID, msgs),
+		"ReplaceSessionMessages (second set)")
 
 	// Force re-evaluation by clearing both the watermark and the cached
 	// session-level boundary fingerprints. The session-level fingerprint
 	// does not include is_system flags (only metadata like MessageCount),
 	// so the boundary cache must be cleared for the incremental push to
 	// reach pushMessages and compare the message-level string fingerprint.
-	if err := localDB.SetSyncState("last_push_at", ""); err != nil {
-		t.Fatalf("clearing last_push_at: %v", err)
-	}
-	if err := localDB.SetSyncState(lastPushBoundaryStateKey, ""); err != nil {
-		t.Fatalf("clearing boundary state: %v", err)
-	}
+	require.NoError(t, localDB.SetSyncState("last_push_at", ""),
+		"clearing last_push_at")
+	require.NoError(t, localDB.SetSyncState(lastPushBoundaryStateKey, ""),
+		"clearing boundary state")
 
 	// Second push — must NOT skip due to fingerprint match.
 	_, err = sync.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("Push (second): %v", err)
-	}
+	require.NoError(t, err, "Push (second)")
 
 	// Verify PG now reflects updated system ordinals {1,2,6}.
 	checkIsSystem(t, pg, sessID, secondSet, 7)
@@ -139,23 +124,16 @@ func TestPushSessionTerminationStatus(t *testing.T) {
 
 	const schema = "agentsview_push_termstatus_test"
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	ctx := context.Background()
-	if _, err := pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
 	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
-	if err != nil {
-		t.Fatalf("db.Open: %v", err)
-	}
+	require.NoError(t, err, "db.Open")
 	defer localDB.Close()
 
 	sync := &Sync{
@@ -183,44 +161,33 @@ func TestPushSessionTerminationStatus(t *testing.T) {
 	pushOnce := func(s db.Session) {
 		t.Helper()
 		tx, err := pg.BeginTx(ctx, nil)
-		if err != nil {
-			t.Fatalf("BeginTx: %v", err)
-		}
+		require.NoError(t, err, "BeginTx")
 		if err := sync.pushSession(ctx, tx, s); err != nil {
 			_ = tx.Rollback()
 			t.Fatalf("pushSession: %v", err)
 		}
-		if err := tx.Commit(); err != nil {
-			t.Fatalf("Commit: %v", err)
-		}
+		require.NoError(t, tx.Commit(), "Commit")
 	}
 
 	pushOnce(sess)
 
 	var got *string
-	if err := pg.QueryRow(
+	require.NoError(t, pg.QueryRow(
 		`SELECT termination_status FROM sessions WHERE id = $1`,
 		sess.ID,
-	).Scan(&got); err != nil {
-		t.Fatalf("read back: %v", err)
-	}
-	if got == nil || *got != "tool_call_pending" {
-		t.Fatalf("got %v, want tool_call_pending", got)
-	}
+	).Scan(&got), "read back")
+	require.NotNil(t, got)
+	assert.Equal(t, "tool_call_pending", *got)
 
 	// Update to NULL and verify ON CONFLICT clears it.
 	sess.TerminationStatus = nil
 	pushOnce(sess)
 
-	if err := pg.QueryRow(
+	require.NoError(t, pg.QueryRow(
 		`SELECT termination_status FROM sessions WHERE id = $1`,
 		sess.ID,
-	).Scan(&got); err != nil {
-		t.Fatalf("read back 2: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("got %q, want NULL", *got)
-	}
+	).Scan(&got), "read back 2")
+	assert.Nil(t, got)
 }
 
 // checkIsSystem asserts that PG contains exactly wantTotal rows for the
@@ -240,35 +207,23 @@ func checkIsSystem(
 		 WHERE session_id = $1 ORDER BY ordinal`,
 		sessID,
 	)
-	if err != nil {
-		t.Fatalf("querying PG messages: %v", err)
-	}
+	require.NoError(t, err, "querying PG messages")
 	defer rows.Close()
 	seen := make(map[int]bool, wantTotal)
 	for rows.Next() {
 		var ordinal int
 		var isSystem bool
-		if err := rows.Scan(&ordinal, &isSystem); err != nil {
-			t.Fatalf("scanning row: %v", err)
-		}
+		require.NoError(t, rows.Scan(&ordinal, &isSystem), "scanning row")
 		seen[ordinal] = true
 		want := wantSystem[ordinal]
-		if isSystem != want {
-			t.Errorf("ordinal %d: is_system=%v, want %v",
-				ordinal, isSystem, want)
-		}
+		assert.Equal(t, want, isSystem, "ordinal %d is_system", ordinal)
 	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("rows error: %v", err)
-	}
-	if len(seen) != wantTotal {
-		t.Errorf("PG has %d message rows for session %s, want %d",
-			len(seen), sessID, wantTotal)
-	}
+	require.NoError(t, rows.Err(), "rows error")
+	assert.Len(t, seen, wantTotal,
+		"PG has %d message rows for session %s, want %d",
+		len(seen), sessID, wantTotal)
 	// Verify every expected ordinal was present (no gaps or substitutions).
 	for i := range wantTotal {
-		if !seen[i] {
-			t.Errorf("ordinal %d missing from PG messages", i)
-		}
+		assert.True(t, seen[i], "ordinal %d missing from PG messages", i)
 	}
 }

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -91,23 +94,9 @@ func TestReadPushBoundaryStateValidity(t *testing.T) {
 				syncStateReaderStub{value: tc.raw},
 				cutoff,
 			)
-			if err != nil {
-				t.Fatalf(
-					"readBoundaryAndFingerprints: %v", err,
-				)
-			}
-			if valid != tc.wantValid {
-				t.Fatalf(
-					"valid = %v, want %v",
-					valid, tc.wantValid,
-				)
-			}
-			if len(got) != tc.wantLen {
-				t.Fatalf(
-					"len(state) = %d, want %d",
-					len(got), tc.wantLen,
-				)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantValid, valid)
+			require.Len(t, got, tc.wantLen)
 		})
 	}
 }
@@ -122,12 +111,7 @@ func TestLocalSessionSyncMarkerNormalizesSecondPrecisionTimestamps(t *testing.T)
 		EndedAt:   &endedAt,
 	})
 
-	if got != endedAt {
-		t.Fatalf(
-			"localSessionSyncMarker = %q, want %q",
-			got, endedAt,
-		)
-	}
+	require.Equal(t, endedAt, got)
 }
 
 func TestSessionPushFingerprintDiffers(t *testing.T) {
@@ -199,21 +183,13 @@ func TestSessionPushFingerprintDiffers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			modified := tc.modify(base)
 			fp2 := sessionPushFingerprint(modified, "")
-			if fp1 == fp2 {
-				t.Fatalf(
-					"fingerprint should differ after %s",
-					tc.name,
-				)
-			}
+			require.NotEqual(t, fp1, fp2,
+				"fingerprint should differ after %s", tc.name)
 		})
 	}
 
-	if fp1 != sessionPushFingerprint(base, "") {
-		t.Fatal(
-			"identical sessions should produce " +
-				"identical fingerprints",
-		)
-	}
+	assert.Equal(t, fp1, sessionPushFingerprint(base, ""),
+		"identical sessions should produce identical fingerprints")
 }
 
 func TestSessionPushFingerprintIncludesUsageEventFingerprint(
@@ -231,9 +207,8 @@ func TestSessionPushFingerprintIncludesUsageEventFingerprint(
 
 	withoutUsage := sessionPushFingerprint(base, "")
 	withUsage := sessionPushFingerprint(base, "usage-fp")
-	if withoutUsage == withUsage {
-		t.Fatal("usage event fingerprint should affect session fingerprint")
-	}
+	assert.NotEqual(t, withoutUsage, withUsage,
+		"usage event fingerprint should affect session fingerprint")
 }
 
 func TestSessionPushFingerprintNoFieldCollisions(
@@ -249,11 +224,10 @@ func TestSessionPushFingerprintNoFieldCollisions(
 		Project:   "bcd",
 		CreatedAt: "2026-03-11T12:00:00Z",
 	}
-	if sessionPushFingerprint(s1, "") == sessionPushFingerprint(s2, "") {
-		t.Fatal(
-			"length-prefixed fingerprints should not collide",
-		)
-	}
+	assert.NotEqual(t,
+		sessionPushFingerprint(s1, ""),
+		sessionPushFingerprint(s2, ""),
+		"length-prefixed fingerprints should not collide")
 }
 
 func TestFinalizePushStatePersistsEmptyBoundary(
@@ -262,42 +236,18 @@ func TestFinalizePushStatePersistsEmptyBoundary(
 	const cutoff = "2026-03-11T12:34:56.123Z"
 
 	store := &syncStateStoreStub{}
-	if err := finalizePushState(
+	require.NoError(t, finalizePushState(
 		store, cutoff, nil, nil, map[string]string{},
-	); err != nil {
-		t.Fatalf("finalizePushState: %v", err)
-	}
-	if got := store.values["last_push_at"]; got != cutoff {
-		t.Fatalf(
-			"last_push_at = %q, want %q", got, cutoff,
-		)
-	}
+	))
+	assert.Equal(t, cutoff, store.values["last_push_at"])
 
 	raw := store.values[lastPushBoundaryStateKey]
-	if raw == "" {
-		t.Fatal(
-			"last_push_boundary_state should be written",
-		)
-	}
+	require.NotEmpty(t, raw, "last_push_boundary_state should be written")
 
 	var state pushBoundaryState
-	if err := json.Unmarshal(
-		[]byte(raw), &state,
-	); err != nil {
-		t.Fatalf("unmarshal boundary state: %v", err)
-	}
-	if state.Cutoff != cutoff {
-		t.Fatalf(
-			"boundary cutoff = %q, want %q",
-			state.Cutoff, cutoff,
-		)
-	}
-	if len(state.Fingerprints) != 0 {
-		t.Fatalf(
-			"boundary fingerprints = %v, want empty",
-			state.Fingerprints,
-		)
-	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &state))
+	assert.Equal(t, cutoff, state.Cutoff)
+	assert.Empty(t, state.Fingerprints)
 }
 
 func TestFinalizePushStateMergesPriorFingerprints(
@@ -318,43 +268,22 @@ func TestFinalizePushStateMergesPriorFingerprints(
 	}
 
 	store := &syncStateStoreStub{}
-	if err := finalizePushState(
+	require.NoError(t, finalizePushState(
 		store, cutoff, cycle2Sessions,
 		priorFingerprints,
 		map[string]string{"sess-002": sessionPushFingerprint(cycle2Sessions[0], "")},
-	); err != nil {
-		t.Fatalf("finalizePushState: %v", err)
-	}
+	))
 
 	raw := store.values[lastPushBoundaryStateKey]
-	if raw == "" {
-		t.Fatal(
-			"last_push_boundary_state should be written",
-		)
-	}
+	require.NotEmpty(t, raw, "last_push_boundary_state should be written")
 
 	var state pushBoundaryState
-	if err := json.Unmarshal(
-		[]byte(raw), &state,
-	); err != nil {
-		t.Fatalf("unmarshal boundary state: %v", err)
-	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &state))
 
-	if len(state.Fingerprints) != 2 {
-		t.Fatalf(
-			"len(fingerprints) = %d, want 2",
-			len(state.Fingerprints),
-		)
-	}
-	if state.Fingerprints["sess-001"] != "fp-001" {
-		t.Fatalf(
-			"sess-001 fingerprint = %q, want %q",
-			state.Fingerprints["sess-001"], "fp-001",
-		)
-	}
-	if _, ok := state.Fingerprints["sess-002"]; !ok {
-		t.Fatal("sess-002 fingerprint should be present")
-	}
+	require.Len(t, state.Fingerprints, 2)
+	assert.Equal(t, "fp-001", state.Fingerprints["sess-001"])
+	_, ok := state.Fingerprints["sess-002"]
+	assert.True(t, ok, "sess-002 fingerprint should be present")
 }
 
 func TestSanitizePG(t *testing.T) {
@@ -407,51 +336,27 @@ func TestSanitizePG(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := sanitizePG(tc.input)
-			if got != tc.want {
-				t.Errorf(
-					"sanitizePG(%q) = %q, want %q",
-					tc.input, got, tc.want,
-				)
-			}
+			assert.Equal(t, tc.want, sanitizePG(tc.input))
 		})
 	}
 }
 
 func TestNilIfEmptySanitizes(t *testing.T) {
-	got := nilIfEmpty("hello\x00world")
-	if got != "helloworld" {
-		t.Errorf(
-			"nilIfEmpty with null byte = %q, want %q",
-			got, "helloworld",
-		)
-	}
+	assert.Equal(t, any("helloworld"), nilIfEmpty("hello\x00world"))
 
-	if nilIfEmpty("") != nil {
-		t.Error("nilIfEmpty(\"\") should be nil")
-	}
+	assert.Nil(t, nilIfEmpty(""), "nilIfEmpty(\"\") should be nil")
 
 	// A string that reduces to empty after sanitization
 	// should return nil, not "".
-	if nilIfEmpty("\x00") != nil {
-		t.Error("nilIfEmpty(\"\\x00\") should be nil")
-	}
+	assert.Nil(t, nilIfEmpty("\x00"), "nilIfEmpty(\"\\x00\") should be nil")
 }
 
 func TestNilStrSanitizes(t *testing.T) {
 	s := "hello\xe2world"
-	got := nilStr(&s)
-	if got != "helloworld" {
-		t.Errorf(
-			"nilStr with invalid UTF-8 = %q, want %q",
-			got, "helloworld",
-		)
-	}
+	assert.Equal(t, any("helloworld"), nilStr(&s))
 
 	// A *string that reduces to empty after sanitization
 	// should return nil.
 	nul := "\x00"
-	if nilStr(&nul) != nil {
-		t.Error("nilStr(\"\\x00\") should be nil")
-	}
+	assert.Nil(t, nilStr(&nul), "nilStr(\"\\x00\") should be nil")
 }

--- a/internal/postgres/push_thinking_pgtest_test.go
+++ b/internal/postgres/push_thinking_pgtest_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -26,15 +29,11 @@ func TestPushThinkingText_SanitizesNullAndInvalidUTF8(t *testing.T) {
 		"thinking-test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := time.Now().UTC().Format(time.RFC3339)
 	first := "hello"
@@ -47,48 +46,33 @@ func TestPushThinkingText_SanitizesNullAndInvalidUTF8(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert: %v", err)
-	}
+	require.NoError(t, local.UpsertSession(sess), "upsert")
 
 	// Message whose thinking_text contains a NUL byte and a
 	// truncated multi-byte UTF-8 sequence. Before the fix the
 	// insert would fail with "invalid byte sequence".
 	thinking := "plan\x00step\xe2"
-	if err := local.InsertMessages([]db.Message{{
+	require.NoError(t, local.InsertMessages([]db.Message{{
 		SessionID:    "think-1",
 		Ordinal:      0,
 		Role:         "assistant",
 		Content:      "ok",
 		ThinkingText: thinking,
 		HasThinking:  true,
-	}}); err != nil {
-		t.Fatalf("insert local message: %v", err)
-	}
+	}}), "insert local message")
 
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("push: %v", err)
-	}
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "push")
 
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	msgs, err := store.GetMessages(ctx, "think-1", 0, 10, true)
-	if err != nil {
-		t.Fatalf("GetMessages: %v", err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("got %d messages, want 1", len(msgs))
-	}
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, msgs, 1)
 	// NUL bytes and invalid UTF-8 must be stripped; the
 	// remaining text stays intact and in order.
-	if got, want := msgs[0].ThinkingText, "planstep"; got != want {
-		t.Errorf(
-			"ThinkingText = %q, want %q (sanitize skipped?)",
-			got, want,
-		)
-	}
+	assert.Equal(t, "planstep", msgs[0].ThinkingText,
+		"sanitize skipped?")
 }

--- a/internal/postgres/schema_pgtest_test.go
+++ b/internal/postgres/schema_pgtest_test.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const schemaTestSchema = "agentsview_schema_test"
@@ -13,9 +16,7 @@ const schemaTestSchema = "agentsview_schema_test"
 func cleanSchemaTestPG(t *testing.T, pgURL string) {
 	t.Helper()
 	pg, err := sql.Open("pgx", pgURL)
-	if err != nil {
-		t.Fatalf("connecting to pg: %v", err)
-	}
+	require.NoError(t, err, "connecting to pg")
 	defer pg.Close()
 	_, _ = pg.Exec(
 		"DROP SCHEMA IF EXISTS " + schemaTestSchema + " CASCADE",
@@ -32,20 +33,16 @@ func TestSecretFindingsSchema(t *testing.T) {
 	t.Cleanup(func() { cleanSchemaTestPG(t, pgURL) })
 
 	pg, err := Open(pgURL, schemaTestSchema, true)
-	if err != nil {
-		t.Fatalf("connecting to pg: %v", err)
-	}
+	require.NoError(t, err, "connecting to pg")
 	defer pg.Close()
 
 	ctx := context.Background()
 
 	// Run EnsureSchema twice to verify idempotency.
-	if err := EnsureSchema(ctx, pg, schemaTestSchema); err != nil {
-		t.Fatalf("EnsureSchema (first): %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schemaTestSchema); err != nil {
-		t.Fatalf("EnsureSchema (second, idempotency check): %v", err)
-	}
+	require.NoError(t, EnsureSchema(ctx, pg, schemaTestSchema),
+		"EnsureSchema (first)")
+	require.NoError(t, EnsureSchema(ctx, pg, schemaTestSchema),
+		"EnsureSchema (second, idempotency check)")
 
 	// Verify secret_findings table exists.
 	var tableExists bool
@@ -55,12 +52,8 @@ func TestSecretFindingsSchema(t *testing.T) {
 			WHERE table_schema = $1
 			  AND table_name = 'secret_findings'
 		)`, schemaTestSchema).Scan(&tableExists)
-	if err != nil {
-		t.Fatalf("checking secret_findings table: %v", err)
-	}
-	if !tableExists {
-		t.Fatal("secret_findings table does not exist")
-	}
+	require.NoError(t, err, "checking secret_findings table")
+	require.True(t, tableExists, "secret_findings table does not exist")
 
 	// Verify all required columns on secret_findings.
 	requiredFindingsCols := []string{
@@ -79,16 +72,8 @@ func TestSecretFindingsSchema(t *testing.T) {
 				  AND table_name = 'secret_findings'
 				  AND column_name = $2
 			)`, schemaTestSchema, col).Scan(&exists)
-		if err != nil {
-			t.Fatalf(
-				"checking secret_findings.%s: %v", col, err,
-			)
-		}
-		if !exists {
-			t.Errorf(
-				"secret_findings.%s column missing", col,
-			)
-		}
+		require.NoError(t, err, "checking secret_findings.%s", col)
+		assert.True(t, exists, "secret_findings.%s column missing", col)
 	}
 
 	// Verify sessions has both secret-scan state columns.
@@ -105,13 +90,7 @@ func TestSecretFindingsSchema(t *testing.T) {
 				  AND table_name = 'sessions'
 				  AND column_name = $2
 			)`, schemaTestSchema, col).Scan(&exists)
-		if err != nil {
-			t.Fatalf(
-				"checking sessions.%s: %v", col, err,
-			)
-		}
-		if !exists {
-			t.Errorf("sessions.%s column missing", col)
-		}
+		require.NoError(t, err, "checking sessions.%s", col)
+		assert.True(t, exists, "sessions.%s column missing", col)
 	}
 }

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type schemaProbeDriver struct{}
@@ -65,9 +68,7 @@ func newSchemaProbeDB(
 	})
 
 	db, err := sql.Open("agentsview_schema_probe", name)
-	if err != nil {
-		t.Fatalf("open fake schema probe db: %v", err)
-	}
+	require.NoError(t, err, "open fake schema probe db")
 	t.Cleanup(func() { db.Close() })
 	return db, state
 }
@@ -210,16 +211,10 @@ func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
 	}
 	db, state := newSchemaProbeDB(t, existing)
 
-	if err := EnsureSchema(context.Background(), db, "agentsview"); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	require.NoError(t, EnsureSchema(context.Background(), db, "agentsview"))
 
-	if got := state.informationQueryCount(); got != 1 {
-		t.Fatalf(
-			"information_schema.columns queries = %d, want 1",
-			got,
-		)
-	}
+	assert.Equal(t, 1, state.informationQueryCount(),
+		"information_schema.columns queries")
 }
 
 func TestEnsureSchemaGroupsMissingColumnMigrationsByTable(t *testing.T) {
@@ -254,14 +249,10 @@ func TestEnsureSchemaGroupsMissingColumnMigrationsByTable(t *testing.T) {
 		},
 	})
 
-	if err := EnsureSchema(context.Background(), db, "agentsview"); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	require.NoError(t, EnsureSchema(context.Background(), db, "agentsview"))
 
 	// Two tables have missing columns (sessions: termination_status;
 	// messages: source_parent_uuid, is_sidechain, is_compact_boundary,
 	// thinking_text). Per-table batching means one ALTER each.
-	if got := state.alterTableExecCount(); got != 2 {
-		t.Fatalf("ALTER TABLE execs = %d, want 2", got)
-	}
+	assert.Equal(t, 2, state.alterTableExecCount(), "ALTER TABLE execs")
 }

--- a/internal/postgres/search_content_pgtest_test.go
+++ b/internal/postgres/search_content_pgtest_test.go
@@ -4,8 +4,12 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
 )
@@ -21,23 +25,16 @@ func setupContentSearch(t *testing.T) *Store {
 	pgURL := testPGURL(t)
 
 	pg, err := Open(pgURL, contentSearchSchema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
-	if _, err := pg.Exec(`DROP SCHEMA IF EXISTS ` + contentSearchSchema + ` CASCADE`); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + contentSearchSchema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
 	ctx := context.Background()
-	if err := EnsureSchema(ctx, pg, contentSearchSchema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	require.NoError(t, EnsureSchema(ctx, pg, contentSearchSchema), "EnsureSchema")
 
 	store, err := NewStore(pgURL, contentSearchSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	t.Cleanup(func() { store.Close() })
 	return store
 }
@@ -59,9 +56,7 @@ func insertCSSession(
 		ON CONFLICT (id) DO NOTHING`,
 		id, project, agent, startedAt, endedAt,
 	)
-	if err != nil {
-		t.Fatalf("insert session %s: %v", id, err)
-	}
+	require.NoError(t, err, "insert session %s", id)
 }
 
 // insertCSMessage inserts a message; isSystem=true sets is_system.
@@ -78,9 +73,7 @@ func insertCSMessage(
 		ON CONFLICT DO NOTHING`,
 		sessionID, ordinal, role, content, ts, len(content), isSystem,
 	)
-	if err != nil {
-		t.Fatalf("insert message ord=%d: %v", ordinal, err)
-	}
+	require.NoError(t, err, "insert message ord=%d", ordinal)
 }
 
 // insertCSToolCall inserts a tool_call row.
@@ -99,9 +92,7 @@ func insertCSToolCall(
 		sessionID, messageOrdinal, callIndex, toolName,
 		toolName, toolUseID, inputJSON, resultContent,
 	)
-	if err != nil {
-		t.Fatalf("insert tool_call: %v", err)
-	}
+	require.NoError(t, err, "insert tool_call")
 }
 
 // insertCSToolResultEvent inserts a tool_result_event row.
@@ -119,9 +110,7 @@ func insertCSToolResultEvent(
 		ON CONFLICT DO NOTHING`,
 		sessionID, messageOrdinal, callIndex, toolUseID, content, eventIndex,
 	)
-	if err != nil {
-		t.Fatalf("insert tool_result_event: %v", err)
-	}
+	require.NoError(t, err, "insert tool_result_event")
 }
 
 // ---- tests ----
@@ -142,22 +131,14 @@ func TestPGSearchContentSubstringMessages(t *testing.T) {
 		Sources: []string{"messages"}, Limit: 50,
 		IncludeOneShot: true,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 {
-		t.Fatalf("got %d matches, want 1: %+v", len(got.Matches), got.Matches)
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1, "matches=%+v", got.Matches)
 	m := got.Matches[0]
-	if m.SessionID != "cs-m1" || m.Location != "message" || m.Ordinal != 0 {
-		t.Errorf("unexpected match: %+v", m)
-	}
-	if m.Role != "user" {
-		t.Errorf("Role = %q, want user", m.Role)
-	}
-	if m.Snippet == "" {
-		t.Errorf("Snippet is empty")
-	}
+	assert.Equal(t, "cs-m1", m.SessionID)
+	assert.Equal(t, "message", m.Location)
+	assert.Equal(t, 0, m.Ordinal)
+	assert.Equal(t, "user", m.Role)
+	assert.NotEmpty(t, m.Snippet)
 }
 
 // TestPGSearchContentRedactsStraddlingSecret pins the PG default (non-reveal)
@@ -179,24 +160,16 @@ func TestPGSearchContentRedactsStraddlingSecret(t *testing.T) {
 		Sources: []string{"messages"}, Limit: 50, IncludeOneShot: true,
 	}
 	got, err := store.SearchContent(ctx, base)
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 {
-		t.Fatalf("got %d matches, want 1: %+v", len(got.Matches), got.Matches)
-	}
-	if strings.Contains(got.Matches[0].Snippet, "SECRETKEYMATERIAL") {
-		t.Errorf("default snippet leaked key material: %q", got.Matches[0].Snippet)
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1, "matches=%+v", got.Matches)
+	assert.NotContains(t, got.Matches[0].Snippet, "SECRETKEYMATERIAL",
+		"default snippet leaked key material")
 
 	base.RevealSecrets = true
 	rev, err := store.SearchContent(ctx, base)
-	if err != nil {
-		t.Fatalf("SearchContent reveal: %v", err)
-	}
-	if !strings.Contains(rev.Matches[0].Snippet, "SECRETKEYMATERIAL") {
-		t.Errorf("reveal snippet should show raw bytes: %q", rev.Matches[0].Snippet)
-	}
+	require.NoError(t, err, "SearchContent reveal")
+	assert.Contains(t, rev.Matches[0].Snippet, "SECRETKEYMATERIAL",
+		"reveal snippet should show raw bytes")
 }
 
 // TestPGSearchContentSubstringToolInput verifies substring match in tool_input.
@@ -214,19 +187,11 @@ func TestPGSearchContentSubstringToolInput(t *testing.T) {
 		Pattern: "printenv", Mode: "substring",
 		Sources: []string{"tool_input"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 {
-		t.Fatalf("got %d matches, want 1: %+v", len(got.Matches), got.Matches)
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1, "matches=%+v", got.Matches)
 	m := got.Matches[0]
-	if m.Location != "tool_input" {
-		t.Errorf("Location = %q, want tool_input", m.Location)
-	}
-	if m.ToolName != "Bash" {
-		t.Errorf("ToolName = %q, want Bash", m.ToolName)
-	}
+	assert.Equal(t, "tool_input", m.Location)
+	assert.Equal(t, "Bash", m.ToolName)
 }
 
 // TestPGSearchContentSubstringToolResult verifies substring match in tool_result
@@ -245,12 +210,9 @@ func TestPGSearchContentSubstringToolResult(t *testing.T) {
 		Pattern: "topsecretvalue", Mode: "substring",
 		Sources: []string{"tool_result"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 || got.Matches[0].Location != "tool_result" {
-		t.Fatalf("tool_result search: %+v", got.Matches)
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1, "matches=%+v", got.Matches)
+	assert.Equal(t, "tool_result", got.Matches[0].Location)
 }
 
 // TestPGSearchContentToolResultEvents verifies that the tool_result_events
@@ -272,12 +234,9 @@ func TestPGSearchContentToolResultEvents(t *testing.T) {
 		Pattern: "EVENTNEEDLE", Mode: "substring",
 		Sources: []string{"tool_result"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 || got.Matches[0].Location != "tool_result" {
-		t.Fatalf("event branch search: %+v", got.Matches)
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1, "matches=%+v", got.Matches)
+	assert.Equal(t, "tool_result", got.Matches[0].Location)
 }
 
 // TestPGSearchContentToolResultDedup verifies dedup: when a tool_use_id has
@@ -301,13 +260,9 @@ func TestPGSearchContentToolResultDedup(t *testing.T) {
 		Pattern: "DUPNEEDLE", Mode: "substring",
 		Sources: []string{"tool_result"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
+	require.NoError(t, err, "SearchContent")
 	// Should be exactly 1 match (from the event, not result_content).
-	if len(got.Matches) != 1 {
-		t.Fatalf("dedup: got %d matches, want 1: %+v", len(got.Matches), got.Matches)
-	}
+	require.Len(t, got.Matches, 1, "dedup: matches=%+v", got.Matches)
 }
 
 // TestPGSearchContentSourcesSelector verifies that searching only "messages"
@@ -327,24 +282,18 @@ func TestPGSearchContentSourcesSelector(t *testing.T) {
 		Pattern: "SRCNEEDLE", Mode: "substring",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 0 {
-		t.Errorf("messages-only source returned tool match: %+v", got.Matches)
-	}
+	require.NoError(t, err, "SearchContent")
+	assert.Empty(t, got.Matches,
+		"messages-only source returned tool match")
 
 	// Both tool sources — must match.
 	all, err := store.SearchContent(ctx, db.ContentSearchFilter{
 		Pattern: "SRCNEEDLE", Mode: "substring",
 		Sources: []string{"tool_input", "tool_result"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent all: %v", err)
-	}
-	if len(all.Matches) == 0 {
-		t.Error("expected matches when sources include tool_input/tool_result")
-	}
+	require.NoError(t, err, "SearchContent all")
+	assert.NotEmpty(t, all.Matches,
+		"expected matches when sources include tool_input/tool_result")
 }
 
 // TestPGSearchContentExcludeSystem verifies that is_system=true messages are
@@ -363,24 +312,17 @@ func TestPGSearchContentExcludeSystem(t *testing.T) {
 		Pattern: "SYSNEEDLE", Mode: "substring",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent with system: %v", err)
-	}
-	if len(with.Matches) != 1 {
-		t.Errorf("expected 1 match without ExcludeSystem, got %d", len(with.Matches))
-	}
+	require.NoError(t, err, "SearchContent with system")
+	assert.Len(t, with.Matches, 1)
 
 	// ExcludeSystem=true should suppress it.
 	without, err := store.SearchContent(ctx, db.ContentSearchFilter{
 		Pattern: "SYSNEEDLE", Mode: "substring",
 		Sources: []string{"messages"}, ExcludeSystem: true, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent exclude system: %v", err)
-	}
-	if len(without.Matches) != 0 {
-		t.Errorf("ExcludeSystem=true should suppress system messages, got %d", len(without.Matches))
-	}
+	require.NoError(t, err, "SearchContent exclude system")
+	assert.Empty(t, without.Matches,
+		"ExcludeSystem=true should suppress system messages")
 }
 
 // TestPGSearchContentProjectFilter verifies the Project session filter.
@@ -402,17 +344,11 @@ func TestPGSearchContentProjectFilter(t *testing.T) {
 		Project: "alpha",
 		Limit:   50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent project filter: %v", err)
-	}
+	require.NoError(t, err, "SearchContent project filter")
 	for _, m := range got.Matches {
-		if m.Project != "alpha" {
-			t.Errorf("project filter leak: got project %q", m.Project)
-		}
+		assert.Equal(t, "alpha", m.Project, "project filter leak")
 	}
-	if len(got.Matches) == 0 {
-		t.Error("expected matches in alpha project")
-	}
+	assert.NotEmpty(t, got.Matches, "expected matches in alpha project")
 }
 
 // TestPGSearchContentPagination verifies Limit+1 sentinel and NextCursor.
@@ -430,29 +366,17 @@ func TestPGSearchContentPagination(t *testing.T) {
 		Pattern: "PAGENEEDLE", Mode: "substring",
 		Sources: []string{"messages"}, Limit: 2,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent page1: %v", err)
-	}
-	if len(first.Matches) != 2 {
-		t.Fatalf("page1: got %d matches, want 2", len(first.Matches))
-	}
-	if first.NextCursor == 0 {
-		t.Fatal("page1: expected NextCursor to be set")
-	}
+	require.NoError(t, err, "SearchContent page1")
+	require.Len(t, first.Matches, 2)
+	require.NotZero(t, first.NextCursor, "page1: expected NextCursor to be set")
 
 	second, err := store.SearchContent(ctx, db.ContentSearchFilter{
 		Pattern: "PAGENEEDLE", Mode: "substring",
 		Sources: []string{"messages"}, Limit: 2, Cursor: first.NextCursor,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent page2: %v", err)
-	}
-	if len(second.Matches) != 1 {
-		t.Fatalf("page2: got %d matches, want 1", len(second.Matches))
-	}
-	if second.NextCursor != 0 {
-		t.Errorf("page2: NextCursor = %d, want 0 (last page)", second.NextCursor)
-	}
+	require.NoError(t, err, "SearchContent page2")
+	require.Len(t, second.Matches, 1)
+	assert.Zero(t, second.NextCursor, "page2: last page")
 }
 
 // TestPGSearchContentPaginationStableAcrossTies seeds one message ordinal that
@@ -476,17 +400,11 @@ func TestPGSearchContentPaginationStableAcrossTies(t *testing.T) {
 	full := base
 	full.Limit = 50
 	all, err := store.SearchContent(ctx, full)
-	if err != nil {
-		t.Fatalf("SearchContent full: %v", err)
-	}
-	if len(all.Matches) != 3 {
-		t.Fatalf("want 3 tied matches, got %d: %+v", len(all.Matches), all.Matches)
-	}
+	require.NoError(t, err, "SearchContent full")
+	require.Len(t, all.Matches, 3, "tied matches: %+v", all.Matches)
 	wantOrder := []string{"message", "tool_input", "tool_result"}
 	for i, loc := range wantOrder {
-		if all.Matches[i].Location != loc {
-			t.Errorf("match %d Location = %q, want %q", i, all.Matches[i].Location, loc)
-		}
+		assert.Equal(t, loc, all.Matches[i].Location, "match %d", i)
 	}
 	var paged []db.ContentMatch
 	for cursor := 0; ; {
@@ -494,23 +412,17 @@ func TestPGSearchContentPaginationStableAcrossTies(t *testing.T) {
 		p.Limit = 1
 		p.Cursor = cursor
 		page, err := store.SearchContent(ctx, p)
-		if err != nil {
-			t.Fatalf("SearchContent page at cursor %d: %v", cursor, err)
-		}
+		require.NoError(t, err, "SearchContent page at cursor %d", cursor)
 		paged = append(paged, page.Matches...)
 		if page.NextCursor == 0 {
 			break
 		}
 		cursor = page.NextCursor
 	}
-	if len(paged) != len(all.Matches) {
-		t.Fatalf("paged %d rows, want %d (duplicates or gaps)", len(paged), len(all.Matches))
-	}
+	require.Len(t, paged, len(all.Matches), "duplicates or gaps")
 	for i := range all.Matches {
-		if paged[i].Location != all.Matches[i].Location {
-			t.Errorf("row %d: paged Location %q != single-page %q",
-				i, paged[i].Location, all.Matches[i].Location)
-		}
+		assert.Equal(t, all.Matches[i].Location, paged[i].Location,
+			"row %d: paged vs single-page", i)
 	}
 }
 
@@ -537,13 +449,10 @@ func TestPGSearchContentEmptyToolUseIDNotSuppressed(t *testing.T) {
 			Pattern: "FINDA", Mode: mode,
 			Sources: []string{"tool_result"}, Limit: 50,
 		})
-		if err != nil {
-			t.Fatalf("SearchContent %s: %v", mode, err)
-		}
-		if len(got.Matches) != 1 || got.Matches[0].Location != "tool_result" {
-			t.Fatalf("%s: empty-ID result_content suppressed: got %+v",
-				mode, got.Matches)
-		}
+		require.NoError(t, err, "SearchContent %s", mode)
+		require.Len(t, got.Matches, 1,
+			"%s: empty-ID result_content suppressed: %+v", mode, got.Matches)
+		assert.Equal(t, "tool_result", got.Matches[0].Location)
 	}
 }
 
@@ -556,27 +465,22 @@ func TestPGContentSearchTrigramIndex(t *testing.T) {
 	ctx := context.Background()
 
 	var hasExt bool
-	if err := store.DB().QueryRowContext(ctx,
+	require.NoError(t, store.DB().QueryRowContext(ctx,
 		`SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm')`,
-	).Scan(&hasExt); err != nil {
-		t.Fatalf("query pg_extension: %v", err)
-	}
+	).Scan(&hasExt), "query pg_extension")
 	if !hasExt {
 		t.Skip("pg_trgm not installable on this instance; index is best-effort")
 	}
 
 	var hasIdx bool
-	if err := store.DB().QueryRowContext(ctx,
+	require.NoError(t, store.DB().QueryRowContext(ctx,
 		`SELECT EXISTS (
 			SELECT 1 FROM pg_indexes
 			WHERE schemaname = $1 AND indexname = 'idx_messages_content_trgm'
 		)`, contentSearchSchema,
-	).Scan(&hasIdx); err != nil {
-		t.Fatalf("query pg_indexes: %v", err)
-	}
-	if !hasIdx {
-		t.Errorf("idx_messages_content_trgm missing after EnsureSchema")
-	}
+	).Scan(&hasIdx), "query pg_indexes")
+	assert.True(t, hasIdx,
+		"idx_messages_content_trgm missing after EnsureSchema")
 }
 
 // TestPGSearchContentRegex verifies regex mode.
@@ -594,12 +498,9 @@ func TestPGSearchContentRegex(t *testing.T) {
 		Pattern: `AKIA[0-9A-Z]{16}`, Mode: "regex",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent regex: %v", err)
-	}
-	if len(got.Matches) != 1 || got.Matches[0].Ordinal != 0 {
-		t.Fatalf("regex match = %+v, want 1 at ordinal 0", got.Matches)
-	}
+	require.NoError(t, err, "SearchContent regex")
+	require.Len(t, got.Matches, 1)
+	assert.Equal(t, 0, got.Matches[0].Ordinal)
 }
 
 // TestPGSearchContentRegexInvalid verifies that an invalid pattern returns a
@@ -611,14 +512,10 @@ func TestPGSearchContentRegexInvalid(t *testing.T) {
 		Pattern: `(unclosed`, Mode: "regex",
 		Sources: []string{"messages"},
 	})
-	if err == nil {
-		t.Fatal("expected error for invalid regex")
-	}
+	require.Error(t, err, "expected error for invalid regex")
 	var inputErr *db.SearchInputError
-	if _, ok := err.(*db.SearchInputError); !ok {
-		_ = inputErr
-		t.Errorf("expected *SearchInputError, got %T: %v", err, err)
-	}
+	assert.True(t, errors.As(err, &inputErr),
+		"expected *SearchInputError, got %T: %v", err, err)
 }
 
 // TestPGSearchContentFTSFallsBackToSubstring verifies that fts mode runs
@@ -635,12 +532,9 @@ func TestPGSearchContentFTSFallsBackToSubstring(t *testing.T) {
 		Pattern: "optimize", Mode: "fts",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent fts (should fall back): %v", err)
-	}
-	if len(got.Matches) != 1 || got.Matches[0].Location != "message" {
-		t.Fatalf("fts fallback = %+v, want 1 message", got.Matches)
-	}
+	require.NoError(t, err, "SearchContent fts (should fall back)")
+	require.Len(t, got.Matches, 1)
+	assert.Equal(t, "message", got.Matches[0].Location)
 }
 
 // TestPGSearchContentUnknownSource verifies that an unknown source name
@@ -652,12 +546,10 @@ func TestPGSearchContentUnknownSource(t *testing.T) {
 		Pattern: "x", Mode: "substring",
 		Sources: []string{"messages", "bogus"},
 	})
-	if err == nil {
-		t.Fatal("expected error for unknown source name")
-	}
-	if _, ok := err.(*db.SearchInputError); !ok {
-		t.Errorf("expected *SearchInputError, got %T: %v", err, err)
-	}
+	require.Error(t, err, "expected error for unknown source name")
+	var inputErr *db.SearchInputError
+	assert.True(t, errors.As(err, &inputErr),
+		"expected *SearchInputError, got %T: %v", err, err)
 }
 
 // TestPGSearchContentSnippetPresent verifies that the snippet field is
@@ -674,15 +566,9 @@ func TestPGSearchContentSnippetPresent(t *testing.T) {
 		Pattern: "SNIPNEEDLE", Mode: "substring",
 		Sources: []string{"messages"}, Limit: 50,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent: %v", err)
-	}
-	if len(got.Matches) != 1 {
-		t.Fatalf("got %d matches, want 1", len(got.Matches))
-	}
-	if got.Matches[0].Snippet == "" {
-		t.Error("Snippet is empty, want non-empty")
-	}
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1)
+	assert.NotEmpty(t, got.Matches[0].Snippet)
 }
 
 // insertCSChildSession inserts a child session (relationship_type=subagent)
@@ -704,9 +590,7 @@ func insertCSChildSession(
 		ON CONFLICT (id) DO NOTHING`,
 		id, project, agent, parentID, startedAt, endedAt,
 	)
-	if err != nil {
-		t.Fatalf("insert child session %s: %v", id, err)
-	}
+	require.NoError(t, err, "insert child session %s", id)
 }
 
 // TestPGSearchContentIncludeChildren verifies that IncludeChildren=true
@@ -753,9 +637,7 @@ func TestPGSearchContentIncludeChildren(t *testing.T) {
 		IncludeChildren: true,
 		IncludeOneShot:  true,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent IncludeChildren=true: %v", err)
-	}
+	require.NoError(t, err, "SearchContent IncludeChildren=true")
 
 	var foundToolInput, foundToolResult bool
 	for _, m := range withChildren.Matches {
@@ -766,18 +648,12 @@ func TestPGSearchContentIncludeChildren(t *testing.T) {
 			foundToolResult = true
 		}
 	}
-	if !foundToolInput {
-		t.Errorf(
-			"IncludeChildren=true: child tool_input match not found; matches=%+v",
-			withChildren.Matches,
-		)
-	}
-	if !foundToolResult {
-		t.Errorf(
-			"IncludeChildren=true: child tool_result event match not found; matches=%+v",
-			withChildren.Matches,
-		)
-	}
+	assert.True(t, foundToolInput,
+		"IncludeChildren=true: child tool_input match not found; matches=%+v",
+		withChildren.Matches)
+	assert.True(t, foundToolResult,
+		"IncludeChildren=true: child tool_result event match not found; matches=%+v",
+		withChildren.Matches)
 
 	// --- IncludeChildren=false: child matches must be absent ---
 	withoutChildren, err := store.SearchContent(ctx, db.ContentSearchFilter{
@@ -788,15 +664,9 @@ func TestPGSearchContentIncludeChildren(t *testing.T) {
 		IncludeChildren: false,
 		IncludeOneShot:  true,
 	})
-	if err != nil {
-		t.Fatalf("SearchContent IncludeChildren=false: %v", err)
-	}
+	require.NoError(t, err, "SearchContent IncludeChildren=false")
 	for _, m := range withoutChildren.Matches {
-		if m.SessionID == "ic-child" || m.SessionID == "ic-child2" {
-			t.Errorf(
-				"IncludeChildren=false: child session %q appeared in results",
-				m.SessionID,
-			)
-		}
+		assert.NotContains(t, []string{"ic-child", "ic-child2"}, m.SessionID,
+			"IncludeChildren=false: child session %q appeared in results", m.SessionID)
 	}
 }

--- a/internal/postgres/secret_findings_pgtest_test.go
+++ b/internal/postgres/secret_findings_pgtest_test.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -24,27 +27,18 @@ func seedSecretFindingsSession(
 	t.Helper()
 	pg := store.DB()
 
-	if _, err := pg.Exec(
-		`DELETE FROM secret_findings WHERE session_id = $1`, sid,
-	); err != nil {
-		t.Fatalf("delete secret_findings: %v", err)
-	}
-	if _, err := pg.Exec(
-		`DELETE FROM messages WHERE session_id = $1`, sid,
-	); err != nil {
-		t.Fatalf("delete messages: %v", err)
-	}
-	if _, err := pg.Exec(
-		`DELETE FROM sessions WHERE id = $1`, sid,
-	); err != nil {
-		t.Fatalf("delete session: %v", err)
-	}
+	_, err := pg.Exec(`DELETE FROM secret_findings WHERE session_id = $1`, sid)
+	require.NoError(t, err, "delete secret_findings")
+	_, err = pg.Exec(`DELETE FROM messages WHERE session_id = $1`, sid)
+	require.NoError(t, err, "delete messages")
+	_, err = pg.Exec(`DELETE FROM sessions WHERE id = $1`, sid)
+	require.NoError(t, err, "delete session")
 
 	var saVal interface{} = nil
 	if startedAt != "" {
 		saVal = startedAt
 	}
-	if _, err := pg.Exec(`
+	_, err = pg.Exec(`
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, message_count, user_message_count,
@@ -53,23 +47,21 @@ func seedSecretFindingsSession(
 			$4::timestamptz, $5, 0, $6)`,
 		sid, project, agent, saVal,
 		len(msgs)+1, len(findings),
-	); err != nil {
-		t.Fatalf("insert session %s: %v", sid, err)
-	}
+	)
+	require.NoError(t, err, "insert session %s", sid)
 
 	for _, m := range msgs {
-		if _, err := pg.Exec(`
+		_, err := pg.Exec(`
 			INSERT INTO messages
 				(session_id, ordinal, role, content, content_length)
 			VALUES ($1, $2, $3, $4, $5)`,
 			sid, m.ordinal, m.role, m.content, len(m.content),
-		); err != nil {
-			t.Fatalf("insert message ord=%d: %v", m.ordinal, err)
-		}
+		)
+		require.NoError(t, err, "insert message ord=%d", m.ordinal)
 	}
 
 	for _, f := range findings {
-		if _, err := pg.Exec(`
+		_, err := pg.Exec(`
 			INSERT INTO secret_findings
 				(session_id, rule_name, confidence, location_kind,
 				 message_ordinal, call_index, event_index,
@@ -80,9 +72,8 @@ func seedSecretFindingsSession(
 			f.MessageOrdinal, f.CallIndex, f.EventIndex,
 			f.MatchStart, f.MatchEnd, f.MatchIndex,
 			f.RedactedMatch, f.RulesVersion,
-		); err != nil {
-			t.Fatalf("insert finding: %v", err)
-		}
+		)
+		require.NoError(t, err, "insert finding")
 	}
 }
 
@@ -91,9 +82,7 @@ func TestPGListSecretFindings(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -123,45 +112,30 @@ func TestPGListSecretFindings(t *testing.T) {
 
 	// All findings.
 	all, err := store.ListSecretFindings(ctx, db.SecretFindingFilter{Limit: 50})
-	if err != nil {
-		t.Fatalf("ListSecretFindings all: %v", err)
-	}
+	require.NoError(t, err, "ListSecretFindings all")
 	// At least 2 findings (may be more from other tests).
 	foundS1, foundS2 := false, false
 	for _, f := range all.Findings {
 		if f.SessionID == "sf-s1" {
 			foundS1 = true
-			if f.Project != "alpha-proj" {
-				t.Errorf("sf-s1 Project = %q, want alpha-proj", f.Project)
-			}
-			if f.Agent != "claude-code" {
-				t.Errorf("sf-s1 Agent = %q, want claude-code", f.Agent)
-			}
+			assert.Equal(t, "alpha-proj", f.Project, "sf-s1 Project")
+			assert.Equal(t, "claude-code", f.Agent, "sf-s1 Agent")
 		}
 		if f.SessionID == "sf-s2" {
 			foundS2 = true
-			if f.Project != "beta-proj" {
-				t.Errorf("sf-s2 Project = %q, want beta-proj", f.Project)
-			}
-			if f.Agent != "codex" {
-				t.Errorf("sf-s2 Agent = %q, want codex", f.Agent)
-			}
+			assert.Equal(t, "beta-proj", f.Project, "sf-s2 Project")
+			assert.Equal(t, "codex", f.Agent, "sf-s2 Agent")
 		}
 	}
-	if !foundS1 || !foundS2 {
-		t.Errorf("foundS1=%v foundS2=%v; both must be present", foundS1, foundS2)
-	}
+	assert.True(t, foundS1 && foundS2,
+		"foundS1=%v foundS2=%v; both must be present", foundS1, foundS2)
 
 	// Project filter.
 	alpha, err := store.ListSecretFindings(ctx,
 		db.SecretFindingFilter{Project: "alpha-proj", Limit: 50})
-	if err != nil {
-		t.Fatalf("ListSecretFindings project filter: %v", err)
-	}
+	require.NoError(t, err, "ListSecretFindings project filter")
 	for _, f := range alpha.Findings {
-		if f.Project != "alpha-proj" {
-			t.Errorf("project filter leak: got project %q", f.Project)
-		}
+		assert.Equal(t, "alpha-proj", f.Project, "project filter leak")
 	}
 	found := false
 	for _, f := range alpha.Findings {
@@ -169,45 +143,31 @@ func TestPGListSecretFindings(t *testing.T) {
 			found = true
 		}
 	}
-	if !found {
-		t.Errorf("sf-s1 not found in project filter results")
-	}
+	assert.True(t, found, "sf-s1 not found in project filter results")
 
 	// Agent filter.
 	codex, err := store.ListSecretFindings(ctx,
 		db.SecretFindingFilter{Agent: "codex", Limit: 50})
-	if err != nil {
-		t.Fatalf("ListSecretFindings agent filter: %v", err)
-	}
+	require.NoError(t, err, "ListSecretFindings agent filter")
 	for _, f := range codex.Findings {
-		if f.Agent != "codex" {
-			t.Errorf("agent filter leak: got agent %q", f.Agent)
-		}
+		assert.Equal(t, "codex", f.Agent, "agent filter leak")
 	}
 
 	// Confidence filter: definite.
 	def, err := store.ListSecretFindings(ctx,
 		db.SecretFindingFilter{Confidence: "definite", Limit: 50})
-	if err != nil {
-		t.Fatalf("ListSecretFindings confidence filter: %v", err)
-	}
+	require.NoError(t, err, "ListSecretFindings confidence filter")
 	for _, f := range def.Findings {
-		if f.Confidence != "definite" {
-			t.Errorf("confidence filter leak: got %q", f.Confidence)
-		}
+		assert.Equal(t, "definite", f.Confidence, "confidence filter leak")
 	}
 
 	// Rules-version filter.
 	current, err := store.ListSecretFindings(ctx,
 		db.SecretFindingFilter{RulesVersions: []string{"v1"}, Limit: 50})
-	if err != nil {
-		t.Fatalf("ListSecretFindings rules version filter: %v", err)
-	}
+	require.NoError(t, err, "ListSecretFindings rules version filter")
 	foundS1, foundS2 = false, false
 	for _, f := range current.Findings {
-		if f.RulesVersion != "v1" {
-			t.Errorf("rules version filter leak: got %q", f.RulesVersion)
-		}
+		assert.Equal(t, "v1", f.RulesVersion, "rules version filter leak")
 		if f.SessionID == "sf-s1" {
 			foundS1 = true
 		}
@@ -215,30 +175,22 @@ func TestPGListSecretFindings(t *testing.T) {
 			foundS2 = true
 		}
 	}
-	if !foundS1 || !foundS2 {
-		t.Errorf("rules version filter foundS1=%v foundS2=%v", foundS1, foundS2)
-	}
+	assert.True(t, foundS1 && foundS2,
+		"rules version filter foundS1=%v foundS2=%v", foundS1, foundS2)
 	stale, err := store.ListSecretFindings(ctx,
 		db.SecretFindingFilter{RulesVersions: []string{"v2"}, Limit: 50})
-	if err != nil {
-		t.Fatalf("ListSecretFindings stale rules version filter: %v", err)
-	}
+	require.NoError(t, err, "ListSecretFindings stale rules version filter")
 	for _, f := range stale.Findings {
-		if f.SessionID == "sf-s1" || f.SessionID == "sf-s2" {
-			t.Errorf("stale rules version filter returned %s", f.SessionID)
-		}
+		assert.NotContains(t, []string{"sf-s1", "sf-s2"}, f.SessionID,
+			"stale rules version filter returned %s", f.SessionID)
 	}
 
 	// Rule filter.
 	jwt, err := store.ListSecretFindings(ctx,
 		db.SecretFindingFilter{Rule: "jwt", Limit: 50})
-	if err != nil {
-		t.Fatalf("ListSecretFindings rule filter: %v", err)
-	}
+	require.NoError(t, err, "ListSecretFindings rule filter")
 	for _, f := range jwt.Findings {
-		if f.RuleName != "jwt" {
-			t.Errorf("rule filter leak: got %q", f.RuleName)
-		}
+		assert.Equal(t, "jwt", f.RuleName, "rule filter leak")
 	}
 }
 
@@ -247,9 +199,7 @@ func TestPGListSecretFindingsPagination(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -278,27 +228,21 @@ func TestPGListSecretFindingsPagination(t *testing.T) {
 				Rule:  "pg-pagination-test",
 				Limit: 2, Cursor: cursor,
 			})
-		if err != nil {
-			t.Fatalf("page at cursor %d: %v", cursor, err)
-		}
+		require.NoError(t, err, "page at cursor %d", cursor)
 		for _, f := range page.Findings {
 			seen[f.MatchStart]++
 		}
-		if pages++; pages > 10 {
-			t.Fatal("pagination did not terminate")
-		}
+		pages++
+		require.LessOrEqual(t, pages, 10, "pagination did not terminate")
 		if page.NextCursor == 0 {
 			break
 		}
 		cursor = page.NextCursor
 	}
-	if len(seen) != 5 {
-		t.Fatalf("saw %d distinct findings across pages, want 5", len(seen))
-	}
+	require.Len(t, seen, 5, "distinct findings across pages")
 	for start, n := range seen {
-		if n != 1 {
-			t.Errorf("finding at MatchStart=%d seen %d times, want 1", start, n)
-		}
+		assert.Equal(t, 1, n,
+			"finding at MatchStart=%d seen %d times", start, n)
 	}
 }
 
@@ -307,9 +251,7 @@ func TestPGListSecretFindingsDateFilter(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -342,12 +284,8 @@ func TestPGListSecretFindingsDateFilter(t *testing.T) {
 		db.SecretFindingFilter{
 			Rule: "df-rule", DateFrom: "2000-01-01", Limit: 50,
 		})
-	if err != nil {
-		t.Fatalf("wide: %v", err)
-	}
-	if len(wide.Findings) != 2 {
-		t.Fatalf("wide = %d findings, want 2", len(wide.Findings))
-	}
+	require.NoError(t, err, "wide")
+	require.Len(t, wide.Findings, 2)
 
 	// March-only range.
 	mar, err := store.ListSecretFindings(ctx,
@@ -356,12 +294,9 @@ func TestPGListSecretFindingsDateFilter(t *testing.T) {
 			DateFrom: "2026-03-01", DateTo: "2026-03-31",
 			Limit: 50,
 		})
-	if err != nil {
-		t.Fatalf("march: %v", err)
-	}
-	if len(mar.Findings) != 1 || mar.Findings[0].SessionID != "sf-date-mar" {
-		t.Fatalf("march filter = %+v, want only sf-date-mar", mar.Findings)
-	}
+	require.NoError(t, err, "march")
+	require.Len(t, mar.Findings, 1)
+	assert.Equal(t, "sf-date-mar", mar.Findings[0].SessionID)
 }
 
 func TestPGSecretFindingSource(t *testing.T) {
@@ -369,9 +304,7 @@ func TestPGSecretFindingSource(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	pg := store.DB()
@@ -383,68 +316,57 @@ func TestPGSecretFindingSource(t *testing.T) {
 		"secret_findings", "tool_result_events",
 		"tool_calls", "messages",
 	} {
-		if _, err := pg.Exec(
-			"DELETE FROM "+tbl+" WHERE session_id = $1", sid,
-		); err != nil {
-			t.Fatalf("cleanup %s: %v", tbl, err)
-		}
+		_, err := pg.Exec("DELETE FROM "+tbl+" WHERE session_id = $1", sid)
+		require.NoError(t, err, "cleanup %s", tbl)
 	}
-	if _, err := pg.Exec(
-		"DELETE FROM sessions WHERE id = $1", sid,
-	); err != nil {
-		t.Fatalf("cleanup sessions: %v", err)
-	}
+	_, err = pg.Exec("DELETE FROM sessions WHERE id = $1", sid)
+	require.NoError(t, err, "cleanup sessions")
 
-	if _, err := pg.Exec(`
+	_, err = pg.Exec(`
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, message_count, user_message_count)
 		VALUES ($1, 'test-machine', 'src-proj', 'claude-code',
 			'test', '2026-05-01T00:00:00Z'::timestamptz, 1, 0)`,
 		sid,
-	); err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
-	if _, err := pg.Exec(`
+	)
+	require.NoError(t, err, "insert session")
+	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content, content_length)
 		VALUES ($1, 0, 'assistant',
 			'key AKIA7QHWN2DKR4FYPLJM here', 28)`,
 		sid,
-	); err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	)
+	require.NoError(t, err, "insert message")
 	// Insert a tool_call at call_index=0 with result_content.
-	if _, err := pg.Exec(`
+	_, err = pg.Exec(`
 		INSERT INTO tool_calls
 			(session_id, message_ordinal, call_index, tool_name, category,
 			 tool_use_id, input_json, result_content)
 		VALUES ($1, 0, 0, 'Bash', 'Bash', 'tu0',
 			'{"command":"printenv"}', 'AWS_SECRET=topsecretvalue123')`,
 		sid,
-	); err != nil {
-		t.Fatalf("insert tool_call: %v", err)
-	}
+	)
+	require.NoError(t, err, "insert tool_call")
 	// Insert a tool_call at call_index=1 with a result event.
-	if _, err := pg.Exec(`
+	_, err = pg.Exec(`
 		INSERT INTO tool_calls
 			(session_id, message_ordinal, call_index, tool_name, category,
 			 tool_use_id)
 		VALUES ($1, 0, 1, 'Bash', 'Bash', 'tu1')`,
 		sid,
-	); err != nil {
-		t.Fatalf("insert tool_call 2: %v", err)
-	}
-	if _, err := pg.Exec(`
+	)
+	require.NoError(t, err, "insert tool_call 2")
+	_, err = pg.Exec(`
 		INSERT INTO tool_result_events
 			(session_id, tool_call_message_ordinal, call_index,
 			 tool_use_id, source, status, content, event_index)
 		VALUES ($1, 0, 1, 'tu1', 'stdout', 'ok',
 			'event-secret-value', 0)`,
 		sid,
-	); err != nil {
-		t.Fatalf("insert tool_result_event: %v", err)
-	}
+	)
+	require.NoError(t, err, "insert tool_result_event")
 
 	cases := []struct {
 		name string
@@ -485,13 +407,9 @@ func TestPGSecretFindingSource(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, ok, err := store.SecretFindingSource(ctx, tc.f)
-			if err != nil {
-				t.Fatalf("SecretFindingSource: %v", err)
-			}
-			if ok != tc.ok || got != tc.want {
-				t.Errorf("got (%q, %v), want (%q, %v)",
-					got, ok, tc.want, tc.ok)
-			}
+			require.NoError(t, err, "SecretFindingSource")
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/postgres/session_timing_pgtest_test.go
+++ b/internal/postgres/session_timing_pgtest_test.go
@@ -6,17 +6,17 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // timingResetSession deletes any prior fixtures for the given session id
 // (and cascades to messages and tool_calls) so each test starts clean.
 func timingResetSession(t *testing.T, pg *sql.DB, sessionID string) {
 	t.Helper()
-	if _, err := pg.Exec(
-		`DELETE FROM sessions WHERE id = $1`, sessionID,
-	); err != nil {
-		t.Fatalf("reset session: %v", err)
-	}
+	_, err := pg.Exec(`DELETE FROM sessions WHERE id = $1`, sessionID)
+	require.NoError(t, err, "reset session")
 }
 
 func timingInsertSessionPG(
@@ -38,9 +38,7 @@ func timingInsertSessionPG(
 		VALUES ($1, '', '', 'claude',
 		        $2::timestamptz, $3::timestamptz, 0, 0)
 	`, id, startedAt, endedAt)
-	if err != nil {
-		t.Fatalf("insert session %s: %v", id, err)
-	}
+	require.NoError(t, err, "insert session %s", id)
 }
 
 func timingInsertMessagePG(
@@ -54,10 +52,7 @@ func timingInsertMessagePG(
 			 has_tool_use, content_length)
 		VALUES ($1, $2, $3, $4, $5::timestamptz, $6, 0)
 	`, sessionID, ordinal, role, content, ts, hasToolUse)
-	if err != nil {
-		t.Fatalf("insert message %s/%d: %v",
-			sessionID, ordinal, err)
-	}
+	require.NoError(t, err, "insert message %s/%d", sessionID, ordinal)
 }
 
 func timingInsertToolCallPG(
@@ -78,10 +73,7 @@ func timingInsertToolCallPG(
 		VALUES ($1, $2, $3, $4, $5, '{}', $6, $7)
 	`, sessionID, toolName, category, callIndex, toolUseID,
 		sub, msgOrdinal)
-	if err != nil {
-		t.Fatalf("insert tool_call %s/%d: %v",
-			sessionID, msgOrdinal, err)
-	}
+	require.NoError(t, err, "insert tool_call %s/%d", sessionID, msgOrdinal)
 }
 
 func TestPGGetSessionTiming_Solo(t *testing.T) {
@@ -89,9 +81,7 @@ func TestPGGetSessionTiming_Solo(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	timingResetSession(t, pg, "timing-solo")
@@ -107,42 +97,22 @@ func TestPGGetSessionTiming_Solo(t *testing.T) {
 		"ok", "2026-04-26T10:00:30Z", false)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	got, err := store.GetSessionTiming(
 		context.Background(), "timing-solo",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got == nil {
-		t.Fatal("GetSessionTiming returned nil, want timing")
-	}
-	if got.TurnCount != 1 {
-		t.Errorf("TurnCount = %d, want 1", got.TurnCount)
-	}
-	if got.ToolCallCount != 1 {
-		t.Errorf("ToolCallCount = %d, want 1", got.ToolCallCount)
-	}
-	if got.Running {
-		t.Errorf("Running = true, want false")
-	}
-	if len(got.Turns) != 1 {
-		t.Fatalf("len(Turns) = %d, want 1", len(got.Turns))
-	}
-	if got.Turns[0].DurationMs == nil ||
-		*got.Turns[0].DurationMs != 29_000 {
-		t.Errorf("turn duration = %v, want 29000",
-			got.Turns[0].DurationMs)
-	}
-	if got.Turns[0].Calls[0].DurationMs == nil ||
-		*got.Turns[0].Calls[0].DurationMs != 29_000 {
-		t.Errorf("call duration = %v, want 29000",
-			got.Turns[0].Calls[0].DurationMs)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	require.NotNil(t, got, "GetSessionTiming returned nil, want timing")
+	assert.Equal(t, 1, got.TurnCount)
+	assert.Equal(t, 1, got.ToolCallCount)
+	assert.False(t, got.Running)
+	require.Len(t, got.Turns, 1)
+	require.NotNil(t, got.Turns[0].DurationMs)
+	assert.Equal(t, int64(29_000), *got.Turns[0].DurationMs)
+	require.NotNil(t, got.Turns[0].Calls[0].DurationMs)
+	assert.Equal(t, int64(29_000), *got.Turns[0].Calls[0].DurationMs)
 }
 
 func TestPGGetSessionTiming_LastMessageFallsBackToSessionEnd(t *testing.T) {
@@ -150,9 +120,7 @@ func TestPGGetSessionTiming_LastMessageFallsBackToSessionEnd(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	timingResetSession(t, pg, "timing-fallback")
@@ -166,32 +134,19 @@ func TestPGGetSessionTiming_LastMessageFallsBackToSessionEnd(t *testing.T) {
 		"tu_1", "Bash", "Bash", "")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	got, err := store.GetSessionTiming(
 		context.Background(), "timing-fallback",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got.Turns[0].DurationMs == nil {
-		t.Fatalf("turn duration = nil, want 20000 " +
-			"(fallback to ended_at)")
-	}
-	if *got.Turns[0].DurationMs != 20_000 {
-		t.Errorf("turn duration = %d, want 20000 "+
-			"(fallback to ended_at)",
-			*got.Turns[0].DurationMs)
-	}
-	if got.Turns[0].Calls[0].DurationMs == nil ||
-		*got.Turns[0].Calls[0].DurationMs != 20_000 {
-		t.Errorf("call duration = %v, want 20000 "+
-			"(solo non-subagent inherits turn duration)",
-			got.Turns[0].Calls[0].DurationMs)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	require.NotNil(t, got.Turns[0].DurationMs,
+		"turn duration nil, want 20000 (fallback to ended_at)")
+	assert.Equal(t, int64(20_000), *got.Turns[0].DurationMs)
+	require.NotNil(t, got.Turns[0].Calls[0].DurationMs,
+		"solo non-subagent inherits turn duration")
+	assert.Equal(t, int64(20_000), *got.Turns[0].Calls[0].DurationMs)
 }
 
 func TestPGGetSessionTiming_RunningSessionLastTurnNull(t *testing.T) {
@@ -199,9 +154,7 @@ func TestPGGetSessionTiming_RunningSessionLastTurnNull(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	timingResetSession(t, pg, "timing-running")
@@ -215,24 +168,15 @@ func TestPGGetSessionTiming_RunningSessionLastTurnNull(t *testing.T) {
 		"tu_1", "Bash", "Bash", "")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	got, err := store.GetSessionTiming(
 		context.Background(), "timing-running",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if !got.Running {
-		t.Errorf("Running = false, want true")
-	}
-	if got.Turns[0].DurationMs != nil {
-		t.Errorf("turn duration = %v, want nil (running)",
-			*got.Turns[0].DurationMs)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.True(t, got.Running)
+	assert.Nil(t, got.Turns[0].DurationMs, "turn duration should be nil (running)")
 }
 
 func TestPGGetSessionTiming_NonMonotonicTimestampClampsNull(t *testing.T) {
@@ -240,9 +184,7 @@ func TestPGGetSessionTiming_NonMonotonicTimestampClampsNull(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	timingResetSession(t, pg, "timing-nonmono")
@@ -258,21 +200,14 @@ func TestPGGetSessionTiming_NonMonotonicTimestampClampsNull(t *testing.T) {
 		"ok", "2026-04-26T10:00:00Z", false)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	got, err := store.GetSessionTiming(
 		context.Background(), "timing-nonmono",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got.Turns[0].DurationMs != nil {
-		t.Errorf("turn duration = %v, want nil (clamp)",
-			*got.Turns[0].DurationMs)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.Nil(t, got.Turns[0].DurationMs, "turn duration should be nil (clamp)")
 }
 
 func TestPGGetSessionTiming_NoToolUseHasNoTurnDuration(t *testing.T) {
@@ -280,9 +215,7 @@ func TestPGGetSessionTiming_NoToolUseHasNoTurnDuration(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	timingResetSession(t, pg, "timing-notool")
@@ -294,20 +227,14 @@ func TestPGGetSessionTiming_NoToolUseHasNoTurnDuration(t *testing.T) {
 		"hi back", "2026-04-26T10:00:01Z", false)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	got, err := store.GetSessionTiming(
 		context.Background(), "timing-notool",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got.TurnCount != 0 {
-		t.Errorf("TurnCount = %d, want 0", got.TurnCount)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.Equal(t, 0, got.TurnCount)
 }
 
 func TestPGGetSessionTiming_SubagentExactDuration(t *testing.T) {
@@ -315,9 +242,7 @@ func TestPGGetSessionTiming_SubagentExactDuration(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	timingResetSession(t, pg, "timing-parent")
@@ -336,24 +261,16 @@ func TestPGGetSessionTiming_SubagentExactDuration(t *testing.T) {
 		"done", "2026-04-26T10:02:16Z", false)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	got, err := store.GetSessionTiming(
 		context.Background(), "timing-parent",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	dms := got.Turns[0].Calls[0].DurationMs
-	if dms == nil || *dms != 134_000 {
-		t.Errorf("subagent duration = %v, want 134000", dms)
-	}
-	if got.SubagentCount != 1 {
-		t.Errorf("SubagentCount = %d, want 1", got.SubagentCount)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	require.NotNil(t, got.Turns[0].Calls[0].DurationMs)
+	assert.Equal(t, int64(134_000), *got.Turns[0].Calls[0].DurationMs)
+	assert.Equal(t, 1, got.SubagentCount)
 }
 
 func TestPGGetSessionTiming_MissingSessionReturnsNil(t *testing.T) {
@@ -361,18 +278,12 @@ func TestPGGetSessionTiming_MissingSessionReturnsNil(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	got, err := store.GetSessionTiming(
 		context.Background(), "no-such-session",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionTiming: %v", err)
-	}
-	if got != nil {
-		t.Errorf("GetSessionTiming = %v, want nil", got)
-	}
+	require.NoError(t, err, "GetSessionTiming")
+	assert.Nil(t, got)
 }

--- a/internal/postgres/sessions_pgtest_test.go
+++ b/internal/postgres/sessions_pgtest_test.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -16,9 +19,7 @@ func TestListSessions_HasSecret(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	pg := store.DB()
@@ -41,26 +42,19 @@ func TestListSessions_HasSecret(t *testing.T) {
 			 '2026-03-12T08:30:00Z'::timestamptz,
 			 2, 1, 0)
 	`)
-	if err != nil {
-		t.Fatalf("inserting test sessions: %v", err)
-	}
+	require.NoError(t, err, "inserting test sessions")
 
 	ctx := context.Background()
 	page, err := store.ListSessions(ctx, db.SessionFilter{
 		HasSecret: true,
 		Limit:     50,
 	})
-	if err != nil {
-		t.Fatalf("ListSessions: %v", err)
-	}
+	require.NoError(t, err, "ListSessions")
 
 	// Only the leaky session should appear.
 	for _, s := range page.Sessions {
-		if s.ID == "has-secret-clean" {
-			t.Errorf(
-				"clean session (secret_leak_count=0) included in HasSecret results",
-			)
-		}
+		assert.NotEqual(t, "has-secret-clean", s.ID,
+			"clean session (secret_leak_count=0) included in HasSecret results")
 	}
 
 	var found *db.Session
@@ -70,15 +64,8 @@ func TestListSessions_HasSecret(t *testing.T) {
 			break
 		}
 	}
-	if found == nil {
-		t.Fatal("leaky session not found in HasSecret results")
-	}
-	if found.SecretLeakCount != 3 {
-		t.Errorf(
-			"SecretLeakCount = %d, want 3",
-			found.SecretLeakCount,
-		)
-	}
+	require.NotNil(t, found, "leaky session not found in HasSecret results")
+	assert.Equal(t, 3, found.SecretLeakCount)
 
 	_, err = pg.Exec(`
 		UPDATE sessions
@@ -95,20 +82,15 @@ func TestListSessions_HasSecret(t *testing.T) {
 			 '2026-03-12T07:30:00Z'::timestamptz,
 			 2, 1, 2, 'old-rules')
 	`)
-	if err != nil {
-		t.Fatalf("seeding stale secret session: %v", err)
-	}
+	require.NoError(t, err, "seeding stale secret session")
 	current, err := store.ListSessions(ctx, db.SessionFilter{
 		HasSecret:            true,
 		SecretsRulesVersions: []string{"v-current"},
 		Limit:                50,
 	})
-	if err != nil {
-		t.Fatalf("ListSessions current rules: %v", err)
-	}
+	require.NoError(t, err, "ListSessions current rules")
 	for _, s := range current.Sessions {
-		if s.ID == "has-secret-stale" {
-			t.Fatal("stale secret session included in versioned HasSecret results")
-		}
+		require.NotEqual(t, "has-secret-stale", s.ID,
+			"stale secret session included in versioned HasSecret results")
 	}
 }

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -15,22 +18,16 @@ const testSchema = "agentsview_store_test"
 func ensureStoreSchema(t *testing.T, pgURL string) {
 	t.Helper()
 	pg, err := Open(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("connecting to pg: %v", err)
-	}
+	require.NoError(t, err, "connecting to pg")
 	defer pg.Close()
 
 	_, err = pg.Exec(`
 		DROP SCHEMA IF EXISTS ` + testSchema + ` CASCADE;
 	`)
-	if err != nil {
-		t.Fatalf("dropping schema: %v", err)
-	}
+	require.NoError(t, err, "dropping schema")
 
 	ctx := context.Background()
-	if err := EnsureSchema(ctx, pg, testSchema); err != nil {
-		t.Fatalf("creating schema: %v", err)
-	}
+	require.NoError(t, EnsureSchema(ctx, pg, testSchema), "creating schema")
 
 	_, err = pg.Exec(`
 		INSERT INTO sessions
@@ -45,9 +42,7 @@ func ensureStoreSchema(t *testing.T, pgURL string) {
 			 '2026-03-12T10:30:00Z'::timestamptz,
 			 2, 1)
 	`)
-	if err != nil {
-		t.Fatalf("inserting test session: %v", err)
-	}
+	require.NoError(t, err, "inserting test session")
 	_, err = pg.Exec(`
 		INSERT INTO messages
 			(session_id, ordinal, role, content,
@@ -60,9 +55,7 @@ func ensureStoreSchema(t *testing.T, pgURL string) {
 			 'hi there',
 			 '2026-03-12T10:00:01Z'::timestamptz, 8)
 	`)
-	if err != nil {
-		t.Fatalf("inserting test messages: %v", err)
-	}
+	require.NoError(t, err, "inserting test messages")
 }
 
 func ensureAnalyticsTokenStoreSchema(
@@ -70,22 +63,16 @@ func ensureAnalyticsTokenStoreSchema(
 ) {
 	t.Helper()
 	pg, err := Open(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("connecting to pg: %v", err)
-	}
+	require.NoError(t, err, "connecting to pg")
 	defer pg.Close()
 
 	_, err = pg.Exec(`
 		DROP SCHEMA IF EXISTS ` + testSchema + ` CASCADE;
 	`)
-	if err != nil {
-		t.Fatalf("dropping schema: %v", err)
-	}
+	require.NoError(t, err, "dropping schema")
 
 	ctx := context.Background()
-	if err := EnsureSchema(ctx, pg, testSchema); err != nil {
-		t.Fatalf("creating schema: %v", err)
-	}
+	require.NoError(t, EnsureSchema(ctx, pg, testSchema), "creating schema")
 
 	_, err = pg.Exec(`
 		INSERT INTO sessions (
@@ -115,9 +102,7 @@ func ensureAnalyticsTokenStoreSchema(
 			 '2026-03-13T11:20:00Z'::timestamptz,
 			 9, 5, 0, FALSE)
 	`)
-	if err != nil {
-		t.Fatalf("inserting analytics token sessions: %v", err)
-	}
+	require.NoError(t, err, "inserting analytics token sessions")
 }
 
 func TestNewStore(t *testing.T) {
@@ -125,17 +110,11 @@ func TestNewStore(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
-	if !store.ReadOnly() {
-		t.Error("ReadOnly() = false, want true")
-	}
-	if !store.HasFTS() {
-		t.Error("HasFTS() = false, want true")
-	}
+	assert.True(t, store.ReadOnly())
+	assert.True(t, store.HasFTS())
 }
 
 func TestStoreListSessions(t *testing.T) {
@@ -143,21 +122,15 @@ func TestStoreListSessions(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
 	page, err := store.ListSessions(
 		ctx, db.SessionFilter{Limit: 10},
 	)
-	if err != nil {
-		t.Fatalf("ListSessions: %v", err)
-	}
-	if page.Total == 0 {
-		t.Error("expected at least 1 session")
-	}
+	require.NoError(t, err, "ListSessions")
+	assert.NotZero(t, page.Total, "expected at least 1 session")
 	t.Logf("sessions: %d, total: %d",
 		len(page.Sessions), page.Total)
 }
@@ -167,9 +140,7 @@ func TestStoreListSessions_MachineMultiSelect(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	_, err = store.DB().Exec(`
@@ -191,9 +162,7 @@ func TestStoreListSessions_MachineMultiSelect(t *testing.T) {
 			 '2026-03-12T12:30:00Z'::timestamptz,
 			 2, 1)
 	`)
-	if err != nil {
-		t.Fatalf("inserting extra sessions: %v", err)
-	}
+	require.NoError(t, err, "inserting extra sessions")
 
 	ctx := context.Background()
 	page, err := store.ListSessions(
@@ -203,22 +172,14 @@ func TestStoreListSessions_MachineMultiSelect(t *testing.T) {
 			Limit:   10,
 		},
 	)
-	if err != nil {
-		t.Fatalf("ListSessions: %v", err)
-	}
-	if page.Total != 2 {
-		t.Fatalf("total = %d, want 2", page.Total)
-	}
+	require.NoError(t, err, "ListSessions")
+	require.Equal(t, 2, page.Total)
 	got := []string{
 		page.Sessions[0].Machine,
 		page.Sessions[1].Machine,
 	}
-	if got[0] != "test-machine" && got[1] != "test-machine" {
-		t.Fatalf("machines = %v, want test-machine included", got)
-	}
-	if got[0] != "machine-c" && got[1] != "machine-c" {
-		t.Fatalf("machines = %v, want machine-c included", got)
-	}
+	assert.Contains(t, got, "test-machine")
+	assert.Contains(t, got, "machine-c")
 }
 
 func ensureSidebarIndexStoreSchema(
@@ -228,15 +189,11 @@ func ensureSidebarIndexStoreSchema(
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
-	if _, err := store.DB().Exec(`DELETE FROM messages`); err != nil {
-		t.Fatalf("clearing seed messages: %v", err)
-	}
-	if _, err := store.DB().Exec(`DELETE FROM sessions`); err != nil {
-		t.Fatalf("clearing seed sessions: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
+	_, err = store.DB().Exec(`DELETE FROM messages`)
+	require.NoError(t, err, "clearing seed messages")
+	_, err = store.DB().Exec(`DELETE FROM sessions`)
+	require.NoError(t, err, "clearing seed sessions")
 	return store
 }
 
@@ -278,9 +235,7 @@ func insertSidebarIndexSession(
 		row.endedAt, row.messageCount, row.userMessageCount,
 		row.parentSessionID, row.relationshipType,
 		row.isAutomated)
-	if err != nil {
-		t.Fatalf("inserting sidebar index session %s: %v", id, err)
-	}
+	require.NoError(t, err, "inserting sidebar index session %s", id)
 }
 
 type sidebarIndexSessionSeed struct {
@@ -316,14 +271,10 @@ func requireSidebarIndexIDs(
 ) {
 	t.Helper()
 	rows := sidebarIndexRowsByID(sessions)
-	if len(rows) != len(wantIDs) {
-		t.Fatalf("session count = %d, want %d; rows=%v",
-			len(rows), len(wantIDs), rows)
-	}
+	require.Len(t, rows, len(wantIDs), "session count; rows=%v", rows)
 	for _, id := range wantIDs {
-		if _, ok := rows[id]; !ok {
-			t.Fatalf("session %q missing from rows=%v", id, rows)
-		}
+		_, ok := rows[id]
+		require.True(t, ok, "session %q missing from rows=%v", id, rows)
 	}
 }
 
@@ -344,17 +295,11 @@ func TestStoreGetSidebarSessionIndexComputesIsTeammate(
 	index, err := store.GetSidebarSessionIndex(
 		context.Background(), db.SessionFilter{},
 	)
-	if err != nil {
-		t.Fatalf("GetSidebarSessionIndex: %v", err)
-	}
+	require.NoError(t, err, "GetSidebarSessionIndex")
 
 	rows := sidebarIndexRowsByID(index.Sessions)
-	if !rows["teammate"].IsTeammate {
-		t.Fatal("teammate IsTeammate = false, want true")
-	}
-	if rows["normal"].IsTeammate {
-		t.Fatal("normal IsTeammate = true, want false")
-	}
+	assert.True(t, rows["teammate"].IsTeammate, "teammate IsTeammate")
+	assert.False(t, rows["normal"].IsTeammate, "normal IsTeammate")
 }
 
 func TestStoreGetSidebarSessionIndexReturnsDisplayName(
@@ -374,16 +319,11 @@ func TestStoreGetSidebarSessionIndexReturnsDisplayName(
 	index, err := store.GetSidebarSessionIndex(
 		context.Background(), db.SessionFilter{},
 	)
-	if err != nil {
-		t.Fatalf("GetSidebarSessionIndex: %v", err)
-	}
-	if len(index.Sessions) != 1 {
-		t.Fatalf("sessions = %d, want 1", len(index.Sessions))
-	}
+	require.NoError(t, err, "GetSidebarSessionIndex")
+	require.Len(t, index.Sessions, 1)
 	got := index.Sessions[0].DisplayName
-	if got == nil || *got != displayName {
-		t.Fatalf("display_name = %v, want %q", got, displayName)
-	}
+	require.NotNil(t, got)
+	assert.Equal(t, displayName, *got)
 }
 
 func TestStoreGetSidebarSessionIndexExcludeAutomated(
@@ -406,21 +346,15 @@ func TestStoreGetSidebarSessionIndexExcludeAutomated(
 		context.Background(),
 		db.SessionFilter{ExcludeAutomated: true},
 	)
-	if err != nil {
-		t.Fatalf("GetSidebarSessionIndex exclude automated: %v", err)
-	}
+	require.NoError(t, err, "GetSidebarSessionIndex exclude automated")
 	requireSidebarIndexIDs(t, index.Sessions, []string{"normal"})
-	if index.Total != 1 {
-		t.Fatalf("total = %d, want 1", index.Total)
-	}
+	assert.Equal(t, 1, index.Total)
 
 	index, err = store.GetSidebarSessionIndex(
 		context.Background(),
 		db.SessionFilter{ExcludeAutomated: false},
 	)
-	if err != nil {
-		t.Fatalf("GetSidebarSessionIndex include automated: %v", err)
-	}
+	require.NoError(t, err, "GetSidebarSessionIndex include automated")
 	requireSidebarIndexIDs(
 		t, index.Sessions, []string{"normal", "review"},
 	)
@@ -458,9 +392,7 @@ func TestStoreGetSidebarSessionIndexExcludeOneShotKeepsAutomated(
 			ExcludeAutomated: false,
 		},
 	)
-	if err != nil {
-		t.Fatalf("GetSidebarSessionIndex: %v", err)
-	}
+	require.NoError(t, err, "GetSidebarSessionIndex")
 	requireSidebarIndexIDs(t, index.Sessions, []string{"multi", "review"})
 }
 
@@ -503,9 +435,7 @@ func TestStoreGetSidebarSessionIndexIncludesChildrenForMatchingRoot(
 	index, err := store.GetSidebarSessionIndex(
 		context.Background(), db.SessionFilter{Agent: "claude"},
 	)
-	if err != nil {
-		t.Fatalf("GetSidebarSessionIndex: %v", err)
-	}
+	require.NoError(t, err, "GetSidebarSessionIndex")
 	requireSidebarIndexIDs(
 		t, index.Sessions, []string{"root", "sub", "fork"},
 	)
@@ -516,23 +446,14 @@ func TestStoreGetSession(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
 	sess, err := store.GetSession(ctx, "store-test-001")
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected session, got nil")
-	}
-	if sess.Project != "test-project" {
-		t.Errorf("project = %q, want %q",
-			sess.Project, "test-project")
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, sess, "expected session, got nil")
+	assert.Equal(t, "test-project", sess.Project)
 }
 
 func TestStoreGetMessages(t *testing.T) {
@@ -540,21 +461,15 @@ func TestStoreGetMessages(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
 	msgs, err := store.GetMessages(
 		ctx, "store-test-001", 0, 100, true,
 	)
-	if err != nil {
-		t.Fatalf("GetMessages: %v", err)
-	}
-	if len(msgs) != 2 {
-		t.Errorf("got %d messages, want 2", len(msgs))
-	}
+	require.NoError(t, err, "GetMessages")
+	assert.Len(t, msgs, 2)
 }
 
 func TestStoreGetStats(t *testing.T) {
@@ -562,19 +477,13 @@ func TestStoreGetStats(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
 	stats, err := store.GetStats(ctx, false, false)
-	if err != nil {
-		t.Fatalf("GetStats: %v", err)
-	}
-	if stats.SessionCount == 0 {
-		t.Error("expected at least 1 session in stats")
-	}
+	require.NoError(t, err, "GetStats")
+	assert.NotZero(t, stats.SessionCount, "expected at least 1 session in stats")
 	t.Logf("stats: %+v", stats)
 }
 
@@ -583,9 +492,7 @@ func TestStoreSearch(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -593,12 +500,8 @@ func TestStoreSearch(t *testing.T) {
 		Query: "hello",
 		Limit: 5,
 	})
-	if err != nil {
-		t.Fatalf("Search: %v", err)
-	}
-	if len(page.Results) == 0 {
-		t.Error("expected at least 1 search result")
-	}
+	require.NoError(t, err, "Search")
+	assert.NotEmpty(t, page.Results, "expected at least 1 search result")
 	t.Logf("search results: %d", len(page.Results))
 }
 
@@ -607,9 +510,7 @@ func TestStoreAnalyticsSummary(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
@@ -619,12 +520,8 @@ func TestStoreAnalyticsSummary(t *testing.T) {
 			To:   "2026-12-31",
 		},
 	)
-	if err != nil {
-		t.Fatalf("GetAnalyticsSummary: %v", err)
-	}
-	if summary.TotalSessions == 0 {
-		t.Error("expected at least 1 session in summary")
-	}
+	require.NoError(t, err, "GetAnalyticsSummary")
+	assert.NotZero(t, summary.TotalSessions, "expected at least 1 session in summary")
 	t.Logf("summary: %+v", summary)
 }
 
@@ -642,17 +539,15 @@ func seedActivitySession(
 
 	// PG doesn't allow multi-statement prepared queries,
 	// so run each statement separately.
-	if _, err := pg.Exec(
+	_, err := pg.Exec(
 		`DELETE FROM messages WHERE session_id = $1`, sid,
-	); err != nil {
-		t.Fatalf("deleting messages: %v", err)
-	}
-	if _, err := pg.Exec(
+	)
+	require.NoError(t, err, "deleting messages")
+	_, err = pg.Exec(
 		`DELETE FROM sessions WHERE id = $1`, sid,
-	); err != nil {
-		t.Fatalf("deleting session: %v", err)
-	}
-	if _, err := pg.Exec(`
+	)
+	require.NoError(t, err, "deleting session")
+	_, err = pg.Exec(`
 		INSERT INTO sessions
 			(id, machine, project, agent, first_message,
 			 started_at, ended_at, message_count,
@@ -663,26 +558,23 @@ func seedActivitySession(
 			 '2026-03-26T10:00:00Z'::timestamptz,
 			 '2026-03-26T11:00:00Z'::timestamptz,
 			 $2, 0)
-	`, sid, len(msgs)); err != nil {
-		t.Fatalf("inserting session: %v", err)
-	}
+	`, sid, len(msgs))
+	require.NoError(t, err, "inserting session")
 
 	for _, m := range msgs {
 		var tsVal interface{} = nil
 		if m.ts != "" {
 			tsVal = m.ts
 		}
-		if _, err := pg.Exec(`
+		_, err := pg.Exec(`
 			INSERT INTO messages
 				(session_id, ordinal, role, content,
 				 timestamp, content_length, is_system)
 			VALUES ($1, $2, $3, $4,
 				$5::timestamptz, $6, $7)
 		`, sid, m.ordinal, m.role, m.content,
-			tsVal, len(m.content), m.system); err != nil {
-			t.Fatalf("inserting message ord=%d: %v",
-				m.ordinal, err)
-		}
+			tsVal, len(m.content), m.system)
+		require.NoError(t, err, "inserting message ord=%d", m.ordinal)
 	}
 }
 
@@ -691,9 +583,7 @@ func TestStoreGetSessionActivity(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	sid := "store-test-activity"
@@ -716,44 +606,22 @@ func TestStoreGetSessionActivity(t *testing.T) {
 
 	ctx := context.Background()
 	resp, err := store.GetSessionActivity(ctx, sid)
-	if err != nil {
-		t.Fatalf("GetSessionActivity: %v", err)
-	}
+	require.NoError(t, err, "GetSessionActivity")
 
-	if resp.IntervalSeconds != 60 {
-		t.Errorf("interval = %d, want 60",
-			resp.IntervalSeconds)
-	}
-
-	if resp.TotalMessages != 7 {
-		t.Errorf("total = %d, want 7",
-			resp.TotalMessages)
-	}
-
-	if len(resp.Buckets) < 28 {
-		t.Errorf("bucket count = %d, want >= 28",
-			len(resp.Buckets))
-	}
+	assert.Equal(t, 60, resp.IntervalSeconds)
+	assert.Equal(t, 7, resp.TotalMessages)
+	assert.GreaterOrEqual(t, len(resp.Buckets), 28, "bucket count")
 
 	first := resp.Buckets[0]
-	if first.UserCount != 1 || first.AssistantCount != 1 {
-		t.Errorf("first bucket: user=%d asst=%d, want 1,1",
-			first.UserCount, first.AssistantCount)
-	}
-	if first.FirstOrdinal == nil || *first.FirstOrdinal != 0 {
-		t.Errorf("first bucket first_ordinal: got %v, want 0",
-			first.FirstOrdinal)
-	}
+	assert.Equal(t, 1, first.UserCount)
+	assert.Equal(t, 1, first.AssistantCount)
+	require.NotNil(t, first.FirstOrdinal)
+	assert.Equal(t, 0, *first.FirstOrdinal)
 
 	mid := resp.Buckets[15]
-	if mid.UserCount != 0 || mid.AssistantCount != 0 {
-		t.Errorf("mid bucket: user=%d asst=%d, want 0,0",
-			mid.UserCount, mid.AssistantCount)
-	}
-	if mid.FirstOrdinal != nil {
-		t.Errorf("mid bucket first_ordinal: got %v, want nil",
-			mid.FirstOrdinal)
-	}
+	assert.Equal(t, 0, mid.UserCount)
+	assert.Equal(t, 0, mid.AssistantCount)
+	assert.Nil(t, mid.FirstOrdinal)
 }
 
 func TestStoreGetSessionActivity_NoMessages(t *testing.T) {
@@ -761,9 +629,7 @@ func TestStoreGetSessionActivity_NoMessages(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	sid := "store-test-activity-empty"
@@ -772,13 +638,8 @@ func TestStoreGetSessionActivity_NoMessages(t *testing.T) {
 	resp, err := store.GetSessionActivity(
 		context.Background(), sid,
 	)
-	if err != nil {
-		t.Fatalf("GetSessionActivity: %v", err)
-	}
-	if len(resp.Buckets) != 0 {
-		t.Errorf("buckets = %d, want 0",
-			len(resp.Buckets))
-	}
+	require.NoError(t, err, "GetSessionActivity")
+	assert.Empty(t, resp.Buckets)
 }
 
 func TestStoreGetSessionActivity_NullTimestamps(
@@ -788,9 +649,7 @@ func TestStoreGetSessionActivity_NullTimestamps(
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	sid := "store-test-activity-nullts"
@@ -808,17 +667,9 @@ func TestStoreGetSessionActivity_NullTimestamps(
 	resp, err := store.GetSessionActivity(
 		context.Background(), sid,
 	)
-	if err != nil {
-		t.Fatalf("GetSessionActivity: %v", err)
-	}
-	if len(resp.Buckets) != 0 {
-		t.Errorf("buckets = %d, want 0",
-			len(resp.Buckets))
-	}
-	if resp.TotalMessages != 2 {
-		t.Errorf("total = %d, want 2",
-			resp.TotalMessages)
-	}
+	require.NoError(t, err, "GetSessionActivity")
+	assert.Empty(t, resp.Buckets)
+	assert.Equal(t, 2, resp.TotalMessages)
 }
 
 func TestStoreGetSessionActivity_SingleMessage(
@@ -828,9 +679,7 @@ func TestStoreGetSessionActivity_SingleMessage(
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	sid := "store-test-activity-single"
@@ -847,17 +696,9 @@ func TestStoreGetSessionActivity_SingleMessage(
 	resp, err := store.GetSessionActivity(
 		context.Background(), sid,
 	)
-	if err != nil {
-		t.Fatalf("GetSessionActivity: %v", err)
-	}
-	if len(resp.Buckets) != 1 {
-		t.Fatalf("buckets = %d, want 1",
-			len(resp.Buckets))
-	}
-	if resp.Buckets[0].UserCount != 1 {
-		t.Errorf("user count = %d, want 1",
-			resp.Buckets[0].UserCount)
-	}
+	require.NoError(t, err, "GetSessionActivity")
+	require.Len(t, resp.Buckets, 1)
+	assert.Equal(t, 1, resp.Buckets[0].UserCount)
 }
 
 func TestStoreGetSessionActivity_PrefixInjectedExcluded(
@@ -867,9 +708,7 @@ func TestStoreGetSessionActivity_PrefixInjectedExcluded(
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	sid := "store-test-activity-prefix"
@@ -889,34 +728,23 @@ func TestStoreGetSessionActivity_PrefixInjectedExcluded(
 
 	ctx := context.Background()
 	resp, err := store.GetSessionActivity(ctx, sid)
-	if err != nil {
-		t.Fatalf("GetSessionActivity: %v", err)
-	}
+	require.NoError(t, err, "GetSessionActivity")
 
 	// The prefix-detected message should be excluded from
 	// buckets but still count toward TotalMessages.
-	if resp.TotalMessages != 3 {
-		t.Errorf("total = %d, want 3",
-			resp.TotalMessages)
-	}
+	assert.Equal(t, 3, resp.TotalMessages)
 
 	// Only ordinals 0 and 1 should appear in buckets.
 	totalBucketed := 0
 	for _, b := range resp.Buckets {
 		totalBucketed += b.UserCount + b.AssistantCount
 	}
-	if totalBucketed != 2 {
-		t.Errorf("bucketed messages = %d, want 2",
-			totalBucketed)
-	}
+	assert.Equal(t, 2, totalBucketed)
 
 	// The excluded message at 10:01:00 must not extend the
 	// timestamp range. With only 10:00:00-10:00:30 visible,
 	// a single bucket should cover the entire span.
-	if len(resp.Buckets) != 1 {
-		t.Errorf("bucket count = %d, want 1",
-			len(resp.Buckets))
-	}
+	assert.Len(t, resp.Buckets, 1)
 }
 
 func TestStoreGetSessionActivity_FractionalTimestamps(
@@ -926,9 +754,7 @@ func TestStoreGetSessionActivity_FractionalTimestamps(
 	ensureStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	sid := "store-test-frac-ts"
@@ -946,41 +772,19 @@ func TestStoreGetSessionActivity_FractionalTimestamps(
 
 	ctx := context.Background()
 	resp, err := store.GetSessionActivity(ctx, sid)
-	if err != nil {
-		t.Fatalf("GetSessionActivity: %v", err)
-	}
+	require.NoError(t, err, "GetSessionActivity")
 
-	if resp.IntervalSeconds != 60 {
-		t.Fatalf(
-			"interval = %d, want 60",
-			resp.IntervalSeconds,
-		)
-	}
-
-	if len(resp.Buckets) < 2 {
-		t.Fatalf(
-			"buckets = %d, want >= 2",
-			len(resp.Buckets),
-		)
-	}
+	require.Equal(t, 60, resp.IntervalSeconds)
+	require.GreaterOrEqual(t, len(resp.Buckets), 2)
 
 	// First bucket should have both sub-second messages.
 	first := resp.Buckets[0]
-	if first.UserCount != 1 || first.AssistantCount != 1 {
-		t.Errorf(
-			"first bucket: user=%d asst=%d, want 1,1",
-			first.UserCount, first.AssistantCount,
-		)
-	}
+	assert.Equal(t, 1, first.UserCount)
+	assert.Equal(t, 1, first.AssistantCount)
 
 	// Second bucket should have the third message.
 	second := resp.Buckets[1]
-	if second.UserCount != 1 {
-		t.Errorf(
-			"second bucket user=%d, want 1",
-			second.UserCount,
-		)
-	}
+	assert.Equal(t, 1, second.UserCount)
 }
 
 func TestStoreAnalyticsSummaryOutputTokenCoverage(
@@ -990,9 +794,7 @@ func TestStoreAnalyticsSummaryOutputTokenCoverage(
 	ensureAnalyticsTokenStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	summary, err := store.GetAnalyticsSummary(
@@ -1002,22 +804,9 @@ func TestStoreAnalyticsSummaryOutputTokenCoverage(
 			To:   "2026-03-13",
 		},
 	)
-	if err != nil {
-		t.Fatalf("GetAnalyticsSummary: %v", err)
-	}
-
-	if summary.TotalOutputTokens != 1800 {
-		t.Errorf(
-			"TotalOutputTokens = %d, want 1800",
-			summary.TotalOutputTokens,
-		)
-	}
-	if summary.TokenReportingSessions != 3 {
-		t.Errorf(
-			"TokenReportingSessions = %d, want 3",
-			summary.TokenReportingSessions,
-		)
-	}
+	require.NoError(t, err, "GetAnalyticsSummary")
+	assert.Equal(t, 1800, summary.TotalOutputTokens)
+	assert.Equal(t, 3, summary.TokenReportingSessions)
 }
 
 func TestStoreAnalyticsHeatmapOutputTokens(t *testing.T) {
@@ -1025,9 +814,7 @@ func TestStoreAnalyticsHeatmapOutputTokens(t *testing.T) {
 	ensureAnalyticsTokenStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	heatmap, err := store.GetAnalyticsHeatmap(
@@ -1038,36 +825,14 @@ func TestStoreAnalyticsHeatmapOutputTokens(t *testing.T) {
 		},
 		"output_tokens",
 	)
-	if err != nil {
-		t.Fatalf("GetAnalyticsHeatmap: %v", err)
-	}
+	require.NoError(t, err, "GetAnalyticsHeatmap")
 
-	if heatmap.Metric != "output_tokens" {
-		t.Fatalf(
-			"Metric = %q, want %q",
-			heatmap.Metric, "output_tokens",
-		)
-	}
-	if len(heatmap.Entries) != 2 {
-		t.Fatalf(
-			"len(Entries) = %d, want 2",
-			len(heatmap.Entries),
-		)
-	}
-	if heatmap.Entries[0].Date != "2026-03-12" ||
-		heatmap.Entries[0].Value != 1500 {
-		t.Errorf(
-			"Entries[0] = %+v, want date 2026-03-12 value 1500",
-			heatmap.Entries[0],
-		)
-	}
-	if heatmap.Entries[1].Date != "2026-03-13" ||
-		heatmap.Entries[1].Value != 300 {
-		t.Errorf(
-			"Entries[1] = %+v, want date 2026-03-13 value 300",
-			heatmap.Entries[1],
-		)
-	}
+	assert.Equal(t, "output_tokens", heatmap.Metric)
+	require.Len(t, heatmap.Entries, 2)
+	assert.Equal(t, "2026-03-12", heatmap.Entries[0].Date)
+	assert.Equal(t, 1500, heatmap.Entries[0].Value)
+	assert.Equal(t, "2026-03-13", heatmap.Entries[1].Date)
+	assert.Equal(t, 300, heatmap.Entries[1].Value)
 }
 
 func TestStoreAnalyticsTopSessionsOutputTokens(
@@ -1077,9 +842,7 @@ func TestStoreAnalyticsTopSessionsOutputTokens(
 	ensureAnalyticsTokenStoreSchema(t, pgURL)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	top, err := store.GetAnalyticsTopSessions(
@@ -1090,36 +853,15 @@ func TestStoreAnalyticsTopSessionsOutputTokens(
 		},
 		"output_tokens",
 	)
-	if err != nil {
-		t.Fatalf("GetAnalyticsTopSessions: %v", err)
-	}
+	require.NoError(t, err, "GetAnalyticsTopSessions")
 
-	if top.Metric != "output_tokens" {
-		t.Fatalf(
-			"Metric = %q, want %q",
-			top.Metric, "output_tokens",
-		)
-	}
-	if len(top.Sessions) != 3 {
-		t.Fatalf(
-			"len(Sessions) = %d, want 3",
-			len(top.Sessions),
-		)
-	}
-	if top.Sessions[0].ID != "pg-token-001" ||
-		top.Sessions[0].OutputTokens != 900 {
-		t.Errorf(
-			"Sessions[0] = %+v, want pg-token-001 with 900 output tokens",
-			top.Sessions[0],
-		)
-	}
+	assert.Equal(t, "output_tokens", top.Metric)
+	require.Len(t, top.Sessions, 3)
+	assert.Equal(t, "pg-token-001", top.Sessions[0].ID)
+	assert.Equal(t, 900, top.Sessions[0].OutputTokens)
 	for _, session := range top.Sessions {
-		if session.ID == "pg-token-missing" {
-			t.Fatalf(
-				"session without token coverage was included: %+v",
-				session,
-			)
-		}
+		assert.NotEqual(t, "pg-token-missing", session.ID,
+			"session without token coverage was included: %+v", session)
 	}
 }
 
@@ -1127,9 +869,7 @@ func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 	pgURL := testPGURL(t)
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	tests := []struct {
@@ -1174,10 +914,7 @@ func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.fn()
-			if err != db.ErrReadOnly {
-				t.Errorf("got %v, want ErrReadOnly", err)
-			}
+			assert.Equal(t, db.ErrReadOnly, tt.fn())
 		})
 	}
 }

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -608,7 +608,7 @@ func TestStoreGetSessionActivity(t *testing.T) {
 	resp, err := store.GetSessionActivity(ctx, sid)
 	require.NoError(t, err, "GetSessionActivity")
 
-	assert.Equal(t, 60, resp.IntervalSeconds)
+	assert.Equal(t, int64(60), resp.IntervalSeconds)
 	assert.Equal(t, 7, resp.TotalMessages)
 	assert.GreaterOrEqual(t, len(resp.Buckets), 28, "bucket count")
 
@@ -774,7 +774,7 @@ func TestStoreGetSessionActivity_FractionalTimestamps(
 	resp, err := store.GetSessionActivity(ctx, sid)
 	require.NoError(t, err, "GetSessionActivity")
 
-	require.Equal(t, 60, resp.IntervalSeconds)
+	require.Equal(t, int64(60), resp.IntervalSeconds)
 	require.GreaterOrEqual(t, len(resp.Buckets), 2)
 
 	// First bucket should have both sub-second messages.

--- a/internal/postgres/store_unit_test.go
+++ b/internal/postgres/store_unit_test.go
@@ -1,6 +1,10 @@
 package postgres
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestStripFTSQuotes(t *testing.T) {
 	tests := []struct {
@@ -15,11 +19,8 @@ func TestStripFTSQuotes(t *testing.T) {
 		{`already unquoted`, "already unquoted"},
 	}
 	for _, tt := range tests {
-		got := stripFTSQuotes(tt.input)
-		if got != tt.want {
-			t.Errorf("stripFTSQuotes(%q) = %q, want %q",
-				tt.input, got, tt.want)
-		}
+		assert.Equal(t, tt.want, stripFTSQuotes(tt.input),
+			"input=%q", tt.input)
 	}
 }
 
@@ -35,10 +36,7 @@ func TestEscapeLike(t *testing.T) {
 		{`%_\`, `\%\_\\`},
 	}
 	for _, tt := range tests {
-		got := escapeLike(tt.input)
-		if got != tt.want {
-			t.Errorf("escapeLike(%q) = %q, want %q",
-				tt.input, got, tt.want)
-		}
+		assert.Equal(t, tt.want, escapeLike(tt.input),
+			"input=%q", tt.input)
 	}
 }

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -10,15 +10,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
 func testDB(t *testing.T) *db.DB {
 	t.Helper()
 	d, err := db.Open(t.TempDir() + "/test.db")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
+	require.NoError(t, err, "opening test db")
 	t.Cleanup(func() { d.Close() })
 	return d
 }
@@ -26,9 +27,7 @@ func testDB(t *testing.T) *db.DB {
 func cleanPGSchema(t *testing.T, pgURL string) {
 	t.Helper()
 	pg, err := sql.Open("pgx", pgURL)
-	if err != nil {
-		t.Fatalf("connecting to pg: %v", err)
-	}
+	require.NoError(t, err, "connecting to pg")
 	defer pg.Close()
 	_, _ = pg.Exec(
 		"DROP SCHEMA IF EXISTS agentsview CASCADE",
@@ -46,20 +45,13 @@ func TestEnsureSchemaIdempotent(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
 
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("first EnsureSchema: %v", err)
-	}
-
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("second EnsureSchema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "first EnsureSchema")
+	require.NoError(t, ps.EnsureSchema(ctx), "second EnsureSchema")
 
 	var eventIndex int
 	err = ps.pg.QueryRowContext(ctx,
@@ -76,20 +68,17 @@ func TestEnsureSchemaMigratesLegacySchema(t *testing.T) {
 	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
 
 	pg, err := Open(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("connecting to pg: %v", err)
-	}
+	require.NoError(t, err, "connecting to pg")
 	defer pg.Close()
 
 	ctx := context.Background()
 
 	// Simulate a 0.16.x schema: create the schema and core
 	// tables but omit tool_result_events.
-	if _, err := pg.ExecContext(ctx,
+	_, err = pg.ExecContext(ctx,
 		"CREATE SCHEMA IF NOT EXISTS agentsview",
-	); err != nil {
-		t.Fatalf("creating schema: %v", err)
-	}
+	)
+	require.NoError(t, err, "creating schema")
 	legacyDDL := `
 CREATE TABLE IF NOT EXISTS sync_metadata (
     key   TEXT PRIMARY KEY,
@@ -142,26 +131,20 @@ CREATE TABLE IF NOT EXISTS tool_calls (
     FOREIGN KEY (session_id)
         REFERENCES sessions(id) ON DELETE CASCADE
 );`
-	if _, err := pg.ExecContext(ctx, legacyDDL); err != nil {
-		t.Fatalf("creating legacy tables: %v", err)
-	}
+	_, err = pg.ExecContext(ctx, legacyDDL)
+	require.NoError(t, err, "creating legacy tables")
 
 	// Verify tool_result_events does not exist yet.
-	if err := CheckSchemaCompat(ctx, pg); err == nil {
-		t.Fatal("expected CheckSchemaCompat to fail on legacy schema")
-	}
+	require.Error(t, CheckSchemaCompat(ctx, pg),
+		"expected CheckSchemaCompat to fail on legacy schema")
 
 	// Run EnsureSchema — should create the missing table.
-	if err := EnsureSchema(ctx, pg, "agentsview"); err != nil {
-		t.Fatalf("EnsureSchema on legacy schema: %v", err)
-	}
+	require.NoError(t, EnsureSchema(ctx, pg, "agentsview"),
+		"EnsureSchema on legacy schema")
 
 	// Now the compat check should pass.
-	if err := CheckSchemaCompat(ctx, pg); err != nil {
-		t.Fatalf(
-			"CheckSchemaCompat after migration: %v", err,
-		)
-	}
+	require.NoError(t, CheckSchemaCompat(ctx, pg),
+		"CheckSchemaCompat after migration")
 }
 
 // TestCheckSchemaCompatMissingSecretsRulesVersion pins the schema-compat
@@ -178,26 +161,19 @@ func TestCheckSchemaCompatMissingSecretsRulesVersion(t *testing.T) {
 	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
 
 	pg, err := Open(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("connecting to pg: %v", err)
-	}
+	require.NoError(t, err, "connecting to pg")
 	defer pg.Close()
 
 	ctx := context.Background()
-	if err := EnsureSchema(ctx, pg, "agentsview"); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
-	if err := CheckSchemaCompat(ctx, pg); err != nil {
-		t.Fatalf("precondition: CheckSchemaCompat should pass after EnsureSchema: %v", err)
-	}
-	if _, err := pg.ExecContext(ctx,
+	require.NoError(t, EnsureSchema(ctx, pg, "agentsview"), "EnsureSchema")
+	require.NoError(t, CheckSchemaCompat(ctx, pg),
+		"precondition: CheckSchemaCompat should pass after EnsureSchema")
+	_, err = pg.ExecContext(ctx,
 		`ALTER TABLE sessions DROP COLUMN secrets_rules_version`,
-	); err != nil {
-		t.Fatalf("dropping secrets_rules_version: %v", err)
-	}
-	if err := CheckSchemaCompat(ctx, pg); err == nil {
-		t.Fatal("CheckSchemaCompat should fail when secrets_rules_version is missing")
-	}
+	)
+	require.NoError(t, err, "dropping secrets_rules_version")
+	require.Error(t, CheckSchemaCompat(ctx, pg),
+		"CheckSchemaCompat should fail when secrets_rules_version is missing")
 }
 
 func TestPushSingleSession(t *testing.T) {
@@ -211,15 +187,11 @@ func TestPushSingleSession(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := "2026-03-11T12:00:00Z"
 	firstMsg := "hello world"
@@ -232,72 +204,37 @@ func TestPushSingleSession(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{
 		{
 			SessionID: "sess-001",
 			Ordinal:   0,
 			Role:      "user",
 			Content:   firstMsg,
 		},
-	}); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	}), "insert messages")
 
 	result, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("push: %v", err)
-	}
-	if result.SessionsPushed != 1 {
-		t.Errorf(
-			"sessions pushed = %d, want 1",
-			result.SessionsPushed,
-		)
-	}
-	if result.MessagesPushed != 1 {
-		t.Errorf(
-			"messages pushed = %d, want 1",
-			result.MessagesPushed,
-		)
-	}
+	require.NoError(t, err, "push")
+	assert.Equal(t, 1, result.SessionsPushed)
+	assert.Equal(t, 1, result.MessagesPushed)
 
 	var pgProject, pgMachine string
 	err = ps.pg.QueryRowContext(ctx,
 		"SELECT project, machine FROM sessions WHERE id = $1",
 		"sess-001",
 	).Scan(&pgProject, &pgMachine)
-	if err != nil {
-		t.Fatalf("querying pg session: %v", err)
-	}
-	if pgProject != "test-project" {
-		t.Errorf(
-			"pg project = %q, want %q",
-			pgProject, "test-project",
-		)
-	}
-	if pgMachine != "test-machine" {
-		t.Errorf(
-			"pg machine = %q, want %q",
-			pgMachine, "test-machine",
-		)
-	}
+	require.NoError(t, err, "querying pg session")
+	assert.Equal(t, "test-project", pgProject)
+	assert.Equal(t, "test-machine", pgMachine)
 
 	var pgMsgContent string
 	err = ps.pg.QueryRowContext(ctx,
 		"SELECT content FROM messages WHERE session_id = $1 AND ordinal = 0",
 		"sess-001",
 	).Scan(&pgMsgContent)
-	if err != nil {
-		t.Fatalf("querying pg message: %v", err)
-	}
-	if pgMsgContent != firstMsg {
-		t.Errorf(
-			"pg message content = %q, want %q",
-			pgMsgContent, firstMsg,
-		)
-	}
+	require.NoError(t, err, "querying pg message")
+	assert.Equal(t, firstMsg, pgMsgContent)
 }
 
 func TestPushIdempotent(t *testing.T) {
@@ -311,15 +248,11 @@ func TestPushIdempotent(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := "2026-03-11T12:00:00Z"
 	sess := db.Session{
@@ -330,31 +263,15 @@ func TestPushIdempotent(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 0,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
 
 	result1, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("first push: %v", err)
-	}
-	if result1.SessionsPushed != 1 {
-		t.Errorf(
-			"first push sessions = %d, want 1",
-			result1.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "first push")
+	assert.Equal(t, 1, result1.SessionsPushed)
 
 	result2, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("second push: %v", err)
-	}
-	if result2.SessionsPushed != 0 {
-		t.Errorf(
-			"second push sessions = %d, want 0",
-			result2.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "second push")
+	assert.Equal(t, 0, result2.SessionsPushed)
 }
 
 func TestPushWithToolCalls(t *testing.T) {
@@ -368,15 +285,11 @@ func TestPushWithToolCalls(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := "2026-03-11T12:00:00Z"
 	sess := db.Session{
@@ -387,10 +300,8 @@ func TestPushWithToolCalls(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{
 		{
 			SessionID:  "sess-tc-001",
 			Ordinal:    0,
@@ -407,20 +318,11 @@ func TestPushWithToolCalls(t *testing.T) {
 				},
 			},
 		},
-	}); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	}), "insert messages")
 
 	result, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("push: %v", err)
-	}
-	if result.MessagesPushed != 1 {
-		t.Errorf(
-			"messages pushed = %d, want 1",
-			result.MessagesPushed,
-		)
-	}
+	require.NoError(t, err, "push")
+	assert.Equal(t, 1, result.MessagesPushed)
 
 	var toolName string
 	var resultLen int
@@ -428,20 +330,9 @@ func TestPushWithToolCalls(t *testing.T) {
 		"SELECT tool_name, result_content_length FROM tool_calls WHERE session_id = $1",
 		"sess-tc-001",
 	).Scan(&toolName, &resultLen)
-	if err != nil {
-		t.Fatalf("querying pg tool_call: %v", err)
-	}
-	if toolName != "Read" {
-		t.Errorf(
-			"tool_name = %q, want %q", toolName, "Read",
-		)
-	}
-	if resultLen != 42 {
-		t.Errorf(
-			"result_content_length = %d, want 42",
-			resultLen,
-		)
-	}
+	require.NoError(t, err, "querying pg tool_call")
+	assert.Equal(t, "Read", toolName)
+	assert.Equal(t, 42, resultLen)
 }
 
 func TestPushWithToolResultEvents(t *testing.T) {
@@ -455,15 +346,11 @@ func TestPushWithToolResultEvents(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	sess := db.Session{
 		ID:           "sess-events-001",
@@ -472,10 +359,8 @@ func TestPushWithToolResultEvents(t *testing.T) {
 		Agent:        "codex",
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{
 		{
 			SessionID:  "sess-events-001",
 			Ordinal:    0,
@@ -503,25 +388,18 @@ func TestPushWithToolResultEvents(t *testing.T) {
 				},
 			},
 		},
-	}); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	}), "insert messages")
 
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("push: %v", err)
-	}
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "push")
 
 	var count int
 	err = ps.pg.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM tool_result_events WHERE session_id = $1",
 		"sess-events-001",
 	).Scan(&count)
-	if err != nil {
-		t.Fatalf("querying pg tool_result_events: %v", err)
-	}
-	if count != 1 {
-		t.Fatalf("pg tool_result_events = %d, want 1", count)
-	}
+	require.NoError(t, err, "querying pg tool_result_events")
+	assert.Equal(t, 1, count)
 }
 
 func TestStatus(t *testing.T) {
@@ -535,32 +413,16 @@ func TestStatus(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	status, err := ps.Status(ctx)
-	if err != nil {
-		t.Fatalf("status: %v", err)
-	}
-	if status.Machine != "test-machine" {
-		t.Errorf(
-			"machine = %q, want %q",
-			status.Machine, "test-machine",
-		)
-	}
-	if status.PGSessions != 0 {
-		t.Errorf(
-			"pg sessions = %d, want 0",
-			status.PGSessions,
-		)
-	}
+	require.NoError(t, err, "status")
+	assert.Equal(t, "test-machine", status.Machine)
+	assert.Equal(t, 0, status.PGSessions)
 }
 
 func TestStatusMissingSchema(t *testing.T) {
@@ -574,34 +436,15 @@ func TestStatusMissingSchema(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
 	status, err := ps.Status(ctx)
-	if err != nil {
-		t.Fatalf("status on missing schema: %v", err)
-	}
-	if status.PGSessions != 0 {
-		t.Errorf(
-			"pg sessions = %d, want 0",
-			status.PGSessions,
-		)
-	}
-	if status.PGMessages != 0 {
-		t.Errorf(
-			"pg messages = %d, want 0",
-			status.PGMessages,
-		)
-	}
-	if status.Machine != "test-machine" {
-		t.Errorf(
-			"machine = %q, want %q",
-			status.Machine, "test-machine",
-		)
-	}
+	require.NoError(t, err, "status on missing schema")
+	assert.Equal(t, 0, status.PGSessions)
+	assert.Equal(t, 0, status.PGMessages)
+	assert.Equal(t, "test-machine", status.Machine)
 }
 
 func TestNewRejectsMachineLocal(t *testing.T) {
@@ -611,9 +454,7 @@ func TestNewRejectsMachineLocal(t *testing.T) {
 		pgURL, "agentsview", local, "local", true,
 		SyncOptions{},
 	)
-	if err == nil {
-		t.Fatal("expected error for machine=local")
-	}
+	require.Error(t, err, "expected error for machine=local")
 }
 
 func TestNewRejectsEmptyMachine(t *testing.T) {
@@ -623,9 +464,7 @@ func TestNewRejectsEmptyMachine(t *testing.T) {
 		pgURL, "agentsview", local, "", true,
 		SyncOptions{},
 	)
-	if err == nil {
-		t.Fatal("expected error for empty machine")
-	}
+	require.Error(t, err, "expected error for empty machine")
 }
 
 func TestNewRejectsEmptyURL(t *testing.T) {
@@ -634,9 +473,7 @@ func TestNewRejectsEmptyURL(t *testing.T) {
 		"", "agentsview", local, "test", true,
 		SyncOptions{},
 	)
-	if err == nil {
-		t.Fatal("expected error for empty URL")
-	}
+	require.Error(t, err, "expected error for empty URL")
 }
 
 func TestPushUpdatedAtFormat(t *testing.T) {
@@ -650,15 +487,11 @@ func TestPushUpdatedAtFormat(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := "2026-03-11T12:00:00Z"
 	sess := db.Session{
@@ -668,22 +501,17 @@ func TestPushUpdatedAtFormat(t *testing.T) {
 		Agent:     "claude",
 		StartedAt: &started,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
 
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("push: %v", err)
-	}
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "push")
 
 	var updatedAt time.Time
 	err = ps.pg.QueryRowContext(ctx,
 		"SELECT updated_at FROM sessions WHERE id = $1",
 		"sess-ts-001",
 	).Scan(&updatedAt)
-	if err != nil {
-		t.Fatalf("querying updated_at: %v", err)
-	}
+	require.NoError(t, err, "querying updated_at")
 
 	formatted := updatedAt.UTC().Format(
 		"2006-01-02T15:04:05.000000Z",
@@ -691,12 +519,8 @@ func TestPushUpdatedAtFormat(t *testing.T) {
 	pattern := regexp.MustCompile(
 		`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$`,
 	)
-	if !pattern.MatchString(formatted) {
-		t.Errorf(
-			"updated_at = %q, want ISO-8601 "+
-				"microsecond format", formatted,
-		)
-	}
+	assert.True(t, pattern.MatchString(formatted),
+		"updated_at = %q, want ISO-8601 microsecond format", formatted)
 }
 
 func TestPushBumpsUpdatedAtOnMessageRewrite(
@@ -712,15 +536,11 @@ func TestPushBumpsUpdatedAtOnMessageRewrite(
 		"machine-a", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := time.Now().UTC().Format(time.RFC3339)
 	sess := db.Session{
@@ -731,9 +551,7 @@ func TestPushBumpsUpdatedAtOnMessageRewrite(
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
 	msg := db.Message{
 		SessionID:     "sess-bump-001",
 		Ordinal:       0,
@@ -741,53 +559,34 @@ func TestPushBumpsUpdatedAtOnMessageRewrite(
 		Content:       "hello",
 		ContentLength: 5,
 	}
-	if err := local.ReplaceSessionMessages(
+	require.NoError(t, local.ReplaceSessionMessages(
 		"sess-bump-001", []db.Message{msg},
-	); err != nil {
-		t.Fatalf("replace messages: %v", err)
-	}
+	), "replace messages")
 
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("initial push: %v", err)
-	}
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "initial push")
 
 	var updatedAt1 time.Time
-	if err := ps.pg.QueryRowContext(ctx,
+	require.NoError(t, ps.pg.QueryRowContext(ctx,
 		"SELECT updated_at FROM sessions WHERE id = $1",
 		"sess-bump-001",
-	).Scan(&updatedAt1); err != nil {
-		t.Fatalf("querying updated_at: %v", err)
-	}
+	).Scan(&updatedAt1), "querying updated_at")
 
 	time.Sleep(50 * time.Millisecond)
 
 	result, err := ps.Push(ctx, true, nil)
-	if err != nil {
-		t.Fatalf("full push: %v", err)
-	}
-	if result.MessagesPushed == 0 {
-		t.Fatal(
-			"expected messages to be pushed on full push",
-		)
-	}
+	require.NoError(t, err, "full push")
+	require.NotZero(t, result.MessagesPushed,
+		"expected messages to be pushed on full push")
 
 	var updatedAt2 time.Time
-	if err := ps.pg.QueryRowContext(ctx,
+	require.NoError(t, ps.pg.QueryRowContext(ctx,
 		"SELECT updated_at FROM sessions WHERE id = $1",
 		"sess-bump-001",
-	).Scan(&updatedAt2); err != nil {
-		t.Fatalf(
-			"querying updated_at after full push: %v",
-			err,
-		)
-	}
+	).Scan(&updatedAt2), "querying updated_at after full push")
 
-	if !updatedAt2.After(updatedAt1) {
-		t.Errorf(
-			"updated_at not bumped: before=%v, after=%v",
-			updatedAt1, updatedAt2,
-		)
-	}
+	assert.True(t, updatedAt2.After(updatedAt1),
+		"updated_at not bumped: before=%v, after=%v", updatedAt1, updatedAt2)
 }
 
 func TestPushFullBypassesHeuristic(t *testing.T) {
@@ -801,15 +600,11 @@ func TestPushFullBypassesHeuristic(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	started := "2026-03-11T12:00:00Z"
 	sess := db.Session{
@@ -820,46 +615,27 @@ func TestPushFullBypassesHeuristic(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{
 		{
 			SessionID: "sess-full-001",
 			Ordinal:   0,
 			Role:      "user",
 			Content:   "test",
 		},
-	}); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	}), "insert messages")
 
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("first push: %v", err)
-	}
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "first push")
 
-	if err := local.SetSyncState(
+	require.NoError(t, local.SetSyncState(
 		"last_push_at", "",
-	); err != nil {
-		t.Fatalf("resetting watermark: %v", err)
-	}
+	), "resetting watermark")
 
 	result, err := ps.Push(ctx, true, nil)
-	if err != nil {
-		t.Fatalf("full push: %v", err)
-	}
-	if result.SessionsPushed != 1 {
-		t.Errorf(
-			"full push sessions = %d, want 1",
-			result.SessionsPushed,
-		)
-	}
-	if result.MessagesPushed != 1 {
-		t.Errorf(
-			"full push messages = %d, want 1",
-			result.MessagesPushed,
-		)
-	}
+	require.NoError(t, err, "full push")
+	assert.Equal(t, 1, result.SessionsPushed)
+	assert.Equal(t, 1, result.MessagesPushed)
 }
 
 func TestPushDetectsSchemaReset(t *testing.T) {
@@ -873,15 +649,11 @@ func TestPushDetectsSchemaReset(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	// Push a session so the watermark advances.
 	started := "2026-03-11T12:00:00Z"
@@ -893,29 +665,18 @@ func TestPushDetectsSchemaReset(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: 1,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{{
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{{
 		SessionID:     "sess-reset-001",
 		Ordinal:       0,
 		Role:          "user",
 		Content:       "hello",
 		ContentLength: 5,
-	}}); err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	}}), "insert message")
 
 	r1, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("initial push: %v", err)
-	}
-	if r1.SessionsPushed != 1 {
-		t.Fatalf(
-			"initial push sessions = %d, want 1",
-			r1.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "initial push")
+	require.Equal(t, 1, r1.SessionsPushed)
 
 	// Simulate a PG schema reset — don't manually recreate;
 	// let Push detect and handle it via the coherence check.
@@ -925,22 +686,10 @@ func TestPushDetectsSchemaReset(t *testing.T) {
 	// (local watermark set, PG has 0 sessions), recreate
 	// the schema, and automatically force a full push.
 	r2, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("post-reset push: %v", err)
-	}
-	if r2.SessionsPushed != 1 {
-		t.Errorf(
-			"post-reset push sessions = %d, want 1 "+
-				"(should auto-detect schema reset)",
-			r2.SessionsPushed,
-		)
-	}
-	if r2.MessagesPushed != 1 {
-		t.Errorf(
-			"post-reset push messages = %d, want 1",
-			r2.MessagesPushed,
-		)
-	}
+	require.NoError(t, err, "post-reset push")
+	assert.Equal(t, 1, r2.SessionsPushed,
+		"should auto-detect schema reset")
+	assert.Equal(t, 1, r2.MessagesPushed)
 }
 
 func TestPushFullAfterSchemaDropRecreatesSchema(
@@ -956,9 +705,7 @@ func TestPushFullAfterSchemaDropRecreatesSchema(
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	ctx := context.Background()
 
 	sess := db.Session{
@@ -968,20 +715,11 @@ func TestPushFullAfterSchemaDropRecreatesSchema(
 		Agent:     "claude",
 		CreatedAt: "2026-03-11T12:00:00.000Z",
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
 
 	r1, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("initial push: %v", err)
-	}
-	if r1.SessionsPushed != 1 {
-		t.Fatalf(
-			"initial push sessions = %d, want 1",
-			r1.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "initial push")
+	require.Equal(t, 1, r1.SessionsPushed)
 
 	// Drop the schema without clearing local state.
 	cleanPGSchema(t, pgURL)
@@ -989,15 +727,8 @@ func TestPushFullAfterSchemaDropRecreatesSchema(
 	// A full push should recreate the schema even though
 	// schemaDone is memoized from the first push.
 	r2, err := ps.Push(ctx, true, nil)
-	if err != nil {
-		t.Fatalf("full push after drop: %v", err)
-	}
-	if r2.SessionsPushed != 1 {
-		t.Errorf(
-			"full push sessions = %d, want 1",
-			r2.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "full push after drop")
+	assert.Equal(t, 1, r2.SessionsPushed)
 }
 
 func TestPushBatchesMultipleSessions(t *testing.T) {
@@ -1011,15 +742,11 @@ func TestPushBatchesMultipleSessions(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	// Create 75 sessions to exercise two batches (50 + 25).
 	const totalSessions = 75
@@ -1034,10 +761,9 @@ func TestPushBatchesMultipleSessions(t *testing.T) {
 			StartedAt:    &started,
 			MessageCount: 2,
 		}
-		if err := local.UpsertSession(sess); err != nil {
-			t.Fatalf("upsert session %d: %v", i, err)
-		}
-		if err := local.InsertMessages([]db.Message{
+		require.NoError(t, local.UpsertSession(sess),
+			"upsert session %d", i)
+		require.NoError(t, local.InsertMessages([]db.Message{
 			{
 				SessionID:     id,
 				Ordinal:       0,
@@ -1052,55 +778,25 @@ func TestPushBatchesMultipleSessions(t *testing.T) {
 				Content:       fmt.Sprintf("reply %d", i),
 				ContentLength: 7,
 			},
-		}); err != nil {
-			t.Fatalf("insert messages %d: %v", i, err)
-		}
+		}), "insert messages %d", i)
 	}
 
 	result, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("push: %v", err)
-	}
-	if result.SessionsPushed != totalSessions {
-		t.Errorf(
-			"sessions pushed = %d, want %d",
-			result.SessionsPushed, totalSessions,
-		)
-	}
-	if result.MessagesPushed != totalSessions*2 {
-		t.Errorf(
-			"messages pushed = %d, want %d",
-			result.MessagesPushed, totalSessions*2,
-		)
-	}
-	if result.Errors != 0 {
-		t.Errorf("errors = %d, want 0", result.Errors)
-	}
+	require.NoError(t, err, "push")
+	assert.Equal(t, totalSessions, result.SessionsPushed)
+	assert.Equal(t, totalSessions*2, result.MessagesPushed)
+	assert.Equal(t, 0, result.Errors)
 
 	// Verify PG state.
 	var pgSessions, pgMessages int
-	if err := ps.pg.QueryRowContext(ctx,
+	require.NoError(t, ps.pg.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM sessions",
-	).Scan(&pgSessions); err != nil {
-		t.Fatalf("counting pg sessions: %v", err)
-	}
-	if err := ps.pg.QueryRowContext(ctx,
+	).Scan(&pgSessions), "counting pg sessions")
+	require.NoError(t, ps.pg.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM messages",
-	).Scan(&pgMessages); err != nil {
-		t.Fatalf("counting pg messages: %v", err)
-	}
-	if pgSessions != totalSessions {
-		t.Errorf(
-			"pg sessions = %d, want %d",
-			pgSessions, totalSessions,
-		)
-	}
-	if pgMessages != totalSessions*2 {
-		t.Errorf(
-			"pg messages = %d, want %d",
-			pgMessages, totalSessions*2,
-		)
-	}
+	).Scan(&pgMessages), "counting pg messages")
+	assert.Equal(t, totalSessions, pgSessions)
+	assert.Equal(t, totalSessions*2, pgMessages)
 }
 
 func TestPushBulkInsertManyMessages(t *testing.T) {
@@ -1114,15 +810,11 @@ func TestPushBulkInsertManyMessages(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	// Create a session with 250 messages to exercise
 	// multi-row VALUES batching (100 per batch).
@@ -1136,9 +828,7 @@ func TestPushBulkInsertManyMessages(t *testing.T) {
 		StartedAt:    &started,
 		MessageCount: msgCount,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("upsert session: %v", err)
-	}
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
 	msgs := make([]db.Message, msgCount)
 	for i := range msgs {
 		role := "user"
@@ -1164,50 +854,27 @@ func TestPushBulkInsertManyMessages(t *testing.T) {
 			}}
 		}
 	}
-	if err := local.InsertMessages(msgs); err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, local.InsertMessages(msgs), "insert messages")
 
 	result, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("push: %v", err)
-	}
-	if result.SessionsPushed != 1 {
-		t.Errorf(
-			"sessions pushed = %d, want 1",
-			result.SessionsPushed,
-		)
-	}
-	if result.MessagesPushed != msgCount {
-		t.Errorf(
-			"messages pushed = %d, want %d",
-			result.MessagesPushed, msgCount,
-		)
-	}
+	require.NoError(t, err, "push")
+	assert.Equal(t, 1, result.SessionsPushed)
+	assert.Equal(t, msgCount, result.MessagesPushed)
 
 	// Verify all messages landed in PG.
 	var pgMsgCount int
-	if err := ps.pg.QueryRowContext(ctx,
+	require.NoError(t, ps.pg.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM messages WHERE session_id = $1",
 		"bulk-msg-sess",
-	).Scan(&pgMsgCount); err != nil {
-		t.Fatalf("counting pg messages: %v", err)
-	}
-	if pgMsgCount != msgCount {
-		t.Errorf(
-			"pg messages = %d, want %d",
-			pgMsgCount, msgCount,
-		)
-	}
+	).Scan(&pgMsgCount), "counting pg messages")
+	assert.Equal(t, msgCount, pgMsgCount)
 
 	// Verify tool calls landed.
 	var pgTCCount int
-	if err := ps.pg.QueryRowContext(ctx,
+	require.NoError(t, ps.pg.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM tool_calls WHERE session_id = $1",
 		"bulk-msg-sess",
-	).Scan(&pgTCCount); err != nil {
-		t.Fatalf("counting pg tool_calls: %v", err)
-	}
+	).Scan(&pgTCCount), "counting pg tool_calls")
 	// Every 10th assistant message (ordinals 1, 11, 21, ...).
 	expectedTC := 0
 	for i := range msgCount {
@@ -1215,12 +882,7 @@ func TestPushBulkInsertManyMessages(t *testing.T) {
 			expectedTC++
 		}
 	}
-	if pgTCCount != expectedTC {
-		t.Errorf(
-			"pg tool_calls = %d, want %d",
-			pgTCCount, expectedTC,
-		)
-	}
+	assert.Equal(t, expectedTC, pgTCCount)
 }
 
 func TestPushSimplePK(t *testing.T) {
@@ -1234,15 +896,11 @@ func TestPushSimplePK(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	var constraintDef string
 	err = ps.pg.QueryRowContext(ctx, `
@@ -1253,15 +911,8 @@ func TestPushSimplePK(t *testing.T) {
 		  AND c.conrelid = 'agentsview.sessions'::regclass
 		  AND c.contype = 'p'
 	`).Scan(&constraintDef)
-	if err != nil {
-		t.Fatalf("querying sessions PK: %v", err)
-	}
-	if constraintDef != "PRIMARY KEY (id)" {
-		t.Errorf(
-			"sessions PK = %q, want PRIMARY KEY (id)",
-			constraintDef,
-		)
-	}
+	require.NoError(t, err, "querying sessions PK")
+	assert.Equal(t, "PRIMARY KEY (id)", constraintDef)
 
 	err = ps.pg.QueryRowContext(ctx, `
 		SELECT pg_get_constraintdef(c.oid)
@@ -1271,16 +922,8 @@ func TestPushSimplePK(t *testing.T) {
 		  AND c.conrelid = 'agentsview.messages'::regclass
 		  AND c.contype = 'p'
 	`).Scan(&constraintDef)
-	if err != nil {
-		t.Fatalf("querying messages PK: %v", err)
-	}
-	if constraintDef != "PRIMARY KEY (session_id, ordinal)" {
-		t.Errorf(
-			"messages PK = %q, "+
-				"want PRIMARY KEY (session_id, ordinal)",
-			constraintDef,
-		)
-	}
+	require.NoError(t, err, "querying messages PK")
+	assert.Equal(t, "PRIMARY KEY (session_id, ordinal)", constraintDef)
 }
 
 func TestPushFilteredByProject(t *testing.T) {
@@ -1308,17 +951,13 @@ func TestPushFilteredByProject(t *testing.T) {
 			MessageCount: 1,
 		},
 	} {
-		if err := local.UpsertSession(s); err != nil {
-			t.Fatalf("upsert %s: %v", s.ID, err)
-		}
-		if err := local.InsertMessages([]db.Message{
+		require.NoError(t, local.UpsertSession(s), "upsert %s", s.ID)
+		require.NoError(t, local.InsertMessages([]db.Message{
 			{
 				SessionID: s.ID, Ordinal: 0,
 				Role: "user", Content: "msg " + s.ID,
 			},
-		}); err != nil {
-			t.Fatalf("insert msg %s: %v", s.ID, err)
-		}
+		}), "insert msg %s", s.ID)
 	}
 
 	ctx := context.Background()
@@ -1329,24 +968,13 @@ func TestPushFilteredByProject(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{Projects: []string{"alpha"}},
 	)
-	if err != nil {
-		t.Fatalf("creating filtered sync: %v", err)
-	}
+	require.NoError(t, err, "creating filtered sync")
 	defer filtered.Close()
 
-	if err := filtered.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, filtered.EnsureSchema(ctx), "ensure schema")
 	r1, err := filtered.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("filtered push: %v", err)
-	}
-	if r1.SessionsPushed != 1 {
-		t.Fatalf(
-			"filtered push: sessions = %d, want 1",
-			r1.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "filtered push")
+	require.Equal(t, 1, r1.SessionsPushed)
 
 	// Verify only alpha is in PG.
 	pgSessionCount := func(project string) int {
@@ -1357,20 +985,12 @@ func TestPushFilteredByProject(t *testing.T) {
 				"WHERE project = $1",
 			project,
 		).Scan(&n)
-		if err != nil {
-			t.Fatalf("count %s: %v", project, err)
-		}
+		require.NoError(t, err, "count %s", project)
 		return n
 	}
-	if n := pgSessionCount("alpha"); n != 1 {
-		t.Errorf("alpha count = %d, want 1", n)
-	}
-	if n := pgSessionCount("beta"); n != 0 {
-		t.Errorf("beta count = %d, want 0", n)
-	}
-	if n := pgSessionCount("gamma"); n != 0 {
-		t.Errorf("gamma count = %d, want 0", n)
-	}
+	assert.Equal(t, 1, pgSessionCount("alpha"))
+	assert.Equal(t, 0, pgSessionCount("beta"))
+	assert.Equal(t, 0, pgSessionCount("gamma"))
 
 	// Step 2: push unfiltered — beta and gamma should arrive.
 	unfiltered, err := New(
@@ -1378,41 +998,23 @@ func TestPushFilteredByProject(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{},
 	)
-	if err != nil {
-		t.Fatalf("creating unfiltered sync: %v", err)
-	}
+	require.NoError(t, err, "creating unfiltered sync")
 	defer unfiltered.Close()
 
 	r2, err := unfiltered.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("unfiltered push: %v", err)
-	}
-	if r2.SessionsPushed < 2 {
-		t.Fatalf(
-			"unfiltered push: sessions = %d, want >= 2",
-			r2.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "unfiltered push")
+	require.GreaterOrEqual(t, r2.SessionsPushed, 2)
 
 	// Verify all three projects are in PG.
 	for _, p := range []string{"alpha", "beta", "gamma"} {
-		if n := pgSessionCount(p); n != 1 {
-			t.Errorf("%s count = %d, want 1", p, n)
-		}
+		assert.Equal(t, 1, pgSessionCount(p), "project %s", p)
 	}
 
 	// Step 3: second filtered push is a no-op (fingerprints
 	// match).
 	r3, err := filtered.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("second filtered push: %v", err)
-	}
-	if r3.SessionsPushed != 0 {
-		t.Errorf(
-			"second filtered push: sessions = %d, want 0",
-			r3.SessionsPushed,
-		)
-	}
+	require.NoError(t, err, "second filtered push")
+	assert.Equal(t, 0, r3.SessionsPushed)
 }
 
 func TestPushExcludeProject(t *testing.T) {
@@ -1434,17 +1036,13 @@ func TestPushExcludeProject(t *testing.T) {
 			MessageCount: 1,
 		},
 	} {
-		if err := local.UpsertSession(s); err != nil {
-			t.Fatalf("upsert %s: %v", s.ID, err)
-		}
-		if err := local.InsertMessages([]db.Message{
+		require.NoError(t, local.UpsertSession(s), "upsert %s", s.ID)
+		require.NoError(t, local.InsertMessages([]db.Message{
 			{
 				SessionID: s.ID, Ordinal: 0,
 				Role: "user", Content: "msg",
 			},
-		}); err != nil {
-			t.Fatalf("insert msg %s: %v", s.ID, err)
-		}
+		}), "insert msg %s", s.ID)
 	}
 
 	ctx := context.Background()
@@ -1454,32 +1052,20 @@ func TestPushExcludeProject(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{ExcludeProjects: []string{"beta"}},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 	r, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("push: %v", err)
-	}
-	if r.SessionsPushed != 1 {
-		t.Fatalf("sessions = %d, want 1", r.SessionsPushed)
-	}
+	require.NoError(t, err, "push")
+	require.Equal(t, 1, r.SessionsPushed)
 
 	var pgProject string
 	err = ps.pg.QueryRowContext(ctx,
 		"SELECT project FROM sessions LIMIT 1",
 	).Scan(&pgProject)
-	if err != nil {
-		t.Fatalf("query pg: %v", err)
-	}
-	if pgProject != "alpha" {
-		t.Errorf("project = %q, want alpha", pgProject)
-	}
+	require.NoError(t, err, "query pg")
+	assert.Equal(t, "alpha", pgProject)
 }
 
 func TestPushFilteredFullIsIncremental(t *testing.T) {
@@ -1489,21 +1075,17 @@ func TestPushFilteredFullIsIncremental(t *testing.T) {
 
 	local := testDB(t)
 
-	if err := local.UpsertSession(db.Session{
+	require.NoError(t, local.UpsertSession(db.Session{
 		ID: "s1", Project: "alpha",
 		Machine: "local", Agent: "claude",
 		MessageCount: 1,
-	}); err != nil {
-		t.Fatalf("upsert: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{
+	}), "upsert")
+	require.NoError(t, local.InsertMessages([]db.Message{
 		{
 			SessionID: "s1", Ordinal: 0,
 			Role: "user", Content: "hello",
 		},
-	}); err != nil {
-		t.Fatalf("insert msg: %v", err)
-	}
+	}), "insert msg")
 
 	ctx := context.Background()
 	ps, err := New(
@@ -1511,54 +1093,31 @@ func TestPushFilteredFullIsIncremental(t *testing.T) {
 		"test-machine", true,
 		SyncOptions{Projects: []string{"alpha"}},
 	)
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("ensure schema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "ensure schema")
 
 	// First push with --full.
 	r1, err := ps.Push(ctx, true, nil)
-	if err != nil {
-		t.Fatalf("first push: %v", err)
-	}
-	if r1.SessionsPushed != 1 {
-		t.Fatalf("first push: sessions = %d, want 1",
-			r1.SessionsPushed)
-	}
+	require.NoError(t, err, "first push")
+	require.Equal(t, 1, r1.SessionsPushed)
 
 	// Filtered --full must not advance the global watermark.
 	wm, err := local.GetSyncState("last_push_at")
-	if err != nil {
-		t.Fatalf("reading watermark: %v", err)
-	}
-	if wm != "" {
-		t.Errorf("watermark after filtered --full = %q, "+
-			"want empty", wm)
-	}
+	require.NoError(t, err, "reading watermark")
+	assert.Empty(t, wm, "watermark after filtered --full")
 
 	// Boundary fingerprints must have been written.
 	bs, err := local.GetSyncState(
 		"last_push_boundary_state",
 	)
-	if err != nil {
-		t.Fatalf("reading boundary state: %v", err)
-	}
-	if bs == "" {
-		t.Fatal("boundary state empty after filtered --full")
-	}
+	require.NoError(t, err, "reading boundary state")
+	require.NotEmpty(t, bs, "boundary state empty after filtered --full")
 
 	// Second push (not --full) should be a no-op because
 	// fingerprints were persisted after the filtered --full.
 	r2, err := ps.Push(ctx, false, nil)
-	if err != nil {
-		t.Fatalf("second push: %v", err)
-	}
-	if r2.SessionsPushed != 0 {
-		t.Errorf("second push: sessions = %d, want 0",
-			r2.SessionsPushed)
-	}
+	require.NoError(t, err, "second push")
+	assert.Equal(t, 0, r2.SessionsPushed)
 }

--- a/internal/postgres/sync_unit_test.go
+++ b/internal/postgres/sync_unit_test.go
@@ -3,6 +3,8 @@ package postgres
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsUndefinedTable(t *testing.T) {
@@ -40,13 +42,7 @@ func TestIsUndefinedTable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isUndefinedTable(tt.err)
-			if got != tt.want {
-				t.Errorf(
-					"isUndefinedTable(%v) = %v, want %v",
-					tt.err, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, isUndefinedTable(tt.err))
 		})
 	}
 }

--- a/internal/postgres/time_test.go
+++ b/internal/postgres/time_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -54,24 +57,12 @@ func TestParseSQLiteTimestamp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := ParseSQLiteTimestamp(tt.input)
-			if ok != tt.wantOK {
-				t.Fatalf(
-					"ParseSQLiteTimestamp(%q) ok = %v, "+
-						"want %v",
-					tt.input, ok, tt.wantOK,
-				)
-			}
+			require.Equal(t, tt.wantOK, ok)
 			if !ok {
 				return
 			}
 			gotStr := got.UTC().Format(time.RFC3339Nano)
-			if gotStr != tt.wantUTC {
-				t.Errorf(
-					"ParseSQLiteTimestamp(%q) = %q, "+
-						"want %q",
-					tt.input, gotStr, tt.wantUTC,
-				)
-			}
+			assert.Equal(t, tt.wantUTC, gotStr)
 		})
 	}
 }
@@ -81,24 +72,14 @@ func TestFormatISO8601(t *testing.T) {
 		2026, 3, 11, 12, 34, 56, 123456789,
 		time.UTC,
 	)
-	got := FormatISO8601(ts)
-	want := "2026-03-11T12:34:56.123456789Z"
-	if got != want {
-		t.Errorf("FormatISO8601() = %q, want %q", got, want)
-	}
+	assert.Equal(t, "2026-03-11T12:34:56.123456789Z", FormatISO8601(ts))
 }
 
 func TestFormatISO8601NonUTC(t *testing.T) {
 	loc := time.FixedZone("EST", -5*3600)
 	ts := time.Date(2026, 3, 11, 7, 34, 56, 0, loc)
-	got := FormatISO8601(ts)
-	want := "2026-03-11T12:34:56Z"
-	if got != want {
-		t.Errorf(
-			"FormatISO8601() = %q, want %q (should be UTC)",
-			got, want,
-		)
-	}
+	assert.Equal(t, "2026-03-11T12:34:56Z", FormatISO8601(ts),
+		"should be UTC")
 }
 
 func TestNormalizeSyncTimestamp(t *testing.T) {
@@ -126,12 +107,8 @@ func TestNormalizeSyncTimestamp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NormalizeSyncTimestamp(tt.input)
-			if err != nil {
-				t.Fatalf("error = %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -161,12 +138,8 @@ func TestNormalizeLocalSyncTimestamp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NormalizeLocalSyncTimestamp(tt.input)
-			if err != nil {
-				t.Fatalf("error = %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -175,49 +148,29 @@ func TestPreviousLocalSyncTimestamp(t *testing.T) {
 	got, err := PreviousLocalSyncTimestamp(
 		"2026-03-11T12:34:56.124Z",
 	)
-	if err != nil {
-		t.Fatalf("error = %v", err)
-	}
-	want := "2026-03-11T12:34:56.123Z"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "2026-03-11T12:34:56.123Z", got)
 }
 
 func TestPreviousLocalSyncTimestampEmpty(t *testing.T) {
 	got, err := PreviousLocalSyncTimestamp("")
-	if err != nil {
-		t.Fatalf("error = %v", err)
-	}
-	if got != "" {
-		t.Errorf("got %q, want empty", got)
-	}
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }
 
 func TestNormalizeLocalSyncStateTimestamps(t *testing.T) {
 	local, err := db.Open(t.TempDir() + "/test.db")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
+	require.NoError(t, err)
 	defer local.Close()
 
-	if err := local.SetSyncState(
+	require.NoError(t, local.SetSyncState(
 		"last_push_at",
 		"2026-03-11T12:34:56.123456789Z",
-	); err != nil {
-		t.Fatalf("SetSyncState: %v", err)
-	}
+	))
 
-	if err := NormalizeLocalSyncStateTimestamps(local); err != nil {
-		t.Fatalf("NormalizeLocalSyncStateTimestamps: %v", err)
-	}
+	require.NoError(t, NormalizeLocalSyncStateTimestamps(local))
 
 	got, err := local.GetSyncState("last_push_at")
-	if err != nil {
-		t.Fatalf("GetSyncState: %v", err)
-	}
-	want := "2026-03-11T12:34:56.123Z"
-	if got != want {
-		t.Errorf("last_push_at = %q, want %q", got, want)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "2026-03-11T12:34:56.123Z", got)
 }

--- a/internal/postgres/token_usage_pgtest_test.go
+++ b/internal/postgres/token_usage_pgtest_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -15,9 +18,7 @@ func TestStoreSessionAndMessageTokenUsage(t *testing.T) {
 	ensureStoreSchema(t, pgURL)
 
 	pg, err := Open(pgURL, testSchema, false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	_, err = pg.Exec(`
@@ -36,9 +37,7 @@ func TestStoreSessionAndMessageTokenUsage(t *testing.T) {
 			has_total_output_tokens = EXCLUDED.has_total_output_tokens,
 			has_peak_context_tokens = EXCLUDED.has_peak_context_tokens
 	`)
-	if err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
+	require.NoError(t, err, "insert session")
 	_, err = pg.Exec(`
 		INSERT INTO messages (
 			session_id, ordinal, role, content,
@@ -56,50 +55,26 @@ func TestStoreSessionAndMessageTokenUsage(t *testing.T) {
 			has_context_tokens = EXCLUDED.has_context_tokens,
 			has_output_tokens = EXCLUDED.has_output_tokens
 	`)
-	if err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	require.NoError(t, err, "insert message")
 
 	store, err := NewStore(pgURL, testSchema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	ctx := context.Background()
 	sess, err := store.GetSession(ctx, "token-store-001")
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected session")
-	}
-	if !sess.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = false, want true")
-	}
-	if !sess.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = false, want true")
-	}
-	if sess.TotalOutputTokens != 500 {
-		t.Errorf("TotalOutputTokens = %d, want 500", sess.TotalOutputTokens)
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, sess)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+	assert.Equal(t, 500, sess.TotalOutputTokens)
 
 	msgs, err := store.GetMessages(ctx, "token-store-001", 0, 10, true)
-	if err != nil {
-		t.Fatalf("GetMessages: %v", err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("GetMessages len = %d, want 1", len(msgs))
-	}
-	if !msgs[0].HasOutputTokens {
-		t.Error("HasOutputTokens = false, want true")
-	}
-	if !msgs[0].HasContextTokens {
-		t.Error("HasContextTokens = false, want true")
-	}
-	if msgs[0].OutputTokens != 200 {
-		t.Errorf("OutputTokens = %d, want 200", msgs[0].OutputTokens)
-	}
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, msgs, 1)
+	assert.True(t, msgs[0].HasOutputTokens)
+	assert.True(t, msgs[0].HasContextTokens)
+	assert.Equal(t, 200, msgs[0].OutputTokens)
 }
 
 func TestPushTokenUsageToPostgres(t *testing.T) {
@@ -109,15 +84,11 @@ func TestPushTokenUsageToPostgres(t *testing.T) {
 
 	local := testDB(t)
 	ps, err := New(pgURL, "agentsview", local, "test-machine", true, SyncOptions{})
-	if err != nil {
-		t.Fatalf("creating sync: %v", err)
-	}
+	require.NoError(t, err, "creating sync")
 	defer ps.Close()
 
 	ctx := context.Background()
-	if err := ps.EnsureSchema(ctx); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	require.NoError(t, ps.EnsureSchema(ctx), "EnsureSchema")
 
 	sess := db.Session{
 		ID:                   "token-push-001",
@@ -131,10 +102,8 @@ func TestPushTokenUsageToPostgres(t *testing.T) {
 		HasTotalOutputTokens: true,
 		HasPeakContextTokens: true,
 	}
-	if err := local.UpsertSession(sess); err != nil {
-		t.Fatalf("UpsertSession: %v", err)
-	}
-	if err := local.InsertMessages([]db.Message{{
+	require.NoError(t, local.UpsertSession(sess), "UpsertSession")
+	require.NoError(t, local.InsertMessages([]db.Message{{
 		SessionID:        "token-push-001",
 		Ordinal:          0,
 		Role:             "assistant",
@@ -146,53 +115,28 @@ func TestPushTokenUsageToPostgres(t *testing.T) {
 		OutputTokens:     200,
 		HasContextTokens: true,
 		HasOutputTokens:  true,
-	}}); err != nil {
-		t.Fatalf("InsertMessages: %v", err)
-	}
+	}}), "InsertMessages")
 
-	if _, err := ps.Push(ctx, false, nil); err != nil {
-		t.Fatalf("Push: %v", err)
-	}
+	_, err = ps.Push(ctx, false, nil)
+	require.NoError(t, err, "Push")
 
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	gotSess, err := store.GetSession(ctx, "token-push-001")
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if gotSess == nil {
-		t.Fatal("expected pushed session")
-	}
-	if !gotSess.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = false, want true")
-	}
-	if !gotSess.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = false, want true")
-	}
-	if gotSess.TotalOutputTokens != 500 {
-		t.Errorf("TotalOutputTokens = %d, want 500", gotSess.TotalOutputTokens)
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, gotSess, "expected pushed session")
+	assert.True(t, gotSess.HasTotalOutputTokens)
+	assert.True(t, gotSess.HasPeakContextTokens)
+	assert.Equal(t, 500, gotSess.TotalOutputTokens)
 
 	gotMsgs, err := store.GetMessages(ctx, "token-push-001", 0, 10, true)
-	if err != nil {
-		t.Fatalf("GetMessages: %v", err)
-	}
-	if len(gotMsgs) != 1 {
-		t.Fatalf("GetMessages len = %d, want 1", len(gotMsgs))
-	}
-	if !gotMsgs[0].HasContextTokens {
-		t.Error("HasContextTokens = false, want true")
-	}
-	if !gotMsgs[0].HasOutputTokens {
-		t.Error("HasOutputTokens = false, want true")
-	}
-	if gotMsgs[0].OutputTokens != 200 {
-		t.Errorf("OutputTokens = %d, want 200", gotMsgs[0].OutputTokens)
-	}
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, gotMsgs, 1)
+	assert.True(t, gotMsgs[0].HasContextTokens)
+	assert.True(t, gotMsgs[0].HasOutputTokens)
+	assert.Equal(t, 200, gotMsgs[0].OutputTokens)
 }
 
 func TestEnsureSchemaBackfillsTokenCoverageFlags(t *testing.T) {
@@ -201,15 +145,11 @@ func TestEnsureSchemaBackfillsTokenCoverageFlags(t *testing.T) {
 	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
 
 	pg, err := Open(pgURL, "agentsview", false)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	defer pg.Close()
 
 	ctx := context.Background()
-	if err := EnsureSchema(ctx, pg, "agentsview"); err != nil {
-		t.Fatalf("EnsureSchema initial: %v", err)
-	}
+	require.NoError(t, EnsureSchema(ctx, pg, "agentsview"), "EnsureSchema initial")
 
 	_, err = pg.Exec(`
 		INSERT INTO sessions (
@@ -222,9 +162,7 @@ func TestEnsureSchemaBackfillsTokenCoverageFlags(t *testing.T) {
 			('pg-legacy-zero', 'test-machine', 'proj', 'claude', 1,
 			 0, 0, FALSE, FALSE)
 	`)
-	if err != nil {
-		t.Fatalf("insert legacy sessions: %v", err)
-	}
+	require.NoError(t, err, "insert legacy sessions")
 	_, err = pg.Exec(`
 		INSERT INTO messages (
 			session_id, ordinal, role, content, content_length,
@@ -235,59 +173,33 @@ func TestEnsureSchemaBackfillsTokenCoverageFlags(t *testing.T) {
 			 'claude-sonnet-4-20250514',
 			 '{"input_tokens":0,"output_tokens":0}', 0, 0, FALSE, FALSE)
 	`)
-	if err != nil {
-		t.Fatalf("insert legacy message: %v", err)
-	}
+	require.NoError(t, err, "insert legacy message")
 
-	if err := EnsureSchema(ctx, pg, "agentsview"); err != nil {
-		t.Fatalf("EnsureSchema backfill: %v", err)
-	}
+	require.NoError(t, EnsureSchema(ctx, pg, "agentsview"), "EnsureSchema backfill")
 
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	nonzero, err := store.GetSession(ctx, "pg-legacy-nonzero")
-	if err != nil {
-		t.Fatalf("GetSession nonzero: %v", err)
-	}
-	if nonzero == nil {
-		t.Fatal("pg-legacy-nonzero missing")
-	}
-	if !nonzero.HasTotalOutputTokens {
-		t.Error("pg-legacy-nonzero HasTotalOutputTokens = false, want true")
-	}
-	if !nonzero.HasPeakContextTokens {
-		t.Error("pg-legacy-nonzero HasPeakContextTokens = false, want true")
-	}
+	require.NoError(t, err, "GetSession nonzero")
+	require.NotNil(t, nonzero, "pg-legacy-nonzero missing")
+	assert.True(t, nonzero.HasTotalOutputTokens,
+		"pg-legacy-nonzero HasTotalOutputTokens")
+	assert.True(t, nonzero.HasPeakContextTokens,
+		"pg-legacy-nonzero HasPeakContextTokens")
 
 	zero, err := store.GetSession(ctx, "pg-legacy-zero")
-	if err != nil {
-		t.Fatalf("GetSession zero: %v", err)
-	}
-	if zero == nil {
-		t.Fatal("pg-legacy-zero missing")
-	}
-	if !zero.HasTotalOutputTokens {
-		t.Error("pg-legacy-zero HasTotalOutputTokens = false, want true")
-	}
-	if !zero.HasPeakContextTokens {
-		t.Error("pg-legacy-zero HasPeakContextTokens = false, want true")
-	}
+	require.NoError(t, err, "GetSession zero")
+	require.NotNil(t, zero, "pg-legacy-zero missing")
+	assert.True(t, zero.HasTotalOutputTokens,
+		"pg-legacy-zero HasTotalOutputTokens")
+	assert.True(t, zero.HasPeakContextTokens,
+		"pg-legacy-zero HasPeakContextTokens")
 
 	msgs, err := store.GetMessages(ctx, "pg-legacy-zero", 0, 10, true)
-	if err != nil {
-		t.Fatalf("GetMessages zero: %v", err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("messages len = %d, want 1", len(msgs))
-	}
-	if !msgs[0].HasContextTokens {
-		t.Error("message HasContextTokens = false, want true")
-	}
-	if !msgs[0].HasOutputTokens {
-		t.Error("message HasOutputTokens = false, want true")
-	}
+	require.NoError(t, err, "GetMessages zero")
+	require.Len(t, msgs, 1)
+	assert.True(t, msgs[0].HasContextTokens, "message HasContextTokens")
+	assert.True(t, msgs[0].HasOutputTokens, "message HasOutputTokens")
 }

--- a/internal/postgres/trends_pgtest_test.go
+++ b/internal/postgres/trends_pgtest_test.go
@@ -4,8 +4,10 @@ package postgres
 
 import (
 	"context"
-	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
 )
@@ -23,9 +25,7 @@ func TestStoreGetTrendsTerms(t *testing.T) {
 			'2024-06-01T10:00:00Z'::timestamptz,
 			3, 2
 		)`)
-	if err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
+	require.NoError(t, err, "insert session")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO messages (
 			session_id, ordinal, role, content, timestamp,
@@ -37,41 +37,25 @@ func TestStoreGetTrendsTerms(t *testing.T) {
 			 '2024-06-08T09:00:00Z'::timestamptz, 23, FALSE),
 			('trends-pg-001', 2, 'user', 'seam system',
 			 '2024-06-08T09:00:00Z'::timestamptz, 11, TRUE)`)
-	if err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, err, "insert messages")
 	terms, err := db.ParseTrendTerms([]string{"load bearing | load-bearing", "seam"})
-	if err != nil {
-		t.Fatalf("ParseTrendTerms: %v", err)
-	}
+	require.NoError(t, err, "ParseTrendTerms")
 	got, err := store.GetTrendsTerms(ctx, db.AnalyticsFilter{
 		From: "2024-06-01", To: "2024-06-09", Timezone: "UTC",
 	}, terms, "week")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if want := []string{"2024-05-27", "2024-06-03"}; !slices.Equal(trendBucketDates(got.Buckets), want) {
-		t.Fatalf("bucket dates = %#v, want %#v", trendBucketDates(got.Buckets), want)
-	}
-	if want := []int{1, 1}; !slices.Equal(trendBucketMessageCounts(got.Buckets), want) {
-		t.Fatalf("bucket message counts = %#v, want %#v", trendBucketMessageCounts(got.Buckets), want)
-	}
-	if got.MessageCount != 2 {
-		t.Fatalf("message count = %d, want 2", got.MessageCount)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, []string{"2024-05-27", "2024-06-03"},
+		trendBucketDates(got.Buckets))
+	assert.Equal(t, []int{1, 1},
+		trendBucketMessageCounts(got.Buckets))
+	assert.Equal(t, 2, got.MessageCount)
 	byTerm := trendSeriesByTerm(got.Series)
-	if got := byTerm["load bearing"].Total; got != 2 {
-		t.Fatalf("load bearing total = %d, want 2", got)
-	}
-	if got := byTerm["seam"].Total; got != 3 {
-		t.Fatalf("seam total = %d, want 3", got)
-	}
-	if want := []int{1, 1}; !slices.Equal(trendPointCounts(byTerm["load bearing"].Points), want) {
-		t.Fatalf("load bearing points = %#v, want %#v", trendPointCounts(byTerm["load bearing"].Points), want)
-	}
-	if want := []int{1, 2}; !slices.Equal(trendPointCounts(byTerm["seam"].Points), want) {
-		t.Fatalf("seam points = %#v, want %#v", trendPointCounts(byTerm["seam"].Points), want)
-	}
+	assert.Equal(t, 2, byTerm["load bearing"].Total)
+	assert.Equal(t, 3, byTerm["seam"].Total)
+	assert.Equal(t, []int{1, 1},
+		trendPointCounts(byTerm["load bearing"].Points))
+	assert.Equal(t, []int{1, 2},
+		trendPointCounts(byTerm["seam"].Points))
 }
 
 func TestStoreGetTrendsTermsUsesMessageTimestampFilters(t *testing.T) {
@@ -86,9 +70,7 @@ func TestStoreGetTrendsTermsUsesMessageTimestampFilters(t *testing.T) {
 			'alpha', 'claude',
 			'2024-06-04T08:00:00Z'::timestamptz, 2, 2
 		)`)
-	if err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
+	require.NoError(t, err, "insert session")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO messages (
 			session_id, ordinal, role, content, timestamp,
@@ -98,13 +80,9 @@ func TestStoreGetTrendsTermsUsesMessageTimestampFilters(t *testing.T) {
 			 '2024-06-05T09:00:00Z'::timestamptz, 4, FALSE),
 			('trends-pg-message-filters-001', 1, 'user', 'seam',
 			 '2024-06-05T10:00:00Z'::timestamptz, 4, FALSE)`)
-	if err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, err, "insert messages")
 	terms, err := db.ParseTrendTerms([]string{"seam"})
-	if err != nil {
-		t.Fatalf("ParseTrendTerms: %v", err)
-	}
+	require.NoError(t, err, "ParseTrendTerms")
 	dow := 2
 	hour := 9
 	got, err := store.GetTrendsTerms(ctx, db.AnalyticsFilter{
@@ -114,15 +92,9 @@ func TestStoreGetTrendsTermsUsesMessageTimestampFilters(t *testing.T) {
 		DayOfWeek: &dow,
 		Hour:      &hour,
 	}, terms, "day")
-	if err != nil {
-		t.Fatalf("GetTrendsTerms: %v", err)
-	}
-	if got.MessageCount != 1 {
-		t.Fatalf("message count = %d, want 1", got.MessageCount)
-	}
-	if got := trendSeriesByTerm(got.Series)["seam"].Total; got != 1 {
-		t.Fatalf("message timestamp filtered total = %d, want 1", got)
-	}
+	require.NoError(t, err, "GetTrendsTerms")
+	assert.Equal(t, 1, got.MessageCount)
+	assert.Equal(t, 1, trendSeriesByTerm(got.Series)["seam"].Total)
 }
 
 func trendBucketDates(buckets []db.TrendBucket) []string {

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -17,23 +20,16 @@ func prepareUsageSchema(
 
 	pgURL := testPGURL(t)
 	pg, err := Open(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
+	require.NoError(t, err, "Open")
 	t.Cleanup(func() { _ = pg.Close() })
 
 	ctx := context.Background()
-	if _, err := pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`); err != nil {
-		t.Fatalf("drop schema: %v", err)
-	}
-	if err := EnsureSchema(ctx, pg, schema); err != nil {
-		t.Fatalf("EnsureSchema: %v", err)
-	}
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
 
 	store, err := NewStore(pgURL, schema, true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	t.Cleanup(func() { _ = store.Close() })
 	return pgURL, store
 }
@@ -50,9 +46,7 @@ func TestStoreGetDailyUsageUsesFallbackPricing(t *testing.T) {
 			'usage-fallback-001', 'test-machine', 'proj', 'claude',
 			'2026-03-12T10:00:00Z'::timestamptz, 1, 1
 		)`)
-	if err != nil {
-		t.Fatalf("insert session: %v", err)
-	}
+	require.NoError(t, err, "insert session")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO messages (
 			session_id, ordinal, role, content, timestamp,
@@ -63,24 +57,16 @@ func TestStoreGetDailyUsageUsesFallbackPricing(t *testing.T) {
 			'claude-sonnet-4-20250514',
 			'{"input_tokens":1000000}'
 		)`)
-	if err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	require.NoError(t, err, "insert message")
 
 	result, err := store.GetDailyUsage(ctx, db.UsageFilter{
 		From:     "2026-03-12",
 		To:       "2026-03-12",
 		Timezone: "UTC",
 	})
-	if err != nil {
-		t.Fatalf("GetDailyUsage: %v", err)
-	}
-	if got := result.Totals.TotalCost; got != 3.0 {
-		t.Fatalf("TotalCost = %.2f, want 3.0", got)
-	}
-	if len(result.Daily) != 1 {
-		t.Fatalf("daily len = %d, want 1", len(result.Daily))
-	}
+	require.NoError(t, err, "GetDailyUsage")
+	assert.Equal(t, 3.0, result.Totals.TotalCost)
+	assert.Len(t, result.Daily, 1)
 }
 
 func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
@@ -94,9 +80,7 @@ func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
 		) VALUES
 			('test-model-a', 1, 2, 3, 0.5, 'seed'),
 			('test-model-b', 2, 4, 0, 0, 'seed')`)
-	if err != nil {
-		t.Fatalf("insert pricing: %v", err)
-	}
+	require.NoError(t, err, "insert pricing")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO sessions (
 			id, machine, project, agent, started_at,
@@ -106,9 +90,7 @@ func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
 			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
 			('usage-breakdown-002', 'test-machine', 'proj-b', 'codex',
 			 '2026-03-12T11:00:00Z'::timestamptz, 1, 1)`)
-	if err != nil {
-		t.Fatalf("insert sessions: %v", err)
-	}
+	require.NoError(t, err, "insert sessions")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO messages (
 			session_id, ordinal, role, content, timestamp, content_length,
@@ -122,9 +104,7 @@ func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
 			 '2026-03-12T11:00:00Z'::timestamptz, 3,
 			 'test-model-b',
 			 '{"input_tokens":500000,"output_tokens":250000}')`)
-	if err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, err, "insert messages")
 
 	result, err := store.GetDailyUsage(ctx, db.UsageFilter{
 		From:       "2026-03-12",
@@ -132,31 +112,15 @@ func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
 		Timezone:   "UTC",
 		Breakdowns: true,
 	})
-	if err != nil {
-		t.Fatalf("GetDailyUsage: %v", err)
-	}
-	if len(result.Daily) != 1 {
-		t.Fatalf("daily len = %d, want 1", len(result.Daily))
-	}
+	require.NoError(t, err, "GetDailyUsage")
+	require.Len(t, result.Daily, 1)
 	day := result.Daily[0]
-	if got, want := day.InputTokens, 1500000; got != want {
-		t.Fatalf("InputTokens = %d, want %d", got, want)
-	}
-	if got, want := day.OutputTokens, 750000; got != want {
-		t.Fatalf("OutputTokens = %d, want %d", got, want)
-	}
-	if got, want := len(day.ProjectBreakdowns), 2; got != want {
-		t.Fatalf("ProjectBreakdowns len = %d, want %d", got, want)
-	}
-	if got, want := len(day.AgentBreakdowns), 2; got != want {
-		t.Fatalf("AgentBreakdowns len = %d, want %d", got, want)
-	}
-	if got, want := len(day.ModelBreakdowns), 2; got != want {
-		t.Fatalf("ModelBreakdowns len = %d, want %d", got, want)
-	}
-	if day.TotalCost <= 0 {
-		t.Fatalf("TotalCost = %.4f, want > 0", day.TotalCost)
-	}
+	assert.Equal(t, 1500000, day.InputTokens)
+	assert.Equal(t, 750000, day.OutputTokens)
+	assert.Len(t, day.ProjectBreakdowns, 2)
+	assert.Len(t, day.AgentBreakdowns, 2)
+	assert.Len(t, day.ModelBreakdowns, 2)
+	assert.Greater(t, day.TotalCost, 0.0)
 }
 
 func TestStoreGetTopSessionsByCostDedupesClaudeKeys(t *testing.T) {
@@ -168,9 +132,7 @@ func TestStoreGetTopSessionsByCostDedupesClaudeKeys(t *testing.T) {
 			model_pattern, input_per_mtok, output_per_mtok,
 			cache_creation_per_mtok, cache_read_per_mtok, updated_at
 		) VALUES ('test-model-top', 1, 0, 0, 0, 'seed')`)
-	if err != nil {
-		t.Fatalf("insert pricing: %v", err)
-	}
+	require.NoError(t, err, "insert pricing")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO sessions (
 			id, machine, project, agent, started_at,
@@ -180,9 +142,7 @@ func TestStoreGetTopSessionsByCostDedupesClaudeKeys(t *testing.T) {
 			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
 			('usage-top-002', 'test-machine', 'proj-b', 'claude',
 			 '2026-03-12T10:01:00Z'::timestamptz, 1, 1)`)
-	if err != nil {
-		t.Fatalf("insert sessions: %v", err)
-	}
+	require.NoError(t, err, "insert sessions")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO messages (
 			session_id, ordinal, role, content, timestamp, content_length,
@@ -194,24 +154,16 @@ func TestStoreGetTopSessionsByCostDedupesClaudeKeys(t *testing.T) {
 			('usage-top-002', 0, 'assistant', 'two',
 			 '2026-03-12T10:01:00Z'::timestamptz, 3,
 			 'test-model-top', '{"input_tokens":1000000}', 'msg-1', 'req-1')`)
-	if err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, err, "insert messages")
 
 	top, err := store.GetTopSessionsByCost(ctx, db.UsageFilter{
 		From:     "2026-03-12",
 		To:       "2026-03-12",
 		Timezone: "UTC",
 	}, 20)
-	if err != nil {
-		t.Fatalf("GetTopSessionsByCost: %v", err)
-	}
-	if len(top) != 1 {
-		t.Fatalf("top len = %d, want 1", len(top))
-	}
-	if top[0].SessionID != "usage-top-001" {
-		t.Fatalf("top[0].SessionID = %q, want usage-top-001", top[0].SessionID)
-	}
+	require.NoError(t, err, "GetTopSessionsByCost")
+	require.Len(t, top, 1)
+	assert.Equal(t, "usage-top-001", top[0].SessionID)
 }
 
 func TestStoreGetUsageSessionCountsDedupesClaudeKeys(t *testing.T) {
@@ -227,9 +179,7 @@ func TestStoreGetUsageSessionCountsDedupesClaudeKeys(t *testing.T) {
 			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
 			('usage-counts-002', 'test-machine', 'proj-b', 'claude',
 			 '2026-03-12T10:01:00Z'::timestamptz, 1, 1)`)
-	if err != nil {
-		t.Fatalf("insert sessions: %v", err)
-	}
+	require.NoError(t, err, "insert sessions")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO messages (
 			session_id, ordinal, role, content, timestamp, content_length,
@@ -241,27 +191,18 @@ func TestStoreGetUsageSessionCountsDedupesClaudeKeys(t *testing.T) {
 			('usage-counts-002', 0, 'assistant', 'two',
 			 '2026-03-12T10:01:00Z'::timestamptz, 3,
 			 'test-model-counts', '{"input_tokens":1}', 'msg-1', 'req-1')`)
-	if err != nil {
-		t.Fatalf("insert messages: %v", err)
-	}
+	require.NoError(t, err, "insert messages")
 
 	counts, err := store.GetUsageSessionCounts(ctx, db.UsageFilter{
 		From:     "2026-03-12",
 		To:       "2026-03-12",
 		Timezone: "UTC",
 	})
-	if err != nil {
-		t.Fatalf("GetUsageSessionCounts: %v", err)
-	}
-	if counts.Total != 1 {
-		t.Fatalf("Total = %d, want 1", counts.Total)
-	}
-	if counts.ByProject["proj-a"] != 1 {
-		t.Fatalf("ByProject[proj-a] = %d, want 1", counts.ByProject["proj-a"])
-	}
-	if _, ok := counts.ByProject["proj-b"]; ok {
-		t.Fatalf("proj-b should have been deduped out: %#v", counts.ByProject)
-	}
+	require.NoError(t, err, "GetUsageSessionCounts")
+	assert.Equal(t, 1, counts.Total)
+	assert.Equal(t, 1, counts.ByProject["proj-a"])
+	_, ok := counts.ByProject["proj-b"]
+	assert.False(t, ok, "proj-b should have been deduped out: %#v", counts.ByProject)
 }
 
 func TestPostgresUsageQueriesUnionUsageEvents(t *testing.T) {
@@ -275,9 +216,7 @@ func TestPostgresUsageQueriesUnionUsageEvents(t *testing.T) {
 		) VALUES
 			('claude-sonnet-4-20250514', 1, 1, 1, 1, 'seed'),
 			('gpt-5.4', 1, 1, 1, 1, 'seed')`)
-	if err != nil {
-		t.Fatalf("insert pricing: %v", err)
-	}
+	require.NoError(t, err, "insert pricing")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO sessions (
 			id, machine, project, agent, started_at,
@@ -289,9 +228,7 @@ func TestPostgresUsageQueriesUnionUsageEvents(t *testing.T) {
 			 '2026-05-14T10:00:00Z'::timestamptz, 1, 1),
 			('hermes-event-2', 'test-machine', 'proj-b', 'hermes',
 			 '2026-05-14T10:10:00Z'::timestamptz, 1, 1)`)
-	if err != nil {
-		t.Fatalf("insert sessions: %v", err)
-	}
+	require.NoError(t, err, "insert sessions")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO messages (
 			session_id, ordinal, role, content, timestamp, content_length,
@@ -301,9 +238,7 @@ func TestPostgresUsageQueriesUnionUsageEvents(t *testing.T) {
 			 '2026-05-14T09:05:00Z'::timestamptz, 3,
 			 'claude-sonnet-4-20250514',
 			 '{"input_tokens":100,"output_tokens":40}')`)
-	if err != nil {
-		t.Fatalf("insert message: %v", err)
-	}
+	require.NoError(t, err, "insert message")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO usage_events (
 			session_id, source, model, input_tokens, output_tokens,
@@ -313,9 +248,7 @@ func TestPostgresUsageQueriesUnionUsageEvents(t *testing.T) {
 			 '2026-05-14T10:05:00Z'::timestamptz, 'shared-key'),
 			('hermes-event-2', 'session', 'gpt-5.4', 50, 5, 0,
 			 '2026-05-14T10:10:00Z'::timestamptz, 'shared-key')`)
-	if err != nil {
-		t.Fatalf("insert usage event: %v", err)
-	}
+	require.NoError(t, err, "insert usage event")
 
 	filter := db.UsageFilter{
 		From:       "2026-05-14",
@@ -324,49 +257,23 @@ func TestPostgresUsageQueriesUnionUsageEvents(t *testing.T) {
 		Breakdowns: true,
 	}
 	result, err := store.GetDailyUsage(ctx, filter)
-	if err != nil {
-		t.Fatalf("GetDailyUsage: %v", err)
-	}
-	if got, want := result.Totals.InputTokens, 450; got != want {
-		t.Fatalf("InputTokens = %d, want %d", got, want)
-	}
-	if got, want := result.Totals.OutputTokens, 115; got != want {
-		t.Fatalf("OutputTokens = %d, want %d", got, want)
-	}
-	if got, want := result.Totals.CacheReadTokens, 20; got != want {
-		t.Fatalf("CacheReadTokens = %d, want %d", got, want)
-	}
-	if got, want := len(result.Daily[0].AgentBreakdowns), 2; got != want {
-		t.Fatalf("AgentBreakdowns len = %d, want %d", got, want)
-	}
+	require.NoError(t, err, "GetDailyUsage")
+	assert.Equal(t, 450, result.Totals.InputTokens)
+	assert.Equal(t, 115, result.Totals.OutputTokens)
+	assert.Equal(t, 20, result.Totals.CacheReadTokens)
+	assert.Len(t, result.Daily[0].AgentBreakdowns, 2)
 
 	top, err := store.GetTopSessionsByCost(ctx, filter, 10)
-	if err != nil {
-		t.Fatalf("GetTopSessionsByCost: %v", err)
-	}
-	if got, want := len(top), 3; got != want {
-		t.Fatalf("top len = %d, want %d", got, want)
-	}
-	if got, want := top[0].SessionID, "hermes-event"; got != want {
-		t.Fatalf("top[0].SessionID = %q, want %q", got, want)
-	}
-	if got, want := top[0].TotalTokens, 390; got != want {
-		t.Fatalf("top[0].TotalTokens = %d, want %d", got, want)
-	}
+	require.NoError(t, err, "GetTopSessionsByCost")
+	require.Len(t, top, 3)
+	assert.Equal(t, "hermes-event", top[0].SessionID)
+	assert.Equal(t, 390, top[0].TotalTokens)
 
 	counts, err := store.GetUsageSessionCounts(ctx, filter)
-	if err != nil {
-		t.Fatalf("GetUsageSessionCounts: %v", err)
-	}
-	if got, want := counts.Total, 3; got != want {
-		t.Fatalf("Total = %d, want %d", got, want)
-	}
-	if got, want := counts.ByAgent["hermes"], 2; got != want {
-		t.Fatalf("ByAgent[hermes] = %d, want %d", got, want)
-	}
-	if got, want := counts.ByProject["proj-b"], 2; got != want {
-		t.Fatalf("ByProject[proj-b] = %d, want %d", got, want)
-	}
+	require.NoError(t, err, "GetUsageSessionCounts")
+	assert.Equal(t, 3, counts.Total)
+	assert.Equal(t, 2, counts.ByAgent["hermes"])
+	assert.Equal(t, 2, counts.ByProject["proj-b"])
 }
 
 func TestPushSyncsModelPricingToPostgres(t *testing.T) {
@@ -375,30 +282,23 @@ func TestPushSyncsModelPricingToPostgres(t *testing.T) {
 	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
 
 	local := testDB(t)
-	if err := local.UpsertModelPricing([]db.ModelPricing{{
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{{
 		ModelPattern:         "test-model-sync",
 		InputPerMTok:         1.5,
 		OutputPerMTok:        2.5,
 		CacheCreationPerMTok: 3.5,
 		CacheReadPerMTok:     0.5,
-	}}); err != nil {
-		t.Fatalf("UpsertModelPricing: %v", err)
-	}
+	}}), "UpsertModelPricing")
 
 	ps, err := New(pgURL, "agentsview", local, "test-machine", true, SyncOptions{})
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	require.NoError(t, err, "New")
 	defer ps.Close()
 
-	if _, err := ps.Push(context.Background(), false, nil); err != nil {
-		t.Fatalf("Push: %v", err)
-	}
+	_, err = ps.Push(context.Background(), false, nil)
+	require.NoError(t, err, "Push")
 
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	rows, err := store.DB().QueryContext(context.Background(), `
@@ -406,32 +306,22 @@ func TestPushSyncsModelPricingToPostgres(t *testing.T) {
 			cache_creation_per_mtok, cache_read_per_mtok
 		FROM model_pricing
 		WHERE model_pattern = 'test-model-sync'`)
-	if err != nil {
-		t.Fatalf("query pricing: %v", err)
-	}
+	require.NoError(t, err, "query pricing")
 	defer rows.Close()
 
-	if !rows.Next() {
-		t.Fatal("expected synced pricing row")
-	}
+	require.True(t, rows.Next(), "expected synced pricing row")
 	var (
 		model                                   string
 		input, output, cacheCreation, cacheRead float64
 	)
-	if err := rows.Scan(
+	require.NoError(t, rows.Scan(
 		&model, &input, &output, &cacheCreation, &cacheRead,
-	); err != nil {
-		t.Fatalf("scan pricing: %v", err)
-	}
-	if model != "test-model-sync" {
-		t.Fatalf("model = %q, want test-model-sync", model)
-	}
-	if input != 1.5 || output != 2.5 || cacheCreation != 3.5 || cacheRead != 0.5 {
-		t.Fatalf(
-			"pricing row = (%v,%v,%v,%v), want (1.5,2.5,3.5,0.5)",
-			input, output, cacheCreation, cacheRead,
-		)
-	}
+	), "scan pricing")
+	assert.Equal(t, "test-model-sync", model)
+	assert.Equal(t, 1.5, input)
+	assert.Equal(t, 2.5, output)
+	assert.Equal(t, 3.5, cacheCreation)
+	assert.Equal(t, 0.5, cacheRead)
 }
 
 func TestPushFallsBackToBuiltinPricingWhenLocalTableEmpty(t *testing.T) {
@@ -441,43 +331,31 @@ func TestPushFallsBackToBuiltinPricingWhenLocalTableEmpty(t *testing.T) {
 
 	local := testDB(t)
 	ps, err := New(pgURL, "agentsview", local, "test-machine", true, SyncOptions{})
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	require.NoError(t, err, "New")
 	defer ps.Close()
 
-	if _, err := ps.Push(context.Background(), false, nil); err != nil {
-		t.Fatalf("Push: %v", err)
-	}
+	_, err = ps.Push(context.Background(), false, nil)
+	require.NoError(t, err, "Push")
 
 	store, err := NewStore(pgURL, "agentsview", true)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
+	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
 	rows, err := store.DB().QueryContext(context.Background(), `
 		SELECT model_pattern
 		FROM model_pricing
 		ORDER BY model_pattern`)
-	if err != nil {
-		t.Fatalf("query pricing: %v", err)
-	}
+	require.NoError(t, err, "query pricing")
 	defer rows.Close()
 
 	var models []string
 	for rows.Next() {
 		var model string
-		if err := rows.Scan(&model); err != nil {
-			t.Fatalf("scan model: %v", err)
-		}
+		require.NoError(t, rows.Scan(&model), "scan model")
 		models = append(models, model)
 	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("rows err: %v", err)
-	}
+	require.NoError(t, rows.Err(), "rows err")
 	joined := strings.Join(models, ",")
-	if !strings.Contains(joined, "claude-sonnet-4-20250514") {
-		t.Fatalf("fallback pricing not synced: %s", joined)
-	}
+	assert.Contains(t, joined, "claude-sonnet-4-20250514",
+		"fallback pricing not synced")
 }

--- a/internal/pricing/fallback_test.go
+++ b/internal/pricing/fallback_test.go
@@ -1,6 +1,11 @@
 package pricing
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestFallbackPricing_Opus46Rates(t *testing.T) {
 	prices := FallbackPricing()
@@ -11,9 +16,7 @@ func TestFallbackPricing_Opus46Rates(t *testing.T) {
 			break
 		}
 	}
-	if got == nil {
-		t.Fatal("claude-opus-4-6 entry missing from FallbackPricing")
-	}
+	require.NotNil(t, got, "claude-opus-4-6 entry missing from FallbackPricing")
 
 	// Source: https://claude.com/pricing — Opus 4.5/4.6 tier.
 	want := ModelPricing{
@@ -23,7 +26,5 @@ func TestFallbackPricing_Opus46Rates(t *testing.T) {
 		CacheCreationPerMTok: 6.25,
 		CacheReadPerMTok:     0.50,
 	}
-	if *got != want {
-		t.Errorf("claude-opus-4-6 pricing = %+v, want %+v", *got, want)
-	}
+	assert.Equal(t, want, *got)
 }

--- a/internal/pricing/litellm_test.go
+++ b/internal/pricing/litellm_test.go
@@ -3,6 +3,9 @@ package pricing
 import (
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseLiteLLMPricing(t *testing.T) {
@@ -18,9 +21,7 @@ func TestParseLiteLLMPricing(t *testing.T) {
 	}`)
 
 	prices, err := ParseLiteLLMPricing(data)
-	if err != nil {
-		t.Fatalf("ParseLiteLLMPricing: %v", err)
-	}
+	require.NoError(t, err)
 
 	var found *ModelPricing
 	for i := range prices {
@@ -29,9 +30,7 @@ func TestParseLiteLLMPricing(t *testing.T) {
 			break
 		}
 	}
-	if found == nil {
-		t.Fatal("claude-sonnet-4-20250514 not found in results")
-	}
+	require.NotNil(t, found, "claude-sonnet-4-20250514 not found in results")
 
 	assertClose(t, "InputPerMTok", found.InputPerMTok, 3.0)
 	assertClose(t, "OutputPerMTok", found.OutputPerMTok, 15.0)
@@ -56,9 +55,7 @@ func TestParseLiteLLMPricingMultipleProviders(t *testing.T) {
 	}`)
 
 	prices, err := ParseLiteLLMPricing(data)
-	if err != nil {
-		t.Fatalf("ParseLiteLLMPricing: %v", err)
-	}
+	require.NoError(t, err)
 
 	foundAnthropic := false
 	foundOpenAI := false
@@ -70,12 +67,8 @@ func TestParseLiteLLMPricingMultipleProviders(t *testing.T) {
 			foundOpenAI = true
 		}
 	}
-	if !foundAnthropic {
-		t.Error("anthropic model not found")
-	}
-	if !foundOpenAI {
-		t.Error("openai model not found")
-	}
+	assert.True(t, foundAnthropic, "anthropic model not found")
+	assert.True(t, foundOpenAI, "openai model not found")
 }
 
 func TestParseLiteLLMPricingSkipsNoCost(t *testing.T) {
@@ -91,23 +84,15 @@ func TestParseLiteLLMPricingSkipsNoCost(t *testing.T) {
 	}`)
 
 	prices, err := ParseLiteLLMPricing(data)
-	if err != nil {
-		t.Fatalf("ParseLiteLLMPricing: %v", err)
-	}
+	require.NoError(t, err)
 
-	if len(prices) != 1 {
-		t.Fatalf("expected 1 model, got %d", len(prices))
-	}
-	if prices[0].ModelPattern != "claude-sonnet-4-20250514" {
-		t.Errorf("unexpected model: %s", prices[0].ModelPattern)
-	}
+	require.Len(t, prices, 1)
+	assert.Equal(t, "claude-sonnet-4-20250514", prices[0].ModelPattern)
 }
 
 func TestFallbackPricing(t *testing.T) {
 	prices := FallbackPricing()
-	if len(prices) == 0 {
-		t.Fatal("FallbackPricing returned empty")
-	}
+	require.NotEmpty(t, prices, "FallbackPricing returned empty")
 
 	required := map[string]bool{
 		"claude-sonnet-4-6":         false,
@@ -123,9 +108,7 @@ func TestFallbackPricing(t *testing.T) {
 		}
 	}
 	for model, found := range required {
-		if !found {
-			t.Errorf("required model %s missing", model)
-		}
+		assert.True(t, found, "required model %s missing", model)
 	}
 }
 
@@ -135,7 +118,5 @@ func assertClose(
 	got, want float64,
 ) {
 	t.Helper()
-	if math.Abs(got-want) > 0.001 {
-		t.Errorf("%s: got %f, want %f", name, got, want)
-	}
+	assert.LessOrEqual(t, math.Abs(got-want), 0.001, "%s: got %f, want %f", name, got, want)
 }

--- a/internal/secrets/placeholder_test.go
+++ b/internal/secrets/placeholder_test.go
@@ -3,6 +3,8 @@ package secrets
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestRejectsAWSDocsPlaceholders pins the new aws-access-key validator: every
@@ -26,10 +28,9 @@ func TestRejectsAWSDocsPlaceholders(t *testing.T) {
 		t.Run(p, func(t *testing.T) {
 			text := "key=" + p + " end"
 			for _, m := range Scan(text) {
-				if m.Rule == "aws-access-key" {
-					t.Errorf("aws-access-key matched placeholder %q (mask=%q)",
-						p, m.Redacted)
-				}
+				assert.NotEqual(t, "aws-access-key", m.Rule,
+					"aws-access-key matched placeholder %q (mask=%q)",
+					p, m.Redacted)
 			}
 		})
 	}
@@ -54,9 +55,7 @@ func TestAcceptsRealAWSKeys(t *testing.T) {
 					found = true
 				}
 			}
-			if !found {
-				t.Errorf("aws-access-key did not match real-looking key %q", k)
-			}
+			assert.True(t, found, "aws-access-key did not match real-looking key %q", k)
 		})
 	}
 }
@@ -77,10 +76,9 @@ func TestRejectsAnthropicPlaceholders(t *testing.T) {
 		t.Run(p, func(t *testing.T) {
 			text := "TOKEN=" + p + " end"
 			for _, m := range Scan(text) {
-				if m.Rule == "anthropic-key" {
-					t.Errorf("anthropic-key matched placeholder %q (mask=%q)",
-						p, m.Redacted)
-				}
+				assert.NotEqual(t, "anthropic-key", m.Rule,
+					"anthropic-key matched placeholder %q (mask=%q)",
+					p, m.Redacted)
 			}
 		})
 	}
@@ -104,9 +102,7 @@ func TestAcceptsRealAnthropicKeys(t *testing.T) {
 					found = true
 				}
 			}
-			if !found {
-				t.Errorf("anthropic-key did not match real-looking key %q", k)
-			}
+			assert.True(t, found, "anthropic-key did not match real-looking key %q", k)
 		})
 	}
 }
@@ -126,10 +122,9 @@ func TestRejectsSlackPlaceholders(t *testing.T) {
 		t.Run(p, func(t *testing.T) {
 			text := "TOKEN=" + p + " end"
 			for _, m := range Scan(text) {
-				if m.Rule == "slack-token" {
-					t.Errorf("slack-token matched placeholder %q (mask=%q)",
-						p, m.Redacted)
-				}
+				assert.NotEqual(t, "slack-token", m.Rule,
+					"slack-token matched placeholder %q (mask=%q)",
+					p, m.Redacted)
 			}
 		})
 	}
@@ -152,9 +147,7 @@ func TestAcceptsRealSlackTokens(t *testing.T) {
 					found = true
 				}
 			}
-			if !found {
-				t.Errorf("slack-token did not match real-looking token %q", k)
-			}
+			assert.True(t, found, "slack-token did not match real-looking token %q", k)
 		})
 	}
 }
@@ -173,9 +166,8 @@ func TestRejectsTrivialPEMBodies(t *testing.T) {
 	for _, p := range cases {
 		t.Run(p[:40], func(t *testing.T) {
 			for _, m := range Scan(p) {
-				if m.Rule == "private-key-block" {
-					t.Errorf("private-key-block matched trivial body %q", p)
-				}
+				assert.NotEqual(t, "private-key-block", m.Rule,
+					"private-key-block matched trivial body %q", p)
 			}
 		})
 	}
@@ -199,9 +191,7 @@ func TestAcceptsRealisticPEMBodies(t *testing.T) {
 					found = true
 				}
 			}
-			if !found {
-				t.Errorf("private-key-block did not match realistic PEM (%s)", header)
-			}
+			assert.True(t, found, "private-key-block did not match realistic PEM (%s)", header)
 		})
 	}
 }
@@ -224,9 +214,7 @@ func TestAcceptsPKCS8Ed25519PEM(t *testing.T) {
 			found = true
 		}
 	}
-	if !found {
-		t.Errorf("private-key-block did not match PKCS#8 Ed25519 PEM (64-byte body)")
-	}
+	assert.True(t, found, "private-key-block did not match PKCS#8 Ed25519 PEM (64-byte body)")
 }
 
 // TestAcceptsEncryptedPEMWithHeaders pins the header-skipping behavior:
@@ -250,10 +238,8 @@ func TestAcceptsEncryptedPEMWithHeaders(t *testing.T) {
 			found = true
 		}
 	}
-	if !found {
-		t.Errorf("private-key-block did not match encrypted PEM with " +
-			"Proc-Type/DEK-Info headers")
-	}
+	assert.True(t, found,
+		"private-key-block did not match encrypted PEM with Proc-Type/DEK-Info headers")
 }
 
 // TestAcceptsAWSKeysWithRepeatedChars pins the entropy-skip on short
@@ -280,9 +266,8 @@ func TestAcceptsAWSKeysWithRepeatedChars(t *testing.T) {
 					found = true
 				}
 			}
-			if !found {
-				t.Errorf("aws-access-key did not match low-entropy real-looking key %q", key)
-			}
+			assert.True(t, found,
+				"aws-access-key did not match low-entropy real-looking key %q", key)
 		})
 	}
 }
@@ -315,10 +300,9 @@ func TestFixtureDenyListSuppressesAgentsviewFixtures(t *testing.T) {
 	for _, f := range fixtures {
 		t.Run(f.name, func(t *testing.T) {
 			for _, m := range Scan(f.text) {
-				if m.Confidence == ConfidenceDefinite {
-					t.Errorf("deny-list let through fixture %q: rule=%s mask=%s",
-						f.text, m.Rule, m.Redacted)
-				}
+				assert.NotEqual(t, ConfidenceDefinite, m.Confidence,
+					"deny-list let through fixture %q: rule=%s mask=%s",
+					f.text, m.Rule, m.Redacted)
 			}
 		})
 	}
@@ -335,9 +319,8 @@ func TestFixtureDenyListExcludesTranscriptOnlyLeakHashes(t *testing.T) {
 		"df26a79256a73d9b7c014e9ea73372498e70a6072d22c0386ed3c6edea9817ac",
 	}
 	for _, h := range transcriptOnlyLeakHashes {
-		if _, ok := agentsviewTestFixtureHashes[h]; ok {
-			t.Fatalf("transcript-only leak hash %s must not be fixture-denied", h)
-		}
+		_, ok := agentsviewTestFixtureHashes[h]
+		assert.False(t, ok, "transcript-only leak hash %s must not be fixture-denied", h)
 	}
 }
 
@@ -352,9 +335,7 @@ func TestFixtureDenyListOffByDefault(t *testing.T) {
 			found = true
 		}
 	}
-	if !found {
-		t.Errorf("default behavior should allow fixture matches; got %+v", matches)
-	}
+	assert.True(t, found, "default behavior should allow fixture matches; got %+v", matches)
 }
 
 // TestRejectsPEMDocsPlaceholders pins the tighter base64-purity gate
@@ -377,9 +358,8 @@ func TestRejectsPEMDocsPlaceholders(t *testing.T) {
 	for i, p := range cases {
 		t.Run(p[:40]+"#"+itoa(i), func(t *testing.T) {
 			for _, m := range Scan(p) {
-				if m.Rule == "private-key-block" {
-					t.Errorf("private-key-block matched docs placeholder: %q", m.Redacted)
-				}
+				assert.NotEqual(t, "private-key-block", m.Rule,
+					"private-key-block matched docs placeholder: %q", m.Redacted)
 			}
 		})
 	}
@@ -406,9 +386,8 @@ func TestRejectsPEMInMarkdownDiff(t *testing.T) {
 	text := "-----BEGIN PRIVATE KEY-----\n" + body +
 		"-----END PRIVATE KEY-----"
 	for _, m := range Scan(text) {
-		if m.Rule == "private-key-block" {
-			t.Errorf("private-key-block matched markdown diff: %q", m.Redacted)
-		}
+		assert.NotEqual(t, "private-key-block", m.Rule,
+			"private-key-block matched markdown diff: %q", m.Redacted)
 	}
 }
 

--- a/internal/secrets/rules_test.go
+++ b/internal/secrets/rules_test.go
@@ -3,6 +3,9 @@ package secrets
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefiniteRules(t *testing.T) {
@@ -40,11 +43,12 @@ func TestDefiniteRules(t *testing.T) {
 					found = m.Rule
 				}
 			}
-			if c.want && found == "" {
-				t.Errorf("expected rule %q to match %q; got %+v", c.rule, c.text, got)
-			}
-			if !c.want && len(got) != 0 {
-				t.Errorf("expected no match for %q; got %+v", c.text, got)
+			if c.want {
+				assert.NotEmpty(t, found,
+					"expected rule %q to match %q; got %+v", c.rule, c.text, got)
+			} else {
+				assert.Empty(t, got,
+					"expected no match for %q; got %+v", c.text, got)
 			}
 		})
 	}
@@ -72,15 +76,13 @@ func TestCandidateRules(t *testing.T) {
 			for _, m := range got {
 				if m.Rule == c.rule {
 					found = true
-					if m.Confidence != ConfidenceCandidate {
-						t.Errorf("%s confidence = %q, want candidate", c.rule, m.Confidence)
-					}
+					assert.Equal(t, ConfidenceCandidate, m.Confidence,
+						"%s confidence", c.rule)
 				}
 			}
-			if found != c.want {
-				t.Errorf("rule %q match=%v want=%v for %q (got %+v)",
-					c.rule, found, c.want, c.text, got)
-			}
+			assert.Equal(t, c.want, found,
+				"rule %q match=%v want=%v for %q (got %+v)",
+				c.rule, found, c.want, c.text, got)
 		})
 	}
 }
@@ -91,21 +93,15 @@ func TestCandidateRules(t *testing.T) {
 func TestScanDefiniteReturnsOnlyDefinite(t *testing.T) {
 	// One definite AWS key and one candidate high-entropy assignment.
 	text := "aws AKIA7QHWN2DKR4FYPLJM and SECRET=Xa9Kd03Lm5Qp7Rt2Vw8Zb4Nc6"
-	if full := Scan(text); len(full) != 2 {
-		t.Fatalf("precondition: Scan should report 2 matches (1 definite, 1 "+
-			"candidate), got %d: %+v", len(full), full)
-	}
+	full := Scan(text)
+	require.Len(t, full, 2,
+		"precondition: Scan should report 2 matches (1 definite, 1 candidate)")
 	got := ScanDefinite(text)
-	if len(got) != 1 {
-		t.Fatalf("ScanDefinite returned %d matches, want 1: %+v", len(got), got)
-	}
-	if got[0].Rule != "aws-access-key" {
-		t.Errorf("rule = %q, want aws-access-key", got[0].Rule)
-	}
+	require.Len(t, got, 1)
+	assert.Equal(t, "aws-access-key", got[0].Rule)
 	for _, m := range got {
-		if m.Confidence != ConfidenceDefinite {
-			t.Errorf("ScanDefinite returned non-definite match: %+v", m)
-		}
+		assert.Equal(t, ConfidenceDefinite, m.Confidence,
+			"ScanDefinite returned non-definite match: %+v", m)
 	}
 }
 
@@ -122,16 +118,13 @@ func TestScanDefiniteMatchesScanDefiniteSubset(t *testing.T) {
 		}
 	}
 	got := ScanDefinite(text)
-	if len(got) != len(wantDef) {
-		t.Fatalf("ScanDefinite count = %d, Scan definite count = %d (%+v vs %+v)",
-			len(got), len(wantDef), got, wantDef)
-	}
+	require.Len(t, got, len(wantDef),
+		"ScanDefinite count vs Scan definite count (%+v vs %+v)", got, wantDef)
 	for i := range got {
-		if got[i].Rule != wantDef[i].Rule || got[i].Start != wantDef[i].Start ||
-			got[i].End != wantDef[i].End || got[i].Redacted != wantDef[i].Redacted {
-			t.Errorf("match %d differs: ScanDefinite=%+v Scan=%+v",
-				i, got[i], wantDef[i])
-		}
+		assert.Equal(t, wantDef[i].Rule, got[i].Rule, "match %d rule differs", i)
+		assert.Equal(t, wantDef[i].Start, got[i].Start, "match %d start differs", i)
+		assert.Equal(t, wantDef[i].End, got[i].End, "match %d end differs", i)
+		assert.Equal(t, wantDef[i].Redacted, got[i].Redacted, "match %d redacted differs", i)
 	}
 }
 
@@ -142,38 +135,26 @@ func TestScanDefiniteMatchesScanDefiniteSubset(t *testing.T) {
 func TestDefiniteRulesVersionDistinctFromFull(t *testing.T) {
 	def := DefiniteRulesVersion()
 	full := RulesVersion()
-	if def == full {
-		t.Fatalf("DefiniteRulesVersion must differ from RulesVersion (both %q)", def)
-	}
-	if def == "" || full == "" {
-		t.Fatal("versions must be non-empty")
-	}
-	if def != DefiniteRulesVersion() {
-		t.Error("DefiniteRulesVersion not stable across calls")
-	}
-	if len(def) != 64 {
-		t.Errorf("DefiniteRulesVersion length = %d, want 64 hex chars: %q", len(def), def)
-	}
+	require.NotEqual(t, full, def,
+		"DefiniteRulesVersion must differ from RulesVersion (both %q)", def)
+	require.NotEmpty(t, def, "versions must be non-empty")
+	require.NotEmpty(t, full, "versions must be non-empty")
+	assert.Equal(t, def, DefiniteRulesVersion(), "DefiniteRulesVersion not stable across calls")
+	assert.Len(t, def, 64, "DefiniteRulesVersion length: %q", def)
 	for _, c := range def {
-		if !isLowerHex(c) {
-			t.Fatalf("DefiniteRulesVersion has non-hex char %q in %q", c, def)
-		}
+		require.True(t, isLowerHex(c),
+			"DefiniteRulesVersion has non-hex char %q in %q", c, def)
 	}
 }
 
 func TestRulesVersionStableAndHex(t *testing.T) {
 	v1 := RulesVersion()
 	v2 := RulesVersion()
-	if v1 != v2 {
-		t.Fatalf("RulesVersion not stable: %q != %q", v1, v2)
-	}
-	if len(v1) != 64 { // sha256 hex
-		t.Fatalf("RulesVersion length = %d, want 64 hex chars: %q", len(v1), v1)
-	}
+	require.Equal(t, v1, v2, "RulesVersion not stable")
+	require.Len(t, v1, 64, "RulesVersion length: %q", v1) // sha256 hex
 	for _, c := range v1 {
-		if !isLowerHex(c) {
-			t.Fatalf("RulesVersion has non-hex char %q in %q", c, v1)
-		}
+		require.True(t, isLowerHex(c),
+			"RulesVersion has non-hex char %q in %q", c, v1)
 	}
 }
 
@@ -182,26 +163,21 @@ func TestVerify(t *testing.T) {
 	awsSrc := "export KEY=AKIA7QHWN2DKR4FYPLJM done"
 	s := strings.Index(awsSrc, "AKIA")
 	e := s + len("AKIA7QHWN2DKR4FYPLJM")
-	if !Verify("aws-access-key", awsSrc, s, e) {
-		t.Error("Verify should accept a valid AWS key at its coordinates")
-	}
-	if Verify("aws-access-key", awsSrc, 0, 6) {
-		t.Error("Verify should reject coordinates that are not the key")
-	}
-	if Verify("nonexistent-rule", awsSrc, s, e) {
-		t.Error("Verify should reject an unknown rule")
-	}
-	if Verify("aws-access-key", awsSrc, s, len(awsSrc)+10) {
-		t.Error("Verify should reject out-of-bounds coordinates")
-	}
+	assert.True(t, Verify("aws-access-key", awsSrc, s, e),
+		"Verify should accept a valid AWS key at its coordinates")
+	assert.False(t, Verify("aws-access-key", awsSrc, 0, 6),
+		"Verify should reject coordinates that are not the key")
+	assert.False(t, Verify("nonexistent-rule", awsSrc, s, e),
+		"Verify should reject an unknown rule")
+	assert.False(t, Verify("aws-access-key", awsSrc, s, len(awsSrc)+10),
+		"Verify should reject out-of-bounds coordinates")
 	// Grouped rule: the stored span is the captured group (the password),
 	// not the full URL match. Verify must still accept it.
 	urlSrc := "db=postgres://user:s3cretP4ss@host:5432/db"
 	ps := strings.Index(urlSrc, "s3cretP4ss")
 	pe := ps + len("s3cretP4ss")
-	if !Verify("basic-auth-url", urlSrc, ps, pe) {
-		t.Error("Verify should accept a grouped finding at its group coordinates")
-	}
+	assert.True(t, Verify("basic-auth-url", urlSrc, ps, pe),
+		"Verify should accept a grouped finding at its group coordinates")
 }
 
 // TestVerifyDetectsChangedSource locks in the core --reveal guarantee: a scan
@@ -211,19 +187,15 @@ func TestVerifyDetectsChangedSource(t *testing.T) {
 	source := "export AWS=AKIA7QHWN2DKR4FYPLJM"
 	// Seed from canonical Scan (what produces findings and what Verify uses).
 	matches := Scan(source)
-	if len(matches) == 0 {
-		t.Fatal("expected at least one match in source")
-	}
+	require.NotEmpty(t, matches, "expected at least one match in source")
 	m := matches[0]
-	if !Verify(m.Rule, source, m.Start, m.End) {
-		t.Errorf("Verify should accept unchanged source at [%d,%d)", m.Start, m.End)
-	}
+	assert.True(t, Verify(m.Rule, source, m.Start, m.End),
+		"Verify should accept unchanged source at [%d,%d)", m.Start, m.End)
 	// Same length, but the secret at [Start,End) is replaced by a zero-entropy
 	// run that matches no rule, so Verify must reject the stale coordinates.
 	changed := source[:m.Start] + strings.Repeat("X", m.End-m.Start)
-	if Verify(m.Rule, changed, m.Start, m.End) {
-		t.Error("Verify should reject when the source changed at those coords")
-	}
+	assert.False(t, Verify(m.Rule, changed, m.Start, m.End),
+		"Verify should reject when the source changed at those coords")
 }
 
 // TestVerifyRejectsSuppressedCandidate ensures Verify mirrors canonical Scan,
@@ -238,12 +210,10 @@ func TestVerifyRejectsSuppressedCandidate(t *testing.T) {
 			break
 		}
 	}
-	if cand.Rule == "" {
-		t.Fatal("precondition: scanRaw should report a basic-auth-url candidate")
-	}
-	if Verify("basic-auth-url", src, cand.Start, cand.End) {
-		t.Error("Verify must reject a candidate that canonical Scan suppresses")
-	}
+	require.NotEmpty(t, cand.Rule,
+		"precondition: scanRaw should report a basic-auth-url candidate")
+	assert.False(t, Verify("basic-auth-url", src, cand.Start, cand.End),
+		"Verify must reject a candidate that canonical Scan suppresses")
 }
 
 // isLowerHex reports whether c is a lowercase hexadecimal digit, the alphabet
@@ -282,9 +252,7 @@ func TestHasRepeatingBlock(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := hasRepeatingBlock(c.s); got != c.want {
-				t.Errorf("hasRepeatingBlock(%q) = %v, want %v", c.s, got, c.want)
-			}
+			assert.Equal(t, c.want, hasRepeatingBlock(c.s))
 		})
 	}
 }
@@ -311,9 +279,7 @@ func TestHasMonotoneRun(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := hasMonotoneRun(c.s, 6); got != c.want {
-				t.Errorf("hasMonotoneRun(%q, 6) = %v, want %v", c.s, got, c.want)
-			}
+			assert.Equal(t, c.want, hasMonotoneRun(c.s, 6))
 		})
 	}
 }

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -4,57 +4,38 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanFindsAWSAccessKey(t *testing.T) {
 	text := "export AWS_KEY=AKIA7QHWN2DKR4FYPLJM then continue"
 	got := Scan(text)
-	if len(got) != 1 {
-		t.Fatalf("Scan returned %d matches, want 1: %+v", len(got), got)
-	}
+	require.Len(t, got, 1)
 	m := got[0]
-	if m.Rule != "aws-access-key" {
-		t.Errorf("Rule = %q, want aws-access-key", m.Rule)
-	}
-	if m.Confidence != ConfidenceDefinite {
-		t.Errorf("Confidence = %q, want definite", m.Confidence)
-	}
-	if text[m.Start:m.End] != "AKIA7QHWN2DKR4FYPLJM" {
-		t.Errorf("span = %q, want AKIA7QHWN2DKR4FYPLJM", text[m.Start:m.End])
-	}
-	if m.Index != 0 {
-		t.Errorf("Index = %d, want 0", m.Index)
-	}
+	assert.Equal(t, "aws-access-key", m.Rule)
+	assert.Equal(t, ConfidenceDefinite, m.Confidence)
+	assert.Equal(t, "AKIA7QHWN2DKR4FYPLJM", text[m.Start:m.End])
+	assert.Equal(t, 0, m.Index)
 }
 
 func TestScanNoMatch(t *testing.T) {
-	if got := Scan("just some ordinary prose with no secrets"); len(got) != 0 {
-		t.Fatalf("Scan returned %d matches, want 0: %+v", len(got), got)
-	}
+	assert.Empty(t, Scan("just some ordinary prose with no secrets"))
 }
 
 func TestRedactMasksSecretButKeepsContext(t *testing.T) {
 	text := "export AWS_KEY=AKIA7QHWN2DKR4FYPLJM then continue"
 	got := Redact(text)
-	if strings.Contains(got, "AKIA7QHWN2DKR4FYPLJM") {
-		t.Fatalf("Redact leaked the full secret: %q", got)
-	}
-	if !strings.HasPrefix(got, "export AWS_KEY=") {
-		t.Errorf("Redact dropped surrounding context: %q", got)
-	}
-	if !strings.HasSuffix(got, " then continue") {
-		t.Errorf("Redact dropped trailing context: %q", got)
-	}
-	if !strings.Contains(got, "AKIA…PLJM") {
-		t.Errorf("Redact did not use the masked form: %q", got)
-	}
+	assert.NotContains(t, got, "AKIA7QHWN2DKR4FYPLJM", "Redact leaked the full secret")
+	assert.True(t, strings.HasPrefix(got, "export AWS_KEY="), "Redact dropped surrounding context: %q", got)
+	assert.True(t, strings.HasSuffix(got, " then continue"), "Redact dropped trailing context: %q", got)
+	assert.Contains(t, got, "AKIA…PLJM", "Redact did not use the masked form")
 }
 
 func TestRedactNoMatchReturnsInput(t *testing.T) {
 	in := "nothing to see here"
-	if got := Redact(in); got != in {
-		t.Fatalf("Redact mutated clean text: %q", got)
-	}
+	assert.Equal(t, in, Redact(in))
 }
 
 func TestScanSuppressesCandidateOverlappingDefinite(t *testing.T) {
@@ -63,21 +44,16 @@ func TestScanSuppressesCandidateOverlappingDefinite(t *testing.T) {
 	text := "https://user:sk-ant-api03-Xa9Kd03Lm5Qp7Rt2Vw8Zb4@example.com"
 	got := Scan(text)
 	for _, m := range got {
-		if m.Confidence == ConfidenceCandidate {
-			t.Errorf("candidate %q not suppressed despite overlapping definite", m.Rule)
-		}
+		assert.NotEqual(t, ConfidenceCandidate, m.Confidence,
+			"candidate %q not suppressed despite overlapping definite", m.Rule)
 	}
-	if len(got) == 0 {
-		t.Fatal("expected at least the definite anthropic-key finding")
-	}
+	require.NotEmpty(t, got, "expected at least the definite anthropic-key finding")
 }
 
 func TestRedactMasksUnionIncludingCandidate(t *testing.T) {
 	text := "TOKEN=sk-ant-api03-Nc6Mp1Hj9Bg3Tf5Ds8Lr0E end"
 	got := Redact(text)
-	if strings.Contains(got, "sk-ant-api03-Nc6Mp1Hj9Bg3Tf5Ds8Lr0E") {
-		t.Fatalf("Redact leaked secret: %q", got)
-	}
+	assert.NotContains(t, got, "sk-ant-api03-Nc6Mp1Hj9Bg3Tf5Ds8Lr0E", "Redact leaked secret")
 }
 
 // TestRedactWindowMasksStraddlingSecret pins the content-search guarantee: a
@@ -94,17 +70,13 @@ func TestRedactWindowMasksStraddlingSecret(t *testing.T) {
 
 	// Hazard check: redacting the bare window leaks, because the fragment has
 	// no END line for the private-key-block rule to anchor on.
-	if naive := Redact(full[lo:hi]); !strings.Contains(naive, "BEGIN RSA PRIVATE KEY") {
-		t.Fatalf("precondition: window should straddle the key; got %q", naive)
-	}
+	naive := Redact(full[lo:hi])
+	require.Contains(t, naive, "BEGIN RSA PRIVATE KEY",
+		"precondition: window should straddle the key")
 
 	got := RedactWindow(full, lo, hi)
-	if strings.Contains(got, "SECRETKEYMATERIAL") {
-		t.Errorf("RedactWindow leaked straddling key material: %q", got)
-	}
-	if !strings.Contains(got, "[redacted private key block]") {
-		t.Errorf("RedactWindow did not mask the key block: %q", got)
-	}
+	assert.NotContains(t, got, "SECRETKEYMATERIAL", "RedactWindow leaked straddling key material")
+	assert.Contains(t, got, "[redacted private key block]", "RedactWindow did not mask the key block")
 }
 
 // TestRedactWindowMasksStraddlingGroupedSecret covers grouped rules, whose
@@ -119,9 +91,7 @@ func TestRedactWindowMasksStraddlingGroupedSecret(t *testing.T) {
 		vs := strings.Index(full, val)
 		// Window starts inside the value, past the "api_key=" the rule needs.
 		got := RedactWindow(full, vs+5, vs+15)
-		if strings.Contains(got, val[5:20]) {
-			t.Errorf("leaked high-entropy value fragment: %q", got)
-		}
+		assert.NotContains(t, got, val[5:20], "leaked high-entropy value fragment")
 	})
 	t.Run("basic-auth-url", func(t *testing.T) {
 		pw := "Sup3rSecretP4ssw0rd"
@@ -129,9 +99,7 @@ func TestRedactWindowMasksStraddlingGroupedSecret(t *testing.T) {
 		ps := strings.Index(full, pw)
 		// Window lands inside the password, past the "://user:" the rule needs.
 		got := RedactWindow(full, ps+2, ps+8)
-		if strings.Contains(got, pw[2:12]) {
-			t.Errorf("leaked basic-auth password fragment: %q", got)
-		}
+		assert.NotContains(t, got, pw[2:12], "leaked basic-auth password fragment")
 	})
 }
 
@@ -141,16 +109,11 @@ func TestRedactWindowMasksStraddlingGroupedSecret(t *testing.T) {
 func TestRedactWindowKeepsContextAndContainedSecrets(t *testing.T) {
 	full := "the key is AKIA7QHWN2DKR4FYPLJM in config"
 	got := RedactWindow(full, 0, len(full))
-	if strings.Contains(got, "AKIA7QHWN2DKR4FYPLJM") {
-		t.Errorf("contained secret not masked: %q", got)
-	}
-	if !strings.Contains(got, "the key is ") || !strings.Contains(got, " in config") {
-		t.Errorf("context not preserved: %q", got)
-	}
+	assert.NotContains(t, got, "AKIA7QHWN2DKR4FYPLJM", "contained secret not masked")
+	assert.Contains(t, got, "the key is ", "context not preserved")
+	assert.Contains(t, got, " in config", "context not preserved")
 	clean := "just some ordinary prose with no secrets at all"
-	if got := RedactWindow(clean, 0, len(clean)); got != clean {
-		t.Errorf("clean window altered: %q", got)
-	}
+	assert.Equal(t, clean, RedactWindow(clean, 0, len(clean)))
 }
 
 func TestRedactNeverLeaksKnownSecrets(t *testing.T) {
@@ -169,9 +132,8 @@ func TestRedactNeverLeaksKnownSecrets(t *testing.T) {
 		for _, tmpl := range []string{"%s", "prefix %s suffix", "a=%s\nb=2"} {
 			text := fmt.Sprintf(tmpl, sec)
 			out := Redact(text)
-			if strings.Contains(out, sec) {
-				t.Errorf("Redact leaked %q in template %q -> %q", sec, tmpl, out)
-			}
+			assert.NotContains(t, out, sec,
+				"Redact leaked %q in template %q -> %q", sec, tmpl, out)
 		}
 	}
 }
@@ -199,9 +161,8 @@ func TestScanRedactedNeverEqualsFullSecret(t *testing.T) {
 		}
 		for _, m := range matches {
 			full := text[m.Start:m.End]
-			if m.Redacted == full {
-				t.Errorf("Redacted equals full secret for rule %q: %q", m.Rule, full)
-			}
+			assert.NotEqual(t, full, m.Redacted,
+				"Redacted equals full secret for rule %q: %q", m.Rule, full)
 		}
 	}
 }
@@ -214,22 +175,15 @@ func TestBasicAuthURLDetectsPasswordSpan(t *testing.T) {
 			m = &got
 		}
 	}
-	if m == nil {
-		t.Fatalf("expected a basic-auth-url candidate; got %+v", Scan(text))
-	}
-	if span := text[m.Start:m.End]; span != "Sup3rSecretPw" {
-		t.Errorf("span = %q, want only the password Sup3rSecretPw", span)
-	}
-	if m.Confidence != ConfidenceCandidate {
-		t.Errorf("Confidence = %q, want candidate", m.Confidence)
-	}
+	require.NotNil(t, m, "expected a basic-auth-url candidate; got %+v", Scan(text))
+	assert.Equal(t, "Sup3rSecretPw", text[m.Start:m.End])
+	assert.Equal(t, ConfidenceCandidate, m.Confidence)
 	red := Redact(text)
 	// Assert the exact fully-masked form: no password character survives
 	// (this fails if the mask is loosened to reveal a suffix) while the
 	// surrounding URL context is preserved.
-	if !strings.Contains(red, "postgres://admin:…@db.example.com") {
-		t.Errorf("Redact did not fully mask the password in context: %q", red)
-	}
+	assert.Contains(t, red, "postgres://admin:…@db.example.com",
+		"Redact did not fully mask the password in context")
 }
 
 func TestScanJWTNotDuplicatedAsHighEntropy(t *testing.T) {
@@ -237,14 +191,11 @@ func TestScanJWTNotDuplicatedAsHighEntropy(t *testing.T) {
 	got := Scan("auth: " + jwt)
 	foundJWT := false
 	for _, m := range got {
-		if m.Rule == "high-entropy-assignment" {
-			t.Errorf("JWT segment reported as high-entropy-assignment: %+v", got)
-		}
+		assert.NotEqual(t, "high-entropy-assignment", m.Rule,
+			"JWT segment reported as high-entropy-assignment: %+v", got)
 		if m.Rule == "jwt" {
 			foundJWT = true
 		}
 	}
-	if !foundJWT {
-		t.Errorf("expected a jwt candidate; got %+v", got)
-	}
+	assert.True(t, foundJWT, "expected a jwt candidate; got %+v", got)
 }

--- a/internal/server/activity_test.go
+++ b/internal/server/activity_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -14,39 +17,23 @@ func TestGetSessionActivity(t *testing.T) {
 	te.seedMessages(t, "s1", 10)
 
 	w := te.get(t, "/api/v1/sessions/s1/activity")
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", w.Code)
-	}
+	require.Equal(t, http.StatusOK, w.Code)
 
 	var body db.SessionActivityResponse
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
 
-	if body.TotalMessages == 0 {
-		t.Error("expected non-zero total_messages")
-	}
-	if len(body.Buckets) == 0 {
-		t.Error("expected non-empty buckets")
-	}
-	if body.IntervalSeconds <= 0 {
-		t.Error("expected positive interval_seconds")
-	}
+	assert.NotZero(t, body.TotalMessages, "expected non-zero total_messages")
+	assert.NotEmpty(t, body.Buckets, "expected non-empty buckets")
+	assert.Positive(t, body.IntervalSeconds, "expected positive interval_seconds")
 }
 
 func TestGetSessionActivity_NotFound(t *testing.T) {
 	te := setup(t)
 
 	w := te.get(t, "/api/v1/sessions/nonexistent/activity")
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200", w.Code)
-	}
+	require.Equal(t, http.StatusOK, w.Code)
 
 	var body db.SessionActivityResponse
-	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
-		t.Fatal(err)
-	}
-	if len(body.Buckets) != 0 {
-		t.Error("expected empty buckets for nonexistent session")
-	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	assert.Empty(t, body.Buckets, "expected empty buckets for nonexistent session")
 }

--- a/internal/server/agent_config_internal_test.go
+++ b/internal/server/agent_config_internal_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -11,7 +13,5 @@ func TestInsightAgentConfigMapsBinaryOverrides(t *testing.T) {
 		"claude": {Binary: "/opt/claude"},
 	})
 
-	if got["claude"].Binary != "/opt/claude" {
-		t.Fatalf("claude binary = %q", got["claude"].Binary)
-	}
+	assert.Equal(t, "/opt/claude", got["claude"].Binary)
 }

--- a/internal/server/analytics_test.go
+++ b/internal/server/analytics_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
 )
@@ -182,18 +184,10 @@ func TestAnalyticsSummary(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.AnalyticsSummary](t, w)
-		if resp.TotalSessions != stats.TotalSessions {
-			t.Errorf("TotalSessions = %d, want %d", resp.TotalSessions, stats.TotalSessions)
-		}
-		if resp.TotalMessages != stats.TotalMessages {
-			t.Errorf("TotalMessages = %d, want %d", resp.TotalMessages, stats.TotalMessages)
-		}
-		if resp.ActiveProjects != stats.ActiveProjects {
-			t.Errorf("ActiveProjects = %d, want %d", resp.ActiveProjects, stats.ActiveProjects)
-		}
-		if resp.ActiveDays != stats.ActiveDays {
-			t.Errorf("ActiveDays = %d, want %d", resp.ActiveDays, stats.ActiveDays)
-		}
+		assert.Equal(t, stats.TotalSessions, resp.TotalSessions)
+		assert.Equal(t, stats.TotalMessages, resp.TotalMessages)
+		assert.Equal(t, stats.ActiveProjects, resp.ActiveProjects)
+		assert.Equal(t, stats.ActiveDays, resp.ActiveDays)
 	})
 
 	t.Run("NonUTCTimezone", func(t *testing.T) {
@@ -215,12 +209,8 @@ func TestAnalyticsSummary_OutputTokenCoverage(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	resp := decode[db.AnalyticsSummary](t, w)
-	if resp.TotalOutputTokens != stats.TotalOutputTokens {
-		t.Errorf("TotalOutputTokens = %d, want %d", resp.TotalOutputTokens, stats.TotalOutputTokens)
-	}
-	if resp.TokenReportingSessions != stats.TokenReportingSessions {
-		t.Errorf("TokenReportingSessions = %d, want %d", resp.TokenReportingSessions, stats.TokenReportingSessions)
-	}
+	assert.Equal(t, stats.TotalOutputTokens, resp.TotalOutputTokens)
+	assert.Equal(t, stats.TokenReportingSessions, resp.TokenReportingSessions)
 }
 
 func TestAnalyticsSummary_DateValidation(t *testing.T) {
@@ -284,9 +274,8 @@ func TestAnalyticsErrorRedaction(t *testing.T) {
 			w := te.get(t, buildURLWithRange(ep, nil))
 			assertStatus(t, w, http.StatusInternalServerError)
 			body := w.Body.String()
-			if strings.Contains(body, "sql") || strings.Contains(body, "database") {
-				t.Errorf("response exposes internal error: %s", body)
-			}
+			assert.NotContains(t, body, "sql", "response exposes internal error")
+			assert.NotContains(t, body, "database", "response exposes internal error")
 		})
 	}
 }
@@ -494,22 +483,16 @@ func TestAnalyticsActivity(t *testing.T) {
 				if expectedGran == "" {
 					expectedGran = "day" // default
 				}
-				if resp.Granularity != expectedGran {
-					t.Errorf("Granularity = %q, want %q", resp.Granularity, expectedGran)
-				}
+				assert.Equal(t, expectedGran, resp.Granularity)
 				if expectedGran == "day" {
-					if len(resp.Series) != stats.ActiveDays {
-						t.Fatalf("len(Series) = %d, want %d", len(resp.Series), stats.ActiveDays)
-					}
+					require.Len(t, resp.Series, stats.ActiveDays)
 					totalUser := 0
 					totalAsst := 0
 					for _, e := range resp.Series {
 						totalUser += e.UserMessages
 						totalAsst += e.AssistantMessages
 					}
-					if totalUser+totalAsst != stats.TotalMessages {
-						t.Errorf("total messages = %d, want %d", totalUser+totalAsst, stats.TotalMessages)
-					}
+					assert.Equal(t, stats.TotalMessages, totalUser+totalAsst)
 				}
 			}
 		})
@@ -547,21 +530,20 @@ func TestAnalyticsHeatmap(t *testing.T) {
 				if expectedMetric == "" {
 					expectedMetric = "messages" // default
 				}
-				if resp.Metric != expectedMetric {
-					t.Errorf("Metric = %q, want %q", resp.Metric, expectedMetric)
-				}
-				if tt.wantEntries >= 0 && len(resp.Entries) != tt.wantEntries {
-					t.Errorf("len(Entries) = %d, want %d", len(resp.Entries), tt.wantEntries)
+				assert.Equal(t, expectedMetric, resp.Metric)
+				if tt.wantEntries >= 0 {
+					assert.Len(t, resp.Entries, tt.wantEntries)
 				}
 				if tt.wantEntries > 0 {
 					total := 0
 					for _, e := range resp.Entries {
 						total += e.Value
 					}
-					if expectedMetric == "messages" && total != stats.TotalMessages {
-						t.Errorf("total messages = %d, want %d", total, stats.TotalMessages)
-					} else if expectedMetric == "sessions" && total != stats.TotalSessions {
-						t.Errorf("total sessions = %d, want %d", total, stats.TotalSessions)
+					switch expectedMetric {
+					case "messages":
+						assert.Equal(t, stats.TotalMessages, total)
+					case "sessions":
+						assert.Equal(t, stats.TotalSessions, total)
 					}
 				}
 			}
@@ -578,21 +560,10 @@ func TestAnalyticsHeatmap(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.HeatmapResponse](t, w)
-		if len(resp.Entries) > db.MaxHeatmapDays {
-			t.Errorf(
-				"len(Entries) = %d, want <= %d",
-				len(resp.Entries), db.MaxHeatmapDays,
-			)
-		}
-		if resp.EntriesFrom == "" {
-			t.Fatal("EntriesFrom is empty")
-		}
-		if resp.EntriesFrom <= "2022-01-01" {
-			t.Errorf(
-				"EntriesFrom = %q, want later than 2022-01-01",
-				resp.EntriesFrom,
-			)
-		}
+		assert.LessOrEqual(t, len(resp.Entries), db.MaxHeatmapDays)
+		require.NotEmpty(t, resp.EntriesFrom)
+		assert.Greater(t, resp.EntriesFrom, "2022-01-01",
+			"EntriesFrom should be later than 2022-01-01")
 	})
 
 	t.Run("ShortRange_NoClamping", func(t *testing.T) {
@@ -601,12 +572,7 @@ func TestAnalyticsHeatmap(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.HeatmapResponse](t, w)
-		if resp.EntriesFrom != "2024-06-01" {
-			t.Errorf(
-				"EntriesFrom = %q, want %q",
-				resp.EntriesFrom, "2024-06-01",
-			)
-		}
+		assert.Equal(t, "2024-06-01", resp.EntriesFrom)
 	})
 
 	t.Run("Levels_FromClampedWindow", func(t *testing.T) {
@@ -635,19 +601,14 @@ func TestAnalyticsHeatmap(t *testing.T) {
 		// The outlier at 2020-01-15 should be clamped out.
 		// Verify no entry has the outlier date.
 		for _, e := range resp.Entries {
-			if e.Date == "2020-01-15" {
-				t.Error("outlier date should be outside clamped window")
-			}
+			assert.NotEqual(t, "2020-01-15", e.Date,
+				"outlier date should be outside clamped window")
 		}
 
 		// Levels should reflect the recent data (max ~30 msgs),
 		// not the 500-message outlier.
-		if resp.Levels.L4 >= 500 {
-			t.Errorf(
-				"L4 = %d, should be << 500 (outlier leaked into levels)",
-				resp.Levels.L4,
-			)
-		}
+		assert.Less(t, resp.Levels.L4, 500,
+			"L4 should be << 500 (outlier leaked into levels)")
 	})
 }
 
@@ -662,17 +623,13 @@ func TestAnalyticsHeatmap_OutputTokens(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	resp := decode[db.HeatmapResponse](t, w)
-	if resp.Metric != "output_tokens" {
-		t.Fatalf("Metric = %q, want %q", resp.Metric, "output_tokens")
-	}
+	require.Equal(t, "output_tokens", resp.Metric)
 
 	total := 0
 	for _, e := range resp.Entries {
 		total += e.Value
 	}
-	if total != stats.TotalOutputTokens {
-		t.Errorf("total output tokens = %d, want %d", total, stats.TotalOutputTokens)
-	}
+	assert.Equal(t, stats.TotalOutputTokens, total)
 }
 
 func TestAnalyticsHeatmap_OutputTokensNoReporting(
@@ -689,19 +646,9 @@ func TestAnalyticsHeatmap_OutputTokensNoReporting(
 	assertStatus(t, w, http.StatusOK)
 
 	resp := decode[db.HeatmapResponse](t, w)
-	if resp.Metric != "output_tokens" {
-		t.Fatalf(
-			"Metric = %q, want output_tokens",
-			resp.Metric,
-		)
-	}
-	if len(resp.Entries) != 0 {
-		t.Errorf(
-			"len(Entries) = %d, want 0 "+
-				"(no sessions report token coverage)",
-			len(resp.Entries),
-		)
-	}
+	require.Equal(t, "output_tokens", resp.Metric)
+	assert.Empty(t, resp.Entries,
+		"no sessions report token coverage")
 }
 
 func TestAnalyticsProjects(t *testing.T) {
@@ -713,17 +660,13 @@ func TestAnalyticsProjects(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.ProjectsAnalyticsResponse](t, w)
-		if len(resp.Projects) != stats.ActiveProjects {
-			t.Fatalf("len(Projects) = %d, want %d", len(resp.Projects), stats.ActiveProjects)
-		}
+		require.Len(t, resp.Projects, stats.ActiveProjects)
 
 		total := 0
 		for _, p := range resp.Projects {
 			total += p.Messages
 		}
-		if total != stats.TotalMessages {
-			t.Errorf("total messages across projects = %d, want %d", total, stats.TotalMessages)
-		}
+		assert.Equal(t, stats.TotalMessages, total)
 	})
 
 	t.Run("MachineFilter", func(t *testing.T) {
@@ -731,9 +674,7 @@ func TestAnalyticsProjects(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.ProjectsAnalyticsResponse](t, w)
-		if len(resp.Projects) != 0 {
-			t.Errorf("len(Projects) = %d, want 0", len(resp.Projects))
-		}
+		assert.Empty(t, resp.Projects)
 	})
 }
 
@@ -746,9 +687,7 @@ func TestAnalyticsHourOfWeek(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.HourOfWeekResponse](t, w)
-		if len(resp.Cells) != 168 {
-			t.Errorf("len(Cells) = %d, want 168", len(resp.Cells))
-		}
+		assert.Len(t, resp.Cells, 168)
 	})
 }
 
@@ -761,9 +700,7 @@ func TestAnalyticsSessionShape(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.SessionShapeResponse](t, w)
-		if resp.Count != stats.TotalSessions {
-			t.Errorf("Count = %d, want %d", resp.Count, stats.TotalSessions)
-		}
+		assert.Equal(t, stats.TotalSessions, resp.Count)
 	})
 }
 
@@ -776,9 +713,7 @@ func TestAnalyticsVelocity(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.VelocityResponse](t, w)
-		if len(resp.ByAgent) != stats.Agents {
-			t.Errorf("len(ByAgent) = %d, want %d", len(resp.ByAgent), stats.Agents)
-		}
+		assert.Len(t, resp.ByAgent, stats.Agents)
 	})
 }
 
@@ -791,15 +726,9 @@ func TestAnalyticsTools(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.ToolsAnalyticsResponse](t, w)
-		if resp.TotalCalls != stats.TotalToolCalls {
-			t.Errorf("TotalCalls = %d, want %d", resp.TotalCalls, stats.TotalToolCalls)
-		}
-		if len(resp.ByCategory) == 0 {
-			t.Error("expected non-empty ByCategory")
-		}
-		if len(resp.ByAgent) != stats.Agents {
-			t.Errorf("len(ByAgent) = %d, want %d", len(resp.ByAgent), stats.Agents)
-		}
+		assert.Equal(t, stats.TotalToolCalls, resp.TotalCalls)
+		assert.NotEmpty(t, resp.ByCategory)
+		assert.Len(t, resp.ByAgent, stats.Agents)
 	})
 
 	t.Run("WithProjectFilter", func(t *testing.T) {
@@ -807,9 +736,7 @@ func TestAnalyticsTools(t *testing.T) {
 		assertStatus(t, w, http.StatusOK)
 
 		resp := decode[db.ToolsAnalyticsResponse](t, w)
-		if resp.TotalCalls == 0 {
-			t.Error("expected non-zero TotalCalls for alpha")
-		}
+		assert.NotZero(t, resp.TotalCalls, "TotalCalls for alpha")
 	})
 
 	t.Run("InvalidTimezone", func(t *testing.T) {
@@ -857,23 +784,15 @@ func TestAnalyticsTopSessions(t *testing.T) {
 				if expectedMetric == "" {
 					expectedMetric = "messages"
 				}
-				if resp.Metric != expectedMetric {
-					t.Errorf("Metric = %q, want %q", resp.Metric, expectedMetric)
-				}
+				assert.Equal(t, expectedMetric, resp.Metric)
 				if tt.project == "" {
 					expected := min(stats.TotalSessions, 10)
-					if len(resp.Sessions) != expected {
-						t.Errorf("len(Sessions) = %d, want %d", len(resp.Sessions), expected)
-					}
+					assert.Len(t, resp.Sessions, expected)
 				}
 				if tt.project != "" {
-					if len(resp.Sessions) == 0 {
-						t.Errorf("expected at least one session for project %q", tt.project)
-					}
+					assert.NotEmpty(t, resp.Sessions, "project %q", tt.project)
 					for _, s := range resp.Sessions {
-						if s.Project != tt.project {
-							t.Errorf("session project = %q, want %q", s.Project, tt.project)
-						}
+						assert.Equal(t, tt.project, s.Project)
 					}
 				}
 			}
@@ -892,15 +811,9 @@ func TestAnalyticsTopSessions_OutputTokens(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	resp := decode[db.TopSessionsResponse](t, w)
-	if resp.Metric != "output_tokens" {
-		t.Fatalf("Metric = %q, want %q", resp.Metric, "output_tokens")
-	}
-	if len(resp.Sessions) == 0 {
-		t.Fatal("Sessions is empty")
-	}
-	if resp.Sessions[0].OutputTokens != stats.TopSessionOutputTokens {
-		t.Errorf("Sessions[0].OutputTokens = %d, want %d", resp.Sessions[0].OutputTokens, stats.TopSessionOutputTokens)
-	}
+	require.Equal(t, "output_tokens", resp.Metric)
+	require.NotEmpty(t, resp.Sessions)
+	assert.Equal(t, stats.TopSessionOutputTokens, resp.Sessions[0].OutputTokens)
 }
 
 // TestSessionCountConsistency verifies that session counts from
@@ -1006,27 +919,17 @@ func TestSessionCountConsistency(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 	summaryResp := decode[db.AnalyticsSummary](t, w)
 
-	if listResp.Total != wantCount {
-		t.Errorf("session list total = %d, want %d",
-			listResp.Total, wantCount)
-	}
-	if statsResp.SessionCount != wantCount {
-		t.Errorf("stats session_count = %d, want %d",
-			statsResp.SessionCount, wantCount)
-	}
-	if summaryResp.TotalSessions != wantCount {
-		t.Errorf("analytics total_sessions = %d, want %d",
-			summaryResp.TotalSessions, wantCount)
-	}
+	assert.Equal(t, wantCount, listResp.Total, "session list total")
+	assert.Equal(t, wantCount, statsResp.SessionCount, "stats session_count")
+	assert.Equal(t, wantCount, summaryResp.TotalSessions, "analytics total_sessions")
 
 	// All three must be equal.
-	if listResp.Total != statsResp.SessionCount ||
-		statsResp.SessionCount != summaryResp.TotalSessions {
-		t.Fatalf(
-			"session counts disagree: list=%d stats=%d analytics=%d",
-			listResp.Total,
-			statsResp.SessionCount,
-			summaryResp.TotalSessions,
-		)
-	}
+	require.True(t,
+		listResp.Total == statsResp.SessionCount &&
+			statsResp.SessionCount == summaryResp.TotalSessions,
+		"session counts disagree: list=%d stats=%d analytics=%d",
+		listResp.Total,
+		statsResp.SessionCount,
+		summaryResp.TotalSessions,
+	)
 }

--- a/internal/server/basepath_test.go
+++ b/internal/server/basepath_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBasePath_StripsPrefixForAPI(t *testing.T) {
@@ -19,11 +21,12 @@ func TestBasePath_StripsPrefixForAPI(t *testing.T) {
 	// 200 or 503 (timeout) both confirm the route was matched
 	// and prefix was stripped. 404 or 403 would indicate a
 	// base-path routing failure.
-	if w.Code == http.StatusNotFound ||
-		w.Code == http.StatusForbidden {
-		t.Fatalf("GET /app/api/v1/sessions = %d, want route match; body: %s",
-			w.Code, w.Body.String())
-	}
+	require.NotEqual(t, http.StatusNotFound, w.Code,
+		"GET /app/api/v1/sessions = %d, want route match; body: %s",
+		w.Code, w.Body.String())
+	require.NotEqual(t, http.StatusForbidden, w.Code,
+		"GET /app/api/v1/sessions = %d, want route match; body: %s",
+		w.Code, w.Body.String())
 }
 
 func TestBasePath_RedirectsBarePrefix(t *testing.T) {
@@ -33,13 +36,8 @@ func TestBasePath_RedirectsBarePrefix(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusMovedPermanently {
-		t.Fatalf("GET /app = %d, want 301", w.Code)
-	}
-	loc := w.Header().Get("Location")
-	if loc != "/app/" {
-		t.Fatalf("Location = %q, want /app/", loc)
-	}
+	require.Equal(t, http.StatusMovedPermanently, w.Code)
+	require.Equal(t, "/app/", w.Header().Get("Location"))
 }
 
 func TestBasePath_InjectsBaseHrefIntoHTML(t *testing.T) {
@@ -49,13 +47,9 @@ func TestBasePath_InjectsBaseHrefIntoHTML(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("GET /viewer/ = %d, want 200", w.Code)
-	}
-	body := w.Body.String()
-	if !strings.Contains(body, `<base href="/viewer/">`) {
-		t.Error("missing <base href> tag in response")
-	}
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `<base href="/viewer/">`,
+		"missing <base href> tag in response")
 }
 
 func TestBasePath_RewritesAssetPaths(t *testing.T) {
@@ -68,20 +62,16 @@ func TestBasePath_RewritesAssetPaths(t *testing.T) {
 	body := w.Body.String()
 
 	// Asset paths should be prefixed.
-	if strings.Contains(body, `src="/assets/`) {
-		t.Error("found unprefixed src=\"/assets/ in HTML")
-	}
-	if strings.Contains(body, `href="/assets/`) {
-		t.Error("found unprefixed href=\"/assets/ in HTML")
-	}
-	if strings.Contains(body, `href="/favicon`) {
-		t.Error("found unprefixed href=\"/favicon in HTML")
-	}
+	assert.NotContains(t, body, `src="/assets/`,
+		"found unprefixed src=\"/assets/ in HTML")
+	assert.NotContains(t, body, `href="/assets/`,
+		"found unprefixed href=\"/assets/ in HTML")
+	assert.NotContains(t, body, `href="/favicon`,
+		"found unprefixed href=\"/favicon in HTML")
 
 	// External URLs must NOT be prefixed.
-	if strings.Contains(body, `href="/viewer/https://`) {
-		t.Error("external URL was incorrectly prefixed")
-	}
+	assert.NotContains(t, body, `href="/viewer/https://`,
+		"external URL was incorrectly prefixed")
 }
 
 func TestBasePath_SPAFallbackServesIndex(t *testing.T) {
@@ -93,12 +83,9 @@ func TestBasePath_SPAFallbackServesIndex(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("GET /app/some/route = %d, want 200", w.Code)
-	}
-	if !strings.Contains(w.Body.String(), `<base href="/app/">`) {
-		t.Error("SPA fallback missing <base href> tag")
-	}
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `<base href="/app/">`,
+		"SPA fallback missing <base href> tag")
 }
 
 func TestBasePath_RejectsSiblingPath(t *testing.T) {
@@ -111,18 +98,12 @@ func TestBasePath_RejectsSiblingPath(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusNotFound {
-		t.Fatalf(
-			"GET /appfoo/bar = %d, want 404", w.Code,
-		)
-	}
+	require.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestBasePath_TrailingSlashNormalized(t *testing.T) {
 	s := testServer(t, 0, WithBasePath("/app/"))
 
 	// WithBasePath trims trailing slash.
-	if s.basePath != "/app" {
-		t.Fatalf("basePath = %q, want /app", s.basePath)
-	}
+	require.Equal(t, "/app", s.basePath)
 }

--- a/internal/server/broadcaster_test.go
+++ b/internal/server/broadcaster_test.go
@@ -4,6 +4,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBroadcaster_EmitFansOutToAllSubscribers(t *testing.T) {
@@ -18,11 +21,9 @@ func TestBroadcaster_EmitFansOutToAllSubscribers(t *testing.T) {
 	for i, sub := range []<-chan Event{sub1, sub2} {
 		select {
 		case ev := <-sub:
-			if ev.Scope != "messages" {
-				t.Errorf("sub %d: got scope %q, want %q", i, ev.Scope, "messages")
-			}
+			assert.Equal(t, "messages", ev.Scope, "sub %d", i)
 		case <-time.After(time.Second):
-			t.Fatalf("sub %d: timed out waiting for event", i)
+			require.Fail(t, "timed out waiting for event", "sub %d", i)
 		}
 	}
 }
@@ -47,7 +48,7 @@ func TestBroadcaster_EmitIsNonBlockingOnSlowSubscriber(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("Emit blocked on slow subscriber")
+		require.Fail(t, "Emit blocked on slow subscriber")
 	}
 
 	// Drain what we can — drop count >= extra, exact count not guaranteed.
@@ -57,9 +58,7 @@ func TestBroadcaster_EmitIsNonBlockingOnSlowSubscriber(t *testing.T) {
 		case <-slow:
 			drained++
 		case <-time.After(50 * time.Millisecond):
-			if drained == 0 {
-				t.Fatalf("slow subscriber received nothing")
-			}
+			require.NotZero(t, drained, "slow subscriber received nothing")
 			return
 		}
 	}
@@ -74,9 +73,7 @@ func TestBroadcaster_UnsubscribeStopsDelivery(t *testing.T) {
 
 	select {
 	case ev, ok := <-sub:
-		if ok {
-			t.Fatalf("got event after unsubscribe: %v", ev)
-		}
+		require.False(t, ok, "got event after unsubscribe: %v", ev)
 		// channel closed by unsubscribe — acceptable
 	case <-time.After(100 * time.Millisecond):
 		// no delivery — also acceptable
@@ -96,7 +93,7 @@ func TestBroadcaster_ConcurrentSubscribeAndEmit(t *testing.T) {
 			select {
 			case <-sub:
 			case <-time.After(time.Second):
-				t.Errorf("concurrent subscriber did not receive event")
+				assert.Fail(t, "concurrent subscriber did not receive event")
 			}
 		})
 	}
@@ -112,11 +109,9 @@ func TestBroadcaster_LeadingEdgeEmitsImmediately(t *testing.T) {
 
 	select {
 	case ev := <-sub:
-		if ev.Scope != "messages" {
-			t.Errorf("got scope %q, want %q", ev.Scope, "messages")
-		}
+		assert.Equal(t, "messages", ev.Scope)
 	case <-time.After(100 * time.Millisecond):
-		t.Fatal("first emit did not broadcast immediately")
+		require.Fail(t, "first emit did not broadcast immediately")
 	}
 }
 
@@ -131,7 +126,7 @@ func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
 	select {
 	case <-sub:
 	case <-time.After(50 * time.Millisecond):
-		t.Fatal("leading-edge emit did not broadcast immediately")
+		require.Fail(t, "leading-edge emit did not broadcast immediately")
 	}
 
 	// Bursts within the window are coalesced; no broadcast yet.
@@ -141,7 +136,7 @@ func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
 
 	select {
 	case ev := <-sub:
-		t.Fatalf("got early broadcast during rate-limit window: %v", ev)
+		require.Fail(t, "got early broadcast during rate-limit window", "ev=%v", ev)
 	case <-time.After(interval / 2):
 	}
 
@@ -149,17 +144,15 @@ func TestBroadcaster_CoalescesWithinWindow(t *testing.T) {
 	// carrying the most recent scope.
 	select {
 	case ev := <-sub:
-		if ev.Scope != "sessions" {
-			t.Errorf("trailing scope %q, want %q", ev.Scope, "sessions")
-		}
+		assert.Equal(t, "sessions", ev.Scope, "trailing scope")
 	case <-time.After(interval * 3):
-		t.Fatal("trailing broadcast never arrived")
+		require.Fail(t, "trailing broadcast never arrived")
 	}
 
 	// The three coalesced emits produce exactly one trailing broadcast.
 	select {
 	case ev := <-sub:
-		t.Fatalf("got duplicate broadcast after trailing fire: %v", ev)
+		require.Fail(t, "got duplicate broadcast after trailing fire", "ev=%v", ev)
 	case <-time.After(interval):
 	}
 }
@@ -175,7 +168,7 @@ func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
 	select {
 	case <-sub:
 	case <-time.After(interval):
-		t.Fatal("leading emit did not broadcast")
+		require.Fail(t, "leading emit did not broadcast")
 	}
 
 	// Rate-limited emit schedules a trailing broadcast of "b".
@@ -193,11 +186,9 @@ func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
 	b.Emit("c")
 	select {
 	case ev := <-sub:
-		if ev.Scope != "c" {
-			t.Errorf("leading broadcast scope %q, want %q", ev.Scope, "c")
-		}
+		assert.Equal(t, "c", ev.Scope, "leading broadcast scope")
 	case <-time.After(interval):
-		t.Fatal("second leading emit did not broadcast")
+		require.Fail(t, "second leading emit did not broadcast")
 	}
 
 	// The pre-existing trailing timer for "b" may still fire. If the
@@ -206,7 +197,7 @@ func TestBroadcaster_LeadingEdgeCancelsPendingTrailing(t *testing.T) {
 	// original deadline and assert no extra event arrives.
 	select {
 	case ev := <-sub:
-		t.Fatalf("stale trailing broadcast after leading edge: %v", ev)
+		require.Fail(t, "stale trailing broadcast after leading edge", "ev=%v", ev)
 	case <-time.After(2 * interval):
 	}
 }
@@ -255,7 +246,7 @@ func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.
 	// callback supposedly ran.
 	select {
 	case ev := <-sub:
-		t.Fatalf("stale callback consumed newer pending: %v", ev)
+		require.Fail(t, "stale callback consumed newer pending", "ev=%v", ev)
 	case <-time.After(interval / 2):
 	}
 
@@ -266,11 +257,9 @@ func TestBroadcaster_StaleTrailingCallbackDoesNotConsumeNewerPending(t *testing.
 	// arrives.
 	select {
 	case ev := <-sub:
-		if ev.Scope != "d" {
-			t.Errorf("got scope %q, want d", ev.Scope)
-		}
+		assert.Equal(t, "d", ev.Scope)
 	case <-time.After(interval * 3):
-		t.Fatal("new trailing timer did not fire with pending scope")
+		require.Fail(t, "new trailing timer did not fire with pending scope")
 	}
 }
 
@@ -288,10 +277,8 @@ func TestBroadcaster_EmitAfterIntervalBroadcastsImmediately(t *testing.T) {
 	b.Emit("second")
 	select {
 	case ev := <-sub:
-		if ev.Scope != "second" {
-			t.Errorf("got scope %q, want %q", ev.Scope, "second")
-		}
+		assert.Equal(t, "second", ev.Scope)
 	case <-time.After(interval):
-		t.Fatal("emit after quiet interval did not broadcast immediately")
+		require.Fail(t, "emit after quiet interval did not broadcast immediately")
 	}
 }

--- a/internal/server/deadline_internal_test.go
+++ b/internal/server/deadline_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -20,9 +22,7 @@ func TestHandlers_Internal_DeadlineExceeded(t *testing.T) {
 		Project:   "test-proj",
 		StartedAt: &started,
 	}
-	if err := s.db.UpsertSession(sess); err != nil {
-		t.Fatalf("seeding session: %v", err)
-	}
+	require.NoError(t, s.db.UpsertSession(sess))
 
 	tests := []struct {
 		name        string

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -40,16 +43,9 @@ func stubServer(
 	return httptest.NewServer(
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != expectedMethod {
-					t.Errorf("expected method %q, got %q", expectedMethod, r.Method)
-				}
-				if r.Header.Get("User-Agent") != "agentsview" {
-					t.Errorf("expected User-Agent %q, got %q", "agentsview", r.Header.Get("User-Agent"))
-				}
-				expectedAuth := "token " + expectedToken
-				if auth := r.Header.Get("Authorization"); auth != expectedAuth {
-					t.Errorf("expected Authorization header %q, got %q", expectedAuth, auth)
-				}
+				assert.Equal(t, expectedMethod, r.Method)
+				assert.Equal(t, "agentsview", r.Header.Get("User-Agent"))
+				assert.Equal(t, "token "+expectedToken, r.Header.Get("Authorization"))
 				w.WriteHeader(status)
 				if body != "" {
 					w.Write([]byte(body))
@@ -62,27 +58,22 @@ func stubServer(
 // assertErrorContains checks that err is non-nil and contains want.
 func assertErrorContains(t *testing.T, err error, want string) {
 	t.Helper()
-	if err == nil {
-		t.Fatalf("expected error containing %q, got nil", want)
-	}
-	if !strings.Contains(err.Error(), want) {
-		t.Errorf("expected error containing %q, got: %v", want, err)
-	}
+	require.Error(t, err, "expected error containing %q", want)
+	assert.Contains(t, err.Error(), want)
 }
 
 // assertContextCancelled checks that err is non-nil and
 // wraps context.Canceled.
 func assertContextCancelled(t *testing.T, err error) {
 	t.Helper()
-	if err == nil {
-		t.Fatal("expected error for cancelled context")
-	}
+	require.Error(t, err, "expected error for cancelled context")
 	if !errors.Is(err, context.Canceled) &&
 		!strings.Contains(
 			err.Error(), "context canceled",
 		) {
-		t.Errorf(
-			"expected context.Canceled, got: %v", err,
+		assert.Fail(t,
+			"expected context.Canceled",
+			"got: %v", err,
 		)
 	}
 }
@@ -129,12 +120,7 @@ func TestFormatTimestamp(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := formatTimestamp(tt.in)
-			if got != tt.want {
-				t.Errorf(
-					"formatTimestamp(%q) = %q, want %q",
-					tt.in, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -169,12 +155,7 @@ func TestFormatDateShort(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := formatDateShort(tt.in)
-			if got != tt.want {
-				t.Errorf(
-					"formatDateShort(%v) = %q, want %q",
-					tt.in, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -196,12 +177,7 @@ func TestParseTimestamp(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, ok := parseTimestamp(tt.in)
-			if ok != tt.valid {
-				t.Errorf(
-					"parseTimestamp(%q) ok=%v, want %v",
-					tt.in, ok, tt.valid,
-				)
-			}
+			assert.Equal(t, tt.valid, ok)
 		})
 	}
 }
@@ -358,12 +334,7 @@ func TestIsThinkingOnly(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := isThinkingOnly(tt.in)
-			if got != tt.want {
-				t.Errorf(
-					"isThinkingOnly(%q) = %v, want %v",
-					tt.in, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -420,10 +391,8 @@ func TestGenerateExportHTML_ThinkingOnlyClass(t *testing.T) {
 	}
 
 	html := generateExportHTML(session, msgs)
-	if !strings.Contains(html, "thinking-only") {
-		t.Error("expected thinking-only class for" +
-			" thinking-only message")
-	}
+	assert.Contains(t, html, "thinking-only",
+		"expected thinking-only class for thinking-only message")
 }
 
 func TestGenerateExportHTML_EscapesHostileInput(t *testing.T) {
@@ -444,13 +413,11 @@ func TestGenerateExportHTML_EscapesHostileInput(t *testing.T) {
 	out := generateExportHTML(session, msgs)
 
 	// Template auto-escapes the <img> tag in project name
-	if strings.Contains(out, "<img src=x") {
-		t.Error("project name XSS: raw <img> tag not escaped")
-	}
+	assert.NotContains(t, out, "<img src=x",
+		"project name XSS: raw <img> tag not escaped")
 	// Content is escaped by formatContentForExport
-	if strings.Contains(out, "<script>alert") {
-		t.Error("message content XSS not escaped")
-	}
+	assert.NotContains(t, out, "<script>alert",
+		"message content XSS not escaped")
 }
 
 func TestGenerateExportHTML_CodexAgent(t *testing.T) {
@@ -460,9 +427,8 @@ func TestGenerateExportHTML_CodexAgent(t *testing.T) {
 	})
 
 	html := generateExportHTML(session, nil)
-	if !strings.Contains(html, "Codex") {
-		t.Error("expected Codex display name for codex agent")
-	}
+	assert.Contains(t, html, "Codex",
+		"expected Codex display name for codex agent")
 }
 
 func TestGenerateExportHTML_NilStartedAt(t *testing.T) {
@@ -472,9 +438,8 @@ func TestGenerateExportHTML_NilStartedAt(t *testing.T) {
 	})
 
 	html := generateExportHTML(session, nil)
-	if !strings.Contains(html, "<!DOCTYPE html>") {
-		t.Error("expected valid HTML even with nil StartedAt")
-	}
+	assert.Contains(t, html, "<!DOCTYPE html>",
+		"expected valid HTML even with nil StartedAt")
 }
 
 func TestGenerateExportHTML_TranscriptModeControls(t *testing.T) {
@@ -516,15 +481,15 @@ func TestGenerateExportHTML_TranscriptModeControls(t *testing.T) {
 		`class="message assistant focused-hidden" data-ordinal="2"`,
 		`class="message assistant" data-ordinal="3"`,
 	})
-	if strings.Index(
-		html,
-		`#transcript-focused:checked ~ main .message.focused-hidden`,
-	) < strings.Index(
-		html,
-		`#thinking-toggle:checked ~ main .message.thinking-only`,
-	) {
-		t.Error("focused hide rule must follow thinking display rule")
-	}
+	assert.GreaterOrEqual(t,
+		strings.Index(html,
+			`#transcript-focused:checked ~ main .message.focused-hidden`,
+		),
+		strings.Index(html,
+			`#thinking-toggle:checked ~ main .message.thinking-only`,
+		),
+		"focused hide rule must follow thinking display rule",
+	)
 	assertContainsNone(t, html, []string{
 		`class="message user focused-hidden" data-ordinal="0"`,
 		`class="message assistant focused-hidden" data-ordinal="3"`,
@@ -645,9 +610,8 @@ func TestFocusedExportOrdinals(t *testing.T) {
 					got = append(got, msg.Ordinal)
 				}
 			}
-			if !slices.Equal(got, tt.want) {
-				t.Fatalf("visible ordinals = %v, want %v", got, tt.want)
-			}
+			assert.True(t, slices.Equal(got, tt.want),
+				"visible ordinals = %v, want %v", got, tt.want)
 		})
 	}
 }
@@ -875,9 +839,8 @@ func TestGenerateExportMarkdown_SanitizesHeadingAndAvoidsDuplicateAnchors(t *tes
 		AnchoredChildren: map[string]*exportSessionTree{"child-a": child},
 	}, exportMarkdownOptions{Depth: "all"})
 	assertContainsNone(t, out, []string{"# Session: proj\n<script>alert(1)</script>"})
-	if strings.Count(out, `<subagent_session id="child-a"`) != 1 {
-		t.Fatalf("expected child session once, got:\n%s", out)
-	}
+	assert.Equal(t, 1, strings.Count(out, `<subagent_session id="child-a"`),
+		"expected child session once, got:\n%s", out)
 }
 
 func TestGenerateExportMarkdown_DoesNotParseToolMarkersInsideCodeBlocks(t *testing.T) {
@@ -1016,12 +979,7 @@ func TestSanitizeFilename(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := sanitizeFilename(tt.in)
-			if got != tt.want {
-				t.Errorf(
-					"sanitizeFilename(%q) = %q, want %q",
-					tt.in, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1042,12 +1000,7 @@ func TestTruncateStr(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := truncateStr(tt.in, tt.max)
-			if got != tt.want {
-				t.Errorf(
-					"truncateStr(%q, %d) = %q, want %q",
-					tt.in, tt.max, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1071,12 +1024,10 @@ func TestExportTemplateValid(t *testing.T) {
 		},
 	}
 	var b strings.Builder
-	if err := exportTmpl.Execute(&b, data); err != nil {
-		t.Fatalf("template execution failed: %v", err)
-	}
-	if !strings.Contains(b.String(), "<!DOCTYPE html>") {
-		t.Error("expected valid HTML doctype")
-	}
+	require.NoError(t, exportTmpl.Execute(&b, data),
+		"template execution failed")
+	assert.Contains(t, b.String(), "<!DOCTYPE html>",
+		"expected valid HTML doctype")
 }
 
 func TestExportTemplateAccentColors(t *testing.T) {
@@ -1096,9 +1047,8 @@ func TestExportTemplateAccentColors(t *testing.T) {
 		"--accent-indigo",
 	}
 	for _, v := range required {
-		if !strings.Contains(exportTemplateStr, v) {
-			t.Errorf("export template missing CSS variable %s", v)
-		}
+		assert.Contains(t, exportTemplateStr, v,
+			"export template missing CSS variable %s", v)
 	}
 }
 
@@ -1176,19 +1126,11 @@ func TestCreateGist(t *testing.T) {
 				assertErrorContains(t, err, tt.wantErr)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
-			if got.ID != tt.wantID {
-				t.Errorf("expected ID %q, got %q", tt.wantID, got.ID)
-			}
-			if got.HTMLURL != tt.wantURL {
-				t.Errorf("expected HTMLURL %q, got %q", tt.wantURL, got.HTMLURL)
-			}
-			if got.Owner.Login != tt.wantLogin {
-				t.Errorf("expected Owner.Login %q, got %q", tt.wantLogin, got.Owner.Login)
-			}
+			assert.Equal(t, tt.wantID, got.ID)
+			assert.Equal(t, tt.wantURL, got.HTMLURL)
+			assert.Equal(t, tt.wantLogin, got.Owner.Login)
 		})
 	}
 }
@@ -1262,13 +1204,9 @@ func TestValidateGithubToken(t *testing.T) {
 				assertErrorContains(t, err, tt.wantErr)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			require.NoError(t, err)
 
-			if login != tt.wantLogin {
-				t.Errorf("expected login %q, got %q", tt.wantLogin, login)
-			}
+			assert.Equal(t, tt.wantLogin, login)
 		})
 	}
 }

--- a/internal/server/ghostty_test.go
+++ b/internal/server/ghostty_test.go
@@ -5,6 +5,9 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLaunchResumeDarwinGhosttyDirectCli(t *testing.T) {
@@ -19,17 +22,12 @@ func TestLaunchResumeDarwinGhosttyDirectCli(t *testing.T) {
 		"cursor agent --resume chat-1",
 		cwd,
 	)
-	if proc == nil {
-		t.Fatal("launchResumeDarwin returned nil")
-	}
-	if strings.HasSuffix(proc.Args[0], "osascript") {
-		t.Fatalf("expected direct CLI, got osascript: %v",
-			proc.Args)
-	}
+	require.NotNil(t, proc, "launchResumeDarwin returned nil")
+	assert.False(t, strings.HasSuffix(proc.Args[0], "osascript"),
+		"expected direct CLI, got osascript: %v", proc.Args)
 	wantWD := "--working-directory=" + cwd
-	if !sliceContains(proc.Args, wantWD) {
-		t.Fatalf("missing %q in args: %v", wantWD, proc.Args)
-	}
+	assert.True(t, sliceContains(proc.Args, wantWD),
+		"missing %q in args: %v", wantWD, proc.Args)
 }
 
 func TestLaunchResumeDarwinGhosttyAppBundle(t *testing.T) {
@@ -44,21 +42,15 @@ func TestLaunchResumeDarwinGhosttyAppBundle(t *testing.T) {
 		"cursor agent --resume chat-1",
 		cwd,
 	)
-	if proc == nil {
-		t.Fatal("launchResumeDarwin returned nil")
-	}
+	require.NotNil(t, proc, "launchResumeDarwin returned nil")
 	// App bundle wraps with `open -na`.
-	if !strings.HasSuffix(proc.Args[0], "open") {
-		t.Fatalf("expected open for app bundle, got %q",
-			proc.Args[0])
-	}
-	if !sliceContains(proc.Args, "-na") {
-		t.Fatalf("missing -na flag: %v", proc.Args)
-	}
+	assert.True(t, strings.HasSuffix(proc.Args[0], "open"),
+		"expected open for app bundle, got %q", proc.Args[0])
+	assert.True(t, sliceContains(proc.Args, "-na"),
+		"missing -na flag: %v", proc.Args)
 	wantWD := "--working-directory=" + cwd
-	if !sliceContains(proc.Args, wantWD) {
-		t.Fatalf("missing %q in args: %v", wantWD, proc.Args)
-	}
+	assert.True(t, sliceContains(proc.Args, wantWD),
+		"missing %q in args: %v", wantWD, proc.Args)
 }
 
 func TestLaunchResumeDarwinGhosttyNoCwd(t *testing.T) {
@@ -72,14 +64,10 @@ func TestLaunchResumeDarwinGhosttyNoCwd(t *testing.T) {
 		"cursor agent --resume chat-1",
 		"",
 	)
-	if proc == nil {
-		t.Fatal("launchResumeDarwin returned nil")
-	}
+	require.NotNil(t, proc, "launchResumeDarwin returned nil")
 	for _, arg := range proc.Args {
-		if strings.HasPrefix(arg, "--working-directory") {
-			t.Fatalf("unexpected --working-directory with empty cwd: %v",
-				proc.Args)
-		}
+		assert.False(t, strings.HasPrefix(arg, "--working-directory"),
+			"unexpected --working-directory with empty cwd: %v", proc.Args)
 	}
 }
 
@@ -97,17 +85,12 @@ func TestLaunchTerminalInDirGhosttyDirectCliOnDarwin(t *testing.T) {
 		},
 		dir,
 	)
-	if proc == nil {
-		t.Fatal("launchTerminalInDir returned nil")
-	}
-	if strings.HasSuffix(proc.Args[0], "osascript") {
-		t.Fatalf("expected direct launch, got osascript: %v",
-			proc.Args)
-	}
+	require.NotNil(t, proc, "launchTerminalInDir returned nil")
+	assert.False(t, strings.HasSuffix(proc.Args[0], "osascript"),
+		"expected direct launch, got osascript: %v", proc.Args)
 	wantWD := "--working-directory=" + dir
-	if !sliceContains(proc.Args, wantWD) {
-		t.Fatalf("missing %q in args: %v", wantWD, proc.Args)
-	}
+	assert.True(t, sliceContains(proc.Args, wantWD),
+		"missing %q in args: %v", wantWD, proc.Args)
 }
 
 func sliceContains(ss []string, s string) bool {

--- a/internal/server/helpers_internal_test.go
+++ b/internal/server/helpers_internal_test.go
@@ -8,9 +8,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
@@ -29,9 +31,7 @@ func testServer(
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 	database, err := db.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening db: %v", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { database.Close() })
 
 	cfg := config.Config{
@@ -64,39 +64,18 @@ func assertTimeoutResponse(
 	t *testing.T, resp *http.Response,
 ) {
 	t.Helper()
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf(
-			"status = %d, want %d",
-			resp.StatusCode, http.StatusServiceUnavailable,
-		)
-	}
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("reading body: %v", err)
-	}
+	require.NoError(t, err)
 	resp.Body = struct {
 		io.Reader
 		io.Closer
 	}{bytes.NewReader(body), resp.Body}
 	var je jsonError
-	if err := json.Unmarshal(body, &je); err != nil {
-		t.Fatalf(
-			"body is not valid JSON: %v (body=%q)",
-			err, string(body),
-		)
-	}
-	if je.Error != "request timed out" {
-		t.Fatalf(
-			"error = %q, want %q",
-			je.Error, "request timed out",
-		)
-	}
-	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
-		t.Fatalf(
-			"Content-Type = %q, want %q",
-			ct, "application/json",
-		)
-	}
+	require.NoError(t, json.Unmarshal(body, &je),
+		"body is not valid JSON; body=%q", string(body))
+	require.Equal(t, "request timed out", je.Error)
+	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 }
 
 // isTimeoutResponse returns true when the response is a 503
@@ -144,12 +123,7 @@ func assertRecorderStatus(
 	t *testing.T, w *httptest.ResponseRecorder, code int,
 ) {
 	t.Helper()
-	if w.Code != code {
-		t.Fatalf(
-			"expected status %d, got %d: %s",
-			code, w.Code, w.Body.String(),
-		)
-	}
+	require.Equal(t, code, w.Code, "body: %s", w.Body.String())
 }
 
 // assertContentType checks that the recorder has the expected
@@ -158,11 +132,7 @@ func assertContentType(
 	t *testing.T, w *httptest.ResponseRecorder, expected string,
 ) {
 	t.Helper()
-	if got := w.Header().Get("Content-Type"); got != expected {
-		t.Errorf(
-			"Content-Type = %q, want %q", got, expected,
-		)
-	}
+	assert.Equal(t, expected, w.Header().Get("Content-Type"))
 }
 
 // newTestServerMinimal creates a lightweight Server with only the
@@ -195,12 +165,7 @@ func assertContainsAll(
 ) {
 	t.Helper()
 	for _, want := range wants {
-		if !strings.Contains(got, want) {
-			t.Errorf(
-				"expected to contain %q, got:\n%s",
-				want, got,
-			)
-		}
+		assert.Contains(t, got, want)
 	}
 }
 
@@ -211,11 +176,6 @@ func assertContainsNone(
 ) {
 	t.Helper()
 	for _, bad := range bads {
-		if strings.Contains(got, bad) {
-			t.Errorf(
-				"expected NOT to contain %q, got:\n%s",
-				bad, got,
-			)
-		}
+		assert.NotContains(t, got, bad)
 	}
 }

--- a/internal/server/import_test.go
+++ b/internal/server/import_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/importer"
 )
 
@@ -42,9 +45,7 @@ func TestHandleImportClaudeAI(t *testing.T) {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	part, err := writer.CreateFormFile("file", "conversations.json")
-	if err != nil {
-		t.Fatalf("creating form file: %v", err)
-	}
+	require.NoError(t, err)
 	_, _ = part.Write([]byte(conversations))
 	writer.Close()
 
@@ -58,23 +59,12 @@ func TestHandleImportClaudeAI(t *testing.T) {
 	rec := httptest.NewRecorder()
 	srv.mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf(
-			"status = %d, want 200: %s",
-			rec.Code, rec.Body.String(),
-		)
-	}
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
 	var stats importer.ImportStats
-	if err := json.NewDecoder(rec.Body).Decode(&stats); err != nil {
-		t.Fatalf("decoding response: %v", err)
-	}
-	if stats.Imported != 1 {
-		t.Errorf("imported = %d, want 1", stats.Imported)
-	}
-	if stats.Updated != 0 {
-		t.Errorf("updated = %d, want 0", stats.Updated)
-	}
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&stats))
+	assert.Equal(t, 1, stats.Imported)
+	assert.Zero(t, stats.Updated)
 }
 
 func TestHandleImportChatGPT_RequiresZip(t *testing.T) {
@@ -83,9 +73,7 @@ func TestHandleImportChatGPT_RequiresZip(t *testing.T) {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	part, err := writer.CreateFormFile("file", "data.json")
-	if err != nil {
-		t.Fatalf("creating form file: %v", err)
-	}
+	require.NoError(t, err)
 	_, _ = part.Write([]byte("[]"))
 	writer.Close()
 
@@ -101,12 +89,7 @@ func TestHandleImportChatGPT_RequiresZip(t *testing.T) {
 	rec := httptest.NewRecorder()
 	srv.mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf(
-			"status = %d, want 400: %s",
-			rec.Code, rec.Body.String(),
-		)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
 }
 
 func TestHandleImportClaudeAI_SSE(t *testing.T) {
@@ -129,9 +112,7 @@ func TestHandleImportClaudeAI_SSE(t *testing.T) {
 	part, err := writer.CreateFormFile(
 		"file", "conversations.json",
 	)
-	if err != nil {
-		t.Fatalf("creating form file: %v", err)
-	}
+	require.NoError(t, err)
 	_, _ = part.Write([]byte(conversations))
 	writer.Close()
 
@@ -148,19 +129,9 @@ func TestHandleImportClaudeAI_SSE(t *testing.T) {
 	rec := httptest.NewRecorder()
 	srv.mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf(
-			"status = %d, want 200: %s",
-			rec.Code, rec.Body.String(),
-		)
-	}
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
-	ct := rec.Header().Get("Content-Type")
-	if !strings.Contains(ct, "text/event-stream") {
-		t.Fatalf(
-			"Content-Type = %q, want text/event-stream", ct,
-		)
-	}
+	require.Contains(t, rec.Header().Get("Content-Type"), "text/event-stream")
 
 	// Parse the done event from the SSE body.
 	var stats importer.ImportStats
@@ -170,16 +141,10 @@ func TestHandleImportClaudeAI_SSE(t *testing.T) {
 			data := strings.TrimPrefix(
 				lines[i+1], "data: ",
 			)
-			if err := json.Unmarshal(
-				[]byte(data), &stats,
-			); err != nil {
-				t.Fatalf("decoding done event: %v", err)
-			}
+			require.NoError(t, json.Unmarshal([]byte(data), &stats))
 		}
 	}
-	if stats.Imported != 1 {
-		t.Errorf("imported = %d, want 1", stats.Imported)
-	}
+	assert.Equal(t, 1, stats.Imported)
 }
 
 func TestHandleImportClaudeAI_NoFile(t *testing.T) {
@@ -199,10 +164,5 @@ func TestHandleImportClaudeAI_NoFile(t *testing.T) {
 	rec := httptest.NewRecorder()
 	srv.mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf(
-			"status = %d, want 400: %s",
-			rec.Code, rec.Body.String(),
-		)
-	}
+	require.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
 }

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -15,6 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/insight"
 	"go.kenn.io/agentsview/internal/server"
@@ -128,9 +131,7 @@ func TestListInsights(t *testing.T) {
 
 			if tt.wantStatus == http.StatusOK {
 				r := decode[listInsightsResponse](t, w)
-				if len(r.Insights) != tt.wantCount {
-					t.Fatalf("expected %d insights, got %d", tt.wantCount, len(r.Insights))
-				}
+				require.Len(t, r.Insights, tt.wantCount)
 			}
 		})
 	}
@@ -146,12 +147,8 @@ func TestGetInsight_Found(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	r := decode[db.Insight](t, w)
-	if r.ID != id {
-		t.Fatalf("expected id=%d, got %d", id, r.ID)
-	}
-	if r.Type != "daily_activity" {
-		t.Errorf("type = %q, want daily_activity", r.Type)
-	}
+	require.Equal(t, id, r.ID)
+	assert.Equal(t, "daily_activity", r.Type)
 }
 
 func TestGenerateInsight_Validation(t *testing.T) {
@@ -185,9 +182,7 @@ func TestGenerateInsight_DefaultAgent(t *testing.T) {
 	stubGen := func(
 		_ context.Context, agent, _ string,
 	) (insight.Result, error) {
-		if agent != "claude" {
-			t.Errorf("expected default agent claude, got %q", agent)
-		}
+		assert.Equal(t, "claude", agent, "expected default agent claude")
 		return insight.Result{}, fmt.Errorf("stub: no CLI")
 	}
 	te := setupWithServerOpts(t, []server.Option{
@@ -217,12 +212,9 @@ func TestGenerateInsight_ErrorMessageStripsStderr(t *testing.T) {
 		`{"type":"daily_activity","date_from":"2025-01-15","date_to":"2025-01-15"}`)
 	assertStatus(t, w, http.StatusOK)
 	body := w.Body.String()
-	if !strings.Contains(body, "claude CLI failed: exit status 1") {
-		t.Fatalf("expected error detail in response, got: %s", body)
-	}
-	if strings.Contains(body, "some debug output") {
-		t.Fatalf("expected stderr to be stripped from client message")
-	}
+	require.Contains(t, body, "claude CLI failed: exit status 1")
+	require.NotContains(t, body, "some debug output",
+		"expected stderr to be stripped from client message")
 }
 
 func TestGenerateInsight_ErrorMessageStripsRaw(t *testing.T) {
@@ -241,12 +233,9 @@ func TestGenerateInsight_ErrorMessageStripsRaw(t *testing.T) {
 		`{"type":"daily_activity","date_from":"2025-01-15","date_to":"2025-01-15"}`)
 	assertStatus(t, w, http.StatusOK)
 	body := w.Body.String()
-	if !strings.Contains(body, "claude returned empty result") {
-		t.Fatalf("expected error detail in response, got: %s", body)
-	}
-	if strings.Contains(body, `"type":"result"`) {
-		t.Fatalf("expected raw payload to be stripped from client message")
-	}
+	require.Contains(t, body, "claude returned empty result")
+	require.NotContains(t, body, `"type":"result"`,
+		"expected raw payload to be stripped from client message")
 }
 
 func TestGenerateInsight_InitialStatusWriteFailureSkipsGeneration(t *testing.T) {
@@ -271,9 +260,8 @@ func TestGenerateInsight_InitialStatusWriteFailureSkipsGeneration(t *testing.T) 
 	w := newFailFirstWriteRecorder()
 	te.handler.ServeHTTP(w, req)
 
-	if called.Load() {
-		t.Fatalf("generation should not run when initial SSE status write fails")
-	}
+	require.False(t, called.Load(),
+		"generation should not run when initial SSE status write fails")
 }
 
 func TestGenerateInsight_StreamsLogs(t *testing.T) {
@@ -303,34 +291,19 @@ func TestGenerateInsight_StreamsLogs(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	events := parseSSE(w.Body.String())
-	if len(events) < 4 {
-		t.Fatalf("expected >=4 SSE events, got %d: %s", len(events), w.Body.String())
-	}
-	if events[0].Event != "status" {
-		t.Fatalf("first event = %q, want status", events[0].Event)
-	}
-	if events[1].Event != "log" || events[2].Event != "log" {
-		t.Fatalf("expected two log events, got: %#v", events)
-	}
-	if events[len(events)-1].Event != "done" {
-		t.Fatalf("last event = %q, want done", events[len(events)-1].Event)
-	}
+	require.GreaterOrEqual(t, len(events), 4, "expected >=4 SSE events: %s", w.Body.String())
+	require.Equal(t, "status", events[0].Event, "first event")
+	require.Equal(t, "log", events[1].Event, "events: %#v", events)
+	require.Equal(t, "log", events[2].Event, "events: %#v", events)
+	require.Equal(t, "done", events[len(events)-1].Event, "last event")
 
 	var log1 insight.LogEvent
-	if err := json.Unmarshal([]byte(events[1].Data), &log1); err != nil {
-		t.Fatalf("unmarshal first log event: %v", err)
-	}
-	if log1.Stream != "stdout" {
-		t.Fatalf("first log stream = %q, want stdout", log1.Stream)
-	}
+	require.NoError(t, json.Unmarshal([]byte(events[1].Data), &log1))
+	require.Equal(t, "stdout", log1.Stream)
 
 	var log2 insight.LogEvent
-	if err := json.Unmarshal([]byte(events[2].Data), &log2); err != nil {
-		t.Fatalf("unmarshal second log event: %v", err)
-	}
-	if log2.Stream != "stderr" {
-		t.Fatalf("second log stream = %q, want stderr", log2.Stream)
-	}
+	require.NoError(t, json.Unmarshal([]byte(events[2].Data), &log2))
+	require.Equal(t, "stderr", log2.Stream)
 }
 
 type slowFlushRecorder struct {
@@ -573,7 +546,7 @@ func TestGenerateInsight_LogDropSummaryAndCompletion(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(8 * time.Second):
-		t.Fatalf("timed out waiting for generate handler")
+		require.Fail(t, "timed out waiting for generate handler")
 	}
 
 	assertStatus(t, w.ResponseRecorder, http.StatusOK)
@@ -598,15 +571,9 @@ func TestGenerateInsight_LogDropSummaryAndCompletion(t *testing.T) {
 			foundDropSummary = true
 		}
 	}
-	if !foundDropSummary {
-		t.Fatalf(
-			"expected dropped-log summary event, got %d events",
-			len(events),
-		)
-	}
-	if !foundDone {
-		t.Fatalf("expected done event")
-	}
+	require.True(t, foundDropSummary,
+		"expected dropped-log summary event, got %d events", len(events))
+	require.True(t, foundDone, "expected done event")
 }
 
 func TestGenerateInsight_LogDrainTimeoutReturnsWithoutHang(t *testing.T) {
@@ -650,18 +617,16 @@ func TestGenerateInsight_LogDrainTimeoutReturnsWithoutHang(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(12 * time.Second):
-		t.Fatalf("timed out waiting for generate handler completion")
+		require.Fail(t, "timed out waiting for generate handler completion")
 	}
-	if elapsed := time.Since(started); elapsed > 7*time.Second {
-		t.Fatalf("handler should return within bounded timeout handling, took %s", elapsed)
-	}
+	require.LessOrEqual(t, time.Since(started), 7*time.Second,
+		"handler should return within bounded timeout handling")
 
 	assertStatus(t, w.ResponseRecorder, http.StatusOK)
 	events := parseSSE(w.BodyString())
 	for _, ev := range events {
-		if ev.Event == "done" {
-			t.Fatalf("did not expect done event when timeout path is triggered")
-		}
+		require.NotEqual(t, "done", ev.Event,
+			"did not expect done event when timeout path is triggered")
 	}
 }
 
@@ -705,7 +670,7 @@ func TestGenerateInsight_LogDrainTimeoutReportsBufferedDrops(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(10 * time.Second):
-		t.Fatalf("timed out waiting for generate handler completion")
+		require.Fail(t, "timed out waiting for generate handler completion")
 	}
 
 	assertStatus(t, w.ResponseRecorder, http.StatusOK)
@@ -713,9 +678,8 @@ func TestGenerateInsight_LogDrainTimeoutReportsBufferedDrops(t *testing.T) {
 	foundTimeoutError := false
 	foundDropSummary := false
 	for _, ev := range events {
-		if ev.Event == "done" {
-			t.Fatalf("did not expect done event when timeout path is triggered")
-		}
+		require.NotEqual(t, "done", ev.Event,
+			"did not expect done event when timeout path is triggered")
 		if ev.Event == "error" &&
 			strings.Contains(ev.Data, "timed out before completion") {
 			foundTimeoutError = true
@@ -742,17 +706,14 @@ func TestGenerateInsight_LogDrainTimeoutReportsBufferedDrops(t *testing.T) {
 		}
 		// 10 events were enqueued; timeout truncation should account
 		// for most buffered entries that were never flushed.
-		if dropped < 8 {
-			t.Fatalf("expected timeout drop summary >=8, got %d (%q)", dropped, line.Line)
-		}
+		require.GreaterOrEqual(t, dropped, 8,
+			"expected timeout drop summary >=8 (%q)", line.Line)
 		foundDropSummary = true
 	}
-	if !foundTimeoutError {
-		t.Fatalf("expected timeout error event, got %d events", len(events))
-	}
-	if !foundDropSummary {
-		t.Fatalf("expected timeout-aware drop summary, got %d events", len(events))
-	}
+	require.True(t, foundTimeoutError,
+		"expected timeout error event, got %d events", len(events))
+	require.True(t, foundDropSummary,
+		"expected timeout-aware drop summary, got %d events", len(events))
 }
 
 func TestGenerateInsight_LogDrainTimeoutBoundedWhenWriterStuck(t *testing.T) {
@@ -789,20 +750,18 @@ func TestGenerateInsight_LogDrainTimeoutBoundedWhenWriterStuck(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(7 * time.Second):
-		t.Fatalf("timed out waiting for bounded timeout behavior")
+		require.Fail(t, "timed out waiting for bounded timeout behavior")
 	}
 	elapsed := time.Since(started)
-	if elapsed > 6*time.Second {
-		t.Fatalf("handler returned too slowly for stuck writer path: %s", elapsed)
-	}
+	require.LessOrEqual(t, elapsed, 6*time.Second,
+		"handler returned too slowly for stuck writer path")
 	close(release)
 
 	assertStatus(t, w.ResponseRecorder, http.StatusOK)
 	events := parseSSE(w.BodyString())
 	for _, ev := range events {
-		if ev.Event == "done" {
-			t.Fatalf("did not expect done event on stuck writer timeout path")
-		}
+		require.NotEqual(t, "done", ev.Event,
+			"did not expect done event on stuck writer timeout path")
 	}
 }
 
@@ -837,33 +796,28 @@ func TestGenerateInsight_LogDrainTimeoutForceUnblocksAndNoPostReturnWrites(t *te
 	select {
 	case <-done:
 	case <-time.After(8 * time.Second):
-		t.Fatalf("timed out waiting for forced-unblock completion")
+		require.Fail(t, "timed out waiting for forced-unblock completion")
 	}
 
 	select {
 	case <-w.PostReturnAttempted():
-		t.Fatalf("expected no writes after handler return")
+		require.Fail(t, "expected no writes after handler return")
 	case <-time.After(300 * time.Millisecond):
 	}
-	if got := w.PostReturnWrites(); got != 0 {
-		t.Fatalf("expected no writes after handler return, got %d", got)
-	}
+	require.Zero(t, w.PostReturnWrites(), "expected no writes after handler return")
 
 	assertStatus(t, w.ResponseRecorder, http.StatusOK)
 	events := parseSSE(w.BodyString())
 	foundTimeoutError := false
 	for _, ev := range events {
-		if ev.Event == "done" {
-			t.Fatalf("did not expect done event on forced-unblock timeout path")
-		}
+		require.NotEqual(t, "done", ev.Event,
+			"did not expect done event on forced-unblock timeout path")
 		if ev.Event == "error" &&
 			strings.Contains(ev.Data, "timed out before completion") {
 			foundTimeoutError = true
 		}
 	}
-	if !foundTimeoutError {
-		t.Fatalf("expected timeout error event")
-	}
+	require.True(t, foundTimeoutError, "expected timeout error event")
 }
 
 func TestDeleteInsight_Found(t *testing.T) {
@@ -923,8 +877,6 @@ func (te *testEnv) seedInsight(
 		Agent:    "claude",
 		Content:  "Test insight content",
 	})
-	if err != nil {
-		t.Fatalf("seeding insight: %v", err)
-	}
+	require.NoError(t, err)
 	return id
 }

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestContentTypeWrapper verifies that Content-Type is only set if missing
@@ -78,21 +81,15 @@ func TestContentTypeWrapper(t *testing.T) {
 
 			gotCT := resp.Header.Get("Content-Type")
 			if tt.wantContentType != "" {
-				if gotCT != tt.wantContentType {
-					t.Errorf("Content-Type = %q, want %q", gotCT, tt.wantContentType)
-				}
-			} else if gotCT == "application/json" {
-				// Wrapper shouldn't improperly force its Content-Type
-				t.Errorf("Content-Type = %q, unexpectedly forced by wrapper", gotCT)
+				assert.Equal(t, tt.wantContentType, gotCT)
+			} else {
+				assert.NotEqual(t, "application/json", gotCT,
+					"Content-Type unexpectedly forced by wrapper")
 			}
 
 			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatalf("failed to read body: %v", err)
-			}
-			if string(body) != tt.wantBody {
-				t.Errorf("body = %q, want %q", string(body), tt.wantBody)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBody, string(body))
 		})
 	}
 }
@@ -111,9 +108,7 @@ func TestMiddlewareTimeout(t *testing.T) {
 	// rebuild Handler() with the correct port in the Host
 	// allowlist.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
+	require.NoError(t, err)
 	port := ln.Addr().(*net.TCPAddr).Port
 	srv.SetPort(port)
 	ts := httptest.NewUnstartedServer(srv.Handler())
@@ -137,20 +132,15 @@ func TestMiddlewareTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			resp, err := ts.Client().Get(ts.URL + tt.path)
-			if err != nil {
-				t.Fatalf("request failed: %v", err)
-			}
+			require.NoError(t, err)
 			defer resp.Body.Close()
 
 			if tt.wantTimeout {
 				assertTimeoutResponse(t, resp)
 			} else {
-				if isTimeoutResponse(t, resp) {
-					t.Errorf("%s: unexpected timeout for unwrapped route", tt.path)
-				}
-				if resp.StatusCode != tt.wantStatus {
-					t.Errorf("%s: status = %d, want %d", tt.path, resp.StatusCode, tt.wantStatus)
-				}
+				assert.False(t, isTimeoutResponse(t, resp),
+					"%s: unexpected timeout for unwrapped route", tt.path)
+				assert.Equal(t, tt.wantStatus, resp.StatusCode, tt.path)
 			}
 		})
 	}
@@ -257,23 +247,15 @@ func TestCSPMiddlewareSetsHeaderOnNonAPIRoutes(t *testing.T) {
 
 			csp := w.Header().Get("Content-Security-Policy")
 			if !tt.wantCSP {
-				if csp != "" {
-					t.Errorf("expected no CSP header on API route, got %q", csp)
-				}
+				assert.Empty(t, csp, "expected no CSP header on API route")
 				return
 			}
-			if csp == "" {
-				t.Fatal("expected CSP header, got empty")
-			}
+			require.NotEmpty(t, csp, "expected CSP header")
 			got := parseCSP(csp)
 			for name, want := range tt.wantDirectives {
-				if got[name] != want {
-					t.Errorf("directive %s = %q, want %q", name, got[name], want)
-				}
+				assert.Equal(t, want, got[name], "directive %s", name)
 			}
-			if xfo := w.Header().Get("X-Frame-Options"); xfo != "DENY" {
-				t.Errorf("X-Frame-Options = %q, want DENY", xfo)
-			}
+			assert.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
 		})
 	}
 }
@@ -289,9 +271,8 @@ func TestBuildCSPPolicyWidensConnectSrcOnly(t *testing.T) {
 
 	directives := parseCSP(buildCSPPolicy("127.0.0.1", 8081, ""))
 
-	if got := directives["connect-src"]; got != "'self' http: https: ws: wss:" {
-		t.Errorf("connect-src = %q, want it widened to any http/https/ws/wss origin", got)
-	}
+	assert.Equal(t, "'self' http: https: ws: wss:", directives["connect-src"],
+		"connect-src should be widened to any http/https/ws/wss origin")
 
 	// Scheme-source wildcards must not leak into the directives that
 	// gate code/resource loading, or the widening would defeat the
@@ -302,10 +283,9 @@ func TestBuildCSPPolicyWidensConnectSrcOnly(t *testing.T) {
 	}
 	for _, name := range locked {
 		for field := range strings.FieldsSeq(directives[name]) {
-			if schemeWildcards[field] {
-				t.Errorf("directive %s must stay pinned but allows %q (full: %q)",
-					name, field, directives[name])
-			}
+			assert.False(t, schemeWildcards[field],
+				"directive %s must stay pinned but allows %q (full: %q)",
+				name, field, directives[name])
 		}
 	}
 }
@@ -334,10 +314,6 @@ func TestCORSMiddlewareMergesVaryHeader(t *testing.T) {
 
 	assertRecorderStatus(t, w, http.StatusOK)
 	vary := w.Header().Get("Vary")
-	if !strings.Contains(vary, "Accept-Encoding") {
-		t.Fatalf("expected Vary to include Accept-Encoding, got %q", vary)
-	}
-	if !strings.Contains(vary, "Origin") {
-		t.Fatalf("expected Vary to include Origin, got %q", vary)
-	}
+	assert.Contains(t, vary, "Accept-Encoding")
+	assert.Contains(t, vary, "Origin")
 }

--- a/internal/server/params_test.go
+++ b/internal/server/params_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseIntParam(t *testing.T) {
@@ -61,17 +63,9 @@ func TestParseIntParam(t *testing.T) {
 			w, r := newTestRequest(t, tt.query)
 
 			val, ok := parseIntParam(w, r, tt.param)
-			if ok != tt.wantOK {
-				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
-			}
-			if val != tt.wantVal {
-				t.Errorf("val = %d, want %d", val, tt.wantVal)
-			}
-			if w.Code != tt.wantStatus {
-				t.Errorf(
-					"status = %d, want %d", w.Code, tt.wantStatus,
-				)
-			}
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantVal, val)
+			assert.Equal(t, tt.wantStatus, w.Code)
 		})
 	}
 }
@@ -127,15 +121,9 @@ func TestParseNonNegativeIntParam(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w, r := newTestRequest(t, tt.query)
 			val, ok := parseNonNegativeIntParam(w, r, "cursor")
-			if ok != tt.wantOK {
-				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
-			}
-			if val != tt.wantVal {
-				t.Errorf("val = %d, want %d", val, tt.wantVal)
-			}
-			if w.Code != tt.wantStatus {
-				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
-			}
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantVal, val)
+			assert.Equal(t, tt.wantStatus, w.Code)
 		})
 	}
 }
@@ -158,11 +146,7 @@ func TestClampLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := clampLimit(tt.limit, defaultLimit, max)
-			if got != tt.want {
-				t.Errorf("clampLimit(%d, %d, %d) = %d, want %d",
-					tt.limit, defaultLimit, max, got, tt.want)
-			}
+			assert.Equal(t, tt.want, clampLimit(tt.limit, defaultLimit, max))
 		})
 	}
 }

--- a/internal/server/pins_test.go
+++ b/internal/server/pins_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -14,13 +17,11 @@ import (
 func pinSessionMessage(t *testing.T, te *testEnv, sessionID string) {
 	t.Helper()
 	msgs, err := te.db.GetMessages(context.Background(), sessionID, 0, 1, true)
-	if err != nil || len(msgs) == 0 {
-		t.Fatalf("pinSessionMessage: no messages in session %s (err=%v)", sessionID, err)
-	}
+	require.NoError(t, err, "pinSessionMessage: GetMessages for session %s", sessionID)
+	require.NotEmpty(t, msgs, "pinSessionMessage: no messages in session %s", sessionID)
 	id, err := te.db.PinMessage(sessionID, msgs[0].ID, nil)
-	if err != nil || id == 0 {
-		t.Fatalf("pinSessionMessage: PinMessage failed for session %s (id=%d, err=%v)", sessionID, id, err)
-	}
+	require.NoError(t, err, "pinSessionMessage: PinMessage for session %s", sessionID)
+	require.NotZero(t, id, "pinSessionMessage: PinMessage returned 0 id for session %s", sessionID)
 }
 
 func TestHandleListPins_NoFilter(t *testing.T) {
@@ -33,18 +34,12 @@ func TestHandleListPins_NoFilter(t *testing.T) {
 	pinSessionMessage(t, te, "s2")
 
 	w := te.get(t, "/api/v1/pins")
-	if w.Code != http.StatusOK {
-		t.Fatalf("GET /api/v1/pins: status %d, want 200", w.Code)
-	}
+	require.Equal(t, http.StatusOK, w.Code)
 	var resp struct {
 		Pins []db.PinnedMessage `json:"pins"`
 	}
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("decoding response: %v", err)
-	}
-	if len(resp.Pins) != 2 {
-		t.Errorf("got %d pins, want 2", len(resp.Pins))
-	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Len(t, resp.Pins, 2)
 }
 
 func TestHandleListPins_ProjectFilter(t *testing.T) {
@@ -71,19 +66,12 @@ func TestHandleListPins_ProjectFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("query="+tc.query, func(t *testing.T) {
 			w := te.get(t, "/api/v1/pins"+tc.query)
-			if w.Code != http.StatusOK {
-				t.Fatalf("GET /api/v1/pins%s: status %d, want 200", tc.query, w.Code)
-			}
+			require.Equal(t, http.StatusOK, w.Code, "GET /api/v1/pins%s", tc.query)
 			var resp struct {
 				Pins []db.PinnedMessage `json:"pins"`
 			}
-			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-				t.Fatalf("decoding response: %v", err)
-			}
-			if len(resp.Pins) != tc.wantCount {
-				t.Errorf("query %q: got %d pins, want %d",
-					tc.query, len(resp.Pins), tc.wantCount)
-			}
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+			assert.Len(t, resp.Pins, tc.wantCount, "query %q", tc.query)
 		})
 	}
 }

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -41,7 +44,7 @@ func assertSamePath(t *testing.T, label, got, want string) {
 	if gotErr == nil && wantErr == nil && os.SameFile(gotInfo, wantInfo) {
 		return
 	}
-	t.Errorf("%s = %q, want %q", label, got, want)
+	assert.Fail(t, "path mismatch", "%s = %q, want %q", label, got, want)
 }
 
 func TestResumeSession(t *testing.T) {
@@ -64,15 +67,9 @@ func TestResumeSession(t *testing.T) {
 			Command  string `json:"command"`
 			Cwd      string `json:"cwd"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp.Launched {
-			t.Error("expected launched=false for command_only")
-		}
-		if resp.Command == "" {
-			t.Error("expected non-empty command")
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
+		assert.NotEmpty(t, resp.Command)
 		assertSamePath(t, "cwd", resp.Cwd, projectDir)
 	})
 
@@ -100,16 +97,9 @@ func TestResumeSession(t *testing.T) {
 			Launched bool   `json:"launched"`
 			Command  string `json:"command"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp.Launched {
-			t.Error("expected launched=false for command_only")
-		}
-		wantCmd := "copilot --resume=abc123"
-		if resp.Command != wantCmd {
-			t.Errorf("command = %q, want %q", resp.Command, wantCmd)
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
+		assert.Equal(t, "copilot --resume=abc123", resp.Command)
 	})
 
 	t.Run("kiro current-store command only", func(t *testing.T) {
@@ -128,20 +118,14 @@ func TestResumeSession(t *testing.T) {
 			Command  string `json:"command"`
 			Cwd      string `json:"cwd"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp.Launched {
-			t.Error("expected launched=false for command_only")
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
 		const cmdSuffix = "' && kiro-cli chat --resume-id sqlite-chat"
 		if !strings.HasPrefix(resp.Command, "cd '") ||
 			!strings.HasSuffix(resp.Command, cmdSuffix) {
-			t.Errorf(
+			assert.Fail(t, "command shape mismatch",
 				"command = %q, want cd command ending with %q",
-				resp.Command,
-				cmdSuffix,
-			)
+				resp.Command, cmdSuffix)
 		} else {
 			commandCwd := strings.TrimSuffix(
 				strings.TrimPrefix(resp.Command, "cd '"),
@@ -166,16 +150,12 @@ func TestResumeSession(t *testing.T) {
 	t.Run("cursor command only", func(t *testing.T) {
 		projectDir := t.TempDir()
 		runDir := filepath.Join(projectDir, "frontend")
-		if err := os.MkdirAll(runDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(runDir, 0o755))
 		runDirJSON, _ := json.Marshal(runDir)
 		sessionFile := filepath.Join(t.TempDir(), "cursor.jsonl")
 		content := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` +
 			string(runDirJSON) + `}}]}}` + "\n"
-		if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(sessionFile, []byte(content), 0o644))
 		te.seedSession(t, "cursor:chat-1", projectDir, 3, func(s *db.Session) {
 			s.Agent = "cursor"
 			s.FilePath = &sessionFile
@@ -190,32 +170,23 @@ func TestResumeSession(t *testing.T) {
 			Command  string `json:"command"`
 			Cwd      string `json:"cwd"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp.Launched {
-			t.Error("expected launched=false for command_only")
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
 		wantProjectDir := canonicalTestPath(projectDir)
-		wantCmd := "cursor agent --resume chat-1 --workspace '" + wantProjectDir + "'"
-		if resp.Command != wantCmd {
-			t.Errorf("command = %q, want %q", resp.Command, wantCmd)
-		}
+		assert.Equal(t,
+			"cursor agent --resume chat-1 --workspace '"+wantProjectDir+"'",
+			resp.Command)
 		assertSamePath(t, "cwd", resp.Cwd, runDir)
 	})
 
 	t.Run("cursor command only falls back workspace to cwd", func(t *testing.T) {
 		runDir := filepath.Join(t.TempDir(), "frontend")
-		if err := os.MkdirAll(runDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(runDir, 0o755))
 		runDirJSON, _ := json.Marshal(runDir)
 		sessionFile := filepath.Join(t.TempDir(), "cursor.jsonl")
 		content := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` +
 			string(runDirJSON) + `}}]}}` + "\n"
-		if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(sessionFile, []byte(content), 0o644))
 		te.seedSession(t, "cursor:chat-2", "li_tools", 3, func(s *db.Session) {
 			s.Agent = "cursor"
 			s.FilePath = &sessionFile
@@ -230,17 +201,12 @@ func TestResumeSession(t *testing.T) {
 			Command  string `json:"command"`
 			Cwd      string `json:"cwd"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp.Launched {
-			t.Error("expected launched=false for command_only")
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
 		wantRunDir := canonicalTestPath(runDir)
-		wantCmd := "cursor agent --resume chat-2 --workspace '" + wantRunDir + "'"
-		if resp.Command != wantCmd {
-			t.Errorf("command = %q, want %q", resp.Command, wantCmd)
-		}
+		assert.Equal(t,
+			"cursor agent --resume chat-2 --workspace '"+wantRunDir+"'",
+			resp.Command)
 		assertSamePath(t, "cwd", resp.Cwd, runDir)
 	})
 
@@ -259,9 +225,7 @@ func TestResumeSession(t *testing.T) {
 		te.seedSession(t, "del-1", "/tmp", 3, func(s *db.Session) {
 			s.Agent = "claude"
 		})
-		if err := te.db.SoftDeleteSession("del-1"); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, te.db.SoftDeleteSession("del-1"))
 		w := te.post(t,
 			"/api/v1/sessions/del-1/resume",
 			`{"command_only":true}`,
@@ -282,9 +246,7 @@ func TestGetSessionDirectory(t *testing.T) {
 		var resp struct {
 			Path string `json:"path"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assertSamePath(t, "path", resp.Path, projectDir)
 	})
 
@@ -295,12 +257,8 @@ func TestGetSessionDirectory(t *testing.T) {
 		var resp struct {
 			Path string `json:"path"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp.Path != "" {
-			t.Errorf("path = %q, want empty", resp.Path)
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Empty(t, resp.Path)
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -310,15 +268,11 @@ func TestGetSessionDirectory(t *testing.T) {
 
 	t.Run("prefers session file cwd", func(t *testing.T) {
 		cwdDir := filepath.Join(t.TempDir(), "nested")
-		if err := os.Mkdir(cwdDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Mkdir(cwdDir, 0o755))
 		sessionFile := filepath.Join(t.TempDir(), "session.jsonl")
 		cwdJSON, _ := json.Marshal(cwdDir)
 		content := `{"cwd":` + string(cwdJSON) + "}\n"
-		if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(sessionFile, []byte(content), 0o644))
 		te.seedSession(t, "dir-3", projectDir, 3, func(s *db.Session) {
 			s.FilePath = &sessionFile
 		})
@@ -327,25 +281,19 @@ func TestGetSessionDirectory(t *testing.T) {
 		var resp struct {
 			Path string `json:"path"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assertSamePath(t, "path", resp.Path, cwdDir)
 	})
 
 	t.Run("cursor directory returns workspace root", func(t *testing.T) {
 		projectDir := t.TempDir()
 		runDir := filepath.Join(projectDir, "frontend")
-		if err := os.MkdirAll(runDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(runDir, 0o755))
 		runDirJSON, _ := json.Marshal(runDir)
 		sessionFile := filepath.Join(t.TempDir(), "cursor.jsonl")
 		content := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` +
 			string(runDirJSON) + `}}]}}` + "\n"
-		if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(sessionFile, []byte(content), 0o644))
 		te.seedSession(t, "dir-cursor", projectDir, 3, func(s *db.Session) {
 			s.Agent = "cursor"
 			s.FilePath = &sessionFile
@@ -356,9 +304,7 @@ func TestGetSessionDirectory(t *testing.T) {
 		var resp struct {
 			Path string `json:"path"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assertSamePath(t, "path", resp.Path, projectDir)
 	})
 }
@@ -377,14 +323,10 @@ func TestListOpeners(t *testing.T) {
 			Bin  string `json:"bin"`
 		} `json:"openers"`
 	}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	// The response should always be an array (possibly empty),
 	// never null.
-	if resp.Openers == nil {
-		t.Error("openers should be [] not null")
-	}
+	assert.NotNil(t, resp.Openers, "openers should be [] not null")
 }
 
 func TestGetTerminalConfig(t *testing.T) {
@@ -396,12 +338,8 @@ func TestGetTerminalConfig(t *testing.T) {
 		var resp struct {
 			Mode string `json:"mode"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp.Mode != "auto" {
-			t.Errorf("mode = %q, want %q", resp.Mode, "auto")
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "auto", resp.Mode)
 	})
 
 	t.Run("set and get", func(t *testing.T) {
@@ -416,12 +354,8 @@ func TestGetTerminalConfig(t *testing.T) {
 		var resp struct {
 			Mode string `json:"mode"`
 		}
-		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp.Mode != "clipboard" {
-			t.Errorf("mode = %q, want %q", resp.Mode, "clipboard")
-		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "clipboard", resp.Mode)
 	})
 
 	t.Run("invalid mode", func(t *testing.T) {

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -25,9 +28,7 @@ func assertSameDir(t *testing.T, label, got, want string) {
 	t.Helper()
 	got = canonicalTestDir(got)
 	want = canonicalTestDir(want)
-	if got != want {
-		t.Errorf("%s = %q, want %q", label, got, want)
-	}
+	assert.Equal(t, want, got, label)
 }
 
 func TestShellQuote(t *testing.T) {
@@ -51,12 +52,7 @@ func TestShellQuote(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := shellQuote(tt.in)
-			if got != tt.want {
-				t.Errorf(
-					"shellQuote(%q) = %q, want %q",
-					tt.in, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -69,9 +65,7 @@ func TestDetectTerminalLinux_NoTerminal(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("TERMINAL", "")
 	_, _, _, err := detectTerminalLinux("echo test")
-	if err == nil {
-		t.Error("expected error with empty PATH, got nil")
-	}
+	assert.Error(t, err, "expected error with empty PATH")
 }
 
 func TestDetectTerminalLinux_EnvTerminal(t *testing.T) {
@@ -81,25 +75,17 @@ func TestDetectTerminalLinux_EnvTerminal(t *testing.T) {
 	// Create a fake terminal binary on PATH.
 	binDir := t.TempDir()
 	fakeBin := filepath.Join(binDir, "myterm")
-	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t,
+		os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755),
+	)
 	t.Setenv("PATH", binDir)
 	t.Setenv("TERMINAL", "myterm")
 
 	bin, args, name, err := detectTerminalLinux("echo hello")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if bin != fakeBin {
-		t.Errorf("bin = %q, want %q", bin, fakeBin)
-	}
-	if name != "myterm" {
-		t.Errorf("name = %q, want %q", name, "myterm")
-	}
-	if len(args) == 0 {
-		t.Error("expected non-empty args")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, fakeBin, bin)
+	assert.Equal(t, "myterm", name)
+	assert.NotEmpty(t, args, "expected non-empty args")
 }
 
 func TestDetectTerminalLinux_EnvTerminalWithArgs(t *testing.T) {
@@ -108,26 +94,21 @@ func TestDetectTerminalLinux_EnvTerminalWithArgs(t *testing.T) {
 	}
 	binDir := t.TempDir()
 	fakeBin := filepath.Join(binDir, "kitty")
-	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t,
+		os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0o755),
+	)
 	t.Setenv("PATH", binDir)
 	t.Setenv("TERMINAL", "kitty --single-instance")
 
 	bin, args, name, err := detectTerminalLinux("echo hello")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if bin != fakeBin {
-		t.Errorf("bin = %q, want %q", bin, fakeBin)
-	}
-	if name != "kitty" {
-		t.Errorf("name = %q, want %q", name, "kitty")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, fakeBin, bin)
+	assert.Equal(t, "kitty", name)
 	// Should have --single-instance prepended before template args.
-	if len(args) < 2 || args[0] != "--single-instance" {
-		t.Errorf("args = %v, want --single-instance as first arg", args)
-	}
+	require.GreaterOrEqual(t, len(args), 2,
+		"args = %v, want --single-instance as first arg", args)
+	assert.Equal(t, "--single-instance", args[0],
+		"args = %v, want --single-instance as first arg", args)
 }
 
 func TestLaunchClaudeDesktop(t *testing.T) {
@@ -160,17 +141,13 @@ func TestLaunchClaudeDesktop(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := launchClaudeDesktop(tt.sessionID, tt.cwd)
-			if cmd.Path == "" {
-				t.Fatal("expected non-empty command path")
-			}
+			require.NotEmpty(t, cmd.Path,
+				"expected non-empty command path")
 			// The command should be "open <url>".
 			args := cmd.Args
-			if len(args) != 2 {
-				t.Fatalf("args = %v, want 2 elements", args)
-			}
-			if args[1] != tt.wantArg {
-				t.Errorf("url = %q, want %q", args[1], tt.wantArg)
-			}
+			require.Len(t, args, 2,
+				"args = %v, want 2 elements", args)
+			assert.Equal(t, tt.wantArg, args[1])
 		})
 	}
 }
@@ -180,9 +157,7 @@ func TestReadSessionCwd_LargeLine(t *testing.T) {
 	// old 2MB scanner limit without losing the cwd field.
 	dir := t.TempDir()
 	cwdDir := filepath.Join(dir, "project")
-	if err := os.Mkdir(cwdDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(cwdDir, 0o755))
 
 	cwdJSON, _ := json.Marshal(cwdDir)
 	// Build a 3MB padding string to exceed the old scanner limit.
@@ -191,45 +166,33 @@ func TestReadSessionCwd_LargeLine(t *testing.T) {
 		`,"big":"` + padding + `"}` + "\n"
 
 	sessionFile := filepath.Join(dir, "session.jsonl")
-	if err := os.WriteFile(sessionFile, []byte(line), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(sessionFile, []byte(line), 0o644))
 
 	got := readSessionCwd(sessionFile)
-	if got != cwdDir {
-		t.Errorf("readSessionCwd() = %q, want %q", got, cwdDir)
-	}
+	assert.Equal(t, cwdDir, got)
 }
 
 func TestReadSessionCwd_CopilotFormat(t *testing.T) {
 	dir := t.TempDir()
 	cwdDir := filepath.Join(dir, "project")
-	if err := os.Mkdir(cwdDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(cwdDir, 0o755))
 
 	cwdJSON, _ := json.Marshal(cwdDir)
 	line := `{"type":"session.start","data":{"sessionId":"abc","context":{"cwd":` +
 		string(cwdJSON) + `}}}` + "\n"
 
 	sessionFile := filepath.Join(dir, "session.jsonl")
-	if err := os.WriteFile(sessionFile, []byte(line), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(sessionFile, []byte(line), 0o644))
 
 	got := readSessionCwd(sessionFile)
-	if got != cwdDir {
-		t.Errorf("readSessionCwd() = %q, want %q", got, cwdDir)
-	}
+	assert.Equal(t, cwdDir, got)
 }
 
 func TestReadCursorLastWorkingDir(t *testing.T) {
 	dir := t.TempDir()
 	workspaceDir := filepath.Join(dir, "project")
 	lastDir := filepath.Join(workspaceDir, "frontend")
-	if err := os.MkdirAll(lastDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(lastDir, 0o755))
 
 	firstJSON, _ := json.Marshal(workspaceDir)
 	lastJSON, _ := json.Marshal(lastDir)
@@ -239,9 +202,7 @@ func TestReadCursorLastWorkingDir(t *testing.T) {
 		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` + string(firstJSON) + `}}]}}` + "\n" +
 		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":"relative/path"}}]}}` + "\n" +
 		`{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` + string(lastJSON) + `}}]}}` + "\n"
-	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(sessionFile, []byte(content), 0o644))
 
 	got := readCursorLastWorkingDir(sessionFile)
 	assertSameDir(t, "readCursorLastWorkingDir()", got, lastDir)
@@ -284,12 +245,7 @@ func TestCursorProjectDirNameFromTranscriptPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := cursorProjectDirNameFromTranscriptPath(tt.path)
-			if got != tt.want {
-				t.Errorf(
-					"cursorProjectDirNameFromTranscriptPath(%q) = %q, want %q",
-					tt.path, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -300,31 +256,20 @@ func TestResolveCursorProjectDirNameFromRoot(t *testing.T) {
 		root, "Users", "alice", "code", "li",
 		"project-cache-hdfs",
 	)
-	if err := os.MkdirAll(want, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(want, 0o755))
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "Users", "alice", "code", "li"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(
+	))
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "Users", "alice", "code", "li", "project"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	got := resolveCursorProjectDirNameFromRoot(
 		root, "Users-alice-code-li-project-cache-hdfs",
 	)
-	if got != want {
-		t.Errorf(
-			"resolveCursorProjectDirNameFromRoot() = %q, want %q",
-			got, want,
-		)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestResolveCursorProjectDirNameFromRootMatchesUnderscoreComponents(
@@ -335,19 +280,12 @@ func TestResolveCursorProjectDirNameFromRootMatchesUnderscoreComponents(
 		root, "Users", "alice", "code", "li",
 		"project_cache_hdfs",
 	)
-	if err := os.MkdirAll(want, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(want, 0o755))
 
 	got := resolveCursorProjectDirNameFromRoot(
 		root, "Users-alice-code-li-project-cache-hdfs",
 	)
-	if got != want {
-		t.Errorf(
-			"resolveCursorProjectDirNameFromRoot() = %q, want %q",
-			got, want,
-		)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestResolveCursorProjectDirFromSessionFileDetectsAmbiguity(
@@ -357,15 +295,11 @@ func TestResolveCursorProjectDirFromSessionFileDetectsAmbiguity(
 	want := filepath.Join(
 		root, "Users", "alice", "code", "li-tools",
 	)
-	if err := os.MkdirAll(want, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(want, 0o755))
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "Users", "alice", "code", "li", "tools"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	filePath := filepath.Join(
 		root, ".cursor", "projects",
@@ -381,15 +315,8 @@ func TestResolveCursorProjectDirFromSessionFileDetectsAmbiguity(
 		got = matches[0]
 	}
 	ambiguous := len(matches) > 1
-	if got != want {
-		t.Errorf(
-			"resolveCursorProjectDirFromSessionFile() = %q, want %q",
-			got, want,
-		)
-	}
-	if !ambiguous {
-		t.Error("expected ambiguous transcript path")
-	}
+	assert.Equal(t, want, got)
+	assert.True(t, ambiguous, "expected ambiguous transcript path")
 }
 
 func TestResolveCursorProjectDirFromSessionFileUnambiguous(
@@ -399,9 +326,7 @@ func TestResolveCursorProjectDirFromSessionFileUnambiguous(
 	want := filepath.Join(
 		root, "Users", "alice", "code", "li-openhouse",
 	)
-	if err := os.MkdirAll(want, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(want, 0o755))
 
 	filePath := filepath.Join(
 		root, ".cursor", "projects",
@@ -417,15 +342,8 @@ func TestResolveCursorProjectDirFromSessionFileUnambiguous(
 		got = matches[0]
 	}
 	ambiguous := len(matches) > 1
-	if got != want {
-		t.Errorf(
-			"resolveCursorProjectDirFromSessionFile() = %q, want %q",
-			got, want,
-		)
-	}
-	if ambiguous {
-		t.Error("expected unambiguous transcript path")
-	}
+	assert.Equal(t, want, got)
+	assert.False(t, ambiguous, "expected unambiguous transcript path")
 }
 
 func TestResolveCursorProjectDirNameFromRootBacktracksOnDeadEnd(
@@ -435,25 +353,16 @@ func TestResolveCursorProjectDirNameFromRootBacktracksOnDeadEnd(
 	want := filepath.Join(
 		root, "Users", "alice", "code", "li", "tools-app",
 	)
-	if err := os.MkdirAll(want, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(want, 0o755))
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "Users", "alice", "code", "li-tools"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	got := resolveCursorProjectDirNameFromRoot(
 		root, "Users-alice-code-li-tools-app",
 	)
-	if got != want {
-		t.Errorf(
-			"resolveCursorProjectDirNameFromRoot() = %q, want %q",
-			got, want,
-		)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestResolveCursorProjectDirNameFromRootHintPrefersContainingPath(
@@ -464,57 +373,38 @@ func TestResolveCursorProjectDirNameFromRootHintPrefersContainingPath(
 		root, "Users", "alice", "code", "li", "tools",
 	)
 	hint := filepath.Join(want, "frontend")
-	if err := os.MkdirAll(hint, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(hint, 0o755))
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "Users", "alice", "code", "li-tools"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	got := resolveCursorProjectDirNameFromRootHint(
 		root, "Users-alice-code-li-tools", hint,
 	)
-	if got != want {
-		t.Errorf(
-			"resolveCursorProjectDirNameFromRootHint() = %q, want %q",
-			got, want,
-		)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestResolveCursorProjectDirNameFromRootHintStaleReturnsEmpty(
 	t *testing.T,
 ) {
 	root := t.TempDir()
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "Users", "alice", "code", "li-tools"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(
+	))
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "Users", "alice", "code", "li", "tools"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	staleHint := filepath.Join(root, "unrelated")
-	if err := os.MkdirAll(staleHint, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(staleHint, 0o755))
 
 	got := resolveCursorProjectDirNameFromRootHint(
 		root, "Users-alice-code-li-tools", staleHint,
 	)
-	if got != "" {
-		t.Errorf(
-			"with stale hint = %q, want empty", got,
-		)
-	}
+	assert.Empty(t, got, "with stale hint = %q, want empty", got)
 }
 
 func TestResolveCursorProjectDirNameFromRootHintSymlinkMatch(
@@ -525,16 +415,12 @@ func TestResolveCursorProjectDirNameFromRootHintSymlinkMatch(
 	// Real project with a hint subdir.
 	realProject := filepath.Join(root, "repos", "li-tools")
 	hintDir := filepath.Join(realProject, "src")
-	if err := os.MkdirAll(hintDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(hintDir, 0o755))
 	// Second ambiguous path.
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(root, "repos", "li", "tools"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	// Symlink: root/code -> root/repos. The DFS walks through
 	// the symlink but the hint uses the resolved real path.
@@ -558,63 +444,43 @@ func TestResolveSessionDir(t *testing.T) {
 	// Create a session file with a cwd field.
 	sessionFile := filepath.Join(tmpDir, "session.jsonl")
 	cwdDir := filepath.Join(tmpDir, "project")
-	if err := os.Mkdir(cwdDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(cwdDir, 0o755))
 	cwdJSON, _ := json.Marshal(cwdDir)
 	content := `{"cwd":` + string(cwdJSON) + `}` + "\n"
-	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(sessionFile, []byte(content), 0o644))
 
 	kiroStoreDir := filepath.Join(tmpDir, "kiro-store")
-	if err := os.Mkdir(kiroStoreDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(kiroStoreDir, 0o755))
 	kiroProjectDir := filepath.Join(tmpDir, "kiro-project")
-	if err := os.Mkdir(kiroProjectDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.Mkdir(kiroProjectDir, 0o755))
 	kiroVirtualPath := filepath.Join(kiroStoreDir, "data.sqlite3") + "#sqlite-session"
 
 	hashPathDir := filepath.Join(tmpDir, "project#dev")
 	hashPathCwd := filepath.Join(hashPathDir, "workspace")
-	if err := os.MkdirAll(hashPathCwd, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(hashPathCwd, 0o755))
 	hashPathSessionFile := filepath.Join(hashPathDir, "session.jsonl")
 	hashPathCwdJSON, _ := json.Marshal(hashPathCwd)
 	hashPathContent := `{"cwd":` + string(hashPathCwdJSON) + `}` + "\n"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		hashPathSessionFile, []byte(hashPathContent), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	cursorProject := filepath.Join(
 		tmpDir, "workspace-root", "li-openhouse",
 	)
-	if err := os.MkdirAll(cursorProject, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(cursorProject, 0o755))
 	cursorTranscript := filepath.Join(
 		tmpDir, ".cursor", "projects",
 		encodeCursorProjectPathForTest(cursorProject),
 		"agent-transcripts", "cursor-sess",
 		"cursor-sess.jsonl",
 	)
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Dir(cursorTranscript), 0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(cursorTranscript, []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	))
+	require.NoError(t, os.WriteFile(cursorTranscript, []byte("{}\n"), 0o644))
 	cursorLastDir := filepath.Join(cursorProject, "frontend")
-	if err := os.MkdirAll(cursorLastDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(cursorLastDir, 0o755))
 	cursorLastDirJSON, _ := json.Marshal(cursorLastDir)
 	cursorTranscriptWithLastDir := filepath.Join(
 		tmpDir, ".cursor", "projects",
@@ -622,18 +488,14 @@ func TestResolveSessionDir(t *testing.T) {
 		"agent-transcripts", "cursor-sess-last",
 		"cursor-sess-last.jsonl",
 	)
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Dir(cursorTranscriptWithLastDir), 0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 	lastDirContent := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` +
 		string(cursorLastDirJSON) + `}}]}}` + "\n"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		cursorTranscriptWithLastDir, []byte(lastDirContent), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	tests := []struct {
 		name    string
@@ -739,20 +601,15 @@ func TestResolveSessionDir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resolveSessionDir(tt.session)
 			if tt.want == "" {
-				if got != "" {
-					t.Errorf(
-						"resolveSessionDir() = %q, want %q",
-						got, tt.want,
-					)
-				}
+				assert.Empty(t, got,
+					"resolveSessionDir() = %q, want empty", got)
 				return
 			}
-			if canonicalTestDir(got) != canonicalTestDir(tt.want) {
-				t.Errorf(
-					"resolveSessionDir() = %q, want %q",
-					canonicalTestDir(got), canonicalTestDir(tt.want),
-				)
-			}
+			assert.Equal(t,
+				canonicalTestDir(tt.want),
+				canonicalTestDir(got),
+				"resolveSessionDir()",
+			)
 		})
 	}
 }
@@ -764,9 +621,7 @@ func TestResolveResumeDir(t *testing.T) {
 		tmpDir, "workspace-root", "li-openhouse",
 	)
 	cursorLastDir := filepath.Join(cursorProject, "frontend")
-	if err := os.MkdirAll(cursorLastDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(cursorLastDir, 0o755))
 
 	cursorLastDirJSON, _ := json.Marshal(cursorLastDir)
 	cursorTranscript := filepath.Join(
@@ -775,18 +630,14 @@ func TestResolveResumeDir(t *testing.T) {
 		"agent-transcripts", "cursor-sess-last",
 		"cursor-sess-last.jsonl",
 	)
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Dir(cursorTranscript), 0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 	lastDirContent := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` +
 		string(cursorLastDirJSON) + `}}]}}` + "\n"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		cursorTranscript, []byte(lastDirContent), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	got := resolveResumeDir(&db.Session{
 		Agent:    "cursor",
@@ -803,15 +654,11 @@ func TestResolveCursorWorkspaceDirUsesLastWorkingDirHint(t *testing.T) {
 		tmpDir, "workspace-root", "li", "tools",
 	)
 	cursorLastDir := filepath.Join(cursorProject, "frontend")
-	if err := os.MkdirAll(cursorLastDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(cursorLastDir, 0o755))
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(tmpDir, "workspace-root", "li-tools"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	cursorLastDirJSON, _ := json.Marshal(cursorLastDir)
 	cursorTranscript := filepath.Join(
@@ -820,18 +667,14 @@ func TestResolveCursorWorkspaceDirUsesLastWorkingDirHint(t *testing.T) {
 		"agent-transcripts", "cursor-sess-last",
 		"cursor-sess-last.jsonl",
 	)
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Dir(cursorTranscript), 0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 	lastDirContent := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` +
 		string(cursorLastDirJSON) + `}}]}}` + "\n"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		cursorTranscript, []byte(lastDirContent), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	got := resolveCursorWorkspaceDir(&db.Session{
 		Agent:    "cursor",
@@ -849,12 +692,8 @@ func TestResolveCursorWorkspaceDirAmbiguousWithoutHintReturnsEmpty(
 	// Create two paths that decode from the same encoded name.
 	pathA := filepath.Join(tmpDir, "li-tools")
 	pathB := filepath.Join(tmpDir, "li", "tools")
-	if err := os.MkdirAll(pathA, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(pathB, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(pathA, 0o755))
+	require.NoError(t, os.MkdirAll(pathB, 0o755))
 
 	encoded := encodeCursorProjectPathForTest(pathA)
 	cursorTranscript := filepath.Join(
@@ -869,13 +708,9 @@ func TestResolveCursorWorkspaceDirAmbiguousWithoutHintReturnsEmpty(
 		Project:  "li_tools", // Not absolute — no hint.
 		FilePath: &cursorTranscript,
 	})
-	if got != "" {
-		t.Errorf(
-			"resolveCursorWorkspaceDir() = %q, want empty "+
-				"(ambiguous without hint)",
-			got,
-		)
-	}
+	assert.Empty(t, got,
+		"resolveCursorWorkspaceDir() = %q, want empty "+
+			"(ambiguous without hint)", got)
 }
 
 func TestResolveCursorWorkspaceDirStaleHintReturnsEmpty(
@@ -885,18 +720,12 @@ func TestResolveCursorWorkspaceDirStaleHintReturnsEmpty(
 
 	pathA := filepath.Join(tmpDir, "li-tools")
 	pathB := filepath.Join(tmpDir, "li", "tools")
-	if err := os.MkdirAll(pathA, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(pathB, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(pathA, 0o755))
+	require.NoError(t, os.MkdirAll(pathB, 0o755))
 
 	// Stale hint: exists on disk but not under either candidate.
 	staleDir := filepath.Join(tmpDir, "unrelated-project")
-	if err := os.MkdirAll(staleDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(staleDir, 0o755))
 
 	encoded := encodeCursorProjectPathForTest(pathA)
 	staleDirJSON, _ := json.Marshal(staleDir)
@@ -906,33 +735,25 @@ func TestResolveCursorWorkspaceDirStaleHintReturnsEmpty(
 		"agent-transcripts", "cursor-sess",
 		"cursor-sess.jsonl",
 	)
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(
 		filepath.Dir(cursorTranscript), 0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 	content := `{"role":"assistant","message":{"content":[` +
 		`{"type":"tool_use","name":"Shell","input":{` +
 		`"command":"pwd","working_directory":` +
 		string(staleDirJSON) + `}}]}}` + "\n"
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		cursorTranscript, []byte(content), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	got := resolveCursorWorkspaceDir(&db.Session{
 		Agent:    "cursor",
 		Project:  "li_tools",
 		FilePath: &cursorTranscript,
 	})
-	if got != "" {
-		t.Errorf(
-			"resolveCursorWorkspaceDir() with stale hint = %q, "+
-				"want empty",
-			got,
-		)
-	}
+	assert.Empty(t, got,
+		"resolveCursorWorkspaceDir() with stale hint = %q, want empty",
+		got)
 }
 
 func TestResolveCursorWorkspaceDirWithoutTranscriptContents(
@@ -943,9 +764,7 @@ func TestResolveCursorWorkspaceDirWithoutTranscriptContents(
 	cursorProject := filepath.Join(
 		tmpDir, "workspace-root", "li-openhouse",
 	)
-	if err := os.MkdirAll(cursorProject, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(cursorProject, 0o755))
 
 	cursorTranscript := filepath.Join(
 		tmpDir, ".cursor", "projects",
@@ -971,15 +790,11 @@ func TestResolveCursorResumePathsUsesProvidedLastWorkingDir(
 		tmpDir, "workspace-root", "li", "tools",
 	)
 	cursorLastDir := filepath.Join(cursorProject, "frontend")
-	if err := os.MkdirAll(cursorLastDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(
+	require.NoError(t, os.MkdirAll(cursorLastDir, 0o755))
+	require.NoError(t, os.MkdirAll(
 		filepath.Join(tmpDir, "workspace-root", "li-tools"),
 		0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	cursorTranscript := filepath.Join(
 		tmpDir, ".cursor", "projects",
@@ -1004,9 +819,7 @@ func TestResolveCursorResumePathsFallbackWorkspaceToLastWorkingDir(
 	t *testing.T,
 ) {
 	lastCwd := filepath.Join(t.TempDir(), "frontend")
-	if err := os.MkdirAll(lastCwd, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(lastCwd, 0o755))
 
 	launchDir, workspaceDir := resolveCursorResumePaths(
 		&db.Session{
@@ -1024,13 +837,9 @@ func TestResolveResumeDirCanonicalizesSymlink(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	realProject := filepath.Join(tmpDir, "repos", "openhouse")
-	if err := os.MkdirAll(realProject, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(realProject, 0o755))
 	cacheDir := filepath.Join(tmpDir, "project_cache_hdfs")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
 	linkProject := filepath.Join(cacheDir, "openhouse")
 	if err := os.Symlink(realProject, linkProject); err != nil {
 		t.Skipf("symlink not supported: %v", err)
@@ -1040,9 +849,7 @@ func TestResolveResumeDirCanonicalizesSymlink(t *testing.T) {
 	sessionFile := filepath.Join(tmpDir, "cursor-symlink.jsonl")
 	content := `{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"pwd","working_directory":` +
 		string(linkJSON) + `}}]}}` + "\n"
-	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(sessionFile, []byte(content), 0o644))
 
 	got := resolveResumeDir(&db.Session{
 		Agent:    "cursor",
@@ -1056,13 +863,9 @@ func TestResolveSessionDirCursorProjectFallbackCanonicalizesSymlink(t *testing.T
 	tmpDir := t.TempDir()
 
 	realProject := filepath.Join(tmpDir, "repos", "openhouse")
-	if err := os.MkdirAll(realProject, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(realProject, 0o755))
 	cacheDir := filepath.Join(tmpDir, "project_cache_hdfs")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
 	linkProject := filepath.Join(cacheDir, "openhouse")
 	if err := os.Symlink(realProject, linkProject); err != nil {
 		t.Skipf("symlink not supported: %v", err)
@@ -1141,12 +944,7 @@ func TestResumeLaunchCwd(t *testing.T) {
 			got := resumeLaunchCwd(
 				tt.agent, tt.openerID, tt.goos, cwd,
 			)
-			if got != tt.want {
-				t.Errorf(
-					"resumeLaunchCwd() = %q, want %q",
-					got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/server/search_content_test.go
+++ b/internal/server/search_content_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -42,10 +44,7 @@ func TestHandleSearchContentInvalidParams(t *testing.T) {
 			}
 			w := httptest.NewRecorder()
 			srv.handleSearchContent(w, req)
-			if w.Code != tt.wantStatus {
-				t.Errorf("status = %d, want %d: %s",
-					w.Code, tt.wantStatus, w.Body.String())
-			}
+			assert.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body.String())
 		})
 	}
 }
@@ -78,9 +77,7 @@ func TestIsLocalhostRequest(t *testing.T) {
 			if tt.header != "" {
 				req.Header.Set(tt.header, tt.value)
 			}
-			if got := isLocalhostRequest(req); got != tt.want {
-				t.Errorf("isLocalhostRequest = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, isLocalhostRequest(req))
 		})
 	}
 }

--- a/internal/server/search_test.go
+++ b/internal/server/search_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 )
@@ -26,11 +29,7 @@ func TestValidateSort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := validateSort(tt.sortParam)
-			if got != tt.wantSort {
-				t.Errorf("validateSort(%q) = %q, want %q",
-					tt.sortParam, got, tt.wantSort)
-			}
+			assert.Equal(t, tt.wantSort, validateSort(tt.sortParam))
 		})
 	}
 }
@@ -52,10 +51,7 @@ func TestPrepareFTSQuery(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := prepareFTSQuery(tt.raw)
-			if got != tt.want {
-				t.Errorf("prepareFTSQuery(%q) = %q, want %q", tt.raw, got, tt.want)
-			}
+			assert.Equal(t, tt.want, prepareFTSQuery(tt.raw))
 		})
 	}
 }
@@ -100,14 +96,8 @@ func TestHandleSearchSortParam(t *testing.T) {
 			)
 			w := httptest.NewRecorder()
 			srv.handleSearch(w, req)
-			if w.Code != http.StatusOK {
-				t.Fatalf("status = %d, want 200: %s",
-					w.Code, w.Body.String())
-			}
-			if spy.filter.Sort != tt.wantSort {
-				t.Errorf("SearchFilter.Sort = %q, want %q",
-					spy.filter.Sort, tt.wantSort)
-			}
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			assert.Equal(t, tt.wantSort, spy.filter.Sort)
 		})
 	}
 }

--- a/internal/server/secrets_test.go
+++ b/internal/server/secrets_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -15,10 +17,7 @@ func TestHandleScanSecretsReadOnly(t *testing.T) {
 	req.RemoteAddr = "127.0.0.1:1234"
 	w := httptest.NewRecorder()
 	srv.handleScanSecrets(w, req)
-	if w.Code != http.StatusNotImplemented {
-		t.Errorf("status = %d, want %d: %s",
-			w.Code, http.StatusNotImplemented, w.Body.String())
-	}
+	assert.Equal(t, http.StatusNotImplemented, w.Code, "body: %s", w.Body.String())
 }
 
 // TestHandleListSecretsRevealGate verifies the endpoint rejects reveal from a
@@ -55,10 +54,7 @@ func TestHandleListSecretsRevealGate(t *testing.T) {
 			}
 			w := httptest.NewRecorder()
 			srv.handleListSecrets(w, req)
-			if w.Code != tt.wantStatus {
-				t.Errorf("status = %d, want %d: %s",
-					w.Code, tt.wantStatus, w.Body.String())
-			}
+			assert.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body.String())
 		})
 	}
 }

--- a/internal/server/session_search_test.go
+++ b/internal/server/session_search_test.go
@@ -4,6 +4,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -109,13 +112,9 @@ func TestHandleSearchSession(t *testing.T) {
 			if resp.Ordinals == nil {
 				resp.Ordinals = []int{}
 			}
-			if len(resp.Ordinals) != len(tt.wantOrdinals) {
-				t.Fatalf("ordinals = %v, want %v", resp.Ordinals, tt.wantOrdinals)
-			}
+			require.Len(t, resp.Ordinals, len(tt.wantOrdinals), "ordinals = %v", resp.Ordinals)
 			for i, ord := range resp.Ordinals {
-				if ord != tt.wantOrdinals[i] {
-					t.Errorf("ordinal[%d] = %d, want %d", i, ord, tt.wantOrdinals[i])
-				}
+				assert.Equal(t, tt.wantOrdinals[i], ord, "ordinal[%d]", i)
 			}
 		})
 	}

--- a/internal/server/session_timing_test.go
+++ b/internal/server/session_timing_test.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 )
@@ -16,24 +19,12 @@ func TestHandleSessionTiming_OK(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	got := decode[db.SessionTiming](t, w)
-	if got.SessionID != "timing-handler-ok" {
-		t.Errorf("SessionID = %q, want timing-handler-ok",
-			got.SessionID)
-	}
-	if got.TurnCount != 1 {
-		t.Errorf("TurnCount = %d, want 1", got.TurnCount)
-	}
-	if got.ToolCallCount != 1 {
-		t.Errorf("ToolCallCount = %d, want 1", got.ToolCallCount)
-	}
-	if len(got.Turns) != 1 {
-		t.Fatalf("len(Turns) = %d, want 1", len(got.Turns))
-	}
-	if got.Turns[0].DurationMs == nil ||
-		*got.Turns[0].DurationMs != 29_000 {
-		t.Errorf("turn duration = %v, want 29000",
-			got.Turns[0].DurationMs)
-	}
+	assert.Equal(t, "timing-handler-ok", got.SessionID)
+	assert.Equal(t, 1, got.TurnCount)
+	assert.Equal(t, 1, got.ToolCallCount)
+	require.Len(t, got.Turns, 1)
+	require.NotNil(t, got.Turns[0].DurationMs)
+	assert.Equal(t, int64(29_000), *got.Turns[0].DurationMs)
 }
 
 func TestHandleSessionTiming_NotFound(t *testing.T) {
@@ -96,7 +87,5 @@ func seedTimingFixture(t *testing.T, d *db.DB, sessionID string) {
 			Timestamp:     "2026-04-26T10:00:30Z",
 		},
 	}
-	if err := d.ReplaceSessionMessages(sessionID, msgs); err != nil {
-		t.Fatalf("seeding timing fixture: %v", err)
-	}
+	require.NoError(t, d.ReplaceSessionMessages(sessionID, msgs))
 }

--- a/internal/server/statefile_test.go
+++ b/internal/server/statefile_test.go
@@ -8,50 +8,33 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteAndRemoveStateFile(t *testing.T) {
 	dir := t.TempDir()
 
 	path, err := WriteStateFile(dir, "127.0.0.1", 8080, "1.0.0", false)
-	if err != nil {
-		t.Fatalf("WriteStateFile: %v", err)
-	}
+	require.NoError(t, err)
 
-	want := filepath.Join(dir, "server.8080.json")
-	if path != want {
-		t.Errorf("path = %q, want %q", path, want)
-	}
+	assert.Equal(t, filepath.Join(dir, "server.8080.json"), path)
 
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("reading state file: %v", err)
-	}
+	require.NoError(t, err)
 
 	var sf StateFile
-	if err := json.Unmarshal(data, &sf); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if sf.Port != 8080 {
-		t.Errorf("port = %d, want 8080", sf.Port)
-	}
-	if sf.Host != "127.0.0.1" {
-		t.Errorf("host = %q, want 127.0.0.1", sf.Host)
-	}
-	if sf.Version != "1.0.0" {
-		t.Errorf("version = %q, want 1.0.0", sf.Version)
-	}
-	if sf.PID != os.Getpid() {
-		t.Errorf("pid = %d, want %d", sf.PID, os.Getpid())
-	}
-	if sf.StartedAt == "" {
-		t.Error("started_at is empty")
-	}
+	require.NoError(t, json.Unmarshal(data, &sf))
+	assert.Equal(t, 8080, sf.Port)
+	assert.Equal(t, "127.0.0.1", sf.Host)
+	assert.Equal(t, "1.0.0", sf.Version)
+	assert.Equal(t, os.Getpid(), sf.PID)
+	assert.NotEmpty(t, sf.StartedAt)
 
 	RemoveStateFile(dir, 8080)
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Error("state file not removed")
-	}
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "state file not removed")
 }
 
 // TestWriteStateFile_UsesProcessStartTime verifies that
@@ -69,23 +52,15 @@ func TestWriteStateFile_UsesProcessStartTime(t *testing.T) {
 	path, err := WriteStateFile(
 		dir, "127.0.0.1", 7777, "1.0.0", false,
 	)
-	if err != nil {
-		t.Fatalf("WriteStateFile: %v", err)
-	}
+	require.NoError(t, err)
 
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("reading state file: %v", err)
-	}
+	require.NoError(t, err)
 	var sf StateFile
-	if err := json.Unmarshal(data, &sf); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(data, &sf))
 
 	started, err := time.Parse(time.RFC3339, sf.StartedAt)
-	if err != nil {
-		t.Fatalf("parsing StartedAt: %v", err)
-	}
+	require.NoError(t, err)
 
 	// StartedAt should match the process start time, not
 	// time.Now(). With RFC3339Nano precision there is no
@@ -101,37 +76,20 @@ func TestWriteStateFile_UsesProcessStartTime(t *testing.T) {
 	if diffFromNow < 0 {
 		diffFromNow = -diffFromNow
 	}
-	if diffFromStart > time.Millisecond {
-		t.Errorf(
-			"StartedAt = %v, want ≈ process start %v "+
-				"(diff %v)",
-			started, procStart, diffFromStart,
-		)
-	}
-	if diffFromNow < diffFromStart {
-		t.Errorf(
-			"StartedAt %v is closer to Now %v than "+
-				"to process start %v; likely using "+
-				"time.Now() instead of process "+
-				"start time",
-			started, now, procStart,
-		)
-	}
+	assert.LessOrEqual(t, diffFromStart, time.Millisecond,
+		"StartedAt = %v, want ≈ process start %v", started, procStart)
+	assert.GreaterOrEqual(t, diffFromNow, diffFromStart,
+		"StartedAt %v is closer to Now %v than to process start %v",
+		started, now, procStart)
 
 	// The state file must pass hasLiveStateFile validation.
-	if !IsServerActive(dir) {
-		t.Error(
-			"state file written by WriteStateFile " +
-				"failed IsServerActive",
-		)
-	}
+	assert.True(t, IsServerActive(dir),
+		"state file written by WriteStateFile failed IsServerActive")
 }
 
 func TestFindRunningServer_NoFiles(t *testing.T) {
 	dir := t.TempDir()
-	if sf := FindRunningServer(dir); sf != nil {
-		t.Errorf("expected nil, got %+v", sf)
-	}
+	assert.Nil(t, FindRunningServer(dir))
 }
 
 func TestFindRunningServer_StaleFile(t *testing.T) {
@@ -149,15 +107,11 @@ func TestFindRunningServer_StaleFile(t *testing.T) {
 	path := filepath.Join(dir, "server.9999.json")
 	os.WriteFile(path, data, 0o644)
 
-	result := FindRunningServer(dir)
-	if result != nil {
-		t.Errorf("expected nil for stale PID, got %+v", result)
-	}
+	assert.Nil(t, FindRunningServer(dir), "expected nil for stale PID")
 
 	// Stale file should be cleaned up.
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Error("stale state file not cleaned up")
-	}
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "stale state file not cleaned up")
 }
 
 func TestFindRunningServer_InvalidJSON(t *testing.T) {
@@ -165,10 +119,7 @@ func TestFindRunningServer_InvalidJSON(t *testing.T) {
 	path := filepath.Join(dir, "server.8080.json")
 	os.WriteFile(path, []byte("not json"), 0o644)
 
-	result := FindRunningServer(dir)
-	if result != nil {
-		t.Errorf("expected nil for invalid JSON, got %+v", result)
-	}
+	assert.Nil(t, FindRunningServer(dir), "expected nil for invalid JSON")
 }
 
 func TestFindRunningServer_IgnoresNonStateFiles(t *testing.T) {
@@ -182,10 +133,7 @@ func TestFindRunningServer_IgnoresNonStateFiles(t *testing.T) {
 		[]byte("nope"), 0o644,
 	)
 
-	result := FindRunningServer(dir)
-	if result != nil {
-		t.Errorf("expected nil, got %+v", result)
-	}
+	assert.Nil(t, FindRunningServer(dir))
 }
 
 func TestFindRunningServer_LiveProcess(t *testing.T) {
@@ -193,9 +141,7 @@ func TestFindRunningServer_LiveProcess(t *testing.T) {
 
 	// Start a real TCP listener so the port probe succeeds.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
+	require.NoError(t, err)
 	defer ln.Close()
 
 	port := ln.Addr().(*net.TCPAddr).Port
@@ -211,32 +157,19 @@ func TestFindRunningServer_LiveProcess(t *testing.T) {
 	path := filepath.Join(
 		dir, fmt.Sprintf("server.%d.json", port),
 	)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatalf("write state file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, data, 0o644))
 
 	result := FindRunningServer(dir)
-	if result == nil {
-		t.Fatal("expected running server, got nil")
-		return
-	}
-	if result.Port != port {
-		t.Errorf("port = %d, want %d", result.Port, port)
-	}
-	if result.PID != os.Getpid() {
-		t.Errorf(
-			"pid = %d, want %d", result.PID, os.Getpid(),
-		)
-	}
+	require.NotNil(t, result, "expected running server")
+	assert.Equal(t, port, result.Port)
+	assert.Equal(t, os.Getpid(), result.PID)
 }
 
 func TestFindRunningServer_BindAll(t *testing.T) {
 	dir := t.TempDir()
 
 	ln, err := net.Listen("tcp", "0.0.0.0:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
+	require.NoError(t, err)
 	defer ln.Close()
 
 	port := ln.Addr().(*net.TCPAddr).Port
@@ -252,20 +185,11 @@ func TestFindRunningServer_BindAll(t *testing.T) {
 	path := filepath.Join(
 		dir, fmt.Sprintf("server.%d.json", port),
 	)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatalf("write state file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, data, 0o644))
 
 	result := FindRunningServer(dir)
-	if result == nil {
-		t.Fatal(
-			"expected running server for 0.0.0.0 host, got nil",
-		)
-		return
-	}
-	if result.Port != port {
-		t.Errorf("port = %d, want %d", result.Port, port)
-	}
+	require.NotNil(t, result, "expected running server for 0.0.0.0 host")
+	assert.Equal(t, port, result.Port)
 }
 
 // recentStartedAt returns a StartedAt timestamp that passes
@@ -304,19 +228,14 @@ func TestIsServerActive_LivePIDNoPort(t *testing.T) {
 	os.WriteFile(path, data, 0o644)
 
 	// FindRunningServer should return nil (no TCP).
-	if FindRunningServer(dir) != nil {
-		t.Error("expected FindRunningServer nil (no listener)")
-	}
+	assert.Nil(t, FindRunningServer(dir), "expected FindRunningServer nil (no listener)")
 
 	// But IsServerActive should return true (live PID).
-	if !IsServerActive(dir) {
-		t.Error("expected IsServerActive true for live PID")
-	}
+	assert.True(t, IsServerActive(dir), "expected IsServerActive true for live PID")
 
 	// State file should NOT be deleted.
-	if _, err := os.Stat(path); err != nil {
-		t.Error("state file was deleted despite live PID")
-	}
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr, "state file was deleted despite live PID")
 }
 
 // TestIsServerActive_LivePIDNoPort_NoStartupLock verifies
@@ -342,15 +261,9 @@ func TestIsServerActive_LivePIDNoPort_NoStartupLock(
 		filepath.Join(dir, "server.59998.json"), data, 0o644,
 	)
 
-	if FindRunningServer(dir) != nil {
-		t.Error("expected FindRunningServer nil")
-	}
-	if !IsServerActive(dir) {
-		t.Error("expected IsServerActive true")
-	}
-	if IsStartupLocked(dir) {
-		t.Error("expected IsStartupLocked false")
-	}
+	assert.Nil(t, FindRunningServer(dir), "expected FindRunningServer nil")
+	assert.True(t, IsServerActive(dir), "expected IsServerActive true")
+	assert.False(t, IsStartupLocked(dir), "expected IsStartupLocked false")
 }
 
 // TestIsServerActive_LongRunningServer verifies that a
@@ -372,14 +285,11 @@ func TestIsServerActive_LongRunningServer(t *testing.T) {
 	path := filepath.Join(dir, "server.59997.json")
 	os.WriteFile(path, data, 0o644)
 
-	if !IsServerActive(dir) {
-		t.Error("expected IsServerActive true for old but live PID")
-	}
+	assert.True(t, IsServerActive(dir), "expected IsServerActive true for old but live PID")
 
 	// State file must NOT be deleted.
-	if _, err := os.Stat(path); err != nil {
-		t.Error("state file was deleted for long-running server")
-	}
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr, "state file was deleted for long-running server")
 }
 
 // TestIsServerActive_PreBootStateFile verifies that a state
@@ -407,17 +317,12 @@ func TestIsServerActive_PreBootStateFile(t *testing.T) {
 	path := filepath.Join(dir, "server.59996.json")
 	os.WriteFile(path, data, 0o644)
 
-	if IsServerActive(dir) {
-		t.Error(
-			"expected false for pre-boot state file " +
-				"(PID reuse after reboot)",
-		)
-	}
+	assert.False(t, IsServerActive(dir),
+		"expected false for pre-boot state file (PID reuse after reboot)")
 
 	// Stale file should be cleaned up.
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Error("pre-boot state file was not cleaned up")
-	}
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "pre-boot state file was not cleaned up")
 }
 
 // TestIsServerActive_DeadPIDStateFile verifies that a state
@@ -437,14 +342,11 @@ func TestIsServerActive_DeadPIDStateFile(t *testing.T) {
 	path := filepath.Join(dir, "server.59994.json")
 	os.WriteFile(path, data, 0o644)
 
-	if IsServerActive(dir) {
-		t.Error("expected false for dead PID state file")
-	}
+	assert.False(t, IsServerActive(dir), "expected false for dead PID state file")
 
 	// Dead-PID state file should be cleaned up.
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Error("dead-PID state file not cleaned up")
-	}
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "dead-PID state file not cleaned up")
 }
 
 // TestIsServerActive_StartupLock verifies that IsServerActive
@@ -452,37 +354,25 @@ func TestIsServerActive_DeadPIDStateFile(t *testing.T) {
 func TestIsServerActive_StartupLock(t *testing.T) {
 	dir := t.TempDir()
 
-	if IsServerActive(dir) {
-		t.Fatal("expected false with no files")
-	}
+	require.False(t, IsServerActive(dir), "expected false with no files")
 
 	WriteStartupLock(dir)
-	if !IsServerActive(dir) {
-		t.Fatal("expected true with startup lock")
-	}
+	require.True(t, IsServerActive(dir), "expected true with startup lock")
 
 	RemoveStartupLock(dir)
-	if IsServerActive(dir) {
-		t.Fatal("expected false after lock removed")
-	}
+	require.False(t, IsServerActive(dir), "expected false after lock removed")
 }
 
 func TestStartupLock_OwnProcess(t *testing.T) {
 	dir := t.TempDir()
 
-	if isServerStarting(dir) {
-		t.Fatal("expected false before lock written")
-	}
+	require.False(t, isServerStarting(dir), "expected false before lock written")
 
 	WriteStartupLock(dir)
-	if !isServerStarting(dir) {
-		t.Fatal("expected true after lock written")
-	}
+	require.True(t, isServerStarting(dir), "expected true after lock written")
 
 	RemoveStartupLock(dir)
-	if isServerStarting(dir) {
-		t.Fatal("expected false after lock removed")
-	}
+	require.False(t, isServerStarting(dir), "expected false after lock removed")
 }
 
 func TestStartupLock_StalePID(t *testing.T) {
@@ -492,14 +382,11 @@ func TestStartupLock_StalePID(t *testing.T) {
 	path := filepath.Join(dir, startupLockFile(999999999))
 	os.WriteFile(path, []byte("999999999"), 0o644)
 
-	if isServerStarting(dir) {
-		t.Fatal("expected false for stale PID")
-	}
+	require.False(t, isServerStarting(dir), "expected false for stale PID")
 
 	// Stale lock should be cleaned up.
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Error("stale startup lock not cleaned up")
-	}
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "stale startup lock not cleaned up")
 }
 
 // TestStartupLock_MalformedContent verifies that a malformed
@@ -511,14 +398,11 @@ func TestStartupLock_MalformedContent(t *testing.T) {
 	path := filepath.Join(dir, startupLockPrefix+"bad")
 	os.WriteFile(path, []byte("not-a-pid"), 0o644)
 
-	if isServerStarting(dir) {
-		t.Fatal("expected false for malformed content")
-	}
+	require.False(t, isServerStarting(dir), "expected false for malformed content")
 
 	// File should NOT be deleted.
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		t.Error("malformed lock file was deleted")
-	}
+	_, statErr := os.Stat(path)
+	assert.False(t, os.IsNotExist(statErr), "malformed lock file was deleted")
 }
 
 // TestStartupLock_AtomicWrite verifies the lock file is written
@@ -530,49 +414,37 @@ func TestStartupLock_AtomicWrite(t *testing.T) {
 
 	path := filepath.Join(dir, startupLockFile(os.Getpid()))
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("reading lock: %v", err)
-	}
+	require.NoError(t, err)
 
-	want := fmt.Sprintf("%d", os.Getpid())
-	if string(data) != want {
-		t.Errorf("lock content = %q, want %q", data, want)
-	}
+	assert.Equal(t, fmt.Sprintf("%d", os.Getpid()), string(data))
 
 	// No temp file should remain.
 	tmpPath := path + ".tmp"
-	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
-		t.Error("temp file was not cleaned up")
-	}
+	_, tmpErr := os.Stat(tmpPath)
+	assert.True(t, os.IsNotExist(tmpErr), "temp file was not cleaned up")
 }
 
 func TestWaitForStartup_AlreadyRunning(t *testing.T) {
 	dir := t.TempDir()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
+	require.NoError(t, err)
 	defer ln.Close()
 
 	port := ln.Addr().(*net.TCPAddr).Port
 	WriteStateFile(dir, "127.0.0.1", port, "1.0.0", false)
 
 	// Should return immediately since server is running.
-	if !WaitForStartup(dir, 100*millisecondsForTest) {
-		t.Error("expected true, server is running")
-	}
+	assert.True(t, WaitForStartup(dir, 100*millisecondsForTest),
+		"expected true, server is running")
 }
 
 func TestWaitForStartup_LockClearsNoServer(t *testing.T) {
 	dir := t.TempDir()
 
 	// No lock, no server — should return false immediately.
-	if WaitForStartup(dir, 100*millisecondsForTest) {
-		t.Error(
-			"expected false, no lock and no server",
-		)
-	}
+	assert.False(t, WaitForStartup(dir, 100*millisecondsForTest),
+		"expected false, no lock and no server")
 }
 
 // millisecondsForTest is a scaling factor for test timeouts.
@@ -590,13 +462,8 @@ func TestProbeHostForDial(t *testing.T) {
 		{"192.168.1.100", "192.168.1.100"},
 	}
 	for _, tt := range tests {
-		got := probeHostForDial(tt.host)
-		if got != tt.want {
-			t.Errorf(
-				"probeHostForDial(%q) = %q, want %q",
-				tt.host, got, tt.want,
-			)
-		}
+		assert.Equal(t, tt.want, probeHostForDial(tt.host),
+			"probeHostForDial(%q)", tt.host)
 	}
 }
 
@@ -609,19 +476,12 @@ func TestProcessStartTime_OwnProcess(t *testing.T) {
 		t.Skipf("processStartTime not available: %v", err)
 	}
 	// Our process started before now.
-	if st.After(time.Now()) {
-		t.Errorf(
-			"process start time %v is in the future",
-			st,
-		)
-	}
+	assert.False(t, st.After(time.Now()),
+		"process start time %v is in the future", st)
 	// And after boot (if available).
 	if bt, btErr := systemBootTime(); btErr == nil {
-		if st.Before(bt) {
-			t.Errorf(
-				"start %v is before boot %v", st, bt,
-			)
-		}
+		assert.False(t, st.Before(bt),
+			"start %v is before boot %v", st, bt)
 	}
 }
 
@@ -673,19 +533,12 @@ func TestIsServerActive_SameBootPIDReuse(t *testing.T) {
 	path := filepath.Join(dir, "server.59995.json")
 	os.WriteFile(path, data, 0o644)
 
-	if IsServerActive(dir) {
-		t.Error(
-			"expected false for same-boot PID reuse",
-		)
-	}
+	assert.False(t, IsServerActive(dir), "expected false for same-boot PID reuse")
 
 	// Stale file should be cleaned up.
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Error(
-			"state file not cleaned up after " +
-				"PID reuse detection",
-		)
-	}
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr),
+		"state file not cleaned up after PID reuse detection")
 }
 
 // TestIsStaleByProcessStart_OwnPID verifies that
@@ -698,15 +551,13 @@ func TestIsStaleByProcessStart_OwnPID(t *testing.T) {
 	}
 
 	// Within tolerance — not stale.
-	if isStaleByProcessStart(os.Getpid(), procStart) {
-		t.Error("expected false for matching start time")
-	}
+	assert.False(t, isStaleByProcessStart(os.Getpid(), procStart),
+		"expected false for matching start time")
 
 	// Far off — stale.
 	fakeTime := procStart.Add(-1 * time.Hour)
-	if !isStaleByProcessStart(os.Getpid(), fakeTime) {
-		t.Error("expected true for mismatched start time")
-	}
+	assert.True(t, isStaleByProcessStart(os.Getpid(), fakeTime),
+		"expected true for mismatched start time")
 }
 
 // TestStateFile_ReadOnlyPersisted verifies that
@@ -720,28 +571,16 @@ func TestStateFile_ReadOnlyPersisted(t *testing.T) {
 	path, err := WriteStateFile(
 		dir, "127.0.0.1", 9876, "test", true,
 	)
-	if err != nil {
-		t.Fatalf("WriteStateFile: %v", err)
-	}
+	require.NoError(t, err)
 	defer RemoveStateFile(dir, 9876)
 
 	raw, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("reading state file: %v", err)
-	}
+	require.NoError(t, err)
 	var sf StateFile
-	if err := json.Unmarshal(raw, &sf); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if !sf.ReadOnly {
-		t.Error("ReadOnly = false, want true")
-	}
-	if sf.Port != 9876 {
-		t.Errorf("port = %d, want 9876", sf.Port)
-	}
-	if sf.Version != "test" {
-		t.Errorf("version = %q, want test", sf.Version)
-	}
+	require.NoError(t, json.Unmarshal(raw, &sf))
+	assert.True(t, sf.ReadOnly)
+	assert.Equal(t, 9876, sf.Port)
+	assert.Equal(t, "test", sf.Version)
 }
 
 // TestStateFile_ReadOnlyDefaultsToFalse verifies that
@@ -755,22 +594,14 @@ func TestStateFile_ReadOnlyDefaultsToFalse(t *testing.T) {
 	path, err := WriteStateFile(
 		dir, "127.0.0.1", 9877, "test", false,
 	)
-	if err != nil {
-		t.Fatalf("WriteStateFile: %v", err)
-	}
+	require.NoError(t, err)
 	defer RemoveStateFile(dir, 9877)
 
 	raw, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("reading state file: %v", err)
-	}
+	require.NoError(t, err)
 	var sf StateFile
-	if err := json.Unmarshal(raw, &sf); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if sf.ReadOnly {
-		t.Error("ReadOnly = true, want false")
-	}
+	require.NoError(t, json.Unmarshal(raw, &sf))
+	assert.False(t, sf.ReadOnly)
 }
 
 func TestStateFileName(t *testing.T) {
@@ -783,12 +614,7 @@ func TestStateFileName(t *testing.T) {
 		{443, "server.443.json"},
 	}
 	for _, tt := range tests {
-		got := stateFileName(tt.port)
-		if got != tt.want {
-			t.Errorf(
-				"stateFileName(%d) = %q, want %q",
-				tt.port, got, tt.want,
-			)
-		}
+		assert.Equal(t, tt.want, stateFileName(tt.port),
+			"stateFileName(%d)", tt.port)
 	}
 }

--- a/internal/server/timeout_custom_test.go
+++ b/internal/server/timeout_custom_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithTimeout(t *testing.T) {
@@ -67,18 +70,14 @@ func TestWithTimeout(t *testing.T) {
 			assertRecorderStatus(t, w, tt.wantStatus)
 
 			if tt.wantHeaderKey != "" {
-				if val := resp.Header.Get(tt.wantHeaderKey); val != tt.wantHeaderVal {
-					t.Errorf("expected header %s=%q, got %q", tt.wantHeaderKey, tt.wantHeaderVal, val)
-				}
+				assert.Equal(t, tt.wantHeaderVal,
+					resp.Header.Get(tt.wantHeaderKey),
+					"header %s", tt.wantHeaderKey)
 			}
 
 			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatalf("failed to read body: %v", err)
-			}
-			if string(body) != tt.wantBody {
-				t.Errorf("expected body %q, got %q", tt.wantBody, string(body))
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBody, string(body))
 		})
 	}
 }

--- a/internal/server/timeout_test.go
+++ b/internal/server/timeout_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
@@ -45,19 +47,13 @@ func TestServerTimeouts(t *testing.T) {
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodGet, url, nil,
 	)
-	if err != nil {
-		t.Fatalf("creating request: %v", err)
-	}
+	require.NoError(t, err)
 
 	resp, err := (&http.Client{}).Do(req)
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
+	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
-	}
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Trigger an update after 500ms (> WriteTimeout).
 	errCh := make(chan error, 1)

--- a/internal/server/trends_test.go
+++ b/internal/server/trends_test.go
@@ -6,6 +6,9 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -36,16 +39,11 @@ func TestTrendsTermsEndpoint(t *testing.T) {
 	}))
 	assertStatus(t, w, http.StatusOK)
 	resp := decode[db.TrendsTermsResponse](t, w)
-	if want := []string{"2024-05-27"}; !slices.Equal(trendBucketDates(resp.Buckets), want) {
-		t.Fatalf("bucket dates = %#v, want %#v", trendBucketDates(resp.Buckets), want)
-	}
+	require.True(t, slices.Equal(trendBucketDates(resp.Buckets), []string{"2024-05-27"}),
+		"bucket dates = %#v", trendBucketDates(resp.Buckets))
 	byTerm := trendSeriesByTerm(resp.Series)
-	if got := byTerm["load bearing"].Total; got != 2 {
-		t.Fatalf("load bearing total = %d, want 2", got)
-	}
-	if got := byTerm["seam"].Total; got != 2 {
-		t.Fatalf("seam total = %d, want 2", got)
-	}
+	assert.Equal(t, 2, byTerm["load bearing"].Total, "load bearing total")
+	assert.Equal(t, 2, byTerm["seam"].Total, "seam total")
 }
 
 func TestTrendsTermsValidation(t *testing.T) {
@@ -100,9 +98,7 @@ func TestTrendsTermsProjectFilter(t *testing.T) {
 	}))
 	assertStatus(t, w, http.StatusOK)
 	resp := decode[db.TrendsTermsResponse](t, w)
-	if got := trendSeriesByTerm(resp.Series)["seam"].Total; got != 1 {
-		t.Fatalf("project-filtered total = %d, want 1", got)
-	}
+	assert.Equal(t, 1, trendSeriesByTerm(resp.Series)["seam"].Total, "project-filtered total")
 }
 
 func trendsURL(q url.Values) string {

--- a/internal/server/update_test.go
+++ b/internal/server/update_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/server"
 	"go.kenn.io/agentsview/internal/update"
@@ -33,15 +35,8 @@ func TestCheckUpdateUpToDate(t *testing.T) {
 	assertStatus(t, w, 200)
 
 	resp := decode[updateCheckResp](t, w)
-	if resp.CurrentVersion != "v1.0.0" {
-		t.Errorf(
-			"current_version = %q, want %q",
-			resp.CurrentVersion, "v1.0.0",
-		)
-	}
-	if resp.UpdateAvailable {
-		t.Error("expected update_available=false when up to date")
-	}
+	assert.Equal(t, "v1.0.0", resp.CurrentVersion)
+	assert.False(t, resp.UpdateAvailable, "expected update_available=false when up to date")
 }
 
 func TestCheckUpdateAvailable(t *testing.T) {
@@ -66,21 +61,9 @@ func TestCheckUpdateAvailable(t *testing.T) {
 	assertStatus(t, w, 200)
 
 	resp := decode[updateCheckResp](t, w)
-	if !resp.UpdateAvailable {
-		t.Error("expected update_available=true")
-	}
-	if resp.LatestVersion != "v1.0.0" {
-		t.Errorf(
-			"latest_version = %q, want %q",
-			resp.LatestVersion, "v1.0.0",
-		)
-	}
-	if resp.CurrentVersion != "v0.9.0" {
-		t.Errorf(
-			"current_version = %q, want %q",
-			resp.CurrentVersion, "v0.9.0",
-		)
-	}
+	assert.True(t, resp.UpdateAvailable)
+	assert.Equal(t, "v1.0.0", resp.LatestVersion)
+	assert.Equal(t, "v0.9.0", resp.CurrentVersion)
 }
 
 func TestCheckUpdateDevBuild(t *testing.T) {
@@ -106,20 +89,9 @@ func TestCheckUpdateDevBuild(t *testing.T) {
 	assertStatus(t, w, 200)
 
 	resp := decode[updateCheckResp](t, w)
-	if resp.UpdateAvailable {
-		t.Error(
-			"expected update_available=false for dev build",
-		)
-	}
-	if !resp.IsDevBuild {
-		t.Error("expected is_dev_build=true")
-	}
-	if resp.CurrentVersion != "dev" {
-		t.Errorf(
-			"current_version = %q, want %q",
-			resp.CurrentVersion, "dev",
-		)
-	}
+	assert.False(t, resp.UpdateAvailable, "expected update_available=false for dev build")
+	assert.True(t, resp.IsDevBuild)
+	assert.Equal(t, "dev", resp.CurrentVersion)
 }
 
 func TestCheckUpdateError(t *testing.T) {
@@ -140,17 +112,8 @@ func TestCheckUpdateError(t *testing.T) {
 	assertStatus(t, w, 200)
 
 	resp := decode[updateCheckResp](t, w)
-	if resp.CurrentVersion != "v1.0.0" {
-		t.Errorf(
-			"current_version = %q, want %q",
-			resp.CurrentVersion, "v1.0.0",
-		)
-	}
-	if resp.UpdateAvailable {
-		t.Error(
-			"expected update_available=false on error",
-		)
-	}
+	assert.Equal(t, "v1.0.0", resp.CurrentVersion)
+	assert.False(t, resp.UpdateAvailable, "expected update_available=false on error")
 }
 
 func TestCheckUpdateDisabled(t *testing.T) {
@@ -177,17 +140,8 @@ func TestCheckUpdateDisabled(t *testing.T) {
 	assertStatus(t, w, 200)
 
 	resp := decode[updateCheckResp](t, w)
-	if resp.UpdateAvailable {
-		t.Error(
-			"expected update_available=false when disabled",
-		)
-	}
-	if resp.CurrentVersion != "v1.0.0" {
-		t.Errorf(
-			"current_version = %q, want %q",
-			resp.CurrentVersion, "v1.0.0",
-		)
-	}
+	assert.False(t, resp.UpdateAvailable, "expected update_available=false when disabled")
+	assert.Equal(t, "v1.0.0", resp.CurrentVersion)
 }
 
 type updateCheckResp struct {

--- a/internal/server/upload_failure_test.go
+++ b/internal/server/upload_failure_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/server"
@@ -44,12 +47,8 @@ func TestUploadSession_SaveFailure(t *testing.T) {
 	// to force os.MkdirAll to fail
 	projectName := "failproj"
 	projectPath := filepath.Join(te.dataDir, "uploads", projectName)
-	if err := os.MkdirAll(filepath.Dir(projectPath), 0o755); err != nil {
-		t.Fatalf("creating uploads dir: %v", err)
-	}
-	if err := os.WriteFile(projectPath, nil, 0o644); err != nil {
-		t.Fatalf("creating conflict file: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(projectPath), 0o755))
+	require.NoError(t, os.WriteFile(projectPath, nil, 0o644))
 
 	w := te.upload(t, "test.jsonl", "{}", "project="+projectName)
 	assertStatus(t, w, http.StatusInternalServerError)
@@ -76,9 +75,7 @@ func TestUploadSession_CommitFailureDoesNotWriteDB(t *testing.T) {
 	finalPath := filepath.Join(
 		te.dataDir, "uploads", project, filename,
 	)
-	if err := os.MkdirAll(finalPath, 0o755); err != nil {
-		t.Fatalf("creating final path directory: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(finalPath, 0o755))
 
 	content := testjsonl.NewSessionBuilder().
 		AddClaudeUser("2024-01-01T10:00:00Z", "hello").
@@ -91,12 +88,8 @@ func TestUploadSession_CommitFailureDoesNotWriteDB(t *testing.T) {
 	sess, err := te.db.GetSessionFull(
 		context.Background(), "rename-fail",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if sess != nil {
-		t.Fatalf("session persisted despite upload commit failure: %+v", sess)
-	}
+	require.NoError(t, err)
+	assert.Nil(t, sess, "session persisted despite upload commit failure")
 }
 
 func TestUploadSession_DBCommitFailureAfterFileCommitRollsBackUpload(
@@ -124,15 +117,10 @@ func TestUploadSession_DBCommitFailureAfterFileCommitRollsBackUpload(
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
 	fw, err := mw.CreateFormFile("file", filename)
-	if err != nil {
-		t.Fatalf("creating form file: %v", err)
-	}
-	if _, err := fw.Write([]byte(content)); err != nil {
-		t.Fatalf("writing form file: %v", err)
-	}
-	if err := mw.Close(); err != nil {
-		t.Fatalf("closing multipart writer: %v", err)
-	}
+	require.NoError(t, err)
+	_, err = fw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
 
 	req := httptest.NewRequest(http.MethodPost,
 		"/api/v1/sessions/upload?project="+project+"&machine=remote", &buf)
@@ -145,9 +133,8 @@ func TestUploadSession_DBCommitFailureAfterFileCommitRollsBackUpload(
 
 	assertStatus(t, w, http.StatusInternalServerError)
 	assertErrorResponse(t, w, "failed to save session to database")
-	if _, err := os.Stat(finalPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("upload file exists after DB commit failure: %v", err)
-	}
+	_, statErr := os.Stat(finalPath)
+	require.ErrorIs(t, statErr, os.ErrNotExist, "upload file exists after DB commit failure")
 }
 
 func TestUploadSession_DBCommitFailureAfterReplacingFileRestoresPrevious(
@@ -159,13 +146,9 @@ func TestUploadSession_DBCommitFailureAfterReplacingFileRestoresPrevious(
 		filename = "replace-then-commit-fails.jsonl"
 	)
 	finalPath := filepath.Join(dir, "uploads", project, filename)
-	if err := os.MkdirAll(filepath.Dir(finalPath), 0o755); err != nil {
-		t.Fatalf("creating upload dir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(finalPath), 0o755))
 	previous := []byte("previous file contents")
-	if err := os.WriteFile(finalPath, previous, 0o644); err != nil {
-		t.Fatalf("writing previous upload: %v", err)
-	}
+	require.NoError(t, os.WriteFile(finalPath, previous, 0o644))
 
 	srv := server.New(config.Config{
 		Host:         "127.0.0.1",
@@ -182,15 +165,10 @@ func TestUploadSession_DBCommitFailureAfterReplacingFileRestoresPrevious(
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
 	fw, err := mw.CreateFormFile("file", filename)
-	if err != nil {
-		t.Fatalf("creating form file: %v", err)
-	}
-	if _, err := fw.Write([]byte(content)); err != nil {
-		t.Fatalf("writing form file: %v", err)
-	}
-	if err := mw.Close(); err != nil {
-		t.Fatalf("closing multipart writer: %v", err)
-	}
+	require.NoError(t, err)
+	_, err = fw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
 
 	req := httptest.NewRequest(http.MethodPost,
 		"/api/v1/sessions/upload?project="+project+"&machine=remote", &buf)
@@ -204,10 +182,6 @@ func TestUploadSession_DBCommitFailureAfterReplacingFileRestoresPrevious(
 	assertStatus(t, w, http.StatusInternalServerError)
 	assertErrorResponse(t, w, "failed to save session to database")
 	got, err := os.ReadFile(finalPath)
-	if err != nil {
-		t.Fatalf("reading restored upload: %v", err)
-	}
-	if !bytes.Equal(got, previous) {
-		t.Fatalf("restored file = %q, want %q", got, previous)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, previous, got, "restored file differs")
 }

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -1,17 +1,12 @@
 package server
 
 import (
-	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"go.kenn.io/agentsview/internal/db"
 )
-
-// approxEqual returns true if a and b are within eps (for
-// float comparisons that have rounding from division).
-func approxEqual(a, b, eps float64) bool {
-	return math.Abs(a-b) <= eps
-}
 
 func TestComputeCacheStats_SavingsPassThrough(t *testing.T) {
 	// SavingsVsUncached is now computed per-model in the DB
@@ -32,25 +27,15 @@ func TestComputeCacheStats_SavingsPassThrough(t *testing.T) {
 			cs := computeCacheStats(db.UsageTotals{
 				CacheSavings: tc.in,
 			})
-			if !approxEqual(cs.SavingsVsUncached, tc.in, 1e-9) {
-				t.Errorf(
-					"SavingsVsUncached = %v, want %v",
-					cs.SavingsVsUncached, tc.in,
-				)
-			}
+			assert.InDelta(t, tc.in, cs.SavingsVsUncached, 1e-9)
 		})
 	}
 }
 
 func TestComputeCacheStats_ZeroTotalsIsZero(t *testing.T) {
 	cs := computeCacheStats(db.UsageTotals{})
-	if cs.SavingsVsUncached != 0 {
-		t.Errorf("SavingsVsUncached = %v, want 0",
-			cs.SavingsVsUncached)
-	}
-	if cs.HitRate != 0 {
-		t.Errorf("HitRate = %v, want 0", cs.HitRate)
-	}
+	assert.Zero(t, cs.SavingsVsUncached)
+	assert.Zero(t, cs.HitRate)
 }
 
 func TestComputeCacheStats_HitRate(t *testing.T) {
@@ -63,9 +48,7 @@ func TestComputeCacheStats_HitRate(t *testing.T) {
 		CacheReadTokens: 800,
 	})
 	// denom = 800 + 200 = 1000; hit = 800/1000 = 0.80.
-	if !approxEqual(cs.HitRate, 0.80, 1e-9) {
-		t.Errorf("HitRate = %v, want ~0.80", cs.HitRate)
-	}
+	assert.InDelta(t, 0.80, cs.HitRate, 1e-9)
 }
 
 func TestComputeCacheStats_UncachedPassesInputThrough(t *testing.T) {
@@ -80,17 +63,8 @@ func TestComputeCacheStats_UncachedPassesInputThrough(t *testing.T) {
 		CacheReadTokens:     200,
 		CacheCreationTokens: 50,
 	})
-	if cs.UncachedInputTokens != 100 {
-		t.Errorf("UncachedInputTokens = %d, want 100",
-			cs.UncachedInputTokens)
-	}
+	assert.Equal(t, 100, cs.UncachedInputTokens)
 	// And the cache buckets are reported verbatim alongside it.
-	if cs.CacheReadTokens != 200 {
-		t.Errorf("CacheReadTokens = %d, want 200",
-			cs.CacheReadTokens)
-	}
-	if cs.CacheCreationTokens != 50 {
-		t.Errorf("CacheCreationTokens = %d, want 50",
-			cs.CacheCreationTokens)
-	}
+	assert.Equal(t, 200, cs.CacheReadTokens)
+	assert.Equal(t, 50, cs.CacheCreationTokens)
 }

--- a/internal/server/usage_readonly_internal_test.go
+++ b/internal/server/usage_readonly_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -71,12 +73,8 @@ func TestUsageHandlers_ReturnNotImplementedOnReadOnlyStore(
 			)
 			w := httptest.NewRecorder()
 			tc.handler(w, req)
-			if w.Code != http.StatusNotImplemented {
-				t.Errorf(
-					"status = %d, want 501; body=%s",
-					w.Code, w.Body.String(),
-				)
-			}
+			assert.Equal(t, http.StatusNotImplemented, w.Code,
+				"body=%s", w.Body.String())
 		})
 	}
 }

--- a/internal/server/usage_test.go
+++ b/internal/server/usage_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/server"
 )
@@ -25,16 +28,10 @@ func TestParseUsageFilterDefaults(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	resp := decode[server.UsageSummaryResponse](t, w)
-	if resp.From == "" {
-		t.Error("From is empty, expected defaulted value")
-	}
-	if resp.To == "" {
-		t.Error("To is empty, expected defaulted value")
-	}
+	assert.NotEmpty(t, resp.From, "expected defaulted From")
+	assert.NotEmpty(t, resp.To, "expected defaulted To")
 	// from should be ~30 days before to.
-	if resp.From >= resp.To {
-		t.Errorf("From %q >= To %q", resp.From, resp.To)
-	}
+	assert.Less(t, resp.From, resp.To)
 }
 
 func TestParseUsageFilterExplicit(t *testing.T) {
@@ -52,12 +49,8 @@ func TestParseUsageFilterExplicit(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	resp := decode[server.UsageSummaryResponse](t, w)
-	if resp.From != "2024-06-01" {
-		t.Errorf("From = %q, want 2024-06-01", resp.From)
-	}
-	if resp.To != "2024-06-15" {
-		t.Errorf("To = %q, want 2024-06-15", resp.To)
-	}
+	assert.Equal(t, "2024-06-01", resp.From)
+	assert.Equal(t, "2024-06-15", resp.To)
 }
 
 func TestParseUsageFilterDefaultsIncludeOneShot(t *testing.T) {
@@ -90,10 +83,7 @@ func TestParseUsageFilterDefaultsIncludeOneShot(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	resp := decode[server.UsageSummaryResponse](t, w)
-	if resp.SessionCounts.Total != 1 {
-		t.Fatalf("SessionCounts.Total = %d, want 1",
-			resp.SessionCounts.Total)
-	}
+	require.Equal(t, 1, resp.SessionCounts.Total)
 }
 
 func TestParseUsageFilterInvalidDate(t *testing.T) {
@@ -154,11 +144,7 @@ func TestHandleUsageSummaryJSONShape(t *testing.T) {
 
 	// Verify all expected top-level keys exist.
 	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(
-		w.Body.Bytes(), &raw,
-	); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
 
 	required := []string{
 		"from", "to", "totals", "daily",
@@ -166,24 +152,14 @@ func TestHandleUsageSummaryJSONShape(t *testing.T) {
 		"sessionCounts", "cacheStats",
 	}
 	for _, key := range required {
-		if _, ok := raw[key]; !ok {
-			t.Errorf("missing key %q in response", key)
-		}
+		assert.Contains(t, raw, key, "missing key in response")
 	}
 
 	resp := decode[server.UsageSummaryResponse](t, w)
-	if len(resp.Daily) == 0 {
-		t.Error("Daily is empty, expected entries")
-	}
-	if len(resp.ProjectTotals) == 0 {
-		t.Error("ProjectTotals is empty")
-	}
-	if len(resp.ModelTotals) == 0 {
-		t.Error("ModelTotals is empty")
-	}
-	if len(resp.AgentTotals) == 0 {
-		t.Error("AgentTotals is empty")
-	}
+	assert.NotEmpty(t, resp.Daily)
+	assert.NotEmpty(t, resp.ProjectTotals)
+	assert.NotEmpty(t, resp.ModelTotals)
+	assert.NotEmpty(t, resp.AgentTotals)
 }
 
 func TestHandleUsageTopSessionsEmpty(t *testing.T) {
@@ -199,14 +175,8 @@ func TestHandleUsageTopSessionsEmpty(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	var entries []db.TopSessionEntry
-	if err := json.Unmarshal(
-		w.Body.Bytes(), &entries,
-	); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if entries == nil {
-		t.Error("expected non-null JSON array")
-	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &entries))
+	assert.NotNil(t, entries, "expected non-null JSON array")
 }
 
 func TestHandleUsageTopSessionsLimit(t *testing.T) {
@@ -224,15 +194,8 @@ func TestHandleUsageTopSessionsLimit(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 
 	var entries []db.TopSessionEntry
-	if err := json.Unmarshal(
-		w.Body.Bytes(), &entries,
-	); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if len(entries) > 1 {
-		t.Errorf("len(entries) = %d, want <= 1",
-			len(entries))
-	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &entries))
+	assert.LessOrEqual(t, len(entries), 1)
 }
 
 // TestUsageSummaryErrorRedaction verifies internal errors
@@ -265,9 +228,7 @@ func TestUsageRoutesRegistered(t *testing.T) {
 			)
 			w := httptest.NewRecorder()
 			te.handler.ServeHTTP(w, req)
-			if w.Code == http.StatusNotFound {
-				t.Errorf("%s returned 404", ep)
-			}
+			assert.NotEqual(t, http.StatusNotFound, w.Code, "%s returned 404", ep)
 		})
 	}
 }

--- a/internal/server/worktree_mappings_test.go
+++ b/internal/server/worktree_mappings_test.go
@@ -10,6 +10,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -22,15 +25,9 @@ func TestWorktreeMappingsAPIUsesCurrentMachine(t *testing.T) {
 		"project":     "canonical-app",
 		"machine":     "other-machine",
 	})
-	if created.Machine != "test" {
-		t.Fatalf("machine = %q, want test", created.Machine)
-	}
-	if created.Project != "canonical_app" {
-		t.Fatalf("project = %q, want canonical_app", created.Project)
-	}
-	if !created.Enabled {
-		t.Fatal("created mapping should default enabled")
-	}
+	require.Equal(t, "test", created.Machine)
+	require.Equal(t, "canonical_app", created.Project)
+	require.True(t, created.Enabled, "created mapping should default enabled")
 
 	var list struct {
 		Machine  string                      `json:"machine"`
@@ -39,21 +36,16 @@ func TestWorktreeMappingsAPIUsesCurrentMachine(t *testing.T) {
 	w := te.get(t, "/api/v1/settings/worktree-mappings")
 	assertStatus(t, w, http.StatusOK)
 	decodeInto(t, w, &list)
-	if list.Machine != "test" || len(list.Mappings) != 1 {
-		t.Fatalf("list = %+v, want one test-machine mapping", list)
-	}
+	require.Equal(t, "test", list.Machine)
+	require.Len(t, list.Mappings, 1)
 
 	updated := putWorktreeMapping(t, te, created.ID, map[string]any{
 		"path_prefix": prefix,
 		"project":     "disabled-app",
 		"enabled":     false,
 	})
-	if updated.Enabled {
-		t.Fatal("updated mapping should be disabled")
-	}
-	if updated.Project != "disabled_app" {
-		t.Fatalf("updated project = %q, want disabled_app", updated.Project)
-	}
+	assert.False(t, updated.Enabled, "updated mapping should be disabled")
+	assert.Equal(t, "disabled_app", updated.Project)
 
 	req := httptest.NewRequest(
 		http.MethodDelete,
@@ -69,9 +61,7 @@ func TestWorktreeMappingsAPIUsesCurrentMachine(t *testing.T) {
 	w = te.get(t, "/api/v1/settings/worktree-mappings")
 	assertStatus(t, w, http.StatusOK)
 	decodeInto(t, w, &list)
-	if len(list.Mappings) != 0 {
-		t.Fatalf("mappings after delete = %+v, want none", list.Mappings)
-	}
+	assert.Empty(t, list.Mappings, "mappings after delete should be empty")
 }
 
 func TestWorktreeMappingsAPIApply(t *testing.T) {
@@ -81,15 +71,13 @@ func TestWorktreeMappingsAPIApply(t *testing.T) {
 		"path_prefix": prefix,
 		"project":     "canonical-app",
 	})
-	if err := te.db.UpsertSession(db.Session{
+	require.NoError(t, te.db.UpsertSession(db.Session{
 		ID:      "s1",
 		Machine: "test",
 		Agent:   "claude",
 		Project: "feature_login",
 		Cwd:     filepath.Join(prefix, "feature-login"),
-	}); err != nil {
-		t.Fatalf("UpsertSession: %v", err)
-	}
+	}))
 
 	w := te.post(t, "/api/v1/settings/worktree-mappings/apply", `{}`)
 	assertStatus(t, w, http.StatusOK)
@@ -99,18 +87,12 @@ func TestWorktreeMappingsAPIApply(t *testing.T) {
 		UpdatedSessions int    `json:"updated_sessions"`
 	}
 	decodeInto(t, w, &resp)
-	if resp.Machine != "test" ||
-		resp.MatchedSessions != 1 ||
-		resp.UpdatedSessions != 1 {
-		t.Fatalf("apply response = %+v, want test matched=1 updated=1", resp)
-	}
+	assert.Equal(t, "test", resp.Machine)
+	assert.Equal(t, 1, resp.MatchedSessions)
+	assert.Equal(t, 1, resp.UpdatedSessions)
 	sess, err := te.db.GetSession(context.Background(), "s1")
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if sess.Project != "canonical_app" {
-		t.Fatalf("session project = %q, want canonical_app", sess.Project)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "canonical_app", sess.Project)
 }
 
 func TestWorktreeMappingsAPIRejectsRemoteMode(t *testing.T) {
@@ -149,9 +131,7 @@ func postWorktreeMapping(
 ) db.WorktreeProjectMapping {
 	t.Helper()
 	data, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
+	require.NoError(t, err)
 	w := te.post(
 		t,
 		"/api/v1/settings/worktree-mappings",
@@ -169,9 +149,7 @@ func putWorktreeMapping(
 ) db.WorktreeProjectMapping {
 	t.Helper()
 	data, err := json.Marshal(body)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
+	require.NoError(t, err)
 	req := httptest.NewRequest(
 		http.MethodPut,
 		"/api/v1/settings/worktree-mappings/"+
@@ -192,7 +170,6 @@ func decodeInto(
 	target any,
 ) {
 	t.Helper()
-	if err := json.Unmarshal(w.Body.Bytes(), target); err != nil {
-		t.Fatalf("decoding JSON: %v\nbody: %s", err, w.Body.String())
-	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), target),
+		"decoding JSON; body: %s", w.Body.String())
 }

--- a/internal/sessionwatch/watcher_test.go
+++ b/internal/sessionwatch/watcher_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
@@ -19,9 +21,7 @@ func testWatcher(t *testing.T) *Watcher {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 	database, err := db.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening db: %v", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { database.Close() })
 
 	engine := sync.NewEngine(database, sync.EngineConfig{
@@ -38,23 +38,15 @@ func TestStatMtime_NonexistentFile(t *testing.T) {
 	got := StatMtime(
 		filepath.Join(t.TempDir(), "no-such-file"),
 	)
-	if got != 0 {
-		t.Errorf("StatMtime(nonexistent) = %d, want 0", got)
-	}
+	assert.Equal(t, int64(0), got)
 }
 
 func TestStatMtime_ExistingFile(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(t.TempDir(), "file.txt")
-	if err := os.WriteFile(
-		path, []byte("data"), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
 	got := StatMtime(path)
-	if got == 0 {
-		t.Error("StatMtime(existing) = 0, want nonzero")
-	}
+	assert.NotZero(t, got)
 }
 
 func TestCheckDBForChanges_FileDisappears(t *testing.T) {
@@ -75,13 +67,7 @@ func TestCheckDBForChanges_FileDisappears(t *testing.T) {
 		&lastMtime,
 		&mchanged,
 	)
-	if changed {
-		t.Error("expected no change signal")
-	}
-	if path != "" {
-		t.Errorf("sourcePath = %q, want empty", path)
-	}
-	if lastMtime != 0 {
-		t.Errorf("lastMtime = %d, want 0", lastMtime)
-	}
+	assert.False(t, changed, "expected no change signal")
+	assert.Empty(t, path)
+	assert.Equal(t, int64(0), lastMtime)
 }

--- a/internal/signals/context_test.go
+++ b/internal/signals/context_test.go
@@ -3,22 +3,15 @@ package signals
 import (
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestComputeContextPressure_NoData(t *testing.T) {
 	got := ComputeContextPressure(nil, 0, "")
-	if got.CompactionCount != 0 {
-		t.Errorf(
-			"CompactionCount = %d, want 0",
-			got.CompactionCount,
-		)
-	}
-	if got.PressureMax != nil {
-		t.Errorf(
-			"PressureMax = %v, want nil",
-			*got.PressureMax,
-		)
-	}
+	assert.Equal(t, 0, got.CompactionCount)
+	assert.Nil(t, got.PressureMax)
 }
 
 func TestCountCompactions(t *testing.T) {
@@ -120,13 +113,7 @@ func TestCountCompactions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := countCompactions(tt.tokens)
-			if got != tt.want {
-				t.Errorf(
-					"countCompactions = %d, want %d",
-					got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, countCompactions(tt.tokens))
 		})
 	}
 }
@@ -210,23 +197,11 @@ func TestComputePressure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := computePressure(tt.peak, tt.model)
 			if tt.wantNil {
-				if got != nil {
-					t.Errorf(
-						"computePressure = %v, want nil",
-						*got,
-					)
-				}
+				assert.Nil(t, got)
 				return
 			}
-			if got == nil {
-				t.Fatal("computePressure = nil, want non-nil")
-			}
-			if math.Abs(*got-tt.wantVal) > tt.wantPrec {
-				t.Errorf(
-					"computePressure = %v, want %v",
-					*got, tt.wantVal,
-				)
-			}
+			require.NotNil(t, got)
+			assert.LessOrEqual(t, math.Abs(*got-tt.wantVal), tt.wantPrec)
 		})
 	}
 }
@@ -257,13 +232,7 @@ func TestLookupWindowSize(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := lookupWindowSize(tt.model)
-			if got != tt.want {
-				t.Errorf(
-					"lookupWindowSize(%q) = %d, want %d",
-					tt.model, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, lookupWindowSize(tt.model))
 		})
 	}
 }
@@ -279,21 +248,9 @@ func TestComputeContextPressure_Combined(t *testing.T) {
 	got := ComputeContextPressure(
 		tokens, 150000, "claude-sonnet-4-5",
 	)
-	if got.CompactionCount != 1 {
-		t.Errorf(
-			"CompactionCount = %d, want 1",
-			got.CompactionCount,
-		)
-	}
-	if got.PressureMax == nil {
-		t.Fatal("PressureMax = nil, want 0.75")
-	}
-	if math.Abs(*got.PressureMax-0.75) > 1e-9 {
-		t.Errorf(
-			"PressureMax = %v, want 0.75",
-			*got.PressureMax,
-		)
-	}
+	assert.Equal(t, 1, got.CompactionCount)
+	require.NotNil(t, got.PressureMax)
+	assert.LessOrEqual(t, math.Abs(*got.PressureMax-0.75), 1e-9)
 }
 
 func TestCountMidTaskCompactions(t *testing.T) {
@@ -416,12 +373,7 @@ func TestCountMidTaskCompactions(t *testing.T) {
 			got := CountMidTaskCompactions(
 				tc.boundaryOrdinals, tc.toolCalls,
 			)
-			if got != tc.wantMidTaskCount {
-				t.Errorf(
-					"CountMidTaskCompactions = %d, want %d",
-					got, tc.wantMidTaskCount,
-				)
-			}
+			assert.Equal(t, tc.wantMidTaskCount, got)
 		})
 	}
 }

--- a/internal/signals/outcome_test.go
+++ b/internal/signals/outcome_test.go
@@ -3,6 +3,8 @@ package signals
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClassifyOutcome(t *testing.T) {
@@ -205,12 +207,7 @@ func TestClassifyOutcome(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ClassifyOutcome(tt.input)
-			if got != tt.wantResult {
-				t.Errorf(
-					"ClassifyOutcome() = %+v, want %+v",
-					got, tt.wantResult,
-				)
-			}
+			assert.Equal(t, tt.wantResult, got)
 		})
 	}
 }

--- a/internal/signals/score_test.go
+++ b/internal/signals/score_test.go
@@ -2,6 +2,9 @@ package signals
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestComputeHealthScore(t *testing.T) {
@@ -324,47 +327,22 @@ func TestComputeHealthScore(t *testing.T) {
 
 			// Check score.
 			if tt.wantScore == nil {
-				if got.Score != nil {
-					t.Errorf(
-						"Score = %d, want nil",
-						*got.Score,
-					)
-				}
+				assert.Nil(t, got.Score)
 			} else {
-				if got.Score == nil {
-					t.Fatal("Score = nil, want", *tt.wantScore)
-				}
-				if *got.Score != *tt.wantScore {
-					t.Errorf(
-						"Score = %d, want %d",
-						*got.Score, *tt.wantScore,
-					)
-				}
+				require.NotNil(t, got.Score)
+				assert.Equal(t, *tt.wantScore, *got.Score)
 			}
 
 			// Check grade.
-			if got.Grade != tt.wantGrade {
-				t.Errorf(
-					"Grade = %q, want %q",
-					got.Grade, tt.wantGrade,
-				)
-			}
+			assert.Equal(t, tt.wantGrade, got.Grade)
 
 			// Check basis.
-			if !slicesEqual(got.Basis, tt.wantBasis) {
-				t.Errorf(
-					"Basis = %v, want %v",
-					got.Basis, tt.wantBasis,
-				)
-			}
+			assert.True(t, slicesEqual(got.Basis, tt.wantBasis),
+				"Basis = %v, want %v", got.Basis, tt.wantBasis)
 
 			// Check penalties.
-			if !mapsEqual(got.Penalties, tt.wantPenalties) {
-				t.Errorf(
-					"Penalties = %v, want %v",
-					got.Penalties, tt.wantPenalties,
-				)
-			}
+			assert.True(t, mapsEqual(got.Penalties, tt.wantPenalties),
+				"Penalties = %v, want %v", got.Penalties, tt.wantPenalties)
 		})
 	}
 }
@@ -439,26 +417,13 @@ func TestComputeHealthScore_MidTaskCompactionPenalty(t *testing.T) {
 				MidTaskCompactionCount: tc.midTaskCount,
 			})
 			if tc.wantPenaltyKey == "" {
-				if _, ok := res.Penalties["mid_task_compactions"]; ok {
-					t.Errorf("unexpected mid-task penalty: %v",
-						res.Penalties)
-				}
+				_, ok := res.Penalties["mid_task_compactions"]
+				assert.False(t, ok, "unexpected mid-task penalty: %v", res.Penalties)
 				return
 			}
 			got, ok := res.Penalties[tc.wantPenaltyKey]
-			if !ok {
-				t.Fatalf(
-					"missing penalty %q in %v",
-					tc.wantPenaltyKey, res.Penalties,
-				)
-			}
-			if got != tc.wantPenaltyValue {
-				t.Errorf(
-					"penalty[%q] = %d, want %d",
-					tc.wantPenaltyKey, got,
-					tc.wantPenaltyValue,
-				)
-			}
+			require.True(t, ok, "missing penalty %q in %v", tc.wantPenaltyKey, res.Penalties)
+			assert.Equal(t, tc.wantPenaltyValue, got)
 		})
 	}
 }

--- a/internal/signals/toolhealth_test.go
+++ b/internal/signals/toolhealth_test.go
@@ -1,12 +1,14 @@
 package signals
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestComputeToolHealth_NoCalls(t *testing.T) {
 	got := ComputeToolHealth(nil)
-	if got != (ToolHealthSignals{}) {
-		t.Errorf("empty input = %+v, want zero", got)
-	}
+	assert.Equal(t, ToolHealthSignals{}, got)
 }
 
 func TestIsFailure_BashContent(t *testing.T) {
@@ -106,12 +108,7 @@ func TestIsFailure_BashContent(t *testing.T) {
 				Category:      "Bash",
 				ResultContent: tt.content,
 			}
-			if got := IsFailure(row); got != tt.want {
-				t.Errorf(
-					"IsFailure(Bash %q) = %v, want %v",
-					tt.name, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, IsFailure(row))
 		})
 	}
 }
@@ -154,12 +151,7 @@ func TestIsFailure_EditWrite(t *testing.T) {
 				Category:      tt.category,
 				ResultContent: tt.content,
 			}
-			if got := IsFailure(row); got != tt.want {
-				t.Errorf(
-					"IsFailure(%s) = %v, want %v",
-					tt.name, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, IsFailure(row))
 		})
 	}
 }
@@ -169,9 +161,7 @@ func TestIsFailure_SearchNotFailure(t *testing.T) {
 		Category:      "Search",
 		ResultContent: "",
 	}
-	if IsFailure(row) {
-		t.Error("empty search result should not be failure")
-	}
+	assert.False(t, IsFailure(row), "empty search result should not be failure")
 }
 
 func TestIsFailure_EventStatus(t *testing.T) {
@@ -225,12 +215,7 @@ func TestIsFailure_EventStatus(t *testing.T) {
 				EventStatus:   tt.status,
 				ResultContent: tt.content,
 			}
-			if got := IsFailure(row); got != tt.wantFailure {
-				t.Errorf(
-					"IsFailure(status=%q) = %v, want %v",
-					tt.status, got, tt.wantFailure,
-				)
-			}
+			assert.Equal(t, tt.wantFailure, IsFailure(row))
 		})
 	}
 }
@@ -245,18 +230,8 @@ func TestConsecutiveFailureMax(t *testing.T) {
 		{Category: "Bash", ResultContent: "command not found"},
 	}
 	got := ComputeToolHealth(calls)
-	if got.ConsecutiveFailureMax != 3 {
-		t.Errorf(
-			"ConsecutiveFailureMax = %d, want 3",
-			got.ConsecutiveFailureMax,
-		)
-	}
-	if got.FailureSignalCount != 4 {
-		t.Errorf(
-			"FailureSignalCount = %d, want 4",
-			got.FailureSignalCount,
-		)
-	}
+	assert.Equal(t, 3, got.ConsecutiveFailureMax)
+	assert.Equal(t, 4, got.FailureSignalCount)
 }
 
 func TestRetryCount(t *testing.T) {
@@ -329,13 +304,7 @@ func TestRetryCount(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := countRetries(tt.calls)
-			if got != tt.want {
-				t.Errorf(
-					"countRetries = %d, want %d",
-					got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, countRetries(tt.calls))
 		})
 	}
 }
@@ -513,13 +482,7 @@ func TestEditChurn(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := countEditChurn(tt.calls)
-			if got != tt.want {
-				t.Errorf(
-					"countEditChurn = %d, want %d",
-					got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, countEditChurn(tt.calls))
 		})
 	}
 }
@@ -548,13 +511,7 @@ func TestExtractFilePath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractFilePath(tt.input)
-			if got != tt.want {
-				t.Errorf(
-					"extractFilePath = %q, want %q",
-					got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, extractFilePath(tt.input))
 		})
 	}
 }
@@ -609,25 +566,8 @@ func TestComputeToolHealth_Combined(t *testing.T) {
 
 	got := ComputeToolHealth(calls)
 
-	if got.FailureSignalCount != 3 {
-		t.Errorf(
-			"FailureSignalCount = %d, want 3",
-			got.FailureSignalCount,
-		)
-	}
-	if got.RetryCount != 2 {
-		t.Errorf("RetryCount = %d, want 2", got.RetryCount)
-	}
-	if got.EditChurnCount != 1 {
-		t.Errorf(
-			"EditChurnCount = %d, want 1",
-			got.EditChurnCount,
-		)
-	}
-	if got.ConsecutiveFailureMax != 3 {
-		t.Errorf(
-			"ConsecutiveFailureMax = %d, want 3",
-			got.ConsecutiveFailureMax,
-		)
-	}
+	assert.Equal(t, 3, got.FailureSignalCount)
+	assert.Equal(t, 2, got.RetryCount)
+	assert.Equal(t, 1, got.EditChurnCount)
+	assert.Equal(t, 3, got.ConsecutiveFailureMax)
 }

--- a/internal/ssh/helpers_sshtest_test.go
+++ b/internal/ssh/helpers_sshtest_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -27,9 +28,7 @@ func testSSHPort(t *testing.T) int {
 		p = "2222"
 	}
 	port, err := strconv.Atoi(p)
-	if err != nil {
-		t.Fatalf("invalid TEST_SSH_PORT: %v", err)
-	}
+	require.NoError(t, err, "invalid TEST_SSH_PORT")
 	return port
 }
 
@@ -67,9 +66,7 @@ func testDB(t *testing.T) *db.DB {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	database, err := db.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
+	require.NoError(t, err, "opening test db")
 	t.Cleanup(func() { database.Close() })
 	return database
 }

--- a/internal/ssh/integration_sshtest_test.go
+++ b/internal/ssh/integration_sshtest_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -33,42 +35,28 @@ func TestSSHSyncEndToEnd(t *testing.T) {
 	defer cancel()
 
 	stats, err := rs.Run(ctx)
-	if err != nil {
-		t.Fatalf("remote sync: %v", err)
-	}
+	require.NoError(t, err, "remote sync")
 
-	if stats.SessionsSynced == 0 {
-		t.Fatal("expected at least 1 session synced")
-	}
+	require.NotZero(t, stats.SessionsSynced, "expected at least 1 session synced")
 
 	// Verify session landed in DB.
 	page, err := database.ListSessions(
 		context.Background(), db.SessionFilter{Limit: 100},
 	)
-	if err != nil {
-		t.Fatalf("listing sessions: %v", err)
-	}
-	if len(page.Sessions) == 0 {
-		t.Fatal("no sessions in database")
-	}
+	require.NoError(t, err, "listing sessions")
+	require.NotEmpty(t, page.Sessions, "no sessions in database")
 
 	// Session ID should carry the host prefix.
 	found := false
 	for _, s := range page.Sessions {
 		if s.Machine == host {
 			found = true
-			if !strings.HasPrefix(s.ID, host+"~") {
-				t.Errorf(
-					"session ID %q missing host prefix",
-					s.ID,
-				)
-			}
+			assert.True(t, strings.HasPrefix(s.ID, host+"~"),
+				"session ID %q missing host prefix", s.ID)
 			break
 		}
 	}
-	if !found {
-		t.Errorf("no session with machine=%q", host)
-	}
+	assert.True(t, found, "no session with machine=%q", host)
 }
 
 func TestSSHSyncIncremental(t *testing.T) {
@@ -94,27 +82,14 @@ func TestSSHSyncIncremental(t *testing.T) {
 
 	// First sync: should pull sessions.
 	stats1, err := rs.Run(ctx)
-	if err != nil {
-		t.Fatalf("first sync: %v", err)
-	}
-	if stats1.SessionsSynced == 0 {
-		t.Fatal("first sync: expected sessions")
-	}
+	require.NoError(t, err, "first sync")
+	require.NotZero(t, stats1.SessionsSynced, "first sync: expected sessions")
 
 	// Second sync: nothing changed, should skip all.
 	stats2, err := rs.Run(ctx)
-	if err != nil {
-		t.Fatalf("second sync: %v", err)
-	}
-	if stats2.SessionsSynced != 0 {
-		t.Errorf(
-			"second sync: expected 0 synced, got %d",
-			stats2.SessionsSynced,
-		)
-	}
-	if stats2.Skipped == 0 {
-		t.Error("second sync: expected skipped > 0")
-	}
+	require.NoError(t, err, "second sync")
+	assert.Equal(t, 0, stats2.SessionsSynced, "second sync: expected 0 synced")
+	assert.NotZero(t, stats2.Skipped, "second sync: expected skipped > 0")
 }
 
 func TestSSHSyncFull(t *testing.T) {
@@ -139,21 +114,16 @@ func TestSSHSyncFull(t *testing.T) {
 		SSHOpts: opts,
 	}
 	_, err := rs.Run(ctx)
-	if err != nil {
-		t.Fatalf("first sync: %v", err)
-	}
+	require.NoError(t, err, "first sync")
 
 	// Full flag clears the remote skip cache but the engine
 	// still skips unchanged sessions via DB lookup. Verify
 	// it completes without error.
 	rs.Full = true
 	stats, err := rs.Run(ctx)
-	if err != nil {
-		t.Fatalf("full sync: %v", err)
-	}
+	require.NoError(t, err, "full sync")
 	// Session was already synced and unchanged, so it may
 	// be skipped by the engine's own DB-based detection.
-	if stats.SessionsSynced+stats.Skipped == 0 {
-		t.Fatal("full sync: expected sessions processed")
-	}
+	assert.NotZero(t, stats.SessionsSynced+stats.Skipped,
+		"full sync: expected sessions processed")
 }

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -12,9 +14,7 @@ func TestBuildResolveScript(t *testing.T) {
 	script := buildResolveScript()
 
 	// Claude has CLAUDE_PROJECTS_DIR env var — must be referenced.
-	if !strings.Contains(script, "CLAUDE_PROJECTS_DIR") {
-		t.Error("script missing CLAUDE_PROJECTS_DIR")
-	}
+	assert.Contains(t, script, "CLAUDE_PROJECTS_DIR")
 
 	// Non-file-based agents must not appear.
 	for _, def := range parser.Registry {
@@ -22,12 +22,8 @@ func TestBuildResolveScript(t *testing.T) {
 			continue
 		}
 		marker := "echo \"" + string(def.Type) + ":"
-		if strings.Contains(script, marker) {
-			t.Errorf(
-				"non-file-based agent %s in script",
-				def.Type,
-			)
-		}
+		assert.NotContains(t, script, marker,
+			"non-file-based agent %s in script", def.Type)
 	}
 
 	// Every file-based agent with DiscoverFunc must appear.
@@ -36,12 +32,8 @@ func TestBuildResolveScript(t *testing.T) {
 			continue
 		}
 		marker := "echo \"" + string(def.Type) + ":"
-		if !strings.Contains(script, marker) {
-			t.Errorf(
-				"file-based agent %s missing from script",
-				def.Type,
-			)
-		}
+		assert.Contains(t, script, marker,
+			"file-based agent %s missing from script", def.Type)
 	}
 }
 
@@ -53,18 +45,9 @@ func TestResolveScriptExitsZero(t *testing.T) {
 	cmd := exec.Command("sh", "-c", script)
 	cmd.Env = []string{"HOME=/nonexistent"}
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf(
-			"resolve script failed: %v\noutput: %s",
-			err, out,
-		)
-	}
+	require.NoError(t, err, "resolve script failed: output: %s", out)
 	// No dirs should be found.
-	if s := strings.TrimSpace(string(out)); s != "" {
-		t.Errorf(
-			"expected no output, got: %s", s,
-		)
-	}
+	assert.Empty(t, strings.TrimSpace(string(out)))
 }
 
 func TestParseResolvedDirs(t *testing.T) {
@@ -76,21 +59,12 @@ func TestParseResolvedDirs(t *testing.T) {
 	dirs := parseResolvedDirs(input)
 
 	// codex has empty dir — excluded.
-	if _, ok := dirs[parser.AgentCodex]; ok {
-		t.Error("codex should be excluded (empty dir)")
-	}
+	_, ok := dirs[parser.AgentCodex]
+	assert.False(t, ok, "codex should be excluded (empty dir)")
 
 	// claude and copilot present.
-	if got := dirs[parser.AgentClaude]; len(got) != 1 ||
-		got[0] != "/home/wes/.claude/projects" {
-		t.Errorf("claude dirs = %v, want [/home/wes/.claude/projects]", got)
-	}
-	if got := dirs[parser.AgentCopilot]; len(got) != 1 ||
-		got[0] != "/home/wes/.copilot" {
-		t.Errorf("copilot dirs = %v, want [/home/wes/.copilot]", got)
-	}
+	assert.Equal(t, []string{"/home/wes/.claude/projects"}, dirs[parser.AgentClaude])
+	assert.Equal(t, []string{"/home/wes/.copilot"}, dirs[parser.AgentCopilot])
 
-	if len(dirs) != 2 {
-		t.Errorf("got %d entries, want 2", len(dirs))
-	}
+	assert.Len(t, dirs, 2)
 }

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -3,7 +3,7 @@ package ssh
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildSSHArgs(t *testing.T) {
@@ -85,9 +85,7 @@ func TestBuildSSHArgs(t *testing.T) {
 				tt.host, tt.user, tt.port,
 				tt.sshOpts, tt.cmd,
 			)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/ssh/transfer_test.go
+++ b/internal/ssh/transfer_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -15,20 +16,12 @@ func TestBuildTarCommand(t *testing.T) {
 	}
 	cmd := buildTarCommand(dirs)
 
-	if !strings.HasPrefix(cmd, "tar cf - -C / -- ") {
-		t.Errorf("bad prefix: %s", cmd)
-	}
+	assert.True(t, strings.HasPrefix(cmd, "tar cf - -C / -- "), "bad prefix: %s", cmd)
 	// Paths are shell-quoted.
-	if !strings.Contains(cmd, "'home/wes/.claude/projects'") {
-		t.Error("missing quoted claude dir")
-	}
-	if !strings.Contains(cmd, "'home/wes/.codex/sessions'") {
-		t.Error("missing quoted codex dir")
-	}
+	assert.Contains(t, cmd, "'home/wes/.claude/projects'")
+	assert.Contains(t, cmd, "'home/wes/.codex/sessions'")
 	// No leading slash in dir args.
-	if strings.Contains(cmd, "'/home/") {
-		t.Errorf("dir has leading slash: %s", cmd)
-	}
+	assert.NotContains(t, cmd, "'/home/", "dir has leading slash: %s", cmd)
 }
 
 func TestRemapPath(t *testing.T) {
@@ -40,10 +33,7 @@ func TestRemapPath(t *testing.T) {
 		"tmp", "sync-123", "home", "wes", ".claude", "foo.jsonl",
 	)
 	got := remapToRemotePath(tempDir, remoteDir, localPath)
-	want := "/home/wes/.claude/foo.jsonl"
-	if got != want {
-		t.Errorf("remapToRemotePath = %q, want %q", got, want)
-	}
+	assert.Equal(t, "/home/wes/.claude/foo.jsonl", got)
 }
 
 func TestRemappedDir(t *testing.T) {
@@ -51,7 +41,5 @@ func TestRemappedDir(t *testing.T) {
 	remoteDir := "/home/wes/.claude"
 	got := remappedDir(tempDir, remoteDir)
 	want := filepath.Join("tmp", "sync-123", "home", "wes", ".claude")
-	if got != want {
-		t.Errorf("remappedDir = %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }

--- a/internal/sync/common_helpers_test.go
+++ b/internal/sync/common_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"io/fs"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -14,13 +16,9 @@ const (
 // requirePathError asserts that err is non-nil and wraps *fs.PathError.
 func requirePathError(t *testing.T, err error) {
 	t.Helper()
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
+	require.Error(t, err)
 	var pathErr *fs.PathError
-	if !errors.As(err, &pathErr) {
-		t.Fatalf("expected *fs.PathError, got %T: %v", err, err)
-	}
+	require.True(t, errors.As(err, &pathErr), "expected *fs.PathError, got %T: %v", err, err)
 }
 
 // failingReader is an io.Reader that always returns an error.

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -18,6 +18,9 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
 	"go.kenn.io/agentsview/internal/testjsonl"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testEnv struct {
@@ -179,12 +182,10 @@ func TestSyncEngineKiroSQLiteCurrentStore(t *testing.T) {
 	assertSessionProject(t, env.db, "kiro:sqlite-session", "kiro_app")
 	assertSessionMessageCount(t, env.db, "kiro:sqlite-session", 4)
 	source := env.engine.FindSourceFile("kiro:sqlite-session")
-	if want := filepath.Join(env.kiroDir, "data.sqlite3") + "#sqlite-session"; source != want {
-		t.Fatalf("FindSourceFile = %q, want %q", source, want)
-	}
-	if got, want := env.engine.SourceMtime("kiro:sqlite-session"), int64(1779012030000)*1_000_000; got != want {
-		t.Fatalf("SourceMtime = %d, want %d", got, want)
-	}
+	want := filepath.Join(env.kiroDir, "data.sqlite3") + "#sqlite-session"
+	require.Equal(t, want, source)
+	got, wantMtime := env.engine.SourceMtime("kiro:sqlite-session"), int64(1779012030000)*1_000_000
+	require.Equal(t, wantMtime, got)
 
 	ks.updateSession(
 		t, "sqlite-session",
@@ -291,26 +292,20 @@ func TestSyncEngineKiroSQLiteCurrentStoreShadowsLegacy(t *testing.T) {
 	sess, err := env.db.GetSessionFull(
 		context.Background(), "kiro:overlap-session",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if sess == nil || sess.FilePath == nil ||
-		!strings.Contains(*sess.FilePath, "data.sqlite3#overlap-session") {
-		t.Fatalf("expected sqlite-backed session, got %+v", sess)
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "expected sqlite-backed session")
+	require.NotNil(t, sess.FilePath, "expected sqlite-backed session")
+	require.Contains(t, *sess.FilePath, "data.sqlite3#overlap-session", "expected sqlite-backed session, got %+v", sess)
 
 	legacyPath := filepath.Join(env.kiroDir, "overlap-session.jsonl")
 	env.engine.SyncPaths([]string{legacyPath})
 	sess, err = env.db.GetSessionFull(
 		context.Background(), "kiro:overlap-session",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull after legacy event: %v", err)
-	}
-	if sess == nil || sess.FilePath == nil ||
-		!strings.Contains(*sess.FilePath, "data.sqlite3#overlap-session") {
-		t.Fatalf("legacy event replaced sqlite-backed session: %+v", sess)
-	}
+	require.NoError(t, err, "GetSessionFull after legacy event")
+	require.NotNil(t, sess, "legacy event replaced sqlite-backed session")
+	require.NotNil(t, sess.FilePath, "legacy event replaced sqlite-backed session")
+	require.Contains(t, *sess.FilePath, "data.sqlite3#overlap-session", "legacy event replaced sqlite-backed session: %+v", sess)
 }
 
 func TestSyncEngineKiroLegacyOnlySyncPath(t *testing.T) {
@@ -498,9 +493,7 @@ func TestSyncEngineIntegration(t *testing.T) {
 
 	// FindSourceFile
 	src := env.engine.FindSourceFile("test-session")
-	if src == "" {
-		t.Error("FindSourceFile returned empty")
-	}
+	assert.NotEmpty(t, src, "FindSourceFile returned empty")
 }
 
 func TestSyncEngineWorktreesShareProject(t *testing.T) {
@@ -517,9 +510,7 @@ func TestSyncEngineWorktreesShareProject(t *testing.T) {
 		[]byte("../..\n"))
 
 	// Create a standard main repository marker.
-	if err := os.MkdirAll(filepath.Join(mainRepo, ".git"), 0o755); err != nil {
-		t.Fatalf("mkdir main .git: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Join(mainRepo, ".git"), 0o755), "mkdir main .git")
 
 	mainContent := testjsonl.NewSessionBuilder().
 		AddClaudeUser(tsEarly, "Main repo", mainRepo).
@@ -545,18 +536,10 @@ func TestSyncEngineWorktreesShareProject(t *testing.T) {
 	assertSessionProject(t, env.db, "worktree-repo", "agentsview")
 
 	projects, err := env.db.GetProjects(context.Background(), false, false)
-	if err != nil {
-		t.Fatalf("GetProjects: %v", err)
-	}
-	if len(projects) != 1 {
-		t.Fatalf("len(projects) = %d, want 1", len(projects))
-	}
-	if projects[0].Name != "agentsview" {
-		t.Fatalf("project name = %q, want %q", projects[0].Name, "agentsview")
-	}
-	if projects[0].SessionCount != 2 {
-		t.Fatalf("session_count = %d, want 2", projects[0].SessionCount)
-	}
+	require.NoError(t, err, "GetProjects")
+	require.Equal(t, 1, len(projects), "len(projects) = %d, want 1", len(projects))
+	require.Equal(t, "agentsview", projects[0].Name, "project name = %q, want %q", projects[0].Name, "agentsview")
+	require.Equal(t, 2, projects[0].SessionCount, "session_count = %d, want 2", projects[0].SessionCount)
 }
 
 func TestSyncEngineWorktreeProjectWhenPathMissing(t *testing.T) {
@@ -590,9 +573,7 @@ func TestSyncEngineWorktreeProjectWhenPathMissing(t *testing.T) {
 func TestSyncEngineAppliesWorktreeProjectMapping(t *testing.T) {
 	env := setupTestEnv(t)
 
-	if got := env.engine.Machine(); got != "local" {
-		t.Fatalf("engine machine = %q, want local", got)
-	}
+	assert.Equal(t, "local", env.engine.Machine())
 
 	root := t.TempDir()
 	worktreePrefix := filepath.Join(root, "my-app.worktrees")
@@ -606,9 +587,7 @@ func TestSyncEngineAppliesWorktreeProjectMapping(t *testing.T) {
 			Enabled:    true,
 		},
 	)
-	if err != nil {
-		t.Fatalf("CreateWorktreeProjectMapping: %v", err)
-	}
+	require.NoError(t, err, "CreateWorktreeProjectMapping")
 
 	content := testjsonl.NewSessionBuilder().
 		AddClaudeUser(tsEarly, "Worktree mapped", sessionCwd).
@@ -646,9 +625,7 @@ func TestSyncSingleSessionAppliesWorktreeProjectMapping(t *testing.T) {
 			Enabled:    true,
 		},
 	)
-	if err != nil {
-		t.Fatalf("CreateWorktreeProjectMapping: %v", err)
-	}
+	require.NoError(t, err, "CreateWorktreeProjectMapping")
 
 	content := testjsonl.NewSessionBuilder().
 		AddClaudeUser(tsEarly, "Worktree mapped single", sessionCwd).
@@ -660,11 +637,10 @@ func TestSyncSingleSessionAppliesWorktreeProjectMapping(t *testing.T) {
 		"mapped-worktree-single.jsonl", content,
 	)
 
-	if err := env.engine.SyncSingleSession(
+	err = env.engine.SyncSingleSession(
 		"mapped-worktree-single",
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertSessionProject(
 		t, env.db, "mapped-worktree-single", "canonical_app",
@@ -697,21 +673,10 @@ func TestSyncSingleSessionSkippedClaudeDoesNotApplyWorktreeProjectMapping(
 	before, err := env.db.GetSession(
 		context.Background(), "mapped-worktree-single-skip",
 	)
-	if err != nil {
-		t.Fatalf("GetSession before mapping: %v", err)
-	}
-	if before == nil {
-		t.Fatal("session missing before mapping")
-	}
-	if before.Project == "canonical_app" {
-		t.Fatalf("project before mapping = %q, want stale project", before.Project)
-	}
-	if before.LocalModifiedAt != nil {
-		t.Fatalf(
-			"local_modified_at before mapping = %v, want nil",
-			before.LocalModifiedAt,
-		)
-	}
+	require.NoError(t, err, "GetSession before mapping")
+	require.NotNil(t, before, "session missing before mapping")
+	require.NotEqual(t, "canonical_app", before.Project, "project before mapping = %q, want stale project", before.Project)
+	require.Nil(t, before.LocalModifiedAt, "local_modified_at before mapping = %v, want nil", before.LocalModifiedAt)
 
 	_, err = env.db.CreateWorktreeProjectMapping(
 		context.Background(),
@@ -722,32 +687,19 @@ func TestSyncSingleSessionSkippedClaudeDoesNotApplyWorktreeProjectMapping(
 			Enabled:    true,
 		},
 	)
-	if err != nil {
-		t.Fatalf("CreateWorktreeProjectMapping: %v", err)
-	}
+	require.NoError(t, err, "CreateWorktreeProjectMapping")
 
-	if err := env.engine.SyncSingleSession(
+	err = env.engine.SyncSingleSession(
 		"mapped-worktree-single-skip",
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	after, err := env.db.GetSession(
 		context.Background(), "mapped-worktree-single-skip",
 	)
-	if err != nil {
-		t.Fatalf("GetSession after skipped sync: %v", err)
-	}
-	if after == nil {
-		t.Fatal("session missing after skipped sync")
-	}
-	if after.Project != before.Project {
-		t.Fatalf(
-			"project after skipped sync = %q, want %q",
-			after.Project,
-			before.Project,
-		)
-	}
+	require.NoError(t, err, "GetSession after skipped sync")
+	require.NotNil(t, after, "session missing after skipped sync")
+	require.Equal(t, before.Project, after.Project, "project after skipped sync = %q, want %q", after.Project, before.Project)
 }
 
 func TestSyncAllSkippedClaudeDoesNotApplyWorktreeProjectMapping(
@@ -776,15 +728,9 @@ func TestSyncAllSkippedClaudeDoesNotApplyWorktreeProjectMapping(
 	before, err := env.db.GetSession(
 		context.Background(), "mapped-worktree-syncall-skip",
 	)
-	if err != nil {
-		t.Fatalf("GetSession before mapping: %v", err)
-	}
-	if before == nil {
-		t.Fatal("session missing before mapping")
-	}
-	if before.Project == "canonical_app" {
-		t.Fatalf("project before mapping = %q, want stale project", before.Project)
-	}
+	require.NoError(t, err, "GetSession before mapping")
+	require.NotNil(t, before, "session missing before mapping")
+	require.NotEqual(t, "canonical_app", before.Project, "project before mapping = %q, want stale project", before.Project)
 	_, err = env.db.CreateWorktreeProjectMapping(
 		context.Background(),
 		db.WorktreeProjectMapping{
@@ -794,9 +740,7 @@ func TestSyncAllSkippedClaudeDoesNotApplyWorktreeProjectMapping(
 			Enabled:    true,
 		},
 	)
-	if err != nil {
-		t.Fatalf("CreateWorktreeProjectMapping: %v", err)
-	}
+	require.NoError(t, err, "CreateWorktreeProjectMapping")
 
 	runSyncAndAssert(t, env.engine, sync.SyncStats{
 		TotalSessions: 1,
@@ -807,19 +751,9 @@ func TestSyncAllSkippedClaudeDoesNotApplyWorktreeProjectMapping(
 	after, err := env.db.GetSession(
 		context.Background(), "mapped-worktree-syncall-skip",
 	)
-	if err != nil {
-		t.Fatalf("GetSession after skipped sync: %v", err)
-	}
-	if after == nil {
-		t.Fatal("session missing after skipped sync")
-	}
-	if after.Project != before.Project {
-		t.Fatalf(
-			"project after skipped sync = %q, want %q",
-			after.Project,
-			before.Project,
-		)
-	}
+	require.NoError(t, err, "GetSession after skipped sync")
+	require.NotNil(t, after, "session missing after skipped sync")
+	require.Equal(t, before.Project, after.Project, "project after skipped sync = %q, want %q", after.Project, before.Project)
 }
 
 func TestSyncPathsSkippedClaudeDoesNotApplyWorktreeProjectMapping(
@@ -848,21 +782,13 @@ func TestSyncPathsSkippedClaudeDoesNotApplyWorktreeProjectMapping(
 	before, err := env.db.GetSession(
 		context.Background(), "mapped-worktree-syncpaths-skip",
 	)
-	if err != nil {
-		t.Fatalf("GetSession before mapping: %v", err)
-	}
-	if before == nil {
-		t.Fatal("session missing before mapping")
-	}
-	if before.Project == "canonical_app" {
-		t.Fatalf("project before mapping = %q, want stale project", before.Project)
-	}
+	require.NoError(t, err, "GetSession before mapping")
+	require.NotNil(t, before, "session missing before mapping")
+	require.NotEqual(t, "canonical_app", before.Project, "project before mapping = %q, want stale project", before.Project)
 	beforeFull, err := env.db.GetSessionFull(
 		context.Background(), "mapped-worktree-syncpaths-skip",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull before mapping: %v", err)
-	}
+	require.NoError(t, err, "GetSessionFull before mapping")
 
 	_, err = env.db.CreateWorktreeProjectMapping(
 		context.Background(),
@@ -873,9 +799,7 @@ func TestSyncPathsSkippedClaudeDoesNotApplyWorktreeProjectMapping(
 			Enabled:    true,
 		},
 	)
-	if err != nil {
-		t.Fatalf("CreateWorktreeProjectMapping: %v", err)
-	}
+	require.NoError(t, err, "CreateWorktreeProjectMapping")
 
 	env.engine.SyncPaths([]string{path})
 
@@ -883,24 +807,15 @@ func TestSyncPathsSkippedClaudeDoesNotApplyWorktreeProjectMapping(
 		context.Background(),
 		"mapped-worktree-syncpaths-skip",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull after skipped path sync: %v", err)
-	}
-	if after.Project != beforeFull.Project {
-		t.Fatalf(
-			"project after skipped path sync = %q, want %q",
-			after.Project,
-			beforeFull.Project,
-		)
-	}
-	if testStringPtrValue(after.LocalModifiedAt) !=
-		testStringPtrValue(beforeFull.LocalModifiedAt) {
-		t.Fatalf(
-			"local_modified_at after skipped path sync = %v, want %v",
-			after.LocalModifiedAt,
-			beforeFull.LocalModifiedAt,
-		)
-	}
+	require.NoError(t, err, "GetSessionFull after skipped path sync")
+	require.Equal(t, beforeFull.Project, after.Project, "project after skipped path sync = %q, want %q", after.Project, beforeFull.Project)
+	require.Equal(t,
+		testStringPtrValue(beforeFull.LocalModifiedAt),
+		testStringPtrValue(after.LocalModifiedAt),
+		"local_modified_at after skipped path sync = %v, want %v",
+		after.LocalModifiedAt,
+		beforeFull.LocalModifiedAt,
+	)
 }
 
 func TestSyncSingleSessionIncrementalAppliesWorktreeProjectMapping(
@@ -928,15 +843,9 @@ func TestSyncSingleSessionIncrementalAppliesWorktreeProjectMapping(
 	before, err := env.db.GetSession(
 		context.Background(), "mapped-worktree-single-incremental",
 	)
-	if err != nil {
-		t.Fatalf("GetSession before mapping: %v", err)
-	}
-	if before == nil {
-		t.Fatal("session missing before mapping")
-	}
-	if before.Project == "canonical_app" {
-		t.Fatalf("project before mapping = %q, want stale project", before.Project)
-	}
+	require.NoError(t, err, "GetSession before mapping")
+	require.NotNil(t, before, "session missing before mapping")
+	require.NotEqual(t, "canonical_app", before.Project, "project before mapping = %q, want stale project", before.Project)
 	_, err = env.db.CreateWorktreeProjectMapping(
 		context.Background(),
 		db.WorktreeProjectMapping{
@@ -946,22 +855,17 @@ func TestSyncSingleSessionIncrementalAppliesWorktreeProjectMapping(
 			Enabled:    true,
 		},
 	)
-	if err != nil {
-		t.Fatalf("CreateWorktreeProjectMapping: %v", err)
-	}
+	require.NoError(t, err, "CreateWorktreeProjectMapping")
 
 	appended := initial + testjsonl.NewSessionBuilder().
 		AddClaudeAssistant(tsEarlyS5, "ok").
 		String()
-	if err := os.WriteFile(path, []byte(appended), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(appended), 0o644), "WriteFile")
 
-	if err := env.engine.SyncSingleSession(
+	err = env.engine.SyncSingleSession(
 		"mapped-worktree-single-incremental",
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertSessionMessageCount(
 		t, env.db, "mapped-worktree-single-incremental", 2,
@@ -996,15 +900,9 @@ func TestSyncAllIncrementalAppliesWorktreeProjectMapping(
 	before, err := env.db.GetSession(
 		context.Background(), "mapped-worktree-syncall-incremental",
 	)
-	if err != nil {
-		t.Fatalf("GetSession before mapping: %v", err)
-	}
-	if before == nil {
-		t.Fatal("session missing before mapping")
-	}
-	if before.Project == "canonical_app" {
-		t.Fatalf("project before mapping = %q, want stale project", before.Project)
-	}
+	require.NoError(t, err, "GetSession before mapping")
+	require.NotNil(t, before, "session missing before mapping")
+	require.NotEqual(t, "canonical_app", before.Project, "project before mapping = %q, want stale project", before.Project)
 	_, err = env.db.CreateWorktreeProjectMapping(
 		context.Background(),
 		db.WorktreeProjectMapping{
@@ -1014,16 +912,12 @@ func TestSyncAllIncrementalAppliesWorktreeProjectMapping(
 			Enabled:    true,
 		},
 	)
-	if err != nil {
-		t.Fatalf("CreateWorktreeProjectMapping: %v", err)
-	}
+	require.NoError(t, err, "CreateWorktreeProjectMapping")
 
 	appended := initial + testjsonl.NewSessionBuilder().
 		AddClaudeAssistant(tsEarlyS5, "ok").
 		String()
-	if err := os.WriteFile(path, []byte(appended), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(appended), 0o644), "WriteFile")
 
 	runSyncAndAssert(t, env.engine, sync.SyncStats{
 		TotalSessions: 1,
@@ -1056,9 +950,7 @@ func TestResyncAllAppliesWorktreeProjectMappingDuringBulkWrites(
 			Enabled:    true,
 		},
 	)
-	if err != nil {
-		t.Fatalf("CreateWorktreeProjectMapping: %v", err)
-	}
+	require.NoError(t, err, "CreateWorktreeProjectMapping")
 
 	content := testjsonl.NewSessionBuilder().
 		AddClaudeUser(tsEarly, "Worktree mapped by resync", sessionCwd).
@@ -1071,12 +963,8 @@ func TestResyncAllAppliesWorktreeProjectMappingDuringBulkWrites(
 	)
 
 	stats := env.engine.ResyncAll(context.Background(), nil)
-	if stats.Aborted {
-		t.Fatalf("ResyncAll aborted: %+v", stats)
-	}
-	if stats.Synced != 1 {
-		t.Fatalf("ResyncAll synced = %d, want 1: %+v", stats.Synced, stats)
-	}
+	require.False(t, stats.Aborted, "ResyncAll aborted: %+v", stats)
+	require.Equal(t, 1, stats.Synced, "ResyncAll synced = %d, want 1: %+v", stats.Synced, stats)
 
 	assertSessionProject(
 		t, env.db, "mapped-worktree-resync", "canonical_app",
@@ -1101,9 +989,7 @@ func TestSyncEngineCodex(t *testing.T) {
 
 	assertSessionProject(t, env.db, "codex:test-uuid", "api")
 	assertSessionState(t, env.db, "codex:test-uuid", func(sess *db.Session) {
-		if sess.Agent != "codex" {
-			t.Errorf("agent = %q", sess.Agent)
-		}
+		assert.Equal(t, "codex", sess.Agent, "agent = %q", sess.Agent)
 	})
 }
 
@@ -1133,15 +1019,10 @@ func TestSyncEngineProgress(t *testing.T) {
 		last = p
 	})
 
-	if progressCalls == 0 {
-		t.Error("expected progress callbacks")
-	}
-	if firstTotal != 4 {
-		t.Errorf("first progress total = %d, want 4", firstTotal)
-	}
-	if last.SessionsDone != 4 || last.SessionsTotal != 4 {
-		t.Errorf("last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
-	}
+	assert.NotZero(t, progressCalls, "expected progress callbacks")
+	assert.Equal(t, 4, firstTotal, "first progress total = %d, want 4", firstTotal)
+	assert.Equal(t, 4, last.SessionsDone, "last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
+	assert.Equal(t, 4, last.SessionsTotal, "last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
 
 	progressCalls = 0
 	firstTotal = 0
@@ -1153,15 +1034,10 @@ func TestSyncEngineProgress(t *testing.T) {
 		}
 		last = p
 	})
-	if progressCalls == 0 {
-		t.Error("expected progress callbacks on second sync")
-	}
-	if firstTotal != 4 {
-		t.Errorf("second first progress total = %d, want 4", firstTotal)
-	}
-	if last.SessionsDone != 4 || last.SessionsTotal != 4 {
-		t.Errorf("second last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
-	}
+	assert.NotZero(t, progressCalls, "expected progress callbacks on second sync")
+	assert.Equal(t, 4, firstTotal, "second first progress total = %d, want 4", firstTotal)
+	assert.Equal(t, 4, last.SessionsDone, "second last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
+	assert.Equal(t, 4, last.SessionsTotal, "second last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
 }
 
 func TestSyncEngineProgressEmitsPhaseDoneOnce(t *testing.T) {
@@ -1190,25 +1066,19 @@ func TestSyncEngineProgressEmitsPhaseDoneOnce(t *testing.T) {
 			}
 		}
 	}
-	if doneCount != 1 {
-		t.Fatalf("PhaseDone emitted %d times, want exactly 1; events=%+v", doneCount, events)
-	}
-	if firstDoneIdx != len(events)-1 {
-		t.Fatalf("PhaseDone at index %d, want last event (index %d)", firstDoneIdx, len(events)-1)
-	}
+	require.Equal(t, 1, doneCount, "PhaseDone emitted %d times, want exactly 1; events=%+v", doneCount, events)
+	require.Equal(t, len(events)-1, firstDoneIdx, "PhaseDone at index %d, want last event (index %d)", firstDoneIdx, len(events)-1)
 	last := events[len(events)-1]
-	if last.SessionsDone != last.SessionsTotal || last.SessionsTotal != 2 {
-		t.Fatalf("final progress = %d/%d, want 2/2", last.SessionsDone, last.SessionsTotal)
-	}
+	require.Equal(t, last.SessionsTotal, last.SessionsDone, "final progress = %d/%d, want 2/2", last.SessionsDone, last.SessionsTotal)
+	require.Equal(t, 2, last.SessionsTotal, "final progress = %d/%d, want 2/2", last.SessionsDone, last.SessionsTotal)
 	var peakMessages int
 	for _, e := range events {
 		if e.MessagesIndexed > peakMessages {
 			peakMessages = e.MessagesIndexed
 		}
 	}
-	if last.MessagesIndexed < peakMessages {
-		t.Fatalf("final MessagesIndexed = %d regressed from peak %d", last.MessagesIndexed, peakMessages)
-	}
+	require.GreaterOrEqual(t, last.MessagesIndexed, peakMessages,
+		"final MessagesIndexed = %d regressed from peak %d", last.MessagesIndexed, peakMessages)
 }
 
 func TestSyncEngineProgressDoneCatchesResyncDBBackedWork(t *testing.T) {
@@ -1227,16 +1097,11 @@ func TestSyncEngineProgressDoneCatchesResyncDBBackedWork(t *testing.T) {
 	env.engine.SyncAll(context.Background(), func(p sync.Progress) {
 		seen = append(seen, p)
 	})
-	if len(seen) == 0 {
-		t.Fatal("expected progress callbacks")
-	}
+	require.NotEmpty(t, seen, "expected progress callbacks")
 	last := seen[len(seen)-1]
-	if last.Phase != sync.PhaseDone {
-		t.Fatalf("last phase = %q, want done", last.Phase)
-	}
-	if last.SessionsDone != last.SessionsTotal || last.SessionsTotal != 3 {
-		t.Fatalf("last progress = %d/%d, want 3/3", last.SessionsDone, last.SessionsTotal)
-	}
+	require.Equal(t, sync.PhaseDone, last.Phase, "last phase = %q, want done", last.Phase)
+	require.Equal(t, last.SessionsTotal, last.SessionsDone, "last progress = %d/%d, want 3/3", last.SessionsDone, last.SessionsTotal)
+	require.Equal(t, 3, last.SessionsTotal, "last progress = %d/%d, want 3/3", last.SessionsDone, last.SessionsTotal)
 }
 
 func TestSyncEngineHashSkip(t *testing.T) {
@@ -1255,15 +1120,9 @@ func TestSyncEngineHashSkip(t *testing.T) {
 
 	// Verify file metadata was stored
 	size, mtime, ok := env.db.GetSessionFileInfo("hash-test")
-	if !ok {
-		t.Fatal("file info not stored")
-	}
-	if mtime == 0 {
-		t.Fatal("mtime not stored")
-	}
-	if size == 0 {
-		t.Fatal("size not stored")
-	}
+	require.True(t, ok, "file info not stored")
+	require.NotZero(t, mtime, "mtime not stored")
+	require.NotZero(t, size, "size not stored")
 
 	// Second sync — unchanged content → skipped
 	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 0 + 1, Synced: 0, Skipped: 1})
@@ -1362,11 +1221,10 @@ func TestSyncSingleSessionReplacesContent(
 	os.WriteFile(path, []byte(updated), 0o644)
 
 	// SyncSingleSession should fully replace messages.
-	if err := env.engine.SyncSingleSession(
+	err := env.engine.SyncSingleSession(
 		"replace-test",
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertMessageContent(
 		t, env.db, "replace-test",
@@ -1438,10 +1296,7 @@ func TestSyncAllImportsCodexExec(
 	assertSessionState(
 		t, env.db, "codex:"+uuid,
 		func(sess *db.Session) {
-			if sess.Agent != "codex" {
-				t.Errorf("agent = %q, want codex",
-					sess.Agent)
-			}
+			assert.Equal(t, "codex", sess.Agent, "agent = %q, want codex", sess.Agent)
 		},
 	)
 }
@@ -1466,26 +1321,21 @@ func TestSyncAllImportsCodexExecFromLegacySkipCache(
 		"rollout-20240115-"+uuid+".jsonl", content,
 	)
 	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat codex session: %v", err)
-	}
+	require.NoError(t, err, "stat codex session")
 
-	if err := env.db.ReplaceSkippedFiles(map[string]int64{
+	require.NoError(t, env.db.ReplaceSkippedFiles(map[string]int64{
 		path: info.ModTime().UnixNano(),
-	}); err != nil {
-		t.Fatalf("seed skipped files: %v", err)
-	}
+	}), "seed skipped files")
 
 	// setupTestEnv already built an engine, which ran the
 	// codex exec migration against an empty skip cache and
 	// flipped the flag to "done". Reset the flag so the new
 	// engine below observes a legacy skip entry and scrubs
 	// it, matching the production upgrade path.
-	if err := env.db.SetSyncState(
+	err = env.db.SetSyncState(
 		sync.CodexExecMigrationKey, "",
-	); err != nil {
-		t.Fatalf("reset migration flag: %v", err)
-	}
+	)
+	require.NoError(t, err, "reset migration flag")
 
 	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
@@ -1506,10 +1356,7 @@ func TestSyncAllImportsCodexExecFromLegacySkipCache(
 	assertSessionState(
 		t, env.db, "codex:"+uuid,
 		func(sess *db.Session) {
-			if sess.Agent != "codex" {
-				t.Errorf("agent = %q, want codex",
-					sess.Agent)
-			}
+			assert.Equal(t, "codex", sess.Agent, "agent = %q, want codex", sess.Agent)
 		},
 	)
 }
@@ -1543,15 +1390,11 @@ func TestCodexExecMigrationIdempotent(t *testing.T) {
 		"rollout-20240115-"+uuid+".jsonl", content,
 	)
 	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat codex session: %v", err)
-	}
+	require.NoError(t, err, "stat codex session")
 
-	if err := env.db.ReplaceSkippedFiles(map[string]int64{
+	require.NoError(t, env.db.ReplaceSkippedFiles(map[string]int64{
 		path: info.ModTime().UnixNano(),
-	}); err != nil {
-		t.Fatalf("seed skipped files: %v", err)
-	}
+	}), "seed skipped files")
 
 	// Rebuild the engine without resetting the migration
 	// flag. The migration must be a no-op: the seeded entry
@@ -1573,16 +1416,12 @@ func TestCodexExecMigrationIdempotent(t *testing.T) {
 	env.engine.SyncAll(context.Background(), nil)
 
 	loaded, err := env.db.LoadSkippedFiles()
-	if err != nil {
-		t.Fatalf("load skipped files: %v", err)
-	}
-	if _, ok := loaded[path]; !ok {
-		t.Fatalf(
-			"post-migration skip entry for %s was cleared; "+
-				"migration must be idempotent",
-			path,
-		)
-	}
+	require.NoError(t, err, "load skipped files")
+	_, ok := loaded[path]
+	require.True(t, ok,
+		"post-migration skip entry for %s was cleared; migration must be idempotent",
+		path,
+	)
 }
 
 func TestSyncEngineTombstoneClearOnMtimeChange(t *testing.T) {
@@ -1635,9 +1474,7 @@ func TestSyncSingleSessionProjectFallback(t *testing.T) {
 
 	// 4. SyncSingleSession should NOT revert to "default_proj"
 	err := env.engine.SyncSingleSession("fallback-test")
-	if err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertSessionProject(t, env.db, "fallback-test", "custom_proj")
 
@@ -1645,9 +1482,7 @@ func TestSyncSingleSessionProjectFallback(t *testing.T) {
 	env.updateSessionProject(t, "fallback-test", "")
 
 	err = env.engine.SyncSingleSession("fallback-test")
-	if err != nil {
-		t.Fatalf("SyncSingleSession (empty): %v", err)
-	}
+	require.NoError(t, err, "SyncSingleSession (empty)")
 
 	assertSessionProject(t, env.db, "fallback-test", "default_proj")
 
@@ -1655,9 +1490,7 @@ func TestSyncSingleSessionProjectFallback(t *testing.T) {
 	env.updateSessionProject(t, "fallback-test", "_Users_alice_bad")
 
 	err = env.engine.SyncSingleSession("fallback-test")
-	if err != nil {
-		t.Fatalf("SyncSingleSession (bad): %v", err)
-	}
+	require.NoError(t, err, "SyncSingleSession (bad)")
 
 	assertSessionProject(t, env.db, "fallback-test", "default_proj")
 }
@@ -1776,10 +1609,7 @@ func TestSyncPathsCodex(t *testing.T) {
 	assertSessionState(
 		t, env.db, "codex:"+uuid,
 		func(sess *db.Session) {
-			if sess.Agent != "codex" {
-				t.Errorf("agent = %q, want codex",
-					sess.Agent)
-			}
+			assert.Equal(t, "codex", sess.Agent, "agent = %q, want codex", sess.Agent)
 		},
 	)
 }
@@ -1803,9 +1633,7 @@ func TestSyncPathsIgnoresAgentFiles(t *testing.T) {
 	sess, _ := env.db.GetSession(
 		context.Background(), "agent-abc",
 	)
-	if sess != nil {
-		t.Error("agent-* file should be ignored")
-	}
+	assert.Nil(t, sess, "agent-* file should be ignored")
 }
 
 func TestSyncEngineCodexNoTrailingNewline(t *testing.T) {
@@ -1880,10 +1708,7 @@ func TestSyncPathsGemini(t *testing.T) {
 	assertSessionState(
 		t, env.db, "gemini:"+sessionID,
 		func(sess *db.Session) {
-			if sess.Agent != "gemini" {
-				t.Errorf("agent = %q, want gemini",
-					sess.Agent)
-			}
+			assert.Equal(t, "gemini", sess.Agent, "agent = %q, want gemini", sess.Agent)
 		},
 	)
 	assertSessionMessageCount(t, env.db, "gemini:"+sessionID, 2)
@@ -1915,10 +1740,7 @@ func TestSyncPathsGeminiJSONL(t *testing.T) {
 	assertSessionState(
 		t, env.db, "gemini:"+sessionID,
 		func(sess *db.Session) {
-			if sess.Agent != "gemini" {
-				t.Errorf("agent = %q, want gemini",
-					sess.Agent)
-			}
+			assert.Equal(t, "gemini", sess.Agent, "agent = %q, want gemini", sess.Agent)
 		},
 	)
 	assertSessionMessageCount(t, env.db, "gemini:"+sessionID, 2)
@@ -1946,15 +1768,9 @@ func TestSyncPathsCodexAcceptsFlatArchived(t *testing.T) {
 	sess, err := env.db.GetSession(
 		context.Background(), "codex:"+uuid,
 	)
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected flat archived Codex session to sync")
-	}
-	if got := env.db.GetSessionFilePath("codex:" + uuid); got != path {
-		t.Fatalf("file path = %q, want %q", got, path)
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, sess, "expected flat archived Codex session to sync")
+	assert.Equal(t, path, env.db.GetSessionFilePath("codex:"+uuid))
 }
 
 func TestSyncPathsCodexPrefersLivePathOverArchived(t *testing.T) {
@@ -1986,15 +1802,9 @@ func TestSyncPathsCodexPrefersLivePathOverArchived(t *testing.T) {
 	sess, err := env.db.GetSession(
 		context.Background(), "codex:"+uuid,
 	)
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected Codex session to sync")
-	}
-	if got := env.db.GetSessionFilePath("codex:" + uuid); got != livePath {
-		t.Fatalf("file path = %q, want %q", got, livePath)
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, sess, "expected Codex session to sync")
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("codex:"+uuid))
 	assertSessionMessageCount(t, env.db, "codex:"+uuid, 1)
 	_ = archivedPath
 }
@@ -2026,30 +1836,18 @@ func TestSyncAllSinceCodexKeepsChangedArchivedDuplicate(t *testing.T) {
 	oldTime := time.Now().Add(-2 * time.Hour)
 	newTime := time.Now().Add(-30 * time.Minute)
 	cutoff := time.Now().Add(-1 * time.Hour)
-	if err := os.Chtimes(livePath, oldTime, oldTime); err != nil {
-		t.Fatalf("chtimes live: %v", err)
-	}
-	if err := os.Chtimes(archivedPath, newTime, newTime); err != nil {
-		t.Fatalf("chtimes archived: %v", err)
-	}
+	require.NoError(t, os.Chtimes(livePath, oldTime, oldTime), "chtimes live")
+	require.NoError(t, os.Chtimes(archivedPath, newTime, newTime), "chtimes archived")
 
 	stats := env.engine.SyncAllSince(context.Background(), cutoff, nil)
-	if stats.Synced != 1 {
-		t.Fatalf("SyncAllSince synced = %d, want 1", stats.Synced)
-	}
+	require.Equal(t, 1, stats.Synced, "SyncAllSince synced = %d, want 1", stats.Synced)
 
 	sess, err := env.db.GetSession(
 		context.Background(), "codex:"+uuid,
 	)
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatal("expected archived Codex session to sync")
-	}
-	if got := env.db.GetSessionFilePath("codex:" + uuid); got != archivedPath {
-		t.Fatalf("file path = %q, want %q", got, archivedPath)
-	}
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, sess, "expected archived Codex session to sync")
+	assert.Equal(t, archivedPath, env.db.GetSessionFilePath("codex:"+uuid))
 }
 
 func TestSyncPathsGeminiRejectsWrongStructure(t *testing.T) {
@@ -2081,12 +1879,7 @@ func TestSyncPathsGeminiRejectsWrongStructure(t *testing.T) {
 	sess, _ := env.db.GetSession(
 		context.Background(), "gemini:"+sessionID,
 	)
-	if sess != nil {
-		t.Error(
-			"Gemini file outside tmp/<hash>/chats " +
-				"should be ignored",
-		)
-	}
+	assert.Nil(t, sess, "Gemini file outside tmp/<hash>/chats " + "should be ignored")
 }
 
 func TestSyncPathsAmp(t *testing.T) {
@@ -2105,9 +1898,7 @@ func TestSyncPathsAmp(t *testing.T) {
 		t, env.db,
 		"amp:T-019ca26f-aaaa-bbbb-cccc-dddddddddddd",
 		func(sess *db.Session) {
-			if sess.Agent != "amp" {
-				t.Errorf("agent = %q, want amp", sess.Agent)
-			}
+			assert.Equal(t, "amp", sess.Agent, "agent = %q, want amp", sess.Agent)
 		},
 	)
 	assertSessionMessageCount(
@@ -2152,9 +1943,7 @@ func TestSyncPathsAmpRejectsWrongStructure(t *testing.T) {
 	sess, _ := env.db.GetSession(
 		context.Background(), "amp:T-019ca26f-aaaa-bbbb-cccc-dddddddddddd",
 	)
-	if sess != nil {
-		t.Error("Amp files outside root-level valid T-<id>.json should be ignored")
-	}
+	assert.Nil(t, sess, "Amp files outside root-level valid T-<id>.json should be ignored")
 }
 
 func TestSyncPathsStatsUpdated(t *testing.T) {
@@ -2171,14 +1960,9 @@ func TestSyncPathsStatsUpdated(t *testing.T) {
 	env.engine.SyncPaths([]string{path})
 
 	stats := env.engine.LastSyncStats()
-	if stats.Synced != 1 {
-		t.Errorf("LastSyncStats.Synced = %d, want 1",
-			stats.Synced)
-	}
+	assert.Equal(t, 1, stats.Synced, "LastSyncStats.Synced = %d, want 1", stats.Synced)
 	lastSync := env.engine.LastSync()
-	if lastSync.IsZero() {
-		t.Error("LastSync should be set after SyncPaths")
-	}
+	assert.False(t, lastSync.IsZero(), "LastSync should be set after SyncPaths")
 }
 
 func TestSyncPathsClaudeParentSessionID(t *testing.T) {
@@ -2200,11 +1984,10 @@ func TestSyncPathsClaudeParentSessionID(t *testing.T) {
 	assertSessionState(
 		t, env.db, "child-test",
 		func(sess *db.Session) {
-			if sess.ParentSessionID == nil ||
-				*sess.ParentSessionID != "parent-uuid" {
-				t.Errorf("parent_session_id = %v, want %q",
-					sess.ParentSessionID, "parent-uuid")
-			}
+			require.NotNil(t, sess.ParentSessionID,
+				"parent_session_id = %v, want %q", sess.ParentSessionID, "parent-uuid")
+			assert.Equal(t, "parent-uuid", *sess.ParentSessionID,
+				"parent_session_id = %v, want %q", sess.ParentSessionID, "parent-uuid")
 		},
 	)
 }
@@ -2225,10 +2008,7 @@ func TestSyncPathsClaudeNoParentSessionID(t *testing.T) {
 	assertSessionState(
 		t, env.db, "no-parent-test",
 		func(sess *db.Session) {
-			if sess.ParentSessionID != nil {
-				t.Errorf("parent_session_id = %v, want nil",
-					sess.ParentSessionID)
-			}
+			assert.Nil(t, sess.ParentSessionID, "parent_session_id = %v, want nil", sess.ParentSessionID)
 		},
 	)
 }
@@ -2270,12 +2050,7 @@ func TestSyncSubagentSetsParentSessionID(t *testing.T) {
 	assertSessionState(
 		t, env.db, "parent-uuid",
 		func(sess *db.Session) {
-			if sess.ParentSessionID != nil {
-				t.Errorf(
-					"parent parent_session_id = %v, want nil",
-					sess.ParentSessionID,
-				)
-			}
+			assert.Nil(t, sess.ParentSessionID, "parent parent_session_id = %v, want nil", sess.ParentSessionID)
 		},
 	)
 
@@ -2283,27 +2058,18 @@ func TestSyncSubagentSetsParentSessionID(t *testing.T) {
 	assertSessionState(
 		t, env.db, "agent-worker1",
 		func(sess *db.Session) {
-			if sess.ParentSessionID == nil ||
-				*sess.ParentSessionID != "parent-uuid" {
-				t.Errorf(
-					"subagent parent_session_id = %v, "+
-						"want %q",
-					sess.ParentSessionID, "parent-uuid",
-				)
-			}
-			if sess.Agent != "claude" {
-				t.Errorf("agent = %q, want claude",
-					sess.Agent)
-			}
+			require.NotNil(t, sess.ParentSessionID,
+				"subagent parent_session_id = %v, want %q", sess.ParentSessionID, "parent-uuid")
+			assert.Equal(t, "parent-uuid", *sess.ParentSessionID,
+				"subagent parent_session_id = %v, want %q", sess.ParentSessionID, "parent-uuid")
+			assert.Equal(t, "claude", sess.Agent, "agent = %q, want claude", sess.Agent)
 		},
 	)
 	assertSessionMessageCount(t, env.db, "agent-worker1", 2)
 
 	// Verify FindSourceFile works for subagent
 	src := env.engine.FindSourceFile("agent-worker1")
-	if src == "" {
-		t.Error("FindSourceFile returned empty for subagent")
-	}
+	assert.NotEmpty(t, src, "FindSourceFile returned empty for subagent")
 }
 
 func TestSyncClaudeToolResultAgentIDLinksSubagentToolCall(t *testing.T) {
@@ -2344,15 +2110,8 @@ func TestSyncClaudeToolResultAgentIDLinksSubagentToolCall(t *testing.T) {
 		WHERE session_id = ? AND tool_use_id = ?`,
 		"parent-agentid", "toolu_agent_result",
 	).Scan(&got)
-	if err != nil {
-		t.Fatalf("query linked subagent tool call: %v", err)
-	}
-	if got != "agent-abc123def4567890" {
-		t.Errorf(
-			"subagent_session_id = %q, want %q",
-			got, "agent-abc123def4567890",
-		)
-	}
+	require.NoError(t, err, "query linked subagent tool call")
+	assert.Equal(t, "agent-abc123def4567890", got, "subagent_session_id = %q, want %q", got, "agent-abc123def4567890")
 }
 
 func TestSyncClaudeSameMessageIDAgentChunksLinkAllSubagents(t *testing.T) {
@@ -2399,38 +2158,25 @@ func TestSyncClaudeSameMessageIDAgentChunksLinkAllSubagents(t *testing.T) {
 		ORDER BY tool_use_id`,
 		"parent-same-message",
 	)
-	if err != nil {
-		t.Fatalf("query linked subagent tool calls: %v", err)
-	}
+	require.NoError(t, err, "query linked subagent tool calls")
 	defer rows.Close()
 
 	got := map[string]string{}
 	for rows.Next() {
 		var toolUseID, subagentSessionID string
-		if err := rows.Scan(&toolUseID, &subagentSessionID); err != nil {
-			t.Fatalf("scan linked subagent tool call: %v", err)
-		}
+		require.NoError(t, rows.Scan(&toolUseID, &subagentSessionID), "scan linked subagent tool call")
 		got[toolUseID] = subagentSessionID
 	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("iterate linked subagent tool calls: %v", err)
-	}
+	require.NoError(t, rows.Err(), "iterate linked subagent tool calls")
 
 	want := map[string]string{
 		"toolu_first":  "agent-childfirst",
 		"toolu_second": "agent-childsecond",
 		"toolu_third":  "agent-childthird",
 	}
-	if len(got) != len(want) {
-		t.Fatalf("linked tool calls = %v, want %v", got, want)
-	}
+	require.Equal(t, len(want), len(got), "linked tool calls = %v, want %v", got, want)
 	for toolUseID, wantSessionID := range want {
-		if got[toolUseID] != wantSessionID {
-			t.Errorf(
-				"%s subagent_session_id = %q, want %q",
-				toolUseID, got[toolUseID], wantSessionID,
-			)
-		}
+		assert.Equal(t, wantSessionID, got[toolUseID], "%s subagent_session_id = %q, want %q", toolUseID, got[toolUseID], wantSessionID)
 	}
 }
 
@@ -2470,10 +2216,7 @@ func TestSyncPathsClaudeSubagent(t *testing.T) {
 	assertSessionState(
 		t, env.db, "agent-sub1",
 		func(sess *db.Session) {
-			if sess.Agent != "claude" {
-				t.Errorf("agent = %q, want claude",
-					sess.Agent)
-			}
+			assert.Equal(t, "claude", sess.Agent, "agent = %q, want claude", sess.Agent)
 		},
 	)
 }
@@ -2500,12 +2243,7 @@ func TestSyncPathsClaudeRejectsNonAgentInSubagents(t *testing.T) {
 	sess, _ := env.db.GetSession(
 		context.Background(), "not-agent",
 	)
-	if sess != nil {
-		t.Error(
-			"non-agent file in subagents dir " +
-				"should be rejected",
-		)
-	}
+	assert.Nil(t, sess, "non-agent file in subagents dir " + "should be rejected")
 }
 
 func TestSyncPathsClaudeRejectsNested(t *testing.T) {
@@ -2527,12 +2265,7 @@ func TestSyncPathsClaudeRejectsNested(t *testing.T) {
 	sess, _ := env.db.GetSession(
 		context.Background(), "nested",
 	)
-	if sess != nil {
-		t.Error(
-			"nested Claude path should be rejected " +
-				"(only <project>/<session>.jsonl allowed)",
-		)
-	}
+	assert.Nil(t, sess, "nested Claude path should be rejected " + "(only <project>/<session>.jsonl allowed)")
 }
 
 // TestSyncEngineOpenCodeBulkSync verifies that SyncAll
@@ -2575,10 +2308,7 @@ func TestSyncEngineOpenCodeBulkSync(t *testing.T) {
 	agentviewID := "opencode:" + sessionID
 	assertSessionState(t, env.db, agentviewID,
 		func(sess *db.Session) {
-			if sess.Agent != "opencode" {
-				t.Errorf("agent = %q, want opencode",
-					sess.Agent)
-			}
+			assert.Equal(t, "opencode", sess.Agent, "agent = %q, want opencode", sess.Agent)
 		},
 	)
 	assertSessionMessageCount(t, env.db, agentviewID, 2)
@@ -2651,15 +2381,10 @@ func TestSyncEngineOpenCodeStorageBulkSync(t *testing.T) {
 
 	assertSessionState(t, env.db, "opencode:oc-storage-1",
 		func(sess *db.Session) {
-			if sess.Agent != "opencode" {
-				t.Errorf("agent = %q, want opencode",
-					sess.Agent)
-			}
+			assert.Equal(t, "opencode", sess.Agent, "agent = %q, want opencode", sess.Agent)
 		},
 	)
-	if got := env.engine.FindSourceFile("opencode:oc-storage-1"); got != sessionPath {
-		t.Fatalf("FindSourceFile() = %q, want %q", got, sessionPath)
-	}
+	assert.Equal(t, sessionPath, env.engine.FindSourceFile("opencode:oc-storage-1"))
 	assertMessageContent(
 		t, env.db, "opencode:oc-storage-1",
 		"hello from storage", "reply from storage",
@@ -2708,11 +2433,10 @@ func TestSyncSingleSessionOpenCodeSQLiteFallback(t *testing.T) {
 	)
 	oc.updateSessionTime(t, sessionID, timeUpdated+1000)
 
-	if err := env.engine.SyncSingleSession(
+	err := env.engine.SyncSingleSession(
 		"opencode:" + sessionID,
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
@@ -2756,11 +2480,10 @@ func TestSyncSingleSessionOpenCodeSQLiteFallbackPreservesStorageArchive(
 		Skipped:       0,
 	})
 
-	if err := os.RemoveAll(
+	err := os.RemoveAll(
 		filepath.Join(env.opencodeDir, "storage"),
-	); err != nil {
-		t.Fatalf("remove storage tree: %v", err)
-	}
+	)
+	require.NoError(t, err, "remove storage tree")
 
 	sqlite := createOpenCodeDB(t, env.opencodeDir)
 	sqlite.addProject(t, "proj-1", "/home/user/code/myapp")
@@ -2777,11 +2500,10 @@ func TestSyncSingleSessionOpenCodeSQLiteFallbackPreservesStorageArchive(
 		"hello sqlite fallback", 1704067200000,
 	)
 
-	if err := env.engine.SyncSingleSession(
+	err = env.engine.SyncSingleSession(
 		"opencode:" + sessionID,
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
@@ -2875,11 +2597,10 @@ func TestSyncAllOpenCodeSQLiteFallbackPreservesStorageArchive(
 		Skipped:       0,
 	})
 
-	if err := os.RemoveAll(
+	err := os.RemoveAll(
 		filepath.Join(env.opencodeDir, "storage"),
-	); err != nil {
-		t.Fatalf("remove storage tree: %v", err)
-	}
+	)
+	require.NoError(t, err, "remove storage tree")
 
 	sqlite := createOpenCodeDB(t, env.opencodeDir)
 	sqlite.addProject(t, "proj-1", "/home/user/code/myapp")
@@ -2897,12 +2618,8 @@ func TestSyncAllOpenCodeSQLiteFallbackPreservesStorageArchive(
 	)
 
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Failed != 0 {
-		t.Fatalf("stats.Failed = %d, want 0", stats.Failed)
-	}
-	if stats.Synced != 0 {
-		t.Fatalf("stats.Synced = %d, want 0", stats.Synced)
-	}
+	require.Equal(t, 0, stats.Failed, "stats.Failed = %d, want 0", stats.Failed)
+	require.Equal(t, 0, stats.Synced, "stats.Synced = %d, want 0", stats.Synced)
 
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
@@ -2947,9 +2664,7 @@ func TestSyncPathsOpenCodeSQLiteDBEventIgnoresStaleSkipCache(
 	})
 
 	info, err := os.Stat(oc.path)
-	if err != nil {
-		t.Fatalf("stat opencode db: %v", err)
-	}
+	require.NoError(t, err, "stat opencode db")
 	cachedMtime := info.ModTime()
 	env.engine.InjectSkipCache(map[string]int64{
 		oc.path: cachedMtime.UnixNano(),
@@ -2962,9 +2677,7 @@ func TestSyncPathsOpenCodeSQLiteDBEventIgnoresStaleSkipCache(
 		timeCreated,
 	)
 	oc.updateSessionTime(t, sessionID, timeUpdated+1000)
-	if err := os.Chtimes(oc.path, cachedMtime, cachedMtime); err != nil {
-		t.Fatalf("restore db mtime: %v", err)
-	}
+	require.NoError(t, os.Chtimes(oc.path, cachedMtime, cachedMtime), "restore db mtime")
 
 	env.engine.SyncPaths([]string{oc.path})
 
@@ -3091,21 +2804,16 @@ func TestSyncAllOpenCodeSQLiteReparsesStaleDataVersion(
 		"role":    "assistant",
 		"modelID": "claude-3-7-sonnet",
 	})
-	if err := env.db.SetSessionDataVersion(
+	err := env.db.SetSessionDataVersion(
 		"opencode:"+sessionID, 0,
-	); err != nil {
-		t.Fatalf("SetSessionDataVersion: %v", err)
-	}
+	)
+	require.NoError(t, err, "SetSessionDataVersion")
 
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Synced != 1 {
-		t.Fatalf("SyncAll synced = %d, want 1", stats.Synced)
-	}
+	require.Equal(t, 1, stats.Synced, "SyncAll synced = %d, want 1", stats.Synced)
 
 	msgs := fetchMessages(t, env.db, "opencode:"+sessionID)
-	if got := msgs[1].Model; got != "claude-3-7-sonnet" {
-		t.Fatalf("assistant model = %q, want claude-3-7-sonnet", got)
-	}
+	assert.Equal(t, "claude-3-7-sonnet", msgs[1].Model)
 }
 
 func TestSyncPathsOpenCodeStorageChildRetryWithoutSessionMtimeChange(
@@ -3123,28 +2831,21 @@ func TestSyncPathsOpenCodeStorageChildRetryWithoutSessionMtimeChange(
 		env.opencodeDir, "storage", "message",
 		"oc-storage-retry", "msg-u1.json",
 	)
-	if err := os.MkdirAll(filepath.Dir(messagePath), 0o755); err != nil {
-		t.Fatalf("mkdir message dir: %v", err)
-	}
-	if err := os.WriteFile(
+	require.NoError(t, os.MkdirAll(filepath.Dir(messagePath), 0o755), "mkdir message dir")
+	err := os.WriteFile(
 		messagePath, []byte(`{"id":"msg-u1"`), 0o644,
-	); err != nil {
-		t.Fatalf("write invalid message: %v", err)
-	}
+	)
+	require.NoError(t, err, "write invalid message")
 
 	env.engine.SyncPaths([]string{messagePath})
-	if sess, err := env.db.GetSession(
+	sess, err := env.db.GetSession(
 		context.Background(), "opencode:oc-storage-retry",
-	); err != nil {
-		t.Fatalf("GetSession: %v", err)
-	} else if sess != nil {
-		t.Fatalf("unexpected session after invalid child parse: %+v", sess)
-	}
+	)
+	require.NoError(t, err, "GetSession")
+	require.Nil(t, sess, "unexpected session after invalid child parse: %+v", sess)
 
 	info, err := os.Stat(sessionPath)
-	if err != nil {
-		t.Fatalf("stat session path: %v", err)
-	}
+	require.NoError(t, err, "stat session path")
 	sessionMtime := info.ModTime().UnixNano()
 
 	oc.addMessage(
@@ -3155,13 +2856,12 @@ func TestSyncPathsOpenCodeStorageChildRetryWithoutSessionMtimeChange(
 		t, "oc-storage-retry", "msg-u1", "part-u1",
 		"hello after retry", 1704067200000,
 	)
-	if err := os.Chtimes(
+	err = os.Chtimes(
 		sessionPath,
 		time.Unix(0, sessionMtime),
 		time.Unix(0, sessionMtime),
-	); err != nil {
-		t.Fatalf("restore session mtime: %v", err)
-	}
+	)
+	require.NoError(t, err, "restore session mtime")
 
 	env.engine.SyncPaths([]string{messagePath})
 
@@ -3200,54 +2900,37 @@ func TestSyncPathsOpenCodeStorageChildUpdateAdvancesSessionMtime(
 	_, initialMtime, ok := env.db.GetSessionFileInfo(
 		"opencode:oc-storage-mtime",
 	)
-	if !ok {
-		t.Fatal("expected initial session file_mtime")
-	}
+	require.True(t, ok, "expected initial session file_mtime")
 
 	info, err := os.Stat(sessionPath)
-	if err != nil {
-		t.Fatalf("stat session path: %v", err)
-	}
+	require.NoError(t, err, "stat session path")
 	sessionMtime := info.ModTime().UnixNano()
 
-	if err := os.WriteFile(partPath, []byte(
+	err = os.WriteFile(partPath, []byte(
 		`{"id":"part-a1","sessionID":"oc-storage-mtime","messageID":"msg-a1","type":"text","text":"updated reply","time":{"created":1704067201000}}`,
-	), 0o644); err != nil {
-		t.Fatalf("rewrite part: %v", err)
-	}
-	if err := os.Chtimes(
+	), 0o644)
+	require.NoError(t, err, "rewrite part")
+	err = os.Chtimes(
 		sessionPath,
 		time.Unix(0, sessionMtime),
 		time.Unix(0, sessionMtime),
-	); err != nil {
-		t.Fatalf("restore session mtime: %v", err)
-	}
-	if _, parsedMsgs, err := parser.ParseOpenCodeFile(
+	)
+	require.NoError(t, err, "restore session mtime")
+	_, parsedMsgs, parseErr := parser.ParseOpenCodeFile(
 		sessionPath, "local",
-	); err != nil {
-		t.Fatalf("ParseOpenCodeFile after rewrite: %v", err)
-	} else if len(parsedMsgs) != 1 ||
-		parsedMsgs[0].Content != "updated reply" {
-		t.Fatalf(
-			"parsed messages after rewrite = %#v, want updated reply",
-			parsedMsgs,
-		)
-	}
+	)
+	require.NoError(t, parseErr, "ParseOpenCodeFile after rewrite")
+	require.Len(t, parsedMsgs, 1, "parsed messages after rewrite = %#v, want updated reply", parsedMsgs)
+	require.Equal(t, "updated reply", parsedMsgs[0].Content,
+		"parsed messages after rewrite = %#v, want updated reply", parsedMsgs)
 
 	env.engine.SyncPaths([]string{partPath})
 
 	_, updatedMtime, ok := env.db.GetSessionFileInfo(
 		"opencode:oc-storage-mtime",
 	)
-	if !ok {
-		t.Fatal("expected updated session file_mtime")
-	}
-	if updatedMtime <= initialMtime {
-		t.Fatalf(
-			"updated file_mtime = %d, want > %d",
-			updatedMtime, initialMtime,
-		)
-	}
+	require.True(t, ok, "expected updated session file_mtime")
+	require.Greater(t, updatedMtime, initialMtime, "updated file_mtime = %d, want > %d", updatedMtime, initialMtime)
 	assertMessageContent(
 		t, env.db, "opencode:oc-storage-mtime",
 		"updated reply",
@@ -3273,33 +2956,22 @@ func TestSourceMtimeOpenCodeStorageIncludesChildFiles(t *testing.T) {
 	)
 
 	initialMtime := env.engine.SourceMtime("opencode:oc-source-mtime")
-	if initialMtime == 0 {
-		t.Fatal("expected initial composite source mtime")
-	}
+	require.NotZero(t, initialMtime, "expected initial composite source mtime")
 
 	info, err := os.Stat(sessionPath)
-	if err != nil {
-		t.Fatalf("stat session path: %v", err)
-	}
+	require.NoError(t, err, "stat session path")
 	sessionMtime := info.ModTime()
 	future := time.Now().Add(2 * time.Second)
 
-	if err := os.WriteFile(partPath, []byte(
+	err = os.WriteFile(partPath, []byte(
 		`{"id":"part-a1","sessionID":"oc-source-mtime","messageID":"msg-a1","type":"text","text":"updated reply","time":{"created":1704067201000}}`,
-	), 0o644); err != nil {
-		t.Fatalf("rewrite part: %v", err)
-	}
-	if err := os.Chtimes(partPath, future, future); err != nil {
-		t.Fatalf("chtimes part: %v", err)
-	}
-	if err := os.Chtimes(sessionPath, sessionMtime, sessionMtime); err != nil {
-		t.Fatalf("restore session mtime: %v", err)
-	}
+	), 0o644)
+	require.NoError(t, err, "rewrite part")
+	require.NoError(t, os.Chtimes(partPath, future, future), "chtimes part")
+	require.NoError(t, os.Chtimes(sessionPath, sessionMtime, sessionMtime), "restore session mtime")
 
 	updatedMtime := env.engine.SourceMtime("opencode:oc-source-mtime")
-	if updatedMtime <= initialMtime {
-		t.Fatalf("updated source mtime = %d, want > %d", updatedMtime, initialMtime)
-	}
+	require.Greater(t, updatedMtime, initialMtime, "updated source mtime = %d, want > %d", updatedMtime, initialMtime)
 }
 
 func TestSourceMtimeOpenCodeStorageTracksChildRemoval(t *testing.T) {
@@ -3321,23 +2993,15 @@ func TestSourceMtimeOpenCodeStorageTracksChildRemoval(t *testing.T) {
 	)
 
 	initialMtime := env.engine.SourceMtime("opencode:oc-source-remove")
-	if initialMtime == 0 {
-		t.Fatal("expected initial composite source mtime")
-	}
+	require.NotZero(t, initialMtime, "expected initial composite source mtime")
 
 	partDir := filepath.Dir(partPath)
-	if err := os.Remove(partPath); err != nil {
-		t.Fatalf("remove part: %v", err)
-	}
+	require.NoError(t, os.Remove(partPath), "remove part")
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(partDir, future, future); err != nil {
-		t.Fatalf("chtimes part dir: %v", err)
-	}
+	require.NoError(t, os.Chtimes(partDir, future, future), "chtimes part dir")
 
 	updatedMtime := env.engine.SourceMtime("opencode:oc-source-remove")
-	if updatedMtime <= initialMtime {
-		t.Fatalf("updated source mtime = %d, want > %d", updatedMtime, initialMtime)
-	}
+	require.Greater(t, updatedMtime, initialMtime, "updated source mtime = %d, want > %d", updatedMtime, initialMtime)
 }
 
 func TestSourceMtimeOpenCodeStorageTracksPartDirRemoval(t *testing.T) {
@@ -3359,25 +3023,17 @@ func TestSourceMtimeOpenCodeStorageTracksPartDirRemoval(t *testing.T) {
 	)
 
 	initialMtime := env.engine.SourceMtime("opencode:oc-source-remove-dir")
-	if initialMtime == 0 {
-		t.Fatal("expected initial composite source mtime")
-	}
+	require.NotZero(t, initialMtime, "expected initial composite source mtime")
 
 	future := time.Now().Add(2 * time.Second)
-	if err := os.RemoveAll(filepath.Dir(partPath)); err != nil {
-		t.Fatalf("remove part dir: %v", err)
-	}
+	require.NoError(t, os.RemoveAll(filepath.Dir(partPath)), "remove part dir")
 	partRoot := filepath.Join(
 		env.opencodeDir, "storage", "part",
 	)
-	if err := os.Chtimes(partRoot, future, future); err != nil {
-		t.Fatalf("chtimes part root: %v", err)
-	}
+	require.NoError(t, os.Chtimes(partRoot, future, future), "chtimes part root")
 
 	updatedMtime := env.engine.SourceMtime("opencode:oc-source-remove-dir")
-	if updatedMtime <= initialMtime {
-		t.Fatalf("updated source mtime = %d, want > %d", updatedMtime, initialMtime)
-	}
+	require.Greater(t, updatedMtime, initialMtime, "updated source mtime = %d, want > %d", updatedMtime, initialMtime)
 }
 
 func TestSourceMtimeOpenCodeStorageTracksMessageDirRemoval(
@@ -3403,30 +3059,19 @@ func TestSourceMtimeOpenCodeStorageTracksMessageDirRemoval(
 	initialMtime := env.engine.SourceMtime(
 		"opencode:oc-source-remove-message-dir",
 	)
-	if initialMtime == 0 {
-		t.Fatal("expected initial composite source mtime")
-	}
+	require.NotZero(t, initialMtime, "expected initial composite source mtime")
 
 	future := time.Now().Add(2 * time.Second)
-	if err := os.RemoveAll(filepath.Dir(messagePath)); err != nil {
-		t.Fatalf("remove message dir: %v", err)
-	}
+	require.NoError(t, os.RemoveAll(filepath.Dir(messagePath)), "remove message dir")
 	messageRoot := filepath.Join(
 		env.opencodeDir, "storage", "message",
 	)
-	if err := os.Chtimes(messageRoot, future, future); err != nil {
-		t.Fatalf("chtimes message root: %v", err)
-	}
+	require.NoError(t, os.Chtimes(messageRoot, future, future), "chtimes message root")
 
 	updatedMtime := env.engine.SourceMtime(
 		"opencode:oc-source-remove-message-dir",
 	)
-	if updatedMtime <= initialMtime {
-		t.Fatalf(
-			"updated source mtime = %d, want > %d",
-			updatedMtime, initialMtime,
-		)
-	}
+	require.Greater(t, updatedMtime, initialMtime, "updated source mtime = %d, want > %d", updatedMtime, initialMtime)
 }
 
 func TestSourceMtimeOpenCodeSQLiteUsesSessionTime(t *testing.T) {
@@ -3439,16 +3084,12 @@ func TestSourceMtimeOpenCodeSQLiteUsesSessionTime(t *testing.T) {
 	)
 
 	initialMtime := env.engine.SourceMtime("opencode:oc-source-sqlite")
-	if initialMtime != 1704067205000*1_000_000 {
-		t.Fatalf("initial source mtime = %d, want %d", initialMtime, 1704067205000*1_000_000)
-	}
+	require.Equal(t, int64(1704067205000*1_000_000), initialMtime, "initial source mtime = %d, want %d", initialMtime, 1704067205000*1_000_000)
 
 	oc.updateSessionTime(t, "oc-source-sqlite", 1704067210000)
 
 	updatedMtime := env.engine.SourceMtime("opencode:oc-source-sqlite")
-	if updatedMtime != 1704067210000*1_000_000 {
-		t.Fatalf("updated source mtime = %d, want %d", updatedMtime, 1704067210000*1_000_000)
-	}
+	require.Equal(t, int64(1704067210000*1_000_000), updatedMtime, "updated source mtime = %d, want %d", updatedMtime, 1704067210000*1_000_000)
 }
 
 func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
@@ -3509,12 +3150,8 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 	)
 
 	virtualPath := parser.OpenCodeSQLiteVirtualPath(sqlite.path, sessionID)
-	if got := env.engine.FindSourceFile("opencode:" + sessionID); got != virtualPath {
-		t.Fatalf("FindSourceFile() = %q, want %q", got, virtualPath)
-	}
-	if got := env.engine.SourceMtime("opencode:" + sessionID); got != timeUpdated*1_000_000 {
-		t.Fatalf("SourceMtime() = %d, want %d", got, timeUpdated*1_000_000)
-	}
+	assert.Equal(t, virtualPath, env.engine.FindSourceFile("opencode:"+sessionID))
+	assert.Equal(t, timeUpdated*1_000_000, env.engine.SourceMtime("opencode:"+sessionID))
 
 	sqlite.replaceTextContent(
 		t, sessionID,
@@ -3537,9 +3174,7 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 		timeCreated,
 	)
 	sqlite.updateSessionTime(t, sessionID, timeUpdated+2000)
-	if err := env.engine.SyncSingleSession("opencode:" + sessionID); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	require.NoError(t, env.engine.SyncSingleSession("opencode:" + sessionID), "SyncSingleSession")
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
 		"updated by single sync",
@@ -3556,18 +3191,16 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 func TestFindSourceFileSkipsHybridRootMissingSession(t *testing.T) {
 	hybridRoot := t.TempDir()
 	storageRoot := t.TempDir()
-	if err := os.MkdirAll(
+	err := os.MkdirAll(
 		filepath.Join(hybridRoot, "storage", "session", "global"),
 		0o755,
-	); err != nil {
-		t.Fatalf("mkdir hybrid storage: %v", err)
-	}
-	if err := os.MkdirAll(
+	)
+	require.NoError(t, err, "mkdir hybrid storage")
+	err = os.MkdirAll(
 		filepath.Join(storageRoot, "storage", "session", "global"),
 		0o755,
-	); err != nil {
-		t.Fatalf("mkdir storage root: %v", err)
-	}
+	)
+	require.NoError(t, err, "mkdir storage root")
 
 	hybridDB := createOpenCodeDB(t, hybridRoot)
 	hybridDB.addProject(t, "proj-x", "/tmp/x")
@@ -3600,12 +3233,7 @@ func TestFindSourceFileSkipsHybridRootMissingSession(t *testing.T) {
 		storageRoot, "storage", "session", "global",
 		wantedID+".json",
 	)
-	if got := env.engine.FindSourceFile("opencode:" + wantedID); got != wantPath {
-		t.Fatalf(
-			"FindSourceFile() = %q, want %q (hybrid root must not shadow)",
-			got, wantPath,
-		)
-	}
+	require.Equal(t, wantPath, env.engine.FindSourceFile("opencode:"+wantedID), "FindSourceFile() = ..., want %q (hybrid root must not shadow)", wantPath)
 }
 
 // TestOpenCodeHybridRootStorageWinsOnDuplicateID covers a hybrid
@@ -3673,9 +3301,7 @@ func TestOpenCodeHybridRootStorageWinsOnDuplicateID(t *testing.T) {
 		env.opencodeDir, "storage", "session", "global",
 		sessionID+".json",
 	)
-	if got := env.engine.FindSourceFile("opencode:" + sessionID); got != storagePath {
-		t.Fatalf("FindSourceFile() = %q, want %q", got, storagePath)
-	}
+	assert.Equal(t, storagePath, env.engine.FindSourceFile("opencode:"+sessionID))
 
 	// SyncPaths on opencode.db must also leave the storage
 	// transcript untouched, even though the SQLite session was
@@ -3720,41 +3346,28 @@ func TestSyncAllSinceOpenCodeStorageRequiresSessionMtime(t *testing.T) {
 
 	cutoff := time.Now()
 	info, err := os.Stat(sessionPath)
-	if err != nil {
-		t.Fatalf("stat session path: %v", err)
-	}
+	require.NoError(t, err, "stat session path")
 	sessionMtime := info.ModTime()
 	future := cutoff.Add(2 * time.Second)
 
-	if err := os.WriteFile(partPath, []byte(
+	err = os.WriteFile(partPath, []byte(
 		`{"id":"part-a1","sessionID":"oc-since-child","messageID":"msg-a1","type":"text","text":"updated reply","time":{"created":1704067201000}}`,
-	), 0o644); err != nil {
-		t.Fatalf("rewrite part: %v", err)
-	}
-	if err := os.Chtimes(partPath, future, future); err != nil {
-		t.Fatalf("chtimes part: %v", err)
-	}
-	if err := os.Chtimes(sessionPath, sessionMtime, sessionMtime); err != nil {
-		t.Fatalf("restore session mtime: %v", err)
-	}
+	), 0o644)
+	require.NoError(t, err, "rewrite part")
+	require.NoError(t, os.Chtimes(partPath, future, future), "chtimes part")
+	require.NoError(t, os.Chtimes(sessionPath, sessionMtime, sessionMtime), "restore session mtime")
 
 	stats := env.engine.SyncAllSince(context.Background(), cutoff, nil)
-	if stats.Synced != 0 {
-		t.Fatalf("SyncAllSince synced = %d, want 0", stats.Synced)
-	}
+	require.Equal(t, 0, stats.Synced, "SyncAllSince synced = %d, want 0", stats.Synced)
 	assertMessageContent(
 		t, env.db, "opencode:oc-since-child",
 		"initial reply",
 	)
 
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("chtimes session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "chtimes session path")
 
 	stats = env.engine.SyncAllSince(context.Background(), cutoff, nil)
-	if stats.Synced != 1 {
-		t.Fatalf("SyncAllSince synced = %d, want 1", stats.Synced)
-	}
+	require.Equal(t, 1, stats.Synced, "SyncAllSince synced = %d, want 1", stats.Synced)
 	assertMessageContent(
 		t, env.db, "opencode:oc-since-child",
 		"updated reply",
@@ -3786,9 +3399,8 @@ func TestSyncAllOpenCodeStorageSkipsUnchangedSessions(t *testing.T) {
 	})
 
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Skipped != 1 || stats.Synced != 0 {
-		t.Fatalf("SyncAll stats = %+v, want 1 skipped and 0 synced", stats)
-	}
+	require.Equal(t, 1, stats.Skipped, "SyncAll stats = %+v, want 1 skipped and 0 synced", stats)
+	require.Equal(t, 0, stats.Synced, "SyncAll stats = %+v, want 1 skipped and 0 synced", stats)
 }
 
 func TestSyncAllOpenCodeStorageMissingMessagePreservesArchive(t *testing.T) {
@@ -3823,13 +3435,9 @@ func TestSyncAllOpenCodeStorageMissingMessagePreservesArchive(t *testing.T) {
 		Skipped:       0,
 	})
 
-	if err := os.Remove(messagePath); err != nil {
-		t.Fatalf("remove message file: %v", err)
-	}
+	require.NoError(t, os.Remove(messagePath), "remove message file")
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("touch session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "touch session path")
 
 	env.engine.SyncAll(context.Background(), nil)
 
@@ -3931,21 +3539,13 @@ func TestSyncAllOpenCodeStorageMissingPartDirPreservesArchive(t *testing.T) {
 		Skipped:       0,
 	})
 
-	if err := os.RemoveAll(filepath.Dir(partPath)); err != nil {
-		t.Fatalf("remove part dir: %v", err)
-	}
+	require.NoError(t, os.RemoveAll(filepath.Dir(partPath)), "remove part dir")
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("touch session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "touch session path")
 
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Failed != 0 {
-		t.Fatalf("stats.Failed = %d, want 0", stats.Failed)
-	}
-	if stats.Synced != 0 {
-		t.Fatalf("stats.Synced = %d, want 0", stats.Synced)
-	}
+	require.Equal(t, 0, stats.Failed, "stats.Failed = %d, want 0", stats.Failed)
+	require.Equal(t, 0, stats.Synced, "stats.Synced = %d, want 0", stats.Synced)
 
 	assertMessageContent(
 		t, env.db, "opencode:oc-missing-part",
@@ -3988,19 +3588,14 @@ func TestSyncSingleSessionOpenCodeStorageMissingMessagePreservesArchive(
 		Skipped:       0,
 	})
 
-	if err := os.Remove(messagePath); err != nil {
-		t.Fatalf("remove message file: %v", err)
-	}
+	require.NoError(t, os.Remove(messagePath), "remove message file")
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("touch session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "touch session path")
 
-	if err := env.engine.SyncSingleSession(
+	err := env.engine.SyncSingleSession(
 		"opencode:" + sessionID,
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
@@ -4048,23 +3643,16 @@ func TestSyncSingleSessionOpenCodeStoragePreservedUpdateDoesNotEmit(
 	em.scopes = em.scopes[:0]
 	em.mu.Unlock()
 
-	if err := os.Remove(messagePath); err != nil {
-		t.Fatalf("remove message file: %v", err)
-	}
+	require.NoError(t, os.Remove(messagePath), "remove message file")
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("touch session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "touch session path")
 
-	if err := env.engine.SyncSingleSession(
+	err := env.engine.SyncSingleSession(
 		"opencode:" + sessionID,
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
-	if got := em.got(); len(got) != 0 {
-		t.Fatalf("expected no emissions for preserved update, got %v", got)
-	}
+	assert.Empty(t, em.got(), "expected no emissions for preserved update")
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
 		"question", "answer",
@@ -4106,9 +3694,7 @@ func TestSyncPathsOpenCodeStorageMissingMessagePreservesArchive(
 		Skipped:       0,
 	})
 
-	if err := os.Remove(messagePath); err != nil {
-		t.Fatalf("remove message file: %v", err)
-	}
+	require.NoError(t, os.Remove(messagePath), "remove message file")
 
 	env.engine.SyncPaths([]string{messagePath})
 
@@ -4158,19 +3744,13 @@ func TestSyncPathsOpenCodeStoragePreservedUpdateDoesNotEmitOrCountSynced(
 	em.scopes = em.scopes[:0]
 	em.mu.Unlock()
 
-	if err := os.Remove(messagePath); err != nil {
-		t.Fatalf("remove message file: %v", err)
-	}
+	require.NoError(t, os.Remove(messagePath), "remove message file")
 
 	env.engine.SyncPaths([]string{messagePath})
 
-	if got := em.got(); len(got) != 0 {
-		t.Fatalf("expected no emissions for preserved SyncPaths update, got %v", got)
-	}
+	assert.Empty(t, em.got(), "expected no emissions for preserved SyncPaths update")
 	stats := env.engine.LastSyncStats()
-	if stats.Synced != 0 {
-		t.Fatalf("LastSyncStats().Synced = %d, want 0", stats.Synced)
-	}
+	require.Equal(t, 0, stats.Synced, "LastSyncStats().Synced = %d, want 0", stats.Synced)
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
 		"question", "answer",
@@ -4212,9 +3792,7 @@ func TestSyncPathsOpenCodeStorageMissingPartDirPreservesArchive(
 		Skipped:       0,
 	})
 
-	if err := os.RemoveAll(filepath.Dir(partPath)); err != nil {
-		t.Fatalf("remove part dir: %v", err)
-	}
+	require.NoError(t, os.RemoveAll(filepath.Dir(partPath)), "remove part dir")
 
 	env.engine.SyncPaths([]string{messagePath})
 
@@ -4255,19 +3833,14 @@ func TestSyncSingleSessionOpenCodeStorageMissingPartPreservesArchive(
 		Skipped:       0,
 	})
 
-	if err := os.Remove(part1Path); err != nil {
-		t.Fatalf("remove part file: %v", err)
-	}
+	require.NoError(t, os.Remove(part1Path), "remove part file")
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("touch session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "touch session path")
 
-	if err := env.engine.SyncSingleSession(
+	err := env.engine.SyncSingleSession(
 		"opencode:" + sessionID,
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
@@ -4306,9 +3879,7 @@ func TestSyncAllOpenCodeStorageContentRewritePreservesArchive(
 		`{"id":"part-u1","sessionID":"`+sessionID+`","messageID":"msg-u1","type":"text","text":"cut","time":{"created":1704067200000}}`,
 	))
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("touch session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "touch session path")
 
 	env.engine.SyncAll(context.Background(), nil)
 
@@ -4362,54 +3933,28 @@ func TestSyncAllOpenCodeStorageMissingStepFinishPreservesTokens(
 		Skipped:       0,
 	})
 
-	if err := os.Remove(stepFinishPath); err != nil {
-		t.Fatalf("remove step-finish part: %v", err)
-	}
+	require.NoError(t, os.Remove(stepFinishPath), "remove step-finish part")
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("touch session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "touch session path")
 
 	env.engine.SyncAll(context.Background(), nil)
 
 	full, err := env.db.GetSessionFull(
 		context.Background(), "opencode:"+sessionID,
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if full == nil {
-		t.Fatal("session missing after preserve")
-	}
-	if !full.HasTotalOutputTokens || full.TotalOutputTokens != 200 {
-		t.Fatalf(
-			"session output tokens = (%v, %d), want (true, 200)",
-			full.HasTotalOutputTokens, full.TotalOutputTokens,
-		)
-	}
-	if !full.HasPeakContextTokens || full.PeakContextTokens != 300 {
-		t.Fatalf(
-			"session context tokens = (%v, %d), want (true, 300)",
-			full.HasPeakContextTokens, full.PeakContextTokens,
-		)
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, full, "session missing after preserve")
+	require.True(t, full.HasTotalOutputTokens, "session output tokens = (%v, %d), want (true, 200)", full.HasTotalOutputTokens, full.TotalOutputTokens)
+	require.Equal(t, 200, full.TotalOutputTokens, "session output tokens = (%v, %d), want (true, 200)", full.HasTotalOutputTokens, full.TotalOutputTokens)
+	require.True(t, full.HasPeakContextTokens, "session context tokens = (%v, %d), want (true, 300)", full.HasPeakContextTokens, full.PeakContextTokens)
+	require.Equal(t, 300, full.PeakContextTokens, "session context tokens = (%v, %d), want (true, 300)", full.HasPeakContextTokens, full.PeakContextTokens)
 
 	msgs := fetchMessages(t, env.db, "opencode:"+sessionID)
-	if len(msgs) != 1 {
-		t.Fatalf("len(msgs) = %d, want 1", len(msgs))
-	}
-	if !msgs[0].HasOutputTokens || msgs[0].OutputTokens != 200 {
-		t.Fatalf(
-			"message output tokens = (%v, %d), want (true, 200)",
-			msgs[0].HasOutputTokens, msgs[0].OutputTokens,
-		)
-	}
-	if !msgs[0].HasContextTokens || msgs[0].ContextTokens != 300 {
-		t.Fatalf(
-			"message context tokens = (%v, %d), want (true, 300)",
-			msgs[0].HasContextTokens, msgs[0].ContextTokens,
-		)
-	}
+	require.Len(t, msgs, 1, "len(msgs) = %d, want 1", len(msgs))
+	require.True(t, msgs[0].HasOutputTokens, "message output tokens = (%v, %d), want (true, 200)", msgs[0].HasOutputTokens, msgs[0].OutputTokens)
+	require.Equal(t, 200, msgs[0].OutputTokens, "message output tokens = (%v, %d), want (true, 200)", msgs[0].HasOutputTokens, msgs[0].OutputTokens)
+	require.True(t, msgs[0].HasContextTokens, "message context tokens = (%v, %d), want (true, 300)", msgs[0].HasContextTokens, msgs[0].ContextTokens)
+	require.Equal(t, 300, msgs[0].ContextTokens, "message context tokens = (%v, %d), want (true, 300)", msgs[0].HasContextTokens, msgs[0].ContextTokens)
 }
 
 // TestSyncEngineOpenCodeToolCallReplace verifies that tool
@@ -4610,9 +4155,7 @@ func TestSyncEnginePostFilterCounts(t *testing.T) {
 	// Verify stored counts match post-filter values.
 	assertSessionMessageCount(t, env.db, "filter-count", 3)
 	assertSessionState(t, env.db, "filter-count", func(sess *db.Session) {
-		if sess.UserMessageCount != 1 {
-			t.Errorf("user_message_count = %d, want 1", sess.UserMessageCount)
-		}
+		assert.Equal(t, 1, sess.UserMessageCount, "user_message_count = %d, want 1", sess.UserMessageCount)
 	})
 }
 
@@ -4671,22 +4214,17 @@ func TestSyncSingleSessionPostFilterCounts(t *testing.T) {
 		}
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("corrupt counts: %v", err)
-	}
+	require.NoError(t, err, "corrupt counts")
 
-	if err := env.engine.SyncSingleSession(
+	err = env.engine.SyncSingleSession(
 		"filter-single",
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	// Counts should be corrected by writeSessionFull.
 	assertSessionMessageCount(t, env.db, "filter-single", 3)
 	assertSessionState(t, env.db, "filter-single", func(sess *db.Session) {
-		if sess.UserMessageCount != 1 {
-			t.Errorf("user_message_count = %d, want 1", sess.UserMessageCount)
-		}
+		assert.Equal(t, 1, sess.UserMessageCount, "user_message_count = %d, want 1", sess.UserMessageCount)
 	})
 }
 
@@ -4725,9 +4263,7 @@ func TestSyncEngineMultiClaudeDir(t *testing.T) {
 
 	// FindSourceFile should search across directories
 	src := env.engine.FindSourceFile("sess2")
-	if src == "" {
-		t.Error("FindSourceFile failed for sess2 in second directory")
-	}
+	assert.NotEmpty(t, src, "FindSourceFile failed for sess2 in second directory")
 }
 
 // TestSyncEngineMultiCursorDir verifies that SyncAll and
@@ -4768,23 +4304,13 @@ func TestSyncEngineMultiCursorDir(t *testing.T) {
 	assertSessionState(
 		t, env.db, "cursor:sess1",
 		func(sess *db.Session) {
-			if sess.Agent != "cursor" {
-				t.Errorf(
-					"agent = %q, want cursor",
-					sess.Agent,
-				)
-			}
+			assert.Equal(t, "cursor", sess.Agent, "agent = %q, want cursor", sess.Agent)
 		},
 	)
 	assertSessionState(
 		t, env.db, "cursor:sess2",
 		func(sess *db.Session) {
-			if sess.Agent != "cursor" {
-				t.Errorf(
-					"agent = %q, want cursor",
-					sess.Agent,
-				)
-			}
+			assert.Equal(t, "cursor", sess.Agent, "agent = %q, want cursor", sess.Agent)
 		},
 	)
 
@@ -4800,12 +4326,7 @@ func TestSyncEngineMultiCursorDir(t *testing.T) {
 
 	// FindSourceFile should work across directories.
 	src := env.engine.FindSourceFile("cursor:sess2")
-	if src == "" {
-		t.Error(
-			"FindSourceFile failed for cursor:sess2 " +
-				"in second directory",
-		)
-	}
+	assert.NotEmpty(t, src, "FindSourceFile failed for cursor:sess2 " + "in second directory")
 }
 
 func TestSyncPathsCursorNestedLayout(t *testing.T) {
@@ -4851,15 +4372,12 @@ func TestSyncSingleSessionCursorNestedLayoutPreservesProject(
 		"assistant:\nHi there!\n" +
 		"user:\nFollow-up\n" +
 		"assistant:\nGot it.\n"
-	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(updated), 0o644), "WriteFile")
 
-	if err := env.engine.SyncSingleSession(
+	err := env.engine.SyncSingleSession(
 		"cursor:nested-resync",
-	); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "SyncSingleSession")
 
 	assertSessionProject(
 		t, env.db, "cursor:nested-resync", "nested_proj",
@@ -4897,12 +4415,9 @@ func TestSyncForkDetection(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "parent-uuid-i", 2)
 
 	assertSessionState(t, env.db, "parent-uuid-i", func(sess *db.Session) {
-		if sess.ParentSessionID == nil || *sess.ParentSessionID != "parent-uuid" {
-			t.Errorf("fork parent = %v, want parent-uuid", sess.ParentSessionID)
-		}
-		if sess.RelationshipType != "fork" {
-			t.Errorf("fork relationship_type = %q, want fork", sess.RelationshipType)
-		}
+		require.NotNil(t, sess.ParentSessionID, "fork parent = nil, want parent-uuid")
+		assert.Equal(t, "parent-uuid", *sess.ParentSessionID, "fork parent = %v, want parent-uuid", sess.ParentSessionID)
+		assert.Equal(t, "fork", sess.RelationshipType, "fork relationship_type = %q, want fork", sess.RelationshipType)
 	})
 }
 
@@ -4963,9 +4478,7 @@ func TestResyncAllReplacesMessageContent(t *testing.T) {
 
 	fullID := "gemini:" + sessionID
 	msgs := fetchMessages(t, env.db, fullID)
-	if len(msgs) != 2 {
-		t.Fatalf("got %d messages, want 2", len(msgs))
-	}
+	require.Equal(t, 2, len(msgs), "got %d messages, want 2", len(msgs))
 
 	// Simulate a parser change by directly modifying message
 	// content in the DB. This mirrors what happens when the Go
@@ -4980,19 +4493,13 @@ func TestResyncAllReplacesMessageContent(t *testing.T) {
 		)
 		return err
 	})
-	if err != nil {
-		t.Fatalf("update message content: %v", err)
-	}
+	require.NoError(t, err, "update message content")
 
 	// Normal SyncAll should skip (file unchanged on disk).
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Skipped != 1 {
-		t.Fatalf("expected 1 skip, got %d", stats.Skipped)
-	}
+	require.Equal(t, 1, stats.Skipped, "expected 1 skip, got %d", stats.Skipped)
 	msgs = fetchMessages(t, env.db, fullID)
-	if !strings.Contains(msgs[1].Content, "stale content") {
-		t.Fatal("SyncAll should not have replaced content")
-	}
+	require.True(t, strings.Contains(msgs[1].Content, "stale content"), "SyncAll should not have replaced content")
 
 	// Capture FTS state before resync so a regression that
 	// breaks FTS isn't masked by HasFTS() returning false
@@ -5002,44 +4509,21 @@ func TestResyncAllReplacesMessageContent(t *testing.T) {
 	// ResyncAll should re-parse and replace message content.
 	env.engine.ResyncAll(context.Background(), nil)
 	msgs = fetchMessages(t, env.db, fullID)
-	if len(msgs) != 2 {
-		t.Fatalf("got %d messages after resync, want 2",
-			len(msgs))
-	}
-	if strings.Contains(msgs[1].Content, "stale content") {
-		t.Error(
-			"ResyncAll did not replace message content",
-		)
-	}
-	if !strings.Contains(
-		msgs[1].Content, "Here is the explanation.",
-	) {
-		t.Errorf(
-			"unexpected content after resync: %q",
-			msgs[1].Content,
-		)
-	}
+	require.Equal(t, 2, len(msgs), "got %d messages after resync, want 2", len(msgs))
+	assert.NotContains(t, msgs[1].Content, "stale content", "ResyncAll did not replace message content")
+	assert.Contains(t, msgs[1].Content, "Here is the explanation.",
+		"unexpected content after resync: %q", msgs[1].Content)
 
 	// FTS search should work after resync (index was dropped
 	// and rebuilt).
 	if hadFTS {
-		if !env.db.HasFTS() {
-			t.Fatal(
-				"FTS available before resync but not after",
-			)
-		}
+		require.True(t, env.db.HasFTS(), "FTS available before resync but not after")
 		page, err := env.db.Search(
 			context.Background(),
 			db.SearchFilter{Query: "explanation"},
 		)
-		if err != nil {
-			t.Fatalf("search after resync: %v", err)
-		}
-		if len(page.Results) == 0 {
-			t.Error(
-				"FTS search returned no results after resync",
-			)
-		}
+		require.NoError(t, err, "search after resync")
+		assert.NotZero(t, len(page.Results), "FTS search returned no results after resync")
 	}
 }
 
@@ -5066,13 +4550,9 @@ func TestResyncAllPreservesTrashedSessionData(t *testing.T) {
 	)
 	env.engine.SyncPaths([]string{orphanPath})
 	assertSessionMessageCount(t, env.db, "active-orphan", 2)
-	if err := os.Remove(orphanPath); err != nil {
-		t.Fatalf("remove orphan source: %v", err)
-	}
+	require.NoError(t, os.Remove(orphanPath), "remove orphan source")
 
-	if err := env.db.SoftDeleteSession("resync-trash"); err != nil {
-		t.Fatalf("SoftDeleteSession: %v", err)
-	}
+	require.NoError(t, env.db.SoftDeleteSession("resync-trash"), "SoftDeleteSession")
 
 	replacement := testjsonl.NewSessionBuilder().
 		AddClaudeUser(tsZero, "replacement prompt").
@@ -5081,30 +4561,18 @@ func TestResyncAllPreservesTrashedSessionData(t *testing.T) {
 	dbtest.WriteTestFile(t, path, []byte(replacement))
 
 	stats := env.engine.ResyncAll(context.Background(), nil)
-	if stats.Aborted {
-		t.Fatalf("ResyncAll aborted: %+v", stats)
-	}
+	require.False(t, stats.Aborted, "ResyncAll aborted: %+v", stats)
 	assertSessionMessageCount(t, env.db, "active-orphan", 2)
 
 	full, err := env.db.GetSessionFull(
 		context.Background(), "resync-trash",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if full == nil || full.DeletedAt == nil {
-		t.Fatal("trashed session was not preserved as trashed")
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, full, "trashed session was not preserved as trashed")
+	require.NotNil(t, full.DeletedAt, "trashed session was not preserved as trashed")
 	msgs := fetchMessages(t, env.db, "resync-trash")
-	if len(msgs) != 2 {
-		t.Fatalf("messages = %d, want 2", len(msgs))
-	}
-	if msgs[0].Content != "original trashed prompt" {
-		t.Fatalf(
-			"trashed content = %q, want original content",
-			msgs[0].Content,
-		)
-	}
+	require.Equal(t, 2, len(msgs), "messages = %d, want 2", len(msgs))
+	require.Equal(t, "original trashed prompt", msgs[0].Content, "trashed content = %q, want original content", msgs[0].Content)
 }
 
 // TestResyncAllSurfacesQueuedCommands locks in that bumping
@@ -5141,9 +4609,7 @@ func TestResyncAllSurfacesQueuedCommands(t *testing.T) {
 
 	const sessionID = "queued-resync"
 	msgs := fetchMessages(t, env.db, sessionID)
-	if len(msgs) != 4 {
-		t.Fatalf("initial sync: got %d messages, want 4", len(msgs))
-	}
+	require.Equal(t, 4, len(msgs), "initial sync: got %d messages, want 4", len(msgs))
 
 	// Simulate an old-parser DB by removing the queued_command
 	// row directly. Older versions of the parser would never
@@ -5156,35 +4622,23 @@ func TestResyncAllSurfacesQueuedCommands(t *testing.T) {
 		)
 		return err
 	})
-	if err != nil {
-		t.Fatalf("delete queued_command row: %v", err)
-	}
+	require.NoError(t, err, "delete queued_command row")
 	msgs = fetchMessages(t, env.db, sessionID)
-	if len(msgs) != 3 {
-		t.Fatalf("after stale simulation: got %d, want 3",
-			len(msgs))
-	}
+	require.Equal(t, 3, len(msgs), "after stale simulation: got %d, want 3", len(msgs))
 
 	// SyncAll must NOT recover the dropped row: the source
 	// file is unchanged on disk, so the engine skips it.
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Skipped != 1 {
-		t.Fatalf("SyncAll: expected Skipped=1, got %d",
-			stats.Skipped)
-	}
+	require.Equal(t, 1, stats.Skipped, "SyncAll: expected Skipped=1, got %d", stats.Skipped)
 	msgs = fetchMessages(t, env.db, sessionID)
-	if len(msgs) != 3 {
-		t.Fatalf("after SyncAll: got %d, want 3", len(msgs))
-	}
+	require.Equal(t, 3, len(msgs), "after SyncAll: got %d, want 3", len(msgs))
 
 	// ResyncAll re-parses every session from scratch and the
 	// queued_command reappears.
 	env.engine.ResyncAll(context.Background(), nil)
 
 	msgs = fetchMessages(t, env.db, sessionID)
-	if len(msgs) != 4 {
-		t.Fatalf("after ResyncAll: got %d, want 4", len(msgs))
-	}
+	require.Equal(t, 4, len(msgs), "after ResyncAll: got %d, want 4", len(msgs))
 
 	var queued *db.Message
 	for i := range msgs {
@@ -5193,20 +4647,10 @@ func TestResyncAllSurfacesQueuedCommands(t *testing.T) {
 			break
 		}
 	}
-	if queued == nil {
-		t.Fatal("ResyncAll did not restore queued_command row")
-	}
-	if queued.Content != "also do X" {
-		t.Errorf("queued_command content = %q, want %q",
-			queued.Content, "also do X")
-	}
-	if queued.Role != "user" {
-		t.Errorf("queued_command role = %q, want user",
-			queued.Role)
-	}
-	if queued.IsSystem {
-		t.Error("queued_command should not be is_system=true")
-	}
+	require.NotNil(t, queued, "ResyncAll did not restore queued_command row")
+	assert.Equal(t, "also do X", queued.Content, "queued_command content = %q, want %q", queued.Content, "also do X")
+	assert.Equal(t, "user", queued.Role, "queued_command role = %q, want user", queued.Role)
+	assert.False(t, queued.IsSystem, "queued_command should not be is_system=true")
 }
 
 func TestResyncAllPreservesInsights(t *testing.T) {
@@ -5232,34 +4676,21 @@ func TestResyncAllPreservesInsights(t *testing.T) {
 		Agent:    "claude",
 		Content:  "test insight survives resync",
 	})
-	if err != nil {
-		t.Fatalf("InsertInsight: %v", err)
-	}
+	require.NoError(t, err, "InsertInsight")
 
 	// ResyncAll should rebuild sessions and preserve
 	// insights.
 	stats := env.engine.ResyncAll(context.Background(), nil)
-	if stats.Synced == 0 {
-		t.Fatal("expected at least 1 synced session")
-	}
+	require.NotZero(t, stats.Synced, "expected at least 1 synced session")
 
 	assertSessionMessageCount(t, env.db, "insight-test", 2)
 
 	insights, err := env.db.ListInsights(
 		context.Background(), db.InsightFilter{},
 	)
-	if err != nil {
-		t.Fatalf("ListInsights: %v", err)
-	}
-	if len(insights) != 1 {
-		t.Fatalf("got %d insights, want 1", len(insights))
-	}
-	if insights[0].Content != "test insight survives resync" {
-		t.Errorf(
-			"insight content = %q, want preserved",
-			insights[0].Content,
-		)
-	}
+	require.NoError(t, err, "ListInsights")
+	require.Equal(t, 1, len(insights), "got %d insights, want 1", len(insights))
+	assert.Equal(t, "test insight survives resync", insights[0].Content, "insight content = %q, want preserved", insights[0].Content)
 }
 
 // TestResyncAllAbortsOnFailures verifies that ResyncAll
@@ -5293,25 +4724,17 @@ func TestResyncAllAbortsOnFailures(t *testing.T) {
 	sessionPath := filepath.Join(
 		env.claudeDir, "test-proj", "abort-test.jsonl",
 	)
-	if err := os.Chmod(sessionPath, 0); err != nil {
-		t.Fatalf("chmod: %v", err)
-	}
+	require.NoError(t, os.Chmod(sessionPath, 0), "chmod")
 	t.Cleanup(func() {
 		os.Chmod(sessionPath, 0o644)
 	})
 
 	stats := env.engine.ResyncAll(context.Background(), nil)
 
-	if stats.Failed == 0 {
-		t.Fatalf("expected failures, got 0")
-	}
-	if stats.TotalSessions == 0 {
-		t.Fatal("expected TotalSessions > 0")
-	}
+	require.NotEqual(t, 0, stats.Failed, "expected failures, got 0")
+	require.NotZero(t, stats.TotalSessions, "expected TotalSessions > 0")
 
-	if !stats.Aborted {
-		t.Error("expected Aborted = true")
-	}
+	assert.True(t, stats.Aborted, "expected Aborted = true")
 
 	hasAbortWarning := false
 	for _, w := range stats.Warnings {
@@ -5319,9 +4742,7 @@ func TestResyncAllAbortsOnFailures(t *testing.T) {
 			hasAbortWarning = true
 		}
 	}
-	if !hasAbortWarning {
-		t.Error("expected 'resync aborted' warning")
-	}
+	assert.True(t, hasAbortWarning, "expected 'resync aborted' warning")
 
 	// Original data should be preserved since swap was
 	// aborted.
@@ -5412,9 +4833,7 @@ func TestResyncAllAbortsWithForkAndFailures(t *testing.T) {
 	// Make both normal files unreadable.
 	for _, name := range []string{"bad1.jsonl", "bad2.jsonl"} {
 		p := filepath.Join(env.claudeDir, "proj", name)
-		if err := os.Chmod(p, 0); err != nil {
-			t.Fatalf("chmod %s: %v", name, err)
-		}
+		require.NoError(t, os.Chmod(p, 0), "chmod %s", name)
 		t.Cleanup(func() { os.Chmod(p, 0o644) })
 	}
 
@@ -5422,12 +4841,8 @@ func TestResyncAllAbortsWithForkAndFailures(t *testing.T) {
 
 	// Expect: filesOK=1, Failed=2, Synced=2.
 	// Abort should fire because Failed(2) > filesOK(1).
-	if stats.Failed != 2 {
-		t.Fatalf("Failed = %d, want 2", stats.Failed)
-	}
-	if stats.Synced != 2 {
-		t.Fatalf("Synced = %d, want 2", stats.Synced)
-	}
+	require.Equal(t, 2, stats.Failed, "Failed = %d, want 2", stats.Failed)
+	require.Equal(t, 2, stats.Synced, "Synced = %d, want 2", stats.Synced)
 
 	hasAbortWarning := false
 	for _, w := range stats.Warnings {
@@ -5435,12 +4850,7 @@ func TestResyncAllAbortsWithForkAndFailures(t *testing.T) {
 			hasAbortWarning = true
 		}
 	}
-	if !hasAbortWarning {
-		t.Error(
-			"expected abort: Failed(2) > filesOK(1) " +
-				"should trigger even though Failed == Synced",
-		)
-	}
+	assert.True(t, hasAbortWarning, "expected abort: Failed(2) > filesOK(1) " + "should trigger even though Failed == Synced")
 
 	// Original data preserved.
 	assertSessionMessageCount(t, env.db, "forked", 10)
@@ -5469,31 +4879,21 @@ func TestResyncAllPostReopenAvailability(t *testing.T) {
 
 	// Resync triggers the full close-rename-reopen cycle.
 	stats := env.engine.ResyncAll(context.Background(), nil)
-	if stats.Synced != 1 {
-		t.Fatalf("resync: synced = %d, want 1", stats.Synced)
-	}
-	if stats.Aborted {
-		t.Error("unexpected Aborted = true on successful resync")
-	}
+	require.Equal(t, 1, stats.Synced, "resync: synced = %d, want 1", stats.Synced)
+	assert.False(t, stats.Aborted, "unexpected Aborted = true on successful resync")
 	for _, w := range stats.Warnings {
-		t.Errorf("unexpected warning: %s", w)
+		assert.Fail(t, "unexpected warning", w)
 	}
 
 	// Verify reads work on the reopened DB.
 	s, err := env.db.GetSession(
 		context.Background(), "avail",
 	)
-	if err != nil {
-		t.Fatalf("GetSession after resync: %v", err)
-	}
-	if s == nil {
-		t.Fatal("session missing after resync")
-	}
+	require.NoError(t, err, "GetSession after resync")
+	require.NotNil(t, s, "session missing after resync")
 
 	msgs := fetchMessages(t, env.db, "avail")
-	if len(msgs) != 2 {
-		t.Fatalf("got %d messages, want 2", len(msgs))
-	}
+	require.Equal(t, 2, len(msgs), "got %d messages, want 2", len(msgs))
 
 	// Verify writes work on the reopened DB.
 	err = env.db.UpsertSession(db.Session{
@@ -5503,28 +4903,18 @@ func TestResyncAllPostReopenAvailability(t *testing.T) {
 		Agent:        "claude",
 		MessageCount: 1,
 	})
-	if err != nil {
-		t.Fatalf("UpsertSession after resync: %v", err)
-	}
+	require.NoError(t, err, "UpsertSession after resync")
 	s2, err := env.db.GetSession(
 		context.Background(), "post-resync-write",
 	)
-	if err != nil {
-		t.Fatalf("GetSession post-write: %v", err)
-	}
-	if s2 == nil {
-		t.Fatal("session written after resync not found")
-	}
+	require.NoError(t, err, "GetSession post-write")
+	require.NotNil(t, s2, "session written after resync not found")
 
 	// Verify a subsequent SyncAll still works (engine state
 	// is consistent with the reopened DB).
 	stats2 := env.engine.SyncAll(context.Background(), nil)
-	if stats2.Synced != 0 || stats2.Skipped != 1 {
-		t.Errorf(
-			"post-resync SyncAll: synced=%d skipped=%d",
-			stats2.Synced, stats2.Skipped,
-		)
-	}
+	assert.Equal(t, 0, stats2.Synced, "post-resync SyncAll: synced=%d skipped=%d", stats2.Synced, stats2.Skipped)
+	assert.Equal(t, 1, stats2.Skipped, "post-resync SyncAll: synced=%d skipped=%d", stats2.Synced, stats2.Skipped)
 }
 
 // TestResyncAllConcurrentReads verifies that concurrent reads
@@ -5594,20 +4984,14 @@ func TestResyncAllConcurrentReads(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	if stats.Synced != 1 {
-		t.Fatalf("resync: synced = %d, want 1", stats.Synced)
-	}
+	require.Equal(t, 1, stats.Synced, "resync: synced = %d, want 1", stats.Synced)
 
 	// Post-resync reads must succeed.
 	s, err := env.db.GetSession(
 		context.Background(), "conc",
 	)
-	if err != nil {
-		t.Fatalf("GetSession after resync: %v", err)
-	}
-	if s == nil {
-		t.Fatal("session missing after resync")
-	}
+	require.NoError(t, err, "GetSession after resync")
+	require.NotNil(t, s, "session missing after resync")
 }
 
 // TestResyncAllAbortsOnEmptyDiscovery verifies that resync does
@@ -5630,9 +5014,7 @@ func TestResyncAllAbortsOnEmptyDiscovery(t *testing.T) {
 	entries, err := os.ReadDir(
 		filepath.Join(env.claudeDir, "proj"),
 	)
-	if err != nil {
-		t.Fatalf("reading dir: %v", err)
-	}
+	require.NoError(t, err, "reading dir")
 	for _, e := range entries {
 		p := filepath.Join(env.claudeDir, "proj", e.Name())
 		os.Remove(p)
@@ -5647,12 +5029,7 @@ func TestResyncAllAbortsOnEmptyDiscovery(t *testing.T) {
 			hasAbortWarning = true
 		}
 	}
-	if !hasAbortWarning {
-		t.Error(
-			"expected abort when discovery returns zero files " +
-				"but old DB has sessions",
-		)
-	}
+	assert.True(t, hasAbortWarning, "expected abort when discovery returns zero files " + "but old DB has sessions")
 
 	// Original data must be preserved.
 	assertSessionMessageCount(t, env.db, "keep", 2)
@@ -5702,16 +5079,9 @@ func TestResyncAllOpenCodeOnly(t *testing.T) {
 	stats := env.engine.ResyncAll(context.Background(), nil)
 
 	for _, w := range stats.Warnings {
-		if strings.Contains(w, "resync aborted") {
-			t.Fatalf(
-				"ResyncAll aborted for OpenCode-only "+
-					"dataset: %s", w,
-			)
-		}
+		require.False(t, strings.Contains(w, "resync aborted"), "ResyncAll aborted for OpenCode-only "+ "dataset: %s", w)
 	}
-	if stats.Synced == 0 {
-		t.Fatal("expected OpenCode sessions to be synced")
-	}
+	require.NotZero(t, stats.Synced, "expected OpenCode sessions to be synced")
 
 	assertSessionMessageCount(t, env.db, agentviewID, 2)
 	assertMessageContent(
@@ -5738,16 +5108,9 @@ func TestResyncAllKiroSQLiteOnly(t *testing.T) {
 
 	stats := env.engine.ResyncAll(context.Background(), nil)
 	for _, w := range stats.Warnings {
-		if strings.Contains(w, "resync aborted") {
-			t.Fatalf(
-				"ResyncAll aborted for Kiro SQLite-only dataset: %s",
-				w,
-			)
-		}
+		require.False(t, strings.Contains(w, "resync aborted"), "ResyncAll aborted for Kiro SQLite-only dataset: %s", w)
 	}
-	if stats.Synced == 0 {
-		t.Fatal("expected Kiro SQLite sessions to be synced")
-	}
+	require.NotZero(t, stats.Synced, "expected Kiro SQLite sessions to be synced")
 	assertSessionMessageCount(t, env.db, agentviewID, 4)
 }
 
@@ -5755,11 +5118,10 @@ func TestResyncAllMixedOpenCodeRootsKeepsSQLiteFallback(t *testing.T) {
 	storageBase := t.TempDir()
 	storageRoot := filepath.Join(storageBase, "storage#root")
 	sqliteRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(
+	err := os.MkdirAll(filepath.Join(
 		storageRoot, "storage", "session", "global",
-	), 0o755); err != nil {
-		t.Fatalf("mkdir storage root: %v", err)
-	}
+	), 0o755)
+	require.NoError(t, err, "mkdir storage root")
 
 	env := setupTestEnv(
 		t, WithOpenCodeDirs([]string{storageRoot, sqliteRoot}),
@@ -5791,18 +5153,9 @@ func TestResyncAllMixedOpenCodeRootsKeepsSQLiteFallback(t *testing.T) {
 	stats := env.engine.ResyncAll(context.Background(), nil)
 
 	for _, w := range stats.Warnings {
-		if strings.Contains(w, "resync aborted") {
-			t.Fatalf(
-				"ResyncAll aborted for mixed OpenCode roots: %s",
-				w,
-			)
-		}
+		require.False(t, strings.Contains(w, "resync aborted"), "ResyncAll aborted for mixed OpenCode roots: %s", w)
 	}
-	if stats.Synced == 0 {
-		t.Fatal(
-			"expected SQLite fallback OpenCode session to be synced",
-		)
-	}
+	require.NotZero(t, stats.Synced, "expected SQLite fallback OpenCode session to be synced")
 
 	assertSessionMessageCount(t, env.db, agentviewID, 1)
 	assertMessageContent(
@@ -5838,11 +5191,10 @@ func TestResyncAllOpenCodeStorageArchivePreservesStaleSQLiteFallback(
 		Skipped:       0,
 	})
 
-	if err := os.RemoveAll(
+	err := os.RemoveAll(
 		filepath.Join(env.opencodeDir, "storage"),
-	); err != nil {
-		t.Fatalf("remove storage tree: %v", err)
-	}
+	)
+	require.NoError(t, err, "remove storage tree")
 
 	oc := createOpenCodeDB(t, env.opencodeDir)
 	oc.addProject(t, "proj-1", "/home/user/code/myapp")
@@ -5861,16 +5213,9 @@ func TestResyncAllOpenCodeStorageArchivePreservesStaleSQLiteFallback(
 
 	stats := env.engine.ResyncAll(context.Background(), nil)
 	for _, w := range stats.Warnings {
-		if strings.Contains(w, "resync aborted") {
-			t.Fatalf(
-				"ResyncAll aborted for storage->sqlite fallback: %s",
-				w,
-			)
-		}
+		require.False(t, strings.Contains(w, "resync aborted"), "ResyncAll aborted for storage->sqlite fallback: %s", w)
 	}
-	if stats.Synced != 0 {
-		t.Fatalf("stats.Synced = %d, want 0", stats.Synced)
-	}
+	require.Equal(t, 0, stats.Synced, "stats.Synced = %d, want 0", stats.Synced)
 
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
@@ -5905,11 +5250,10 @@ func TestResyncAllOpenCodeStorageArchiveAllowsNewerSQLiteFallback(
 		Skipped:       0,
 	})
 
-	if err := os.RemoveAll(
+	err := os.RemoveAll(
 		filepath.Join(env.opencodeDir, "storage"),
-	); err != nil {
-		t.Fatalf("remove storage tree: %v", err)
-	}
+	)
+	require.NoError(t, err, "remove storage tree")
 
 	sqliteUpdatedAt := time.Now().Add(2 * time.Second).UnixMilli()
 
@@ -5930,16 +5274,9 @@ func TestResyncAllOpenCodeStorageArchiveAllowsNewerSQLiteFallback(
 
 	stats := env.engine.ResyncAll(context.Background(), nil)
 	for _, w := range stats.Warnings {
-		if strings.Contains(w, "resync aborted") {
-			t.Fatalf(
-				"ResyncAll aborted for newer storage->sqlite fallback: %s",
-				w,
-			)
-		}
+		require.False(t, strings.Contains(w, "resync aborted"), "ResyncAll aborted for newer storage->sqlite fallback: %s", w)
 	}
-	if stats.Synced == 0 {
-		t.Fatal("expected newer sqlite fallback to be synced")
-	}
+	require.NotZero(t, stats.Synced, "expected newer sqlite fallback to be synced")
 
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
@@ -5982,22 +5319,13 @@ func TestResyncAllOpenCodeStorageMissingMessagePreservesArchive(
 		Skipped:       0,
 	})
 
-	if err := os.Remove(messagePath); err != nil {
-		t.Fatalf("remove message file: %v", err)
-	}
+	require.NoError(t, os.Remove(messagePath), "remove message file")
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(sessionPath, future, future); err != nil {
-		t.Fatalf("touch session path: %v", err)
-	}
+	require.NoError(t, os.Chtimes(sessionPath, future, future), "touch session path")
 
 	stats := env.engine.ResyncAll(context.Background(), nil)
 	for _, w := range stats.Warnings {
-		if strings.Contains(w, "resync aborted") {
-			t.Fatalf(
-				"ResyncAll aborted for missing OpenCode message: %s",
-				w,
-			)
-		}
+		require.False(t, strings.Contains(w, "resync aborted"), "ResyncAll aborted for missing OpenCode message: %s", w)
 	}
 
 	assertMessageContent(
@@ -6063,9 +5391,7 @@ func TestResyncAllAbortsMixedSourceEmptyFiles(t *testing.T) {
 	entries, err := os.ReadDir(
 		filepath.Join(env.claudeDir, "proj"),
 	)
-	if err != nil {
-		t.Fatalf("reading dir: %v", err)
-	}
+	require.NoError(t, err, "reading dir")
 	for _, e := range entries {
 		p := filepath.Join(env.claudeDir, "proj", e.Name())
 		os.Remove(p)
@@ -6080,12 +5406,7 @@ func TestResyncAllAbortsMixedSourceEmptyFiles(t *testing.T) {
 			hasAbortWarning = true
 		}
 	}
-	if !hasAbortWarning {
-		t.Error(
-			"expected abort when file dirs are empty " +
-				"but old DB has file-backed sessions",
-		)
-	}
+	assert.True(t, hasAbortWarning, "expected abort when file dirs are empty " + "but old DB has file-backed sessions")
 
 	// Both file-backed and OpenCode data preserved.
 	assertSessionMessageCount(t, env.db, "mixed-file", 2)
@@ -6129,12 +5450,7 @@ func TestNewEngineDefensiveCopy(t *testing.T) {
 
 	// Engine should still find the session via its own copy.
 	stats := engine.SyncAll(context.Background(), nil)
-	if stats.Synced != 1 {
-		t.Fatalf(
-			"Synced = %d, want 1 (engine used mutated map)",
-			stats.Synced,
-		)
-	}
+	require.Equal(t, 1, stats.Synced, "Synced = %d, want 1 (engine used mutated map)", stats.Synced)
 	assertSessionMessageCount(t, database, "copy-test", 1)
 
 	// Verify slice-level aliasing is also prevented.
@@ -6163,12 +5479,7 @@ func TestNewEngineDefensiveCopy(t *testing.T) {
 	sliceDirs[0] = "/nonexistent"
 
 	stats2 := engine2.SyncAll(context.Background(), nil)
-	if stats2.Synced != 1 {
-		t.Fatalf(
-			"Synced = %d, want 1 (engine used aliased slice)",
-			stats2.Synced,
-		)
-	}
+	require.Equal(t, 1, stats2.Synced, "Synced = %d, want 1 (engine used aliased slice)", stats2.Synced)
 	assertSessionMessageCount(t, db2, "slice-test", 1)
 }
 
@@ -6219,11 +5530,7 @@ func TestSyncPathsClaudeFallsThrough(t *testing.T) {
 		t, database,
 		"amp:T-019ca26f-eeee-dddd-cccc-bbbbbbbbbbbb",
 		func(sess *db.Session) {
-			if sess.Agent != "amp" {
-				t.Errorf(
-					"agent = %q, want amp", sess.Agent,
-				)
-			}
+			assert.Equal(t, "amp", sess.Agent, "agent = %q, want amp", sess.Agent)
 		},
 	)
 }
@@ -6270,11 +5577,7 @@ func TestSyncPathsClassifyFallsThrough(t *testing.T) {
 		t, database,
 		"amp:T-019ca26f-ffff-aaaa-bbbb-cccccccccccc",
 		func(sess *db.Session) {
-			if sess.Agent != "amp" {
-				t.Errorf(
-					"agent = %q, want amp", sess.Agent,
-				)
-			}
+			assert.Equal(t, "amp", sess.Agent, "agent = %q, want amp", sess.Agent)
 		},
 	)
 }
@@ -6327,15 +5630,8 @@ func TestSyncPathsVSCodeCopilotJSONLPriority(t *testing.T) {
 	page, err := database.ListSessions(
 		ctx, db.SessionFilter{Limit: 10},
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(page.Sessions) != 0 {
-		t.Errorf(
-			"expected 0 sessions (.json skipped), got %d",
-			len(page.Sessions),
-		)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(page.Sessions), "expected 0 sessions (.json skipped), got %d", len(page.Sessions))
 }
 
 func TestPiSessionIntegration(t *testing.T) {
@@ -6347,9 +5643,7 @@ func TestPiSessionIntegration(t *testing.T) {
 	//   <piDir>/<encoded-cwd>/<session-id>.jsonl
 	piDir := t.TempDir()
 	cwdSubdir := filepath.Join(piDir, "--Users-alice-code-my-project")
-	if err := os.MkdirAll(cwdSubdir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(cwdSubdir, 0o755))
 
 	// Use the existing pi session fixture from the parser testdata.
 	// The fixture has id="pi-test-session-uuid".
@@ -6360,9 +5654,7 @@ func TestPiSessionIntegration(t *testing.T) {
 	fixtureContent, err := os.ReadFile(
 		filepath.Join(fixtureDir, "session.jsonl"),
 	)
-	if err != nil {
-		t.Fatalf("reading pi fixture: %v", err)
-	}
+	require.NoError(t, err, "reading pi fixture")
 
 	sessionFile := filepath.Join(cwdSubdir, "pi-test-session-uuid.jsonl")
 	dbtest.WriteTestFile(t, sessionFile, fixtureContent)
@@ -6376,40 +5668,27 @@ func TestPiSessionIntegration(t *testing.T) {
 	})
 
 	stats := engine.SyncAll(context.Background(), nil)
-	if stats.Synced != 1 {
-		t.Fatalf("expected 1 synced session, got %d (failed=%d)",
-			stats.Synced, stats.Failed)
-	}
+	require.Equal(t, 1, stats.Synced, "expected 1 synced session, got %d (failed=%d)", stats.Synced, stats.Failed)
 
 	assertSessionState(t, database, "pi:pi-test-session-uuid",
 		func(sess *db.Session) {
-			if sess.Agent != "pi" {
-				t.Errorf("agent = %q, want %q", sess.Agent, "pi")
-			}
+			assert.Equal(t, "pi", sess.Agent, "agent = %q, want %q", sess.Agent, "pi")
 			// The fixture has 2 real user messages. model_change and
 			// compaction entries must not inflate the count after
 			// postFilterCounts re-counts role="user" messages.
-			if sess.UserMessageCount != 2 {
-				t.Errorf("UserMessageCount = %d, want 2", sess.UserMessageCount)
-			}
+			assert.Equal(t, 2, sess.UserMessageCount, "UserMessageCount = %d, want 2", sess.UserMessageCount)
 		},
 	)
 
 	// FindSourceFile should locate pi sessions via the "pi:" prefix.
 	src := engine.FindSourceFile("pi:pi-test-session-uuid")
-	if src == "" {
-		t.Error("FindSourceFile returned empty for pi session")
-	}
+	assert.NotEmpty(t, src, "FindSourceFile returned empty for pi session")
 
 	// SyncSingleSession should work for pi sessions.
-	if err := engine.SyncSingleSession("pi:pi-test-session-uuid"); err != nil {
-		t.Fatalf("SyncSingleSession pi: %v", err)
-	}
+	require.NoError(t, engine.SyncSingleSession("pi:pi-test-session-uuid"), "SyncSingleSession pi")
 	assertSessionState(t, database, "pi:pi-test-session-uuid",
 		func(sess *db.Session) {
-			if sess.Agent != "pi" {
-				t.Errorf("after SyncSingleSession: agent = %q, want %q", sess.Agent, "pi")
-			}
+			assert.Equal(t, "pi", sess.Agent, "after SyncSingleSession: agent = %q, want %q", sess.Agent, "pi")
 		},
 	)
 }
@@ -6429,23 +5708,15 @@ func TestIncrementalSync_ClaudeAppend(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "inc-test", 1)
 	assertMessageRoles(t, env.db, "inc-test", "user")
 	msgs := fetchMessages(t, env.db, "inc-test")
-	if msgs[0].SessionID != "inc-test" {
-		t.Fatalf(
-			"msgs[0].SessionID = %q, want inc-test",
-			msgs[0].SessionID,
-		)
-	}
+	require.Equal(t, "inc-test", msgs[0].SessionID, "msgs[0].SessionID = %q, want inc-test", msgs[0].SessionID)
 
 	// Verify metadata is set from full parse.
 	full, err := env.db.GetSessionFull(
 		context.Background(), "inc-test",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if full.FileHash == nil || *full.FileHash == "" {
-		t.Fatal("file_hash not set after full parse")
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, full.FileHash, "file_hash not set after full parse")
+	require.NotEmpty(t, *full.FileHash, "file_hash not set after full parse")
 	origHash := *full.FileHash
 
 	// Append an assistant response.
@@ -6465,21 +5736,15 @@ func TestIncrementalSync_ClaudeAppend(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("marshal assistant fixture: %v", err)
-	}
+	require.NoError(t, err, "marshal assistant fixture")
 	appended := string(appendedJSON) + "\n"
 	f, err := os.OpenFile(
 		path, os.O_APPEND|os.O_WRONLY, 0o644,
 	)
-	if err != nil {
-		t.Fatalf("open for append: %v", err)
-	}
+	require.NoError(t, err, "open for append")
 	_, err = f.WriteString(appended)
 	f.Close()
-	if err != nil {
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, err, "append")
 
 	// SyncPaths triggers incremental parse.
 	env.engine.SyncPaths([]string{path})
@@ -6493,56 +5758,25 @@ func TestIncrementalSync_ClaudeAppend(t *testing.T) {
 	// New message has correct session_id.
 	msgs = fetchMessages(t, env.db, "inc-test")
 	for i, m := range msgs {
-		if m.SessionID != "inc-test" {
-			t.Errorf(
-				"msgs[%d].SessionID = %q, want inc-test",
-				i, m.SessionID,
-			)
-		}
+		assert.Equal(t, "inc-test", m.SessionID, "msgs[%d].SessionID = %q, want inc-test", i, m.SessionID)
 	}
 
 	// Metadata preserved (file_hash not cleared).
 	updated, err := env.db.GetSessionFull(
 		context.Background(), "inc-test",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull after incremental: %v", err)
-	}
-	if updated.FileHash == nil ||
-		*updated.FileHash != origHash {
-		t.Errorf(
-			"file_hash = %v, want %q (preserved)",
-			updated.FileHash, origHash,
-		)
-	}
-	if !updated.HasTotalOutputTokens {
-		t.Error("HasTotalOutputTokens = false, want true")
-	}
-	if !updated.HasPeakContextTokens {
-		t.Error("HasPeakContextTokens = false, want true")
-	}
-	if updated.TotalOutputTokens != 200 {
-		t.Errorf("TotalOutputTokens = %d, want 200",
-			updated.TotalOutputTokens)
-	}
-	if updated.PeakContextTokens != 500 {
-		t.Errorf("PeakContextTokens = %d, want 500",
-			updated.PeakContextTokens)
-	}
-	if !msgs[1].HasContextTokens {
-		t.Error("assistant HasContextTokens = false, want true")
-	}
-	if !msgs[1].HasOutputTokens {
-		t.Error("assistant HasOutputTokens = false, want true")
-	}
-	if msgs[1].OutputTokens != 200 {
-		t.Errorf("assistant OutputTokens = %d, want 200",
-			msgs[1].OutputTokens)
-	}
-	if msgs[1].ContextTokens != 500 {
-		t.Errorf("assistant ContextTokens = %d, want 500",
-			msgs[1].ContextTokens)
-	}
+	require.NoError(t, err, "GetSessionFull after incremental")
+	require.NotNil(t, updated.FileHash, "file_hash = nil, want %q (preserved)", origHash)
+	assert.Equal(t, origHash, *updated.FileHash,
+		"file_hash = %v, want %q (preserved)", updated.FileHash, origHash)
+	assert.True(t, updated.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
+	assert.True(t, updated.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
+	assert.Equal(t, 200, updated.TotalOutputTokens, "TotalOutputTokens = %d, want 200", updated.TotalOutputTokens)
+	assert.Equal(t, 500, updated.PeakContextTokens, "PeakContextTokens = %d, want 500", updated.PeakContextTokens)
+	assert.True(t, msgs[1].HasContextTokens, "assistant HasContextTokens = false, want true")
+	assert.True(t, msgs[1].HasOutputTokens, "assistant HasOutputTokens = false, want true")
+	assert.Equal(t, 200, msgs[1].OutputTokens, "assistant OutputTokens = %d, want 200", msgs[1].OutputTokens)
+	assert.Equal(t, 500, msgs[1].ContextTokens, "assistant ContextTokens = %d, want 500", msgs[1].ContextTokens)
 }
 
 // TestIncrementalSync_ClaudeFileReplaced verifies that when a
@@ -6568,12 +5802,9 @@ func TestIncrementalSync_ClaudeFileReplaced(t *testing.T) {
 	full, err := env.db.GetSessionFull(
 		context.Background(), "replaced",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if full.FileInode == nil || *full.FileInode == 0 {
-		t.Fatal("file_inode not populated after initial sync")
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, full.FileInode, "file_inode not populated after initial sync")
+	require.NotZero(t, *full.FileInode, "file_inode not populated after initial sync")
 	origInode := *full.FileInode
 
 	// Atomically replace the file. The content is longer than the
@@ -6584,12 +5815,8 @@ func TestIncrementalSync_ClaudeFileReplaced(t *testing.T) {
 		testjsonl.ClaudeUserJSON("third", tsZeroS5),
 	)
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(replacement), 0o644); err != nil {
-		t.Fatalf("write replacement: %v", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		t.Fatalf("rename replacement: %v", err)
-	}
+	require.NoError(t, os.WriteFile(tmp, []byte(replacement), 0o644), "write replacement")
+	require.NoError(t, os.Rename(tmp, path), "rename replacement")
 
 	env.engine.SyncPaths([]string{path})
 
@@ -6601,27 +5828,16 @@ func TestIncrementalSync_ClaudeFileReplaced(t *testing.T) {
 	full, err = env.db.GetSessionFull(
 		context.Background(), "replaced",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull after replace: %v", err)
-	}
-	if full.FileInode == nil {
-		t.Fatal("file_inode cleared after replace")
-	}
-	if *full.FileInode == origInode {
-		t.Errorf("file_inode = %d, want change from original",
-			*full.FileInode)
-	}
+	require.NoError(t, err, "GetSessionFull after replace")
+	require.NotNil(t, full.FileInode, "file_inode cleared after replace")
+	assert.NotEqual(t, origInode, *full.FileInode, "file_inode = %d, want change from original", *full.FileInode)
 	// File size in the DB should match the replacement, not the
 	// pre-replacement size that an incremental parse would have
 	// left in place.
 	newInfo, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat replacement: %v", err)
-	}
-	if full.FileSize == nil || *full.FileSize != newInfo.Size() {
-		t.Errorf("file_size = %v, want %d (full-parse size)",
-			full.FileSize, newInfo.Size())
-	}
+	require.NoError(t, err, "stat replacement")
+	require.NotNil(t, full.FileSize, "file_size = nil, want %d (full-parse size)", newInfo.Size())
+	assert.Equal(t, newInfo.Size(), *full.FileSize, "file_size = %v, want %d (full-parse size)", *full.FileSize, newInfo.Size())
 }
 
 // TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse covers
@@ -6651,9 +5867,7 @@ func TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse(t *testing.T) 
 			"stop_reason": "tool_use",
 		},
 	})
-	if err != nil {
-		t.Fatalf("marshal first snapshot: %v", err)
-	}
+	require.NoError(t, err, "marshal first snapshot")
 
 	initial := testjsonl.JoinJSONL(
 		testjsonl.ClaudeUserJSON("hello", tsZero),
@@ -6686,19 +5900,13 @@ func TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse(t *testing.T) 
 			"stop_reason": "end_turn",
 		},
 	})
-	if err != nil {
-		t.Fatalf("marshal second snapshot: %v", err)
-	}
+	require.NoError(t, err, "marshal second snapshot")
 
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		t.Fatalf("open for append: %v", err)
-	}
-	if _, err := f.WriteString(string(second) + "\n"); err != nil {
-		f.Close()
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(string(second) + "\n")
 	f.Close()
+	require.NoError(t, writeErr, "append")
 
 	env.engine.SyncPaths([]string{path})
 
@@ -6708,20 +5916,11 @@ func TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse(t *testing.T) 
 	assertSessionMessageCount(t, env.db, "split-stream", 2)
 
 	msgs := fetchMessages(t, env.db, "split-stream")
-	if len(msgs) != 2 {
-		t.Fatalf("len(msgs) = %d, want 2", len(msgs))
-	}
-	if string(msgs[1].Role) != "assistant" {
-		t.Fatalf("msgs[1].Role = %q, want assistant", msgs[1].Role)
-	}
+	require.Equal(t, 2, len(msgs), "len(msgs) = %d, want 2", len(msgs))
+	require.Equal(t, "assistant", string(msgs[1].Role), "msgs[1].Role = %q, want assistant", msgs[1].Role)
 	// The partial snapshot ("Hello") must be REPLACED by the final
 	// snapshot ("Hello world"), not concatenated as additive content.
-	if msgs[1].Content != "Hello world" {
-		t.Errorf(
-			"msgs[1].Content = %q, want exactly %q",
-			msgs[1].Content, "Hello world",
-		)
-	}
+	assert.Equal(t, "Hello world", msgs[1].Content, "msgs[1].Content = %q, want exactly %q", msgs[1].Content, "Hello world")
 }
 
 // TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall covers
@@ -6763,19 +5962,14 @@ func TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall(t *testing.T
 
 	// Linkage starts empty (the toolUseResult hasn't appeared yet).
 	var got sql.NullString
-	if err := env.db.Reader().QueryRow(`
+	require.NoError(t, env.db.Reader().QueryRow(`
 		SELECT subagent_session_id
 		FROM tool_calls
 		WHERE session_id = ? AND tool_use_id = ?`,
 		"parent-late-link", "toolu_late",
-	).Scan(&got); err != nil {
-		t.Fatalf("query before append: %v", err)
-	}
-	if got.Valid && got.String != "" {
-		t.Fatalf(
-			"subagent_session_id = %q before tool_result, want empty",
-			got.String,
-		)
+	).Scan(&got), "query before append")
+	if got.Valid {
+		require.Equal(t, "", got.String, "subagent_session_id = %q before tool_result, want empty", got.String)
 	}
 
 	// Append a tool_result with toolUseResult.agentId pointing at
@@ -6784,31 +5978,20 @@ func TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall(t *testing.T
 	// parse with forceReplace to update the stored tool_call row.
 	toolResult := `{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_late","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"childlate"}}`
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		t.Fatalf("open for append: %v", err)
-	}
-	if _, err := f.WriteString(toolResult + "\n"); err != nil {
-		f.Close()
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(toolResult + "\n")
 	f.Close()
+	require.NoError(t, writeErr, "append")
 
 	env.engine.SyncPaths([]string{path})
 
-	if err := env.db.Reader().QueryRow(`
+	require.NoError(t, env.db.Reader().QueryRow(`
 		SELECT subagent_session_id
 		FROM tool_calls
 		WHERE session_id = ? AND tool_use_id = ?`,
 		"parent-late-link", "toolu_late",
-	).Scan(&got); err != nil {
-		t.Fatalf("query after append: %v", err)
-	}
-	if got.String != "agent-childlate" {
-		t.Errorf(
-			"subagent_session_id = %q, want %q",
-			got.String, "agent-childlate",
-		)
-	}
+	).Scan(&got), "query after append")
+	assert.Equal(t, "agent-childlate", got.String, "subagent_session_id = %q, want %q", got.String, "agent-childlate")
 }
 
 func TestIncrementalSync_CodexAppend(t *testing.T) {
@@ -6840,14 +6023,10 @@ func TestIncrementalSync_CodexAppend(t *testing.T) {
 	f, err := os.OpenFile(
 		path, os.O_APPEND|os.O_WRONLY, 0o644,
 	)
-	if err != nil {
-		t.Fatalf("open for append: %v", err)
-	}
+	require.NoError(t, err, "open for append")
 	_, err = f.WriteString(appended)
 	f.Close()
-	if err != nil {
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, err, "append")
 
 	env.engine.SyncPaths([]string{path})
 
@@ -6861,12 +6040,7 @@ func TestIncrementalSync_CodexAppend(t *testing.T) {
 	// Verify session_id on all messages.
 	msgs := fetchMessages(t, env.db, "codex:inc-cx")
 	for i, m := range msgs {
-		if m.SessionID != "codex:inc-cx" {
-			t.Errorf(
-				"msgs[%d].SessionID = %q, want codex:inc-cx",
-				i, m.SessionID,
-			)
-		}
+		assert.Equal(t, "codex:inc-cx", m.SessionID, "msgs[%d].SessionID = %q, want codex:inc-cx", i, m.SessionID)
 	}
 }
 
@@ -6908,14 +6082,10 @@ func TestIncrementalSync_CodexSubagentAppendFallsBackToFullParse(t *testing.T) {
 	f, err := os.OpenFile(
 		path, os.O_APPEND|os.O_WRONLY, 0o644,
 	)
-	if err != nil {
-		t.Fatalf("open for append: %v", err)
-	}
+	require.NoError(t, err, "open for append")
 	_, err = f.WriteString(appended)
 	f.Close()
-	if err != nil {
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, err, "append")
 
 	// SyncPaths hits the incremental Codex path first. The appended
 	// wait call is an explicit full-parse fallback case and should
@@ -6926,34 +6096,14 @@ func TestIncrementalSync_CodexSubagentAppendFallsBackToFullParse(t *testing.T) {
 		t, env.db, "codex:inc-cx-sub", 3,
 	)
 	msgs := fetchMessages(t, env.db, "codex:inc-cx-sub")
-	if len(msgs) != 3 {
-		t.Fatalf("messages len = %d, want 3", len(msgs))
-	}
-	if len(msgs[2].ToolCalls) != 1 {
-		t.Fatalf("tool calls len = %d, want 1", len(msgs[2].ToolCalls))
-	}
+	require.Equal(t, 3, len(msgs), "messages len = %d, want 3", len(msgs))
+	require.Equal(t, 1, len(msgs[2].ToolCalls), "tool calls len = %d, want 1", len(msgs[2].ToolCalls))
 	waitCall := msgs[2].ToolCalls[0]
-	if waitCall.ToolName != "wait" {
-		t.Fatalf("tool name = %q, want %q", waitCall.ToolName, "wait")
-	}
-	if len(waitCall.ResultEvents) != 1 {
-		t.Fatalf("result events len = %d, want 1", len(waitCall.ResultEvents))
-	}
-	if waitCall.ResultEvents[0].AgentID != childID {
-		t.Fatalf("event agent_id = %q, want %q", waitCall.ResultEvents[0].AgentID, childID)
-	}
-	if waitCall.ResultEvents[0].Content != "Finished successfully" {
-		t.Fatalf(
-			"event content = %q, want %q",
-			waitCall.ResultEvents[0].Content, "Finished successfully",
-		)
-	}
-	if waitCall.ResultContent != "Finished successfully" {
-		t.Fatalf(
-			"result_content = %q, want %q",
-			waitCall.ResultContent, "Finished successfully",
-		)
-	}
+	require.Equal(t, "wait", waitCall.ToolName, "tool name = %q, want %q", waitCall.ToolName, "wait")
+	require.Equal(t, 1, len(waitCall.ResultEvents), "result events len = %d, want 1", len(waitCall.ResultEvents))
+	require.Equal(t, childID, waitCall.ResultEvents[0].AgentID, "event agent_id = %q, want %q", waitCall.ResultEvents[0].AgentID, childID)
+	require.Equal(t, "Finished successfully", waitCall.ResultEvents[0].Content, "event content = %q, want %q", waitCall.ResultEvents[0].Content, "Finished successfully")
+	require.Equal(t, "Finished successfully", waitCall.ResultContent, "result_content = %q, want %q", waitCall.ResultContent, "Finished successfully")
 }
 
 func TestResyncAllCancelledPreservesOriginalDB(t *testing.T) {
@@ -6973,13 +6123,10 @@ func TestResyncAllCancelledPreservesOriginalDB(t *testing.T) {
 	sess, err := env.db.GetSession(
 		context.Background(), "cancel-sess",
 	)
-	if err != nil || sess == nil {
-		t.Fatalf("session not found: %v", err)
-	}
+	require.NoError(t, err, "session not found")
+	require.NotNil(t, sess, "session not found")
 	origCount := sess.MessageCount
-	if origCount == 0 {
-		t.Fatal("expected messages after initial sync")
-	}
+	require.NotZero(t, origCount, "expected messages after initial sync")
 
 	// Cancel the context before starting ResyncAll so
 	// collectAndBatch aborts immediately.
@@ -6988,24 +6135,16 @@ func TestResyncAllCancelledPreservesOriginalDB(t *testing.T) {
 
 	stats := env.engine.ResyncAll(ctx, nil)
 
-	if !stats.Aborted {
-		t.Fatal("expected ResyncAll to report Aborted")
-	}
+	require.True(t, stats.Aborted, "expected ResyncAll to report Aborted")
 
 	// Original DB should be preserved — session still
 	// has the original data.
 	sess, err = env.db.GetSession(
 		context.Background(), "cancel-sess",
 	)
-	if err != nil || sess == nil {
-		t.Fatal("session lost after cancelled resync")
-	}
-	if sess.MessageCount != origCount {
-		t.Errorf(
-			"message count = %d, want %d",
-			sess.MessageCount, origCount,
-		)
-	}
+	require.NoError(t, err, "session lost after cancelled resync")
+	require.NotNil(t, sess, "session lost after cancelled resync")
+	assert.Equal(t, origCount, sess.MessageCount, "message count = %d, want %d", sess.MessageCount, origCount)
 }
 
 func TestSyncAllCancelledDoesNotUpdateLastSync(t *testing.T) {
@@ -7022,29 +6161,19 @@ func TestSyncAllCancelledDoesNotUpdateLastSync(t *testing.T) {
 	// Run a successful sync to set lastSync.
 	env.engine.SyncAll(context.Background(), nil)
 	lastSync := env.engine.LastSync()
-	if lastSync.IsZero() {
-		t.Fatal("expected lastSync to be set")
-	}
+	require.False(t, lastSync.IsZero(), "expected lastSync to be set")
 	lastStats := env.engine.LastSyncStats()
-	if lastStats.Synced == 0 {
-		t.Fatal("expected synced > 0")
-	}
+	require.NotZero(t, lastStats.Synced, "expected synced > 0")
 
 	// Run a cancelled sync.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	stats := env.engine.SyncAll(ctx, nil)
-	if !stats.Aborted {
-		t.Fatal("expected SyncAll to report Aborted")
-	}
+	require.True(t, stats.Aborted, "expected SyncAll to report Aborted")
 
 	// lastSync and lastSyncStats should be unchanged.
-	if env.engine.LastSync() != lastSync {
-		t.Error("lastSync was updated by cancelled sync")
-	}
-	if env.engine.LastSyncStats().Synced != lastStats.Synced {
-		t.Error("lastSyncStats was updated by cancelled sync")
-	}
+	assert.Equal(t, lastSync, env.engine.LastSync(), "lastSync was updated by cancelled sync")
+	assert.Equal(t, lastStats.Synced, env.engine.LastSyncStats().Synced, "lastSyncStats was updated by cancelled sync")
 }
 
 func TestSyncAllSince_FiltersByMtime(t *testing.T) {
@@ -7068,9 +6197,7 @@ func TestSyncAllSince_FiltersByMtime(t *testing.T) {
 	// Backdate the old file to simulate an unchanged prior
 	// session; keep the new file at its natural mtime.
 	longAgo := time.Now().Add(-48 * time.Hour)
-	if err := os.Chtimes(oldPath, longAgo, longAgo); err != nil {
-		t.Fatalf("chtimes old: %v", err)
-	}
+	require.NoError(t, os.Chtimes(oldPath, longAgo, longAgo), "chtimes old")
 
 	// SyncAllSince with a cutoff 1 hour ago should only
 	// process the new file.
@@ -7078,20 +6205,14 @@ func TestSyncAllSince_FiltersByMtime(t *testing.T) {
 	stats := env.engine.SyncAllSince(
 		context.Background(), cutoff, nil,
 	)
-	if stats.Synced != 1 {
-		t.Errorf("synced = %d, want 1", stats.Synced)
-	}
+	assert.Equal(t, 1, stats.Synced, "synced = %d, want 1", stats.Synced)
 
 	// Verify only the new session is in the DB.
 	page, err := env.db.ListSessions(
 		context.Background(), db.SessionFilter{Limit: 10},
 	)
-	if err != nil {
-		t.Fatalf("list sessions: %v", err)
-	}
-	if len(page.Sessions) != 1 {
-		t.Fatalf("sessions = %d, want 1", len(page.Sessions))
-	}
+	require.NoError(t, err, "list sessions")
+	require.Equal(t, 1, len(page.Sessions), "sessions = %d, want 1", len(page.Sessions))
 
 	// Second call with zero cutoff syncs everything.
 	stats = env.engine.SyncAllSince(
@@ -7099,19 +6220,13 @@ func TestSyncAllSince_FiltersByMtime(t *testing.T) {
 	)
 	// The new file is already in the DB (skip cache);
 	// the old file should now be synced too.
-	if stats.Synced == 0 {
-		t.Error("expected second sync to pick up backdated file")
-	}
+	assert.NotZero(t, stats.Synced, "expected second sync to pick up backdated file")
 
 	page, err = env.db.ListSessions(
 		context.Background(), db.SessionFilter{Limit: 10},
 	)
-	if err != nil {
-		t.Fatalf("list sessions: %v", err)
-	}
-	if len(page.Sessions) != 2 {
-		t.Errorf("sessions = %d, want 2", len(page.Sessions))
-	}
+	require.NoError(t, err, "list sessions")
+	assert.Equal(t, 2, len(page.Sessions), "sessions = %d, want 2", len(page.Sessions))
 
 	_ = newPath
 }
@@ -7131,23 +6246,15 @@ func TestSyncAll_PersistsStartedAndFinishedAt(t *testing.T) {
 	after := time.Now().UTC().Add(1 * time.Second)
 
 	startedAt := env.engine.LastSyncStartedAt()
-	if startedAt.IsZero() {
-		t.Fatal("LastSyncStartedAt is zero after sync")
-	}
-	if startedAt.Before(before) || startedAt.After(after) {
-		t.Errorf("LastSyncStartedAt %v outside [%v, %v]",
-			startedAt, before, after)
-	}
+	require.False(t, startedAt.IsZero(), "LastSyncStartedAt is zero after sync")
+	assert.False(t, startedAt.Before(before) || startedAt.After(after),
+		"LastSyncStartedAt %v outside [%v, %v]", startedAt, before, after)
 
 	finishedRaw, err := env.db.GetSyncState(
 		"last_sync_finished_at",
 	)
-	if err != nil {
-		t.Fatalf("get finish state: %v", err)
-	}
-	if finishedRaw == "" {
-		t.Fatal("last_sync_finished_at not persisted")
-	}
+	require.NoError(t, err, "get finish state")
+	require.NotEmpty(t, finishedRaw, "last_sync_finished_at not persisted")
 }
 
 func TestSyncAllOpenCodeExcludedNotCountedAsFailed(
@@ -7170,16 +6277,14 @@ func TestSyncAllOpenCodeExcludedNotCountedAsFailed(
 	sess, err := env.db.GetSession(
 		context.Background(), "opencode:oc-excl-1",
 	)
-	if err != nil || sess == nil {
-		t.Fatal("opencode session not found after sync")
-	}
+	require.NoError(t, err, "opencode session not found after sync")
+	require.NotNil(t, sess, "opencode session not found after sync")
 
 	// Permanently delete the session (marks it excluded).
-	if err := env.db.DeleteSession(
+	err = env.db.DeleteSession(
 		"opencode:oc-excl-1",
-	); err != nil {
-		t.Fatalf("delete session: %v", err)
-	}
+	)
+	require.NoError(t, err, "delete session")
 
 	// Bump the time_updated so the next sync picks it up.
 	oc.updateSessionTime(t, "oc-excl-1", 2000)
@@ -7187,13 +6292,7 @@ func TestSyncAllOpenCodeExcludedNotCountedAsFailed(
 	// Sync again — the excluded session should not be
 	// counted as a failure.
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Failed > 0 {
-		t.Errorf(
-			"Failed = %d, want 0 (excluded session "+
-				"should not count as failure)",
-			stats.Failed,
-		)
-	}
+	assert.LessOrEqual(t, stats.Failed, 0, "Failed = %d, want 0 (excluded session "+ "should not count as failure)", stats.Failed)
 }
 
 // TestSyncSingleSessionExcludedIsNoOp verifies that
@@ -7215,21 +6314,14 @@ func TestSyncSingleSessionExcludedIsNoOp(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "excl-single", 2)
 
 	// Permanently delete → marks it excluded.
-	if err := env.db.DeleteSession(
+	err := env.db.DeleteSession(
 		"excl-single",
-	); err != nil {
-		t.Fatalf("DeleteSession: %v", err)
-	}
+	)
+	require.NoError(t, err, "DeleteSession")
 
 	// SyncSingleSession should silently skip, not error.
-	if err := env.engine.SyncSingleSession(
-		"excl-single",
-	); err != nil {
-		t.Fatalf(
-			"SyncSingleSession on excluded session "+
-				"returned error: %v", err,
-		)
-	}
+	require.NoError(t, env.engine.SyncSingleSession("excl-single"),
+		"SyncSingleSession on excluded session returned error")
 }
 
 func TestSyncAllTrashedSessionIsSkippedAndCached(t *testing.T) {
@@ -7246,36 +6338,22 @@ func TestSyncAllTrashedSessionIsSkippedAndCached(t *testing.T) {
 	env.engine.SyncAll(context.Background(), nil)
 	assertSessionMessageCount(t, env.db, "trashed-sync", 2)
 
-	if err := env.db.SoftDeleteSession("trashed-sync"); err != nil {
-		t.Fatalf("SoftDeleteSession: %v", err)
-	}
-	if err := env.db.ResetAllMtimes(); err != nil {
-		t.Fatalf("ResetAllMtimes: %v", err)
-	}
+	require.NoError(t, env.db.SoftDeleteSession("trashed-sync"), "SoftDeleteSession")
+	require.NoError(t, env.db.ResetAllMtimes(), "ResetAllMtimes")
 
 	updated := testjsonl.NewSessionBuilder().
 		AddClaudeUser(tsZero, "hello again with a longer prompt").
 		AddClaudeAssistant(tsZeroS5, "still here with a longer reply").
 		String()
-	if err := os.Remove(path); err != nil {
-		t.Fatalf("Remove: %v", err)
-	}
+	require.NoError(t, os.Remove(path), "Remove")
 	dbtest.WriteTestFile(t, path, []byte(updated))
 	future := time.Now().Add(2 * time.Second)
-	if err := os.Chtimes(path, future, future); err != nil {
-		t.Fatalf("Chtimes: %v", err)
-	}
+	require.NoError(t, os.Chtimes(path, future, future), "Chtimes")
 
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Failed != 0 {
-		t.Fatalf("Failed = %d, want 0 for trashed session", stats.Failed)
-	}
-	if stats.Synced != 0 {
-		t.Fatalf("Synced = %d, want 0 for trashed session", stats.Synced)
-	}
-	if got := env.engine.SnapshotSkipCache()[path]; got == 0 {
-		t.Fatalf("skip cache missing trashed session path %s", path)
-	}
+	require.Equal(t, 0, stats.Failed, "Failed = %d, want 0 for trashed session", stats.Failed)
+	require.Equal(t, 0, stats.Synced, "Synced = %d, want 0 for trashed session", stats.Synced)
+	require.NotZero(t, env.engine.SnapshotSkipCache()[path], "skip cache missing trashed session path %s", path)
 }
 
 func TestSyncAllTrashedSessionAppendUsesSkipPath(t *testing.T) {
@@ -7292,43 +6370,28 @@ func TestSyncAllTrashedSessionAppendUsesSkipPath(t *testing.T) {
 	env.engine.SyncAll(context.Background(), nil)
 	assertSessionMessageCount(t, env.db, "trashed-append", 2)
 
-	if err := env.db.SoftDeleteSession("trashed-append"); err != nil {
-		t.Fatalf("SoftDeleteSession: %v", err)
-	}
+	require.NoError(t, env.db.SoftDeleteSession("trashed-append"), "SoftDeleteSession")
 
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		t.Fatalf("open append: %v", err)
-	}
+	require.NoError(t, err, "open append")
 	_, err = f.WriteString(
 		testjsonl.NewSessionBuilder().
 			AddClaudeUser(tsEarly, "new prompt").
 			AddClaudeAssistant(tsEarlyS5, "new reply").
 			String(),
 	)
-	if closeErr := f.Close(); closeErr != nil {
-		t.Fatalf("close append: %v", closeErr)
-	}
-	if err != nil {
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, err, "append")
 
 	stats := env.engine.SyncAll(context.Background(), nil)
-	if stats.Failed != 0 {
-		t.Fatalf("Failed = %d, want 0 for trashed append", stats.Failed)
-	}
-	if stats.Synced != 0 {
-		t.Fatalf("Synced = %d, want 0 for trashed append", stats.Synced)
-	}
+	require.Equal(t, 0, stats.Failed, "Failed = %d, want 0 for trashed append", stats.Failed)
+	require.Equal(t, 0, stats.Synced, "Synced = %d, want 0 for trashed append", stats.Synced)
 	full, err := env.db.GetSessionFull(
 		context.Background(), "trashed-append",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if full == nil || full.MessageCount != 2 {
-		t.Fatalf("MessageCount = %v, want preserved count 2", full)
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, full, "MessageCount = nil, want preserved count 2")
+	require.Equal(t, 2, full.MessageCount, "MessageCount = %v, want preserved count 2", full)
 }
 
 func TestSyncSingleSessionTrashedIsNoOp(t *testing.T) {
@@ -7345,16 +6408,9 @@ func TestSyncSingleSessionTrashedIsNoOp(t *testing.T) {
 	env.engine.SyncAll(context.Background(), nil)
 	assertSessionMessageCount(t, env.db, "trashed-single", 2)
 
-	if err := env.db.SoftDeleteSession("trashed-single"); err != nil {
-		t.Fatalf("SoftDeleteSession: %v", err)
-	}
+	require.NoError(t, env.db.SoftDeleteSession("trashed-single"), "SoftDeleteSession")
 
-	if err := env.engine.SyncSingleSession("trashed-single"); err != nil {
-		t.Fatalf(
-			"SyncSingleSession on trashed session "+
-				"returned error: %v", err,
-		)
-	}
+	require.NoError(t, env.engine.SyncSingleSession("trashed-single"), "SyncSingleSession on trashed session "+ "returned error")
 }
 
 // TestSyncSingleSessionOpenCodeExcludedIsNoOp verifies that
@@ -7381,21 +6437,13 @@ func TestSyncSingleSessionOpenCodeExcludedIsNoOp(
 	sessionID := "opencode:oc-excl-single"
 	assertSessionMessageCount(t, env.db, sessionID, 1)
 
-	if err := env.db.DeleteSession(sessionID); err != nil {
-		t.Fatalf("DeleteSession: %v", err)
-	}
+	require.NoError(t, env.db.DeleteSession(sessionID), "DeleteSession")
 
 	// Bump time so parser would normally pick it up.
 	oc.updateSessionTime(t, "oc-excl-single", 2000)
 
-	if err := env.engine.SyncSingleSession(
-		sessionID,
-	); err != nil {
-		t.Fatalf(
-			"SyncSingleSession on excluded OpenCode "+
-				"session returned error: %v", err,
-		)
-	}
+	require.NoError(t, env.engine.SyncSingleSession(sessionID),
+		"SyncSingleSession on excluded OpenCode session returned error")
 }
 
 func TestIncrementalSync_ClaudeClearOnlyRepairedOnAppend(t *testing.T) {
@@ -7418,21 +6466,11 @@ func TestIncrementalSync_ClaudeClearOnlyRepairedOnAppend(t *testing.T) {
 	full, err := env.db.GetSessionFull(
 		context.Background(), "clear-only",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull after initial sync: %v", err)
+	require.NoError(t, err, "GetSessionFull after initial sync")
+	if full.FirstMessage != nil {
+		require.Equal(t, "", *full.FirstMessage, "initial FirstMessage = %q, want empty", *full.FirstMessage)
 	}
-	if full.FirstMessage != nil && *full.FirstMessage != "" {
-		t.Fatalf(
-			"initial FirstMessage = %q, want empty",
-			*full.FirstMessage,
-		)
-	}
-	if full.UserMessageCount != 1 {
-		t.Fatalf(
-			"initial UserMessageCount = %d, want 1",
-			full.UserMessageCount,
-		)
-	}
+	require.Equal(t, 1, full.UserMessageCount, "initial UserMessageCount = %d, want 1", full.UserMessageCount)
 
 	// Append a real user message — incremental sync must now
 	// fall back to a full parse so first_message gets populated.
@@ -7442,40 +6480,22 @@ func TestIncrementalSync_ClaudeClearOnlyRepairedOnAppend(t *testing.T) {
 	f, err := os.OpenFile(
 		path, os.O_APPEND|os.O_WRONLY, 0o644,
 	)
-	if err != nil {
-		t.Fatalf("open for append: %v", err)
-	}
+	require.NoError(t, err, "open for append")
 	_, err = f.WriteString(appended)
 	f.Close()
-	if err != nil {
-		t.Fatalf("append: %v", err)
-	}
+	require.NoError(t, err, "append")
 
 	env.engine.SyncPaths([]string{path})
 
 	updated, err := env.db.GetSessionFull(
 		context.Background(), "clear-only",
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull after append: %v", err)
-	}
-	if updated.FirstMessage == nil ||
-		*updated.FirstMessage != "Fix the login bug" {
-		got := ""
-		if updated.FirstMessage != nil {
-			got = *updated.FirstMessage
-		}
-		t.Errorf(
-			"FirstMessage after append = %q, want %q",
-			got, "Fix the login bug",
-		)
-	}
-	if updated.UserMessageCount != 2 {
-		t.Errorf(
-			"UserMessageCount after append = %d, want 2",
-			updated.UserMessageCount,
-		)
-	}
+	require.NoError(t, err, "GetSessionFull after append")
+	require.NotNil(t, updated.FirstMessage,
+		"FirstMessage after append = nil, want %q", "Fix the login bug")
+	assert.Equal(t, "Fix the login bug", *updated.FirstMessage,
+		"FirstMessage after append = %q, want %q", *updated.FirstMessage, "Fix the login bug")
+	assert.Equal(t, 2, updated.UserMessageCount, "UserMessageCount after append = %d, want 2", updated.UserMessageCount)
 }
 
 func testStringPtrValue(v *string) string {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
@@ -24,9 +26,7 @@ func openTestDB(t *testing.T) *db.DB {
 	d, err := db.Open(
 		filepath.Join(t.TempDir(), "test.db"),
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { d.Close() })
 	return d
 }
@@ -192,9 +192,8 @@ func TestFilterEmptyMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := pairAndFilter(tt.msgs, nil)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("pairAndFilter() mismatch (-want +got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.want, got)
+			assert.Empty(t, diff, "pairAndFilter() mismatch (-want +got):\n%s", diff)
 		})
 	}
 }
@@ -254,9 +253,8 @@ func TestPostFilterCounts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			total, user := postFilterCounts(tt.msgs)
 			got := counts{Total: total, User: user}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("postFilterCounts() mismatch (-want +got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.want, got)
+			assert.Empty(t, diff, "postFilterCounts() mismatch (-want +got):\n%s", diff)
 		})
 	}
 }
@@ -342,9 +340,8 @@ func TestPairToolResults(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pairToolResults(tt.msgs, nil)
-			if diff := cmp.Diff(tt.want, tt.msgs); diff != "" {
-				t.Errorf("pairToolResults() mismatch (-want +got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.want, tt.msgs)
+			assert.Empty(t, diff, "pairToolResults() mismatch (-want +got):\n%s", diff)
 		})
 	}
 }
@@ -460,9 +457,8 @@ func TestPairToolResultsContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pairToolResults(tt.msgs, tt.blocked)
-			if diff := cmp.Diff(tt.want, tt.msgs); diff != "" {
-				t.Errorf("pairToolResults() mismatch (-want +got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.want, tt.msgs)
+			assert.Empty(t, diff, "pairToolResults() mismatch (-want +got):\n%s", diff)
 		})
 	}
 }
@@ -666,9 +662,8 @@ func TestPairToolResultEventSummaries(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pairToolResultEventSummaries(tt.msgs, tt.blocked)
-			if diff := cmp.Diff(tt.want, tt.msgs); diff != "" {
-				t.Fatalf("pairToolResultEventSummaries() mismatch (-want +got):\n%s", diff)
-			}
+			diff := cmp.Diff(tt.want, tt.msgs)
+			require.Empty(t, diff, "pairToolResultEventSummaries() mismatch (-want +got):\n%s", diff)
 		})
 	}
 }
@@ -772,31 +767,15 @@ func TestApplyRemoteRewrites(t *testing.T) {
 			}
 			e.applyRemoteRewrites(&tt.sess, tt.msgs)
 
-			if tt.sess.ID != tt.wantSessID {
-				t.Errorf(
-					"ID = %q, want %q",
-					tt.sess.ID, tt.wantSessID,
-				)
-			}
-			if diff := cmp.Diff(
-				tt.wantParent, tt.sess.ParentSessionID,
-			); diff != "" {
-				t.Errorf("ParentSessionID %s", diff)
-			}
+			assert.Equal(t, tt.wantSessID, tt.sess.ID)
+			diff := cmp.Diff(tt.wantParent, tt.sess.ParentSessionID)
+			assert.Empty(t, diff, "ParentSessionID %s", diff)
 			if tt.wantFilePath != nil {
-				if diff := cmp.Diff(
-					tt.wantFilePath, tt.sess.FilePath,
-				); diff != "" {
-					t.Errorf("FilePath %s", diff)
-				}
+				diff := cmp.Diff(tt.wantFilePath, tt.sess.FilePath)
+				assert.Empty(t, diff, "FilePath %s", diff)
 			}
 			for _, m := range tt.msgs {
-				if m.SessionID != tt.wantMsgSess {
-					t.Errorf(
-						"msg SessionID = %q, want %q",
-						m.SessionID, tt.wantMsgSess,
-					)
-				}
+				assert.Equal(t, tt.wantMsgSess, m.SessionID)
 			}
 			var gotSubs, gotEvSubs []string
 			for _, m := range tt.msgs {
@@ -812,16 +791,10 @@ func TestApplyRemoteRewrites(t *testing.T) {
 					}
 				}
 			}
-			if diff := cmp.Diff(
-				tt.wantSubs, gotSubs,
-			); diff != "" {
-				t.Errorf("SubagentSessionIDs %s", diff)
-			}
-			if diff := cmp.Diff(
-				tt.wantEvSubs, gotEvSubs,
-			); diff != "" {
-				t.Errorf("ResultEvent SubagentSessionIDs %s", diff)
-			}
+			diff = cmp.Diff(tt.wantSubs, gotSubs)
+			assert.Empty(t, diff, "SubagentSessionIDs %s", diff)
+			diff = cmp.Diff(tt.wantEvSubs, gotEvSubs)
+			assert.Empty(t, diff, "ResultEvent SubagentSessionIDs %s", diff)
 		})
 	}
 }
@@ -841,17 +814,13 @@ func TestShouldSkipFileWithIDPrefix(t *testing.T) {
 			int64(1700000000000000000),
 		),
 	}
-	if err := database.UpsertSession(sess); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, database.UpsertSession(sess))
 	// data_version is no longer persisted by UpsertSession;
 	// stamp it explicitly so the skip check sees a current
 	// row.
-	if err := database.SetSessionDataVersion(
+	require.NoError(t, database.SetSessionDataVersion(
 		sess.ID, db.CurrentDataVersion(),
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	// Engine with IDPrefix should find the session.
 	e := &Engine{
@@ -862,9 +831,7 @@ func TestShouldSkipFileWithIDPrefix(t *testing.T) {
 		"abc-123",
 		fakeFileInfo{size: 1024, mtime: 1700000000000000000},
 	)
-	if !got {
-		t.Error("shouldSkipFile should return true")
-	}
+	assert.True(t, got, "shouldSkipFile should return true")
 
 	// Engine WITHOUT IDPrefix should NOT find it.
 	e2 := &Engine{db: database}
@@ -872,11 +839,7 @@ func TestShouldSkipFileWithIDPrefix(t *testing.T) {
 		"abc-123",
 		fakeFileInfo{size: 1024, mtime: 1700000000000000000},
 	)
-	if got2 {
-		t.Error(
-			"shouldSkipFile without prefix should return false",
-		)
-	}
+	assert.False(t, got2, "shouldSkipFile without prefix should return false")
 }
 
 func TestShouldSkipByPathWithRewriter(t *testing.T) {
@@ -894,14 +857,10 @@ func TestShouldSkipByPathWithRewriter(t *testing.T) {
 			int64(1700000000000000000),
 		),
 	}
-	if err := database.UpsertSession(sess); err != nil {
-		t.Fatal(err)
-	}
-	if err := database.SetSessionDataVersion(
+	require.NoError(t, database.UpsertSession(sess))
+	require.NoError(t, database.SetSessionDataVersion(
 		sess.ID, db.CurrentDataVersion(),
-	); err != nil {
-		t.Fatal(err)
-	}
+	))
 
 	rewriter := func(p string) string {
 		return "host:" + p
@@ -916,9 +875,7 @@ func TestShouldSkipByPathWithRewriter(t *testing.T) {
 		"/remote/codex/abc.jsonl",
 		fakeFileInfo{size: 2048, mtime: 1700000000000000000},
 	)
-	if !got {
-		t.Error("shouldSkipByPath should return true")
-	}
+	assert.True(t, got, "shouldSkipByPath should return true")
 
 	// Without rewriter, lookup misses.
 	e2 := &Engine{db: database}
@@ -926,12 +883,7 @@ func TestShouldSkipByPathWithRewriter(t *testing.T) {
 		"/remote/codex/abc.jsonl",
 		fakeFileInfo{size: 2048, mtime: 1700000000000000000},
 	)
-	if got2 {
-		t.Error(
-			"shouldSkipByPath without rewriter should " +
-				"return false",
-		)
-	}
+	assert.False(t, got2, "shouldSkipByPath without rewriter should return false")
 }
 
 func TestBlockedCategorySet(t *testing.T) {
@@ -952,12 +904,8 @@ func TestBlockedCategorySet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := blockedCategorySet(tt.input)
 			got := m[tt.check]
-			if got != tt.want {
-				t.Errorf(
-					"blockedCategorySet(%v)[%q] = %v, want %v",
-					tt.input, tt.check, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, got,
+				"blockedCategorySet(%v)[%q]", tt.input, tt.check)
 		})
 	}
 }
@@ -995,9 +943,8 @@ func TestOpenCodeLegacyArchiveLooksIncomplete(t *testing.T) {
 			},
 		}
 
-		if !openCodeLegacyArchiveLooksIncomplete(parsed, stored) {
-			t.Fatal("want incomplete archive detection")
-		}
+		require.True(t, openCodeLegacyArchiveLooksIncomplete(parsed, stored),
+			"want incomplete archive detection")
 	})
 
 	t.Run("extra parsed messages with complete prefix do not preserve", func(t *testing.T) {
@@ -1020,9 +967,8 @@ func TestOpenCodeLegacyArchiveLooksIncomplete(t *testing.T) {
 			},
 		}
 
-		if openCodeLegacyArchiveLooksIncomplete(parsed, stored) {
-			t.Fatal("got incomplete archive detection, want false")
-		}
+		require.False(t, openCodeLegacyArchiveLooksIncomplete(parsed, stored),
+			"got incomplete archive detection, want false")
 	})
 }
 
@@ -1091,12 +1037,8 @@ func (fx *engineFixture) writeClaudeSession(
 		AddClaudeUser("2024-01-01T00:00:00Z", firstMessage).
 		String()
 	path := filepath.Join(fx.claudeDir, proj, filename)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 	return path
 }
 
@@ -1111,13 +1053,10 @@ func (fx *engineFixture) appendClaudeMessage(
 		AddClaudeUser("2024-01-01T00:00:05Z", message).
 		String()
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		t.Fatalf("OpenFile: %v", err)
-	}
+	require.NoError(t, err, "OpenFile")
 	defer f.Close()
-	if _, err := f.WriteString(line); err != nil {
-		t.Fatalf("WriteString: %v", err)
-	}
+	_, err = f.WriteString(line)
+	require.NoError(t, err, "WriteString")
 }
 
 // sessionIDFor returns the session ID the engine uses for the
@@ -1137,16 +1076,10 @@ func TestEngine_SyncAllEmitsWhenSessionsChange(t *testing.T) {
 
 	fx.writeClaudeSession(t, "proj", "s1.jsonl", "hello")
 	stats := fx.engine.SyncAll(context.Background(), nil)
-	if stats.Synced == 0 {
-		t.Fatal("expected Synced > 0")
-	}
+	require.NotZero(t, stats.Synced, "expected Synced > 0")
 	got := em.got()
-	if len(got) != 1 {
-		t.Fatalf("expected 1 emission, got %d: %v", len(got), got)
-	}
-	if got[0] != "sessions" {
-		t.Errorf("SyncAll scope: got %q, want %q", got[0], "sessions")
-	}
+	require.Len(t, got, 1, "expected 1 emission, got %v", got)
+	assert.Equal(t, "sessions", got[0], "SyncAll scope")
 }
 
 func TestEngine_SyncAllDoesNotEmitOnEmptyRun(t *testing.T) {
@@ -1156,12 +1089,8 @@ func TestEngine_SyncAllDoesNotEmitOnEmptyRun(t *testing.T) {
 
 	// No session files — sync finds nothing.
 	stats := fx.engine.SyncAll(context.Background(), nil)
-	if stats.Synced != 0 {
-		t.Fatalf("expected Synced == 0, got %d", stats.Synced)
-	}
-	if got := em.got(); len(got) != 0 {
-		t.Fatalf("expected no emissions, got %v", got)
-	}
+	require.Zero(t, stats.Synced)
+	assert.Empty(t, em.got(), "expected no emissions")
 }
 
 func TestEngine_SyncPathsEmitsWhenSessionsChange(t *testing.T) {
@@ -1173,12 +1102,8 @@ func TestEngine_SyncPathsEmitsWhenSessionsChange(t *testing.T) {
 	fx.engine.SyncPaths([]string{path})
 
 	got := em.got()
-	if len(got) != 1 {
-		t.Fatalf("expected 1 emission, got %d: %v", len(got), got)
-	}
-	if got[0] != "sessions" {
-		t.Errorf("SyncPaths scope: got %q, want %q", got[0], "sessions")
-	}
+	require.Len(t, got, 1, "expected 1 emission, got %v", got)
+	assert.Equal(t, "sessions", got[0], "SyncPaths scope")
 }
 
 // emitterFunc adapts a plain function to the Emitter interface so
@@ -1208,9 +1133,8 @@ func TestEngine_SyncPathsEmitsAfterSyncMuReleased(t *testing.T) {
 	path := fx.writeClaudeSession(t, "proj", "s1.jsonl", "hello")
 	fx.engine.SyncPaths([]string{path})
 
-	if !acquired.Load() {
-		t.Fatal("syncMu was still held when SyncPaths emitted — defer-order regression")
-	}
+	assert.True(t, acquired.Load(),
+		"syncMu was still held when SyncPaths emitted — defer-order regression")
 }
 
 func TestEngine_SyncPathsDoesNotEmitOnNoMatches(t *testing.T) {
@@ -1222,9 +1146,7 @@ func TestEngine_SyncPathsDoesNotEmitOnNoMatches(t *testing.T) {
 	// returns zero files and SyncPaths returns early.
 	fx.engine.SyncPaths([]string{"/nonexistent/bogus.txt"})
 
-	if got := em.got(); len(got) != 0 {
-		t.Fatalf("expected no emissions, got %v", got)
-	}
+	assert.Empty(t, em.got(), "expected no emissions")
 }
 
 func TestEngine_ClassifyOnePathClaudeStatPermissionErrorStillClassifies(
@@ -1245,29 +1167,17 @@ func TestEngine_ClassifyOnePathClaudeStatPermissionErrorStillClassifies(
 
 	projectDir := filepath.Join(claudeDir, "proj")
 	path := filepath.Join(projectDir, "session.jsonl")
-	if err := os.MkdirAll(projectDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(%q): %v", projectDir, err)
-	}
-	if err := os.WriteFile(path, []byte("[]"), 0o644); err != nil {
-		t.Fatalf("WriteFile(%q): %v", path, err)
-	}
-	if err := os.Chmod(projectDir, 0o000); err != nil {
-		t.Fatalf("Chmod(%q): %v", projectDir, err)
-	}
+	require.NoError(t, os.MkdirAll(projectDir, 0o755), "MkdirAll(%q)", projectDir)
+	require.NoError(t, os.WriteFile(path, []byte("[]"), 0o644), "WriteFile(%q)", path)
+	require.NoError(t, os.Chmod(projectDir, 0o000), "Chmod(%q)", projectDir)
 	defer func() {
 		_ = os.Chmod(projectDir, 0o755)
 	}()
 
 	got, ok := engine.classifyOnePath(path, nil)
-	if !ok {
-		t.Fatal("expected path to classify despite stat permission error")
-	}
-	if got.Path != path {
-		t.Fatalf("Path = %q, want %q", got.Path, path)
-	}
-	if got.Agent != parser.AgentClaude {
-		t.Fatalf("Agent = %q, want %q", got.Agent, parser.AgentClaude)
-	}
+	require.True(t, ok, "expected path to classify despite stat permission error")
+	assert.Equal(t, path, got.Path)
+	assert.Equal(t, parser.AgentClaude, got.Agent)
 }
 
 func TestEngine_ClassifyPathsDedupesOpenCodeChildPaths(t *testing.T) {
@@ -1297,27 +1207,16 @@ func TestEngine_ClassifyPathsDedupesOpenCodeChildPaths(t *testing.T) {
 		messagePath: `{"id":"msg_1","sessionID":"ses_123","role":"user","time":{"created":1}}`,
 		partPath:    `{"id":"part_1","sessionID":"ses_123","messageID":"msg_1","type":"text","text":"hi","time":{"created":1}}`,
 	} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", path, err)
-		}
-		if err := os.WriteFile(
-			path, []byte(content), 0o644,
-		); err != nil {
-			t.Fatalf("WriteFile(%q): %v", path, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "MkdirAll(%q)", path)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644), "WriteFile(%q)", path)
 	}
 
 	files := engine.classifyPaths([]string{
 		messagePath,
 		partPath,
 	})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1", len(files))
-	}
-	if files[0].Path != sessionPath {
-		t.Fatalf("files[0].Path = %q, want %q",
-			files[0].Path, sessionPath)
-	}
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionPath, files[0].Path)
 }
 
 func TestEngine_ClassifyPathsOpenCodeRemovedMessageDir(
@@ -1344,29 +1243,16 @@ func TestEngine_ClassifyPathsOpenCodeRemovedMessageDir(
 		sessionPath: `{"id":"ses_123","directory":"/tmp/proj","time":{"created":1,"updated":2}}`,
 		messagePath: `{"id":"msg_1","sessionID":"ses_123","role":"user","time":{"created":1}}`,
 	} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", path, err)
-		}
-		if err := os.WriteFile(
-			path, []byte(content), 0o644,
-		); err != nil {
-			t.Fatalf("WriteFile(%q): %v", path, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "MkdirAll(%q)", path)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644), "WriteFile(%q)", path)
 	}
 
 	messageDir := filepath.Dir(messagePath)
-	if err := os.RemoveAll(messageDir); err != nil {
-		t.Fatalf("RemoveAll(%q): %v", messageDir, err)
-	}
+	require.NoError(t, os.RemoveAll(messageDir), "RemoveAll(%q)", messageDir)
 
 	files := engine.classifyPaths([]string{messageDir})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1", len(files))
-	}
-	if files[0].Path != sessionPath {
-		t.Fatalf("files[0].Path = %q, want %q",
-			files[0].Path, sessionPath)
-	}
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionPath, files[0].Path)
 }
 
 func TestEngine_ClassifyPathsOpenCodeSQLiteWALFile(
@@ -1382,22 +1268,13 @@ func TestEngine_ClassifyPathsOpenCodeSQLiteWALFile(
 	})
 
 	dbPath := filepath.Join(opencodeDir, "opencode.db")
-	if err := os.WriteFile(dbPath, []byte("db"), 0o644); err != nil {
-		t.Fatalf("WriteFile(%q): %v", dbPath, err)
-	}
+	require.NoError(t, os.WriteFile(dbPath, []byte("db"), 0o644), "WriteFile(%q)", dbPath)
 	walPath := filepath.Join(opencodeDir, "opencode.db-wal")
-	if err := os.WriteFile(walPath, []byte("wal"), 0o644); err != nil {
-		t.Fatalf("WriteFile(%q): %v", walPath, err)
-	}
+	require.NoError(t, os.WriteFile(walPath, []byte("wal"), 0o644), "WriteFile(%q)", walPath)
 
 	files := engine.classifyPaths([]string{walPath})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1", len(files))
-	}
-	if files[0].Path != dbPath {
-		t.Fatalf("files[0].Path = %q, want %q",
-			files[0].Path, dbPath)
-	}
+	require.Len(t, files, 1)
+	assert.Equal(t, dbPath, files[0].Path)
 }
 
 func TestEngine_ClassifyPathsOpenCodeRemovedMessageFile(
@@ -1424,28 +1301,15 @@ func TestEngine_ClassifyPathsOpenCodeRemovedMessageFile(
 		sessionPath: `{"id":"ses_123","directory":"/tmp/proj","time":{"created":1,"updated":2}}`,
 		messagePath: `{"id":"msg_1","sessionID":"ses_123","role":"user","time":{"created":1}}`,
 	} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", path, err)
-		}
-		if err := os.WriteFile(
-			path, []byte(content), 0o644,
-		); err != nil {
-			t.Fatalf("WriteFile(%q): %v", path, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "MkdirAll(%q)", path)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644), "WriteFile(%q)", path)
 	}
 
-	if err := os.Remove(messagePath); err != nil {
-		t.Fatalf("Remove(%q): %v", messagePath, err)
-	}
+	require.NoError(t, os.Remove(messagePath), "Remove(%q)", messagePath)
 
 	files := engine.classifyPaths([]string{messagePath})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1", len(files))
-	}
-	if files[0].Path != sessionPath {
-		t.Fatalf("files[0].Path = %q, want %q",
-			files[0].Path, sessionPath)
-	}
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionPath, files[0].Path)
 }
 
 func TestEngine_ClassifyPathsOpenCodeRemovedPartDir(
@@ -1477,29 +1341,16 @@ func TestEngine_ClassifyPathsOpenCodeRemovedPartDir(
 		messagePath: `{"id":"msg_1","sessionID":"ses_123","role":"user","time":{"created":1}}`,
 		partPath:    `{"id":"part_1","messageID":"msg_1","type":"text","text":"hi","time":{"created":1}}`,
 	} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", path, err)
-		}
-		if err := os.WriteFile(
-			path, []byte(content), 0o644,
-		); err != nil {
-			t.Fatalf("WriteFile(%q): %v", path, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "MkdirAll(%q)", path)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644), "WriteFile(%q)", path)
 	}
 
 	partDir := filepath.Dir(partPath)
-	if err := os.RemoveAll(partDir); err != nil {
-		t.Fatalf("RemoveAll(%q): %v", partDir, err)
-	}
+	require.NoError(t, os.RemoveAll(partDir), "RemoveAll(%q)", partDir)
 
 	files := engine.classifyPaths([]string{partDir})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1", len(files))
-	}
-	if files[0].Path != sessionPath {
-		t.Fatalf("files[0].Path = %q, want %q",
-			files[0].Path, sessionPath)
-	}
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionPath, files[0].Path)
 }
 
 func TestEngine_ClassifyPathsOpenCodeRemovedPartFile(
@@ -1531,28 +1382,15 @@ func TestEngine_ClassifyPathsOpenCodeRemovedPartFile(
 		messagePath: `{"id":"msg_1","sessionID":"ses_123","role":"user","time":{"created":1}}`,
 		partPath:    `{"id":"part_1","messageID":"msg_1","type":"text","text":"hi","time":{"created":1}}`,
 	} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", path, err)
-		}
-		if err := os.WriteFile(
-			path, []byte(content), 0o644,
-		); err != nil {
-			t.Fatalf("WriteFile(%q): %v", path, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "MkdirAll(%q)", path)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644), "WriteFile(%q)", path)
 	}
 
-	if err := os.Remove(partPath); err != nil {
-		t.Fatalf("Remove(%q): %v", partPath, err)
-	}
+	require.NoError(t, os.Remove(partPath), "Remove(%q)", partPath)
 
 	files := engine.classifyPaths([]string{partPath})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1", len(files))
-	}
-	if files[0].Path != sessionPath {
-		t.Fatalf("files[0].Path = %q, want %q",
-			files[0].Path, sessionPath)
-	}
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionPath, files[0].Path)
 }
 
 // TestEngine_ClassifyPathsQwenSession verifies fsnotify events for
@@ -1574,27 +1412,15 @@ func TestEngine_ClassifyPathsQwenSession(t *testing.T) {
 	sessionID := "adc026b4-c620-43e4-8cc4-295593889d18"
 	encodedProject := "-Users-alice-code-sample-project"
 	chatsDir := filepath.Join(qwenDir, encodedProject, "chats")
-	if err := os.MkdirAll(chatsDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(%q): %v", chatsDir, err)
-	}
+	require.NoError(t, os.MkdirAll(chatsDir, 0o755), "MkdirAll(%q)", chatsDir)
 	sessionPath := filepath.Join(chatsDir, sessionID+".jsonl")
-	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile(%q): %v", sessionPath, err)
-	}
+	require.NoError(t, os.WriteFile(sessionPath, []byte("{}\n"), 0o644), "WriteFile(%q)", sessionPath)
 
 	files := engine.classifyPaths([]string{sessionPath})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1 (%v)", len(files), files)
-	}
-	if files[0].Path != sessionPath {
-		t.Errorf("Path = %q, want %q", files[0].Path, sessionPath)
-	}
-	if files[0].Agent != parser.AgentQwen {
-		t.Errorf("Agent = %q, want %q", files[0].Agent, parser.AgentQwen)
-	}
-	if files[0].Project != "sample_project" {
-		t.Errorf("Project = %q, want %q", files[0].Project, "sample_project")
-	}
+	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
+	assert.Equal(t, sessionPath, files[0].Path)
+	assert.Equal(t, parser.AgentQwen, files[0].Agent)
+	assert.Equal(t, "sample_project", files[0].Project)
 
 	// Non-Qwen siblings (a stray file directly under projectsDir, a
 	// file under <project>/<not-chats>/, a non-jsonl in chats/, and a
@@ -1607,17 +1433,11 @@ func TestEngine_ClassifyPathsQwenSession(t *testing.T) {
 		filepath.Join(qwenDir, "chats", sessionID+".jsonl"),
 	}
 	for _, p := range bogus {
-		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", p, err)
-		}
-		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
-			t.Fatalf("WriteFile(%q): %v", p, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755), "MkdirAll(%q)", p)
+		require.NoError(t, os.WriteFile(p, []byte("{}"), 0o644), "WriteFile(%q)", p)
 	}
-	if got := engine.classifyPaths(bogus); len(got) != 0 {
-		t.Fatalf("expected no Qwen classifications for %v, got %v",
-			bogus, got)
-	}
+	got := engine.classifyPaths(bogus)
+	assert.Empty(t, got, "expected no Qwen classifications for %v, got %v", bogus, got)
 }
 
 func TestEngine_ClassifyPathsQClawSession(t *testing.T) {
@@ -1637,15 +1457,9 @@ func TestEngine_ClassifyPathsQClawSession(t *testing.T) {
 	dbtest.WriteTestFile(t, sessionPath, []byte("{}\n"))
 
 	files := engine.classifyPaths([]string{sessionPath})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1 (%v)", len(files), files)
-	}
-	if files[0].Path != sessionPath {
-		t.Errorf("Path = %q, want %q", files[0].Path, sessionPath)
-	}
-	if files[0].Agent != parser.AgentQClaw {
-		t.Errorf("Agent = %q, want %q", files[0].Agent, parser.AgentQClaw)
-	}
+	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
+	assert.Equal(t, sessionPath, files[0].Path)
+	assert.Equal(t, parser.AgentQClaw, files[0].Agent)
 
 	bogus := []string{
 		filepath.Join(qclawDir, "stray.jsonl"),
@@ -1656,10 +1470,8 @@ func TestEngine_ClassifyPathsQClawSession(t *testing.T) {
 	for _, p := range bogus {
 		dbtest.WriteTestFile(t, p, []byte("{}"))
 	}
-	if got := engine.classifyPaths(bogus); len(got) != 0 {
-		t.Fatalf("expected no QClaw classifications for %v, got %v",
-			bogus, got)
-	}
+	got := engine.classifyPaths(bogus)
+	assert.Empty(t, got, "expected no QClaw classifications for %v, got %v", bogus, got)
 }
 
 func TestEngine_ClassifyPathsQClawArchivedSession(t *testing.T) {
@@ -1684,23 +1496,14 @@ func TestEngine_ClassifyPathsQClawArchivedSession(t *testing.T) {
 	dbtest.WriteTestFile(t, active, []byte("{}\n"))
 	dbtest.WriteTestFile(t, archived, []byte("{}\n"))
 
-	if got := engine.classifyPaths([]string{archived}); len(got) != 0 {
-		t.Fatalf("expected archived file shadowed by active to be ignored, got %v", got)
-	}
+	got := engine.classifyPaths([]string{archived})
+	require.Empty(t, got, "expected archived file shadowed by active to be ignored, got %v", got)
 
-	if err := os.Remove(active); err != nil {
-		t.Fatalf("Remove(%q): %v", active, err)
-	}
+	require.NoError(t, os.Remove(active), "Remove(%q)", active)
 	files := engine.classifyPaths([]string{archived})
-	if len(files) != 1 {
-		t.Fatalf("len(files) = %d, want 1 (%v)", len(files), files)
-	}
-	if files[0].Path != archived {
-		t.Errorf("Path = %q, want %q", files[0].Path, archived)
-	}
-	if files[0].Agent != parser.AgentQClaw {
-		t.Errorf("Agent = %q, want %q", files[0].Agent, parser.AgentQClaw)
-	}
+	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
+	assert.Equal(t, archived, files[0].Path)
+	assert.Equal(t, parser.AgentQClaw, files[0].Agent)
 }
 
 func TestEngine_SyncSingleSessionEmitsOnSuccess(t *testing.T) {
@@ -1719,16 +1522,10 @@ func TestEngine_SyncSingleSessionEmitsOnSuccess(t *testing.T) {
 
 	fx.appendClaudeMessage(t, path, "world")
 	sessionID := fx.sessionIDFor(t, path)
-	if err := fx.engine.SyncSingleSession(sessionID); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	require.NoError(t, fx.engine.SyncSingleSession(sessionID), "SyncSingleSession")
 	got := em.got()
-	if len(got) != 1 {
-		t.Fatalf("expected 1 emission, got %d: %v", len(got), got)
-	}
-	if got[0] != "messages" {
-		t.Errorf("SyncSingleSession scope: got %q, want %q", got[0], "messages")
-	}
+	require.Len(t, got, 1, "expected 1 emission, got %v", got)
+	assert.Equal(t, "messages", got[0], "SyncSingleSession scope")
 }
 
 func TestToDBSessionTerminationStatus(t *testing.T) {
@@ -1760,13 +1557,11 @@ func TestToDBSessionTerminationStatus(t *testing.T) {
 			}
 			got := toDBSession(pw)
 
-			if (got.TerminationStatus == nil) != (tc.want == nil) {
-				t.Fatalf("nil mismatch: got=%v want=%v",
-					got.TerminationStatus, tc.want)
-			}
-			if got.TerminationStatus != nil && *got.TerminationStatus != *tc.want {
-				t.Fatalf("value mismatch: got=%q want=%q",
-					*got.TerminationStatus, *tc.want)
+			if tc.want == nil {
+				assert.Nil(t, got.TerminationStatus)
+			} else {
+				require.NotNil(t, got.TerminationStatus)
+				assert.Equal(t, *tc.want, *got.TerminationStatus)
 			}
 		})
 	}

--- a/internal/sync/forge_integration_test.go
+++ b/internal/sync/forge_integration_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/sync"
 )
 
@@ -20,9 +22,7 @@ func createForgeDB(t *testing.T, dir string) *forgeTestDB {
 	t.Helper()
 	path := filepath.Join(dir, ".forge.db")
 	d, err := sql.Open("sqlite3", path)
-	if err != nil {
-		t.Fatalf("opening forge test db: %v", err)
-	}
+	require.NoError(t, err, "opening forge test db")
 	t.Cleanup(func() { d.Close() })
 
 	schema := `
@@ -36,17 +36,15 @@ func createForgeDB(t *testing.T, dir string) *forgeTestDB {
 			metrics TEXT
 		);
 	`
-	if _, err := d.Exec(schema); err != nil {
-		t.Fatalf("creating forge schema: %v", err)
-	}
+	_, err = d.Exec(schema)
+	require.NoError(t, err, "creating forge schema")
 	return &forgeTestDB{path: path, db: d}
 }
 
 func (f *forgeTestDB) mustExec(t *testing.T, msg, query string, args ...any) {
 	t.Helper()
-	if _, err := f.db.Exec(query, args...); err != nil {
-		t.Fatalf("%s: %v", msg, err)
-	}
+	_, err := f.db.Exec(query, args...)
+	require.NoError(t, err, msg)
 }
 
 func (f *forgeTestDB) addConversation(
@@ -198,30 +196,20 @@ func TestSyncSingleSessionForge(t *testing.T) {
 		`{"input_tokens":360,"output_tokens":55,"cached_input_tokens":85}`,
 	)
 
-	if err := env.engine.SyncSingleSession("forge:forge-sync-single"); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	require.NoError(t, env.engine.SyncSingleSession("forge:forge-sync-single"), "SyncSingleSession")
 	assertSessionProject(t, env.db, "forge:forge-sync-single", "agentsview")
 	assertSessionMessageCount(t, env.db, "forge:forge-sync-single", 3)
 
 	src := env.engine.FindSourceFile("forge:forge-sync-single")
 	wantSrc := filepath.Join(env.forgeDir, ".forge.db")
-	if src != wantSrc {
-		t.Fatalf("FindSourceFile() = %q, want %q", src, wantSrc)
-	}
+	assert.Equal(t, wantSrc, src)
 
 	mtime := env.engine.SourceMtime("forge:forge-sync-single")
-	if mtime == 0 {
-		t.Fatal("SourceMtime returned zero")
-	}
+	require.NotZero(t, mtime, "SourceMtime returned zero")
 
 	_, storedMtime, ok := env.db.GetSessionFileInfo("forge:forge-sync-single")
-	if !ok {
-		t.Fatal("session file info not found")
-	}
-	if storedMtime != mtime {
-		t.Fatalf("stored mtime = %d, want %d", storedMtime, mtime)
-	}
+	require.True(t, ok, "session file info not found")
+	assert.Equal(t, mtime, storedMtime)
 
 	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 0, Synced: 0, Skipped: 0})
 }
@@ -257,9 +245,7 @@ func TestSyncForgeMultiConversationIncremental(t *testing.T) {
 
 	// Capture the stored mtime for A (should remain unchanged after the partial sync).
 	_, storedMtimeA, okA := env.db.GetSessionFileInfo("forge:multi-conv-A")
-	if !okA {
-		t.Fatal("session A file info not found after initial sync")
-	}
+	require.True(t, okA, "session A file info not found after initial sync")
 
 	// Update only B's updated_at (and its context) to simulate a newer version.
 	updatedContextB := forgeTestContext("First prompt B updated.", "Answer B updated.")
@@ -273,21 +259,13 @@ func TestSyncForgeMultiConversationIncremental(t *testing.T) {
 
 	// A's stored mtime must be unchanged.
 	_, storedMtimeA2, okA2 := env.db.GetSessionFileInfo("forge:multi-conv-A")
-	if !okA2 {
-		t.Fatal("session A file info not found after partial sync")
-	}
-	if storedMtimeA != storedMtimeA2 {
-		t.Errorf("A's stored mtime changed: was %d, now %d", storedMtimeA, storedMtimeA2)
-	}
+	require.True(t, okA2, "session A file info not found after partial sync")
+	assert.Equal(t, storedMtimeA, storedMtimeA2, "A's stored mtime changed")
 
 	// B's stored mtime must have advanced.
 	_, storedMtimeB2, okB2 := env.db.GetSessionFileInfo("forge:multi-conv-B")
-	if !okB2 {
-		t.Fatal("session B file info not found after partial sync")
-	}
-	if storedMtimeB2 <= storedMtimeA {
-		t.Errorf("B's stored mtime did not advance: got %d, A had %d", storedMtimeB2, storedMtimeA)
-	}
+	require.True(t, okB2, "session B file info not found after partial sync")
+	assert.Greater(t, storedMtimeB2, storedMtimeA, "B's stored mtime did not advance")
 }
 
 // ---------------------------------------------------------------------------
@@ -306,9 +284,7 @@ func TestSyncForgeMissingConversation(t *testing.T) {
 		`{"input_tokens":50,"output_tokens":10}`,
 	)
 
-	if err := env.engine.SyncSingleSession("forge:disappearing-conv"); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	require.NoError(t, env.engine.SyncSingleSession("forge:disappearing-conv"), "SyncSingleSession")
 
 	// Now delete the conversation from .forge.db.
 	forge.mustExec(t, "delete conversation",
@@ -318,25 +294,18 @@ func TestSyncForgeMissingConversation(t *testing.T) {
 	// FindSourceFile still returns the db path (it's a directory-level lookup).
 	// SourceMtime returns 0 because the conversation row is gone.
 	mtime := env.engine.SourceMtime("forge:disappearing-conv")
-	if mtime != 0 {
-		t.Errorf("SourceMtime after delete = %d, want 0", mtime)
-	}
+	assert.Zero(t, mtime, "SourceMtime after delete")
 
 	src := env.engine.FindSourceFile("forge:disappearing-conv")
-	if src != "" {
-		t.Errorf("FindSourceFile after delete = %q, want empty", src)
-	}
+	assert.Empty(t, src, "FindSourceFile after delete")
 
 	// SyncSingleSession must return an error indicating the conversation
 	// could not be found (either "not found" or a db no-rows error).
 	err := env.engine.SyncSingleSession("forge:disappearing-conv")
-	if err == nil {
-		t.Fatal("expected error from SyncSingleSession for deleted conversation, got nil")
-	}
+	require.Error(t, err, "expected error from SyncSingleSession for deleted conversation")
 	msg := strings.ToLower(err.Error())
-	if !strings.Contains(msg, "not found") && !strings.Contains(msg, "no rows") {
-		t.Errorf("expected 'not found' or 'no rows' error, got: %v", err)
-	}
+	assert.True(t, strings.Contains(msg, "not found") || strings.Contains(msg, "no rows"),
+		"expected 'not found' or 'no rows' error, got: %v", err)
 }
 
 func TestSyncForgeSyncSingleNonExistent(t *testing.T) {
@@ -345,13 +314,10 @@ func TestSyncForgeSyncSingleNonExistent(t *testing.T) {
 	createForgeDB(t, env.forgeDir)
 
 	err := env.engine.SyncSingleSession("forge:does-not-exist")
-	if err == nil {
-		t.Fatal("expected error for non-existent session, got nil")
-	}
+	require.Error(t, err, "expected error for non-existent session")
 	msg := strings.ToLower(err.Error())
-	if !strings.Contains(msg, "not found") && !strings.Contains(msg, "no rows") {
-		t.Errorf("expected 'not found' or 'no rows' error, got: %v", err)
-	}
+	assert.True(t, strings.Contains(msg, "not found") || strings.Contains(msg, "no rows"),
+		"expected 'not found' or 'no rows' error, got: %v", err)
 }
 
 // ---------------------------------------------------------------------------
@@ -421,12 +387,9 @@ func TestSyncForgeSubagentLinking(t *testing.T) {
 		`SELECT subagent_session_id FROM tool_calls WHERE session_id = ? AND tool_name = 'task'`,
 		"forge:"+parentID,
 	).Scan(&subagentSessID)
-	if err != nil {
-		t.Fatalf("query tool_calls for parent: %v", err)
-	}
-	if !subagentSessID.Valid || subagentSessID.String != "forge:"+childID {
-		t.Errorf("tool_calls.subagent_session_id = %v, want forge:%s", subagentSessID, childID)
-	}
+	require.NoError(t, err, "query tool_calls for parent")
+	require.True(t, subagentSessID.Valid, "tool_calls.subagent_session_id not valid")
+	assert.Equal(t, "forge:"+childID, subagentSessID.String)
 
 	// SyncAll must now call LinkSubagentSessions after the Forge write,
 	// so parent_session_id and relationship_type on the child must already
@@ -437,15 +400,11 @@ func TestSyncForgeSubagentLinking(t *testing.T) {
 		`SELECT parent_session_id, relationship_type FROM sessions WHERE id = ?`,
 		"forge:"+childID,
 	).Scan(&parentSessID, &relType)
-	if err != nil {
-		t.Fatalf("query child session: %v", err)
-	}
-	if !parentSessID.Valid || parentSessID.String != "forge:"+parentID {
-		t.Errorf("child parent_session_id = %v, want forge:%s", parentSessID, parentID)
-	}
-	if !relType.Valid || relType.String != "subagent" {
-		t.Errorf("child relationship_type = %v, want subagent", relType)
-	}
+	require.NoError(t, err, "query child session")
+	require.True(t, parentSessID.Valid, "child parent_session_id not valid")
+	assert.Equal(t, "forge:"+parentID, parentSessID.String)
+	require.True(t, relType.Valid, "child relationship_type not valid")
+	assert.Equal(t, "subagent", relType.String)
 }
 
 // ---------------------------------------------------------------------------
@@ -484,10 +443,6 @@ func TestSyncForgeFailureIsolation(t *testing.T) {
 	err := env.db.Reader().QueryRow(
 		"SELECT COUNT(*) FROM sessions WHERE id = 'forge:broken-conv'",
 	).Scan(&count)
-	if err != nil {
-		t.Fatalf("query broken session: %v", err)
-	}
-	if count != 0 {
-		t.Errorf("broken session present in DB (count=%d), expected 0", count)
-	}
+	require.NoError(t, err, "query broken session")
+	assert.Zero(t, count, "broken session present in DB")
 }

--- a/internal/sync/hash_test.go
+++ b/internal/sync/hash_test.go
@@ -6,15 +6,16 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createTempFile(t *testing.T, content []byte) string {
 	t.Helper()
 	cleanName := strings.ReplaceAll(t.Name(), "/", "_")
 	path := filepath.Join(t.TempDir(), cleanName+".txt")
-	if err := os.WriteFile(path, content, 0o644); err != nil {
-		t.Fatalf("create temp file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, content, 0o644))
 	return path
 }
 
@@ -39,12 +40,8 @@ func TestComputeHash(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ComputeHash(strings.NewReader(tt.input))
-			if err != nil {
-				t.Fatalf("ComputeHash: %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("ComputeHash() = %q, want %q", got, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -84,16 +81,13 @@ func TestComputeFileHash(t *testing.T) {
 			path := tt.setup(t)
 
 			got, err := ComputeFileHash(path)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ComputeFileHash() error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				require.Error(t, err)
 				requirePathError(t, err)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("ComputeFileHash() = %q, want %q", got, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -102,21 +96,15 @@ func TestComputeHash_ReaderError(t *testing.T) {
 	errInjected := errors.New("injected error")
 	reader := &failingReader{err: errInjected}
 	_, err := ComputeHash(reader)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, errInjected) {
-		t.Errorf("expected error wrapping 'injected error', got %v", err)
-	}
+	require.Error(t, err)
+	require.ErrorIs(t, err, errInjected)
 }
 
 func TestComputeFileHash_ReadError(t *testing.T) {
 	// Use a directory to simulate a read error after open
 	dir := t.TempDir()
 	_, err := ComputeFileHash(dir)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
+	require.Error(t, err)
 	// On most systems, reading a directory fails.
 	requirePathError(t, err)
 }

--- a/internal/sync/iflow_discovery_test.go
+++ b/internal/sync/iflow_discovery_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -16,49 +18,33 @@ func TestDiscoverIflowProjects(t *testing.T) {
 	proj1 := filepath.Join(tmpDir, "project1")
 	proj2 := filepath.Join(tmpDir, "project2")
 
-	if err := os.MkdirAll(proj1, 0o755); err != nil {
-		t.Fatalf("failed to create project1 directory: %v", err)
-	}
-	if err := os.MkdirAll(proj2, 0o755); err != nil {
-		t.Fatalf("failed to create project2 directory: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(proj1, 0o755))
+	require.NoError(t, os.MkdirAll(proj2, 0o755))
 
 	// Create session files in project1
 	session1 := filepath.Join(proj1, "session-abc123.jsonl")
 	session2 := filepath.Join(proj1, "session-def456.jsonl")
 
-	if err := os.WriteFile(session1, []byte(`{"test":"data"}`), 0o644); err != nil {
-		t.Fatalf("failed to create session1: %v", err)
-	}
-	if err := os.WriteFile(session2, []byte(`{"test":"data"}`), 0o644); err != nil {
-		t.Fatalf("failed to create session2: %v", err)
-	}
+	require.NoError(t, os.WriteFile(session1, []byte(`{"test":"data"}`), 0o644))
+	require.NoError(t, os.WriteFile(session2, []byte(`{"test":"data"}`), 0o644))
 
 	// Create a session file in project2
 	session3 := filepath.Join(proj2, "session-ghi789.jsonl")
-	if err := os.WriteFile(session3, []byte(`{"test":"data"}`), 0o644); err != nil {
-		t.Fatalf("failed to create session3: %v", err)
-	}
+	require.NoError(t, os.WriteFile(session3, []byte(`{"test":"data"}`), 0o644))
 
 	// Create a non-session file (should be ignored)
 	otherFile := filepath.Join(proj1, "other.txt")
-	if err := os.WriteFile(otherFile, []byte(`not a session`), 0o644); err != nil {
-		t.Fatalf("failed to create other file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(otherFile, []byte(`not a session`), 0o644))
 
 	// Create a directory (should be ignored)
 	subDir := filepath.Join(proj1, "subdir")
-	if err := os.MkdirAll(subDir, 0o755); err != nil {
-		t.Fatalf("failed to create subdir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
 
 	// Run discovery
 	files := parser.DiscoverIflowProjects(tmpDir)
 
 	// Verify results
-	if len(files) != 3 {
-		t.Errorf("expected 3 files, got %d", len(files))
-	}
+	assert.Len(t, files, 3)
 
 	// Verify file paths
 	paths := make(map[string]bool)
@@ -66,18 +52,10 @@ func TestDiscoverIflowProjects(t *testing.T) {
 		paths[f.Path] = true
 	}
 
-	if !paths[session1] {
-		t.Errorf("session1 not found in results")
-	}
-	if !paths[session2] {
-		t.Errorf("session2 not found in results")
-	}
-	if !paths[session3] {
-		t.Errorf("session3 not found in results")
-	}
-	if paths[otherFile] {
-		t.Errorf("other.txt should not be in results")
-	}
+	assert.True(t, paths[session1], "session1 not found in results")
+	assert.True(t, paths[session2], "session2 not found in results")
+	assert.True(t, paths[session3], "session3 not found in results")
+	assert.False(t, paths[otherFile], "other.txt should not be in results")
 
 	// Verify project names
 	projects := make(map[string]bool)
@@ -85,18 +63,12 @@ func TestDiscoverIflowProjects(t *testing.T) {
 		projects[f.Project] = true
 	}
 
-	if !projects["project1"] {
-		t.Errorf("project1 not found in projects")
-	}
-	if !projects["project2"] {
-		t.Errorf("project2 not found in projects")
-	}
+	assert.True(t, projects["project1"], "project1 not found in projects")
+	assert.True(t, projects["project2"], "project2 not found in projects")
 
 	// Verify agent type
 	for _, f := range files {
-		if f.Agent != "iflow" {
-			t.Errorf("expected agent 'iflow', got '%s'", f.Agent)
-		}
+		assert.Equal(t, parser.AgentType("iflow"), f.Agent)
 	}
 }
 
@@ -105,28 +77,20 @@ func TestFindIflowSourceFile(t *testing.T) {
 
 	// Create a project directory
 	proj := filepath.Join(tmpDir, "test-project")
-	if err := os.MkdirAll(proj, 0o755); err != nil {
-		t.Fatalf("failed to create project directory: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(proj, 0o755))
 
 	// Create a session file
 	sessionID := "abc123-def456"
 	sessionFile := filepath.Join(proj, "session-"+sessionID+".jsonl")
-	if err := os.WriteFile(sessionFile, []byte(`{"test":"data"}`), 0o644); err != nil {
-		t.Fatalf("failed to create session file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(sessionFile, []byte(`{"test":"data"}`), 0o644))
 
 	// Test finding the file
 	found := parser.FindIflowSourceFile(tmpDir, sessionID)
-	if found != sessionFile {
-		t.Errorf("expected to find %s, got %s", sessionFile, found)
-	}
+	assert.Equal(t, sessionFile, found)
 
 	// Test finding a non-existent file
 	notFound := parser.FindIflowSourceFile(tmpDir, "nonexistent")
-	if notFound != "" {
-		t.Errorf("expected empty string for non-existent file, got %s", notFound)
-	}
+	assert.Empty(t, notFound)
 
 	// Test finding a fork ID (should extract base session ID)
 	// Fork IDs have format: <baseUUID>-<childUUID>
@@ -134,13 +98,9 @@ func TestFindIflowSourceFile(t *testing.T) {
 	baseSessionID := "96e6d875-92eb-40b9-b193-a9ba99f0f709"
 	forkSessionID := baseSessionID + "-12345678-1234-5678-9abc-def012345678"
 	forkSessionFile := filepath.Join(proj, "session-"+baseSessionID+".jsonl")
-	if err := os.WriteFile(forkSessionFile, []byte(`{"test":"fork"}`), 0o644); err != nil {
-		t.Fatalf("failed to create fork session file: %v", err)
-	}
+	require.NoError(t, os.WriteFile(forkSessionFile, []byte(`{"test":"fork"}`), 0o644))
 
 	// Test finding the fork session - should find the base file
 	foundFork := parser.FindIflowSourceFile(tmpDir, forkSessionID)
-	if foundFork != forkSessionFile {
-		t.Errorf("expected to find %s for fork ID %s, got %s", forkSessionFile, forkSessionID, foundFork)
-	}
+	assert.Equal(t, forkSessionFile, foundFork, "for fork ID %s", forkSessionID)
 }

--- a/internal/sync/piebald_integration_test.go
+++ b/internal/sync/piebald_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/sync"
 )
 
@@ -18,9 +20,7 @@ func createPiebaldDB(t *testing.T, dir string) *piebaldTestDB {
 	t.Helper()
 	path := filepath.Join(dir, "app.db")
 	d, err := sql.Open("sqlite3", path)
-	if err != nil {
-		t.Fatalf("opening piebald test db: %v", err)
-	}
+	require.NoError(t, err, "opening piebald test db")
 	t.Cleanup(func() { d.Close() })
 
 	schema := `
@@ -90,17 +90,15 @@ func createPiebaldDB(t *testing.T, dir string) *piebaldTestDB {
 			sub_agent_chat_id INTEGER
 		);
 	`
-	if _, err := d.Exec(schema); err != nil {
-		t.Fatalf("creating piebald schema: %v", err)
-	}
+	_, err = d.Exec(schema)
+	require.NoError(t, err, "creating piebald schema")
 	return &piebaldTestDB{path: path, db: d}
 }
 
 func (p *piebaldTestDB) mustExec(t *testing.T, msg, query string, args ...any) {
 	t.Helper()
-	if _, err := p.db.Exec(query, args...); err != nil {
-		t.Fatalf("%s: %v", msg, err)
-	}
+	_, err := p.db.Exec(query, args...)
+	require.NoError(t, err, msg)
 }
 
 func (p *piebaldTestDB) addChat(t *testing.T, id int64, title, prompt, answer, updatedAt string) {
@@ -192,21 +190,16 @@ func TestSyncSingleSessionPiebaldFork(t *testing.T) {
 	piebald := createPiebaldDB(t, env.piebaldDir)
 	piebald.addChatWithFork(t, 42)
 
-	if err := env.engine.SyncSingleSession("piebald:42-200"); err != nil {
-		t.Fatalf("SyncSingleSession(fork): %v", err)
-	}
+	require.NoError(t, env.engine.SyncSingleSession("piebald:42-200"), "SyncSingleSession(fork)")
 	assertSessionMessageCount(t, env.db, "piebald:42-200", 2)
 	assertSessionMessageCount(t, env.db, "piebald:42", 4)
 
 	src := env.engine.FindSourceFile("piebald:42-200")
 	wantSrc := filepath.Join(env.piebaldDir, "app.db")
-	if src != wantSrc {
-		t.Fatalf("FindSourceFile(fork) = %q, want %q", src, wantSrc)
-	}
+	assert.Equal(t, wantSrc, src)
 
-	if mtime := env.engine.SourceMtime("piebald:42-200"); mtime == 0 {
-		t.Fatal("SourceMtime(fork) returned zero")
-	}
+	mtime := env.engine.SourceMtime("piebald:42-200")
+	assert.NotZero(t, mtime, "SourceMtime(fork) returned zero")
 }
 
 func TestSyncSingleSessionPiebaldUnknownFork(t *testing.T) {
@@ -214,15 +207,12 @@ func TestSyncSingleSessionPiebaldUnknownFork(t *testing.T) {
 	piebald := createPiebaldDB(t, env.piebaldDir)
 	piebald.addChatWithFork(t, 42)
 
-	if err := env.engine.SyncSingleSession("piebald:42-999"); err == nil {
-		t.Fatal("SyncSingleSession(piebald:42-999) returned nil; want not-found error")
-	}
-	if src := env.engine.FindSourceFile("piebald:42-999"); src != "" {
-		t.Fatalf("FindSourceFile(piebald:42-999) = %q, want empty", src)
-	}
-	if mtime := env.engine.SourceMtime("piebald:42-999"); mtime != 0 {
-		t.Fatalf("SourceMtime(piebald:42-999) = %d, want 0", mtime)
-	}
+	err := env.engine.SyncSingleSession("piebald:42-999")
+	require.Error(t, err, "SyncSingleSession(piebald:42-999) returned nil; want not-found error")
+	src := env.engine.FindSourceFile("piebald:42-999")
+	assert.Empty(t, src, "FindSourceFile(piebald:42-999)")
+	mtime := env.engine.SourceMtime("piebald:42-999")
+	assert.Zero(t, mtime, "SourceMtime(piebald:42-999)")
 }
 
 func TestSyncEnginePiebaldBulkSync(t *testing.T) {
@@ -245,30 +235,20 @@ func TestSyncSingleSessionPiebald(t *testing.T) {
 	piebald := createPiebaldDB(t, env.piebaldDir)
 	piebald.addChat(t, 7, "Single Piebald", "One chat.", "One answer.", "2026-05-01T10:05:00Z")
 
-	if err := env.engine.SyncSingleSession("piebald:7"); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	require.NoError(t, env.engine.SyncSingleSession("piebald:7"), "SyncSingleSession")
 	assertSessionProject(t, env.db, "piebald:7", "app")
 	assertSessionMessageCount(t, env.db, "piebald:7", 2)
 
 	src := env.engine.FindSourceFile("piebald:7")
 	wantSrc := filepath.Join(env.piebaldDir, "app.db")
-	if src != wantSrc {
-		t.Fatalf("FindSourceFile() = %q, want %q", src, wantSrc)
-	}
+	assert.Equal(t, wantSrc, src)
 
 	mtime := env.engine.SourceMtime("piebald:7")
-	if mtime == 0 {
-		t.Fatal("SourceMtime returned zero")
-	}
+	require.NotZero(t, mtime, "SourceMtime returned zero")
 
 	_, storedMtime, ok := env.db.GetSessionFileInfo("piebald:7")
-	if !ok {
-		t.Fatal("session file info not found")
-	}
-	if storedMtime != mtime {
-		t.Fatalf("stored mtime = %d, want %d", storedMtime, mtime)
-	}
+	require.True(t, ok, "session file info not found")
+	assert.Equal(t, mtime, storedMtime)
 }
 
 func TestSyncPiebaldMultiChatIncremental(t *testing.T) {
@@ -279,9 +259,7 @@ func TestSyncPiebaldMultiChatIncremental(t *testing.T) {
 
 	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 2, Synced: 2, Skipped: 0})
 	_, storedMtimeA, okA := env.db.GetSessionFileInfo("piebald:1")
-	if !okA {
-		t.Fatal("session A file info not found after initial sync")
-	}
+	require.True(t, okA, "session A file info not found after initial sync")
 
 	piebald.mustExec(t, "update B updated_at",
 		`UPDATE chats SET updated_at = '2026-05-01T10:03:00Z' WHERE id = 2`,
@@ -289,10 +267,6 @@ func TestSyncPiebaldMultiChatIncremental(t *testing.T) {
 
 	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1, Synced: 1, Skipped: 0})
 	_, storedMtimeA2, okA2 := env.db.GetSessionFileInfo("piebald:1")
-	if !okA2 {
-		t.Fatal("session A file info not found after partial sync")
-	}
-	if storedMtimeA != storedMtimeA2 {
-		t.Errorf("A's stored mtime changed: was %d, now %d", storedMtimeA, storedMtimeA2)
-	}
+	require.True(t, okA2, "session A file info not found after partial sync")
+	assert.Equal(t, storedMtimeA, storedMtimeA2, "A's stored mtime changed")
 }

--- a/internal/sync/secret_persist_test.go
+++ b/internal/sync/secret_persist_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
@@ -42,38 +44,22 @@ func TestSyncPersistsSecretFindings(t *testing.T) {
 
 	filename := "secret-session.jsonl"
 	path := filepath.Join(fx.claudeDir, "proj", filename)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 
 	stats := fx.engine.SyncAll(context.Background(), nil)
-	if stats.Synced == 0 {
-		t.Fatalf("expected Synced > 0, got %+v", stats)
-	}
+	require.NotZero(t, stats.Synced, "expected Synced > 0, got %+v", stats)
 
 	sessionID := fx.sessionIDFor(t, path)
 
 	sess, err := fx.db.GetSession(context.Background(), sessionID)
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatalf("session %q not found after SyncAll", sessionID)
-	}
-	if sess.SecretLeakCount < 1 {
-		t.Errorf("SecretLeakCount = %d, want >= 1", sess.SecretLeakCount)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, sess, "session %q not found after SyncAll", sessionID)
+	assert.GreaterOrEqual(t, sess.SecretLeakCount, 1, "SecretLeakCount = %d, want >= 1", sess.SecretLeakCount)
 
 	findings, err := fx.db.SessionSecretFindings(context.Background(), sessionID)
-	if err != nil {
-		t.Fatalf("SessionSecretFindings: %v", err)
-	}
-	if len(findings) == 0 {
-		t.Fatal("expected non-empty findings slice, got 0")
-	}
+	require.NoError(t, err)
+	require.NotEmpty(t, findings, "expected non-empty findings slice, got 0")
 
 	var sawAWS, sawToolOutput bool
 	for _, f := range findings {
@@ -85,14 +71,10 @@ func TestSyncPersistsSecretFindings(t *testing.T) {
 			sawToolOutput = true
 		}
 	}
-	if !sawAWS {
-		t.Errorf("no aws-access-key finding in %+v", findings)
-	}
+	assert.True(t, sawAWS, "no aws-access-key finding in %+v", findings)
 	// Pin the real use case: the secret captured in tool output must be
 	// detected, not only the copy in the user message.
-	if !sawToolOutput {
-		t.Errorf("no aws-access-key finding in tool output: %+v", findings)
-	}
+	assert.True(t, sawToolOutput, "no aws-access-key finding in tool output: %+v", findings)
 }
 
 // TestSyncNoSecretsLeavesZero verifies a clean session persists no findings
@@ -106,31 +88,16 @@ func TestSyncNoSecretsLeavesZero(t *testing.T) {
 		AddClaudeUser("2024-01-01T00:00:02Z", "thanks, that works").
 		String()
 	path := filepath.Join(fx.claudeDir, "proj", "clean-session.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	if stats := fx.engine.SyncAll(context.Background(), nil); stats.Synced == 0 {
-		t.Fatalf("expected Synced > 0, got %+v", stats)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	stats := fx.engine.SyncAll(context.Background(), nil)
+	require.NotZero(t, stats.Synced, "expected Synced > 0, got %+v", stats)
 	sessionID := fx.sessionIDFor(t, path)
 	sess, err := fx.db.GetSession(context.Background(), sessionID)
-	if err != nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if sess == nil {
-		t.Fatalf("session %q not found after SyncAll", sessionID)
-	}
-	if sess.SecretLeakCount != 0 {
-		t.Errorf("SecretLeakCount = %d, want 0", sess.SecretLeakCount)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, sess, "session %q not found after SyncAll", sessionID)
+	assert.Equal(t, 0, sess.SecretLeakCount)
 	findings, err := fx.db.SessionSecretFindings(context.Background(), sessionID)
-	if err != nil {
-		t.Fatalf("SessionSecretFindings: %v", err)
-	}
-	if len(findings) != 0 {
-		t.Errorf("expected 0 findings, got %d: %+v", len(findings), findings)
-	}
+	require.NoError(t, err)
+	assert.Empty(t, findings, "expected 0 findings, got %d: %+v", len(findings), findings)
 }

--- a/internal/sync/secret_scan_test.go
+++ b/internal/sync/secret_scan_test.go
@@ -2,9 +2,10 @@ package sync
 
 import (
 	"context"
-	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/secrets"
 )
@@ -22,9 +23,7 @@ func TestScanSecretsFromMessages(t *testing.T) {
 			}}},
 	}
 	findings, leak := scanSecretsFromMessages(sess, msgs, secrets.Scan)
-	if leak < 1 {
-		t.Fatalf("expected >=1 definite finding, got leak=%d", leak)
-	}
+	require.GreaterOrEqual(t, leak, 1, "expected >=1 definite finding, got leak=%d", leak)
 	var sawMsg, sawTool bool
 	for _, f := range findings {
 		if f.LocationKind == "message" && f.MessageOrdinal == 0 {
@@ -32,14 +31,10 @@ func TestScanSecretsFromMessages(t *testing.T) {
 		}
 		if f.LocationKind == "tool_result" && f.MessageOrdinal == 1 {
 			sawTool = true
-			if f.RedactedMatch == "" {
-				t.Error("tool finding has empty RedactedMatch")
-			}
+			assert.NotEmpty(t, f.RedactedMatch, "tool finding has empty RedactedMatch")
 		}
 	}
-	if !sawMsg || !sawTool {
-		t.Errorf("missing findings: msg=%v tool=%v (%+v)", sawMsg, sawTool, findings)
-	}
+	assert.True(t, sawMsg && sawTool, "missing findings: msg=%v tool=%v (%+v)", sawMsg, sawTool, findings)
 }
 
 func TestScanSecretsDedupEventsVsResult(t *testing.T) {
@@ -63,9 +58,7 @@ func TestScanSecretsDedupEventsVsResult(t *testing.T) {
 			n++
 		}
 	}
-	if n != 1 {
-		t.Fatalf("expected 1 aws finding (event canonical), got %d", n)
-	}
+	require.Equal(t, 1, n, "expected 1 aws finding (event canonical), got %d", n)
 }
 
 // TestScanSecretsResultEventIndexIsSlicePosition pins the contract that makes
@@ -95,15 +88,10 @@ func TestScanSecretsResultEventIndexIsSlicePosition(t *testing.T) {
 			break
 		}
 	}
-	if got == nil {
-		t.Fatalf("no aws-access-key finding: %+v", findings)
-	}
-	if got.LocationKind != "tool_result_event" {
-		t.Errorf("LocationKind = %q, want tool_result_event", got.LocationKind)
-	}
-	if got.EventIndex == nil || *got.EventIndex != 1 {
-		t.Errorf("EventIndex = %v, want slice position 1", got.EventIndex)
-	}
+	require.NotNil(t, got, "no aws-access-key finding: %+v", findings)
+	assert.Equal(t, "tool_result_event", got.LocationKind)
+	require.NotNil(t, got.EventIndex, "EventIndex = nil, want slice position 1")
+	assert.Equal(t, 1, *got.EventIndex, "EventIndex = %v, want slice position 1", *got.EventIndex)
 }
 
 // TestComputeSignalsAndSecretsDefiniteOnly pins the inline-sync contract: the
@@ -117,21 +105,12 @@ func TestComputeSignalsAndSecretsDefiniteOnly(t *testing.T) {
 		Content: "aws AKIA7QHWN2DKR4FYPLJM and SECRET=Xa9Kd03Lm5Qp7Rt2Vw8Zb4Nc6",
 	}}
 	update, findings := computeSignalsAndSecrets(sess, msgs)
-	if len(findings) == 0 {
-		t.Fatal("expected at least one definite finding")
-	}
+	require.NotEmpty(t, findings, "expected at least one definite finding")
 	for _, f := range findings {
-		if f.Confidence != secrets.ConfidenceDefinite {
-			t.Errorf("inline scan stored a non-definite finding: %+v", f)
-		}
+		assert.Equal(t, secrets.ConfidenceDefinite, f.Confidence, "inline scan stored a non-definite finding: %+v", f)
 	}
-	if update.SecretsRulesVersion != secrets.DefiniteRulesVersion() {
-		t.Errorf("SecretsRulesVersion = %q, want DefiniteRulesVersion %q",
-			update.SecretsRulesVersion, secrets.DefiniteRulesVersion())
-	}
-	if update.SecretLeakCount != 1 {
-		t.Errorf("SecretLeakCount = %d, want 1 (one definite)", update.SecretLeakCount)
-	}
+	assert.Equal(t, secrets.DefiniteRulesVersion(), update.SecretsRulesVersion)
+	assert.Equal(t, 1, update.SecretLeakCount, "SecretLeakCount = %d, want 1 (one definite)", update.SecretLeakCount)
 }
 
 // TestInlineScanThenBackfillStoresCandidates verifies the full split-version
@@ -144,60 +123,34 @@ func TestInlineScanThenBackfillStoresCandidates(t *testing.T) {
 	fx := newEngineFixture(t)
 	ctx := context.Background()
 	const id = "s1"
-	if err := fx.db.UpsertSession(db.Session{
+	require.NoError(t, fx.db.UpsertSession(db.Session{
 		ID: id, Project: "proj", Machine: "m", Agent: "claude",
 		MessageCount: 1, UserMessageCount: 1,
-	}); err != nil {
-		t.Fatalf("UpsertSession: %v", err)
-	}
-	if err := fx.db.ReplaceSessionMessages(id, []db.Message{
+	}))
+	require.NoError(t, fx.db.ReplaceSessionMessages(id, []db.Message{
 		{SessionID: id, Ordinal: 0, Role: "user",
 			Content: "aws AKIA7QHWN2DKR4FYPLJM and SECRET=Xa9Kd03Lm5Qp7Rt2Vw8Zb4Nc6"},
-	}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	}))
 
 	// Inline sync path: definite-only findings, definite version.
-	if err := fx.engine.RecomputeSignals(ctx, id); err != nil {
-		t.Fatalf("RecomputeSignals: %v", err)
-	}
+	require.NoError(t, fx.engine.RecomputeSignals(ctx, id))
 	got, err := fx.db.SessionSecretFindings(ctx, id)
-	if err != nil {
-		t.Fatalf("SessionSecretFindings: %v", err)
-	}
-	if countConfidence(got, secrets.ConfidenceCandidate) != 0 {
-		t.Errorf("inline scan stored candidate findings: %+v", got)
-	}
-	if countConfidence(got, secrets.ConfidenceDefinite) == 0 {
-		t.Error("inline scan stored no definite findings")
-	}
+	require.NoError(t, err)
+	assert.Zero(t, countConfidence(got, secrets.ConfidenceCandidate), "inline scan stored candidate findings: %+v", got)
+	assert.NotZero(t, countConfidence(got, secrets.ConfidenceDefinite), "inline scan stored no definite findings")
 
 	// Backfill must treat the inline-only session as stale and rescan it.
 	sum, err := fx.engine.ScanSecrets(ctx, SecretScanInput{Backfill: true}, nil)
-	if err != nil {
-		t.Fatalf("ScanSecrets backfill: %v", err)
-	}
-	if sum.Scanned != 1 {
-		t.Fatalf("backfill Scanned = %d, want 1 (inline-only session is stale)",
-			sum.Scanned)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 1, sum.Scanned, "backfill Scanned = %d, want 1 (inline-only session is stale)", sum.Scanned)
 	got, err = fx.db.SessionSecretFindings(ctx, id)
-	if err != nil {
-		t.Fatalf("SessionSecretFindings after backfill: %v", err)
-	}
-	if countConfidence(got, secrets.ConfidenceCandidate) == 0 {
-		t.Errorf("backfill did not store candidate findings: %+v", got)
-	}
+	require.NoError(t, err)
+	assert.NotZero(t, countConfidence(got, secrets.ConfidenceCandidate), "backfill did not store candidate findings: %+v", got)
 
 	// Now current at the full version: a second backfill scans nothing.
 	sum2, err := fx.engine.ScanSecrets(ctx, SecretScanInput{Backfill: true}, nil)
-	if err != nil {
-		t.Fatalf("ScanSecrets backfill rerun: %v", err)
-	}
-	if sum2.Scanned != 0 {
-		t.Errorf("second backfill Scanned = %d, want 0 (now at full version)",
-			sum2.Scanned)
-	}
+	require.NoError(t, err)
+	assert.Zero(t, sum2.Scanned, "second backfill Scanned = %d, want 0 (now at full version)", sum2.Scanned)
 }
 
 func countConfidence(findings []db.SecretFinding, confidence string) int {
@@ -216,48 +169,32 @@ func TestEngineScanSecretsBackfillResumable(t *testing.T) {
 	// Seed two sessions with secret-bearing content directly, bypassing the
 	// sync scan path, so secrets_rules_version stays "" (unscanned).
 	for _, id := range []string{"s1", "s2"} {
-		if err := fx.db.UpsertSession(db.Session{
+		require.NoError(t, fx.db.UpsertSession(db.Session{
 			ID: id, Project: "proj", Machine: "m", Agent: "claude",
 			MessageCount: 1, UserMessageCount: 1,
-		}); err != nil {
-			t.Fatalf("UpsertSession %s: %v", id, err)
-		}
-		if err := fx.db.ReplaceSessionMessages(id, []db.Message{
+		}))
+		require.NoError(t, fx.db.ReplaceSessionMessages(id, []db.Message{
 			{SessionID: id, Ordinal: 0, Role: "user",
 				Content: "my key AKIA7QHWN2DKR4FYPLJM here"},
-		}); err != nil {
-			t.Fatalf("ReplaceSessionMessages %s: %v", id, err)
-		}
+		}))
 	}
 	ticks := 0
 	sum, err := fx.engine.ScanSecrets(ctx, SecretScanInput{Backfill: true},
 		func(SecretScanProgress) { ticks++ })
-	if err != nil {
-		t.Fatalf("ScanSecrets: %v", err)
-	}
-	if sum.Scanned != 2 || sum.WithSecrets != 2 {
-		t.Fatalf("scan summary = %+v, want Scanned=2 WithSecrets=2", sum)
-	}
-	if ticks == 0 {
-		t.Error("expected at least one progress tick")
-	}
+	require.NoError(t, err)
+	require.Equal(t, 2, sum.Scanned, "scan summary = %+v, want Scanned=2", sum)
+	require.Equal(t, 2, sum.WithSecrets, "scan summary = %+v, want WithSecrets=2", sum)
+	assert.NotZero(t, ticks, "expected at least one progress tick")
 	for _, id := range []string{"s1", "s2"} {
 		s, err := fx.db.GetSession(ctx, id)
-		if err != nil || s == nil {
-			t.Fatalf("GetSession %s: %v", id, err)
-		}
-		if s.SecretLeakCount < 1 {
-			t.Errorf("%s SecretLeakCount = %d, want >=1", id, s.SecretLeakCount)
-		}
+		require.NoError(t, err)
+		require.NotNil(t, s)
+		assert.GreaterOrEqual(t, s.SecretLeakCount, 1, "%s SecretLeakCount = %d, want >=1", id, s.SecretLeakCount)
 	}
 	// Re-running the backfill scans nothing: all sessions are now current.
 	sum2, err := fx.engine.ScanSecrets(ctx, SecretScanInput{Backfill: true}, nil)
-	if err != nil {
-		t.Fatalf("ScanSecrets rerun: %v", err)
-	}
-	if sum2.Scanned != 0 {
-		t.Errorf("resumed Scanned = %d, want 0 (already current)", sum2.Scanned)
-	}
+	require.NoError(t, err)
+	assert.Zero(t, sum2.Scanned, "resumed Scanned = %d, want 0 (already current)", sum2.Scanned)
 }
 
 // TestScanSecretsCanceledContextReturnsError pins the cancellation contract: a
@@ -265,30 +202,20 @@ func TestEngineScanSecretsBackfillResumable(t *testing.T) {
 // partial scan as success, and must persist nothing.
 func TestScanSecretsCanceledContextReturnsError(t *testing.T) {
 	fx := newEngineFixture(t)
-	if err := fx.db.UpsertSession(db.Session{
+	require.NoError(t, fx.db.UpsertSession(db.Session{
 		ID: "s1", Project: "proj", Machine: "m", Agent: "claude",
 		MessageCount: 1, UserMessageCount: 1,
-	}); err != nil {
-		t.Fatalf("UpsertSession: %v", err)
-	}
-	if err := fx.db.ReplaceSessionMessages("s1", []db.Message{
+	}))
+	require.NoError(t, fx.db.ReplaceSessionMessages("s1", []db.Message{
 		{SessionID: "s1", Ordinal: 0, Role: "user",
 			Content: "my key AKIA7QHWN2DKR4FYPLJM here"},
-	}); err != nil {
-		t.Fatalf("ReplaceSessionMessages: %v", err)
-	}
+	}))
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := fx.engine.ScanSecrets(ctx, SecretScanInput{Backfill: true}, nil)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("ScanSecrets(canceled) err = %v, want context.Canceled", err)
-	}
+	require.ErrorIs(t, err, context.Canceled)
 	s, err := fx.db.GetSession(context.Background(), "s1")
-	if err != nil || s == nil {
-		t.Fatalf("GetSession: %v", err)
-	}
-	if s.SecretLeakCount != 0 {
-		t.Errorf("SecretLeakCount = %d, want 0 (canceled scan persisted nothing)",
-			s.SecretLeakCount)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Zero(t, s.SecretLeakCount, "SecretLeakCount = %d, want 0 (canceled scan persisted nothing)", s.SecretLeakCount)
 }

--- a/internal/sync/signal_compute_test.go
+++ b/internal/sync/signal_compute_test.go
@@ -1,9 +1,10 @@
 package sync
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/signals"
 )
@@ -78,9 +79,7 @@ func TestExtractToolCallRows(t *testing.T) {
 			CallIndex:      0,
 		},
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("extractToolCallRows mismatch\n got = %+v\nwant = %+v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestExtractContextTokens(t *testing.T) {
@@ -104,9 +103,7 @@ func TestExtractContextTokens(t *testing.T) {
 		{ContextTokens: 2000, HasContextTokens: true},
 		{ContextTokens: 0, HasContextTokens: false},
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("extractContextTokens mismatch\n got = %+v\nwant = %+v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestExtractCompactBoundaryOrdinals(t *testing.T) {
@@ -119,13 +116,9 @@ func TestExtractCompactBoundaryOrdinals(t *testing.T) {
 	}
 	got := extractCompactBoundaryOrdinals(msgs)
 	want := []int{2, 4}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("extractCompactBoundaryOrdinals = %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 
-	if extractCompactBoundaryOrdinals(nil) != nil {
-		t.Error("extractCompactBoundaryOrdinals(nil) should return nil")
-	}
+	assert.Nil(t, extractCompactBoundaryOrdinals(nil), "extractCompactBoundaryOrdinals(nil) should return nil")
 }
 
 func TestExtractMostCommonModel(t *testing.T) {
@@ -136,22 +129,16 @@ func TestExtractMostCommonModel(t *testing.T) {
 		{Role: "assistant", Model: "claude-opus-4-6"},
 		{Role: "assistant", Model: ""}, // ignored
 	}
-	if got := extractMostCommonModel(msgs); got != "claude-sonnet-4-5" {
-		t.Errorf("extractMostCommonModel = %q, want claude-sonnet-4-5", got)
-	}
+	assert.Equal(t, "claude-sonnet-4-5", extractMostCommonModel(msgs))
 
 	// Tie broken by chronological-first.
 	tied := []db.Message{
 		{Role: "assistant", Model: "claude-sonnet-4-5"},
 		{Role: "assistant", Model: "claude-opus-4-6"},
 	}
-	if got := extractMostCommonModel(tied); got != "claude-sonnet-4-5" {
-		t.Errorf("tied: extractMostCommonModel = %q, want claude-sonnet-4-5", got)
-	}
+	assert.Equal(t, "claude-sonnet-4-5", extractMostCommonModel(tied), "tied")
 
-	if got := extractMostCommonModel(nil); got != "" {
-		t.Errorf("empty: extractMostCommonModel = %q, want empty", got)
-	}
+	assert.Empty(t, extractMostCommonModel(nil), "empty")
 }
 
 func TestExtractLastMessageRole(t *testing.T) {
@@ -162,14 +149,12 @@ func TestExtractLastMessageRole(t *testing.T) {
 		{Ordinal: 3, Role: "user", Content: "system noise", IsSystem: true},
 	}
 	role, content := extractLastMessageRole(msgs)
-	if role != "user" || content != "thanks" {
-		t.Errorf("extractLastMessageRole = (%q, %q), want (user, thanks)", role, content)
-	}
+	assert.Equal(t, "user", role)
+	assert.Equal(t, "thanks", content)
 
 	role, content = extractLastMessageRole(nil)
-	if role != "" || content != "" {
-		t.Errorf("nil case: got (%q, %q), want empty", role, content)
-	}
+	assert.Empty(t, role, "nil case role")
+	assert.Empty(t, content, "nil case content")
 }
 
 func TestComputeSignalsFromMessages_Errors(t *testing.T) {
@@ -210,30 +195,15 @@ func TestComputeSignalsFromMessages_Errors(t *testing.T) {
 
 	got := computeSignalsFromMessages(sess, msgs)
 
-	if !got.HasToolCalls {
-		t.Error("HasToolCalls = false, want true")
-	}
-	if !got.HasContextData {
-		t.Error("HasContextData = false, want true")
-	}
-	if got.ToolFailureSignalCount == 0 {
-		t.Error("ToolFailureSignalCount = 0, want > 0")
-	}
-	if got.FinalFailureStreak == 0 {
-		t.Errorf("FinalFailureStreak = 0, want > 0")
-	}
-	if got.HealthScore == nil {
-		t.Fatal("HealthScore is nil; want a value")
-	}
-	if *got.HealthScore >= 100 {
-		t.Errorf("HealthScore = %d, want < 100", *got.HealthScore)
-	}
-	if got.HealthGrade == nil || *got.HealthGrade == "" {
-		t.Errorf("HealthGrade = %v, want non-empty", got.HealthGrade)
-	}
-	if got.EndedWithRole != "assistant" {
-		t.Errorf("EndedWithRole = %q, want assistant", got.EndedWithRole)
-	}
+	assert.True(t, got.HasToolCalls, "HasToolCalls = false, want true")
+	assert.True(t, got.HasContextData, "HasContextData = false, want true")
+	assert.NotZero(t, got.ToolFailureSignalCount, "ToolFailureSignalCount = 0, want > 0")
+	assert.NotZero(t, got.FinalFailureStreak, "FinalFailureStreak = 0, want > 0")
+	require.NotNil(t, got.HealthScore, "HealthScore is nil; want a value")
+	assert.Less(t, *got.HealthScore, 100, "HealthScore = %d, want < 100", *got.HealthScore)
+	require.NotNil(t, got.HealthGrade, "HealthGrade = nil, want non-empty")
+	assert.NotEmpty(t, *got.HealthGrade, "HealthGrade = %v, want non-empty", got.HealthGrade)
+	assert.Equal(t, "assistant", got.EndedWithRole)
 }
 
 func TestComputeSignalsFromMessages_ExplicitBoundariesOverrideHeuristic(t *testing.T) {
@@ -247,7 +217,5 @@ func TestComputeSignalsFromMessages_ExplicitBoundariesOverrideHeuristic(t *testi
 		{Ordinal: 4, Role: "user", IsCompactBoundary: true},
 	}
 	got := computeSignalsFromMessages(sess, msgs)
-	if got.CompactionCount != 2 {
-		t.Errorf("CompactionCount = %d, want 2", got.CompactionCount)
-	}
+	assert.Equal(t, 2, got.CompactionCount)
 }

--- a/internal/sync/test_helpers_test.go
+++ b/internal/sync/test_helpers_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/sync"
@@ -33,13 +35,8 @@ const (
 func assertSessionState(t *testing.T, database *db.DB, sessionID string, check func(*db.Session)) {
 	t.Helper()
 	sess, err := database.GetSession(context.Background(), sessionID)
-	if err != nil {
-		t.Fatalf("GetSession(%q): %v", sessionID, err)
-	}
-	if sess == nil {
-		t.Fatalf("Session %q not found", sessionID)
-		return
-	}
+	require.NoError(t, err, "GetSession(%q)", sessionID)
+	require.NotNil(t, sess, "Session %q not found", sessionID)
 	if check != nil {
 		check(sess)
 	}
@@ -48,29 +45,24 @@ func assertSessionState(t *testing.T, database *db.DB, sessionID string, check f
 func assertSessionMessageCount(t *testing.T, database *db.DB, sessionID string, want int) {
 	t.Helper()
 	assertSessionState(t, database, sessionID, func(sess *db.Session) {
-		if sess.MessageCount != want {
-			t.Errorf("session %q message_count = %d, want %d", sessionID, sess.MessageCount, want)
-		}
+		assert.Equal(t, want, sess.MessageCount, "session %q message_count", sessionID)
 	})
 }
 
 func assertSessionProject(t *testing.T, database *db.DB, sessionID string, want string) {
 	t.Helper()
 	assertSessionState(t, database, sessionID, func(sess *db.Session) {
-		if sess.Project != want {
-			t.Errorf("session %q project = %q, want %q", sessionID, sess.Project, want)
-		}
+		assert.Equal(t, want, sess.Project, "session %q project", sessionID)
 	})
 }
 
 func runSyncAndAssert(t *testing.T, engine *sync.Engine, want sync.SyncStats) sync.SyncStats {
 	t.Helper()
 	stats := engine.SyncAll(context.Background(), nil)
-	if diff := cmp.Diff(want, stats,
+	diff := cmp.Diff(want, stats,
 		cmpopts.IgnoreUnexported(sync.SyncStats{}),
-	); diff != "" {
-		t.Fatalf("SyncAll() mismatch (-want +got):\n%s", diff)
-	}
+	)
+	require.Empty(t, diff, "SyncAll() mismatch (-want +got):\n%s", diff)
 	return stats
 }
 
@@ -91,23 +83,13 @@ func (e *testEnv) assertResyncRoundTrip(
 		)
 		return err
 	})
-	if err != nil {
-		t.Fatalf(
-			"clear mtime for %s: %v", sessionID, err,
-		)
-	}
+	require.NoError(t, err, "clear mtime for %s", sessionID)
 
-	if err := e.engine.SyncSingleSession(sessionID); err != nil {
-		t.Fatalf("SyncSingleSession: %v", err)
-	}
+	require.NoError(t, e.engine.SyncSingleSession(sessionID))
 
 	_, mtime, ok := e.db.GetSessionFileInfo(sessionID)
-	if !ok {
-		t.Fatal("session file info not found")
-	}
-	if mtime == 0 {
-		t.Error("SyncSingleSession did not store mtime")
-	}
+	require.True(t, ok, "session file info not found")
+	assert.NotZero(t, mtime, "SyncSingleSession did not store mtime")
 
 	runSyncAndAssert(t, e.engine, sync.SyncStats{TotalSessions: 0 + 1, Synced: 0, Skipped: 1})
 }
@@ -115,9 +97,7 @@ func (e *testEnv) assertResyncRoundTrip(
 func fetchMessages(t *testing.T, database *db.DB, sessionID string) []db.Message {
 	t.Helper()
 	msgs, err := database.GetAllMessages(context.Background(), sessionID)
-	if err != nil {
-		t.Fatalf("GetAllMessages(%q): %v", sessionID, err)
-	}
+	require.NoError(t, err, "GetAllMessages(%q)", sessionID)
 	return msgs
 }
 
@@ -129,15 +109,9 @@ func assertMessageRoles(
 ) {
 	t.Helper()
 	msgs := fetchMessages(t, database, sessionID)
-	if len(msgs) != len(wantRoles) {
-		t.Fatalf("got %d messages, want %d",
-			len(msgs), len(wantRoles))
-	}
+	require.Len(t, msgs, len(wantRoles))
 	for i, want := range wantRoles {
-		if msgs[i].Role != want {
-			t.Errorf("msgs[%d].Role = %q, want %q",
-				i, msgs[i].Role, want)
-		}
+		assert.Equal(t, want, msgs[i].Role, "msgs[%d].Role", i)
 	}
 }
 
@@ -149,15 +123,9 @@ func assertMessageContent(
 ) {
 	t.Helper()
 	msgs := fetchMessages(t, database, sessionID)
-	if len(msgs) != len(wantContent) {
-		t.Fatalf("got %d messages, want %d",
-			len(msgs), len(wantContent))
-	}
+	require.Len(t, msgs, len(wantContent))
 	for i, want := range wantContent {
-		if msgs[i].Content != want {
-			t.Errorf("msgs[%d].Content = %q, want %q",
-				i, msgs[i].Content, want)
-		}
+		assert.Equal(t, want, msgs[i].Content, "msgs[%d].Content", i)
 	}
 }
 
@@ -174,14 +142,8 @@ func assertToolCallCount(
 			" WHERE session_id = ?",
 		sessionID,
 	).Scan(&got)
-	if err != nil {
-		t.Fatalf("count tool_calls for %q: %v",
-			sessionID, err)
-	}
-	if got != want {
-		t.Errorf("tool_calls count for %q = %d, want %d",
-			sessionID, got, want)
-	}
+	require.NoError(t, err, "count tool_calls for %q", sessionID)
+	assert.Equal(t, want, got, "tool_calls count for %q", sessionID)
 }
 
 // updateSessionProject fetches the session, updates its
@@ -194,17 +156,10 @@ func (e *testEnv) updateSessionProject(
 	sess, err := e.db.GetSessionFull(
 		context.Background(), sessionID,
 	)
-	if err != nil {
-		t.Fatalf("GetSessionFull: %v", err)
-	}
-	if sess == nil {
-		t.Fatalf("session %q not found", sessionID)
-		return
-	}
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "session %q not found", sessionID)
 	sess.Project = project
-	if err := e.db.UpsertSession(*sess); err != nil {
-		t.Fatalf("UpsertSession: %v", err)
-	}
+	require.NoError(t, e.db.UpsertSession(*sess), "UpsertSession")
 }
 
 // openCodeTestDB manages an OpenCode SQLite database for tests.
@@ -225,9 +180,7 @@ func createOpenCodeDB(t *testing.T, dir string) *openCodeTestDB {
 	t.Helper()
 	path := filepath.Join(dir, "opencode.db")
 	d, err := sql.Open("sqlite3", path)
-	if err != nil {
-		t.Fatalf("opening opencode test db: %v", err)
-	}
+	require.NoError(t, err, "opening opencode test db")
 	t.Cleanup(func() { d.Close() })
 
 	schema := `
@@ -257,9 +210,8 @@ func createOpenCodeDB(t *testing.T, dir string) *openCodeTestDB {
 			time_created INTEGER NOT NULL
 		);
 	`
-	if _, err := d.Exec(schema); err != nil {
-		t.Fatalf("creating opencode schema: %v", err)
-	}
+	_, err = d.Exec(schema)
+	require.NoError(t, err, "creating opencode schema")
 	return &openCodeTestDB{path: path, db: d}
 }
 
@@ -267,9 +219,7 @@ func createKiroSQLiteDB(t *testing.T, dir string) *kiroSQLiteTestDB {
 	t.Helper()
 	path := filepath.Join(dir, "data.sqlite3")
 	d, err := sql.Open("sqlite3", path)
-	if err != nil {
-		t.Fatalf("opening kiro sqlite test db: %v", err)
-	}
+	require.NoError(t, err, "opening kiro sqlite test db")
 	t.Cleanup(func() { d.Close() })
 	schema := `
 		CREATE TABLE conversations_v2 (
@@ -281,9 +231,8 @@ func createKiroSQLiteDB(t *testing.T, dir string) *kiroSQLiteTestDB {
 			PRIMARY KEY (key, conversation_id)
 		);
 	`
-	if _, err := d.Exec(schema); err != nil {
-		t.Fatalf("creating kiro sqlite schema: %v", err)
-	}
+	_, err = d.Exec(schema)
+	require.NoError(t, err, "creating kiro sqlite schema")
 	return &kiroSQLiteTestDB{path: path, db: d}
 }
 
@@ -293,9 +242,7 @@ func readKiroSQLiteFixture(t *testing.T, name string) string {
 		"..", "parser", "testdata", "kiro_sqlite", name,
 	)
 	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read kiro sqlite fixture %s: %v", name, err)
-	}
+	require.NoError(t, err, "read kiro sqlite fixture %s", name)
 	return string(data)
 }
 
@@ -304,28 +251,26 @@ func (ks *kiroSQLiteTestDB) addSession(
 	createdAt, updatedAt int64,
 ) {
 	t.Helper()
-	if _, err := ks.db.Exec(
+	_, err := ks.db.Exec(
 		`INSERT INTO conversations_v2
 			(key, conversation_id, value, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?)`,
 		key, id, payload, createdAt, updatedAt,
-	); err != nil {
-		t.Fatalf("insert kiro sqlite session: %v", err)
-	}
+	)
+	require.NoError(t, err, "insert kiro sqlite session")
 }
 
 func (ks *kiroSQLiteTestDB) updateSession(
 	t *testing.T, id, payload string, updatedAt int64,
 ) {
 	t.Helper()
-	if _, err := ks.db.Exec(
+	_, err := ks.db.Exec(
 		`UPDATE conversations_v2
 		    SET value = ?, updated_at = ?
 		  WHERE conversation_id = ?`,
 		payload, updatedAt, id,
-	); err != nil {
-		t.Fatalf("update kiro sqlite session: %v", err)
-	}
+	)
+	require.NoError(t, err, "update kiro sqlite session")
 }
 
 func writeLegacyKiroSession(
@@ -334,30 +279,25 @@ func writeLegacyKiroSession(
 	t.Helper()
 	jsonlPath := filepath.Join(dir, id+".jsonl")
 	metaPath := filepath.Join(dir, id+".json")
-	if err := os.WriteFile(
+	require.NoError(t, os.WriteFile(
 		jsonlPath,
 		[]byte(`{"kind":"Prompt","data":{"content":[{"kind":"text","data":"`+
 			prompt+`"}]}}`+"\n"+
 			`{"kind":"AssistantMessage","data":{"content":[{"kind":"text","data":"legacy assistant"}]}}`+
 			"\n"),
 		0o644,
-	); err != nil {
-		t.Fatalf("write legacy kiro jsonl: %v", err)
-	}
-	if err := os.WriteFile(
+	), "write legacy kiro jsonl")
+	require.NoError(t, os.WriteFile(
 		metaPath,
 		[]byte(`{"session_id":"`+id+`","cwd":"/home/user/code/legacy-kiro","created_at":"2026-05-17T09:00:00Z","updated_at":"2026-05-17T09:01:00Z"}`),
 		0o644,
-	); err != nil {
-		t.Fatalf("write legacy kiro metadata: %v", err)
-	}
+	), "write legacy kiro metadata")
 }
 
 func (oc *openCodeTestDB) mustExec(t *testing.T, msg, query string, args ...any) {
 	t.Helper()
-	if _, err := oc.db.Exec(query, args...); err != nil {
-		t.Fatalf("%s: %v", msg, err)
-	}
+	_, err := oc.db.Exec(query, args...)
+	require.NoError(t, err, msg)
 }
 
 func (oc *openCodeTestDB) addProject(
@@ -403,9 +343,7 @@ func (oc *openCodeTestDB) addMessage(
 	data, err := json.Marshal(map[string]string{
 		"role": role,
 	})
-	if err != nil {
-		t.Fatalf("marshal message: %v", err)
-	}
+	require.NoError(t, err, "marshal message")
 	oc.mustExec(t, "insert message",
 		`INSERT INTO message
 			(id, session_id, data, time_created)
@@ -419,9 +357,7 @@ func (oc *openCodeTestDB) updateMessageData(
 ) {
 	t.Helper()
 	raw, err := json.Marshal(data)
-	if err != nil {
-		t.Fatalf("marshal message update: %v", err)
-	}
+	require.NoError(t, err, "marshal message update")
 	oc.mustExec(t, "update message data",
 		"UPDATE message SET data = ? WHERE id = ?",
 		string(raw), id,
@@ -438,9 +374,7 @@ func (oc *openCodeTestDB) addTextPart(
 		"type":    "text",
 		"content": content,
 	})
-	if err != nil {
-		t.Fatalf("marshal text part: %v", err)
-	}
+	require.NoError(t, err, "marshal text part")
 	oc.mustExec(t, "insert part",
 		`INSERT INTO part
 			(id, session_id, message_id, data, time_created)
@@ -461,9 +395,7 @@ func (oc *openCodeTestDB) addToolPart(
 		"tool":   toolName,
 		"callID": callID,
 	})
-	if err != nil {
-		t.Fatalf("marshal tool part: %v", err)
-	}
+	require.NoError(t, err, "marshal tool part")
 	oc.mustExec(t, "insert tool part",
 		`INSERT INTO part
 			(id, session_id, message_id, data, time_created)
@@ -536,16 +468,10 @@ func (oc *openCodeStorageFixture) writeJSON(
 	t *testing.T, path string, data any,
 ) string {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755), "mkdir %s", filepath.Dir(path))
 	raw, err := json.Marshal(data)
-	if err != nil {
-		t.Fatalf("marshal %s: %v", path, err)
-	}
-	if err := os.WriteFile(path, raw, 0o644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
+	require.NoError(t, err, "marshal %s", path)
+	require.NoError(t, os.WriteFile(path, raw, 0o644), "write %s", path)
 	return path
 }
 

--- a/internal/sync/watcher_test.go
+++ b/internal/sync/watcher_test.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +11,8 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // startTestWatcherNoCleanup sets up a watcher without registering
@@ -22,12 +23,9 @@ func startTestWatcherNoCleanup(
 	t.Helper()
 	dir := t.TempDir()
 	w, err := NewWatcher(debounce, onChange, nil)
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
-	if _, _, err := w.WatchRecursive(dir); err != nil {
-		t.Fatalf("WatchRecursive: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
+	_, _, err = w.WatchRecursive(dir)
+	require.NoError(t, err, "WatchRecursive")
 	w.Start()
 	return w, dir
 }
@@ -66,18 +64,13 @@ func TestWatcherCallsOnChange(t *testing.T) {
 	})
 
 	path := filepath.Join(dir, "test.jsonl")
-	if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0o644))
 
 	select {
 	case gotPaths := <-pathsCh:
-		if len(gotPaths) == 0 {
-			t.Fatal("onChange called with empty paths")
-		}
-		if !slices.Contains(gotPaths, path) {
-			t.Fatalf("onChange did not contain expected path %s, got %v", path, gotPaths)
-		}
+		require.NotEmpty(t, gotPaths, "onChange called with empty paths")
+		require.True(t, slices.Contains(gotPaths, path),
+			"onChange did not contain expected path %s, got %v", path, gotPaths)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for onChange callback")
 	}
@@ -91,9 +84,7 @@ func TestWatcherAutoWatchesNewDirs(t *testing.T) {
 	})
 
 	subdir := filepath.Join(dir, "newdir")
-	if err := os.Mkdir(subdir, 0o755); err != nil {
-		t.Fatalf("Mkdir: %v", err)
-	}
+	require.NoError(t, os.Mkdir(subdir, 0o755))
 
 	// Wait for fsnotify to process the mkdir and add the watch
 	pollUntil(t, func() bool {
@@ -101,9 +92,7 @@ func TestWatcherAutoWatchesNewDirs(t *testing.T) {
 	})
 
 	nestedPath := filepath.Join(subdir, "nested.jsonl")
-	if err := os.WriteFile(nestedPath, []byte("nested"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.WriteFile(nestedPath, []byte("nested"), 0o644))
 
 	deadline := time.Now().Add(5 * time.Second)
 	found := false
@@ -117,9 +106,7 @@ func TestWatcherAutoWatchesNewDirs(t *testing.T) {
 		}
 	}
 
-	if !found {
-		t.Fatal("timed out waiting for nested file change")
-	}
+	require.True(t, found, "timed out waiting for nested file change")
 }
 
 func TestWatcherStopIsClean(t *testing.T) {
@@ -154,9 +141,7 @@ func TestWatcherStopIdempotency(t *testing.T) {
 	)
 
 	stressPath := filepath.Join(dir2, "stress.txt")
-	if err := os.WriteFile(stressPath, []byte("data"), 0o644); err != nil {
-		t.Fatalf("stress write: %v", err)
-	}
+	require.NoError(t, os.WriteFile(stressPath, []byte("data"), 0o644), "stress write")
 
 	// Wait for fsnotify to process it before concurrent stop
 	select {
@@ -193,9 +178,7 @@ func TestWatcherIgnoresNonWriteCreate(t *testing.T) {
 	t.Cleanup(func() { w.Stop() })
 
 	path := filepath.Join(dir, "file.txt")
-	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte("data"), 0o644))
 
 	// Wait for the initial write event to clear
 	select {
@@ -205,9 +188,7 @@ func TestWatcherIgnoresNonWriteCreate(t *testing.T) {
 	}
 
 	// Now do a chmod (should be ignored)
-	if err := os.Chmod(path, 0o666); err != nil {
-		t.Fatalf("Chmod: %v", err)
-	}
+	require.NoError(t, os.Chmod(path, 0o666))
 
 	// We can manually flush and see if anything triggers, but since the
 	// event won't even be recorded, flush won't do anything. We just wait a bit.
@@ -224,9 +205,7 @@ func TestWatcherHandlesRemoveAndRename(t *testing.T) {
 	w, err := NewWatcher(time.Millisecond, func(paths []string) {
 		pathsCh <- paths
 	}, nil)
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
 	w.Start()
 	t.Cleanup(func() { w.Stop() })
 	base := time.Unix(0, 0)
@@ -244,12 +223,8 @@ func TestWatcherHandlesRemoveAndRename(t *testing.T) {
 	w.flush()
 
 	got := <-pathsCh
-	if !slices.Contains(got, "/tmp/remove.json") {
-		t.Fatalf("remove event missing from %v", got)
-	}
-	if !slices.Contains(got, "/tmp/rename.json") {
-		t.Fatalf("rename event missing from %v", got)
-	}
+	assert.Contains(t, got, "/tmp/remove.json")
+	assert.Contains(t, got, "/tmp/rename.json")
 }
 
 func TestWatcherDebounceLogic(t *testing.T) {
@@ -276,9 +251,7 @@ func TestWatcherDebounceLogic(t *testing.T) {
 	w.mu.Unlock()
 
 	path := filepath.Join(dir, "recent_dir")
-	if err := os.Mkdir(path, 0o755); err != nil {
-		t.Fatalf("Mkdir: %v", err)
-	}
+	require.NoError(t, os.Mkdir(path, 0o755))
 
 	// Wait for fsnotify to process the mkdir and add the watch
 	pollUntil(t, func() bool {
@@ -303,9 +276,8 @@ func TestWatcherDebounceLogic(t *testing.T) {
 
 	select {
 	case gotPaths := <-pathsCh:
-		if len(gotPaths) != 1 || gotPaths[0] != path {
-			t.Fatalf("expected [%s], got %v", path, gotPaths)
-		}
+		require.Len(t, gotPaths, 1, "expected [%s], got %v", path, gotPaths)
+		assert.Equal(t, path, gotPaths[0])
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected onChange to be called after debounce elapsed")
 	}
@@ -321,9 +293,7 @@ func TestWatcherDebounceLogic(t *testing.T) {
 
 func TestWatchRecursive_ExcludesDirectoryNames(t *testing.T) {
 	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{".git", "node_modules"})
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
 	w.Start()
 	t.Cleanup(func() { w.Stop() })
 
@@ -332,61 +302,40 @@ func TestWatchRecursive_ExcludesDirectoryNames(t *testing.T) {
 	excludedGit := filepath.Join(root, "project", ".git", "objects")
 	excludedModules := filepath.Join(root, "project", "node_modules", "pkg")
 	for _, p := range []string{included, excludedGit, excludedModules} {
-		if err := os.MkdirAll(p, 0o755); err != nil {
-			t.Fatalf("MkdirAll(%s): %v", p, err)
-		}
+		require.NoError(t, os.MkdirAll(p, 0o755), "MkdirAll(%s)", p)
 	}
 
-	if _, _, err := w.WatchRecursive(root); err != nil {
-		t.Fatalf("WatchRecursive: %v", err)
-	}
+	_, _, err = w.WatchRecursive(root)
+	require.NoError(t, err, "WatchRecursive")
 
 	got := w.watcher.WatchList()
-	if slices.Contains(got, filepath.Join(root, "project", ".git")) {
-		t.Fatal(".git should be excluded from watch list")
-	}
-	if slices.Contains(got, filepath.Join(root, "project", "node_modules")) {
-		t.Fatal("node_modules should be excluded from watch list")
-	}
-	if !slices.Contains(got, included) {
-		t.Fatalf("expected included dir %s in watch list", included)
-	}
+	assert.NotContains(t, got, filepath.Join(root, "project", ".git"),
+		".git should be excluded from watch list")
+	assert.NotContains(t, got, filepath.Join(root, "project", "node_modules"),
+		"node_modules should be excluded from watch list")
+	assert.Contains(t, got, included, "expected included dir in watch list")
 }
 
 func TestWatchRecursiveBudget_DegradesWhenBudgetExhausted(t *testing.T) {
 	root := t.TempDir()
 	for i := range 5 {
-		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf("dir-%d", i)), 0o755); err != nil {
-			t.Fatalf("MkdirAll: %v", err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Join(root, fmt.Sprintf("dir-%d", i)), 0o755))
 	}
 
 	w, err := NewWatcher(time.Second, func(_ []string) {}, nil)
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
 	w.Start()
 	t.Cleanup(func() { w.Stop() })
 
 	result := w.WatchRecursiveBudgeted(root, 3)
-	if result.Watched != 3 {
-		t.Fatalf("Watched = %d, want 3", result.Watched)
-	}
-	if !result.BudgetExhausted {
-		t.Fatal("BudgetExhausted = false, want true")
-	}
+	assert.Equal(t, 3, result.Watched)
+	assert.True(t, result.BudgetExhausted, "BudgetExhausted = false, want true")
 }
 
 func TestIsWatchResourceExhaustion(t *testing.T) {
-	if !isWatchResourceExhaustion(syscall.EMFILE) {
-		t.Fatal("EMFILE should be resource exhaustion")
-	}
-	if !isWatchResourceExhaustion(syscall.ENOSPC) {
-		t.Fatal("ENOSPC should be resource exhaustion")
-	}
-	if isWatchResourceExhaustion(os.ErrNotExist) {
-		t.Fatal("ErrNotExist should not be resource exhaustion")
-	}
+	assert.True(t, isWatchResourceExhaustion(syscall.EMFILE), "EMFILE should be resource exhaustion")
+	assert.True(t, isWatchResourceExhaustion(syscall.ENOSPC), "ENOSPC should be resource exhaustion")
+	assert.False(t, isWatchResourceExhaustion(os.ErrNotExist), "ErrNotExist should not be resource exhaustion")
 }
 
 func TestWatcherAutoWatchesNewDirs_RespectsExcludes(t *testing.T) {
@@ -394,37 +343,28 @@ func TestWatcherAutoWatchesNewDirs_RespectsExcludes(t *testing.T) {
 	w, err := NewWatcher(20*time.Millisecond, func(paths []string) {
 		pathsCh <- paths
 	}, []string{".git"})
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
 	t.Cleanup(func() { w.Stop() })
 
 	root := t.TempDir()
-	if _, _, err := w.WatchRecursive(root); err != nil {
-		t.Fatalf("WatchRecursive: %v", err)
-	}
+	_, _, err = w.WatchRecursive(root)
+	require.NoError(t, err, "WatchRecursive")
 	w.Start()
 
 	gitDir := filepath.Join(root, ".git")
-	if err := os.Mkdir(gitDir, 0o755); err != nil {
-		t.Fatalf("Mkdir(.git): %v", err)
-	}
+	require.NoError(t, os.Mkdir(gitDir, 0o755), "Mkdir(.git)")
 
 	time.Sleep(100 * time.Millisecond)
-	if slices.Contains(w.watcher.WatchList(), gitDir) {
-		t.Fatal("newly created excluded dir should not be watched")
-	}
+	assert.NotContains(t, w.watcher.WatchList(), gitDir,
+		"newly created excluded dir should not be watched")
 
 	fileInGit := filepath.Join(gitDir, "config")
-	if err := os.WriteFile(fileInGit, []byte("x"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
+	require.NoError(t, os.WriteFile(fileInGit, []byte("x"), 0o644))
 
 	select {
 	case paths := <-pathsCh:
-		if slices.Contains(paths, fileInGit) {
-			t.Fatal("changes inside excluded dir should not trigger onChange")
-		}
+		assert.NotContains(t, paths, fileInGit,
+			"changes inside excluded dir should not trigger onChange")
 	case <-time.After(200 * time.Millisecond):
 		// no events from excluded dir; expected
 	}
@@ -432,37 +372,26 @@ func TestWatcherAutoWatchesNewDirs_RespectsExcludes(t *testing.T) {
 
 func TestWatchRecursive_RootUnderExcludedAncestorStillWatchesDescendants(t *testing.T) {
 	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{"venv"})
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
 	w.Start()
 	t.Cleanup(func() { w.Stop() })
 
 	base := t.TempDir()
 	root := filepath.Join(base, "venv", "project")
 	included := filepath.Join(root, "src")
-	if err := os.MkdirAll(included, 0o755); err != nil {
-		t.Fatalf("MkdirAll(%s): %v", included, err)
-	}
+	require.NoError(t, os.MkdirAll(included, 0o755), "MkdirAll(%s)", included)
 
-	if _, _, err := w.WatchRecursive(root); err != nil {
-		t.Fatalf("WatchRecursive: %v", err)
-	}
+	_, _, err = w.WatchRecursive(root)
+	require.NoError(t, err, "WatchRecursive")
 
 	got := w.watcher.WatchList()
-	if !slices.Contains(got, root) {
-		t.Fatalf("expected root %s in watch list", root)
-	}
-	if !slices.Contains(got, included) {
-		t.Fatalf("expected included dir %s in watch list", included)
-	}
+	assert.Contains(t, got, root, "expected root in watch list")
+	assert.Contains(t, got, included, "expected included dir in watch list")
 }
 
 func TestWatchRecursive_ExcludesSlashPatternRelativeToRoot(t *testing.T) {
 	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{"foo/bar"})
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
 	w.Start()
 	t.Cleanup(func() { w.Stop() })
 
@@ -470,29 +399,20 @@ func TestWatchRecursive_ExcludesSlashPatternRelativeToRoot(t *testing.T) {
 	excluded := filepath.Join(root, "foo", "bar")
 	includedSibling := filepath.Join(root, "foo", "baz")
 	for _, p := range []string{excluded, includedSibling} {
-		if err := os.MkdirAll(p, 0o755); err != nil {
-			t.Fatalf("MkdirAll(%s): %v", p, err)
-		}
+		require.NoError(t, os.MkdirAll(p, 0o755), "MkdirAll(%s)", p)
 	}
 
-	if _, _, err := w.WatchRecursive(root); err != nil {
-		t.Fatalf("WatchRecursive: %v", err)
-	}
+	_, _, err = w.WatchRecursive(root)
+	require.NoError(t, err, "WatchRecursive")
 
 	got := w.watcher.WatchList()
-	if slices.Contains(got, excluded) {
-		t.Fatalf("expected %s to be excluded", excluded)
-	}
-	if !slices.Contains(got, includedSibling) {
-		t.Fatalf("expected %s to be included", includedSibling)
-	}
+	assert.NotContains(t, got, excluded, "expected %s to be excluded", excluded)
+	assert.Contains(t, got, includedSibling, "expected %s to be included", includedSibling)
 }
 
 func TestWatchRecursive_OverlappingRoots_UsesMostSpecificRoot(t *testing.T) {
 	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{"venv"})
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
 	w.Start()
 	t.Cleanup(func() { w.Stop() })
 
@@ -501,25 +421,17 @@ func TestWatchRecursive_OverlappingRoots_UsesMostSpecificRoot(t *testing.T) {
 	nestedRoot := filepath.Join(parentRoot, "venv", "project")
 	included := filepath.Join(nestedRoot, "src")
 	for _, p := range []string{parentRoot, included} {
-		if err := os.MkdirAll(p, 0o755); err != nil {
-			t.Fatalf("MkdirAll(%s): %v", p, err)
-		}
+		require.NoError(t, os.MkdirAll(p, 0o755), "MkdirAll(%s)", p)
 	}
 
-	if _, _, err := w.WatchRecursive(parentRoot); err != nil {
-		t.Fatalf("WatchRecursive(parent): %v", err)
-	}
-	if _, _, err := w.WatchRecursive(nestedRoot); err != nil {
-		t.Fatalf("WatchRecursive(nested): %v", err)
-	}
+	_, _, err = w.WatchRecursive(parentRoot)
+	require.NoError(t, err, "WatchRecursive(parent)")
+	_, _, err = w.WatchRecursive(nestedRoot)
+	require.NoError(t, err, "WatchRecursive(nested)")
 
 	got := w.watcher.WatchList()
-	if !slices.Contains(got, nestedRoot) {
-		t.Fatalf("expected nested root %s in watch list", nestedRoot)
-	}
-	if !slices.Contains(got, included) {
-		t.Fatalf("expected included dir %s in watch list", included)
-	}
+	assert.Contains(t, got, nestedRoot, "expected nested root in watch list")
+	assert.Contains(t, got, included, "expected included dir in watch list")
 }
 
 func TestWatcherExcludedCreateDir_DoesNotTriggerOnChange(t *testing.T) {
@@ -527,27 +439,21 @@ func TestWatcherExcludedCreateDir_DoesNotTriggerOnChange(t *testing.T) {
 	w, err := NewWatcher(20*time.Millisecond, func(paths []string) {
 		pathsCh <- paths
 	}, []string{".git"})
-	if err != nil {
-		t.Fatalf("NewWatcher: %v", err)
-	}
+	require.NoError(t, err, "NewWatcher")
 	t.Cleanup(func() { w.Stop() })
 
 	root := t.TempDir()
-	if _, _, err := w.WatchRecursive(root); err != nil {
-		t.Fatalf("WatchRecursive: %v", err)
-	}
+	_, _, err = w.WatchRecursive(root)
+	require.NoError(t, err, "WatchRecursive")
 	w.Start()
 
 	gitDir := filepath.Join(root, ".git")
-	if err := os.Mkdir(gitDir, 0o755); err != nil {
-		t.Fatalf("Mkdir(.git): %v", err)
-	}
+	require.NoError(t, os.Mkdir(gitDir, 0o755), "Mkdir(.git)")
 
 	select {
 	case paths := <-pathsCh:
-		if slices.Contains(paths, gitDir) {
-			t.Fatal("excluded directory create should not trigger onChange")
-		}
+		assert.NotContains(t, paths, gitDir,
+			"excluded directory create should not trigger onChange")
 	case <-time.After(250 * time.Millisecond):
 		// Expected: no callback for excluded dir creation.
 	}
@@ -555,16 +461,9 @@ func TestWatcherExcludedCreateDir_DoesNotTriggerOnChange(t *testing.T) {
 
 func TestNewWatcher_NilOnChange(t *testing.T) {
 	_, err := NewWatcher(time.Second, nil, nil)
-	if err == nil {
-		t.Fatal("NewWatcher(nil) should return error")
-	}
-
-	if !errors.Is(err, os.ErrInvalid) {
-		t.Errorf("expected wrapped os.ErrInvalid, got %v", err)
-	}
+	require.Error(t, err, "NewWatcher(nil) should return error")
+	require.ErrorIs(t, err, os.ErrInvalid)
 
 	expectedMsg := "onChange callback is nil"
-	if err.Error() != expectedMsg+": "+os.ErrInvalid.Error() {
-		t.Errorf("expected error message to contain %q, got %q", expectedMsg, err.Error())
-	}
+	assert.Equal(t, expectedMsg+": "+os.ErrInvalid.Error(), err.Error())
 }

--- a/internal/sync/workbuddy_test.go
+++ b/internal/sync/workbuddy_test.go
@@ -5,17 +5,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestWorkBuddyRegistryUsesRecursiveWatch(t *testing.T) {
 	def, ok := parser.AgentByType(parser.AgentWorkBuddy)
-	if !ok {
-		t.Fatal("AgentWorkBuddy missing from Registry")
-	}
-	if def.ShallowWatch {
-		t.Fatal("WorkBuddy should use recursive watch for nested sessions")
-	}
+	require.True(t, ok, "AgentWorkBuddy missing from Registry")
+	require.False(t, def.ShallowWatch, "WorkBuddy should use recursive watch for nested sessions")
 }
 
 func TestEngineClassifyWorkBuddyPaths(t *testing.T) {
@@ -32,33 +30,24 @@ func TestEngineClassifyWorkBuddyPaths(t *testing.T) {
 	subPath := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
 	toolPath := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111", "tool-results", "tool_123.txt")
 	for _, path := range []string{mainPath, subPath, toolPath} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll(%q): %v", path, err)
-		}
-		if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
-			t.Fatalf("WriteFile(%q): %v", path, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
 	}
 
 	got, ok := engine.classifyOnePath(mainPath, nil)
-	if !ok {
-		t.Fatal("main path did not classify")
-	}
-	if got.Path != mainPath || got.Project != "proj" || got.Agent != parser.AgentWorkBuddy {
-		t.Fatalf("main classified as %+v", got)
-	}
+	require.True(t, ok, "main path did not classify")
+	assert.Equal(t, mainPath, got.Path)
+	assert.Equal(t, "proj", got.Project)
+	assert.Equal(t, parser.AgentWorkBuddy, got.Agent)
 
 	got, ok = engine.classifyOnePath(subPath, nil)
-	if !ok {
-		t.Fatal("subagent path did not classify")
-	}
-	if got.Path != subPath || got.Project != "proj" || got.Agent != parser.AgentWorkBuddy {
-		t.Fatalf("subagent classified as %+v", got)
-	}
+	require.True(t, ok, "subagent path did not classify")
+	assert.Equal(t, subPath, got.Path)
+	assert.Equal(t, "proj", got.Project)
+	assert.Equal(t, parser.AgentWorkBuddy, got.Agent)
 
-	if got, ok = engine.classifyOnePath(toolPath, nil); ok {
-		t.Fatalf("tool result classified as %+v", got)
-	}
+	got, ok = engine.classifyOnePath(toolPath, nil)
+	assert.False(t, ok, "tool result classified as %+v", got)
 }
 
 func TestEngineClassifyWorkBuddyProjectNamedSubagentsAsMainSession(t *testing.T) {
@@ -72,18 +61,12 @@ func TestEngineClassifyWorkBuddyProjectNamedSubagentsAsMainSession(t *testing.T)
 	})
 
 	path := filepath.Join(root, "subagents", "11111111-1111-4111-8111-111111111111.jsonl")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
 
 	got, ok := engine.classifyOnePath(path, nil)
-	if !ok {
-		t.Fatal("path did not classify")
-	}
-	if got.Path != path || got.Project != "subagents" || got.Agent != parser.AgentWorkBuddy {
-		t.Fatalf("classified as %+v", got)
-	}
+	require.True(t, ok, "path did not classify")
+	assert.Equal(t, path, got.Path)
+	assert.Equal(t, "subagents", got.Project)
+	assert.Equal(t, parser.AgentWorkBuddy, got.Agent)
 }

--- a/internal/timeutil/timeutil_test.go
+++ b/internal/timeutil/timeutil_test.go
@@ -3,6 +3,9 @@ package timeutil
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPtr(t *testing.T) {
@@ -32,18 +35,11 @@ func TestPtr(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Ptr(tt.in)
 			if tt.want == nil {
-				if got != nil {
-					t.Errorf("Ptr() = %v, want nil", *got)
-				}
+				assert.Nil(t, got)
 				return
 			}
-			if got == nil {
-				t.Fatalf("Ptr() returned nil, want %q", *tt.want)
-				return
-			}
-			if *got != *tt.want {
-				t.Errorf("Ptr() = %q, want %q", *got, *tt.want)
-			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tt.want, *got)
 		})
 	}
 }
@@ -60,9 +56,7 @@ func TestFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Format(tt.in); got != tt.want {
-				t.Errorf("Format() = %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, Format(tt.in))
 		})
 	}
 }
@@ -84,9 +78,7 @@ func TestIsValidDate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsValidDate(tt.in); got != tt.want {
-				t.Errorf("IsValidDate(%q) = %v, want %v", tt.in, got, tt.want)
-			}
+			assert.Equal(t, tt.want, IsValidDate(tt.in))
 		})
 	}
 }
@@ -107,9 +99,7 @@ func TestIsValidTimestamp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsValidTimestamp(tt.in); got != tt.want {
-				t.Errorf("IsValidTimestamp(%q) = %v, want %v", tt.in, got, tt.want)
-			}
+			assert.Equal(t, tt.want, IsValidTimestamp(tt.in))
 		})
 	}
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -9,6 +9,9 @@ import (
 	"runtime"
 	"sync/atomic"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsDevBuildVersion(t *testing.T) {
@@ -27,13 +30,7 @@ func TestIsDevBuildVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			got := IsDevBuildVersion(tt.version)
-			if got != tt.want {
-				t.Errorf(
-					"IsDevBuildVersion(%q) = %v, want %v",
-					tt.version, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, IsDevBuildVersion(tt.version))
 		})
 	}
 }
@@ -53,13 +50,7 @@ func TestIsNewer(t *testing.T) {
 	for _, tt := range tests {
 		name := tt.v1 + "_vs_" + tt.v2
 		t.Run(name, func(t *testing.T) {
-			got := isNewer(tt.v1, tt.v2)
-			if got != tt.want {
-				t.Errorf(
-					"isNewer(%q, %q) = %v, want %v",
-					tt.v1, tt.v2, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, isNewer(tt.v1, tt.v2))
 		})
 	}
 }
@@ -79,10 +70,7 @@ fff000  yet_another.zip`
 
 	for _, tt := range tests {
 		t.Run(tt.filename, func(t *testing.T) {
-			got := extractChecksum(body, tt.filename)
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			assert.Equal(t, tt.want, extractChecksum(body, tt.filename))
 		})
 	}
 }
@@ -105,19 +93,12 @@ func TestSanitizePath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotPath, err := sanitizePath(destDir, tt.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf(
-					"sanitizePath(%q) error = %v, wantErr %v",
-					tt.path, err, tt.wantErr,
-				)
+			if tt.wantErr {
+				assert.Error(t, err)
 				return
 			}
-			if err == nil && gotPath != tt.wantPath {
-				t.Errorf(
-					"sanitizePath(%q) path = %q, wantPath %q",
-					tt.path, gotPath, tt.wantPath,
-				)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPath, gotPath)
 		})
 	}
 }
@@ -130,19 +111,13 @@ func TestExtractTarGz(t *testing.T) {
 	archivePath := filepath.Join(srcDir, "test.tar.gz")
 	createTestTarGz(t, archivePath, "agentsview", "binary-content")
 
-	if err := extractTarGz(archivePath, destDir); err != nil {
-		t.Fatalf("extractTarGz: %v", err)
-	}
+	require.NoError(t, extractTarGz(archivePath, destDir))
 
 	content, err := os.ReadFile(
 		filepath.Join(destDir, "agentsview"),
 	)
-	if err != nil {
-		t.Fatalf("read extracted file: %v", err)
-	}
-	if string(content) != "binary-content" {
-		t.Errorf("got %q, want %q", content, "binary-content")
-	}
+	require.NoError(t, err, "read extracted file")
+	assert.Equal(t, "binary-content", string(content))
 }
 
 func TestInstallBinaryToSetsExecutableMode(t *testing.T) {
@@ -155,53 +130,33 @@ func TestInstallBinaryToSetsExecutableMode(t *testing.T) {
 	srcPath := filepath.Join(srcDir, "agentsview")
 	dstPath := filepath.Join(dstDir, "agentsview")
 
-	if err := os.WriteFile(srcPath, []byte("binary"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(srcPath, []byte("binary"), 0o644))
 
-	if err := installBinaryTo(srcPath, dstPath); err != nil {
-		t.Fatalf("installBinaryTo: %v", err)
-	}
+	require.NoError(t, installBinaryTo(srcPath, dstPath))
 
 	info, err := os.Stat(dstPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := info.Mode().Perm(); got != 0o755 {
-		t.Errorf("dstPath mode = %o, want 0755", got)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
 }
 
 func TestInstallBinaryToPreservesOnSourceMissing(t *testing.T) {
 	dstDir := t.TempDir()
 	dstPath := filepath.Join(dstDir, "agentsview")
 
-	if err := os.WriteFile(
-		dstPath, []byte("original"), 0o755,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(dstPath, []byte("original"), 0o755))
 
 	missingSrc := filepath.Join(t.TempDir(), "does-not-exist")
 
-	if err := installBinaryTo(missingSrc, dstPath); err == nil {
-		t.Fatal("expected error from missing source")
-	}
+	require.Error(t, installBinaryTo(missingSrc, dstPath), "expected error from missing source")
 
 	got, err := os.ReadFile(dstPath)
-	if err != nil {
-		t.Fatalf("dstPath should still exist: %v", err)
-	}
-	if string(got) != "original" {
-		t.Errorf("dstPath content = %q, want %q", got, "original")
-	}
+	require.NoError(t, err, "dstPath should still exist")
+	assert.Equal(t, "original", string(got))
 
-	if _, err := os.Stat(dstPath + ".new"); !os.IsNotExist(err) {
-		t.Error("staging .new file should not be left behind")
-	}
-	if _, err := os.Stat(dstPath + ".old"); !os.IsNotExist(err) {
-		t.Error("backup .old file should not be left behind")
-	}
+	_, err = os.Stat(dstPath + ".new")
+	assert.True(t, os.IsNotExist(err), "staging .new file should not be left behind")
+	_, err = os.Stat(dstPath + ".old")
+	assert.True(t, os.IsNotExist(err), "backup .old file should not be left behind")
 }
 
 func TestInstallBinaryToNeverMissingDuringUpdate(t *testing.T) {
@@ -217,12 +172,8 @@ func TestInstallBinaryToNeverMissingDuringUpdate(t *testing.T) {
 	srcPath := filepath.Join(srcDir, "agentsview")
 	dstPath := filepath.Join(dstDir, "agentsview")
 
-	if err := os.WriteFile(srcPath, []byte("new"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(dstPath, []byte("old"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(srcPath, []byte("new"), 0o755))
+	require.NoError(t, os.WriteFile(dstPath, []byte("old"), 0o755))
 
 	var observations, missing atomic.Uint64
 	stop := make(chan struct{})
@@ -267,12 +218,8 @@ func TestInstallBinaryToNeverMissingDuringUpdate(t *testing.T) {
 			observations.Load(),
 		)
 	}
-	if missing.Load() > 0 {
-		t.Errorf(
-			"dstPath observed missing %d times during install",
-			missing.Load(),
-		)
-	}
+	assert.Zero(t, missing.Load(),
+		"dstPath observed missing %d times during install", missing.Load())
 }
 
 func TestInstallBinaryToRemovesStaleStagingFile(t *testing.T) {
@@ -281,28 +228,15 @@ func TestInstallBinaryToRemovesStaleStagingFile(t *testing.T) {
 	srcPath := filepath.Join(srcDir, "agentsview")
 	dstPath := filepath.Join(dstDir, "agentsview")
 
-	if err := os.WriteFile(srcPath, []byte("new-binary"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(dstPath, []byte("old-binary"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(srcPath, []byte("new-binary"), 0o755))
+	require.NoError(t, os.WriteFile(dstPath, []byte("old-binary"), 0o755))
 	stagingPath := dstPath + ".new"
-	if err := os.WriteFile(
-		stagingPath, []byte("stale-staging"), 0o644,
-	); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.WriteFile(stagingPath, []byte("stale-staging"), 0o644))
 
-	if err := installBinaryTo(srcPath, dstPath); err != nil {
-		t.Fatalf("installBinaryTo: %v", err)
-	}
+	require.NoError(t, installBinaryTo(srcPath, dstPath))
 
-	if _, err := os.Stat(stagingPath); !os.IsNotExist(err) {
-		t.Errorf(
-			"stale staging file should be removed, got err=%v", err,
-		)
-	}
+	_, err := os.Stat(stagingPath)
+	assert.True(t, os.IsNotExist(err), "stale staging file should be removed, got err=%v", err)
 }
 
 func TestInstallBinaryTo(t *testing.T) {
@@ -335,31 +269,20 @@ func TestInstallBinaryTo(t *testing.T) {
 			dstPath := filepath.Join(dstDir, "agentsview")
 
 			if tt.existingDest != "" {
-				if err := os.WriteFile(dstPath, []byte(tt.existingDest), 0o755); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, os.WriteFile(dstPath, []byte(tt.existingDest), 0o755))
 			}
 
-			if err := os.WriteFile(srcPath, []byte(tt.newBinary), 0o755); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, os.WriteFile(srcPath, []byte(tt.newBinary), 0o755))
 
-			if err := installBinaryTo(srcPath, dstPath); err != nil {
-				t.Fatalf("installBinaryTo: %v", err)
-			}
+			require.NoError(t, installBinaryTo(srcPath, dstPath))
 
 			got, err := os.ReadFile(dstPath)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if string(got) != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
 
 			if tt.existingDest != "" {
-				if _, err := os.Stat(dstPath + ".old"); !os.IsNotExist(err) {
-					t.Error("backup .old file should be removed")
-				}
+				_, err := os.Stat(dstPath + ".old")
+				assert.True(t, os.IsNotExist(err), "backup .old file should be removed")
 			}
 		})
 	}
@@ -379,13 +302,7 @@ func TestFormatSize(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%d_bytes", tt.bytes), func(t *testing.T) {
-			got := FormatSize(tt.bytes)
-			if got != tt.want {
-				t.Errorf(
-					"FormatSize(%d) = %q, want %q",
-					tt.bytes, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, FormatSize(tt.bytes))
 		})
 	}
 }
@@ -396,12 +313,8 @@ func TestCacheRoundtrip(t *testing.T) {
 	saveCache("v1.2.3", dir)
 
 	cached, err := loadCache(dir)
-	if err != nil {
-		t.Fatalf("loadCache: %v", err)
-	}
-	if cached.Version != "v1.2.3" {
-		t.Errorf("got version %q, want %q", cached.Version, "v1.2.3")
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "v1.2.3", cached.Version)
 }
 
 func TestNormalizeSemver(t *testing.T) {
@@ -418,13 +331,7 @@ func TestNormalizeSemver(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := normalizeSemver(tt.input)
-			if got != tt.want {
-				t.Errorf(
-					"normalizeSemver(%q) = %q, want %q",
-					tt.input, got, tt.want,
-				)
-			}
+			assert.Equal(t, tt.want, normalizeSemver(tt.input))
 		})
 	}
 }
@@ -435,9 +342,7 @@ func createTestTarGz(
 ) {
 	t.Helper()
 	f, err := os.Create(archivePath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer f.Close()
 
 	gw := gzip.NewWriter(f)
@@ -452,10 +357,7 @@ func createTestTarGz(
 		Mode: 0o755,
 		Size: int64(len(data)),
 	}
-	if err := tw.WriteHeader(header); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tw.Write(data); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, tw.WriteHeader(header))
+	_, err = tw.Write(data)
+	require.NoError(t, err)
 }

--- a/internal/web/embed_test.go
+++ b/internal/web/embed_test.go
@@ -2,33 +2,25 @@ package web
 
 import (
 	"io/fs"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAssetsIncludesIndex(t *testing.T) {
 	assets, err := Assets()
-	if err != nil {
-		t.Fatalf("Assets: %v", err)
-	}
+	require.NoError(t, err)
 
-	if _, err := fs.ReadFile(assets, "index.html"); err != nil {
-		t.Fatalf("ReadFile(index.html): %v", err)
-	}
+	_, err = fs.ReadFile(assets, "index.html")
+	require.NoError(t, err)
 }
 
 func TestFallbackAssetsIncludePlaceholderIndex(t *testing.T) {
 	fallback, err := fs.Sub(assetFS, "fallback")
-	if err != nil {
-		t.Fatalf("fs.Sub(fallback): %v", err)
-	}
+	require.NoError(t, err)
 
 	raw, err := fs.ReadFile(fallback, "index.html")
-	if err != nil {
-		t.Fatalf("ReadFile(fallback/index.html): %v", err)
-	}
-	body := string(raw)
-	if !strings.Contains(body, "AgentsView frontend assets are not built.") {
-		t.Fatalf("fallback body missing placeholder heading: %s", body)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "AgentsView frontend assets are not built.")
 }


### PR DESCRIPTION
Standardize Go test assertions on `github.com/stretchr/testify` (`require` + `assert`). Roughly 169 of 199 test files previously used stdlib `t.Errorf` / `t.Fatalf` patterns; this PR converts them.

`CLAUDE.md` and `AGENTS.md` document the rule: use `require.X` for checks that must abort the test (setup errors, nil receivers, lengths before indexing) and `assert.X` for independent checks that should keep running. Custom domain helpers like `assertSessionMeta` and `assertTimeoutRace` are retained but now route through testify internally.

Intentionally not migrated:
- `internal/secrets/bench_test.go` — benchmarks only, no assertions
- `internal/postgres/helpers_pgtest_test.go` — `TEST_PG_URL` skip helper
- `internal/sync/export_test.go` — exposes a package constant, not a test
- `internal/server/deadline_test.go` — all assertions delegate to helpers in the already-migrated `server_test.go`

One unused helper (`floatsClose` in `session_stats_test.go`) was dropped after lint flagged it as dead code. Four `cmp.Diff` blocks in `internal/db/db_test.go` keep their stdlib `t.Errorf` calls because testify has no structured-diff equivalent.