### PR TITLE
fix: use HTML redirect endpoint to avoid GitHub API rate limit

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -103,8 +103,18 @@ func CheckForUpdate(
 		"%s/%s/SHA256SUMS", githubReleaseDownloadBase, tag,
 	)
 
+	// HEAD the asset to confirm it exists for this platform. The previous
+	// API-based code returned "no release asset for OS/ARCH" up front; now
+	// that we construct the URL ourselves, we have to verify it resolves.
+	size, err := fetchContentLength(downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"no release asset for %s/%s: %w",
+			runtime.GOOS, runtime.GOARCH, err,
+		)
+	}
+
 	checksum, _ := fetchChecksumFromFile(checksumsURL, assetName)
-	size, _ := fetchContentLength(downloadURL)
 
 	return &UpdateInfo{
 		CurrentVersion: currentVersion,

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -21,25 +21,16 @@ import (
 )
 
 const (
-	githubAPIURL     = "https://api.github.com/repos/kenn-io/agentsview/releases/latest"
-	cacheFileName    = "update_check.json"
-	cacheDuration    = 1 * time.Hour
-	devCacheDuration = 15 * time.Minute
+	// githubLatestReleaseURL is the HTML endpoint that 302-redirects to
+	// /releases/tag/<tag>. Unlike api.github.com it is not rate-limited
+	// at 60 req/hr per IP for unauthenticated callers.
+	githubLatestReleaseURL    = "https://github.com/kenn-io/agentsview/releases/latest"
+	githubReleaseDownloadBase = "https://github.com/kenn-io/agentsview/releases/download"
+	updateUserAgent           = "agentsview-update"
+	cacheFileName             = "update_check.json"
+	cacheDuration             = 1 * time.Hour
+	devCacheDuration          = 15 * time.Minute
 )
-
-// Release represents a GitHub release.
-type Release struct {
-	TagName string  `json:"tag_name"`
-	Body    string  `json:"body"`
-	Assets  []Asset `json:"assets"`
-}
-
-// Asset represents a release asset.
-type Asset struct {
-	Name               string `json:"name"`
-	Size               int64  `json:"size"`
-	BrowserDownloadURL string `json:"browser_download_url"`
-}
 
 // UpdateInfo contains information about an available update.
 type UpdateInfo struct {
@@ -59,22 +50,6 @@ type UpdateInfo struct {
 // and lacks the download URL/checksum needed for an install.
 func (u *UpdateInfo) NeedsRefetch() bool {
 	return u.cacheOnly
-}
-
-// findAssets locates the platform binary and checksums file.
-func findAssets(
-	assets []Asset, assetName string,
-) (asset *Asset, checksumsAsset *Asset) {
-	for i := range assets {
-		a := &assets[i]
-		if a.Name == assetName {
-			asset = a
-		}
-		if a.Name == "SHA256SUMS" || a.Name == "checksums.txt" {
-			checksumsAsset = a
-		}
-	}
-	return asset, checksumsAsset
 }
 
 type cachedCheck struct {
@@ -100,14 +75,14 @@ func CheckForUpdate(
 		}
 	}
 
-	release, err := fetchLatestRelease()
+	tag, err := resolveLatestTag(githubLatestReleaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("check for updates: %w", err)
 	}
 
-	saveCache(release.TagName, cacheDir)
+	saveCache(tag, cacheDir)
 
-	latestVersion := strings.TrimPrefix(release.TagName, "v")
+	latestVersion := strings.TrimPrefix(tag, "v")
 
 	if !isDevBuild && !isNewer(latestVersion, cleanVersion) {
 		return nil, nil
@@ -121,30 +96,22 @@ func CheckForUpdate(
 		"agentsview_%s_%s_%s%s",
 		latestVersion, runtime.GOOS, runtime.GOARCH, ext,
 	)
-	asset, checksumsAsset := findAssets(release.Assets, assetName)
-	if asset == nil {
-		return nil, fmt.Errorf(
-			"no release asset for %s/%s",
-			runtime.GOOS, runtime.GOARCH,
-		)
-	}
+	downloadURL := fmt.Sprintf(
+		"%s/%s/%s", githubReleaseDownloadBase, tag, assetName,
+	)
+	checksumsURL := fmt.Sprintf(
+		"%s/%s/SHA256SUMS", githubReleaseDownloadBase, tag,
+	)
 
-	var checksum string
-	if checksumsAsset != nil {
-		checksum, _ = fetchChecksumFromFile(
-			checksumsAsset.BrowserDownloadURL, assetName,
-		)
-	}
-	if checksum == "" {
-		checksum = extractChecksum(release.Body, assetName)
-	}
+	checksum, _ := fetchChecksumFromFile(checksumsURL, assetName)
+	size, _ := fetchContentLength(downloadURL)
 
 	return &UpdateInfo{
 		CurrentVersion: currentVersion,
-		LatestVersion:  release.TagName,
-		DownloadURL:    asset.BrowserDownloadURL,
-		AssetName:      asset.Name,
-		Size:           asset.Size,
+		LatestVersion:  tag,
+		DownloadURL:    downloadURL,
+		AssetName:      assetName,
+		Size:           size,
 		Checksum:       checksum,
 		IsDevBuild:     isDevBuild,
 	}, nil
@@ -358,34 +325,81 @@ func movePreviousAside(dstPath, backupPath string) (bool, error) {
 	return true, nil
 }
 
-func fetchLatestRelease() (*Release, error) {
-	req, err := http.NewRequest("GET", githubAPIURL, nil)
-	if err != nil {
-		return nil, err
+// resolveLatestTag follows the /releases/latest 302 redirect to
+// /releases/tag/<tag> and returns the tag. Using the HTML endpoint
+// avoids api.github.com's 60-req/hr unauthenticated rate limit.
+func resolveLatestTag(url string) (string, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
-	req.Header.Set(
-		"Accept", "application/vnd.github.v3+json",
-	)
-	req.Header.Set("User-Agent", "agentsview-update")
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", updateUserAgent)
 
-	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return "", fmt.Errorf(
+			"expected redirect from %s, got %s", url, resp.Status,
+		)
+	}
+
+	loc, err := resp.Location()
+	if err != nil {
+		return "", fmt.Errorf("read Location header: %w", err)
+	}
+
+	const marker = "/releases/tag/"
+	idx := strings.Index(loc.Path, marker)
+	if idx < 0 {
+		return "", fmt.Errorf(
+			"unexpected redirect target %q", loc.String(),
+		)
+	}
+	tag := loc.Path[idx+len(marker):]
+	if tag == "" {
+		return "", fmt.Errorf(
+			"empty tag in redirect target %q", loc.String(),
+		)
+	}
+	return tag, nil
+}
+
+// fetchContentLength does a HEAD request and returns the Content-Length
+// of the eventual asset (following redirects to the S3 backend).
+// Returns 0 if the size can't be determined; callers degrade gracefully.
+func fetchContentLength(url string) (int64, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("User-Agent", updateUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(
-			"GitHub API returned %s", resp.Status,
+		return 0, fmt.Errorf(
+			"HEAD %s returned %s", url, resp.Status,
 		)
 	}
-
-	var release Release
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, err
+	if resp.ContentLength < 0 {
+		return 0, nil
 	}
-	return &release, nil
+	return resp.ContentLength, nil
 }
 
 func downloadFile(

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -71,6 +73,115 @@ fff000  yet_another.zip`
 	for _, tt := range tests {
 		t.Run(tt.filename, func(t *testing.T) {
 			assert.Equal(t, tt.want, extractChecksum(body, tt.filename))
+		})
+	}
+}
+
+func TestResolveLatestTag(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		location   string
+		wantTag    string
+		wantErrSub string
+	}{
+		{
+			name:     "valid 302 redirect",
+			status:   http.StatusFound,
+			location: "https://github.com/kenn-io/agentsview/releases/tag/v0.30.1",
+			wantTag:  "v0.30.1",
+		},
+		{
+			name:     "pre-release tag",
+			status:   http.StatusFound,
+			location: "https://github.com/kenn-io/agentsview/releases/tag/v0.9.0-rc1",
+			wantTag:  "v0.9.0-rc1",
+		},
+		{
+			name:       "200 OK is not a redirect",
+			status:     http.StatusOK,
+			wantErrSub: "expected redirect",
+		},
+		{
+			name:       "redirect target without /tag/",
+			status:     http.StatusFound,
+			location:   "https://github.com/kenn-io/agentsview/releases",
+			wantErrSub: "unexpected redirect target",
+		},
+		{
+			name:       "empty tag after /tag/",
+			status:     http.StatusFound,
+			location:   "https://github.com/kenn-io/agentsview/releases/tag/",
+			wantErrSub: "empty tag",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					if tt.location != "" {
+						w.Header().Set("Location", tt.location)
+					}
+					w.WriteHeader(tt.status)
+				},
+			))
+			defer srv.Close()
+
+			tag, err := resolveLatestTag(srv.URL)
+			if tt.wantErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTag, tag)
+		})
+	}
+}
+
+func TestFetchContentLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		bodySize   int
+		wantSize   int64
+		wantErrSub string
+	}{
+		{
+			name:     "200 with body",
+			status:   http.StatusOK,
+			bodySize: 1234,
+			wantSize: 1234,
+		},
+		{
+			name:       "404",
+			status:     http.StatusNotFound,
+			wantErrSub: "404",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					if tt.bodySize > 0 {
+						w.Header().Set(
+							"Content-Length",
+							fmt.Sprintf("%d", tt.bodySize),
+						)
+					}
+					w.WriteHeader(tt.status)
+				},
+			))
+			defer srv.Close()
+
+			size, err := fetchContentLength(srv.URL)
+			if tt.wantErrSub != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSize, size)
 		})
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,19 +54,25 @@ download() {
 }
 
 get_latest_version() {
-    local url="https://api.github.com/repos/${REPO}/releases/latest"
-    local json
+    # Use the HTML /releases/latest endpoint, which 302-redirects to
+    # /releases/tag/<version>. Unlike api.github.com it is not rate-limited
+    # at 60 req/hr per IP, so users behind shared NAT / VPN don't get 403.
+    local url="https://github.com/${REPO}/releases/latest"
+    local final_url=""
     if command -v curl &>/dev/null; then
-        json=$(curl -fsSL "$url")
+        final_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$url") || return 1
     elif command -v wget &>/dev/null; then
-        json=$(wget -qO- "$url")
+        final_url=$(wget --spider -S "$url" 2>&1 \
+            | awk 'tolower($1)=="location:" {print $2}' \
+            | tail -1 \
+            | tr -d '\r\n') || return 1
     else
         return 1
     fi
-    echo "$json" \
-        | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' \
-        | head -1 \
-        | cut -d'"' -f4
+    case "$final_url" in
+        */releases/tag/*) echo "${final_url##*/releases/tag/}" ;;
+        *) return 1 ;;
+    esac
 }
 
 verify_checksum() {

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -27,42 +27,46 @@ assert_eq() {
     fi
 }
 
-# Mock curl to return a fixture instead of hitting the network.
-# get_latest_version uses `curl -fsSL "$url"` so we intercept
-# that and emit $MOCK_JSON.
-MOCK_JSON=""
-curl() { printf '%s\n' "$MOCK_JSON"; }
+# Mock curl to simulate the redirect-follow behavior of the real install
+# script. get_latest_version uses `curl ... -w '%{url_effective}'` so we
+# intercept that and emit $MOCK_FINAL_URL (the URL after following 302s).
+MOCK_FINAL_URL=""
+MOCK_CURL_EXIT=0
+curl() {
+    if [ "$MOCK_CURL_EXIT" != "0" ]; then
+        return "$MOCK_CURL_EXIT"
+    fi
+    printf '%s' "$MOCK_FINAL_URL"
+}
 export -f curl
 
 echo "=== get_latest_version parsing ==="
 
-# Pretty-printed JSON (typical curl response)
-MOCK_JSON='{
-  "url": "https://api.github.com/repos/kenn-io/agentsview/releases/291105519",
-  "tag_name": "v0.8.0",
-  "name": "v0.8.0"
-}'
-assert_eq "pretty-printed JSON" "v0.8.0" "$(get_latest_version)"
+# Normal release tag
+MOCK_FINAL_URL="https://github.com/kenn-io/agentsview/releases/tag/v0.8.0"
+assert_eq "release tag" "v0.8.0" "$(get_latest_version)"
 
-# Minified JSON (the case that caused #61)
-MOCK_JSON='{"url":"https://api.github.com/repos/kenn-io/agentsview/releases/291105519","assets_url":"https://api.github.com/repos/kenn-io/agentsview/releases/291105519/assets","tag_name":"v0.8.0","name":"v0.8.0"}'
-assert_eq "minified JSON" "v0.8.0" "$(get_latest_version)"
-
-# tag_name before url field
-MOCK_JSON='{"tag_name":"v1.2.3","url":"https://api.github.com/repos/kenn-io/agentsview/releases/1"}'
-assert_eq "tag_name before url" "v1.2.3" "$(get_latest_version)"
-
-# Extra whitespace around colon
-MOCK_JSON='{  "tag_name" :  "v2.0.0"  }'
-assert_eq "extra whitespace" "v2.0.0" "$(get_latest_version)"
+# Newer release tag
+MOCK_FINAL_URL="https://github.com/kenn-io/agentsview/releases/tag/v0.30.1"
+assert_eq "two-digit minor" "v0.30.1" "$(get_latest_version)"
 
 # Pre-release version
-MOCK_JSON='{"tag_name":"v0.9.0-rc1","name":"v0.9.0-rc1"}'
+MOCK_FINAL_URL="https://github.com/kenn-io/agentsview/releases/tag/v0.9.0-rc1"
 assert_eq "pre-release version" "v0.9.0-rc1" "$(get_latest_version)"
 
-# No tag_name field (API error / rate limit)
-MOCK_JSON='{"message":"API rate limit exceeded"}'
-assert_eq "missing tag_name returns empty" "" "$(get_latest_version)"
+# No releases: GitHub returns the /releases page itself instead of a 302.
+MOCK_FINAL_URL="https://github.com/kenn-io/agentsview/releases"
+assert_eq "no releases returns empty" "" "$(get_latest_version || true)"
+
+# Redirect to latest sentinel (no follow / no tag in URL).
+MOCK_FINAL_URL="https://github.com/kenn-io/agentsview/releases/latest"
+assert_eq "unresolved latest returns empty" "" "$(get_latest_version || true)"
+
+# Network failure: curl exits non-zero, function should fail.
+MOCK_FINAL_URL=""
+MOCK_CURL_EXIT=22
+assert_eq "curl failure returns empty" "" "$(get_latest_version || true)"
+MOCK_CURL_EXIT=0
 
 echo
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Fixes #545. Both `install.sh` and the in-binary `agentsview update` command called `api.github.com/repos/.../releases/latest`, which GitHub rate-limits to 60 req/hr per IP for unauthenticated callers. Users behind shared NAT, VPN, or CGNAT exhaust that quota and see `curl: (22) ... 403` from the installer or `GitHub API returned 403` from the update command.

Both code paths now use the HTML `https://github.com/OWNER/REPO/releases/latest` endpoint, which 302-redirects to `/releases/tag/<tag>` and isn't subject to the same rate limit.

**`scripts/install.sh`** — `get_latest_version` uses `curl -fsSLI -w '%{url_effective}'` (or `wget --server-response`) and reads the redirect target. Tests in `scripts/install_test.sh` mock the new redirect flow.

**`internal/update/update.go`** — `resolveLatestTag` follows the redirect with `CheckRedirect: ErrUseLastResponse` and parses the Location header. Download and `SHA256SUMS` URLs are constructed from the tag. Asset size comes from a HEAD request (`fetchContentLength`) so the progress bar still shows a percentage. Drops the now-unused `Release`/`Asset` structs and the release-body checksum fallback; every release since GoReleaser was set up publishes `SHA256SUMS` as a release asset. New httptest-based tests cover both helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)