### PR TITLE
Improve header accessibility hints

### DIFF
--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -225,6 +225,24 @@
 </script>
 
 <div class="vital">
+  <header class="vital-titlebar">
+    <div>
+      <div class="vital-title">Analysis</div>
+      <div class="vital-subtitle">Session vital signs</div>
+    </div>
+    <button
+      type="button"
+      class="vital-close"
+      title="Close session analysis"
+      aria-label="Close session analysis"
+      onclick={() => ui.closeVitals()}
+    >
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+        <path d="M3.22 3.22a.75.75 0 011.06 0L8 6.94l3.72-3.72a.75.75 0 111.06 1.06L9.06 8l3.72 3.72a.75.75 0 11-1.06 1.06L8 9.06l-3.72 3.72a.75.75 0 11-1.06-1.06L6.94 8 3.22 4.28a.75.75 0 010-1.06z"/>
+      </svg>
+    </button>
+  </header>
+
   {#if timing}
     <section class="v-section">
       <header class="v-h">
@@ -495,6 +513,56 @@
     flex: 1;
     overflow-y: auto;
     min-height: 0;
+  }
+
+  .vital-titlebar {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    min-height: 42px;
+    padding: 7px 10px 7px 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-default);
+  }
+
+  .vital-title {
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 650;
+    line-height: 1.2;
+  }
+
+  .vital-subtitle {
+    color: var(--text-muted);
+    font-size: 10px;
+    line-height: 1.2;
+    margin-top: 1px;
+  }
+
+  .vital-close {
+    width: 26px;
+    height: 26px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    transition: background 0.12s, color 0.12s;
+  }
+
+  .vital-close:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .vital-close:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 2px;
   }
 
   .v-section {

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { mount, tick, unmount } from "svelte";
+import type { SessionTiming } from "../../api/types/timing.js";
+
+const mocks = vi.hoisted(() => {
+  const timing: SessionTiming = {
+    session_id: "sess-1",
+    total_duration_ms: 1200,
+    tool_duration_ms: 0,
+    turn_count: 1,
+    tool_call_count: 0,
+    subagent_count: 0,
+    slowest_call: null,
+    by_category: [],
+    turns: [],
+    running: false,
+  };
+
+  return {
+    fetchSessionTiming: vi.fn().mockResolvedValue(timing),
+  };
+});
+
+vi.mock("../../api/timing.js", () => ({
+  fetchSessionTiming: mocks.fetchSessionTiming,
+}));
+
+import { ui } from "../../stores/ui.svelte.js";
+import { sessionTiming } from "../../stores/sessionTiming.svelte.js";
+// @ts-ignore
+import SessionVitals from "./SessionVitals.svelte";
+
+describe("SessionVitals", () => {
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    sessionTiming.reset();
+    ui.vitalsOpen = true;
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = undefined;
+    }
+    sessionTiming.reset();
+    ui.vitalsOpen = false;
+    document.body.innerHTML = "";
+  });
+
+  it("has an obvious close control inside the analysis pane", async () => {
+    component = mount(SessionVitals, {
+      target: document.body,
+      props: { sessionId: "sess-1" },
+    });
+    await tick();
+    await tick();
+
+    const closeButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Close session analysis"]',
+    );
+
+    expect(closeButton).not.toBeNull();
+    expect(closeButton?.title).toBe("Close session analysis");
+
+    closeButton!.click();
+    await tick();
+
+    expect(ui.vitalsOpen).toBe(false);
+  });
+});

--- a/frontend/src/lib/components/filters/SessionFilterControl.svelte
+++ b/frontend/src/lib/components/filters/SessionFilterControl.svelte
@@ -125,6 +125,7 @@
   class="filter-btn"
   bind:this={filterBtnRef}
   onclick={() => (open = !open)}
+  title="Filter sessions"
   aria-label="Filters"
   aria-expanded={open}
 >

--- a/frontend/src/lib/components/import/ImportModal.svelte
+++ b/frontend/src/lib/components/import/ImportModal.svelte
@@ -217,6 +217,7 @@
           class="modal-close"
           onclick={handleClose}
           disabled={importing}
+          title="Close import dialog"
           aria-label="Close"
         >&times;</button>
       </div>

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -255,6 +255,7 @@
         class:active={router.route === "trends" || router.route === "pinned" || router.route === "insights" || router.route === "trash" || moreOpen}
         bind:this={moreBtnRef}
         onclick={() => { moreOpen = !moreOpen; }}
+        title="More navigation"
         aria-label="More navigation"
         aria-expanded={moreOpen}
       >
@@ -637,6 +638,7 @@
       class="header-btn"
       onclick={() => (ui.activeModal = "shortcuts")}
       title="Keyboard shortcuts (?)"
+      aria-label="Keyboard shortcuts"
     >
       ?
     </button>

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -99,4 +99,21 @@ describe("AppHeader export actions", () => {
     expect(ui.followLatest).toBe(false);
     expect(followButton!.classList.contains("active")).toBe(false);
   });
+
+  it("labels compact title-bar actions with hover hints", async () => {
+    component = mount(AppHeader, { target: document.body });
+    await tick();
+
+    const moreButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="More navigation"]',
+    );
+    const shortcutsButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Keyboard shortcuts"]',
+    );
+
+    expect(moreButton).not.toBeNull();
+    expect(moreButton?.title).toBe("More navigation");
+    expect(shortcutsButton).not.toBeNull();
+    expect(shortcutsButton?.title).toBe("Keyboard shortcuts (?)");
+  });
 });

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -601,9 +601,13 @@
         <button
           class="minimap-btn"
           class:minimap-btn--active={ui.vitalsOpen}
-          title="Session vital signs"
+          title={ui.vitalsOpen
+            ? "Hide session analysis"
+            : "Show session analysis"}
           onclick={() => ui.toggleVitals()}
-          aria-label="Toggle session vital signs"
+          aria-label={ui.vitalsOpen
+            ? "Hide session analysis"
+            : "Show session analysis"}
         >
           <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor">
             <path d="M1 14V8h2v6H1zm4 0V2h2v12H5zm4 0V5h2v9H9zm4 0V9h2v5h-2z"/>

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -388,7 +388,11 @@
 
 
 <div class="session-breadcrumb">
-  <button class="breadcrumb-link" onclick={onBack}>
+  <button
+    class="breadcrumb-link"
+    onclick={onBack}
+    title="Back to sessions"
+  >
     Sessions
   </button>
   <span class="breadcrumb-sep">/</span>
@@ -552,8 +556,9 @@
         {@const rawId = sessionDisplayId(session.id)}
         <button
           class="session-id"
-          title={rawId}
+          title="Copy session ID: {rawId}"
           onclick={() => copySessionId(rawId, session.id)}
+          aria-label="Copy session ID"
         >
           {copiedSessionId === session.id
             ? "Copied!"
@@ -618,6 +623,7 @@
         <button
           class="actions-btn"
           title="Session actions"
+          aria-label="Session actions"
           bind:this={menuBtnEl}
           onclick={toggleMenu}
         >

--- a/frontend/src/lib/components/modals/AboutModal.svelte
+++ b/frontend/src/lib/components/modals/AboutModal.svelte
@@ -49,6 +49,8 @@
       <button
         class="close-btn"
         onclick={() => ui.activeModal = null}
+        title="Close about dialog"
+        aria-label="Close about dialog"
       >
         &times;
       </button>

--- a/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
@@ -69,7 +69,12 @@
   <div class="confirm-modal">
     <div class="confirm-header">
       <h3 class="confirm-title">Delete Session</h3>
-      <button class="close-btn" onclick={close}>&times;</button>
+      <button
+        class="close-btn"
+        onclick={close}
+        title="Close delete confirmation"
+        aria-label="Close delete confirmation"
+      >&times;</button>
     </div>
 
     <div class="confirm-body">

--- a/frontend/src/lib/components/modals/PublishModal.svelte
+++ b/frontend/src/lib/components/modals/PublishModal.svelte
@@ -93,6 +93,8 @@
       <button
         class="modal-close"
         onclick={() => ui.activeModal = null}
+        title="Close publish dialog"
+        aria-label="Close publish dialog"
       >
         &times;
       </button>

--- a/frontend/src/lib/components/modals/ResyncModal.svelte
+++ b/frontend/src/lib/components/modals/ResyncModal.svelte
@@ -67,7 +67,12 @@
     <div class="modal-header">
       <h3 class="modal-title">Full Resync</h3>
       {#if view !== "progress"}
-        <button class="modal-close" onclick={close}>
+        <button
+          class="modal-close"
+          onclick={close}
+          title="Close resync dialog"
+          aria-label="Close resync dialog"
+        >
           &times;
         </button>
       {/if}

--- a/frontend/src/lib/components/modals/ShortcutsModal.svelte
+++ b/frontend/src/lib/components/modals/ShortcutsModal.svelte
@@ -59,6 +59,8 @@
       <button
         class="close-btn"
         onclick={() => ui.activeModal = null}
+        title="Close shortcuts"
+        aria-label="Close shortcuts"
       >
         &times;
       </button>

--- a/frontend/src/lib/components/modals/UpdateModal.svelte
+++ b/frontend/src/lib/components/modals/UpdateModal.svelte
@@ -32,7 +32,12 @@
   <div class="modal-panel update-panel">
     <div class="modal-header">
       <h3 class="modal-title">Software Update</h3>
-      <button class="modal-close" onclick={close}>
+      <button
+        class="modal-close"
+        onclick={close}
+        title="Close update dialog"
+        aria-label="Close update dialog"
+      >
         &times;
       </button>
     </div>

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -448,6 +448,8 @@
           <button
             class="group-header"
             onclick={() => toggleGroup(item.label)}
+            title="{collapsed.has(item.label) ? 'Expand' : 'Collapse'} {item.label} group"
+            aria-label="{collapsed.has(item.label) ? 'Expand' : 'Collapse'} {item.label} group"
           >
             <svg
               class="chevron"
@@ -485,6 +487,8 @@
             class="sub-group-header"
             style:padding-left="{8 + (item.depth ?? 1) * 16}px"
             onclick={() => toggleChainExpand(subKey)}
+            title="{subExpanded ? 'Collapse' : 'Expand'} Subagents group"
+            aria-label="{subExpanded ? 'Collapse' : 'Expand'} Subagents group"
           >
             <svg class="sub-group-arrow" class:expanded={subExpanded} width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"/></svg>
             <svg class="sub-group-icon" width="10" height="10" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -500,6 +504,8 @@
             class="sub-group-header"
             style:padding-left="{8 + (item.depth ?? 1) * 16}px"
             onclick={() => toggleChainExpand(teamKey)}
+            title="{teamExpanded ? 'Collapse' : 'Expand'} Team group"
+            aria-label="{teamExpanded ? 'Collapse' : 'Expand'} Team group"
           >
             <svg class="sub-group-arrow" class:expanded={teamExpanded} width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"/></svg>
             <svg class="sub-group-icon" width="12" height="10" viewBox="0 0 20 16" fill="currentColor" aria-hidden="true">

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -120,6 +120,19 @@ describe("SessionList filter dropdown", () => {
     );
     expect(sessionFilterControlSource).toContain("overflow-y: auto;");
   });
+
+  it("labels compact header controls with hover hints", async () => {
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    const filterButton = document.querySelector<HTMLButtonElement>(
+      ".filter-btn",
+    );
+
+    expect(filterButton).not.toBeNull();
+    expect(filterButton?.title).toBe("Filter sessions");
+    expect(filterButton?.getAttribute("aria-label")).toBe("Filters");
+  });
 });
 
 describe("SessionList visible hydration", () => {

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -459,6 +459,10 @@ class UIStore {
     this.vitalsOpen = !this.vitalsOpen;
   }
 
+  closeVitals() {
+    this.vitalsOpen = false;
+  }
+
   toggleSignalPanel() {
     this.signalPanelOpen = !this.signalPanelOpen;
   }


### PR DESCRIPTION
## Summary
- add missing hover/title hints and accessible labels to compact title-bar and modal controls
- add a sticky Analysis pane title bar with an explicit close button
- clarify the session analysis toggle label based on open/closed state

## Validation
- npm run check
- npm test -- AppHeader.test.ts SessionList.test.ts
- npm test -- SessionVitals.test.ts AppHeader.test.ts
- npm test
- git diff --check