### PR TITLE
Avoid auth prompt for forbidden settings responses

### DIFF
--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -20,7 +20,7 @@ class SettingsStore {
   loading: boolean = $state(false);
   saving: boolean = $state(false);
   error: string | null = $state(null);
-  /** True when the API returned 401/403, indicating the user needs
+  /** True when the API returned 401, indicating the user needs
    *  to provide an auth token before the app can load. */
   needsAuth: boolean = $state(false);
 
@@ -44,7 +44,7 @@ class SettingsStore {
         setAuthToken(data.auth_token);
       }
     } catch (e) {
-      if (e instanceof ApiError && (e.status === 401 || e.status === 403)) {
+      if (e instanceof ApiError && e.status === 401) {
         this.needsAuth = true;
       } else {
         this.error =

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -1,0 +1,61 @@
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { settings } from "./settings.svelte.js";
+import * as api from "../api/client.js";
+import { ApiError } from "../api/client.js";
+
+vi.mock("../api/client.js", async (importOriginal) => {
+  const orig =
+    await importOriginal<typeof import("../api/client.js")>();
+  return {
+    ...orig,
+    getSettings: vi.fn(),
+    updateSettings: vi.fn(),
+    setAuthToken: vi.fn(),
+    isRemoteConnection: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  settings.agentDirs = {};
+  settings.githubConfigured = false;
+  settings.terminal = { mode: "auto" };
+  settings.host = "";
+  settings.port = 0;
+  settings.authToken = "";
+  settings.requireAuth = false;
+  settings.loading = false;
+  settings.saving = false;
+  settings.error = null;
+  settings.needsAuth = false;
+});
+
+describe("SettingsStore.load auth handling", () => {
+  it("prompts for a token on 401 responses", async () => {
+    vi.mocked(api.getSettings).mockRejectedValue(
+      new ApiError(401, "Unauthorized"),
+    );
+
+    await settings.load();
+
+    expect(settings.needsAuth).toBe(true);
+    expect(settings.error).toBeNull();
+  });
+
+  it("does not prompt for a token on non-auth 403 responses", async () => {
+    vi.mocked(api.getSettings).mockRejectedValue(
+      new ApiError(403, "Forbidden"),
+    );
+
+    await settings.load();
+
+    expect(settings.needsAuth).toBe(false);
+    expect(settings.error).toBe("Forbidden");
+  });
+});


### PR DESCRIPTION
## Summary
- Treat only `401 Unauthorized` from settings load as a token-auth challenge.
- Surface `403 Forbidden` as a settings error instead of showing a misleading auth-token prompt.
- Add settings-store regression coverage for 401 vs 403 handling.

Related to #562 

## Test Plan
- [x] `npm test`
- [x] `npm run check`
