### PR TITLE
fix(pricing): ship claude-opus-4-8 fallback rates

### DIFF
--- a/internal/pricing/fallback.go
+++ b/internal/pricing/fallback.go
@@ -2,11 +2,11 @@ package pricing
 
 // FallbackVersion must be bumped whenever FallbackPricing
 // rates change so the startup seeder knows to re-upsert.
-const FallbackVersion = "2026-04-13"
+const FallbackVersion = "2026-05-28"
 
 // FallbackPricing returns hardcoded pricing for key Claude
 // models. Used when the LiteLLM fetch fails.
-// Prices in USD per million tokens, current as of 2026-04.
+// Prices in USD per million tokens, current as of 2026-05.
 func FallbackPricing() []ModelPricing {
 	return []ModelPricing{
 		// Current model names (used by Claude Code / Codex)
@@ -19,6 +19,16 @@ func FallbackPricing() []ModelPricing {
 		},
 		{
 			ModelPattern:         "claude-opus-4-6",
+			InputPerMTok:         5.0,
+			OutputPerMTok:        25.0,
+			CacheCreationPerMTok: 6.25,
+			CacheReadPerMTok:     0.50,
+		},
+		{
+			// Opus 4.8 launched at the Opus 4.6/4.7 rates and is
+			// not yet in the LiteLLM catalog, so it ships here so
+			// usage is priced until LiteLLM adds it.
+			ModelPattern:         "claude-opus-4-8",
 			InputPerMTok:         5.0,
 			OutputPerMTok:        25.0,
 			CacheCreationPerMTok: 6.25,

--- a/internal/pricing/fallback_test.go
+++ b/internal/pricing/fallback_test.go
@@ -28,3 +28,27 @@ func TestFallbackPricing_Opus46Rates(t *testing.T) {
 	}
 	assert.Equal(t, want, *got)
 }
+
+func TestFallbackPricing_Opus48Rates(t *testing.T) {
+	prices := FallbackPricing()
+	var got *ModelPricing
+	for i := range prices {
+		if prices[i].ModelPattern == "claude-opus-4-8" {
+			got = &prices[i]
+			break
+		}
+	}
+	require.NotNil(t, got, "claude-opus-4-8 entry missing from FallbackPricing")
+
+	// Opus 4.8 launched at the same rates as Opus 4.6/4.7 and is
+	// not yet in the LiteLLM catalog, so the shipped fallback must
+	// price it at the current Opus tier.
+	want := ModelPricing{
+		ModelPattern:         "claude-opus-4-8",
+		InputPerMTok:         5.0,
+		OutputPerMTok:        25.0,
+		CacheCreationPerMTok: 6.25,
+		CacheReadPerMTok:     0.50,
+	}
+	assert.Equal(t, want, *got)
+}

--- a/internal/pricing/litellm_test.go
+++ b/internal/pricing/litellm_test.go
@@ -97,6 +97,7 @@ func TestFallbackPricing(t *testing.T) {
 	required := map[string]bool{
 		"claude-sonnet-4-6":         false,
 		"claude-opus-4-6":           false,
+		"claude-opus-4-8":           false,
 		"claude-haiku-4-5-20251001": false,
 		"claude-sonnet-4-20250514":  false,
 		"claude-opus-4-20250514":    false,


### PR DESCRIPTION
Opus 4.8 launched at the same rates as Opus 4.6/4.7 ($5/$25 input/output, $6.25/$0.50 cache create/read) but is not yet in the LiteLLM catalog. The daily-usage cost lookup matches a message's model string exactly against the `model_pricing` table, so `claude-opus-4-8` rows fell through to zero rates and showed $0 in `usage daily`.

This adds a `claude-opus-4-8` entry to `FallbackPricing()` at the current Opus tier and bumps `FallbackVersion` (`2026-04-13` → `2026-05-28`) so the startup seeder re-upserts the fallback table. The async LiteLLM refresh leaves the row untouched because the upstream catalog has no `opus-4-8` key yet; it will take over automatically once LiteLLM adds one.

Verified against a copy of a real database: today's opus-4-8 usage reprices from $0 to $22.60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)