### PR TITLE
fix(ssh): stop benign tar warnings from aborting remote sync

### DIFF
--- a/internal/ssh/classify_test.go
+++ b/internal/ssh/classify_test.go
@@ -82,6 +82,20 @@ func TestRemoteTarStderrBenign(t *testing.T) {
 				"tar: Error exit delayed from previous errors.",
 			want: true,
 		},
+		{
+			// GNU tar uses a capital F here (create.c), unlike the
+			// lowercase "file changed as we read it".
+			name: "capitalized GNU file-removed warning is benign",
+			stderr: "tar: home/wes/.codex/x.json: " +
+				"File removed before we read it",
+			want: true,
+		},
+		{
+			name: "capitalized file-changed warning is benign",
+			stderr: "tar: home/wes/.claude/y.jsonl: " +
+				"File changed as we read it",
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/ssh/classify_test.go
+++ b/internal/ssh/classify_test.go
@@ -1,0 +1,97 @@
+package ssh
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteTarStderrBenign(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{
+			name: "file changed with delayed-exit fallout",
+			stderr: "tar: home/wes/.claude/x.jsonl: " +
+				"file changed as we read it\n" +
+				"tar: Exiting with failure status " +
+				"due to previous errors",
+			want: true,
+		},
+		{
+			name: "file removed before read",
+			stderr: "tar: home/wes/.codex/y.json: " +
+				"file removed before we read it",
+			want: true,
+		},
+		{
+			name: "permission denied is fatal",
+			stderr: "tar: home/wes/.claude: Cannot open: " +
+				"Permission denied\n" +
+				"tar: Exiting with failure status " +
+				"due to previous errors",
+			want: false,
+		},
+		{
+			name:   "remote truncation is fatal",
+			stderr: "tar: Unexpected EOF in archive",
+			want:   false,
+		},
+		{
+			name: "delayed-exit summary alone is not benign",
+			stderr: "tar: Exiting with failure status " +
+				"due to previous errors",
+			want: false,
+		},
+		{
+			name:   "empty stderr is not benign",
+			stderr: "",
+			want:   false,
+		},
+		{
+			name: "ssh connection failure is fatal",
+			stderr: "ssh: connect to host devbox port 22: " +
+				"Connection refused",
+			want: false,
+		},
+		{
+			name: "benign mixed with fatal stays fatal",
+			stderr: "tar: a: file changed as we read it\n" +
+				"tar: b: Cannot stat: No such file or directory",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &commandError{
+				Host:   "devbox",
+				Stderr: tt.stderr,
+				Err:    errors.New("exit status 1"),
+			}
+			assert.Equal(t, tt.want, remoteTarStderrBenign(err))
+		})
+	}
+}
+
+func TestRemoteTarStderrBenignNonCommandError(t *testing.T) {
+	// Anything that is not a classified SSH command failure must
+	// never be treated as benign.
+	assert.False(t, remoteTarStderrBenign(errors.New("boom")))
+	assert.False(t, remoteTarStderrBenign(nil))
+}
+
+func TestRemoteTarStderrBenignWrapped(t *testing.T) {
+	// The classifier must see through fmt.Errorf wrapping, since
+	// downloadAndExtract wraps cleanup errors as "ssh tar: %w".
+	base := &commandError{
+		Host:   "devbox",
+		Stderr: "tar: f: file changed as we read it",
+		Err:    errors.New("exit status 1"),
+	}
+	wrapped := fmt.Errorf("ssh tar: %w", base)
+	assert.True(t, remoteTarStderrBenign(wrapped))
+}

--- a/internal/ssh/classify_test.go
+++ b/internal/ssh/classify_test.go
@@ -64,6 +64,24 @@ func TestRemoteTarStderrBenign(t *testing.T) {
 				"tar: b: Cannot stat: No such file or directory",
 			want: false,
 		},
+		{
+			name: "benign phrase in path with real error stays fatal",
+			stderr: "tar: home/wes/file changed as we read it: " +
+				"Cannot open: Permission denied",
+			want: false,
+		},
+		{
+			name: "genuine warning on a path containing the phrase",
+			stderr: "tar: home/file changed as we read it: " +
+				"file changed as we read it",
+			want: true,
+		},
+		{
+			name: "bsd delayed-exit summary with trailing period",
+			stderr: "tar: x.jsonl: file changed as we read it\n" +
+				"tar: Error exit delayed from previous errors.",
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/ssh/extract.go
+++ b/internal/ssh/extract.go
@@ -66,7 +66,11 @@ func extractEntry(
 	case tar.TypeReg:
 		return false, writeRegular(target, tr, hdr)
 	case tar.TypeSymlink:
-		return false, writeSymlink(dst, target, hdr)
+		// Symlinks are not session data, and a symlink restored from
+		// an archive can redirect later writes outside the extraction
+		// dir. Any regular file a symlink might alias is extracted on
+		// its own, so skip symlinks entirely.
+		return false, nil
 	case tar.TypeLink:
 		return writeHardlink(dst, target, hdr)
 	default:
@@ -143,30 +147,13 @@ func writeRegular(
 			hdr.Name, n, hdr.Size,
 		)
 	}
-	return nil
-}
-
-// writeSymlink recreates a symlink only if its target stays within
-// dst; a link pointing outside the extraction dir is rejected so it
-// cannot be used to write through to the real filesystem.
-func writeSymlink(dst, target string, hdr *tar.Header) error {
-	link := hdr.Linkname
-	var resolved string
-	if filepath.IsAbs(link) {
-		resolved = filepath.Clean(link)
-	} else {
-		resolved = filepath.Join(filepath.Dir(target), link)
-	}
-	if !within(dst, resolved) {
-		return fmt.Errorf(
-			"symlink %q points outside extraction dir", hdr.Name,
-		)
-	}
-	if err := mkdirAll(filepath.Dir(target), hdr.Name); err != nil {
-		return err
-	}
-	if err := os.Symlink(link, target); err != nil {
-		return fmt.Errorf("symlink %q: %w", hdr.Name, err)
+	// Restore the archived mtime: the incremental skip cache keys on
+	// (path, mtime), so files must keep their remote mtime across
+	// syncs or nothing is ever skipped. Best-effort: a failure only
+	// forces a redundant resync, never data loss, so it must not
+	// discard an otherwise complete extraction.
+	if !hdr.ModTime.IsZero() {
+		_ = os.Chtimes(target, hdr.ModTime, hdr.ModTime)
 	}
 	return nil
 }

--- a/internal/ssh/extract.go
+++ b/internal/ssh/extract.go
@@ -1,0 +1,196 @@
+package ssh
+
+import (
+	"archive/tar"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	extractDirPerm  = 0o755
+	extractFilePerm = 0o644
+)
+
+// extractTarStream reads a tar stream from r and writes its entries
+// under dst. Extraction is fail-closed: it tolerates exactly one
+// anomaly, self-referential hardlinks (an entry whose link target is
+// itself, which macOS bsdtar emits for some Antigravity data and which
+// carries no content), and treats every other problem as fatal so a
+// truncated or corrupt transfer can never masquerade as a successful
+// sync. Unexpected EOF, bad headers, paths escaping dst, and
+// write/short-read errors all return an error. Returns the number of
+// self-referential hardlinks skipped.
+func extractTarStream(
+	ctx context.Context, r io.Reader, dst string,
+) (int, error) {
+	tr := tar.NewReader(r)
+	skipped := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return skipped, err
+		}
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return skipped, nil
+		}
+		if err != nil {
+			return skipped, fmt.Errorf("read tar entry: %w", err)
+		}
+		selfLink, err := extractEntry(tr, dst, hdr)
+		if err != nil {
+			return skipped, err
+		}
+		if selfLink {
+			skipped++
+		}
+	}
+}
+
+// extractEntry writes a single tar entry under dst. It reports whether
+// the entry was a self-referential hardlink (skipped, no error).
+func extractEntry(
+	tr *tar.Reader, dst string, hdr *tar.Header,
+) (bool, error) {
+	target, err := safeJoin(dst, hdr.Name)
+	if err != nil {
+		return false, err
+	}
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		return false, mkdirAll(target, hdr.Name)
+	case tar.TypeReg:
+		return false, writeRegular(target, tr, hdr)
+	case tar.TypeSymlink:
+		return false, writeSymlink(dst, target, hdr)
+	case tar.TypeLink:
+		return writeHardlink(dst, target, hdr)
+	default:
+		// Char/block/fifo and similar special files do not appear
+		// in agent session directories; there is no content to lose
+		// by ignoring them.
+		return false, nil
+	}
+}
+
+// safeJoin resolves name against dst and rejects any path that escapes
+// dst (via "..", an absolute component, or symlink-free traversal).
+func safeJoin(dst, name string) (string, error) {
+	target := filepath.Join(dst, filepath.FromSlash(name))
+	if !within(dst, target) {
+		return "", fmt.Errorf(
+			"tar entry %q escapes extraction dir", name,
+		)
+	}
+	return target, nil
+}
+
+// within reports whether p is dst itself or lies inside dst.
+func within(dst, p string) bool {
+	rel, err := filepath.Rel(dst, p)
+	if err != nil {
+		return false
+	}
+	if rel == ".." {
+		return false
+	}
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func mkdirAll(path, name string) error {
+	if err := os.MkdirAll(path, extractDirPerm); err != nil {
+		return fmt.Errorf("mkdir %q: %w", name, err)
+	}
+	return nil
+}
+
+// writeRegular extracts a regular file, failing on a short read so a
+// truncated stream cannot leave a half-written file behind. On any
+// failure the partial file is removed, so an aborted entry never looks
+// complete.
+func writeRegular(
+	target string, tr io.Reader, hdr *tar.Header,
+) (err error) {
+	if e := mkdirAll(filepath.Dir(target), hdr.Name); e != nil {
+		return e
+	}
+	f, e := os.OpenFile(
+		target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, extractFilePerm,
+	)
+	if e != nil {
+		return fmt.Errorf("create %q: %w", hdr.Name, e)
+	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(target)
+		}
+	}()
+	n, copyErr := io.Copy(f, tr)
+	closeErr := f.Close()
+	if copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		return fmt.Errorf("write %q: %w", hdr.Name, copyErr)
+	}
+	if n != hdr.Size {
+		return fmt.Errorf(
+			"short write %q: got %d of %d bytes",
+			hdr.Name, n, hdr.Size,
+		)
+	}
+	return nil
+}
+
+// writeSymlink recreates a symlink only if its target stays within
+// dst; a link pointing outside the extraction dir is rejected so it
+// cannot be used to write through to the real filesystem.
+func writeSymlink(dst, target string, hdr *tar.Header) error {
+	link := hdr.Linkname
+	var resolved string
+	if filepath.IsAbs(link) {
+		resolved = filepath.Clean(link)
+	} else {
+		resolved = filepath.Join(filepath.Dir(target), link)
+	}
+	if !within(dst, resolved) {
+		return fmt.Errorf(
+			"symlink %q points outside extraction dir", hdr.Name,
+		)
+	}
+	if err := mkdirAll(filepath.Dir(target), hdr.Name); err != nil {
+		return err
+	}
+	if err := os.Symlink(link, target); err != nil {
+		return fmt.Errorf("symlink %q: %w", hdr.Name, err)
+	}
+	return nil
+}
+
+// writeHardlink recreates a hardlink. A self-referential hardlink
+// (target equals the entry itself) carries no content and is skipped;
+// the bool return reports that case. Any other failure is fatal.
+func writeHardlink(
+	dst, target string, hdr *tar.Header,
+) (bool, error) {
+	linkTarget, err := safeJoin(dst, hdr.Linkname)
+	if err != nil {
+		return false, err
+	}
+	if linkTarget == target {
+		return true, nil
+	}
+	if err := mkdirAll(filepath.Dir(target), hdr.Name); err != nil {
+		return false, err
+	}
+	if err := os.Link(linkTarget, target); err != nil {
+		return false, fmt.Errorf(
+			"hardlink %q -> %q: %w", hdr.Name, hdr.Linkname, err,
+		)
+	}
+	return false, nil
+}

--- a/internal/ssh/extract_test.go
+++ b/internal/ssh/extract_test.go
@@ -246,3 +246,31 @@ func TestExtractTarStreamCreatesDirsAndFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "{}", string(body))
 }
+
+// TestExtractTarStreamExtractsLegacyRegularType guards against the
+// assumption that the extractor must special-case the deprecated
+// TypeRegA ('\x00') regular-file marker: tar.Reader.Next normalizes it
+// to TypeReg (or TypeDir) before we see the header, so an entry
+// authored as TypeRegA must still extract, not be silently skipped.
+func TestExtractTarStreamExtractsLegacyRegularType(t *testing.T) {
+	dst := t.TempDir()
+	body := []byte("legacy regular file")
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "home/wes/.codex/old.json",
+		Typeflag: tar.TypeRegA, //nolint:staticcheck // testing the deprecated marker
+		Mode:     0o644,
+		Size:     int64(len(body)),
+	}))
+	_, err := tw.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	_, err = extract(t, buf.Bytes(), dst)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(dst, "home/wes/.codex/old.json"))
+	require.NoError(t, err)
+	assert.Equal(t, string(body), string(got))
+}

--- a/internal/ssh/extract_test.go
+++ b/internal/ssh/extract_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,7 @@ type tarEntry struct {
 	typeflag byte
 	body     string
 	linkname string
+	modTime  time.Time
 }
 
 // buildTestTar serializes entries into an in-memory tar archive.
@@ -32,6 +34,7 @@ func buildTestTar(t *testing.T, entries []tarEntry) []byte {
 			Typeflag: e.typeflag,
 			Linkname: e.linkname,
 			Mode:     0o644,
+			ModTime:  e.modTime,
 		}
 		if e.typeflag == tar.TypeReg {
 			hdr.Size = int64(len(e.body))
@@ -136,32 +139,47 @@ func TestExtractTarStreamRejectsRelativePathEscape(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(filepath.Dir(dst), "escape.txt"))
 }
 
-func TestExtractTarStreamRejectsRelativeSymlinkEscape(t *testing.T) {
+func TestExtractTarStreamSkipsSymlinks(t *testing.T) {
 	dst := t.TempDir()
 	data := buildTestTar(t, []tarEntry{
+		{name: "home/target.txt", typeflag: tar.TypeReg, body: "data"},
+		// An in-tree link plus relative and absolute escapes: all
+		// are skipped, never created, so none can redirect a later
+		// write outside the extraction dir.
 		{
-			name:     "home/evil",
+			name:     "home/link.txt",
+			typeflag: tar.TypeSymlink,
+			linkname: "target.txt",
+		},
+		{
+			name:     "home/rel-escape",
 			typeflag: tar.TypeSymlink,
 			linkname: "../../../../etc",
 		},
-	})
-
-	_, err := extract(t, data, dst)
-	require.Error(t, err)
-}
-
-func TestExtractTarStreamRejectsAbsoluteSymlinkEscape(t *testing.T) {
-	dst := t.TempDir()
-	data := buildTestTar(t, []tarEntry{
 		{
-			name:     "home/evil",
+			name:     "home/abs-escape",
 			typeflag: tar.TypeSymlink,
 			linkname: "/etc/passwd",
 		},
 	})
 
 	_, err := extract(t, data, dst)
-	require.Error(t, err)
+	require.NoError(t, err)
+
+	// The regular file is still extracted.
+	body, err := os.ReadFile(filepath.Join(dst, "home/target.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "data", string(body))
+
+	// No symlink is created anywhere.
+	for _, name := range []string{
+		"home/link.txt", "home/rel-escape", "home/abs-escape",
+	} {
+		_, statErr := os.Lstat(filepath.Join(dst, name))
+		assert.True(
+			t, os.IsNotExist(statErr), "%s should be skipped", name,
+		)
+	}
 }
 
 func TestExtractTarStreamNormalHardlink(t *testing.T) {
@@ -180,24 +198,30 @@ func TestExtractTarStreamNormalHardlink(t *testing.T) {
 	assert.Equal(t, "shared", string(b))
 }
 
-func TestExtractTarStreamSymlinkWithinDst(t *testing.T) {
+func TestExtractTarStreamPreservesModTime(t *testing.T) {
 	dst := t.TempDir()
+	// The incremental skip cache keys on (path, mtime) and the sync
+	// engine treats it as authoritative, so extracted files must keep
+	// their archived mtime across syncs or nothing is ever skipped.
+	want := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
 	data := buildTestTar(t, []tarEntry{
-		{name: "home/target.txt", typeflag: tar.TypeReg, body: "data"},
 		{
-			name:     "home/link.txt",
-			typeflag: tar.TypeSymlink,
-			linkname: "target.txt",
+			name:     "home/wes/.claude/s.jsonl",
+			typeflag: tar.TypeReg,
+			body:     "session",
+			modTime:  want,
 		},
 	})
 
-	skipped, err := extract(t, data, dst)
+	_, err := extract(t, data, dst)
 	require.NoError(t, err)
-	assert.Equal(t, 0, skipped)
 
-	got, err := os.Readlink(filepath.Join(dst, "home/link.txt"))
+	info, err := os.Stat(filepath.Join(dst, "home/wes/.claude/s.jsonl"))
 	require.NoError(t, err)
-	assert.Equal(t, "target.txt", got)
+	assert.True(
+		t, info.ModTime().Equal(want),
+		"extracted mtime = %s, want %s", info.ModTime(), want,
+	)
 }
 
 func TestExtractTarStreamCreatesDirsAndFiles(t *testing.T) {

--- a/internal/ssh/extract_test.go
+++ b/internal/ssh/extract_test.go
@@ -1,0 +1,224 @@
+package ssh
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tarEntry describes one entry to write into a test tar archive.
+type tarEntry struct {
+	name     string
+	typeflag byte
+	body     string
+	linkname string
+}
+
+// buildTestTar serializes entries into an in-memory tar archive.
+func buildTestTar(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: e.typeflag,
+			Linkname: e.linkname,
+			Mode:     0o644,
+		}
+		if e.typeflag == tar.TypeReg {
+			hdr.Size = int64(len(e.body))
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		if e.typeflag == tar.TypeReg {
+			_, err := tw.Write([]byte(e.body))
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+	return buf.Bytes()
+}
+
+func extract(t *testing.T, data []byte, dst string) (int, error) {
+	t.Helper()
+	return extractTarStream(context.Background(), bytes.NewReader(data), dst)
+}
+
+func TestExtractTarStreamSkipsSelfHardlink(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{name: "home/wes/good.txt", typeflag: tar.TypeReg, body: "hello"},
+		// Self-referential hardlink: the Antigravity case bsdtar
+		// reports as "hardlink pointing to itself".
+		{
+			name:     "home/wes/loop.jsonl",
+			typeflag: tar.TypeLink,
+			linkname: "home/wes/loop.jsonl",
+		},
+		{name: "home/wes/after.txt", typeflag: tar.TypeReg, body: "world"},
+	})
+
+	skipped, err := extract(t, data, dst)
+	require.NoError(t, err)
+	assert.Equal(t, 1, skipped)
+
+	good, err := os.ReadFile(filepath.Join(dst, "home/wes/good.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(good))
+	after, err := os.ReadFile(filepath.Join(dst, "home/wes/after.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(after))
+
+	_, statErr := os.Lstat(filepath.Join(dst, "home/wes/loop.jsonl"))
+	assert.True(
+		t, os.IsNotExist(statErr),
+		"self-referential hardlink should not be created",
+	)
+}
+
+func TestExtractTarStreamTruncatedMidBodyFails(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{name: "home/a.txt", typeflag: tar.TypeReg, body: "aaa"},
+		{
+			name:     "home/big.txt",
+			typeflag: tar.TypeReg,
+			body:     strings.Repeat("x", 4096),
+		},
+	})
+	// First entry (1024B) intact; cut inside the second file's body.
+	truncated := data[:1024+512+100]
+
+	_, err := extract(t, truncated, dst)
+	require.Error(t, err, "truncated transfer must fail, not be accepted")
+	assert.NoFileExists(
+		t, filepath.Join(dst, "home/big.txt"),
+		"a truncated file must not be left as if complete",
+	)
+}
+
+func TestExtractTarStreamTruncatedMidHeaderFails(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{name: "home/a.txt", typeflag: tar.TypeReg, body: "aaa"},
+		{name: "home/b.txt", typeflag: tar.TypeReg, body: "bbb"},
+	})
+	// Keep first entry whole; cut partway through the second header.
+	truncated := data[:1024+200]
+
+	_, err := extract(t, truncated, dst)
+	require.Error(t, err)
+}
+
+func TestExtractTarStreamCorruptHeaderFails(t *testing.T) {
+	dst := t.TempDir()
+	garbage := bytes.Repeat([]byte("A"), 1024)
+
+	_, err := extract(t, garbage, dst)
+	require.Error(t, err, "corrupt/unrecognized archive must fail")
+}
+
+func TestExtractTarStreamRejectsRelativePathEscape(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{name: "../escape.txt", typeflag: tar.TypeReg, body: "pwned"},
+	})
+
+	_, err := extract(t, data, dst)
+	require.Error(t, err)
+	assert.NoFileExists(t, filepath.Join(filepath.Dir(dst), "escape.txt"))
+}
+
+func TestExtractTarStreamRejectsRelativeSymlinkEscape(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{
+			name:     "home/evil",
+			typeflag: tar.TypeSymlink,
+			linkname: "../../../../etc",
+		},
+	})
+
+	_, err := extract(t, data, dst)
+	require.Error(t, err)
+}
+
+func TestExtractTarStreamRejectsAbsoluteSymlinkEscape(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{
+			name:     "home/evil",
+			typeflag: tar.TypeSymlink,
+			linkname: "/etc/passwd",
+		},
+	})
+
+	_, err := extract(t, data, dst)
+	require.Error(t, err)
+}
+
+func TestExtractTarStreamNormalHardlink(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{name: "home/a.txt", typeflag: tar.TypeReg, body: "shared"},
+		{name: "home/b.txt", typeflag: tar.TypeLink, linkname: "home/a.txt"},
+	})
+
+	skipped, err := extract(t, data, dst)
+	require.NoError(t, err)
+	assert.Equal(t, 0, skipped)
+
+	b, err := os.ReadFile(filepath.Join(dst, "home/b.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "shared", string(b))
+}
+
+func TestExtractTarStreamSymlinkWithinDst(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{name: "home/target.txt", typeflag: tar.TypeReg, body: "data"},
+		{
+			name:     "home/link.txt",
+			typeflag: tar.TypeSymlink,
+			linkname: "target.txt",
+		},
+	})
+
+	skipped, err := extract(t, data, dst)
+	require.NoError(t, err)
+	assert.Equal(t, 0, skipped)
+
+	got, err := os.Readlink(filepath.Join(dst, "home/link.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "target.txt", got)
+}
+
+func TestExtractTarStreamCreatesDirsAndFiles(t *testing.T) {
+	dst := t.TempDir()
+	data := buildTestTar(t, []tarEntry{
+		{name: "home/wes/.claude/", typeflag: tar.TypeDir},
+		{
+			name:     "home/wes/.claude/s.jsonl",
+			typeflag: tar.TypeReg,
+			body:     "{}",
+		},
+	})
+
+	skipped, err := extract(t, data, dst)
+	require.NoError(t, err)
+	assert.Equal(t, 0, skipped)
+
+	info, err := os.Stat(filepath.Join(dst, "home/wes/.claude"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+	body, err := os.ReadFile(filepath.Join(dst, "home/wes/.claude/s.jsonl"))
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(body))
+}

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -88,17 +88,32 @@ func runSSHStream(
 
 	cleanup := func() error {
 		if waitErr := c.Wait(); waitErr != nil {
-			msg := strings.TrimSpace(stderr.String())
-			if msg == "" {
-				return fmt.Errorf(
-					"ssh %s: %w", host, waitErr,
-				)
+			return &commandError{
+				Host:   host,
+				Stderr: strings.TrimSpace(stderr.String()),
+				Err:    waitErr,
 			}
-			return fmt.Errorf(
-				"ssh %s: %w: %s", host, waitErr, msg,
-			)
 		}
 		return nil
 	}
 	return stdout, cleanup, nil
 }
+
+// commandError reports a streamed SSH command that exited non-zero. It
+// carries the captured remote stderr so callers can tell benign tar
+// warnings (e.g. "file changed as we read it") apart from fatal
+// failures via remoteTarStderrBenign.
+type commandError struct {
+	Host   string
+	Stderr string
+	Err    error
+}
+
+func (e *commandError) Error() string {
+	if e.Stderr == "" {
+		return fmt.Sprintf("ssh %s: %v", e.Host, e.Err)
+	}
+	return fmt.Sprintf("ssh %s: %v: %s", e.Host, e.Err, e.Stderr)
+}
+
+func (e *commandError) Unwrap() error { return e.Err }

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -180,7 +180,8 @@ func remappedDir(tempDir, remoteDir string) string {
 // benignRemoteTarPrimary are remote tar (creation-side) stderr
 // messages we treat as non-fatal: a file mutated or vanished while it
 // was being archived. The resulting archive is still well-formed, and
-// the local extractor independently validates its integrity.
+// the local extractor independently validates its integrity. Stored
+// lowercase; matched case-insensitively against a lowercased line.
 var benignRemoteTarPrimary = []string{
 	"file changed as we read it",
 	"file removed before we read it",
@@ -188,10 +189,10 @@ var benignRemoteTarPrimary = []string{
 
 // benignRemoteTarFallout are the summary lines tar prints after a
 // non-zero exit. They are tolerated only alongside a primary benign
-// warning, never on their own.
+// warning, never on their own. Stored lowercase (see above).
 var benignRemoteTarFallout = []string{
-	"Exiting with failure status due to previous errors", // GNU tar
-	"Error exit delayed from previous errors",            // bsdtar
+	"exiting with failure status due to previous errors", // GNU tar
+	"error exit delayed from previous errors",            // bsdtar
 }
 
 // remoteTarStderrBenign reports whether a non-nil cleanup() error from
@@ -208,7 +209,13 @@ func remoteTarStderrBenign(err error) bool {
 	}
 	sawPrimary := false
 	for line := range strings.SplitSeq(ce.Stderr, "\n") {
-		line = strings.TrimRight(strings.TrimSpace(line), ". ")
+		// Lowercase for case-insensitive matching: GNU tar is
+		// inconsistent about capitalization (create.c emits
+		// "File removed before we read it" with a capital F but
+		// "file changed as we read it" lowercase).
+		line = strings.ToLower(
+			strings.TrimRight(strings.TrimSpace(line), ". "),
+		)
 		switch {
 		case line == "":
 			continue

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -208,14 +208,14 @@ func remoteTarStderrBenign(err error) bool {
 	}
 	sawPrimary := false
 	for line := range strings.SplitSeq(ce.Stderr, "\n") {
-		line = strings.TrimSpace(line)
+		line = strings.TrimRight(strings.TrimSpace(line), ". ")
 		switch {
 		case line == "":
 			continue
-		case lineContainsAny(line, benignRemoteTarPrimary):
+		case hasBenignPrimary(line):
 			sawPrimary = true
-		case lineContainsAny(line, benignRemoteTarFallout):
-			// Tolerated only as attached fallout.
+		case hasBenignFallout(line):
+			// Summary line: tolerated only as attached fallout.
 		default:
 			return false
 		}
@@ -223,9 +223,27 @@ func remoteTarStderrBenign(err error) bool {
 	return sawPrimary
 }
 
-func lineContainsAny(line string, subs []string) bool {
-	for _, sub := range subs {
-		if strings.Contains(line, sub) {
+// hasBenignPrimary reports whether line is a per-file remote tar
+// warning about a file mutating or vanishing mid-archive. tar formats
+// these as "<path>: <message>", so the phrase is matched as a suffix
+// after the ": " separator. Matching it anywhere in the line would let
+// a benign phrase embedded in a file path mask a real error reported
+// for that same path (e.g. ".../file changed as we read it: Cannot
+// open: Permission denied").
+func hasBenignPrimary(line string) bool {
+	for _, phrase := range benignRemoteTarPrimary {
+		if strings.HasSuffix(line, ": "+phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasBenignFallout reports whether line is a tar end-of-run summary,
+// which tar prints with no leading path.
+func hasBenignFallout(line string) bool {
+	for _, phrase := range benignRemoteTarFallout {
+		if strings.HasSuffix(line, phrase) {
 			return true
 		}
 	}

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -2,10 +2,10 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -64,12 +64,7 @@ func downloadAndExtract(
 	done := make(chan struct{})
 	go pr.printLoop(done)
 
-	extract := exec.CommandContext(
-		ctx, "tar", "xf", "-", "-C", tmpDir,
-	)
-	extract.Stdin = pr
-
-	extractErr := extract.Run()
+	skipped, extractErr := extractTarStream(ctx, pr, tmpDir)
 	close(done)
 	pr.printFinal()
 
@@ -79,13 +74,26 @@ func downloadAndExtract(
 		_ = cleanup()
 		return "", fmt.Errorf("extract tar: %w", extractErr)
 	}
+	if skipped > 0 {
+		fmt.Printf(
+			"  Skipped %d self-referential hardlink(s).\n",
+			skipped,
+		)
+	}
 
-	// stdout is consumed by tar; close it so the SSH
-	// process can exit cleanly.
+	// stdout is consumed by the extractor; close it so the SSH
+	// process can exit cleanly. A non-zero remote tar exit is
+	// fatal unless its stderr shows only benign warnings (files
+	// changing or vanishing as the remote read them).
 	stdout.Close()
 	if err := cleanup(); err != nil {
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("ssh tar: %w", err)
+		if !remoteTarStderrBenign(err) {
+			os.RemoveAll(tmpDir)
+			return "", fmt.Errorf("ssh tar: %w", err)
+		}
+		fmt.Printf(
+			"  Remote tar reported benign warnings; continuing.\n",
+		)
 	}
 	return tmpDir, nil
 }
@@ -167,4 +175,59 @@ func remappedDir(tempDir, remoteDir string) string {
 	return filepath.Join(
 		tempDir, strings.TrimPrefix(remoteDir, "/"),
 	)
+}
+
+// benignRemoteTarPrimary are remote tar (creation-side) stderr
+// messages we treat as non-fatal: a file mutated or vanished while it
+// was being archived. The resulting archive is still well-formed, and
+// the local extractor independently validates its integrity.
+var benignRemoteTarPrimary = []string{
+	"file changed as we read it",
+	"file removed before we read it",
+}
+
+// benignRemoteTarFallout are the summary lines tar prints after a
+// non-zero exit. They are tolerated only alongside a primary benign
+// warning, never on their own.
+var benignRemoteTarFallout = []string{
+	"Exiting with failure status due to previous errors", // GNU tar
+	"Error exit delayed from previous errors",            // bsdtar
+}
+
+// remoteTarStderrBenign reports whether a non-nil cleanup() error from
+// the remote tar stream is safe to ignore. It is fail-closed: it
+// returns true only for a *commandError whose every stderr line is a
+// known-benign warning and which includes at least one primary
+// warning. Truncation, corrupt archives, permission errors, and
+// SSH-level failures are never benign, so they can never be persisted
+// to the skip cache as a successful sync.
+func remoteTarStderrBenign(err error) bool {
+	var ce *commandError
+	if !errors.As(err, &ce) {
+		return false
+	}
+	sawPrimary := false
+	for line := range strings.SplitSeq(ce.Stderr, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "":
+			continue
+		case lineContainsAny(line, benignRemoteTarPrimary):
+			sawPrimary = true
+		case lineContainsAny(line, benignRemoteTarFallout):
+			// Tolerated only as attached fallout.
+		default:
+			return false
+		}
+	}
+	return sawPrimary
+}
+
+func lineContainsAny(line string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(line, sub) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Remote sync streamed `tar cf` over SSH into `tar xf -` and treated any non-zero exit from either tar as fatal, deleting the extracted temp directory. macOS bsdtar exits 1 on self-referential hardlinks (Antigravity `.system_generated` logs) while still extracting everything else, so an entire multi-GB sync was discarded over skipped junk files. The remote `tar cf` exits 1 the same way for "file changed as we read it", aborting through `cleanup()`/`Wait()`.

Exit code 1 is not a safe warning boundary: bsdtar also returns 1 for truncated and corrupt archives. Tolerating exit 1 would persist partial transfers as successful syncs and poison the mtime skip cache, which the sync engine treats as authoritative.

- Replace the local `tar xf` with a stdlib `archive/tar` extractor (`internal/ssh/extract.go`) that skips only self-referential hardlinks and fails on unexpected EOF, malformed headers, paths escaping the temp dir, escaping symlinks, and short writes; partial files are removed on error.
- Carry the remote tar exit and its stderr in a typed `commandError` and classify it (`remoteTarStderrBenign`): a non-zero remote exit is tolerated only when every stderr line is "file changed"/"file removed as we read it" plus the delayed-exit summary as attached fallout. Everything else stays fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)