### PR TITLE
feat(pricing): ship claude-opus-4-7 fallback rates

### DIFF
--- a/internal/pricing/fallback.go
+++ b/internal/pricing/fallback.go
@@ -2,7 +2,7 @@ package pricing
 
 // FallbackVersion must be bumped whenever FallbackPricing
 // rates change so the startup seeder knows to re-upsert.
-const FallbackVersion = "2026-05-29"
+const FallbackVersion = "2026-05-30"
 
 // FallbackPricing returns hardcoded pricing for key Claude
 // models. Used when the LiteLLM fetch fails.
@@ -19,6 +19,13 @@ func FallbackPricing() []ModelPricing {
 		},
 		{
 			ModelPattern:         "claude-opus-4-6",
+			InputPerMTok:         5.0,
+			OutputPerMTok:        25.0,
+			CacheCreationPerMTok: 6.25,
+			CacheReadPerMTok:     0.50,
+		},
+		{
+			ModelPattern:         "claude-opus-4-7",
 			InputPerMTok:         5.0,
 			OutputPerMTok:        25.0,
 			CacheCreationPerMTok: 6.25,

--- a/internal/pricing/fallback_test.go
+++ b/internal/pricing/fallback_test.go
@@ -29,6 +29,30 @@ func TestFallbackPricing_Opus46Rates(t *testing.T) {
 	assert.Equal(t, want, *got)
 }
 
+func TestFallbackPricing_Opus47Rates(t *testing.T) {
+	prices := FallbackPricing()
+	var got *ModelPricing
+	for i := range prices {
+		if prices[i].ModelPattern == "claude-opus-4-7" {
+			got = &prices[i]
+			break
+		}
+	}
+	require.NotNil(t, got, "claude-opus-4-7 entry missing from FallbackPricing")
+
+	// Opus 4.7 shares the Opus 4.6/4.8 tier. LiteLLM already lists
+	// it, but the fallback ships it too so offline and fresh-seed
+	// pricing covers the whole current Opus generation.
+	want := ModelPricing{
+		ModelPattern:         "claude-opus-4-7",
+		InputPerMTok:         5.0,
+		OutputPerMTok:        25.0,
+		CacheCreationPerMTok: 6.25,
+		CacheReadPerMTok:     0.50,
+	}
+	assert.Equal(t, want, *got)
+}
+
 func TestFallbackPricing_Opus48Rates(t *testing.T) {
 	prices := FallbackPricing()
 	var got *ModelPricing

--- a/internal/pricing/litellm_test.go
+++ b/internal/pricing/litellm_test.go
@@ -97,6 +97,7 @@ func TestFallbackPricing(t *testing.T) {
 	required := map[string]bool{
 		"claude-sonnet-4-6":         false,
 		"claude-opus-4-6":           false,
+		"claude-opus-4-7":           false,
 		"claude-opus-4-8":           false,
 		"claude-haiku-4-5-20251001": false,
 		"claude-sonnet-4-20250514":  false,


### PR DESCRIPTION
Follow-up to #565 (opus-4-8). The shipped fallback table had `claude-opus-4-6` and `claude-opus-4-8` but not `claude-opus-4-7`, so offline runs (`usage daily --offline`) and fresh-seed installs left 4.7 unpriced even though it sits at the same tier ($5/$25 input/output, $6.25/$0.50 cache create/read). LiteLLM already lists 4.7, so online users were unaffected; this closes the offline gap.

Adds a `claude-opus-4-7` entry and bumps `FallbackVersion` so the startup seeder re-upserts the fallback table, giving the current Opus generation (4.6/4.7/4.8) uniform offline coverage.

Verified by wiping `model_pricing` on a copy of a real database and running `--offline`: 4.6, 4.7, and 4.8 all price from the fallback alone (4.7 was $0 before this change in that scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)