### PR TITLE
fix: rename frontend package to agentsview-frontend

### DIFF
--- a/cmd/agentsview/sync_profile.go
+++ b/cmd/agentsview/sync_profile.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
+	"slices"
 )
 
 // startSyncProfile starts whichever of the hidden --cpuprofile,
@@ -75,8 +76,8 @@ func startSyncProfile(cfg SyncConfig) func() {
 	return func() {
 		// Stop in reverse order so trace.Stop runs before file
 		// close.
-		for i := len(stoppers) - 1; i >= 0; i-- {
-			stoppers[i]()
+		for _, stop := range slices.Backward(stoppers) {
+			stop()
 		}
 	}
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "agent-session-viewer-frontend",
+  "name": "agentsview-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent-session-viewer-frontend",
+      "name": "agentsview-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@lucide/svelte": "1.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-session-viewer-frontend",
+  "name": "agentsview-frontend",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -204,8 +204,6 @@ func testDB(t *testing.T) *DB {
 }
 
 // Ptr returns a pointer to v.
-//
-//go:fix inline
 func Ptr[T any](v T) *T { return new(v) }
 
 // insertSession creates and upserts a session with sensible

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -13,8 +13,6 @@ import (
 )
 
 // Ptr returns a pointer to v.
-//
-//go:fix inline
 func Ptr[T any](v T) *T { return new(v) }
 
 // WriteTestFile creates a file at path with the given content,


### PR DESCRIPTION
The frontend npm package was still named `agent-session-viewer-frontend`,
the project's old working name. This renames it to `agentsview-frontend` in
`package.json` and `package-lock.json` so the name matches the rest of the
project (the Go module is already `go.kenn.io/agentsview`). The package is
private and referenced nowhere else, so this is an identity-only change. No
other occurrences of the old name remain in the repo.

It also clears two pre-existing `golangci-lint` failures that blocked the
pre-commit hook:

- Removed the `//go:fix inline` directive from the generic `Ptr[T]` test
  helpers in `internal/db` and `internal/dbtest`. The Go fix inliner cannot
  inline generic calls ("type parameter inference is not yet supported"), so
  every `Ptr(...)` call site raised a `govet` error.
- Rewrote the reverse loop in `cmd/agentsview/sync_profile.go` to use
  `slices.Backward`.

`golangci-lint run ./...` now reports no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)