### PR TITLE
Add per-session usage REST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ agentsview session usage <id>
 agentsview session usage <id> --format json
 ```
 
+The same per-session usage data is available from the REST API:
+
+```bash
+GET /api/v1/sessions/{id}/usage
+```
+
+The response includes the `session_id`, `agent`, `project`,
+`total_output_tokens`, `peak_context_tokens`, `has_token_data`, `cost_usd`,
+`has_cost`, `models`, and `unpriced_models` fields from the CLI JSON schema.
+HTTP responses also include `server_running: true`. Existing sessions return
+`200` even when token or cost data is absent; missing sessions return `404`.
+
 The deprecated alias `agentsview token-use <id>` remains available for
 compatibility and now also reports cost estimates.
 

--- a/cmd/agentsview/session_usage_test.go
+++ b/cmd/agentsview/session_usage_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -54,4 +55,41 @@ func TestRenderSessionUsageHuman_NoCost(t *testing.T) {
 	assert.NotContains(t, s, "$", "no-cost output should not contain '$'")
 	assert.Contains(t, s, "local-llama-99",
 		"output should note unpriced model")
+}
+
+func TestSessionUsageJSONSchemaIncludesCostContract(t *testing.T) {
+	out := &sessionUsageOutput{
+		SessionUsage: db.SessionUsage{
+			SessionID:         "codex:abc",
+			Agent:             "codex",
+			Project:           "my-project",
+			TotalOutputTokens: 123,
+			PeakContextTokens: 456,
+			HasTokenData:      true,
+			CostUSD:           0.42,
+			HasCost:           true,
+			Models:            []string{"gpt-5.1"},
+			UnpricedModels:    []string{"local-model"},
+		},
+		ServerRunning: true,
+	}
+
+	data, err := json.Marshal(out)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.Equal(t, map[string]any{
+		"session_id":          "codex:abc",
+		"agent":               "codex",
+		"project":             "my-project",
+		"total_output_tokens": float64(123),
+		"peak_context_tokens": float64(456),
+		"has_token_data":      true,
+		"cost_usd":            0.42,
+		"has_cost":            true,
+		"models":              []any{"gpt-5.1"},
+		"unpriced_models":     []any{"local-model"},
+		"server_running":      true,
+	}, raw)
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -68,6 +68,7 @@ type Store interface {
 	GetDailyUsage(ctx context.Context, f UsageFilter) (DailyUsageResult, error)
 	GetTopSessionsByCost(ctx context.Context, f UsageFilter, limit int) ([]TopSessionEntry, error)
 	GetUsageSessionCounts(ctx context.Context, f UsageFilter) (UsageSessionCounts, error)
+	GetSessionUsage(ctx context.Context, sessionID string) (*SessionUsage, error)
 
 	// Stars.
 	StarSession(sessionID string) (bool, error)

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -280,6 +280,40 @@ func pgUsageAmounts(
 	return
 }
 
+func pgSessionRowCost(
+	r pgUsageScanRow, pricing map[string]modelRates,
+) (cost float64, priced, contributes bool) {
+	var inTok, outTok, crTok, rdTok int
+	if r.usageSource == "message" {
+		usage := gjson.Parse(r.tokenJSON)
+		inTok = int(usage.Get("input_tokens").Int())
+		outTok = int(usage.Get("output_tokens").Int())
+		crTok = int(usage.Get("cache_creation_input_tokens").Int())
+		rdTok = int(usage.Get("cache_read_input_tokens").Int())
+	} else {
+		inTok = r.inputTokens
+		outTok = r.outputTokens
+		crTok = r.cacheCreationInputTokens
+		rdTok = r.cacheReadInputTokens
+	}
+
+	if r.costUSD.Valid {
+		return r.costUSD.Float64, true, true
+	}
+	if inTok == 0 && outTok == 0 && crTok == 0 && rdTok == 0 {
+		return 0, true, false
+	}
+	rates, ok := pricing[r.model]
+	if !ok {
+		return 0, false, true
+	}
+	cost = (float64(inTok)*rates.input +
+		float64(outTok)*rates.output +
+		float64(crTok)*rates.cacheCreation +
+		float64(rdTok)*rates.cacheRead) / 1_000_000
+	return cost, true, true
+}
+
 func usageDate(ts sql.NullTime, loc *time.Location) string {
 	if !ts.Valid {
 		return ""
@@ -292,6 +326,118 @@ func startedAtString(ts sql.NullTime) string {
 		return ""
 	}
 	return FormatISO8601(ts.Time)
+}
+
+// GetSessionUsage returns one session's token totals and cost
+// estimate from the PostgreSQL session store.
+func (s *Store) GetSessionUsage(
+	ctx context.Context, sessionID string,
+) (*db.SessionUsage, error) {
+	sess, err := s.GetSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if sess == nil {
+		return nil, nil
+	}
+
+	pricing, err := s.loadPricingMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading pg pricing: %w", err)
+	}
+
+	pb := &paramBuilder{}
+	query := pgUsageRowSelect() + " AND u.session_id = " +
+		pb.add(sessionID) + ` ORDER BY u.ts ASC, u.session_id ASC,
+		COALESCE(u.message_ordinal, -1) ASC`
+	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying pg session usage: %w", err)
+	}
+	defer rows.Close()
+
+	var cost float64
+	contributing := false
+	allPriced := true
+	modelsSet := make(map[string]struct{})
+	unpricedSet := make(map[string]struct{})
+
+	type dedupKey struct {
+		msgID string
+		reqID string
+	}
+	seen := make(map[dedupKey]struct{})
+
+	for rows.Next() {
+		r, scanErr := scanPGUsageRow(rows)
+		if scanErr != nil {
+			return nil,
+				fmt.Errorf("scanning pg session usage row: %w", scanErr)
+		}
+		if r.claudeMessageID != "" && r.claudeRequestID != "" {
+			key := dedupKey{
+				msgID: r.claudeMessageID,
+				reqID: r.claudeRequestID,
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+		} else if r.usageDedupKey != "" {
+			key := dedupKey{
+				msgID: "usage",
+				reqID: r.usageDedupKey,
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+
+		c, priced, contributes := pgSessionRowCost(r, pricing)
+		if !contributes {
+			continue
+		}
+		contributing = true
+		modelsSet[r.model] = struct{}{}
+		if priced {
+			cost += c
+		} else {
+			allPriced = false
+			unpricedSet[r.model] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating pg session usage rows: %w", err)
+	}
+
+	out := &db.SessionUsage{
+		SessionID:         sess.ID,
+		Agent:             sess.Agent,
+		Project:           sess.Project,
+		TotalOutputTokens: sess.TotalOutputTokens,
+		PeakContextTokens: sess.PeakContextTokens,
+		HasTokenData: sess.HasTotalOutputTokens ||
+			sess.HasPeakContextTokens,
+		Models:  sortedStringSetKeys(modelsSet),
+		HasCost: contributing && allPriced,
+	}
+	if out.HasCost {
+		out.CostUSD = cost
+	}
+	if len(unpricedSet) > 0 {
+		out.UnpricedModels = sortedStringSetKeys(unpricedSet)
+	}
+	return out, nil
+}
+
+func sortedStringSetKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // GetDailyUsage returns token usage and cost aggregated by day.

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -123,6 +123,90 @@ func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
 	assert.Greater(t, day.TotalCost, 0.0)
 }
 
+func TestStoreGetSessionUsagePricedModel(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_session_usage_priced_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('gpt-5.1', 3, 15, 3.75, 0.30, 'seed')`)
+	require.NoError(t, err, "insert pricing")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count,
+			total_output_tokens, peak_context_tokens,
+			has_total_output_tokens, has_peak_context_tokens
+		) VALUES (
+			'codex:usage-priced', 'test-machine', 'my-project', 'codex',
+			'2026-03-12T10:00:00Z'::timestamptz, 2, 1,
+			1234, 56789, true, true
+		)`)
+	require.NoError(t, err, "insert session")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES (
+			'codex:usage-priced', 1, 'assistant', 'done',
+			'2026-03-12T10:01:00Z'::timestamptz, 4,
+			'gpt-5.1',
+			'{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":200,"cache_read_input_tokens":300}'
+		)`)
+	require.NoError(t, err, "insert message")
+
+	got, err := store.GetSessionUsage(ctx, "codex:usage-priced")
+	require.NoError(t, err, "GetSessionUsage")
+	require.NotNil(t, got, "GetSessionUsage result")
+	assert.Equal(t, "codex:usage-priced", got.SessionID)
+	assert.Equal(t, "codex", got.Agent)
+	assert.Equal(t, "my-project", got.Project)
+	assert.Equal(t, 1234, got.TotalOutputTokens)
+	assert.Equal(t, 56789, got.PeakContextTokens)
+	assert.True(t, got.HasTokenData)
+	assert.True(t, got.HasCost)
+	assert.InDelta(t, 0.01134, got.CostUSD, 1e-9)
+	assert.Equal(t, []string{"gpt-5.1"}, got.Models)
+	assert.Empty(t, got.UnpricedModels)
+}
+
+func TestStoreGetSessionUsageNoTokenRowsKeepsMetadata(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_session_usage_empty_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES (
+			'codex:usage-empty', 'test-machine', 'quiet-project', 'codex',
+			'2026-03-12T10:00:00Z'::timestamptz, 1, 1
+		)`)
+	require.NoError(t, err, "insert session")
+
+	got, err := store.GetSessionUsage(ctx, "codex:usage-empty")
+	require.NoError(t, err, "GetSessionUsage")
+	require.NotNil(t, got, "GetSessionUsage result")
+	assert.Equal(t, "codex:usage-empty", got.SessionID)
+	assert.Equal(t, "codex", got.Agent)
+	assert.Equal(t, "quiet-project", got.Project)
+	assert.False(t, got.HasTokenData)
+	assert.False(t, got.HasCost)
+	assert.Zero(t, got.CostUSD)
+	assert.Empty(t, got.Models)
+	assert.Empty(t, got.UnpricedModels)
+}
+
+func TestStoreGetSessionUsageNotFound(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_session_usage_missing_test")
+
+	got, err := store.GetSessionUsage(context.Background(), "missing")
+	require.NoError(t, err, "GetSessionUsage")
+	assert.Nil(t, got, "GetSessionUsage")
+}
+
 func TestStoreGetTopSessionsByCostDedupesClaudeKeys(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_usage_top_test")
 

--- a/internal/server/deadline_test.go
+++ b/internal/server/deadline_test.go
@@ -25,6 +25,7 @@ func TestMiddleware_Timeout(t *testing.T) {
 		{"ListProjects", http.MethodGet, "/api/v1/projects"},
 		{"ListMachines", http.MethodGet, "/api/v1/machines"},
 		{"GetSessionActivity", http.MethodGet, "/api/v1/sessions/s1/activity"},
+		{"GetSessionUsage", http.MethodGet, "/api/v1/sessions/s1/usage"},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -224,6 +224,9 @@ func (s *Server) routes() {
 	s.mux.Handle(
 		"GET /api/v1/sessions/{id}/timing", s.withTimeout(s.handleSessionTiming),
 	)
+	s.mux.Handle(
+		"GET /api/v1/sessions/{id}/usage", s.withTimeout(s.handleSessionUsage),
+	)
 	// SSE: Do not use timeout, as this is a long-lived connection.
 	s.mux.HandleFunc(
 		"GET /api/v1/sessions/{id}/watch", s.handleWatchSession,

--- a/internal/server/session_usage.go
+++ b/internal/server/session_usage.go
@@ -12,6 +12,15 @@ type sessionUsageResponse struct {
 	ServerRunning  bool     `json:"server_running"`
 }
 
+type sessionUsageErrorResponse struct {
+	Error sessionUsageError `json:"error"`
+}
+
+type sessionUsageError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 func (s *Server) handleSessionUsage(
 	w http.ResponseWriter, r *http.Request,
 ) {
@@ -20,11 +29,21 @@ func (s *Server) handleSessionUsage(
 		if handleContextError(w, err) {
 			return
 		}
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeSessionUsageError(
+			w,
+			http.StatusInternalServerError,
+			"usage_query_failed",
+			"failed to query session usage",
+		)
 		return
 	}
 	if usage == nil {
-		writeError(w, http.StatusNotFound, "session not found")
+		writeSessionUsageError(
+			w,
+			http.StatusNotFound,
+			"session_not_found",
+			"session not found",
+		)
 		return
 	}
 
@@ -41,4 +60,18 @@ func newSessionUsageResponse(usage *db.SessionUsage) sessionUsageResponse {
 		UnpricedModels: unpricedModels,
 		ServerRunning:  true,
 	}
+}
+
+func writeSessionUsageError(
+	w http.ResponseWriter,
+	status int,
+	code string,
+	message string,
+) {
+	writeJSON(w, status, sessionUsageErrorResponse{
+		Error: sessionUsageError{
+			Code:    code,
+			Message: message,
+		},
+	})
 }

--- a/internal/server/session_usage.go
+++ b/internal/server/session_usage.go
@@ -6,21 +6,6 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-type sessionUsageResponse struct {
-	db.SessionUsage
-	UnpricedModels []string `json:"unpriced_models"`
-	ServerRunning  bool     `json:"server_running"`
-}
-
-type sessionUsageErrorResponse struct {
-	Error sessionUsageError `json:"error"`
-}
-
-type sessionUsageError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-}
-
 func (s *Server) handleSessionUsage(
 	w http.ResponseWriter, r *http.Request,
 ) {
@@ -50,15 +35,23 @@ func (s *Server) handleSessionUsage(
 	writeJSON(w, http.StatusOK, newSessionUsageResponse(usage))
 }
 
-func newSessionUsageResponse(usage *db.SessionUsage) sessionUsageResponse {
+func newSessionUsageResponse(usage *db.SessionUsage) map[string]any {
 	unpricedModels := usage.UnpricedModels
 	if unpricedModels == nil {
 		unpricedModels = []string{}
 	}
-	return sessionUsageResponse{
-		SessionUsage:   *usage,
-		UnpricedModels: unpricedModels,
-		ServerRunning:  true,
+	return map[string]any{
+		"session_id":          usage.SessionID,
+		"agent":               usage.Agent,
+		"project":             usage.Project,
+		"total_output_tokens": usage.TotalOutputTokens,
+		"peak_context_tokens": usage.PeakContextTokens,
+		"has_token_data":      usage.HasTokenData,
+		"cost_usd":            usage.CostUSD,
+		"has_cost":            usage.HasCost,
+		"models":              usage.Models,
+		"unpriced_models":     unpricedModels,
+		"server_running":      true,
 	}
 }
 
@@ -68,10 +61,10 @@ func writeSessionUsageError(
 	code string,
 	message string,
 ) {
-	writeJSON(w, status, sessionUsageErrorResponse{
-		Error: sessionUsageError{
-			Code:    code,
-			Message: message,
+	writeJSON(w, status, map[string]any{
+		"error": map[string]string{
+			"code":    code,
+			"message": message,
 		},
 	})
 }

--- a/internal/server/session_usage.go
+++ b/internal/server/session_usage.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"net/http"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+type sessionUsageResponse struct {
+	db.SessionUsage
+	UnpricedModels []string `json:"unpriced_models"`
+	ServerRunning  bool     `json:"server_running"`
+}
+
+func (s *Server) handleSessionUsage(
+	w http.ResponseWriter, r *http.Request,
+) {
+	usage, err := s.db.GetSessionUsage(r.Context(), r.PathValue("id"))
+	if err != nil {
+		if handleContextError(w, err) {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if usage == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, newSessionUsageResponse(usage))
+}
+
+func newSessionUsageResponse(usage *db.SessionUsage) sessionUsageResponse {
+	unpricedModels := usage.UnpricedModels
+	if unpricedModels == nil {
+		unpricedModels = []string{}
+	}
+	return sessionUsageResponse{
+		SessionUsage:   *usage,
+		UnpricedModels: unpricedModels,
+		ServerRunning:  true,
+	}
+}

--- a/internal/server/session_usage_test.go
+++ b/internal/server/session_usage_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,6 +89,7 @@ func TestHandleSessionUsage_NotFound(t *testing.T) {
 
 	w := te.get(t, "/api/v1/sessions/missing/usage")
 	assertStatus(t, w, http.StatusNotFound)
+	assertSessionUsageError(t, w, "session_not_found", "session not found")
 }
 
 func TestHandleSessionUsage_DBError(t *testing.T) {
@@ -96,6 +98,7 @@ func TestHandleSessionUsage_DBError(t *testing.T) {
 
 	w := te.get(t, "/api/v1/sessions/codex:usage-error/usage")
 	assertStatus(t, w, http.StatusInternalServerError)
+	assertSessionUsageError(t, w, "usage_query_failed", "failed to query session usage")
 }
 
 func seedSessionUsagePricing(t *testing.T, d *db.DB) {
@@ -107,4 +110,22 @@ func seedSessionUsagePricing(t *testing.T, d *db.DB) {
 		CacheCreationPerMTok: 3.75,
 		CacheReadPerMTok:     0.30,
 	}}))
+}
+
+func assertSessionUsageError(
+	t *testing.T,
+	w *httptest.ResponseRecorder,
+	code string,
+	message string,
+) {
+	t.Helper()
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, map[string]any{
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	}, got)
 }

--- a/internal/server/session_usage_test.go
+++ b/internal/server/session_usage_test.go
@@ -1,0 +1,110 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestHandleSessionUsage_PricedSession(t *testing.T) {
+	te := setup(t)
+	seedSessionUsagePricing(t, te.db)
+	te.seedSession(t, "codex:usage-priced", "my-project", 2,
+		func(s *db.Session) {
+			s.Agent = "codex"
+			s.TotalOutputTokens = 1234
+			s.PeakContextTokens = 56789
+			s.HasTotalOutputTokens = true
+			s.HasPeakContextTokens = true
+		})
+	te.seedMessages(t, "codex:usage-priced", 2,
+		func(i int, m *db.Message) {
+			if i != 1 {
+				return
+			}
+			m.Role = "assistant"
+			m.Model = "gpt-5.1"
+			m.TokenUsage = json.RawMessage(
+				`{"input_tokens":1000,"output_tokens":500,` +
+					`"cache_creation_input_tokens":200,` +
+					`"cache_read_input_tokens":300}`,
+			)
+		})
+
+	w := te.get(t, "/api/v1/sessions/codex:usage-priced/usage")
+	assertStatus(t, w, http.StatusOK)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, map[string]any{
+		"session_id":          "codex:usage-priced",
+		"agent":               "codex",
+		"project":             "my-project",
+		"total_output_tokens": float64(1234),
+		"peak_context_tokens": float64(56789),
+		"has_token_data":      true,
+		"cost_usd":            0.01134,
+		"has_cost":            true,
+		"models":              []any{"gpt-5.1"},
+		"unpriced_models":     []any{},
+		"server_running":      true,
+	}, got)
+}
+
+func TestHandleSessionUsage_NoTokenOrCostData(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "codex:usage-empty", "quiet-project", 1,
+		func(s *db.Session) {
+			s.Agent = "codex"
+		})
+
+	w := te.get(t, "/api/v1/sessions/codex:usage-empty/usage")
+	assertStatus(t, w, http.StatusOK)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, map[string]any{
+		"session_id":          "codex:usage-empty",
+		"agent":               "codex",
+		"project":             "quiet-project",
+		"total_output_tokens": float64(0),
+		"peak_context_tokens": float64(0),
+		"has_token_data":      false,
+		"cost_usd":            float64(0),
+		"has_cost":            false,
+		"models":              []any{},
+		"unpriced_models":     []any{},
+		"server_running":      true,
+	}, got)
+}
+
+func TestHandleSessionUsage_NotFound(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, "/api/v1/sessions/missing/usage")
+	assertStatus(t, w, http.StatusNotFound)
+}
+
+func TestHandleSessionUsage_DBError(t *testing.T) {
+	te := setup(t)
+	require.NoError(t, te.db.Close())
+
+	w := te.get(t, "/api/v1/sessions/codex:usage-error/usage")
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func seedSessionUsagePricing(t *testing.T, d *db.DB) {
+	t.Helper()
+	require.NoError(t, d.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern:         "gpt-5.1",
+		InputPerMTok:         3.0,
+		OutputPerMTok:        15.0,
+		CacheCreationPerMTok: 3.75,
+		CacheReadPerMTok:     0.30,
+	}}))
+}


### PR DESCRIPTION
## Summary
- add GET /api/v1/sessions/{id}/usage using the existing SessionUsage DTO and GetSessionUsage aggregation
- support the usage endpoint in both SQLite serve and pg serve paths
- preserve the successful REST and CLI usage JSON contract, including cost_usd, has_cost, and server_running
- return structured error codes for missing sessions and usage query failures

## Test Plan
- git diff --check
- nix develop --impure --expr "let pkgs = import (builtins.getFlake \"nixpkgs\") { system = builtins.currentSystem; }; in pkgs.mkShell { packages = [ pkgs.golangci-lint pkgs.go pkgs.clangStdenv.cc pkgs.darwin.libresolv ]; }" --command go test ./internal/server ./cmd/agentsview ./internal/db -count=1
- nix develop --impure --expr "let pkgs = import (builtins.getFlake \"nixpkgs\") { system = builtins.currentSystem; }; in pkgs.mkShell { packages = [ pkgs.golangci-lint pkgs.go pkgs.clangStdenv.cc pkgs.darwin.libresolv ]; }" --command make lint-ci