### PR TITLE
Avoid git subprocesses during sync project resolution

### DIFF
--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -459,36 +459,42 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 		}
 	}
 
-	if root := findGitRepoRootLocal(dir); root != "" {
+	root, conservative := findGitRepoRootLocal(dir)
+	if root != "" && !conservative {
 		return root
 	}
 	if !cwdMissing {
-		return gitMainRoot(ctx, startDir)
+		if gitRoot := gitMainRoot(ctx, startDir); gitRoot != "" {
+			return gitRoot
+		}
 	}
-	return ""
+	return root
 }
 
-func findGitRepoRootLocal(dir string) string {
+func findGitRepoRootLocal(dir string) (root string, conservative bool) {
 	for {
 		gitPath := filepath.Join(dir, ".git")
 		info, err := osStat(gitPath)
 		if err == nil {
 			if info.IsDir() {
-				return dir
+				return dir, false
 			}
 			if info.Mode().IsRegular() {
 				if root := repoRootFromGitFile(dir, gitPath); root != "" {
-					return root
+					if root == dir {
+						return root, true
+					}
+					return root, false
 				}
 				// Keep conservative fallback for gitfile repos
 				// when metadata cannot be parsed.
-				return dir
+				return dir, true
 			}
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return ""
+			return "", false
 		}
 		dir = parent
 	}

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unicode"
 
+	gitrepo "go.kenn.io/kit/git/repo"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -419,7 +420,6 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 	if cwd == "" {
 		return ""
 	}
-	_ = ctx
 
 	dir := cwd
 	cwdMissing := false
@@ -435,6 +435,7 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 		cwdMissing = true
 		dir = filepath.Dir(dir)
 	}
+	startDir := dir
 
 	// When the original path is gone, walk up to the first
 	// existing ancestor and check its children for worktree
@@ -458,6 +459,16 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 		}
 	}
 
+	if root := findGitRepoRootLocal(dir); root != "" {
+		return root
+	}
+	if !cwdMissing {
+		return gitMainRoot(ctx, startDir)
+	}
+	return ""
+}
+
+func findGitRepoRootLocal(dir string) string {
 	for {
 		gitPath := filepath.Join(dir, ".git")
 		info, err := osStat(gitPath)
@@ -481,6 +492,19 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 		}
 		dir = parent
 	}
+}
+
+func gitMainRoot(ctx context.Context, dir string) string {
+	if ctx == nil || dir == "" {
+		return ""
+	}
+	opCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	root, err := gitrepo.MainRoot(opCtx, dir)
+	if err != nil {
+		return ""
+	}
+	return root
 }
 
 // repoRootFromSiblings checks child directories of dir for

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -12,7 +12,6 @@ import (
 	"time"
 	"unicode"
 
-	gitrepo "go.kenn.io/kit/git/repo"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -420,6 +419,7 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 	if cwd == "" {
 		return ""
 	}
+	_ = ctx
 
 	dir := cwd
 	cwdMissing := false
@@ -434,14 +434,6 @@ func findGitRepoRoot(ctx context.Context, cwd string) string {
 		}
 		cwdMissing = true
 		dir = filepath.Dir(dir)
-	}
-
-	if !cwdMissing {
-		opCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-		if root, err := gitrepo.MainRoot(opCtx, dir); err == nil {
-			return root
-		}
 	}
 
 	// When the original path is gone, walk up to the first

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -159,6 +159,45 @@ func TestExtractProjectFromCwdFallsBackToGitWhenLocalWalkMisses(t *testing.T) {
 	assert.FileExists(t, gitLog, "git fallback should be used when local walk misses")
 }
 
+func TestExtractProjectFromCwdTriesGitBeforeConservativeGitFileFallback(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell git shim")
+	}
+
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	mustMkdirAll(t, binDir)
+	gitLog := filepath.Join(root, "git-log")
+	mainRepo := filepath.Join(root, "main-repo")
+	worktree := filepath.Join(root, "feature-worktree")
+	cwd := filepath.Join(worktree, "internal", "parser")
+	commonDir := filepath.Join(mainRepo, ".git")
+	externalGitDir := filepath.Join(root, "bare-common", "worktrees", "feature")
+	mustMkdirAll(t, commonDir)
+	mustMkdirAll(t, externalGitDir)
+	mustMkdirAll(t, cwd)
+	mustWriteFile(t, filepath.Join(worktree, ".git"),
+		"gitdir: "+externalGitDir+"\n")
+
+	fakeGit := filepath.Join(binDir, "git")
+	mustWriteFile(t, fakeGit, "#!/bin/sh\n"+
+		"echo \"$*\" >> "+shellQuote(gitLog)+"\n"+
+		"case \"$*\" in\n"+
+		"  'rev-parse --git-dir') echo "+shellQuote(externalGitDir)+" ;;\n"+
+		"  'rev-parse --git-common-dir') echo "+shellQuote(commonDir)+" ;;\n"+
+		"  *) exit 1 ;;\n"+
+		"esac\n")
+	require.NoError(t, os.Chmod(fakeGit, 0o755), "chmod fake git")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	assert.Equal(t, "main_repo",
+		ExtractProjectFromCwdWithBranchContext(context.Background(), cwd, ""))
+	assert.FileExists(t, gitLog,
+		"git fallback should run before accepting conservative gitfile root")
+}
+
 func TestExtractProjectFromCwd_DeletedNestedWorktree(t *testing.T) {
 	// Simulates a nested worktree layout where the session's
 	// worktree has been deleted but a sibling worktree still

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -129,6 +129,36 @@ func TestExtractProjectFromCwdPlainRepoDoesNotInvokeGit(t *testing.T) {
 	assert.NoFileExists(t, marker, "plain .git directory should resolve without invoking git")
 }
 
+func TestExtractProjectFromCwdFallsBackToGitWhenLocalWalkMisses(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell git shim")
+	}
+
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	mustMkdirAll(t, binDir)
+	gitLog := filepath.Join(root, "git-log")
+	repo := filepath.Join(root, "virtual-repo")
+	cwd := filepath.Join(repo, "internal", "parser")
+	mustMkdirAll(t, cwd)
+
+	fakeGit := filepath.Join(binDir, "git")
+	mustWriteFile(t, fakeGit, "#!/bin/sh\n"+
+		"echo \"$*\" >> "+shellQuote(gitLog)+"\n"+
+		"case \"$*\" in\n"+
+		"  'rev-parse --git-dir') echo .git ;;\n"+
+		"  'rev-parse --git-common-dir') echo .git ;;\n"+
+		"  'rev-parse --show-toplevel') echo "+shellQuote(repo)+" ;;\n"+
+		"  *) exit 1 ;;\n"+
+		"esac\n")
+	require.NoError(t, os.Chmod(fakeGit, 0o755), "chmod fake git")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	assert.Equal(t, "virtual_repo",
+		ExtractProjectFromCwdWithBranchContext(context.Background(), cwd, ""))
+	assert.FileExists(t, gitLog, "git fallback should be used when local walk misses")
+}
+
 func TestExtractProjectFromCwd_DeletedNestedWorktree(t *testing.T) {
 	// Simulates a nested worktree layout where the session's
 	// worktree has been deleted but a sibling worktree still

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -106,6 +106,29 @@ func TestExtractProjectFromCwdWithBranchContext_GitWorktreeMainRoot(t *testing.T
 		"kit-backed worktree resolution should use the main repo name")
 }
 
+func TestExtractProjectFromCwdPlainRepoDoesNotInvokeGit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell git shim")
+	}
+
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	mustMkdirAll(t, binDir)
+	marker := filepath.Join(root, "git-invoked")
+	fakeGit := filepath.Join(binDir, "git")
+	mustWriteFile(t, fakeGit, "#!/bin/sh\n: > "+shellQuote(marker)+"\nexit 1\n")
+	require.NoError(t, os.Chmod(fakeGit, 0o755), "chmod fake git")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	repo := filepath.Join(root, "plain-repo")
+	subdir := filepath.Join(repo, "internal", "parser")
+	mustMkdirAll(t, filepath.Join(repo, ".git"))
+	mustMkdirAll(t, subdir)
+
+	assert.Equal(t, "plain_repo", ExtractProjectFromCwd(subdir))
+	assert.NoFileExists(t, marker, "plain .git directory should resolve without invoking git")
+}
+
 func TestExtractProjectFromCwd_DeletedNestedWorktree(t *testing.T) {
 	// Simulates a nested worktree layout where the session's
 	// worktree has been deleted but a sibling worktree still
@@ -589,6 +612,10 @@ func mustWriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644),
 		"WriteFile(%q)", path)
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 func skipIfNoGit(t *testing.T) {


### PR DESCRIPTION
## Summary
- Prefer the cheap filesystem `.git` walk for sync-time project extraction so normal repos and linked worktrees do not shell out to `git` per session.
- Preserve the kit `gitrepo.MainRoot` fallback for rare live-repo layouts when the local walk cannot resolve a root.
- Add regression coverage for both sides: plain repos must not invoke `git`, and the git fallback remains available when local resolution misses.

## Investigation
- Reproduced with isolated data dirs only (`AGENTSVIEW_DATA_DIR=/tmp/...`, also set `AGENTSVIEW_HOME=/tmp/...`); production DB was not touched.
- Same source session set: about 35.7k discovered sessions.
- `v0.31.1` cold sync: 1m12.7s.
- `v0.32.0` cold sync: 4m31.4s.
- Revised PR build cold sync: 1m14.2s.
- 0.32.0 CPU profile showed ~190s cumulative under `go.kenn.io/kit/git/repo.MainRoot` / `os/exec` from `ExtractProjectFromCwdWithBranch`; revised PR profile returns to SQLite/file-read dominated work.

## Test Plan
- [x] `go test ./internal/parser ./internal/sync ./cmd/agentsview`
- [x] Isolated revised PR cold sync with `AGENTSVIEW_DATA_DIR=/tmp/agentsview-prof-pr-fallback`: 1m14.2s
