### PR TITLE
Discover nested Claude workflow subagents

### DIFF
--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -463,7 +463,7 @@ func FindClaudeSourceFile(
 	}
 
 	// Subagent files live under session directories:
-	// <project>/<session>/subagents/agent-<id>.jsonl
+	// <project>/<session>/subagents/**/agent-<id>.jsonl
 	if strings.HasPrefix(sessionID, "agent-") {
 		for _, entry := range entries {
 			if !entry.IsDir() {
@@ -480,12 +480,22 @@ func FindClaudeSourceFile(
 				if !sd.IsDir() {
 					continue
 				}
-				candidate := filepath.Join(
-					projDir, sd.Name(),
-					"subagents", target,
+				var found string
+				subagentsDir := filepath.Join(
+					projDir, sd.Name(), "subagents",
 				)
-				if _, err := os.Stat(candidate); err == nil {
-					return candidate
+				_ = filepath.WalkDir(
+					subagentsDir,
+					func(path string, d os.DirEntry, err error) error {
+						if err != nil || d.IsDir() || d.Name() != target {
+							return nil
+						}
+						found = path
+						return filepath.SkipAll
+					},
+				)
+				if found != "" {
+					return found
 				}
 			}
 		}

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -344,7 +344,11 @@ func DiscoverClaudeProjects(projectsDir string) []DiscoveredFile {
 			})
 		}
 
-		// Scan session directories for subagent files
+		// Scan session directories for subagent files. Claude workflow
+		// tools group subagents under nested paths such as
+		// subagents/workflows/<workflow-id>/agent-<id>.jsonl, so walk the
+		// whole subagents tree instead of assuming transcripts are direct
+		// children of subagents/.
 		for _, sf := range sessionFiles {
 			if !sf.IsDir() {
 				continue
@@ -352,26 +356,27 @@ func DiscoverClaudeProjects(projectsDir string) []DiscoveredFile {
 			subagentsDir := filepath.Join(
 				projDir, sf.Name(), "subagents",
 			)
-			subFiles, err := os.ReadDir(subagentsDir)
+			err := filepath.WalkDir(
+				subagentsDir,
+				func(path string, sub os.DirEntry, err error) error {
+					if err != nil || sub.IsDir() {
+						return nil
+					}
+					name := sub.Name()
+					if !strings.HasPrefix(name, "agent-") ||
+						!strings.HasSuffix(name, ".jsonl") {
+						return nil
+					}
+					files = append(files, DiscoveredFile{
+						Path:    path,
+						Project: entry.Name(),
+						Agent:   AgentClaude,
+					})
+					return nil
+				},
+			)
 			if err != nil {
 				continue
-			}
-			for _, sub := range subFiles {
-				if sub.IsDir() {
-					continue
-				}
-				name := sub.Name()
-				if !strings.HasPrefix(name, "agent-") ||
-					!strings.HasSuffix(name, ".jsonl") {
-					continue
-				}
-				files = append(files, DiscoveredFile{
-					Path: filepath.Join(
-						subagentsDir, name,
-					),
-					Project: entry.Name(),
-					Agent:   AgentClaude,
-				})
 			}
 		}
 	}

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -356,7 +356,7 @@ func DiscoverClaudeProjects(projectsDir string) []DiscoveredFile {
 			subagentsDir := filepath.Join(
 				projDir, sf.Name(), "subagents",
 			)
-			err := filepath.WalkDir(
+			_ = filepath.WalkDir(
 				subagentsDir,
 				func(path string, sub os.DirEntry, err error) error {
 					if err != nil || sub.IsDir() {
@@ -375,9 +375,6 @@ func DiscoverClaudeProjects(projectsDir string) []DiscoveredFile {
 					return nil
 				},
 			)
-			if err != nil {
-				continue
-			}
 		}
 	}
 

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -249,6 +249,14 @@ func TestFindClaudeSourceFile(t *testing.T) {
 			wantFile: filepath.Join("project-a", "parent-sess", "subagents", "agent-sub1.jsonl"),
 		},
 		{
+			name: "Nested workflow subagent",
+			files: map[string]string{
+				filepath.Join("project-a", "parent-sess", "subagents", "workflows", "wf-123", "agent-deep.jsonl"): "{}",
+			},
+			targetID: "agent-deep",
+			wantFile: filepath.Join("project-a", "parent-sess", "subagents", "workflows", "wf-123", "agent-deep.jsonl"),
+		},
+		{
 			name: "Nonexistent",
 			files: map[string]string{
 				filepath.Join("project-a", "session-abc.jsonl"): "{}",

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -92,6 +92,19 @@ func TestDiscoverClaudeProjects(t *testing.T) {
 			},
 		},
 		{
+			name: "Nested workflow subagents",
+			files: map[string]string{
+				filepath.Join("project-a", "parent-session.jsonl"):                                                       "{}",
+				filepath.Join("project-a", "parent-session", "subagents", "workflows", "wf-123", "agent-deep.jsonl"):     "{}",
+				filepath.Join("project-a", "parent-session", "subagents", "workflows", "wf-123", "agent-deep.meta.json"): "{}",
+				filepath.Join("project-a", "parent-session", "subagents", "workflows", "wf-123", "not-agent.jsonl"):      "{}",
+			},
+			wantFiles: []string{
+				"parent-session.jsonl",
+				"agent-deep.jsonl",
+			},
+		},
+		{
 			name:      "Empty",
 			files:     map[string]string{},
 			wantFiles: nil,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -484,10 +484,10 @@ func (e *Engine) classifyOnePath(
 				}, true
 			}
 
-			// Subagent: project/session/subagents/agent-*.jsonl
-			if len(parts) == 4 && parts[2] == "subagents" {
+			// Subagent: project/session/subagents/**/agent-*.jsonl
+			if len(parts) >= 4 && parts[2] == "subagents" {
 				stem := strings.TrimSuffix(
-					parts[3], ".jsonl",
+					parts[len(parts)-1], ".jsonl",
 				)
 				if !strings.HasPrefix(stem, "agent-") {
 					continue

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -458,7 +458,7 @@ func (e *Engine) classifyOnePath(
 	}
 
 	// Claude: <claudeDir>/<project>/<session>.jsonl
-	//     or: <claudeDir>/<project>/<session>/subagents/agent-<id>.jsonl
+	//     or: <claudeDir>/<project>/<session>/subagents/**/agent-<id>.jsonl
 	for _, claudeDir := range e.agentDirs[parser.AgentClaude] {
 		if claudeDir == "" {
 			continue

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2270,6 +2270,36 @@ func TestSyncPathsClaudeSubagent(t *testing.T) {
 	)
 }
 
+func TestSyncPathsClaudeNestedWorkflowSubagent(t *testing.T) {
+	env := setupTestEnv(t)
+
+	subagentContent := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithSessionID(
+			tsZero, "Deep research", "parent-sess",
+		).
+		AddClaudeAssistant(tsZeroS5, "Done.").
+		String()
+
+	subPath := env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"test-proj", "parent-sess",
+			"subagents", "workflows", "wf-123",
+			"agent-deep.jsonl",
+		),
+		subagentContent,
+	)
+
+	env.engine.SyncPaths([]string{subPath})
+
+	assertSessionState(
+		t, env.db, "agent-deep",
+		func(sess *db.Session) {
+			assert.Equal(t, "claude", sess.Agent, "agent = %q, want claude", sess.Agent)
+		},
+	)
+}
+
 func TestSyncPathsClaudeRejectsNonAgentInSubagents(t *testing.T) {
 	env := setupTestEnv(t)
 


### PR DESCRIPTION
## Summary
- Walk Claude session `subagents/` directories recursively so workflow/deep-research subagent transcripts are discovered under `subagents/workflows/<workflow-id>/`
- Preserve existing direct subagent discovery and continue ignoring `.meta.json` sidecars/non-agent JSONL files
- Add regression coverage for nested workflow subagent discovery

Fixes #596

## Validation
- `go test ./internal/parser -run TestDiscoverClaudeProjects/Nested_workflow_subagents -count=1` failed before the implementation
- `go test ./internal/parser`
- `go test ./...`
- Reviewer subagent approved the diff with no issues
