### PR TITLE
Antigravity CLI: extract sidecar generatorMetadata token usage

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,12 +28,18 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 37: Antigravity and Antigravity CLI parsers now extract
+// Bumped to 38: Antigravity CLI parser extracts generatorMetadata
+// token usage from agy-reader trajectory sidecars: usage events for
+// legacy .pb sessions (and .db sessions without gen_metadata) and
+// per-message model/token attribution on sidecar transcripts. Existing
+// Antigravity CLI rows need re-parsing so usage reports include them.
+//
+// (37: Antigravity and Antigravity CLI parsers now extract
 // per-generation model names and token usage (input, output,
 // reasoning) from the gen_metadata table into per-message token
 // fields, session totals, and usage events. Existing Antigravity
 // rows need re-parsing so usage and cost reports include older
-// sessions.
+// sessions.)
 //
 // (36: the Antigravity CLI .pb branch dropped its sidecar
 // mtime gate: a trajectory.json older than the .pb was rejected in
@@ -149,7 +155,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 37
+const dataVersion = 38
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,11 +28,17 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 38: Antigravity CLI parser extracts generatorMetadata
-// token usage from agy-reader trajectory sidecars: usage events for
-// legacy .pb sessions (and .db sessions without gen_metadata) and
-// per-message model/token attribution on sidecar transcripts. Existing
-// Antigravity CLI rows need re-parsing so usage reports include them.
+// Bumped to 38: two Antigravity parsing changes. (a) The Antigravity
+// CLI parser extracts generatorMetadata token usage from agy-reader
+// trajectory sidecars: usage events for legacy .pb sessions (and .db
+// sessions without gen_metadata) and per-message model/token
+// attribution on sidecar transcripts, so existing Antigravity CLI rows
+// need re-parsing to gain usage data. (b) The gen_metadata model-name
+// heuristic now rejects non-printable candidates: field 21/19
+// sometimes carries a nested protobuf message whose low bytes are
+// valid UTF-8, and the raw fragment (including NUL bytes) was
+// persisted as messages.model, so existing Antigravity rows need
+// re-parsing to clear the corrupt model values.
 //
 // (37: Antigravity and Antigravity CLI parsers now extract
 // per-generation model names and token usage (input, output,

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -968,6 +968,17 @@ func (db *DB) MessageContentFingerprint(sessionID string) (sum, max, min int64, 
 	return sum, max, min, err
 }
 
+// SanitizeUTF8 strips NUL bytes and replaces invalid UTF-8
+// sequences. PostgreSQL enforces strict UTF-8 and rejects NUL in
+// text columns, so the push boundary applies this to every
+// parser-derived string; the local fingerprint builders below apply
+// it too so local fingerprints stay comparable to PG-readback
+// fingerprints when a stored row carries NUL bytes.
+func SanitizeUTF8(s string) string {
+	s = strings.ReplaceAll(s, "\x00", "")
+	return strings.ToValidUTF8(s, "")
+}
+
 // MessageTokenFingerprint returns an exact ordered fingerprint of
 // stored token metadata for a session's messages. Used by PG push
 // fast-paths to detect token metadata changes without rewriting
@@ -1007,6 +1018,19 @@ func (db *DB) MessageTokenFingerprint(sessionID string) (string, error) {
 		); err != nil {
 			return "", err
 		}
+		// Sanitize before measuring: the PG-readback
+		// fingerprint sees values sanitized at insert time,
+		// so raw values (e.g. NUL bytes from a corrupt parse)
+		// would never match and the fast path would rewrite
+		// the session on every push.
+		model = SanitizeUTF8(model)
+		tokenUsage = SanitizeUTF8(tokenUsage)
+		claudeMsgID = SanitizeUTF8(claudeMsgID)
+		claudeReqID = SanitizeUTF8(claudeReqID)
+		srcType = SanitizeUTF8(srcType)
+		srcSubtype = SanitizeUTF8(srcSubtype)
+		srcUUID = SanitizeUTF8(srcUUID)
+		srcParentUUID = SanitizeUTF8(srcParentUUID)
 		fmt.Fprintf(&b,
 			"%d|%d:%s|%d:%s|%d|%d|%t|%t|%s|%s|"+
 				"%d:%s|%d:%s|%d:%s|%d:%s|%t|%t;",

--- a/internal/db/usage_events.go
+++ b/internal/db/usage_events.go
@@ -213,6 +213,14 @@ func (db *DB) appendUsageEventFingerprints(
 		if occurredAt.Valid {
 			occurred = occurredAt.String
 		}
+		// Sanitize before measuring so fingerprints match the
+		// PG-readback fingerprint, whose values were sanitized
+		// at insert time (see SanitizeUTF8).
+		source = SanitizeUTF8(source)
+		model = SanitizeUTF8(model)
+		costStatus = SanitizeUTF8(costStatus)
+		costSource = SanitizeUTF8(costSource)
+		dedupKey.String = SanitizeUTF8(dedupKey.String)
 		fmt.Fprintf(b,
 			"%t|%d|%d:%s|%d:%s|%d|%d|%d|%d|%d|%t|%g|%d:%s|%d:%s|%d:%s|%d:%s;",
 			ordinal.Valid,

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -416,13 +417,15 @@ func extractModelName(data []byte) string {
 			return
 		}
 		if f21, ok := agProtoFind(fs, 21); ok {
-			if s, ok := agProtoString(f21); ok && s != "" {
+			if s, ok := agProtoString(f21); ok &&
+				isPlausibleModelName(s) {
 				model = s
 				return
 			}
 		}
 		if f19, ok := agProtoFind(fs, 19); ok {
-			if s, ok := agProtoString(f19); ok && s != "" {
+			if s, ok := agProtoString(f19); ok &&
+				isPlausibleModelName(s) {
 				model = s
 				return
 			}
@@ -435,6 +438,29 @@ func extractModelName(data []byte) string {
 	}
 	walk(fields)
 	return model
+}
+
+// isPlausibleModelName reports whether s looks like a human-readable
+// model identifier. Field 21/19 sometimes carries a nested protobuf
+// message whose low bytes (tags, varints, NULs) are valid UTF-8 --
+// agProtoString cannot tell those apart from text, and the raw bytes
+// previously leaked into messages.model (and broke `pg push`, which
+// rejects NUL bytes). Require every rune to be printable and at least
+// one letter to be present.
+func isPlausibleModelName(s string) bool {
+	if s == "" {
+		return false
+	}
+	hasLetter := false
+	for _, r := range s {
+		if !unicode.IsPrint(r) {
+			return false
+		}
+		if unicode.IsLetter(r) {
+			hasLetter = true
+		}
+	}
+	return hasLetter
 }
 
 // decodeAntigravityStep extracts a ParsedMessage from one step's

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -241,7 +241,13 @@ func ParseAntigravityCLISessionWithStatus(
 		case dbErr != nil || dbResult.rawStepCount > 0:
 			status.NeedsRetry = true
 		}
-		if len(usageEvents) == 0 && tErr == nil {
+		// Coverage gates usage just like the transcript: a lagging
+		// sidecar carries only the generations it has seen, and
+		// persisting those would underreport totals on a row that
+		// looks current. sidecarCovers stays true when the DB offers
+		// no coverage signal (unreadable or zero rows), so gap-fill
+		// still applies there.
+		if len(usageEvents) == 0 && tErr == nil && sidecarCovers {
 			usageEvents = tRes.usageEvents
 		}
 	} else {

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -276,6 +276,9 @@ func ParseAntigravityCLISessionWithStatus(
 		)...,
 	)
 
+	// Last resort for legacy .pb archives: AES decrypt via
+	// ANTIGRAVITY_KEY; the sidecar and history fallbacks above
+	// take precedence.
 	if ext == ".pb" && !hasTrajectory && hasAntigravityKey() {
 		if extra, ok := decryptAntigravityCLITranscript(path); ok {
 			messages = append(messages, extra)
@@ -702,7 +705,9 @@ func readAntigravityArtifactMeta(
 // decryptAntigravityCLITranscript attempts to decrypt a .pb file
 // and returns a single assistant ParsedMessage holding the raw
 // strings extracted from the plaintext. Returns ok=false when
-// decryption fails or yields no usable text.
+// decryption fails or yields no usable text. Last-resort decode
+// path: sidecar and history fallbacks take precedence; see the
+// header of antigravity_crypto.go for the retention rationale.
 func decryptAntigravityCLITranscript(
 	path string,
 ) (ParsedMessage, bool) {

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -256,7 +256,12 @@ func ParseAntigravityCLISessionWithStatus(
 			// Usage events flow whenever the sidecar parses, even when
 			// no message is displayable, matching the message-less
 			// usage stance of the .db branch. The displayable gate
-			// below applies to the transcript decision only.
+			// below applies to the transcript decision only. A
+			// metadata-only sidecar can therefore pair usage events
+			// with a history/decrypt transcript; events without a
+			// generation timestamp bucket at session start in daily
+			// usage (occurred_at stored as NULL, COALESCEd to
+			// started_at).
 			usageEvents = tRes.usageEvents
 			if hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages) {
 				messages = tRes.messages
@@ -909,7 +914,9 @@ func (c *agyTokenCount) UnmarshalJSON(data []byte) error {
 		s = unquoted
 	}
 	n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
-	if err != nil {
+	if err != nil || n < 0 {
+		// Negative counts are garbage too: emitting them would
+		// subtract from session and daily usage totals.
 		return nil
 	}
 	*c = agyTokenCount(n)
@@ -1166,16 +1173,6 @@ func agyToolDetail(name, inputJSON string) string {
 	return name
 }
 
-// parseAntigravityCLITrajectory reads a <uuid>.trajectory.json sidecar
-// produced out-of-process by agy-reader and returns the decoded
-// transcript as ParsedMessages.
-//
-// Trust posture (see SECURITY.md, "Imports and new readers" row of the
-// Trust boundaries table): the sidecar is treated as untrusted
-// structured input — same posture as any other agent session file.
-// The read is size-capped (maxTrajectorySidecarBytes) and unknown step
-// types are silently skipped further down. No content from the sidecar
-// is executed or echoed back over any outbound channel.
 // agyTrajectoryParseResult is the decoded output of one trajectory
 // sidecar: the transcript messages, the raw step count (used by
 // callers to compare coverage against other decode sources for the
@@ -1187,7 +1184,16 @@ type agyTrajectoryParseResult struct {
 	usageEvents []ParsedUsageEvent
 }
 
-// parseAntigravityCLITrajectory parses an agy-reader trajectory sidecar.
+// parseAntigravityCLITrajectory reads a <uuid>.trajectory.json sidecar
+// produced out-of-process by agy-reader and returns the decoded
+// transcript as ParsedMessages.
+//
+// Trust posture (see SECURITY.md, "Imports and new readers" row of the
+// Trust boundaries table): the sidecar is treated as untrusted
+// structured input — same posture as any other agent session file.
+// The read is size-capped (maxTrajectorySidecarBytes) and unknown step
+// types are silently skipped further down. No content from the sidecar
+// is executed or echoed back over any outbound channel.
 func parseAntigravityCLITrajectory(
 	trajectoryPath string,
 ) (agyTrajectoryParseResult, error) {

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -194,8 +195,11 @@ func ParseAntigravityCLISessionWithStatus(
 	if ext == ".db" {
 		dbResult, dbErr := loadAntigravityCLIDBSteps(path)
 		// gen_metadata token usage describes the session's actual
-		// consumption no matter which transcript source wins below;
-		// the sidecar decode does not extract token data.
+		// consumption no matter which transcript source wins below.
+		// The sidecar also extracts generatorMetadata usage, but
+		// gen_metadata events win and sidecar events only fill the gap
+		// (unreadable DB or missing gen_metadata table) so the same
+		// generation is never counted twice.
 		usageEvents = dbResult.usageEvents
 		dbOK := dbErr == nil &&
 			hasDisplayableAntigravityCLITrajectoryMessage(dbResult.messages)
@@ -210,14 +214,14 @@ func ParseAntigravityCLISessionWithStatus(
 		// heuristic cannot decode -- so a partial sidecar is never persisted
 		// as a current transcript.
 		sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
-		tMsgs, tSteps, tErr := parseAntigravityCLITrajectory(sidecarPath)
+		tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
 		sidecarOK := tErr == nil &&
-			hasDisplayableAntigravityCLITrajectoryMessage(tMsgs)
+			hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages)
 		sidecarCovers := dbErr != nil || dbResult.rawStepCount == 0 ||
-			tSteps >= dbResult.rawStepCount
+			tRes.rawSteps >= dbResult.rawStepCount
 		switch {
 		case sidecarOK && sidecarCovers:
-			messages = tMsgs
+			messages = tRes.messages
 			hasTrajectory = true
 		case dbOK:
 			messages = mergeAntigravityDBHistoryMessages(
@@ -231,11 +235,14 @@ func ParseAntigravityCLISessionWithStatus(
 			// Partial sidecar and an undecodable DB: store the best
 			// available transcript but leave the row stale so the next
 			// pass re-parses once agy-reader catches up.
-			messages = tMsgs
+			messages = tRes.messages
 			hasTrajectory = true
 			status.NeedsRetry = true
 		case dbErr != nil || dbResult.rawStepCount > 0:
 			status.NeedsRetry = true
+		}
+		if len(usageEvents) == 0 && tErr == nil {
+			usageEvents = tRes.usageEvents
 		}
 	} else {
 		// Legacy .pb: the file itself is AES-encrypted, so the sidecar is
@@ -245,10 +252,16 @@ func ParseAntigravityCLISessionWithStatus(
 		// .pb files are no longer produced, so their sidecars are final,
 		// and even a sidecar older than the .pb beats the fallbacks.
 		sidecarPath := strings.TrimSuffix(path, ".pb") + ".trajectory.json"
-		if tMsgs, _, err := parseAntigravityCLITrajectory(sidecarPath); err == nil &&
-			hasDisplayableAntigravityCLITrajectoryMessage(tMsgs) {
-			messages = tMsgs
-			hasTrajectory = true
+		if tRes, err := parseAntigravityCLITrajectory(sidecarPath); err == nil {
+			// Usage events flow whenever the sidecar parses, even when
+			// no message is displayable, matching the message-less
+			// usage stance of the .db branch. The displayable gate
+			// below applies to the transcript decision only.
+			usageEvents = tRes.usageEvents
+			if hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages) {
+				messages = tRes.messages
+				hasTrajectory = true
+			}
 		}
 	}
 
@@ -831,9 +844,71 @@ func (f fakeFileInfo) Sys() any    { return nil }
 // We parse this trajectory JSON on a best-effort basis. If the JSON contains unknown step types,
 // they are silently ignored/skipped in the switch statements of the parser.
 type agyTrajectory struct {
-	TrajectoryID string    `json:"trajectoryId"`
-	CascadeID    string    `json:"cascadeId"`
-	Steps        []agyStep `json:"steps"`
+	TrajectoryID      string                 `json:"trajectoryId"`
+	CascadeID         string                 `json:"cascadeId"`
+	Steps             []agyStep              `json:"steps"`
+	GeneratorMetadata []agyGeneratorMetadata `json:"generatorMetadata"`
+}
+
+// agyGeneratorMetadata records one model generation: the trajectory
+// step indices it produced and the chat-model accounting for the call.
+// Empirically (26 real sidecars / 1839 generations at the time of
+// writing) stepIndices[0] is always a PLANNER_RESPONSE step and no
+// planner step is claimed by two generations.
+type agyGeneratorMetadata struct {
+	StepIndices []int         `json:"stepIndices"`
+	ChatModel   *agyChatModel `json:"chatModel"`
+}
+
+type agyChatModel struct {
+	Model             string                `json:"model"`
+	Usage             *agyChatModelUsage    `json:"usage"`
+	ChatStartMetadata *agyChatStartMetadata `json:"chatStartMetadata"`
+}
+
+type agyChatStartMetadata struct {
+	CreatedAt string `json:"createdAt"`
+}
+
+// agyChatModelUsage carries the daemon's own token accounting for one
+// generation. Empirically OutputTokens already INCLUDES
+// ThinkingOutputTokens, so reasoning must NOT be re-folded into output
+// (unlike the .db gen_metadata path, which splits candidates and
+// thoughts Gemini-style). responseOutputTokens is deliberately
+// omitted: it is derivable (output - thinking) and unused.
+// chatModel.retryInfos[] per-attempt usage is intentionally not
+// summed - an accepted undercount on retried generations.
+type agyChatModelUsage struct {
+	Model                string        `json:"model"`
+	InputTokens          agyTokenCount `json:"inputTokens"`
+	OutputTokens         agyTokenCount `json:"outputTokens"`
+	ThinkingOutputTokens agyTokenCount `json:"thinkingOutputTokens"`
+	CacheReadTokens      agyTokenCount `json:"cacheReadTokens"`
+}
+
+// agyTokenCount decodes a token count the daemon serializes as a JSON
+// string ("19733"), tolerating bare numbers as well. Garbage, null, or
+// empty values decode to 0 WITHOUT returning an error: the sidecar is
+// untrusted structured input (see the trust-posture note above), and
+// an unmarshal error here would fail the whole trajectory decode and
+// destroy the transcript.
+type agyTokenCount int
+
+func (c *agyTokenCount) UnmarshalJSON(data []byte) error {
+	*c = 0
+	s := strings.TrimSpace(string(data))
+	if s == "" || s == "null" {
+		return nil
+	}
+	if unquoted, err := strconv.Unquote(s); err == nil {
+		s = unquoted
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return nil
+	}
+	*c = agyTokenCount(n)
+	return nil
 }
 
 type agyStep struct {
@@ -1096,33 +1171,46 @@ func agyToolDetail(name, inputJSON string) string {
 // The read is size-capped (maxTrajectorySidecarBytes) and unknown step
 // types are silently skipped further down. No content from the sidecar
 // is executed or echoed back over any outbound channel.
+// agyTrajectoryParseResult is the decoded output of one trajectory
+// sidecar: the transcript messages, the raw step count (used by
+// callers to compare coverage against other decode sources for the
+// same session), and the usage events extracted from
+// generatorMetadata.
+type agyTrajectoryParseResult struct {
+	messages    []ParsedMessage
+	rawSteps    int
+	usageEvents []ParsedUsageEvent
+}
+
 // parseAntigravityCLITrajectory parses an agy-reader trajectory sidecar.
-// The int is the raw step count of the trajectory, used by callers to
-// compare coverage against other decode sources for the same session.
 func parseAntigravityCLITrajectory(
 	trajectoryPath string,
-) ([]ParsedMessage, int, error) {
+) (agyTrajectoryParseResult, error) {
 	f, err := os.Open(trajectoryPath)
 	if err != nil {
-		return nil, 0, err
+		return agyTrajectoryParseResult{}, err
 	}
 	defer f.Close()
 	data, err := io.ReadAll(io.LimitReader(f, maxTrajectorySidecarBytes+1))
 	if err != nil {
-		return nil, 0, err
+		return agyTrajectoryParseResult{}, err
 	}
 	if int64(len(data)) > maxTrajectorySidecarBytes {
-		return nil, 0, fmt.Errorf(
+		return agyTrajectoryParseResult{}, fmt.Errorf(
 			"trajectory sidecar %s exceeds %d-byte cap",
 			trajectoryPath, maxTrajectorySidecarBytes,
 		)
 	}
 	var traj agyTrajectory
 	if err := json.Unmarshal(data, &traj); err != nil {
-		return nil, 0, err
+		return agyTrajectoryParseResult{}, err
 	}
 
 	var msgs []ParsedMessage
+	// plannerMsgIdx maps a PLANNER_RESPONSE step index to the index of
+	// the assistant message it produced in msgs, so generatorMetadata
+	// usage can be attributed to the right message.
+	plannerMsgIdx := make(map[int]int)
 
 	var pendingResults []ParsedToolResult
 	var pendingResultsTime time.Time
@@ -1146,7 +1234,7 @@ func parseAntigravityCLITrajectory(
 		pendingResults = nil
 	}
 
-	for _, step := range traj.Steps {
+	for stepIdx, step := range traj.Steps {
 		stepTime := parseTrajectoryTime(step.Metadata.CreatedAt)
 
 		switch step.Type {
@@ -1203,6 +1291,7 @@ func parseAntigravityCLITrajectory(
 				msg.HasThinking = true
 			}
 			msgs = append(msgs, msg)
+			plannerMsgIdx[stepIdx] = len(msgs) - 1
 
 		case "CORTEX_STEP_TYPE_RUN_COMMAND",
 			"CORTEX_STEP_TYPE_VIEW_FILE",
@@ -1315,5 +1404,117 @@ func parseAntigravityCLITrajectory(
 	}
 
 	flushPendingResults()
-	return msgs, len(traj.Steps), nil
+	return agyTrajectoryParseResult{
+		messages:    msgs,
+		rawSteps:    len(traj.Steps),
+		usageEvents: extractAgyGeneratorUsage(traj, plannerMsgIdx, msgs),
+	}, nil
+}
+
+// extractAgyGeneratorUsage turns trajectory generatorMetadata entries
+// into usage events and attributes each generation's tokens to the
+// planner message it produced (the first stepIndices entry that maps
+// to a PLANNER_RESPONSE message; empirically always stepIndices[0]).
+//
+// Per-message attribution sets Model, ContextTokens (input +
+// cacheRead, the full context window, matching the Claude parser's
+// semantics), and OutputTokens, but deliberately never sets
+// msg.TokenUsage raw JSON: the usage analytics count message rows with
+// a non-empty token_usage and that would double-count against the
+// emitted usage_events (the .db gen_metadata path leaves it empty for
+// the same reason).
+//
+// MessageOrdinal is left nil: ordinals are reassigned after the
+// timestamp re-sort and brain-doc merge in
+// ParseAntigravityCLISessionWithStatus, so any ordinal computed here
+// would be wrong. Cost fields stay zero/empty - MODEL_PLACEHOLDER_*
+// models are unpriced.
+func extractAgyGeneratorUsage(
+	traj agyTrajectory,
+	plannerMsgIdx map[int]int,
+	msgs []ParsedMessage,
+) []ParsedUsageEvent {
+	var events []ParsedUsageEvent
+	for _, gen := range traj.GeneratorMetadata {
+		if gen.ChatModel == nil || gen.ChatModel.Usage == nil {
+			continue
+		}
+		usage := gen.ChatModel.Usage
+		input := int(usage.InputTokens)
+		output := int(usage.OutputTokens)
+		thinking := int(usage.ThinkingOutputTokens)
+		cacheRead := int(usage.CacheReadTokens)
+		if input == 0 && output == 0 && cacheRead == 0 {
+			// Empty usage:{} marks a failed/retried generation.
+			continue
+		}
+
+		// Keep MODEL_PLACEHOLDER_* verbatim: it is lossless and
+		// groupable in the Usage view. isNoisyAntigravityStepString
+		// filters MODEL_PLACEHOLDER_ from message CONTENT only; the
+		// Model field is data.
+		model := gen.ChatModel.Model
+		if model == "" {
+			model = usage.Model
+		}
+
+		// Find the planner message this generation produced.
+		target := -1
+		fallbackStep := -1
+		for _, si := range gen.StepIndices {
+			k, ok := plannerMsgIdx[si]
+			if !ok || k < 0 || k >= len(msgs) {
+				continue
+			}
+			target = k
+			fallbackStep = si
+			break
+		}
+
+		var occurred time.Time
+		if gen.ChatModel.ChatStartMetadata != nil {
+			occurred = parseTrajectoryTime(
+				gen.ChatModel.ChatStartMetadata.CreatedAt,
+			)
+		}
+		if occurred.IsZero() &&
+			fallbackStep >= 0 && fallbackStep < len(traj.Steps) {
+			occurred = parseTrajectoryTime(
+				traj.Steps[fallbackStep].Metadata.CreatedAt,
+			)
+		}
+		var occurredAt string
+		if !occurred.IsZero() {
+			occurredAt = occurred.Format(time.RFC3339Nano)
+		}
+
+		// Attribute tokens to the planner message unless another
+		// generation already claimed it (should not happen: no planner
+		// step is claimed by two generations in observed sidecars).
+		// Either way the usage event below is still emitted.
+		if target >= 0 &&
+			!msgs[target].HasContextTokens &&
+			!msgs[target].HasOutputTokens {
+			if model != "" {
+				msgs[target].Model = model
+			}
+			msgs[target].ContextTokens = input + cacheRead
+			msgs[target].OutputTokens = output
+			msgs[target].HasContextTokens = input+cacheRead > 0
+			msgs[target].HasOutputTokens = output > 0
+		}
+
+		// OutputTokens already includes thinking (empirical invariant)
+		// so reasoning is NOT re-folded into output here.
+		events = append(events, ParsedUsageEvent{
+			Source:               "sidecar",
+			Model:                model,
+			InputTokens:          input,
+			OutputTokens:         output,
+			ReasoningTokens:      thinking,
+			CacheReadInputTokens: cacheRead,
+			OccurredAt:           occurredAt,
+		})
+	}
+	return events
 }

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -1464,14 +1464,14 @@ func extractAgyGeneratorUsage(
 		}
 
 		// Find the planner message this generation produced.
-		target := -1
+		var targetMsg *ParsedMessage
 		fallbackStep := -1
 		for _, si := range gen.StepIndices {
 			k, ok := plannerMsgIdx[si]
 			if !ok || k < 0 || k >= len(msgs) {
 				continue
 			}
-			target = k
+			targetMsg = &msgs[k]
 			fallbackStep = si
 			break
 		}
@@ -1497,16 +1497,16 @@ func extractAgyGeneratorUsage(
 		// generation already claimed it (should not happen: no planner
 		// step is claimed by two generations in observed sidecars).
 		// Either way the usage event below is still emitted.
-		if target >= 0 &&
-			!msgs[target].HasContextTokens &&
-			!msgs[target].HasOutputTokens {
+		if targetMsg != nil &&
+			!targetMsg.HasContextTokens &&
+			!targetMsg.HasOutputTokens {
 			if model != "" {
-				msgs[target].Model = model
+				targetMsg.Model = model
 			}
-			msgs[target].ContextTokens = input + cacheRead
-			msgs[target].OutputTokens = output
-			msgs[target].HasContextTokens = input+cacheRead > 0
-			msgs[target].HasOutputTokens = output > 0
+			targetMsg.ContextTokens = input + cacheRead
+			targetMsg.OutputTokens = output
+			targetMsg.HasContextTokens = input+cacheRead > 0
+			targetMsg.HasOutputTokens = output > 0
 		}
 
 		// OutputTokens already includes thinking (empirical invariant)

--- a/internal/parser/antigravity_crypto.go
+++ b/internal/parser/antigravity_crypto.go
@@ -14,6 +14,19 @@ import (
 // tries CTR (primary) then CBC / GCM with various skip offsets.
 // We mirror that strategy with Go stdlib primitives.
 //
+// LAST RESORT. This is the lowest-priority decode path for
+// legacy .pb sessions; agy-reader trajectory.json sidecars are
+// the documented, preferred path, and the history.jsonl + brain
+// fallbacks rank above this too (priority: sidecar > history
+// fallback > this). It is kept because it is the only decode
+// that works with zero agy-reader setup on archived .pb files.
+// Current Antigravity CLI versions no longer produce .pb files,
+// so this path serves only pre-existing archives; every parallel
+// reimplementation of the undocumented agy format is a breakage
+// surface per agy release, so this code is deliberately not
+// extended and is a removal candidate once archived .pb sessions
+// without sidecars are no longer a concern.
+//
 // Key sources (v1, in order):
 //  1. ANTIGRAVITY_KEY env var, base64-encoded (matches the
 //     Python tool's env-var fallback).

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -1740,6 +1740,45 @@ func TestAntigravityCLIDBWithoutGenMetadataGetsSidecarUsage(t *testing.T) {
 	assert.True(t, sess.HasPeakContextTokens)
 }
 
+func TestAntigravityCLINonCoveringSidecarUsageRejected(t *testing.T) {
+	root := t.TempDir()
+	id := "acacacac-bdbd-cece-dfdf-565656565656"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // 2 raw steps, no gen_metadata table
+
+	// Sidecar lags the DB: 1 step vs 2 raw rows. Its generatorMetadata
+	// would decode to a usage event, but a lagging sidecar has only seen
+	// part of the session, so persisting it would underreport totals on
+	// a row that looks current.
+	genJSON := `[{
+		"stepIndices": [0],
+		"chatModel": {
+			"model": "MODEL_PLACEHOLDER_M20",
+			"usage": {
+				"inputTokens": "1500",
+				"outputTokens": "77"
+			}
+		}
+	}]`
+	writeAntigravityTestSidecarWithGenMetadata(t, root, id, 1, genJSON)
+
+	sess, msgs, usageEvents, status, err := ParseAntigravityCLISessionWithStatus(
+		dbPath, "", "test-machine",
+	)
+	require.NoError(t, err)
+	assert.False(t, status.NeedsRetry)
+	require.NotEmpty(t, msgs)
+	assert.Equal(t, "user prompt text goes here", msgs[0].Content,
+		"non-covering sidecar must lose the transcript to the DB decode")
+
+	assert.Empty(t, usageEvents,
+		"non-covering sidecar usage must be rejected like its transcript")
+	assert.False(t, sess.HasTotalOutputTokens)
+	assert.False(t, sess.HasPeakContextTokens)
+}
+
 func TestAgyTokenCountUnmarshal(t *testing.T) {
 	tcs := []struct {
 		name string

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -1752,6 +1752,8 @@ func TestAgyTokenCountUnmarshal(t *testing.T) {
 		{"null", `null`, 0},
 		{"garbage string", `"abc"`, 0},
 		{"object garbage", `{"bogus":true}`, 0},
+		{"negative quoted", `"-5"`, 0},
+		{"negative bare", `-5`, 0},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"database/sql"
 	"encoding/binary"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1179,6 +1180,20 @@ func writeAntigravityTestSidecar(
 	t *testing.T, root, id string, numSteps int,
 ) string {
 	t.Helper()
+	return writeAntigravityTestSidecarWithGenMetadata(
+		t, root, id, numSteps, "",
+	)
+}
+
+// writeAntigravityTestSidecarWithGenMetadata writes the same fixed
+// step sequence as writeAntigravityTestSidecar plus an optional
+// generatorMetadata JSON array (steps: 0=USER_INPUT,
+// 1=PLANNER_RESPONSE, 2=RUN_COMMAND; realistic generations use
+// stepIndices [1,2]).
+func writeAntigravityTestSidecarWithGenMetadata(
+	t *testing.T, root, id string, numSteps int, genMetadataJSON string,
+) string {
+	t.Helper()
 	allSteps := []string{
 		`{
 			"type": "CORTEX_STEP_TYPE_USER_INPUT",
@@ -1213,7 +1228,11 @@ func writeAntigravityTestSidecar(
 	}
 	require.LessOrEqual(t, numSteps, len(allSteps))
 	body := `{"trajectoryId":"traj","cascadeId":"` + id + `","steps":[` +
-		strings.Join(allSteps[:numSteps], ",") + `]}`
+		strings.Join(allSteps[:numSteps], ",") + `]`
+	if genMetadataJSON != "" {
+		body += `,"generatorMetadata":` + genMetadataJSON
+	}
+	body += `}`
 	p := filepath.Join(root, "conversations", id+".trajectory.json")
 	mustWrite(t, p, []byte(body))
 	return p
@@ -1436,7 +1455,9 @@ func TestAntigravityCLISidecarWinsKeepsTokenUsage(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	// Sidecar covers both raw steps, so its transcript wins over the
-	// DB decode and the selected messages carry no token fields.
+	// DB decode. This sidecar has no generatorMetadata, so the selected
+	// messages carry no token fields and usage flows only from the DB
+	// gen_metadata events.
 	writeAntigravityTestSidecar(t, root, id, 2)
 
 	sess, msgs, usageEvents, status, err := ParseAntigravityCLISessionWithStatus(
@@ -1498,6 +1519,345 @@ func TestAntigravityCLISidecarRescueKeepsGenMetadataUsage(t *testing.T) {
 	assert.Equal(t, 30, usageEvents[0].ReasoningTokens)
 	assert.Equal(t, 210, sess.TotalOutputTokens)
 	assert.Equal(t, 2400, sess.PeakContextTokens)
+}
+
+func TestAntigravityCLIPBSidecarEmitsUsageEvents(t *testing.T) {
+	root := t.TempDir()
+	id := "ffffffff-0000-1111-2222-333333333333"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	pbPath := filepath.Join(root, "conversations", id+".pb")
+	mustWrite(t, pbPath, []byte("pb-junk-bytes"))
+
+	// Gen A claims the planner step (1) and its tool step (2). Gen B
+	// only claims a non-planner step. Gen C is the failed/retried
+	// usage:{} case and must be skipped.
+	genJSON := `[
+		{
+			"stepIndices": [1, 2],
+			"chatModel": {
+				"model": "MODEL_PLACEHOLDER_M20",
+				"chatStartMetadata": {"createdAt": "2026-06-10T20:40:30Z"},
+				"usage": {
+					"inputTokens": "19733",
+					"outputTokens": "253",
+					"thinkingOutputTokens": "208"
+				}
+			}
+		},
+		{
+			"stepIndices": [2],
+			"chatModel": {
+				"model": "MODEL_PLACEHOLDER_M20",
+				"usage": {
+					"inputTokens": "1820",
+					"outputTokens": "97",
+					"cacheReadTokens": "18661"
+				}
+			}
+		},
+		{
+			"stepIndices": [2],
+			"chatModel": {
+				"model": "MODEL_PLACEHOLDER_M20",
+				"usage": {}
+			}
+		}
+	]`
+	writeAntigravityTestSidecarWithGenMetadata(t, root, id, 3, genJSON)
+
+	sess, msgs, usageEvents, status, err := ParseAntigravityCLISessionWithStatus(
+		pbPath, "", "test-machine",
+	)
+	require.NoError(t, err)
+	assert.False(t, status.NeedsRetry)
+
+	require.Len(t, usageEvents, 2, "usage:{} generation must be skipped")
+
+	evA := usageEvents[0]
+	assert.Equal(t, "sidecar", evA.Source)
+	assert.Equal(t, "MODEL_PLACEHOLDER_M20", evA.Model,
+		"placeholder model names are kept verbatim")
+	assert.Equal(t, 19733, evA.InputTokens)
+	assert.Equal(t, 253, evA.OutputTokens,
+		"outputTokens already includes thinking; no re-fold")
+	assert.Equal(t, 208, evA.ReasoningTokens)
+	assert.Equal(t, 0, evA.CacheReadInputTokens)
+	assert.Equal(t, "2026-06-10T20:40:30Z", evA.OccurredAt,
+		"chatStartMetadata.createdAt formatted RFC3339Nano")
+	assert.Empty(t, evA.DedupKey)
+	assert.Nil(t, evA.MessageOrdinal)
+	assert.Equal(t, sess.ID, evA.SessionID)
+
+	evB := usageEvents[1]
+	assert.Equal(t, "sidecar", evB.Source)
+	assert.Equal(t, 1820, evB.InputTokens)
+	assert.Equal(t, 97, evB.OutputTokens)
+	assert.Equal(t, 0, evB.ReasoningTokens)
+	assert.Equal(t, 18661, evB.CacheReadInputTokens)
+	assert.Empty(t, evB.OccurredAt,
+		"no chatStartMetadata and no mapped planner step")
+	assert.Equal(t, sess.ID, evB.SessionID)
+
+	// Gen A attributes its tokens to the planner message.
+	require.Len(t, msgs, 3)
+	planner := msgs[1]
+	assert.Equal(t, RoleAssistant, planner.Role)
+	assert.Equal(t, "MODEL_PLACEHOLDER_M20", planner.Model)
+	assert.Equal(t, 19733, planner.ContextTokens,
+		"context = input + cacheRead of the first attributing gen")
+	assert.Equal(t, 253, planner.OutputTokens)
+	assert.True(t, planner.HasContextTokens)
+	assert.True(t, planner.HasOutputTokens)
+	assert.Empty(t, planner.TokenUsage,
+		"raw token_usage must stay empty or analytics double-count")
+
+	// Session totals come from the events: output sums, peak context
+	// is max(input + cacheRead).
+	assert.Equal(t, 253+97, sess.TotalOutputTokens)
+	assert.Equal(t, 1820+18661, sess.PeakContextTokens)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+}
+
+func TestAntigravityCLIDBGenMetadataWinsOverSidecarUsage(t *testing.T) {
+	root := t.TempDir()
+	id := "abababab-cdcd-efef-0101-232323232323"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	createAntigravityStepTables(t, db)
+	mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+
+	tsEarly := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000000}})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{num: 17, wire: pbWireBytes, bytes: []byte("user question text goes here and is long")},
+	})
+	tsLate := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000100}})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsLate},
+		{num: 17, wire: pbWireBytes, bytes: []byte("assistant response body goes here and is long")},
+	})
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 14, ?)`, userPayload)
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 17, ?)`, asstPayload)
+
+	genData := createAntigravityMockGenMetadata(t, 2400, 180, 30, "Test Gemini 3.5")
+	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
+	require.NoError(t, db.Close())
+
+	// Covering sidecar whose generatorMetadata carries DIFFERENT
+	// numbers than the DB gen_metadata: the DB events must win so the
+	// generation is not double counted, while the sidecar transcript
+	// still carries per-message attribution from the sidecar numbers.
+	genJSON := `[{
+		"stepIndices": [1],
+		"chatModel": {
+			"model": "MODEL_PLACEHOLDER_M132",
+			"usage": {
+				"inputTokens": "5000",
+				"outputTokens": "111",
+				"thinkingOutputTokens": "60"
+			}
+		}
+	}]`
+	writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
+
+	sess, msgs, usageEvents, status, err := ParseAntigravityCLISessionWithStatus(
+		dbPath, "", "test-machine",
+	)
+	require.NoError(t, err)
+	assert.False(t, status.NeedsRetry)
+	require.NotEmpty(t, msgs)
+	assert.Equal(t, "sidecar prompt", msgs[0].Content, "sidecar transcript should win")
+
+	// Exactly one event: gen_metadata wins, sidecar events fill gaps only.
+	require.Len(t, usageEvents, 1)
+	assert.Equal(t, "generation", usageEvents[0].Source)
+	assert.Equal(t, 2400, usageEvents[0].InputTokens)
+	assert.Equal(t, 210, usageEvents[0].OutputTokens)
+
+	// Session totals follow the winning gen_metadata events.
+	assert.Equal(t, 210, sess.TotalOutputTokens)
+	assert.Equal(t, 2400, sess.PeakContextTokens)
+
+	// Per-message attribution comes from the sidecar generatorMetadata.
+	require.Len(t, msgs, 2)
+	planner := msgs[1]
+	assert.Equal(t, RoleAssistant, planner.Role)
+	assert.Equal(t, "MODEL_PLACEHOLDER_M132", planner.Model)
+	assert.Equal(t, 5000, planner.ContextTokens)
+	assert.Equal(t, 111, planner.OutputTokens)
+	assert.True(t, planner.HasContextTokens)
+	assert.True(t, planner.HasOutputTokens)
+}
+
+func TestAntigravityCLIDBWithoutGenMetadataGetsSidecarUsage(t *testing.T) {
+	root := t.TempDir()
+	id := "acacacac-bdbd-cece-dfdf-454545454545"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // 2 raw steps, no gen_metadata table
+
+	genJSON := `[{
+		"stepIndices": [1],
+		"chatModel": {
+			"model": "MODEL_PLACEHOLDER_M20",
+			"usage": {
+				"inputTokens": "1500",
+				"outputTokens": "77",
+				"thinkingOutputTokens": "20",
+				"cacheReadTokens": "300"
+			}
+		}
+	}]`
+	writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
+
+	sess, msgs, usageEvents, status, err := ParseAntigravityCLISessionWithStatus(
+		dbPath, "", "test-machine",
+	)
+	require.NoError(t, err)
+	assert.False(t, status.NeedsRetry)
+	require.NotEmpty(t, msgs)
+	assert.Equal(t, "sidecar prompt", msgs[0].Content)
+
+	// No gen_metadata table: sidecar generatorMetadata fills the gap.
+	require.Len(t, usageEvents, 1)
+	assert.Equal(t, "sidecar", usageEvents[0].Source)
+	assert.Equal(t, "MODEL_PLACEHOLDER_M20", usageEvents[0].Model)
+	assert.Equal(t, 1500, usageEvents[0].InputTokens)
+	assert.Equal(t, 77, usageEvents[0].OutputTokens)
+	assert.Equal(t, 20, usageEvents[0].ReasoningTokens)
+	assert.Equal(t, 300, usageEvents[0].CacheReadInputTokens)
+	assert.Equal(t, sess.ID, usageEvents[0].SessionID)
+
+	assert.Equal(t, 77, sess.TotalOutputTokens)
+	assert.Equal(t, 1800, sess.PeakContextTokens)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+}
+
+func TestAgyTokenCountUnmarshal(t *testing.T) {
+	tcs := []struct {
+		name string
+		json string
+		want int
+	}{
+		{"quoted number", `"21186"`, 21186},
+		{"bare number", `21186`, 21186},
+		{"empty string", `""`, 0},
+		{"null", `null`, 0},
+		{"garbage string", `"abc"`, 0},
+		{"object garbage", `{"bogus":true}`, 0},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var c agyTokenCount
+			require.NoError(t, json.Unmarshal([]byte(tc.json), &c),
+				"garbage must decode to 0, never error")
+			assert.Equal(t, tc.want, int(c))
+		})
+	}
+
+	t.Run("surrounding object survives garbage", func(t *testing.T) {
+		var u agyChatModelUsage
+		require.NoError(t, json.Unmarshal([]byte(
+			`{"inputTokens":{"bogus":true},"outputTokens":"5"}`,
+		), &u))
+		assert.Equal(t, 0, int(u.InputTokens))
+		assert.Equal(t, 5, int(u.OutputTokens))
+	})
+}
+
+func TestAntigravityCLISidecarUsageStepIndexEdgeCases(t *testing.T) {
+	const usageJSON = `"usage":{"inputTokens":"100","outputTokens":"10"}`
+	tcs := []struct {
+		name        string
+		gens        string
+		wantEvents  int
+		wantAttrib  bool
+		wantContext int
+		wantOutput  int
+	}{
+		{
+			name: "non-planner step indices emit event without attribution",
+			gens: `[{"stepIndices":[2],"chatModel":{` +
+				`"model":"MODEL_PLACEHOLDER_M20",` + usageJSON + `}}]`,
+			wantEvents: 1,
+		},
+		{
+			name: "empty step indices",
+			gens: `[{"stepIndices":[],"chatModel":{` +
+				`"model":"MODEL_PLACEHOLDER_M20",` + usageJSON + `}}]`,
+			wantEvents: 1,
+		},
+		{
+			name: "out of range step index does not panic",
+			gens: `[{"stepIndices":[99],"chatModel":{` +
+				`"model":"MODEL_PLACEHOLDER_M20",` + usageJSON + `}}]`,
+			wantEvents: 1,
+		},
+		{
+			name: "two gens claiming one planner: first attributes",
+			gens: `[{"stepIndices":[1],"chatModel":{` +
+				`"model":"MODEL_PLACEHOLDER_M20",` + usageJSON + `}},` +
+				`{"stepIndices":[1],"chatModel":{` +
+				`"model":"MODEL_PLACEHOLDER_M132",` +
+				`"usage":{"inputTokens":"999","outputTokens":"99"}}}]`,
+			wantEvents:  2,
+			wantAttrib:  true,
+			wantContext: 100,
+			wantOutput:  10,
+		},
+		{
+			name:       "missing chatModel skipped",
+			gens:       `[{"stepIndices":[1]}]`,
+			wantEvents: 0,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			id := "edededed-0101-2323-4545-676767676767"
+			mustMkdir(t, filepath.Join(root, "conversations"))
+			pbPath := filepath.Join(root, "conversations", id+".pb")
+			mustWrite(t, pbPath, []byte("pb-junk-bytes"))
+			writeAntigravityTestSidecarWithGenMetadata(
+				t, root, id, 3, tc.gens,
+			)
+
+			_, msgs, usageEvents, _, err := ParseAntigravityCLISessionWithStatus(
+				pbPath, "", "test-machine",
+			)
+			require.NoError(t, err)
+			assert.Len(t, usageEvents, tc.wantEvents)
+
+			var planner *ParsedMessage
+			for i := range msgs {
+				if msgs[i].Role == RoleAssistant {
+					planner = &msgs[i]
+					break
+				}
+			}
+			require.NotNil(t, planner)
+			if tc.wantAttrib {
+				assert.True(t, planner.HasContextTokens)
+				assert.True(t, planner.HasOutputTokens)
+				assert.Equal(t, tc.wantContext, planner.ContextTokens)
+				assert.Equal(t, tc.wantOutput, planner.OutputTokens)
+				assert.Equal(t, "MODEL_PLACEHOLDER_M20", planner.Model,
+					"second gen claiming the planner stays event-only")
+			} else {
+				assert.False(t, planner.HasContextTokens)
+				assert.False(t, planner.HasOutputTokens)
+				assert.Zero(t, planner.ContextTokens)
+				assert.Zero(t, planner.OutputTokens)
+			}
+		})
+	}
 }
 
 // TestAntigravitySessionFileMetadataIncludesWAL verifies the persisted

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2338,6 +2338,73 @@ func TestExtractTokenUsageFalsePositiveGuards(t *testing.T) {
 	}
 }
 
+// TestExtractModelNameRejectsNonPrintable verifies that field 21/19
+// payloads that are valid UTF-8 but not human-readable text (nested
+// protobuf messages whose low bytes pass utf8.Valid) are rejected
+// instead of being persisted as the model name. The fragment bytes are
+// the exact gen_metadata field-21 payload observed in production
+// sessions, which leaked into messages.model with an embedded NUL byte
+// and broke `pg push` (PG rejects NUL with SQLSTATE 22021).
+func TestExtractModelNameRejectsNonPrintable(t *testing.T) {
+	// hex 080020022A0201024001: a nested message (field 1 varint,
+	// field 4 varint, field 5 bytes, field 8 varint), all bytes
+	// < 0x80 so utf8.Valid accepts it.
+	protoFragment := []byte{
+		0x08, 0x00, 0x20, 0x02, 0x2A, 0x02,
+		0x01, 0x02, 0x40, 0x01,
+	}
+	tests := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{
+			name: "real protobuf fragment in field 21",
+			data: encodePB([]pbField{
+				{num: 21, wire: pbWireBytes, bytes: protoFragment},
+			}),
+			want: "",
+		},
+		{
+			name: "fragment in field 21 falls back to field 19",
+			data: encodePB([]pbField{
+				{num: 21, wire: pbWireBytes, bytes: protoFragment},
+				{num: 19, wire: pbWireBytes, bytes: []byte("gemini-3-pro")},
+			}),
+			want: "gemini-3-pro",
+		},
+		{
+			name: "fragment at top level falls through to nested model",
+			data: encodePB([]pbField{
+				{num: 21, wire: pbWireBytes, bytes: protoFragment},
+				{num: 2, wire: pbWireBytes, bytes: encodePB([]pbField{
+					{num: 21, wire: pbWireBytes, bytes: []byte("gemini-3-flash")},
+				})},
+			}),
+			want: "gemini-3-flash",
+		},
+		{
+			name: "digits-only value is rejected",
+			data: encodePB([]pbField{
+				{num: 21, wire: pbWireBytes, bytes: []byte("12345678")},
+			}),
+			want: "",
+		},
+		{
+			name: "plain model name still accepted",
+			data: encodePB([]pbField{
+				{num: 21, wire: pbWireBytes, bytes: []byte("Test Gemini 3.5")},
+			}),
+			want: "Test Gemini 3.5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractModelName(tt.data))
+		})
+	}
+}
+
 // TestExtractTokenUsageNoReasoningField verifies a real token block is
 // accepted when field 3 is absent: proto3 omits zero values, and zero
 // reasoning tokens is a legitimate generation.

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -706,6 +706,12 @@ func accumulateMessageTokenUsage(
 // therefore covers transcripts that dropped steps (sidecar wins,
 // undecodable rows) without double counting. Message-derived totals
 // are kept where the events are silent.
+//
+// Peak context counts the full context window per event: fresh input
+// plus cache-creation and cache-read tokens. That keeps event-derived
+// session totals consistent with per-message ContextTokens attribution
+// (input + cacheRead) from parsers whose events carry cache fields,
+// such as the Antigravity CLI sidecar parser.
 func applyUsageEventTokenTotals(
 	sess *ParsedSession,
 	events []ParsedUsageEvent,
@@ -719,10 +725,13 @@ func applyUsageEventTokenTotals(
 			hasOutput = true
 			totalOutput += ev.OutputTokens
 		}
-		if ev.InputTokens > 0 {
+		context := ev.InputTokens +
+			ev.CacheCreationInputTokens +
+			ev.CacheReadInputTokens
+		if context > 0 {
 			hasContext = true
-			if ev.InputTokens > peakContext {
-				peakContext = ev.InputTokens
+			if context > peakContext {
+				peakContext = context
 			}
 		}
 	}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1883,11 +1883,11 @@ func (s *Sync) normalizeSyncTimestamps(
 
 // sanitizePG strips null bytes and replaces invalid UTF-8
 // sequences so text can be safely inserted into PostgreSQL,
-// which enforces strict UTF-8 encoding.
+// which enforces strict UTF-8 encoding. It delegates to
+// db.SanitizeUTF8 so the local fingerprint builders apply the
+// exact same normalization.
 func sanitizePG(s string) string {
-	s = strings.ReplaceAll(s, "\x00", "")
-	s = strings.ToValidUTF8(s, "")
-	return s
+	return db.SanitizeUTF8(s)
 }
 
 func nilIfEmpty(s string) any {

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -909,15 +909,17 @@ func (s *Sync) pushSession(
 		sess.TotalOutputTokens, sess.PeakContextTokens,
 		sess.HasTotalOutputTokens, sess.HasPeakContextTokens,
 		isAutomated, sess.DataVersion,
-		sess.Cwd, sess.GitBranch, sess.SourceSessionID,
-		sess.SourceVersion, sess.ParserMalformedLines,
+		sanitizePG(sess.Cwd), sanitizePG(sess.GitBranch),
+		sanitizePG(sess.SourceSessionID),
+		sanitizePG(sess.SourceVersion),
+		sess.ParserMalformedLines,
 		sess.IsTruncated, nilStr(sess.TerminationStatus),
 		nilStr(sess.ParentSessionID),
 		sess.RelationshipType,
 		sess.ToolFailureSignalCount, sess.ToolRetryCount,
 		sess.EditChurnCount, sess.ConsecutiveFailureMax,
 		sess.Outcome, sess.OutcomeConfidence,
-		sess.EndedWithRole, sess.FinalFailureStreak,
+		sanitizePG(sess.EndedWithRole), sess.FinalFailureStreak,
 		nilStr(sess.SignalsPendingSince),
 		sess.CompactionCount, sess.MidTaskCompactionCount,
 		sess.ContextPressureMax,
@@ -1528,18 +1530,28 @@ func bulkInsertMessages(
 					ts = t
 				}
 			}
+			// Sanitize every parser-derived string, not just
+			// content: model and source fields come from
+			// third-party session files and have carried NUL
+			// bytes (e.g. raw protobuf fragments), which PG
+			// rejects with SQLSTATE 22021.
 			args = append(args,
-				sessionID, m.Ordinal, m.Role,
+				sessionID, m.Ordinal, sanitizePG(m.Role),
 				sanitizePG(m.Content),
 				sanitizePG(m.ThinkingText), ts,
 				m.HasThinking,
 				m.HasToolUse, m.ContentLength, m.IsSystem,
-				m.Model, string(m.TokenUsage),
+				sanitizePG(m.Model),
+				sanitizePG(string(m.TokenUsage)),
 				m.ContextTokens, m.OutputTokens,
 				m.HasContextTokens, m.HasOutputTokens,
-				m.ClaudeMessageID, m.ClaudeRequestID,
-				m.SourceType, m.SourceSubtype, m.SourceUUID,
-				m.SourceParentUUID, m.IsSidechain,
+				sanitizePG(m.ClaudeMessageID),
+				sanitizePG(m.ClaudeRequestID),
+				sanitizePG(m.SourceType),
+				sanitizePG(m.SourceSubtype),
+				sanitizePG(m.SourceUUID),
+				sanitizePG(m.SourceParentUUID),
+				m.IsSidechain,
 				m.IsCompactBoundary,
 			)
 		}
@@ -1836,7 +1848,7 @@ func (s *Sync) pushSecretFindings(
 				f.LocationKind, f.MessageOrdinal,
 				f.CallIndex, f.EventIndex,
 				f.MatchStart, f.MatchEnd, f.MatchIndex,
-				f.RedactedMatch, f.RulesVersion,
+				sanitizePG(f.RedactedMatch), f.RulesVersion,
 			)
 		}
 		if _, err := tx.ExecContext(

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -315,3 +315,82 @@ func checkIsSystem(
 		assert.True(t, seen[i], "ordinal %d missing from PG messages", i)
 	}
 }
+
+// TestPushMessagesSanitizesNULBytes verifies that a message whose
+// model and source fields carry NUL bytes (observed in production:
+// the Antigravity gen_metadata heuristic persisted a raw protobuf
+// fragment as the model name) pushes to PG without the whole-session
+// rollback caused by SQLSTATE 22021 (invalid byte sequence for
+// encoding "UTF8": 0x00). Model and source fields come from
+// third-party session files, so the push boundary must be defensive
+// regardless of any single parser fix.
+func TestPushMessagesSanitizesNULBytes(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_nul_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(
+		filepath.Join(t.TempDir(), "local.db"),
+	)
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	// The exact 10-byte protobuf fragment persisted as a model
+	// name by the pre-fix Antigravity parser (hex
+	// 080020022A0201024001, contains 0x00).
+	badModel := "\x08\x00\x20\x02\x2a\x02\x01\x02\x40\x01"
+
+	const sessID = "nul-bytes-001"
+	sess := db.Session{
+		ID:           sessID,
+		Project:      "test-proj",
+		Machine:      "test-machine",
+		Agent:        "antigravity",
+		MessageCount: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+		Cwd:          "/tmp/with\x00nul",
+		GitBranch:    "main\x00",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+
+	msgs := []db.Message{{
+		SessionID:     sessID,
+		Ordinal:       0,
+		Role:          "assistant",
+		Content:       "thinking summary",
+		ContentLength: 16,
+		Model:         badModel,
+		SourceUUID:    "uuid\x00tail",
+	}}
+	require.NoError(t, localDB.InsertMessages(msgs), "InsertMessages")
+
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push")
+	assert.Zero(t, res.Errors, "push should report no failed sessions")
+
+	var model, sourceUUID string
+	err = pg.QueryRow(
+		`SELECT model, source_uuid FROM messages
+		 WHERE session_id = $1 AND ordinal = 0`, sessID,
+	).Scan(&model, &sourceUUID)
+	require.NoError(t, err, "querying pushed message")
+	assert.Equal(t, sanitizePG(badModel), model, "model stripped of NUL")
+	assert.NotContains(t, model, "\x00")
+	assert.Equal(t, "uuidtail", sourceUUID, "source_uuid stripped of NUL")
+}

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -393,4 +393,34 @@ func TestPushMessagesSanitizesNULBytes(t *testing.T) {
 	assert.Equal(t, sanitizePG(badModel), model, "model stripped of NUL")
 	assert.NotContains(t, model, "\x00")
 	assert.Equal(t, "uuidtail", sourceUUID, "source_uuid stripped of NUL")
+
+	// Second push with sync state cleared: the local token
+	// fingerprint (sanitized, see db.SanitizeUTF8) must match the
+	// PG-readback fingerprint despite the NUL bytes still stored
+	// locally, so the metadata fast path skips the rewrite. ctid
+	// changes on DELETE+reinsert, so an unchanged ctid proves the
+	// row was left alone.
+	var ctidBefore string
+	require.NoError(t, pg.QueryRow(
+		`SELECT ctid::text FROM messages
+		 WHERE session_id = $1 AND ordinal = 0`, sessID,
+	).Scan(&ctidBefore), "reading ctid before second push")
+
+	require.NoError(t, localDB.SetSyncState("last_push_at", ""),
+		"clearing last_push_at")
+	require.NoError(t,
+		localDB.SetSyncState(lastPushBoundaryStateKey, ""),
+		"clearing boundary state")
+
+	res, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push (second)")
+	assert.Zero(t, res.Errors, "second push should report no failures")
+
+	var ctidAfter string
+	require.NoError(t, pg.QueryRow(
+		`SELECT ctid::text FROM messages
+		 WHERE session_id = $1 AND ordinal = 0`, sessID,
+	).Scan(&ctidAfter), "reading ctid after second push")
+	assert.Equal(t, ctidBefore, ctidAfter,
+		"fast path should skip rewriting a NUL-field session")
 }

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -3,6 +3,7 @@ package sync_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -474,6 +475,102 @@ func TestSyncSingleSessionAntigravityCLI_DBDecodeFallbackRetries(t *testing.T) {
 	require.NoError(t, env.engine.SyncSingleSession(sessionID))
 	assert.Less(t, env.db.GetSessionDataVersion(sessionID), db.CurrentDataVersion(),
 		"single-session DB decode fallback should demote previously current rows")
+}
+
+// writeAntigravityCLIInferredProjectFixture writes a .db session whose
+// history.jsonl row omits conversationId, so the workspace can only reach
+// the session row through the GH #579 prompt/timestamp inference fallback.
+// The fixture step carries no timestamp, so the parser falls back to the
+// .db mtime; pinning it with Chtimes keeps the 60s window deterministic.
+func writeAntigravityCLIInferredProjectFixture(
+	t *testing.T, env *testEnv, uuid, display, workspace string,
+	dbMtime, rowTime time.Time,
+) {
+	t.Helper()
+
+	convDir := filepath.Join(env.antigravityCLIDir, "conversations")
+	require.NoError(t, os.MkdirAll(convDir, 0o755))
+
+	historyLine := fmt.Sprintf(
+		`{"workspace": %q, "timestamp": %d, "display": %q}`+"\n",
+		workspace, rowTime.UnixMilli(), display,
+	)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(env.antigravityCLIDir, "history.jsonl"),
+		[]byte(historyLine), 0o644,
+	))
+
+	dbPath := filepath.Join(convDir, uuid+".db")
+	createAntigravityCLIDisplayStepDB(t, dbPath, "Fix the flux capacitor BUG")
+	require.NoError(t, os.Chtimes(dbPath, dbMtime, dbMtime))
+}
+
+func TestSyncEngineAntigravityCLI_InferredProjectWithoutConversationID(t *testing.T) {
+	base := time.UnixMilli(1716244800000)
+	// Display differs from the stored prompt in case and extra
+	// leading/trailing/internal whitespace; only the normalized
+	// (lowercased, whitespace-collapsed) forms match.
+	const display = "  fix  THE Flux   Capacitor Bug "
+	const workspace = "/home/user/inferred-project"
+
+	tests := []struct {
+		name        string
+		rowTime     time.Time
+		wantProject string
+	}{
+		{
+			name:        "normalized match within window infers project",
+			rowTime:     base.Add(10 * time.Second),
+			wantProject: workspace,
+		},
+		{
+			name:        "match outside 60s window leaves project empty",
+			rowTime:     base.Add(2 * time.Minute),
+			wantProject: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := setupTestEnv(t)
+			uuid := "ab12cd34-1111-2222-3333-444455556666"
+			sessionID := "antigravity-cli:" + uuid
+
+			writeAntigravityCLIInferredProjectFixture(
+				t, env, uuid, display, workspace, base, tt.rowTime,
+			)
+
+			runSyncAndAssert(t, env.engine, sync.SyncStats{
+				TotalSessions: 1,
+				Synced:        1,
+				Skipped:       0,
+			})
+
+			assertSessionProject(t, env.db, sessionID, tt.wantProject)
+			assertSessionMessageCount(t, env.db, sessionID, 1)
+			msgs := fetchMessages(t, env.db, sessionID)
+			require.Len(t, msgs, 1)
+			assert.Equal(t, "Fix the flux capacitor BUG", msgs[0].Content)
+		})
+	}
+}
+
+func TestSyncSingleSessionAntigravityCLI_InferredProjectWithoutConversationID(t *testing.T) {
+	base := time.UnixMilli(1716244800000)
+	env := setupTestEnv(t)
+	uuid := "cd34ef56-7777-8888-9999-aaaabbbbcccc"
+	sessionID := "antigravity-cli:" + uuid
+
+	writeAntigravityCLIInferredProjectFixture(
+		t, env, uuid, "  fix  THE Flux   Capacitor Bug ",
+		"/home/user/inferred-project-single",
+		base, base.Add(10*time.Second),
+	)
+
+	// The file-watcher path must persist the inferred project too.
+	require.NoError(t, env.engine.SyncSingleSession(sessionID))
+
+	assertSessionProject(t, env.db, sessionID, "/home/user/inferred-project-single")
+	assertSessionMessageCount(t, env.db, sessionID, 1)
 }
 
 func TestSyncEngineAntigravityCLI_MissingPbOrphanSidecar(t *testing.T) {


### PR DESCRIPTION
Follow-up to #591 and the remaining gap after #619: legacy `.pb` sessions have no SQLite `gen_metadata`, so they get no usage data, and sidecar-rendered transcripts carry no per-message model/token attribution.

## What this does

- `parseAntigravityCLITrajectory` now decodes the agy-reader sidecar's `generatorMetadata[]` and emits usage events (`source: "sidecar"`) from `chatModel.usage`: `inputTokens`, `outputTokens` (already includes thinking; not re-folded), `thinkingOutputTokens` as reasoning, and `cacheReadTokens`. Token counts are string-encoded in the sidecar; a tolerant `agyTokenCount` type decodes strings or numbers and treats garbage, null, and negative values as 0 so a malformed sidecar can never fail the transcript or corrupt totals.
- Precedence rule: `gen_metadata`-derived events always win; sidecar events fill the gap only when the DB path produced none (legacy `.pb`, unreadable `.db`, or `.db` without a `gen_metadata` table). A session never mixes the two sources, so nothing double-counts.
- Per-message attribution: each generation maps to the planner-response message in its `stepIndices` range, setting `Model`, `ContextTokens` (input + cache read), and `OutputTokens`. `TokenUsage` raw JSON is deliberately left empty — usage analytics count message rows with non-empty `token_usage`, and events remain the single analytics source.
- Model names from the sidecar are obfuscated enums (`MODEL_PLACEHOLDER_M16`/`M20`/`M132`); they are stored verbatim as a token-count-only, unpriced source (the tradeoff accepted in #591). Real model names still come only from `gen_metadata`.
- `applyUsageEventTokenTotals` peak-context now includes cache fields (no-op for existing callers, whose events never set them) so event totals agree with per-message context.
- dataVersion 38 so settled legacy sessions re-parse and gain usage on next sync.
- New internal/sync regression test covering #579's project-inference fallback through `SyncAll`/`SyncSingleSession` persistence (history row without `conversationId`), which previously had parser-only coverage.
- Comment-only docs marking the `.pb` AES decryptor (`antigravity_crypto.go`) as the explicit last-resort decode path.

## Limitations

- `chatModel.retryInfos[]` per-attempt usage is not summed, so retried generations may undercount (noted in a code comment).
- `outputTokens ⊇ thinkingOutputTokens` containment is an empirically verified invariant of current sidecars (26 sidecars / 1839 generations checked), recorded in a comment.
- Sidecar usage events for `.pb`-only sessions are unpriced ($0), matching what the #591 filer accepted.

## Where to look

`internal/parser/antigravity_cli.go` carries the schema types, extraction, and the precedence wiring in `ParseAntigravityCLISessionWithStatus` (both `.db` and `.pb` branches). `TestAntigravityCLIDBGenMetadataWinsOverSidecarUsage` pins the no-double-count rule; `TestAntigravityCLIPBSidecarEmitsUsageEvents` pins the field mapping.

Verified live against a real archive: 15 legacy `.pb`+sidecar sessions gained usage events with placeholder models after resync, `.db` sessions kept their `gen_metadata`-sourced events with no mixed-source sessions, and a freshly recorded session whose `gen_metadata` blob defeats the wire-walk heuristic was rescued by the sidecar gap-fill end to end.

## NUL-byte model names and `pg push` (added after filing)

Two production Antigravity IDE sessions carried a `messages.model` value that
was not a model name but a raw protobuf fragment (hex `080020022A0201024001`,
containing `0x00`): `extractModelName` accepted any field 21/19 payload that
passed `utf8.Valid`, but a nested protobuf message whose bytes are all < 0x80
is valid UTF-8. PostgreSQL rejects NUL in text (`SQLSTATE 22021`), so
`pg push` rolled back those sessions on every run. Fixed in two layers plus a
follow-up:

- `bulkInsertMessages` and `pushSession` now sanitize every parser-derived
  string (model, token_usage, role, claude ids, source fields, cwd,
  git_branch), not just content -- these values come from third-party session
  files, so the PG boundary is defensive regardless of any single parser fix.
- `extractModelName` rejects non-printable candidates
  (`isPlausibleModelName`: printable runes, at least one letter); the walk
  then continues, which in the observed sessions recovered the real
  `gemini-3.5-flash` name from a nested field. Covered by a fixture test
  using the exact production bytes. This shares the dataVersion 38 bump so
  corrupt persisted model values clear on resync.
- The metadata fast path compares local fingerprints against PG-readback
  fingerprints whose values were sanitized at insert; the sanitizer moved to
  `db.SanitizeUTF8` and the local builders apply it too, so a NUL-carrying
  local row no longer forces a full message rewrite on every push. A pgtest
  pins this via unchanged ctid across a forced second push.

Verified live: the two stuck sessions push cleanly and re-parse to the
correct model name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
