### PR TITLE
parser: fuzz the Antigravity wire-walk with output invariants

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,61 @@
+name: Fuzz
+
+# Long-running fuzz exploration of the Antigravity wire-walk
+# (GitHub #648). Every CI run already executes the committed seed
+# corpus via plain `go test`; this workflow spends real fuzz time
+# searching for new invariant violations on a schedule. A found
+# failure is written to testdata/fuzz/ by the fuzz engine and
+# uploaded as an artifact so it can be committed as a regression
+# case.
+
+on:
+  schedule:
+    - cron: "17 5 * * 1" # weekly, Monday 05:17 UTC
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: "Fuzz time per target (Go duration)"
+        required: false
+        default: "10m"
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - FuzzAgProtoParse
+          - FuzzAgProtoLooksLikePrefix
+          - FuzzDecodeAntigravityStep
+          - FuzzExtractModelName
+          - FuzzExtractTokenUsage
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      # The dispatch input goes through an env var, never directly
+      # into the run script, so it cannot inject shell commands.
+      - name: Fuzz ${{ matrix.target }}
+        run: >
+          go test -tags "fts5,kit_posthog_disabled"
+          -fuzz "^${TARGET}$"
+          -fuzztime "$FUZZTIME"
+          ./internal/parser/
+        env:
+          CGO_ENABLED: "1"
+          TARGET: ${{ matrix.target }}
+          FUZZTIME: ${{ github.event.inputs.fuzztime || '10m' }}
+
+      - name: Upload failing inputs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: fuzz-failures-${{ matrix.target }}
+          path: internal/parser/testdata/fuzz/
+          if-no-files-found: ignore

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,7 +28,17 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 38: two Antigravity parsing changes. (a) The Antigravity
+// Bumped to 39: the Antigravity wire-walk hardened its output
+// invariants (issue #648): model-name candidates must be printable,
+// collected strings replace NUL bytes with U+FFFD, nanos values
+// outside the protobuf Timestamp range no longer match
+// timestamp-shaped fields, token blocks whose output+reasoning sum
+// breaches the plausibility cap are rejected, and parses truncate
+// at a total-fields allocation budget. Existing Antigravity rows
+// may hold content/model/usage values the parser no longer
+// produces and need re-parsing.
+//
+// (38: two Antigravity parsing changes. (a) The Antigravity
 // CLI parser extracts generatorMetadata token usage from agy-reader
 // trajectory sidecars: usage events for legacy .pb sessions (and .db
 // sessions without gen_metadata) and per-message model/token
@@ -38,7 +48,7 @@ import (
 // sometimes carries a nested protobuf message whose low bytes are
 // valid UTF-8, and the raw fragment (including NUL bytes) was
 // persisted as messages.model, so existing Antigravity rows need
-// re-parsing to clear the corrupt model values.
+// re-parsing to clear the corrupt model values.)
 //
 // (37: Antigravity and Antigravity CLI parsers now extract
 // per-generation model names and token usage (input, output,
@@ -161,7 +171,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 38
+const dataVersion = 39
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -380,6 +380,9 @@ func extractTokenUsage(data []byte) (input, output, reasoning int, ok bool) {
 // latency counters) lack it. Field 3 stays optional because zero
 // reasoning is legitimate and omitted from the wire, but a present
 // field 3 with a non-varint wire type marks the block as a decoy.
+// The cap also applies to output+reasoning combined, because that sum
+// is the billable output the caller persists: capping the fields only
+// individually would let a decoy block persist up to twice the cap.
 func tokenBlockFrom(fs []agProtoField) (input, output, reasoning int, ok bool) {
 	f1, ok1 := agProtoFind(fs, 1)
 	f2, ok2 := agProtoFind(fs, 2)
@@ -396,7 +399,8 @@ func tokenBlockFrom(fs []agProtoField) (input, output, reasoning int, ok bool) {
 		return 0, 0, 0, false
 	}
 	if f3, hasF3 := agProtoFind(fs, 3); hasF3 {
-		if f3.Wire != pbWireVarint || f3.Varint > maxPlausibleTokens {
+		if f3.Wire != pbWireVarint || f3.Varint > maxPlausibleTokens ||
+			f2.Varint+f3.Varint > maxPlausibleTokens {
 			return 0, 0, 0, false
 		}
 		reasoning = int(f3.Varint)

--- a/internal/parser/antigravity_fuzz_test.go
+++ b/internal/parser/antigravity_fuzz_test.go
@@ -145,10 +145,14 @@ func fuzzAgWireSeeds() [][]byte {
 		onion,
 		bytes.Repeat([]byte{0x08, 0x00}, 64), // dense minimal fields
 		fuzzAgTimestamp(1_779_326_586, 4_000_000_000), // nanos out of range
-		stepWithTS(946_684_800, 0),                    // window lower bound (excluded)
-		stepWithTS(946_684_801, 999_999_999),          // first inside window
-		stepWithTS(4_102_444_799, 999_999_999),        // last inside window
-		stepWithTS(4_102_444_800, 0),                  // window upper bound (excluded)
+		// Out-of-range nanos behind collectable content: the
+		// timestamp is rejected, so the decoded message keeps a
+		// zero Timestamp instead of a shifted one.
+		stepWithTS(1_779_326_586, 4_000_000_000),
+		stepWithTS(946_684_800, 0),             // window lower bound (excluded)
+		stepWithTS(946_684_801, 999_999_999),   // first inside window
+		stepWithTS(4_102_444_799, 999_999_999), // last inside window
+		stepWithTS(4_102_444_800, 0),           // window upper bound (excluded)
 		encodePB([]pbField{
 			{num: 21, wire: pbWireBytes, bytes: []byte("   ")},
 		}), // whitespace-only model candidate

--- a/internal/parser/antigravity_fuzz_test.go
+++ b/internal/parser/antigravity_fuzz_test.go
@@ -1,0 +1,314 @@
+package parser
+
+// Fuzz targets for the Antigravity wire-walk (GitHub #648).
+//
+// The Antigravity format is an undocumented, unversioned protobuf
+// schema that has changed across dot releases; fixtures only cover
+// payload shapes we have happened to observe. These targets assert
+// output INVARIANTS instead of expected values, so corner cases we
+// cannot enumerate still have pinned properties:
+//
+//   - agProtoParse: never panics, returns a structurally sound
+//     field tree bounded by the input, and is deterministic. The
+//     total-fields allocation budget (each two-byte wire field
+//     decodes into a ~100-byte struct, so unbudgeted parses
+//     amplify memory two orders of magnitude) is asserted here
+//     but pinned deterministically by TestAgProtoFieldBudget:
+//     mutated inputs stay far too small to probe it.
+//   - decodeAntigravityStep: content is non-empty valid UTF-8 with
+//     no NUL bytes, roles are in the enum, timestamps are zero or
+//     inside the 2000..2100 plausibility window.
+//   - extractModelName: empty or printable with at least one letter
+//     (the 2026-06-11 incident: a nested protobuf fragment whose
+//     bytes are all < 0x80 is valid UTF-8, leaked into
+//     messages.model, and broke pg push with SQLSTATE 22021).
+//   - extractTokenUsage: counts are non-negative and bounded by
+//     maxPlausibleTokens, including the output+reasoning sum the
+//     caller persists as billable output.
+//
+// Plain `go test` runs the f.Add seeds plus any regression inputs
+// committed under testdata/fuzz/<Target>/, so the corpus is enforced
+// on every CI run; `go test -fuzz=<Target>` explores from there.
+
+import (
+	"bytes"
+	"testing"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// agIncidentFragment is the real gen_metadata fragment (hex
+// 080020022A0201024001) that extractModelName persisted verbatim as
+// a model name before isPlausibleModelName existed: every byte is
+// < 0x80, so it passes utf8.Valid while containing a NUL.
+var agIncidentFragment = []byte{
+	0x08, 0x00, 0x20, 0x02, 0x2A, 0x02, 0x01, 0x02, 0x40, 0x01,
+}
+
+// fuzzAgTimestamp encodes a google.protobuf.Timestamp-shaped message.
+func fuzzAgTimestamp(sec, nanos uint64) []byte {
+	return encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: sec},
+		{num: 2, wire: pbWireVarint, varint: nanos},
+	})
+}
+
+// fuzzAgWireSeeds returns payloads exercising the walker: realistic
+// step and gen_metadata shapes, the incident fragment, and malformed
+// edges (truncated varints, oversized lengths, deep nesting, group
+// wire types, window-boundary timestamps).
+func fuzzAgWireSeeds() [][]byte {
+	userStep := encodePB([]pbField{
+		{num: 3, wire: pbWireBytes, bytes: fuzzAgTimestamp(1_779_326_586, 959_000_000)},
+		{num: 17, wire: pbWireBytes, bytes: []byte(
+			"Please refactor the sync engine to retry failed pushes.",
+		)},
+	})
+	nulStep := encodePB([]pbField{
+		{num: 17, wire: pbWireBytes, bytes: []byte(
+			"abcdefghij\x00klmnopqrstuvwxyz now twenty-plus runes",
+		)},
+	})
+	usageBlock := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1020},
+		{num: 2, wire: pbWireVarint, varint: 1542},
+		{num: 3, wire: pbWireVarint, varint: 256},
+		{num: 5, wire: pbWireVarint, varint: 8133},
+	})
+	genMeta := encodePB([]pbField{
+		{num: 17, wire: pbWireBytes, bytes: usageBlock},
+		{num: 21, wire: pbWireBytes, bytes: []byte("gemini-3.5-flash")},
+	})
+	nestedFragmentModel := encodePB([]pbField{
+		{num: 2, wire: pbWireBytes, bytes: encodePB([]pbField{
+			{num: 21, wire: pbWireBytes, bytes: agIncidentFragment},
+		})},
+	})
+	usageDecoyLatency := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1020},
+		{num: 2, wire: pbWireVarint, varint: 2_000_001},
+		{num: 5, wire: pbWireVarint, varint: 1},
+	})
+	usageDecoyWire := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1020},
+		{num: 2, wire: pbWireVarint, varint: 5},
+		{num: 3, wire: pbWireBytes, bytes: []byte("xx")},
+		{num: 5, wire: pbWireVarint, varint: 9},
+	})
+	usageDecoyFoldedCap := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1020},
+		{num: 2, wire: pbWireVarint, varint: 2_000_000},
+		{num: 3, wire: pbWireVarint, varint: 2_000_000},
+		{num: 5, wire: pbWireVarint, varint: 2_000_000},
+	})
+	onion := []byte("core")
+	for range agProtoMaxDepth + 4 {
+		onion = encodePB([]pbField{
+			{num: 1, wire: pbWireBytes, bytes: onion},
+		})
+	}
+	// Step-shaped payloads (nested timestamp + a collectable
+	// string) so the window-boundary values actually reach the
+	// timestamp assertions in FuzzDecodeAntigravityStep: bare
+	// timestamp messages decode to no content and bail before
+	// any invariant is checked.
+	stepWithTS := func(sec, nanos uint64) []byte {
+		return encodePB([]pbField{
+			{num: 3, wire: pbWireBytes, bytes: fuzzAgTimestamp(sec, nanos)},
+			{num: 17, wire: pbWireBytes, bytes: []byte(
+				"Boundary probe prompt with enough runes to keep.",
+			)},
+		})
+	}
+	return [][]byte{
+		nil,
+		{0x00},                               // zero field number
+		{0x80},                               // truncated tag varint
+		{0x08},                               // varint field, missing value
+		{0x0A, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F}, // length far past input
+		{0x09, 0x01},                         // short fixed64
+		{0x0D, 0x01, 0x02},                   // short fixed32
+		{0x0B, 0x0C},                         // start/end group pair
+		{0x08, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01}, // 10-byte varint
+		agIncidentFragment,
+		userStep,
+		nulStep,
+		genMeta,
+		nestedFragmentModel,
+		usageDecoyLatency,
+		usageDecoyWire,
+		usageDecoyFoldedCap,
+		onion,
+		bytes.Repeat([]byte{0x08, 0x00}, 64), // dense minimal fields
+		fuzzAgTimestamp(1_779_326_586, 4_000_000_000), // nanos out of range
+		stepWithTS(946_684_800, 0),                    // window lower bound (excluded)
+		stepWithTS(946_684_801, 999_999_999),          // first inside window
+		stepWithTS(4_102_444_799, 999_999_999),        // last inside window
+		stepWithTS(4_102_444_800, 0),                  // window upper bound (excluded)
+		encodePB([]pbField{
+			{num: 21, wire: pbWireBytes, bytes: []byte("   ")},
+		}), // whitespace-only model candidate
+		encodePB([]pbField{
+			{num: 19, wire: pbWireBytes, bytes: []byte("123-456_789")},
+		}), // letterless model candidate
+	}
+}
+
+// checkAgProtoFieldTree asserts the structural invariants of a
+// decoded field tree against the buffer it was parsed from: positive
+// field numbers, wire types from the wire-format enum, fixed payloads
+// of exactly 4/8 bytes, length-delimited payloads no longer than the
+// enclosing buffer, and nesting bounded by the recursion cap. Returns
+// the total number of fields in the tree so callers can assert the
+// allocation budget.
+func checkAgProtoFieldTree(
+	t *testing.T, fields []agProtoField, buf []byte, depth int,
+) int {
+	t.Helper()
+	require.LessOrEqual(t, depth, agProtoMaxDepth,
+		"nested past the recursion cap")
+	total := len(fields)
+	for _, f := range fields {
+		assert.GreaterOrEqual(t, f.Number, 1, "field number")
+		switch f.Wire {
+		case pbWireVarint:
+			assert.Nil(t, f.Fixed, "varint field carries fixed bytes")
+			assert.Nil(t, f.Bytes, "varint field carries payload")
+		case pbWireFixed64:
+			assert.Len(t, f.Fixed, 8, "fixed64 payload")
+		case pbWireFixed32:
+			assert.Len(t, f.Fixed, 4, "fixed32 payload")
+		case pbWireBytes:
+			assert.LessOrEqual(t, len(f.Bytes), len(buf),
+				"payload longer than enclosing buffer")
+			if f.Nested != nil {
+				total += checkAgProtoFieldTree(
+					t, f.Nested, f.Bytes, depth+1,
+				)
+			}
+		case pbWireStartGroup, pbWireEndGroup:
+			assert.Nil(t, f.Fixed, "group field carries fixed bytes")
+			assert.Nil(t, f.Bytes, "group field carries payload")
+		default:
+			assert.Failf(t, "unknown wire type",
+				"field %d wire %d", f.Number, f.Wire)
+		}
+	}
+	return total
+}
+
+func FuzzAgProtoParse(f *testing.F) {
+	for _, seed := range fuzzAgWireSeeds() {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fields, err := agProtoParse(data)
+		if err != nil {
+			return
+		}
+		total := checkAgProtoFieldTree(t, fields, data, 0)
+		assert.LessOrEqual(t, total, agProtoMaxFields,
+			"decoded fields exceed the allocation budget")
+		again, err := agProtoParse(data)
+		require.NoError(t, err, "second parse of accepted input")
+		assert.Equal(t, fields, again, "parse is not deterministic")
+	})
+}
+
+func FuzzAgProtoLooksLikePrefix(f *testing.F) {
+	for _, seed := range fuzzAgWireSeeds() {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Panic safety only: the prefix sniff runs on untrusted
+		// decryption candidates, but shares no output contract
+		// with the full parse (it bounds field numbers, the
+		// parser does not).
+		first := agProtoLooksLikePrefix(data)
+		assert.Equal(t, first, agProtoLooksLikePrefix(data),
+			"prefix sniff is not deterministic")
+	})
+}
+
+func FuzzDecodeAntigravityStep(f *testing.F) {
+	for i, seed := range fuzzAgWireSeeds() {
+		f.Add(i, 14, seed)
+		f.Add(i, 2, seed)
+	}
+	windowMin := time.Unix(946_684_801, 0)
+	windowMax := time.Unix(4_102_444_800, 0)
+	f.Fuzz(func(t *testing.T, idx, stepType int, payload []byte) {
+		msg, ok := decodeAntigravityStep(idx, stepType, payload)
+		if !ok {
+			return
+		}
+		require.NotEmpty(t, msg.Content, "decoded message without content")
+		assert.True(t, utf8.ValidString(msg.Content),
+			"content is not valid UTF-8")
+		assert.NotContains(t, msg.Content, "\x00",
+			"content contains a NUL byte")
+		assert.Equal(t, len(msg.Content), msg.ContentLength)
+		wantRole := RoleAssistant
+		if stepType == 14 {
+			wantRole = RoleUser
+		}
+		assert.Equal(t, wantRole, msg.Role)
+		if !msg.Timestamp.IsZero() {
+			assert.False(t, msg.Timestamp.Before(windowMin),
+				"timestamp %v before plausibility window", msg.Timestamp)
+			assert.False(t, !msg.Timestamp.Before(windowMax),
+				"timestamp %v after plausibility window", msg.Timestamp)
+		}
+	})
+}
+
+func FuzzExtractModelName(f *testing.F) {
+	for _, seed := range fuzzAgWireSeeds() {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		model := extractModelName(data)
+		if model == "" {
+			return
+		}
+		hasLetter := false
+		for _, r := range model {
+			assert.True(t, unicode.IsPrint(r),
+				"model %q contains non-printable rune %q", model, r)
+			if unicode.IsLetter(r) {
+				hasLetter = true
+			}
+		}
+		assert.True(t, hasLetter, "model %q has no letters", model)
+	})
+}
+
+func FuzzExtractTokenUsage(f *testing.F) {
+	for _, seed := range fuzzAgWireSeeds() {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		input, output, reasoning, ok := extractTokenUsage(data)
+		if !ok {
+			assert.Zero(t, input)
+			assert.Zero(t, output)
+			assert.Zero(t, reasoning)
+			return
+		}
+		for name, v := range map[string]int{
+			"input": input, "output": output, "reasoning": reasoning,
+		} {
+			assert.GreaterOrEqual(t, v, 0, "%s tokens negative", name)
+			assert.LessOrEqual(t, v, maxPlausibleTokens,
+				"%s tokens above plausibility cap", name)
+		}
+		// The caller persists output+reasoning as billable output,
+		// so the plausibility cap must hold for the sum as well.
+		assert.LessOrEqual(t, output+reasoning, maxPlausibleTokens,
+			"billable output+reasoning above plausibility cap")
+	})
+}

--- a/internal/parser/antigravity_proto.go
+++ b/internal/parser/antigravity_proto.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"encoding/binary"
 	"errors"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -23,7 +24,28 @@ const (
 	// agProtoMaxDepth caps nested-message recursion to keep
 	// malformed payloads from exploding the call stack.
 	agProtoMaxDepth = 32
+
+	// agProtoMaxFields caps the total number of fields decoded
+	// across one parse, including speculative nested re-parses.
+	// Each wire field can be as small as two bytes but decodes
+	// into a ~100-byte agProtoField, so without a budget a flat
+	// run of minimal varint fields amplifies memory by two
+	// orders of magnitude (an 8 MiB blob allocates over 1 GiB).
+	// Step payloads, gen_metadata, and decrypted .pb transcripts
+	// are unbounded blobs, so the depth cap alone does not bound
+	// allocation: the blowup is breadth, not nesting. On
+	// exhaustion the walk truncates rather than fails (see
+	// agProtoParse), so a payload past the budget degrades to a
+	// decoded prefix instead of losing everything. Real payloads
+	// sit well under the cap (the largest observed gen_metadata
+	// blob, 186 KB, could hold at most ~95k minimal fields).
+	agProtoMaxFields = 1 << 20
 )
+
+// errAgProtoBudget signals that the shared total-fields budget ran
+// out mid-walk. It never escapes agProtoParse: the partial result is
+// returned instead.
+var errAgProtoBudget = errors.New("antigravity proto: too many fields")
 
 // agProtoField is one wire-format field decoded from a payload.
 // For length-delimited fields, Bytes holds the raw payload and
@@ -46,13 +68,29 @@ type agProtoField struct {
 
 // agProtoParse decodes a protobuf payload into a flat slice of
 // fields at the top level. Length-delimited sub-payloads are
-// speculatively re-parsed as nested messages.
+// speculatively re-parsed as nested messages. A payload that runs
+// past the total-fields budget yields the decoded prefix rather
+// than an error: the memory bound holds either way, and a huge
+// transcript should degrade to partial content, not disappear.
 func agProtoParse(data []byte) ([]agProtoField, error) {
-	return agProtoParseDepth(data, 0)
+	budget := agProtoMaxFields
+	fields, err := agProtoParseDepth(data, 0, &budget)
+	if errors.Is(err, errAgProtoBudget) {
+		return fields, nil
+	}
+	return fields, err
 }
 
+// agProtoParseDepth decodes one message level. budget is shared
+// across the whole parse tree (failed speculative nested parses
+// included, since their discarded fields were still allocated)
+// and makes total allocation independent of how adversarially
+// dense the input packs its fields. On exhaustion it returns the
+// fields decoded so far alongside errAgProtoBudget; a nested
+// caller drops the partial slice (the payload stays opaque) while
+// the top-level caller keeps it.
 func agProtoParseDepth(
-	data []byte, depth int,
+	data []byte, depth int, budget *int,
 ) ([]agProtoField, error) {
 	if depth > agProtoMaxDepth {
 		return nil, errors.New("antigravity proto: max depth")
@@ -60,6 +98,10 @@ func agProtoParseDepth(
 	var out []agProtoField
 	pos := 0
 	for pos < len(data) {
+		if *budget <= 0 {
+			return out, errAgProtoBudget
+		}
+		*budget--
 		tag, n := binary.Uvarint(data[pos:])
 		if n <= 0 {
 			return nil, errors.New("antigravity proto: bad tag")
@@ -117,7 +159,7 @@ func agProtoParseDepth(
 			f.Bytes = data[pos : pos+int(ln)]
 			pos += int(ln)
 			if nested, err := agProtoParseDepth(
-				f.Bytes, depth+1,
+				f.Bytes, depth+1, budget,
 			); err == nil && agProtoLooksLikeMessage(nested) {
 				f.Nested = nested
 			}
@@ -177,7 +219,12 @@ func agProtoFind(
 
 // agProtoCollectStrings walks the field tree and returns every
 // UTF-8 string with at least minLen runes. Returned in encounter
-// order. Duplicates are preserved (callers can dedupe).
+// order. Duplicates are preserved (callers can dedupe). NUL runes
+// are replaced with U+FFFD: they are valid UTF-8 (NUL-delimited
+// tool output like `git ls-files -z` is realistic content), but a
+// NUL that leaks into persisted content breaks `pg push`
+// (PostgreSQL rejects NUL in text columns with SQLSTATE 22021),
+// so the strings are sanitized rather than dropped.
 func agProtoCollectStrings(
 	fields []agProtoField, minLen int,
 ) []string {
@@ -188,7 +235,8 @@ func agProtoCollectStrings(
 			if f.Wire == pbWireBytes && f.Nested == nil {
 				if s, ok := agProtoString(f); ok &&
 					utf8.RuneCountInString(s) >= minLen {
-					out = append(out, s)
+					out = append(out,
+						strings.ReplaceAll(s, "\x00", "\uFFFD"))
 				}
 			}
 			if f.Nested != nil {
@@ -262,6 +310,11 @@ func agProtoLooksLikePrefix(data []byte) bool {
 // agProtoTimestamp returns (seconds, nanos, ok) when fields
 // match the google.protobuf.Timestamp shape: field 1 varint
 // seconds, optional field 2 varint nanos, and no other fields.
+// A nanos value outside [0, 1e9) marks the message as not a
+// Timestamp: the spec bounds nanos to that range, and a larger
+// varint cast to int32 could go negative and shift time.Unix
+// results outside the plausibility window callers check on
+// seconds alone.
 func agProtoTimestamp(
 	fields []agProtoField,
 ) (int64, int32, bool) {
@@ -277,6 +330,9 @@ func agProtoTimestamp(
 			sec = int64(f.Varint)
 			sawSec = true
 		case 2:
+			if f.Varint >= 1_000_000_000 {
+				return 0, 0, false
+			}
 			nanos = int32(f.Varint)
 		default:
 			return 0, 0, false

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -118,6 +118,42 @@ func TestAgProtoLengthOverflow(t *testing.T) {
 	require.Error(t, err, "expected error for oversized length")
 }
 
+// TestAgProtoFieldBudget verifies the total-fields cap: a flat run
+// of minimal two-byte varint fields amplifies into ~100-byte field
+// structs, so without the budget an unbounded blob could allocate
+// two orders of magnitude more memory than its size. Exhaustion
+// truncates instead of failing, so a payload past the budget keeps
+// its decoded prefix rather than losing all content.
+func TestAgProtoFieldBudget(t *testing.T) {
+	// One field per two bytes: tag 0x08 (field 1, varint), value 0.
+	dense := func(fields int) []byte {
+		return bytes.Repeat([]byte{0x08, 0x00}, fields)
+	}
+
+	within, err := agProtoParse(dense(1000))
+	require.NoError(t, err)
+	assert.Len(t, within, 1000)
+
+	truncated, err := agProtoParse(dense(agProtoMaxFields + 10))
+	require.NoError(t, err)
+	assert.Len(t, truncated, agProtoMaxFields,
+		"expected truncation at the field budget")
+
+	// Speculative nested re-parses consume the shared budget too: a
+	// small envelope around a dense payload must not bypass it. The
+	// exhausted child stays opaque (no Nested) and the field after
+	// it is truncated away, but the parse itself still succeeds.
+	fields, err := agProtoParse(encodePB([]pbField{
+		{num: 1, wire: pbWireBytes, bytes: dense(agProtoMaxFields)},
+		{num: 2, wire: pbWireVarint, varint: 1},
+	}))
+	require.NoError(t, err)
+	require.Len(t, fields, 1,
+		"expected the post-exhaustion field to be truncated")
+	assert.Nil(t, fields[0].Nested,
+		"expected the budget-exhausted child to stay opaque")
+}
+
 // TestAgProtoLooksLikePrefix exercises the prefix-tolerant
 // validator used by the decryption retry loop. It must accept a
 // well-formed prefix followed by a truncated final field, but
@@ -604,6 +640,25 @@ func TestDecodeAntigravityStepKeepsCleanAssistantText(t *testing.T) {
 	assert.NotContains(t, msg.Content, "mYseaoyPDcS6qtsP7c6Z6QE")
 	assert.NotContains(t, msg.Content, "toolAction")
 	assert.NotContains(t, msg.Content, "MODEL_PLACEHOLDER")
+}
+
+// TestDecodeAntigravityStepSanitizesNUL verifies that NUL bytes in
+// otherwise-valid content are replaced rather than the string (or
+// the whole message) being dropped: NUL-delimited tool output such
+// as `git ls-files -z` is realistic transcript content, while a NUL
+// that leaks into persisted text breaks `pg push` (SQLSTATE 22021).
+func TestDecodeAntigravityStepSanitizesNUL(t *testing.T) {
+	payload := encodePB([]pbField{
+		{
+			num: 17, wire: pbWireBytes,
+			bytes: []byte("file_a.go\x00file_b.go\x00file_c.go"),
+		},
+	})
+	msg, ok := decodeAntigravityStep(0, 2, payload)
+	require.True(t, ok, "NUL-bearing content must survive, not drop")
+	assert.NotContains(t, msg.Content, "\x00")
+	assert.Equal(t,
+		"file_a.go�file_b.go�file_c.go", msg.Content)
 }
 
 func TestMergeAntigravityDBHistoryMessagesAppendsMissingPrompts(t *testing.T) {
@@ -2317,6 +2372,18 @@ func TestExtractTokenUsageFalsePositiveGuards(t *testing.T) {
 				{num: 1, wire: pbWireVarint, varint: 1371},
 				{num: 2, wire: pbWireVarint, varint: 1234},
 				{num: 3, wire: pbWireBytes, bytes: []byte("not a varint")},
+				{num: 5, wire: pbWireVarint, varint: 2000},
+			},
+		},
+		{
+			// Output and reasoning are each within the cap, but the
+			// caller persists output+reasoning as billable output, so
+			// the sum must satisfy the cap too.
+			name: "decoy with folded output+reasoning above cap",
+			decoy: []pbField{
+				{num: 1, wire: pbWireVarint, varint: 1371},
+				{num: 2, wire: pbWireVarint, varint: 1_999_999},
+				{num: 3, wire: pbWireVarint, varint: 1_999_999},
 				{num: 5, wire: pbWireVarint, varint: 2000},
 			},
 		},

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -90,6 +90,38 @@ func TestAgProtoParseAndExtract(t *testing.T) {
 	assert.Equal(t, "Hi, what's up next?", strs[0])
 }
 
+// TestAgProtoTimestampNanosRange pins the nanos guard: the protobuf
+// Timestamp spec bounds nanos to [0, 1e9), and an out-of-range varint
+// cast to int32 could go negative and shift time.Unix results outside
+// the plausibility window callers check on seconds alone.
+func TestAgProtoTimestampNanosRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		nanos  uint64
+		wantOK bool
+	}{
+		{"max valid nanos", 999_999_999, true},
+		{"one past the cap", 1_000_000_000, false},
+		{"int32-overflowing nanos", 4_000_000_000, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := encodePB([]pbField{
+				{num: 1, wire: pbWireVarint, varint: 1_779_326_586},
+				{num: 2, wire: pbWireVarint, varint: tt.nanos},
+			})
+			fields, err := agProtoParse(payload)
+			require.NoError(t, err, "parse")
+			sec, nanos, ok := agProtoTimestamp(fields)
+			assert.Equal(t, tt.wantOK, ok, "timestamp ok")
+			if tt.wantOK {
+				assert.Equal(t, int64(1_779_326_586), sec, "timestamp sec")
+				assert.Equal(t, int32(tt.nanos), nanos, "timestamp nanos")
+			}
+		})
+	}
+}
+
 // TestAgProtoLengthOverflow feeds a length-delimited field whose
 // declared length is near uint64-max. The pre-fix code computed
 // pos+ln in uint64 and wrapped, then sliced with int(ln) which


### PR DESCRIPTION
Closes #648.

Adds Go native fuzz targets over the Antigravity wire-walk and hardens the
parser so the asserted invariants hold by construction. The Antigravity format
is reverse-engineered, unversioned, and has changed across dot releases, so
these targets pin output *properties* instead of expected values: corner cases
we cannot enumerate still have enforced contracts.

## Fuzz targets (`internal/parser/antigravity_fuzz_test.go`)

- `FuzzAgProtoParse`: structurally sound field tree (positive field numbers,
  4/8-byte fixed payloads, payloads bounded by the enclosing buffer, nesting
  bounded by the recursion cap, total fields within the allocation budget),
  deterministic.
- `FuzzAgProtoLooksLikePrefix`: panic safety on the decryption-candidate sniff.
- `FuzzDecodeAntigravityStep`: content non-empty, valid UTF-8, NUL-free;
  `ContentLength` consistent; role in enum; timestamp zero or inside the
  2000–2100 plausibility window (boundary seeds are step-shaped so the window
  assertions actually execute; mutation-testing the bounds fails the seeds).
- `FuzzExtractModelName`: empty or printable with at least one letter.
- `FuzzExtractTokenUsage`: counts non-negative and within
  `maxPlausibleTokens`, including the output+reasoning sum the caller
  persists as billable output.

Seeds cover realistic step/gen_metadata shapes, the raw fragment from the
NUL-byte incident (#647), decoy token blocks, window-boundary timestamps, and
malformed wire edges. Plain `go test` executes the seeds, so existing CI
enforces the corpus on every PR with no changes; a new scheduled workflow
(`.github/workflows/fuzz.yml`) runs each target 10 minutes weekly (dispatch
input passed via env var, not interpolated into the script) and uploads
failing inputs as artifacts.

## Parser hardening

Each guard exists because the corresponding invariant did not hold on main,
and each degrades gracefully rather than dropping content:

- `extractModelName` requires printable candidates with at least one letter
  (`isPlausibleModelName`). This hunk is textually identical to the same fix
  on the #647 branch, so whichever PR lands first, the other rebases cleanly.
- `agProtoCollectStrings` replaces NUL with U+FFFD instead of dropping the
  string: NUL-delimited tool output (`git ls-files -z`) is legitimate
  valid-UTF-8 content, but a leaked NUL breaks `pg push` (SQLSTATE 22021).
- `agProtoTimestamp` bounds nanos to [0, 1e9): larger varints cast to int32
  could go negative and shift `time.Unix` results outside the window callers
  check on seconds alone.
- `agProtoParse` threads a total-fields budget (1<<20) across the parse tree,
  including failed speculative nested re-parses. Each two-byte wire field
  decodes into a ~100-byte struct, so a flat run of minimal fields amplifies
  memory ~280x (a measured 8 MiB blob allocated over 1 GiB); step payloads,
  gen_metadata, and decrypted transcripts are unbounded blobs and the depth
  cap cannot bound breadth. Exhaustion truncates (top level keeps the decoded
  prefix, an exhausted speculative child stays opaque) so oversized payloads
  degrade to partial content instead of losing everything.
- `tokenBlockFrom` caps the output+reasoning sum: the caller folds reasoning
  into billable output, so individual caps alone let a decoy block persist
  twice `maxPlausibleTokens` into message tokens, session totals, and usage
  events.

`dataVersion` bumps to 38 so existing Antigravity rows re-parse. This is the
same number #647 uses, deliberately: the bumps touch the same line with
different comment text, so whichever PR lands second gets a visible rebase
conflict and bumps again, rather than a silently merged duplicate version.

## Limitations

- The content invariant is NUL-only by design; other control characters
  (ESC, C1 range) and unbounded printable model names are real but belong to
  a future centralized validation layer, not per-incident guards.
- The budget makes acceptance of pathologically dense >2 MiB payloads
  order-dependent (what fits in the budget survives); real payloads sit an
  order of magnitude under the cap.
- ~90 minutes of cumulative local fuzzing per target (180M+ total execs)
  found no violations after the fixes; the scheduled workflow continues the
  search over time.

Reviewers should look first at the budget threading and truncation semantics
in `internal/parser/antigravity_proto.go` and the fold cap in
`tokenBlockFrom`.
