### PR TITLE
fix(codex): stop double counting history replayed into forked sessions

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -34,7 +34,11 @@ import (
 // the fork's own session id instead of letting the replayed parent
 // session_meta overwrite it. Existing forked rows persist the
 // double-counted totals under the parent's identity, so they need
-// re-parsing to be rewritten with post-fork activity only.
+// re-parsing to be rewritten with post-fork activity only. Resync's
+// orphan copy also skips stale Codex rows whose file_path was
+// reparsed under a different session id, so the old parent-ID row
+// does not survive the rebuild when the parent's own file is gone
+// (see CopyOrphanedDataFromExcluding).
 //
 // (39: the Antigravity wire-walk hardened its output
 // invariants (issue #648): model-name candidates must be printable,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,7 +28,15 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 39: the Antigravity wire-walk hardened its output
+// Bumped to 40: the Codex parser now suppresses the parent history
+// that `codex fork` replays at the top of a forked rollout, which was
+// double counted as the fork's own messages and token usage, and kept
+// the fork's own session id instead of letting the replayed parent
+// session_meta overwrite it. Existing forked rows persist the
+// double-counted totals under the parent's identity, so they need
+// re-parsing to be rewritten with post-fork activity only.
+//
+// (39: the Antigravity wire-walk hardened its output
 // invariants (issue #648): model-name candidates must be printable,
 // collected strings replace NUL bytes with U+FFFD, nanos values
 // outside the protobuf Timestamp range no longer match
@@ -36,7 +44,7 @@ import (
 // breaches the plausibility cap are rejected, and parses truncate
 // at a total-fields allocation budget. Existing Antigravity rows
 // may hold content/model/usage values the parser no longer
-// produces and need re-parsing.
+// produces and need re-parsing.)
 //
 // (38: two Antigravity parsing changes. (a) The Antigravity
 // CLI parser extracts generatorMetadata token usage from agy-reader
@@ -171,7 +179,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 39
+const dataVersion = 40
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3356,6 +3356,75 @@ func TestCopyOrphanedDataFrom(t *testing.T) {
 		"expected 0 tool_calls for s2, got %d", tcCount)
 }
 
+// TestCopyOrphanedDataFrom_SkipsStaleCodexForkRows covers the
+// dataVersion 40 upgrade path (#643): a pre-fix DB stored a forked
+// Codex rollout under the replayed parent's id with double-counted
+// totals. After the fresh sync reparses the same file under the
+// fork's own id, the stale parent-ID row must not be resurrected as
+// an orphan — but genuine Codex orphans (file gone) and SQLite-backed
+// agents that share a file_path across sessions must still be copied.
+func TestCopyOrphanedDataFrom_SkipsStaleCodexForkRows(t *testing.T) {
+	dir := t.TempDir()
+	forkFile := filepath.Join(dir, "fork.jsonl")
+	goneFile := filepath.Join(dir, "gone.jsonl")
+	sharedDB := filepath.Join(dir, "chats.db")
+
+	srcPath := filepath.Join(dir, "old.db")
+	srcDB, err := Open(srcPath)
+	require.NoError(t, err, "Open src")
+	// Stale pre-fix row: the fork file stored under the parent's id.
+	insertSession(t, srcDB, "codex:parent-1", "proj", func(s *Session) {
+		s.Agent = "codex"
+		s.FilePath = &forkFile
+	})
+	// Genuine Codex orphan: its file no longer exists.
+	insertSession(t, srcDB, "codex:gone-1", "proj", func(s *Session) {
+		s.Agent = "codex"
+		s.FilePath = &goneFile
+	})
+	// SQLite-backed agent: many sessions share one file_path. An id
+	// missing from the fresh parse is an evicted chat, not a stale
+	// duplicate, and must survive as an orphan.
+	insertSession(t, srcDB, "piebald:old-chat", "proj", func(s *Session) {
+		s.Agent = "piebald"
+		s.FilePath = &sharedDB
+	})
+	srcDB.Close()
+
+	dstPath := filepath.Join(dir, "new.db")
+	dstDB, err := Open(dstPath)
+	require.NoError(t, err, "Open dst")
+	defer dstDB.Close()
+	// The fork file reparsed under the fork's own id.
+	insertSession(t, dstDB, "codex:fork-1", "proj", func(s *Session) {
+		s.Agent = "codex"
+		s.FilePath = &forkFile
+	})
+	insertSession(t, dstDB, "piebald:new-chat", "proj", func(s *Session) {
+		s.Agent = "piebald"
+		s.FilePath = &sharedDB
+	})
+
+	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
+	require.NoError(t, err, "CopyOrphanedDataFrom")
+	assert.Equal(t, 2, count, "gone-1 and old-chat are the only orphans")
+
+	ctx := context.Background()
+	stale, err := dstDB.GetSession(ctx, "codex:parent-1")
+	require.NoError(t, err, "GetSession codex:parent-1")
+	assert.Nil(t, stale,
+		"stale parent-ID row for a reparsed fork file must not be copied")
+
+	gone, err := dstDB.GetSession(ctx, "codex:gone-1")
+	require.NoError(t, err, "GetSession codex:gone-1")
+	assert.NotNil(t, gone, "genuine codex orphan must be copied")
+
+	evicted, err := dstDB.GetSession(ctx, "piebald:old-chat")
+	require.NoError(t, err, "GetSession piebald:old-chat")
+	assert.NotNil(t, evicted,
+		"evicted chat sharing a file_path must be copied")
+}
+
 func TestCopyOrphanedDataFrom_NoOrphans(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -141,12 +141,31 @@ func (d *DB) CopyOrphanedDataFromExcluding(
 	// Snapshot orphaned session IDs before any inserts
 	// change main.sessions. Exclude permanently deleted sessions
 	// so they are not resurrected as orphans.
+	//
+	// Also exclude stale Codex rows whose file was reparsed into
+	// the new DB under a different session id: before dataVersion
+	// 40 a forked rollout's replayed parent session_meta overwrote
+	// the fork's id (#643), so the fork file's row was stored under
+	// the parent's identity with double-counted totals. That row is
+	// a stale duplicate of a live file, not an archive of a lost
+	// one. Scoped to Codex because it is strictly one session per
+	// file; SQLite-backed agents share a file_path across many
+	// sessions, where an id missing from the fresh parse can be a
+	// genuinely evicted chat that must survive as an orphan.
 	if _, err := conn.ExecContext(ctx, `
 		CREATE TEMP TABLE _orphaned_ids AS
 		SELECT id FROM old_db.sessions
 		WHERE id NOT IN (SELECT id FROM main.sessions)
 		  AND id NOT IN (SELECT id FROM main.excluded_sessions)
-		  AND id NOT IN (SELECT id FROM _extra_excluded_orphan_ids)`,
+		  AND id NOT IN (SELECT id FROM _extra_excluded_orphan_ids)
+		  AND id NOT IN (
+			SELECT old_s.id
+			FROM old_db.sessions old_s
+			JOIN main.sessions new_s
+				ON new_s.file_path = old_s.file_path
+			WHERE old_s.agent = 'codex'
+			  AND new_s.agent = 'codex'
+		  )`,
 	); err != nil {
 		return 0, fmt.Errorf(
 			"identifying orphaned sessions: %w", err,

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -58,6 +58,94 @@ type codexSessionBuilder struct {
 	// matching task_complete after) means the agent was working
 	// when the file was last written.
 	lastTaskEvent string
+
+	// Suppresses the parent history a forked rollout replays at the
+	// top of the file, which would otherwise double count messages
+	// and token usage across the parent and the fork (#643).
+	forkGate codexForkGate
+}
+
+// codexForkGate drops the replayed parent history at the top of a
+// forked Codex rollout (#643).
+//
+// `codex fork` copies the parent's lines — its session_meta, turns,
+// messages and token_count events — into the new file with re-stamped
+// envelope timestamps, so the same usage exists in two session files
+// and gets counted twice. Envelope timestamps cannot locate the
+// boundary (the replay is re-stamped at fork creation), but turn ids
+// are UUIDv7 values minted when the turn originally ran: every
+// replayed turn predates the fork instant, and the first genuine turn
+// is minted at or after it. The gate stays closed until the first
+// turn_context whose turn_id timestamp is >= the fork's own creation
+// time, then everything flows normally.
+//
+// Replayed turn_context entries from parents recorded before Codex
+// stamped turn ids carry no turn_id at all; a CLI new enough to write
+// forked_from_id always stamps genuine turns, so a missing turn_id
+// while gated means replayed history. An unparseable turn_id fails
+// open (pre-#643 behaviour) rather than risk dropping live data.
+type codexForkGate struct {
+	active    bool
+	createdMs int64
+}
+
+// armFromMeta activates the gate when the session_meta belongs to a
+// forked session and its creation instant can be anchored: from the
+// fork's UUIDv7 id, the payload timestamp, or the JSONL envelope
+// timestamp, in that order.
+func (g *codexForkGate) armFromMeta(payload gjson.Result, envelopeTS time.Time) {
+	if payload.Get("forked_from_id").Str == "" {
+		return
+	}
+	ms := uuidV7Millis(payload.Get("id").Str)
+	if ms == 0 {
+		if t := parseTimestamp(payload.Get("timestamp").Str); !t.IsZero() {
+			ms = t.UnixMilli()
+		}
+	}
+	if ms == 0 && !envelopeTS.IsZero() {
+		ms = envelopeTS.UnixMilli()
+	}
+	if ms == 0 {
+		return // no anchor for the boundary — fail open
+	}
+	g.active = true
+	g.createdMs = ms
+}
+
+// suppresses reports whether the line is replayed parent history.
+// turn_context lines open the gate when their turn id was minted at
+// or after the fork instant.
+func (g *codexForkGate) suppresses(lineType string, payload gjson.Result) bool {
+	if !g.active {
+		return false
+	}
+	if lineType != codexTypeTurnContext {
+		return true
+	}
+	tid := payload.Get("turn_id").Str
+	if tid == "" {
+		return true // pre-turn_id parent history
+	}
+	if ms := uuidV7Millis(tid); ms != 0 && ms < g.createdMs {
+		return true
+	}
+	g.active = false
+	return false
+}
+
+// uuidV7Millis extracts the millisecond timestamp embedded in a
+// UUIDv7, returning 0 for anything that is not a v7 UUID.
+func uuidV7Millis(id string) int64 {
+	hex := strings.ReplaceAll(id, "-", "")
+	if len(hex) != 32 || hex[12] != '7' {
+		return 0
+	}
+	ms, err := strconv.ParseInt(hex[:12], 16, 64)
+	if err != nil {
+		return 0
+	}
+	return ms
 }
 
 type codexToolCallRef struct {
@@ -109,19 +197,33 @@ func (b *codexSessionBuilder) processLine(
 
 	switch gjson.Get(line, "type").Str {
 	case codexTypeSessionMeta:
-		return b.handleSessionMeta(payload)
+		if b.forkGate.active {
+			// A forked rollout replays the parent's session_meta
+			// too — the fork's own meta came first and wins.
+			return false
+		}
+		return b.handleSessionMeta(payload, ts)
 	case codexTypeTurnContext:
+		if b.forkGate.suppresses(codexTypeTurnContext, payload) {
+			return false
+		}
 		b.currentModel = payload.Get("model").Str
 	case codexTypeResponseItem:
+		if b.forkGate.suppresses(codexTypeResponseItem, payload) {
+			return false
+		}
 		b.handleResponseItem(payload, ts)
 	case codexTypeEventMsg:
+		if b.forkGate.suppresses(codexTypeEventMsg, payload) {
+			return false
+		}
 		b.handleEventMsg(payload)
 	}
 	return false
 }
 
 func (b *codexSessionBuilder) handleSessionMeta(
-	payload gjson.Result,
+	payload gjson.Result, envelopeTS time.Time,
 ) (skip bool) {
 	b.sessionID = payload.Get("id").Str
 
@@ -133,6 +235,8 @@ func (b *codexSessionBuilder) handleSessionMeta(
 			b.project = "unknown"
 		}
 	}
+
+	b.forkGate.armFromMeta(payload, envelopeTS)
 
 	return false
 }
@@ -1289,6 +1393,8 @@ func readCodexModelAtOffset(
 		io.LimitReader(f, offset), maxLineSize,
 	)
 	var model string
+	var gate codexForkGate
+	sawMeta := false
 	for {
 		line, ok := lr.next()
 		if !ok {
@@ -1297,7 +1403,23 @@ func readCodexModelAtOffset(
 		if !gjson.Valid(line) {
 			continue
 		}
-		if gjson.Get(line, "type").Str != codexTypeTurnContext {
+		lineType := gjson.Get(line, "type").Str
+		if lineType == codexTypeSessionMeta {
+			if !sawMeta {
+				sawMeta = true
+				gate.armFromMeta(
+					gjson.Get(line, "payload"),
+					parseTimestamp(gjson.Get(line, "timestamp").Str),
+				)
+			}
+			continue
+		}
+		if lineType != codexTypeTurnContext {
+			continue
+		}
+		// Skip turn_contexts replayed into a forked rollout (#643)
+		// so the seeded model mirrors the full parser's view.
+		if gate.suppresses(lineType, gjson.Get(line, "payload")) {
 			continue
 		}
 		model = gjson.Get(line, "payload.model").Str
@@ -1327,6 +1449,8 @@ func seedCodexUserDedup(
 	defer f.Close()
 
 	lr := newLineReader(io.LimitReader(f, offset), maxLineSize)
+	var gate codexForkGate
+	sawMeta := false
 	for {
 		line, ok := lr.next()
 		if !ok {
@@ -1335,7 +1459,23 @@ func seedCodexUserDedup(
 		if !gjson.Valid(line) {
 			continue
 		}
-		switch gjson.Get(line, "type").Str {
+		lineType := gjson.Get(line, "type").Str
+		// Mirror the full parser's fork handling (#643): the dedup
+		// state must come from genuine turns, not replayed history.
+		if lineType == codexTypeSessionMeta {
+			if !sawMeta {
+				sawMeta = true
+				gate.armFromMeta(
+					gjson.Get(line, "payload"),
+					parseTimestamp(gjson.Get(line, "timestamp").Str),
+				)
+			}
+			continue
+		}
+		if gate.suppresses(lineType, gjson.Get(line, "payload")) {
+			continue
+		}
+		switch lineType {
 		case codexTypeEventMsg:
 			if gjson.Get(line, "payload.type").Str == "turn_aborted" &&
 				firstContent != "" &&

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1368,89 +1368,38 @@ func classifyCodexTermination(lastTaskEvent string) TerminationStatus {
 	return ""
 }
 
-// readCodexModelAtOffset scans a Codex JSONL file from the
-// start up to the given byte offset and returns the model
-// from the most recent turn_context entry. Returns "" when
-// no turn_context is found before the offset. Used to seed
-// currentModel for incremental parses that resume past turn
-// boundaries.
-// readCodexModelAtOffset scans a Codex JSONL file from the
-// start up to the given byte offset and returns the model
-// from the most recent turn_context entry. Mirrors the full
-// parser: every turn_context unconditionally overwrites the
-// model, including empty strings. Returns "" when no
-// turn_context is found before the offset.
-func readCodexModelAtOffset(
-	path string, offset int64,
-) string {
-	f, err := os.Open(path)
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-
-	lr := newLineReader(
-		io.LimitReader(f, offset), maxLineSize,
-	)
-	var model string
-	var gate codexForkGate
-	sawMeta := false
-	for {
-		line, ok := lr.next()
-		if !ok {
-			break
-		}
-		if !gjson.Valid(line) {
-			continue
-		}
-		lineType := gjson.Get(line, "type").Str
-		if lineType == codexTypeSessionMeta {
-			if !sawMeta {
-				sawMeta = true
-				gate.armFromMeta(
-					gjson.Get(line, "payload"),
-					parseTimestamp(gjson.Get(line, "timestamp").Str),
-				)
-			}
-			continue
-		}
-		if lineType != codexTypeTurnContext {
-			continue
-		}
-		// Skip turn_contexts replayed into a forked rollout (#643)
-		// so the seeded model mirrors the full parser's view.
-		if gate.suppresses(lineType, gjson.Get(line, "payload")) {
-			continue
-		}
-		model = gjson.Get(line, "payload.model").Str
-	}
-	return model
+// codexIncrementalSeed carries the builder state recovered from the
+// already-parsed prefix [0, offset) of a Codex JSONL file so an
+// incremental parse resumes with the same view a full parse would
+// have at that offset: the current model, the re-emitted-prompt
+// dedup state, and the fork replay gate (#643).
+type codexIncrementalSeed struct {
+	model                    string
+	firstUserContent         string
+	sawUserTurnAfterFirst    bool
+	mayReplayFirstUserPrompt bool
+	forkGate                 codexForkGate
 }
 
-// seedCodexUserDedup scans a Codex JSONL prefix [0, offset) to recover
-// the state the re-emitted-prompt dedup needs when resuming an
-// incremental parse: the full content of the first real user message,
-// whether another real user turn already occurred, and whether a
-// turn_aborted signal allows the next identical first prompt to be
-// dropped. It mirrors handleResponseItem's user-message filtering and
-// full-content matching so the incremental path dedups re-emitted
-// prompts identically to a full parse.
-func seedCodexUserDedup(
+// seedCodexIncrementalState scans a Codex JSONL prefix [0, offset)
+// and mirrors processLine's dispatch: every turn_context overwrites
+// the model (including empty strings), user messages feed the
+// re-emitted-prompt dedup exactly as handleResponseItem would, and
+// the fork gate arms/opens on the same lines as a full parse. A gate
+// still active at the end of the scan means the stored offset landed
+// inside the replayed parent history of a forked rollout, so the
+// incremental parse must keep suppressing appended replay lines.
+func seedCodexIncrementalState(
 	path string, offset int64,
-) (
-	firstContent string,
-	sawUserTurnAfterFirst bool,
-	mayReplayFirstUserPrompt bool,
-) {
+) codexIncrementalSeed {
+	var seed codexIncrementalSeed
 	f, err := os.Open(path)
 	if err != nil {
-		return "", false, false
+		return seed
 	}
 	defer f.Close()
 
 	lr := newLineReader(io.LimitReader(f, offset), maxLineSize)
-	var gate codexForkGate
-	sawMeta := false
 	for {
 		line, ok := lr.next()
 		if !ok {
@@ -1460,65 +1409,73 @@ func seedCodexUserDedup(
 			continue
 		}
 		lineType := gjson.Get(line, "type").Str
-		// Mirror the full parser's fork handling (#643): the dedup
-		// state must come from genuine turns, not replayed history.
+		payload := gjson.Get(line, "payload")
 		if lineType == codexTypeSessionMeta {
-			if !sawMeta {
-				sawMeta = true
-				gate.armFromMeta(
-					gjson.Get(line, "payload"),
+			// Mirror processLine: the fork's own meta arms the
+			// gate, and replayed parent metas are dropped while
+			// it is active.
+			if !seed.forkGate.active {
+				seed.forkGate.armFromMeta(
+					payload,
 					parseTimestamp(gjson.Get(line, "timestamp").Str),
 				)
 			}
 			continue
 		}
-		if gate.suppresses(lineType, gjson.Get(line, "payload")) {
+		if seed.forkGate.suppresses(lineType, payload) {
 			continue
 		}
 		switch lineType {
+		case codexTypeTurnContext:
+			seed.model = payload.Get("model").Str
 		case codexTypeEventMsg:
-			if gjson.Get(line, "payload.type").Str == "turn_aborted" &&
-				firstContent != "" &&
-				!sawUserTurnAfterFirst {
-				mayReplayFirstUserPrompt = true
+			if payload.Get("type").Str == "turn_aborted" &&
+				seed.firstUserContent != "" &&
+				!seed.sawUserTurnAfterFirst {
+				seed.mayReplayFirstUserPrompt = true
 			}
-			continue
 		case codexTypeResponseItem:
-		default:
-			continue
-		}
-		payload := gjson.Get(line, "payload")
-		if payload.Get("role").Str != "user" {
-			continue
-		}
-		content := extractCodexContent(payload)
-		if strings.TrimSpace(content) == "" {
-			continue
-		}
-		if isCodexTurnAbortedMessage(content) &&
-			firstContent != "" &&
-			!sawUserTurnAfterFirst {
-			mayReplayFirstUserPrompt = true
-		}
-		if isCodexSystemMessage(content) {
-			continue
-		}
-		switch {
-		case firstContent == "":
-			firstContent = content
-		case content == firstContent &&
-			!sawUserTurnAfterFirst &&
-			mayReplayFirstUserPrompt:
-			mayReplayFirstUserPrompt = false
-		case content == firstContent:
-			sawUserTurnAfterFirst = true
-			mayReplayFirstUserPrompt = false
-		default:
-			sawUserTurnAfterFirst = true
-			mayReplayFirstUserPrompt = false
+			seed.observeUserMessage(payload)
 		}
 	}
-	return firstContent, sawUserTurnAfterFirst, mayReplayFirstUserPrompt
+	return seed
+}
+
+// observeUserMessage feeds one response_item into the
+// re-emitted-prompt dedup state, mirroring handleResponseItem's
+// user-message filtering and full-content matching.
+func (s *codexIncrementalSeed) observeUserMessage(
+	payload gjson.Result,
+) {
+	if payload.Get("role").Str != "user" {
+		return
+	}
+	content := extractCodexContent(payload)
+	if strings.TrimSpace(content) == "" {
+		return
+	}
+	if isCodexTurnAbortedMessage(content) &&
+		s.firstUserContent != "" &&
+		!s.sawUserTurnAfterFirst {
+		s.mayReplayFirstUserPrompt = true
+	}
+	if isCodexSystemMessage(content) {
+		return
+	}
+	switch {
+	case s.firstUserContent == "":
+		s.firstUserContent = content
+	case content == s.firstUserContent &&
+		!s.sawUserTurnAfterFirst &&
+		s.mayReplayFirstUserPrompt:
+		s.mayReplayFirstUserPrompt = false
+	case content == s.firstUserContent:
+		s.sawUserTurnAfterFirst = true
+		s.mayReplayFirstUserPrompt = false
+	default:
+		s.sawUserTurnAfterFirst = true
+		s.mayReplayFirstUserPrompt = false
+	}
 }
 
 // ParseCodexSessionFrom parses only new lines from a Codex
@@ -1534,13 +1491,16 @@ func ParseCodexSessionFrom(
 ) ([]ParsedMessage, time.Time, int64, error) {
 	b := newCodexSessionBuilder(includeExec)
 	b.ordinal = startOrdinal
-	b.currentModel = readCodexModelAtOffset(path, offset)
-	// Recover the re-emitted-prompt dedup state from the already-parsed
-	// prefix so a replay appended across syncs is dropped just as a
-	// full parse would.
-	b.firstUserContent,
-		b.sawUserTurnAfterFirst,
-		b.mayReplayFirstUserPrompt = seedCodexUserDedup(path, offset)
+	// Recover model, re-emitted-prompt dedup state, and the fork
+	// replay gate from the already-parsed prefix so appended lines —
+	// including a replay that spans the stored offset — are handled
+	// just as a full parse would.
+	seed := seedCodexIncrementalState(path, offset)
+	b.currentModel = seed.model
+	b.firstUserContent = seed.firstUserContent
+	b.sawUserTurnAfterFirst = seed.sawUserTurnAfterFirst
+	b.mayReplayFirstUserPrompt = seed.mayReplayFirstUserPrompt
+	b.forkGate = seed.forkGate
 	var fallbackErr error
 
 	consumed, err := readJSONLFrom(

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1210,6 +1210,67 @@ func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
 	})
 }
 
+// TestParseCodexSessionFrom_ForkReplaySpansOffset covers the
+// incremental case of the fork replay gate (#643): a sync boundary
+// lands inside the replayed parent history, so the rest of the replay
+// arrives via ParseCodexSessionFrom. The incremental parser must
+// restore the still-active gate from the prefix and keep suppressing
+// the replay until the fork's first genuine turn.
+func TestParseCodexSessionFrom_ForkReplaySpansOffset(t *testing.T) {
+	t.Parallel()
+
+	forkCreatedMs := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli() // == tsEarly
+	forkID := testUUIDv7(forkCreatedMs, 1)
+	parentTurnID := testUUIDv7(forkCreatedMs-3600_000, 2)
+	genuineTurnID := testUUIDv7(forkCreatedMs+1000, 3)
+
+	// The initial sync sees only part of the replayed parent history.
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexForkedSessionMetaJSON(forkID, "parent-1", "/tmp", "user", tsEarly),
+		testjsonl.CodexSessionMetaJSON("parent-1", "/tmp", "user", tsEarly),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+		testjsonl.CodexMsgJSON("user", "replayed question", tsEarly),
+	)
+	path := createTestFile(t, "fork-incremental.jsonl", initial)
+
+	sess, msgs, err := ParseCodexSession(path, "local", false)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "codex:"+forkID, sess.ID)
+	require.Empty(t, msgs, "replayed prefix must not produce messages")
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// The rest of the replay plus the fork's first genuine turn
+	// arrive after the sync boundary.
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("assistant", "replayed answer", tsEarly),
+		testjsonl.CodexTokenCountJSON(tsEarly, 50_000, 9_000, 0),
+		testjsonl.CodexTurnContextWithIDJSON("gpt-5.5", genuineTurnID, tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "genuine question", tsEarlyS1),
+		testjsonl.CodexMsgJSON("assistant", "genuine answer", tsEarlyS5),
+		testjsonl.CodexTokenCountJSON(tsEarlyS5, 10_000, 500, 6_000),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := ParseCodexSessionFrom(path, offset, 0, false)
+	require.NoError(t, err)
+
+	// Only the genuine turn survives; the replayed assistant answer
+	// and its 9,000 output tokens stay suppressed.
+	require.Len(t, newMsgs, 2)
+	assert.Equal(t, "genuine question", newMsgs[0].Content)
+	assert.Equal(t, "genuine answer", newMsgs[1].Content)
+	assert.Equal(t, "gpt-5.5", newMsgs[1].Model)
+	assert.Equal(t, 500, newMsgs[1].OutputTokens)
+}
+
 func TestParseCodexSession_EdgeCases(t *testing.T) {
 	t.Run("skips system messages", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
@@ -2046,7 +2107,7 @@ func TestParseCodexSessionFrom_EmptyModelReset(
 		"empty-model turn_context should reset model")
 }
 
-func TestReadCodexModelAtOffset_SkipsInvalidJSON(
+func TestSeedCodexIncrementalState_SkipsInvalidJSON(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -2070,12 +2131,12 @@ func TestReadCodexModelAtOffset_SkipsInvalidJSON(
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	got := readCodexModelAtOffset(path, info.Size())
+	got := seedCodexIncrementalState(path, info.Size()).model
 	assert.Equal(t, "gpt-5.4", got,
 		"truncated turn_context should be skipped")
 }
 
-func TestReadCodexModelAtOffset(t *testing.T) {
+func TestSeedCodexIncrementalState_Model(t *testing.T) {
 	t.Parallel()
 
 	content := testjsonl.JoinJSONL(
@@ -2099,17 +2160,17 @@ func TestReadCodexModelAtOffset(t *testing.T) {
 	t.Run("full file returns last model", func(t *testing.T) {
 		info, err := os.Stat(path)
 		require.NoError(t, err)
-		got := readCodexModelAtOffset(path, info.Size())
+		got := seedCodexIncrementalState(path, info.Size()).model
 		assert.Equal(t, "gpt-5.4", got)
 	})
 
 	t.Run("zero offset returns empty", func(t *testing.T) {
-		got := readCodexModelAtOffset(path, 0)
+		got := seedCodexIncrementalState(path, 0).model
 		assert.Equal(t, "", got)
 	})
 
 	t.Run("nonexistent file returns empty", func(t *testing.T) {
-		got := readCodexModelAtOffset("/no/such/file", 100)
+		got := seedCodexIncrementalState("/no/such/file", 100).model
 		assert.Equal(t, "", got)
 	})
 }

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1,9 +1,11 @@
 package parser
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1080,6 +1082,131 @@ func TestParseCodexSession_TokenUsage(t *testing.T) {
 		require.Len(t, msgs, 2)
 		assert.Empty(t, msgs[1].TokenUsage)
 		assert.Equal(t, 0, msgs[1].OutputTokens)
+	})
+}
+
+// testUUIDv7 builds a syntactically valid UUIDv7 whose embedded
+// timestamp is the given unix-millisecond value.
+func testUUIDv7(ms int64, seq byte) string {
+	h := fmt.Sprintf("%012x", ms)
+	return fmt.Sprintf(
+		"%s-%s-7000-8000-0000000000%02x", h[:8], h[8:12], seq,
+	)
+}
+
+func TestParseCodexSession_ForkedSessionSkipsReplayedHistory(t *testing.T) {
+	// `codex fork` replays the parent's history — its session_meta,
+	// turns, messages and token_count events — into the top of the new
+	// rollout with re-stamped envelope timestamps, so the same usage
+	// lives in two files and was counted twice (#643). Turn ids are
+	// UUIDv7 values minted when the turn originally ran, which is what
+	// locates the replay/genuine boundary.
+	forkCreatedMs := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC).UnixMilli() // == tsEarly
+	forkID := testUUIDv7(forkCreatedMs, 1)
+	parentTurnID := testUUIDv7(forkCreatedMs-3600_000, 2) // minted an hour earlier
+	genuineTurnID := testUUIDv7(forkCreatedMs+1000, 3)
+
+	t.Run("replayed history is dropped, genuine turns kept", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexForkedSessionMetaJSON(forkID, "parent-1", "/tmp", "user", tsEarly),
+			// Replayed parent history (all re-stamped at fork creation):
+			testjsonl.CodexSessionMetaJSON("parent-1", "/other-project", "user", tsEarly),
+			testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+			testjsonl.CodexMsgJSON("user", "replayed question", tsEarly),
+			testjsonl.CodexMsgJSON("assistant", "replayed answer", tsEarly),
+			testjsonl.CodexTokenCountJSON(tsEarly, 50_000, 9_000, 0),
+			// A replayed turn from before Codex stamped turn ids:
+			testjsonl.CodexTurnContextJSON("gpt-5.3", tsEarly),
+			testjsonl.CodexMsgJSON("assistant", "older replayed answer", tsEarly),
+			// The fork's own first turn:
+			testjsonl.CodexTurnContextWithIDJSON("gpt-5.5", genuineTurnID, tsEarlyS1),
+			testjsonl.CodexMsgJSON("user", "genuine question", tsEarlyS1),
+			testjsonl.CodexMsgJSON("assistant", "genuine answer", tsEarlyS5),
+			testjsonl.CodexTokenCountJSON(tsEarlyS5, 10_000, 500, 6_000),
+		)
+		sess, msgs := runCodexParserTest(t, "fork.jsonl", content, false)
+		require.NotNil(t, sess)
+
+		// The fork keeps its own identity — the replayed parent
+		// session_meta must not overwrite the id.
+		assert.Equal(t, "codex:"+forkID, sess.ID)
+
+		require.Len(t, msgs, 2)
+		assert.Equal(t, "genuine question", msgs[0].Content)
+		assert.Equal(t, "genuine answer", msgs[1].Content)
+		assert.Equal(t, "gpt-5.5", msgs[1].Model)
+
+		// Usage comes only from the genuine turn: 9,000 replayed
+		// output tokens must not be re-billed to the fork.
+		assert.Equal(t, 500, sess.TotalOutputTokens)
+		assert.Equal(t, 10_000, sess.PeakContextTokens)
+	})
+
+	t.Run("fork with no genuine turns yields no messages", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexForkedSessionMetaJSON(forkID, "parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexSessionMetaJSON("parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+			testjsonl.CodexMsgJSON("user", "replayed question", tsEarly),
+			testjsonl.CodexMsgJSON("assistant", "replayed answer", tsEarly),
+			testjsonl.CodexTokenCountJSON(tsEarly, 50_000, 9_000, 0),
+		)
+		sess, msgs := runCodexParserTest(t, "fork.jsonl", content, false)
+		require.NotNil(t, sess)
+		assert.Equal(t, "codex:"+forkID, sess.ID)
+		assert.Empty(t, msgs)
+		assert.Equal(t, 0, sess.TotalOutputTokens)
+	})
+
+	t.Run("non-v7 fork id anchors the boundary from the envelope timestamp", func(t *testing.T) {
+		// Neither the fork id nor the payload carries a usable
+		// timestamp here — the gate must fall back to the JSONL
+		// envelope timestamp and still suppress the replay.
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexForkedSessionMetaJSON("fork-plain-1", "parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexSessionMetaJSON("parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexTurnContextWithIDJSON("gpt-5.4", parentTurnID, tsEarly),
+			testjsonl.CodexMsgJSON("user", "replayed question", tsEarly),
+			testjsonl.CodexMsgJSON("assistant", "replayed answer", tsEarly),
+			testjsonl.CodexTokenCountJSON(tsEarly, 50_000, 9_000, 0),
+			testjsonl.CodexTurnContextWithIDJSON("gpt-5.5", genuineTurnID, tsEarlyS1),
+			testjsonl.CodexMsgJSON("user", "genuine question", tsEarlyS1),
+			testjsonl.CodexMsgJSON("assistant", "genuine answer", tsEarlyS5),
+			testjsonl.CodexTokenCountJSON(tsEarlyS5, 10_000, 500, 6_000),
+		)
+		sess, msgs := runCodexParserTest(t, "fork.jsonl", content, false)
+		require.NotNil(t, sess)
+		assert.Equal(t, "codex:fork-plain-1", sess.ID)
+		require.Len(t, msgs, 2)
+		assert.Equal(t, "genuine question", msgs[0].Content)
+		assert.Equal(t, 500, sess.TotalOutputTokens)
+	})
+
+	t.Run("unparseable turn_id fails open instead of dropping live data", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexForkedSessionMetaJSON(forkID, "parent-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexTurnContextWithIDJSON("gpt-5.5", "not-a-uuid", tsEarlyS1),
+			testjsonl.CodexMsgJSON("user", "kept question", tsEarlyS1),
+			testjsonl.CodexMsgJSON("assistant", "kept answer", tsEarlyS5),
+		)
+		_, msgs := runCodexParserTest(t, "fork.jsonl", content, false)
+		require.Len(t, msgs, 2)
+		assert.Equal(t, "kept question", msgs[0].Content)
+	})
+
+	t.Run("non-forked sessions are untouched", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("plain-1", "/tmp", "user", tsEarly),
+			testjsonl.CodexTurnContextJSON("gpt-5.4", tsEarlyS1),
+			testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+			testjsonl.CodexMsgJSON("assistant", "hi", tsEarlyS5),
+			testjsonl.CodexTokenCountJSON(tsEarlyS5, 10_000, 500, 6_000),
+		)
+		sess, msgs := runCodexParserTest(t, "plain.jsonl", content, false)
+		require.NotNil(t, sess)
+		assert.Equal(t, "codex:plain-1", sess.ID)
+		require.Len(t, msgs, 2)
+		assert.Equal(t, 500, sess.TotalOutputTokens)
 	})
 }
 

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -148,6 +148,39 @@ func CodexSessionMetaJSON(
 	return mustMarshal(m)
 }
 
+// CodexForkedSessionMetaJSON returns the session_meta of a forked
+// Codex session (payload carries forked_from_id).
+func CodexForkedSessionMetaJSON(
+	id, forkedFromID, cwd, originator, timestamp string,
+) string {
+	m := map[string]any{
+		"type":      "session_meta",
+		"timestamp": timestamp,
+		"payload": map[string]any{
+			"id":             id,
+			"forked_from_id": forkedFromID,
+			"cwd":            cwd,
+			"originator":     originator,
+		},
+	}
+	return mustMarshal(m)
+}
+
+// CodexTurnContextWithIDJSON returns a Codex turn_context entry
+// carrying a turn_id, as newer CLI versions write.
+func CodexTurnContextWithIDJSON(model, turnID, timestamp string) string {
+	m := map[string]any{
+		"type":      "turn_context",
+		"timestamp": timestamp,
+		"payload": map[string]any{
+			"model":   model,
+			"cwd":     "/tmp",
+			"turn_id": turnID,
+		},
+	}
+	return mustMarshal(m)
+}
+
 // CodexMsgJSON returns a Codex response_item message as a JSON
 // string.
 func CodexMsgJSON(role, text, timestamp string) string {


### PR DESCRIPTION
Fixes #643

## Bug

`codex fork` copies the parent's rollout lines — its **session_meta**, turns, messages and token_count events — into the top of the new file with re-stamped envelope timestamps. The parser counted that replayed history as the fork's own activity, so the shared prefix was billed in **both** the parent and the fork. Worse: the replayed parent `session_meta` overwrote the fork's session id (`handleSessionMeta` is last-wins), so the forked session was stored under the **parent's identity**.

Parsing a real forked rollout from my machine:

| | session id | messages | total output tokens |
|---|---|---|---|
| before | `codex:<parent-id>` (misattributed) | 658 | 160,687 |
| after | `codex:<fork-id>` | 65 | 11,366 |

## Fix

Envelope timestamps can't locate the replay boundary — the whole replay is re-stamped at fork creation within ~50ms. But **turn ids are UUIDv7** values minted when the turn originally ran: every replayed turn predates the fork instant, and the first genuine turn is minted at or after it. A `codexForkGate` arms on `session_meta.forked_from_id` and suppresses lines until the first `turn_context` whose turn_id timestamp reaches the fork's own creation time (taken from its UUIDv7 id, falling back to the meta timestamp). The replayed parent session_meta is skipped, so the fork keeps its own identity.

Robustness choices, **validated against 13 real forked rollouts spanning three CLI eras** (April replay format, June no-replay format, and a fork of a long-lived parent whose old turns predate turn ids):

- replayed `turn_context`s **without** a turn_id stay suppressed — a CLI new enough to write `forked_from_id` always stamps genuine turns (held in all 13 files, including one with 21 id-less replayed turns)
- an **unparseable** turn_id fails open to the pre-fix behaviour rather than risk dropping live data
- newer-CLI forks that replay nothing open the gate on their first (genuine) turn immediately
- non-forked sessions: gate never arms, zero behaviour change (multi-meta exec files keep last-wins)

The incremental-parse seed helpers (`seedCodexUserDedup`, `readCodexModelAtOffset`) apply the same gate so resumed parses mirror the full parser's view.

## Tests

`TestParseCodexSession_ForkedSessionSkipsReplayedHistory` (4 subtests): replay dropped + genuine kept + id preserved; fork with no genuine turns yields no messages; unparseable turn_id fails open; non-forked sessions untouched. **Red on main, green with the fix.** Two small `testjsonl` helpers added (`CodexForkedSessionMetaJSON`, `CodexTurnContextWithIDJSON`).

```
CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled" ./internal/parser/ -count=1   # ok (full package)
go vet ./internal/parser/ ./internal/testjsonl/                                         # clean
```