### PR TITLE
fix(frontend): key ToolCallGroup message each-block by ordinal

### DIFF
--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -140,7 +140,7 @@
   </div>
 
   <div class="tool-group-body">
-    {#each messages as message (message.id)}
+    {#each messages as message (message.ordinal)}
       {@const calls = message.tool_calls ?? []}
       {@const turn = turnByMessage.get(message.id)}
       {#if calls.length === 1}


### PR DESCRIPTION
The `pg serve` read path leaves `Message.ID` at 0 for every row: the PG
messages table has no `id` column (its primary key is `(session_id,
ordinal)`) and `scanPGMessages` never assigns `m.ID`. ToolCallGroup keys
its outer `{#each}` block on `message.id`, so any session viewed through
`pg serve` whose group holds more than one message hits Svelte 5's
`each_key_duplicate` hard error and tears down the message panel.

Keying on `ordinal` instead is correct on both backends: it is unique
within a session by primary key in SQLite and PostgreSQL alike, whereas
`id` is only populated on the SQLite read path. One-line change in
`frontend/src/lib/components/content/ToolCallGroup.svelte`.

Refs #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
