### PR TITLE
feat: improve Antigravity token extraction and sync metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ html/
 # graphify knowledge-graph output (local analysis)
 graphify-out/
 .kata.local.toml
+# roborev snapshots
+/.roborev/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ Instructions for autonomous coding agents working in this repository.
 - Keep commits focused and related to the requested task.
 - Use clear conventional commit messages.
 - Do not push, pull, or rebase unless explicitly requested.
-- Do not include generated-with lines, attribution blocks, validation footers, or
-  command transcripts in commit messages.
+- Do not include generated-with lines, attribution blocks, validation footers,
+  or command transcripts in commit messages.
 
 ## Validation
 
@@ -59,8 +59,8 @@ Instructions for autonomous coding agents working in this repository.
   recreate it to handle data version changes. Schema changes use non-destructive
   migrations such as `ALTER TABLE` and `UPDATE`; parser changes trigger a full
   resync that builds a fresh DB, syncs files, copies orphaned sessions from the
-  old DB, and swaps atomically. Existing session data must be preserved even when
-  source files no longer exist on disk.
+  old DB, and swaps atomically. Existing session data must be preserved even
+  when source files no longer exist on disk.
 
 ## Project Overview
 
@@ -94,8 +94,9 @@ CLI (agentsview) -> Config -> DB (SQLite/FTS5)
   directories.
 - PG sync: on-demand push sync from SQLite to PostgreSQL via `pg push`.
 - Frontend: Svelte 5 SPA embedded in the Go binary at build time.
-- Config: `AGENTSVIEW_DATA_DIR` plus per-agent directory overrides and CLI flags.
-  Per-agent env vars are listed on each entry in `internal/parser/types.go`.
+- Config: `AGENTSVIEW_DATA_DIR` plus per-agent directory overrides and CLI
+  flags. Per-agent env vars are listed on each entry in
+  `internal/parser/types.go`.
 
 ## Project Structure
 
@@ -109,7 +110,8 @@ CLI (agentsview) -> Config -> DB (SQLite/FTS5)
 - `internal/server/` - HTTP handlers, SSE, middleware, search, and export.
 - `internal/sync/` - Sync engine, file watcher, discovery, and hashing.
 - `internal/timeutil/` - Time parsing utilities.
-- `internal/web/` - Embedded frontend copied from `frontend/dist/` at build time.
+- `internal/web/` - Embedded frontend copied from `frontend/dist/` at build
+  time.
 - `frontend/` - Svelte 5 SPA with Vite and TypeScript.
 - `scripts/` - Utility scripts for E2E server setup and changelog work.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,200 +3,189 @@
 ## Status
 
 Foundational document. Describes agentsview's current security and privacy
-behavior and the assumptions that behavior rests on, much of which is
-already enforced in code but has not been written down in one place. It
-is intentionally descriptive rather than prescriptive — several questions
-are flagged as open and will be resolved by future proposals rather than
-decided here.
+behavior and the assumptions that behavior rests on, much of which is already
+enforced in code but has not been written down in one place. It is intentionally
+descriptive rather than prescriptive — several questions are flagged as open and
+will be resolved by future proposals rather than decided here.
 
 If you are reporting a vulnerability, see [Reporting](#reporting) below.
 
 ## Audience and deployment model
 
-agentsview is designed to run on a single-user workstation, alongside the
-agent tools whose sessions it indexes. Single-user laptop or developer
-workstation is the assumed deployment; other deployments (shared hosts,
-public exposure, multi-machine sync) are possible but require the user
-to opt into additional risk via documented flags and config.
+agentsview is designed to run on a single-user workstation, alongside the agent
+tools whose sessions it indexes. Single-user laptop or developer workstation is
+the assumed deployment; other deployments (shared hosts, public exposure,
+multi-machine sync) are possible but require the user to opt into additional
+risk via documented flags and config.
 
 ## Threat model
 
 ### In scope
 
-- A local, authenticated user reading their own session archive through
-  the agentsview UI, CLI, or API.
-- Network attackers who cannot already execute code as the local user.
-  The default loopback bind, Host-header allowlist (DNS rebinding
-  defense), CORS restrictions, and CSP / `X-Frame-Options: DENY`
-  headers are aimed at this attacker.
-- Parser crashes, excessive resource use, or active-content injection
-  triggered by content inside supported session files. Session files
-  often contain web/tool output that agentsview did not author, and
-  defensive parsing of that content is a security-relevant concern.
-- Inadvertent exposure of secrets that appear in transcripts.
-  agentsview ships a best-effort secret detector and redacts findings
-  in the UI and CLI by default (see [Secrets subsystem](#secrets-subsystem)).
+- A local, authenticated user reading their own session archive through the
+  agentsview UI, CLI, or API.
+- Network attackers who cannot already execute code as the local user. The
+  default loopback bind, Host-header allowlist (DNS rebinding defense), CORS
+  restrictions, and CSP / `X-Frame-Options: DENY` headers are aimed at this
+  attacker.
+- Parser crashes, excessive resource use, or active-content injection triggered
+  by content inside supported session files. Session files often contain
+  web/tool output that agentsview did not author, and defensive parsing of that
+  content is a security-relevant concern.
+- Inadvertent exposure of secrets that appear in transcripts. agentsview ships a
+  best-effort secret detector and redacts findings in the UI and CLI by default
+  (see [Secrets subsystem](#secrets-subsystem)).
 
 ### Explicitly out of scope (today)
 
 - Hostile peers on the same OS account. agentsview's data dir inherits
-  permissions from the user's umask; no defense is offered against
-  another process running as the same user.
-- Same-user arbitrary file write or code execution. If an attacker can
-  drop files into the configured session directories as the local user,
-  they are inside the trust base.
+  permissions from the user's umask; no defense is offered against another
+  process running as the same user.
+- Same-user arbitrary file write or code execution. If an attacker can drop
+  files into the configured session directories as the local user, they are
+  inside the trust base.
 - Multi-user machines with hostile peer accounts.
 - Side-channel attacks against the local SQLite database.
-- Strong isolation between projects, agents, or time periods within a
-  single agentsview instance. The database is a unified archive; any
-  caller able to read it can read all of it.
-- Strong guarantees about data destruction. Deletion removes rows but
-  does not promise SQLite page, WAL, or filesystem-level erasure.
+- Strong isolation between projects, agents, or time periods within a single
+  agentsview instance. The database is a unified archive; any caller able to
+  read it can read all of it.
+- Strong guarantees about data destruction. Deletion removes rows but does not
+  promise SQLite page, WAL, or filesystem-level erasure.
 
 ## Trust boundaries
 
-| Boundary                          | Posture                                            | Notes                                                            |
-| --------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------- |
-| Session files → parser            | Treated as untrusted data                          | Parsers should not exec/eval; bugs are security-relevant.        |
-| Imports and new readers           | Treated as untrusted structured data               | Same posture as parsers; imported archives may be remote-origin. |
-| SSH remote sync                   | Treated as user-provisioned and user-authenticated | Pulled archives are parsed locally as untrusted data.            |
-| Parser → SQLite / FTS5            | Trusted                                            | Indexed content is preserved verbatim.                           |
-| HTTP server → caller              | Loopback-trusted; bearer-gated for `/api/` when `--require-auth` | Static assets are not gated.                       |
-| Browser → HTTP server             | Host-header allowlist + CORS + CSP + X-Frame-Options enforced    | DNS-rebinding, framing, and cross-origin defenses. |
-| agentsview → PostgreSQL (pg push) | TLS required for non-loopback hosts                | Plaintext rejected unless `allow_insecure = true` is set explicitly. |
-| agentsview → update endpoint      | One-way outbound, opt-out                          | Disable with `--no-update-check`.                                |
-| agentsview → LiteLLM pricing      | One-way outbound, on-demand                        | Public JSON fetched from GitHub raw; no session data sent.       |
+| Boundary                          | Posture                                                          | Notes                                                                |
+| --------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Session files → parser            | Treated as untrusted data                                        | Parsers should not exec/eval; bugs are security-relevant.            |
+| Imports and new readers           | Treated as untrusted structured data                             | Same posture as parsers; imported archives may be remote-origin.     |
+| SSH remote sync                   | Treated as user-provisioned and user-authenticated               | Pulled archives are parsed locally as untrusted data.                |
+| Parser → SQLite / FTS5            | Trusted                                                          | Indexed content is preserved verbatim.                               |
+| HTTP server → caller              | Loopback-trusted; bearer-gated for `/api/` when `--require-auth` | Static assets are not gated.                                         |
+| Browser → HTTP server             | Host-header allowlist + CORS + CSP + X-Frame-Options enforced    | DNS-rebinding, framing, and cross-origin defenses.                   |
+| agentsview → PostgreSQL (pg push) | TLS required for non-loopback hosts                              | Plaintext rejected unless `allow_insecure = true` is set explicitly. |
+| agentsview → update endpoint      | One-way outbound, opt-out                                        | Disable with `--no-update-check`.                                    |
+| agentsview → LiteLLM pricing      | One-way outbound, on-demand                                      | Public JSON fetched from GitHub raw; no session data sent.           |
 
 ## Data at rest
 
-- The local archive (SQLite + FTS5 index) stores indexed session data
-  in plaintext. This includes assistant responses, user prompts, tool
-  arguments, command output, file contents fetched by agents, and any
-  secrets that may have been pasted into an agent session.
-- File permissions follow the user's umask. agentsview does not chmod
-  the data directory and does not encrypt at rest.
-- Treat the agentsview data directory with the same care you would
-  treat your shell history or your editor's swap files. It is at least
-  as sensitive.
+- The local archive (SQLite + FTS5 index) stores indexed session data in
+  plaintext. This includes assistant responses, user prompts, tool arguments,
+  command output, file contents fetched by agents, and any secrets that may have
+  been pasted into an agent session.
+- File permissions follow the user's umask. agentsview does not chmod the data
+  directory and does not encrypt at rest.
+- Treat the agentsview data directory with the same care you would treat your
+  shell history or your editor's swap files. It is at least as sensitive.
 - Deletion semantics: the UI supports both a soft-delete (trash) and a
-  permanent-delete path. Permanent delete removes rows from the primary
-  tables and the FTS5 index; it does not promise erasure of SQLite
-  pages, the WAL, on-disk backups, OS file caches, or any external
-  copy that was made via `pg push` or SSH sync.
+  permanent-delete path. Permanent delete removes rows from the primary tables
+  and the FTS5 index; it does not promise erasure of SQLite pages, the WAL,
+  on-disk backups, OS file caches, or any external copy that was made via
+  `pg push` or SSH sync.
 
 ## Data in transit
 
 agentsview makes several distinct outbound connections. Each is listed
-explicitly because "data stays on your machine" is the default but is
-not a complete description of the system once optional features are in
-use.
+explicitly because "data stays on your machine" is the default but is not a
+complete description of the system once optional features are in use.
 
-- **Local UI / API.** The HTTP server binds to `127.0.0.1` by default.
-  When exposed beyond loopback, `--require-auth` should be enabled.
-  Authentication is a bearer token applied to `/api/` routes only;
-  static assets remain ungated. Browser-facing defenses (Host-header
-  allowlist, CORS restrictions, CSP, `X-Frame-Options: DENY`) are
-  always on. See the CLI reference for token configuration.
-- **PostgreSQL sync.** `agentsview pg push` exports the local archive
-  to a user-supplied PostgreSQL instance. Non-loopback DSNs are
-  rejected unless TLS is enabled (`sslmode=require` or stronger), or
-  the user has explicitly set `allow_insecure = true` under `[pg]`.
-  The destination database itself is treated as user-provisioned
-  infrastructure; agentsview asserts nothing about its access
-  controls.
-- **SSH remote sync.** agentsview can pull session archives from
-  another machine over SSH. Authentication is whatever the user's SSH
-  configuration provides. Pulled files are parsed locally as untrusted
-  data and merged into the unified archive.
-- **Imports.** Imported archives from other agentsview instances or
-  third-party exports are treated as untrusted structured data, no
-  different from session files written by local agents.
+- **Local UI / API.** The HTTP server binds to `127.0.0.1` by default. When
+  exposed beyond loopback, `--require-auth` should be enabled. Authentication is
+  a bearer token applied to `/api/` routes only; static assets remain ungated.
+  Browser-facing defenses (Host-header allowlist, CORS restrictions, CSP,
+  `X-Frame-Options: DENY`) are always on. See the CLI reference for token
+  configuration.
+- **PostgreSQL sync.** `agentsview pg push` exports the local archive to a
+  user-supplied PostgreSQL instance. Non-loopback DSNs are rejected unless TLS
+  is enabled (`sslmode=require` or stronger), or the user has explicitly set
+  `allow_insecure = true` under `[pg]`. The destination database itself is
+  treated as user-provisioned infrastructure; agentsview asserts nothing about
+  its access controls.
+- **SSH remote sync.** agentsview can pull session archives from another machine
+  over SSH. Authentication is whatever the user's SSH configuration provides.
+  Pulled files are parsed locally as untrusted data and merged into the unified
+  archive.
+- **Imports.** Imported archives from other agentsview instances or third-party
+  exports are treated as untrusted structured data, no different from session
+  files written by local agents.
 - **LiteLLM pricing.** Pricing metadata is fetched on demand from
-  `raw.githubusercontent.com/BerriAI/litellm/...` to compute token
-  costs. No session data is sent.
-- **Update check.** On startup agentsview makes one outbound HTTPS
-  request to check for new releases. No session data is sent; the
-  request is opt-out via `--no-update-check`.
+  `raw.githubusercontent.com/BerriAI/litellm/...` to compute token costs. No
+  session data is sent.
+- **Update check.** On startup agentsview makes one outbound HTTPS request to
+  check for new releases. No session data is sent; the request is opt-out via
+  `--no-update-check`.
 
 ## Browser-facing hardening
 
 The HTTP server applies the following defenses unconditionally:
 
-- **Host-header allowlist.** Requests whose `Host` does not match the
-  configured listen address (or a configured public URL/origin) are
-  rejected, defending against DNS-rebinding attacks where an attacker
-  domain resolves to `127.0.0.1`.
-- **CORS restrictions.** Cross-origin API requests must come from an
-  allowed origin or carry the bearer token; preflight handling is
-  explicit.
-- **Content-Security-Policy.** A policy pinning the server's exact
-  origin for script/style/image/font/default-src is set on non-API
-  responses. `connect-src` is intentionally widened to allow the
-  remote-server feature in the SPA; this is a documented tradeoff.
-- **X-Frame-Options: DENY.** Framing is disallowed on non-API
-  responses.
+- **Host-header allowlist.** Requests whose `Host` does not match the configured
+  listen address (or a configured public URL/origin) are rejected, defending
+  against DNS-rebinding attacks where an attacker domain resolves to
+  `127.0.0.1`.
+- **CORS restrictions.** Cross-origin API requests must come from an allowed
+  origin or carry the bearer token; preflight handling is explicit.
+- **Content-Security-Policy.** A policy pinning the server's exact origin for
+  script/style/image/font/default-src is set on non-API responses. `connect-src`
+  is intentionally widened to allow the remote-server feature in the SPA; this
+  is a documented tradeoff.
+- **X-Frame-Options: DENY.** Framing is disallowed on non-API responses.
 
 ## Secrets subsystem
 
-agentsview includes best-effort detection of secrets that appear in
-session content (API keys, tokens, credentials). Detected secrets are:
+agentsview includes best-effort detection of secrets that appear in session
+content (API keys, tokens, credentials). Detected secrets are:
 
 - recorded as findings in the database;
 - redacted by default in CLI and UI views;
 - revealable only via localhost-gated paths.
 
-This is a defense-in-depth feature, not data-loss prevention. It does
-not catch every secret pattern, does not retroactively remove secrets
-from the on-disk archive, and does not make plaintext-at-rest storage
-safe. Treat the archive as if it contains every secret that ever
-appeared in any indexed session.
+This is a defense-in-depth feature, not data-loss prevention. It does not catch
+every secret pattern, does not retroactively remove secrets from the on-disk
+archive, and does not make plaintext-at-rest storage safe. Treat the archive as
+if it contains every secret that ever appeared in any indexed session.
 
 ## Contributing features that touch sensitive data
 
-Contributors adding parsers, indexes, readers, or sync targets that
-expand the data agentsview ingests, retains, or transmits should:
+Contributors adding parsers, indexes, readers, or sync targets that expand the
+data agentsview ingests, retains, or transmits should:
 
 1. State explicitly which trust boundary the change crosses.
-2. Make a deliberate opt-in vs opt-out decision and document it.
-3. Add any new egress channel to the Data-in-transit section of this
-   document, with a clear description of what is sent.
-4. Treat any new structured input source (file format, RPC, import)
-   as untrusted by default.
+1. Make a deliberate opt-in vs opt-out decision and document it.
+1. Add any new egress channel to the Data-in-transit section of this document,
+   with a clear description of what is sent.
+1. Treat any new structured input source (file format, RPC, import) as untrusted
+   by default.
 
-Configuration ergonomics (one boolean vs many granular toggles) is a
-maintainer design call and out of scope for this document.
+Configuration ergonomics (one boolean vs many granular toggles) is a maintainer
+design call and out of scope for this document.
 
 ## Reporting
 
-Security issues should be reported privately, not via public GitHub
-issues.
+Security issues should be reported privately, not via public GitHub issues.
 
-[TODO: maintainer to enable GitHub private vulnerability reporting on
-the repository and/or provide a private contact (email, PGP key).
-Until that contact is published, please open a non-detailed GitHub
-issue requesting a private channel and a maintainer will follow up
-out-of-band; do not include exploit details in the public issue.]
+\[TODO: maintainer to enable GitHub private vulnerability reporting on the
+repository and/or provide a private contact (email, PGP key). Until that contact
+is published, please open a non-detailed GitHub issue requesting a private
+channel and a maintainer will follow up out-of-band; do not include exploit
+details in the public issue.\]
 
 ## Open questions
 
-These are intentionally not resolved in this document. Each is a
-candidate for its own proposal.
+These are intentionally not resolved in this document. Each is a candidate for
+its own proposal.
 
-1. **Encryption at rest.** Should the SQLite archive support optional
-   at-rest encryption (e.g., SQLCipher)? At what UX cost?
-2. **Auth model evolution.** Should the bearer-token model grow
-   (per-client tokens, expiry, rotation), and how should tokens be
-   stored on disk?
-3. **Multi-user machine support.** Is agentsview ever meant to run on
-   a shared host, and if so what are the minimum hardening steps?
-4. **`allow_insecure` UX.** Should setting `[pg] allow_insecure = true`
-   require an additional confirmation (e.g., a `--yes-really` flag) on
-   first use, given that it disables the only protection against
-   plaintext PG egress?
-5. **Deletion guarantees.** Should "permanent delete" grow into a
-   stronger erasure path (VACUUM, WAL checkpoint + truncate, mirror
-   propagation to PG/SSH targets), or should the docs simply make the
-   current limits clearer?
-6. **Secret detection scope.** Should the detector expand (more
-   patterns, structured-secret types), should redacted-by-default
-   extend to exports, and should there be a "scrub-on-import" pass?
+1. **Encryption at rest.** Should the SQLite archive support optional at-rest
+   encryption (e.g., SQLCipher)? At what UX cost?
+1. **Auth model evolution.** Should the bearer-token model grow (per-client
+   tokens, expiry, rotation), and how should tokens be stored on disk?
+1. **Multi-user machine support.** Is agentsview ever meant to run on a shared
+   host, and if so what are the minimum hardening steps?
+1. **`allow_insecure` UX.** Should setting `[pg] allow_insecure = true` require
+   an additional confirmation (e.g., a `--yes-really` flag) on first use, given
+   that it disables the only protection against plaintext PG egress?
+1. **Deletion guarantees.** Should "permanent delete" grow into a stronger
+   erasure path (VACUUM, WAL checkpoint + truncate, mirror propagation to PG/SSH
+   targets), or should the docs simply make the current limits clearer?
+1. **Secret detection scope.** Should the detector expand (more patterns,
+   structured-secret types), should redacted-by-default extend to exports, and
+   should there be a "scrub-on-import" pass?

--- a/docs/huma-api-routes.md
+++ b/docs/huma-api-routes.md
@@ -5,13 +5,13 @@ self-contained so OpenAPI ownership stays close to runtime behavior.
 
 ## File Ownership
 
-- Put route registration, endpoint-specific input types, response wrapper
-  types, enums, and handlers in the route group file that owns the path.
-- Keep `internal/server/huma_routes.go` limited to shared Huma plumbing:
-  API configuration, route registration helpers, common path/query inputs,
-  error conversion, schema naming, SSE/write helpers, and middleware.
-- Move a helper into shared plumbing only when at least two route groups use
-  it and it has no domain-specific policy.
+- Put route registration, endpoint-specific input types, response wrapper types,
+  enums, and handlers in the route group file that owns the path.
+- Keep `internal/server/huma_routes.go` limited to shared Huma plumbing: API
+  configuration, route registration helpers, common path/query inputs, error
+  conversion, schema naming, SSE/write helpers, and middleware.
+- Move a helper into shared plumbing only when at least two route groups use it
+  and it has no domain-specific policy.
 - Do not add new typed handlers to a catch-all API file. Add a new group file
   when a new API area does not fit an existing group.
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -183,7 +183,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 40
+const dataVersion = 41
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -296,14 +296,17 @@ func (r *antigravityStepLoadResult) appendGenMetadataUsage(
 	data []byte, msg ParsedMessage, decoded bool,
 ) ParsedMessage {
 	genModel := extractModelName(data)
-	input, output, reasoning, okUsage := extractTokenUsage(data)
+	block, okUsage := extractTokenUsage(data)
 	if okUsage {
-		// gen_metadata splits candidates (field 2) and thoughts
-		// (field 3) Gemini-style, but cost paths price OutputTokens
-		// only. Fold reasoning into the billable output — matching
-		// the Gemini parser — and keep ReasoningTokens as a
-		// breakdown.
-		billableOutput := output + reasoning
+		// gen_metadata field semantics (cross-validated against sidecar
+		// generatorMetadata ground truth in 550/550 blocks):
+		//   f2 = uncached input (inputTokens)
+		//   f3 = total output including thinking (outputTokens)
+		//   f5 = cache-read (cacheReadTokens, absent when no cache hits)
+		//   f4 = always 0/absent, ignored
+		// No per-field reasoning breakdown is available; f3 already
+		// includes thinking tokens.
+		context := block.UncachedInput + block.CacheRead
 		eventModel := genModel
 		var occurredAt string
 		if decoded {
@@ -313,18 +316,20 @@ func (r *antigravityStepLoadResult) appendGenMetadataUsage(
 			if !msg.Timestamp.IsZero() {
 				occurredAt = msg.Timestamp.Format(time.RFC3339Nano)
 			}
-			msg.ContextTokens = input
-			msg.OutputTokens = billableOutput
-			msg.HasContextTokens = input > 0
-			msg.HasOutputTokens = billableOutput > 0
+			msg.ContextTokens = context
+			msg.OutputTokens = block.TotalOutput
+			msg.HasContextTokens = context > 0
+			msg.HasOutputTokens = block.TotalOutput > 0
+
 		}
 		r.usageEvents = append(r.usageEvents, ParsedUsageEvent{
-			Source:          "generation",
-			Model:           eventModel,
-			InputTokens:     input,
-			OutputTokens:    billableOutput,
-			ReasoningTokens: reasoning,
-			OccurredAt:      occurredAt,
+			Source:               "generation",
+			Model:                eventModel,
+			InputTokens:          block.UncachedInput,
+			OutputTokens:         block.TotalOutput,
+			CacheReadInputTokens: block.CacheRead,
+			ReasoningTokens:      0, // not available in gen_metadata
+			OccurredAt:           occurredAt,
 		})
 	}
 	if decoded && genModel != "" {
@@ -333,10 +338,23 @@ func (r *antigravityStepLoadResult) appendGenMetadataUsage(
 	return msg
 }
 
-// extractTokenUsage walks the decoded protobuf fields recursively to find
-// the token usage block containing Field 1 = 1020, Field 2 = output,
-// Field 3 = reasoning, and Field 5 = input.
+// agTokenBlock carries the decoded token usage extracted from one
+// gen_metadata blob. Field semantics are cross-validated against sidecar
+// ground truth (generatorMetadata[].chatModel.usage matches in 550/550
+// blocks):
 //
+//	UncachedInput = f2 (inputTokens, tokens not served from cache)
+//	TotalOutput   = f3 (outputTokens, includes thinking)
+//	CacheRead     = f5 (cacheReadTokens, absent/zero for cache-miss sessions)
+//
+// No per-field reasoning breakdown is available in gen_metadata;
+// TotalOutput already includes thinking tokens.
+type agTokenBlock struct {
+	UncachedInput int // f2: tokens not served from cache
+	TotalOutput   int // f3: total output including thinking
+	CacheRead     int // f5: cache-read tokens (0 when absent)
+}
+
 // maxPlausibleTokens caps the token values accepted by the heuristic.
 // Other nested messages can coincidentally satisfy field1 ∈ [1000, 5000)
 // while carrying large integers (e.g. a nanosecond latency).
@@ -345,19 +363,20 @@ func (r *antigravityStepLoadResult) appendGenMetadataUsage(
 // positives and skipped.
 const maxPlausibleTokens = 2_000_000
 
-func extractTokenUsage(data []byte) (input, output, reasoning int, ok bool) {
+func extractTokenUsage(data []byte) (agTokenBlock, bool) {
 	fields, err := agProtoParse(data)
 	if err != nil {
-		return 0, 0, 0, false
+		return agTokenBlock{}, false
 	}
 	var found bool
+	var block agTokenBlock
 	var walk func([]agProtoField)
 	walk = func(fs []agProtoField) {
 		if found {
 			return
 		}
-		if in, out, reas, blockOK := tokenBlockFrom(fs); blockOK {
-			input, output, reasoning = in, out, reas
+		if b, ok := tokenBlockFrom(fs); ok {
+			block = b
 			found = true
 			return
 		}
@@ -368,44 +387,76 @@ func extractTokenUsage(data []byte) (input, output, reasoning int, ok bool) {
 		}
 	}
 	walk(fields)
-	return input, output, reasoning, found
+	return block, found
 }
 
-// tokenBlockFrom reports whether fs is a plausible token usage block:
-// field 1 holds a model-kind varint in [1000, 5000), fields 2 (output)
-// and 5 (input) are varints within maxPlausibleTokens, and field 3
-// (reasoning), when present, is a varint within the cap too. Field 5
-// is required: a real generation always consumes input context (proto3
-// omits only zero values), while observed false-positive blocks (e.g.
-// latency counters) lack it. Field 3 stays optional because zero
-// reasoning is legitimate and omitted from the wire, but a present
-// field 3 with a non-varint wire type marks the block as a decoy.
-// The cap also applies to output+reasoning combined, because that sum
-// is the billable output the caller persists: capping the fields only
-// individually would let a decoy block persist up to twice the cap.
-func tokenBlockFrom(fs []agProtoField) (input, output, reasoning int, ok bool) {
+// tokenBlockFrom reports whether fs is a plausible token usage block.
+//
+// Field semantics are cross-validated against sidecar ground truth
+// (generatorMetadata[].chatModel.usage matches in 550/550 blocks):
+//
+//	f1 = model-kind varint in [1000, 5000)
+//	f2 = uncached input (inputTokens)
+//	f3 = total output including thinking (outputTokens)
+//	f4 = always 0/absent, ignored
+//	f5 = cache-read (cacheReadTokens, absent when no cache hits)
+//
+// No per-field reasoning breakdown is available in gen_metadata;
+// the reasoning return value is always 0.
+//
+// f2 and f3 are required. f5 is optional: proto3 omits zero-valued
+// fields, and a fresh session with no cache hits omits f5 entirely.
+// Requiring f5 (the previous heuristic) caused the parser to miss
+// token blocks in such sessions, which is why the single-generation
+// June-11 archives all have no extracted block under the old mapping.
+func tokenBlockFrom(fs []agProtoField) (agTokenBlock, bool) {
 	f1, ok1 := agProtoFind(fs, 1)
 	f2, ok2 := agProtoFind(fs, 2)
-	f5, ok5 := agProtoFind(fs, 5)
-	if !ok1 || !ok2 || !ok5 ||
+	f3, ok3 := agProtoFind(fs, 3)
+	// f5 (cache-read) is optional: proto3 omits zero-valued fields, and
+	// cache-read is absent when a session has no cache hits.
+	f5, hasF5 := agProtoFind(fs, 5)
+
+	if !ok1 || !ok2 || !ok3 ||
 		f1.Wire != pbWireVarint || f2.Wire != pbWireVarint ||
-		f5.Wire != pbWireVarint {
-		return 0, 0, 0, false
+		f3.Wire != pbWireVarint {
+		return agTokenBlock{}, false
 	}
 	if f1.Varint < 1000 || f1.Varint >= 5000 {
-		return 0, 0, 0, false
+		return agTokenBlock{}, false
 	}
-	if f2.Varint > maxPlausibleTokens || f5.Varint > maxPlausibleTokens {
-		return 0, 0, 0, false
+	if f2.Varint > maxPlausibleTokens || f3.Varint > maxPlausibleTokens {
+		return agTokenBlock{}, false
 	}
-	if f3, hasF3 := agProtoFind(fs, 3); hasF3 {
-		if f3.Wire != pbWireVarint || f3.Varint > maxPlausibleTokens ||
-			f2.Varint+f3.Varint > maxPlausibleTokens {
-			return 0, 0, 0, false
+	// f2 (input) and f3 (output) are independent quantities, but an
+	// implausibly large combined footprint (input + output > cap)
+	// signals a decoy block where both values individually pass the
+	// per-field cap but are collectively implausible for a single
+	// generation.
+	if f2.Varint+f3.Varint > maxPlausibleTokens {
+		return agTokenBlock{}, false
+	}
+	// f4 is consistently absent/zero in real blocks and carries no
+	// semantics. Tolerate its presence but ignore the value.
+	if f4, hasF4 := agProtoFind(fs, 4); hasF4 {
+		if f4.Wire != pbWireVarint || f4.Varint > maxPlausibleTokens {
+			return agTokenBlock{}, false
 		}
-		reasoning = int(f3.Varint)
 	}
-	return int(f5.Varint), int(f2.Varint), reasoning, true
+	if hasF5 {
+		if f5.Wire != pbWireVarint || f5.Varint > maxPlausibleTokens {
+			return agTokenBlock{}, false
+		}
+	}
+
+	block := agTokenBlock{
+		UncachedInput: int(f2.Varint),
+		TotalOutput:   int(f3.Varint),
+	}
+	if hasF5 {
+		block.CacheRead = int(f5.Varint)
+	}
+	return block, true
 }
 
 // extractModelName recursively walks fields to extract the model name from Field 21 or Field 19.
@@ -477,6 +528,9 @@ func isPlausibleModelName(s string) bool {
 //     model placeholders, and duplicate payload echoes are filtered
 //     out. User-input steps prefer a single prompt-like string.
 //   - timestamp: earliest google.protobuf.Timestamp-shaped field.
+//   - tool calls: assistant steps whose payloads contain known tool
+//     name strings emit structured ParsedToolCall entries so that
+//     the timing panel can compute turns, categories, and counts.
 func decodeAntigravityStep(
 	idx, stepType int, payload []byte,
 ) (ParsedMessage, bool) {
@@ -487,24 +541,233 @@ func decodeAntigravityStep(
 	if err != nil || len(fields) == 0 {
 		return ParsedMessage{}, false
 	}
-	strs := cleanAntigravityStepStrings(
-		dedupeStrings(agProtoCollectStrings(fields, 20)), stepType,
-	)
 	ts := earliestAntigravityTimestamp(fields)
-	if len(strs) == 0 {
-		return ParsedMessage{}, false
-	}
+
 	role := RoleAssistant
 	if stepType == 14 {
 		role = RoleUser
 	}
+
+	// Extract tool calls for assistant steps before the content guard
+	// so that tool-only steps (no displayable text) are not silently
+	// dropped.
+	var calls []ParsedToolCall
+	if role == RoleAssistant {
+		calls = extractAntigravityToolCalls(idx, fields)
+	}
+
+	strs := cleanAntigravityStepStrings(
+		dedupeStrings(agProtoCollectStrings(fields, 20)), stepType,
+	)
+
+	// Emit the message if it has displayable content OR tool calls.
+	// Tool-only assistant steps (empty prose) are valid.
+	if len(strs) == 0 && len(calls) == 0 {
+		return ParsedMessage{}, false
+	}
+
 	content := strings.Join(strs, "\n\n")
-	return ParsedMessage{
+	msg := ParsedMessage{
 		Role:          role,
 		Content:       content,
 		ContentLength: len(content),
 		Timestamp:     ts,
-	}, true
+	}
+	if len(calls) > 0 {
+		msg.ToolCalls = calls
+		msg.HasToolUse = true
+	}
+	return msg, true
+}
+
+// isLikelyToolName returns true if s is a reasonable candidate for a tool name:
+// - length between 1 and 64 characters
+// - contains only ASCII letters, digits, underscores, hyphens, and colons.
+func isLikelyToolName(s string) bool {
+	if len(s) == 0 || len(s) > 64 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		r := s[i]
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_' && r != '-' && r != ':' {
+			return false
+		}
+	}
+	return true
+}
+
+// knownAntigravityToolNames is the set of tool names that Antigravity
+// actually uses. Only strings present in this set are accepted as tool
+// calls; generic taxonomy matches without a known Antigravity name
+// are rejected. This prevents generic strings like "read", "write",
+// "message", or "process" from being falsely matched.
+var knownAntigravityToolNames = map[string]bool{
+	// Antigravity-specific tools
+	"view_file":                  true,
+	"read_url_content":           true,
+	"replace_file_content":       true,
+	"multi_replace_file_content": true,
+	"write_to_file":              true,
+	"define_subagent":            true,
+	"invoke_subagent":            true,
+	"manage_subagents":           true,
+	"send_message":               true,
+	"manage_task":                true,
+	"ask_permission":             true,
+	"ask_question":               true,
+	"schedule":                   true,
+	"search_web":                 true,
+	"generate_image":             true,
+	// Gemini/Antigravity shared tools (also appear in CLI variant)
+	"run_command":       true,
+	"execute_command":   true,
+	"run_shell_command": true,
+	"grep_search":       true,
+	"search_files":      true,
+	"list_directory":    true,
+	// Known CLI JSON structure tool names
+	"edit_file":  true,
+	"read_file":  true,
+	"write_file": true,
+}
+
+// isAntigravityToolName reports whether s is a known Antigravity tool
+// name. Only strings present in knownAntigravityToolNames are accepted;
+// generic taxonomy matches are rejected.
+func isAntigravityToolName(s string) bool {
+	return knownAntigravityToolNames[s]
+}
+
+// extractAntigravityToolCalls walks the decoded protobuf field tree
+// and returns one ParsedToolCall per tool invocation found. Uses the
+// same heuristic-walker approach as extractTokenUsage / extractModelName:
+// we identify strings that exactly match known tool names, collect any
+// adjacent UUID-like string as the ToolUseID, and any adjacent JSON
+// object string as the InputJSON.
+//
+// When no UUID-like ID is found, a synthetic deterministic ID is
+// generated so the timing pipeline still has a stable key per call.
+//
+// Only strings matching Antigravity-known tool names are accepted.
+func extractAntigravityToolCalls(
+	stepIdx int, fields []agProtoField,
+) []ParsedToolCall {
+	// Collect all string values reachable from this step's field tree.
+	// minLen=1 so we catch even short tool names like "Bash" or "Read".
+	all := agProtoCollectStrings(fields, 1)
+
+	var calls []ParsedToolCall
+	seen := map[string]bool{}
+	for i, s := range all {
+		if !isLikelyToolName(s) {
+			continue
+		}
+		cat := NormalizeToolCategory(s)
+		if cat == "Other" {
+			continue
+		}
+		// Reject generic taxonomy matches that are not known Antigravity tools.
+		if !isAntigravityToolName(s) {
+			continue
+		}
+		// Look for an adjacent UUID-like string to use as ToolUseID.
+		// We scan the neighbouring strings (within a small window on
+		// either side) since the proto walker returns siblings in
+		// encounter order. Prefer following siblings so a flat sequence
+		// of tools doesn't mistakenly pick up previous IDs.
+		toolUseID := ""
+		for _, offset := range []int{1, 2, -1, -2} {
+			j := i + offset
+			if j < 0 || j >= len(all) {
+				continue
+			}
+			// Check for intervening tool names to avoid stealing UUID of another tool call
+			interveningTool := false
+			if offset > 0 {
+				for k := i + 1; k < j; k++ {
+					if isAntigravityToolName(all[k]) {
+						interveningTool = true
+						break
+					}
+				}
+			} else {
+				for k := j + 1; k < i; k++ {
+					if isAntigravityToolName(all[k]) {
+						interveningTool = true
+						break
+					}
+				}
+			}
+			if interveningTool {
+				continue
+			}
+
+			if antigravityUUIDLikeRE.MatchString(all[j]) {
+				toolUseID = all[j]
+				break
+			}
+		}
+
+		// Look for an adjacent JSON-object string to use as InputJSON.
+		inputJSON := ""
+		for _, offset := range []int{1, 2, -1} {
+			j := i + offset
+			if j < 0 || j >= len(all) {
+				continue
+			}
+			// Check for intervening tool names to avoid stealing InputJSON of another tool call
+			interveningTool := false
+			if offset > 0 {
+				for k := i + 1; k < j; k++ {
+					if isAntigravityToolName(all[k]) {
+						interveningTool = true
+						break
+					}
+				}
+			} else {
+				for k := j + 1; k < i; k++ {
+					if isAntigravityToolName(all[k]) {
+						interveningTool = true
+						break
+					}
+				}
+			}
+			if interveningTool {
+				continue
+			}
+
+			if strings.HasPrefix(strings.TrimSpace(all[j]), "{") {
+				inputJSON = all[j]
+				break
+			}
+		}
+
+		// Assign a synthetic ID when no UUID was found in the payload,
+		// using the string index to make each invocation unique.
+		if toolUseID == "" {
+			toolUseID = fmt.Sprintf("ag-step-%d-%d", stepIdx, i)
+		}
+
+		// Avoid emitting duplicate tool hits from the same payload
+		// (the walker may surface the same string via multiple paths).
+		// We deduplicate by tool name + ID + Input JSON to avoid collapsing
+		// multiple distinct invocations of the same tool in one step.
+		// This runs after synthetic-ID assignment so that calls without
+		// adjacent UUIDs still get position-unique keys.
+		dedupKey := s + ":" + toolUseID + ":" + inputJSON
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+
+		calls = append(calls, ParsedToolCall{
+			ToolUseID: toolUseID,
+			ToolName:  s,
+			Category:  cat,
+			InputJSON: inputJSON,
+		})
+	}
+	return calls
 }
 
 func dedupeStrings(in []string) []string {

--- a/internal/parser/antigravity_fuzz_test.go
+++ b/internal/parser/antigravity_fuzz_test.go
@@ -23,8 +23,9 @@ package parser
 //     bytes are all < 0x80 is valid UTF-8, leaked into
 //     messages.model, and broke pg push with SQLSTATE 22021).
 //   - extractTokenUsage: counts are non-negative and bounded by
-//     maxPlausibleTokens, including the output+reasoning sum the
-//     caller persists as billable output.
+//     maxPlausibleTokens, including the input+output sum used as a
+//     combined plausibility guard. Reasoning is always 0 (no per-field
+//     breakdown available in gen_metadata).
 //
 // Plain `go test` runs the f.Add seeds plus any regression inputs
 // committed under testdata/fuzz/<Target>/, so the corpus is enforced
@@ -73,11 +74,13 @@ func fuzzAgWireSeeds() [][]byte {
 			"abcdefghij\x00klmnopqrstuvwxyz now twenty-plus runes",
 		)},
 	})
+	// f2=5529 (uncached input), f3=72 (total output), f5=38885 (cache-read).
+	// Remapped field semantics cross-validated against sidecar ground truth.
 	usageBlock := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1020},
-		{num: 2, wire: pbWireVarint, varint: 1542},
-		{num: 3, wire: pbWireVarint, varint: 256},
-		{num: 5, wire: pbWireVarint, varint: 8133},
+		{num: 2, wire: pbWireVarint, varint: 5529},
+		{num: 3, wire: pbWireVarint, varint: 72},
+		{num: 5, wire: pbWireVarint, varint: 38885},
 	})
 	genMeta := encodePB([]pbField{
 		{num: 17, wire: pbWireBytes, bytes: usageBlock},
@@ -88,22 +91,23 @@ func fuzzAgWireSeeds() [][]byte {
 			{num: 21, wire: pbWireBytes, bytes: agIncidentFragment},
 		})},
 	})
+	// Decoy: f2 input above cap.
 	usageDecoyLatency := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1020},
 		{num: 2, wire: pbWireVarint, varint: 2_000_001},
-		{num: 5, wire: pbWireVarint, varint: 1},
+		{num: 3, wire: pbWireVarint, varint: 1},
 	})
+	// Decoy: f3 output with wrong wire type.
 	usageDecoyWire := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1020},
 		{num: 2, wire: pbWireVarint, varint: 5},
 		{num: 3, wire: pbWireBytes, bytes: []byte("xx")},
-		{num: 5, wire: pbWireVarint, varint: 9},
 	})
+	// Decoy: f2+f3 sum above cap (each individually plausible).
 	usageDecoyFoldedCap := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1020},
 		{num: 2, wire: pbWireVarint, varint: 2_000_000},
 		{num: 3, wire: pbWireVarint, varint: 2_000_000},
-		{num: 5, wire: pbWireVarint, varint: 2_000_000},
 	})
 	onion := []byte("core")
 	for range agProtoMaxDepth + 4 {
@@ -296,23 +300,24 @@ func FuzzExtractTokenUsage(f *testing.F) {
 		f.Add(seed)
 	}
 	f.Fuzz(func(t *testing.T, data []byte) {
-		input, output, reasoning, ok := extractTokenUsage(data)
+		block, ok := extractTokenUsage(data)
 		if !ok {
-			assert.Zero(t, input)
-			assert.Zero(t, output)
-			assert.Zero(t, reasoning)
+			assert.Zero(t, block.UncachedInput)
+			assert.Zero(t, block.TotalOutput)
+			assert.Zero(t, block.CacheRead)
 			return
 		}
 		for name, v := range map[string]int{
-			"input": input, "output": output, "reasoning": reasoning,
+			"uncachedInput": block.UncachedInput, "totalOutput": block.TotalOutput, "cacheRead": block.CacheRead,
 		} {
 			assert.GreaterOrEqual(t, v, 0, "%s tokens negative", name)
 			assert.LessOrEqual(t, v, maxPlausibleTokens,
 				"%s tokens above plausibility cap", name)
 		}
-		// The caller persists output+reasoning as billable output,
-		// so the plausibility cap must hold for the sum as well.
-		assert.LessOrEqual(t, output+reasoning, maxPlausibleTokens,
-			"billable output+reasoning above plausibility cap")
+		// The caller uses input+output as a combined plausibility guard
+		// (each independently bounded, but decoys with both near the cap
+		// are implausible for a single generation).
+		assert.LessOrEqual(t, block.UncachedInput+block.TotalOutput, maxPlausibleTokens,
+			"input+output above plausibility cap")
 	})
 }

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -198,7 +198,7 @@ func TestAgProtoLooksLikePrefix(t *testing.T) {
 	require.True(t, agProtoLooksLikePrefix(complete), "complete message rejected")
 
 	// Append a length-delimited field whose declared length runs
-	// past the end of the buffer — agProtoParse rejects this, but
+	// past the end of the buffer - agProtoParse rejects this, but
 	// the prefix-tolerant check should accept since at least one
 	// full field decoded cleanly first.
 	truncated := append(append([]byte{}, complete...),
@@ -1056,9 +1056,207 @@ func mustExec(
 	require.NoError(t, err, "exec %q", q)
 }
 
+// createAntigravityToolCallDB creates a .db with two steps:
+//   - step_type=14 (user): plain text prompt
+//   - step_type=17 (assistant): payload containing the string "view_file"
+//     embedded as a protobuf string field, simulating a planner response
+//     that invoked the view_file tool.
+func createAntigravityToolCallDB(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open")
+	defer db.Close()
+	createAntigravityStepTables(t, db)
+
+	tsEarly := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000000},
+	})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{num: 17, wire: pbWireBytes, bytes: []byte("please check the file")},
+	})
+
+	tsLate := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000100},
+	})
+	// Embed "view_file" as a string field inside a nested message
+	// that also contains a UUID-like tool-use ID. This mirrors the
+	// protobuf shape observed in real Antigravity .db step payloads.
+	toolCallNested := encodePB([]pbField{
+		{num: 3, wire: pbWireBytes, bytes: []byte("view_file")},
+		{num: 4, wire: pbWireBytes, bytes: []byte("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")},
+	})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsLate},
+		{num: 17, wire: pbWireBytes, bytes: []byte("I will read the file for you")},
+		{num: 8, wire: pbWireBytes, bytes: toolCallNested},
+	})
+
+	mustExec(t, db,
+		`INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
+		0, 14, userPayload)
+	mustExec(t, db,
+		`INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
+		1, 17, asstPayload)
+}
+
+// TestDecodeAntigravityStepToolCall is the tracer bullet: parsing a .db
+// session whose assistant step contains a known tool name ("view_file")
+// produces a message with HasToolUse=true and one ToolCall entry.
+func TestDecodeAntigravityStepToolCall(t *testing.T) {
+	root := t.TempDir()
+	id := "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityToolCallDB(t, dbPath)
+
+	sess, msgs, _, err := ParseAntigravitySession(dbPath, "/tmp/proj", "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Find the assistant message.
+	var asstMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].Role == RoleAssistant {
+			asstMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, asstMsg, "expected an assistant message")
+
+	assert.True(t, asstMsg.HasToolUse, "assistant message should have HasToolUse=true")
+	require.Len(t, asstMsg.ToolCalls, 1, "expected one tool call")
+	assert.Equal(t, "view_file", asstMsg.ToolCalls[0].ToolName)
+	assert.Equal(t, "Read", asstMsg.ToolCalls[0].Category)
+}
+
 // silence unused warning on time import in case the file is
 // trimmed in the future.
 var _ = time.Time{}
+
+// TestDecodeAntigravityStepUserNoToolCalls asserts that a user step
+// (step_type=14) whose payload happens to contain a known tool name string
+// does NOT produce any ToolCall entries - tool calls only belong on assistant
+// messages.
+func TestDecodeAntigravityStepUserNoToolCalls(t *testing.T) {
+	root := t.TempDir()
+	id := "bbbb2222-cccc-dddd-eeee-ffffffffffff"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+
+	// Build a .db where the USER step payload contains "view_file".
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	createAntigravityStepTables(t, db)
+
+	ts := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000000}})
+	// User step (step_type=14) whose payload includes a tool name string.
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: ts},
+		{num: 17, wire: pbWireBytes, bytes: []byte("please use view_file on that path")},
+	})
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
+		0, 14, userPayload)
+
+	sess, msgs, _, err := ParseAntigravitySession(dbPath, "/tmp/proj", "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	require.Len(t, msgs, 1)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.False(t, msgs[0].HasToolUse, "user step should not have HasToolUse=true")
+	assert.Empty(t, msgs[0].ToolCalls, "user step should have no ToolCalls")
+}
+
+// TestDecodeAntigravityStepNoFalsePositives asserts that an assistant step
+// whose payload contains only plain prose (no known tool name strings)
+// produces no ToolCall entries and HasToolUse=false.
+func TestDecodeAntigravityStepNoFalsePositives(t *testing.T) {
+	root := t.TempDir()
+	id := "cccc3333-dddd-eeee-ffff-000000000000"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	createAntigravityStepTables(t, db)
+
+	ts := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000000}})
+	// Assistant step with no known tool names - just prose.
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: ts},
+		{num: 17, wire: pbWireBytes, bytes: []byte("Here is my analysis of the codebase and recommendations for improvement.")},
+	})
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
+		0, 17, asstPayload)
+
+	sess, msgs, _, err := ParseAntigravitySession(dbPath, "/tmp/proj", "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	require.Len(t, msgs, 1)
+	assert.Equal(t, RoleAssistant, msgs[0].Role)
+	assert.False(t, msgs[0].HasToolUse, "plain-prose step should not have HasToolUse=true")
+	assert.Empty(t, msgs[0].ToolCalls, "plain-prose step should have no ToolCalls")
+}
+
+// TestDecodeAntigravityStepMultipleToolCalls asserts that an assistant step
+// whose payload contains two distinct known tool names produces two ToolCall
+// entries with the correct names and categories.
+func TestDecodeAntigravityStepMultipleToolCalls(t *testing.T) {
+	root := t.TempDir()
+	id := "dddd4444-eeee-ffff-0000-111111111111"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	createAntigravityStepTables(t, db)
+
+	ts := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000000}})
+	// Two tool call nested messages in the same assistant step.
+	tc1 := encodePB([]pbField{
+		{num: 3, wire: pbWireBytes, bytes: []byte("view_file")},
+		{num: 4, wire: pbWireBytes, bytes: []byte("11111111-2222-3333-4444-555555555555")},
+	})
+	tc2 := encodePB([]pbField{
+		{num: 3, wire: pbWireBytes, bytes: []byte("run_command")},
+		{num: 4, wire: pbWireBytes, bytes: []byte("66666666-7777-8888-9999-aaaaaaaaaaaa")},
+	})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: ts},
+		{num: 17, wire: pbWireBytes, bytes: []byte("reading file and running command")},
+		{num: 8, wire: pbWireBytes, bytes: tc1},
+		{num: 9, wire: pbWireBytes, bytes: tc2},
+	})
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
+		0, 17, asstPayload)
+
+	sess, msgs, _, err := ParseAntigravitySession(dbPath, "/tmp/proj", "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	require.Len(t, msgs, 1)
+	assert.True(t, msgs[0].HasToolUse)
+	require.Len(t, msgs[0].ToolCalls, 2, "expected two tool calls")
+
+	toolNames := []string{msgs[0].ToolCalls[0].ToolName, msgs[0].ToolCalls[1].ToolName}
+	assert.ElementsMatch(t, []string{"view_file", "run_command"}, toolNames)
+
+	for _, tc := range msgs[0].ToolCalls {
+		switch tc.ToolName {
+		case "view_file":
+			assert.Equal(t, "Read", tc.Category)
+		case "run_command":
+			assert.Equal(t, "Bash", tc.Category)
+		}
+	}
+}
 
 func TestAntigravityCLITrajectoryParse(t *testing.T) {
 	root := t.TempDir()
@@ -1537,7 +1735,7 @@ func TestAntigravityCLISidecarWinsKeepsTokenUsage(t *testing.T) {
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 14, ?)`, userPayload)
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 17, ?)`, asstPayload)
 
-	genData := createAntigravityMockGenMetadata(t, 2400, 180, 30, "Test Gemini 3.5")
+	genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
 	require.NoError(t, db.Close())
 
@@ -1557,11 +1755,11 @@ func TestAntigravityCLISidecarWinsKeepsTokenUsage(t *testing.T) {
 
 	require.Len(t, usageEvents, 1)
 	assert.Equal(t, 2400, usageEvents[0].InputTokens)
-	assert.Equal(t, 210, usageEvents[0].OutputTokens)
+	assert.Equal(t, 180, usageEvents[0].OutputTokens)
 
 	// Session totals must come from gen_metadata usage even though
 	// the sidecar transcript has no per-message token metadata.
-	assert.Equal(t, 210, sess.TotalOutputTokens)
+	assert.Equal(t, 180, sess.TotalOutputTokens)
 	assert.Equal(t, 2400, sess.PeakContextTokens)
 	assert.True(t, sess.HasTotalOutputTokens)
 	assert.True(t, sess.HasPeakContextTokens)
@@ -1583,7 +1781,7 @@ func TestAntigravityCLISidecarRescueKeepsGenMetadataUsage(t *testing.T) {
 			`INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
 			i, 99, []byte{0xff, 0xff, 0xff})
 	}
-	genData := createAntigravityMockGenMetadata(t, 2400, 180, 30, "Test Gemini 3.5")
+	genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
 	require.NoError(t, db.Close())
 
@@ -1602,9 +1800,9 @@ func TestAntigravityCLISidecarRescueKeepsGenMetadataUsage(t *testing.T) {
 	require.Len(t, usageEvents, 1)
 	assert.Equal(t, "Test Gemini 3.5", usageEvents[0].Model)
 	assert.Equal(t, 2400, usageEvents[0].InputTokens)
-	assert.Equal(t, 210, usageEvents[0].OutputTokens)
-	assert.Equal(t, 30, usageEvents[0].ReasoningTokens)
-	assert.Equal(t, 210, sess.TotalOutputTokens)
+	assert.Equal(t, 180, usageEvents[0].OutputTokens)
+	assert.Equal(t, 0, usageEvents[0].ReasoningTokens, "reasoning not available in gen_metadata")
+	assert.Equal(t, 180, sess.TotalOutputTokens)
 	assert.Equal(t, 2400, sess.PeakContextTokens)
 }
 
@@ -1731,7 +1929,7 @@ func TestAntigravityCLIDBGenMetadataWinsOverSidecarUsage(t *testing.T) {
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 14, ?)`, userPayload)
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 17, ?)`, asstPayload)
 
-	genData := createAntigravityMockGenMetadata(t, 2400, 180, 30, "Test Gemini 3.5")
+	genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
 	require.NoError(t, db.Close())
 
@@ -1764,10 +1962,10 @@ func TestAntigravityCLIDBGenMetadataWinsOverSidecarUsage(t *testing.T) {
 	require.Len(t, usageEvents, 1)
 	assert.Equal(t, "generation", usageEvents[0].Source)
 	assert.Equal(t, 2400, usageEvents[0].InputTokens)
-	assert.Equal(t, 210, usageEvents[0].OutputTokens)
+	assert.Equal(t, 180, usageEvents[0].OutputTokens)
 
 	// Session totals follow the winning gen_metadata events.
-	assert.Equal(t, 210, sess.TotalOutputTokens)
+	assert.Equal(t, 180, sess.TotalOutputTokens)
 	assert.Equal(t, 2400, sess.PeakContextTokens)
 
 	// Per-message attribution comes from the sidecar generatorMetadata.
@@ -2012,7 +2210,7 @@ func TestAntigravitySessionFileMetadataIncludesWAL(t *testing.T) {
 
 	// The parse's own read-only open can create or touch -shm/-wal
 	// siblings, so the expected composite comes from post-parse disk
-	// state — the same state the next sync's skip check will stat.
+	// state - the same state the next sync's skip check will stat.
 	var wantSize int64
 	for _, p := range []string{dbPath, walPath, dbPath + "-shm"} {
 		fi, statErr := os.Stat(p)
@@ -2102,7 +2300,7 @@ func TestAntigravityTokenUsage(t *testing.T) {
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 17, ?)`, asstPayload)
 
 	// Create gen_metadata entry for the assistant step (idx=1)
-	genData := createAntigravityMockGenMetadata(t, 2400, 180, 30, "Test Gemini 3.5")
+	genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
 
 	sess, msgs, usageEvents, err := ParseAntigravitySession(dbPath, "test-project", "test-machine")
@@ -2114,7 +2312,7 @@ func TestAntigravityTokenUsage(t *testing.T) {
 	assert.Equal(t, RoleAssistant, msgs[1].Role)
 	assert.Equal(t, "Test Gemini 3.5", msgs[1].Model)
 	assert.Equal(t, 2400, msgs[1].ContextTokens)
-	assert.Equal(t, 210, msgs[1].OutputTokens)
+	assert.Equal(t, 180, msgs[1].OutputTokens)
 	assert.True(t, msgs[1].HasContextTokens)
 	assert.True(t, msgs[1].HasOutputTokens)
 
@@ -2123,12 +2321,131 @@ func TestAntigravityTokenUsage(t *testing.T) {
 	assert.Equal(t, "generation", usageEvents[0].Source)
 	assert.Equal(t, "Test Gemini 3.5", usageEvents[0].Model)
 	assert.Equal(t, 2400, usageEvents[0].InputTokens)
-	assert.Equal(t, 210, usageEvents[0].OutputTokens)
-	assert.Equal(t, 30, usageEvents[0].ReasoningTokens)
+	assert.Equal(t, 180, usageEvents[0].OutputTokens)
+	assert.Equal(t, 0, usageEvents[0].ReasoningTokens, "reasoning not available in gen_metadata")
 
 	// 3. Verify session rollup
-	assert.Equal(t, 210, sess.TotalOutputTokens)
+	assert.Equal(t, 180, sess.TotalOutputTokens)
 	assert.Equal(t, 2400, sess.PeakContextTokens)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+}
+
+// TestAntigravityTokenUsageCachedTokens verifies the gen_metadata path
+// when cache-read tokens are present. ContextTokens is the full context
+// window (uncached input + cache-read), InputTokens carries just the
+// uncached portion, and CacheReadInputTokens carries the cache-read
+// count. HasContextTokens must be true when context > 0.
+func TestAntigravityTokenUsageCachedTokens(t *testing.T) {
+	root := t.TempDir()
+	id := "55555555-6666-7777-8888-aaaaaaaaaaaa"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	dbPath := filepath.Join(root, "conversations", id+".db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	createAntigravityStepTables(t, db)
+	mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+
+	tsEarly := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000000}})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{num: 17, wire: pbWireBytes, bytes: []byte("user question text goes here and is long")},
+	})
+	tsLate := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000100}})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsLate},
+		{num: 17, wire: pbWireBytes, bytes: []byte("assistant response body goes here and is long")},
+	})
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 14, ?)`, userPayload)
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 17, ?)`, asstPayload)
+
+	// uncachedInput=2200, totalOutput=180, cacheRead=200
+	genData := createAntigravityMockGenMetadata(t, 2200, 180, 200, "Test Gemini 3.5")
+	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
+
+	sess, msgs, usageEvents, err := ParseAntigravitySession(dbPath, "test-project", "test-machine")
+	require.NoError(t, err)
+
+	// Message token counts: context = uncached + cache-read.
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, 2400, msgs[1].ContextTokens, "ContextTokens = uncached + cache-read = 2200 + 200")
+	assert.Equal(t, 180, msgs[1].OutputTokens)
+	assert.True(t, msgs[1].HasContextTokens, "HasContextTokens true when context > 0")
+	assert.True(t, msgs[1].HasOutputTokens)
+
+	// Usage event: InputTokens is the uncached portion, CacheReadInputTokens the rest.
+	require.Len(t, usageEvents, 1)
+	assert.Equal(t, "generation", usageEvents[0].Source)
+	assert.Equal(t, 2200, usageEvents[0].InputTokens, "InputTokens = uncached input")
+	assert.Equal(t, 200, usageEvents[0].CacheReadInputTokens)
+	assert.Equal(t, 180, usageEvents[0].OutputTokens)
+	assert.Equal(t, 0, usageEvents[0].ReasoningTokens, "reasoning not available in gen_metadata")
+
+	// Session rollup: PeakContextTokens is the peak context (uncached + cache-read).
+	assert.Equal(t, 180, sess.TotalOutputTokens)
+	assert.Equal(t, 2400, sess.PeakContextTokens)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+}
+
+// TestAntigravityTokenUsageCachedTokensAllInputs verifies the edge case
+// where input == cached (so uncached = 0). HasContextTokens must still be
+// true because cached > 0, and InputTokens (uncached) should be 0.
+func TestAntigravityTokenUsageCachedTokensAllInputs(t *testing.T) {
+	root := t.TempDir()
+	id := "55555555-6666-7777-8888-bbbbbbbbbbbb"
+
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	dbPath := filepath.Join(root, "conversations", id+".db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	createAntigravityStepTables(t, db)
+	mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+
+	tsEarly := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000000}})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{num: 17, wire: pbWireBytes, bytes: []byte("user question text goes here and is long")},
+	})
+	tsLate := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000100}})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsLate},
+		{num: 17, wire: pbWireBytes, bytes: []byte("assistant response body goes here and is long")},
+	})
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 14, ?)`, userPayload)
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 17, ?)`, asstPayload)
+
+	// uncachedInput=50, totalOutput=100, cacheRead=200
+	// Nearly all input tokens served from cache (50 uncached out of 250 total context).
+	genData := createAntigravityMockGenMetadata(t, 50, 100, 200, "Test Gemini 3.5")
+	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
+
+	sess, msgs, usageEvents, err := ParseAntigravitySession(dbPath, "test-project", "test-machine")
+	require.NoError(t, err)
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, 250, msgs[1].ContextTokens, "ContextTokens = uncached + cache-read = 50 + 200")
+	assert.Equal(t, 100, msgs[1].OutputTokens)
+	assert.True(t, msgs[1].HasContextTokens, "HasContextTokens true when context > 0")
+	assert.True(t, msgs[1].HasOutputTokens)
+
+	require.Len(t, usageEvents, 1)
+	assert.Equal(t, 50, usageEvents[0].InputTokens, "InputTokens = uncached input = 50")
+	assert.Equal(t, 200, usageEvents[0].CacheReadInputTokens)
+	assert.Equal(t, 100, usageEvents[0].OutputTokens)
+	assert.Equal(t, 0, usageEvents[0].ReasoningTokens)
+
+	assert.Equal(t, 100, sess.TotalOutputTokens)
+	assert.Equal(t, 250, sess.PeakContextTokens)
 	assert.True(t, sess.HasTotalOutputTokens)
 	assert.True(t, sess.HasPeakContextTokens)
 }
@@ -2164,9 +2481,9 @@ func TestAntigravityTokenUsageMixedDecode(t *testing.T) {
 	// Undecodable step with its own gen_metadata usage.
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (2, 99, ?)`, []byte{0xff, 0xff, 0xff})
 
-	genDecoded := createAntigravityMockGenMetadata(t, 2400, 180, 30, "Test Gemini 3.5")
+	genDecoded := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genDecoded, len(genDecoded))
-	genUndecoded := createAntigravityMockGenMetadata(t, 3000, 220, 10, "Test Gemini 3.5")
+	genUndecoded := createAntigravityMockGenMetadata(t, 3000, 220, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (2, ?, ?)`, genUndecoded, len(genUndecoded))
 
 	sess, msgs, usageEvents, err := ParseAntigravitySession(dbPath, "test-project", "test-machine")
@@ -2174,7 +2491,7 @@ func TestAntigravityTokenUsageMixedDecode(t *testing.T) {
 	require.Len(t, msgs, 2, "undecodable step contributes no message")
 	require.Len(t, usageEvents, 2, "both gen rows emit usage events")
 
-	assert.Equal(t, 440, sess.TotalOutputTokens, "totals must include undecoded gen usage")
+	assert.Equal(t, 400, sess.TotalOutputTokens, "totals must include undecoded gen usage")
 	assert.Equal(t, 3000, sess.PeakContextTokens, "peak must include undecoded gen usage")
 	assert.True(t, sess.HasTotalOutputTokens)
 	assert.True(t, sess.HasPeakContextTokens)
@@ -2202,9 +2519,9 @@ func TestAntigravityCLITokenUsageMixedDecode(t *testing.T) {
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 17, ?)`, asstPayload)
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 99, ?)`, []byte{0xff, 0xff, 0xff})
 
-	genDecoded := createAntigravityMockGenMetadata(t, 2400, 180, 30, "Test Gemini 3.5")
+	genDecoded := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (0, ?, ?)`, genDecoded, len(genDecoded))
-	genUndecoded := createAntigravityMockGenMetadata(t, 3000, 220, 10, "Test Gemini 3.5")
+	genUndecoded := createAntigravityMockGenMetadata(t, 3000, 220, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genUndecoded, len(genUndecoded))
 	require.NoError(t, db.Close())
 
@@ -2215,7 +2532,7 @@ func TestAntigravityCLITokenUsageMixedDecode(t *testing.T) {
 	require.NotEmpty(t, msgs)
 	require.Len(t, usageEvents, 2, "both gen rows emit usage events")
 
-	assert.Equal(t, 440, sess.TotalOutputTokens, "totals must include undecoded gen usage")
+	assert.Equal(t, 400, sess.TotalOutputTokens, "totals must include undecoded gen usage")
 	assert.Equal(t, 3000, sess.PeakContextTokens, "peak must include undecoded gen usage")
 }
 
@@ -2235,7 +2552,7 @@ func TestAntigravityZeroMessageKeepsUsageEvents(t *testing.T) {
 	createAntigravityStepTables(t, db)
 	mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 99, ?)`, []byte{0xff, 0xff, 0xff})
-	genData := createAntigravityMockGenMetadata(t, 2400, 180, 30, "Test Gemini 3.5")
+	genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (0, ?, ?)`, genData, len(genData))
 
 	sess, msgs, usageEvents, err := ParseAntigravitySession(dbPath, "test-project", "test-machine")
@@ -2243,7 +2560,7 @@ func TestAntigravityZeroMessageKeepsUsageEvents(t *testing.T) {
 	assert.Empty(t, msgs)
 	require.Len(t, usageEvents, 1, "usage events must survive zero-message parses")
 	assert.Equal(t, "Test Gemini 3.5", usageEvents[0].Model)
-	assert.Equal(t, 210, sess.TotalOutputTokens)
+	assert.Equal(t, 180, sess.TotalOutputTokens)
 	assert.Equal(t, 2400, sess.PeakContextTokens)
 }
 
@@ -2261,7 +2578,7 @@ func TestAntigravityCLIZeroMessageKeepsUsageEvents(t *testing.T) {
 	createAntigravityStepTables(t, db)
 	mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 99, ?)`, []byte{0xff, 0xff, 0xff})
-	genData := createAntigravityMockGenMetadata(t, 3000, 220, 10, "Test Gemini 3.5")
+	genData := createAntigravityMockGenMetadata(t, 3000, 220, 0, "Test Gemini 3.5")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (0, ?, ?)`, genData, len(genData))
 	require.NoError(t, db.Close())
 
@@ -2272,8 +2589,8 @@ func TestAntigravityCLIZeroMessageKeepsUsageEvents(t *testing.T) {
 	assert.True(t, status.NeedsRetry, "undecodable rows stay retryable")
 	assert.Empty(t, msgs)
 	require.Len(t, usageEvents, 1, "usage events must survive zero-message parses")
-	assert.Equal(t, 230, usageEvents[0].OutputTokens)
-	assert.Equal(t, 230, sess.TotalOutputTokens)
+	assert.Equal(t, 220, usageEvents[0].OutputTokens)
+	assert.Equal(t, 220, sess.TotalOutputTokens)
 	assert.Equal(t, 3000, sess.PeakContextTokens)
 }
 
@@ -2309,7 +2626,7 @@ func TestAntigravityTokenUsageDynamicField(t *testing.T) {
 	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 17, ?)`, asstPayload)
 
 	// Create gen_metadata entry with a dynamic model field number: 1187 (for MODEL_PLACEHOLDER_M187)
-	genData := createAntigravityMockGenMetadataWithField(t, 1187, 5000, 400, 80, "Test Gemini 3.5 Flash")
+	genData := createAntigravityMockGenMetadataWithField(t, 1187, 5000, 400, 0, "Test Gemini 3.5 Flash")
 	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
 
 	sess, msgs, usageEvents, err := ParseAntigravitySession(dbPath, "test-project", "test-machine")
@@ -2318,30 +2635,42 @@ func TestAntigravityTokenUsageDynamicField(t *testing.T) {
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "Test Gemini 3.5 Flash", msgs[1].Model)
 	assert.Equal(t, 5000, msgs[1].ContextTokens)
-	assert.Equal(t, 480, msgs[1].OutputTokens)
+	assert.Equal(t, 400, msgs[1].OutputTokens)
 
 	require.Len(t, usageEvents, 1)
 	assert.Equal(t, "Test Gemini 3.5 Flash", usageEvents[0].Model)
 	assert.Equal(t, 5000, usageEvents[0].InputTokens)
-	assert.Equal(t, 480, usageEvents[0].OutputTokens)
-	assert.Equal(t, 80, usageEvents[0].ReasoningTokens)
+	assert.Equal(t, 400, usageEvents[0].OutputTokens)
+	assert.Equal(t, 0, usageEvents[0].ReasoningTokens, "reasoning not available in gen_metadata")
 
-	assert.Equal(t, 480, sess.TotalOutputTokens)
+	assert.Equal(t, 400, sess.TotalOutputTokens)
 	assert.Equal(t, 5000, sess.PeakContextTokens)
 }
 
-func createAntigravityMockGenMetadata(t *testing.T, input, output, reasoning int, model string) []byte {
-	return createAntigravityMockGenMetadataWithField(t, 1020, input, output, reasoning, model)
+func createAntigravityMockGenMetadata(t *testing.T, uncachedInput, totalOutput, cacheRead int, model string) []byte {
+	return createAntigravityMockGenMetadataWithField(t, 1020, uncachedInput, totalOutput, cacheRead, model)
 }
 
-func createAntigravityMockGenMetadataWithField(t *testing.T, fieldNum int, input, output, reasoning int, model string) []byte {
-	// Build token usage inner block: Field 1 = fieldNum, Field 2 = output, Field 3 = reasoning, Field 5 = input
+func createAntigravityMockGenMetadataWithField(t *testing.T, fieldNum int, uncachedInput, totalOutput, cacheRead int, model string) []byte {
+	// Build token usage inner block with remapped field semantics
+	// cross-validated against sidecar ground truth:
+	//   f2 = uncached input (inputTokens)
+	//   f3 = total output including thinking (outputTokens)
+	//   f4 = absent (never carries semantics)
+	//   f5 = cache-read (cacheReadTokens, present when > 0)
 	usageInner := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: uint64(fieldNum)},
-		{num: 2, wire: pbWireVarint, varint: uint64(output)},
-		{num: 3, wire: pbWireVarint, varint: uint64(reasoning)},
-		{num: 5, wire: pbWireVarint, varint: uint64(input)},
+		{num: 2, wire: pbWireVarint, varint: uint64(uncachedInput)},
+		{num: 3, wire: pbWireVarint, varint: uint64(totalOutput)},
 	})
+	if cacheRead > 0 {
+		usageInner = encodePB([]pbField{
+			{num: 1, wire: pbWireVarint, varint: uint64(fieldNum)},
+			{num: 2, wire: pbWireVarint, varint: uint64(uncachedInput)},
+			{num: 3, wire: pbWireVarint, varint: uint64(totalOutput)},
+			{num: 5, wire: pbWireVarint, varint: uint64(cacheRead)},
+		})
+	}
 
 	// Build Field 2 (Nested message) of Field 17
 	f17Inner := encodePB([]pbField{
@@ -2366,16 +2695,16 @@ func createAntigravityMockGenMetadataWithField(t *testing.T, fieldNum int, input
 func TestExtractTokenUsageFalsePositiveGuards(t *testing.T) {
 	realToken := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1187},
-		{num: 2, wire: pbWireVarint, varint: 2497},
-		{num: 3, wire: pbWireVarint, varint: 100},
-		{num: 5, wire: pbWireVarint, varint: 44769},
+		{num: 2, wire: pbWireVarint, varint: 5529},  // uncached input
+		{num: 3, wire: pbWireVarint, varint: 72},    // total output
+		{num: 5, wire: pbWireVarint, varint: 38885}, // cache-read
 	})
 	tests := []struct {
 		name  string
 		decoy []pbField
 	}{
 		{
-			name: "decoy without input field",
+			name: "decoy without output field",
 			decoy: []pbField{
 				{num: 1, wire: pbWireVarint, varint: 1371},
 				{num: 2, wire: pbWireVarint, varint: 1234},
@@ -2385,38 +2714,44 @@ func TestExtractTokenUsageFalsePositiveGuards(t *testing.T) {
 			name: "decoy with implausible input",
 			decoy: []pbField{
 				{num: 1, wire: pbWireVarint, varint: 1371},
-				{num: 2, wire: pbWireVarint, varint: 1234},
-				{num: 5, wire: pbWireVarint, varint: 679261000},
+				{num: 2, wire: pbWireVarint, varint: 679261000},
+				{num: 3, wire: pbWireVarint, varint: 100},
 			},
 		},
 		{
-			name: "decoy with implausible reasoning",
+			name: "decoy with implausible output",
 			decoy: []pbField{
 				{num: 1, wire: pbWireVarint, varint: 1371},
 				{num: 2, wire: pbWireVarint, varint: 1234},
 				{num: 3, wire: pbWireVarint, varint: 679261000},
-				{num: 5, wire: pbWireVarint, varint: 2000},
 			},
 		},
 		{
-			name: "decoy with wrong-typed reasoning",
+			name: "decoy with wrong-typed output",
 			decoy: []pbField{
 				{num: 1, wire: pbWireVarint, varint: 1371},
 				{num: 2, wire: pbWireVarint, varint: 1234},
 				{num: 3, wire: pbWireBytes, bytes: []byte("not a varint")},
-				{num: 5, wire: pbWireVarint, varint: 2000},
 			},
 		},
 		{
-			// Output and reasoning are each within the cap, but the
-			// caller persists output+reasoning as billable output, so
-			// the sum must satisfy the cap too.
-			name: "decoy with folded output+reasoning above cap",
+			name: "decoy with implausible cache-read",
+			decoy: []pbField{
+				{num: 1, wire: pbWireVarint, varint: 1371},
+				{num: 2, wire: pbWireVarint, varint: 1234},
+				{num: 3, wire: pbWireVarint, varint: 100},
+				{num: 5, wire: pbWireVarint, varint: 679261000},
+			},
+		},
+		{
+			// Input and output are each within the cap, but their
+			// combined footprint exceeds the plausibility threshold,
+			// rejecting blocks that individually pass per-field checks.
+			name: "decoy with input+output above cap",
 			decoy: []pbField{
 				{num: 1, wire: pbWireVarint, varint: 1371},
 				{num: 2, wire: pbWireVarint, varint: 1_999_999},
 				{num: 3, wire: pbWireVarint, varint: 1_999_999},
-				{num: 5, wire: pbWireVarint, varint: 2000},
 			},
 		},
 	}
@@ -2428,11 +2763,11 @@ func TestExtractTokenUsageFalsePositiveGuards(t *testing.T) {
 				{num: 1, wire: pbWireBytes, bytes: encodePB(tt.decoy)},
 				{num: 2, wire: pbWireBytes, bytes: realToken},
 			})
-			inp, out, reasoning, ok := extractTokenUsage(data)
+			block, ok := extractTokenUsage(data)
 			require.True(t, ok, "real token block should be found")
-			assert.Equal(t, 44769, inp, "input tokens")
-			assert.Equal(t, 2497, out, "output tokens")
-			assert.Equal(t, 100, reasoning, "reasoning tokens")
+			assert.Equal(t, 5529, block.UncachedInput, "uncached input tokens")
+			assert.Equal(t, 72, block.TotalOutput, "total output tokens")
+			assert.Equal(t, 38885, block.CacheRead, "cache-read tokens")
 		})
 	}
 }
@@ -2504,23 +2839,45 @@ func TestExtractModelNameRejectsNonPrintable(t *testing.T) {
 	}
 }
 
-// TestExtractTokenUsageNoReasoningField verifies a real token block is
-// accepted when field 3 is absent: proto3 omits zero values, and zero
-// reasoning tokens is a legitimate generation.
-func TestExtractTokenUsageNoReasoningField(t *testing.T) {
+// TestExtractTokenUsageNoCacheReadField verifies a real token block is
+// accepted when field 5 (cache-read) is absent: proto3 omits zero-valued
+// fields, and a fresh session with no cache hits legitimately has
+// f5=0, which is omitted from the wire.
+func TestExtractTokenUsageNoCacheReadField(t *testing.T) {
 	block := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1187},
-		{num: 2, wire: pbWireVarint, varint: 2497},
-		{num: 5, wire: pbWireVarint, varint: 44769},
+		{num: 2, wire: pbWireVarint, varint: 5529}, // uncached input
+		{num: 3, wire: pbWireVarint, varint: 72},   // total output
 	})
 	data := encodePB([]pbField{
 		{num: 1, wire: pbWireBytes, bytes: block},
 	})
-	inp, out, reasoning, ok := extractTokenUsage(data)
-	require.True(t, ok, "token block without reasoning should be accepted")
-	assert.Equal(t, 44769, inp, "input tokens")
-	assert.Equal(t, 2497, out, "output tokens")
-	assert.Equal(t, 0, reasoning, "reasoning tokens")
+	result, ok := extractTokenUsage(data)
+	require.True(t, ok, "token block without cache-read should be accepted")
+	assert.Equal(t, 5529, result.UncachedInput, "uncached input tokens")
+	assert.Equal(t, 72, result.TotalOutput, "total output tokens")
+	assert.Equal(t, 0, result.CacheRead, "cache-read defaults to 0 when absent")
+}
+
+// TestTokenBlockFromIgnoresField4 verifies that a protobuf block
+// where field 4 is present (always 0/absent in real blocks) is still
+// accepted as long as all required fields are valid. Field 4 carries
+// no semantics and is tolerated but ignored.
+func TestTokenBlockFromIgnoresField4(t *testing.T) {
+	block := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1371},
+		{num: 2, wire: pbWireVarint, varint: 500},
+		{num: 3, wire: pbWireVarint, varint: 100},
+		{num: 4, wire: pbWireVarint, varint: 0}, // f4 is tolerated
+	})
+	data := encodePB([]pbField{
+		{num: 1, wire: pbWireBytes, bytes: block},
+	})
+	result, ok := extractTokenUsage(data)
+	assert.True(t, ok, "block with f4=0 should be accepted")
+	assert.Equal(t, 500, result.UncachedInput)
+	assert.Equal(t, 100, result.TotalOutput)
+	assert.Equal(t, 0, result.CacheRead)
 }
 
 // TestExtractTokenUsageLargeValueFalsePositive is a regression test for the
@@ -2542,12 +2899,13 @@ func TestExtractTokenUsageLargeValueFalsePositive(t *testing.T) {
 		{num: 9, wire: pbWireBytes, bytes: innerWrapper},
 	})
 
-	// Real token block: field1=1187, field2=2497 (plausible), field5=44769
+	// Real token block with remapped field semantics:
+	// f2=5529 (uncached input), f3=72 (total output), f5=38885 (cache-read).
 	realToken := encodePB([]pbField{
 		{num: 1, wire: pbWireVarint, varint: 1187},
-		{num: 2, wire: pbWireVarint, varint: 2497},
-		{num: 3, wire: pbWireVarint, varint: 100},
-		{num: 5, wire: pbWireVarint, varint: 44769},
+		{num: 2, wire: pbWireVarint, varint: 5529},
+		{num: 3, wire: pbWireVarint, varint: 72},
+		{num: 5, wire: pbWireVarint, varint: 38885},
 	})
 	realWrapper := encodePB([]pbField{
 		{num: 4, wire: pbWireBytes, bytes: realToken},
@@ -2561,9 +2919,208 @@ func TestExtractTokenUsageLargeValueFalsePositive(t *testing.T) {
 		{num: 2, wire: pbWireBytes, bytes: realWrapper},  // real token block second
 	})
 
-	inp, out, reasoning, ok := extractTokenUsage(data)
+	block, ok := extractTokenUsage(data)
 	require.True(t, ok, "extractTokenUsage should find a token block")
-	assert.Equal(t, 44769, inp, "input tokens")
-	assert.Equal(t, 2497, out, "output tokens")
-	assert.Equal(t, 100, reasoning, "reasoning tokens")
+	assert.Equal(t, 5529, block.UncachedInput, "uncached input tokens")
+	assert.Equal(t, 72, block.TotalOutput, "total output tokens")
+	assert.Equal(t, 38885, block.CacheRead, "cache-read tokens")
+}
+
+func TestAntigravityAdjacentToolCalls(t *testing.T) {
+	// A flat sequence of strings simulating two consecutive tool calls, e.g. run_command.
+	// The new logic should prefer the following UUID and not deduplicate distinct calls.
+	fields := []agProtoField{
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("run_command")},
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("11111111-1111-1111-1111-111111111111")},
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte(`{"command": "ls"}`)},
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("run_command")},
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("22222222-2222-2222-2222-222222222222")},
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte(`{"command": "pwd"}`)},
+	}
+
+	calls := extractAntigravityToolCalls(0, fields)
+
+	require.Len(t, calls, 2)
+	assert.Equal(t, "run_command", calls[0].ToolName)
+	assert.Equal(t, "Bash", calls[0].Category)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", calls[0].ToolUseID)
+	assert.Equal(t, `{"command": "ls"}`, calls[0].InputJSON)
+
+	assert.Equal(t, "run_command", calls[1].ToolName)
+	assert.Equal(t, "Bash", calls[1].Category)
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", calls[1].ToolUseID)
+	assert.Equal(t, `{"command": "pwd"}`, calls[1].InputJSON)
+}
+
+func TestAntigravityAdjacentToolCallsNoUUIDs(t *testing.T) {
+	// Two identical tool names with no adjacent UUIDs or JSON.
+	// Both must be emitted as separate calls with synthetic IDs.
+	fields := []agProtoField{
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("run_command")},
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("run_command")},
+	}
+
+	calls := extractAntigravityToolCalls(0, fields)
+
+	require.Len(t, calls, 2)
+	assert.Equal(t, "run_command", calls[0].ToolName)
+	assert.Equal(t, "run_command", calls[1].ToolName)
+	// Synthetic IDs should differ because they encode the string index.
+	assert.NotEqual(t, calls[0].ToolUseID, calls[1].ToolUseID)
+	assert.Contains(t, calls[0].ToolUseID, "ag-step-")
+	assert.Contains(t, calls[1].ToolUseID, "ag-step-")
+}
+
+func TestAntigravityToolCallUUIDBackwardFallback(t *testing.T) {
+	// UUID appears before the tool name (e.g. tool at end of string list).
+	// The backward scan offsets (-1, -2) should still pick it up.
+	fields := []agProtoField{
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")},
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("view_file")},
+	}
+
+	calls := extractAntigravityToolCalls(0, fields)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "view_file", calls[0].ToolName)
+	assert.Equal(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", calls[0].ToolUseID)
+}
+
+// TestAntigravityToolCallsRejectsGenericStrings verifies that standalone
+// generic strings like "read", "write", "message", "process" that happen
+// to match the global taxonomy but are NOT known Antigravity tool names
+// are not fabricated into tool calls without corroborating evidence.
+func TestAntigravityToolCallsRejectsGenericStrings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		fields  []agProtoField
+		wantLen int
+	}{
+		{
+			name: "standalone read with no evidence",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("read")},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "standalone write with no evidence",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("write")},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "standalone message with no evidence",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("message")},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "standalone process with no evidence",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("process")},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "string containing subagent is not a tool name",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("some_subagent_thing")},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "read with adjacent UUID is rejected",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("read")},
+				{Number: 2, Wire: pbWireBytes, Bytes: []byte("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "read with adjacent JSON input is rejected",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("read")},
+				{Number: 2, Wire: pbWireBytes, Bytes: []byte(`{"path": "/tmp/x"}`)},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "known Antigravity tool view_file always accepted",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("view_file")},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "known Antigravity tool invoke_subagent always accepted",
+			fields: []agProtoField{
+				{Number: 1, Wire: pbWireBytes, Bytes: []byte("invoke_subagent")},
+			},
+			wantLen: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := extractAntigravityToolCalls(0, tc.fields)
+			assert.Len(t, calls, tc.wantLen)
+		})
+	}
+}
+
+func TestAntigravityAdjacentToolCallsIntervening(t *testing.T) {
+	// Tool call N has no UUID. Tool call N+1 has a UUID.
+	// Call N should not steal Call N+1's UUID or JSON input across the intervening tool name.
+	fields := []agProtoField{
+		{Number: 1, Wire: pbWireBytes, Bytes: []byte("run_command")},
+		{Number: 2, Wire: pbWireBytes, Bytes: []byte("run_command")},
+		{Number: 3, Wire: pbWireBytes, Bytes: []byte("11111111-1111-1111-1111-111111111111")},
+		{Number: 4, Wire: pbWireBytes, Bytes: []byte(`{"command": "pwd"}`)},
+	}
+
+	calls := extractAntigravityToolCalls(0, fields)
+	require.Len(t, calls, 2)
+
+	// First call should have synthetic ID and NO JSON input (it is blocked by the second tool name)
+	assert.Equal(t, "run_command", calls[0].ToolName)
+	assert.Contains(t, calls[0].ToolUseID, "ag-step-")
+	assert.Empty(t, calls[0].InputJSON)
+
+	// Second call should have the UUID and JSON input
+	assert.Equal(t, "run_command", calls[1].ToolName)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", calls[1].ToolUseID)
+	assert.Equal(t, `{"command": "pwd"}`, calls[1].InputJSON)
+}
+
+// TestDecodeAntigravityStepToolOnlyAssistantStep verifies that an
+// assistant step containing only tool calls (no displayable prose)
+// is still emitted as a ParsedMessage with HasToolUse=true rather
+// than being silently dropped.
+func TestDecodeAntigravityStepToolOnlyAssistantStep(t *testing.T) {
+	// An assistant step (stepType=15) with only a tool name and a UUID.
+	// agProtoCollectStrings with minLen=20 would miss the short strings,
+	// and the UUID would be filtered by cleanAntigravityStepStrings,
+	// leaving no displayable content. Previously this caused the step
+	// to be dropped entirely; now it should still be emitted with the
+	// tool call intact.
+	inner := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779326586},
+	})
+	payload := encodePB([]pbField{
+		{num: 17, wire: pbWireBytes, bytes: []byte("view_file")},
+		{num: 18, wire: pbWireBytes, bytes: []byte("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")},
+		{num: 5, wire: pbWireBytes, bytes: inner},
+	})
+
+	msg, ok := decodeAntigravityStep(0, 15, payload)
+	require.True(t, ok, "tool-only assistant step should not be dropped")
+	assert.Equal(t, RoleAssistant, msg.Role)
+	assert.True(t, msg.HasToolUse, "HasToolUse should be true")
+	require.Len(t, msg.ToolCalls, 1)
+	assert.Equal(t, "view_file", msg.ToolCalls[0].ToolName)
 }

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -840,3 +840,34 @@ func TestVSCodeCopilotDefaultDirs(t *testing.T) {
 			"missing default dir: %s", path)
 	}
 }
+
+func TestApplyUsageEventTokenTotals(t *testing.T) {
+	// Verify that applyUsageEventTokenTotals computes PeakContextTokens
+	// correctly including cache-creation and cache-read tokens.
+	sess := &ParsedSession{}
+	events := []ParsedUsageEvent{
+		{
+			InputTokens:              1000,
+			OutputTokens:             200,
+			CacheReadInputTokens:     500,
+			CacheCreationInputTokens: 300,
+		},
+		{
+			InputTokens:              800,
+			OutputTokens:             150,
+			CacheReadInputTokens:     1200,
+			CacheCreationInputTokens: 100,
+		},
+	}
+
+	applyUsageEventTokenTotals(sess, events)
+
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 350, sess.TotalOutputTokens)
+
+	assert.True(t, sess.HasPeakContextTokens)
+	// Peak context should be max of context window (InputTokens + CacheRead + CacheCreation)
+	// Event 1 context = 1000 + 500 + 300 = 1800
+	// Event 2 context = 800 + 1200 + 100 = 2100
+	assert.Equal(t, 2100, sess.PeakContextTokens)
+}


### PR DESCRIPTION
## Summary

- Improve Antigravity session parser to extract richer tool-call metadata and token usage from session transcripts
- Expand test coverage for the Antigravity parser with new edge cases and structured assertions
- Surface sync progress metrics in the sync engine for observability

## Changed

- `internal/parser/antigravity.go`: Enhanced token extraction logic and tool-call analysis
- `internal/parser/antigravity_test.go`: 333 lines of new/improved test cases
- `internal/sync/engine.go` / `progress.go`: Added sync metric hooks
- Minor doc and config updates (AGENTS.md, SECURITY.md, Makefile, huma routes)