### PR TITLE
cli: add parse-diff report mode to vet parser changes against a real archive

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -68,6 +68,7 @@ func newRootCommand() *cobra.Command {
 	root.AddCommand(newDuckDBCommand())
 	root.AddCommand(newSessionCommand())
 	root.AddCommand(newStatsCommand())
+	root.AddCommand(newParseDiffCommand())
 	root.AddCommand(newClassifierCommand())
 	root.AddCommand(newSecretsCommand())
 	root.AddCommand(newVersionCommand())

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -55,10 +55,16 @@ func newParseDiffCommand() *cobra.Command {
 		Short: "Re-parse session files and diff against the archive",
 		Long: "Re-parses session source files with the current binary, runs\n" +
 			"the result through the same normalization sync applies, and\n" +
-			"compares it against the stored rows. Writes nothing: no\n" +
-			"sessions, no skip cache, no sync state.\n\n" +
+			"compares it against the stored rows. It does not write\n" +
+			"session, skip-cache, or sync-state data; opening the archive\n" +
+			"still creates the database and runs schema migrations if\n" +
+			"needed.\n\n" +
 			"Use it to vet parser changes against the real archive before\n" +
-			"bumping the data version, or to detect upstream format drift.",
+			"bumping the data version, or to detect upstream format drift.\n" +
+			"Run it against a quiescent archive: sessions still being\n" +
+			"written, and sessions last written through the incremental\n" +
+			"append path, can show benign drift against a full re-parse. A\n" +
+			"freshly resynced archive gives the cleanest baseline.",
 		GroupID:      groupData,
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
@@ -132,6 +138,9 @@ func doParseDiff(cfg ParseDiffConfig) (failed bool) {
 	if err != nil {
 		fatal("parse-diff: %v", err)
 	}
+	// Stamp the archive identity so an attached JSON report is
+	// self-describing.
+	report.DBPath = appCfg.DBPath
 
 	if cfg.JSON {
 		writeJSON(cfg.stdout(), report)
@@ -239,12 +248,74 @@ func renderParseDiffReport(
 	}
 	fmt.Fprintln(w)
 
+	if r.VacuousResync() {
+		fmt.Fprintln(w,
+			"Warning: this binary's data version is ahead of every "+
+				"examined session, so all of them are pending resync "+
+				"and no drift can be detected. Run parse-diff with a "+
+				"binary built before the data-version bump, or against "+
+				"a freshly resynced archive, to vet a parser change.")
+		fmt.Fprintln(w)
+	}
+
 	renderParseDiffSummary(w, r.Totals)
 	renderParseDiffFieldCounts(w, r.FieldCounts)
+	renderParseDiffParseErrors(w, r.Sessions)
 	renderParseDiffChanged(w, r.Sessions, verbose)
+	if verbose {
+		renderParseDiffPendingResync(w, r.Sessions)
+	}
 
 	fmt.Fprintf(w, "%d sessions changed, %d identical.\n",
 		r.Totals.Changed, r.Totals.Identical)
+}
+
+// renderParseDiffPendingResync lists pending-resync sessions that
+// carry attached field diffs (verbose only). These are not counted as
+// drift — a resync rewrites them — but showing the diffs lets an
+// operator see what would change, which is the only signal available
+// when the whole run is vacuous (data version ahead of the archive).
+func renderParseDiffPendingResync(w io.Writer, sessions []sync.SessionDiff) {
+	var pending []sync.SessionDiff
+	for _, s := range sessions {
+		if s.Class == sync.DiffPendingResync && len(s.Fields) > 0 {
+			pending = append(pending, s)
+		}
+	}
+	if len(pending) == 0 {
+		return
+	}
+	fmt.Fprintln(w,
+		"Pending-resync sessions (not counted; resync rewrites these)")
+	for _, s := range pending {
+		renderParseDiffSessionVerbose(w, s)
+	}
+	fmt.Fprintln(w)
+}
+
+// renderParseDiffParseErrors lists files the current binary could not
+// parse, with the path and error. Parse errors trip --fail-on-change,
+// so the human report must explain why a run failed; the summary count
+// alone is not actionable.
+func renderParseDiffParseErrors(w io.Writer, sessions []sync.SessionDiff) {
+	var errs []sync.SessionDiff
+	for _, s := range sessions {
+		if s.Class == sync.DiffParseError {
+			errs = append(errs, s)
+		}
+	}
+	if len(errs) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Parse errors")
+	for _, s := range errs {
+		path := s.FilePath
+		if path == "" {
+			path = "(unknown file)"
+		}
+		fmt.Fprintf(w, "  %s  %s\n    %s\n", s.Agent, path, s.Reason)
+	}
+	fmt.Fprintln(w)
 }
 
 // renderParseDiffSummary prints one line per non-zero total, with
@@ -270,7 +341,7 @@ func renderParseDiffSummary(w io.Writer, t sync.ParseDiffTotals) {
 	line("Skipped", t.Skipped,
 		"(source not re-parsed: missing, remote, trashed, or not sampled)")
 	line("Excluded by parser", t.ExcludedByParser,
-		"(parser no longer emits these; sync would delete them)")
+		"(parser intentionally drops these; sync would delete them)")
 	line("Parse errors", t.ParseErrors,
 		"(current binary failed to parse the source file)")
 	line("Needs retry", t.NeedsRetry,

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -1,0 +1,359 @@
+// ABOUTME: `agentsview parse-diff` — report-only re-parse of session
+// ABOUTME: source files diffed against the stored SQLite archive.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// parseDiffChangedCap caps the non-verbose changed-sessions
+// drill-down so a badly drifted archive doesn't flood the terminal.
+const parseDiffChangedCap = 20
+
+// ParseDiffConfig holds parsed CLI options for the parse-diff command.
+type ParseDiffConfig struct {
+	Agents       []string
+	Limit        int
+	FailOnChange bool
+	JSON         bool
+	Verbose      bool
+
+	// Stdout and Stderr default to the process streams. The command
+	// wires them to cobra's writers so tests can capture output.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func (c ParseDiffConfig) stdout() io.Writer {
+	if c.Stdout != nil {
+		return c.Stdout
+	}
+	return os.Stdout
+}
+
+func (c ParseDiffConfig) stderr() io.Writer {
+	if c.Stderr != nil {
+		return c.Stderr
+	}
+	return os.Stderr
+}
+
+func newParseDiffCommand() *cobra.Command {
+	var cfg ParseDiffConfig
+	cmd := &cobra.Command{
+		Use:   "parse-diff",
+		Short: "Re-parse session files and diff against the archive",
+		Long: "Re-parses session source files with the current binary, runs\n" +
+			"the result through the same normalization sync applies, and\n" +
+			"compares it against the stored rows. Writes nothing: no\n" +
+			"sessions, no skip cache, no sync state.\n\n" +
+			"Use it to vet parser changes against the real archive before\n" +
+			"bumping the data version, or to detect upstream format drift.",
+		GroupID:      groupData,
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if cfg.Limit < 0 {
+				return fmt.Errorf("--limit must be >= 0")
+			}
+			_, err := parseDiffAgentTypes(cfg.Agents)
+			return err
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg.Stdout = cmd.OutOrStdout()
+			cfg.Stderr = cmd.ErrOrStderr()
+			runParseDiff(cfg)
+		},
+	}
+	cmd.Flags().StringArrayVar(&cfg.Agents, "agent", nil,
+		"Restrict to these agents (repeatable; default: all file-based agents)")
+	cmd.Flags().IntVar(&cfg.Limit, "limit", 0,
+		"Re-parse only the N most recently modified source files (0 = all)")
+	cmd.Flags().BoolVar(&cfg.FailOnChange, "fail-on-change", false,
+		"Exit 1 when sessions changed or files failed to parse")
+	cmd.Flags().BoolVar(&cfg.JSON, "json", false,
+		"Output the full report as JSON")
+	cmd.Flags().BoolVarP(&cfg.Verbose, "verbose", "v", false,
+		"Show every field diff for every changed session")
+	return cmd
+}
+
+func runParseDiff(cfg ParseDiffConfig) {
+	if doParseDiff(cfg) {
+		os.Exit(1)
+	}
+}
+
+// doParseDiff runs the report-only comparison and reports whether
+// --fail-on-change should turn the run into a non-zero exit. It owns
+// the deferred db close so runParseDiff can translate the result into
+// an exit code without skipping cleanup. It deliberately skips
+// setupLogFile: stdout owns the report and engine warnings belong on
+// stderr, matching the health command's diagnostic style.
+func doParseDiff(cfg ParseDiffConfig) (failed bool) {
+	agents, err := parseDiffAgentTypes(cfg.Agents)
+	if err != nil {
+		fatal("%v", err)
+	}
+
+	appCfg, err := config.LoadMinimal()
+	if err != nil {
+		fatal("loading config: %v", err)
+	}
+	if err := os.MkdirAll(appCfg.DataDir, 0o755); err != nil {
+		fatal("creating data dir: %v", err)
+	}
+
+	database := mustOpenDB(appCfg)
+	defer database.Close()
+
+	engine := sync.NewDiffEngine(database, sync.EngineConfig{
+		AgentDirs:               appCfg.AgentDirs,
+		Machine:                 "local",
+		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
+	})
+
+	opts := sync.ParseDiffOptions{Agents: agents, Limit: cfg.Limit}
+	if !cfg.JSON {
+		opts.Progress = parseDiffProgress(cfg.stderr())
+	}
+
+	report, err := engine.ParseDiff(context.Background(), opts)
+	if err != nil {
+		fatal("parse-diff: %v", err)
+	}
+
+	if cfg.JSON {
+		writeJSON(cfg.stdout(), report)
+	} else {
+		renderParseDiffReport(
+			cfg.stdout(), report, appCfg.DBPath, cfg.Verbose,
+		)
+	}
+	return cfg.FailOnChange && report.HasFailures()
+}
+
+// parseDiffProgress returns a simple stderr counter for
+// ParseDiffOptions.Progress. It rewrites one line in place and
+// terminates it once the last file completes.
+func parseDiffProgress(w io.Writer) func(done, total int) {
+	return func(done, total int) {
+		fmt.Fprintf(w, "\rRe-parsing files: %d/%d", done, total)
+		if done >= total {
+			fmt.Fprintln(w)
+		}
+	}
+}
+
+// parseDiffAgentTypes validates --agent values against the parser
+// registry and returns the corresponding agent types, de-duplicated
+// in flag order. An empty input means "every supported agent" and
+// returns nil.
+func parseDiffAgentTypes(names []string) ([]parser.AgentType, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	out := make([]parser.AgentType, 0, len(names))
+	seen := make(map[parser.AgentType]bool, len(names))
+	for _, raw := range names {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		def, ok := parser.AgentByType(parser.AgentType(name))
+		if !ok {
+			return nil, fmt.Errorf(
+				"unknown agent %q (supported: %s)",
+				raw,
+				strings.Join(parseDiffSupportedAgents(), ", "),
+			)
+		}
+		if !def.FileBased || def.DiscoverFunc == nil {
+			return nil, fmt.Errorf(
+				"agent %q is not supported by parse-diff "+
+					"(no on-disk source to re-parse)",
+				raw,
+			)
+		}
+		if !seen[def.Type] {
+			seen[def.Type] = true
+			out = append(out, def.Type)
+		}
+	}
+	return out, nil
+}
+
+// parseDiffSupportedAgents lists the agent types parse-diff can
+// re-parse: file-based agents with a discovery function.
+func parseDiffSupportedAgents() []string {
+	var names []string
+	for _, def := range parser.Registry {
+		if def.FileBased && def.DiscoverFunc != nil {
+			names = append(names, string(def.Type))
+		}
+	}
+	return names
+}
+
+// renderParseDiffReport writes the human-readable report. An empty
+// archive renders a zero-count summary with no tables.
+func renderParseDiffReport(
+	w io.Writer, r *sync.ParseDiffReport, dbPath string, verbose bool,
+) {
+	agents := "all agents"
+	if len(r.Agents) > 0 {
+		agents = strings.Join(r.Agents, ", ")
+	}
+	fmt.Fprintf(w,
+		"Parse diff: %d files re-parsed (%s) against %s (data version %d)\n",
+		r.FilesExamined, agents, dbPath, r.DataVersion)
+	if r.FilesLimited {
+		fmt.Fprintln(w,
+			"Note: --limit truncated discovery; totals cover a sample.")
+	}
+	fmt.Fprintln(w)
+
+	renderParseDiffSummary(w, r.Totals)
+	renderParseDiffFieldCounts(w, r.FieldCounts)
+	renderParseDiffChanged(w, r.Sessions, verbose)
+
+	fmt.Fprintf(w, "%d sessions changed, %d identical.\n",
+		r.Totals.Changed, r.Totals.Identical)
+}
+
+// renderParseDiffSummary prints one line per non-zero total, with
+// short explanations for the non-obvious buckets. Examined always
+// prints so an empty archive still renders a summary.
+func renderParseDiffSummary(w io.Writer, t sync.ParseDiffTotals) {
+	fmt.Fprintln(w, "Summary")
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	line := func(name string, n int, note string) {
+		if n == 0 && name != "Examined" {
+			return
+		}
+		fmt.Fprintf(tw, "  %s\t%d\t%s\n", name, n, note)
+	}
+	line("Examined", t.Examined,
+		"(stored sessions compared against a fresh parse)")
+	line("Identical", t.Identical, "")
+	line("Changed", t.Changed, "")
+	line("Pending resync", t.PendingResync,
+		"(stored data version behind; next resync rewrites these)")
+	line("New on disk", t.NewOnDisk,
+		"(no stored row; sync would add them)")
+	line("Skipped", t.Skipped,
+		"(source not re-parsed: missing, remote, trashed, or not sampled)")
+	line("Excluded by parser", t.ExcludedByParser,
+		"(parser no longer emits these; sync would delete them)")
+	line("Parse errors", t.ParseErrors,
+		"(current binary failed to parse the source file)")
+	line("Needs retry", t.NeedsRetry,
+		"(transient low-fidelity parse; differences expected)")
+	line("Informational only", t.InformationalOnly,
+		"(identical except informational diffs)")
+	tw.Flush()
+	fmt.Fprintln(w)
+}
+
+// renderParseDiffFieldCounts prints the changed-field histogram,
+// sorted by count descending with alphabetical tie-breaks.
+func renderParseDiffFieldCounts(w io.Writer, counts map[string]int) {
+	if len(counts) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Changed fields (sessions affected)")
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	for _, e := range sortedIntMap(counts) {
+		fmt.Fprintf(tw, "  %s\t%d\n", e.key, e.val)
+	}
+	tw.Flush()
+	fmt.Fprintln(w)
+}
+
+// renderParseDiffChanged prints the changed-sessions drill-down:
+// one compact line per session, capped unless verbose; verbose
+// prints a block per session with every field diff.
+func renderParseDiffChanged(
+	w io.Writer, sessions []sync.SessionDiff, verbose bool,
+) {
+	var changed []sync.SessionDiff
+	for _, s := range sessions {
+		if s.Class == sync.DiffChanged {
+			changed = append(changed, s)
+		}
+	}
+	if len(changed) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Changed sessions")
+	if verbose {
+		for _, s := range changed {
+			renderParseDiffSessionVerbose(w, s)
+		}
+		fmt.Fprintln(w)
+		return
+	}
+	shown := changed
+	if len(shown) > parseDiffChangedCap {
+		shown = shown[:parseDiffChangedCap]
+	}
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	for _, s := range shown {
+		fmt.Fprintf(tw, "  %s\t%s\t%s\n",
+			s.Agent, shortID(s.SessionID),
+			parseDiffFieldSummary(s.Fields))
+	}
+	tw.Flush()
+	if extra := len(changed) - len(shown); extra > 0 {
+		fmt.Fprintf(w, "  ... (%d more; use --verbose or --json)\n",
+			extra)
+	}
+	fmt.Fprintln(w)
+}
+
+// renderParseDiffSessionVerbose prints one changed session with
+// every field diff: Field, Stored -> Parsed, Detail, and an
+// [informational] tag where applicable.
+func renderParseDiffSessionVerbose(w io.Writer, s sync.SessionDiff) {
+	fmt.Fprintf(w, "  %s  %s", s.Agent, s.SessionID)
+	if s.FilePath != "" {
+		fmt.Fprintf(w, "  %s", s.FilePath)
+	}
+	fmt.Fprintln(w)
+	for _, f := range s.Fields {
+		fmt.Fprintf(w, "    %s: %s -> %s", f.Field, f.Stored, f.Parsed)
+		if f.Detail != "" {
+			fmt.Fprintf(w, " (%s)", f.Detail)
+		}
+		if f.Informational {
+			fmt.Fprint(w, " [informational]")
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+// parseDiffFieldSummary renders the compact field list for one
+// changed-session line: the non-informational field names in diff
+// order. If every diff is informational (defensive; such sessions
+// are classified identical), the names are tagged instead.
+func parseDiffFieldSummary(fields []sync.FieldDiff) string {
+	names := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if !f.Informational {
+			names = append(names, f.Field)
+		}
+	}
+	if len(names) == 0 {
+		for _, f := range fields {
+			names = append(names, f.Field+" [informational]")
+		}
+	}
+	return strings.Join(names, ", ")
+}

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -156,7 +156,39 @@ func doParseDiff(cfg ParseDiffConfig) (failed bool) {
 			cfg.stdout(), report, appCfg.DBPath, agentsLabel, cfg.Verbose,
 		)
 	}
-	return cfg.FailOnChange && report.HasFailures()
+	return parseDiffExitFailure(report, cfg.FailOnChange, cfg.stderr())
+}
+
+// parseDiffExitFailure decides whether --fail-on-change should turn the
+// run into a non-zero exit and writes the vacuous-run explanation to
+// stderr when that is the reason. It is split from doParseDiff's I/O so
+// the exit contract is unit-testable, mirroring ParseDiffReport's own
+// HasFailures/VacuousResync helpers.
+//
+// A vacuous run -- this binary's data version is ahead of every
+// examined session, so all of them are pending_resync -- detects no
+// drift by construction (a resync rewrites every row), so a clean
+// result is not evidence the parser is unchanged. Treat it as a gate
+// failure rather than a green light, and explain the non-zero exit on
+// stderr: the stdout warning is absent under --json and easy to miss in
+// CI logs.
+func parseDiffExitFailure(
+	report *sync.ParseDiffReport, failOnChange bool, stderr io.Writer,
+) bool {
+	if !failOnChange {
+		return false
+	}
+	vacuous := report.VacuousResync()
+	if vacuous {
+		fmt.Fprintln(stderr,
+			"parse-diff: --fail-on-change failed: the run was vacuous "+
+				"(every examined session is pending resync because this "+
+				"binary's data version is ahead of the whole archive), so "+
+				"no parser drift could be detected. Re-run against a freshly "+
+				"resynced archive, or with a binary built before the "+
+				"data-version bump, to vet the change.")
+	}
+	return report.HasFailures() || vacuous
 }
 
 // parseDiffProgress returns a simple stderr counter for

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -234,14 +234,19 @@ func parseDiffSupportedAgents() []string {
 }
 
 // renderParseDiffReport writes the human-readable report. An empty
-// archive renders a zero-count summary with no tables.
+// archive renders a zero-count summary with no tables. Every value
+// that originates in session files or archive rows (IDs, paths,
+// agents, field values, error reasons) passes through
+// sanitizeTerminal: session content can carry ESC/OSC sequences that
+// would otherwise reach the terminal. JSON output is left raw.
 func renderParseDiffReport(
 	w io.Writer, r *sync.ParseDiffReport, dbPath, agentsLabel string,
 	verbose bool,
 ) {
 	fmt.Fprintf(w,
 		"Parse diff: %d files re-parsed (%s) against %s (data version %d)\n",
-		r.FilesExamined, agentsLabel, dbPath, r.DataVersion)
+		r.FilesExamined, sanitizeTerminal(agentsLabel),
+		sanitizeTerminal(dbPath), r.DataVersion)
 	if r.FilesLimited {
 		fmt.Fprintln(w,
 			"Note: --limit truncated discovery; totals cover a sample.")
@@ -313,7 +318,9 @@ func renderParseDiffParseErrors(w io.Writer, sessions []sync.SessionDiff) {
 		if path == "" {
 			path = "(unknown file)"
 		}
-		fmt.Fprintf(w, "  %s  %s\n    %s\n", s.Agent, path, s.Reason)
+		fmt.Fprintf(w, "  %s  %s\n    %s\n",
+			sanitizeTerminal(s.Agent), sanitizeTerminal(path),
+			sanitizeTerminal(s.Reason))
 	}
 	fmt.Fprintln(w)
 }
@@ -361,7 +368,7 @@ func renderParseDiffFieldCounts(w io.Writer, counts map[string]int) {
 	fmt.Fprintln(w, "Changed fields (sessions affected)")
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 	for _, e := range sortedIntMap(counts) {
-		fmt.Fprintf(tw, "  %s\t%d\n", e.key, e.val)
+		fmt.Fprintf(tw, "  %s\t%d\n", sanitizeTerminal(e.key), e.val)
 	}
 	tw.Flush()
 	fmt.Fprintln(w)
@@ -397,8 +404,9 @@ func renderParseDiffChanged(
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
 	for _, s := range shown {
 		fmt.Fprintf(tw, "  %s\t%s\t%s\n",
-			s.Agent, shortID(s.SessionID),
-			parseDiffFieldSummary(s.Fields))
+			sanitizeTerminal(s.Agent),
+			sanitizeTerminal(shortID(s.SessionID)),
+			sanitizeTerminal(parseDiffFieldSummary(s.Fields)))
 	}
 	tw.Flush()
 	if extra := len(changed) - len(shown); extra > 0 {
@@ -412,15 +420,18 @@ func renderParseDiffChanged(
 // every field diff: Field, Stored -> Parsed, Detail, and an
 // [informational] tag where applicable.
 func renderParseDiffSessionVerbose(w io.Writer, s sync.SessionDiff) {
-	fmt.Fprintf(w, "  %s  %s", s.Agent, s.SessionID)
+	fmt.Fprintf(w, "  %s  %s",
+		sanitizeTerminal(s.Agent), sanitizeTerminal(s.SessionID))
 	if s.FilePath != "" {
-		fmt.Fprintf(w, "  %s", s.FilePath)
+		fmt.Fprintf(w, "  %s", sanitizeTerminal(s.FilePath))
 	}
 	fmt.Fprintln(w)
 	for _, f := range s.Fields {
-		fmt.Fprintf(w, "    %s: %s -> %s", f.Field, f.Stored, f.Parsed)
+		fmt.Fprintf(w, "    %s: %s -> %s",
+			sanitizeTerminal(f.Field),
+			sanitizeTerminal(f.Stored), sanitizeTerminal(f.Parsed))
 		if f.Detail != "" {
-			fmt.Fprintf(w, " (%s)", f.Detail)
+			fmt.Fprintf(w, " (%s)", sanitizeTerminal(f.Detail))
 		}
 		if f.Informational {
 			fmt.Fprint(w, " [informational]")

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -124,7 +124,7 @@ func doParseDiff(cfg ParseDiffConfig) (failed bool) {
 	})
 
 	opts := sync.ParseDiffOptions{Agents: agents, Limit: cfg.Limit}
-	if !cfg.JSON {
+	if !cfg.JSON && isTerminalWriter(cfg.stderr()) {
 		opts.Progress = parseDiffProgress(cfg.stderr())
 	}
 
@@ -136,8 +136,15 @@ func doParseDiff(cfg ParseDiffConfig) (failed bool) {
 	if cfg.JSON {
 		writeJSON(cfg.stdout(), report)
 	} else {
+		// The header says "all agents" only when the user did not
+		// restrict the run; report.Agents always carries the full
+		// resolved list.
+		agentsLabel := "all agents"
+		if len(agents) > 0 {
+			agentsLabel = strings.Join(report.Agents, ", ")
+		}
 		renderParseDiffReport(
-			cfg.stdout(), report, appCfg.DBPath, cfg.Verbose,
+			cfg.stdout(), report, appCfg.DBPath, agentsLabel, cfg.Verbose,
 		)
 	}
 	return cfg.FailOnChange && report.HasFailures()
@@ -153,6 +160,21 @@ func parseDiffProgress(w io.Writer) func(done, total int) {
 			fmt.Fprintln(w)
 		}
 	}
+}
+
+// isTerminalWriter reports whether w is an interactive terminal, so
+// the carriage-return progress ticker never spams piped output or CI
+// logs.
+func isTerminalWriter(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
 }
 
 // parseDiffAgentTypes validates --agent values against the parser
@@ -205,15 +227,12 @@ func parseDiffSupportedAgents() []string {
 // renderParseDiffReport writes the human-readable report. An empty
 // archive renders a zero-count summary with no tables.
 func renderParseDiffReport(
-	w io.Writer, r *sync.ParseDiffReport, dbPath string, verbose bool,
+	w io.Writer, r *sync.ParseDiffReport, dbPath, agentsLabel string,
+	verbose bool,
 ) {
-	agents := "all agents"
-	if len(r.Agents) > 0 {
-		agents = strings.Join(r.Agents, ", ")
-	}
 	fmt.Fprintf(w,
 		"Parse diff: %d files re-parsed (%s) against %s (data version %d)\n",
-		r.FilesExamined, agents, dbPath, r.DataVersion)
+		r.FilesExamined, agentsLabel, dbPath, r.DataVersion)
 	if r.FilesLimited {
 		fmt.Fprintln(w,
 			"Note: --limit truncated discovery; totals cover a sample.")

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -6,14 +6,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 // isolateParseDiffEnv points the data dir, HOME, and every per-agent
@@ -410,4 +413,167 @@ func TestRenderParseDiffReport_NonZeroTotalsOnly(t *testing.T) {
 		assert.NotContains(t, out, unwanted,
 			"zero totals must not render a summary line")
 	}
+}
+
+func TestRenderParseDiffReport_ParseErrorsListed(t *testing.T) {
+	r := &sync.ParseDiffReport{
+		DataVersion: 39,
+		Totals:      sync.ParseDiffTotals{ParseErrors: 2},
+		FieldCounts: map[string]int{},
+		Sessions: []sync.SessionDiff{
+			{
+				SessionID: "broken-1", Agent: "claude",
+				FilePath: "/data/proj/broken-1.jsonl",
+				Class:    sync.DiffParseError,
+				Reason:   "unexpected end of JSON input",
+			},
+			{
+				Agent:    "gemini",
+				FilePath: "/data/proj/headless.json",
+				Class:    sync.DiffParseError,
+				Reason:   "invalid character '}'",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	renderParseDiffReport(&buf, r, "db", "all agents", false)
+	out := buf.String()
+
+	assert.Contains(t, out, "Parse errors")
+	assert.Contains(t, out, "/data/proj/broken-1.jsonl",
+		"parse-error file path must be shown, not just the count")
+	assert.Contains(t, out, "unexpected end of JSON input",
+		"parse-error reason must be shown")
+	assert.Contains(t, out, "/data/proj/headless.json")
+	assert.Contains(t, out, "invalid character")
+}
+
+func TestRenderParseDiffReport_VacuousResyncWarning(t *testing.T) {
+	r := &sync.ParseDiffReport{
+		DataVersion: 40,
+		Totals: sync.ParseDiffTotals{
+			Examined: 5, PendingResync: 5,
+		},
+		FieldCounts: map[string]int{},
+	}
+
+	var buf bytes.Buffer
+	renderParseDiffReport(&buf, r, "db", "all agents", false)
+	out := buf.String()
+	assert.Contains(t, out, "Warning:")
+	assert.Contains(t, out, "data version is ahead",
+		"vacuous run must warn that no drift can be detected")
+
+	// A run with at least one comparable session is not vacuous.
+	r.Totals = sync.ParseDiffTotals{Examined: 5, Identical: 1, PendingResync: 4}
+	var buf2 bytes.Buffer
+	renderParseDiffReport(&buf2, r, "db", "all agents", false)
+	assert.NotContains(t, buf2.String(), "Warning:",
+		"a run with comparable sessions must not warn")
+}
+
+func TestRenderParseDiffReport_PendingResyncVerbose(t *testing.T) {
+	r := &sync.ParseDiffReport{
+		DataVersion: 40,
+		Totals:      sync.ParseDiffTotals{Examined: 1, PendingResync: 1},
+		FieldCounts: map[string]int{},
+		Sessions: []sync.SessionDiff{{
+			SessionID:         "stale-1",
+			Agent:             "claude",
+			Class:             sync.DiffPendingResync,
+			StoredDataVersion: 38,
+			Fields: []sync.FieldDiff{{
+				Field: sync.FieldFirstMessage, Stored: "old", Parsed: "new",
+			}},
+		}},
+	}
+
+	var plain bytes.Buffer
+	renderParseDiffReport(&plain, r, "db", "all agents", false)
+	assert.NotContains(t, plain.String(), "stale-1",
+		"pending-resync drill-down is verbose-only")
+
+	var verbose bytes.Buffer
+	renderParseDiffReport(&verbose, r, "db", "all agents", true)
+	out := verbose.String()
+	assert.Contains(t, out, "Pending-resync sessions")
+	assert.Contains(t, out, "stale-1")
+	assert.Contains(t, out, "first_message: old -> new")
+}
+
+func TestParseDiff_JSONSessionsAndDBPath(t *testing.T) {
+	isolateParseDiffEnv(t)
+
+	out, err := executeCommand(newRootCommand(), "parse-diff", "--json")
+	require.NoError(t, err)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	// A clean run must serialize an empty array, never null, so jq
+	// pipelines and typed consumers do not break.
+	require.Contains(t, got, "sessions")
+	assert.Equal(t, "[]", strings.TrimSpace(string(got["sessions"])),
+		"clean run must emit sessions: [] not null")
+	// The archive identity must be present so the report is
+	// self-describing when attached to a PR.
+	require.Contains(t, got, "db_path")
+	var dbPath string
+	require.NoError(t, json.Unmarshal(got["db_path"], &dbPath))
+	assert.NotEmpty(t, dbPath, "db_path must identify the vetted archive")
+}
+
+// TestDoParseDiff_FailOnChangeDirections exercises both directions of
+// the exit-code conjunction (cfg.FailOnChange && report.HasFailures()).
+// A stored session at the current data version whose source file no
+// longer emits it is a presence change, so HasFailures() is true; the
+// flag then decides the exit. Staging it via a valid source file plus a
+// phantom stored row keeps the test independent of the parser's session
+// ID derivation.
+func TestDoParseDiff_FailOnChangeDirections(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("HOME", t.TempDir())
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_PROJECTS_DIR", claudeDir)
+
+	// A valid Claude source file so discovery and parse succeed.
+	projDir := filepath.Join(claudeDir, "-home-proj")
+	require.NoError(t, os.MkdirAll(projDir, 0o755))
+	srcPath := filepath.Join(projDir, "real-session.jsonl")
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "hello").
+		AddClaudeAssistant("2026-01-01T00:00:01Z", "hi").
+		String()
+	require.NoError(t, os.WriteFile(srcPath, []byte(content), 0o644))
+
+	// A phantom stored row under that file at the current data version:
+	// the re-parse never emits this id, so it reports as a presence
+	// change (HasFailures() == true).
+	d, err := db.Open(filepath.Join(dataDir, "sessions.db"))
+	require.NoError(t, err)
+	require.NoError(t, d.UpsertSession(db.Session{
+		ID: "phantom-session", Project: "proj", Machine: "m",
+		Agent: "claude", MessageCount: 4, UserMessageCount: 2,
+		FilePath: &srcPath,
+	}))
+	require.NoError(t,
+		d.SetSessionDataVersion("phantom-session", db.CurrentDataVersion()))
+	require.NoError(t, d.Close())
+
+	var failBuf bytes.Buffer
+	failed := doParseDiff(ParseDiffConfig{
+		FailOnChange: true, Stdout: &failBuf, Stderr: &failBuf,
+	})
+	assert.True(t, failed,
+		"a presence change with --fail-on-change must fail")
+	assert.Contains(t, failBuf.String(), "sessions changed")
+
+	var cleanBuf bytes.Buffer
+	notFailed := doParseDiff(ParseDiffConfig{
+		FailOnChange: false, Stdout: &cleanBuf, Stderr: &cleanBuf,
+	})
+	assert.False(t, notFailed,
+		"without --fail-on-change the same drift must not fail")
 }

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -1,0 +1,395 @@
+// ABOUTME: tests for the parse-diff CLI command: flag validation,
+// ABOUTME: empty-archive runs, JSON shape, and the text renderer.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+func TestParseDiff_RegisteredInRootHelp(t *testing.T) {
+	help, err := executeCommand(newRootCommand(), "--help")
+	require.NoError(t, err, "Execute")
+	assert.Contains(t, help, "parse-diff",
+		"root help should list the parse-diff command")
+}
+
+func TestParseDiff_UnknownAgentListsSupported(t *testing.T) {
+	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+
+	_, err := executeCommand(newRootCommand(),
+		"parse-diff", "--agent", "definitely-not-an-agent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		`unknown agent "definitely-not-an-agent"`)
+	for _, want := range []string{"claude", "codex", "gemini"} {
+		assert.Contains(t, err.Error(), want,
+			"error should list supported agent %q", want)
+	}
+	for _, unwanted := range []string{"forge", "piebald", "warp"} {
+		assert.NotContains(t, err.Error(), unwanted,
+			"error should not list unsupported agent %q", unwanted)
+	}
+}
+
+func TestParseDiff_RejectsAgentsWithoutOnDiskSource(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent string
+	}{
+		{"database-backed forge", "forge"},
+		{"database-backed piebald", "piebald"},
+		{"database-backed warp", "warp"},
+		{"import-only claude-ai", "claude-ai"},
+		{"import-only chatgpt", "chatgpt"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+
+			_, err := executeCommand(newRootCommand(),
+				"parse-diff", "--agent", tc.agent)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), fmt.Sprintf(
+				"agent %q is not supported by parse-diff "+
+					"(no on-disk source to re-parse)", tc.agent))
+		})
+	}
+}
+
+func TestParseDiff_RejectsNegativeLimit(t *testing.T) {
+	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+
+	_, err := executeCommand(newRootCommand(),
+		"parse-diff", "--limit", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--limit must be >= 0")
+}
+
+func TestParseDiffAgentTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		want    []string
+		wantErr string
+	}{
+		{name: "empty means all", in: nil, want: nil},
+		{
+			name: "single agent",
+			in:   []string{"claude"},
+			want: []string{"claude"},
+		},
+		{
+			name: "trims and lowercases",
+			in:   []string{" Claude "},
+			want: []string{"claude"},
+		},
+		{
+			name: "dedupes preserving order",
+			in:   []string{"codex", "claude", "codex"},
+			want: []string{"codex", "claude"},
+		},
+		{
+			name:    "unknown agent",
+			in:      []string{"nope"},
+			wantErr: `unknown agent "nope"`,
+		},
+		{
+			name:    "db-backed agent",
+			in:      []string{"forge"},
+			wantErr: "no on-disk source to re-parse",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDiffAgentTypes(tc.in)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			strs := make([]string, 0, len(got))
+			for _, a := range got {
+				strs = append(strs, string(a))
+			}
+			if tc.want == nil {
+				assert.Empty(t, strs)
+				return
+			}
+			assert.Equal(t, tc.want, strs)
+		})
+	}
+}
+
+func TestParseDiff_EmptyArchiveRunsClean(t *testing.T) {
+	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+
+	out, err := executeCommand(newRootCommand(), "parse-diff")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Parse diff: 0 files re-parsed (all agents)")
+	assert.Contains(t, out, "Summary")
+	assert.Contains(t, out, "Examined")
+	assert.Contains(t, out, "0 sessions changed, 0 identical.")
+	assert.NotContains(t, out, "Changed fields")
+	assert.NotContains(t, out, "Changed sessions")
+}
+
+func TestParseDiff_JSONShape(t *testing.T) {
+	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+
+	out, err := executeCommand(newRootCommand(), "parse-diff", "--json")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"stdout should be valid JSON: %q", out)
+	for _, key := range []string{
+		"generated_at", "data_version", "agents",
+		"files_examined", "files_limited",
+		"totals", "field_counts", "sessions",
+	} {
+		assert.Contains(t, got, key,
+			"JSON report missing top-level key %q", key)
+	}
+	assert.NotEmpty(t, got["generated_at"])
+}
+
+func TestDoParseDiff_FailOnChangeFalseOnEmptyArchive(t *testing.T) {
+	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+
+	var buf bytes.Buffer
+	failed := doParseDiff(ParseDiffConfig{
+		FailOnChange: true,
+		Stdout:       &buf,
+		Stderr:       &buf,
+	})
+	assert.False(t, failed,
+		"empty archive must not trip --fail-on-change")
+	assert.Contains(t, buf.String(),
+		"0 sessions changed, 0 identical.")
+}
+
+// changedSession builds a DiffChanged SessionDiff fixture.
+func changedSession(
+	agent, id string, fields ...sync.FieldDiff,
+) sync.SessionDiff {
+	return sync.SessionDiff{
+		SessionID: id,
+		Agent:     agent,
+		Class:     sync.DiffChanged,
+		Fields:    fields,
+	}
+}
+
+func TestRenderParseDiffReport_ChangedSessions(t *testing.T) {
+	r := &sync.ParseDiffReport{
+		GeneratedAt:   "2026-06-12T00:00:00Z",
+		DataVersion:   42,
+		Agents:        []string{"claude", "codex"},
+		FilesExamined: 7,
+		Totals: sync.ParseDiffTotals{
+			Examined:  5,
+			Identical: 3,
+			Changed:   2,
+		},
+		FieldCounts: map[string]int{
+			sync.FieldMessageCount: 2,
+			sync.FieldModels:       1,
+		},
+		Sessions: []sync.SessionDiff{
+			changedSession("claude", "abcdef1234567890",
+				sync.FieldDiff{
+					Field:  sync.FieldMessageCount,
+					Stored: "10",
+					Parsed: "11",
+				},
+				sync.FieldDiff{
+					Field:  sync.FieldModels,
+					Stored: "opus",
+					Parsed: "opus, sonnet",
+				},
+			),
+			changedSession("codex", "ffff00001111",
+				sync.FieldDiff{
+					Field:  sync.FieldMessageCount,
+					Stored: "4",
+					Parsed: "5",
+				},
+			),
+			{
+				SessionID: "skip-me",
+				Agent:     "claude",
+				Class:     sync.DiffSkipped,
+				Reason:    "source missing",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	renderParseDiffReport(&buf, r, "/tmp/sessions.db", false)
+	out := buf.String()
+
+	assert.Contains(t, out,
+		"Parse diff: 7 files re-parsed (claude, codex) "+
+			"against /tmp/sessions.db (data version 42)")
+	assert.Contains(t, out, "Changed fields (sessions affected)")
+	assert.Contains(t, out, "Changed sessions")
+	assert.Contains(t, out, "abcdef12",
+		"changed session should be listed by short id")
+	assert.Contains(t, out, "message_count, models")
+	assert.Contains(t, out, "2 sessions changed, 3 identical.")
+	assert.NotContains(t, out, "skip-me",
+		"skipped sessions must not appear in the changed list")
+	assert.NotContains(t, out, "more; use --verbose",
+		"no cap notice when under the cap")
+}
+
+func TestRenderParseDiffReport_FieldCountOrdering(t *testing.T) {
+	r := &sync.ParseDiffReport{
+		FieldCounts: map[string]int{
+			"alpha_field": 2,
+			"beta_field":  2,
+			"big_field":   9,
+		},
+		Totals: sync.ParseDiffTotals{Changed: 9, Examined: 9},
+	}
+
+	var buf bytes.Buffer
+	renderParseDiffReport(&buf, r, "db", false)
+	out := buf.String()
+
+	big := strings.Index(out, "big_field")
+	alpha := strings.Index(out, "alpha_field")
+	beta := strings.Index(out, "beta_field")
+	require.NotEqual(t, -1, big)
+	require.NotEqual(t, -1, alpha)
+	require.NotEqual(t, -1, beta)
+	assert.Less(t, big, alpha,
+		"highest count must sort first")
+	assert.Less(t, alpha, beta,
+		"ties must break alphabetically")
+}
+
+func TestRenderParseDiffReport_CapAndVerbose(t *testing.T) {
+	// IDs stay at 7 chars so shortID does not truncate them and
+	// each compact line keeps a distinguishable id.
+	var sessions []sync.SessionDiff
+	for i := range parseDiffChangedCap + 5 {
+		sessions = append(sessions, changedSession(
+			"claude",
+			fmt.Sprintf("sess-%02d", i),
+			sync.FieldDiff{
+				Field:  sync.FieldFirstMessage,
+				Stored: "old",
+				Parsed: "new",
+				Detail: "lengths 3 vs 3",
+			},
+			sync.FieldDiff{
+				Field:         sync.FieldTerminationStatus,
+				Stored:        "completed",
+				Parsed:        "(null)",
+				Informational: true,
+			},
+		))
+	}
+	r := &sync.ParseDiffReport{
+		Totals: sync.ParseDiffTotals{
+			Examined: len(sessions),
+			Changed:  len(sessions),
+		},
+		Sessions: sessions,
+	}
+
+	t.Run("capped", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderParseDiffReport(&buf, r, "db", false)
+		out := buf.String()
+
+		assert.Contains(t, out,
+			"... (5 more; use --verbose or --json)")
+		assert.Contains(t, out, "sess-00")
+		assert.Contains(t, out,
+			fmt.Sprintf("sess-%02d", parseDiffChangedCap-1))
+		assert.NotContains(t, out,
+			fmt.Sprintf("sess-%02d", parseDiffChangedCap),
+			"sessions past the cap must be elided")
+		assert.NotContains(t, out, "[informational]",
+			"compact lines summarize non-informational fields only")
+	})
+
+	t.Run("verbose", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderParseDiffReport(&buf, r, "db", true)
+		out := buf.String()
+
+		assert.NotContains(t, out, "more; use --verbose",
+			"verbose output is never capped")
+		assert.Contains(t, out,
+			fmt.Sprintf("sess-%02d", parseDiffChangedCap+4),
+			"verbose lists every changed session")
+		assert.Contains(t, out,
+			"first_message: old -> new (lengths 3 vs 3)")
+		assert.Contains(t, out,
+			"termination_status: completed -> (null) [informational]")
+	})
+}
+
+func TestRenderParseDiffReport_EmptyReport(t *testing.T) {
+	r := &sync.ParseDiffReport{
+		DataVersion: 7,
+		FieldCounts: map[string]int{},
+	}
+
+	var buf bytes.Buffer
+	require.NotPanics(t, func() {
+		renderParseDiffReport(&buf, r, "/data/sessions.db", false)
+	})
+	out := buf.String()
+
+	assert.Contains(t, out,
+		"Parse diff: 0 files re-parsed (all agents) "+
+			"against /data/sessions.db (data version 7)")
+	assert.Contains(t, out, "Examined")
+	assert.NotContains(t, out, "Changed fields")
+	assert.NotContains(t, out, "Changed sessions")
+	assert.Contains(t, out, "0 sessions changed, 0 identical.")
+}
+
+func TestRenderParseDiffReport_NonZeroTotalsOnly(t *testing.T) {
+	r := &sync.ParseDiffReport{
+		FilesLimited: true,
+		Totals: sync.ParseDiffTotals{
+			Examined:    4,
+			Identical:   3,
+			Changed:     1,
+			ParseErrors: 2,
+		},
+		FieldCounts: map[string]int{},
+	}
+
+	var buf bytes.Buffer
+	renderParseDiffReport(&buf, r, "db", false)
+	out := buf.String()
+
+	for _, want := range []string{
+		"Examined", "Identical", "Changed", "Parse errors",
+		"--limit truncated discovery",
+	} {
+		assert.Contains(t, out, want)
+	}
+	for _, unwanted := range []string{
+		"Pending resync", "New on disk", "Skipped",
+		"Excluded by parser", "Needs retry", "Informational only",
+	} {
+		assert.NotContains(t, out, unwanted,
+			"zero totals must not render a summary line")
+	}
+}

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -6,13 +6,31 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
 )
+
+// isolateParseDiffEnv points the data dir, HOME, and every per-agent
+// directory override at empty temp dirs so end-to-end runs never
+// discover the developer machine's real session files.
+func isolateParseDiffEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for _, def := range parser.Registry {
+		if def.EnvVar != "" {
+			t.Setenv(def.EnvVar,
+				filepath.Join(home, "agent-dirs", string(def.Type)))
+		}
+	}
+}
 
 func TestParseDiff_RegisteredInRootHelp(t *testing.T) {
 	help, err := executeCommand(newRootCommand(), "--help")
@@ -130,7 +148,7 @@ func TestParseDiffAgentTypes(t *testing.T) {
 }
 
 func TestParseDiff_EmptyArchiveRunsClean(t *testing.T) {
-	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+	isolateParseDiffEnv(t)
 
 	out, err := executeCommand(newRootCommand(), "parse-diff")
 	require.NoError(t, err)
@@ -143,7 +161,7 @@ func TestParseDiff_EmptyArchiveRunsClean(t *testing.T) {
 }
 
 func TestParseDiff_JSONShape(t *testing.T) {
-	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+	isolateParseDiffEnv(t)
 
 	out, err := executeCommand(newRootCommand(), "parse-diff", "--json")
 	require.NoError(t, err)
@@ -163,7 +181,7 @@ func TestParseDiff_JSONShape(t *testing.T) {
 }
 
 func TestDoParseDiff_FailOnChangeFalseOnEmptyArchive(t *testing.T) {
-	t.Setenv("AGENTSVIEW_DATA_DIR", t.TempDir())
+	isolateParseDiffEnv(t)
 
 	var buf bytes.Buffer
 	failed := doParseDiff(ParseDiffConfig{
@@ -234,7 +252,7 @@ func TestRenderParseDiffReport_ChangedSessions(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	renderParseDiffReport(&buf, r, "/tmp/sessions.db", false)
+	renderParseDiffReport(&buf, r, "/tmp/sessions.db", "claude, codex", false)
 	out := buf.String()
 
 	assert.Contains(t, out,
@@ -263,7 +281,7 @@ func TestRenderParseDiffReport_FieldCountOrdering(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	renderParseDiffReport(&buf, r, "db", false)
+	renderParseDiffReport(&buf, r, "db", "all agents", false)
 	out := buf.String()
 
 	big := strings.Index(out, "big_field")
@@ -310,7 +328,7 @@ func TestRenderParseDiffReport_CapAndVerbose(t *testing.T) {
 
 	t.Run("capped", func(t *testing.T) {
 		var buf bytes.Buffer
-		renderParseDiffReport(&buf, r, "db", false)
+		renderParseDiffReport(&buf, r, "db", "all agents", false)
 		out := buf.String()
 
 		assert.Contains(t, out,
@@ -327,7 +345,7 @@ func TestRenderParseDiffReport_CapAndVerbose(t *testing.T) {
 
 	t.Run("verbose", func(t *testing.T) {
 		var buf bytes.Buffer
-		renderParseDiffReport(&buf, r, "db", true)
+		renderParseDiffReport(&buf, r, "db", "all agents", true)
 		out := buf.String()
 
 		assert.NotContains(t, out, "more; use --verbose",
@@ -350,7 +368,7 @@ func TestRenderParseDiffReport_EmptyReport(t *testing.T) {
 
 	var buf bytes.Buffer
 	require.NotPanics(t, func() {
-		renderParseDiffReport(&buf, r, "/data/sessions.db", false)
+		renderParseDiffReport(&buf, r, "/data/sessions.db", "all agents", false)
 	})
 	out := buf.String()
 
@@ -376,7 +394,7 @@ func TestRenderParseDiffReport_NonZeroTotalsOnly(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	renderParseDiffReport(&buf, r, "db", false)
+	renderParseDiffReport(&buf, r, "db", "all agents", false)
 	out := buf.String()
 
 	for _, want := range []string{

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -449,6 +449,67 @@ func TestRenderParseDiffReport_ParseErrorsListed(t *testing.T) {
 	assert.Contains(t, out, "invalid character")
 }
 
+// TestRenderParseDiffReport_SanitizesControlSequences proves the
+// human renderer strips terminal control bytes from every
+// session-derived value (agents, IDs, paths, field values, details,
+// parse-error reasons). Session files control these strings, so
+// without sanitization a crafted session could emit OSC 52 clipboard
+// writes, OSC 8 phishing hyperlinks, or cursor movement on a plain
+// `parse-diff --verbose` run.
+func TestRenderParseDiffReport_SanitizesControlSequences(t *testing.T) {
+	r := &sync.ParseDiffReport{
+		DataVersion: 42,
+		Totals: sync.ParseDiffTotals{
+			Examined: 1, Changed: 1, ParseErrors: 1,
+		},
+		FieldCounts: map[string]int{
+			sync.FieldFirstMessage + "\x1b[31m": 1,
+		},
+		Sessions: []sync.SessionDiff{
+			changedSession(
+				"claude\x1b[31m",
+				"evil\x1b]0;title\x07session",
+				sync.FieldDiff{
+					Field:  sync.FieldFirstMessage,
+					Stored: "safe\x1b]52;c;ZXZpbA==\x07clip",
+					Parsed: "new\x1b[2K\rvalue",
+					Detail: "detail\x1b[1;31mred",
+				},
+			),
+			{
+				Agent:    "gemini",
+				FilePath: "/data/evil\x1b[8mhidden.jsonl",
+				Class:    sync.DiffParseError,
+				Reason:   "bad\x1b]8;;https://evil.example\x07link",
+			},
+		},
+	}
+
+	for _, verbose := range []bool{false, true} {
+		var buf bytes.Buffer
+		renderParseDiffReport(&buf, r,
+			"/tmp/db\x1b[5m", "all agents", verbose)
+		out := buf.String()
+
+		assert.NotContains(t, out, "\x1b",
+			"verbose=%v output must contain no ESC bytes", verbose)
+		assert.NotContains(t, out, "\x07",
+			"verbose=%v output must contain no BEL bytes", verbose)
+		assert.NotContains(t, out, "\r",
+			"verbose=%v output must contain no carriage returns", verbose)
+		// The text around the stripped sequences must survive.
+		assert.Contains(t, out, "link", "reason text retained")
+		assert.Contains(t, out, "hidden.jsonl", "path text retained")
+	}
+
+	var verbose bytes.Buffer
+	renderParseDiffReport(&verbose, r, "db", "all agents", true)
+	out := verbose.String()
+	assert.Contains(t, out, "clip", "stored value text retained")
+	assert.Contains(t, out, "value", "parsed value text retained")
+	assert.Contains(t, out, "red", "detail text retained")
+}
+
 func TestRenderParseDiffReport_VacuousResyncWarning(t *testing.T) {
 	r := &sync.ParseDiffReport{
 		DataVersion: 40,

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -198,6 +198,78 @@ func TestDoParseDiff_FailOnChangeFalseOnEmptyArchive(t *testing.T) {
 		"0 sessions changed, 0 identical.")
 }
 
+// TestParseDiffExitFailure pins the --fail-on-change exit contract,
+// including the rule that a vacuous run (data version ahead of the whole
+// archive) is a gate failure, not a passing vet, with an explanation on
+// stderr that also reaches --json callers.
+func TestParseDiffExitFailure(t *testing.T) {
+	tests := []struct {
+		name         string
+		totals       sync.ParseDiffTotals
+		failOnChange bool
+		wantFail     bool
+		wantStderr   bool
+	}{
+		{
+			name:         "flag off never fails",
+			totals:       sync.ParseDiffTotals{Examined: 5, PendingResync: 5},
+			failOnChange: false,
+		},
+		{
+			name:         "identical passes",
+			totals:       sync.ParseDiffTotals{Examined: 5, Identical: 5},
+			failOnChange: true,
+		},
+		{
+			name:         "real change fails without stderr note",
+			totals:       sync.ParseDiffTotals{Examined: 5, Identical: 4, Changed: 1},
+			failOnChange: true,
+			wantFail:     true,
+		},
+		{
+			name:         "parse error fails without stderr note",
+			totals:       sync.ParseDiffTotals{Examined: 1, Identical: 1, ParseErrors: 1},
+			failOnChange: true,
+			wantFail:     true,
+		},
+		{
+			name:         "vacuous run fails with stderr note",
+			totals:       sync.ParseDiffTotals{Examined: 5, PendingResync: 5},
+			failOnChange: true,
+			wantFail:     true,
+			wantStderr:   true,
+		},
+		{
+			name: "partial pending resync is not vacuous",
+			totals: sync.ParseDiffTotals{
+				Examined: 5, Identical: 1, PendingResync: 4,
+			},
+			failOnChange: true,
+		},
+		{
+			name:         "no examined sessions is not vacuous",
+			totals:       sync.ParseDiffTotals{},
+			failOnChange: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &sync.ParseDiffReport{Totals: tc.totals}
+			var stderr bytes.Buffer
+			got := parseDiffExitFailure(r, tc.failOnChange, &stderr)
+			assert.Equal(t, tc.wantFail, got, "exit failure")
+			if tc.wantStderr {
+				assert.Contains(t, stderr.String(),
+					"--fail-on-change failed: the run was vacuous",
+					"vacuous run must explain the non-zero exit on stderr")
+			} else {
+				assert.Empty(t, stderr.String(),
+					"only a vacuous run writes to stderr")
+			}
+		})
+	}
+}
+
 // changedSession builds a DiffChanged SessionDiff fixture.
 func changedSession(
 	agent, id string, fields ...sync.FieldDiff,

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1121,6 +1121,105 @@ func (db *DB) MessageRoleTimeFingerprint(sessionID string) (string, error) {
 	return b.String(), rows.Err()
 }
 
+// MessageFlagsFingerprint returns an exact ordered fingerprint of the
+// per-message flag and thinking columns that the token, role/time, and
+// content fingerprints do not cover: is_system, has_thinking,
+// has_tool_use, and a SHA-256 over the sanitized thinking_text. The
+// parse-diff comparator uses it as a tier-1 fast path so a parser change
+// confined to these columns still triggers the tier-2 row comparison.
+// Not used by the PG push fast-path.
+func (db *DB) MessageFlagsFingerprint(sessionID string) (string, error) {
+	rows, err := db.getReader().Query(
+		`SELECT ordinal, is_system, has_thinking, has_tool_use,
+			thinking_text
+		 FROM messages
+		 WHERE session_id = ?
+		 ORDER BY ordinal ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var ordinal int
+		var isSystem, hasThinking, hasToolUse bool
+		var thinkingText string
+		if err := rows.Scan(
+			&ordinal, &isSystem, &hasThinking, &hasToolUse, &thinkingText,
+		); err != nil {
+			return "", err
+		}
+		sum := sha256.Sum256([]byte(SanitizeUTF8(thinkingText)))
+		fmt.Fprintf(&b, "%d|%t|%t|%t|%x;",
+			ordinal, isSystem, hasThinking, hasToolUse, sum)
+	}
+	return b.String(), rows.Err()
+}
+
+// ToolCallFingerprint returns an exact ordered fingerprint of a
+// session's parser-owned tool_call columns: tool_name, category,
+// tool_use_id, a SHA-256 over input_json, skill_name,
+// subagent_session_id, and result_content_length. The database-assigned
+// id/message_id/session_id columns are excluded, and result_content (the
+// possibly blocked body) is represented only by its length, mirroring
+// the sizes-not-bodies rule the message content fingerprint follows.
+// Rows are ordered by the owning message's ordinal then tool_calls.id
+// (insertion order within a message). The parse-diff comparator uses it
+// as a tier-1 fast path so tool-call drift that moves none of the
+// message fingerprints still triggers the tier-2 comparison. Not used by
+// the PG push fast-path.
+func (db *DB) ToolCallFingerprint(sessionID string) (string, error) {
+	rows, err := db.getReader().Query(
+		`SELECT m.ordinal, tc.tool_name, tc.category, tc.tool_use_id,
+			tc.input_json, tc.skill_name, tc.subagent_session_id,
+			tc.result_content_length
+		 FROM tool_calls tc
+		 JOIN messages m ON m.id = tc.message_id
+		 WHERE tc.session_id = ?
+		 ORDER BY m.ordinal ASC, tc.id ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var ordinal int
+		var resultLen sql.NullInt64
+		var toolName, category string
+		var toolUseID, inputJSON, skillName, subagentSessionID sql.NullString
+		if err := rows.Scan(
+			&ordinal, &toolName, &category, &toolUseID,
+			&inputJSON, &skillName, &subagentSessionID, &resultLen,
+		); err != nil {
+			return "", err
+		}
+		toolName = SanitizeUTF8(toolName)
+		category = SanitizeUTF8(category)
+		tu := SanitizeUTF8(toolUseID.String)
+		skill := SanitizeUTF8(skillName.String)
+		sub := SanitizeUTF8(subagentSessionID.String)
+		sum := sha256.Sum256([]byte(SanitizeUTF8(inputJSON.String)))
+		fmt.Fprintf(&b,
+			"%d|%d:%s|%d:%s|%d:%s|%x|%d:%s|%d:%s|%d;",
+			ordinal,
+			len(toolName), toolName,
+			len(category), category,
+			len(tu), tu,
+			sum,
+			len(skill), skill,
+			len(sub), sub,
+			int(resultLen.Int64),
+		)
+	}
+	return b.String(), rows.Err()
+}
+
 // ToolCallCount returns the number of tool_calls rows for a session.
 func (db *DB) ToolCallCount(sessionID string) (int, error) {
 	var n int

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -1046,6 +1047,41 @@ func (db *DB) MessageTokenFingerprint(sessionID string) (string, error) {
 			len(srcParentUUID), srcParentUUID,
 			isSidechain, isCompactBoundary,
 		)
+	}
+	return b.String(), rows.Err()
+}
+
+// MessageContentHashFingerprint returns an exact ordered fingerprint
+// of per-message body content: ordinal, the stored content_length
+// column, and a SHA-256 over the sanitized content. The parse-diff
+// comparator uses it instead of the aggregate
+// MessageContentFingerprint (sum/max/min of content_length, kept for
+// the PG push fast-path), which cannot see equal-length body rewrites
+// or per-message length changes whose aggregates collide.
+func (db *DB) MessageContentHashFingerprint(sessionID string) (string, error) {
+	rows, err := db.getReader().Query(
+		`SELECT ordinal, content, content_length
+		 FROM messages
+		 WHERE session_id = ?
+		 ORDER BY ordinal ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var ordinal, contentLength int
+		var content string
+		if err := rows.Scan(
+			&ordinal, &content, &contentLength,
+		); err != nil {
+			return "", err
+		}
+		sum := sha256.Sum256([]byte(SanitizeUTF8(content)))
+		fmt.Fprintf(&b, "%d|%d|%x;", ordinal, contentLength, sum)
 	}
 	return b.String(), rows.Err()
 }

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -16,7 +16,8 @@ import (
 const (
 	selectMessageCols = `id, session_id, ordinal, role, content,
 		thinking_text,
-		timestamp, has_thinking, has_tool_use, content_length,
+		COALESCE(timestamp, '') AS timestamp,
+		has_thinking, has_tool_use, content_length,
 		is_system,
 		model, token_usage, context_tokens, output_tokens,
 		has_context_tokens, has_output_tokens,
@@ -1093,10 +1094,14 @@ func (db *DB) MessageContentHashFingerprint(sessionID string) (string, error) {
 // columns; without it, role-only or timestamp-only parser drift would
 // never trigger the tier-2 row comparison. Role is sanitized to mirror
 // the tier-2 compare in messageMetadataDiff; timestamp is compared raw
-// there, so it stays raw here.
+// there, so it stays raw here. timestamp is nullable, so a NULL is
+// coalesced to the empty string to match both the in-memory twin (which
+// emits "" for a zero-value Go timestamp) and the tier-2 read path
+// (selectMessageCols coalesces the same way); without it a single
+// imported NULL row would error here and abort the whole parse-diff run.
 func (db *DB) MessageRoleTimeFingerprint(sessionID string) (string, error) {
 	rows, err := db.getReader().Query(
-		`SELECT ordinal, role, timestamp
+		`SELECT ordinal, role, COALESCE(timestamp, '')
 		 FROM messages
 		 WHERE session_id = ?
 		 ORDER BY ordinal ASC`,

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1165,7 +1165,11 @@ func (db *DB) MessageFlagsFingerprint(sessionID string) (string, error) {
 // subagent_session_id, and result_content_length. The database-assigned
 // id/message_id/session_id columns are excluded, and result_content (the
 // possibly blocked body) is represented only by its length, mirroring
-// the sizes-not-bodies rule the message content fingerprint follows.
+// the sizes-not-bodies rule the message content fingerprint follows. The
+// sibling tool_result_events rows are not fingerprinted: the
+// blocked-category config clears them wholesale, so comparing them would
+// be config-sensitive; result_content_length already captures their
+// summarized size.
 // Rows are ordered by the owning message's ordinal then tool_calls.id
 // (insertion order within a message). The parse-diff comparator uses it
 // as a tier-1 fast path so tool-call drift that moves none of the

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1164,7 +1164,7 @@ func (db *DB) MessageFlagsFingerprint(sessionID string) (string, error) {
 	return b.String(), rows.Err()
 }
 
-// ToolCallFingerprint returns an exact ordered fingerprint of a
+// ToolCallParseDiffFingerprint returns an exact ordered fingerprint of a
 // session's parser-owned tool_call columns: tool_name, category,
 // tool_use_id, a SHA-256 over input_json, skill_name,
 // subagent_session_id, and result_content_length. The database-assigned
@@ -1180,7 +1180,7 @@ func (db *DB) MessageFlagsFingerprint(sessionID string) (string, error) {
 // as a tier-1 fast path so tool-call drift that moves none of the
 // message fingerprints still triggers the tier-2 comparison. Not used by
 // the PG push fast-path.
-func (db *DB) ToolCallFingerprint(sessionID string) (string, error) {
+func (db *DB) ToolCallParseDiffFingerprint(sessionID string) (string, error) {
 	rows, err := db.getReader().Query(
 		`SELECT m.ordinal, tc.tool_name, tc.category, tc.tool_use_id,
 			tc.input_json, tc.skill_name, tc.subagent_session_id,

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1050,6 +1050,41 @@ func (db *DB) MessageTokenFingerprint(sessionID string) (string, error) {
 	return b.String(), rows.Err()
 }
 
+// MessageRoleTimeFingerprint returns an exact ordered fingerprint of
+// per-message role and timestamp for a session's messages. The
+// parse-diff comparator uses it as a tier-1 fast path alongside
+// MessageTokenFingerprint, which deliberately excludes these two
+// columns; without it, role-only or timestamp-only parser drift would
+// never trigger the tier-2 row comparison. Role is sanitized to mirror
+// the tier-2 compare in messageMetadataDiff; timestamp is compared raw
+// there, so it stays raw here.
+func (db *DB) MessageRoleTimeFingerprint(sessionID string) (string, error) {
+	rows, err := db.getReader().Query(
+		`SELECT ordinal, role, timestamp
+		 FROM messages
+		 WHERE session_id = ?
+		 ORDER BY ordinal ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var ordinal int
+		var role, timestamp string
+		if err := rows.Scan(&ordinal, &role, &timestamp); err != nil {
+			return "", err
+		}
+		role = SanitizeUTF8(role)
+		fmt.Fprintf(&b, "%d|%d:%s|%d:%s;",
+			ordinal, len(role), role, len(timestamp), timestamp)
+	}
+	return b.String(), rows.Err()
+}
+
 // ToolCallCount returns the number of tool_calls rows for a session.
 func (db *DB) ToolCallCount(sessionID string) (int, error) {
 	var n int

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -334,3 +334,64 @@ func TestReplaceSessionMessages_LargeSession(t *testing.T) {
 	assert.Zero(t, leaked,
 		"FTS still contains rows matching 'xxx' from deleted blob")
 }
+
+// TestMessageReadsTolerateNullTimestamp pins NULL-timestamp robustness
+// across the three message read paths. timestamp is the only nullable
+// text column in the messages table; fresh inserts always bind a Go
+// string (never NULL), so a NULL only reaches a row via an imported or
+// migrated archive. Before the COALESCE guard such a row made rows.Scan
+// fail with "converting NULL to string is unsupported", which aborted
+// the parse-diff run (MessageRoleTimeFingerprint) and broke ordinary
+// reads (GetAllMessages, GetMessageByOrdinal).
+func TestMessageReadsTolerateNullTimestamp(t *testing.T) {
+	t.Parallel()
+	d := testDB(t)
+	insertSession(t, d, "null-ts", "proj1")
+	insertMessages(t, d,
+		userMsgAt("null-ts", 0, "hello", "2024-01-01T10:00:00Z"),
+		asstMsgAt("null-ts", 1, "hi there", "2024-01-01T10:00:05Z"),
+	)
+
+	nullOrdinal1 := func() {
+		require.NoError(t, d.Update(func(tx *sql.Tx) error {
+			_, err := tx.Exec(
+				"UPDATE messages SET timestamp = NULL"+
+					" WHERE session_id = ? AND ordinal = ?", "null-ts", 1)
+			return err
+		}), "null the stored timestamp")
+	}
+
+	// Tier-1 fingerprint: must not error, and a NULL must fingerprint
+	// identically to an empty string so the report cannot distinguish
+	// the two. InsertMessages binds a Go string, so reach past it with
+	// raw SQL to plant the NULL.
+	nullOrdinal1()
+	fpNull, err := d.MessageRoleTimeFingerprint("null-ts")
+	require.NoError(t, err, "fingerprint over NULL timestamp")
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"UPDATE messages SET timestamp = ''"+
+				" WHERE session_id = ? AND ordinal = ?", "null-ts", 1)
+		return err
+	}), "set the stored timestamp to empty string")
+	fpEmpty, err := d.MessageRoleTimeFingerprint("null-ts")
+	require.NoError(t, err, "fingerprint over empty timestamp")
+	assert.Equal(t, fpEmpty, fpNull,
+		"NULL timestamp must fingerprint identically to empty string")
+
+	// Tier-2 batch read path (scanMessages via selectMessageCols).
+	nullOrdinal1()
+	msgs, err := d.GetAllMessages(context.Background(), "null-ts")
+	require.NoError(t, err, "GetAllMessages over NULL timestamp")
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "2024-01-01T10:00:00Z", msgs[0].Timestamp)
+	assert.Equal(t, "", msgs[1].Timestamp,
+		"NULL timestamp reads as empty string")
+
+	// Single-row read path (GetMessageByOrdinal via selectMessageCols).
+	m, err := d.GetMessageByOrdinal("null-ts", 1)
+	require.NoError(t, err, "GetMessageByOrdinal over NULL timestamp")
+	require.NotNil(t, m)
+	assert.Equal(t, "", m.Timestamp,
+		"NULL timestamp reads as empty string")
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3035,15 +3035,30 @@ type incrementalUpdate struct {
 	hasPeakContextTokens bool
 }
 
+// sessionParseError is a per-session parse failure inside a shared
+// SQLite store (OpenCode, Zed, Kiro), where one file path fans out to
+// many sessions and a single bad payload must not fail the whole db.
+type sessionParseError struct {
+	sessionID   string // raw parser-side ID, no engine prefix
+	virtualPath string // dbPath#rawID source path
+	err         error
+}
+
 type processResult struct {
 	results            []parser.ParseResult
 	excludedSessionIDs []string
-	skip               bool
-	mtime              int64
-	err                error
-	incremental        *incrementalUpdate
-	cacheSkip          bool
-	needsRetry         bool
+	// sessionErrs carries per-session parse failures from the
+	// shared-db fan-out loops. Normal sync logs and skips these;
+	// parse-diff (forceParse) surfaces them as DiffParseError report
+	// entries so --fail-on-change cannot pass over a session the
+	// current binary failed to parse.
+	sessionErrs []sessionParseError
+	skip        bool
+	mtime       int64
+	err         error
+	incremental *incrementalUpdate
+	cacheSkip   bool
+	needsRetry  bool
 	// forceReplace requests full message replacement on write,
 	// even when the existing rows would otherwise be left in
 	// place. Set when a fall-through to full parse is recovering
@@ -3715,6 +3730,7 @@ func (e *Engine) processOpenCode(
 			filepath.Dir(file.Path),
 		)
 		var results []parser.ParseResult
+		var sessionErrs []sessionParseError
 		for _, meta := range metas {
 			if _, ok := storageIDs[meta.SessionID]; ok {
 				continue
@@ -3730,10 +3746,18 @@ func (e *Engine) processOpenCode(
 				file.Path, meta.SessionID, e.machine,
 			)
 			if err != nil {
-				log.Printf(
-					"opencode sqlite watch session %s: %v",
-					meta.SessionID, err,
-				)
+				if e.forceParse {
+					sessionErrs = append(sessionErrs, sessionParseError{
+						sessionID:   meta.SessionID,
+						virtualPath: meta.VirtualPath,
+						err:         err,
+					})
+				} else {
+					log.Printf(
+						"opencode sqlite watch session %s: %v",
+						meta.SessionID, err,
+					)
+				}
 				continue
 			}
 			if sess == nil {
@@ -3744,7 +3768,11 @@ func (e *Engine) processOpenCode(
 				Messages: msgs,
 			})
 		}
-		return processResult{results: results, forceReplace: true}
+		return processResult{
+			results:      results,
+			sessionErrs:  sessionErrs,
+			forceReplace: true,
+		}
 	}
 	if e.shouldSkipOpenCodeByPath(file.Path) {
 		return processResult{skip: true}
@@ -4127,6 +4155,7 @@ func (e *Engine) processZed(
 	hash, _ := ComputeFileHash(file.Path)
 
 	var results []parser.ParseResult
+	var sessionErrs []sessionParseError
 	for _, meta := range metas {
 		_, storedMtime, ok := e.db.GetFileInfoByPath(meta.VirtualPath)
 		// parse-diff: !e.forceParse disables the stored-state skip.
@@ -4139,7 +4168,15 @@ func (e *Engine) processZed(
 			conn, file.Path, meta.RawID, e.machine, info,
 		)
 		if err != nil {
-			log.Printf("zed thread %s: %v", meta.RawID, err)
+			if e.forceParse {
+				sessionErrs = append(sessionErrs, sessionParseError{
+					sessionID:   meta.RawID,
+					virtualPath: meta.VirtualPath,
+					err:         err,
+				})
+			} else {
+				log.Printf("zed thread %s: %v", meta.RawID, err)
+			}
 			continue
 		}
 		if result == nil {
@@ -4150,7 +4187,11 @@ func (e *Engine) processZed(
 		}
 		results = append(results, *result)
 	}
-	return processResult{results: results, forceReplace: true}
+	return processResult{
+		results:      results,
+		sessionErrs:  sessionErrs,
+		forceReplace: true,
+	}
 }
 
 func (e *Engine) processKiro(
@@ -4184,6 +4225,7 @@ func (e *Engine) processKiro(
 			return processResult{err: err}
 		}
 		var results []parser.ParseResult
+		var sessionErrs []sessionParseError
 		for _, meta := range metas {
 			_, storedMtime, ok := e.db.GetFileInfoByPath(
 				meta.VirtualPath,
@@ -4198,10 +4240,18 @@ func (e *Engine) processKiro(
 				meta.SessionID, e.machine,
 			)
 			if err != nil {
-				log.Printf(
-					"kiro sqlite watch session %s: %v",
-					meta.SessionID, err,
-				)
+				if e.forceParse {
+					sessionErrs = append(sessionErrs, sessionParseError{
+						sessionID:   meta.SessionID,
+						virtualPath: meta.VirtualPath,
+						err:         err,
+					})
+				} else {
+					log.Printf(
+						"kiro sqlite watch session %s: %v",
+						meta.SessionID, err,
+					)
+				}
 				continue
 			}
 			if sess == nil {
@@ -4212,7 +4262,11 @@ func (e *Engine) processKiro(
 				Messages: msgs,
 			})
 		}
-		return processResult{results: results, forceReplace: true}
+		return processResult{
+			results:      results,
+			sessionErrs:  sessionErrs,
+			forceReplace: true,
+		}
 	}
 	if e.isShadowedLegacyKiroPath(file.Path) {
 		return processResult{skip: true}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -103,6 +103,12 @@ type Engine struct {
 	pathRewriter func(string) string
 	emitter      Emitter
 
+	// forceParse disables every stored-state skip (skip cache,
+	// size/mtime/data_version checks, incremental JSONL deltas) so
+	// parse-diff fully re-parses every discovered file. Normal sync
+	// never sets it; behavior must be identical when false.
+	forceParse bool
+
 	// phaseStats accumulates per-phase wall-clock time inside the bulk
 	// write path. Exposed via PhaseStats() so a CLI driver can log the
 	// totals after a sync pass completes.
@@ -3095,7 +3101,7 @@ func (e *Engine) processFile(
 	// migrateLegacyCodexExecSkips, so this check can treat
 	// the skip cache as authoritative without per-file
 	// re-validation.
-	if cacheSkip {
+	if cacheSkip && !e.forceParse { // parse-diff: ignore the skip cache
 		e.skipMu.RLock()
 		cachedMtime, cached := e.skipCache[file.Path]
 		e.skipMu.RUnlock()
@@ -3283,6 +3289,9 @@ func (e *Engine) persistSkipCache() int {
 func (e *Engine) shouldSkipFile(
 	sessionID string, info os.FileInfo,
 ) bool {
+	if e.forceParse { // parse-diff: always re-parse
+		return false
+	}
 	fullID := e.idPrefix + sessionID
 	storedSize, storedMtime, ok := e.db.GetSessionFileInfo(
 		fullID,
@@ -3307,6 +3316,9 @@ func (e *Engine) shouldSkipFile(
 func (e *Engine) shouldSkipByPath(
 	path string, info os.FileInfo,
 ) bool {
+	if e.forceParse { // parse-diff: always re-parse
+		return false
+	}
 	lookupPath := path
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
@@ -3441,6 +3453,9 @@ func (e *Engine) tryIncrementalJSONL(
 	agent parser.AgentType,
 	parseFn incrementalParseFunc,
 ) (processResult, bool) {
+	if e.forceParse { // parse-diff: never produce append deltas
+		return processResult{}, false
+	}
 	lookupPath := file.Path
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(file.Path)
@@ -3705,7 +3720,8 @@ func (e *Engine) processOpenCode(
 				continue
 			}
 			_, storedMtime, ok := e.db.GetFileInfoByPath(meta.VirtualPath)
-			if ok && storedMtime == meta.FileMtime &&
+			// parse-diff: !e.forceParse disables the stored-state skip.
+			if !e.forceParse && ok && storedMtime == meta.FileMtime &&
 				e.db.GetDataVersionByPath(meta.VirtualPath) >=
 					db.CurrentDataVersion() {
 				continue
@@ -3759,6 +3775,9 @@ func (e *Engine) processOpenCode(
 }
 
 func (e *Engine) shouldSkipOpenCodeByPath(path string) bool {
+	if e.forceParse { // parse-diff: always re-parse
+		return false
+	}
 	lookupPath := path
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
@@ -3847,6 +3866,9 @@ func copilotEffectiveMtime(eventsPath string, info os.FileInfo) int64 {
 func (e *Engine) shouldSkipCopilot(
 	path string, info os.FileInfo, effectiveMtime int64,
 ) bool {
+	if e.forceParse { // parse-diff: always re-parse
+		return false
+	}
 	lookupPath := path
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
@@ -4107,7 +4129,8 @@ func (e *Engine) processZed(
 	var results []parser.ParseResult
 	for _, meta := range metas {
 		_, storedMtime, ok := e.db.GetFileInfoByPath(meta.VirtualPath)
-		if ok && storedMtime == meta.FileMtime &&
+		// parse-diff: !e.forceParse disables the stored-state skip.
+		if !e.forceParse && ok && storedMtime == meta.FileMtime &&
 			e.db.GetDataVersionByPath(meta.VirtualPath) >=
 				db.CurrentDataVersion() {
 			continue
@@ -4165,7 +4188,8 @@ func (e *Engine) processKiro(
 			_, storedMtime, ok := e.db.GetFileInfoByPath(
 				meta.VirtualPath,
 			)
-			if ok && storedMtime == meta.FileMtime &&
+			// parse-diff: !e.forceParse disables the stored-state skip.
+			if !e.forceParse && ok && storedMtime == meta.FileMtime &&
 				e.db.GetDataVersionByPath(meta.VirtualPath) >=
 					db.CurrentDataVersion() {
 				continue

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -463,7 +463,7 @@ func (e *Engine) parseDiffPresenceSweep(
 				continue
 			}
 			visited[s.ID] = true
-			report.Sessions = append(report.Sessions, SessionDiff{
+			diff := SessionDiff{
 				SessionID:         s.ID,
 				Agent:             s.Agent,
 				FilePath:          derefString(s.FilePath),
@@ -474,7 +474,21 @@ func (e *Engine) parseDiffPresenceSweep(
 					Stored: "stored",
 					Parsed: "(not emitted)",
 				}},
-			})
+			}
+			// A row below the current data version is pipeline
+			// history, not drift: incomplete writes (data_version 0)
+			// and orphan-copied rows from earlier resyncs commonly
+			// survive in the archive under IDs the current parser no
+			// longer derives. Only a current-version row that vanished
+			// from its file's parse output is a real presence change.
+			if s.DataVersion < db.CurrentDataVersion() {
+				diff.Class = DiffPendingResync
+				diff.Reason = "stale row; parser no longer emits this ID"
+				report.Sessions = append(report.Sessions, diff)
+				report.Totals.PendingResync++
+				continue
+			}
+			report.Sessions = append(report.Sessions, diff)
 			report.Totals.Changed++
 			report.FieldCounts[FieldPresence]++
 		}

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -2,6 +2,10 @@ package sync
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
@@ -29,7 +33,9 @@ type ParseDiffOptions struct {
 // state.
 func NewDiffEngine(database *db.DB, cfg EngineConfig) *Engine {
 	cfg.Ephemeral = true
-	return NewEngine(database, cfg)
+	e := NewEngine(database, cfg)
+	e.forceParse = true
+	return e
 }
 
 // ParseDiff re-parses session source files with the current binary,
@@ -38,9 +44,505 @@ func NewDiffEngine(database *db.DB, cfg EngineConfig) *Engine {
 // no skip cache, no sync state. It holds the engine's sync mutex for
 // the duration.
 func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDiffReport, error) {
-	return &ParseDiffReport{
+	e.syncMu.Lock()
+	defer e.syncMu.Unlock()
+
+	resolved, err := resolveParseDiffAgents(opts.Agents)
+	if err != nil {
+		return nil, err
+	}
+	resolvedSet := make(map[parser.AgentType]bool, len(resolved))
+
+	report := &ParseDiffReport{
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		DataVersion: db.CurrentDataVersion(),
 		FieldCounts: map[string]int{},
-	}, nil
+	}
+	for _, def := range resolved {
+		resolvedSet[def.Type] = true
+		report.Agents = append(report.Agents, string(def.Type))
+	}
+
+	// Discovery mirrors syncAllLocked's file phase: per-agent
+	// DiscoverFunc over the configured dirs, then dedupe and the
+	// legacy-Kiro shadow filter.
+	var files []parser.DiscoveredFile
+	for _, def := range resolved {
+		for _, d := range e.agentDirs[def.Type] {
+			files = append(files, def.DiscoverFunc(d)...)
+		}
+	}
+	files = dedupeDiscoveredFiles(files)
+	files = e.filterShadowedLegacyKiroFiles(files)
+
+	// Newest first by source mtime (composite stats for virtual
+	// paths), tie-broken by path so the --limit sample is stable.
+	files, cutPaths, limited := sortAndLimitParseDiffFiles(
+		files, opts.Limit,
+	)
+	report.FilesLimited = limited
+	report.FilesExamined = len(files)
+
+	// One full snapshot of the archive (empty range = every session,
+	// including trashed rows, with full columns and the raw
+	// session_name) indexed by ID and by base source path.
+	storedSessions, err := e.db.ListSessionsModifiedBetween(
+		ctx, "", "", nil, nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("parse-diff: list stored sessions: %w", err)
+	}
+	storedByID := make(map[string]*db.Session, len(storedSessions))
+	storedByPath := make(map[string][]*db.Session)
+	for i := range storedSessions {
+		s := &storedSessions[i]
+		storedByID[s.ID] = s
+		if s.FilePath != nil && *s.FilePath != "" {
+			base := stripVirtualSourceSuffix(*s.FilePath)
+			storedByPath[base] = append(storedByPath[base], s)
+		}
+	}
+
+	fileAgents := make(map[string]parser.AgentType, len(files))
+	for _, f := range files {
+		fileAgents[f.Path] = f.Agent
+	}
+
+	// The worktree resolver caches are not thread-safe; everything
+	// below runs in this single collector goroutine.
+	resolver := e.loadWorktreeProjectResolver()
+	visited := make(map[string]bool)
+	var presencePaths []string
+
+	total := len(files)
+	if opts.Progress != nil {
+		opts.Progress(0, total)
+	}
+	results := e.startWorkers(ctx, files)
+	for i := range total {
+		var r syncJob
+		select {
+		case <-ctx.Done():
+			drainResults(results, total-i)
+			return nil, ctx.Err()
+		case r = <-results:
+		}
+		if r.err != nil && ctx.Err() != nil {
+			// Workers emit ctx.Err() for files skipped after
+			// cancellation.
+			drainResults(results, total-i-1)
+			return nil, ctx.Err()
+		}
+		if r.incremental != nil {
+			drainResults(results, total-i-1)
+			return nil, fmt.Errorf(
+				"parse-diff: internal error: incremental parse of %s "+
+					"despite force-parse mode", r.path,
+			)
+		}
+		if err := e.parseDiffCollectFile(
+			ctx, report, r, fileAgents, storedByID, storedByPath,
+			visited, resolver, &presencePaths,
+		); err != nil {
+			drainResults(results, total-i-1)
+			return nil, err
+		}
+		if opts.Progress != nil {
+			opts.Progress(i+1, total)
+		}
+	}
+
+	// Presence sweep after all files: stored sessions under a
+	// successfully parsed file that no parse result or exclusion
+	// accounted for were silently dropped by the current parser.
+	e.parseDiffPresenceSweep(report, presencePaths, storedByPath, visited)
+
+	// Final sweep: stored sessions never visited by any file.
+	parseDiffSweepStored(
+		report, storedSessions, resolvedSet,
+		len(opts.Agents) == 0, cutPaths, visited,
+	)
+	report.Totals.Examined = report.Totals.Identical +
+		report.Totals.Changed + report.Totals.PendingResync
+
+	sort.Slice(report.Sessions, func(i, j int) bool {
+		a, b := report.Sessions[i], report.Sessions[j]
+		if a.Class != b.Class {
+			return a.Class < b.Class
+		}
+		if a.Agent != b.Agent {
+			return a.Agent < b.Agent
+		}
+		if a.FilePath != b.FilePath {
+			return a.FilePath < b.FilePath
+		}
+		return a.SessionID < b.SessionID
+	})
+	return report, nil
+}
+
+// resolveParseDiffAgents validates the requested agent set against
+// the registry and returns the matching defs in registry order. Only
+// file-based agents with a DiscoverFunc have an on-disk source to
+// re-parse.
+func resolveParseDiffAgents(
+	requested []parser.AgentType,
+) ([]parser.AgentDef, error) {
+	var allowed []parser.AgentDef
+	allowedSet := make(map[parser.AgentType]bool)
+	var names []string
+	for _, def := range parser.Registry {
+		if def.FileBased && def.DiscoverFunc != nil {
+			allowed = append(allowed, def)
+			allowedSet[def.Type] = true
+			names = append(names, string(def.Type))
+		}
+	}
+	if len(requested) == 0 {
+		return allowed, nil
+	}
+
+	supported := strings.Join(names, ", ")
+	reqSet := make(map[parser.AgentType]bool, len(requested))
+	for _, t := range requested {
+		if allowedSet[t] {
+			reqSet[t] = true
+			continue
+		}
+		if _, known := parser.AgentByType(t); known {
+			return nil, fmt.Errorf(
+				"agent %q has no on-disk source to re-parse; "+
+					"supported agents: %s", t, supported,
+			)
+		}
+		return nil, fmt.Errorf(
+			"unknown agent %q; supported agents: %s", t, supported,
+		)
+	}
+	out := make([]parser.AgentDef, 0, len(reqSet))
+	for _, def := range allowed {
+		if reqSet[def.Type] {
+			out = append(out, def)
+		}
+	}
+	return out, nil
+}
+
+// sortAndLimitParseDiffFiles orders files newest-first by source
+// mtime (tie-break: path ascending) and applies the file cap. It
+// returns the kept files and the base paths of files cut by the
+// limit, used by the final sweep's "not sampled" reason.
+func sortAndLimitParseDiffFiles(
+	files []parser.DiscoveredFile, limit int,
+) ([]parser.DiscoveredFile, map[string]bool, bool) {
+	mtimes := make(map[string]int64, len(files))
+	for _, f := range files {
+		m, err := discoveredFileMtime(f)
+		if err != nil {
+			m = 0
+		}
+		mtimes[f.Path] = m
+	}
+	sort.SliceStable(files, func(i, j int) bool {
+		mi, mj := mtimes[files[i].Path], mtimes[files[j].Path]
+		if mi != mj {
+			return mi > mj
+		}
+		return files[i].Path < files[j].Path
+	})
+
+	cutPaths := map[string]bool{}
+	limited := false
+	if limit > 0 && len(files) > limit {
+		limited = true
+		for _, f := range files[limit:] {
+			cutPaths[stripVirtualSourceSuffix(f.Path)] = true
+		}
+		files = files[:limit]
+	}
+	return files, cutPaths, limited
+}
+
+// stripVirtualSourceSuffix maps a stored file_path to its on-disk
+// base file by removing the "#rawID" suffix Kiro, Zed, and OpenCode
+// SQLite-backed sessions append to their shared database path.
+func stripVirtualSourceSuffix(path string) string {
+	if dbPath, _, ok := parser.ParseKiroSQLiteVirtualPath(path); ok {
+		return dbPath
+	}
+	if dbPath, _, ok := parser.ParseZedSQLiteVirtualPath(path); ok {
+		return dbPath
+	}
+	if dbPath, _, ok := parser.ParseOpenCodeSQLiteVirtualPath(path); ok {
+		return dbPath
+	}
+	return path
+}
+
+// parseDiffCollectFile folds one worker result into the report.
+func (e *Engine) parseDiffCollectFile(
+	ctx context.Context,
+	report *ParseDiffReport,
+	job syncJob,
+	fileAgents map[string]parser.AgentType,
+	storedByID map[string]*db.Session,
+	storedByPath map[string][]*db.Session,
+	visited map[string]bool,
+	resolver worktreeProjectResolver,
+	presencePaths *[]string,
+) error {
+	base := stripVirtualSourceSuffix(job.path)
+
+	if job.err != nil {
+		storedHere := storedByPath[base]
+		if len(storedHere) == 0 {
+			report.Sessions = append(report.Sessions, SessionDiff{
+				Agent:    string(fileAgents[job.path]),
+				FilePath: job.path,
+				Class:    DiffParseError,
+				Reason:   job.err.Error(),
+			})
+			report.Totals.ParseErrors++
+			return nil
+		}
+		for _, s := range storedHere {
+			visited[s.ID] = true
+			report.Sessions = append(report.Sessions, SessionDiff{
+				SessionID:         s.ID,
+				Agent:             s.Agent,
+				FilePath:          job.path,
+				Class:             DiffParseError,
+				Reason:            job.err.Error(),
+				StoredDataVersion: s.DataVersion,
+			})
+			report.Totals.ParseErrors++
+		}
+		return nil
+	}
+
+	for _, pr := range job.results {
+		pw := pendingWrite{
+			sess:        pr.Session,
+			msgs:        pr.Messages,
+			usageEvents: pr.UsageEvents,
+			needsRetry:  job.needsRetry,
+		}
+		prepared, msgs, ok := e.prepareSessionWrite(pw, resolver)
+		id := prepared.ID
+		if !ok {
+			// prepareSessionWrite returns a zero session on veto;
+			// reconstruct the final ID the way applyRemoteRewrites
+			// would have.
+			id = e.idPrefix + pw.sess.ID
+		}
+		stored := storedByID[id]
+		if stored != nil {
+			visited[stored.ID] = true
+		}
+
+		var fields []FieldDiff
+		compare := ok && !pw.needsRetry &&
+			stored != nil && stored.DeletedAt == nil
+		if compare {
+			events := toDBUsageEvents(id, pw.usageEvents)
+			var err error
+			fields, err = e.compareStoredSession(
+				ctx, stored, prepared, msgs, events,
+			)
+			if err != nil {
+				return err
+			}
+		}
+		realDiffs := 0
+		for _, f := range fields {
+			if !f.Informational {
+				realDiffs++
+			}
+		}
+
+		class, reason := classifyParseDiffSession(
+			pw.needsRetry,
+			ok,
+			stored != nil,
+			stored != nil && stored.DeletedAt != nil,
+			stored != nil && stored.DataVersion < db.CurrentDataVersion(),
+			realDiffs,
+		)
+
+		entry := SessionDiff{
+			SessionID: id,
+			Agent:     string(pw.sess.Agent),
+			FilePath:  pw.sess.File.Path,
+			Class:     class,
+			Reason:    reason,
+			Fields:    fields,
+		}
+		if stored != nil {
+			entry.StoredDataVersion = stored.DataVersion
+		}
+
+		switch class {
+		case DiffNeedsRetry:
+			report.Totals.NeedsRetry++
+			report.Sessions = append(report.Sessions, entry)
+		case DiffExcluded:
+			report.Totals.ExcludedByParser++
+			report.Sessions = append(report.Sessions, entry)
+		case DiffNewOnDisk:
+			report.Totals.NewOnDisk++
+			report.Sessions = append(report.Sessions, entry)
+		case DiffPendingResync:
+			// Field diffs are attached for drill-down but never
+			// counted as parser drift (FieldCounts excluded).
+			report.Totals.PendingResync++
+			report.Sessions = append(report.Sessions, entry)
+		case DiffChanged:
+			report.Totals.Changed++
+			for _, f := range fields {
+				if !f.Informational {
+					report.FieldCounts[f.Field]++
+				}
+			}
+			report.Sessions = append(report.Sessions, entry)
+		case DiffIdentical:
+			report.Totals.Identical++
+			if len(fields) > 0 {
+				// Informational-only: counted identical, but
+				// listed so the explanation is visible.
+				report.Totals.InformationalOnly++
+				report.Sessions = append(report.Sessions, entry)
+			}
+		}
+	}
+
+	for _, exID := range e.applyIDPrefixToSessionIDs(
+		job.excludedSessionIDs,
+	) {
+		stored := storedByID[exID]
+		if stored == nil {
+			continue
+		}
+		visited[stored.ID] = true
+		report.Sessions = append(report.Sessions, SessionDiff{
+			SessionID:         stored.ID,
+			Agent:             stored.Agent,
+			FilePath:          job.path,
+			Class:             DiffExcluded,
+			Reason:            "parser exclusion (would delete)",
+			StoredDataVersion: stored.DataVersion,
+		})
+		report.Totals.ExcludedByParser++
+	}
+
+	// needsRetry output is transient and low fidelity; missing
+	// sessions there are expected, not parser drift.
+	if !job.needsRetry {
+		*presencePaths = append(*presencePaths, base)
+	}
+	return nil
+}
+
+// parseDiffPresenceSweep flags stored sessions whose source file
+// parsed cleanly but no longer emits them. Runs after every file has
+// been collected so a session re-emitted from a different file (by
+// ID) is never falsely reported missing.
+func (e *Engine) parseDiffPresenceSweep(
+	report *ParseDiffReport,
+	presencePaths []string,
+	storedByPath map[string][]*db.Session,
+	visited map[string]bool,
+) {
+	for _, base := range presencePaths {
+		for _, s := range storedByPath[base] {
+			if visited[s.ID] {
+				continue
+			}
+			if s.DeletedAt != nil {
+				// Trashed rows are intentionally absent; the final
+				// sweep reports them as skipped/trashed.
+				continue
+			}
+			visited[s.ID] = true
+			report.Sessions = append(report.Sessions, SessionDiff{
+				SessionID:         s.ID,
+				Agent:             s.Agent,
+				FilePath:          derefString(s.FilePath),
+				Class:             DiffChanged,
+				StoredDataVersion: s.DataVersion,
+				Fields: []FieldDiff{{
+					Field:  FieldPresence,
+					Stored: "stored",
+					Parsed: "(not emitted)",
+				}},
+			})
+			report.Totals.Changed++
+			report.FieldCounts[FieldPresence]++
+		}
+	}
+}
+
+// parseDiffSweepStored classifies every stored session that no
+// re-parsed file accounted for. With an explicit agent filter the
+// sweep is restricted to those agents; an unrestricted run accounts
+// for every stored session, including import-only and
+// database-backed agents.
+func parseDiffSweepStored(
+	report *ParseDiffReport,
+	storedSessions []db.Session,
+	resolvedSet map[parser.AgentType]bool,
+	unrestricted bool,
+	cutPaths map[string]bool,
+	visited map[string]bool,
+) {
+	for i := range storedSessions {
+		s := &storedSessions[i]
+		if visited[s.ID] {
+			continue
+		}
+		def, defOK := parser.AgentByPrefix(s.ID)
+		if !unrestricted && (!defOK || !resolvedSet[def.Type]) {
+			continue
+		}
+		host, _ := parser.StripHostPrefix(s.ID)
+
+		var reason string
+		switch {
+		case host != "":
+			reason = "remote session"
+		case s.DeletedAt != nil:
+			reason = "trashed"
+		case defOK && !def.FileBased &&
+			def.EnvVar == "" && def.ConfigKey == "":
+			reason = "import-only agent"
+		case defOK && !def.FileBased:
+			reason = "database-backed agent"
+		case s.FilePath == nil || *s.FilePath == "":
+			reason = "source missing"
+		default:
+			base := stripVirtualSourceSuffix(*s.FilePath)
+			switch {
+			case cutPaths[base]:
+				reason = "not sampled (--limit)"
+			case !statExists(base):
+				reason = "source missing"
+			default:
+				reason = "not discovered"
+			}
+		}
+
+		report.Sessions = append(report.Sessions, SessionDiff{
+			SessionID:         s.ID,
+			Agent:             s.Agent,
+			FilePath:          derefString(s.FilePath),
+			Class:             DiffSkipped,
+			Reason:            reason,
+			StoredDataVersion: s.DataVersion,
+		})
+		report.Totals.Skipped++
+	}
+}
+
+func statExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -1,0 +1,46 @@
+package sync
+
+import (
+	"context"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// ParseDiffOptions configures a report-only re-parse comparison.
+type ParseDiffOptions struct {
+	// Agents restricts the run; empty means every file-based agent with
+	// a DiscoverFunc. Agents without an on-disk source to re-parse
+	// (database-backed or import-only) are rejected with an error.
+	Agents []parser.AgentType
+	// Limit caps the number of source files parsed, newest mtime first
+	// across all agents. 0 means no limit.
+	Limit int
+	// Progress, when non-nil, is called as (filesDone, filesTotal) from
+	// the result collector.
+	Progress func(done, total int)
+}
+
+// NewDiffEngine creates an engine for report-only parse-diff runs. It
+// forces Ephemeral so nothing is persisted (no skip cache, no sync
+// state) and arms the engine's force-parse mode so every discovered
+// file is fully re-parsed regardless of stored size/mtime/data_version
+// state.
+func NewDiffEngine(database *db.DB, cfg EngineConfig) *Engine {
+	cfg.Ephemeral = true
+	return NewEngine(database, cfg)
+}
+
+// ParseDiff re-parses session source files with the current binary,
+// runs the result through the same normalization sync applies, and
+// compares it against the stored rows. It writes nothing: no sessions,
+// no skip cache, no sync state. It holds the engine's sync mutex for
+// the duration.
+func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDiffReport, error) {
+	return &ParseDiffReport{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		DataVersion: db.CurrentDataVersion(),
+		FieldCounts: map[string]int{},
+	}, nil
+}

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -57,6 +57,9 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		DataVersion: db.CurrentDataVersion(),
 		FieldCounts: map[string]int{},
+		// Non-nil so a clean run serializes "sessions": [] rather than
+		// null, which jq pipelines and typed consumers expect.
+		Sessions: []SessionDiff{},
 	}
 	for _, def := range resolved {
 		resolvedSet[def.Type] = true
@@ -72,6 +75,12 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 			files = append(files, def.DiscoverFunc(d)...)
 		}
 	}
+	// DiscoverFunc does not emit the shared-SQLite source for Kiro
+	// (data.sqlite3) or db-mode OpenCode (opencode.db) — normal sync
+	// reaches those through dedicated phases. Synthesize them here so
+	// their sessions are actually re-parsed; processKiro/processOpenCode
+	// fan one db path out to every contained session under forceParse.
+	files = append(files, e.parseDiffDatabaseSources(resolved)...)
 	files = dedupeDiscoveredFiles(files)
 	files = e.filterShadowedLegacyKiroFiles(files)
 
@@ -118,22 +127,29 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 	if opts.Progress != nil {
 		opts.Progress(0, total)
 	}
-	results := e.startWorkers(ctx, files)
+	// A local cancel lets the error-return paths stop the worker pool
+	// instead of parsing every remaining file just to drain it.
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	results := e.startWorkers(runCtx, files)
 	for i := range total {
 		var r syncJob
 		select {
-		case <-ctx.Done():
+		case <-runCtx.Done():
+			cancel()
 			drainResults(results, total-i)
 			return nil, ctx.Err()
 		case r = <-results:
 		}
-		if r.err != nil && ctx.Err() != nil {
+		if r.err != nil && runCtx.Err() != nil {
 			// Workers emit ctx.Err() for files skipped after
 			// cancellation.
+			cancel()
 			drainResults(results, total-i-1)
 			return nil, ctx.Err()
 		}
 		if r.incremental != nil {
+			cancel()
 			drainResults(results, total-i-1)
 			return nil, fmt.Errorf(
 				"parse-diff: internal error: incremental parse of %s "+
@@ -144,6 +160,7 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 			ctx, report, r, fileAgents, storedByID, storedByPath,
 			visited, resolver, &presencePaths,
 		); err != nil {
+			cancel()
 			drainResults(results, total-i-1)
 			return nil, err
 		}
@@ -226,6 +243,50 @@ func resolveParseDiffAgents(
 		}
 	}
 	return out, nil
+}
+
+// parseDiffDatabaseSources synthesizes DiscoveredFile entries for the
+// shared-SQLite agent stores that DiscoverFunc does not emit: Kiro's
+// data.sqlite3 and db-mode OpenCode's opencode.db. processKiro and
+// processOpenCode recognize those base filenames and fan one db path
+// out to every contained session, so routing them through the normal
+// worker loop re-parses every CLI Kiro / db-mode OpenCode session.
+// Without this, those sessions fall to the "not discovered" sweep and
+// an --agent kiro / --agent opencode run would pass while comparing
+// nothing.
+func (e *Engine) parseDiffDatabaseSources(
+	resolved []parser.AgentDef,
+) []parser.DiscoveredFile {
+	var extra []parser.DiscoveredFile
+	for _, def := range resolved {
+		switch def.Type {
+		case parser.AgentKiro:
+			for _, dir := range e.agentDirs[def.Type] {
+				if dir == "" {
+					continue
+				}
+				if dbPath := parser.FindKiroSQLiteDBPath(dir); dbPath != "" {
+					extra = append(extra, parser.DiscoveredFile{
+						Path: dbPath, Agent: parser.AgentKiro,
+					})
+				}
+			}
+		case parser.AgentOpenCode:
+			for _, dir := range e.agentDirs[def.Type] {
+				if dir == "" {
+					continue
+				}
+				src := parser.ResolveOpenCodeSource(dir)
+				if src.Mode == parser.OpenCodeSourceSQLite &&
+					src.DBPath != "" {
+					extra = append(extra, parser.DiscoveredFile{
+						Path: src.DBPath, Agent: parser.AgentOpenCode,
+					})
+				}
+			}
+		}
+	}
+	return extra
 }
 
 // sortAndLimitParseDiffFiles orders files newest-first by source
@@ -403,6 +464,11 @@ func (e *Engine) parseDiffCollectFile(
 					report.FieldCounts[f.Field]++
 				}
 			}
+			report.Sessions = append(report.Sessions, entry)
+		case DiffSkipped:
+			// A re-parsed but trashed session: counted with the rest
+			// of the skipped (not-re-parsed) trashed rows.
+			report.Totals.Skipped++
 			report.Sessions = append(report.Sessions, entry)
 		case DiffIdentical:
 			report.Totals.Identical++

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -247,13 +248,20 @@ func resolveParseDiffAgents(
 
 // parseDiffDatabaseSources synthesizes DiscoveredFile entries for the
 // shared-SQLite agent stores that DiscoverFunc does not emit: Kiro's
-// data.sqlite3 and db-mode OpenCode's opencode.db. processKiro and
+// data.sqlite3 and OpenCode's opencode.db. processKiro and
 // processOpenCode recognize those base filenames and fan one db path
 // out to every contained session, so routing them through the normal
-// worker loop re-parses every CLI Kiro / db-mode OpenCode session.
+// worker loop re-parses every CLI Kiro / DB-backed OpenCode session.
 // Without this, those sessions fall to the "not discovered" sweep and
 // an --agent kiro / --agent opencode run would pass while comparing
 // nothing.
+//
+// The OpenCode db is added whenever it exists, regardless of which
+// source mode ResolveOpenCodeSource picks: normal sync reads
+// opencode.db in storage-mode roots too (openCodePendingSessionIDs),
+// because a migrated root can still hold DB-only legacy sessions.
+// processOpenCode's storage-ID filtering keeps file-backed sessions
+// from being compared twice.
 func (e *Engine) parseDiffDatabaseSources(
 	resolved []parser.AgentDef,
 ) []parser.DiscoveredFile {
@@ -276,11 +284,11 @@ func (e *Engine) parseDiffDatabaseSources(
 				if dir == "" {
 					continue
 				}
-				src := parser.ResolveOpenCodeSource(dir)
-				if src.Mode == parser.OpenCodeSourceSQLite &&
-					src.DBPath != "" {
+				dbPath := filepath.Join(dir, "opencode.db")
+				if info, err := os.Stat(dbPath); err == nil &&
+					!info.IsDir() {
 					extra = append(extra, parser.DiscoveredFile{
-						Path: src.DBPath, Agent: parser.AgentOpenCode,
+						Path: dbPath, Agent: parser.AgentOpenCode,
 					})
 				}
 			}
@@ -479,6 +487,34 @@ func (e *Engine) parseDiffCollectFile(
 				report.Sessions = append(report.Sessions, entry)
 			}
 		}
+	}
+
+	// Per-session parse failures inside a shared SQLite store: the db
+	// itself opened fine, so job.err is nil, but individual sessions
+	// could not be parsed. Each becomes a DiffParseError; matching the
+	// stored row by its virtual source path marks it visited so the
+	// presence sweep does not double-report it as "not emitted".
+	for _, se := range job.sessionErrs {
+		entry := SessionDiff{
+			Agent:    string(fileAgents[job.path]),
+			FilePath: se.virtualPath,
+			Class:    DiffParseError,
+			Reason:   se.err.Error(),
+		}
+		if entry.FilePath == "" {
+			entry.FilePath = job.path
+		}
+		for _, s := range storedByPath[base] {
+			if derefString(s.FilePath) == se.virtualPath {
+				visited[s.ID] = true
+				entry.SessionID = s.ID
+				entry.Agent = s.Agent
+				entry.StoredDataVersion = s.DataVersion
+				break
+			}
+		}
+		report.Sessions = append(report.Sessions, entry)
+		report.Totals.ParseErrors++
 	}
 
 	for _, exID := range e.applyIDPrefixToSessionIDs(

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -1048,14 +1048,23 @@ func usageTotalsDetail(stored, parsed usageTokenTotals) string {
 }
 
 // usageEventKey identifies one event inside the order-insensitive
-// multiset. The DedupKey form still folds in source and model so that
-// attribution drift (e.g. the same event re-tagged to a different
-// model) under a stable dedup key surfaces as a composition diff
-// rather than passing silently.
+// multiset. The DedupKey form still folds in source, model, and
+// parser-owned token fields so that attribution drift (e.g. the same
+// event re-tagged to a different model) or per-event token
+// redistribution under stable dedup keys surfaces as a composition
+// diff rather than passing silently.
 func usageEventKey(ev db.UsageEvent) string {
 	if ev.DedupKey != "" {
 		return strings.Join([]string{
-			"dedup", ev.DedupKey, ev.Source, ev.Model,
+			"dedup",
+			ev.DedupKey,
+			ev.Source,
+			ev.Model,
+			strconv.Itoa(ev.InputTokens),
+			strconv.Itoa(ev.OutputTokens),
+			strconv.Itoa(ev.CacheCreationInputTokens),
+			strconv.Itoa(ev.CacheReadInputTokens),
+			strconv.Itoa(ev.ReasoningTokens),
 		}, "|")
 	}
 	ord := "-"

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -16,6 +16,7 @@ import (
 	"unicode/utf8"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // maxRenderedValueRunes caps rendered string values in FieldDiff;
@@ -34,28 +35,46 @@ func (e *Engine) compareStoredSession(
 ) ([]FieldDiff, error) {
 	diffs := compareSessionFields(stored, prepared)
 
-	// Tier 1: cheap exact fingerprint over per-message model and
-	// token metadata. Equal fingerprints prove models and message
-	// tokens are identical without loading any message rows.
-	storedFP, err := e.db.MessageTokenFingerprint(stored.ID)
+	// Tier 1: two cheap aggregate fingerprints over the stored
+	// messages. The token fingerprint covers per-message model and
+	// token metadata; the content fingerprint covers body length
+	// (sum/max/min), which the token fingerprint does not. Equal
+	// fingerprints prove the messages match on the compared fields
+	// without loading any rows.
+	storedTokenFP, err := e.db.MessageTokenFingerprint(stored.ID)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"parse-diff: message fingerprint for %s: %w",
 			stored.ID, err,
 		)
 	}
-	if messageTokenFingerprintTwin(msgs) != storedFP {
-		// Tier 2: load stored rows and attribute the mismatch to
-		// the contract fields (models, message tokens).
+	storedSum, storedMax, storedMin, err :=
+		e.db.MessageContentFingerprint(stored.ID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parse-diff: content fingerprint for %s: %w",
+			stored.ID, err,
+		)
+	}
+	parsedSum, parsedMax, parsedMin := contentLengthAggregate(msgs)
+
+	tokenFPDiffers := messageTokenFingerprintTwin(msgs) != storedTokenFP
+	contentFPDiffers := storedSum != parsedSum ||
+		storedMax != parsedMax || storedMin != parsedMin
+	if tokenFPDiffers || contentFPDiffers {
+		// Tier 2: load stored rows and attribute the mismatch to the
+		// per-message contract fields. A mismatch that lands on none
+		// of them still yields a fallback diff so a fingerprint
+		// inequality is never reported identical.
 		storedMsgs, err := e.db.GetAllMessages(ctx, stored.ID)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"parse-diff: messages for %s: %w", stored.ID, err,
 			)
 		}
-		diffs = append(
-			diffs, compareMessageMetadata(storedMsgs, msgs)...,
-		)
+		diffs = append(diffs, compareMessageMetadata(
+			storedMsgs, msgs, tokenFPDiffers, contentFPDiffers,
+		)...)
 	}
 
 	storedEvents, err := e.db.GetUsageEvents(ctx, stored.ID)
@@ -66,6 +85,23 @@ func (e *Engine) compareStoredSession(
 	}
 	diffs = append(diffs, compareUsageEvents(storedEvents, events)...)
 	return diffs, nil
+}
+
+// contentLengthAggregate mirrors db.MessageContentFingerprint over the
+// in-memory prepared messages: sum, max, and min of content_length
+// (max/min are 0 for an empty slice, matching the SQL COALESCE).
+func contentLengthAggregate(msgs []db.Message) (sum, max, min int64) {
+	for i, m := range msgs {
+		l := int64(m.ContentLength)
+		sum += l
+		if i == 0 || l > max {
+			max = l
+		}
+		if i == 0 || l < min {
+			min = l
+		}
+	}
+	return sum, max, min
 }
 
 // compareSessionFields compares the session-row contract fields.
@@ -97,6 +133,14 @@ func compareSessionFields(
 	diffs = appendTextFieldDiff(
 		diffs, FieldSessionName,
 		stored.SessionName, prepared.SessionName,
+	)
+	diffs = appendTextFieldDiff(
+		diffs, FieldStartedAt,
+		stored.StartedAt, prepared.StartedAt,
+	)
+	diffs = appendTextFieldDiff(
+		diffs, FieldEndedAt,
+		stored.EndedAt, prepared.EndedAt,
 	)
 
 	if tokenAggregateDiffers(
@@ -131,9 +175,13 @@ func compareSessionFields(
 	}
 
 	// termination_status: NULL and "" are the same pipeline state.
-	// Stored NULL with a parsed value is explained by incremental
-	// appends (UpdateSessionIncremental clears the column to NULL by
-	// design), so it is informational rather than parser drift.
+	// Stored NULL with a parsed value is only explained as pipeline
+	// history for the incremental-append agents: UpdateSessionIncremental
+	// clears the column to NULL by design, and only Claude and Codex
+	// take that path. For full-replace agents a stored NULL means the
+	// writing parser emitted nothing, so newly producing a value is
+	// real parser drift (precisely the new-field detection the tool
+	// exists to catch).
 	ts := derefString(stored.TerminationStatus)
 	tp := derefString(prepared.TerminationStatus)
 	if ts != tp {
@@ -142,13 +190,22 @@ func compareSessionFields(
 			Stored: renderNullableScalar(ts),
 			Parsed: renderNullableScalar(tp),
 		}
-		if ts == "" {
+		if ts == "" && usesIncrementalAppend(prepared.Agent) {
 			d.Informational = true
 			d.Detail = "incremental-append history"
 		}
 		diffs = append(diffs, d)
 	}
 	return diffs
+}
+
+// usesIncrementalAppend reports whether an agent's sync path can clear
+// termination_status to NULL via UpdateSessionIncremental. Only the
+// JSONL-tail agents (Claude, Codex) take that path; see
+// tryIncrementalJSONL call sites in engine.go.
+func usesIncrementalAppend(agent string) bool {
+	return agent == string(parser.AgentClaude) ||
+		agent == string(parser.AgentCodex)
 }
 
 // tokenAggregateDiffers compares a session token aggregate as a
@@ -268,17 +325,20 @@ func messageTokenFingerprintTwin(msgs []db.Message) string {
 	return b.String()
 }
 
-// compareMessageMetadata is the tier-2 per-message comparison. Both
+// compareMessageMetadata is the tier-2 per-message comparison, run
+// when either tier-1 fingerprint (token or content) mismatched. Both
 // slices are aligned by ordinal value and only the overlap is
-// compared; a length mismatch is message_count's job.
+// compared; a length mismatch is message_count's job. The two
+// FP-differ flags guarantee a non-empty result: if the fingerprints
+// proved inequality but none of the attributed fields differ on the
+// overlap, a fallback diff is emitted so the session never classifies
+// identical after its own fingerprint proved otherwise.
 func compareMessageMetadata(
 	storedMsgs, parsedMsgs []db.Message,
+	tokenFPDiffers, contentFPDiffers bool,
 ) []FieldDiff {
 	pairs := alignByOrdinal(storedMsgs, parsedMsgs)
 	n := len(pairs)
-	if n == 0 {
-		return nil
-	}
 
 	var (
 		modelDiffs       int
@@ -290,6 +350,14 @@ func compareMessageMetadata(
 		firstTokenOrd    int
 		firstTokenStored string
 		firstTokenParsed string
+
+		contentDiffs     int
+		firstContentOrd  int
+		firstContentSize string
+
+		metaDiffs     int
+		firstMetaOrd  int
+		firstMetaWhat string
 	)
 	for _, p := range pairs {
 		sModel := db.SanitizeUTF8(p.stored.Model)
@@ -309,6 +377,23 @@ func compareMessageMetadata(
 				firstTokenParsed = renderMessageTokenState(p.parsed)
 			}
 			tokenDiffs++
+		}
+		if p.stored.ContentLength != p.parsed.ContentLength {
+			if contentDiffs == 0 {
+				firstContentOrd = p.stored.Ordinal
+				firstContentSize = fmt.Sprintf(
+					"%d -> %d bytes",
+					p.stored.ContentLength, p.parsed.ContentLength,
+				)
+			}
+			contentDiffs++
+		}
+		if what := messageMetadataDiff(p.stored, p.parsed); what != "" {
+			if metaDiffs == 0 {
+				firstMetaOrd = p.stored.Ordinal
+				firstMetaWhat = what
+			}
+			metaDiffs++
 		}
 	}
 
@@ -337,7 +422,93 @@ func compareMessageMetadata(
 			),
 		})
 	}
+	if contentDiffs > 0 {
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldMessageContent,
+			Stored: "see detail",
+			Parsed: "see detail",
+			Detail: fmt.Sprintf(
+				"%d/%d messages differ; first at ordinal %d: %s",
+				contentDiffs, n, firstContentOrd, firstContentSize,
+			),
+		})
+	}
+	if metaDiffs > 0 {
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldMessageMetadata,
+			Stored: "see detail",
+			Parsed: "see detail",
+			Detail: fmt.Sprintf(
+				"%d/%d messages differ; first at ordinal %d: %s",
+				metaDiffs, n, firstMetaOrd, firstMetaWhat,
+			),
+		})
+	}
+
+	// The fingerprints proved inequality but nothing on the aligned
+	// overlap accounts for it (e.g. an equal-count ordinal-set shift,
+	// or content drift that only changed a non-overlapping message).
+	// Emit a fallback so the session is never reported identical.
+	if len(diffs) == 0 && (tokenFPDiffers || contentFPDiffers) {
+		which := "content"
+		if tokenFPDiffers {
+			which = "token/metadata"
+		}
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldMessageMetadata,
+			Stored: "fingerprint",
+			Parsed: "fingerprint",
+			Detail: "per-message " + which +
+				" fingerprint differs but no aligned-ordinal field " +
+				"accounts for it (likely an ordinal-set change)",
+		})
+	}
 	return diffs
+}
+
+// messageMetadataDiff reports the first differing per-message field
+// among the fingerprint-covered identity columns that models/tokens do
+// not separately surface: role, timestamp, source-tracking ids, and
+// the sidechain/compact-boundary flags. Returns "" when they match.
+func messageMetadataDiff(stored, parsed db.Message) string {
+	switch {
+	case db.SanitizeUTF8(stored.Role) != db.SanitizeUTF8(parsed.Role):
+		return fmt.Sprintf("role %q -> %q", stored.Role, parsed.Role)
+	case stored.Timestamp != parsed.Timestamp:
+		return fmt.Sprintf(
+			"timestamp %q -> %q", stored.Timestamp, parsed.Timestamp,
+		)
+	case stored.IsSidechain != parsed.IsSidechain:
+		return fmt.Sprintf(
+			"is_sidechain %t -> %t",
+			stored.IsSidechain, parsed.IsSidechain,
+		)
+	case stored.IsCompactBoundary != parsed.IsCompactBoundary:
+		return fmt.Sprintf(
+			"is_compact_boundary %t -> %t",
+			stored.IsCompactBoundary, parsed.IsCompactBoundary,
+		)
+	case db.SanitizeUTF8(stored.SourceType) !=
+		db.SanitizeUTF8(parsed.SourceType):
+		return "source_type differs"
+	case db.SanitizeUTF8(stored.SourceSubtype) !=
+		db.SanitizeUTF8(parsed.SourceSubtype):
+		return "source_subtype differs"
+	case db.SanitizeUTF8(stored.SourceUUID) !=
+		db.SanitizeUTF8(parsed.SourceUUID):
+		return "source_uuid differs"
+	case db.SanitizeUTF8(stored.SourceParentUUID) !=
+		db.SanitizeUTF8(parsed.SourceParentUUID):
+		return "source_parent_uuid differs"
+	case db.SanitizeUTF8(stored.ClaudeMessageID) !=
+		db.SanitizeUTF8(parsed.ClaudeMessageID):
+		return "claude_message_id differs"
+	case db.SanitizeUTF8(stored.ClaudeRequestID) !=
+		db.SanitizeUTF8(parsed.ClaudeRequestID):
+		return "claude_request_id differs"
+	default:
+		return ""
+	}
 }
 
 type ordinalPair struct {
@@ -481,10 +652,15 @@ func usageTotalsDetail(stored, parsed usageTokenTotals) string {
 }
 
 // usageEventKey identifies one event inside the order-insensitive
-// multiset: DedupKey when present, otherwise the full content tuple.
+// multiset. The DedupKey form still folds in source and model so that
+// attribution drift (e.g. the same event re-tagged to a different
+// model) under a stable dedup key surfaces as a composition diff
+// rather than passing silently.
 func usageEventKey(ev db.UsageEvent) string {
 	if ev.DedupKey != "" {
-		return "dedup:" + ev.DedupKey
+		return strings.Join([]string{
+			"dedup", ev.DedupKey, ev.Source, ev.Model,
+		}, "|")
 	}
 	ord := "-"
 	if ev.MessageOrdinal != nil {

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -1,0 +1,634 @@
+package sync
+
+// Parse-diff comparator: compares one freshly parsed, sync-normalized
+// session against its stored SQLite rows and emits FieldDiff entries
+// for the contract fields only. All comparisons mirror the
+// normalization the write path applies (nil <-> "" equivalence,
+// SanitizeUTF8, TokenPresence inference) so that an unchanged parser
+// produces zero diffs against rows it wrote itself.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// maxRenderedValueRunes caps rendered string values in FieldDiff;
+// longer values are truncated with the full lengths noted in Detail.
+const maxRenderedValueRunes = 80
+
+// compareStoredSession compares the prepared (normalized) parse output
+// against the stored session row, lazily reading message and usage
+// event rows from the archive only when needed.
+func (e *Engine) compareStoredSession(
+	ctx context.Context,
+	stored *db.Session,
+	prepared db.Session,
+	msgs []db.Message,
+	events []db.UsageEvent,
+) ([]FieldDiff, error) {
+	diffs := compareSessionFields(stored, prepared)
+
+	// Tier 1: cheap exact fingerprint over per-message model and
+	// token metadata. Equal fingerprints prove models and message
+	// tokens are identical without loading any message rows.
+	storedFP, err := e.db.MessageTokenFingerprint(stored.ID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parse-diff: message fingerprint for %s: %w",
+			stored.ID, err,
+		)
+	}
+	if messageTokenFingerprintTwin(msgs) != storedFP {
+		// Tier 2: load stored rows and attribute the mismatch to
+		// the contract fields (models, message tokens).
+		storedMsgs, err := e.db.GetAllMessages(ctx, stored.ID)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"parse-diff: messages for %s: %w", stored.ID, err,
+			)
+		}
+		diffs = append(
+			diffs, compareMessageMetadata(storedMsgs, msgs)...,
+		)
+	}
+
+	storedEvents, err := e.db.GetUsageEvents(ctx, stored.ID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parse-diff: usage events for %s: %w", stored.ID, err,
+		)
+	}
+	diffs = append(diffs, compareUsageEvents(storedEvents, events)...)
+	return diffs, nil
+}
+
+// compareSessionFields compares the session-row contract fields.
+// Pure function over the two rows; no database access.
+func compareSessionFields(
+	stored *db.Session, prepared db.Session,
+) []FieldDiff {
+	var diffs []FieldDiff
+
+	if stored.MessageCount != prepared.MessageCount {
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldMessageCount,
+			Stored: strconv.Itoa(stored.MessageCount),
+			Parsed: strconv.Itoa(prepared.MessageCount),
+		})
+	}
+	if stored.UserMessageCount != prepared.UserMessageCount {
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldUserMessageCount,
+			Stored: strconv.Itoa(stored.UserMessageCount),
+			Parsed: strconv.Itoa(prepared.UserMessageCount),
+		})
+	}
+
+	diffs = appendTextFieldDiff(
+		diffs, FieldFirstMessage,
+		stored.FirstMessage, prepared.FirstMessage,
+	)
+	diffs = appendTextFieldDiff(
+		diffs, FieldSessionName,
+		stored.SessionName, prepared.SessionName,
+	)
+
+	if tokenAggregateDiffers(
+		stored.HasTotalOutputTokens, stored.TotalOutputTokens,
+		prepared.HasTotalOutputTokens, prepared.TotalOutputTokens,
+	) {
+		diffs = append(diffs, FieldDiff{
+			Field: FieldTotalOutputTokens,
+			Stored: renderTokenAggregate(
+				stored.HasTotalOutputTokens, stored.TotalOutputTokens,
+			),
+			Parsed: renderTokenAggregate(
+				prepared.HasTotalOutputTokens,
+				prepared.TotalOutputTokens,
+			),
+		})
+	}
+	if tokenAggregateDiffers(
+		stored.HasPeakContextTokens, stored.PeakContextTokens,
+		prepared.HasPeakContextTokens, prepared.PeakContextTokens,
+	) {
+		diffs = append(diffs, FieldDiff{
+			Field: FieldPeakContextTokens,
+			Stored: renderTokenAggregate(
+				stored.HasPeakContextTokens, stored.PeakContextTokens,
+			),
+			Parsed: renderTokenAggregate(
+				prepared.HasPeakContextTokens,
+				prepared.PeakContextTokens,
+			),
+		})
+	}
+
+	// termination_status: NULL and "" are the same pipeline state.
+	// Stored NULL with a parsed value is explained by incremental
+	// appends (UpdateSessionIncremental clears the column to NULL by
+	// design), so it is informational rather than parser drift.
+	ts := derefString(stored.TerminationStatus)
+	tp := derefString(prepared.TerminationStatus)
+	if ts != tp {
+		d := FieldDiff{
+			Field:  FieldTerminationStatus,
+			Stored: renderNullableScalar(ts),
+			Parsed: renderNullableScalar(tp),
+		}
+		if ts == "" {
+			d.Informational = true
+			d.Detail = "incremental-append history"
+		}
+		diffs = append(diffs, d)
+	}
+	return diffs
+}
+
+// tokenAggregateDiffers compares a session token aggregate as a
+// (value, has-flag) unit. A coverage-flag flip is a real difference
+// even when the numeric values match; values are only meaningful
+// when coverage is present on both sides.
+func tokenAggregateDiffers(
+	storedHas bool, storedVal int,
+	parsedHas bool, parsedVal int,
+) bool {
+	if storedHas != parsedHas {
+		return true
+	}
+	return storedHas && storedVal != parsedVal
+}
+
+func renderTokenAggregate(has bool, v int) string {
+	if !has {
+		return "absent"
+	}
+	return strconv.Itoa(v)
+}
+
+func renderNullableScalar(s string) string {
+	if s == "" {
+		return "(null)"
+	}
+	return s
+}
+
+// appendTextFieldDiff compares a nullable text column. NULL and ""
+// are equivalent (toDBSession and db.ParsedSessionName map "" to
+// nil), and both sides pass through SanitizeUTF8 the way the PG-push
+// fingerprint readers do.
+func appendTextFieldDiff(
+	diffs []FieldDiff, field string, stored, parsed *string,
+) []FieldDiff {
+	sv := db.SanitizeUTF8(derefString(stored))
+	pv := db.SanitizeUTF8(derefString(parsed))
+	if sv == pv {
+		return diffs
+	}
+	d := FieldDiff{
+		Field:  field,
+		Stored: renderTextValue(stored, sv),
+		Parsed: renderTextValue(parsed, pv),
+	}
+	var notes []string
+	if utf8.RuneCountInString(sv) > maxRenderedValueRunes {
+		notes = append(notes, fmt.Sprintf(
+			"stored %d runes", utf8.RuneCountInString(sv),
+		))
+	}
+	if utf8.RuneCountInString(pv) > maxRenderedValueRunes {
+		notes = append(notes, fmt.Sprintf(
+			"parsed %d runes", utf8.RuneCountInString(pv),
+		))
+	}
+	d.Detail = strings.Join(notes, "; ")
+	return append(diffs, d)
+}
+
+func renderTextValue(ptr *string, sanitized string) string {
+	if ptr == nil {
+		return "(null)"
+	}
+	return truncateRunes(sanitized, maxRenderedValueRunes)
+}
+
+func truncateRunes(s string, limit int) string {
+	if utf8.RuneCountInString(s) <= limit {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:limit]) + "..."
+}
+
+// messageTokenFingerprintTwin is the in-memory twin of
+// db.MessageTokenFingerprint (internal/db/messages.go): identical
+// field order, identical SanitizeUTF8 application, identical format
+// string, over a slice ordered by ordinal ascending. Any drift
+// between the two breaks the tier-1 fast path, so a white-box test
+// pins them against each other through the real write pipeline.
+func messageTokenFingerprintTwin(msgs []db.Message) string {
+	ordered := make([]db.Message, len(msgs))
+	copy(ordered, msgs)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Ordinal < ordered[j].Ordinal
+	})
+
+	var b strings.Builder
+	for _, m := range ordered {
+		model := db.SanitizeUTF8(m.Model)
+		tokenUsage := db.SanitizeUTF8(string(m.TokenUsage))
+		claudeMsgID := db.SanitizeUTF8(m.ClaudeMessageID)
+		claudeReqID := db.SanitizeUTF8(m.ClaudeRequestID)
+		srcType := db.SanitizeUTF8(m.SourceType)
+		srcSubtype := db.SanitizeUTF8(m.SourceSubtype)
+		srcUUID := db.SanitizeUTF8(m.SourceUUID)
+		srcParentUUID := db.SanitizeUTF8(m.SourceParentUUID)
+		fmt.Fprintf(&b,
+			"%d|%d:%s|%d:%s|%d|%d|%t|%t|%s|%s|"+
+				"%d:%s|%d:%s|%d:%s|%d:%s|%t|%t;",
+			m.Ordinal,
+			len(model), model,
+			len(tokenUsage), tokenUsage,
+			m.ContextTokens, m.OutputTokens,
+			m.HasContextTokens, m.HasOutputTokens,
+			claudeMsgID, claudeReqID,
+			len(srcType), srcType,
+			len(srcSubtype), srcSubtype,
+			len(srcUUID), srcUUID,
+			len(srcParentUUID), srcParentUUID,
+			m.IsSidechain, m.IsCompactBoundary,
+		)
+	}
+	return b.String()
+}
+
+// compareMessageMetadata is the tier-2 per-message comparison. Both
+// slices are aligned by ordinal value and only the overlap is
+// compared; a length mismatch is message_count's job.
+func compareMessageMetadata(
+	storedMsgs, parsedMsgs []db.Message,
+) []FieldDiff {
+	pairs := alignByOrdinal(storedMsgs, parsedMsgs)
+	n := len(pairs)
+	if n == 0 {
+		return nil
+	}
+
+	var (
+		modelDiffs       int
+		firstModelOrd    int
+		firstModelStored string
+		firstModelParsed string
+
+		tokenDiffs       int
+		firstTokenOrd    int
+		firstTokenStored string
+		firstTokenParsed string
+	)
+	for _, p := range pairs {
+		sModel := db.SanitizeUTF8(p.stored.Model)
+		pModel := db.SanitizeUTF8(p.parsed.Model)
+		if sModel != pModel {
+			if modelDiffs == 0 {
+				firstModelOrd = p.stored.Ordinal
+				firstModelStored = sModel
+				firstModelParsed = pModel
+			}
+			modelDiffs++
+		}
+		if messageTokensDiffer(p.stored, p.parsed) {
+			if tokenDiffs == 0 {
+				firstTokenOrd = p.stored.Ordinal
+				firstTokenStored = renderMessageTokenState(p.stored)
+				firstTokenParsed = renderMessageTokenState(p.parsed)
+			}
+			tokenDiffs++
+		}
+	}
+
+	var diffs []FieldDiff
+	if modelDiffs > 0 {
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldModels,
+			Stored: renderModelSet(pairs, true),
+			Parsed: renderModelSet(pairs, false),
+			Detail: fmt.Sprintf(
+				"%d/%d messages differ; first at ordinal %d: %s -> %s",
+				modelDiffs, n, firstModelOrd,
+				renderNullableScalar(firstModelStored),
+				renderNullableScalar(firstModelParsed),
+			),
+		})
+	}
+	if tokenDiffs > 0 {
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldMessageTokens,
+			Stored: firstTokenStored,
+			Parsed: firstTokenParsed,
+			Detail: fmt.Sprintf(
+				"%d/%d messages differ; first at ordinal %d",
+				tokenDiffs, n, firstTokenOrd,
+			),
+		})
+	}
+	return diffs
+}
+
+type ordinalPair struct {
+	stored db.Message
+	parsed db.Message
+}
+
+// alignByOrdinal intersects two message slices on ordinal value.
+// Both inputs are sorted by ordinal (defensively re-sorted here) and
+// ordinals within a session are unique.
+func alignByOrdinal(stored, parsed []db.Message) []ordinalPair {
+	s := make([]db.Message, len(stored))
+	copy(s, stored)
+	sort.SliceStable(s, func(i, j int) bool {
+		return s[i].Ordinal < s[j].Ordinal
+	})
+	p := make([]db.Message, len(parsed))
+	copy(p, parsed)
+	sort.SliceStable(p, func(i, j int) bool {
+		return p[i].Ordinal < p[j].Ordinal
+	})
+
+	var pairs []ordinalPair
+	i, j := 0, 0
+	for i < len(s) && j < len(p) {
+		switch {
+		case s[i].Ordinal < p[j].Ordinal:
+			i++
+		case s[i].Ordinal > p[j].Ordinal:
+			j++
+		default:
+			pairs = append(pairs, ordinalPair{
+				stored: s[i], parsed: p[j],
+			})
+			i++
+			j++
+		}
+	}
+	return pairs
+}
+
+// messageTokensDiffer compares the per-message token contract
+// fields: raw token_usage payload, context/output values, and
+// coverage via Message.TokenPresence semantics (which preserve
+// legacy-row inference).
+func messageTokensDiffer(stored, parsed db.Message) bool {
+	if db.SanitizeUTF8(string(stored.TokenUsage)) !=
+		db.SanitizeUTF8(string(parsed.TokenUsage)) {
+		return true
+	}
+	if stored.ContextTokens != parsed.ContextTokens ||
+		stored.OutputTokens != parsed.OutputTokens {
+		return true
+	}
+	sCtx, sOut := stored.TokenPresence()
+	pCtx, pOut := parsed.TokenPresence()
+	return sCtx != pCtx || sOut != pOut
+}
+
+func renderMessageTokenState(m db.Message) string {
+	hasCtx, hasOut := m.TokenPresence()
+	ctx := "absent"
+	if hasCtx {
+		ctx = strconv.Itoa(m.ContextTokens)
+	}
+	out := "absent"
+	if hasOut {
+		out = strconv.Itoa(m.OutputTokens)
+	}
+	return fmt.Sprintf(
+		"context=%s output=%s usage_bytes=%d",
+		ctx, out, len(m.TokenUsage),
+	)
+}
+
+// renderModelSet renders the distinct sorted models of one side of
+// the aligned pairs.
+func renderModelSet(pairs []ordinalPair, storedSide bool) string {
+	set := map[string]bool{}
+	for _, p := range pairs {
+		m := p.parsed.Model
+		if storedSide {
+			m = p.stored.Model
+		}
+		set[db.SanitizeUTF8(m)] = true
+	}
+	models := make([]string, 0, len(set))
+	for m := range set {
+		if m == "" {
+			m = "(none)"
+		}
+		models = append(models, m)
+	}
+	sort.Strings(models)
+	return strings.Join(models, ", ")
+}
+
+// usageTokenTotals aggregates the per-token-class sums of a usage
+// event set. Cost columns are pricing enrichment, not parser output,
+// and are deliberately excluded.
+type usageTokenTotals struct {
+	input         int
+	output        int
+	cacheCreation int
+	cacheRead     int
+	reasoning     int
+}
+
+func sumUsageTokenTotals(events []db.UsageEvent) usageTokenTotals {
+	var t usageTokenTotals
+	for _, ev := range events {
+		t.input += ev.InputTokens
+		t.output += ev.OutputTokens
+		t.cacheCreation += ev.CacheCreationInputTokens
+		t.cacheRead += ev.CacheReadInputTokens
+		t.reasoning += ev.ReasoningTokens
+	}
+	return t
+}
+
+func (t usageTokenTotals) render() string {
+	return fmt.Sprintf(
+		"input=%d output=%d cache_creation=%d cache_read=%d reasoning=%d",
+		t.input, t.output, t.cacheCreation, t.cacheRead, t.reasoning,
+	)
+}
+
+func usageTotalsDetail(stored, parsed usageTokenTotals) string {
+	var parts []string
+	add := func(name string, s, p int) {
+		if s != p {
+			parts = append(parts, fmt.Sprintf("%s %d -> %d", name, s, p))
+		}
+	}
+	add("input", stored.input, parsed.input)
+	add("output", stored.output, parsed.output)
+	add("cache_creation", stored.cacheCreation, parsed.cacheCreation)
+	add("cache_read", stored.cacheRead, parsed.cacheRead)
+	add("reasoning", stored.reasoning, parsed.reasoning)
+	return strings.Join(parts, "; ")
+}
+
+// usageEventKey identifies one event inside the order-insensitive
+// multiset: DedupKey when present, otherwise the full content tuple.
+func usageEventKey(ev db.UsageEvent) string {
+	if ev.DedupKey != "" {
+		return "dedup:" + ev.DedupKey
+	}
+	ord := "-"
+	if ev.MessageOrdinal != nil {
+		ord = strconv.Itoa(*ev.MessageOrdinal)
+	}
+	return strings.Join([]string{
+		"tuple",
+		ev.Source,
+		ev.Model,
+		strconv.Itoa(ev.InputTokens),
+		strconv.Itoa(ev.OutputTokens),
+		strconv.Itoa(ev.CacheCreationInputTokens),
+		strconv.Itoa(ev.CacheReadInputTokens),
+		strconv.Itoa(ev.ReasoningTokens),
+		ev.OccurredAt,
+		ord,
+	}, "|")
+}
+
+func usageEventMultiset(events []db.UsageEvent) map[string]int {
+	set := make(map[string]int, len(events))
+	for _, ev := range events {
+		set[usageEventKey(ev)]++
+	}
+	return set
+}
+
+func multisetsEqual(a, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// firstDifferingUsageKey returns the lexicographically smallest key
+// whose multiplicity differs between the two multisets.
+func firstDifferingUsageKey(a, b map[string]int) string {
+	var keys []string
+	seen := map[string]bool{}
+	for k := range a {
+		if a[k] != b[k] {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	for k := range b {
+		if !seen[k] && a[k] != b[k] {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+	return keys[0]
+}
+
+// compareUsageEvents compares the two event sets as order-insensitive
+// multisets. Stored rows come back ordered by (occurred_at, id) while
+// in-memory events carry no ids, so ordering must not matter.
+func compareUsageEvents(
+	storedEvents, parsedEvents []db.UsageEvent,
+) []FieldDiff {
+	if len(storedEvents) == 0 && len(parsedEvents) == 0 {
+		return nil
+	}
+
+	storedSet := usageEventMultiset(storedEvents)
+	parsedSet := usageEventMultiset(parsedEvents)
+	storedTotals := sumUsageTokenTotals(storedEvents)
+	parsedTotals := sumUsageTokenTotals(parsedEvents)
+
+	countDiff := len(storedEvents) != len(parsedEvents)
+	totalsDiff := storedTotals != parsedTotals
+	compositionDiff := !multisetsEqual(storedSet, parsedSet)
+	if !countDiff && !totalsDiff && !compositionDiff {
+		return nil
+	}
+
+	var diffs []FieldDiff
+	if countDiff {
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldUsageEventCount,
+			Stored: strconv.Itoa(len(storedEvents)),
+			Parsed: strconv.Itoa(len(parsedEvents)),
+		})
+	}
+	switch {
+	case totalsDiff:
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldUsageEventTotals,
+			Stored: storedTotals.render(),
+			Parsed: parsedTotals.render(),
+			Detail: usageTotalsDetail(storedTotals, parsedTotals),
+		})
+	case !countDiff:
+		// Composition drift with equal cardinality and token
+		// totals (e.g. a model or timestamp attribution change).
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldUsageEventTotals,
+			Stored: storedTotals.render(),
+			Parsed: parsedTotals.render(),
+			Detail: "event composition differs; token totals are equal; " +
+				"first differing event: " +
+				firstDifferingUsageKey(storedSet, parsedSet),
+		})
+	}
+	return diffs
+}
+
+// classifyParseDiffSession resolves the classification precedence for
+// one parsed session. Pure function so the precedence is unit
+// testable; the caller is responsible for totals and field counts.
+//   - needsRetry: the parse was flagged transient low-fidelity.
+//   - prepared: prepareSessionWrite accepted the session (false means
+//     the OpenCode archive-preserve veto fired).
+//   - hasStored / storedTrashed: archive row state.
+//   - pendingResync: stored data_version is behind the binary.
+//   - realDiffs: count of non-informational field diffs.
+func classifyParseDiffSession(
+	needsRetry, prepared, hasStored, storedTrashed,
+	pendingResync bool,
+	realDiffs int,
+) (DiffClass, string) {
+	switch {
+	case needsRetry:
+		return DiffNeedsRetry,
+			"transient low-fidelity parse; differences expected"
+	case !prepared:
+		return DiffExcluded, "archive-preserved"
+	case !hasStored:
+		return DiffNewOnDisk, ""
+	case storedTrashed:
+		return DiffExcluded, "trashed in archive"
+	case pendingResync:
+		return DiffPendingResync, ""
+	case realDiffs > 0:
+		return DiffChanged, ""
+	default:
+		return DiffIdentical, ""
+	}
+}

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -9,6 +9,7 @@ package sync
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"sort"
 	"strconv"
@@ -35,13 +36,15 @@ func (e *Engine) compareStoredSession(
 ) ([]FieldDiff, error) {
 	diffs := compareSessionFields(stored, prepared)
 
-	// Tier 1: three cheap fingerprints over the stored messages. The
-	// token fingerprint covers per-message model and token metadata;
-	// the role/time fingerprint covers per-message role and timestamp,
-	// which the token fingerprint deliberately excludes (its shape is
-	// shared with the PG push fast-path); the content fingerprint
-	// covers body length (sum/max/min). Equal fingerprints prove the
-	// messages match on the compared fields without loading any rows.
+	// Tier 1: three exact ordered fingerprints over the stored
+	// messages. The token fingerprint covers per-message model and
+	// token metadata; the role/time fingerprint covers per-message
+	// role and timestamp, which the token fingerprint deliberately
+	// excludes (its shape is shared with the PG push fast-path); the
+	// content fingerprint covers per-message content_length and a
+	// body hash. Equal fingerprints prove the messages match on the
+	// compared fields without materializing full rows; only a
+	// mismatch loads them for attribution.
 	storedTokenFP, err := e.db.MessageTokenFingerprint(stored.ID)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -56,21 +59,19 @@ func (e *Engine) compareStoredSession(
 			stored.ID, err,
 		)
 	}
-	storedSum, storedMax, storedMin, err :=
-		e.db.MessageContentFingerprint(stored.ID)
+	storedContentFP, err := e.db.MessageContentHashFingerprint(stored.ID)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"parse-diff: content fingerprint for %s: %w",
 			stored.ID, err,
 		)
 	}
-	parsedSum, parsedMax, parsedMin := contentLengthAggregate(msgs)
 
 	tokenFPDiffers := messageTokenFingerprintTwin(msgs) != storedTokenFP
 	roleTimeFPDiffers :=
 		messageRoleTimeFingerprintTwin(msgs) != storedRoleTimeFP
-	contentFPDiffers := storedSum != parsedSum ||
-		storedMax != parsedMax || storedMin != parsedMin
+	contentFPDiffers :=
+		messageContentHashFingerprintTwin(msgs) != storedContentFP
 	if tokenFPDiffers || roleTimeFPDiffers || contentFPDiffers {
 		// Tier 2: load stored rows and attribute the mismatch to the
 		// per-message contract fields. A mismatch that lands on none
@@ -96,23 +97,6 @@ func (e *Engine) compareStoredSession(
 	}
 	diffs = append(diffs, compareUsageEvents(storedEvents, events)...)
 	return diffs, nil
-}
-
-// contentLengthAggregate mirrors db.MessageContentFingerprint over the
-// in-memory prepared messages: sum, max, and min of content_length
-// (max/min are 0 for an empty slice, matching the SQL COALESCE).
-func contentLengthAggregate(msgs []db.Message) (sum, max, min int64) {
-	for i, m := range msgs {
-		l := int64(m.ContentLength)
-		sum += l
-		if i == 0 || l > max {
-			max = l
-		}
-		if i == 0 || l < min {
-			min = l
-		}
-	}
-	return sum, max, min
 }
 
 // compareSessionFields compares the session-row contract fields.
@@ -360,6 +344,27 @@ func messageRoleTimeFingerprintTwin(msgs []db.Message) string {
 	return b.String()
 }
 
+// messageContentHashFingerprintTwin is the in-memory twin of
+// db.MessageContentHashFingerprint (internal/db/messages.go):
+// identical field order, identical sanitization, identical format
+// string, over a slice ordered by ordinal ascending. Like the other
+// twins, parity with the DB query is pinned by a white-box test
+// through the real write pipeline.
+func messageContentHashFingerprintTwin(msgs []db.Message) string {
+	ordered := make([]db.Message, len(msgs))
+	copy(ordered, msgs)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Ordinal < ordered[j].Ordinal
+	})
+
+	var b strings.Builder
+	for _, m := range ordered {
+		sum := sha256.Sum256([]byte(db.SanitizeUTF8(m.Content)))
+		fmt.Fprintf(&b, "%d|%d|%x;", m.Ordinal, m.ContentLength, sum)
+	}
+	return b.String()
+}
+
 // compareMessageMetadata is the tier-2 per-message comparison, run
 // when any tier-1 fingerprint (token, role/time, or content)
 // mismatched. tokenFPDiffers carries the token and role/time
@@ -416,12 +421,11 @@ func compareMessageMetadata(
 			}
 			tokenDiffs++
 		}
-		if p.stored.ContentLength != p.parsed.ContentLength {
+		if messageContentDiffers(p.stored, p.parsed) {
 			if contentDiffs == 0 {
 				firstContentOrd = p.stored.Ordinal
-				firstContentSize = fmt.Sprintf(
-					"%d -> %d bytes",
-					p.stored.ContentLength, p.parsed.ContentLength,
+				firstContentSize = renderContentChange(
+					p.stored, p.parsed,
 				)
 			}
 			contentDiffs++
@@ -502,6 +506,31 @@ func compareMessageMetadata(
 		})
 	}
 	return diffs
+}
+
+// messageContentDiffers compares the per-message content contract:
+// the content_length column and the body itself (sanitized like the
+// fingerprint), so equal-length rewrites still attribute to
+// message_content instead of falling through to the generic
+// fingerprint-mismatch diff.
+func messageContentDiffers(stored, parsed db.Message) bool {
+	return stored.ContentLength != parsed.ContentLength ||
+		db.SanitizeUTF8(stored.Content) != db.SanitizeUTF8(parsed.Content)
+}
+
+// renderContentChange describes the first content change. Bodies are
+// never echoed (they can be huge and are exactly what the terminal
+// renderer must not leak); only sizes are reported.
+func renderContentChange(stored, parsed db.Message) string {
+	if stored.ContentLength != parsed.ContentLength {
+		return fmt.Sprintf(
+			"%d -> %d bytes",
+			stored.ContentLength, parsed.ContentLength,
+		)
+	}
+	return fmt.Sprintf(
+		"body differs at equal length (%d bytes)", stored.ContentLength,
+	)
 }
 
 // messageMetadataDiff reports the first differing per-message field

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -95,7 +95,7 @@ func (e *Engine) compareStoredSession(
 			stored.ID, err,
 		)
 	}
-	storedToolFP, err := e.db.ToolCallFingerprint(stored.ID)
+	storedToolFP, err := e.db.ToolCallParseDiffFingerprint(stored.ID)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"parse-diff: tool-call fingerprint for %s: %w",
@@ -111,7 +111,7 @@ func (e *Engine) compareStoredSession(
 	flagsFPDiffers :=
 		messageFlagsFingerprintTwin(msgs) != storedFlagsFP
 	toolFPDiffers :=
-		toolCallFingerprintTwin(msgs) != storedToolFP
+		toolCallParseDiffFingerprintTwin(msgs) != storedToolFP
 	if tokenFPDiffers || roleTimeFPDiffers || contentFPDiffers ||
 		flagsFPDiffers || toolFPDiffers {
 		// Tier 2: load stored rows (with tool calls attached) and
@@ -544,14 +544,14 @@ func messageFlagsFingerprintTwin(msgs []db.Message) string {
 	return b.String()
 }
 
-// toolCallFingerprintTwin is the in-memory twin of
-// db.ToolCallFingerprint (internal/db/messages.go). It iterates messages
+// toolCallParseDiffFingerprintTwin is the in-memory twin of
+// db.ToolCallParseDiffFingerprint (internal/db/messages.go). It iterates messages
 // in ordinal order and, within each, its tool calls in array order --
 // the same (ordinal, insertion) order the DB query reproduces via
 // ORDER BY m.ordinal, tc.id. Field order, sanitization, and the format
 // string match the query exactly; parity is pinned by a white-box test
 // through the real write pipeline.
-func toolCallFingerprintTwin(msgs []db.Message) string {
+func toolCallParseDiffFingerprintTwin(msgs []db.Message) string {
 	ordered := make([]db.Message, len(msgs))
 	copy(ordered, msgs)
 	sort.SliceStable(ordered, func(i, j int) bool {

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -35,16 +35,24 @@ func (e *Engine) compareStoredSession(
 ) ([]FieldDiff, error) {
 	diffs := compareSessionFields(stored, prepared)
 
-	// Tier 1: two cheap aggregate fingerprints over the stored
-	// messages. The token fingerprint covers per-message model and
-	// token metadata; the content fingerprint covers body length
-	// (sum/max/min), which the token fingerprint does not. Equal
-	// fingerprints prove the messages match on the compared fields
-	// without loading any rows.
+	// Tier 1: three cheap fingerprints over the stored messages. The
+	// token fingerprint covers per-message model and token metadata;
+	// the role/time fingerprint covers per-message role and timestamp,
+	// which the token fingerprint deliberately excludes (its shape is
+	// shared with the PG push fast-path); the content fingerprint
+	// covers body length (sum/max/min). Equal fingerprints prove the
+	// messages match on the compared fields without loading any rows.
 	storedTokenFP, err := e.db.MessageTokenFingerprint(stored.ID)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"parse-diff: message fingerprint for %s: %w",
+			stored.ID, err,
+		)
+	}
+	storedRoleTimeFP, err := e.db.MessageRoleTimeFingerprint(stored.ID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parse-diff: role/time fingerprint for %s: %w",
 			stored.ID, err,
 		)
 	}
@@ -59,9 +67,11 @@ func (e *Engine) compareStoredSession(
 	parsedSum, parsedMax, parsedMin := contentLengthAggregate(msgs)
 
 	tokenFPDiffers := messageTokenFingerprintTwin(msgs) != storedTokenFP
+	roleTimeFPDiffers :=
+		messageRoleTimeFingerprintTwin(msgs) != storedRoleTimeFP
 	contentFPDiffers := storedSum != parsedSum ||
 		storedMax != parsedMax || storedMin != parsedMin
-	if tokenFPDiffers || contentFPDiffers {
+	if tokenFPDiffers || roleTimeFPDiffers || contentFPDiffers {
 		// Tier 2: load stored rows and attribute the mismatch to the
 		// per-message contract fields. A mismatch that lands on none
 		// of them still yields a fallback diff so a fingerprint
@@ -73,7 +83,8 @@ func (e *Engine) compareStoredSession(
 			)
 		}
 		diffs = append(diffs, compareMessageMetadata(
-			storedMsgs, msgs, tokenFPDiffers, contentFPDiffers,
+			storedMsgs, msgs,
+			tokenFPDiffers || roleTimeFPDiffers, contentFPDiffers,
 		)...)
 	}
 
@@ -325,14 +336,41 @@ func messageTokenFingerprintTwin(msgs []db.Message) string {
 	return b.String()
 }
 
+// messageRoleTimeFingerprintTwin is the in-memory twin of
+// db.MessageRoleTimeFingerprint (internal/db/messages.go): identical
+// field order, identical sanitization, identical format string, over
+// a slice ordered by ordinal ascending. Like the token twin above,
+// parity with the DB query is pinned by a white-box test through the
+// real write pipeline.
+func messageRoleTimeFingerprintTwin(msgs []db.Message) string {
+	ordered := make([]db.Message, len(msgs))
+	copy(ordered, msgs)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Ordinal < ordered[j].Ordinal
+	})
+
+	var b strings.Builder
+	for _, m := range ordered {
+		role := db.SanitizeUTF8(m.Role)
+		fmt.Fprintf(&b, "%d|%d:%s|%d:%s;",
+			m.Ordinal, len(role), role,
+			len(m.Timestamp), m.Timestamp,
+		)
+	}
+	return b.String()
+}
+
 // compareMessageMetadata is the tier-2 per-message comparison, run
-// when either tier-1 fingerprint (token or content) mismatched. Both
-// slices are aligned by ordinal value and only the overlap is
-// compared; a length mismatch is message_count's job. The two
-// FP-differ flags guarantee a non-empty result: if the fingerprints
-// proved inequality but none of the attributed fields differ on the
-// overlap, a fallback diff is emitted so the session never classifies
-// identical after its own fingerprint proved otherwise.
+// when any tier-1 fingerprint (token, role/time, or content)
+// mismatched. tokenFPDiffers carries the token and role/time
+// fingerprint results combined, since both attribute to the same
+// per-message fields. Both slices are aligned by ordinal value and
+// only the overlap is compared; a length mismatch is message_count's
+// job. The two FP-differ flags guarantee a non-empty result: if the
+// fingerprints proved inequality but none of the attributed fields
+// differ on the overlap, a fallback diff is emitted so the session
+// never classifies identical after its own fingerprint proved
+// otherwise.
 func compareMessageMetadata(
 	storedMsgs, parsedMsgs []db.Message,
 	tokenFPDiffers, contentFPDiffers bool,

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -8,14 +8,21 @@ package sync
 // "" equivalence, SanitizeUTF8, TokenPresence inference) so that an
 // unchanged parser produces zero diffs against rows it wrote itself.
 //
-// Two parser-owned-but-derived values are deliberately not compared:
-// the session "project" column (rewritten from the mutable
-// worktree_project_mappings table, so its parser-owned input cwd is
-// compared instead) and the tool_call result body (possibly redacted by
-// the blocked-category config and unbounded in size, so only its length
-// is compared). Session columns that the incremental-append path leaves
-// frozen are compared but marked informational for the incremental
-// agents, mirroring termination_status.
+// Three parser-owned-but-derived areas are deliberately not compared:
+//   - the session "project" column, rewritten from the mutable
+//     worktree_project_mappings table (its parser-owned input cwd is
+//     compared instead);
+//   - the tool_call result body, possibly redacted to "" by the
+//     blocked-category config and unbounded in size; and
+//   - the tool_result_events rows, which the same blocked-category
+//     config clears wholesale (the events slice is set to nil) and whose
+//     content is likewise unbounded.
+//
+// For the latter two, only the config-stable result_content_length --
+// set from the event summary before the redaction check, so it captures
+// the dominant content-size signal -- is compared. Session columns that
+// the incremental-append path leaves frozen are compared but marked
+// informational for the incremental agents, mirroring termination_status.
 
 import (
 	"context"
@@ -160,10 +167,22 @@ func compareSessionFields(
 		diffs, FieldFirstMessage,
 		stored.FirstMessage, prepared.FirstMessage,
 	)
+	// session_name is frozen by the incremental-append path
+	// (UpdateSessionIncremental never rewrites it) yet mutable
+	// mid-session via Claude's /rename, so for the incremental-append
+	// agents a difference is benign pipeline history rather than parser
+	// drift -- mark it informational, like termination_status. By
+	// contrast first_message and started_at, also appended via
+	// appendTextFieldDiff, derive from the session head and are
+	// byte-stable across appends, so they stay strict.
+	before := len(diffs)
 	diffs = appendTextFieldDiff(
 		diffs, FieldSessionName,
 		stored.SessionName, prepared.SessionName,
 	)
+	if len(diffs) > before {
+		markIncrementalHistory(&diffs[len(diffs)-1], prepared.Agent)
+	}
 	diffs = appendTextFieldDiff(
 		diffs, FieldStartedAt,
 		stored.StartedAt, prepared.StartedAt,
@@ -320,10 +339,16 @@ func appendScalarSessionDiff(
 // markIncrementalHistory tags a session-field diff as benign pipeline
 // history for the incremental-append agents (Claude, Codex). See
 // appendSessionMetadataDiffs for why those agents legitimately diverge.
+// Any existing Detail (e.g. a long-value rune count) is preserved.
 func markIncrementalHistory(d *FieldDiff, agent string) {
-	if usesIncrementalAppend(agent) {
-		d.Informational = true
+	if !usesIncrementalAppend(agent) {
+		return
+	}
+	d.Informational = true
+	if d.Detail == "" {
 		d.Detail = "incremental-append history"
+	} else {
+		d.Detail += " (incremental-append history)"
 	}
 }
 

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -1,11 +1,21 @@
 package sync
 
 // Parse-diff comparator: compares one freshly parsed, sync-normalized
-// session against its stored SQLite rows and emits FieldDiff entries
-// for the contract fields only. All comparisons mirror the
-// normalization the write path applies (nil <-> "" equivalence,
-// SanitizeUTF8, TokenPresence inference) so that an unchanged parser
-// produces zero diffs against rows it wrote itself.
+// session against its stored SQLite rows and emits FieldDiff entries.
+// It covers the parser-owned session columns, every persisted
+// per-message column, and the parser-owned tool_call columns. All
+// comparisons mirror the normalization the write path applies (nil <->
+// "" equivalence, SanitizeUTF8, TokenPresence inference) so that an
+// unchanged parser produces zero diffs against rows it wrote itself.
+//
+// Two parser-owned-but-derived values are deliberately not compared:
+// the session "project" column (rewritten from the mutable
+// worktree_project_mappings table, so its parser-owned input cwd is
+// compared instead) and the tool_call result body (possibly redacted by
+// the blocked-category config and unbounded in size, so only its length
+// is compared). Session columns that the incremental-append path leaves
+// frozen are compared but marked informational for the incremental
+// agents, mirroring termination_status.
 
 import (
 	"context"
@@ -66,17 +76,41 @@ func (e *Engine) compareStoredSession(
 			stored.ID, err,
 		)
 	}
+	// The flags fingerprint covers the per-message thinking/system/
+	// tool-use columns; the tool-call fingerprint covers the parser-owned
+	// tool_calls rows. Neither is reachable through the token, role/time,
+	// or content fingerprints, so without them a change confined to those
+	// columns would never load the rows and would report identical.
+	storedFlagsFP, err := e.db.MessageFlagsFingerprint(stored.ID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parse-diff: flags fingerprint for %s: %w",
+			stored.ID, err,
+		)
+	}
+	storedToolFP, err := e.db.ToolCallFingerprint(stored.ID)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parse-diff: tool-call fingerprint for %s: %w",
+			stored.ID, err,
+		)
+	}
 
 	tokenFPDiffers := messageTokenFingerprintTwin(msgs) != storedTokenFP
 	roleTimeFPDiffers :=
 		messageRoleTimeFingerprintTwin(msgs) != storedRoleTimeFP
 	contentFPDiffers :=
 		messageContentHashFingerprintTwin(msgs) != storedContentFP
-	if tokenFPDiffers || roleTimeFPDiffers || contentFPDiffers {
-		// Tier 2: load stored rows and attribute the mismatch to the
-		// per-message contract fields. A mismatch that lands on none
-		// of them still yields a fallback diff so a fingerprint
-		// inequality is never reported identical.
+	flagsFPDiffers :=
+		messageFlagsFingerprintTwin(msgs) != storedFlagsFP
+	toolFPDiffers :=
+		toolCallFingerprintTwin(msgs) != storedToolFP
+	if tokenFPDiffers || roleTimeFPDiffers || contentFPDiffers ||
+		flagsFPDiffers || toolFPDiffers {
+		// Tier 2: load stored rows (with tool calls attached) and
+		// attribute the mismatch to the per-message contract fields. A
+		// mismatch that lands on none of them still yields a fallback
+		// diff so a fingerprint inequality is never reported identical.
 		storedMsgs, err := e.db.GetAllMessages(ctx, stored.ID)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -85,7 +119,8 @@ func (e *Engine) compareStoredSession(
 		}
 		diffs = append(diffs, compareMessageMetadata(
 			storedMsgs, msgs,
-			tokenFPDiffers || roleTimeFPDiffers, contentFPDiffers,
+			tokenFPDiffers || roleTimeFPDiffers || flagsFPDiffers,
+			contentFPDiffers, toolFPDiffers,
 		)...)
 	}
 
@@ -191,7 +226,105 @@ func compareSessionFields(
 		}
 		diffs = append(diffs, d)
 	}
+
+	return appendSessionMetadataDiffs(diffs, stored, prepared)
+}
+
+// appendSessionMetadataDiffs compares the parser-owned session columns
+// beyond the summary set: the cwd/branch/source diagnostics and the
+// parent/relationship threading fields. UpdateSessionIncremental does
+// not rewrite any of them (see internal/db/sessions.go), so for the
+// incremental-append agents (Claude, Codex) the stored value is frozen
+// at the last full-replace write while parse-diff always re-parses the
+// whole file; a difference there is benign pipeline history, not parser
+// drift, and is marked informational exactly as termination_status is.
+//
+// The session "project" column is intentionally excluded: it is
+// overwritten in prepareSessionWrite from the mutable
+// worktree_project_mappings table, so a re-parse can legitimately differ
+// from the stored value whenever those mappings changed since the last
+// sync even with an unchanged parser. Its parser-owned input, cwd, is
+// compared here instead.
+func appendSessionMetadataDiffs(
+	diffs []FieldDiff, stored *db.Session, prepared db.Session,
+) []FieldDiff {
+	agent := prepared.Agent
+	diffs = appendScalarSessionDiff(
+		diffs, FieldCwd, agent, stored.Cwd, prepared.Cwd,
+	)
+	diffs = appendScalarSessionDiff(
+		diffs, FieldGitBranch, agent, stored.GitBranch, prepared.GitBranch,
+	)
+	diffs = appendScalarSessionDiff(
+		diffs, FieldRelationshipType, agent,
+		stored.RelationshipType, prepared.RelationshipType,
+	)
+	diffs = appendScalarSessionDiff(
+		diffs, FieldSourceSessionID, agent,
+		stored.SourceSessionID, prepared.SourceSessionID,
+	)
+	diffs = appendScalarSessionDiff(
+		diffs, FieldSourceVersion, agent,
+		stored.SourceVersion, prepared.SourceVersion,
+	)
+	// parent_session_id is *string: NULL and "" are the same state
+	// (toDBSession maps "" to nil via strPtr).
+	diffs = appendScalarSessionDiff(
+		diffs, FieldParentSessionID, agent,
+		derefString(stored.ParentSessionID),
+		derefString(prepared.ParentSessionID),
+	)
+	if stored.ParserMalformedLines != prepared.ParserMalformedLines {
+		d := FieldDiff{
+			Field:  FieldParserMalformedLines,
+			Stored: strconv.Itoa(stored.ParserMalformedLines),
+			Parsed: strconv.Itoa(prepared.ParserMalformedLines),
+		}
+		markIncrementalHistory(&d, agent)
+		diffs = append(diffs, d)
+	}
+	if stored.IsTruncated != prepared.IsTruncated {
+		d := FieldDiff{
+			Field:  FieldIsTruncated,
+			Stored: strconv.FormatBool(stored.IsTruncated),
+			Parsed: strconv.FormatBool(prepared.IsTruncated),
+		}
+		markIncrementalHistory(&d, agent)
+		diffs = append(diffs, d)
+	}
 	return diffs
+}
+
+// appendScalarSessionDiff compares one parser-owned session string
+// column. Both sides pass through SanitizeUTF8 the way the write path
+// does, NULL and "" compare equal (callers deref *string first), long
+// values are truncated, and a difference is marked informational for the
+// incremental-append agents via markIncrementalHistory.
+func appendScalarSessionDiff(
+	diffs []FieldDiff, field, agent, stored, parsed string,
+) []FieldDiff {
+	sv := db.SanitizeUTF8(stored)
+	pv := db.SanitizeUTF8(parsed)
+	if sv == pv {
+		return diffs
+	}
+	d := FieldDiff{
+		Field:  field,
+		Stored: truncateRunes(renderNullableScalar(sv), maxRenderedValueRunes),
+		Parsed: truncateRunes(renderNullableScalar(pv), maxRenderedValueRunes),
+	}
+	markIncrementalHistory(&d, agent)
+	return append(diffs, d)
+}
+
+// markIncrementalHistory tags a session-field diff as benign pipeline
+// history for the incremental-append agents (Claude, Codex). See
+// appendSessionMetadataDiffs for why those agents legitimately diverge.
+func markIncrementalHistory(d *FieldDiff, agent string) {
+	if usesIncrementalAppend(agent) {
+		d.Informational = true
+		d.Detail = "incremental-append history"
+	}
 }
 
 // usesIncrementalAppend reports whether an agent's sync path can clear
@@ -365,20 +498,80 @@ func messageContentHashFingerprintTwin(msgs []db.Message) string {
 	return b.String()
 }
 
-// compareMessageMetadata is the tier-2 per-message comparison, run
-// when any tier-1 fingerprint (token, role/time, or content)
-// mismatched. tokenFPDiffers carries the token and role/time
-// fingerprint results combined, since both attribute to the same
-// per-message fields. Both slices are aligned by ordinal value and
-// only the overlap is compared; a length mismatch is message_count's
-// job. The two FP-differ flags guarantee a non-empty result: if the
-// fingerprints proved inequality but none of the attributed fields
-// differ on the overlap, a fallback diff is emitted so the session
-// never classifies identical after its own fingerprint proved
-// otherwise.
+// messageFlagsFingerprintTwin is the in-memory twin of
+// db.MessageFlagsFingerprint (internal/db/messages.go): identical field
+// order, identical sanitization, identical format string, over a slice
+// ordered by ordinal ascending. Parity with the DB query is pinned by a
+// white-box test through the real write pipeline.
+func messageFlagsFingerprintTwin(msgs []db.Message) string {
+	ordered := make([]db.Message, len(msgs))
+	copy(ordered, msgs)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Ordinal < ordered[j].Ordinal
+	})
+
+	var b strings.Builder
+	for _, m := range ordered {
+		sum := sha256.Sum256([]byte(db.SanitizeUTF8(m.ThinkingText)))
+		fmt.Fprintf(&b, "%d|%t|%t|%t|%x;",
+			m.Ordinal, m.IsSystem, m.HasThinking, m.HasToolUse, sum)
+	}
+	return b.String()
+}
+
+// toolCallFingerprintTwin is the in-memory twin of
+// db.ToolCallFingerprint (internal/db/messages.go). It iterates messages
+// in ordinal order and, within each, its tool calls in array order --
+// the same (ordinal, insertion) order the DB query reproduces via
+// ORDER BY m.ordinal, tc.id. Field order, sanitization, and the format
+// string match the query exactly; parity is pinned by a white-box test
+// through the real write pipeline.
+func toolCallFingerprintTwin(msgs []db.Message) string {
+	ordered := make([]db.Message, len(msgs))
+	copy(ordered, msgs)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Ordinal < ordered[j].Ordinal
+	})
+
+	var b strings.Builder
+	for _, m := range ordered {
+		for _, tc := range m.ToolCalls {
+			toolName := db.SanitizeUTF8(tc.ToolName)
+			category := db.SanitizeUTF8(tc.Category)
+			tu := db.SanitizeUTF8(tc.ToolUseID)
+			skill := db.SanitizeUTF8(tc.SkillName)
+			sub := db.SanitizeUTF8(tc.SubagentSessionID)
+			sum := sha256.Sum256([]byte(db.SanitizeUTF8(tc.InputJSON)))
+			fmt.Fprintf(&b,
+				"%d|%d:%s|%d:%s|%d:%s|%x|%d:%s|%d:%s|%d;",
+				m.Ordinal,
+				len(toolName), toolName,
+				len(category), category,
+				len(tu), tu,
+				sum,
+				len(skill), skill,
+				len(sub), sub,
+				tc.ResultContentLength,
+			)
+		}
+	}
+	return b.String()
+}
+
+// compareMessageMetadata is the tier-2 per-message comparison, run when
+// any tier-1 fingerprint (token, role/time, content, flags, or
+// tool-call) mismatched. metaFPDiffers carries the token, role/time, and
+// flags fingerprint results combined, since all attribute to the same
+// per-message fields; toolFPDiffers carries the tool-call fingerprint.
+// Both slices are aligned by ordinal value and only the overlap is
+// compared; a length mismatch is message_count's job. The FP-differ
+// flags guarantee a non-empty result: if the fingerprints proved
+// inequality but none of the attributed fields differ on the overlap, a
+// fallback diff is emitted so the session never classifies identical
+// after its own fingerprint proved otherwise.
 func compareMessageMetadata(
 	storedMsgs, parsedMsgs []db.Message,
-	tokenFPDiffers, contentFPDiffers bool,
+	metaFPDiffers, contentFPDiffers, toolFPDiffers bool,
 ) []FieldDiff {
 	pairs := alignByOrdinal(storedMsgs, parsedMsgs)
 	n := len(pairs)
@@ -401,6 +594,10 @@ func compareMessageMetadata(
 		metaDiffs     int
 		firstMetaOrd  int
 		firstMetaWhat string
+
+		toolDiffs     int
+		firstToolOrd  int
+		firstToolWhat string
 	)
 	for _, p := range pairs {
 		sModel := db.SanitizeUTF8(p.stored.Model)
@@ -436,6 +633,13 @@ func compareMessageMetadata(
 				firstMetaWhat = what
 			}
 			metaDiffs++
+		}
+		if what := messageToolCallsDiff(p.stored, p.parsed); what != "" {
+			if toolDiffs == 0 {
+				firstToolOrd = p.stored.Ordinal
+				firstToolWhat = what
+			}
+			toolDiffs++
 		}
 	}
 
@@ -486,24 +690,43 @@ func compareMessageMetadata(
 			),
 		})
 	}
+	if toolDiffs > 0 {
+		diffs = append(diffs, FieldDiff{
+			Field:  FieldToolCalls,
+			Stored: "see detail",
+			Parsed: "see detail",
+			Detail: fmt.Sprintf(
+				"%d/%d messages differ; first at ordinal %d: %s",
+				toolDiffs, n, firstToolOrd, firstToolWhat,
+			),
+		})
+	}
 
 	// The fingerprints proved inequality but nothing on the aligned
 	// overlap accounts for it (e.g. an equal-count ordinal-set shift,
-	// or content drift that only changed a non-overlapping message).
-	// Emit a fallback so the session is never reported identical.
-	if len(diffs) == 0 && (tokenFPDiffers || contentFPDiffers) {
-		which := "content"
-		if tokenFPDiffers {
+	// or drift that only changed a non-overlapping message). Emit a
+	// fallback so the session is never reported identical, attributed to
+	// the field family whose fingerprint moved.
+	if len(diffs) == 0 {
+		field, which := FieldMessageMetadata, ""
+		switch {
+		case metaFPDiffers:
 			which = "token/metadata"
+		case contentFPDiffers:
+			which = "content"
+		case toolFPDiffers:
+			field, which = FieldToolCalls, "tool-call"
 		}
-		diffs = append(diffs, FieldDiff{
-			Field:  FieldMessageMetadata,
-			Stored: "fingerprint",
-			Parsed: "fingerprint",
-			Detail: "per-message " + which +
-				" fingerprint differs but no aligned-ordinal field " +
-				"accounts for it (likely an ordinal-set change)",
-		})
+		if which != "" {
+			diffs = append(diffs, FieldDiff{
+				Field:  field,
+				Stored: "fingerprint",
+				Parsed: "fingerprint",
+				Detail: "per-message " + which +
+					" fingerprint differs but no aligned-ordinal field " +
+					"accounts for it (likely an ordinal-set change)",
+			})
+		}
 	}
 	return diffs
 }
@@ -535,8 +758,10 @@ func renderContentChange(stored, parsed db.Message) string {
 
 // messageMetadataDiff reports the first differing per-message field
 // among the fingerprint-covered identity columns that models/tokens do
-// not separately surface: role, timestamp, source-tracking ids, and
-// the sidechain/compact-boundary flags. Returns "" when they match.
+// not separately surface: role, timestamp, source-tracking ids, the
+// sidechain/compact-boundary flags, and the thinking/system/tool-use
+// flags (is_system, has_thinking, has_tool_use, thinking_text). Returns
+// "" when they match.
 func messageMetadataDiff(stored, parsed db.Message) string {
 	switch {
 	case db.SanitizeUTF8(stored.Role) != db.SanitizeUTF8(parsed.Role):
@@ -555,6 +780,21 @@ func messageMetadataDiff(stored, parsed db.Message) string {
 			"is_compact_boundary %t -> %t",
 			stored.IsCompactBoundary, parsed.IsCompactBoundary,
 		)
+	case stored.IsSystem != parsed.IsSystem:
+		return fmt.Sprintf(
+			"is_system %t -> %t", stored.IsSystem, parsed.IsSystem,
+		)
+	case stored.HasThinking != parsed.HasThinking:
+		return fmt.Sprintf(
+			"has_thinking %t -> %t", stored.HasThinking, parsed.HasThinking,
+		)
+	case stored.HasToolUse != parsed.HasToolUse:
+		return fmt.Sprintf(
+			"has_tool_use %t -> %t", stored.HasToolUse, parsed.HasToolUse,
+		)
+	case db.SanitizeUTF8(stored.ThinkingText) !=
+		db.SanitizeUTF8(parsed.ThinkingText):
+		return "thinking_text differs"
 	case db.SanitizeUTF8(stored.SourceType) !=
 		db.SanitizeUTF8(parsed.SourceType):
 		return "source_type differs"
@@ -573,6 +813,70 @@ func messageMetadataDiff(stored, parsed db.Message) string {
 	case db.SanitizeUTF8(stored.ClaudeRequestID) !=
 		db.SanitizeUTF8(parsed.ClaudeRequestID):
 		return "claude_request_id differs"
+	default:
+		return ""
+	}
+}
+
+// messageToolCallsDiff reports the first parser-owned tool_call
+// difference between two aligned messages: a count change, or a
+// per-position change in tool_name, category, tool_use_id, input_json,
+// skill_name, subagent_session_id, or result_content_length. Tool calls
+// are compared by array position, which matches the (ordinal, insertion)
+// order the stored fingerprint and attachToolCalls reproduce. Returns ""
+// when they match.
+func messageToolCallsDiff(stored, parsed db.Message) string {
+	if len(stored.ToolCalls) != len(parsed.ToolCalls) {
+		return fmt.Sprintf(
+			"tool_call count %d -> %d",
+			len(stored.ToolCalls), len(parsed.ToolCalls),
+		)
+	}
+	for i := range stored.ToolCalls {
+		if what := toolCallDiff(
+			stored.ToolCalls[i], parsed.ToolCalls[i],
+		); what != "" {
+			return what
+		}
+	}
+	return ""
+}
+
+// toolCallDiff reports the first differing parser-owned column of one
+// tool call. The database-assigned ids and the (possibly blocked)
+// result body are not compared; result content is compared only by
+// length, the same sizes-not-bodies rule message content follows.
+func toolCallDiff(stored, parsed db.ToolCall) string {
+	switch {
+	case db.SanitizeUTF8(stored.ToolName) !=
+		db.SanitizeUTF8(parsed.ToolName):
+		return fmt.Sprintf(
+			"tool_name %q -> %q", stored.ToolName, parsed.ToolName,
+		)
+	case db.SanitizeUTF8(stored.Category) !=
+		db.SanitizeUTF8(parsed.Category):
+		return fmt.Sprintf(
+			"category %q -> %q", stored.Category, parsed.Category,
+		)
+	case db.SanitizeUTF8(stored.ToolUseID) !=
+		db.SanitizeUTF8(parsed.ToolUseID):
+		return "tool_use_id differs"
+	case db.SanitizeUTF8(stored.InputJSON) !=
+		db.SanitizeUTF8(parsed.InputJSON):
+		return "input_json differs"
+	case db.SanitizeUTF8(stored.SkillName) !=
+		db.SanitizeUTF8(parsed.SkillName):
+		return fmt.Sprintf(
+			"skill_name %q -> %q", stored.SkillName, parsed.SkillName,
+		)
+	case db.SanitizeUTF8(stored.SubagentSessionID) !=
+		db.SanitizeUTF8(parsed.SubagentSessionID):
+		return "subagent_session_id differs"
+	case stored.ResultContentLength != parsed.ResultContentLength:
+		return fmt.Sprintf(
+			"result_content_length %d -> %d",
+			stored.ResultContentLength, parsed.ResultContentLength,
+		)
 	default:
 		return ""
 	}

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -799,7 +799,12 @@ func classifyParseDiffSession(
 	case !hasStored:
 		return DiffNewOnDisk, ""
 	case storedTrashed:
-		return DiffExcluded, "trashed in archive"
+		// The parser still emits this session, but the user trashed it
+		// in the archive; sync preserves trash (UpsertSession returns
+		// ErrSessionTrashed) rather than deleting, so this is neither a
+		// parser exclusion nor drift. Bucket it as skipped, matching
+		// how a not-re-parsed trashed row is reported.
+		return DiffSkipped, "trashed in archive"
 	case pendingResync:
 		return DiffPendingResync, ""
 	case realDiffs > 0:

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -647,6 +647,15 @@ func TestFingerprintTwinMatchesDB(t *testing.T) {
 		t, storedFP, messageTokenFingerprintTwin(msgs),
 		"in-memory twin must match db.MessageTokenFingerprint exactly",
 	)
+
+	storedRoleTimeFP, err := d.MessageRoleTimeFingerprint(prepared.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, storedRoleTimeFP)
+
+	assert.Equal(
+		t, storedRoleTimeFP, messageRoleTimeFingerprintTwin(msgs),
+		"in-memory twin must match db.MessageRoleTimeFingerprint exactly",
+	)
 }
 
 // TestCompareStoredSessionRoundTrip proves that a session written

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -112,8 +112,24 @@ func TestCompareSessionFields(t *testing.T) {
 			},
 		},
 		{
-			name: "session name drift",
+			name: "session name drift is informational for incremental agents",
 			prepared: func(s *db.Session) {
+				s.SessionName = new("Renamed")
+			},
+			want: []want{{
+				field:         FieldSessionName,
+				stored:        "My Session",
+				parsed:        "Renamed",
+				informational: true,
+			}},
+		},
+		{
+			name: "session name drift is a real diff for full-replace agents",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
 				s.SessionName = new("Renamed")
 			},
 			want: []want{{
@@ -670,6 +686,52 @@ func TestCompareMessageMetadata(t *testing.T) {
 		assert.Contains(t, diffs[0].Detail, `tool_name "Read" -> "Bash"`)
 		assert.Contains(t, diffs[0].Detail, "first at ordinal 0")
 	})
+
+	t.Run("tool_call sub-field drift attributes to tool_calls",
+		func(t *testing.T) {
+			base := db.ToolCall{
+				ToolName: "Read", Category: "Read", ToolUseID: "tu1",
+				InputJSON: `{"file":"a"}`, SkillName: "s1",
+				SubagentSessionID: "agent-1",
+			}
+			subCases := []struct {
+				name   string
+				mutate func(*db.ToolCall)
+				detail string
+			}{
+				{"category", func(tc *db.ToolCall) { tc.Category = "Bash" },
+					`category "Read" -> "Bash"`},
+				{"tool_use_id", func(tc *db.ToolCall) { tc.ToolUseID = "tu2" },
+					"tool_use_id differs"},
+				{"input_json", func(tc *db.ToolCall) { tc.InputJSON = `{"file":"b"}` },
+					"input_json differs"},
+				{"skill_name", func(tc *db.ToolCall) { tc.SkillName = "s2" },
+					`skill_name "s1" -> "s2"`},
+				{"subagent_session_id",
+					func(tc *db.ToolCall) { tc.SubagentSessionID = "agent-2" },
+					"subagent_session_id differs"},
+			}
+			for _, sc := range subCases {
+				t.Run(sc.name, func(t *testing.T) {
+					parsedTC := base
+					sc.mutate(&parsedTC)
+					stored := []db.Message{{
+						Ordinal: 0, Role: "assistant",
+						ToolCalls: []db.ToolCall{base},
+					}}
+					parsed := []db.Message{{
+						Ordinal: 0, Role: "assistant",
+						ToolCalls: []db.ToolCall{parsedTC},
+					}}
+					diffs := compareMessageMetadata(
+						stored, parsed, false, false, true,
+					)
+					require.Len(t, diffs, 1)
+					assert.Equal(t, FieldToolCalls, diffs[0].Field)
+					assert.Contains(t, diffs[0].Detail, sc.detail)
+				})
+			}
+		})
 
 	t.Run("tool_call count drift is a tool_calls diff", func(t *testing.T) {
 		stored := []db.Message{{

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -915,10 +915,10 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 			wantClass: DiffNewOnDisk,
 		},
 		{
-			name:     "trashed stored row wins over pending resync",
+			name:     "trashed stored row is skipped, not excluded",
 			prepared: true, hasStored: true, storedTrashed: true,
 			pendingResync: true, realDiffs: 2,
-			wantClass:  DiffExcluded,
+			wantClass:  DiffSkipped,
 			wantReason: "trashed in archive",
 		},
 		{

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -399,6 +399,22 @@ func TestCompareMessageMetadata(t *testing.T) {
 		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
 	})
 
+	t.Run("equal-length body rewrite is a content diff", func(t *testing.T) {
+		stored := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			Content: "aaa", ContentLength: 3,
+		}}
+		parsed := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			Content: "bbb", ContentLength: 3,
+		}}
+		diffs := compareMessageMetadata(stored, parsed, false, true)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldMessageContent, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail,
+			"body differs at equal length (3 bytes)")
+	})
+
 	t.Run("length mismatch compares the overlap only", func(t *testing.T) {
 		stored := []db.Message{pdMsg(0, "m", 100, 5)}
 		parsed := []db.Message{
@@ -655,6 +671,15 @@ func TestFingerprintTwinMatchesDB(t *testing.T) {
 	assert.Equal(
 		t, storedRoleTimeFP, messageRoleTimeFingerprintTwin(msgs),
 		"in-memory twin must match db.MessageRoleTimeFingerprint exactly",
+	)
+
+	storedContentFP, err := d.MessageContentHashFingerprint(prepared.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, storedContentFP)
+
+	assert.Equal(
+		t, storedContentFP, messageContentHashFingerprintTwin(msgs),
+		"in-memory twin must match db.MessageContentHashFingerprint exactly",
 	)
 }
 

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -1371,11 +1371,11 @@ func TestToolCallAndFlagsFingerprintTwinsMatchDB(t *testing.T) {
 	assert.Equal(t, storedFlagsFP, messageFlagsFingerprintTwin(msgs),
 		"flags twin must match db.MessageFlagsFingerprint exactly")
 
-	storedToolFP, err := d.ToolCallFingerprint(prepared.ID)
+	storedToolFP, err := d.ToolCallParseDiffFingerprint(prepared.ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, storedToolFP)
-	assert.Equal(t, storedToolFP, toolCallFingerprintTwin(msgs),
-		"tool-call twin must match db.ToolCallFingerprint exactly")
+	assert.Equal(t, storedToolFP, toolCallParseDiffFingerprintTwin(msgs),
+		"tool-call twin must match db.ToolCallParseDiffFingerprint exactly")
 }
 
 // TestCompareStoredSessionRoundTripToolCalls is the false-diff acid test

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -253,6 +253,183 @@ func TestCompareSessionFields(t *testing.T) {
 				parsed: "2026-01-01T02:00:00Z",
 			}},
 		},
+		{
+			name: "cwd drift is informational for incremental agents",
+			stored: func(s *db.Session) {
+				s.Cwd = "/home/me/old"
+			},
+			prepared: func(s *db.Session) {
+				s.Cwd = "/home/me/new"
+			},
+			want: []want{{
+				field:         FieldCwd,
+				stored:        "/home/me/old",
+				parsed:        "/home/me/new",
+				informational: true,
+			}},
+		},
+		{
+			name: "cwd drift is a real diff for full-replace agents",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.Cwd = "/home/me/old"
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.Cwd = "/home/me/new"
+			},
+			want: []want{{
+				field:  FieldCwd,
+				stored: "/home/me/old",
+				parsed: "/home/me/new",
+			}},
+		},
+		{
+			name: "git_branch drift is a real diff for full-replace agents",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.GitBranch = "main"
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.GitBranch = "feature"
+			},
+			want: []want{{
+				field:  FieldGitBranch,
+				stored: "main",
+				parsed: "feature",
+			}},
+		},
+		{
+			name: "relationship_type drift is a real diff",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.RelationshipType = "continuation"
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.RelationshipType = "fork"
+			},
+			want: []want{{
+				field:  FieldRelationshipType,
+				stored: "continuation",
+				parsed: "fork",
+			}},
+		},
+		{
+			name: "source_session_id drift is a real diff",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.SourceSessionID = "abc"
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.SourceSessionID = "xyz"
+			},
+			want: []want{{
+				field:  FieldSourceSessionID,
+				stored: "abc",
+				parsed: "xyz",
+			}},
+		},
+		{
+			name: "source_version drift is a real diff",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.SourceVersion = "1.0.0"
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.SourceVersion = "1.1.0"
+			},
+			want: []want{{
+				field:  FieldSourceVersion,
+				stored: "1.0.0",
+				parsed: "1.1.0",
+			}},
+		},
+		{
+			name: "parent_session_id nil stored vs empty parsed is no diff",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.ParentSessionID = nil
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.ParentSessionID = new("")
+			},
+		},
+		{
+			name: "parent_session_id drift renders (null) for nil stored",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.ParentSessionID = nil
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.ParentSessionID = new("parent-1")
+			},
+			want: []want{{
+				field:  FieldParentSessionID,
+				stored: "(null)",
+				parsed: "parent-1",
+			}},
+		},
+		{
+			name: "parser_malformed_lines drift is a real diff",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.ParserMalformedLines = 0
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.ParserMalformedLines = 3
+			},
+			want: []want{{
+				field:  FieldParserMalformedLines,
+				stored: "0",
+				parsed: "3",
+			}},
+		},
+		{
+			name: "parser_malformed_lines drift is informational for incremental agents",
+			prepared: func(s *db.Session) {
+				s.ParserMalformedLines = 2
+			},
+			want: []want{{
+				field:         FieldParserMalformedLines,
+				stored:        "0",
+				parsed:        "2",
+				informational: true,
+			}},
+		},
+		{
+			name: "is_truncated drift is a real diff",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.IsTruncated = false
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.IsTruncated = true
+			},
+			want: []want{{
+				field:  FieldIsTruncated,
+				stored: "false",
+				parsed: "true",
+			}},
+		},
+		{
+			name: "project is not compared (resolver-derived)",
+			stored: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.Project = "project-old"
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "gemini"
+				s.Project = "project-new"
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -325,7 +502,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 		parsed := []db.Message{
 			pdMsg(0, "", 0, 0), pdMsg(1, "model-a", 100, 5),
 		}
-		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false))
+		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false, false))
 	})
 
 	t.Run("model drift reports count and first ordinal", func(t *testing.T) {
@@ -339,7 +516,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			pdMsg(1, "model-b", 0, 0),
 			pdMsg(2, "model-b", 0, 0),
 		}
-		diffs := compareMessageMetadata(stored, parsed, true, false)
+		diffs := compareMessageMetadata(stored, parsed, true, false, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldModels, diffs[0].Field)
 		assert.Equal(t, "model-a", diffs[0].Stored)
@@ -354,7 +531,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 	t.Run("token value drift reports message tokens", func(t *testing.T) {
 		stored := []db.Message{pdMsg(0, "m", 100, 5)}
 		parsed := []db.Message{pdMsg(0, "m", 110, 5)}
-		diffs := compareMessageMetadata(stored, parsed, true, false)
+		diffs := compareMessageMetadata(stored, parsed, true, false, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
 		assert.Equal(
@@ -378,7 +555,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			Ordinal: 0, Role: "assistant",
 			OutputTokens: 0, HasOutputTokens: false,
 		}}
-		diffs := compareMessageMetadata(stored, parsed, true, false)
+		diffs := compareMessageMetadata(stored, parsed, true, false, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
 		assert.Contains(t, diffs[0].Stored, "output=0")
@@ -394,7 +571,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			Ordinal: 0, Role: "assistant",
 			TokenUsage: json.RawMessage(`{"input_tokens":2}`),
 		}}
-		diffs := compareMessageMetadata(stored, parsed, true, false)
+		diffs := compareMessageMetadata(stored, parsed, true, false, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
 	})
@@ -408,7 +585,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			Ordinal: 0, Role: "assistant",
 			Content: "bbb", ContentLength: 3,
 		}}
-		diffs := compareMessageMetadata(stored, parsed, false, true)
+		diffs := compareMessageMetadata(stored, parsed, false, true, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldMessageContent, diffs[0].Field)
 		assert.Contains(t, diffs[0].Detail,
@@ -421,7 +598,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			pdMsg(0, "m", 100, 5),
 			pdMsg(1, "different-model", 999, 9),
 		}
-		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false))
+		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false, false))
 	})
 
 	t.Run("alignment matches ordinal values not indices", func(t *testing.T) {
@@ -431,8 +608,119 @@ func TestCompareMessageMetadata(t *testing.T) {
 		parsed := []db.Message{
 			pdMsg(2, "m", 200, 6), pdMsg(0, "m", 100, 5),
 		}
-		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false))
+		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false, false))
 	})
+
+	t.Run("is_system flip is a metadata diff", func(t *testing.T) {
+		stored := []db.Message{{Ordinal: 0, Role: "user", IsSystem: false}}
+		parsed := []db.Message{{Ordinal: 0, Role: "user", IsSystem: true}}
+		diffs := compareMessageMetadata(stored, parsed, true, false, false)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldMessageMetadata, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "is_system false -> true")
+	})
+
+	t.Run("has_thinking flip is a metadata diff", func(t *testing.T) {
+		stored := []db.Message{{Ordinal: 0, Role: "assistant"}}
+		parsed := []db.Message{{Ordinal: 0, Role: "assistant", HasThinking: true}}
+		diffs := compareMessageMetadata(stored, parsed, true, false, false)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldMessageMetadata, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "has_thinking false -> true")
+	})
+
+	t.Run("has_tool_use flip is a metadata diff", func(t *testing.T) {
+		stored := []db.Message{{Ordinal: 0, Role: "assistant"}}
+		parsed := []db.Message{{Ordinal: 0, Role: "assistant", HasToolUse: true}}
+		diffs := compareMessageMetadata(stored, parsed, true, false, false)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldMessageMetadata, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "has_tool_use false -> true")
+	})
+
+	t.Run("thinking_text drift is a metadata diff", func(t *testing.T) {
+		stored := []db.Message{{
+			Ordinal: 0, Role: "assistant", ThinkingText: "old reasoning",
+		}}
+		parsed := []db.Message{{
+			Ordinal: 0, Role: "assistant", ThinkingText: "new reasoning",
+		}}
+		diffs := compareMessageMetadata(stored, parsed, true, false, false)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldMessageMetadata, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "thinking_text differs")
+	})
+
+	t.Run("tool_name drift is a tool_calls diff", func(t *testing.T) {
+		stored := []db.Message{{
+			Ordinal: 0, Role: "assistant", HasToolUse: true,
+			ToolCalls: []db.ToolCall{
+				{ToolName: "Read", Category: "Read", ToolUseID: "tu1"},
+			},
+		}}
+		parsed := []db.Message{{
+			Ordinal: 0, Role: "assistant", HasToolUse: true,
+			ToolCalls: []db.ToolCall{
+				{ToolName: "Bash", Category: "Read", ToolUseID: "tu1"},
+			},
+		}}
+		diffs := compareMessageMetadata(stored, parsed, false, false, true)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldToolCalls, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, `tool_name "Read" -> "Bash"`)
+		assert.Contains(t, diffs[0].Detail, "first at ordinal 0")
+	})
+
+	t.Run("tool_call count drift is a tool_calls diff", func(t *testing.T) {
+		stored := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			ToolCalls: []db.ToolCall{{ToolName: "Read", ToolUseID: "tu1"}},
+		}}
+		parsed := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			ToolCalls: []db.ToolCall{
+				{ToolName: "Read", ToolUseID: "tu1"},
+				{ToolName: "Bash", ToolUseID: "tu2"},
+			},
+		}}
+		diffs := compareMessageMetadata(stored, parsed, false, false, true)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldToolCalls, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "tool_call count 1 -> 2")
+	})
+
+	t.Run("result_content_length drift is a tool_calls diff", func(t *testing.T) {
+		stored := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			ToolCalls: []db.ToolCall{
+				{ToolName: "Read", ToolUseID: "tu1", ResultContentLength: 100},
+			},
+		}}
+		parsed := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			ToolCalls: []db.ToolCall{
+				{ToolName: "Read", ToolUseID: "tu1", ResultContentLength: 250},
+			},
+		}}
+		diffs := compareMessageMetadata(stored, parsed, false, false, true)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldToolCalls, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "result_content_length 100 -> 250")
+	})
+
+	t.Run("tool fingerprint differs but overlap matches yields fallback",
+		func(t *testing.T) {
+			// No aligned-ordinal tool diff (e.g. an ordinal-set shift),
+			// but the tool fingerprint asserted inequality: the session
+			// must not report identical.
+			stored := []db.Message{{Ordinal: 0, Role: "assistant"}}
+			parsed := []db.Message{{Ordinal: 0, Role: "assistant"}}
+			diffs := compareMessageMetadata(stored, parsed, false, false, true)
+			require.Len(t, diffs, 1)
+			assert.Equal(t, FieldToolCalls, diffs[0].Field)
+			assert.Equal(t, "fingerprint", diffs[0].Stored)
+			assert.Contains(t, diffs[0].Detail, "tool-call fingerprint differs")
+		})
 }
 
 func pdEvent(
@@ -901,6 +1189,152 @@ func TestCompareStoredSessionDetectsMetadataDrift(t *testing.T) {
 	require.Len(t, diffs, 1)
 	assert.Equal(t, FieldMessageMetadata, diffs[0].Field)
 	assert.Contains(t, diffs[0].Detail, "is_sidechain")
+}
+
+// pdToolSession builds a Claude pendingWrite that exercises the
+// flags and tool-call comparison paths: a thinking block, two tool calls
+// (one with a paired result), and a system message.
+func pdToolSession(id string) pendingWrite {
+	ts := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	return pendingWrite{
+		sess: parser.ParsedSession{
+			ID: id, Project: "proj", Machine: "test-machine",
+			Agent: parser.AgentClaude, FirstMessage: "do a thing",
+			StartedAt: ts, MessageCount: 3,
+			File: parser.FileInfo{
+				Path: "/tmp/" + id + ".jsonl", Size: 128, Mtime: ts.UnixNano(),
+			},
+		},
+		msgs: []parser.ParsedMessage{
+			{
+				Ordinal: 0, Role: parser.RoleUser,
+				Content: "do a thing", ContentLength: 10, Timestamp: ts,
+			},
+			{
+				Ordinal: 1, Role: parser.RoleAssistant,
+				Content: "working on it", ContentLength: 13,
+				Timestamp:   ts.Add(time.Second),
+				Model:       "claude-sonnet",
+				HasThinking: true, ThinkingText: "let me reason about this",
+				HasToolUse: true,
+				ToolCalls: []parser.ParsedToolCall{
+					{
+						ToolUseID: "tu1", ToolName: "Read",
+						Category: "Read", InputJSON: `{"file":"a.go"}`,
+					},
+					{
+						ToolUseID: "tu2", ToolName: "Bash",
+						Category: "Bash", InputJSON: `{"cmd":"ls"}`,
+					},
+				},
+			},
+			{
+				Ordinal: 2, Role: parser.RoleUser,
+				Content: "looks good", ContentLength: 10,
+				Timestamp: ts.Add(2 * time.Second),
+				IsSystem:  true,
+				ToolResults: []parser.ParsedToolResult{
+					{
+						ToolUseID: "tu1", ContentLength: 18,
+						ContentRaw: `"file contents x"`,
+					},
+				},
+			},
+		},
+	}
+}
+
+// pdWriteToolSession writes pdToolSession through the real pipeline.
+func pdWriteToolSession(
+	t *testing.T, id string,
+) (*Engine, *db.DB, pendingWrite) {
+	t.Helper()
+	d := openTestDB(t)
+	e := NewEngine(d, EngineConfig{Machine: "test-machine"})
+	pw := pdToolSession(id)
+	written, _, failed := e.writeBatch(
+		[]pendingWrite{pw}, syncWriteBulk, false,
+	)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	return e, d, pw
+}
+
+// TestToolCallAndFlagsFingerprintTwinsMatchDB pins the two new in-memory
+// twins against their DB queries through the real write pipeline, the
+// way TestFingerprintTwinMatchesDB does for the message fingerprints.
+func TestToolCallAndFlagsFingerprintTwinsMatchDB(t *testing.T) {
+	e, d, pw := pdWriteToolSession(t, "pd-tool-twin")
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+
+	storedFlagsFP, err := d.MessageFlagsFingerprint(prepared.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, storedFlagsFP)
+	assert.Equal(t, storedFlagsFP, messageFlagsFingerprintTwin(msgs),
+		"flags twin must match db.MessageFlagsFingerprint exactly")
+
+	storedToolFP, err := d.ToolCallFingerprint(prepared.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, storedToolFP)
+	assert.Equal(t, storedToolFP, toolCallFingerprintTwin(msgs),
+		"tool-call twin must match db.ToolCallFingerprint exactly")
+}
+
+// TestCompareStoredSessionRoundTripToolCalls is the false-diff acid test
+// for the new fields: a session with tool calls, a thinking block, and a
+// system message must compare identical against itself.
+func TestCompareStoredSessionRoundTripToolCalls(t *testing.T) {
+	e, d, pw := pdWriteToolSession(t, "pd-tool-rt")
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+
+	stored := pdFetchStored(t, d, prepared.ID)
+	diffs, err := e.compareStoredSession(
+		context.Background(), stored, prepared, msgs, nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, diffs,
+		"tool calls, thinking, and a system message must round-trip clean")
+}
+
+// TestCompareStoredSessionDetectsToolCallDrift proves a change confined
+// to a tool_call column is caught: none of the message
+// token/role/content/flags fingerprints move, so it surfaces only if the
+// tool-call fingerprint triggers the tier-2 comparison.
+func TestCompareStoredSessionDetectsToolCallDrift(t *testing.T) {
+	e, d, pw := pdWriteToolSession(t, "pd-tool-drift")
+	pw.msgs[1].ToolCalls[0].ToolName = "Grep"
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+
+	stored := pdFetchStored(t, d, prepared.ID)
+	diffs, err := e.compareStoredSession(
+		context.Background(), stored, prepared, msgs, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, FieldToolCalls, diffs[0].Field)
+	assert.Contains(t, diffs[0].Detail, `tool_name "Read" -> "Grep"`)
+}
+
+// TestCompareStoredSessionDetectsFlagDrift proves a change confined to a
+// per-message flag (has_thinking) is caught only via the flags
+// fingerprint triggering the tier-2 comparison.
+func TestCompareStoredSessionDetectsFlagDrift(t *testing.T) {
+	e, d, pw := pdWriteToolSession(t, "pd-flag-drift")
+	pw.msgs[1].HasThinking = false
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+
+	stored := pdFetchStored(t, d, prepared.ID)
+	diffs, err := e.compareStoredSession(
+		context.Background(), stored, prepared, msgs, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, FieldMessageMetadata, diffs[0].Field)
+	assert.Contains(t, diffs[0].Detail, "has_thinking true -> false")
 }
 
 func pdFetchStored(t *testing.T, d *db.DB, id string) *db.Session {

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -209,6 +209,50 @@ func TestCompareSessionFields(t *testing.T) {
 				s.TerminationStatus = nil
 			},
 		},
+		{
+			name: "termination stored null parsed value is real drift for full-replace agents",
+			stored: func(s *db.Session) {
+				s.Agent = "antigravity-cli"
+				s.TerminationStatus = nil
+			},
+			prepared: func(s *db.Session) {
+				s.Agent = "antigravity-cli"
+			},
+			want: []want{{
+				field:         FieldTerminationStatus,
+				stored:        "(null)",
+				parsed:        "clean",
+				informational: false,
+			}},
+		},
+		{
+			name: "started_at drift is a real diff",
+			stored: func(s *db.Session) {
+				s.StartedAt = new("2026-01-01T00:00:00Z")
+			},
+			prepared: func(s *db.Session) {
+				s.StartedAt = new("2026-01-02T00:00:00Z")
+			},
+			want: []want{{
+				field:  FieldStartedAt,
+				stored: "2026-01-01T00:00:00Z",
+				parsed: "2026-01-02T00:00:00Z",
+			}},
+		},
+		{
+			name: "ended_at drift is a real diff",
+			stored: func(s *db.Session) {
+				s.EndedAt = new("2026-01-01T01:00:00Z")
+			},
+			prepared: func(s *db.Session) {
+				s.EndedAt = new("2026-01-01T02:00:00Z")
+			},
+			want: []want{{
+				field:  FieldEndedAt,
+				stored: "2026-01-01T01:00:00Z",
+				parsed: "2026-01-01T02:00:00Z",
+			}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -281,7 +325,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 		parsed := []db.Message{
 			pdMsg(0, "", 0, 0), pdMsg(1, "model-a", 100, 5),
 		}
-		assert.Empty(t, compareMessageMetadata(stored, parsed))
+		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false))
 	})
 
 	t.Run("model drift reports count and first ordinal", func(t *testing.T) {
@@ -295,7 +339,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			pdMsg(1, "model-b", 0, 0),
 			pdMsg(2, "model-b", 0, 0),
 		}
-		diffs := compareMessageMetadata(stored, parsed)
+		diffs := compareMessageMetadata(stored, parsed, true, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldModels, diffs[0].Field)
 		assert.Equal(t, "model-a", diffs[0].Stored)
@@ -310,7 +354,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 	t.Run("token value drift reports message tokens", func(t *testing.T) {
 		stored := []db.Message{pdMsg(0, "m", 100, 5)}
 		parsed := []db.Message{pdMsg(0, "m", 110, 5)}
-		diffs := compareMessageMetadata(stored, parsed)
+		diffs := compareMessageMetadata(stored, parsed, true, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
 		assert.Equal(
@@ -334,7 +378,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			Ordinal: 0, Role: "assistant",
 			OutputTokens: 0, HasOutputTokens: false,
 		}}
-		diffs := compareMessageMetadata(stored, parsed)
+		diffs := compareMessageMetadata(stored, parsed, true, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
 		assert.Contains(t, diffs[0].Stored, "output=0")
@@ -350,7 +394,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			Ordinal: 0, Role: "assistant",
 			TokenUsage: json.RawMessage(`{"input_tokens":2}`),
 		}}
-		diffs := compareMessageMetadata(stored, parsed)
+		diffs := compareMessageMetadata(stored, parsed, true, false)
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
 	})
@@ -361,7 +405,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 			pdMsg(0, "m", 100, 5),
 			pdMsg(1, "different-model", 999, 9),
 		}
-		assert.Empty(t, compareMessageMetadata(stored, parsed))
+		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false))
 	})
 
 	t.Run("alignment matches ordinal values not indices", func(t *testing.T) {
@@ -371,7 +415,7 @@ func TestCompareMessageMetadata(t *testing.T) {
 		parsed := []db.Message{
 			pdMsg(2, "m", 200, 6), pdMsg(0, "m", 100, 5),
 		}
-		assert.Empty(t, compareMessageMetadata(stored, parsed))
+		assert.Empty(t, compareMessageMetadata(stored, parsed, false, false))
 	})
 }
 
@@ -456,7 +500,22 @@ func TestCompareUsageEvents(t *testing.T) {
 		require.Len(t, diffs, 1)
 		assert.Equal(t, FieldUsageEventTotals, diffs[0].Field)
 		assert.Contains(t, diffs[0].Detail, "event composition differs")
-		assert.Contains(t, diffs[0].Detail, "dedup:k1")
+		assert.Contains(t, diffs[0].Detail, "dedup|k1")
+	})
+
+	t.Run("model drift under stable dedup key surfaces", func(t *testing.T) {
+		// Same dedup key and equal token totals, but the event is
+		// re-attributed to a different model: must not pass silently.
+		stored := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "k1", nil),
+		}
+		parsed := []db.UsageEvent{
+			pdEvent("api", "m2", 10, 2, "2026-01-01T00:00:00Z", "k1", nil),
+		}
+		diffs := compareUsageEvents(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldUsageEventTotals, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "event composition differs")
 	})
 
 	t.Run("tuple fallback detects occurred_at drift", func(t *testing.T) {
@@ -727,6 +786,87 @@ func TestCompareStoredSessionDetectsDrift(t *testing.T) {
 	assert.Equal(t, "claude-sonnet", diffs[0].Stored)
 	assert.Equal(t, "claude-haiku", diffs[0].Parsed)
 	assert.Contains(t, diffs[0].Detail, "first at ordinal 0")
+}
+
+// pdWriteSingleMessageSession writes a one-message session through the
+// real pipeline and returns the engine plus DB for re-parse comparison.
+func pdWriteSingleMessageSession(
+	t *testing.T, id string, msg parser.ParsedMessage,
+) (*Engine, *db.DB, pendingWrite) {
+	t.Helper()
+	d := openTestDB(t)
+	e := NewEngine(d, EngineConfig{Machine: "test-machine"})
+	ts := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	pw := pendingWrite{
+		sess: parser.ParsedSession{
+			ID: id, Project: "proj", Machine: "test-machine",
+			Agent: parser.AgentClaude, FirstMessage: "x",
+			StartedAt: ts, MessageCount: 1,
+			File: parser.FileInfo{
+				Path: "/tmp/" + id + ".jsonl", Size: 32, Mtime: ts.UnixNano(),
+			},
+		},
+		msgs: []parser.ParsedMessage{msg},
+	}
+	written, _, failed := e.writeBatch(
+		[]pendingWrite{pw}, syncWriteBulk, false,
+	)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	return e, d, pw
+}
+
+// TestCompareStoredSessionDetectsContentDrift proves the content tier
+// catches a message-body change the token fingerprint cannot see: only
+// the content length moves, model and tokens are unchanged.
+func TestCompareStoredSessionDetectsContentDrift(t *testing.T) {
+	ts := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	e, d, pw := pdWriteSingleMessageSession(t, "pd-content", parser.ParsedMessage{
+		Ordinal: 0, Role: parser.RoleAssistant,
+		Content: "short", ContentLength: 5, Timestamp: ts,
+		Model: "claude-sonnet",
+	})
+
+	// New parse: same model and tokens, longer body.
+	pw.msgs[0].Content = "a much longer reply body"
+	pw.msgs[0].ContentLength = len(pw.msgs[0].Content)
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+
+	stored := pdFetchStored(t, d, prepared.ID)
+	diffs, err := e.compareStoredSession(
+		context.Background(), stored, prepared, msgs, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, FieldMessageContent, diffs[0].Field)
+	assert.Contains(t, diffs[0].Detail, "first at ordinal 0")
+}
+
+// TestCompareStoredSessionDetectsMetadataDrift proves a fingerprint
+// mismatch confined to a non-model/token field (is_sidechain) is
+// surfaced as message_metadata rather than silently reported identical.
+func TestCompareStoredSessionDetectsMetadataDrift(t *testing.T) {
+	ts := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	e, d, pw := pdWriteSingleMessageSession(t, "pd-meta", parser.ParsedMessage{
+		Ordinal: 0, Role: parser.RoleAssistant,
+		Content: "body", ContentLength: 4, Timestamp: ts,
+		Model: "claude-sonnet", IsSidechain: false,
+	})
+
+	// New parse flips only is_sidechain: same model, tokens, content.
+	pw.msgs[0].IsSidechain = true
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+
+	stored := pdFetchStored(t, d, prepared.ID)
+	diffs, err := e.compareStoredSession(
+		context.Background(), stored, prepared, msgs, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, FieldMessageMetadata, diffs[0].Field)
+	assert.Contains(t, diffs[0].Detail, "is_sidechain")
 }
 
 func pdFetchStored(t *testing.T, d *db.DB, id string) *db.Session {

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -1,0 +1,854 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// pdBaseSession returns a stored/prepared session pair that compares
+// as identical, for tests to mutate.
+func pdBaseSession() db.Session {
+	return db.Session{
+		ID:                   "pd-sess",
+		Agent:                "claude",
+		MessageCount:         4,
+		UserMessageCount:     2,
+		FirstMessage:         new("hello there"),
+		SessionName:          new("My Session"),
+		TotalOutputTokens:    120,
+		PeakContextTokens:    9000,
+		HasTotalOutputTokens: true,
+		HasPeakContextTokens: true,
+		TerminationStatus:    new("clean"),
+	}
+}
+
+func TestCompareSessionFields(t *testing.T) {
+	type want struct {
+		field         string
+		stored        string
+		parsed        string
+		informational bool
+	}
+	tests := []struct {
+		name     string
+		stored   func(*db.Session)
+		prepared func(*db.Session)
+		want     []want
+	}{
+		{
+			name: "identical sessions produce no diffs",
+		},
+		{
+			name:   "message count drift",
+			stored: func(s *db.Session) { s.MessageCount = 3 },
+			want: []want{{
+				field: FieldMessageCount, stored: "3", parsed: "4",
+			}},
+		},
+		{
+			name:   "user message count drift",
+			stored: func(s *db.Session) { s.UserMessageCount = 1 },
+			want: []want{{
+				field: FieldUserMessageCount, stored: "1", parsed: "2",
+			}},
+		},
+		{
+			name: "first message nil stored vs empty parsed is no diff",
+			stored: func(s *db.Session) {
+				s.FirstMessage = nil
+			},
+			prepared: func(s *db.Session) {
+				s.FirstMessage = new("")
+			},
+		},
+		{
+			name: "first message empty stored vs nil parsed is no diff",
+			stored: func(s *db.Session) {
+				s.FirstMessage = new("")
+			},
+			prepared: func(s *db.Session) {
+				s.FirstMessage = nil
+			},
+		},
+		{
+			name: "first message drift",
+			prepared: func(s *db.Session) {
+				s.FirstMessage = new("different opener")
+			},
+			want: []want{{
+				field:  FieldFirstMessage,
+				stored: "hello there",
+				parsed: "different opener",
+			}},
+		},
+		{
+			name: "first message null vs value renders (null)",
+			stored: func(s *db.Session) {
+				s.FirstMessage = nil
+			},
+			want: []want{{
+				field:  FieldFirstMessage,
+				stored: "(null)",
+				parsed: "hello there",
+			}},
+		},
+		{
+			name: "session name nil vs empty is no diff",
+			stored: func(s *db.Session) {
+				s.SessionName = new("")
+			},
+			prepared: func(s *db.Session) {
+				s.SessionName = nil
+			},
+		},
+		{
+			name: "session name drift",
+			prepared: func(s *db.Session) {
+				s.SessionName = new("Renamed")
+			},
+			want: []want{{
+				field:  FieldSessionName,
+				stored: "My Session",
+				parsed: "Renamed",
+			}},
+		},
+		{
+			name: "total output tokens value drift",
+			prepared: func(s *db.Session) {
+				s.TotalOutputTokens = 121
+			},
+			want: []want{{
+				field:  FieldTotalOutputTokens,
+				stored: "120",
+				parsed: "121",
+			}},
+		},
+		{
+			name: "total output coverage-flag-only flip is a real diff",
+			prepared: func(s *db.Session) {
+				s.HasTotalOutputTokens = false
+			},
+			want: []want{{
+				field:  FieldTotalOutputTokens,
+				stored: "120",
+				parsed: "absent",
+			}},
+		},
+		{
+			name: "absent-on-both-sides values are not compared",
+			stored: func(s *db.Session) {
+				s.HasTotalOutputTokens = false
+				s.TotalOutputTokens = 0
+			},
+			prepared: func(s *db.Session) {
+				s.HasTotalOutputTokens = false
+				s.TotalOutputTokens = 7
+			},
+		},
+		{
+			name: "peak context tokens drift",
+			stored: func(s *db.Session) {
+				s.PeakContextTokens = 8000
+			},
+			want: []want{{
+				field:  FieldPeakContextTokens,
+				stored: "8000",
+				parsed: "9000",
+			}},
+		},
+		{
+			name: "termination stored null parsed value is informational",
+			stored: func(s *db.Session) {
+				s.TerminationStatus = nil
+			},
+			want: []want{{
+				field:         FieldTerminationStatus,
+				stored:        "(null)",
+				parsed:        "clean",
+				informational: true,
+			}},
+		},
+		{
+			name: "termination stored value parsed null is a real diff",
+			prepared: func(s *db.Session) {
+				s.TerminationStatus = nil
+			},
+			want: []want{{
+				field:  FieldTerminationStatus,
+				stored: "clean",
+				parsed: "(null)",
+			}},
+		},
+		{
+			name: "termination value drift is a real diff",
+			prepared: func(s *db.Session) {
+				s.TerminationStatus = new("awaiting_user")
+			},
+			want: []want{{
+				field:  FieldTerminationStatus,
+				stored: "clean",
+				parsed: "awaiting_user",
+			}},
+		},
+		{
+			name: "termination null on both sides is no diff",
+			stored: func(s *db.Session) {
+				s.TerminationStatus = nil
+			},
+			prepared: func(s *db.Session) {
+				s.TerminationStatus = nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := pdBaseSession()
+			prepared := pdBaseSession()
+			if tt.stored != nil {
+				tt.stored(&stored)
+			}
+			if tt.prepared != nil {
+				tt.prepared(&prepared)
+			}
+			diffs := compareSessionFields(&stored, prepared)
+			require.Len(t, diffs, len(tt.want))
+			for i, w := range tt.want {
+				assert.Equal(t, w.field, diffs[i].Field)
+				assert.Equal(t, w.stored, diffs[i].Stored)
+				assert.Equal(t, w.parsed, diffs[i].Parsed)
+				assert.Equal(
+					t, w.informational, diffs[i].Informational,
+				)
+			}
+		})
+	}
+}
+
+func TestCompareSessionFieldsTruncatesLongValues(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	stored := pdBaseSession()
+	prepared := pdBaseSession()
+	prepared.FirstMessage = new(long)
+
+	diffs := compareSessionFields(&stored, prepared)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, FieldFirstMessage, diffs[0].Field)
+	assert.Equal(
+		t, strings.Repeat("x", maxRenderedValueRunes)+"...",
+		diffs[0].Parsed,
+	)
+	assert.Contains(t, diffs[0].Detail, "parsed 200 runes")
+}
+
+func TestCompareSessionFieldsInformationalTerminationDetail(t *testing.T) {
+	stored := pdBaseSession()
+	stored.TerminationStatus = nil
+	prepared := pdBaseSession()
+
+	diffs := compareSessionFields(&stored, prepared)
+	require.Len(t, diffs, 1)
+	assert.True(t, diffs[0].Informational)
+	assert.Equal(t, "incremental-append history", diffs[0].Detail)
+}
+
+func pdMsg(ordinal int, model string, ctx, out int) db.Message {
+	return db.Message{
+		Ordinal:          ordinal,
+		Role:             "assistant",
+		Model:            model,
+		ContextTokens:    ctx,
+		OutputTokens:     out,
+		HasContextTokens: ctx != 0,
+		HasOutputTokens:  out != 0,
+	}
+}
+
+func TestCompareMessageMetadata(t *testing.T) {
+	t.Run("identical slices produce no diffs", func(t *testing.T) {
+		stored := []db.Message{
+			pdMsg(0, "", 0, 0), pdMsg(1, "model-a", 100, 5),
+		}
+		parsed := []db.Message{
+			pdMsg(0, "", 0, 0), pdMsg(1, "model-a", 100, 5),
+		}
+		assert.Empty(t, compareMessageMetadata(stored, parsed))
+	})
+
+	t.Run("model drift reports count and first ordinal", func(t *testing.T) {
+		stored := []db.Message{
+			pdMsg(0, "model-a", 0, 0),
+			pdMsg(1, "model-a", 0, 0),
+			pdMsg(2, "model-a", 0, 0),
+		}
+		parsed := []db.Message{
+			pdMsg(0, "model-a", 0, 0),
+			pdMsg(1, "model-b", 0, 0),
+			pdMsg(2, "model-b", 0, 0),
+		}
+		diffs := compareMessageMetadata(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldModels, diffs[0].Field)
+		assert.Equal(t, "model-a", diffs[0].Stored)
+		assert.Equal(t, "model-a, model-b", diffs[0].Parsed)
+		assert.Equal(
+			t,
+			"2/3 messages differ; first at ordinal 1: model-a -> model-b",
+			diffs[0].Detail,
+		)
+	})
+
+	t.Run("token value drift reports message tokens", func(t *testing.T) {
+		stored := []db.Message{pdMsg(0, "m", 100, 5)}
+		parsed := []db.Message{pdMsg(0, "m", 110, 5)}
+		diffs := compareMessageMetadata(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
+		assert.Equal(
+			t, "context=100 output=5 usage_bytes=0", diffs[0].Stored,
+		)
+		assert.Equal(
+			t, "context=110 output=5 usage_bytes=0", diffs[0].Parsed,
+		)
+		assert.Equal(
+			t, "1/1 messages differ; first at ordinal 0",
+			diffs[0].Detail,
+		)
+	})
+
+	t.Run("presence-flag-only flip is a token diff", func(t *testing.T) {
+		stored := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			OutputTokens: 0, HasOutputTokens: true,
+		}}
+		parsed := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			OutputTokens: 0, HasOutputTokens: false,
+		}}
+		diffs := compareMessageMetadata(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
+		assert.Contains(t, diffs[0].Stored, "output=0")
+		assert.Contains(t, diffs[0].Parsed, "output=absent")
+	})
+
+	t.Run("token_usage payload drift is a token diff", func(t *testing.T) {
+		stored := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			TokenUsage: json.RawMessage(`{"input_tokens":1}`),
+		}}
+		parsed := []db.Message{{
+			Ordinal: 0, Role: "assistant",
+			TokenUsage: json.RawMessage(`{"input_tokens":2}`),
+		}}
+		diffs := compareMessageMetadata(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldMessageTokens, diffs[0].Field)
+	})
+
+	t.Run("length mismatch compares the overlap only", func(t *testing.T) {
+		stored := []db.Message{pdMsg(0, "m", 100, 5)}
+		parsed := []db.Message{
+			pdMsg(0, "m", 100, 5),
+			pdMsg(1, "different-model", 999, 9),
+		}
+		assert.Empty(t, compareMessageMetadata(stored, parsed))
+	})
+
+	t.Run("alignment matches ordinal values not indices", func(t *testing.T) {
+		stored := []db.Message{
+			pdMsg(0, "m", 100, 5), pdMsg(2, "m", 200, 6),
+		}
+		parsed := []db.Message{
+			pdMsg(2, "m", 200, 6), pdMsg(0, "m", 100, 5),
+		}
+		assert.Empty(t, compareMessageMetadata(stored, parsed))
+	})
+}
+
+func pdEvent(
+	source, model string, in, out int, occurredAt, dedup string,
+	ordinal *int,
+) db.UsageEvent {
+	return db.UsageEvent{
+		Source:         source,
+		Model:          model,
+		InputTokens:    in,
+		OutputTokens:   out,
+		OccurredAt:     occurredAt,
+		DedupKey:       dedup,
+		MessageOrdinal: ordinal,
+	}
+}
+
+func TestCompareUsageEvents(t *testing.T) {
+	t.Run("both empty produces no diffs", func(t *testing.T) {
+		assert.Empty(t, compareUsageEvents(nil, nil))
+	})
+
+	t.Run("shuffled order produces no diffs", func(t *testing.T) {
+		a := pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "", new(0))
+		b := pdEvent("api", "m2", 20, 4, "2026-01-01T00:01:00Z", "", new(1))
+		c := pdEvent("api", "m1", 10, 2, "2026-01-01T00:02:00Z", "k1", nil)
+		stored := []db.UsageEvent{a, b, c}
+		parsed := []db.UsageEvent{c, a, b}
+		assert.Empty(t, compareUsageEvents(stored, parsed))
+	})
+
+	t.Run("removed event reports count and totals", func(t *testing.T) {
+		a := pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "", nil)
+		b := pdEvent("api", "m2", 20, 4, "2026-01-01T00:01:00Z", "", nil)
+		diffs := compareUsageEvents(
+			[]db.UsageEvent{a, b}, []db.UsageEvent{a},
+		)
+		require.Len(t, diffs, 2)
+		assert.Equal(t, FieldUsageEventCount, diffs[0].Field)
+		assert.Equal(t, "2", diffs[0].Stored)
+		assert.Equal(t, "1", diffs[0].Parsed)
+		assert.Equal(t, FieldUsageEventTotals, diffs[1].Field)
+		assert.Equal(t, "input 30 -> 10; output 6 -> 2", diffs[1].Detail)
+	})
+
+	t.Run("total drift with equal count reports totals only", func(t *testing.T) {
+		stored := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "", nil),
+		}
+		parsed := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 3, "2026-01-01T00:00:00Z", "", nil),
+		}
+		diffs := compareUsageEvents(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldUsageEventTotals, diffs[0].Field)
+		assert.Equal(t, "output 2 -> 3", diffs[0].Detail)
+		assert.Contains(t, diffs[0].Stored, "output=2")
+		assert.Contains(t, diffs[0].Parsed, "output=3")
+	})
+
+	t.Run("matching dedup keys override tuple drift", func(t *testing.T) {
+		// Same dedup key with a different occurred_at: the key is
+		// authoritative, totals match, so no diff.
+		stored := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "k1", nil),
+		}
+		parsed := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T09:09:09Z", "k1", nil),
+		}
+		assert.Empty(t, compareUsageEvents(stored, parsed))
+	})
+
+	t.Run("dedup key drift with equal totals reports composition", func(t *testing.T) {
+		stored := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "k1", nil),
+		}
+		parsed := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "k2", nil),
+		}
+		diffs := compareUsageEvents(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldUsageEventTotals, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "event composition differs")
+		assert.Contains(t, diffs[0].Detail, "dedup:k1")
+	})
+
+	t.Run("tuple fallback detects occurred_at drift", func(t *testing.T) {
+		stored := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "", nil),
+		}
+		parsed := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T09:09:09Z", "", nil),
+		}
+		diffs := compareUsageEvents(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldUsageEventTotals, diffs[0].Field)
+		assert.Contains(t, diffs[0].Detail, "event composition differs")
+	})
+
+	t.Run("dedup key drift in totals still reports totals", func(t *testing.T) {
+		// Same dedup key but token drift: the multiset is equal by
+		// key, yet the per-class sums must still be compared.
+		stored := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "k1", nil),
+		}
+		parsed := []db.UsageEvent{
+			pdEvent("api", "m1", 99, 2, "2026-01-01T00:00:00Z", "k1", nil),
+		}
+		diffs := compareUsageEvents(stored, parsed)
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldUsageEventTotals, diffs[0].Field)
+		assert.Equal(t, "input 10 -> 99", diffs[0].Detail)
+	})
+
+	t.Run("cost columns are ignored", func(t *testing.T) {
+		cost := 0.42
+		stored := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "", nil),
+		}
+		stored[0].CostUSD = &cost
+		stored[0].CostStatus = "final"
+		stored[0].CostSource = "pricing"
+		parsed := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "", nil),
+		}
+		assert.Empty(t, compareUsageEvents(stored, parsed))
+	})
+}
+
+// TestFingerprintTwinMatchesDB pins the in-memory fingerprint twin
+// against db.MessageTokenFingerprint for messages written through the
+// real bulk sync pipeline. Twin drift silently breaks the tier-1 fast
+// path, so this parity is the design's top risk.
+func TestFingerprintTwinMatchesDB(t *testing.T) {
+	d := openTestDB(t)
+	e := NewEngine(d, EngineConfig{Machine: "test-machine"})
+
+	ts := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	pw := pendingWrite{
+		sess: parser.ParsedSession{
+			ID:           "pd-twin-session",
+			Project:      "proj",
+			Machine:      "test-machine",
+			Agent:        parser.AgentClaude,
+			FirstMessage: "hello",
+			StartedAt:    ts,
+			EndedAt:      ts.Add(time.Minute),
+			MessageCount: 3,
+			File: parser.FileInfo{
+				Path:  "/tmp/pd-twin.jsonl",
+				Size:  100,
+				Mtime: ts.UnixNano(),
+			},
+		},
+		msgs: []parser.ParsedMessage{
+			{
+				Ordinal:       0,
+				Role:          parser.RoleUser,
+				Content:       "hello",
+				ContentLength: 5,
+				Timestamp:     ts,
+				SourceType:    "user",
+				SourceUUID:    "uuid-0",
+			},
+			{
+				Ordinal:       1,
+				Role:          parser.RoleAssistant,
+				Content:       "hi with NUL \x00 and unicode ünï",
+				ContentLength: 20,
+				Timestamp:     ts.Add(time.Second),
+				Model:         "claude-op\x00us-4",
+				TokenUsage: json.RawMessage(
+					`{"input_tokens":10,"output_tokens":2}`,
+				),
+				ContextTokens:    12,
+				OutputTokens:     2,
+				HasContextTokens: true,
+				HasOutputTokens:  true,
+				ClaudeMessageID:  "msg_01",
+				ClaudeRequestID:  "req_01",
+				SourceType:       "assistant",
+				SourceUUID:       "uuid-1",
+				SourceParentUUID: "uuid-0",
+			},
+			{
+				Ordinal:           2,
+				Role:              parser.RoleAssistant,
+				Content:           "sidechain boundary",
+				ContentLength:     18,
+				Timestamp:         ts.Add(2 * time.Second),
+				Model:             "claude-haiku",
+				IsSidechain:       true,
+				IsCompactBoundary: true,
+			},
+		},
+	}
+
+	written, _, failed := e.writeBatch(
+		[]pendingWrite{pw}, syncWriteBulk, false,
+	)
+	require.Equal(t, 1, written, "session must be written")
+	require.Zero(t, failed)
+
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+	require.NotEmpty(t, msgs)
+
+	storedFP, err := d.MessageTokenFingerprint(prepared.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, storedFP)
+
+	assert.Equal(
+		t, storedFP, messageTokenFingerprintTwin(msgs),
+		"in-memory twin must match db.MessageTokenFingerprint exactly",
+	)
+}
+
+// TestCompareStoredSessionRoundTrip proves that a session written
+// through the real pipeline compares as identical against itself,
+// covering the session row, message metadata, and usage events.
+func TestCompareStoredSessionRoundTrip(t *testing.T) {
+	d := openTestDB(t)
+	e := NewEngine(d, EngineConfig{Machine: "test-machine"})
+
+	ts := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	pw := pendingWrite{
+		sess: parser.ParsedSession{
+			ID:                "pd-roundtrip",
+			Project:           "proj",
+			Machine:           "test-machine",
+			Agent:             parser.AgentClaude,
+			FirstMessage:      "round trip",
+			SessionName:       "Round Trip",
+			StartedAt:         ts,
+			EndedAt:           ts.Add(time.Minute),
+			MessageCount:      2,
+			UserMessageCount:  1,
+			TerminationStatus: parser.TerminationClean,
+			File: parser.FileInfo{
+				Path:  "/tmp/pd-roundtrip.jsonl",
+				Size:  64,
+				Mtime: ts.UnixNano(),
+			},
+		},
+		msgs: []parser.ParsedMessage{
+			{
+				Ordinal:       0,
+				Role:          parser.RoleUser,
+				Content:       "round trip",
+				ContentLength: 10,
+				Timestamp:     ts,
+			},
+			{
+				Ordinal:       1,
+				Role:          parser.RoleAssistant,
+				Content:       "ack",
+				ContentLength: 3,
+				Timestamp:     ts.Add(time.Second),
+				Model:         "claude-sonnet",
+				TokenUsage: json.RawMessage(
+					`{"input_tokens":7,"output_tokens":3}`,
+				),
+				ContextTokens:    10,
+				OutputTokens:     3,
+				HasContextTokens: true,
+				HasOutputTokens:  true,
+			},
+		},
+		usageEvents: []parser.ParsedUsageEvent{
+			{
+				MessageOrdinal: new(1),
+				Source:         "transcript",
+				Model:          "claude-sonnet",
+				InputTokens:    7,
+				OutputTokens:   3,
+				OccurredAt:     "2026-06-01T10:00:01Z",
+				DedupKey:       "msg_rt:req_rt",
+			},
+		},
+	}
+
+	written, _, failed := e.writeBatch(
+		[]pendingWrite{pw}, syncWriteBulk, false,
+	)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+	events := toDBUsageEvents(prepared.ID, pw.usageEvents)
+
+	stored := pdFetchStored(t, d, prepared.ID)
+	diffs, err := e.compareStoredSession(
+		context.Background(), stored, prepared, msgs, events,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, diffs, "self-written session must be identical")
+}
+
+// TestCompareStoredSessionDetectsDrift mutates one stored column and
+// expects the comparator to attribute it through the database path.
+func TestCompareStoredSessionDetectsDrift(t *testing.T) {
+	d := openTestDB(t)
+	e := NewEngine(d, EngineConfig{Machine: "test-machine"})
+
+	ts := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	pw := pendingWrite{
+		sess: parser.ParsedSession{
+			ID:           "pd-drift",
+			Project:      "proj",
+			Machine:      "test-machine",
+			Agent:        parser.AgentClaude,
+			FirstMessage: "drift",
+			StartedAt:    ts,
+			MessageCount: 1,
+			File: parser.FileInfo{
+				Path:  "/tmp/pd-drift.jsonl",
+				Size:  32,
+				Mtime: ts.UnixNano(),
+			},
+		},
+		msgs: []parser.ParsedMessage{
+			{
+				Ordinal:       0,
+				Role:          parser.RoleAssistant,
+				Content:       "drift",
+				ContentLength: 5,
+				Timestamp:     ts,
+				Model:         "claude-sonnet",
+				OutputTokens:  3,
+			},
+		},
+	}
+	written, _, failed := e.writeBatch(
+		[]pendingWrite{pw}, syncWriteBulk, false,
+	)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+
+	// Simulate parser drift: the new parse reports a different model.
+	pw.msgs[0].Model = "claude-haiku"
+	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
+	require.True(t, ok)
+
+	stored := pdFetchStored(t, d, prepared.ID)
+	diffs, err := e.compareStoredSession(
+		context.Background(), stored, prepared, msgs, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+	assert.Equal(t, FieldModels, diffs[0].Field)
+	assert.Equal(t, "claude-sonnet", diffs[0].Stored)
+	assert.Equal(t, "claude-haiku", diffs[0].Parsed)
+	assert.Contains(t, diffs[0].Detail, "first at ordinal 0")
+}
+
+func pdFetchStored(t *testing.T, d *db.DB, id string) *db.Session {
+	t.Helper()
+	sessions, err := d.ListSessionsModifiedBetween(
+		context.Background(), "", "", nil, nil,
+	)
+	require.NoError(t, err)
+	for i := range sessions {
+		if sessions[i].ID == id {
+			return &sessions[i]
+		}
+	}
+	require.Failf(t, "session not found", "id %s", id)
+	return nil
+}
+
+func TestParseDiffClassifyPrecedence(t *testing.T) {
+	tests := []struct {
+		name          string
+		needsRetry    bool
+		prepared      bool
+		hasStored     bool
+		storedTrashed bool
+		pendingResync bool
+		realDiffs     int
+		wantClass     DiffClass
+		wantReason    string
+	}{
+		{
+			name:       "needs retry wins over everything",
+			needsRetry: true, prepared: false, hasStored: true,
+			storedTrashed: true, pendingResync: true, realDiffs: 3,
+			wantClass:  DiffNeedsRetry,
+			wantReason: "transient low-fidelity parse; differences expected",
+		},
+		{
+			name:     "archive-preserve veto wins over missing stored row",
+			prepared: false, hasStored: false,
+			wantClass:  DiffExcluded,
+			wantReason: "archive-preserved",
+		},
+		{
+			name:     "no stored row is new on disk",
+			prepared: true, hasStored: false,
+			wantClass: DiffNewOnDisk,
+		},
+		{
+			name:     "trashed stored row wins over pending resync",
+			prepared: true, hasStored: true, storedTrashed: true,
+			pendingResync: true, realDiffs: 2,
+			wantClass:  DiffExcluded,
+			wantReason: "trashed in archive",
+		},
+		{
+			name:     "pending resync wins over changed",
+			prepared: true, hasStored: true, pendingResync: true,
+			realDiffs: 2,
+			wantClass: DiffPendingResync,
+		},
+		{
+			name:     "real diffs mean changed",
+			prepared: true, hasStored: true, realDiffs: 1,
+			wantClass: DiffChanged,
+		},
+		{
+			name:     "no real diffs mean identical",
+			prepared: true, hasStored: true, realDiffs: 0,
+			wantClass: DiffIdentical,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class, reason := classifyParseDiffSession(
+				tt.needsRetry, tt.prepared, tt.hasStored,
+				tt.storedTrashed, tt.pendingResync, tt.realDiffs,
+			)
+			assert.Equal(t, tt.wantClass, class)
+			assert.Equal(t, tt.wantReason, reason)
+		})
+	}
+}
+
+func TestParseDiffReportHasFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		totals ParseDiffTotals
+		want   bool
+	}{
+		{name: "empty report has no failures"},
+		{
+			name:   "identical only",
+			totals: ParseDiffTotals{Identical: 10, Examined: 10},
+		},
+		{
+			name:   "changed sessions fail",
+			totals: ParseDiffTotals{Changed: 1},
+			want:   true,
+		},
+		{
+			name:   "parse errors fail",
+			totals: ParseDiffTotals{ParseErrors: 1},
+			want:   true,
+		},
+		{
+			name:   "both fail",
+			totals: ParseDiffTotals{Changed: 2, ParseErrors: 3},
+			want:   true,
+		},
+		{
+			name: "pending resync, skipped, retry, new do not fail",
+			totals: ParseDiffTotals{
+				PendingResync: 4, Skipped: 9,
+				NeedsRetry: 2, NewOnDisk: 3,
+				ExcludedByParser: 1, InformationalOnly: 5,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ParseDiffReport{Totals: tt.totals}
+			assert.Equal(t, tt.want, r.HasFailures())
+		})
+	}
+}

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -884,6 +884,41 @@ func TestCompareUsageEvents(t *testing.T) {
 		assert.Contains(t, diffs[0].Detail, "event composition differs")
 	})
 
+	t.Run("dedup keyed token redistribution surfaces", func(t *testing.T) {
+		// Equal event count, equal aggregate totals, and stable
+		// dedup keys, but the per-event token payload changed.
+		// --fail-on-change must not pass over that data drift.
+		stored := []db.UsageEvent{
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "k1", nil),
+			pdEvent("api", "m1", 20, 4, "2026-01-01T00:01:00Z", "k2", nil),
+		}
+		stored[0].CacheCreationInputTokens = 1
+		stored[1].CacheCreationInputTokens = 3
+		stored[0].CacheReadInputTokens = 5
+		stored[1].CacheReadInputTokens = 7
+		stored[0].ReasoningTokens = 11
+		stored[1].ReasoningTokens = 13
+		parsed := []db.UsageEvent{
+			pdEvent("api", "m1", 20, 4, "2026-01-01T00:00:00Z", "k1", nil),
+			pdEvent("api", "m1", 10, 2, "2026-01-01T00:01:00Z", "k2", nil),
+		}
+		parsed[0].CacheCreationInputTokens = 3
+		parsed[1].CacheCreationInputTokens = 1
+		parsed[0].CacheReadInputTokens = 7
+		parsed[1].CacheReadInputTokens = 5
+		parsed[0].ReasoningTokens = 13
+		parsed[1].ReasoningTokens = 11
+
+		diffs := compareUsageEvents(stored, parsed)
+
+		require.Len(t, diffs, 1)
+		assert.Equal(t, FieldUsageEventTotals, diffs[0].Field)
+		assert.Equal(t, sumUsageTokenTotals(stored).render(), diffs[0].Stored)
+		assert.Equal(t, sumUsageTokenTotals(parsed).render(), diffs[0].Parsed)
+		assert.Contains(t, diffs[0].Detail, "event composition differs")
+		assert.Contains(t, diffs[0].Detail, "dedup|k1")
+	})
+
 	t.Run("tuple fallback detects occurred_at drift", func(t *testing.T) {
 		stored := []db.UsageEvent{
 			pdEvent("api", "m1", 10, 2, "2026-01-01T00:00:00Z", "", nil),

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -111,6 +111,33 @@ func parseDiffClaudeContent(prompt, reply string) string {
 		String()
 }
 
+// parseDiffClaudeContentRich builds a Claude session that exercises the
+// thinking, tool_use/tool_result, and system-message paths, so the
+// clean-archive acid test covers the message-flag and tool-call
+// comparisons against real parsed data rather than empty fingerprints.
+func parseDiffClaudeContentRich() string {
+	return testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "run the build").
+		AddRaw(testjsonl.ClaudeAssistantJSON(
+			[]map[string]any{
+				{"type": "thinking", "thinking": "I should run make build"},
+				{"type": "text", "text": "Running the build now."},
+				{
+					"type":  "tool_use",
+					"id":    "tu-1",
+					"name":  "Bash",
+					"input": map[string]any{"command": "make build"},
+				},
+			},
+			tsEarlyS1,
+		)).
+		AddRaw(testjsonl.ClaudeToolResultUserJSON(
+			"tu-1", "build succeeded", tsEarlyS5,
+		)).
+		AddClaudeMetaUser(tsEarlyS5, "system notice", true, false).
+		String()
+}
+
 // parseDiffCodexContent builds a minimal Codex rollout session with
 // the given session ID.
 func parseDiffCodexContent(id string) string {
@@ -141,8 +168,11 @@ func parseDiffGeminiContent(sessionID, hash string) string {
 func TestParseDiffCleanArchiveIsIdentical(t *testing.T) {
 	env := setupTestEnv(t)
 
+	// pd-alpha carries thinking, a tool_use/tool_result pair, and a
+	// system message so the run exercises the message-flag and tool-call
+	// comparisons, not just the summary fields.
 	env.writeClaudeSession(t, "test-proj", "pd-alpha.jsonl",
-		parseDiffClaudeContent("alpha prompt", "alpha reply"))
+		parseDiffClaudeContentRich())
 	env.writeClaudeSession(t, "test-proj", "pd-beta.jsonl",
 		parseDiffClaudeContent("beta prompt", "beta reply"))
 	env.writeCodexSession(
@@ -303,6 +333,97 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 		assert.Empty(t, sessionDiffFieldNames(sd, false),
 			"control session non-informational fields")
 	}
+	assert.True(t, report.HasFailures(), "HasFailures with drift")
+}
+
+// TestParseDiffDetectsExtendedFieldDrift covers the comparator surface
+// added beyond the summary fields end-to-end: tool_call drift, a
+// per-message flag, a full-replace-agent session-metadata field, and the
+// informational-for-incremental rule on a Claude session.
+func TestParseDiffDetectsExtendedFieldDrift(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Two rich Claude sessions (thinking + tool_use/result + system),
+	// one minimal Claude session, and a full-replace Gemini session.
+	env.writeClaudeSession(t, "test-proj", "pd-ext-tool.jsonl",
+		parseDiffClaudeContentRich())
+	env.writeClaudeSession(t, "test-proj", "pd-ext-flag.jsonl",
+		parseDiffClaudeContentRich())
+	env.writeClaudeSession(t, "test-proj", "pd-ext-cwd.jsonl",
+		parseDiffClaudeContent("cwd prompt", "cwd reply"))
+	env.writeGeminiSession(t,
+		filepath.Join("tmp", "exthash", "chats", "session-001.json"),
+		parseDiffGeminiContent("pd-ext-branch", "exthash"))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 4, Synced: 4,
+	})
+
+	// Tool-call drift: rename a stored tool call. None of the message
+	// token/role/content/flag fingerprints move, so this is caught only
+	// via the tool-call fingerprint.
+	mutateDB(t, env,
+		"UPDATE tool_calls SET tool_name = ? WHERE session_id = ?",
+		"DRIFTED", "pd-ext-tool")
+	// Flag drift: flip has_thinking on the assistant message (the one
+	// carrying the tool use). Only the flags fingerprint moves.
+	mutateDB(t, env,
+		"UPDATE messages SET has_thinking = NOT has_thinking"+
+			" WHERE session_id = ? AND has_tool_use = 1", "pd-ext-flag")
+	// Incremental-append session field on a Claude session: a real
+	// difference, but classified informational, so the session stays
+	// identical rather than changed.
+	mutateDB(t, env,
+		"UPDATE sessions SET cwd = ? WHERE id = ?",
+		"/drifted/path", "pd-ext-cwd")
+	// Full-replace-agent session metadata: Gemini does not take the
+	// incremental path, so a git_branch difference is real drift.
+	mutateDB(t, env,
+		"UPDATE sessions SET git_branch = ? WHERE id = ?",
+		"feature-x", "gemini:pd-ext-branch")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 4, Identical: 1, Changed: 3, InformationalOnly: 1,
+	}, report.Totals, "totals")
+
+	cases := []struct {
+		name      string
+		sessionID string
+		field     string
+	}{
+		{"tool call drift", "pd-ext-tool", sync.FieldToolCalls},
+		{"flag drift", "pd-ext-flag", sync.FieldMessageMetadata},
+		{"git_branch drift", "gemini:pd-ext-branch", sync.FieldGitBranch},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sd := findSessionDiff(report, tc.sessionID)
+			require.NotNil(t, sd, "session %q not listed", tc.sessionID)
+			assert.Equal(t, sync.DiffChanged, sd.Class,
+				"class for %q", tc.sessionID)
+			assert.ElementsMatch(t, []string{tc.field},
+				sessionDiffFieldNames(sd, false),
+				"non-informational fields for %q", tc.sessionID)
+			assert.Equal(t, 1, report.FieldCounts[tc.field],
+				"FieldCounts[%s]", tc.field)
+		})
+	}
+
+	t.Run("incremental cwd drift is informational", func(t *testing.T) {
+		sd := findSessionDiff(report, "pd-ext-cwd")
+		require.NotNil(t, sd, "pd-ext-cwd not listed")
+		assert.Equal(t, sync.DiffIdentical, sd.Class,
+			"informational-only session stays identical")
+		assert.Empty(t, sessionDiffFieldNames(sd, false),
+			"no non-informational fields")
+		assert.Contains(t, sessionDiffFieldNames(sd, true), sync.FieldCwd,
+			"informational cwd diff must be attached")
+		assert.Zero(t, report.FieldCounts[sync.FieldCwd],
+			"informational diffs are excluded from FieldCounts")
+	})
+
 	assert.True(t, report.HasFailures(), "HasFailures with drift")
 }
 

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1,0 +1,583 @@
+package sync_test
+
+// Integration tests for the report-only parse-diff mode. They are
+// written strictly against the exported contract in parsediff.go and
+// parsediff_report.go: assertions go through DiffClass buckets, the
+// Field* name constants, and ParseDiffTotals — never through rendered
+// strings, whose exact wording belongs to the renderer.
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+// newParseDiffEngine builds a report-only diff engine over the same
+// database and agent directories the setupTestEnv harness used for
+// the initial SyncAll.
+func newParseDiffEngine(env *testEnv) *sync.Engine {
+	return sync.NewDiffEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude:         {env.claudeDir},
+			parser.AgentCodex:          {env.codexDir},
+			parser.AgentCursor:         {env.cursorDir},
+			parser.AgentGemini:         {env.geminiDir},
+			parser.AgentOpenCode:       {env.opencodeDir},
+			parser.AgentForge:          {env.forgeDir},
+			parser.AgentPiebald:        {env.piebaldDir},
+			parser.AgentIflow:          {env.iflowDir},
+			parser.AgentAmp:            {env.ampDir},
+			parser.AgentPi:             {env.piDir},
+			parser.AgentKiro:           {env.kiroDir},
+			parser.AgentAntigravityCLI: {env.antigravityCLIDir},
+		},
+		Machine: "local",
+	})
+}
+
+// runParseDiff runs ParseDiff with the given options and fails the
+// test on error or a nil report.
+func runParseDiff(
+	t *testing.T, env *testEnv, opts sync.ParseDiffOptions,
+) *sync.ParseDiffReport {
+	t.Helper()
+	report, err := newParseDiffEngine(env).ParseDiff(
+		context.Background(), opts,
+	)
+	require.NoError(t, err, "ParseDiff")
+	require.NotNil(t, report, "ParseDiff report")
+	return report
+}
+
+// findSessionDiff returns the listed SessionDiff for the given
+// session ID, or nil when the session is not listed.
+func findSessionDiff(
+	report *sync.ParseDiffReport, sessionID string,
+) *sync.SessionDiff {
+	for i := range report.Sessions {
+		if report.Sessions[i].SessionID == sessionID {
+			return &report.Sessions[i]
+		}
+	}
+	return nil
+}
+
+// sessionDiffFieldNames collects the Field names attached to one
+// session diff. Informational diffs are excluded unless
+// includeInformational is set.
+func sessionDiffFieldNames(
+	sd *sync.SessionDiff, includeInformational bool,
+) []string {
+	var names []string
+	for _, f := range sd.Fields {
+		if f.Informational && !includeInformational {
+			continue
+		}
+		names = append(names, f.Field)
+	}
+	return names
+}
+
+// mutateDB executes a single statement against the archive to
+// simulate stored-row drift.
+func mutateDB(
+	t *testing.T, env *testEnv, query string, args ...any,
+) {
+	t.Helper()
+	err := env.db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(query, args...)
+		return err
+	})
+	require.NoError(t, err, "mutate db: %s", query)
+}
+
+// parseDiffClaudeContent builds a minimal two-message Claude session.
+func parseDiffClaudeContent(prompt, reply string) string {
+	return testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, prompt).
+		AddClaudeAssistant(tsEarlyS5, reply).
+		String()
+}
+
+// parseDiffCodexContent builds a minimal Codex rollout session with
+// the given session ID.
+func parseDiffCodexContent(id string) string {
+	return testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, id, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Add tests").
+		AddCodexMessage(tsEarlyS5, "assistant", "Adding coverage.").
+		String()
+}
+
+// parseDiffGeminiContent builds a minimal two-message Gemini session.
+func parseDiffGeminiContent(sessionID, hash string) string {
+	return testjsonl.GeminiSessionJSON(
+		sessionID, hash, tsEarly, tsEarlyS5,
+		[]map[string]any{
+			testjsonl.GeminiUserMsg("u1", tsEarly, "Explain this"),
+			testjsonl.GeminiAssistantMsg(
+				"a1", tsEarlyS5, "Here you go.", nil,
+			),
+		},
+	)
+}
+
+// TestParseDiffCleanArchiveIsIdentical is the false-diff acid test:
+// a freshly synced archive re-parsed by the same binary must come
+// back identical on every session, with no field counts and no
+// listed sessions.
+func TestParseDiffCleanArchiveIsIdentical(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.writeClaudeSession(t, "test-proj", "pd-alpha.jsonl",
+		parseDiffClaudeContent("alpha prompt", "alpha reply"))
+	env.writeClaudeSession(t, "test-proj", "pd-beta.jsonl",
+		parseDiffClaudeContent("beta prompt", "beta reply"))
+	env.writeCodexSession(
+		t, filepath.Join("2024", "01", "15"),
+		"rollout-20240115-pd-codex.jsonl",
+		parseDiffCodexContent("pd-codex"),
+	)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 3, Synced: 3,
+	})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+
+	assert.Equal(t, db.CurrentDataVersion(), report.DataVersion,
+		"report data version")
+	assert.Equal(t, 3, report.FilesExamined, "files examined")
+	assert.False(t, report.FilesLimited, "files limited")
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 3, Identical: 3,
+	}, report.Totals, "totals")
+	assert.Empty(t, report.FieldCounts, "field counts")
+	assert.Empty(t, report.Sessions,
+		"identical sessions must not be listed")
+	assert.False(t, report.HasFailures(), "HasFailures")
+}
+
+// TestParseDiffDetectsStoredDrift mutates stored rows directly after
+// a sync and verifies each drifted session is classified DiffChanged
+// with the expected field names while an untouched control session
+// stays identical.
+func TestParseDiffDetectsStoredDrift(t *testing.T) {
+	env := setupTestEnv(t)
+
+	ids := []string{
+		"pd-count", "pd-first", "pd-model",
+		"pd-term", "pd-usage", "pd-control",
+	}
+	for _, id := range ids {
+		env.writeClaudeSession(t, "test-proj", id+".jsonl",
+			parseDiffClaudeContent(id+" prompt", id+" reply"))
+	}
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 6, Synced: 6,
+	})
+
+	// Simulate drift between the stored rows and what the current
+	// parser produces from the unchanged source files.
+	mutateDB(t, env,
+		"UPDATE sessions SET message_count = message_count + 5"+
+			" WHERE id = ?", "pd-count")
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-first")
+	mutateDB(t, env,
+		"UPDATE messages SET model = ? WHERE session_id = ?",
+		"drifted-model", "pd-model")
+	// The parser classifies this fixture's termination; store a
+	// different non-null value so the diff is real drift, not the
+	// informational cleared-to-NULL case.
+	mutateDB(t, env,
+		"UPDATE sessions SET termination_status = ? WHERE id = ?",
+		"truncated", "pd-term")
+	// The Claude parser emits no usage events for this fixture, so
+	// a synthetic stored event is pure drift.
+	require.NoError(t, env.db.ReplaceSessionUsageEvents(
+		"pd-usage", []db.UsageEvent{{
+			SessionID: "pd-usage",
+			Source:    "synthetic",
+			Model:     "synthetic-model",
+		}},
+	), "insert synthetic usage event")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+
+	assert.Equal(t, 6, report.FilesExamined, "files examined")
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 6, Identical: 1, Changed: 5,
+	}, report.Totals, "totals")
+
+	cases := []struct {
+		name      string
+		sessionID string
+		field     string
+		// exact asserts the drifted field is the only
+		// non-informational diff; otherwise presence suffices
+		// (a synthetic usage event may also move totals).
+		exact bool
+	}{
+		{"message count drift", "pd-count", sync.FieldMessageCount, true},
+		{"first message drift", "pd-first", sync.FieldFirstMessage, true},
+		{"model drift", "pd-model", sync.FieldModels, true},
+		{"termination status drift", "pd-term", sync.FieldTerminationStatus, true},
+		{"usage event drift", "pd-usage", sync.FieldUsageEventCount, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sd := findSessionDiff(report, tc.sessionID)
+			require.NotNil(t, sd, "session %q not listed", tc.sessionID)
+			assert.Equal(t, sync.DiffChanged, sd.Class,
+				"class for %q", tc.sessionID)
+			got := sessionDiffFieldNames(sd, false)
+			if tc.exact {
+				assert.ElementsMatch(t, []string{tc.field}, got,
+					"non-informational fields for %q", tc.sessionID)
+			} else {
+				assert.Contains(t, got, tc.field,
+					"fields for %q", tc.sessionID)
+			}
+			assert.Equal(t, 1, report.FieldCounts[tc.field],
+				"FieldCounts[%s]", tc.field)
+		})
+	}
+
+	if sd := findSessionDiff(report, "pd-control"); sd != nil {
+		assert.Equal(t, sync.DiffIdentical, sd.Class,
+			"control session class")
+		assert.Empty(t, sessionDiffFieldNames(sd, false),
+			"control session non-informational fields")
+	}
+	assert.True(t, report.HasFailures(), "HasFailures with drift")
+}
+
+// TestParseDiffWritesNothing verifies the report-only promise: the
+// stored drift is detected but not repaired, and nothing is persisted
+// (no skip cache entries, no row rewrites).
+func TestParseDiffWritesNothing(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.writeClaudeSession(t, "test-proj", "pd-keep.jsonl",
+		parseDiffClaudeContent("keep prompt", "keep reply"))
+	geminiPath := env.writeGeminiSession(
+		t, filepath.Join("tmp", "pdhash", "chats", "session-001.json"),
+		parseDiffGeminiContent("pd-err", "pdhash"),
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2, Synced: 2,
+	})
+
+	// Corrupt the Gemini source so the diff run exercises the parse
+	// error path, which a writing sync would record in skipped_files.
+	dbtest.WriteTestFile(t, geminiPath, []byte("{corrupt"))
+
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-keep")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Changed: 1, ParseErrors: 1,
+	}, report.Totals, "totals")
+
+	// The drift must still be there: ParseDiff reports, never fixes.
+	sess, err := env.db.GetSessionFull(
+		context.Background(), "pd-keep",
+	)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "session pd-keep not found")
+	require.NotNil(t, sess.FirstMessage, "first_message is NULL")
+	assert.Equal(t, "drifted first message", *sess.FirstMessage,
+		"ParseDiff must not repair stored drift")
+
+	// The corrupt session's archived rows are untouched.
+	assertSessionMessageCount(t, env.db, "gemini:pd-err", 2)
+
+	// Nothing was persisted: the parse error did not land in the
+	// skip cache table.
+	skipped, err := env.db.LoadSkippedFiles()
+	require.NoError(t, err, "LoadSkippedFiles")
+	assert.Empty(t, skipped, "skipped_files must stay empty")
+}
+
+// TestParseDiffBypassesSkipLayers proves ParseDiff re-parses every
+// file even when the sync engine's size/mtime/skip-cache layers
+// would skip it, by appending to a source file without re-syncing.
+func TestParseDiffBypassesSkipLayers(t *testing.T) {
+	env := setupTestEnv(t)
+
+	path := env.writeClaudeSession(t, "test-proj", "pd-skip.jsonl",
+		parseDiffClaudeContent("skip prompt", "skip reply"))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+	// Second pass proves the skip layers are armed.
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 0, Skipped: 1,
+	})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+	assert.Equal(t, 1, report.FilesExamined,
+		"skip layers must not hide files from ParseDiff")
+	assert.Positive(t, report.Totals.Examined, "examined sessions")
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Identical: 1,
+	}, report.Totals, "totals before append")
+
+	// Append one more message without syncing. The incremental
+	// append path would normally absorb this; a full re-parse must
+	// surface it as a message count change instead.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open session file for append")
+	_, err = f.WriteString(testjsonl.ClaudeAssistantJSON(
+		[]map[string]any{{"type": "text", "text": "appended reply"}},
+		"2024-01-01T10:00:10Z",
+	) + "\n")
+	require.NoError(t, err, "append message line")
+	require.NoError(t, f.Close(), "close session file")
+
+	report = runParseDiff(t, env, sync.ParseDiffOptions{})
+	assert.Equal(t, 1, report.FilesExamined, "files examined")
+	assert.Equal(t, 1, report.Totals.Changed, "changed sessions")
+
+	sd := findSessionDiff(report, "pd-skip")
+	require.NotNil(t, sd, "session pd-skip not listed")
+	assert.Equal(t, sync.DiffChanged, sd.Class, "class")
+	assert.Contains(t, sessionDiffFieldNames(sd, false),
+		sync.FieldMessageCount,
+		"appended message must surface as a message_count diff")
+	assert.Equal(t, 1, report.FieldCounts[sync.FieldMessageCount],
+		"FieldCounts[message_count]")
+}
+
+// TestParseDiffBuckets covers the non-compared classification
+// buckets: skipped (source missing), new on disk, pending resync,
+// and parse error.
+func TestParseDiffBuckets(t *testing.T) {
+	t.Run("source missing", func(t *testing.T) {
+		env := setupTestEnv(t)
+		path := env.writeClaudeSession(
+			t, "test-proj", "pd-gone.jsonl",
+			parseDiffClaudeContent("gone prompt", "gone reply"),
+		)
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+		require.NoError(t, os.Remove(path), "remove source file")
+
+		report := runParseDiff(t, env, sync.ParseDiffOptions{})
+		assert.Equal(t, 0, report.FilesExamined, "files examined")
+		assert.Equal(t, sync.ParseDiffTotals{
+			Skipped: 1,
+		}, report.Totals, "totals")
+
+		sd := findSessionDiff(report, "pd-gone")
+		require.NotNil(t, sd, "session pd-gone not listed")
+		assert.Equal(t, sync.DiffSkipped, sd.Class, "class")
+		assert.NotEmpty(t, sd.Reason, "skip reason")
+	})
+
+	t.Run("new on disk", func(t *testing.T) {
+		env := setupTestEnv(t)
+		env.writeClaudeSession(t, "test-proj", "pd-base.jsonl",
+			parseDiffClaudeContent("base prompt", "base reply"))
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+		// Written after the sync: the archive is behind the disk.
+		env.writeClaudeSession(t, "test-proj", "pd-new.jsonl",
+			parseDiffClaudeContent("new prompt", "new reply"))
+
+		report := runParseDiff(t, env, sync.ParseDiffOptions{})
+		assert.Equal(t, 2, report.FilesExamined, "files examined")
+		assert.Equal(t, sync.ParseDiffTotals{
+			Examined: 1, Identical: 1, NewOnDisk: 1,
+		}, report.Totals, "totals")
+
+		sd := findSessionDiff(report, "pd-new")
+		require.NotNil(t, sd, "session pd-new not listed")
+		assert.Equal(t, sync.DiffNewOnDisk, sd.Class, "class")
+	})
+
+	t.Run("pending resync", func(t *testing.T) {
+		env := setupTestEnv(t)
+		env.writeClaudeSession(t, "test-proj", "pd-stale.jsonl",
+			parseDiffClaudeContent("stale prompt", "stale reply"))
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+
+		staleVersion := db.CurrentDataVersion() - 1
+		require.NoError(t,
+			env.db.SetSessionDataVersion("pd-stale", staleVersion),
+			"downgrade data_version")
+		// A real field diff that must NOT count as parser drift.
+		mutateDB(t, env,
+			"UPDATE sessions SET first_message = ? WHERE id = ?",
+			"drifted first message", "pd-stale")
+
+		report := runParseDiff(t, env, sync.ParseDiffOptions{})
+		assert.Equal(t, sync.ParseDiffTotals{
+			Examined: 1, PendingResync: 1,
+		}, report.Totals, "totals")
+		assert.Empty(t, report.FieldCounts,
+			"pending_resync diffs must not be counted")
+
+		sd := findSessionDiff(report, "pd-stale")
+		require.NotNil(t, sd, "session pd-stale not listed")
+		assert.Equal(t, sync.DiffPendingResync, sd.Class, "class")
+		assert.Equal(t, staleVersion, sd.StoredDataVersion,
+			"stored data version")
+		// Field diffs are still attached for drill-down.
+		assert.Contains(t, sessionDiffFieldNames(sd, true),
+			sync.FieldFirstMessage,
+			"pending_resync field diffs attached for drill-down")
+		assert.False(t, report.HasFailures(),
+			"pending_resync must not trip HasFailures")
+	})
+
+	t.Run("parse error", func(t *testing.T) {
+		env := setupTestEnv(t)
+		env.writeClaudeSession(t, "test-proj", "pd-ok.jsonl",
+			parseDiffClaudeContent("ok prompt", "ok reply"))
+		geminiPath := env.writeGeminiSession(
+			t, filepath.Join(
+				"tmp", "badhash", "chats", "session-001.json",
+			),
+			parseDiffGeminiContent("pd-bad", "badhash"),
+		)
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 2, Synced: 2,
+		})
+		dbtest.WriteTestFile(t, geminiPath, []byte("{corrupt"))
+
+		// The corrupt file must not abort the run.
+		report := runParseDiff(t, env, sync.ParseDiffOptions{})
+		assert.Equal(t, sync.ParseDiffTotals{
+			Examined: 1, Identical: 1, ParseErrors: 1,
+		}, report.Totals, "totals")
+
+		sd := findSessionDiff(report, "gemini:pd-bad")
+		require.NotNil(t, sd, "session gemini:pd-bad not listed")
+		assert.Equal(t, sync.DiffParseError, sd.Class, "class")
+		assert.True(t, report.HasFailures(),
+			"parse errors must trip HasFailures")
+	})
+}
+
+// TestParseDiffLimitNewestFirst verifies Limit samples files newest
+// mtime first and reports the unexamined sessions as skipped.
+func TestParseDiffLimitNewestFirst(t *testing.T) {
+	env := setupTestEnv(t)
+
+	base := time.Now()
+	files := []struct {
+		id    string
+		mtime time.Time
+	}{
+		{"pd-oldest", base.Add(-2 * time.Hour)},
+		{"pd-middle", base.Add(-1 * time.Hour)},
+		{"pd-newest", base},
+	}
+	for _, f := range files {
+		path := env.writeClaudeSession(
+			t, "test-proj", f.id+".jsonl",
+			parseDiffClaudeContent(f.id+" prompt", f.id+" reply"),
+		)
+		require.NoError(t, os.Chtimes(path, f.mtime, f.mtime),
+			"chtimes %s", path)
+	}
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 3, Synced: 3,
+	})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{Limit: 1})
+
+	assert.Equal(t, 1, report.FilesExamined, "files examined")
+	assert.True(t, report.FilesLimited, "files limited")
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Identical: 1, Skipped: 2,
+	}, report.Totals, "totals")
+
+	for _, id := range []string{"pd-oldest", "pd-middle"} {
+		sd := findSessionDiff(report, id)
+		require.NotNil(t, sd, "session %q not listed", id)
+		assert.Equal(t, sync.DiffSkipped, sd.Class,
+			"class for %q", id)
+		assert.NotEmpty(t, sd.Reason, "skip reason for %q", id)
+	}
+	// The newest file was the one examined; it round-trips clean so
+	// it is either unlisted or listed as identical.
+	if sd := findSessionDiff(report, "pd-newest"); sd != nil {
+		assert.Equal(t, sync.DiffIdentical, sd.Class,
+			"newest session class")
+	}
+}
+
+// TestParseDiffAgentScope verifies Agents restricts the run to the
+// requested agents and that agents without an on-disk source to
+// re-parse are rejected.
+func TestParseDiffAgentScope(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.writeClaudeSession(t, "test-proj", "pd-claude.jsonl",
+		parseDiffClaudeContent("claude prompt", "claude reply"))
+	env.writeCodexSession(
+		t, filepath.Join("2024", "01", "15"),
+		"rollout-20240115-pd-codex.jsonl",
+		parseDiffCodexContent("pd-codex"),
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2, Synced: 2,
+	})
+
+	engine := newParseDiffEngine(env)
+	report, err := engine.ParseDiff(
+		context.Background(), sync.ParseDiffOptions{
+			Agents: []parser.AgentType{parser.AgentCodex},
+		},
+	)
+	require.NoError(t, err, "ParseDiff scoped to codex")
+	require.NotNil(t, report, "ParseDiff report")
+
+	assert.Equal(t, 1, report.FilesExamined,
+		"claude files must not be counted in a codex-scoped run")
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Identical: 1,
+	}, report.Totals, "totals")
+	for _, s := range report.Sessions {
+		assert.NotEqual(t, "claude", s.Agent,
+			"claude session listed in codex-scoped run: %+v", s)
+		assert.NotEqual(t, "pd-claude", s.SessionID,
+			"claude session listed in codex-scoped run: %+v", s)
+	}
+	if len(report.Agents) > 0 {
+		assert.Contains(t, report.Agents, "codex", "report agents")
+		assert.NotContains(t, report.Agents, "claude", "report agents")
+	}
+
+	// Database-backed agents have no on-disk source to re-parse.
+	_, err = engine.ParseDiff(
+		context.Background(), sync.ParseDiffOptions{
+			Agents: []parser.AgentType{parser.AgentClaudeAI},
+		},
+	)
+	require.Error(t, err,
+		"ParseDiff must reject database-backed agents")
+}

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -581,3 +581,72 @@ func TestParseDiffAgentScope(t *testing.T) {
 	require.Error(t, err,
 		"ParseDiff must reject database-backed agents")
 }
+
+func TestParseDiffPresenceSweep(t *testing.T) {
+	t.Run("current-version row no longer emitted", func(t *testing.T) {
+		env := setupTestEnv(t)
+		path := env.writeClaudeSession(t, "test-proj", "pd-real.jsonl",
+			parseDiffClaudeContent("real prompt", "real reply"))
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+
+		// A current-version row under the same source file with an ID
+		// today's parser never derives: the loudest drift signal.
+		require.NoError(t, env.db.UpsertSession(db.Session{
+			ID: "pd-phantom", Project: "test-proj", Machine: "local",
+			Agent: "claude", FilePath: &path,
+		}), "insert phantom session")
+		require.NoError(t,
+			env.db.SetSessionDataVersion(
+				"pd-phantom", db.CurrentDataVersion(),
+			), "stamp current data version")
+
+		report := runParseDiff(t, env, sync.ParseDiffOptions{})
+		assert.Equal(t, sync.ParseDiffTotals{
+			Examined: 2, Identical: 1, Changed: 1,
+		}, report.Totals, "totals")
+		assert.Equal(t, map[string]int{sync.FieldPresence: 1},
+			report.FieldCounts, "field counts")
+
+		sd := findSessionDiff(report, "pd-phantom")
+		require.NotNil(t, sd, "phantom session not listed")
+		assert.Equal(t, sync.DiffChanged, sd.Class, "class")
+		assert.Contains(t, sessionDiffFieldNames(sd, false),
+			sync.FieldPresence, "presence diff")
+		assert.True(t, report.HasFailures(),
+			"a current-version presence drop is parser drift")
+	})
+
+	t.Run("stale row no longer emitted is pending resync", func(t *testing.T) {
+		env := setupTestEnv(t)
+		path := env.writeClaudeSession(t, "test-proj", "pd-real.jsonl",
+			parseDiffClaudeContent("real prompt", "real reply"))
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+
+		// Data version 0: an incomplete write preserved by the
+		// archive (e.g. a transient fork row left by a live sync).
+		require.NoError(t, env.db.UpsertSession(db.Session{
+			ID: "pd-zombie", Project: "test-proj", Machine: "local",
+			Agent: "claude", FilePath: &path,
+		}), "insert zombie session")
+
+		report := runParseDiff(t, env, sync.ParseDiffOptions{})
+		assert.Equal(t, sync.ParseDiffTotals{
+			Examined: 2, Identical: 1, PendingResync: 1,
+		}, report.Totals, "totals")
+		assert.Empty(t, report.FieldCounts,
+			"stale presence is pipeline history, not drift")
+
+		sd := findSessionDiff(report, "pd-zombie")
+		require.NotNil(t, sd, "zombie session not listed")
+		assert.Equal(t, sync.DiffPendingResync, sd.Class, "class")
+		assert.Contains(t, sessionDiffFieldNames(sd, true),
+			sync.FieldPresence,
+			"presence field attached for drill-down")
+		assert.False(t, report.HasFailures(),
+			"stale rows must not trip --fail-on-change")
+	})
+}

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -178,15 +178,15 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 	env := setupTestEnv(t)
 
 	ids := []string{
-		"pd-count", "pd-first", "pd-model", "pd-role",
-		"pd-time", "pd-term", "pd-usage", "pd-control",
+		"pd-count", "pd-first", "pd-model", "pd-role", "pd-time",
+		"pd-body", "pd-swap", "pd-term", "pd-usage", "pd-control",
 	}
 	for _, id := range ids {
 		env.writeClaudeSession(t, "test-proj", id+".jsonl",
 			parseDiffClaudeContent(id+" prompt", id+" reply"))
 	}
 	runSyncAndAssert(t, env.engine, sync.SyncStats{
-		TotalSessions: 8, Synced: 8,
+		TotalSessions: 10, Synced: 10,
 	})
 
 	// Simulate drift between the stored rows and what the current
@@ -211,6 +211,28 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 		"UPDATE messages SET timestamp = ?"+
 			" WHERE session_id = ? AND ordinal = 1",
 		"2024-01-01T10:00:06Z", "pd-time")
+	// Equal-length body rewrite: upper() changes the bytes without
+	// moving content_length, so neither the length aggregates nor the
+	// token fingerprint see it. Only the content hash can.
+	mutateDB(t, env,
+		"UPDATE messages SET content = upper(content)"+
+			" WHERE session_id = ? AND ordinal = 0", "pd-body")
+	// Aggregate collision: swapping content and content_length between
+	// the two ordinals permutes the lengths, so sum/max/min are
+	// unchanged while every per-ordinal value differs.
+	swapMsgs := fetchMessages(t, env.db, "pd-swap")
+	require.Len(t, swapMsgs, 2, "pd-swap fixture")
+	require.NotEqual(t,
+		swapMsgs[0].ContentLength, swapMsgs[1].ContentLength,
+		"swap needs distinct lengths or the collision test is vacuous")
+	mutateDB(t, env,
+		"UPDATE messages SET content = ?, content_length = ?"+
+			" WHERE session_id = ? AND ordinal = 0",
+		swapMsgs[1].Content, swapMsgs[1].ContentLength, "pd-swap")
+	mutateDB(t, env,
+		"UPDATE messages SET content = ?, content_length = ?"+
+			" WHERE session_id = ? AND ordinal = 1",
+		swapMsgs[0].Content, swapMsgs[0].ContentLength, "pd-swap")
 	// The parser classifies this fixture's termination; store a
 	// different non-null value so the diff is real drift, not the
 	// informational cleared-to-NULL case.
@@ -229,9 +251,9 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 
 	report := runParseDiff(t, env, sync.ParseDiffOptions{})
 
-	assert.Equal(t, 8, report.FilesExamined, "files examined")
+	assert.Equal(t, 10, report.FilesExamined, "files examined")
 	assert.Equal(t, sync.ParseDiffTotals{
-		Examined: 8, Identical: 1, Changed: 7,
+		Examined: 10, Identical: 1, Changed: 9,
 	}, report.Totals, "totals")
 
 	cases := []struct {
@@ -251,6 +273,8 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 		{"model drift", "pd-model", sync.FieldModels, 1, true},
 		{"role-only drift", "pd-role", sync.FieldMessageMetadata, 2, true},
 		{"timestamp-only drift", "pd-time", sync.FieldMessageMetadata, 2, true},
+		{"equal-length body drift", "pd-body", sync.FieldMessageContent, 2, true},
+		{"aggregate-collision length swap", "pd-swap", sync.FieldMessageContent, 2, true},
 		{"termination status drift", "pd-term", sync.FieldTerminationStatus, 1, true},
 		{"usage event drift", "pd-usage", sync.FieldUsageEventCount, 1, false},
 	}

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -336,6 +336,58 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 	assert.True(t, report.HasFailures(), "HasFailures with drift")
 }
 
+// TestParseDiffToleratesNullStoredTimestamp guards the NULL-timestamp
+// regression. timestamp is the only nullable text column in messages, and
+// a single imported row with a NULL timestamp once made the tier-1
+// role/time fingerprint scan fail, aborting the whole run instead of
+// producing a report. The run must complete and surface the now-empty
+// stored timestamp as ordinary message_metadata drift.
+func TestParseDiffToleratesNullStoredTimestamp(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.writeClaudeSession(t, "test-proj", "pd-nullts.jsonl",
+		parseDiffClaudeContent("nullts prompt", "nullts reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	// Null the assistant message's stored timestamp. The source file is
+	// unchanged, so the re-parse still yields a real timestamp there;
+	// the stored NULL (coalesced to "") then differs from it as drift.
+	mutateDB(t, env,
+		"UPDATE messages SET timestamp = NULL"+
+			" WHERE session_id = ? AND ordinal = 1", "pd-nullts")
+
+	// runParseDiff requires no error and a non-nil report: before the
+	// COALESCE guard the NULL row aborted the run inside the fingerprint.
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Changed: 1,
+	}, report.Totals, "totals")
+
+	sd := findSessionDiff(report, "pd-nullts")
+	require.NotNil(t, sd, "session not listed")
+	assert.Equal(t, sync.DiffChanged, sd.Class, "class")
+	assert.ElementsMatch(t,
+		[]string{sync.FieldMessageMetadata},
+		sessionDiffFieldNames(sd, false),
+		"non-informational fields")
+	assert.True(t, report.HasFailures(), "HasFailures")
+
+	// messageMetadataDiff compares role before timestamp, so the field
+	// family alone does not prove timestamp was the trigger. Pin the
+	// detail to the timestamp column to match this test's intent.
+	var metaDetail string
+	for _, f := range sd.Fields {
+		if f.Field == sync.FieldMessageMetadata {
+			metaDetail = f.Detail
+		}
+	}
+	assert.Contains(t, metaDetail, "timestamp",
+		"message_metadata drift should attribute to the timestamp column")
+}
+
 // TestParseDiffDetectsExtendedFieldDrift covers the comparator surface
 // added beyond the summary fields end-to-end: tool_call drift, a
 // per-message flag, a full-replace-agent session-metadata field, and the

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -178,15 +178,15 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 	env := setupTestEnv(t)
 
 	ids := []string{
-		"pd-count", "pd-first", "pd-model",
-		"pd-term", "pd-usage", "pd-control",
+		"pd-count", "pd-first", "pd-model", "pd-role",
+		"pd-time", "pd-term", "pd-usage", "pd-control",
 	}
 	for _, id := range ids {
 		env.writeClaudeSession(t, "test-proj", id+".jsonl",
 			parseDiffClaudeContent(id+" prompt", id+" reply"))
 	}
 	runSyncAndAssert(t, env.engine, sync.SyncStats{
-		TotalSessions: 6, Synced: 6,
+		TotalSessions: 8, Synced: 8,
 	})
 
 	// Simulate drift between the stored rows and what the current
@@ -200,6 +200,17 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 	mutateDB(t, env,
 		"UPDATE messages SET model = ? WHERE session_id = ?",
 		"drifted-model", "pd-model")
+	// Role-only and timestamp-only drift: neither moves the token or
+	// content-length fingerprints, so the dedicated role/time
+	// fingerprint is the only thing that can trigger the row-level
+	// comparison. A regression here reports these sessions identical.
+	mutateDB(t, env,
+		"UPDATE messages SET role = 'assistant'"+
+			" WHERE session_id = ? AND ordinal = 0", "pd-role")
+	mutateDB(t, env,
+		"UPDATE messages SET timestamp = ?"+
+			" WHERE session_id = ? AND ordinal = 1",
+		"2024-01-01T10:00:06Z", "pd-time")
 	// The parser classifies this fixture's termination; store a
 	// different non-null value so the diff is real drift, not the
 	// informational cleared-to-NULL case.
@@ -218,25 +229,30 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 
 	report := runParseDiff(t, env, sync.ParseDiffOptions{})
 
-	assert.Equal(t, 6, report.FilesExamined, "files examined")
+	assert.Equal(t, 8, report.FilesExamined, "files examined")
 	assert.Equal(t, sync.ParseDiffTotals{
-		Examined: 6, Identical: 1, Changed: 5,
+		Examined: 8, Identical: 1, Changed: 7,
 	}, report.Totals, "totals")
 
 	cases := []struct {
 		name      string
 		sessionID string
 		field     string
+		// fieldCount is the expected FieldCounts entry; message_metadata
+		// is shared by the role and timestamp drift sessions.
+		fieldCount int
 		// exact asserts the drifted field is the only
 		// non-informational diff; otherwise presence suffices
 		// (a synthetic usage event may also move totals).
 		exact bool
 	}{
-		{"message count drift", "pd-count", sync.FieldMessageCount, true},
-		{"first message drift", "pd-first", sync.FieldFirstMessage, true},
-		{"model drift", "pd-model", sync.FieldModels, true},
-		{"termination status drift", "pd-term", sync.FieldTerminationStatus, true},
-		{"usage event drift", "pd-usage", sync.FieldUsageEventCount, false},
+		{"message count drift", "pd-count", sync.FieldMessageCount, 1, true},
+		{"first message drift", "pd-first", sync.FieldFirstMessage, 1, true},
+		{"model drift", "pd-model", sync.FieldModels, 1, true},
+		{"role-only drift", "pd-role", sync.FieldMessageMetadata, 2, true},
+		{"timestamp-only drift", "pd-time", sync.FieldMessageMetadata, 2, true},
+		{"termination status drift", "pd-term", sync.FieldTerminationStatus, 1, true},
+		{"usage event drift", "pd-usage", sync.FieldUsageEventCount, 1, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -252,7 +268,7 @@ func TestParseDiffDetectsStoredDrift(t *testing.T) {
 				assert.Contains(t, got, tc.field,
 					"fields for %q", tc.sessionID)
 			}
-			assert.Equal(t, 1, report.FieldCounts[tc.field],
+			assert.Equal(t, tc.fieldCount, report.FieldCounts[tc.field],
 				"FieldCounts[%s]", tc.field)
 		})
 	}
@@ -611,6 +627,147 @@ func TestParseDiffCoversKiroSQLite(t *testing.T) {
 	}, report.Totals, "kiro sqlite session must be examined, not skipped")
 	assert.Equal(t, 1, report.FilesExamined, "data.sqlite3 examined")
 	assert.False(t, report.HasFailures(), "clean kiro sqlite run")
+}
+
+// TestParseDiffCoversMixedOpenCodeRoot proves a storage-mode OpenCode
+// root that still carries DB-only legacy sessions in opencode.db gets
+// BOTH sources re-parsed. Normal sync reads opencode.db regardless of
+// source mode, so parse-diff must too; a mode-gated synthesized
+// discovery would leave the legacy session "not discovered" and let
+// --fail-on-change pass without vetting it.
+func TestParseDiffCoversMixedOpenCodeRoot(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// File-backed storage session: this makes ResolveOpenCodeSource
+	// pick storage mode for the root.
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const storageID = "oc-mixed-storage"
+	storage.addSession(
+		t, "global", storageID,
+		"/home/user/code/storage-app", "Mixed Storage",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, storageID, "msg-a1", "assistant", 1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, storageID, "msg-a1", "part-a1",
+		"storage reply", 1704067201000,
+	)
+
+	// DB-only legacy session in the same root, plus a SQLite duplicate
+	// of the storage session that the storage-ID filter must drop.
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "proj-1", "/home/user/code/legacy-app")
+	const legacyID = "oc-mixed-legacy"
+	timeCreated := int64(1704067200000)
+	sqlite.addSession(t, legacyID, "proj-1", timeCreated, timeCreated+5000)
+	sqlite.addMessage(t, "lg-msg-u1", legacyID, "user", timeCreated)
+	sqlite.addMessage(t, "lg-msg-a1", legacyID, "assistant", timeCreated+1)
+	sqlite.addTextPart(
+		t, "lg-part-u1", legacyID, "lg-msg-u1",
+		"legacy question", timeCreated,
+	)
+	sqlite.addTextPart(
+		t, "lg-part-a1", legacyID, "lg-msg-a1",
+		"legacy answer", timeCreated+1,
+	)
+	sqlite.addSession(t, storageID, "proj-1", timeCreated, timeCreated+5000)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2, Synced: 2,
+	})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentOpenCode},
+	})
+	// Examined:2/Identical:2 proves the DB-only legacy session was
+	// re-parsed and compared alongside the storage session. A Skipped
+	// count here means opencode.db was not synthesized for the
+	// storage-mode root; a Changed count means the storage-ID filter
+	// let the SQLite duplicate shadow the storage transcript.
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 2, Identical: 2,
+	}, report.Totals, "both opencode sources must be examined")
+	assert.Equal(t, 2, report.FilesExamined,
+		"storage session file and opencode.db examined")
+	assert.False(t, report.HasFailures(), "clean mixed opencode run")
+}
+
+// TestParseDiffKiroSQLitePerSessionError proves a malformed session
+// inside the shared Kiro store surfaces as DiffParseError instead of
+// being silently dropped (unstored) or misclassified as presence
+// drift (stored), so --fail-on-change stays trustworthy.
+func TestParseDiffKiroSQLitePerSessionError(t *testing.T) {
+	t.Run("stored session turned malformed", func(t *testing.T) {
+		env := setupTestEnv(t)
+		ks := createKiroSQLiteDB(t, env.kiroDir)
+		ks.addSession(
+			t, "/home/user/code/kiro-app", "sqlite-session",
+			readKiroSQLiteFixture(t, "standard_payload.json"),
+			1779012000000, 1779012030000,
+		)
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+
+		ks.updateSession(t, "sqlite-session", "{corrupt", 1779012060000)
+
+		report := runParseDiff(t, env, sync.ParseDiffOptions{
+			Agents: []parser.AgentType{parser.AgentKiro},
+		})
+		assert.Equal(t, sync.ParseDiffTotals{
+			ParseErrors: 1,
+		}, report.Totals,
+			"a malformed stored session is a parse error, not presence drift")
+		assert.Empty(t, report.FieldCounts,
+			"no presence diff for a session that failed to parse")
+
+		sd := findSessionDiff(report, "kiro:sqlite-session")
+		require.NotNil(t, sd, "stored session must be attributed by ID")
+		assert.Equal(t, sync.DiffParseError, sd.Class, "class")
+		assert.Contains(t, sd.Reason, "malformed payload", "reason")
+		assert.True(t, report.HasFailures(),
+			"per-session parse errors must trip --fail-on-change")
+	})
+
+	t.Run("unstored malformed session still reported", func(t *testing.T) {
+		env := setupTestEnv(t)
+		ks := createKiroSQLiteDB(t, env.kiroDir)
+		ks.addSession(
+			t, "/home/user/code/kiro-app", "good-session",
+			readKiroSQLiteFixture(t, "standard_payload.json"),
+			1779012000000, 1779012030000,
+		)
+		runSyncAndAssert(t, env.engine, sync.SyncStats{
+			TotalSessions: 1, Synced: 1,
+		})
+
+		// Never synced: written to the store after the sync.
+		ks.addSession(
+			t, "/home/user/code/kiro-app", "bad-session",
+			"{corrupt", 1779012040000, 1779012050000,
+		)
+
+		report := runParseDiff(t, env, sync.ParseDiffOptions{
+			Agents: []parser.AgentType{parser.AgentKiro},
+		})
+		assert.Equal(t, sync.ParseDiffTotals{
+			Examined: 1, Identical: 1, ParseErrors: 1,
+		}, report.Totals,
+			"good session compared; bad session is a parse error")
+
+		var errEntry *sync.SessionDiff
+		for i := range report.Sessions {
+			if report.Sessions[i].Class == sync.DiffParseError {
+				errEntry = &report.Sessions[i]
+			}
+		}
+		require.NotNil(t, errEntry, "parse error entry listed")
+		assert.Contains(t, errEntry.FilePath, "data.sqlite3#bad-session",
+			"error attributed to the per-session virtual path")
+		assert.True(t, report.HasFailures(), "HasFailures")
+	})
 }
 
 func TestParseDiffPresenceSweep(t *testing.T) {

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -567,10 +567,8 @@ func TestParseDiffAgentScope(t *testing.T) {
 		assert.NotEqual(t, "pd-claude", s.SessionID,
 			"claude session listed in codex-scoped run: %+v", s)
 	}
-	if len(report.Agents) > 0 {
-		assert.Contains(t, report.Agents, "codex", "report agents")
-		assert.NotContains(t, report.Agents, "claude", "report agents")
-	}
+	assert.Equal(t, []string{"codex"}, report.Agents,
+		"report.Agents must reflect the scoped run")
 
 	// Database-backed agents have no on-disk source to re-parse.
 	_, err = engine.ParseDiff(
@@ -580,6 +578,39 @@ func TestParseDiffAgentScope(t *testing.T) {
 	)
 	require.Error(t, err,
 		"ParseDiff must reject database-backed agents")
+}
+
+// TestParseDiffCoversKiroSQLite proves that Kiro's shared data.sqlite3
+// store — which DiscoverFunc never emits and which normal sync reaches
+// through a dedicated phase — is actually re-parsed by parse-diff. A
+// regressed force-parse guard or missing synthesized discovery would
+// surface here as the session being skipped/"not discovered" with
+// Examined 0 rather than compared.
+func TestParseDiffCoversKiroSQLite(t *testing.T) {
+	env := setupTestEnv(t)
+	ks := createKiroSQLiteDB(t, env.kiroDir)
+	ks.addSession(
+		t, "/home/user/code/kiro-app", "sqlite-session",
+		readKiroSQLiteFixture(t, "standard_payload.json"),
+		1779012000000, 1779012030000,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentKiro},
+	})
+	// Examined:1/Identical:1 proves the data.sqlite3 session was
+	// re-parsed and compared (not bucketed skipped/"not discovered").
+	// Identical sessions are intentionally not listed, so a Skipped or
+	// NewOnDisk count here would mean the synthesized discovery or the
+	// force-parse guard regressed.
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Identical: 1,
+	}, report.Totals, "kiro sqlite session must be examined, not skipped")
+	assert.Equal(t, 1, report.FilesExamined, "data.sqlite3 examined")
+	assert.False(t, report.HasFailures(), "clean kiro sqlite run")
 }
 
 func TestParseDiffPresenceSweep(t *testing.T) {

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -1,0 +1,135 @@
+package sync
+
+// Parse-diff report model. Renderer-agnostic: the text renderer in
+// cmd/agentsview and --json output share these structs, so field names
+// are part of the CLI's machine-readable surface and must stay stable.
+
+// DiffClass buckets one session's parse-diff outcome.
+type DiffClass string
+
+const (
+	// DiffIdentical: the freshly parsed, normalized session matches the
+	// stored rows on every compared field. Identical sessions are counted
+	// but not listed, unless they carry informational-only field diffs.
+	DiffIdentical DiffClass = "identical"
+	// DiffChanged: at least one non-informational field differs.
+	DiffChanged DiffClass = "changed"
+	// DiffPendingResync: stored data_version < db.CurrentDataVersion().
+	// Field diffs are still computed and attached for drill-down, but the
+	// next resync rewrites these rows by definition, so they are never
+	// counted as parser drift.
+	DiffPendingResync DiffClass = "pending_resync"
+	// DiffNewOnDisk: a parsed session with no stored row (the archive is
+	// behind the disk; running sync would add it).
+	DiffNewOnDisk DiffClass = "new_on_disk"
+	// DiffParseError: the current binary failed to parse the source file.
+	// The error attributes to every stored session of that file; a failing
+	// file with no stored sessions yields one entry with an empty
+	// SessionID.
+	DiffParseError DiffClass = "parse_error"
+	// DiffExcluded: the parser intentionally no longer emits this stored
+	// session (e.g. Claude usage-probe exclusions); sync would delete it.
+	DiffExcluded DiffClass = "excluded_by_parser"
+	// DiffNeedsRetry: the parse succeeded but was marked transient
+	// low-fidelity output (antigravity-cli with a lagging agy-reader
+	// sidecar); differences are expected and not parser drift.
+	DiffNeedsRetry DiffClass = "transient_needs_retry"
+	// DiffSkipped: a stored session whose source was never re-parsed.
+	// Reason says why: source missing (archive-only), remote session,
+	// trashed, import-only agent, database-backed agent, not sampled
+	// (--limit), or not discovered.
+	DiffSkipped DiffClass = "skipped"
+)
+
+// Compared-field names. Used as FieldDiff.Field values and
+// ParseDiffReport.FieldCounts keys.
+const (
+	FieldMessageCount      = "message_count"
+	FieldUserMessageCount  = "user_message_count"
+	FieldFirstMessage      = "first_message"
+	FieldSessionName       = "session_name"
+	FieldModels            = "models"
+	FieldTotalOutputTokens = "total_output_tokens"
+	FieldPeakContextTokens = "peak_context_tokens"
+	FieldMessageTokens     = "message_tokens"
+	FieldUsageEventCount   = "usage_event_count"
+	FieldUsageEventTotals  = "usage_event_totals"
+	FieldTerminationStatus = "termination_status"
+	// FieldPresence is the synthetic diff attached when a stored,
+	// non-excluded session disappears from its file's parse output.
+	FieldPresence = "presence"
+)
+
+// FieldDiff is one changed field with pre-rendered old/new values.
+// Values are rendered at build time (NULL -> "(null)", long strings
+// truncated with the full length noted in Detail) so both renderers
+// share one representation.
+type FieldDiff struct {
+	Field  string `json:"field"`
+	Stored string `json:"stored"`
+	Parsed string `json:"parsed"`
+	// Detail carries comparison context, e.g. "2/142 messages differ;
+	// first at ordinal 17".
+	Detail string `json:"detail,omitempty"`
+	// Informational marks differences explained by pipeline history
+	// rather than parser drift (e.g. termination_status cleared to NULL
+	// by an incremental append). Informational diffs never make a
+	// session DiffChanged and never trip --fail-on-change.
+	Informational bool `json:"informational,omitempty"`
+}
+
+// SessionDiff is one listed session. Identical sessions appear only
+// when they carry informational-only diffs.
+type SessionDiff struct {
+	SessionID         string      `json:"session_id"`
+	Agent             string      `json:"agent"`
+	FilePath          string      `json:"file_path,omitempty"`
+	Class             DiffClass   `json:"class"`
+	Reason            string      `json:"reason,omitempty"`
+	StoredDataVersion int         `json:"stored_data_version,omitempty"`
+	Fields            []FieldDiff `json:"fields,omitempty"`
+}
+
+// ParseDiffTotals aggregates per-class session counts.
+type ParseDiffTotals struct {
+	// Examined counts stored sessions compared against a fresh parse
+	// (identical + changed + pending_resync).
+	Examined         int `json:"examined"`
+	Identical        int `json:"identical"`
+	Changed          int `json:"changed"`
+	PendingResync    int `json:"pending_resync"`
+	NewOnDisk        int `json:"new_on_disk"`
+	ParseErrors      int `json:"parse_errors"`
+	ExcludedByParser int `json:"excluded_by_parser"`
+	NeedsRetry       int `json:"transient_needs_retry"`
+	Skipped          int `json:"skipped"`
+	// InformationalOnly counts sessions classified identical whose only
+	// diffs are informational. Included in Identical.
+	InformationalOnly int `json:"informational_only"`
+}
+
+// ParseDiffReport is the full result of one report-only re-parse
+// comparison. Sessions is sorted by (class, agent, file path, session
+// id) for deterministic output.
+type ParseDiffReport struct {
+	GeneratedAt string `json:"generated_at"`
+	// DataVersion is db.CurrentDataVersion() of the running binary.
+	DataVersion int      `json:"data_version"`
+	Agents      []string `json:"agents"`
+	// FilesExamined counts source files re-parsed; FilesLimited reports
+	// whether --limit truncated discovery.
+	FilesExamined int  `json:"files_examined"`
+	FilesLimited  bool `json:"files_limited"`
+
+	Totals ParseDiffTotals `json:"totals"`
+	// FieldCounts maps a compared-field name to the number of
+	// DiffChanged sessions with a non-informational diff on that field.
+	FieldCounts map[string]int `json:"field_counts"`
+	Sessions    []SessionDiff  `json:"sessions"`
+}
+
+// HasFailures reports whether --fail-on-change should exit non-zero:
+// real per-session changes or files the current binary cannot parse.
+func (r *ParseDiffReport) HasFailures() bool {
+	return r.Totals.Changed > 0 || r.Totals.ParseErrors > 0
+}

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -54,9 +54,10 @@ const (
 	FieldTotalOutputTokens = "total_output_tokens"
 	FieldPeakContextTokens = "peak_context_tokens"
 	FieldMessageTokens     = "message_tokens"
-	// FieldMessageContent aggregates per-message content-length drift
-	// (sum/max/min), catching body changes the token fingerprint does
-	// not cover.
+	// FieldMessageContent covers per-message body drift: the
+	// content_length column and a hash of the body itself, catching
+	// equal-length rewrites the token fingerprint does not cover.
+	// Bodies are never included in the diff; only sizes are reported.
 	FieldMessageContent = "message_content"
 	// FieldMessageMetadata catches per-message drift in fields that are
 	// in the fingerprint but not separately surfaced (role, timestamp,

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -48,10 +48,20 @@ const (
 	FieldUserMessageCount  = "user_message_count"
 	FieldFirstMessage      = "first_message"
 	FieldSessionName       = "session_name"
+	FieldStartedAt         = "started_at"
+	FieldEndedAt           = "ended_at"
 	FieldModels            = "models"
 	FieldTotalOutputTokens = "total_output_tokens"
 	FieldPeakContextTokens = "peak_context_tokens"
 	FieldMessageTokens     = "message_tokens"
+	// FieldMessageContent aggregates per-message content-length drift
+	// (sum/max/min), catching body changes the token fingerprint does
+	// not cover.
+	FieldMessageContent = "message_content"
+	// FieldMessageMetadata catches per-message drift in fields that are
+	// in the fingerprint but not separately surfaced (role, timestamp,
+	// source ids, sidechain/compact flags).
+	FieldMessageMetadata   = "message_metadata"
 	FieldUsageEventCount   = "usage_event_count"
 	FieldUsageEventTotals  = "usage_event_totals"
 	FieldTerminationStatus = "termination_status"
@@ -81,7 +91,7 @@ type FieldDiff struct {
 // SessionDiff is one listed session. Identical sessions appear only
 // when they carry informational-only diffs.
 type SessionDiff struct {
-	SessionID         string      `json:"session_id"`
+	SessionID         string      `json:"session_id,omitempty"`
 	Agent             string      `json:"agent"`
 	FilePath          string      `json:"file_path,omitempty"`
 	Class             DiffClass   `json:"class"`
@@ -114,8 +124,11 @@ type ParseDiffTotals struct {
 type ParseDiffReport struct {
 	GeneratedAt string `json:"generated_at"`
 	// DataVersion is db.CurrentDataVersion() of the running binary.
-	DataVersion int      `json:"data_version"`
-	Agents      []string `json:"agents"`
+	DataVersion int `json:"data_version"`
+	// DBPath identifies the archive that was vetted, so an attached
+	// report is self-describing. Set by the CLI after the run.
+	DBPath string   `json:"db_path,omitempty"`
+	Agents []string `json:"agents"`
 	// FilesExamined counts source files re-parsed; FilesLimited reports
 	// whether --limit truncated discovery.
 	FilesExamined int  `json:"files_examined"`
@@ -132,4 +145,16 @@ type ParseDiffReport struct {
 // real per-session changes or files the current binary cannot parse.
 func (r *ParseDiffReport) HasFailures() bool {
 	return r.Totals.Changed > 0 || r.Totals.ParseErrors > 0
+}
+
+// VacuousResync reports that every examined session is pending_resync,
+// i.e. the running binary's data version is ahead of the whole
+// archive. In that state the comparison detects no drift by
+// construction (resync will rewrite every row), so a clean result is
+// not evidence the parser is unchanged. Parser PRs that bump
+// dataVersion in the same commit hit this; the caller should warn and
+// not treat the run as a passing vet.
+func (r *ParseDiffReport) VacuousResync() bool {
+	return r.Totals.Examined > 0 &&
+		r.Totals.Examined == r.Totals.PendingResync
 }

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -60,12 +60,35 @@ const (
 	// Bodies are never included in the diff; only sizes are reported.
 	FieldMessageContent = "message_content"
 	// FieldMessageMetadata catches per-message drift in fields that are
-	// in the fingerprint but not separately surfaced (role, timestamp,
-	// source ids, sidechain/compact flags).
-	FieldMessageMetadata   = "message_metadata"
+	// in the fingerprint but not separately surfaced: role, timestamp,
+	// source ids, sidechain/compact flags, and the thinking/system/
+	// tool-use flags (is_system, has_thinking, has_tool_use, thinking_text).
+	FieldMessageMetadata = "message_metadata"
+	// FieldToolCalls covers per-message tool_call drift in the
+	// parser-owned columns: tool_name, category, tool_use_id, input_json,
+	// skill_name, subagent_session_id, and result_content_length. The
+	// database-assigned ids and the (possibly blocked) result body are
+	// never compared; result content is represented only by its length.
+	FieldToolCalls         = "tool_calls"
 	FieldUsageEventCount   = "usage_event_count"
 	FieldUsageEventTotals  = "usage_event_totals"
 	FieldTerminationStatus = "termination_status"
+	// Session metadata fields written only on the full-replace path.
+	// UpdateSessionIncremental leaves them frozen, so for the
+	// incremental-append agents (Claude, Codex) a difference is benign
+	// pipeline history rather than parser drift and is marked
+	// informational, mirroring termination_status. The session "project"
+	// column is deliberately not compared: it is rewritten from the
+	// mutable worktree_project_mappings table, so its parser-owned input
+	// (cwd) is compared instead.
+	FieldCwd                  = "cwd"
+	FieldGitBranch            = "git_branch"
+	FieldParentSessionID      = "parent_session_id"
+	FieldRelationshipType     = "relationship_type"
+	FieldSourceSessionID      = "source_session_id"
+	FieldSourceVersion        = "source_version"
+	FieldParserMalformedLines = "parser_malformed_lines"
+	FieldIsTruncated          = "is_truncated"
 	// FieldPresence is the synthetic diff attached when a stored,
 	// non-excluded session disappears from its file's parse output.
 	FieldPresence = "presence"

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -69,6 +69,10 @@ const (
 	// skill_name, subagent_session_id, and result_content_length. The
 	// database-assigned ids and the (possibly blocked) result body are
 	// never compared; result content is represented only by its length.
+	// The sibling tool_result_events table is also not compared per-event:
+	// the blocked-category config clears those rows wholesale, so a strict
+	// comparison would be config-sensitive; their dominant signal, the
+	// summarized content length, is captured by result_content_length.
 	FieldToolCalls         = "tool_calls"
 	FieldUsageEventCount   = "usage_event_count"
 	FieldUsageEventTotals  = "usage_event_totals"


### PR DESCRIPTION
Closes #649.

Adds `agentsview parse-diff`, a report-only CLI mode that re-parses session
source files with the current binary, runs the result through the same
normalization the sync engine applies, and compares it against the stored
SQLite rows. It writes no session, skip-cache, or sync-state data; per the
issue it turns each parser PR's "I hope this is right" into a reviewable
artifact and surfaces upstream format drift the day it lands.

```
agentsview parse-diff [--agent X ...] [--limit N] [--fail-on-change] [--json] [-v]
```

The report classifies every session into one bucket — identical, changed,
pending_resync, new_on_disk, parse_error, excluded_by_parser,
transient_needs_retry, or skipped (with a reason) — so genuine parser drift
is separated from pipeline history. Human output is a summary plus a
field-affected histogram plus a changed-session drill-down; `--json` emits the
same model for scripting and PR attachment. `--fail-on-change` exits non-zero
on real changes or parse errors.

## How it works

The comparison runs through the engine's real write-path normalization
(`prepareSessionWrite` -> `toDBMessages`/`pairAndFilter`, `toDBSession`,
`postFilterCounts`, `toDBUsageEvents`), so an unchanged parser produces zero
diffs against rows it wrote itself. Because that pipeline is unexported, the
differ lives in `internal/sync` (`Engine.ParseDiff`, `NewDiffEngine`) and the
CLI is a thin renderer over a renderer-agnostic report model in
`parsediff_report.go`.

Re-parse reuses `processFile` and the production worker pool. A new unexported
`forceParse` flag (set only by `NewDiffEngine`, which also forces `Ephemeral`)
disables the three skip layers — the in-memory/persisted skip cache, the
stored size/mtime/data_version short-circuits, and the incremental JSONL path
— so every discovered file is fully re-parsed against the populated archive.
Normal sync never sets the flag, so its behavior is unchanged.

Comparison is two-tier for speed: a per-session token fingerprint and a
content-length fingerprint gate the cheap identical path; only on a mismatch
are message rows loaded and the difference attributed to a specific field.
Usage events compare as an order-insensitive multiset. Known false-diff
sources are classified rather than reported as drift: pending-resync rows
(data version behind the binary), incremental-append `termination_status`
clears for Claude/Codex, orphaned/source-missing sessions, remote and
import-only sessions, and user-trashed rows.

## Coverage and limitations

- Covers every file-based agent, including Claude DAG forks, and the shared
  SQLite stores (Kiro `data.sqlite3`, db-mode OpenCode `opencode.db`) that
  discovery does not emit. Database-backed and import-only agents (Warp,
  Forge, Piebald, claude-ai, ChatGPT) have no on-disk source and are rejected.
- Best run against a quiescent archive. Sessions still being written, and
  sessions last written through the incremental-append path, can show benign
  drift against a full re-parse; a freshly resynced archive is the cleanest
  baseline. `--help` and the report say so, and a run whose data version is
  ahead of the whole archive prints a warning that no drift can be detected.

## Where to look

`internal/sync/parsediff.go` (loop + classification), `parsediff_compare.go`
(field-by-field comparison and the fingerprint tiers), `parsediff_report.go`
(the shared model), the `forceParse` guards in `internal/sync/engine.go`, and
`cmd/agentsview/parse_diff.go` (command + renderer). The feature was vetted
against a real ~726-session local archive across the supported agents.
