### PR TITLE
fix(frontend): skip local-only calls in read-only mode

### DIFF
--- a/frontend/src/lib/api/generated/models/SettingsResponse.ts
+++ b/frontend/src/lib/api/generated/models/SettingsResponse.ts
@@ -9,7 +9,7 @@ export type SettingsResponse = {
   github_configured: boolean;
   host: string;
   port: number;
+  read_only: boolean;
   require_auth: boolean;
   terminal: TerminalResponse;
 };
-

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -31,7 +31,7 @@
     <h2 class="settings-title">Settings</h2>
   </div>
 
-  {#if settings.loading}
+  {#if settings.loading || !settings.loaded}
     <div class="settings-loading">Loading settings...</div>
   {:else if settings.needsAuth}
     <div class="auth-prompt">

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -89,7 +89,7 @@
       <AppearanceSettings />
       <AgentDirSettings />
       <TerminalSettings />
-      <WorktreeMappingSettings />
+      <WorktreeMappingSettings readOnly={settings.readOnly} />
       <GithubSettings />
       <RemoteSettings />
 

--- a/frontend/src/lib/components/settings/SettingsPage.test.ts
+++ b/frontend/src/lib/components/settings/SettingsPage.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount, tick, unmount } from "svelte";
+// @ts-ignore
+import SettingsPage from "./SettingsPage.svelte";
+import { SettingsService } from "../../api/generated/index";
+import { settings } from "../../stores/settings.svelte.js";
+
+vi.mock("../../api/runtime.js", async (importOriginal) => {
+  const orig =
+    await importOriginal<typeof import("../../api/runtime.js")>();
+  return {
+    ...orig,
+    configureGeneratedClient: vi.fn(),
+    getAuthToken: vi.fn(() => ""),
+    isRemoteConnection: vi.fn(() => false),
+    setAuthToken: vi.fn(),
+    setServerUrl: vi.fn(),
+  };
+});
+
+vi.mock("../../api/generated/index", async (importOriginal) => {
+  const orig =
+    await importOriginal<typeof import("../../api/generated/index")>();
+  return {
+    ...orig,
+    SettingsService: {
+      getApiV1Settings: vi.fn(),
+      getApiV1SettingsWorktreeMappings: vi.fn(),
+    },
+  };
+});
+
+const settingsService = SettingsService as unknown as {
+  getApiV1Settings: ReturnType<typeof vi.fn>;
+  getApiV1SettingsWorktreeMappings: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  settings.loading = false;
+  settings.loaded = false;
+  settings.needsAuth = false;
+  settings.error = null;
+  settings.readOnly = false;
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SettingsPage", () => {
+  it("does not mount local-only settings before backend mode is loaded", async () => {
+    let resolveSettings!: (value: unknown) => void;
+    settingsService.getApiV1Settings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSettings = resolve;
+      }),
+    );
+
+    const component = mount(SettingsPage, {
+      target: document.body,
+    });
+    await tick();
+
+    expect(document.body.textContent).toContain("Loading settings");
+    expect(
+      settingsService.getApiV1SettingsWorktreeMappings,
+    ).not.toHaveBeenCalled();
+
+    resolveSettings({
+      agent_dirs: {},
+      github_configured: false,
+      host: "127.0.0.1",
+      port: 8080,
+      read_only: true,
+      require_auth: false,
+      terminal: { mode: "auto" },
+    });
+    await tick();
+
+    expect(
+      settingsService.getApiV1SettingsWorktreeMappings,
+    ).not.toHaveBeenCalled();
+
+    unmount(component);
+  });
+});

--- a/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
+++ b/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
@@ -13,6 +13,12 @@
     mappings: DbWorktreeProjectMapping[];
   }
 
+  interface Props {
+    readOnly?: boolean;
+  }
+
+  let { readOnly = false }: Props = $props();
+
   let machine = $state("");
   let mappings: DbWorktreeProjectMapping[] = $state([]);
   let loading = $state(true);
@@ -26,6 +32,10 @@
   let enabled = $state(true);
 
   $effect(() => {
+    if (readOnly) {
+      loading = false;
+      return;
+    }
     loadMappings();
   });
 
@@ -140,7 +150,9 @@
   title="Worktree mappings"
   description="Map worktree path prefixes to canonical projects on this machine."
 >
-  {#if loading}
+  {#if readOnly}
+    <div class="muted">Worktree mappings are available in local mode only.</div>
+  {:else if loading}
     <div class="muted">Loading mappings...</div>
   {:else if error && mappings.length === 0}
     <div class="error-text">{error}</div>

--- a/frontend/src/lib/components/settings/WorktreeMappingSettings.test.ts
+++ b/frontend/src/lib/components/settings/WorktreeMappingSettings.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { mount, unmount } from "svelte";
+// @ts-ignore
+import WorktreeMappingSettings from "./WorktreeMappingSettings.svelte";
+import { SettingsService } from "../../api/generated/index";
+
+vi.mock("../../api/runtime.js", async (importOriginal) => {
+  const orig =
+    await importOriginal<typeof import("../../api/runtime.js")>();
+  return {
+    ...orig,
+    callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  };
+});
+
+vi.mock("../../api/generated/index", async (importOriginal) => {
+  const orig =
+    await importOriginal<typeof import("../../api/generated/index")>();
+  return {
+    ...orig,
+    SettingsService: {
+      getApiV1SettingsWorktreeMappings: vi.fn(),
+    },
+  };
+});
+
+const settingsService = SettingsService as unknown as {
+  getApiV1SettingsWorktreeMappings: ReturnType<typeof vi.fn>;
+};
+
+describe("WorktreeMappingSettings", () => {
+  it("does not request local worktree mappings in read-only mode", () => {
+    const component = mount(WorktreeMappingSettings, {
+      target: document.body,
+      props: {
+        readOnly: true,
+      },
+    });
+
+    expect(
+      settingsService.getApiV1SettingsWorktreeMappings,
+    ).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("local mode");
+
+    unmount(component);
+  });
+});

--- a/frontend/src/lib/stores/events.svelte.ts
+++ b/frontend/src/lib/stores/events.svelte.ts
@@ -24,7 +24,21 @@ class EventsStore {
   // tab becomes visible again (giving a user-initiated retry
   // window so false positives recover without a page reload).
   private permanentlyFailed = false;
+  private available = false;
   private visibilityHandlerInstalled = false;
+
+  /** Enable or disable the live event stream for the current backend mode. */
+  setAvailable(available: boolean) {
+    this.available = available;
+    if (!available) {
+      this.close();
+      return;
+    }
+    if (this.listeners.size > 0) {
+      this.ensureOpen();
+      this.ensureHealTimer();
+    }
+  }
 
   /** Subscribe to every event. Returns unsubscribe. */
   subscribe(fn: Listener): () => void {
@@ -72,6 +86,7 @@ class EventsStore {
   }
 
   private ensureOpen() {
+    if (!this.available) return;
     // Don't retry once watchEvents has told us the endpoint is
     // permanently unavailable. The safety-net polls on each view
     // still keep data fresh in that mode.

--- a/frontend/src/lib/stores/events.test.ts
+++ b/frontend/src/lib/stores/events.test.ts
@@ -44,9 +44,11 @@ class FakeEventSource {
   }
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   FakeEventSource.reset();
   vi.stubGlobal("EventSource", FakeEventSource);
+  const { events } = await import("./events.svelte.js");
+  events.setAvailable(true);
 });
 
 afterEach(() => {
@@ -54,6 +56,20 @@ afterEach(() => {
 });
 
 describe("events store", () => {
+  it("does not open an EventSource while live events are unavailable", async () => {
+    const { events } = await import("./events.svelte.js");
+    events.setAvailable(false);
+
+    const unsub = events.subscribe(() => {});
+
+    expect(FakeEventSource.instances).toHaveLength(0);
+
+    events.setAvailable(true);
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    unsub();
+  });
+
   it("opens a single EventSource on first subscribe", async () => {
     const { events } = await import("./events.svelte.js");
     const unsub1 = events.subscribe(() => {});

--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -50,6 +50,7 @@ class SettingsStore {
   port: number = $state(0);
   authToken: string = $state("");
   requireAuth: boolean = $state(false);
+  readOnly: boolean = $state(false);
   loading: boolean = $state(false);
   saving: boolean = $state(false);
   error: string | null = $state(null);
@@ -72,6 +73,7 @@ class SettingsStore {
       this.port = data.port;
       this.authToken = data.auth_token ?? "";
       this.requireAuth = data.require_auth ?? false;
+      this.readOnly = data.read_only === true;
       // When the server returns an auth token (localhost only), persist
       // it so the client stays authenticated after remote access is
       // toggled on (which starts requiring auth for all requests).
@@ -108,6 +110,7 @@ class SettingsStore {
       this.port = data.port;
       this.authToken = data.auth_token ?? "";
       this.requireAuth = data.require_auth ?? false;
+      this.readOnly = data.read_only === true;
       if (data.auth_token && !isRemoteConnection()) {
         setAuthToken(data.auth_token);
       }

--- a/frontend/src/lib/stores/settings.svelte.ts
+++ b/frontend/src/lib/stores/settings.svelte.ts
@@ -51,6 +51,7 @@ class SettingsStore {
   authToken: string = $state("");
   requireAuth: boolean = $state(false);
   readOnly: boolean = $state(false);
+  loaded: boolean = $state(false);
   loading: boolean = $state(false);
   saving: boolean = $state(false);
   error: string | null = $state(null);
@@ -60,6 +61,7 @@ class SettingsStore {
 
   async load() {
     this.loading = true;
+    this.loaded = false;
     this.error = null;
     this.needsAuth = false;
     try {
@@ -91,6 +93,7 @@ class SettingsStore {
       }
     } finally {
       this.loading = false;
+      this.loaded = true;
     }
   }
 

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -69,6 +69,7 @@ beforeEach(() => {
   settings.authToken = "";
   settings.requireAuth = false;
   settings.readOnly = false;
+  settings.loaded = false;
   settings.loading = false;
   settings.saving = false;
   settings.error = null;

--- a/frontend/src/lib/stores/settings.test.ts
+++ b/frontend/src/lib/stores/settings.test.ts
@@ -68,10 +68,29 @@ beforeEach(() => {
   settings.port = 0;
   settings.authToken = "";
   settings.requireAuth = false;
+  settings.readOnly = false;
   settings.loading = false;
   settings.saving = false;
   settings.error = null;
   settings.needsAuth = false;
+});
+
+describe("SettingsStore.load mode handling", () => {
+  it("records read-only mode from the settings response", async () => {
+    settingsService.getApiV1Settings.mockResolvedValue({
+      agent_dirs: {},
+      github_configured: false,
+      host: "127.0.0.1",
+      port: 8080,
+      read_only: true,
+      require_auth: false,
+      terminal: { mode: "auto" },
+    });
+
+    await settings.load();
+
+    expect(settings.readOnly).toBe(true);
+  });
 });
 
 describe("SettingsStore.load auth handling", () => {

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -140,6 +140,9 @@ class SyncStore {
       configureGeneratedClient();
       const status = await SyncService.getApiV1SyncStatus();
       this.markRemoteReachable(true);
+      if (this.serverVersion === null) {
+        await this.loadVersion();
+      }
       const newLastSync = status.last_sync || null;
       const isInitial = !this.statusHydrated;
       this.statusHydrated = true;
@@ -219,7 +222,6 @@ class SyncStore {
         this.serverVersion.commit,
       );
     } catch (error) {
-      events.setAvailable(false);
       this.markBackendFailure(error);
       console.warn("Failed to load version info:", error);
     }

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -141,7 +141,7 @@ class SyncStore {
       const status = await SyncService.getApiV1SyncStatus();
       this.markRemoteReachable(true);
       if (this.serverVersion === null) {
-        await this.loadVersion();
+        await this.loadVersion({ updateBackendHealth: false });
       }
       const newLastSync = status.last_sync || null;
       const isInitial = !this.statusHydrated;
@@ -210,7 +210,10 @@ class SyncStore {
     }
   }
 
-  async loadVersion() {
+  async loadVersion(
+    opts: { updateBackendHealth?: boolean } = {},
+  ) {
+    const updateBackendHealth = opts.updateBackendHealth ?? true;
     try {
       configureGeneratedClient();
       this.serverVersion =
@@ -222,7 +225,9 @@ class SyncStore {
         this.serverVersion.commit,
       );
     } catch (error) {
-      this.markBackendFailure(error);
+      if (updateBackendHealth) {
+        this.markBackendFailure(error);
+      }
       console.warn("Failed to load version info:", error);
     }
   }

--- a/frontend/src/lib/stores/sync.svelte.ts
+++ b/frontend/src/lib/stores/sync.svelte.ts
@@ -13,6 +13,7 @@ import {
   configureGeneratedClient,
   isRemoteConnection,
 } from "../api/runtime.js";
+import { events } from "./events.svelte.js";
 import type {
   SyncProgress,
   SyncStats,
@@ -211,12 +212,14 @@ class SyncStore {
       configureGeneratedClient();
       this.serverVersion =
         await MetadataService.getApiV1Version() as VersionInfo;
+      events.setAvailable(this.serverVersion.read_only !== true);
       this.markRemoteReachable(true);
       this.versionMismatch = commitsDisagree(
         this.buildCommit,
         this.serverVersion.commit,
       );
     } catch (error) {
+      events.setAvailable(false);
       this.markBackendFailure(error);
       console.warn("Failed to load version info:", error);
     }

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -17,6 +17,7 @@ const api = vi.hoisted(() => ({
   getVersion: vi.fn(),
   checkForUpdate: vi.fn(),
   isRemoteConnection: vi.fn(),
+  setEventsAvailable: vi.fn(),
   ApiError: class MockGeneratedApiError extends Error {
     status: number;
 
@@ -49,6 +50,12 @@ vi.mock("../api/generated/index", () => ({
   },
   SyncService: {
     getApiV1SyncStatus: vi.fn(() => api.getSyncStatus()),
+  },
+}));
+
+vi.mock("./events.svelte.js", () => ({
+  events: {
+    setAvailable: api.setEventsAvailable,
   },
 }));
 
@@ -559,6 +566,32 @@ describe("SyncStore.remoteUnreachable", () => {
     expect(sync.remoteUnreachable).toBe(false);
     expect(sync.backendDegraded).toBe(true);
     expect(sync.backendDegradedMessage).toBe("sync not ready");
+  });
+
+  it("retries version mode detection after status recovers", async () => {
+    const s = sync as unknown as Record<string, unknown>;
+    s.serverVersion = null;
+    vi.mocked(api.getVersion)
+      .mockRejectedValueOnce(new Error("version temporarily unavailable"))
+      .mockResolvedValueOnce({
+        build_date: "",
+        commit: "abc123",
+        read_only: false,
+        version: "dev",
+      });
+    vi.mocked(api.getSyncStatus).mockResolvedValue({
+      last_sync: "",
+      stats: MOCK_STATS,
+    });
+
+    await sync.loadVersion();
+
+    expect(api.setEventsAvailable).not.toHaveBeenCalled();
+
+    await sync.loadStatus();
+
+    expect(api.getVersion).toHaveBeenCalledTimes(2);
+    expect(api.setEventsAvailable).toHaveBeenCalledWith(true);
   });
 
   it("clears backend degraded when stats load succeeds", async () => {

--- a/frontend/src/lib/stores/sync.test.ts
+++ b/frontend/src/lib/stores/sync.test.ts
@@ -594,6 +594,28 @@ describe("SyncStore.remoteUnreachable", () => {
     expect(api.setEventsAvailable).toHaveBeenCalledWith(true);
   });
 
+  it("keeps status health when opportunistic version retry fails", async () => {
+    vi.mocked(api.isRemoteConnection).mockReturnValue(true);
+    const s = sync as unknown as Record<string, unknown>;
+    s.serverVersion = null;
+    s.remoteUnreachable = true;
+    s.backendDegraded = false;
+    s.backendDegradedMessage = null;
+    vi.mocked(api.getSyncStatus).mockResolvedValue({
+      last_sync: "",
+      stats: MOCK_STATS,
+    });
+    vi.mocked(api.getVersion).mockRejectedValue(
+      new Error("version still unavailable"),
+    );
+
+    await sync.loadStatus();
+
+    expect(sync.remoteUnreachable).toBe(false);
+    expect(sync.backendDegraded).toBe(false);
+    expect(sync.backendDegradedMessage).toBeNull();
+  });
+
   it("clears backend degraded when stats load succeeds", async () => {
     vi.mocked(api.isRemoteConnection).mockReturnValue(true);
     const s = sync as unknown as Record<string, unknown>;

--- a/internal/server/huma_routes_settings.go
+++ b/internal/server/huma_routes_settings.go
@@ -72,6 +72,7 @@ func (s *Server) humaGetSettings(
 		Host:             s.cfg.Host,
 		Port:             s.cfg.Port,
 		RequireAuth:      s.cfg.RequireAuth,
+		ReadOnly:         s.db.ReadOnly(),
 	}
 	if isLocalhostContext(ctx) {
 		resp.AuthToken = s.cfg.AuthToken

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -9,6 +9,7 @@ type settingsResponse struct {
 	Port             int                 `json:"port"`
 	AuthToken        string              `json:"auth_token,omitempty"`
 	RequireAuth      bool                `json:"require_auth"`
+	ReadOnly         bool                `json:"read_only"`
 }
 
 // terminalResponse mirrors config.TerminalConfig for JSON output.


### PR DESCRIPTION
Fixes #663.

Adds read-only mode propagation to settings, defers local-only settings controls until backend mode has loaded, and gates the global live event stream from the server mode reported by /api/v1/version. Status polling can retry mode detection after startup recovery without turning a successful status response into a backend health failure.