### PR TITLE
fix(server): pin CSP resources to public origin

### DIFF
--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -314,6 +314,25 @@ func TestBuildCSPPolicyPinsPublicURLOrigin(t *testing.T) {
 	assert.NotContains(t, directives["default-src"], "0.0.0.0")
 }
 
+func TestBuildCSPPolicyKeepsLocalOriginWithPublicURL(t *testing.T) {
+	t.Parallel()
+
+	directives := parseCSP(buildCSPPolicy(
+		"127.0.0.1", 8080, "",
+		"https://agentsview.example.com/app",
+		nil,
+	))
+
+	assert.Equal(t,
+		"'self' https://agentsview.example.com http://127.0.0.1:8080",
+		directives["default-src"],
+	)
+	assert.Equal(t,
+		"'self' https://agentsview.example.com http://127.0.0.1:8080",
+		directives["script-src"],
+	)
+}
+
 func TestBuildCSPPolicyPinsPublicOriginWhenPublicURLUnset(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -239,7 +239,7 @@ func TestCSPMiddlewareSetsHeaderOnNonAPIRoutes(t *testing.T) {
 			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
-			handler := cspMiddleware(tt.host, tt.port, tt.basePath, inner)
+			handler := cspMiddleware(tt.host, tt.port, tt.basePath, "", nil, inner)
 
 			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
 			w := httptest.NewRecorder()
@@ -269,7 +269,7 @@ func TestCSPMiddlewareSetsHeaderOnNonAPIRoutes(t *testing.T) {
 func TestBuildCSPPolicyWidensConnectSrcOnly(t *testing.T) {
 	t.Parallel()
 
-	directives := parseCSP(buildCSPPolicy("127.0.0.1", 8081, ""))
+	directives := parseCSP(buildCSPPolicy("127.0.0.1", 8081, "", "", nil))
 
 	assert.Equal(t, "'self' http: https: ws: wss:", directives["connect-src"],
 		"connect-src should be widened to any http/https/ws/wss origin")
@@ -288,6 +288,46 @@ func TestBuildCSPPolicyWidensConnectSrcOnly(t *testing.T) {
 				name, field, directives[name])
 		}
 	}
+}
+
+func TestBuildCSPPolicyPinsPublicURLOrigin(t *testing.T) {
+	t.Parallel()
+
+	directives := parseCSP(buildCSPPolicy(
+		"0.0.0.0", 8080, "",
+		"https://agentsview.example.com/app",
+		nil,
+	))
+
+	assert.Equal(t,
+		"'self' https://agentsview.example.com",
+		directives["default-src"],
+	)
+	assert.Equal(t,
+		"'self' https://agentsview.example.com",
+		directives["script-src"],
+	)
+	assert.Equal(t,
+		"'self' https://agentsview.example.com data:",
+		directives["img-src"],
+	)
+	assert.NotContains(t, directives["default-src"], "0.0.0.0")
+}
+
+func TestBuildCSPPolicyPinsPublicOriginWhenPublicURLUnset(t *testing.T) {
+	t.Parallel()
+
+	directives := parseCSP(buildCSPPolicy(
+		"0.0.0.0", 8080, "",
+		"",
+		[]string{"https://viewer.example.test"},
+	))
+
+	assert.Equal(t,
+		"'self' https://viewer.example.test",
+		directives["default-src"],
+	)
+	assert.NotContains(t, directives["default-src"], "0.0.0.0")
 }
 
 func TestCORSMiddlewareMergesVaryHeader(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -346,7 +346,9 @@ func (s *Server) Handler() http.Handler {
 	if bindAll {
 		bindAllIPs = localInterfaceIPs()
 	}
-	h := cspMiddleware(s.cfg.Host, s.cfg.Port, s.basePath,
+	h := cspMiddleware(
+		s.cfg.Host, s.cfg.Port, s.basePath,
+		s.cfg.PublicURL, s.cfg.PublicOrigins,
 		s.authMiddleware(
 			hostCheckMiddleware(
 				allowedHosts, bindAll, s.cfg.Port, bindAllIPs,
@@ -386,8 +388,15 @@ func (s *Server) Handler() http.Handler {
 // responses. The policy pins the exact host:port origin so that
 // even if Tauri's compile-time CSP uses a wildcard port, the
 // intersection narrows to the actual runtime port.
-func cspMiddleware(host string, port int, basePath string, next http.Handler) http.Handler {
-	policy := buildCSPPolicy(host, port, basePath)
+func cspMiddleware(
+	host string,
+	port int,
+	basePath string,
+	publicURL string,
+	publicOrigins []string,
+	next http.Handler,
+) http.Handler {
+	policy := buildCSPPolicy(host, port, basePath, publicURL, publicOrigins)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/api/") {
 			w.Header().Set("Content-Security-Policy", policy)
@@ -415,11 +424,18 @@ func cspMiddleware(host string, port int, basePath string, next http.Handler) ht
 // if an XSS ever executed in the app, exfiltration would be easier;
 // the other directives stay pinned so script execution remains gated
 // to 'self'.
-func buildCSPPolicy(host string, port int, basePath string) string {
-	// serverOrigin is the pinned http origin for the configured
-	// host:port, used in the resource directives so resources load
-	// correctly regardless of how the webview resolves 'self'.
-	serverOrigin := "http://" + net.JoinHostPort(host, strconv.Itoa(port))
+func buildCSPPolicy(
+	host string,
+	port int,
+	basePath string,
+	publicURL string,
+	publicOrigins []string,
+) string {
+	// serverOrigin is the pinned origin used in the resource
+	// directives so resources load correctly regardless of how the
+	// webview resolves 'self'. In reverse-proxy deployments, prefer
+	// the browser-visible public origin over the bind socket.
+	serverOrigin := cspPinnedOrigin(host, port, publicURL, publicOrigins)
 	resourceSrc := "'self' " + serverOrigin
 
 	baseURI := "'none'"
@@ -439,6 +455,36 @@ func buildCSPPolicy(host string, port int, basePath string) string {
 			"frame-ancestors 'none'",
 		resourceSrc, baseURI,
 	)
+}
+
+func cspPinnedOrigin(
+	host string,
+	port int,
+	publicURL string,
+	publicOrigins []string,
+) string {
+	for _, raw := range append([]string{publicURL}, publicOrigins...) {
+		origin := normalizedOrigin(raw)
+		if origin != "" {
+			return origin
+		}
+	}
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+func normalizedOrigin(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
 }
 
 // buildAllowedHosts returns the set of Host header values that

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -431,12 +431,13 @@ func buildCSPPolicy(
 	publicURL string,
 	publicOrigins []string,
 ) string {
-	// serverOrigin is the pinned origin used in the resource
+	// serverOrigins are the pinned origins used in the resource
 	// directives so resources load correctly regardless of how the
-	// webview resolves 'self'. In reverse-proxy deployments, prefer
-	// the browser-visible public origin over the bind socket.
-	serverOrigin := cspPinnedOrigin(host, port, publicURL, publicOrigins)
-	resourceSrc := "'self' " + serverOrigin
+	// webview resolves 'self'. Public origins are included for
+	// reverse-proxy deployments; concrete local origins are preserved
+	// for desktop webviews that need the backend socket pinned.
+	serverOrigins := cspPinnedOrigins(host, port, publicURL, publicOrigins)
+	resourceSrc := "'self' " + strings.Join(serverOrigins, " ")
 
 	baseURI := "'none'"
 	if basePath != "" {
@@ -457,19 +458,36 @@ func buildCSPPolicy(
 	)
 }
 
-func cspPinnedOrigin(
+func cspPinnedOrigins(
 	host string,
 	port int,
 	publicURL string,
 	publicOrigins []string,
-) string {
-	for _, raw := range append([]string{publicURL}, publicOrigins...) {
-		origin := normalizedOrigin(raw)
-		if origin != "" {
-			return origin
+) []string {
+	origins := make([]string, 0, 1+len(publicOrigins)+1)
+	seen := make(map[string]bool)
+	add := func(origin string) {
+		if origin == "" || seen[origin] {
+			return
 		}
+		seen[origin] = true
+		origins = append(origins, origin)
 	}
-	return "http://" + net.JoinHostPort(host, strconv.Itoa(port))
+	for _, raw := range append([]string{publicURL}, publicOrigins...) {
+		add(normalizedOrigin(raw))
+	}
+	if !isUnspecifiedHost(host) {
+		add("http://" + net.JoinHostPort(host, strconv.Itoa(port)))
+	}
+	if len(origins) == 0 {
+		add("http://" + net.JoinHostPort(host, strconv.Itoa(port)))
+	}
+	return origins
+}
+
+func isUnspecifiedHost(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsUnspecified()
 }
 
 func normalizedOrigin(raw string) string {


### PR DESCRIPTION
Fixes #664.

Threads configured public URL/origin values into CSP generation so resource directives use the browser-visible origin in reverse-proxy deployments. Local and Tauri-style launches continue to fall back to the bind host and port.