### PR TITLE
fix(frontend): route command palette session picks

### DIFF
--- a/frontend/src/lib/components/command-palette/CommandPalette.svelte
+++ b/frontend/src/lib/components/command-palette/CommandPalette.svelte
@@ -5,6 +5,7 @@
   import { sessions } from "../../stores/sessions.svelte.js";
   import { searchStore } from "../../stores/search.svelte.js";
   import { messages } from "../../stores/messages.svelte.js";
+  import { router } from "../../stores/router.svelte.js";
   import {
     formatRelativeTime,
     truncate,
@@ -101,6 +102,7 @@
 
   function selectSession(s: Session) {
     sessions.selectSession(s.id);
+    router.navigateToSession(s.id);
     close();
   }
 
@@ -113,6 +115,7 @@
       // previously highlighted ordinal is not left active.
       ui.clearScrollState();
     }
+    router.navigateToSession(r.session_id);
     close();
   }
 

--- a/frontend/src/lib/components/command-palette/CommandPalette.svelte
+++ b/frontend/src/lib/components/command-palette/CommandPalette.svelte
@@ -107,7 +107,7 @@
   }
 
   function selectSearchResult(r: SearchResult) {
-    sessions.selectSession(r.session_id);
+    void sessions.navigateToSession(r.session_id);
     if (r.ordinal !== -1) {
       ui.scrollToOrdinal(r.ordinal, r.session_id);
     } else {

--- a/frontend/src/lib/components/command-palette/CommandPalette.test.ts
+++ b/frontend/src/lib/components/command-palette/CommandPalette.test.ts
@@ -33,6 +33,7 @@ const { mockUi, mockSessions, mockSearchStore, mockRouter, mockCopyToClipboard }
       }>,
       filters: { project: "" },
       selectSession: vi.fn(),
+      navigateToSession: vi.fn(),
     },
     mockSearchStore: {
       results: [] as Array<unknown>,
@@ -223,7 +224,7 @@ describe("CommandPalette", () => {
     unmount(component);
   });
 
-  it("name-only result (ordinal === -1) selects session and clears selection without scrolling", async () => {
+  it("name-only result (ordinal === -1) hydrates session and clears selection without scrolling", async () => {
     mockSearchStore.results = [
       {
         session_id: "claude:nameonly123",
@@ -248,7 +249,8 @@ describe("CommandPalette", () => {
     item.click();
     await tick();
 
-    expect(mockSessions.selectSession).toHaveBeenCalledWith("claude:nameonly123");
+    expect(mockSessions.selectSession).not.toHaveBeenCalled();
+    expect(mockSessions.navigateToSession).toHaveBeenCalledWith("claude:nameonly123");
     expect(mockRouter.navigateToSession).toHaveBeenCalledWith("claude:nameonly123");
     expect(mockUi.scrollToOrdinal).not.toHaveBeenCalled();
     expect(mockUi.clearScrollState).toHaveBeenCalled();
@@ -280,7 +282,8 @@ describe("CommandPalette", () => {
     item.click();
     await tick();
 
-    expect(mockSessions.selectSession).toHaveBeenCalledWith("codex:search123");
+    expect(mockSessions.selectSession).not.toHaveBeenCalled();
+    expect(mockSessions.navigateToSession).toHaveBeenCalledWith("codex:search123");
     expect(mockUi.scrollToOrdinal).toHaveBeenCalledWith(7, "codex:search123");
     expect(mockRouter.navigateToSession).toHaveBeenCalledWith("codex:search123");
 

--- a/frontend/src/lib/components/command-palette/CommandPalette.test.ts
+++ b/frontend/src/lib/components/command-palette/CommandPalette.test.ts
@@ -8,7 +8,7 @@ import {
 } from "vitest";
 import { mount, unmount, tick } from "svelte";
 
-const { mockUi, mockSessions, mockSearchStore, mockCopyToClipboard } = vi.hoisted(
+const { mockUi, mockSessions, mockSearchStore, mockRouter, mockCopyToClipboard } = vi.hoisted(
   () => ({
     mockUi: {
       activeModal: "commandPalette" as
@@ -43,6 +43,9 @@ const { mockUi, mockSessions, mockSearchStore, mockCopyToClipboard } = vi.hoiste
       resetSort: vi.fn(),
       setSort: vi.fn(),
     },
+    mockRouter: {
+      navigateToSession: vi.fn(),
+    },
     mockCopyToClipboard: vi.fn(),
   }),
 );
@@ -57,6 +60,10 @@ vi.mock("../../stores/sessions.svelte.js", () => ({
 
 vi.mock("../../stores/search.svelte.js", () => ({
   searchStore: mockSearchStore,
+}));
+
+vi.mock("../../stores/router.svelte.js", () => ({
+  router: mockRouter,
 }));
 
 vi.mock("../../stores/messages.svelte.js", () => ({
@@ -242,8 +249,40 @@ describe("CommandPalette", () => {
     await tick();
 
     expect(mockSessions.selectSession).toHaveBeenCalledWith("claude:nameonly123");
+    expect(mockRouter.navigateToSession).toHaveBeenCalledWith("claude:nameonly123");
     expect(mockUi.scrollToOrdinal).not.toHaveBeenCalled();
     expect(mockUi.clearScrollState).toHaveBeenCalled();
+
+    unmount(component);
+  });
+
+  it("search result click navigates to the session route", async () => {
+    mockSearchStore.results = [
+      {
+        session_id: "codex:search123",
+        project: "proj-a",
+        agent: "codex",
+        ordinal: 7,
+        session_ended_at: "2026-01-01T00:00:00Z",
+        snippet: "matching content",
+        rank: 0,
+      },
+    ];
+
+    const component = mount(CommandPalette, { target: document.body });
+    await tick();
+
+    const input = document.querySelector<HTMLInputElement>(".palette-input")!;
+    input.value = "match";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+
+    const item = await tickUntil(".palette-item");
+    item.click();
+    await tick();
+
+    expect(mockSessions.selectSession).toHaveBeenCalledWith("codex:search123");
+    expect(mockUi.scrollToOrdinal).toHaveBeenCalledWith(7, "codex:search123");
+    expect(mockRouter.navigateToSession).toHaveBeenCalledWith("codex:search123");
 
     unmount(component);
   });


### PR DESCRIPTION
Fixes #90.

Command palette session selections now update the router to /sessions/{id} in addition to selecting the session in local state. This lets search results opened from non-session tabs, including Insights, land on the selected transcript instead of returning to the current tab.