### PR TITLE
fix: render Cursor ApplyPatch tool calls

### DIFF
--- a/frontend/src/lib/components/content/ToolBlock.test.ts
+++ b/frontend/src/lib/components/content/ToolBlock.test.ts
@@ -279,6 +279,30 @@ describe("ToolBlock fallback content", () => {
     expect(toolContent!.textContent).toContain("patch_file: /path/to/patch.diff");
   });
 
+  it("renders Cursor ApplyPatch patch input as a diff", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "ApplyPatch",
+      category: "Edit",
+      input_json: JSON.stringify({
+        path: "src/app.ts",
+        patch: "@@ -1,1 +1,1 @@\n-old\n+new",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", toolCall },
+    });
+    await tick();
+
+    document.querySelector<HTMLButtonElement>(".tool-header")!.click();
+    await tick();
+
+    const diffView = document.querySelector(".diff-view");
+    expect(diffView).not.toBeNull();
+    expect(diffView!.textContent).toContain("-old");
+    expect(diffView!.textContent).toContain("+new");
+  });
+
   it("renders fallback content when no category is provided", async () => {
     // Tool without category - should use tool_name directly
     const toolCall: ToolCall = {

--- a/frontend/src/lib/utils/content-parser.test.ts
+++ b/frontend/src/lib/utils/content-parser.test.ts
@@ -138,6 +138,15 @@ describe("parseContent", () => {
     });
   });
 
+  it("parses patch markers emitted for apply-patch tools", () => {
+    const segments = parseContent("[Patch: src/app.ts]\n@@\n-old\n+new");
+    expect(segments[0]).toEqual({
+      type: "tool",
+      content: "@@\n-old\n+new",
+      label: "Edit : src/app.ts",
+    });
+  });
+
   it("drops overlapping matches", () => {
     const text = "[Thinking]\nI think\n[Bash]\necho ok";
     const segments = parseContent(text);

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -37,7 +37,7 @@ const TOOL_NAMES =
   "Tool|Read|Write|Edit|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|Skill|" +
   "SendMessage|Question|Todo List|Entering Plan Mode|" +
   "Exiting Plan Mode|exec_command|shell_command|" +
-  "write_stdin|apply_patch|shell|parallel|view_image|" +
+  "write_stdin|apply_patch|ApplyPatch|shell|parallel|view_image|" +
   "request_user_input|update_plan";
 
 const TOOL_ALIASES: Record<string, string> = {
@@ -47,6 +47,7 @@ const TOOL_ALIASES: Record<string, string> = {
   write_stdin: "Bash",
   shell: "Bash",
   apply_patch: "Edit",
+  ApplyPatch: "Edit",
   // Pi tool names
   str_replace: "Edit",
   run_command: "Bash",

--- a/frontend/src/lib/utils/content-parser.ts
+++ b/frontend/src/lib/utils/content-parser.ts
@@ -34,7 +34,7 @@ const SKILL_RE =
   /\[Skill: (.+?)\]\n?([\s\S]*?)\n?\[\/Skill\]/g;
 
 const TOOL_NAMES =
-  "Tool|Read|Write|Edit|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|Skill|" +
+  "Tool|Read|Write|Edit|Patch|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|Skill|" +
   "SendMessage|Question|Todo List|Entering Plan Mode|" +
   "Exiting Plan Mode|exec_command|shell_command|" +
   "write_stdin|apply_patch|ApplyPatch|shell|parallel|view_image|" +
@@ -48,6 +48,7 @@ const TOOL_ALIASES: Record<string, string> = {
   shell: "Bash",
   apply_patch: "Edit",
   ApplyPatch: "Edit",
+  Patch: "Edit",
   // Pi tool names
   str_replace: "Edit",
   run_command: "Bash",

--- a/frontend/src/lib/utils/tool-params.test.ts
+++ b/frontend/src/lib/utils/tool-params.test.ts
@@ -259,6 +259,17 @@ describe("generateFallbackContent", () => {
     ).toBeNull();
   });
 
+  it("renders Cursor ApplyPatch patch text from input_json", () => {
+    const patch = "@@ -1,1 +1,1 @@\n-old\n+new";
+
+    expect(
+      generateFallbackContent("Edit", {
+        path: "src/app.ts",
+        patch,
+      }),
+    ).toBe(patch);
+  });
+
   it("shows diff for Edit tool", () => {
     const result = generateFallbackContent("Edit", {
       file_path: "/src/app.ts",

--- a/frontend/src/lib/utils/tool-params.ts
+++ b/frontend/src/lib/utils/tool-params.ts
@@ -190,6 +190,15 @@ export function generateFallbackContent(
       }
       return diffText;
     }
+    const patchText = params.patch ?? params.patch_text ?? params.patchText;
+    if (!lines.length && typeof patchText === "string" && patchText) {
+      const patchLines = patchText.split("\n");
+      if (patchLines.length > MAX_DIFF_LINES) {
+        return patchLines.slice(0, MAX_DIFF_LINES).join("\n")
+          + `\n... (${patchLines.length} lines total)`;
+      }
+      return patchText;
+    }
     if (oldStr != null || newStr != null) {
       const oldText = String(oldStr ?? "");
       const newText = String(newStr ?? "");

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,7 +28,12 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 40: the Codex parser now suppresses the parent history
+// Bumped to 41: the Cursor parser now stores structured tool-call
+// input JSON for text transcripts and normalizes ApplyPatch calls as
+// edits. Existing Cursor rows need re-parsing so archived ApplyPatch
+// calls render with the new patch-aware UI.
+//
+// (40: the Codex parser now suppresses the parent history
 // that `codex fork` replays at the top of a forked rollout, which was
 // double counted as the fork's own messages and token usage, and kept
 // the fork's own session id instead of letting the replayed parent
@@ -38,7 +43,7 @@ import (
 // orphan copy also skips stale Codex rows whose file_path was
 // reparsed under a different session id, so the old parent-ID row
 // does not survive the rebuild when the parent's own file is gone
-// (see CopyOrphanedDataFromExcluding).
+// see CopyOrphanedDataFromExcluding.)
 //
 // (39: the Antigravity wire-walk hardened its output
 // invariants (issue #648): model-name candidates must be printable,
@@ -183,7 +188,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 40
+const dataVersion = 41
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5123,6 +5123,50 @@ func TestToolCallCountAndFingerprint(t *testing.T) {
 	assert.Equal(t, int64(150), sum, "sum")
 }
 
+func TestToolCallFingerprintIncludesStableFields(t *testing.T) {
+	d := testDB(t)
+	for _, id := range []string{"tc-old", "tc-new"} {
+		err := d.UpsertSession(Session{
+			ID: id, Project: "p", Machine: "local", Agent: "cursor",
+		})
+		require.NoError(t, err, "upsert %s", id)
+	}
+	require.NoError(t, d.InsertMessages([]Message{
+		{
+			SessionID: "tc-old", Ordinal: 0, Role: "assistant", Content: "tool",
+			ToolCalls: []ToolCall{
+				{
+					ToolName:            "ApplyPatch",
+					Category:            "ApplyPatch",
+					ToolUseID:           "toolu_patch",
+					ResultContentLength: 12,
+				},
+			},
+		},
+		{
+			SessionID: "tc-new", Ordinal: 0, Role: "assistant", Content: "tool",
+			ToolCalls: []ToolCall{
+				{
+					ToolName:            "ApplyPatch",
+					Category:            "Edit",
+					ToolUseID:           "toolu_patch",
+					InputJSON:           `{"patch":"@@\n-old\n+new"}`,
+					ResultContentLength: 12,
+				},
+			},
+		},
+	}), "insert")
+
+	oldFP, err := d.ToolCallFingerprint("tc-old")
+	require.NoError(t, err, "old fingerprint")
+	newFP, err := d.ToolCallFingerprint("tc-new")
+	require.NoError(t, err, "new fingerprint")
+
+	assert.NotEqual(t, oldFP, newFP)
+	assert.Contains(t, newFP, "Edit")
+	assert.Contains(t, newFP, `{"patch":"@@\n-old\n+new"}`)
+}
+
 func TestListSessionsModifiedBetween_ProjectFilter(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5167,6 +5167,33 @@ func TestToolCallFingerprintIncludesStableFields(t *testing.T) {
 	assert.Contains(t, newFP, `{"patch":"@@\n-old\n+new"}`)
 }
 
+func TestToolCallFingerprintHandlesEmptyToolUseID(t *testing.T) {
+	d := testDB(t)
+	err := d.UpsertSession(Session{
+		ID: "tc-empty-id", Project: "p", Machine: "local", Agent: "cursor",
+	})
+	require.NoError(t, err, "upsert")
+	require.NoError(t, d.InsertMessages([]Message{
+		{
+			SessionID: "tc-empty-id", Ordinal: 0, Role: "assistant",
+			Content: "tool",
+			ToolCalls: []ToolCall{
+				{
+					ToolName:  "ApplyPatch",
+					Category:  "Edit",
+					InputJSON: `{"patch":"@@\n-old\n+new"}`,
+				},
+			},
+		},
+	}), "insert")
+
+	fp, err := d.ToolCallFingerprint("tc-empty-id")
+	require.NoError(t, err, "fingerprint")
+
+	assert.Contains(t, fp, "ApplyPatch")
+	assert.Contains(t, fp, "Edit")
+}
+
 func TestListSessionsModifiedBetween_ProjectFilter(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1094,6 +1094,72 @@ func (db *DB) ToolCallContentFingerprint(sessionID string) (int64, error) {
 	return sum, err
 }
 
+// ToolCallFingerprint returns an exact ordered fingerprint of persisted
+// tool-call fields that can change without changing the message body or the
+// tool-call count. Used by PG push fast-paths to avoid skipping parser
+// changes that only affect tool metadata or inputs.
+func (db *DB) ToolCallFingerprint(sessionID string) (string, error) {
+	rows, err := db.getReader().Query(
+		`SELECT m.ordinal, tc.tool_name, tc.category,
+			tc.tool_use_id, COALESCE(tc.input_json, ''),
+			COALESCE(tc.skill_name, ''),
+			COALESCE(tc.subagent_session_id, ''),
+			COALESCE(tc.result_content_length, 0),
+			COALESCE(tc.result_content, '')
+		 FROM tool_calls tc
+		 JOIN messages m ON m.id = tc.message_id
+		 WHERE tc.session_id = ?
+		 ORDER BY m.ordinal ASC, tc.id ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	lastMessageOrdinal := -1
+	callIndex := 0
+	for rows.Next() {
+		var messageOrdinal, resultContentLength int
+		var toolName, category, toolUseID, inputJSON string
+		var skillName, subagentSessionID, resultContent string
+		if err := rows.Scan(
+			&messageOrdinal, &toolName, &category,
+			&toolUseID, &inputJSON, &skillName, &subagentSessionID,
+			&resultContentLength, &resultContent,
+		); err != nil {
+			return "", err
+		}
+		if messageOrdinal == lastMessageOrdinal {
+			callIndex++
+		} else {
+			lastMessageOrdinal = messageOrdinal
+			callIndex = 0
+		}
+		toolName = SanitizeUTF8(toolName)
+		category = SanitizeUTF8(category)
+		toolUseID = SanitizeUTF8(toolUseID)
+		inputJSON = SanitizeUTF8(inputJSON)
+		skillName = SanitizeUTF8(skillName)
+		subagentSessionID = SanitizeUTF8(subagentSessionID)
+		resultContent = SanitizeUTF8(resultContent)
+		fmt.Fprintf(&b,
+			"%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%d:%s;",
+			messageOrdinal, callIndex,
+			len(toolName), toolName,
+			len(category), category,
+			len(toolUseID), toolUseID,
+			len(inputJSON), inputJSON,
+			len(skillName), skillName,
+			len(subagentSessionID), subagentSessionID,
+			resultContentLength,
+			len(resultContent), resultContent,
+		)
+	}
+	return b.String(), rows.Err()
+}
+
 // GetMessageByOrdinal returns a single message by session ID and ordinal.
 func (db *DB) GetMessageByOrdinal(
 	sessionID string, ordinal int,

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1101,7 +1101,7 @@ func (db *DB) ToolCallContentFingerprint(sessionID string) (int64, error) {
 func (db *DB) ToolCallFingerprint(sessionID string) (string, error) {
 	rows, err := db.getReader().Query(
 		`SELECT m.ordinal, tc.tool_name, tc.category,
-			tc.tool_use_id, COALESCE(tc.input_json, ''),
+			COALESCE(tc.tool_use_id, ''), COALESCE(tc.input_json, ''),
 			COALESCE(tc.skill_name, ''),
 			COALESCE(tc.subagent_session_id, ''),
 			COALESCE(tc.result_content_length, 0),

--- a/internal/parser/content.go
+++ b/internal/parser/content.go
@@ -194,7 +194,9 @@ func formatToolUse(block gjson.Result) string {
 	case "look_at":
 		return fmt.Sprintf("[Read: %s]", input.Get("path").Str)
 	case "apply_patch":
-		return fmt.Sprintf("[Patch: %s]", input.Get("path").Str)
+		return formatPatch(input)
+	case "ApplyPatch":
+		return formatPatch(input)
 	case "undo_edit":
 		return fmt.Sprintf("[Undo: %s]", input.Get("path").Str)
 	case "finder":
@@ -324,6 +326,17 @@ func formatBash(input gjson.Result) string {
 		return fmt.Sprintf("[Bash: %s]\n$ %s", desc, cmd)
 	}
 	return fmt.Sprintf("[Bash]\n$ %s", cmd)
+}
+
+func formatPatch(input gjson.Result) string {
+	path := resolveFilePath(input)
+	if path == "" {
+		path = input.Get("file").Str
+	}
+	if path == "" {
+		return "[Patch]"
+	}
+	return fmt.Sprintf("[Patch: %s]", path)
 }
 
 func formatTask(input gjson.Result) string {

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -280,7 +280,7 @@ func extractAssistantContent(
 }
 
 func cursorToolInputJSON(toolName string, lines []string) string {
-	raw := strings.TrimSpace(strings.Join(lines, "\n"))
+	raw := strings.TrimSpace(strings.Join(dedentCursorBlock(lines), "\n"))
 	if raw == "" {
 		return ""
 	}
@@ -312,6 +312,41 @@ func cursorToolInputJSON(toolName string, lines []string) string {
 		return ""
 	}
 	return marshalCursorToolParams(params)
+}
+
+func dedentCursorBlock(lines []string) []string {
+	minIndent := -1
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent := cursorLineIndent(line)
+		if minIndent < 0 || indent < minIndent {
+			minIndent = indent
+		}
+	}
+	if minIndent <= 0 {
+		return lines
+	}
+
+	dedented := make([]string, len(lines))
+	for i, line := range lines {
+		if len(line) < minIndent {
+			dedented[i] = strings.TrimLeft(line, " \t")
+			continue
+		}
+		dedented[i] = line[minIndent:]
+	}
+	return dedented
+}
+
+func cursorLineIndent(line string) int {
+	for i, r := range line {
+		if r != ' ' && r != '\t' {
+			return i
+		}
+	}
+	return len(line)
 }
 
 func marshalCursorToolParams(params map[string]string) string {

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -238,17 +239,22 @@ func extractAssistantContent(
 		if toolName, ok := strings.CutPrefix(
 			trimmed, "[Tool call] ",
 		); ok {
-			toolCalls = append(toolCalls, ParsedToolCall{
-				ToolName: toolName,
-				Category: NormalizeToolCategory(toolName),
-			})
 			i++
+			bodyStart := i
 			for i < len(lines) {
 				if isBlockBodyEnd(lines[i]) {
 					break
 				}
 				i++
 			}
+			toolCalls = append(toolCalls, ParsedToolCall{
+				ToolName: toolName,
+				Category: NormalizeToolCategory(toolName),
+				InputJSON: cursorToolInputJSON(
+					toolName,
+					lines[bodyStart:i],
+				),
+			})
 			continue
 		}
 
@@ -271,6 +277,49 @@ func extractAssistantContent(
 
 	content := strings.TrimSpace(strings.Join(textParts, "\n"))
 	return content, hasThinking, toolCalls
+}
+
+func cursorToolInputJSON(toolName string, lines []string) string {
+	raw := strings.TrimSpace(strings.Join(lines, "\n"))
+	if raw == "" {
+		return ""
+	}
+	if gjson.Valid(raw) {
+		return raw
+	}
+	if strings.EqualFold(toolName, "ApplyPatch") &&
+		(strings.Contains(raw, "*** Begin Patch") ||
+			strings.HasPrefix(raw, "@@")) {
+		return marshalCursorToolParams(map[string]string{
+			"patch": raw,
+		})
+	}
+
+	params := make(map[string]string)
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(trimmed, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return ""
+		}
+		params[key] = strings.TrimSpace(value)
+	}
+	if len(params) == 0 {
+		return ""
+	}
+	return marshalCursorToolParams(params)
+}
+
+func marshalCursorToolParams(params map[string]string) string {
+	data, err := json.Marshal(params)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 // isAssistantMarker returns true if the line is a structural

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -134,6 +134,22 @@ func TestExtractAssistantContentCursorApplyPatch(t *testing.T) {
 		toolCalls[0].InputJSON)
 }
 
+func TestExtractAssistantContentCursorApplyPatchDedentsRawPatch(t *testing.T) {
+	lines := []string{
+		"[Tool call] ApplyPatch",
+		"  @@ -1,1 +1,1 @@",
+		"  -old",
+		"  +new",
+	}
+
+	_, _, toolCalls := extractAssistantContent(lines)
+
+	require.Len(t, toolCalls, 1)
+	assert.JSONEq(t,
+		`{"patch":"@@ -1,1 +1,1 @@\n-old\n+new"}`,
+		toolCalls[0].InputJSON)
+}
+
 func TestIsContainedIn_EdgeCases(t *testing.T) {
 	// isContainedIn is in sync/discovery.go; we test
 	// isBlockBodyEnd here since it's in cursor.go.

--- a/internal/parser/cursor_test.go
+++ b/internal/parser/cursor_test.go
@@ -115,6 +115,25 @@ func TestExtractAssistantContent(t *testing.T) {
 	}
 }
 
+func TestExtractAssistantContentCursorApplyPatch(t *testing.T) {
+	patch := "@@ -1,1 +1,1 @@\n-old\n+new"
+	lines := []string{
+		"[Tool call] ApplyPatch",
+		`  {"patch":"` + strings.ReplaceAll(patch, "\n", `\n`) + `","path":"src/app.ts"}`,
+	}
+
+	text, hasThinking, toolCalls := extractAssistantContent(lines)
+
+	assert.Empty(t, text)
+	assert.False(t, hasThinking)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "ApplyPatch", toolCalls[0].ToolName)
+	assert.Equal(t, "Edit", toolCalls[0].Category)
+	assert.JSONEq(t,
+		`{"patch":"@@ -1,1 +1,1 @@\n-old\n+new","path":"src/app.ts"}`,
+		toolCalls[0].InputJSON)
+}
+
 func TestIsContainedIn_EdgeCases(t *testing.T) {
 	// isContainedIn is in sync/discovery.go; we test
 	// isBlockBodyEnd here since it's in cursor.go.
@@ -262,6 +281,18 @@ func TestParseCursorJSONL(t *testing.T) {
 			wantCount:        2,
 			wantFirstRole:    RoleUser,
 			wantFirstContent: "Fix it",
+			wantToolUse:      true,
+			wantToolCount:    1,
+		},
+		{
+			name: "assistant with Cursor ApplyPatch",
+			lines: []string{
+				`{"role":"user","message":{"content":"Patch it"}}`,
+				`{"role":"assistant","message":{"content":[{"type":"tool_use","id":"tu_patch","name":"ApplyPatch","input":{"patch":"@@ -1,1 +1,1 @@\n-old\n+new","path":"src/app.ts"}}]}}`,
+			},
+			wantCount:        2,
+			wantFirstRole:    RoleUser,
+			wantFirstContent: "Patch it",
 			wantToolUse:      true,
 			wantToolCount:    1,
 		},

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -84,6 +84,8 @@ func NormalizeToolCategory(rawName string) string {
 		return "Tool"
 
 	// Cursor tools
+	case "ApplyPatch":
+		return "Edit"
 	case "Shell":
 		return "Bash"
 	case "StrReplace":

--- a/internal/parser/taxonomy_test.go
+++ b/internal/parser/taxonomy_test.go
@@ -68,6 +68,9 @@ func TestNormalizeToolCategory(t *testing.T) {
 		{"view", "Read"},
 		{"report_intent", "Tool"},
 
+		// Cursor tools
+		{"ApplyPatch", "Edit"},
+
 		// Piebald / Zencoder-style built-in tools
 		{"ReadFile", "Read"},
 		{"WriteFile", "Write"},

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1053,6 +1053,12 @@ func (s *Sync) pushMessages(
 					"fingerprint: %w", err,
 			)
 		}
+		localTCFP, err := s.local.ToolCallFingerprint(sessionID)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing local tool_call fingerprint: %w", err,
+			)
+		}
 		localTokenFP, err := s.local.MessageTokenFingerprint(sessionID)
 		if err != nil {
 			return 0, fmt.Errorf(
@@ -1063,6 +1069,12 @@ func (s *Sync) pushMessages(
 		if err != nil {
 			return 0, fmt.Errorf(
 				"computing pg token fingerprint: %w", err,
+			)
+		}
+		pgTCFP, err := pgToolCallFingerprint(ctx, tx, sessionID)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing pg tool_call fingerprint: %w", err,
 			)
 		}
 		localUsageFP, err := s.local.UsageEventFingerprint(sessionID)
@@ -1083,6 +1095,7 @@ func (s *Sync) pushMessages(
 			localSysFP == pgSystemFP.String &&
 			localTCCount == pgToolCallCount &&
 			localTCSum == pgTCContentSum &&
+			localTCFP == pgTCFP &&
 			localTokenFP == pgTokenFP &&
 			localUsageFP == pgUsageFP {
 			return 0, nil
@@ -1417,6 +1430,53 @@ func pgMessageTokenFingerprint(
 			len(srcUUID), srcUUID,
 			len(srcParentUUID), srcParentUUID,
 			isSidechain, isCompactBoundary,
+		)
+	}
+	return b.String(), rows.Err()
+}
+
+func pgToolCallFingerprint(
+	ctx context.Context, tx *sql.Tx, sessionID string,
+) (string, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT message_ordinal, call_index, tool_name, category,
+			tool_use_id, COALESCE(input_json, ''),
+			COALESCE(skill_name, ''), COALESCE(subagent_session_id, ''),
+			COALESCE(result_content_length, 0),
+			COALESCE(result_content, '')
+		 FROM tool_calls
+		 WHERE session_id = $1
+		 ORDER BY message_ordinal ASC, call_index ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var messageOrdinal, callIndex, resultContentLength int
+		var toolName, category, toolUseID, inputJSON string
+		var skillName, subagentSessionID, resultContent string
+		if err := rows.Scan(
+			&messageOrdinal, &callIndex, &toolName, &category,
+			&toolUseID, &inputJSON, &skillName, &subagentSessionID,
+			&resultContentLength, &resultContent,
+		); err != nil {
+			return "", err
+		}
+		fmt.Fprintf(&b,
+			"%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%d:%s;",
+			messageOrdinal, callIndex,
+			len(toolName), toolName,
+			len(category), category,
+			len(toolUseID), toolUseID,
+			len(inputJSON), inputJSON,
+			len(skillName), skillName,
+			len(subagentSessionID), subagentSessionID,
+			resultContentLength,
+			len(resultContent), resultContent,
 		)
 	}
 	return b.String(), rows.Err()

--- a/internal/server/export_markdown.go
+++ b/internal/server/export_markdown.go
@@ -130,10 +130,10 @@ var (
 	mdCodeBlockRe      = regexp.MustCompile("(?s)```(\\w*)\\n(.*?)```")
 )
 
-const exportToolNames = "Tool|Read|Write|Edit|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|" +
+const exportToolNames = "Tool|Read|Write|Edit|Patch|Bash|Glob|Grep|Other|TaskCreate|TaskUpdate|TaskGet|TaskList|Task|Agent|" +
 	"SendMessage|Question|Todo List|Entering Plan Mode|" +
 	"Exiting Plan Mode|exec_command|shell_command|" +
-	"write_stdin|apply_patch|shell|parallel|view_image|" +
+	"write_stdin|apply_patch|ApplyPatch|shell|parallel|view_image|" +
 	"request_user_input|update_plan"
 
 const markdownToolNames = exportToolNames + "|Skill"
@@ -146,6 +146,8 @@ var (
 		"write_stdin":   "Bash",
 		"shell":         "Bash",
 		"apply_patch":   "Edit",
+		"ApplyPatch":    "Edit",
+		"Patch":         "Edit",
 		"str_replace":   "Edit",
 		"run_command":   "Bash",
 		"create_file":   "Write",
@@ -478,6 +480,9 @@ func markdownToolFallback(tc *db.ToolCall) string {
 	if isEdit {
 		if diff := stringValue(params["diff"]); diff != "" {
 			return capLines(diff, 200)
+		}
+		if patch := firstString(params, "patch", "patch_text", "patchText"); patch != "" {
+			return capLines(patch, 200)
 		}
 		oldText := firstString(params, "old_string", "old_str", "oldString", "oldStr")
 		newText := firstString(params, "new_string", "new_str", "newString", "newStr")

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -739,6 +739,33 @@ func TestGenerateExportMarkdown_RendersCursorApplyPatch(t *testing.T) {
 	})
 }
 
+func TestGenerateExportMarkdown_RendersCursorApplyPatchFromInputJSON(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID:  "test-id",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "[Patch: src/app.ts]",
+		HasToolUse: true,
+		ToolCalls: []db.ToolCall{{
+			ToolName:  "ApplyPatch",
+			Category:  "Edit",
+			ToolUseID: "toolu_patch",
+			InputJSON: `{"path":"src/app.ts","patch":"@@ -1,1 +1,1 @@\n-old\n+new"}`,
+		}},
+	}}
+
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_call id="toolu_patch" name="ApplyPatch" category="Edit">`,
+		`<tool_body><![CDATA[` + "\n@@ -1,1 +1,1 @@\n-old\n+new\n" + `]]></tool_body>`,
+	})
+	assertContainsNone(t, out, []string{
+		`[Patch: src/app.ts]`,
+	})
+}
+
 func TestGenerateExportMarkdown_OmitsEmptyOptionalAttributes(t *testing.T) {
 	t.Parallel()
 	session := testSession(func(s *db.Session) {

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -711,6 +711,34 @@ func TestGenerateExportMarkdown_SerializesCodeSkillAndCDATAFallback(t *testing.T
 	})
 }
 
+func TestGenerateExportMarkdown_RendersCursorApplyPatch(t *testing.T) {
+	t.Parallel()
+	session := testSession()
+	msgs := []db.Message{{
+		SessionID:  "test-id",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "[Patch: src/app.ts]\n@@ -1,1 +1,1 @@\n-old\n+new",
+		HasToolUse: true,
+		ToolCalls: []db.ToolCall{{
+			ToolName:  "ApplyPatch",
+			Category:  "Edit",
+			ToolUseID: "toolu_patch",
+			InputJSON: `{"path":"src/app.ts","patch":"@@ -1,1 +1,1 @@\n-old\n+new"}`,
+		}},
+	}}
+
+	out := generateExportMarkdown(session, msgs, exportMarkdownOptions{})
+	assertContainsAll(t, out, []string{
+		`<tool_call id="toolu_patch" name="ApplyPatch" category="Edit">`,
+		`<tool_body><![CDATA[` + "\n@@ -1,1 +1,1 @@\n-old\n+new\n" + `]]></tool_body>`,
+	})
+	assertContainsNone(t, out, []string{
+		`[Patch: src/app.ts]`,
+		`patch: @@ -1,1 +1,1 @@`,
+	})
+}
+
 func TestGenerateExportMarkdown_OmitsEmptyOptionalAttributes(t *testing.T) {
 	t.Parallel()
 	session := testSession(func(s *db.Session) {


### PR DESCRIPTION
Fixes #504.

This teaches the Cursor parser to recognize ApplyPatch as an edit tool and preserve its structured patch input from both JSONL and plain-text transcripts. Patch payloads now render as patch/diff content in the session UI instead of generic JSON-like key/value output.

The markdown/export parser now shares the same Patch/ApplyPatch marker handling, so exported transcripts do not leak patch markers as assistant prose and render the patch body consistently.