### PR TITLE
fix(cli): advertise WSL eth0 URL for bind-all serve

### DIFF
--- a/cmd/agentsview/managed_caddy.go
+++ b/cmd/agentsview/managed_caddy.go
@@ -23,14 +23,69 @@ type managedCaddy struct {
 }
 
 func browserURL(cfg config.Config) string {
+	return browserURLWithPlatform(cfg, runningInWSL, interfaceIPv4)
+}
+
+func browserURLWithPlatform(
+	cfg config.Config,
+	isWSL func() bool,
+	ifaceIPv4 func(string) (string, bool),
+) string {
 	if cfg.PublicURL != "" {
 		return cfg.PublicURL
 	}
 	host := cfg.Host
 	if host == "0.0.0.0" || host == "::" {
-		host = "127.0.0.1"
+		if isWSL != nil && isWSL() {
+			if ip, ok := ifaceIPv4("eth0"); ok {
+				host = ip
+			} else {
+				host = "127.0.0.1"
+			}
+		} else {
+			host = "127.0.0.1"
+		}
 	}
 	return fmt.Sprintf("http://%s:%d", host, cfg.Port)
+}
+
+func runningInWSL() bool {
+	if os.Getenv("WSL_DISTRO_NAME") != "" {
+		return true
+	}
+	if _, err := os.Stat("/proc/sys/fs/binfmt_misc/WSLInterop"); err == nil {
+		return true
+	}
+	return false
+}
+
+func interfaceIPv4(name string) (string, bool) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil || iface == nil {
+		return "", false
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", false
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		default:
+			continue
+		}
+		if ip == nil || ip.IsLoopback() {
+			continue
+		}
+		if v4 := ip.To4(); v4 != nil {
+			return v4.String(), true
+		}
+	}
+	return "", false
 }
 
 func rewriteConfiguredPublicURLPort(

--- a/cmd/agentsview/managed_caddy_test.go
+++ b/cmd/agentsview/managed_caddy_test.go
@@ -23,6 +23,48 @@ func TestBrowserURLUsesPublicURL(t *testing.T) {
 	assert.Equal(t, "https://viewer.example.test", browserURL(cfg))
 }
 
+func TestBrowserURLWithPlatformUsesWSLEth0ForBindAll(t *testing.T) {
+	cfg := config.Config{Host: "0.0.0.0", Port: 8080}
+
+	got := browserURLWithPlatform(
+		cfg,
+		func() bool { return true },
+		func(name string) (string, bool) {
+			assert.Equal(t, "eth0", name)
+			return "172.20.10.5", true
+		},
+	)
+
+	assert.Equal(t, "http://172.20.10.5:8080", got)
+}
+
+func TestBrowserURLWithPlatformKeepsLoopbackOutsideWSL(t *testing.T) {
+	cfg := config.Config{Host: "0.0.0.0", Port: 8080}
+
+	got := browserURLWithPlatform(
+		cfg,
+		func() bool { return false },
+		func(string) (string, bool) {
+			t.Fatal("interface lookup should not run outside WSL")
+			return "", false
+		},
+	)
+
+	assert.Equal(t, "http://127.0.0.1:8080", got)
+}
+
+func TestBrowserURLWithPlatformKeepsLoopbackWhenWSLEth0Missing(t *testing.T) {
+	cfg := config.Config{Host: "0.0.0.0", Port: 8080}
+
+	got := browserURLWithPlatform(
+		cfg,
+		func() bool { return true },
+		func(string) (string, bool) { return "", false },
+	)
+
+	assert.Equal(t, "http://127.0.0.1:8080", got)
+}
+
 func TestValidateServeConfigManagedCaddyAllowsHTTPS(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, "viewer.crt")


### PR DESCRIPTION
Fixes #440.

When agentsview is running under WSL and no explicit public URL is configured, bind-all serve URLs now prefer the IPv4 address from the WSL `eth0` interface instead of advertising the WSL loopback address.

Outside WSL, and when WSL `eth0` cannot be resolved, the existing loopback fallback remains unchanged. Explicit `--public-url` values continue to take precedence.
