### PR TITLE
fix(frontend): show hourly heatmap Sunday first

### DIFF
--- a/frontend/src/lib/components/analytics/HourOfWeekHeatmap.svelte
+++ b/frontend/src/lib/components/analytics/HourOfWeekHeatmap.svelte
@@ -6,8 +6,14 @@
   const CELL_STEP = CELL_SIZE + CELL_GAP;
   const ROW_LABEL_WIDTH = 29;
   const COL_LABEL_HEIGHT = 18;
-  const DAY_LABELS = [
-    "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
+  const DAYS = [
+    { label: "Sun", dayIdx: 6 },
+    { label: "Mon", dayIdx: 0 },
+    { label: "Tue", dayIdx: 1 },
+    { label: "Wed", dayIdx: 2 },
+    { label: "Thu", dayIdx: 3 },
+    { label: "Fri", dayIdx: 4 },
+    { label: "Sat", dayIdx: 5 },
   ];
 
   const LEVEL_COLORS_LIGHT = [
@@ -71,21 +77,25 @@
         level: number;
       }[];
     }[] = [];
-    for (let d = 0; d < 7; d++) {
+    for (const day of DAYS) {
       const hours: {
         hour: number;
         value: number;
         level: number;
       }[] = [];
       for (let h = 0; h < 24; h++) {
-        const value = lookup.get(`${d}:${h}`) ?? 0;
+        const value = lookup.get(`${day.dayIdx}:${h}`) ?? 0;
         hours.push({
           hour: h,
           value,
           level: assignLevel(value, max),
         });
       }
-      rows.push({ day: DAY_LABELS[d]!, dayIdx: d, hours });
+      rows.push({
+        day: day.label,
+        dayIdx: day.dayIdx,
+        hours,
+      });
     }
     return rows;
   });

--- a/frontend/src/lib/components/analytics/HourOfWeekHeatmap.test.ts
+++ b/frontend/src/lib/components/analytics/HourOfWeekHeatmap.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { mount, tick, unmount } from "svelte";
+// @ts-ignore
+import HourOfWeekHeatmap from "./HourOfWeekHeatmap.svelte";
+import { analytics } from "../../stores/analytics.svelte.js";
+
+describe("HourOfWeekHeatmap", () => {
+  afterEach(() => {
+    analytics.hourOfWeek = null;
+    analytics.selectedDow = null;
+    analytics.selectedHour = null;
+    // @ts-ignore
+    analytics.errors = {
+      ...analytics.errors,
+      hourOfWeek: null,
+    };
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  function mountWithData() {
+    analytics.hourOfWeek = {
+      cells: [
+        { day_of_week: 6, hour: 0, messages: 9 },
+        { day_of_week: 0, hour: 1, messages: 3 },
+      ],
+    };
+    // @ts-ignore
+    analytics.errors = {
+      ...analytics.errors,
+      hourOfWeek: null,
+    };
+
+    return mount(HourOfWeekHeatmap, { target: document.body });
+  }
+
+  function stubFetches(): MockInstance[] {
+    return [
+      vi.spyOn(analytics, "fetchSummary").mockResolvedValue(),
+      vi.spyOn(analytics, "fetchActivity").mockResolvedValue(),
+      vi.spyOn(analytics, "fetchHeatmap").mockResolvedValue(),
+      vi.spyOn(analytics, "fetchProjects").mockResolvedValue(),
+      vi.spyOn(analytics, "fetchSessionShape").mockResolvedValue(),
+      vi.spyOn(analytics, "fetchVelocity").mockResolvedValue(),
+      vi.spyOn(analytics, "fetchTools").mockResolvedValue(),
+      vi.spyOn(analytics, "fetchTopSessions").mockResolvedValue(),
+      vi.spyOn(analytics, "fetchSignals").mockResolvedValue(),
+    ];
+  }
+
+  it("renders Sunday first while preserving Monday-zero filter values", async () => {
+    const component = mountWithData();
+    await tick();
+
+    const dayLabels = Array.from(
+      document.querySelectorAll(".day-label"),
+    ).map((el) => el.textContent?.trim());
+    expect(dayLabels).toEqual([
+      "Sun",
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri",
+      "Sat",
+    ]);
+
+    const fetchSpies = stubFetches();
+    const firstCell = document.querySelector(".how-cell");
+    expect(firstCell).toBeTruthy();
+    firstCell!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
+    await tick();
+
+    expect(analytics.selectedDow).toBe(6);
+    expect(analytics.selectedHour).toBe(0);
+    for (const spy of fetchSpies) {
+      expect(spy).toHaveBeenCalledOnce();
+    }
+
+    unmount(component);
+  });
+});


### PR DESCRIPTION
Fixes #82.

The hour-of-week analytics heatmap now displays rows in the same Sunday-first order as the activity heatmap. It keeps the existing Monday-zero API/filter contract, so selecting the Sunday row still sends the correct Sunday filter value.

A focused component test covers the row order and the top-row selection mapping.