### PR TITLE
feat(cli): add background serve mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ docker run --rm -p 127.0.0.1:8080:8080 \
 
 ```bash
 agentsview serve           # start server, open web UI
+agentsview serve --background  # start server and return to the shell
 agentsview usage daily     # print daily cost summary
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ docker run --rm -p 127.0.0.1:8080:8080 \
 ```bash
 agentsview serve               # start foreground server
 agentsview serve --background  # start server and return to the shell
+agentsview serve status        # show whether a server is running
+agentsview serve stop          # stop the running server
 agentsview usage daily         # print daily cost summary
 ```
 
@@ -47,8 +49,8 @@ machine, syncs them into a local SQLite database, and serves a web UI at
 
 Use `agentsview serve --background` when you want the dashboard to keep running
 after your terminal prompt returns. The command prints the server URL, process
-ID, and log path (`~/.agentsview/serve.log`). Stop the background server with
-`kill <pid>`.
+ID, and log path (`~/.agentsview/serve.log`). Check on it with
+`agentsview serve status` and shut it down with `agentsview serve stop`.
 
 ## Remote / forwarded access
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,19 @@ docker run --rm -p 127.0.0.1:8080:8080 \
 ## Quick Start
 
 ```bash
-agentsview serve           # start server, open web UI
+agentsview serve               # start foreground server
 agentsview serve --background  # start server and return to the shell
-agentsview usage daily     # print daily cost summary
+agentsview usage daily         # print daily cost summary
 ```
 
 On first run, agentsview discovers sessions from every supported agent on your
-machine, syncs them into a local SQLite database, and opens a web UI at
+machine, syncs them into a local SQLite database, and serves a web UI at
 `http://127.0.0.1:8080`.
+
+Use `agentsview serve --background` when you want the dashboard to keep running
+after your terminal prompt returns. The command prints the server URL, process
+ID, and log path (`~/.agentsview/serve.log`). Stop the background server with
+`kill <pid>`.
 
 ## Remote / forwarded access
 

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -95,12 +95,14 @@ func newServeCommand() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			cfg := mustLoadConfig(cmd)
 			if background {
-				runServeBackground(cfg, os.Args[1:])
+				// Acquire the launch lock before loading config; config
+				// loading writes config.toml and must be single-writer
+				// across concurrent launches.
+				runServeBackgroundCommand(cmd)
 				return
 			}
-			runServe(cfg)
+			runServe(mustLoadConfig(cmd))
 		},
 	}
 	cmd.Flags().BoolVar(

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -87,6 +87,7 @@ func newRootCommand() *cobra.Command {
 }
 
 func newServeCommand() *cobra.Command {
+	var background bool
 	cmd := &cobra.Command{
 		Use:          "serve",
 		Short:        "Start server",
@@ -94,9 +95,20 @@ func newServeCommand() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			runServe(mustLoadConfig(cmd))
+			cfg := mustLoadConfig(cmd)
+			if background {
+				runServeBackground(cfg, os.Args[1:])
+				return
+			}
+			runServe(cfg)
 		},
 	}
+	cmd.Flags().BoolVar(
+		&background,
+		"background",
+		false,
+		"Start server in the background and return to the shell",
+	)
 	config.RegisterServePFlags(cmd.Flags())
 	return cmd
 }

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -110,7 +110,33 @@ func newServeCommand() *cobra.Command {
 		"Start server in the background and return to the shell",
 	)
 	config.RegisterServePFlags(cmd.Flags())
+	cmd.AddCommand(newServeStatusCommand())
+	cmd.AddCommand(newServeStopCommand())
 	return cmd
+}
+
+func newServeStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "status",
+		Short:        "Show whether a server is running and where to reach it",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServeStatus(mustLoadConfig(cmd))
+		},
+	}
+}
+
+func newServeStopCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "stop",
+		Short:        "Stop the running server",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runServeStop(mustLoadConfig(cmd))
+		},
+	}
 }
 
 func newOpenAPICommand() *cobra.Command {

--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -16,15 +16,17 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"github.com/shirou/gopsutil/v4/process"
 	"go.kenn.io/kit/daemon"
 )
 
 const (
-	daemonService   = "agentsview"
-	runtimeReadOnly = "read_only"
-	runtimeHost     = "host"
-	runtimePort     = "port"
-	startProbeTick  = 250 * time.Millisecond
+	daemonService     = "agentsview"
+	runtimeReadOnly   = "read_only"
+	runtimeHost       = "host"
+	runtimePort       = "port"
+	runtimeCreateTime = "create_time"
+	startProbeTick    = 250 * time.Millisecond
 )
 
 // DaemonRuntime is the agentsview-specific view of a kit daemon runtime record.
@@ -55,7 +57,29 @@ func WriteDaemonRuntime(
 		runtimePort:     strconv.Itoa(port),
 		runtimeReadOnly: strconv.FormatBool(readOnly),
 	}
+	// Persist this process's OS create time so `serve stop` can confirm a
+	// PID still belongs to the recorded daemon (and was not reused) by
+	// matching create times exactly. Best-effort: if it cannot be read, stop
+	// falls back to ping confirmation only.
+	if ct, ok := processCreateTimeMillis(os.Getpid()); ok {
+		rec.Metadata[runtimeCreateTime] = strconv.FormatInt(ct, 10)
+	}
 	return runtimeStore(dataDir).Write(rec)
+}
+
+// processCreateTimeMillis returns the OS-reported create time of pid in
+// milliseconds since the Unix epoch. ok is false when the process is gone or
+// its create time cannot be read.
+func processCreateTimeMillis(pid int) (int64, bool) {
+	proc, err := process.NewProcess(int32(pid))
+	if err != nil {
+		return 0, false
+	}
+	created, err := proc.CreateTime()
+	if err != nil {
+		return 0, false
+	}
+	return created, true
 }
 
 // RemoveDaemonRuntime removes the current process's kit daemon runtime record.

--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -21,12 +21,14 @@ import (
 )
 
 const (
-	daemonService     = "agentsview"
-	runtimeReadOnly   = "read_only"
-	runtimeHost       = "host"
-	runtimePort       = "port"
-	runtimeCreateTime = "create_time"
-	startProbeTick    = 250 * time.Millisecond
+	daemonService          = "agentsview"
+	runtimeReadOnly        = "read_only"
+	runtimeHost            = "host"
+	runtimePort            = "port"
+	runtimeCreateTime      = "create_time"
+	runtimeCaddyPID        = "caddy_pid"
+	runtimeCaddyCreateTime = "caddy_create_time"
+	startProbeTick         = 250 * time.Millisecond
 )
 
 // DaemonRuntime is the agentsview-specific view of a kit daemon runtime record.
@@ -42,10 +44,12 @@ func runtimeStore(dataDir string) daemon.RuntimeStore {
 }
 
 // WriteDaemonRuntime writes a shared kit daemon runtime record for the running
-// server. It returns the path written.
+// server. It returns the path written. The optional caddyPID records a managed
+// Caddy child so `serve stop` can terminate it if the server is force-killed
+// before it can stop Caddy itself.
 func WriteDaemonRuntime(
 	dataDir string, host string, port int, version string,
-	readOnly bool,
+	readOnly bool, caddyPID ...int,
 ) (string, error) {
 	ep := daemon.Endpoint{
 		Network: daemon.NetworkTCP,
@@ -63,6 +67,12 @@ func WriteDaemonRuntime(
 	// falls back to ping confirmation only.
 	if ct, ok := processCreateTimeMillis(os.Getpid()); ok {
 		rec.Metadata[runtimeCreateTime] = strconv.FormatInt(ct, 10)
+	}
+	if len(caddyPID) > 0 && caddyPID[0] > 0 {
+		rec.Metadata[runtimeCaddyPID] = strconv.Itoa(caddyPID[0])
+		if ct, ok := processCreateTimeMillis(caddyPID[0]); ok {
+			rec.Metadata[runtimeCaddyCreateTime] = strconv.FormatInt(ct, 10)
+		}
 	}
 	return runtimeStore(dataDir).Write(rec)
 }

--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -187,6 +187,30 @@ func daemonRuntimeFromRecord(rec daemon.RuntimeRecord) *DaemonRuntime {
 	}
 }
 
+// liveDaemonRecords returns runtime records for agentsview daemons in dataDir
+// whose process is still alive. Unlike FindDaemonRuntime it does not require a
+// successful ping, so it can target a hung-but-alive server (e.g. for stop).
+func liveDaemonRecords(dataDir string) []daemon.RuntimeRecord {
+	migrateLegacyDaemonRuntimes(dataDir)
+
+	store := runtimeStore(dataDir)
+	_, _ = store.CleanupDead()
+	records, err := store.List()
+	if err != nil {
+		return nil
+	}
+	var alive []daemon.RuntimeRecord
+	for _, rec := range records {
+		if rec.Service != "" && rec.Service != daemonService {
+			continue
+		}
+		if daemon.ProcessAlive(rec.PID) {
+			alive = append(alive, rec)
+		}
+	}
+	return alive
+}
+
 func hasLiveDaemonRuntime(dataDir string, authToken ...string) bool {
 	migrateLegacyDaemonRuntimes(dataDir, authToken...)
 

--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -266,6 +266,7 @@ func runDuckDBServe(appCfg config.Config, basePath string) {
 	}
 	if _, sfErr := WriteDaemonRuntime(
 		rt.Cfg.DataDir, rt.Cfg.Host, rt.Cfg.Port, version, true,
+		rt.Caddy.Pid(),
 	); sfErr != nil {
 		log.Printf(
 			"warning: could not write daemon runtime record: %v"+

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -245,6 +245,7 @@ func runServe(cfg config.Config) {
 	// on-demand sync against our live DB.
 	if _, sfErr := WriteDaemonRuntime(
 		rt.Cfg.DataDir, rt.Cfg.Host, rt.Cfg.Port, version, false,
+		rt.Caddy.Pid(),
 	); sfErr != nil {
 		log.Printf(
 			"warning: could not write daemon runtime record: %v"+

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -89,7 +89,11 @@ func runServe(cfg config.Config) {
 		if err := cfg.EnsureAuthToken(); err != nil {
 			log.Fatalf("Failed to generate auth token: %v", err)
 		}
-		if cfg.AuthToken != "" {
+		// A background child redirects stdout to serve.log; printing the
+		// token there would persist it to a file. The parent already
+		// printed the token to the invoking terminal, so the child stays
+		// quiet about it.
+		if cfg.AuthToken != "" && !runningAsBackgroundChild() {
 			fmt.Printf("Auth enabled. Token: %s\n", cfg.AuthToken)
 		}
 	}

--- a/cmd/agentsview/managed_caddy.go
+++ b/cmd/agentsview/managed_caddy.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"net/url"
 	"os"
@@ -20,7 +21,19 @@ const managedCaddyStartGrace = 300 * time.Millisecond
 type managedCaddy struct {
 	cancel context.CancelFunc
 	errCh  chan error
+	guard  caddyGuard
 }
+
+// caddyGuard ties the managed Caddy child to the server's lifetime. On Windows
+// it holds a job-object handle whose closure -- when the server exits for any
+// reason, including the uncatchable kill `serve stop` issues there -- tears
+// down Caddy with it. On other platforms it is a no-op: `serve stop` shuts the
+// server down with SIGTERM, so the server's own cleanup stops Caddy.
+type caddyGuard interface{ Close() error }
+
+type noopCaddyGuard struct{}
+
+func (noopCaddyGuard) Close() error { return nil }
 
 func browserURL(cfg config.Config) string {
 	return browserURLWithPlatform(cfg, runningInWSL, interfaceIPv4)
@@ -309,6 +322,17 @@ func startManagedCaddy(
 		return nil, fmt.Errorf("starting managed caddy: %w", err)
 	}
 
+	// Bind Caddy's lifetime to this server process so it cannot outlive a
+	// `serve stop` that kills the server without a graceful shutdown (Windows).
+	// Best-effort: a failure leaves the prior behavior, so log and continue.
+	guard, gErr := newCaddyGuard(cmd)
+	if gErr != nil {
+		log.Printf("warning: could not confine managed caddy: %v", gErr)
+	}
+	if guard == nil {
+		guard = noopCaddyGuard{}
+	}
+
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- cmd.Wait()
@@ -317,6 +341,7 @@ func startManagedCaddy(
 	select {
 	case err := <-errCh:
 		cancel()
+		_ = guard.Close()
 		if err == nil {
 			return nil, fmt.Errorf("managed caddy exited immediately")
 		}
@@ -324,20 +349,27 @@ func startManagedCaddy(
 	case <-time.After(managedCaddyStartGrace):
 	case <-parent.Done():
 		cancel()
+		_ = guard.Close()
 		return nil, parent.Err()
 	}
 
 	return &managedCaddy{
 		cancel: cancel,
 		errCh:  errCh,
+		guard:  guard,
 	}, nil
 }
 
 func (m *managedCaddy) Stop() {
-	if m == nil || m.cancel == nil {
+	if m == nil {
 		return
 	}
-	m.cancel()
+	if m.cancel != nil {
+		m.cancel()
+	}
+	if m.guard != nil {
+		_ = m.guard.Close()
+	}
 }
 
 func (m *managedCaddy) Err() <-chan error {

--- a/cmd/agentsview/managed_caddy.go
+++ b/cmd/agentsview/managed_caddy.go
@@ -22,6 +22,17 @@ type managedCaddy struct {
 	cancel context.CancelFunc
 	errCh  chan error
 	guard  caddyGuard
+	pid    int
+}
+
+// Pid returns the managed Caddy process id, or 0 when no Caddy is running.
+// `serve stop` records it so it can terminate an orphaned Caddy if the server
+// is force-killed before it can stop Caddy itself.
+func (m *managedCaddy) Pid() int {
+	if m == nil {
+		return 0
+	}
+	return m.pid
 }
 
 // caddyGuard ties the managed Caddy child to the server's lifetime. On Windows
@@ -357,6 +368,7 @@ func startManagedCaddy(
 		cancel: cancel,
 		errCh:  errCh,
 		guard:  guard,
+		pid:    cmd.Process.Pid,
 	}, nil
 }
 

--- a/cmd/agentsview/managed_caddy_other.go
+++ b/cmd/agentsview/managed_caddy_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+import "os/exec"
+
+// newCaddyGuard is a no-op on POSIX. `serve stop` terminates the server with
+// SIGTERM, so the server's own shutdown stops the managed Caddy child; there is
+// nothing extra to confine.
+func newCaddyGuard(*exec.Cmd) (caddyGuard, error) {
+	return noopCaddyGuard{}, nil
+}

--- a/cmd/agentsview/managed_caddy_test.go
+++ b/cmd/agentsview/managed_caddy_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -294,4 +295,39 @@ func TestWaitForLocalPortPrefersContextCancellationOverError(t *testing.T) {
 		errCh,
 	)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+type countingCaddyGuard struct{ closed int }
+
+func (g *countingCaddyGuard) Close() error {
+	g.closed++
+	return nil
+}
+
+func TestManagedCaddyStopClosesGuard(t *testing.T) {
+	guard := &countingCaddyGuard{}
+	called := 0
+	m := &managedCaddy{
+		cancel: func() { called++ },
+		guard:  guard,
+	}
+	m.Stop()
+	assert.Equal(t, 1, called, "Stop must cancel the run context")
+	assert.Equal(t, 1, guard.closed, "Stop must close the lifetime guard")
+}
+
+func TestManagedCaddyStopNilSafe(t *testing.T) {
+	var m *managedCaddy
+	assert.NotPanics(t, func() { m.Stop() })
+	assert.NotPanics(t, func() { (&managedCaddy{}).Stop() })
+}
+
+func TestNewCaddyGuardNoopOnPosix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX no-op guard; Windows builds a job-object guard")
+	}
+	guard, err := newCaddyGuard(nil)
+	require.NoError(t, err)
+	require.NotNil(t, guard)
+	require.NoError(t, guard.Close())
 }

--- a/cmd/agentsview/managed_caddy_windows.go
+++ b/cmd/agentsview/managed_caddy_windows.go
@@ -1,0 +1,73 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// jobCaddyGuard holds a job-object handle. While the server process keeps it
+// open, the job lives; when the server exits and the OS closes its handles, the
+// job's KILL_ON_JOB_CLOSE limit terminates every process in it, including Caddy.
+type jobCaddyGuard struct {
+	job windows.Handle
+}
+
+func (g jobCaddyGuard) Close() error {
+	return windows.CloseHandle(g.job)
+}
+
+// newCaddyGuard assigns the started Caddy process to a job object configured to
+// kill its processes when the last handle to the job closes. The server holds
+// that handle for its lifetime, so when the server is terminated -- including
+// the uncatchable TerminateProcess that `serve stop` issues on Windows -- the
+// OS tears down the job and the managed Caddy child with it, instead of leaving
+// Caddy holding the public port. On any failure it returns a no-op guard so the
+// caller can keep running with the prior (leak-prone) behavior.
+func newCaddyGuard(cmd *exec.Cmd) (caddyGuard, error) {
+	if cmd == nil || cmd.Process == nil {
+		return noopCaddyGuard{}, fmt.Errorf("caddy process not started")
+	}
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return noopCaddyGuard{}, fmt.Errorf("creating job object: %w", err)
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return noopCaddyGuard{}, fmt.Errorf("configuring job object: %w", err)
+	}
+
+	proc, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		return noopCaddyGuard{}, fmt.Errorf("opening caddy process: %w", err)
+	}
+	defer windows.CloseHandle(proc)
+
+	if err := windows.AssignProcessToJobObject(job, proc); err != nil {
+		_ = windows.CloseHandle(job)
+		return noopCaddyGuard{}, fmt.Errorf("assigning caddy to job: %w", err)
+	}
+
+	return jobCaddyGuard{job: job}, nil
+}

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -305,6 +305,7 @@ func runPGServe(appCfg config.Config, basePath string) {
 	// so clients can select an appropriate transport.
 	if _, sfErr := WriteDaemonRuntime(
 		rt.Cfg.DataDir, rt.Cfg.Host, rt.Cfg.Port, version, true,
+		rt.Caddy.Pid(),
 	); sfErr != nil {
 		log.Printf(
 			"warning: could not write daemon runtime record: %v"+

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -44,12 +45,12 @@ func acquireBackgroundLaunchLock(dataDir string) (*flock.Flock, bool) {
 
 // reportBackgroundLaunchInProgress waits for an in-flight startup to publish
 // its runtime record and reports the running server, or notes that a launch
-// is still in progress when no record appears in time.
-func reportBackgroundLaunchInProgress(cfg config.Config) {
-	WaitForDaemonStartup(
-		cfg.DataDir, backgroundServeReadyTimeout, cfg.AuthToken,
-	)
-	if rt := FindDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil &&
+// is still in progress when no record appears in time. authToken may be empty
+// for a contender that has not loaded config; a require_auth daemon then
+// reports as in-progress rather than by URL.
+func reportBackgroundLaunchInProgress(dataDir, authToken string) {
+	WaitForDaemonStartup(dataDir, backgroundServeReadyTimeout, authToken)
+	if rt := FindDaemonRuntime(dataDir, authToken); rt != nil &&
 		!rt.ReadOnly {
 		fmt.Printf(
 			"agentsview already running at %s (pid %d)\n",
@@ -61,29 +62,41 @@ func reportBackgroundLaunchInProgress(cfg config.Config) {
 	fmt.Println("agentsview serve --background is already in progress.")
 }
 
-func runServeBackground(cfg config.Config, args []string) {
-	// The launch lock lives under the data dir, which may not exist yet on
-	// first run.
-	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
+// runServeBackgroundCommand serializes the launch before loading config.
+// Config loading writes config.toml (the cursor secret, and the auth token via
+// EnsureAuthToken), so two concurrent launches that loaded config outside the
+// lock could clobber each other's writes -- leaving the spawned server using a
+// token the parent never printed. Holding the launch lock across both config
+// load and token generation makes those writes single-writer.
+func runServeBackgroundCommand(cmd *cobra.Command) {
+	dataDir, err := config.ResolveDataDir()
+	if err != nil {
+		fatal("serve background: resolving data dir: %v", err)
+	}
+	// The launch lock lives under the data dir, which may not exist on first
+	// run.
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		fatal("serve background: creating data dir: %v", err)
 	}
 
-	// Serialize concurrent `serve --background` launches before any config
-	// mutation. Without this, two invocations issued before either child
-	// publishes its runtime record would both pass the checks below and
-	// spawn a server, leaving a stray second daemon on its own
-	// auto-discovered port. Acquiring the lock before EnsureAuthToken also
-	// stops contenders from each generating and persisting a different
-	// require_auth token. The launch lock is distinct from the daemon start
-	// lock so the spawned child can still claim the start lock during its
-	// own (possibly long) startup.
-	launchLock, ok := acquireBackgroundLaunchLock(cfg.DataDir)
+	launchLock, ok := acquireBackgroundLaunchLock(dataDir)
 	if !ok {
-		reportBackgroundLaunchInProgress(cfg)
+		// Another launch holds the lock and owns the config writes. Report
+		// without loading config so this process never touches config.toml.
+		reportBackgroundLaunchInProgress(dataDir, "")
 		return
 	}
 	defer func() { _ = launchLock.Unlock() }()
 
+	runServeBackground(mustLoadConfig(cmd), os.Args[1:])
+}
+
+// runServeBackground generates the auth token, checks for an existing daemon,
+// and spawns the detached child. The caller must already hold the background
+// launch lock (see runServeBackgroundCommand). The launch lock is distinct
+// from the daemon start lock so the spawned child can still claim the start
+// lock during its own (possibly long) startup.
+func runServeBackground(cfg config.Config, args []string) {
 	if cfg.RequireAuth {
 		if err := cfg.EnsureAuthToken(); err != nil {
 			fatal("serve background: generating auth token: %v", err)
@@ -107,7 +120,7 @@ func runServeBackground(cfg config.Config, args []string) {
 	// is mid-startup and holds the start lock but has not yet published a
 	// runtime record. Wait for it instead of racing a second server.
 	if IsLocalDaemonActive(cfg.DataDir, cfg.AuthToken) {
-		reportBackgroundLaunchInProgress(cfg)
+		reportBackgroundLaunchInProgress(cfg.DataDir, cfg.AuthToken)
 		return
 	}
 

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -62,6 +62,28 @@ func reportBackgroundLaunchInProgress(cfg config.Config) {
 }
 
 func runServeBackground(cfg config.Config, args []string) {
+	// The launch lock lives under the data dir, which may not exist yet on
+	// first run.
+	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
+		fatal("serve background: creating data dir: %v", err)
+	}
+
+	// Serialize concurrent `serve --background` launches before any config
+	// mutation. Without this, two invocations issued before either child
+	// publishes its runtime record would both pass the checks below and
+	// spawn a server, leaving a stray second daemon on its own
+	// auto-discovered port. Acquiring the lock before EnsureAuthToken also
+	// stops contenders from each generating and persisting a different
+	// require_auth token. The launch lock is distinct from the daemon start
+	// lock so the spawned child can still claim the start lock during its
+	// own (possibly long) startup.
+	launchLock, ok := acquireBackgroundLaunchLock(cfg.DataDir)
+	if !ok {
+		reportBackgroundLaunchInProgress(cfg)
+		return
+	}
+	defer func() { _ = launchLock.Unlock() }()
+
 	if cfg.RequireAuth {
 		if err := cfg.EnsureAuthToken(); err != nil {
 			fatal("serve background: generating auth token: %v", err)
@@ -70,19 +92,6 @@ func runServeBackground(cfg config.Config, args []string) {
 			fmt.Printf("Auth enabled. Token: %s\n", cfg.AuthToken)
 		}
 	}
-
-	// Serialize concurrent `serve --background` launches. Without this,
-	// two invocations issued before either child publishes its runtime
-	// record would both pass the checks below and spawn a server, leaving
-	// a stray second daemon on its own auto-discovered port. The launch
-	// lock is distinct from the daemon start lock so the spawned child can
-	// still claim the start lock during its own (possibly long) startup.
-	launchLock, ok := acquireBackgroundLaunchLock(cfg.DataDir)
-	if !ok {
-		reportBackgroundLaunchInProgress(cfg)
-		return
-	}
-	defer func() { _ = launchLock.Unlock() }()
 
 	if rt := FindDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil &&
 		!rt.ReadOnly {

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/flock"
 	"go.kenn.io/agentsview/internal/config"
 )
 
@@ -24,6 +25,42 @@ func runningAsBackgroundChild() bool {
 	return os.Getenv(backgroundChildEnvVar) == "1"
 }
 
+// backgroundLaunchLockPath is the advisory lock that serializes concurrent
+// `serve --background` launches for a data dir.
+func backgroundLaunchLockPath(dataDir string) string {
+	return filepath.Join(dataDir, "serve.background.lock")
+}
+
+// acquireBackgroundLaunchLock takes the background launch lock without
+// blocking. ok is false when another launch already holds it.
+func acquireBackgroundLaunchLock(dataDir string) (*flock.Flock, bool) {
+	lock := flock.New(backgroundLaunchLockPath(dataDir))
+	locked, err := lock.TryLock()
+	if err != nil || !locked {
+		return nil, false
+	}
+	return lock, true
+}
+
+// reportBackgroundLaunchInProgress waits for an in-flight startup to publish
+// its runtime record and reports the running server, or notes that a launch
+// is still in progress when no record appears in time.
+func reportBackgroundLaunchInProgress(cfg config.Config) {
+	WaitForDaemonStartup(
+		cfg.DataDir, backgroundServeReadyTimeout, cfg.AuthToken,
+	)
+	if rt := FindDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil &&
+		!rt.ReadOnly {
+		fmt.Printf(
+			"agentsview already running at %s (pid %d)\n",
+			urlFromDaemonRuntime(rt),
+			rt.Record.PID,
+		)
+		return
+	}
+	fmt.Println("agentsview serve --background is already in progress.")
+}
+
 func runServeBackground(cfg config.Config, args []string) {
 	if cfg.RequireAuth {
 		if err := cfg.EnsureAuthToken(); err != nil {
@@ -34,12 +71,34 @@ func runServeBackground(cfg config.Config, args []string) {
 		}
 	}
 
+	// Serialize concurrent `serve --background` launches. Without this,
+	// two invocations issued before either child publishes its runtime
+	// record would both pass the checks below and spawn a server, leaving
+	// a stray second daemon on its own auto-discovered port. The launch
+	// lock is distinct from the daemon start lock so the spawned child can
+	// still claim the start lock during its own (possibly long) startup.
+	launchLock, ok := acquireBackgroundLaunchLock(cfg.DataDir)
+	if !ok {
+		reportBackgroundLaunchInProgress(cfg)
+		return
+	}
+	defer func() { _ = launchLock.Unlock() }()
+
 	if rt := FindDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil &&
 		!rt.ReadOnly {
 		fmt.Printf(
-			"agentsview already running at %s\n",
+			"agentsview already running at %s (pid %d)\n",
 			urlFromDaemonRuntime(rt),
+			rt.Record.PID,
 		)
+		return
+	}
+
+	// A writable daemon (a foreground `serve` or a prior background launch)
+	// is mid-startup and holds the start lock but has not yet published a
+	// runtime record. Wait for it instead of racing a second server.
+	if IsLocalDaemonActive(cfg.DataDir, cfg.AuthToken) {
+		reportBackgroundLaunchInProgress(cfg)
 		return
 	}
 
@@ -53,7 +112,7 @@ func runServeBackground(cfg config.Config, args []string) {
 		waitCh <- child.Wait()
 	}()
 
-	rt, ready, err := waitForBackgroundServeReady(
+	rt, err := waitForBackgroundServeReady(
 		cfg.DataDir,
 		cfg.AuthToken,
 		waitCh,
@@ -67,7 +126,7 @@ func runServeBackground(cfg config.Config, args []string) {
 			logPath,
 		)
 	}
-	if ready {
+	if rt != nil {
 		fmt.Printf(
 			"agentsview running at %s (pid %d)\n",
 			urlFromDaemonRuntime(rt),
@@ -156,12 +215,15 @@ func isBackgroundFlagArg(arg string) bool {
 	return false
 }
 
+// waitForBackgroundServeReady polls for the spawned child to publish a
+// writable runtime record. It returns the runtime once ready, nil on timeout
+// (the child is still starting), or an error if the child exits first.
 func waitForBackgroundServeReady(
 	dataDir string,
 	authToken string,
 	waitCh <-chan error,
 	timeout time.Duration,
-) (*DaemonRuntime, bool, error) {
+) (*DaemonRuntime, error) {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	ticker := time.NewTicker(startProbeTick)
@@ -170,7 +232,7 @@ func waitForBackgroundServeReady(
 	for {
 		if rt := FindDaemonRuntime(dataDir, authToken); rt != nil &&
 			!rt.ReadOnly {
-			return rt, true, nil
+			return rt, nil
 		}
 
 		select {
@@ -178,10 +240,10 @@ func waitForBackgroundServeReady(
 			if err == nil {
 				err = fmt.Errorf("server process exited")
 			}
-			return nil, false, err
+			return nil, err
 		case <-ticker.C:
 		case <-timer.C:
-			return nil, false, nil
+			return nil, nil
 		}
 	}
 }

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/config"
+)
+
+const backgroundServeReadyTimeout = 5 * time.Second
+
+func runServeBackground(cfg config.Config, args []string) {
+	if cfg.RequireAuth {
+		if err := cfg.EnsureAuthToken(); err != nil {
+			fatal("serve background: generating auth token: %v", err)
+		}
+		if cfg.AuthToken != "" {
+			fmt.Printf("Auth enabled. Token: %s\n", cfg.AuthToken)
+		}
+	}
+
+	if rt := FindDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil &&
+		!rt.ReadOnly {
+		fmt.Printf(
+			"agentsview already running at %s\n",
+			urlFromDaemonRuntime(rt),
+		)
+		return
+	}
+
+	child, logPath, err := startServeBackgroundProcess(cfg, args)
+	if err != nil {
+		fatal("serve background: %v", err)
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- child.Wait()
+	}()
+
+	rt, ready, err := waitForBackgroundServeReady(
+		cfg.DataDir,
+		cfg.AuthToken,
+		waitCh,
+		backgroundServeReadyTimeout,
+	)
+	if err != nil {
+		fatal(
+			"serve background: server exited before becoming ready: %v\n"+
+				"Logs: %s",
+			err,
+			logPath,
+		)
+	}
+	if ready {
+		fmt.Printf(
+			"agentsview running at %s (pid %d)\n",
+			urlFromDaemonRuntime(rt),
+			child.Process.Pid,
+		)
+		fmt.Printf("Logs: %s\n", logPath)
+		return
+	}
+
+	fmt.Printf(
+		"agentsview starting in background (pid %d)\n",
+		child.Process.Pid,
+	)
+	fmt.Printf("Logs: %s\n", logPath)
+}
+
+func startServeBackgroundProcess(
+	cfg config.Config,
+	args []string,
+) (*exec.Cmd, string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, "", fmt.Errorf("finding executable: %w", err)
+	}
+	logPath := filepath.Join(cfg.DataDir, "serve.log")
+	logFile, err := os.OpenFile(
+		logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("opening log file: %w", err)
+	}
+	defer logFile.Close()
+
+	if _, err := fmt.Fprintf(
+		logFile,
+		"\n--- agentsview serve background start %s ---\n",
+		time.Now().Format(time.RFC3339),
+	); err != nil {
+		return nil, "", fmt.Errorf("writing log header: %w", err)
+	}
+
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		return nil, "", fmt.Errorf("opening null device: %w", err)
+	}
+	defer devNull.Close()
+
+	childArgs := serveBackgroundChildArgs(args)
+	cmd := exec.Command(exe, childArgs...)
+	cmd.Stdin = devNull
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	configureServeBackgroundCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return nil, "", fmt.Errorf("starting server: %w", err)
+	}
+	return cmd, logPath, nil
+}
+
+func serveBackgroundChildArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg == "--background" ||
+			strings.HasPrefix(arg, "--background=") {
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
+}
+
+func waitForBackgroundServeReady(
+	dataDir string,
+	authToken string,
+	waitCh <-chan error,
+	timeout time.Duration,
+) (*DaemonRuntime, bool, error) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(startProbeTick)
+	defer ticker.Stop()
+
+	for {
+		if rt := FindDaemonRuntime(dataDir, authToken); rt != nil &&
+			!rt.ReadOnly {
+			return rt, true, nil
+		}
+
+		select {
+		case err := <-waitCh:
+			if err == nil {
+				err = fmt.Errorf("server process exited")
+			}
+			return nil, false, err
+		case <-ticker.C:
+		case <-timer.C:
+			return nil, false, nil
+		}
+	}
+}

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -13,6 +13,17 @@ import (
 
 const backgroundServeReadyTimeout = 5 * time.Second
 
+// backgroundChildEnvVar marks the re-exec'd serve process as the child of a
+// background launch. The child reads it to keep the auth token out of
+// serve.log; the parent prints the token to the invoking terminal instead.
+const backgroundChildEnvVar = "AGENTSVIEW_BACKGROUND_CHILD"
+
+// runningAsBackgroundChild reports whether this process was spawned by
+// runServeBackground.
+func runningAsBackgroundChild() bool {
+	return os.Getenv(backgroundChildEnvVar) == "1"
+}
+
 func runServeBackground(cfg config.Config, args []string) {
 	if cfg.RequireAuth {
 		if err := cfg.EnsureAuthToken(); err != nil {
@@ -82,8 +93,10 @@ func startServeBackgroundProcess(
 		return nil, "", fmt.Errorf("finding executable: %w", err)
 	}
 	logPath := filepath.Join(cfg.DataDir, "serve.log")
+	// 0o600: the child writes its startup output here, which can include
+	// auth details, so keep the log readable only by the owner.
 	logFile, err := os.OpenFile(
-		logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644,
+		logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600,
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("opening log file: %w", err)
@@ -106,6 +119,7 @@ func startServeBackgroundProcess(
 
 	childArgs := serveBackgroundChildArgs(args)
 	cmd := exec.Command(exe, childArgs...)
+	cmd.Env = append(os.Environ(), backgroundChildEnvVar+"=1")
 	cmd.Stdin = devNull
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
@@ -119,13 +133,27 @@ func startServeBackgroundProcess(
 func serveBackgroundChildArgs(args []string) []string {
 	out := make([]string, 0, len(args))
 	for _, arg := range args {
-		if arg == "--background" ||
-			strings.HasPrefix(arg, "--background=") {
+		if isBackgroundFlagArg(arg) {
 			continue
 		}
 		out = append(out, arg)
 	}
 	return out
+}
+
+// isBackgroundFlagArg reports whether arg is the --background flag in any
+// spelling the CLI accepts. The legacy flag normalizer rewrites the
+// single-dash form -background to --background before Cobra parses, so the
+// raw args handed to the child still carry -background. Stripping both
+// spellings stops the child from re-entering background mode and spawning
+// itself recursively.
+func isBackgroundFlagArg(arg string) bool {
+	for _, name := range []string{"--background", "-background"} {
+		if arg == name || strings.HasPrefix(arg, name+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 func waitForBackgroundServeReady(

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -25,6 +25,20 @@ func TestServeBackgroundChildArgsRemovesBackgroundFlag(t *testing.T) {
 			want: []string{"serve", "--host", "0.0.0.0"},
 		},
 		{
+			// The legacy normalizer rewrites -background to --background
+			// before Cobra parses, so the raw child args still carry the
+			// single-dash form. It must be stripped too, or the child
+			// re-backgrounds itself in an unbounded loop.
+			name: "legacy single-dash flag",
+			args: []string{"serve", "-background", "--port", "0"},
+			want: []string{"serve", "--port", "0"},
+		},
+		{
+			name: "legacy single-dash equals form",
+			args: []string{"serve", "-background=true", "--port", "0"},
+			want: []string{"serve", "--port", "0"},
+		},
+		{
 			name: "keeps similarly named flags",
 			args: []string{
 				"serve",
@@ -61,4 +75,10 @@ func TestServeCommandParsesBackgroundFlag(t *testing.T) {
 	cfg := mustLoadConfig(cmd)
 	assert.Equal(t, 9090, cfg.Port)
 	assert.Equal(t, filepath.Join(dataDir, "sessions.db"), cfg.DBPath)
+}
+
+func TestRunningAsBackgroundChild(t *testing.T) {
+	assert.False(t, runningAsBackgroundChild())
+	t.Setenv(backgroundChildEnvVar, "1")
+	assert.True(t, runningAsBackgroundChild())
 }

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeBackgroundChildArgsRemovesBackgroundFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "bare flag",
+			args: []string{"serve", "--background", "--port", "0"},
+			want: []string{"serve", "--port", "0"},
+		},
+		{
+			name: "equals form",
+			args: []string{"serve", "--background=true", "--host", "0.0.0.0"},
+			want: []string{"serve", "--host", "0.0.0.0"},
+		},
+		{
+			name: "keeps similarly named flags",
+			args: []string{
+				"serve",
+				"--public-url",
+				"https://viewer.example.test/background",
+			},
+			want: []string{
+				"serve",
+				"--public-url",
+				"https://viewer.example.test/background",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, serveBackgroundChildArgs(tt.args))
+		})
+	}
+}
+
+func TestServeCommandParsesBackgroundFlag(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+
+	cmd := newServeCommand()
+	require.NoError(t,
+		cmd.Flags().Parse([]string{"--background", "--port", "9090"}),
+	)
+	got, err := cmd.Flags().GetBool("background")
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	cfg := mustLoadConfig(cmd)
+	assert.Equal(t, 9090, cfg.Port)
+	assert.Equal(t, filepath.Join(dataDir, "sessions.db"), cfg.DBPath)
+}

--- a/cmd/agentsview/serve_background_unix.go
+++ b/cmd/agentsview/serve_background_unix.go
@@ -3,10 +3,17 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
 
 func configureServeBackgroundCommand(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// terminateProcess asks the server to shut down gracefully. The server traps
+// SIGTERM and exits cleanly, removing its runtime record.
+func terminateProcess(proc *os.Process) error {
+	return proc.Signal(syscall.SIGTERM)
 }

--- a/cmd/agentsview/serve_background_unix.go
+++ b/cmd/agentsview/serve_background_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureServeBackgroundCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/cmd/agentsview/serve_background_windows.go
+++ b/cmd/agentsview/serve_background_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -16,4 +17,11 @@ func configureServeBackgroundCommand(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: detachedProcess | createNewProcessGroup,
 	}
+}
+
+// terminateProcess stops the server. Windows does not deliver POSIX signals to
+// a detached process, so there is no graceful equivalent of SIGTERM here; the
+// process is killed and serve stop removes its runtime record afterward.
+func terminateProcess(proc *os.Process) error {
+	return proc.Kill()
 }

--- a/cmd/agentsview/serve_background_windows.go
+++ b/cmd/agentsview/serve_background_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const (
+	detachedProcess       = 0x00000008
+	createNewProcessGroup = 0x00000200
+)
+
+func configureServeBackgroundCommand(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: detachedProcess | createNewProcessGroup,
+	}
+}

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -58,7 +59,10 @@ func serveStatusLines(rt *DaemonRuntime) []string {
 	return lines
 }
 
-// runServeStop terminates every live agentsview server owning this data dir.
+// runServeStop terminates every agentsview server owning this data dir that
+// still answers as one. A record is signalled only after its PID confirms via
+// the ping probe that it is the recorded agentsview daemon, so a stale record
+// whose PID has been reused by an unrelated process is never signalled.
 func runServeStop(cfg config.Config) {
 	records := liveDaemonRecords(cfg.DataDir)
 	if len(records) == 0 {
@@ -68,12 +72,45 @@ func runServeStop(cfg config.Config) {
 		fmt.Println("No agentsview server is running.")
 		return
 	}
+	stopped, skipped := 0, 0
 	for _, rec := range records {
+		if !daemonRecordIdentityConfirmed(rec, cfg.AuthToken) {
+			fmt.Printf(
+				"Skipping pid %d: not responding as the recorded "+
+					"agentsview daemon (stale record or reused pid).\n",
+				rec.PID,
+			)
+			skipped++
+			continue
+		}
 		if err := stopDaemonProcess(rec, serveStopGraceTimeout); err != nil {
 			fatal("serve stop: stopping pid %d: %v", rec.PID, err)
 		}
 		fmt.Printf("Stopped agentsview (pid %d).\n", rec.PID)
+		stopped++
 	}
+	if stopped == 0 && skipped > 0 {
+		fmt.Println(
+			"No agentsview server was stopped; runtime records may be stale.",
+		)
+	}
+}
+
+// daemonRecordIdentityConfirmed reports whether rec's PID still answers the kit
+// ping probe as the agentsview daemon it claims to be. This guards serve stop
+// against signalling an unrelated process that reused a stale record's PID. A
+// genuinely hung daemon that no longer answers pings is treated as unconfirmed
+// and left alone rather than risk killing the wrong process.
+func daemonRecordIdentityConfirmed(
+	rec daemon.RuntimeRecord, authToken string,
+) bool {
+	info, err := probeRuntime(
+		context.Background(), rec, authToken, daemon.ProbeOptions{
+			ExpectedService: daemonService,
+			Timeout:         500 * time.Millisecond,
+		},
+	)
+	return err == nil && info.PID == rec.PID
 }
 
 // stopDaemonProcess signals the daemon to shut down, waits up to grace for it

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -6,9 +6,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
-	"github.com/shirou/gopsutil/v4/process"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/kit/daemon"
 )
@@ -16,11 +16,6 @@ import (
 // serveStopGraceTimeout bounds how long serve stop waits for a graceful
 // shutdown after signalling before escalating to a forced kill.
 const serveStopGraceTimeout = 10 * time.Second
-
-// processIdentitySlack tolerates clock rounding between the OS-reported process
-// create time and the record's StartedAt when confirming a stop target by
-// process identity.
-const processIdentitySlack = 2 * time.Second
 
 // runServeStatus reports whether a server owns this data dir, and where to
 // reach it. It always exits zero; the output distinguishes the states.
@@ -107,11 +102,12 @@ func runServeStop(cfg config.Config) {
 // stopTargetConfirmed reports whether rec's live PID is safe to signal as the
 // recorded agentsview daemon. It accepts the target when the daemon answers the
 // ping probe, or, for a daemon that is alive but no longer answering, when the
-// process start time predates the record. Either check rules out a PID that an
-// unrelated process reused after the record was written.
+// process create time exactly matches the one recorded at startup. Either check
+// rules out a PID that an unrelated process reused after the record was
+// written.
 func stopTargetConfirmed(rec daemon.RuntimeRecord, authToken string) bool {
 	return daemonRecordPingConfirmed(rec, authToken) ||
-		processStartedBeforeRecord(rec)
+		processIdentityConfirmed(rec)
 }
 
 // daemonRecordPingConfirmed reports whether rec's PID answers the kit ping
@@ -128,25 +124,28 @@ func daemonRecordPingConfirmed(
 	return err == nil && info.PID == rec.PID
 }
 
-// processStartedBeforeRecord reports whether the process now holding rec.PID
-// started no later than the record was written. The recorded daemon was alive
-// when it wrote StartedAt, so its create time predates StartedAt; a process
-// that reused the PID after the daemon died started afterward. Records without
-// a StartedAt (legacy) cannot be checked this way and return false.
-func processStartedBeforeRecord(rec daemon.RuntimeRecord) bool {
-	if rec.StartedAt.IsZero() {
+// processIdentityConfirmed reports whether the process now holding rec.PID is
+// the same one that wrote the record, by matching the OS create time persisted
+// at startup against the live process's current create time. The match is
+// exact: the create time is fixed for a given process, so a PID reused by a
+// different process yields a different value and is rejected -- there is no
+// slack window an impostor could fall into. Records without a persisted create
+// time (legacy, or a daemon whose create time could not be read) cannot be
+// confirmed this way and return false.
+func processIdentityConfirmed(rec daemon.RuntimeRecord) bool {
+	raw := rec.Metadata[runtimeCreateTime]
+	if raw == "" {
 		return false
 	}
-	proc, err := process.NewProcess(int32(rec.PID))
+	recorded, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
 		return false
 	}
-	createdMillis, err := proc.CreateTime()
-	if err != nil {
+	live, ok := processCreateTimeMillis(rec.PID)
+	if !ok {
 		return false
 	}
-	created := time.UnixMilli(createdMillis)
-	return !created.After(rec.StartedAt.Add(processIdentitySlack))
+	return live == recorded
 }
 
 // stopDaemonProcess signals the daemon to shut down, waits up to grace for it

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -1,0 +1,123 @@
+// ABOUTME: serve status and serve stop inspect and terminate a running
+// ABOUTME: agentsview server using its kit daemon runtime record.
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/kit/daemon"
+)
+
+// serveStopGraceTimeout bounds how long serve stop waits for a graceful
+// shutdown after signalling before escalating to a forced kill.
+const serveStopGraceTimeout = 10 * time.Second
+
+// runServeStatus reports whether a server owns this data dir, and where to
+// reach it. It always exits zero; the output distinguishes the states.
+func runServeStatus(cfg config.Config) {
+	if rt := FindDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil {
+		for _, line := range serveStatusLines(rt) {
+			fmt.Println(line)
+		}
+		return
+	}
+	if recs := liveDaemonRecords(cfg.DataDir); len(recs) > 0 {
+		fmt.Printf(
+			"agentsview process running (pid %d) but not responding "+
+				"to health checks.\n",
+			recs[0].PID,
+		)
+		return
+	}
+	if IsDaemonStarting(cfg.DataDir) {
+		fmt.Println("agentsview is starting up.")
+		return
+	}
+	fmt.Println("No agentsview server is running.")
+}
+
+// serveStatusLines renders the human-readable status of a discovered daemon.
+func serveStatusLines(rt *DaemonRuntime) []string {
+	lines := []string{
+		fmt.Sprintf("agentsview running at %s", urlFromDaemonRuntime(rt)),
+		fmt.Sprintf("  pid:     %d", rt.Record.PID),
+	}
+	if rt.Record.Version != "" {
+		lines = append(lines, fmt.Sprintf("  version: %s", rt.Record.Version))
+	}
+	if !rt.Record.StartedAt.IsZero() {
+		uptime := time.Since(rt.Record.StartedAt).Round(time.Second)
+		lines = append(lines, fmt.Sprintf("  uptime:  %s", uptime))
+	}
+	if rt.ReadOnly {
+		lines = append(lines, "  mode:    read-only (pg serve)")
+	}
+	return lines
+}
+
+// runServeStop terminates every live agentsview server owning this data dir.
+func runServeStop(cfg config.Config) {
+	records := liveDaemonRecords(cfg.DataDir)
+	if len(records) == 0 {
+		if IsDaemonStarting(cfg.DataDir) {
+			fatal("serve stop: a server is starting; retry once it is ready")
+		}
+		fmt.Println("No agentsview server is running.")
+		return
+	}
+	for _, rec := range records {
+		if err := stopDaemonProcess(rec, serveStopGraceTimeout); err != nil {
+			fatal("serve stop: stopping pid %d: %v", rec.PID, err)
+		}
+		fmt.Printf("Stopped agentsview (pid %d).\n", rec.PID)
+	}
+}
+
+// stopDaemonProcess signals the daemon to shut down, waits up to grace for it
+// to exit, then escalates to a forced kill. It cleans up the runtime record if
+// the process leaves one behind.
+func stopDaemonProcess(rec daemon.RuntimeRecord, grace time.Duration) error {
+	proc, err := os.FindProcess(rec.PID)
+	if err != nil {
+		return fmt.Errorf("finding process: %w", err)
+	}
+	if err := terminateProcess(proc); err != nil {
+		return fmt.Errorf("signalling shutdown: %w", err)
+	}
+	if waitForProcessExit(rec.PID, grace) {
+		removeRuntimeRecordFile(rec)
+		return nil
+	}
+	if err := proc.Kill(); err != nil {
+		return fmt.Errorf("force killing: %w", err)
+	}
+	waitForProcessExit(rec.PID, grace)
+	removeRuntimeRecordFile(rec)
+	return nil
+}
+
+// waitForProcessExit polls until pid is gone or timeout elapses. It reports
+// whether the process exited.
+func waitForProcessExit(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !daemon.ProcessAlive(pid) {
+			return true
+		}
+		time.Sleep(startProbeTick)
+	}
+	return !daemon.ProcessAlive(pid)
+}
+
+// removeRuntimeRecordFile deletes the daemon's runtime record. A graceful
+// shutdown removes its own record; a forced kill does not, so clean up the
+// stale file to keep discovery accurate.
+func removeRuntimeRecordFile(rec daemon.RuntimeRecord) {
+	if rec.SourcePath == "" {
+		return
+	}
+	_ = os.Remove(rec.SourcePath)
+}

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/shirou/gopsutil/v4/process"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/kit/daemon"
 )
@@ -15,6 +16,11 @@ import (
 // serveStopGraceTimeout bounds how long serve stop waits for a graceful
 // shutdown after signalling before escalating to a forced kill.
 const serveStopGraceTimeout = 10 * time.Second
+
+// processIdentitySlack tolerates clock rounding between the OS-reported process
+// create time and the record's StartedAt when confirming a stop target by
+// process identity.
+const processIdentitySlack = 2 * time.Second
 
 // runServeStatus reports whether a server owns this data dir, and where to
 // reach it. It always exits zero; the output distinguishes the states.
@@ -59,10 +65,12 @@ func serveStatusLines(rt *DaemonRuntime) []string {
 	return lines
 }
 
-// runServeStop terminates every agentsview server owning this data dir that
-// still answers as one. A record is signalled only after its PID confirms via
-// the ping probe that it is the recorded agentsview daemon, so a stale record
-// whose PID has been reused by an unrelated process is never signalled.
+// runServeStop terminates every agentsview server owning this data dir whose
+// identity it can confirm. A record is signalled only once its PID is confirmed
+// to be the recorded daemon -- either it answers the ping probe, or its process
+// start time predates the record (proving the PID was not reused by an
+// unrelated process). This keeps a hung-but-alive daemon stoppable while never
+// signalling a stale record whose PID belongs to something else.
 func runServeStop(cfg config.Config) {
 	records := liveDaemonRecords(cfg.DataDir)
 	if len(records) == 0 {
@@ -74,9 +82,9 @@ func runServeStop(cfg config.Config) {
 	}
 	stopped, skipped := 0, 0
 	for _, rec := range records {
-		if !daemonRecordIdentityConfirmed(rec, cfg.AuthToken) {
+		if !stopTargetConfirmed(rec, cfg.AuthToken) {
 			fmt.Printf(
-				"Skipping pid %d: not responding as the recorded "+
+				"Skipping pid %d: cannot confirm it is the recorded "+
 					"agentsview daemon (stale record or reused pid).\n",
 				rec.PID,
 			)
@@ -96,12 +104,19 @@ func runServeStop(cfg config.Config) {
 	}
 }
 
-// daemonRecordIdentityConfirmed reports whether rec's PID still answers the kit
-// ping probe as the agentsview daemon it claims to be. This guards serve stop
-// against signalling an unrelated process that reused a stale record's PID. A
-// genuinely hung daemon that no longer answers pings is treated as unconfirmed
-// and left alone rather than risk killing the wrong process.
-func daemonRecordIdentityConfirmed(
+// stopTargetConfirmed reports whether rec's live PID is safe to signal as the
+// recorded agentsview daemon. It accepts the target when the daemon answers the
+// ping probe, or, for a daemon that is alive but no longer answering, when the
+// process start time predates the record. Either check rules out a PID that an
+// unrelated process reused after the record was written.
+func stopTargetConfirmed(rec daemon.RuntimeRecord, authToken string) bool {
+	return daemonRecordPingConfirmed(rec, authToken) ||
+		processStartedBeforeRecord(rec)
+}
+
+// daemonRecordPingConfirmed reports whether rec's PID answers the kit ping
+// probe as the agentsview daemon it claims to be.
+func daemonRecordPingConfirmed(
 	rec daemon.RuntimeRecord, authToken string,
 ) bool {
 	info, err := probeRuntime(
@@ -111,6 +126,27 @@ func daemonRecordIdentityConfirmed(
 		},
 	)
 	return err == nil && info.PID == rec.PID
+}
+
+// processStartedBeforeRecord reports whether the process now holding rec.PID
+// started no later than the record was written. The recorded daemon was alive
+// when it wrote StartedAt, so its create time predates StartedAt; a process
+// that reused the PID after the daemon died started afterward. Records without
+// a StartedAt (legacy) cannot be checked this way and return false.
+func processStartedBeforeRecord(rec daemon.RuntimeRecord) bool {
+	if rec.StartedAt.IsZero() {
+		return false
+	}
+	proc, err := process.NewProcess(int32(rec.PID))
+	if err != nil {
+		return false
+	}
+	createdMillis, err := proc.CreateTime()
+	if err != nil {
+		return false
+	}
+	created := time.UnixMilli(createdMillis)
+	return !created.After(rec.StartedAt.Add(processIdentitySlack))
 }
 
 // stopDaemonProcess signals the daemon to shut down, waits up to grace for it

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -176,20 +176,27 @@ func stopOrphanedCaddyChild(rec daemon.RuntimeRecord) {
 	if !processCreateTimeMatches(pid, caddyCreateTime) {
 		return
 	}
-	// SourcePath is empty, so stopDaemonProcess only signals and waits; it
-	// removes no record file for the Caddy child. Carry the Caddy create time
-	// as runtimeCreateTime so the pre-force-kill identity check guards a Caddy
-	// PID reused during the grace wait.
-	if err := stopDaemonProcess(daemon.RuntimeRecord{
-		PID:      pid,
-		Metadata: map[string]string{runtimeCreateTime: caddyCreateTime},
-	}, serveStopGraceTimeout); err != nil {
+	if err := stopDaemonProcess(
+		caddyStopRecord(pid, caddyCreateTime), serveStopGraceTimeout,
+	); err != nil {
 		fmt.Printf(
 			"warning: could not stop managed caddy (pid %d): %v\n", pid, err,
 		)
 		return
 	}
 	fmt.Printf("Stopped managed caddy (pid %d).\n", pid)
+}
+
+// caddyStopRecord builds the record used to stop a managed Caddy child. It has
+// no SourcePath, so stopDaemonProcess only signals and waits and removes no
+// record file. The Caddy create time is carried as runtimeCreateTime so
+// stopDaemonProcess's pre-force-kill identity check guards a Caddy PID that was
+// reused during the grace wait.
+func caddyStopRecord(pid int, createTime string) daemon.RuntimeRecord {
+	return daemon.RuntimeRecord{
+		PID:      pid,
+		Metadata: map[string]string{runtimeCreateTime: createTime},
+	}
 }
 
 // stopDaemonProcess signals the daemon to shut down, waits up to grace for it

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -206,7 +206,11 @@ func stopDaemonProcess(rec daemon.RuntimeRecord, grace time.Duration) error {
 	if err := proc.Kill(); err != nil {
 		return fmt.Errorf("force killing: %w", err)
 	}
-	waitForProcessExit(rec.PID, grace)
+	if !waitForProcessExit(rec.PID, grace) {
+		// The process outlived even SIGKILL. Keep the runtime record so other
+		// commands still see the daemon owns the DB rather than racing it.
+		return fmt.Errorf("process %d still running after force kill", rec.PID)
+	}
 	removeRuntimeRecordFile(rec)
 	return nil
 }

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -172,14 +172,18 @@ func stopOrphanedCaddyChild(rec daemon.RuntimeRecord) {
 	if !daemon.ProcessAlive(pid) {
 		return
 	}
-	if !processCreateTimeMatches(pid, rec.Metadata[runtimeCaddyCreateTime]) {
+	caddyCreateTime := rec.Metadata[runtimeCaddyCreateTime]
+	if !processCreateTimeMatches(pid, caddyCreateTime) {
 		return
 	}
 	// SourcePath is empty, so stopDaemonProcess only signals and waits; it
-	// removes no record file for the Caddy child.
-	if err := stopDaemonProcess(
-		daemon.RuntimeRecord{PID: pid}, serveStopGraceTimeout,
-	); err != nil {
+	// removes no record file for the Caddy child. Carry the Caddy create time
+	// as runtimeCreateTime so the pre-force-kill identity check guards a Caddy
+	// PID reused during the grace wait.
+	if err := stopDaemonProcess(daemon.RuntimeRecord{
+		PID:      pid,
+		Metadata: map[string]string{runtimeCreateTime: caddyCreateTime},
+	}, serveStopGraceTimeout); err != nil {
 		fmt.Printf(
 			"warning: could not stop managed caddy (pid %d): %v\n", pid, err,
 		)

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -53,7 +53,7 @@ func serveStatusLines(rt *DaemonRuntime) []string {
 		lines = append(lines, fmt.Sprintf("  uptime:  %s", uptime))
 	}
 	if rt.ReadOnly {
-		lines = append(lines, "  mode:    read-only (pg serve)")
+		lines = append(lines, "  mode:    read-only")
 	}
 	return lines
 }

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -89,6 +89,7 @@ func runServeStop(cfg config.Config) {
 		if err := stopDaemonProcess(rec, serveStopGraceTimeout); err != nil {
 			fatal("serve stop: stopping pid %d: %v", rec.PID, err)
 		}
+		stopOrphanedCaddyChild(rec)
 		fmt.Printf("Stopped agentsview (pid %d).\n", rec.PID)
 		stopped++
 	}
@@ -126,26 +127,65 @@ func daemonRecordPingConfirmed(
 
 // processIdentityConfirmed reports whether the process now holding rec.PID is
 // the same one that wrote the record, by matching the OS create time persisted
-// at startup against the live process's current create time. The match is
-// exact: the create time is fixed for a given process, so a PID reused by a
-// different process yields a different value and is rejected -- there is no
-// slack window an impostor could fall into. Records without a persisted create
-// time (legacy, or a daemon whose create time could not be read) cannot be
-// confirmed this way and return false.
+// at startup against the live process's current create time.
 func processIdentityConfirmed(rec daemon.RuntimeRecord) bool {
-	raw := rec.Metadata[runtimeCreateTime]
-	if raw == "" {
+	return processCreateTimeMatches(rec.PID, rec.Metadata[runtimeCreateTime])
+}
+
+// processCreateTimeMatches reports whether pid's current OS create time equals
+// recordedMillis. The match is exact: the create time is fixed for a given
+// process, so a PID reused by a different process yields a different value and
+// is rejected -- there is no slack window an impostor could fall into. An empty
+// or unparseable recordedMillis (legacy, or unreadable at write time) returns
+// false.
+func processCreateTimeMatches(pid int, recordedMillis string) bool {
+	if recordedMillis == "" {
 		return false
 	}
-	recorded, err := strconv.ParseInt(raw, 10, 64)
+	recorded, err := strconv.ParseInt(recordedMillis, 10, 64)
 	if err != nil {
 		return false
 	}
-	live, ok := processCreateTimeMillis(rec.PID)
+	live, ok := processCreateTimeMillis(pid)
 	if !ok {
 		return false
 	}
 	return live == recorded
+}
+
+// stopOrphanedCaddyChild terminates a managed Caddy child recorded in rec if it
+// is still alive after the server stopped. When the server shuts down
+// gracefully it stops Caddy itself, so by here Caddy is already gone and this
+// is a no-op. When the server had to be force-killed (it ignored SIGTERM until
+// the grace timeout, then took SIGKILL), its cleanup never ran and Caddy would
+// otherwise keep holding the public port. The create time is matched exactly
+// before signalling, so a reused Caddy PID is never touched.
+func stopOrphanedCaddyChild(rec daemon.RuntimeRecord) {
+	raw := rec.Metadata[runtimeCaddyPID]
+	if raw == "" {
+		return
+	}
+	pid, err := strconv.Atoi(raw)
+	if err != nil || pid <= 0 {
+		return
+	}
+	if !daemon.ProcessAlive(pid) {
+		return
+	}
+	if !processCreateTimeMatches(pid, rec.Metadata[runtimeCaddyCreateTime]) {
+		return
+	}
+	// SourcePath is empty, so stopDaemonProcess only signals and waits; it
+	// removes no record file for the Caddy child.
+	if err := stopDaemonProcess(
+		daemon.RuntimeRecord{PID: pid}, serveStopGraceTimeout,
+	); err != nil {
+		fmt.Printf(
+			"warning: could not stop managed caddy (pid %d): %v\n", pid, err,
+		)
+		return
+	}
+	fmt.Printf("Stopped managed caddy (pid %d).\n", pid)
 }
 
 // stopDaemonProcess signals the daemon to shut down, waits up to grace for it

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -189,8 +189,10 @@ func stopOrphanedCaddyChild(rec daemon.RuntimeRecord) {
 }
 
 // stopDaemonProcess signals the daemon to shut down, waits up to grace for it
-// to exit, then escalates to a forced kill. It cleans up the runtime record if
-// the process leaves one behind.
+// to exit, then escalates to a forced kill. Before escalating it re-checks that
+// the live PID is still the recorded daemon, so a PID reused during the grace
+// wait is never killed. It cleans up the runtime record if the process leaves
+// one behind.
 func stopDaemonProcess(rec daemon.RuntimeRecord, grace time.Duration) error {
 	proc, err := os.FindProcess(rec.PID)
 	if err != nil {
@@ -200,6 +202,14 @@ func stopDaemonProcess(rec daemon.RuntimeRecord, grace time.Duration) error {
 		return fmt.Errorf("signalling shutdown: %w", err)
 	}
 	if waitForProcessExit(rec.PID, grace) {
+		removeRuntimeRecordFile(rec)
+		return nil
+	}
+	if !recordedDaemonStillPresent(rec) {
+		// The PID is alive but its identity no longer matches the record: the
+		// daemon exited during the grace wait and the PID was reused by an
+		// unrelated process. Do not force-kill the impostor; just drop the
+		// stale record.
 		removeRuntimeRecordFile(rec)
 		return nil
 	}

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -206,13 +206,29 @@ func stopDaemonProcess(rec daemon.RuntimeRecord, grace time.Duration) error {
 	if err := proc.Kill(); err != nil {
 		return fmt.Errorf("force killing: %w", err)
 	}
-	if !waitForProcessExit(rec.PID, grace) {
-		// The process outlived even SIGKILL. Keep the runtime record so other
-		// commands still see the daemon owns the DB rather than racing it.
+	if !waitForProcessExit(rec.PID, grace) && recordedDaemonStillPresent(rec) {
+		// The recorded daemon genuinely outlived even SIGKILL. Keep the
+		// runtime record so other commands still see it owns the DB rather
+		// than racing it. (A live PID whose identity no longer matches the
+		// record was reused after the daemon exited, so fall through and
+		// remove the stale record.)
 		return fmt.Errorf("process %d still running after force kill", rec.PID)
 	}
 	removeRuntimeRecordFile(rec)
 	return nil
+}
+
+// recordedDaemonStillPresent reports whether rec.PID still belongs to the
+// recorded daemon. With a persisted create time it is an exact identity match,
+// so a PID reused by an unrelated process is reported as not present. Without a
+// create time (legacy record) it conservatively assumes the live PID is still
+// the daemon.
+func recordedDaemonStillPresent(rec daemon.RuntimeRecord) bool {
+	raw := rec.Metadata[runtimeCreateTime]
+	if raw == "" {
+		return true
+	}
+	return processCreateTimeMatches(rec.PID, raw)
 }
 
 // waitForProcessExit polls until pid is gone or timeout elapses. It reports

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -64,7 +64,7 @@ func TestServeStatusLinesReadOnly(t *testing.T) {
 	}
 
 	out := strings.Join(serveStatusLines(rt), "\n")
-	assert.Contains(t, out, "read-only (pg serve)")
+	assert.Contains(t, out, "mode:    read-only")
 	assert.NotContains(t, out, "uptime:", "zero StartedAt must omit uptime")
 }
 

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -164,6 +164,62 @@ func TestStopDaemonProcessKeepsRecordWhenProcessSurvives(t *testing.T) {
 		"runtime record must be kept when the daemon is still alive")
 }
 
+func TestRecordedDaemonStillPresent(t *testing.T) {
+	live, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+
+	assert.True(t, recordedDaemonStillPresent(daemon.RuntimeRecord{
+		PID: os.Getpid(),
+		Metadata: map[string]string{
+			runtimeCreateTime: strconv.FormatInt(live, 10),
+		},
+	}), "exact create-time match means the daemon is still present")
+
+	assert.False(t, recordedDaemonStillPresent(daemon.RuntimeRecord{
+		PID:      os.Getpid(),
+		Metadata: map[string]string{runtimeCreateTime: "1"},
+	}), "mismatched create time means the PID was reused, daemon is gone")
+
+	assert.True(t, recordedDaemonStillPresent(daemon.RuntimeRecord{
+		PID: os.Getpid(),
+	}), "legacy record without a create time conservatively assumes presence")
+}
+
+func TestStopDaemonProcessRemovesRecordWhenPIDReused(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX zombie semantics for ProcessAlive")
+	}
+	dir := runtimeTestDir(t)
+
+	target := exec.Command("sleep", "60")
+	require.NoError(t, target.Start())
+	pid := target.Process.Pid
+	t.Cleanup(func() {
+		_ = target.Process.Kill()
+		_ = target.Wait()
+	})
+
+	// A create time that cannot match the live process models the daemon
+	// having exited with the PID reused by something unrelated. The record
+	// must be removed (not kept) so later commands do not think the DB is
+	// still owned.
+	_, err := writeRuntimeRecordForTest(dir, daemon.RuntimeRecord{
+		PID:      pid,
+		Network:  daemon.NetworkTCP,
+		Address:  "127.0.0.1:1",
+		Metadata: map[string]string{runtimeCreateTime: "1"},
+	})
+	require.NoError(t, err)
+	records := liveDaemonRecords(dir)
+	require.Len(t, records, 1)
+
+	err = stopDaemonProcess(records[0], 100*time.Millisecond)
+	require.NoError(t, err,
+		"a reused PID means the daemon exited; stop should succeed")
+	assert.Empty(t, liveDaemonRecords(dir),
+		"the stale record for a reused PID must be removed")
+}
+
 func TestWriteDaemonRuntimePersistsCaddyMetadata(t *testing.T) {
 	dir := runtimeTestDir(t)
 	// Use this process as a stand-in caddy child: it is alive with a readable

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -347,6 +347,16 @@ func TestStopOrphanedCaddyChildSkipsMismatchedCreateTime(t *testing.T) {
 		"a reused caddy PID must not be signalled")
 }
 
+func TestCaddyStopRecordCarriesCreateTime(t *testing.T) {
+	rec := caddyStopRecord(4321, "1700000000000")
+	assert.Equal(t, 4321, rec.PID)
+	assert.Equal(t, "1700000000000", rec.Metadata[runtimeCreateTime],
+		"the caddy create time must be carried as runtimeCreateTime so the "+
+			"pre-force-kill identity check guards a reused caddy PID")
+	assert.Empty(t, rec.SourcePath,
+		"a caddy stop record has no source file to remove")
+}
+
 func TestStopOrphanedCaddyChildNoMetadataIsNoop(t *testing.T) {
 	assert.NotPanics(t, func() {
 		stopOrphanedCaddyChild(daemon.RuntimeRecord{PID: os.Getpid()})

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -168,56 +168,98 @@ func TestDaemonRecordPingConfirmedRequiresAuthToken(t *testing.T) {
 	assert.True(t, daemonRecordPingConfirmed(rec, "secret"))
 }
 
-func TestProcessStartedBeforeRecord(t *testing.T) {
-	// This test process started before "now", so a record stamped now is a
-	// genuine match.
-	now := time.Now()
-	assert.True(t, processStartedBeforeRecord(daemon.RuntimeRecord{
-		PID:       os.Getpid(),
-		StartedAt: now,
-	}))
+func TestWriteDaemonRuntimePersistsCreateTimeForStop(t *testing.T) {
+	dir := runtimeTestDir(t)
+	_, err := WriteDaemonRuntime(dir, "127.0.0.1", 65535, "test", false)
+	require.NoError(t, err)
 
-	// A record stamped long before this process started models a PID reused
-	// by an unrelated process: the live process started after the record.
-	assert.False(t, processStartedBeforeRecord(daemon.RuntimeRecord{
-		PID:       os.Getpid(),
-		StartedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
-	}))
+	recs := liveDaemonRecords(dir)
+	require.Len(t, recs, 1)
+	assert.NotEmpty(t, recs[0].Metadata[runtimeCreateTime],
+		"WriteDaemonRuntime must persist the process create time")
 
-	// A legacy record without a StartedAt cannot be checked this way.
-	assert.False(t, processStartedBeforeRecord(daemon.RuntimeRecord{
+	// No server answers at that port, so ping confirmation fails; the
+	// persisted create time must still confirm the record belongs to this
+	// live process so a wedged daemon is stoppable.
+	assert.False(t, daemonRecordPingConfirmed(recs[0], ""))
+	assert.True(t, stopTargetConfirmed(recs[0], ""))
+}
+
+func TestProcessIdentityConfirmed(t *testing.T) {
+	live, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok, "must be able to read this process's create time")
+
+	// Exact create-time match: the recorded daemon is still on this PID.
+	assert.True(t, processIdentityConfirmed(daemon.RuntimeRecord{
 		PID: os.Getpid(),
+		Metadata: map[string]string{
+			runtimeCreateTime: strconv.FormatInt(live, 10),
+		},
+	}))
+
+	// Different create time models a PID reused by another process: there is
+	// no slack window, so a mismatch is always rejected.
+	assert.False(t, processIdentityConfirmed(daemon.RuntimeRecord{
+		PID: os.Getpid(),
+		Metadata: map[string]string{
+			runtimeCreateTime: strconv.FormatInt(live+1, 10),
+		},
+	}))
+
+	// Missing or unparseable metadata cannot be confirmed this way.
+	assert.False(t, processIdentityConfirmed(daemon.RuntimeRecord{
+		PID: os.Getpid(),
+	}))
+	assert.False(t, processIdentityConfirmed(daemon.RuntimeRecord{
+		PID:      os.Getpid(),
+		Metadata: map[string]string{runtimeCreateTime: "not-a-number"},
 	}))
 }
 
-func TestStopTargetConfirmedHungDaemonByStartTime(t *testing.T) {
+func TestStopTargetConfirmedHungDaemonByCreateTime(t *testing.T) {
 	// A daemon that is alive but no longer answers the ping probe (dead
-	// address) must still be confirmed by its process start time, so a
+	// address) must still be confirmed by its persisted create time, so a
 	// wedged server remains stoppable.
+	live, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
 	rec := daemon.RuntimeRecord{
-		PID:       os.Getpid(),
-		Network:   daemon.NetworkTCP,
-		Address:   "127.0.0.1:1",
-		Service:   daemonService,
-		StartedAt: time.Now(),
+		PID:     os.Getpid(),
+		Network: daemon.NetworkTCP,
+		Address: "127.0.0.1:1",
+		Service: daemonService,
+		Metadata: map[string]string{
+			runtimeCreateTime: strconv.FormatInt(live, 10),
+		},
 	}
 	assert.False(t, daemonRecordPingConfirmed(rec, ""),
 		"precondition: the dead address must not ping-confirm")
 	assert.True(t, stopTargetConfirmed(rec, ""),
-		"a hung-but-alive daemon must remain stoppable via start-time identity")
+		"a hung-but-alive daemon must remain stoppable via create-time identity")
 }
 
 func TestStopTargetConfirmedRejectsReusedPID(t *testing.T) {
-	// No ping and a StartedAt predating this process: neither check confirms,
-	// so stop must not signal the unrelated process holding the PID.
+	// No ping and a create time that does not match this process: neither
+	// check confirms, so stop must not signal the process holding the PID.
+	live, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
 	rec := daemon.RuntimeRecord{
-		PID:       os.Getpid(),
-		Network:   daemon.NetworkTCP,
-		Address:   "127.0.0.1:1",
-		Service:   daemonService,
-		StartedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+		PID:     os.Getpid(),
+		Network: daemon.NetworkTCP,
+		Address: "127.0.0.1:1",
+		Service: daemonService,
+		Metadata: map[string]string{
+			runtimeCreateTime: strconv.FormatInt(live+5000, 10),
+		},
 	}
 	assert.False(t, stopTargetConfirmed(rec, ""))
+
+	// A legacy record with no create time also cannot be confirmed.
+	assert.False(t, stopTargetConfirmed(daemon.RuntimeRecord{
+		PID:     os.Getpid(),
+		Network: daemon.NetworkTCP,
+		Address: "127.0.0.1:1",
+		Service: daemonService,
+	}, ""))
 }
 
 // startReapedProcess starts and fully reaps a short-lived process, returning a

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -132,7 +132,7 @@ func TestStopDaemonProcessTerminatesAndCleansRecord(t *testing.T) {
 		"runtime record must be removed after stop")
 }
 
-func TestDaemonRecordIdentityConfirmedRespondingDaemon(t *testing.T) {
+func TestDaemonRecordPingConfirmedRespondingDaemon(t *testing.T) {
 	host, port := testPingServer(t)
 	rec := daemon.RuntimeRecord{
 		PID:     os.Getpid(),
@@ -140,23 +140,22 @@ func TestDaemonRecordIdentityConfirmedRespondingDaemon(t *testing.T) {
 		Address: net.JoinHostPort(host, strconv.Itoa(port)),
 		Service: daemonService,
 	}
-	assert.True(t, daemonRecordIdentityConfirmed(rec, ""))
+	assert.True(t, daemonRecordPingConfirmed(rec, ""))
 }
 
-func TestDaemonRecordIdentityConfirmedUnresponsivePID(t *testing.T) {
+func TestDaemonRecordPingConfirmedUnresponsivePID(t *testing.T) {
 	// A live PID (this process) but a record pointing at a port with no
-	// agentsview daemon. The probe must fail so stop does not signal a
-	// process that merely reused a stale record's PID.
+	// agentsview daemon. The probe must fail.
 	rec := daemon.RuntimeRecord{
 		PID:     os.Getpid(),
 		Network: daemon.NetworkTCP,
 		Address: "127.0.0.1:1",
 		Service: daemonService,
 	}
-	assert.False(t, daemonRecordIdentityConfirmed(rec, ""))
+	assert.False(t, daemonRecordPingConfirmed(rec, ""))
 }
 
-func TestDaemonRecordIdentityConfirmedRequiresAuthToken(t *testing.T) {
+func TestDaemonRecordPingConfirmedRequiresAuthToken(t *testing.T) {
 	host, port := testAuthenticatedPingServer(t, "secret")
 	rec := daemon.RuntimeRecord{
 		PID:     os.Getpid(),
@@ -164,9 +163,61 @@ func TestDaemonRecordIdentityConfirmedRequiresAuthToken(t *testing.T) {
 		Address: net.JoinHostPort(host, strconv.Itoa(port)),
 		Service: daemonService,
 	}
-	assert.False(t, daemonRecordIdentityConfirmed(rec, ""),
+	assert.False(t, daemonRecordPingConfirmed(rec, ""),
 		"a require_auth daemon must not be confirmed without the token")
-	assert.True(t, daemonRecordIdentityConfirmed(rec, "secret"))
+	assert.True(t, daemonRecordPingConfirmed(rec, "secret"))
+}
+
+func TestProcessStartedBeforeRecord(t *testing.T) {
+	// This test process started before "now", so a record stamped now is a
+	// genuine match.
+	now := time.Now()
+	assert.True(t, processStartedBeforeRecord(daemon.RuntimeRecord{
+		PID:       os.Getpid(),
+		StartedAt: now,
+	}))
+
+	// A record stamped long before this process started models a PID reused
+	// by an unrelated process: the live process started after the record.
+	assert.False(t, processStartedBeforeRecord(daemon.RuntimeRecord{
+		PID:       os.Getpid(),
+		StartedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+	}))
+
+	// A legacy record without a StartedAt cannot be checked this way.
+	assert.False(t, processStartedBeforeRecord(daemon.RuntimeRecord{
+		PID: os.Getpid(),
+	}))
+}
+
+func TestStopTargetConfirmedHungDaemonByStartTime(t *testing.T) {
+	// A daemon that is alive but no longer answers the ping probe (dead
+	// address) must still be confirmed by its process start time, so a
+	// wedged server remains stoppable.
+	rec := daemon.RuntimeRecord{
+		PID:       os.Getpid(),
+		Network:   daemon.NetworkTCP,
+		Address:   "127.0.0.1:1",
+		Service:   daemonService,
+		StartedAt: time.Now(),
+	}
+	assert.False(t, daemonRecordPingConfirmed(rec, ""),
+		"precondition: the dead address must not ping-confirm")
+	assert.True(t, stopTargetConfirmed(rec, ""),
+		"a hung-but-alive daemon must remain stoppable via start-time identity")
+}
+
+func TestStopTargetConfirmedRejectsReusedPID(t *testing.T) {
+	// No ping and a StartedAt predating this process: neither check confirms,
+	// so stop must not signal the unrelated process holding the PID.
+	rec := daemon.RuntimeRecord{
+		PID:       os.Getpid(),
+		Network:   daemon.NetworkTCP,
+		Address:   "127.0.0.1:1",
+		Service:   daemonService,
+		StartedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	assert.False(t, stopTargetConfirmed(rec, ""))
 }
 
 // startReapedProcess starts and fully reaps a short-lived process, returning a

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -132,6 +132,38 @@ func TestStopDaemonProcessTerminatesAndCleansRecord(t *testing.T) {
 		"runtime record must be removed after stop")
 }
 
+func TestStopDaemonProcessKeepsRecordWhenProcessSurvives(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX zombie semantics for ProcessAlive")
+	}
+	dir := runtimeTestDir(t)
+
+	target := exec.Command("sleep", "60")
+	require.NoError(t, target.Start())
+	pid := target.Process.Pid
+	// Deliberately do NOT reap until cleanup: once signalled, the child
+	// becomes a zombie, which daemon.ProcessAlive reports as still alive.
+	// That drives stopDaemonProcess down its "survived the kill" path.
+	t.Cleanup(func() {
+		_ = target.Process.Kill()
+		_ = target.Wait()
+	})
+
+	_, err := writeRuntimeRecordForTest(dir, daemon.RuntimeRecord{
+		PID:     pid,
+		Network: daemon.NetworkTCP,
+		Address: "127.0.0.1:1",
+	})
+	require.NoError(t, err)
+	records := liveDaemonRecords(dir)
+	require.Len(t, records, 1)
+
+	err = stopDaemonProcess(records[0], 100*time.Millisecond)
+	require.Error(t, err, "must report failure when the process does not exit")
+	assert.NotEmpty(t, liveDaemonRecords(dir),
+		"runtime record must be kept when the daemon is still alive")
+}
+
 func TestWriteDaemonRuntimePersistsCaddyMetadata(t *testing.T) {
 	dir := runtimeTestDir(t)
 	// Use this process as a stand-in caddy child: it is alive with a readable

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"net"
+	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -127,6 +130,43 @@ func TestStopDaemonProcessTerminatesAndCleansRecord(t *testing.T) {
 	assert.False(t, daemon.ProcessAlive(pid))
 	assert.Empty(t, liveDaemonRecords(dir),
 		"runtime record must be removed after stop")
+}
+
+func TestDaemonRecordIdentityConfirmedRespondingDaemon(t *testing.T) {
+	host, port := testPingServer(t)
+	rec := daemon.RuntimeRecord{
+		PID:     os.Getpid(),
+		Network: daemon.NetworkTCP,
+		Address: net.JoinHostPort(host, strconv.Itoa(port)),
+		Service: daemonService,
+	}
+	assert.True(t, daemonRecordIdentityConfirmed(rec, ""))
+}
+
+func TestDaemonRecordIdentityConfirmedUnresponsivePID(t *testing.T) {
+	// A live PID (this process) but a record pointing at a port with no
+	// agentsview daemon. The probe must fail so stop does not signal a
+	// process that merely reused a stale record's PID.
+	rec := daemon.RuntimeRecord{
+		PID:     os.Getpid(),
+		Network: daemon.NetworkTCP,
+		Address: "127.0.0.1:1",
+		Service: daemonService,
+	}
+	assert.False(t, daemonRecordIdentityConfirmed(rec, ""))
+}
+
+func TestDaemonRecordIdentityConfirmedRequiresAuthToken(t *testing.T) {
+	host, port := testAuthenticatedPingServer(t, "secret")
+	rec := daemon.RuntimeRecord{
+		PID:     os.Getpid(),
+		Network: daemon.NetworkTCP,
+		Address: net.JoinHostPort(host, strconv.Itoa(port)),
+		Service: daemonService,
+	}
+	assert.False(t, daemonRecordIdentityConfirmed(rec, ""),
+		"a require_auth daemon must not be confirmed without the token")
+	assert.True(t, daemonRecordIdentityConfirmed(rec, "secret"))
 }
 
 // startReapedProcess starts and fully reaps a short-lived process, returning a

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -132,6 +132,102 @@ func TestStopDaemonProcessTerminatesAndCleansRecord(t *testing.T) {
 		"runtime record must be removed after stop")
 }
 
+func TestWriteDaemonRuntimePersistsCaddyMetadata(t *testing.T) {
+	dir := runtimeTestDir(t)
+	// Use this process as a stand-in caddy child: it is alive with a readable
+	// create time. We never signal it here.
+	_, err := WriteDaemonRuntime(dir, "127.0.0.1", 65535, "test", false, os.Getpid())
+	require.NoError(t, err)
+
+	recs := liveDaemonRecords(dir)
+	require.Len(t, recs, 1)
+	assert.Equal(t, strconv.Itoa(os.Getpid()), recs[0].Metadata[runtimeCaddyPID])
+	ct, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	assert.Equal(t,
+		strconv.FormatInt(ct, 10), recs[0].Metadata[runtimeCaddyCreateTime])
+}
+
+func TestWriteDaemonRuntimeOmitsCaddyMetadataWhenAbsent(t *testing.T) {
+	dir := runtimeTestDir(t)
+	_, err := WriteDaemonRuntime(dir, "127.0.0.1", 65535, "test", false)
+	require.NoError(t, err)
+	recs := liveDaemonRecords(dir)
+	require.Len(t, recs, 1)
+	_, has := recs[0].Metadata[runtimeCaddyPID]
+	assert.False(t, has, "no caddy pid means no caddy metadata")
+
+	// A zero caddy pid must also be omitted.
+	dir2 := runtimeTestDir(t)
+	_, err = WriteDaemonRuntime(dir2, "127.0.0.1", 65535, "test", false, 0)
+	require.NoError(t, err)
+	recs2 := liveDaemonRecords(dir2)
+	require.Len(t, recs2, 1)
+	_, has = recs2[0].Metadata[runtimeCaddyPID]
+	assert.False(t, has)
+}
+
+func TestStopOrphanedCaddyChildTerminatesConfirmed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("graceful SIGTERM termination is POSIX-specific")
+	}
+	caddy := exec.Command("sleep", "60")
+	require.NoError(t, caddy.Start())
+	pid := caddy.Process.Pid
+	reaped := make(chan struct{})
+	go func() {
+		_ = caddy.Wait()
+		close(reaped)
+	}()
+	t.Cleanup(func() { _ = caddy.Process.Kill() })
+
+	ct, ok := processCreateTimeMillis(pid)
+	require.True(t, ok)
+	rec := daemon.RuntimeRecord{
+		PID: os.Getpid(),
+		Metadata: map[string]string{
+			runtimeCaddyPID:        strconv.Itoa(pid),
+			runtimeCaddyCreateTime: strconv.FormatInt(ct, 10),
+		},
+	}
+
+	stopOrphanedCaddyChild(rec)
+	<-reaped
+	assert.False(t, daemon.ProcessAlive(pid),
+		"a confirmed orphaned caddy child must be terminated")
+}
+
+func TestStopOrphanedCaddyChildSkipsMismatchedCreateTime(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("graceful SIGTERM termination is POSIX-specific")
+	}
+	caddy := exec.Command("sleep", "60")
+	require.NoError(t, caddy.Start())
+	pid := caddy.Process.Pid
+	t.Cleanup(func() {
+		_ = caddy.Process.Kill()
+		_ = caddy.Wait()
+	})
+
+	rec := daemon.RuntimeRecord{
+		PID: os.Getpid(),
+		Metadata: map[string]string{
+			runtimeCaddyPID:        strconv.Itoa(pid),
+			runtimeCaddyCreateTime: "1", // deliberately wrong: models a reused PID
+		},
+	}
+
+	stopOrphanedCaddyChild(rec)
+	assert.True(t, daemon.ProcessAlive(pid),
+		"a reused caddy PID must not be signalled")
+}
+
+func TestStopOrphanedCaddyChildNoMetadataIsNoop(t *testing.T) {
+	assert.NotPanics(t, func() {
+		stopOrphanedCaddyChild(daemon.RuntimeRecord{PID: os.Getpid()})
+	})
+}
+
 func TestDaemonRecordPingConfirmedRespondingDaemon(t *testing.T) {
 	host, port := testPingServer(t)
 	rec := daemon.RuntimeRecord{

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/daemon"
+)
+
+func TestLiveDaemonRecordsFiltersDeadProcesses(t *testing.T) {
+	dir := runtimeTestDir(t)
+
+	// WriteDaemonRuntime stamps the record with this live test process PID.
+	host, port := testPingServer(t)
+	_, err := WriteDaemonRuntime(dir, host, port, "1.0.0", false)
+	require.NoError(t, err)
+
+	// A record for a process that has already exited must be excluded.
+	dead := startReapedProcess(t)
+	_, err = writeRuntimeRecordForTest(dir, daemon.RuntimeRecord{
+		PID:     dead,
+		Network: daemon.NetworkTCP,
+		Address: "127.0.0.1:1",
+	})
+	require.NoError(t, err)
+
+	records := liveDaemonRecords(dir)
+	require.Len(t, records, 1)
+	assert.NotEqual(t, dead, records[0].PID)
+	assert.NotEmpty(t, records[0].SourcePath,
+		"List must populate SourcePath so stop can clean up the record")
+}
+
+func TestServeStatusLinesWritable(t *testing.T) {
+	rt := &DaemonRuntime{
+		Record: daemon.RuntimeRecord{
+			PID:       4242,
+			Version:   "9.9.9",
+			StartedAt: time.Now().Add(-90 * time.Second),
+		},
+		Host: "127.0.0.1",
+		Port: 8080,
+	}
+
+	out := strings.Join(serveStatusLines(rt), "\n")
+	assert.Contains(t, out, "running at http://127.0.0.1:8080")
+	assert.Contains(t, out, "pid:     4242")
+	assert.Contains(t, out, "version: 9.9.9")
+	assert.Contains(t, out, "uptime:")
+	assert.NotContains(t, out, "read-only")
+}
+
+func TestServeStatusLinesReadOnly(t *testing.T) {
+	rt := &DaemonRuntime{
+		Record:   daemon.RuntimeRecord{PID: 7},
+		Host:     "127.0.0.1",
+		Port:     9000,
+		ReadOnly: true,
+	}
+
+	out := strings.Join(serveStatusLines(rt), "\n")
+	assert.Contains(t, out, "read-only (pg serve)")
+	assert.NotContains(t, out, "uptime:", "zero StartedAt must omit uptime")
+}
+
+func TestAcquireBackgroundLaunchLockSerializes(t *testing.T) {
+	dir := t.TempDir()
+
+	first, ok := acquireBackgroundLaunchLock(dir)
+	require.True(t, ok, "first launch must acquire the lock")
+
+	_, ok = acquireBackgroundLaunchLock(dir)
+	assert.False(t, ok, "a concurrent launch must not acquire the lock")
+
+	require.NoError(t, first.Unlock())
+
+	third, ok := acquireBackgroundLaunchLock(dir)
+	require.True(t, ok, "lock must be reacquirable after release")
+	require.NoError(t, third.Unlock())
+}
+
+func TestServeCommandHasLifecycleSubcommands(t *testing.T) {
+	cmd := newServeCommand()
+	names := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		names[sub.Name()] = true
+	}
+	assert.True(t, names["status"], "serve must expose a status subcommand")
+	assert.True(t, names["stop"], "serve must expose a stop subcommand")
+}
+
+func TestStopDaemonProcessTerminatesAndCleansRecord(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("graceful SIGTERM termination is POSIX-specific")
+	}
+	dir := runtimeTestDir(t)
+
+	target := exec.Command("sleep", "60")
+	require.NoError(t, target.Start())
+	pid := target.Process.Pid
+	// Reap concurrently so the process leaves the zombie state once it
+	// exits; daemon.ProcessAlive treats an unreaped zombie as alive.
+	reaped := make(chan struct{})
+	go func() {
+		_ = target.Wait()
+		close(reaped)
+	}()
+	t.Cleanup(func() { _ = target.Process.Kill() })
+
+	_, err := writeRuntimeRecordForTest(dir, daemon.RuntimeRecord{
+		PID:     pid,
+		Network: daemon.NetworkTCP,
+		Address: "127.0.0.1:1",
+	})
+	require.NoError(t, err)
+
+	records := liveDaemonRecords(dir)
+	require.Len(t, records, 1)
+
+	require.NoError(t, stopDaemonProcess(records[0], 5*time.Second))
+	<-reaped
+	assert.False(t, daemon.ProcessAlive(pid))
+	assert.Empty(t, liveDaemonRecords(dir),
+		"runtime record must be removed after stop")
+}
+
+// startReapedProcess starts and fully reaps a short-lived process, returning a
+// PID that is guaranteed dead.
+func startReapedProcess(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "exit")
+	}
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	require.NoError(t, cmd.Wait())
+	return pid
+}

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -220,6 +220,43 @@ func TestStopDaemonProcessRemovesRecordWhenPIDReused(t *testing.T) {
 		"the stale record for a reused PID must be removed")
 }
 
+func TestStopDaemonProcessSparesReusedPIDBeforeForceKill(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX signal semantics")
+	}
+	dir := runtimeTestDir(t)
+
+	// A process that ignores SIGTERM stays alive through the grace wait,
+	// reaching the force-kill escalation. With a mismatched create time it
+	// stands in for a live process that reused the daemon's PID. The pre-kill
+	// identity check must spare it instead of escalating to SIGKILL.
+	target := exec.Command("sh", "-c", "trap '' TERM; sleep 60")
+	require.NoError(t, target.Start())
+	pid := target.Process.Pid
+	t.Cleanup(func() {
+		_ = target.Process.Kill()
+		_ = target.Wait()
+	})
+
+	_, err := writeRuntimeRecordForTest(dir, daemon.RuntimeRecord{
+		PID:      pid,
+		Network:  daemon.NetworkTCP,
+		Address:  "127.0.0.1:1",
+		Metadata: map[string]string{runtimeCreateTime: "1"},
+	})
+	require.NoError(t, err)
+	records := liveDaemonRecords(dir)
+	require.Len(t, records, 1)
+
+	err = stopDaemonProcess(records[0], 100*time.Millisecond)
+	require.NoError(t, err,
+		"a reused PID means the daemon exited; stop should succeed")
+	assert.Empty(t, liveDaemonRecords(dir),
+		"the stale record for a reused PID must be removed")
+	assert.True(t, daemon.ProcessAlive(pid),
+		"the reused PID must not be force-killed")
+}
+
 func TestWriteDaemonRuntimePersistsCaddyMetadata(t *testing.T) {
 	dir := runtimeTestDir(t)
 	// Use this process as a stand-in caddy child: it is alive with a readable

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.kenn.io/kit v0.1.5
 	golang.org/x/mod v0.37.0
 	golang.org/x/sync v0.21.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 )
 
@@ -94,7 +95,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/mattn/go-sqlite3 v1.14.45
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -79,7 +80,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/posthog/posthog-go v1.12.6 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect


### PR DESCRIPTION
Closes #682

`agentsview serve` runs in the foreground and holds the terminal until you stop
it. This adds background startup plus the lifecycle commands to manage it:

- `agentsview serve --background` starts the server as a detached process and
  returns your shell prompt.
- `agentsview serve status` reports whether a server owns the data dir and where
  to reach it (URL, pid, version, uptime).
- `agentsview serve stop` signals the running server, waits for it to shut down,
  and cleans up its runtime record.

## Background startup

The parent re-execs the same binary with `--background` removed, points the
child's stdin at the null device and its stdout and stderr at
`~/.agentsview/serve.log`, and detaches it from the controlling terminal
(`setsid` on Unix, `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows). It
then polls the kit daemon runtime record until the child reports ready, up to 5
seconds, prints the URL, pid, and log path, and exits.

Concurrent launches are serialized with a dedicated launch lock
(`serve.background.lock`), held only for the parent's startup and distinct from
the daemon start lock so the spawned child can still claim that lock during its
own (possibly long) startup. A launch that loses the lock, or that finds a
writable daemon already running or still starting (`IsLocalDaemonActive`),
reports the existing server instead of spawning a second one. The launch lock is
taken before any config mutation, so two `--background --require-auth`
invocations can no longer each generate and persist a different auth token; only
the launch that wins the lock generates one.

## Lifecycle

`status` and `stop` are subcommands of `serve` and read the kit daemon runtime
records. `stop` sends a graceful signal (SIGTERM on POSIX), waits for the
process to exit, escalates to a forced kill if it does not, and removes a
leftover record.

## Tradeoffs and limitations

- On Windows there is no POSIX-signal equivalent for a detached process, so
  `serve stop` kills it; the runtime record is removed afterward.
- Two near-simultaneous `--background` launches are serialized by the launch
  lock. A `--background` launch issued at the same instant as a foreground
  `serve`, before either claims the start lock, can still race -- the same
  window two foreground `serve` calls already have.
- With `require_auth`, a launch that loses the lock prints "already in progress"
  rather than the URL, because its in-memory token predates the winner's freshly
  persisted one. It still avoids spawning a second server.
- `serve.log` is append-only. Each start adds a short banner; the bulk of
  logging goes to `debug.log`, which is capped.

## Where to look

- `cmd/agentsview/serve_background.go`: spawn, launch-lock serialization,
  readiness wait, and argument handling.
- `cmd/agentsview/serve_lifecycle.go`: `serve status` and `serve stop`.
- `cmd/agentsview/serve_background_unix.go` and `serve_background_windows.go`:
  platform detach attributes and terminate signal.
- `cmd/agentsview/daemon_runtime.go`: `liveDaemonRecords`, used by status and
  stop to find live daemons without requiring a ping.
- `cmd/agentsview/cli.go`: the `--background` flag and the `status` / `stop`
  subcommands.
