### PR TITLE
fix(frontend): strengthen selected sidebar row

### DIFF
--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -255,6 +255,7 @@
   class:orphaned-teammate={isOrphanedTeammate}
   data-session-id={session.id}
   role="button"
+  aria-current={isActive ? "page" : undefined}
   tabindex="0"
   style:padding-left="{8 + depth * 16}px"
   onclick={() => sessions.selectSession(session.id)}
@@ -392,7 +393,7 @@
     padding: 0 10px;
     padding-right: 10px;
     text-align: left;
-    transition: background 0.1s;
+    transition: background 0.1s, box-shadow 0.1s;
     user-select: none;
     -webkit-user-select: none;
     cursor: pointer;
@@ -414,7 +415,28 @@
   }
 
   .session-item.active {
-    background: var(--bg-surface-hover);
+    background: color-mix(in srgb, var(--accent-blue) 11%, var(--bg-surface-hover));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-blue) 28%, transparent);
+  }
+
+  .session-item.active::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 5px;
+    bottom: 5px;
+    width: 3px;
+    border-radius: 0 2px 2px 0;
+    background: var(--accent-blue);
+  }
+
+  .session-item.active .session-name {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  .session-item.active .session-meta {
+    color: var(--text-secondary);
   }
 
   /* Orphaned teammate at root level — dim it slightly */

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -11,6 +11,7 @@ import { mount, tick, unmount } from "svelte";
 // @ts-ignore
 import SessionList from "./SessionList.svelte";
 import sessionFilterControlSource from "../filters/SessionFilterControl.svelte?raw";
+import sessionItemSource from "./SessionItem.svelte?raw";
 import { sessions } from "../../stores/sessions.svelte.js";
 import type { Session } from "../../api/types.js";
 import { starred } from "../../stores/starred.svelte.js";
@@ -268,6 +269,45 @@ describe("SessionList visible hydration", () => {
     const name = document.querySelector<HTMLElement>(".session-name");
     expect(name).not.toBeNull();
     expect(name?.textContent).toBe(title);
+  });
+
+  it("marks the active session row for assistive tech", async () => {
+    sessions.sessions = [
+      makeSession({
+        id: "active-session",
+        first_message: "Selected transcript",
+        is_index_only: false,
+      }),
+      makeSession({
+        id: "other-session",
+        first_message: "Other transcript",
+        is_index_only: false,
+      }),
+    ];
+    sessions.activeSessionId = "active-session";
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    const active = document.querySelector<HTMLElement>(
+      '[data-session-id="active-session"]',
+    );
+    const other = document.querySelector<HTMLElement>(
+      '[data-session-id="other-session"]',
+    );
+    expect(active).not.toBeNull();
+    expect(active?.getAttribute("aria-current")).toBe("page");
+    expect(other).not.toBeNull();
+    expect(other?.hasAttribute("aria-current")).toBe(false);
+  });
+
+  it("gives active rows a persistent visual indicator distinct from hover", () => {
+    expect(sessionItemSource).toContain(".session-item.active::before");
+    expect(sessionItemSource).toContain("background: var(--accent-blue)");
+    expect(sessionItemSource).toContain(
+      "box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-blue) 28%, transparent)",
+    );
   });
 
   it("hydrates newly visible rows after scrolling", async () => {


### PR DESCRIPTION
Fixes #161.

Selected sidebar rows now expose `aria-current="page"` for assistive technology and use a persistent accent rail, stronger selected fill, inset outline, and heavier title weight so the active transcript is visibly distinct from hover state.

Focused sidebar tests cover the active-row accessibility marker and selected-state styling guard.

Screenshot of proposed fix:

![agentsview-pr-675-selected-sidebar.png](https://github.com/user-attachments/assets/4d3158ae-d8fd-49c2-a95f-937e19c820b3)
