### PR TITLE
feat(frontend): copy active session source path

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -5,6 +5,7 @@
     ArrowUpNarrowWideIcon,
     CheckIcon,
     CloudUploadIcon,
+    CopyIcon,
     DownloadIcon,
     EllipsisIcon,
     FunnelIcon,
@@ -119,6 +120,15 @@
     showOverflow = false;
   }
 
+  async function handleCopySourceFilePath() {
+    const filePath = sessions.activeSession?.file_path;
+    if (!filePath) return;
+    const ok = await copyToClipboard(filePath);
+    if (!ok) return;
+    showExportMenu = false;
+    showOverflow = false;
+  }
+
   function openPublish(secret: boolean) {
     ui.publishSecret = secret;
     ui.activeModal = "publish";
@@ -128,6 +138,9 @@
 
   const hasActiveSession = $derived(
     sessions.activeSessionId !== null,
+  );
+  const activeSessionFilePath = $derived(
+    sessions.activeSession?.file_path ?? "",
   );
 
   // Close block filter dropdown on outside click
@@ -516,6 +529,15 @@
                 {/if}
               </span>
             </button>
+            {#if activeSessionFilePath}
+              <button
+                class="overflow-item"
+                onclick={handleCopySourceFilePath}
+              >
+                <CopyIcon size="13" strokeWidth="2" aria-hidden="true" />
+                <span>Copy source file path</span>
+              </button>
+            {/if}
           </div>
         {/if}
       </div>
@@ -602,6 +624,15 @@
                 {/if}
               </span>
             </button>
+            {#if activeSessionFilePath}
+              <button
+                class="overflow-item"
+                onclick={handleCopySourceFilePath}
+              >
+                <CopyIcon size="13" strokeWidth="2" aria-hidden="true" />
+                <span>Copy source file path</span>
+              </button>
+            {/if}
             <button
               class="overflow-item"
               onclick={() => openPublish(false)}

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -27,9 +27,29 @@ vi.mock("../../utils/clipboard.js", () => ({
 
 import { sessions } from "../../stores/sessions.svelte.js";
 import { ui } from "../../stores/ui.svelte.js";
+import type { Session } from "../../api/types.js";
 
 // @ts-ignore
 import AppHeader from "./AppHeader.svelte";
+
+function testSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "sess-123",
+    project: "agentsview",
+    machine: "test-machine",
+    agent: "codex",
+    first_message: "Synthetic test session",
+    started_at: "2026-06-13T12:00:00Z",
+    ended_at: "2026-06-13T12:05:00Z",
+    message_count: 2,
+    user_message_count: 1,
+    total_output_tokens: 0,
+    peak_context_tokens: 0,
+    is_automated: false,
+    created_at: "2026-06-13T12:00:00Z",
+    ...overrides,
+  };
+}
 
 describe("AppHeader export actions", () => {
   let component: ReturnType<typeof mount> | undefined;
@@ -37,6 +57,7 @@ describe("AppHeader export actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessions.activeSessionId = "sess-123";
+    sessions.sessions = [testSession()];
     ui.isMobileViewport = false;
     ui.followLatest = false;
   });
@@ -74,6 +95,39 @@ describe("AppHeader export actions", () => {
     expect(mocks.getMarkdownExportUrl).toHaveBeenCalledWith("sess-123");
     expect(mocks.copyToClipboard).toHaveBeenCalledWith(
       "http://localhost:3000/api/v1/sessions/sess-123/md",
+    );
+  });
+
+  it("copies active session source path from export menu", async () => {
+    sessions.sessions = [
+      testSession({
+        file_path: "/tmp/agentsview/sessions/session-123.jsonl",
+      }),
+    ];
+
+    component = mount(AppHeader, { target: document.body });
+    await tick();
+
+    const exportButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Export session"]',
+    );
+    expect(exportButton).not.toBeNull();
+
+    exportButton!.click();
+    await tick();
+
+    const copyPathButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) =>
+      button.textContent?.includes("Copy source file path"),
+    );
+    expect(copyPathButton).toBeDefined();
+
+    copyPathButton!.click();
+    await tick();
+
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith(
+      "/tmp/agentsview/sessions/session-123.jsonl",
     );
   });
 


### PR DESCRIPTION
Fixes #214.

Adds a source-file-path copy action to the existing session export surfaces when the active session includes an on-disk file path. The action uses the current clipboard helper and is hidden for sessions without a local source path.