### PR TITLE
fix: support Claude companion session layout

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,6 +28,13 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 42: the Claude parser now infers subagent parent
+// relationships from Claude Code companion directories
+// (<session>/subagents/agent-*.jsonl) and resolves externalized
+// tool-results content from <session>/tool-results. Existing Claude
+// rows need re-parsing so companion subagents are linked and
+// persisted tool outputs replace preview placeholders.
+//
 // Bumped to 41: the Cursor parser now stores structured tool-call
 // input JSON for text transcripts and normalizes ApplyPatch calls as
 // edits. Existing Cursor rows need re-parsing so archived ApplyPatch
@@ -43,7 +50,7 @@ import (
 // orphan copy also skips stale Codex rows whose file_path was
 // reparsed under a different session id, so the old parent-ID row
 // does not survive the rebuild when the parent's own file is gone
-// see CopyOrphanedDataFromExcluding.)
+// (see CopyOrphanedDataFromExcluding.)
 //
 // (39: the Antigravity wire-walk hardened its output
 // invariants (issue #648): model-name candidates must be printable,
@@ -188,7 +195,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 41
+const dataVersion = 42
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -588,6 +588,11 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
+func TestCurrentDataVersionClaudeCompanionLayout(t *testing.T) {
+	assert.Equal(t, 42, CurrentDataVersion(),
+		"Claude companion-session parser changes require a data version bump")
+}
+
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "s-events", "proj")

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -19,12 +19,13 @@ import (
 )
 
 var (
-	xmlTaskIDRe   = regexp.MustCompile(`<task-id>([^<]+)</task-id>`)
-	xmlToolUseRe  = regexp.MustCompile(`<tool-use-id>([^<]+)</tool-use-id>`)
-	xmlCmdNameRe  = regexp.MustCompile(`<command-name>([^<]+)</command-name>`)
-	xmlCmdMsgRe   = regexp.MustCompile(`<command-message>([^<]+)</command-message>`)
-	xmlCmdArgsRe  = regexp.MustCompile(`<command-args>([^<]*)</command-args>`)
-	xmlCmdStripRe = regexp.MustCompile(`<command-(?:name|message|args)>[^<]*</command-(?:name|message|args)>`)
+	xmlTaskIDRe               = regexp.MustCompile(`<task-id>([^<]+)</task-id>`)
+	xmlToolUseRe              = regexp.MustCompile(`<tool-use-id>([^<]+)</tool-use-id>`)
+	xmlCmdNameRe              = regexp.MustCompile(`<command-name>([^<]+)</command-name>`)
+	xmlCmdMsgRe               = regexp.MustCompile(`<command-message>([^<]+)</command-message>`)
+	xmlCmdArgsRe              = regexp.MustCompile(`<command-args>([^<]*)</command-args>`)
+	xmlCmdStripRe             = regexp.MustCompile(`<command-(?:name|message|args)>[^<]*</command-(?:name|message|args)>`)
+	persistedToolResultPathRe = regexp.MustCompile(`(?m)Full output saved to:\s*(.+)$`)
 )
 
 const (
@@ -109,6 +110,7 @@ func ParseClaudeSessionWithExclusions(
 		globalEnd       time.Time
 	)
 	allHaveUUID = true
+	parentSessionID = claudeCompanionParentSessionID(path, sessionID)
 
 	lr := newLineReader(f, maxLineSize)
 	lastLineFailed := false
@@ -123,6 +125,7 @@ func ParseClaudeSessionWithExclusions(
 			lastLineFailed = true
 			continue
 		}
+		line = resolveClaudePersistedToolResults(path, line)
 		lastLineFailed = false
 
 		entryType := gjson.Get(line, "type").Str
@@ -403,6 +406,7 @@ func ParseClaudeSessionFrom(
 
 	consumed, err := readJSONLFrom(
 		path, offset, func(line string) {
+			line = resolveClaudePersistedToolResults(path, line)
 			if ts := extractTimestamp(line); !ts.IsZero() {
 				if ts.After(latestTS) {
 					latestTS = ts
@@ -1274,6 +1278,164 @@ func replaceClaudeMessageContent(line string, blocks []gjson.Result) string {
 		return line
 	}
 	return string(encoded)
+}
+
+func claudeCompanionParentSessionID(path, sessionID string) string {
+	if !strings.HasPrefix(sessionID, "agent-") {
+		return ""
+	}
+	parts := splitCleanPath(path)
+	for i, part := range parts {
+		if part != "subagents" || i == 0 {
+			continue
+		}
+		parent := parts[i-1]
+		if parent != "" {
+			return parent
+		}
+	}
+	return ""
+}
+
+func splitCleanPath(path string) []string {
+	clean := filepath.Clean(path)
+	var parts []string
+	for {
+		dir, file := filepath.Split(clean)
+		if file != "" {
+			parts = append(parts, file)
+		}
+		next := filepath.Clean(strings.TrimSuffix(dir, string(filepath.Separator)))
+		if next == clean || next == "." || next == string(filepath.Separator) || next == "" {
+			break
+		}
+		clean = next
+	}
+	slices.Reverse(parts)
+	return parts
+}
+
+func resolveClaudePersistedToolResults(sessionPath, line string) string {
+	if !strings.Contains(line, "persisted-output") &&
+		!strings.Contains(line, "persistedOutputPath") {
+		return line
+	}
+
+	dec := json.NewDecoder(strings.NewReader(line))
+	dec.UseNumber()
+	var top map[string]any
+	if err := dec.Decode(&top); err != nil {
+		return line
+	}
+
+	msg, ok := top["message"].(map[string]any)
+	if !ok {
+		return line
+	}
+	blocks, ok := msg["content"].([]any)
+	if !ok {
+		return line
+	}
+
+	persistedPath := ""
+	if tur, ok := top["toolUseResult"].(map[string]any); ok {
+		if p, ok := tur["persistedOutputPath"].(string); ok {
+			persistedPath = p
+		}
+	}
+
+	changed := false
+	for _, rawBlock := range blocks {
+		block, ok := rawBlock.(map[string]any)
+		if !ok || block["type"] != "tool_result" {
+			continue
+		}
+		content, ok := block["content"].(string)
+		if !ok {
+			continue
+		}
+		path := persistedOutputPathFromContent(content)
+		if path == "" {
+			path = persistedPath
+		}
+		if path == "" {
+			continue
+		}
+		output, ok := readClaudePersistedToolResult(sessionPath, path)
+		if !ok {
+			continue
+		}
+		block["content"] = output
+		changed = true
+	}
+	if !changed {
+		return line
+	}
+
+	encoded, err := json.Marshal(top)
+	if err != nil {
+		return line
+	}
+	return string(encoded)
+}
+
+func persistedOutputPathFromContent(content string) string {
+	match := persistedToolResultPathRe.FindStringSubmatch(content)
+	if len(match) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(match[1])
+}
+
+func readClaudePersistedToolResult(
+	sessionPath, resultPath string,
+) (string, bool) {
+	if resultPath == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(resultPath) {
+		return "", false
+	}
+	cleanResult := filepath.Clean(resultPath)
+	for _, dir := range claudeToolResultDirs(sessionPath) {
+		if !pathWithinDir(cleanResult, dir) {
+			continue
+		}
+		b, err := os.ReadFile(cleanResult)
+		if err != nil {
+			return "", false
+		}
+		return string(b), true
+	}
+	return "", false
+}
+
+func claudeToolResultDirs(sessionPath string) []string {
+	var dirs []string
+	sessionDir := filepath.Join(
+		filepath.Dir(sessionPath),
+		strings.TrimSuffix(filepath.Base(sessionPath), ".jsonl"),
+		"tool-results",
+	)
+	dirs = append(dirs, filepath.Clean(sessionDir))
+
+	clean := filepath.Clean(sessionPath)
+	needle := string(filepath.Separator) + "subagents" + string(filepath.Separator)
+	if idx := strings.Index(clean, needle); idx > 0 {
+		dirs = append(dirs, filepath.Join(clean[:idx], "tool-results"))
+	}
+	return dirs
+}
+
+func pathWithinDir(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
+	if err != nil {
+		return false
+	}
+	return rel != "." &&
+		rel != "" &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator)) &&
+		rel != ".."
 }
 
 // countUserTurns counts all user entries reachable from a

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1343,6 +1343,7 @@ func resolveClaudePersistedToolResults(sessionPath, line string) string {
 			persistedPath = p
 		}
 	}
+	toolResultCount := countClaudeToolResultBlocks(blocks)
 
 	changed := false
 	for _, rawBlock := range blocks {
@@ -1355,7 +1356,8 @@ func resolveClaudePersistedToolResults(sessionPath, line string) string {
 			continue
 		}
 		path := persistedOutputPathFromContent(content)
-		if path == "" {
+		if path == "" && (toolResultCount == 1 ||
+			isPersistedToolResultPlaceholder(content)) {
 			path = persistedPath
 		}
 		if path == "" {
@@ -1377,6 +1379,21 @@ func resolveClaudePersistedToolResults(sessionPath, line string) string {
 		return line
 	}
 	return string(encoded)
+}
+
+func countClaudeToolResultBlocks(blocks []any) int {
+	count := 0
+	for _, rawBlock := range blocks {
+		block, ok := rawBlock.(map[string]any)
+		if ok && block["type"] == "tool_result" {
+			count++
+		}
+	}
+	return count
+}
+
+func isPersistedToolResultPlaceholder(content string) bool {
+	return strings.Contains(content, "<persisted-output>")
 }
 
 func persistedOutputPathFromContent(content string) string {

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -882,6 +882,39 @@ func TestParseClaudeSession_ResolvesPersistedToolResultOutput(
 	assert.Equal(t, fullOutput, DecodeContent(got.ContentRaw))
 }
 
+func TestParseClaudeSession_PersistedToolResultDoesNotOverwriteSiblings(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "project", "parent-session")
+	resultPath := filepath.Join(sessionDir, "tool-results", "b123.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(resultPath), 0o755))
+
+	fullOutput := "full persisted output\n"
+	require.NoError(t, os.WriteFile(resultPath, []byte(fullOutput), 0o644))
+
+	content := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"},"cwd":"/tmp/project"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_big","name":"Bash","input":{"command":"make logs"}},{"type":"tool_use","id":"toolu_small","name":"Read","input":{"file_path":"README.md"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_big","content":"<persisted-output>\nOutput too large. Full output saved to: ` + resultPath + `\n\nPreview (first 2KB):\npreview only\n</persisted-output>","is_error":false},{"type":"tool_result","tool_use_id":"toolu_small","content":"small inline result","is_error":false}]},"toolUseResult":{"persistedOutputPath":"` + resultPath + `","persistedOutputSize":22}}`,
+	}, "\n")
+	sessionPath := filepath.Join(dir, "project", "parent-session.jsonl")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
+
+	results, err := ParseClaudeSession(sessionPath, "project", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Messages, 3)
+	require.Len(t, results[0].Messages[2].ToolResults, 2)
+
+	toolResults := results[0].Messages[2].ToolResults
+	assert.Equal(t, fullOutput, DecodeContent(toolResults[0].ContentRaw))
+	assert.Equal(t, "small inline result", DecodeContent(toolResults[1].ContentRaw))
+	assert.Equal(t, len("small inline result"), toolResults[1].ContentLength)
+}
+
 // Two appended assistant entries with the same message.id form a
 // run that the full parser merges into one message; the incremental
 // path would otherwise produce two separate stored messages, so it

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -850,6 +850,38 @@ func TestParseClaudeSessionFrom_ToolUseResultAgentIDFallsBack(
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
 
+func TestParseClaudeSession_ResolvesPersistedToolResultOutput(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "project", "parent-session")
+	resultPath := filepath.Join(sessionDir, "tool-results", "b123.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(resultPath), 0o755))
+
+	fullOutput := "full output line 1\nfull output line 2\n"
+	require.NoError(t, os.WriteFile(resultPath, []byte(fullOutput), 0o644))
+
+	content := strings.Join([]string{
+		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"},"cwd":"/tmp/project"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make logs"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"<persisted-output>\nOutput too large (32B). Full output saved to: ` + resultPath + `\n\nPreview (first 2KB):\npreview only\n</persisted-output>","is_error":false}]},"toolUseResult":{"persistedOutputPath":"` + resultPath + `","persistedOutputSize":32}}`,
+	}, "\n")
+	sessionPath := filepath.Join(dir, "project", "parent-session.jsonl")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
+
+	results, err := ParseClaudeSession(sessionPath, "project", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Messages, 3)
+	require.Len(t, results[0].Messages[2].ToolResults, 1)
+
+	got := results[0].Messages[2].ToolResults[0]
+	assert.Equal(t, len(fullOutput), got.ContentLength)
+	assert.Equal(t, fullOutput, DecodeContent(got.ContentRaw))
+}
+
 // Two appended assistant entries with the same message.id form a
 // run that the full parser merges into one message; the incremental
 // path would otherwise produce two separate stored messages, so it

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -863,10 +863,16 @@ func TestParseClaudeSession_ResolvesPersistedToolResultOutput(
 	fullOutput := "full output line 1\nfull output line 2\n"
 	require.NoError(t, os.WriteFile(resultPath, []byte(fullOutput), 0o644))
 
+	resultPathJSON := mustJSONString(t, resultPath)
+	persistedContentJSON := mustJSONString(t,
+		"<persisted-output>\n"+
+			"Output too large (32B). Full output saved to: "+resultPath+
+			"\n\nPreview (first 2KB):\npreview only\n</persisted-output>")
+
 	content := strings.Join([]string{
 		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"},"cwd":"/tmp/project"}`,
 		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"make logs"}}]}}`,
-		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"<persisted-output>\nOutput too large (32B). Full output saved to: ` + resultPath + `\n\nPreview (first 2KB):\npreview only\n</persisted-output>","is_error":false}]},"toolUseResult":{"persistedOutputPath":"` + resultPath + `","persistedOutputSize":32}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":` + persistedContentJSON + `,"is_error":false}]},"toolUseResult":{"persistedOutputPath":` + resultPathJSON + `,"persistedOutputSize":32}}`,
 	}, "\n")
 	sessionPath := filepath.Join(dir, "project", "parent-session.jsonl")
 	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
@@ -895,10 +901,16 @@ func TestParseClaudeSession_PersistedToolResultDoesNotOverwriteSiblings(
 	fullOutput := "full persisted output\n"
 	require.NoError(t, os.WriteFile(resultPath, []byte(fullOutput), 0o644))
 
+	resultPathJSON := mustJSONString(t, resultPath)
+	persistedContentJSON := mustJSONString(t,
+		"<persisted-output>\n"+
+			"Output too large. Full output saved to: "+resultPath+
+			"\n\nPreview (first 2KB):\npreview only\n</persisted-output>")
+
 	content := strings.Join([]string{
 		`{"type":"user","timestamp":"2024-01-01T00:00:00Z","uuid":"u1","message":{"content":"run it"},"cwd":"/tmp/project"}`,
 		`{"type":"assistant","timestamp":"2024-01-01T00:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_big","name":"Bash","input":{"command":"make logs"}},{"type":"tool_use","id":"toolu_small","name":"Read","input":{"file_path":"README.md"}}]}}`,
-		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_big","content":"<persisted-output>\nOutput too large. Full output saved to: ` + resultPath + `\n\nPreview (first 2KB):\npreview only\n</persisted-output>","is_error":false},{"type":"tool_result","tool_use_id":"toolu_small","content":"small inline result","is_error":false}]},"toolUseResult":{"persistedOutputPath":"` + resultPath + `","persistedOutputSize":22}}`,
+		`{"type":"user","timestamp":"2024-01-01T00:00:02Z","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_big","content":` + persistedContentJSON + `,"is_error":false},{"type":"tool_result","tool_use_id":"toolu_small","content":"small inline result","is_error":false}]},"toolUseResult":{"persistedOutputPath":` + resultPathJSON + `,"persistedOutputSize":22}}`,
 	}, "\n")
 	sessionPath := filepath.Join(dir, "project", "parent-session.jsonl")
 	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
@@ -913,6 +925,13 @@ func TestParseClaudeSession_PersistedToolResultDoesNotOverwriteSiblings(
 	assert.Equal(t, fullOutput, DecodeContent(toolResults[0].ContentRaw))
 	assert.Equal(t, "small inline result", DecodeContent(toolResults[1].ContentRaw))
 	assert.Equal(t, len("small inline result"), toolResults[1].ContentLength)
+}
+
+func mustJSONString(t *testing.T, value string) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(encoded)
 }
 
 // Two appended assistant entries with the same message.id form a

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2270,6 +2270,49 @@ func TestSyncPathsClaudeSubagent(t *testing.T) {
 	)
 }
 
+func TestSyncPathsClaudeSubagentUsesCompanionDirectoryParent(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	parentContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "Hello").
+		AddClaudeAssistant(tsZeroS5, "Hi!").
+		String()
+
+	env.writeClaudeSession(
+		t, "test-proj", "parent-sess.jsonl", parentContent,
+	)
+
+	subagentContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "Do subtask").
+		AddClaudeAssistant(tsZeroS5, "Done.").
+		String()
+
+	subPath := env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"test-proj", "parent-sess",
+			"subagents", "agent-sub1.jsonl",
+		),
+		subagentContent,
+	)
+
+	env.engine.SyncPaths([]string{subPath})
+
+	assertSessionState(
+		t, env.db, "agent-sub1",
+		func(sess *db.Session) {
+			require.NotNil(t, sess.ParentSessionID,
+				"subagent parent_session_id = %v, want %q", sess.ParentSessionID, "parent-sess")
+			assert.Equal(t, "parent-sess", *sess.ParentSessionID,
+				"subagent parent_session_id = %v, want %q", sess.ParentSessionID, "parent-sess")
+			assert.Equal(t, "subagent", sess.RelationshipType,
+				"relationship_type = %q, want subagent", sess.RelationshipType)
+		},
+	)
+}
+
 func TestSyncPathsClaudeNestedWorkflowSubagent(t *testing.T) {
 	env := setupTestEnv(t)
 


### PR DESCRIPTION
Updates Claude parsing for Claude Code companion session directories by inferring subagent parents from the <session>/subagents path when transcripts do not carry a parent session id. Resolves externalized tool-result content from the session's tool-results companion directory so parsed tool result content and lengths reflect the full saved output while preserving the existing flat transcript path. Adds regression coverage for both behaviors.