### PR TITLE
feat: route CLI read subcommands to the Postgres sync store via --pg / AGENTSVIEW_PG_URL

### DIFF
--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -61,6 +61,13 @@ func resolveService(
 			"loading config: %w", err,
 		)
 	}
+	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	if usePG {
+		return newPGReadService(cfg, pgCfg)
+	}
 	tr, err := detectTransport(cfg.DataDir, cfg.AuthToken, 0)
 	if err != nil {
 		return nil, nil, err
@@ -78,6 +85,11 @@ func resolveWritableService(
 ) (service.SessionService, func(), error) {
 	if remote, _ := cmd.Flags().GetString("server"); remote != "" {
 		return nil, nil, errors.New("--server not yet implemented")
+	}
+	if pgReadRequested(cmd) {
+		return nil, nil, errors.New(
+			"--pg is read-only and cannot be used with write commands",
+		)
 	}
 	cfg, err := config.LoadPFlags(cmd.Flags())
 	if err != nil {
@@ -102,6 +114,34 @@ func resolveWritableService(
 		)
 	}
 	return syncService(cfg, tr)
+}
+
+func resolvePGReadConfig(
+	cmd *cobra.Command, cfg config.Config,
+) (config.PGConfig, bool, error) {
+	requested := pgReadRequested(cmd)
+	if !requested && cfg.PG.URL == "" {
+		return config.PGConfig{}, false, nil
+	}
+	pgCfg, err := cfg.ResolvePG()
+	if err != nil {
+		return config.PGConfig{}, false,
+			fmt.Errorf("resolving pg config: %w", err)
+	}
+	if pgCfg.URL == "" {
+		return config.PGConfig{}, false, errors.New(
+			"pg url not configured; set AGENTSVIEW_PG_URL or [pg].url",
+		)
+	}
+	return pgCfg, true, nil
+}
+
+func pgReadRequested(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	v, err := cmd.Flags().GetBool("pg")
+	return err == nil && v
 }
 
 // outputFormat returns the requested --format flag value

--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -30,6 +30,10 @@ func newSessionCommand() *cobra.Command {
 		"server", "",
 		"Remote daemon URL (not yet implemented)",
 	)
+	cmd.PersistentFlags().Bool(
+		"pg", false,
+		"Read session data from configured PostgreSQL",
+	)
 
 	cmd.AddCommand(newSessionGetCommand())
 	cmd.AddCommand(newSessionUsageCommand())

--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -30,6 +30,11 @@ func newSessionExportCommand() *cobra.Command {
 					"session export: streams raw bytes; --format not supported",
 				)
 			}
+			if pgReadRequested(cmd) {
+				return fmt.Errorf(
+					"session export: local-only command; --pg not supported",
+				)
+			}
 			cfg, err := config.LoadPFlags(cmd.Flags())
 			if err != nil {
 				return fmt.Errorf("loading config: %w", err)

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -38,6 +38,8 @@ func TestSessionHelp_ShowsSubcommands(t *testing.T) {
 	}
 	assert.Contains(t, help, "--format",
 		"expected --format persistent flag in help")
+	assert.Contains(t, help, "--pg",
+		"expected --pg persistent flag in help")
 }
 
 // seedSession opens the SQLite DB at dataDir/sessions.db, inserts
@@ -198,7 +200,7 @@ func TestSessionList_PGFlagUsesPGReadStore(t *testing.T) {
 	cleanupCalled := false
 	orig := openPGReadStore
 	openPGReadStore = func(
-		pgCfg config.PGConfig,
+		_ config.Config, pgCfg config.PGConfig,
 	) (db.Store, func(), error) {
 		gotPG = pgCfg
 		return remoteDB, func() {
@@ -242,7 +244,7 @@ func TestSessionList_PGEnvUsesPGReadStore(t *testing.T) {
 	var gotPG config.PGConfig
 	orig := openPGReadStore
 	openPGReadStore = func(
-		pgCfg config.PGConfig,
+		_ config.Config, pgCfg config.PGConfig,
 	) (db.Store, func(), error) {
 		gotPG = pgCfg
 		return remoteDB, func() { require.NoError(t, remoteDB.Close()) }, nil
@@ -288,7 +290,7 @@ func TestSessionList_DefaultDoesNotOpenPGStore(t *testing.T) {
 
 	orig := openPGReadStore
 	openPGReadStore = func(
-		config.PGConfig,
+		config.Config, config.PGConfig,
 	) (db.Store, func(), error) {
 		t.Fatal("openPGReadStore should not be called without --pg or PG URL")
 		return nil, nil, nil
@@ -316,7 +318,7 @@ func TestPGReadServiceClosesStoreWhenOpenFailsAfterCleanupProvided(t *testing.T)
 	closed := false
 	orig := openPGReadStore
 	openPGReadStore = func(
-		config.PGConfig,
+		config.Config, config.PGConfig,
 	) (db.Store, func(), error) {
 		return nil, func() { closed = true },
 			errors.New("schema check failed")
@@ -590,6 +592,18 @@ func TestSessionExport_RejectsFormatFlag(t *testing.T) {
 	assert.Contains(t, err.Error(), "--format not supported")
 }
 
+func TestSessionExport_RejectsPGFlag(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+
+	_, err := executeCommand(newRootCommand(),
+		"session", "export", "some-id", "--pg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local-only command")
+	assert.Contains(t, err.Error(), "--pg not supported")
+}
+
 // TestSessionUsage_RejectsServerFlag verifies that `session usage`
 // rejects the inherited --server flag instead of silently querying
 // the local SQLite archive. usage uses the direct token-use path
@@ -605,6 +619,53 @@ func TestSessionUsage_RejectsServerFlag(t *testing.T) {
 		"--server", "http://localhost:9999")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--server not yet implemented")
+}
+
+func TestSessionUsage_PGEnvUsesPGStore(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+
+	pgDB, err := db.Open(filepath.Join(dataDir, "pg.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { pgDB.Close() })
+	require.NoError(t, pgDB.UpsertSession(db.Session{
+		ID:                   "pg-session",
+		Project:              "pg-project",
+		Machine:              "pg-host",
+		Agent:                "codex",
+		MessageCount:         2,
+		UserMessageCount:     2,
+		TotalOutputTokens:    42,
+		HasTotalOutputTokens: true,
+	}))
+
+	opened := false
+	orig := openPGReadStore
+	openPGReadStore = func(
+		_ config.Config, pgCfg config.PGConfig,
+	) (db.Store, func(), error) {
+		opened = true
+		assert.Equal(t, "postgres://example.test/agentsview", pgCfg.URL)
+		return pgDB, func() {}, nil
+	}
+	t.Cleanup(func() { openPGReadStore = orig })
+
+	root := newRootCommand()
+	args := []string{"session", "usage", "pg-session"}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(nil))
+
+	out, code, err := sessionUsageDataForCommand(cmd, "pg-session")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.True(t, opened, "expected session usage to open PG store")
+	assert.Equal(t, tokenUseExitOK, code)
+	assert.Equal(t, "pg-session", out.SessionID)
+	assert.Equal(t, "pg-project", out.Project)
+	assert.Equal(t, 42, out.TotalOutputTokens)
+	assert.False(t, out.ServerRunning)
 }
 
 // TestSessionSync_UnknownID_ReportsNoFilePath verifies that the

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -712,6 +712,50 @@ func TestSessionUsage_PGEnvResolvesBareSessionID(t *testing.T) {
 	assert.Equal(t, 42, out.TotalOutputTokens)
 }
 
+func TestSessionUsage_PGEnvResolvesColonBearingRawSessionID(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+
+	rawID := "project-hash:session-uuid"
+	storedID := "kimi:" + rawID
+	pgDB, err := db.Open(filepath.Join(dataDir, "pg.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { pgDB.Close() })
+	require.NoError(t, pgDB.UpsertSession(db.Session{
+		ID:                   storedID,
+		Project:              "pg-project",
+		Machine:              "pg-host",
+		Agent:                "kimi",
+		MessageCount:         2,
+		UserMessageCount:     2,
+		TotalOutputTokens:    84,
+		HasTotalOutputTokens: true,
+	}))
+
+	orig := openPGReadStore
+	openPGReadStore = func(
+		_ config.Config, _ config.PGConfig,
+	) (db.Store, func(), error) {
+		return pgDB, func() {}, nil
+	}
+	t.Cleanup(func() { openPGReadStore = orig })
+
+	root := newRootCommand()
+	args := []string{"session", "usage", rawID}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(nil))
+
+	out, code, err := sessionUsageDataForCommand(cmd, rawID)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, tokenUseExitOK, code)
+	assert.Equal(t, storedID, out.SessionID)
+	assert.Equal(t, "pg-project", out.Project)
+	assert.Equal(t, 84, out.TotalOutputTokens)
+}
+
 // TestSessionSync_UnknownID_ReportsNoFilePath verifies that the
 // sync engine is plumbed in direct mode. No daemon running, no
 // sessions in DB — Execute returns an error whose message contains

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 )
 
@@ -179,6 +180,158 @@ func TestSessionList_FilterByProject(t *testing.T) {
 		"stdout should be valid JSON: %q", out)
 	require.Len(t, got.Sessions, 1)
 	assert.Equal(t, "s-a", got.Sessions[0]["id"])
+}
+
+func TestSessionList_PGFlagUsesPGReadStore(t *testing.T) {
+	localDir := t.TempDir()
+	remoteDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", localDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+	t.Setenv("AGENTSVIEW_PG_SCHEMA", "custom_schema")
+
+	seedSession(t, localDir, "local-session", "local")
+	seedSession(t, remoteDir, "pg-session", "remote")
+
+	remoteDB, err := db.Open(filepath.Join(remoteDir, "sessions.db"))
+	require.NoError(t, err)
+	var gotPG config.PGConfig
+	cleanupCalled := false
+	orig := openPGReadStore
+	openPGReadStore = func(
+		pgCfg config.PGConfig,
+	) (db.Store, func(), error) {
+		gotPG = pgCfg
+		return remoteDB, func() {
+			cleanupCalled = true
+			require.NoError(t, remoteDB.Close())
+		}, nil
+	}
+	t.Cleanup(func() {
+		openPGReadStore = orig
+	})
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--pg", "--format", "json")
+	require.NoError(t, err)
+
+	var got struct {
+		Sessions []map[string]any `json:"sessions"`
+		Total    int              `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"stdout should be valid JSON: %q", out)
+	assert.Equal(t, 1, got.Total)
+	require.Len(t, got.Sessions, 1)
+	assert.Equal(t, "pg-session", got.Sessions[0]["id"])
+	assert.Equal(t, "postgres://example.test/agentsview", gotPG.URL)
+	assert.Equal(t, "custom_schema", gotPG.Schema)
+	assert.True(t, cleanupCalled, "expected PG store cleanup")
+}
+
+func TestSessionList_PGEnvUsesPGReadStore(t *testing.T) {
+	localDir := t.TempDir()
+	remoteDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", localDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/from-env")
+
+	seedSession(t, localDir, "local-session", "local")
+	seedSession(t, remoteDir, "pg-session", "remote")
+
+	remoteDB, err := db.Open(filepath.Join(remoteDir, "sessions.db"))
+	require.NoError(t, err)
+	var gotPG config.PGConfig
+	orig := openPGReadStore
+	openPGReadStore = func(
+		pgCfg config.PGConfig,
+	) (db.Store, func(), error) {
+		gotPG = pgCfg
+		return remoteDB, func() { require.NoError(t, remoteDB.Close()) }, nil
+	}
+	t.Cleanup(func() {
+		openPGReadStore = orig
+	})
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--format", "json")
+	require.NoError(t, err)
+
+	var got struct {
+		Sessions []map[string]any `json:"sessions"`
+		Total    int              `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"stdout should be valid JSON: %q", out)
+	assert.Equal(t, 1, got.Total)
+	require.Len(t, got.Sessions, 1)
+	assert.Equal(t, "pg-session", got.Sessions[0]["id"])
+	assert.Equal(t, "postgres://example.test/from-env", gotPG.URL)
+	assert.Equal(t, "agentsview", gotPG.Schema)
+}
+
+func TestSessionList_PGFlagRequiresURL(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "")
+
+	_, err := executeCommand(newRootCommand(),
+		"session", "list", "--pg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pg url not configured")
+	assert.Contains(t, err.Error(), "AGENTSVIEW_PG_URL")
+}
+
+func TestSessionList_DefaultDoesNotOpenPGStore(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "")
+	seedSession(t, dataDir, "local-session", "local")
+
+	orig := openPGReadStore
+	openPGReadStore = func(
+		config.PGConfig,
+	) (db.Store, func(), error) {
+		t.Fatal("openPGReadStore should not be called without --pg or PG URL")
+		return nil, nil, nil
+	}
+	t.Cleanup(func() {
+		openPGReadStore = orig
+	})
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--format", "json")
+	require.NoError(t, err)
+
+	var got struct {
+		Sessions []map[string]any `json:"sessions"`
+		Total    int              `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"stdout should be valid JSON: %q", out)
+	assert.Equal(t, 1, got.Total)
+	require.Len(t, got.Sessions, 1)
+	assert.Equal(t, "local-session", got.Sessions[0]["id"])
+}
+
+func TestPGReadServiceClosesStoreWhenOpenFailsAfterCleanupProvided(t *testing.T) {
+	closed := false
+	orig := openPGReadStore
+	openPGReadStore = func(
+		config.PGConfig,
+	) (db.Store, func(), error) {
+		return nil, func() { closed = true },
+			errors.New("schema check failed")
+	}
+	t.Cleanup(func() {
+		openPGReadStore = orig
+	})
+
+	_, _, err := newPGReadService(config.Config{}, config.PGConfig{
+		URL:    "postgres://example.test/agentsview",
+		Schema: "agentsview",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opening pg store")
+	assert.True(t, closed, "expected cleanup on error-after-open path")
 }
 
 // TestSessionList_MinToolFailuresZero verifies that passing
@@ -473,6 +626,18 @@ func TestSessionSync_UnknownID_ReportsNoFilePath(t *testing.T) {
 		"error should come from directBackend.Sync validation, not ErrReadOnly")
 	assert.NotContains(t, err.Error(), "read-only",
 		"engine must be plumbed; got ErrReadOnly-style message: %v", err)
+}
+
+func TestSessionSync_PGFlagRefusesWrite(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+
+	_, err := executeCommand(newRootCommand(),
+		"session", "sync", "--pg", "some-id")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--pg is read-only")
+	assert.Contains(t, err.Error(), "write commands")
 }
 
 // TestSessionSync_AgainstReadOnlyDaemon_Refuses verifies the CLI

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -668,6 +668,50 @@ func TestSessionUsage_PGEnvUsesPGStore(t *testing.T) {
 	assert.False(t, out.ServerRunning)
 }
 
+func TestSessionUsage_PGEnvResolvesBareSessionID(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+
+	bareID := "019da6a6-8c67-7c23-b102-ef48502852d0"
+	storedID := "codex:" + bareID
+	pgDB, err := db.Open(filepath.Join(dataDir, "pg.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { pgDB.Close() })
+	require.NoError(t, pgDB.UpsertSession(db.Session{
+		ID:                   storedID,
+		Project:              "pg-project",
+		Machine:              "pg-host",
+		Agent:                "codex",
+		MessageCount:         2,
+		UserMessageCount:     2,
+		TotalOutputTokens:    42,
+		HasTotalOutputTokens: true,
+	}))
+
+	orig := openPGReadStore
+	openPGReadStore = func(
+		_ config.Config, _ config.PGConfig,
+	) (db.Store, func(), error) {
+		return pgDB, func() {}, nil
+	}
+	t.Cleanup(func() { openPGReadStore = orig })
+
+	root := newRootCommand()
+	args := []string{"session", "usage", bareID}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(nil))
+
+	out, code, err := sessionUsageDataForCommand(cmd, bareID)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, tokenUseExitOK, code)
+	assert.Equal(t, storedID, out.SessionID)
+	assert.Equal(t, "pg-project", out.Project)
+	assert.Equal(t, 42, out.TotalOutputTokens)
+}
+
 // TestSessionSync_UnknownID_ReportsNoFilePath verifies that the
 // sync engine is plumbed in direct mode. No daemon running, no
 // sessions in DB — Execute returns an error whose message contains

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func newSessionUsageCommand() *cobra.Command {
@@ -107,7 +108,20 @@ func pgSessionUsageData(
 		}
 	}
 
-	u, err := store.GetSessionUsage(context.Background(), sessionID)
+	ctx := context.Background()
+	resolvedID, err := resolveServiceSessionID(
+		ctx, service.NewReadOnlyBackend(store), sessionID,
+	)
+	if err != nil {
+		if !strings.HasPrefix(err.Error(), "session not found:") {
+			return nil, tokenUseExitErr,
+				fmt.Errorf("resolving pg session id: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "session not found: %s\n", sessionID)
+		return nil, tokenUseExitNotFound, nil
+	}
+
+	u, err := store.GetSessionUsage(ctx, resolvedID)
 	if err != nil {
 		return nil, tokenUseExitErr,
 			fmt.Errorf("querying pg session usage: %w", err)

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -13,9 +13,16 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/service"
 )
+
+type rawSessionIDResolver interface {
+	FindSessionIDsByRawSuffix(
+		ctx context.Context, raw string, limit int,
+	) ([]string, error)
+}
 
 func newSessionUsageCommand() *cobra.Command {
 	return &cobra.Command{
@@ -109,9 +116,7 @@ func pgSessionUsageData(
 	}
 
 	ctx := context.Background()
-	resolvedID, err := resolveServiceSessionID(
-		ctx, service.NewReadOnlyBackend(store), sessionID,
-	)
+	resolvedID, err := resolveStoreSessionID(ctx, store, sessionID)
 	if err != nil {
 		if !strings.HasPrefix(err.Error(), "session not found:") {
 			return nil, tokenUseExitErr,
@@ -139,6 +144,35 @@ func pgSessionUsageData(
 		SessionUsage:  *u,
 		ServerRunning: false,
 	}, usageExitCode(u), nil
+}
+
+func resolveStoreSessionID(
+	ctx context.Context, store db.Store, sessionID string,
+) (string, error) {
+	if resolver, ok := store.(rawSessionIDResolver); ok {
+		matches, err := resolver.FindSessionIDsByRawSuffix(
+			ctx, sessionID, tokenUseResolveMatchLimit,
+		)
+		if err != nil {
+			return "", err
+		}
+		if len(matches) > 0 {
+			if matches[0] == sessionID {
+				return sessionID, nil
+			}
+			if len(matches) > 1 {
+				fmt.Fprintf(os.Stderr,
+					"warning: ambiguous session id %q matches "+
+						"multiple sessions, using most recent (%s)\n",
+					sessionID, matches[0],
+				)
+			}
+			return matches[0], nil
+		}
+	}
+	return resolveServiceSessionID(
+		ctx, service.NewReadOnlyBackend(store), sessionID,
+	)
 }
 
 // renderSessionUsageHuman writes a compact key/value summary. The

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func newSessionUsageCommand() *cobra.Command {
@@ -34,7 +37,7 @@ func newSessionUsageCommand() *cobra.Command {
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			runSessionUsage(args[0], outputFormat(cmd))
+			runSessionUsage(cmd, args[0], outputFormat(cmd))
 		},
 	}
 }
@@ -43,8 +46,8 @@ func newSessionUsageCommand() *cobra.Command {
 // exiting with the shared usage exit code (0 = token data or cost,
 // 2 = not found, 3 = neither). Uses Run + os.Exit (not RunE) so the
 // 2/3 codes survive — cobra RunE errors collapse to exit 1.
-func runSessionUsage(sessionID, format string) {
-	out, code, err := sessionUsageData(sessionID)
+func runSessionUsage(cmd *cobra.Command, sessionID, format string) {
+	out, code, err := sessionUsageDataForCommand(cmd, sessionID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(tokenUseExitErr)
@@ -65,6 +68,63 @@ func runSessionUsage(sessionID, format string) {
 		}
 	}
 	os.Exit(code)
+}
+
+func sessionUsageDataForCommand(
+	cmd *cobra.Command, sessionID string,
+) (*sessionUsageOutput, int, error) {
+	cfg, err := config.LoadPFlags(cmd.Flags())
+	if err != nil {
+		return nil, tokenUseExitErr, fmt.Errorf("loading config: %w", err)
+	}
+	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
+	if err != nil {
+		return nil, tokenUseExitErr, err
+	}
+	if !usePG {
+		return sessionUsageData(sessionID)
+	}
+	return pgSessionUsageData(cfg, pgCfg, sessionID)
+}
+
+func pgSessionUsageData(
+	cfg config.Config, pgCfg config.PGConfig, sessionID string,
+) (*sessionUsageOutput, int, error) {
+	store, cleanup, err := openPGReadStore(cfg, pgCfg)
+	if err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return nil, tokenUseExitErr, fmt.Errorf("opening pg store: %w", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	if len(cfg.CustomModelPricing) > 0 {
+		if priced, ok := store.(customPricingStore); ok {
+			priced.SetCustomPricing(cfg.CustomModelPricing)
+		}
+	}
+
+	u, err := store.GetSessionUsage(context.Background(), sessionID)
+	if err != nil {
+		return nil, tokenUseExitErr,
+			fmt.Errorf("querying pg session usage: %w", err)
+	}
+	if u == nil {
+		fmt.Fprintf(os.Stderr, "session not found: %s\n", sessionID)
+		return nil, tokenUseExitNotFound, nil
+	}
+	if u.Agent == "" {
+		if def, ok := parser.AgentByPrefix(u.SessionID); ok {
+			u.Agent = string(def.Type)
+		}
+	}
+	return &sessionUsageOutput{
+		SessionUsage:  *u,
+		ServerRunning: false,
+	}, usageExitCode(u), nil
 }
 
 // renderSessionUsageHuman writes a compact key/value summary. The

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -37,8 +37,10 @@ type customPricingStore interface {
 }
 
 var openPGReadStore = func(
+	cfg config.Config,
 	pgCfg config.PGConfig,
 ) (db.Store, func(), error) {
+	applyClassifierConfig(cfg)
 	store, err := postgres.NewStore(
 		pgCfg.URL, pgCfg.Schema, pgCfg.AllowInsecure,
 	)
@@ -139,8 +141,7 @@ func newService(
 func newPGReadService(
 	cfg config.Config, pgCfg config.PGConfig,
 ) (service.SessionService, func(), error) {
-	applyClassifierConfig(cfg)
-	store, cleanup, err := openPGReadStore(pgCfg)
+	store, cleanup, err := openPGReadStore(cfg, pgCfg)
 	if err != nil {
 		if cleanup != nil {
 			cleanup()

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -12,6 +12,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/postgres"
 	"go.kenn.io/agentsview/internal/service"
 )
 
@@ -29,6 +30,22 @@ type transport struct {
 	URL            string
 	ReadOnly       bool // daemon runtime ReadOnly flag (true for pg serve)
 	DirectReadOnly bool // writable daemon owns DB but is not reachable
+}
+
+type customPricingStore interface {
+	SetCustomPricing(map[string]config.CustomModelRate)
+}
+
+var openPGReadStore = func(
+	pgCfg config.PGConfig,
+) (db.Store, func(), error) {
+	store, err := postgres.NewStore(
+		pgCfg.URL, pgCfg.Schema, pgCfg.AllowInsecure,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return store, func() { _ = store.Close() }, nil
 }
 
 // detectTransport picks the transport mode:
@@ -113,4 +130,27 @@ func newService(
 		// is handled via the HTTP daemon when one is running.
 		return service.NewDirectBackend(d, nil), cleanup, nil
 	}
+}
+
+// newPGReadService builds a read-only SessionService over the
+// configured PostgreSQL sync store. It shares the same store
+// construction path as pg serve, but leaves schema repair/migration
+// to pg push/serve because CLI read commands never mutate PG.
+func newPGReadService(
+	cfg config.Config, pgCfg config.PGConfig,
+) (service.SessionService, func(), error) {
+	applyClassifierConfig(cfg)
+	store, cleanup, err := openPGReadStore(pgCfg)
+	if err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return nil, nil, fmt.Errorf("opening pg store: %w", err)
+	}
+	if len(cfg.CustomModelPricing) > 0 {
+		if priced, ok := store.(customPricingStore); ok {
+			priced.SetCustomPricing(cfg.CustomModelPricing)
+		}
+	}
+	return service.NewReadOnlyBackend(store), cleanup, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -928,6 +928,10 @@ func applyFlagValue(cfg *Config, name, value string) {
 		if d, err := time.ParseDuration(value); err == nil {
 			cfg.EventsCoalesceInterval = d
 		}
+	case "pg":
+		// Read-routing only. The CLI resolver combines this flag
+		// with cfg.PG from env/config and does not persist a new
+		// config field for it.
 	}
 }
 

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -506,6 +506,54 @@ func (s *Store) GetSession(
 	return &sess, nil
 }
 
+// FindSessionIDsByRawSuffix returns up to limit session IDs whose
+// stored id is either the exact raw input or the raw input preceded
+// by an agent prefix. The suffix comparison is literal and results
+// match SQLite ordering: exact match first, then most recent session.
+func (s *Store) FindSessionIDsByRawSuffix(
+	ctx context.Context, raw string, limit int,
+) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	rows, err := s.pg.QueryContext(ctx,
+		`SELECT id FROM sessions
+		 WHERE (id = $1
+		        OR RIGHT(id, LENGTH($1) + 1) = ':' || $1)
+		   AND deleted_at IS NULL
+		 ORDER BY (id = $1) DESC,
+		          COALESCE(ended_at, started_at, created_at) DESC
+		 LIMIT $2`,
+		raw, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"finding pg sessions by raw suffix %q: %w",
+			raw, err,
+		)
+	}
+	defer rows.Close()
+	ids := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf(
+				"scanning pg session id: %w", err,
+			)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating pg raw suffix session ids: %w", err,
+		)
+	}
+	return ids, nil
+}
+
 // GetSessionFull returns a single session by ID including
 // soft-deleted sessions.
 func (s *Store) GetSessionFull(

--- a/internal/postgres/sessions_unit_test.go
+++ b/internal/postgres/sessions_unit_test.go
@@ -1,0 +1,34 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPGFindSessionIDsByRawSuffixUsesExactFirstSuffixQuery(t *testing.T) {
+	state := &usageProbeState{}
+	store := &Store{pg: newUsageProbeDB(t, state)}
+
+	ids, err := store.FindSessionIDsByRawSuffix(
+		context.Background(), "project-hash:session-uuid", 2,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"kimi:project-hash:session-uuid",
+		"openclaw:project-hash:session-uuid",
+	}, ids)
+
+	state.mu.Lock()
+	require.NotEmpty(t, state.queries)
+	query := strings.ToLower(state.queries[len(state.queries)-1])
+	state.mu.Unlock()
+
+	assert.Contains(t, query, "right(id, length($1) + 1) = ':' || $1")
+	assert.Contains(t, query, "deleted_at is null")
+	assert.Contains(t, query, "order by (id = $1) desc")
+	assert.Contains(t, query, "coalesce(ended_at, started_at, created_at) desc")
+}

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -103,6 +103,15 @@ func (c *usageProbeConn) QueryContext(
 			}},
 		}, nil
 	}
+	if strings.Contains(normalized, "select id from sessions") {
+		return &usageProbeRows{
+			columns: []string{"id"},
+			values: [][]driver.Value{
+				{"kimi:project-hash:session-uuid"},
+				{"openclaw:project-hash:session-uuid"},
+			},
+		}, nil
+	}
 	if strings.Contains(normalized, "from (") &&
 		strings.Contains(normalized, "from messages") {
 		ts := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

Route CLI read subcommands to the Postgres sync store via --pg / AGENTSVIEW_PG_URL

## Why this matters

A user runs a central Postgres instance that multiple machines `agentsview pg push` to. `agentsview serve` already exposes the aggregated PG data over the web UI (read-only PG serve shipped in #326), but the read-only CLI subcommands (`session list`, `usage daily`, `stats`, `session messages`, etc.) only query the local machine's SQLite, so a multi-machine user can only CLI-query whatever the current machine generated, not the union across all machines. The ask is a `--pg` flag (or `AGENTSVIEW_PG_URL` env var) that routes read queries to the configured Postgres store instead of local SQLite. Read-only coverage is sufficient; no CLI writes against central PG are needed. Maintainer wesm (MEMBER) responded "makes sense to me" with no competing PR cross-referenced.

## Changes

All read CLI subcommands obtain their data store through `resolveService(cmd)` in `cmd/agentsview/session.go`, which today calls `detectTransport` then `newService(cfg, tr)` (in `transport.go`) to pick HTTP-daemon vs direct-SQLite. Add a `--pg` opt-in: when `--pg` is set (or `cfg.PG.URL` is populated from `AGENTSVIEW_PG_URL`/config), bypass transport detection and build a Postgres-backed read service the same way `pg serve` does in `cmd/agentsview/pg.go` -- `postgres.NewStore(pgCfg.URL, pgCfg.Schema, pgCfg.AllowInsecure)` wrapped in `service.NewReadOnlyBackend(store)` (the PG `*Store` already implements the `db.Store` read interface and reports `ReadOnly() bool == true`, which is exactly what `server.New(appCfg, store, ...)` relies on in the pg-serve path). Register `--pg` as a boolean persistent flag where the global flags are wired (`main.go`) so it is available to every read subcommand, resolve `pgCfg` via the existing `config.ResolvePG()`, and return a cleanup that closes the store. Keep write subcommands (those using `resolveWritableService`) unaffected -- they should error clearly if `--pg` is combined with a write op rather than silently writing to SQLite.

## Testing

- Happy path: `--pg` set with a reachable PG URL routes `session list` / `usage` / `stats` reads through `service.NewReadOnlyBackend(postgres.NewStore(...))` and returns the aggregated rows (assert backend selection given a fake/PGConfig, since live PG is gated behind pgtest tags).
- Env equivalence: `AGENTSVIEW_PG_URL` set with no `--pg` flag resolves the same PG route via `config.ResolvePG()`; flag and env produce identical store selection.
- Default unchanged: with neither `--pg` nor any PG config, `resolveService` falls back to the existing transport-detection path (HTTP daemon when discoverable, else direct SQLite) -- existing transport tests still pass.
- Error path: `--pg` requested but `pgCfg.URL` is empty returns a clear "pg url not configured" error instead of silently falling back to SQLite.
- Write guard: combining `--pg` with a write-capable subcommand (resolveWritableService path) returns an explicit read-only refusal rather than writing to local SQLite.
- Cleanup: the returned cleanup closes the PG store (no leaked connection) on both success and error-after-open paths.

Fixes #392

AI was used for assistance.
