### PR TITLE
feat(cowork): index Claude Desktop cowork (local agent mode) sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ agentsview auto-discovers sessions from all of these:
 | Antigravity        | `~/.gemini/antigravity/`                               |
 | Antigravity CLI    | `~/.gemini/antigravity-cli/` (see note below)          |
 | Claude Code        | `~/.claude/projects/`                                  |
+| Claude Cowork      | `~/Library/Application Support/Claude/local-agent-mode-sessions/` (macOS) |
 | Codex              | `~/.codex/sessions/`                                   |
 | Copilot CLI        | `~/.copilot/`                                          |
 | Cortex Code        | `~/.snowflake/cortex/conversations/`                   |

--- a/frontend/src/lib/components/settings/AgentDirSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentDirSettings.svelte
@@ -4,6 +4,7 @@
 
   const AGENT_LABELS: Record<string, string> = {
     claude: "Claude Code",
+    cowork: "Claude Cowork",
     codex: "Codex",
     copilot: "Copilot",
     gemini: "Gemini",

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -10,6 +10,7 @@ describe("KNOWN_AGENTS", () => {
     const names = KNOWN_AGENTS.map((a) => a.name);
     expect(names).toEqual([
       "claude",
+      "cowork",
       "codex",
       "copilot",
       "gemini",

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -6,6 +6,7 @@ export interface AgentMeta {
 
 export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "claude", color: "var(--accent-blue)" },
+  { name: "cowork", color: "var(--accent-sky)", label: "Claude Cowork" },
   { name: "codex", color: "var(--accent-green)" },
   { name: "copilot", color: "var(--accent-amber)" },
   { name: "gemini", color: "var(--accent-rose)" },

--- a/internal/parser/cowork.go
+++ b/internal/parser/cowork.go
@@ -1,0 +1,470 @@
+// ABOUTME: Parses Claude Desktop "cowork" (local agent mode) sessions.
+// ABOUTME: Reuses the Claude Code JSONL parser on the nested transcript and
+// enriches it with cowork session metadata (title, project, timestamps).
+package parser
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+// coworkIDPrefix is prepended to every cowork session ID so cowork
+// conversations never collide with regular Claude Code sessions, which
+// share the same on-disk transcript format.
+const coworkIDPrefix = "cowork:"
+
+// Cowork on-disk layout (Claude Desktop local agent mode):
+//
+//	<root>/<orgId>/<workspaceId>/local_<uuid>.json          session metadata
+//	<root>/<orgId>/<workspaceId>/local_<uuid>/.claude/projects/<enc>/<cliSessionId>.jsonl
+//	<root>/<orgId>/<workspaceId>/local_<uuid>/.claude/projects/<enc>/<cliSessionId>/subagents/**/agent-<id>.jsonl
+//
+// The metadata file (local_<uuid>.json) carries the human-facing title,
+// model, and the cliSessionId that names the transcript. The transcript
+// itself is a standard Claude Code JSONL file (same uuid/parentUuid DAG,
+// message.usage token accounting, and event types), so the Claude parser
+// handles it directly. The encoded project directory name varies between
+// versions (".../-...-outputs" for host-loop sessions, "/sessions/<name>"
+// for VM sessions), so the transcript is located by scanning the projects
+// directory for "<cliSessionId>.jsonl" rather than reconstructing the name.
+// Subagent transcripts live alongside it under subagents/, mirroring
+// regular Claude Code, and are ingested the same way.
+
+// coworkMeta holds the fields of a local_<uuid>.json metadata file that
+// enrich the parsed session.
+type coworkMeta struct {
+	SessionID           string   `json:"sessionId"`
+	CliSessionID        string   `json:"cliSessionId"`
+	Title               string   `json:"title"`
+	UserSelectedFolders []string `json:"userSelectedFolders"`
+	CreatedAt           int64    `json:"createdAt"`      // epoch milliseconds
+	LastActivityAt      int64    `json:"lastActivityAt"` // epoch milliseconds
+}
+
+// readCoworkMeta reads a local_<uuid>.json metadata file. Missing or
+// malformed files yield a zero-value meta so the transcript can still be
+// parsed on its own.
+func readCoworkMeta(path string) coworkMeta {
+	var meta coworkMeta
+	if path == "" {
+		return meta
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return meta
+	}
+	_ = json.Unmarshal(data, &meta)
+	return meta
+}
+
+// coworkProjectName derives a project grouping for a cowork session.
+// Cowork conversations are not tied to a code repository, so they group
+// under "cowork" unless the user explicitly attached local folders.
+func coworkProjectName(meta coworkMeta) string {
+	for _, folder := range meta.UserSelectedFolders {
+		if p := ExtractProjectFromCwd(folder); p != "" {
+			return p
+		}
+	}
+	return "cowork"
+}
+
+// isCoworkMetaFileName reports whether name is a cowork session metadata
+// file (local_<uuid>.json), distinguishing it from sibling cache files
+// such as cowork-clientdata-cache.json or cowork_settings.json.
+func isCoworkMetaFileName(name string) bool {
+	if !strings.HasPrefix(name, "local_") ||
+		!strings.HasSuffix(name, ".json") {
+		return false
+	}
+	return IsValidSessionID(strings.TrimSuffix(name, ".json"))
+}
+
+// resolveCoworkSession locates the Claude Code transcript for a cowork
+// session given its working directory (the local_<uuid> dir) and the
+// cliSessionId. It returns the transcript path and the encoded project
+// directory that contains it (used to locate subagent transcripts), or
+// ("", "") when no transcript exists yet. A symlinked project directory
+// is followed only when its target stays inside the session directory,
+// mirroring the containment guard used by Cursor discovery.
+func resolveCoworkSession(sessionDir, cliSessionID string) (string, string) {
+	if sessionDir == "" || !IsValidSessionID(cliSessionID) {
+		return "", ""
+	}
+	projectsDir := filepath.Join(sessionDir, ".claude", "projects")
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return "", ""
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(sessionDir)
+	if err != nil {
+		return "", ""
+	}
+	target := cliSessionID + ".jsonl"
+	for _, entry := range entries {
+		if !isDirOrSymlink(entry, projectsDir) {
+			continue
+		}
+		encDir := filepath.Join(projectsDir, entry.Name())
+		candidate := filepath.Join(encDir, target)
+		if !IsRegularFile(candidate) {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil || !isContainedIn(resolved, resolvedRoot) {
+			continue
+		}
+		return candidate, encDir
+	}
+	return "", ""
+}
+
+// coworkSubagentTranscripts returns the subagent transcript files
+// (agent-*.jsonl) for a cowork session, found under
+// <encDir>/<cliSessionId>/subagents/**, mirroring regular Claude Code.
+func coworkSubagentTranscripts(encDir, cliSessionID string) []string {
+	if encDir == "" {
+		return nil
+	}
+	subagentsDir := filepath.Join(encDir, cliSessionID, "subagents")
+	var out []string
+	_ = filepath.WalkDir(
+		subagentsDir,
+		func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			name := d.Name()
+			if !strings.HasPrefix(name, "agent-") ||
+				!strings.HasSuffix(name, ".jsonl") {
+				return nil
+			}
+			if !IsRegularFile(path) {
+				return nil
+			}
+			out = append(out, path)
+			return nil
+		},
+	)
+	sort.Strings(out)
+	return out
+}
+
+// coworkMetaPathForTranscript derives the local_<uuid>.json metadata path
+// from a transcript path. The transcript lives under
+// <sessionDir>/.claude/projects/..., and the metadata file is the sibling
+// <sessionDir>.json. Returns "" when the path is not a cowork transcript.
+func coworkMetaPathForTranscript(transcriptPath string) string {
+	sep := string(filepath.Separator)
+	marker := sep + ".claude" + sep + "projects" + sep
+	sessionDir, _, ok := strings.Cut(transcriptPath, marker)
+	if !ok {
+		return ""
+	}
+	return sessionDir + ".json"
+}
+
+// CoworkSessionMtime returns the larger of a cowork transcript's mtime and
+// its metadata file's mtime (nanoseconds). The human-facing title lives in
+// the metadata file, so a rename changes only the metadata; folding its
+// mtime into the skip key ensures renames are re-parsed instead of skipped
+// as "unchanged". Returns transcriptMtime when the metadata file is absent
+// or unreadable.
+func CoworkSessionMtime(transcriptPath string, transcriptMtime int64) int64 {
+	metaPath := coworkMetaPathForTranscript(transcriptPath)
+	if metaPath == "" {
+		return transcriptMtime
+	}
+	info, err := os.Stat(metaPath)
+	if err != nil {
+		return transcriptMtime
+	}
+	if m := info.ModTime().UnixNano(); m > transcriptMtime {
+		return m
+	}
+	return transcriptMtime
+}
+
+// walkCoworkSessions traverses a cowork root and invokes fn for every
+// session transcript on disk (the main conversation and each subagent).
+// The walk is shallow: it descends only the org/workspace directory
+// structure and never enters the session working directories
+// (local_<uuid>/, which hold large .claude/outputs subtrees) or the
+// sibling skills-plugin mirror.
+func walkCoworkSessions(root string, fn func(transcriptPath string)) {
+	if root == "" {
+		return
+	}
+	_ = filepath.WalkDir(
+		root,
+		func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				if path == root {
+					return nil
+				}
+				name := d.Name()
+				if strings.HasPrefix(name, "local_") ||
+					name == "skills-plugin" ||
+					name == "node_modules" ||
+					name == ".git" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !isCoworkMetaFileName(d.Name()) {
+				return nil
+			}
+			meta := readCoworkMeta(path)
+			if meta.CliSessionID == "" {
+				return nil
+			}
+			sessionDir := strings.TrimSuffix(path, ".json")
+			main, encDir := resolveCoworkSession(
+				sessionDir, meta.CliSessionID,
+			)
+			if main == "" {
+				return nil
+			}
+			fn(main)
+			for _, sub := range coworkSubagentTranscripts(
+				encDir, meta.CliSessionID,
+			) {
+				fn(sub)
+			}
+			return nil
+		},
+	)
+}
+
+// DiscoverCoworkSessions finds all cowork session transcripts under root,
+// including subagent transcripts.
+func DiscoverCoworkSessions(root string) []DiscoveredFile {
+	var files []DiscoveredFile
+	walkCoworkSessions(root, func(transcript string) {
+		files = append(files, DiscoveredFile{
+			Path:  transcript,
+			Agent: AgentCowork,
+		})
+	})
+	return files
+}
+
+// FindCoworkSourceFile locates a cowork transcript by its raw session ID
+// (the cliSessionId or "agent-<id>" subagent id, with the "cowork:" prefix
+// already stripped).
+func FindCoworkSourceFile(root, sessionID string) string {
+	if !IsValidSessionID(sessionID) {
+		return ""
+	}
+	target := sessionID + ".jsonl"
+	var found string
+	walkCoworkSessions(root, func(transcript string) {
+		if found == "" && filepath.Base(transcript) == target {
+			found = transcript
+		}
+	})
+	return found
+}
+
+// ClassifyCoworkPath reports whether a changed path under a cowork root is
+// a cowork session transcript (main or subagent) or its sibling metadata
+// file, and returns the transcript file that should be (re)parsed.
+// Metadata changes (e.g. a title rename) resolve to the session's main
+// transcript so the rename is picked up.
+func ClassifyCoworkPath(root, path string) (string, bool) {
+	rel, ok := relUnder(root, path)
+	if !ok {
+		return "", false
+	}
+	sep := string(filepath.Separator)
+	parts := strings.Split(rel, sep)
+	n := len(parts)
+	base := parts[n-1]
+
+	if strings.HasSuffix(base, ".jsonl") {
+		// Must live under a .claude/projects/ subtree.
+		marker := sep + ".claude" + sep + "projects" + sep
+		if !strings.Contains(sep+rel, marker) {
+			return "", false
+		}
+		stem := strings.TrimSuffix(base, ".jsonl")
+		if strings.HasPrefix(stem, "agent-") {
+			// Subagent transcript: <enc>/<cli>/subagents/**/agent-*.jsonl.
+			if slices.Contains(parts, "subagents") {
+				return path, true
+			}
+			return "", false
+		}
+		// Main transcript: <enc>/<cliSessionId>.jsonl directly under projects.
+		if n >= 5 && parts[n-4] == ".claude" && parts[n-3] == "projects" &&
+			IsValidSessionID(stem) {
+			return path, true
+		}
+		return "", false
+	}
+
+	// Metadata: <orgId>/<workspaceId>/local_<uuid>.json
+	if isCoworkMetaFileName(base) {
+		meta := readCoworkMeta(path)
+		if meta.CliSessionID == "" {
+			return "", false
+		}
+		sessionDir := strings.TrimSuffix(path, ".json")
+		if main, _ := resolveCoworkSession(
+			sessionDir, meta.CliSessionID,
+		); main != "" {
+			return main, true
+		}
+	}
+	return "", false
+}
+
+// relUnder returns the path of child relative to dir when child is
+// strictly contained within dir, mirroring the engine's isUnder helper so
+// the parser can classify paths without importing sync internals.
+func relUnder(dir, child string) (string, bool) {
+	if dir == "" {
+		return "", false
+	}
+	rel, err := filepath.Rel(dir, child)
+	if err != nil {
+		return "", false
+	}
+	if rel == "." || rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return rel, true
+}
+
+// extractCoworkAITitle scans a cowork transcript for the most recent
+// "ai-title" event, which carries the auto-generated conversation title.
+// Returns "" when no title event is present.
+func extractCoworkAITitle(transcriptPath string) string {
+	f, err := os.Open(transcriptPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	lr := newLineReader(f, maxLineSize)
+	title := ""
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if !gjson.Valid(line) {
+			continue
+		}
+		if gjson.Get(line, "type").Str != "ai-title" {
+			continue
+		}
+		if t := gjson.Get(line, "aiTitle").Str; t != "" {
+			title = t
+		}
+	}
+	return title
+}
+
+// ParseCoworkSession parses a cowork session transcript. It reuses the
+// Claude Code parser on the transcript and then rewrites the results into
+// the cowork namespace: agent type, "cowork:"-prefixed IDs, the session
+// title, and metadata-derived timestamps for transcripts that carry none.
+// Returns parsed results plus session IDs the parser intentionally
+// excluded (prefixed), matching ParseClaudeSessionWithExclusions.
+func ParseCoworkSession(
+	transcriptPath, machine string,
+) ([]ParseResult, []string, error) {
+	metaPath := coworkMetaPathForTranscript(transcriptPath)
+	meta := readCoworkMeta(metaPath)
+	project := coworkProjectName(meta)
+
+	results, excluded, err := ParseClaudeSessionWithExclusions(
+		transcriptPath, project, machine,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	title := strings.TrimSpace(meta.Title)
+	if title == "" {
+		title = strings.TrimSpace(extractCoworkAITitle(transcriptPath))
+	}
+
+	// Infer relationship types on the raw (unprefixed) IDs before
+	// rewriting them into the cowork namespace, so the "agent-" subagent
+	// heuristic still applies.
+	InferRelationshipTypes(results)
+	applyCoworkIdentity(results, title, meta)
+
+	// Fold the metadata file's mtime into the stored session mtime so a
+	// later title rename (which touches only the metadata) is detected as
+	// a change and re-parsed rather than skipped as unchanged.
+	if len(results) > 0 {
+		composite := CoworkSessionMtime(
+			transcriptPath, results[0].Session.File.Mtime,
+		)
+		for i := range results {
+			results[i].Session.File.Mtime = composite
+		}
+	}
+
+	for i := range excluded {
+		excluded[i] = coworkIDPrefix + excluded[i]
+	}
+	return results, excluded, nil
+}
+
+// applyCoworkIdentity rewrites Claude parse results into the cowork
+// namespace. Every session ID, parent ID, and subagent link is prefixed
+// uniformly so relationships are preserved.
+func applyCoworkIdentity(
+	results []ParseResult, title string, meta coworkMeta,
+) {
+	for i := range results {
+		sess := &results[i].Session
+		sess.Agent = AgentCowork
+		sess.ID = coworkIDPrefix + sess.ID
+		if sess.ParentSessionID != "" {
+			sess.ParentSessionID = coworkIDPrefix + sess.ParentSessionID
+		}
+		if title != "" {
+			sess.SessionName = title
+		}
+		// Fall back to metadata timestamps for transcripts with no
+		// message timestamps (e.g. a session created but never run).
+		if sess.StartedAt.IsZero() && meta.CreatedAt > 0 {
+			sess.StartedAt = time.UnixMilli(meta.CreatedAt).UTC()
+		}
+		if sess.EndedAt.IsZero() && meta.LastActivityAt > 0 {
+			sess.EndedAt = time.UnixMilli(meta.LastActivityAt).UTC()
+		}
+
+		for m := range results[i].Messages {
+			msg := &results[i].Messages[m]
+			for t := range msg.ToolCalls {
+				tc := &msg.ToolCalls[t]
+				if tc.SubagentSessionID != "" {
+					tc.SubagentSessionID = coworkIDPrefix + tc.SubagentSessionID
+				}
+				for r := range tc.ResultEvents {
+					if tc.ResultEvents[r].SubagentSessionID != "" {
+						tc.ResultEvents[r].SubagentSessionID =
+							coworkIDPrefix + tc.ResultEvents[r].SubagentSessionID
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/parser/cowork_paths.go
+++ b/internal/parser/cowork_paths.go
@@ -1,0 +1,29 @@
+package parser
+
+// coworkDefaultDirs returns platform-specific default directories that
+// hold Claude Desktop "cowork" (local agent mode) session data. The
+// Claude desktop app is an Electron app, so its user-data directory
+// follows the standard Electron convention per platform:
+//
+//	macOS:   ~/Library/Application Support/Claude
+//	Linux:   ~/.config/Claude
+//	Windows: %LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude
+//	         or %APPDATA%\Claude on non-MSIX/older installs
+//
+// Cowork sessions live under <userData>/local-agent-mode-sessions.
+// Paths that don't exist on a given platform are skipped silently by
+// discovery, so listing all three unconditionally is safe. In Docker
+// the host directory is mounted and COWORK_DIR points at the mount.
+func coworkDefaultDirs() []string {
+	return []string{
+		// macOS
+		"Library/Application Support/Claude/local-agent-mode-sessions",
+		// Linux
+		".config/Claude/local-agent-mode-sessions",
+		// Windows MSIX package install
+		"AppData/Local/Packages/Claude_pzs8sxrjxfjjc/" +
+			"LocalCache/Roaming/Claude/local-agent-mode-sessions",
+		// Windows non-MSIX / older installs
+		"AppData/Roaming/Claude/local-agent-mode-sessions",
+	}
+}

--- a/internal/parser/cowork_test.go
+++ b/internal/parser/cowork_test.go
@@ -1,0 +1,417 @@
+package parser
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// All identifiers, titles, and content below are synthetic fixtures.
+
+// coworkFixture describes one cowork session to materialize on disk.
+type coworkFixture struct {
+	org             string
+	workspace       string
+	sessionUUID     string // names local_<uuid>.json and local_<uuid>/
+	cliSessionID    string // names the nested transcript
+	encodedProject  string // the .claude/projects/<enc> directory name
+	title           string
+	folders         []string
+	createdAt       int64
+	lastActivityAt  int64
+	transcriptLines []string
+}
+
+// writeCoworkSession materializes a cowork session under root and returns
+// the metadata path and transcript path.
+func writeCoworkSession(
+	t *testing.T, root string, f coworkFixture,
+) (metaPath, transcriptPath string) {
+	t.Helper()
+
+	wsDir := filepath.Join(root, f.org, f.workspace)
+	sessionDirName := "local_" + f.sessionUUID
+	metaPath = filepath.Join(wsDir, sessionDirName+".json")
+
+	meta := map[string]any{
+		"sessionId":           sessionDirName,
+		"cliSessionId":        f.cliSessionID,
+		"title":               f.title,
+		"userSelectedFolders": f.folders,
+		"createdAt":           f.createdAt,
+		"lastActivityAt":      f.lastActivityAt,
+	}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err, "marshal meta")
+	require.NoError(t, os.MkdirAll(wsDir, 0o755), "mkdir workspace")
+	require.NoError(t, os.WriteFile(metaPath, metaBytes, 0o644), "write meta")
+
+	projectDir := filepath.Join(
+		wsDir, sessionDirName, ".claude", "projects", f.encodedProject,
+	)
+	require.NoError(t, os.MkdirAll(projectDir, 0o755), "mkdir project")
+	transcriptPath = filepath.Join(projectDir, f.cliSessionID+".jsonl")
+	require.NoError(t,
+		os.WriteFile(
+			transcriptPath,
+			[]byte(strings.Join(f.transcriptLines, "\n")+"\n"),
+			0o644,
+		),
+		"write transcript",
+	)
+	return metaPath, transcriptPath
+}
+
+// coworkTranscriptLines returns a small but realistic Claude Code
+// transcript: an ai-title event, one user turn, and one assistant turn
+// carrying token usage.
+func coworkTranscriptLines(cli string) []string {
+	return []string{
+		`{"type":"ai-title","aiTitle":"Auto title","sessionId":"` + cli + `"}`,
+		`{"type":"user","uuid":"u1","parentUuid":null,` +
+			`"sessionId":"` + cli + `","cwd":"/sessions/test",` +
+			`"gitBranch":"HEAD","version":"2.1.119",` +
+			`"timestamp":"2026-03-01T10:00:00.000Z",` +
+			`"message":{"role":"user","content":"hello there"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1",` +
+			`"sessionId":"` + cli + `","requestId":"req_1",` +
+			`"timestamp":"2026-03-01T10:00:05.000Z",` +
+			`"message":{"role":"assistant","id":"msg_1",` +
+			`"model":"claude-sonnet-4-6","stop_reason":"end_turn",` +
+			`"content":[{"type":"text","text":"hi back"}],` +
+			`"usage":{"input_tokens":10,"cache_read_input_tokens":2,` +
+			`"output_tokens":5}}}`,
+	}
+}
+
+func TestDiscoverCoworkSessions(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000001"
+	_, transcript := writeCoworkSession(t, root, coworkFixture{
+		org:             "org",
+		workspace:       "ws",
+		sessionUUID:     "50000000-0000-4000-8000-000000000001",
+		cliSessionID:    cli,
+		encodedProject:  "-sessions-demo",
+		title:           "Demo session",
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+
+	got := DiscoverCoworkSessions(root)
+	require.Len(t, got, 1, "discovered files")
+	assert.Equal(t, transcript, got[0].Path, "Path")
+	assert.Equal(t, AgentCowork, got[0].Agent, "Agent")
+}
+
+func TestDiscoverCoworkSessionsIgnoresNoise(t *testing.T) {
+	root := t.TempDir()
+	wsDir := filepath.Join(root, "org", "ws")
+	require.NoError(t, os.MkdirAll(wsDir, 0o755), "mkdir ws")
+
+	// Sibling cache files must not be treated as session metadata.
+	for _, name := range []string{
+		"cowork_settings.json",
+		"cowork-clientdata-cache.json",
+		"artifacts.json",
+	} {
+		require.NoError(t,
+			os.WriteFile(filepath.Join(wsDir, name), []byte("{}"), 0o644),
+			"write %s", name,
+		)
+	}
+	// A skills-plugin mirror must be skipped entirely.
+	skillDir := filepath.Join(root, "skills-plugin", "ws", "org")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755), "mkdir skills")
+	require.NoError(t,
+		os.WriteFile(
+			filepath.Join(skillDir, "local_fake.json"), []byte("{}"), 0o644,
+		),
+		"write skills noise",
+	)
+	// A metadata file with no transcript yet must be skipped.
+	require.NoError(t,
+		os.WriteFile(
+			filepath.Join(wsDir, "local_"+
+				"00000000-0000-4000-8000-0000000000ff.json"),
+			[]byte(`{"cliSessionId":"00000000-0000-4000-8000-0000000000fe"}`), 0o644,
+		),
+		"write transcript-less meta",
+	)
+
+	assert.Empty(t, DiscoverCoworkSessions(root))
+}
+
+func TestParseCoworkSession(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000002"
+	_, transcript := writeCoworkSession(t, root, coworkFixture{
+		org:             "org",
+		workspace:       "ws",
+		sessionUUID:     "50000000-0000-4000-8000-000000000002",
+		cliSessionID:    cli,
+		encodedProject:  "-sessions-demo",
+		title:           "Sample session title",
+		createdAt:       1700000000000,
+		lastActivityAt:  1700000100000,
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+
+	results, excluded, err := ParseCoworkSession(transcript, "host-1")
+	require.NoError(t, err, "parse")
+	require.Empty(t, excluded, "excluded")
+	require.Len(t, results, 1, "results")
+
+	sess := results[0].Session
+	assert.Equal(t, "cowork:"+cli, sess.ID, "ID prefixed")
+	assert.Equal(t, AgentCowork, sess.Agent, "Agent")
+	assert.Equal(t, "cowork", sess.Project, "Project")
+	assert.Equal(t, "Sample session title", sess.SessionName, "title")
+	assert.Equal(t, "host-1", sess.Machine, "Machine")
+	assert.Equal(t, 2, sess.MessageCount, "MessageCount")
+	assert.Equal(t, 1, sess.UserMessageCount, "UserMessageCount")
+
+	// Token usage must be counted (this is the crux of issue #639).
+	hasTotal, hasPeak := sess.AggregateTokenPresence()
+	assert.True(t, hasTotal, "HasTotalOutputTokens")
+	assert.True(t, hasPeak, "HasPeakContextTokens")
+	assert.Equal(t, 5, sess.TotalOutputTokens, "TotalOutputTokens")
+	assert.Equal(t, 12, sess.PeakContextTokens, "PeakContextTokens (input+cacheRead)")
+}
+
+func TestParseCoworkSessionTitleFallsBackToAITitle(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000003"
+	_, transcript := writeCoworkSession(t, root, coworkFixture{
+		org:             "org",
+		workspace:       "ws",
+		sessionUUID:     "50000000-0000-4000-8000-000000000003",
+		cliSessionID:    cli,
+		encodedProject:  "-sessions-demo",
+		title:           "", // no explicit title
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+
+	results, _, err := ParseCoworkSession(transcript, "host-1")
+	require.NoError(t, err, "parse")
+	require.Len(t, results, 1, "results")
+	assert.Equal(t, "Auto title", results[0].Session.SessionName,
+		"falls back to ai-title event")
+}
+
+func TestParseCoworkSessionProjectFromSelectedFolder(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000004"
+	_, transcript := writeCoworkSession(t, root, coworkFixture{
+		org:             "org",
+		workspace:       "ws",
+		sessionUUID:     "50000000-0000-4000-8000-000000000004",
+		cliSessionID:    cli,
+		encodedProject:  "-sessions-demo",
+		title:           "With folder",
+		folders:         []string{"/home/user/code/my-app"},
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+
+	results, _, err := ParseCoworkSession(transcript, "host-1")
+	require.NoError(t, err, "parse")
+	require.Len(t, results, 1, "results")
+	assert.Equal(t, "my_app", results[0].Session.Project,
+		"project derived from userSelectedFolders")
+}
+
+func TestFindCoworkSourceFile(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000005"
+	_, transcript := writeCoworkSession(t, root, coworkFixture{
+		org:             "org",
+		workspace:       "ws",
+		sessionUUID:     "50000000-0000-4000-8000-000000000005",
+		cliSessionID:    cli,
+		encodedProject:  "-sessions-demo",
+		title:           "x",
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+
+	assert.Equal(t, transcript, FindCoworkSourceFile(root, cli), "found")
+	assert.Empty(t, FindCoworkSourceFile(root, "nonexistent-id"), "missing")
+}
+
+func TestClassifyCoworkPath(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000006"
+	metaPath, transcript := writeCoworkSession(t, root, coworkFixture{
+		org:             "org",
+		workspace:       "ws",
+		sessionUUID:     "50000000-0000-4000-8000-000000000006",
+		cliSessionID:    cli,
+		encodedProject:  "-sessions-demo",
+		title:           "x",
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+
+	// A transcript change classifies to itself.
+	got, ok := ClassifyCoworkPath(root, transcript)
+	require.True(t, ok, "transcript classified")
+	assert.Equal(t, transcript, got, "transcript path")
+
+	// A metadata change resolves to the session's transcript.
+	got, ok = ClassifyCoworkPath(root, metaPath)
+	require.True(t, ok, "metadata classified")
+	assert.Equal(t, transcript, got, "metadata resolves to transcript")
+
+	// Unrelated and outside-root paths are ignored.
+	_, ok = ClassifyCoworkPath(root, filepath.Join(root, "org", "ws", "artifacts.json"))
+	assert.False(t, ok, "cache file ignored")
+	_, ok = ClassifyCoworkPath(root, "/some/other/place.jsonl")
+	assert.False(t, ok, "outside root ignored")
+}
+
+func TestCoworkSessionMtime(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000007"
+	metaPath, transcript := writeCoworkSession(t, root, coworkFixture{
+		org:             "org",
+		workspace:       "ws",
+		sessionUUID:     "50000000-0000-4000-8000-000000000007",
+		cliSessionID:    cli,
+		encodedProject:  "-sessions-demo",
+		title:           "Before",
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+
+	tInfo, err := os.Stat(transcript)
+	require.NoError(t, err, "stat transcript")
+	tMtime := tInfo.ModTime().UnixNano()
+
+	// Baseline: with metadata older than the transcript, the transcript
+	// mtime wins.
+	older := tInfo.ModTime().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, older, older), "age metadata")
+	assert.Equal(t, tMtime, CoworkSessionMtime(transcript, tMtime),
+		"transcript mtime wins when metadata is older")
+
+	// A title rename bumps only the metadata file's mtime; the composite
+	// must reflect it so the session is re-parsed instead of skipped.
+	newer := tInfo.ModTime().Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, newer, newer), "touch metadata")
+	assert.Equal(t, newer.UnixNano(), CoworkSessionMtime(transcript, tMtime),
+		"metadata mtime folded into composite")
+
+	// No metadata file -> transcript mtime.
+	require.NoError(t, os.Remove(metaPath), "remove metadata")
+	assert.Equal(t, tMtime, CoworkSessionMtime(transcript, tMtime),
+		"transcript mtime when metadata missing")
+}
+
+func TestDiscoverCoworkSessionsIncludesSubagents(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000008"
+	enc := "-sessions-demo"
+	_, transcript := writeCoworkSession(t, root, coworkFixture{
+		org:             "org",
+		workspace:       "ws",
+		sessionUUID:     "50000000-0000-4000-8000-000000000008",
+		cliSessionID:    cli,
+		encodedProject:  enc,
+		title:           "Subagent demo",
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+
+	// Write a subagent transcript alongside the main one, mirroring
+	// Claude Code's layout: <enc>/<cli>/subagents/agent-<id>.jsonl.
+	subDir := filepath.Join(filepath.Dir(transcript), cli, "subagents")
+	require.NoError(t, os.MkdirAll(subDir, 0o755), "mkdir subagents")
+	subPath := filepath.Join(subDir, "agent-0000000000000001.jsonl")
+	subLines := []string{
+		`{"type":"user","uuid":"su1","parentUuid":null,"sessionId":"` + cli + `",` +
+			`"cwd":"/sessions/test","timestamp":"2026-03-01T10:01:00.000Z",` +
+			`"message":{"role":"user","content":"sub task"}}`,
+		`{"type":"assistant","uuid":"sa1","parentUuid":"su1","sessionId":"` + cli + `",` +
+			`"timestamp":"2026-03-01T10:01:05.000Z","message":{"role":"assistant",` +
+			`"id":"m2","model":"claude-sonnet-4-6","stop_reason":"end_turn",` +
+			`"content":[{"type":"text","text":"done"}],` +
+			`"usage":{"input_tokens":3,"output_tokens":2}}}`,
+	}
+	require.NoError(t,
+		os.WriteFile(subPath, []byte(strings.Join(subLines, "\n")+"\n"), 0o644),
+		"write subagent",
+	)
+
+	got := DiscoverCoworkSessions(root)
+	paths := make([]string, len(got))
+	for i, f := range got {
+		paths[i] = f.Path
+		assert.Equal(t, AgentCowork, f.Agent, "Agent")
+	}
+	assert.Contains(t, paths, transcript, "main transcript discovered")
+	assert.Contains(t, paths, subPath, "subagent transcript discovered")
+
+	// The subagent parses into a cowork-namespaced subagent session whose
+	// parent is the main session.
+	results, _, err := ParseCoworkSession(subPath, "host-1")
+	require.NoError(t, err, "parse subagent")
+	require.Len(t, results, 1, "results")
+	sub := results[0].Session
+	assert.Equal(t, "cowork:agent-0000000000000001", sub.ID, "subagent ID")
+	assert.Equal(t, "cowork:"+cli, sub.ParentSessionID, "parent prefixed")
+	assert.Equal(t, RelSubagent, sub.RelationshipType, "RelSubagent")
+
+	// FindCoworkSourceFile resolves the subagent by its raw ID too.
+	assert.Equal(t, subPath,
+		FindCoworkSourceFile(root, "agent-0000000000000001"),
+		"find subagent source")
+}
+
+func TestResolveCoworkSessionRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000009"
+	sessionDir := filepath.Join(root, "org", "ws", "local_session")
+	projectsDir := filepath.Join(sessionDir, ".claude", "projects")
+	require.NoError(t, os.MkdirAll(projectsDir, 0o755), "mkdir projects")
+
+	// Plant the real transcript OUTSIDE the session dir, then expose it
+	// inside projects/ via a directory symlink. resolveCoworkSession must
+	// refuse to follow the escape.
+	outside := filepath.Join(root, "outside")
+	require.NoError(t, os.MkdirAll(outside, 0o755), "mkdir outside")
+	require.NoError(t,
+		os.WriteFile(filepath.Join(outside, cli+".jsonl"), []byte("{}\n"), 0o644),
+		"write escaped transcript",
+	)
+	require.NoError(t,
+		os.Symlink(outside, filepath.Join(projectsDir, "-evil")),
+		"symlink enc dir",
+	)
+
+	main, encDir := resolveCoworkSession(sessionDir, cli)
+	assert.Empty(t, main, "symlinked escape rejected")
+	assert.Empty(t, encDir, "no enc dir for escape")
+}
+
+func TestCoworkDefaultDirs(t *testing.T) {
+	dirs := coworkDefaultDirs()
+	require.Len(t, dirs, 4, "macOS, Linux, Windows MSIX, Windows Roaming")
+	assert.Contains(t, dirs,
+		"AppData/Local/Packages/Claude_pzs8sxrjxfjjc/"+
+			"LocalCache/Roaming/Claude/local-agent-mode-sessions",
+		"Windows MSIX package-local path")
+	assert.Contains(t, dirs,
+		"AppData/Roaming/Claude/local-agent-mode-sessions",
+		"Windows Roaming fallback")
+	for _, d := range dirs {
+		assert.True(t,
+			strings.HasSuffix(d, "local-agent-mode-sessions"),
+			"dir %q targets local-agent-mode-sessions", d,
+		)
+	}
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -11,6 +11,7 @@ type AgentType string
 
 const (
 	AgentClaude         AgentType = "claude"
+	AgentCowork         AgentType = "cowork"
 	AgentCodex          AgentType = "codex"
 	AgentCopilot        AgentType = "copilot"
 	AgentGemini         AgentType = "gemini"
@@ -89,6 +90,18 @@ var Registry = []AgentDef{
 		FileBased:      true,
 		DiscoverFunc:   DiscoverClaudeProjects,
 		FindSourceFunc: FindClaudeSourceFile,
+	},
+	{
+		Type:           AgentCowork,
+		DisplayName:    "Claude Cowork",
+		EnvVar:         "COWORK_DIR",
+		ConfigKey:      "cowork_dirs",
+		DefaultDirs:    coworkDefaultDirs(),
+		IDPrefix:       "cowork:",
+		FileBased:      true,
+		ShallowWatch:   true,
+		DiscoverFunc:   DiscoverCoworkSessions,
+		FindSourceFunc: FindCoworkSourceFile,
 	},
 	{
 		Type:        AgentCodex,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -269,6 +269,7 @@ func TestAgentByPrefix(t *testing.T) {
 func TestRegistryCompleteness(t *testing.T) {
 	allTypes := []AgentType{
 		AgentClaude,
+		AgentCowork,
 		AgentCodex,
 		AgentCopilot,
 		AgentGemini,
@@ -443,6 +444,26 @@ func TestOpenCodeRegistryEntry(t *testing.T) {
 	}
 	require.Truef(t, slices.Equal(def.WatchSubdirs, want),
 		"OpenCode WatchSubdirs = %v, want %v", def.WatchSubdirs, want)
+}
+
+func TestCoworkRegistryEntry(t *testing.T) {
+	def, ok := AgentByType(AgentCowork)
+	require.True(t, ok, "AgentCowork missing from Registry")
+	require.True(t, def.FileBased, "Cowork FileBased")
+	require.NotNil(t, def.DiscoverFunc, "Cowork DiscoverFunc")
+	require.NotNil(t, def.FindSourceFunc, "Cowork FindSourceFunc")
+	assert.Equal(t, "COWORK_DIR", def.EnvVar)
+	assert.Equal(t, "cowork_dirs", def.ConfigKey)
+	assert.Equal(t, "cowork:", def.IDPrefix)
+	assert.Equal(t, coworkDefaultDirs(), def.DefaultDirs)
+	assert.True(t, def.ShallowWatch,
+		"Cowork root contains large local_* working trees that discovery skips")
+}
+
+func TestAgentByPrefixCowork(t *testing.T) {
+	def, ok := AgentByPrefix("cowork:c0000000-0000-4000-8000-000000000001")
+	require.True(t, ok, "cowork-prefixed ID should resolve")
+	assert.Equal(t, AgentCowork, def.Type)
 }
 
 func TestCommandCodeRegistryEntry(t *testing.T) {

--- a/internal/sync/cowork_integration_test.go
+++ b/internal/sync/cowork_integration_test.go
@@ -1,0 +1,195 @@
+package sync_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+type coworkSyncFixture struct {
+	sessionUUID string
+	cliID       string
+	title       string
+}
+
+func writeCoworkSyncFixture(
+	t *testing.T, root string, f coworkSyncFixture,
+) (metaPath, transcriptPath string) {
+	t.Helper()
+
+	sessionDirName := "local_" + f.sessionUUID
+	workspaceDir := filepath.Join(root, "org", "workspace")
+	metaPath = filepath.Join(workspaceDir, sessionDirName+".json")
+	meta := map[string]any{
+		"sessionId":      sessionDirName,
+		"cliSessionId":   f.cliID,
+		"title":          f.title,
+		"createdAt":      int64(1_700_000_000_000),
+		"lastActivityAt": int64(1_700_000_001_000),
+	}
+	data, err := json.Marshal(meta)
+	require.NoError(t, err, "marshal cowork metadata")
+	require.NoError(t, os.MkdirAll(workspaceDir, 0o755), "mkdir workspace")
+	require.NoError(t, os.WriteFile(metaPath, data, 0o644), "write metadata")
+
+	projectDir := filepath.Join(
+		workspaceDir, sessionDirName, ".claude", "projects", "-sessions-demo",
+	)
+	require.NoError(t, os.MkdirAll(projectDir, 0o755), "mkdir project")
+	transcriptPath = filepath.Join(projectDir, f.cliID+".jsonl")
+	lines := []string{
+		`{"type":"user","uuid":"u1","parentUuid":null,` +
+			`"sessionId":"` + f.cliID + `","cwd":"/sessions/test",` +
+			`"timestamp":"2026-03-01T10:00:00.000Z",` +
+			`"message":{"role":"user","content":"hello there"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1",` +
+			`"sessionId":"` + f.cliID + `","timestamp":"2026-03-01T10:00:05.000Z",` +
+			`"message":{"role":"assistant","id":"msg_1",` +
+			`"model":"claude-sonnet-4-6","stop_reason":"end_turn",` +
+			`"content":[{"type":"text","text":"hi back"}],` +
+			`"usage":{"input_tokens":10,"output_tokens":5}}}`,
+	}
+	require.NoError(t,
+		os.WriteFile(transcriptPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644),
+		"write transcript",
+	)
+	return metaPath, transcriptPath
+}
+
+func TestSyncAllSinceCoworkMetaUpdateTriggersResync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	coworkDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCowork: {coworkDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "3021ea26-c727-48d2-934a-3e169c6ab04e"
+	metaPath, transcriptPath := writeCoworkSyncFixture(t, coworkDir, coworkSyncFixture{
+		sessionUUID: "0b4eea33-12a0-42ac-856b-98d61a4717c3",
+		cliID:       sessionID,
+		title:       "Before rename",
+	})
+
+	engine.SyncPaths([]string{transcriptPath})
+	assertSessionState(t, testDB, "cowork:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Before rename", *sess.DisplayName)
+	})
+
+	transcriptTime := time.Unix(1_781_475_210, 0)
+	metaTime := transcriptTime.Add(time.Second)
+	require.NoError(t, os.Chtimes(transcriptPath, transcriptTime, transcriptTime))
+	require.NoError(t, os.WriteFile(metaPath, []byte(
+		`{"sessionId":"local_0b4eea33-12a0-42ac-856b-98d61a4717c3",`+
+			`"cliSessionId":"`+sessionID+`","title":"After rename"}`,
+	), 0o644), "rewrite metadata")
+	require.NoError(t, os.Chtimes(metaPath, metaTime, metaTime))
+
+	cutoff := transcriptTime.Add(500 * time.Millisecond)
+	stats := engine.SyncAllSince(context.Background(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced, "synced = %d, want 1", stats.Synced)
+
+	assertSessionState(t, testDB, "cowork:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "After rename", *sess.DisplayName)
+	})
+}
+
+func TestSourceMtimeCoworkIncludesMetaMtime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	coworkDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCowork: {coworkDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "3021ea26-c727-48d2-934a-3e169c6ab04e"
+	metaPath, transcriptPath := writeCoworkSyncFixture(t, coworkDir, coworkSyncFixture{
+		sessionUUID: "0b4eea33-12a0-42ac-856b-98d61a4717c3",
+		cliID:       sessionID,
+		title:       "Source mtime",
+	})
+
+	transcriptTime := time.Unix(1_781_475_210, 0)
+	metaTime := transcriptTime.Add(time.Second)
+	require.NoError(t, os.Chtimes(transcriptPath, transcriptTime, transcriptTime))
+	require.NoError(t, os.Chtimes(metaPath, metaTime, metaTime))
+
+	engine.SyncPaths([]string{transcriptPath})
+	assert.Equal(t, metaTime.UnixNano(), engine.SourceMtime("cowork:"+sessionID))
+}
+
+func TestSyncPathsCoworkReplacesUpdatedMessageOrdinal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	coworkDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCowork: {coworkDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "3021ea26-c727-48d2-934a-3e169c6ab04e"
+	_, transcriptPath := writeCoworkSyncFixture(t, coworkDir, coworkSyncFixture{
+		sessionUUID: "0b4eea33-12a0-42ac-856b-98d61a4717c3",
+		cliID:       sessionID,
+		title:       "Streaming update",
+	})
+
+	engine.SyncPaths([]string{transcriptPath})
+	assertCoworkAssistantContent(t, testDB, sessionID, "hi back")
+
+	data, err := os.ReadFile(transcriptPath)
+	require.NoError(t, err, "read transcript")
+	updated := strings.Replace(string(data), "hi back", "updated answer", 1)
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(updated), 0o644),
+		"rewrite transcript")
+	require.NoError(t, os.Chtimes(transcriptPath, time.Now(), time.Now()),
+		"touch transcript")
+
+	engine.SyncPaths([]string{transcriptPath})
+	assertCoworkAssistantContent(t, testDB, sessionID, "updated answer")
+}
+
+func assertCoworkAssistantContent(
+	t *testing.T, database *db.DB, rawSessionID, want string,
+) {
+	t.Helper()
+
+	msgs, err := database.GetMessages(
+		context.Background(), "cowork:"+rawSessionID, 0, 100, true,
+	)
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, msgs, 2, "messages")
+	assert.Equal(t, "assistant", msgs[1].Role)
+	assert.Equal(t, want, msgs[1].Content)
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -524,6 +524,23 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
+	// Cowork: <coworkDir>/<orgId>/<workspaceId>/local_<uuid>/.claude/
+	//   projects/<enc>/<cliSessionId>.jsonl (transcript), or the sibling
+	//   local_<uuid>.json metadata file (resolves to its transcript).
+	for _, coworkDir := range e.agentDirs[parser.AgentCowork] {
+		if coworkDir == "" {
+			continue
+		}
+		if transcript, ok := parser.ClassifyCoworkPath(
+			coworkDir, path,
+		); ok {
+			return parser.DiscoveredFile{
+				Path:  transcript,
+				Agent: parser.AgentCowork,
+			}, true
+		}
+	}
+
 	// Codex: either <codexDir>/<year>/<month>/<day>/<file>.jsonl
 	// or <codexDir>/<file>.jsonl for archived sessions.
 	for _, codexDir := range e.agentDirs[parser.AgentCodex] {
@@ -2488,6 +2505,15 @@ func discoveredFileMtime(
 		}
 		return info.ModTime().UnixNano(), nil
 	}
+	if file.Agent == parser.AgentCowork {
+		info, err := os.Stat(file.Path)
+		if err != nil {
+			return 0, err
+		}
+		return parser.CoworkSessionMtime(
+			file.Path, info.ModTime().UnixNano(),
+		), nil
+	}
 	if file.Agent == parser.AgentCommandCode {
 		info, err := os.Stat(file.Path)
 		if err != nil {
@@ -3217,6 +3243,9 @@ func (e *Engine) processFile(
 		}
 		mtime = snapshot.Mtime
 	}
+	if file.Agent == parser.AgentCowork {
+		mtime = parser.CoworkSessionMtime(file.Path, mtime)
+	}
 	cacheSkip := e.shouldCacheSkip(file)
 
 	// Skip files cached from a previous sync (parse errors
@@ -3243,6 +3272,8 @@ func (e *Engine) processFile(
 	switch file.Agent {
 	case parser.AgentClaude:
 		res = e.processClaude(ctx, file, info)
+	case parser.AgentCowork:
+		res = e.processCowork(file, info)
 	case parser.AgentCodex:
 		res = e.processCodex(file, info)
 	case parser.AgentCopilot:
@@ -3557,6 +3588,50 @@ func (e *Engine) processClaude(
 		results:            results,
 		excludedSessionIDs: excludedIDs,
 		forceReplace:       forceReplace,
+	}
+}
+
+// processCowork parses a Claude Desktop "cowork" (local agent mode)
+// session. The transcript is a standard Claude Code JSONL file nested
+// inside the cowork session directory, so the work is delegated to the
+// Claude parser and rewritten into the cowork namespace by
+// parser.ParseCoworkSession. Cowork session IDs are "cowork:"-prefixed, so
+// the skip check keys off file_path rather than the bare filename stem.
+func (e *Engine) processCowork(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+
+	// The session title lives in the sibling metadata file, so a rename
+	// changes only that file. Skip on the composite (transcript+metadata)
+	// mtime so renames are re-parsed instead of skipped as unchanged.
+	compositeMtime := parser.CoworkSessionMtime(
+		file.Path, info.ModTime().UnixNano(),
+	)
+	fi := fakeSnapshotInfo{fSize: info.Size(), fMtime: compositeMtime}
+	if e.shouldSkipByPath(file.Path, fi) {
+		return processResult{skip: true}
+	}
+
+	results, excludedIDs, err := parser.ParseCoworkSession(
+		file.Path, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+
+	inode, device := getFileIdentity(info)
+	hash, hashErr := ComputeFileHash(file.Path)
+	for i := range results {
+		results[i].Session.File.Inode = inode
+		results[i].Session.File.Device = device
+		if hashErr == nil {
+			results[i].Session.File.Hash = hash
+		}
+	}
+
+	return processResult{
+		results:            results,
+		excludedSessionIDs: excludedIDs,
 	}
 }
 
@@ -5163,10 +5238,9 @@ func (e *Engine) writeBatch(
 			continue
 		}
 
-		replaceMessages := forceReplace || pw.forceReplace || pw.needsRetry ||
-			stale || isOpenCodeFormatStorageAgent(pw.sess.Agent) ||
-			pw.sess.Agent == parser.AgentAntigravity ||
-			pw.sess.Agent == parser.AgentAntigravityCLI
+		replaceMessages := shouldReplaceFullParseMessages(
+			pw, forceReplace, stale,
+		)
 
 		update, findings := computeSignalsAndSecrets(s, msgs)
 
@@ -5272,10 +5346,9 @@ func (e *Engine) writeBatchBulk(
 		if !ok {
 			continue
 		}
-		replaceMessages := forceReplace || pw.forceReplace || pw.needsRetry ||
-			isOpenCodeFormatStorageAgent(pw.sess.Agent) ||
-			pw.sess.Agent == parser.AgentAntigravity ||
-			pw.sess.Agent == parser.AgentAntigravityCLI
+		replaceMessages := shouldReplaceFullParseMessages(
+			pw, forceReplace, false,
+		)
 		tScan := time.Now()
 		update, findings := computeSignalsAndSecrets(s, msgs)
 		e.phaseStats.ScanNanos.Add(int64(time.Since(tScan)))
@@ -5320,6 +5393,16 @@ func (e *Engine) writeBatchBulk(
 	return result.WrittenSessions,
 		result.WrittenMessages,
 		result.FailedSessions
+}
+
+func shouldReplaceFullParseMessages(
+	pw pendingWrite, forceReplace, stale bool,
+) bool {
+	return forceReplace || pw.forceReplace || pw.needsRetry || stale ||
+		pw.sess.Agent == parser.AgentCowork ||
+		isOpenCodeFormatStorageAgent(pw.sess.Agent) ||
+		pw.sess.Agent == parser.AgentAntigravity ||
+		pw.sess.Agent == parser.AgentAntigravityCLI
 }
 
 // writeIncremental appends new messages and partially updates
@@ -6188,6 +6271,13 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 			return 0
 		}
 		return info.ModTime().UnixNano()
+	}
+	if def.Type == parser.AgentCowork {
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0
+		}
+		return parser.CoworkSessionMtime(path, info.ModTime().UnixNano())
 	}
 	if def.Type == parser.AgentCommandCode {
 		info, err := os.Stat(path)

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -34,6 +34,7 @@ type Watcher struct {
 	debounce time.Duration
 	excludes []string
 	roots    []string
+	shallow  []string
 	rootsMu  sync.RWMutex
 	pending  map[string]time.Time
 	mu       sync.Mutex
@@ -133,6 +134,7 @@ func isWatchResourceExhaustion(err error) bool {
 func (w *Watcher) WatchShallow(root string) bool {
 	root = filepath.Clean(root)
 	w.addRoot(root)
+	w.addShallowRoot(root)
 	return w.watcher.Add(root) == nil
 }
 
@@ -207,6 +209,9 @@ func (w *Watcher) watchIfDir(path string) (isDir bool, excluded bool) {
 	if err != nil || !info.IsDir() {
 		return false, false
 	}
+	if w.isUnderShallowRoot(path) {
+		return true, false
+	}
 	if w.shouldExclude(path) {
 		return true, true
 	}
@@ -237,6 +242,32 @@ func (w *Watcher) addRoot(root string) {
 	if !slices.Contains(w.roots, root) {
 		w.roots = append(w.roots, root)
 	}
+}
+
+func (w *Watcher) addShallowRoot(root string) {
+	w.rootsMu.Lock()
+	defer w.rootsMu.Unlock()
+	if !slices.Contains(w.shallow, root) {
+		w.shallow = append(w.shallow, root)
+	}
+}
+
+func (w *Watcher) isUnderShallowRoot(path string) bool {
+	w.rootsMu.RLock()
+	defer w.rootsMu.RUnlock()
+
+	clean := filepath.Clean(path)
+	for _, root := range w.shallow {
+		rel, err := filepath.Rel(root, clean)
+		if err != nil || rel == "." {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func (w *Watcher) shouldExclude(path string) bool {

--- a/internal/sync/watcher_test.go
+++ b/internal/sync/watcher_test.go
@@ -370,6 +370,32 @@ func TestWatcherAutoWatchesNewDirs_RespectsExcludes(t *testing.T) {
 	}
 }
 
+func TestWatcherShallowRootDoesNotAutoWatchNewDirs(t *testing.T) {
+	pathsCh := make(chan []string, 10)
+	w, err := NewWatcher(20*time.Millisecond, func(paths []string) {
+		pathsCh <- paths
+	}, nil)
+	require.NoError(t, err, "NewWatcher")
+	t.Cleanup(func() { w.Stop() })
+
+	root := t.TempDir()
+	require.True(t, w.WatchShallow(root), "WatchShallow")
+	w.Start()
+
+	localDir := filepath.Join(root, "local_session")
+	require.NoError(t, os.Mkdir(localDir, 0o755), "Mkdir(local)")
+
+	select {
+	case paths := <-pathsCh:
+		assert.Contains(t, paths, localDir,
+			"root-level create should still trigger onChange")
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for shallow root create event")
+	}
+	assert.NotContains(t, w.watcher.WatchList(), localDir,
+		"shallow root descendant should not be auto-watched")
+}
+
 func TestWatchRecursive_RootUnderExcludedAncestorStillWatchesDescendants(t *testing.T) {
 	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{"venv"})
 	require.NoError(t, err, "NewWatcher")


### PR DESCRIPTION
Adds support for indexing Claude Desktop "cowork" (local agent mode) sessions, which were previously not discovered, so their conversations and statistics never showed up in Sessions/Usage.

Fixes #639.

Claude Desktop stores cowork sessions under its local-agent-mode-sessions directories — on macOS `~/Library/Application Support/Claude/local-agent-mode-sessions/<uuid>/<uuid>`, with Linux and Windows equivalents. This adds a new `cowork` agent to the registry with its own discovery, parser, and source-file resolution, so these sessions sync into SQLite and are counted like any other agent.

What's included:

- New `cowork` agent definition in the parser registry (`internal/parser/types.go`) with the `cowork:` ID prefix and per-OS default directories (`internal/parser/cowork_paths.go`).
- Cowork session parser and discovery (`internal/parser/cowork.go`) plus tests.
- Sync engine wiring (`internal/sync/engine.go`) so cowork directories are discovered and watched.
- Frontend label so the agent renders as "Claude Cowork".

Where to look: `internal/parser/cowork.go` for the parsing and discovery logic, and the registry entry in `internal/parser/types.go`.

Limitation: the on-disk cowork format is derived from observing Claude Desktop's local-agent-mode-sessions output, so it may need updates if that format changes.
