### PR TITLE
feat(parser): add DeepSeek TUI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ agentsview auto-discovers sessions from all of these:
 | Copilot CLI        | `~/.copilot/`                                          |
 | Cortex Code        | `~/.snowflake/cortex/conversations/`                   |
 | Cursor             | `~/.cursor/projects/`                                  |
+| DeepSeek TUI       | `~/.codewhale/sessions/`, `~/.deepseek/sessions/`      |
 | Forge              | `~/.forge/`                                            |
 | Gemini CLI         | `~/.gemini/`                                           |
 | gptme              | `~/.local/share/gptme/logs/`                           |

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -611,6 +611,8 @@ func writeRootHelp(w io.Writer, root *cobra.Command) {
 	fmt.Fprintln(w, "  AMP_DIR                 Amp threads directory")
 	fmt.Fprintln(w, "  ZED_DIR                 Zed data directory")
 	fmt.Fprintln(w, "  QWEN_PROJECTS_DIR       Qwen Code projects directory")
+	fmt.Fprintln(w, "  DEEPSEEK_TUI_SESSIONS_DIR")
+	fmt.Fprintln(w, "                          DeepSeek TUI sessions directory")
 	fmt.Fprintln(w, "  QCLAW_DIR               QClaw agents directory")
 	fmt.Fprintln(w, "  WORKBUDDY_PROJECTS_DIR  WorkBuddy projects directory")
 	fmt.Fprintln(w, "  PIEBALD_DIR             Piebald data directory")

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -22,6 +22,7 @@ describe("KNOWN_AGENTS", () => {
       "vscode-copilot",
       "pi",
       "qwen",
+      "deepseek-tui",
       "openclaw",
       "qclaw",
       "iflow",
@@ -83,6 +84,9 @@ describe("agentColor", () => {
     expect(agentColor("qwen")).toBe(
       "var(--accent-cyan)",
     );
+    expect(agentColor("deepseek-tui")).toBe(
+      "var(--accent-cyan)",
+    );
     expect(agentColor("vscode-copilot")).toBe(
       "var(--accent-teal)",
     );
@@ -118,6 +122,7 @@ describe("agentLabel", () => {
     expect(agentLabel("piebald")).toBe("Piebald");
     expect(agentLabel("zed")).toBe("Zed");
     expect(agentLabel("qwen")).toBe("Qwen Code");
+    expect(agentLabel("deepseek-tui")).toBe("DeepSeek TUI");
   });
 
   it("capitalizes simple agent names", () => {

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -23,6 +23,11 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "pi", color: "var(--accent-indigo)", label: "Pi" },
   { name: "qwen", color: "var(--accent-cyan)", label: "Qwen Code" },
   {
+    name: "deepseek-tui",
+    color: "var(--accent-cyan)",
+    label: "DeepSeek TUI",
+  },
+  {
     name: "openclaw",
     color: "var(--accent-orange)",
     label: "OpenClaw",

--- a/internal/parser/deepseek_tui.go
+++ b/internal/parser/deepseek_tui.go
@@ -1,0 +1,347 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+const deepSeekTUIPrefix = "deepseek-tui:"
+
+// DiscoverDeepSeekTUISessions finds DeepSeek TUI / CodeWhale session
+// JSON documents under a sessions directory.
+func DiscoverDeepSeekTUISessions(root string) []DiscoveredFile {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+
+	files := make([]DiscoveredFile, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || !isDeepSeekTUISessionFile(entry.Name()) {
+			continue
+		}
+		files = append(files, DiscoveredFile{
+			Path:  filepath.Join(root, entry.Name()),
+			Agent: AgentDeepSeekTUI,
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// FindDeepSeekTUISourceFile locates a DeepSeek TUI / CodeWhale session
+// JSON document by raw session ID.
+func FindDeepSeekTUISourceFile(root, rawID string) string {
+	if !IsValidSessionID(rawID) {
+		return ""
+	}
+	path := filepath.Join(root, rawID+".json")
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return path
+	}
+	return ""
+}
+
+// ParseDeepSeekTUISession parses a DeepSeek TUI / CodeWhale saved
+// session JSON file.
+func ParseDeepSeekTUISession(
+	path, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if !gjson.ValidBytes(data) {
+		return nil, nil, fmt.Errorf("invalid JSON in %s", path)
+	}
+
+	root := gjson.ParseBytes(data)
+	rawID := root.Get("metadata.id").Str
+	if !IsValidSessionID(rawID) {
+		rawID = deepSeekTUISessionIDFromPath(path)
+	}
+	if rawID == "" {
+		return nil, nil, fmt.Errorf("missing or invalid id in %s", path)
+	}
+
+	metadata := root.Get("metadata")
+	workspace := metadata.Get("workspace").Str
+	project := ExtractProjectFromCwd(workspace)
+	if project == "" {
+		project = "deepseek_tui"
+	}
+	model := metadata.Get("model").Str
+
+	startedAt := parseTimestamp(metadata.Get("created_at").Str)
+	endedAt := parseTimestamp(metadata.Get("updated_at").Str)
+
+	var (
+		messages     []ParsedMessage
+		firstMessage string
+		ordinal      int
+	)
+	root.Get("messages").ForEach(func(_, msg gjson.Result) bool {
+		roleStr := msg.Get("role").Str
+		role, ok := deepSeekTUIRole(roleStr)
+		if !ok {
+			return true
+		}
+
+		ts := parseTimestamp(msg.Get("timestamp").Str)
+		if !ts.IsZero() {
+			if startedAt.IsZero() || ts.Before(startedAt) {
+				startedAt = ts
+			}
+			if ts.After(endedAt) {
+				endedAt = ts
+			}
+		}
+
+		content, thinking, hasThinking, hasToolUse, calls, results :=
+			extractDeepSeekTUIContent(msg.Get("content"))
+		if strings.TrimSpace(content) == "" && len(calls) == 0 &&
+			len(results) == 0 {
+			return true
+		}
+		if role == RoleUser && firstMessage == "" &&
+			strings.TrimSpace(content) != "" {
+			firstMessage = truncate(
+				strings.ReplaceAll(content, "\n", " "),
+				300,
+			)
+		}
+
+		msgModel := msg.Get("model").Str
+		if msgModel == "" {
+			msgModel = model
+		}
+		messages = append(messages, ParsedMessage{
+			Ordinal:       ordinal,
+			Role:          role,
+			Content:       content,
+			ThinkingText:  thinking,
+			Timestamp:     ts,
+			HasThinking:   hasThinking,
+			HasToolUse:    hasToolUse,
+			ContentLength: len(content),
+			ToolCalls:     calls,
+			ToolResults:   results,
+			Model:         msgModel,
+		})
+		ordinal++
+		return true
+	})
+
+	if len(messages) == 0 {
+		return nil, nil, nil
+	}
+
+	sessionName := metadata.Get("title").Str
+	if firstMessage == "" {
+		firstMessage = sessionName
+	}
+	userCount := 0
+	for _, msg := range messages {
+		if msg.Role == RoleUser && strings.TrimSpace(msg.Content) != "" {
+			userCount++
+		}
+	}
+
+	sess := &ParsedSession{
+		ID:               deepSeekTUIPrefix + rawID,
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentDeepSeekTUI,
+		Cwd:              workspace,
+		FirstMessage:     firstMessage,
+		SessionName:      sessionName,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(messages),
+		UserMessageCount: userCount,
+		File: FileInfo{
+			Path:  path,
+			Size:  info.Size(),
+			Mtime: info.ModTime().UnixNano(),
+		},
+	}
+	return sess, messages, nil
+}
+
+func isDeepSeekTUISessionFile(name string) bool {
+	if name == "latest.json" || name == "offline_queue.json" {
+		return false
+	}
+	stem, ok := strings.CutSuffix(name, ".json")
+	return ok && IsValidSessionID(stem)
+}
+
+func deepSeekTUISessionIDFromPath(path string) string {
+	name := filepath.Base(path)
+	stem, ok := strings.CutSuffix(name, ".json")
+	if !ok || !IsValidSessionID(stem) {
+		return ""
+	}
+	return stem
+}
+
+func deepSeekTUIRole(role string) (RoleType, bool) {
+	switch role {
+	case "user":
+		return RoleUser, true
+	case "assistant":
+		return RoleAssistant, true
+	default:
+		return "", false
+	}
+}
+
+func extractDeepSeekTUIContent(
+	content gjson.Result,
+) (string, string, bool, bool, []ParsedToolCall, []ParsedToolResult) {
+	if content.Type == gjson.String {
+		return content.Str, "", false, false, nil, nil
+	}
+	if !content.IsArray() {
+		return "", "", false, false, nil, nil
+	}
+
+	var (
+		parts         []string
+		thinkingParts []string
+		calls         []ParsedToolCall
+		results       []ParsedToolResult
+		hasThinking   bool
+		hasToolUse    bool
+	)
+	content.ForEach(func(_, block gjson.Result) bool {
+		switch block.Get("type").Str {
+		case "text":
+			if text := block.Get("text").Str; text != "" {
+				parts = append(parts, text)
+			}
+		case "thinking":
+			thinking := block.Get("thinking").Str
+			if thinking == "" {
+				thinking = block.Get("text").Str
+			}
+			if thinking != "" {
+				hasThinking = true
+				thinkingParts = append(thinkingParts, thinking)
+				parts = append(parts,
+					"[Thinking]\n"+thinking+"\n[/Thinking]")
+			}
+		case "tool_use", "server_tool_use":
+			if call, ok := deepSeekTUIToolCall(block); ok {
+				hasToolUse = true
+				calls = append(calls, call)
+				parts = append(parts, formatToolUse(block))
+			}
+		case "tool_result", "tool_search_tool_result",
+			"code_execution_tool_result":
+			if result, ok := deepSeekTUIToolResult(block); ok {
+				results = append(results, result)
+			}
+		}
+		return true
+	})
+
+	return strings.Join(parts, "\n"),
+		strings.Join(thinkingParts, "\n\n"),
+		hasThinking, hasToolUse, calls, results
+}
+
+func deepSeekTUIToolCall(block gjson.Result) (ParsedToolCall, bool) {
+	name := block.Get("name").Str
+	if name == "" {
+		name = block.Get("tool_name").Str
+	}
+	if name == "" {
+		return ParsedToolCall{}, false
+	}
+	input := block.Get("input")
+	if !input.Exists() {
+		input = block.Get("parameters")
+	}
+	return ParsedToolCall{
+		ToolUseID: block.Get("id").Str,
+		ToolName:  name,
+		Category:  NormalizeToolCategory(name),
+		InputJSON: input.Raw,
+	}, true
+}
+
+func deepSeekTUIToolResult(block gjson.Result) (ParsedToolResult, bool) {
+	toolUseID := block.Get("tool_use_id").Str
+	if toolUseID == "" {
+		toolUseID = block.Get("toolUseID").Str
+	}
+	if toolUseID == "" {
+		toolUseID = block.Get("id").Str
+	}
+	if toolUseID == "" {
+		return ParsedToolResult{}, false
+	}
+
+	content := block.Get("content")
+	if !content.Exists() {
+		content = block.Get("result")
+	}
+	if !content.Exists() {
+		content = block.Get("output")
+	}
+	raw := content.Raw
+	if raw == "" {
+		raw = `""`
+	}
+	return ParsedToolResult{
+		ToolUseID:     toolUseID,
+		ContentLength: deepSeekTUIContentLength(content),
+		ContentRaw:    raw,
+	}, true
+}
+
+func deepSeekTUIContentLength(content gjson.Result) int {
+	if content.Type == gjson.String {
+		return len(content.Str)
+	}
+	if content.IsArray() {
+		total := 0
+		content.ForEach(func(_, block gjson.Result) bool {
+			total += len(block.Get("text").Str)
+			return true
+		})
+		return total
+	}
+	if content.IsObject() {
+		for _, key := range []string{"output", "text", "content"} {
+			if text := content.Get(key).Str; text != "" {
+				return len(text)
+			}
+		}
+	}
+	if content.Raw == "" {
+		return 0
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(content.Raw), &decoded); err == nil {
+		if text, ok := decoded.(string); ok {
+			return len(text)
+		}
+	}
+	return len(content.Raw)
+}

--- a/internal/parser/deepseek_tui.go
+++ b/internal/parser/deepseek_tui.go
@@ -304,15 +304,29 @@ func deepSeekTUIToolResult(block gjson.Result) (ParsedToolResult, bool) {
 	if !content.Exists() {
 		content = block.Get("output")
 	}
-	raw := content.Raw
-	if raw == "" {
-		raw = `""`
-	}
 	return ParsedToolResult{
 		ToolUseID:     toolUseID,
 		ContentLength: deepSeekTUIContentLength(content),
-		ContentRaw:    raw,
+		ContentRaw:    deepSeekTUIResultRaw(content),
 	}, true
+}
+
+func deepSeekTUIResultRaw(content gjson.Result) string {
+	// Object results such as {"output":"..."} are not recognized by
+	// DecodeContent's object branch (which handles only the iFlow shape),
+	// so extract the known string field and store it as a plain string.
+	if content.IsObject() {
+		for _, key := range []string{"output", "text", "content"} {
+			if text := content.Get(key).Str; text != "" {
+				quoted, _ := json.Marshal(text)
+				return string(quoted)
+			}
+		}
+	}
+	if content.Raw == "" {
+		return `""`
+	}
+	return content.Raw
 }
 
 func deepSeekTUIContentLength(content gjson.Result) int {

--- a/internal/parser/deepseek_tui.go
+++ b/internal/parser/deepseek_tui.go
@@ -311,16 +311,28 @@ func deepSeekTUIToolResult(block gjson.Result) (ParsedToolResult, bool) {
 	}, true
 }
 
+// deepSeekTUIObjectText extracts the string content from an object-shaped
+// tool result such as {"output":"..."}. It reports whether a known field
+// holds a string value, treating an empty string as present so a valid
+// no-output result is not mistaken for a missing field.
+func deepSeekTUIObjectText(content gjson.Result) (string, bool) {
+	for _, key := range []string{"output", "text", "content"} {
+		if field := content.Get(key); field.Exists() &&
+			field.Type == gjson.String {
+			return field.Str, true
+		}
+	}
+	return "", false
+}
+
 func deepSeekTUIResultRaw(content gjson.Result) string {
 	// Object results such as {"output":"..."} are not recognized by
 	// DecodeContent's object branch (which handles only the iFlow shape),
 	// so extract the known string field and store it as a plain string.
 	if content.IsObject() {
-		for _, key := range []string{"output", "text", "content"} {
-			if text := content.Get(key).Str; text != "" {
-				quoted, _ := json.Marshal(text)
-				return string(quoted)
-			}
+		if text, ok := deepSeekTUIObjectText(content); ok {
+			quoted, _ := json.Marshal(text)
+			return string(quoted)
 		}
 	}
 	if content.Raw == "" {
@@ -342,10 +354,8 @@ func deepSeekTUIContentLength(content gjson.Result) int {
 		return total
 	}
 	if content.IsObject() {
-		for _, key := range []string{"output", "text", "content"} {
-			if text := content.Get(key).Str; text != "" {
-				return len(text)
-			}
+		if text, ok := deepSeekTUIObjectText(content); ok {
+			return len(text)
 		}
 	}
 	if content.Raw == "" {

--- a/internal/parser/deepseek_tui_test.go
+++ b/internal/parser/deepseek_tui_test.go
@@ -1,0 +1,144 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverDeepSeekTUISessions(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "session_b.json"), []byte(`{}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "session_a.json"), []byte(`{}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "latest.json"), []byte(`{}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "offline_queue.json"), []byte(`{}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "notes.txt"), []byte(`ignore`), 0o644))
+	checkpointDir := filepath.Join(root, "checkpoints")
+	require.NoError(t, os.MkdirAll(checkpointDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(checkpointDir, "nested.json"), []byte(`{}`), 0o644))
+
+	files := DiscoverDeepSeekTUISessions(root)
+	require.Len(t, files, 2)
+	assert.Equal(t, filepath.Join(root, "session_a.json"), files[0].Path)
+	assert.Equal(t, AgentDeepSeekTUI, files[0].Agent)
+	assert.Equal(t, filepath.Join(root, "session_b.json"), files[1].Path)
+	assert.Equal(t, AgentDeepSeekTUI, files[1].Agent)
+}
+
+func TestFindDeepSeekTUISourceFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "session_123.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{}`), 0o644))
+
+	assert.Equal(t, path, FindDeepSeekTUISourceFile(root, "session_123"))
+	assert.Empty(t, FindDeepSeekTUISourceFile(root, "missing"))
+	assert.Empty(t, FindDeepSeekTUISourceFile(root, "../session_123"))
+}
+
+func TestParseDeepSeekTUISessionBasic(t *testing.T) {
+	t.Parallel()
+
+	content := `{
+  "schema_version": 1,
+  "metadata": {
+    "id": "session_123",
+    "title": "Investigate DeepSeek TUI",
+    "created_at": "2026-06-01T10:00:00Z",
+    "updated_at": "2026-06-01T10:02:00Z",
+    "model": "deepseek-chat",
+    "workspace": "/Users/alice/code/sample-project",
+    "total_tokens": 999
+  },
+  "messages": [
+    {"role": "user", "content": "Inspect server logs", "timestamp": "2026-06-01T10:00:05Z"},
+    {"role": "assistant", "content": [{"type": "text", "text": "The server failed during startup."}], "timestamp": "2026-06-01T10:00:10Z"}
+  ]
+}`
+	path := createTestFile(t, "deepseek_tui.json", content)
+
+	sess, msgs, err := ParseDeepSeekTUISession(path, "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 2)
+
+	assert.Equal(t, "deepseek-tui:session_123", sess.ID)
+	assert.Equal(t, AgentDeepSeekTUI, sess.Agent)
+	assert.Equal(t, "local", sess.Machine)
+	assert.Equal(t, "sample_project", sess.Project)
+	assert.Equal(t, "/Users/alice/code/sample-project", sess.Cwd)
+	assert.Equal(t, "Investigate DeepSeek TUI", sess.SessionName)
+	assert.Equal(t, "Inspect server logs", sess.FirstMessage)
+	assert.Equal(t, 2, sess.MessageCount)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.False(t, sess.HasTotalOutputTokens)
+	assert.False(t, sess.HasPeakContextTokens)
+	assert.Equal(t, "2026-06-01T10:00:00Z", sess.StartedAt.Format("2006-01-02T15:04:05Z"))
+	assert.Equal(t, "2026-06-01T10:02:00Z", sess.EndedAt.Format("2006-01-02T15:04:05Z"))
+
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Inspect server logs", msgs[0].Content)
+	assert.Equal(t, "deepseek-chat", msgs[0].Model)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, "The server failed during startup.", msgs[1].Content)
+}
+
+func TestParseDeepSeekTUISessionToolUseAndThinking(t *testing.T) {
+	t.Parallel()
+
+	content := `{
+  "metadata": {"id": "session_tools", "workspace": "/repo"},
+  "messages": [
+    {"role": "user", "content": [{"type": "text", "text": "Read the file"}]},
+    {"role": "assistant", "content": [
+      {"type": "thinking", "thinking": "Need to inspect the target."},
+      {"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {"file_path": "main.go"}}
+    ]},
+    {"role": "user", "content": [
+      {"type": "tool_result", "tool_use_id": "toolu_1", "content": "package main"}
+    ]},
+    {"role": "assistant", "content": [{"type": "text", "text": "It is a Go file."}]}
+  ]
+}`
+	path := createTestFile(t, "deepseek_tui_tools.json", content)
+
+	sess, msgs, err := ParseDeepSeekTUISession(path, "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 4)
+
+	assert.True(t, msgs[1].HasThinking)
+	assert.Equal(t, "Need to inspect the target.", msgs[1].ThinkingText)
+	assert.Contains(t, msgs[1].Content, "[Thinking]")
+	assert.True(t, msgs[1].HasToolUse)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "toolu_1", msgs[1].ToolCalls[0].ToolUseID)
+	assert.Equal(t, "Read", msgs[1].ToolCalls[0].ToolName)
+	assert.Equal(t, "Read", msgs[1].ToolCalls[0].Category)
+	assert.JSONEq(t, `{"file_path":"main.go"}`, msgs[1].ToolCalls[0].InputJSON)
+
+	require.Len(t, msgs[2].ToolResults, 1)
+	assert.Equal(t, "toolu_1", msgs[2].ToolResults[0].ToolUseID)
+	assert.Equal(t, len("package main"), msgs[2].ToolResults[0].ContentLength)
+	assert.Equal(t, "package main", DecodeContent(msgs[2].ToolResults[0].ContentRaw))
+}
+
+func TestParseDeepSeekTUISessionSkipsEmpty(t *testing.T) {
+	t.Parallel()
+
+	path := createTestFile(t, "deepseek_tui_empty.json", `{
+  "metadata": {"id": "empty_session"},
+  "messages": []
+}`)
+
+	sess, msgs, err := ParseDeepSeekTUISession(path, "local")
+	require.NoError(t, err)
+	assert.Nil(t, sess)
+	assert.Nil(t, msgs)
+}

--- a/internal/parser/deepseek_tui_test.go
+++ b/internal/parser/deepseek_tui_test.go
@@ -129,6 +129,33 @@ func TestParseDeepSeekTUISessionToolUseAndThinking(t *testing.T) {
 	assert.Equal(t, "package main", DecodeContent(msgs[2].ToolResults[0].ContentRaw))
 }
 
+func TestParseDeepSeekTUISessionObjectToolResult(t *testing.T) {
+	t.Parallel()
+
+	content := `{
+  "metadata": {"id": "session_obj", "workspace": "/repo"},
+  "messages": [
+    {"role": "user", "content": [{"type": "text", "text": "Run it"}]},
+    {"role": "assistant", "content": [
+      {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "ls"}}
+    ]},
+    {"role": "user", "content": [
+      {"type": "tool_result", "tool_use_id": "toolu_1", "content": {"output": "file1.go\nfile2.go"}}
+    ]}
+  ]
+}`
+	path := createTestFile(t, "deepseek_tui_obj.json", content)
+
+	_, msgs, err := ParseDeepSeekTUISession(path, "local")
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+
+	require.Len(t, msgs[2].ToolResults, 1)
+	result := msgs[2].ToolResults[0]
+	assert.Equal(t, len("file1.go\nfile2.go"), result.ContentLength)
+	assert.Equal(t, "file1.go\nfile2.go", DecodeContent(result.ContentRaw))
+}
+
 func TestParseDeepSeekTUISessionSkipsEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/deepseek_tui_test.go
+++ b/internal/parser/deepseek_tui_test.go
@@ -156,6 +156,33 @@ func TestParseDeepSeekTUISessionObjectToolResult(t *testing.T) {
 	assert.Equal(t, "file1.go\nfile2.go", DecodeContent(result.ContentRaw))
 }
 
+func TestParseDeepSeekTUISessionEmptyObjectToolResult(t *testing.T) {
+	t.Parallel()
+
+	content := `{
+  "metadata": {"id": "session_empty_obj", "workspace": "/repo"},
+  "messages": [
+    {"role": "user", "content": [{"type": "text", "text": "Run it"}]},
+    {"role": "assistant", "content": [
+      {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "true"}}
+    ]},
+    {"role": "user", "content": [
+      {"type": "tool_result", "tool_use_id": "toolu_1", "content": {"output": ""}}
+    ]}
+  ]
+}`
+	path := createTestFile(t, "deepseek_tui_empty_obj.json", content)
+
+	_, msgs, err := ParseDeepSeekTUISession(path, "local")
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+
+	require.Len(t, msgs[2].ToolResults, 1)
+	result := msgs[2].ToolResults[0]
+	assert.Equal(t, 0, result.ContentLength)
+	assert.Empty(t, DecodeContent(result.ContentRaw))
+}
+
 func TestParseDeepSeekTUISessionSkipsEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -24,6 +24,7 @@ const (
 	AgentPi             AgentType = "pi"
 	AgentQwen           AgentType = "qwen"
 	AgentCommandCode    AgentType = "commandcode"
+	AgentDeepSeekTUI    AgentType = "deepseek-tui"
 	AgentOpenClaw       AgentType = "openclaw"
 	AgentQClaw          AgentType = "qclaw"
 	AgentKimi           AgentType = "kimi"
@@ -256,6 +257,20 @@ var Registry = []AgentDef{
 		FindSourceFunc: FindCommandCodeSourceFile,
 	},
 	{
+		Type:        AgentDeepSeekTUI,
+		DisplayName: "DeepSeek TUI",
+		EnvVar:      "DEEPSEEK_TUI_SESSIONS_DIR",
+		ConfigKey:   "deepseek_tui_sessions_dirs",
+		DefaultDirs: []string{
+			".codewhale/sessions",
+			".deepseek/sessions",
+		},
+		IDPrefix:       "deepseek-tui:",
+		FileBased:      true,
+		DiscoverFunc:   DiscoverDeepSeekTUISessions,
+		FindSourceFunc: FindDeepSeekTUISourceFile,
+	},
+	{
 		Type:        AgentOpenClaw,
 		DisplayName: "OpenClaw",
 		EnvVar:      "OPENCLAW_DIR",
@@ -459,14 +474,14 @@ var Registry = []AgentDef{
 		FindSourceFunc: FindAntigravityCLISourceFile,
 	},
 	{
-		Type:        AgentGptme,
-		DisplayName: "gptme",
-		EnvVar:      "GPTME_DIR",
-		ConfigKey:   "gptme_dirs",
-		DefaultDirs: []string{".local/share/gptme/logs"},
-		IDPrefix:    "gptme:",
-		FileBased:   true,
-		DiscoverFunc: DiscoverGptmeSessions,
+		Type:           AgentGptme,
+		DisplayName:    "gptme",
+		EnvVar:         "GPTME_DIR",
+		ConfigKey:      "gptme_dirs",
+		DefaultDirs:    []string{".local/share/gptme/logs"},
+		IDPrefix:       "gptme:",
+		FileBased:      true,
+		DiscoverFunc:   DiscoverGptmeSessions,
 		FindSourceFunc: FindGptmeSourceFile,
 	},
 }

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -144,6 +144,7 @@ func TestAgentByType(t *testing.T) {
 		{AgentAmp, true},
 		{AgentVSCodeCopilot, true},
 		{AgentPi, true},
+		{AgentDeepSeekTUI, true},
 		{"unknown", false},
 	}
 	for _, tt := range tests {
@@ -229,6 +230,18 @@ func TestAgentByPrefix(t *testing.T) {
 			true,
 		},
 		{
+			"deepseek tui prefix",
+			"deepseek-tui:sess-id",
+			AgentDeepSeekTUI,
+			true,
+		},
+		{
+			"remote deepseek tui prefix",
+			"devbox~deepseek-tui:sess-id",
+			AgentDeepSeekTUI,
+			true,
+		},
+		{
 			"unknown prefix",
 			"future:sess-id",
 			"",
@@ -267,6 +280,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentPi,
 		AgentQwen,
 		AgentCommandCode,
+		AgentDeepSeekTUI,
 		AgentOpenClaw,
 		AgentQClaw,
 		AgentKimi,
@@ -439,6 +453,19 @@ func TestCommandCodeRegistryEntry(t *testing.T) {
 	require.NotNil(t, def.FindSourceFunc, "Command Code FindSourceFunc")
 	assert.Equal(t, []string{".commandcode/projects"}, def.DefaultDirs)
 	assert.Equal(t, "commandcode:", def.IDPrefix)
+}
+
+func TestDeepSeekTUIRegistryEntry(t *testing.T) {
+	def, ok := AgentByType(AgentDeepSeekTUI)
+	require.True(t, ok, "AgentDeepSeekTUI missing from Registry")
+	require.True(t, def.FileBased, "DeepSeek TUI FileBased")
+	require.NotNil(t, def.DiscoverFunc, "DeepSeek TUI DiscoverFunc")
+	require.NotNil(t, def.FindSourceFunc, "DeepSeek TUI FindSourceFunc")
+	assert.Equal(t, "DeepSeek TUI", def.DisplayName)
+	assert.Equal(t, "DEEPSEEK_TUI_SESSIONS_DIR", def.EnvVar)
+	assert.Equal(t, "deepseek_tui_sessions_dirs", def.ConfigKey)
+	assert.Equal(t, []string{".codewhale/sessions", ".deepseek/sessions"}, def.DefaultDirs)
+	assert.Equal(t, "deepseek-tui:", def.IDPrefix)
 }
 
 func TestResolveOpenCodeSourcePrefersStorage(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -783,6 +783,30 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
+	// DeepSeek TUI / CodeWhale: <sessionsDir>/<session>.json
+	for _, dsDir := range e.agentDirs[parser.AgentDeepSeekTUI] {
+		if dsDir == "" {
+			continue
+		}
+		if rel, ok := isUnder(dsDir, path); ok {
+			if strings.Count(rel, sep) != 0 {
+				continue
+			}
+			name := filepath.Base(rel)
+			if name == "latest.json" || name == "offline_queue.json" {
+				continue
+			}
+			sessionID, ok := strings.CutSuffix(name, ".json")
+			if !ok || !parser.IsValidSessionID(sessionID) {
+				continue
+			}
+			return parser.DiscoveredFile{
+				Path:  path,
+				Agent: parser.AgentDeepSeekTUI,
+			}, true
+		}
+	}
+
 	// Zencoder: <zencoderDir>/<uuid>.jsonl
 	for _, zenDir := range e.agentDirs[parser.AgentZencoder] {
 		if zenDir == "" {
@@ -3182,6 +3206,8 @@ func (e *Engine) processFile(
 		res = e.processIflow(ctx, file, info)
 	case parser.AgentAmp:
 		res = e.processAmp(file, info)
+	case parser.AgentDeepSeekTUI:
+		res = e.processDeepSeekTUI(file, info)
 	case parser.AgentZencoder:
 		res = e.processZencoder(file, info)
 	case parser.AgentVSCodeCopilot:
@@ -4002,6 +4028,38 @@ func (e *Engine) processAmp(
 	if err == nil {
 		sess.File.Hash = hash
 	}
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: *sess, Messages: msgs},
+		},
+	}
+}
+
+func (e *Engine) processDeepSeekTUI(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	if e.shouldSkipByPath(file.Path, info) {
+		return processResult{skip: true}
+	}
+
+	sess, msgs, err := parser.ParseDeepSeekTUISession(
+		file.Path, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
+	}
+
+	hash, err := ComputeFileHash(file.Path)
+	if err == nil {
+		sess.File.Hash = hash
+	}
+	inode, device := getFileIdentity(info)
+	sess.File.Inode = inode
+	sess.File.Device = device
 
 	return processResult{
 		results: []parser.ParseResult{

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1795,6 +1795,40 @@ func TestEngine_ClassifyPathsQwenSession(t *testing.T) {
 	assert.Empty(t, got, "expected no Qwen classifications for %v, got %v", bogus, got)
 }
 
+func TestEngine_ClassifyPathsDeepSeekTUISession(t *testing.T) {
+	db := openTestDB(t)
+	deepSeekDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentDeepSeekTUI: {deepSeekDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "adc026b4-c620-43e4-8cc4-295593889d18"
+	sessionPath := filepath.Join(deepSeekDir, sessionID+".json")
+	dbtest.WriteTestFile(t, sessionPath, []byte("{}"))
+
+	files := engine.classifyPaths([]string{sessionPath})
+	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
+	assert.Equal(t, sessionPath, files[0].Path)
+	assert.Equal(t, parser.AgentDeepSeekTUI, files[0].Agent)
+
+	bogus := []string{
+		filepath.Join(deepSeekDir, "stray.jsonl"),
+		filepath.Join(deepSeekDir, "latest.json"),
+		filepath.Join(deepSeekDir, "offline_queue.json"),
+		filepath.Join(deepSeekDir, "nested", sessionID+".json"),
+		filepath.Join(deepSeekDir, "..bad.json"),
+	}
+	for _, p := range bogus {
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755), "MkdirAll(%q)", p)
+		dbtest.WriteTestFile(t, p, []byte("{}"))
+	}
+	got := engine.classifyPaths(bogus)
+	assert.Empty(t, got, "expected no DeepSeek TUI classifications for %v, got %v", bogus, got)
+}
+
 func TestEngine_ClassifyPathsCommandCodeSession(t *testing.T) {
 	db := openTestDB(t)
 	commandCodeDir := t.TempDir()


### PR DESCRIPTION
### Description
This PR adds full parser and sync engine support for the open-source coding agent **DeepSeek-TUI**, as requested in #505.

### Changes
- Added `deepseek_tui.go` and its corresponding unit tests under `internal/parser/`.
- Wired the new parser into the sync engine and registered the agent type.
- Updated CLI logic and README documentation.
- All unit tests (`go test`) and linter checks (`go vet`) have passed successfully.

### Closes
Closes #505