### PR TITLE
fix: base skill analytics on message timestamps

### DIFF
--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -1800,6 +1800,25 @@ type skillUsageAccumulator struct {
 	lastUsedAt    string
 }
 
+// timestampAfter reports whether timestamp a is chronologically later
+// than b. Both are parsed as UTC timestamps so callers stay correct when
+// stores feed differing precisions (for example fractional seconds). It
+// falls back to lexical comparison only when a value cannot be parsed.
+func timestampAfter(a, b string) bool {
+	if b == "" {
+		return a != ""
+	}
+	if a == "" {
+		return false
+	}
+	ta, aok := localTime(a, time.UTC)
+	tb, bok := localTime(b, time.UTC)
+	if aok && bok {
+		return ta.After(tb)
+	}
+	return a > b
+}
+
 // BuildSkillsAnalytics folds backend-neutral skill rows into the public
 // response shape. Skill names are trimmed and empty names are ignored.
 func BuildSkillsAnalytics(rows []SkillAnalyticsRow) SkillsAnalyticsResponse {
@@ -1839,7 +1858,7 @@ func BuildSkillsAnalytics(rows []SkillAnalyticsRow) SkillsAnalyticsResponse {
 		if row.Project != "" {
 			acc.projectCounts[row.Project] += row.Count
 		}
-		if row.LastUsedAt > acc.lastUsedAt {
+		if timestampAfter(row.LastUsedAt, acc.lastUsedAt) {
 			acc.lastUsedAt = row.LastUsedAt
 		}
 		if row.Date != "" {
@@ -1930,11 +1949,15 @@ func analyticsToolsQuery(placeholders string) string {
 }
 
 func analyticsSkillsQuery(placeholders string) string {
-	return `SELECT session_id, TRIM(skill_name), COUNT(*)
-		FROM tool_calls
-		WHERE session_id IN ` + placeholders + `
-			AND TRIM(COALESCE(skill_name, '')) != ''
-		GROUP BY session_id, TRIM(skill_name)`
+	return `SELECT tc.session_id, TRIM(tc.skill_name), COUNT(*),
+			COALESCE(m.timestamp, '')
+		FROM tool_calls tc
+		LEFT JOIN messages m
+			ON m.session_id = tc.session_id AND m.id = tc.message_id
+		WHERE tc.session_id IN ` + placeholders + `
+			AND TRIM(COALESCE(tc.skill_name, '')) != ''
+		GROUP BY tc.session_id, TRIM(tc.skill_name),
+			COALESCE(m.timestamp, '')`
 }
 
 // GetAnalyticsTools returns tool usage analytics aggregated
@@ -2152,23 +2175,44 @@ func (db *DB) GetAnalyticsTools(
 	return resp, nil
 }
 
+// ResolveSkillRowTime resolves the timestamp for a single skill call and
+// applies the date and hour/day-of-week filters to it. The message
+// timestamp is authoritative; the session timestamp is used only when the
+// message has none. Because skill rows are bucketed by the call's own
+// timestamp, the date/time filters must be applied here rather than to the
+// owning session, so a session that started outside the range still
+// contributes its in-range calls and drops its out-of-range ones.
+//
+// It returns the resolved timestamp, its local date, and whether the call
+// passes the filters.
+func (f AnalyticsFilter) ResolveSkillRowTime(
+	messageTS, sessionTS string,
+) (usedTS, date string, keep bool) {
+	loc := f.location()
+	usedTS = messageTS
+	if strings.TrimSpace(usedTS) == "" {
+		usedTS = sessionTS
+	}
+	date = localDate(usedTS, loc)
+	if !inDateRange(date, f.From, f.To) {
+		return usedTS, date, false
+	}
+	if f.HasTimeFilter() {
+		t, ok := localTime(usedTS, loc)
+		if !ok || !f.matchesTimeFilter(t) {
+			return usedTS, date, false
+		}
+	}
+	return usedTS, date, true
+}
+
 // GetAnalyticsSkills returns skill usage analytics aggregated
 // from non-empty tool_calls.skill_name values.
 func (db *DB) GetAnalyticsSkills(
 	ctx context.Context, f AnalyticsFilter,
 ) (SkillsAnalyticsResponse, error) {
-	loc := f.location()
 	dateCol := "COALESCE(NULLIF(started_at, ''), created_at)"
-	where, args := f.buildWhere(dateCol)
-
-	var timeIDs map[string]bool
-	if f.HasTimeFilter() {
-		var err error
-		timeIDs, err = db.filteredSessionIDs(ctx, f)
-		if err != nil {
-			return SkillsAnalyticsResponse{}, err
-		}
-	}
+	where, args := f.buildWhereWithoutDate()
 
 	sessQ := `SELECT id, ` + dateCol + `, agent, project
 		FROM sessions WHERE ` + where
@@ -2181,7 +2225,6 @@ func (db *DB) GetAnalyticsSkills(
 	defer sessRows.Close()
 
 	type sessInfo struct {
-		date    string
 		ts      string
 		agent   string
 		project string
@@ -2197,15 +2240,7 @@ func (db *DB) GetAnalyticsSkills(
 			return SkillsAnalyticsResponse{},
 				fmt.Errorf("scanning skill session: %w", err)
 		}
-		date := localDate(ts, loc)
-		if !inDateRange(date, f.From, f.To) {
-			continue
-		}
-		if timeIDs != nil && !timeIDs[id] {
-			continue
-		}
 		sessionMap[id] = sessInfo{
-			date:    date,
 			ts:      ts,
 			agent:   agent,
 			project: project,
@@ -2235,23 +2270,29 @@ func (db *DB) GetAnalyticsSkills(
 			}
 			defer rows.Close()
 			for rows.Next() {
-				var sid, skill string
+				var sid, skill, lastTS string
 				var count int
 				if err := rows.Scan(
-					&sid, &skill, &count,
+					&sid, &skill, &count, &lastTS,
 				); err != nil {
 					return fmt.Errorf(
 						"scanning skill tool_call: %w", err,
 					)
 				}
 				info := sessionMap[sid]
+				usedTS, date, keep := f.ResolveSkillRowTime(
+					lastTS, info.ts,
+				)
+				if !keep {
+					continue
+				}
 				skillRows = append(skillRows, SkillAnalyticsRow{
 					SessionID:  sid,
 					SkillName:  skill,
 					Agent:      info.agent,
 					Project:    info.project,
-					Date:       info.date,
-					LastUsedAt: info.ts,
+					Date:       date,
+					LastUsedAt: usedTS,
 					Count:      count,
 				})
 			}

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1371,7 +1371,7 @@ func TestGetAnalyticsSkills(t *testing.T) {
 		s.Agent = "claude"
 		s.Machine = "mac"
 	})
-	sk1m1 := asstMsg("sk1", 0, "skill calls")
+	sk1m1 := asstMsgAt("sk1", 0, "skill calls", "2024-06-01T09:00:00Z")
 	sk1m1.HasToolUse = true
 	sk1m1.ToolCalls = []ToolCall{
 		{SessionID: "sk1", ToolName: "Skill", Category: "Skill", SkillName: "review-code"},
@@ -1388,7 +1388,7 @@ func TestGetAnalyticsSkills(t *testing.T) {
 		s.Agent = "codex"
 		s.Machine = "linux"
 	})
-	sk2m1 := asstMsg("sk2", 0, "skill call")
+	sk2m1 := asstMsgAt("sk2", 0, "skill call", "2024-06-02T10:00:00Z")
 	sk2m1.HasToolUse = true
 	sk2m1.ToolCalls = []ToolCall{
 		{SessionID: "sk2", ToolName: "Skill", Category: "Skill", SkillName: "review-code"},
@@ -1405,7 +1405,7 @@ func TestGetAnalyticsSkills(t *testing.T) {
 		`UPDATE sessions SET is_automated = 1 WHERE id = 'sk3'`,
 	)
 	require.NoError(t, err, "mark sk3 automated")
-	sk3m1 := asstMsg("sk3", 0, "automated skill call")
+	sk3m1 := asstMsgAt("sk3", 0, "automated skill call", "2024-06-03T11:00:00Z")
 	sk3m1.HasToolUse = true
 	sk3m1.ToolCalls = []ToolCall{
 		{SessionID: "sk3", ToolName: "Skill", Category: "Skill", SkillName: "write-tests"},
@@ -1494,16 +1494,249 @@ func TestGetAnalyticsSkills(t *testing.T) {
 	})
 }
 
+func TestGetAnalyticsSkillsUsesMessageTimestamp(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	filter := AnalyticsFilter{
+		From:     "2024-06-01",
+		To:       "2024-06-30",
+		Timezone: "UTC",
+	}
+
+	// Long-running session: starts early, uses the skill weeks later.
+	insertSession(t, d, "lr1", "alpha", func(s *Session) {
+		s.StartedAt = new("2024-06-01T09:00:00Z")
+		s.MessageCount = 1
+		s.Agent = "claude"
+	})
+	lrMsg := asstMsgAt("lr1", 0, "late skill call", "2024-06-20T15:00:00Z")
+	lrMsg.HasToolUse = true
+	lrMsg.ToolCalls = []ToolCall{
+		{SessionID: "lr1", ToolName: "Skill", Category: "Skill", SkillName: "deploy"},
+	}
+	insertMessages(t, d, lrMsg)
+
+	// Fallback session: skill-call message has no timestamp.
+	insertSession(t, d, "fb1", "beta", func(s *Session) {
+		s.StartedAt = new("2024-06-05T08:00:00Z")
+		s.MessageCount = 1
+		s.Agent = "codex"
+	})
+	fbMsg := asstMsg("fb1", 0, "skill call")
+	fbMsg.Timestamp = ""
+	fbMsg.HasToolUse = true
+	fbMsg.ToolCalls = []ToolCall{
+		{SessionID: "fb1", ToolName: "Skill", Category: "Skill", SkillName: "build"},
+	}
+	insertMessages(t, d, fbMsg)
+
+	resp, err := d.GetAnalyticsSkills(ctx, filter)
+	require.NoError(t, err, "GetAnalyticsSkills")
+	require.Len(t, resp.BySkill, 2, "BySkill")
+
+	bySkill := map[string]SkillUsage{}
+	for _, s := range resp.BySkill {
+		bySkill[s.SkillName] = s
+	}
+
+	deploy, ok := bySkill["deploy"]
+	require.True(t, ok, "deploy present")
+	assert.Equal(t, "2024-06-20T15:00:00Z", deploy.LastUsedAt,
+		"deploy LastUsedAt uses message timestamp, not session start")
+
+	build, ok := bySkill["build"]
+	require.True(t, ok, "build present")
+	assert.Equal(t, "2024-06-05T08:00:00Z", build.LastUsedAt,
+		"build LastUsedAt falls back to session timestamp")
+
+	trend := map[string]int{}
+	for _, e := range resp.Trend {
+		if e.BySkill["deploy"] > 0 {
+			trend[e.Date] += e.BySkill["deploy"]
+		}
+	}
+	assert.Equal(t, map[string]int{"2024-06-17": 1}, trend,
+		"deploy trend bucket follows message timestamp week")
+}
+
+func TestGetAnalyticsSkillsSpreadsTrendAcrossWeeks(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	filter := AnalyticsFilter{
+		From:     "2024-06-01",
+		To:       "2024-06-30",
+		Timezone: "UTC",
+	}
+
+	// One long-running session invokes the same skill in two messages
+	// that fall in different weeks. Each call must bucket into its own
+	// week, not roll up onto the latest message's week.
+	insertSession(t, d, "sp1", "alpha", func(s *Session) {
+		s.StartedAt = new("2024-06-03T09:00:00Z")
+		s.MessageCount = 2
+		s.Agent = "claude"
+	})
+	early := asstMsgAt("sp1", 0, "early skill call", "2024-06-03T09:00:00Z")
+	early.HasToolUse = true
+	early.ToolCalls = []ToolCall{
+		{SessionID: "sp1", ToolName: "Skill", Category: "Skill", SkillName: "deploy"},
+	}
+	late := asstMsgAt("sp1", 1, "late skill call", "2024-06-17T15:00:00Z")
+	late.HasToolUse = true
+	late.ToolCalls = []ToolCall{
+		{SessionID: "sp1", ToolName: "Skill", Category: "Skill", SkillName: "deploy"},
+		{SessionID: "sp1", ToolName: "Skill", Category: "Skill", SkillName: "deploy"},
+	}
+	insertMessages(t, d, early, late)
+
+	resp, err := d.GetAnalyticsSkills(ctx, filter)
+	require.NoError(t, err, "GetAnalyticsSkills")
+	require.Len(t, resp.BySkill, 1, "BySkill")
+	assert.Equal(t, 3, resp.BySkill[0].CallCount, "rolled-up CallCount")
+	assert.Equal(t, 1, resp.BySkill[0].SessionCount, "SessionCount")
+
+	trend := map[string]int{}
+	for _, e := range resp.Trend {
+		if c := e.BySkill["deploy"]; c > 0 {
+			trend[e.Date] += c
+		}
+	}
+	assert.Equal(t, map[string]int{
+		"2024-06-03": 1,
+		"2024-06-17": 2,
+	}, trend, "each call buckets into its own message-timestamp week")
+}
+
+func TestBuildSkillsAnalyticsLastUsedChronological(t *testing.T) {
+	// The fractional-second timestamp is chronologically later but
+	// lexically smaller ('.' sorts before 'Z'), so a string compare
+	// would pick the wrong value.
+	rows := []SkillAnalyticsRow{
+		{
+			SessionID: "a", SkillName: "deploy", Date: "2024-06-10",
+			LastUsedAt: "2024-06-10T09:00:00Z", Count: 1,
+		},
+		{
+			SessionID: "b", SkillName: "deploy", Date: "2024-06-10",
+			LastUsedAt: "2024-06-10T09:00:00.500Z", Count: 1,
+		},
+	}
+
+	resp := BuildSkillsAnalytics(rows)
+	require.Len(t, resp.BySkill, 1, "BySkill")
+	assert.Equal(t, "2024-06-10T09:00:00.500Z",
+		resp.BySkill[0].LastUsedAt,
+		"LastUsedAt picks the chronologically latest timestamp")
+}
+
+func TestResolveSkillRowTime(t *testing.T) {
+	hour := 10
+	monday := 0 // ISO Mon=0
+	base := func() AnalyticsFilter {
+		return AnalyticsFilter{From: "2024-06-01", To: "2024-06-30", Timezone: "UTC"}
+	}
+	tests := []struct {
+		name          string
+		f             AnalyticsFilter
+		msgTS, sessTS string
+		wantUsed      string
+		wantDate      string
+		wantKeep      bool
+	}{
+		{"in range", base(), "2024-06-10T10:00:00Z", "2024-05-01T00:00:00Z",
+			"2024-06-10T10:00:00Z", "2024-06-10", true},
+		{"before range", base(), "2024-05-31T10:00:00Z", "ignored",
+			"2024-05-31T10:00:00Z", "2024-05-31", false},
+		{"after range", base(), "2024-07-01T10:00:00Z", "ignored",
+			"2024-07-01T10:00:00Z", "2024-07-01", false},
+		{"fallback to session ts", base(), "", "2024-06-15T08:00:00Z",
+			"2024-06-15T08:00:00Z", "2024-06-15", true},
+		{"hour excludes", func() AnalyticsFilter {
+			f := base()
+			f.Hour = &hour
+			return f
+		}(), "2024-06-10T09:00:00Z", "", "2024-06-10T09:00:00Z", "2024-06-10", false},
+		{"hour includes", func() AnalyticsFilter {
+			f := base()
+			f.Hour = &hour
+			return f
+		}(), "2024-06-10T10:00:00Z", "", "2024-06-10T10:00:00Z", "2024-06-10", true},
+		{"day-of-week excludes", func() AnalyticsFilter {
+			f := base()
+			f.DayOfWeek = &monday
+			return f
+		}(), "2024-06-11T10:00:00Z", "", "2024-06-11T10:00:00Z", "2024-06-11", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			used, date, keep := tc.f.ResolveSkillRowTime(tc.msgTS, tc.sessTS)
+			assert.Equal(t, tc.wantUsed, used, "usedTS")
+			assert.Equal(t, tc.wantDate, date, "date")
+			assert.Equal(t, tc.wantKeep, keep, "keep")
+		})
+	}
+}
+
+func TestGetAnalyticsSkillsDateBoundaries(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	filter := AnalyticsFilter{From: "2024-06-01", To: "2024-06-30", Timezone: "UTC"}
+
+	// The session starts before the range and uses the skill before,
+	// inside, and after it. Only the in-range call should count.
+	insertSession(t, d, "span", "alpha", func(s *Session) {
+		s.StartedAt = new("2024-05-20T09:00:00Z")
+		s.MessageCount = 3
+		s.Agent = "claude"
+	})
+	mkCall := func(ord int, ts string) Message {
+		m := asstMsgAt("span", ord, "call", ts)
+		m.HasToolUse = true
+		m.ToolCalls = []ToolCall{
+			{SessionID: "span", ToolName: "Skill", Category: "Skill", SkillName: "deploy"},
+		}
+		return m
+	}
+	insertMessages(t, d,
+		mkCall(0, "2024-05-25T10:00:00Z"), // before From
+		mkCall(1, "2024-06-10T10:00:00Z"), // in range
+		mkCall(2, "2024-07-05T10:00:00Z"), // after To
+	)
+
+	resp, err := d.GetAnalyticsSkills(ctx, filter)
+	require.NoError(t, err, "GetAnalyticsSkills")
+	require.Len(t, resp.BySkill, 1, "BySkill")
+	assert.Equal(t, "deploy", resp.BySkill[0].SkillName)
+	assert.Equal(t, 1, resp.BySkill[0].CallCount,
+		"only the in-range call counts, even though the session started "+
+			"before the range")
+	assert.Equal(t, "2024-06-10T10:00:00Z", resp.BySkill[0].LastUsedAt)
+
+	trend := map[string]int{}
+	for _, e := range resp.Trend {
+		if c := e.BySkill["deploy"]; c > 0 {
+			trend[e.Date] += c
+		}
+	}
+	assert.Equal(t, map[string]int{"2024-06-10": 1}, trend,
+		"only the in-range week is bucketed")
+}
+
 func TestAnalyticsSkillsToolCallsQueryAggregatesInSQL(t *testing.T) {
 	q := analyticsSkillsQuery("(?,?)")
 	normalized := strings.Join(strings.Fields(strings.ToLower(q)), " ")
 
 	assert.Contains(t, normalized,
-		"select session_id, trim(skill_name), count(*)")
+		"select tc.session_id, trim(tc.skill_name), count(*), "+
+			"coalesce(m.timestamp, '')")
 	assert.Contains(t, normalized,
-		"trim(coalesce(skill_name, '')) != ''")
+		"left join messages m on m.session_id = tc.session_id "+
+			"and m.id = tc.message_id")
 	assert.Contains(t, normalized,
-		"group by session_id, trim(skill_name)")
+		"trim(coalesce(tc.skill_name, '')) != ''")
+	assert.Contains(t, normalized,
+		"group by tc.session_id, trim(tc.skill_name), "+
+			"coalesce(m.timestamp, '')")
 }
 
 func TestGetAnalyticsToolsCanceled(t *testing.T) {

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -48,8 +48,20 @@ type duckAnalyticsSession struct {
 func (s *Store) analyticsSessions(
 	ctx context.Context, f db.AnalyticsFilter,
 ) ([]duckAnalyticsSession, error) {
+	return s.analyticsSessionsFiltered(ctx, f, true, true)
+}
+
+// analyticsSessionsFiltered loads candidate sessions, optionally applying
+// the date and hour/day-of-week predicates at the session level. Skill
+// analytics passes false for both so those filters can be applied to each
+// call's own message timestamp instead.
+func (s *Store) analyticsSessionsFiltered(
+	ctx context.Context, f db.AnalyticsFilter,
+	includeDate, includeTime bool,
+) ([]duckAnalyticsSession, error) {
 	where, args := duckBuildAnalyticsWhere(
-		f, "COALESCE(s.started_at, s.created_at)", "s.", true, true)
+		f, "COALESCE(s.started_at, s.created_at)", "s.",
+		includeDate, includeTime)
 	rows, err := s.duck.QueryContext(ctx, `
 		SELECT id, project, machine, agent, first_message,
 			COALESCE(display_name, session_name) AS display_name,
@@ -1092,6 +1104,30 @@ func (s *Store) analyticsAutonomyBuckets(
 	return counts, rows.Err()
 }
 
+// duckMaxSQLVars bounds the IN-list size per query to stay well under
+// driver bind-variable limits; larger ID sets are split into chunks.
+const duckMaxSQLVars = 900
+
+func duckInPlaceholders(ids []string) (string, []any) {
+	ph := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		ph[i] = "?"
+		args[i] = id
+	}
+	return "(" + strings.Join(ph, ",") + ")", args
+}
+
+func duckQueryChunked(ids []string, fn func(chunk []string) error) error {
+	for i := 0; i < len(ids); i += duckMaxSQLVars {
+		end := min(i+duckMaxSQLVars, len(ids))
+		if err := fn(ids[i:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Store) GetAnalyticsTools(
 	ctx context.Context, f db.AnalyticsFilter,
 ) (db.ToolsAnalyticsResponse, error) {
@@ -1108,38 +1144,46 @@ func (s *Store) GetAnalyticsTools(
 	if len(ids) == 0 {
 		return db.ToolsAnalyticsResponse{}, nil
 	}
-	rows, err := s.duck.QueryContext(ctx, `
-		SELECT session_id, category FROM tool_calls`)
-	if err != nil {
-		return db.ToolsAnalyticsResponse{}, err
-	}
-	defer rows.Close()
 	cats := map[string]int{}
 	agents := map[string]map[string]int{}
 	trends := map[string]map[string]int{}
 	total := 0
-	for rows.Next() {
-		var sid, cat string
-		if err := rows.Scan(&sid, &cat); err != nil {
-			return db.ToolsAnalyticsResponse{}, err
+	err = duckQueryChunked(ids, func(chunk []string) error {
+		ph, args := duckInPlaceholders(chunk)
+		rows, qErr := s.duck.QueryContext(ctx,
+			`SELECT session_id, category, COUNT(*)
+				FROM tool_calls
+				WHERE session_id IN `+ph+`
+				GROUP BY session_id, category`, args...)
+		if qErr != nil {
+			return qErr
 		}
-		r, ok := meta[sid]
-		if !ok {
-			continue
+		defer rows.Close()
+		for rows.Next() {
+			var sid, cat string
+			var count int
+			if err := rows.Scan(&sid, &cat, &count); err != nil {
+				return err
+			}
+			r, ok := meta[sid]
+			if !ok {
+				continue
+			}
+			total += count
+			cats[cat] += count
+			if agents[r.agent] == nil {
+				agents[r.agent] = map[string]int{}
+			}
+			agents[r.agent][cat] += count
+			week := bucketAnalyticsDate(analyticsLocalDate(analyticsDateTime(r), f.Timezone), "week")
+			if trends[week] == nil {
+				trends[week] = map[string]int{}
+			}
+			trends[week][cat] += count
 		}
-		total++
-		cats[cat]++
-		if agents[r.agent] == nil {
-			agents[r.agent] = map[string]int{}
-		}
-		agents[r.agent][cat]++
-		week := bucketAnalyticsDate(analyticsLocalDate(analyticsDateTime(r), f.Timezone), "week")
-		if trends[week] == nil {
-			trends[week] = map[string]int{}
-		}
-		trends[week][cat]++
-	}
-	if err := rows.Err(); err != nil {
+		return rows.Err()
+	})
+	if err != nil {
 		return db.ToolsAnalyticsResponse{}, err
 	}
 	resp := db.ToolsAnalyticsResponse{TotalCalls: total}
@@ -1174,49 +1218,68 @@ func (s *Store) GetAnalyticsTools(
 func (s *Store) GetAnalyticsSkills(
 	ctx context.Context, f db.AnalyticsFilter,
 ) (db.SkillsAnalyticsResponse, error) {
-	sessions, err := s.analyticsSessions(ctx, f)
+	sessions, err := s.analyticsSessionsFiltered(ctx, f, false, false)
 	if err != nil {
 		return db.SkillsAnalyticsResponse{}, err
 	}
 	meta := map[string]duckAnalyticsSession{}
+	var ids []string
 	for _, r := range sessions {
 		meta[r.id] = r
+		ids = append(ids, r.id)
 	}
-	if len(meta) == 0 {
+	if len(ids) == 0 {
 		return db.BuildSkillsAnalytics(nil), nil
 	}
 
-	rows, err := s.duck.QueryContext(ctx, `
-		SELECT session_id, TRIM(COALESCE(skill_name, ''))
-		FROM tool_calls
-		WHERE TRIM(COALESCE(skill_name, '')) != ''`)
-	if err != nil {
-		return db.SkillsAnalyticsResponse{}, err
-	}
-	defer rows.Close()
-
 	var skillRows []db.SkillAnalyticsRow
-	for rows.Next() {
-		var sid, skill string
-		if err := rows.Scan(&sid, &skill); err != nil {
-			return db.SkillsAnalyticsResponse{}, err
+	err = duckQueryChunked(ids, func(chunk []string) error {
+		ph, args := duckInPlaceholders(chunk)
+		rows, qErr := s.duck.QueryContext(ctx,
+			`SELECT tc.session_id, TRIM(COALESCE(tc.skill_name, '')),
+				COUNT(*), m.timestamp
+				FROM tool_calls tc
+				LEFT JOIN messages m
+					ON m.session_id = tc.session_id
+					AND m.id = tc.message_id
+				WHERE tc.session_id IN `+ph+`
+					AND TRIM(COALESCE(tc.skill_name, '')) != ''
+				GROUP BY tc.session_id, TRIM(COALESCE(tc.skill_name, '')),
+					m.timestamp`, args...)
+		if qErr != nil {
+			return qErr
 		}
-		r, ok := meta[sid]
-		if !ok {
-			continue
+		defer rows.Close()
+		for rows.Next() {
+			var sid, skill string
+			var count int
+			var msgTS any
+			if err := rows.Scan(&sid, &skill, &count, &msgTS); err != nil {
+				return err
+			}
+			r, ok := meta[sid]
+			if !ok {
+				continue
+			}
+			usedTS, date, keep := f.ResolveSkillRowTime(
+				formatDBTime(msgTS), analyticsDateTime(r),
+			)
+			if !keep {
+				continue
+			}
+			skillRows = append(skillRows, db.SkillAnalyticsRow{
+				SessionID:  sid,
+				SkillName:  skill,
+				Agent:      r.agent,
+				Project:    r.project,
+				Date:       date,
+				LastUsedAt: usedTS,
+				Count:      count,
+			})
 		}
-		ts := analyticsDateTime(r)
-		skillRows = append(skillRows, db.SkillAnalyticsRow{
-			SessionID:  sid,
-			SkillName:  skill,
-			Agent:      r.agent,
-			Project:    r.project,
-			Date:       analyticsLocalDate(ts, f.Timezone),
-			LastUsedAt: ts,
-			Count:      1,
-		})
-	}
-	if err := rows.Err(); err != nil {
+		return rows.Err()
+	})
+	if err != nil {
 		return db.SkillsAnalyticsResponse{}, err
 	}
 	return db.BuildSkillsAnalytics(skillRows), nil

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -1747,6 +1747,123 @@ func TestGetChildSessionsOrderedByStartedAt(t *testing.T) {
 		duckSessionIDs(children))
 }
 
+// TestDuckGetAnalyticsSkillsAggregatesAcrossWeeks exercises the SQL
+// pushdown path: COUNT(*) aggregation per message timestamp and trend
+// buckets spread across the weeks a skill was actually used.
+func TestDuckGetAnalyticsSkillsAggregatesAcrossWeeks(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+
+	const sid = "dk-multi"
+	skill := func(use string) db.ToolCall {
+		return db.ToolCall{
+			ToolName: "Skill", Category: "Skill",
+			SkillName: "deploy", ToolUseID: use,
+		}
+	}
+	writes := []db.SessionBatchWrite{{
+		Session: syncSession(sid, "alpha", "first",
+			"2026-01-06T09:00:00.000Z", 3),
+		Messages: []db.Message{
+			syncMessage(sid, 0, "user", "go", "2026-01-06T09:00:00.000Z"),
+			syncMessage(sid, 1, "assistant", "two calls",
+				"2026-01-06T10:00:00.000Z",
+				skill("tu-1"), skill("tu-2")),
+			syncMessage(sid, 2, "assistant", "one call",
+				"2026-01-20T10:00:00.000Z",
+				skill("tu-3")),
+		},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}}
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+
+	syncer := newTestSync(t,
+		filepath.Join(t.TempDir(), "mirror.duckdb"), local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	resp, err := store.GetAnalyticsSkills(ctx, db.AnalyticsFilter{
+		From: "2026-01-01", To: "2026-01-31", Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetAnalyticsSkills")
+	require.Len(t, resp.BySkill, 1, "BySkill")
+	assert.Equal(t, "deploy", resp.BySkill[0].SkillName)
+	assert.Equal(t, 3, resp.BySkill[0].CallCount, "CallCount")
+	assert.Equal(t, 1, resp.BySkill[0].SessionCount, "SessionCount")
+	assert.Equal(t, "2026-01-20T10:00:00Z", resp.BySkill[0].LastUsedAt,
+		"LastUsedAt is the latest message timestamp")
+
+	trend := map[string]int{}
+	for _, e := range resp.Trend {
+		if c := e.BySkill["deploy"]; c > 0 {
+			trend[e.Date] += c
+		}
+	}
+	assert.Equal(t, map[string]int{"2026-01-05": 2, "2026-01-19": 1}, trend,
+		"calls bucket into their own message-timestamp weeks")
+}
+
+// TestDuckGetAnalyticsSkillsFiltersByMessageDate checks that the date
+// filter applies to each call's message timestamp, not the session start:
+// a session that started before the range still contributes its in-range
+// call, and its out-of-range calls are dropped.
+func TestDuckGetAnalyticsSkillsFiltersByMessageDate(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+
+	const sid = "dk-span"
+	skill := func() db.ToolCall {
+		return db.ToolCall{
+			ToolName: "Skill", Category: "Skill", SkillName: "deploy",
+		}
+	}
+	writes := []db.SessionBatchWrite{{
+		Session: syncSession(sid, "alpha", "first",
+			"2026-01-20T09:00:00.000Z", 4),
+		Messages: []db.Message{
+			syncMessage(sid, 0, "user", "go", "2026-01-20T09:00:00.000Z"),
+			syncMessage(sid, 1, "assistant", "before",
+				"2026-01-25T10:00:00.000Z", skill()),
+			syncMessage(sid, 2, "assistant", "inrange",
+				"2026-02-10T10:00:00.000Z", skill()),
+			syncMessage(sid, 3, "assistant", "after",
+				"2026-03-05T10:00:00.000Z", skill()),
+		},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}}
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+
+	syncer := newTestSync(t,
+		filepath.Join(t.TempDir(), "mirror.duckdb"), local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	resp, err := store.GetAnalyticsSkills(ctx, db.AnalyticsFilter{
+		From: "2026-02-01", To: "2026-02-28", Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetAnalyticsSkills")
+	require.Len(t, resp.BySkill, 1, "BySkill")
+	assert.Equal(t, "deploy", resp.BySkill[0].SkillName)
+	assert.Equal(t, 1, resp.BySkill[0].CallCount,
+		"only the in-range call counts")
+	assert.Equal(t, "2026-02-10T10:00:00Z", resp.BySkill[0].LastUsedAt)
+
+	trend := map[string]int{}
+	for _, e := range resp.Trend {
+		if c := e.BySkill["deploy"]; c > 0 {
+			trend[e.Date] += c
+		}
+	}
+	assert.Equal(t, map[string]int{"2026-02-09": 1}, trend,
+		"only the in-range week is bucketed")
+}
+
 func newSyncedStore(t *testing.T) (*Store, syncFixture) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -703,6 +703,81 @@ func newTestSync(
 	return syncer
 }
 
+// TestDuckGetAnalyticsSkillsIgnoresCrossSessionDuplicateIDs guards the
+// skill join: DuckDB mirrors SQLite row IDs from many machines, so
+// messages.id is not globally unique. A tool call must join only to a
+// message in its own session, not another session's row with the same id.
+func TestDuckGetAnalyticsSkillsIgnoresCrossSessionDuplicateIDs(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	syncer := newTestSync(t,
+		filepath.Join(t.TempDir(), "mirror.duckdb"), local, SyncOptions{})
+	_, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	duck := syncer.DB()
+	store := NewStoreFromDB(duck)
+
+	// Both sessions mirror a message with id 100; only sess-a has the
+	// skill call. The join must not also match sess-b's message.
+	insertDuckSkillCollision(t, duck, "sess-a", 100,
+		"2026-02-03 10:00:00", "deploy")
+	insertDuckSkillCollision(t, duck, "sess-b", 100,
+		"2026-02-25 10:00:00", "")
+
+	resp, err := store.GetAnalyticsSkills(ctx, db.AnalyticsFilter{
+		From: "2026-02-01", To: "2026-02-28", Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetAnalyticsSkills")
+	require.Len(t, resp.BySkill, 1, "BySkill")
+	assert.Equal(t, "deploy", resp.BySkill[0].SkillName)
+	assert.Equal(t, 1, resp.BySkill[0].CallCount,
+		"cross-session id collision must not double-count")
+	assert.Equal(t, "2026-02-03T10:00:00Z", resp.BySkill[0].LastUsedAt,
+		"timestamp comes from the call's own session")
+
+	trend := map[string]int{}
+	for _, e := range resp.Trend {
+		if c := e.BySkill["deploy"]; c > 0 {
+			trend[e.Date] += c
+		}
+	}
+	assert.Equal(t, map[string]int{"2026-02-02": 1}, trend,
+		"no bucket from the colliding session's message")
+}
+
+// insertDuckSkillCollision raw-inserts a session and a message with an
+// explicit (non-unique) id. A skill tool call is added only when skill
+// is non-empty.
+func insertDuckSkillCollision(
+	t *testing.T, duck *sql.DB, sessionID string, msgID int, ts, skill string,
+) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := duck.ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, project, machine, agent, message_count,
+			user_message_count, relationship_type, started_at, created_at
+		) VALUES (?, 'alpha', 'local', 'claude', 1, 1, 'root',
+			CAST(? AS TIMESTAMP), CAST(? AS TIMESTAMP))`,
+		sessionID, ts, ts)
+	require.NoError(t, err)
+	_, err = duck.ExecContext(ctx, `
+		INSERT INTO messages (id, session_id, ordinal, role, content, timestamp)
+		VALUES (?, ?, 0, 'assistant', 'msg', CAST(? AS TIMESTAMP))`,
+		msgID, sessionID, ts)
+	require.NoError(t, err)
+	if skill == "" {
+		return
+	}
+	_, err = duck.ExecContext(ctx, `
+		INSERT INTO tool_calls (
+			id, message_id, session_id, tool_name, category,
+			call_index, tool_use_id, skill_name
+		) VALUES (?, ?, ?, 'Skill', 'Skill', 0, ?, ?)`,
+		msgID, msgID, sessionID, sessionID+"-tu", skill)
+	require.NoError(t, err)
+}
+
 func insertOtherMachineDuckSession(t *testing.T, duck *sql.DB) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -1621,18 +1621,8 @@ func (s *Store) GetAnalyticsTools(
 func (s *Store) GetAnalyticsSkills(
 	ctx context.Context, f db.AnalyticsFilter,
 ) (db.SkillsAnalyticsResponse, error) {
-	loc := analyticsLocation(f)
 	pb := &paramBuilder{}
-	where := buildAnalyticsWhere(f, pgDateCol, pb)
-
-	var timeIDs map[string]bool
-	if f.HasTimeFilter() {
-		var err error
-		timeIDs, err = s.filteredSessionIDs(ctx, f)
-		if err != nil {
-			return db.SkillsAnalyticsResponse{}, err
-		}
-	}
+	where := buildAnalyticsWhereWithoutDate(f, pb)
 
 	sessQ := `SELECT id, ` + pgDateCol + `, agent, project
 		FROM sessions WHERE ` + where
@@ -1645,7 +1635,6 @@ func (s *Store) GetAnalyticsSkills(
 	defer sessRows.Close()
 
 	type sessInfo struct {
-		date    string
 		ts      string
 		agent   string
 		project string
@@ -1662,17 +1651,8 @@ func (s *Store) GetAnalyticsSkills(
 			return db.SkillsAnalyticsResponse{},
 				fmt.Errorf("scanning skill session: %w", err)
 		}
-		tsText := scanDateCol(ts)
-		date := localDate(tsText, loc)
-		if !inDateRange(date, f.From, f.To) {
-			continue
-		}
-		if timeIDs != nil && !timeIDs[id] {
-			continue
-		}
 		sessionMap[id] = sessInfo{
-			date:    date,
-			ts:      tsText,
+			ts:      scanDateCol(ts),
 			agent:   agent,
 			project: project,
 		}
@@ -1691,14 +1671,19 @@ func (s *Store) GetAnalyticsSkills(
 		func(chunk []string) error {
 			chunkPB := &paramBuilder{}
 			ph := pgInPlaceholders(chunk, chunkPB)
-			q := `SELECT session_id,
-					TRIM(COALESCE(skill_name, '')),
-					COUNT(*)
-				FROM tool_calls
-				WHERE session_id IN ` + ph + `
-					AND TRIM(COALESCE(skill_name, '')) != ''
-				GROUP BY session_id,
-					TRIM(COALESCE(skill_name, ''))`
+			q := `SELECT tc.session_id,
+					TRIM(COALESCE(tc.skill_name, '')),
+					COUNT(*),
+					m.timestamp
+				FROM tool_calls tc
+				LEFT JOIN messages m
+					ON m.session_id = tc.session_id
+					AND m.ordinal = tc.message_ordinal
+				WHERE tc.session_id IN ` + ph + `
+					AND TRIM(COALESCE(tc.skill_name, '')) != ''
+				GROUP BY tc.session_id,
+					TRIM(COALESCE(tc.skill_name, '')),
+					m.timestamp`
 			rows, qErr := s.pg.QueryContext(
 				ctx, q, chunkPB.args...,
 			)
@@ -1711,21 +1696,28 @@ func (s *Store) GetAnalyticsSkills(
 			for rows.Next() {
 				var sid, skill string
 				var count int
+				var lastTS *time.Time
 				if err := rows.Scan(
-					&sid, &skill, &count,
+					&sid, &skill, &count, &lastTS,
 				); err != nil {
 					return fmt.Errorf(
 						"scanning skill tool_call: %w", err,
 					)
 				}
 				info := sessionMap[sid]
+				usedTS, date, keep := f.ResolveSkillRowTime(
+					scanDateCol(lastTS), info.ts,
+				)
+				if !keep {
+					continue
+				}
 				skillRows = append(skillRows, db.SkillAnalyticsRow{
 					SessionID:  sid,
 					SkillName:  skill,
 					Agent:      info.agent,
 					Project:    info.project,
-					Date:       info.date,
-					LastUsedAt: info.ts,
+					Date:       date,
+					LastUsedAt: usedTS,
 					Count:      count,
 				})
 			}

--- a/internal/postgres/analytics_unit_test.go
+++ b/internal/postgres/analytics_unit_test.go
@@ -107,16 +107,29 @@ func (c *analyticsProbeConn) QueryContext(
 			},
 		}, nil
 	case strings.Contains(normalized, "from tool_calls"):
-		if strings.Contains(normalized, "trim(coalesce(skill_name") {
-			if !strings.Contains(normalized, "group by session_id") ||
-				!strings.Contains(normalized, "trim(coalesce(skill_name") {
-				return nil, errors.New("skill query must group by session_id and skill_name")
+		if strings.Contains(normalized, "trim(coalesce(tc.skill_name") {
+			if !strings.Contains(normalized, "group by tc.session_id") ||
+				!strings.Contains(normalized, "m.timestamp") {
+				return nil, errors.New(
+					"skill query must group by session, skill, and message timestamp")
+			}
+			if !strings.Contains(normalized, "left join messages") {
+				return nil, errors.New("skill query must join messages")
+			}
+			if strings.Contains(normalized, "to_char(m.timestamp") {
+				return nil, errors.New(
+					"skill query must scan native message timestamps")
 			}
 			return &analyticsProbeRows{
-				columns: []string{"session_id", "skill_name", "count"},
+				columns: []string{
+					"session_id", "skill_name", "count", "last_used_at",
+				},
 				values: [][]driver.Value{
-					{"s1", "review-code", int64(2)},
-					{"s2", "review-code", int64(1)},
+					{
+						"s1", "review-code", int64(2),
+						time.Date(2024, 6, 3, 12, 30, 0, 0, time.UTC),
+					},
+					{"s2", "review-code", int64(1), nil},
 				},
 			}, nil
 		}
@@ -219,6 +232,9 @@ func TestGetAnalyticsSkillsAggregatesToolCallsInSQL(t *testing.T) {
 		{Project: "alpha", Count: 2},
 		{Project: "beta", Count: 1},
 	}, resp.BySkill[0].ProjectBreakdown)
+	assert.Equal(t, "2024-06-04T09:00:00Z", resp.BySkill[0].LastUsedAt,
+		"LastUsedAt is the latest message timestamp, "+
+			"with session fallback for null timestamps")
 }
 
 func TestQueryVelocityMsgsScansNativeTimestamps(t *testing.T) {

--- a/internal/server/analytics_test.go
+++ b/internal/server/analytics_test.go
@@ -71,6 +71,9 @@ func seedAnalyticsEnv(t *testing.T, te *testEnv) seedStats {
 		)
 		te.seedMessages(t, s.id, s.msgs,
 			func(i int, m *db.Message) {
+				// Skill analytics now buckets and filters by message
+				// timestamp, so align messages with the session window.
+				m.Timestamp = started
 				// Add tool calls on every other assistant msg
 				if m.Role == "assistant" && i%4 == 1 {
 					m.HasToolUse = true


### PR DESCRIPTION
Skill usage analytics is new in 0.34.0 and hasn't shipped yet, so this
refines it before release rather than changing released behavior.

The initial implementation derived `last_used_at` and the weekly trend from
each session's start timestamp, and the DuckDB backend used a different query
shape than SQLite/PostgreSQL. This corrects both:

- `last_used_at` and trend buckets now come from the timestamp of the message
  that invoked the skill, falling back to the session timestamp only when a
  message has none.
- Each call buckets into its own week, so a skill used across several weeks of
  a long session contributes to each week instead of collapsing onto the
  latest one.
- `last_used_at` is compared chronologically, so timestamps stored at differing
  precisions across backends resolve correctly.
- DuckDB now pushes the session filter and grouping into SQL for both the skill
  and tool queries, matching the SQLite and PostgreSQL query shape instead of
  scanning all tool calls and folding them in Go. Closes #710.

Behavior is identical across the SQLite, PostgreSQL, and DuckDB backends.

## Where to review

- `internal/db/analytics.go` — response shape, `BuildSkillsAnalytics`,
  `timestampAfter`, and the SQLite query
- `internal/postgres/analytics.go` and `internal/duckdb/analytics_usage.go` —
  the other two backends
