### PR TITLE
feat: infer skill names from SKILL.md reads

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -208,9 +208,18 @@ import (
 // user message in the sidebar instead of the command text.
 // Re-parsing rewrites first_message with the new logic.)
 //
+// (46: Cursor and Codex parsers now infer skill_name from
+// read-like SKILL.md tool calls. Covers Read/ReadFile tool
+// calls and Codex/Cursor shell reads across the Cursor JSONL
+// and plain-text transcript paths, with ~ expansion, relative
+// paths resolved against the tool-call workdir or session cwd,
+// glob/space handling, and grep/rg pattern-vs-file
+// classification, so historical skill usage is backfilled on
+// re-parse.)
+//
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 45
+const dataVersion = 46
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -588,9 +588,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionCodexTitle(t *testing.T) {
-	assert.Equal(t, 45, CurrentDataVersion(),
-		"Codex session_index.jsonl title import requires a data version bump")
+func TestCurrentDataVersionSkillInference(t *testing.T) {
+	assert.Equal(t, 46, CurrentDataVersion(),
+		"Cursor/Codex skill_name inference requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -55,6 +55,7 @@ type codexSessionBuilder struct {
 	startedAt                time.Time
 	endedAt                  time.Time
 	sessionID                string
+	cwd                      string // session working dir from meta
 	project                  string
 	ordinal                  int
 	currentModel             string
@@ -242,6 +243,7 @@ func (b *codexSessionBuilder) handleSessionMeta(
 	b.sessionID = payload.Get("id").Str
 
 	if cwd := payload.Get("cwd").Str; cwd != "" {
+		b.cwd = cwd
 		branch := payload.Get("git.branch").Str
 		if proj := ExtractProjectFromCwdWithBranch(cwd, branch); proj != "" {
 			b.project = proj
@@ -437,6 +439,7 @@ func (b *codexSessionBuilder) handleFunctionCall(
 
 	content := formatCodexFunctionCall(name, payload)
 	inputJSON := extractCodexInputJSON(payload)
+	skillName := inferCodexSkillNameWithBase(name, inputJSON, b.cwd)
 	waitAgentIDs := []string(nil)
 	if isCodexWaitAgentCall(name) && callID != "" {
 		args, _ := parseCodexFunctionArgs(payload)
@@ -456,6 +459,7 @@ func (b *codexSessionBuilder) handleFunctionCall(
 			ToolName:  name,
 			Category:  NormalizeToolCategory(name),
 			InputJSON: inputJSON,
+			SkillName: skillName,
 		}},
 	})
 	if callID != "" {
@@ -1517,6 +1521,7 @@ func classifyCodexTermination(lastTaskEvent string) TerminationStatus {
 // dedup state, and the fork replay gate (#643).
 type codexIncrementalSeed struct {
 	model                    string
+	cwd                      string
 	firstUserContent         string
 	sawUserTurnAfterFirst    bool
 	mayReplayFirstUserPrompt bool
@@ -1554,9 +1559,12 @@ func seedCodexIncrementalState(
 		payload := gjson.Get(line, "payload")
 		if lineType == codexTypeSessionMeta {
 			// Mirror processLine: the fork's own meta arms the
-			// gate, and replayed parent metas are dropped while
-			// it is active.
+			// gate and supplies cwd, and replayed parent metas are
+			// dropped while it is active.
 			if !seed.forkGate.active {
+				if cwd := payload.Get("cwd").Str; cwd != "" {
+					seed.cwd = cwd
+				}
 				seed.forkGate.armFromMeta(
 					payload,
 					parseTimestamp(gjson.Get(line, "timestamp").Str),
@@ -1639,6 +1647,7 @@ func ParseCodexSessionFrom(
 	// just as a full parse would.
 	seed := seedCodexIncrementalState(path, offset)
 	b.currentModel = seed.model
+	b.cwd = seed.cwd
 	b.firstUserContent = seed.firstUserContent
 	b.sawUserTurnAfterFirst = seed.sawUserTurnAfterFirst
 	b.mayReplayFirstUserPrompt = seed.mayReplayFirstUserPrompt

--- a/internal/parser/content.go
+++ b/internal/parser/content.go
@@ -66,6 +66,11 @@ func ExtractTextContent(
 					if tc.SkillName == "" {
 						tc.SkillName = block.Get("input.name").Str
 					}
+				default:
+					tc.SkillName = inferToolSkillName(
+						name,
+						tc.InputJSON,
+					)
 				}
 				toolCalls = append(toolCalls, tc)
 			}

--- a/internal/parser/cursor.go
+++ b/internal/parser/cursor.go
@@ -247,12 +247,17 @@ func extractAssistantContent(
 				}
 				i++
 			}
+			inputJSON := cursorToolInputJSON(
+				toolName,
+				lines[bodyStart:i],
+			)
 			toolCalls = append(toolCalls, ParsedToolCall{
-				ToolName: toolName,
-				Category: NormalizeToolCategory(toolName),
-				InputJSON: cursorToolInputJSON(
+				ToolName:  toolName,
+				Category:  NormalizeToolCategory(toolName),
+				InputJSON: inputJSON,
+				SkillName: inferToolSkillName(
 					toolName,
-					lines[bodyStart:i],
+					inputJSON,
 				),
 			})
 			continue

--- a/internal/parser/skill_inference.go
+++ b/internal/parser/skill_inference.go
@@ -19,10 +19,9 @@ import (
 const maxSkillFrontmatterSize = 64 << 10
 
 var (
-	skillNameByPath  sync.Map
-	skillPathRE      = regexp.MustCompile(`(?:"([^"]*[/\\]SKILL\.md)"|'([^']*[/\\]SKILL\.md)'|(\S*[/\\]SKILL\.md)|(?:^|[\s"'])(SKILL\.md))`)
-	shellSegmentRE   = regexp.MustCompile(`\s*(?:&&|\|\||;|&|\|)\s*`)
-	outputRedirectRE = regexp.MustCompile(`^[0-9&]*>>?$`)
+	skillNameByPath sync.Map
+	skillPathRE     = regexp.MustCompile(`(?:"([^"]*[/\\]SKILL\.md)"|'([^']*[/\\]SKILL\.md)'|(\S*[/\\]SKILL\.md)|(?:^|[\s"'])(SKILL\.md))`)
+	shellSegmentRE  = regexp.MustCompile(`\s*(?:&&|\|\||;|&|\|)\s*`)
 )
 
 // searchValueFlags lists grep/rg flags (short and long) that consume
@@ -100,7 +99,7 @@ func skillPathsFromSegment(seg string) []string {
 	if len(tokens) == 0 {
 		return nil
 	}
-	args := stripRedirects(tokens[1:])
+	args := tokens[1:]
 	switch commandVerb(tokens[0]) {
 	case "grep", "rg":
 		return skillPathsFromSearchArgs(args)
@@ -119,31 +118,24 @@ func skillPathsFromSegment(seg string) []string {
 }
 
 // sedWritesInPlace reports whether a sed invocation edits its file
-// operands in place via -i (optionally with a backup suffix, e.g.
-// -i.bak) or --in-place, which makes a SKILL.md operand a write target.
+// operands in place, which makes a SKILL.md operand a write target. It
+// matches --in-place[=suffix] and any single-dash short-flag cluster
+// containing -i, whether alone (-i, -i.bak) or combined with other
+// flags (-ni, -Ei); i is the only sed short option named i, so its
+// presence in a short cluster always means in-place editing.
 func sedWritesInPlace(args []string) bool {
 	for _, arg := range args {
-		if strings.HasPrefix(arg, "-i") || strings.HasPrefix(arg, "--in-place") {
+		switch {
+		case strings.HasPrefix(arg, "--in-place"):
+			return true
+		case strings.HasPrefix(arg, "--"):
+			// Some other long option (e.g. --posix); not in-place even
+			// though its name may contain the letter i.
+		case strings.HasPrefix(arg, "-") && strings.ContainsRune(arg, 'i'):
 			return true
 		}
 	}
 	return false
-}
-
-// stripRedirects drops output-redirection operators (>, >>, 2>, &>,
-// ...) together with their target token, so a redirect destination
-// such as the SKILL.md in `cat foo > SKILL.md` is written, not read,
-// and is never collected as a file operand.
-func stripRedirects(args []string) []string {
-	var out []string
-	for i := 0; i < len(args); i++ {
-		if outputRedirectRE.MatchString(args[i]) {
-			i++ // also skip the redirect target token
-			continue
-		}
-		out = append(out, args[i])
-	}
-	return out
 }
 
 // tokenizeCommand splits a command segment into tokens on unquoted
@@ -151,17 +143,29 @@ func stripRedirects(args []string) []string {
 // stays one token (e.g. the multi-word pattern in `grep "a b" f`).
 // Unlike a full shell lexer it treats backslash literally, preserving
 // Windows paths such as C:\skills\foo\SKILL.md.
+//
+// An unquoted output redirection (>, >>, 2>, ...) is dropped together
+// with its target token, because that target is written, not read.
+// Doing this during tokenization, rather than over the token slice
+// afterward, is what keeps a quoted ">" (a literal search pattern) from
+// being mistaken for a redirect operator once the quotes are stripped.
 func tokenizeCommand(seg string) []string {
 	var tokens []string
 	var cur strings.Builder
 	inToken := false
+	skipNext := false
 	var quote rune
 	flush := func() {
-		if inToken {
-			tokens = append(tokens, cur.String())
-			cur.Reset()
-			inToken = false
+		if !inToken {
+			return
 		}
+		if skipNext {
+			skipNext = false
+		} else {
+			tokens = append(tokens, cur.String())
+		}
+		cur.Reset()
+		inToken = false
 	}
 	for _, r := range seg {
 		switch {
@@ -176,6 +180,11 @@ func tokenizeCommand(seg string) []string {
 			inToken = true
 		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
 			flush()
+		case r == '>':
+			// Unquoted '>' starts an output redirect: emit any preceding
+			// source token, then drop the redirect target that follows.
+			flush()
+			skipNext = true
 		default:
 			cur.WriteRune(r)
 			inToken = true

--- a/internal/parser/skill_inference.go
+++ b/internal/parser/skill_inference.go
@@ -1,0 +1,504 @@
+package parser
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/tidwall/gjson"
+)
+
+// maxSkillFrontmatterSize bounds how much of a SKILL.md file is
+// read when extracting the frontmatter name. Frontmatter sits at
+// the top of the file and is tiny; the cap protects against a
+// transcript pointing at a device or very large file.
+const maxSkillFrontmatterSize = 64 << 10
+
+var (
+	skillNameByPath sync.Map
+	skillPathRE     = regexp.MustCompile(`(?:"([^"]*[/\\]SKILL\.md)"|'([^']*[/\\]SKILL\.md)'|(\S*[/\\]SKILL\.md)|(?:^|[\s"'])(SKILL\.md))`)
+	readCommandRE   = regexp.MustCompile(`(?:^|(?:&&|\|\||[;&|])\s*)(?:[A-Za-z0-9_.-]+/)?(?:cat|sed|head|tail|less|more|rg|grep)\b`)
+	writeCommandRE  = regexp.MustCompile(`(?:^|(?:&&|\|\||[;&|])\s*)(?:[A-Za-z0-9_.-]+/)?(?:cp|mv|mkdir|touch|rm|chmod|chown|install|tee)\b|\bgit\s+(?:add|mv|rm)\b|\bsed\s+-i\b|>\s*["']?[^"'\s]*[/\\]SKILL\.md\b`)
+	shellSegmentRE  = regexp.MustCompile(`\s*(?:&&|\|\||;|&|\|)\s*`)
+)
+
+// searchValueFlags lists grep/rg flags (short and long) that consume
+// the following token as their value, so it is neither the search
+// pattern nor a file operand.
+var searchValueFlags = map[string]bool{
+	"-A": true, "-B": true, "-C": true, "-m": true, "-d": true,
+	"-e": true, "-f": true, "-g": true, "-t": true, "-T": true,
+	"--after-context": true, "--before-context": true, "--context": true,
+	"--max-count": true, "--max-depth": true, "--regexp": true,
+	"--file": true, "--glob": true, "--type": true, "--type-not": true,
+}
+
+// inferToolSkillName infers a skill name for an assistant tool
+// call by trying the read-file heuristic first, then the shell
+// read-command heuristic. Used by both the Cursor JSONL and
+// plain-text transcript paths so they stay in sync.
+func inferToolSkillName(toolName, inputJSON string) string {
+	if name := inferCursorSkillName(toolName, inputJSON); name != "" {
+		return name
+	}
+	return inferCodexSkillName(toolName, inputJSON)
+}
+
+func inferCursorSkillName(toolName, inputJSON string) string {
+	if !isCursorSkillReadTool(toolName) {
+		return ""
+	}
+	return inferSkillNameFromJSONPaths(inputJSON)
+}
+
+func inferCodexSkillName(toolName, inputJSON string) string {
+	return inferCodexSkillNameWithBase(toolName, inputJSON, "")
+}
+
+// inferCodexSkillNameWithBase infers a Codex skill name, resolving
+// relative SKILL.md paths against the tool call's own workdir/cwd
+// hint when present, otherwise against fallbackBaseDir (typically
+// the session working directory from session_meta).
+func inferCodexSkillNameWithBase(toolName, inputJSON, fallbackBaseDir string) string {
+	if !isCodexShellTool(toolName) {
+		return ""
+	}
+	cmd := skillCommandFromInput(inputJSON)
+	if !looksLikeSkillReadCommand(cmd) {
+		return ""
+	}
+	baseDir := skillBaseDirFromInput(inputJSON)
+	if baseDir == "" {
+		baseDir = fallbackBaseDir
+	}
+	for _, path := range skillPathsFromCommand(cmd) {
+		if name := skillNameFromPath(path, baseDir); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+// skillPathsFromCommand extracts candidate SKILL.md paths from a shell
+// command. Each control-operator-delimited segment is handled by its
+// own leading verb: only read commands (cat/sed/... and grep/rg) yield
+// paths, so SKILL.md in an unrelated segment (e.g. `echo SKILL.md`) is
+// ignored, and a grep/rg search pattern is not mistaken for a file.
+func skillPathsFromCommand(cmd string) []string {
+	var paths []string
+	for _, seg := range shellSegmentRE.Split(cmd, -1) {
+		paths = append(paths, skillPathsFromSegment(seg)...)
+	}
+	return paths
+}
+
+func skillPathsFromSegment(seg string) []string {
+	tokens := tokenizeCommand(seg)
+	if len(tokens) == 0 {
+		return nil
+	}
+	switch commandVerb(tokens[0]) {
+	case "grep", "rg":
+		return skillPathsFromSearchArgs(tokens[1:])
+	case "cat", "sed", "head", "tail", "less", "more":
+		return skillFilePaths(tokens[1:])
+	default:
+		return nil
+	}
+}
+
+// tokenizeCommand splits a command segment into tokens on unquoted
+// whitespace, honoring single and double quotes so a quoted argument
+// stays one token (e.g. the multi-word pattern in `grep "a b" f`).
+// Unlike a full shell lexer it treats backslash literally, preserving
+// Windows paths such as C:\skills\foo\SKILL.md.
+func tokenizeCommand(seg string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inToken := false
+	var quote rune
+	flush := func() {
+		if inToken {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+			inToken = false
+		}
+	}
+	for _, r := range seg {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				cur.WriteRune(r)
+			}
+		case r == '\'' || r == '"':
+			quote = r
+			inToken = true
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			flush()
+		default:
+			cur.WriteRune(r)
+			inToken = true
+		}
+	}
+	flush()
+	return tokens
+}
+
+// commandVerb returns the lowercased base name of a command token,
+// dropping any leading path (e.g. "/usr/bin/grep" -> "grep").
+func commandVerb(token string) string {
+	token = strings.ToLower(token)
+	if i := strings.LastIndexAny(token, `/\`); i >= 0 {
+		token = token[i+1:]
+	}
+	return token
+}
+
+// skillFilePaths returns the operand tokens that name a SKILL.md file.
+// Each token is a whole shell operand, so a path is taken verbatim
+// rather than re-scanned, preserving spaces inside quoted paths.
+func skillFilePaths(args []string) []string {
+	var paths []string
+	for _, arg := range args {
+		if isSkillMarkdownPath(strings.TrimSpace(arg)) {
+			paths = append(paths, arg)
+		}
+	}
+	return paths
+}
+
+// skillPathsFromSearchArgs extracts SKILL.md file operands from grep/rg
+// arguments. The search pattern (the value of -e/-f, or otherwise the
+// first non-flag operand) is skipped so it is not read as a file;
+// operands after it are files.
+func skillPathsFromSearchArgs(args []string) []string {
+	var files []string
+	patternSeen := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg != "-" && strings.HasPrefix(arg, "-") {
+			flag, _, hasValue := strings.Cut(arg, "=")
+			if flag == "-e" || flag == "-f" ||
+				flag == "--regexp" || flag == "--file" {
+				patternSeen = true
+			}
+			if !hasValue && searchValueFlags[flag] {
+				i++
+			}
+			continue
+		}
+		if !patternSeen {
+			patternSeen = true
+			continue
+		}
+		files = append(files, arg)
+	}
+	return skillFilePaths(files)
+}
+
+func inferSkillNameFromJSONPaths(inputJSON string) string {
+	trimmed := strings.TrimSpace(inputJSON)
+	if trimmed == "" {
+		return ""
+	}
+	baseDir := skillBaseDirFromInput(trimmed)
+	if !gjson.Valid(trimmed) {
+		for _, path := range skillPathsFromText(trimmed) {
+			if name := skillNameFromPath(path, baseDir); name != "" {
+				return name
+			}
+		}
+		return ""
+	}
+
+	var v any
+	if err := json.Unmarshal([]byte(trimmed), &v); err != nil {
+		return ""
+	}
+	var found string
+	var walk func(any)
+	walk = func(x any) {
+		if found != "" {
+			return
+		}
+		switch t := x.(type) {
+		case string:
+			// A JSON string value is already one unescaped path, so
+			// try it whole first — the free-text regex below splits
+			// on whitespace and would truncate paths with spaces.
+			if name := skillNameFromPath(t, baseDir); name != "" {
+				found = name
+				return
+			}
+			for _, path := range skillPathsFromText(t) {
+				if name := skillNameFromPath(path, baseDir); name != "" {
+					found = name
+					return
+				}
+			}
+		case []any:
+			for _, item := range t {
+				walk(item)
+				if found != "" {
+					return
+				}
+			}
+		case map[string]any:
+			for _, item := range t {
+				walk(item)
+				if found != "" {
+					return
+				}
+			}
+		}
+	}
+	walk(v)
+	return found
+}
+
+func isCursorSkillReadTool(toolName string) bool {
+	switch strings.ToLower(strings.TrimSpace(toolName)) {
+	case "read", "readfile", "read_file":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCodexShellTool(toolName string) bool {
+	switch strings.ToLower(strings.TrimSpace(toolName)) {
+	case "exec_command", "shell_command", "shell", "bash":
+		return true
+	default:
+		return false
+	}
+}
+
+func skillCommandFromInput(inputJSON string) string {
+	trimmed := strings.TrimSpace(inputJSON)
+	if trimmed == "" {
+		return ""
+	}
+	if gjson.Valid(trimmed) {
+		g := gjson.Parse(trimmed)
+		for _, key := range []string{"cmd", "command", "script"} {
+			if s := strings.TrimSpace(g.Get(key).Str); s != "" {
+				return s
+			}
+		}
+	}
+	return trimmed
+}
+
+func looksLikeSkillReadCommand(cmd string) bool {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" || !strings.Contains(cmd, "SKILL.md") {
+		return false
+	}
+	if writeCommandRE.MatchString(cmd) {
+		return false
+	}
+	return readCommandRE.MatchString(cmd)
+}
+
+func skillPathsFromText(text string) []string {
+	matches := skillPathRE.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if !skillPathMatchHasBoundary(text, m[1]) {
+			continue
+		}
+		for i := 2; i < len(m); i += 2 {
+			if m[i] >= 0 && m[i+1] >= 0 {
+				paths = append(paths, text[m[i]:m[i+1]])
+				break
+			}
+		}
+	}
+	return paths
+}
+
+func skillPathMatchHasBoundary(text string, end int) bool {
+	if end >= len(text) {
+		return true
+	}
+	switch text[end] {
+	case ' ', '\t', '\n', '\r', '"', '\'', ';', '&', '|', ')', '}', ']':
+		return true
+	default:
+		return false
+	}
+}
+
+// skillNameFromPath derives a skill name from a captured
+// SKILL.md path. baseDir is the tool/session working directory
+// (when known) used to resolve relative paths before reading
+// frontmatter. A leading "~" is expanded to the user home dir.
+// When the path stays relative because no base directory is
+// available, the frontmatter read is skipped so an unrelated
+// SKILL.md under the agentsview process cwd cannot be read by
+// accident; the parent-directory name is used as a fallback.
+// Paths carrying shell glob metacharacters are rejected: they come
+// from discovery commands (e.g. "**/SKILL.md") rather than a
+// concrete file, and would otherwise yield a bogus name like "**".
+func skillNameFromPath(path, baseDir string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || skillPathIsGlob(path) || !isSkillMarkdownPath(path) {
+		return ""
+	}
+	resolved, readable := resolveSkillPath(path, baseDir)
+	clean := filepath.Clean(resolved)
+	if cached, ok := skillNameByPath.Load(clean); ok {
+		return cached.(string)
+	}
+
+	var name string
+	if readable {
+		name = skillNameFromFrontmatter(clean)
+	}
+	if name == "" && !skillPathIsBare(path) {
+		// A path with a directory component names the skill via its
+		// folder even when the file is unreadable (e.g.
+		// "skills/foo/SKILL.md" -> "foo"). A bare "SKILL.md" carries
+		// no such signal, so it is only inferred from frontmatter of
+		// a resolvable file; this keeps a read command that merely
+		// references SKILL.md (e.g. `grep SKILL.md notes.txt`) from
+		// being miscounted as the working directory's name.
+		name = skillNameFromParentDir(clean)
+	}
+	skillNameByPath.Store(clean, name)
+	return name
+}
+
+// resolveSkillPath expands a leading "~" and joins relative
+// paths against baseDir. It returns the path to use and whether
+// that path is absolute (and therefore safe to read frontmatter
+// from). A relative path with no usable base is returned as-is
+// with readable=false.
+func resolveSkillPath(path, baseDir string) (string, bool) {
+	path = expandSkillHome(path)
+	if filepath.IsAbs(path) {
+		return path, true
+	}
+	if baseDir = expandSkillHome(strings.TrimSpace(baseDir)); filepath.IsAbs(baseDir) {
+		return filepath.Join(baseDir, path), true
+	}
+	return path, false
+}
+
+// expandSkillHome replaces a leading "~" or "~/" with the
+// current user's home directory. Other inputs are returned
+// unchanged.
+func expandSkillHome(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, path[len("~/"):])
+}
+
+// skillBaseDirFromInput extracts a working-directory hint from a
+// tool call's input JSON (e.g. Codex exec_command "workdir").
+func skillBaseDirFromInput(inputJSON string) string {
+	trimmed := strings.TrimSpace(inputJSON)
+	if trimmed == "" || !gjson.Valid(trimmed) {
+		return ""
+	}
+	g := gjson.Parse(trimmed)
+	for _, key := range []string{"workdir", "cwd", "working_directory"} {
+		if s := strings.TrimSpace(g.Get(key).Str); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func isSkillMarkdownPath(path string) bool {
+	normalized := strings.ReplaceAll(path, "\\", "/")
+	return strings.HasSuffix(normalized, "/SKILL.md") ||
+		normalized == "SKILL.md"
+}
+
+// skillPathIsGlob reports whether a captured path holds shell glob
+// metacharacters, marking it as a discovery pattern rather than a
+// concrete file to read.
+func skillPathIsGlob(path string) bool {
+	return strings.ContainsAny(path, "*?[")
+}
+
+// skillPathIsBare reports whether a captured path is just "SKILL.md"
+// with no directory component, so the surrounding folder name is not
+// available as a skill-name fallback.
+func skillPathIsBare(path string) bool {
+	return !strings.ContainsAny(path, `/\`)
+}
+
+func skillNameFromFrontmatter(path string) string {
+	// Lstat first so a symlink, FIFO, device, or directory captured
+	// from a transcript is rejected before open — opening a FIFO
+	// read-only would otherwise block waiting for a writer.
+	if li, err := os.Lstat(path); err != nil || !li.Mode().IsRegular() {
+		return ""
+	}
+
+	// Open with O_NOFOLLOW and re-check via Fstat to close the
+	// window between Lstat and open, then read only a bounded
+	// prefix so a crafted path cannot exhaust memory during sync.
+	f, err := openNoFollow(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return ""
+	}
+
+	b, err := io.ReadAll(io.LimitReader(f, maxSkillFrontmatterSize))
+	if err != nil {
+		return ""
+	}
+	text := strings.TrimPrefix(string(b), "\ufeff")
+	if !strings.HasPrefix(text, "---") {
+		return ""
+	}
+	lines := strings.Split(text, "\n")
+	for i := 1; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "---" || line == "..." {
+			return ""
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(key) != "name" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"'`)
+		return value
+	}
+	return ""
+}
+
+func skillNameFromParentDir(path string) string {
+	dir := filepath.Base(filepath.Dir(path))
+	if dir == "." || dir == string(filepath.Separator) {
+		return ""
+	}
+	return dir
+}

--- a/internal/parser/skill_inference.go
+++ b/internal/parser/skill_inference.go
@@ -19,11 +19,12 @@ import (
 const maxSkillFrontmatterSize = 64 << 10
 
 var (
-	skillNameByPath sync.Map
-	skillPathRE     = regexp.MustCompile(`(?:"([^"]*[/\\]SKILL\.md)"|'([^']*[/\\]SKILL\.md)'|(\S*[/\\]SKILL\.md)|(?:^|[\s"'])(SKILL\.md))`)
-	readCommandRE   = regexp.MustCompile(`(?:^|(?:&&|\|\||[;&|])\s*)(?:[A-Za-z0-9_.-]+/)?(?:cat|sed|head|tail|less|more|rg|grep)\b`)
-	writeCommandRE  = regexp.MustCompile(`(?:^|(?:&&|\|\||[;&|])\s*)(?:[A-Za-z0-9_.-]+/)?(?:cp|mv|mkdir|touch|rm|chmod|chown|install|tee)\b|\bgit\s+(?:add|mv|rm)\b|\bsed\s+-i\b|>\s*["']?[^"'\s]*[/\\]SKILL\.md\b`)
-	shellSegmentRE  = regexp.MustCompile(`\s*(?:&&|\|\||;|&|\|)\s*`)
+	skillNameByPath  sync.Map
+	skillPathRE      = regexp.MustCompile(`(?:"([^"]*[/\\]SKILL\.md)"|'([^']*[/\\]SKILL\.md)'|(\S*[/\\]SKILL\.md)|(?:^|[\s"'])(SKILL\.md))`)
+	readCommandRE    = regexp.MustCompile(`(?:^|(?:&&|\|\||[;&|])\s*)(?:[A-Za-z0-9_.-]+/)?(?:cat|sed|head|tail|less|more|rg|grep)\b`)
+	writeCommandRE   = regexp.MustCompile(`(?:^|(?:&&|\|\||[;&|])\s*)(?:[A-Za-z0-9_.-]+/)?(?:cp|mv|mkdir|touch|rm|chmod|chown|install|tee)\b|\bgit\s+(?:add|mv|rm)\b|\bsed\s+-i\b|>\s*["']?[^"'\s]*[/\\]SKILL\.md\b`)
+	shellSegmentRE   = regexp.MustCompile(`\s*(?:&&|\|\||;|&|\|)\s*`)
+	outputRedirectRE = regexp.MustCompile(`^[0-9&]*>>?$`)
 )
 
 // searchValueFlags lists grep/rg flags (short and long) that consume
@@ -101,14 +102,31 @@ func skillPathsFromSegment(seg string) []string {
 	if len(tokens) == 0 {
 		return nil
 	}
+	args := stripRedirects(tokens[1:])
 	switch commandVerb(tokens[0]) {
 	case "grep", "rg":
-		return skillPathsFromSearchArgs(tokens[1:])
+		return skillPathsFromSearchArgs(args)
 	case "cat", "sed", "head", "tail", "less", "more":
-		return skillFilePaths(tokens[1:])
+		return skillFilePaths(args)
 	default:
 		return nil
 	}
+}
+
+// stripRedirects drops output-redirection operators (>, >>, 2>, &>,
+// ...) together with their target token, so a redirect destination
+// such as the SKILL.md in `cat foo > SKILL.md` is written, not read,
+// and is never collected as a file operand.
+func stripRedirects(args []string) []string {
+	var out []string
+	for i := 0; i < len(args); i++ {
+		if outputRedirectRE.MatchString(args[i]) {
+			i++ // also skip the redirect target token
+			continue
+		}
+		out = append(out, args[i])
+	}
+	return out
 }
 
 // tokenizeCommand splits a command segment into tokens on unquoted

--- a/internal/parser/skill_inference.go
+++ b/internal/parser/skill_inference.go
@@ -21,8 +21,6 @@ const maxSkillFrontmatterSize = 64 << 10
 var (
 	skillNameByPath  sync.Map
 	skillPathRE      = regexp.MustCompile(`(?:"([^"]*[/\\]SKILL\.md)"|'([^']*[/\\]SKILL\.md)'|(\S*[/\\]SKILL\.md)|(?:^|[\s"'])(SKILL\.md))`)
-	readCommandRE    = regexp.MustCompile(`(?:^|(?:&&|\|\||[;&|])\s*)(?:[A-Za-z0-9_.-]+/)?(?:cat|sed|head|tail|less|more|rg|grep)\b`)
-	writeCommandRE   = regexp.MustCompile(`(?:^|(?:&&|\|\||[;&|])\s*)(?:[A-Za-z0-9_.-]+/)?(?:cp|mv|mkdir|touch|rm|chmod|chown|install|tee)\b|\bgit\s+(?:add|mv|rm)\b|\bsed\s+-i\b|>\s*["']?[^"'\s]*[/\\]SKILL\.md\b`)
 	shellSegmentRE   = regexp.MustCompile(`\s*(?:&&|\|\||;|&|\|)\s*`)
 	outputRedirectRE = regexp.MustCompile(`^[0-9&]*>>?$`)
 )
@@ -69,7 +67,7 @@ func inferCodexSkillNameWithBase(toolName, inputJSON, fallbackBaseDir string) st
 		return ""
 	}
 	cmd := skillCommandFromInput(inputJSON)
-	if !looksLikeSkillReadCommand(cmd) {
+	if !strings.Contains(cmd, "SKILL.md") {
 		return ""
 	}
 	baseDir := skillBaseDirFromInput(inputJSON)
@@ -106,11 +104,30 @@ func skillPathsFromSegment(seg string) []string {
 	switch commandVerb(tokens[0]) {
 	case "grep", "rg":
 		return skillPathsFromSearchArgs(args)
-	case "cat", "sed", "head", "tail", "less", "more":
+	case "sed":
+		// sed is a read verb, but -i / --in-place edits its operands in
+		// place, so a SKILL.md argument is written, not read.
+		if sedWritesInPlace(args) {
+			return nil
+		}
+		return skillFilePaths(args)
+	case "cat", "head", "tail", "less", "more":
 		return skillFilePaths(args)
 	default:
 		return nil
 	}
+}
+
+// sedWritesInPlace reports whether a sed invocation edits its file
+// operands in place via -i (optionally with a backup suffix, e.g.
+// -i.bak) or --in-place, which makes a SKILL.md operand a write target.
+func sedWritesInPlace(args []string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-i") || strings.HasPrefix(arg, "--in-place") {
+			return true
+		}
+	}
+	return false
 }
 
 // stripRedirects drops output-redirection operators (>, >>, 2>, &>,
@@ -312,17 +329,6 @@ func skillCommandFromInput(inputJSON string) string {
 		}
 	}
 	return trimmed
-}
-
-func looksLikeSkillReadCommand(cmd string) bool {
-	cmd = strings.TrimSpace(cmd)
-	if cmd == "" || !strings.Contains(cmd, "SKILL.md") {
-		return false
-	}
-	if writeCommandRE.MatchString(cmd) {
-		return false
-	}
-	return readCommandRE.MatchString(cmd)
 }
 
 func skillPathsFromText(text string) []string {

--- a/internal/parser/skill_inference_nonwindows_test.go
+++ b/internal/parser/skill_inference_nonwindows_test.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillNameFromFrontmatterRejectsSymlink(t *testing.T) {
+	real := writeTestSkill(t, "index", "data-analytics:index")
+
+	// A SKILL.md symlink pointing at the real skill must not have
+	// its frontmatter read; resolution falls back to the parent
+	// directory name of the symlink path instead.
+	linkDir := filepath.Join(t.TempDir(), "evil")
+	require.NoError(t, os.MkdirAll(linkDir, 0o755))
+	link := filepath.Join(linkDir, "SKILL.md")
+	require.NoError(t, os.Symlink(real, link))
+
+	assert.Equal(t, "evil", skillNameFromPath(link, ""))
+}
+
+func TestSkillNameFromFrontmatterRejectsNonRegularFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "qa")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	fifo := filepath.Join(dir, "SKILL.md")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+
+	// Must not block on the FIFO open and must not read frontmatter;
+	// resolution falls back to the parent directory name.
+	assert.Equal(t, "qa", skillNameFromPath(fifo, ""))
+}

--- a/internal/parser/skill_inference_test.go
+++ b/internal/parser/skill_inference_test.go
@@ -130,6 +130,8 @@ func TestInferCodexSkillNameIgnoresWriteCommands(t *testing.T) {
 		"mkdir -p " + filepath.Dir(path),
 		"git add " + path,
 		"sed -i '' 's/a/b/' " + path,
+		"sed -ni 's/a/b/' " + path,
+		"sed -Ei 's/a/b/' " + path,
 		"echo hi && sed -i '' 's/a/b/' " + path,
 		"cat > " + path,
 	} {
@@ -337,6 +339,26 @@ func TestTokenizeCommand(t *testing.T) {
 			cmd:  `rg 'see SKILL.md for'`,
 			want: []string{"rg", "see SKILL.md for"},
 		},
+		{
+			name: "drops redirect target attached to operator",
+			cmd:  "cat foo >skills/x/SKILL.md",
+			want: []string{"cat", "foo"},
+		},
+		{
+			name: "drops redirect operator attached to source",
+			cmd:  "cat file> out",
+			want: []string{"cat", "file"},
+		},
+		{
+			name: "drops space-separated redirect target",
+			cmd:  "cat a > b",
+			want: []string{"cat", "a"},
+		},
+		{
+			name: "keeps quoted redirect char as content",
+			cmd:  `grep ">" f`,
+			want: []string{"grep", ">", "f"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -347,7 +369,9 @@ func TestTokenizeCommand(t *testing.T) {
 
 func TestInferCodexSkillNameIgnoresRedirectTargets(t *testing.T) {
 	// A redirect destination (>, >>, 2> ...) is written, not read, so a
-	// bare SKILL.md target must not be inferred even with a workdir file.
+	// SKILL.md target must not be inferred even with a workdir file. The
+	// operator may be attached to the target (>SKILL.md) or to the source
+	// token (file>), so whitespace around it cannot be relied upon.
 	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
 	workdir := filepath.Dir(path)
 
@@ -356,6 +380,11 @@ func TestInferCodexSkillNameIgnoresRedirectTargets(t *testing.T) {
 		"grep name file > SKILL.md",
 		"cat foo >> SKILL.md",
 		"cat foo 2> SKILL.md",
+		"cat foo >SKILL.md",
+		"cat foo >>SKILL.md",
+		"cat file> SKILL.md",
+		"grep name file 2>SKILL.md",
+		"cat foo >skills/data-analytics/SKILL.md",
 	} {
 		t.Run(cmd, func(t *testing.T) {
 			got := inferCodexSkillName(
@@ -366,6 +395,18 @@ func TestInferCodexSkillNameIgnoresRedirectTargets(t *testing.T) {
 			assert.Empty(t, got)
 		})
 	}
+}
+
+func TestInferCodexSkillNameReadsFileDespiteQuotedRedirectChar(t *testing.T) {
+	// A quoted ">" is a literal search pattern, not a redirect operator,
+	// so the SKILL.md file operand is still read.
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+
+	got := inferCodexSkillName(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, `grep ">" `+path)+`}`,
+	)
+	assert.Equal(t, "data-analytics:index", got)
 }
 
 func TestInferCodexSkillNameReadsSourceDespiteRedirect(t *testing.T) {

--- a/internal/parser/skill_inference_test.go
+++ b/internal/parser/skill_inference_test.go
@@ -1,0 +1,666 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+func TestInferCursorSkillNameFromReadFile(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+
+	_, _, toolCalls := extractAssistantContent([]string{
+		"[Tool call] ReadFile",
+		"  path=" + path,
+	})
+
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "ReadFile", toolCalls[0].ToolName)
+	assert.Equal(t, "foo", toolCalls[0].SkillName)
+}
+
+func TestInferCursorSkillNameFromShellCommand(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+
+	_, _, toolCalls := extractAssistantContent([]string{
+		"[Tool call] Shell",
+		"  command=cat " + path,
+	})
+
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "Shell", toolCalls[0].ToolName)
+	assert.Equal(t, "foo", toolCalls[0].SkillName)
+}
+
+func TestInferCursorSkillNameIgnoresShellWriteCommand(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+
+	_, _, toolCalls := extractAssistantContent([]string{
+		"[Tool call] Shell",
+		"  command=cp " + path + " /tmp/SKILL.md",
+	})
+
+	require.Len(t, toolCalls, 1)
+	assert.Empty(t, toolCalls[0].SkillName)
+}
+
+func TestInferCursorSkillNameUsesFrontmatterName(t *testing.T) {
+	path := writeTestSkill(t, "index", "data-analytics:index")
+
+	_, _, toolCalls := extractAssistantContent([]string{
+		"[Tool call] ReadFile",
+		`  {"path":` + quoteJSON(t, path) + `}`,
+	})
+
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "data-analytics:index", toolCalls[0].SkillName)
+}
+
+func TestInferCursorSkillNameIgnoresDiscoveryAndNonSkillPaths(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "glob discovery",
+			line: "[Tool call] Glob\n  " +
+				`{"target_directory":` + quoteJSON(t, filepath.Dir(path)) +
+				`,"glob_pattern":"**/SKILL.md"}`,
+		},
+		{
+			name: "non skill path",
+			line: `[Tool call] ReadFile
+  path=` + filepath.Join(t.TempDir(), "README.md"),
+		},
+		{
+			name: "empty input",
+			line: "[Tool call] ReadFile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, toolCalls := extractAssistantContent(
+				splitTestLines(tt.line),
+			)
+			require.Len(t, toolCalls, 1)
+			assert.Empty(t, toolCalls[0].SkillName)
+		})
+	}
+}
+
+func TestInferCodexSkillNameFromReadCommands(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+
+	for _, cmd := range []string{
+		"cat " + path,
+		"sed -n '1,220p' " + path,
+		"head -40 " + path,
+		"tail -40 " + path,
+		"rg name " + path,
+		"grep name " + path,
+		"cd /tmp && sed -n '1,220p' " + path,
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+`}`,
+			)
+			assert.Equal(t, "foo", got)
+		})
+	}
+}
+
+func TestInferCodexSkillNameIgnoresWriteCommands(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+
+	for _, cmd := range []string{
+		"cp " + path + " /tmp/SKILL.md",
+		"mv " + path + " /tmp/SKILL.md",
+		"mkdir -p " + filepath.Dir(path),
+		"git add " + path,
+		"sed -i '' 's/a/b/' " + path,
+		"cat > " + path,
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+`}`,
+			)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestInferCodexSkillNameIgnoresGlobDiscovery(t *testing.T) {
+	for _, cmd := range []string{
+		"rg --files -g '**/SKILL.md'",
+		"cat **/SKILL.md",
+		"sed -n '1,40p' skills/*/SKILL.md",
+		"grep name skills/?ndex/SKILL.md",
+		"head -40 skills/[ab]/SKILL.md",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+`}`,
+			)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestInferCodexSkillNameBareSkillFileWithWorkdir(t *testing.T) {
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+	workdir := filepath.Dir(path)
+
+	got := inferCodexSkillName(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "cat SKILL.md")+
+			`,"workdir":`+quoteJSON(t, workdir)+`}`,
+	)
+	assert.Equal(t, "data-analytics:index", got)
+}
+
+func TestInferCodexSkillNameBareSkillFileUsesFallbackCwd(t *testing.T) {
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+	cwd := filepath.Dir(path)
+
+	got := inferCodexSkillNameWithBase(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "sed -n '1,40p' SKILL.md")+`}`,
+		cwd,
+	)
+	assert.Equal(t, "data-analytics:index", got)
+}
+
+func TestInferCodexSkillNameBareSkillPatternWithoutFileIgnored(t *testing.T) {
+	// "grep SKILL.md notes.txt" uses SKILL.md as a search pattern, not
+	// a file. With a workdir that holds no SKILL.md the bare token must
+	// not be resolved to the workdir name and miscounted as usage.
+	workdir := t.TempDir()
+
+	got := inferCodexSkillName(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "grep SKILL.md notes.txt")+
+			`,"workdir":`+quoteJSON(t, workdir)+`}`,
+	)
+	assert.Empty(t, got)
+}
+
+func TestInferCodexSkillNameBareSkillSearchPatternIgnoredEvenWithFile(t *testing.T) {
+	// grep/rg take the search pattern as their first operand, so a bare
+	// "SKILL.md" there is the pattern, not a file to read. It must not be
+	// inferred even when the workdir holds a readable SKILL.md.
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+	workdir := filepath.Dir(path)
+
+	for _, cmd := range []string{
+		"grep SKILL.md notes.txt",
+		"rg SKILL.md",
+		"rg SKILL.md notes.txt",
+		"rg -t md SKILL.md",            // SKILL.md is the pattern; md is -t's value
+		"grep -A 3 SKILL.md notes.txt", // SKILL.md is the pattern; 3 is -A's value
+		"grep -e SKILL.md notes.txt",   // SKILL.md is the -e pattern value
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+
+					`,"workdir":`+quoteJSON(t, workdir)+`}`,
+			)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestInferCodexSkillNameSearchCommandReadsFileOperand(t *testing.T) {
+	// When a pattern precedes SKILL.md (or -e/-f supplies the pattern),
+	// SKILL.md is a file operand and a workdir-local read is inferred.
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+	workdir := filepath.Dir(path)
+
+	for _, cmd := range []string{
+		"grep name SKILL.md",
+		"rg pattern SKILL.md",
+		"cat SKILL.md | grep name",
+		"grep -e foo SKILL.md",
+		"grep -i name SKILL.md",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+
+					`,"workdir":`+quoteJSON(t, workdir)+`}`,
+			)
+			assert.Equal(t, "data-analytics:index", got)
+		})
+	}
+}
+
+func TestInferCodexSkillNameSearchQuotedPatternIgnored(t *testing.T) {
+	// A quoted multi-word search pattern containing SKILL.md must not be
+	// split into fields and read as a file, even with a workdir SKILL.md.
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+	workdir := filepath.Dir(path)
+
+	for _, cmd := range []string{
+		`grep "foo SKILL.md" notes.txt`,
+		`rg 'see SKILL.md for details'`,
+		`grep -e "read the SKILL.md" notes.txt`,
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+
+					`,"workdir":`+quoteJSON(t, workdir)+`}`,
+			)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestInferCodexSkillNameIgnoresNonReadSegments(t *testing.T) {
+	// A read command elsewhere in the line must not let SKILL.md in an
+	// unrelated segment (echo, ls, ...) be inferred as a read.
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+	workdir := filepath.Dir(path)
+
+	for _, cmd := range []string{
+		"grep foo notes.txt && echo SKILL.md",
+		"cat notes.txt && echo see SKILL.md",
+		"grep foo notes.txt; ls SKILL.md",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+
+					`,"workdir":`+quoteJSON(t, workdir)+`}`,
+			)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestTokenizeCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want []string
+	}{
+		{
+			// Backslashes are literal so Windows paths survive intact;
+			// a full shell lexer such as shlex would consume them.
+			name: "preserves backslash path",
+			cmd:  `cat C:\Users\me\skills\foo\SKILL.md`,
+			want: []string{"cat", `C:\Users\me\skills\foo\SKILL.md`},
+		},
+		{
+			name: "double-quoted argument stays one token",
+			cmd:  `grep "foo SKILL.md" notes.txt`,
+			want: []string{"grep", "foo SKILL.md", "notes.txt"},
+		},
+		{
+			name: "single-quoted argument stays one token",
+			cmd:  `rg 'see SKILL.md for'`,
+			want: []string{"rg", "see SKILL.md for"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tokenizeCommand(tt.cmd))
+		})
+	}
+}
+
+func TestInferCodexSkillNameSearchCommandStillReadsPathOperand(t *testing.T) {
+	// A path-qualified SKILL.md operand to grep/rg is a real file read
+	// (the pattern is a separate token), so it is still inferred.
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+
+	got := inferCodexSkillName(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "grep name "+path)+`}`,
+	)
+	assert.Equal(t, "data-analytics:index", got)
+}
+
+func TestParseCodexSessionInfersSkillName(t *testing.T) {
+	path := writeTestSkill(t, "index", "data-analytics:index")
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON("skill-read", "/tmp", "user", tsEarly),
+		testjsonl.CodexMsgJSON("user", "use the dashboard skill", tsEarlyS1),
+		testjsonl.CodexFunctionCallArgsJSON("exec_command", map[string]any{
+			"cmd": "sed -n '1,220p' '" + path + "'",
+		}, tsEarlyS5),
+	)
+
+	_, msgs := runCodexParserTest(t, "skill-read.jsonl", content, false)
+
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "data-analytics:index", msgs[1].ToolCalls[0].SkillName)
+}
+
+func TestParseCodexSessionInfersSkillNameFromSessionCwd(t *testing.T) {
+	path := writeTestSkill(t, "index", "data-analytics:index")
+	cwd := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON("skill-read", cwd, "user", tsEarly),
+		testjsonl.CodexMsgJSON("user", "use the dashboard skill", tsEarlyS1),
+		testjsonl.CodexFunctionCallArgsJSON("exec_command", map[string]any{
+			"cmd": "sed -n '1,220p' skills/index/SKILL.md",
+		}, tsEarlyS5),
+	)
+
+	_, msgs := runCodexParserTest(t, "skill-read.jsonl", content, false)
+
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "data-analytics:index", msgs[1].ToolCalls[0].SkillName)
+}
+
+func TestParseCodexSessionFromInfersSkillNameFromSeededCwd(t *testing.T) {
+	path := writeTestSkill(t, "index", "data-analytics:index")
+	cwd := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON("inc-skill", cwd, "codex_cli_rs", tsEarly),
+		testjsonl.CodexMsgJSON("user", "use the dashboard skill", tsEarlyS1),
+	)
+	file := createTestFile(t, "incremental-skill.jsonl", initial)
+	_, msgs, err := ParseCodexSession(file, "local", false)
+	require.NoError(t, err)
+
+	info, err := os.Stat(file)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := testjsonl.CodexFunctionCallArgsJSON(
+		"exec_command", map[string]any{
+			"cmd": "sed -n '1,220p' skills/index/SKILL.md",
+		}, tsLateS5)
+	f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := ParseCodexSessionFrom(file, offset, len(msgs), false)
+	require.NoError(t, err)
+	require.Len(t, newMsgs, 1)
+	require.Len(t, newMsgs[0].ToolCalls, 1)
+	assert.Equal(t, "data-analytics:index", newMsgs[0].ToolCalls[0].SkillName)
+}
+
+func TestExtractTextContentInfersCursorJSONLSkillName(t *testing.T) {
+	path := writeTestSkill(t, "planning-and-task-breakdown", "planning-and-task-breakdown")
+	content := gjson.Parse(
+		`[{"type":"tool_use","id":"tu_read","name":"Read","input":{"path":` +
+			quoteJSON(t, path) + `}}]`,
+	)
+
+	_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "Read", toolCalls[0].ToolName)
+	assert.Equal(t, "planning-and-task-breakdown", toolCalls[0].SkillName)
+}
+
+func TestExtractTextContentInfersCursorJSONLSkillNameFromFrontmatter(t *testing.T) {
+	path := writeTestSkill(t, "index", "data-analytics:index")
+	content := gjson.Parse(
+		`[{"type":"tool_use","id":"tu_read_file","name":"ReadFile","input":{"path":` +
+			quoteJSON(t, path) + `}}]`,
+	)
+
+	_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "ReadFile", toolCalls[0].ToolName)
+	assert.Equal(t, "data-analytics:index", toolCalls[0].SkillName)
+}
+
+func TestExtractTextContentInfersSkillNameFromPathWithSpaces(t *testing.T) {
+	path := writeTestSkill(t, "my index", "data-analytics:index")
+	require.Contains(t, path, " ")
+
+	content := gjson.Parse(
+		`[{"type":"tool_use","id":"tu_read","name":"Read","input":{"path":` +
+			quoteJSON(t, path) + `}}]`,
+	)
+
+	_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "data-analytics:index", toolCalls[0].SkillName)
+}
+
+func TestExtractTextContentInfersCursorJSONLSkillNameFromShellRead(t *testing.T) {
+	path := writeTestSkill(t, "qa", "qa")
+	content := gjson.Parse(
+		`[{"type":"tool_use","id":"tu_shell","name":"Shell","input":{"command":` +
+			quoteJSON(t, "cd /tmp && sed -n '1,120p' "+path) + `}}]`,
+	)
+
+	_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "Shell", toolCalls[0].ToolName)
+	assert.Equal(t, "qa", toolCalls[0].SkillName)
+}
+
+func TestExtractTextContentDoesNotInferCursorJSONLNonUsage(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+	templatePath := filepath.Join(t.TempDir(), "SKILL.md.tmpl")
+	require.NoError(t, os.WriteFile(templatePath, []byte("template"), 0o644))
+
+	tests := []struct {
+		name     string
+		toolName string
+		input    string
+	}{
+		{
+			name:     "glob discovery",
+			toolName: "Glob",
+			input:    `{"glob_pattern":"**/SKILL.md"}`,
+		},
+		{
+			name:     "write skill file",
+			toolName: "Write",
+			input:    `{"path":` + quoteJSON(t, path) + `,"contents":"---"}`,
+		},
+		{
+			name:     "str replace skill file",
+			toolName: "StrReplace",
+			input:    `{"path":` + quoteJSON(t, path) + `,"old_string":"a","new_string":"b"}`,
+		},
+		{
+			name:     "apply patch skill file",
+			toolName: "ApplyPatch",
+			input:    `{"path":` + quoteJSON(t, path) + `,"patch":"*** Begin Patch"}`,
+		},
+		{
+			name:     "template file",
+			toolName: "Read",
+			input:    `{"path":` + quoteJSON(t, templatePath) + `}`,
+		},
+		{
+			name:     "shell write command",
+			toolName: "Shell",
+			input:    `{"command":` + quoteJSON(t, "cp "+path+" /tmp/SKILL.md") + `}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := gjson.Parse(
+				`[{"type":"tool_use","id":"tu","name":` +
+					quoteJSON(t, tt.toolName) + `,"input":` + tt.input + `}]`,
+			)
+
+			_, _, _, _, toolCalls, _ := ExtractTextContent(content)
+
+			require.Len(t, toolCalls, 1)
+			assert.Empty(t, toolCalls[0].SkillName)
+		})
+	}
+}
+
+func TestInferCodexSkillNameResolvesRelativePathAgainstWorkdir(t *testing.T) {
+	path := writeTestSkill(t, "index", "data-analytics:index")
+	workdir := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+
+	got := inferCodexSkillName(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "sed -n '1,220p' skills/index/SKILL.md")+
+			`,"workdir":`+quoteJSON(t, workdir)+`}`,
+	)
+
+	assert.Equal(t, "data-analytics:index", got)
+}
+
+func TestInferCodexSkillNameWorkdirOverridesFallbackBase(t *testing.T) {
+	path := writeTestSkill(t, "index", "data-analytics:index")
+	workdir := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+
+	got := inferCodexSkillNameWithBase(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "cat skills/index/SKILL.md")+
+			`,"workdir":`+quoteJSON(t, workdir)+`}`,
+		"/nonexistent/fallback",
+	)
+
+	assert.Equal(t, "data-analytics:index", got)
+}
+
+func TestInferCodexSkillNameUsesFallbackBaseWhenNoWorkdir(t *testing.T) {
+	path := writeTestSkill(t, "index", "data-analytics:index")
+	fallback := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+
+	got := inferCodexSkillNameWithBase(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "cat skills/index/SKILL.md")+`}`,
+		fallback,
+	)
+
+	assert.Equal(t, "data-analytics:index", got)
+}
+
+func TestInferCodexSkillNameRelativePathNoWorkdirUsesParentFallback(t *testing.T) {
+	// Frontmatter name ("data-analytics:index") differs from the
+	// parent dir ("index"). Without a workdir the relative path
+	// cannot be resolved, so the frontmatter read is skipped and
+	// the parent-dir fallback is used instead of reading an
+	// unrelated SKILL.md under the process cwd.
+	writeTestSkill(t, "index", "data-analytics:index")
+
+	got := inferCodexSkillName(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "cat skills/index/SKILL.md")+`}`,
+	)
+
+	assert.Equal(t, "index", got)
+}
+
+func TestExpandSkillHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare tilde", "~", home},
+		{"tilde slash", "~/.claude/skills/foo/SKILL.md",
+			filepath.Join(home, ".claude/skills/foo/SKILL.md")},
+		{"absolute unchanged", "/abs/SKILL.md", "/abs/SKILL.md"},
+		{"relative unchanged", "skills/foo/SKILL.md", "skills/foo/SKILL.md"},
+		{"tilde user not expanded", "~bob/SKILL.md", "~bob/SKILL.md"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, expandSkillHome(tt.in))
+		})
+	}
+}
+
+func TestResolveSkillPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	absSkillPath := filepath.Join(t.TempDir(), "a", "b", "SKILL.md")
+	baseDir := filepath.Join(t.TempDir(), "repo")
+	relativeSkillPath := filepath.Join("s", "SKILL.md")
+
+	tests := []struct {
+		name         string
+		path         string
+		baseDir      string
+		wantPath     string
+		wantReadable bool
+	}{
+		{"absolute", absSkillPath, "", absSkillPath, true},
+		{"tilde expands", "~/s/SKILL.md", "",
+			filepath.Join(home, "s/SKILL.md"), true},
+		{"relative joined to base", relativeSkillPath, baseDir,
+			filepath.Join(baseDir, relativeSkillPath), true},
+		{"relative no base", relativeSkillPath, "", relativeSkillPath, false},
+		{"relative with relative base", relativeSkillPath, "rel",
+			relativeSkillPath, false},
+		{"tilde base expands", relativeSkillPath, "~/repo",
+			filepath.Join(home, "repo", relativeSkillPath), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotReadable := resolveSkillPath(tt.path, tt.baseDir)
+			assert.Equal(t, tt.wantPath, gotPath)
+			assert.Equal(t, tt.wantReadable, gotReadable)
+		})
+	}
+}
+
+func TestSkillNameFromFrontmatterBoundsReadSize(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "huge")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "SKILL.md")
+	// Frontmatter terminator sits past the read cap, so the name
+	// cannot be parsed and resolution falls back to the parent dir.
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.WriteString("description: ")
+	sb.WriteString(strings.Repeat("x", maxSkillFrontmatterSize))
+	sb.WriteString("\nname: too-far\n---\n")
+	require.NoError(t, os.WriteFile(path, []byte(sb.String()), 0o644))
+
+	assert.Equal(t, "huge", skillNameFromPath(path, ""))
+}
+
+func writeTestSkill(t *testing.T, folder, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "skills", folder)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "SKILL.md")
+	content := "---\nname: " + name + "\ndescription: Test skill\n---\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func splitTestLines(s string) []string {
+	return strings.Split(s, "\n")
+}
+
+func quoteJSON(t *testing.T, s string) string {
+	t.Helper()
+	return strconv.Quote(s)
+}

--- a/internal/parser/skill_inference_test.go
+++ b/internal/parser/skill_inference_test.go
@@ -323,6 +323,41 @@ func TestTokenizeCommand(t *testing.T) {
 	}
 }
 
+func TestInferCodexSkillNameIgnoresRedirectTargets(t *testing.T) {
+	// A redirect destination (>, >>, 2> ...) is written, not read, so a
+	// bare SKILL.md target must not be inferred even with a workdir file.
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+	workdir := filepath.Dir(path)
+
+	for _, cmd := range []string{
+		"cat foo > SKILL.md",
+		"grep name file > SKILL.md",
+		"cat foo >> SKILL.md",
+		"cat foo 2> SKILL.md",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+
+					`,"workdir":`+quoteJSON(t, workdir)+`}`,
+			)
+			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestInferCodexSkillNameReadsSourceDespiteRedirect(t *testing.T) {
+	// SKILL.md is the input being read; output is redirected elsewhere,
+	// so the read is still inferred.
+	path := writeTestSkill(t, "data-analytics", "data-analytics:index")
+
+	got := inferCodexSkillName(
+		"exec_command",
+		`{"cmd":`+quoteJSON(t, "cat "+path+" > out.txt")+`}`,
+	)
+	assert.Equal(t, "data-analytics:index", got)
+}
+
 func TestInferCodexSkillNameSearchCommandStillReadsPathOperand(t *testing.T) {
 	// A path-qualified SKILL.md operand to grep/rg is a real file read
 	// (the pattern is a separate token), so it is still inferred.

--- a/internal/parser/skill_inference_test.go
+++ b/internal/parser/skill_inference_test.go
@@ -130,6 +130,7 @@ func TestInferCodexSkillNameIgnoresWriteCommands(t *testing.T) {
 		"mkdir -p " + filepath.Dir(path),
 		"git add " + path,
 		"sed -i '' 's/a/b/' " + path,
+		"echo hi && sed -i '' 's/a/b/' " + path,
 		"cat > " + path,
 	} {
 		t.Run(cmd, func(t *testing.T) {
@@ -138,6 +139,27 @@ func TestInferCodexSkillNameIgnoresWriteCommands(t *testing.T) {
 				`{"cmd":`+quoteJSON(t, cmd)+`}`,
 			)
 			assert.Empty(t, got)
+		})
+	}
+}
+
+func TestInferCodexSkillNameMixedWriteThenRead(t *testing.T) {
+	// A write segment earlier in the command must not suppress a real
+	// skill read in a later segment; each segment is classified on its
+	// own leading verb rather than rejecting the whole command.
+	path := writeTestSkill(t, "foo", "data-analytics:foo")
+
+	for _, cmd := range []string{
+		"mkdir -p out && cat " + path,
+		"git add -A && sed -n '1,40p' " + path,
+		"touch marker; grep name " + path,
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			got := inferCodexSkillName(
+				"exec_command",
+				`{"cmd":`+quoteJSON(t, cmd)+`}`,
+			)
+			assert.Equal(t, "data-analytics:foo", got)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- infer `tool_calls.skill_name` when Codex/Cursor read a `SKILL.md` file
- use `SKILL.md` frontmatter `name` when available, with parent directory fallback
- apply inference to Cursor JSONL `tool_use` blocks as well as parser-specific tool calls
- bump `dataVersion` so historical sessions are reparsed

## Compatibility

- no schema changes
- preserves explicit skill names when already present
- does not infer from discovery-only `Glob` or write/edit/copy/move operations

## Privacy/Data

- reads local `SKILL.md` metadata only when the referenced file is available
- no data is uploaded

## Tests

- `go test -tags "fts5,kit_posthog_disabled" ./internal/parser ./internal/db ./internal/server`
- `go test -tags "fts5,kit_posthog_disabled" ./internal/...`
- `git diff --check`

## Review note

This is intentionally separate from the analytics endpoint/UI. It improves data population for agents that do not emit explicit `skill_name` values.