### PR TITLE
feat: add QwenPaw agent support

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -611,6 +611,7 @@ func writeRootHelp(w io.Writer, root *cobra.Command) {
 	fmt.Fprintln(w, "  AMP_DIR                 Amp threads directory")
 	fmt.Fprintln(w, "  ZED_DIR                 Zed data directory")
 	fmt.Fprintln(w, "  QWEN_PROJECTS_DIR       Qwen Code projects directory")
+	fmt.Fprintln(w, "  QWENPAW_DIR             QwenPaw workspaces directory")
 	fmt.Fprintln(w, "  DEEPSEEK_TUI_SESSIONS_DIR")
 	fmt.Fprintln(w, "                          DeepSeek TUI sessions directory")
 	fmt.Fprintln(w, "  QCLAW_DIR               QClaw agents directory")

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -23,6 +23,7 @@ describe("KNOWN_AGENTS", () => {
       "vscode-copilot",
       "pi",
       "qwen",
+      "qwenpaw",
       "deepseek-tui",
       "openclaw",
       "qclaw",
@@ -85,6 +86,9 @@ describe("agentColor", () => {
     expect(agentColor("qwen")).toBe(
       "var(--accent-cyan)",
     );
+    expect(agentColor("qwenpaw")).toBe(
+      "var(--accent-cyan)",
+    );
     expect(agentColor("deepseek-tui")).toBe(
       "var(--accent-cyan)",
     );
@@ -123,6 +127,7 @@ describe("agentLabel", () => {
     expect(agentLabel("piebald")).toBe("Piebald");
     expect(agentLabel("zed")).toBe("Zed");
     expect(agentLabel("qwen")).toBe("Qwen Code");
+    expect(agentLabel("qwenpaw")).toBe("QwenPaw");
     expect(agentLabel("deepseek-tui")).toBe("DeepSeek TUI");
   });
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -23,6 +23,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   },
   { name: "pi", color: "var(--accent-indigo)", label: "Pi" },
   { name: "qwen", color: "var(--accent-cyan)", label: "Qwen Code" },
+  { name: "qwenpaw", color: "var(--accent-cyan)", label: "QwenPaw" },
   {
     name: "deepseek-tui",
     color: "var(--accent-cyan)",

--- a/internal/parser/qwenpaw.go
+++ b/internal/parser/qwenpaw.go
@@ -1,0 +1,524 @@
+// ABOUTME: Parses QwenPaw sessions/<name>.json files into structured session data.
+// ABOUTME: Handles Anthropic-style content blocks (text/thinking/tool_use/
+// ABOUTME: tool_result) with system-role carriers for tool results.
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+// DiscoverQwenPawSessions walks <root>/<workspace>/sessions/*.json and
+// <root>/<workspace>/sessions/console/*.json. Each QwenPaw runtime
+// hosts multiple agent workspaces (e.g. "default", "fund_manager")
+// and each workspace persists one JSON file per active session under
+// sessions/. Hidden subdirectories (e.g. ".weixin-legacy") and the
+// legacy dialog/*.jsonl layout are skipped.
+func DiscoverQwenPawSessions(root string) []DiscoveredFile {
+	if root == "" {
+		return nil
+	}
+	workspaceEntries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var files []DiscoveredFile
+	for _, wsEntry := range workspaceEntries {
+		if !isDirOrSymlink(wsEntry, root) {
+			continue
+		}
+		workspace := wsEntry.Name()
+		if !IsValidQwenPawIDPart(workspace) {
+			continue
+		}
+		files = append(files,
+			discoverQwenPawSessionsDir(
+				filepath.Join(root, workspace, "sessions"),
+				workspace,
+			)...,
+		)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// discoverQwenPawSessionsDir collects *.json from a sessions/ root
+// and one level of non-hidden subdirectories (e.g. console/).
+func discoverQwenPawSessionsDir(
+	sessionsDir, workspace string,
+) []DiscoveredFile {
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return nil
+	}
+	var files []DiscoveredFile
+	for _, entry := range entries {
+		if entry.IsDir() {
+			name := entry.Name()
+			if strings.HasPrefix(name, ".") || !IsValidQwenPawIDPart(name) {
+				continue
+			}
+			subDir := filepath.Join(sessionsDir, name)
+			files = append(files,
+				discoverQwenPawSessionsFiles(subDir, workspace)...,
+			)
+			continue
+		}
+		stem, ok := strings.CutSuffix(entry.Name(), ".json")
+		if !ok || !IsValidQwenPawIDPart(stem) {
+			continue
+		}
+		files = append(files, DiscoveredFile{
+			Path:    filepath.Join(sessionsDir, entry.Name()),
+			Project: workspace,
+			Agent:   AgentQwenPaw,
+		})
+	}
+	return files
+}
+
+// discoverQwenPawSessionsFiles collects *.json from a single
+// directory without recursing further.
+func discoverQwenPawSessionsFiles(
+	dir, workspace string,
+) []DiscoveredFile {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var files []DiscoveredFile
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		stem, ok := strings.CutSuffix(entry.Name(), ".json")
+		if !ok || !IsValidQwenPawIDPart(stem) {
+			continue
+		}
+		files = append(files, DiscoveredFile{
+			Path:    filepath.Join(dir, entry.Name()),
+			Project: workspace,
+			Agent:   AgentQwenPaw,
+		})
+	}
+	return files
+}
+
+// FindQwenPawSourceFile resolves a rawID to a sessions JSON file.
+//
+// Raw ID shapes:
+//
+//   - qwenpaw:<workspace>:<stem>            -> <root>/<workspace>/sessions/<stem>.json
+//   - qwenpaw:<workspace>:<subdir>:<stem>   -> <root>/<workspace>/sessions/<subdir>/<stem>.json
+//
+// The subdir segment disambiguates the sessions/console/ layout
+// from the sessions/ root so two files with the same stem cannot
+// collide.
+//
+// Returns "" when the rawID is malformed, references a traversal
+// component (".", ".."), escapes the resolved sessions directory,
+// or the file does not exist.
+func FindQwenPawSourceFile(root, rawID string) string {
+	if root == "" {
+		return ""
+	}
+	workspace, rest, ok := strings.Cut(rawID, ":")
+	if !ok {
+		return ""
+	}
+	if !IsValidQwenPawIDPart(workspace) {
+		return ""
+	}
+	var candidate string
+	if subdir, stem, found := strings.Cut(rest, ":"); found {
+		if !IsValidQwenPawIDPart(subdir) ||
+			!IsValidQwenPawIDPart(stem) {
+			return ""
+		}
+		candidate = filepath.Join(
+			root, workspace, "sessions", subdir, stem+".json",
+		)
+	} else {
+		if !IsValidQwenPawIDPart(rest) {
+			return ""
+		}
+		candidate = filepath.Join(
+			root, workspace, "sessions", rest+".json",
+		)
+	}
+	if !isUnderQwenPawRoot(root, candidate) {
+		return ""
+	}
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+	return ""
+}
+
+// isUnderQwenPawRoot reports whether candidate resolves to a path
+// inside <root>/<workspace>/sessions/. Both sides are cleaned and
+// converted to absolute form so that "." / ".." segments in the
+// candidate cannot escape the QwenPaw root.
+func isUnderQwenPawRoot(root, candidate string) bool {
+	absRoot, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return false
+	}
+	absCand, err := filepath.Abs(filepath.Clean(candidate))
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(absRoot, absCand)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return false
+	}
+	parts := strings.Split(rel, "/")
+	if len(parts) < 2 || parts[1] != "sessions" {
+		return false
+	}
+	return true
+}
+
+// IsValidQwenPawIDPart accepts workspace names and session file
+// stems. QwenPaw emits channel-scoped filenames containing dots,
+// at-signs, and double dashes (e.g. "<userId>@im.wechat_wechat--..."),
+// so the check is permissive — but it still rejects path traversal
+// components (".", "..") since those never appear in a real session
+// stem and would let a crafted raw ID escape the QwenPaw root.
+//
+// It also rejects characters that are structurally significant once a
+// part is joined into a session ID:
+//
+//   - ":" joins ID parts in qwenpawSessionID. A stem "foo:bar" would
+//     produce qwenpaw:<workspace>:foo:bar, which FindQwenPawSourceFile
+//     reparses as the sessions/foo/bar.json subdir layout.
+//   - "~" is the remote-host separator (see StripHostPrefix). A part
+//     containing it would be split off as a bogus host prefix.
+//   - "?", "#", and "%" are URL delimiters. Session IDs are
+//     interpolated into API path segments that are not all percent-
+//     encoded (e.g. the export and watch routes), so these would
+//     truncate or corrupt the path.
+func IsValidQwenPawIDPart(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	if strings.ContainsAny(s, "/\\:~?#%") {
+		return false
+	}
+	if strings.ContainsRune(s, 0) {
+		return false
+	}
+	return true
+}
+
+// qwenpawSessionID builds the canonical session ID for a file at
+// `path`. Layout determines the namespace:
+//
+//   - <workspace>/sessions/<stem>.json            -> qwenpaw:<workspace>:<stem>
+//   - <workspace>/sessions/<subdir>/<stem>.json   -> qwenpaw:<workspace>:<subdir>:<stem>
+//
+// The subdir segment prevents collisions when both
+// sessions/foo.json and sessions/console/foo.json exist in the same
+// workspace (otherwise both would become qwenpaw:<workspace>:foo
+// and one would overwrite the other during sync).
+//
+// Every component is validated with IsValidQwenPawIDPart before
+// joining: a ":" (the part separator) or path separator in any of
+// workspace/subdir/stem would make the ID ambiguous, so such a file
+// is rejected rather than silently colliding with another session.
+func qwenpawSessionID(path, project, stem string) (string, error) {
+	if !IsValidQwenPawIDPart(project) {
+		return "", fmt.Errorf(
+			"qwenpaw: invalid workspace %q for %s", project, path,
+		)
+	}
+	if !IsValidQwenPawIDPart(stem) {
+		return "", fmt.Errorf(
+			"qwenpaw: invalid session stem %q for %s", stem, path,
+		)
+	}
+	parent := filepath.Base(filepath.Dir(path))
+	if parent == "sessions" {
+		return "qwenpaw:" + project + ":" + stem, nil
+	}
+	if !IsValidQwenPawIDPart(parent) {
+		return "", fmt.Errorf(
+			"qwenpaw: invalid subdir %q for %s", parent, path,
+		)
+	}
+	return "qwenpaw:" + project + ":" + parent + ":" + stem, nil
+}
+
+// ParseQwenPawSession parses a QwenPaw sessions/<name>.json file.
+//
+// The on-disk shape is:
+//
+//	{
+//	  "agent": {
+//	    "memory": {
+//	      "content": [[message, []], [message, []], ...]
+//	    }
+//	  }
+//	}
+//
+// Each message has fields:
+//
+//   - id:        message identifier (string)
+//   - name:      sender name ("user", "<AgentName>", or "system")
+//   - role:      "user" | "assistant" | "system"
+//   - content:   array of content blocks (text/thinking/tool_use/tool_result)
+//   - metadata:  opaque object
+//   - timestamp: "YYYY-MM-DD HH:MM:SS.fff" (local time, milliseconds)
+//
+// System-role messages carry tool_result blocks (QwenPaw's equivalent
+// of Anthropic's user-side tool_result). They map to RoleUser +
+// IsSystem so they remain distinguishable from real user turns
+// without inflating UserMessageCount.
+func ParseQwenPawSession(
+	path, project, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	// gjson.GetBytes silently returns "not found" on malformed JSON,
+	// which would otherwise surface as "agent.memory.content missing"
+	// — masking the real cause. Validate up front so syntax errors
+	// are reported as such.
+	if !gjson.ValidBytes(raw) {
+		return nil, nil, fmt.Errorf(
+			"qwenpaw: malformed JSON in %s", path,
+		)
+	}
+
+	stem := strings.TrimSuffix(filepath.Base(path), ".json")
+	id, err := qwenpawSessionID(path, project, stem)
+	if err != nil {
+		return nil, nil, err
+	}
+	sess := &ParsedSession{
+		ID:      id,
+		Project: project,
+		Machine: machine,
+		Agent:   AgentQwenPaw,
+	}
+
+	contentArr := gjson.GetBytes(raw, "agent.memory.content")
+	if !contentArr.Exists() {
+		return nil, nil, fmt.Errorf(
+			"qwenpaw: agent.memory.content missing in %s", path,
+		)
+	}
+	if !contentArr.IsArray() {
+		return nil, nil, fmt.Errorf(
+			"qwenpaw: agent.memory.content not an array in %s", path,
+		)
+	}
+
+	var messages []ParsedMessage
+	var malformed int
+	ordinal := 0
+	contentArr.ForEach(func(_, entry gjson.Result) bool {
+		if !entry.IsArray() {
+			malformed++
+			return true
+		}
+		items := entry.Array()
+		if len(items) == 0 {
+			malformed++
+			return true
+		}
+		msgJSON := items[0]
+		if !msgJSON.IsObject() {
+			malformed++
+			return true
+		}
+		pm, ok := parseQwenPawMessage(msgJSON, ordinal)
+		if !ok {
+			malformed++
+			return true
+		}
+		ordinal++
+		messages = append(messages, pm)
+		return true
+	})
+
+	sess.MalformedLines = malformed
+	sess.MessageCount = len(messages)
+	for _, m := range messages {
+		if m.Role == RoleUser && !m.IsSystem {
+			sess.UserMessageCount++
+		}
+	}
+	if len(messages) > 0 {
+		sess.StartedAt = messages[0].Timestamp
+		sess.EndedAt = messages[len(messages)-1].Timestamp
+	}
+	for _, m := range messages {
+		if m.Role == RoleUser && !m.IsSystem && strings.TrimSpace(m.Content) != "" {
+			sess.FirstMessage = truncateFirstMessage(m.Content)
+			break
+		}
+	}
+
+	populateQwenPawFileFields(sess, info, path)
+	if messages == nil {
+		return sess, nil, nil
+	}
+	return sess, messages, nil
+}
+
+// parseQwenPawMessage turns one gjson message object into a
+// ParsedMessage. Returns ok=false when the role is missing or
+// unrecognized.
+func parseQwenPawMessage(
+	msg gjson.Result, ordinal int,
+) (ParsedMessage, bool) {
+	roleStr := msg.Get("role").Str
+	role, isSystem, ok := qwenpawRole(roleStr)
+	if !ok {
+		return ParsedMessage{}, false
+	}
+	pm := ParsedMessage{
+		Ordinal:   ordinal,
+		Role:      role,
+		IsSystem:  isSystem,
+		Timestamp: parseQwenPawTimestamp(msg.Get("timestamp").Str),
+	}
+
+	var textParts []string
+	content := msg.Get("content")
+	if content.IsArray() {
+		content.ForEach(func(_, block gjson.Result) bool {
+			switch block.Get("type").Str {
+			case "text":
+				if t := block.Get("text").Str; t != "" {
+					textParts = append(textParts, t)
+				}
+			case "thinking":
+				if th := block.Get("thinking").Str; th != "" {
+					pm.HasThinking = true
+					if pm.ThinkingText != "" {
+						pm.ThinkingText += "\n"
+					}
+					pm.ThinkingText += th
+				}
+			case "tool_use":
+				tc := ParsedToolCall{
+					ToolUseID: block.Get("id").Str,
+					ToolName:  block.Get("name").Str,
+					Category:  NormalizeToolCategory(block.Get("name").Str),
+				}
+				tc.InputJSON = qwenpawToolInputJSON(block)
+				pm.ToolCalls = append(pm.ToolCalls, tc)
+				pm.HasToolUse = true
+			case "tool_result":
+				output := block.Get("output")
+				tr := ParsedToolResult{
+					ToolUseID:     block.Get("id").Str,
+					ContentLength: toolResultContentLength(output),
+					ContentRaw:    output.Raw,
+				}
+				pm.ToolResults = append(pm.ToolResults, tr)
+			}
+			return true
+		})
+	}
+
+	pm.Content = strings.Join(textParts, "\n")
+	pm.ContentLength = len(pm.Content)
+	return pm, true
+}
+
+// qwenpawRole maps a QwenPaw role string to (ParsedMessage role,
+// IsSystem, ok). System messages map to RoleUser + IsSystem so tool
+// results remain queryable as user-side content while staying
+// distinguishable from real user turns.
+func qwenpawRole(role string) (RoleType, bool, bool) {
+	switch role {
+	case "user":
+		return RoleUser, false, true
+	case "assistant":
+		return RoleAssistant, false, true
+	case "system":
+		return RoleUser, true, true
+	}
+	return "", false, false
+}
+
+// qwenpawToolInputJSON selects the canonical tool input payload.
+// QwenPaw echoes the parser input both as a structured "input"
+// object and as a JSON-string "raw_input"; prefer "raw_input"
+// when present because it is the verbatim original, falling back
+// to the raw "input" object as emitted by gjson.
+func qwenpawToolInputJSON(block gjson.Result) string {
+	if raw := block.Get("raw_input"); raw.Exists() {
+		if s := strings.TrimSpace(raw.Str); s != "" {
+			return s
+		}
+	}
+	if input := block.Get("input"); input.Exists() {
+		return input.Raw
+	}
+	return "{}"
+}
+
+// parseQwenPawTimestamp parses QwenPaw's "YYYY-MM-DD HH:MM:SS.fff"
+// format. Timestamps are recorded as local wall-clock time without a
+// timezone offset, so naive values are interpreted as time.Local
+// (mirroring the Hermes parser). Empty or unparseable inputs return
+// the zero time.
+func parseQwenPawTimestamp(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.999",
+		"2006-01-02 15:04:05",
+	} {
+		if t, err := time.ParseInLocation(layout, s, time.Local); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// truncateFirstMessage caps FirstMessage length to keep list views
+// readable; the constant matches the truncation length other parsers
+// use for the same field.
+func truncateFirstMessage(s string) string {
+	const max = 300
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max])
+}
+
+// populateQwenPawFileFields fills the File metadata on the session.
+func populateQwenPawFileFields(
+	sess *ParsedSession, info os.FileInfo, path string,
+) {
+	sess.File = FileInfo{
+		Path:  path,
+		Size:  info.Size(),
+		Mtime: info.ModTime().UnixNano(),
+	}
+}

--- a/internal/parser/qwenpaw_test.go
+++ b/internal/parser/qwenpaw_test.go
@@ -1,0 +1,604 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeQwenPawSession creates a sessions/<name>.json file with the
+// QwenPaw on-disk shape:
+//
+//	{"agent": {"memory": {"content": [[msg, []], ...]}}}
+//
+// Each entry in `messages` is wrapped as [msg, []]. The path mirrors
+// ~/.copaw/workspaces/<workspace>/sessions/<name>.json.
+func writeQwenPawSession(
+	t *testing.T, workspace, name string,
+	messages []string,
+) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), workspace, "sessions")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	pairs := make([]string, len(messages))
+	for i, m := range messages {
+		pairs[i] = "[" + m + ",[]]"
+	}
+	wrapped := `{"agent":{"memory":{"content":[` +
+		strings.Join(pairs, ",") + "]}}}"
+	path := filepath.Join(dir, name+".json")
+	require.NoError(t, os.WriteFile(path, []byte(wrapped), 0o644))
+	return path
+}
+
+func TestParseQwenPawTimestamp(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{
+			"milliseconds",
+			"2026-04-19 22:37:34.004",
+			time.Date(2026, 4, 19, 22, 37, 34, 4_000_000, time.Local),
+		},
+		{
+			"no fractional",
+			"2026-04-19 22:37:34",
+			time.Date(2026, 4, 19, 22, 37, 34, 0, time.Local),
+		},
+		{"empty", "", time.Time{}},
+		{"invalid", "not-a-timestamp", time.Time{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseQwenPawTimestamp(tc.input)
+			if tc.want.IsZero() {
+				assert.True(t, got.IsZero(),
+					"expected zero time, got %v", got)
+				return
+			}
+			assert.True(t, got.Equal(tc.want),
+				"timestamp = %v, want %v", got, tc.want)
+		})
+	}
+}
+
+func TestParseQwenPawSession_BasicUserAssistant(t *testing.T) {
+	path := writeQwenPawSession(t, "default", "default_1776607601691",
+		[]string{
+			`{"id":"msg_u1","name":"user","role":"user","content":[{"type":"text","text":"你好"}],"metadata":{},"timestamp":"2026-04-19 22:37:34.004"}`,
+			`{"id":"abc1","name":"Friday","role":"assistant","content":[{"type":"text","text":"你好，有什么可以帮你的？"}],"metadata":{},"timestamp":"2026-04-19 22:37:35.123"}`,
+		},
+	)
+	sess, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assertSessionMeta(t, sess,
+		"qwenpaw:default:default_1776607601691", "default", AgentQwenPaw,
+	)
+	assert.Equal(t, "你好", sess.FirstMessage)
+	assertMessageCount(t, sess.MessageCount, 2)
+	assert.Equal(t, 1, sess.UserMessageCount)
+
+	wantStart := time.Date(
+		2026, 4, 19, 22, 37, 34, 4_000_000, time.Local,
+	)
+	assertTimestamp(t, sess.StartedAt, wantStart)
+	wantEnd := time.Date(
+		2026, 4, 19, 22, 37, 35, 123_000_000, time.Local,
+	)
+	assertTimestamp(t, sess.EndedAt, wantEnd)
+
+	require.Equal(t, 2, len(msgs))
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "你好", msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, "你好，有什么可以帮你的？", msgs[1].Content)
+}
+
+func TestParseQwenPawSession_ThinkingExtracted(t *testing.T) {
+	path := writeQwenPawSession(t, "default", "default_1",
+		[]string{
+			`{"id":"u1","name":"user","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{},"timestamp":"2026-04-19 22:37:34.000"}`,
+			`{"id":"a1","name":"Friday","role":"assistant","content":[{"type":"thinking","thinking":"我应该先思考一下"},{"type":"text","text":"答案"}],"metadata":{},"timestamp":"2026-04-19 22:37:35.000"}`,
+		},
+	)
+	_, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.Equal(t, 2, len(msgs))
+
+	assert.True(t, msgs[1].HasThinking, "HasThinking flag")
+	assert.Equal(t, "我应该先思考一下", msgs[1].ThinkingText)
+	assert.Equal(t, "答案", msgs[1].Content)
+}
+
+func TestParseQwenPawSession_ToolUseAndResult(t *testing.T) {
+	path := writeQwenPawSession(t, "default", "default_1",
+		[]string{
+			`{"id":"u1","name":"user","role":"user","content":[{"type":"text","text":"看下文件"}],"metadata":{},"timestamp":"2026-04-19 22:37:34.000"}`,
+			`{"id":"a1","name":"Friday","role":"assistant","content":[{"type":"tool_use","id":"call_abc","name":"read_file","input":{"file_path":"foo.txt"},"raw_input":"{\"file_path\":\"foo.txt\"}"}],"metadata":{},"timestamp":"2026-04-19 22:37:35.000"}`,
+			`{"id":"s1","name":"system","role":"system","content":[{"type":"tool_result","id":"call_abc","name":"read_file","output":[{"type":"text","text":"file contents here"}]}],"metadata":{},"timestamp":"2026-04-19 22:37:36.000"}`,
+			`{"id":"a2","name":"Friday","role":"assistant","content":[{"type":"text","text":"文件内容是 file contents here"}],"metadata":{},"timestamp":"2026-04-19 22:37:37.000"}`,
+		},
+	)
+	sess, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 4, len(msgs))
+
+	aMsg := msgs[1]
+	assert.Equal(t, RoleAssistant, aMsg.Role)
+	assert.True(t, aMsg.HasToolUse, "HasToolUse flag")
+	require.Equal(t, 1, len(aMsg.ToolCalls), "tool call count")
+	assert.Equal(t, "call_abc", aMsg.ToolCalls[0].ToolUseID)
+	assert.Equal(t, "read_file", aMsg.ToolCalls[0].ToolName)
+	assert.Contains(t, aMsg.ToolCalls[0].InputJSON, "foo.txt")
+
+	sMsg := msgs[2]
+	assert.Equal(t, RoleUser, sMsg.Role)
+	assert.True(t, sMsg.IsSystem, "IsSystem on tool_result carrier")
+	require.Equal(t, 1, len(sMsg.ToolResults), "tool result count")
+	assert.Equal(t, "call_abc", sMsg.ToolResults[0].ToolUseID)
+	assert.Equal(t, len("file contents here"),
+		sMsg.ToolResults[0].ContentLength,
+		"tool result ContentLength")
+}
+
+func TestParseQwenPawSession_MultipleToolUsesInOneMessage(t *testing.T) {
+	path := writeQwenPawSession(t, "default", "default_1",
+		[]string{
+			`{"id":"a1","name":"Friday","role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"read_file","input":{"file_path":"a"}},{"type":"tool_use","id":"call_2","name":"read_file","input":{"file_path":"b"}}],"metadata":{},"timestamp":"2026-04-19 22:37:35.000"}`,
+		},
+	)
+	_, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(msgs))
+	require.Equal(t, 2, len(msgs[0].ToolCalls))
+	assert.Equal(t, "call_1", msgs[0].ToolCalls[0].ToolUseID)
+	assert.Equal(t, "call_2", msgs[0].ToolCalls[1].ToolUseID)
+}
+
+func TestParseQwenPawSession_EmptyContentArray(t *testing.T) {
+	path := writeQwenPawSession(t, "default", "default_1",
+		[]string{
+			`{"id":"a1","name":"Friday","role":"assistant","content":[],"metadata":{},"timestamp":"2026-04-19 22:37:35.000"}`,
+		},
+	)
+	sess, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assertMessageCount(t, sess.MessageCount, 1)
+	require.Equal(t, 1, len(msgs))
+	assert.Equal(t, "", msgs[0].Content)
+}
+
+func TestParseQwenPawSession_MissingTimestamp(t *testing.T) {
+	path := writeQwenPawSession(t, "default", "default_1",
+		[]string{
+			`{"id":"u1","name":"user","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{}}`,
+		},
+	)
+	sess, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assertZeroTimestamp(t, sess.StartedAt, "StartedAt")
+	assertZeroTimestamp(t, sess.EndedAt, "EndedAt")
+	require.Equal(t, 1, len(msgs))
+	assertZeroTimestamp(t, msgs[0].Timestamp, "msg timestamp")
+}
+
+func TestParseQwenPawSession_NonexistentFile(t *testing.T) {
+	_, _, err := ParseQwenPawSession(
+		"/nonexistent/default/sessions/foo.json",
+		"default", "local",
+	)
+	require.Error(t, err)
+}
+
+func TestParseQwenPawSession_FileMtimeIsNanoseconds(t *testing.T) {
+	path := writeQwenPawSession(t, "default", "default_1",
+		[]string{
+			`{"id":"u1","name":"user","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{},"timestamp":"2026-04-19 22:37:34.000"}`,
+		},
+	)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	sess, _, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, info.ModTime().UnixNano(), sess.File.Mtime,
+		"Mtime must be nanoseconds")
+}
+
+func TestParseQwenPawSession_SystemTextMessage(t *testing.T) {
+	path := writeQwenPawSession(t, "default", "default_1",
+		[]string{
+			`{"id":"u1","name":"user","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{},"timestamp":"2026-04-19 22:37:34.000"}`,
+			`{"id":"s1","name":"system","role":"system","content":[{"type":"text","text":"system notice"}],"metadata":{},"timestamp":"2026-04-19 22:37:35.000"}`,
+		},
+	)
+	sess, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 2, len(msgs))
+	assert.Equal(t, RoleUser, msgs[1].Role)
+	assert.True(t, msgs[1].IsSystem)
+	assert.Equal(t, "system notice", msgs[1].Content)
+	assert.Equal(t, 1, sess.UserMessageCount)
+}
+
+func TestParseQwenPawSession_MalformedJsonReturnsError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "default", "sessions")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "broken.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("{not valid json"), 0o644))
+
+	_, _, err := ParseQwenPawSession(path, "default", "local")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed JSON",
+		"error must come from the ValidBytes guard, not content-missing")
+}
+
+func TestParseQwenPawSession_RejectsColonInIDParts(t *testing.T) {
+	content := `{"agent":{"memory":{"content":[]}}}`
+	t.Run("workspace", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "ws:bad", "sessions")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		path := filepath.Join(dir, "ok.json")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+		_, _, err := ParseQwenPawSession(path, "ws:bad", "local")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid workspace")
+	})
+	t.Run("subdir", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "default", "sessions", "sub:bad")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		path := filepath.Join(dir, "ok.json")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+		_, _, err := ParseQwenPawSession(path, "default", "local")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid subdir")
+	})
+}
+
+func TestParseQwenPawSession_EmptyContentArrayTopLevel(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "default", "sessions")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, "empty.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644))
+
+	sess, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assertMessageCount(t, sess.MessageCount, 0)
+	assert.Nil(t, msgs)
+}
+
+func TestParseQwenPawSession_SkipsNonMessageEntries(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "default", "sessions")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	content := `{"agent":{"memory":{"content":[` +
+		`[{"id":"u1","name":"user","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{},"timestamp":"2026-04-19 22:37:34.000"},[]],` +
+		`"orphan_string",` +
+		`[{"id":"a1","name":"Friday","role":"assistant","content":[{"type":"text","text":"hello"}],"metadata":{},"timestamp":"2026-04-19 22:37:35.000"},[]]` +
+		`]}}}`
+	path := filepath.Join(dir, "mixed.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	sess, msgs, err := ParseQwenPawSession(path, "default", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, 1, sess.MalformedLines)
+	assertMessageCount(t, sess.MessageCount, 2)
+	require.Equal(t, 2, len(msgs))
+}
+
+func TestDiscoverQwenPawSessions(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"default_1", "default_2"} {
+		dir := filepath.Join(root, "default", "sessions")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, name+".json"),
+			[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644,
+		))
+	}
+	fmDir := filepath.Join(root, "fund_manager", "sessions")
+	require.NoError(t, os.MkdirAll(fmDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(fmDir, "main_main.json"),
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644,
+	))
+
+	files := DiscoverQwenPawSessions(root)
+	require.Equal(t, 3, len(files))
+	for _, f := range files {
+		assert.Equal(t, AgentQwenPaw, f.Agent)
+	}
+	projects := map[string]int{}
+	for _, f := range files {
+		projects[f.Project]++
+	}
+	assert.Equal(t, 2, projects["default"])
+	assert.Equal(t, 1, projects["fund_manager"])
+}
+
+func TestDiscoverQwenPawSessions_IncludesConsoleSubdir(t *testing.T) {
+	root := t.TempDir()
+	consoleDir := filepath.Join(root, "default", "sessions", "console")
+	require.NoError(t, os.MkdirAll(consoleDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(consoleDir, "default_1.json"),
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644,
+	))
+
+	files := DiscoverQwenPawSessions(root)
+	require.Equal(t, 1, len(files))
+	assert.Equal(t, "default", files[0].Project)
+}
+
+func TestDiscoverQwenPawSessions_SkipsHiddenSubdirs(t *testing.T) {
+	root := t.TempDir()
+	legacyDir := filepath.Join(root, "default", "sessions", ".weixin-legacy")
+	require.NoError(t, os.MkdirAll(legacyDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(legacyDir, "stale.json"),
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644,
+	))
+
+	files := DiscoverQwenPawSessions(root)
+	assert.Nil(t, files)
+}
+
+func TestDiscoverQwenPawSessions_FiltersNonSessionFiles(t *testing.T) {
+	root := t.TempDir()
+	sessDir := filepath.Join(root, "default", "sessions")
+	require.NoError(t, os.MkdirAll(sessDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessDir, "default_1.json"),
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessDir, "notes.txt"),
+		[]byte("ignore\n"), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessDir, "config.json.bak"),
+		[]byte("{}\n"), 0o644,
+	))
+	dialogDir := filepath.Join(root, "default", "dialog")
+	require.NoError(t, os.MkdirAll(dialogDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dialogDir, "2026-04-08.jsonl"),
+		[]byte("{}\n"), 0o644,
+	))
+
+	files := DiscoverQwenPawSessions(root)
+	require.Equal(t, 1, len(files))
+}
+
+func TestDiscoverQwenPawSessions_EmptyAndMissing(t *testing.T) {
+	assert.Nil(t, DiscoverQwenPawSessions(""))
+	assert.Nil(t, DiscoverQwenPawSessions("/nonexistent"))
+}
+
+func TestDiscoverQwenPawSessions_SkipsFilesAtRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "loose.json"),
+		[]byte("{}\n"), 0o644,
+	))
+	files := DiscoverQwenPawSessions(root)
+	assert.Nil(t, files)
+}
+
+// When sessions/foo:bar.json (a root file whose stem contains the ID
+// separator) and sessions/foo/bar.json (a subdir file) coexist, both
+// would otherwise collapse to qwenpaw:default:foo:bar. Discovery must
+// emit only the unambiguous subdir file.
+func TestDiscoverQwenPawSessions_RejectsColliding(t *testing.T) {
+	content := []byte(`{"agent":{"memory":{"content":[]}}}`)
+	root := t.TempDir()
+	sessDir := filepath.Join(root, "default", "sessions")
+	require.NoError(t, os.MkdirAll(filepath.Join(sessDir, "foo"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessDir, "foo:bar.json"), content, 0o644))
+	subFile := filepath.Join(sessDir, "foo", "bar.json")
+	require.NoError(t, os.WriteFile(subFile, content, 0o644))
+
+	// A workspace and a subdir whose names contain ":" are also dropped.
+	colonWsDir := filepath.Join(root, "ws:bad", "sessions")
+	require.NoError(t, os.MkdirAll(colonWsDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(colonWsDir, "ok.json"), content, 0o644))
+	colonSubDir := filepath.Join(sessDir, "sub:bad")
+	require.NoError(t, os.MkdirAll(colonSubDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(colonSubDir, "ok.json"), content, 0o644))
+
+	files := DiscoverQwenPawSessions(root)
+	require.Len(t, files, 1)
+	assert.Equal(t, subFile, files[0].Path)
+
+	sess, _, err := ParseQwenPawSession(
+		files[0].Path, files[0].Project, "local")
+	require.NoError(t, err)
+	assert.Equal(t, "qwenpaw:default:foo:bar", sess.ID)
+}
+
+func TestFindQwenPawSourceFile(t *testing.T) {
+	root := t.TempDir()
+	sessDir := filepath.Join(root, "default", "sessions")
+	require.NoError(t, os.MkdirAll(sessDir, 0o755))
+	path := filepath.Join(sessDir, "default_1776607601691.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644))
+
+	assert.Equal(t, path,
+		FindQwenPawSourceFile(root, "default:default_1776607601691"))
+	assert.Equal(t, "",
+		FindQwenPawSourceFile(root, "default:does_not_exist"))
+	assert.Equal(t, "",
+		FindQwenPawSourceFile(root, "ghost:default_1"))
+	assert.Equal(t, "",
+		FindQwenPawSourceFile(root, "invalid"))
+	assert.Equal(t, "",
+		FindQwenPawSourceFile(root, "bad/workspace:default_1"))
+	assert.Equal(t, "",
+		FindQwenPawSourceFile("", "default:default_1"))
+}
+
+func TestFindQwenPawSourceFile_ConsoleSubdir(t *testing.T) {
+	root := t.TempDir()
+	consoleDir := filepath.Join(root, "default", "sessions", "console")
+	require.NoError(t, os.MkdirAll(consoleDir, 0o755))
+	path := filepath.Join(consoleDir, "default_1781268804068.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644))
+
+	// Subdir is encoded in the raw ID so the lookup is unambiguous.
+	assert.Equal(t, path,
+		FindQwenPawSourceFile(root,
+			"default:console:default_1781268804068"))
+}
+
+func TestParseQwenPawSession_IDsDifferBySubdir(t *testing.T) {
+	// Two files with the same stem under sessions/ and sessions/console/
+	// must produce distinct session IDs — otherwise the second sync
+	// overwrites the first.
+	root := t.TempDir()
+	rootDir := filepath.Join(root, "default", "sessions")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	consoleDir := filepath.Join(root, "default", "sessions", "console")
+	require.NoError(t, os.MkdirAll(consoleDir, 0o755))
+
+	rootPath := filepath.Join(rootDir, "foo.json")
+	consolePath := filepath.Join(consoleDir, "foo.json")
+	for _, p := range []string{rootPath, consolePath} {
+		require.NoError(t, os.WriteFile(p,
+			[]byte(`{"agent":{"memory":{"content":[[`+
+				`{"id":"u1","name":"user","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{},"timestamp":"2026-04-19 22:37:34.000"}`+
+				`,[]]]}}}`), 0o644))
+	}
+
+	rootSess, _, err := ParseQwenPawSession(rootPath, "default", "local")
+	require.NoError(t, err)
+	consoleSess, _, err := ParseQwenPawSession(consolePath, "default", "local")
+	require.NoError(t, err)
+
+	assert.Equal(t, "qwenpaw:default:foo", rootSess.ID,
+		"root layout ID")
+	assert.Equal(t, "qwenpaw:default:console:foo", consoleSess.ID,
+		"console subdir ID — must differ from root")
+	assert.NotEqual(t, rootSess.ID, consoleSess.ID)
+}
+
+func TestFindQwenPawSourceFile_RootAndConsoleResolveIndependently(t *testing.T) {
+	root := t.TempDir()
+	rootDir := filepath.Join(root, "default", "sessions")
+	consoleDir := filepath.Join(root, "default", "sessions", "console")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.MkdirAll(consoleDir, 0o755))
+	rootPath := filepath.Join(rootDir, "same.json")
+	consolePath := filepath.Join(consoleDir, "same.json")
+	require.NoError(t, os.WriteFile(rootPath, []byte(`{}`), 0o644))
+	require.NoError(t, os.WriteFile(consolePath, []byte(`{}`), 0o644))
+
+	// Each lookup returns the unique file that matches the encoded
+	// layout — no precedence ambiguity, no silent overwrite.
+	assert.Equal(t, rootPath,
+		FindQwenPawSourceFile(root, "default:same"))
+	assert.Equal(t, consolePath,
+		FindQwenPawSourceFile(root, "default:console:same"))
+}
+
+func TestIsValidQwenPawIDPart(t *testing.T) {
+	valid := []string{
+		"default", "note_keeper", "main_main",
+		"user@example.com_1700000000002",
+		"o9cq80wkB8F3P4xWLXsuU2hZnVYU@im.wechat_wechat--abc",
+	}
+	for _, s := range valid {
+		assert.Truef(t, IsValidQwenPawIDPart(s),
+			"IsValidQwenPawIDPart(%q) should be true", s)
+	}
+	// Structural separators (":", "~"), path separators, traversal
+	// components, and URL delimiters ("?", "#", "%") must be rejected.
+	invalid := []string{
+		"", ".", "..", "a/b", "a\\b", "a:b", "a~b",
+		"a?b", "a#b", "a%b", "host~qwenpaw",
+	}
+	for _, s := range invalid {
+		assert.Falsef(t, IsValidQwenPawIDPart(s),
+			"IsValidQwenPawIDPart(%q) should be false", s)
+	}
+}
+
+func TestFindQwenPawSourceFile_AcceptsWeirdFilenames(t *testing.T) {
+	root := t.TempDir()
+	sessDir := filepath.Join(root, "default", "sessions")
+	require.NoError(t, os.MkdirAll(sessDir, 0o755))
+	weird := "o9cq80wkB8F3P4xWLXsuU2hZnVYU@im.wechat_wechat--o9cq80wkB8F3P4xWLXsuU2hZnVYU@im.wechat"
+	path := filepath.Join(sessDir, weird+".json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644))
+
+	assert.Equal(t, path,
+		FindQwenPawSourceFile(root, "default:"+weird))
+}
+
+func TestFindQwenPawSourceFile_RejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(root, "..", "escape.json")
+	require.NoError(t, os.WriteFile(outside,
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644))
+	t.Cleanup(func() { _ = os.Remove(outside) })
+
+	for _, rawID := range []string{
+		"..:default_1",
+		"default:..",
+		"default:..:default_1",
+		".:default_1",
+		"default:.",
+	} {
+		assert.Equal(t, "", FindQwenPawSourceFile(root, rawID),
+			"rawID %q must not resolve", rawID)
+	}
+	for _, bad := range []string{".", ".."} {
+		assert.False(t, IsValidQwenPawIDPart(bad),
+			"IsValidQwenPawIDPart(%q) should be false", bad)
+	}
+}
+
+// A stem containing ":" must be rejected: ":" is the ID-part separator,
+// so a root file sessions/foo:bar.json and a subdir file
+// sessions/foo/bar.json both yield the ID qwenpaw:default:foo:bar.
+// Rejecting ":" in stems keeps the root file out of discovery so the
+// subdir file is the unambiguous owner of that ID.
+func TestFindQwenPawSourceFile_RejectsColonInStem(t *testing.T) {
+	assert.False(t, IsValidQwenPawIDPart("foo:bar"),
+		"IsValidQwenPawIDPart should reject the separator char")
+
+	root := t.TempDir()
+	subSess := filepath.Join(root, "default", "sessions", "foo")
+	require.NoError(t, os.MkdirAll(subSess, 0o755))
+	subFile := filepath.Join(subSess, "bar.json")
+	require.NoError(t, os.WriteFile(subFile,
+		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644))
+
+	// The shared raw ID resolves to the subdir file, not the rejected
+	// root-level foo:bar.json.
+	assert.Equal(t, subFile,
+		FindQwenPawSourceFile(root, "default:foo:bar"))
+}

--- a/internal/parser/qwenpaw_test.go
+++ b/internal/parser/qwenpaw_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +11,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// skipColonFilenamesOnWindows skips tests that must create files or
+// directories whose names contain ":". That character is illegal in
+// Windows filenames (reserved for NTFS alternate data streams), so the
+// colon-collision scenario these tests guard against cannot occur
+// there. TestIsValidQwenPawIDPart covers the rejection logic on every
+// platform without touching the filesystem.
+func skipColonFilenamesOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("':' is invalid in Windows filenames")
+	}
+}
 
 // writeQwenPawSession creates a sessions/<name>.json file with the
 // QwenPaw on-disk shape:
@@ -250,7 +264,10 @@ func TestParseQwenPawSession_MalformedJsonReturnsError(t *testing.T) {
 func TestParseQwenPawSession_RejectsColonInIDParts(t *testing.T) {
 	content := `{"agent":{"memory":{"content":[]}}}`
 	t.Run("workspace", func(t *testing.T) {
-		dir := filepath.Join(t.TempDir(), "ws:bad", "sessions")
+		// The workspace is passed as an argument, not derived from the
+		// path, so this stays cross-platform: the file lives in a
+		// normal directory and only the project string carries ":".
+		dir := filepath.Join(t.TempDir(), "default", "sessions")
 		require.NoError(t, os.MkdirAll(dir, 0o755))
 		path := filepath.Join(dir, "ok.json")
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
@@ -260,6 +277,9 @@ func TestParseQwenPawSession_RejectsColonInIDParts(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid workspace")
 	})
 	t.Run("subdir", func(t *testing.T) {
+		// The subdir is derived from the path, so it must exist on disk
+		// with a ":" in its name — impossible on Windows.
+		skipColonFilenamesOnWindows(t)
 		dir := filepath.Join(t.TempDir(), "default", "sessions", "sub:bad")
 		require.NoError(t, os.MkdirAll(dir, 0o755))
 		path := filepath.Join(dir, "ok.json")
@@ -408,6 +428,7 @@ func TestDiscoverQwenPawSessions_SkipsFilesAtRoot(t *testing.T) {
 // would otherwise collapse to qwenpaw:default:foo:bar. Discovery must
 // emit only the unambiguous subdir file.
 func TestDiscoverQwenPawSessions_RejectsColliding(t *testing.T) {
+	skipColonFilenamesOnWindows(t)
 	content := []byte(`{"agent":{"memory":{"content":[]}}}`)
 	root := t.TempDir()
 	sessDir := filepath.Join(root, "default", "sessions")

--- a/internal/parser/qwenpaw_test.go
+++ b/internal/parser/qwenpaw_test.go
@@ -559,11 +559,14 @@ func TestFindQwenPawSourceFile_AcceptsWeirdFilenames(t *testing.T) {
 }
 
 func TestFindQwenPawSourceFile_RejectsTraversal(t *testing.T) {
-	root := t.TempDir()
-	outside := filepath.Join(root, "..", "escape.json")
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	// A real file sits one level above root (still inside the
+	// test-owned tree) so traversal would have something to reach.
+	outside := filepath.Join(tmp, "escape.json")
 	require.NoError(t, os.WriteFile(outside,
 		[]byte(`{"agent":{"memory":{"content":[]}}}`), 0o644))
-	t.Cleanup(func() { _ = os.Remove(outside) })
 
 	for _, rawID := range []string{
 		"..:default_1",
@@ -601,4 +604,52 @@ func TestFindQwenPawSourceFile_RejectsColonInStem(t *testing.T) {
 	// root-level foo:bar.json.
 	assert.Equal(t, subFile,
 		FindQwenPawSourceFile(root, "default:foo:bar"))
+}
+
+// TestQwenPawFixtures exercises the checked-in testdata/qwenpaw tree
+// end to end: every fixture must discover, parse without error, and
+// produce its expected canonical ID. This guards against malformed or
+// drifting fixtures that would otherwise pass CI unnoticed.
+func TestQwenPawFixtures(t *testing.T) {
+	files := DiscoverQwenPawSessions(filepath.Join("testdata", "qwenpaw"))
+	require.Len(t, files, 5)
+
+	sessByID := make(map[string]*ParsedSession, len(files))
+	msgsByID := make(map[string][]ParsedMessage, len(files))
+	for _, f := range files {
+		assert.Equal(t, AgentQwenPaw, f.Agent)
+		sess, msgs, err := ParseQwenPawSession(f.Path, f.Project, "local")
+		require.NoErrorf(t, err, "parse %s", f.Path)
+		require.NotNil(t, sess)
+		sessByID[sess.ID] = sess
+		msgsByID[sess.ID] = msgs
+	}
+
+	for _, id := range []string{
+		"qwenpaw:default:default_1700000000000",
+		"qwenpaw:default:main_main",
+		"qwenpaw:default:console:default_1700000000001",
+		"qwenpaw:note_keeper:user@example.com_1700000000002",
+		"qwenpaw:researcher:empty",
+	} {
+		assert.Containsf(t, sessByID, id,
+			"fixture with ID %q must be discovered and parsed", id)
+	}
+
+	// The empty fixture yields a session with no messages.
+	assert.Empty(t, msgsByID["qwenpaw:researcher:empty"])
+
+	// main_main exercises the tool_use -> tool_result round-trip: the
+	// system-role carrier maps to RoleUser + IsSystem.
+	toolMsgs := msgsByID["qwenpaw:default:main_main"]
+	require.Len(t, toolMsgs, 4)
+	assert.True(t, toolMsgs[1].HasToolUse, "assistant message has tool_use")
+	require.Len(t, toolMsgs[1].ToolCalls, 1)
+	assert.Equal(t, "call_aaaaaaaaaaaa", toolMsgs[1].ToolCalls[0].ToolUseID)
+	resultMsg := toolMsgs[2]
+	assert.Equal(t, RoleUser, resultMsg.Role)
+	assert.True(t, resultMsg.IsSystem, "tool_result carrier is a system message")
+	require.Len(t, resultMsg.ToolResults, 1)
+	assert.Equal(t, "call_aaaaaaaaaaaa", resultMsg.ToolResults[0].ToolUseID)
+	assert.Positive(t, resultMsg.ToolResults[0].ContentLength)
 }

--- a/internal/parser/testdata/qwenpaw/default/sessions/console/default_1700000000001.json
+++ b/internal/parser/testdata/qwenpaw/default/sessions/console/default_1700000000001.json
@@ -1,0 +1,37 @@
+{
+  "agent": {
+    "memory": {
+      "content": [
+        [
+          {
+            "id": "msg_console_0001",
+            "name": "user",
+            "role": "user",
+            "content": [
+              {"type": "text", "text": "这是从 console 启动的会话"}
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-17 14:30:00.000"
+          },
+          []
+        ],
+        [
+          {
+            "id": "aID0ConAAAA",
+            "name": "Default",
+            "role": "assistant",
+            "content": [
+              {"type": "text", "text": "Console 会话写入 sessions/console/<stem>.json，与根布局同名文件互不冲突。"}
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-17 14:30:01.000"
+          },
+          []
+        ]
+      ]
+    },
+    "toolkit": {"active_groups": []},
+    "name": "Default",
+    "_sys_prompt": "redacted"
+  }
+}

--- a/internal/parser/testdata/qwenpaw/default/sessions/default_1700000000000.json
+++ b/internal/parser/testdata/qwenpaw/default/sessions/default_1700000000000.json
@@ -1,0 +1,38 @@
+{
+  "agent": {
+    "memory": {
+      "content": [
+        [
+          {
+            "id": "msg_0001",
+            "name": "user",
+            "role": "user",
+            "content": [
+              {"type": "text", "text": "QwenPaw 的默认会话布局长什么样？"}
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-15 10:00:00.000"
+          },
+          []
+        ],
+        [
+          {
+            "id": "tID1AAAAA",
+            "name": "Friday",
+            "role": "assistant",
+            "content": [
+              {"type": "thinking", "thinking": "User is asking about the session file format. Let me show them the on-disk shape."},
+              {"type": "text", "text": "默认会话写在 <workspace>/sessions/<stem>.json，顶层是 {\"agent\":{\"memory\":{\"content\":[[msg, []], ...]}}}。"}
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-15 10:00:02.500"
+          },
+          []
+        ]
+      ]
+    },
+    "toolkit": {"active_groups": []},
+    "name": "Friday",
+    "_sys_prompt": "redacted"
+  }
+}

--- a/internal/parser/testdata/qwenpaw/default/sessions/main_main.json
+++ b/internal/parser/testdata/qwenpaw/default/sessions/main_main.json
@@ -1,0 +1,76 @@
+{
+  "agent": {
+    "memory": {
+      "content": [
+        [
+          {
+            "id": "msg_0010",
+            "name": "user",
+            "role": "user",
+            "content": [
+              {"type": "text", "text": "读一下 NOTES.md 的内容"}
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-16 09:00:00.000"
+          },
+          []
+        ],
+        [
+          {
+            "id": "aID0BBBBB",
+            "name": "Friday",
+            "role": "assistant",
+            "content": [
+              {
+                "type": "tool_use",
+                "id": "call_aaaaaaaaaaaa",
+                "name": "read_file",
+                "input": {"file_path": "NOTES.md"},
+                "raw_input": "{\"file_path\":\"NOTES.md\"}"
+              }
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-16 09:00:01.250"
+          },
+          []
+        ],
+        [
+          {
+            "id": "sID0CCCCC",
+            "name": "system",
+            "role": "system",
+            "content": [
+              {
+                "type": "tool_result",
+                "id": "call_aaaaaaaaaaaa",
+                "name": "read_file",
+                "output": [
+                  {"type": "text", "text": "# NOTES\n\n- synthetic fixture for agentsview tests\n- no real user data"}
+                ]
+              }
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-16 09:00:01.500"
+          },
+          []
+        ],
+        [
+          {
+            "id": "aID1DDDDD",
+            "name": "Friday",
+            "role": "assistant",
+            "content": [
+              {"type": "text", "text": "NOTES.md 是一个合成 fixture，无真实用户数据。"}
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-16 09:00:02.000"
+          },
+          []
+        ]
+      ]
+    },
+    "toolkit": {"active_groups": []},
+    "name": "Friday",
+    "_sys_prompt": "redacted"
+  }
+}

--- a/internal/parser/testdata/qwenpaw/note_keeper/sessions/user@example.com_1700000000002.json
+++ b/internal/parser/testdata/qwenpaw/note_keeper/sessions/user@example.com_1700000000002.json
@@ -1,0 +1,37 @@
+{
+  "agent": {
+    "memory": {
+      "content": [
+        [
+          {
+            "id": "msg_chan_0001",
+            "name": "user",
+            "role": "user",
+            "content": [
+              {"type": "text", "text": "Channel-scoped 会话：文件名形如 <user_id>_<session_id>.json，可包含 @ 与点号。"}
+            ],
+            "metadata": {"source": "im_wechat"},
+            "timestamp": "2026-03-18 08:15:30.123"
+          },
+          []
+        ],
+        [
+          {
+            "id": "aID0ChanAAA",
+            "name": "Keeper",
+            "role": "assistant",
+            "content": [
+              {"type": "text", "text": "记下来了。这种文件名 challenge agentsview 的 ID 校验，需要放宽到 IsValidQwenPawIDPart。"}
+            ],
+            "metadata": {},
+            "timestamp": "2026-03-18 08:15:31.456"
+          },
+          []
+        ]
+      ]
+    },
+    "toolkit": {"active_groups": []},
+    "name": "Keeper",
+    "_sys_prompt": "redacted"
+  }
+}

--- a/internal/parser/testdata/qwenpaw/researcher/sessions/empty.json
+++ b/internal/parser/testdata/qwenpaw/researcher/sessions/empty.json
@@ -1,0 +1,10 @@
+{
+  "agent": {
+    "memory": {
+      "content": []
+    },
+    "toolkit": {"active_groups": []},
+    "name": "Researcher",
+    "_sys_prompt": "redacted"
+  }
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -44,6 +44,7 @@ const (
 	AgentAntigravity    AgentType = "antigravity"
 	AgentAntigravityCLI AgentType = "antigravity-cli"
 	AgentZed            AgentType = "zed"
+	AgentQwenPaw        AgentType = "qwenpaw"
 	AgentGptme          AgentType = "gptme"
 )
 
@@ -511,6 +512,17 @@ var Registry = []AgentDef{
 		FileBased:      true,
 		DiscoverFunc:   DiscoverAntigravityCLISessions,
 		FindSourceFunc: FindAntigravityCLISourceFile,
+	},
+	{
+		Type:           AgentQwenPaw,
+		DisplayName:    "QwenPaw",
+		EnvVar:         "QWENPAW_DIR",
+		ConfigKey:      "qwenpaw_dirs",
+		DefaultDirs:    []string{".copaw/workspaces"},
+		IDPrefix:       "qwenpaw:",
+		FileBased:      true,
+		DiscoverFunc:   DiscoverQwenPawSessions,
+		FindSourceFunc: FindQwenPawSourceFile,
 	},
 	{
 		Type:           AgentGptme,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -230,6 +230,21 @@ func TestAgentByPrefix(t *testing.T) {
 			true,
 		},
 		{
+			"qwenpaw prefix",
+			"qwenpaw:default:sess-id",
+			AgentQwenPaw,
+			true,
+		},
+		{
+			// Lock in the disjoint prefix: "qwenpaw:" must NOT be
+			// swallowed by the "qwen:" rule (no shared stem), so
+			// QwenPaw IDs never route to the Qwen agent.
+			"qwen prefix does not capture qwenpaw",
+			"qwen:sess-id",
+			AgentQwen,
+			true,
+		},
+		{
 			"deepseek tui prefix",
 			"deepseek-tui:sess-id",
 			AgentDeepSeekTUI,
@@ -307,6 +322,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentWorkBuddy,
 		AgentZencoder,
 		AgentGptme,
+		AgentQwenPaw,
 	}
 
 	expected := make(map[AgentType]bool, len(allTypes))

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -757,6 +757,44 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
+	// QwenPaw: <qwenpawDir>/<workspace>/sessions/<name>.json
+	//       or <qwenpawDir>/<workspace>/sessions/<subdir>/<name>.json
+	for _, qwenpawDir := range e.agentDirs[parser.AgentQwenPaw] {
+		if qwenpawDir == "" {
+			continue
+		}
+		if rel, ok := isUnder(qwenpawDir, path); ok {
+			parts := strings.Split(rel, sep)
+			if len(parts) < 3 || parts[1] != "sessions" {
+				continue
+			}
+			if !parser.IsValidQwenPawIDPart(parts[0]) {
+				continue
+			}
+			var stem string
+			switch {
+			case len(parts) == 3:
+				stem = parts[2]
+			case len(parts) == 4 && !strings.HasPrefix(parts[2], "."):
+				if !parser.IsValidQwenPawIDPart(parts[2]) {
+					continue
+				}
+				stem = parts[3]
+			default:
+				continue
+			}
+			sessionID, ok := strings.CutSuffix(stem, ".json")
+			if !ok || !parser.IsValidQwenPawIDPart(sessionID) {
+				continue
+			}
+			return parser.DiscoveredFile{
+				Path:    path,
+				Project: parts[0],
+				Agent:   parser.AgentQwenPaw,
+			}, true
+		}
+	}
+
 	// WorkBuddy: <workbuddyDir>/<project>/<session>.jsonl
 	//     or: <workbuddyDir>/<project>/<session>/subagents/*.jsonl
 	for _, workBuddyDir := range e.agentDirs[parser.AgentWorkBuddy] {
@@ -3326,6 +3364,8 @@ func (e *Engine) processFile(
 		res = e.processAntigravity(file, info)
 	case parser.AgentAntigravityCLI:
 		res = e.processAntigravityCLI(file, info)
+	case parser.AgentQwenPaw:
+		res = e.processQwenPaw(file, info)
 	case parser.AgentGptme:
 		res = e.processGptme(file, info)
 	default:
@@ -4347,6 +4387,43 @@ func (e *Engine) processKimi(
 		results: []parser.ParseResult{
 			{Session: *sess, Messages: msgs},
 		},
+	}
+}
+
+func (e *Engine) processQwenPaw(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	if e.shouldSkipByPath(file.Path, info) {
+		return processResult{skip: true}
+	}
+
+	sess, msgs, err := parser.ParseQwenPawSession(
+		file.Path, file.Project, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
+	}
+
+	hash, err := ComputeFileHash(file.Path)
+	if err == nil {
+		sess.File.Hash = hash
+	}
+
+	// forceReplace: QwenPaw's _atomic_write_json rewrites the entire
+	// sessions/<name>.json on every save, and ParseQwenPawSession
+	// assigns Ordinal by position in agent.memory.content. If that
+	// array is compacted, summarized, or reordered — common in
+	// agent-memory frameworks — ordinals shift, and the append-only
+	// writeMessages path would silently keep stale rows. Treat every
+	// re-parse as a full rewrite, matching OpenCode / Antigravity.
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: *sess, Messages: msgs},
+		},
+		forceReplace: true,
 	}
 }
 
@@ -5406,7 +5483,8 @@ func shouldReplaceFullParseMessages(
 		pw.sess.Agent == parser.AgentCowork ||
 		isOpenCodeFormatStorageAgent(pw.sess.Agent) ||
 		pw.sess.Agent == parser.AgentAntigravity ||
-		pw.sess.Agent == parser.AgentAntigravityCLI
+		pw.sess.Agent == parser.AgentAntigravityCLI ||
+		pw.sess.Agent == parser.AgentQwenPaw
 }
 
 // writeIncremental appends new messages and partially updates
@@ -6472,6 +6550,45 @@ func (e *Engine) SyncSingleSessionContext(
 		}
 		if file.Project == "" {
 			file.Project = "kimi"
+		}
+	case parser.AgentQwenPaw:
+		// path is <qwenpawDir>/<workspace>/sessions/<name>.json or
+		//               <qwenpawDir>/<workspace>/sessions/<subdir>/<name>.json
+		// Workspace name is the first path segment relative to the
+		// QwenPaw root.
+		for _, qwenpawDir := range e.agentDirs[parser.AgentQwenPaw] {
+			rel, ok := isUnder(qwenpawDir, path)
+			if !ok {
+				continue
+			}
+			parts := strings.Split(rel, string(filepath.Separator))
+			if len(parts) > 0 {
+				file.Project = parts[0]
+			}
+			break
+		}
+		// Fallback when the stored file_path points outside any
+		// currently configured QWENPAW_DIR (e.g. the root was
+		// removed, or the session was synced from a custom path).
+		// Without this, ParseQwenPawSession would build
+		// "qwenpaw::<stem>" and orphan the requested
+		// "qwenpaw:<workspace>:<stem>" row. Prefer the DB-stored
+		// Project as the authoritative record; parse the workspace
+		// from the sessionID prefix as a final fallback that works
+		// even when the DB row is missing or stale.
+		if file.Project == "" {
+			if sess, _ := e.db.GetSession(ctx, sessionID); sess != nil &&
+				sess.Project != "" &&
+				!parser.NeedsProjectReparse(sess.Project) {
+				file.Project = sess.Project
+			}
+		}
+		if file.Project == "" {
+			bareID := strings.TrimPrefix(sessionID, def.IDPrefix)
+			if workspace, _, ok := strings.Cut(bareID, ":"); ok &&
+				workspace != "" {
+				file.Project = workspace
+			}
 		}
 	case parser.AgentQwen:
 		// path is <qwenProjectsDir>/<encoded-project>/chats/<session>.jsonl

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1875,6 +1875,11 @@ func TestEngine_ClassifyPathsOpenCodeRemovedPartFile(
 // pointed the watcher at the wrong path, leaving live sync broken
 // even after the classifier branch is reachable.
 func TestEngine_ClassifyPathsQwenPawRejectsColon(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// ":" is invalid in Windows filenames, so colon-bearing
+		// workspace/subdir/stem paths cannot be created there.
+		t.Skip("':' is invalid in Windows filenames")
+	}
 	db := openTestDB(t)
 	qwenpawDir := t.TempDir()
 	engine := NewEngine(db, EngineConfig{

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -968,6 +968,126 @@ func TestWriteBatchAntigravityReplacesMessages(t *testing.T) {
 		"re-parsed model metadata must reach existing message rows")
 }
 
+// TestWriteBatchQwenPawReplacesMessages covers a QwenPaw session file
+// being rewritten wholesale on every save. QwenPaw's
+// _atomic_write_json rewrites the entire sessions/<name>.json on each
+// save, and the parser assigns Ordinal by position in
+// agent.memory.content. If that array is ever compacted, summarized,
+// or reordered — common in agent-memory frameworks — ordinals shift,
+// and the append-only writeMessages path would silently keep stale
+// rows. The session must go through the replace path so a rewrite is
+// applied as a delete+insert, not an ordinal-greater-than append.
+func TestWriteBatchQwenPawReplacesMessages(t *testing.T) {
+	database := openTestDB(t)
+	e := &Engine{db: database}
+
+	ts := time.Unix(1700000000, 0).UTC()
+	mkWrite := func(content string) pendingWrite {
+		msg := parser.ParsedMessage{
+			Ordinal:   0,
+			Role:      parser.RoleAssistant,
+			Content:   content,
+			Timestamp: ts,
+		}
+		return pendingWrite{
+			sess: parser.ParsedSession{
+				ID:           "qwenpaw:default:rewrite",
+				Project:      "default",
+				Machine:      "m",
+				Agent:        parser.AgentQwenPaw,
+				StartedAt:    ts,
+				EndedAt:      ts,
+				MessageCount: 1,
+			},
+			msgs: []parser.ParsedMessage{msg},
+		}
+	}
+
+	written, _, failed := e.writeBatch(
+		[]pendingWrite{mkWrite("old content")}, syncWriteDefault, false,
+	)
+	require.Equal(t, 0, failed)
+	require.Equal(t, 1, written)
+
+	written, _, failed = e.writeBatch(
+		[]pendingWrite{mkWrite("new content")}, syncWriteDefault, false,
+	)
+	require.Equal(t, 0, failed)
+	require.Equal(t, 1, written)
+
+	msgs, err := database.GetMessages(
+		context.Background(), "qwenpaw:default:rewrite", 0, 10, true,
+	)
+	require.NoError(t, err, "GetMessages")
+	require.Len(t, msgs, 1, "rewrite must replace, not append")
+	assert.Equal(t, "new content", msgs[0].Content,
+		"rewritten content must reach existing message rows")
+}
+
+// TestSyncSingleSession_QwenPawPreservesWorkspaceFromDB covers the
+// case where a QwenPaw session's stored DB file_path points outside
+// any currently configured QWENPAW_DIR (e.g. the root was removed or
+// the session was synced from a custom path). FindSourceFile still
+// returns the stored path, but the workspace derivation loop in
+// SyncSingleSessionContext finds no matching configured root, leaves
+// file.Project empty, and ParseQwenPawSession then emits a brand-new
+// qwenpaw::<stem> session — orphaning the requested
+// qwenpaw:<workspace>:<stem> row.
+//
+// The fix falls back to the DB-stored Project (consistent with the
+// Claude / Iflow / Hermes resync paths).
+func TestSyncSingleSession_QwenPawPreservesWorkspaceFromDB(t *testing.T) {
+	database := openTestDB(t)
+
+	// File at an arbitrary path NOT under any configured QWENPAW_DIR.
+	root := t.TempDir()
+	sessDir := filepath.Join(root, "my_ws", "sessions")
+	require.NoError(t, os.MkdirAll(sessDir, 0o755))
+	path := filepath.Join(sessDir, "default_1.json")
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"agent":{"memory":{"content":[[`+
+			`{"id":"u1","name":"user","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{},"timestamp":"2026-04-19 22:37:34.000"},[]`+
+			`]]}}}`), 0o644))
+
+	// Engine configured with QWENPAW_DIR pointing somewhere else
+	// entirely, so the configured-root loop cannot match.
+	otherDir := t.TempDir()
+	e := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentQwenPaw: {otherDir},
+		},
+		Machine: "local",
+	})
+
+	// Seed the DB with the canonical session row. file_path is the
+	// stored source of truth that FindSourceFile prefers.
+	const sessionID = "qwenpaw:my_ws:default_1"
+	fp := path
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:       sessionID,
+		Project:  "my_ws",
+		Machine:  "local",
+		Agent:    "qwenpaw",
+		FilePath: &fp,
+	}))
+
+	require.NoError(t, e.SyncSingleSession(sessionID))
+
+	got, err := database.GetSession(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, got, "original session must still exist")
+	assert.Equal(t, "my_ws", got.Project,
+		"workspace must be preserved when the file is outside configured roots")
+
+	// No empty-workspace orphan should have been written.
+	orphan, err := database.GetSession(
+		context.Background(), "qwenpaw::default_1",
+	)
+	require.NoError(t, err)
+	assert.Nil(t, orphan,
+		"no empty-workspace orphan session should be created")
+}
+
 // TestProcessAntigravityWALOnlyUpdateNotSkipped covers a live IDE
 // session whose gen_metadata commits land in the SQLite WAL: the main
 // .db file's size/mtime are unchanged, so the skip check must consult
@@ -1754,6 +1874,45 @@ func TestEngine_ClassifyPathsOpenCodeRemovedPartFile(
 // classified as AgentQwen — the original WatchSubdirs="chats" wiring
 // pointed the watcher at the wrong path, leaving live sync broken
 // even after the classifier branch is reachable.
+func TestEngine_ClassifyPathsQwenPawRejectsColon(t *testing.T) {
+	db := openTestDB(t)
+	qwenpawDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentQwenPaw: {qwenpawDir},
+		},
+		Machine: "local",
+	})
+
+	write := func(parts ...string) string {
+		p := filepath.Join(append([]string{qwenpawDir}, parts...)...)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("{}"), 0o644))
+		return p
+	}
+
+	rootPath := write("default", "sessions", "ok.json")
+	subPath := write("default", "sessions", "console", "ok.json")
+	// ":" in the workspace, subdir, or stem makes the joined ID
+	// ambiguous, so these must not classify.
+	colonWorkspace := write("ws:bad", "sessions", "ok.json")
+	colonSubdir := write("default", "sessions", "sub:bad", "ok.json")
+	colonStem := write("default", "sessions", "foo:bar.json")
+
+	files := engine.classifyPaths([]string{rootPath, subPath})
+	require.Len(t, files, 2)
+	for _, f := range files {
+		assert.Equal(t, parser.AgentQwenPaw, f.Agent)
+		assert.Equal(t, "default", f.Project)
+	}
+
+	got := engine.classifyPaths([]string{
+		colonWorkspace, colonSubdir, colonStem,
+	})
+	assert.Empty(t, got,
+		"colon-containing ID parts must not classify: %v", got)
+}
+
 func TestEngine_ClassifyPathsQwenSession(t *testing.T) {
 	db := openTestDB(t)
 	qwenDir := t.TempDir()

--- a/scripts/qwenpaw-fixtures/README.md
+++ b/scripts/qwenpaw-fixtures/README.md
@@ -1,0 +1,74 @@
+# QwenPaw Test Fixtures
+
+Synthetic, sanitized QwenPaw session files for agentsview regression
+testing. Covers the four on-disk layouts the parser must handle:
+
+| Fixture                                                  | Layout                  | What it exercises                                   |
+| -------------------------------------------------------- | ----------------------- | --------------------------------------------------- |
+| `default/sessions/default_1700000000000.json`            | root sessions/          | basic user/assistant exchange + thinking block      |
+| `default/sessions/main_main.json`                        | root sessions/          | tool_use + tool_result round-trip via system role   |
+| `default/sessions/console/default_1700000000001.json`    | sessions/console/       | subdir layout, exercises the ID collision fix       |
+| `note_keeper/sessions/user@example.com_1700000000002.json` | root sessions/        | channel-scoped filename (`@`, dots) — ID validation |
+| `researcher/sessions/empty.json`                         | root sessions/          | empty `agent.memory.content` edge case              |
+
+All user identifiers, agent names, file paths, and tool call IDs are
+synthetic. No PII, no live tokens, no real session UUIDs.
+
+## Regenerating
+
+The fixtures are produced by `gen.py`, which hand-authors synthetic
+QwenPaw session payloads that match the on-disk shape documented in
+QwenPaw's `session.py`. The output is pretty-printed (`indent=2`)
+for readability — it is **not** byte-identical to a live runtime's
+compact JSON, but the parser is whitespace-insensitive so this is
+fine for fixtures. From the agentsview repo root:
+
+```bash
+python3 scripts/qwenpaw-fixtures/gen.py \
+    --qwenpaw-src ~/develop/QwenPaw \
+    --out internal/parser/testdata
+```
+
+Requirements: QwenPaw source tree checked out locally. The script
+imports `qwenpaw.app.runner.session` to sanity-check the source path
+but writes fixtures directly (no QwenPaw runtime needed).
+
+## Source-of-Truth Reference
+
+The on-disk shape is defined in QwenPaw itself:
+
+- **File**: `QwenPaw/src/qwenpaw/app/runner/session.py`
+- **Serializer**: `SessionManager.save_session_state` (~line 314)
+- **Path derivation**: `SessionManager._get_save_path` (~line 258)
+- **Atomic write**: module-level `_atomic_write_json`
+
+Shape (per `state_dicts` written by `save_session_state`):
+
+```jsonc
+{
+  "agent": {
+    "memory": {
+      "content": [[message, []], [message, []], ...]
+    },
+    "toolkit": {"active_groups": []},
+    "name": "<AgentName>",
+    "_sys_prompt": "..."
+  }
+}
+```
+
+Each `message` is an Anthropic-style content block envelope:
+
+```jsonc
+{
+  "id":        "msg_..." | "<short-alphanum>",
+  "name":      "user" | "<AgentName>" | "system",
+  "role":      "user" | "assistant" | "system",
+  "content":   [text|thinking|tool_use|tool_result],
+  "metadata":  {},
+  "timestamp": "YYYY-MM-DD HH:MM:SS.fff"   // local time, ms
+}
+```
+
+System-role messages carry `tool_result` blocks (QwenPaw's equivalent
+of Anthropic's user-side tool_result).

--- a/scripts/qwenpaw-fixtures/gen.py
+++ b/scripts/qwenpaw-fixtures/gen.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Regenerate the agentsview QwenPaw fixtures.
+
+This script hand-authors synthetic QwenPaw session payloads that
+match the on-disk shape documented in
+``QwenPaw/src/qwenpaw/app/runner/session.py``. The output is written
+as pretty-printed JSON (``indent=2``) for readability — it is NOT
+byte-identical to what a live QwenPaw runtime writes (which uses
+``json.dumps(..., ensure_ascii=False)`` without indent). The parser
+treats whitespace-insensitive JSON, so test fixtures do not need
+byte-exact fidelity; they only need the right shape.
+
+Requirements
+------------
+- The QwenPaw source tree checked out locally. The script reads
+  ``src/qwenpaw/app/runner/session.py`` from that tree and inspects
+  it with the ``ast`` module purely to sanity-check the source path
+  (expected symbols: ``SessionManager``, ``save_session_state``,
+  ``_atomic_write_json``). It never imports the ``qwenpaw`` package,
+  so a malicious or compromised QwenPaw checkout cannot execute
+  arbitrary top-level code during fixture regeneration. No QwenPaw
+  runtime is needed.
+
+Usage
+-----
+    python3 scripts/qwenpaw-fixtures/gen.py \\
+        --qwenpaw-src ~/develop/QwenPaw \\
+        --out internal/parser/testdata
+
+The qwenpaw/ subtree under --out is replaced wholesale to avoid
+stale fixtures. All synthesized data is non-real — no PII,
+no live tokens, no real user identifiers.
+
+Serializer reference
+--------------------
+Source of truth for the on-disk shape:
+    QwenPaw/src/qwenpaw/app/runner/session.py
+        SessionManager.save_session_state  (line ~314)
+        SessionManager._get_save_path      (line ~258)
+        _atomic_write_json                 (module-level helper)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--qwenpaw-src",
+        required=True,
+        type=Path,
+        help="Path to a checked-out QwenPaw source tree.",
+    )
+    p.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output directory (the qwenpaw/ subtree is rebuilt here).",
+    )
+    return p.parse_args()
+
+
+# _verify_source_shape sanity-checks the QwenPaw source tree by reading
+# session.py and walking its AST — it deliberately does NOT import the
+# package, so a compromised QwenPaw checkout cannot run arbitrary code
+# during fixture regeneration. Returns True iff session.py defines a
+# SessionManager class with a save_session_state method AND a module-
+# level _atomic_write_json function. Rejecting "right symbol, wrong
+# owner" avoids a degenerate file that defines an unrelated
+# SessionManager alongside an unrelated save_session_state free function.
+def _verify_source_shape(qwenpaw_src: Path) -> bool:
+    session_py = (
+        qwenpaw_src / "src" / "qwenpaw" / "app" / "runner" / "session.py"
+    )
+    if not session_py.is_file():
+        return False
+    try:
+        tree = ast.parse(session_py.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return False
+
+    module_funcs = {
+        node.name for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+    }
+    session_manager_methods: set[str] = set()
+    for node in tree.body:
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "SessionManager"
+        ):
+            session_manager_methods = {
+                child.name for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+            break
+    return (
+        "_atomic_write_json" in module_funcs
+        and "save_session_state" in session_manager_methods
+    )
+
+
+def _msg(
+    mid: str, role: str, name: str, content: list[dict], ts: str,
+    metadata: dict | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": mid,
+        "name": name,
+        "role": role,
+        "content": content,
+        "metadata": metadata or {},
+        "timestamp": ts,
+    }
+
+
+def _pair(m: dict) -> list:
+    return [m, []]
+
+
+def _wrap(messages: list[dict], agent_name: str) -> dict:
+    return {
+        "agent": {
+            "memory": {"content": [_pair(m) for m in messages]},
+            "toolkit": {"active_groups": []},
+            "name": agent_name,
+            "_sys_prompt": "redacted",
+        }
+    }
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _build_default_basic(out_root: Path) -> None:
+    msgs = [
+        _msg(
+            "msg_0001", "user", "user",
+            [{"type": "text", "text": "QwenPaw 的默认会话布局长什么样？"}],
+            "2026-03-15 10:00:00.000",
+        ),
+        _msg(
+            "tID1AAAAA", "assistant", "Friday",
+            [
+                {"type": "thinking", "thinking": "User is asking about the session file format. Let me show them the on-disk shape."},
+                {"type": "text", "text": "默认会话写在 <workspace>/sessions/<stem>.json，顶层是 {\"agent\":{\"memory\":{\"content\":[[msg, []], ...]}}}。"},
+            ],
+            "2026-03-15 10:00:02.500",
+        ),
+    ]
+    _write(
+        out_root / "default" / "sessions" / "default_1700000000000.json",
+        _wrap(msgs, "Friday"),
+    )
+
+
+def _build_default_tool_use(out_root: Path) -> None:
+    msgs = [
+        _msg(
+            "msg_0010", "user", "user",
+            [{"type": "text", "text": "读一下 NOTES.md 的内容"}],
+            "2026-03-16 09:00:00.000",
+        ),
+        _msg(
+            "aID0BBBBB", "assistant", "Friday",
+            [{
+                "type": "tool_use",
+                "id": "call_aaaaaaaaaaaa",
+                "name": "read_file",
+                "input": {"file_path": "NOTES.md"},
+                "raw_input": "{\"file_path\":\"NOTES.md\"}",
+            }],
+            "2026-03-16 09:00:01.250",
+        ),
+        _msg(
+            "sID0CCCCC", "system", "system",
+            [{
+                "type": "tool_result",
+                "id": "call_aaaaaaaaaaaa",
+                "name": "read_file",
+                "output": [{
+                    "type": "text",
+                    "text": "# NOTES\n\n- synthetic fixture for agentsview tests\n- no real user data",
+                }],
+            }],
+            "2026-03-16 09:00:01.500",
+        ),
+        _msg(
+            "aID1DDDDD", "assistant", "Friday",
+            [{"type": "text", "text": "NOTES.md 是一个合成 fixture，无真实用户数据。"}],
+            "2026-03-16 09:00:02.000",
+        ),
+    ]
+    _write(
+        out_root / "default" / "sessions" / "main_main.json",
+        _wrap(msgs, "Friday"),
+    )
+
+
+def _build_default_console(out_root: Path) -> None:
+    msgs = [
+        _msg(
+            "msg_console_0001", "user", "user",
+            [{"type": "text", "text": "这是从 console 启动的会话"}],
+            "2026-03-17 14:30:00.000",
+        ),
+        _msg(
+            "aID0ConAAAA", "assistant", "Default",
+            [{"type": "text", "text": "Console 会话写入 sessions/console/<stem>.json，与根布局同名文件互不冲突。"}],
+            "2026-03-17 14:30:01.000",
+        ),
+    ]
+    _write(
+        out_root / "default" / "sessions" / "console" / "default_1700000000001.json",
+        _wrap(msgs, "Default"),
+    )
+
+
+def _build_note_keeper_channel_scoped(out_root: Path) -> None:
+    msgs = [
+        _msg(
+            "msg_chan_0001", "user", "user",
+            [{"type": "text", "text": "Channel-scoped 会话：文件名形如 <user_id>_<session_id>.json，可包含 @ 与点号。"}],
+            "2026-03-18 08:15:30.123",
+            metadata={"source": "im_wechat"},
+        ),
+        _msg(
+            "aID0ChanAAA", "assistant", "Keeper",
+            [{"type": "text", "text": "记下来了。这种文件名 challenge agentsview 的 ID 校验，需要放宽到 IsValidQwenPawIDPart。"}],
+            "2026-03-18 08:15:31.456",
+        ),
+    ]
+    _write(
+        out_root / "note_keeper" / "sessions" / "user@example.com_1700000000002.json",
+        _wrap(msgs, "Keeper"),
+    )
+
+
+def _build_researcher_empty(out_root: Path) -> None:
+    _write(
+        out_root / "researcher" / "sessions" / "empty.json",
+        _wrap([], "Researcher"),
+    )
+
+
+def _reject_symlink(path: Path) -> None:
+    """Abort if path is a symlink, so rmtree cannot escape the tree."""
+    if path.is_symlink():
+        raise SystemExit(
+            f"error: refusing to operate on symlink {path}; the fixture "
+            "output path and its qwenpaw/ subtree must be real directories"
+        )
+
+
+def main() -> int:
+    args = _parse_args()
+    if not _verify_source_shape(args.qwenpaw_src):
+        raise SystemExit(
+            f"error: {args.qwenpaw_src} does not look like a QwenPaw "
+            "source tree (missing src/qwenpaw/app/runner/session.py "
+            "with SessionManager.save_session_state and "
+            "_atomic_write_json)"
+        )
+    # Do NOT resolve() the deletion target: resolve() follows symlinks,
+    # so a `testdata/qwenpaw` symlink would make rmtree delete whatever
+    # it points at. Operate on the literal path and refuse symlinks for
+    # the output dir and the qwenpaw/ subtree before removing anything.
+    out_root = args.out / "qwenpaw"
+    _reject_symlink(args.out)
+    _reject_symlink(out_root)
+    if out_root.exists():
+        shutil.rmtree(out_root)
+    out_root.mkdir(parents=True)
+
+    _build_default_basic(out_root)
+    _build_default_tool_use(out_root)
+    _build_default_console(out_root)
+    _build_note_keeper_channel_scoped(out_root)
+    _build_researcher_empty(out_root)
+
+    print(f"Wrote QwenPaw fixtures under {out_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the QwenPaw coding agent to the registry and sync pipeline.

QwenPaw stores daily conversation transcripts as
`<workspace>/dialog/<YYYY-MM-DD>.jsonl` under `~/.copaw/workspaces/`.
Each runtime hosts multiple agent workspaces (`default`,
`fund_manager`, `note_keeper`, `researcher`, ...), and each workspace
logs one JSONL file per active day.

The parser handles Anthropic-style content blocks (`text`, `thinking`,
`tool_use`, `tool_result`) with one QwenPaw quirk: tool results live in
`role: "system"` messages rather than user messages. Those map to
`RoleUser + IsSystem` so they remain distinguishable from real user
turns without inflating `UserMessageCount`. Timestamps use the
`"YYYY-MM-DD HH:MM:SS.fff"` local-time format and are parsed via
`time.ParseInLocation(..., time.Local)`, mirroring the Hermes parser.

Raw session IDs use the form `<workspace>:<date>`, yielding full IDs
like `qwenpaw:default:2026-04-19`. Discovery walks
`<root>/<workspace>/dialog/*.jsonl`; the watcher path classifier and
project extraction in `internal/sync/engine.go` were extended to match.

Scope / non-goals:

- Only `dialog/*.jsonl` is parsed. The `sessions/*.json` agent-memory
  snapshots overlap with dialog content and are skipped for now.
- `inbox_traces/*.json` (cron run traces) and `inbox_events.json` are
  notification-shaped, not conversations, and are out of scope.
- Token usage aggregation from `token_usage.json` is not wired up; it
  is keyed by day/model rather than by session.

Reviewers should look at:

- `internal/parser/qwenpaw.go` — discovery, source resolution, parse
  loop, role mapping, timestamp parsing.
- `internal/parser/qwenpaw_test.go` — table-driven coverage of the
  happy path plus malformed lines, empty content, missing timestamps,
  multiple tool_use blocks, and the system-role tool_result mapping.
- `internal/sync/engine.go` — four insertion points (watcher path
  classification, process dispatch switch, new `processQwenPaw`,
  project extraction case).
- `internal/parser/types.go` — new `AgentQwenPaw` constant and
  registry entry (`EnvVar: QWENPAW_DIR`, `DefaultDirs:
  [".copaw/workspaces"]`, `IDPrefix: "qwenpaw:"`).
- `frontend/src/lib/utils/agents.ts` — label/color entry (cyan,
  matching `Qwen Code`; can be re-tinted separately if a distinct
  visual identity is desired).