### PR TITLE
Fill in cwd for pi sessions

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,6 +28,10 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 43: the Pi parser now persists cwd from the
+// session header. Existing Pi rows need re-parsing so their cwd column
+// is populated.
+//
 // Bumped to 42: the Claude parser now infers subagent parent
 // relationships from Claude Code companion directories
 // (<session>/subagents/agent-*.jsonl) and resolves externalized
@@ -195,7 +199,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 42
+const dataVersion = 43
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -588,9 +588,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionClaudeCompanionLayout(t *testing.T) {
-	assert.Equal(t, 42, CurrentDataVersion(),
-		"Claude companion-session parser changes require a data version bump")
+func TestCurrentDataVersionPiCwd(t *testing.T) {
+	assert.Equal(t, 43, CurrentDataVersion(),
+		"Pi cwd parser changes require a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -199,6 +199,7 @@ func ParsePiSession(
 		Machine:          machine,
 		Agent:            AgentPi,
 		ParentSessionID:  parentSessionID,
+		Cwd:              cwd,
 		FirstMessage:     firstMessage,
 		SessionName:      sessionName,
 		StartedAt:        startedAt,

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -35,6 +35,9 @@ func TestParsePiSession_SessionHeader(t *testing.T) {
 	assert.Equal(t, "pi:pi-test-session-uuid", sess.ID, "PRSR-01: session ID")
 	assert.Equal(t, AgentPi, sess.Agent, "PRSR-11: agent type")
 
+	assert.Equal(t, "/Users/alice/code/my-project", sess.Cwd,
+		"PRSR-01: cwd from session header")
+
 	// ExtractProjectFromCwd("/Users/alice/code/my-project") -> "my_project"
 	assert.Equal(t, "my_project", sess.Project, "PRSR-01: project from cwd")
 


### PR DESCRIPTION
This patch updates the pi session parser to extract the session's cwd. We were already extracting the `cwd` field from the session's header line, but we weren't adding it to the `ParsedSession`.