### PR TITLE
feat(parser): add MiMoCode session support via OpenCode format registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ agentsview auto-discovers sessions from all of these:
 | Kimi               | `~/.kimi/sessions/`                                    |
 | Kiro CLI           | `~/.kiro/sessions/cli/`, `~/.local/share/kiro-cli/`    |
 | Kiro IDE           | `~/Library/Application Support/Kiro/` (macOS)          |
+| MiMoCode           | `~/.local/share/mimocode/`                             |
 | OpenClaw           | `~/.openclaw/agents/`                                  |
 | OpenCode           | `~/.local/share/opencode/`                             |
 | OpenHands CLI      | `~/.openhands/conversations/`                          |

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -71,18 +71,29 @@ type OpenCodeSource struct {
 }
 
 // openCodeFormat parameterizes the shared OpenCode storage format by
-// the per-agent SQLite filename and the agent label stamped on
-// discovered sessions. Kilo is a fork of OpenCode with an identical
-// on-disk layout, so both agents share one implementation and differ
-// only in these two values.
+// the per-agent SQLite filename, the storage/<sessionSubdir> that holds
+// session JSON, and the agent label stamped on discovered sessions.
+// Kilo is a fork of OpenCode with an identical on-disk layout; MiMoCode
+// is a fork that stores sessions under storage/session_diff and a
+// mimocode.db SQLite fallback. All share one implementation and differ
+// only in these values.
 type openCodeFormat struct {
-	agent  AgentType
-	dbName string
+	agent         AgentType
+	dbName        string
+	sessionSubdir string
 }
 
 var (
-	openCodeFmt = openCodeFormat{agent: AgentOpenCode, dbName: "opencode.db"}
-	kiloFmt     = openCodeFormat{agent: AgentKilo, dbName: "kilo.db"}
+	openCodeFmt = openCodeFormat{
+		agent: AgentOpenCode, dbName: "opencode.db", sessionSubdir: "session",
+	}
+	kiloFmt = openCodeFormat{
+		agent: AgentKilo, dbName: "kilo.db", sessionSubdir: "session",
+	}
+	mimoFmt = openCodeFormat{
+		agent: AgentMiMoCode, dbName: "mimocode.db",
+		sessionSubdir: "session_diff",
+	}
 )
 
 func resolveOpenCodeFormatSource(
@@ -92,7 +103,7 @@ func resolveOpenCodeFormatSource(
 		return OpenCodeSource{}
 	}
 
-	sessionRoot := filepath.Join(root, "storage", "session")
+	sessionRoot := filepath.Join(root, "storage", f.sessionSubdir)
 	if info, err := os.Stat(sessionRoot); err == nil && info.IsDir() {
 		return OpenCodeSource{
 			Mode:        OpenCodeSourceStorage,
@@ -382,6 +393,38 @@ func ParseKiloSQLiteVirtualPath(
 	sourcePath string,
 ) (dbPath, sessionID string, ok bool) {
 	return parseOpenCodeFormatVirtualPath(kiloFmt.dbName, sourcePath)
+}
+
+// ResolveMiMoCodeSource detects whether a MiMoCode root is using
+// file-backed storage (storage/session_diff) or SQLite storage.
+func ResolveMiMoCodeSource(root string) OpenCodeSource {
+	return resolveOpenCodeFormatSource(mimoFmt, root)
+}
+
+func DiscoverMiMoCodeSessions(root string) []DiscoveredFile {
+	return discoverOpenCodeFormatSessions(mimoFmt, root)
+}
+
+func FindMiMoCodeSourceFile(root, sessionID string) string {
+	return findOpenCodeFormatSourceFile(mimoFmt, root, sessionID)
+}
+
+func MiMoCodeStorageSessionIDs(root string) map[string]struct{} {
+	return openCodeFormatStorageSessionIDs(mimoFmt, root)
+}
+
+func ResolveMiMoCodeWatchRoots(root string) []string {
+	return resolveOpenCodeFormatWatchRoots(mimoFmt, root)
+}
+
+func MiMoCodeSQLiteVirtualPath(dbPath, sessionID string) string {
+	return OpenCodeSQLiteVirtualPath(dbPath, sessionID)
+}
+
+func ParseMiMoCodeSQLiteVirtualPath(
+	sourcePath string,
+) (dbPath, sessionID string, ok bool) {
+	return parseOpenCodeFormatVirtualPath(mimoFmt.dbName, sourcePath)
 }
 
 // DiscoverClaudeProjects finds all project directories under the

--- a/internal/parser/mimocode.go
+++ b/internal/parser/mimocode.go
@@ -1,0 +1,66 @@
+package parser
+
+import "strings"
+
+// MiMoCode uses OpenCode's storage format, but stores sessions under
+// storage/session_diff and is exposed as a distinct agent with the
+// mimocode: ID prefix.
+func ParseMiMoCodeFile(
+	sessionPath, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	sess, msgs, err := ParseOpenCodeFile(sessionPath, machine)
+	if err != nil || sess == nil {
+		return sess, msgs, err
+	}
+	relabelOpenCodeSessionAsMiMoCode(sess)
+	return sess, msgs, nil
+}
+
+func ParseMiMoCodeSession(
+	dbPath, sessionID, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	sess, msgs, err := ParseOpenCodeSession(dbPath, sessionID, machine)
+	if err != nil || sess == nil {
+		return sess, msgs, err
+	}
+	relabelOpenCodeSessionAsMiMoCode(sess)
+	return sess, msgs, nil
+}
+
+func ListMiMoCodeSessionMeta(dbPath string) ([]OpenCodeSessionMeta, error) {
+	metas, err := ListOpenCodeSessionMeta(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	for i := range metas {
+		metas[i].VirtualPath = MiMoCodeSQLiteVirtualPath(
+			dbPath, metas[i].SessionID,
+		)
+	}
+	return metas, nil
+}
+
+func MiMoCodeSourceMtime(sourcePath string) (int64, error) {
+	if sourcePath == "" {
+		return 0, nil
+	}
+	if dbPath, sessionID, ok := ParseMiMoCodeSQLiteVirtualPath(sourcePath); ok {
+		return openCodeSQLiteSessionMtime(dbPath, sessionID)
+	}
+	return openCodeStorageSessionMtime(sourcePath)
+}
+
+func relabelOpenCodeSessionAsMiMoCode(sess *ParsedSession) {
+	sess.ID = strings.Replace(sess.ID, "opencode:", "mimocode:", 1)
+	if sess.ParentSessionID != "" {
+		sess.ParentSessionID = strings.Replace(
+			sess.ParentSessionID, "opencode:", "mimocode:", 1,
+		)
+	}
+	if sess.SourceSessionID != "" {
+		sess.SourceSessionID = strings.Replace(
+			sess.SourceSessionID, "opencode:", "mimocode:", 1,
+		)
+	}
+	sess.Agent = AgentMiMoCode
+}

--- a/internal/parser/mimocode_test.go
+++ b/internal/parser/mimocode_test.go
@@ -1,0 +1,95 @@
+package parser
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMiMoCodeFileRelabelsOpenCodeSession(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(
+		root, "storage", "session_diff", "global", "ses_mimo.json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id":        "ses_mimo",
+		"parentID":  "ses_parent",
+		"directory": "/home/user/code/mimoapp",
+		"title":     "MiMoCode Session",
+		"time": map[string]any{
+			"created": 1700000000000,
+			"updated": 1700000060000,
+		},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "message", "ses_mimo", "msg_1.json",
+	), map[string]any{
+		"id":        "msg_1",
+		"sessionID": "ses_mimo",
+		"role":      "user",
+		"time": map[string]any{
+			"created": 1700000000000,
+		},
+	})
+	writeOpenCodeStorageFile(t, filepath.Join(
+		root, "storage", "part", "msg_1", "prt_1.json",
+	), map[string]any{
+		"id":        "prt_1",
+		"sessionID": "ses_mimo",
+		"messageID": "msg_1",
+		"type":      "text",
+		"text":      "Hello from MiMoCode",
+		"time": map[string]any{
+			"created": 1700000000000,
+		},
+	})
+
+	sess, msgs, err := ParseMiMoCodeFile(sessionPath, "testmachine")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 1)
+
+	assert.Equal(t, "mimocode:ses_mimo", sess.ID)
+	assert.Equal(t, "mimocode:ses_parent", sess.ParentSessionID)
+	assert.Equal(t, AgentMiMoCode, sess.Agent)
+	assert.Equal(t, "mimoapp", sess.Project)
+	assert.Equal(t, "Hello from MiMoCode", msgs[0].Content)
+}
+
+func TestDiscoverMiMoCodeSessions(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(
+		root, "storage", "session_diff", "global", "ses_mimo.json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id":        "ses_mimo",
+		"directory": "/home/user/code/mimoapp",
+		"time": map[string]any{
+			"created": 1700000000000,
+			"updated": 1700000060000,
+		},
+	})
+
+	files := DiscoverMiMoCodeSessions(root)
+	require.Len(t, files, 1)
+
+	assert.Equal(t, sessionPath, files[0].Path)
+	assert.Equal(t, "mimoapp", files[0].Project)
+	assert.Equal(t, AgentMiMoCode, files[0].Agent)
+}
+
+func TestParseMiMoCodeSQLiteVirtualPath(t *testing.T) {
+	wantDBPath := filepath.Join(t.TempDir(), "mimocode.db")
+	virtual := wantDBPath + "#ses_mimo"
+	dbPath, sessionID, ok := ParseMiMoCodeSQLiteVirtualPath(virtual)
+	require.True(t, ok)
+	assert.Equal(t, wantDBPath, dbPath)
+	assert.Equal(t, "ses_mimo", sessionID)
+
+	_, _, ok = ParseMiMoCodeSQLiteVirtualPath(
+		filepath.Join(t.TempDir(), "opencode.db") + "#ses_mimo",
+	)
+	assert.False(t, ok)
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -15,6 +15,7 @@ const (
 	AgentCodex          AgentType = "codex"
 	AgentCopilot        AgentType = "copilot"
 	AgentGemini         AgentType = "gemini"
+	AgentMiMoCode       AgentType = "mimocode"
 	AgentOpenCode       AgentType = "opencode"
 	AgentKilo           AgentType = "kilo"
 	AgentOpenHands      AgentType = "openhands"
@@ -140,6 +141,23 @@ var Registry = []AgentDef{
 		FileBased:      true,
 		DiscoverFunc:   DiscoverGeminiSessions,
 		FindSourceFunc: FindGeminiSourceFile,
+	},
+	{
+		Type:        AgentMiMoCode,
+		DisplayName: "MiMoCode",
+		EnvVar:      "MIMOCODE_DIR",
+		ConfigKey:   "mimocode_dirs",
+		DefaultDirs: []string{".local/share/mimocode"},
+		IDPrefix:    "mimocode:",
+		WatchSubdirs: []string{
+			"storage/session_diff",
+			"storage/message",
+			"storage/part",
+		},
+		FileBased:      true,
+		DiscoverFunc:   DiscoverMiMoCodeSessions,
+		FindSourceFunc: FindMiMoCodeSourceFile,
+		WatchRootsFunc: ResolveMiMoCodeWatchRoots,
 	},
 	{
 		Type:        AgentOpenCode,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -138,6 +138,7 @@ func TestAgentByType(t *testing.T) {
 		{AgentCodex, true},
 		{AgentCopilot, true},
 		{AgentGemini, true},
+		{AgentMiMoCode, true},
 		{AgentOpenCode, true},
 		{AgentOpenHands, true},
 		{AgentCursor, true},
@@ -185,6 +186,12 @@ func TestAgentByPrefix(t *testing.T) {
 			"gemini prefix",
 			"gemini:sess-id",
 			AgentGemini,
+			true,
+		},
+		{
+			"mimocode prefix",
+			"mimocode:sess-id",
+			AgentMiMoCode,
 			true,
 		},
 		{
@@ -278,7 +285,9 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentCodex,
 		AgentCopilot,
 		AgentGemini,
+		AgentMiMoCode,
 		AgentOpenCode,
+		AgentKilo,
 		AgentOpenHands,
 		AgentCursor,
 		AgentAmp,
@@ -491,6 +500,25 @@ func TestAgentByPrefixCowork(t *testing.T) {
 	assert.Equal(t, AgentCowork, def.Type)
 }
 
+func TestMiMoCodeRegistryEntry(t *testing.T) {
+	def, ok := AgentByType(AgentMiMoCode)
+	require.True(t, ok, "AgentMiMoCode missing from Registry")
+	require.True(t, def.FileBased, "MiMoCode FileBased")
+	require.NotNil(t, def.DiscoverFunc, "MiMoCode DiscoverFunc")
+	require.NotNil(t, def.FindSourceFunc, "MiMoCode FindSourceFunc")
+	assert.Equal(t, "MIMOCODE_DIR", def.EnvVar)
+	assert.Equal(t, "mimocode_dirs", def.ConfigKey)
+	assert.Equal(t, []string{".local/share/mimocode"}, def.DefaultDirs)
+	assert.Equal(t, "mimocode:", def.IDPrefix)
+	want := []string{
+		"storage/session_diff",
+		"storage/message",
+		"storage/part",
+	}
+	require.Truef(t, slices.Equal(def.WatchSubdirs, want),
+		"MiMoCode WatchSubdirs = %v, want %v", def.WatchSubdirs, want)
+}
+
 func TestCommandCodeRegistryEntry(t *testing.T) {
 	def, ok := AgentByType(AgentCommandCode)
 	require.True(t, ok, "AgentCommandCode missing from Registry")
@@ -524,6 +552,29 @@ func TestResolveOpenCodeSourcePrefersStorage(t *testing.T) {
 	got := ResolveOpenCodeSource(root)
 	require.Equal(t, OpenCodeSourceStorage, got.Mode, "Mode")
 	require.Equal(t, filepath.Join(root, "storage", "session"), got.SessionRoot, "SessionRoot")
+}
+
+func TestResolveMiMoCodeSourcePrefersStorage(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "storage", "session_diff", "global")
+	require.NoError(t, os.MkdirAll(dir, 0o755), "mkdir")
+	dbPath := filepath.Join(root, "mimocode.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("x"), 0o644), "write db marker")
+
+	src := ResolveMiMoCodeSource(root)
+	require.Equal(t, OpenCodeSourceStorage, src.Mode, "Mode")
+	require.Equal(t, filepath.Join(root, "storage", "session_diff"), src.SessionRoot)
+
+	path := filepath.Join(dir, "ses_test.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"id":"ses_test","directory":"/home/user/code/my-app"}`),
+		0o644))
+
+	discovered := DiscoverMiMoCodeSessions(root)
+	require.Len(t, discovered, 1)
+	require.Equal(t, AgentMiMoCode, discovered[0].Agent)
+
+	require.Equal(t, path, FindMiMoCodeSourceFile(root, "ses_test"))
 }
 
 func TestResolveOpenCodeSourceFallsBackToSQLiteOnBrokenStoragePath(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1329,10 +1329,13 @@ func (e *Engine) classifyAntigravityCLIBrainPath(
 }
 
 // classifyOpenCodeFormatPath classifies a path under an OpenCode-format
-// root (OpenCode or its Kilo fork), which share an identical on-disk
-// layout and differ only in the SQLite filename and agent label.
+// root (OpenCode, its Kilo fork, or MiMoCode), which share an on-disk
+// layout and differ only in the SQLite filename, the storage/<subdir>
+// holding session JSON, and the agent label. MiMoCode stores sessions
+// under storage/session_diff; the session subdir is taken from the
+// resolved source rather than assumed.
 //
-//	<dir>/storage/session/<project>/<session>.json
+//	<dir>/storage/<sessionSubdir>/<project>/<session>.json
 //	<dir>/storage/message/<session>/<message>.json
 //	<dir>/storage/part/<message>/<part>.json
 func (e *Engine) classifyOpenCodeFormatPath(
@@ -1361,16 +1364,17 @@ func (e *Engine) classifyOpenCodeFormatPath(
 			}
 			continue
 		}
-		if resolveOpenCodeFormatSource(agent, dir).Mode !=
-			parser.OpenCodeSourceStorage {
+		src := resolveOpenCodeFormatSource(agent, dir)
+		if src.Mode != parser.OpenCodeSourceStorage {
 			continue
 		}
+		sessionSubdir := filepath.Base(src.SessionRoot)
 		parts := strings.Split(rel, sep)
 		switch {
 		case pathExists &&
 			len(parts) == 4 &&
 			parts[0] == "storage" &&
-			parts[1] == "session" &&
+			parts[1] == sessionSubdir &&
 			strings.HasSuffix(parts[3], ".json"):
 			return parser.DiscoveredFile{
 				Path:  path,
@@ -3395,15 +3399,15 @@ func (e *Engine) shouldCacheSkip(
 		if dir == "" {
 			continue
 		}
-		if resolveOpenCodeFormatSource(file.Agent, dir).Mode !=
-			parser.OpenCodeSourceStorage {
+		src := resolveOpenCodeFormatSource(file.Agent, dir)
+		if src.Mode != parser.OpenCodeSourceStorage {
 			continue
 		}
 		if rel, ok := isUnder(dir, file.Path); ok {
 			rel = filepath.ToSlash(rel)
-			return !strings.HasPrefix(
-				rel, "storage/session/",
-			)
+			sessionPrefix := "storage/" +
+				filepath.Base(src.SessionRoot) + "/"
+			return !strings.HasPrefix(rel, sessionPrefix)
 		}
 	}
 	return true

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -470,6 +470,11 @@ func (e *Engine) classifyOnePath(
 	); ok {
 		return df, true
 	}
+	if df, ok := e.classifyOpenCodeFormatPath(
+		parser.AgentMiMoCode, path, pathExists,
+	); ok {
+		return df, true
+	}
 	if df, ok := e.classifyKiroSQLitePath(path); ok {
 		return df, true
 	}
@@ -1586,6 +1591,9 @@ func (e *Engine) ResyncAll(
 		oldFileSessions -= e.countRootOpenCodeFormatSessions(
 			origDB, parser.AgentKilo,
 		)
+		oldFileSessions -= e.countRootOpenCodeFormatSessions(
+			origDB, parser.AgentMiMoCode,
+		)
 		if oldFileSessions < 0 {
 			oldFileSessions = 0
 		}
@@ -2216,6 +2224,13 @@ func (e *Engine) syncAllLocked(
 		stats.Aborted = true
 		return stats
 	}
+	if e.syncOpenCodeFormatAgent(
+		ctx, parser.AgentMiMoCode, "mimocode",
+		writeMode, verbose, &stats, advanceDBProgress,
+	) {
+		stats.Aborted = true
+		return stats
+	}
 
 	// Sync Warp sessions (DB-backed, not file-based).
 	tWarp := time.Now()
@@ -2619,7 +2634,7 @@ func (e *Engine) countDBBackedProgressTotal(agent parser.AgentType) int {
 		switch agent {
 		case parser.AgentKiro:
 			total += e.countOneKiroSQLiteSessions(dir)
-		case parser.AgentOpenCode, parser.AgentKilo:
+		case parser.AgentOpenCode, parser.AgentKilo, parser.AgentMiMoCode:
 			total += e.countOneOpenCodeFormatSessions(agent, dir)
 		case parser.AgentWarp:
 			total += e.countOneWarpSessions(dir)
@@ -2654,6 +2669,12 @@ func (e *Engine) countDBBackedSessions(ctx context.Context) int {
 			continue
 		}
 		total += e.countOneOpenCodeFormatSessions(parser.AgentKilo, dir)
+	}
+	for _, dir := range e.agentDirs[parser.AgentMiMoCode] {
+		if dir == "" {
+			continue
+		}
+		total += e.countOneOpenCodeFormatSessions(parser.AgentMiMoCode, dir)
 	}
 	for _, dir := range e.agentDirs[parser.AgentWarp] {
 		if dir == "" {
@@ -3222,6 +3243,8 @@ func (e *Engine) processFile(
 			statPath = dbPath
 		} else if dbPath, _, ok := parser.ParseKiloSQLiteVirtualPath(file.Path); ok {
 			statPath = dbPath
+		} else if dbPath, _, ok := parser.ParseMiMoCodeSQLiteVirtualPath(file.Path); ok {
+			statPath = dbPath
 		} else if dbPath, _, ok := parser.ParseZedSQLiteVirtualPath(file.Path); ok {
 			statPath = dbPath
 		}
@@ -3280,7 +3303,7 @@ func (e *Engine) processFile(
 		res = e.processCopilot(file, info)
 	case parser.AgentGemini:
 		res = e.processGemini(file, info)
-	case parser.AgentOpenCode, parser.AgentKilo:
+	case parser.AgentOpenCode, parser.AgentKilo, parser.AgentMiMoCode:
 		res = e.processOpenCodeFormat(file.Agent, file, info)
 	case parser.AgentOpenHands:
 		res = e.processOpenHands(file, info)
@@ -5662,7 +5685,9 @@ func (e *Engine) shouldPreserveOpenCodeFormatArchive(
 }
 
 func isOpenCodeFormatStorageAgent(agent parser.AgentType) bool {
-	return agent == parser.AgentOpenCode || agent == parser.AgentKilo
+	return agent == parser.AgentOpenCode ||
+		agent == parser.AgentKilo ||
+		agent == parser.AgentMiMoCode
 }
 
 func openCodeFormatDBName(agent parser.AgentType) string {
@@ -5671,6 +5696,8 @@ func openCodeFormatDBName(agent parser.AgentType) string {
 		return "opencode.db"
 	case parser.AgentKilo:
 		return "kilo.db"
+	case parser.AgentMiMoCode:
+		return "mimocode.db"
 	default:
 		return ""
 	}
@@ -5684,6 +5711,8 @@ func resolveOpenCodeFormatSource(
 		return parser.ResolveOpenCodeSource(dir)
 	case parser.AgentKilo:
 		return parser.ResolveKiloSource(dir)
+	case parser.AgentMiMoCode:
+		return parser.ResolveMiMoCodeSource(dir)
 	default:
 		return parser.OpenCodeSource{}
 	}
@@ -5697,6 +5726,8 @@ func openCodeFormatSourceMtime(
 		return parser.OpenCodeSourceMtime(path)
 	case parser.AgentKilo:
 		return parser.KiloSourceMtime(path)
+	case parser.AgentMiMoCode:
+		return parser.MiMoCodeSourceMtime(path)
 	default:
 		return 0, fmt.Errorf("unknown OpenCode-format agent: %s", agent)
 	}
@@ -5735,6 +5766,8 @@ func parseOpenCodeFormatSQLiteVirtualPath(
 	switch agent {
 	case parser.AgentKilo:
 		return parser.ParseKiloSQLiteVirtualPath(path)
+	case parser.AgentMiMoCode:
+		return parser.ParseMiMoCodeSQLiteVirtualPath(path)
 	default:
 		return parser.ParseOpenCodeSQLiteVirtualPath(path)
 	}
@@ -5746,6 +5779,8 @@ func listOpenCodeFormatSessionMeta(
 	switch agent {
 	case parser.AgentKilo:
 		return parser.ListKiloSessionMeta(dbPath)
+	case parser.AgentMiMoCode:
+		return parser.ListMiMoCodeSessionMeta(dbPath)
 	default:
 		return parser.ListOpenCodeSessionMeta(dbPath)
 	}
@@ -5757,6 +5792,8 @@ func openCodeFormatStorageSessionIDs(
 	switch agent {
 	case parser.AgentKilo:
 		return parser.KiloStorageSessionIDs(dir)
+	case parser.AgentMiMoCode:
+		return parser.MiMoCodeStorageSessionIDs(dir)
 	default:
 		return parser.OpenCodeStorageSessionIDs(dir)
 	}
@@ -5768,6 +5805,8 @@ func findOpenCodeFormatSourceFile(
 	switch agent {
 	case parser.AgentKilo:
 		return parser.FindKiloSourceFile(dir, sessionID)
+	case parser.AgentMiMoCode:
+		return parser.FindMiMoCodeSourceFile(dir, sessionID)
 	default:
 		return parser.FindOpenCodeSourceFile(dir, sessionID)
 	}
@@ -5779,6 +5818,8 @@ func parseOpenCodeFormatSession(
 	switch agent {
 	case parser.AgentKilo:
 		return parser.ParseKiloSession(dbPath, sessionID, machine)
+	case parser.AgentMiMoCode:
+		return parser.ParseMiMoCodeSession(dbPath, sessionID, machine)
 	default:
 		return parser.ParseOpenCodeSession(dbPath, sessionID, machine)
 	}
@@ -5790,6 +5831,8 @@ func parseOpenCodeFormatFile(
 	switch agent {
 	case parser.AgentKilo:
 		return parser.ParseKiloFile(path, machine)
+	case parser.AgentMiMoCode:
+		return parser.ParseMiMoCodeFile(path, machine)
 	default:
 		return parser.ParseOpenCodeFile(path, machine)
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -30,6 +30,7 @@ type testEnv struct {
 	geminiDir         string
 	opencodeDir       string
 	kiloDir           string
+	mimocodeDir       string
 	forgeDir          string
 	piebaldDir        string
 	iflowDir          string
@@ -108,6 +109,7 @@ func setupTestEnv(t *testing.T, opts ...TestEnvOption) *testEnv {
 
 	env := &testEnv{
 		geminiDir:         t.TempDir(),
+		mimocodeDir:       t.TempDir(),
 		forgeDir:          t.TempDir(),
 		piebaldDir:        t.TempDir(),
 		iflowDir:          t.TempDir(),
@@ -173,6 +175,7 @@ func setupTestEnv(t *testing.T, opts ...TestEnvOption) *testEnv {
 			parser.AgentGemini:         {env.geminiDir},
 			parser.AgentOpenCode:       opencodeDirs,
 			parser.AgentKilo:           kiloDirs,
+			parser.AgentMiMoCode:       {env.mimocodeDir},
 			parser.AgentForge:          {env.forgeDir},
 			parser.AgentPiebald:        {env.piebaldDir},
 			parser.AgentIflow:          {env.iflowDir},
@@ -3495,6 +3498,55 @@ func TestKiloStorageRewriteReplacesMessages(t *testing.T) {
 
 	assertMessageContent(
 		t, env.db, "kilo:"+sessionID, "rewritten kilo reply",
+	)
+}
+
+// TestMiMoCodeSessionDiffStorageWatcherEvents drives MiMoCode indexing
+// purely through SyncPaths watcher events so the path classifier is the
+// only route into the DB. The session JSON lives under
+// storage/session_diff, so classification must use the resolved session
+// subdir rather than the default storage/session. The follow-up part
+// rewrite exercises the message/part classification branch, which
+// resolves the session file under session_diff to advance the message.
+func TestMiMoCodeSessionDiffStorageWatcherEvents(t *testing.T) {
+	env := setupTestEnv(t)
+	storage := createMiMoCodeStorageFixture(t, env.mimocodeDir)
+	const sessionID = "mimo-storage-watch"
+	sessionPath := storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/mimo-app", "MiMoCode Watch",
+		1704067200000, 1704067205000,
+	)
+	require.Contains(t, sessionPath,
+		filepath.Join("storage", "session_diff"),
+		"session JSON must live under storage/session_diff")
+	storage.addMessage(
+		t, sessionID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	partPath := storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"initial mimo reply", 1704067201000,
+	)
+
+	// A session-JSON create event under storage/session_diff must
+	// classify and index the session without any prior full sync.
+	env.engine.SyncPaths([]string{sessionPath})
+	assertSessionProject(t, env.db, "mimocode:"+sessionID, "mimo_app")
+	assertMessageContent(
+		t, env.db, "mimocode:"+sessionID, "initial mimo reply",
+	)
+
+	storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"rewritten mimo reply", 1704067201000,
+	)
+	changed := time.Unix(1804067200, 0)
+	require.NoError(t, os.Chtimes(partPath, changed, changed))
+	env.engine.SyncPaths([]string{partPath})
+
+	assertMessageContent(
+		t, env.db, "mimocode:"+sessionID, "rewritten mimo reply",
 	)
 }
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -3550,6 +3550,66 @@ func TestMiMoCodeSessionDiffStorageWatcherEvents(t *testing.T) {
 	)
 }
 
+// TestSyncPathsMiMoCodeStorageIgnoresStaleSessionSkipCache covers the
+// shouldCacheSkip change: a MiMoCode session JSON under
+// storage/session_diff must never be skip-cached by its own mtime,
+// because its content depends on message/part files that change
+// independently. With the session subdir hard-coded to storage/session,
+// shouldCacheSkip would treat the session_diff file as cacheable, and a
+// stale skip-cache entry at an unchanged session mtime would suppress a
+// child-driven update.
+func TestSyncPathsMiMoCodeStorageIgnoresStaleSessionSkipCache(t *testing.T) {
+	env := setupTestEnv(t)
+	storage := createMiMoCodeStorageFixture(t, env.mimocodeDir)
+	const sessionID = "mimo-storage-skip-cache"
+	sessionPath := storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/mimo-app", "MiMoCode Skip Cache",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	partPath := storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"initial mimo reply", 1704067201000,
+	)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+	})
+	assertMessageContent(
+		t, env.db, "mimocode:"+sessionID, "initial mimo reply",
+	)
+
+	// Seed the skip cache for the session file at its current mtime.
+	info, err := os.Stat(sessionPath)
+	require.NoError(t, err, "stat session path")
+	sessionMtime := info.ModTime()
+	env.engine.InjectSkipCache(map[string]int64{
+		sessionPath: sessionMtime.UnixNano(),
+	})
+
+	// Rewrite the part while holding the session JSON mtime constant,
+	// so a stale skip-cache entry keyed on the session path would
+	// suppress the update if session files were treated as cacheable.
+	storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"rewritten mimo reply", 1704067201000,
+	)
+	require.NoError(t,
+		os.Chtimes(sessionPath, sessionMtime, sessionMtime),
+		"restore session mtime")
+
+	env.engine.SyncPaths([]string{partPath})
+
+	assertMessageContent(
+		t, env.db, "mimocode:"+sessionID, "rewritten mimo reply",
+	)
+}
+
 func TestKiloPreservesStorageArchiveAgainstSQLiteFallback(t *testing.T) {
 	env := setupTestEnv(t)
 	storage := createOpenCodeStorageFixture(t, env.kiloDir)

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -280,7 +280,7 @@ func (e *Engine) parseDiffDatabaseSources(
 					})
 				}
 			}
-		case parser.AgentOpenCode, parser.AgentKilo:
+		case parser.AgentOpenCode, parser.AgentKilo, parser.AgentMiMoCode:
 			for _, dir := range e.agentDirs[def.Type] {
 				if dir == "" {
 					continue
@@ -349,6 +349,9 @@ func stripVirtualSourceSuffix(path string) string {
 		return dbPath
 	}
 	if dbPath, _, ok := parser.ParseKiloSQLiteVirtualPath(path); ok {
+		return dbPath
+	}
+	if dbPath, _, ok := parser.ParseMiMoCodeSQLiteVirtualPath(path); ok {
 		return dbPath
 	}
 	return path

--- a/internal/sync/test_helpers_test.go
+++ b/internal/sync/test_helpers_test.go
@@ -469,14 +469,25 @@ func (oc *openCodeTestDB) replaceTextContent(
 }
 
 type openCodeStorageFixture struct {
-	root string
+	root          string
+	sessionSubdir string
 }
 
 func createOpenCodeStorageFixture(
 	t *testing.T, root string,
 ) *openCodeStorageFixture {
 	t.Helper()
-	return &openCodeStorageFixture{root: root}
+	return &openCodeStorageFixture{root: root, sessionSubdir: "session"}
+}
+
+// createMiMoCodeStorageFixture builds a fixture for MiMoCode, which
+// stores session JSON under storage/session_diff instead of
+// storage/session while sharing the message/part layout.
+func createMiMoCodeStorageFixture(
+	t *testing.T, root string,
+) *openCodeStorageFixture {
+	t.Helper()
+	return &openCodeStorageFixture{root: root, sessionSubdir: "session_diff"}
 }
 
 func (oc *openCodeStorageFixture) writeJSON(
@@ -497,7 +508,7 @@ func (oc *openCodeStorageFixture) addSession(
 ) string {
 	t.Helper()
 	return oc.writeJSON(t, filepath.Join(
-		oc.root, "storage", "session", projectID,
+		oc.root, "storage", oc.sessionSubdir, projectID,
 		sessionID+".json",
 	), map[string]any{
 		"id":        sessionID,


### PR DESCRIPTION
## Summary
- add `OpenCodeFormatDef` to `AgentDef` so agents that reuse OpenCode's storage layout are declared via registry config rather than per-agent engine wiring
- add a MiMoCode registry entry with its own env/config keys, ID prefix, default root, and `OpenCodeFormat` config
- refactor existing OpenCode discovery/source/virtual-path helpers into shared parameterized internals; engine checks use `IsOpenCodeFormatAgent()` instead of enumerating agent types
- future forks of the OpenCode storage format need only a registry entry and thin wrapper one-liners

## Scope
- bounded to parser registration, discovery/source lookup, sync engine wiring, focused parser coverage, and the supported-source README table entry
- follow-up to `#384`'s OpenCode storage-backed support; no unrelated UI, analytics, or taxonomy changes
- addresses the factoring direction from [#679 review](https://github.com/kenn-io/agentsview/pull/679#issuecomment-4701192544): "make the OpenCode path itself storage-format-agent-aware so the next fork is a registry add"

## Review Notes
- start with `OpenCodeFormatDef` and `IsOpenCodeFormatAgent` in `internal/parser/types.go`
- `buildOpenCodeParsedSession` is parameterized with `agentType` and `idPrefix` so MiMoCode sessions get `AgentMiMoCode` and `"mimocode:"` prefixes without duplicating the session builder
- `ParseOpenCodeFormatVirtualPath` iterates registered OpenCode-format DB names so engine callers don't need per-agent branches
- focused local validation covered `./internal/parser/...` with the `MiMoCode|OpenCode` filter; `go vet ./...` passed

Fixes #697
