### PR TITLE
fix(parser): import Codex renamed session titles

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -515,11 +515,26 @@ func startFileWatcher(
 	}
 
 	var roots []watchRoot
+	seenRoots := make(map[string]struct{})
+	addRoot := func(r watchRoot) {
+		if _, ok := seenRoots[r.root]; ok {
+			return
+		}
+		seenRoots[r.root] = struct{}{}
+		roots = append(roots, r)
+	}
 	for _, def := range parser.Registry {
 		if !def.FileBased {
 			continue
 		}
 		for _, d := range cfg.ResolveDirs(def.Type) {
+			if def.ShallowWatchRootsFunc != nil {
+				for _, watchDir := range def.ShallowWatchRootsFunc(d) {
+					if _, err := os.Stat(watchDir); err == nil {
+						addRoot(watchRoot{d, watchDir, true})
+					}
+				}
+			}
 			if def.WatchRootsFunc != nil {
 				watchDirs := def.WatchRootsFunc(d)
 				if len(watchDirs) == 0 {
@@ -528,9 +543,7 @@ func startFileWatcher(
 				}
 				for _, watchDir := range watchDirs {
 					if _, err := os.Stat(watchDir); err == nil {
-						roots = append(
-							roots, watchRoot{d, watchDir, def.ShallowWatch},
-						)
+						addRoot(watchRoot{d, watchDir, def.ShallowWatch})
 						continue
 					}
 					unwatchedDirs = append(unwatchedDirs, d)
@@ -539,18 +552,14 @@ func startFileWatcher(
 			}
 			if len(def.WatchSubdirs) == 0 {
 				if _, err := os.Stat(d); err == nil {
-					roots = append(
-						roots, watchRoot{d, d, def.ShallowWatch},
-					)
+					addRoot(watchRoot{d, d, def.ShallowWatch})
 				}
 				continue
 			}
 			for _, sub := range def.WatchSubdirs {
 				watchDir := filepath.Join(d, sub)
 				if _, err := os.Stat(watchDir); err == nil {
-					roots = append(
-						roots, watchRoot{d, watchDir, def.ShallowWatch},
-					)
+					addRoot(watchRoot{d, watchDir, def.ShallowWatch})
 				}
 			}
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -29,6 +29,10 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 45: the Codex parser now imports renamed session
+// titles from session_index.jsonl. Existing Codex rows need
+// re-parsing so their titles reflect later renames.
+//
 // Bumped to 44: the VSCode Copilot parser now extracts per-turn
 // token usage (promptTokens/outputTokens) and the resolved model from
 // result.metadata into usage events, session output totals, and peak
@@ -206,7 +210,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 44
+const dataVersion = 45
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -588,9 +588,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionPiCwd(t *testing.T) {
-	assert.Equal(t, 44, CurrentDataVersion(),
-		"Pi cwd parser changes require a data version bump")
+func TestCurrentDataVersionCodexTitle(t *testing.T) {
+	assert.Equal(t, 45, CurrentDataVersion(),
+		"Codex session_index.jsonl title import requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -29,6 +30,19 @@ const (
 var errCodexIncrementalNeedsFullParse = errors.New(
 	"codex subagent event requires full parse",
 )
+
+var codexSessionIndexCache = struct {
+	mu      sync.Mutex
+	entries map[string]codexSessionIndexEntry
+}{
+	entries: make(map[string]codexSessionIndexEntry),
+}
+
+type codexSessionIndexEntry struct {
+	mtime  int64
+	size   int64
+	titles map[string]string
+}
 
 // codexSessionBuilder accumulates state while scanning a Codex
 // JSONL session file line by line.
@@ -1325,12 +1339,23 @@ func ParseCodexSession(
 		}
 	}
 
+	mtime := info.ModTime().UnixNano()
+	// Include session_index.jsonl mtime so renames trigger a re-parse.
+	if idxPath := codexSessionIndexPath(path); idxPath != "" {
+		if idxInfo, err := os.Stat(idxPath); err == nil {
+			if idxMtime := idxInfo.ModTime().UnixNano(); idxMtime > mtime {
+				mtime = idxMtime
+			}
+		}
+	}
+
 	sess := &ParsedSession{
 		ID:                sessionID,
 		Project:           b.project,
 		Machine:           machine,
 		Agent:             AgentCodex,
 		FirstMessage:      b.firstMessage,
+		SessionName:       LookupCodexThreadName(path, b.sessionID),
 		StartedAt:         b.startedAt,
 		EndedAt:           b.endedAt,
 		MessageCount:      len(b.messages),
@@ -1339,13 +1364,130 @@ func ParseCodexSession(
 		File: FileInfo{
 			Path:  path,
 			Size:  info.Size(),
-			Mtime: info.ModTime().UnixNano(),
+			Mtime: mtime,
 		},
 	}
 
 	accumulateMessageTokenUsage(sess, b.messages)
 
 	return sess, b.messages, nil
+}
+
+// CodexSessionIndexFilename is the name of the Codex index file that maps
+// session UUIDs to their (renameable) thread titles. It sits next to the
+// sessions/ and archived_sessions/ directories.
+const CodexSessionIndexFilename = "session_index.jsonl"
+
+// CodexSessionIndexTitles returns the session UUID to thread-title map from
+// a Codex session_index.jsonl file, or nil when it cannot be read. The
+// underlying read is cached by path, mtime, and size.
+func CodexSessionIndexTitles(indexPath string) map[string]string {
+	titles, err := loadCodexSessionIndex(indexPath)
+	if err != nil {
+		return nil
+	}
+	return titles
+}
+
+// LookupCodexThreadName returns the current Codex thread name for a session
+// from the session_index.jsonl file next to the session root.
+func LookupCodexThreadName(sessionPath, sessionID string) string {
+	if strings.TrimSpace(sessionID) == "" {
+		return ""
+	}
+	indexPath := codexSessionIndexPath(sessionPath)
+	if indexPath == "" {
+		return ""
+	}
+	titles, err := loadCodexSessionIndex(indexPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(titles[sessionID])
+}
+
+// CodexEffectiveMtime returns the effective mtime for a Codex session file,
+// incorporating session_index.jsonl so renames invalidate the cache.
+func CodexEffectiveMtime(sessionPath string, fileMtime int64) int64 {
+	if idxPath := codexSessionIndexPath(sessionPath); idxPath != "" {
+		if si, err := os.Stat(idxPath); err == nil {
+			if idxMtime := si.ModTime().UnixNano(); idxMtime > fileMtime {
+				return idxMtime
+			}
+		}
+	}
+	return fileMtime
+}
+
+func codexSessionIndexPath(sessionPath string) string {
+	dir := filepath.Dir(sessionPath)
+	for dir != "" {
+		base := filepath.Base(dir)
+		if base == "sessions" || base == "archived_sessions" {
+			return filepath.Join(
+				filepath.Dir(dir), CodexSessionIndexFilename,
+			)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+func loadCodexSessionIndex(indexPath string) (map[string]string, error) {
+	info, err := os.Stat(indexPath)
+	if err != nil {
+		return nil, err
+	}
+
+	mtime := info.ModTime().UnixNano()
+	size := info.Size()
+
+	codexSessionIndexCache.mu.Lock()
+	if entry, ok := codexSessionIndexCache.entries[indexPath]; ok &&
+		entry.mtime == mtime && entry.size == size {
+		codexSessionIndexCache.mu.Unlock()
+		return entry.titles, nil
+	}
+	codexSessionIndexCache.mu.Unlock()
+
+	f, err := os.Open(indexPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	titles := make(map[string]string)
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 64*1024), maxLineSize)
+	for s.Scan() {
+		line := s.Text()
+		if !gjson.Valid(line) {
+			continue
+		}
+		id := gjson.Get(line, "id").Str
+		title := strings.TrimSpace(gjson.Get(line, "thread_name").Str)
+		if id == "" || title == "" {
+			continue
+		}
+		titles[id] = title
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
+	codexSessionIndexCache.mu.Lock()
+	codexSessionIndexCache.entries[indexPath] = codexSessionIndexEntry{
+		mtime:  mtime,
+		size:   size,
+		titles: titles,
+	}
+	codexSessionIndexCache.mu.Unlock()
+
+	return titles, nil
 }
 
 // classifyCodexTermination maps the most recent task lifecycle

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -48,6 +49,95 @@ func TestParseCodexSession_Basic(t *testing.T) {
 	assert.Equal(t, "codex:abc-123", sess.ID)
 	assert.Equal(t, 2, len(msgs))
 	assertSessionMeta(t, sess, "codex:abc-123", "my_api", AgentCodex)
+}
+
+func TestParseCodexSession_UsesThreadNameFromSessionIndex(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "sessions", "2026", "06", "11")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	sessionPath := filepath.Join(sessionDir, "rollout-2026-06-11T12-44-06-019eb791-cf7d-75c1-8439-9ed74c1229e1.jsonl")
+	content := loadFixture(t, "codex/standard_session.jsonl")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	index := `{"id":"abc-123","thread_name":"Renamed from Codex","updated_at":"2026-06-11T17:34:20.3755243Z"}` + "\n"
+	require.NoError(t, os.WriteFile(indexPath, []byte(index), 0o644))
+
+	sess, msgs, err := ParseCodexSession(sessionPath, "local", false)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "Renamed from Codex", sess.SessionName)
+	assert.Equal(t, "Add rate limiting", sess.FirstMessage)
+	assert.Len(t, msgs, 2)
+}
+
+func TestParseCodexSession_LeavesSessionNameEmptyWithoutThreadName(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "sessions", "2026", "06", "11")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	sessionPath := filepath.Join(sessionDir, "rollout-2026-06-11T12-44-06-019eb791-cf7d-75c1-8439-9ed74c1229e1.jsonl")
+	content := loadFixture(t, "codex/standard_session.jsonl")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	index := `{"id":"abc-123","updated_at":"2026-06-11T17:34:20.3755243Z"}` + "\n"
+	require.NoError(t, os.WriteFile(indexPath, []byte(index), 0o644))
+
+	sess, _, err := ParseCodexSession(sessionPath, "local", false)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Empty(t, sess.SessionName)
+	assert.Equal(t, "Add rate limiting", sess.FirstMessage)
+}
+
+func TestParseCodexSession_UsesThreadNameFromArchivedSessions(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "archived_sessions")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	sessionPath := filepath.Join(sessionDir, "rollout-2026-06-11T12-44-06-019eb791-cf7d-75c1-8439-9ed74c1229e1.jsonl")
+	content := loadFixture(t, "codex/standard_session.jsonl")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	index := `{"id":"abc-123","thread_name":"Archived title","updated_at":"2026-06-11T17:34:20.3755243Z"}` + "\n"
+	require.NoError(t, os.WriteFile(indexPath, []byte(index), 0o644))
+
+	sess, _, err := ParseCodexSession(sessionPath, "local", false)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "Archived title", sess.SessionName)
+}
+
+func TestParseCodexSession_MtimeIncludesSessionIndex(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "sessions", "2026", "06", "11")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	sessionPath := filepath.Join(sessionDir, "rollout-2026-06-11T12-44-06-019eb791-cf7d-75c1-8439-9ed74c1229e1.jsonl")
+	content := loadFixture(t, "codex/standard_session.jsonl")
+	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	index := `{"id":"abc-123","thread_name":"Original","updated_at":"2026-06-11T17:34:20Z"}` + "\n"
+	require.NoError(t, os.WriteFile(indexPath, []byte(index), 0o644))
+
+	sess1, _, err := ParseCodexSession(sessionPath, "local", false)
+	require.NoError(t, err)
+	mtime1 := sess1.File.Mtime
+
+	// Simulate a rename by rewriting the index after a delay.
+	future := time.Now().Add(2 * time.Second)
+	renamed := `{"id":"abc-123","thread_name":"Renamed","updated_at":"2026-06-11T18:00:00Z"}` + "\n"
+	require.NoError(t, os.WriteFile(indexPath, []byte(renamed), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, future, future))
+
+	sess2, _, err := ParseCodexSession(sessionPath, "local", false)
+	require.NoError(t, err)
+	assert.Greater(t, sess2.File.Mtime, mtime1, "mtime must advance when session_index.jsonl is updated")
+	assert.Equal(t, "Renamed", sess2.SessionName)
 }
 
 func TestParseCodexSession_PreservesAssistantBlockquotes(t *testing.T) {

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -427,6 +427,21 @@ func ParseMiMoCodeSQLiteVirtualPath(
 	return parseOpenCodeFormatVirtualPath(mimoFmt.dbName, sourcePath)
 }
 
+// ResolveCodexShallowWatchRoots returns directories that should be watched
+// shallowly (root only) for live Codex updates, in addition to the recursive
+// watch on the configured sessions root. Codex writes title renames to
+// session_index.jsonl in the parent of sessions/ and archived_sessions/, so
+// that parent must be watched for renames to surface without waiting for the
+// periodic sync. A shallow watch avoids recursing over unrelated Codex state
+// such as logs.
+func ResolveCodexShallowWatchRoots(root string) []string {
+	parent := filepath.Dir(root)
+	if parent == "" || parent == "." || parent == root {
+		return nil
+	}
+	return []string{parent}
+}
+
 // DiscoverClaudeProjects finds all project directories under the
 // Claude projects dir and returns their JSONL session files.
 func DiscoverClaudeProjects(projectsDir string) []DiscoveredFile {

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -76,6 +76,13 @@ type AgentDef struct {
 	// WatchSubdirs list. When set, it takes precedence over
 	// WatchSubdirs. Nil for agents that use WatchSubdirs.
 	WatchRootsFunc func(string) []string
+
+	// ShallowWatchRootsFunc resolves directories to watch shallowly
+	// (root only) for a configured root, in addition to the agent's
+	// normal recursive watch. Used for sibling metadata files that
+	// live outside the session tree, such as Codex's
+	// session_index.jsonl. Nil for agents with no such files.
+	ShallowWatchRootsFunc func(string) []string
 }
 
 // Registry lists all supported agents. Order is stable and
@@ -113,10 +120,11 @@ var Registry = []AgentDef{
 			".codex/sessions",
 			".codex/archived_sessions",
 		},
-		IDPrefix:       "codex:",
-		FileBased:      true,
-		DiscoverFunc:   DiscoverCodexSessions,
-		FindSourceFunc: FindCodexSourceFile,
+		IDPrefix:              "codex:",
+		FileBased:             true,
+		DiscoverFunc:          DiscoverCodexSessions,
+		FindSourceFunc:        FindCodexSourceFile,
+		ShallowWatchRootsFunc: ResolveCodexShallowWatchRoots,
 	},
 	{
 		Type:           AgentCopilot,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -737,6 +737,59 @@ func TestOpenCodeStorageSessionIDsNilForNonStorageRoot(t *testing.T) {
 	assert.Nil(t, got, "want nil for SQLite-only root")
 }
 
+func TestResolveCodexShallowWatchRoots(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+		want []string
+	}{
+		{
+			name: "sessions dir",
+			root: filepath.Join("home", ".codex", "sessions"),
+			want: []string{filepath.Join("home", ".codex")},
+		},
+		{
+			name: "archived sessions dir",
+			root: filepath.Join("home", ".codex", "archived_sessions"),
+			want: []string{filepath.Join("home", ".codex")},
+		},
+		{
+			name: "empty root",
+			root: "",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveCodexShallowWatchRoots(tt.root)
+			assert.Truef(t, slices.Equal(got, tt.want),
+				"ResolveCodexShallowWatchRoots(%q) = %v, want %v",
+				tt.root, got, tt.want)
+		})
+	}
+}
+
+func TestCodexDefShallowWatchesIndexParent(t *testing.T) {
+	var def AgentDef
+	found := false
+	for _, d := range Registry {
+		if d.Type == AgentCodex {
+			def = d
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "Codex agent def must exist")
+	require.NotNil(t, def.ShallowWatchRootsFunc,
+		"Codex must watch its index parent shallowly")
+	got := def.ShallowWatchRootsFunc(
+		filepath.Join("home", ".codex", "sessions"),
+	)
+	want := []string{filepath.Join("home", ".codex")}
+	assert.Truef(t, slices.Equal(got, want),
+		"Codex ShallowWatchRootsFunc = %v, want %v", got, want)
+}
+
 func TestResolveOpenCodeWatchRootsStorage(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.MkdirAll(

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -8,14 +8,20 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 )
 
+// resolveFilePrefix marks lines in the resolve script output that name
+// an extra file (not an agent directory) to include in the transfer. It
+// is not a valid agent type, so parseResolvedDirs routes it separately.
+const resolveFilePrefix = "@file"
+
 // buildResolveScript generates a shell script that echoes each
 // file-based agent's resolved directory on the remote host.
-// Output format: "agentType:dir\n" per agent.
+// Output format: "agentType:dir\n" per agent, plus "@file:path\n"
+// lines for sibling metadata files such as Codex's session_index.jsonl.
 //
 // Only includes agents where FileBased is true and DiscoverFunc
 // is non-nil. For each agent with an EnvVar, the script checks
-// the env var first and falls back to the default dir. Dirs that
-// don't exist on the remote are skipped.
+// the env var first and falls back to the default dir. Dirs (and
+// files) that don't exist on the remote are skipped.
 func buildResolveScript() string {
 	var b strings.Builder
 	for _, def := range parser.Registry {
@@ -24,63 +30,80 @@ func buildResolveScript() string {
 		}
 		for _, rel := range def.DefaultDirs {
 			defaultDir := "$HOME/" + rel
+			dirExpr := defaultDir
 			if def.EnvVar != "" {
 				// env var overrides default
+				dirExpr = fmt.Sprintf("${%s:-%s}", def.EnvVar, defaultDir)
+			}
+			fmt.Fprintf(&b,
+				"dir=\"%s\"; [ -d \"$dir\" ] && echo \"%s:$dir\"\n",
+				dirExpr, string(def.Type),
+			)
+			// Codex stores renameable session titles in
+			// session_index.jsonl, which sits beside (not inside)
+			// sessions/ and archived_sessions/. Emit it so renames
+			// import on remote hosts too. ${dir%/*} is the parent.
+			if def.Type == parser.AgentCodex {
 				fmt.Fprintf(&b,
-					"dir=\"${%s:-%s}\"; "+
-						"[ -d \"$dir\" ] && "+
-						"echo \"%s:$dir\"\n",
-					def.EnvVar, defaultDir,
-					string(def.Type),
-				)
-			} else {
-				fmt.Fprintf(&b,
-					"dir=\"%s\"; "+
-						"[ -d \"$dir\" ] && "+
-						"echo \"%s:$dir\"\n",
-					defaultDir,
-					string(def.Type),
+					"idx=\"${dir%%/*}/%s\"; "+
+						"[ -f \"$idx\" ] && echo \"%s:$idx\"\n",
+					parser.CodexSessionIndexFilename,
+					resolveFilePrefix,
 				)
 			}
 		}
 	}
-	// Ensure exit 0 — the last [ -d ] test may fail if that
-	// dir doesn't exist, which would make sh exit non-zero.
+	// Ensure exit 0 — the last [ -d ]/[ -f ] test may fail if that
+	// path doesn't exist, which would make sh exit non-zero.
 	b.WriteString("true\n")
 	return b.String()
 }
 
-// parseResolvedDirs parses script output into a map of agent type
-// to directory paths. Skips empty lines and entries with empty dir.
+// parseResolvedDirs parses script output into a map of agent type to
+// directory paths plus a deduplicated list of extra files (lines tagged
+// with resolveFilePrefix). Skips empty lines and entries with empty
+// values.
 func parseResolvedDirs(
 	output string,
-) map[parser.AgentType][]string {
-	result := make(map[parser.AgentType][]string)
+) (map[parser.AgentType][]string, []string) {
+	dirs := make(map[parser.AgentType][]string)
+	var extraFiles []string
+	seenFile := make(map[string]struct{})
 	for line := range strings.SplitSeq(output, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		agentStr, dir, ok := strings.Cut(line, ":")
-		if !ok || dir == "" {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok || value == "" {
 			continue
 		}
-		at := parser.AgentType(agentStr)
-		result[at] = append(result[at], dir)
+		if key == resolveFilePrefix {
+			if _, dup := seenFile[value]; dup {
+				continue
+			}
+			seenFile[value] = struct{}{}
+			extraFiles = append(extraFiles, value)
+			continue
+		}
+		at := parser.AgentType(key)
+		dirs[at] = append(dirs[at], value)
 	}
-	return result
+	return dirs, extraFiles
 }
 
-// resolveDirs runs the resolve script on the remote host via SSH
-// and returns the discovered agent directories.
+// resolveDirs runs the resolve script on the remote host via SSH and
+// returns the discovered agent directories plus extra sibling files
+// (such as Codex's session_index.jsonl) to include in the transfer.
 func resolveDirs(
 	ctx context.Context,
 	host, user string, port int, sshOpts []string,
-) (map[parser.AgentType][]string, error) {
+) (map[parser.AgentType][]string, []string, error) {
 	script := buildResolveScript()
 	out, err := runSSH(ctx, host, user, port, sshOpts, script)
 	if err != nil {
-		return nil, fmt.Errorf("resolve dirs: %w", err)
+		return nil, nil, fmt.Errorf("resolve dirs: %w", err)
 	}
-	return parseResolvedDirs(string(out)), nil
+	dirs, extraFiles := parseResolvedDirs(string(out))
+	return dirs, extraFiles, nil
 }

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -69,11 +69,25 @@ func TestResolveScriptIncludesCodexIndex(t *testing.T) {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "resolve script failed: output: %s", out)
 
+	// The script runs in a POSIX shell (MSYS on Windows), so it emits
+	// forward-slash paths that differ from native filepath.Join output.
+	// Match by POSIX suffix, which also guards against the parent
+	// expansion collapsing the index path to /session_index.jsonl.
 	dirs, extraFiles := parseResolvedDirs(string(out))
-	assert.Contains(t, dirs[parser.AgentCodex], sessionsDir,
-		"codex sessions dir should be resolved")
-	assert.Contains(t, extraFiles, indexPath,
-		"codex session_index.jsonl should be included as an extra file")
+	assert.Truef(t, hasSuffix(dirs[parser.AgentCodex], ".codex/sessions"),
+		"codex sessions dir should be resolved, got %v", dirs[parser.AgentCodex])
+	assert.Truef(t, hasSuffix(extraFiles, ".codex/session_index.jsonl"),
+		"codex session_index.jsonl should be an extra file, got %v", extraFiles)
+}
+
+// hasSuffix reports whether any element of paths ends with suffix.
+func hasSuffix(paths []string, suffix string) bool {
+	for _, p := range paths {
+		if strings.HasSuffix(p, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 // TestResolveScriptSkipsMissingCodexIndex verifies that a missing index

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -1,7 +1,9 @@
 package ssh
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -50,21 +52,71 @@ func TestResolveScriptExitsZero(t *testing.T) {
 	assert.Empty(t, strings.TrimSpace(string(out)))
 }
 
+// TestResolveScriptIncludesCodexIndex verifies the resolve script emits the
+// Codex session_index.jsonl as an extra file when it exists, so renamed
+// titles get transferred and imported during remote SSH sync. Runs the real
+// script through sh against a temp HOME rather than mocking it.
+func TestResolveScriptIncludesCodexIndex(t *testing.T) {
+	home := t.TempDir()
+	sessionsDir := filepath.Join(home, ".codex", "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755), "mkdir sessions")
+	indexPath := filepath.Join(home, ".codex", "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, []byte("{}\n"), 0o644), "write index")
+
+	script := buildResolveScript()
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = []string{"HOME=" + home}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "resolve script failed: output: %s", out)
+
+	dirs, extraFiles := parseResolvedDirs(string(out))
+	assert.Contains(t, dirs[parser.AgentCodex], sessionsDir,
+		"codex sessions dir should be resolved")
+	assert.Contains(t, extraFiles, indexPath,
+		"codex session_index.jsonl should be included as an extra file")
+}
+
+// TestResolveScriptSkipsMissingCodexIndex verifies that a missing index
+// produces no extra-file entry, so the transfer's tar command never names a
+// nonexistent path (which would be a fatal, non-benign error).
+func TestResolveScriptSkipsMissingCodexIndex(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t,
+		os.MkdirAll(filepath.Join(home, ".codex", "sessions"), 0o755),
+		"mkdir sessions")
+
+	script := buildResolveScript()
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = []string{"HOME=" + home}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "resolve script failed: output: %s", out)
+
+	_, extraFiles := parseResolvedDirs(string(out))
+	assert.Empty(t, extraFiles,
+		"no extra files when session_index.jsonl is absent")
+}
+
 func TestParseResolvedDirs(t *testing.T) {
 	input := "claude:/home/wes/.claude/projects\n" +
+		"codex:/home/wes/.codex/sessions\n" +
 		"codex:\n" +
 		"copilot:/home/wes/.copilot\n" +
+		"@file:/home/wes/.codex/session_index.jsonl\n" +
+		"@file:/home/wes/.codex/session_index.jsonl\n" +
 		"\n"
 
-	dirs := parseResolvedDirs(input)
+	dirs, extraFiles := parseResolvedDirs(input)
 
-	// codex has empty dir — excluded.
-	_, ok := dirs[parser.AgentCodex]
-	assert.False(t, ok, "codex should be excluded (empty dir)")
+	// codex has one valid dir and one empty (excluded) entry.
+	assert.Equal(t, []string{"/home/wes/.codex/sessions"}, dirs[parser.AgentCodex])
 
 	// claude and copilot present.
 	assert.Equal(t, []string{"/home/wes/.claude/projects"}, dirs[parser.AgentClaude])
 	assert.Equal(t, []string{"/home/wes/.copilot"}, dirs[parser.AgentCopilot])
 
-	assert.Len(t, dirs, 2)
+	assert.Len(t, dirs, 3)
+
+	// The duplicate index file line is deduplicated.
+	assert.Equal(t,
+		[]string{"/home/wes/.codex/session_index.jsonl"}, extraFiles)
 }

--- a/internal/ssh/sync.go
+++ b/internal/ssh/sync.go
@@ -44,7 +44,7 @@ func (rs *RemoteSync) Run(
 	fmt.Printf(
 		"Resolving agent directories on %s...\n", rs.Host,
 	)
-	dirs, err := resolveDirs(
+	dirs, extraFiles, err := resolveDirs(
 		ctx, rs.Host, rs.User, rs.Port, rs.SSHOpts,
 	)
 	if err != nil {
@@ -62,7 +62,7 @@ func (rs *RemoteSync) Run(
 		rs.Host, len(dirs),
 	)
 	tmpDir, err := downloadAndExtract(
-		ctx, rs.Host, rs.User, rs.Port, rs.SSHOpts, dirs,
+		ctx, rs.Host, rs.User, rs.Port, rs.SSHOpts, dirs, extraFiles,
 	)
 	if err != nil {
 		return stats, fmt.Errorf(

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -15,17 +15,22 @@ import (
 )
 
 // buildTarCommand generates the remote tar command for the given
-// agent directories. Uses -C / so paths are relative to root.
-// Strips leading / from each dir and shell-quotes each path.
+// agent directories and extra files. Uses -C / so paths are relative
+// to root. Strips leading / from each path and shell-quotes it. The
+// extra files are resolved to exist on the remote (see
+// buildResolveScript), so tar does not fail on a missing path.
 func buildTarCommand(
 	dirs map[parser.AgentType][]string,
+	extraFiles []string,
 ) string {
 	var paths []string
 	for _, agentDirs := range dirs {
 		for _, d := range agentDirs {
-			p := strings.TrimPrefix(d, "/")
-			paths = append(paths, shellQuote(p))
+			paths = append(paths, shellQuote(strings.TrimPrefix(d, "/")))
 		}
+	}
+	for _, f := range extraFiles {
+		paths = append(paths, shellQuote(strings.TrimPrefix(f, "/")))
 	}
 	return "tar cf - -C / -- " + strings.Join(paths, " ")
 }
@@ -42,8 +47,9 @@ func downloadAndExtract(
 	ctx context.Context,
 	host, user string, port int, sshOpts []string,
 	dirs map[parser.AgentType][]string,
+	extraFiles []string,
 ) (string, error) {
-	tarCmd := buildTarCommand(dirs)
+	tarCmd := buildTarCommand(dirs, extraFiles)
 	stdout, cleanup, err := runSSHStream(
 		ctx, host, user, port, sshOpts, tarCmd,
 	)

--- a/internal/ssh/transfer_test.go
+++ b/internal/ssh/transfer_test.go
@@ -14,14 +14,16 @@ func TestBuildTarCommand(t *testing.T) {
 		parser.AgentClaude: {"/home/wes/.claude/projects"},
 		parser.AgentCodex:  {"/home/wes/.codex/sessions"},
 	}
-	cmd := buildTarCommand(dirs)
+	cmd := buildTarCommand(dirs, []string{"/home/wes/.codex/session_index.jsonl"})
 
 	assert.True(t, strings.HasPrefix(cmd, "tar cf - -C / -- "), "bad prefix: %s", cmd)
 	// Paths are shell-quoted.
 	assert.Contains(t, cmd, "'home/wes/.claude/projects'")
 	assert.Contains(t, cmd, "'home/wes/.codex/sessions'")
-	// No leading slash in dir args.
-	assert.NotContains(t, cmd, "'/home/", "dir has leading slash: %s", cmd)
+	// Extra files are included, shell-quoted, with no leading slash.
+	assert.Contains(t, cmd, "'home/wes/.codex/session_index.jsonl'")
+	// No leading slash in path args.
+	assert.NotContains(t, cmd, "'/home/", "path has leading slash: %s", cmd)
 }
 
 func TestRemapPath(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -330,6 +330,9 @@ func (e *Engine) classifyPaths(
 		// path was deleted, so they bypass classifyOnePath.
 		dfs := e.classifyAntigravitySidecarPath(p)
 		if len(dfs) == 0 {
+			dfs = e.classifyCodexIndexPath(p)
+		}
+		if len(dfs) == 0 {
 			if df, ok := e.classifyOnePath(
 				p, geminiProjectsByDir,
 			); ok {
@@ -2081,7 +2084,7 @@ func (e *Engine) syncAllLocked(
 	}
 
 	if !since.IsZero() {
-		all = filterFilesByMtime(all, since)
+		all = e.filterFilesByMtime(all, since)
 	}
 
 	all = dedupeDiscoveredFiles(all)
@@ -2476,11 +2479,12 @@ func (e *Engine) recordSyncFinished() {
 // (so errors surface in the worker rather than being silently
 // dropped). The cost is one stat per file — acceptable for
 // polling use cases where most files will be skipped.
-func filterFilesByMtime(
+func (e *Engine) filterFilesByMtime(
 	files []parser.DiscoveredFile, cutoff time.Time,
 ) []parser.DiscoveredFile {
 	cutoffNs := cutoff.UnixNano()
 	out := files[:0]
+	codexIndexRefresh := make(map[string][]parser.DiscoveredFile)
 	for _, f := range files {
 		mtime, err := discoveredFileMtime(f)
 		if err != nil {
@@ -2489,7 +2493,27 @@ func filterFilesByMtime(
 		}
 		if mtime >= cutoffNs {
 			out = append(out, f)
+			continue
 		}
+		if f.Agent != parser.AgentCodex || !e.codexIndexNeedsRefreshSince(f.Path, cutoffNs) {
+			continue
+		}
+		key := discoveredFileKey(f)
+		codexIndexRefresh[key] = append(codexIndexRefresh[key], f)
+	}
+	if len(codexIndexRefresh) == 0 {
+		return out
+	}
+
+	included := make(map[string]struct{}, len(out))
+	for _, f := range out {
+		included[discoveredFileKey(f)] = struct{}{}
+	}
+	for key, candidates := range codexIndexRefresh {
+		if _, ok := included[key]; ok {
+			continue
+		}
+		out = append(out, pickPreferredCodexDiscoveredFile(e.db, candidates))
 	}
 	return out
 }
@@ -3878,26 +3902,211 @@ func (e *Engine) tryIncrementalJSONL(
 	}, true
 }
 
+func (e *Engine) shouldSkipCodex(
+	path string, info os.FileInfo,
+) bool {
+	if e.forceParse { // parse-diff: always re-parse
+		return false
+	}
+	lookupPath := path
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(path)
+	}
+	storedSize, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
+	if !ok || storedSize != info.Size() {
+		return false
+	}
+	if e.db.GetDataVersionByPath(lookupPath) <
+		db.CurrentDataVersion() {
+		return false
+	}
+	fileMtime := info.ModTime().UnixNano()
+	effectiveMtime := parser.CodexEffectiveMtime(path, fileMtime)
+	if storedMtime == effectiveMtime {
+		return true
+	}
+	return effectiveMtime > storedMtime &&
+		fileMtime <= storedMtime &&
+		!e.codexIndexSessionNameChanged(path)
+}
+
+// codexIndexMtimeChanged returns true when session_index.jsonl is newer
+// than the stored DB mtime, meaning a title rename happened since the
+// last parse, regardless of whether the session file itself also changed.
+func (e *Engine) codexIndexMtimeChanged(path string) bool {
+	indexMtime := parser.CodexEffectiveMtime(path, 0)
+	if indexMtime == 0 {
+		return false
+	}
+	lookupPath := path
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(path)
+	}
+	_, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
+	if !ok {
+		return false
+	}
+	return indexMtime > storedMtime && e.codexIndexSessionNameChanged(path)
+}
+
+func (e *Engine) codexIndexNeedsRefreshSince(
+	path string, cutoffNs int64,
+) bool {
+	indexMtime := parser.CodexEffectiveMtime(path, 0)
+	if indexMtime == 0 || indexMtime < cutoffNs {
+		return false
+	}
+	lookupPath := path
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(path)
+	}
+	_, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
+	if !ok {
+		return false
+	}
+	return indexMtime > storedMtime && e.codexIndexSessionNameChanged(path)
+}
+
+func (e *Engine) codexIndexSessionNameChanged(path string) bool {
+	uuid := parser.CodexSessionUUIDFromFilename(filepath.Base(path))
+	if uuid == "" {
+		return false
+	}
+	currentName := parser.LookupCodexThreadName(path, uuid)
+	stored, err := e.db.GetSessionFull(
+		context.Background(), e.idPrefix+"codex:"+uuid,
+	)
+	if err != nil || stored == nil {
+		return true
+	}
+	storedName := ""
+	if stored.SessionName != nil {
+		storedName = strings.TrimSpace(*stored.SessionName)
+	}
+	return currentName != storedName
+}
+
+// classifyCodexIndexPath maps a Codex session_index.jsonl change to the
+// session files whose stored title no longer matches the index. The live
+// watcher sees this file only because its parent directory is watched
+// shallowly (see ResolveCodexShallowWatchRoots); without this translation a
+// title-only rename would not refresh until the next periodic sync, since the
+// session transcript itself is untouched.
+func (e *Engine) classifyCodexIndexPath(
+	path string,
+) []parser.DiscoveredFile {
+	if filepath.Base(path) != parser.CodexSessionIndexFilename {
+		return nil
+	}
+	indexDir := filepath.Dir(path)
+	var sessionRoots []string
+	for _, agDir := range e.agentDirs[parser.AgentCodex] {
+		if agDir != "" && filepath.Dir(agDir) == indexDir {
+			sessionRoots = append(sessionRoots, agDir)
+		}
+	}
+	if len(sessionRoots) == 0 {
+		return nil
+	}
+	titles := parser.CodexSessionIndexTitles(path)
+	if len(titles) == 0 {
+		return nil
+	}
+
+	var out []parser.DiscoveredFile
+	for uuid, title := range titles {
+		if !e.codexStoredNameDiffers(uuid, title) {
+			continue
+		}
+		var candidates []parser.DiscoveredFile
+		for _, root := range sessionRoots {
+			if src := parser.FindCodexSourceFile(root, uuid); src != "" {
+				candidates = append(candidates, parser.DiscoveredFile{
+					Path:  src,
+					Agent: parser.AgentCodex,
+				})
+			}
+		}
+		if len(candidates) == 0 {
+			continue
+		}
+		// A UUID can exist in both sessions/ and archived_sessions/.
+		// Prefer the path the DB already tracks so a title rename does
+		// not reparse a stale duplicate over the stored copy.
+		out = append(out, pickPreferredCodexDiscoveredFile(e.db, candidates))
+	}
+	return out
+}
+
+// codexStoredNameDiffers reports whether the stored session_name for a Codex
+// session differs from the given index title. Unknown sessions return false:
+// a brand-new session is synced through its own transcript event, not the
+// index, so the index path only refreshes renames of already-synced sessions.
+func (e *Engine) codexStoredNameDiffers(uuid, indexTitle string) bool {
+	stored, err := e.db.GetSessionFull(
+		context.Background(), e.idPrefix+"codex:"+uuid,
+	)
+	if err != nil || stored == nil {
+		return false
+	}
+	storedName := ""
+	if stored.SessionName != nil {
+		storedName = strings.TrimSpace(*stored.SessionName)
+	}
+	return strings.TrimSpace(indexTitle) != storedName
+}
+
+func pickPreferredCodexDiscoveredFile(
+	database *db.DB, candidates []parser.DiscoveredFile,
+) parser.DiscoveredFile {
+	if len(candidates) == 0 {
+		return parser.DiscoveredFile{}
+	}
+	if id := parser.CodexSessionUUIDFromFilename(
+		filepath.Base(candidates[0].Path),
+	); id != "" {
+		storedPath := filepath.Clean(database.GetSessionFilePath("codex:" + id))
+		if storedPath != "" {
+			for _, candidate := range candidates {
+				if filepath.Clean(candidate.Path) == storedPath {
+					return candidate
+				}
+			}
+		}
+	}
+	chosen := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if preferDiscoveredFile(candidate, chosen) {
+			chosen = candidate
+		}
+	}
+	return chosen
+}
+
 func (e *Engine) processCodex(
 	file parser.DiscoveredFile, info os.FileInfo,
 ) processResult {
 
-	// Fast path: skip by file_path + mtime before parsing.
-	if e.shouldSkipByPath(file.Path, info) {
+	// Fast path: skip by file_path + effective mtime (includes session_index.jsonl).
+	if e.shouldSkipCodex(file.Path, info) {
 		return processResult{skip: true}
 	}
 
-	codexParseFn := func(
-		path string, offset int64, startOrd int,
-	) ([]parser.ParsedMessage, time.Time, int64, error) {
-		return parser.ParseCodexSessionFrom(
-			path, offset, startOrd, false,
-		)
-	}
-	if res, ok := e.tryIncrementalJSONL(
-		file, info, parser.AgentCodex, codexParseFn,
-	); ok {
-		return res
+	indexMtimeChanged := e.codexIndexMtimeChanged(file.Path)
+
+	if !indexMtimeChanged {
+		codexParseFn := func(
+			path string, offset int64, startOrd int,
+		) ([]parser.ParsedMessage, time.Time, int64, error) {
+			return parser.ParseCodexSessionFrom(
+				path, offset, startOrd, false,
+			)
+		}
+		if res, ok := e.tryIncrementalJSONL(
+			file, info, parser.AgentCodex, codexParseFn,
+		); ok {
+			return res
+		}
 	}
 
 	sess, msgs, err := parser.ParseCodexSession(

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1919,6 +1919,369 @@ func TestSyncAllSinceCodexKeepsChangedArchivedDuplicate(t *testing.T) {
 	assert.Equal(t, archivedPath, env.db.GetSessionFilePath("codex:"+uuid))
 }
 
+func TestSyncAllSinceCodexRefreshesSessionNameFromIndex(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e1"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			tsEarly, uuid,
+			"/home/user/code/api", "user",
+		).
+		AddCodexMessage(tsEarlyS1, "user", "Rename me").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original title","updated_at":"2026-06-11T17:34:20Z"}`+"\n",
+		uuid,
+	), 0o644))
+	initialTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(path, initialTime, initialTime), "chtimes initial session")
+	require.NoError(t, os.Chtimes(indexPath, initialTime, initialTime), "chtimes initial index")
+
+	env.engine.SyncAll(context.Background(), nil)
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "expected Codex session to sync")
+	if assert.NotNil(t, sess.SessionName, "expected session_name to be imported") {
+		assert.Equal(t, "Original title", *sess.SessionName)
+	}
+
+	cutoff := time.Now().Add(-1 * time.Hour)
+	newIndexTime := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2026-06-11T18:00:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, newIndexTime, newIndexTime), "chtimes index")
+
+	stats := env.engine.SyncAllSince(context.Background(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced, "SyncAllSince synced = %d, want 1", stats.Synced)
+
+	sess, err = env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull after rename")
+	require.NotNil(t, sess, "expected renamed Codex session to remain")
+	if assert.NotNil(t, sess.SessionName, "expected renamed session_name") {
+		assert.Equal(t, "Renamed title", *sess.SessionName)
+	}
+}
+
+func TestSyncAllSinceCodexIndexRefreshOnlySyncsRenamedSession(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	renamedUUID := "019eb791-cf7d-75c1-8439-9ed74c1229e1"
+	unchangedUUID := "019eb791-cf7d-75c1-8439-9ed74c1229e2"
+	renamedContent := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			tsEarly, renamedUUID,
+			"/home/user/code/api", "user",
+		).
+		AddCodexMessage(tsEarlyS1, "user", "Rename me").
+		String()
+	unchangedContent := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			tsEarly, unchangedUUID,
+			"/home/user/code/api", "user",
+		).
+		AddCodexMessage(tsEarlyS1, "user", "Leave me").
+		String()
+	renamedPath := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+renamedUUID+".jsonl",
+		renamedContent,
+	)
+	unchangedPath := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-45-06-"+unchangedUUID+".jsonl",
+		unchangedContent,
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original renamed title","updated_at":"2026-06-11T17:34:20Z"}`+"\n"+
+			`{"id":"%s","thread_name":"Unchanged title","updated_at":"2026-06-11T17:35:20Z"}`+"\n",
+		renamedUUID, unchangedUUID,
+	), 0o644))
+	initialTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(renamedPath, initialTime, initialTime), "chtimes initial renamed")
+	require.NoError(t, os.Chtimes(unchangedPath, initialTime, initialTime), "chtimes initial unchanged")
+	require.NoError(t, os.Chtimes(indexPath, initialTime, initialTime), "chtimes initial index")
+
+	env.engine.SyncAll(context.Background(), nil)
+	unchangedBefore, err := env.db.GetSessionFull(context.Background(), "codex:"+unchangedUUID)
+	require.NoError(t, err, "GetSessionFull unchanged before rename")
+	require.NotNil(t, unchangedBefore, "expected unchanged Codex session to sync")
+	require.NotNil(t, unchangedBefore.SessionName, "expected unchanged session_name")
+	assert.Equal(t, "Unchanged title", *unchangedBefore.SessionName)
+	require.NotNil(t, unchangedBefore.FileMtime, "expected unchanged file_mtime")
+
+	cutoff := time.Now().Add(-1 * time.Hour)
+	newIndexTime := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2026-06-11T18:00:00Z"}`+"\n"+
+			`{"id":"%s","thread_name":"Unchanged title","updated_at":"2026-06-11T17:35:20Z"}`+"\n",
+		renamedUUID, unchangedUUID,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, newIndexTime, newIndexTime), "chtimes index")
+
+	stats := env.engine.SyncAllSince(context.Background(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced, "SyncAllSince synced = %d, want 1", stats.Synced)
+
+	renamed, err := env.db.GetSessionFull(context.Background(), "codex:"+renamedUUID)
+	require.NoError(t, err, "GetSessionFull renamed after index update")
+	require.NotNil(t, renamed, "expected renamed Codex session to remain")
+	if assert.NotNil(t, renamed.SessionName, "expected renamed session_name") {
+		assert.Equal(t, "Renamed title", *renamed.SessionName)
+	}
+
+	unchangedAfter, err := env.db.GetSessionFull(context.Background(), "codex:"+unchangedUUID)
+	require.NoError(t, err, "GetSessionFull unchanged after index update")
+	require.NotNil(t, unchangedAfter, "expected unchanged Codex session to remain")
+	if assert.NotNil(t, unchangedAfter.SessionName, "expected unchanged session_name") {
+		assert.Equal(t, "Unchanged title", *unchangedAfter.SessionName)
+	}
+	assert.Equal(t, *unchangedBefore.FileMtime, *unchangedAfter.FileMtime,
+		"unchanged session should not be reparsed just because the global index mtime advanced")
+
+	unchangedIndexTime := time.Now().Add(-15 * time.Minute)
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2026-06-11T18:00:00Z"}`+"\n"+
+			`{"id":"%s","thread_name":"Unchanged title","updated_at":"2026-06-11T17:35:20Z"}`+"\n",
+		renamedUUID, unchangedUUID,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, unchangedIndexTime, unchangedIndexTime), "chtimes unchanged index")
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 0, stats.Synced,
+		"SyncAll synced = %d, want 0 when only the global index mtime changed", stats.Synced)
+}
+
+func TestSyncPathsCodexIndexEventRefreshesRenamedSession(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	renamedUUID := "019eb791-cf7d-75c1-8439-9ed74c1229e1"
+	unchangedUUID := "019eb791-cf7d-75c1-8439-9ed74c1229e2"
+	renamedPath := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+renamedUUID+".jsonl",
+		testjsonl.NewSessionBuilder().
+			AddCodexMeta(tsEarly, renamedUUID, "/home/user/code/api", "user").
+			AddCodexMessage(tsEarlyS1, "user", "Rename me").
+			String(),
+	)
+	unchangedPath := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-45-06-"+unchangedUUID+".jsonl",
+		testjsonl.NewSessionBuilder().
+			AddCodexMeta(tsEarly, unchangedUUID, "/home/user/code/api", "user").
+			AddCodexMessage(tsEarlyS1, "user", "Leave me").
+			String(),
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original title","updated_at":"2026-06-11T17:34:20Z"}`+"\n"+
+			`{"id":"%s","thread_name":"Unchanged title","updated_at":"2026-06-11T17:35:20Z"}`+"\n",
+		renamedUUID, unchangedUUID,
+	), 0o644))
+	initialTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(renamedPath, initialTime, initialTime), "chtimes renamed")
+	require.NoError(t, os.Chtimes(unchangedPath, initialTime, initialTime), "chtimes unchanged")
+	require.NoError(t, os.Chtimes(indexPath, initialTime, initialTime), "chtimes index")
+
+	env.engine.SyncAll(context.Background(), nil)
+	unchangedBefore, err := env.db.GetSessionFull(context.Background(), "codex:"+unchangedUUID)
+	require.NoError(t, err, "GetSessionFull unchanged before rename")
+	require.NotNil(t, unchangedBefore, "expected unchanged Codex session to sync")
+	require.NotNil(t, unchangedBefore.FileMtime, "expected unchanged file_mtime")
+
+	newIndexTime := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2026-06-11T18:00:00Z"}`+"\n"+
+			`{"id":"%s","thread_name":"Unchanged title","updated_at":"2026-06-11T17:35:20Z"}`+"\n",
+		renamedUUID, unchangedUUID,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, newIndexTime, newIndexTime), "chtimes index")
+
+	// The live watcher only delivers the index path; SyncPaths must translate
+	// it into a refresh of the renamed session.
+	env.engine.SyncPaths([]string{indexPath})
+
+	renamed, err := env.db.GetSessionFull(context.Background(), "codex:"+renamedUUID)
+	require.NoError(t, err, "GetSessionFull renamed after index event")
+	require.NotNil(t, renamed, "expected renamed Codex session to remain")
+	if assert.NotNil(t, renamed.SessionName, "expected renamed session_name") {
+		assert.Equal(t, "Renamed title", *renamed.SessionName)
+	}
+
+	unchangedAfter, err := env.db.GetSessionFull(context.Background(), "codex:"+unchangedUUID)
+	require.NoError(t, err, "GetSessionFull unchanged after index event")
+	require.NotNil(t, unchangedAfter, "expected unchanged Codex session to remain")
+	require.NotNil(t, unchangedAfter.FileMtime, "expected unchanged file_mtime after event")
+	assert.Equal(t, *unchangedBefore.FileMtime, *unchangedAfter.FileMtime,
+		"unchanged session must not be reparsed from an index-only event")
+}
+
+func TestSyncAllSinceCodexIndexRefreshDoesNotShadowChangedArchivedDuplicate(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	archivedDir := filepath.Join(root, "archived_sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	require.NoError(t, os.MkdirAll(archivedDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir, archivedDir}))
+
+	uuid := "f7a8b9ca-7890-1234-ef01-456789012345"
+	liveContent := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			tsEarly, uuid,
+			"/home/user/code/api", "user",
+		).
+		AddCodexMessage(tsEarlyS1, "user", "Live copy").
+		String()
+	archivedContent := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			tsEarly, uuid,
+			"/home/user/code/api", "user",
+		).
+		AddCodexMessage(tsEarlyS1, "user", "Archived copy").
+		AddCodexMessage(tsEarlyS5, "assistant", "Updated archive").
+		String()
+
+	livePath := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "05", "04"),
+		"rollout-2026-05-04T02-10-04-"+uuid+".jsonl",
+		liveContent,
+	)
+	archivedPath := env.writeSession(
+		t,
+		archivedDir,
+		"rollout-2026-05-04T14-31-58-"+uuid+".jsonl",
+		liveContent,
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original title","updated_at":"2026-05-04T15:00:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	initialTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(livePath, initialTime, initialTime), "chtimes initial live")
+	require.NoError(t, os.Chtimes(archivedPath, initialTime, initialTime), "chtimes initial archived")
+	require.NoError(t, os.Chtimes(indexPath, initialTime, initialTime), "chtimes initial index")
+
+	env.engine.SyncAll(context.Background(), nil)
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("codex:"+uuid))
+
+	newTime := time.Now().Add(-30 * time.Minute)
+	cutoff := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.WriteFile(archivedPath, []byte(archivedContent), 0o644))
+	require.NoError(t, os.Chtimes(archivedPath, newTime, newTime), "chtimes archived")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2026-05-04T16:00:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, newTime, newTime), "chtimes index")
+
+	stats := env.engine.SyncAllSince(context.Background(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced, "SyncAllSince synced = %d, want 1", stats.Synced)
+
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "expected Codex session to sync")
+	assert.Equal(t, archivedPath, env.db.GetSessionFilePath("codex:"+uuid))
+	if assert.NotNil(t, sess.SessionName, "expected renamed session_name") {
+		assert.Equal(t, "Renamed title", *sess.SessionName)
+	}
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 2)
+}
+
+func TestSyncPathsCodexIndexEventRefreshesStoredDuplicate(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	archivedDir := filepath.Join(root, "archived_sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	require.NoError(t, os.MkdirAll(archivedDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir, archivedDir}))
+
+	uuid := "f7a8b9ca-7890-1234-ef01-456789012345"
+	archivedContent := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Archived copy").
+		AddCodexMessage(tsEarlyS5, "assistant", "Archived reply").
+		String()
+	staleLiveContent := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Stale live copy").
+		String()
+
+	// Only the archived copy exists at first sync, so the DB tracks it.
+	archivedPath := env.writeSession(
+		t, archivedDir,
+		"rollout-2026-05-04T14-31-58-"+uuid+".jsonl",
+		archivedContent,
+	)
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original title","updated_at":"2026-05-04T15:00:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	initialTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(archivedPath, initialTime, initialTime), "chtimes archived")
+	require.NoError(t, os.Chtimes(indexPath, initialTime, initialTime), "chtimes index")
+
+	env.engine.SyncAll(context.Background(), nil)
+	require.Equal(t, archivedPath, env.db.GetSessionFilePath("codex:"+uuid),
+		"DB must track the archived copy before the rename")
+
+	// A stale live duplicate now exists, and the index records a rename.
+	livePath := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "05", "04"),
+		"rollout-2026-05-04T02-10-04-"+uuid+".jsonl",
+		staleLiveContent,
+	)
+	require.NoError(t, os.Chtimes(livePath, initialTime, initialTime), "chtimes live")
+	newIndexTime := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2026-05-04T16:00:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, newIndexTime, newIndexTime), "chtimes index rename")
+
+	env.engine.SyncPaths([]string{indexPath})
+
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull after index event")
+	require.NotNil(t, sess, "expected Codex session to remain")
+	assert.Equal(t, archivedPath, env.db.GetSessionFilePath("codex:"+uuid),
+		"index rename must refresh the stored archived copy, not the stale live duplicate")
+	if assert.NotNil(t, sess.SessionName, "expected renamed session_name") {
+		assert.Equal(t, "Renamed title", *sess.SessionName)
+	}
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 2)
+}
+
 func TestSyncPathsGeminiRejectsWrongStructure(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -252,22 +252,20 @@ func (w *Watcher) addShallowRoot(root string) {
 	}
 }
 
+// isUnderShallowRoot reports whether path's most specific containing watch
+// root is a shallow root. A path that also sits under a more specific
+// recursive root (for example a new sessions/YYYY/MM/DD directory beneath a
+// recursive sessions root that itself lives inside a shallow parent root) is
+// NOT shadowed, so auto-watching still adds new subdirectories of recursive
+// roots.
 func (w *Watcher) isUnderShallowRoot(path string) bool {
+	root, ok := w.mostSpecificContainingRoot(path)
+	if !ok {
+		return false
+	}
 	w.rootsMu.RLock()
 	defer w.rootsMu.RUnlock()
-
-	clean := filepath.Clean(path)
-	for _, root := range w.shallow {
-		rel, err := filepath.Rel(root, clean)
-		if err != nil || rel == "." {
-			continue
-		}
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			continue
-		}
-		return true
-	}
-	return false
+	return slices.Contains(w.shallow, root)
 }
 
 func (w *Watcher) shouldExclude(path string) bool {

--- a/internal/sync/watcher_test.go
+++ b/internal/sync/watcher_test.go
@@ -396,6 +396,60 @@ func TestWatcherShallowRootDoesNotAutoWatchNewDirs(t *testing.T) {
 		"shallow root descendant should not be auto-watched")
 }
 
+// A shallow parent root (e.g. Codex's .codex) must not shadow a recursive
+// child root (.codex/sessions) nested inside it: newly created directories
+// under the recursive child still need to be auto-watched so new sessions in
+// new date directories live-sync.
+func TestWatcherShallowParentDoesNotShadowRecursiveChild(t *testing.T) {
+	pathsCh := make(chan []string, 10)
+	w, err := NewWatcher(20*time.Millisecond, func(paths []string) {
+		pathsCh <- paths
+	}, nil)
+	require.NoError(t, err, "NewWatcher")
+	t.Cleanup(func() { w.Stop() })
+
+	parent := t.TempDir()
+	child := filepath.Join(parent, "sessions")
+	require.NoError(t, os.Mkdir(child, 0o755), "Mkdir(child)")
+
+	require.True(t, w.WatchShallow(parent), "WatchShallow(parent)")
+	_, _, err = w.WatchRecursive(child)
+	require.NoError(t, err, "WatchRecursive(child)")
+	w.Start()
+
+	// A sibling write directly under the shallow parent is still seen but its
+	// directory is not auto-watched.
+	logDir := filepath.Join(parent, "log")
+	require.NoError(t, os.Mkdir(logDir, 0o755), "Mkdir(log)")
+
+	// A new directory created under the recursive child must be auto-watched
+	// even though it also sits inside the shallow parent root.
+	dateDir := filepath.Join(child, "2026-06-16")
+	require.NoError(t, os.Mkdir(dateDir, 0o755), "Mkdir(dateDir)")
+	pollUntil(t, func() bool {
+		return slices.Contains(w.watcher.WatchList(), dateDir)
+	})
+
+	sessionFile := filepath.Join(dateDir, "rollout.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte("x"), 0o644))
+
+	deadline := time.Now().Add(5 * time.Second)
+	found := false
+	for time.Now().Before(deadline) && !found {
+		select {
+		case paths := <-pathsCh:
+			if slices.Contains(paths, sessionFile) {
+				found = true
+			}
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	require.True(t, found,
+		"file in a new date dir under the recursive child must trigger onChange")
+	assert.NotContains(t, w.watcher.WatchList(), logDir,
+		"sibling dir under the shallow parent must not be auto-watched")
+}
+
 func TestWatchRecursive_RootUnderExcludedAncestorStillWatchesDescendants(t *testing.T) {
 	w, err := NewWatcher(time.Second, func(_ []string) {}, []string{"venv"})
 	require.NoError(t, err, "NewWatcher")


### PR DESCRIPTION
## Summary
- import Codex renamed session titles from Codex's `session_index.jsonl` `thread_name` into the existing session-name field instead of always falling back to the first user message preview
- handle both `sessions` and `archived_sessions` directory layouts when resolving the `session_index.jsonl` path so archived session titles are also captured
- add focused Codex parser coverage for both the title-capture path and the archived-session directory variant

## Scope
- limited to Codex parser title extraction and focused parser tests
- follow-up to the broader session-title surfaces already shipped in `#601` and `#209`; no unrelated UI changes

## Review Notes
- start with `internal/parser/codex.go` and the matching Codex parser tests
- the validated wire shape is `session_meta.payload.id` in the session file joined to adjacent `session_index.jsonl` `thread_name`; no guessed transcript-only rename event is involved

Fixes #405
