### PR TITLE
feat(parser): extract token usage and cost for VSCode Copilot sessions

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -30,8 +30,9 @@ import (
 //
 // Bumped to 44: the VSCode Copilot parser now extracts per-turn
 // token usage (promptTokens/outputTokens) and the resolved model from
-// result.metadata into usage events and session output totals, so
-// existing VSCode Copilot rows need re-parsing to gain usage and cost.
+// result.metadata into usage events, session output totals, and peak
+// context, so existing VSCode Copilot rows need re-parsing to gain
+// usage and cost.
 //
 // Bumped to 43: the Pi parser now persists cwd from the
 // session header. Existing Pi rows need re-parsing so their cwd column

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,6 +28,11 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 44: the VSCode Copilot parser now extracts per-turn
+// token usage (promptTokens/outputTokens) and the resolved model from
+// result.metadata into usage events and session output totals, so
+// existing VSCode Copilot rows need re-parsing to gain usage and cost.
+//
 // Bumped to 43: the Pi parser now persists cwd from the
 // session header. Existing Pi rows need re-parsing so their cwd column
 // is populated.
@@ -199,7 +204,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 43
+const dataVersion = 44
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -589,7 +589,7 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionPiCwd(t *testing.T) {
-	assert.Equal(t, 43, CurrentDataVersion(),
+	assert.Equal(t, 44, CurrentDataVersion(),
 		"Pi cwd parser changes require a data version bump")
 }
 

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -588,6 +588,12 @@ type ParsedSession struct {
 	HasTotalOutputTokens bool
 	HasPeakContextTokens bool
 
+	// UsageEvents carries parser-emitted aggregate usage rows for
+	// agents whose session-level accounting is computed inline
+	// (e.g. VSCode Copilot). The sync engine forwards these into
+	// the usage_events table for catalog-based cost pricing.
+	UsageEvents []ParsedUsageEvent
+
 	// aggregateTokenPresenceKnown marks session aggregate token
 	// coverage as parser-owned and authoritative.
 	aggregateTokenPresenceKnown bool

--- a/internal/parser/vscode_copilot.go
+++ b/internal/parser/vscode_copilot.go
@@ -188,6 +188,7 @@ func parseVSCodeCopilotData(
 
 	var usageEvents []ParsedUsageEvent
 	totalOutput := 0
+	peakContext := 0
 	sawTokens := false
 	startedAt := session.CreationDate.Time()
 
@@ -216,6 +217,9 @@ func parseVSCodeCopilotData(
 		if ev, ok := vscodeCopilotUsageEvent(req, startedAt); ok {
 			usageEvents = append(usageEvents, ev)
 			totalOutput += ev.OutputTokens
+			// promptTokens is the full context billed for the turn,
+			// so the largest one is the session's peak context.
+			peakContext = max(peakContext, ev.InputTokens)
 			sawTokens = true
 		}
 
@@ -297,6 +301,8 @@ func parseVSCodeCopilotData(
 	if sawTokens {
 		sess.TotalOutputTokens = totalOutput
 		sess.HasTotalOutputTokens = true
+		sess.PeakContextTokens = peakContext
+		sess.HasPeakContextTokens = true
 	}
 
 	return sess, messages, nil

--- a/internal/parser/vscode_copilot.go
+++ b/internal/parser/vscode_copilot.go
@@ -65,6 +65,17 @@ type vscodeCopilotResult struct {
 	Metadata json.RawMessage       `json:"metadata,omitempty"`
 }
 
+// vscodeCopilotMetadata holds the per-request token accounting
+// found in result.metadata. VSCode Copilot records the full
+// prompt size (promptTokens, cumulative context for that turn)
+// and the generated output (outputTokens), plus the resolved
+// model id already in pricing-catalog form (e.g. "claude-opus-4-8").
+type vscodeCopilotMetadata struct {
+	PromptTokens  int    `json:"promptTokens"`
+	OutputTokens  int    `json:"outputTokens"`
+	ResolvedModel string `json:"resolvedModel"`
+}
+
 type vscodeCopilotTimings struct {
 	FirstProgress int64 `json:"firstProgress"`
 	TotalElapsed  int64 `json:"totalElapsed"`
@@ -175,6 +186,11 @@ func parseVSCodeCopilotData(
 	var firstMessage string
 	ordinal := 0
 
+	var usageEvents []ParsedUsageEvent
+	totalOutput := 0
+	sawTokens := false
+	startedAt := session.CreationDate.Time()
+
 	for _, req := range session.Requests {
 		// User message
 		text := strings.TrimSpace(req.Message.Text)
@@ -192,6 +208,15 @@ func parseVSCodeCopilotData(
 				ContentLength: len(text),
 			})
 			ordinal++
+		}
+
+		// Token accounting: VSCode records prompt/output tokens and
+		// the resolved model in result.metadata. Emit one usage event
+		// per turn so the cost gets catalog-priced downstream.
+		if ev, ok := vscodeCopilotUsageEvent(req, startedAt); ok {
+			usageEvents = append(usageEvents, ev)
+			totalOutput += ev.OutputTokens
+			sawTokens = true
 		}
 
 		// Assistant response: parse response items
@@ -251,7 +276,6 @@ func parseVSCodeCopilotData(
 		}
 	}
 
-	startedAt := session.CreationDate.Time()
 	endedAt := session.LastMessageDate.Time()
 	if endedAt.IsZero() && len(session.Requests) > 0 {
 		last := session.Requests[len(session.Requests)-1]
@@ -267,9 +291,53 @@ func parseVSCodeCopilotData(
 		EndedAt:          endedAt,
 		MessageCount:     len(messages),
 		UserMessageCount: userCount,
+		UsageEvents:      usageEvents,
+	}
+
+	if sawTokens {
+		sess.TotalOutputTokens = totalOutput
+		sess.HasTotalOutputTokens = true
 	}
 
 	return sess, messages, nil
+}
+
+// vscodeCopilotUsageEvent builds a per-turn usage event from a
+// request's result.metadata token accounting. Returns ok=false
+// when the request carries no usable token data. The prompt size
+// (promptTokens) is the full context billed for that turn; without
+// a cache breakdown it is treated as input tokens, so the derived
+// cost is an upper-bound estimate that ignores prompt-cache discounts.
+func vscodeCopilotUsageEvent(
+	req vscodeCopilotRequest, sessionStart time.Time,
+) (ParsedUsageEvent, bool) {
+	if req.Result == nil || len(req.Result.Metadata) == 0 {
+		return ParsedUsageEvent{}, false
+	}
+	var md vscodeCopilotMetadata
+	if err := json.Unmarshal(req.Result.Metadata, &md); err != nil {
+		return ParsedUsageEvent{}, false
+	}
+	if md.PromptTokens <= 0 && md.OutputTokens <= 0 {
+		return ParsedUsageEvent{}, false
+	}
+
+	// resolvedModel is already in pricing-catalog form
+	// (e.g. "claude-opus-4-8"). Fall back to the prefixed modelId
+	// (e.g. "copilot/claude-opus-4.8") and normalize it.
+	model := md.ResolvedModel
+	if model == "" {
+		model = strings.TrimPrefix(req.ModelID, "copilot/")
+	}
+	model = normalizeCopilotModel(model)
+
+	return ParsedUsageEvent{
+		Source:       "vscode-copilot",
+		Model:        model,
+		InputTokens:  md.PromptTokens,
+		OutputTokens: md.OutputTokens,
+		OccurredAt:   timeString(req.Timestamp.Time(), sessionStart),
+	}, true
 }
 
 // parseVSCodeCopilotResponse extracts text and tool calls

--- a/internal/parser/vscode_copilot_test.go
+++ b/internal/parser/vscode_copilot_test.go
@@ -774,3 +774,130 @@ func TestFindVSCodeCopilotSourceFile(t *testing.T) {
 		})
 	}
 }
+
+func TestParseVSCodeCopilotSession_TokenUsage(t *testing.T) {
+	// Two turns carry result.metadata token accounting (the
+	// post-credits VSCode Copilot format); a third turn has no
+	// metadata and must not produce a usage event.
+	sessionJSON := `{
+		"version": 3,
+		"sessionId": "usage-1",
+		"creationDate": 1755340000000,
+		"lastMessageDate": 1755350000000,
+		"requests": [
+			{
+				"requestId": "r1",
+				"message": {"text": "First"},
+				"response": [{"value": "answer one"}],
+				"timestamp": 1755340000000,
+				"modelId": "copilot/claude-opus-4.8",
+				"result": {"metadata": {
+					"promptTokens": 35875,
+					"outputTokens": 221,
+					"resolvedModel": "claude-opus-4-8"
+				}}
+			},
+			{
+				"requestId": "r2",
+				"message": {"text": "Second"},
+				"response": [{"value": "answer two"}],
+				"timestamp": 1755345000000,
+				"modelId": "copilot/claude-opus-4.8",
+				"result": {"metadata": {
+					"promptTokens": 41055,
+					"outputTokens": 69,
+					"resolvedModel": "claude-opus-4-8"
+				}}
+			},
+			{
+				"requestId": "r3",
+				"message": {"text": "Third"},
+				"response": [{"value": "answer three"}],
+				"timestamp": 1755350000000,
+				"modelId": "copilot/claude-opus-4.8"
+			}
+		]
+	}`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+	require.NoError(t, os.WriteFile(path, []byte(sessionJSON), 0644))
+
+	sess, _, err := ParseVSCodeCopilotSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Only the two turns with metadata yield usage events.
+	require.Len(t, sess.UsageEvents, 2, "usage events")
+
+	for i, ev := range sess.UsageEvents {
+		assert.Equal(t, "vscode-copilot", ev.Source, "event[%d] source", i)
+		assert.Equal(t, "claude-opus-4-8", ev.Model, "event[%d] model", i)
+		assert.NotEmpty(t, ev.OccurredAt, "event[%d] occurredAt", i)
+	}
+
+	assert.Equal(t, 35875, sess.UsageEvents[0].InputTokens)
+	assert.Equal(t, 221, sess.UsageEvents[0].OutputTokens)
+	assert.Equal(t, 41055, sess.UsageEvents[1].InputTokens)
+	assert.Equal(t, 69, sess.UsageEvents[1].OutputTokens)
+
+	// Session output total sums the per-turn output tokens.
+	assert.True(t, sess.HasTotalOutputTokens, "has total output")
+	assert.Equal(t, 290, sess.TotalOutputTokens, "total output")
+}
+
+func TestParseVSCodeCopilotSession_TokenUsageModelFallback(t *testing.T) {
+	// No resolvedModel: fall back to the prefixed modelId and
+	// normalize the claude version dots to hyphens.
+	sessionJSON := `{
+		"version": 3,
+		"sessionId": "usage-2",
+		"creationDate": 1755340000000,
+		"requests": [{
+			"requestId": "r1",
+			"message": {"text": "Hi"},
+			"response": [{"value": "Hello"}],
+			"timestamp": 1755340000000,
+			"modelId": "copilot/claude-sonnet-4.6",
+			"result": {"metadata": {"promptTokens": 1000, "outputTokens": 50}}
+		}]
+	}`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage2.json")
+	require.NoError(t, os.WriteFile(path, []byte(sessionJSON), 0644))
+
+	sess, _, err := ParseVSCodeCopilotSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	require.Len(t, sess.UsageEvents, 1)
+	assert.Equal(t, "claude-sonnet-4-6", sess.UsageEvents[0].Model)
+}
+
+func TestParseVSCodeCopilotSession_NoTokenUsage(t *testing.T) {
+	// A session whose requests carry no token metadata yields no
+	// usage events and leaves output totals unset (cost -> n/a).
+	sessionJSON := `{
+		"version": 3,
+		"sessionId": "no-usage",
+		"creationDate": 1755340000000,
+		"requests": [{
+			"requestId": "r1",
+			"message": {"text": "Hi"},
+			"response": [{"value": "Hello"}],
+			"timestamp": 1755340000000
+		}]
+	}`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nousage.json")
+	require.NoError(t, os.WriteFile(path, []byte(sessionJSON), 0644))
+
+	sess, _, err := ParseVSCodeCopilotSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.Empty(t, sess.UsageEvents, "no usage events expected")
+	assert.False(t, sess.HasTotalOutputTokens, "no total output expected")
+}

--- a/internal/parser/vscode_copilot_test.go
+++ b/internal/parser/vscode_copilot_test.go
@@ -844,6 +844,10 @@ func TestParseVSCodeCopilotSession_TokenUsage(t *testing.T) {
 	// Session output total sums the per-turn output tokens.
 	assert.True(t, sess.HasTotalOutputTokens, "has total output")
 	assert.Equal(t, 290, sess.TotalOutputTokens, "total output")
+
+	// Peak context is the largest per-turn promptTokens.
+	assert.True(t, sess.HasPeakContextTokens, "has peak context")
+	assert.Equal(t, 41055, sess.PeakContextTokens, "peak context")
 }
 
 func TestParseVSCodeCopilotSession_TokenUsageModelFallback(t *testing.T) {
@@ -900,4 +904,5 @@ func TestParseVSCodeCopilotSession_NoTokenUsage(t *testing.T) {
 
 	assert.Empty(t, sess.UsageEvents, "no usage events expected")
 	assert.False(t, sess.HasTotalOutputTokens, "no total output expected")
+	assert.False(t, sess.HasPeakContextTokens, "no peak context expected")
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4063,7 +4063,11 @@ func (e *Engine) processVSCodeCopilot(
 
 	return processResult{
 		results: []parser.ParseResult{
-			{Session: *sess, Messages: msgs},
+			{
+				Session:     *sess,
+				Messages:    msgs,
+				UsageEvents: sess.UsageEvents,
+			},
 		},
 	}
 }


### PR DESCRIPTION
VSCode Copilot records per-turn token accounting in each request's result.metadata (promptTokens, outputTokens) along with the resolved model id (resolvedModel, already in pricing-catalog form, e.g. "claude-opus-4-8"). The vscode-copilot parser previously ignored this, so sessions reported 0 output tokens and "n/a" cost while Copilot CLI sessions priced correctly.

The parser now emits one usage event per turn (source "vscode-copilot") and rolls the output tokens into the session total, so cost is catalog-priced downstream exactly like other agents. Turns without token metadata produce no event and leave the totals unset (cost stays "n/a"). The resolved model falls back to the prefixed modelId (e.g. "copilot/claude-opus-4.8") with claude version dots normalized to hyphens when resolvedModel is absent.

Usage events are carried on ParsedSession.UsageEvents and forwarded by the sync engine, keeping the public parser signature (and the shared Positron path) unchanged. Bumps the data version to 44 so existing VSCode Copilot rows re-parse and gain usage/cost.

Adds unit tests covering multi-turn extraction, the model fallback, and the no-token-metadata case.