### PR TITLE
fix(db): tolerate NULL message timestamps in velocity analytics

### DIFF
--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -2284,8 +2284,14 @@ func (db *DB) queryVelocityMsgs(
 	sessionMsgs map[string][]velocityMsg,
 ) error {
 	ph, args := inPlaceholders(chunk)
+	// COALESCE the nullable timestamp column to '' so a NULL (only present
+	// on imported/migrated archives) does not fail rows.Scan with
+	// "converting NULL to string is unsupported". localTime treats "" as
+	// invalid, so the row is excluded from velocity stats rather than
+	// crashing the analytics endpoint. This matches the NULL-safe
+	// PostgreSQL and DuckDB velocity twins.
 	q := `SELECT session_id, ordinal, role,
-		timestamp, content_length
+		COALESCE(timestamp, ''), content_length
 		FROM messages
 		WHERE session_id IN ` + ph + `
 		ORDER BY session_id, ordinal`

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
@@ -1159,6 +1160,43 @@ func TestVelocityChunkedQuery(t *testing.T) {
 	require.NoError(t, err,
 		"GetAnalyticsSessionShape with %d sessions", n)
 	assert.Equal(t, n, shape.Count, "Count")
+}
+
+// TestGetAnalyticsVelocity_NullTimestamp guards against the velocity scan
+// crashing on a NULL messages.timestamp. NULLs only occur on imported or
+// migrated archives (fresh inserts always bind a Go string), so reach past
+// InsertMessages with raw SQL to plant one. Before the COALESCE fix this
+// failed with "converting NULL to string is unsupported"; now the NULL row
+// is treated as an invalid timestamp and excluded while the rest of the
+// session's messages still drive velocity metrics.
+func TestGetAnalyticsVelocity_NullTimestamp(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertConversation(t, d, "v-null", "proj", "claude", "2024-06-01T09:00:00Z",
+		[]time.Duration{
+			0, 10 * time.Second, 10 * time.Second,
+			10 * time.Second, 10 * time.Second, 10 * time.Second,
+		})
+
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"UPDATE messages SET timestamp = NULL"+
+				" WHERE session_id = ? AND ordinal = ?", "v-null", 5)
+		return err
+	}), "null the stored timestamp")
+
+	resp, err := d.GetAnalyticsVelocity(ctx, baseFilter())
+	require.NoError(t, err, "GetAnalyticsVelocity over NULL timestamp")
+
+	// The session is still processed and its remaining timestamped
+	// messages still produce velocity metrics; the NULL row is simply
+	// excluded.
+	require.Len(t, resp.ByAgent, 1)
+	assert.Equal(t, "claude", resp.ByAgent[0].Label)
+	assert.Equal(t, 1, resp.ByAgent[0].Sessions, "session counted")
+	assert.Equal(t, 10.0, resp.Overall.TurnCycleSec.P50,
+		"valid-timestamped turns still drive velocity")
 }
 
 func TestPercentileFloat(t *testing.T) {


### PR DESCRIPTION
`queryVelocityMsgs` scanned the nullable `messages.timestamp` column into a plain Go string, so a single row with a NULL timestamp made `rows.Scan` fail with `converting NULL to string is unsupported` and returned an error from the analytics velocity endpoint (`GetAnalyticsVelocity`) instead of a result. NULL timestamps only occur on imported or migrated archives, since fresh inserts always bind a Go string.

The fix wraps the column in `COALESCE(timestamp, '')`. `localTime` already treats `""` as an invalid timestamp (returns `!ok`), so a coalesced NULL row is excluded from velocity stats rather than crashing the endpoint — no metric change for real rows.

This is a SQLite-only fix that restores backend parity: the PostgreSQL (`*time.Time`) and DuckDB (`any`) velocity twins already tolerate NULL, so an archive DuckDB/PG served fine would crash on SQLite. It also matches the `COALESCE` convention used for the parse-diff message-read paths (17a93be5).

Reviewers: the one-line query change is in `internal/db/analytics.go`; the regression test `TestGetAnalyticsVelocity_NullTimestamp` in `internal/db/analytics_test.go` plants a raw NULL via `UPDATE` and asserts the endpoint returns results rather than erroring.