### PR TITLE
Drop redundant kit_posthog_disabled test tag; discourage PR test sections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,15 +109,15 @@ jobs:
           path-type: inherit
 
       - name: Run Go tests
-        run: go test -tags "fts5,kit_posthog_disabled" ./... -v -count=1
+        run: go test -tags "fts5" ./... -v -count=1
         env:
           CGO_ENABLED: "1"
 
       - name: Run Go tests (race detector)
         if: runner.os == 'Linux'
         run: |
-          go test -tags "fts5,kit_posthog_disabled" ./internal/duckdb -count=1
-          go test -tags "fts5,kit_posthog_disabled" -race $(go list ./... | grep -v '/internal/duckdb$') -count=1
+          go test -tags "fts5" ./internal/duckdb -count=1
+          go test -tags "fts5" -race $(go list ./... | grep -v '/internal/duckdb$') -count=1
         env:
           CGO_ENABLED: "1"
 
@@ -154,7 +154,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Test with coverage
-        run: go test -tags "fts5,kit_posthog_disabled" -coverprofile=coverage.out ./...
+        run: go test -tags "fts5" -coverprofile=coverage.out ./...
         env:
           CGO_ENABLED: "1"
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,7 +43,7 @@ jobs:
       # into the run script, so it cannot inject shell commands.
       - name: Fuzz ${{ matrix.target }}
         run: >
-          go test -tags "fts5,kit_posthog_disabled"
+          go test -tags "fts5"
           -fuzz "^${TARGET}$"
           -fuzztime "$FUZZTIME"
           ./internal/parser/

--- a/.github/workflows/msys2-update-check.yml
+++ b/.github/workflows/msys2-update-check.yml
@@ -33,6 +33,6 @@ jobs:
         run: mkdir -p internal/web/dist && echo ok > internal/web/dist/stub.html
 
       - name: Run Go tests
-        run: go test -tags "fts5,kit_posthog_disabled" ./... -v -count=1
+        run: go test -tags "fts5" ./... -v -count=1
         env:
           CGO_ENABLED: "1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,6 @@ Instructions for autonomous coding agents working in this repository.
 ## Validation
 
 - Run relevant tests before committing when practical.
-- Run tests through the `make` targets (`make test`, `make test-short`,
-  `make vet`, `make lint`) rather than invoking `go test` directly. The targets
-  already set `CGO_ENABLED=1` and the required build tags, so you never need to
-  pass `-tags "fts5,kit_posthog_disabled"` by hand.
 - If tests cannot be run, state that clearly in the handoff.
 - After Go code changes, run `go fmt ./...` and `go vet ./...` before
   committing.
@@ -163,7 +159,7 @@ All new features and bug fixes must include unit tests. Run tests before
 committing:
 
 ```bash
-make test       # Go tests (the target sets CGO_ENABLED=1 and the required build tags)
+make test       # Go tests with CGO_ENABLED=1 and -tags "fts5,kit_posthog_disabled"
 make test-short # Fast tests only with -short
 make e2e        # Playwright E2E tests
 make lint       # golangci-lint plus NilAway

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ All new features and bug fixes must include unit tests. Run tests before
 committing:
 
 ```bash
-make test       # Go tests with CGO_ENABLED=1 and -tags "fts5,kit_posthog_disabled"
+make test       # Go tests with CGO_ENABLED=1 and -tags "fts5"
 make test-short # Fast tests only with -short
 make e2e        # Playwright E2E tests
 make lint       # golangci-lint plus NilAway
@@ -195,7 +195,7 @@ Or manually with an existing PostgreSQL instance:
 
 ```bash
 TEST_PG_URL="postgres://user:pass@host:5432/dbname?sslmode=disable" \
-  CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled,pgtest" ./internal/postgres/... -v
+  CGO_ENABLED=1 go test -tags "fts5,pgtest" ./internal/postgres/... -v
 ```
 
 Tests create and drop the `agentsview` schema, so use a dedicated database or
@@ -206,8 +206,11 @@ GitHub Actions service container in `.github/workflows/ci.yml`.
 
 - `CGO_ENABLED=1` is required for the sqlite3 driver.
 - The `fts5` build tag is required for full-text search.
-- Go test binaries also use kit's `kit_posthog_disabled` build tag so tests
-  cannot send PostHog telemetry.
+- `go test` does not need kit's `kit_posthog_disabled` build tag. The telemetry
+  reporter already short-circuits to a disabled no-op under `testing.Testing()`,
+  so tests never send PostHog events. Binaries built for e2e tests (`make e2e`,
+  the CI pre-build of `agentsview`/`testfixture`) do use the tag, because they
+  run as real processes where the test guard does not apply.
 - Node.js and npm are required to build the Svelte frontend embedded under
   `internal/web/dist/`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ Instructions for autonomous coding agents working in this repository.
 ## Validation
 
 - Run relevant tests before committing when practical.
+- Run tests through the `make` targets (`make test`, `make test-short`,
+  `make vet`, `make lint`) rather than invoking `go test` directly. The targets
+  already set `CGO_ENABLED=1` and the required build tags, so you never need to
+  pass `-tags "fts5,kit_posthog_disabled"` by hand.
 - If tests cannot be run, state that clearly in the handoff.
 - After Go code changes, run `go fmt ./...` and `go vet ./...` before
   committing.
@@ -159,7 +163,7 @@ All new features and bug fixes must include unit tests. Run tests before
 committing:
 
 ```bash
-make test       # Go tests with CGO_ENABLED=1 and -tags "fts5,kit_posthog_disabled"
+make test       # Go tests (the target sets CGO_ENABLED=1 and the required build tags)
 make test-short # Fast tests only with -short
 make e2e        # Playwright E2E tests
 make lint       # golangci-lint plus NilAway
@@ -221,6 +225,9 @@ GitHub Actions service container in `.github/workflows/ci.yml`.
 
 ## Pull Requests
 
-- PR descriptions should be summaries only, with no test plans or checklists.
+- PR descriptions should be summaries only, with no test plans or checklists. Do
+  not add a "Tests", "Testing", "Verification", or "Test plan" section. CI runs
+  the tests, so the description must not restate the suite, list test commands,
+  or describe how the change was verified.
 - Describe what the code does now, why it changed, tradeoffs, limitations, and
   where reviewers should look.

--- a/Makefile
+++ b/Makefile
@@ -216,11 +216,11 @@ desktop-app: desktop-macos-app
 
 # Run tests
 test: ensure-embed-dir
-	go test -tags "fts5,kit_posthog_disabled" ./... -v -count=1
+	go test -tags "fts5" ./... -v -count=1
 
 # Run fast tests only
 test-short: ensure-embed-dir
-	go test -tags "fts5,kit_posthog_disabled" ./... -short -count=1
+	go test -tags "fts5" ./... -short -count=1
 
 # Compare db.Store read-query performance across SQLite, DuckDB, and PostgreSQL.
 # Requires Docker because the PostgreSQL backend is started with testcontainers.
@@ -245,11 +245,11 @@ test-postgres: ensure-embed-dir postgres-up
 	@echo "Waiting for postgres to be ready..."
 	@sleep 2
 	TEST_PG_URL="postgres://agentsview_test:agentsview_test_password@localhost:5433/agentsview_test?sslmode=disable" \
-		CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled,pgtest" -v ./internal/postgres/... -count=1
+		CGO_ENABLED=1 go test -tags "fts5,pgtest" -v ./internal/postgres/... -count=1
 
 # PostgreSQL integration tests for CI (postgres already running as service)
 test-postgres-ci: ensure-embed-dir
-	CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled,pgtest" -v ./internal/postgres/... -count=1
+	CGO_ENABLED=1 go test -tags "fts5,pgtest" -v ./internal/postgres/... -count=1
 
 # Start test SSH container
 ssh-up:
@@ -265,11 +265,11 @@ ssh-down:
 test-ssh: ensure-embed-dir ssh-up
 	TEST_SSH_HOST=localhost TEST_SSH_PORT=2222 TEST_SSH_USER=testuser \
 		TEST_SSH_KEY=$(CURDIR)/testdata/ssh/test_key \
-		CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled,sshtest" -v ./internal/ssh/... -count=1
+		CGO_ENABLED=1 go test -tags "fts5,sshtest" -v ./internal/ssh/... -count=1
 
 # SSH integration tests for CI (sshd already running)
 test-ssh-ci: ensure-embed-dir
-	CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled,sshtest" -v ./internal/ssh/... -count=1
+	CGO_ENABLED=1 go test -tags "fts5,sshtest" -v ./internal/ssh/... -count=1
 
 # Run Playwright E2E tests
 e2e:

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ make install        # install to ~/.local/bin
 ```
 
 ```bash
-make test           # Go tests (CGO_ENABLED=1 -tags "fts5,kit_posthog_disabled")
+make test           # Go tests (CGO_ENABLED=1 -tags "fts5")
 make bench-backends # compare SQLite, DuckDB, and PostgreSQL store reads
 make lint           # golangci-lint + NilAway
 make nilaway        # NilAway through custom golangci-lint

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -81,7 +81,6 @@ func TestLoadOrCreateInstallIDIsStableAndAnonymous(t *testing.T) {
 }
 
 func TestAllowedEventOptionsConfigureDaemonActiveShape(t *testing.T) {
-	skipWhenPostHogDisabledByBuildTag(t)
 	t.Setenv(EnabledEnv, "1")
 	t.Setenv(GenericEnabledEnv, "1")
 
@@ -125,7 +124,6 @@ func TestAllowedEventOptionsConfigureDaemonActiveShape(t *testing.T) {
 }
 
 func TestReporterCaptureDaemonActiveNoopsDuringTests(t *testing.T) {
-	skipWhenPostHogDisabledByBuildTag(t)
 	t.Setenv(EnabledEnv, "1")
 	t.Setenv(GenericEnabledEnv, "1")
 
@@ -150,11 +148,4 @@ func TestReporterCaptureDaemonActiveTestBlockerWinsOverCanceledContext(t *testin
 
 	err := reporter.CaptureDaemonActive(ctx)
 	require.NoError(t, err)
-}
-
-func skipWhenPostHogDisabledByBuildTag(t *testing.T) {
-	t.Helper()
-	if kittelemetry.PostHogTelemetryDisabled() {
-		t.Skip("kit_posthog_disabled disables enabled PostHog reporter setup")
-	}
 }


### PR DESCRIPTION
Two unrelated maintenance changes to the agent instructions and the test build setup.

## Agent instructions (AGENTS.md / CLAUDE.md)

The Pull Requests guidance now explicitly forbids a "Tests", "Testing", "Verification", or "Test plan" section in PR descriptions. CI runs the tests, so the description should not restate the suite, list test commands, or describe how the change was verified.

## Drop kit_posthog_disabled from `go test`

`go test` no longer passes the `kit_posthog_disabled` build tag. The telemetry reporter already returns a disabled no-op under `testing.Testing()` (`NewReporter` and `CaptureDaemonActive` both short-circuit), so tests never send PostHog events without the tag. The tag is removed from the Makefile test targets, the CI test/race/coverage/fuzz/msys2 steps, and the docs.

The tag is kept on the `go build` steps that produce e2e binaries (`scripts/e2e-server.sh` and the CI pre-build of `agentsview`/`testfixture`), since those run as real processes where the `testing.Testing()` guard does not apply and telemetry defaults to enabled.

With the tag gone from the test binary, `skipWhenPostHogDisabledByBuildTag` and its two call sites in `internal/telemetry/telemetry_test.go` are dead and removed. Those two enabled-reporter tests previously always skipped under the tag; they now run.

Reviewers: see `internal/telemetry/telemetry.go` for the `testing.Testing()` guards that make the tag unnecessary, and `.github/workflows/ci.yml` for the kept `go build` uses.