### PR TITLE
feat(cli): support explicit session server targets

### DIFF
--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -5,6 +5,8 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/config"
@@ -35,8 +37,8 @@ func newSessionCommand() *cobra.Command {
 		"Remote daemon URL",
 	)
 	cmd.PersistentFlags().String(
-		"server-token", "",
-		"Bearer token for explicit --server requests",
+		"server-token-file", "",
+		"File containing bearer token for explicit --server requests",
 	)
 	cmd.PersistentFlags().Bool(
 		"pg", false,
@@ -61,12 +63,6 @@ func newSessionCommand() *cobra.Command {
 func resolveService(
 	cmd *cobra.Command,
 ) (service.SessionService, func(), error) {
-	cfg, err := config.LoadPFlags(cmd.Flags())
-	if err != nil {
-		return nil, nil, fmt.Errorf(
-			"loading config: %w", err,
-		)
-	}
 	remote, _ := cmd.Flags().GetString("server")
 	if remote != "" {
 		if pgReadRequested(cmd) {
@@ -74,8 +70,18 @@ func resolveService(
 				"--server and --pg are mutually exclusive",
 			)
 		}
-		return service.NewHTTPBackend(remote, explicitServerToken(cmd), false),
+		token, err := explicitServerToken(cmd)
+		if err != nil {
+			return nil, nil, err
+		}
+		return service.NewHTTPBackend(remote, token, false),
 			func() {}, nil
+	}
+	cfg, err := config.LoadPFlags(cmd.Flags())
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"loading config: %w", err,
+		)
 	}
 	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
 	if err != nil {
@@ -99,23 +105,27 @@ func resolveService(
 func resolveWritableService(
 	cmd *cobra.Command,
 ) (service.SessionService, func(), error) {
-	cfg, err := config.LoadPFlags(cmd.Flags())
-	if err != nil {
-		return nil, nil, fmt.Errorf("loading config: %w", err)
-	}
 	if remote, _ := cmd.Flags().GetString("server"); remote != "" {
 		if pgReadRequested(cmd) {
 			return nil, nil, errors.New(
 				"--server and --pg are mutually exclusive",
 			)
 		}
-		return service.NewHTTPBackend(remote, explicitServerToken(cmd), false),
+		token, err := explicitServerToken(cmd)
+		if err != nil {
+			return nil, nil, err
+		}
+		return service.NewHTTPBackend(remote, token, false),
 			func() {}, nil
 	}
 	if pgReadRequested(cmd) {
 		return nil, nil, errors.New(
 			"--pg is read-only and cannot be used with write commands",
 		)
+	}
+	cfg, err := config.LoadPFlags(cmd.Flags())
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading config: %w", err)
 	}
 	tr, err := detectTransport(cfg.DataDir, cfg.AuthToken, 0)
 	if err != nil {
@@ -166,15 +176,19 @@ func pgReadRequested(cmd *cobra.Command) bool {
 	return err == nil && v
 }
 
-func explicitServerToken(cmd *cobra.Command) string {
+func explicitServerToken(cmd *cobra.Command) (string, error) {
 	if cmd == nil {
-		return ""
+		return "", nil
 	}
-	v, err := cmd.Flags().GetString("server-token")
-	if err != nil {
-		return ""
+	path, err := cmd.Flags().GetString("server-token-file")
+	if err == nil && strings.TrimSpace(path) != "" {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("reading --server-token-file: %w", err)
+		}
+		return strings.TrimSpace(string(b)), nil
 	}
-	return v
+	return strings.TrimSpace(os.Getenv("AGENTSVIEW_SERVER_TOKEN")), nil
 }
 
 // outputFormat returns the requested --format flag value

--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -34,6 +34,10 @@ func newSessionCommand() *cobra.Command {
 		"server", "",
 		"Remote daemon URL",
 	)
+	cmd.PersistentFlags().String(
+		"server-token", "",
+		"Bearer token for explicit --server requests",
+	)
 	cmd.PersistentFlags().Bool(
 		"pg", false,
 		"Read session data from configured PostgreSQL",
@@ -70,7 +74,7 @@ func resolveService(
 				"--server and --pg are mutually exclusive",
 			)
 		}
-		return service.NewHTTPBackend(remote, cfg.AuthToken, false),
+		return service.NewHTTPBackend(remote, explicitServerToken(cmd), false),
 			func() {}, nil
 	}
 	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
@@ -105,7 +109,7 @@ func resolveWritableService(
 				"--server and --pg are mutually exclusive",
 			)
 		}
-		return service.NewHTTPBackend(remote, cfg.AuthToken, false),
+		return service.NewHTTPBackend(remote, explicitServerToken(cmd), false),
 			func() {}, nil
 	}
 	if pgReadRequested(cmd) {
@@ -160,6 +164,17 @@ func pgReadRequested(cmd *cobra.Command) bool {
 	}
 	v, err := cmd.Flags().GetBool("pg")
 	return err == nil && v
+}
+
+func explicitServerToken(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	v, err := cmd.Flags().GetString("server-token")
+	if err != nil {
+		return ""
+	}
+	return v
 }
 
 // outputFormat returns the requested --format flag value

--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -26,9 +26,13 @@ func newSessionCommand() *cobra.Command {
 		"format", "human",
 		"Output format: human or json",
 	)
+	cmd.PersistentFlags().Bool(
+		"json", false,
+		"Emit JSON output (alias for --format json)",
+	)
 	cmd.PersistentFlags().String(
 		"server", "",
-		"Remote daemon URL (not yet implemented)",
+		"Remote daemon URL",
 	)
 	cmd.PersistentFlags().Bool(
 		"pg", false,
@@ -53,17 +57,21 @@ func newSessionCommand() *cobra.Command {
 func resolveService(
 	cmd *cobra.Command,
 ) (service.SessionService, func(), error) {
-	remote, _ := cmd.Flags().GetString("server")
-	if remote != "" {
-		return nil, nil, errors.New(
-			"--server not yet implemented",
-		)
-	}
 	cfg, err := config.LoadPFlags(cmd.Flags())
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"loading config: %w", err,
 		)
+	}
+	remote, _ := cmd.Flags().GetString("server")
+	if remote != "" {
+		if pgReadRequested(cmd) {
+			return nil, nil, errors.New(
+				"--server and --pg are mutually exclusive",
+			)
+		}
+		return service.NewHTTPBackend(remote, cfg.AuthToken, false),
+			func() {}, nil
 	}
 	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
 	if err != nil {
@@ -87,17 +95,23 @@ func resolveService(
 func resolveWritableService(
 	cmd *cobra.Command,
 ) (service.SessionService, func(), error) {
+	cfg, err := config.LoadPFlags(cmd.Flags())
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading config: %w", err)
+	}
 	if remote, _ := cmd.Flags().GetString("server"); remote != "" {
-		return nil, nil, errors.New("--server not yet implemented")
+		if pgReadRequested(cmd) {
+			return nil, nil, errors.New(
+				"--server and --pg are mutually exclusive",
+			)
+		}
+		return service.NewHTTPBackend(remote, cfg.AuthToken, false),
+			func() {}, nil
 	}
 	if pgReadRequested(cmd) {
 		return nil, nil, errors.New(
 			"--pg is read-only and cannot be used with write commands",
 		)
-	}
-	cfg, err := config.LoadPFlags(cmd.Flags())
-	if err != nil {
-		return nil, nil, fmt.Errorf("loading config: %w", err)
 	}
 	tr, err := detectTransport(cfg.DataDir, cfg.AuthToken, 0)
 	if err != nil {
@@ -151,6 +165,10 @@ func pgReadRequested(cmd *cobra.Command) bool {
 // outputFormat returns the requested --format flag value
 // ("human" or "json"). Defaults to "human".
 func outputFormat(cmd *cobra.Command) string {
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		return "json"
+	}
 	v, _ := cmd.Flags().GetString("format")
 	if v == "" {
 		return "human"

--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -64,10 +64,13 @@ func resolveServiceSessionID(
 	if detail != nil {
 		return id, nil
 	}
-	// If the user already supplied a prefixed ID (contains ":")
-	// or a host-prefixed remote ID ("host~..."), don't second-
-	// guess them — the exact lookup is authoritative.
-	if strings.ContainsAny(id, ":~") {
+	// If the user already supplied a known agent-prefixed ID or
+	// a host-prefixed remote ID ("host~..."), don't second-guess
+	// them — the exact lookup is authoritative. Some raw IDs
+	// (Kimi/Kimi Code, OpenClaw) contain colons before the agent
+	// prefix is added, so an arbitrary colon is not enough to
+	// classify the input as canonical.
+	if isCanonicalServiceSessionID(id) {
 		return "", fmt.Errorf("session not found: %s", id)
 	}
 	for _, def := range parser.Registry {
@@ -84,6 +87,19 @@ func resolveServiceSessionID(
 		}
 	}
 	return "", fmt.Errorf("session not found: %s", id)
+}
+
+func isCanonicalServiceSessionID(id string) bool {
+	if strings.Contains(id, "~") {
+		return true
+	}
+	_, rawID := parser.StripHostPrefix(id)
+	for _, def := range parser.Registry {
+		if def.IDPrefix != "" && strings.HasPrefix(rawID, def.IDPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // lookupSessionWithPrefixes fetches a session detail, trying agent

--- a/cmd/agentsview/session_sync.go
+++ b/cmd/agentsview/session_sync.go
@@ -30,7 +30,9 @@ func newSessionSyncCommand() *cobra.Command {
 			}
 			defer cleanup()
 
-			detail, err := svc.Sync(cmd.Context(), classifySyncArg(args[0]))
+			detail, err := svc.Sync(
+				cmd.Context(), classifySyncArgForCommand(cmd, args[0]),
+			)
 			if err != nil {
 				return err
 			}
@@ -42,6 +44,16 @@ func newSessionSyncCommand() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func classifySyncArgForCommand(
+	cmd *cobra.Command, arg string,
+) service.SyncInput {
+	remote, _ := cmd.Flags().GetString("server")
+	if remote != "" && looksLikePath(arg) {
+		return service.SyncInput{Path: arg}
+	}
+	return classifySyncArg(arg)
 }
 
 // syncService resembles newService but constructs a real

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -833,6 +833,60 @@ func TestSessionUsage_ServerFlagResolvesBareID(t *testing.T) {
 	assert.Equal(t, "/api/v1/sessions/"+canonicalID+"/usage", gotUsagePath)
 }
 
+func TestSessionUsage_ServerFlagResolvesKimiRawID(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	const rawID = "project-hash:session-uuid"
+	const canonicalID = "kimi:" + rawID
+
+	var gotUsagePath string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/api/v1/sessions/" + rawID:
+				http.NotFound(w, r)
+			case "/api/v1/sessions/" + canonicalID:
+				_, _ = w.Write([]byte(`{
+					"id": "` + canonicalID + `",
+					"agent": "kimi",
+					"project": "remote-project"
+				}`))
+			case "/api/v1/sessions/" + canonicalID + "/usage":
+				gotUsagePath = r.URL.Path
+				_, _ = w.Write([]byte(`{
+					"session_id": "` + canonicalID + `",
+					"agent": "kimi",
+					"project": "remote-project",
+					"total_output_tokens": 84,
+					"peak_context_tokens": 2048,
+					"has_token_data": true,
+					"cost_usd": 0.5,
+					"has_cost": true,
+					"models": ["kimi-k2"],
+					"unpriced_models": [],
+					"server_running": true
+				}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	defer ts.Close()
+
+	root := newRootCommand()
+	args := []string{"session", "usage", rawID, "--server", ts.URL}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(args[3:]))
+
+	out, code, err := sessionUsageDataForCommand(cmd, rawID)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, tokenUseExitOK, code)
+	assert.Equal(t, canonicalID, out.SessionID)
+	assert.Equal(t, "/api/v1/sessions/"+canonicalID+"/usage", gotUsagePath)
+}
+
 func TestSessionUsage_ServerFlagDoesNotSendConfigAuthToken(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -241,6 +241,47 @@ func TestSessionList_ServerFlagUsesHTTP(t *testing.T) {
 	assert.Equal(t, "remote-session", got.Sessions[0]["id"])
 }
 
+func TestSessionList_ServerFlagDoesNotSendConfigAuthToken(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dataDir, "config.toml"),
+		[]byte(`auth_token = "local-secret"`),
+		0o600,
+	))
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Empty(t, r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"sessions":[],"total":0}`))
+		}))
+	defer ts.Close()
+
+	_, err := executeCommand(newRootCommand(),
+		"session", "list", "--server", ts.URL, "--json")
+	require.NoError(t, err)
+}
+
+func TestSessionList_ServerTokenSendsBearer(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer remote-secret",
+				r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"sessions":[],"total":0}`))
+		}))
+	defer ts.Close()
+
+	_, err := executeCommand(newRootCommand(),
+		"session", "list", "--server", ts.URL,
+		"--server-token", "remote-secret", "--json")
+	require.NoError(t, err)
+}
+
 func TestSessionList_PGFlagUsesPGReadStore(t *testing.T) {
 	localDir := t.TempDir()
 	remoteDir := t.TempDir()
@@ -768,6 +809,139 @@ func TestSessionUsage_ServerFlagResolvesBareID(t *testing.T) {
 	assert.Equal(t, tokenUseExitOK, code)
 	assert.Equal(t, canonicalID, out.SessionID)
 	assert.Equal(t, "/api/v1/sessions/"+canonicalID+"/usage", gotUsagePath)
+}
+
+func TestSessionUsage_ServerFlagDoesNotSendConfigAuthToken(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dataDir, "config.toml"),
+		[]byte(`auth_token = "local-secret"`),
+		0o600,
+	))
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Empty(t, r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/api/v1/sessions/remote-session":
+				_, _ = w.Write([]byte(`{"id":"remote-session"}`))
+			case "/api/v1/sessions/remote-session/usage":
+				_, _ = w.Write([]byte(`{
+					"session_id": "remote-session",
+					"agent": "codex",
+					"project": "remote-project",
+					"total_output_tokens": 42,
+					"peak_context_tokens": 2048,
+					"has_token_data": true,
+					"cost_usd": 0.5,
+					"has_cost": true,
+					"models": ["gpt-5.1"],
+					"unpriced_models": [],
+					"server_running": true
+				}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	defer ts.Close()
+
+	root := newRootCommand()
+	args := []string{"session", "usage", "remote-session", "--server", ts.URL}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(args[3:]))
+
+	out, _, err := sessionUsageDataForCommand(cmd, "remote-session")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+}
+
+func TestSessionUsage_ServerTokenSendsBearer(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer remote-secret",
+				r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/api/v1/sessions/remote-session":
+				_, _ = w.Write([]byte(`{"id":"remote-session"}`))
+			case "/api/v1/sessions/remote-session/usage":
+				_, _ = w.Write([]byte(`{
+					"session_id": "remote-session",
+					"agent": "codex",
+					"project": "remote-project",
+					"total_output_tokens": 42,
+					"peak_context_tokens": 2048,
+					"has_token_data": true,
+					"cost_usd": 0.5,
+					"has_cost": true,
+					"models": ["gpt-5.1"],
+					"unpriced_models": [],
+					"server_running": true
+				}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	defer ts.Close()
+
+	root := newRootCommand()
+	args := []string{
+		"session", "usage", "remote-session",
+		"--server", ts.URL,
+		"--server-token", "remote-secret",
+	}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(args[3:]))
+
+	out, _, err := sessionUsageDataForCommand(cmd, "remote-session")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+}
+
+func TestSessionUsage_ServerHTTPClientHasTimeout(t *testing.T) {
+	oldClient := sessionUsageHTTPClient
+	sessionUsageHTTPClient = &http.Client{Timeout: 20 * time.Millisecond}
+	t.Cleanup(func() { sessionUsageHTTPClient = oldClient })
+
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/api/v1/sessions/remote-session":
+				_, _ = w.Write([]byte(`{"id":"remote-session"}`))
+			case "/api/v1/sessions/remote-session/usage":
+				time.Sleep(200 * time.Millisecond)
+				_, _ = w.Write([]byte(`{"session_id":"remote-session"}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	defer ts.Close()
+
+	root := newRootCommand()
+	args := []string{"session", "usage", "remote-session", "--server", ts.URL}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(args[3:]))
+
+	start := time.Now()
+	out, code, err := sessionUsageDataForCommand(cmd, "remote-session")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Nil(t, out)
+	assert.Equal(t, tokenUseExitErr, code)
+	assert.Less(t, elapsed, 150*time.Millisecond)
 }
 
 func TestSessionUsage_PGEnvUsesPGStore(t *testing.T) {

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,6 +100,22 @@ func TestSessionGet_JSON(t *testing.T) {
 	assert.Equal(t, "proj", got["project"])
 }
 
+func TestSessionGet_JSONAlias(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedSession(t, dataDir, "s-json", "proj")
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "get", "s-json", "--json")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"stdout should be valid JSON: %q", out)
+	assert.Equal(t, "s-json", got["id"])
+	assert.Equal(t, "proj", got["project"])
+}
+
 func TestSessionGet_NotFound(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
@@ -182,6 +200,45 @@ func TestSessionList_FilterByProject(t *testing.T) {
 		"stdout should be valid JSON: %q", out)
 	require.Len(t, got.Sessions, 1)
 	assert.Equal(t, "s-a", got.Sessions[0]["id"])
+}
+
+func TestSessionList_ServerFlagUsesHTTP(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedSession(t, dataDir, "local-session", "local")
+
+	var gotPath, gotProject string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotProject = r.URL.Query().Get("project")
+			assert.Equal(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"sessions": [
+					{"id":"remote-session","project":"remote","agent":"claude"}
+				],
+				"total": 1
+			}`))
+		}))
+	defer ts.Close()
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--server", ts.URL, "--project", "remote",
+		"--json")
+	require.NoError(t, err)
+
+	var got struct {
+		Sessions []map[string]any `json:"sessions"`
+		Total    int              `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"stdout should be valid JSON: %q", out)
+	assert.Equal(t, "/api/v1/sessions", gotPath)
+	assert.Equal(t, "remote", gotProject)
+	assert.Equal(t, 1, got.Total)
+	require.Len(t, got.Sessions, 1)
+	assert.Equal(t, "remote-session", got.Sessions[0]["id"])
 }
 
 func TestSessionList_PGFlagUsesPGReadStore(t *testing.T) {
@@ -604,21 +661,47 @@ func TestSessionExport_RejectsPGFlag(t *testing.T) {
 	assert.Contains(t, err.Error(), "--pg not supported")
 }
 
-// TestSessionUsage_RejectsServerFlag verifies that `session usage`
-// rejects the inherited --server flag instead of silently querying
-// the local SQLite archive. usage uses the direct token-use path
-// (not the SessionService layer), so a user explicitly targeting a
-// daemon must get the same "not yet implemented" error the other
-// session commands return — not stale or local-only data.
-func TestSessionUsage_RejectsServerFlag(t *testing.T) {
+func TestSessionUsage_ServerFlagUsesHTTP(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 
-	_, err := executeCommand(newRootCommand(),
-		"session", "usage", "some-id",
-		"--server", "http://localhost:9999")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--server not yet implemented")
+	var gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			assert.Equal(t, http.MethodGet, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"session_id": "remote-session",
+				"agent": "codex",
+				"project": "remote-project",
+				"total_output_tokens": 42,
+				"peak_context_tokens": 2048,
+				"has_token_data": true,
+				"cost_usd": 0.5,
+				"has_cost": true,
+				"models": ["gpt-5.1"],
+				"unpriced_models": [],
+				"server_running": true
+			}`))
+		}))
+	defer ts.Close()
+
+	root := newRootCommand()
+	args := []string{"session", "usage", "remote-session", "--server", ts.URL}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(args[3:]))
+
+	out, code, err := sessionUsageDataForCommand(cmd, "remote-session")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "/api/v1/sessions/remote-session/usage", gotPath)
+	assert.Equal(t, tokenUseExitOK, code)
+	assert.Equal(t, "remote-session", out.SessionID)
+	assert.Equal(t, "remote-project", out.Project)
+	assert.Equal(t, 42, out.TotalOutputTokens)
+	assert.True(t, out.ServerRunning)
 }
 
 func TestSessionUsage_PGEnvUsesPGStore(t *testing.T) {

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -668,22 +668,34 @@ func TestSessionUsage_ServerFlagUsesHTTP(t *testing.T) {
 	var gotPath string
 	ts := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			gotPath = r.URL.Path
 			assert.Equal(t, http.MethodGet, r.Method)
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{
-				"session_id": "remote-session",
-				"agent": "codex",
-				"project": "remote-project",
-				"total_output_tokens": 42,
-				"peak_context_tokens": 2048,
-				"has_token_data": true,
-				"cost_usd": 0.5,
-				"has_cost": true,
-				"models": ["gpt-5.1"],
-				"unpriced_models": [],
-				"server_running": true
-			}`))
+			switch r.URL.Path {
+			case "/api/v1/sessions/remote-session":
+				_, _ = w.Write([]byte(`{
+					"id": "remote-session",
+					"agent": "codex",
+					"project": "remote-project"
+				}`))
+			case "/api/v1/sessions/remote-session/usage":
+				gotPath = r.URL.Path
+				_, _ = w.Write([]byte(`{
+					"session_id": "remote-session",
+					"agent": "codex",
+					"project": "remote-project",
+					"total_output_tokens": 42,
+					"peak_context_tokens": 2048,
+					"has_token_data": true,
+					"cost_usd": 0.5,
+					"has_cost": true,
+					"models": ["gpt-5.1"],
+					"unpriced_models": [],
+					"server_running": true
+				}`))
+			default:
+				t.Errorf("unexpected path: %s", r.URL.Path)
+				http.NotFound(w, r)
+			}
 		}))
 	defer ts.Close()
 
@@ -702,6 +714,60 @@ func TestSessionUsage_ServerFlagUsesHTTP(t *testing.T) {
 	assert.Equal(t, "remote-project", out.Project)
 	assert.Equal(t, 42, out.TotalOutputTokens)
 	assert.True(t, out.ServerRunning)
+}
+
+func TestSessionUsage_ServerFlagResolvesBareID(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	const bareID = "019da6a6-8c67-7c23-b102-ef48502852d0"
+	const canonicalID = "codex:" + bareID
+
+	var gotUsagePath string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/api/v1/sessions/" + bareID:
+				http.NotFound(w, r)
+			case "/api/v1/sessions/" + canonicalID:
+				_, _ = w.Write([]byte(`{
+					"id": "` + canonicalID + `",
+					"agent": "codex",
+					"project": "remote-project"
+				}`))
+			case "/api/v1/sessions/" + canonicalID + "/usage":
+				gotUsagePath = r.URL.Path
+				_, _ = w.Write([]byte(`{
+					"session_id": "` + canonicalID + `",
+					"agent": "codex",
+					"project": "remote-project",
+					"total_output_tokens": 42,
+					"peak_context_tokens": 2048,
+					"has_token_data": true,
+					"cost_usd": 0.5,
+					"has_cost": true,
+					"models": ["gpt-5.1"],
+					"unpriced_models": [],
+					"server_running": true
+				}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	defer ts.Close()
+
+	root := newRootCommand()
+	args := []string{"session", "usage", bareID, "--server", ts.URL}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(args[3:]))
+
+	out, code, err := sessionUsageDataForCommand(cmd, bareID)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, tokenUseExitOK, code)
+	assert.Equal(t, canonicalID, out.SessionID)
+	assert.Equal(t, "/api/v1/sessions/"+canonicalID+"/usage", gotUsagePath)
 }
 
 func TestSessionUsage_PGEnvUsesPGStore(t *testing.T) {

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -244,6 +244,7 @@ func TestSessionList_ServerFlagUsesHTTP(t *testing.T) {
 func TestSessionList_ServerFlagDoesNotSendConfigAuthToken(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_SERVER_TOKEN", "")
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dataDir, "config.toml"),
 		[]byte(`auth_token = "local-secret"`),
@@ -263,9 +264,31 @@ func TestSessionList_ServerFlagDoesNotSendConfigAuthToken(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSessionList_ServerFlagDoesNotLoadLocalConfig(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dataDir, "config.toml"),
+		[]byte(`not = valid = toml`),
+		0o600,
+	))
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"sessions":[],"total":0}`))
+		}))
+	defer ts.Close()
+
+	_, err := executeCommand(newRootCommand(),
+		"session", "list", "--server", ts.URL, "--json")
+	require.NoError(t, err)
+}
+
 func TestSessionList_ServerTokenSendsBearer(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_SERVER_TOKEN", "remote-secret")
 
 	ts := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -277,8 +300,7 @@ func TestSessionList_ServerTokenSendsBearer(t *testing.T) {
 	defer ts.Close()
 
 	_, err := executeCommand(newRootCommand(),
-		"session", "list", "--server", ts.URL,
-		"--server-token", "remote-secret", "--json")
+		"session", "list", "--server", ts.URL, "--json")
 	require.NoError(t, err)
 }
 
@@ -814,6 +836,7 @@ func TestSessionUsage_ServerFlagResolvesBareID(t *testing.T) {
 func TestSessionUsage_ServerFlagDoesNotSendConfigAuthToken(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_SERVER_TOKEN", "")
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dataDir, "config.toml"),
 		[]byte(`auth_token = "local-secret"`),
@@ -858,9 +881,59 @@ func TestSessionUsage_ServerFlagDoesNotSendConfigAuthToken(t *testing.T) {
 	require.NotNil(t, out)
 }
 
+func TestSessionUsage_ServerFlagDoesNotLoadLocalConfig(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dataDir, "config.toml"),
+		[]byte(`not = valid = toml`),
+		0o600,
+	))
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/api/v1/sessions/remote-session":
+				_, _ = w.Write([]byte(`{"id":"remote-session"}`))
+			case "/api/v1/sessions/remote-session/usage":
+				_, _ = w.Write([]byte(`{
+					"session_id": "remote-session",
+					"agent": "codex",
+					"project": "remote-project",
+					"total_output_tokens": 42,
+					"peak_context_tokens": 2048,
+					"has_token_data": true,
+					"cost_usd": 0.5,
+					"has_cost": true,
+					"models": ["gpt-5.1"],
+					"unpriced_models": [],
+					"server_running": true
+				}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+	defer ts.Close()
+
+	root := newRootCommand()
+	args := []string{"session", "usage", "remote-session", "--server", ts.URL}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(args[3:]))
+
+	out, _, err := sessionUsageDataForCommand(cmd, "remote-session")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+}
+
 func TestSessionUsage_ServerTokenSendsBearer(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	tokenFile := filepath.Join(dataDir, "remote-token")
+	require.NoError(t, os.WriteFile(
+		tokenFile, []byte("remote-secret\n"), 0o600,
+	))
 
 	ts := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -894,7 +967,7 @@ func TestSessionUsage_ServerTokenSendsBearer(t *testing.T) {
 	args := []string{
 		"session", "usage", "remote-session",
 		"--server", ts.URL,
-		"--server-token", "remote-secret",
+		"--server-token-file", tokenFile,
 	}
 	cmd, _, err := root.Find(args)
 	require.NoError(t, err)
@@ -1110,6 +1183,42 @@ func TestSessionSync_PGFlagRefusesWrite(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--pg is read-only")
 	assert.Contains(t, err.Error(), "write commands")
+}
+
+func TestSessionSync_ServerFlagTreatsPathShapedArgAsRemotePath(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dataDir, "config.toml"),
+		[]byte(`not = valid = toml`),
+		0o600,
+	))
+
+	var got struct {
+		ID   string `json:"id"`
+		Path string `json:"path"`
+	}
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/api/v1/sessions/sync", r.URL.Path)
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id": "remote-session",
+				"agent": "codex",
+				"project": "remote-project"
+			}`))
+		}))
+	defer ts.Close()
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "sync", "--server", ts.URL,
+		"/remote/session.jsonl", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"id":"remote-session"`)
+	assert.Empty(t, got.ID)
+	assert.Equal(t, "/remote/session.jsonl", got.Path)
 }
 
 // TestSessionSync_AgainstReadOnlyDaemon_Refuses verifies the CLI

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -71,10 +71,6 @@ func runSessionUsage(cmd *cobra.Command, sessionID, format string) {
 func sessionUsageDataForCommand(
 	cmd *cobra.Command, sessionID string,
 ) (*sessionUsageOutput, int, error) {
-	cfg, err := config.LoadPFlags(cmd.Flags())
-	if err != nil {
-		return nil, tokenUseExitErr, fmt.Errorf("loading config: %w", err)
-	}
 	remote, _ := cmd.Flags().GetString("server")
 	if remote != "" {
 		if pgReadRequested(cmd) {
@@ -82,9 +78,17 @@ func sessionUsageDataForCommand(
 				"--server and --pg are mutually exclusive",
 			)
 		}
+		token, err := explicitServerToken(cmd)
+		if err != nil {
+			return nil, tokenUseExitErr, err
+		}
 		return httpSessionUsageData(
-			cmd.Context(), remote, explicitServerToken(cmd), sessionID,
+			cmd.Context(), remote, token, sessionID,
 		)
+	}
+	cfg, err := config.LoadPFlags(cmd.Flags())
+	if err != nil {
+		return nil, tokenUseExitErr, fmt.Errorf("loading config: %w", err)
 	}
 	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
 	if err != nil {

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/config"
@@ -18,6 +19,8 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/service"
 )
+
+var sessionUsageHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 type rawSessionIDResolver interface {
 	FindSessionIDsByRawSuffix(
@@ -80,7 +83,7 @@ func sessionUsageDataForCommand(
 			)
 		}
 		return httpSessionUsageData(
-			cmd.Context(), remote, cfg.AuthToken, sessionID,
+			cmd.Context(), remote, explicitServerToken(cmd), sessionID,
 		)
 	}
 	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
@@ -123,7 +126,7 @@ func httpSessionUsageData(
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := sessionUsageHTTPClient.Do(req)
 	if err != nil {
 		return nil, tokenUseExitErr, err
 	}

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -102,8 +102,18 @@ func httpSessionUsageData(
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	resolvedID, err := resolveServiceSessionID(
+		ctx, service.NewHTTPBackend(baseURL, token, false), sessionID,
+	)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "session not found:") {
+			fmt.Fprintf(os.Stderr, "session not found: %s\n", sessionID)
+			return nil, tokenUseExitNotFound, nil
+		}
+		return nil, tokenUseExitErr, err
+	}
 	endpoint := strings.TrimSuffix(baseURL, "/") +
-		"/api/v1/sessions/" + url.PathEscape(sessionID) + "/usage"
+		"/api/v1/sessions/" + url.PathEscape(resolvedID) + "/usage"
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodGet, endpoint, nil,
 	)

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -5,9 +5,10 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -30,20 +31,6 @@ func newSessionUsageCommand() *cobra.Command {
 		Short:        "Show token usage and cost estimate for a session",
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
-		// usage uses the direct token-use path (local SQLite +
-		// on-demand sync), not the SessionService layer, so it cannot
-		// honor --server. Reject it here with the same "--server not
-		// yet implemented" error the service-backed session commands
-		// return via resolveService, rather than silently querying
-		// local data for a daemon-targeted request. PreRunE surfaces
-		// the error through Execute (exit 1); Run keeps os.Exit for
-		// the 0/2/3 usage codes.
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if remote, _ := cmd.Flags().GetString("server"); remote != "" {
-				return errors.New("--server not yet implemented")
-			}
-			return nil
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runSessionUsage(cmd, args[0], outputFormat(cmd))
 		},
@@ -85,6 +72,17 @@ func sessionUsageDataForCommand(
 	if err != nil {
 		return nil, tokenUseExitErr, fmt.Errorf("loading config: %w", err)
 	}
+	remote, _ := cmd.Flags().GetString("server")
+	if remote != "" {
+		if pgReadRequested(cmd) {
+			return nil, tokenUseExitErr, fmt.Errorf(
+				"--server and --pg are mutually exclusive",
+			)
+		}
+		return httpSessionUsageData(
+			cmd.Context(), remote, cfg.AuthToken, sessionID,
+		)
+	}
 	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
 	if err != nil {
 		return nil, tokenUseExitErr, err
@@ -93,6 +91,49 @@ func sessionUsageDataForCommand(
 		return sessionUsageData(sessionID)
 	}
 	return pgSessionUsageData(cfg, pgCfg, sessionID)
+}
+
+func httpSessionUsageData(
+	ctx context.Context,
+	baseURL string,
+	token string,
+	sessionID string,
+) (*sessionUsageOutput, int, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	endpoint := strings.TrimSuffix(baseURL, "/") +
+		"/api/v1/sessions/" + url.PathEscape(sessionID) + "/usage"
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, endpoint, nil,
+	)
+	if err != nil {
+		return nil, tokenUseExitErr, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, tokenUseExitErr, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		fmt.Fprintf(os.Stderr, "session not found: %s\n", sessionID)
+		return nil, tokenUseExitNotFound, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, tokenUseExitErr, fmt.Errorf(
+			"usage: HTTP %d: %s", resp.StatusCode, body,
+		)
+	}
+	var out sessionUsageOutput
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, tokenUseExitErr, err
+	}
+	out.ServerRunning = true
+	return &out, usageExitCode(&out.SessionUsage), nil
 }
 
 func pgSessionUsageData(


### PR DESCRIPTION
Adds explicit daemon targeting for the programmatic `agentsview session` CLI so scripts can point read/write session operations at a known AgentsView server instead of relying only on local daemon discovery.

The session command group now also accepts `--json` as a shorthand for `--format json`, matching the scripting examples users expect. `session usage` calls the existing per-session usage REST endpoint when `--server` is provided while preserving its established exit-code behavior.

The implementation keeps PostgreSQL direct-read mode separate from explicit server targeting by rejecting `--server` and `--pg` together.