### PR TITLE
Fix refresh toolbar affordance

### DIFF
--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -20,6 +20,10 @@
   import { events } from "../../stores/events.svelte.js";
   import { ui } from "../../stores/ui.svelte.js";
   import { exportAnalyticsCSV } from "../../utils/csv-export.js";
+  import {
+    createRefreshScheduler,
+    formatRefreshAge,
+  } from "../../utils/refresh.js";
   import { RefreshCwIcon } from "../../icons.js";
 
   function shortTz(tz: string): string {
@@ -30,13 +34,7 @@
   }
 
   const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
-
-  function formatUpdatedAt(value: number): string {
-    return new Date(value).toLocaleTimeString([], {
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  }
+  const REFRESH_LABEL_INTERVAL_MS = 60 * 1000;
 
   function handleExportCSV() {
     exportAnalyticsCSV({
@@ -50,15 +48,33 @@
     });
   }
 
-  let refreshTimer: ReturnType<typeof setInterval> | undefined;
+  const refreshScheduler = createRefreshScheduler(
+    () => analytics.fetchAll(),
+    REFRESH_INTERVAL_MS,
+  );
+  let refreshLabelTick = $state(Date.now());
+  let refreshLabelTimer:
+    | ReturnType<typeof setTimeout>
+    | undefined;
   let unsubEvents: (() => void) | undefined;
 
-  onMount(() => {
-    analytics.fetchAll();
-    refreshTimer = setInterval(
-      () => analytics.fetchAll(),
-      REFRESH_INTERVAL_MS,
+  let refreshLabel = $derived.by(() => {
+    return formatRefreshAge(
+      analytics.lastUpdatedAt,
+      refreshLabelTick,
     );
+  });
+
+  function scheduleRefreshLabelTick() {
+    refreshLabelTimer = setTimeout(() => {
+      refreshLabelTick = Date.now();
+      scheduleRefreshLabelTick();
+    }, REFRESH_LABEL_INTERVAL_MS);
+  }
+
+  onMount(() => {
+    refreshScheduler.start();
+    scheduleRefreshLabelTick();
     unsubEvents = events.subscribe(() => analytics.markNewData());
   });
 
@@ -142,8 +158,9 @@
   });
 
   onDestroy(() => {
-    if (refreshTimer !== undefined) {
-      clearInterval(refreshTimer);
+    refreshScheduler.stop();
+    if (refreshLabelTimer !== undefined) {
+      clearTimeout(refreshLabelTimer);
     }
     unsubEvents?.();
   });
@@ -171,7 +188,7 @@
     <button
       class="refresh-btn"
       class:querying={analytics.isQuerying}
-      onclick={() => analytics.fetchAll()}
+      onclick={() => refreshScheduler.refreshNow()}
       disabled={analytics.isQuerying}
       title="Refresh analytics"
       aria-label="Refresh analytics"
@@ -179,13 +196,13 @@
       <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
     </button>
     <div class="refresh-status" aria-live="polite">
-      {#if analytics.lastUpdatedAt !== null}
-        <span title={new Date(analytics.lastUpdatedAt).toLocaleString()}>
-          Updated {formatUpdatedAt(analytics.lastUpdatedAt)}
-        </span>
-      {:else}
-        <span>Not updated</span>
-      {/if}
+      <span
+        title={analytics.lastUpdatedAt === null
+          ? undefined
+          : new Date(analytics.lastUpdatedAt).toLocaleString()}
+      >
+        {refreshLabel}
+      </span>
       {#if analytics.hasNewData}
         <span class="new-data">New data</span>
       {/if}

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -381,11 +381,12 @@
   }
 
   .query-progress {
-    position: sticky;
+    position: absolute;
     top: 0;
+    left: 0;
+    right: 0;
     z-index: 4;
     height: 2px;
-    margin: -16px -16px 14px;
     overflow: hidden;
     background: color-mix(
       in srgb,

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -185,24 +185,26 @@
       onChange={(from, to) => analytics.setDateRange(from, to)}
       onPreset={(days) => analytics.setRollingWindow(days)}
     />
-    <button
-      class="refresh-btn"
-      class:querying={analytics.isQuerying}
-      onclick={() => refreshScheduler.refreshNow()}
-      disabled={analytics.isQuerying}
-      title="Refresh analytics"
-      aria-label="Refresh analytics"
-    >
-      <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
-    </button>
-    <div class="refresh-status" aria-live="polite">
-      <span
-        title={analytics.lastUpdatedAt === null
-          ? undefined
-          : new Date(analytics.lastUpdatedAt).toLocaleString()}
+    <div class="refresh-control">
+      <button
+        class="refresh-btn"
+        class:querying={analytics.isQuerying}
+        onclick={() => refreshScheduler.refreshNow()}
+        disabled={analytics.isQuerying}
+        title="Refresh analytics"
+        aria-label="Refresh analytics"
       >
-        {refreshLabel}
-      </span>
+        <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
+      </button>
+      <div class="refresh-status" aria-live="polite">
+        <span
+          title={analytics.lastUpdatedAt === null
+            ? undefined
+            : new Date(analytics.lastUpdatedAt).toLocaleString()}
+        >
+          {refreshLabel}
+        </span>
+      </div>
     </div>
     <button class="export-btn" onclick={handleExportCSV}>
       Export CSV
@@ -298,12 +300,20 @@
     align-items: center;
   }
 
+  .refresh-control {
+    min-height: 28px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
   .refresh-btn {
     width: 28px;
     height: 28px;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
+    padding-right: 2px;
     border-radius: var(--radius-sm);
     color: var(--text-muted);
     cursor: pointer;

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -203,9 +203,6 @@
       >
         {refreshLabel}
       </span>
-      {#if analytics.hasNewData}
-        <span class="new-data">New data</span>
-      {/if}
     </div>
     <button class="export-btn" onclick={handleExportCSV}>
       Export CSV
@@ -335,17 +332,6 @@
     color: var(--text-muted);
     font-size: 11px;
     white-space: nowrap;
-  }
-
-  .new-data {
-    display: inline-flex;
-    align-items: center;
-    min-height: 18px;
-    padding: 0 6px;
-    border-radius: var(--radius-sm);
-    background: var(--bg-surface-hover);
-    color: var(--accent-blue);
-    font-weight: 600;
   }
 
   .export-btn {

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -304,7 +304,7 @@
     min-height: 28px;
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: 8px;
   }
 
   .refresh-btn {
@@ -312,8 +312,7 @@
     height: 28px;
     display: flex;
     align-items: center;
-    justify-content: flex-end;
-    padding-right: 2px;
+    justify-content: center;
     border-radius: var(--radius-sm);
     color: var(--text-muted);
     cursor: pointer;

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -196,7 +196,7 @@
       >
         <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
       </button>
-      <div class="refresh-status" aria-live="polite">
+      <div class="refresh-status">
         <span
           title={analytics.lastUpdatedAt === null
             ? undefined

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -23,6 +23,12 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(source).not.toContain(".new-data");
   });
 
+  it("does not announce passive refresh-age ticks as live updates", () => {
+    expect(source).not.toContain(
+      'class="refresh-status" aria-live="polite"',
+    );
+  });
+
   it("keeps the refresh timestamp beside the centered icon button", () => {
     const refreshControl =
       source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -23,7 +23,7 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(source).not.toContain(".new-data");
   });
 
-  it("keeps the refresh timestamp visually attached to the icon", () => {
+  it("keeps the refresh timestamp beside the centered icon button", () => {
     const refreshControl =
       source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";
     const refreshButton =
@@ -32,10 +32,10 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(source).toContain('class="refresh-control"');
     expect(refreshControl).toContain("display: inline-flex");
     expect(refreshControl).toContain("align-items: center");
-    expect(refreshControl).toContain("gap: 4px");
+    expect(refreshControl).toContain("gap: 8px");
     expect(refreshButton).toContain("width: 28px");
-    expect(refreshButton).toContain("justify-content: flex-end");
-    expect(refreshButton).toContain("padding-right: 2px");
+    expect(refreshButton).toContain("justify-content: center");
+    expect(refreshButton).not.toContain("padding-right");
     expect(source).not.toContain(".refresh-btn::before");
   });
 

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -8,11 +8,16 @@ describe("AnalyticsPage refresh behavior", () => {
 
   it("keeps automatic refresh bounded to five minutes", () => {
     expect(source).toContain("REFRESH_INTERVAL_MS = 5 * 60 * 1000");
-    expect(source).toContain("setInterval");
+    expect(source).toContain("createRefreshScheduler");
+    expect(source).toContain("refreshScheduler.refreshNow()");
+    expect(source).not.toContain("setInterval");
   });
 
-  it("shows last-updated and new-data refresh hints", () => {
+  it("shows relative last-updated and new-data refresh hints", () => {
     expect(source).toContain("analytics.lastUpdatedAt");
+    expect(source).toContain("REFRESH_LABEL_INTERVAL_MS = 60 * 1000");
+    expect(source).toContain("formatRefreshAge");
+    expect(source).not.toContain("formatUpdatedAt");
     expect(source).toContain("analytics.hasNewData");
     expect(source).toContain("New data");
   });

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -21,4 +21,15 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(source).toContain("analytics.hasNewData");
     expect(source).toContain("New data");
   });
+
+  it("keeps refresh progress out of content layout flow", () => {
+    const queryProgress =
+      source.match(/\.query-progress\s*{[^}]+}/)?.[0] ?? "";
+
+    expect(queryProgress).toContain("position: absolute");
+    expect(queryProgress).toContain("left: 0;");
+    expect(queryProgress).toContain("right: 0;");
+    expect(queryProgress).not.toContain("position: sticky");
+    expect(queryProgress).not.toContain("margin:");
+  });
 });

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -23,6 +23,22 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(source).not.toContain(".new-data");
   });
 
+  it("keeps the refresh timestamp visually attached to the icon", () => {
+    const refreshControl =
+      source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";
+    const refreshButton =
+      source.match(/\.refresh-btn\s*{[^}]+}/)?.[0] ?? "";
+
+    expect(source).toContain('class="refresh-control"');
+    expect(refreshControl).toContain("display: inline-flex");
+    expect(refreshControl).toContain("align-items: center");
+    expect(refreshControl).toContain("gap: 4px");
+    expect(refreshButton).toContain("width: 28px");
+    expect(refreshButton).toContain("justify-content: flex-end");
+    expect(refreshButton).toContain("padding-right: 2px");
+    expect(source).not.toContain(".refresh-btn::before");
+  });
+
   it("keeps refresh progress out of content layout flow", () => {
     const queryProgress =
       source.match(/\.query-progress\s*{[^}]+}/)?.[0] ?? "";

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -13,13 +13,14 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(source).not.toContain("setInterval");
   });
 
-  it("shows relative last-updated and new-data refresh hints", () => {
+  it("shows relative last-updated refresh status without ambiguous badges", () => {
     expect(source).toContain("analytics.lastUpdatedAt");
     expect(source).toContain("REFRESH_LABEL_INTERVAL_MS = 60 * 1000");
     expect(source).toContain("formatRefreshAge");
     expect(source).not.toContain("formatUpdatedAt");
-    expect(source).toContain("analytics.hasNewData");
-    expect(source).toContain("New data");
+    expect(source).not.toContain("analytics.hasNewData");
+    expect(source).not.toContain("New data");
+    expect(source).not.toContain(".new-data");
   });
 
   it("keeps refresh progress out of content layout flow", () => {

--- a/frontend/src/lib/components/shared/DateRangeSelector.svelte
+++ b/frontend/src/lib/components/shared/DateRangeSelector.svelte
@@ -81,13 +81,6 @@
       onchange={handleToChange}
     />
   </div>
-
-  {#if busy}
-    <span class="range-busy" aria-live="polite">
-      <span class="range-spinner" aria-hidden="true"></span>
-      Updating
-    </span>
-  {/if}
 </div>
 
 <style>
@@ -158,32 +151,4 @@
     font-size: 11px;
   }
 
-  .range-busy {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    color: var(--accent-blue);
-    font-size: 11px;
-    font-weight: 500;
-    white-space: nowrap;
-  }
-
-  .range-spinner {
-    width: 11px;
-    height: 11px;
-    border-radius: 50%;
-    border: 2px solid color-mix(
-      in srgb,
-      var(--accent-blue) 28%,
-      transparent
-    );
-    border-top-color: var(--accent-blue);
-    animation: spin 0.8s linear infinite;
-  }
-
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
-    }
-  }
 </style>

--- a/frontend/src/lib/components/shared/dateRangeSelector.test.ts
+++ b/frontend/src/lib/components/shared/dateRangeSelector.test.ts
@@ -5,6 +5,7 @@ import {
   isPresetActive,
   presetRange,
 } from "./dateRangeSelector.js";
+import source from "./DateRangeSelector.svelte?raw";
 
 describe("date range selector presets", () => {
   it("builds last-n-days ranges ending today", () => {
@@ -36,5 +37,13 @@ describe("date range selector presets", () => {
 
     expect(isPresetActive("2026-01-25", "2026-04-25", 90, null)).toBe(true);
     expect(isPresetActive("2026-01-26", "2026-04-25", 90, null)).toBe(false);
+  });
+});
+
+describe("DateRangeSelector busy state", () => {
+  it("does not render a separate updating spinner label", () => {
+    expect(source).not.toContain("Updating");
+    expect(source).not.toContain("range-spinner");
+    expect(source).toContain("aria-busy={busy}");
   });
 });

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -332,9 +332,6 @@
         >
           {refreshLabel}
         </span>
-        {#if usage.hasNewData}
-          <span class="new-data">New data</span>
-        {/if}
       </div>
 
     </div>
@@ -443,17 +440,6 @@
     color: var(--text-muted);
     font-size: 11px;
     white-space: nowrap;
-  }
-
-  .new-data {
-    display: inline-flex;
-    align-items: center;
-    min-height: 18px;
-    padding: 0 6px;
-    border-radius: var(--radius-sm);
-    background: var(--bg-surface-hover);
-    color: var(--accent-blue);
-    font-weight: 600;
   }
 
   .usage-content {

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -472,11 +472,12 @@
   }
 
   .query-progress {
-    position: sticky;
+    position: absolute;
     top: 0;
+    left: 0;
+    right: 0;
     z-index: 4;
     height: 2px;
-    margin: -16px -16px 14px;
     overflow: hidden;
     background: color-mix(
       in srgb,

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -23,16 +23,27 @@
   import SessionFilterControl from "../filters/SessionFilterControl.svelte";
   import SessionActiveFilters from "../filters/SessionActiveFilters.svelte";
   import FilterDropdown from "./FilterDropdown.svelte";
+  import { formatRefreshAge } from "../../utils/refresh.js";
   import { RefreshCwIcon } from "../../icons.js";
 
+  const REFRESH_LABEL_INTERVAL_MS = 60 * 1000;
+
   let mounted = false;
+  let refreshLabelTick = $state(Date.now());
+  let refreshLabelTimer:
+    | ReturnType<typeof setTimeout>
+    | undefined;
   let unsubEvents: (() => void) | undefined;
 
-  function formatUpdatedAt(value: number): string {
-    return new Date(value).toLocaleTimeString([], {
-      hour: "numeric",
-      minute: "2-digit",
-    });
+  let refreshLabel = $derived.by(() => {
+    return formatRefreshAge(usage.lastUpdatedAt, refreshLabelTick);
+  });
+
+  function scheduleRefreshLabelTick() {
+    refreshLabelTimer = setTimeout(() => {
+      refreshLabelTick = Date.now();
+      scheduleRefreshLabelTick();
+    }, REFRESH_LABEL_INTERVAL_MS);
   }
 
   const projectItems = $derived(
@@ -244,12 +255,16 @@
   onMount(() => {
     mounted = true;
     unsubEvents = events.subscribe(() => usage.markNewData());
+    scheduleRefreshLabelTick();
     tick().then(() => {
       urlWritebackReady = true;
     });
   });
 
   onDestroy(() => {
+    if (refreshLabelTimer !== undefined) {
+      clearTimeout(refreshLabelTimer);
+    }
     unsubEvents?.();
   });
 </script>
@@ -310,13 +325,13 @@
         <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
       </button>
       <div class="refresh-status" aria-live="polite">
-        {#if usage.lastUpdatedAt !== null}
-          <span title={new Date(usage.lastUpdatedAt).toLocaleString()}>
-            Updated {formatUpdatedAt(usage.lastUpdatedAt)}
-          </span>
-        {:else}
-          <span>Not updated</span>
-        {/if}
+        <span
+          title={usage.lastUpdatedAt === null
+            ? undefined
+            : new Date(usage.lastUpdatedAt).toLocaleString()}
+        >
+          {refreshLabel}
+        </span>
         {#if usage.hasNewData}
           <span class="new-data">New data</span>
         {/if}

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -314,24 +314,26 @@
           usage.deselectAllModels(modelItems.map((m) => m.name))}
       />
 
-      <button
-        class="refresh-btn"
-        class:querying={usage.isQuerying}
-        onclick={() => usage.fetchAll()}
-        disabled={usage.isQuerying}
-        title="Refresh"
-        aria-label="Refresh usage data"
-      >
-        <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
-      </button>
-      <div class="refresh-status" aria-live="polite">
-        <span
-          title={usage.lastUpdatedAt === null
-            ? undefined
-            : new Date(usage.lastUpdatedAt).toLocaleString()}
+      <div class="refresh-control">
+        <button
+          class="refresh-btn"
+          class:querying={usage.isQuerying}
+          onclick={() => usage.fetchAll()}
+          disabled={usage.isQuerying}
+          title="Refresh"
+          aria-label="Refresh usage data"
         >
-          {refreshLabel}
-        </span>
+          <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
+        </button>
+        <div class="refresh-status" aria-live="polite">
+          <span
+            title={usage.lastUpdatedAt === null
+              ? undefined
+              : new Date(usage.lastUpdatedAt).toLocaleString()}
+          >
+            {refreshLabel}
+          </span>
+        </div>
       </div>
 
     </div>
@@ -406,12 +408,20 @@
     align-items: center;
   }
 
+  .refresh-control {
+    min-height: 28px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
   .refresh-btn {
     width: 28px;
     height: 28px;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
+    padding-right: 2px;
     border-radius: var(--radius-sm);
     color: var(--text-muted);
     cursor: pointer;

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -325,7 +325,7 @@
         >
           <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
         </button>
-        <div class="refresh-status" aria-live="polite">
+        <div class="refresh-status">
           <span
             title={usage.lastUpdatedAt === null
               ? undefined

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -412,7 +412,7 @@
     min-height: 28px;
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: 8px;
   }
 
   .refresh-btn {
@@ -420,8 +420,7 @@
     height: 28px;
     display: flex;
     align-items: center;
-    justify-content: flex-end;
-    padding-right: 2px;
+    justify-content: center;
     border-radius: var(--radius-sm);
     color: var(--text-muted);
     cursor: pointer;

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -15,4 +15,15 @@ describe("UsagePage refresh behavior", () => {
     expect(source).toContain("usage.hasNewData");
     expect(source).toContain("New data");
   });
+
+  it("keeps refresh progress out of content layout flow", () => {
+    const queryProgress =
+      source.match(/\.query-progress\s*{[^}]+}/)?.[0] ?? "";
+
+    expect(queryProgress).toContain("position: absolute");
+    expect(queryProgress).toContain("left: 0;");
+    expect(queryProgress).toContain("right: 0;");
+    expect(queryProgress).not.toContain("position: sticky");
+    expect(queryProgress).not.toContain("margin:");
+  });
 });

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -17,6 +17,22 @@ describe("UsagePage refresh behavior", () => {
     expect(source).not.toContain(".new-data");
   });
 
+  it("keeps the refresh timestamp visually attached to the icon", () => {
+    const refreshControl =
+      source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";
+    const refreshButton =
+      source.match(/\.refresh-btn\s*{[^}]+}/)?.[0] ?? "";
+
+    expect(source).toContain('class="refresh-control"');
+    expect(refreshControl).toContain("display: inline-flex");
+    expect(refreshControl).toContain("align-items: center");
+    expect(refreshControl).toContain("gap: 4px");
+    expect(refreshButton).toContain("width: 28px");
+    expect(refreshButton).toContain("justify-content: flex-end");
+    expect(refreshButton).toContain("padding-right: 2px");
+    expect(source).not.toContain(".refresh-btn::before");
+  });
+
   it("keeps refresh progress out of content layout flow", () => {
     const queryProgress =
       source.match(/\.query-progress\s*{[^}]+}/)?.[0] ?? "";

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -7,13 +7,14 @@ describe("UsagePage refresh behavior", () => {
     expect(source).not.toContain("REFRESH_MS");
   });
 
-  it("shows relative last-updated and new-data refresh hints", () => {
+  it("shows relative last-updated refresh status without ambiguous badges", () => {
     expect(source).toContain("usage.lastUpdatedAt");
     expect(source).toContain("REFRESH_LABEL_INTERVAL_MS = 60 * 1000");
     expect(source).toContain("formatRefreshAge");
     expect(source).not.toContain("formatUpdatedAt");
-    expect(source).toContain("usage.hasNewData");
-    expect(source).toContain("New data");
+    expect(source).not.toContain("usage.hasNewData");
+    expect(source).not.toContain("New data");
+    expect(source).not.toContain(".new-data");
   });
 
   it("keeps refresh progress out of content layout flow", () => {

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -17,7 +17,7 @@ describe("UsagePage refresh behavior", () => {
     expect(source).not.toContain(".new-data");
   });
 
-  it("keeps the refresh timestamp visually attached to the icon", () => {
+  it("keeps the refresh timestamp beside the centered icon button", () => {
     const refreshControl =
       source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";
     const refreshButton =
@@ -26,10 +26,10 @@ describe("UsagePage refresh behavior", () => {
     expect(source).toContain('class="refresh-control"');
     expect(refreshControl).toContain("display: inline-flex");
     expect(refreshControl).toContain("align-items: center");
-    expect(refreshControl).toContain("gap: 4px");
+    expect(refreshControl).toContain("gap: 8px");
     expect(refreshButton).toContain("width: 28px");
-    expect(refreshButton).toContain("justify-content: flex-end");
-    expect(refreshButton).toContain("padding-right: 2px");
+    expect(refreshButton).toContain("justify-content: center");
+    expect(refreshButton).not.toContain("padding-right");
     expect(source).not.toContain(".refresh-btn::before");
   });
 

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -2,14 +2,16 @@ import { describe, expect, it } from "vite-plus/test";
 import source from "./UsagePage.svelte?raw";
 
 describe("UsagePage refresh behavior", () => {
-  it("does not auto-refresh usage scans from SSE or a timer", () => {
+  it("does not auto-refresh usage scans from SSE updates", () => {
     expect(source).not.toContain("subscribeDebounced");
-    expect(source).not.toContain("setInterval");
     expect(source).not.toContain("REFRESH_MS");
   });
 
-  it("shows last-updated and new-data refresh hints", () => {
+  it("shows relative last-updated and new-data refresh hints", () => {
     expect(source).toContain("usage.lastUpdatedAt");
+    expect(source).toContain("REFRESH_LABEL_INTERVAL_MS = 60 * 1000");
+    expect(source).toContain("formatRefreshAge");
+    expect(source).not.toContain("formatUpdatedAt");
     expect(source).toContain("usage.hasNewData");
     expect(source).toContain("New data");
   });

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -17,6 +17,12 @@ describe("UsagePage refresh behavior", () => {
     expect(source).not.toContain(".new-data");
   });
 
+  it("does not announce passive refresh-age ticks as live updates", () => {
+    expect(source).not.toContain(
+      'class="refresh-status" aria-live="polite"',
+    );
+  });
+
   it("keeps the refresh timestamp beside the centered icon button", () => {
     const refreshControl =
       source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";

--- a/frontend/src/lib/utils/refresh.test.ts
+++ b/frontend/src/lib/utils/refresh.test.ts
@@ -1,0 +1,75 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import {
+  createRefreshScheduler,
+  formatRefreshAge,
+} from "./refresh.js";
+
+describe("formatRefreshAge", () => {
+  const now = Date.parse("2026-06-16T12:10:00Z");
+
+  it.each([
+    { updatedAt: null, expected: "Not updated" },
+    {
+      updatedAt: Date.parse("2026-06-16T12:09:45Z"),
+      expected: "Updated just now",
+    },
+    {
+      updatedAt: Date.parse("2026-06-16T12:08:00Z"),
+      expected: "Updated 2m ago",
+    },
+    {
+      updatedAt: Date.parse("2026-06-16T10:00:00Z"),
+      expected: "Updated 2h ago",
+    },
+  ])("returns $expected", ({ updatedAt, expected }) => {
+    expect(formatRefreshAge(updatedAt, now)).toBe(expected);
+  });
+});
+
+describe("createRefreshScheduler", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs immediately and then at the configured interval", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const scheduler = createRefreshScheduler(refresh, 300_000);
+
+    scheduler.start();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(299_999);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  it("resets the next automatic refresh after a manual refresh", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const scheduler = createRefreshScheduler(refresh, 300_000);
+
+    scheduler.start();
+    await vi.advanceTimersByTimeAsync(290_000);
+    scheduler.refreshNow();
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(299_999);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(3);
+
+    scheduler.stop();
+  });
+});

--- a/frontend/src/lib/utils/refresh.ts
+++ b/frontend/src/lib/utils/refresh.ts
@@ -1,0 +1,46 @@
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export function formatRefreshAge(
+  updatedAt: number | null | undefined,
+  now = Date.now(),
+): string {
+  if (updatedAt == null) return "Not updated";
+
+  const ageMs = Math.max(0, now - updatedAt);
+  if (ageMs < MINUTE_MS) return "Updated just now";
+  if (ageMs < HOUR_MS) {
+    return `Updated ${Math.floor(ageMs / MINUTE_MS)}m ago`;
+  }
+  if (ageMs < DAY_MS) {
+    return `Updated ${Math.floor(ageMs / HOUR_MS)}h ago`;
+  }
+  return `Updated ${Math.floor(ageMs / DAY_MS)}d ago`;
+}
+
+export function createRefreshScheduler(
+  refresh: () => void | Promise<void>,
+  intervalMs: number,
+) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function stop() {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  }
+
+  function runAndReschedule() {
+    stop();
+    void refresh();
+    timer = setTimeout(runAndReschedule, intervalMs);
+  }
+
+  return {
+    start: runAndReschedule,
+    refreshNow: runAndReschedule,
+    stop,
+  };
+}


### PR DESCRIPTION
This updates the Analytics and Usage refresh affordance so the circular-arrow button remains the only explicit action, with a compact relative "Updated ..." timestamp grouped immediately to its right.

Manual Analytics refreshes now reset the five-minute automatic refresh scheduler, so clicking the arrow does not leave an imminent auto-refresh queued behind it. The old Updating text/spinner and passive New data badge were removed because they competed with the refresh button without adding a clear user action.

While refreshing, the icon still spins and the query progress bar now overlays the content instead of entering layout flow, so a refresh does not temporarily add space below the toolbar.

Reviewers should look at `frontend/src/lib/utils/refresh.ts`, the Analytics and Usage page toolbar markup/styles, and the colocated refresh behavior tests.
