### PR TITLE
fix(db): classify automation from transcripts

### DIFF
--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"slices"
 	"strings"
 	"sync"
@@ -131,4 +132,51 @@ func IsAutomatedSession(firstMessage string) bool {
 	}
 	trimmed := strings.TrimSpace(firstMessage)
 	return slices.Contains(automatedExactMatches, trimmed)
+}
+
+// IsAutomatedTranscript classifies automation from the actual
+// transcript and the stored first_message. The first_message
+// candidate preserves legacy/imported rows whose messages are
+// unavailable or less specific than the parser-owned preview.
+func IsAutomatedTranscript(
+	userMessageCount int,
+	msgs []Message,
+	firstMessage *string,
+) bool {
+	if userMessageCount > 1 {
+		return false
+	}
+	if firstUser, ok := firstUserMessageContent(msgs); ok &&
+		IsAutomatedSession(firstUser) {
+		return true
+	}
+	return firstMessage != nil && IsAutomatedSession(*firstMessage)
+}
+
+func firstUserMessageContent(msgs []Message) (string, bool) {
+	for _, m := range msgs {
+		if m.Role != "user" || m.IsSystem {
+			continue
+		}
+		if strings.TrimSpace(m.Content) == "" {
+			continue
+		}
+		return m.Content, true
+	}
+	return "", false
+}
+
+func isAutomatedFromTextCandidates(
+	userMessageCount int,
+	firstUserMessage, firstMessage sql.NullString,
+) bool {
+	if userMessageCount > 1 {
+		return false
+	}
+	if firstUserMessage.Valid &&
+		strings.TrimSpace(firstUserMessage.String) != "" &&
+		IsAutomatedSession(firstUserMessage.String) {
+		return true
+	}
+	return firstMessage.Valid && IsAutomatedSession(firstMessage.String)
 }

--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -144,6 +144,40 @@ func TestBackfillIsAutomatedRepairsFalseNegativeWithMatchingHash(t *testing.T) {
 		"matching classifier hash must not hide stale is_automated=0")
 }
 
+func TestBackfillIsAutomatedUsesFirstUserMessageWhenFirstMessageIsTitle(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	title := "Generated review title"
+	insertSession(t, d, "title-review", "proj", func(s *Session) {
+		s.FirstMessage = &title
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+	})
+	require.NoError(t, d.ReplaceSessionMessages("title-review", []Message{
+		userMsg("title-review", 0,
+			"You are a code reviewer. Review the code changes shown below."),
+		asstMsg("title-review", 1, "Review complete."),
+	}), "ReplaceSessionMessages")
+	_, err := d.getWriter().Exec(
+		"UPDATE sessions SET is_automated = 0 WHERE id = 'title-review'",
+	)
+	require.NoError(t, err, "force stale is_automated=0")
+
+	d.mu.Lock()
+	err = d.backfillIsAutomatedLocked(d.getWriter())
+	d.mu.Unlock()
+	require.NoError(t, err, "backfill")
+
+	got, err := d.GetSession(ctx, "title-review")
+	require.NoError(t, err, "get title-review")
+	require.NotNil(t, got, "title-review")
+	assert.True(t, got.IsAutomated,
+		"backfill should classify automation from the first stored user message")
+}
+
 func TestOpenRepairsAutomatedFalseNegativeWithMatchingHash(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.db")
 	d, err := Open(path)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -923,9 +923,22 @@ func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
 	}
 
 	rows, err := w.Query(
-		`SELECT id, first_message, user_message_count,
-			is_automated
-		 FROM sessions`,
+		`SELECT
+			s.id,
+			s.first_message,
+			s.user_message_count,
+			s.is_automated,
+			(
+				SELECT m.content
+				FROM messages m
+				WHERE m.session_id = s.id
+				  AND m.role = 'user'
+				  AND m.is_system = 0
+				  AND TRIM(m.content) <> ''
+				ORDER BY m.ordinal
+				LIMIT 1
+			) AS first_user_message
+		 FROM sessions s`,
 	)
 	if err != nil {
 		return fmt.Errorf(
@@ -938,19 +951,19 @@ func (db *DB) backfillIsAutomatedLocked(w *sql.DB) error {
 	for rows.Next() {
 		var id string
 		var fm sql.NullString
+		var firstUser sql.NullString
 		var umc int
 		var rowAutomated bool
 		if err := rows.Scan(
-			&id, &fm, &umc, &rowAutomated,
+			&id, &fm, &umc, &rowAutomated, &firstUser,
 		); err != nil {
 			return fmt.Errorf(
 				"scanning backfill candidate: %w", err,
 			)
 		}
-		want := false
-		if fm.Valid {
-			want = umc <= 1 && IsAutomatedSession(fm.String)
-		}
+		want := isAutomatedFromTextCandidates(
+			umc, firstUser, fm,
+		)
 		if want && !rowAutomated {
 			setIDs = append(setIDs, id)
 		} else if !want && rowAutomated {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1165,6 +1165,40 @@ func TestReplaceSessionMessages(t *testing.T) {
 	assert.Equal(t, "new1", got[0].Content, "content")
 }
 
+func TestReplaceSessionMessagesClassifiesAutomationFromUserTranscript(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	title := "Generated review title"
+	insertSession(t, d, "review-title", "p", func(s *Session) {
+		s.FirstMessage = &title
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+	})
+
+	require.NoError(t, d.ReplaceSessionMessages("review-title", []Message{
+		userMsg("review-title", 0,
+			"You are a code reviewer. Review the code changes shown below."),
+		asstMsg("review-title", 1, "Review complete."),
+	}), "ReplaceSessionMessages")
+
+	got, err := d.GetSession(ctx, "review-title")
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, got, "review-title session")
+	assert.True(t, got.IsAutomated,
+		"automation should be classified from the first stored user message")
+
+	page, err := d.ListSessions(ctx, SessionFilter{
+		ExcludeAutomated: true,
+		Limit:            10,
+	})
+	require.NoError(t, err, "ListSessions")
+	assert.Empty(t, page.Sessions,
+		"automated transcript should be excluded even when first_message is a title")
+}
+
 // TestReplaceSessionMessagesPreservesPins verifies that pinned
 // messages survive a full message replacement (regression test for
 // the ON DELETE CASCADE bug: deleting messages used to cascade-delete

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1191,6 +1191,41 @@ func TestInsertMessagesClassifiesAutomationFromUserTranscript(
 		"automation should be classified from the first inserted user message")
 }
 
+func TestUpsertSessionPreservesTranscriptAutomation(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	title := "Generated review title"
+	insertSession(t, d, "upsert-review-title", "p", func(s *Session) {
+		s.FirstMessage = &title
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+	})
+
+	require.NoError(t, d.InsertMessages([]Message{
+		userMsg("upsert-review-title", 0,
+			"You are a code reviewer. Review the code changes shown below."),
+		asstMsg("upsert-review-title", 1, "Review complete."),
+	}), "InsertMessages")
+
+	require.NoError(t, d.UpsertSession(Session{
+		ID:               "upsert-review-title",
+		Project:          "p",
+		Machine:          defaultMachine,
+		Agent:            defaultAgent,
+		FirstMessage:     &title,
+		MessageCount:     2,
+		UserMessageCount: 1,
+		IsAutomated:      true,
+	}), "UpsertSession")
+
+	got, err := d.GetSession(ctx, "upsert-review-title")
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, got, "upsert-review-title session")
+	assert.True(t, got.IsAutomated,
+		"upsert should persist the transcript-derived automation flag")
+}
+
 func TestReplaceSessionMessagesClassifiesAutomationFromUserTranscript(
 	t *testing.T,
 ) {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1165,6 +1165,32 @@ func TestReplaceSessionMessages(t *testing.T) {
 	assert.Equal(t, "new1", got[0].Content, "content")
 }
 
+func TestInsertMessagesClassifiesAutomationFromUserTranscript(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	title := "Generated review title"
+	insertSession(t, d, "insert-review-title", "p", func(s *Session) {
+		s.FirstMessage = &title
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+	})
+
+	require.NoError(t, d.InsertMessages([]Message{
+		userMsg("insert-review-title", 0,
+			"You are a code reviewer. Review the code changes shown below."),
+		asstMsg("insert-review-title", 1, "Review complete."),
+	}), "InsertMessages")
+
+	got, err := d.GetSession(ctx, "insert-review-title")
+	require.NoError(t, err, "GetSession")
+	require.NotNil(t, got, "insert-review-title session")
+	assert.True(t, got.IsAutomated,
+		"automation should be classified from the first inserted user message")
+}
+
 func TestReplaceSessionMessagesClassifiesAutomationFromUserTranscript(
 	t *testing.T,
 ) {

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -504,6 +505,9 @@ func (db *DB) ReplaceSessionMessages(
 	if err := replaceSessionMessagesTx(tx, sessionID, msgs); err != nil {
 		return err
 	}
+	if err := updateSessionAutomationFromMessagesTx(tx, sessionID); err != nil {
+		return err
+	}
 	// The new messages invalidate any findings scanned from the old content, so
 	// clear them and reset the scan state (empty version => secrets scan
 	// --backfill re-scans). ReplaceSessionContent does not call this method; it
@@ -626,6 +630,9 @@ func (db *DB) ReplaceSessionContent(
 	if err := replaceSessionMessagesTx(tx, sessionID, msgs); err != nil {
 		return err
 	}
+	if err := updateSessionAutomationFromMessagesTx(tx, sessionID); err != nil {
+		return err
+	}
 	if err := updateSessionSignalsTx(tx, sessionID, signals); err != nil {
 		return err
 	}
@@ -637,6 +644,68 @@ func (db *DB) ReplaceSessionContent(
 		return err
 	}
 	return tx.Commit()
+}
+
+func updateSessionAutomationFromMessagesTx(
+	tx *sql.Tx, sessionID string,
+) error {
+	var (
+		firstMessage     sql.NullString
+		firstUserMessage sql.NullString
+		userMsgCount     int
+		rowAutomated     bool
+	)
+	err := tx.QueryRow(`
+		SELECT
+			s.first_message,
+			s.user_message_count,
+			s.is_automated,
+			(
+				SELECT m.content
+				FROM messages m
+				WHERE m.session_id = s.id
+				  AND m.role = 'user'
+				  AND m.is_system = 0
+				  AND TRIM(m.content) <> ''
+				ORDER BY m.ordinal
+				LIMIT 1
+			) AS first_user_message
+		FROM sessions s
+		WHERE s.id = ?`,
+		sessionID,
+	).Scan(
+		&firstMessage, &userMsgCount,
+		&rowAutomated, &firstUserMessage,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf(
+			"reading automation candidate for %s: %w",
+			sessionID, err,
+		)
+	}
+
+	want := isAutomatedFromTextCandidates(
+		userMsgCount, firstUserMessage, firstMessage,
+	)
+	if want == rowAutomated {
+		return nil
+	}
+	if _, err := tx.Exec(`
+		UPDATE sessions
+		   SET is_automated = ?,
+		       local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		 WHERE id = ?`,
+		want, sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"updating is_automated from messages for %s: %w",
+			sessionID, err,
+		)
+	}
+	return nil
 }
 
 func savePinsTx(tx *sql.Tx, sessionID string) ([]savedPin, error) {

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -421,7 +421,30 @@ func (db *DB) InsertMessages(msgs []Message) error {
 	if err := insertToolResultEventsTx(tx, events); err != nil {
 		return err
 	}
+	for _, sessionID := range messageSessionIDs(msgs) {
+		if err := setSessionAutomationFromMessagesTx(
+			tx, sessionID,
+		); err != nil {
+			return err
+		}
+	}
 	return tx.Commit()
+}
+
+func messageSessionIDs(msgs []Message) []string {
+	seen := make(map[string]struct{})
+	ids := make([]string, 0, 1)
+	for _, m := range msgs {
+		if m.SessionID == "" {
+			continue
+		}
+		if _, ok := seen[m.SessionID]; ok {
+			continue
+		}
+		seen[m.SessionID] = struct{}{}
+		ids = append(ids, m.SessionID)
+	}
+	return ids
 }
 
 // MaxOrdinal returns the highest ordinal for a session,
@@ -649,13 +672,39 @@ func (db *DB) ReplaceSessionContent(
 func updateSessionAutomationFromMessagesTx(
 	tx *sql.Tx, sessionID string,
 ) error {
+	want, rowAutomated, ok, err := sessionAutomationStateTx(
+		tx, sessionID,
+	)
+	if err != nil || !ok {
+		return err
+	}
+	if want == rowAutomated {
+		return nil
+	}
+	return setSessionAutomationTx(tx, sessionID, want)
+}
+
+func setSessionAutomationFromMessagesTx(
+	tx *sql.Tx, sessionID string,
+) error {
+	want, rowAutomated, ok, err := sessionAutomationStateTx(
+		tx, sessionID,
+	)
+	if err != nil || !ok || !want || rowAutomated {
+		return err
+	}
+	return setSessionAutomationTx(tx, sessionID, true)
+}
+
+func sessionAutomationStateTx(
+	tx *sql.Tx, sessionID string,
+) (want, rowAutomated, ok bool, err error) {
 	var (
 		firstMessage     sql.NullString
 		firstUserMessage sql.NullString
 		userMsgCount     int
-		rowAutomated     bool
 	)
-	err := tx.QueryRow(`
+	err = tx.QueryRow(`
 		SELECT
 			s.first_message,
 			s.user_message_count,
@@ -678,27 +727,30 @@ func updateSessionAutomationFromMessagesTx(
 		&rowAutomated, &firstUserMessage,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil
+		return false, false, false, nil
 	}
 	if err != nil {
-		return fmt.Errorf(
+		return false, false, false, fmt.Errorf(
 			"reading automation candidate for %s: %w",
 			sessionID, err,
 		)
 	}
 
-	want := isAutomatedFromTextCandidates(
+	want = isAutomatedFromTextCandidates(
 		userMsgCount, firstUserMessage, firstMessage,
 	)
-	if want == rowAutomated {
-		return nil
-	}
+	return want, rowAutomated, true, nil
+}
+
+func setSessionAutomationTx(
+	tx *sql.Tx, sessionID string, isAutomated bool,
+) error {
 	if _, err := tx.Exec(`
 		UPDATE sessions
 		   SET is_automated = ?,
 		       local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
 		 WHERE id = ?`,
-		want, sessionID,
+		isAutomated, sessionID,
 	); err != nil {
 		return fmt.Errorf(
 			"updating is_automated from messages for %s: %w",

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -256,6 +256,11 @@ func writeOneSessionBatchTx(
 			return 0, err
 		}
 	}
+	if err := updateSessionAutomationFromMessagesTx(
+		tx, write.Session.ID,
+	); err != nil {
+		return 0, err
+	}
 
 	if write.DataVersion > 0 {
 		if _, err := tx.Exec(

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1430,10 +1430,11 @@ func (db *DB) GetSessionForIncremental(
 // aggregates. All values are absolute (not deltas) so the
 // update is idempotent on retry.
 //
-// is_automated is recomputed from the current first_message and
-// the new user_message_count so that classifier additions reach
-// rows that only ever take the incremental path. Without this,
-// a row whose first parse predates a new pattern would stay
+// is_automated is recomputed from the stored transcript's first
+// user message (falling back to first_message for legacy rows)
+// and the new user_message_count so that classifier additions
+// reach rows that only ever take the incremental path. Without
+// this, a row whose first parse predates a new pattern would stay
 // is_automated=0 indefinitely (UpsertSession sets the flag once
 // at insert; the incremental path never re-evaluates it).
 //
@@ -1458,29 +1459,17 @@ func (db *DB) UpdateSessionIncremental(
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	isAutomated := false
-	if userMsgCount <= 1 {
-		var fm sql.NullString
-		err := db.getReader().QueryRow(
-			"SELECT first_message FROM sessions WHERE id = ?", id,
-		).Scan(&fm)
-		if err != nil && err != sql.ErrNoRows {
-			return fmt.Errorf(
-				"reading first_message for incremental update %s: %w",
-				id, err,
-			)
-		}
-		if fm.Valid {
-			isAutomated = IsAutomatedSession(fm.String)
-		}
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return fmt.Errorf("beginning incremental update tx: %w", err)
 	}
+	defer func() { _ = tx.Rollback() }()
 
-	_, err := db.getWriter().Exec(`
+	_, err = tx.Exec(`
 		UPDATE sessions SET
 			ended_at = COALESCE(?, ended_at),
 			message_count = ?,
 			user_message_count = ?,
-			is_automated = ?,
 			file_size = ?,
 			file_mtime = ?,
 			total_output_tokens = ?,
@@ -1489,7 +1478,7 @@ func (db *DB) UpdateSessionIncremental(
 			has_peak_context_tokens = ?,
 			termination_status = NULL
 		WHERE id = ?`,
-		endedAt, msgCount, userMsgCount, isAutomated,
+		endedAt, msgCount, userMsgCount,
 		fileSize, fileMtime,
 		totalOutputTokens, peakContextTokens,
 		hasTotalOutputTokens, hasPeakContextTokens, id,
@@ -1498,6 +1487,12 @@ func (db *DB) UpdateSessionIncremental(
 		return fmt.Errorf(
 			"incremental update session %s: %w", id, err,
 		)
+	}
+	if err := updateSessionAutomationFromMessagesTx(tx, id); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing incremental update tx: %w", err)
 	}
 	return nil
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1001,9 +1001,10 @@ const upsertSessionSQL = `
 			file_hash = excluded.file_hash`
 
 func sessionIsAutomated(s Session) bool {
-	return s.UserMessageCount <= 1 &&
-		s.FirstMessage != nil &&
-		IsAutomatedSession(*s.FirstMessage)
+	return s.IsAutomated ||
+		(s.UserMessageCount <= 1 &&
+			s.FirstMessage != nil &&
+			IsAutomatedSession(*s.FirstMessage))
 }
 
 func upsertSessionArgs(s Session) []any {

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -766,9 +766,22 @@ func backfillIsAutomatedPG(
 	}
 
 	rows, err := pg.QueryContext(ctx,
-		`SELECT id, first_message, user_message_count,
-			is_automated
-		 FROM sessions`)
+		`SELECT
+			s.id,
+			s.first_message,
+			s.user_message_count,
+			s.is_automated,
+			(
+				SELECT m.content
+				FROM messages m
+				WHERE m.session_id = s.id
+				  AND m.role = 'user'
+				  AND COALESCE(m.is_system, false) = false
+				  AND btrim(m.content) <> ''
+				ORDER BY m.ordinal
+				LIMIT 1
+			) AS first_user_message
+		 FROM sessions s`)
 	if err != nil {
 		return fmt.Errorf(
 			"querying PG automated backfill candidates: %w",
@@ -781,18 +794,25 @@ func backfillIsAutomatedPG(
 	for rows.Next() {
 		var id string
 		var fm sql.NullString
+		var firstUser sql.NullString
 		var umc int
 		var rowAutomated bool
 		if err := rows.Scan(
-			&id, &fm, &umc, &rowAutomated,
+			&id, &fm, &umc, &rowAutomated, &firstUser,
 		); err != nil {
 			return fmt.Errorf(
 				"scanning PG backfill candidate: %w", err,
 			)
 		}
 		want := false
-		if fm.Valid {
-			want = umc <= 1 && db.IsAutomatedSession(fm.String)
+		if umc <= 1 {
+			if firstUser.Valid &&
+				strings.TrimSpace(firstUser.String) != "" {
+				want = db.IsAutomatedSession(firstUser.String)
+			}
+			if !want && fm.Valid {
+				want = db.IsAutomatedSession(fm.String)
+			}
 		}
 		if want && !rowAutomated {
 			setIDs = append(setIDs, id)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5438,17 +5438,6 @@ func (e *Engine) recomputeSignalsFromDB(
 	return nil
 }
 
-// isAutomatedFromSession recomputes the is_automated flag using
-// the same rule UpsertSession applies. Hoisted out of UpsertSession
-// so callers can set the field on their in-memory Session before
-// running signal computation, ensuring the same value is used by
-// outcome classification and persisted to the row.
-func isAutomatedFromSession(s db.Session) bool {
-	return s.UserMessageCount <= 1 &&
-		s.FirstMessage != nil &&
-		db.IsAutomatedSession(*s.FirstMessage)
-}
-
 type pendingWrite struct {
 	sess         parser.ParsedSession
 	msgs         []parser.ParsedMessage
@@ -5637,7 +5626,9 @@ func (e *Engine) prepareSessionWrite(
 			s.Project = mapped
 		}
 	}
-	s.IsAutomated = isAutomatedFromSession(s)
+	s.IsAutomated = db.IsAutomatedTranscript(
+		s.UserMessageCount, msgs, s.FirstMessage,
+	)
 
 	if e.shouldPreserveOpenCodeFormatArchive(
 		pw.sess.Agent, pw.sess.File.Path, s.ID,

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2850,6 +2850,55 @@ func TestSyncEngineOpenCodeBulkSync(t *testing.T) {
 	)
 }
 
+func TestSyncEngineOpenCodeReviewWithGeneratedTitleIsAutomated(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj-1", "/home/user/code/myapp")
+
+	sessionID := "oc-review-title"
+	timeCreated := int64(1704067200000)
+	timeUpdated := int64(1704067205000)
+	oc.mustExec(t, "insert titled session",
+		`INSERT INTO session
+			(id, project_id, title, time_created, time_updated)
+		 VALUES (?, ?, ?, ?, ?)`,
+		sessionID, "proj-1", "Review generated title",
+		timeCreated, timeUpdated,
+	)
+	oc.addMessage(t, "msg-u1", sessionID, "user", timeCreated)
+	oc.addMessage(t, "msg-a1", sessionID, "assistant", timeCreated+1)
+	oc.addTextPart(
+		t, "part-u1", sessionID, "msg-u1",
+		"You are a code reviewer. Review the code changes shown below.",
+		timeCreated,
+	)
+	oc.addTextPart(
+		t, "part-a1", sessionID, "msg-a1",
+		"Review complete.", timeCreated+1,
+	)
+
+	env.engine.SyncAll(context.Background(), nil)
+
+	agentviewID := "opencode:" + sessionID
+	assertSessionState(t, env.db, agentviewID,
+		func(sess *db.Session) {
+			assert.True(t, sess.IsAutomated,
+				"OpenCode review sessions with generated titles must still be classified as automated")
+		},
+	)
+
+	page, err := env.db.ListSessions(
+		context.Background(),
+		db.SessionFilter{ExcludeAutomated: true, Limit: 10},
+	)
+	require.NoError(t, err, "ListSessions exclude automated")
+	assert.Empty(t, page.Sessions,
+		"automated OpenCode review should be excluded")
+}
+
 func TestSyncEngineOpenCodeStorageBulkSync(t *testing.T) {
 	env := setupTestEnv(t)
 	oc := createOpenCodeStorageFixture(t, env.opencodeDir)


### PR DESCRIPTION
Automated session filtering now classifies single-turn automation from the first stored non-system user transcript message as well as the legacy `first_message` preview. This fixes review sessions whose parser-supplied preview can be a generated title instead of the actual automated review prompt, which made them appear when automated sessions were excluded.

The change is intentionally in the shared SQLite/sync path rather than in an OpenCode-specific parser rule. Transcript-based classification runs after message replacement, full content replacement, batch sync writes, incremental metadata updates, classifier backfills, and message inserts; session upserts also preserve a parser-computed automation flag so metadata-only syncs cannot clobber a transcript-derived classification. PostgreSQL backfill uses the same candidate order so pushed/shared stores repair the same stale rows.

`first_message` remains a compatibility candidate for imported or incomplete rows where the transcript is unavailable or less specific than the parser-owned preview. Reviewers should start with `internal/db/automated.go`, `internal/db/messages.go`, `internal/db/sessions.go`, `internal/db/db.go`, and `internal/sync/engine.go`; the OpenCode regression is covered in `internal/sync/engine_integration_test.go`.
