### PR TITLE
docs: add GitHub issue forms for bug reports, agent support, and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_support.yml
+++ b/.github/ISSUE_TEMPLATE/agent_support.yml
@@ -1,0 +1,48 @@
+name: New agent support
+description: Request support for a coding agent agentsview does not parse yet
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues first; support for many agents is already
+        requested or in progress.
+
+        A real (redacted) session file is by far the most useful thing you can
+        provide. It lets a parser be written against actual data instead of a
+        guessed file format.
+  - type: input
+    id: agent-name
+    attributes:
+      label: Agent name and link
+      placeholder: "Kimi Code - https://github.com/MoonshotAI/kimi-code"
+    validations:
+      required: true
+  - type: textarea
+    id: storage
+    attributes:
+      label: Where does it store sessions?
+      description: Directory path(s), per OS if they differ
+      placeholder: "~/.kimi-code/sessions/"
+    validations:
+      required: true
+  - type: textarea
+    id: format
+    attributes:
+      label: File format
+      description: One file per session or many? JSON / JSONL / nested directories? Anything notable about the layout.
+  - type: textarea
+    id: sample
+    attributes:
+      label: Sample session file
+      description: >
+        Attach a real session file with secrets and private data removed. This
+        is the most valuable part of the request.
+      render: text
+  - type: checkboxes
+    id: help
+    attributes:
+      label: Can you help?
+      options:
+        - label: I can share a sample session file
+        - label: I use this agent and can test a PR or build a parser

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Something is parsed, rendered, counted, installed, or updated incorrectly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please search existing issues first.
+
+        For a wrong-render, wrong-count, or wrong-parse bug, the single most
+        useful thing you can give us is a small session file that reproduces it.
+        Session files can contain secrets and proprietary code, so redact before
+        sharing.
+  - type: input
+    id: version
+    attributes:
+      label: agentsview version
+      description: "Output of `agentsview version`"
+      placeholder: "agentsview v0.32.1 (commit 1964e4f8, built 2026-06-05T19:05:47Z)"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: Install method
+      options:
+        - Homebrew cask
+        - install.sh / install.ps1
+        - GitHub release binary
+        - Docker image
+        - go install
+        - Built from source
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / platform
+      placeholder: "macOS 26.5 (arm64) / Windows 11 / Fedora 44"
+    validations:
+      required: true
+  - type: input
+    id: agent
+    attributes:
+      label: Which agent(s) and version
+      description: The coding agent whose sessions are affected, plus its version, if relevant
+      placeholder: "OpenClaw 0.x.y"
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened, and what did you expect
+      placeholder: "Tool-call messages do not render; only user/assistant turns show. Expected the tool call and its result to appear."
+    validations:
+      required: true
+  - type: textarea
+    id: session-file
+    attributes:
+      label: Sample session file or snippet
+      description: >
+        For parse/render/usage bugs: attach a small session file that reproduces
+        the problem, or paste the relevant entry (for example the raw tool-call
+        object). Remove secrets and private data first.
+      render: text
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        Include exact CLI commands where relevant.
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues
+          required: true
+        - label: I removed secrets and private data from any attached session files
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,9 +43,19 @@ body:
   - type: input
     id: agent
     attributes:
-      label: Which agent(s) and version
-      description: The coding agent whose sessions are affected, plus its version, if relevant
+      label: Which agent and version
+      description: The coding agent whose sessions are affected, plus its version. Write "n/a" for bugs unrelated to a specific agent (install, updater, UI).
       placeholder: "OpenClaw 0.x.y"
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Which model(s)
+      description: The model(s) behind the affected session, with provider if relevant. Write "n/a" if not applicable.
+      placeholder: "claude-opus-4-8 / gpt-5 / gemini-3-pro"
+    validations:
+      required: true
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+# Route every new issue through one of the templates above. If GitHub
+# Discussions is enabled for this repo, add a contact_links entry pointing
+# usage/"how do I" questions there instead of the issue tracker.
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Suggest a new feature or an improvement to an existing one
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues first. To request support for a new coding
+        agent, use the "New agent support" template instead.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what makes it hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like agentsview to do?
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you have tried or thought about.


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/` with three issue forms and a config. The repo
currently has no templates, so reports often arrive missing the context a
maintainer needs to act on them.

The fields are derived from what recurring issues actually lacked:

- **Version** is the single most-chased detail (for example #575 opens with
  "which version were you on?"). The bug form requires `agentsview version`
  output up front, alongside install method and OS.
- **Parse / render / usage bugs** are only actionable with the underlying
  session data. The reports that got fixed quickly carried a sample file or the
  raw entry (#504, #515, #639, #646); the recent #703 ("no tool call message
  render") is a plausible bug that stalled for lack of one. The bug form asks
  for a sanitized sample session file or snippet, with a checkbox reminding
  filers to strip secrets.
- **New-agent requests** live or die on where the sessions live and what they
  look like. The useful ones named the storage path (#685); the thin ones drew
  "ask the agent to make a PR so it can look at real data" (#617). The agent
  form requires the storage path and asks for a real sample file.

`config.yml` sets `blank_issues_enabled: false` so every new issue routes
through a form. The Discussions contact link is intentionally omitted because
Discussions is not enabled on this repo; a comment notes how to add it if that
changes.

Where to look: the three `.yml` field sets. No application code is touched.