### PR TITLE
Show display names in "Top sessions" section

### DIFF
--- a/frontend/src/lib/api/generated/models/DbTopSession.ts
+++ b/frontend/src/lib/api/generated/models/DbTopSession.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 export type DbTopSession = {
   duration_min: number;
+  display_name?: string;
   ended_at?: string;
   first_message: string | null;
   id: string;

--- a/frontend/src/lib/api/types/analytics.ts
+++ b/frontend/src/lib/api/types/analytics.ts
@@ -134,6 +134,7 @@ export interface TopSession {
   id: string;
   project: string;
   first_message: string | null;
+  display_name?: string | null;
   message_count: number;
   output_tokens: number;
   duration_min: number;

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -14,6 +14,18 @@
     return text.slice(0, max - 1) + "\u2026";
   }
 
+  function sessionLabel(session: {
+    id: string;
+    first_message: string | null;
+    display_name?: string | null;
+  }): string {
+    return (
+      session.display_name ||
+      normalizeMessagePreview(session.first_message) ||
+      session.id.slice(0, 12)
+    );
+  }
+
   function formatDuration(mins: number): string {
     const total = Math.round(mins);
     if (total < 60) return `${total}m`;
@@ -104,7 +116,7 @@
   {:else if analytics.topSessions && analytics.topSessions.sessions.length > 0}
     <div class="session-list">
       {#each analytics.topSessions.sessions as session, i}
-        {@const preview = normalizeMessagePreview(session.first_message)}
+        {@const label = sessionLabel(session)}
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
@@ -117,9 +129,7 @@
           </span>
           <div class="session-info">
             <span class="session-label">
-              {preview
-                ? truncate(preview, 50)
-                : session.id.slice(0, 12)}
+              {truncate(label, 50)}
             </span>
             <span class="session-project">{session.project}</span>
           </div>

--- a/frontend/src/lib/components/analytics/TopSessions.test.ts
+++ b/frontend/src/lib/components/analytics/TopSessions.test.ts
@@ -135,6 +135,42 @@ describe("TopSessions", () => {
     unmount(component);
   });
 
+  it("renders display names before first-message previews", async () => {
+    analytics.topSessions = {
+      metric: "messages",
+      sessions: [
+        {
+          id: "sess-1",
+          project: "proj",
+          first_message: "raw first message",
+          display_name: "Renamed sidebar title",
+          message_count: 10,
+          output_tokens: 0,
+          duration_min: 5,
+        },
+      ],
+    };
+    // @ts-ignore — loading is reactive state
+    analytics.loading = {
+      ...analytics.loading,
+      topSessions: false,
+    };
+    // @ts-ignore
+    analytics.errors = {
+      ...analytics.errors,
+      topSessions: null,
+    };
+
+    const component = mount(TopSessions, { target: document.body });
+    await tick();
+
+    expect(
+      document.querySelector(".session-label")?.textContent?.trim(),
+    ).toBe("Renamed sidebar title");
+
+    unmount(component);
+  });
+
   describe("status column", () => {
     function mountWithFourStates() {
       analytics.topSessions = {

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -3272,6 +3272,7 @@ type TopSession struct {
 	ID           string  `json:"id"`
 	Project      string  `json:"project"`
 	FirstMessage *string `json:"first_message"`
+	DisplayName  *string `json:"display_name,omitempty"`
 	MessageCount int     `json:"message_count"`
 	OutputTokens int     `json:"output_tokens"`
 	DurationMin  float64 `json:"duration_min"`
@@ -3323,8 +3324,9 @@ func (db *DB) GetAnalyticsTopSessions(
 		orderExpr = "message_count DESC, id ASC"
 	}
 
-	query := `SELECT id, project, first_message, message_count,
-		total_output_tokens, ` + durationSelectExpr + `,
+	query := `SELECT id, project, first_message,
+		COALESCE(display_name, session_name) AS display_name,
+		message_count, total_output_tokens, ` + durationSelectExpr + `,
 		started_at, ended_at, termination_status
 		FROM sessions WHERE ` + where +
 		` ORDER BY ` + orderExpr + ` LIMIT 10`
@@ -3341,8 +3343,9 @@ func (db *DB) GetAnalyticsTopSessions(
 		var row TopSession
 		if err := rows.Scan(
 			&row.ID, &row.Project, &row.FirstMessage,
-			&row.MessageCount, &row.OutputTokens,
-			&row.DurationMin, &row.StartedAt, &row.EndedAt,
+			&row.DisplayName, &row.MessageCount,
+			&row.OutputTokens, &row.DurationMin,
+			&row.StartedAt, &row.EndedAt,
 			&row.TerminationStatus,
 		); err != nil {
 			return TopSessionsResponse{},
@@ -3389,9 +3392,10 @@ func (db *DB) getAnalyticsTopSessionsGo(
 	}
 
 	query := `SELECT id, ` + dateCol + `, project,
-		first_message, message_count,
-		total_output_tokens, started_at, ended_at,
-		termination_status
+		first_message,
+		COALESCE(display_name, session_name) AS display_name,
+		message_count, total_output_tokens,
+		started_at, ended_at, termination_status
 		FROM sessions WHERE ` + where +
 		` ORDER BY ` + orderExpr + ` LIMIT 200`
 
@@ -3405,12 +3409,13 @@ func (db *DB) getAnalyticsTopSessionsGo(
 	var sessions []TopSession
 	for rows.Next() {
 		var id, ts, project string
-		var firstMsg, startedAt, endedAt, termStatus *string
+		var firstMsg, displayName, startedAt, endedAt *string
+		var termStatus *string
 		var mc, outputTokens int
 		if err := rows.Scan(
 			&id, &ts, &project, &firstMsg,
-			&mc, &outputTokens, &startedAt, &endedAt,
-			&termStatus,
+			&displayName, &mc, &outputTokens,
+			&startedAt, &endedAt, &termStatus,
 		); err != nil {
 			return TopSessionsResponse{},
 				fmt.Errorf("scanning top session: %w", err)
@@ -3435,6 +3440,7 @@ func (db *DB) getAnalyticsTopSessionsGo(
 			ID:                id,
 			Project:           project,
 			FirstMessage:      firstMsg,
+			DisplayName:       displayName,
 			MessageCount:      mc,
 			OutputTokens:      outputTokens,
 			DurationMin:       durMin,

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1624,6 +1624,57 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 	})
 }
 
+func TestGetAnalyticsTopSessionsDisplayName(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	rawFirst := "raw first user message"
+	sessionName := "Agent generated title"
+	insertSession(t, d, "session-name", "project-alpha", func(s *Session) {
+		s.FirstMessage = &rawFirst
+		s.SessionName = &sessionName
+		s.StartedAt = new("2024-06-01T09:00:00Z")
+		s.EndedAt = new("2024-06-01T10:00:00Z")
+		s.MessageCount = 10
+		s.UserMessageCount = 2
+	})
+
+	customName := "User renamed title"
+	customSessionName := "Generated title hidden by rename"
+	insertSession(t, d, "custom-name", "project-alpha", func(s *Session) {
+		s.FirstMessage = &rawFirst
+		s.SessionName = &customSessionName
+		s.StartedAt = new("2024-06-01T11:00:00Z")
+		s.EndedAt = new("2024-06-01T12:00:00Z")
+		s.MessageCount = 9
+		s.UserMessageCount = 2
+	})
+	require.NoError(t, d.RenameSession("custom-name", &customName),
+		"RenameSession")
+
+	resp, err := d.GetAnalyticsTopSessions(
+		ctx, baseFilter(), "messages",
+	)
+	require.NoError(t, err, "GetAnalyticsTopSessions")
+
+	byID := map[string]TopSession{}
+	for _, session := range resp.Sessions {
+		byID[session.ID] = session
+	}
+
+	named, ok := byID["session-name"]
+	require.True(t, ok, "session-name missing from top sessions")
+	require.NotNil(t, named.DisplayName,
+		"session_name should be exposed as display_name")
+	assert.Equal(t, sessionName, *named.DisplayName)
+
+	custom, ok := byID["custom-name"]
+	require.True(t, ok, "custom-name missing from top sessions")
+	require.NotNil(t, custom.DisplayName,
+		"custom display_name should be exposed")
+	assert.Equal(t, customName, *custom.DisplayName)
+}
+
 func TestBuildWhereProjectFilter(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2195,8 +2195,9 @@ func (s *Store) GetAnalyticsTopSessions(
 		limitClause = ""
 	}
 	query := `SELECT id, ` + pgDateCol + `, project,
-		first_message, message_count,
-		total_output_tokens,
+		first_message,
+		COALESCE(display_name, session_name) AS display_name,
+		message_count, total_output_tokens,
 		EXTRACT(EPOCH FROM ended_at - started_at)
 			AS duration_sec,
 		started_at, ended_at,
@@ -2220,13 +2221,13 @@ func (s *Store) GetAnalyticsTopSessions(
 		var id, project string
 		var ts *time.Time
 		var startedAt, endedAt *time.Time
-		var firstMsg, termStatus *string
+		var firstMsg, displayName, termStatus *string
 		var mc, outputTokens int
 		var durationSec *float64
 		if err := rows.Scan(
 			&id, &ts, &project, &firstMsg,
-			&mc, &outputTokens, &durationSec,
-			&startedAt, &endedAt,
+			&displayName, &mc, &outputTokens,
+			&durationSec, &startedAt, &endedAt,
 			&termStatus,
 		); err != nil {
 			return db.TopSessionsResponse{},
@@ -2260,6 +2261,7 @@ func (s *Store) GetAnalyticsTopSessions(
 			ID:                id,
 			Project:           project,
 			FirstMessage:      firstMsg,
+			DisplayName:       displayName,
 			MessageCount:      mc,
 			OutputTokens:      outputTokens,
 			DurationMin:       durMin,

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -1019,6 +1019,64 @@ func TestStoreAnalyticsTopSessionsOutputTokens(
 	}
 }
 
+func TestStoreAnalyticsTopSessionsDisplayName(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, first_message,
+			display_name, session_name,
+			started_at, ended_at, message_count,
+			user_message_count
+		) VALUES
+			('pg-session-name', 'test-machine', 'test-project',
+			 'claude', 'raw first user message', NULL,
+			 'Agent generated title',
+			 '2026-03-12T11:00:00Z'::timestamptz,
+			 '2026-03-12T11:30:00Z'::timestamptz,
+			 10, 2),
+			('pg-custom-name', 'test-machine', 'test-project',
+			 'claude', 'raw first user message',
+			 'User renamed title', 'Generated title hidden by rename',
+			 '2026-03-12T12:00:00Z'::timestamptz,
+			 '2026-03-12T12:30:00Z'::timestamptz,
+			 9, 2)
+	`)
+	require.NoError(t, err, "inserting top session names")
+
+	top, err := store.GetAnalyticsTopSessions(
+		context.Background(),
+		db.AnalyticsFilter{
+			From: "2026-03-12",
+			To:   "2026-03-12",
+		},
+		"messages",
+	)
+	require.NoError(t, err, "GetAnalyticsTopSessions")
+
+	byID := map[string]db.TopSession{}
+	for _, session := range top.Sessions {
+		byID[session.ID] = session
+	}
+
+	named, ok := byID["pg-session-name"]
+	require.True(t, ok, "pg-session-name missing from top sessions")
+	require.NotNil(t, named.DisplayName,
+		"session_name should be exposed as display_name")
+	assert.Equal(t, "Agent generated title", *named.DisplayName)
+
+	custom, ok := byID["pg-custom-name"]
+	require.True(t, ok, "pg-custom-name missing from top sessions")
+	require.NotNil(t, custom.DisplayName,
+		"custom display_name should be exposed")
+	assert.Equal(t, "User renamed title", *custom.DisplayName)
+}
+
 func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 	pgURL := testPGURL(t)
 


### PR DESCRIPTION
This updates the "Top sessions" section of the `/sessions` page to show the display name of each session if present, instead of always showing the first message. This makes it match up with what is displayed in the session list in the sidebar. This required plumbing the display name through the top sessions API endpoint.