### PR TITLE
fix(parser): extract OpenClaw camelCase toolCall/toolResult blocks

### DIFF
--- a/internal/parser/content.go
+++ b/internal/parser/content.go
@@ -48,23 +48,34 @@ func ExtractTextContent(
 				parts = append(parts,
 					"[Thinking]\n"+thinking+"\n[/Thinking]")
 			}
-		case "tool_use":
+		case "tool_use", "toolCall":
+			// "tool_use" is the Anthropic block type; "toolCall" is
+			// the camelCase variant emitted by OpenClaw. OpenClaw
+			// usually carries the call arguments under "input", but
+			// some tools populate only "arguments", so fall back to
+			// it when "input" is missing or empty.
 			hasToolUse = true
 			name := block.Get("name").Str
 			if name != "" {
+				input := block.Get("input")
+				if input.Raw == "" || input.Raw == "{}" {
+					if args := block.Get("arguments"); args.Exists() {
+						input = args
+					}
+				}
 				tc := ParsedToolCall{
 					ToolUseID: block.Get("id").Str,
 					ToolName:  name,
 					Category:  NormalizeToolCategory(name),
-					InputJSON: block.Get("input").Raw,
+					InputJSON: input.Raw,
 				}
 				switch name {
 				case "Skill":
-					tc.SkillName = block.Get("input.skill").Str
+					tc.SkillName = input.Get("skill").Str
 				case "skill":
-					tc.SkillName = block.Get("input.skill").Str
+					tc.SkillName = input.Get("skill").Str
 					if tc.SkillName == "" {
-						tc.SkillName = block.Get("input.name").Str
+						tc.SkillName = input.Get("name").Str
 					}
 				}
 				toolCalls = append(toolCalls, tc)
@@ -151,6 +162,13 @@ var todoIcons = map[string]string{
 func formatToolUse(block gjson.Result) string {
 	name := block.Get("name").Str
 	input := block.Get("input")
+	if input.Raw == "" || input.Raw == "{}" {
+		// OpenClaw emits some tool calls with args only under
+		// "arguments" rather than "input".
+		if args := block.Get("arguments"); args.Exists() {
+			input = args
+		}
+	}
 
 	switch name {
 	case "AskUserQuestion":

--- a/internal/parser/openclaw.go
+++ b/internal/parser/openclaw.go
@@ -325,21 +325,14 @@ func extractToolResultText(content gjson.Result) string {
 
 	var parts []string
 	content.ForEach(func(_, block gjson.Result) bool {
+		// OpenClaw tool-result content blocks (type "toolResult") carry
+		// the rendered text inline under "text", the same field plain
+		// "text" blocks use. This matches what DecodeContent reads, so
+		// the measured length and the stored/decoded content agree.
 		switch block.Get("type").Str {
-		case "text":
+		case "text", "toolResult":
 			if t := block.Get("text").Str; t != "" {
 				parts = append(parts, t)
-			}
-		case "toolResult":
-			// OpenClaw tool-result content blocks carry the rendered
-			// text inline under "text", with the structured payload
-			// under "content".
-			if t := block.Get("text").Str; t != "" {
-				parts = append(parts, t)
-			} else if nested := block.Get("content"); nested.Exists() {
-				if nt := extractToolResultText(nested); nt != "" {
-					parts = append(parts, nt)
-				}
 			}
 		}
 		return true

--- a/internal/parser/openclaw.go
+++ b/internal/parser/openclaw.go
@@ -181,6 +181,7 @@ func ParseOpenClawSession(
 				ToolResults: []ParsedToolResult{{
 					ToolUseID:     toolCallID,
 					ContentLength: contentLen,
+					ContentRaw:    content.Raw,
 				}},
 			})
 			ordinal++

--- a/internal/parser/openclaw.go
+++ b/internal/parser/openclaw.go
@@ -324,9 +324,21 @@ func extractToolResultText(content gjson.Result) string {
 
 	var parts []string
 	content.ForEach(func(_, block gjson.Result) bool {
-		if block.Get("type").Str == "text" {
+		switch block.Get("type").Str {
+		case "text":
 			if t := block.Get("text").Str; t != "" {
 				parts = append(parts, t)
+			}
+		case "toolResult":
+			// OpenClaw tool-result content blocks carry the rendered
+			// text inline under "text", with the structured payload
+			// under "content".
+			if t := block.Get("text").Str; t != "" {
+				parts = append(parts, t)
+			} else if nested := block.Get("content"); nested.Exists() {
+				if nt := extractToolResultText(nested); nt != "" {
+					parts = append(parts, nt)
+				}
 			}
 		}
 		return true

--- a/internal/parser/openclaw_test.go
+++ b/internal/parser/openclaw_test.go
@@ -138,6 +138,13 @@ func TestParseOpenClawSession_RealToolCallFormat(t *testing.T) {
 	assert.Equal(t, "call_1", result.ToolResults[0].ToolUseID)
 	assert.Equal(t, len("file1\nfile2"), result.ToolResults[0].ContentLength,
 		"toolResult content block text must be extracted")
+	// ContentRaw must be stored so pairToolResults can decode it into
+	// tool_calls.result_content for the UI, search, copy, and exports.
+	require.NotEmpty(t, result.ToolResults[0].ContentRaw,
+		"ContentRaw must be stored for downstream decoding")
+	assert.Equal(t, "file1\nfile2",
+		DecodeContent(result.ToolResults[0].ContentRaw),
+		"stored ContentRaw must decode to the tool result text")
 
 	// An arguments-only toolCall still yields InputJSON from "arguments".
 	argsOnly := msgs[3]

--- a/internal/parser/openclaw_test.go
+++ b/internal/parser/openclaw_test.go
@@ -96,6 +96,56 @@ func TestParseOpenClawSession_ToolResult(t *testing.T) {
 	assert.Equal(t, 1, sess.UserMessageCount, "expected UserMessageCount 1 (tool results excluded), got %d")
 }
 
+func TestParseOpenClawSession_RealToolCallFormat(t *testing.T) {
+	// Real OpenClaw output uses camelCase "toolCall" blocks for
+	// assistant tool calls and "toolResult" content blocks inside
+	// role:"toolResult" messages -- not the Anthropic snake_case
+	// "tool_use"/"tool_result" the shared extractor originally knew.
+	// Some tools (read/exec) populate only "arguments"; others (bash)
+	// duplicate it under "input".
+	path, _ := writeOpenClawTestFile(t, "main",
+		`{"type":"session","version":3,"id":"real-tc","timestamp":"2026-02-25T10:00:00Z","cwd":"/home/user/project"}`,
+		`{"type":"message","id":"m1","timestamp":"2026-02-25T10:00:01Z","message":{"role":"user","content":[{"type":"text","text":"list files"}],"timestamp":"2026-02-25T10:00:01Z"}}`,
+		// Assistant turn that is ONLY a toolCall (input + arguments duplicated).
+		`{"type":"message","id":"m2","timestamp":"2026-02-25T10:00:02Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_1","name":"bash","input":{"command":"ls"},"arguments":{"command":"ls"}}],"timestamp":"2026-02-25T10:00:02Z"}}`,
+		// Tool result as a standalone toolResult-role message carrying a toolResult content block.
+		`{"type":"message","id":"m3","timestamp":"2026-02-25T10:00:03Z","message":{"role":"toolResult","toolCallId":"call_1","toolName":"bash","isError":false,"content":[{"type":"toolResult","toolCallId":"call_1","tool_use_id":"call_1","name":"bash","text":"file1\nfile2"}],"timestamp":"2026-02-25T10:00:03Z"}}`,
+		// Second toolCall where args live ONLY under "arguments".
+		`{"type":"message","id":"m4","timestamp":"2026-02-25T10:00:04Z","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_2","name":"read","arguments":{"path":"/etc/hosts"}}],"timestamp":"2026-02-25T10:00:04Z"}}`,
+	)
+
+	sess, msgs, err := ParseOpenClawSession(path, "", "test")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Equal(t, 4, len(msgs),
+		"expected user, assistant(toolCall), toolResult, assistant(toolCall)")
+
+	// The assistant turn that is only a toolCall must survive and
+	// carry its parsed call rather than being dropped as empty.
+	assistant := msgs[1]
+	assert.Equal(t, RoleAssistant, assistant.Role)
+	assert.True(t, assistant.HasToolUse, "toolCall block must set HasToolUse")
+	require.Equal(t, 1, len(assistant.ToolCalls), "expected 1 parsed tool call")
+	assert.Equal(t, "bash", assistant.ToolCalls[0].ToolName)
+	assert.Equal(t, "call_1", assistant.ToolCalls[0].ToolUseID)
+	assert.Contains(t, assistant.ToolCalls[0].InputJSON, "ls")
+
+	// The standalone toolResult message pairs by toolCallId and
+	// extracts the text from the toolResult content block.
+	result := msgs[2]
+	assert.Equal(t, RoleUser, result.Role)
+	require.Equal(t, 1, len(result.ToolResults), "expected 1 tool result")
+	assert.Equal(t, "call_1", result.ToolResults[0].ToolUseID)
+	assert.Equal(t, len("file1\nfile2"), result.ToolResults[0].ContentLength,
+		"toolResult content block text must be extracted")
+
+	// An arguments-only toolCall still yields InputJSON from "arguments".
+	argsOnly := msgs[3]
+	require.Equal(t, 1, len(argsOnly.ToolCalls), "expected 1 parsed tool call")
+	assert.Equal(t, "read", argsOnly.ToolCalls[0].ToolName)
+	assert.Contains(t, argsOnly.ToolCalls[0].InputJSON, "/etc/hosts")
+}
+
 func TestParseOpenClawSession_OrphanToolResult(t *testing.T) {
 	path, _ := writeOpenClawTestFile(t, "main",
 		`{"type":"session","version":3,"id":"orphan-tr","timestamp":"2026-02-25T10:00:00Z","cwd":"/tmp"}`,


### PR DESCRIPTION
Fixes #703.

OpenClaw emits assistant tool calls as `toolCall` content blocks and tool
results as `toolResult` blocks (camelCase), but the shared content extractor in
`ExtractTextContent` only recognized the Anthropic snake_case `tool_use` /
`tool_result` names. As a result every OpenClaw tool call was silently dropped,
and assistant turns that consisted solely of a tool call parsed to empty content
and were discarded entirely — so transcripts showed only plain user and
assistant text, exactly as reported.

This recognizes the camelCase block types. OpenClaw usually carries the call
arguments under `input` but some tools (e.g. `read`, `exec`) populate only
`arguments`, so the extractor prefers `input` and falls back to `arguments`;
`formatToolUse` does the same so the rendered text matches. The OpenClaw
tool-result text extractor now reads `toolResult` content blocks (text inline
under `text`, structured payload under `content`) in addition to plain `text`
blocks.

The existing OpenClaw parser tests passed because their fixtures used the
Anthropic snake_case block names rather than real OpenClaw output. A new test,
`TestParseOpenClawSession_RealToolCallFormat`, is built from the real on-disk
shape: a `toolCall` block with `input`+`arguments`, an `arguments`-only
`toolCall`, and a standalone `toolResult`-role message carrying a `toolResult`
content block.

Verified against a real archive: re-parsing an OpenClaw session that has 18
`toolCall` blocks on disk now yields 18 parsed tool calls (it previously yielded
zero); across a full archive every OpenClaw session previously had zero parsed
tool calls while other agents were unaffected.

Where to look: `internal/parser/content.go` (shared block-type handling) and
`internal/parser/openclaw.go` (`extractToolResultText`). The change is additive:
among current parsers, the claw-family agents (OpenClaw and QClaw) both route
assistant content through the shared `ExtractTextContent` and were losing these
camelCase blocks, so this also recovers QClaw's tool calls; other agents use the
Anthropic snake_case names and are unaffected. QClaw's separate tool-result text
extractor (`extractQClawToolResultText`) is intentionally left unchanged, since
its real result-block format has not been confirmed against actual session data.