### PR TITLE
fix(codex): reparse late token counts

### DIFF
--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -28,7 +28,7 @@ const (
 )
 
 var errCodexIncrementalNeedsFullParse = errors.New(
-	"codex subagent event requires full parse",
+	"codex incremental event requires full parse",
 )
 
 var codexSessionIndexCache = struct {
@@ -66,6 +66,7 @@ type codexSessionBuilder struct {
 	pendingAgentEvents       map[string][]codexPendingEvent
 	orphanNotificationIx     map[string]int
 	lastTokenUsageRaw        string // dedup streaming duplicates
+	unattachedTokenUsage     bool
 
 	// Most recent task lifecycle event seen on the file. Used to
 	// classify termination_status — task_complete maps to
@@ -373,6 +374,7 @@ func (b *codexSessionBuilder) handleTokenCountEvent(
 			return
 		}
 	}
+	b.unattachedTokenUsage = true
 }
 
 func (b *codexSessionBuilder) handleCollabAgentSpawnEnd(
@@ -1670,6 +1672,10 @@ func ParseCodexSessionFrom(
 				return
 			}
 			b.processLine(line)
+			if b.unattachedTokenUsage {
+				fallbackErr = errCodexIncrementalNeedsFullParse
+				return
+			}
 		},
 	)
 	if err != nil {

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1668,6 +1668,45 @@ func TestParseCodexSessionFrom_Incremental(t *testing.T) {
 	assert.False(t, endedAt.IsZero())
 }
 
+func TestParseCodexSessionFrom_LateTokenCountRequiresFullParse(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"inc-late-usage", "/projects/api",
+			"codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextJSON("gpt-5.5", tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "run command", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command", "call_cmd",
+			map[string]any{"cmd": "sleep 1"}, tsEarlyS5,
+		),
+	)
+	path := createTestFile(t, "late-token-count.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.JoinJSONL(
+		testjsonl.CodexFunctionCallOutputJSON(
+			"call_cmd", "done", tsLate,
+		),
+		testjsonl.CodexTokenCountJSON(
+			tsLate, 100_000, 250, 64_000,
+		),
+	))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 2, false)
+	require.Error(t, err)
+	assert.True(t, IsIncrementalFullParseFallback(err))
+}
+
 // TestParseCodexSessionFrom_DedupsReemittedPrompt covers the
 // incremental-sync case of the re-emitted-prompt dedup: when Codex
 // appends a positive replay signal followed by a verbatim replay of

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4135,21 +4135,26 @@ func (e *Engine) processCodex(
 	indexMtimeChanged := e.codexIndexMtimeChanged(file.Path)
 	forceReplace := false
 
-	if !indexMtimeChanged {
-		codexParseFn := func(
-			path string, offset int64, startOrd int,
-		) ([]parser.ParsedMessage, time.Time, int64, error) {
-			return parser.ParseCodexSessionFrom(
-				path, offset, startOrd, false,
-			)
-		}
-		if res, ok := e.tryIncrementalJSONL(
-			file, info, parser.AgentCodex, codexParseFn,
-		); ok {
+	codexParseFn := func(
+		path string, offset int64, startOrd int,
+	) ([]parser.ParsedMessage, time.Time, int64, error) {
+		return parser.ParseCodexSessionFrom(
+			path, offset, startOrd, false,
+		)
+	}
+	if res, ok := e.tryIncrementalJSONL(
+		file, info, parser.AgentCodex, codexParseFn,
+	); ok {
+		if !indexMtimeChanged {
 			return res
-		} else {
-			forceReplace = res.forceReplace
 		}
+		// The index title changed, so a full parse still needs to refresh
+		// session metadata. Keep any fallback signal discovered while probing
+		// appended bytes so existing rows rewritten by the full parse are not
+		// dropped by the append-only write path.
+		forceReplace = res.forceReplace
+	} else {
+		forceReplace = res.forceReplace
 	}
 
 	sess, msgs, err := parser.ParseCodexSession(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4133,6 +4133,7 @@ func (e *Engine) processCodex(
 	}
 
 	indexMtimeChanged := e.codexIndexMtimeChanged(file.Path)
+	forceReplace := false
 
 	if !indexMtimeChanged {
 		codexParseFn := func(
@@ -4146,6 +4147,8 @@ func (e *Engine) processCodex(
 			file, info, parser.AgentCodex, codexParseFn,
 		); ok {
 			return res
+		} else {
+			forceReplace = res.forceReplace
 		}
 	}
 
@@ -4170,6 +4173,7 @@ func (e *Engine) processCodex(
 		results: []parser.ParseResult{
 			{Session: *sess, Messages: msgs},
 		},
+		forceReplace: forceReplace,
 	}
 }
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6941,6 +6941,87 @@ func TestIncrementalSync_CodexLateTokenCountRewritesStoredMessage(t *testing.T) 
 	assert.Equal(t, 100_000, msgs[1].ContextTokens)
 }
 
+func TestIncrementalSync_CodexLateTokenCountWithIndexRenameRewritesStoredMessage(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e1"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/tmp/proj",
+			"codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextJSON("gpt-5.5", tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "run command", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command", "call_cmd",
+			map[string]any{"cmd": "sleep 1"}, tsEarlyS5,
+		),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "01"),
+		"rollout-2024-01-01T10-00-00-"+uuid+".jsonl",
+		initial,
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original title","updated_at":"2024-01-01T10:00:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+
+	initialTime := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(path, initialTime, initialTime), "chtimes initial session")
+	require.NoError(t, os.Chtimes(indexPath, initialTime, initialTime), "chtimes initial index")
+
+	env.engine.SyncAll(context.Background(), nil)
+
+	msgs := fetchMessages(t, env.db, "codex:"+uuid)
+	require.Len(t, msgs, 2)
+	assert.Empty(t, msgs[1].TokenUsage)
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexFunctionCallOutputJSON(
+			"call_cmd", "done", "2024-01-01T10:01:00Z",
+		),
+		testjsonl.CodexTokenCountJSON(
+			"2024-01-01T10:01:00Z", 100_000, 250, 64_000,
+		),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append")
+	require.NoError(t, f.Close())
+
+	newTime := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, os.Chtimes(path, newTime, newTime), "chtimes appended session")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2024-01-01T10:01:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, newTime.Add(time.Second), newTime.Add(time.Second)), "chtimes renamed index")
+
+	env.engine.SyncPaths([]string{path})
+
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull after rename")
+	require.NotNil(t, sess, "expected Codex session to remain")
+	if assert.NotNil(t, sess.SessionName, "expected renamed session_name") {
+		assert.Equal(t, "Renamed title", *sess.SessionName)
+	}
+
+	msgs = fetchMessages(t, env.db, "codex:"+uuid)
+	require.Len(t, msgs, 2)
+	assert.NotEmpty(t, msgs[1].TokenUsage)
+	assert.Equal(t, 250, msgs[1].OutputTokens)
+	assert.Equal(t, 100_000, msgs[1].ContextTokens)
+}
+
 func TestIncrementalSync_CodexSubagentAppendFallsBackToFullParse(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6890,6 +6890,57 @@ func TestIncrementalSync_CodexAppend(t *testing.T) {
 	}
 }
 
+func TestIncrementalSync_CodexLateTokenCountRewritesStoredMessage(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"inc-cx-late-usage", "/tmp/proj",
+			"codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextJSON("gpt-5.5", tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "run command", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command", "call_cmd",
+			map[string]any{"cmd": "sleep 1"}, tsEarlyS5,
+		),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "01"),
+		"rollout-20240101-inc-cx-late-usage.jsonl",
+		initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	msgs := fetchMessages(t, env.db, "codex:inc-cx-late-usage")
+	require.Len(t, msgs, 2)
+	assert.Empty(t, msgs[1].TokenUsage)
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexFunctionCallOutputJSON(
+			"call_cmd", "done", "2024-01-01T10:01:00Z",
+		),
+		testjsonl.CodexTokenCountJSON(
+			"2024-01-01T10:01:00Z", 100_000, 250, 64_000,
+		),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs = fetchMessages(t, env.db, "codex:inc-cx-late-usage")
+	require.Len(t, msgs, 2)
+	assert.NotEmpty(t, msgs[1].TokenUsage)
+	assert.Equal(t, 250, msgs[1].OutputTokens)
+	assert.Equal(t, 100_000, msgs[1].ContextTokens)
+}
+
 func TestIncrementalSync_CodexSubagentAppendFallsBackToFullParse(t *testing.T) {
 	env := setupTestEnv(t)
 


### PR DESCRIPTION
Codex can append `event_msg:token_count` after the assistant or tool-call row that should carry the usage. When agentsview incrementally synced the earlier row before the later usage event arrived, the parser had no in-window assistant message to attach usage to and the append-only writer preserved the empty `token_usage` row until a manual full resync.

This makes unattached non-duplicate Codex token counts during incremental parsing trigger the existing full-parse fallback, and carries the Codex replacement flag through that fallback so corrected existing rows are rewritten instead of skipped. That keeps continual refresh behavior aligned with a full resync without changing the normal full-parse token attachment rules.

Reviewers should start with `internal/parser/codex.go` for the fallback trigger and `internal/sync/engine.go` for the replacement flag propagation; the regression coverage is in the matching parser and sync integration tests. Local validation passed with `go fmt ./...`, `CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled" ./internal/parser ./internal/sync -count=1`, and `go vet ./...`.