### PR TITLE
docs(readme): add QwenPaw to supported agents table

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ agentsview auto-discovers sessions from all of these:
 | Positron Assistant | `~/Library/Application Support/Positron/User/` (macOS) |
 | QClaw              | `~/.qclaw/agents/`                                     |
 | Qwen Code          | `~/.qwen/projects/`                                    |
+| QwenPaw            | `~/.copaw/workspaces/`, `~/.qwenpaw/workspaces/`       |
 | VSCode Copilot     | `~/Library/Application Support/Code/User/` (macOS)     |
 | Warp               | `~/.warp/` (platform-dependent)                        |
 | WorkBuddy          | `~/.workbuddy/projects/`                               |


### PR DESCRIPTION
## Summary
- Adds QwenPaw to the supported agents table in README.md, listing both `~/.copaw/workspaces/` and `~/.qwenpaw/workspaces/` as session directories.
- Sits alphabetically between Qwen Code and VSCode Copilot to match existing ordering.

## Context
The QwenPaw parser (`internal/parser/qwenpaw.go`) and fixtures landed earlier, but the user-facing supported agents table never picked it up. This fills that doc gap.

## Notes for reviewers
- The on-disk default in `internal/parser/types.go` is `.copaw/workspaces`; the second path `~/.qwenpaw/workspaces/` is listed because QwenPaw runtimes are occasionally deployed under either name, and the parser does not restrict the root.
- No code changes; README-only.