### PR TITLE
feat(parser): add Shelley (exe.dev) agent support

### DIFF
--- a/frontend/src/lib/components/settings/AgentDirSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentDirSettings.svelte
@@ -24,6 +24,7 @@
     piebald: "Piebald",
     antigravity: "Antigravity",
     "antigravity-cli": "Antigravity CLI",
+    shelley: "Shelley",
   };
 </script>
 

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1252,7 +1252,8 @@ func (db *DB) MessageRoleTimeFingerprint(sessionID string) (string, error) {
 // has_tool_use, and a SHA-256 over the sanitized thinking_text. The
 // parse-diff comparator uses it as a tier-1 fast path so a parser change
 // confined to these columns still triggers the tier-2 row comparison.
-// Not used by the PG push fast-path.
+// PG push uses it with a PostgreSQL-side twin to avoid skipping
+// metadata-only rewrites.
 func (db *DB) MessageFlagsFingerprint(sessionID string) (string, error) {
 	rows, err := db.getReader().Query(
 		`SELECT ordinal, is_system, has_thinking, has_tool_use,

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1175,11 +1175,10 @@ func (db *DB) MessageTokenFingerprint(sessionID string) (string, error) {
 
 // MessageContentHashFingerprint returns an exact ordered fingerprint
 // of per-message body content: ordinal, the stored content_length
-// column, and a SHA-256 over the sanitized content. The parse-diff
-// comparator uses it instead of the aggregate
-// MessageContentFingerprint (sum/max/min of content_length, kept for
-// the PG push fast-path), which cannot see equal-length body rewrites
-// or per-message length changes whose aggregates collide.
+// column, and a SHA-256 over the sanitized content. Parse-diff and PG
+// push use it alongside the aggregate MessageContentFingerprint
+// (sum/max/min of content_length), which cannot see equal-length body
+// rewrites or per-message length changes whose aggregates collide.
 func (db *DB) MessageContentHashFingerprint(sessionID string) (string, error) {
 	rows, err := db.getReader().Query(
 		`SELECT ordinal, content, content_length

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1220,6 +1220,20 @@ func (db *DB) MessageContentHashFingerprint(sessionID string) (string, error) {
 // (selectMessageCols coalesces the same way); without it a single
 // imported NULL row would error here and abort the whole parse-diff run.
 func (db *DB) MessageRoleTimeFingerprint(sessionID string) (string, error) {
+	return db.MessageRoleTimeFingerprintWithTimestampNormalizer(
+		sessionID, nil,
+	)
+}
+
+// MessageRoleTimeFingerprintWithTimestampNormalizer returns the same
+// fingerprint as MessageRoleTimeFingerprint after applying normalizeTimestamp
+// to each timestamp value. It lets callers compare against stores that preserve
+// a different timestamp representation while keeping the query and field
+// ordering identical to the raw parse-diff fingerprint.
+func (db *DB) MessageRoleTimeFingerprintWithTimestampNormalizer(
+	sessionID string,
+	normalizeTimestamp func(string) string,
+) (string, error) {
 	rows, err := db.getReader().Query(
 		`SELECT ordinal, role, COALESCE(timestamp, '')
 		 FROM messages
@@ -1240,6 +1254,9 @@ func (db *DB) MessageRoleTimeFingerprint(sessionID string) (string, error) {
 			return "", err
 		}
 		role = SanitizeUTF8(role)
+		if normalizeTimestamp != nil {
+			timestamp = normalizeTimestamp(timestamp)
+		}
 		fmt.Fprintf(&b, "%d|%d:%s|%d:%s;",
 			ordinal, len(role), role, len(timestamp), timestamp)
 	}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1517,6 +1517,25 @@ func (db *DB) GetFileInfoByPath(
 	return s.Int64, m.Int64, true
 }
 
+// GetFileHashByPath returns the stored file_hash for the session
+// matching file_path, preferring the most recently modified row.
+// The bool is false when no row exists or the column is NULL. Used
+// by the Shelley skip to compare a per-conversation content
+// fingerprint alongside file_mtime.
+func (db *DB) GetFileHashByPath(path string) (hash string, ok bool) {
+	var h sql.NullString
+	err := db.getReader().QueryRow(
+		"SELECT file_hash FROM sessions"+
+			" WHERE file_path = ?"+
+			" ORDER BY file_mtime DESC LIMIT 1",
+		path,
+	).Scan(&h)
+	if err != nil {
+		return "", false
+	}
+	return h.String, h.Valid
+}
+
 // GetDataVersionByPath returns the minimum data_version for
 // sessions matching a file_path. Returns 0 when no session
 // exists for the path.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1323,20 +1323,49 @@ func (db *DB) GetSessionMessageCount(
 	return count, true
 }
 
-// GetSessionVersion returns the message count and file mtime
-// for change detection in SSE watchers.
+// SessionVersionMarker returns a compact marker for one or more
+// version fields. Inputs are length-framed so adjacent fields cannot
+// collide by concatenation.
+func SessionVersionMarker(parts ...string) int64 {
+	const (
+		offset64 = uint64(14695981039346656037)
+		prime64  = uint64(1099511628211)
+	)
+	h := offset64
+	write := func(s string) {
+		for _, b := range []byte(s) {
+			h ^= uint64(b)
+			h *= prime64
+		}
+	}
+	for _, part := range parts {
+		write(fmt.Sprintf("%d:", len(part)))
+		write(part)
+	}
+	return int64(h)
+}
+
+// GetSessionVersion returns the message count and a compact version
+// marker for change detection in SSE watchers.
 func (db *DB) GetSessionVersion(
 	id string,
-) (count int, fileMtime int64, ok bool) {
+) (count int, version int64, ok bool) {
+	var fileMtime int64
+	var fileHash, localModifiedAt string
 	err := db.getReader().QueryRow(
-		"SELECT message_count, COALESCE(file_mtime, 0)"+
+		"SELECT message_count, COALESCE(file_mtime, 0),"+
+			" COALESCE(file_hash, ''), COALESCE(local_modified_at, '')"+
 			" FROM sessions WHERE id = ?",
 		id,
-	).Scan(&count, &fileMtime)
+	).Scan(&count, &fileMtime, &fileHash, &localModifiedAt)
 	if err != nil {
 		return 0, 0, false
 	}
-	return count, fileMtime, true
+	return count, SessionVersionMarker(
+		fmt.Sprintf("%d", fileMtime),
+		fileHash,
+		localModifiedAt,
+	), true
 }
 
 // IncrementalInfo holds the data needed for incremental

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -45,7 +45,7 @@ type Store interface {
 	SecretFindingSource(ctx context.Context, f SecretFinding) (string, bool, error)
 
 	// SSE change detection.
-	GetSessionVersion(id string) (count int, fileMtime int64, ok bool)
+	GetSessionVersion(id string) (count int, version int64, ok bool)
 
 	// Metadata.
 	GetStats(ctx context.Context, excludeOneShot, excludeAutomated bool) (Stats, error)

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -399,21 +399,31 @@ func (s *Store) GetChildSessions(ctx context.Context, parentID string) ([]db.Ses
 
 func (s *Store) GetSessionVersion(id string) (int, int64, bool) {
 	var count int
+	var fileMtime sql.NullInt64
+	var fileHash sql.NullString
 	var updated any
 	err := s.duck.QueryRow(
-		`SELECT message_count, COALESCE(local_modified_at, ended_at, started_at, created_at)
+		`SELECT message_count, file_mtime, file_hash,
+		        COALESCE(local_modified_at, ended_at, started_at, created_at)
 		 FROM sessions WHERE id = ?`,
 		id,
-	).Scan(&count, &updated)
+	).Scan(&count, &fileMtime, &fileHash, &updated)
 	if err != nil {
 		return 0, 0, false
 	}
-	formatted := formatDBTime(updated)
-	var h int64
-	for _, c := range formatted {
-		h = h*31 + int64(c)
+	fileMtimePart := ""
+	if fileMtime.Valid {
+		fileMtimePart = fmt.Sprintf("%d", fileMtime.Int64)
 	}
-	return count, h, true
+	fileHashPart := ""
+	if fileHash.Valid {
+		fileHashPart = fileHash.String
+	}
+	return count, db.SessionVersionMarker(
+		fileMtimePart,
+		fileHashPart,
+		formatDBTime(updated),
+	), true
 }
 
 func (s *Store) GetStats(ctx context.Context, excludeOneShot, excludeAutomated bool) (db.Stats, error) {

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -181,19 +181,43 @@ func ShelleyConversationExists(dbPath, conversationID string) bool {
 type ShelleyConversationMeta struct {
 	RawID       string
 	VirtualPath string
-	FileMtime   int64
+	// FileMtime is the per-conversation change signal (see
+	// shelleyChangeMtime), not a raw timestamp.
+	FileMtime int64
 }
 
-// ListShelleyConversationMetas queries conversation IDs and updated_at
-// timestamps using an already-open connection, sharing it with the
-// subsequent parse loop to avoid a second DB open.
+// shelleyChangeMtime combines a conversation's updated_at (whole-second
+// precision: Shelley writes it as SQLite CURRENT_TIMESTAMP) with the
+// conversation's max message sequence_id into the per-conversation change
+// signal stored as File.Mtime. sequence_id is Shelley's own monotonic,
+// append-only cursor -- it powers Shelley's incremental-fetch protocol --
+// so adding it lets the sync engine detect conversations that changed
+// within the same wall-clock second, which updated_at alone cannot
+// distinguish. Both inputs are monotonic non-decreasing, so the sum
+// strictly increases on any real change and never collides for a given
+// conversation. Drift from the true timestamp is at most maxSeq
+// nanoseconds (sub-millisecond), so File.Mtime stays a valid timestamp.
+//
+// This is a deliberate, documented divergence from the otherwise-mirrored
+// Zed parser: Zed's updated_at is sub-second RFC3339, so its skip signal
+// is already collision-free; Shelley's second-precision updated_at is not.
+func shelleyChangeMtime(updatedAtNanos, maxSeq int64) int64 {
+	return updatedAtNanos + maxSeq
+}
+
+// ListShelleyConversationMetas queries conversation IDs, updated_at
+// timestamps, and max message sequence_id using an already-open
+// connection, sharing it with the subsequent parse loop to avoid a second
+// DB open.
 func ListShelleyConversationMetas(
 	conn *sql.DB, dbPath string,
 ) ([]ShelleyConversationMeta, error) {
 	rows, err := conn.Query(
-		`SELECT conversation_id, COALESCE(updated_at, '')
-		   FROM conversations
-		  ORDER BY updated_at, conversation_id`,
+		`SELECT c.conversation_id, COALESCE(c.updated_at, ''),
+		        COALESCE((SELECT MAX(m.sequence_id) FROM messages m
+		                   WHERE m.conversation_id = c.conversation_id), 0)
+		   FROM conversations c
+		  ORDER BY c.updated_at, c.conversation_id`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing shelley conversations: %w", err)
@@ -203,7 +227,8 @@ func ListShelleyConversationMetas(
 	var metas []ShelleyConversationMeta
 	for rows.Next() {
 		var id, updatedAt string
-		if err := rows.Scan(&id, &updatedAt); err != nil {
+		var maxSeq int64
+		if err := rows.Scan(&id, &updatedAt, &maxSeq); err != nil {
 			return nil, fmt.Errorf("scanning shelley conversation meta: %w", err)
 		}
 		if !IsValidSessionID(id) {
@@ -212,16 +237,19 @@ func ListShelleyConversationMetas(
 		metas = append(metas, ShelleyConversationMeta{
 			RawID:       id,
 			VirtualPath: ShelleyVirtualPath(dbPath, id),
-			FileMtime:   parseTimestamp(updatedAt).UnixNano(),
+			FileMtime: shelleyChangeMtime(
+				parseTimestamp(updatedAt).UnixNano(), maxSeq,
+			),
 		})
 	}
 	return metas, rows.Err()
 }
 
-// ShelleySourceMtime resolves the per-conversation updated_at timestamp
-// for a virtual Shelley source path. Used by the per-session live
-// watcher, which treats a zero result as "source gone", so this returns
-// the conversation's updated_at consistent with the stored FileMtime.
+// ShelleySourceMtime resolves the per-conversation change signal for a
+// virtual Shelley source path. Used by the per-session live watcher,
+// which treats a zero result as "source gone", so this returns the same
+// updated_at + max(sequence_id) composite as the stored FileMtime (see
+// shelleyChangeMtime).
 func ShelleySourceMtime(path string) (int64, error) {
 	dbPath, conversationID, ok := ParseShelleyVirtualPath(path)
 	if !ok {
@@ -234,19 +262,22 @@ func ShelleySourceMtime(path string) (int64, error) {
 	defer conn.Close()
 
 	var updatedAt string
+	var maxSeq int64
 	err = conn.QueryRow(
-		`SELECT COALESCE(updated_at, '')
-		   FROM conversations
-		  WHERE conversation_id = ?`,
+		`SELECT COALESCE(c.updated_at, ''),
+		        COALESCE((SELECT MAX(m.sequence_id) FROM messages m
+		                   WHERE m.conversation_id = c.conversation_id), 0)
+		   FROM conversations c
+		  WHERE c.conversation_id = ?`,
 		conversationID,
-	).Scan(&updatedAt)
+	).Scan(&updatedAt, &maxSeq)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"loading shelley conversation mtime %s: %w",
 			conversationID, err,
 		)
 	}
-	return parseTimestamp(updatedAt).UnixNano(), nil
+	return shelleyChangeMtime(parseTimestamp(updatedAt).UnixNano(), maxSeq), nil
 }
 
 // OpenShelleyDB opens the Shelley shelley.db file read-only. Callers are
@@ -294,11 +325,13 @@ func ParseShelleyConversationFromDB(
 	if err != nil {
 		return nil, err
 	}
-	messages, err := loadShelleyMessages(conn, rawID, conv.model)
+	messages, maxSeq, err := loadShelleyMessages(conn, rawID, conv.model)
 	if err != nil {
 		return nil, err
 	}
-	result, ok := buildShelleyParseResult(conv, messages, dbPath, dbInfo, machine)
+	result, ok := buildShelleyParseResult(
+		conv, messages, maxSeq, dbPath, dbInfo, machine,
+	)
 	if !ok {
 		return nil, nil
 	}
@@ -349,7 +382,7 @@ type shelleyMessageRow struct {
 
 func loadShelleyMessages(
 	conn *sql.DB, conversationID, convModel string,
-) ([]ParsedMessage, error) {
+) ([]ParsedMessage, int64, error) {
 	// All generations are included, ordered by sequence_id. A generation
 	// bump is a context-reset/compaction boundary within the conversation
 	// (e.g. distillation); older-generation rows remain as real history
@@ -365,26 +398,33 @@ func loadShelleyMessages(
 		conversationID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, 0, fmt.Errorf(
 			"listing shelley messages for %s: %w", conversationID, err,
 		)
 	}
 	defer rows.Close()
 
 	var messages []ParsedMessage
+	var maxSeq int64
 	for rows.Next() {
 		var r shelleyMessageRow
 		if err := rows.Scan(
 			&r.sequenceID, &r.msgType, &r.llmData,
 			&r.userData, &r.usageData, &r.createdAt,
 		); err != nil {
-			return nil, fmt.Errorf("scanning shelley message: %w", err)
+			return nil, 0, fmt.Errorf("scanning shelley message: %w", err)
+		}
+		// Track max sequence_id over ALL rows (even ones decodeShelleyMessage
+		// drops) so the change signal matches ListShelleyConversationMetas'
+		// MAX(sequence_id) query exactly; a mismatch would re-parse forever.
+		if r.sequenceID > maxSeq {
+			maxSeq = r.sequenceID
 		}
 		if msg, ok := decodeShelleyMessage(r, convModel); ok {
 			messages = append(messages, msg)
 		}
 	}
-	return messages, rows.Err()
+	return messages, maxSeq, rows.Err()
 }
 
 func decodeShelleyMessage(
@@ -616,6 +656,7 @@ func shelleyTokenCount(n json.Number) int {
 func buildShelleyParseResult(
 	conv shelleyConversationRow,
 	messages []ParsedMessage,
+	maxSeq int64,
 	dbPath string,
 	info os.FileInfo,
 	machine string,
@@ -694,7 +735,7 @@ func buildShelleyParseResult(
 		File: FileInfo{
 			Path:  ShelleyVirtualPath(dbPath, conv.conversationID),
 			Size:  info.Size(),
-			Mtime: endedAt.UnixNano(),
+			Mtime: shelleyChangeMtime(endedAt.UnixNano(), maxSeq),
 		},
 	}
 	if parent := strings.TrimSpace(conv.parentConversationID); parent != "" {

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -179,9 +179,8 @@ func ShelleyConversationExists(dbPath, conversationID string) bool {
 	return err == nil
 }
 
-// ShelleyConversationMeta holds lightweight per-conversation metadata
-// used by the sync engine for per-session skip detection without loading
-// message payloads.
+// ShelleyConversationMeta holds per-conversation state used by the sync
+// engine for per-session skip detection.
 type ShelleyConversationMeta struct {
 	RawID       string
 	VirtualPath string
@@ -190,10 +189,10 @@ type ShelleyConversationMeta struct {
 	// modified-between range queries that drive PG/DuckDB push never
 	// see a Shelley row as "future"; see shelleyChangeMtime.
 	FileMtime int64
-	// Fingerprint is a content digest over the conversation's messages.
-	// It is stored in file_hash and compared in the sync skip to catch
-	// same-second changes FileMtime's second precision cannot; see
-	// shelleyDigest.
+	// Fingerprint is a digest over every parser-observed conversation and
+	// message field. It is stored in file_hash and compared in the sync
+	// skip to catch same-second changes FileMtime's second precision
+	// cannot; see shelleyDigestConversation and shelleyDigestMessage.
 	Fingerprint string
 }
 
@@ -208,10 +207,11 @@ type ShelleyConversationMeta struct {
 //     ListSessionsModifiedBetween filters file_mtime <= now for PG/DuckDB
 //     push; a synthetic future value would drop a just-synced Shelley row
 //     from a same-second push until a later run.
-//   - Fingerprint, a content digest stored in file_hash, distinguishes any
-//     same-second change the timestamp cannot: appends, in-place rewrites,
-//     and even length-preserving edits (shelleyDigest length-frames each
-//     field). The skip re-parses whenever it differs.
+//   - Fingerprint, a digest stored in file_hash, distinguishes any
+//     same-second parser-visible change the timestamp cannot: metadata
+//     edits, appends, in-place rewrites, and even length-preserving edits
+//     (the digest length-frames each field). The skip re-parses whenever
+//     it differs.
 //
 // Computing the digest means reading message payloads, which the cheaper
 // siblings (Zed, Kiro) avoid because their sub-second / millisecond
@@ -219,16 +219,42 @@ type ShelleyConversationMeta struct {
 // second-precision timestamp does not, so the content read is the price of
 // not silently skipping a rewrite.
 //
-// shelleyDigest folds one message row into a running FNV-1a hash. The
-// sequence_id and per-field length prefixes make the digest sensitive to
-// row identity and field boundaries, so moving bytes between fields (a
-// length-preserving edit) still changes it. Callers must feed rows in a
-// fixed order (sequence_id ascending) so the parse and skip paths agree.
-func shelleyDigest(h hash.Hash64, seq int64, llm, user, usage string) {
+// shelleyDigestConversation and shelleyDigestMessage fold every
+// parser-observed Shelley field into a running FNV-1a hash. Each field is
+// length-framed so equal total byte counts cannot collide by moving bytes
+// between fields. Callers must feed messages in sequence_id order so the
+// parse, skip, and source-mtime paths agree.
+func shelleyDigestConversation(h hash.Hash64, conv shelleyConversationRow) {
+	shelleyDigestFields(
+		h,
+		"conversation",
+		conv.conversationID,
+		conv.slug,
+		strconv.FormatBool(conv.userInitiated),
+		conv.createdAt,
+		conv.updatedAt,
+		conv.cwd,
+		conv.parentConversationID,
+		conv.model,
+	)
+}
+
+func shelleyDigestMessage(h hash.Hash64, r shelleyMessageRow) {
+	shelleyDigestFields(
+		h,
+		"message",
+		strconv.FormatInt(r.sequenceID, 10),
+		r.msgType,
+		r.llmData,
+		r.userData,
+		r.usageData,
+		r.createdAt,
+	)
+}
+
+func shelleyDigestFields(h hash.Hash64, fields ...string) {
 	var n [8]byte
-	binary.LittleEndian.PutUint64(n[:], uint64(seq))
-	_, _ = h.Write(n[:])
-	for _, s := range []string{llm, user, usage} {
+	for _, s := range fields {
 		binary.LittleEndian.PutUint64(n[:], uint64(len(s)))
 		_, _ = h.Write(n[:])
 		_, _ = h.Write([]byte(s))
@@ -242,21 +268,26 @@ func shelleyFingerprint(h hash.Hash64) string {
 }
 
 // ListShelleyConversationMetas returns the skip state for every
-// conversation: its updated_at timestamp (FileMtime) and a content digest
-// (Fingerprint). It scans message payloads ordered by conversation and
-// sequence_id, hashing each conversation's rows the same way the parse
+// conversation: its updated_at timestamp (FileMtime) and parser-visible
+// digest (Fingerprint). It scans message payloads ordered by conversation
+// and sequence_id, hashing each conversation's rows the same way the parse
 // loop does, so the meta digest and the stored file_hash match for
 // unchanged conversations. It shares the caller's open connection.
 func ListShelleyConversationMetas(
 	conn *sql.DB, dbPath string,
 ) ([]ShelleyConversationMeta, error) {
 	rows, err := conn.Query(
-		`SELECT m.conversation_id, COALESCE(c.updated_at, ''),
-		        COALESCE(m.sequence_id, 0), COALESCE(m.llm_data, ''),
-		        COALESCE(m.user_data, ''), COALESCE(m.usage_data, '')
+		`SELECT c.conversation_id, COALESCE(c.slug, ''),
+		        COALESCE(c.user_initiated, 1),
+		        COALESCE(c.created_at, ''), COALESCE(c.updated_at, ''),
+		        COALESCE(c.cwd, ''), COALESCE(c.parent_conversation_id, ''),
+		        COALESCE(c.model, ''),
+		        COALESCE(m.sequence_id, 0), COALESCE(m.type, ''),
+		        COALESCE(m.llm_data, ''), COALESCE(m.user_data, ''),
+		        COALESCE(m.usage_data, ''), COALESCE(m.created_at, '')
 		   FROM conversations c
 		   JOIN messages m ON m.conversation_id = c.conversation_id
-		  ORDER BY m.conversation_id, m.sequence_id`,
+		  ORDER BY c.conversation_id, m.sequence_id`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing shelley conversations: %w", err)
@@ -264,9 +295,9 @@ func ListShelleyConversationMetas(
 	defer rows.Close()
 
 	var (
-		metas      []ShelleyConversationMeta
-		curID      string
-		curUpdated string
+		metas []ShelleyConversationMeta
+		curID string
+		conv  shelleyConversationRow
 	)
 	h := fnv.New64a()
 	flush := func() {
@@ -277,23 +308,29 @@ func ListShelleyConversationMetas(
 		metas = append(metas, ShelleyConversationMeta{
 			RawID:       curID,
 			VirtualPath: ShelleyVirtualPath(dbPath, curID),
-			FileMtime:   parseTimestamp(curUpdated).UnixNano(),
+			FileMtime:   parseTimestamp(conv.updatedAt).UnixNano(),
 			Fingerprint: shelleyFingerprint(h),
 		})
 	}
 	for rows.Next() {
-		var id, updatedAt, llm, user, usage string
-		var seq int64
+		var rowConv shelleyConversationRow
+		var msg shelleyMessageRow
 		if err := rows.Scan(
-			&id, &updatedAt, &seq, &llm, &user, &usage,
+			&rowConv.conversationID, &rowConv.slug,
+			&rowConv.userInitiated, &rowConv.createdAt,
+			&rowConv.updatedAt, &rowConv.cwd,
+			&rowConv.parentConversationID, &rowConv.model,
+			&msg.sequenceID, &msg.msgType, &msg.llmData,
+			&msg.userData, &msg.usageData, &msg.createdAt,
 		); err != nil {
 			return nil, fmt.Errorf("scanning shelley conversation meta: %w", err)
 		}
-		if id != curID {
+		if rowConv.conversationID != curID {
 			flush()
-			curID, curUpdated, h = id, updatedAt, fnv.New64a()
+			curID, conv, h = rowConv.conversationID, rowConv, fnv.New64a()
+			shelleyDigestConversation(h, conv)
 		}
-		shelleyDigest(h, seq, llm, user, usage)
+		shelleyDigestMessage(h, msg)
 	}
 	flush()
 	return metas, rows.Err()
@@ -303,7 +340,8 @@ func ListShelleyConversationMetas(
 // virtual Shelley source path. Used by the live watcher, which compares it
 // for inequality and treats a zero/error result as "source gone". It
 // returns the conversation's updated_at plus a sub-second term derived
-// from the content digest, so the watcher reacts to same-second edits.
+// from the parser-visible digest, so the watcher reacts to same-second
+// edits.
 // This value is watcher-only and never written to file_mtime or
 // range-filtered, so the sub-second term is harmless here.
 func ShelleySourceMtime(path string) (int64, error) {
@@ -317,12 +355,8 @@ func ShelleySourceMtime(path string) (int64, error) {
 	}
 	defer conn.Close()
 
-	var updatedAt string
-	if err := conn.QueryRow(
-		`SELECT COALESCE(updated_at, '') FROM conversations
-		  WHERE conversation_id = ?`,
-		conversationID,
-	).Scan(&updatedAt); err != nil {
+	conv, err := loadShelleyConversation(conn, conversationID)
+	if err != nil {
 		return 0, fmt.Errorf(
 			"loading shelley conversation mtime %s: %w",
 			conversationID, err,
@@ -330,8 +364,9 @@ func ShelleySourceMtime(path string) (int64, error) {
 	}
 
 	rows, err := conn.Query(
-		`SELECT COALESCE(sequence_id, 0), COALESCE(llm_data, ''),
-		        COALESCE(user_data, ''), COALESCE(usage_data, '')
+		`SELECT COALESCE(sequence_id, 0), COALESCE(type, ''),
+		        COALESCE(llm_data, ''), COALESCE(user_data, ''),
+		        COALESCE(usage_data, ''), COALESCE(created_at, '')
 		   FROM messages WHERE conversation_id = ?
 		  ORDER BY sequence_id`,
 		conversationID,
@@ -343,18 +378,21 @@ func ShelleySourceMtime(path string) (int64, error) {
 	}
 	defer rows.Close()
 	h := fnv.New64a()
+	shelleyDigestConversation(h, conv)
 	for rows.Next() {
-		var seq int64
-		var llm, user, usage string
-		if err := rows.Scan(&seq, &llm, &user, &usage); err != nil {
+		var r shelleyMessageRow
+		if err := rows.Scan(
+			&r.sequenceID, &r.msgType, &r.llmData,
+			&r.userData, &r.usageData, &r.createdAt,
+		); err != nil {
 			return 0, fmt.Errorf("scanning shelley message: %w", err)
 		}
-		shelleyDigest(h, seq, llm, user, usage)
+		shelleyDigestMessage(h, r)
 	}
 	if err := rows.Err(); err != nil {
 		return 0, err
 	}
-	return parseTimestamp(updatedAt).UnixNano() +
+	return parseTimestamp(conv.updatedAt).UnixNano() +
 		int64(h.Sum64()%1_000_000_000), nil
 }
 
@@ -403,9 +441,7 @@ func ParseShelleyConversationFromDB(
 	if err != nil {
 		return nil, err
 	}
-	messages, fingerprint, err := loadShelleyMessages(
-		conn, rawID, conv.model,
-	)
+	messages, fingerprint, err := loadShelleyMessages(conn, conv)
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +497,7 @@ type shelleyMessageRow struct {
 }
 
 func loadShelleyMessages(
-	conn *sql.DB, conversationID, convModel string,
+	conn *sql.DB, conv shelleyConversationRow,
 ) ([]ParsedMessage, string, error) {
 	// All generations are included, ordered by sequence_id. A generation
 	// bump is a context-reset/compaction boundary within the conversation
@@ -475,17 +511,18 @@ func loadShelleyMessages(
 		   FROM messages
 		  WHERE conversation_id = ?
 		  ORDER BY sequence_id ASC`,
-		conversationID,
+		conv.conversationID,
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf(
-			"listing shelley messages for %s: %w", conversationID, err,
+			"listing shelley messages for %s: %w", conv.conversationID, err,
 		)
 	}
 	defer rows.Close()
 
 	var messages []ParsedMessage
 	h := fnv.New64a()
+	shelleyDigestConversation(h, conv)
 	for rows.Next() {
 		var r shelleyMessageRow
 		if err := rows.Scan(
@@ -494,12 +531,12 @@ func loadShelleyMessages(
 		); err != nil {
 			return nil, "", fmt.Errorf("scanning shelley message: %w", err)
 		}
-		// Digest every row (even ones decodeShelleyMessage drops) in
-		// sequence_id order, exactly as ListShelleyConversationMetas does,
-		// so the stored fingerprint matches the meta skip query; a mismatch
-		// would re-parse forever. See shelleyDigest.
-		shelleyDigest(h, r.sequenceID, r.llmData, r.userData, r.usageData)
-		if msg, ok := decodeShelleyMessage(r, convModel); ok {
+		// Digest every parser-observed row field (even for rows
+		// decodeShelleyMessage drops) in sequence_id order, exactly as
+		// ListShelleyConversationMetas does, so the stored fingerprint
+		// matches the meta skip query; a mismatch would re-parse forever.
+		shelleyDigestMessage(h, r)
+		if msg, ok := decodeShelleyMessage(r, conv.model); ok {
 			messages = append(messages, msg)
 		}
 	}

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -5,9 +5,11 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"hash/fnv"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -183,120 +185,127 @@ func ShelleyConversationExists(dbPath, conversationID string) bool {
 type ShelleyConversationMeta struct {
 	RawID       string
 	VirtualPath string
-	// FileMtime is the per-conversation change signal (see
-	// shelleyChangeMtime), not a raw timestamp.
+	// FileMtime is the conversation's updated_at as a nanosecond
+	// timestamp. It stays a real (whole-second) timestamp so the
+	// modified-between range queries that drive PG/DuckDB push never
+	// see a Shelley row as "future"; see shelleyChangeMtime.
 	FileMtime int64
+	// Fingerprint is a content digest over the conversation's messages.
+	// It is stored in file_hash and compared in the sync skip to catch
+	// same-second changes FileMtime's second precision cannot; see
+	// shelleyDigest.
+	Fingerprint string
 }
 
-// shelleyContentBytesExpr is a correlated subquery that sums the byte
-// length of every message payload in a conversation. CAST(... AS BLOB)
-// makes LENGTH count bytes rather than UTF-8 characters, so the result
-// matches Go's len() over the same COALESCE'd columns loadShelleyMessages
-// reads. It references the conversations alias "c" and is shared by the
-// meta and single-conversation queries; see shelleyChangeMtime.
-const shelleyContentBytesExpr = `COALESCE((SELECT SUM(
-	        LENGTH(CAST(COALESCE(m.llm_data, '') AS BLOB)) +
-	        LENGTH(CAST(COALESCE(m.user_data, '') AS BLOB)) +
-	        LENGTH(CAST(COALESCE(m.usage_data, '') AS BLOB)))
-	   FROM messages m
-	  WHERE m.conversation_id = c.conversation_id), 0)`
-
-// shelleyChangeMtime derives the per-conversation change signal stored as
-// File.Mtime from three quantities: updated_at (whole-second precision,
-// since Shelley writes it as SQLite CURRENT_TIMESTAMP), the conversation's
-// max message sequence_id, and the total byte length of its message
-// payloads. updated_at sets the whole-second base; maxSeq and contentBytes
-// are mixed into a sub-second offset by shelleyChangeOffset.
+// Shelley change detection uses two per-conversation signals, because
+// Shelley's updated_at is only whole-second precision (it writes it as
+// SQLite CURRENT_TIMESTAMP) and so cannot, on its own, distinguish two
+// writes in the same wall-clock second:
 //
-// Each input closes a gap the others cannot:
-//   - updated_at alone has second precision, so two writes in the same
-//     wall-clock second are indistinguishable.
-//   - maxSeq is Shelley's monotonic, append-only cursor (it powers the
-//     incremental-fetch protocol), so it detects same-second appends.
-//   - contentBytes detects a same-second in-place rewrite of an existing
-//     row -- where updated_at stays in the same second and no row is
-//     appended (maxSeq unchanged) -- because any edit that changes a
-//     payload's length changes the sum. The meta query computes it in
-//     SQLite (no payload transfer) and the parse loop sums the same bytes
-//     it already reads, so the two sides match exactly.
+//   - File.Mtime / ShelleyConversationMeta.FileMtime is the conversation's
+//     updated_at as a real nanosecond timestamp. The sync skip compares it
+//     for equality, but it must also stay a true timestamp because
+//     ListSessionsModifiedBetween filters file_mtime <= now for PG/DuckDB
+//     push; a synthetic future value would drop a just-synced Shelley row
+//     from a same-second push until a later run.
+//   - Fingerprint, a content digest stored in file_hash, distinguishes any
+//     same-second change the timestamp cannot: appends, in-place rewrites,
+//     and even length-preserving edits (shelleyDigest length-frames each
+//     field). The skip re-parses whenever it differs.
 //
-// The offset is a hash of the (maxSeq, contentBytes) pair, not their sum,
-// so the two cannot cancel: a plain additive fold would collide when one
-// rises by k while the other falls by k (e.g. +1 sequence_id, -1 byte).
-// Folding the hash into [0, 1s) keeps File.Mtime within the source's
-// reported second, so it stays a valid nanosecond timestamp for the
-// range queries in ListSessionsModifiedBetween. The residual gap is a
-// same-second change whose (maxSeq, contentBytes) pair hashes to the same
-// sub-second offset (~1e-9), plus a length-preserving in-place edit with
-// no append -- neither of which real conversation edits produce.
+// Computing the digest means reading message payloads, which the cheaper
+// siblings (Zed, Kiro) avoid because their sub-second / millisecond
+// updated_at already distinguishes same-second writes. Shelley's
+// second-precision timestamp does not, so the content read is the price of
+// not silently skipping a rewrite.
 //
-// This is a deliberate, documented divergence from the otherwise-mirrored
-// Zed parser: Zed's updated_at is sub-second RFC3339, so its skip signal
-// is already collision-free; Shelley's second-precision updated_at is not.
-func shelleyChangeMtime(updatedAtNanos, maxSeq, contentBytes int64) int64 {
-	return updatedAtNanos + shelleyChangeOffset(maxSeq, contentBytes)
+// shelleyDigest folds one message row into a running FNV-1a hash. The
+// sequence_id and per-field length prefixes make the digest sensitive to
+// row identity and field boundaries, so moving bytes between fields (a
+// length-preserving edit) still changes it. Callers must feed rows in a
+// fixed order (sequence_id ascending) so the parse and skip paths agree.
+func shelleyDigest(h hash.Hash64, seq int64, llm, user, usage string) {
+	var n [8]byte
+	binary.LittleEndian.PutUint64(n[:], uint64(seq))
+	_, _ = h.Write(n[:])
+	for _, s := range []string{llm, user, usage} {
+		binary.LittleEndian.PutUint64(n[:], uint64(len(s)))
+		_, _ = h.Write(n[:])
+		_, _ = h.Write([]byte(s))
+	}
 }
 
-// shelleyChangeOffset mixes a conversation's max sequence_id and total
-// payload byte length into a sub-second nanosecond offset in [0, 1e9).
-// FNV-1a over both values means a change in either shifts the offset
-// without the additive cancellation a plain sum allows; see
-// shelleyChangeMtime.
-func shelleyChangeOffset(maxSeq, contentBytes int64) int64 {
-	var buf [16]byte
-	binary.LittleEndian.PutUint64(buf[0:8], uint64(maxSeq))
-	binary.LittleEndian.PutUint64(buf[8:16], uint64(contentBytes))
-	h := fnv.New64a()
-	_, _ = h.Write(buf[:])
-	return int64(h.Sum64() % 1_000_000_000)
+// shelleyFingerprint renders a content-digest hash as the stable string
+// stored in file_hash and compared by the sync skip.
+func shelleyFingerprint(h hash.Hash64) string {
+	return strconv.FormatUint(h.Sum64(), 16)
 }
 
-// ListShelleyConversationMetas queries conversation IDs, updated_at
-// timestamps, and max message sequence_id using an already-open
-// connection, sharing it with the subsequent parse loop to avoid a second
-// DB open.
+// ListShelleyConversationMetas returns the skip state for every
+// conversation: its updated_at timestamp (FileMtime) and a content digest
+// (Fingerprint). It scans message payloads ordered by conversation and
+// sequence_id, hashing each conversation's rows the same way the parse
+// loop does, so the meta digest and the stored file_hash match for
+// unchanged conversations. It shares the caller's open connection.
 func ListShelleyConversationMetas(
 	conn *sql.DB, dbPath string,
 ) ([]ShelleyConversationMeta, error) {
 	rows, err := conn.Query(
-		`SELECT c.conversation_id, COALESCE(c.updated_at, ''),
-		        COALESCE((SELECT MAX(m.sequence_id) FROM messages m
-		                   WHERE m.conversation_id = c.conversation_id), 0),
-		        ` + shelleyContentBytesExpr + `
+		`SELECT m.conversation_id, COALESCE(c.updated_at, ''),
+		        COALESCE(m.sequence_id, 0), COALESCE(m.llm_data, ''),
+		        COALESCE(m.user_data, ''), COALESCE(m.usage_data, '')
 		   FROM conversations c
-		  ORDER BY c.updated_at, c.conversation_id`,
+		   JOIN messages m ON m.conversation_id = c.conversation_id
+		  ORDER BY m.conversation_id, m.sequence_id`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing shelley conversations: %w", err)
 	}
 	defer rows.Close()
 
-	var metas []ShelleyConversationMeta
-	for rows.Next() {
-		var id, updatedAt string
-		var maxSeq, contentBytes int64
-		if err := rows.Scan(&id, &updatedAt, &maxSeq, &contentBytes); err != nil {
-			return nil, fmt.Errorf("scanning shelley conversation meta: %w", err)
-		}
-		if !IsValidSessionID(id) {
-			continue
+	var (
+		metas      []ShelleyConversationMeta
+		curID      string
+		curUpdated string
+	)
+	h := fnv.New64a()
+	flush := func() {
+		// curID is "" before the first row; IsValidSessionID rejects it.
+		if !IsValidSessionID(curID) {
+			return
 		}
 		metas = append(metas, ShelleyConversationMeta{
-			RawID:       id,
-			VirtualPath: ShelleyVirtualPath(dbPath, id),
-			FileMtime: shelleyChangeMtime(
-				parseTimestamp(updatedAt).UnixNano(), maxSeq, contentBytes,
-			),
+			RawID:       curID,
+			VirtualPath: ShelleyVirtualPath(dbPath, curID),
+			FileMtime:   parseTimestamp(curUpdated).UnixNano(),
+			Fingerprint: shelleyFingerprint(h),
 		})
 	}
+	for rows.Next() {
+		var id, updatedAt, llm, user, usage string
+		var seq int64
+		if err := rows.Scan(
+			&id, &updatedAt, &seq, &llm, &user, &usage,
+		); err != nil {
+			return nil, fmt.Errorf("scanning shelley conversation meta: %w", err)
+		}
+		if id != curID {
+			flush()
+			curID, curUpdated, h = id, updatedAt, fnv.New64a()
+		}
+		shelleyDigest(h, seq, llm, user, usage)
+	}
+	flush()
 	return metas, rows.Err()
 }
 
 // ShelleySourceMtime resolves the per-conversation change signal for a
-// virtual Shelley source path. Used by the per-session live watcher,
-// which treats a zero result as "source gone", so this returns the same
-// updated_at / max(sequence_id) / content-bytes signal as the stored
-// FileMtime (see shelleyChangeMtime).
+// virtual Shelley source path. Used by the live watcher, which compares it
+// for inequality and treats a zero/error result as "source gone". It
+// returns the conversation's updated_at plus a sub-second term derived
+// from the content digest, so the watcher reacts to same-second edits.
+// This value is watcher-only and never written to file_mtime or
+// range-filtered, so the sub-second term is harmless here.
 func ShelleySourceMtime(path string) (int64, error) {
 	dbPath, conversationID, ok := ParseShelleyVirtualPath(path)
 	if !ok {
@@ -309,25 +318,44 @@ func ShelleySourceMtime(path string) (int64, error) {
 	defer conn.Close()
 
 	var updatedAt string
-	var maxSeq, contentBytes int64
-	err = conn.QueryRow(
-		`SELECT COALESCE(c.updated_at, ''),
-		        COALESCE((SELECT MAX(m.sequence_id) FROM messages m
-		                   WHERE m.conversation_id = c.conversation_id), 0),
-		        `+shelleyContentBytesExpr+`
-		   FROM conversations c
-		  WHERE c.conversation_id = ?`,
+	if err := conn.QueryRow(
+		`SELECT COALESCE(updated_at, '') FROM conversations
+		  WHERE conversation_id = ?`,
 		conversationID,
-	).Scan(&updatedAt, &maxSeq, &contentBytes)
-	if err != nil {
+	).Scan(&updatedAt); err != nil {
 		return 0, fmt.Errorf(
 			"loading shelley conversation mtime %s: %w",
 			conversationID, err,
 		)
 	}
-	return shelleyChangeMtime(
-		parseTimestamp(updatedAt).UnixNano(), maxSeq, contentBytes,
-	), nil
+
+	rows, err := conn.Query(
+		`SELECT COALESCE(sequence_id, 0), COALESCE(llm_data, ''),
+		        COALESCE(user_data, ''), COALESCE(usage_data, '')
+		   FROM messages WHERE conversation_id = ?
+		  ORDER BY sequence_id`,
+		conversationID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"loading shelley messages %s: %w", conversationID, err,
+		)
+	}
+	defer rows.Close()
+	h := fnv.New64a()
+	for rows.Next() {
+		var seq int64
+		var llm, user, usage string
+		if err := rows.Scan(&seq, &llm, &user, &usage); err != nil {
+			return 0, fmt.Errorf("scanning shelley message: %w", err)
+		}
+		shelleyDigest(h, seq, llm, user, usage)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return parseTimestamp(updatedAt).UnixNano() +
+		int64(h.Sum64()%1_000_000_000), nil
 }
 
 // OpenShelleyDB opens the Shelley shelley.db file read-only. Callers are
@@ -375,14 +403,14 @@ func ParseShelleyConversationFromDB(
 	if err != nil {
 		return nil, err
 	}
-	messages, maxSeq, contentBytes, err := loadShelleyMessages(
+	messages, fingerprint, err := loadShelleyMessages(
 		conn, rawID, conv.model,
 	)
 	if err != nil {
 		return nil, err
 	}
 	result, ok := buildShelleyParseResult(
-		conv, messages, maxSeq, contentBytes, dbPath, dbInfo, machine,
+		conv, messages, fingerprint, dbPath, dbInfo, machine,
 	)
 	if !ok {
 		return nil, nil
@@ -434,7 +462,7 @@ type shelleyMessageRow struct {
 
 func loadShelleyMessages(
 	conn *sql.DB, conversationID, convModel string,
-) ([]ParsedMessage, int64, int64, error) {
+) ([]ParsedMessage, string, error) {
 	// All generations are included, ordered by sequence_id. A generation
 	// bump is a context-reset/compaction boundary within the conversation
 	// (e.g. distillation); older-generation rows remain as real history
@@ -450,36 +478,35 @@ func loadShelleyMessages(
 		conversationID,
 	)
 	if err != nil {
-		return nil, 0, 0, fmt.Errorf(
+		return nil, "", fmt.Errorf(
 			"listing shelley messages for %s: %w", conversationID, err,
 		)
 	}
 	defer rows.Close()
 
 	var messages []ParsedMessage
-	var maxSeq, contentBytes int64
+	h := fnv.New64a()
 	for rows.Next() {
 		var r shelleyMessageRow
 		if err := rows.Scan(
 			&r.sequenceID, &r.msgType, &r.llmData,
 			&r.userData, &r.usageData, &r.createdAt,
 		); err != nil {
-			return nil, 0, 0, fmt.Errorf("scanning shelley message: %w", err)
+			return nil, "", fmt.Errorf("scanning shelley message: %w", err)
 		}
-		// Track max sequence_id and total payload bytes over ALL rows (even
-		// ones decodeShelleyMessage drops) so the change signal matches the
-		// MAX(sequence_id) and byte-sum the meta query computes; a mismatch
-		// would re-parse forever. len() counts bytes, matching the meta
-		// query's LENGTH(CAST(... AS BLOB)); see shelleyChangeMtime.
-		if r.sequenceID > maxSeq {
-			maxSeq = r.sequenceID
-		}
-		contentBytes += int64(len(r.llmData) + len(r.userData) + len(r.usageData))
+		// Digest every row (even ones decodeShelleyMessage drops) in
+		// sequence_id order, exactly as ListShelleyConversationMetas does,
+		// so the stored fingerprint matches the meta skip query; a mismatch
+		// would re-parse forever. See shelleyDigest.
+		shelleyDigest(h, r.sequenceID, r.llmData, r.userData, r.usageData)
 		if msg, ok := decodeShelleyMessage(r, convModel); ok {
 			messages = append(messages, msg)
 		}
 	}
-	return messages, maxSeq, contentBytes, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+	return messages, shelleyFingerprint(h), nil
 }
 
 func decodeShelleyMessage(
@@ -711,7 +738,7 @@ func shelleyTokenCount(n json.Number) int {
 func buildShelleyParseResult(
 	conv shelleyConversationRow,
 	messages []ParsedMessage,
-	maxSeq, contentBytes int64,
+	fingerprint string,
 	dbPath string,
 	info os.FileInfo,
 	machine string,
@@ -790,7 +817,8 @@ func buildShelleyParseResult(
 		File: FileInfo{
 			Path:  ShelleyVirtualPath(dbPath, conv.conversationID),
 			Size:  info.Size(),
-			Mtime: shelleyChangeMtime(endedAt.UnixNano(), maxSeq, contentBytes),
+			Mtime: endedAt.UnixNano(),
+			Hash:  fingerprint,
 		},
 	}
 	if parent := strings.TrimSpace(conv.parentConversationID); parent != "" {

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -500,7 +500,9 @@ func shelleyToolInput(raw json.RawMessage) string {
 
 // shelleyToolResultText flattens the nested tool_result content blocks
 // into a single string that DecodeContent can later decode via its
-// string branch.
+// string branch. Blocks are joined with newlines so multiple results
+// (notably web_search_result lists) stay readable instead of running
+// together.
 func shelleyToolResultText(blocks []shelleyContent) string {
 	var parts []string
 	for _, b := range blocks {
@@ -508,10 +510,20 @@ func shelleyToolResultText(blocks []shelleyContent) string {
 		case b.Text != "":
 			parts = append(parts, b.Text)
 		case len(b.ToolResult) > 0:
-			parts = append(parts, shelleyToolResultText(b.ToolResult))
+			if nested := shelleyToolResultText(b.ToolResult); nested != "" {
+				parts = append(parts, nested)
+			}
+		case b.Title != "" || b.URL != "":
+			// web_search_result blocks (inside a web_search_tool_result)
+			// carry their payload in Title/URL rather than Text. Without
+			// this branch the whole result would be stored empty and the
+			// carrier message could be dropped.
+			if label := strings.TrimSpace(b.Title + " " + b.URL); label != "" {
+				parts = append(parts, label)
+			}
 		}
 	}
-	return strings.Join(parts, "")
+	return strings.Join(parts, "\n")
 }
 
 // shelleyUserDataText best-effort extracts displayable text from a

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -315,9 +315,10 @@ func ListShelleyConversationMetas(
 	for rows.Next() {
 		var rowConv shelleyConversationRow
 		var msg shelleyMessageRow
+		var userInitiated int64
 		if err := rows.Scan(
 			&rowConv.conversationID, &rowConv.slug,
-			&rowConv.userInitiated, &rowConv.createdAt,
+			&userInitiated, &rowConv.createdAt,
 			&rowConv.updatedAt, &rowConv.cwd,
 			&rowConv.parentConversationID, &rowConv.model,
 			&msg.sequenceID, &msg.msgType, &msg.llmData,
@@ -325,6 +326,7 @@ func ListShelleyConversationMetas(
 		); err != nil {
 			return nil, fmt.Errorf("scanning shelley conversation meta: %w", err)
 		}
+		rowConv.userInitiated = userInitiated != 0
 		if rowConv.conversationID != curID {
 			flush()
 			curID, conv, h = rowConv.conversationID, rowConv, fnv.New64a()
@@ -469,6 +471,7 @@ func loadShelleyConversation(
 	conn *sql.DB, conversationID string,
 ) (shelleyConversationRow, error) {
 	row := shelleyConversationRow{conversationID: conversationID}
+	var userInitiated int64
 	err := conn.QueryRow(
 		`SELECT COALESCE(slug, ''), COALESCE(user_initiated, 1),
 		        COALESCE(created_at, ''), COALESCE(updated_at, ''),
@@ -478,12 +481,13 @@ func loadShelleyConversation(
 		  WHERE conversation_id = ?`,
 		conversationID,
 	).Scan(
-		&row.slug, &row.userInitiated, &row.createdAt, &row.updatedAt,
+		&row.slug, &userInitiated, &row.createdAt, &row.updatedAt,
 		&row.cwd, &row.parentConversationID, &row.model,
 	)
 	if err != nil {
 		return shelleyConversationRow{}, err
 	}
+	row.userInitiated = userInitiated != 0
 	return row, nil
 }
 

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -622,11 +622,6 @@ func decodeShelleyMessage(
 		content = shelleyUserDataText(r.userData)
 	}
 
-	if content == "" && thinking == "" &&
-		len(toolCalls) == 0 && len(toolResults) == 0 {
-		return ParsedMessage{}, false
-	}
-
 	msg := ParsedMessage{
 		Ordinal:       int(r.sequenceID),
 		Role:          role,
@@ -647,6 +642,13 @@ func decodeShelleyMessage(
 	// usage blobs Shelley writes for user/tool messages.
 	if r.usageData != "" {
 		applyShelleyUsage(&msg, r.usageData, convModel)
+	}
+	if content == "" && thinking == "" &&
+		len(toolCalls) == 0 && len(toolResults) == 0 {
+		if !msg.HasContextTokens && !msg.HasOutputTokens {
+			return ParsedMessage{}, false
+		}
+		msg.IsSystem = true
 	}
 	return msg, true
 }

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -45,12 +45,12 @@ const (
 	shelleyContentWebSearchResult     = 7
 )
 
-// Shelley message-table row types.
+// Shelley message-table row types. Other types (system, error,
+// gitinfo) are handled by the default branch in decodeShelleyMessage.
 const (
-	shelleyTypeUser   = "user"
-	shelleyTypeAgent  = "agent"
-	shelleyTypeTool   = "tool"
-	shelleyTypeSystem = "system"
+	shelleyTypeUser  = "user"
+	shelleyTypeAgent = "agent"
+	shelleyTypeTool  = "tool"
 )
 
 // shelleyLLMMessage mirrors the serialized llm.Message stored in the
@@ -215,6 +215,37 @@ func ListShelleyConversationMetas(
 	return metas, rows.Err()
 }
 
+// ShelleySourceMtime resolves the per-conversation updated_at timestamp
+// for a virtual Shelley source path. Used by the per-session live
+// watcher, which treats a zero result as "source gone", so this returns
+// the conversation's updated_at consistent with the stored FileMtime.
+func ShelleySourceMtime(path string) (int64, error) {
+	dbPath, conversationID, ok := ParseShelleyVirtualPath(path)
+	if !ok {
+		return 0, fmt.Errorf("not a shelley virtual path: %s", path)
+	}
+	conn, err := openShelleyDB(dbPath)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+
+	var updatedAt string
+	err = conn.QueryRow(
+		`SELECT COALESCE(updated_at, '')
+		   FROM conversations
+		  WHERE conversation_id = ?`,
+		conversationID,
+	).Scan(&updatedAt)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"loading shelley conversation mtime %s: %w",
+			conversationID, err,
+		)
+	}
+	return parseTimestamp(updatedAt).UnixNano(), nil
+}
+
 // OpenShelleyDB opens the Shelley shelley.db file read-only. Callers are
 // responsible for calling Close on the returned *sql.DB.
 func OpenShelleyDB(dbPath string) (*sql.DB, error) {
@@ -356,7 +387,7 @@ func loadShelleyMessages(
 func decodeShelleyMessage(
 	r shelleyMessageRow, convModel string,
 ) (ParsedMessage, bool) {
-	role := RoleUser
+	var role RoleType
 	isSystem := false
 	switch r.msgType {
 	case shelleyTypeAgent:
@@ -444,7 +475,11 @@ func decodeShelleyMessage(
 		Timestamp:     parseTimestamp(r.createdAt),
 	}
 
-	if role == RoleAssistant && r.usageData != "" {
+	// Apply usage for any row that carries it, not just agent rows:
+	// Shelley records token usage on errored assistant turns too (stored
+	// as type="error"), and applyShelleyUsage no-ops on the all-zero
+	// usage blobs Shelley writes for user/tool messages.
+	if r.usageData != "" {
 		applyShelleyUsage(&msg, r.usageData, convModel)
 	}
 	return msg, true
@@ -510,8 +545,21 @@ func applyShelleyUsage(msg *ParsedMessage, usageData, convModel string) {
 		shelleyTokenCount(u.CacheReadInputTokens)
 	output := shelleyTokenCount(u.OutputTokens)
 
+	// Shelley writes an all-zero usage blob on user/tool rows; skip those
+	// so they do not produce spurious token-presence flags or empty
+	// token_usage rows in the cost UNION.
+	if context == 0 && output == 0 {
+		return
+	}
+
 	// The usage_data keys are already the AgentsView canonical names, so
 	// the raw blob is stored verbatim for catalog cost pricing.
+	//
+	// usage_data also carries an exact gateway cost_usd. It is not yet
+	// surfaced: capturing it cleanly (without double-counting cost
+	// against the catalog-priced per-message tokens) needs a dedicated
+	// usage-event path and is left as a follow-up. Standard gateway
+	// models are priced correctly by the catalog today.
 	msg.TokenUsage = json.RawMessage(usageData)
 	msg.ContextTokens = context
 	msg.OutputTokens = output

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -186,23 +186,51 @@ type ShelleyConversationMeta struct {
 	FileMtime int64
 }
 
-// shelleyChangeMtime combines a conversation's updated_at (whole-second
-// precision: Shelley writes it as SQLite CURRENT_TIMESTAMP) with the
-// conversation's max message sequence_id into the per-conversation change
-// signal stored as File.Mtime. sequence_id is Shelley's own monotonic,
-// append-only cursor -- it powers Shelley's incremental-fetch protocol --
-// so adding it lets the sync engine detect conversations that changed
-// within the same wall-clock second, which updated_at alone cannot
-// distinguish. Both inputs are monotonic non-decreasing, so the sum
-// strictly increases on any real change and never collides for a given
-// conversation. Drift from the true timestamp is at most maxSeq
-// nanoseconds (sub-millisecond), so File.Mtime stays a valid timestamp.
+// shelleyContentBytesExpr is a correlated subquery that sums the byte
+// length of every message payload in a conversation. CAST(... AS BLOB)
+// makes LENGTH count bytes rather than UTF-8 characters, so the result
+// matches Go's len() over the same COALESCE'd columns loadShelleyMessages
+// reads. It references the conversations alias "c" and is shared by the
+// meta and single-conversation queries; see shelleyChangeMtime.
+const shelleyContentBytesExpr = `COALESCE((SELECT SUM(
+	        LENGTH(CAST(COALESCE(m.llm_data, '') AS BLOB)) +
+	        LENGTH(CAST(COALESCE(m.user_data, '') AS BLOB)) +
+	        LENGTH(CAST(COALESCE(m.usage_data, '') AS BLOB)))
+	   FROM messages m
+	  WHERE m.conversation_id = c.conversation_id), 0)`
+
+// shelleyChangeMtime combines three per-conversation quantities into the
+// change signal stored as File.Mtime: updated_at (whole-second precision,
+// since Shelley writes it as SQLite CURRENT_TIMESTAMP), the conversation's
+// max message sequence_id, and the total byte length of its message
+// payloads. The signal is only ever compared for equality (the sync skip
+// check) or inequality (the live watcher), so it is a change detector, not
+// an exact timestamp.
+//
+// Each component closes a gap the others cannot:
+//   - updated_at alone has second precision, so two writes in the same
+//     wall-clock second are indistinguishable.
+//   - maxSeq is Shelley's monotonic, append-only cursor (it powers the
+//     incremental-fetch protocol), so it detects same-second appends.
+//   - contentBytes detects a same-second in-place rewrite of an existing
+//     row -- where updated_at stays in the same second and no row is
+//     appended (maxSeq unchanged) -- because any edit that changes a
+//     payload's length changes the sum. The meta query computes it in
+//     SQLite (no payload transfer) and the parse loop sums the same bytes
+//     it already reads, so the two sides match exactly. The residual gap
+//     is a length-preserving same-second in-place edit with no append,
+//     which real content rewrites essentially never produce.
+//
+// Drift from the true timestamp is at most maxSeq + contentBytes
+// nanoseconds (well under a second for any real conversation), and
+// File.Mtime is never surfaced as a user-facing time, so this stays a
+// valid change signal.
 //
 // This is a deliberate, documented divergence from the otherwise-mirrored
 // Zed parser: Zed's updated_at is sub-second RFC3339, so its skip signal
 // is already collision-free; Shelley's second-precision updated_at is not.
-func shelleyChangeMtime(updatedAtNanos, maxSeq int64) int64 {
-	return updatedAtNanos + maxSeq
+func shelleyChangeMtime(updatedAtNanos, maxSeq, contentBytes int64) int64 {
+	return updatedAtNanos + maxSeq + contentBytes
 }
 
 // ListShelleyConversationMetas queries conversation IDs, updated_at
@@ -215,7 +243,8 @@ func ListShelleyConversationMetas(
 	rows, err := conn.Query(
 		`SELECT c.conversation_id, COALESCE(c.updated_at, ''),
 		        COALESCE((SELECT MAX(m.sequence_id) FROM messages m
-		                   WHERE m.conversation_id = c.conversation_id), 0)
+		                   WHERE m.conversation_id = c.conversation_id), 0),
+		        ` + shelleyContentBytesExpr + `
 		   FROM conversations c
 		  ORDER BY c.updated_at, c.conversation_id`,
 	)
@@ -227,8 +256,8 @@ func ListShelleyConversationMetas(
 	var metas []ShelleyConversationMeta
 	for rows.Next() {
 		var id, updatedAt string
-		var maxSeq int64
-		if err := rows.Scan(&id, &updatedAt, &maxSeq); err != nil {
+		var maxSeq, contentBytes int64
+		if err := rows.Scan(&id, &updatedAt, &maxSeq, &contentBytes); err != nil {
 			return nil, fmt.Errorf("scanning shelley conversation meta: %w", err)
 		}
 		if !IsValidSessionID(id) {
@@ -238,7 +267,7 @@ func ListShelleyConversationMetas(
 			RawID:       id,
 			VirtualPath: ShelleyVirtualPath(dbPath, id),
 			FileMtime: shelleyChangeMtime(
-				parseTimestamp(updatedAt).UnixNano(), maxSeq,
+				parseTimestamp(updatedAt).UnixNano(), maxSeq, contentBytes,
 			),
 		})
 	}
@@ -262,22 +291,25 @@ func ShelleySourceMtime(path string) (int64, error) {
 	defer conn.Close()
 
 	var updatedAt string
-	var maxSeq int64
+	var maxSeq, contentBytes int64
 	err = conn.QueryRow(
 		`SELECT COALESCE(c.updated_at, ''),
 		        COALESCE((SELECT MAX(m.sequence_id) FROM messages m
-		                   WHERE m.conversation_id = c.conversation_id), 0)
+		                   WHERE m.conversation_id = c.conversation_id), 0),
+		        `+shelleyContentBytesExpr+`
 		   FROM conversations c
 		  WHERE c.conversation_id = ?`,
 		conversationID,
-	).Scan(&updatedAt, &maxSeq)
+	).Scan(&updatedAt, &maxSeq, &contentBytes)
 	if err != nil {
 		return 0, fmt.Errorf(
 			"loading shelley conversation mtime %s: %w",
 			conversationID, err,
 		)
 	}
-	return shelleyChangeMtime(parseTimestamp(updatedAt).UnixNano(), maxSeq), nil
+	return shelleyChangeMtime(
+		parseTimestamp(updatedAt).UnixNano(), maxSeq, contentBytes,
+	), nil
 }
 
 // OpenShelleyDB opens the Shelley shelley.db file read-only. Callers are
@@ -325,12 +357,14 @@ func ParseShelleyConversationFromDB(
 	if err != nil {
 		return nil, err
 	}
-	messages, maxSeq, err := loadShelleyMessages(conn, rawID, conv.model)
+	messages, maxSeq, contentBytes, err := loadShelleyMessages(
+		conn, rawID, conv.model,
+	)
 	if err != nil {
 		return nil, err
 	}
 	result, ok := buildShelleyParseResult(
-		conv, messages, maxSeq, dbPath, dbInfo, machine,
+		conv, messages, maxSeq, contentBytes, dbPath, dbInfo, machine,
 	)
 	if !ok {
 		return nil, nil
@@ -382,7 +416,7 @@ type shelleyMessageRow struct {
 
 func loadShelleyMessages(
 	conn *sql.DB, conversationID, convModel string,
-) ([]ParsedMessage, int64, error) {
+) ([]ParsedMessage, int64, int64, error) {
 	// All generations are included, ordered by sequence_id. A generation
 	// bump is a context-reset/compaction boundary within the conversation
 	// (e.g. distillation); older-generation rows remain as real history
@@ -398,33 +432,36 @@ func loadShelleyMessages(
 		conversationID,
 	)
 	if err != nil {
-		return nil, 0, fmt.Errorf(
+		return nil, 0, 0, fmt.Errorf(
 			"listing shelley messages for %s: %w", conversationID, err,
 		)
 	}
 	defer rows.Close()
 
 	var messages []ParsedMessage
-	var maxSeq int64
+	var maxSeq, contentBytes int64
 	for rows.Next() {
 		var r shelleyMessageRow
 		if err := rows.Scan(
 			&r.sequenceID, &r.msgType, &r.llmData,
 			&r.userData, &r.usageData, &r.createdAt,
 		); err != nil {
-			return nil, 0, fmt.Errorf("scanning shelley message: %w", err)
+			return nil, 0, 0, fmt.Errorf("scanning shelley message: %w", err)
 		}
-		// Track max sequence_id over ALL rows (even ones decodeShelleyMessage
-		// drops) so the change signal matches ListShelleyConversationMetas'
-		// MAX(sequence_id) query exactly; a mismatch would re-parse forever.
+		// Track max sequence_id and total payload bytes over ALL rows (even
+		// ones decodeShelleyMessage drops) so the change signal matches the
+		// MAX(sequence_id) and byte-sum the meta query computes; a mismatch
+		// would re-parse forever. len() counts bytes, matching the meta
+		// query's LENGTH(CAST(... AS BLOB)); see shelleyChangeMtime.
 		if r.sequenceID > maxSeq {
 			maxSeq = r.sequenceID
 		}
+		contentBytes += int64(len(r.llmData) + len(r.userData) + len(r.usageData))
 		if msg, ok := decodeShelleyMessage(r, convModel); ok {
 			messages = append(messages, msg)
 		}
 	}
-	return messages, maxSeq, rows.Err()
+	return messages, maxSeq, contentBytes, rows.Err()
 }
 
 func decodeShelleyMessage(
@@ -656,7 +693,7 @@ func shelleyTokenCount(n json.Number) int {
 func buildShelleyParseResult(
 	conv shelleyConversationRow,
 	messages []ParsedMessage,
-	maxSeq int64,
+	maxSeq, contentBytes int64,
 	dbPath string,
 	info os.FileInfo,
 	machine string,
@@ -735,7 +772,7 @@ func buildShelleyParseResult(
 		File: FileInfo{
 			Path:  ShelleyVirtualPath(dbPath, conv.conversationID),
 			Size:  info.Size(),
-			Mtime: shelleyChangeMtime(endedAt.UnixNano(), maxSeq),
+			Mtime: shelleyChangeMtime(endedAt.UnixNano(), maxSeq, contentBytes),
 		},
 	}
 	if parent := strings.TrimSpace(conv.parentConversationID); parent != "" {

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -2,8 +2,10 @@ package parser
 
 import (
 	"database/sql"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -199,15 +201,14 @@ const shelleyContentBytesExpr = `COALESCE((SELECT SUM(
 	   FROM messages m
 	  WHERE m.conversation_id = c.conversation_id), 0)`
 
-// shelleyChangeMtime combines three per-conversation quantities into the
-// change signal stored as File.Mtime: updated_at (whole-second precision,
+// shelleyChangeMtime derives the per-conversation change signal stored as
+// File.Mtime from three quantities: updated_at (whole-second precision,
 // since Shelley writes it as SQLite CURRENT_TIMESTAMP), the conversation's
 // max message sequence_id, and the total byte length of its message
-// payloads. The signal is only ever compared for equality (the sync skip
-// check) or inequality (the live watcher), so it is a change detector, not
-// an exact timestamp.
+// payloads. updated_at sets the whole-second base; maxSeq and contentBytes
+// are mixed into a sub-second offset by shelleyChangeOffset.
 //
-// Each component closes a gap the others cannot:
+// Each input closes a gap the others cannot:
 //   - updated_at alone has second precision, so two writes in the same
 //     wall-clock second are indistinguishable.
 //   - maxSeq is Shelley's monotonic, append-only cursor (it powers the
@@ -217,20 +218,37 @@ const shelleyContentBytesExpr = `COALESCE((SELECT SUM(
 //     appended (maxSeq unchanged) -- because any edit that changes a
 //     payload's length changes the sum. The meta query computes it in
 //     SQLite (no payload transfer) and the parse loop sums the same bytes
-//     it already reads, so the two sides match exactly. The residual gap
-//     is a length-preserving same-second in-place edit with no append,
-//     which real content rewrites essentially never produce.
+//     it already reads, so the two sides match exactly.
 //
-// Drift from the true timestamp is at most maxSeq + contentBytes
-// nanoseconds (well under a second for any real conversation), and
-// File.Mtime is never surfaced as a user-facing time, so this stays a
-// valid change signal.
+// The offset is a hash of the (maxSeq, contentBytes) pair, not their sum,
+// so the two cannot cancel: a plain additive fold would collide when one
+// rises by k while the other falls by k (e.g. +1 sequence_id, -1 byte).
+// Folding the hash into [0, 1s) keeps File.Mtime within the source's
+// reported second, so it stays a valid nanosecond timestamp for the
+// range queries in ListSessionsModifiedBetween. The residual gap is a
+// same-second change whose (maxSeq, contentBytes) pair hashes to the same
+// sub-second offset (~1e-9), plus a length-preserving in-place edit with
+// no append -- neither of which real conversation edits produce.
 //
 // This is a deliberate, documented divergence from the otherwise-mirrored
 // Zed parser: Zed's updated_at is sub-second RFC3339, so its skip signal
 // is already collision-free; Shelley's second-precision updated_at is not.
 func shelleyChangeMtime(updatedAtNanos, maxSeq, contentBytes int64) int64 {
-	return updatedAtNanos + maxSeq + contentBytes
+	return updatedAtNanos + shelleyChangeOffset(maxSeq, contentBytes)
+}
+
+// shelleyChangeOffset mixes a conversation's max sequence_id and total
+// payload byte length into a sub-second nanosecond offset in [0, 1e9).
+// FNV-1a over both values means a change in either shifts the offset
+// without the additive cancellation a plain sum allows; see
+// shelleyChangeMtime.
+func shelleyChangeOffset(maxSeq, contentBytes int64) int64 {
+	var buf [16]byte
+	binary.LittleEndian.PutUint64(buf[0:8], uint64(maxSeq))
+	binary.LittleEndian.PutUint64(buf[8:16], uint64(contentBytes))
+	h := fnv.New64a()
+	_, _ = h.Write(buf[:])
+	return int64(h.Sum64() % 1_000_000_000)
 }
 
 // ListShelleyConversationMetas queries conversation IDs, updated_at
@@ -277,8 +295,8 @@ func ListShelleyConversationMetas(
 // ShelleySourceMtime resolves the per-conversation change signal for a
 // virtual Shelley source path. Used by the per-session live watcher,
 // which treats a zero result as "source gone", so this returns the same
-// updated_at + max(sequence_id) composite as the stored FileMtime (see
-// shelleyChangeMtime).
+// updated_at / max(sequence_id) / content-bytes signal as the stored
+// FileMtime (see shelleyChangeMtime).
 func ShelleySourceMtime(path string) (int64, error) {
 	dbPath, conversationID, ok := ParseShelleyVirtualPath(path)
 	if !ok {

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -33,16 +33,19 @@ const (
 
 // Shelley llm_data content block type tags. Upstream these are the
 // llm.ContentType iota constants; the enum has no JSON marshaler, so
-// they serialize as bare integers.
+// they serialize as bare integers. Note the values start at 2, not 0:
+// ContentType shares its const block with MessageRole (User=0,
+// Assistant=1) and iota does not reset between the two type groups.
+// These values are verified against real shelley.db data.
 const (
-	shelleyContentText                = 0
-	shelleyContentThinking            = 1
-	shelleyContentRedactedThinking    = 2
-	shelleyContentToolUse             = 3
-	shelleyContentToolResult          = 4
-	shelleyContentServerToolUse       = 5
-	shelleyContentWebSearchToolResult = 6
-	shelleyContentWebSearchResult     = 7
+	shelleyContentText                = 2
+	shelleyContentThinking            = 3
+	shelleyContentRedactedThinking    = 4
+	shelleyContentToolUse             = 5
+	shelleyContentToolResult          = 6
+	shelleyContentServerToolUse       = 7
+	shelleyContentWebSearchToolResult = 8
+	shelleyContentWebSearchResult     = 9
 )
 
 // Shelley message-table row types. Other types (system, error,

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -1,0 +1,648 @@
+package parser
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	shelleyIDPrefix = "shelley:"
+	shelleyDBName   = "shelley.db"
+)
+
+// Shelley (exe.dev) stores every conversation in a single SQLite DB
+// (~/.config/shelley/shelley.db) with two tables that matter here:
+//
+//	conversations(conversation_id, slug, user_initiated, created_at,
+//	              updated_at, cwd, parent_conversation_id, model,
+//	              current_generation, ...)
+//	messages(message_id, conversation_id, sequence_id, type,
+//	         llm_data, user_data, usage_data, display_data,
+//	         created_at, generation, excluded_from_context)
+//
+// Like Zed, each conversation is addressed by a virtual source path of
+// the form "<dbPath>#<conversationID>". sequence_id is monotonic and
+// unique per conversation (never reused across generations), so it maps
+// directly to the AgentsView message Ordinal.
+
+// Shelley llm_data content block type tags. Upstream these are the
+// llm.ContentType iota constants; the enum has no JSON marshaler, so
+// they serialize as bare integers.
+const (
+	shelleyContentText                = 0
+	shelleyContentThinking            = 1
+	shelleyContentRedactedThinking    = 2
+	shelleyContentToolUse             = 3
+	shelleyContentToolResult          = 4
+	shelleyContentServerToolUse       = 5
+	shelleyContentWebSearchToolResult = 6
+	shelleyContentWebSearchResult     = 7
+)
+
+// Shelley message-table row types.
+const (
+	shelleyTypeUser   = "user"
+	shelleyTypeAgent  = "agent"
+	shelleyTypeTool   = "tool"
+	shelleyTypeSystem = "system"
+)
+
+// shelleyLLMMessage mirrors the serialized llm.Message stored in the
+// messages.llm_data column. Field names are PascalCase to match the
+// upstream Go struct's default JSON encoding.
+type shelleyLLMMessage struct {
+	Role    int              `json:"Role"`
+	Content []shelleyContent `json:"Content"`
+}
+
+// shelleyContent mirrors the serialized llm.Content block.
+type shelleyContent struct {
+	ID         string           `json:"ID"`
+	Type       int              `json:"Type"`
+	Text       string           `json:"Text"`
+	Thinking   string           `json:"Thinking"`
+	ToolName   string           `json:"ToolName"`
+	ToolInput  json.RawMessage  `json:"ToolInput"`
+	ToolUseID  string           `json:"ToolUseID"`
+	ToolError  bool             `json:"ToolError"`
+	ToolResult []shelleyContent `json:"ToolResult"`
+	Title      string           `json:"Title"`
+	URL        string           `json:"URL"`
+}
+
+// shelleyUsage mirrors the serialized llm.Usage stored in
+// messages.usage_data. The token keys are already the AgentsView
+// canonical Anthropic names, so the raw blob is stored verbatim for
+// cost pricing. json.Number keeps decoding tolerant of string- or
+// float-encoded counts.
+type shelleyUsage struct {
+	InputTokens              json.Number `json:"input_tokens"`
+	CacheCreationInputTokens json.Number `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     json.Number `json:"cache_read_input_tokens"`
+	OutputTokens             json.Number `json:"output_tokens"`
+	Model                    string      `json:"model"`
+}
+
+// ShelleyVirtualPath gives each conversation in the shared Shelley DB a
+// stable source identity for the AgentsView archive.
+func ShelleyVirtualPath(dbPath, conversationID string) string {
+	return dbPath + "#" + conversationID
+}
+
+// ParseShelleyVirtualPath splits a virtual Shelley source path back into
+// its database path and raw conversation ID.
+func ParseShelleyVirtualPath(path string) (string, string, bool) {
+	idx := strings.LastIndex(path, "#")
+	if idx < 0 {
+		return "", "", false
+	}
+	dbPath, conversationID := path[:idx], path[idx+1:]
+	if filepath.Base(dbPath) != shelleyDBName || conversationID == "" {
+		return "", "", false
+	}
+	return dbPath, conversationID, true
+}
+
+// FindShelleyDBPath returns the shelley.db under the configured root, or
+// "" when the root holds no Shelley database.
+func FindShelleyDBPath(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	path := filepath.Join(dir, shelleyDBName)
+	if !IsRegularFile(path) {
+		return ""
+	}
+	return path
+}
+
+// DiscoverShelleySessions discovers Shelley's conversation database under
+// the configured data directory. Like Zed, it returns a single entry for
+// the shared DB; the sync engine fans it out to one session per
+// conversation.
+func DiscoverShelleySessions(root string) []DiscoveredFile {
+	dbPath := FindShelleyDBPath(root)
+	if dbPath == "" {
+		return nil
+	}
+	return []DiscoveredFile{{Path: dbPath, Agent: AgentShelley}}
+}
+
+// FindShelleySourceFile locates Shelley's shared conversation database
+// for a raw conversation ID. All conversations live in one SQLite DB, so
+// the ID is validated only to reject path-like input and is resolved to
+// a virtual path when the conversation exists under this root.
+func FindShelleySourceFile(root, rawID string) string {
+	if root == "" || !IsValidSessionID(rawID) {
+		return ""
+	}
+	dbPath := FindShelleyDBPath(root)
+	if dbPath == "" {
+		return ""
+	}
+	if ShelleyConversationExists(dbPath, rawID) {
+		return ShelleyVirtualPath(dbPath, rawID)
+	}
+	return ""
+}
+
+// ShelleyConversationExists reports whether the Shelley DB has a
+// conversation row with the given ID.
+func ShelleyConversationExists(dbPath, conversationID string) bool {
+	if dbPath == "" || conversationID == "" || !IsRegularFile(dbPath) {
+		return false
+	}
+	conn, err := openShelleyDB(dbPath)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	var found int
+	err = conn.QueryRow(
+		`SELECT 1 FROM conversations WHERE conversation_id = ? LIMIT 1`,
+		conversationID,
+	).Scan(&found)
+	return err == nil
+}
+
+// ShelleyConversationMeta holds lightweight per-conversation metadata
+// used by the sync engine for per-session skip detection without loading
+// message payloads.
+type ShelleyConversationMeta struct {
+	RawID       string
+	VirtualPath string
+	FileMtime   int64
+}
+
+// ListShelleyConversationMetas queries conversation IDs and updated_at
+// timestamps using an already-open connection, sharing it with the
+// subsequent parse loop to avoid a second DB open.
+func ListShelleyConversationMetas(
+	conn *sql.DB, dbPath string,
+) ([]ShelleyConversationMeta, error) {
+	rows, err := conn.Query(
+		`SELECT conversation_id, COALESCE(updated_at, '')
+		   FROM conversations
+		  ORDER BY updated_at, conversation_id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing shelley conversations: %w", err)
+	}
+	defer rows.Close()
+
+	var metas []ShelleyConversationMeta
+	for rows.Next() {
+		var id, updatedAt string
+		if err := rows.Scan(&id, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scanning shelley conversation meta: %w", err)
+		}
+		if !IsValidSessionID(id) {
+			continue
+		}
+		metas = append(metas, ShelleyConversationMeta{
+			RawID:       id,
+			VirtualPath: ShelleyVirtualPath(dbPath, id),
+			FileMtime:   parseTimestamp(updatedAt).UnixNano(),
+		})
+	}
+	return metas, rows.Err()
+}
+
+// OpenShelleyDB opens the Shelley shelley.db file read-only. Callers are
+// responsible for calling Close on the returned *sql.DB.
+func OpenShelleyDB(dbPath string) (*sql.DB, error) {
+	return openShelleyDB(dbPath)
+}
+
+func openShelleyDB(dbPath string) (*sql.DB, error) {
+	dsn := dbPath + "?mode=ro&_journal_mode=WAL&_busy_timeout=3000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening shelley db %s: %w", dbPath, err)
+	}
+	return db, nil
+}
+
+// ParseShelleyConversationDirect parses a single conversation by ID,
+// opening and closing its own connection. dbInfo must be the os.FileInfo
+// of the shelley.db file itself.
+func ParseShelleyConversationDirect(
+	dbPath, rawID, machine string, dbInfo os.FileInfo,
+) (*ParseResult, error) {
+	if !IsValidSessionID(rawID) {
+		return nil, fmt.Errorf("invalid Shelley session ID: %s", rawID)
+	}
+	conn, err := openShelleyDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	return ParseShelleyConversationFromDB(conn, dbPath, rawID, machine, dbInfo)
+}
+
+// ParseShelleyConversationFromDB parses one conversation using an
+// already-open connection. Callers parsing multiple conversations should
+// open the DB once and call this in a loop.
+func ParseShelleyConversationFromDB(
+	conn *sql.DB, dbPath, rawID, machine string, dbInfo os.FileInfo,
+) (*ParseResult, error) {
+	conv, err := loadShelleyConversation(conn, rawID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	messages, err := loadShelleyMessages(conn, rawID, conv.model)
+	if err != nil {
+		return nil, err
+	}
+	result, ok := buildShelleyParseResult(conv, messages, dbPath, dbInfo, machine)
+	if !ok {
+		return nil, nil
+	}
+	return &result, nil
+}
+
+type shelleyConversationRow struct {
+	conversationID       string
+	slug                 string
+	userInitiated        bool
+	createdAt            string
+	updatedAt            string
+	cwd                  string
+	parentConversationID string
+	model                string
+}
+
+func loadShelleyConversation(
+	conn *sql.DB, conversationID string,
+) (shelleyConversationRow, error) {
+	row := shelleyConversationRow{conversationID: conversationID}
+	err := conn.QueryRow(
+		`SELECT COALESCE(slug, ''), COALESCE(user_initiated, 1),
+		        COALESCE(created_at, ''), COALESCE(updated_at, ''),
+		        COALESCE(cwd, ''), COALESCE(parent_conversation_id, ''),
+		        COALESCE(model, '')
+		   FROM conversations
+		  WHERE conversation_id = ?`,
+		conversationID,
+	).Scan(
+		&row.slug, &row.userInitiated, &row.createdAt, &row.updatedAt,
+		&row.cwd, &row.parentConversationID, &row.model,
+	)
+	if err != nil {
+		return shelleyConversationRow{}, err
+	}
+	return row, nil
+}
+
+type shelleyMessageRow struct {
+	sequenceID int64
+	msgType    string
+	llmData    string
+	userData   string
+	usageData  string
+	createdAt  string
+}
+
+func loadShelleyMessages(
+	conn *sql.DB, conversationID, convModel string,
+) ([]ParsedMessage, error) {
+	// All generations are included, ordered by sequence_id. A generation
+	// bump is a context-reset/compaction boundary within the conversation
+	// (e.g. distillation); older-generation rows remain as real history
+	// and must not be hidden. sequence_id is unique per conversation
+	// across generations, so it is a safe Ordinal.
+	rows, err := conn.Query(
+		`SELECT COALESCE(sequence_id, 0), COALESCE(type, ''),
+		        COALESCE(llm_data, ''), COALESCE(user_data, ''),
+		        COALESCE(usage_data, ''), COALESCE(created_at, '')
+		   FROM messages
+		  WHERE conversation_id = ?
+		  ORDER BY sequence_id ASC`,
+		conversationID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"listing shelley messages for %s: %w", conversationID, err,
+		)
+	}
+	defer rows.Close()
+
+	var messages []ParsedMessage
+	for rows.Next() {
+		var r shelleyMessageRow
+		if err := rows.Scan(
+			&r.sequenceID, &r.msgType, &r.llmData,
+			&r.userData, &r.usageData, &r.createdAt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning shelley message: %w", err)
+		}
+		if msg, ok := decodeShelleyMessage(r, convModel); ok {
+			messages = append(messages, msg)
+		}
+	}
+	return messages, rows.Err()
+}
+
+func decodeShelleyMessage(
+	r shelleyMessageRow, convModel string,
+) (ParsedMessage, bool) {
+	role := RoleUser
+	isSystem := false
+	switch r.msgType {
+	case shelleyTypeAgent:
+		role = RoleAssistant
+	case shelleyTypeUser, shelleyTypeTool:
+		role = RoleUser
+	default:
+		// system, error, gitinfo, and any future bookkeeping types.
+		role = RoleUser
+		isSystem = true
+	}
+
+	var (
+		textParts     []string
+		thinkingParts []string
+		toolCalls     []ParsedToolCall
+		toolResults   []ParsedToolResult
+	)
+
+	if r.llmData != "" {
+		var msg shelleyLLMMessage
+		if err := json.Unmarshal([]byte(r.llmData), &msg); err == nil {
+			for _, c := range msg.Content {
+				switch c.Type {
+				case shelleyContentText:
+					if c.Text != "" {
+						textParts = append(textParts, c.Text)
+					}
+				case shelleyContentThinking:
+					if c.Thinking != "" {
+						thinkingParts = append(thinkingParts, c.Thinking)
+					}
+				case shelleyContentRedactedThinking:
+					thinkingParts = append(thinkingParts, "[redacted thinking]")
+				case shelleyContentToolUse, shelleyContentServerToolUse:
+					if c.ToolName != "" {
+						toolCalls = append(toolCalls, ParsedToolCall{
+							ToolUseID: c.ID,
+							ToolName:  c.ToolName,
+							Category:  NormalizeToolCategory(c.ToolName),
+							InputJSON: shelleyToolInput(c.ToolInput),
+						})
+					}
+				case shelleyContentToolResult, shelleyContentWebSearchToolResult:
+					text := shelleyToolResultText(c.ToolResult)
+					quoted, _ := json.Marshal(text)
+					toolResults = append(toolResults, ParsedToolResult{
+						ToolUseID:     c.ToolUseID,
+						ContentRaw:    string(quoted),
+						ContentLength: len(text),
+					})
+				case shelleyContentWebSearchResult:
+					if label := strings.TrimSpace(c.Title + " " + c.URL); label != "" {
+						textParts = append(textParts, label)
+					}
+				}
+			}
+		}
+	}
+
+	content := strings.TrimSpace(strings.Join(textParts, ""))
+	thinking := strings.TrimSpace(strings.Join(thinkingParts, "\n"))
+
+	// User-typed text may live only in user_data for some message types.
+	if content == "" && len(toolCalls) == 0 && len(toolResults) == 0 {
+		content = shelleyUserDataText(r.userData)
+	}
+
+	if content == "" && thinking == "" &&
+		len(toolCalls) == 0 && len(toolResults) == 0 {
+		return ParsedMessage{}, false
+	}
+
+	msg := ParsedMessage{
+		Ordinal:       int(r.sequenceID),
+		Role:          role,
+		Content:       content,
+		ThinkingText:  thinking,
+		HasThinking:   thinking != "",
+		HasToolUse:    len(toolCalls) > 0,
+		IsSystem:      isSystem,
+		ContentLength: len(content),
+		ToolCalls:     toolCalls,
+		ToolResults:   toolResults,
+		Timestamp:     parseTimestamp(r.createdAt),
+	}
+
+	if role == RoleAssistant && r.usageData != "" {
+		applyShelleyUsage(&msg, r.usageData, convModel)
+	}
+	return msg, true
+}
+
+// shelleyToolInput returns the raw tool input JSON, normalizing the
+// absent/null cases to an empty string.
+func shelleyToolInput(raw json.RawMessage) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" {
+		return ""
+	}
+	return s
+}
+
+// shelleyToolResultText flattens the nested tool_result content blocks
+// into a single string that DecodeContent can later decode via its
+// string branch.
+func shelleyToolResultText(blocks []shelleyContent) string {
+	var parts []string
+	for _, b := range blocks {
+		switch {
+		case b.Text != "":
+			parts = append(parts, b.Text)
+		case len(b.ToolResult) > 0:
+			parts = append(parts, shelleyToolResultText(b.ToolResult))
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// shelleyUserDataText best-effort extracts displayable text from a
+// message's user_data JSON. user_data is UI-display data whose shape
+// varies by message type, so this only recovers obvious text fields.
+func shelleyUserDataText(userData string) string {
+	if userData == "" {
+		return ""
+	}
+	var raw any
+	if err := json.Unmarshal([]byte(userData), &raw); err != nil {
+		return ""
+	}
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case map[string]any:
+		for _, key := range []string{"text", "content", "prompt", "message"} {
+			if s, ok := v[key].(string); ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	return ""
+}
+
+func applyShelleyUsage(msg *ParsedMessage, usageData, convModel string) {
+	var u shelleyUsage
+	if err := json.Unmarshal([]byte(usageData), &u); err != nil {
+		return
+	}
+	context := shelleyTokenCount(u.InputTokens) +
+		shelleyTokenCount(u.CacheCreationInputTokens) +
+		shelleyTokenCount(u.CacheReadInputTokens)
+	output := shelleyTokenCount(u.OutputTokens)
+
+	// The usage_data keys are already the AgentsView canonical names, so
+	// the raw blob is stored verbatim for catalog cost pricing.
+	msg.TokenUsage = json.RawMessage(usageData)
+	msg.ContextTokens = context
+	msg.OutputTokens = output
+	msg.HasContextTokens = context > 0
+	msg.HasOutputTokens = output > 0
+	msg.tokenPresenceKnown = true
+
+	model := strings.TrimSpace(u.Model)
+	if model == "" {
+		model = strings.TrimSpace(convModel)
+	}
+	if model != "" {
+		msg.Model = model
+	}
+}
+
+// shelleyTokenCount tolerantly decodes a token count, mapping
+// empty/garbage/negative values to 0 and bounding implausibly large
+// values so a single corrupt count cannot poison aggregate totals.
+func shelleyTokenCount(n json.Number) int {
+	if n == "" {
+		return 0
+	}
+	v, err := n.Int64()
+	if err != nil {
+		f, ferr := n.Float64()
+		if ferr != nil {
+			return 0
+		}
+		v = int64(f)
+	}
+	const maxPlausible = 1 << 40 // ~1.1e12 tokens; far above any real session
+	if v < 0 || v > maxPlausible {
+		return 0
+	}
+	return int(v)
+}
+
+func buildShelleyParseResult(
+	conv shelleyConversationRow,
+	messages []ParsedMessage,
+	dbPath string,
+	info os.FileInfo,
+	machine string,
+) (ParseResult, bool) {
+	if len(messages) == 0 {
+		return ParseResult{}, false
+	}
+	hasContent := false
+	for _, m := range messages {
+		if m.Content != "" || m.HasThinking ||
+			m.HasToolUse || len(m.ToolResults) > 0 {
+			hasContent = true
+			break
+		}
+	}
+	if !hasContent {
+		return ParseResult{}, false
+	}
+
+	startedAt := parseTimestamp(conv.createdAt)
+	endedAt := parseTimestamp(conv.updatedAt)
+	if startedAt.IsZero() {
+		startedAt = messages[0].Timestamp
+	}
+	if endedAt.IsZero() {
+		endedAt = messages[len(messages)-1].Timestamp
+	}
+	if startedAt.IsZero() {
+		startedAt = endedAt
+	}
+	if endedAt.IsZero() {
+		endedAt = startedAt
+	}
+
+	cwd := strings.TrimSpace(conv.cwd)
+	project := ExtractProjectFromCwd(cwd)
+	if project == "" {
+		project = "unknown"
+	}
+
+	// Count only genuine user turns: tool-result messages also carry
+	// the user role but hold their payload in ToolResults with empty
+	// Content, so the Content != "" guard excludes them (matching the
+	// Claude parser's firstMessageAndUserCount convention).
+	var firstMessage string
+	var userCount int
+	for _, m := range messages {
+		if m.IsSystem || m.Role != RoleUser || m.Content == "" {
+			continue
+		}
+		userCount++
+		if firstMessage == "" {
+			firstMessage = truncate(
+				strings.ReplaceAll(m.Content, "\n", " "), 300,
+			)
+		}
+	}
+	sessionName := strings.TrimSpace(conv.slug)
+	if firstMessage == "" {
+		firstMessage = truncate(sessionName, 300)
+	}
+
+	sessionID := shelleyIDPrefix + conv.conversationID
+	sess := ParsedSession{
+		ID:               sessionID,
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentShelley,
+		Cwd:              cwd,
+		FirstMessage:     firstMessage,
+		SessionName:      sessionName,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(messages),
+		UserMessageCount: userCount,
+		File: FileInfo{
+			Path:  ShelleyVirtualPath(dbPath, conv.conversationID),
+			Size:  info.Size(),
+			Mtime: endedAt.UnixNano(),
+		},
+	}
+	if parent := strings.TrimSpace(conv.parentConversationID); parent != "" {
+		sess.ParentSessionID = shelleyIDPrefix + parent
+		if conv.userInitiated {
+			sess.RelationshipType = RelContinuation
+		} else {
+			sess.RelationshipType = RelSubagent
+		}
+	}
+	accumulateMessageTokenUsage(&sess, messages)
+
+	return ParseResult{Session: sess, Messages: messages}, true
+}

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -110,24 +110,24 @@ func seedShelleyMainConversation(t *testing.T, db *sql.DB) {
 		"2026-06-15T10:00:00Z", "2026-06-15T10:05:00Z",
 	)
 	seedShelleyMessage(t, db, "cMAIN1", 1, 1, "user",
-		`{"Role":0,"Content":[{"Type":0,"Text":"Add a Shelley parser"}]}`,
+		`{"Role":0,"Content":[{"Type":2,"Text":"Add a Shelley parser"}]}`,
 		"", "", "2026-06-15T10:00:00Z")
 	seedShelleyMessage(t, db, "cMAIN1", 2, 1, "agent",
 		`{"Role":1,"Content":[`+
-			`{"Type":1,"Thinking":"Plan it."},`+
-			`{"Type":0,"Text":"On it."},`+
-			`{"ID":"toolu_1","Type":3,"ToolName":"bash","ToolInput":{"cmd":"ls"}}]}`,
+			`{"Type":3,"Thinking":"Plan it."},`+
+			`{"Type":2,"Text":"On it."},`+
+			`{"ID":"toolu_1","Type":5,"ToolName":"bash","ToolInput":{"cmd":"ls"}}]}`,
 		"",
 		`{"input_tokens":1000,"cache_creation_input_tokens":200,`+
 			`"cache_read_input_tokens":50,"output_tokens":300,`+
 			`"cost_usd":0.012,"model":"claude-sonnet-4-6"}`,
 		"2026-06-15T10:00:05Z")
 	seedShelleyMessage(t, db, "cMAIN1", 3, 1, "tool",
-		`{"Role":0,"Content":[{"Type":4,"ToolUseID":"toolu_1",`+
-			`"ToolResult":[{"Type":0,"Text":"file1\nfile2"}],"ToolError":false}]}`,
+		`{"Role":0,"Content":[{"Type":6,"ToolUseID":"toolu_1",`+
+			`"ToolResult":[{"Type":2,"Text":"file1\nfile2"}],"ToolError":false}]}`,
 		"", "", "2026-06-15T10:00:06Z")
 	seedShelleyMessage(t, db, "cMAIN1", 4, 1, "agent",
-		`{"Role":1,"Content":[{"Type":0,"Text":"Done."}]}`,
+		`{"Role":1,"Content":[{"Type":2,"Text":"Done."}]}`,
 		"",
 		`{"input_tokens":1500,"cache_creation_input_tokens":0,`+
 			`"cache_read_input_tokens":0,"output_tokens":120,`+
@@ -136,7 +136,7 @@ func seedShelleyMainConversation(t *testing.T, db *sql.DB) {
 	// Second generation: a post-compaction continuation that must still
 	// be included in the full history view.
 	seedShelleyMessage(t, db, "cMAIN1", 5, 2, "agent",
-		`{"Role":1,"Content":[{"Type":0,"Text":"Continued after compaction."}]}`,
+		`{"Role":1,"Content":[{"Type":2,"Text":"Continued after compaction."}]}`,
 		"",
 		`{"input_tokens":800,"cache_creation_input_tokens":0,`+
 			`"cache_read_input_tokens":0,"output_tokens":90,`+
@@ -233,10 +233,10 @@ func TestParseShelleySubagentRelationship(t *testing.T) {
 		"2026-06-15T10:01:00Z", "2026-06-15T10:01:30Z",
 	)
 	seedShelleyMessage(t, db, "cSUB01", 1, 1, "user",
-		`{"Role":0,"Content":[{"Type":0,"Text":"do the subtask"}]}`,
+		`{"Role":0,"Content":[{"Type":2,"Text":"do the subtask"}]}`,
 		"", "", "2026-06-15T10:01:00Z")
 	seedShelleyMessage(t, db, "cSUB01", 2, 1, "agent",
-		`{"Role":1,"Content":[{"Type":0,"Text":"subtask done"}]}`,
+		`{"Role":1,"Content":[{"Type":2,"Text":"subtask done"}]}`,
 		"", "", "2026-06-15T10:01:30Z")
 
 	info, err := os.Stat(dbPath)
@@ -335,7 +335,7 @@ func TestParseShelleyTimestampFormats(t *testing.T) {
 		"2026-06-15 10:00:00", "2026-06-15 10:00:30",
 	)
 	seedShelleyMessage(t, db, "cTIME1", 1, 1, "user",
-		`{"Role":0,"Content":[{"Type":0,"Text":"hi"}]}`,
+		`{"Role":0,"Content":[{"Type":2,"Text":"hi"}]}`,
 		"", "", "2026-06-15 10:00:00")
 
 	info, err := os.Stat(dbPath)
@@ -359,20 +359,20 @@ func TestParseShelleyRobustContent(t *testing.T) {
 		"2026-06-15T10:00:00Z", "2026-06-15T10:00:40Z",
 	)
 	seedShelleyMessage(t, db, "cROB1", 1, 1, "user",
-		`{"Role":0,"Content":[{"Type":0,"Text":"go"}]}`,
+		`{"Role":0,"Content":[{"Type":2,"Text":"go"}]}`,
 		"", "", "2026-06-15T10:00:00Z")
 	// Unknown content type (99) is ignored; redacted thinking (2) is
 	// surfaced as a placeholder; the text block survives.
 	seedShelleyMessage(t, db, "cROB1", 2, 1, "agent",
-		`{"Role":1,"Content":[{"Type":2},{"Type":99,"Text":"ignored"},`+
-			`{"Type":0,"Text":"real text"}]}`,
+		`{"Role":1,"Content":[{"Type":4},{"Type":99,"Text":"ignored"},`+
+			`{"Type":2,"Text":"real text"}]}`,
 		"", "", "2026-06-15T10:00:05Z")
 	// Malformed llm_data with no user_data fallback is dropped.
 	seedShelleyMessage(t, db, "cROB1", 3, 1, "agent",
 		`{not json`, "", "", "2026-06-15T10:00:06Z")
 	// Errored assistant turn stored as type="error" still carries usage.
 	seedShelleyMessage(t, db, "cROB1", 4, 1, "error",
-		`{"Role":1,"Content":[{"Type":0,"Text":"request failed"}]}`,
+		`{"Role":1,"Content":[{"Type":2,"Text":"request failed"}]}`,
 		"",
 		`{"input_tokens":700,"output_tokens":40,"model":"claude-sonnet-4-6"}`,
 		"2026-06-15T10:00:40Z")

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -455,10 +455,10 @@ func TestParseShelleyWebSearchToolResult(t *testing.T) {
 // the same wall-clock second (so updated_at is unchanged) still advances
 // the per-conversation File.Mtime change signal, so the sync engine's
 // skip cannot drop it. Shelley's updated_at is second-precision, so the
-// max(sequence_id) component is what distinguishes same-second writes.
-// The three signal sources (stored File.Mtime, the meta skip query, and
-// ShelleySourceMtime) must agree, or unchanged conversations would
-// re-parse forever.
+// max(sequence_id) and content-byte-length components are what
+// distinguish same-second writes. The three signal sources (stored
+// File.Mtime, the meta skip query, and ShelleySourceMtime) must agree, or
+// unchanged conversations would re-parse forever.
 func TestShelleySameSecondChangeSignal(t *testing.T) {
 	_, dbPath, db := newShelleyTestDB(t)
 	seedShelleyConversation(
@@ -493,10 +493,10 @@ func TestShelleySameSecondChangeSignal(t *testing.T) {
 	assert.Equal(t, mtime1, srcMtime1, "SourceMtime must match File.Mtime")
 
 	// Append a second message in the SAME second: updated_at is unchanged,
-	// only sequence_id advances (1 -> 2).
+	// sequence_id advances (1 -> 2) and the payload adds content bytes.
+	const secondLLM = `{"Role":1,"Content":[{"Type":2,"Text":"second"}]}`
 	seedShelleyMessage(t, db, "cSEC1", 2, 1, "agent",
-		`{"Role":1,"Content":[{"Type":2,"Text":"second"}]}`,
-		"", "", "2026-06-15T10:00:00Z")
+		secondLLM, "", "", "2026-06-15T10:00:00Z")
 
 	second, err := ParseShelleyConversationDirect(dbPath, "cSEC1", "m", info)
 	require.NoError(t, err)
@@ -505,8 +505,8 @@ func TestShelleySameSecondChangeSignal(t *testing.T) {
 
 	assert.NotEqual(t, mtime1, mtime2,
 		"a same-second append must change the skip signal")
-	assert.Equal(t, mtime1+1, mtime2,
-		"signal advances by exactly the sequence_id delta")
+	assert.Equal(t, mtime1+1+int64(len(secondLLM)), mtime2,
+		"signal advances by the sequence_id delta plus the appended payload bytes")
 
 	metas2, err := ListShelleyConversationMetas(conn, dbPath)
 	require.NoError(t, err)

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -399,6 +399,58 @@ func TestParseShelleyRobustContent(t *testing.T) {
 	assert.Equal(t, 40, result.Session.TotalOutputTokens, "session output total")
 }
 
+// TestParseShelleyWebSearchToolResult verifies that a server-side web
+// search turn is preserved: the web_search call (Type 7) becomes a tool
+// call, and the web_search_tool_result (Type 8) whose nested
+// web_search_result blocks (Type 9) carry Title/URL instead of Text is
+// stored with readable content rather than dropped empty.
+func TestParseShelleyWebSearchToolResult(t *testing.T) {
+	_, dbPath, db := newShelleyTestDB(t)
+	seedShelleyConversation(
+		t, db, "cWEB1", "search the web", "/home/user/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:30Z",
+	)
+	seedShelleyMessage(t, db, "cWEB1", 1, 1, "user",
+		`{"Role":0,"Content":[{"Type":2,"Text":"what is iota"}]}`,
+		"", "", "2026-06-15T10:00:00Z")
+	seedShelleyMessage(t, db, "cWEB1", 2, 1, "agent",
+		`{"Role":1,"Content":[`+
+			`{"ID":"srvtoolu_1","Type":7,"ToolName":"web_search",`+
+			`"ToolInput":{"query":"golang iota"}},`+
+			`{"Type":8,"ToolUseID":"srvtoolu_1","ToolResult":[`+
+			`{"Type":9,"Title":"Go iota explained","URL":"https://go.dev/iota"},`+
+			`{"Type":9,"Title":"Effective Go",`+
+			`"URL":"https://go.dev/doc/effective_go"}]}]}`,
+		"", "", "2026-06-15T10:00:05Z")
+
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat db")
+	result, err := ParseShelleyConversationDirect(dbPath, "cWEB1", "m", info)
+	require.NoError(t, err, "parse web search conversation")
+	require.NotNil(t, result, "expected result")
+
+	require.Len(t, result.Messages, 2, "messages len")
+	agent := result.Messages[1]
+
+	// The server-side web_search call is captured as a tool call.
+	require.Len(t, agent.ToolCalls, 1, "web_search tool call captured")
+	assert.Equal(t, "web_search", agent.ToolCalls[0].ToolName, "tool name")
+
+	// The web_search_tool_result is paired to the server tool call and its
+	// nested Title/URL result blocks are preserved, not stored empty.
+	require.Len(t, agent.ToolResults, 1, "web_search tool result captured")
+	assert.Equal(t, "srvtoolu_1",
+		agent.ToolResults[0].ToolUseID, "result tool use id")
+	decoded := DecodeContent(agent.ToolResults[0].ContentRaw)
+	assert.Equal(t,
+		"Go iota explained https://go.dev/iota\n"+
+			"Effective Go https://go.dev/doc/effective_go",
+		decoded, "web search result title/url preserved")
+	assert.Positive(t, agent.ToolResults[0].ContentLength,
+		"content length nonzero")
+}
+
 func TestApplyShelleyUsageTolerant(t *testing.T) {
 	var msg ParsedMessage
 	applyShelleyUsage(&msg,

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -451,14 +451,14 @@ func TestParseShelleyWebSearchToolResult(t *testing.T) {
 		"content length nonzero")
 }
 
-// TestShelleySameSecondChangeSignal verifies that a message appended in
-// the same wall-clock second (so updated_at is unchanged) still advances
-// the per-conversation File.Mtime change signal, so the sync engine's
-// skip cannot drop it. Shelley's updated_at is second-precision, so the
-// max(sequence_id) and content-byte-length components are what
-// distinguish same-second writes. The three signal sources (stored
-// File.Mtime, the meta skip query, and ShelleySourceMtime) must agree, or
-// unchanged conversations would re-parse forever.
+// TestShelleySameSecondChangeSignal verifies the split change signal: a
+// message appended in the same wall-clock second (so updated_at is
+// unchanged) leaves File.Mtime fixed at the conversation's real
+// timestamp but shifts the content fingerprint (stored in file_hash), so
+// the sync skip still re-parses. The watcher-only ShelleySourceMtime,
+// compared for inequality, must also change. The stored values and the
+// meta skip query must agree, or unchanged conversations would re-parse
+// forever.
 func TestShelleySameSecondChangeSignal(t *testing.T) {
 	_, dbPath, db := newShelleyTestDB(t)
 	seedShelleyConversation(
@@ -481,49 +481,51 @@ func TestShelleySameSecondChangeSignal(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, first)
 	mtime1 := first.Session.File.Mtime
+	hash1 := first.Session.File.Hash
+
+	// File.Mtime is the conversation's real timestamp, so it stays a valid
+	// value for modified-between range queries (never a synthetic future).
+	base := parseTimestamp("2026-06-15T10:00:00Z").UnixNano()
+	assert.Equal(t, base, mtime1, "File.Mtime is the real updated_at")
+	assert.NotEmpty(t, hash1, "content fingerprint set")
 
 	metas1, err := ListShelleyConversationMetas(conn, dbPath)
 	require.NoError(t, err)
 	require.Len(t, metas1, 1)
 	assert.Equal(t, mtime1, metas1[0].FileMtime,
-		"stored File.Mtime must match the meta skip signal")
+		"stored File.Mtime must match the meta skip timestamp")
+	assert.Equal(t, hash1, metas1[0].Fingerprint,
+		"stored file_hash must match the meta skip fingerprint")
 
 	srcMtime1, err := ShelleySourceMtime(dbPath + "#cSEC1")
 	require.NoError(t, err)
-	assert.Equal(t, mtime1, srcMtime1, "SourceMtime must match File.Mtime")
-
-	// The signal stays within the conversation's reported second so it
-	// remains a valid timestamp for modified-between range queries.
-	base := parseTimestamp("2026-06-15T10:00:00Z").UnixNano()
-	assert.GreaterOrEqual(t, mtime1, base, "signal at or after the second")
-	assert.Less(t, mtime1, base+1_000_000_000, "signal within the second")
+	assert.Positive(t, srcMtime1, "SourceMtime resolves the conversation")
 
 	// Append a second message in the SAME second: updated_at is unchanged,
 	// sequence_id advances (1 -> 2) and the payload adds content bytes.
-	const secondLLM = `{"Role":1,"Content":[{"Type":2,"Text":"second"}]}`
 	seedShelleyMessage(t, db, "cSEC1", 2, 1, "agent",
-		secondLLM, "", "", "2026-06-15T10:00:00Z")
+		`{"Role":1,"Content":[{"Type":2,"Text":"second"}]}`,
+		"", "", "2026-06-15T10:00:00Z")
 
 	second, err := ParseShelleyConversationDirect(dbPath, "cSEC1", "m", info)
 	require.NoError(t, err)
 	require.NotNil(t, second)
-	mtime2 := second.Session.File.Mtime
 
-	assert.NotEqual(t, mtime1, mtime2,
-		"a same-second append must change the skip signal")
-	assert.GreaterOrEqual(t, mtime2, base, "appended signal at or after the second")
-	assert.Less(t, mtime2, base+1_000_000_000, "appended signal within the second")
+	assert.Equal(t, mtime1, second.Session.File.Mtime,
+		"same-second append leaves the real timestamp unchanged")
+	assert.NotEqual(t, hash1, second.Session.File.Hash,
+		"a same-second append must change the content fingerprint")
 
 	metas2, err := ListShelleyConversationMetas(conn, dbPath)
 	require.NoError(t, err)
 	require.Len(t, metas2, 1)
-	assert.Equal(t, mtime2, metas2[0].FileMtime,
-		"meta skip signal tracks the same-second append")
+	assert.Equal(t, second.Session.File.Hash, metas2[0].Fingerprint,
+		"meta fingerprint tracks the same-second append")
 
 	srcMtime2, err := ShelleySourceMtime(dbPath + "#cSEC1")
 	require.NoError(t, err)
-	assert.Equal(t, mtime2, srcMtime2,
-		"SourceMtime tracks the same-second append")
+	assert.NotEqual(t, srcMtime1, srcMtime2,
+		"watcher SourceMtime tracks the same-second append")
 }
 
 func TestApplyShelleyUsageTolerant(t *testing.T) {

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -451,6 +451,70 @@ func TestParseShelleyWebSearchToolResult(t *testing.T) {
 		"content length nonzero")
 }
 
+// TestShelleySameSecondChangeSignal verifies that a message appended in
+// the same wall-clock second (so updated_at is unchanged) still advances
+// the per-conversation File.Mtime change signal, so the sync engine's
+// skip cannot drop it. Shelley's updated_at is second-precision, so the
+// max(sequence_id) component is what distinguishes same-second writes.
+// The three signal sources (stored File.Mtime, the meta skip query, and
+// ShelleySourceMtime) must agree, or unchanged conversations would
+// re-parse forever.
+func TestShelleySameSecondChangeSignal(t *testing.T) {
+	_, dbPath, db := newShelleyTestDB(t)
+	seedShelleyConversation(
+		t, db, "cSEC1", "same second", "/home/user/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:00Z",
+	)
+	seedShelleyMessage(t, db, "cSEC1", 1, 1, "user",
+		`{"Role":0,"Content":[{"Type":2,"Text":"first"}]}`,
+		"", "", "2026-06-15T10:00:00Z")
+
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat db")
+
+	conn, err := OpenShelleyDB(dbPath)
+	require.NoError(t, err, "open shelley db")
+	defer conn.Close()
+
+	first, err := ParseShelleyConversationDirect(dbPath, "cSEC1", "m", info)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	mtime1 := first.Session.File.Mtime
+
+	metas1, err := ListShelleyConversationMetas(conn, dbPath)
+	require.NoError(t, err)
+	require.Len(t, metas1, 1)
+	assert.Equal(t, mtime1, metas1[0].FileMtime,
+		"stored File.Mtime must match the meta skip signal")
+
+	srcMtime1, err := ShelleySourceMtime(dbPath + "#cSEC1")
+	require.NoError(t, err)
+	assert.Equal(t, mtime1, srcMtime1, "SourceMtime must match File.Mtime")
+
+	// Append a second message in the SAME second: updated_at is unchanged,
+	// only sequence_id advances (1 -> 2).
+	seedShelleyMessage(t, db, "cSEC1", 2, 1, "agent",
+		`{"Role":1,"Content":[{"Type":2,"Text":"second"}]}`,
+		"", "", "2026-06-15T10:00:00Z")
+
+	second, err := ParseShelleyConversationDirect(dbPath, "cSEC1", "m", info)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	mtime2 := second.Session.File.Mtime
+
+	assert.NotEqual(t, mtime1, mtime2,
+		"a same-second append must change the skip signal")
+	assert.Equal(t, mtime1+1, mtime2,
+		"signal advances by exactly the sequence_id delta")
+
+	metas2, err := ListShelleyConversationMetas(conn, dbPath)
+	require.NoError(t, err)
+	require.Len(t, metas2, 1)
+	assert.Equal(t, mtime2, metas2[0].FileMtime,
+		"meta skip signal tracks the same-second append")
+}
+
 func TestApplyShelleyUsageTolerant(t *testing.T) {
 	var msg ParsedMessage
 	applyShelleyUsage(&msg,

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -492,6 +492,12 @@ func TestShelleySameSecondChangeSignal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, mtime1, srcMtime1, "SourceMtime must match File.Mtime")
 
+	// The signal stays within the conversation's reported second so it
+	// remains a valid timestamp for modified-between range queries.
+	base := parseTimestamp("2026-06-15T10:00:00Z").UnixNano()
+	assert.GreaterOrEqual(t, mtime1, base, "signal at or after the second")
+	assert.Less(t, mtime1, base+1_000_000_000, "signal within the second")
+
 	// Append a second message in the SAME second: updated_at is unchanged,
 	// sequence_id advances (1 -> 2) and the payload adds content bytes.
 	const secondLLM = `{"Role":1,"Content":[{"Type":2,"Text":"second"}]}`
@@ -505,14 +511,19 @@ func TestShelleySameSecondChangeSignal(t *testing.T) {
 
 	assert.NotEqual(t, mtime1, mtime2,
 		"a same-second append must change the skip signal")
-	assert.Equal(t, mtime1+1+int64(len(secondLLM)), mtime2,
-		"signal advances by the sequence_id delta plus the appended payload bytes")
+	assert.GreaterOrEqual(t, mtime2, base, "appended signal at or after the second")
+	assert.Less(t, mtime2, base+1_000_000_000, "appended signal within the second")
 
 	metas2, err := ListShelleyConversationMetas(conn, dbPath)
 	require.NoError(t, err)
 	require.Len(t, metas2, 1)
 	assert.Equal(t, mtime2, metas2[0].FileMtime,
 		"meta skip signal tracks the same-second append")
+
+	srcMtime2, err := ShelleySourceMtime(dbPath + "#cSEC1")
+	require.NoError(t, err)
+	assert.Equal(t, mtime2, srcMtime2,
+		"SourceMtime tracks the same-second append")
 }
 
 func TestApplyShelleyUsageTolerant(t *testing.T) {

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -414,6 +414,40 @@ func TestParseShelleyRobustContent(t *testing.T) {
 	assert.Equal(t, 40, result.Session.TotalOutputTokens, "session output total")
 }
 
+func TestParseShelleyUsageOnlyRows(t *testing.T) {
+	_, dbPath, db := newShelleyTestDB(t)
+	seedShelleyConversation(
+		t, db, "cUSG1", "usage only", "/home/user/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:40Z",
+	)
+	seedShelleyMessage(t, db, "cUSG1", 1, 1, "user",
+		`{"Role":0,"Content":[{"Type":2,"Text":"go"}]}`,
+		"", "", "2026-06-15T10:00:00Z")
+	seedShelleyMessage(t, db, "cUSG1", 2, 1, "error",
+		`{not json`, "",
+		`{"input_tokens":123,"output_tokens":33,"model":"claude-sonnet-4-6"}`,
+		"2026-06-15T10:00:40Z")
+
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat db")
+	result, err := ParseShelleyConversationDirect(dbPath, "cUSG1", "m", info)
+	require.NoError(t, err, "must not error on usage-only row")
+	require.NotNil(t, result)
+
+	require.Len(t, result.Messages, 2, "messages len")
+	usageOnly := result.Messages[1]
+	assert.True(t, usageOnly.IsSystem, "usage-only row is metadata")
+	assert.Empty(t, usageOnly.Content, "usage-only content")
+	assert.Equal(t, 123, usageOnly.ContextTokens, "context tokens")
+	assert.Equal(t, 33, usageOnly.OutputTokens, "output tokens")
+	assert.True(t, usageOnly.HasContextTokens, "has context tokens")
+	assert.True(t, usageOnly.HasOutputTokens, "has output tokens")
+	assert.NotEmpty(t, usageOnly.TokenUsage, "raw token usage")
+	assert.Equal(t, 123, result.Session.PeakContextTokens, "session peak context")
+	assert.Equal(t, 33, result.Session.TotalOutputTokens, "session output total")
+}
+
 // TestParseShelleyWebSearchToolResult verifies that a server-side web
 // search turn is preserved: the web_search call (Type 7) becomes a tool
 // call, and the web_search_tool_result (Type 8) whose nested

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -1,0 +1,336 @@
+package parser
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const shelleySchema = `
+CREATE TABLE conversations (
+	conversation_id TEXT PRIMARY KEY,
+	slug TEXT,
+	user_initiated BOOLEAN NOT NULL DEFAULT TRUE,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	cwd TEXT,
+	archived BOOLEAN NOT NULL DEFAULT FALSE,
+	parent_conversation_id TEXT,
+	model TEXT,
+	current_generation INTEGER NOT NULL DEFAULT 1,
+	is_draft BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE TABLE messages (
+	message_id TEXT PRIMARY KEY,
+	conversation_id TEXT NOT NULL,
+	sequence_id INTEGER NOT NULL,
+	type TEXT NOT NULL,
+	llm_data TEXT,
+	user_data TEXT,
+	usage_data TEXT,
+	display_data TEXT,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	generation INTEGER NOT NULL DEFAULT 1,
+	excluded_from_context BOOLEAN NOT NULL DEFAULT FALSE
+);
+`
+
+func newShelleyTestDB(t *testing.T) (string, string, *sql.DB) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, shelleyDBName)
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open shelley test db")
+	t.Cleanup(func() { db.Close() })
+	_, err = db.Exec(shelleySchema)
+	require.NoError(t, err, "create shelley schema")
+	return dir, path, db
+}
+
+func seedShelleyConversation(
+	t *testing.T, db *sql.DB,
+	id, slug, cwd, model, parent string, userInitiated bool,
+	createdAt, updatedAt string,
+) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO conversations
+			(conversation_id, slug, user_initiated, created_at,
+			 updated_at, cwd, parent_conversation_id, model)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, slug, userInitiated, createdAt, updatedAt, cwd,
+		nullable(parent), nullable(model),
+	)
+	require.NoError(t, err, "seed shelley conversation %s", id)
+}
+
+func seedShelleyMessage(
+	t *testing.T, db *sql.DB,
+	convID string, seq int, generation int, msgType,
+	llmData, userData, usageData, createdAt string,
+) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO messages
+			(message_id, conversation_id, sequence_id, generation,
+			 type, llm_data, user_data, usage_data, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		convID+"-m"+itoa(seq), convID, seq, generation, msgType,
+		nullable(llmData), nullable(userData), nullable(usageData),
+		createdAt,
+	)
+	require.NoError(t, err, "seed shelley message %s/%d", convID, seq)
+}
+
+func nullable(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func itoa(i int) string {
+	return string(rune('0' + i))
+}
+
+// seedShelleyMainConversation seeds a conversation that exercises text,
+// thinking, a tool call, a tool result, per-message token usage, and a
+// second-generation (post-compaction) message.
+func seedShelleyMainConversation(t *testing.T, db *sql.DB) {
+	t.Helper()
+	seedShelleyConversation(
+		t, db, "cMAIN1", "Add Shelley parser",
+		"/home/user/dev/myapp", "claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:05:00Z",
+	)
+	seedShelleyMessage(t, db, "cMAIN1", 1, 1, "user",
+		`{"Role":0,"Content":[{"Type":0,"Text":"Add a Shelley parser"}]}`,
+		"", "", "2026-06-15T10:00:00Z")
+	seedShelleyMessage(t, db, "cMAIN1", 2, 1, "agent",
+		`{"Role":1,"Content":[`+
+			`{"Type":1,"Thinking":"Plan it."},`+
+			`{"Type":0,"Text":"On it."},`+
+			`{"ID":"toolu_1","Type":3,"ToolName":"bash","ToolInput":{"cmd":"ls"}}]}`,
+		"",
+		`{"input_tokens":1000,"cache_creation_input_tokens":200,`+
+			`"cache_read_input_tokens":50,"output_tokens":300,`+
+			`"cost_usd":0.012,"model":"claude-sonnet-4-6"}`,
+		"2026-06-15T10:00:05Z")
+	seedShelleyMessage(t, db, "cMAIN1", 3, 1, "tool",
+		`{"Role":0,"Content":[{"Type":4,"ToolUseID":"toolu_1",`+
+			`"ToolResult":[{"Type":0,"Text":"file1\nfile2"}],"ToolError":false}]}`,
+		"", "", "2026-06-15T10:00:06Z")
+	seedShelleyMessage(t, db, "cMAIN1", 4, 1, "agent",
+		`{"Role":1,"Content":[{"Type":0,"Text":"Done."}]}`,
+		"",
+		`{"input_tokens":1500,"cache_creation_input_tokens":0,`+
+			`"cache_read_input_tokens":0,"output_tokens":120,`+
+			`"cost_usd":0.004,"model":"claude-sonnet-4-6"}`,
+		"2026-06-15T10:00:10Z")
+	// Second generation: a post-compaction continuation that must still
+	// be included in the full history view.
+	seedShelleyMessage(t, db, "cMAIN1", 5, 2, "agent",
+		`{"Role":1,"Content":[{"Type":0,"Text":"Continued after compaction."}]}`,
+		"",
+		`{"input_tokens":800,"cache_creation_input_tokens":0,`+
+			`"cache_read_input_tokens":0,"output_tokens":90,`+
+			`"model":"claude-sonnet-4-6"}`,
+		"2026-06-15T10:05:00Z")
+}
+
+func TestParseShelleyConversation(t *testing.T) {
+	_, dbPath, db := newShelleyTestDB(t)
+	seedShelleyMainConversation(t, db)
+
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat db")
+
+	result, err := ParseShelleyConversationDirect(
+		dbPath, "cMAIN1", "test-machine", info,
+	)
+	require.NoError(t, err, "ParseShelleyConversationDirect")
+	require.NotNil(t, result, "expected result")
+
+	sess := result.Session
+	assert.Equal(t, "shelley:cMAIN1", sess.ID, "ID")
+	assert.Equal(t, AgentShelley, sess.Agent, "Agent")
+	assert.Equal(t, "test-machine", sess.Machine, "Machine")
+	assert.Equal(t, "myapp", sess.Project, "Project")
+	assert.Equal(t, "/home/user/dev/myapp", sess.Cwd, "Cwd")
+	assert.Equal(t, "Add Shelley parser", sess.SessionName, "SessionName")
+	assert.Equal(t, "Add a Shelley parser", sess.FirstMessage, "FirstMessage")
+	assert.Equal(t, 5, sess.MessageCount, "MessageCount")
+	assert.Equal(t, 1, sess.UserMessageCount, "UserMessageCount")
+	assert.Equal(t, dbPath+"#cMAIN1", sess.File.Path, "File.Path")
+	assert.Empty(t, sess.ParentSessionID, "ParentSessionID")
+
+	// Session token aggregates: peak context is a MAX, total output a SUM.
+	assert.Equal(t, 1500, sess.PeakContextTokens, "PeakContextTokens")
+	assert.Equal(t, 510, sess.TotalOutputTokens, "TotalOutputTokens")
+	assert.True(t, sess.HasPeakContextTokens, "HasPeakContextTokens")
+	assert.True(t, sess.HasTotalOutputTokens, "HasTotalOutputTokens")
+
+	msgs := result.Messages
+	require.Len(t, msgs, 5, "messages len")
+
+	// Ordinals come straight from sequence_id.
+	for i, m := range msgs {
+		assert.Equalf(t, i+1, m.Ordinal, "msg[%d].Ordinal", i)
+	}
+
+	// User message.
+	assert.Equal(t, RoleUser, msgs[0].Role, "msg[0].Role")
+	assert.Equal(t, "Add a Shelley parser", msgs[0].Content, "msg[0].Content")
+
+	// Agent message: text + thinking + tool call + tokens.
+	a := msgs[1]
+	assert.Equal(t, RoleAssistant, a.Role, "msg[1].Role")
+	assert.Equal(t, "On it.", a.Content, "msg[1].Content")
+	assert.True(t, a.HasThinking, "msg[1].HasThinking")
+	assert.Equal(t, "Plan it.", a.ThinkingText, "msg[1].ThinkingText")
+	assert.True(t, a.HasToolUse, "msg[1].HasToolUse")
+	require.Len(t, a.ToolCalls, 1, "msg[1].ToolCalls len")
+	assert.Equal(t, "bash", a.ToolCalls[0].ToolName, "tool name")
+	assert.Equal(t, "Bash", a.ToolCalls[0].Category, "tool category")
+	assert.Equal(t, "toolu_1", a.ToolCalls[0].ToolUseID, "tool use id")
+	assert.JSONEq(t, `{"cmd":"ls"}`, a.ToolCalls[0].InputJSON, "tool input")
+	assert.Equal(t, 1250, a.ContextTokens, "msg[1].ContextTokens")
+	assert.Equal(t, 300, a.OutputTokens, "msg[1].OutputTokens")
+	assert.True(t, a.HasContextTokens, "msg[1].HasContextTokens")
+	assert.True(t, a.HasOutputTokens, "msg[1].HasOutputTokens")
+	assert.Equal(t, "claude-sonnet-4-6", a.Model, "msg[1].Model")
+	assert.NotEmpty(t, a.TokenUsage, "msg[1].TokenUsage raw")
+
+	// Tool result message: user role, empty content, paired by ToolUseID.
+	tr := msgs[2]
+	assert.Equal(t, RoleUser, tr.Role, "msg[2].Role")
+	assert.Empty(t, tr.Content, "msg[2].Content")
+	require.Len(t, tr.ToolResults, 1, "msg[2].ToolResults len")
+	assert.Equal(t, "toolu_1", tr.ToolResults[0].ToolUseID, "result tool use id")
+	assert.Equal(t, "file1\nfile2",
+		DecodeContent(tr.ToolResults[0].ContentRaw), "decoded tool result")
+
+	// Final first-generation agent message.
+	assert.Equal(t, "Done.", msgs[3].Content, "msg[3].Content")
+	assert.Equal(t, 120, msgs[3].OutputTokens, "msg[3].OutputTokens")
+
+	// Second-generation message is included in the history.
+	assert.Equal(t, "Continued after compaction.", msgs[4].Content, "msg[4].Content")
+}
+
+func TestParseShelleySubagentRelationship(t *testing.T) {
+	_, dbPath, db := newShelleyTestDB(t)
+	seedShelleyMainConversation(t, db)
+	seedShelleyConversation(
+		t, db, "cSUB01", "do subtask",
+		"/home/user/dev/myapp", "claude-sonnet-4-6", "cMAIN1", false,
+		"2026-06-15T10:01:00Z", "2026-06-15T10:01:30Z",
+	)
+	seedShelleyMessage(t, db, "cSUB01", 1, 1, "user",
+		`{"Role":0,"Content":[{"Type":0,"Text":"do the subtask"}]}`,
+		"", "", "2026-06-15T10:01:00Z")
+	seedShelleyMessage(t, db, "cSUB01", 2, 1, "agent",
+		`{"Role":1,"Content":[{"Type":0,"Text":"subtask done"}]}`,
+		"", "", "2026-06-15T10:01:30Z")
+
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat db")
+
+	result, err := ParseShelleyConversationDirect(
+		dbPath, "cSUB01", "test-machine", info,
+	)
+	require.NoError(t, err, "parse subagent")
+	require.NotNil(t, result, "expected subagent result")
+	assert.Equal(t, "shelley:cSUB01", result.Session.ID, "subagent ID")
+	assert.Equal(t, "shelley:cMAIN1", result.Session.ParentSessionID, "parent")
+	assert.Equal(t, RelSubagent, result.Session.RelationshipType, "relationship")
+}
+
+func TestDiscoverAndFindShelley(t *testing.T) {
+	root, dbPath, db := newShelleyTestDB(t)
+	seedShelleyMainConversation(t, db)
+
+	files := DiscoverShelleySessions(root)
+	require.Len(t, files, 1, "discovered files")
+	assert.Equal(t, dbPath, files[0].Path, "discovered db path")
+	assert.Equal(t, AgentShelley, files[0].Agent, "discovered agent")
+
+	assert.Equal(t, dbPath+"#cMAIN1",
+		FindShelleySourceFile(root, "cMAIN1"), "find existing")
+	assert.Empty(t, FindShelleySourceFile(root, "cNOPE0"), "find missing")
+	assert.Empty(t, FindShelleySourceFile(root, "../escape"), "reject path-like id")
+	assert.True(t, ShelleyConversationExists(dbPath, "cMAIN1"), "exists")
+	assert.False(t, ShelleyConversationExists(dbPath, "cNOPE0"), "not exists")
+
+	// Empty root yields no discovery and no source file.
+	assert.Nil(t, DiscoverShelleySessions(t.TempDir()), "empty dir discovery")
+}
+
+func TestParseShelleyVirtualPath(t *testing.T) {
+	dbPath := "/home/user/.config/shelley/shelley.db"
+	got, id, ok := ParseShelleyVirtualPath(dbPath + "#cABC123")
+	require.True(t, ok, "valid virtual path")
+	assert.Equal(t, dbPath, got, "db path")
+	assert.Equal(t, "cABC123", id, "conversation id")
+
+	_, _, ok = ParseShelleyVirtualPath("/x/other.db#id")
+	assert.False(t, ok, "wrong db name")
+	_, _, ok = ParseShelleyVirtualPath(dbPath)
+	assert.False(t, ok, "no separator")
+	_, _, ok = ParseShelleyVirtualPath(dbPath + "#")
+	assert.False(t, ok, "empty id")
+}
+
+func TestAgentByPrefixShelley(t *testing.T) {
+	def, ok := AgentByPrefix("shelley:cMAIN1")
+	require.True(t, ok, "shelley prefix matches")
+	assert.Equal(t, AgentShelley, def.Type, "shelley type")
+
+	def, ok = AgentByPrefix("host~shelley:cMAIN1")
+	require.True(t, ok, "host-prefixed shelley matches")
+	assert.Equal(t, AgentShelley, def.Type, "host-prefixed type")
+
+	// A colon-free ID must fall back to Claude, never Shelley.
+	def, ok = AgentByPrefix("cMAIN1")
+	require.True(t, ok, "colon-free id matches Claude fallback")
+	assert.Equal(t, AgentClaude, def.Type, "colon-free routes to Claude")
+}
+
+func TestShelleyTokenCount(t *testing.T) {
+	tests := []struct {
+		name string
+		in   json.Number
+		want int
+	}{
+		{"empty", json.Number(""), 0},
+		{"plain", json.Number("1234"), 1234},
+		{"zero", json.Number("0"), 0},
+		{"negative", json.Number("-5"), 0},
+		{"float", json.Number("42.0"), 42},
+		{"garbage", json.Number("abc"), 0},
+		{"implausible", json.Number("9999999999999"), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shelleyTokenCount(tt.in))
+		})
+	}
+}
+
+func TestApplyShelleyUsageTolerant(t *testing.T) {
+	var msg ParsedMessage
+	applyShelleyUsage(&msg,
+		`{"input_tokens":"-5","cache_read_input_tokens":"100",`+
+			`"output_tokens":"42","model":""}`, "fallback-model")
+	assert.Equal(t, 100, msg.ContextTokens, "ContextTokens (negative input clamped)")
+	assert.Equal(t, 42, msg.OutputTokens, "OutputTokens")
+	assert.True(t, msg.HasContextTokens, "HasContextTokens")
+	assert.True(t, msg.HasOutputTokens, "HasOutputTokens")
+	assert.Equal(t, "fallback-model", msg.Model, "falls back to conversation model")
+}

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -49,6 +50,20 @@ func newShelleyTestDB(t *testing.T) (string, string, *sql.DB) {
 	require.NoError(t, err, "open shelley test db")
 	t.Cleanup(func() { db.Close() })
 	_, err = db.Exec(shelleySchema)
+	require.NoError(t, err, "create shelley schema")
+	return dir, path, db
+}
+
+func newShelleyTestDBWithSchema(
+	t *testing.T, schema string,
+) (string, string, *sql.DB) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, shelleyDBName)
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open shelley test db")
+	t.Cleanup(func() { db.Close() })
+	_, err = db.Exec(schema)
 	require.NoError(t, err, "create shelley schema")
 	return dir, path, db
 }
@@ -526,6 +541,44 @@ func TestShelleySameSecondChangeSignal(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, srcMtime1, srcMtime2,
 		"watcher SourceMtime tracks the same-second append")
+}
+
+func TestShelleyNumericUserInitiatedScans(t *testing.T) {
+	schema := strings.Replace(
+		shelleySchema,
+		"user_initiated BOOLEAN NOT NULL DEFAULT TRUE",
+		"user_initiated INTEGER NOT NULL DEFAULT 1",
+		1,
+	)
+	_, dbPath, db := newShelleyTestDBWithSchema(t, schema)
+	seedShelleyConversation(
+		t, db, "cNUM1", "numeric user_initiated",
+		"/home/user/dev/app", "claude-sonnet-4-6", "cPARENT",
+		false, "2026-06-15T10:00:00Z",
+		"2026-06-15T10:00:10Z",
+	)
+	seedShelleyMessage(t, db, "cNUM1", 1, 1, "user",
+		`{"Role":0,"Content":[{"Type":2,"Text":"hello"}]}`,
+		"", "", "2026-06-15T10:00:00Z")
+
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat db")
+	result, err := ParseShelleyConversationDirect(
+		dbPath, "cNUM1", "m", info,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, RelSubagent, result.Session.RelationshipType,
+		"numeric false user_initiated should map to subagent")
+
+	conn, err := OpenShelleyDB(dbPath)
+	require.NoError(t, err, "open shelley db")
+	defer conn.Close()
+	metas, err := ListShelleyConversationMetas(conn, dbPath)
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	assert.Equal(t, result.Session.File.Hash, metas[0].Fingerprint,
+		"parse and meta paths should convert user_initiated the same way")
 }
 
 func TestApplyShelleyUsageTolerant(t *testing.T) {

--- a/internal/parser/shelley_test.go
+++ b/internal/parser/shelley_test.go
@@ -323,6 +323,82 @@ func TestShelleyTokenCount(t *testing.T) {
 	}
 }
 
+// TestParseShelleyTimestampFormats verifies the real on-disk DATETIME
+// format Shelley writes (space-separated, no T/Z) parses into non-zero
+// timestamps. Shelley relies on SQLite's DEFAULT CURRENT_TIMESTAMP, so
+// stored values look like "2026-06-15 10:00:00".
+func TestParseShelleyTimestampFormats(t *testing.T) {
+	_, dbPath, db := newShelleyTestDB(t)
+	seedShelleyConversation(
+		t, db, "cTIME1", "ts", "/home/user/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15 10:00:00", "2026-06-15 10:00:30",
+	)
+	seedShelleyMessage(t, db, "cTIME1", 1, 1, "user",
+		`{"Role":0,"Content":[{"Type":0,"Text":"hi"}]}`,
+		"", "", "2026-06-15 10:00:00")
+
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat db")
+	result, err := ParseShelleyConversationDirect(dbPath, "cTIME1", "m", info)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.Session.StartedAt.IsZero(), "StartedAt parsed")
+	assert.False(t, result.Session.EndedAt.IsZero(), "EndedAt parsed")
+	assert.Positive(t, result.Session.File.Mtime, "File.Mtime positive")
+}
+
+// TestParseShelleyRobustContent verifies graceful handling of unknown
+// content types, redacted thinking, malformed llm_data, and token
+// capture on errored assistant turns (type="error").
+func TestParseShelleyRobustContent(t *testing.T) {
+	_, dbPath, db := newShelleyTestDB(t)
+	seedShelleyConversation(
+		t, db, "cROB1", "robust", "/home/user/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:40Z",
+	)
+	seedShelleyMessage(t, db, "cROB1", 1, 1, "user",
+		`{"Role":0,"Content":[{"Type":0,"Text":"go"}]}`,
+		"", "", "2026-06-15T10:00:00Z")
+	// Unknown content type (99) is ignored; redacted thinking (2) is
+	// surfaced as a placeholder; the text block survives.
+	seedShelleyMessage(t, db, "cROB1", 2, 1, "agent",
+		`{"Role":1,"Content":[{"Type":2},{"Type":99,"Text":"ignored"},`+
+			`{"Type":0,"Text":"real text"}]}`,
+		"", "", "2026-06-15T10:00:05Z")
+	// Malformed llm_data with no user_data fallback is dropped.
+	seedShelleyMessage(t, db, "cROB1", 3, 1, "agent",
+		`{not json`, "", "", "2026-06-15T10:00:06Z")
+	// Errored assistant turn stored as type="error" still carries usage.
+	seedShelleyMessage(t, db, "cROB1", 4, 1, "error",
+		`{"Role":1,"Content":[{"Type":0,"Text":"request failed"}]}`,
+		"",
+		`{"input_tokens":700,"output_tokens":40,"model":"claude-sonnet-4-6"}`,
+		"2026-06-15T10:00:40Z")
+
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat db")
+	result, err := ParseShelleyConversationDirect(dbPath, "cROB1", "m", info)
+	require.NoError(t, err, "must not error on robust content")
+	require.NotNil(t, result)
+
+	// user + agent(real text) + error message; the malformed row dropped.
+	require.Len(t, result.Messages, 3, "messages len")
+	agentMsg := result.Messages[1]
+	assert.Equal(t, "real text", agentMsg.Content, "unknown type ignored, text kept")
+	assert.Contains(t, agentMsg.ThinkingText, "redacted", "redacted thinking placeholder")
+
+	errMsg := result.Messages[2]
+	assert.True(t, errMsg.IsSystem, "error message flagged system")
+	assert.Equal(t, "request failed", errMsg.Content, "error text preserved")
+	assert.Equal(t, 40, errMsg.OutputTokens, "errored-turn output tokens captured")
+	assert.Equal(t, 700, errMsg.ContextTokens, "errored-turn input tokens captured")
+
+	// Errored-turn tokens roll up into the session totals.
+	assert.Equal(t, 40, result.Session.TotalOutputTokens, "session output total")
+}
+
 func TestApplyShelleyUsageTolerant(t *testing.T) {
 	var msg ParsedMessage
 	applyShelleyUsage(&msg,

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -192,6 +192,18 @@ func NormalizeToolCategory(rawName string) string {
 	case "code_interpreter":
 		return "Bash"
 
+	// Shelley (exe.dev) tools (excluding names already handled above:
+	// bash/shell→Bash, patch→Edit, browser/web_search/web_fetch→Tool,
+	// subagent→Task via the default).
+	case "keyword_search":
+		return "Grep"
+	case "read_context_file", "read_image":
+		return "Read"
+	case "change_dir", "output_iframe", "llm_one_shot",
+		"browser_emulate", "browser_network",
+		"browser_accessibility", "browser_profile":
+		return "Tool"
+
 	// Warp tools
 	case "read_files":
 		return "Read"

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -47,6 +47,7 @@ const (
 	AgentZed            AgentType = "zed"
 	AgentQwenPaw        AgentType = "qwenpaw"
 	AgentGptme          AgentType = "gptme"
+	AgentShelley        AgentType = "shelley"
 )
 
 // AgentDef describes a supported coding agent's filesystem
@@ -560,6 +561,20 @@ var Registry = []AgentDef{
 		FileBased:      true,
 		DiscoverFunc:   DiscoverGptmeSessions,
 		FindSourceFunc: FindGptmeSourceFile,
+	},
+	{
+		// Shelley (exe.dev) stores all conversations in a single
+		// SQLite DB at ~/.config/shelley/shelley.db. Like Zed, each
+		// conversation is addressed by a virtual path (dbPath#id).
+		Type:           AgentShelley,
+		DisplayName:    "Shelley",
+		EnvVar:         "SHELLEY_DIR",
+		ConfigKey:      "shelley_dirs",
+		DefaultDirs:    []string{".config/shelley"},
+		IDPrefix:       "shelley:",
+		FileBased:      true,
+		DiscoverFunc:   DiscoverShelleySessions,
+		FindSourceFunc: FindShelleySourceFile,
 	},
 }
 

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -332,6 +332,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentZencoder,
 		AgentGptme,
 		AgentQwenPaw,
+		AgentShelley,
 	}
 
 	expected := make(map[AgentType]bool, len(allTypes))

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -1118,6 +1119,22 @@ func (s *Sync) pushMessages(
 				err,
 			)
 		}
+		localContentHashFP, err := s.local.MessageContentHashFingerprint(sessionID)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing local content hash fingerprint: %w",
+				err,
+			)
+		}
+		pgContentHashFP, err := pgMessageContentHashFingerprint(
+			ctx, tx, sessionID,
+		)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing pg content hash fingerprint: %w",
+				err,
+			)
+		}
 		localSysFP, err := s.local.SystemMessageFingerprint(sessionID)
 		if err != nil {
 			return 0, fmt.Errorf(
@@ -1176,6 +1193,7 @@ func (s *Sync) pushMessages(
 		if localSum == pgContentSum &&
 			localMax == pgContentMax &&
 			localMin == pgContentMin &&
+			localContentHashFP == pgContentHashFP &&
 			localSysFP == pgSystemFP.String &&
 			localTCCount == pgToolCallCount &&
 			localTCSum == pgTCContentSum &&
@@ -1515,6 +1533,36 @@ func pgMessageTokenFingerprint(
 			len(srcParentUUID), srcParentUUID,
 			isSidechain, isCompactBoundary,
 		)
+	}
+	return b.String(), rows.Err()
+}
+
+func pgMessageContentHashFingerprint(
+	ctx context.Context, tx *sql.Tx, sessionID string,
+) (string, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT ordinal, COALESCE(content, ''), content_length
+		 FROM messages
+		 WHERE session_id = $1
+		 ORDER BY ordinal ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var ordinal, contentLength int
+		var content string
+		if err := rows.Scan(
+			&ordinal, &content, &contentLength,
+		); err != nil {
+			return "", err
+		}
+		sum := sha256.Sum256([]byte(db.SanitizeUTF8(content)))
+		fmt.Fprintf(&b, "%d|%d|%x;", ordinal, contentLength, sum)
 	}
 	return b.String(), rows.Err()
 }

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1135,8 +1135,8 @@ func (s *Sync) pushMessages(
 				err,
 			)
 		}
-		localRoleTimeFP, err := s.local.MessageRoleTimeFingerprint(
-			sessionID,
+		localRoleTimeFP, err := localMessageRoleTimePGFingerprint(
+			s.local, sessionID,
 		)
 		if err != nil {
 			return 0, fmt.Errorf(
@@ -1599,6 +1599,23 @@ func pgMessageContentHashFingerprint(
 		fmt.Fprintf(&b, "%d|%d|%x;", ordinal, contentLength, sum)
 	}
 	return b.String(), rows.Err()
+}
+
+func localMessageRoleTimePGFingerprint(
+	local *db.DB, sessionID string,
+) (string, error) {
+	return local.MessageRoleTimeFingerprintWithTimestampNormalizer(
+		sessionID,
+		pgPushTimestampFingerprintText,
+	)
+}
+
+func pgPushTimestampFingerprintText(value string) string {
+	t, ok := ParseSQLiteTimestamp(value)
+	if !ok {
+		return ""
+	}
+	return FormatISO8601(t.Truncate(time.Microsecond))
 }
 
 func pgMessageRoleTimeFingerprint(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1135,6 +1135,38 @@ func (s *Sync) pushMessages(
 				err,
 			)
 		}
+		localRoleTimeFP, err := s.local.MessageRoleTimeFingerprint(
+			sessionID,
+		)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing local role/time fingerprint: %w",
+				err,
+			)
+		}
+		pgRoleTimeFP, err := pgMessageRoleTimeFingerprint(
+			ctx, tx, sessionID,
+		)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing pg role/time fingerprint: %w",
+				err,
+			)
+		}
+		localFlagsFP, err := s.local.MessageFlagsFingerprint(sessionID)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing local message flags fingerprint: %w",
+				err,
+			)
+		}
+		pgFlagsFP, err := pgMessageFlagsFingerprint(ctx, tx, sessionID)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing pg message flags fingerprint: %w",
+				err,
+			)
+		}
 		localSysFP, err := s.local.SystemMessageFingerprint(sessionID)
 		if err != nil {
 			return 0, fmt.Errorf(
@@ -1194,6 +1226,8 @@ func (s *Sync) pushMessages(
 			localMax == pgContentMax &&
 			localMin == pgContentMin &&
 			localContentHashFP == pgContentHashFP &&
+			localRoleTimeFP == pgRoleTimeFP &&
+			localFlagsFP == pgFlagsFP &&
 			localSysFP == pgSystemFP.String &&
 			localTCCount == pgToolCallCount &&
 			localTCSum == pgTCContentSum &&
@@ -1563,6 +1597,78 @@ func pgMessageContentHashFingerprint(
 		}
 		sum := sha256.Sum256([]byte(db.SanitizeUTF8(content)))
 		fmt.Fprintf(&b, "%d|%d|%x;", ordinal, contentLength, sum)
+	}
+	return b.String(), rows.Err()
+}
+
+func pgMessageRoleTimeFingerprint(
+	ctx context.Context, tx *sql.Tx, sessionID string,
+) (string, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT ordinal, role, timestamp
+		 FROM messages
+		 WHERE session_id = $1
+		 ORDER BY ordinal ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var ordinal int
+		var role string
+		var timestamp sql.NullTime
+		if err := rows.Scan(
+			&ordinal, &role, &timestamp,
+		); err != nil {
+			return "", err
+		}
+		role = db.SanitizeUTF8(role)
+		timestampText := ""
+		if timestamp.Valid {
+			timestampText = FormatISO8601(timestamp.Time)
+		}
+		fmt.Fprintf(&b, "%d|%d:%s|%d:%s;",
+			ordinal, len(role), role,
+			len(timestampText), timestampText,
+		)
+	}
+	return b.String(), rows.Err()
+}
+
+func pgMessageFlagsFingerprint(
+	ctx context.Context, tx *sql.Tx, sessionID string,
+) (string, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT ordinal, is_system, has_thinking, has_tool_use,
+			COALESCE(thinking_text, '')
+		 FROM messages
+		 WHERE session_id = $1
+		 ORDER BY ordinal ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var ordinal int
+		var isSystem, hasThinking, hasToolUse bool
+		var thinkingText string
+		if err := rows.Scan(
+			&ordinal, &isSystem, &hasThinking, &hasToolUse,
+			&thinkingText,
+		); err != nil {
+			return "", err
+		}
+		sum := sha256.Sum256([]byte(db.SanitizeUTF8(thinkingText)))
+		fmt.Fprintf(&b, "%d|%t|%t|%t|%x;",
+			ordinal, isSystem, hasThinking, hasToolUse, sum)
 	}
 	return b.String(), rows.Err()
 }

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -115,6 +115,79 @@ func TestPushSystemFingerprintCollisionRegression(t *testing.T) {
 	checkIsSystem(t, pg, sessID, secondSet, 7)
 }
 
+func TestPushMessageContentHashRewriteRegression(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_contenthash_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessID = "content-hash-rewrite-001"
+	sess := db.Session{
+		ID:               sessID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "shelley",
+		MessageCount:     2,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+	msgs := []db.Message{
+		{
+			SessionID:     sessID,
+			Ordinal:       1,
+			Role:          "user",
+			Content:       "question",
+			ContentLength: len("question"),
+		},
+		{
+			SessionID:     sessID,
+			Ordinal:       2,
+			Role:          "assistant",
+			Content:       "answer aaaa",
+			ContentLength: len("answer aaaa"),
+		},
+	}
+	require.NoError(t, localDB.InsertMessages(msgs),
+		"InsertMessages first content")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push first content")
+	assertPGMessageContent(t, pg, sessID, 2, "answer aaaa")
+
+	msgs[1].Content = "answer bbbb"
+	msgs[1].ContentLength = len("answer bbbb")
+	require.NoError(t, localDB.ReplaceSessionMessages(sessID, msgs),
+		"ReplaceSessionMessages rewritten content")
+	require.NoError(t, localDB.SetSyncState("last_push_at", ""),
+		"clearing last_push_at")
+	require.NoError(t, localDB.SetSyncState(lastPushBoundaryStateKey, ""),
+		"clearing boundary state")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push rewritten content")
+	assertPGMessageContent(t, pg, sessID, 2, "answer bbbb")
+}
+
 // TestPushSessionTerminationStatus verifies that pushSession round-trips
 // the termination_status column to PG: a non-nil value writes the string,
 // and a subsequent push with nil clears the column back to NULL via the
@@ -361,6 +434,23 @@ func checkIsSystem(
 	for i := range wantTotal {
 		assert.True(t, seen[i], "ordinal %d missing from PG messages", i)
 	}
+}
+
+func assertPGMessageContent(
+	t *testing.T,
+	pg *sql.DB,
+	sessionID string,
+	ordinal int,
+	want string,
+) {
+	t.Helper()
+	var got string
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM messages
+		  WHERE session_id = $1 AND ordinal = $2`,
+		sessionID, ordinal,
+	).Scan(&got), "read pg message content")
+	assert.Equal(t, want, got)
 }
 
 // TestPushMessagesSanitizesNULBytes verifies that a message whose

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -262,6 +262,68 @@ func TestPushMessageFlagsRewriteRegression(t *testing.T) {
 		"private chain of thought")
 }
 
+func TestPushMessageNanosecondTimestampNoRewriteRegression(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_msgtime_nanos_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessID = "message-nanotime-rewrite-001"
+	sess := db.Session{
+		ID:               sessID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "shelley",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     sessID,
+		Ordinal:       1,
+		Role:          "user",
+		Content:       "question",
+		ContentLength: len("question"),
+		Timestamp:     "2026-01-01T00:00:00.123456789Z",
+	}}), "InsertMessages")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push first timestamp")
+	assertPGMessageTimestamp(t, pg, sessID, 1,
+		"2026-01-01T00:00:00.123456Z")
+
+	ctidBefore := pgMessageCTID(t, pg, sessID, 1)
+	require.NoError(t, localDB.SetSyncState("last_push_at", ""),
+		"clearing last_push_at")
+	require.NoError(t, localDB.SetSyncState(lastPushBoundaryStateKey, ""),
+		"clearing boundary state")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push same timestamp")
+	assert.Equal(t, ctidBefore, pgMessageCTID(t, pg, sessID, 1),
+		"microsecond-equivalent timestamps should hit the fast path")
+}
+
 // TestPushSessionTerminationStatus verifies that pushSession round-trips
 // the termination_status column to PG: a non-nil value writes the string,
 // and a subsequent push with nil clears the column back to NULL via the
@@ -545,6 +607,40 @@ func assertPGMessageThinking(
 	).Scan(&gotHasThinking, &gotThinkingText), "read pg message thinking")
 	assert.Equal(t, wantHasThinking, gotHasThinking)
 	assert.Equal(t, wantThinkingText, gotThinkingText)
+}
+
+func assertPGMessageTimestamp(
+	t *testing.T,
+	pg *sql.DB,
+	sessionID string,
+	ordinal int,
+	want string,
+) {
+	t.Helper()
+	var gotTime sql.NullTime
+	require.NoError(t, pg.QueryRow(
+		`SELECT timestamp FROM messages
+		  WHERE session_id = $1 AND ordinal = $2`,
+		sessionID, ordinal,
+	).Scan(&gotTime), "read pg message timestamp")
+	require.True(t, gotTime.Valid, "timestamp should be non-NULL")
+	assert.Equal(t, want, FormatISO8601(gotTime.Time))
+}
+
+func pgMessageCTID(
+	t *testing.T,
+	pg *sql.DB,
+	sessionID string,
+	ordinal int,
+) string {
+	t.Helper()
+	var ctid string
+	require.NoError(t, pg.QueryRow(
+		`SELECT ctid::text FROM messages
+		  WHERE session_id = $1 AND ordinal = $2`,
+		sessionID, ordinal,
+	).Scan(&ctid), "read pg message ctid")
+	return ctid
 }
 
 // TestPushMessagesSanitizesNULBytes verifies that a message whose

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -188,6 +188,80 @@ func TestPushMessageContentHashRewriteRegression(t *testing.T) {
 	assertPGMessageContent(t, pg, sessID, 2, "answer bbbb")
 }
 
+func TestPushMessageFlagsRewriteRegression(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_msgflags_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessID = "message-flags-rewrite-001"
+	sess := db.Session{
+		ID:               sessID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "shelley",
+		MessageCount:     2,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+	msgs := []db.Message{
+		{
+			SessionID:     sessID,
+			Ordinal:       1,
+			Role:          "user",
+			Content:       "question",
+			ContentLength: len("question"),
+		},
+		{
+			SessionID:     sessID,
+			Ordinal:       2,
+			Role:          "assistant",
+			Content:       "answer",
+			ContentLength: len("answer"),
+		},
+	}
+	require.NoError(t, localDB.InsertMessages(msgs),
+		"InsertMessages first metadata")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push first metadata")
+	assertPGMessageThinking(t, pg, sessID, 2, false, "")
+
+	msgs[1].ThinkingText = "private chain of thought"
+	msgs[1].HasThinking = true
+	require.NoError(t, localDB.ReplaceSessionMessages(sessID, msgs),
+		"ReplaceSessionMessages rewritten metadata")
+	require.NoError(t, localDB.SetSyncState("last_push_at", ""),
+		"clearing last_push_at")
+	require.NoError(t, localDB.SetSyncState(lastPushBoundaryStateKey, ""),
+		"clearing boundary state")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push rewritten metadata")
+	assertPGMessageThinking(t, pg, sessID, 2, true,
+		"private chain of thought")
+}
+
 // TestPushSessionTerminationStatus verifies that pushSession round-trips
 // the termination_status column to PG: a non-nil value writes the string,
 // and a subsequent push with nil clears the column back to NULL via the
@@ -451,6 +525,26 @@ func assertPGMessageContent(
 		sessionID, ordinal,
 	).Scan(&got), "read pg message content")
 	assert.Equal(t, want, got)
+}
+
+func assertPGMessageThinking(
+	t *testing.T,
+	pg *sql.DB,
+	sessionID string,
+	ordinal int,
+	wantHasThinking bool,
+	wantThinkingText string,
+) {
+	t.Helper()
+	var gotHasThinking bool
+	var gotThinkingText string
+	require.NoError(t, pg.QueryRow(
+		`SELECT has_thinking, thinking_text FROM messages
+		  WHERE session_id = $1 AND ordinal = $2`,
+		sessionID, ordinal,
+	).Scan(&gotHasThinking, &gotThinkingText), "read pg message thinking")
+	assert.Equal(t, wantHasThinking, gotHasThinking)
+	assert.Equal(t, wantThinkingText, gotThinkingText)
 }
 
 // TestPushMessagesSanitizesNULBytes verifies that a message whose

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -305,6 +306,42 @@ func TestSessionPushFingerprintNoFieldCollisions(
 		sessionPushFingerprint(s1, s1.Machine, ""),
 		sessionPushFingerprint(s2, s2.Machine, ""),
 		"length-prefixed fingerprints should not collide")
+}
+
+func TestLocalMessageRoleTimePGFingerprintNormalizesNanoseconds(
+	t *testing.T,
+) {
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	const sessID = "pg-role-time-nanos"
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:        sessID,
+		Project:   "proj",
+		Machine:   "host",
+		Agent:     "shelley",
+		CreatedAt: "2026-03-11T12:34:56Z",
+	}), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     sessID,
+		Ordinal:       1,
+		Role:          "assistant",
+		Content:       "answer",
+		ContentLength: len("answer"),
+		Timestamp:     "2026-03-11T12:34:56.123456789Z",
+	}}), "InsertMessages")
+
+	got, err := localMessageRoleTimePGFingerprint(localDB, sessID)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"1|9:assistant|27:2026-03-11T12:34:56.123456Z;",
+		got)
+
+	raw, err := localDB.MessageRoleTimeFingerprint(sessID)
+	require.NoError(t, err)
+	assert.NotEqual(t, raw, got,
+		"PG push fingerprint must not use raw nanosecond text")
 }
 
 func TestFinalizePushStatePersistsEmptyBoundary(

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -54,8 +54,8 @@ func (s *Store) SetCursorSecret(secret []byte) {
 // and pins) is writable through dedicated methods.
 func (s *Store) ReadOnly() bool { return true }
 
-// GetSessionVersion returns the message count and a hash of
-// updated_at for SSE change detection.
+// GetSessionVersion returns the message count and a compact version
+// marker for SSE change detection.
 func (s *Store) GetSessionVersion(
 	id string,
 ) (int, int64, bool) {
@@ -69,12 +69,7 @@ func (s *Store) GetSessionVersion(
 	if err != nil {
 		return 0, 0, false
 	}
-	formatted := FormatISO8601(updatedAt)
-	var h int64
-	for _, c := range formatted {
-		h = h*31 + int64(c)
-	}
-	return count, h, true
+	return count, db.SessionVersionMarker(FormatISO8601(updatedAt)), true
 }
 
 // ------------------------------------------------------------

--- a/internal/sessionwatch/watcher.go
+++ b/internal/sessionwatch/watcher.go
@@ -43,7 +43,7 @@ func New(d db.Store, engine *sync.Engine) *Watcher {
 }
 
 // Events polls the database for session changes and signals the
-// returned channel when the message count changes. This is
+// returned channel when the session version changes. This is
 // decoupled from file I/O — the file watcher handles syncing
 // files to the database, and this monitor detects the resulting
 // DB changes.
@@ -60,7 +60,7 @@ func (w *Watcher) Events(
 		defer close(ch)
 
 		// Seed initial state from the database.
-		lastCount, lastDBMtime, _ := w.db.GetSessionVersion(
+		lastCount, lastDBVersion, _ := w.db.GetSessionVersion(
 			sessionID,
 		)
 
@@ -68,7 +68,7 @@ func (w *Watcher) Events(
 			// PG read mode: poll GetSessionVersion only,
 			// no file watching or fallback sync.
 			w.pollDBOnly(ctx, ch, sessionID,
-				lastCount, lastDBMtime)
+				lastCount, lastDBVersion)
 			return
 		}
 
@@ -91,7 +91,7 @@ func (w *Watcher) Events(
 				changed := w.checkDBForChanges(
 					sessionID,
 					&lastCount,
-					&lastDBMtime,
+					&lastDBVersion,
 					&sourcePath,
 					&lastFileMtime,
 					&fileMtimeChangedAt,
@@ -114,7 +114,7 @@ func (w *Watcher) Events(
 // no sync engine or file watcher.
 func (w *Watcher) pollDBOnly(
 	ctx context.Context, ch chan<- struct{},
-	sessionID string, lastCount int, lastDBMtime int64,
+	sessionID string, lastCount int, lastDBVersion int64,
 ) {
 	ticker := time.NewTicker(PollInterval)
 	defer ticker.Stop()
@@ -124,10 +124,10 @@ func (w *Watcher) pollDBOnly(
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			count, dbMtime, ok := w.db.GetSessionVersion(sessionID)
-			if ok && (count != lastCount || dbMtime != lastDBMtime) {
+			count, dbVersion, ok := w.db.GetSessionVersion(sessionID)
+			if ok && (count != lastCount || dbVersion != lastDBVersion) {
 				lastCount = count
-				lastDBMtime = dbMtime
+				lastDBVersion = dbVersion
 				select {
 				case ch <- struct{}{}:
 				case <-ctx.Done():
@@ -138,28 +138,25 @@ func (w *Watcher) pollDBOnly(
 	}
 }
 
-// checkDBForChanges polls the database for a session's
-// message_count and file_mtime. If either changed, it
-// returns true. As a fallback, it monitors source file
-// mtime and triggers a direct sync when the watcher
-// hasn't updated the DB.
+// checkDBForChanges polls the database for a session version change.
+// As a fallback, it monitors source file mtime and triggers a direct
+// sync when the watcher hasn't updated the DB.
 func (w *Watcher) checkDBForChanges(
 	sessionID string,
 	lastCount *int,
-	lastDBMtime *int64,
+	lastDBVersion *int64,
 	sourcePath *string,
 	lastFileMtime *int64,
 	fileMtimeChangedAt *time.Time,
 ) bool {
-	// Primary: check if the DB has new data (message count
-	// or file_mtime changed, covering both message appends
-	// and metadata-only updates like progress events).
-	if count, dbMtime, ok := w.db.GetSessionVersion(
+	// Primary: check if the DB has new data. The version marker covers
+	// message appends and metadata/content-only updates.
+	if count, dbVersion, ok := w.db.GetSessionVersion(
 		sessionID,
 	); ok && (count != *lastCount ||
-		dbMtime != *lastDBMtime) {
+		dbVersion != *lastDBVersion) {
 		*lastCount = count
-		*lastDBMtime = dbMtime
+		*lastDBVersion = dbVersion
 		// DB was updated; clear any pending fallback.
 		*fileMtimeChangedAt = time.Time{}
 		return true
@@ -208,12 +205,12 @@ func (w *Watcher) checkDBForChanges(
 			return false
 		}
 		// Re-check the DB after syncing.
-		if count, dbMtime, ok := w.db.GetSessionVersion(
+		if count, dbVersion, ok := w.db.GetSessionVersion(
 			sessionID,
 		); ok && (count != *lastCount ||
-			dbMtime != *lastDBMtime) {
+			dbVersion != *lastDBVersion) {
 			*lastCount = count
-			*lastDBMtime = dbMtime
+			*lastDBVersion = dbVersion
 			return true
 		}
 	}

--- a/internal/sessionwatch/watcher_test.go
+++ b/internal/sessionwatch/watcher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
 )
@@ -70,4 +71,45 @@ func TestCheckDBForChanges_FileDisappears(t *testing.T) {
 	assert.False(t, changed, "expected no change signal")
 	assert.Empty(t, path)
 	assert.Equal(t, int64(0), lastMtime)
+}
+
+func TestCheckDBForChanges_FileHashChange(t *testing.T) {
+	t.Parallel()
+	w := testWatcher(t)
+	database, ok := w.db.(*db.DB)
+	require.True(t, ok, "test watcher should use SQLite DB")
+
+	const sessionID = "hash-change"
+	var mtime int64 = 12345
+	hash1 := "shelley-fingerprint-1"
+	dbtest.SeedSession(t, database, sessionID, "proj", func(s *db.Session) {
+		s.MessageCount = 2
+		s.FileMtime = &mtime
+		s.FileHash = &hash1
+	})
+
+	lastCount, lastDBMtime, ok := w.db.GetSessionVersion(sessionID)
+	require.True(t, ok, "initial session version")
+
+	hash2 := "shelley-fingerprint-2"
+	dbtest.SeedSession(t, database, sessionID, "proj", func(s *db.Session) {
+		s.MessageCount = 2
+		s.FileMtime = &mtime
+		s.FileHash = &hash2
+	})
+
+	sourcePath := ""
+	var lastFileMtime int64
+	var mchanged time.Time
+	changed := w.checkDBForChanges(
+		sessionID,
+		&lastCount,
+		&lastDBMtime,
+		&sourcePath,
+		&lastFileMtime,
+		&mchanged,
+	)
+
+	assert.True(t, changed,
+		"file_hash-only rewrites must refresh session watchers")
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -484,6 +484,9 @@ func (e *Engine) classifyOnePath(
 	if df, ok := e.classifyZedSQLitePath(path); ok {
 		return df, true
 	}
+	if df, ok := e.classifyShelleySQLitePath(path); ok {
+		return df, true
+	}
 	if !pathExists {
 		return parser.DiscoveredFile{}, false
 	}
@@ -1579,6 +1582,53 @@ func (e *Engine) classifyZedSQLitePath(
 	return parser.DiscoveredFile{}, false
 }
 
+const shelleyDBFile = "shelley.db"
+
+// classifyShelleySQLitePath classifies a Shelley source path. Shelley
+// stores every conversation in a single shelley.db under its config
+// directory, so paths are either a virtual conversation path
+// (shelley.db#<id>) or the real DB file and its WAL/SHM siblings.
+func (e *Engine) classifyShelleySQLitePath(
+	path string,
+) (parser.DiscoveredFile, bool) {
+	// Virtual path: shelley.db#<conversationID>
+	if dbPath, _, ok := parser.ParseShelleyVirtualPath(path); ok {
+		for _, dir := range e.agentDirs[parser.AgentShelley] {
+			if _, under := isUnder(dir, dbPath); under {
+				return parser.DiscoveredFile{
+					Path:  path,
+					Agent: parser.AgentShelley,
+				}, true
+			}
+		}
+	}
+	// Real path: shelley.db or its WAL/SHM siblings. Handled here
+	// (before the !pathExists guard) so that delete and rename events
+	// on shelley.db-wal / shelley.db-shm are not dropped when the
+	// sibling no longer exists on disk.
+	for _, dir := range e.agentDirs[parser.AgentShelley] {
+		if dir == "" {
+			continue
+		}
+		rel, ok := isUnder(dir, path)
+		if !ok {
+			continue
+		}
+		base := filepath.Base(rel)
+		if rel != shelleyDBFile && !strings.HasPrefix(base, shelleyDBFile+"-") {
+			continue
+		}
+		dbPath := filepath.Join(dir, shelleyDBFile)
+		if fi, err := os.Stat(dbPath); err == nil && !fi.IsDir() {
+			return parser.DiscoveredFile{
+				Path:  dbPath,
+				Agent: parser.AgentShelley,
+			}, true
+		}
+	}
+	return parser.DiscoveredFile{}, false
+}
+
 // vscodeJSONLSiblingExists returns true when path is a .json
 // file and a .jsonl sibling exists for the same UUID. This
 // mirrors the dedup logic in DiscoverVSCodeCopilotSessions.
@@ -2578,6 +2628,13 @@ func discoveredFileMtime(
 		}
 		return zedDBCompositeMtime(dbPath)
 	}
+	if file.Agent == parser.AgentShelley {
+		dbPath := file.Path
+		if p, _, ok := parser.ParseShelleyVirtualPath(file.Path); ok {
+			dbPath = p
+		}
+		return shelleyDBCompositeMtime(dbPath)
+	}
 	if file.Agent == parser.AgentAntigravityCLI {
 		info, err := parser.AntigravityCLIFileInfo(file.Path)
 		if err != nil {
@@ -2626,6 +2683,27 @@ func discoveredFileMtime(
 // do not touch threads.db itself, so the composite is needed to
 // detect all changes.
 func zedDBCompositeMtime(dbPath string) (int64, error) {
+	var maxMtime int64
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		info, err := os.Stat(dbPath + suffix)
+		if err != nil {
+			continue
+		}
+		if t := info.ModTime().UnixNano(); t > maxMtime {
+			maxMtime = t
+		}
+	}
+	if maxMtime == 0 {
+		return 0, &os.PathError{Op: "stat", Path: dbPath, Err: os.ErrNotExist}
+	}
+	return maxMtime, nil
+}
+
+// shelleyDBCompositeMtime returns the maximum mtime across the Shelley
+// shelley.db main file and its WAL/SHM siblings. The DB is WAL-mode and
+// churns constantly, so WAL-only updates that do not touch shelley.db
+// itself still need to be detected.
+func shelleyDBCompositeMtime(dbPath string) (int64, error) {
 	var maxMtime int64
 	for _, suffix := range []string{"", "-wal", "-shm"} {
 		info, err := os.Stat(dbPath + suffix)
@@ -3319,6 +3397,8 @@ func (e *Engine) processFile(
 			statPath = dbPath
 		} else if dbPath, _, ok := parser.ParseZedSQLiteVirtualPath(file.Path); ok {
 			statPath = dbPath
+		} else if dbPath, _, ok := parser.ParseShelleyVirtualPath(file.Path); ok {
+			statPath = dbPath
 		}
 		info, err = os.Stat(statPath)
 	}
@@ -3417,6 +3497,8 @@ func (e *Engine) processFile(
 		res = e.processPositron(file, info)
 	case parser.AgentZed:
 		res = e.processZed(file, info)
+	case parser.AgentShelley:
+		res = e.processShelley(file, info)
 	case parser.AgentAntigravity:
 		res = e.processAntigravity(file, info)
 	case parser.AgentAntigravityCLI:
@@ -3453,6 +3535,14 @@ func (e *Engine) shouldCacheSkip(
 			return false
 		}
 		if _, _, ok := parser.ParseZedSQLiteVirtualPath(file.Path); ok {
+			return false
+		}
+	}
+	if file.Agent == parser.AgentShelley {
+		if filepath.Base(file.Path) == shelleyDBFile {
+			return false
+		}
+		if _, _, ok := parser.ParseShelleyVirtualPath(file.Path); ok {
 			return false
 		}
 	}
@@ -4725,6 +4815,80 @@ func (e *Engine) processZed(
 				})
 			} else {
 				log.Printf("zed thread %s: %v", meta.RawID, err)
+			}
+			continue
+		}
+		if result == nil {
+			continue
+		}
+		if hash != "" {
+			result.Session.File.Hash = hash
+		}
+		results = append(results, *result)
+	}
+	return processResult{
+		results:      results,
+		sessionErrs:  sessionErrs,
+		forceReplace: true,
+	}
+}
+
+func (e *Engine) processShelley(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	if dbPath, sessionID, ok := parser.ParseShelleyVirtualPath(file.Path); ok {
+		result, err := parser.ParseShelleyConversationDirect(
+			dbPath, sessionID, e.machine, info,
+		)
+		if err != nil {
+			return processResult{err: err}
+		}
+		if result == nil {
+			return processResult{}
+		}
+		if hash, err := ComputeFileHash(dbPath); err == nil {
+			result.Session.File.Hash = hash
+		}
+		return processResult{
+			results:      []parser.ParseResult{*result},
+			forceReplace: true,
+		}
+	}
+	conn, err := parser.OpenShelleyDB(file.Path)
+	if err != nil {
+		return processResult{err: err}
+	}
+	defer conn.Close()
+
+	metas, err := parser.ListShelleyConversationMetas(conn, file.Path)
+	if err != nil {
+		return processResult{err: err}
+	}
+
+	hash, _ := ComputeFileHash(file.Path)
+
+	var results []parser.ParseResult
+	var sessionErrs []sessionParseError
+	for _, meta := range metas {
+		_, storedMtime, ok := e.db.GetFileInfoByPath(meta.VirtualPath)
+		// parse-diff: !e.forceParse disables the stored-state skip.
+		if !e.forceParse && ok && storedMtime == meta.FileMtime &&
+			e.db.GetDataVersionByPath(meta.VirtualPath) >=
+				db.CurrentDataVersion() {
+			continue
+		}
+		result, err := parser.ParseShelleyConversationFromDB(
+			conn, file.Path, meta.RawID, e.machine, info,
+		)
+		if err != nil {
+			if e.forceParse {
+				sessionErrs = append(sessionErrs, sessionParseError{
+					sessionID:   meta.RawID,
+					virtualPath: meta.VirtualPath,
+					err:         err,
+				})
+			} else {
+				log.Printf("shelley conversation %s: %v", meta.RawID, err)
 			}
 			continue
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4846,9 +4846,9 @@ func (e *Engine) processShelley(
 		if result == nil {
 			return processResult{}
 		}
-		if hash, err := ComputeFileHash(dbPath); err == nil {
-			result.Session.File.Hash = hash
-		}
+		// File.Hash is the parser's per-conversation content fingerprint;
+		// the whole-db hash would be identical across conversations and is
+		// not used for Shelley change detection.
 		return processResult{
 			results:      []parser.ParseResult{*result},
 			forceReplace: true,
@@ -4865,14 +4865,17 @@ func (e *Engine) processShelley(
 		return processResult{err: err}
 	}
 
-	hash, _ := ComputeFileHash(file.Path)
-
 	var results []parser.ParseResult
 	var sessionErrs []sessionParseError
 	for _, meta := range metas {
 		_, storedMtime, ok := e.db.GetFileInfoByPath(meta.VirtualPath)
+		storedHash, _ := e.db.GetFileHashByPath(meta.VirtualPath)
 		// parse-diff: !e.forceParse disables the stored-state skip.
+		// FileMtime alone has second precision, so the content fingerprint
+		// (stored in file_hash) catches same-second appends and in-place
+		// rewrites; see shelleyChangeMtime in the parser.
 		if !e.forceParse && ok && storedMtime == meta.FileMtime &&
+			storedHash == meta.Fingerprint &&
 			e.db.GetDataVersionByPath(meta.VirtualPath) >=
 				db.CurrentDataVersion() {
 			continue
@@ -4894,9 +4897,6 @@ func (e *Engine) processShelley(
 		}
 		if result == nil {
 			continue
-		}
-		if hash != "" {
-			result.Session.File.Hash = hash
 		}
 		results = append(results, *result)
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -6757,6 +6757,15 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 			return mtime
 		}
 	}
+	if def.Type == parser.AgentShelley {
+		if _, _, ok := parser.ParseShelleyVirtualPath(path); ok {
+			mtime, err := parser.ShelleySourceMtime(path)
+			if err != nil {
+				return 0
+			}
+			return mtime
+		}
+	}
 	if def.Type == parser.AgentAntigravityCLI {
 		info, err := parser.AntigravityCLIFileInfo(path)
 		if err != nil {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4868,15 +4868,19 @@ func (e *Engine) processShelley(
 	var results []parser.ParseResult
 	var sessionErrs []sessionParseError
 	for _, meta := range metas {
-		_, storedMtime, ok := e.db.GetFileInfoByPath(meta.VirtualPath)
-		storedHash, _ := e.db.GetFileHashByPath(meta.VirtualPath)
+		lookupPath := meta.VirtualPath
+		if e.pathRewriter != nil {
+			lookupPath = e.pathRewriter(lookupPath)
+		}
+		_, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
+		storedHash, _ := e.db.GetFileHashByPath(lookupPath)
 		// parse-diff: !e.forceParse disables the stored-state skip.
 		// FileMtime alone has second precision, so the content fingerprint
 		// (stored in file_hash) catches same-second appends and in-place
 		// rewrites; see shelleyChangeMtime in the parser.
 		if !e.forceParse && ok && storedMtime == meta.FileMtime &&
 			storedHash == meta.Fingerprint &&
-			e.db.GetDataVersionByPath(meta.VirtualPath) >=
+			e.db.GetDataVersionByPath(lookupPath) >=
 				db.CurrentDataVersion() {
 			continue
 		}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -37,6 +37,7 @@ type testEnv struct {
 	ampDir            string
 	piDir             string
 	kiroDir           string
+	shelleyDir        string
 	antigravityCLIDir string
 	db                *db.DB
 	engine            *sync.Engine
@@ -115,6 +116,7 @@ func setupTestEnv(t *testing.T, opts ...TestEnvOption) *testEnv {
 		iflowDir:          t.TempDir(),
 		ampDir:            t.TempDir(),
 		piDir:             t.TempDir(),
+		shelleyDir:        t.TempDir(),
 		antigravityCLIDir: t.TempDir(),
 		db:                dbtest.OpenTestDB(t),
 	}
@@ -182,6 +184,7 @@ func setupTestEnv(t *testing.T, opts ...TestEnvOption) *testEnv {
 			parser.AgentAmp:            {env.ampDir},
 			parser.AgentPi:             {env.piDir},
 			parser.AgentKiro:           kiroDirs,
+			parser.AgentShelley:        {env.shelleyDir},
 			parser.AgentAntigravityCLI: {env.antigravityCLIDir},
 		},
 		Machine: "local",

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -335,9 +335,10 @@ func sortAndLimitParseDiffFiles(
 	return files, cutPaths, limited
 }
 
-// stripVirtualSourceSuffix maps a stored file_path to its on-disk
-// base file by removing the "#rawID" suffix Kiro, Zed, OpenCode, and
-// Kilo SQLite-backed sessions append to their shared database path.
+// stripVirtualSourceSuffix maps a stored file_path to its on-disk base
+// file by removing the "#rawID" suffix that Kiro, Zed, OpenCode, Kilo,
+// MiMoCode, and Shelley SQLite-backed sessions append to their shared
+// database path.
 func stripVirtualSourceSuffix(path string) string {
 	if dbPath, _, ok := parser.ParseKiroSQLiteVirtualPath(path); ok {
 		return dbPath
@@ -352,6 +353,9 @@ func stripVirtualSourceSuffix(path string) string {
 		return dbPath
 	}
 	if dbPath, _, ok := parser.ParseMiMoCodeSQLiteVirtualPath(path); ok {
+		return dbPath
+	}
+	if dbPath, _, ok := parser.ParseShelleyVirtualPath(path); ok {
 		return dbPath
 	}
 	return path

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -42,6 +42,7 @@ func newParseDiffEngine(env *testEnv) *sync.Engine {
 			parser.AgentPi:             {env.piDir},
 			parser.AgentKiro:           {env.kiroDir},
 			parser.AgentKilo:           {env.kiloDir},
+			parser.AgentShelley:        {env.shelleyDir},
 			parser.AgentAntigravityCLI: {env.antigravityCLIDir},
 		},
 		Machine: "local",
@@ -950,6 +951,71 @@ func TestParseDiffCoversMixedKiloRoot(t *testing.T) {
 	assert.Equal(t, 2, report.FilesExamined,
 		"storage session file and kilo.db examined")
 	assert.False(t, report.HasFailures(), "clean mixed kilo run")
+}
+
+// TestParseDiffCoversShelley proves Shelley's shared shelley.db — which
+// DiscoverFunc emits as a single file and which normal sync fans out to
+// one session per conversation — is re-parsed and compared by parse-diff.
+// Examined:1/Identical:1 means the stored conversation was matched and
+// vetted, not bucketed as skipped/"not discovered".
+func TestParseDiffCoversShelley(t *testing.T) {
+	env := setupTestEnv(t)
+	dbPath := createShelleyDB(t, env.shelleyDir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:06Z", mainConvoMsgs())
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentShelley},
+	})
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Identical: 1,
+	}, report.Totals, "shelley conversation must be examined, not skipped")
+	assert.Equal(t, 1, report.FilesExamined, "shelley.db examined")
+	assert.False(t, report.HasFailures(), "clean shelley run")
+}
+
+// TestParseDiffShelleyDBErrorAttributed proves that when the whole
+// shelley.db can no longer be read, the stored conversations under it
+// are reported as DiffParseError attributed to their session IDs, not
+// misclassified as source-missing in the final sweep. This exercises
+// stripVirtualSourceSuffix mapping shelley.db#id back to shelley.db so
+// the parse error keyed by the real DB path matches the stored rows.
+func TestParseDiffShelleyDBErrorAttributed(t *testing.T) {
+	env := setupTestEnv(t)
+	dbPath := createShelleyDB(t, env.shelleyDir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:06Z", mainConvoMsgs())
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	// Break the DB so the conversation meta query fails: the file is
+	// still a regular shelley.db (so it is discovered), but reading it
+	// errors, forcing the whole-file job error path.
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = conn.Exec(`DROP TABLE messages`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentShelley},
+	})
+	assert.Equal(t, sync.ParseDiffTotals{ParseErrors: 1}, report.Totals,
+		"unreadable shelley.db is a parse error for the stored conversation")
+
+	sd := findSessionDiff(report, "shelley:cMAIN1")
+	require.NotNil(t, sd, "stored conversation attributed by session ID")
+	assert.Equal(t, sync.DiffParseError, sd.Class, "class")
+	assert.True(t, report.HasFailures(),
+		"a DB read failure must trip --fail-on-change")
 }
 
 // TestParseDiffKiroSQLitePerSessionError proves a malformed session

--- a/internal/sync/shelley_integration_test.go
+++ b/internal/sync/shelley_integration_test.go
@@ -114,6 +114,14 @@ func newShelleyEngine(t *testing.T, dir string) (*sync.Engine, *db.DB) {
 	return engine, database
 }
 
+func sessionIDs(sessions []db.Session) []string {
+	ids := make([]string, 0, len(sessions))
+	for _, s := range sessions {
+		ids = append(ids, s.ID)
+	}
+	return ids
+}
+
 func mainConvoMsgs() []shelleyMsg {
 	return []shelleyMsg{
 		{1, "user",
@@ -357,10 +365,20 @@ func TestSyncShelleySameSecondInPlaceRewrite(t *testing.T) {
 	engine, database := newShelleyEngine(t, dir)
 	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
 	assertMessageContent(t, database, "shelley:cMAIN1", "q", "partial")
+	before, err := database.GetSessionFull(
+		context.Background(), "shelley:cMAIN1",
+	)
+	require.NoError(t, err, "GetSessionFull before rewrite")
+	require.NotNil(t, before, "session before rewrite")
+	require.NotNil(t, before.FileMtime, "file_mtime before rewrite")
+	require.NotNil(t, before.FileHash, "file_hash before rewrite")
+	require.NotNil(t, before.LocalModifiedAt,
+		"local_modified_at before rewrite")
 
 	// Rewrite the agent message in place. Crucially, updated_at is left
 	// untouched (same second) and sequence_id is unchanged, so only the
 	// content fingerprint differs.
+	time.Sleep(20 * time.Millisecond)
 	conn, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
 	_, err = conn.Exec(
@@ -376,6 +394,32 @@ func TestSyncShelleySameSecondInPlaceRewrite(t *testing.T) {
 	assertMessageContent(
 		t, database, "shelley:cMAIN1", "q", "the full streamed answer",
 	)
+	after, err := database.GetSessionFull(
+		context.Background(), "shelley:cMAIN1",
+	)
+	require.NoError(t, err, "GetSessionFull after rewrite")
+	require.NotNil(t, after, "session after rewrite")
+	require.NotNil(t, after.FileMtime, "file_mtime after rewrite")
+	require.NotNil(t, after.FileHash, "file_hash after rewrite")
+	require.NotNil(t, after.LocalModifiedAt,
+		"local_modified_at after rewrite")
+	assert.Equal(t, *before.FileMtime, *after.FileMtime,
+		"same-second rewrite keeps the real Shelley updated_at timestamp")
+	assert.NotEqual(t, *before.FileHash, *after.FileHash,
+		"same-count same-second rewrite changes the content fingerprint")
+	assert.Greater(t, *after.LocalModifiedAt, *before.LocalModifiedAt,
+		"successful rewrite must bump local_modified_at for push windows")
+
+	candidates, err := database.ListSessionsModifiedBetween(
+		context.Background(),
+		*before.LocalModifiedAt,
+		time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano),
+		nil,
+		nil,
+	)
+	require.NoError(t, err, "ListSessionsModifiedBetween after rewrite")
+	assert.Contains(t, sessionIDs(candidates), "shelley:cMAIN1",
+		"local_modified_at must select the rewritten session for pushes")
 }
 
 // TestSyncShelleyLengthPreservingRewrite is the case a byte-length signal

--- a/internal/sync/shelley_integration_test.go
+++ b/internal/sync/shelley_integration_test.go
@@ -422,6 +422,63 @@ func TestSyncShelleySameSecondInPlaceRewrite(t *testing.T) {
 		"local_modified_at must select the rewritten session for pushes")
 }
 
+// TestSyncShelleySameSecondMetadataRewrite covers conversation fields the
+// parser reads outside the message payloads. A same-second slug/cwd edit
+// must change the stored fingerprint so the bulk skip re-parses the
+// conversation and refreshes session metadata.
+func TestSyncShelleySameSecondMetadataRewrite(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:10Z", []shelleyMsg{
+			{1, "user", `{"Role":0,"Content":[{"Type":2,"Text":"q"}]}`,
+				"", "2026-06-15T10:00:00Z"},
+			{2, "agent", `{"Role":1,"Content":[{"Type":2,"Text":"answer"}]}`,
+				"", "2026-06-15T10:00:10Z"},
+		})
+
+	engine, database := newShelleyEngine(t, dir)
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	before, err := database.GetSessionFull(
+		context.Background(), "shelley:cMAIN1",
+	)
+	require.NoError(t, err, "GetSessionFull before metadata rewrite")
+	require.NotNil(t, before, "session before metadata rewrite")
+	require.NotNil(t, before.SessionName, "session_name before rewrite")
+	require.NotNil(t, before.FileMtime, "file_mtime before rewrite")
+	require.NotNil(t, before.FileHash, "file_hash before rewrite")
+	assert.Equal(t, "main", *before.SessionName)
+	assert.Equal(t, "app", before.Project)
+
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = conn.Exec(
+		`UPDATE conversations
+		    SET slug = 'renamed',
+		        cwd = '/home/u/dev/renamed-app'
+		  WHERE conversation_id = 'cMAIN1'`,
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	after, err := database.GetSessionFull(
+		context.Background(), "shelley:cMAIN1",
+	)
+	require.NoError(t, err, "GetSessionFull after metadata rewrite")
+	require.NotNil(t, after, "session after metadata rewrite")
+	require.NotNil(t, after.SessionName, "session_name after rewrite")
+	require.NotNil(t, after.FileMtime, "file_mtime after rewrite")
+	require.NotNil(t, after.FileHash, "file_hash after rewrite")
+	assert.Equal(t, *before.FileMtime, *after.FileMtime,
+		"same-second metadata rewrite keeps the real updated_at timestamp")
+	assert.NotEqual(t, *before.FileHash, *after.FileHash,
+		"metadata rewrite must change the Shelley fingerprint")
+	assert.Equal(t, "renamed", *after.SessionName)
+	assert.Equal(t, "renamed_app", after.Project)
+}
+
 // TestSyncShelleyLengthPreservingRewrite is the case a byte-length signal
 // cannot catch: a same-second in-place edit that changes content while
 // keeping the exact byte length (and sequence_id and updated_at). Only a

--- a/internal/sync/shelley_integration_test.go
+++ b/internal/sync/shelley_integration_test.go
@@ -116,18 +116,18 @@ func newShelleyEngine(t *testing.T, dir string) (*sync.Engine, *db.DB) {
 func mainConvoMsgs() []shelleyMsg {
 	return []shelleyMsg{
 		{1, "user",
-			`{"Role":0,"Content":[{"Type":0,"Text":"hello shelley"}]}`,
+			`{"Role":0,"Content":[{"Type":2,"Text":"hello shelley"}]}`,
 			"", "2026-06-15T10:00:00Z"},
 		{2, "agent",
-			`{"Role":1,"Content":[{"Type":0,"Text":"hi"},` +
-				`{"ID":"toolu_x","Type":3,"ToolName":"bash","ToolInput":{"cmd":"ls"}}]}`,
+			`{"Role":1,"Content":[{"Type":2,"Text":"hi"},` +
+				`{"ID":"toolu_x","Type":5,"ToolName":"bash","ToolInput":{"cmd":"ls"}}]}`,
 			`{"input_tokens":500,"cache_read_input_tokens":0,` +
 				`"cache_creation_input_tokens":0,"output_tokens":50,` +
 				`"model":"claude-sonnet-4-6"}`,
 			"2026-06-15T10:00:05Z"},
 		{3, "tool",
-			`{"Role":0,"Content":[{"Type":4,"ToolUseID":"toolu_x",` +
-				`"ToolResult":[{"Type":0,"Text":"file1"}]}]}`,
+			`{"Role":0,"Content":[{"Type":6,"ToolUseID":"toolu_x",` +
+				`"ToolResult":[{"Type":2,"Text":"file1"}]}]}`,
 			"", "2026-06-15T10:00:06Z"},
 	}
 }
@@ -181,9 +181,9 @@ func TestSyncAllShelleyIngestsConversations(t *testing.T) {
 	seedShelleyConvo(t, dbPath, "cAUX1", "aux", "/home/u/dev/app",
 		"claude-sonnet-4-6", "", true,
 		"2026-06-15T10:01:00Z", "2026-06-15T10:01:10Z", []shelleyMsg{
-			{1, "user", `{"Role":0,"Content":[{"Type":0,"Text":"second"}]}`,
+			{1, "user", `{"Role":0,"Content":[{"Type":2,"Text":"second"}]}`,
 				"", "2026-06-15T10:01:00Z"},
-			{2, "agent", `{"Role":1,"Content":[{"Type":0,"Text":"ok"}]}`,
+			{2, "agent", `{"Role":1,"Content":[{"Type":2,"Text":"ok"}]}`,
 				"", "2026-06-15T10:01:10Z"},
 		})
 
@@ -240,9 +240,9 @@ func TestResyncAllShelleyPreservesRemovedConversation(t *testing.T) {
 	seedShelleyConvo(t, dbPath, "cGONE1", "gone", "/home/u/dev/app",
 		"claude-sonnet-4-6", "", true,
 		"2026-06-15T09:00:00Z", "2026-06-15T09:00:10Z", []shelleyMsg{
-			{1, "user", `{"Role":0,"Content":[{"Type":0,"Text":"old work"}]}`,
+			{1, "user", `{"Role":0,"Content":[{"Type":2,"Text":"old work"}]}`,
 				"", "2026-06-15T09:00:00Z"},
-			{2, "agent", `{"Role":1,"Content":[{"Type":0,"Text":"old reply"}]}`,
+			{2, "agent", `{"Role":1,"Content":[{"Type":2,"Text":"old reply"}]}`,
 				"", "2026-06-15T09:00:10Z"},
 		})
 
@@ -280,9 +280,9 @@ func TestSyncShelleyForceReplaceOnInPlaceUpdate(t *testing.T) {
 	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
 		"claude-sonnet-4-6", "", true,
 		"2026-06-15T10:00:00Z", "2026-06-15T10:00:10Z", []shelleyMsg{
-			{1, "user", `{"Role":0,"Content":[{"Type":0,"Text":"q"}]}`,
+			{1, "user", `{"Role":0,"Content":[{"Type":2,"Text":"q"}]}`,
 				"", "2026-06-15T10:00:00Z"},
-			{2, "agent", `{"Role":1,"Content":[{"Type":0,"Text":"first answer"}]}`,
+			{2, "agent", `{"Role":1,"Content":[{"Type":2,"Text":"first answer"}]}`,
 				"", "2026-06-15T10:00:10Z"},
 		})
 
@@ -296,7 +296,7 @@ func TestSyncShelleyForceReplaceOnInPlaceUpdate(t *testing.T) {
 	require.NoError(t, err)
 	_, err = conn.Exec(
 		`UPDATE messages SET llm_data = ? WHERE conversation_id = 'cMAIN1' AND sequence_id = 2`,
-		`{"Role":1,"Content":[{"Type":0,"Text":"second answer"}]}`,
+		`{"Role":1,"Content":[{"Type":2,"Text":"second answer"}]}`,
 	)
 	require.NoError(t, err)
 	_, err = conn.Exec(

--- a/internal/sync/shelley_integration_test.go
+++ b/internal/sync/shelley_integration_test.go
@@ -216,6 +216,57 @@ func TestSyncAllShelleyIngestsConversations(t *testing.T) {
 	assert.Contains(t, resultContent, "file1", "tool result preserved on tool call")
 }
 
+func TestSyncShelleyRemotePathRewriterSkip(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:06Z", mainConvoMsgs())
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentShelley: {dir},
+		},
+		Machine:  "host",
+		IDPrefix: "host~",
+		PathRewriter: func(path string) string {
+			return "host:" + path
+		},
+	})
+
+	stats := engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync should write the session")
+
+	const sessionID = "host~shelley:cMAIN1"
+	storedPath := "host:" + dbPath + "#cMAIN1"
+	assert.Equal(t, storedPath,
+		database.GetSessionFilePath(sessionID), "stored remote path")
+	before, err := database.GetSessionFull(context.Background(), sessionID)
+	require.NoError(t, err, "GetSessionFull before second sync")
+	require.NotNil(t, before, "session before second sync")
+	require.NotNil(t, before.LocalModifiedAt,
+		"local_modified_at before second sync")
+	_, storedMtime, ok := database.GetFileInfoByPath(storedPath)
+	require.True(t, ok, "remote virtual path should be indexed")
+	assert.NotZero(t, storedMtime, "stored mtime")
+
+	time.Sleep(20 * time.Millisecond)
+	stats = engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 0, stats.Synced,
+		"unchanged remote Shelley conversation should be skipped")
+
+	after, err := database.GetSessionFull(context.Background(), sessionID)
+	require.NoError(t, err, "GetSessionFull after second sync")
+	require.NotNil(t, after, "session after second sync")
+	require.NotNil(t, after.LocalModifiedAt,
+		"local_modified_at after second sync")
+	assert.Equal(t, *before.LocalModifiedAt, *after.LocalModifiedAt,
+		"skip lookup must use the rewritten virtual path")
+}
+
 // TestResyncAllShelleyRebuildsFromDB verifies that a full resync
 // re-parses the present Shelley DB without aborting and preserves
 // content. Shelley is a Zed-style single-DB agent, so it re-syncs fresh

--- a/internal/sync/shelley_integration_test.go
+++ b/internal/sync/shelley_integration_test.go
@@ -1,0 +1,296 @@
+package sync_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+const shelleyTestSchema = `
+CREATE TABLE conversations (
+	conversation_id TEXT PRIMARY KEY,
+	slug TEXT,
+	user_initiated BOOLEAN NOT NULL DEFAULT TRUE,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	cwd TEXT,
+	archived BOOLEAN NOT NULL DEFAULT FALSE,
+	parent_conversation_id TEXT,
+	model TEXT,
+	current_generation INTEGER NOT NULL DEFAULT 1
+);
+CREATE TABLE messages (
+	message_id TEXT PRIMARY KEY,
+	conversation_id TEXT NOT NULL,
+	sequence_id INTEGER NOT NULL,
+	type TEXT NOT NULL,
+	llm_data TEXT,
+	user_data TEXT,
+	usage_data TEXT,
+	display_data TEXT,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	generation INTEGER NOT NULL DEFAULT 1,
+	excluded_from_context BOOLEAN NOT NULL DEFAULT FALSE
+);
+`
+
+// shelleyMsg is a minimal message fixture for the integration DB.
+type shelleyMsg struct {
+	seq      int
+	msgType  string
+	llmData  string
+	usageDat string
+	created  string
+}
+
+func createShelleyDB(t *testing.T, dir string) string {
+	t.Helper()
+	dbPath := filepath.Join(dir, "shelley.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err, "open shelley test db")
+	defer db.Close()
+	_, err = db.Exec(shelleyTestSchema)
+	require.NoError(t, err, "create shelley schema")
+	return dbPath
+}
+
+func seedShelleyConvo(
+	t *testing.T, dbPath, id, slug, cwd, model, parent string,
+	userInitiated bool, created, updated string, msgs []shelleyMsg,
+) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec(
+		`INSERT INTO conversations
+			(conversation_id, slug, user_initiated, created_at,
+			 updated_at, cwd, parent_conversation_id, model)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, slug, userInitiated, created, updated, cwd,
+		nullIfEmpty(parent), nullIfEmpty(model),
+	)
+	require.NoError(t, err, "insert conversation %s", id)
+	for _, m := range msgs {
+		_, err = db.Exec(
+			`INSERT INTO messages
+				(message_id, conversation_id, sequence_id, type,
+				 llm_data, usage_data, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			id+"-m"+string(rune('0'+m.seq)), id, m.seq, m.msgType,
+			nullIfEmpty(m.llmData), nullIfEmpty(m.usageDat), m.created,
+		)
+		require.NoError(t, err, "insert message %s/%d", id, m.seq)
+	}
+}
+
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func newShelleyEngine(t *testing.T, dir string) (*sync.Engine, *db.DB) {
+	t.Helper()
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentShelley: {dir},
+		},
+		Machine: "local",
+	})
+	return engine, database
+}
+
+func mainConvoMsgs() []shelleyMsg {
+	return []shelleyMsg{
+		{1, "user",
+			`{"Role":0,"Content":[{"Type":0,"Text":"hello shelley"}]}`,
+			"", "2026-06-15T10:00:00Z"},
+		{2, "agent",
+			`{"Role":1,"Content":[{"Type":0,"Text":"hi"},` +
+				`{"ID":"toolu_x","Type":3,"ToolName":"bash","ToolInput":{"cmd":"ls"}}]}`,
+			`{"input_tokens":500,"cache_read_input_tokens":0,` +
+				`"cache_creation_input_tokens":0,"output_tokens":50,` +
+				`"model":"claude-sonnet-4-6"}`,
+			"2026-06-15T10:00:05Z"},
+		{3, "tool",
+			`{"Role":0,"Content":[{"Type":4,"ToolUseID":"toolu_x",` +
+				`"ToolResult":[{"Type":0,"Text":"file1"}]}]}`,
+			"", "2026-06-15T10:00:06Z"},
+	}
+}
+
+func TestSyncSingleSessionShelleyUsesVirtualSourcePath(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:06Z", mainConvoMsgs())
+
+	engine, database := newShelleyEngine(t, dir)
+
+	assert.Equal(t, dbPath+"#cMAIN1",
+		engine.FindSourceFile("shelley:cMAIN1"), "virtual source path")
+	require.NoError(t, engine.SyncSingleSession("shelley:cMAIN1"))
+
+	sess, err := database.GetSession(context.Background(), "shelley:cMAIN1")
+	require.NoError(t, err)
+	require.NotNil(t, sess, "session present")
+	// The user prompt and the agent reply remain; the tool-result-only
+	// carrier message is paired into the tool call and dropped.
+	assert.Equal(t, 2, sess.MessageCount, "message count")
+	assert.Equal(t, "app", sess.Project, "project")
+	assert.Equal(t, dbPath+"#cMAIN1",
+		database.GetSessionFilePath("shelley:cMAIN1"), "stored file path")
+}
+
+func TestSyncAllShelleyIngestsConversations(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:06Z", mainConvoMsgs())
+	seedShelleyConvo(t, dbPath, "cAUX1", "aux", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:01:00Z", "2026-06-15T10:01:10Z", []shelleyMsg{
+			{1, "user", `{"Role":0,"Content":[{"Type":0,"Text":"second"}]}`,
+				"", "2026-06-15T10:01:00Z"},
+			{2, "agent", `{"Role":1,"Content":[{"Type":0,"Text":"ok"}]}`,
+				"", "2026-06-15T10:01:10Z"},
+		})
+
+	engine, database := newShelleyEngine(t, dir)
+	stats := engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "sync aborted: %+v", stats)
+	assert.Equal(t, 2, stats.Synced, "synced count")
+
+	assertSessionMessageCount(t, database, "shelley:cMAIN1", 2)
+	assertSessionMessageCount(t, database, "shelley:cAUX1", 2)
+	assertToolCallCount(t, database, "shelley:cMAIN1", 1)
+	assertMessageContent(t, database, "shelley:cAUX1", "second", "ok")
+
+	// The tool result from the dropped carrier message is paired into
+	// the tool call's result_content.
+	var resultContent string
+	require.NoError(t, database.Reader().QueryRow(
+		`SELECT COALESCE(result_content, '') FROM tool_calls WHERE session_id = ?`,
+		"shelley:cMAIN1",
+	).Scan(&resultContent), "query tool result content")
+	assert.Contains(t, resultContent, "file1", "tool result preserved on tool call")
+}
+
+// TestResyncAllShelleyRebuildsFromDB verifies that a full resync
+// re-parses the present Shelley DB without aborting and preserves
+// content. Shelley is a Zed-style single-DB agent, so it re-syncs fresh
+// (Synced > 0) rather than relying on archive-preservation accounting.
+func TestResyncAllShelleyRebuildsFromDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:06Z", mainConvoMsgs())
+
+	engine, database := newShelleyEngine(t, dir)
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+
+	stats := engine.ResyncAll(context.Background(), nil)
+	assert.False(t, stats.Aborted, "resync aborted: %+v", stats)
+	assert.NotZero(t, stats.Synced, "resync should re-parse fresh")
+	assertSessionMessageCount(t, database, "shelley:cMAIN1", 2)
+}
+
+// TestResyncAllShelleyPreservesRemovedConversation verifies that a
+// conversation deleted from the source DB survives a resync via
+// orphan-copy, satisfying the archive-preservation requirement
+// (existing session data must survive when source rows disappear).
+func TestResyncAllShelleyPreservesRemovedConversation(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:06Z", mainConvoMsgs())
+	seedShelleyConvo(t, dbPath, "cGONE1", "gone", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T09:00:00Z", "2026-06-15T09:00:10Z", []shelleyMsg{
+			{1, "user", `{"Role":0,"Content":[{"Type":0,"Text":"old work"}]}`,
+				"", "2026-06-15T09:00:00Z"},
+			{2, "agent", `{"Role":1,"Content":[{"Type":0,"Text":"old reply"}]}`,
+				"", "2026-06-15T09:00:10Z"},
+		})
+
+	engine, database := newShelleyEngine(t, dir)
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	assertSessionMessageCount(t, database, "shelley:cGONE1", 2)
+
+	// Remove cGONE1 from the source DB entirely.
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = conn.Exec(`DELETE FROM messages WHERE conversation_id = 'cGONE1'`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`DELETE FROM conversations WHERE conversation_id = 'cGONE1'`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	stats := engine.ResyncAll(context.Background(), nil)
+	assert.False(t, stats.Aborted, "resync aborted: %+v", stats)
+
+	// cMAIN1 re-parsed, cGONE1 preserved from the old DB.
+	assertSessionMessageCount(t, database, "shelley:cMAIN1", 2)
+	gone, err := database.GetSession(context.Background(), "shelley:cGONE1")
+	require.NoError(t, err)
+	require.NotNil(t, gone, "removed conversation should survive resync")
+	assert.Equal(t, 2, gone.MessageCount, "preserved message count")
+}
+
+// TestSyncShelleyForceReplaceOnInPlaceUpdate verifies that when a
+// message's content changes in place (Shelley rewrites rows and bumps
+// updated_at), a re-sync fully replaces the session's messages rather
+// than appending duplicates.
+func TestSyncShelleyForceReplaceOnInPlaceUpdate(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:10Z", []shelleyMsg{
+			{1, "user", `{"Role":0,"Content":[{"Type":0,"Text":"q"}]}`,
+				"", "2026-06-15T10:00:00Z"},
+			{2, "agent", `{"Role":1,"Content":[{"Type":0,"Text":"first answer"}]}`,
+				"", "2026-06-15T10:00:10Z"},
+		})
+
+	engine, database := newShelleyEngine(t, dir)
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	assertMessageContent(t, database, "shelley:cMAIN1", "q", "first answer")
+
+	// Rewrite the agent message in place and bump updated_at so the
+	// per-session skip detects the change.
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = conn.Exec(
+		`UPDATE messages SET llm_data = ? WHERE conversation_id = 'cMAIN1' AND sequence_id = 2`,
+		`{"Role":1,"Content":[{"Type":0,"Text":"second answer"}]}`,
+	)
+	require.NoError(t, err)
+	_, err = conn.Exec(
+		`UPDATE conversations SET updated_at = '2026-06-15T10:05:00Z' WHERE conversation_id = 'cMAIN1'`,
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	// Replaced, not appended: still two messages, new content.
+	assertSessionMessageCount(t, database, "shelley:cMAIN1", 2)
+	assertMessageContent(t, database, "shelley:cMAIN1", "q", "second answer")
+}

--- a/internal/sync/shelley_integration_test.go
+++ b/internal/sync/shelley_integration_test.go
@@ -156,6 +156,22 @@ func TestSyncSingleSessionShelleyUsesVirtualSourcePath(t *testing.T) {
 		database.GetSessionFilePath("shelley:cMAIN1"), "stored file path")
 }
 
+// TestSourceMtimeShelleyResolvesVirtualPath guards the live per-session
+// watcher: SourceMtime must resolve a shelley.db#<id> virtual path to the
+// conversation's updated_at, not fall through to os.Stat (which fails on a
+// virtual path and returns 0, which the watcher reads as "source gone").
+func TestSourceMtimeShelleyResolvesVirtualPath(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:06Z", mainConvoMsgs())
+
+	engine, _ := newShelleyEngine(t, dir)
+	assert.Positive(t, engine.SourceMtime("shelley:cMAIN1"),
+		"SourceMtime must resolve the virtual path, not return 0")
+}
+
 func TestSyncAllShelleyIngestsConversations(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := createShelleyDB(t, dir)

--- a/internal/sync/shelley_integration_test.go
+++ b/internal/sync/shelley_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
@@ -311,12 +312,36 @@ func TestSyncShelleyForceReplaceOnInPlaceUpdate(t *testing.T) {
 	assertMessageContent(t, database, "shelley:cMAIN1", "q", "second answer")
 }
 
+// TestSyncShelleyStoresRealTimestamp guards against a synthetic future
+// file_mtime. ListSessionsModifiedBetween filters file_mtime <= now for
+// PG/DuckDB push, so a Shelley row whose stored mtime drifted past its
+// updated_at second could be dropped from a same-second push. The stored
+// file_mtime must equal the conversation's real updated_at instant.
+func TestSyncShelleyStoresRealTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	const updatedAt = "2026-06-15T10:00:05Z"
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", updatedAt, mainConvoMsgs())
+
+	engine, database := newShelleyEngine(t, dir)
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+
+	want, err := time.Parse(time.RFC3339, updatedAt)
+	require.NoError(t, err)
+	_, mtime, ok := database.GetSessionFileInfo("shelley:cMAIN1")
+	require.True(t, ok, "session file info present")
+	assert.Equal(t, want.UnixNano(), mtime,
+		"stored file_mtime is the real updated_at, not a synthetic offset")
+}
+
 // TestSyncShelleySameSecondInPlaceRewrite covers the gap that
 // updated_at + MAX(sequence_id) alone cannot close: a message rewritten
 // in place where updated_at stays in the same wall-clock second and no
-// new row is appended (sequence_id unchanged). The content byte-length
-// component of the change signal detects it, so a re-sync replaces the
-// stored transcript instead of skipping it as unchanged.
+// new row is appended (sequence_id unchanged). The content fingerprint
+// detects it, so a re-sync replaces the stored transcript instead of
+// skipping it as unchanged.
 func TestSyncShelleySameSecondInPlaceRewrite(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := createShelleyDB(t, dir)
@@ -333,9 +358,9 @@ func TestSyncShelleySameSecondInPlaceRewrite(t *testing.T) {
 	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
 	assertMessageContent(t, database, "shelley:cMAIN1", "q", "partial")
 
-	// Rewrite the agent message in place with a longer body. Crucially,
-	// updated_at is left untouched (same second) and sequence_id is
-	// unchanged, so only the content byte-length signal differs.
+	// Rewrite the agent message in place. Crucially, updated_at is left
+	// untouched (same second) and sequence_id is unchanged, so only the
+	// content fingerprint differs.
 	conn, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
 	_, err = conn.Exec(
@@ -346,9 +371,46 @@ func TestSyncShelleySameSecondInPlaceRewrite(t *testing.T) {
 	require.NoError(t, conn.Close())
 
 	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
-	// Detected via the content byte-length signal: replaced, not skipped.
+	// Detected via the content fingerprint: replaced, not skipped.
 	assertSessionMessageCount(t, database, "shelley:cMAIN1", 2)
 	assertMessageContent(
 		t, database, "shelley:cMAIN1", "q", "the full streamed answer",
 	)
+}
+
+// TestSyncShelleyLengthPreservingRewrite is the case a byte-length signal
+// cannot catch: a same-second in-place edit that changes content while
+// keeping the exact byte length (and sequence_id and updated_at). Only a
+// real content digest detects it, so the re-sync must replace the stored
+// transcript rather than skip it.
+func TestSyncShelleyLengthPreservingRewrite(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:10Z", []shelleyMsg{
+			{1, "user", `{"Role":0,"Content":[{"Type":2,"Text":"q"}]}`,
+				"", "2026-06-15T10:00:00Z"},
+			{2, "agent", `{"Role":1,"Content":[{"Type":2,"Text":"answer aaaa"}]}`,
+				"", "2026-06-15T10:00:10Z"},
+		})
+
+	engine, database := newShelleyEngine(t, dir)
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	assertMessageContent(t, database, "shelley:cMAIN1", "q", "answer aaaa")
+
+	// Same byte length, different content. updated_at and sequence_id are
+	// untouched, so a byte-length signal would skip this as unchanged.
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = conn.Exec(
+		`UPDATE messages SET llm_data = ? WHERE conversation_id = 'cMAIN1' AND sequence_id = 2`,
+		`{"Role":1,"Content":[{"Type":2,"Text":"answer bbbb"}]}`,
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	assertSessionMessageCount(t, database, "shelley:cMAIN1", 2)
+	assertMessageContent(t, database, "shelley:cMAIN1", "q", "answer bbbb")
 }

--- a/internal/sync/shelley_integration_test.go
+++ b/internal/sync/shelley_integration_test.go
@@ -310,3 +310,45 @@ func TestSyncShelleyForceReplaceOnInPlaceUpdate(t *testing.T) {
 	assertSessionMessageCount(t, database, "shelley:cMAIN1", 2)
 	assertMessageContent(t, database, "shelley:cMAIN1", "q", "second answer")
 }
+
+// TestSyncShelleySameSecondInPlaceRewrite covers the gap that
+// updated_at + MAX(sequence_id) alone cannot close: a message rewritten
+// in place where updated_at stays in the same wall-clock second and no
+// new row is appended (sequence_id unchanged). The content byte-length
+// component of the change signal detects it, so a re-sync replaces the
+// stored transcript instead of skipping it as unchanged.
+func TestSyncShelleySameSecondInPlaceRewrite(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyDB(t, dir)
+	seedShelleyConvo(t, dbPath, "cMAIN1", "main", "/home/u/dev/app",
+		"claude-sonnet-4-6", "", true,
+		"2026-06-15T10:00:00Z", "2026-06-15T10:00:10Z", []shelleyMsg{
+			{1, "user", `{"Role":0,"Content":[{"Type":2,"Text":"q"}]}`,
+				"", "2026-06-15T10:00:00Z"},
+			{2, "agent", `{"Role":1,"Content":[{"Type":2,"Text":"partial"}]}`,
+				"", "2026-06-15T10:00:10Z"},
+		})
+
+	engine, database := newShelleyEngine(t, dir)
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	assertMessageContent(t, database, "shelley:cMAIN1", "q", "partial")
+
+	// Rewrite the agent message in place with a longer body. Crucially,
+	// updated_at is left untouched (same second) and sequence_id is
+	// unchanged, so only the content byte-length signal differs.
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = conn.Exec(
+		`UPDATE messages SET llm_data = ? WHERE conversation_id = 'cMAIN1' AND sequence_id = 2`,
+		`{"Role":1,"Content":[{"Type":2,"Text":"the full streamed answer"}]}`,
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.False(t, engine.SyncAll(context.Background(), nil).Aborted)
+	// Detected via the content byte-length signal: replaced, not skipped.
+	assertSessionMessageCount(t, database, "shelley:cMAIN1", 2)
+	assertMessageContent(
+		t, database, "shelley:cMAIN1", "q", "the full streamed answer",
+	)
+}


### PR DESCRIPTION
Adds first-class support for **Shelley**, the exe.dev / boldsoftware coding agent ([github.com/boldsoftware/shelley](https://github.com/boldsoftware/shelley)), so its sessions appear alongside every other agent.

## Storage model

Shelley stores all conversations in a single SQLite DB at `~/.config/shelley/shelley.db` (`conversations` + `messages` tables). This is structurally identical to Zed, so the parser and sync wiring mirror the Zed single-DB pattern: a virtual source path (`shelley.db#<conversationID>`), classification before the `pathExists` guard, a WAL/SHM composite mtime, per-session `forceReplace` on parse, and a `SourceMtime` branch for the live per-session watcher. No `ResyncAll` `oldFileSessions` accounting is needed (that path is specific to the OpenCode-format storage agents) — Shelley re-parses fresh from the present DB, and vanished conversations are preserved via the generic orphan-copy.

## Extraction

`messages.llm_data` is a serialized `llm.Message` with PascalCase keys and integer enums. The content `Type` integers start at 2 (text=2, thinking=3, tool_use=5, tool_result=6) because `ContentType` shares an `iota` const block with `MessageRole` and `iota` does not reset between the two groups; this was verified against a real `shelley.db`. Tool results are stored as `user`-role messages (Anthropic-style) and pair into the originating tool call. All generations are included, ordered by `sequence_id` (monotonic and unique per conversation), so a context-reset / compaction boundary never hides earlier history.

## Tokens & cost

`usage_data` already uses the canonical Anthropic token keys, so the raw blob is stored verbatim and cost is catalog-priced. Token usage is also captured on errored assistant turns (stored as `type="error"`). The exact gateway `cost_usd` is present in the payload but is currently 0 from the exe.dev gateway; capturing it without double-counting the catalog-priced per-message tokens is left as a follow-up.

## Where to look

- `internal/parser/shelley.go` — parser, virtual-path / read-only store helpers, content and token extraction.
- `internal/sync/engine.go` — the Shelley sites mirroring Zed (classify, composite mtime, `processShelley`, dispatch, `SourceMtime`, cache-skip).
- `internal/parser/types.go` — the `AgentShelley` registry entry.

## Limitations

- Exact `cost_usd` capture is deferred (see above); standard gateway models are priced correctly by the catalog.
- Validated against real `shelley.db` data; tool-name categories cover the current Shelley tool set (`bash`, `patch`, `keyword_search`, `browser*`, `subagent`, …).
