### PR TITLE
Feat/add mistral vibe support

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ agentsview auto-discovers sessions from all of these:
 | Kiro CLI              | `~/.kiro/sessions/cli/`, `~/.local/share/kiro-cli/`                                                                                                                     |
 | Kiro IDE              | `~/Library/Application Support/Kiro/` (macOS)                                                                                                                           |
 | MiMoCode              | `~/.local/share/mimocode/`                                                                                                                                              |
+| Mistral Vibe          | `~/.vibe/logs/session/`                                                                                                                                                 |
 | OpenClaw              | `~/.openclaw/agents/`                                                                                                                                                   |
 | OpenCode              | `~/.local/share/opencode/`                                                                                                                                              |
 | OpenHands CLI         | `~/.openhands/conversations/`                                                                                                                                           |

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -39,6 +39,7 @@ describe("KNOWN_AGENTS", () => {
       "piebald",
       "antigravity",
       "antigravity-cli",
+      "vibe",
     ]);
   });
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -63,6 +63,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
     color: "var(--accent-violet)",
     label: "Antigravity CLI",
   },
+  { name: "vibe", color: "var(--accent-orange)", label: "Mistral Vibe" },
 ];
 
 const agentColorMap = new Map(

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4123,6 +4123,88 @@ func TestDeleteSessionExcludes(t *testing.T) {
 	requireSessionGone(t, d, "s1")
 }
 
+func TestVibeCanonicalDeleteExcludesFallbackAlias(t *testing.T) {
+	cases := []struct {
+		name       string
+		id         string
+		filePath   string
+		fallbackID string
+		delete     func(*testing.T, *DB, string) error
+	}{
+		{
+			name:       "single delete",
+			id:         "vibe:abc123def-0000-0000-0000-000000000000",
+			filePath:   "/tmp/vibe/session_20260616_083518_abc123/messages.jsonl",
+			fallbackID: "vibe:session_20260616_083518_abc123",
+			delete: func(t *testing.T, d *DB, id string) error {
+				return d.DeleteSession(id)
+			},
+		},
+		{
+			name:       "remote single delete",
+			id:         "host~vibe:abc123def-0000-0000-0000-000000000000",
+			filePath:   "host:/remote/vibe/session_20260616_083518_abc123/messages.jsonl",
+			fallbackID: "host~vibe:session_20260616_083518_abc123",
+			delete: func(t *testing.T, d *DB, id string) error {
+				return d.DeleteSession(id)
+			},
+		},
+		{
+			name:       "delete if trashed",
+			id:         "vibe:abc123def-0000-0000-0000-000000000001",
+			filePath:   "/tmp/vibe/session_20260616_083518_def456/messages.jsonl",
+			fallbackID: "vibe:session_20260616_083518_def456",
+			delete: func(t *testing.T, d *DB, id string) error {
+				requireNoError(t, d.SoftDeleteSession(id), "SoftDeleteSession")
+				n, err := d.DeleteSessionIfTrashed(id)
+				require.Equal(t, int64(1), n, "DeleteSessionIfTrashed rows")
+				return err
+			},
+		},
+		{
+			name:       "batch delete",
+			id:         "vibe:abc123def-0000-0000-0000-000000000002",
+			filePath:   "/tmp/vibe/session_20260616_083518_ghi789/messages.jsonl",
+			fallbackID: "vibe:session_20260616_083518_ghi789",
+			delete: func(t *testing.T, d *DB, id string) error {
+				n, err := d.DeleteSessions([]string{id})
+				require.Equal(t, 1, n, "DeleteSessions rows")
+				return err
+			},
+		},
+		{
+			name:       "empty trash",
+			id:         "vibe:abc123def-0000-0000-0000-000000000003",
+			filePath:   "/tmp/vibe/session_20260616_083518_jkl012/messages.jsonl",
+			fallbackID: "vibe:session_20260616_083518_jkl012",
+			delete: func(t *testing.T, d *DB, id string) error {
+				requireNoError(t, d.SoftDeleteSession(id), "SoftDeleteSession")
+				n, err := d.EmptyTrash()
+				require.Equal(t, 1, n, "EmptyTrash rows")
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := testDB(t)
+			insertSession(t, d, tc.id, "p", func(s *Session) {
+				s.Agent = "vibe"
+				s.FilePath = &tc.filePath
+			})
+
+			requireNoError(t, tc.delete(t, d, tc.id), "delete")
+
+			assert.True(t, d.IsSessionExcluded(tc.id),
+				"canonical ID should be excluded")
+			assert.True(t, d.IsSessionExcluded(tc.fallbackID),
+				"fallback alias should be excluded")
+			requireSessionGone(t, d, tc.id)
+		})
+	}
+}
+
 func TestUpsertSessionTrashedReturnsErrSessionTrashed(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -898,6 +899,28 @@ func (db *DB) IsSessionExcluded(id string) bool {
 	return n == 1
 }
 
+// IsSessionTrashed returns true if the session ID exists in the trash.
+func (db *DB) IsSessionTrashed(id string) bool {
+	var n int
+	_ = db.getReader().QueryRow(
+		"SELECT 1 FROM sessions WHERE id = ? AND deleted_at IS NOT NULL", id,
+	).Scan(&n)
+	return n == 1
+}
+
+// HasTrashedSessionByFilePath returns true when a source path already belongs
+// to a trashed row for this agent.
+func (db *DB) HasTrashedSessionByFilePath(path, agent string) bool {
+	var n int
+	_ = db.getReader().QueryRow(
+		"SELECT 1 FROM sessions"+
+			" WHERE file_path = ? AND agent = ? AND deleted_at IS NOT NULL"+
+			" LIMIT 1",
+		path, agent,
+	).Scan(&n)
+	return n == 1
+}
+
 // PurgeExcludedSessions removes any session rows whose IDs
 // appear in excluded_sessions. Used after a resync to clean
 // up sessions that were synced before their exclusion was
@@ -1565,6 +1588,35 @@ func (db *DB) GetFileHashByPath(path string) (hash string, ok bool) {
 	return h.String, h.Valid
 }
 
+// ListSessionIDsByFilePath returns non-deleted session IDs for a source path
+// and agent. Used by parsers whose canonical session ID can change while the
+// underlying source file remains the same.
+func (db *DB) ListSessionIDsByFilePath(path, agent string) ([]string, error) {
+	rows, err := db.getReader().Query(
+		"SELECT id FROM sessions"+
+			" WHERE file_path = ? AND agent = ? AND deleted_at IS NULL"+
+			" ORDER BY id",
+		path, agent,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing session IDs by file path: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning session ID by file path: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating session IDs by file path: %w", err)
+	}
+	return ids, nil
+}
+
 // GetDataVersionByPath returns the minimum data_version for
 // sessions matching a file_path. Returns 0 when no session
 // exists for the path.
@@ -1612,6 +1664,11 @@ func (db *DB) DeleteSession(id string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	aliasIDs, err := sessionAliasIDsTx(tx, "id = ?", id)
+	if err != nil {
+		return err
+	}
+
 	res, err := tx.Exec(
 		"DELETE FROM sessions WHERE id = ?", id,
 	)
@@ -1620,14 +1677,71 @@ func (db *DB) DeleteSession(id string) error {
 	}
 	n, _ := res.RowsAffected()
 	if n > 0 {
-		if _, err := tx.Exec(
-			"INSERT OR IGNORE INTO excluded_sessions (id) VALUES (?)",
-			id,
-		); err != nil {
+		if err := excludeSessionIDTx(tx, id); err != nil {
 			return fmt.Errorf("excluding session %s: %w", id, err)
+		}
+		for _, aliasID := range aliasIDs {
+			if err := excludeSessionIDTx(tx, aliasID); err != nil {
+				return fmt.Errorf(
+					"excluding session alias %s: %w", aliasID, err,
+				)
+			}
 		}
 	}
 	return tx.Commit()
+}
+
+func excludeSessionIDTx(tx *sql.Tx, id string) error {
+	_, err := tx.Exec(
+		"INSERT OR IGNORE INTO excluded_sessions (id) VALUES (?)",
+		id,
+	)
+	return err
+}
+
+func sessionAliasIDsTx(tx *sql.Tx, where string, args ...any) ([]string, error) {
+	rows, err := tx.Query(
+		"SELECT id, agent, file_path FROM sessions WHERE "+where,
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("loading session alias state: %w", err)
+	}
+	defer rows.Close()
+
+	var aliases []string
+	for rows.Next() {
+		var id, agent string
+		var filePath sql.NullString
+		if err := rows.Scan(&id, &agent, &filePath); err != nil {
+			return nil, fmt.Errorf("scanning session alias state: %w", err)
+		}
+		if aliasID := vibeFallbackAliasID(id, agent, filePath); aliasID != "" {
+			aliases = append(aliases, aliasID)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating session alias state: %w", err)
+	}
+	return aliases, nil
+}
+
+func vibeFallbackAliasID(id, agent string, filePath sql.NullString) string {
+	if agent != "vibe" || !filePath.Valid || filePath.String == "" {
+		return ""
+	}
+	dir := filepath.Base(filepath.Dir(filePath.String))
+	if !strings.HasPrefix(dir, "session_") {
+		return ""
+	}
+	fallbackID := "vibe:" + dir
+	if idx := strings.LastIndex(id, "vibe:"); idx > 0 {
+		fallbackID = id[:idx] + fallbackID
+	}
+	if fallbackID == id {
+		return ""
+	}
+	return fallbackID
 }
 
 // DeleteSessionIfTrashed atomically deletes a session only if it
@@ -1645,6 +1759,13 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	aliasIDs, err := sessionAliasIDsTx(
+		tx, "id = ? AND deleted_at IS NOT NULL", id,
+	)
+	if err != nil {
+		return 0, err
+	}
+
 	// Only delete if the session is currently trashed.
 	res, err := tx.Exec(
 		"DELETE FROM sessions WHERE id = ? AND deleted_at IS NOT NULL",
@@ -1659,10 +1780,15 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 	}
 
 	// Record in exclusion list so sync doesn't re-import.
-	if _, err := tx.Exec(
-		"INSERT OR IGNORE INTO excluded_sessions (id) VALUES (?)", id,
-	); err != nil {
+	if err := excludeSessionIDTx(tx, id); err != nil {
 		return 0, fmt.Errorf("excluding session %s: %w", id, err)
+	}
+	for _, aliasID := range aliasIDs {
+		if err := excludeSessionIDTx(tx, aliasID); err != nil {
+			return 0, fmt.Errorf(
+				"excluding session alias %s: %w", aliasID, err,
+			)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -1995,12 +2121,24 @@ func (db *DB) EmptyTrash() (int, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	aliasIDs, err := sessionAliasIDsTx(tx, "deleted_at IS NOT NULL")
+	if err != nil {
+		return 0, err
+	}
+
 	// Record all trashed session IDs before deleting.
 	if _, err := tx.Exec(
 		`INSERT OR IGNORE INTO excluded_sessions (id)
 		 SELECT id FROM sessions WHERE deleted_at IS NOT NULL`,
 	); err != nil {
 		return 0, fmt.Errorf("excluding trashed sessions: %w", err)
+	}
+	for _, aliasID := range aliasIDs {
+		if err := excludeSessionIDTx(tx, aliasID); err != nil {
+			return 0, fmt.Errorf(
+				"excluding trashed session alias %s: %w", aliasID, err,
+			)
+		}
 	}
 	res, err := tx.Exec(
 		"DELETE FROM sessions WHERE deleted_at IS NOT NULL",
@@ -2046,6 +2184,13 @@ func (db *DB) DeleteSessions(ids []string) (int, error) {
 		}
 		placeholders := strings.Repeat(",?", len(batch))[1:]
 
+		aliasIDs, err := sessionAliasIDsTx(
+			tx, "id IN ("+placeholders+")", args...,
+		)
+		if err != nil {
+			return 0, err
+		}
+
 		// Exclude only IDs that exist before we delete them.
 		if _, err := tx.Exec(
 			"INSERT OR IGNORE INTO excluded_sessions (id) "+
@@ -2053,6 +2198,13 @@ func (db *DB) DeleteSessions(ids []string) (int, error) {
 			args...,
 		); err != nil {
 			return 0, fmt.Errorf("excluding batch: %w", err)
+		}
+		for _, aliasID := range aliasIDs {
+			if err := excludeSessionIDTx(tx, aliasID); err != nil {
+				return 0, fmt.Errorf(
+					"excluding batch session alias %s: %w", aliasID, err,
+				)
+			}
 		}
 
 		res, err := tx.Exec(

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -2388,3 +2388,81 @@ func FindIflowSourceFile(
 
 	return ""
 }
+
+// DiscoverVibeSessions finds all Vibe session files under the given root directory.
+// Vibe stores sessions in: ~/.vibe/logs/session/session_YYYYMMDD_HHMMSS_uuid/
+// Each session directory contains messages.jsonl
+func DiscoverVibeSessions(root string) []DiscoveredFile {
+	var results []DiscoveredFile
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return results
+	}
+
+	for _, entry := range entries {
+		if !isDirOrSymlink(entry, root) {
+			continue
+		}
+
+		// Vibe session directories match pattern: session_YYYYMMDD_HHMMSS_uuid
+		// The uuid part can contain hyphens
+		if !strings.HasPrefix(entry.Name(), "session_") || !strings.Contains(entry.Name(), "_") {
+			continue
+		}
+
+		sessionDir := filepath.Join(root, entry.Name())
+		messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+
+		if info, err := os.Stat(messagesPath); err == nil && !info.IsDir() {
+			results = append(results, DiscoveredFile{
+				Path:    messagesPath,
+				Agent:   AgentVibe,
+				Project: entry.Name(),
+			})
+		}
+	}
+
+	return results
+}
+
+// FindVibeSourceFile locates a specific Vibe session file by ID. The ID is the
+// session_id recorded in meta.json (a uuid), which usually differs from the
+// session directory name. Sessions without meta.json fall back to the directory
+// name, so a direct path is tried first before scanning meta.json files.
+func FindVibeSourceFile(root, sessionID string) string {
+	// Fast path: sessionID is the directory name (no-meta fallback).
+	if messagesPath := filepath.Join(root, sessionID, "messages.jsonl"); isVibeMessagesFile(messagesPath) {
+		return messagesPath
+	}
+
+	// Otherwise sessionID is a meta.json session_id; scan session
+	// directories and match on their recorded session_id.
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if !isDirOrSymlink(entry, root) || !strings.HasPrefix(entry.Name(), "session_") {
+			continue
+		}
+		messagesPath := filepath.Join(root, entry.Name(), "messages.jsonl")
+		if !isVibeMessagesFile(messagesPath) {
+			continue
+		}
+		metaPath := filepath.Join(root, entry.Name(), "meta.json")
+		if meta, err := parseVibeMetadata(metaPath); err == nil && meta.SessionID == sessionID {
+			return messagesPath
+		}
+	}
+	return ""
+}
+
+// isVibeMessagesFile reports whether path is an existing regular file.
+func isVibeMessagesFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info == nil {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -1360,3 +1360,29 @@ func TestIsPiSessionFile(t *testing.T) {
 			"expected false for empty file")
 	})
 }
+
+func TestDiscoverVibeSessionsIntegration(t *testing.T) {
+	// Test discovery with testdata
+	files := DiscoverVibeSessions("testdata/vibe")
+
+	// Should find all session directories with messages.jsonl
+	require.NotEmpty(t, files)
+
+	// Verify all files are Vibe sessions
+	for _, f := range files {
+		assert.Equal(t, AgentVibe, f.Agent)
+		assert.Contains(t, f.Path, "messages.jsonl")
+	}
+
+	// Should find at least 3 sessions (basic, with_tools, empty)
+	assert.GreaterOrEqual(t, len(files), 3)
+}
+
+func TestFindVibeSourceFileIntegration(t *testing.T) {
+	// Test with actual testdata
+	sessionID := "session_basic"
+	result := FindVibeSourceFile("testdata/vibe", sessionID)
+
+	expected := filepath.Join("testdata", "vibe", sessionID, "messages.jsonl")
+	assert.Equal(t, expected, result)
+}

--- a/internal/parser/testdata/vibe/session_basic/messages.jsonl
+++ b/internal/parser/testdata/vibe/session_basic/messages.jsonl
@@ -1,0 +1,5 @@
+{"role": "user", "content": "Create a Python function to sort a list", "message_id": "msg_001"}
+{"role": "assistant", "content": "Here's a Python function to sort a list:", "message_id": "msg_002"}
+{"role": "assistant", "content": "```python\ndef sort_list(lst):\n    return sorted(lst)\n```", "message_id": "msg_003"}
+{"role": "user", "content": "Can you add type hints?", "message_id": "msg_004"}
+{"role": "assistant", "content": "Here's the updated version with type hints:", "message_id": "msg_005"}

--- a/internal/parser/testdata/vibe/session_basic/meta.json
+++ b/internal/parser/testdata/vibe/session_basic/meta.json
@@ -1,0 +1,25 @@
+{
+  "session_id": "abc123def-0000-0000-0000-000000000000",
+  "parent_session_id": null,
+  "start_time": "2026-06-13T10:00:00Z",
+  "end_time": "2026-06-13T10:05:00Z",
+  "git_commit": "abc123def456",
+  "git_branch": "main",
+  "model": "mistral-medium-3.5",
+  "environment": {
+    "working_directory": "/home/user/projects/myapp"
+  },
+  "title": "Create a Python function to sort a list",
+  "title_source": "auto",
+  "stats": {
+    "steps": 5,
+    "session_prompt_tokens": 100,
+    "session_completion_tokens": 50,
+    "context_tokens": 150,
+    "last_turn_prompt_tokens": 50,
+    "last_turn_completion_tokens": 25,
+    "session_total_llm_tokens": 150,
+    "last_turn_total_tokens": 75
+  },
+  "total_messages": 5
+}

--- a/internal/parser/testdata/vibe/session_with_tools/messages.jsonl
+++ b/internal/parser/testdata/vibe/session_with_tools/messages.jsonl
@@ -1,0 +1,4 @@
+{"role": "user", "content": "Read the README file", "message_id": "msg_001"}
+{"role": "assistant", "content": "I'll read the README file for you.", "message_id": "msg_002", "tool_calls": [{"id": "call_001", "index": 0, "function": {"name": "read_file", "arguments": {"path": "README.md"}}}]}
+{"role": "tool", "content": "# My Project\n\nThis is a sample project.", "name": "read_file", "tool_call_id": "call_001", "message_id": "msg_003"}
+{"role": "assistant", "content": "The README.md file contains:\n\n# My Project\n\nThis is a sample project.", "message_id": "msg_004"}

--- a/internal/parser/testdata/vibe/session_with_tools/meta.json
+++ b/internal/parser/testdata/vibe/session_with_tools/meta.json
@@ -1,0 +1,25 @@
+{
+  "session_id": "def456ghi-0000-0000-0000-000000000000",
+  "parent_session_id": null,
+  "start_time": "2026-06-13T11:00:00Z",
+  "end_time": "2026-06-13T11:01:00Z",
+  "git_commit": "def456ghi789",
+  "git_branch": "feature/tool-support",
+  "model": "mistral-medium-3.5",
+  "environment": {
+    "working_directory": "/home/user/projects/myapp"
+  },
+  "title": "Read the README file",
+  "title_source": "auto",
+  "stats": {
+    "steps": 4,
+    "session_prompt_tokens": 200,
+    "session_completion_tokens": 100,
+    "context_tokens": 300,
+    "last_turn_prompt_tokens": 100,
+    "last_turn_completion_tokens": 50,
+    "session_total_llm_tokens": 300,
+    "last_turn_total_tokens": 150
+  },
+  "total_messages": 4
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -45,6 +45,7 @@ const (
 	AgentPositron       AgentType = "positron"
 	AgentAntigravity    AgentType = "antigravity"
 	AgentAntigravityCLI AgentType = "antigravity-cli"
+	AgentVibe           AgentType = "vibe"
 	AgentZed            AgentType = "zed"
 	AgentQwenPaw        AgentType = "qwenpaw"
 	AgentGptme          AgentType = "gptme"
@@ -594,6 +595,17 @@ var Registry = []AgentDef{
 		FileBased:      true,
 		DiscoverFunc:   DiscoverShelleySessions,
 		FindSourceFunc: FindShelleySourceFile,
+	},
+	{
+		Type:           AgentVibe,
+		DisplayName:    "Mistral Vibe",
+		EnvVar:         "VIBE_SESSIONS_DIR",
+		ConfigKey:      "vibe_session_dirs",
+		DefaultDirs:    []string{".vibe/logs/session"},
+		IDPrefix:       "vibe:",
+		FileBased:      true,
+		DiscoverFunc:   DiscoverVibeSessions,
+		FindSourceFunc: FindVibeSourceFile,
 	},
 }
 

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -340,6 +340,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentGptme,
 		AgentQwenPaw,
 		AgentShelley,
+		AgentVibe,
 	}
 
 	expected := make(map[AgentType]bool, len(allTypes))

--- a/internal/parser/vibe.go
+++ b/internal/parser/vibe.go
@@ -1,0 +1,473 @@
+package parser
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// VibeMessage represents a single message in a Mistral Vibe session
+type VibeMessage struct {
+	Role             string         `json:"role"`
+	Content          string         `json:"content,omitempty"`
+	ReasoningContent string         `json:"reasoning_content,omitempty"`
+	ToolCalls        []VibeToolCall `json:"tool_calls,omitempty"`
+	Name             string         `json:"name,omitempty"`
+	ToolCallID       string         `json:"tool_call_id,omitempty"`
+	MessageID        string         `json:"message_id,omitempty"`
+	Injected         bool           `json:"injected,omitempty"`
+	Model            string         `json:"model,omitempty"`
+}
+
+// VibeToolCall represents a tool invocation in Vibe
+type VibeToolCall struct {
+	ID       string               `json:"id"`
+	Index    int                  `json:"index,omitempty"`
+	Function VibeToolCallFunction `json:"function"`
+}
+
+// VibeToolCallFunction represents the function details of a tool call
+type VibeToolCallFunction struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// VibeSessionMetadata represents session-level metadata from meta.json
+type VibeSessionMetadata struct {
+	SessionID       string    `json:"session_id"`
+	ParentSessionID *string   `json:"parent_session_id"`
+	StartTime       time.Time `json:"start_time"`
+	EndTime         time.Time `json:"end_time"`
+	GitCommit       string    `json:"git_commit,omitempty"`
+	GitBranch       string    `json:"git_branch,omitempty"`
+	Model           string    `json:"model,omitempty"`
+	WorkingDir      string    `json:"working_dir,omitempty"`
+	Title           string    `json:"title,omitempty"`
+	Stats           VibeStats `json:"stats,omitempty"`
+	Environment     struct {
+		WorkingDirectory string `json:"working_directory,omitempty"`
+	} `json:"environment,omitempty"`
+	Config struct {
+		ActiveModel string `json:"active_model,omitempty"`
+	} `json:"config,omitempty"`
+}
+
+// VibeStats represents token usage statistics from meta.json
+type VibeStats struct {
+	Steps                    int   `json:"steps"`
+	SessionPromptTokens      int   `json:"session_prompt_tokens"`
+	SessionCompletionTokens  int   `json:"session_completion_tokens"`
+	ContextTokens            int   `json:"context_tokens"`
+	LastTurnPromptTokens     int   `json:"last_turn_prompt_tokens"`
+	LastTurnCompletionTokens int   `json:"last_turn_completion_tokens"`
+	SessionTotalLLMTokens    int64 `json:"session_total_llm_tokens"`
+	LastTurnTotalTokens      int   `json:"last_turn_total_tokens"`
+}
+
+// ParseVibeSession parses a Mistral Vibe messages.jsonl file
+func ParseVibeSession(path string, fileInfo FileInfo) (ParseResult, error) {
+	result := ParseResult{
+		Session: ParsedSession{
+			Agent:     AgentVibe,
+			File:      fileInfo,
+			StartedAt: time.Unix(0, fileInfo.Mtime),
+			EndedAt:   time.Unix(0, fileInfo.Mtime),
+		},
+	}
+
+	// Extract session ID from directory name as a fallback. The "vibe:"
+	// prefix is always applied so prefix-based routing (AgentByPrefix,
+	// FindSourceFile) works even when meta.json is missing.
+	// Path format: .../session/session_YYYYMMDD_HHMMSS_uuid/messages.jsonl
+	dir := filepath.Dir(path)
+	result.Session.ID = "vibe:" + filepath.Base(dir)
+	result.Session.Project = "vibe"
+
+	// Try to parse meta.json for additional metadata
+	var sessionModel string
+	var sessionStats VibeStats
+	var hasMetaData bool
+	metaPath := filepath.Join(dir, "meta.json")
+	metaData, metaErr := parseVibeMetadata(metaPath)
+	switch {
+	case metaErr != nil && errors.Is(metaErr, os.ErrNotExist):
+		// meta.json has not been written yet (a freshly created session):
+		// keep the directory-name fallback ID set above.
+	case metaErr != nil:
+		// meta.json exists but the full parse failed: a partial write or a
+		// single malformed optional field. Recover the canonical session_id
+		// from a tolerant minimal parse so a transient error does not abandon
+		// the canonical session row for the directory-name fallback (which
+		// would exclude and re-create the row, dropping pins and usage). If
+		// even the minimal parse fails, surface the error so the sync retries
+		// and leaves the existing row untouched rather than replacing it.
+		id, idErr := parseVibeSessionID(metaPath)
+		if idErr != nil {
+			return result, fmt.Errorf(
+				"parsing Vibe meta.json %s: %w", metaPath, metaErr,
+			)
+		}
+		if id != "" {
+			result.Session.ID = "vibe:" + id
+			result.Session.SourceSessionID = id
+		}
+	default:
+		hasMetaData = true
+		sessionStats = metaData.Stats
+		// Use the actual session_id from meta.json as the canonical ID
+		if metaData.SessionID != "" {
+			result.Session.ID = "vibe:" + metaData.SessionID
+			result.Session.SourceSessionID = metaData.SessionID
+		}
+		if metaData.Title != "" {
+			result.Session.SessionName = metaData.Title
+		}
+		if !metaData.StartTime.IsZero() {
+			result.Session.StartedAt = metaData.StartTime
+		}
+		if !metaData.EndTime.IsZero() {
+			result.Session.EndedAt = metaData.EndTime
+		}
+		if metaData.Model != "" {
+			sessionModel = metaData.Model
+		}
+		if metaData.WorkingDir != "" {
+			result.Session.Cwd = metaData.WorkingDir
+			// Derive a human-readable project name from the working
+			// directory (the enclosing git repo, or its basename),
+			// matching how Claude sessions are grouped. Falls back to
+			// "vibe" when no working directory is recorded.
+			if p := ExtractProjectFromCwdWithBranch(
+				metaData.WorkingDir, metaData.GitBranch,
+			); p != "" {
+				result.Session.Project = p
+			}
+		}
+		if metaData.GitBranch != "" {
+			result.Session.GitBranch = metaData.GitBranch
+		}
+		if metaData.GitCommit != "" {
+			result.Session.SourceVersion = metaData.GitCommit
+		}
+		// Extract token usage from stats
+		if metaData.Stats.SessionCompletionTokens > 0 {
+			result.Session.HasTotalOutputTokens = true
+			result.Session.TotalOutputTokens = metaData.Stats.SessionCompletionTokens
+		}
+		if metaData.Stats.ContextTokens > 0 {
+			result.Session.HasPeakContextTokens = true
+			result.Session.PeakContextTokens = metaData.Stats.ContextTokens
+		} else if metaData.Stats.SessionPromptTokens > 0 {
+			result.Session.HasPeakContextTokens = true
+			result.Session.PeakContextTokens = metaData.Stats.SessionPromptTokens
+		}
+
+		// Handle parent session relationship. The parent reference is a
+		// bare session_id, so prefix it to match the canonical ID scheme.
+		if metaData.ParentSessionID != nil && *metaData.ParentSessionID != "" {
+			result.Session.ParentSessionID = "vibe:" + *metaData.ParentSessionID
+			result.Session.RelationshipType = RelContinuation
+		}
+	}
+
+	// Parse messages.jsonl
+	file, err := os.Open(path)
+	if err != nil {
+		return result, fmt.Errorf("failed to open Vibe session file: %w", err)
+	}
+	defer file.Close()
+
+	lr := newLineReader(file, maxLineSize)
+	messageOrdinal := 0
+	var firstUserContent string
+
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+
+		var vibeMsg VibeMessage
+		if err := json.Unmarshal([]byte(line), &vibeMsg); err != nil {
+			result.Session.MalformedLines++
+			continue
+		}
+
+		// Try to extract session model from first assistant message if not set yet
+		if sessionModel == "" && vibeMsg.Role == "assistant" && vibeMsg.Model != "" {
+			sessionModel = vibeMsg.Model
+		}
+
+		// Tool results are separate "tool" records linked back to the
+		// assistant's tool call via tool_call_id. Emit them as an empty
+		// RoleUser carrier message (matching the Hermes/QClaw/OpenClaw
+		// convention) so the sync engine's pairToolResults can attach the
+		// result to the originating tool call by ID; the carrier message
+		// itself is filtered out of the visible transcript afterward.
+		if vibeMsg.Role == "tool" {
+			if vibeMsg.ToolCallID == "" {
+				continue
+			}
+			quoted, err := json.Marshal(vibeMsg.Content)
+			if err != nil {
+				continue
+			}
+			result.Messages = append(result.Messages, ParsedMessage{
+				Ordinal:       messageOrdinal,
+				Role:          RoleUser,
+				Content:       "",
+				ContentLength: len(vibeMsg.Content),
+				ToolResults: []ParsedToolResult{{
+					ToolUseID:     vibeMsg.ToolCallID,
+					ContentRaw:    string(quoted),
+					ContentLength: len(vibeMsg.Content),
+				}},
+			})
+			messageOrdinal++
+			continue
+		}
+
+		// Convert Vibe message to AgentsView ParsedMessage
+		msg, _ := convertVibeMessage(vibeMsg, messageOrdinal, sessionModel)
+		result.Messages = append(result.Messages, msg)
+
+		// Track first user message content for session metadata. Skip
+		// system/injected context so it never becomes the session's first
+		// message.
+		if firstUserContent == "" && msg.Role == RoleUser &&
+			!msg.IsSystem && msg.Content != "" {
+			firstUserContent = msg.Content
+		}
+
+		messageOrdinal++
+	}
+
+	if err := lr.Err(); err != nil {
+		return result, fmt.Errorf("failed to read Vibe session file: %w", err)
+	}
+
+	// Set session metadata from messages
+	if len(result.Messages) > 0 {
+		result.Session.MessageCount = len(result.Messages)
+		result.Session.FirstMessage = firstUserContent
+	}
+
+	// Count real user messages, excluding system/injected context and the
+	// empty tool-result carrier messages emitted for "tool" records (which
+	// carry RoleUser to satisfy pairToolResults).
+	for _, msg := range result.Messages {
+		if msg.Role == RoleUser && !msg.IsSystem && len(msg.ToolResults) == 0 {
+			result.Session.UserMessageCount++
+		}
+	}
+
+	// Create usage events from session stats if we have stats, a model, and any token data
+	if hasMetaData && sessionModel != "" {
+		if usageEvents := vibeUsageEvents(
+			sessionStats, sessionModel, result.Session.ID,
+			result.Session.StartedAt, result.Session.EndedAt,
+		); len(usageEvents) > 0 {
+			result.UsageEvents = usageEvents
+		}
+	}
+
+	return result, nil
+}
+
+// parseVibeMetadata parses the meta.json file for session-level metadata
+func parseVibeMetadata(path string) (VibeSessionMetadata, error) {
+	var meta VibeSessionMetadata
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return meta, err
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return meta, err
+	}
+
+	// Extract working directory from environment if not at top level
+	if meta.WorkingDir == "" && meta.Environment.WorkingDirectory != "" {
+		meta.WorkingDir = meta.Environment.WorkingDirectory
+	}
+
+	// Vibe records the model under config.active_model rather than a
+	// top-level "model" field, so fall back to it. Without this the
+	// session has no model and no usage event is emitted.
+	if meta.Model == "" && meta.Config.ActiveModel != "" {
+		meta.Model = meta.Config.ActiveModel
+	}
+
+	return meta, nil
+}
+
+// parseVibeSessionID extracts only the canonical session_id from meta.json
+// using a minimal tolerant struct. A malformed optional field (for example a
+// bad timestamp) fails the full VibeSessionMetadata parse but must not cost the
+// session its stable identity, so the id is recovered independently. Returns an
+// error when the file cannot be read or is not even minimally valid JSON.
+func parseVibeSessionID(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var meta struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", err
+	}
+	return meta.SessionID, nil
+}
+
+// convertVibeMessage converts a VibeMessage to a ParsedMessage
+func convertVibeMessage(vibeMsg VibeMessage, ordinal int, defaultModel string) (ParsedMessage, []ParsedToolCall) {
+	msg := ParsedMessage{
+		Ordinal:       ordinal,
+		Role:          RoleType(vibeMsg.Role),
+		Content:       vibeMsg.Content,
+		ContentLength: len(vibeMsg.Content),
+		Model:         vibeMsg.Model,
+		SourceUUID:    vibeMsg.MessageID,
+	}
+
+	// Use default model if message doesn't have one
+	if msg.Model == "" && defaultModel != "" {
+		msg.Model = defaultModel
+	}
+
+	// Handle reasoning content as thinking
+	if vibeMsg.ReasoningContent != "" {
+		msg.ThinkingText = vibeMsg.ReasoningContent
+		msg.HasThinking = true
+	}
+
+	// Handle system messages. Injected records carry system context (often
+	// under a user role), so mark them system too; they are then excluded from
+	// first-message and user-message-count derivation.
+	if vibeMsg.Role == "system" || vibeMsg.Injected {
+		msg.IsSystem = true
+	}
+
+	var toolCalls []ParsedToolCall
+
+	// Convert tool calls
+	for _, tc := range vibeMsg.ToolCalls {
+		toolCall := ParsedToolCall{
+			ToolUseID: tc.ID,
+			ToolName:  tc.Function.Name,
+			Category:  NormalizeToolCategory(tc.Function.Name),
+			InputJSON: vibeToolArguments(tc.Function.Arguments),
+		}
+		toolCalls = append(toolCalls, toolCall)
+	}
+
+	if len(toolCalls) > 0 {
+		msg.HasToolUse = true
+		msg.ToolCalls = toolCalls
+	}
+
+	return msg, toolCalls
+}
+
+// vibeToolArguments normalizes a tool call's arguments to a raw JSON object.
+// Vibe (like the OpenAI/Mistral wire format) may encode arguments either as a
+// nested JSON object or as a JSON-encoded string; the latter is unwrapped so
+// InputJSON is always the underlying object.
+func vibeToolArguments(args json.RawMessage) string {
+	if len(args) > 0 && args[0] == '"' {
+		var s string
+		if err := json.Unmarshal(args, &s); err == nil {
+			return s
+		}
+	}
+	return string(args)
+}
+
+// ParseVibeSessionWrapper wraps ParseVibeSession and returns the session,
+// messages, and usage events in the shape the sync engine consumes:
+// (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error). It stats the
+// file to build FileInfo and optionally overrides the project and machine.
+func ParseVibeSessionWrapper(path, project, machine string) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	fileInfo := FileInfo{
+		Path:  path,
+		Size:  info.Size(),
+		Mtime: info.ModTime().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Override project if provided
+	if project != "" {
+		result.Session.Project = project
+	}
+
+	// Override machine if provided
+	if machine != "" {
+		result.Session.Machine = machine
+	}
+
+	return &result.Session, result.Messages, result.UsageEvents, nil
+}
+
+// vibeUsageEvents creates usage events from Vibe session stats.
+// Vibe stores aggregate token usage in meta.json stats, so we emit a single
+// session-level usage event similar to Hermes.
+func vibeUsageEvents(
+	stats VibeStats, model, sessionID string, startedAt, endedAt time.Time,
+) []ParsedUsageEvent {
+	// Only emit an event if we have a model and at least some token usage data
+	if model == "" {
+		return nil
+	}
+	if stats.SessionPromptTokens == 0 && stats.SessionCompletionTokens == 0 &&
+		stats.ContextTokens == 0 && stats.SessionTotalLLMTokens == 0 {
+		return nil
+	}
+
+	// Use SessionPromptTokens for input tokens and SessionCompletionTokens for output tokens.
+	// SessionTotalLLMTokens appears to be the sum of input + output tokens,
+	// so we don't use it as a direct source but it can serve as validation.
+	inputTokens := stats.SessionPromptTokens
+	outputTokens := stats.SessionCompletionTokens
+
+	return []ParsedUsageEvent{{
+		SessionID:    sessionID,
+		Source:       "session",
+		Model:        model,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		// Vibe doesn't currently expose cache token breakdown in meta.json
+		CacheCreationInputTokens: 0,
+		CacheReadInputTokens:     0,
+		ReasoningTokens:          0,
+		// Vibe doesn't currently expose cost information
+		CostUSD:    nil,
+		CostStatus: "",
+		CostSource: "",
+		OccurredAt: vibeTimeString(endedAt, startedAt),
+		DedupKey:   "session:" + sessionID,
+	}}
+}
+
+// vibeTimeString returns the RFC3339Nano formatted string for primary time,
+// falling back to fallback if primary is zero.
+func vibeTimeString(primary, fallback time.Time) string {
+	if !primary.IsZero() {
+		return primary.Format(time.RFC3339Nano)
+	}
+	if !fallback.IsZero() {
+		return fallback.Format(time.RFC3339Nano)
+	}
+	return ""
+}

--- a/internal/parser/vibe_test.go
+++ b/internal/parser/vibe_test.go
@@ -1,0 +1,665 @@
+package parser
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverVibeSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create file system structure
+	files := map[string]string{
+		"session_20260613_123456_abc123def/messages.jsonl": "test",
+	}
+	setupFileSystem(t, tmpDir, files)
+
+	// Create invalid directory (no messages.jsonl)
+	invalidDir := filepath.Join(tmpDir, "session_invalid")
+	require.NoError(t, os.MkdirAll(invalidDir, 0755))
+
+	// Create directory without session prefix
+	otherDir := filepath.Join(tmpDir, "other_dir")
+	require.NoError(t, os.MkdirAll(otherDir, 0755))
+
+	// Run discovery
+	discovered := DiscoverVibeSessions(tmpDir)
+
+	// Verify results
+	require.Len(t, discovered, 1)
+	assert.Equal(t, AgentVibe, discovered[0].Agent)
+	assert.Equal(t, "session_20260613_123456_abc123def", discovered[0].Project)
+}
+
+func TestDiscoverVibeSessionsMultiple(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create file system structure with multiple sessions
+	files := map[string]string{
+		"session_20260613_100000_aaa/messages.jsonl": "test",
+		"session_20260613_110000_bbb/messages.jsonl": "test",
+		"session_20260613_120000_ccc/messages.jsonl": "test",
+	}
+	setupFileSystem(t, tmpDir, files)
+
+	// Create a directory without messages.jsonl
+	invalidDir := filepath.Join(tmpDir, "session_20260613_130000_ddd")
+	require.NoError(t, os.MkdirAll(invalidDir, 0755))
+
+	// Run discovery
+	discovered := DiscoverVibeSessions(tmpDir)
+
+	// Verify results - should find only 3 valid sessions
+	require.Len(t, discovered, 3)
+	for i, f := range discovered {
+		assert.Equal(t, AgentVibe, f.Agent)
+		assert.Contains(t, f.Path, "session_20260613_")
+		assert.Contains(t, f.Path, "messages.jsonl")
+		_ = i // avoid unused variable
+	}
+}
+
+func TestDiscoverVibeSessionsEmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Run discovery on empty directory
+	files := DiscoverVibeSessions(tmpDir)
+
+	// Should return empty slice
+	assert.Len(t, files, 0)
+}
+
+func TestDiscoverVibeSessionsNonExistentDir(t *testing.T) {
+	// Run discovery on non-existent directory
+	files := DiscoverVibeSessions("/nonexistent/path")
+
+	// Should return empty slice without error
+	assert.Len(t, files, 0)
+}
+
+func TestFindVibeSourceFile(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "session_20260613_123456_abc123def"
+	setupFileSystem(t, root, map[string]string{
+		filepath.Join(sessionID, "messages.jsonl"): "test",
+	})
+
+	// When the ID matches the directory name (no meta.json), the file is
+	// resolved directly.
+	result := FindVibeSourceFile(root, sessionID)
+	expected := filepath.Join(root, sessionID, "messages.jsonl")
+	assert.Equal(t, expected, result)
+}
+
+func TestFindVibeSourceFileWithSpecialChars(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "session_20260613_123456_abc-123-def"
+	setupFileSystem(t, root, map[string]string{
+		filepath.Join(sessionID, "messages.jsonl"): "test",
+	})
+
+	result := FindVibeSourceFile(root, sessionID)
+	expected := filepath.Join(root, sessionID, "messages.jsonl")
+	assert.Equal(t, expected, result)
+}
+
+func TestFindVibeSourceFileByMetaSessionID(t *testing.T) {
+	root := t.TempDir()
+	dirName := "session_20260613_123456_abc123def"
+	setupFileSystem(t, root, map[string]string{
+		filepath.Join(dirName, "messages.jsonl"): "test",
+		filepath.Join(dirName, "meta.json"):      `{"session_id": "uuid-1234"}`,
+	})
+
+	// The canonical ID is the meta.json session_id, which differs from the
+	// directory name; the lookup must scan meta.json to resolve it.
+	result := FindVibeSourceFile(root, "uuid-1234")
+	expected := filepath.Join(root, dirName, "messages.jsonl")
+	assert.Equal(t, expected, result)
+
+	// An unknown ID resolves to nothing.
+	assert.Empty(t, FindVibeSourceFile(root, "does-not-exist"))
+}
+
+func TestParseVibeSession(t *testing.T) {
+	path := "testdata/vibe/session_basic/messages.jsonl"
+	fileInfo := FileInfo{
+		Path:  path,
+		Mtime: time.Now().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	// Verify session metadata
+	assert.Equal(t, AgentVibe, result.Session.Agent)
+	assert.NotEmpty(t, result.Session.ID)
+	assert.True(t, len(result.Session.ID) > 0)
+
+	// Verify messages
+	require.NotEmpty(t, result.Messages)
+	assert.Equal(t, 5, len(result.Messages))
+
+	// Verify first message is user
+	assert.Equal(t, RoleUser, result.Messages[0].Role)
+	assert.Equal(t, "Create a Python function to sort a list", result.Messages[0].Content)
+
+	// Verify last message is assistant
+	assert.Equal(t, RoleAssistant, result.Messages[4].Role)
+
+	// Verify session metadata from meta.json
+	assert.Equal(t, "vibe:abc123def-0000-0000-0000-000000000000", result.Session.ID)
+	assert.Equal(t, "abc123def-0000-0000-0000-000000000000", result.Session.SourceSessionID)
+	assert.Equal(t, "Create a Python function to sort a list", result.Session.SessionName)
+	assert.Equal(t, "/home/user/projects/myapp", result.Session.Cwd)
+	// Project is derived from the working directory (basename here, since
+	// the path is not a real git repo), not the cryptic session directory.
+	assert.Equal(t, "myapp", result.Session.Project)
+	assert.Equal(t, "main", result.Session.GitBranch)
+	assert.Equal(t, "abc123def456", result.Session.SourceVersion)
+	assert.True(t, result.Session.HasTotalOutputTokens)
+	assert.Equal(t, 50, result.Session.TotalOutputTokens)
+	assert.True(t, result.Session.HasPeakContextTokens)
+	assert.Equal(t, 150, result.Session.PeakContextTokens)
+
+	// Verify usage events are created from session stats
+	require.Len(t, result.UsageEvents, 1)
+	usageEvent := result.UsageEvents[0]
+	assert.Equal(t, "vibe:abc123def-0000-0000-0000-000000000000", usageEvent.SessionID)
+	assert.Equal(t, "session", usageEvent.Source)
+	assert.Equal(t, "mistral-medium-3.5", usageEvent.Model)
+	assert.Equal(t, 100, usageEvent.InputTokens)
+	assert.Equal(t, 50, usageEvent.OutputTokens) // Uses session_completion_tokens
+	assert.Equal(t, 0, usageEvent.CacheCreationInputTokens)
+	assert.Equal(t, 0, usageEvent.CacheReadInputTokens)
+	assert.Equal(t, 0, usageEvent.ReasoningTokens)
+	assert.Nil(t, usageEvent.CostUSD)
+	assert.Equal(t, "", usageEvent.CostStatus)
+	assert.Equal(t, "", usageEvent.CostSource)
+	assert.Equal(t, "session:vibe:abc123def-0000-0000-0000-000000000000", usageEvent.DedupKey)
+}
+
+func TestParseVibeSessionWithTools(t *testing.T) {
+	path := "testdata/vibe/session_with_tools/messages.jsonl"
+	fileInfo := FileInfo{
+		Path:  path,
+		Mtime: time.Now().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	// Verify messages
+	require.NotEmpty(t, result.Messages)
+	assert.Equal(t, 4, len(result.Messages))
+
+	// Verify tool calls were parsed
+	hasToolCalls := false
+	for _, msg := range result.Messages {
+		if len(msg.ToolCalls) > 0 {
+			hasToolCalls = true
+			assert.Equal(t, 1, len(msg.ToolCalls))
+			assert.Equal(t, "call_001", msg.ToolCalls[0].ToolUseID)
+			assert.Equal(t, "read_file", msg.ToolCalls[0].ToolName)
+			assert.Equal(t, "Read", msg.ToolCalls[0].Category)
+			break
+		}
+	}
+	assert.True(t, hasToolCalls, "Expected tool calls to be parsed")
+
+	// Verify tool results are carried in a dedicated empty RoleUser
+	// message (matching the Hermes/QClaw/OpenClaw convention) rather
+	// than duplicated as a separate visible "tool" message.
+	hasToolResults := false
+	for _, msg := range result.Messages {
+		if len(msg.ToolResults) > 0 {
+			hasToolResults = true
+			assert.Equal(t, RoleUser, msg.Role)
+			assert.Equal(t, "", msg.Content)
+			assert.Equal(t, 1, len(msg.ToolResults))
+			assert.Equal(t, "call_001", msg.ToolResults[0].ToolUseID)
+
+			// ContentRaw must be valid JSON (a quoted string) so
+			// DecodeContent can surface the plain-text tool output.
+			var decoded string
+			require.NoError(
+				t, json.Unmarshal(
+					[]byte(msg.ToolResults[0].ContentRaw), &decoded,
+				),
+			)
+			assert.Contains(t, decoded, "# My Project")
+			break
+		}
+	}
+	assert.True(t, hasToolResults, "Expected tool results to be linked")
+
+	for _, msg := range result.Messages {
+		assert.NotEqual(
+			t, RoleType("tool"), msg.Role,
+			"raw tool-result records must not appear as standalone messages",
+		)
+	}
+}
+
+func TestParseVibeSessionEmpty(t *testing.T) {
+	path := "testdata/vibe/session_empty/messages.jsonl"
+	fileInfo := FileInfo{
+		Path:  path,
+		Mtime: time.Now().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	// Empty file should have no messages
+	assert.Len(t, result.Messages, 0)
+	assert.Equal(t, 0, result.Session.MessageCount)
+}
+
+func TestParseVibeSessionMalformedLines(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a messages.jsonl with malformed JSON
+	content := `{"role": "user", "content": "valid", "message_id": "1"}
+{this is not valid json}
+{"role": "assistant", "content": "another valid", "message_id": "2"}
+`
+	files := map[string]string{
+		"session_test/messages.jsonl": content,
+	}
+	setupFileSystem(t, tmpDir, files)
+
+	path := filepath.Join(tmpDir, "session_test", "messages.jsonl")
+	fileInfo := FileInfo{
+		Path:  path,
+		Mtime: time.Now().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	// Should have parsed 2 valid messages and counted 1 malformed line
+	assert.Len(t, result.Messages, 2)
+	assert.Equal(t, 1, result.Session.MalformedLines)
+}
+
+func TestParseVibeSessionWithoutMeta(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a messages.jsonl without meta.json in a session subdirectory
+	content := `{"role": "user", "content": "test message", "message_id": "1"}
+{"role": "assistant", "content": "test response", "message_id": "2"}
+`
+	files := map[string]string{
+		"session_test/messages.jsonl": content,
+	}
+	setupFileSystem(t, tmpDir, files)
+
+	path := filepath.Join(tmpDir, "session_test", "messages.jsonl")
+	fileInfo := FileInfo{
+		Path:  path,
+		Mtime: time.Now().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	// Should have parsed messages but no metadata from meta.json. The ID
+	// falls back to the directory name but still carries the "vibe:" prefix
+	// so prefix-based routing works.
+	assert.Len(t, result.Messages, 2)
+	assert.Equal(t, "vibe:session_test", result.Session.ID)
+	assert.Equal(t, "vibe", result.Session.Project) // Vibe sessions use "vibe" as project
+
+	// Should have no usage events since there's no meta.json with stats
+	assert.Empty(t, result.UsageEvents)
+}
+
+func TestParseVibeSessionEmptyStats(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a messages.jsonl with meta.json that has empty stats
+	content := `{"role": "user", "content": "test message", "message_id": "1"}
+{"role": "assistant", "content": "test response", "message_id": "2"}
+`
+	metaContent := `{
+		"session_id": "test-session-123",
+		"start_time": "2026-06-13T10:00:00Z",
+		"end_time": "2026-06-13T10:05:00Z",
+		"model": "mistral-medium-3.5",
+		"title": "Test session",
+		"stats": {
+			"steps": 0,
+			"session_prompt_tokens": 0,
+			"session_completion_tokens": 0,
+			"context_tokens": 0,
+			"last_turn_prompt_tokens": 0,
+			"last_turn_completion_tokens": 0,
+			"session_total_llm_tokens": 0,
+			"last_turn_total_tokens": 0
+		}
+	}
+`
+	files := map[string]string{
+		"session_test/messages.jsonl": content,
+		"session_test/meta.json":      metaContent,
+	}
+	setupFileSystem(t, tmpDir, files)
+
+	path := filepath.Join(tmpDir, "session_test", "messages.jsonl")
+	fileInfo := FileInfo{
+		Path:  path,
+		Mtime: time.Now().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	// Should have parsed messages and metadata but no usage events due to empty stats
+	assert.Len(t, result.Messages, 2)
+	assert.Equal(t, "vibe:test-session-123", result.Session.ID)
+	assert.Equal(t, "Test session", result.Session.SessionName)
+
+	// Should have no usage events since all stats are zero
+	assert.Empty(t, result.UsageEvents)
+}
+
+func TestParseVibeSessionModelFromMessages(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a messages.jsonl with meta.json that has stats but no model
+	content := `{"role": "user", "content": "test message", "message_id": "1"}
+{"role": "assistant", "content": "test response", "model": "mistral-medium", "message_id": "2"}
+`
+	metaContent := `{
+		"session_id": "test-session-456",
+		"start_time": "2026-06-13T10:00:00Z",
+		"end_time": "2026-06-13T10:05:00Z",
+		"title": "Test session with model in messages",
+		"stats": {
+			"steps": 2,
+			"session_prompt_tokens": 50,
+			"session_completion_tokens": 25,
+			"context_tokens": 75,
+			"last_turn_prompt_tokens": 25,
+			"last_turn_completion_tokens": 12,
+			"session_total_llm_tokens": 75,
+			"last_turn_total_tokens": 37
+		}
+	}
+`
+	files := map[string]string{
+		"session_test/messages.jsonl": content,
+		"session_test/meta.json":      metaContent,
+	}
+	setupFileSystem(t, tmpDir, files)
+
+	path := filepath.Join(tmpDir, "session_test", "messages.jsonl")
+	fileInfo := FileInfo{
+		Path:  path,
+		Mtime: time.Now().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	// Should have parsed messages and metadata
+	assert.Len(t, result.Messages, 2)
+	assert.Equal(t, "vibe:test-session-456", result.Session.ID)
+	assert.Equal(t, "Test session with model in messages", result.Session.SessionName)
+
+	// Should have usage events created with model extracted from assistant message
+	require.Len(t, result.UsageEvents, 1)
+	usageEvent := result.UsageEvents[0]
+	assert.Equal(t, "vibe:test-session-456", usageEvent.SessionID)
+	assert.Equal(t, "session", usageEvent.Source)
+	assert.Equal(t, "mistral-medium", usageEvent.Model)
+	assert.Equal(t, 50, usageEvent.InputTokens)
+	assert.Equal(t, 25, usageEvent.OutputTokens)
+}
+
+// TestParseVibeSessionModelFromConfig verifies that the model is read from
+// config.active_model when there is no top-level "model" field. Real Vibe
+// meta.json files record the model only under config.active_model, so without
+// this fallback no usage event is emitted and the model never reaches the
+// usage view.
+func TestParseVibeSessionModelFromConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := `{"role": "user", "content": "test message", "message_id": "1"}
+{"role": "assistant", "content": "test response", "message_id": "2"}
+`
+	// No top-level "model"; model lives under config.active_model, and no
+	// message carries a model either, matching real Vibe sessions.
+	metaContent := `{
+		"session_id": "test-session-789",
+		"start_time": "2026-06-13T10:00:00Z",
+		"end_time": "2026-06-13T10:05:00Z",
+		"title": "Test session with model in config",
+		"config": {"active_model": "mistral-medium-3.5"},
+		"stats": {
+			"session_prompt_tokens": 100,
+			"session_completion_tokens": 40,
+			"context_tokens": 140,
+			"session_total_llm_tokens": 140
+		}
+	}
+`
+	files := map[string]string{
+		"session_test/messages.jsonl": content,
+		"session_test/meta.json":      metaContent,
+	}
+	setupFileSystem(t, tmpDir, files)
+
+	path := filepath.Join(tmpDir, "session_test", "messages.jsonl")
+	fileInfo := FileInfo{Path: path, Mtime: time.Now().UnixNano()}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	require.Len(t, result.UsageEvents, 1)
+	usageEvent := result.UsageEvents[0]
+	assert.Equal(t, "mistral-medium-3.5", usageEvent.Model)
+	assert.Equal(t, 100, usageEvent.InputTokens)
+	assert.Equal(t, 40, usageEvent.OutputTokens)
+}
+
+// TestParseVibeSessionInjectedUserExcluded verifies that an injected user
+// record (system context) is marked system and excluded from both the first
+// message and the user-message count, so it cannot masquerade as the user's
+// opening prompt or inflate the count.
+func TestParseVibeSessionInjectedUserExcluded(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := `{"role": "user", "content": "<system context>", "injected": true, "message_id": "0"}
+{"role": "user", "content": "real prompt", "message_id": "1"}
+{"role": "assistant", "content": "ok", "message_id": "2"}
+`
+	setupFileSystem(t, tmpDir, map[string]string{
+		"session_test/messages.jsonl": content,
+	})
+
+	path := filepath.Join(tmpDir, "session_test", "messages.jsonl")
+	fileInfo := FileInfo{Path: path, Mtime: time.Now().UnixNano()}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	require.Len(t, result.Messages, 3)
+	// The injected record is preserved but marked system so the UI hides it.
+	assert.True(t, result.Messages[0].IsSystem, "injected record must be system")
+	assert.False(t, result.Messages[1].IsSystem, "real prompt must not be system")
+
+	// The first message and user count skip the injected record.
+	assert.Equal(t, "real prompt", result.Session.FirstMessage)
+	assert.Equal(t, 1, result.Session.UserMessageCount)
+}
+
+// TestParseVibeSessionToolResultNotCountedAsUser verifies the empty RoleUser
+// carrier emitted for a "tool" record is not counted as a user message.
+func TestParseVibeSessionToolResultNotCountedAsUser(t *testing.T) {
+	path := "testdata/vibe/session_with_tools/messages.jsonl"
+	fileInfo := FileInfo{Path: path, Mtime: time.Now().UnixNano()}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Session.UserMessageCount)
+	assert.Equal(t, "Read the README file", result.Session.FirstMessage)
+}
+
+// TestParseVibeSessionMalformedMetaRecoversID verifies that when meta.json has
+// a valid session_id but a malformed optional field (a bad timestamp here that
+// fails the full parse), the canonical ID is still recovered rather than
+// dropping to the directory-name fallback, which would abandon the canonical
+// session row.
+func TestParseVibeSessionMalformedMetaRecoversID(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := `{"role": "user", "content": "hello", "message_id": "1"}
+`
+	metaContent := `{"session_id": "uuid-canonical-1", "start_time": "not-a-timestamp"}`
+	setupFileSystem(t, tmpDir, map[string]string{
+		"session_dir/messages.jsonl": content,
+		"session_dir/meta.json":      metaContent,
+	})
+
+	path := filepath.Join(tmpDir, "session_dir", "messages.jsonl")
+	fileInfo := FileInfo{Path: path, Mtime: time.Now().UnixNano()}
+
+	result, err := ParseVibeSession(path, fileInfo)
+	require.NoError(t, err)
+
+	assert.Equal(t, "vibe:uuid-canonical-1", result.Session.ID)
+	assert.Equal(t, "uuid-canonical-1", result.Session.SourceSessionID)
+	// The malformed optional fields are skipped, so no usage event is emitted.
+	assert.Empty(t, result.UsageEvents)
+}
+
+// TestParseVibeSessionCorruptMetaReturnsError verifies that a meta.json which
+// is not even minimally valid JSON (a truncated/partial write) makes the parse
+// fail, so the sync retries and leaves any existing canonical row untouched
+// rather than silently re-creating it under the directory-name fallback.
+func TestParseVibeSessionCorruptMetaReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	content := `{"role": "user", "content": "hello", "message_id": "1"}
+`
+	metaContent := `{"session_id": "uuid-canonical-2",`
+	setupFileSystem(t, tmpDir, map[string]string{
+		"session_dir/messages.jsonl": content,
+		"session_dir/meta.json":      metaContent,
+	})
+
+	path := filepath.Join(tmpDir, "session_dir", "messages.jsonl")
+	fileInfo := FileInfo{Path: path, Mtime: time.Now().UnixNano()}
+
+	_, err := ParseVibeSession(path, fileInfo)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "meta.json")
+}
+
+func TestVibeAgentByType(t *testing.T) {
+	def, ok := AgentByType(AgentVibe)
+	require.True(t, ok, "Expected AgentVibe to be registered")
+
+	assert.Equal(t, AgentVibe, def.Type)
+	assert.Equal(t, "Mistral Vibe", def.DisplayName)
+	assert.Equal(t, "VIBE_SESSIONS_DIR", def.EnvVar)
+	assert.Equal(t, "vibe_session_dirs", def.ConfigKey)
+	assert.Equal(t, "vibe:", def.IDPrefix)
+	assert.True(t, def.FileBased)
+	assert.NotNil(t, def.DiscoverFunc)
+	assert.NotNil(t, def.FindSourceFunc)
+}
+
+func TestVibeAgentByPrefix(t *testing.T) {
+	// Test with vibe: prefix
+	def, ok := AgentByPrefix("vibe:session_123")
+	require.True(t, ok, "Expected vibe: prefix to match")
+	assert.Equal(t, AgentVibe, def.Type)
+
+	// Test with just session_123 - this will match Claude (empty prefix) since it has no colon
+	// This is expected behavior per AgentByPrefix logic
+	def2, ok2 := AgentByPrefix("session_123")
+	assert.True(t, ok2, "session_123 matches Claude (empty prefix)")
+	assert.Equal(t, AgentClaude, def2.Type)
+}
+
+func TestConvertVibeMessageToolCalls(t *testing.T) {
+	// Tool categorization is delegated to the shared NormalizeToolCategory,
+	// and string-encoded arguments are unwrapped to the raw JSON object.
+	vibeMsg := VibeMessage{
+		Role: "assistant",
+		ToolCalls: []VibeToolCall{
+			{ID: "call_obj", Function: VibeToolCallFunction{
+				Name: "read_file", Arguments: json.RawMessage(`{"path":"a.txt"}`),
+			}},
+			{ID: "call_str", Function: VibeToolCallFunction{
+				Name: "run_shell_command", Arguments: json.RawMessage(`"{\"cmd\":\"ls\"}"`),
+			}},
+		},
+	}
+
+	msg, toolCalls := convertVibeMessage(vibeMsg, 0, "")
+	require.Len(t, toolCalls, 2)
+	assert.True(t, msg.HasToolUse)
+
+	assert.Equal(t, "Read", toolCalls[0].Category)
+	assert.JSONEq(t, `{"path":"a.txt"}`, toolCalls[0].InputJSON)
+
+	assert.Equal(t, "Bash", toolCalls[1].Category)
+	assert.JSONEq(t, `{"cmd":"ls"}`, toolCalls[1].InputJSON)
+}
+
+// TestParseRealVibeSession tests parsing with real Vibe session data only when
+// explicitly requested. It is skipped by default so tests never read private
+// local session data from a developer's home directory.
+func TestParseRealVibeSession(t *testing.T) {
+	vibeSessionDir := os.Getenv("AGENTSVIEW_TEST_VIBE_SESSION_DIR")
+	if vibeSessionDir == "" {
+		t.Skip("AGENTSVIEW_TEST_VIBE_SESSION_DIR not set")
+	}
+	messagesPath := filepath.Join(vibeSessionDir, "messages.jsonl")
+	metaPath := filepath.Join(vibeSessionDir, "meta.json")
+
+	// Skip if test session doesn't exist
+	if _, err := os.Stat(messagesPath); os.IsNotExist(err) {
+		t.Skipf("Test Vibe session not found at %s", messagesPath)
+	}
+	if _, err := os.Stat(metaPath); os.IsNotExist(err) {
+		t.Skipf("Test Vibe meta.json not found at %s", metaPath)
+	}
+
+	fileInfo := FileInfo{
+		Path:  messagesPath,
+		Mtime: time.Now().UnixNano(),
+	}
+
+	result, err := ParseVibeSession(messagesPath, fileInfo)
+	require.NoError(t, err)
+
+	// Verify basic session metadata
+	assert.Equal(t, AgentVibe, result.Session.Agent)
+	assert.NotEmpty(t, result.Session.ID)
+	assert.True(t, len(result.Session.ID) > 0)
+
+	// Should have parsed messages
+	require.NotEmpty(t, result.Messages)
+	assert.Greater(t, len(result.Messages), 0)
+
+	// Verify timestamps from meta.json
+	assert.False(t, result.Session.StartedAt.IsZero())
+	assert.False(t, result.Session.EndedAt.IsZero())
+
+	// Verify token usage from meta.json
+	assert.True(t, result.Session.HasTotalOutputTokens || result.Session.TotalOutputTokens > 0)
+
+	t.Logf("Successfully parsed real Vibe session with %d messages", len(result.Messages))
+}

--- a/internal/pricing/fallback.go
+++ b/internal/pricing/fallback.go
@@ -2,7 +2,7 @@ package pricing
 
 // FallbackVersion must be bumped whenever FallbackPricing
 // rates change so the startup seeder knows to re-upsert.
-const FallbackVersion = "2026-06-10"
+const FallbackVersion = "2026-06-16.1"
 
 // FallbackPricing returns hardcoded pricing for key Claude
 // models. Used when the LiteLLM fetch fails.
@@ -129,6 +129,36 @@ func FallbackPricing() []ModelPricing {
 			ModelPattern:  "openrouter/owl-alpha",
 			InputPerMTok:  0,
 			OutputPerMTok: 0,
+		},
+		// Mistral models (Mistral Vibe)
+		{
+			ModelPattern:  "mistral-medium",
+			InputPerMTok:  2.75,
+			OutputPerMTok: 2.75,
+		},
+		{
+			ModelPattern:  "mistral-medium-3",
+			InputPerMTok:  2.75,
+			OutputPerMTok: 2.75,
+		},
+		{
+			ModelPattern:         "mistral-medium-3.5",
+			InputPerMTok:         1.5,
+			OutputPerMTok:        7.5,
+			CacheCreationPerMTok: 1.5,
+			CacheReadPerMTok:     0.25,
+		},
+		{
+			ModelPattern:  "mistral-large",
+			InputPerMTok:  4.0,
+			OutputPerMTok: 4.0,
+		},
+		{
+			ModelPattern:         "mistral-large-3",
+			InputPerMTok:         4.0,
+			OutputPerMTok:        4.0,
+			CacheCreationPerMTok: 4.0,
+			CacheReadPerMTok:     0.30,
 		},
 	}
 }

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -298,8 +298,57 @@ func (b *directBackend) Sync(
 			return nil, err
 		}
 		id = resolved
+		return b.Get(ctx, id)
 	}
-	return b.Get(ctx, id)
+
+	detail, err := b.Get(ctx, id)
+	if err != nil || detail != nil {
+		return detail, err
+	}
+	// The requested session is gone after sync. Vibe is the only agent that
+	// reassigns a session's canonical ID for an unchanged source file: a
+	// fallback ID is promoted when meta.json appears, and a canonical ID is
+	// demoted to the directory-name fallback when meta.json is removed or
+	// becomes unparseable. For a Vibe ID, resolve the file's current session
+	// and confirm it is the replacement before returning it.
+	if !isVibeSessionID(id) {
+		return nil, syncSessionNotFoundError(id)
+	}
+	resolved, err := b.resolveSessionIDByPath(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	detail, err = b.Get(ctx, resolved)
+	if err != nil || detail == nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, syncSessionNotFoundError(id)
+	}
+	if !isVibeReplacement(id, detail) {
+		return nil, syncSessionNotFoundError(id)
+	}
+	return detail, nil
+}
+
+func syncSessionNotFoundError(id string) error {
+	return fmt.Errorf("sync: session %q was not found after sync", id)
+}
+
+func isVibeSessionID(id string) bool {
+	return strings.HasPrefix(id, "vibe:")
+}
+
+// isVibeReplacement reports whether detail is the Vibe session that now owns
+// the requested session's source file after a canonical-ID reassignment. The
+// caller resolves detail strictly by the requested session's file_path, so a
+// different-ID Vibe session is the replacement regardless of direction
+// (fallback->canonical when meta.json appears, canonical->fallback when it is
+// removed or unparseable).
+func isVibeReplacement(requestedID string, detail *SessionDetail) bool {
+	return detail != nil &&
+		detail.Agent == "vibe" &&
+		requestedID != detail.ID
 }
 
 // resolveSessionIDByPath returns the single session id whose

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/agentsview/internal/secrets"
 	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 // directTestEnv is a lightweight environment helper for testing
@@ -384,6 +385,162 @@ func TestDirectBackend_Sync_VSCopilotIDRefreshesOnlyRequestedConversation(t *tes
 	require.NotNil(t, untouched.FirstMessage)
 	assert.Equal(t, "Before untouched", *untouched.FirstMessage,
 		"syncing by id must not refresh sibling conversations in the same trace")
+}
+
+func TestDirectBackend_Sync_VibeFallbackIDReturnsPromotedSession(t *testing.T) {
+	vibeDir := t.TempDir()
+	d := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(d, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+	svc := service.NewDirectBackend(d, engine)
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	))
+
+	engine.SyncPaths([]string{messagesPath})
+	fallbackID := "vibe:" + dirName
+	fallback, err := d.GetSession(context.Background(), fallbackID)
+	require.NoError(t, err)
+	require.NotNil(t, fallback)
+
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Promoted"}`+"\n"),
+		0o644,
+	))
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	detail, err := svc.Sync(context.Background(), service.SyncInput{
+		ID: fallbackID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.Equal(t, "vibe:"+sessionID, detail.ID)
+	require.NotNil(t, detail.DisplayName)
+	assert.Equal(t, "Promoted", *detail.DisplayName)
+
+	stale, err := d.GetSession(context.Background(), fallbackID)
+	require.NoError(t, err)
+	assert.Nil(t, stale)
+}
+
+// TestDirectBackend_Sync_VibeCanonicalIDResolvesFallbackAfterMetaRemoved
+// verifies the reverse of the promotion case: when meta.json is removed, the
+// session is demoted to the directory-name fallback ID, and syncing the old
+// canonical ID resolves to that fallback session instead of reporting the
+// session as not found.
+func TestDirectBackend_Sync_VibeCanonicalIDResolvesFallbackAfterMetaRemoved(t *testing.T) {
+	vibeDir := t.TempDir()
+	d := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(d, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+	svc := service.NewDirectBackend(d, engine)
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	))
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	canonicalID := "vibe:" + sessionID
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Canonical"}`+"\n"),
+		0o644,
+	))
+
+	// First sync stores the session under the canonical meta-derived ID.
+	engine.SyncPaths([]string{messagesPath})
+	canonical, err := d.GetSession(context.Background(), canonicalID)
+	require.NoError(t, err)
+	require.NotNil(t, canonical)
+
+	// meta.json is removed, so the next sync demotes the session to the
+	// directory-name fallback ID. Bump the transcript mtime so the sync does
+	// not skip the otherwise-unchanged file.
+	require.NoError(t, os.Remove(metaPath))
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(messagesPath, future, future))
+
+	detail, err := svc.Sync(context.Background(), service.SyncInput{
+		ID: canonicalID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.Equal(t, "vibe:"+dirName, detail.ID)
+
+	stale, err := d.GetSession(context.Background(), canonicalID)
+	require.NoError(t, err)
+	assert.Nil(t, stale)
+}
+
+func TestDirectBackend_Sync_MissingNonVibeIDDoesNotReturnSamePathSession(t *testing.T) {
+	claudeDir := t.TempDir()
+	d := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(d, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeDir},
+		},
+		Machine: "local",
+	})
+	svc := service.NewDirectBackend(d, engine)
+
+	projectDir := filepath.Join(claudeDir, "ClaudeProbe")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	path := filepath.Join(projectDir, "requested.jsonl")
+	const usageCmd = "<command-name>/usage</command-name>\n" +
+		"            <command-message>usage</command-message>\n" +
+		"            <command-args></command-args>"
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte(testjsonl.ClaudeUserJSON(usageCmd, "2026-06-17T12:00:00Z")+"\n"),
+		0o644,
+	))
+
+	require.NoError(t, d.UpsertSession(db.Session{
+		ID:       "requested",
+		Project:  "proj",
+		Machine:  "local",
+		Agent:    "claude",
+		FilePath: &path,
+	}))
+	require.NoError(t, d.UpsertSession(db.Session{
+		ID:       "unrelated",
+		Project:  "proj",
+		Machine:  "local",
+		Agent:    "claude",
+		FilePath: &path,
+	}))
+
+	detail, err := svc.Sync(context.Background(), service.SyncInput{
+		ID: "requested",
+	})
+	assert.Nil(t, detail)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `sync: session "requested" was not found after sync`)
 }
 
 // TestDirectBackend_Watch_UnknownID_Errors verifies that Watch

--- a/internal/sync/classify_vibe_test.go
+++ b/internal/sync/classify_vibe_test.go
@@ -1,0 +1,92 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestClassifyOnePath_Vibe(t *testing.T) {
+	dir := t.TempDir()
+	sessionDir := "session_20260616_083518_0107f266"
+
+	// Vibe layout: <vibeDir>/session_<ts>_<uuid>/messages.jsonl.
+	msgPath := filepath.Join(dir, sessionDir, "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(msgPath), 0o755))
+	require.NoError(t, os.WriteFile(msgPath, []byte("{}\n"), 0o644))
+
+	// A real meta.json sits beside messages.jsonl. Changes to it should
+	// route back to the sibling messages.jsonl, since title/model/usage
+	// stats are sourced from meta.json.
+	metaPath := filepath.Join(dir, sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(metaPath, []byte("{}\n"), 0o644))
+
+	deletedMetaDir := "session_20260616_083519_deleted"
+	deletedMetaMsgPath := filepath.Join(dir, deletedMetaDir, "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(deletedMetaMsgPath), 0o755))
+	require.NoError(t, os.WriteFile(deletedMetaMsgPath, []byte("{}\n"), 0o644))
+	deletedMetaPath := filepath.Join(dir, deletedMetaDir, "meta.json")
+
+	// A non-session directory must not classify.
+	otherPath := filepath.Join(dir, "scratch", "messages.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(otherPath), 0o755))
+	require.NoError(t, os.WriteFile(otherPath, []byte("{}\n"), 0o644))
+
+	eng := &Engine{
+		agentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {dir},
+		},
+	}
+	geminiMap := make(map[string]map[string]string)
+
+	tests := []struct {
+		name        string
+		path        string
+		want        bool
+		wantPath    string
+		wantProject string
+	}{
+		{
+			name:        "messages.jsonl under session dir classifies",
+			path:        msgPath,
+			want:        true,
+			wantPath:    msgPath,
+			wantProject: sessionDir,
+		},
+		{
+			name: "messages.jsonl outside session dir ignored",
+			path: otherPath,
+			want: false,
+		},
+		{
+			name:        "meta.json routes to sibling messages.jsonl",
+			path:        metaPath,
+			want:        true,
+			wantPath:    msgPath,
+			wantProject: sessionDir,
+		},
+		{
+			name:        "deleted meta.json routes to sibling messages.jsonl",
+			path:        deletedMetaPath,
+			want:        true,
+			wantPath:    deletedMetaMsgPath,
+			wantProject: deletedMetaDir,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := eng.classifyOnePath(tt.path, geminiMap)
+			assert.Equal(t, tt.want, ok)
+			if ok {
+				assert.Equal(t, parser.AgentVibe, got.Agent)
+				assert.Equal(t, tt.wantPath, got.Path)
+				assert.Equal(t, tt.wantProject, got.Project)
+			}
+		})
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -537,18 +537,13 @@ func findContainingDir(dirs []string, path string) string {
 	return ""
 }
 
-func (e *Engine) classifyOnePath(
-	path string,
-	geminiProjectsByDir map[string]map[string]string,
+// classifyContainerPath runs the container- and SQLite-style classifiers that
+// resolve a path whether or not it currently exists on disk (OpenCode-format
+// stores, Kiro, Zed, Shelley, and Vibe). Split out of classifyOnePath to keep
+// that function within NilAway's per-function CFG-block limit.
+func (e *Engine) classifyContainerPath(
+	path string, pathExists bool,
 ) (parser.DiscoveredFile, bool) {
-	sep := string(filepath.Separator)
-	pathExists := true
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			pathExists = false
-		}
-	}
-
 	if df, ok := e.classifyOpenCodeFormatPath(
 		parser.AgentOpenCode, path, pathExists,
 	); ok {
@@ -571,6 +566,27 @@ func (e *Engine) classifyOnePath(
 		return df, true
 	}
 	if df, ok := e.classifyShelleySQLitePath(path); ok {
+		return df, true
+	}
+	if df, ok := e.classifyVibePath(path); ok {
+		return df, true
+	}
+	return parser.DiscoveredFile{}, false
+}
+
+func (e *Engine) classifyOnePath(
+	path string,
+	geminiProjectsByDir map[string]map[string]string,
+) (parser.DiscoveredFile, bool) {
+	sep := string(filepath.Separator)
+	pathExists := true
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			pathExists = false
+		}
+	}
+
+	if df, ok := e.classifyContainerPath(path, pathExists); ok {
 		return df, true
 	}
 	if !pathExists {
@@ -1385,6 +1401,55 @@ func (e *Engine) classifyVisualStudioCopilotPath(
 			Project: "visualstudio",
 			Agent:   parser.AgentVSCopilot,
 		}, true
+	}
+	return parser.DiscoveredFile{}, false
+}
+
+// classifyVibePath handles Vibe's session directory layout:
+//
+//	<vibeDir>/session_<timestamp>_<uuid>/messages.jsonl
+//	<vibeDir>/session_<timestamp>_<uuid>/meta.json
+//
+// meta.json changes route back to messages.jsonl because title, model,
+// timestamps, and usage stats are sourced from the sidecar metadata file.
+func (e *Engine) classifyVibePath(
+	path string,
+) (parser.DiscoveredFile, bool) {
+	sep := string(filepath.Separator)
+	for _, vibeDir := range e.agentDirs[parser.AgentVibe] {
+		if vibeDir == "" {
+			continue
+		}
+		rel, ok := isUnder(vibeDir, path)
+		if !ok {
+			continue
+		}
+		parts := strings.Split(rel, sep)
+		if len(parts) != 2 || !strings.HasPrefix(parts[0], "session_") {
+			continue
+		}
+		switch parts[1] {
+		case "messages.jsonl":
+			if _, err := os.Stat(path); err != nil {
+				continue
+			}
+			return parser.DiscoveredFile{
+				Path:    path,
+				Project: parts[0],
+				Agent:   parser.AgentVibe,
+			}, true
+		case "meta.json":
+			messagesPath := filepath.Join(
+				vibeDir, parts[0], "messages.jsonl",
+			)
+			if _, err := os.Stat(messagesPath); err == nil {
+				return parser.DiscoveredFile{
+					Path:    messagesPath,
+					Project: parts[0],
+					Agent:   parser.AgentVibe,
+				}, true
+			}
+		}
 	}
 	return parser.DiscoveredFile{}, false
 }
@@ -2304,7 +2369,7 @@ func (e *Engine) syncAllLocked(
 
 	if verbose {
 		log.Printf(
-			"discovered %d files (%d claude, %d codex, %d copilot, %d gemini, %d cursor, %d amp, %d zencoder, %d iflow, %d vscode-copilot, %d visualstudio-copilot, %d pi, %d kiro, %d zed) in %s",
+			"discovered %d files (%d claude, %d codex, %d copilot, %d gemini, %d cursor, %d amp, %d zencoder, %d iflow, %d vscode-copilot, %d visualstudio-copilot, %d pi, %d kiro, %d zed, %d vibe) in %s",
 			len(all),
 			counts[parser.AgentClaude],
 			counts[parser.AgentCodex],
@@ -2319,6 +2384,7 @@ func (e *Engine) syncAllLocked(
 			counts[parser.AgentPi],
 			counts[parser.AgentKiro],
 			counts[parser.AgentZed],
+			counts[parser.AgentVibe],
 			time.Since(t0).Round(time.Millisecond),
 		)
 	}
@@ -2797,6 +2863,13 @@ func discoveredFileMtime(
 			return 0, err
 		}
 		return commandCodeEffectiveInfo(file.Path, info).ModTime().UnixNano(), nil
+	}
+	if file.Agent == parser.AgentVibe {
+		info, err := os.Stat(file.Path)
+		if err != nil {
+			return 0, err
+		}
+		return vibeEffectiveInfo(file.Path, info).ModTime().UnixNano(), nil
 	}
 
 	info, err := os.Stat(file.Path)
@@ -3637,6 +3710,8 @@ func (e *Engine) processFile(
 		res = e.processHermes(file, info)
 	case parser.AgentWorkBuddy:
 		res = e.processWorkBuddy(file, info)
+	case parser.AgentVibe:
+		res = e.processVibe(file, info)
 	case parser.AgentPositron:
 		res = e.processPositron(file, info)
 	case parser.AgentZed:
@@ -5380,6 +5455,117 @@ func (e *Engine) processWorkBuddy(
 	}
 }
 
+func (e *Engine) processVibe(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	// Title/model/usage stats come from the sibling meta.json, so the
+	// skip check and stored file info must account for it too, or a
+	// meta.json-only update never refreshes those fields.
+	effectiveInfo := vibeEffectiveInfo(file.Path, info)
+	if e.shouldSkipByPath(file.Path, effectiveInfo) {
+		return processResult{skip: true}
+	}
+
+	// Pass an empty project so the parser-derived project (from the
+	// session's working directory) is kept. file.Project holds the
+	// cryptic session directory name, which must not become the project.
+	sess, msgs, usageEvents, err := parser.ParseVibeSessionWrapper(
+		file.Path, "", e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
+	}
+	sess.File.Size = effectiveInfo.Size()
+	sess.File.Mtime = effectiveInfo.ModTime().UnixNano()
+
+	hash, err := ComputeFileHash(file.Path)
+	if err == nil {
+		sess.File.Hash = hash
+	}
+
+	var excludedIDs []string
+	lookupPath := file.Path
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(file.Path)
+	}
+	existingIDs, err := e.db.ListSessionIDsByFilePath(
+		lookupPath, string(parser.AgentVibe),
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	currentID := sess.ID
+	currentPrefixedID := e.idPrefix + sess.ID
+	fallbackID := "vibe:" + filepath.Base(filepath.Dir(file.Path))
+	for _, id := range existingIDs {
+		if id != currentID && id != currentPrefixedID {
+			excludedIDs = append(excludedIDs, id)
+		}
+	}
+
+	currentFallbackTrashed := sess.ID == fallbackID && e.isSessionTrashed(fallbackID)
+	if e.isSessionBlocked(fallbackID) ||
+		(sess.ID == fallbackID &&
+			e.db.HasTrashedSessionByFilePath(lookupPath, string(parser.AgentVibe))) {
+		if !currentFallbackTrashed && !slices.Contains(excludedIDs, sess.ID) {
+			excludedIDs = append(excludedIDs, sess.ID)
+		}
+		return processResult{excludedSessionIDs: excludedIDs}
+	}
+
+	// Sessions parsed before meta.json existed (or was parseable) are stored
+	// under the directory-name fallback ID. Keep excluding that legacy row even
+	// if it predates file_path metadata and did not appear in the path lookup.
+	if sess.ID != fallbackID && !slices.Contains(excludedIDs, fallbackID) {
+		excludedIDs = append(excludedIDs, fallbackID)
+	}
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: *sess, Messages: msgs, UsageEvents: usageEvents},
+		},
+		excludedSessionIDs: excludedIDs,
+	}
+}
+
+func (e *Engine) isSessionBlocked(id string) bool {
+	if e.idPrefix != "" && !strings.HasPrefix(id, e.idPrefix) {
+		prefixed := e.idPrefix + id
+		return e.db.IsSessionExcluded(prefixed) || e.db.IsSessionTrashed(prefixed)
+	}
+	if e.db.IsSessionExcluded(id) || e.db.IsSessionTrashed(id) {
+		return true
+	}
+	return false
+}
+
+func (e *Engine) isSessionTrashed(id string) bool {
+	if e.idPrefix != "" && !strings.HasPrefix(id, e.idPrefix) {
+		return e.db.IsSessionTrashed(e.idPrefix + id)
+	}
+	return e.db.IsSessionTrashed(id)
+}
+
+// vibeEffectiveInfo returns size/mtime for a Vibe session that account
+// for the sibling meta.json file: size is the sum of both files, and
+// mtime is the larger of the two. Returns info unchanged when meta.json
+// is absent or unreadable.
+func vibeEffectiveInfo(path string, info os.FileInfo) os.FileInfo {
+	size := info.Size()
+	mtime := info.ModTime().UnixNano()
+	metaPath := filepath.Join(filepath.Dir(path), "meta.json")
+	if metaInfo, err := os.Stat(metaPath); err == nil {
+		size += metaInfo.Size()
+		if metaMtime := metaInfo.ModTime().UnixNano(); metaMtime > mtime {
+			mtime = metaMtime
+		}
+	}
+	return fakeSnapshotInfo{fSize: size, fMtime: mtime}
+}
+
 func (e *Engine) processPositron(
 	file parser.DiscoveredFile, info os.FileInfo,
 ) processResult {
@@ -6740,7 +6926,12 @@ func shouldReplaceFullParseMessages(
 		pw.sess.Agent == parser.AgentVSCopilot ||
 		pw.sess.Agent == parser.AgentAntigravity ||
 		pw.sess.Agent == parser.AgentAntigravityCLI ||
-		pw.sess.Agent == parser.AgentQwenPaw
+		pw.sess.Agent == parser.AgentQwenPaw ||
+		// Vibe pairs later tool-result carrier records back to an
+		// earlier assistant tool call. An incremental append would
+		// only add the new ordinals and leave the existing tool call's
+		// result_content empty, so force a full replace.
+		pw.sess.Agent == parser.AgentVibe
 }
 
 // writeIncremental appends new messages and partially updates
@@ -7666,6 +7857,13 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 		)
 		return mtime
 	}
+	if def.Type == parser.AgentVibe {
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0
+		}
+		return vibeEffectiveInfo(path, info).ModTime().UnixNano()
+	}
 
 	// FindSourceFile may return a virtual path (e.g. Visual Studio
 	// Copilot's <traceFile>#<conversationID>); resolve it to the
@@ -7931,6 +8129,24 @@ func (e *Engine) SyncSingleSessionContext(
 	}
 	if res.skip {
 		return nil
+	}
+
+	// Delete parser-excluded sessions before writing the parsed
+	// results, mirroring collectAndBatch. Vibe promotes a session
+	// from its directory-name fallback ID to the canonical
+	// meta.json ID and returns the stale fallback ID here; without
+	// this delete a single-session resync would leave both rows in
+	// the DB and double-count messages and usage.
+	if excluded := e.applyIDPrefixToSessionIDs(
+		res.excludedSessionIDs,
+	); len(excluded) > 0 {
+		if _, err := e.db.DeleteParserExcludedSessions(
+			excluded,
+		); err != nil {
+			return fmt.Errorf(
+				"delete parser-excluded sessions: %w", err,
+			)
+		}
 	}
 
 	// Handle incremental updates from processFile (e.g.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3636,6 +3636,14 @@ func (e *Engine) processFile(
 	if file.Agent == parser.AgentCowork {
 		mtime = parser.CoworkSessionMtime(file.Path, mtime)
 	}
+	if file.Agent == parser.AgentVibe {
+		// Vibe metadata (title, model, usage, canonical ID) lives in the
+		// sibling meta.json, so the skip-cache key must move when either file
+		// changes. Match vibeEffectiveInfo (max of messages.jsonl and
+		// meta.json) so a fixed meta.json retries a cached parse error instead
+		// of staying skipped on the unchanged transcript mtime.
+		mtime = vibeEffectiveInfo(file.Path, info).ModTime().UnixNano()
+	}
 	cacheSkip := e.shouldCacheSkip(file)
 
 	// Skip files cached from a previous sync (parse errors

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1149,6 +1149,71 @@ func TestProcessAntigravityWALOnlyUpdateNotSkipped(t *testing.T) {
 	assert.False(t, res.skip, "WAL-only update must trigger a reparse")
 }
 
+func TestProcessVibeMetaOnlyUpdateNotSkipped(t *testing.T) {
+	database := openTestDB(t)
+	e := &Engine{db: database}
+	ctx := context.Background()
+
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "session_20260616_083518_0107f266")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	msgPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		msgPath,
+		[]byte(`{"role":"user","content":"hi"}`+"\n"),
+		0o644,
+	))
+
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"abc","title":"Original title"}`+"\n"),
+		0o644,
+	))
+
+	file := parser.DiscoveredFile{
+		Agent: parser.AgentVibe,
+		Path:  msgPath,
+	}
+
+	res := e.processFile(ctx, file)
+	require.NoError(t, res.err)
+	require.False(t, res.skip)
+	require.Len(t, res.results, 1)
+	require.Equal(t, "Original title", res.results[0].Session.SessionName)
+
+	pw := pendingWrite{
+		sess: res.results[0].Session,
+		msgs: res.results[0].Messages,
+	}
+	written, _, failed := e.writeBatch(
+		[]pendingWrite{pw}, syncWriteDefault, false,
+	)
+	require.Equal(t, 0, failed)
+	require.Equal(t, 1, written)
+
+	res = e.processFile(ctx, file)
+	require.True(t, res.skip, "unchanged session should skip")
+
+	// meta.json-only update: messages.jsonl is untouched, but the title
+	// (sourced from meta.json) changes.
+	info, err := os.Stat(msgPath)
+	require.NoError(t, err)
+	metaTime := info.ModTime().Add(5 * time.Second)
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"abc","title":"Renamed title"}`+"\n"),
+		0o644,
+	))
+	require.NoError(t, os.Chtimes(metaPath, metaTime, metaTime))
+
+	res = e.processFile(ctx, file)
+	require.False(t, res.skip, "meta.json-only update must trigger a reparse")
+	require.Len(t, res.results, 1)
+	assert.Equal(t, "Renamed title", res.results[0].Session.SessionName)
+}
+
 func TestProcessAntigravityBrainOnlyUpdateNotSkipped(t *testing.T) {
 	database := openTestDB(t)
 	e := &Engine{db: database}

--- a/internal/sync/vibe_integration_test.go
+++ b/internal/sync/vibe_integration_test.go
@@ -122,6 +122,69 @@ func TestSourceMtimeVibeIncludesMetaMtime(t *testing.T) {
 	assert.Equal(t, metaTime.UnixNano(), engine.SourceMtime("vibe:"+sessionID))
 }
 
+// TestSyncVibeCorruptMetaRetriesAfterMetaFixed verifies that a parse error
+// caused by a corrupt meta.json is not permanently skip-cached against the
+// transcript mtime. The skip-cache key uses the Vibe effective mtime (max of
+// messages.jsonl and meta.json), so fixing meta.json (which advances only its
+// mtime) invalidates the cached skip and the next sync reparses the session.
+func TestSyncVibeCorruptMetaRetriesAfterMetaFixed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	sessionDir := filepath.Join(vibeDir, "session_20260616_083518_abc123")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	))
+	// A truncated/partial write: not even minimally valid JSON, so the parse
+	// fails and the file is skip-cached.
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"session_id":"abc`), 0o644))
+
+	baseTime := time.Unix(1_781_475_210, 0)
+	require.NoError(t, os.Chtimes(messagesPath, baseTime, baseTime))
+	require.NoError(t, os.Chtimes(metaPath, baseTime, baseTime))
+
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	canonicalID := "vibe:" + sessionID
+
+	// First sync fails to parse and caches a skip at the effective mtime.
+	engine.SyncPaths([]string{messagesPath})
+	got, err := testDB.GetSession(context.Background(), canonicalID)
+	require.NoError(t, err)
+	assert.Nil(t, got, "corrupt meta.json must not produce a session")
+
+	// Fix meta.json and advance only its mtime; the transcript mtime is
+	// unchanged, so a skip cache keyed on the transcript alone would wrongly
+	// skip this file forever.
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Recovered"}`+"\n"),
+		0o644,
+	))
+	metaTime := baseTime.Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, metaTime, metaTime))
+
+	engine.SyncPaths([]string{messagesPath})
+	got, err = testDB.GetSession(context.Background(), canonicalID)
+	require.NoError(t, err)
+	require.NotNil(t, got, "fixed meta.json must reparse instead of staying skipped")
+	assert.Equal(t, canonicalID, got.ID)
+}
+
 // TestSyncVibeMetaPromotionRemovesFallbackID verifies that when a session is
 // first synced without meta.json (stored under the directory-name fallback ID)
 // and meta.json later appears, the session is re-stored under the meta

--- a/internal/sync/vibe_integration_test.go
+++ b/internal/sync/vibe_integration_test.go
@@ -1,0 +1,733 @@
+package sync_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// writeVibeSyncFixture writes a Vibe session directory with a messages.jsonl
+// transcript and a sibling meta.json. It returns the two file paths.
+func writeVibeSyncFixture(
+	t *testing.T, root, dirName, sessionID, title string,
+) (messagesPath, metaPath string) {
+	t.Helper()
+
+	sessionDir := filepath.Join(root, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir vibe session dir")
+
+	messagesPath = filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	), "write messages.jsonl")
+
+	metaPath = filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"`+title+`",`+
+			`"model":"mistral-medium-3.5",`+
+			`"stats":{"session_prompt_tokens":100,"session_completion_tokens":50}}`+"\n"),
+		0o644,
+	), "write meta.json")
+	return messagesPath, metaPath
+}
+
+func TestSyncAllSinceVibeMetaUpdateTriggersResync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	messagesPath, metaPath := writeVibeSyncFixture(
+		t, vibeDir, "session_20260616_083518_abc123", sessionID, "Before rename",
+	)
+
+	engine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, "vibe:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Before rename", *sess.DisplayName)
+	})
+
+	// meta.json-only update: the transcript is untouched (and left below the
+	// cutoff), but the title in meta.json changes and its mtime moves ahead.
+	transcriptTime := time.Unix(1_781_475_210, 0)
+	metaTime := transcriptTime.Add(time.Second)
+	require.NoError(t, os.Chtimes(messagesPath, transcriptTime, transcriptTime))
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"After rename",`+
+			`"model":"mistral-medium-3.5",`+
+			`"stats":{"session_prompt_tokens":100,"session_completion_tokens":50}}`+"\n"),
+		0o644,
+	), "rewrite meta.json")
+	require.NoError(t, os.Chtimes(metaPath, metaTime, metaTime))
+
+	cutoff := transcriptTime.Add(500 * time.Millisecond)
+	stats := engine.SyncAllSince(context.Background(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced, "synced = %d, want 1", stats.Synced)
+
+	assertSessionState(t, testDB, "vibe:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "After rename", *sess.DisplayName)
+	})
+}
+
+func TestSourceMtimeVibeIncludesMetaMtime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	messagesPath, metaPath := writeVibeSyncFixture(
+		t, vibeDir, "session_20260616_083518_abc123", sessionID, "Source mtime",
+	)
+
+	transcriptTime := time.Unix(1_781_475_210, 0)
+	metaTime := transcriptTime.Add(time.Second)
+	require.NoError(t, os.Chtimes(messagesPath, transcriptTime, transcriptTime))
+	require.NoError(t, os.Chtimes(metaPath, metaTime, metaTime))
+
+	engine.SyncPaths([]string{messagesPath})
+	assert.Equal(t, metaTime.UnixNano(), engine.SourceMtime("vibe:"+sessionID))
+}
+
+// TestSyncVibeMetaPromotionRemovesFallbackID verifies that when a session is
+// first synced without meta.json (stored under the directory-name fallback ID)
+// and meta.json later appears, the session is re-stored under the meta
+// session_id and the stale fallback row is removed rather than left behind to
+// double-count messages and usage.
+func TestSyncVibeMetaPromotionRemovesFallbackID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir vibe session dir")
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	), "write messages.jsonl")
+
+	// First sync without meta.json: stored under the directory-name fallback.
+	engine.SyncPaths([]string{messagesPath})
+	fallbackID := "vibe:" + dirName
+	assertSessionState(t, testDB, fallbackID, nil)
+
+	// meta.json appears with a distinct session_id (a uuid).
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Promoted"}`+"\n"),
+		0o644,
+	), "write meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	engine.SyncPaths([]string{messagesPath})
+
+	// The promoted ID exists, the stale fallback row is gone.
+	assertSessionState(t, testDB, "vibe:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Promoted", *sess.DisplayName)
+	})
+	gone, err := testDB.GetSession(context.Background(), fallbackID)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "stale fallback session row must be deleted")
+}
+
+// TestSyncSingleSessionVibeMetaPromotionRemovesFallbackID verifies that the
+// single-session resync path (used by manual re-sync and the session watcher)
+// also removes the stale directory-name fallback row when meta.json promotes
+// the session to its canonical ID. Without consuming the parser-excluded IDs on
+// this path, both the fallback and the canonical row would linger and
+// double-count messages and usage.
+func TestSyncSingleSessionVibeMetaPromotionRemovesFallbackID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir vibe session dir")
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	), "write messages.jsonl")
+
+	// First sync without meta.json: stored under the directory-name fallback.
+	engine.SyncPaths([]string{messagesPath})
+	fallbackID := "vibe:" + dirName
+	assertSessionState(t, testDB, fallbackID, nil)
+
+	// meta.json appears with a distinct session_id (a uuid).
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Promoted"}`+"\n"),
+		0o644,
+	), "write meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	// Resync via the single-session path keyed by the fallback ID, as the
+	// session watcher would after the fallback row already exists.
+	require.NoError(t, engine.SyncSingleSession(fallbackID))
+
+	// The promoted ID exists, the stale fallback row is gone.
+	assertSessionState(t, testDB, "vibe:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Promoted", *sess.DisplayName)
+	})
+	gone, err := testDB.GetSession(context.Background(), fallbackID)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "stale fallback session row must be deleted")
+}
+
+func TestSyncVibeMetaPromotionHonorsDeletedFallbackID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir vibe session dir")
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	), "write messages.jsonl")
+
+	fallbackID := "vibe:" + dirName
+	engine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, fallbackID, nil)
+	require.NoError(t, testDB.DeleteSession(fallbackID), "delete fallback")
+	assert.True(t, testDB.IsSessionExcluded(fallbackID),
+		"fallback ID should be permanently excluded")
+
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Promoted"}`+"\n"),
+		0o644,
+	), "write meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	engine.SyncPaths([]string{messagesPath})
+
+	canonical, err := testDB.GetSession(context.Background(), "vibe:"+sessionID)
+	require.NoError(t, err)
+	assert.Nil(t, canonical,
+		"promoted canonical ID must not resurrect deleted fallback session")
+}
+
+func TestSyncVibeMetaPromotionHonorsTrashedFallbackID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir vibe session dir")
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	), "write messages.jsonl")
+
+	fallbackID := "vibe:" + dirName
+	engine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, fallbackID, nil)
+	require.NoError(t, testDB.SoftDeleteSession(fallbackID), "trash fallback")
+	trashed, err := testDB.GetSessionFull(context.Background(), fallbackID)
+	require.NoError(t, err)
+	require.NotNil(t, trashed, "trashed fallback row")
+	require.NotNil(t, trashed.DeletedAt, "fallback should be trashed")
+
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Promoted"}`+"\n"),
+		0o644,
+	), "write meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	engine.SyncPaths([]string{messagesPath})
+
+	canonical, err := testDB.GetSession(context.Background(), "vibe:"+sessionID)
+	require.NoError(t, err)
+	assert.Nil(t, canonical,
+		"promoted canonical ID must not resurrect trashed fallback session")
+}
+
+func TestSyncVibeRemotePromotionIgnoresDeletedLocalFallbackID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	localEngine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+	remoteEngine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine:  "remote-host",
+		IDPrefix: "host~",
+		PathRewriter: func(path string) string {
+			return "host:" + path
+		},
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir vibe session dir")
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	), "write messages.jsonl")
+
+	localFallbackID := "vibe:" + dirName
+	localEngine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, localFallbackID, nil)
+	require.NoError(t, testDB.DeleteSession(localFallbackID), "delete local fallback")
+	assert.True(t, testDB.IsSessionExcluded(localFallbackID),
+		"local fallback ID should be permanently excluded")
+
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Remote"}`+"\n"),
+		0o644,
+	), "write meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	remoteEngine.SyncPaths([]string{messagesPath})
+
+	assertSessionState(t, testDB, "host~vibe:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Remote", *sess.DisplayName)
+	})
+}
+
+func TestSyncVibeRemotePromotionIgnoresTrashedLocalFallbackID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	localEngine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+	remoteEngine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine:  "remote-host",
+		IDPrefix: "host~",
+		PathRewriter: func(path string) string {
+			return "host:" + path
+		},
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir vibe session dir")
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	), "write messages.jsonl")
+
+	localFallbackID := "vibe:" + dirName
+	localEngine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, localFallbackID, nil)
+	require.NoError(t, testDB.SoftDeleteSession(localFallbackID), "trash local fallback")
+	trashed, err := testDB.GetSessionFull(context.Background(), localFallbackID)
+	require.NoError(t, err)
+	require.NotNil(t, trashed, "trashed local fallback row")
+	require.NotNil(t, trashed.DeletedAt, "local fallback should be trashed")
+
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	require.NoError(t, os.WriteFile(
+		metaPath,
+		[]byte(`{"session_id":"`+sessionID+`","title":"Remote"}`+"\n"),
+		0o644,
+	), "write meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	remoteEngine.SyncPaths([]string{messagesPath})
+
+	assertSessionState(t, testDB, "host~vibe:"+sessionID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Remote", *sess.DisplayName)
+	})
+}
+
+func TestSyncVibeMissingMetaHonorsDeletedCanonicalID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	messagesPath, metaPath := writeVibeSyncFixture(
+		t, vibeDir, dirName, sessionID, "Canonical",
+	)
+	canonicalID := "vibe:" + sessionID
+	fallbackID := "vibe:" + dirName
+
+	engine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, canonicalID, nil)
+	require.NoError(t, testDB.DeleteSession(canonicalID), "delete canonical")
+	assert.True(t, testDB.IsSessionExcluded(canonicalID),
+		"canonical ID should be permanently excluded")
+
+	require.NoError(t, os.Remove(metaPath), "remove meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(messagesPath, future, future))
+
+	engine.SyncPaths([]string{messagesPath})
+
+	fallback, err := testDB.GetSession(context.Background(), fallbackID)
+	require.NoError(t, err)
+	assert.Nil(t, fallback,
+		"fallback ID must not resurrect deleted canonical session")
+}
+
+func TestSyncVibeMissingMetaHonorsTrashedCanonicalID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	messagesPath, metaPath := writeVibeSyncFixture(
+		t, vibeDir, dirName, sessionID, "Canonical",
+	)
+	canonicalID := "vibe:" + sessionID
+	fallbackID := "vibe:" + dirName
+
+	engine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, canonicalID, nil)
+	require.NoError(t, testDB.SoftDeleteSession(canonicalID), "trash canonical")
+	trashed, err := testDB.GetSessionFull(context.Background(), canonicalID)
+	require.NoError(t, err)
+	require.NotNil(t, trashed, "trashed canonical row")
+	require.NotNil(t, trashed.DeletedAt, "canonical should be trashed")
+
+	require.NoError(t, os.Remove(metaPath), "remove meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(messagesPath, future, future))
+
+	engine.SyncPaths([]string{messagesPath})
+
+	fallback, err := testDB.GetSession(context.Background(), fallbackID)
+	require.NoError(t, err)
+	assert.Nil(t, fallback,
+		"fallback ID must not resurrect trashed canonical session")
+}
+
+func TestSyncVibeMissingMetaKeepsTrashedFallbackID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionDir := filepath.Join(vibeDir, dirName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755), "mkdir vibe session dir")
+	messagesPath := filepath.Join(sessionDir, "messages.jsonl")
+	require.NoError(t, os.WriteFile(
+		messagesPath,
+		[]byte(`{"role":"user","content":"hello vibe"}`+"\n"),
+		0o644,
+	), "write messages.jsonl")
+	fallbackID := "vibe:" + dirName
+
+	engine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, fallbackID, nil)
+	require.NoError(t, testDB.SoftDeleteSession(fallbackID), "trash fallback")
+
+	for i := range 2 {
+		require.NoError(t, os.WriteFile(
+			messagesPath,
+			[]byte(`{"role":"user","content":"hello vibe `+
+				strconv.Itoa(i)+`"}`+"\n"),
+			0o644,
+		), "rewrite messages.jsonl")
+		future := time.Now().Add(time.Duration(i+1) * time.Hour)
+		require.NoError(t, os.Chtimes(messagesPath, future, future))
+
+		engine.SyncPaths([]string{messagesPath})
+
+		visible, err := testDB.GetSession(context.Background(), fallbackID)
+		require.NoError(t, err)
+		assert.Nil(t, visible, "trashed fallback must stay hidden")
+
+		trashed, err := testDB.GetSessionFull(context.Background(), fallbackID)
+		require.NoError(t, err)
+		require.NotNil(t, trashed, "trashed fallback row")
+		require.NotNil(t, trashed.DeletedAt, "fallback should remain trashed")
+		assert.False(t, testDB.IsSessionExcluded(fallbackID),
+			"parser cleanup must not permanently exclude the trashed fallback")
+	}
+}
+
+func TestSyncVibeMissingMetaRemovesCanonicalID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	messagesPath, metaPath := writeVibeSyncFixture(
+		t, vibeDir, dirName, sessionID, "Canonical",
+	)
+	canonicalID := "vibe:" + sessionID
+	fallbackID := "vibe:" + dirName
+
+	engine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, canonicalID, func(sess *db.Session) {
+		require.NotNil(t, sess.DisplayName)
+		assert.Equal(t, "Canonical", *sess.DisplayName)
+	})
+
+	require.NoError(t, os.Remove(metaPath), "remove meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(messagesPath, future, future))
+
+	engine.SyncPaths([]string{messagesPath})
+
+	assertSessionState(t, testDB, fallbackID, nil)
+	gone, err := testDB.GetSession(context.Background(), canonicalID)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "stale canonical session row must be deleted")
+
+	var rowsForPath int
+	require.NoError(t, testDB.Reader().QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE file_path = ?`,
+		messagesPath,
+	).Scan(&rowsForPath), "count rows for vibe file path")
+	assert.Equal(t, 1, rowsForPath,
+		"vibe file path must not leave duplicate session rows")
+}
+
+func TestSyncPathsVibeDeletedMetaPathRemovesCanonicalID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine: "local",
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	messagesPath, metaPath := writeVibeSyncFixture(
+		t, vibeDir, dirName, sessionID, "Canonical",
+	)
+	canonicalID := "vibe:" + sessionID
+	fallbackID := "vibe:" + dirName
+
+	engine.SyncPaths([]string{messagesPath})
+	assertSessionState(t, testDB, canonicalID, nil)
+
+	require.NoError(t, os.Remove(metaPath), "remove meta.json")
+
+	engine.SyncPaths([]string{metaPath})
+
+	assertSessionState(t, testDB, fallbackID, nil)
+	gone, err := testDB.GetSession(context.Background(), canonicalID)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "deleted meta.json event must remove stale canonical row")
+}
+
+func TestSyncVibeMissingMetaRemotePathRemovesCanonicalID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	vibeDir := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	rewriter := func(path string) string {
+		return "host:" + path
+	}
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVibe: {vibeDir},
+		},
+		Machine:      "remote-host",
+		IDPrefix:     "host~",
+		PathRewriter: rewriter,
+	})
+
+	dirName := "session_20260616_083518_abc123"
+	sessionID := "abc123def-0000-0000-0000-000000000000"
+	messagesPath, metaPath := writeVibeSyncFixture(
+		t, vibeDir, dirName, sessionID, "Canonical",
+	)
+	canonicalID := "host~vibe:" + sessionID
+	fallbackID := "host~vibe:" + dirName
+
+	engine.SyncPaths([]string{messagesPath})
+	canonical, err := testDB.GetSessionFull(context.Background(), canonicalID)
+	require.NoError(t, err)
+	require.NotNil(t, canonical, "canonical remote session")
+	require.NotNil(t, canonical.FilePath)
+	assert.Equal(t, rewriter(messagesPath), *canonical.FilePath)
+
+	require.NoError(t, os.Remove(metaPath), "remove meta.json")
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(messagesPath, future, future))
+
+	engine.SyncPaths([]string{messagesPath})
+
+	assertSessionState(t, testDB, fallbackID, nil)
+	gone, err := testDB.GetSession(context.Background(), canonicalID)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "stale remote canonical session row must be deleted")
+
+	var rowsForPath int
+	require.NoError(t, testDB.Reader().QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE file_path = ?`,
+		rewriter(messagesPath),
+	).Scan(&rowsForPath), "count rows for rewritten vibe file path")
+	assert.Equal(t, 1, rowsForPath,
+		"rewritten vibe file path must not leave duplicate remote rows")
+}


### PR DESCRIPTION
Add support for mistral vibe code session.

- Session discovery implemented
- Proper session naming matching
- Pricing according https://mistral.ai/pricing/#api
- Tests for session discovery and parsing

Screenshots:

<img width="2085" height="1051" alt="Screenshot 2026-06-16 153706" src="https://github.com/user-attachments/assets/34ae82b8-9bad-4511-9f50-9f7db28f5f18" />

<img width="2088" height="766" alt="Screenshot 2026-06-16 154853" src="https://github.com/user-attachments/assets/e0657c60-20aa-4197-bb85-a45d74f830f2" />

Tested it under Linux and Windows.