### PR TITLE
fix(postgres): guard pg push against same-id cross-machine row collision

### DIFF
--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -112,27 +113,60 @@ func runPGPush(cfg PGPushConfig) {
 	fmt.Println("Starting PostgreSQL push...")
 	result, err := ps.Push(ctx, forceFull,
 		func(p postgres.PushProgress) {
-			fmt.Printf(
-				"\rPushing... %d/%d sessions, %d messages",
-				p.SessionsDone, p.SessionsTotal,
-				p.MessagesDone,
-			)
+			printPGPushProgress(p)
 		},
 	)
 	fmt.Print("\r\033[K") // clear progress line
 	if err != nil {
 		fatal("pg push: %v", err)
 	}
+	writePGPushSummary(os.Stdout, result)
+	if result.Errors > 0 {
+		fatal("pg push: %d session(s) failed",
+			result.Errors)
+	}
+}
+
+func printPGPushProgress(p postgres.PushProgress) {
+	if p.SkippedConflicts > 0 {
+		fmt.Printf(
+			"\rPushing... %d/%d sessions, %d messages, %d ownership conflicts skipped",
+			p.SessionsDone, p.SessionsTotal,
+			p.MessagesDone, p.SkippedConflicts,
+		)
+		return
+	}
 	fmt.Printf(
+		"\rPushing... %d/%d sessions, %d messages",
+		p.SessionsDone, p.SessionsTotal,
+		p.MessagesDone,
+	)
+}
+
+func writePGPushSummary(w io.Writer, result postgres.PushResult) {
+	if result.SkippedConflicts > 0 {
+		fmt.Fprintf(
+			w,
+			"Pushed %d sessions, %d messages, skipped %d ownership conflict(s) in %s\n",
+			result.SessionsPushed,
+			result.MessagesPushed,
+			result.SkippedConflicts,
+			result.Duration.Round(time.Millisecond),
+		)
+		fmt.Fprintf(
+			w,
+			"Warning: skipped %d session(s) owned by another PostgreSQL push marker\n",
+			result.SkippedConflicts,
+		)
+		return
+	}
+	fmt.Fprintf(
+		w,
 		"Pushed %d sessions, %d messages in %s\n",
 		result.SessionsPushed,
 		result.MessagesPushed,
 		result.Duration.Round(time.Millisecond),
 	)
-	if result.Errors > 0 {
-		fatal("pg push: %d session(s) failed",
-			result.Errors)
-	}
 }
 
 func runPGStatus() {

--- a/cmd/agentsview/pg_test.go
+++ b/cmd/agentsview/pg_test.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/postgres"
 )
 
 func loadPGServeConfigForTest(t *testing.T, args ...string) (config.Config, string, error) {
@@ -165,4 +168,21 @@ func TestRunPGServeHelperProcess(t *testing.T) {
 	cfg, basePath, err := loadPGServeConfig(cmd)
 	require.NoError(t, err)
 	runPGServe(cfg, basePath)
+}
+
+func TestWritePGPushSummaryIncludesSkippedConflicts(t *testing.T) {
+	var out bytes.Buffer
+
+	writePGPushSummary(&out, postgres.PushResult{
+		SessionsPushed:   3,
+		MessagesPushed:   9,
+		SkippedConflicts: 2,
+		Duration:         1500 * time.Millisecond,
+	})
+
+	got := out.String()
+	assert.Contains(t, got,
+		"Pushed 3 sessions, 9 messages, skipped 2 ownership conflict(s) in 1.5s")
+	assert.Contains(t, got,
+		"Warning: skipped 2 session(s) owned by another PostgreSQL push marker")
 }

--- a/cmd/agentsview/pg_watch.go
+++ b/cmd/agentsview/pg_watch.go
@@ -64,21 +64,42 @@ func (p *pgPusher) push(
 		return fmt.Errorf("push: %w", err)
 	}
 	if res.Errors > 0 {
-		log.Printf(
-			"pg watch: pushed %d sessions, %d messages, %d errors (%s)",
-			res.SessionsPushed, res.MessagesPushed, res.Errors, reason,
-		)
+		logPGWatchPushResult(res, reason)
 		log.Printf(
 			"pg watch: %d session(s) failed to push; will retry",
 			res.Errors,
 		)
 		return nil
 	}
+	logPGWatchPushResult(res, reason)
+	return nil
+}
+
+func logPGWatchPushResult(res postgres.PushResult, reason pushReason) {
+	if res.SkippedConflicts > 0 {
+		log.Printf(
+			"pg watch: pushed %d sessions, %d messages, skipped %d ownership conflict(s), %d errors (%s)",
+			res.SessionsPushed, res.MessagesPushed,
+			res.SkippedConflicts, res.Errors, reason,
+		)
+		log.Printf(
+			"pg watch: %d session(s) skipped due to PostgreSQL ownership conflicts",
+			res.SkippedConflicts,
+		)
+		return
+	}
+	if res.Errors > 0 {
+		log.Printf(
+			"pg watch: pushed %d sessions, %d messages, %d errors (%s)",
+			res.SessionsPushed, res.MessagesPushed,
+			res.Errors, reason,
+		)
+		return
+	}
 	log.Printf(
 		"pg watch: pushed %d sessions, %d messages (%s)",
 		res.SessionsPushed, res.MessagesPushed, reason,
 	)
-	return nil
 }
 
 func (p *pgPusher) reset() {

--- a/cmd/agentsview/pg_watch_test.go
+++ b/cmd/agentsview/pg_watch_test.go
@@ -248,6 +248,35 @@ func TestPgPusher_LogsPartialPushErrors(t *testing.T) {
 	assert.Contains(t, got, "change")
 }
 
+func TestPgPusher_LogsSkippedConflicts(t *testing.T) {
+	target := &fakeTarget{
+		pushResult: postgres.PushResult{
+			SessionsPushed:   3,
+			MessagesPushed:   9,
+			SkippedConflicts: 2,
+		},
+	}
+	var logs bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	p := &pgPusher{
+		localSync: func(context.Context) error { return nil },
+		connect: func() (pgTarget, error) {
+			return target, nil
+		},
+	}
+	require.NoError(t, p.push(context.Background(), reasonChange, false))
+
+	got := logs.String()
+	assert.Contains(t, got,
+		"pushed 3 sessions, 9 messages, skipped 2 ownership conflict(s), 0 errors")
+	assert.Contains(t, got,
+		"2 session(s) skipped due to PostgreSQL ownership conflicts")
+	assert.Contains(t, got, "change")
+}
+
 func TestResolveWatchTargets_ErrorsOnEmptyURL(t *testing.T) {
 	appCfg := config.Config{} // no PG URL
 	_, _, _, err := resolveWatchTargets(appCfg, PGPushConfig{})

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1889,3 +1889,29 @@ func (db *DB) SetSyncState(key, value string) error {
 	)
 	return err
 }
+
+// GetOrCreateSyncState returns a sync-state value, atomically creating it
+// with defaultValue when absent.
+func (db *DB) GetOrCreateSyncState(key, defaultValue string) (string, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	w := db.getWriter()
+	var value string
+	err := w.QueryRow(
+		`INSERT INTO pg_sync_state (key, value)
+		 VALUES (?, ?)
+		 ON CONFLICT(key) DO NOTHING
+		 RETURNING value`,
+		key, defaultValue,
+	).Scan(&value)
+	if err == nil {
+		return value, nil
+	}
+	if err != sql.ErrNoRows {
+		return "", err
+	}
+	err = w.QueryRow(
+		"SELECT value FROM pg_sync_state WHERE key = ?", key,
+	).Scan(&value)
+	return value, err
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4317,6 +4317,45 @@ func TestCopySyncStateFrom_NoSourceTable(t *testing.T) {
 	assert.Equal(t, "marker-123", got)
 }
 
+func TestCopySyncStateFrom_OnlyCopiesDurablePGKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	srcPath := filepath.Join(dir, "src.db")
+	srcDB, err := Open(srcPath)
+	require.NoError(t, err, "Open src")
+	require.NoError(t, srcDB.SetSyncState("pg_push_marker_id", "marker-123"),
+		"seed source marker")
+	require.NoError(t, srcDB.SetSyncState("last_sync_started_at", "old-start"),
+		"seed source started")
+	require.NoError(t, srcDB.SetSyncState("last_sync_finished_at", "old-finish"),
+		"seed source finished")
+	require.NoError(t, srcDB.Close(), "Close src")
+
+	dstPath := filepath.Join(dir, "dst.db")
+	dstDB, err := Open(dstPath)
+	require.NoError(t, err, "Open dst")
+	defer dstDB.Close()
+	require.NoError(t, dstDB.SetSyncState("last_sync_started_at", "new-start"),
+		"seed destination started")
+	require.NoError(t, dstDB.SetSyncState("last_sync_finished_at", "new-finish"),
+		"seed destination finished")
+
+	err = dstDB.CopySyncStateFrom(srcPath)
+	require.NoError(t, err, "CopySyncStateFrom")
+
+	gotMarker, err := dstDB.GetSyncState("pg_push_marker_id")
+	require.NoError(t, err, "GetSyncState pg_push_marker_id")
+	assert.Equal(t, "marker-123", gotMarker)
+
+	gotStarted, err := dstDB.GetSyncState("last_sync_started_at")
+	require.NoError(t, err, "GetSyncState last_sync_started_at")
+	assert.Equal(t, "new-start", gotStarted)
+
+	gotFinished, err := dstDB.GetSyncState("last_sync_finished_at")
+	require.NoError(t, err, "GetSyncState last_sync_finished_at")
+	assert.Equal(t, "new-finish", gotFinished)
+}
+
 func TestCopySyncStateFrom_PropagatesErrors(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4289,6 +4289,58 @@ func TestCopyExcludedSessionsFrom(t *testing.T) {
 		"UpsertSession = %v, want ErrSessionExcluded", err)
 }
 
+func TestCopySyncStateFrom_NoSourceTable(t *testing.T) {
+	dir := t.TempDir()
+
+	// Source DB with no tables (legacy DB shape missing pg_sync_state).
+	srcPath := filepath.Join(dir, "src.db")
+	srcConn, err := sql.Open("sqlite3", srcPath)
+	require.NoError(t, err, "open src")
+	require.NoError(t, srcConn.Close(), "close src")
+
+	dstPath := filepath.Join(dir, "dst.db")
+	dstDB, err := Open(dstPath)
+	require.NoError(t, err, "Open dst")
+	defer dstDB.Close()
+
+	// Seed a marker that should be preserved when source has none.
+	require.NoError(t, dstDB.SetSyncState(
+		"pg_push_marker_id", "marker-123",
+	), "seed destination sync state")
+
+	// Copy should be a no-op for legacy source and return nil.
+	err = dstDB.CopySyncStateFrom(srcPath)
+	require.NoError(t, err, "CopySyncStateFrom")
+
+	got, err := dstDB.GetSyncState("pg_push_marker_id")
+	require.NoError(t, err, "GetSyncState")
+	assert.Equal(t, "marker-123", got)
+}
+
+func TestCopySyncStateFrom_PropagatesErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	// Source is not a valid SQLite database, so probing state fails.
+	srcPath := filepath.Join(dir, "src.db")
+	require.NoError(t, os.WriteFile(srcPath, []byte("not sqlite"), 0o600),
+		"write invalid source")
+
+	dstPath := filepath.Join(dir, "dst.db")
+	dstDB, err := Open(dstPath)
+	require.NoError(t, err, "Open dst")
+	defer dstDB.Close()
+	require.NoError(t, dstDB.SetSyncState("pg_push_marker_id", "safe"),
+		"seed destination sync state")
+
+	err = dstDB.CopySyncStateFrom(srcPath)
+	require.Error(t, err, "CopySyncStateFrom")
+	require.ErrorContains(t, err, "attaching source db")
+
+	got, err := dstDB.GetSyncState("pg_push_marker_id")
+	require.NoError(t, err, "GetSyncState")
+	assert.Equal(t, "safe", got)
+}
+
 func TestCopySessionMetadataFrom(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -299,6 +299,38 @@ func (d *DB) CopyTrashedDataFrom(sourcePath string) (int, error) {
 	return count, nil
 }
 
+// CopySyncStateFrom copies pg_sync_state rows from the source database into the
+// current database. ResyncAll uses this to preserve durable local sync metadata
+// such as the PG push owner marker across the temp-DB swap.
+func (d *DB) CopySyncStateFrom(sourcePath string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	ctx := context.Background()
+	conn, err := d.getWriter().Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring connection: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(
+		ctx, "ATTACH DATABASE ? AS old_db", sourcePath,
+	); err != nil {
+		return fmt.Errorf("attaching source db: %w", err)
+	}
+	defer func() {
+		_, _ = execWithoutCancel(ctx, conn, "DETACH DATABASE old_db")
+	}()
+
+	_, err = conn.ExecContext(ctx, `
+		INSERT OR REPLACE INTO main.pg_sync_state (key, value)
+		SELECT key, value FROM old_db.pg_sync_state`)
+	if err != nil {
+		return fmt.Errorf("copying sync state: %w", err)
+	}
+	return nil
+}
+
 // CopyExcludedSessionsFrom copies the excluded_sessions table
 // from the source DB so permanently deleted sessions survive
 // full DB rebuilds. The source must not have active connections.

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -339,7 +339,8 @@ func (d *DB) CopySyncStateFrom(sourcePath string) error {
 
 	_, err = conn.ExecContext(ctx, `
 		INSERT OR REPLACE INTO main.pg_sync_state (key, value)
-		SELECT key, value FROM old_db.pg_sync_state`)
+		SELECT key, value FROM old_db.pg_sync_state
+		WHERE key = 'pg_push_marker_id'`)
 	if err != nil {
 		return fmt.Errorf("copying sync state: %w", err)
 	}

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -322,6 +322,21 @@ func (d *DB) CopySyncStateFrom(sourcePath string) error {
 		_, _ = execWithoutCancel(ctx, conn, "DETACH DATABASE old_db")
 	}()
 
+	// Older databases may have no pg_sync_state table.
+	var tableExists int
+	err = conn.QueryRowContext(
+		ctx, "SELECT 1 FROM old_db.sqlite_master WHERE type='table' AND name='pg_sync_state'",
+	).Scan(&tableExists)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("probing pg_sync_state table: %w", err)
+	}
+	if tableExists != 1 {
+		return nil
+	}
+
 	_, err = conn.ExecContext(ctx, `
 		INSERT OR REPLACE INTO main.pg_sync_state (key, value)
 		SELECT key, value FROM old_db.pg_sync_state`)

--- a/internal/postgres/collision_pgtest_test.go
+++ b/internal/postgres/collision_pgtest_test.go
@@ -84,7 +84,7 @@ func TestPushSessionGuardsAgainstCrossMachineCollision(t *testing.T) {
 	// Execute pushSession.
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	err = sync.pushSession(ctx, tx, sess, markerID)
+	err = sync.pushSession(ctx, tx, sess, markerID, "")
 	require.ErrorIs(t, err, errSessionOwnershipConflict, "pushSession should return ownership conflict sentinel")
 	require.NoError(t, tx.Commit(), "Commit")
 
@@ -156,7 +156,7 @@ func TestPushSessionAllowsMachineRenameForSameOwnerMarker(t *testing.T) {
 
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID), "pushSession")
+	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID, ""), "pushSession")
 	require.NoError(t, tx.Commit(), "Commit")
 
 	var machine, ownerMarker string
@@ -215,7 +215,7 @@ func TestPushSessionAdoptsLegacyLocalSentinelRow(t *testing.T) {
 	require.NoError(t, err, "BeginTx")
 	markerID, err := sync.pushMarkerID()
 	require.NoError(t, err, "pushMarkerID")
-	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID), "pushSession")
+	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID, ""), "pushSession")
 	require.NoError(t, tx.Commit(), "Commit")
 
 	var machine, ownerMarker string

--- a/internal/postgres/collision_pgtest_test.go
+++ b/internal/postgres/collision_pgtest_test.go
@@ -53,11 +53,14 @@ func TestPushSessionGuardsAgainstCrossMachineCollision(t *testing.T) {
 	const clashID = "clash-001"
 
 	// Step 1: Insert a session owned by machine-a directly into PG.
+	markerID, err := sync.pushMarkerID()
+	require.NoError(t, err, "pushMarkerID")
+
 	_, err = pg.ExecContext(ctx, `
 		INSERT INTO sessions (
-			id, machine, project, agent, created_at
-		) VALUES ($1, $2, $3, $4, NOW())
-	`, clashID, "machine-a", "test-proj", "claude")
+			id, machine, owner_marker, project, agent, created_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
+	`, clashID, "machine-a", "different-owner", "test-proj", "claude")
 	require.NoError(t, err, "insert existing session")
 
 	// Step 2: Attempt to push the same session from machine-b.
@@ -102,4 +105,65 @@ func TestPushSessionGuardsAgainstCrossMachineCollision(t *testing.T) {
 	require.NoError(t, err, "count messages")
 	assert.Equal(t, 0, messageCount,
 		"no messages should be written when session is skipped due to collision")
+
+	assert.NotEqual(t, markerID, "different-owner", "precondition: foreign owner marker differs from local marker")
+}
+
+func TestPushSessionAllowsMachineRenameForSameOwnerMarker(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_collision_owner_marker_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "renamed-host",
+		schema:     schema,
+		schemaDone: true,
+	}
+	markerID, err := sync.pushMarkerID()
+	require.NoError(t, err, "pushMarkerID")
+
+	const sessID = "rename-001"
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, owner_marker, project, agent, created_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
+	`, sessID, "old-host", markerID, "test-proj", "claude")
+	require.NoError(t, err, "insert existing session")
+
+	sess := db.Session{
+		ID:           sessID,
+		Project:      "test-proj",
+		Machine:      "local",
+		Agent:        "claude",
+		MessageCount: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+
+	tx, err := pg.BeginTx(ctx, nil)
+	require.NoError(t, err, "BeginTx")
+	require.NoError(t, sync.pushSession(ctx, tx, sess), "pushSession")
+	require.NoError(t, tx.Commit(), "Commit")
+
+	var machine, ownerMarker string
+	err = pg.QueryRowContext(ctx,
+		`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sessID,
+	).Scan(&machine, &ownerMarker)
+	require.NoError(t, err, "read back session")
+	assert.Equal(t, "renamed-host", machine)
+	assert.Equal(t, markerID, ownerMarker)
 }

--- a/internal/postgres/collision_pgtest_test.go
+++ b/internal/postgres/collision_pgtest_test.go
@@ -84,7 +84,7 @@ func TestPushSessionGuardsAgainstCrossMachineCollision(t *testing.T) {
 	// Execute pushSession.
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	err = sync.pushSession(ctx, tx, sess)
+	err = sync.pushSession(ctx, tx, sess, markerID)
 	require.ErrorIs(t, err, errSessionOwnershipConflict, "pushSession should return ownership conflict sentinel")
 	require.NoError(t, tx.Commit(), "Commit")
 
@@ -156,7 +156,7 @@ func TestPushSessionAllowsMachineRenameForSameOwnerMarker(t *testing.T) {
 
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	require.NoError(t, sync.pushSession(ctx, tx, sess), "pushSession")
+	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID), "pushSession")
 	require.NoError(t, tx.Commit(), "Commit")
 
 	var machine, ownerMarker string
@@ -213,11 +213,10 @@ func TestPushSessionAdoptsLegacyLocalSentinelRow(t *testing.T) {
 
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	require.NoError(t, sync.pushSession(ctx, tx, sess), "pushSession")
-	require.NoError(t, tx.Commit(), "Commit")
-
 	markerID, err := sync.pushMarkerID()
 	require.NoError(t, err, "pushMarkerID")
+	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID), "pushSession")
+	require.NoError(t, tx.Commit(), "Commit")
 
 	var machine, ownerMarker string
 	err = pg.QueryRowContext(ctx,

--- a/internal/postgres/collision_pgtest_test.go
+++ b/internal/postgres/collision_pgtest_test.go
@@ -167,3 +167,63 @@ func TestPushSessionAllowsMachineRenameForSameOwnerMarker(t *testing.T) {
 	assert.Equal(t, "renamed-host", machine)
 	assert.Equal(t, markerID, ownerMarker)
 }
+
+func TestPushSessionAdoptsLegacyLocalSentinelRow(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_collision_legacy_local_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "host-a",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessID = "legacy-local-001"
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, owner_marker, project, agent, created_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
+	`, sessID, "local", "", "test-proj", "claude")
+	require.NoError(t, err, "insert legacy local sentinel row")
+
+	sess := db.Session{
+		ID:           sessID,
+		Project:      "test-proj",
+		Machine:      "local",
+		Agent:        "claude",
+		MessageCount: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+
+	tx, err := pg.BeginTx(ctx, nil)
+	require.NoError(t, err, "BeginTx")
+	require.NoError(t, sync.pushSession(ctx, tx, sess), "pushSession")
+	require.NoError(t, tx.Commit(), "Commit")
+
+	markerID, err := sync.pushMarkerID()
+	require.NoError(t, err, "pushMarkerID")
+
+	var machine, ownerMarker string
+	err = pg.QueryRowContext(ctx,
+		`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sessID,
+	).Scan(&machine, &ownerMarker)
+	require.NoError(t, err, "read back session")
+	assert.Equal(t, "host-a", machine)
+	assert.Equal(t, markerID, ownerMarker)
+}

--- a/internal/postgres/collision_pgtest_test.go
+++ b/internal/postgres/collision_pgtest_test.go
@@ -1,0 +1,105 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// TestPushSessionGuardsAgainstCrossMachineCollision verifies that when two
+// machines share the same session ID (from dotfile sync, directory restore, etc.),
+// the second machine's push is skipped if the session is already owned by a
+// different machine. This prevents the ping-pong effect where two pushers
+// fight over the same row on every push cycle.
+//
+// Steps:
+//  1. Insert a session with id="clash-001" and machine="machine-a" directly into PG.
+//  2. Call pushSession with machine="machine-b" and a db.Session{ID: "clash-001", Machine: "machine-b", ...}.
+//  3. Assert that the row's machine column is still "machine-a" (not overwritten).
+//  4. Assert that no messages were written for the conflicting session.
+func TestPushSessionGuardsAgainstCrossMachineCollision(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_collision_guard_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	// Local SQLite DB.
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "machine-b",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const clashID = "clash-001"
+
+	// Step 1: Insert a session owned by machine-a directly into PG.
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, created_at
+		) VALUES ($1, $2, $3, $4, NOW())
+	`, clashID, "machine-a", "test-proj", "claude")
+	require.NoError(t, err, "insert existing session")
+
+	// Step 2: Attempt to push the same session from machine-b.
+	sess := db.Session{
+		ID:           clashID,
+		Project:      "test-proj",
+		Machine:      "machine-b",
+		Agent:        "claude",
+		MessageCount: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     clashID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "test",
+		ContentLength: 4,
+	}}), "InsertMessages")
+
+	// Execute pushSession.
+	tx, err := pg.BeginTx(ctx, nil)
+	require.NoError(t, err, "BeginTx")
+	err = sync.pushSession(ctx, tx, sess)
+	require.ErrorIs(t, err, errSessionOwnershipConflict, "pushSession should return ownership conflict sentinel")
+	require.NoError(t, tx.Commit(), "Commit")
+
+	// Step 3: Verify the machine column is still "machine-a".
+	var existingMachine string
+	err = pg.QueryRowContext(ctx,
+		`SELECT machine FROM sessions WHERE id = $1`, clashID,
+	).Scan(&existingMachine)
+	require.NoError(t, err, "read back machine")
+	assert.Equal(t, "machine-a", existingMachine,
+		"machine should remain as 'machine-a', not overwritten by 'machine-b'")
+
+	// Step 4: Verify no messages were written for this session.
+	var messageCount int
+	err = pg.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM messages WHERE session_id = $1`, clashID,
+	).Scan(&messageCount)
+	require.NoError(t, err, "count messages")
+	assert.Equal(t, 0, messageCount,
+		"no messages should be written when session is skipped due to collision")
+}

--- a/internal/postgres/collision_pgtest_test.go
+++ b/internal/postgres/collision_pgtest_test.go
@@ -84,7 +84,7 @@ func TestPushSessionGuardsAgainstCrossMachineCollision(t *testing.T) {
 	// Execute pushSession.
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	err = sync.pushSession(ctx, tx, sess, markerID, "")
+	err = sync.pushSession(ctx, tx, sess, markerID, nil)
 	require.ErrorIs(t, err, errSessionOwnershipConflict, "pushSession should return ownership conflict sentinel")
 	require.NoError(t, tx.Commit(), "Commit")
 
@@ -156,7 +156,7 @@ func TestPushSessionAllowsMachineRenameForSameOwnerMarker(t *testing.T) {
 
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID, ""), "pushSession")
+	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID, nil), "pushSession")
 	require.NoError(t, tx.Commit(), "Commit")
 
 	var machine, ownerMarker string
@@ -215,7 +215,7 @@ func TestPushSessionAdoptsLegacyLocalSentinelRow(t *testing.T) {
 	require.NoError(t, err, "BeginTx")
 	markerID, err := sync.pushMarkerID()
 	require.NoError(t, err, "pushMarkerID")
-	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID, ""), "pushSession")
+	require.NoError(t, sync.pushSession(ctx, tx, sess, markerID, nil), "pushSession")
 	require.NoError(t, tx.Commit(), "Commit")
 
 	var machine, ownerMarker string

--- a/internal/postgres/name_source_pgtest_test.go
+++ b/internal/postgres/name_source_pgtest_test.go
@@ -56,10 +56,13 @@ func TestPushSessionNameRoundTrip(t *testing.T) {
 		SessionName:      &sessionName,
 	}
 
+	markerID, err := sync.pushMarkerID()
+	require.NoError(t, err, "pushMarkerID")
+
 	// Push via pushSession directly.
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	if err := sync.pushSession(ctx, tx, sess); err != nil {
+	if err := sync.pushSession(ctx, tx, sess, markerID); err != nil {
 		_ = tx.Rollback()
 		t.Fatalf("pushSession: %v", err)
 	}
@@ -102,7 +105,7 @@ func TestPushSessionNameRoundTrip(t *testing.T) {
 
 	tx2, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx (second)")
-	if err := sync.pushSession(ctx, tx2, sess); err != nil {
+	if err := sync.pushSession(ctx, tx2, sess, markerID); err != nil {
 		_ = tx2.Rollback()
 		t.Fatalf("pushSession (second): %v", err)
 	}

--- a/internal/postgres/name_source_pgtest_test.go
+++ b/internal/postgres/name_source_pgtest_test.go
@@ -62,7 +62,7 @@ func TestPushSessionNameRoundTrip(t *testing.T) {
 	// Push via pushSession directly.
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	if err := sync.pushSession(ctx, tx, sess, markerID, ""); err != nil {
+	if err := sync.pushSession(ctx, tx, sess, markerID, nil); err != nil {
 		_ = tx.Rollback()
 		t.Fatalf("pushSession: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestPushSessionNameRoundTrip(t *testing.T) {
 
 	tx2, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx (second)")
-	if err := sync.pushSession(ctx, tx2, sess, markerID, ""); err != nil {
+	if err := sync.pushSession(ctx, tx2, sess, markerID, nil); err != nil {
 		_ = tx2.Rollback()
 		t.Fatalf("pushSession (second): %v", err)
 	}

--- a/internal/postgres/name_source_pgtest_test.go
+++ b/internal/postgres/name_source_pgtest_test.go
@@ -62,7 +62,7 @@ func TestPushSessionNameRoundTrip(t *testing.T) {
 	// Push via pushSession directly.
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	if err := sync.pushSession(ctx, tx, sess, markerID); err != nil {
+	if err := sync.pushSession(ctx, tx, sess, markerID, ""); err != nil {
 		_ = tx.Rollback()
 		t.Fatalf("pushSession: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestPushSessionNameRoundTrip(t *testing.T) {
 
 	tx2, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx (second)")
-	if err := sync.pushSession(ctx, tx2, sess, markerID); err != nil {
+	if err := sync.pushSession(ctx, tx2, sess, markerID, ""); err != nil {
 		_ = tx2.Rollback()
 		t.Fatalf("pushSession (second): %v", err)
 	}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"maps"
@@ -26,6 +27,8 @@ const (
 	pushMarkerIDStateKey = "pg_push_marker_id"
 	pushMarkerKeyPrefix  = "push_marker:"
 )
+
+var errSessionOwnershipConflict = errors.New("session ownership conflict")
 
 // syncStateStore abstracts sync state read/write operations on the
 // local database. Used by push boundary state helpers.
@@ -459,6 +462,9 @@ func (s *Sync) pushBatch(
 		if err := s.pushSession(
 			ctx, tx, sess,
 		); err != nil {
+			if errors.Is(err, errSessionOwnershipConflict) {
+				continue
+			}
 			log.Printf(
 				"pgsync: session %s: %v",
 				sess.ID, err,
@@ -848,6 +854,29 @@ func (s *Sync) pushSession(
 ) error {
 	createdAt, _ := ParseSQLiteTimestamp(sess.CreatedAt)
 	isAutomated := sess.IsAutomated
+	// Guard against cross-machine PK collision: if this session already exists
+	// under a different machine name, skip the upsert and warn. Two machines
+	// pushing the same session ID would otherwise ping-pong the row and its
+	// messages on every push cycle.
+	var existingMachine sql.NullString
+	checkErr := tx.QueryRowContext(ctx,
+		`SELECT machine FROM sessions WHERE id = $1`, sess.ID,
+	).Scan(&existingMachine)
+	if checkErr != nil && !errors.Is(checkErr, sql.ErrNoRows) {
+		return fmt.Errorf("checking session ownership %s: %w", sess.ID, checkErr)
+	}
+	pushedMachine := pushedSessionMachine(sess, s.machine)
+	if existingMachine.Valid &&
+		existingMachine.String != "" &&
+		existingMachine.String != pushedMachine &&
+		sess.Machine != "" && sess.Machine != "local" {
+		log.Printf(
+			"pgsync: session %s: skipping — already owned by machine %q, "+
+				"this pusher is %q; sync from the origin machine to update",
+			sess.ID, existingMachine.String, pushedMachine,
+		)
+		return errSessionOwnershipConflict
+	}
 	_, err := tx.ExecContext(ctx, `
 		INSERT INTO sessions (
 			id, machine, project, agent,

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -85,6 +85,10 @@ func (s *Sync) Push(
 	if err != nil {
 		return result, err
 	}
+	previousMarkerMachine, markerExists, err := s.pgPushMarkerMachine(ctx, markerID)
+	if err != nil {
+		return result, err
+	}
 	if full {
 		lastPush = ""
 		// Caller requested a full push — the PG schema
@@ -113,10 +117,6 @@ func (s *Sync) Push(
 	// was reset (schema dropped, DB recreated, etc.). Force a full
 	// push so all sessions are re-synced.
 	if lastPush != "" {
-		markerExists, cErr := s.pgPushMarkerExists(ctx, markerID)
-		if cErr != nil {
-			return result, cErr
-		}
 		if !markerExists {
 			log.Printf(
 				"pgsync: local watermark set but PG push marker " +
@@ -124,6 +124,7 @@ func (s *Sync) Push(
 			)
 			lastPush = ""
 			full = true
+			previousMarkerMachine = ""
 			s.schemaMu.Lock()
 			s.schemaDone = false
 			s.schemaMu.Unlock()
@@ -278,7 +279,7 @@ func (s *Sync) Push(
 		batch := sessions[i:end]
 
 		batchResult, err := s.pushBatch(
-			ctx, batch, full, markerID, &pushed,
+			ctx, batch, full, markerID, previousMarkerMachine, &pushed,
 		)
 		if err != nil {
 			return result, err
@@ -293,7 +294,7 @@ func (s *Sync) Push(
 			for _, sess := range batch {
 				sr, retryErr := s.pushBatch(
 					ctx, []db.Session{sess},
-					full, markerID, &pushed,
+					full, markerID, previousMarkerMachine, &pushed,
 				)
 				if retryErr != nil {
 					return result, retryErr
@@ -369,7 +370,8 @@ func (s *Sync) Push(
 	return result, nil
 }
 
-// pgPushMarkerExists reports whether this host's push marker is present in PG.
+// pgPushMarkerMachine reports whether this host's push marker is present in PG
+// and returns the machine value stored with the marker.
 // A missing marker while the local watermark is set means PG was reset (schema
 // dropped or recreated) since this host last pushed, so a full re-push is
 // needed. Counting rows by machine cannot detect this reliably: another host
@@ -377,21 +379,24 @@ func (s *Sync) Push(
 // also writes -- a remote host's sessions synced in over SSH, or this host's
 // own renamed identity -- masking the loss of this host's own rows. The marker
 // is per-local-DB, so no other pusher can satisfy this check.
-func (s *Sync) pgPushMarkerExists(ctx context.Context, markerID string) (bool, error) {
-	var exists bool
+func (s *Sync) pgPushMarkerMachine(ctx context.Context, markerID string) (string, bool, error) {
+	var machine string
 	err := s.pg.QueryRowContext(ctx,
-		`SELECT EXISTS (SELECT 1 FROM sync_metadata WHERE key = $1)`,
+		`SELECT value FROM sync_metadata WHERE key = $1`,
 		pushMarkerKeyPrefix+markerID,
-	).Scan(&exists)
+	).Scan(&machine)
 	if err != nil {
-		if isUndefinedTable(err) {
-			return false, nil
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, nil
 		}
-		return false, fmt.Errorf(
+		if isUndefinedTable(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf(
 			"checking pg push marker: %w", err,
 		)
 	}
-	return exists, nil
+	return machine, true, nil
 }
 
 // writePushMarker records this host's push marker in PG so a later push can
@@ -452,6 +457,7 @@ func (s *Sync) pushBatch(
 	batch []db.Session,
 	full bool,
 	markerID string,
+	previousMarkerMachine string,
 	pushed *[]db.Session,
 ) (batchResult, error) {
 	tx, err := s.pg.BeginTx(ctx, nil)
@@ -466,7 +472,7 @@ func (s *Sync) pushBatch(
 	skippedConflicts := 0
 	for _, sess := range batch {
 		if err := s.pushSession(
-			ctx, tx, sess, markerID,
+			ctx, tx, sess, markerID, previousMarkerMachine,
 		); err != nil {
 			if errors.Is(err, errSessionOwnershipConflict) {
 				skippedConflicts++
@@ -798,7 +804,10 @@ func pushedSessionMachine(sess db.Session, fallbackMachine string) string {
 	return fallbackMachine
 }
 
-func sameSessionOwner(existingOwnerMarker, existingMachine, markerID, pushedMachine string) bool {
+func sameSessionOwner(
+	existingOwnerMarker, existingMachine, markerID, pushedMachine,
+	previousMarkerMachine string,
+) bool {
 	if existingOwnerMarker != "" {
 		return existingOwnerMarker == markerID
 	}
@@ -806,6 +815,9 @@ func sameSessionOwner(existingOwnerMarker, existingMachine, markerID, pushedMach
 		return true
 	}
 	if existingMachine == "local" {
+		return true
+	}
+	if previousMarkerMachine != "" && existingMachine == previousMarkerMachine {
 		return true
 	}
 	return existingMachine == pushedMachine
@@ -872,7 +884,7 @@ func nilStrTS(s *string) any {
 // local-only and used solely by the sync engine to detect
 // re-parsed sessions.
 func (s *Sync) pushSession(
-	ctx context.Context, tx *sql.Tx, sess db.Session, markerID string,
+	ctx context.Context, tx *sql.Tx, sess db.Session, markerID, previousMarkerMachine string,
 ) error {
 	createdAt, _ := ParseSQLiteTimestamp(sess.CreatedAt)
 	isAutomated := sess.IsAutomated
@@ -890,6 +902,7 @@ func (s *Sync) pushSession(
 		existingMachine.String,
 		markerID,
 		pushedMachine,
+		previousMarkerMachine,
 	) {
 		log.Printf(
 			"pgsync: session %s: skipping — already owned by machine %q, "+
@@ -989,7 +1002,9 @@ func (s *Sync) pushSession(
 		WHERE ((
 				sessions.owner_marker = ''
 				AND (sessions.machine = EXCLUDED.machine
-					OR sessions.machine = 'local')
+					OR sessions.machine = 'local'
+					OR sessions.machine = ''
+					OR sessions.machine = $48)
 			)
 			OR sessions.owner_marker = EXCLUDED.owner_marker)
 			AND (
@@ -1070,6 +1085,7 @@ func (s *Sync) pushSession(
 		sess.HealthScore, nilStr(sess.HealthGrade),
 		sess.HasToolCalls, sess.HasContextData,
 		sess.SecretLeakCount, sess.SecretsRulesVersion,
+		previousMarkerMachine,
 	)
 	if err != nil {
 		return err
@@ -1084,7 +1100,10 @@ func (s *Sync) pushSession(
 			currentOwnerMarker = existingOwnerMarker.String
 			currentMachine = existingMachine.String
 		}
-		if refreshErr == nil && !sameSessionOwner(currentOwnerMarker, currentMachine, markerID, pushedMachine) {
+		if refreshErr == nil && !sameSessionOwner(
+			currentOwnerMarker, currentMachine, markerID, pushedMachine,
+			previousMarkerMachine,
+		) {
 			log.Printf(
 				"pgsync: session %s: skipping — already owned by machine %q, this pusher is %q; sync from the origin machine to update",
 				sess.ID, currentMachine, pushedMachine,

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -210,10 +210,14 @@ func (s *Sync) Push(
 			"computing local usage event fingerprints: %w", err,
 		)
 	}
+	markerID, err := s.pushMarkerID()
+	if err != nil {
+		return result, err
+	}
 	for id, sess := range sessionByID {
 		sessionFingerprints[id] = sessionPushFingerprint(
 			sess, pushedSessionMachine(sess, s.machine),
-			usageFingerprints[id],
+			usageFingerprints[id], markerID,
 		)
 	}
 
@@ -726,12 +730,14 @@ func localSessionSyncMarker(sess db.Session) string {
 // row is written under the fallback machine, so the fingerprint must track the
 // fallback to force a re-push when s.machine changes.
 func sessionPushFingerprint(
-	sess db.Session, pushedMachine, usageEventFingerprint string,
+	sess db.Session, pushedMachine,
+	usageEventFingerprint, ownerMarker string,
 ) string {
 	fields := []string{
 		sess.ID,
 		sess.Project,
 		pushedMachine,
+		ownerMarker,
 		sess.Agent,
 		stringValue(sess.FirstMessage),
 		stringValue(sess.DisplayName),
@@ -991,7 +997,8 @@ func (s *Sync) pushSession(
 			updated_at = NOW()
 		WHERE ((
 				sessions.owner_marker = ''
-				AND sessions.machine = EXCLUDED.machine
+				AND (sessions.machine = EXCLUDED.machine
+					OR sessions.machine = 'local')
 			)
 			OR sessions.owner_marker = EXCLUDED.owner_marker)
 			AND (

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -804,6 +804,9 @@ func sameSessionOwner(existingOwnerMarker, existingMachine, markerID, pushedMach
 	if existingMachine == "" {
 		return true
 	}
+	if existingMachine == "local" {
+		return true
+	}
 	return existingMachine == pushedMachine
 }
 
@@ -1074,23 +1077,21 @@ func (s *Sync) pushSession(
 		return err
 	}
 	if rowsAffected, rowsErr := result.RowsAffected(); rowsErr == nil && rowsAffected == 0 {
-		if checkErr == nil {
-			currentOwnerMarker := existingOwnerMarker.String
-			currentMachine := existingMachine.String
-			refreshErr := tx.QueryRowContext(ctx,
-				`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sess.ID,
-			).Scan(&existingMachine, &existingOwnerMarker)
-			if refreshErr == nil {
-				currentOwnerMarker = existingOwnerMarker.String
-				currentMachine = existingMachine.String
-			}
-			if !sameSessionOwner(currentOwnerMarker, currentMachine, markerID, pushedMachine) {
-				log.Printf(
-					"pgsync: session %s: skipping — already owned by machine %q, this pusher is %q; sync from the origin machine to update",
-					sess.ID, currentMachine, pushedMachine,
-				)
-				return errSessionOwnershipConflict
-			}
+		currentOwnerMarker := existingOwnerMarker.String
+		currentMachine := existingMachine.String
+		refreshErr := tx.QueryRowContext(ctx,
+			`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sess.ID,
+		).Scan(&existingMachine, &existingOwnerMarker)
+		if refreshErr == nil {
+			currentOwnerMarker = existingOwnerMarker.String
+			currentMachine = existingMachine.String
+		}
+		if refreshErr == nil && !sameSessionOwner(currentOwnerMarker, currentMachine, markerID, pushedMachine) {
+			log.Printf(
+				"pgsync: session %s: skipping — already owned by machine %q, this pusher is %q; sync from the origin machine to update",
+				sess.ID, currentMachine, pushedMachine,
+			)
+			return errSessionOwnershipConflict
 		}
 	}
 	return nil

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -24,8 +25,9 @@ const lastPushBoundaryStateKey = "last_push_boundary_state"
 // stable push-marker identifier. pushMarkerKeyPrefix prefixes that identifier
 // to form the PG sync_metadata key under which the marker row is stored.
 const (
-	pushMarkerIDStateKey = "pg_push_marker_id"
-	pushMarkerKeyPrefix  = "push_marker:"
+	pushMarkerIDStateKey              = "pg_push_marker_id"
+	pushMarkerKeyPrefix               = "push_marker:"
+	pushMarkerMachineAliasesKeyPrefix = "push_marker_machine_aliases:"
 )
 
 var errSessionOwnershipConflict = errors.New("session ownership conflict")
@@ -85,10 +87,13 @@ func (s *Sync) Push(
 	if err != nil {
 		return result, err
 	}
-	previousMarkerMachine, markerExists, err := s.pgPushMarkerMachine(ctx, markerID)
+	markerMachine, markerMachineAliases, markerExists, err := s.pgPushMarkerMachineState(ctx, markerID)
 	if err != nil {
 		return result, err
 	}
+	legacyMarkerMachines := pushMarkerLegacyMachines(
+		markerMachine, markerMachineAliases,
+	)
 	if full {
 		lastPush = ""
 		// Caller requested a full push — the PG schema
@@ -124,7 +129,7 @@ func (s *Sync) Push(
 			)
 			lastPush = ""
 			full = true
-			previousMarkerMachine = ""
+			legacyMarkerMachines = nil
 			s.schemaMu.Lock()
 			s.schemaDone = false
 			s.schemaMu.Unlock()
@@ -265,7 +270,9 @@ func (s *Sync) Push(
 				return result, err
 			}
 		}
-		if err := s.writePushMarker(ctx, markerID); err != nil {
+		if err := s.writePushMarker(
+			ctx, markerID, markerMachine, markerMachineAliases,
+		); err != nil {
 			return result, err
 		}
 		result.Duration = time.Since(start)
@@ -279,7 +286,7 @@ func (s *Sync) Push(
 		batch := sessions[i:end]
 
 		batchResult, err := s.pushBatch(
-			ctx, batch, full, markerID, previousMarkerMachine, &pushed,
+			ctx, batch, full, markerID, legacyMarkerMachines, &pushed,
 		)
 		if err != nil {
 			return result, err
@@ -294,7 +301,7 @@ func (s *Sync) Push(
 			for _, sess := range batch {
 				sr, retryErr := s.pushBatch(
 					ctx, []db.Session{sess},
-					full, markerID, previousMarkerMachine, &pushed,
+					full, markerID, legacyMarkerMachines, &pushed,
 				)
 				if retryErr != nil {
 					return result, retryErr
@@ -363,15 +370,18 @@ func (s *Sync) Push(
 	// succeed. A reset-recovery push that fails before this point leaves
 	// the marker absent, so the next push re-detects the reset and retries
 	// rather than skipping the still-missing sessions.
-	if err := s.writePushMarker(ctx, markerID); err != nil {
+	if err := s.writePushMarker(
+		ctx, markerID, markerMachine, markerMachineAliases,
+	); err != nil {
 		return result, err
 	}
 	result.Duration = time.Since(start)
 	return result, nil
 }
 
-// pgPushMarkerMachine reports whether this host's push marker is present in PG
-// and returns the machine value stored with the marker.
+// pgPushMarkerMachineState reports whether this host's push marker is present
+// in PG and returns the current machine plus legacy machine aliases stored with
+// the marker.
 // A missing marker while the local watermark is set means PG was reset (schema
 // dropped or recreated) since this host last pushed, so a full re-push is
 // needed. Counting rows by machine cannot detect this reliably: another host
@@ -379,7 +389,9 @@ func (s *Sync) Push(
 // also writes -- a remote host's sessions synced in over SSH, or this host's
 // own renamed identity -- masking the loss of this host's own rows. The marker
 // is per-local-DB, so no other pusher can satisfy this check.
-func (s *Sync) pgPushMarkerMachine(ctx context.Context, markerID string) (string, bool, error) {
+func (s *Sync) pgPushMarkerMachineState(
+	ctx context.Context, markerID string,
+) (string, []string, bool, error) {
 	var machine string
 	err := s.pg.QueryRowContext(ctx,
 		`SELECT value FROM sync_metadata WHERE key = $1`,
@@ -387,32 +399,128 @@ func (s *Sync) pgPushMarkerMachine(ctx context.Context, markerID string) (string
 	).Scan(&machine)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", false, nil
+			return "", nil, false, nil
 		}
 		if isUndefinedTable(err) {
-			return "", false, nil
+			return "", nil, false, nil
 		}
-		return "", false, fmt.Errorf(
+		return "", nil, false, fmt.Errorf(
 			"checking pg push marker: %w", err,
 		)
 	}
-	return machine, true, nil
+	aliases, err := s.pgPushMarkerMachineAliases(ctx, markerID)
+	if err != nil {
+		return "", nil, false, err
+	}
+	return machine, aliases, true, nil
+}
+
+func (s *Sync) pgPushMarkerMachineAliases(
+	ctx context.Context, markerID string,
+) ([]string, error) {
+	var raw string
+	err := s.pg.QueryRowContext(ctx,
+		`SELECT value FROM sync_metadata WHERE key = $1`,
+		pushMarkerMachineAliasesKeyPrefix+markerID,
+	).Scan(&raw)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"reading pg push marker machine aliases: %w", err,
+		)
+	}
+	var aliases []string
+	if err := json.Unmarshal([]byte(raw), &aliases); err != nil {
+		return nil, fmt.Errorf(
+			"decoding pg push marker machine aliases: %w", err,
+		)
+	}
+	return normalizePushMarkerMachineAliases("", aliases), nil
 }
 
 // writePushMarker records this host's push marker in PG so a later push can
-// tell whether PG still holds the rows this host pushed. The stored value
-// carries the machine name for debugging only; presence of the row is what
-// reset detection consults.
-func (s *Sync) writePushMarker(ctx context.Context, markerID string) error {
-	if _, err := s.pg.ExecContext(ctx,
+// tell whether PG still holds the rows this host pushed. The primary marker
+// value carries the current machine name for debugging and reset detection;
+// the alias key preserves previous marker machines so ownerless legacy rows can
+// be adopted after renames across multiple incremental pushes.
+func (s *Sync) writePushMarker(
+	ctx context.Context,
+	markerID, previousMarkerMachine string,
+	previousAliases []string,
+) error {
+	tx, err := s.pg.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin push marker tx: %w", err)
+	}
+	aliases := pushMarkerMachineAliases(
+		s.machine, previousMarkerMachine, previousAliases,
+	)
+	aliasesJSON, err := json.Marshal(aliases)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("encoding pg push marker machine aliases: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO sync_metadata (key, value)
 		 VALUES ($1, $2)
 		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
 		pushMarkerKeyPrefix+markerID, s.machine,
 	); err != nil {
+		_ = tx.Rollback()
 		return fmt.Errorf("writing pg push marker: %w", err)
 	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO sync_metadata (key, value)
+		 VALUES ($1, $2)
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+		pushMarkerMachineAliasesKeyPrefix+markerID, string(aliasesJSON),
+	); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("writing pg push marker machine aliases: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing pg push marker: %w", err)
+	}
 	return nil
+}
+
+func pushMarkerLegacyMachines(machine string, aliases []string) []string {
+	machines := append([]string{}, aliases...)
+	if machine != "" {
+		machines = append(machines, machine)
+	}
+	return normalizePushMarkerMachineAliases("", machines)
+}
+
+func pushMarkerMachineAliases(
+	currentMachine, previousMachine string,
+	previousAliases []string,
+) []string {
+	aliases := append([]string{}, previousAliases...)
+	if previousMachine != "" && previousMachine != currentMachine {
+		aliases = append(aliases, previousMachine)
+	}
+	return normalizePushMarkerMachineAliases(currentMachine, aliases)
+}
+
+func normalizePushMarkerMachineAliases(
+	currentMachine string, aliases []string,
+) []string {
+	seen := make(map[string]struct{}, len(aliases))
+	out := make([]string, 0, len(aliases))
+	for _, alias := range aliases {
+		if alias == "" || alias == currentMachine {
+			continue
+		}
+		if _, ok := seen[alias]; ok {
+			continue
+		}
+		seen[alias] = struct{}{}
+		out = append(out, alias)
+	}
+	return out
 }
 
 // pushMarkerID returns this local DB's stable push-marker identifier, creating
@@ -457,7 +565,7 @@ func (s *Sync) pushBatch(
 	batch []db.Session,
 	full bool,
 	markerID string,
-	previousMarkerMachine string,
+	legacyMarkerMachines []string,
 	pushed *[]db.Session,
 ) (batchResult, error) {
 	tx, err := s.pg.BeginTx(ctx, nil)
@@ -472,7 +580,7 @@ func (s *Sync) pushBatch(
 	skippedConflicts := 0
 	for _, sess := range batch {
 		if err := s.pushSession(
-			ctx, tx, sess, markerID, previousMarkerMachine,
+			ctx, tx, sess, markerID, legacyMarkerMachines,
 		); err != nil {
 			if errors.Is(err, errSessionOwnershipConflict) {
 				skippedConflicts++
@@ -805,8 +913,8 @@ func pushedSessionMachine(sess db.Session, fallbackMachine string) string {
 }
 
 func sameSessionOwner(
-	existingOwnerMarker, existingMachine, markerID, pushedMachine,
-	previousMarkerMachine string,
+	existingOwnerMarker, existingMachine, markerID, pushedMachine string,
+	legacyMarkerMachines []string,
 ) bool {
 	if existingOwnerMarker != "" {
 		return existingOwnerMarker == markerID
@@ -817,7 +925,7 @@ func sameSessionOwner(
 	if existingMachine == "local" {
 		return true
 	}
-	if previousMarkerMachine != "" && existingMachine == previousMarkerMachine {
+	if slices.Contains(legacyMarkerMachines, existingMachine) {
 		return true
 	}
 	return existingMachine == pushedMachine
@@ -884,7 +992,8 @@ func nilStrTS(s *string) any {
 // local-only and used solely by the sync engine to detect
 // re-parsed sessions.
 func (s *Sync) pushSession(
-	ctx context.Context, tx *sql.Tx, sess db.Session, markerID, previousMarkerMachine string,
+	ctx context.Context, tx *sql.Tx, sess db.Session, markerID string,
+	legacyMarkerMachines []string,
 ) error {
 	createdAt, _ := ParseSQLiteTimestamp(sess.CreatedAt)
 	isAutomated := sess.IsAutomated
@@ -902,7 +1011,7 @@ func (s *Sync) pushSession(
 		existingMachine.String,
 		markerID,
 		pushedMachine,
-		previousMarkerMachine,
+		legacyMarkerMachines,
 	) {
 		log.Printf(
 			"pgsync: session %s: skipping — already owned by machine %q, "+
@@ -910,6 +1019,13 @@ func (s *Sync) pushSession(
 			sess.ID, existingMachine.String, pushedMachine,
 		)
 		return errSessionOwnershipConflict
+	}
+	if legacyMarkerMachines == nil {
+		legacyMarkerMachines = []string{}
+	}
+	legacyMarkerMachinesJSON, err := json.Marshal(legacyMarkerMachines)
+	if err != nil {
+		return fmt.Errorf("encoding legacy marker machines: %w", err)
 	}
 	result, err := tx.ExecContext(ctx, `
 		INSERT INTO sessions (
@@ -1004,7 +1120,9 @@ func (s *Sync) pushSession(
 				AND (sessions.machine = EXCLUDED.machine
 					OR sessions.machine = 'local'
 					OR sessions.machine = ''
-					OR sessions.machine = $48)
+					OR sessions.machine IN (
+						SELECT jsonb_array_elements_text($48::jsonb)
+					))
 			)
 			OR sessions.owner_marker = EXCLUDED.owner_marker)
 			AND (
@@ -1085,7 +1203,7 @@ func (s *Sync) pushSession(
 		sess.HealthScore, nilStr(sess.HealthGrade),
 		sess.HasToolCalls, sess.HasContextData,
 		sess.SecretLeakCount, sess.SecretsRulesVersion,
-		previousMarkerMachine,
+		string(legacyMarkerMachinesJSON),
 	)
 	if err != nil {
 		return err
@@ -1102,7 +1220,7 @@ func (s *Sync) pushSession(
 		}
 		if refreshErr == nil && !sameSessionOwner(
 			currentOwnerMarker, currentMachine, markerID, pushedMachine,
-			previousMarkerMachine,
+			legacyMarkerMachines,
 		) {
 			log.Printf(
 				"pgsync: session %s: skipping — already owned by machine %q, this pusher is %q; sync from the origin machine to update",

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -44,18 +44,20 @@ type pushBoundaryState struct {
 
 // PushResult summarizes a push sync operation.
 type PushResult struct {
-	SessionsPushed int
-	MessagesPushed int
-	Errors         int
-	Duration       time.Duration
+	SessionsPushed   int
+	MessagesPushed   int
+	SkippedConflicts int
+	Errors           int
+	Duration         time.Duration
 }
 
 // PushProgress is reported after each batch during Push.
 type PushProgress struct {
-	SessionsDone  int
-	SessionsTotal int
-	MessagesDone  int
-	Errors        int
+	SessionsDone     int
+	SessionsTotal    int
+	MessagesDone     int
+	SkippedConflicts int
+	Errors           int
 }
 
 // Push syncs local sessions and messages to PostgreSQL.
@@ -279,6 +281,7 @@ func (s *Sync) Push(
 		if batchResult.ok {
 			result.SessionsPushed += batchResult.sessions
 			result.MessagesPushed += batchResult.messages
+			result.SkippedConflicts += batchResult.skippedConflicts
 		} else {
 			// Batch failed — retry each session individually
 			// so one bad session doesn't block the rest.
@@ -293,6 +296,7 @@ func (s *Sync) Push(
 				if sr.ok {
 					result.SessionsPushed += sr.sessions
 					result.MessagesPushed += sr.messages
+					result.SkippedConflicts += sr.skippedConflicts
 				} else {
 					result.Errors++
 				}
@@ -300,10 +304,11 @@ func (s *Sync) Push(
 		}
 		if onProgress != nil {
 			onProgress(PushProgress{
-				SessionsDone:  end,
-				SessionsTotal: len(sessions),
-				MessagesDone:  result.MessagesPushed,
-				Errors:        result.Errors,
+				SessionsDone:     end,
+				SessionsTotal:    len(sessions),
+				MessagesDone:     result.MessagesPushed,
+				SkippedConflicts: result.SkippedConflicts,
+				Errors:           result.Errors,
 			})
 		}
 	}
@@ -432,9 +437,10 @@ func (s *Sync) pushMarkerID() (string, error) {
 }
 
 type batchResult struct {
-	ok       bool
-	sessions int
-	messages int
+	ok               bool
+	sessions         int
+	messages         int
+	skippedConflicts int
 }
 
 // pushBatch pushes a slice of sessions within a single
@@ -458,11 +464,13 @@ func (s *Sync) pushBatch(
 
 	n := 0
 	msgs := 0
+	skippedConflicts := 0
 	for _, sess := range batch {
 		if err := s.pushSession(
 			ctx, tx, sess,
 		); err != nil {
 			if errors.Is(err, errSessionOwnershipConflict) {
+				skippedConflicts++
 				continue
 			}
 			log.Printf(
@@ -531,7 +539,7 @@ func (s *Sync) pushBatch(
 		*pushed = (*pushed)[:len(*pushed)-n]
 		return batchResult{}, nil
 	}
-	return batchResult{ok: true, sessions: n, messages: msgs}, nil
+	return batchResult{ok: true, sessions: n, messages: msgs, skippedConflicts: skippedConflicts}, nil
 }
 
 func finalizePushState(
@@ -789,6 +797,16 @@ func pushedSessionMachine(sess db.Session, fallbackMachine string) string {
 	return fallbackMachine
 }
 
+func sameSessionOwner(existingOwnerMarker, existingMachine, markerID, pushedMachine string) bool {
+	if existingOwnerMarker != "" {
+		return existingOwnerMarker == markerID
+	}
+	if existingMachine == "" {
+		return true
+	}
+	return existingMachine == pushedMachine
+}
+
 func stringValue(value *string) string {
 	if value == nil {
 		return ""
@@ -854,22 +872,25 @@ func (s *Sync) pushSession(
 ) error {
 	createdAt, _ := ParseSQLiteTimestamp(sess.CreatedAt)
 	isAutomated := sess.IsAutomated
-	// Guard against cross-machine PK collision: if this session already exists
-	// under a different machine name, skip the upsert and warn. Two machines
-	// pushing the same session ID would otherwise ping-pong the row and its
-	// messages on every push cycle.
+	markerID, err := s.pushMarkerID()
+	if err != nil {
+		return err
+	}
+	pushedMachine := pushedSessionMachine(sess, s.machine)
 	var existingMachine sql.NullString
+	var existingOwnerMarker sql.NullString
 	checkErr := tx.QueryRowContext(ctx,
-		`SELECT machine FROM sessions WHERE id = $1`, sess.ID,
-	).Scan(&existingMachine)
+		`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sess.ID,
+	).Scan(&existingMachine, &existingOwnerMarker)
 	if checkErr != nil && !errors.Is(checkErr, sql.ErrNoRows) {
 		return fmt.Errorf("checking session ownership %s: %w", sess.ID, checkErr)
 	}
-	pushedMachine := pushedSessionMachine(sess, s.machine)
-	if existingMachine.Valid &&
-		existingMachine.String != "" &&
-		existingMachine.String != pushedMachine &&
-		sess.Machine != "" && sess.Machine != "local" {
+	if checkErr == nil && !sameSessionOwner(
+		existingOwnerMarker.String,
+		existingMachine.String,
+		markerID,
+		pushedMachine,
+	) {
 		log.Printf(
 			"pgsync: session %s: skipping — already owned by machine %q, "+
 				"this pusher is %q; sync from the origin machine to update",
@@ -877,9 +898,9 @@ func (s *Sync) pushSession(
 		)
 		return errSessionOwnershipConflict
 	}
-	_, err := tx.ExecContext(ctx, `
+	result, err := tx.ExecContext(ctx, `
 		INSERT INTO sessions (
-			id, machine, project, agent,
+			id, machine, owner_marker, project, agent,
 			first_message, display_name, session_name,
 			created_at, started_at, ended_at, deleted_at,
 			message_count, user_message_count,
@@ -902,23 +923,24 @@ func (s *Sync) pushSession(
 			secret_leak_count, secrets_rules_version,
 			updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7,
-			$8, $9, $10, $11,
-			$12, $13, $14, $15,
-			$16, $17, $18, $19,
-			$20, $21, $22, $23, $24, $25, $26,
-			$27, $28,
-			$29, $30, $31, $32,
-			$33, $34, $35, $36,
-			$37,
-			$38, $39,
-			$40,
-			$41, $42, $43, $44,
-			$45, $46,
+			$1, $2, $3, $4, $5, $6, $7, $8,
+			$9, $10, $11, $12,
+			$13, $14, $15, $16,
+			$17, $18, $19, $20,
+			$21, $22, $23, $24, $25, $26, $27,
+			$28, $29,
+			$30, $31, $32, $33,
+			$34, $35, $36, $37,
+			$38,
+			$39, $40,
+			$41,
+			$42, $43, $44, $45,
+			$46, $47,
 			NOW()
 		)
 		ON CONFLICT (id) DO UPDATE SET
 			machine = EXCLUDED.machine,
+			owner_marker = EXCLUDED.owner_marker,
 			project = EXCLUDED.project,
 			agent = EXCLUDED.agent,
 			first_message = EXCLUDED.first_message,
@@ -964,7 +986,14 @@ func (s *Sync) pushSession(
 			secret_leak_count = EXCLUDED.secret_leak_count,
 			secrets_rules_version = EXCLUDED.secrets_rules_version,
 			updated_at = NOW()
-		WHERE sessions.machine IS DISTINCT FROM EXCLUDED.machine
+		WHERE ((
+				sessions.owner_marker = ''
+				AND sessions.machine = EXCLUDED.machine
+			)
+			OR sessions.owner_marker = EXCLUDED.owner_marker)
+			AND (
+			sessions.machine IS DISTINCT FROM EXCLUDED.machine
+			OR sessions.owner_marker IS DISTINCT FROM EXCLUDED.owner_marker
 			OR sessions.project IS DISTINCT FROM EXCLUDED.project
 			OR sessions.agent IS DISTINCT FROM EXCLUDED.agent
 			OR sessions.first_message IS DISTINCT FROM EXCLUDED.first_message
@@ -1008,8 +1037,8 @@ func (s *Sync) pushSession(
 			OR sessions.has_tool_calls IS DISTINCT FROM EXCLUDED.has_tool_calls
 			OR sessions.has_context_data IS DISTINCT FROM EXCLUDED.has_context_data
 			OR sessions.secret_leak_count IS DISTINCT FROM EXCLUDED.secret_leak_count
-			OR sessions.secrets_rules_version IS DISTINCT FROM EXCLUDED.secrets_rules_version`,
-		sess.ID, pushedSessionMachine(sess, s.machine),
+			OR sessions.secrets_rules_version IS DISTINCT FROM EXCLUDED.secrets_rules_version)`,
+		sess.ID, pushedMachine, markerID,
 		sanitizePG(sess.Project),
 		sess.Agent,
 		nilStr(sess.FirstMessage),
@@ -1041,7 +1070,30 @@ func (s *Sync) pushSession(
 		sess.HasToolCalls, sess.HasContextData,
 		sess.SecretLeakCount, sess.SecretsRulesVersion,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	if rowsAffected, rowsErr := result.RowsAffected(); rowsErr == nil && rowsAffected == 0 {
+		if checkErr == nil {
+			currentOwnerMarker := existingOwnerMarker.String
+			currentMachine := existingMachine.String
+			refreshErr := tx.QueryRowContext(ctx,
+				`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sess.ID,
+			).Scan(&existingMachine, &existingOwnerMarker)
+			if refreshErr == nil {
+				currentOwnerMarker = existingOwnerMarker.String
+				currentMachine = existingMachine.String
+			}
+			if !sameSessionOwner(currentOwnerMarker, currentMachine, markerID, pushedMachine) {
+				log.Printf(
+					"pgsync: session %s: skipping — already owned by machine %q, this pusher is %q; sync from the origin machine to update",
+					sess.ID, currentMachine, pushedMachine,
+				)
+				return errSessionOwnershipConflict
+			}
+		}
+	}
+	return nil
 }
 
 // pushMessages replaces a session's messages and tool calls

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -35,6 +35,7 @@ var errSessionOwnershipConflict = errors.New("session ownership conflict")
 type syncStateStore interface {
 	GetSyncState(key string) (string, error)
 	SetSyncState(key, value string) error
+	GetOrCreateSyncState(key, defaultValue string) (string, error)
 }
 
 type pushBoundaryState struct {
@@ -80,6 +81,10 @@ func (s *Sync) Push(
 			"reading last_push_at: %w", err,
 		)
 	}
+	markerID, err := s.pushMarkerID()
+	if err != nil {
+		return result, err
+	}
 	if full {
 		lastPush = ""
 		// Caller requested a full push — the PG schema
@@ -108,7 +113,7 @@ func (s *Sync) Push(
 	// was reset (schema dropped, DB recreated, etc.). Force a full
 	// push so all sessions are re-synced.
 	if lastPush != "" {
-		markerExists, cErr := s.pgPushMarkerExists(ctx)
+		markerExists, cErr := s.pgPushMarkerExists(ctx, markerID)
 		if cErr != nil {
 			return result, cErr
 		}
@@ -210,10 +215,6 @@ func (s *Sync) Push(
 			"computing local usage event fingerprints: %w", err,
 		)
 	}
-	markerID, err := s.pushMarkerID()
-	if err != nil {
-		return result, err
-	}
 	for id, sess := range sessionByID {
 		sessionFingerprints[id] = sessionPushFingerprint(
 			sess, pushedSessionMachine(sess, s.machine),
@@ -263,7 +264,7 @@ func (s *Sync) Push(
 				return result, err
 			}
 		}
-		if err := s.writePushMarker(ctx); err != nil {
+		if err := s.writePushMarker(ctx, markerID); err != nil {
 			return result, err
 		}
 		result.Duration = time.Since(start)
@@ -277,7 +278,7 @@ func (s *Sync) Push(
 		batch := sessions[i:end]
 
 		batchResult, err := s.pushBatch(
-			ctx, batch, full, &pushed,
+			ctx, batch, full, markerID, &pushed,
 		)
 		if err != nil {
 			return result, err
@@ -292,7 +293,7 @@ func (s *Sync) Push(
 			for _, sess := range batch {
 				sr, retryErr := s.pushBatch(
 					ctx, []db.Session{sess},
-					full, &pushed,
+					full, markerID, &pushed,
 				)
 				if retryErr != nil {
 					return result, retryErr
@@ -361,7 +362,7 @@ func (s *Sync) Push(
 	// succeed. A reset-recovery push that fails before this point leaves
 	// the marker absent, so the next push re-detects the reset and retries
 	// rather than skipping the still-missing sessions.
-	if err := s.writePushMarker(ctx); err != nil {
+	if err := s.writePushMarker(ctx, markerID); err != nil {
 		return result, err
 	}
 	result.Duration = time.Since(start)
@@ -376,15 +377,11 @@ func (s *Sync) Push(
 // also writes -- a remote host's sessions synced in over SSH, or this host's
 // own renamed identity -- masking the loss of this host's own rows. The marker
 // is per-local-DB, so no other pusher can satisfy this check.
-func (s *Sync) pgPushMarkerExists(ctx context.Context) (bool, error) {
-	id, err := s.pushMarkerID()
-	if err != nil {
-		return false, err
-	}
+func (s *Sync) pgPushMarkerExists(ctx context.Context, markerID string) (bool, error) {
 	var exists bool
-	err = s.pg.QueryRowContext(ctx,
+	err := s.pg.QueryRowContext(ctx,
 		`SELECT EXISTS (SELECT 1 FROM sync_metadata WHERE key = $1)`,
-		pushMarkerKeyPrefix+id,
+		pushMarkerKeyPrefix+markerID,
 	).Scan(&exists)
 	if err != nil {
 		if isUndefinedTable(err) {
@@ -401,16 +398,12 @@ func (s *Sync) pgPushMarkerExists(ctx context.Context) (bool, error) {
 // tell whether PG still holds the rows this host pushed. The stored value
 // carries the machine name for debugging only; presence of the row is what
 // reset detection consults.
-func (s *Sync) writePushMarker(ctx context.Context) error {
-	id, err := s.pushMarkerID()
-	if err != nil {
-		return err
-	}
+func (s *Sync) writePushMarker(ctx context.Context, markerID string) error {
 	if _, err := s.pg.ExecContext(ctx,
 		`INSERT INTO sync_metadata (key, value)
 		 VALUES ($1, $2)
 		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
-		pushMarkerKeyPrefix+id, s.machine,
+		pushMarkerKeyPrefix+markerID, s.machine,
 	); err != nil {
 		return fmt.Errorf("writing pg push marker: %w", err)
 	}
@@ -434,10 +427,11 @@ func (s *Sync) pushMarkerID() (string, error) {
 		return "", fmt.Errorf("generating push marker id: %w", err)
 	}
 	id = hex.EncodeToString(buf)
-	if err := s.local.SetSyncState(pushMarkerIDStateKey, id); err != nil {
+	storedID, err := s.local.GetOrCreateSyncState(pushMarkerIDStateKey, id)
+	if err != nil {
 		return "", fmt.Errorf("persisting push marker id: %w", err)
 	}
-	return id, nil
+	return storedID, nil
 }
 
 type batchResult struct {
@@ -457,6 +451,7 @@ func (s *Sync) pushBatch(
 	ctx context.Context,
 	batch []db.Session,
 	full bool,
+	markerID string,
 	pushed *[]db.Session,
 ) (batchResult, error) {
 	tx, err := s.pg.BeginTx(ctx, nil)
@@ -471,7 +466,7 @@ func (s *Sync) pushBatch(
 	skippedConflicts := 0
 	for _, sess := range batch {
 		if err := s.pushSession(
-			ctx, tx, sess,
+			ctx, tx, sess, markerID,
 		); err != nil {
 			if errors.Is(err, errSessionOwnershipConflict) {
 				skippedConflicts++
@@ -877,14 +872,10 @@ func nilStrTS(s *string) any {
 // local-only and used solely by the sync engine to detect
 // re-parsed sessions.
 func (s *Sync) pushSession(
-	ctx context.Context, tx *sql.Tx, sess db.Session,
+	ctx context.Context, tx *sql.Tx, sess db.Session, markerID string,
 ) error {
 	createdAt, _ := ParseSQLiteTimestamp(sess.CreatedAt)
 	isAutomated := sess.IsAutomated
-	markerID, err := s.pushMarkerID()
-	if err != nil {
-		return err
-	}
 	pushedMachine := pushedSessionMachine(sess, s.machine)
 	var existingMachine sql.NullString
 	var existingOwnerMarker sql.NullString

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -373,7 +373,7 @@ func TestPushSessionTerminationStatus(t *testing.T) {
 		t.Helper()
 		tx, err := pg.BeginTx(ctx, nil)
 		require.NoError(t, err, "BeginTx")
-		if err := sync.pushSession(ctx, tx, s, markerID, ""); err != nil {
+		if err := sync.pushSession(ctx, tx, s, markerID, nil); err != nil {
 			_ = tx.Rollback()
 			t.Fatalf("pushSession: %v", err)
 		}
@@ -439,7 +439,7 @@ func TestPushSessionPreservesSourceMachine(t *testing.T) {
 	require.NoError(t, err, "BeginTx")
 	markerID, err := sync.pushMarkerID()
 	require.NoError(t, err, "pushMarkerID")
-	require.NoError(t, sync.pushSession(ctx, tx, remoteSession, markerID, ""), "pushSession")
+	require.NoError(t, sync.pushSession(ctx, tx, remoteSession, markerID, nil), "pushSession")
 	require.NoError(t, tx.Commit(), "Commit")
 
 	var got string
@@ -1180,6 +1180,49 @@ func TestPushAdoptsOwnerlessRowsFromPreviousMarkerMachine(t *testing.T) {
 		pushMarkerKeyPrefix+markerID,
 	).Scan(&markerMachine), "reading marker machine")
 	assert.Equal(t, "host-b", markerMachine)
+
+	var aliases string
+	require.NoError(t, pg.QueryRow(
+		`SELECT value FROM sync_metadata WHERE key = $1`,
+		pushMarkerMachineAliasesKeyPrefix+markerID,
+	).Scan(&aliases), "reading marker aliases")
+	assert.JSONEq(t, `["host-a"]`, aliases)
+
+	const laterSessID = "legacy-previous-machine-2"
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:           laterSessID,
+		Project:      "proj",
+		Machine:      "host-b",
+		Agent:        "claude",
+		MessageCount: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+	}), "UpsertSession later legacy row")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     laterSessID,
+		Ordinal:       0,
+		Role:          "assistant",
+		Content:       "later",
+		ContentLength: 5,
+	}}), "InsertMessages later legacy row")
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, owner_marker, project, agent, created_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
+	`, laterSessID, "host-a", "", "proj", "claude")
+	require.NoError(t, err, "seed later ownerless legacy session")
+
+	res, err = sync.Push(ctx, true, nil)
+	require.NoError(t, err, "second Push")
+	assert.Zero(t, res.Errors, "second push should report no failed sessions")
+	assert.Zero(t, res.SkippedConflicts,
+		"preserved marker alias should adopt later legacy row")
+
+	require.NoError(t, pg.QueryRow(
+		`SELECT machine, owner_marker FROM sessions WHERE id = $1`,
+		laterSessID,
+	).Scan(&machine, &ownerMarker), "reading later adopted row")
+	assert.Equal(t, "host-b", machine)
+	assert.Equal(t, markerID, ownerMarker)
 }
 
 func TestPushReportsSkippedConflicts(t *testing.T) {

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -373,7 +373,7 @@ func TestPushSessionTerminationStatus(t *testing.T) {
 		t.Helper()
 		tx, err := pg.BeginTx(ctx, nil)
 		require.NoError(t, err, "BeginTx")
-		if err := sync.pushSession(ctx, tx, s, markerID); err != nil {
+		if err := sync.pushSession(ctx, tx, s, markerID, ""); err != nil {
 			_ = tx.Rollback()
 			t.Fatalf("pushSession: %v", err)
 		}
@@ -439,7 +439,7 @@ func TestPushSessionPreservesSourceMachine(t *testing.T) {
 	require.NoError(t, err, "BeginTx")
 	markerID, err := sync.pushMarkerID()
 	require.NoError(t, err, "pushMarkerID")
-	require.NoError(t, sync.pushSession(ctx, tx, remoteSession, markerID), "pushSession")
+	require.NoError(t, sync.pushSession(ctx, tx, remoteSession, markerID, ""), "pushSession")
 	require.NoError(t, tx.Commit(), "Commit")
 
 	var got string
@@ -1099,6 +1099,87 @@ func TestPushUpdatesSentinelMachineWhenSyncMachineChanges(t *testing.T) {
 	assert.Zero(t, res.Errors, "second push should report no failures")
 	assert.Equal(t, "host-b", machine(),
 		"sentinel machine must follow the new fallback")
+}
+
+func TestPushAdoptsOwnerlessRowsFromPreviousMarkerMachine(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_legacy_marker_machine_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	const markerID = "legacy-marker-1"
+	require.NoError(t, localDB.SetSyncState("pg_push_marker_id", markerID),
+		"seed local push marker")
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "host-b",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessID = "legacy-previous-machine-1"
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:           sessID,
+		Project:      "proj",
+		Machine:      "host-b",
+		Agent:        "claude",
+		MessageCount: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+	}), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     sessID,
+		Ordinal:       0,
+		Role:          "assistant",
+		Content:       "hello",
+		ContentLength: 5,
+	}}), "InsertMessages")
+
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sync_metadata (key, value)
+		VALUES ($1, $2)
+	`, pushMarkerKeyPrefix+markerID, "host-a")
+	require.NoError(t, err, "seed previous marker machine")
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, owner_marker, project, agent, created_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
+	`, sessID, "host-a", "", "proj", "claude")
+	require.NoError(t, err, "seed ownerless legacy session")
+
+	res, err := sync.Push(ctx, true, nil)
+	require.NoError(t, err, "Push")
+	assert.Zero(t, res.Errors, "push should report no failed sessions")
+	assert.Zero(t, res.SkippedConflicts,
+		"previous-marker-machine legacy row should be adopted")
+	assert.Equal(t, 1, res.SessionsPushed,
+		"legacy row should be counted as pushed")
+
+	var machine, ownerMarker string
+	require.NoError(t, pg.QueryRow(
+		`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sessID,
+	).Scan(&machine, &ownerMarker), "reading adopted row")
+	assert.Equal(t, "host-b", machine)
+	assert.Equal(t, markerID, ownerMarker)
+
+	var markerMachine string
+	require.NoError(t, pg.QueryRow(
+		`SELECT value FROM sync_metadata WHERE key = $1`,
+		pushMarkerKeyPrefix+markerID,
+	).Scan(&markerMachine), "reading marker machine")
+	assert.Equal(t, "host-b", markerMachine)
 }
 
 func TestPushReportsSkippedConflicts(t *testing.T) {

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -1096,3 +1096,59 @@ func TestPushUpdatesSentinelMachineWhenSyncMachineChanges(t *testing.T) {
 	assert.Equal(t, "host-b", machine(),
 		"sentinel machine must follow the new fallback")
 }
+
+func TestPushReportsSkippedConflicts(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_skipped_conflicts_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "machine-b",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessID = "conflict-001"
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:           sessID,
+		Project:      "proj",
+		Machine:      "machine-b",
+		Agent:        "claude",
+		MessageCount: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+	}), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     sessID,
+		Ordinal:       0,
+		Role:          "assistant",
+		Content:       "hello",
+		ContentLength: 5,
+	}}), "InsertMessages")
+
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, owner_marker, project, agent, created_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
+	`, sessID, "machine-a", "other-owner", "proj", "claude")
+	require.NoError(t, err, "insert conflicting owner")
+
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push")
+	assert.Zero(t, res.Errors, "push should not report failed sessions")
+	assert.Zero(t, res.SessionsPushed, "conflicting session should not be counted as pushed")
+	assert.Equal(t, 1, res.SkippedConflicts, "skipped conflicts should be observable in PushResult")
+}

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -352,6 +352,8 @@ func TestPushSessionTerminationStatus(t *testing.T) {
 		schema:     schema,
 		schemaDone: true,
 	}
+	markerID, err := sync.pushMarkerID()
+	require.NoError(t, err, "pushMarkerID")
 
 	pending := "tool_call_pending"
 	sess := db.Session{
@@ -371,7 +373,7 @@ func TestPushSessionTerminationStatus(t *testing.T) {
 		t.Helper()
 		tx, err := pg.BeginTx(ctx, nil)
 		require.NoError(t, err, "BeginTx")
-		if err := sync.pushSession(ctx, tx, s); err != nil {
+		if err := sync.pushSession(ctx, tx, s, markerID); err != nil {
 			_ = tx.Rollback()
 			t.Fatalf("pushSession: %v", err)
 		}
@@ -435,7 +437,9 @@ func TestPushSessionPreservesSourceMachine(t *testing.T) {
 
 	tx, err := pg.BeginTx(ctx, nil)
 	require.NoError(t, err, "BeginTx")
-	require.NoError(t, sync.pushSession(ctx, tx, remoteSession), "pushSession")
+	markerID, err := sync.pushMarkerID()
+	require.NoError(t, err, "pushMarkerID")
+	require.NoError(t, sync.pushSession(ctx, tx, remoteSession, markerID), "pushSession")
 	require.NoError(t, tx.Commit(), "Commit")
 
 	var got string

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -28,8 +28,18 @@ func (s syncStateReaderStub) SetSyncState(
 	return nil
 }
 
+func (s syncStateReaderStub) GetOrCreateSyncState(
+	key, defaultValue string,
+) (string, error) {
+	if s.value != "" || s.err != nil {
+		return s.value, s.err
+	}
+	return defaultValue, nil
+}
+
 type syncStateStoreStub struct {
-	values map[string]string
+	values      map[string]string
+	createValue string
 }
 
 func (s *syncStateStoreStub) GetSyncState(
@@ -46,6 +56,38 @@ func (s *syncStateStoreStub) SetSyncState(
 	}
 	s.values[key] = value
 	return nil
+}
+
+func (s *syncStateStoreStub) GetOrCreateSyncState(
+	key, defaultValue string,
+) (string, error) {
+	if s.values == nil {
+		s.values = make(map[string]string)
+	}
+	if value := s.values[key]; value != "" {
+		return value, nil
+	}
+	if s.createValue != "" {
+		s.values[key] = s.createValue
+		return s.createValue, nil
+	}
+	s.values[key] = defaultValue
+	return defaultValue, nil
+}
+
+func TestPushMarkerIDReturnsInsertWinner(t *testing.T) {
+	local, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer local.Close()
+	require.NoError(t, local.SetSyncState(pushMarkerIDStateKey, "winner-marker"))
+	sync := &Sync{local: local}
+
+	got, err := sync.pushMarkerID()
+	require.NoError(t, err, "pushMarkerID")
+	assert.Equal(t, "winner-marker", got)
+	stored, err := local.GetSyncState(pushMarkerIDStateKey)
+	require.NoError(t, err, "GetSyncState")
+	assert.Equal(t, "winner-marker", stored)
 }
 
 func TestReadPushBoundaryStateValidity(t *testing.T) {

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -126,7 +126,7 @@ func TestSessionPushFingerprintDiffers(t *testing.T) {
 		CreatedAt:        "2026-03-11T12:00:00Z",
 	}
 
-	fp1 := sessionPushFingerprint(base, base.Machine, "")
+	fp1 := sessionPushFingerprint(base, base.Machine, "", "")
 
 	tests := []struct {
 		name   string
@@ -191,13 +191,13 @@ func TestSessionPushFingerprintDiffers(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			modified := tc.modify(base)
-			fp2 := sessionPushFingerprint(modified, modified.Machine, "")
+			fp2 := sessionPushFingerprint(modified, modified.Machine, "", "")
 			require.NotEqual(t, fp1, fp2,
 				"fingerprint should differ after %s", tc.name)
 		})
 	}
 
-	assert.Equal(t, fp1, sessionPushFingerprint(base, base.Machine, ""),
+	assert.Equal(t, fp1, sessionPushFingerprint(base, base.Machine, "", ""),
 		"identical sessions should produce identical fingerprints")
 }
 
@@ -214,8 +214,8 @@ func TestSessionPushFingerprintIncludesUsageEventFingerprint(
 		CreatedAt:        "2026-03-11T12:00:00Z",
 	}
 
-	withoutUsage := sessionPushFingerprint(base, base.Machine, "")
-	withUsage := sessionPushFingerprint(base, base.Machine, "usage-fp")
+	withoutUsage := sessionPushFingerprint(base, base.Machine, "", "")
+	withUsage := sessionPushFingerprint(base, base.Machine, "usage-fp", "")
 	assert.NotEqual(t, withoutUsage, withUsage,
 		"usage event fingerprint should affect session fingerprint")
 }
@@ -229,9 +229,9 @@ func TestSessionPushFingerprintTracksResolvedMachine(t *testing.T) {
 		CreatedAt: "2026-03-11T12:00:00Z",
 	}
 	fpA := sessionPushFingerprint(
-		sentinel, pushedSessionMachine(sentinel, "host-a"), "")
+		sentinel, pushedSessionMachine(sentinel, "host-a"), "", "")
 	fpB := sessionPushFingerprint(
-		sentinel, pushedSessionMachine(sentinel, "host-b"), "")
+		sentinel, pushedSessionMachine(sentinel, "host-b"), "", "")
 	assert.NotEqual(t, fpA, fpB,
 		"sentinel session fingerprint must change with the fallback machine")
 
@@ -243,9 +243,9 @@ func TestSessionPushFingerprintTracksResolvedMachine(t *testing.T) {
 		CreatedAt: "2026-03-11T12:00:00Z",
 	}
 	fp1 := sessionPushFingerprint(
-		real, pushedSessionMachine(real, "host-a"), "")
+		real, pushedSessionMachine(real, "host-a"), "", "")
 	fp2 := sessionPushFingerprint(
-		real, pushedSessionMachine(real, "host-b"), "")
+		real, pushedSessionMachine(real, "host-b"), "", "")
 	assert.Equal(t, fp1, fp2,
 		"a session with a real machine ignores the fallback")
 }
@@ -303,8 +303,8 @@ func TestSessionPushFingerprintNoFieldCollisions(
 		CreatedAt: "2026-03-11T12:00:00Z",
 	}
 	assert.NotEqual(t,
-		sessionPushFingerprint(s1, s1.Machine, ""),
-		sessionPushFingerprint(s2, s2.Machine, ""),
+		sessionPushFingerprint(s1, s1.Machine, "", ""),
+		sessionPushFingerprint(s2, s2.Machine, "", ""),
 		"length-prefixed fingerprints should not collide")
 }
 
@@ -385,7 +385,7 @@ func TestFinalizePushStateMergesPriorFingerprints(
 	require.NoError(t, finalizePushState(
 		store, cutoff, cycle2Sessions,
 		priorFingerprints,
-		map[string]string{"sess-002": sessionPushFingerprint(cycle2Sessions[0], cycle2Sessions[0].Machine, "")},
+		map[string]string{"sess-002": sessionPushFingerprint(cycle2Sessions[0], cycle2Sessions[0].Machine, "", "")},
 	))
 
 	raw := store.values[lastPushBoundaryStateKey]

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS sync_metadata (
 CREATE TABLE IF NOT EXISTS sessions (
     id                 TEXT PRIMARY KEY,
     machine            TEXT NOT NULL,
+    owner_marker       TEXT NOT NULL DEFAULT '',
     project            TEXT NOT NULL,
     agent              TEXT NOT NULL,
     first_message      TEXT,
@@ -292,6 +293,11 @@ func EnsureSchema(
 
 	// Idempotent column additions for forward compatibility.
 	alters := []columnMigration{
+		{
+			"sessions", "owner_marker",
+			`owner_marker TEXT NOT NULL DEFAULT ''`,
+			"adding sessions.owner_marker",
+		},
 		{
 			"sessions", "deleted_at",
 			`deleted_at TIMESTAMPTZ`,

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -195,6 +195,7 @@ func (s *schemaProbeState) executedSQL() string {
 func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
 	existing := map[string][]string{
 		"sessions": {
+			"owner_marker",
 			"created_at", "deleted_at",
 			"total_output_tokens", "peak_context_tokens",
 			"has_total_output_tokens",
@@ -236,6 +237,7 @@ func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
 func TestEnsureSchemaCreatesAnalyticsCoveringIndexes(t *testing.T) {
 	db, state := newSchemaProbeDB(t, map[string][]string{
 		"sessions": {
+			"owner_marker",
 			"total_output_tokens", "peak_context_tokens",
 			"has_total_output_tokens",
 			"has_peak_context_tokens",
@@ -263,6 +265,7 @@ func TestEnsureSchemaCreatesAnalyticsCoveringIndexes(t *testing.T) {
 func TestEnsureSchemaCreatesSessionTraversalIndex(t *testing.T) {
 	db, state := newSchemaProbeDB(t, map[string][]string{
 		"sessions": {
+			"owner_marker",
 			"total_output_tokens", "peak_context_tokens",
 			"has_total_output_tokens",
 			"has_peak_context_tokens",
@@ -283,6 +286,7 @@ func TestEnsureSchemaCreatesSessionTraversalIndex(t *testing.T) {
 func TestEnsureSchemaGroupsMissingColumnMigrationsByTable(t *testing.T) {
 	db, state := newSchemaProbeDB(t, map[string][]string{
 		"sessions": {
+			"owner_marker",
 			"created_at", "deleted_at",
 			"total_output_tokens", "peak_context_tokens",
 			"has_total_output_tokens",

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2059,6 +2059,20 @@ func (e *Engine) ResyncAll(
 	}
 	if err := newDB.CopySyncStateFrom(origPath); err != nil {
 		log.Printf("resync: copy sync state: %v", err)
+		stats.Aborted = true
+		stats.Warnings = append(stats.Warnings,
+			"sync state copy failed, aborting swap: "+err.Error(),
+		)
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		if rerr := origDB.Reopen(); rerr != nil {
+			log.Printf("resync: recovery reopen: %v", rerr)
+		}
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats
 	}
 
 	// Copy insights into newDB from the quiesced old DB file.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2057,6 +2057,9 @@ func (e *Engine) ResyncAll(
 	if err := newDB.PurgeExcludedSessions(); err != nil {
 		log.Printf("resync: purge excluded sessions: %v", err)
 	}
+	if err := newDB.CopySyncStateFrom(origPath); err != nil {
+		log.Printf("resync: copy sync state: %v", err)
+	}
 
 	// Copy insights into newDB from the quiesced old DB file.
 	tInsights := time.Now()

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -7238,6 +7238,27 @@ func TestSyncAll_PersistsStartedAndFinishedAt(t *testing.T) {
 	require.NotEmpty(t, finishedRaw, "last_sync_finished_at not persisted")
 }
 
+func TestResyncAllPreservesPGPushMarkerID(t *testing.T) {
+	env := setupTestEnv(t)
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "hello").
+		AddClaudeAssistant(tsZeroS5, "hi").
+		String()
+	env.writeClaudeSession(t, "proj", "sess.jsonl", content)
+	env.engine.SyncAll(context.Background(), nil)
+
+	require.NoError(t, env.db.SetSyncState("pg_push_marker_id", "marker-123"),
+		"SetSyncState pg_push_marker_id")
+
+	stats := env.engine.ResyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "ResyncAll aborted: %+v", stats)
+
+	got, err := env.db.GetSyncState("pg_push_marker_id")
+	require.NoError(t, err, "GetSyncState pg_push_marker_id after resync")
+	assert.Equal(t, "marker-123", got)
+}
+
 func TestSyncAllOpenCodeExcludedNotCountedAsFailed(
 	t *testing.T,
 ) {


### PR DESCRIPTION
# fix(postgres): guard pg push against same-id cross-machine row collision

## Summary

- Adds stable per-local-DB ownership for PostgreSQL-pushed sessions, using `pg_push_marker_id` rather than the mutable `machine` string to decide whether a row belongs to this pusher.
- Moves the collision guard into the `ON CONFLICT ... DO UPDATE WHERE` path and uses `RowsAffected` plus an ownership re-read to detect skipped conflicts atomically.
- Preserves the legacy same-host repair paths: rows pushed with `machine = 'local'` can still be adopted and repaired to the resolved machine name, and existing unmarked same-machine rows can be marked on upgrade.
- Surfaces ownership skips through `PushResult.SkippedConflicts` and `PushProgress.SkippedConflicts` instead of only logging.
- Preserves `pg_push_marker_id` across full local resyncs, treats legacy DBs without `pg_sync_state` as a clean no-op, and aborts the resync swap if sync-state copy fails after the old DB is quiesced.

## Scope

Changed files:

- `internal/postgres/schema.go`, `internal/postgres/schema_test.go` - add and verify `sessions.owner_marker`.
- `internal/postgres/push.go`, `internal/postgres/push_test.go`, `internal/postgres/push_pgtest_test.go`, `internal/postgres/collision_pgtest_test.go` - owner-marker collision handling, atomic guarded upsert, skipped-conflict reporting, legacy local-sentinel adoption, and regression coverage.
- `internal/db/orphaned.go`, `internal/db/db_test.go` - copy `pg_sync_state` across resync swaps, including legacy missing-table and real-error behavior.
- `internal/sync/engine.go`, `internal/sync/engine_integration_test.go` - preserve the push marker through `ResyncAll` and abort the swap if durable sync-state copy fails.

No read-side scoping change is included here. The PR stays focused on preventing PostgreSQL push from overwriting another local DB's row and messages when the same session ID exists in two places.

## Validation

Focused checks run locally:

```
go test -tags "fts5,kit_posthog_disabled" ./internal/db/... -run "CopySyncStateFrom|CopyExcludedSessionsFrom" -count=1
go test -tags "fts5,kit_posthog_disabled" ./internal/sync/... -run "ResyncAll.*PGPushMarkerID" -count=1
go test -tags "fts5,pgtest" ./internal/postgres/... -run "TestPushSessionGuardsAgainstCrossMachineCollision|TestPushSessionAllowsMachineRenameForSameOwnerMarker|TestPushSessionAdoptsLegacyLocalSentinelRow|TestPushReportsSkippedConflicts|TestPushUpdatesSentinelMachineWhenSyncMachineChanges" -count=1
go vet ./internal/db/...
go vet ./internal/postgres/...
go vet ./internal/sync/...
```

Fixes #655
