### PR TITLE
fix(db): promote orphan subagent sessions to sidebar roots

### DIFF
--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -560,9 +560,9 @@ func TestIncludeChildrenExcludesOrphanSubagents(t *testing.T) {
 	requireSessions(t, d, f, []string{"root", "root-sub"})
 }
 
-// TestIncludeOrphansPromotesToRoot verifies that orphan subagent and fork
-// sessions surface as synthetic roots when IncludeOrphans is enabled, and
-// remain hidden when IncludeOrphans is false (default).
+// TestIncludeOrphansPromotesToRoot verifies that canonical orphan rows
+// surface as synthetic roots when IncludeOrphans is enabled, and remain
+// hidden when IncludeOrphans is false.
 func TestIncludeOrphansPromotesToRoot(t *testing.T) {
 	d := testDB(t)
 
@@ -623,7 +623,7 @@ func TestIncludeOrphansPromotesToRoot(t *testing.T) {
 		{
 			name:           "WithoutIncludeOrphans",
 			includeOrphans: false,
-			want:           []string{"root", "root-sub", "continuation-orphan"},
+			want:           []string{"root", "root-sub"},
 		},
 	}
 
@@ -1285,6 +1285,59 @@ func TestSidebarSessionIndexPagedPromotesNestedOrphans(t *testing.T) {
 	require.Equal(t, 3, index.Total, "total paged root groups")
 	require.NotEmpty(t, index.NextCursor, "paged sidebar should expose a next cursor when more root groups remain")
 	requireSidebarIndexIDs(t, index.Sessions, []string{"root", "orphan-sub", "orphan-fork"})
+}
+
+func TestSidebarSessionIndexPagedExcludesContinuationWithSoftDeletedParent(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "root", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-20T00:00:00Z")
+		s.MessageCount = 5
+		s.UserMessageCount = 2
+	})
+	insertSession(t, d, "deleted-parent", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-19T00:00:00Z")
+		s.MessageCount = 5
+		s.UserMessageCount = 2
+	})
+	require.NoError(t, d.SoftDeleteSession("deleted-parent"), "SoftDeleteSession")
+	insertSession(t, d, "continuation-child", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-18T00:00:00Z")
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("deleted-parent")
+		s.RelationshipType = "continuation"
+	})
+
+	index, err := d.GetSidebarSessionIndex(ctx, SessionFilter{Limit: 10})
+	requireNoError(t, err, "GetSidebarSessionIndex")
+	require.Equal(t, 1, index.Total, "soft-deleted parent should not promote continuation root")
+	requireSidebarIndexIDs(t, index.Sessions, []string{"root"})
+}
+
+func TestSidebarSessionIndexPagedKeepsContinuationUnderLiveParent(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "root", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-20T00:00:00Z")
+		s.MessageCount = 5
+		s.UserMessageCount = 2
+	})
+	insertSession(t, d, "continuation-child", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-19T00:00:00Z")
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("root")
+		s.RelationshipType = "continuation"
+	})
+
+	index, err := d.GetSidebarSessionIndex(ctx, SessionFilter{Limit: 1})
+	requireNoError(t, err, "GetSidebarSessionIndex")
+	require.Equal(t, 1, index.Total, "live continuation should stay nested")
+	require.Empty(t, index.NextCursor, "only one root group exists")
+	requireSidebarIndexIDs(t, index.Sessions, []string{"root", "continuation-child"})
 }
 
 func TestSidebarSessionIndexReturnsDisplayName(t *testing.T) {

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -594,6 +594,20 @@ func TestIncludeOrphansPromotesToRoot(t *testing.T) {
 		s.RelationshipType = "fork"
 	})
 
+	insertSession(t, d, "orphan-grandchild", "proj", func(s *Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("orphan-sub")
+		s.RelationshipType = "fork"
+	})
+
+	insertSession(t, d, "continuation-orphan", "proj", func(s *Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("missing-continuation-parent")
+		s.RelationshipType = "continuation"
+	})
+
 	tests := []struct {
 		name           string
 		includeOrphans bool
@@ -603,13 +617,13 @@ func TestIncludeOrphansPromotesToRoot(t *testing.T) {
 			name:           "WithIncludeOrphans",
 			includeOrphans: true,
 			want: []string{
-				"root", "root-sub", "orphan-sub", "orphan-fork",
+				"root", "root-sub", "orphan-sub", "orphan-fork", "orphan-grandchild", "continuation-orphan",
 			},
 		},
 		{
 			name:           "WithoutIncludeOrphans",
 			includeOrphans: false,
-			want:           []string{"root", "root-sub"},
+			want:           []string{"root", "root-sub", "continuation-orphan"},
 		},
 	}
 
@@ -1233,6 +1247,44 @@ func TestSidebarSessionIndexStarredIncludesStarredDescendantRoot(t *testing.T) {
 	require.Empty(t, index.NextCursor)
 	require.Equal(t, 1, index.Total, "total starred root groups")
 	requireSidebarIndexIDs(t, index.Sessions, []string{"root", "starred-child"})
+}
+
+func TestSidebarSessionIndexPagedPromotesNestedOrphans(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "root", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-20T00:00:00Z")
+		s.MessageCount = 5
+		s.UserMessageCount = 2
+	})
+	insertSession(t, d, "orphan-sub", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-19T00:00:00Z")
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("missing-parent")
+		s.RelationshipType = "subagent"
+	})
+	insertSession(t, d, "orphan-fork", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-18T00:00:00Z")
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("orphan-sub")
+		s.RelationshipType = "fork"
+	})
+	insertSession(t, d, "continuation-orphan", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-17T00:00:00Z")
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("missing-continuation-parent")
+		s.RelationshipType = "continuation"
+	})
+
+	index, err := d.GetSidebarSessionIndex(ctx, SessionFilter{Limit: 2})
+	requireNoError(t, err, "GetSidebarSessionIndex")
+	require.Equal(t, 3, index.Total, "total paged root groups")
+	require.NotEmpty(t, index.NextCursor, "paged sidebar should expose a next cursor when more root groups remain")
+	requireSidebarIndexIDs(t, index.Sessions, []string{"root", "orphan-sub", "orphan-fork"})
 }
 
 func TestSidebarSessionIndexReturnsDisplayName(t *testing.T) {

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -560,6 +560,109 @@ func TestIncludeChildrenExcludesOrphanSubagents(t *testing.T) {
 	requireSessions(t, d, f, []string{"root", "root-sub"})
 }
 
+// TestIncludeOrphansPromotesToRoot verifies that orphan subagent and fork
+// sessions surface as synthetic roots when IncludeOrphans is enabled, and
+// remain hidden when IncludeOrphans is false (default).
+func TestIncludeOrphansPromotesToRoot(t *testing.T) {
+	d := testDB(t)
+
+	// Control: legitimate root with a subagent child.
+	insertSession(t, d, "root", "proj", func(s *Session) {
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+	insertSession(t, d, "root-sub", "proj", func(s *Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("root")
+		s.RelationshipType = "subagent"
+	})
+
+	// Orphan subagent: parent doesn't exist in DB.
+	insertSession(t, d, "orphan-sub", "proj", func(s *Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("missing-parent")
+		s.RelationshipType = "subagent"
+	})
+
+	// Orphan fork: parent doesn't exist in DB.
+	insertSession(t, d, "orphan-fork", "proj", func(s *Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("also-missing")
+		s.RelationshipType = "fork"
+	})
+
+	tests := []struct {
+		name           string
+		includeOrphans bool
+		want           []string
+	}{
+		{
+			name:           "WithIncludeOrphans",
+			includeOrphans: true,
+			want: []string{
+				"root", "root-sub", "orphan-sub", "orphan-fork",
+			},
+		},
+		{
+			name:           "WithoutIncludeOrphans",
+			includeOrphans: false,
+			want:           []string{"root", "root-sub"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := SessionFilter{
+				IncludeChildren: true,
+				IncludeOrphans:  tt.includeOrphans,
+			}
+			requireSessions(t, d, f, tt.want)
+		})
+	}
+}
+
+// TestIncludeOrphansWithExcludeAutomated verifies that when both
+// IncludeOrphans and ExcludeAutomated are set, automated orphans
+// are still excluded while non-automated orphans are promoted to roots.
+func TestIncludeOrphansWithExcludeAutomated(t *testing.T) {
+	d := testDB(t)
+
+	// Non-automated root.
+	insertSession(t, d, "root", "proj", func(s *Session) {
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+
+	// Non-automated orphan subagent — should be included.
+	insertSession(t, d, "orphan-sub", "proj", func(s *Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("missing-parent")
+		s.RelationshipType = "subagent"
+	})
+
+	// Automated orphan fork — should be excluded.
+	fm := "You are a code reviewer. Review the code."
+	insertSession(t, d, "orphan-auto-fork", "proj", func(s *Session) {
+		s.FirstMessage = &fm
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = new("also-missing")
+		s.RelationshipType = "fork"
+	})
+
+	f := SessionFilter{
+		IncludeChildren:  true,
+		IncludeOrphans:   true,
+		ExcludeAutomated: true,
+	}
+	// Expected: root + non-automated orphan-sub, automated orphan-auto-fork excluded.
+	requireSessions(t, d, f, []string{"root", "orphan-sub"})
+}
+
 // TestIncludeChildrenKeepsNestedDescendants guards against a
 // regression where a fork spawned inside a subagent thread
 // (root → subagent → fork) was dropped. The direct-match side

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -28,23 +28,24 @@ const (
 // ORM: callers still own SELECTs, JOINs, backend-specific search paths, and
 // table schemas.
 type QueryDialect struct {
-	name                      string
-	placeholderStyle          placeholderStyle
-	trueLiteral               string
-	falseLiteral              string
-	dateExpr                  string
-	dateParam                 func(string) string
-	activityExpr              string
-	activityParam             func(string) string
-	cursorActivityExpr        string
-	cursorParam               func(string) string
-	terminationExpr           string
-	terminationKind           timestampKind
-	caseInsensitiveLike       string
-	caseInsensitiveLikeEsc    string
-	regexPredicate            func(string, string) string
-	sidebarChildRelationships []string
-	nullsLast                 bool
+	name                        string
+	placeholderStyle            placeholderStyle
+	trueLiteral                 string
+	falseLiteral                string
+	dateExpr                    string
+	dateParam                   func(string) string
+	activityExpr                string
+	activityParam               func(string) string
+	cursorActivityExpr          string
+	cursorParam                 func(string) string
+	terminationExpr             string
+	terminationKind             timestampKind
+	caseInsensitiveLike         string
+	caseInsensitiveLikeEsc      string
+	regexPredicate              func(string, string) string
+	sidebarChildRelationships   []string
+	canonicalChildRelationships []string
+	nullsLast                   bool
 }
 
 // SQLiteQueryDialect returns the SQLite SQL fragments used by the local store.
@@ -68,7 +69,8 @@ func SQLiteQueryDialect() QueryDialect {
 		regexPredicate: func(col, ph string) string {
 			return col + " REGEXP " + ph
 		},
-		sidebarChildRelationships: []string{"subagent", "fork"},
+		sidebarChildRelationships:   []string{"subagent", "fork"},
+		canonicalChildRelationships: []string{"subagent", "fork", "continuation"},
 	}
 }
 
@@ -98,8 +100,9 @@ func PostgresQueryDialect() QueryDialect {
 		regexPredicate: func(col, ph string) string {
 			return col + " ~* " + ph
 		},
-		sidebarChildRelationships: []string{"subagent", "fork"},
-		nullsLast:                 true,
+		sidebarChildRelationships:   []string{"subagent", "fork"},
+		canonicalChildRelationships: []string{"subagent", "fork", "continuation"},
+		nullsLast:                   true,
 	}
 }
 
@@ -269,8 +272,20 @@ func (d QueryDialect) SidebarChildRelationshipsSQL() string {
 	return strings.Join(quoted, ", ")
 }
 
+func (d QueryDialect) CanonicalChildRelationshipsSQL() string {
+	quoted := make([]string, 0, len(d.canonicalChildRelationships))
+	for _, rel := range d.canonicalChildRelationships {
+		quoted = append(quoted, "'"+rel+"'")
+	}
+	return strings.Join(quoted, ", ")
+}
+
 func SidebarChildRelationshipPredicate(dialect QueryDialect, sessionAlias string) string {
 	return sessionAlias + ".relationship_type IN (" + dialect.SidebarChildRelationshipsSQL() + ")"
+}
+
+func CanonicalChildRelationshipPredicate(dialect QueryDialect, sessionAlias string) string {
+	return sessionAlias + ".relationship_type IN (" + dialect.CanonicalChildRelationshipsSQL() + ")"
 }
 
 func SidebarOrphanPredicate(sessionAlias, parentAlias string) string {
@@ -282,7 +297,7 @@ func SidebarOrphanPredicate(sessionAlias, parentAlias string) string {
 }
 
 func BuildCanonicalRootWhere(dialect QueryDialect, sessionAlias string, includeOrphans bool) string {
-	base := `NOT (` + SidebarChildRelationshipPredicate(dialect, sessionAlias) + ` AND NOT ` +
+	base := `NOT (` + CanonicalChildRelationshipPredicate(dialect, sessionAlias) + ` AND NOT ` +
 		SidebarOrphanPredicate(sessionAlias, "parent") + `)`
 	if !includeOrphans {
 		return base

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -278,11 +278,33 @@ func buildSessionFilterWithBuilder(
 		"root_session.relationship_type NOT IN ('subagent', 'fork')")
 	rootMatch := strings.Join(rootMatchParts, " AND ")
 
-	cte := "WITH RECURSIVE tree(id) AS (" +
-		"SELECT root_session.id FROM sessions root_session" +
+	// Build the CTE base case. When IncludeOrphans is true, also seed with
+	// orphan child rows (those whose parent doesn't exist in the DB).
+	cteBase := "SELECT root_session.id FROM sessions root_session" +
 		" WHERE root_session.message_count > 0" +
 		" AND root_session.deleted_at IS NULL AND " +
-		rootMatch +
+		rootMatch
+	if f.IncludeOrphans {
+		orphanFilter, orphanOneShotPred := sessionFilterPredicates(f, b, func(col string) string {
+			return "orphan_child." + col
+		})
+		orphanMatchParts := append([]string{}, orphanFilter...)
+		if orphanOneShotPred != "" {
+			orphanMatchParts = append(orphanMatchParts, orphanOneShotPred)
+		}
+		orphanMatchParts = append(orphanMatchParts,
+			"orphan_child.relationship_type IN ('subagent', 'fork', 'continuation')",
+			"NOT EXISTS (SELECT 1 FROM sessions p WHERE p.id = orphan_child.parent_session_id)")
+		orphanMatch := strings.Join(orphanMatchParts, " AND ")
+		cteBase += " UNION " +
+			"SELECT orphan_child.id FROM sessions orphan_child" +
+			" WHERE orphan_child.message_count > 0" +
+			" AND orphan_child.deleted_at IS NULL AND " +
+			orphanMatch
+	}
+
+	cte := "WITH RECURSIVE tree(id) AS (" +
+		cteBase +
 		" UNION " +
 		"SELECT s.id FROM sessions s" +
 		" JOIN tree t ON s.parent_session_id = t.id" +
@@ -389,6 +411,25 @@ func sessionFilterPredicates(
 				q("id")+")")
 	}
 	return preds, oneShotPred
+}
+
+// buildSessionBaseFilter returns a WHERE clause and args containing the base
+// predicates (message_count > 0, deleted_at IS NULL) plus user-facing filter
+// predicates (project, machine, agent, date, etc.) WITHOUT the relationship_type
+// exclusion. Callers that handle root-vs-child discrimination externally (e.g.
+// via buildCanonicalRootWhere) should use this instead of buildSessionFilter.
+func buildSessionBaseFilter(f SessionFilter) (string, []any) {
+	b := NewQueryBuilder(SQLiteQueryDialect(), 0)
+	preds := []string{
+		"message_count > 0",
+		"deleted_at IS NULL",
+	}
+	filterPreds, oneShotPred := sessionFilterPredicates(f, b, func(col string) string { return col })
+	preds = append(preds, filterPreds...)
+	if oneShotPred != "" {
+		preds = append(preds, oneShotPred)
+	}
+	return strings.Join(preds, " AND "), b.Args()
 }
 
 func inPredicate(col string, values []string, b *QueryBuilder) string {

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -131,8 +131,9 @@ func DuckDBQueryDialect() QueryDialect {
 		regexPredicate: func(col, ph string) string {
 			return "regexp_matches(" + col + ", " + ph + ")"
 		},
-		sidebarChildRelationships: []string{"subagent", "fork"},
-		nullsLast:                 true,
+		sidebarChildRelationships:   []string{"subagent", "fork"},
+		canonicalChildRelationships: []string{"subagent", "fork", "continuation"},
+		nullsLast:                   true,
 	}
 }
 
@@ -297,13 +298,12 @@ func SidebarOrphanPredicate(sessionAlias, parentAlias string) string {
 }
 
 func BuildCanonicalRootWhere(dialect QueryDialect, sessionAlias string, includeOrphans bool) string {
-	base := `NOT (` + CanonicalChildRelationshipPredicate(dialect, sessionAlias) + ` AND NOT ` +
-		SidebarOrphanPredicate(sessionAlias, "parent") + `)`
+	base := `NOT (` + CanonicalChildRelationshipPredicate(dialect, sessionAlias) + `)`
 	if !includeOrphans {
 		return base
 	}
 	return `(` + base + ` OR (` +
-		SidebarChildRelationshipPredicate(dialect, sessionAlias) + ` AND ` +
+		CanonicalChildRelationshipPredicate(dialect, sessionAlias) + ` AND ` +
 		SidebarOrphanPredicate(sessionAlias, "parent") + `))`
 }
 
@@ -344,36 +344,14 @@ func buildSessionFilterWithBuilder(
 		rootMatchParts = append(rootMatchParts, oneShotPred)
 	}
 	rootMatchParts = append(rootMatchParts,
-		"NOT "+SidebarChildRelationshipPredicate(b.dialect, "root_session"))
+		BuildCanonicalRootWhere(b.dialect, "root_session", f.IncludeOrphans))
 	rootMatch := strings.Join(rootMatchParts, " AND ")
 
-	// Build the CTE base case. When IncludeOrphans is true, also seed with
-	// orphan child rows (those whose parent doesn't exist in the DB).
-	cteBase := "SELECT root_session.id FROM sessions root_session" +
+	cte := "WITH RECURSIVE tree(id) AS (" +
+		"SELECT root_session.id FROM sessions root_session" +
 		" WHERE root_session.message_count > 0" +
 		" AND root_session.deleted_at IS NULL AND " +
-		rootMatch
-	if f.IncludeOrphans {
-		orphanFilter, orphanOneShotPred := sessionFilterPredicates(f, b, func(col string) string {
-			return "orphan_child." + col
-		})
-		orphanMatchParts := append([]string{}, orphanFilter...)
-		if orphanOneShotPred != "" {
-			orphanMatchParts = append(orphanMatchParts, orphanOneShotPred)
-		}
-		orphanMatchParts = append(orphanMatchParts,
-			SidebarChildRelationshipPredicate(b.dialect, "orphan_child"),
-			SidebarOrphanPredicate("orphan_child", "p"))
-		orphanMatch := strings.Join(orphanMatchParts, " AND ")
-		cteBase += " UNION " +
-			"SELECT orphan_child.id FROM sessions orphan_child" +
-			" WHERE orphan_child.message_count > 0" +
-			" AND orphan_child.deleted_at IS NULL AND " +
-			orphanMatch
-	}
-
-	cte := "WITH RECURSIVE tree(id) AS (" +
-		cteBase +
+		rootMatch +
 		" UNION " +
 		"SELECT s.id FROM sessions s" +
 		" JOIN tree t ON s.parent_session_id = t.id" +

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -275,7 +275,7 @@ func buildSessionFilterWithBuilder(
 		rootMatchParts = append(rootMatchParts, oneShotPred)
 	}
 	rootMatchParts = append(rootMatchParts,
-		"root_session.relationship_type NOT IN ('subagent', 'fork')")
+		"NOT "+sidebarChildRelationshipPredicate("root_session"))
 	rootMatch := strings.Join(rootMatchParts, " AND ")
 
 	// Build the CTE base case. When IncludeOrphans is true, also seed with
@@ -293,8 +293,8 @@ func buildSessionFilterWithBuilder(
 			orphanMatchParts = append(orphanMatchParts, orphanOneShotPred)
 		}
 		orphanMatchParts = append(orphanMatchParts,
-			"orphan_child.relationship_type IN ('subagent', 'fork', 'continuation')",
-			"NOT EXISTS (SELECT 1 FROM sessions p WHERE p.id = orphan_child.parent_session_id)")
+			sidebarChildRelationshipPredicate("orphan_child"),
+			sidebarOrphanPredicate("orphan_child", "p"))
 		orphanMatch := strings.Join(orphanMatchParts, " AND ")
 		cteBase += " UNION " +
 			"SELECT orphan_child.id FROM sessions orphan_child" +

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -28,22 +28,23 @@ const (
 // ORM: callers still own SELECTs, JOINs, backend-specific search paths, and
 // table schemas.
 type QueryDialect struct {
-	name                   string
-	placeholderStyle       placeholderStyle
-	trueLiteral            string
-	falseLiteral           string
-	dateExpr               string
-	dateParam              func(string) string
-	activityExpr           string
-	activityParam          func(string) string
-	cursorActivityExpr     string
-	cursorParam            func(string) string
-	terminationExpr        string
-	terminationKind        timestampKind
-	caseInsensitiveLike    string
-	caseInsensitiveLikeEsc string
-	regexPredicate         func(string, string) string
-	nullsLast              bool
+	name                      string
+	placeholderStyle          placeholderStyle
+	trueLiteral               string
+	falseLiteral              string
+	dateExpr                  string
+	dateParam                 func(string) string
+	activityExpr              string
+	activityParam             func(string) string
+	cursorActivityExpr        string
+	cursorParam               func(string) string
+	terminationExpr           string
+	terminationKind           timestampKind
+	caseInsensitiveLike       string
+	caseInsensitiveLikeEsc    string
+	regexPredicate            func(string, string) string
+	sidebarChildRelationships []string
+	nullsLast                 bool
 }
 
 // SQLiteQueryDialect returns the SQLite SQL fragments used by the local store.
@@ -67,6 +68,7 @@ func SQLiteQueryDialect() QueryDialect {
 		regexPredicate: func(col, ph string) string {
 			return col + " REGEXP " + ph
 		},
+		sidebarChildRelationships: []string{"subagent", "fork"},
 	}
 }
 
@@ -96,7 +98,8 @@ func PostgresQueryDialect() QueryDialect {
 		regexPredicate: func(col, ph string) string {
 			return col + " ~* " + ph
 		},
-		nullsLast: true,
+		sidebarChildRelationships: []string{"subagent", "fork"},
+		nullsLast:                 true,
 	}
 }
 
@@ -125,7 +128,8 @@ func DuckDBQueryDialect() QueryDialect {
 		regexPredicate: func(col, ph string) string {
 			return "regexp_matches(" + col + ", " + ph + ")"
 		},
-		nullsLast: true,
+		sidebarChildRelationships: []string{"subagent", "fork"},
+		nullsLast:                 true,
 	}
 }
 
@@ -238,6 +242,56 @@ func BuildSessionFilterSQL(
 	return where, b.Args()
 }
 
+// BuildSessionBaseFilterSQL returns the base sidebar/list predicates without the
+// child-relationship exclusion. Callers that handle root-vs-child selection
+// separately should use this to avoid diverging filter logic across backends.
+func BuildSessionBaseFilterSQL(
+	f SessionFilter, dialect QueryDialect,
+) (string, []any) {
+	b := NewQueryBuilder(dialect, 0)
+	preds := []string{
+		"message_count > 0",
+		"deleted_at IS NULL",
+	}
+	filterPreds, oneShotPred := sessionFilterPredicates(f, b, func(col string) string { return col })
+	preds = append(preds, filterPreds...)
+	if oneShotPred != "" {
+		preds = append(preds, oneShotPred)
+	}
+	return strings.Join(preds, " AND "), b.Args()
+}
+
+func (d QueryDialect) SidebarChildRelationshipsSQL() string {
+	quoted := make([]string, 0, len(d.sidebarChildRelationships))
+	for _, rel := range d.sidebarChildRelationships {
+		quoted = append(quoted, "'"+rel+"'")
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func SidebarChildRelationshipPredicate(dialect QueryDialect, sessionAlias string) string {
+	return sessionAlias + ".relationship_type IN (" + dialect.SidebarChildRelationshipsSQL() + ")"
+}
+
+func SidebarOrphanPredicate(sessionAlias, parentAlias string) string {
+	return `NOT EXISTS (
+			SELECT 1
+			FROM sessions ` + parentAlias + `
+			WHERE ` + parentAlias + `.id = ` + sessionAlias + `.parent_session_id
+		)`
+}
+
+func BuildCanonicalRootWhere(dialect QueryDialect, sessionAlias string, includeOrphans bool) string {
+	base := `NOT (` + SidebarChildRelationshipPredicate(dialect, sessionAlias) + ` AND NOT ` +
+		SidebarOrphanPredicate(sessionAlias, "parent") + `)`
+	if !includeOrphans {
+		return base
+	}
+	return `(` + base + ` OR (` +
+		SidebarChildRelationshipPredicate(dialect, sessionAlias) + ` AND ` +
+		SidebarOrphanPredicate(sessionAlias, "parent") + `))`
+}
+
 func buildSessionFilterWithBuilder(
 	f SessionFilter, b *QueryBuilder, qualifier string,
 ) string {
@@ -254,7 +308,7 @@ func buildSessionFilterWithBuilder(
 	}
 	if !f.IncludeChildren {
 		basePreds = append(basePreds,
-			q("relationship_type")+" NOT IN ('subagent', 'fork')")
+			q("relationship_type")+" NOT IN ("+b.dialect.SidebarChildRelationshipsSQL()+")")
 	}
 
 	if !f.IncludeChildren {
@@ -275,7 +329,7 @@ func buildSessionFilterWithBuilder(
 		rootMatchParts = append(rootMatchParts, oneShotPred)
 	}
 	rootMatchParts = append(rootMatchParts,
-		"NOT "+sidebarChildRelationshipPredicate("root_session"))
+		"NOT "+SidebarChildRelationshipPredicate(b.dialect, "root_session"))
 	rootMatch := strings.Join(rootMatchParts, " AND ")
 
 	// Build the CTE base case. When IncludeOrphans is true, also seed with
@@ -293,8 +347,8 @@ func buildSessionFilterWithBuilder(
 			orphanMatchParts = append(orphanMatchParts, orphanOneShotPred)
 		}
 		orphanMatchParts = append(orphanMatchParts,
-			sidebarChildRelationshipPredicate("orphan_child"),
-			sidebarOrphanPredicate("orphan_child", "p"))
+			SidebarChildRelationshipPredicate(b.dialect, "orphan_child"),
+			SidebarOrphanPredicate("orphan_child", "p"))
 		orphanMatch := strings.Join(orphanMatchParts, " AND ")
 		cteBase += " UNION " +
 			"SELECT orphan_child.id FROM sessions orphan_child" +
@@ -419,17 +473,7 @@ func sessionFilterPredicates(
 // exclusion. Callers that handle root-vs-child discrimination externally (e.g.
 // via buildCanonicalRootWhere) should use this instead of buildSessionFilter.
 func buildSessionBaseFilter(f SessionFilter) (string, []any) {
-	b := NewQueryBuilder(SQLiteQueryDialect(), 0)
-	preds := []string{
-		"message_count > 0",
-		"deleted_at IS NULL",
-	}
-	filterPreds, oneShotPred := sessionFilterPredicates(f, b, func(col string) string { return col })
-	preds = append(preds, filterPreds...)
-	if oneShotPred != "" {
-		preds = append(preds, oneShotPred)
-	}
-	return strings.Join(preds, " AND "), b.Args()
+	return BuildSessionBaseFilterSQL(f, SQLiteQueryDialect())
 }
 
 func inPredicate(col string, values []string, b *QueryBuilder) string {

--- a/internal/db/query_dialect_test.go
+++ b/internal/db/query_dialect_test.go
@@ -171,7 +171,7 @@ func TestBuildSessionFilterSQLRendersIncludeChildrenCTE(t *testing.T) {
 			assert.Contains(t, normalized, "JOIN tree t ON s.parent_session_id = t.id")
 			assert.Contains(t, normalized, "id IN (WITH RECURSIVE tree(id) AS")
 			assert.Contains(t, normalized,
-				"root_session.relationship_type NOT IN ('subagent', 'fork')")
+				"NOT root_session.relationship_type IN ('subagent', 'fork')")
 			assert.NotContains(t, normalized,
 				"relationship_type NOT IN ('subagent', 'fork') AND id IN")
 			assert.Equal(t, tt.wantArgs, args)

--- a/internal/db/query_dialect_test.go
+++ b/internal/db/query_dialect_test.go
@@ -171,7 +171,7 @@ func TestBuildSessionFilterSQLRendersIncludeChildrenCTE(t *testing.T) {
 			assert.Contains(t, normalized, "JOIN tree t ON s.parent_session_id = t.id")
 			assert.Contains(t, normalized, "id IN (WITH RECURSIVE tree(id) AS")
 			assert.Contains(t, normalized,
-				"NOT root_session.relationship_type IN ('subagent', 'fork')")
+				"NOT (root_session.relationship_type IN ('subagent', 'fork', 'continuation'))")
 			assert.NotContains(t, normalized,
 				"relationship_type NOT IN ('subagent', 'fork') AND id IN")
 			assert.Equal(t, tt.wantArgs, args)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -589,6 +589,7 @@ func (db *DB) getSidebarSessionIndexPage(
 	rootFilter := f
 	rootFilter.Cursor = ""
 	rootFilter.Starred = false
+	rootFilter.IncludeChildren = false
 	rootWhere, rootArgs := buildSessionBaseFilter(rootFilter)
 	canonicalRootWhere := buildCanonicalRootWhere(f.IncludeOrphans)
 

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -333,7 +333,7 @@ const activityExprSQLite = "CAST(strftime('%s', " +
 const sidebarActivityExprSQLiteS = "COALESCE(" +
 	"NULLIF(s.ended_at, ''), NULLIF(s.started_at, ''), s.created_at)"
 
-const sidebarChildRelationshipsSQL = "'subagent', 'fork', 'continuation'"
+const sidebarChildRelationshipsSQL = "'subagent', 'fork'"
 
 func sidebarStarredRootCTE(enabled bool) string {
 	if !enabled {
@@ -354,29 +354,30 @@ func sidebarStarredRootJoin(enabled bool) string {
 	return "JOIN eligible_roots e ON e.id = t.root_id"
 }
 
-// buildCanonicalRootWhere returns a WHERE fragment that identifies canonical root
-// sessions (non-child sessions that appear in the sidebar). When includeOrphans is
-// false, it restricts to sessions whose parent either doesn't exist or is deleted.
-// When includeOrphans is true, it also promotes orphan child rows (missing parent)
-// to synthetic roots.
-func buildCanonicalRootWhere(includeOrphans bool) string {
-	base := `
-		NOT EXISTS (
+func sidebarChildRelationshipPredicate(sessionAlias string) string {
+	return sessionAlias + ".relationship_type IN (" + sidebarChildRelationshipsSQL + ")"
+}
+
+func sidebarOrphanPredicate(sessionAlias, parentAlias string) string {
+	return `NOT EXISTS (
 			SELECT 1
-			FROM sessions parent
-			WHERE parent.id = sessions.parent_session_id
-			  AND parent.deleted_at IS NULL
-			  AND sessions.relationship_type IN (` + sidebarChildRelationshipsSQL + `)
+			FROM sessions ` + parentAlias + `
+			WHERE ` + parentAlias + `.id = ` + sessionAlias + `.parent_session_id
 		)`
+}
+
+// buildCanonicalRootWhere returns a WHERE fragment that identifies canonical root
+// sessions for sidebar pagination. Child rows remain nested under their parent
+// unless IncludeOrphans explicitly promotes missing-parent child rows to roots.
+func buildCanonicalRootWhere(includeOrphans bool) string {
+	base := `NOT (` + sidebarChildRelationshipPredicate("sessions") + ` AND NOT ` +
+		sidebarOrphanPredicate("sessions", "parent") + `)`
 	if !includeOrphans {
 		return base
 	}
-	return `(` + base + `
-		OR NOT EXISTS (
-			SELECT 1
-			FROM sessions parent
-			WHERE parent.id = sessions.parent_session_id
-		))`
+	return `(` + base + ` OR (` +
+		sidebarChildRelationshipPredicate("sessions") + ` AND ` +
+		sidebarOrphanPredicate("sessions", "parent") + `))`
 }
 
 // buildTerminationPredSQLite returns a WHERE fragment and args for

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -296,6 +296,7 @@ type SessionFilter struct {
 	ExcludeOneShot   bool     // exclude sessions with user_message_count <= 1
 	ExcludeAutomated bool     // exclude sessions where is_automated = 1
 	IncludeChildren  bool     // include subagent sessions (for sidebar grouping)
+	IncludeOrphans   bool     // promote orphan child rows to sidebar roots
 	Outcome          []string // filter by outcome values
 	HealthGrade      []string // filter by health grade values
 	MinToolFailures  *int     // minimum tool_failure_signal_count
@@ -351,6 +352,31 @@ func sidebarStarredRootJoin(enabled bool) string {
 		return ""
 	}
 	return "JOIN eligible_roots e ON e.id = t.root_id"
+}
+
+// buildCanonicalRootWhere returns a WHERE fragment that identifies canonical root
+// sessions (non-child sessions that appear in the sidebar). When includeOrphans is
+// false, it restricts to sessions whose parent either doesn't exist or is deleted.
+// When includeOrphans is true, it also promotes orphan child rows (missing parent)
+// to synthetic roots.
+func buildCanonicalRootWhere(includeOrphans bool) string {
+	base := `
+		NOT EXISTS (
+			SELECT 1
+			FROM sessions parent
+			WHERE parent.id = sessions.parent_session_id
+			  AND parent.deleted_at IS NULL
+			  AND sessions.relationship_type IN (` + sidebarChildRelationshipsSQL + `)
+		)`
+	if !includeOrphans {
+		return base
+	}
+	return `(` + base + `
+		OR NOT EXISTS (
+			SELECT 1
+			FROM sessions parent
+			WHERE parent.id = sessions.parent_session_id
+		))`
 }
 
 // buildTerminationPredSQLite returns a WHERE fragment and args for
@@ -497,6 +523,7 @@ func (db *DB) GetSidebarSessionIndex(
 	ctx context.Context, f SessionFilter,
 ) (SidebarSessionIndex, error) {
 	f.IncludeChildren = true
+	f.IncludeOrphans = true
 
 	if f.Limit > 0 || f.Cursor != "" || f.Starred {
 		return db.getSidebarSessionIndexPage(ctx, f)
@@ -580,18 +607,10 @@ func (db *DB) getSidebarSessionIndexPage(
 	}
 
 	rootFilter := f
-	rootFilter.IncludeChildren = false
 	rootFilter.Cursor = ""
 	rootFilter.Starred = false
-	rootWhere, rootArgs := buildSessionFilter(rootFilter)
-	canonicalRootWhere := `
-		NOT EXISTS (
-			SELECT 1
-			FROM sessions parent
-			WHERE parent.id = sessions.parent_session_id
-			  AND parent.deleted_at IS NULL
-			  AND sessions.relationship_type IN (` + sidebarChildRelationshipsSQL + `)
-		)`
+	rootWhere, rootArgs := buildSessionBaseFilter(rootFilter)
+	canonicalRootWhere := buildCanonicalRootWhere(f.IncludeOrphans)
 
 	var total int
 	var cur SessionCursor

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -333,8 +333,6 @@ const activityExprSQLite = "CAST(strftime('%s', " +
 const sidebarActivityExprSQLiteS = "COALESCE(" +
 	"NULLIF(s.ended_at, ''), NULLIF(s.started_at, ''), s.created_at)"
 
-const sidebarChildRelationshipsSQL = "'subagent', 'fork'"
-
 func sidebarStarredRootCTE(enabled bool) string {
 	if !enabled {
 		return ""
@@ -354,30 +352,11 @@ func sidebarStarredRootJoin(enabled bool) string {
 	return "JOIN eligible_roots e ON e.id = t.root_id"
 }
 
-func sidebarChildRelationshipPredicate(sessionAlias string) string {
-	return sessionAlias + ".relationship_type IN (" + sidebarChildRelationshipsSQL + ")"
-}
-
-func sidebarOrphanPredicate(sessionAlias, parentAlias string) string {
-	return `NOT EXISTS (
-			SELECT 1
-			FROM sessions ` + parentAlias + `
-			WHERE ` + parentAlias + `.id = ` + sessionAlias + `.parent_session_id
-		)`
-}
-
 // buildCanonicalRootWhere returns a WHERE fragment that identifies canonical root
 // sessions for sidebar pagination. Child rows remain nested under their parent
 // unless IncludeOrphans explicitly promotes missing-parent child rows to roots.
 func buildCanonicalRootWhere(includeOrphans bool) string {
-	base := `NOT (` + sidebarChildRelationshipPredicate("sessions") + ` AND NOT ` +
-		sidebarOrphanPredicate("sessions", "parent") + `)`
-	if !includeOrphans {
-		return base
-	}
-	return `(` + base + ` OR (` +
-		sidebarChildRelationshipPredicate("sessions") + ` AND ` +
-		sidebarOrphanPredicate("sessions", "parent") + `))`
+	return BuildCanonicalRootWhere(SQLiteQueryDialect(), "sessions", includeOrphans)
 }
 
 // buildTerminationPredSQLite returns a WHERE fragment and args for

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -272,6 +272,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 
 func (s *Store) GetSidebarSessionIndex(ctx context.Context, f db.SessionFilter) (db.SidebarSessionIndex, error) {
 	f.IncludeChildren = true
+	f.IncludeOrphans = true
 	f.Cursor = ""
 	f.Limit = 0
 

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -81,8 +81,6 @@ const pgActivityExpr = "COALESCE(ended_at, started_at, created_at)"
 
 const pgSidebarActivityExprS = "COALESCE(s.ended_at, s.started_at, s.created_at)"
 
-const pgSidebarChildRelationshipsSQL = "'subagent', 'fork', 'continuation'"
-
 func pgSidebarStarredRootCTE(enabled bool) string {
 	if !enabled {
 		return ""
@@ -235,6 +233,12 @@ func buildPGSessionFilter(
 	f db.SessionFilter,
 ) (string, []any) {
 	return db.BuildSessionFilterSQL(f, db.PostgresQueryDialect())
+}
+
+func buildPGSessionBaseFilter(
+	f db.SessionFilter,
+) (string, []any) {
+	return db.BuildSessionBaseFilterSQL(f, db.PostgresQueryDialect())
 }
 
 // EncodeCursor returns a base64-encoded, HMAC-signed cursor.
@@ -421,6 +425,7 @@ func (s *Store) GetSidebarSessionIndex(
 	ctx context.Context, f db.SessionFilter,
 ) (db.SidebarSessionIndex, error) {
 	f.IncludeChildren = true
+	f.IncludeOrphans = true
 
 	if f.Limit > 0 || f.Cursor != "" || f.Starred {
 		return s.getSidebarSessionIndexPage(ctx, f)
@@ -482,15 +487,8 @@ func (s *Store) getSidebarSessionIndexPage(
 	rootFilter.IncludeChildren = false
 	rootFilter.Cursor = ""
 	rootFilter.Starred = false
-	rootWhere, rootArgs := buildPGSessionFilter(rootFilter)
-	canonicalRootWhere := `
-		NOT EXISTS (
-			SELECT 1
-			FROM sessions parent
-			WHERE parent.id = sessions.parent_session_id
-			  AND parent.deleted_at IS NULL
-			  AND sessions.relationship_type IN (` + pgSidebarChildRelationshipsSQL + `)
-		)`
+	rootWhere, rootArgs := buildPGSessionBaseFilter(rootFilter)
+	canonicalRootWhere := db.BuildCanonicalRootWhere(db.PostgresQueryDialect(), "sessions", f.IncludeOrphans)
 
 	var total int
 	var cur db.SessionCursor

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -224,17 +224,17 @@ func insertSidebarIndexSession(
 			id, machine, project, agent, first_message,
 			display_name, started_at, ended_at, message_count,
 			user_message_count, parent_session_id,
-			relationship_type, is_automated
+			relationship_type, is_automated, deleted_at
 		) VALUES (
 			$1, $2, $3, $4, $5,
 			$6, $7::timestamptz, $8::timestamptz, $9,
-			$10, $11, $12, $13
+			$10, $11, $12, $13, $14::timestamptz
 		)
 	`, row.id, row.machine, row.project, row.agent,
 		row.firstMessage, row.displayName, row.startedAt,
 		row.endedAt, row.messageCount, row.userMessageCount,
 		row.parentSessionID, row.relationshipType,
-		row.isAutomated)
+		row.isAutomated, row.deletedAt)
 	require.NoError(t, err, "inserting sidebar index session %s", id)
 }
 
@@ -252,6 +252,7 @@ type sidebarIndexSessionSeed struct {
 	parentSessionID  *string
 	relationshipType string
 	isAutomated      bool
+	deletedAt        *string
 }
 
 func sidebarIndexRowsByID(
@@ -591,6 +592,80 @@ func TestStoreGetSidebarSessionIndexStarredIncludesStarredDescendantRoot(
 	assert.Equal(t, 1, index.Total)
 	assert.ElementsMatch(t,
 		[]string{"root", "starred-child"},
+		sidebarIndexIDs(index.Sessions),
+	)
+}
+
+func TestStoreGetSidebarSessionIndexPaginatesOrphanRoots(t *testing.T) {
+	pgURL := testPGURL(t)
+	store := ensureSidebarIndexStoreSchema(t, pgURL)
+	defer store.Close()
+
+	insertSidebarIndexSession(t, store, "root", func(s *sidebarIndexSessionSeed) {
+		s.endedAt = "2024-01-20T00:00:00Z"
+		s.userMessageCount = 2
+	})
+	insertSidebarIndexSession(t, store, "orphan-sub", func(s *sidebarIndexSessionSeed) {
+		s.endedAt = "2024-01-19T00:00:00Z"
+		s.parentSessionID = strPtr("missing-parent")
+		s.relationshipType = "subagent"
+	})
+	insertSidebarIndexSession(t, store, "orphan-fork", func(s *sidebarIndexSessionSeed) {
+		s.endedAt = "2024-01-18T00:00:00Z"
+		s.parentSessionID = strPtr("orphan-sub")
+		s.relationshipType = "fork"
+	})
+	insertSidebarIndexSession(t, store, "continuation-orphan", func(s *sidebarIndexSessionSeed) {
+		s.endedAt = "2024-01-17T00:00:00Z"
+		s.parentSessionID = strPtr("missing-continuation-parent")
+		s.relationshipType = "continuation"
+	})
+
+	first, err := store.GetSidebarSessionIndex(
+		context.Background(), db.SessionFilter{Limit: 2},
+	)
+	require.NoError(t, err, "first page")
+	assert.Equal(t, 3, first.Total)
+	assert.NotEmpty(t, first.NextCursor)
+	assert.ElementsMatch(t,
+		[]string{"root", "orphan-sub", "orphan-fork"},
+		sidebarIndexIDs(first.Sessions),
+	)
+
+	second, err := store.GetSidebarSessionIndex(
+		context.Background(), db.SessionFilter{Limit: 2, Cursor: first.NextCursor},
+	)
+	require.NoError(t, err, "second page")
+	assert.Equal(t, 3, second.Total)
+	assert.Empty(t, second.NextCursor)
+	assert.Equal(t, []string{"continuation-orphan"}, sidebarIndexIDs(second.Sessions))
+}
+
+func TestStoreGetSidebarSessionIndexDoesNotPromoteSoftDeletedParentChildren(t *testing.T) {
+	pgURL := testPGURL(t)
+	store := ensureSidebarIndexStoreSchema(t, pgURL)
+	defer store.Close()
+
+	rootID := "soft-deleted-root"
+	insertSidebarIndexSession(t, store, rootID, func(s *sidebarIndexSessionSeed) {
+		s.endedAt = "2024-01-20T00:00:00Z"
+		s.deletedAt = strPtr("2024-01-21T00:00:00Z")
+	})
+	insertSidebarIndexSession(t, store, "child-of-deleted-parent", func(s *sidebarIndexSessionSeed) {
+		s.endedAt = "2024-01-19T00:00:00Z"
+		s.parentSessionID = &rootID
+		s.relationshipType = "subagent"
+	})
+	insertSidebarIndexSession(t, store, "other", func(s *sidebarIndexSessionSeed) {
+		s.endedAt = "2024-01-18T00:00:00Z"
+	})
+
+	index, err := store.GetSidebarSessionIndex(
+		context.Background(), db.SessionFilter{Limit: 10},
+	)
+	require.NoError(t, err, "GetSidebarSessionIndex")
+	assert.ElementsMatch(t,
+		[]string{"other"},
 		sidebarIndexIDs(index.Sessions),
 	)
 }


### PR DESCRIPTION
# fix(db): promote orphan subagent sessions to sidebar roots via IncludeOrphans flag

## Summary

- Adds `IncludeOrphans` to `SessionFilter` so sidebar reads can promote missing-parent canonical child sessions as synthetic roots instead of silently dropping them.
- Unifies canonical-root selection across the paginated and unpaginated sidebar paths, using the same canonical child relationship set for `subagent`, `fork`, and `continuation`.
- Keeps flat list behavior distinct from root grouping: `subagent` and `fork` remain hidden from normal root lists, while `continuation` stays attached to its live parent for sidebar grouping.
- Applies sidebar orphan behavior across SQLite, PostgreSQL, and DuckDB by setting `IncludeOrphans` in all three sidebar entrypoints.
- Adds paginated SQLite and PostgreSQL coverage for nested missing-parent orphans, soft-deleted-parent non-promotion, and live-parent continuation nesting.

## Scope

Changed files:

- `internal/db/sessions.go` - SQLite sidebar opts into orphan recovery and paginated roots compose base filtering with shared canonical-root logic.
- `internal/db/query_dialect.go`, `internal/db/query_dialect_test.go` - shared canonical-root predicates, dialect relationship sets, and SQL-shape coverage.
- `internal/db/filter_test.go` - SQLite orphan, continuation, and paginated sidebar regression coverage.
- `internal/postgres/sessions.go`, `internal/postgres/store_test.go` - PostgreSQL sidebar parity and pgtest coverage.
- `internal/duckdb/store.go` - DuckDB sidebar opts into orphan recovery and uses the populated canonical child set.

No schema change. No frontend change. No `dataVersion` bump required.

## Validation

Focused checks run locally:

```
go test -tags "fts5,kit_posthog_disabled" go.kenn.io/agentsview/internal/db -run "TestBuildSessionFilterSQLRendersIncludeChildrenCTE|TestIncludeOrphans|TestSidebarSessionIndex" -count=1
go test -tags "kit_posthog_disabled" go.kenn.io/agentsview/internal/duckdb -run "TestDuckDBStoreContract/sessions_cursors_and_metadata" -count=1
go test -tags "fts5,pgtest" ./internal/postgres/... -run "TestStoreGetSidebarSessionIndex.*Orphan|TestStoreGetSidebarSessionIndexPaginatesByDescendantFreshness|TestStoreGetSidebarSessionIndexPaginatesContinuationsAsDescendants" -count=1
go vet ./internal/db/...
go vet ./internal/postgres/...
```

Fixes #382
