### PR TITLE
feat(activity): add Activity reporting dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ Instructions for autonomous coding agents working in this repository.
 
 ## Required Git Rules
 
-1. Commit every turn.
+1. Commit every turn that changes tracked files.
+1. Do not make empty commits. If a turn is read-only or only changes ignored
+   files, state that no commit was made.
 1. Do not amend commits.
 1. Do not change branches without explicit user permission.
 

--- a/Makefile
+++ b/Makefile
@@ -245,11 +245,11 @@ test-postgres: ensure-embed-dir postgres-up
 	@echo "Waiting for postgres to be ready..."
 	@sleep 2
 	TEST_PG_URL="postgres://agentsview_test:agentsview_test_password@localhost:5433/agentsview_test?sslmode=disable" \
-		CGO_ENABLED=1 go test -tags "fts5,pgtest" -v ./internal/postgres/... -count=1
+		CGO_ENABLED=1 go test -tags "fts5,pgtest" -v ./internal/postgres/... ./internal/activity/... -count=1
 
 # PostgreSQL integration tests for CI (postgres already running as service)
 test-postgres-ci: ensure-embed-dir
-	CGO_ENABLED=1 go test -tags "fts5,pgtest" -v ./internal/postgres/... -count=1
+	CGO_ENABLED=1 go test -tags "fts5,pgtest" -v ./internal/postgres/... ./internal/activity/... -count=1
 
 # Start test SSH container
 ssh-up:

--- a/cmd/agentsview/activity.go
+++ b/cmd/agentsview/activity.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// ActivityReportConfig holds the flags for `agentsview activity report`.
+type ActivityReportConfig struct {
+	Preset   string
+	Date     string
+	From     string
+	To       string
+	Timezone string
+	Bucket   string
+	Project  string
+	Agent    string
+	Machine  string
+	JSON     bool
+	NoSync   bool
+	Offline  bool
+}
+
+// runActivityReport syncs, resolves the range, runs the report, and prints it.
+func runActivityReport(cfg ActivityReportConfig) {
+	database, appCfg := openUsageDB()
+	defer database.Close()
+
+	ensureFreshData(appCfg, database, cfg.NoSync)
+
+	r, err := resolveActivityReportPriced(cfg, database)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if cfg.JSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(r); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	printActivityReport(r)
+}
+
+// resolveActivityReportPriced seeds fallback pricing so fresh-DB token usage is
+// costed, then resolves the report. runActivityReport and the pricing test
+// share this seam so the test exercises the same seeding the command performs.
+func resolveActivityReportPriced(
+	cfg ActivityReportConfig, database *db.DB,
+) (activity.Report, error) {
+	ensurePricing(database, cfg.Offline)
+	return resolveActivityReport(cfg, database)
+}
+
+// resolveActivityReport defaults the timezone and date, resolves the range
+// query, and runs the report against the database. It is the testable seam:
+// all validation (timezone, bounds, bucket allow-list, range limits) happens
+// inside activity.ResolveQuery before any database query.
+func resolveActivityReport(
+	cfg ActivityReportConfig, database *db.DB,
+) (activity.Report, error) {
+	tz := cfg.Timezone
+	if tz == "" {
+		tz = localTimezone()
+	}
+
+	date := cfg.Date
+	if cfg.Preset != "custom" && cfg.From == "" && date == "" {
+		date = todayIn(tz)
+	}
+
+	input := activity.QueryInput{
+		Preset:         cfg.Preset,
+		Date:           date,
+		From:           cfg.From,
+		To:             cfg.To,
+		Timezone:       tz,
+		BucketOverride: cfg.Bucket,
+	}
+	q, err := activity.ResolveQuery(input, time.Now())
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	f := db.AnalyticsFilter{
+		Timezone:         tz,
+		Project:          cfg.Project,
+		Agent:            cfg.Agent,
+		Machine:          cfg.Machine,
+		ExcludeOneShot:   false,
+		ExcludeAutomated: false,
+	}
+	return database.GetActivityReport(context.Background(), f, q)
+}
+
+// todayIn returns today's date as YYYY-MM-DD in the given IANA timezone,
+// falling back to the local zone when tz is unknown.
+func todayIn(tz string) string {
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		loc = time.Local
+	}
+	return time.Now().In(loc).Format("2006-01-02")
+}
+
+// printActivityReport renders the human-readable report: a header, totals,
+// peak concurrency, top breakdowns, and top sessions. It deliberately omits
+// the dense per-bucket timeline, which only the --json output exposes.
+func printActivityReport(r activity.Report) {
+	loc, err := time.LoadLocation(r.Timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	fmt.Printf(
+		"Activity %s to %s (%s, %s buckets)\n",
+		fmtRangeBound(r.RangeStart, loc), fmtRangeBound(r.RangeEnd, loc),
+		r.Timezone, r.BucketUnit,
+	)
+	if r.Partial {
+		fmt.Printf("Partial range, data as of %s\n", fmtInstant(r.AsOf, loc))
+	}
+	fmt.Println()
+
+	printActivityTotals(r.Totals)
+	fmt.Println()
+	printActivityPeak(r.Peak, loc)
+	fmt.Println()
+	printKeyMinutes("By project", r.ByProject)
+	printKeyMinutes("By model", r.ByModel)
+	printKeyMinutes("By agent", r.ByAgent)
+	printActivitySessions(r.BySession)
+}
+
+// printActivityTotals prints the totals block via a tabwriter.
+func printActivityTotals(t activity.Totals) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintf(w, "Active minutes\t%.1f\n", t.ActiveMinutes)
+	fmt.Fprintf(w, "Idle minutes\t%.1f\n", t.IdleMinutes)
+	fmt.Fprintf(w, "Agent minutes\t%.1f\n", t.AgentMinutes)
+	fmt.Fprintf(w, "Sessions\t%d (%d untimed)\n", t.Sessions, t.UntimedSessions)
+	fmt.Fprintf(w, "Distinct projects\t%d\n", t.DistinctProjects)
+	fmt.Fprintf(w, "Distinct models\t%d\n", t.DistinctModels)
+	fmt.Fprintf(w, "Output tokens\t%d\n", t.OutputTokens)
+	fmt.Fprintf(w, "Cost\t%s\n", fmtCost(t.Cost))
+	w.Flush()
+}
+
+// printActivityPeak prints peak concurrency and when it occurred, in loc.
+func printActivityPeak(p activity.Peak, loc *time.Location) {
+	fmt.Printf("Peak concurrency: %d agents at %s\n",
+		p.Agents, fmtInstant(p.At, loc))
+}
+
+// printKeyMinutes prints the top 5 rows of a key/agent-minutes breakdown.
+func printKeyMinutes(label string, rows []activity.KeyMinutes) {
+	fmt.Printf("%s (top 5):\n", label)
+	if len(rows) == 0 {
+		fmt.Println("  (none)")
+		fmt.Println()
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	for _, row := range topKeyMinutes(rows, 5) {
+		fmt.Fprintf(w, "  %s\t%.1f min\n", row.Key, row.AgentMinutes)
+	}
+	w.Flush()
+	fmt.Println()
+}
+
+// printActivitySessions prints the top 5 sessions by appearance order.
+func printActivitySessions(rows []activity.SessionRow) {
+	fmt.Println("Top sessions (top 5):")
+	if len(rows) == 0 {
+		fmt.Println("  (none)")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "  TITLE\tPROJECT\tAGENT\tMINUTES\tCOST")
+	limit := min(len(rows), 5)
+	for _, s := range rows[:limit] {
+		fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n",
+			s.Title, s.Project, s.Agent,
+			fmtMinutes(s.AgentMinutes), fmtCost(s.Cost),
+		)
+	}
+	w.Flush()
+}
+
+// topKeyMinutes returns the first n rows of rows (already sorted by the query).
+func topKeyMinutes(rows []activity.KeyMinutes, n int) []activity.KeyMinutes {
+	return rows[:min(len(rows), n)]
+}
+
+// fmtRangeBound renders an RFC3339 range bound in loc, dropping the time
+// component when the local wall time is exactly midnight.
+func fmtRangeBound(ts string, loc *time.Location) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ts
+	}
+	t = t.In(loc)
+	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 {
+		return t.Format("2006-01-02")
+	}
+	return t.Format("2006-01-02 15:04")
+}
+
+// fmtMinutes renders an agent-minutes value, printing a dash for untimed
+// sessions whose pointer is nil.
+func fmtMinutes(m *float64) string {
+	if m == nil {
+		return "—"
+	}
+	return fmt.Sprintf("%.1f", *m)
+}
+
+// fmtInstant renders a nullable RFC3339 instant in loc as "YYYY-MM-DD HH:MM",
+// printing a dash when nil.
+func fmtInstant(ts *string, loc *time.Location) string {
+	if ts == nil {
+		return "—"
+	}
+	if t, err := time.Parse(time.RFC3339, *ts); err == nil {
+		return t.In(loc).Format("2006-01-02 15:04")
+	}
+	return *ts
+}

--- a/cmd/agentsview/activity.go
+++ b/cmd/agentsview/activity.go
@@ -173,7 +173,8 @@ func printKeyMinutes(label string, rows []activity.KeyMinutes) {
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	for _, row := range topKeyMinutes(rows, 5) {
-		fmt.Fprintf(w, "  %s\t%.1f min\n", row.Key, row.AgentMinutes)
+		fmt.Fprintf(w, "  %s\t%.1f min\n",
+			sanitizeTerminal(row.Key), row.AgentMinutes)
 	}
 	w.Flush()
 	fmt.Println()
@@ -191,7 +192,8 @@ func printActivitySessions(rows []activity.SessionRow) {
 	limit := min(len(rows), 5)
 	for _, s := range rows[:limit] {
 		fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n",
-			s.Title, s.Project, s.Agent,
+			sanitizeTerminal(s.Title), sanitizeTerminal(s.Project),
+			sanitizeTerminal(s.Agent),
 			fmtMinutes(s.AgentMinutes), fmtCost(s.Cost),
 		)
 	}

--- a/cmd/agentsview/activity_test.go
+++ b/cmd/agentsview/activity_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/pricing"
+)
+
+func TestNewActivityCommand_RegistersReport(t *testing.T) {
+	cmd := newActivityCommand()
+	assert.Equal(t, "activity", cmd.Name())
+	sub, _, err := cmd.Find([]string{"report"})
+	require.NoError(t, err)
+	assert.Equal(t, "report", sub.Name())
+}
+
+func TestActivityReportCommand_Flags(t *testing.T) {
+	cmd := newActivityReportCommand()
+	for _, name := range []string{
+		"preset", "date", "from", "to", "timezone",
+		"bucket", "project", "agent", "machine", "json", "no-sync",
+		"offline",
+	} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "flag --%s must exist", name)
+	}
+}
+
+func TestActivityReportCommand_HelpText(t *testing.T) {
+	cmd := newActivityReportCommand()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--help"})
+	require.NoError(t, cmd.Execute())
+	out := buf.String()
+	assert.Contains(t, out, "--preset")
+	assert.Contains(t, out, "--json")
+}
+
+func TestResolveActivityReport_BadBucket(t *testing.T) {
+	d := newTestDB(t)
+	_, err := resolveActivityReport(ActivityReportConfig{
+		Preset: "day", Date: "2026-06-16", Timezone: "UTC", Bucket: "2h",
+	}, d)
+	require.Error(t, err, "off-allow-list bucket is rejected before query")
+}
+
+func TestResolveActivityReport_JSONShape(t *testing.T) {
+	d := newTestDB(t)
+	r, err := resolveActivityReport(ActivityReportConfig{
+		Preset: "day", Date: "2026-06-16", Timezone: "UTC",
+	}, d)
+	require.NoError(t, err)
+	assert.Equal(t, "minute", r.BucketUnit)
+	assert.Equal(t, "2026-06-16T00:00:00Z", r.RangeStart)
+}
+
+func TestFmtRangeBound_RendersInTimezone(t *testing.T) {
+	chicago, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err)
+	// 05:00Z is local midnight in Chicago (CDT, UTC-5) in June.
+	assert.Equal(t, "2026-06-16", fmtRangeBound("2026-06-16T05:00:00Z", chicago))
+	// UTC midnight renders date-only in UTC.
+	assert.Equal(t, "2026-06-16", fmtRangeBound("2026-06-16T00:00:00Z", time.UTC))
+	// A non-midnight bound keeps the local time component.
+	assert.Equal(t, "2026-06-16 12:30", fmtRangeBound("2026-06-16T12:30:00Z", time.UTC))
+}
+
+func TestFmtInstant_NilAndTimezone(t *testing.T) {
+	assert.Equal(t, "—", fmtInstant(nil, time.UTC))
+	chicago, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err)
+	ts := "2026-06-16T05:30:00Z" // 00:30 CDT
+	assert.Equal(t, "2026-06-16 00:30", fmtInstant(&ts, chicago))
+}
+
+// fallbackPricedModel returns a model pattern from the offline fallback table
+// that carries a non-zero output rate, so seeding it prices output tokens.
+func fallbackPricedModel(t *testing.T) string {
+	t.Helper()
+	for _, p := range pricing.FallbackPricing() {
+		if p.OutputPerMTok > 0 {
+			return p.ModelPattern
+		}
+	}
+	require.FailNow(t, "no fallback model with a non-zero output rate")
+	return ""
+}
+
+// TestResolveActivityReport_PricesFreshDBUsage proves the pricing fix: a fresh
+// DB holding unpriced token usage is priced because resolveActivityReportPriced
+// seeds the fallback rates before resolving, exactly as runActivityReport does,
+// so the report's cost is non-zero.
+func TestResolveActivityReport_PricesFreshDBUsage(t *testing.T) {
+	d := newTestDB(t)
+	model := fallbackPricedModel(t)
+
+	started := "2026-06-15T10:00:00Z"
+	ended := "2026-06-15T10:05:00Z"
+	usage, err := json.Marshal(map[string]int{"input_tokens": 100, "output_tokens": 500})
+	require.NoError(t, err)
+	first := "first message"
+	_, err = d.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: db.Session{
+			ID: "cost-1", Project: "alpha", Machine: "local", Agent: "claude",
+			StartedAt: &started, EndedAt: &ended, CreatedAt: started,
+			FirstMessage: &first, MessageCount: 2, UserMessageCount: 1,
+			RelationshipType: "root", DataVersion: 1,
+		},
+		Messages: []db.Message{
+			{SessionID: "cost-1", Ordinal: 0, Role: "user", Content: "u",
+				Timestamp: started, ContentLength: 1},
+			{SessionID: "cost-1", Ordinal: 1, Role: "assistant", Content: "a",
+				Timestamp: ended, ContentLength: 1, Model: model,
+				TokenUsage: usage, OutputTokens: 500, HasOutputTokens: true},
+		},
+		DataVersion: 1, ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+
+	// resolveActivityReportPriced seeds fallback pricing (Offline => no network)
+	// exactly as runActivityReport does, so removing that seeding fails here.
+	r, err := resolveActivityReportPriced(ActivityReportConfig{
+		Preset: "day", Date: "2026-06-15", Timezone: "UTC", Offline: true,
+	}, d)
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens)
+	assert.Greater(t, r.Totals.Cost, 0.0,
+		"resolveActivityReportPriced must seed fallback pricing for fresh-DB usage")
+}

--- a/cmd/agentsview/activity_test.go
+++ b/cmd/agentsview/activity_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/activity"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/pricing"
 )
@@ -78,6 +79,39 @@ func TestFmtInstant_NilAndTimezone(t *testing.T) {
 	require.NoError(t, err)
 	ts := "2026-06-16T05:30:00Z" // 00:30 CDT
 	assert.Equal(t, "2026-06-16 00:30", fmtInstant(&ts, chicago))
+}
+
+// TestPrintActivityReport_SanitizesSessionDerivedStrings confirms the
+// human-readable activity output strips control/escape bytes from
+// session-derived fields (breakdown keys and session title/project/agent), so
+// crafted imported or synced metadata cannot drive terminal escape sequences.
+// JSON output is left untouched and is covered separately.
+func TestPrintActivityReport_SanitizesSessionDerivedStrings(t *testing.T) {
+	mins := 1.0
+	// OSC title-set + BEL, then a bare CR overwrite: all control bytes stripped.
+	evil := "\x1b]0;pwned\x07safe\rEVIL"
+	r := activity.Report{
+		Timezone:   "UTC",
+		RangeStart: "2026-06-16T00:00:00Z",
+		RangeEnd:   "2026-06-17T00:00:00Z",
+		BucketUnit: "minute",
+		ByProject:  []activity.KeyMinutes{{Key: evil, AgentMinutes: 1}},
+		BySession: []activity.SessionRow{{
+			SessionID:    "s1",
+			Title:        evil,
+			Project:      evil,
+			Agent:        evil,
+			AgentMinutes: &mins,
+		}},
+	}
+
+	out := captureStdout(t, func() { printActivityReport(r) })
+
+	assert.NotContains(t, out, "\x1b", "ESC must be stripped from output")
+	assert.NotContains(t, out, "\x07", "BEL must be stripped from output")
+	assert.NotContains(t, out, "\r", "bare CR must be stripped from output")
+	assert.Contains(t, out, "safeEVIL",
+		"printable text survives once control bytes are removed")
 }
 
 // fallbackPricedModel returns a model pattern from the offline fallback table

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -64,6 +64,7 @@ func newRootCommand() *cobra.Command {
 	root.AddCommand(newProjectsCommand())
 	root.AddCommand(newHealthCommand())
 	root.AddCommand(newUsageCommand())
+	root.AddCommand(newActivityCommand())
 	root.AddCommand(newPGCommand())
 	root.AddCommand(newDuckDBCommand())
 	root.AddCommand(newSessionCommand())
@@ -409,6 +410,47 @@ func newUsageStatuslineCommand() *cobra.Command {
 	cmd.Flags().StringVar(&cfg.Agent, "agent", "", "Filter by agent name")
 	cmd.Flags().BoolVar(&cfg.Offline, "offline", false, "Use fallback pricing only")
 	cmd.Flags().BoolVar(&cfg.NoSync, "no-sync", false, "Skip on-demand sync before querying")
+	return cmd
+}
+
+func newActivityCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "activity",
+		Short:        "Activity and concurrency reporting",
+		GroupID:      groupUsage,
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newActivityReportCommand())
+	return cmd
+}
+
+func newActivityReportCommand() *cobra.Command {
+	var cfg ActivityReportConfig
+	cmd := &cobra.Command{
+		Use:          "report",
+		Short:        "Activity report over a date range",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runActivityReport(cfg)
+		},
+	}
+	cmd.Flags().StringVar(&cfg.Preset, "preset", "", "Range preset: day, week, month, custom")
+	cmd.Flags().StringVar(&cfg.Date, "date", "", "Anchor date for presets (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&cfg.From, "from", "", "Start instant for custom range (RFC3339)")
+	cmd.Flags().StringVar(&cfg.To, "to", "", "End instant for custom range (RFC3339)")
+	cmd.Flags().StringVar(&cfg.Timezone, "timezone", "", "IANA timezone for range bucketing")
+	cmd.Flags().StringVar(&cfg.Bucket, "bucket", "", "Bucket size: 5m, 15m, 1h, 1d, 1w")
+	cmd.Flags().StringVar(&cfg.Project, "project", "", "Filter by project")
+	cmd.Flags().StringVar(&cfg.Agent, "agent", "", "Filter by agent name")
+	cmd.Flags().StringVar(&cfg.Machine, "machine", "", "Filter by machine name")
+	cmd.Flags().BoolVar(&cfg.JSON, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&cfg.NoSync, "no-sync", false, "Skip on-demand sync before querying")
+	cmd.Flags().BoolVar(&cfg.Offline, "offline", false, "Use fallback pricing only")
 	return cmd
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,5 +39,6 @@
   "overrides": {
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.24",
     "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.24"
-  }
+  },
+  "packageManager": "npm@11.17.0"
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,6 +19,7 @@
   import PerfDebugPanel from "./lib/components/debug/PerfDebugPanel.svelte";
   import AnalyticsPage from "./lib/components/analytics/AnalyticsPage.svelte";
   import UsagePage from "./lib/components/usage/UsagePage.svelte";
+  import ActivityPage from "./lib/components/activity/ActivityPage.svelte";
   import TrendsPage from "./lib/components/trends/TrendsPage.svelte";
   import InsightsPage from "./lib/components/insights/InsightsPage.svelte";
   import PinnedPage from "./lib/components/pinned/PinnedPage.svelte";
@@ -413,6 +414,10 @@
 {#if router.route === "usage"}
   <div class="page-scroll">
     <UsagePage />
+  </div>
+{:else if router.route === "activity"}
+  <div class="page-scroll">
+    <ActivityPage />
   </div>
 {:else if router.route === "trends"}
   <div class="page-scroll">

--- a/frontend/src/lib/api/generated/index.ts
+++ b/frontend/src/lib/api/generated/index.ts
@@ -7,6 +7,13 @@ export { CancelablePromise, CancelError } from './core/CancelablePromise';
 export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
 
+export type { ActivityBucket } from './models/ActivityBucket';
+export type { ActivityKeyMinutes } from './models/ActivityKeyMinutes';
+export type { ActivityPeak } from './models/ActivityPeak';
+export type { ActivityReport } from './models/ActivityReport';
+export type { ActivityReportInterval } from './models/ActivityReportInterval';
+export type { ActivitySessionRow } from './models/ActivitySessionRow';
+export type { ActivityTotals } from './models/ActivityTotals';
 export type { AgentsResponse } from './models/AgentsResponse';
 export type { AgentTotal } from './models/AgentTotal';
 export type { ApiErrorResponse } from './models/ApiErrorResponse';
@@ -130,6 +137,7 @@ export type { VersionInfo } from './models/VersionInfo';
 export type { WorktreeMappingRequest } from './models/WorktreeMappingRequest';
 export type { WorktreeMappingsResponse } from './models/WorktreeMappingsResponse';
 
+export { ActivityService } from './services/ActivityService';
 export { AnalyticsService } from './services/AnalyticsService';
 export { AssetsService } from './services/AssetsService';
 export { ConfigService } from './services/ConfigService';

--- a/frontend/src/lib/api/generated/models/ActivityBucket.ts
+++ b/frontend/src/lib/api/generated/models/ActivityBucket.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ActivityBucket = {
+  agent_minutes: number;
+  automated_at_peak: number;
+  cost: number;
+  end: string;
+  interactive_at_peak: number;
+  max_agents: number;
+  output_tokens: number;
+  start: string;
+};
+

--- a/frontend/src/lib/api/generated/models/ActivityKeyMinutes.ts
+++ b/frontend/src/lib/api/generated/models/ActivityKeyMinutes.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ActivityKeyMinutes = {
+  agent_minutes: number;
+  automated_agent_minutes: number;
+  automated_cost: number;
+  cost: number;
+  interactive_agent_minutes: number;
+  interactive_cost: number;
+  key: string;
+};
+

--- a/frontend/src/lib/api/generated/models/ActivityPeak.ts
+++ b/frontend/src/lib/api/generated/models/ActivityPeak.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ActivityPeak = {
+  agents: number;
+  at: string | null;
+};
+

--- a/frontend/src/lib/api/generated/models/ActivityReport.ts
+++ b/frontend/src/lib/api/generated/models/ActivityReport.ts
@@ -1,0 +1,27 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ActivityPeak } from './ActivityPeak';
+import type { ActivityTotals } from './ActivityTotals';
+export type ActivityReport = {
+  as_of: string | null;
+  bucket_count: number;
+  bucket_seconds: number;
+  bucket_unit: string;
+  buckets: any[] | null;
+  by_agent: any[] | null;
+  by_model: any[] | null;
+  by_project: any[] | null;
+  by_session: any[] | null;
+  effective_end: string;
+  elapsed_bucket_count: number;
+  intervals: any[] | null;
+  partial: boolean;
+  peak: ActivityPeak;
+  range_end: string;
+  range_start: string;
+  timezone: string;
+  totals: ActivityTotals;
+};
+

--- a/frontend/src/lib/api/generated/models/ActivityReportInterval.ts
+++ b/frontend/src/lib/api/generated/models/ActivityReportInterval.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ActivityReportInterval = {
+  end: string;
+  session_id: string;
+  start: string;
+};
+

--- a/frontend/src/lib/api/generated/models/ActivitySessionRow.ts
+++ b/frontend/src/lib/api/generated/models/ActivitySessionRow.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ActivitySessionRow = {
+  agent: string;
+  agent_minutes: number | null;
+  cost: number;
+  first_active: string | null;
+  is_automated: boolean;
+  last_active: string | null;
+  models: any[] | null;
+  output_tokens: number;
+  primary_model: string;
+  project: string;
+  session_id: string;
+  timing_quality: string;
+  title: string;
+};
+

--- a/frontend/src/lib/api/generated/models/ActivityTotals.ts
+++ b/frontend/src/lib/api/generated/models/ActivityTotals.ts
@@ -7,12 +7,14 @@ export type ActivityTotals = {
   agent_minutes: number;
   automated_agent_minutes: number;
   automated_cost: number;
+  automated_sessions: number;
   cost: number;
   distinct_models: number;
   distinct_projects: number;
   idle_minutes: number;
   interactive_agent_minutes: number;
   interactive_cost: number;
+  interactive_sessions: number;
   output_tokens: number;
   sessions: number;
   untimed_sessions: number;

--- a/frontend/src/lib/api/generated/models/ActivityTotals.ts
+++ b/frontend/src/lib/api/generated/models/ActivityTotals.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ActivityTotals = {
+  active_minutes: number;
+  agent_minutes: number;
+  automated_agent_minutes: number;
+  automated_cost: number;
+  cost: number;
+  distinct_models: number;
+  distinct_projects: number;
+  idle_minutes: number;
+  interactive_agent_minutes: number;
+  interactive_cost: number;
+  output_tokens: number;
+  sessions: number;
+  untimed_sessions: number;
+};
+

--- a/frontend/src/lib/api/generated/models/DbTopSession.ts
+++ b/frontend/src/lib/api/generated/models/DbTopSession.ts
@@ -3,8 +3,8 @@
 /* tslint:disable */
 /* eslint-disable */
 export type DbTopSession = {
-  duration_min: number;
   display_name?: string;
+  duration_min: number;
   ended_at?: string;
   first_message: string | null;
   id: string;

--- a/frontend/src/lib/api/generated/models/GenerateInsightRequest.ts
+++ b/frontend/src/lib/api/generated/models/GenerateInsightRequest.ts
@@ -8,6 +8,7 @@ export type GenerateInsightRequest = {
   date_to: string;
   project?: string;
   prompt?: string;
+  timezone?: string;
   type: string;
 };
 

--- a/frontend/src/lib/api/generated/models/SettingsResponse.ts
+++ b/frontend/src/lib/api/generated/models/SettingsResponse.ts
@@ -13,3 +13,4 @@ export type SettingsResponse = {
   require_auth: boolean;
   terminal: TerminalResponse;
 };
+

--- a/frontend/src/lib/api/generated/services/ActivityService.ts
+++ b/frontend/src/lib/api/generated/services/ActivityService.ts
@@ -22,6 +22,7 @@ export class ActivityService {
     project,
     agent,
     machine,
+    automation = 'all',
   }: {
     /**
      * Range preset
@@ -59,6 +60,10 @@ export class ActivityService {
      * Filter by machine
      */
     machine?: string,
+    /**
+     * Automation class: all, interactive, or automated
+     */
+    automation?: string,
   }): CancelablePromise<ActivityReport> {
     return __request(OpenAPI, {
       method: 'GET',
@@ -73,6 +78,7 @@ export class ActivityService {
         'project': project,
         'agent': agent,
         'machine': machine,
+        'automation': automation,
       },
       errors: {
         400: `Bad Request`,

--- a/frontend/src/lib/api/generated/services/ActivityService.ts
+++ b/frontend/src/lib/api/generated/services/ActivityService.ts
@@ -1,0 +1,92 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ActivityReport } from '../models/ActivityReport';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class ActivityService {
+  /**
+   * Get activity report
+   * @returns ActivityReport OK
+   * @throws ApiError
+   */
+  public static getApiV1ActivityReport({
+    preset,
+    date,
+    from,
+    to,
+    timezone,
+    bucket,
+    project,
+    agent,
+    machine,
+  }: {
+    /**
+     * Range preset
+     */
+    preset?: 'day' | 'week' | 'month' | 'custom',
+    /**
+     * Calendar day (YYYY-MM-DD) for presets
+     */
+    date?: string,
+    /**
+     * Range start (RFC3339) for custom ranges
+     */
+    from?: string,
+    /**
+     * Range end (RFC3339) for custom ranges
+     */
+    to?: string,
+    /**
+     * IANA timezone name
+     */
+    timezone?: string,
+    /**
+     * Timeline bucket size override
+     */
+    bucket?: '5m' | '15m' | '1h' | '1d' | '1w',
+    /**
+     * Filter by project
+     */
+    project?: string,
+    /**
+     * Filter by agent
+     */
+    agent?: string,
+    /**
+     * Filter by machine
+     */
+    machine?: string,
+  }): CancelablePromise<ActivityReport> {
+    return __request(OpenAPI, {
+      method: 'GET',
+      url: '/api/v1/activity/report',
+      query: {
+        'preset': preset,
+        'date': date,
+        'from': from,
+        'to': to,
+        'timezone': timezone,
+        'bucket': bucket,
+        'project': project,
+        'agent': agent,
+        'machine': machine,
+      },
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
+}

--- a/frontend/src/lib/api/generated/services/InsightsService.ts
+++ b/frontend/src/lib/api/generated/services/InsightsService.ts
@@ -17,6 +17,8 @@ export class InsightsService {
   public static getApiV1Insights({
     type,
     project,
+    dateFrom,
+    dateTo,
   }: {
     /**
      * Insight type
@@ -26,6 +28,14 @@ export class InsightsService {
      * Filter by project
      */
     project?: string,
+    /**
+     * Filter date_from >= (YYYY-MM-DD)
+     */
+    dateFrom?: string,
+    /**
+     * Filter date_to <= (YYYY-MM-DD)
+     */
+    dateTo?: string,
   }): CancelablePromise<InsightsResponse> {
     return __request(OpenAPI, {
       method: 'GET',
@@ -33,6 +43,8 @@ export class InsightsService {
       query: {
         'type': type,
         'project': project,
+        'date_from': dateFrom,
+        'date_to': dateTo,
       },
       errors: {
         400: `Bad Request`,

--- a/frontend/src/lib/api/types/activity.ts
+++ b/frontend/src/lib/api/types/activity.ts
@@ -1,0 +1,13 @@
+import type {
+  ActivityReport,
+  ActivityBucket,
+  ActivityReportInterval,
+  ActivitySessionRow,
+  ActivityKeyMinutes,
+} from "../generated/index";
+
+export type Report = ActivityReport;
+export type Bucket = ActivityBucket;
+export type ReportInterval = ActivityReportInterval;
+export type SessionRow = ActivitySessionRow;
+export type KeyMinutes = ActivityKeyMinutes;

--- a/frontend/src/lib/api/types/index.ts
+++ b/frontend/src/lib/api/types/index.ts
@@ -1,6 +1,7 @@
 export type * from "./core.js";
 export type * from "./sync.js";
 export type * from "./analytics.js";
+export type * from "./activity.js";
 export type * from "./github.js";
 export type * from "./insights.js";
 export type * from "./session-activity.js";

--- a/frontend/src/lib/api/types/insights.ts
+++ b/frontend/src/lib/api/types/insights.ts
@@ -33,4 +33,7 @@ export interface GenerateInsightRequest {
   project?: string;
   prompt?: string;
   agent?: AgentName;
+  // IANA timezone the date range is expressed in, so the server's activity
+  // summary covers the same local-day window as the dashboard. Omit for UTC.
+  timezone?: string;
 }

--- a/frontend/src/lib/components/activity/ActivityInsight.svelte
+++ b/frontend/src/lib/components/activity/ActivityInsight.svelte
@@ -10,7 +10,7 @@
   import { router, getBasePath } from "../../stores/router.svelte.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { highlightCodeFences } from "../../utils/highlight-fences.js";
-  import type { Insight, InsightsResponse } from "../../api/types.js";
+  import type { Insight, InsightsResponse, AgentName } from "../../api/types.js";
   import { LightbulbIcon, PlusIcon } from "../../icons.js";
 
   let {
@@ -109,6 +109,12 @@
     return abortGeneration;
   });
 
+  // The agent choice is shared with the standalone Insights page via the
+  // insights store, so picking one here and there stays in sync.
+  function onAgentChange(e: Event) {
+    insights.setAgent((e.currentTarget as HTMLSelectElement).value as AgentName);
+  }
+
   function handleGenerate() {
     if (generationUnavailable || generating) return;
     generating = true;
@@ -122,7 +128,7 @@
         date_from: dateFrom,
         date_to: dateTo,
         timezone,
-        agent: "claude",
+        agent: insights.agent,
       },
       (p) => {
         if (v !== genVersion) return;
@@ -168,6 +174,23 @@
     </a>
   </header>
 
+  {#snippet agentPicker()}
+    <select
+      class="agent-select"
+      value={insights.agent}
+      onchange={onAgentChange}
+      disabled={generationUnavailable}
+      title="Agent CLI used to generate the insight"
+      aria-label="Insight agent"
+    >
+      <option value="claude">Claude</option>
+      <option value="codex">Codex</option>
+      <option value="copilot">Copilot</option>
+      <option value="gemini">Gemini</option>
+      <option value="kiro">Kiro</option>
+    </select>
+  {/snippet}
+
   {#if loading}
     <div class="state muted">Loading insight…</div>
   {:else if generating}
@@ -178,14 +201,17 @@
   {:else if error}
     <div class="state error">
       <span>{error}</span>
-      <button
-        class="generate-btn"
-        onclick={handleGenerate}
-        disabled={generationUnavailable}
-        title={unavailableTitle}
-      >
-        Retry
-      </button>
+      <div class="gen-row">
+        {@render agentPicker()}
+        <button
+          class="generate-btn"
+          onclick={handleGenerate}
+          disabled={generationUnavailable}
+          title={unavailableTitle}
+        >
+          Retry
+        </button>
+      </div>
     </div>
   {:else if insight}
     <article
@@ -200,15 +226,18 @@
         No insight yet for this range. Generate one to summarize this
         period's activity.
       </span>
-      <button
-        class="generate-btn"
-        onclick={handleGenerate}
-        disabled={generationUnavailable}
-        title={unavailableTitle}
-      >
-        <PlusIcon size="12" strokeWidth="2.2" aria-hidden="true" />
-        Generate
-      </button>
+      <div class="gen-row">
+        {@render agentPicker()}
+        <button
+          class="generate-btn"
+          onclick={handleGenerate}
+          disabled={generationUnavailable}
+          title={unavailableTitle}
+        >
+          <PlusIcon size="12" strokeWidth="2.2" aria-hidden="true" />
+          Generate
+        </button>
+      </div>
     </div>
   {/if}
 </section>
@@ -294,6 +323,34 @@
     color: var(--text-muted);
     line-height: 1.5;
     max-width: 420px;
+  }
+
+  .gen-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .agent-select {
+    height: 28px;
+    padding: 0 6px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: border-color 0.15s;
+  }
+
+  .agent-select:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+  }
+
+  .agent-select:disabled {
+    opacity: 0.45;
+    cursor: default;
   }
 
   .generate-btn {

--- a/frontend/src/lib/components/activity/ActivityInsight.svelte
+++ b/frontend/src/lib/components/activity/ActivityInsight.svelte
@@ -13,7 +13,11 @@
   import type { Insight, InsightsResponse } from "../../api/types.js";
   import { LightbulbIcon, PlusIcon } from "../../icons.js";
 
-  let { dateFrom, dateTo }: { dateFrom: string; dateTo: string } = $props();
+  let {
+    dateFrom,
+    dateTo,
+    timezone = "",
+  }: { dateFrom: string; dateTo: string; timezone?: string } = $props();
 
   let insight: Insight | null = $state(null);
   let loading = $state(false);
@@ -110,6 +114,7 @@
         type: "daily_activity",
         date_from: dateFrom,
         date_to: dateTo,
+        timezone,
         agent: "claude",
       },
       (p) => {

--- a/frontend/src/lib/components/activity/ActivityInsight.svelte
+++ b/frontend/src/lib/components/activity/ActivityInsight.svelte
@@ -1,0 +1,447 @@
+<script lang="ts">
+  import { InsightsService } from "../../api/generated/index";
+  import { configureGeneratedClient } from "../../api/runtime.js";
+  import {
+    generateInsight,
+    type GenerateInsightHandle,
+  } from "../../api/client.js";
+  import { sync } from "../../stores/sync.svelte.js";
+  import { insights } from "../../stores/insights.svelte.js";
+  import { router, getBasePath } from "../../stores/router.svelte.js";
+  import { renderMarkdown } from "../../utils/markdown.js";
+  import { highlightCodeFences } from "../../utils/highlight-fences.js";
+  import type { Insight, InsightsResponse } from "../../api/types.js";
+  import { LightbulbIcon, PlusIcon } from "../../icons.js";
+
+  let { dateFrom, dateTo }: { dateFrom: string; dateTo: string } = $props();
+
+  let insight: Insight | null = $state(null);
+  let loading = $state(false);
+  let generating = $state(false);
+  let phase = $state("");
+  let error: string | null = $state(null);
+
+  // Guards stale fetch responses when the range changes mid-flight.
+  let fetchVersion = 0;
+  // The in-flight generation, so we can abort it on range change/unmount.
+  let handle: GenerateInsightHandle | null = null;
+
+  /**
+   * Open the standalone Insights page prefilled for this panel's range.
+   * Modified or middle clicks fall through to the browser so the href opens in
+   * a new tab/window; a plain left click is intercepted for SPA navigation.
+   */
+  function openInsightsPage(e: MouseEvent) {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+      return;
+    }
+    e.preventDefault();
+    insights.setType("daily_activity");
+    insights.setDateFrom(dateFrom);
+    insights.setDateTo(dateTo);
+    insights.setProject("");
+    router.navigate("insights");
+  }
+
+  const readOnly = $derived(sync.serverVersion?.read_only === true);
+  const generationUnavailable = $derived(
+    sync.serverVersion === null || readOnly,
+  );
+  const unavailableTitle = $derived(
+    readOnly
+      ? "Unavailable in read-only remote mode"
+      : sync.serverVersion === null
+        ? "Waiting for server version"
+        : "Generate insight",
+  );
+
+  function abortGeneration() {
+    handle?.abort();
+    handle = null;
+  }
+
+  $effect(() => {
+    // Read both bounds synchronously so the effect re-runs when either
+    // changes, and capture them so the closures below stay stable.
+    const from = dateFrom;
+    const to = dateTo;
+    const v = ++fetchVersion;
+    abortGeneration();
+    error = null;
+    generating = false;
+    loading = true;
+
+    configureGeneratedClient();
+    InsightsService.getApiV1Insights({
+      type: "daily_activity",
+      dateFrom: from,
+      dateTo: to,
+    })
+      .then((res) => {
+        if (v !== fetchVersion) return;
+        // The list endpoint treats date_from/date_to as range BOUNDS, so a
+        // multi-day range also returns narrower insights nested inside it
+        // (e.g. a single day) and project-scoped ones. This panel shows the
+        // global insight for the exact range, so match both bounds and drop
+        // project-scoped rows before taking the newest.
+        const list = (res as unknown as InsightsResponse).insights.filter(
+          (i) => !i.project && i.date_from === from && i.date_to === to,
+        );
+        insight = list[0] ?? null;
+        loading = false;
+      })
+      .catch(() => {
+        if (v !== fetchVersion) return;
+        insight = null;
+        loading = false;
+      });
+
+    return abortGeneration;
+  });
+
+  function handleGenerate() {
+    if (generationUnavailable || generating) return;
+    generating = true;
+    phase = "starting";
+    error = null;
+
+    handle = generateInsight(
+      {
+        type: "daily_activity",
+        date_from: dateFrom,
+        date_to: dateTo,
+        agent: "claude",
+      },
+      (p) => {
+        phase = p;
+      },
+    );
+
+    handle.done
+      .then((result) => {
+        handle = null;
+        insight = result;
+        generating = false;
+      })
+      .catch((e) => {
+        handle = null;
+        if (e instanceof DOMException && e.name === "AbortError") {
+          return;
+        }
+        error = e instanceof Error ? e.message : "Generation failed";
+        generating = false;
+      });
+  }
+</script>
+
+<section class="activity-insight">
+  <header class="panel-header">
+    <span class="panel-title">
+      <LightbulbIcon size="13" strokeWidth="1.8" aria-hidden="true" />
+      <span>Activity Insight</span>
+      {#if !loading && insight?.model}
+        <span class="insight-model">{insight.model}</span>
+      {/if}
+    </span>
+    <a
+      class="insights-link"
+      href={getBasePath() + "/insights"}
+      onclick={openInsightsPage}
+    >
+      Open in Insights page
+    </a>
+  </header>
+
+  {#if loading}
+    <div class="state muted">Loading insight…</div>
+  {:else if generating}
+    <div class="state generating">
+      <span class="spinner"></span>
+      <span>Generating… {phase}</span>
+    </div>
+  {:else if error}
+    <div class="state error">
+      <span>{error}</span>
+      <button
+        class="generate-btn"
+        onclick={handleGenerate}
+        disabled={generationUnavailable}
+        title={unavailableTitle}
+      >
+        Retry
+      </button>
+    </div>
+  {:else if insight}
+    <article
+      class="markdown-body"
+      use:highlightCodeFences={{ content: insight.content }}
+    >
+      {@html renderMarkdown(insight.content)}
+    </article>
+  {:else}
+    <div class="empty-state">
+      <span class="empty-text">
+        No insight yet for this range. Generate one to summarize this
+        period's activity.
+      </span>
+      <button
+        class="generate-btn"
+        onclick={handleGenerate}
+        disabled={generationUnavailable}
+        title={unavailableTitle}
+      >
+        <PlusIcon size="12" strokeWidth="2.2" aria-hidden="true" />
+        Generate
+      </button>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .activity-insight {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .panel-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .insight-model {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 400;
+    opacity: 0.7;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+
+  .insights-link {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--accent-blue);
+    text-decoration: none;
+    letter-spacing: 0.01em;
+  }
+
+  .insights-link:hover {
+    text-decoration: underline;
+  }
+
+  .state {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  .state.error {
+    color: var(--accent-red);
+  }
+
+  .spinner {
+    width: 12px;
+    height: 12px;
+    border: 1.5px solid var(--accent-blue);
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+    flex-shrink: 0;
+  }
+
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 8px 0;
+  }
+
+  .empty-text {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    max-width: 420px;
+  }
+
+  .generate-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 28px;
+    padding: 0 12px;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    font-weight: 600;
+    background: var(--accent-blue);
+    color: white;
+    letter-spacing: 0.01em;
+    transition: opacity 0.12s, transform 0.1s, box-shadow 0.12s;
+    box-shadow: 0 1px 2px rgba(37, 99, 235, 0.2);
+  }
+
+  .generate-btn:hover:not(:disabled) {
+    opacity: 0.92;
+    box-shadow: 0 2px 6px rgba(37, 99, 235, 0.3);
+  }
+
+  .generate-btn:active:not(:disabled) {
+    transform: scale(0.98);
+    box-shadow: none;
+  }
+
+  .generate-btn:disabled {
+    opacity: 0.45;
+    box-shadow: none;
+    cursor: default;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  /* ── Markdown Content ── */
+  .markdown-body {
+    font-size: 14px;
+    line-height: 1.7;
+    color: var(--text-primary);
+    max-width: 720px;
+  }
+
+  .markdown-body :global(h1) {
+    font-size: 20px;
+    font-weight: 700;
+    margin: 0 0 14px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-muted);
+    letter-spacing: -0.02em;
+  }
+
+  .markdown-body :global(h2) {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 28px 0 10px;
+    letter-spacing: -0.015em;
+  }
+
+  .markdown-body :global(h3) {
+    font-size: 14px;
+    font-weight: 600;
+    margin: 20px 0 6px;
+    letter-spacing: -0.01em;
+  }
+
+  .markdown-body :global(p) {
+    margin: 0 0 10px;
+  }
+
+  .markdown-body :global(ul),
+  .markdown-body :global(ol) {
+    margin: 0 0 10px;
+    padding-left: 20px;
+  }
+
+  .markdown-body :global(li) {
+    margin: 3px 0;
+  }
+
+  .markdown-body :global(li + li) {
+    margin-top: 4px;
+  }
+
+  .markdown-body :global(code) {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    padding: 2px 5px;
+    background: var(--bg-inset);
+    border-radius: var(--radius-sm);
+  }
+
+  .markdown-body :global(pre) {
+    background: var(--bg-inset);
+    padding: 10px 14px;
+    border-radius: var(--radius-md);
+    overflow-x: auto;
+    margin: 0 0 10px;
+    border: 1px solid var(--border-muted);
+  }
+
+  .markdown-body :global(pre code) {
+    padding: 0;
+    background: transparent;
+    border: none;
+  }
+
+  .markdown-body :global(blockquote) {
+    margin: 0 0 10px;
+    padding: 6px 14px;
+    border-left: 3px solid var(--accent-blue);
+    color: var(--text-secondary);
+    background: color-mix(
+      in srgb,
+      var(--accent-blue) 4%,
+      transparent
+    );
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  }
+
+  .markdown-body :global(strong) {
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .markdown-body :global(a) {
+    color: var(--accent-blue);
+    text-decoration: none;
+  }
+
+  .markdown-body :global(a:hover) {
+    text-decoration: underline;
+  }
+
+  .markdown-body :global(hr) {
+    border: none;
+    border-top: 1px solid var(--border-muted);
+    margin: 20px 0;
+  }
+
+  .markdown-body :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 10px;
+    font-size: 12px;
+  }
+
+  .markdown-body :global(th),
+  .markdown-body :global(td) {
+    padding: 6px 10px;
+    border: 1px solid var(--border-muted);
+    text-align: left;
+  }
+
+  .markdown-body :global(th) {
+    background: var(--bg-inset);
+    font-weight: 600;
+  }
+</style>

--- a/frontend/src/lib/components/activity/ActivityInsight.svelte
+++ b/frontend/src/lib/components/activity/ActivityInsight.svelte
@@ -27,6 +27,10 @@
 
   // Guards stale fetch responses when the range changes mid-flight.
   let fetchVersion = 0;
+  // Bumped on every generation start and on abort, so a generation that
+  // settles after the range changed (or after a newer one started) is
+  // ignored instead of clobbering the current handle or panel state.
+  let genVersion = 0;
   // The in-flight generation, so we can abort it on range change/unmount.
   let handle: GenerateInsightHandle | null = null;
 
@@ -62,6 +66,8 @@
   function abortGeneration() {
     handle?.abort();
     handle = null;
+    // Invalidate the aborted generation so its late settle is a no-op.
+    genVersion++;
   }
 
   $effect(() => {
@@ -109,7 +115,8 @@
     phase = "starting";
     error = null;
 
-    handle = generateInsight(
+    const v = ++genVersion;
+    const current = generateInsight(
       {
         type: "daily_activity",
         date_from: dateFrom,
@@ -118,17 +125,21 @@
         agent: "claude",
       },
       (p) => {
+        if (v !== genVersion) return;
         phase = p;
       },
     );
+    handle = current;
 
-    handle.done
+    current.done
       .then((result) => {
+        if (v !== genVersion) return;
         handle = null;
         insight = result;
         generating = false;
       })
       .catch((e) => {
+        if (v !== genVersion) return;
         handle = null;
         if (e instanceof DOMException && e.name === "AbortError") {
           return;

--- a/frontend/src/lib/components/activity/ActivityInsight.test.ts
+++ b/frontend/src/lib/components/activity/ActivityInsight.test.ts
@@ -83,6 +83,40 @@ describe("ActivityInsight", () => {
     );
   });
 
+  it("ignores a generation that settles after the range changed", async () => {
+    let resolveStale!: (insight: unknown) => void;
+    const abortStale = vi.fn();
+    mocks.generateInsight.mockReturnValueOnce({
+      abort: abortStale,
+      done: new Promise((r) => {
+        resolveStale = r;
+      }),
+    });
+    const { rerender } = render(ActivityInsight, {
+      dateFrom: "2026-06-15", dateTo: "2026-06-21",
+    });
+    await settle();
+
+    // Start a generation for the first range.
+    await fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(mocks.generateInsight).toHaveBeenCalledTimes(1);
+
+    // Range change aborts and invalidates the in-flight generation.
+    await rerender({ dateFrom: "2026-06-08", dateTo: "2026-06-14" });
+    await settle();
+    expect(abortStale).toHaveBeenCalled();
+
+    // The aborted generation settles late; its result must not reach the panel.
+    resolveStale({
+      id: 99, project: null, content: "STALE RESULT", type: "daily_activity",
+      date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
+      model: null, prompt: null, created_at: "2026-06-21T00:00:00Z",
+    });
+    await settle();
+
+    expect(document.body.textContent).not.toContain("STALE RESULT");
+  });
+
   it("prefills the Insights page range and navigates", async () => {
     render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
     await settle();

--- a/frontend/src/lib/components/activity/ActivityInsight.test.ts
+++ b/frontend/src/lib/components/activity/ActivityInsight.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
   setDateFrom: vi.fn(),
   setDateTo: vi.fn(),
   setProject: vi.fn(),
+  setAgent: vi.fn(),
   navigate: vi.fn(),
+  agent: "claude" as string,
   serverVersion: { read_only: false } as { read_only: boolean } | null,
 }));
 vi.mock("../../api/generated/index", () => ({
@@ -29,6 +31,10 @@ vi.mock("../../stores/insights.svelte.js", () => ({
   insights: {
     setType: mocks.setType, setDateFrom: mocks.setDateFrom,
     setDateTo: mocks.setDateTo, setProject: mocks.setProject,
+    setAgent: mocks.setAgent,
+    get agent() {
+      return mocks.agent;
+    },
   },
 }));
 vi.mock("../../stores/router.svelte.js", () => ({
@@ -43,6 +49,7 @@ beforeEach(() => {
     if (typeof m === "function") m.mockReset();
   }
   mocks.serverVersion = { read_only: false };
+  mocks.agent = "claude";
   mocks.getInsights.mockResolvedValue({ insights: [] });
 });
 
@@ -79,6 +86,30 @@ describe("ActivityInsight", () => {
       expect.objectContaining({
         type: "daily_activity", date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
       }),
+      expect.any(Function),
+    );
+  });
+
+  it("lets the user choose the insight agent", async () => {
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    const select = screen.getByLabelText(/insight agent/i) as HTMLSelectElement;
+    expect(select.value).toBe("claude");
+    await fireEvent.change(select, { target: { value: "codex" } });
+    expect(mocks.setAgent).toHaveBeenCalledWith("codex");
+  });
+
+  it("generates with the selected agent, not a hardcoded one", async () => {
+    mocks.agent = "codex";
+    mocks.generateInsight.mockReturnValue({
+      abort: vi.fn(),
+      done: new Promise(() => {}),
+    });
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    await fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(mocks.generateInsight).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "codex" }),
       expect.any(Function),
     );
   });

--- a/frontend/src/lib/components/activity/ActivityInsight.test.ts
+++ b/frontend/src/lib/components/activity/ActivityInsight.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+const mocks = vi.hoisted(() => ({
+  generateInsight: vi.fn(),
+  getInsights: vi.fn(),
+  setType: vi.fn(),
+  setDateFrom: vi.fn(),
+  setDateTo: vi.fn(),
+  setProject: vi.fn(),
+  navigate: vi.fn(),
+  serverVersion: { read_only: false } as { read_only: boolean } | null,
+}));
+vi.mock("../../api/generated/index", () => ({
+  InsightsService: { getApiV1Insights: mocks.getInsights },
+}));
+vi.mock("../../api/runtime.js", () => ({ configureGeneratedClient: vi.fn() }));
+vi.mock("../../api/client.js", () => ({ generateInsight: mocks.generateInsight }));
+vi.mock("../../stores/sync.svelte.js", () => ({
+  sync: {
+    get serverVersion() {
+      return mocks.serverVersion;
+    },
+  },
+}));
+vi.mock("../../stores/insights.svelte.js", () => ({
+  insights: {
+    setType: mocks.setType, setDateFrom: mocks.setDateFrom,
+    setDateTo: mocks.setDateTo, setProject: mocks.setProject,
+  },
+}));
+vi.mock("../../stores/router.svelte.js", () => ({
+  router: { navigate: mocks.navigate },
+  getBasePath: () => "",
+}));
+
+import ActivityInsight from "./ActivityInsight.svelte";
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) {
+    if (typeof m === "function") m.mockReset();
+  }
+  mocks.serverVersion = { read_only: false };
+  mocks.getInsights.mockResolvedValue({ insights: [] });
+});
+
+function settle() {
+  return Promise.resolve().then(() => tick());
+}
+
+describe("ActivityInsight", () => {
+  it("fetches insights with both date bounds (full identity)", async () => {
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    expect(mocks.getInsights).toHaveBeenCalledWith({
+      type: "daily_activity", dateFrom: "2026-06-15", dateTo: "2026-06-21",
+    });
+  });
+
+  it("ignores project-scoped insights and shows the empty state", async () => {
+    mocks.getInsights.mockResolvedValue({
+      insights: [{ id: 1, project: "p1", content: "scoped", type: "daily_activity",
+        date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
+        model: null, prompt: null, created_at: "2026-06-21T00:00:00Z" }],
+    });
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    expect(screen.getByRole("button", { name: /generate/i })).toBeTruthy();
+  });
+
+  it("generates for the current range", async () => {
+    mocks.generateInsight.mockReturnValue({ abort: vi.fn(), done: new Promise(() => {}) });
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    await fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(mocks.generateInsight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "daily_activity", date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it("prefills the Insights page range and navigates", async () => {
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    const link = screen.getByRole("link", { name: /insights page|open in insights/i });
+    await fireEvent.click(link);
+    expect(mocks.setType).toHaveBeenCalledWith("daily_activity");
+    expect(mocks.setDateFrom).toHaveBeenCalledWith("2026-06-15");
+    expect(mocks.setDateTo).toHaveBeenCalledWith("2026-06-21");
+    expect(mocks.setProject).toHaveBeenCalledWith("");
+    expect(mocks.navigate).toHaveBeenCalledWith("insights");
+  });
+
+  it("disables Generate when the server version is unavailable", async () => {
+    mocks.serverVersion = null;
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    const btn = screen.getByRole("button", { name: /generate/i });
+    expect(btn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("selects the exact-range insight over a newer nested one", async () => {
+    mocks.getInsights.mockResolvedValue({
+      insights: [
+        {
+          id: 3, project: null, content: "SINGLE DAY", type: "daily_activity",
+          date_from: "2026-06-15", date_to: "2026-06-15", agent: "claude",
+          model: null, prompt: null, created_at: "2026-06-22T00:00:00Z",
+        },
+        {
+          id: 2, project: null, content: "WEEKLY ROLLUP", type: "daily_activity",
+          date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
+          model: null, prompt: null, created_at: "2026-06-21T00:00:00Z",
+        },
+      ],
+    });
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("WEEKLY ROLLUP");
+    expect(text).not.toContain("SINGLE DAY");
+  });
+
+  it("shows the model of the displayed insight", async () => {
+    mocks.getInsights.mockResolvedValue({
+      insights: [
+        {
+          id: 5, project: null, content: "summary", type: "daily_activity",
+          date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
+          model: "claude-sonnet-4.5", prompt: null,
+          created_at: "2026-06-21T00:00:00Z",
+        },
+      ],
+    });
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    expect(document.body.textContent).toContain("claude-sonnet-4.5");
+  });
+
+  it("hides the model while a range change is loading", async () => {
+    mocks.getInsights
+      .mockResolvedValueOnce({
+        insights: [
+          {
+            id: 9, project: null, content: "A", type: "daily_activity",
+            date_from: "2026-06-01", date_to: "2026-06-07", agent: "claude",
+            model: "model-A", prompt: null, created_at: "2026-06-07T00:00:00Z",
+          },
+        ],
+      })
+      .mockReturnValueOnce(new Promise(() => {})); // second range stays pending
+    const { rerender } = render(ActivityInsight, {
+      dateFrom: "2026-06-01", dateTo: "2026-06-07",
+    });
+    await settle();
+    expect(document.body.textContent).toContain("model-A");
+    await rerender({ dateFrom: "2026-06-08", dateTo: "2026-06-14" });
+    await settle();
+    // The new range is still loading, so the stale model must not show.
+    expect(document.body.textContent).not.toContain("model-A");
+    expect(document.body.textContent).toContain("Loading insight");
+  });
+});

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -11,16 +11,18 @@
   import ActivityInsight from "./ActivityInsight.svelte";
 
   // Date-only (local) bounds for the inline insight panel, derived from the
-  // loaded report's range. `range_end` is exclusive, so subtract 1ms before
-  // formatting to get the inclusive last local day, matching the date-only
-  // insight convention. Fall back to the anchor date before a report loads.
+  // loaded report's resolved range, the authoritative source for the current
+  // selection (day/week/month/custom are all resolved server-side). `range_end`
+  // is exclusive, so subtract 1ms before formatting to get the inclusive last
+  // local day. The panel is gated on a loaded report (below), so these are read
+  // only when a report exists; the empty-string fallback never reaches the API.
   const insightFrom = $derived(
-    activity.report ? localDateStr(new Date(activity.report.range_start)) : activity.date,
+    activity.report ? localDateStr(new Date(activity.report.range_start)) : "",
   );
   const insightTo = $derived(
     activity.report
       ? localDateStr(new Date(new Date(activity.report.range_end).getTime() - 1))
-      : activity.date,
+      : "",
   );
 
   // Page-local drill-down: clicking a Concurrency bucket filters the sessions
@@ -136,12 +138,17 @@
       <div class="status">No data for this period.</div>
     {/if}
 
-    <!-- Range-scoped, not report-filter-scoped: kept outside the
-         loading/error/report chain so it stays visible and only
-         refetches when the range changes, not on filter/report reloads. -->
-    <div class="chart-panel">
-      <ActivityInsight dateFrom={insightFrom} dateTo={insightTo} />
-    </div>
+    <!-- Range-scoped, not report-filter-scoped: kept outside the loading/error
+         chain so it stays visible across filter reloads and only refetches when
+         the resolved range changes. Gated on a loaded report so its bounds come
+         from the authoritative resolved range, never a stale or pre-load
+         single-day fallback (a deep link to a week/month/custom range would
+         otherwise fetch an insight for the wrong span while the report loads). -->
+    {#if activity.report}
+      <div class="chart-panel">
+        <ActivityInsight dateFrom={insightFrom} dateTo={insightTo} />
+      </div>
+    {/if}
   </div>
 </div>
 

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -142,7 +142,7 @@
       <RefreshControl
         lastUpdatedAt={activity.lastUpdatedAt}
         busy={activity.loading}
-        onRefresh={() => activity.load()}
+        onRefresh={() => activity.load({ background: true })}
         label="Refresh activity"
       />
     </div>

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -5,6 +5,8 @@
     localDateStr,
     type Automation,
   } from "../../stores/activity.svelte.js";
+  import { events } from "../../stores/events.svelte.js";
+  import RefreshControl from "../shared/RefreshControl.svelte";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
   import RangeControl from "./RangeControl.svelte";
   import RangeNavigator from "./RangeNavigator.svelte";
@@ -74,8 +76,19 @@
     // Idempotent; loads the activity filter option lists with one-shot
     // and automated sessions included, matching the activity report.
     activity.loadFilterOptions();
+    // The page owns the initial load. attach() above ran hydrateFromUrl, so the
+    // range/filters are set before this first load. RefreshControl handles the
+    // periodic refresh after that.
     activity.load();
-    return detach;
+    // SSE events only flag that newer data exists; they never refetch the
+    // report directly. Refetching on every event flips `loading` and blanks the
+    // dashboard, so it is bounded to the RefreshControl scheduler and the
+    // manual button.
+    const unsubEvents = events.subscribe(() => activity.markNewData());
+    return () => {
+      detach();
+      unsubEvents();
+    };
   });
 </script>
 
@@ -124,19 +137,24 @@
       <option value="interactive">Interactive</option>
       <option value="automated">Automated</option>
     </select>
+
+    <div class="refresh-slot">
+      <RefreshControl
+        lastUpdatedAt={activity.lastUpdatedAt}
+        busy={activity.loading}
+        onRefresh={() => activity.load()}
+        label="Refresh activity"
+      />
+    </div>
   </div>
 
   <div class="activity-content">
-    {#if activity.loading}
-      <div class="status">Loading activity report...</div>
-    {:else if activity.error}
-      <div class="status error">
-        <span>{activity.error}</span>
-        <button class="retry-btn" onclick={() => activity.load()}>
-          Retry
-        </button>
-      </div>
-    {:else if activity.report}
+    <!-- Report-first ordering: once a report is loaded it stays mounted through
+         every background refresh, so a periodic/SSE-driven reload updates props
+         in place instead of swapping in the full-screen "Loading" state and
+         remounting the charts (which read as a blank flash). The loading and
+         error states only show before the first report exists. -->
+    {#if activity.report}
       <SummaryCards report={activity.report} />
       <div class="chart-panel">
         <ConcurrencyTimeline
@@ -155,6 +173,15 @@
       </div>
       <div class="chart-panel">
         <Breakdowns report={activity.report} />
+      </div>
+    {:else if activity.loading}
+      <div class="status">Loading activity report...</div>
+    {:else if activity.error}
+      <div class="status error">
+        <span>{activity.error}</span>
+        <button class="retry-btn" onclick={() => activity.load()}>
+          Retry
+        </button>
       </div>
     {:else}
       <div class="status">No data for this period.</div>
@@ -211,6 +238,14 @@
   .filter-select:focus {
     outline: none;
     border-color: var(--accent-blue);
+  }
+
+  /* Push the shared refresh control to the right edge of the toolbar, matching
+     the Analytics/Usage refresh affordance. */
+  .refresh-slot {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
   }
 
   .activity-content {

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { activity, localDateStr } from "../../stores/activity.svelte.js";
+  import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
+  import RangeControl from "./RangeControl.svelte";
+  import RangeNavigator from "./RangeNavigator.svelte";
+  import SummaryCards from "./SummaryCards.svelte";
+  import ConcurrencyTimeline from "./ConcurrencyTimeline.svelte";
+  import SessionsTable from "./SessionsTable.svelte";
+  import Breakdowns from "./Breakdowns.svelte";
+  import ActivityInsight from "./ActivityInsight.svelte";
+
+  // Date-only (local) bounds for the inline insight panel, derived from the
+  // loaded report's range. `range_end` is exclusive, so subtract 1ms before
+  // formatting to get the inclusive last local day, matching the date-only
+  // insight convention. Fall back to the anchor date before a report loads.
+  const insightFrom = $derived(
+    activity.report ? localDateStr(new Date(activity.report.range_start)) : activity.date,
+  );
+  const insightTo = $derived(
+    activity.report
+      ? localDateStr(new Date(new Date(activity.report.range_end).getTime() - 1))
+      : activity.date,
+  );
+
+  // Page-local drill-down: clicking a Concurrency bucket filters the sessions
+  // table to the sessions active in that slot. Deliberately not URL-synced — it
+  // is a transient selection that resets whenever the report reloads.
+  let slotFilter = $state<{
+    idx: number;
+    label: string;
+    sessionIds: string[];
+  } | null>(null);
+
+  // A reloaded report (range/filter change) gets fresh buckets and sessions, so
+  // a slot index/membership captured against the old report is stale; clear it.
+  $effect(() => {
+    void activity.report;
+    slotFilter = null;
+  });
+
+  function onProjectSelect(value: string) {
+    activity.setProject(value);
+    activity.load();
+  }
+
+  function onAgentChange(e: Event) {
+    activity.setAgent((e.currentTarget as HTMLSelectElement).value);
+    activity.load();
+  }
+
+  function onMachineChange(e: Event) {
+    activity.setMachine((e.currentTarget as HTMLSelectElement).value);
+    activity.load();
+  }
+
+  onMount(() => {
+    // Register as a consumer so a completed sync refreshes the filter
+    // dropdowns while this page is on screen; detach on unmount.
+    const detach = activity.attach();
+    // Idempotent; loads the activity filter option lists with one-shot
+    // and automated sessions included, matching the activity report.
+    activity.loadFilterOptions();
+    activity.load();
+    return detach;
+  });
+</script>
+
+<div class="activity-page">
+  <div class="activity-toolbar">
+    <RangeControl />
+    <RangeNavigator />
+
+    <ProjectTypeahead
+      projects={activity.projects}
+      value={activity.project}
+      onselect={onProjectSelect}
+    />
+
+    <select
+      class="filter-select"
+      value={activity.agent}
+      onchange={onAgentChange}
+      aria-label="Filter by agent"
+    >
+      <option value="">All Agents</option>
+      {#each activity.agents as a}
+        <option value={a.name}>{a.name}</option>
+      {/each}
+    </select>
+
+    <select
+      class="filter-select"
+      value={activity.machine}
+      onchange={onMachineChange}
+      aria-label="Filter by machine"
+    >
+      <option value="">All Machines</option>
+      {#each activity.machines as m}
+        <option value={m}>{m}</option>
+      {/each}
+    </select>
+  </div>
+
+  <div class="activity-content">
+    {#if activity.loading}
+      <div class="status">Loading activity report...</div>
+    {:else if activity.error}
+      <div class="status error">
+        <span>{activity.error}</span>
+        <button class="retry-btn" onclick={() => activity.load()}>
+          Retry
+        </button>
+      </div>
+    {:else if activity.report}
+      <SummaryCards report={activity.report} />
+      <div class="chart-panel">
+        <ConcurrencyTimeline
+          report={activity.report}
+          selectedBucket={slotFilter?.idx ?? null}
+          onSelectBucket={(sel) => (slotFilter = sel)}
+        />
+      </div>
+      <div class="chart-panel">
+        <SessionsTable
+          report={activity.report}
+          filterIds={slotFilter?.sessionIds ?? null}
+          filterLabel={slotFilter?.label ?? ""}
+          onClearFilter={() => (slotFilter = null)}
+        />
+      </div>
+      <div class="chart-panel">
+        <Breakdowns report={activity.report} />
+      </div>
+    {:else}
+      <div class="status">No data for this period.</div>
+    {/if}
+
+    <!-- Range-scoped, not report-filter-scoped: kept outside the
+         loading/error/report chain so it stays visible and only
+         refetches when the range changes, not on filter/report reloads. -->
+    <div class="chart-panel">
+      <ActivityInsight dateFrom={insightFrom} dateTo={insightTo} />
+    </div>
+  </div>
+</div>
+
+<style>
+  .activity-page {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .activity-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 8px 16px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-muted);
+    flex-shrink: 0;
+  }
+
+  .filter-select {
+    height: 26px;
+    padding: 0 8px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .filter-select:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+  }
+
+  .activity-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .chart-panel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    padding: 12px;
+    min-width: 0;
+  }
+
+  .status {
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 24px;
+    text-align: center;
+  }
+
+  .status.error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: var(--accent-red);
+  }
+
+  .retry-btn {
+    padding: 2px 8px;
+    border: 1px solid var(--accent-red);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: var(--accent-red);
+    cursor: pointer;
+  }
+
+  .retry-btn:hover {
+    background: var(--accent-red);
+    color: #fff;
+  }
+</style>

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -146,7 +146,11 @@
          otherwise fetch an insight for the wrong span while the report loads). -->
     {#if activity.report}
       <div class="chart-panel">
-        <ActivityInsight dateFrom={insightFrom} dateTo={insightTo} />
+        <ActivityInsight
+          dateFrom={insightFrom}
+          dateTo={insightTo}
+          timezone={activity.timezone}
+        />
       </div>
     {/if}
   </div>

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { activity, localDateStr } from "../../stores/activity.svelte.js";
+  import {
+    activity,
+    localDateStr,
+    type Automation,
+  } from "../../stores/activity.svelte.js";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
   import RangeControl from "./RangeControl.svelte";
   import RangeNavigator from "./RangeNavigator.svelte";
@@ -56,6 +60,13 @@
     activity.load();
   }
 
+  function onAutomationChange(e: Event) {
+    activity.setAutomation(
+      (e.currentTarget as HTMLSelectElement).value as Automation,
+    );
+    activity.load();
+  }
+
   onMount(() => {
     // Register as a consumer so a completed sync refreshes the filter
     // dropdowns while this page is on screen; detach on unmount.
@@ -101,6 +112,17 @@
       {#each activity.machines as m}
         <option value={m}>{m}</option>
       {/each}
+    </select>
+
+    <select
+      class="filter-select"
+      value={activity.automation}
+      onchange={onAutomationChange}
+      aria-label="Filter by automation"
+    >
+      <option value="all">All Sessions</option>
+      <option value="interactive">Interactive</option>
+      <option value="automated">Automated</option>
     </select>
   </div>
 

--- a/frontend/src/lib/components/activity/Breakdowns.svelte
+++ b/frontend/src/lib/components/activity/Breakdowns.svelte
@@ -1,0 +1,300 @@
+<script lang="ts">
+  import type { Report } from "../../api/types.js";
+  import type { ActivityKeyMinutes } from "../../api/generated/index";
+
+  let { report }: { report: Report } = $props();
+
+  type Metric = "minutes" | "cost";
+  let metric = $state<Metric>("minutes");
+
+  // by_* fields are typed `any[] | null` by the codegen; cast each
+  // to the generated element model for field-level type safety.
+  function asKeyMinutes(arr: any[] | null): ActivityKeyMinutes[] {
+    return (arr ?? []) as ActivityKeyMinutes[];
+  }
+
+  function rowValue(row: ActivityKeyMinutes): number {
+    return metric === "cost" ? row.cost : row.agent_minutes;
+  }
+
+  // Rank by the selected metric and drop rows that are zero for it: an untimed
+  // cost-only row contributes nothing to the minutes view (and would otherwise
+  // render as an empty "0" bar), and a zero-cost row drops from the cost view.
+  // The backend pre-sorts by minutes, so re-sort for the cost view.
+  function rankedRows(arr: any[] | null): ActivityKeyMinutes[] {
+    return asKeyMinutes(arr)
+      .filter((r) => rowValue(r) > 0)
+      .sort((a, b) => rowValue(b) - rowValue(a));
+  }
+
+  const byProject = $derived(rankedRows(report.by_project));
+  const byModel = $derived(rankedRows(report.by_model));
+  const byAgent = $derived(rankedRows(report.by_agent));
+
+  interface Panel {
+    title: string;
+    rows: ActivityKeyMinutes[];
+  }
+
+  const panels = $derived.by((): Panel[] => [
+    { title: "Project", rows: byProject },
+    { title: "Model", rows: byModel },
+    { title: "Agent", rows: byAgent },
+  ]);
+
+  function maxValue(rows: ActivityKeyMinutes[]): number {
+    if (rows.length === 0) return 1;
+    const m = Math.max(...rows.map(rowValue));
+    // Fall back to 1 only when the max is non-positive, so the largest bar
+    // reaches 100% even when every value is under one unit.
+    return m > 0 ? m : 1;
+  }
+
+  function barWidth(value: number, max: number): number {
+    return (value / max) * 100;
+  }
+
+  function fmtMinutes(v: number): string {
+    return Math.round(v).toLocaleString();
+  }
+
+  function fmtCost(v: number): string {
+    return `$${v.toFixed(2)}`;
+  }
+
+  function fmtValue(row: ActivityKeyMinutes): string {
+    return metric === "cost" ? fmtCost(row.cost) : fmtMinutes(row.agent_minutes);
+  }
+
+  function truncate(name: string, max: number): string {
+    if (name.length <= max) return name;
+    return name.slice(0, max - 1) + "…";
+  }
+
+  let tooltip = $state<{ x: number; y: number; text: string } | null>(null);
+
+  function sumValue(rows: ActivityKeyMinutes[]): number {
+    let total = 0;
+    for (const r of rows) total += rowValue(r);
+    return total;
+  }
+
+  function showTip(e: MouseEvent, row: ActivityKeyMinutes, total: number) {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const pct = total > 0 ? Math.round((rowValue(row) / total) * 100) : 0;
+    const unit = metric === "cost" ? "" : " min";
+    tooltip = {
+      x: rect.left + rect.width / 2,
+      y: rect.top - 4,
+      text: `${row.key} · ${fmtValue(row)}${unit} · ${pct}%`,
+    };
+  }
+
+  function hideTip() {
+    tooltip = null;
+  }
+</script>
+
+<div class="breakdowns">
+  <div class="breakdowns-header">
+    <h3 class="breakdowns-title">Breakdown</h3>
+    <div class="metric-toggle" role="group" aria-label="Breakdown metric">
+      <button
+        type="button"
+        class="metric-btn"
+        class:active={metric === "minutes"}
+        aria-pressed={metric === "minutes"}
+        onclick={() => (metric = "minutes")}
+      >
+        Agent-min
+      </button>
+      <button
+        type="button"
+        class="metric-btn"
+        class:active={metric === "cost"}
+        aria-pressed={metric === "cost"}
+        onclick={() => (metric = "cost")}
+      >
+        Cost
+      </button>
+    </div>
+  </div>
+
+  <div class="breakdown-grid">
+    {#each panels as panel (panel.title)}
+      {@const max = maxValue(panel.rows)}
+      {@const total = sumValue(panel.rows)}
+      <div class="breakdown-panel">
+        <h4 class="panel-title">{panel.title}</h4>
+        {#if panel.rows.length > 0}
+          <div class="bar-list">
+            {#each panel.rows as row (row.key)}
+              <!-- svelte-ignore a11y_no_static_element_interactions -->
+              <div
+                class="bar-row"
+                onmouseenter={(e) => showTip(e, row, total)}
+                onmouseleave={hideTip}
+              >
+                <span class="bar-label" title={row.key}>
+                  {truncate(row.key, 22)}
+                </span>
+                <div class="bar-track">
+                  <div
+                    class="bar-fill"
+                    style="width: {barWidth(rowValue(row), max)}%"
+                  ></div>
+                </div>
+                <span class="bar-value">
+                  {fmtValue(row)}
+                </span>
+              </div>
+            {/each}
+          </div>
+        {:else}
+          <div class="empty">none</div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+
+  {#if tooltip}
+    <div class="tooltip" style="left: {tooltip.x}px; top: {tooltip.y}px;">
+      {tooltip.text}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .breakdowns {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .breakdowns-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+
+  .breakdowns-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .metric-toggle {
+    display: inline-flex;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .metric-btn {
+    padding: 3px 10px;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--text-muted);
+    background: var(--bg-inset);
+    cursor: pointer;
+    border: none;
+  }
+
+  .metric-btn:hover {
+    color: var(--text-secondary);
+  }
+
+  .metric-btn.active {
+    background: var(--accent-blue);
+    color: #fff;
+  }
+
+  .metric-btn + .metric-btn {
+    border-left: 1px solid var(--border-muted);
+  }
+
+  .breakdown-grid {
+    display: grid;
+    grid-template-columns: repeat(
+      auto-fit,
+      minmax(220px, 1fr)
+    );
+    gap: 16px;
+  }
+
+  .breakdown-panel {
+    min-width: 0;
+  }
+
+  .panel-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+  }
+
+  .bar-list {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .bar-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .bar-label {
+    flex-shrink: 0;
+    width: 96px;
+    font-size: 11px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .bar-track {
+    flex: 1;
+    height: 14px;
+    background: var(--bg-inset);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .bar-fill {
+    height: 100%;
+    background: var(--accent-blue);
+    border-radius: 2px;
+    min-width: 2px;
+  }
+
+  .bar-value {
+    flex-shrink: 0;
+    width: 56px;
+    text-align: right;
+    font-size: 10px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+  }
+
+  .empty {
+    color: var(--text-muted);
+    font-size: 11px;
+    padding: 8px 0;
+  }
+
+  .tooltip {
+    position: fixed;
+    transform: translateX(-50%) translateY(-100%);
+    padding: 4px 8px;
+    background: var(--text-primary);
+    color: var(--bg-primary);
+    font-size: 10px;
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 100;
+  }
+</style>

--- a/frontend/src/lib/components/activity/Breakdowns.svelte
+++ b/frontend/src/lib/components/activity/Breakdowns.svelte
@@ -17,6 +17,18 @@
     return metric === "cost" ? row.cost : row.agent_minutes;
   }
 
+  // Per-row automation split for the active metric. Interactive + automated
+  // sum to rowValue, so the two bar segments stack to the full bar width.
+  function interactiveValue(row: ActivityKeyMinutes): number {
+    return metric === "cost"
+      ? row.interactive_cost
+      : row.interactive_agent_minutes;
+  }
+
+  function automatedValue(row: ActivityKeyMinutes): number {
+    return metric === "cost" ? row.automated_cost : row.automated_agent_minutes;
+  }
+
   // Rank by the selected metric and drop rows that are zero for it: an untimed
   // cost-only row contributes nothing to the minutes view (and would otherwise
   // render as an empty "0" bar), and a zero-cost row drops from the cost view.
@@ -66,6 +78,10 @@
     return metric === "cost" ? fmtCost(row.cost) : fmtMinutes(row.agent_minutes);
   }
 
+  function fmtSeg(v: number): string {
+    return metric === "cost" ? fmtCost(v) : fmtMinutes(v);
+  }
+
   function truncate(name: string, max: number): string {
     if (name.length <= max) return name;
     return name.slice(0, max - 1) + "…";
@@ -83,10 +99,13 @@
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
     const pct = total > 0 ? Math.round((rowValue(row) / total) * 100) : 0;
     const unit = metric === "cost" ? "" : " min";
+    const split = `int ${fmtSeg(interactiveValue(row))} / auto ${fmtSeg(
+      automatedValue(row),
+    )}`;
     tooltip = {
       x: rect.left + rect.width / 2,
       y: rect.top - 4,
-      text: `${row.key} · ${fmtValue(row)}${unit} · ${pct}%`,
+      text: `${row.key} · ${fmtValue(row)}${unit} · ${pct}% · ${split}`,
     };
   }
 
@@ -98,7 +117,16 @@
 <div class="breakdowns">
   <div class="breakdowns-header">
     <h3 class="breakdowns-title">Breakdown</h3>
-    <div class="metric-toggle" role="group" aria-label="Breakdown metric">
+    <div class="header-right">
+      <div class="legend" aria-hidden="true">
+        <span class="legend-item">
+          <span class="swatch interactive"></span>Interactive
+        </span>
+        <span class="legend-item">
+          <span class="swatch automated"></span>Automated
+        </span>
+      </div>
+      <div class="metric-toggle" role="group" aria-label="Breakdown metric">
       <button
         type="button"
         class="metric-btn"
@@ -117,6 +145,7 @@
       >
         Cost
       </button>
+      </div>
     </div>
   </div>
 
@@ -140,8 +169,12 @@
                 </span>
                 <div class="bar-track">
                   <div
-                    class="bar-fill"
-                    style="width: {barWidth(rowValue(row), max)}%"
+                    class="bar-seg interactive"
+                    style="width: {barWidth(interactiveValue(row), max)}%"
+                  ></div>
+                  <div
+                    class="bar-seg automated"
+                    style="width: {barWidth(automatedValue(row), max)}%"
                   ></div>
                 </div>
                 <span class="bar-value">
@@ -181,6 +214,40 @@
     font-size: 12px;
     font-weight: 600;
     color: var(--text-primary);
+  }
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .legend {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+
+  .swatch {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+  }
+
+  .swatch.interactive {
+    background: var(--accent-blue);
+  }
+
+  .swatch.automated {
+    background: var(--accent-purple);
   }
 
   .metric-toggle {
@@ -257,17 +324,23 @@
 
   .bar-track {
     flex: 1;
+    display: flex;
     height: 14px;
     background: var(--bg-inset);
     border-radius: 2px;
     overflow: hidden;
   }
 
-  .bar-fill {
+  .bar-seg {
     height: 100%;
+  }
+
+  .bar-seg.interactive {
     background: var(--accent-blue);
-    border-radius: 2px;
-    min-width: 2px;
+  }
+
+  .bar-seg.automated {
+    background: var(--accent-purple);
   }
 
   .bar-value {

--- a/frontend/src/lib/components/activity/Breakdowns.svelte
+++ b/frontend/src/lib/components/activity/Breakdowns.svelte
@@ -247,7 +247,7 @@
   }
 
   .swatch.automated {
-    background: var(--accent-purple);
+    background: var(--accent-orange);
   }
 
   .metric-toggle {
@@ -340,7 +340,7 @@
   }
 
   .bar-seg.automated {
-    background: var(--accent-purple);
+    background: var(--accent-orange);
   }
 
   .bar-value {

--- a/frontend/src/lib/components/activity/Breakdowns.test.ts
+++ b/frontend/src/lib/components/activity/Breakdowns.test.ts
@@ -27,8 +27,16 @@ function makeReport(): Report {
     elapsed_bucket_count: 0,
     buckets: [],
     by_project: [
-      { key: "alpha", agent_minutes: 30 },
-      { key: "beta", agent_minutes: 10 },
+      {
+        key: "alpha", agent_minutes: 30, cost: 0,
+        interactive_agent_minutes: 20, automated_agent_minutes: 10,
+        interactive_cost: 0, automated_cost: 0,
+      },
+      {
+        key: "beta", agent_minutes: 10, cost: 0,
+        interactive_agent_minutes: 10, automated_agent_minutes: 0,
+        interactive_cost: 0, automated_cost: 0,
+      },
     ],
     by_model: [],
     by_agent: [],
@@ -62,13 +70,45 @@ describe("Breakdowns", () => {
     target.remove();
   });
 
+  it("stacks interactive and automated segments and shows the split in the tooltip", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(Breakdowns, { target, props: { report: makeReport() } });
+    await tick();
+    // First project row = alpha (20 interactive + 10 automated agent-minutes).
+    const row = target.querySelector(".bar-row") as HTMLElement;
+    const interactive = row.querySelector(".bar-seg.interactive") as HTMLElement;
+    const automated = row.querySelector(".bar-seg.automated") as HTMLElement;
+    expect(interactive).toBeTruthy();
+    expect(automated).toBeTruthy();
+    // The interactive share (20) is wider than the automated share (10).
+    const width = (el: HTMLElement) => Number.parseFloat(el.style.width);
+    expect(width(interactive)).toBeGreaterThan(width(automated));
+
+    row.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector(".tooltip");
+    expect(tip!.textContent).toContain("int 20");
+    expect(tip!.textContent).toContain("auto 10");
+    unmount(c);
+    target.remove();
+  });
+
   it("filters cost-only rows from the default agent-minutes view", async () => {
     const report = makeReport();
     // The backend emits rows with cost but zero agent-minutes for untimed
     // usage; they must not render as empty "0" bars in the minutes view.
     report.by_project = [
-      { key: "timed", agent_minutes: 30, cost: 1 },
-      { key: "costonly", agent_minutes: 0, cost: 5 },
+      {
+        key: "timed", agent_minutes: 30, cost: 1,
+        interactive_agent_minutes: 30, automated_agent_minutes: 0,
+        interactive_cost: 1, automated_cost: 0,
+      },
+      {
+        key: "costonly", agent_minutes: 0, cost: 5,
+        interactive_agent_minutes: 0, automated_agent_minutes: 0,
+        interactive_cost: 5, automated_cost: 0,
+      },
     ] as Report["by_project"];
     const target = document.createElement("div");
     document.body.appendChild(target);
@@ -86,8 +126,16 @@ describe("Breakdowns", () => {
   it("switches to cost, revealing cost-only rows ranked by cost", async () => {
     const report = makeReport();
     report.by_project = [
-      { key: "timed", agent_minutes: 30, cost: 1 },
-      { key: "costonly", agent_minutes: 0, cost: 5 },
+      {
+        key: "timed", agent_minutes: 30, cost: 1,
+        interactive_agent_minutes: 30, automated_agent_minutes: 0,
+        interactive_cost: 1, automated_cost: 0,
+      },
+      {
+        key: "costonly", agent_minutes: 0, cost: 5,
+        interactive_agent_minutes: 0, automated_agent_minutes: 0,
+        interactive_cost: 5, automated_cost: 0,
+      },
     ] as Report["by_project"];
     const target = document.createElement("div");
     document.body.appendChild(target);

--- a/frontend/src/lib/components/activity/Breakdowns.test.ts
+++ b/frontend/src/lib/components/activity/Breakdowns.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { mount, tick, unmount } from "svelte";
+import Breakdowns from "./Breakdowns.svelte";
+import type { Report } from "../../api/types.js";
+
+function makeReport(): Report {
+  return {
+    peak: { agents: 0, at: null },
+    totals: {
+      active_minutes: 0, idle_minutes: 0, agent_minutes: 0, sessions: 0,
+      untimed_sessions: 0, distinct_projects: 0, distinct_models: 0,
+      output_tokens: 0, cost: 0,
+      automated_agent_minutes: 0, interactive_agent_minutes: 0,
+      automated_cost: 0, interactive_cost: 0,
+    },
+    partial: false,
+    as_of: null,
+    timezone: "UTC",
+    range_start: "2026-06-16T00:00:00Z",
+    range_end: "2026-06-17T00:00:00Z",
+    bucket_unit: "minute",
+    effective_end: "2026-06-17T00:00:00Z",
+    bucket_seconds: 300,
+    bucket_count: 0,
+    elapsed_bucket_count: 0,
+    buckets: [],
+    by_project: [
+      { key: "alpha", agent_minutes: 30 },
+      { key: "beta", agent_minutes: 10 },
+    ],
+    by_model: [],
+    by_agent: [],
+    by_session: [],
+    intervals: [],
+  } as Report;
+}
+
+describe("Breakdowns", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows a tooltip with the key and share-of-total on bar hover", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(Breakdowns, { target, props: { report: makeReport() } });
+    await tick();
+    const row = target.querySelector(".bar-row") as HTMLElement; // first project row = alpha (30 of 40)
+    expect(row).toBeTruthy();
+    row.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector(".tooltip");
+    expect(tip).toBeTruthy();
+    expect(tip!.textContent).toContain("alpha");
+    expect(tip!.textContent).toContain("75%");
+    row.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+    await tick();
+    expect(target.querySelector(".tooltip")).toBeNull();
+    unmount(c);
+    target.remove();
+  });
+
+  it("filters cost-only rows from the default agent-minutes view", async () => {
+    const report = makeReport();
+    // The backend emits rows with cost but zero agent-minutes for untimed
+    // usage; they must not render as empty "0" bars in the minutes view.
+    report.by_project = [
+      { key: "timed", agent_minutes: 30, cost: 1 },
+      { key: "costonly", agent_minutes: 0, cost: 5 },
+    ] as Report["by_project"];
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(Breakdowns, { target, props: { report } });
+    await tick();
+    const labels = [...target.querySelectorAll(".bar-label")].map(
+      (el) => el.textContent?.trim() ?? "",
+    );
+    expect(labels).toContain("timed");
+    expect(labels).not.toContain("costonly");
+    unmount(c);
+    target.remove();
+  });
+
+  it("switches to cost, revealing cost-only rows ranked by cost", async () => {
+    const report = makeReport();
+    report.by_project = [
+      { key: "timed", agent_minutes: 30, cost: 1 },
+      { key: "costonly", agent_minutes: 0, cost: 5 },
+    ] as Report["by_project"];
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(Breakdowns, { target, props: { report } });
+    await tick();
+    const costBtn = [...target.querySelectorAll(".metric-btn")].find(
+      (b) => b.textContent?.trim() === "Cost",
+    ) as HTMLButtonElement | undefined;
+    expect(costBtn).toBeTruthy();
+    costBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    const labels = [...target.querySelectorAll(".bar-label")].map(
+      (el) => el.textContent?.trim() ?? "",
+    );
+    // The cost-only row appears and outranks the lower-cost timed row.
+    expect(labels[0]).toBe("costonly");
+    expect(labels).toContain("timed");
+    const values = [...target.querySelectorAll(".bar-value")].map(
+      (el) => el.textContent?.trim() ?? "",
+    );
+    expect(values.some((v) => v.includes("$5.00"))).toBe(true);
+    unmount(c);
+    target.remove();
+  });
+});

--- a/frontend/src/lib/components/activity/Breakdowns.test.ts
+++ b/frontend/src/lib/components/activity/Breakdowns.test.ts
@@ -13,6 +13,7 @@ function makeReport(): Report {
       output_tokens: 0, cost: 0,
       automated_agent_minutes: 0, interactive_agent_minutes: 0,
       automated_cost: 0, interactive_cost: 0,
+      automated_sessions: 0, interactive_sessions: 0,
     },
     partial: false,
     as_of: null,

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -264,7 +264,7 @@
       const cellW = Math.max(((bEnd - bStart) / rangeSpanMs) * plotWidth, 1);
       const barGap = Math.min(cellW * 0.2, 2);
       const top = scaleY(b.max_agents, scale.max, CHART_H);
-      // Split the peak bar into a blue interactive base and a purple automated
+      // Split the peak bar into a blue interactive base and an orange automated
       // cap. interactive_at_peak + automated_at_peak == max_agents, so the two
       // segments stack to the full bar; interactiveTop is the seam between them.
       const interactiveTop = scaleY(b.interactive_at_peak, scale.max, CHART_H);
@@ -609,7 +609,7 @@
   }
 
   .swatch.automated {
-    background: var(--accent-purple);
+    background: var(--accent-orange);
   }
 
   .overlay-toggle {
@@ -667,7 +667,7 @@
   }
 
   .concurrency-seg.automated {
-    fill: var(--accent-purple);
+    fill: var(--accent-orange);
   }
 
   .concurrency-seg.selected {

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -1,0 +1,646 @@
+<script lang="ts">
+  import type { Report } from "../../api/types.js";
+  import { activeSessionsInSlot } from "./activeSessions.js";
+  import type {
+    ActivityBucket,
+    ActivityReportInterval,
+    ActivitySessionRow,
+  } from "../../api/generated/index";
+
+  let {
+    report,
+    selectedBucket = null,
+    onSelectBucket,
+  }: {
+    report: Report;
+    selectedBucket?: number | null;
+    onSelectBucket?: (
+      sel: { idx: number; label: string; sessionIds: string[] } | null,
+    ) => void;
+  } = $props();
+
+  const CHART_H = 160;
+  const X_LABEL_H = 18;
+  const STRIP_H = 14;
+  const STRIP_GAP = 6;
+  const Y_LABEL_W = 32;
+  const RIGHT_PAD = 8;
+  // Reserved headroom so the tallest bar, its grid line, and
+  // the top y-axis label do not clip against the viewBox edge.
+  const TOP_PAD = 10;
+  const TICK_TARGET = 4;
+
+  // buckets/by_* are typed `any[] | null` by the codegen, so cast
+  // to the generated element model for field-level type safety.
+  const buckets = $derived(
+    (report.buckets ?? []) as ActivityBucket[],
+  );
+
+  let tooltip = $state<{ x: number; y: number; text: string } | null>(null);
+
+  // Format bucket boundaries in the report's own timezone. Bucket start/end are
+  // UTC instants of local calendar boundaries, so rendering them in the report
+  // timezone keeps a "day" bucket on its intended calendar date.
+  function timeLabel(ms: number): string {
+    return new Date(ms).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+      timeZone: report.timezone,
+    });
+  }
+
+  function weekdayLabel(ms: number): string {
+    return new Date(ms).toLocaleDateString([], {
+      weekday: "short",
+      timeZone: report.timezone,
+    });
+  }
+
+  function dateLabel(ms: number): string {
+    return new Date(ms).toLocaleDateString([], {
+      month: "short",
+      day: "numeric",
+      timeZone: report.timezone,
+    });
+  }
+
+  function fmtMinuteRange(startMs: number, endMs: number): string {
+    return `${timeLabel(startMs)}–${timeLabel(endMs)}`;
+  }
+
+  function fmtHourRange(startMs: number, endMs: number): string {
+    return `${weekdayLabel(startMs)} ${timeLabel(startMs)}–${timeLabel(endMs)}`;
+  }
+
+  function fmtDayRange(startMs: number): string {
+    return dateLabel(startMs);
+  }
+
+  // The bucket end is exclusive; the last included instant is 1ms before it,
+  // which formats to the inclusive last day (DST-safe, unlike subtracting 24h).
+  function fmtWeekRange(startMs: number, endMs: number): string {
+    return `${dateLabel(startMs)}–${dateLabel(endMs - 1)}`;
+  }
+
+  function fmtBucketRange(b: ActivityBucket): string {
+    const startMs = Date.parse(b.start);
+    const endMs = Date.parse(b.end);
+    if (Number.isNaN(startMs) || Number.isNaN(endMs)) return "";
+    if (report.bucket_unit === "hour") return fmtHourRange(startMs, endMs);
+    if (report.bucket_unit === "day") return fmtDayRange(startMs);
+    if (report.bucket_unit === "week") return fmtWeekRange(startMs, endMs);
+    return fmtMinuteRange(startMs, endMs);
+  }
+
+  function showSlotTip(e: MouseEvent, b: ActivityBucket) {
+    const rect = (e.currentTarget as Element).getBoundingClientRect();
+    tooltip = {
+      x: rect.left + rect.width / 2,
+      y: rect.top - 4,
+      text:
+        `${fmtBucketRange(b)} · peak ${b.max_agents} · ` +
+        `${b.agent_minutes.toFixed(1)} agent-min · ` +
+        `${b.output_tokens.toLocaleString()} output tokens · ` +
+        `$${b.cost.toFixed(2)}`,
+    };
+  }
+
+  function hideTip() {
+    tooltip = null;
+  }
+
+  const intervals = $derived(
+    (report.intervals ?? []) as ActivityReportInterval[],
+  );
+  const bySession = $derived(
+    new Map(
+      ((report.by_session ?? []) as ActivitySessionRow[]).map(
+        (r) => [r.session_id, r],
+      ),
+    ),
+  );
+
+  // Half-open [startMs, endMs) for a slot, taken straight from the bucket's own
+  // bounds (variable-width across presets). A missing bucket yields NaN bounds;
+  // NaN comparisons are all false in activeSessionsInSlot, so the slot resolves
+  // to an empty membership rather than throwing. In practice idx always maps to
+  // a rendered bucket.
+  function slotBounds(idx: number): { startMs: number; endMs: number } {
+    const b = buckets[idx];
+    if (!b) return { startMs: NaN, endMs: NaN };
+    return { startMs: Date.parse(b.start), endMs: Date.parse(b.end) };
+  }
+
+  // Clicking a bucket hands its active-session membership to the parent, which
+  // owns the page-local sessions-table filter. Clicking the already selected
+  // bucket clears the filter. The parent resets `selectedBucket` to null
+  // whenever the report reloads, so a stale slot never points at a wrong bucket.
+  function selectSlot(idx: number) {
+    if (!onSelectBucket) return;
+    if (selectedBucket === idx) {
+      onSelectBucket(null);
+      return;
+    }
+    const b = buckets[idx];
+    const { startMs, endMs } = slotBounds(idx);
+    const sessionIds = activeSessionsInSlot(
+      intervals,
+      startMs,
+      endMs,
+      bySession,
+    ).map((r) => r.session_id);
+    onSelectBucket({ idx, label: b ? fmtBucketRange(b) : "", sessionIds });
+  }
+
+  function onSlotKey(e: KeyboardEvent, idx: number) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      selectSlot(idx);
+    }
+  }
+
+  // Optional secondary series overlaid on the bars: none, output tokens, or
+  // cost. Each metric scales to its own max so the line reads as a shape over
+  // the concurrency bars, not an absolute count on the agent axis.
+  let overlayMetric = $state<"none" | "tokens" | "cost">("none");
+
+  function bucketOverlayValue(b: ActivityBucket): number {
+    return overlayMetric === "cost" ? b.cost : b.output_tokens;
+  }
+
+  let containerEl: HTMLDivElement | undefined = $state();
+  let containerWidth = $state(600);
+
+  $effect(() => {
+    if (!containerEl) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        containerWidth = Math.floor(entry.contentRect.width);
+      }
+    });
+    ro.observe(containerEl);
+    return () => ro.disconnect();
+  });
+
+  const plotWidth = $derived(
+    Math.max(containerWidth - Y_LABEL_W - RIGHT_PAD, 100),
+  );
+
+  // The plot maps the full [range_start, range_end) window onto plotWidth; every
+  // bucket positions itself by its real bounds within that span.
+  const rangeStartMs = $derived(Date.parse(report.range_start));
+  const rangeEndMs = $derived(Date.parse(report.range_end));
+  const rangeSpanMs = $derived(Math.max(rangeEndMs - rangeStartMs, 1));
+
+  // x pixel for a given instant within the range.
+  function xForMs(ms: number): number {
+    return Y_LABEL_W + ((ms - rangeStartMs) / rangeSpanMs) * plotWidth;
+  }
+
+  function niceScale(maxY: number): { step: number; max: number } {
+    if (!Number.isFinite(maxY) || maxY <= 0) {
+      return { step: 1, max: 1 };
+    }
+    const rough = maxY / TICK_TARGET;
+    const exp = Math.floor(Math.log10(rough));
+    const base = Math.pow(10, exp);
+    const normalized = rough / base;
+    let mult: number;
+    if (normalized <= 1) mult = 1;
+    else if (normalized <= 2) mult = 2;
+    else if (normalized <= 5) mult = 5;
+    else mult = 10;
+    const step = Math.max(mult * base, 1);
+    const max = Math.ceil(maxY / step) * step;
+    return { step, max };
+  }
+
+  const maxAgents = $derived.by(() => {
+    let m = 0;
+    for (const b of buckets) {
+      if (b.max_agents > m) m = b.max_agents;
+    }
+    return m;
+  });
+
+  const scale = $derived(niceScale(maxAgents));
+
+  function scaleY(val: number, max: number, h: number): number {
+    const plotH = h - TOP_PAD;
+    return h - (val / max) * plotH;
+  }
+
+  // Each bucket owns a full contiguous cell [cellX, cellX+cellW); the visible
+  // bar is inset by a small gap. Strip cells and hit targets reuse the cell.
+  const bars = $derived.by(() => {
+    const out: Array<{
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+      cellX: number;
+      cellW: number;
+      idx: number;
+    }> = [];
+    for (let i = 0; i < buckets.length; i++) {
+      const b = buckets[i]!;
+      const bStart = Date.parse(b.start);
+      const bEnd = Date.parse(b.end);
+      const cellX = xForMs(bStart);
+      const cellW = Math.max(((bEnd - bStart) / rangeSpanMs) * plotWidth, 1);
+      const barGap = Math.min(cellW * 0.2, 2);
+      const top = scaleY(b.max_agents, scale.max, CHART_H);
+      out.push({
+        x: cellX + barGap / 2,
+        y: top,
+        w: Math.max(cellW - barGap, 1),
+        h: Math.max(CHART_H - top, 0),
+        cellX,
+        cellW,
+        idx: i,
+      });
+    }
+    return out;
+  });
+
+  const overlayMax = $derived.by(() => {
+    let m = 0;
+    for (const b of buckets) {
+      const v = bucketOverlayValue(b);
+      if (v > m) m = v;
+    }
+    return m || 1;
+  });
+
+  const overlayPath = $derived.by(() => {
+    if (overlayMetric === "none" || buckets.length === 0) return "";
+    let d = "";
+    for (let i = 0; i < buckets.length; i++) {
+      const b = buckets[i]!;
+      const center = (Date.parse(b.start) + Date.parse(b.end)) / 2;
+      const x = xForMs(center);
+      const y = scaleY(bucketOverlayValue(b), overlayMax, CHART_H);
+      d += i === 0 ? `M${x},${y}` : `L${x},${y}`;
+    }
+    return d;
+  });
+
+  const yTicks = $derived.by(() => {
+    const { step, max } = scale;
+    if (max <= 0 || step <= 0) return [];
+    const ticks: Array<{ y: number; label: string }> = [];
+    const count = Math.round(max / step);
+    for (let i = 0; i <= count; i++) {
+      const val = step * i;
+      ticks.push({
+        y: scaleY(val, max, CHART_H),
+        label: String(val),
+      });
+    }
+    return ticks;
+  });
+
+  // Local clock fields in the report timezone, used to pick tick boundaries.
+  function localHour(ms: number): number {
+    return Number(
+      new Date(ms).toLocaleString("en-US", {
+        hour: "2-digit",
+        hourCycle: "h23",
+        timeZone: report.timezone,
+      }),
+    );
+  }
+
+  function localWeekday(ms: number): string {
+    return new Date(ms).toLocaleDateString("en-US", {
+      weekday: "short",
+      timeZone: report.timezone,
+    });
+  }
+
+  function localDayOfMonth(ms: number): number {
+    return Number(
+      new Date(ms).toLocaleDateString("en-US", {
+        day: "numeric",
+        timeZone: report.timezone,
+      }),
+    );
+  }
+
+  // Five ticks at even fractions of the range, each labelled with the actual
+  // local time (report timezone) at that position. A full day reads as
+  // 00:00/06:00/12:00/18:00/00:00; custom sub-day ranges track their real
+  // bounds instead of fixed 0/6/12/18/24 hour marks.
+  function minuteUnitTicks(): Array<{ x: number; label: string }> {
+    const out: Array<{ x: number; label: string }> = [];
+    for (const frac of [0, 0.25, 0.5, 0.75, 1]) {
+      const ms = rangeStartMs + frac * rangeSpanMs;
+      out.push({ x: xForMs(ms), label: timeLabel(ms) });
+    }
+    return out;
+  }
+
+  // One tick per bucket whose start satisfies the boundary predicate, labelled
+  // with its short date (used for hour/day/week presets).
+  function bucketBoundaryTicks(
+    isBoundary: (ms: number) => boolean,
+  ): Array<{ x: number; label: string }> {
+    const out: Array<{ x: number; label: string }> = [];
+    for (const b of buckets) {
+      const ms = Date.parse(b.start);
+      if (Number.isNaN(ms) || !isBoundary(ms)) continue;
+      out.push({ x: xForMs(ms), label: dateLabel(ms) });
+    }
+    return out;
+  }
+
+  const xTicks = $derived.by(() => {
+    if (report.bucket_unit === "hour") {
+      return bucketBoundaryTicks((ms) => localHour(ms) === 0);
+    }
+    if (report.bucket_unit === "day") {
+      return bucketBoundaryTicks((ms) => localWeekday(ms) === "Mon");
+    }
+    if (report.bucket_unit === "week") {
+      return bucketBoundaryTicks((ms) => localDayOfMonth(ms) === 1);
+    }
+    return minuteUnitTicks();
+  });
+
+  // Partial future region: shade from effective_end to range_end.
+  const effEndMs = $derived(Date.parse(report.effective_end));
+  const futureStartMs = $derived(Math.min(effEndMs, rangeEndMs));
+  const futureX = $derived(xForMs(futureStartMs));
+  const futureW = $derived(
+    Math.max(((rangeEndMs - futureStartMs) / rangeSpanMs) * plotWidth, 0),
+  );
+
+  const svgW = $derived(plotWidth + Y_LABEL_W + RIGHT_PAD);
+  const svgH = $derived(CHART_H + STRIP_GAP + STRIP_H + X_LABEL_H);
+  const stripY = $derived(CHART_H + STRIP_GAP);
+</script>
+
+<div class="timeline">
+  <div class="timeline-header">
+    <h3 class="timeline-title">Concurrency</h3>
+    <label class="overlay-toggle">
+      <span>Overlay</span>
+      <select bind:value={overlayMetric} aria-label="Concurrency overlay metric">
+        <option value="none">None</option>
+        <option value="tokens">Tokens</option>
+        <option value="cost">Cost</option>
+      </select>
+    </label>
+  </div>
+
+  <div class="timeline-body" bind:this={containerEl}>
+    <svg
+      width="100%"
+      height={svgH}
+      viewBox="0 0 {svgW} {svgH}"
+      preserveAspectRatio="xMidYMid meet"
+      class="timeline-svg"
+    >
+      {#if futureW > 0}
+        <rect
+          class="concurrency-future"
+          data-future
+          x={futureX}
+          y={TOP_PAD}
+          width={futureW}
+          height={CHART_H - TOP_PAD}
+        />
+      {/if}
+
+      {#each yTicks as tick}
+        <line
+          x1={Y_LABEL_W}
+          y1={tick.y}
+          x2={Y_LABEL_W + plotWidth}
+          y2={tick.y}
+          class="grid-line"
+        />
+        <text
+          x={Y_LABEL_W - 4}
+          y={tick.y + 3}
+          class="y-label"
+          text-anchor="end"
+        >
+          {tick.label}
+        </text>
+      {/each}
+
+      {#each bars as bar (bar.idx)}
+        <rect
+          class="concurrency-bar"
+          class:selected={selectedBucket === bar.idx}
+          x={bar.x}
+          y={bar.y}
+          width={bar.w}
+          height={bar.h}
+        />
+      {/each}
+
+      {#if overlayMetric !== "none" && overlayPath}
+        <path class="overlay-line" d={overlayPath} />
+      {/if}
+
+      {#each xTicks as tick}
+        <text
+          x={tick.x}
+          y={svgH - 4}
+          class="x-label"
+          text-anchor="middle"
+        >
+          {tick.label}
+        </text>
+      {/each}
+
+      <!-- Active/idle strip: one full-width cell per elapsed bucket. -->
+      {#each bars as bar (bar.idx)}
+        {@const b = buckets[bar.idx]}
+        <rect
+          class="strip-cell"
+          class:active={b !== undefined && b.max_agents > 0}
+          x={bar.cellX}
+          y={stripY}
+          width={bar.cellW}
+          height={STRIP_H}
+        />
+      {/each}
+      {#if futureW > 0}
+        <rect
+          class="strip-future"
+          x={futureX}
+          y={stripY}
+          width={futureW}
+          height={STRIP_H}
+        />
+      {/if}
+
+      <!-- Transparent full-cell per-bucket hover/click target (one per bucket).
+           data-bucket-bar lives here, not on the visible bar, because the hover
+           handler that drives the tooltip is on this interactive rect. -->
+      {#each bars as bar (bar.idx)}
+        {@const b = buckets[bar.idx]}
+        <rect
+          class="slot-hit"
+          data-bucket-bar
+          x={bar.cellX}
+          y={TOP_PAD}
+          width={bar.cellW}
+          height={stripY + STRIP_H - TOP_PAD}
+          role="button"
+          tabindex="0"
+          aria-pressed={selectedBucket === bar.idx}
+          aria-label="Filter sessions active in this time slot"
+          onmouseenter={(e) => b && showSlotTip(e, b)}
+          onmouseleave={hideTip}
+          onclick={() => selectSlot(bar.idx)}
+          onkeydown={(e) => onSlotKey(e, bar.idx)}
+        />
+      {/each}
+    </svg>
+
+    {#if tooltip}
+      <div class="tooltip" style="left: {tooltip.x}px; top: {tooltip.y}px;">
+        {tooltip.text}
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .timeline {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .timeline-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+  }
+
+  .timeline-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .overlay-toggle {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  .overlay-toggle select {
+    height: 20px;
+    padding: 0 4px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    font-size: 10px;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .timeline-body {
+    width: 100%;
+  }
+
+  .timeline-svg {
+    display: block;
+  }
+
+  .grid-line {
+    stroke: var(--border-muted);
+    stroke-width: 1;
+    stroke-dasharray: 2 2;
+  }
+
+  .y-label {
+    font-size: 9px;
+    fill: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .x-label {
+    font-size: 9px;
+    fill: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .concurrency-bar {
+    fill: var(--accent-blue);
+    opacity: 0.75;
+  }
+
+  .concurrency-bar.selected {
+    opacity: 1;
+    stroke: var(--text-primary);
+    stroke-width: 1;
+  }
+
+  .concurrency-future {
+    fill: var(--bg-inset);
+    opacity: 0.5;
+  }
+
+  .overlay-line {
+    fill: none;
+    stroke: var(--accent-amber);
+    stroke-width: 1.5;
+    opacity: 0.85;
+  }
+
+  .strip-cell {
+    fill: var(--bg-inset);
+    stroke: var(--bg-surface);
+    stroke-width: 0.5;
+  }
+
+  .strip-cell.active {
+    fill: var(--accent-blue);
+    opacity: 0.55;
+  }
+
+  .strip-future {
+    fill: var(--bg-inset);
+    opacity: 0.5;
+  }
+
+  .slot-hit {
+    fill: transparent;
+    cursor: pointer;
+  }
+
+  .slot-hit:hover {
+    fill: var(--accent-blue);
+    opacity: 0.08;
+  }
+
+  .slot-hit:focus-visible {
+    outline: 1px solid var(--accent-blue);
+    outline-offset: -1px;
+  }
+
+  .tooltip {
+    position: fixed;
+    transform: translateX(-50%) translateY(-100%);
+    padding: 4px 8px;
+    background: var(--text-primary);
+    color: var(--bg-primary);
+    font-size: 10px;
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 100;
+  }
+</style>

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -93,13 +93,21 @@
     return fmtMinuteRange(startMs, endMs);
   }
 
+  // Only the peak count splits by automation; the bucket's agent-minutes and
+  // cost stay combined (the API does not break those down per bucket), so the
+  // split annotation sits on "peak" alone and shows only when an automated
+  // agent was running at the peak.
   function showSlotTip(e: MouseEvent, b: ActivityBucket) {
     const rect = (e.currentTarget as Element).getBoundingClientRect();
+    const peakSplit =
+      b.automated_at_peak > 0
+        ? ` (${b.interactive_at_peak} int / ${b.automated_at_peak} auto)`
+        : "";
     tooltip = {
       x: rect.left + rect.width / 2,
       y: rect.top - 4,
       text:
-        `${fmtBucketRange(b)} · peak ${b.max_agents} · ` +
+        `${fmtBucketRange(b)} · peak ${b.max_agents}${peakSplit} · ` +
         `${b.agent_minutes.toFixed(1)} agent-min · ` +
         `${b.output_tokens.toLocaleString()} output tokens · ` +
         `$${b.cost.toFixed(2)}`,
@@ -240,6 +248,10 @@
       y: number;
       w: number;
       h: number;
+      interactiveY: number;
+      interactiveH: number;
+      automatedY: number;
+      automatedH: number;
       cellX: number;
       cellW: number;
       idx: number;
@@ -252,11 +264,19 @@
       const cellW = Math.max(((bEnd - bStart) / rangeSpanMs) * plotWidth, 1);
       const barGap = Math.min(cellW * 0.2, 2);
       const top = scaleY(b.max_agents, scale.max, CHART_H);
+      // Split the peak bar into a blue interactive base and a purple automated
+      // cap. interactive_at_peak + automated_at_peak == max_agents, so the two
+      // segments stack to the full bar; interactiveTop is the seam between them.
+      const interactiveTop = scaleY(b.interactive_at_peak, scale.max, CHART_H);
       out.push({
         x: cellX + barGap / 2,
         y: top,
         w: Math.max(cellW - barGap, 1),
         h: Math.max(CHART_H - top, 0),
+        interactiveY: interactiveTop,
+        interactiveH: Math.max(CHART_H - interactiveTop, 0),
+        automatedY: top,
+        automatedH: Math.max(interactiveTop - top, 0),
         cellX,
         cellW,
         idx: i,
@@ -385,14 +405,24 @@
 <div class="timeline">
   <div class="timeline-header">
     <h3 class="timeline-title">Concurrency</h3>
-    <label class="overlay-toggle">
-      <span>Overlay</span>
-      <select bind:value={overlayMetric} aria-label="Concurrency overlay metric">
-        <option value="none">None</option>
-        <option value="tokens">Tokens</option>
-        <option value="cost">Cost</option>
-      </select>
-    </label>
+    <div class="header-right">
+      <div class="legend" aria-hidden="true">
+        <span class="legend-item">
+          <span class="swatch interactive"></span>Interactive
+        </span>
+        <span class="legend-item">
+          <span class="swatch automated"></span>Automated
+        </span>
+      </div>
+      <label class="overlay-toggle">
+        <span>Overlay</span>
+        <select bind:value={overlayMetric} aria-label="Concurrency overlay metric">
+          <option value="none">None</option>
+          <option value="tokens">Tokens</option>
+          <option value="cost">Cost</option>
+        </select>
+      </label>
+    </div>
   </div>
 
   <div class="timeline-body" bind:this={containerEl}>
@@ -434,13 +464,30 @@
 
       {#each bars as bar (bar.idx)}
         <rect
-          class="concurrency-bar"
+          class="concurrency-seg interactive"
           class:selected={selectedBucket === bar.idx}
           x={bar.x}
-          y={bar.y}
+          y={bar.interactiveY}
           width={bar.w}
-          height={bar.h}
+          height={bar.interactiveH}
         />
+        <rect
+          class="concurrency-seg automated"
+          class:selected={selectedBucket === bar.idx}
+          x={bar.x}
+          y={bar.automatedY}
+          width={bar.w}
+          height={bar.automatedH}
+        />
+        {#if selectedBucket === bar.idx}
+          <rect
+            class="concurrency-outline"
+            x={bar.x}
+            y={bar.y}
+            width={bar.w}
+            height={bar.h}
+          />
+        {/if}
       {/each}
 
       {#if overlayMetric !== "none" && overlayPath}
@@ -531,6 +578,40 @@
     color: var(--text-primary);
   }
 
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .legend {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+
+  .swatch {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+  }
+
+  .swatch.interactive {
+    background: var(--accent-blue);
+  }
+
+  .swatch.automated {
+    background: var(--accent-purple);
+  }
+
   .overlay-toggle {
     display: flex;
     align-items: center;
@@ -577,13 +658,24 @@
     font-family: var(--font-mono);
   }
 
-  .concurrency-bar {
-    fill: var(--accent-blue);
+  .concurrency-seg {
     opacity: 0.75;
   }
 
-  .concurrency-bar.selected {
+  .concurrency-seg.interactive {
+    fill: var(--accent-blue);
+  }
+
+  .concurrency-seg.automated {
+    fill: var(--accent-purple);
+  }
+
+  .concurrency-seg.selected {
     opacity: 1;
+  }
+
+  .concurrency-outline {
+    fill: none;
     stroke: var(--text-primary);
     stroke-width: 1;
   }

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
@@ -11,14 +11,16 @@ class ResizeObserverMock {
 }
 
 function makeReport(overrides: Partial<Report> = {}): Report {
+  // idx 2 (peak 3) carries a mixed split (2 interactive / 1 automated) for the
+  // stacking and split-tooltip tests; idx 3 (peak 1) is all-interactive.
   const buckets = [
-    { start: "2026-06-16T00:00:00Z", end: "2026-06-16T03:00:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0 },
-    { start: "2026-06-16T03:00:00Z", end: "2026-06-16T06:00:00Z", max_agents: 2, agent_minutes: 12, output_tokens: 4000, cost: 0.4 },
-    { start: "2026-06-16T06:00:00Z", end: "2026-06-16T09:00:00Z", max_agents: 3, agent_minutes: 30, output_tokens: 9000, cost: 0.9 },
-    { start: "2026-06-16T09:00:00Z", end: "2026-06-16T12:00:00Z", max_agents: 1, agent_minutes: 8, output_tokens: 2000, cost: 0.2 },
-    { start: "2026-06-16T12:00:00Z", end: "2026-06-16T15:00:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0 },
+    { start: "2026-06-16T00:00:00Z", end: "2026-06-16T03:00:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0, interactive_at_peak: 0, automated_at_peak: 0 },
+    { start: "2026-06-16T03:00:00Z", end: "2026-06-16T06:00:00Z", max_agents: 2, agent_minutes: 12, output_tokens: 4000, cost: 0.4, interactive_at_peak: 1, automated_at_peak: 1 },
+    { start: "2026-06-16T06:00:00Z", end: "2026-06-16T09:00:00Z", max_agents: 3, agent_minutes: 30, output_tokens: 9000, cost: 0.9, interactive_at_peak: 2, automated_at_peak: 1 },
+    { start: "2026-06-16T09:00:00Z", end: "2026-06-16T12:00:00Z", max_agents: 1, agent_minutes: 8, output_tokens: 2000, cost: 0.2, interactive_at_peak: 1, automated_at_peak: 0 },
+    { start: "2026-06-16T12:00:00Z", end: "2026-06-16T15:00:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0, interactive_at_peak: 0, automated_at_peak: 0 },
   ];
-  return {
+  const report = {
     peak: { agents: 3, at: "2026-06-16T06:00:00Z" },
     totals: {
       active_minutes: 50,
@@ -51,6 +53,15 @@ function makeReport(overrides: Partial<Report> = {}): Report {
     intervals: [],
     ...overrides,
   } as Report;
+  // Backfill the peak-automation split onto any bucket literal that omits it
+  // (most fixtures only set max_agents), so the stacked bars get real geometry
+  // instead of NaN. Unspecified buckets default to all-interactive.
+  report.buckets = (report.buckets ?? []).map((b) => ({
+    interactive_at_peak: b.max_agents,
+    automated_at_peak: 0,
+    ...b,
+  }));
+  return report;
 }
 
 function popoverReport(): Report {
@@ -119,7 +130,7 @@ describe("ConcurrencyTimeline", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders exactly buckets.length solid bars", async () => {
+  it("renders one interactive and one automated segment per bucket", async () => {
     const report = makeReport();
     const c = mount(ConcurrencyTimeline, {
       target: document.body,
@@ -127,8 +138,35 @@ describe("ConcurrencyTimeline", () => {
     });
     await tick();
 
-    const bars = document.querySelectorAll(".concurrency-bar");
-    expect(bars.length).toBe(report.buckets!.length);
+    const interactive = document.querySelectorAll(".concurrency-seg.interactive");
+    const automated = document.querySelectorAll(".concurrency-seg.automated");
+    expect(interactive.length).toBe(report.buckets!.length);
+    expect(automated.length).toBe(report.buckets!.length);
+
+    unmount(c);
+  });
+
+  it("stacks a taller interactive base under a shorter automated cap", async () => {
+    const report = makeReport();
+    const c = mount(ConcurrencyTimeline, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+    // Bucket idx 2 peaks at 3 (2 interactive + 1 automated).
+    const interactive = document.querySelectorAll(
+      ".concurrency-seg.interactive",
+    )[2] as SVGRectElement;
+    const automated = document.querySelectorAll(
+      ".concurrency-seg.automated",
+    )[2] as SVGRectElement;
+    const h = (el: SVGRectElement) => Number(el.getAttribute("height"));
+    const y = (el: SVGRectElement) => Number(el.getAttribute("y"));
+    // The automated cap has real height and sits above (smaller y) the taller
+    // interactive base.
+    expect(h(automated)).toBeGreaterThan(0);
+    expect(h(interactive)).toBeGreaterThan(h(automated));
+    expect(y(automated)).toBeLessThan(y(interactive));
 
     unmount(c);
   });
@@ -215,6 +253,37 @@ describe("ConcurrencyTimeline", () => {
     expect(tip!.textContent).toContain("output tokens");
     expect(tip!.textContent).toContain("9,000");
     expect(tip!.textContent).toContain("$0.90");
+    unmount(c);
+    target.remove();
+  });
+
+  it("splits only the peak count in the tooltip, leaving agent-min combined", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
+    await tick();
+    const hit = target.querySelectorAll(".slot-hit")[2] as SVGRectElement; // peak 3 = 2 int / 1 auto
+    hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector(".tooltip");
+    expect(tip!.textContent).toContain("peak 3 (2 int / 1 auto)");
+    // agent-minutes stays a single combined figure, not split by automation.
+    expect(tip!.textContent).toContain("30.0 agent-min");
+    unmount(c);
+    target.remove();
+  });
+
+  it("omits the peak split when the bucket has no automated agent", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
+    await tick();
+    const hit = target.querySelectorAll(".slot-hit")[3] as SVGRectElement; // peak 1, all interactive
+    hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector(".tooltip");
+    expect(tip!.textContent).toContain("peak 1");
+    expect(tip!.textContent).not.toContain("int /");
     unmount(c);
     target.remove();
   });
@@ -308,7 +377,7 @@ describe("ConcurrencyTimeline", () => {
     target.remove();
   });
 
-  it("marks the selected bucket's bar", async () => {
+  it("marks the selected bucket with an outline and brightened segments", async () => {
     const target = document.createElement("div");
     document.body.appendChild(target);
     const c = mount(ConcurrencyTimeline, {
@@ -316,7 +385,8 @@ describe("ConcurrencyTimeline", () => {
       props: { report: popoverReport(), selectedBucket: 0 },
     });
     await tick();
-    expect(target.querySelector(".concurrency-bar.selected")).toBeTruthy();
+    expect(target.querySelector(".concurrency-outline")).toBeTruthy();
+    expect(target.querySelector(".concurrency-seg.selected")).toBeTruthy();
     unmount(c);
     target.remove();
   });

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
@@ -1,0 +1,422 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/svelte";
+import { mount, tick, unmount } from "svelte";
+import ConcurrencyTimeline from "./ConcurrencyTimeline.svelte";
+import type { Report } from "../../api/types.js";
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  disconnect = vi.fn();
+}
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  const buckets = [
+    { start: "2026-06-16T00:00:00Z", end: "2026-06-16T03:00:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0 },
+    { start: "2026-06-16T03:00:00Z", end: "2026-06-16T06:00:00Z", max_agents: 2, agent_minutes: 12, output_tokens: 4000, cost: 0.4 },
+    { start: "2026-06-16T06:00:00Z", end: "2026-06-16T09:00:00Z", max_agents: 3, agent_minutes: 30, output_tokens: 9000, cost: 0.9 },
+    { start: "2026-06-16T09:00:00Z", end: "2026-06-16T12:00:00Z", max_agents: 1, agent_minutes: 8, output_tokens: 2000, cost: 0.2 },
+    { start: "2026-06-16T12:00:00Z", end: "2026-06-16T15:00:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0 },
+  ];
+  return {
+    peak: { agents: 3, at: "2026-06-16T06:00:00Z" },
+    totals: {
+      active_minutes: 50,
+      idle_minutes: 10,
+      agent_minutes: 50,
+      sessions: 4,
+      untimed_sessions: 0,
+      distinct_projects: 2,
+      distinct_models: 1,
+      output_tokens: 15000,
+      cost: 1.5,
+    },
+    partial: false,
+    as_of: null,
+    timezone: "UTC",
+    range_start: "2026-06-16T00:00:00Z",
+    range_end: "2026-06-17T00:00:00Z",
+    bucket_unit: "hour",
+    // Five 3h buckets (00:00-15:00) have elapsed of the eight-bucket day, so the
+    // effective end is 15:00 and 15:00-24:00 is the future region.
+    effective_end: "2026-06-16T15:00:00Z",
+    bucket_seconds: 10800,
+    bucket_count: 8,
+    elapsed_bucket_count: 5,
+    buckets,
+    by_project: null,
+    by_model: null,
+    by_agent: null,
+    by_session: null,
+    intervals: [],
+    ...overrides,
+  } as Report;
+}
+
+function popoverReport(): Report {
+  return makeReport({
+    bucket_unit: "minute",
+    bucket_seconds: 300,
+    bucket_count: 2,
+    elapsed_bucket_count: 1,
+    buckets: [
+      { start: "2026-06-16T10:00:00Z", end: "2026-06-16T10:05:00Z", max_agents: 2, agent_minutes: 4, output_tokens: 0, cost: 0 },
+    ],
+    by_session: [
+      { session_id: "a", title: "Alpha", project: "p", agent: "claude", primary_model: "m",
+        models: ["m"], agent_minutes: 2, cost: 0, output_tokens: 0,
+        first_active: "2026-06-16T10:00:00Z", last_active: "2026-06-16T10:02:00Z", timing_quality: "timed" },
+      { session_id: "b", title: "Beta", project: "p", agent: "claude", primary_model: "m",
+        models: ["m"], agent_minutes: 2, cost: 0, output_tokens: 0,
+        first_active: "2026-06-16T10:01:00Z", last_active: "2026-06-16T10:03:00Z", timing_quality: "timed" },
+    ] as Report["by_session"],
+    intervals: [
+      { session_id: "a", start: "2026-06-16T10:00:00Z", end: "2026-06-16T10:01:00Z" },
+      { session_id: "a", start: "2026-06-16T10:01:00Z", end: "2026-06-16T10:02:00Z" },
+      { session_id: "b", start: "2026-06-16T10:01:00Z", end: "2026-06-16T10:03:00Z" },
+    ] as Report["intervals"],
+  });
+}
+
+// A minute-bucketed quarter-hour range used by the per-bucket geometry tests.
+function minuteReport(overrides: Partial<Report> = {}): Report {
+  return makeReport({
+    range_start: "2026-06-16T00:00:00Z",
+    range_end: "2026-06-16T00:15:00Z",
+    bucket_unit: "minute",
+    bucket_seconds: 300,
+    bucket_count: 3,
+    elapsed_bucket_count: 3,
+    effective_end: "2026-06-16T00:15:00Z",
+    buckets: [
+      { start: "2026-06-16T00:00:00Z", end: "2026-06-16T00:05:00Z", max_agents: 1, agent_minutes: 5, output_tokens: 10, cost: 0 },
+      { start: "2026-06-16T00:05:00Z", end: "2026-06-16T00:10:00Z", max_agents: 2, agent_minutes: 5, output_tokens: 20, cost: 0 },
+      { start: "2026-06-16T00:10:00Z", end: "2026-06-16T00:15:00Z", max_agents: 1, agent_minutes: 5, output_tokens: 5, cost: 0 },
+    ] as Report["buckets"],
+    ...overrides,
+  });
+}
+
+describe("ConcurrencyTimeline", () => {
+  let originalResizeObserver: typeof ResizeObserver | undefined;
+
+  beforeEach(() => {
+    originalResizeObserver = globalThis.ResizeObserver;
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: ResizeObserverMock,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: originalResizeObserver,
+    });
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("renders exactly buckets.length solid bars", async () => {
+    const report = makeReport();
+    const c = mount(ConcurrencyTimeline, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    const bars = document.querySelectorAll(".concurrency-bar");
+    expect(bars.length).toBe(report.buckets!.length);
+
+    unmount(c);
+  });
+
+  it("draws a future region when elapsed_bucket_count < bucket_count", async () => {
+    const report = makeReport();
+    expect(report.elapsed_bucket_count).toBeLessThan(report.bucket_count);
+    const c = mount(ConcurrencyTimeline, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    const future = document.querySelector(".concurrency-future");
+    expect(future).toBeTruthy();
+
+    unmount(c);
+  });
+
+  it("omits the future region for a complete day", async () => {
+    const report = makeReport({
+      bucket_count: 5,
+      elapsed_bucket_count: 5,
+      effective_end: "2026-06-17T00:00:00Z",
+    });
+    const c = mount(ConcurrencyTimeline, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    expect(document.querySelector(".concurrency-future")).toBeNull();
+
+    unmount(c);
+  });
+
+  it("shades the active/idle strip cell only when max_agents > 0", async () => {
+    const report = makeReport();
+    const c = mount(ConcurrencyTimeline, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    const cells = document.querySelectorAll(".strip-cell");
+    expect(cells.length).toBe(report.buckets!.length);
+    const active = document.querySelectorAll(".strip-cell.active");
+    expect(active.length).toBe(3);
+
+    unmount(c);
+  });
+
+  it("shows a tooltip on slot hover and clears it on leave", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
+    await tick();
+    const hits = target.querySelectorAll(".slot-hit");
+    expect(hits.length).toBe(makeReport().buckets!.length);
+    const hit = hits[2] as SVGRectElement; // bucket idx 2 has max_agents 3
+    hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector(".tooltip");
+    expect(tip).toBeTruthy();
+    expect(tip!.textContent).toContain("peak 3");
+    hit.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+    await tick();
+    expect(target.querySelector(".tooltip")).toBeNull();
+    unmount(c);
+    target.remove();
+  });
+
+  it("labels the token count as output and surfaces cost in the tooltip", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
+    await tick();
+    const hit = target.querySelectorAll(".slot-hit")[2] as SVGRectElement; // 9000 tokens, $0.90
+    hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector(".tooltip");
+    expect(tip).toBeTruthy();
+    // Disambiguates input vs output tokens and shows the overlay's cost value.
+    expect(tip!.textContent).toContain("output tokens");
+    expect(tip!.textContent).toContain("9,000");
+    expect(tip!.textContent).toContain("$0.90");
+    unmount(c);
+    target.remove();
+  });
+
+  it("emits the active session ids for a clicked slot", async () => {
+    const onSelectBucket = vi.fn();
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, {
+      target,
+      props: { report: popoverReport(), onSelectBucket },
+    });
+    await tick();
+    (target.querySelector(".slot-hit") as SVGRectElement)
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    // 3 intervals, "a" deduped to one row, sorted by earliest overlap then id.
+    expect(onSelectBucket).toHaveBeenCalledWith(
+      expect.objectContaining({ idx: 0, sessionIds: ["a", "b"] }),
+    );
+    unmount(c);
+    target.remove();
+  });
+
+  it("emits an empty session list for an idle slot", async () => {
+    const report = makeReport({
+      bucket_unit: "minute",
+      bucket_seconds: 300,
+      bucket_count: 3,
+      elapsed_bucket_count: 2,
+      buckets: [
+        { start: "2026-06-16T10:00:00Z", end: "2026-06-16T10:05:00Z", max_agents: 1, agent_minutes: 1, output_tokens: 0, cost: 0 },
+        { start: "2026-06-16T10:05:00Z", end: "2026-06-16T10:10:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0 },
+      ],
+      by_session: [] as Report["by_session"],
+      intervals: [] as Report["intervals"],
+    });
+    const onSelectBucket = vi.fn();
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, {
+      target,
+      props: { report, onSelectBucket },
+    });
+    await tick();
+    const hits = target.querySelectorAll(".slot-hit");
+    expect(hits.length).toBe(2);
+    (hits[1] as SVGRectElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    expect(onSelectBucket).toHaveBeenCalledWith(
+      expect.objectContaining({ idx: 1, sessionIds: [] }),
+    );
+    unmount(c);
+    target.remove();
+  });
+
+  it("clears the selection when the already selected slot is clicked again", async () => {
+    const onSelectBucket = vi.fn();
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    // selectedBucket=0 marks slot 0 active; clicking it again toggles it off.
+    const c = mount(ConcurrencyTimeline, {
+      target,
+      props: { report: popoverReport(), selectedBucket: 0, onSelectBucket },
+    });
+    await tick();
+    (target.querySelector(".slot-hit") as SVGRectElement)
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    expect(onSelectBucket).toHaveBeenCalledWith(null);
+    unmount(c);
+    target.remove();
+  });
+
+  it("selects a slot with a keyboard Enter", async () => {
+    const onSelectBucket = vi.fn();
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, {
+      target,
+      props: { report: popoverReport(), onSelectBucket },
+    });
+    await tick();
+    const hit = target.querySelector(".slot-hit") as SVGRectElement;
+    hit.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await tick();
+    expect(onSelectBucket).toHaveBeenCalledWith(
+      expect.objectContaining({ idx: 0 }),
+    );
+    unmount(c);
+    target.remove();
+  });
+
+  it("marks the selected bucket's bar", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, {
+      target,
+      props: { report: popoverReport(), selectedBucket: 0 },
+    });
+    await tick();
+    expect(target.querySelector(".concurrency-bar.selected")).toBeTruthy();
+    unmount(c);
+    target.remove();
+  });
+
+  it("renders one bar per bucket with widths from bucket bounds", () => {
+    render(ConcurrencyTimeline, { report: minuteReport() });
+    const bars = document.querySelectorAll("rect[data-bucket-bar]");
+    expect(bars.length).toBe(3);
+  });
+
+  it("shades a future region when the range is partial", () => {
+    const r = minuteReport({
+      bucket_count: 3,
+      elapsed_bucket_count: 2,
+      partial: true,
+      as_of: "2026-06-16T00:10:00Z",
+      effective_end: "2026-06-16T00:10:00Z",
+    });
+    render(ConcurrencyTimeline, { report: r });
+    expect(document.querySelector("rect[data-future]")).toBeTruthy();
+  });
+
+  it("formats a date-range tooltip for daily buckets", async () => {
+    const r = makeReport({
+      bucket_unit: "day",
+      range_start: "2026-06-15T00:00:00Z",
+      range_end: "2026-06-17T00:00:00Z",
+      bucket_seconds: 86400,
+      bucket_count: 2,
+      elapsed_bucket_count: 2,
+      effective_end: "2026-06-17T00:00:00Z",
+      buckets: [
+        { start: "2026-06-15T00:00:00Z", end: "2026-06-16T00:00:00Z", max_agents: 1, agent_minutes: 10, output_tokens: 1, cost: 0 },
+        { start: "2026-06-16T00:00:00Z", end: "2026-06-17T00:00:00Z", max_agents: 1, agent_minutes: 10, output_tokens: 1, cost: 0 },
+      ] as Report["buckets"],
+    });
+    render(ConcurrencyTimeline, { report: r });
+    const bar = document.querySelector("rect[data-bucket-bar]") as Element;
+    await fireEvent.mouseEnter(bar);
+    // Tooltip text should be a date label, not an HH:MM time.
+    expect(document.body.textContent).toMatch(/Jun/);
+  });
+
+  it("formats a DST-safe week tooltip with the inclusive last day", async () => {
+    const r = makeReport({
+      bucket_unit: "week",
+      range_start: "2026-06-15T00:00:00Z",
+      range_end: "2026-06-22T00:00:00Z",
+      bucket_seconds: 604800,
+      bucket_count: 1,
+      elapsed_bucket_count: 1,
+      effective_end: "2026-06-22T00:00:00Z",
+      buckets: [
+        { start: "2026-06-15T00:00:00Z", end: "2026-06-22T00:00:00Z", max_agents: 2, agent_minutes: 20, output_tokens: 100, cost: 0 },
+      ] as Report["buckets"],
+    });
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, { target, props: { report: r } });
+    await tick();
+    const hit = target.querySelector(".slot-hit") as SVGRectElement;
+    hit.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await tick();
+    const tip = target.querySelector(".tooltip");
+    expect(tip).toBeTruthy();
+    expect(tip!.textContent).toContain("Jun 15");
+    expect(tip!.textContent).toContain("Jun 21"); // end - 1ms = inclusive last day
+    expect(tip!.textContent).not.toContain("Jun 22"); // not the exclusive end
+    unmount(c);
+    target.remove();
+  });
+
+  it("labels minute-unit ticks with real local times", () => {
+    render(ConcurrencyTimeline, { report: minuteReport() });
+    const labels = Array.from(
+      document.querySelectorAll("text.x-label"),
+    ).map((el) => el.textContent?.trim() ?? "");
+    expect(labels.length).toBeGreaterThan(0);
+    // Every label is HH:MM, and a sub-hour range yields non-:00 minutes
+    // rather than the old hardcoded 00/06/12/18/24 hour marks.
+    expect(labels.every((l) => /^\d{2}:\d{2}$/.test(l))).toBe(true);
+    expect(labels.some((l) => !l.endsWith(":00"))).toBe(true);
+  });
+
+  it("overlays the selected metric line and hides it when None", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
+    await tick();
+    // Default metric is "none": no overlay line.
+    expect(target.querySelector(".overlay-line")).toBeNull();
+    const select = target.querySelector(
+      ".overlay-toggle select",
+    ) as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    select.value = "cost";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    await tick();
+    expect(target.querySelector(".overlay-line")).toBeTruthy();
+    unmount(c);
+    target.remove();
+  });
+});

--- a/frontend/src/lib/components/activity/RangeControl.svelte
+++ b/frontend/src/lib/components/activity/RangeControl.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { activity } from "../../stores/activity.svelte.js";
+
+  type Preset = "day" | "week" | "month" | "custom";
+
+  const segments: { value: Preset; label: string }[] = [
+    { value: "day", label: "Day" },
+    { value: "week", label: "Week" },
+    { value: "month", label: "Month" },
+    { value: "custom", label: "Custom" },
+  ];
+
+  function select(value: Preset) {
+    activity.setPreset(value);
+    activity.load();
+  }
+</script>
+
+<div class="range-control" role="group" aria-label="Report range">
+  {#each segments as segment (segment.value)}
+    <button
+      class="segment-btn"
+      class:active={activity.preset === segment.value}
+      onclick={() => select(segment.value)}
+    >
+      {segment.label}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .range-control {
+    display: flex;
+    gap: 2px;
+  }
+
+  .segment-btn {
+    height: 26px;
+    padding: 0 10px;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s;
+  }
+
+  .segment-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-secondary);
+  }
+
+  .segment-btn.active {
+    background: var(--accent-blue);
+    color: #fff;
+  }
+</style>

--- a/frontend/src/lib/components/activity/RangeControl.test.ts
+++ b/frontend/src/lib/components/activity/RangeControl.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+
+const store = vi.hoisted(() => ({
+  activity: {
+    preset: "day" as "day" | "week" | "month" | "custom",
+    setPreset: vi.fn(),
+    load: vi.fn(),
+  },
+}));
+vi.mock("../../stores/activity.svelte.js", () => store);
+
+import RangeControl from "./RangeControl.svelte";
+
+beforeEach(() => {
+  store.activity.preset = "day";
+  store.activity.setPreset.mockReset();
+  store.activity.load.mockReset();
+});
+
+describe("RangeControl", () => {
+  it("renders Day/Week/Month/Custom segments", () => {
+    render(RangeControl);
+    for (const label of ["Day", "Week", "Month", "Custom"]) {
+      expect(screen.getByRole("button", { name: label })).toBeTruthy();
+    }
+  });
+  it("selecting Week sets the preset and reloads", async () => {
+    render(RangeControl);
+    await fireEvent.click(screen.getByRole("button", { name: "Week" }));
+    expect(store.activity.setPreset).toHaveBeenCalledWith("week");
+    expect(store.activity.load).toHaveBeenCalled();
+  });
+  it("does not expose a 15m bucket control", () => {
+    render(RangeControl);
+    expect(screen.queryByText(/15m/i)).toBeNull();
+  });
+});

--- a/frontend/src/lib/components/activity/RangeNavigator.svelte
+++ b/frontend/src/lib/components/activity/RangeNavigator.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import { activity } from "../../stores/activity.svelte.js";
+  import { ChevronLeftIcon, ChevronRightIcon } from "../../icons.js";
+
+  // Local YYYY-MM-DD for the real clock, used only for the future-period guard.
+  function todayStr(): string {
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = String(now.getMonth() + 1).padStart(2, "0");
+    const d = String(now.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  }
+
+  // Conservative date-based future check, carried over from the old day
+  // stepper: disable Next once the anchor is at or past today. Precise
+  // week/month period-end gating is intentionally deferred.
+  const atFuture = $derived(activity.date >= todayStr());
+
+  // Human label for the current non-custom range. Day shows the date alone;
+  // week/month prefix the preset so the anchor reads as a period start.
+  const rangeLabel = $derived.by(() => {
+    if (activity.preset === "week") return `Week of ${activity.date}`;
+    if (activity.preset === "month") return `Month of ${activity.date}`;
+    return activity.date;
+  });
+
+  function stepBack() {
+    activity.step(-1);
+    activity.load();
+  }
+
+  function stepForward() {
+    activity.step(1);
+    activity.load();
+  }
+
+  function onFromInput(e: Event) {
+    activity.setFrom((e.currentTarget as HTMLInputElement).value);
+    activity.load();
+  }
+
+  function onToInput(e: Event) {
+    activity.setTo((e.currentTarget as HTMLInputElement).value);
+    activity.load();
+  }
+</script>
+
+{#if activity.preset === "custom"}
+  <div class="range-navigator custom">
+    <input
+      class="date-input"
+      type="date"
+      value={activity.from}
+      oninput={onFromInput}
+      aria-label="Range start"
+    />
+    <span class="date-sep">-</span>
+    <input
+      class="date-input"
+      type="date"
+      value={activity.to}
+      oninput={onToInput}
+      aria-label="Range end"
+    />
+  </div>
+{:else}
+  <div class="range-navigator">
+    <button
+      class="step-btn"
+      onclick={stepBack}
+      title="Previous"
+      aria-label="Previous"
+    >
+      <ChevronLeftIcon size="14" strokeWidth="2" aria-hidden="true" />
+    </button>
+    <span class="range-label">{rangeLabel}</span>
+    <button
+      class="step-btn"
+      onclick={stepForward}
+      disabled={atFuture}
+      title="Next"
+      aria-label="Next"
+    >
+      <ChevronRightIcon size="14" strokeWidth="2" aria-hidden="true" />
+    </button>
+  </div>
+{/if}
+
+<style>
+  .range-navigator {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .step-btn {
+    width: 26px;
+    height: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s, opacity 0.1s;
+  }
+
+  .step-btn:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .step-btn:disabled {
+    cursor: default;
+    opacity: 0.4;
+  }
+
+  .range-label {
+    min-width: 96px;
+    text-align: center;
+    font-size: 11px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .date-input {
+    height: 26px;
+    padding: 0 8px;
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-family: var(--font-mono);
+  }
+
+  .date-input:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+  }
+
+  .date-sep {
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+</style>

--- a/frontend/src/lib/components/activity/RangeNavigator.test.ts
+++ b/frontend/src/lib/components/activity/RangeNavigator.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+
+const store = vi.hoisted(() => ({
+  activity: {
+    preset: "day" as "day" | "week" | "month" | "custom",
+    date: "2026-06-16",
+    from: "",
+    to: "",
+    step: vi.fn(),
+    setFrom: vi.fn(),
+    setTo: vi.fn(),
+    load: vi.fn(),
+  },
+}));
+vi.mock("../../stores/activity.svelte.js", () => store);
+
+import RangeNavigator from "./RangeNavigator.svelte";
+
+beforeEach(() => {
+  store.activity.preset = "day";
+  store.activity.date = "2026-06-16";
+  store.activity.from = "";
+  store.activity.to = "";
+  store.activity.step.mockReset();
+  store.activity.setFrom.mockReset();
+  store.activity.setTo.mockReset();
+  store.activity.load.mockReset();
+});
+
+describe("RangeNavigator", () => {
+  it("steps backward and reloads for a day preset", async () => {
+    render(RangeNavigator);
+    await fireEvent.click(screen.getByRole("button", { name: /previous/i }));
+    expect(store.activity.step).toHaveBeenCalledWith(-1);
+    expect(store.activity.load).toHaveBeenCalled();
+  });
+  it("steps forward and reloads", async () => {
+    render(RangeNavigator);
+    await fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    expect(store.activity.step).toHaveBeenCalledWith(1);
+  });
+  it("shows from/to date inputs for the custom preset", () => {
+    store.activity.preset = "custom";
+    store.activity.from = "2026-06-10";
+    store.activity.to = "2026-06-12";
+    render(RangeNavigator);
+    const inputs = screen.getAllByDisplayValue(/2026-06-1[02]/);
+    expect(inputs.length).toBe(2);
+  });
+  it("editing the from input updates the store and reloads", async () => {
+    store.activity.preset = "custom";
+    render(RangeNavigator);
+    const inputs = document.querySelectorAll('input[type="date"]');
+    await fireEvent.input(inputs[0]!, { target: { value: "2026-06-11" } });
+    expect(store.activity.setFrom).toHaveBeenCalledWith("2026-06-11");
+    expect(store.activity.load).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/components/activity/SessionsTable.svelte
+++ b/frontend/src/lib/components/activity/SessionsTable.svelte
@@ -1,0 +1,442 @@
+<script lang="ts">
+  import type { Report } from "../../api/types.js";
+  import type { ActivitySessionRow } from "../../api/generated/index";
+  import { router } from "../../stores/router.svelte.js";
+
+  let {
+    report,
+    filterIds = null,
+    filterLabel = "",
+    onClearFilter,
+  }: {
+    report: Report;
+    filterIds?: string[] | null;
+    filterLabel?: string;
+    onClearFilter?: () => void;
+  } = $props();
+
+  // by_session is typed `any[] | null` by the codegen; cast to the
+  // generated element model for field-level type safety.
+  const allRows = $derived(
+    (report.by_session ?? []) as ActivitySessionRow[],
+  );
+
+  // Page-local time-slot filter from the Concurrency chart: a non-null id list
+  // restricts the table to the sessions active in the clicked slot. An empty
+  // set (an idle slot was clicked) correctly yields no rows but still shows the
+  // dismissible badge so the selection can be cleared.
+  const filterSet = $derived(filterIds ? new Set(filterIds) : null);
+  const rows = $derived(
+    filterSet
+      ? allRows.filter((r) => filterSet.has(r.session_id))
+      : allRows,
+  );
+
+  type SortKey =
+    | "agent_minutes"
+    | "cost"
+    | "first_active"
+    | "project"
+    | "agent";
+  type SortDir = "asc" | "desc";
+
+  let sortKey = $state<SortKey>("agent_minutes");
+  let sortDir = $state<SortDir>("desc");
+
+  function setSort(key: SortKey) {
+    if (sortKey === key) {
+      sortDir = sortDir === "asc" ? "desc" : "asc";
+    } else {
+      sortKey = key;
+      // Numeric/time columns read best high-to-low first; text
+      // columns alphabetically.
+      sortDir =
+        key === "project" || key === "agent" ? "asc" : "desc";
+    }
+  }
+
+  function isUntimed(row: ActivitySessionRow): boolean {
+    return row.agent_minutes === null;
+  }
+
+  function compare(
+    a: ActivitySessionRow,
+    b: ActivitySessionRow,
+    key: SortKey,
+  ): number {
+    switch (key) {
+      case "agent_minutes":
+        return (a.agent_minutes ?? 0) - (b.agent_minutes ?? 0);
+      case "cost":
+        return a.cost - b.cost;
+      case "first_active": {
+        const av = a.first_active ?? "";
+        const bv = b.first_active ?? "";
+        return av < bv ? -1 : av > bv ? 1 : 0;
+      }
+      case "project":
+        return a.project.localeCompare(b.project);
+      case "agent":
+        return a.agent.localeCompare(b.agent);
+    }
+  }
+
+  function byKeyThenId(
+    a: ActivitySessionRow,
+    b: ActivitySessionRow,
+    dir: number,
+  ): number {
+    const primary = compare(a, b, sortKey) * dir;
+    if (primary !== 0) return primary;
+    // Stable tiebreak: equal primary keys order by session_id
+    // ascending regardless of direction, so toggling sortDir never
+    // reorders peers.
+    return a.session_id.localeCompare(b.session_id);
+  }
+
+  // Untimed rows only have a null value for the timing keys
+  // (agent_minutes, first_active); their cost/project/agent are real.
+  // Partition them to the bottom only when sorting by a timing key, so
+  // a high-cost untimed session still participates in the cost sort.
+  const sortedRows = $derived.by(() => {
+    const dir = sortDir === "asc" ? 1 : -1;
+    const partitionUntimed =
+      sortKey === "agent_minutes" || sortKey === "first_active";
+    if (!partitionUntimed) {
+      return [...rows].sort((a, b) => byKeyThenId(a, b, dir));
+    }
+    const timed: ActivitySessionRow[] = [];
+    const untimed: ActivitySessionRow[] = [];
+    for (const row of rows) {
+      if (isUntimed(row)) untimed.push(row);
+      else timed.push(row);
+    }
+    timed.sort((a, b) => byKeyThenId(a, b, dir));
+    // Keep appended untimed rows in a stable session_id order so they
+    // don't jump around between renders.
+    untimed.sort((a, b) => a.session_id.localeCompare(b.session_id));
+    return [...timed, ...untimed];
+  });
+
+  function fmtCost(v: number): string {
+    return `$${v.toFixed(2)}`;
+  }
+
+  function fmtMinutes(v: number | null): string {
+    if (v === null) return "—";
+    return Math.round(v).toLocaleString();
+  }
+
+  function rowModel(row: ActivitySessionRow): string {
+    const models = (row.models ?? []) as string[];
+    if (models.length > 1) return "mixed";
+    return row.primary_model || "—";
+  }
+
+  // RFC3339 -> "HH:MM" in the viewer's local zone, matching the
+  // server-side local day window.
+  function fmtClock(ts: string | null): string {
+    if (!ts) return "";
+    const d = new Date(ts);
+    if (Number.isNaN(d.getTime())) return "";
+    return d.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
+  }
+
+  function fmtWindow(
+    first: string | null,
+    last: string | null,
+  ): string {
+    const a = fmtClock(first);
+    const b = fmtClock(last);
+    if (!a || !b) return "—";
+    return `${a}–${b}`;
+  }
+
+  interface Column {
+    key: SortKey;
+    label: string;
+  }
+
+  const sortColumns: Column[] = [
+    { key: "project", label: "Project" },
+    { key: "agent", label: "Agent" },
+    { key: "agent_minutes", label: "Agent-min" },
+    { key: "cost", label: "Cost" },
+    { key: "first_active", label: "Window" },
+  ];
+
+  function ariaSort(key: SortKey): "ascending" | "descending" | "none" {
+    if (sortKey !== key) return "none";
+    return sortDir === "asc" ? "ascending" : "descending";
+  }
+</script>
+
+<div class="sessions-table">
+  <div class="sessions-header">
+    <h3 class="chart-title">Sessions</h3>
+    <div class="header-meta">
+      {#if filterSet}
+        <button
+          type="button"
+          class="filter-badge"
+          onclick={() => onClearFilter?.()}
+          title="Clear time filter"
+        >
+          <span>Active: {filterLabel}</span>
+          <span class="filter-badge-x" aria-hidden="true">×</span>
+        </button>
+      {/if}
+      {#if rows.length > 0}
+        <span class="count">{rows.length} total</span>
+      {/if}
+    </div>
+  </div>
+
+  {#if rows.length > 0}
+    <div class="table-scroll">
+      <table class="table">
+        <thead>
+          <tr>
+            <th class="col-session" scope="col">Session</th>
+            <th class="col-model" scope="col">Model</th>
+            {#each sortColumns as col}
+              <th
+                class="col-sortable"
+                class:col-num={col.key === "agent_minutes" ||
+                  col.key === "cost"}
+                scope="col"
+                aria-sort={ariaSort(col.key)}
+              >
+                <button
+                  class="sort-btn"
+                  type="button"
+                  data-sort-key={col.key}
+                  onclick={() => setSort(col.key)}
+                >
+                  {col.label}
+                  {#if sortKey === col.key}
+                    <span class="sort-arrow">
+                      {sortDir === "asc" ? "↑" : "↓"}
+                    </span>
+                  {/if}
+                </button>
+              </th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each sortedRows as row (row.session_id)}
+            <tr class="session-row" data-session-id={row.session_id}>
+              <td class="col-session">
+                <a
+                  class="session-link"
+                  href={router.buildSessionHref(row.session_id)}
+                  title={row.title || row.session_id}
+                  onclick={(e) => {
+                    if (
+                      e.metaKey ||
+                      e.ctrlKey ||
+                      e.shiftKey ||
+                      e.altKey ||
+                      e.button !== 0
+                    )
+                      return;
+                    e.preventDefault();
+                    router.navigateToSession(row.session_id);
+                  }}
+                >
+                  {row.title || row.session_id}
+                </a>
+              </td>
+              <td class="col-model">{rowModel(row)}</td>
+              <td class="col-project" title={row.project}>
+                {row.project}
+              </td>
+              <td class="col-agent">{row.agent}</td>
+              <td class="col-num col-minutes">
+                {fmtMinutes(row.agent_minutes)}
+              </td>
+              <td class="col-num col-cost">{fmtCost(row.cost)}</td>
+              <td class="col-window">
+                {fmtWindow(row.first_active, row.last_active)}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {:else}
+    <div class="empty">
+      {filterSet
+        ? "No sessions active in the selected slot."
+        : "No sessions in range."}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .sessions-table {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .sessions-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+  }
+
+  .chart-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .count {
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+
+  .header-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .filter-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 20px;
+    padding: 0 6px 0 8px;
+    border: 1px solid var(--accent-blue);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
+    color: var(--accent-blue);
+    font-size: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .filter-badge:hover {
+    background: color-mix(in srgb, var(--accent-blue) 22%, transparent);
+  }
+
+  .filter-badge-x {
+    font-size: 13px;
+    line-height: 1;
+  }
+
+  .table-scroll {
+    max-height: 360px;
+    overflow-y: auto;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+  }
+
+  .table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--bg-inset);
+    text-align: left;
+    font-weight: 600;
+    color: var(--text-muted);
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--border-muted);
+    white-space: nowrap;
+  }
+
+  th.col-num {
+    text-align: right;
+  }
+
+  .col-num {
+    text-align: right;
+    font-family: var(--font-mono);
+  }
+
+  .sort-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    font-weight: 600;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .sort-btn:hover {
+    color: var(--text-primary);
+  }
+
+  .sort-arrow {
+    font-size: 9px;
+    color: var(--accent-blue);
+  }
+
+  .col-num .sort-btn {
+    flex-direction: row-reverse;
+  }
+
+  tbody td {
+    padding: 5px 8px;
+    border-bottom: 1px solid var(--border-muted);
+    color: var(--text-secondary);
+    white-space: nowrap;
+  }
+
+  .session-row:last-child td {
+    border-bottom: none;
+  }
+
+  .session-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .col-session {
+    max-width: 240px;
+  }
+
+  .session-link {
+    display: block;
+    max-width: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--accent-blue);
+    text-decoration: none;
+  }
+
+  .session-link:hover {
+    text-decoration: underline;
+  }
+
+  .col-project {
+    max-width: 140px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .empty {
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 24px;
+    text-align: center;
+  }
+</style>

--- a/frontend/src/lib/components/activity/SessionsTable.svelte
+++ b/frontend/src/lib/components/activity/SessionsTable.svelte
@@ -232,25 +232,30 @@
           {#each sortedRows as row (row.session_id)}
             <tr class="session-row" data-session-id={row.session_id}>
               <td class="col-session">
-                <a
-                  class="session-link"
-                  href={router.buildSessionHref(row.session_id)}
-                  title={row.title || row.session_id}
-                  onclick={(e) => {
-                    if (
-                      e.metaKey ||
-                      e.ctrlKey ||
-                      e.shiftKey ||
-                      e.altKey ||
-                      e.button !== 0
-                    )
-                      return;
-                    e.preventDefault();
-                    router.navigateToSession(row.session_id);
-                  }}
-                >
-                  {row.title || row.session_id}
-                </a>
+                <div class="session-cell">
+                  <a
+                    class="session-link"
+                    href={router.buildSessionHref(row.session_id)}
+                    title={row.title || row.session_id}
+                    onclick={(e) => {
+                      if (
+                        e.metaKey ||
+                        e.ctrlKey ||
+                        e.shiftKey ||
+                        e.altKey ||
+                        e.button !== 0
+                      )
+                        return;
+                      e.preventDefault();
+                      router.navigateToSession(row.session_id);
+                    }}
+                  >
+                    {row.title || row.session_id}
+                  </a>
+                  {#if row.is_automated}
+                    <span class="auto-badge" title="Automated session">Auto</span>
+                  {/if}
+                </div>
               </td>
               <td class="col-model">{rowModel(row)}</td>
               <td class="col-project" title={row.project}>
@@ -414,13 +419,32 @@
     max-width: 240px;
   }
 
-  .session-link {
-    display: block;
+  .session-cell {
+    display: flex;
+    align-items: center;
+    gap: 6px;
     max-width: 240px;
+  }
+
+  .session-link {
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
     color: var(--accent-blue);
     text-decoration: none;
+  }
+
+  .auto-badge {
+    flex-shrink: 0;
+    padding: 1px 5px;
+    border-radius: 999px;
+    font-size: 9px;
+    font-weight: 600;
+    color: var(--accent-purple);
+    background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent-purple) 35%, transparent);
   }
 
   .session-link:hover {

--- a/frontend/src/lib/components/activity/SessionsTable.svelte
+++ b/frontend/src/lib/components/activity/SessionsTable.svelte
@@ -442,9 +442,9 @@
     border-radius: 999px;
     font-size: 9px;
     font-weight: 600;
-    color: var(--accent-purple);
-    background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
-    border: 1px solid color-mix(in srgb, var(--accent-purple) 35%, transparent);
+    color: var(--accent-orange);
+    background: color-mix(in srgb, var(--accent-orange) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent-orange) 35%, transparent);
   }
 
   .session-link:hover {

--- a/frontend/src/lib/components/activity/SessionsTable.test.ts
+++ b/frontend/src/lib/components/activity/SessionsTable.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mount, tick, unmount } from "svelte";
+import SessionsTable from "./SessionsTable.svelte";
+import { router } from "../../stores/router.svelte.js";
+import type { Report } from "../../api/types.js";
+import type { ActivitySessionRow } from "../../api/generated/index";
+
+function makeRow(
+  overrides: Partial<ActivitySessionRow> = {},
+): ActivitySessionRow {
+  return {
+    session_id: "sess",
+    title: "Session",
+    project: "proj",
+    agent: "claude",
+    primary_model: "opus",
+    models: ["opus"],
+    agent_minutes: 10,
+    cost: 1,
+    output_tokens: 0,
+    first_active: "2026-06-16T08:00:00Z",
+    last_active: "2026-06-16T09:00:00Z",
+    timing_quality: "high",
+    is_automated: false,
+    ...overrides,
+  };
+}
+
+function makeReport(rows: ActivitySessionRow[]): Report {
+  return {
+    peak: { agents: 0, at: null },
+    totals: {
+      active_minutes: 0,
+      idle_minutes: 0,
+      agent_minutes: 0,
+      sessions: rows.length,
+      untimed_sessions: 0,
+      distinct_projects: 0,
+      distinct_models: 0,
+      output_tokens: 0,
+      cost: 0,
+    },
+    partial: false,
+    as_of: null,
+    timezone: "UTC",
+    range_start: "2026-06-16T00:00:00Z",
+    range_end: "2026-06-17T00:00:00Z",
+    bucket_unit: "hour",
+    effective_end: "2026-06-17T00:00:00Z",
+    bucket_seconds: 10800,
+    bucket_count: 8,
+    elapsed_bucket_count: 8,
+    buckets: null,
+    by_project: null,
+    by_model: null,
+    by_agent: null,
+    by_session: rows,
+    intervals: null,
+  } as Report;
+}
+
+// Two timed rows with distinct agent_minutes/cost orderings plus
+// one untimed row, so default (minutes) and cost sorts differ and
+// the untimed row's placement is observable.
+function fixtureRows(): ActivitySessionRow[] {
+  return [
+    makeRow({
+      session_id: "low-min",
+      title: "Low minutes high cost",
+      agent_minutes: 5,
+      cost: 9,
+    }),
+    makeRow({
+      session_id: "high-min",
+      title: "High minutes low cost",
+      agent_minutes: 40,
+      cost: 1,
+    }),
+    makeRow({
+      session_id: "untimed",
+      title: "Untimed",
+      agent_minutes: null,
+      cost: 4,
+      first_active: null,
+      last_active: null,
+    }),
+  ];
+}
+
+function rowOrder(): string[] {
+  return [...document.querySelectorAll(".session-row")].map(
+    (el) => el.getAttribute("data-session-id") ?? "",
+  );
+}
+
+function minutesCells(): string[] {
+  return [...document.querySelectorAll(".session-row .col-minutes")].map(
+    (el) => el.textContent?.trim() ?? "",
+  );
+}
+
+describe("SessionsTable", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to agent-minutes desc with untimed rows last", async () => {
+    const report = makeReport(fixtureRows());
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    expect(rowOrder()).toEqual(["high-min", "low-min", "untimed"]);
+
+    unmount(c);
+  });
+
+  it("renders an em dash for an untimed row's minutes cell", async () => {
+    const report = makeReport(fixtureRows());
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    // Third row (untimed) shows the placeholder; timed rows show numbers.
+    const cells = minutesCells();
+    expect(cells[2]).toBe("—");
+    expect(cells[0]).not.toBe("—");
+
+    unmount(c);
+  });
+
+  it("sorts the untimed row by its real cost when the Cost header is clicked", async () => {
+    const report = makeReport(fixtureRows());
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    const costHeader = document.querySelector(
+      '[data-sort-key="cost"]',
+    ) as HTMLElement | null;
+    expect(costHeader).toBeTruthy();
+    costHeader!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+
+    // Cost desc over the full set: low-min (9), untimed (4), high-min (1).
+    // The untimed row carries real cost, so it participates in the cost
+    // sort instead of being pinned last.
+    expect(rowOrder()).toEqual(["low-min", "untimed", "high-min"]);
+
+    unmount(c);
+  });
+
+  it("intercepts a plain left-click on a session link for SPA navigation", async () => {
+    const navSpy = vi
+      .spyOn(router, "navigateToSession")
+      .mockImplementation(() => {});
+    const report = makeReport(fixtureRows());
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    // Default order is high-min first, so the first link is its row.
+    const link = document.querySelector(
+      ".session-row .session-link",
+    ) as HTMLAnchorElement | null;
+    expect(link).toBeTruthy();
+
+    // Real browser clicks are cancelable; preventDefault is a no-op
+    // (and defaultPrevented stays false) on a non-cancelable event.
+    const click = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    });
+    link!.dispatchEvent(click);
+    await tick();
+
+    expect(navSpy).toHaveBeenCalledWith("high-min");
+    expect(click.defaultPrevented).toBe(true);
+
+    unmount(c);
+  });
+
+  it("restricts rows to the active session ids when filtered", async () => {
+    const report = makeReport(fixtureRows());
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: { report, filterIds: ["high-min"], filterLabel: "06:00–09:00" },
+    });
+    await tick();
+
+    expect(rowOrder()).toEqual(["high-min"]);
+    expect(document.querySelector(".count")?.textContent).toContain("1 total");
+
+    unmount(c);
+  });
+
+  it("shows a dismissible filter badge that calls onClearFilter", async () => {
+    const onClearFilter = vi.fn();
+    const report = makeReport(fixtureRows());
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: {
+        report,
+        filterIds: ["high-min"],
+        filterLabel: "06:00–09:00",
+        onClearFilter,
+      },
+    });
+    await tick();
+
+    const badge = document.querySelector(
+      ".filter-badge",
+    ) as HTMLButtonElement | null;
+    expect(badge).toBeTruthy();
+    expect(badge!.textContent).toContain("06:00–09:00");
+    badge!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await tick();
+    expect(onClearFilter).toHaveBeenCalledTimes(1);
+
+    unmount(c);
+  });
+
+  it("shows a filter-aware empty message for a slot with no matches", async () => {
+    const report = makeReport(fixtureRows());
+    // An empty (but non-null) id list is an active filter that matches nothing,
+    // e.g. an idle slot was clicked. The badge stays so it can be cleared.
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: { report, filterIds: [], filterLabel: "12:00–15:00" },
+    });
+    await tick();
+
+    expect(document.querySelectorAll(".session-row").length).toBe(0);
+    expect(document.querySelector(".empty")?.textContent).toContain(
+      "No sessions active in the selected slot",
+    );
+    expect(document.querySelector(".filter-badge")).toBeTruthy();
+
+    unmount(c);
+  });
+
+  it("renders no filter badge when no slot filter is active", async () => {
+    const report = makeReport(fixtureRows());
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    expect(document.querySelector(".filter-badge")).toBeNull();
+
+    unmount(c);
+  });
+});

--- a/frontend/src/lib/components/activity/SessionsTable.test.ts
+++ b/frontend/src/lib/components/activity/SessionsTable.test.ts
@@ -250,6 +250,30 @@ describe("SessionsTable", () => {
     unmount(c);
   });
 
+  it("flags only automated sessions with an Auto badge", async () => {
+    const report = makeReport([
+      makeRow({ session_id: "human", title: "Human", is_automated: false }),
+      makeRow({ session_id: "robot", title: "Robot", is_automated: true }),
+    ]);
+    const c = mount(SessionsTable, {
+      target: document.body,
+      props: { report },
+    });
+    await tick();
+
+    expect(document.querySelectorAll(".auto-badge").length).toBe(1);
+    const robotRow = document.querySelector(
+      '.session-row[data-session-id="robot"]',
+    );
+    const humanRow = document.querySelector(
+      '.session-row[data-session-id="human"]',
+    );
+    expect(robotRow?.querySelector(".auto-badge")).toBeTruthy();
+    expect(humanRow?.querySelector(".auto-badge")).toBeNull();
+
+    unmount(c);
+  });
+
   it("renders no filter badge when no slot filter is active", async () => {
     const report = makeReport(fixtureRows());
     const c = mount(SessionsTable, {

--- a/frontend/src/lib/components/activity/SummaryCards.svelte
+++ b/frontend/src/lib/components/activity/SummaryCards.svelte
@@ -61,7 +61,9 @@
       },
       {
         label: "Agent-minutes",
-        value: fmtInt(t.agent_minutes),
+        // Round to a whole minute so the card shows "134", not "134.226";
+        // matches the Breakdowns rounding of the same metric.
+        value: fmtInt(Math.round(t.agent_minutes)),
       },
       {
         label: "Sessions",

--- a/frontend/src/lib/components/activity/SummaryCards.svelte
+++ b/frontend/src/lib/components/activity/SummaryCards.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import type { Report } from "../../api/types.js";
+
+  let { report }: { report: Report } = $props();
+
+  function fmtCost(v: number): string {
+    return `$${v.toFixed(2)}`;
+  }
+
+  function fmtInt(v: number): string {
+    return v.toLocaleString();
+  }
+
+  // minutes -> "Hh Mm" (e.g. 75 -> "1h 15m"). Sub-hour durations
+  // drop the hour segment; whole minutes only.
+  function fmtDuration(mins: number): string {
+    const total = Math.max(Math.round(mins), 0);
+    const h = Math.floor(total / 60);
+    const m = total % 60;
+    if (h === 0) return `${m}m`;
+    return `${h}h ${m}m`;
+  }
+
+  // RFC3339 -> "HH:MM" in the viewer's local zone. The report's
+  // day window is already local-timezone-aligned server-side, so
+  // local formatting keeps the clock label consistent with it.
+  function fmtClock(ts: string | null): string {
+    if (!ts) return "";
+    const d = new Date(ts);
+    if (Number.isNaN(d.getTime())) return "";
+    return d.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
+  }
+
+  const peakAt = $derived(fmtClock(report.peak.at));
+  const asOf = $derived(fmtClock(report.as_of));
+
+  interface Card {
+    label: string;
+    value: string;
+    sub?: string;
+    featured?: boolean;
+  }
+
+  const cards = $derived.by((): Card[] => {
+    const t = report.totals;
+    return [
+      {
+        label: "Peak Concurrency",
+        value: String(report.peak.agents),
+        sub: peakAt ? `at ${peakAt}` : "",
+        featured: true,
+      },
+      {
+        label: "Active",
+        value: fmtDuration(t.active_minutes),
+        sub: `${fmtDuration(t.idle_minutes)} idle`,
+      },
+      {
+        label: "Agent-minutes",
+        value: fmtInt(t.agent_minutes),
+      },
+      {
+        label: "Sessions",
+        value: fmtInt(t.sessions),
+        sub:
+          t.untimed_sessions > 0
+            ? `${fmtInt(t.untimed_sessions)} untimed`
+            : "",
+      },
+      {
+        label: "Projects",
+        value: fmtInt(t.distinct_projects),
+      },
+      {
+        label: "Models",
+        value: fmtInt(t.distinct_models),
+      },
+      {
+        label: "Total Cost",
+        value: fmtCost(t.cost),
+      },
+    ];
+  });
+</script>
+
+<div class="summary-cards">
+  {#each cards as card}
+    <div class="card" class:featured={card.featured}>
+      <span class="card-value">{card.value}</span>
+      <span class="card-label">{card.label}</span>
+      {#if card.sub}
+        <span class="card-sub">{card.sub}</span>
+      {/if}
+    </div>
+  {/each}
+</div>
+
+{#if report.partial && asOf}
+  <div class="partial-note">In progress, as of {asOf}</div>
+{/if}
+
+<style>
+  .summary-cards {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    flex: 1;
+    min-width: 110px;
+    padding: 12px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .card.featured {
+    border-width: 2px;
+    border-color: var(--accent-blue);
+  }
+
+  .card-value {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.2;
+  }
+
+  .card-label {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .card-sub {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-top: 2px;
+  }
+
+  .partial-note {
+    margin-top: 8px;
+    font-size: 11px;
+    color: var(--accent-amber);
+  }
+</style>

--- a/frontend/src/lib/components/activity/SummaryCards.svelte
+++ b/frontend/src/lib/components/activity/SummaryCards.svelte
@@ -11,6 +11,23 @@
     return v.toLocaleString();
   }
 
+  // Sessions card detail line: surface the automation split only when there
+  // are automated sessions, so the common all-interactive view stays clean,
+  // and keep the untimed count. interactive + automated == sessions.
+  function sessionsSub(t: Report["totals"]): string {
+    const parts: string[] = [];
+    if (t.automated_sessions > 0) {
+      parts.push(
+        `${fmtInt(t.interactive_sessions)} interactive / ` +
+          `${fmtInt(t.automated_sessions)} automated`,
+      );
+    }
+    if (t.untimed_sessions > 0) {
+      parts.push(`${fmtInt(t.untimed_sessions)} untimed`);
+    }
+    return parts.join(", ");
+  }
+
   // minutes -> "Hh Mm" (e.g. 75 -> "1h 15m"). Sub-hour durations
   // drop the hour segment; whole minutes only.
   function fmtDuration(mins: number): string {
@@ -68,10 +85,7 @@
       {
         label: "Sessions",
         value: fmtInt(t.sessions),
-        sub:
-          t.untimed_sessions > 0
-            ? `${fmtInt(t.untimed_sessions)} untimed`
-            : "",
+        sub: sessionsSub(t),
       },
       {
         label: "Projects",

--- a/frontend/src/lib/components/activity/SummaryCards.test.ts
+++ b/frontend/src/lib/components/activity/SummaryCards.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { mount, tick } from "svelte";
+import SummaryCards from "./SummaryCards.svelte";
+import type { Report } from "../../api/types.js";
+
+function makeReport(totals: Partial<Report["totals"]> = {}): Report {
+  return {
+    timezone: "UTC",
+    range_start: "2026-06-16T00:00:00Z",
+    range_end: "2026-06-17T00:00:00Z",
+    bucket_unit: "minute",
+    bucket_seconds: 300,
+    bucket_count: 0,
+    partial: false,
+    as_of: null,
+    effective_end: "2026-06-17T00:00:00Z",
+    elapsed_bucket_count: 0,
+    buckets: [],
+    peak: { agents: 0, at: null },
+    totals: {
+      active_minutes: 0,
+      idle_minutes: 0,
+      agent_minutes: 0,
+      sessions: 3,
+      untimed_sessions: 0,
+      distinct_projects: 0,
+      distinct_models: 0,
+      output_tokens: 0,
+      cost: 0,
+      automated_agent_minutes: 0,
+      interactive_agent_minutes: 0,
+      automated_cost: 0,
+      interactive_cost: 0,
+      automated_sessions: 0,
+      interactive_sessions: 3,
+      ...totals,
+    },
+    by_project: [],
+    by_model: [],
+    by_agent: [],
+    by_session: [],
+    intervals: [],
+  } as Report;
+}
+
+// Read the sub-label text of the Sessions card.
+function sessionsSub(target: HTMLElement): string {
+  const card = [...target.querySelectorAll(".card")].find(
+    (c) => c.querySelector(".card-label")?.textContent?.trim() === "Sessions",
+  );
+  return card?.querySelector(".card-sub")?.textContent?.trim() ?? "";
+}
+
+async function render(report: Report): Promise<HTMLElement> {
+  const target = document.createElement("div");
+  document.body.appendChild(target);
+  mount(SummaryCards, { target, props: { report } });
+  await tick();
+  return target;
+}
+
+describe("SummaryCards", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows the interactive/automated split when automated sessions exist", async () => {
+    const target = await render(
+      makeReport({
+        sessions: 3,
+        interactive_sessions: 1,
+        automated_sessions: 2,
+      }),
+    );
+    expect(sessionsSub(target)).toBe("1 interactive / 2 automated");
+  });
+
+  it("omits the split and keeps untimed when there are no automated sessions", async () => {
+    const target = await render(
+      makeReport({
+        sessions: 3,
+        interactive_sessions: 3,
+        automated_sessions: 0,
+        untimed_sessions: 1,
+      }),
+    );
+    expect(sessionsSub(target)).toBe("1 untimed");
+  });
+
+  it("combines the split and the untimed count", async () => {
+    const target = await render(
+      makeReport({
+        sessions: 4,
+        interactive_sessions: 1,
+        automated_sessions: 2,
+        untimed_sessions: 1,
+      }),
+    );
+    expect(sessionsSub(target)).toBe("1 interactive / 2 automated, 1 untimed");
+  });
+});

--- a/frontend/src/lib/components/activity/activeSessions.test.ts
+++ b/frontend/src/lib/components/activity/activeSessions.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { activeSessionsInSlot } from "./activeSessions.js";
+import type {
+  ActivityReportInterval,
+  ActivitySessionRow,
+} from "../../api/generated/index";
+
+function row(id: string): ActivitySessionRow {
+  return {
+    session_id: id, title: id, project: "p", agent: "claude",
+    primary_model: "m", models: ["m"], agent_minutes: 1, cost: 0,
+    output_tokens: 0, first_active: null, last_active: null, timing_quality: "timed",
+  } as ActivitySessionRow;
+}
+const ms = (iso: string) => Date.parse(iso);
+
+describe("activeSessionsInSlot", () => {
+  const bySession = new Map([row("a"), row("b")].map((r) => [r.session_id, r]));
+  const slotStart = ms("2026-06-16T10:00:00Z");
+  const slotEnd = ms("2026-06-16T10:05:00Z");
+
+  it("dedups a session with multiple intervals in the slot to one row", () => {
+    const intervals: ActivityReportInterval[] = [
+      { session_id: "a", start: "2026-06-16T10:00:00Z", end: "2026-06-16T10:01:00Z" },
+      { session_id: "a", start: "2026-06-16T10:01:00Z", end: "2026-06-16T10:02:00Z" },
+      { session_id: "b", start: "2026-06-16T10:01:00Z", end: "2026-06-16T10:03:00Z" },
+    ];
+    const out = activeSessionsInSlot(intervals, slotStart, slotEnd, bySession);
+    expect(out.map((r) => r.session_id)).toEqual(["a", "b"]); // a once, earliest-start first
+  });
+
+  it("excludes intervals that only touch the half-open boundaries", () => {
+    const intervals: ActivityReportInterval[] = [
+      { session_id: "a", start: "2026-06-16T09:55:00Z", end: "2026-06-16T10:00:00Z" }, // end == slotStart
+      { session_id: "b", start: "2026-06-16T10:05:00Z", end: "2026-06-16T10:08:00Z" }, // start == slotEnd
+    ];
+    expect(activeSessionsInSlot(intervals, slotStart, slotEnd, bySession)).toEqual([]);
+  });
+
+  it("places a point interval (sub-second span) in the slot containing the instant", () => {
+    // A sub-second span serialized at second resolution collapses to start==end.
+    // The instant at the slot's start boundary belongs to the half-open slot...
+    const atStart: ActivityReportInterval[] = [
+      { session_id: "a", start: "2026-06-16T10:00:00Z", end: "2026-06-16T10:00:00Z" },
+    ];
+    expect(activeSessionsInSlot(atStart, slotStart, slotEnd, bySession).map((r) => r.session_id))
+      .toEqual(["a"]);
+    // ...while the instant exactly at the slot's end boundary belongs to the next slot.
+    const atEnd: ActivityReportInterval[] = [
+      { session_id: "a", start: "2026-06-16T10:05:00Z", end: "2026-06-16T10:05:00Z" },
+    ];
+    expect(activeSessionsInSlot(atEnd, slotStart, slotEnd, bySession)).toEqual([]);
+  });
+
+  it("skips ids missing from the session map", () => {
+    const intervals: ActivityReportInterval[] = [
+      { session_id: "ghost", start: "2026-06-16T10:01:00Z", end: "2026-06-16T10:02:00Z" },
+    ];
+    expect(activeSessionsInSlot(intervals, slotStart, slotEnd, bySession)).toEqual([]);
+  });
+});

--- a/frontend/src/lib/components/activity/activeSessions.ts
+++ b/frontend/src/lib/components/activity/activeSessions.ts
@@ -1,0 +1,44 @@
+import type {
+  ActivityReportInterval,
+  ActivitySessionRow,
+} from "../../api/generated/index";
+
+/**
+ * The unique sessions whose interval overlaps the half-open slot
+ * [slotStartMs, slotEndMs), joined to their session row, sorted by earliest
+ * overlapping interval start then session id. A session with multiple intervals
+ * in the slot appears once. Ids absent from `bySession` are skipped.
+ */
+export function activeSessionsInSlot(
+  intervals: ActivityReportInterval[],
+  slotStartMs: number,
+  slotEndMs: number,
+  bySession: Map<string, ActivitySessionRow>,
+): ActivitySessionRow[] {
+  const earliestStart = new Map<string, number>();
+  for (const iv of intervals) {
+    const start = Date.parse(iv.start);
+    const end = Date.parse(iv.end);
+    // A sub-second active span is exposed at the report's second resolution (for
+    // cross-backend parity) and so arrives as a point, start === end. Treat it
+    // as the instant `start`, which belongs to the half-open slot containing it;
+    // a positive interval uses the usual half-open overlap test.
+    const overlaps =
+      start === end
+        ? start >= slotStartMs && start < slotEndMs
+        : start < slotEndMs && end > slotStartMs;
+    if (!overlaps) continue;
+    const prev = earliestStart.get(iv.session_id);
+    if (prev === undefined || start < prev) earliestStart.set(iv.session_id, start);
+  }
+  const ids = [...earliestStart.keys()].sort((a, b) => {
+    const d = earliestStart.get(a)! - earliestStart.get(b)!;
+    return d !== 0 ? d : a.localeCompare(b);
+  });
+  const rows: ActivitySessionRow[] = [];
+  for (const id of ids) {
+    const r = bySession.get(id);
+    if (r) rows.push(r);
+  }
+  return rows;
+}

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -20,11 +20,7 @@
   import { events } from "../../stores/events.svelte.js";
   import { ui } from "../../stores/ui.svelte.js";
   import { exportAnalyticsCSV } from "../../utils/csv-export.js";
-  import {
-    createRefreshScheduler,
-    formatRefreshAge,
-  } from "../../utils/refresh.js";
-  import { RefreshCwIcon } from "../../icons.js";
+  import RefreshControl from "../shared/RefreshControl.svelte";
 
   function shortTz(tz: string): string {
     const slash = tz.lastIndexOf("/");
@@ -32,9 +28,6 @@
       ? tz.slice(slash + 1).replace(/_/g, " ")
       : tz;
   }
-
-  const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
-  const REFRESH_LABEL_INTERVAL_MS = 60 * 1000;
 
   function handleExportCSV() {
     exportAnalyticsCSV({
@@ -48,33 +41,14 @@
     });
   }
 
-  const refreshScheduler = createRefreshScheduler(
-    () => analytics.fetchAll(),
-    REFRESH_INTERVAL_MS,
-  );
-  let refreshLabelTick = $state(Date.now());
-  let refreshLabelTimer:
-    | ReturnType<typeof setTimeout>
-    | undefined;
   let unsubEvents: (() => void) | undefined;
 
-  let refreshLabel = $derived.by(() => {
-    return formatRefreshAge(
-      analytics.lastUpdatedAt,
-      refreshLabelTick,
-    );
-  });
-
-  function scheduleRefreshLabelTick() {
-    refreshLabelTimer = setTimeout(() => {
-      refreshLabelTick = Date.now();
-      scheduleRefreshLabelTick();
-    }, REFRESH_LABEL_INTERVAL_MS);
-  }
-
   onMount(() => {
-    refreshScheduler.start();
-    scheduleRefreshLabelTick();
+    // The page owns the initial load; RefreshControl handles the periodic
+    // refresh after that. SSE events only flag new data -- refetching on every
+    // event would thrash the aggregation -- so refetching stays bounded to the
+    // RefreshControl scheduler and its manual button.
+    analytics.fetchAll();
     unsubEvents = events.subscribe(() => analytics.markNewData());
   });
 
@@ -158,10 +132,6 @@
   });
 
   onDestroy(() => {
-    refreshScheduler.stop();
-    if (refreshLabelTimer !== undefined) {
-      clearTimeout(refreshLabelTimer);
-    }
     unsubEvents?.();
   });
 </script>
@@ -185,27 +155,12 @@
       onChange={(from, to) => analytics.setDateRange(from, to)}
       onPreset={(days) => analytics.setRollingWindow(days)}
     />
-    <div class="refresh-control">
-      <button
-        class="refresh-btn"
-        class:querying={analytics.isQuerying}
-        onclick={() => refreshScheduler.refreshNow()}
-        disabled={analytics.isQuerying}
-        title="Refresh analytics"
-        aria-label="Refresh analytics"
-      >
-        <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
-      </button>
-      <div class="refresh-status">
-        <span
-          title={analytics.lastUpdatedAt === null
-            ? undefined
-            : new Date(analytics.lastUpdatedAt).toLocaleString()}
-        >
-          {refreshLabel}
-        </span>
-      </div>
-    </div>
+    <RefreshControl
+      lastUpdatedAt={analytics.lastUpdatedAt}
+      busy={analytics.isQuerying}
+      onRefresh={() => analytics.fetchAll()}
+      label="Refresh analytics"
+    />
     <button class="export-btn" onclick={handleExportCSV}>
       Export CSV
     </button>
@@ -298,49 +253,6 @@
     position: relative;
     display: flex;
     align-items: center;
-  }
-
-  .refresh-control {
-    min-height: 28px;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .refresh-btn {
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: background 0.1s, color 0.1s, opacity 0.1s;
-  }
-
-  .refresh-btn:hover:not(:disabled) {
-    background: var(--bg-surface-hover);
-    color: var(--text-primary);
-  }
-
-  .refresh-btn:disabled {
-    cursor: default;
-    opacity: 0.75;
-  }
-
-  .refresh-btn.querying :global(svg) {
-    animation: spin 0.8s linear infinite;
-  }
-
-  .refresh-status {
-    min-height: 24px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: var(--text-muted);
-    font-size: 11px;
-    white-space: nowrap;
   }
 
   .export-btn {
@@ -451,12 +363,6 @@
   @media (max-width: 800px) {
     .chart-grid {
       grid-template-columns: 1fr;
-    }
-  }
-
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
     }
   }
 

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -4,45 +4,28 @@ import source from "./AnalyticsPage.svelte?raw";
 describe("AnalyticsPage refresh behavior", () => {
   it("does not refresh analytical scans from SSE updates", () => {
     expect(source).not.toContain("subscribeDebounced");
+    // SSE only flags new data; the periodic refetch lives in RefreshControl.
+    expect(source).toContain("analytics.markNewData");
+    expect(source).toContain("events.subscribe");
   });
 
-  it("keeps automatic refresh bounded to five minutes", () => {
-    expect(source).toContain("REFRESH_INTERVAL_MS = 5 * 60 * 1000");
-    expect(source).toContain("createRefreshScheduler");
-    expect(source).toContain("refreshScheduler.refreshNow()");
+  it("delegates the refresh affordance to the shared RefreshControl", () => {
+    expect(source).toContain("<RefreshControl");
+    expect(source).toContain("analytics.lastUpdatedAt");
+    // The scheduler, label tick, and icon now live in the shared component.
+    expect(source).not.toContain("createRefreshScheduler");
+    expect(source).not.toContain("REFRESH_INTERVAL_MS");
+    expect(source).not.toContain("REFRESH_LABEL_INTERVAL_MS");
+    expect(source).not.toContain("formatRefreshAge");
+    expect(source).not.toContain("RefreshCwIcon");
     expect(source).not.toContain("setInterval");
   });
 
-  it("shows relative last-updated refresh status without ambiguous badges", () => {
-    expect(source).toContain("analytics.lastUpdatedAt");
-    expect(source).toContain("REFRESH_LABEL_INTERVAL_MS = 60 * 1000");
-    expect(source).toContain("formatRefreshAge");
+  it("shows relative last-updated status without ambiguous badges", () => {
     expect(source).not.toContain("formatUpdatedAt");
     expect(source).not.toContain("analytics.hasNewData");
     expect(source).not.toContain("New data");
     expect(source).not.toContain(".new-data");
-  });
-
-  it("does not announce passive refresh-age ticks as live updates", () => {
-    expect(source).not.toContain(
-      'class="refresh-status" aria-live="polite"',
-    );
-  });
-
-  it("keeps the refresh timestamp beside the centered icon button", () => {
-    const refreshControl =
-      source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";
-    const refreshButton =
-      source.match(/\.refresh-btn\s*{[^}]+}/)?.[0] ?? "";
-
-    expect(source).toContain('class="refresh-control"');
-    expect(refreshControl).toContain("display: inline-flex");
-    expect(refreshControl).toContain("align-items: center");
-    expect(refreshControl).toContain("gap: 8px");
-    expect(refreshButton).toContain("width: 28px");
-    expect(refreshButton).toContain("justify-content: center");
-    expect(refreshButton).not.toContain("padding-right");
-    expect(source).not.toContain(".refresh-btn::before");
   });
 
   it("keeps refresh progress out of content layout flow", () => {

--- a/frontend/src/lib/components/content/ToolBlock.test.ts
+++ b/frontend/src/lib/components/content/ToolBlock.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 // ABOUTME: Unit tests for ToolBlock's output section behavior.
 // ABOUTME: Covers visibility, collapse/expand, and preview of result_content.
-import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
+import { describe, it, expect, vi, afterEach } from "vite-plus/test";
 import { mount, unmount, tick } from "svelte";
 import type { ToolCall } from "../../api/types.js";
 

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    ActivityIcon,
     ArrowDownIcon,
     ArrowDownWideNarrowIcon,
     ArrowUpNarrowWideIcon,
@@ -323,6 +324,17 @@
     >
       <Grid2x2Icon size="12" strokeWidth="2" aria-hidden="true" />
       <span class="nav-label">Usage</span>
+    </button>
+
+    <button
+      class="nav-btn"
+      class:active={router.route === "activity"}
+      onclick={() => router.navigate("activity")}
+      title="Activity"
+      aria-label="Activity"
+    >
+      <ActivityIcon size="12" strokeWidth="2" aria-hidden="true" />
+      <span class="nav-label">Activity</span>
     </button>
 
     <div class="more-wrap">

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -32,6 +32,7 @@
   });
 
   let lastSyncText = $derived.by(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dependency: recompute relative time when the tick advances
     relativeTimeTick;
     return sync.lastSync
       ? formatRelativeTime(sync.lastSync)

--- a/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
+++ b/frontend/src/lib/components/layout/ThreeColumnLayout.svelte
@@ -13,6 +13,7 @@
   import type { Route } from "../../stores/router.svelte.js";
   import { sessions } from "../../stores/sessions.svelte.js";
   import {
+    ActivityIcon,
     ChartColumnIcon,
     Grid2x2Icon,
     LayoutGridIcon,
@@ -231,6 +232,7 @@
 
   $effect(() => {
     if (!layoutElement) return;
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dependency: re-measure layout when viewport width changes
     viewportWidth;
     measureLayoutWidth();
   });
@@ -315,6 +317,14 @@
       >
         <Grid2x2Icon size="12" strokeWidth="2" aria-hidden="true" />
         Usage
+      </button>
+      <button
+        class="mobile-nav-btn"
+        class:active={router.route === "activity"}
+        onclick={() => mobileNav("activity")}
+      >
+        <ActivityIcon size="12" strokeWidth="2" aria-hidden="true" />
+        Activity
       </button>
       <button
         class="mobile-nav-btn"

--- a/frontend/src/lib/components/shared/RefreshControl.svelte
+++ b/frontend/src/lib/components/shared/RefreshControl.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import { onMount, untrack } from "svelte";
+  import {
+    createRefreshScheduler,
+    DEFAULT_REFRESH_INTERVAL_MS,
+    formatRefreshAge,
+  } from "../../utils/refresh.js";
+  import { RefreshCwIcon } from "../../icons.js";
+
+  // Re-evaluate the relative age label this often so it advances without a data
+  // fetch. Shared by every dashboard that shows an "Updated Xm ago" status.
+  const REFRESH_LABEL_INTERVAL_MS = 60 * 1000;
+
+  let {
+    lastUpdatedAt,
+    busy = false,
+    onRefresh,
+    label,
+    title,
+    intervalMs = DEFAULT_REFRESH_INTERVAL_MS,
+  }: {
+    /** Epoch ms of the last successful fetch, or null before the first load. */
+    lastUpdatedAt: number | null;
+    /** Spins the icon and disables the button while a refresh is in flight. */
+    busy?: boolean;
+    /** Refetches the dashboard data; invoked on the interval and on click. */
+    onRefresh: () => void;
+    /** Accessible name for the button (aria-label). */
+    label: string;
+    /** Tooltip text; defaults to `label` when omitted. */
+    title?: string;
+    /** Auto-refresh cadence in ms; defaults to the shared 5-minute interval. */
+    intervalMs?: number;
+  } = $props();
+
+  // The page owns the initial load -- it alone knows when its URL/filter state
+  // is hydrated -- so this control only keeps the data fresh afterward. Arm the
+  // interval without an immediate fetch (scheduleNext, not start) so the first
+  // auto-refresh lands one interval out instead of racing the page's mount; a
+  // manual click refreshes now and resets that timer. intervalMs is read once
+  // at setup (untrack); a live cadence change would need a fresh scheduler.
+  const scheduler = createRefreshScheduler(
+    () => onRefresh(),
+    untrack(() => intervalMs),
+  );
+
+  // Local clock that ticks once a minute so the age label re-derives without a
+  // data fetch. Seeded once at mount.
+  let tick = $state(Date.now());
+  const ageLabel = $derived(formatRefreshAge(lastUpdatedAt, tick));
+
+  onMount(() => {
+    scheduler.scheduleNext();
+    let labelTimer: ReturnType<typeof setTimeout> | undefined;
+    function scheduleLabelTick() {
+      labelTimer = setTimeout(() => {
+        tick = Date.now();
+        scheduleLabelTick();
+      }, REFRESH_LABEL_INTERVAL_MS);
+    }
+    scheduleLabelTick();
+    return () => {
+      scheduler.stop();
+      if (labelTimer !== undefined) clearTimeout(labelTimer);
+    };
+  });
+</script>
+
+<div class="refresh-control">
+  <button
+    class="refresh-btn"
+    class:querying={busy}
+    onclick={() => scheduler.refreshNow()}
+    disabled={busy}
+    title={title ?? label}
+    aria-label={label}
+  >
+    <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
+  </button>
+  <div class="refresh-status">
+    <span
+      title={lastUpdatedAt === null
+        ? undefined
+        : new Date(lastUpdatedAt).toLocaleString()}
+    >
+      {ageLabel}
+    </span>
+  </div>
+</div>
+
+<style>
+  .refresh-control {
+    min-height: 28px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .refresh-btn {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s, opacity 0.1s;
+  }
+
+  .refresh-btn:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .refresh-btn:disabled {
+    cursor: default;
+    opacity: 0.75;
+  }
+
+  .refresh-btn.querying :global(svg) {
+    animation: spin 0.8s linear infinite;
+  }
+
+  .refresh-status {
+    min-height: 24px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-muted);
+    font-size: 11px;
+    white-space: nowrap;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/frontend/src/lib/components/shared/RefreshControl.test.ts
+++ b/frontend/src/lib/components/shared/RefreshControl.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { mount, unmount } from "svelte";
+// @ts-ignore
+import RefreshControl from "./RefreshControl.svelte";
+import source from "./RefreshControl.svelte?raw";
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("RefreshControl", () => {
+  it("renders the icon button with the given label and tooltip default", () => {
+    const component = mount(RefreshControl, {
+      target: document.body,
+      props: {
+        lastUpdatedAt: null,
+        onRefresh: () => {},
+        label: "Refresh activity",
+      },
+    });
+
+    const button = document.querySelector<HTMLButtonElement>(
+      'button.refresh-btn[aria-label="Refresh activity"]',
+    );
+    expect(button).not.toBeNull();
+    // No explicit title falls back to the label.
+    expect(button!.getAttribute("title")).toBe("Refresh activity");
+    expect(button!.querySelector("svg")).not.toBeNull();
+
+    const status = document.querySelector(".refresh-status span");
+    expect(status?.textContent?.trim()).toBe("Not updated");
+
+    unmount(component);
+  });
+
+  it("uses a distinct tooltip when title differs from the label", () => {
+    const component = mount(RefreshControl, {
+      target: document.body,
+      props: {
+        lastUpdatedAt: null,
+        onRefresh: () => {},
+        label: "Refresh usage data",
+        title: "Refresh",
+      },
+    });
+
+    const button = document.querySelector<HTMLButtonElement>(
+      'button.refresh-btn[aria-label="Refresh usage data"]',
+    );
+    expect(button!.getAttribute("title")).toBe("Refresh");
+
+    unmount(component);
+  });
+
+  it("formats the relative age from the last update", () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(new Date("2026-06-16T12:10:00Z"));
+    const component = mount(RefreshControl, {
+      target: document.body,
+      props: {
+        lastUpdatedAt: new Date("2026-06-16T12:08:00Z").getTime(),
+        onRefresh: () => {},
+        label: "Refresh",
+      },
+    });
+
+    const status = document.querySelector(".refresh-status span");
+    expect(status?.textContent?.trim()).toBe("Updated 2m ago");
+
+    unmount(component);
+  });
+
+  it("refreshes on click", () => {
+    const onRefresh = vi.fn();
+    const component = mount(RefreshControl, {
+      target: document.body,
+      props: { lastUpdatedAt: null, onRefresh, label: "Refresh" },
+    });
+
+    document
+      .querySelector<HTMLButtonElement>("button.refresh-btn")!
+      .click();
+    expect(onRefresh).toHaveBeenCalledOnce();
+
+    unmount(component);
+  });
+
+  it("spins and disables the button while busy", () => {
+    const onRefresh = vi.fn();
+    const component = mount(RefreshControl, {
+      target: document.body,
+      props: { lastUpdatedAt: null, onRefresh, label: "Refresh", busy: true },
+    });
+
+    const button = document.querySelector<HTMLButtonElement>(
+      "button.refresh-btn",
+    );
+    expect(button!.disabled).toBe(true);
+    expect(button!.classList.contains("querying")).toBe(true);
+    button!.click();
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    unmount(component);
+  });
+
+  it("auto-refreshes on the interval without firing on mount", async () => {
+    vi.useFakeTimers();
+    const onRefresh = vi.fn();
+    const component = mount(RefreshControl, {
+      target: document.body,
+      props: {
+        lastUpdatedAt: null,
+        onRefresh,
+        label: "Refresh",
+        intervalMs: 1000,
+      },
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(0);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+
+    unmount(component);
+  });
+
+  it("owns the bounded auto-refresh scheduler", () => {
+    expect(source).toContain("createRefreshScheduler");
+    expect(source).toContain("scheduler.scheduleNext()");
+    expect(source).toContain("scheduler.refreshNow()");
+    expect(source).toContain("DEFAULT_REFRESH_INTERVAL_MS");
+    expect(source).not.toContain("setInterval");
+  });
+
+  it("ticks the age label on a one-minute timer", () => {
+    expect(source).toContain("REFRESH_LABEL_INTERVAL_MS = 60 * 1000");
+    expect(source).toContain("formatRefreshAge");
+  });
+
+  it("does not announce passive refresh-age ticks as live updates", () => {
+    expect(source).not.toContain("aria-live");
+  });
+
+  it("keeps the timestamp beside the centered icon button", () => {
+    const refreshControl =
+      source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";
+    const refreshButton =
+      source.match(/\.refresh-btn\s*{[^}]+}/)?.[0] ?? "";
+
+    expect(refreshControl).toContain("display: inline-flex");
+    expect(refreshControl).toContain("align-items: center");
+    expect(refreshControl).toContain("gap: 8px");
+    expect(refreshButton).toContain("width: 28px");
+    expect(refreshButton).toContain("justify-content: center");
+    expect(refreshButton).not.toContain("padding-right");
+    expect(source).not.toContain(".refresh-btn::before");
+  });
+});

--- a/frontend/src/lib/components/sidebar/session-list-utils.test.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.test.ts
@@ -3,7 +3,6 @@ import type { Session } from "../../api/types.js";
 import type { SessionGroup } from "../../stores/sessions.svelte.js";
 import {
   ITEM_HEIGHT,
-  CHILD_ITEM_HEIGHT,
   HEADER_HEIGHT,
   STORAGE_KEY,
   buildGroupSections,
@@ -13,7 +12,7 @@ import {
   isSubagentDescendant,
   selectPrimaryId,
 } from "./session-list-utils.js";
-import type { GroupSection, DisplayItem } from "./session-list-utils.js";
+import type { DisplayItem } from "./session-list-utils.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/frontend/src/lib/components/sidebar/session-list-utils.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.ts
@@ -193,18 +193,6 @@ export function isSubagentDescendant(
 }
 
 /**
- * Check if a session is a continuation or fork (not a subagent
- * descendant, not a teammate).  These render without a sub-group
- * header or under a "Continuations" label.
- */
-function isContinuation(
-  s: SessionGroupInput,
-  allSessions: SessionGroupInput[],
-): boolean {
-  return !isSubagentDescendant(s, allSessions) && !isTeammate(s, allSessions);
-}
-
-/**
  * Emit display items for a single SessionGroup, expanding
  * child sessions when the group key is in expandedGroups.
  *

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -23,28 +23,10 @@
   import SessionFilterControl from "../filters/SessionFilterControl.svelte";
   import SessionActiveFilters from "../filters/SessionActiveFilters.svelte";
   import FilterDropdown from "./FilterDropdown.svelte";
-  import { formatRefreshAge } from "../../utils/refresh.js";
-  import { RefreshCwIcon } from "../../icons.js";
-
-  const REFRESH_LABEL_INTERVAL_MS = 60 * 1000;
+  import RefreshControl from "../shared/RefreshControl.svelte";
 
   let mounted = false;
-  let refreshLabelTick = $state(Date.now());
-  let refreshLabelTimer:
-    | ReturnType<typeof setTimeout>
-    | undefined;
   let unsubEvents: (() => void) | undefined;
-
-  let refreshLabel = $derived.by(() => {
-    return formatRefreshAge(usage.lastUpdatedAt, refreshLabelTick);
-  });
-
-  function scheduleRefreshLabelTick() {
-    refreshLabelTimer = setTimeout(() => {
-      refreshLabelTick = Date.now();
-      scheduleRefreshLabelTick();
-    }, REFRESH_LABEL_INTERVAL_MS);
-  }
 
   const projectItems = $derived(
     sessions.projects.map((p) => ({
@@ -254,17 +236,16 @@
 
   onMount(() => {
     mounted = true;
+    // SSE events only flag new data; RefreshControl owns the periodic refresh
+    // and the manual button. The initial and filter-change fetches run from the
+    // effects above once URL/filter state is hydrated.
     unsubEvents = events.subscribe(() => usage.markNewData());
-    scheduleRefreshLabelTick();
     tick().then(() => {
       urlWritebackReady = true;
     });
   });
 
   onDestroy(() => {
-    if (refreshLabelTimer !== undefined) {
-      clearTimeout(refreshLabelTimer);
-    }
     unsubEvents?.();
   });
 </script>
@@ -314,27 +295,13 @@
           usage.deselectAllModels(modelItems.map((m) => m.name))}
       />
 
-      <div class="refresh-control">
-        <button
-          class="refresh-btn"
-          class:querying={usage.isQuerying}
-          onclick={() => usage.fetchAll()}
-          disabled={usage.isQuerying}
-          title="Refresh"
-          aria-label="Refresh usage data"
-        >
-          <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
-        </button>
-        <div class="refresh-status">
-          <span
-            title={usage.lastUpdatedAt === null
-              ? undefined
-              : new Date(usage.lastUpdatedAt).toLocaleString()}
-          >
-            {refreshLabel}
-          </span>
-        </div>
-      </div>
+      <RefreshControl
+        lastUpdatedAt={usage.lastUpdatedAt}
+        busy={usage.isQuerying}
+        onRefresh={() => usage.fetchAll()}
+        label="Refresh usage data"
+        title="Refresh"
+      />
 
     </div>
   </div>
@@ -408,49 +375,6 @@
     align-items: center;
   }
 
-  .refresh-control {
-    min-height: 28px;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .refresh-btn {
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: background 0.1s, color 0.1s, opacity 0.1s;
-  }
-
-  .refresh-btn:hover:not(:disabled) {
-    background: var(--bg-surface-hover);
-    color: var(--text-primary);
-  }
-
-  .refresh-btn:disabled {
-    cursor: default;
-    opacity: 0.75;
-  }
-
-  .refresh-btn.querying :global(svg) {
-    animation: spin 0.8s linear infinite;
-  }
-
-  .refresh-status {
-    min-height: 24px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: var(--text-muted);
-    font-size: 11px;
-    white-space: nowrap;
-  }
-
   .usage-content {
     flex: 1;
     overflow-y: auto;
@@ -512,12 +436,6 @@
   @media (max-width: 800px) {
     .bottom-grid {
       grid-template-columns: 1fr;
-    }
-  }
-
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
     }
   }
 

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -5,38 +5,28 @@ describe("UsagePage refresh behavior", () => {
   it("does not auto-refresh usage scans from SSE updates", () => {
     expect(source).not.toContain("subscribeDebounced");
     expect(source).not.toContain("REFRESH_MS");
+    // SSE only flags new data; the periodic refetch lives in RefreshControl.
+    expect(source).toContain("usage.markNewData");
+    expect(source).toContain("events.subscribe");
   });
 
-  it("shows relative last-updated refresh status without ambiguous badges", () => {
+  it("delegates the refresh affordance and scheduler to RefreshControl", () => {
+    expect(source).toContain("<RefreshControl");
     expect(source).toContain("usage.lastUpdatedAt");
-    expect(source).toContain("REFRESH_LABEL_INTERVAL_MS = 60 * 1000");
-    expect(source).toContain("formatRefreshAge");
+    expect(source).toContain('label="Refresh usage data"');
+    expect(source).toContain('title="Refresh"');
+    // The scheduler, label tick, and icon now live in the shared component.
+    expect(source).not.toContain("REFRESH_LABEL_INTERVAL_MS");
+    expect(source).not.toContain("formatRefreshAge");
+    expect(source).not.toContain("RefreshCwIcon");
+    expect(source).not.toContain("setInterval");
+  });
+
+  it("shows relative last-updated status without ambiguous badges", () => {
     expect(source).not.toContain("formatUpdatedAt");
     expect(source).not.toContain("usage.hasNewData");
     expect(source).not.toContain("New data");
     expect(source).not.toContain(".new-data");
-  });
-
-  it("does not announce passive refresh-age ticks as live updates", () => {
-    expect(source).not.toContain(
-      'class="refresh-status" aria-live="polite"',
-    );
-  });
-
-  it("keeps the refresh timestamp beside the centered icon button", () => {
-    const refreshControl =
-      source.match(/\.refresh-control\s*{[^}]+}/)?.[0] ?? "";
-    const refreshButton =
-      source.match(/\.refresh-btn\s*{[^}]+}/)?.[0] ?? "";
-
-    expect(source).toContain('class="refresh-control"');
-    expect(refreshControl).toContain("display: inline-flex");
-    expect(refreshControl).toContain("align-items: center");
-    expect(refreshControl).toContain("gap: 8px");
-    expect(refreshButton).toContain("width: 28px");
-    expect(refreshButton).toContain("justify-content: center");
-    expect(refreshButton).not.toContain("padding-right");
-    expect(source).not.toContain(".refresh-btn::before");
   });
 
   it("keeps refresh progress out of content layout flow", () => {

--- a/frontend/src/lib/icons.test.ts
+++ b/frontend/src/lib/icons.test.ts
@@ -12,6 +12,7 @@ const approvedIconNames = [
   "CheckIcon",
   "ChartColumnIcon",
   "ChevronDownIcon",
+  "ChevronLeftIcon",
   "ChevronRightIcon",
   "ChevronUpIcon",
   "CirclePlayIcon",

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -6,6 +6,7 @@ export { default as CalendarIcon } from "@lucide/svelte/icons/calendar";
 export { default as CheckIcon } from "@lucide/svelte/icons/check";
 export { default as ChartColumnIcon } from "@lucide/svelte/icons/chart-column";
 export { default as ChevronDownIcon } from "@lucide/svelte/icons/chevron-down";
+export { default as ChevronLeftIcon } from "@lucide/svelte/icons/chevron-left";
 export { default as ChevronRightIcon } from "@lucide/svelte/icons/chevron-right";
 export { default as ChevronUpIcon } from "@lucide/svelte/icons/chevron-up";
 export { default as CirclePlayIcon } from "@lucide/svelte/icons/circle-play";

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -1,0 +1,344 @@
+import type { AgentInfo, ProjectInfo } from "../api/types.js";
+import type { Report } from "../api/types/activity.js";
+import { ActivityService, MetadataService } from "../api/generated/index";
+import { configureGeneratedClient } from "../api/runtime.js";
+import { sync } from "./sync.svelte.js";
+import { router } from "./router.svelte.js";
+
+type Preset = "day" | "week" | "month" | "custom";
+
+const PRESETS: ReadonlySet<string> = new Set<Preset>([
+  "day",
+  "week",
+  "month",
+  "custom",
+]);
+
+export function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Translate a date-only custom `to` value (YYYY-MM-DD, local zone) to the
+ * exclusive end of a half-open range: local 00:00 of the day AFTER `to`, as an
+ * RFC3339 instant. The caller passes only a non-empty value.
+ */
+function customToInstant(to: string): string {
+  const end = new Date(to + "T00:00:00");
+  end.setDate(end.getDate() + 1);
+  return end.toISOString();
+}
+
+class ActivityStore {
+  preset = $state<Preset>("day");
+  date: string = $state(localDateStr(new Date()));
+  from = $state("");
+  to = $state("");
+  bucket = $state("");
+  project: string = $state("");
+  agent: string = $state("");
+  machine: string = $state("");
+  report: Report | null = $state(null);
+  loading = $state(false);
+  error: string | null = $state(null);
+
+  // Filter-option lists for the activity controls. Loaded with full
+  // inclusion (one-shot + automated) so every project/agent/machine
+  // that can appear in the always-inclusive activity report is also
+  // selectable here — unlike the sidebar's lists, which honor the
+  // sidebar include toggles.
+  projects: ProjectInfo[] = $state([]);
+  agents: AgentInfo[] = $state([]);
+  machines: string[] = $state([]);
+
+  private loadVersion = 0;
+  #filterOptionsLoaded = false;
+  #filterOptionsPromise: Promise<void> | null = null;
+  #filterOptionsVersion = 0;
+  #attached = 0;
+
+  /** Browser-resolved IANA timezone; not a user control. */
+  get timezone(): string {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+
+  async load() {
+    const v = ++this.loadVersion;
+    // A custom range needs both bounds. With only one present (a cleared date
+    // input or a partial deep link) the backend rejects the request, so hold
+    // the current view until both are set instead of flashing an error.
+    if (this.preset === "custom" && (!this.from || !this.to)) {
+      this.loading = false;
+      return;
+    }
+    this.loading = true;
+    this.error = null;
+    configureGeneratedClient();
+    try {
+      // Custom date-only inputs (YYYY-MM-DD, browser local zone) become
+      // half-open local instants: from = local 00:00 of `from`, to = local
+      // 00:00 of the day after `to`. Non-custom presets rely on preset+date, so
+      // send no range. An empty input maps to undefined so selecting "custom"
+      // before picking dates never builds an Invalid Date. A malformed
+      // hand-edited date throws here, inside the try, so load() still resets
+      // loading rather than leaving it stuck true.
+      const fromParam =
+        this.preset === "custom" && this.from
+          ? new Date(this.from + "T00:00:00").toISOString()
+          : undefined;
+      const toParam =
+        this.preset === "custom" && this.to
+          ? customToInstant(this.to)
+          : undefined;
+      const res = await ActivityService.getApiV1ActivityReport({
+        preset: this.preset,
+        date: this.date,
+        from: fromParam,
+        to: toParam,
+        timezone: this.timezone,
+        // The store keeps bucket as a free-form override string (populated by
+        // the Task 4 control); the generated client narrows it to the server's
+        // accepted set. An out-of-set value is rejected server-side.
+        bucket: (this.bucket || undefined) as
+          | "5m"
+          | "15m"
+          | "1h"
+          | "1d"
+          | "1w"
+          | undefined,
+        project: this.project || undefined,
+        agent: this.agent || undefined,
+        machine: this.machine || undefined,
+      });
+      if (v !== this.loadVersion) return;
+      this.report = res as unknown as Report;
+      this.loading = false;
+    } catch (e) {
+      if (v !== this.loadVersion) return;
+      this.report = null;
+      this.error =
+        e instanceof Error ? e.message : "Failed to load activity report";
+      this.loading = false;
+    }
+  }
+
+  /**
+   * Populate the activity filter dropdowns, including one-shot and automated
+   * sessions so the controls cover everything the always-inclusive activity
+   * report can surface. The result is cached after a fully successful load
+   * and refreshed when a sync/import completes (via invalidateFilterOptions),
+   * mirroring the sessions store. A concurrent call shares the in-flight
+   * request. A transient failure leaves the cache un-loaded so the next call
+   * retries; lists that did succeed keep their values in the meantime.
+   */
+  async loadFilterOptions() {
+    if (this.#filterOptionsLoaded) return;
+    if (this.#filterOptionsPromise) return this.#filterOptionsPromise;
+    const ver = this.#filterOptionsVersion;
+    const opts = { includeOneShot: true, includeAutomated: true };
+    this.#filterOptionsPromise = (async () => {
+      configureGeneratedClient();
+      let ok = true;
+      try {
+        const res = (await MetadataService.getApiV1Projects(
+          opts,
+        )) as unknown as { projects: ProjectInfo[] };
+        if (ver === this.#filterOptionsVersion) this.projects = res.projects;
+      } catch {
+        ok = false; // keep the current list; retry on the next call
+      }
+      try {
+        const res = (await MetadataService.getApiV1Agents(
+          opts,
+        )) as unknown as { agents: AgentInfo[] };
+        if (ver === this.#filterOptionsVersion) this.agents = res.agents;
+      } catch {
+        ok = false;
+      }
+      try {
+        const res = (await MetadataService.getApiV1Machines(
+          opts,
+        )) as unknown as { machines: string[] };
+        if (ver === this.#filterOptionsVersion) this.machines = res.machines;
+      } catch {
+        ok = false;
+      }
+      if (ver === this.#filterOptionsVersion) {
+        // Cache only a fully successful load so a transient failure is
+        // retried rather than frozen as a permanent empty list.
+        this.#filterOptionsLoaded = ok;
+        this.#filterOptionsPromise = null;
+      }
+    })();
+    return this.#filterOptionsPromise;
+  }
+
+  /**
+   * Drop the activity filter-option cache so the next loadFilterOptions()
+   * refetches. Invoked when a sync/import completes, since newly imported
+   * sessions can introduce projects/agents/machines the activity report shows.
+   */
+  invalidateFilterOptions() {
+    this.#filterOptionsVersion++;
+    this.#filterOptionsLoaded = false;
+    this.#filterOptionsPromise = null;
+  }
+
+  /** Whether an ActivityPage is currently mounted and showing the controls. */
+  get attached(): boolean {
+    return this.#attached > 0;
+  }
+
+  /**
+   * Register a mounted ActivityPage so a completed sync can refresh the filter
+   * options while they are on screen. Returns a detach callback for the
+   * component's onMount cleanup.
+   */
+  attach(): () => void {
+    this.#attached++;
+    // Make state URL-canonical on mount, then keep it in sync with browser
+    // back/forward. router's own popstate handler runs first (registered at
+    // module load) and has already refreshed router.params synchronously, so
+    // reading it here observes the navigated-to URL.
+    this.hydrateFromUrl(router.params);
+    const onPop = () => {
+      this.hydrateFromUrl(router.params);
+      void this.load();
+    };
+    window.addEventListener("popstate", onPop);
+    let detached = false;
+    return () => {
+      if (detached) return;
+      detached = true;
+      window.removeEventListener("popstate", onPop);
+      this.#attached = Math.max(0, this.#attached - 1);
+    };
+  }
+
+  /**
+   * Replace range/preset/filter state from URL query params. `preset` defaults
+   * to "day" (and falls back to "day" for any unknown value); `date` defaults
+   * to today's local YYYY-MM-DD. The remaining filters default to empty. This
+   * is the single hydration path, run on mount and on popstate.
+   */
+  hydrateFromUrl(params: Record<string, string>) {
+    this.preset = PRESETS.has(params.preset ?? "")
+      ? (params.preset as Preset)
+      : "day";
+    this.date = params.date || localDateStr(new Date());
+    this.from = params.from ?? "";
+    this.to = params.to ?? "";
+    this.bucket = params.bucket ?? "";
+    this.project = params.project ?? "";
+    this.agent = params.agent ?? "";
+    this.machine = params.machine ?? "";
+  }
+
+  /**
+   * Write the current range/preset/filter state to the URL through the router's
+   * single replaceState path. `preset` is always included; `date` is included
+   * for day/week/month when non-empty; `from`/`to` only for the custom preset;
+   * bucket/project/agent/machine only when non-empty. Empty filters and
+   * preset-irrelevant fields are omitted so URLs stay minimal and deep-linkable.
+   */
+  writeUrl() {
+    const p: Record<string, string> = { preset: this.preset };
+    if (this.preset === "custom") {
+      if (this.from) p.from = this.from;
+      if (this.to) p.to = this.to;
+    } else {
+      if (this.date) p.date = this.date;
+    }
+    if (this.bucket) p.bucket = this.bucket;
+    if (this.project) p.project = this.project;
+    if (this.agent) p.agent = this.agent;
+    if (this.machine) p.machine = this.machine;
+    router.replaceParams(p);
+  }
+
+  setPreset(p: Preset) {
+    this.preset = p;
+    if (p === "custom") {
+      // Seed a 1-day range from the current anchor so selecting Custom shows a
+      // valid range immediately instead of erroring on empty from/to bounds.
+      if (!this.from) this.from = this.date;
+      if (!this.to) this.to = this.date;
+    }
+    this.writeUrl();
+  }
+
+  setDate(date: string) {
+    this.date = date;
+    this.writeUrl();
+  }
+
+  setFrom(d: string) {
+    this.from = d;
+    this.writeUrl();
+  }
+
+  setTo(d: string) {
+    this.to = d;
+    this.writeUrl();
+  }
+
+  /**
+   * Advance the anchor `date` by one preset unit: one day for `day`, seven days
+   * for `week`, one calendar month for `month` (clamped to a valid day). No-op
+   * for `custom`, which is driven by explicit from/to inputs instead.
+   */
+  step(direction: -1 | 1) {
+    if (this.preset === "custom") return;
+    const d = new Date(this.date + "T00:00:00");
+    if (this.preset === "week") {
+      d.setDate(d.getDate() + 7 * direction);
+    } else if (this.preset === "month") {
+      // Advance one calendar month, clamping the day to the target month's last
+      // day so e.g. Jan 31 -> Feb 28 instead of overflowing into March.
+      const target = new Date(d.getFullYear(), d.getMonth() + direction, 1);
+      const lastDay = new Date(
+        target.getFullYear(),
+        target.getMonth() + 1,
+        0,
+      ).getDate();
+      target.setDate(Math.min(d.getDate(), lastDay));
+      d.setTime(target.getTime());
+    } else {
+      d.setDate(d.getDate() + direction);
+    }
+    this.date = localDateStr(d);
+    this.writeUrl();
+  }
+
+  setProject(project: string) {
+    this.project = project;
+    this.writeUrl();
+  }
+
+  setAgent(agent: string) {
+    this.agent = agent;
+    this.writeUrl();
+  }
+
+  setMachine(machine: string) {
+    this.machine = machine;
+    this.writeUrl();
+  }
+}
+
+export const activity = new ActivityStore();
+
+// Refresh the activity filter options after any sync/import, mirroring the
+// sessions store, so newly imported projects/agents/machines appear in the
+// activity controls without a full page reload. Only refetch when an
+// ActivityPage is mounted; otherwise the invalidated cache is picked up lazily
+// by the next mount's loadFilterOptions(). The eager refetch also recovers the
+// controls when a sync lands mid-initial-load and the version bump discards
+// that in-flight response.
+sync.onSyncComplete(() => {
+  activity.invalidateFilterOptions();
+  if (activity.attached) void activity.loadFilterOptions();
+});

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -352,14 +352,20 @@ class ActivityStore {
 
 export const activity = new ActivityStore();
 
-// Refresh the activity filter options after any sync/import, mirroring the
-// sessions store, so newly imported projects/agents/machines appear in the
-// activity controls without a full page reload. Only refetch when an
-// ActivityPage is mounted; otherwise the invalidated cache is picked up lazily
-// by the next mount's loadFilterOptions(). The eager refetch also recovers the
-// controls when a sync lands mid-initial-load and the version bump discards
-// that in-flight response.
+// Refresh the activity view after any sync/import so freshly imported sessions
+// appear without a manual reload. Always drop the filter-option cache (mirroring
+// the sessions store) so new projects/agents/machines can surface. When an
+// ActivityPage is mounted, eagerly refetch those options AND reload the report
+// itself: the report is otherwise only refreshed on a range/filter change or
+// navigation, so without this the charts and table stay stale after a background
+// sync. When nothing is mounted, the invalidated cache is picked up lazily by
+// the next mount's loadFilterOptions(); that mount also calls load(). The eager
+// refetch additionally recovers a sync that lands mid-initial-load, where the
+// version bump discards the in-flight response.
 sync.onSyncComplete(() => {
   activity.invalidateFilterOptions();
-  if (activity.attached) void activity.loadFilterOptions();
+  if (activity.attached) {
+    void activity.loadFilterOptions();
+    void activity.load();
+  }
 });

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -53,6 +53,15 @@ class ActivityStore {
   report: Report | null = $state(null);
   loading = $state(false);
   error: string | null = $state(null);
+  // Epoch ms of the last successful report fetch, powering the "Updated Xm ago"
+  // refresh label. null until the first load completes.
+  lastUpdatedAt: number | null = $state(null);
+  // Set when an SSE event arrives after the first load, signalling that newer
+  // data exists. Mirrors the analytics/usage stores: marking is cheap, and the
+  // actual refetch is left to the manual refresh button and the periodic
+  // scheduler so a session actively writing files does not thrash the report
+  // aggregation on every event.
+  hasNewData: boolean = $state(false);
 
   // Filter-option lists for the activity controls. Loaded with full
   // inclusion (one-shot + automated) so every project/agent/machine
@@ -72,6 +81,18 @@ class ActivityStore {
   /** Browser-resolved IANA timezone; not a user control. */
   get timezone(): string {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+
+  /**
+   * Flag that newer data exists (an SSE event arrived) without refetching, so a
+   * session actively writing files does not thrash the report aggregation on
+   * every event. No-op before the first successful load, matching the
+   * analytics/usage stores. The report refreshes on the manual refresh button,
+   * the periodic scheduler, or a range/filter change.
+   */
+  markNewData(): void {
+    if (this.lastUpdatedAt === null) return;
+    this.hasNewData = true;
   }
 
   async load() {
@@ -125,6 +146,8 @@ class ActivityStore {
       });
       if (v !== this.loadVersion) return;
       this.report = res as unknown as Report;
+      this.lastUpdatedAt = Date.now();
+      this.hasNewData = false;
       this.loading = false;
     } catch (e) {
       if (v !== this.loadVersion) return;
@@ -352,20 +375,17 @@ class ActivityStore {
 
 export const activity = new ActivityStore();
 
-// Refresh the activity view after any sync/import so freshly imported sessions
-// appear without a manual reload. Always drop the filter-option cache (mirroring
-// the sessions store) so new projects/agents/machines can surface. When an
-// ActivityPage is mounted, eagerly refetch those options AND reload the report
-// itself: the report is otherwise only refreshed on a range/filter change or
-// navigation, so without this the charts and table stay stale after a background
-// sync. When nothing is mounted, the invalidated cache is picked up lazily by
-// the next mount's loadFilterOptions(); that mount also calls load(). The eager
-// refetch additionally recovers a sync that lands mid-initial-load, where the
-// version bump discards the in-flight response.
+// Refresh the activity filter options after any sync/import, mirroring the
+// sessions store, so newly imported projects/agents/machines appear in the
+// activity controls without a full page reload. Only refetch when an
+// ActivityPage is mounted; otherwise the invalidated cache is picked up lazily
+// by the next mount's loadFilterOptions(). The report itself is deliberately
+// not refetched here: that is driven by the manual refresh button and the
+// periodic scheduler in ActivityPage, so a session actively writing files does
+// not thrash the report aggregation on every sync. The eager option refetch
+// also recovers the controls when a sync lands mid-initial-load and the version
+// bump discards that in-flight response.
 sync.onSyncComplete(() => {
   activity.invalidateFilterOptions();
-  if (activity.attached) {
-    void activity.loadFilterOptions();
-    void activity.load();
-  }
+  if (activity.attached) void activity.loadFilterOptions();
 });

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -14,6 +14,14 @@ const PRESETS: ReadonlySet<string> = new Set<Preset>([
   "custom",
 ]);
 
+export type Automation = "all" | "interactive" | "automated";
+
+const AUTOMATIONS: ReadonlySet<string> = new Set<Automation>([
+  "all",
+  "interactive",
+  "automated",
+]);
+
 export function localDateStr(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
@@ -41,6 +49,7 @@ class ActivityStore {
   project: string = $state("");
   agent: string = $state("");
   machine: string = $state("");
+  automation: Automation = $state("all");
   report: Report | null = $state(null);
   loading = $state(false);
   error: string | null = $state(null);
@@ -112,6 +121,7 @@ class ActivityStore {
         project: this.project || undefined,
         agent: this.agent || undefined,
         machine: this.machine || undefined,
+        automation: this.automation,
       });
       if (v !== this.loadVersion) return;
       this.report = res as unknown as Report;
@@ -221,8 +231,9 @@ class ActivityStore {
   /**
    * Replace range/preset/filter state from URL query params. `preset` defaults
    * to "day" (and falls back to "day" for any unknown value); `date` defaults
-   * to today's local YYYY-MM-DD. The remaining filters default to empty. This
-   * is the single hydration path, run on mount and on popstate.
+   * to today's local YYYY-MM-DD; `automation` defaults to "all" (and falls back
+   * to "all" for any unknown value). The remaining filters default to empty.
+   * This is the single hydration path, run on mount and on popstate.
    */
   hydrateFromUrl(params: Record<string, string>) {
     this.preset = PRESETS.has(params.preset ?? "")
@@ -235,14 +246,18 @@ class ActivityStore {
     this.project = params.project ?? "";
     this.agent = params.agent ?? "";
     this.machine = params.machine ?? "";
+    this.automation = AUTOMATIONS.has(params.automation ?? "")
+      ? (params.automation as Automation)
+      : "all";
   }
 
   /**
    * Write the current range/preset/filter state to the URL through the router's
    * single replaceState path. `preset` is always included; `date` is included
    * for day/week/month when non-empty; `from`/`to` only for the custom preset;
-   * bucket/project/agent/machine only when non-empty. Empty filters and
-   * preset-irrelevant fields are omitted so URLs stay minimal and deep-linkable.
+   * bucket/project/agent/machine only when non-empty; `automation` only when not
+   * the "all" default. Empty filters and preset-irrelevant fields are omitted so
+   * URLs stay minimal and deep-linkable.
    */
   writeUrl() {
     const p: Record<string, string> = { preset: this.preset };
@@ -256,6 +271,7 @@ class ActivityStore {
     if (this.project) p.project = this.project;
     if (this.agent) p.agent = this.agent;
     if (this.machine) p.machine = this.machine;
+    if (this.automation !== "all") p.automation = this.automation;
     router.replaceParams(p);
   }
 
@@ -325,6 +341,11 @@ class ActivityStore {
 
   setMachine(machine: string) {
     this.machine = machine;
+    this.writeUrl();
+  }
+
+  setAutomation(automation: Automation) {
+    this.automation = automation;
     this.writeUrl();
   }
 }

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -154,9 +154,12 @@ class ActivityStore {
       this.loading = false;
       // A failed background refresh keeps the last good report on screen so a
       // transient blip never blanks the report-first dashboard; the growing
-      // "Updated Xm ago" label signals the staleness. A failed first load or
-      // range/filter change has nothing valid to show, so clear and surface it.
-      if (background) return;
+      // "Updated Xm ago" label signals the staleness. With no report yet (a
+      // first load still failing, or a refresh firing before one lands) there
+      // is nothing to preserve, so fall through and surface the error rather
+      // than leave a misleading empty state. First loads and range/filter
+      // changes are always foreground and clear on error.
+      if (background && this.report !== null) return;
       this.report = null;
       this.error =
         e instanceof Error ? e.message : "Failed to load activity report";

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -95,7 +95,7 @@ class ActivityStore {
     this.hasNewData = true;
   }
 
-  async load() {
+  async load({ background = false }: { background?: boolean } = {}) {
     const v = ++this.loadVersion;
     // A custom range needs both bounds. With only one present (a cleared date
     // input or a partial deep link) the backend rejects the request, so hold
@@ -151,10 +151,15 @@ class ActivityStore {
       this.loading = false;
     } catch (e) {
       if (v !== this.loadVersion) return;
+      this.loading = false;
+      // A failed background refresh keeps the last good report on screen so a
+      // transient blip never blanks the report-first dashboard; the growing
+      // "Updated Xm ago" label signals the staleness. A failed first load or
+      // range/filter change has nothing valid to show, so clear and surface it.
+      if (background) return;
       this.report = null;
       this.error =
         e instanceof Error ? e.message : "Failed to load activity report";
-      this.loading = false;
     }
   }
 

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -200,6 +200,24 @@ describe("load", () => {
     expect(activity.loading).toBe(false);
     expect(activity.lastUpdatedAt).toBe(stampedAt);
   });
+
+  it("surfaces the error when a background refresh fails before any report", async () => {
+    // No successful load yet, so report is null and there is nothing to keep.
+    api.getActivityReport.mockRejectedValueOnce(new Error("first load down"));
+    await activity.load();
+    expect(activity.report).toBeNull();
+    expect(activity.error).toBe("first load down");
+
+    // A refresh (toolbar button or scheduler) firing before any report exists
+    // must still surface the failure: background mode degrades to foreground
+    // when report is null, instead of clearing then suppressing the error and
+    // leaving a misleading "No data" state.
+    api.getActivityReport.mockRejectedValueOnce(new Error("refresh down"));
+    await activity.load({ background: true });
+    expect(activity.report).toBeNull();
+    expect(activity.error).toBe("refresh down");
+    expect(activity.loading).toBe(false);
+  });
 });
 
 describe("loadFilterOptions", () => {

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -180,6 +180,26 @@ describe("load", () => {
     expect(activity.report).toBeNull();
     expect(activity.loading).toBe(false);
   });
+
+  it("keeps the existing report when a background refresh fails", async () => {
+    api.getActivityReport.mockResolvedValueOnce(makeReport());
+    await activity.load();
+    const loadedReport = activity.report;
+    const stampedAt = activity.lastUpdatedAt;
+    expect(loadedReport).not.toBeNull();
+
+    api.getActivityReport.mockRejectedValueOnce(new Error("network down"));
+    await activity.load({ background: true });
+
+    // Report-first rendering depends on the report staying mounted: a transient
+    // background refresh failure must not blank the dashboard or surface an
+    // error, and must not bump the freshness stamp (the age label keeps growing
+    // to signal staleness). A non-background load still clears on error (above).
+    expect(activity.report).toBe(loadedReport);
+    expect(activity.error).toBeNull();
+    expect(activity.loading).toBe(false);
+    expect(activity.lastUpdatedAt).toBe(stampedAt);
+  });
 });
 
 describe("loadFilterOptions", () => {

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Report } from "../api/types/activity.js";
+
+const api = vi.hoisted(() => ({
+  getActivityReport: vi.fn(),
+  getProjects: vi.fn(),
+  getAgents: vi.fn(),
+  getMachines: vi.fn(),
+}));
+
+vi.mock("../api/generated/index", () => ({
+  ActivityService: { getApiV1ActivityReport: api.getActivityReport },
+  MetadataService: {
+    getApiV1Projects: api.getProjects,
+    getApiV1Agents: api.getAgents,
+    getApiV1Machines: api.getMachines,
+  },
+}));
+vi.mock("../api/runtime.js", () => ({ configureGeneratedClient: vi.fn() }));
+vi.mock("./sync.svelte.js", () => ({ sync: { onSyncComplete: vi.fn() } }));
+vi.mock("./router.svelte.js", () => ({
+  router: { params: {}, replaceParams: vi.fn(), route: "activity" },
+}));
+
+import { activity } from "./activity.svelte.js";
+import { sync } from "./sync.svelte.js";
+import * as routerMod from "./router.svelte.js";
+
+// activity.svelte.ts registers its sync hook once, at import time. Capture the
+// callback now, before beforeEach resets the recorded call, so the
+// sync-refresh tests can invoke it directly.
+const syncCallback = vi.mocked(sync.onSyncComplete).mock.calls[0]?.[0];
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  return {
+    timezone: "UTC",
+    range_start: "2026-06-16T00:00:00Z",
+    range_end: "2026-06-17T00:00:00Z",
+    bucket_unit: "minute",
+    bucket_seconds: 300,
+    bucket_count: 288,
+    partial: false,
+    as_of: null,
+    effective_end: "2026-06-17T00:00:00Z",
+    elapsed_bucket_count: 288,
+    buckets: [],
+    peak: { agents: 0, at: null },
+    totals: {
+      active_minutes: 0,
+      idle_minutes: 1440,
+      agent_minutes: 0,
+      sessions: 0,
+      untimed_sessions: 0,
+      distinct_projects: 0,
+      distinct_models: 0,
+      output_tokens: 0,
+      cost: 0,
+    },
+    by_project: [],
+    by_model: [],
+    by_agent: [],
+    by_session: [],
+    intervals: [],
+    ...overrides,
+  } as Report;
+}
+
+// Holds an ActivityPage attachment for tests that register one, so afterEach
+// can release it and keep the shared singleton's attach count isolated.
+let detach: (() => void) | null = null;
+
+beforeEach(() => {
+  api.getActivityReport.mockReset();
+  api.getProjects.mockReset();
+  api.getAgents.mockReset();
+  api.getMachines.mockReset();
+  api.getProjects.mockResolvedValue({ projects: [] });
+  api.getAgents.mockResolvedValue({ agents: [] });
+  api.getMachines.mockResolvedValue({ machines: [] });
+  activity.report = null;
+  activity.loading = false;
+  activity.error = null;
+  activity.projects = [];
+  activity.agents = [];
+  activity.machines = [];
+  activity.setPreset("day");
+  activity.setDate("2026-06-16");
+  activity.setProject("");
+  activity.setAgent("");
+  activity.setMachine("");
+  // Reset the filter-option cache so each test exercises the fetch.
+  activity.invalidateFilterOptions();
+  // Restore a fresh router.replaceParams spy. The writeUrl test reassigns it,
+  // so reset here to keep that reassignment from leaking into later tests.
+  (
+    routerMod.router as unknown as { replaceParams: ReturnType<typeof vi.fn> }
+  ).replaceParams = vi.fn();
+});
+afterEach(() => {
+  // Release any ActivityPage attachment so the singleton's attach count does
+  // not leak into the next test's sync-refresh assertions.
+  detach?.();
+  detach = null;
+});
+
+describe("load", () => {
+  it("sends preset/date/timezone and stores the report", async () => {
+    api.getActivityReport.mockResolvedValue(makeReport());
+    await activity.load();
+    expect(api.getActivityReport).toHaveBeenCalledTimes(1);
+    const arg = api.getActivityReport.mock.calls[0]![0];
+    expect(arg.preset).toBe("day");
+    expect(arg.date).toBe("2026-06-16");
+    expect(typeof arg.timezone).toBe("string");
+    expect(activity.report?.range_start).toBe("2026-06-16T00:00:00Z");
+    expect(activity.error).toBeNull();
+  });
+
+  it("passes project/agent/machine filters", async () => {
+    api.getActivityReport.mockResolvedValue(makeReport());
+    activity.setProject("p1");
+    activity.setAgent("claude");
+    activity.setMachine("m1");
+    await activity.load();
+    const arg = api.getActivityReport.mock.calls.at(-1)![0];
+    expect(arg.project).toBe("p1");
+    expect(arg.agent).toBe("claude");
+    expect(arg.machine).toBe("m1");
+  });
+
+  it("ignores a stale response when params change mid-flight", async () => {
+    let resolveFirst!: (r: Report) => void;
+    api.getActivityReport.mockImplementationOnce(
+      () =>
+        new Promise<Report>((r) => {
+          resolveFirst = r;
+        }),
+    );
+    const p1 = activity.load();
+    activity.setDate("2026-06-17");
+    api.getActivityReport.mockResolvedValueOnce(
+      makeReport({ range_start: "2026-06-17T00:00:00Z" }),
+    );
+    await activity.load();
+    resolveFirst(makeReport({ range_start: "2026-06-16T00:00:00Z" }));
+    await p1;
+    expect(activity.report?.range_start).toBe("2026-06-17T00:00:00Z");
+  });
+
+  it("uses a fallback message for non-Error rejections", async () => {
+    api.getActivityReport.mockRejectedValueOnce("boom");
+    await activity.load();
+    expect(activity.error).toBe("Failed to load activity report");
+    expect(activity.report).toBeNull();
+    expect(activity.loading).toBe(false);
+  });
+
+  it("surfaces the message for Error rejections", async () => {
+    api.getActivityReport.mockRejectedValueOnce(new Error("network down"));
+    await activity.load();
+    expect(activity.error).toBe("network down");
+    expect(activity.report).toBeNull();
+    expect(activity.loading).toBe(false);
+  });
+});
+
+describe("loadFilterOptions", () => {
+  it("fetches options with one-shot + automated included and stores them", async () => {
+    api.getProjects.mockResolvedValueOnce({
+      projects: [{ name: "proj-a", count: 1 }],
+    });
+    api.getAgents.mockResolvedValueOnce({
+      agents: [{ name: "claude", count: 2 }],
+    });
+    api.getMachines.mockResolvedValueOnce({
+      machines: ["laptop", "desktop"],
+    });
+
+    await activity.loadFilterOptions();
+
+    const full = { includeOneShot: true, includeAutomated: true };
+    expect(api.getProjects).toHaveBeenCalledWith(full);
+    expect(api.getAgents).toHaveBeenCalledWith(full);
+    expect(api.getMachines).toHaveBeenCalledWith(full);
+
+    expect(activity.projects).toEqual([{ name: "proj-a", count: 1 }]);
+    expect(activity.agents).toEqual([{ name: "claude", count: 2 }]);
+    expect(activity.machines).toEqual(["laptop", "desktop"]);
+  });
+
+  it("fetches once across repeated calls", async () => {
+    api.getProjects.mockResolvedValue({ projects: [] });
+    api.getAgents.mockResolvedValue({ agents: [] });
+    api.getMachines.mockResolvedValue({ machines: [] });
+
+    await activity.loadFilterOptions();
+    await activity.loadFilterOptions();
+
+    expect(api.getProjects).toHaveBeenCalledTimes(1);
+    expect(api.getAgents).toHaveBeenCalledTimes(1);
+    expect(api.getMachines).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves lists empty when a fetch fails", async () => {
+    api.getProjects.mockRejectedValueOnce(new Error("boom"));
+    api.getAgents.mockResolvedValueOnce({ agents: [] });
+    api.getMachines.mockResolvedValueOnce({ machines: [] });
+
+    await activity.loadFilterOptions();
+
+    expect(activity.projects).toEqual([]);
+  });
+
+  it("retries on the next call after a transient failure", async () => {
+    api.getProjects
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ projects: [{ name: "proj-a", count: 1 }] });
+    api.getAgents.mockResolvedValue({ agents: [] });
+    api.getMachines.mockResolvedValue({ machines: [] });
+
+    await activity.loadFilterOptions();
+    expect(activity.projects).toEqual([]); // projects failed, not cached
+
+    await activity.loadFilterOptions(); // un-cached load retries
+    expect(api.getProjects).toHaveBeenCalledTimes(2);
+    expect(activity.projects).toEqual([{ name: "proj-a", count: 1 }]);
+  });
+
+  it("refetches after invalidateFilterOptions", async () => {
+    api.getProjects.mockResolvedValue({ projects: [] });
+    api.getAgents.mockResolvedValue({ agents: [] });
+    api.getMachines.mockResolvedValue({ machines: [] });
+
+    await activity.loadFilterOptions();
+    expect(api.getProjects).toHaveBeenCalledTimes(1);
+
+    // Mirrors the sync.onSyncComplete hook: a completed sync drops the
+    // cache so newly imported projects/agents/machines are picked up.
+    activity.invalidateFilterOptions();
+    await activity.loadFilterOptions();
+    expect(api.getProjects).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("sync refresh hook", () => {
+  it("refetches options on sync while an ActivityPage is attached", async () => {
+    expect(typeof syncCallback).toBe("function");
+    api.getProjects.mockResolvedValue({ projects: [] });
+    api.getAgents.mockResolvedValue({ agents: [] });
+    api.getMachines.mockResolvedValue({ machines: [] });
+
+    detach = activity.attach();
+    await activity.loadFilterOptions();
+    expect(api.getProjects).toHaveBeenCalledTimes(1);
+
+    // A completed sync runs the registered hook: invalidate + refetch. The
+    // refetch calls getProjects synchronously (before its first await), so
+    // the count bumps immediately -- without any explicit reload here. An
+    // invalidate-only hook would leave it at 1.
+    syncCallback?.();
+    expect(api.getProjects).toHaveBeenCalledTimes(2);
+
+    // Settle the in-flight refetch the hook started.
+    await activity.loadFilterOptions();
+  });
+
+  it("invalidates without refetching on sync when no page is attached", async () => {
+    api.getProjects.mockResolvedValue({ projects: [] });
+    api.getAgents.mockResolvedValue({ agents: [] });
+    api.getMachines.mockResolvedValue({ machines: [] });
+
+    await activity.loadFilterOptions();
+    expect(api.getProjects).toHaveBeenCalledTimes(1);
+
+    // No ActivityPage attached: the hook invalidates but must not fetch on its
+    // own. loadFilterOptions calls getProjects synchronously, so an errant
+    // refetch would already show here.
+    syncCallback?.();
+    expect(api.getProjects).toHaveBeenCalledTimes(1);
+
+    // The invalidation took effect: the next explicit load refetches.
+    await activity.loadFilterOptions();
+    expect(api.getProjects).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("url state", () => {
+  it("hydrates preset/date/filters from params", () => {
+    activity.hydrateFromUrl({
+      preset: "week", date: "2026-06-16", project: "p1", agent: "claude",
+    });
+    expect(activity.preset).toBe("week");
+    expect(activity.date).toBe("2026-06-16");
+    expect(activity.project).toBe("p1");
+    expect(activity.agent).toBe("claude");
+  });
+
+  it("defaults preset to day and date to today when absent", () => {
+    activity.hydrateFromUrl({});
+    expect(activity.preset).toBe("day");
+    expect(activity.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("writeUrl replaces params, omitting empty filters and the day default", () => {
+    const spy = vi.fn();
+    // Setters also write back through replaceParams; install the spy after them
+    // so the count below measures the explicit writeUrl() call alone.
+    activity.setPreset("month");
+    activity.setDate("2026-06-01");
+    activity.setProject("");
+    // Replace router.replaceParams with a spy for this test.
+    (routerMod.router as unknown as { replaceParams: typeof spy }).replaceParams =
+      spy;
+    activity.writeUrl();
+    expect(spy).toHaveBeenCalledTimes(1);
+    const written = spy.mock.calls[0]![0] as Record<string, string>;
+    expect(written.preset).toBe("month");
+    expect(written.date).toBe("2026-06-01");
+    expect("project" in written).toBe(false);
+  });
+
+  it("omits date from the URL when the anchor date is empty", () => {
+    // Mirror the setter test: read the beforeEach default replaceParams mock
+    // rather than a second spy, so this pins the real writeUrl() output.
+    const spy = routerMod.router.replaceParams as ReturnType<typeof vi.fn>;
+    activity.setPreset("day");
+    activity.setDate("");
+    spy.mockClear();
+    activity.writeUrl();
+    const params = spy.mock.calls.at(-1)![0] as Record<string, string>;
+    expect(params.preset).toBe("day");
+    expect("date" in params).toBe(false);
+  });
+
+  it("setters write back to the url via replaceParams", () => {
+    // Observe the beforeEach default mock, not a second spy, so this pins the
+    // setter -> writeUrl -> router.replaceParams contract Task 4 depends on.
+    const spy = routerMod.router.replaceParams as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+    activity.setPreset("week");
+    activity.setDate("2026-06-16");
+    expect(spy).toHaveBeenCalledTimes(2);
+    const last = spy.mock.calls.at(-1)![0] as Record<string, string>;
+    expect(last.preset).toBe("week");
+    expect(last.date).toBe("2026-06-16");
+    expect("project" in last).toBe(false);
+  });
+});
+
+describe("step", () => {
+  it("advances a day preset by one day", () => {
+    activity.setPreset("day");
+    activity.setDate("2026-06-16");
+    activity.step(1);
+    expect(activity.date).toBe("2026-06-17");
+    activity.step(-1);
+    expect(activity.date).toBe("2026-06-16");
+  });
+  it("advances a week preset by seven days", () => {
+    activity.setPreset("week");
+    activity.setDate("2026-06-16");
+    activity.step(1);
+    expect(activity.date).toBe("2026-06-23");
+  });
+  it("advances a month preset by one calendar month, clamping the day", () => {
+    activity.setPreset("month");
+    activity.setDate("2026-01-31");
+    activity.step(1);
+    // Jan 31 + 1 month clamps to Feb 28 instead of overflowing into March.
+    expect(activity.date).toBe("2026-02-28");
+  });
+  it("clamps the day stepping a month preset backward", () => {
+    activity.setPreset("month");
+    activity.setDate("2026-03-31");
+    activity.step(-1);
+    // Mar 31 - 1 month clamps to Feb 28 instead of overflowing into March.
+    expect(activity.date).toBe("2026-02-28");
+  });
+});
+
+describe("custom instant translation", () => {
+  it("seeds from/to from the anchor date when selecting custom with empty bounds", () => {
+    activity.setPreset("day");
+    activity.setDate("2026-06-16");
+    activity.setFrom("");
+    activity.setTo("");
+    activity.setPreset("custom");
+    expect(activity.from).toBe("2026-06-16");
+    expect(activity.to).toBe("2026-06-16");
+  });
+
+  it("sends half-open local instants for a custom range", async () => {
+    api.getActivityReport.mockResolvedValue(makeReport());
+    activity.setPreset("custom");
+    activity.setFrom("2026-06-10");
+    activity.setTo("2026-06-12");
+    await activity.load();
+    const arg = api.getActivityReport.mock.calls.at(-1)![0];
+    expect(arg.preset).toBe("custom");
+    // from = local 00:00 of 2026-06-10; to = local 00:00 of 2026-06-13.
+    expect(arg.from).toBe(new Date("2026-06-10T00:00:00").toISOString());
+    expect(arg.to).toBe(new Date("2026-06-13T00:00:00").toISOString());
+  });
+
+  it("holds the request for a custom range missing a bound", async () => {
+    api.getActivityReport.mockResolvedValue(makeReport());
+    activity.setPreset("custom");
+    activity.setFrom("2026-06-10");
+    activity.setTo(""); // a cleared date input leaves the range incomplete
+    await activity.load();
+    expect(api.getActivityReport).not.toHaveBeenCalled();
+    expect(activity.loading).toBe(false);
+  });
+});

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -261,6 +261,7 @@ describe("loadFilterOptions", () => {
 describe("sync refresh hook", () => {
   it("refetches options on sync while an ActivityPage is attached", async () => {
     expect(typeof syncCallback).toBe("function");
+    api.getActivityReport.mockResolvedValue(makeReport());
     api.getProjects.mockResolvedValue({ projects: [] });
     api.getAgents.mockResolvedValue({ agents: [] });
     api.getMachines.mockResolvedValue({ machines: [] });
@@ -276,11 +277,33 @@ describe("sync refresh hook", () => {
     syncCallback?.();
     expect(api.getProjects).toHaveBeenCalledTimes(2);
 
-    // Settle the in-flight refetch the hook started.
+    // Settle the in-flight refetch + report reload the hook started.
+    await activity.loadFilterOptions();
+  });
+
+  it("reloads the report on sync while an ActivityPage is attached", async () => {
+    api.getActivityReport.mockResolvedValue(makeReport());
+    api.getProjects.mockResolvedValue({ projects: [] });
+    api.getAgents.mockResolvedValue({ agents: [] });
+    api.getMachines.mockResolvedValue({ machines: [] });
+
+    detach = activity.attach();
+    await activity.load();
+    expect(api.getActivityReport).toHaveBeenCalledTimes(1);
+
+    // The hook reloads the report so freshly imported sessions appear without a
+    // manual range/filter change. load() calls getActivityReport synchronously
+    // (before its first await), so the count bumps immediately. Without the
+    // load() in the hook this stays at 1 and the charts/table go stale.
+    syncCallback?.();
+    expect(api.getActivityReport).toHaveBeenCalledTimes(2);
+
+    // Settle the in-flight reload the hook started.
     await activity.loadFilterOptions();
   });
 
   it("invalidates without refetching on sync when no page is attached", async () => {
+    api.getActivityReport.mockResolvedValue(makeReport());
     api.getProjects.mockResolvedValue({ projects: [] });
     api.getAgents.mockResolvedValue({ agents: [] });
     api.getMachines.mockResolvedValue({ machines: [] });
@@ -288,11 +311,12 @@ describe("sync refresh hook", () => {
     await activity.loadFilterOptions();
     expect(api.getProjects).toHaveBeenCalledTimes(1);
 
-    // No ActivityPage attached: the hook invalidates but must not fetch on its
-    // own. loadFilterOptions calls getProjects synchronously, so an errant
-    // refetch would already show here.
+    // No ActivityPage attached: the hook invalidates but must not fetch options
+    // or reload the report on its own. Both calls run synchronously before their
+    // first await, so an errant refetch/reload would already show here.
     syncCallback?.();
     expect(api.getProjects).toHaveBeenCalledTimes(1);
+    expect(api.getActivityReport).not.toHaveBeenCalled();
 
     // The invalidation took effect: the next explicit load refetches.
     await activity.loadFilterOptions();

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -88,6 +88,7 @@ beforeEach(() => {
   activity.setProject("");
   activity.setAgent("");
   activity.setMachine("");
+  activity.setAutomation("all");
   // Reset the filter-option cache so each test exercises the fetch.
   activity.invalidateFilterOptions();
   // Restore a fresh router.replaceParams spy. The writeUrl test reassigns it,
@@ -126,6 +127,21 @@ describe("load", () => {
     expect(arg.project).toBe("p1");
     expect(arg.agent).toBe("claude");
     expect(arg.machine).toBe("m1");
+  });
+
+  it("defaults the automation class to all", async () => {
+    api.getActivityReport.mockResolvedValue(makeReport());
+    await activity.load();
+    expect(api.getActivityReport.mock.calls.at(-1)![0].automation).toBe("all");
+  });
+
+  it("passes the selected automation class", async () => {
+    api.getActivityReport.mockResolvedValue(makeReport());
+    activity.setAutomation("automated");
+    await activity.load();
+    expect(api.getActivityReport.mock.calls.at(-1)![0].automation).toBe(
+      "automated",
+    );
   });
 
   it("ignores a stale response when params change mid-flight", async () => {
@@ -344,6 +360,33 @@ describe("url state", () => {
     expect(last.preset).toBe("week");
     expect(last.date).toBe("2026-06-16");
     expect("project" in last).toBe(false);
+  });
+
+  it("hydrates the automation class from params", () => {
+    activity.hydrateFromUrl({ automation: "interactive" });
+    expect(activity.automation).toBe("interactive");
+  });
+
+  it("defaults automation to all for an absent or unknown value", () => {
+    activity.hydrateFromUrl({});
+    expect(activity.automation).toBe("all");
+    activity.hydrateFromUrl({ automation: "bogus" });
+    expect(activity.automation).toBe("all");
+  });
+
+  it("writeUrl omits automation when all and includes it otherwise", () => {
+    const spy = routerMod.router.replaceParams as ReturnType<typeof vi.fn>;
+    activity.setAutomation("all");
+    spy.mockClear();
+    activity.writeUrl();
+    const cleared = spy.mock.calls.at(-1)![0] as Record<string, string>;
+    expect("automation" in cleared).toBe(false);
+
+    activity.setAutomation("automated");
+    spy.mockClear();
+    activity.writeUrl();
+    const set = spy.mock.calls.at(-1)![0] as Record<string, string>;
+    expect(set.automation).toBe("automated");
   });
 });
 

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -80,6 +80,8 @@ beforeEach(() => {
   activity.report = null;
   activity.loading = false;
   activity.error = null;
+  activity.lastUpdatedAt = null;
+  activity.hasNewData = false;
   activity.projects = [];
   activity.agents = [];
   activity.machines = [];
@@ -277,11 +279,11 @@ describe("sync refresh hook", () => {
     syncCallback?.();
     expect(api.getProjects).toHaveBeenCalledTimes(2);
 
-    // Settle the in-flight refetch + report reload the hook started.
+    // Settle the in-flight refetch the hook started.
     await activity.loadFilterOptions();
   });
 
-  it("reloads the report on sync while an ActivityPage is attached", async () => {
+  it("does not reload the report on sync, only flags new data via SSE", async () => {
     api.getActivityReport.mockResolvedValue(makeReport());
     api.getProjects.mockResolvedValue({ projects: [] });
     api.getAgents.mockResolvedValue({ agents: [] });
@@ -291,14 +293,15 @@ describe("sync refresh hook", () => {
     await activity.load();
     expect(api.getActivityReport).toHaveBeenCalledTimes(1);
 
-    // The hook reloads the report so freshly imported sessions appear without a
-    // manual range/filter change. load() calls getActivityReport synchronously
-    // (before its first await), so the count bumps immediately. Without the
-    // load() in the hook this stays at 1 and the charts/table go stale.
+    // The sync hook refreshes filter options but must NOT reload the report:
+    // re-aggregating on every sync thrashes the CPU while a session is active.
+    // Refetching is bounded to the RefreshControl scheduler and manual button;
+    // SSE only flags new data. load() calls getActivityReport synchronously, so
+    // an errant reload would already show here.
     syncCallback?.();
-    expect(api.getActivityReport).toHaveBeenCalledTimes(2);
+    expect(api.getActivityReport).toHaveBeenCalledTimes(1);
 
-    // Settle the in-flight reload the hook started.
+    // Settle the in-flight options refetch the hook started.
     await activity.loadFilterOptions();
   });
 
@@ -321,6 +324,55 @@ describe("sync refresh hook", () => {
     // The invalidation took effect: the next explicit load refetches.
     await activity.loadFilterOptions();
     expect(api.getProjects).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("freshness state", () => {
+  it("stamps lastUpdatedAt and clears new-data hints on a load", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      api.getActivityReport.mockResolvedValue(makeReport());
+      vi.setSystemTime(new Date("2026-06-16T12:00:00Z"));
+
+      expect(activity.lastUpdatedAt).toBeNull();
+      await activity.load();
+      expect(activity.lastUpdatedAt).toBe(
+        new Date("2026-06-16T12:00:00Z").getTime(),
+      );
+      expect(activity.hasNewData).toBe(false);
+
+      activity.markNewData();
+      expect(activity.hasNewData).toBe(true);
+
+      vi.setSystemTime(new Date("2026-06-16T12:05:00Z"));
+      await activity.load();
+      expect(activity.lastUpdatedAt).toBe(
+        new Date("2026-06-16T12:05:00Z").getTime(),
+      );
+      expect(activity.hasNewData).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("markNewData is a no-op before the first report loads", () => {
+    expect(activity.lastUpdatedAt).toBeNull();
+    activity.markNewData();
+    expect(activity.hasNewData).toBe(false);
+  });
+
+  it("does not stamp lastUpdatedAt when a load fails", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date("2026-06-16T12:00:00Z"));
+      api.getActivityReport.mockRejectedValueOnce(new Error("network down"));
+      await activity.load();
+      expect(activity.lastUpdatedAt).toBeNull();
+      activity.markNewData();
+      expect(activity.hasNewData).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/frontend/src/lib/stores/insights.svelte.ts
+++ b/frontend/src/lib/stores/insights.svelte.ts
@@ -164,6 +164,7 @@ class InsightsStore {
         date_to: snap.dateTo,
         project: snap.project || undefined,
         prompt: this.promptText || undefined,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         agent: snap.agent,
       },
       (phase) => {

--- a/frontend/src/lib/stores/insights.test.ts
+++ b/frontend/src/lib/stores/insights.test.ts
@@ -242,6 +242,24 @@ describe("selectedItem", () => {
 });
 
 describe("generate (multi-task)", () => {
+  it("includes the browser timezone so summaries align with the dashboard", () => {
+    const mockHandle = {
+      abort: vi.fn(),
+      done: Promise.resolve(makeInsight({ id: 1 })),
+    };
+    vi.mocked(api.generateInsight).mockReturnValueOnce(mockHandle);
+
+    insights.generate();
+
+    expect(api.generateInsight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }),
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
   it("adds task to tasks[] and prepends result on completion", async () => {
     const newInsight = makeInsight({ id: 10 });
     const mockHandle = {

--- a/frontend/src/lib/stores/messages.test.ts
+++ b/frontend/src/lib/stores/messages.test.ts
@@ -310,7 +310,7 @@ describe('MessagesStore', () => {
       createDeferred<Session>();
     vi.mocked(api.getSession).mockReturnValue(p1Promise);
 
-    const p1 = messages.reload();
+    messages.reload();
 
     // 3. Switch to Session B
     vi.mocked(api.getSession).mockResolvedValue(

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -1,6 +1,7 @@
 export type Route =
   | "sessions"
   | "usage"
+  | "activity"
   | "trends"
   | "insights"
   | "pinned"
@@ -10,6 +11,7 @@ export type Route =
 const VALID_ROUTES: ReadonlySet<string> = new Set<Route>([
   "sessions",
   "usage",
+  "activity",
   "trends",
   "insights",
   "pinned",

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -77,6 +77,25 @@ describe("parsePath", () => {
     }
   });
 
+  it("parses /activity as a valid route", () => {
+    window.history.replaceState({}, "", "/activity?preset=week&date=2026-06-16");
+    const parsed = parsePath();
+    expect(parsed.route).toBe("activity");
+    expect(parsed.params.preset).toBe("week");
+    expect(parsed.params.date).toBe("2026-06-16");
+  });
+
+  it("replaceParams writes query without a new history entry, keeping the path", () => {
+    window.history.replaceState({}, "", "/activity");
+    const store = new RouterStore();
+    const before = window.history.length;
+    store.replaceParams({ preset: "month", date: "2026-06-01" });
+    expect(window.location.pathname).toBe("/activity");
+    expect(window.location.search).toContain("preset=month");
+    expect(window.location.search).toContain("date=2026-06-01");
+    expect(window.history.length).toBe(before);
+  });
+
   it("falls back to default for unknown routes", () => {
     setURL("/unknown");
     const result = parsePath();

--- a/frontend/src/lib/utils/highlight.test.ts
+++ b/frontend/src/lib/utils/highlight.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vite-plus/test";
+import { describe, it, expect } from "vite-plus/test";
 import { applyHighlight, applyMarks, escapeHTML } from "./highlight.js";
 
 function makeDiv(html: string): HTMLElement {

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -34,7 +34,7 @@ describe("registerShortcuts", () => {
     sessions.activeSessionId = null;
     sessions.sessions = [];
     starred.filterOnly = false;
-    for (const id of [...starred.ids]) {
+    for (const id of starred.ids) {
       starred.unstar(id);
     }
     navigateMessage = vi.fn();

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -46,6 +46,7 @@ function normalizeHref(raw: string): string {
     txt.innerHTML = prev;
     let cur = txt.value;
     // Strip control characters
+    // oxlint-disable-next-line no-control-regex -- intentional: strips control chars used to obfuscate dangerous href schemes
     cur = cur.replace(/[\x00-\x1f\x7f]/g, "");
     // Tolerant percent decode (valid %xx chunks only)
     cur = tolerantDecodeURI(cur);

--- a/frontend/src/lib/utils/refresh.test.ts
+++ b/frontend/src/lib/utils/refresh.test.ts
@@ -7,6 +7,7 @@ import {
 } from "vite-plus/test";
 import {
   createRefreshScheduler,
+  DEFAULT_REFRESH_INTERVAL_MS,
   formatRefreshAge,
 } from "./refresh.js";
 
@@ -71,5 +72,29 @@ describe("createRefreshScheduler", () => {
     expect(refresh).toHaveBeenCalledTimes(3);
 
     scheduler.stop();
+  });
+
+  it("waits one interval before the first deferred refresh", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const scheduler = createRefreshScheduler(refresh, 300_000);
+
+    scheduler.scheduleNext();
+    expect(refresh).toHaveBeenCalledTimes(0);
+
+    await vi.advanceTimersByTimeAsync(299_999);
+    expect(refresh).toHaveBeenCalledTimes(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+  });
+
+  it("shares a five-minute default cadence", () => {
+    expect(DEFAULT_REFRESH_INTERVAL_MS).toBe(5 * 60 * 1000);
   });
 });

--- a/frontend/src/lib/utils/refresh.test.ts
+++ b/frontend/src/lib/utils/refresh.test.ts
@@ -43,7 +43,7 @@ describe("createRefreshScheduler", () => {
     const refresh = vi.fn();
     const scheduler = createRefreshScheduler(refresh, 300_000);
 
-    scheduler.start();
+    scheduler.refreshNow();
     expect(refresh).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(299_999);
@@ -60,7 +60,7 @@ describe("createRefreshScheduler", () => {
     const refresh = vi.fn();
     const scheduler = createRefreshScheduler(refresh, 300_000);
 
-    scheduler.start();
+    scheduler.refreshNow();
     await vi.advanceTimersByTimeAsync(290_000);
     scheduler.refreshNow();
     expect(refresh).toHaveBeenCalledTimes(2);

--- a/frontend/src/lib/utils/refresh.ts
+++ b/frontend/src/lib/utils/refresh.ts
@@ -2,6 +2,14 @@ const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 
+/**
+ * Default auto-refresh cadence shared by every dashboard. Long enough that a
+ * session actively writing files never thrashes the aggregation, short enough
+ * that an idle dashboard stays current. Override per call site when a view
+ * needs a different cadence.
+ */
+export const DEFAULT_REFRESH_INTERVAL_MS = 5 * MINUTE_MS;
+
 export function formatRefreshAge(
   updatedAt: number | null | undefined,
   now = Date.now(),
@@ -38,9 +46,18 @@ export function createRefreshScheduler(
     timer = setTimeout(runAndReschedule, intervalMs);
   }
 
+  // Arm the interval without an immediate refresh. Callers that load their
+  // initial data separately (e.g. after URL/filter hydration) use this so the
+  // first automatic refresh lands one interval out instead of racing mount.
+  function scheduleNext() {
+    stop();
+    timer = setTimeout(runAndReschedule, intervalMs);
+  }
+
   return {
     start: runAndReschedule,
     refreshNow: runAndReschedule,
+    scheduleNext,
     stop,
   };
 }

--- a/frontend/src/lib/utils/refresh.ts
+++ b/frontend/src/lib/utils/refresh.ts
@@ -55,7 +55,6 @@ export function createRefreshScheduler(
   }
 
   return {
-    start: runAndReschedule,
     refreshNow: runAndReschedule,
     scheduleNext,
     stop,

--- a/frontend/src/lib/virtual/createVirtualizer.svelte.ts
+++ b/frontend/src/lib/virtual/createVirtualizer.svelte.ts
@@ -117,6 +117,7 @@ function createBaseVirtualizer<
 
   return {
     get instance() {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- reactive dependency: re-read instance when the virtualizer version bumps
       _version;
       return instance;
     },

--- a/frontend/src/vitest-setup.ts
+++ b/frontend/src/vitest-setup.ts
@@ -1,3 +1,10 @@
+// Register @testing-library/svelte's per-test setup/cleanup against the
+// explicitly imported vitest hooks. The library's own auto-registration only
+// fires when afterEach is a global, which it is not here (globals are off), so
+// component tests using render() would otherwise leak mounted DOM between
+// cases. cleanup() is idempotent, so tests that unmount manually are unharmed.
+import "@testing-library/svelte/vitest";
+
 type StorageName = "localStorage";
 
 function isStorageLike(value: unknown): value is Storage {

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -1,0 +1,787 @@
+// Package activity aggregates a resolved time range of agent activity into a
+// concurrency- and usage-oriented report. It is pure: it depends only on the
+// time and sort packages and operates on in-memory input streams supplied by a
+// storage backend, so the same aggregation runs identically across SQLite,
+// PostgreSQL, and DuckDB.
+package activity
+
+import (
+	"sort"
+	"time"
+)
+
+// Params controls one range aggregation. RangeStart/RangeEnd are the resolved
+// UTC bounds; EffectiveEnd clamps the end to now for an in-progress range
+// (Partial); Bucket is the resolved timeline bucket size. They are copied
+// verbatim from a resolved Query so the range/bucket logic lives only in the
+// query engine.
+type Params struct {
+	RangeStart    time.Time
+	RangeEnd      time.Time
+	Loc           *time.Location
+	EffectiveEnd  time.Time
+	Partial       bool
+	GapCapSeconds float64
+	Bucket        BucketSpec
+}
+
+// SessionMeta is one candidate session whose window intersects the day.
+type SessionMeta struct {
+	SessionID   string
+	Title       string
+	Project     string
+	Agent       string
+	Machine     string
+	StartedAt   string // RFC3339 or ""
+	EndedAt     string // RFC3339 or ""
+	IsAutomated bool   // automated (e.g. roborev) vs interactive session
+}
+
+// ActivityEvent is one timestamped message (backends send only timestamped rows).
+type ActivityEvent struct {
+	SessionID string
+	Ordinal   int
+	Timestamp string // RFC3339 (non-empty)
+	Role      string // "user" | "assistant" | ...
+	Model     string // "" when unknown
+}
+
+// UsageRow is one cost/token row from the usage-row union, with cost already
+// computed by the backend (so cost logic stays in each backend, matching
+// GetDailyUsage). Rows MUST be delivered ordered by
+// (ts ASC, session_id ASC, COALESCE(message_ordinal,-1) ASC).
+type UsageRow struct {
+	SessionID       string
+	Model           string
+	Timestamp       string // ts, RFC3339 or ""
+	OutputTokens    int
+	Cost            float64
+	ClaudeMessageID string
+	ClaudeRequestID string
+	UsageDedupKey   string
+}
+
+// Report is the API payload.
+type Report struct {
+	Timezone           string           `json:"timezone"`
+	RangeStart         string           `json:"range_start"`
+	RangeEnd           string           `json:"range_end"`
+	BucketUnit         string           `json:"bucket_unit"`
+	BucketSeconds      int              `json:"bucket_seconds"`
+	BucketCount        int              `json:"bucket_count"`
+	Partial            bool             `json:"partial"`
+	AsOf               *string          `json:"as_of"`
+	EffectiveEnd       string           `json:"effective_end"`
+	ElapsedBucketCount int              `json:"elapsed_bucket_count"`
+	Buckets            []Bucket         `json:"buckets"`
+	Peak               Peak             `json:"peak"`
+	Totals             Totals           `json:"totals"`
+	ByProject          []KeyMinutes     `json:"by_project"`
+	ByModel            []KeyMinutes     `json:"by_model"`
+	ByAgent            []KeyMinutes     `json:"by_agent"`
+	BySession          []SessionRow     `json:"by_session"`
+	Intervals          []ReportInterval `json:"intervals"`
+}
+
+type Bucket struct {
+	Start        string  `json:"start"`
+	End          string  `json:"end"`
+	MaxAgents    int     `json:"max_agents"`
+	AgentMinutes float64 `json:"agent_minutes"`
+	OutputTokens int     `json:"output_tokens"`
+	Cost         float64 `json:"cost"`
+	// Automated/interactive split of the concurrency peak: the live automated
+	// and interactive counts AT the instant MaxAgents first occurs. They sum to
+	// MaxAgents, so a stacked bar reflects the true peak rather than stacking two
+	// independent peaks (which could exceed it).
+	AutomatedAtPeak   int `json:"automated_at_peak"`
+	InteractiveAtPeak int `json:"interactive_at_peak"`
+}
+
+// ReportInterval is one half-open active span [Start, End) for a single
+// session, exposed so the UI can list the sessions active during a clicked
+// timeline slot. buildIntervals can emit several intervals per session within
+// one slot (one per consecutive message pair), so consumers dedup by SessionID.
+type ReportInterval struct {
+	SessionID string `json:"session_id"`
+	Start     string `json:"start"` // RFC3339 UTC
+	End       string `json:"end"`   // RFC3339 UTC
+}
+
+type Peak struct {
+	Agents int     `json:"agents"`
+	At     *string `json:"at"`
+}
+
+type Totals struct {
+	ActiveMinutes    float64 `json:"active_minutes"`
+	IdleMinutes      float64 `json:"idle_minutes"`
+	AgentMinutes     float64 `json:"agent_minutes"`
+	Sessions         int     `json:"sessions"`
+	UntimedSessions  int     `json:"untimed_sessions"`
+	DistinctProjects int     `json:"distinct_projects"`
+	DistinctModels   int     `json:"distinct_models"`
+	OutputTokens     int     `json:"output_tokens"`
+	Cost             float64 `json:"cost"`
+	// Additive automated/interactive segments (segment + segment == combined).
+	AutomatedAgentMinutes   float64 `json:"automated_agent_minutes"`
+	InteractiveAgentMinutes float64 `json:"interactive_agent_minutes"`
+	AutomatedCost           float64 `json:"automated_cost"`
+	InteractiveCost         float64 `json:"interactive_cost"`
+}
+
+// KeyMinutes is one breakdown row (by project/model/agent). It carries both the
+// combined agent-minutes and cost (so the UI can sort by either metric) plus the
+// additive automated/interactive segments of each, rendered as a stacked bar.
+type KeyMinutes struct {
+	Key                     string  `json:"key"`
+	AgentMinutes            float64 `json:"agent_minutes"`
+	Cost                    float64 `json:"cost"`
+	AutomatedAgentMinutes   float64 `json:"automated_agent_minutes"`
+	InteractiveAgentMinutes float64 `json:"interactive_agent_minutes"`
+	AutomatedCost           float64 `json:"automated_cost"`
+	InteractiveCost         float64 `json:"interactive_cost"`
+}
+
+type SessionRow struct {
+	SessionID     string   `json:"session_id"`
+	Title         string   `json:"title"`
+	Project       string   `json:"project"`
+	Agent         string   `json:"agent"`
+	PrimaryModel  string   `json:"primary_model"`
+	Models        []string `json:"models"`
+	AgentMinutes  *float64 `json:"agent_minutes"` // nil when untimed
+	Cost          float64  `json:"cost"`
+	OutputTokens  int      `json:"output_tokens"`
+	FirstActive   *string  `json:"first_active"`
+	LastActive    *string  `json:"last_active"`
+	TimingQuality string   `json:"timing_quality"` // "timed" | "untimed"
+	IsAutomated   bool     `json:"is_automated"`
+}
+
+// interval is an internal half-open active span anchored to one session.
+type interval struct {
+	sessionID string
+	start     time.Time
+	end       time.Time
+	model     string // model attributed to this interval
+}
+
+// parseTS parses an RFC3339(/Nano) timestamp; ok=false on empty/invalid.
+func parseTS(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), true
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t.UTC(), true
+	}
+	return time.Time{}, false
+}
+
+// rangeWindows tiles the range into bucket windows. BuildBuckets only errors
+// for an unvalidated bucket spec (Query validates upstream); on error or a
+// nil Loc it falls back to a single [start, end) window so the report stays
+// well-formed, mirroring the old dayWindow fallback.
+func rangeWindows(p Params) []BucketWindow {
+	windows, err := BuildBuckets(p.RangeStart, p.RangeEnd, p.Bucket, paramsLoc(p))
+	if err != nil || len(windows) == 0 {
+		return []BucketWindow{{Start: p.RangeStart, End: p.RangeEnd}}
+	}
+	return windows
+}
+
+// Aggregate builds the range's report from the three input streams.
+func Aggregate(p Params, sessions []SessionMeta, activity []ActivityEvent, usage []UsageRow) Report {
+	gapCap := time.Duration(p.GapCapSeconds) * time.Second
+	startUTC, endUTC, effEnd := p.RangeStart, p.RangeEnd, p.EffectiveEnd
+	var asOf *string
+	if p.Partial {
+		s := effEnd.Format(time.RFC3339)
+		asOf = &s
+	}
+
+	windows := rangeWindows(p)
+	intervals := buildIntervals(activity, gapCap, startUTC, effEnd)
+	automatedBy := automatedSet(sessions)
+
+	r := Report{
+		Timezone:      paramsLoc(p).String(),
+		RangeStart:    startUTC.Format(time.RFC3339),
+		RangeEnd:      endUTC.Format(time.RFC3339),
+		BucketUnit:    string(p.Bucket.Unit),
+		BucketSeconds: p.Bucket.NominalSeconds,
+		Partial:       p.Partial,
+		AsOf:          asOf,
+		EffectiveEnd:  effEnd.Format(time.RFC3339),
+		Buckets:       []Bucket{},
+		ByProject:     []KeyMinutes{},
+		ByModel:       []KeyMinutes{},
+		ByAgent:       []KeyMinutes{},
+		BySession:     []SessionRow{},
+		Intervals:     []ReportInterval{},
+	}
+	r.BucketCount = len(windows)
+	r.ElapsedBucketCount = elapsedBucketCount(windows, effEnd)
+
+	buildBuckets(&r, windows, effEnd, intervals, automatedBy)
+	r.Peak, r.Totals.ActiveMinutes, _, _ = sweepLine(intervals, automatedBy)
+	r.Totals.AgentMinutes = sumIntervalMinutes(intervals)
+	r.Totals.AutomatedAgentMinutes, r.Totals.InteractiveAgentMinutes =
+		splitIntervalMinutes(intervals, automatedBy)
+	r.Totals.IdleMinutes = effEnd.Sub(startUTC).Minutes() - r.Totals.ActiveMinutes
+	if r.Totals.IdleMinutes < 0 {
+		r.Totals.IdleMinutes = 0
+	}
+
+	applyUsage(&r, p, windows, startUTC, endUTC, usage, automatedBy)
+	buildSessionsTable(&r, startUTC, endUTC, effEnd, sessions, intervals, usage)
+	r.Intervals = reportIntervals(intervals)
+	return r
+}
+
+// paramsLoc returns the params timezone, defaulting nil to UTC.
+func paramsLoc(p Params) *time.Location {
+	if p.Loc == nil {
+		return time.UTC
+	}
+	return p.Loc
+}
+
+// elapsedBucketCount counts windows that have begun by effEnd.
+func elapsedBucketCount(windows []BucketWindow, effEnd time.Time) int {
+	n := 0
+	for _, w := range windows {
+		if w.Start.Before(effEnd) {
+			n++
+		}
+	}
+	return n
+}
+
+// buildIntervals groups activity by session (already ordered by ordinal),
+// emits one interval per adjacent pair with positive gap, caps at cap, and
+// clips to [start, effEnd). The interval's model is the closing assistant
+// message's model, else the session's last known model, else "unknown".
+func buildIntervals(activity []ActivityEvent, cap time.Duration,
+	start, effEnd time.Time) []interval {
+	bySession := map[string][]ActivityEvent{}
+	order := []string{}
+	for _, e := range activity {
+		if _, ok := bySession[e.SessionID]; !ok {
+			order = append(order, e.SessionID)
+		}
+		bySession[e.SessionID] = append(bySession[e.SessionID], e)
+	}
+	var out []interval
+	for _, sid := range order {
+		evs := bySession[sid]
+		lastModel := "unknown"
+		for i := 1; i < len(evs); i++ {
+			prev, ts := parseTS(evs[i-1].Timestamp)
+			cur, ts2 := parseTS(evs[i].Timestamp)
+			if !ts || !ts2 {
+				continue
+			}
+			gap := cur.Sub(prev)
+			if gap <= 0 {
+				continue
+			}
+			if gap > cap {
+				gap = cap
+			}
+			iv := interval{sessionID: sid, start: prev, end: prev.Add(gap)}
+			// Model attribution: closing assistant message wins.
+			if evs[i].Role == "assistant" && evs[i].Model != "" {
+				lastModel = evs[i].Model
+			}
+			iv.model = lastModel
+			if c, ok := clip(iv, start, effEnd); ok {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+func clip(iv interval, start, end time.Time) (interval, bool) {
+	if iv.start.Before(start) {
+		iv.start = start
+	}
+	if iv.end.After(end) {
+		iv.end = end
+	}
+	if !iv.end.After(iv.start) {
+		return interval{}, false
+	}
+	return iv, true
+}
+
+// reportIntervals maps the aggregator's internal active intervals to the
+// exposed payload form, sorted on the time.Time bounds by (start, end,
+// sessionID) for a deterministic, format-independent order. Bounds are
+// formatted at second resolution (RFC3339), matching every other timestamp in
+// the report and keeping the payload identical across SQLite, PostgreSQL, and
+// DuckDB: the mirror backends store timestamps at microsecond resolution, so
+// exposing finer precision would let one session serialize differently per
+// backend. A sub-second span therefore collapses to a point (start == end); the
+// client places that instant in the slot containing it. Always returns a
+// non-nil slice.
+func reportIntervals(intervals []interval) []ReportInterval {
+	sorted := make([]interval, len(intervals))
+	copy(sorted, intervals)
+	sort.Slice(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+		if !a.start.Equal(b.start) {
+			return a.start.Before(b.start)
+		}
+		if !a.end.Equal(b.end) {
+			return a.end.Before(b.end)
+		}
+		return a.sessionID < b.sessionID
+	})
+	out := make([]ReportInterval, 0, len(sorted))
+	for _, iv := range sorted {
+		out = append(out, ReportInterval{
+			SessionID: iv.sessionID,
+			Start:     iv.start.Format(time.RFC3339),
+			End:       iv.end.Format(time.RFC3339),
+		})
+	}
+	return out
+}
+
+func sumIntervalMinutes(ivs []interval) float64 {
+	var m float64
+	for _, iv := range ivs {
+		m += iv.end.Sub(iv.start).Minutes()
+	}
+	return m
+}
+
+// splitIntervalMinutes sums interval minutes into automated and interactive
+// totals by each interval's session class. The two sum to sumIntervalMinutes.
+func splitIntervalMinutes(ivs []interval, automatedBy map[string]bool) (float64, float64) {
+	var auto, inter float64
+	for _, iv := range ivs {
+		m := iv.end.Sub(iv.start).Minutes()
+		if automatedBy[iv.sessionID] {
+			auto += m
+		} else {
+			inter += m
+		}
+	}
+	return auto, inter
+}
+
+// automatedSet maps each session id to its automated class for the segment
+// split. Sessions absent from the map are treated as interactive (false).
+func automatedSet(sessions []SessionMeta) map[string]bool {
+	m := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		m[s.SessionID] = s.IsAutomated
+	}
+	return m
+}
+
+// sweepLine returns the exact peak concurrency (and the first instant it
+// occurs), the wall-clock minutes where >=1 interval is live, and the
+// automated/interactive split of the live count AT the peak instant. The split
+// counts sum to peak.Agents because they are snapshotted at the same event that
+// sets the peak, so a stacked bar never exceeds the true peak.
+func sweepLine(ivs []interval, automatedBy map[string]bool) (Peak, float64, int, int) {
+	type ev struct {
+		t     time.Time
+		delta int
+		auto  bool
+	}
+	evs := make([]ev, 0, len(ivs)*2)
+	for _, iv := range ivs {
+		a := automatedBy[iv.sessionID]
+		evs = append(evs, ev{iv.start, 1, a}, ev{iv.end, -1, a})
+	}
+	sort.Slice(evs, func(i, j int) bool {
+		if evs[i].t.Equal(evs[j].t) {
+			// Intervals are half-open [start,end): process closes (-1)
+			// before opens (+1) at a tie so two abutting intervals from one
+			// session are not counted as overlapping at the shared boundary.
+			return evs[i].delta < evs[j].delta
+		}
+		return evs[i].t.Before(evs[j].t)
+	})
+	var peak Peak
+	live, liveAuto, liveInter := 0, 0, 0
+	var autoAtPeak, interAtPeak int
+	var active time.Duration
+	var lastT time.Time
+	for i, e := range evs {
+		if i > 0 && live > 0 {
+			active += e.t.Sub(lastT)
+		}
+		live += e.delta
+		if e.auto {
+			liveAuto += e.delta
+		} else {
+			liveInter += e.delta
+		}
+		if live > peak.Agents {
+			peak.Agents = live
+			at := e.t.Format(time.RFC3339)
+			peak.At = &at
+			autoAtPeak, interAtPeak = liveAuto, liveInter
+		}
+		lastT = e.t
+	}
+	return peak, active.Minutes(), autoAtPeak, interAtPeak
+}
+
+// buildBuckets emits one r.Buckets entry per window (with Start/End bounds for
+// ALL windows, elapsed or not, since clients need every window's bounds) and
+// fills agent_minutes / max_agents for windows overlapping [.., effEnd). Each
+// window's own [Start, End) bounds the per-bucket clip, so variable-width
+// calendar buckets accumulate over their actual span, not a fixed step.
+func buildBuckets(r *Report, windows []BucketWindow, effEnd time.Time,
+	ivs []interval, automatedBy map[string]bool) {
+	r.Buckets = make([]Bucket, len(windows))
+	for i, w := range windows {
+		r.Buckets[i] = Bucket{
+			Start: w.Start.Format(time.RFC3339),
+			End:   w.End.Format(time.RFC3339),
+		}
+		if !w.Start.Before(effEnd) {
+			continue // window has not begun; leave metrics zero
+		}
+		for _, iv := range ivs {
+			lo := maxTime(iv.start, w.Start)
+			hi := minTime(iv.end, w.End)
+			if hi.After(lo) {
+				r.Buckets[i].AgentMinutes += hi.Sub(lo).Minutes()
+			}
+		}
+	}
+	fillBucketMaxAgents(r, windows, effEnd, ivs, automatedBy)
+}
+
+// fillBucketMaxAgents sets r.Buckets[b].MaxAgents to the peak concurrency seen
+// within window b. For each elapsed window it clips every interval to the
+// window's half-open span and runs the shared sweep over the survivors. A
+// range has at most maxBuckets windows, so a per-window sweep is fine.
+func fillBucketMaxAgents(r *Report, windows []BucketWindow, effEnd time.Time,
+	ivs []interval, automatedBy map[string]bool) {
+	for b, w := range windows {
+		if !w.Start.Before(effEnd) {
+			continue
+		}
+		var clipped []interval
+		for _, iv := range ivs {
+			if c, ok := clip(iv, w.Start, w.End); ok {
+				clipped = append(clipped, c)
+			}
+		}
+		if len(clipped) == 0 {
+			continue
+		}
+		peak, _, autoAtPeak, interAtPeak := sweepLine(clipped, automatedBy)
+		r.Buckets[b].MaxAgents = peak.Agents
+		r.Buckets[b].AutomatedAtPeak = autoAtPeak
+		r.Buckets[b].InteractiveAtPeak = interAtPeak
+	}
+}
+
+func maxTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}
+
+// usageAgg accumulates per-session cost, output tokens, and per-model cost.
+// buildSessionsTable consumes it to build per-session rows and model breakdowns
+// from the same deduped survivor set dedupUsage returns.
+type usageAgg struct {
+	cost         float64
+	outputTokens int
+	models       map[string]float64 // model -> cost (for primary/mixed)
+}
+
+// dedupUsage filters usage rows to the range and applies the two-tier,
+// first-seen-wins dedup that mirrors GetDailyUsage. Rows arrive pre-sorted by
+// (ts, session_id, COALESCE(message_ordinal,-1)). The half-open instant filter
+// drops rows before start or at/after end; on a partial range effEnd is the
+// as-of clip, so rows at or after effEnd are dropped before they can claim a
+// dedup key, matching the activity/bucket clipping Aggregate applies. For a
+// full range effEnd == end, so nothing extra is excluded.
+func dedupUsage(start, end, effEnd time.Time, usage []UsageRow) []UsageRow {
+	type dk struct{ a, b string }
+	seen := map[dk]struct{}{}
+	out := make([]UsageRow, 0, len(usage))
+	for _, u := range usage {
+		t, ok := parseTS(u.Timestamp)
+		if !ok || t.Before(start) || !t.Before(end) {
+			continue // out-of-range rows never claim a key
+		}
+		if !t.Before(effEnd) {
+			continue // partial range: rows at/after as_of never claim a key
+		}
+		if u.ClaudeMessageID != "" && u.ClaudeRequestID != "" {
+			k := dk{u.ClaudeMessageID, u.ClaudeRequestID}
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+		} else if u.UsageDedupKey != "" {
+			k := dk{"usage", u.UsageDedupKey}
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+		}
+		out = append(out, u)
+	}
+	return out
+}
+
+// applyUsage dedups usage rows to the range, then accumulates output tokens
+// and cost into r.Totals and the window whose [Start, End) contains each row's
+// timestamp.
+func applyUsage(r *Report, p Params, windows []BucketWindow, start, end time.Time,
+	usage []UsageRow, automatedBy map[string]bool) {
+	for _, u := range dedupUsage(start, end, p.EffectiveEnd, usage) {
+		r.Totals.OutputTokens += u.OutputTokens
+		r.Totals.Cost += u.Cost
+		if automatedBy[u.SessionID] {
+			r.Totals.AutomatedCost += u.Cost
+		} else {
+			r.Totals.InteractiveCost += u.Cost
+		}
+		t, _ := parseTS(u.Timestamp)
+		if b := windowIndex(windows, t); b >= 0 && b < len(r.Buckets) {
+			r.Buckets[b].OutputTokens += u.OutputTokens
+			r.Buckets[b].Cost += u.Cost
+		}
+	}
+}
+
+// windowIndex returns the index of the ascending-sorted window whose half-open
+// [Start, End) contains t, or -1 if none does. Uses binary search since
+// windows are sorted by Start.
+func windowIndex(windows []BucketWindow, t time.Time) int {
+	lo, hi := 0, len(windows)-1
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		w := windows[mid]
+		switch {
+		case t.Before(w.Start):
+			hi = mid - 1
+		case !t.Before(w.End):
+			lo = mid + 1
+		default:
+			return mid
+		}
+	}
+	return -1
+}
+
+// buildSessionsTable populates r.BySession plus the by-project/agent/model
+// breakdowns and distinct counts. Per-session interval minutes, model minutes,
+// and the active window come from the timed intervals; cost, output tokens, and
+// model fallbacks come from the deduped usage survivors. Breakdowns roll the
+// per-session minutes up by project/agent (timed sessions only) and by interval
+// model, all sorted by minutes descending with empty/zero keys dropped.
+func buildSessionsTable(r *Report, start, end, effEnd time.Time,
+	sessions []SessionMeta, ivs []interval, usage []UsageRow) {
+	// Per-session interval minutes + model minutes + active window.
+	type sAgg struct {
+		minutes     float64
+		modelMins   map[string]float64
+		first, last time.Time
+		hasIv       bool
+	}
+	agg := map[string]*sAgg{}
+	for _, iv := range ivs {
+		a := agg[iv.sessionID]
+		if a == nil {
+			a = &sAgg{modelMins: map[string]float64{}}
+			agg[iv.sessionID] = a
+		}
+		m := iv.end.Sub(iv.start).Minutes()
+		a.minutes += m
+		a.modelMins[iv.model] += m
+		if !a.hasIv || iv.start.Before(a.first) {
+			a.first = iv.start
+		}
+		if !a.hasIv || iv.end.After(a.last) {
+			a.last = iv.end
+		}
+		a.hasIv = true
+	}
+	// Per-session cost/tokens/models from deduped usage.
+	cost := map[string]*usageAgg{}
+	for _, u := range dedupUsage(start, end, effEnd, usage) {
+		c := cost[u.SessionID]
+		if c == nil {
+			c = &usageAgg{models: map[string]float64{}}
+			cost[u.SessionID] = c
+		}
+		c.cost += u.Cost
+		c.outputTokens += u.OutputTokens
+		if u.Model != "" {
+			c.models[u.Model] += u.Cost
+		}
+	}
+	projSet := map[string]struct{}{}
+	modelSet := map[string]struct{}{}
+	byProject := map[string]*keyAgg{}
+	byAgent := map[string]*keyAgg{}
+	byModel := map[string]*keyAgg{}
+	r.BySession = make([]SessionRow, 0, len(sessions))
+	for _, s := range sessions {
+		au := s.IsAutomated
+		projSet[s.Project] = struct{}{}
+		row := SessionRow{
+			SessionID: s.SessionID, Title: s.Title, Project: s.Project,
+			Agent: s.Agent, TimingQuality: "untimed", IsAutomated: au,
+		}
+		if a := agg[s.SessionID]; a != nil && a.hasIv {
+			mins := a.minutes
+			row.AgentMinutes = &mins
+			row.TimingQuality = "timed"
+			f := a.first.Format(time.RFC3339)
+			l := a.last.Format(time.RFC3339)
+			row.FirstActive, row.LastActive = &f, &l
+			row.PrimaryModel, row.Models = primaryAndModels(a.modelMins)
+			addKey(byProject, s.Project, mins, 0, au)
+			addKey(byAgent, s.Agent, mins, 0, au)
+			for m, mm := range a.modelMins {
+				addKey(byModel, m, mm, 0, au)
+			}
+		} else {
+			r.Totals.UntimedSessions++
+		}
+		if c := cost[s.SessionID]; c != nil {
+			row.Cost = c.cost
+			row.OutputTokens = c.outputTokens
+			if row.PrimaryModel == "" {
+				row.PrimaryModel, row.Models = primaryAndModels(c.models)
+			}
+			// Cost rolls up for every session with usage, timed or not, so the
+			// cost breakdown sums to Totals.Cost. Minutes stay timed-only above.
+			addKey(byProject, s.Project, 0, c.cost, au)
+			addKey(byAgent, s.Agent, 0, c.cost, au)
+			for m, mc := range c.models {
+				addKey(byModel, m, 0, mc, au)
+			}
+		}
+		for _, m := range row.Models {
+			modelSet[m] = struct{}{}
+		}
+		r.BySession = append(r.BySession, row)
+	}
+	sort.Slice(r.BySession, func(i, j int) bool {
+		return minutesOf(r.BySession[i]) > minutesOf(r.BySession[j])
+	})
+	r.Totals.Sessions = len(sessions)
+	r.Totals.DistinctProjects = len(projSet)
+	r.Totals.DistinctModels = len(modelSet)
+	r.ByProject = breakdownRows(byProject, false)
+	r.ByAgent = breakdownRows(byAgent, false)
+	r.ByModel = breakdownRows(byModel, true)
+}
+
+// keyAgg accumulates a breakdown key's combined agent-minutes and cost plus the
+// automated/interactive split of each. Minutes come from timed intervals; cost
+// from deduped usage (all sessions, timed or not).
+type keyAgg struct {
+	minutes      float64
+	cost         float64
+	autoMinutes  float64
+	interMinutes float64
+	autoCost     float64
+	interCost    float64
+}
+
+// addKey accumulates minutes and cost into the key's aggregate, routing the
+// values into the automated or interactive segment by the session's class.
+func addKey(m map[string]*keyAgg, key string, minutes, cost float64, automated bool) {
+	a := m[key]
+	if a == nil {
+		a = &keyAgg{}
+		m[key] = a
+	}
+	a.minutes += minutes
+	a.cost += cost
+	if automated {
+		a.autoMinutes += minutes
+		a.autoCost += cost
+	} else {
+		a.interMinutes += minutes
+		a.interCost += cost
+	}
+}
+
+// breakdownRows turns a key->aggregate map into a slice sorted by combined
+// agent-minutes descending (the UI re-sorts by the selected metric). It drops
+// empty keys and rows with neither minutes nor cost; when dropModelKeys is set
+// it also drops the "unknown" model key.
+func breakdownRows(m map[string]*keyAgg, dropModelKeys bool) []KeyMinutes {
+	out := make([]KeyMinutes, 0, len(m))
+	for k, v := range m {
+		if k == "" || (v.minutes == 0 && v.cost == 0) {
+			continue
+		}
+		if dropModelKeys && k == "unknown" {
+			continue
+		}
+		out = append(out, KeyMinutes{
+			Key:                     k,
+			AgentMinutes:            v.minutes,
+			Cost:                    v.cost,
+			AutomatedAgentMinutes:   v.autoMinutes,
+			InteractiveAgentMinutes: v.interMinutes,
+			AutomatedCost:           v.autoCost,
+			InteractiveCost:         v.interCost,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].AgentMinutes == out[j].AgentMinutes {
+			return out[i].Key < out[j].Key
+		}
+		return out[i].AgentMinutes > out[j].AgentMinutes
+	})
+	return out
+}
+
+func minutesOf(s SessionRow) float64 {
+	if s.AgentMinutes == nil {
+		return -1
+	}
+	return *s.AgentMinutes
+}
+
+// primaryAndModels returns the highest-weight model and the sorted set; the
+// primary is "" when no model has weight. Caller renders "mixed" when len>1.
+func primaryAndModels(w map[string]float64) (string, []string) {
+	var keys []string
+	primary := ""
+	var best float64
+	for k, v := range w {
+		if k == "" || k == "unknown" {
+			continue
+		}
+		keys = append(keys, k)
+		if v > best {
+			best, primary = v, k
+		}
+	}
+	sort.Strings(keys)
+	return primary, keys
+}

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -128,6 +128,10 @@ type Totals struct {
 	InteractiveAgentMinutes float64 `json:"interactive_agent_minutes"`
 	AutomatedCost           float64 `json:"automated_cost"`
 	InteractiveCost         float64 `json:"interactive_cost"`
+	// Session counts split by class (AutomatedSessions + InteractiveSessions
+	// == Sessions), so the summary card can show "total (auto / int)".
+	AutomatedSessions   int `json:"automated_sessions"`
+	InteractiveSessions int `json:"interactive_sessions"`
 }
 
 // KeyMinutes is one breakdown row (by project/model/agent). It carries both the
@@ -656,6 +660,11 @@ func buildSessionsTable(r *Report, start, end, effEnd time.Time,
 	r.BySession = make([]SessionRow, 0, len(sessions))
 	for _, s := range sessions {
 		au := s.IsAutomated
+		if au {
+			r.Totals.AutomatedSessions++
+		} else {
+			r.Totals.InteractiveSessions++
+		}
 		projSet[s.Project] = struct{}{}
 		row := SessionRow{
 			SessionID: s.SessionID, Title: s.Title, Project: s.Project,

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -132,7 +132,8 @@ type Totals struct {
 
 // KeyMinutes is one breakdown row (by project/model/agent). It carries both the
 // combined agent-minutes and cost (so the UI can sort by either metric) plus the
-// additive automated/interactive segments of each, rendered as a stacked bar.
+// additive automated/interactive segments of each, exposed for a stacked-bar
+// rendering the current UI does not yet draw (it shows the combined metric).
 type KeyMinutes struct {
 	Key                     string  `json:"key"`
 	AgentMinutes            float64 `json:"agent_minutes"`
@@ -599,6 +600,15 @@ func windowIndex(windows []BucketWindow, t time.Time) int {
 // model, all sorted by minutes descending with empty/zero keys dropped.
 func buildSessionsTable(r *Report, start, end, effEnd time.Time,
 	sessions []SessionMeta, ivs []interval, usage []UsageRow) {
+	// Sort sessions by ID so the cost and minute rollups below accumulate in
+	// one deterministic order. addKey sums float64 values across sessions and
+	// float addition is not associative, so the unspecified per-backend row
+	// order (no activityReportSessions query imposes ORDER BY) would otherwise
+	// yield 1-ULP-different breakdown costs across SQLite, PostgreSQL, and
+	// DuckDB for identical data.
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].SessionID < sessions[j].SessionID
+	})
 	// Per-session interval minutes + model minutes + active window.
 	type sAgg struct {
 		minutes     float64

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -767,8 +767,11 @@ func minutesOf(s SessionRow) float64 {
 	return *s.AgentMinutes
 }
 
-// primaryAndModels returns the highest-weight model and the sorted set; the
-// primary is "" when no model has weight. Caller renders "mixed" when len>1.
+// primaryAndModels returns the highest-weight model and the sorted set. When
+// no model carries positive weight (e.g. zero-cost or unpriced usage) it falls
+// back to the first model in sorted order, so a known-model session still
+// reports a primary; the primary is "" only when the set is empty. Caller
+// renders "mixed" when len>1.
 func primaryAndModels(w map[string]float64) (string, []string) {
 	var keys []string
 	primary := ""
@@ -783,5 +786,8 @@ func primaryAndModels(w map[string]float64) (string, []string) {
 		}
 	}
 	sort.Strings(keys)
+	if primary == "" && len(keys) > 0 {
+		primary = keys[0]
+	}
 	return primary, keys
 }

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -543,3 +543,56 @@ func TestAggregate_UsageOnlySessionZeroCostKeepsPrimaryModel(t *testing.T) {
 		"zero-cost usage must still report its known model as primary")
 	assert.Equal(t, []string{"m1"}, row.Models)
 }
+
+// TestAggregate_BreakdownCostDeterministicAcrossSessionOrder pins that the
+// per-key cost rollup does not depend on the order sessions arrive in. The
+// activityReportSessions queries impose no ORDER BY, so SQLite, PostgreSQL, and
+// DuckDB can return the same sessions in different orders. addKey sums float64
+// costs across sessions and float addition is not associative -- (0.1+0.2)+0.3
+// rounds to a different last bit than (0.3+0.2)+0.1 -- so without a
+// deterministic session order the three backends produced 1-ULP-different
+// breakdown costs for identical data. Aggregate sorts sessions by ID, so any
+// input order yields byte-identical breakdowns.
+func TestAggregate_BreakdownCostDeterministicAcrossSessionOrder(t *testing.T) {
+	loc := mustLoad(t, "UTC")
+	start := mustStart(t, "2026-06-16T00:00:00Z")
+	end := start.AddDate(0, 0, 1)
+	p := Params{
+		RangeStart: start, RangeEnd: end, Loc: loc,
+		EffectiveEnd: end, Partial: false,
+		GapCapSeconds: 300, Bucket: BucketSpec{BucketMinute, 300},
+	}
+	// Three usage-only sessions sharing one project, agent, and model so all
+	// their costs roll into a single by-project/agent/model key. Costs
+	// 0.1/0.2/0.3 are chosen because (0.1+0.2)+0.3 != (0.3+0.2)+0.1 in float64,
+	// so reversing the session order shifts the rolled-up cost by one ULP unless
+	// the order is normalized.
+	usage := []UsageRow{
+		{SessionID: "s1", Model: "m1", Timestamp: "2026-06-16T10:00:00Z",
+			OutputTokens: 10, Cost: 0.1, ClaudeMessageID: "s1", ClaudeRequestID: "r"},
+		{SessionID: "s2", Model: "m1", Timestamp: "2026-06-16T11:00:00Z",
+			OutputTokens: 20, Cost: 0.2, ClaudeMessageID: "s2", ClaudeRequestID: "r"},
+		{SessionID: "s3", Model: "m1", Timestamp: "2026-06-16T12:00:00Z",
+			OutputTokens: 30, Cost: 0.3, ClaudeMessageID: "s3", ClaudeRequestID: "r"},
+	}
+	meta := func(id string) SessionMeta {
+		return SessionMeta{SessionID: id, Project: "P", Agent: "claude"}
+	}
+	ascending := []SessionMeta{meta("s1"), meta("s2"), meta("s3")}
+	descending := []SessionMeta{meta("s3"), meta("s2"), meta("s1")}
+
+	rAsc := Aggregate(p, ascending, nil, usage)
+	rDesc := Aggregate(p, descending, nil, usage)
+
+	require.Len(t, rAsc.ByModel, 1)
+	require.Len(t, rDesc.ByModel, 1)
+	require.Len(t, rAsc.ByAgent, 1)
+	require.Len(t, rAsc.ByProject, 1)
+	// Exact float equality (not InDelta): byte-for-byte parity is the point.
+	require.Equal(t, rAsc.ByModel[0].Cost, rDesc.ByModel[0].Cost,
+		"by-model cost must not depend on session arrival order")
+	require.Equal(t, rAsc.ByAgent[0].Cost, rDesc.ByAgent[0].Cost,
+		"by-agent cost must not depend on session arrival order")
+	require.Equal(t, rAsc.ByProject[0].Cost, rDesc.ByProject[0].Cost,
+		"by-project cost must not depend on session arrival order")
+}

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -1,0 +1,513 @@
+package activity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustLoad(t *testing.T, name string) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation(name)
+	require.NoError(t, err)
+	return loc
+}
+
+// fixedNow is a far-future instant so test ranges are never "partial".
+func fixedNow(t *testing.T) time.Time {
+	t.Helper()
+	n, err := time.Parse(time.RFC3339, "2030-01-01T00:00:00Z")
+	require.NoError(t, err)
+	return n
+}
+
+// baseParams resolves a one-day "day" Query for date/tz against a far-future
+// now (so the day is complete) and copies it into aggregator Params.
+func baseParams(t *testing.T, date, tz string) Params {
+	t.Helper()
+	q, err := ResolveQuery(QueryInput{Preset: "day", Date: date, Timezone: tz}, fixedNow(t))
+	require.NoError(t, err)
+	return paramsFromQuery(q)
+}
+
+// paramsFromQuery copies a resolved Query into the aggregator Params it feeds.
+func paramsFromQuery(q Query) Params {
+	return Params{
+		RangeStart:    q.RangeStart,
+		RangeEnd:      q.RangeEnd,
+		Loc:           q.Loc,
+		EffectiveEnd:  q.EffectiveEnd,
+		Partial:       q.Partial,
+		GapCapSeconds: q.GapCapSeconds,
+		Bucket:        q.Bucket,
+	}
+}
+
+func TestAggregate_DayWindowUTC(t *testing.T) {
+	r := Aggregate(baseParams(t, "2026-06-16", "UTC"), nil, nil, nil)
+	assert.Equal(t, "2026-06-16T00:00:00Z", r.RangeStart)
+	assert.Equal(t, "2026-06-17T00:00:00Z", r.RangeEnd)
+	assert.Equal(t, "minute", r.BucketUnit)
+	assert.Equal(t, 300, r.BucketSeconds)
+	assert.Equal(t, 288, r.BucketCount)
+	assert.False(t, r.Partial)
+	assert.Equal(t, 288, r.ElapsedBucketCount)
+	assert.Len(t, r.Buckets, 288)
+	assert.Equal(t, "2026-06-16T00:00:00Z", r.Buckets[0].Start)
+	assert.Equal(t, "2026-06-16T00:05:00Z", r.Buckets[0].End)
+}
+
+func TestAggregate_HourlyBucketRange(t *testing.T) {
+	q, err := ResolveQuery(QueryInput{
+		Preset: "custom", Timezone: "UTC",
+		From: "2026-06-16T00:00:00Z", To: "2026-06-19T00:00:00Z", // 3 days -> hourly
+	}, fixedNow(t))
+	require.NoError(t, err)
+	p := paramsFromQuery(q)
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:30:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	assert.Equal(t, "hour", r.BucketUnit)
+	assert.Equal(t, 72, r.BucketCount, "3 days of hourly buckets")
+	assert.Equal(t, "2026-06-16T10:00:00Z", r.Buckets[10].Start)
+	assert.Equal(t, "2026-06-16T11:00:00Z", r.Buckets[10].End)
+	// The 30-min gap caps to 5 min; that activity lands in the 10:00 bucket.
+	assert.InDelta(t, 5.0, r.Buckets[10].AgentMinutes, 1e-9)
+}
+
+func TestAggregate_DailyCalendarBucketRange(t *testing.T) {
+	q, err := ResolveQuery(QueryInput{Preset: "month", Date: "2026-06-10", Timezone: "UTC"}, fixedNow(t))
+	require.NoError(t, err)
+	p := paramsFromQuery(q)
+	r := Aggregate(p, nil, nil, nil)
+	assert.Equal(t, "day", r.BucketUnit)
+	assert.Equal(t, 86400, r.BucketSeconds, "nominal day seconds")
+	assert.Equal(t, 30, r.BucketCount, "June has 30 calendar-day buckets")
+	assert.Equal(t, "2026-06-01T00:00:00Z", r.Buckets[0].Start)
+	assert.Equal(t, "2026-06-02T00:00:00Z", r.Buckets[0].End)
+}
+
+func TestAggregate_ArbitraryRangeIntervalClip(t *testing.T) {
+	// Range starts mid-day at 10:30, not midnight.
+	q, err := ResolveQuery(QueryInput{
+		Preset: "custom", Timezone: "UTC",
+		From: "2026-06-16T10:30:00Z", To: "2026-06-16T12:00:00Z",
+	}, fixedNow(t))
+	require.NoError(t, err)
+	p := paramsFromQuery(q)
+	// Anchor at 10:28 (before range_start), successor at 10:40: interval
+	// [10:28,10:33) clips to [10:30,10:33) = 3 min inside the range.
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:28:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:40:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	require.Len(t, r.Intervals, 1)
+	assert.Equal(t, "2026-06-16T10:30:00Z", r.Intervals[0].Start, "clipped to range_start, not midnight")
+	assert.Equal(t, "2026-06-16T10:33:00Z", r.Intervals[0].End)
+	assert.InDelta(t, 3.0, r.Totals.AgentMinutes, 1e-9)
+}
+
+func TestAggregate_FutureRangeNoActivity(t *testing.T) {
+	now, err := time.Parse(time.RFC3339, "2026-06-16T00:00:00Z")
+	require.NoError(t, err)
+	q, err := ResolveQuery(QueryInput{Preset: "day", Date: "2026-06-20", Timezone: "UTC"}, now)
+	require.NoError(t, err)
+	p := paramsFromQuery(q)
+	r := Aggregate(p, nil, nil, nil)
+	assert.True(t, r.Partial)
+	assert.Equal(t, 0, r.ElapsedBucketCount, "fully future range elapses no buckets")
+	assert.Equal(t, 288, r.BucketCount, "but the full day's buckets are still listed")
+	assert.InDelta(t, 0.0, r.Totals.AgentMinutes, 1e-9)
+}
+
+func TestAggregate_DSTSpringForward23Hours(t *testing.T) {
+	// America/New_York springs forward 2026-03-08 (23-hour local day).
+	r := Aggregate(baseParams(t, "2026-03-08", "America/New_York"), nil, nil, nil)
+	assert.Equal(t, 276, r.BucketCount) // 23h * 12
+}
+
+func TestAggregate_DSTFallBack25Hours(t *testing.T) {
+	// America/New_York falls back 2026-11-01 (25-hour local day).
+	r := Aggregate(baseParams(t, "2026-11-01", "America/New_York"), nil, nil, nil)
+	assert.Equal(t, 300, r.BucketCount) // 25h * 12
+}
+
+func TestAggregate_SweepLineNonOverlapVsOverlap(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// Two sessions each with two messages 1 min apart, in the SAME 5-min
+	// bucket but never overlapping in time.
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:01:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "b", Ordinal: 1, Timestamp: "2026-06-16T10:03:00Z", Role: "user"},
+		{SessionID: "b", Ordinal: 2, Timestamp: "2026-06-16T10:03:30Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	assert.Equal(t, 1, r.Peak.Agents, "non-overlapping must peak at 1")
+
+	// Now make them overlap: b starts inside a's interval.
+	act[2].Timestamp = "2026-06-16T10:00:30Z"
+	act[3].Timestamp = "2026-06-16T10:01:30Z"
+	r = Aggregate(p, nil, act, nil)
+	assert.Equal(t, 2, r.Peak.Agents, "overlapping must peak at 2")
+}
+
+func TestAggregate_AdjacentIntervalsOneSessionNotConcurrent(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// A SINGLE session with three adjacent messages yields two abutting
+	// half-open intervals [10:00,10:02) and [10:02,10:05). They share the
+	// boundary 10:02 but must NOT be counted as overlapping there.
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:02:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "a", Ordinal: 3, Timestamp: "2026-06-16T10:05:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	assert.Equal(t, 1, r.Peak.Agents, "abutting intervals from one session never overlap")
+	for i, b := range r.Buckets {
+		assert.LessOrEqualf(t, b.MaxAgents, 1, "bucket %d max_agents", i)
+	}
+}
+
+func TestAggregate_PartialDayClipsUsage(t *testing.T) {
+	loc := mustLoad(t, "UTC")
+	start, err := time.Parse(time.RFC3339, "2026-06-16T00:00:00Z")
+	require.NoError(t, err)
+	end := start.AddDate(0, 0, 1)
+	effEnd, err := time.Parse(time.RFC3339, "2026-06-16T12:00:00Z")
+	require.NoError(t, err)
+	p := Params{
+		RangeStart: start, RangeEnd: end, Loc: loc,
+		EffectiveEnd: effEnd, Partial: true,
+		GapCapSeconds: 300, Bucket: BucketSpec{BucketMinute, 300},
+	}
+	usage := []UsageRow{
+		{SessionID: "s1", Model: "m1", Timestamp: "2026-06-16T10:00:00Z",
+			OutputTokens: 100, Cost: 1.0, ClaudeMessageID: "a", ClaudeRequestID: "x"},
+		{SessionID: "s1", Model: "m1", Timestamp: "2026-06-16T14:00:00Z",
+			OutputTokens: 200, Cost: 2.0, ClaudeMessageID: "b", ClaudeRequestID: "y"},
+	}
+	sessions := []SessionMeta{{SessionID: "s1", Project: "p", Agent: "claude"}}
+	r := Aggregate(p, sessions, nil, usage)
+	assert.True(t, r.Partial, "mid-day report must be partial")
+	assert.Equal(t, 100, r.Totals.OutputTokens, "row at/after effEnd excluded from totals")
+	assert.InDelta(t, 1.0, r.Totals.Cost, 1e-9)
+	require.Len(t, r.BySession, 1)
+	assert.Equal(t, 100, r.BySession[0].OutputTokens, "session row clipped to as_of")
+	assert.InDelta(t, 1.0, r.BySession[0].Cost, 1e-9)
+}
+
+func TestAggregate_OverlapUnionVsSumAndPeakAt(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// Two OVERLAPPING sessions on a full past day:
+	//   a = [10:00, 10:03)  (3 min)
+	//   b = [10:01, 10:05)  (4 min)
+	// Active minutes are the UNION (10:00-10:05 = 5), agent-minutes are the
+	// SUM (3+4 = 7). Asserting both proves union != sum here, so a regression
+	// that dropped the `live > 0` guard in sweepLine (making active accumulate
+	// the SUM) would be caught.
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:03:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "b", Ordinal: 1, Timestamp: "2026-06-16T10:01:00Z", Role: "user"},
+		{SessionID: "b", Ordinal: 2, Timestamp: "2026-06-16T10:05:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	assert.InDelta(t, 5.0, r.Totals.ActiveMinutes, 1e-9,
+		"active minutes are the union 10:00-10:05, not the sum")
+	assert.InDelta(t, 7.0, r.Totals.AgentMinutes, 1e-9,
+		"agent minutes are the sum 3+4, proving union != sum")
+	assert.Equal(t, 2, r.Peak.Agents, "both sessions live in [10:01,10:03)")
+	require.NotNil(t, r.Peak.At, "peak instant must be reported")
+	assert.Equal(t, "2026-06-16T10:01:00Z", *r.Peak.At,
+		"peak first occurs when b opens at 10:01")
+	// Full-day denominator: 1440 minutes minus the 5 active union minutes.
+	assert.InDelta(t, 1435.0, r.Totals.IdleMinutes, 1e-9,
+		"idle is the full-day 1440 minus active 5")
+}
+
+func TestAggregate_PartialDayClipsActivityAndBuckets(t *testing.T) {
+	loc := mustLoad(t, "UTC")
+	// "Today" with effEnd mid-day at 12:00 makes the report partial.
+	start, err := time.Parse(time.RFC3339, "2026-06-16T00:00:00Z")
+	require.NoError(t, err)
+	end := start.AddDate(0, 0, 1)
+	effEnd, err := time.Parse(time.RFC3339, "2026-06-16T12:00:00Z")
+	require.NoError(t, err)
+	p := Params{
+		RangeStart: start, RangeEnd: end, Loc: loc,
+		EffectiveEnd: effEnd, Partial: true,
+		GapCapSeconds: 300, Bucket: BucketSpec{BucketMinute, 300},
+	}
+	// One session whose activity interval STRADDLES effEnd: messages at 11:58
+	// and 12:10. The 12-minute gap caps to 5 min, so the natural interval is
+	// [11:58, 12:03) -- it crosses 12:00. The clip to effEnd is the binding
+	// constraint here (the cap alone would leave 5 min past 11:58), so only
+	// 11:58->12:00 = 2 minutes are counted, proving the straddle is clipped.
+	act := []ActivityEvent{
+		{SessionID: "s1", Ordinal: 1, Timestamp: "2026-06-16T11:58:00Z", Role: "user"},
+		{SessionID: "s1", Ordinal: 2, Timestamp: "2026-06-16T12:10:00Z", Role: "assistant", Model: "m1"},
+	}
+	sessions := []SessionMeta{{SessionID: "s1", Project: "p", Agent: "claude"}}
+	r := Aggregate(p, sessions, act, nil)
+
+	assert.True(t, r.Partial, "mid-day report must be partial")
+	// All windows are emitted regardless of how much of the range has elapsed.
+	assert.Equal(t, 288, r.BucketCount, "full local day has 288 five-minute buckets")
+	assert.Len(t, r.Buckets, r.BucketCount,
+		"buckets slice lists every window, not just the elapsed ones")
+	assert.Less(t, r.ElapsedBucketCount, r.BucketCount,
+		"a partial day elapses fewer buckets than the full day")
+	assert.Equal(t, 144, r.ElapsedBucketCount, "12h elapsed yields 144 buckets")
+	// Straddling interval clipped to effEnd: 11:58->12:00 = 2 minutes.
+	assert.InDelta(t, 2.0, r.Totals.AgentMinutes, 1e-9,
+		"interval clipped to effEnd, not the full capped span")
+	assert.InDelta(t, 2.0, r.Totals.ActiveMinutes, 1e-9,
+		"single clipped interval contributes 2 active minutes")
+	require.Len(t, r.BySession, 1)
+	require.NotNil(t, r.BySession[0].AgentMinutes)
+	assert.InDelta(t, 2.0, *r.BySession[0].AgentMinutes, 1e-9,
+		"per-session minutes also clipped to effEnd")
+	// Idle is measured against the ELAPSED denominator (720 min), not the
+	// full-day 1440: 720 - 2 = 718.
+	assert.InDelta(t, 718.0, r.Totals.IdleMinutes, 1e-9,
+		"partial idle uses the elapsed denominator, not full day")
+}
+
+func TestAggregate_GapCapAndActiveMinutes(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// One session: 3 messages. Gap 1 -> 2 is 2 min, gap 2 -> 3 is 40 min
+	// (capped to 5). Active = 2 + 5 = 7 minutes.
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:02:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "a", Ordinal: 3, Timestamp: "2026-06-16T10:42:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	assert.InDelta(t, 7.0, r.Totals.AgentMinutes, 1e-9)
+	assert.InDelta(t, 7.0, r.Totals.ActiveMinutes, 1e-9)
+}
+
+func TestAggregate_NonMonotonicGapIgnored(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:05:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:04:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	assert.InDelta(t, 0.0, r.Totals.AgentMinutes, 1e-9)
+}
+
+func TestAggregate_MidnightClipWithFarSuccessor(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// Anchor at 23:59 on the day, successor at 00:20 next day (gap capped to
+	// 5 min). Interval [23:59, 00:04) clipped to the day end 00:00 leaves
+	// [23:59, 00:00) = 1 minute in-range.
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T23:59:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-17T00:20:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	assert.InDelta(t, 1.0, r.Totals.AgentMinutes, 1e-9)
+}
+
+func TestAggregate_IntervalsExposedSortedAndContiguous(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// Session "a" has THREE messages in the 10:00-10:05 slot, so buildIntervals
+	// emits TWO contiguous consecutive-pair intervals there: [10:00,10:01) and
+	// [10:01,10:02). The frontend must dedup these by session id. Session "b"
+	// yields one interval [10:01,10:03).
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:01:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "a", Ordinal: 3, Timestamp: "2026-06-16T10:02:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "b", Ordinal: 1, Timestamp: "2026-06-16T10:01:00Z", Role: "user"},
+		{SessionID: "b", Ordinal: 2, Timestamp: "2026-06-16T10:03:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	want := []ReportInterval{
+		{SessionID: "a", Start: "2026-06-16T10:00:00Z", End: "2026-06-16T10:01:00Z"},
+		{SessionID: "a", Start: "2026-06-16T10:01:00Z", End: "2026-06-16T10:02:00Z"},
+		{SessionID: "b", Start: "2026-06-16T10:01:00Z", End: "2026-06-16T10:03:00Z"},
+	}
+	assert.Equal(t, want, r.Intervals,
+		"intervals exposed, sorted by (start,end,session); a's two contiguous "+
+			"intervals are both present so the frontend dedups by session id")
+}
+
+func TestAggregate_IntervalsClippedToEffEnd(t *testing.T) {
+	loc := mustLoad(t, "UTC")
+	start, err := time.Parse(time.RFC3339, "2026-06-16T00:00:00Z")
+	require.NoError(t, err)
+	end := start.AddDate(0, 0, 1)
+	effEnd, err := time.Parse(time.RFC3339, "2026-06-16T12:00:00Z")
+	require.NoError(t, err)
+	p := Params{
+		RangeStart: start, RangeEnd: end, Loc: loc,
+		EffectiveEnd: effEnd, Partial: true,
+		GapCapSeconds: 300, Bucket: BucketSpec{BucketMinute, 300},
+	}
+	// Pair [11:58,12:10): the 12-min gap caps to 5 min -> [11:58,12:03); the clip
+	// to effEnd (12:00) is binding, so the exposed interval ends at 12:00.
+	act := []ActivityEvent{
+		{SessionID: "s1", Ordinal: 1, Timestamp: "2026-06-16T11:58:00Z", Role: "user"},
+		{SessionID: "s1", Ordinal: 2, Timestamp: "2026-06-16T12:10:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	require.True(t, r.Partial)
+	require.Len(t, r.Intervals, 1)
+	assert.Equal(t, "2026-06-16T11:58:00Z", r.Intervals[0].Start)
+	assert.Equal(t, "2026-06-16T12:00:00Z", r.Intervals[0].End,
+		"interval straddling effEnd is clipped to it")
+}
+
+func TestAggregate_OverlapExceedsPeakConcurrency(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// Within the single 5-min slot [10:05,10:10): session a is active
+	// [10:05,10:07) and session b [10:08,10:10). They never overlap in time, so
+	// peak concurrency is 1 -- but TWO distinct sessions overlap the slot. This
+	// is exactly why the popover's "N active" can exceed the bar's max_agents.
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:05:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:07:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "b", Ordinal: 1, Timestamp: "2026-06-16T10:08:00Z", Role: "user"},
+		{SessionID: "b", Ordinal: 2, Timestamp: "2026-06-16T10:10:00Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	assert.Equal(t, 1, r.Peak.Agents, "sessions never overlap in time -> peak concurrency 1")
+	want := []ReportInterval{
+		{SessionID: "a", Start: "2026-06-16T10:05:00Z", End: "2026-06-16T10:07:00Z"},
+		{SessionID: "b", Start: "2026-06-16T10:08:00Z", End: "2026-06-16T10:10:00Z"},
+	}
+	assert.Equal(t, want, r.Intervals,
+		"two distinct sessions overlap the slot though peak concurrency is 1")
+}
+
+func TestAggregate_IntervalsUseSecondResolutionForParity(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// Two messages 0.5s apart yield a sub-second interval. Bounds are exposed at
+	// second resolution (RFC3339) so they stay byte-identical across the
+	// microsecond-resolution PostgreSQL/DuckDB mirrors; finer precision would let
+	// the same session serialize differently per backend. The span therefore
+	// collapses to a point (start == end), which the client places in the slot
+	// containing the instant. See activeSessions.ts.
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00.300Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:00:00.800Z", Role: "assistant", Model: "m1"},
+	}
+	r := Aggregate(p, nil, act, nil)
+	require.Len(t, r.Intervals, 1)
+	assert.Equal(t, "2026-06-16T10:00:00Z", r.Intervals[0].Start)
+	assert.Equal(t, "2026-06-16T10:00:00Z", r.Intervals[0].End,
+		"sub-second bounds collapse to second resolution for cross-backend parity")
+}
+
+func TestAggregate_BucketPeakSplitAtTotalPeakInstant(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// All activity falls in the single 5-min bucket [10:00,10:05). Two AUTOMATED
+	// sessions are both live [10:00,10:01); two INTERACTIVE sessions are both
+	// live [10:02,10:04). Each class independently peaks at 2, but at DIFFERENT
+	// instants, so naively stacking the two independent peaks (2+2=4) would
+	// overstate the true peak of 2. The split is taken at the instant the total
+	// peak first occurs (10:00), where only the two automated sessions are live:
+	// AutomatedAtPeak=2, InteractiveAtPeak=0, summing to MaxAgents=2.
+	act := []ActivityEvent{
+		{SessionID: "a1", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a1", Ordinal: 2, Timestamp: "2026-06-16T10:01:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "a2", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a2", Ordinal: 2, Timestamp: "2026-06-16T10:01:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "i1", Ordinal: 1, Timestamp: "2026-06-16T10:02:00Z", Role: "user"},
+		{SessionID: "i1", Ordinal: 2, Timestamp: "2026-06-16T10:04:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "i2", Ordinal: 1, Timestamp: "2026-06-16T10:02:00Z", Role: "user"},
+		{SessionID: "i2", Ordinal: 2, Timestamp: "2026-06-16T10:04:00Z", Role: "assistant", Model: "m1"},
+	}
+	sessions := []SessionMeta{
+		{SessionID: "a1", Project: "P", Agent: "claude", IsAutomated: true},
+		{SessionID: "a2", Project: "P", Agent: "claude", IsAutomated: true},
+		{SessionID: "i1", Project: "P", Agent: "claude", IsAutomated: false},
+		{SessionID: "i2", Project: "P", Agent: "claude", IsAutomated: false},
+	}
+	r := Aggregate(p, sessions, act, nil)
+
+	b := r.Buckets[120] // [10:00,10:05)
+	assert.Equal(t, 2, b.MaxAgents, "true peak is 2, never the 2+2 independent stack")
+	assert.Equal(t, 2, b.AutomatedAtPeak, "both automated sessions live at the peak instant")
+	assert.Equal(t, 0, b.InteractiveAtPeak, "no interactive session live at the peak instant")
+
+	// Invariant across every bucket: the split sums to the true peak.
+	for i, bk := range r.Buckets {
+		assert.Equalf(t, bk.MaxAgents, bk.AutomatedAtPeak+bk.InteractiveAtPeak,
+			"bucket %d: automated+interactive at-peak must equal max_agents", i)
+	}
+}
+
+func TestAggregate_BreakdownCostAndAutomatedSegments(t *testing.T) {
+	loc := mustLoad(t, "UTC")
+	start := mustStart(t, "2026-06-16T00:00:00Z")
+	end := start.AddDate(0, 0, 1)
+	p := Params{
+		RangeStart: start, RangeEnd: end, Loc: loc,
+		EffectiveEnd: end, Partial: false,
+		GapCapSeconds: 300, Bucket: BucketSpec{BucketMinute, 300},
+	}
+	// ta: timed automated (2 min, cost 1). ti: timed interactive (3 min, cost 2).
+	// ua: UNTIMED automated (no activity, cost 4). All project "P", model "m1".
+	act := []ActivityEvent{
+		{SessionID: "ta", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "ta", Ordinal: 2, Timestamp: "2026-06-16T10:02:00Z", Role: "assistant", Model: "m1"},
+		{SessionID: "ti", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "ti", Ordinal: 2, Timestamp: "2026-06-16T10:03:00Z", Role: "assistant", Model: "m1"},
+	}
+	usage := []UsageRow{
+		{SessionID: "ta", Model: "m1", Timestamp: "2026-06-16T10:00:00Z", OutputTokens: 10, Cost: 1.0, ClaudeMessageID: "ta", ClaudeRequestID: "r"},
+		{SessionID: "ti", Model: "m1", Timestamp: "2026-06-16T10:00:00Z", OutputTokens: 20, Cost: 2.0, ClaudeMessageID: "ti", ClaudeRequestID: "r"},
+		{SessionID: "ua", Model: "m1", Timestamp: "2026-06-16T10:00:00Z", OutputTokens: 40, Cost: 4.0, ClaudeMessageID: "ua", ClaudeRequestID: "r"},
+	}
+	sessions := []SessionMeta{
+		{SessionID: "ta", Project: "P", Agent: "claude", IsAutomated: true},
+		{SessionID: "ti", Project: "P", Agent: "claude", IsAutomated: false},
+		{SessionID: "ua", Project: "P", Agent: "claude", IsAutomated: true},
+	}
+	r := Aggregate(p, sessions, act, usage)
+
+	require.Len(t, r.ByProject, 1)
+	proj := r.ByProject[0]
+	assert.Equal(t, "P", proj.Key)
+	assert.InDelta(t, 5.0, proj.AgentMinutes, 1e-9, "2+3 timed minutes")
+	assert.InDelta(t, 7.0, proj.Cost, 1e-9, "1+2+4 includes the untimed session")
+	assert.InDelta(t, 2.0, proj.AutomatedAgentMinutes, 1e-9)
+	assert.InDelta(t, 3.0, proj.InteractiveAgentMinutes, 1e-9)
+	assert.InDelta(t, 5.0, proj.AutomatedCost, 1e-9, "ta 1 + ua 4")
+	assert.InDelta(t, 2.0, proj.InteractiveCost, 1e-9, "ti 2")
+	assert.InDelta(t, proj.AgentMinutes,
+		proj.AutomatedAgentMinutes+proj.InteractiveAgentMinutes, 1e-9)
+	assert.InDelta(t, proj.Cost, proj.AutomatedCost+proj.InteractiveCost, 1e-9)
+	assert.InDelta(t, r.Totals.Cost, proj.Cost, 1e-9,
+		"cost breakdown sums to total cost; untimed cost is not dropped")
+
+	assert.InDelta(t, 5.0, r.Totals.AgentMinutes, 1e-9)
+	assert.InDelta(t, 2.0, r.Totals.AutomatedAgentMinutes, 1e-9)
+	assert.InDelta(t, 3.0, r.Totals.InteractiveAgentMinutes, 1e-9)
+	assert.InDelta(t, 5.0, r.Totals.AutomatedCost, 1e-9)
+	assert.InDelta(t, 2.0, r.Totals.InteractiveCost, 1e-9)
+
+	autoByID := map[string]bool{}
+	for _, row := range r.BySession {
+		autoByID[row.SessionID] = row.IsAutomated
+	}
+	assert.True(t, autoByID["ta"])
+	assert.False(t, autoByID["ti"])
+	assert.True(t, autoByID["ua"], "untimed automated session keeps its class")
+
+	require.Len(t, r.ByModel, 1)
+	assert.Equal(t, "m1", r.ByModel[0].Key)
+	assert.InDelta(t, 5.0, r.ByModel[0].AgentMinutes, 1e-9)
+	assert.InDelta(t, 7.0, r.ByModel[0].Cost, 1e-9)
+	assert.InDelta(t, 5.0, r.ByModel[0].AutomatedCost, 1e-9)
+	assert.InDelta(t, 2.0, r.ByModel[0].InteractiveCost, 1e-9)
+}

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -511,3 +511,35 @@ func TestAggregate_BreakdownCostAndAutomatedSegments(t *testing.T) {
 	assert.InDelta(t, 5.0, r.ByModel[0].AutomatedCost, 1e-9)
 	assert.InDelta(t, 2.0, r.ByModel[0].InteractiveCost, 1e-9)
 }
+
+// TestAggregate_UsageOnlySessionZeroCostKeepsPrimaryModel confirms a session
+// whose only signal is zero-cost or unpriced usage still reports its known
+// model as the primary. Model weight for usage-only sessions comes from cost,
+// so a zero cost left primary_model blank while models listed the model,
+// showing a known-model session with no model in the table.
+func TestAggregate_UsageOnlySessionZeroCostKeepsPrimaryModel(t *testing.T) {
+	loc := mustLoad(t, "UTC")
+	start := mustStart(t, "2026-06-16T00:00:00Z")
+	end := start.AddDate(0, 0, 1)
+	p := Params{
+		RangeStart: start, RangeEnd: end, Loc: loc,
+		EffectiveEnd: end, Partial: false,
+		GapCapSeconds: 300, Bucket: BucketSpec{BucketMinute, 300},
+	}
+	// One untimed session (no activity events) whose single usage row has a
+	// known model but ZERO cost.
+	usage := []UsageRow{
+		{SessionID: "u", Model: "m1", Timestamp: "2026-06-16T10:00:00Z",
+			OutputTokens: 0, Cost: 0, ClaudeMessageID: "u", ClaudeRequestID: "r"},
+	}
+	sessions := []SessionMeta{
+		{SessionID: "u", Project: "P", Agent: "claude"},
+	}
+	r := Aggregate(p, sessions, nil, usage)
+
+	require.Len(t, r.BySession, 1)
+	row := r.BySession[0]
+	assert.Equal(t, "m1", row.PrimaryModel,
+		"zero-cost usage must still report its known model as primary")
+	assert.Equal(t, []string{"m1"}, row.Models)
+}

--- a/internal/activity/parity_pgtest_test.go
+++ b/internal/activity/parity_pgtest_test.go
@@ -1,0 +1,404 @@
+//go:build pgtest
+
+// This parity test proves that GetActivityReport returns an identical
+// activity.Report from all three storage backends (SQLite, PostgreSQL,
+// DuckDB) given the same underlying data. One SQLite fixture is built, then
+// pushed to PostgreSQL and DuckDB through the production push paths
+// (postgres.Sync / duckdb.Sync). All three stores are queried with the same
+// filter and date and the resulting reports are deep-compared.
+//
+// It lives in internal/activity as an EXTERNAL test package
+// (activity_test) rather than inside any backend package: postgres, duckdb,
+// and db all import activity, so an internal activity test that imported
+// them would form an import cycle. An external _test package is compiled
+// separately and may import all three backends -- activity_test -> {db,
+// postgres, duckdb} -> activity is acyclic. The pgtest build tag keeps it
+// out of the package's default, backend-free test runs.
+package activity_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+	duckdbstore "go.kenn.io/agentsview/internal/duckdb"
+	postgresstore "go.kenn.io/agentsview/internal/postgres"
+)
+
+// parityDate is a calendar day safely in the past relative to any realistic
+// test-run wall clock. A past full day makes activity.Aggregate treat the
+// report as complete (partial=false, effective_end == day_end, as_of=nil),
+// removing the only source of nondeterminism: each backend calls
+// time.Now().UTC() independently, so a current-or-future day could yield
+// microsecond-different as_of/effective_end values across the three reports.
+const parityDate = "2026-06-14"
+
+// paritySchema is dedicated to this test so it never collides with the shared
+// "agentsview" schema that internal/postgres pgtests create and drop. Go runs
+// package tests concurrently, so a shared-schema DROP here could wipe another
+// package's active schema mid-run.
+const paritySchema = "agentsview_daily_report_parity_test"
+
+// parityFixtureSession describes one seeded session and its message stream for
+// the parity fixture. Assistant messages carry token_usage JSON so cost is
+// exercised through the message-source usage path (no usage_events needed).
+type parityFixtureSession struct {
+	id      string
+	project string
+	model   string
+	// events is an ordered (role, RFC3339-timestamp) list. Assistant rows get
+	// token_usage with the given outputTokens so they contribute cost.
+	events       []parityEvent
+	outputTokens int
+}
+
+type parityEvent struct {
+	role string
+	ts   string
+	// model and outputTokens override the session defaults for this one
+	// assistant message. They exist so the fixture can inject an
+	// ineligible (synthetic-model) usage row that every backend must
+	// exclude identically. Zero values mean "use the session defaults".
+	model        string
+	outputTokens int
+}
+
+// parityFixture returns the sessions seeded into every backend. Two sessions
+// overlap on parityDate across two projects and two models (driving peak
+// concurrency 2 and multi-key breakdowns); a third, non-overlapping session
+// adds a second interval to the alpha/model-x rollups so the breakdowns are
+// non-trivial. All timestamps are well inside the day so the report is a full,
+// non-partial day.
+func parityFixture() []parityFixtureSession {
+	return []parityFixtureSession{
+		{
+			id: "parity-a", project: "alpha", model: "model-x",
+			outputTokens: 1200,
+			events: []parityEvent{
+				{role: "user", ts: parityDate + "T10:00:00Z"},
+				{role: "assistant", ts: parityDate + "T10:02:00Z"},
+				{role: "user", ts: parityDate + "T10:05:00Z"},
+				{role: "assistant", ts: parityDate + "T10:07:00Z"},
+			},
+		},
+		{
+			id: "parity-b", project: "beta", model: "model-y",
+			outputTokens: 800,
+			events: []parityEvent{
+				{role: "user", ts: parityDate + "T10:01:00Z"},
+				{role: "assistant", ts: parityDate + "T10:03:00Z"},
+				{role: "user", ts: parityDate + "T10:06:00Z"},
+				{role: "assistant", ts: parityDate + "T10:08:00Z"},
+			},
+		},
+		{
+			id: "parity-c", project: "alpha", model: "model-x",
+			outputTokens: 300,
+			events: []parityEvent{
+				{role: "user", ts: parityDate + "T14:00:00Z"},
+				{role: "assistant", ts: parityDate + "T14:04:00Z"},
+				// Ineligible usage row: a synthetic-model assistant message
+				// carrying real tokens. Every backend's usage union must drop
+				// model == '<synthetic>', so it contributes no cost or output
+				// tokens. If any backend (notably DuckDB, which inlines its own
+				// usage CTE) failed to exclude it, that backend's totals would
+				// diverge and the deep-compare below would fail.
+				{role: "assistant", ts: parityDate + "T14:06:00Z",
+					model: "<synthetic>", outputTokens: 9999},
+			},
+		},
+	}
+}
+
+// seedParitySQLite builds the SQLite fixture: pricing rows for the two models
+// plus the sessions and messages from parityFixture, all written through the
+// public WriteSessionBatchAtomic path so the data matches what a real sync
+// would push.
+func seedParitySQLite(t *testing.T) *db.DB {
+	t.Helper()
+	local, err := db.Open(filepath.Join(t.TempDir(), "parity.sqlite"))
+	require.NoError(t, err, "opening sqlite fixture")
+	t.Cleanup(func() { require.NoError(t, local.Close()) })
+
+	// Explicit pricing for both models so all three backends price the same
+	// token amounts identically (the syncs copy model_pricing to PG/DuckDB).
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{
+		{ModelPattern: "model-x", InputPerMTok: 3, OutputPerMTok: 15,
+			CacheCreationPerMTok: 3.75, CacheReadPerMTok: 0.3},
+		{ModelPattern: "model-y", InputPerMTok: 1, OutputPerMTok: 5,
+			CacheCreationPerMTok: 1.25, CacheReadPerMTok: 0.1},
+	}), "seeding pricing")
+
+	var writes []db.SessionBatchWrite
+	for _, fs := range parityFixture() {
+		writes = append(writes, paritySessionWrite(fs))
+	}
+	_, err = local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err, "writing fixture sessions")
+	return local
+}
+
+// paritySessionWrite turns one fixture session into a SessionBatchWrite. The
+// session window spans its first and last event; assistant messages carry the
+// model and token_usage so they feed the usage path.
+func paritySessionWrite(fs parityFixtureSession) db.SessionBatchWrite {
+	first := fs.events[0].ts
+	last := fs.events[len(fs.events)-1].ts
+	firstMsg := "parity " + fs.id
+	sess := db.Session{
+		ID:               fs.id,
+		Project:          fs.project,
+		Machine:          "local",
+		Agent:            "claude",
+		FirstMessage:     &firstMsg,
+		StartedAt:        &first,
+		EndedAt:          &last,
+		CreatedAt:        first,
+		LocalModifiedAt:  &first,
+		MessageCount:     len(fs.events),
+		UserMessageCount: 1,
+		RelationshipType: "root",
+		DataVersion:      1,
+	}
+	msgs := make([]db.Message, 0, len(fs.events))
+	for i, ev := range fs.events {
+		m := db.Message{
+			SessionID:     fs.id,
+			Ordinal:       i,
+			Role:          ev.role,
+			Content:       ev.role + " " + fs.id,
+			Timestamp:     ev.ts,
+			ContentLength: len(ev.role + " " + fs.id),
+		}
+		if ev.role == "assistant" {
+			model := fs.model
+			if ev.model != "" {
+				model = ev.model
+			}
+			outputTokens := fs.outputTokens
+			if ev.outputTokens != 0 {
+				outputTokens = ev.outputTokens
+			}
+			m.Model = model
+			usage, _ := json.Marshal(map[string]int{
+				"input_tokens":  outputTokens / 2,
+				"output_tokens": outputTokens,
+			})
+			m.TokenUsage = usage
+			m.OutputTokens = outputTokens
+			m.HasOutputTokens = true
+		}
+		msgs = append(msgs, m)
+	}
+	return db.SessionBatchWrite{
+		Session:         sess,
+		Messages:        msgs,
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}
+}
+
+// pushParityPostgres pushes the SQLite fixture to PostgreSQL via the production
+// Sync and returns a read-only PG store over the same database. The schema is
+// dropped before and after so the test is self-contained.
+func pushParityPostgres(
+	t *testing.T, ctx context.Context, local *db.DB,
+) *postgresstore.Store {
+	t.Helper()
+	pgURL := os.Getenv("TEST_PG_URL")
+	if pgURL == "" {
+		t.Skip("TEST_PG_URL not set; skipping cross-backend parity test")
+	}
+	dropParitySchema(t, pgURL)
+	t.Cleanup(func() { dropParitySchema(t, pgURL) })
+
+	ps, err := postgresstore.New(
+		pgURL, paritySchema, local, "parity-machine", true,
+		postgresstore.SyncOptions{},
+	)
+	require.NoError(t, err, "creating pg sync")
+	t.Cleanup(func() { require.NoError(t, ps.Close()) })
+	require.NoError(t, ps.EnsureSchema(ctx), "ensuring pg schema")
+
+	res, err := ps.Push(ctx, false, nil)
+	require.NoError(t, err, "pushing to pg")
+	require.Equal(t, len(parityFixture()), res.SessionsPushed,
+		"pg sessions pushed")
+
+	store, err := postgresstore.NewStore(pgURL, paritySchema, true)
+	require.NoError(t, err, "opening pg store")
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store
+}
+
+// dropParitySchema removes the PG schema so each run starts clean.
+func dropParitySchema(t *testing.T, pgURL string) {
+	t.Helper()
+	store, err := postgresstore.NewStore(pgURL, paritySchema, true)
+	require.NoError(t, err, "opening pg for schema drop")
+	defer func() { require.NoError(t, store.Close()) }()
+	_, _ = store.DB().Exec("DROP SCHEMA IF EXISTS " + paritySchema + " CASCADE")
+}
+
+// pushParityDuckDB pushes the SQLite fixture to a DuckDB mirror via the
+// production Sync and returns a read-only DuckDB store over the same
+// connection.
+func pushParityDuckDB(
+	t *testing.T, ctx context.Context, local *db.DB,
+) *duckdbstore.Store {
+	t.Helper()
+	target := filepath.Join(t.TempDir(), "parity.duckdb")
+	syncer, err := duckdbstore.New(
+		target, local, "parity-machine", duckdbstore.SyncOptions{})
+	require.NoError(t, err, "creating duckdb sync")
+	t.Cleanup(func() { require.NoError(t, syncer.Close()) })
+
+	res, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "pushing to duckdb")
+	require.Equal(t, len(parityFixture()), res.SessionsPushed,
+		"duckdb sessions pushed")
+
+	return duckdbstore.NewStoreFromDB(syncer.DB())
+}
+
+// canonicalizeReport sorts the report's order-unspecified slices by a stable
+// key so the deep comparison is order-independent. ByProject/ByModel/ByAgent
+// are already minutes-then-key sorted by the aggregator, but resorting purely
+// by Key guards against any backend-introduced ordering difference among equal
+// minutes. BySession is minutes-desc from the aggregator; we resort by
+// SessionID so equal-minute ties cannot diverge across backends. Intervals
+// needs no canonicalization: Aggregate already sorts it by (start, end,
+// sessionID), a total order with no cross-backend ties to break.
+func canonicalizeReport(r *activity.Report) {
+	sort.Slice(r.ByProject, func(i, j int) bool {
+		return r.ByProject[i].Key < r.ByProject[j].Key
+	})
+	sort.Slice(r.ByModel, func(i, j int) bool {
+		return r.ByModel[i].Key < r.ByModel[j].Key
+	})
+	sort.Slice(r.ByAgent, func(i, j int) bool {
+		return r.ByAgent[i].Key < r.ByAgent[j].Key
+	})
+	sort.Slice(r.BySession, func(i, j int) bool {
+		return r.BySession[i].SessionID < r.BySession[j].SessionID
+	})
+}
+
+// TestGetActivityReportParityAcrossBackends builds one fixture, loads it into
+// all three backends through their production push paths, and asserts the three
+// GetActivityReport results are byte-for-byte equal after canonicalizing the
+// order-unspecified slices. It sweeps several ranges and bucket policies --
+// minute, hourly, daily-calendar, a custom sub-day window, and a DST-spanning NY
+// month -- so the parity guarantee covers every bucketing path, not just one
+// day. Each case resolves against a fixed far-future now so the range is always
+// complete (non-partial) and every backend's report is deterministic regardless
+// of wall clock.
+func TestGetActivityReportParityAcrossBackends(t *testing.T) {
+	ctx := context.Background()
+	local := seedParitySQLite(t)
+
+	// Materialize PG first: it skips the whole test when TEST_PG_URL is unset,
+	// so we avoid building the DuckDB mirror needlessly on a skip.
+	pgStore := pushParityPostgres(t, ctx, local)
+	duckStore := pushParityDuckDB(t, ctx, local)
+
+	fixedNow, err := time.Parse(time.RFC3339, "2030-01-01T00:00:00Z")
+	require.NoError(t, err, "parsing fixed now")
+
+	cases := []struct {
+		name  string
+		input activity.QueryInput
+	}{
+		// A single past day -> minute (5m) buckets; carries the full fixture
+		// activity and the fixture-sanity assertions below.
+		{"day-minute", activity.QueryInput{
+			Preset: "day", Date: parityDate, Timezone: "UTC"}},
+		// A 3-day range -> hourly buckets.
+		{"three-day-hourly", activity.QueryInput{
+			Preset: "custom", Timezone: "UTC",
+			From: "2026-06-12T00:00:00Z", To: "2026-06-15T00:00:00Z"}},
+		// A 30-day range -> daily calendar buckets.
+		{"thirty-day-daily", activity.QueryInput{
+			Preset: "custom", Timezone: "UTC",
+			From: "2026-05-16T00:00:00Z", To: "2026-06-15T00:00:00Z"}},
+		// A custom sub-day window that slices into the fixture's morning.
+		{"custom-subday", activity.QueryInput{
+			Preset: "custom", Timezone: "UTC",
+			From: parityDate + "T09:30:00Z", To: parityDate + "T15:00:00Z"}},
+		// A NY month spanning the March 8 2026 DST transition. The fixture has
+		// no March activity, so this asserts every backend produces identical
+		// empty aggregation over identical DST-aware calendar bucket boundaries.
+		{"dst-month-ny", activity.QueryInput{
+			Preset: "month", Date: "2026-03-14", Timezone: "America/New_York"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q, err := activity.ResolveQuery(tc.input, fixedNow)
+			require.NoError(t, err, "resolving query")
+			filter := db.AnalyticsFilter{Timezone: tc.input.Timezone}
+
+			sqliteReport := assertParityForCase(t, ctx, q, filter,
+				local, pgStore, duckStore)
+
+			if tc.name == "day-minute" {
+				assertDayMinuteFixtureSanity(t, sqliteReport)
+			}
+		})
+	}
+}
+
+// assertParityForCase queries all three backends with the resolved query and
+// filter, asserts the range is complete, deep-compares the canonicalized
+// reports (SQLite==PG and SQLite==DuckDB), and returns the canonicalized SQLite
+// report so the caller can run case-specific fixture assertions on it.
+func assertParityForCase(
+	t *testing.T, ctx context.Context, q activity.Query,
+	filter db.AnalyticsFilter,
+	local *db.DB, pgStore *postgresstore.Store, duckStore *duckdbstore.Store,
+) activity.Report {
+	t.Helper()
+
+	sqliteReport, err := local.GetActivityReport(ctx, filter, q)
+	require.NoError(t, err, "sqlite GetActivityReport")
+	pgReport, err := pgStore.GetActivityReport(ctx, filter, q)
+	require.NoError(t, err, "pg GetActivityReport")
+	duckReport, err := duckStore.GetActivityReport(ctx, filter, q)
+	require.NoError(t, err, "duckdb GetActivityReport")
+
+	require.False(t, sqliteReport.Partial, "past range must be complete")
+
+	canonicalizeReport(&sqliteReport)
+	canonicalizeReport(&pgReport)
+	canonicalizeReport(&duckReport)
+
+	require.Equal(t, sqliteReport, pgReport,
+		"SQLite and PostgreSQL activity reports diverge")
+	require.Equal(t, sqliteReport, duckReport,
+		"SQLite and DuckDB activity reports diverge")
+	return sqliteReport
+}
+
+// assertDayMinuteFixtureSanity checks the day-minute report actually exercises
+// the fixture: a full day with peak concurrency 2, three sessions, non-zero
+// cost, and exactly 4300 output tokens. The token total proves the synthetic
+// model usage row (9999 tokens) is excluded by the eligibility filter -- not
+// merely that the backends agree on a wrong number -- so the deep-compare above
+// extends that exclusion guarantee to PG and DuckDB.
+func assertDayMinuteFixtureSanity(t *testing.T, r activity.Report) {
+	t.Helper()
+	require.False(t, r.Partial, "fixture day must be a full day")
+	require.Equal(t, 2, r.Peak.Agents, "fixture must reach peak concurrency 2")
+	require.Equal(t, 3, r.Totals.Sessions, "fixture session count")
+	require.Greater(t, r.Totals.Cost, 0.0, "fixture must exercise cost")
+	require.Equal(t, 4300, r.Totals.OutputTokens,
+		"synthetic-model usage row must be excluded from the totals")
+}

--- a/internal/activity/parity_pgtest_test.go
+++ b/internal/activity/parity_pgtest_test.go
@@ -69,14 +69,23 @@ type parityEvent struct {
 	// exclude identically. Zero values mean "use the session defaults".
 	model        string
 	outputTokens int
+	// claudeMessageID/claudeRequestID set the message's Claude dedup keys.
+	// When the same pair recurs across sessions the usage union dedups to a
+	// single first-seen-wins row, exercising the cross-backend ordering of
+	// duplicate usage rows.
+	claudeMessageID string
+	claudeRequestID string
 }
 
 // parityFixture returns the sessions seeded into every backend. Two sessions
 // overlap on parityDate across two projects and two models (driving peak
 // concurrency 2 and multi-key breakdowns); a third, non-overlapping session
 // adds a second interval to the alpha/model-x rollups so the breakdowns are
-// non-trivial. All timestamps are well inside the day so the report is a full,
-// non-partial day.
+// non-trivial. Three more untimed sessions exercise the usage edge cases the
+// dedup/primary-model fixes touched: a resumed/forked pair (parity-d/parity-e)
+// sharing one Claude dedup key in the same second (whole-second vs fractional),
+// and a zero-cost known-model session (parity-f). All timestamps are well
+// inside the day so the report is a full, non-partial day.
 func parityFixture() []parityFixtureSession {
 	return []parityFixtureSession{
 		{
@@ -113,6 +122,39 @@ func parityFixture() []parityFixtureSession {
 				// diverge and the deep-compare below would fail.
 				{role: "assistant", ts: parityDate + "T14:06:00Z",
 					model: "<synthetic>", outputTokens: 9999},
+			},
+		},
+		{
+			// Resumed/forked dedup pair: parity-d and parity-e share one
+			// (claude_message_id, claude_request_id) in the same second, one
+			// whole-second instant and one fractional. First-seen-wins dedup
+			// keeps the earlier whole-second row (500 tokens) on every backend;
+			// the later fractional duplicate (9000) is dropped. A text sort of
+			// the timestamp would invert them ('.' < 'Z'), so this guards the
+			// parsed-instant ordering across backends.
+			id: "parity-d", project: "gamma", model: "model-x",
+			outputTokens: 500,
+			events: []parityEvent{
+				{role: "assistant", ts: parityDate + "T11:00:00Z",
+					claudeMessageID: "dup-m", claudeRequestID: "dup-r"},
+			},
+		},
+		{
+			id: "parity-e", project: "gamma", model: "model-x",
+			outputTokens: 9000,
+			events: []parityEvent{
+				{role: "assistant", ts: parityDate + "T11:00:00.123Z",
+					claudeMessageID: "dup-m", claudeRequestID: "dup-r"},
+			},
+		},
+		{
+			// Zero-cost usage-only session: a single known-model assistant
+			// message with zero tokens (zero cost). Every backend must still
+			// report model-x as the primary model rather than a blank one.
+			id: "parity-f", project: "delta", model: "model-x",
+			outputTokens: 0,
+			events: []parityEvent{
+				{role: "assistant", ts: parityDate + "T12:00:00Z"},
 			},
 		},
 	}
@@ -177,6 +219,12 @@ func paritySessionWrite(fs parityFixtureSession) db.SessionBatchWrite {
 			Content:       ev.role + " " + fs.id,
 			Timestamp:     ev.ts,
 			ContentLength: len(ev.role + " " + fs.id),
+		}
+		if ev.claudeMessageID != "" {
+			m.ClaudeMessageID = ev.claudeMessageID
+		}
+		if ev.claudeRequestID != "" {
+			m.ClaudeRequestID = ev.claudeRequestID
 		}
 		if ev.role == "assistant" {
 			model := fs.model
@@ -388,17 +436,35 @@ func assertParityForCase(
 }
 
 // assertDayMinuteFixtureSanity checks the day-minute report actually exercises
-// the fixture: a full day with peak concurrency 2, three sessions, non-zero
-// cost, and exactly 4300 output tokens. The token total proves the synthetic
-// model usage row (9999 tokens) is excluded by the eligibility filter -- not
-// merely that the backends agree on a wrong number -- so the deep-compare above
-// extends that exclusion guarantee to PG and DuckDB.
+// the fixture: a full day with peak concurrency 2, six sessions, non-zero cost,
+// and exactly 4800 output tokens. The token total proves the synthetic-model
+// usage row (9999 tokens) is excluded and the dedup pair collapses to its
+// earlier 500-token row -- not merely that the backends agree on a wrong number
+// -- so the deep-compare above extends those guarantees, plus the zero-cost
+// primary-model fallback, to PG and DuckDB.
 func assertDayMinuteFixtureSanity(t *testing.T, r activity.Report) {
 	t.Helper()
 	require.False(t, r.Partial, "fixture day must be a full day")
 	require.Equal(t, 2, r.Peak.Agents, "fixture must reach peak concurrency 2")
-	require.Equal(t, 3, r.Totals.Sessions, "fixture session count")
+	require.Equal(t, 6, r.Totals.Sessions, "fixture session count")
 	require.Greater(t, r.Totals.Cost, 0.0, "fixture must exercise cost")
-	require.Equal(t, 4300, r.Totals.OutputTokens,
-		"synthetic-model usage row must be excluded from the totals")
+	// 2400 (parity-a) + 1600 (parity-b) + 300 (parity-c; synthetic 9999 row
+	// excluded) + 500 (parity-d wins the dedup) + 0 (parity-e deduped away;
+	// parity-f zero-cost) = 4800.
+	require.Equal(t, 4800, r.Totals.OutputTokens,
+		"synthetic row excluded and the dedup pair collapses to its earlier row")
+
+	bySession := map[string]activity.SessionRow{}
+	for _, s := range r.BySession {
+		bySession[s.SessionID] = s
+	}
+	require.Contains(t, bySession, "parity-d")
+	require.Contains(t, bySession, "parity-e")
+	require.Contains(t, bySession, "parity-f")
+	require.Equal(t, 500, bySession["parity-d"].OutputTokens,
+		"dedup keeps the earlier whole-second duplicate's tokens")
+	require.Equal(t, 0, bySession["parity-e"].OutputTokens,
+		"the later fractional duplicate is dropped")
+	require.Equal(t, "model-x", bySession["parity-f"].PrimaryModel,
+		"zero-cost usage still reports its known model as primary")
 }

--- a/internal/activity/query.go
+++ b/internal/activity/query.go
@@ -1,0 +1,276 @@
+package activity
+
+import (
+	"fmt"
+	"time"
+)
+
+// BucketUnit names the calendar/clock unit a timeline bucket spans.
+type BucketUnit string
+
+const (
+	BucketMinute BucketUnit = "minute"
+	BucketHour   BucketUnit = "hour"
+	BucketDay    BucketUnit = "day"
+	BucketWeek   BucketUnit = "week"
+)
+
+// BucketSpec is a resolved bucket size: its unit plus the nominal number of
+// seconds one bucket spans (calendar buckets may deviate per DST).
+type BucketSpec struct {
+	Unit           BucketUnit
+	NominalSeconds int
+}
+
+// QueryInput is the raw, request-level description of a range to report on.
+type QueryInput struct {
+	Preset         string // "day" | "week" | "month" | "custom" | ""
+	Date           string // YYYY-MM-DD for presets
+	From           string // RFC3339 for custom ranges
+	To             string // RFC3339 for custom ranges
+	Timezone       string
+	BucketOverride string // "", "5m", "15m", "1h", "1d", "1w"
+}
+
+// Query is a fully resolved range: its timezone, UTC bounds, the effective end
+// after clamping to now, the selected bucket size, and the idle-gap cap.
+type Query struct {
+	Timezone      string
+	Loc           *time.Location
+	RangeStart    time.Time
+	RangeEnd      time.Time
+	EffectiveEnd  time.Time
+	Partial       bool
+	Bucket        BucketSpec
+	GapCapSeconds float64
+}
+
+// BucketWindow is a half-open [Start, End) timeline bucket; bounds are UTC.
+type BucketWindow struct {
+	Start time.Time
+	End   time.Time
+}
+
+const (
+	maxRange      = 365 * 24 * time.Hour
+	maxBuckets    = 2000
+	defaultGapCap = 300.0
+)
+
+// ResolveQuery turns a raw QueryInput into a fully resolved Query, expanding
+// presets in the requested timezone, validating the range, clamping the
+// effective end to now, and selecting (and bounding) the bucket size.
+func ResolveQuery(input QueryInput, now time.Time) (Query, error) {
+	loc, err := loadLocation(input.Timezone)
+	if err != nil {
+		return Query{}, err
+	}
+	start, end, err := resolveRange(input, loc, now)
+	if err != nil {
+		return Query{}, err
+	}
+	if !start.Before(end) {
+		return Query{}, fmt.Errorf("from must be before to")
+	}
+	if end.Sub(start) > maxRange {
+		return Query{}, fmt.Errorf("range exceeds maximum of one year")
+	}
+	bucket, err := ResolveBucket(start, end, input.BucketOverride, loc)
+	if err != nil {
+		return Query{}, err
+	}
+	windows, err := BuildBuckets(start, end, bucket, loc)
+	if err != nil {
+		return Query{}, err
+	}
+	if len(windows) > maxBuckets {
+		return Query{}, fmt.Errorf("bucket configuration would produce too many buckets")
+	}
+	nowUTC := now.UTC()
+	return Query{
+		Timezone:      input.Timezone,
+		Loc:           loc,
+		RangeStart:    start,
+		RangeEnd:      end,
+		EffectiveEnd:  maxTime(start, minTime(end, nowUTC)),
+		Partial:       nowUTC.Before(end),
+		Bucket:        bucket,
+		GapCapSeconds: defaultGapCap,
+	}, nil
+}
+
+// loadLocation resolves an IANA timezone name; empty and "UTC" map to time.UTC.
+func loadLocation(tz string) (*time.Location, error) {
+	if tz == "" || tz == "UTC" {
+		return time.UTC, nil
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timezone: %s", tz)
+	}
+	return loc, nil
+}
+
+// resolveRange picks the UTC [start, end) bounds for the input, expanding a
+// preset in loc or parsing the custom From/To instants. An empty request
+// defaults to the day preset, and a preset with an empty Date defaults to
+// today in loc, so ResolveQuery(QueryInput{}, now) resolves the current day.
+func resolveRange(
+	input QueryInput, loc *time.Location, now time.Time,
+) (time.Time, time.Time, error) {
+	preset := input.Preset
+	if preset == "" && input.From == "" && input.To == "" {
+		preset = "day"
+	}
+	if preset == "custom" {
+		return parseCustomRange(input)
+	}
+	date := input.Date
+	if date == "" {
+		date = now.In(loc).Format("2006-01-02")
+	}
+	return expandPreset(preset, date, loc)
+}
+
+// parseCustomRange parses the RFC3339 From/To bounds; both are required.
+func parseCustomRange(input QueryInput) (time.Time, time.Time, error) {
+	if input.From == "" || input.To == "" {
+		return time.Time{}, time.Time{}, fmt.Errorf("custom range requires both from and to")
+	}
+	from, err := time.Parse(time.RFC3339, input.From)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid from: %s", input.From)
+	}
+	to, err := time.Parse(time.RFC3339, input.To)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid to: %s", input.To)
+	}
+	return from.UTC(), to.UTC(), nil
+}
+
+// expandPreset expands a day/week/month preset anchored at Date into UTC
+// bounds, walking calendar units in loc so DST shifts are reflected.
+func expandPreset(preset, date string, loc *time.Location) (time.Time, time.Time, error) {
+	d, err := time.ParseInLocation("2006-01-02", date, loc)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid date: %s", date)
+	}
+	switch preset {
+	case "day":
+		return d.UTC(), d.AddDate(0, 0, 1).UTC(), nil
+	case "week":
+		monday := d.AddDate(0, 0, -isoMondayOffset(d.Weekday()))
+		return monday.UTC(), monday.AddDate(0, 0, 7).UTC(), nil
+	case "month":
+		first := time.Date(d.Year(), d.Month(), 1, 0, 0, 0, 0, loc)
+		return first.UTC(), first.AddDate(0, 1, 0).UTC(), nil
+	default:
+		return time.Time{}, time.Time{}, fmt.Errorf("invalid preset: %s", preset)
+	}
+}
+
+// isoMondayOffset is the number of days from the ISO Monday of the week
+// containing wd to wd itself (Mon=0, Tue=1, ..., Sun=6).
+func isoMondayOffset(wd time.Weekday) int {
+	return (int(wd) + 6) % 7
+}
+
+// ResolveBucket selects a bucket size for [start, end). An empty override
+// applies the duration-based auto policy; otherwise the allow-list is consulted.
+func ResolveBucket(start, end time.Time, override string, _ *time.Location) (BucketSpec, error) {
+	if override != "" {
+		return bucketFromOverride(override)
+	}
+	switch d := end.Sub(start); {
+	case d <= 36*time.Hour:
+		return BucketSpec{BucketMinute, 300}, nil
+	case d <= 14*24*time.Hour:
+		return BucketSpec{BucketHour, 3600}, nil
+	case d <= 90*24*time.Hour:
+		return BucketSpec{BucketDay, 86400}, nil
+	default:
+		return BucketSpec{BucketWeek, 604800}, nil
+	}
+}
+
+// bucketFromOverride maps an allow-listed override string to a BucketSpec.
+func bucketFromOverride(override string) (BucketSpec, error) {
+	switch override {
+	case "5m":
+		return BucketSpec{BucketMinute, 300}, nil
+	case "15m":
+		return BucketSpec{BucketMinute, 900}, nil
+	case "1h":
+		return BucketSpec{BucketHour, 3600}, nil
+	case "1d":
+		return BucketSpec{BucketDay, 86400}, nil
+	case "1w":
+		return BucketSpec{BucketWeek, 604800}, nil
+	default:
+		return BucketSpec{}, fmt.Errorf("invalid bucket: %s", override)
+	}
+}
+
+// BuildBuckets tiles [start, end) into half-open UTC windows for spec. Minute
+// and hour buckets are fixed-duration; day and week buckets follow local
+// calendar boundaries in loc so they absorb DST shifts.
+func BuildBuckets(start, end time.Time, spec BucketSpec, loc *time.Location) ([]BucketWindow, error) {
+	switch spec.Unit {
+	case BucketMinute, BucketHour:
+		return fixedBuckets(start, end, time.Duration(spec.NominalSeconds)*time.Second), nil
+	case BucketDay:
+		return calendarBuckets(start, end, loc, 1), nil
+	case BucketWeek:
+		return calendarBuckets(start, end, loc, 7), nil
+	default:
+		return nil, fmt.Errorf("invalid bucket unit: %s", spec.Unit)
+	}
+}
+
+// fixedBuckets tiles [start, end) into windows of a constant duration anchored
+// at start; the final window is clipped to end and may be shorter than step.
+func fixedBuckets(start, end time.Time, step time.Duration) []BucketWindow {
+	if step <= 0 || !start.Before(end) {
+		return nil
+	}
+	var out []BucketWindow
+	for bStart := start; bStart.Before(end); bStart = bStart.Add(step) {
+		bEnd := minTime(bStart.Add(step), end)
+		out = append(out, BucketWindow{Start: bStart, End: bEnd})
+	}
+	return out
+}
+
+// calendarBuckets tiles [start, end) into local calendar windows of stepDays
+// days each, anchored at the local midnight (ISO Monday for weeks) at or before
+// start. The first Start is clipped up to start and the last End down to end.
+func calendarBuckets(start, end time.Time, loc *time.Location, stepDays int) []BucketWindow {
+	if !start.Before(end) {
+		return nil
+	}
+	local := localMidnight(start, loc)
+	if stepDays == 7 {
+		local = local.AddDate(0, 0, -isoMondayOffset(local.Weekday()))
+	}
+	var out []BucketWindow
+	for {
+		next := local.AddDate(0, 0, stepDays)
+		bStart := maxTime(local.UTC(), start)
+		bEnd := minTime(next.UTC(), end)
+		if bEnd.After(bStart) {
+			out = append(out, BucketWindow{Start: bStart, End: bEnd})
+		}
+		if !next.UTC().Before(end) {
+			break
+		}
+		local = next
+	}
+	return out
+}
+
+// localMidnight returns the local 00:00 wall time on the calendar day that
+// contains t in loc.
+func localMidnight(t time.Time, loc *time.Location) time.Time {
+	l := t.In(loc)
+	return time.Date(l.Year(), l.Month(), l.Day(), 0, 0, 0, 0, loc)
+}

--- a/internal/activity/query_test.go
+++ b/internal/activity/query_test.go
@@ -1,0 +1,249 @@
+package activity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loc(t *testing.T, name string) *time.Location {
+	t.Helper()
+	l, err := time.LoadLocation(name)
+	require.NoError(t, err)
+	return l
+}
+
+func mustRFC3339(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return ts.UTC()
+}
+
+func TestResolveQuery_PresetDayUTC(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	q, err := ResolveQuery(QueryInput{Preset: "day", Date: "2026-06-16", Timezone: "UTC"}, now)
+	require.NoError(t, err)
+	assert.Equal(t, mustRFC3339(t, "2026-06-16T00:00:00Z"), q.RangeStart)
+	assert.Equal(t, mustRFC3339(t, "2026-06-17T00:00:00Z"), q.RangeEnd)
+	assert.Equal(t, BucketMinute, q.Bucket.Unit)
+	assert.Equal(t, 300, q.Bucket.NominalSeconds)
+	assert.False(t, q.Partial, "past day is complete")
+	assert.Equal(t, q.RangeEnd, q.EffectiveEnd, "complete day clamps to range_end")
+	assert.InDelta(t, 300.0, q.GapCapSeconds, 0)
+}
+
+func TestResolveQuery_EmptyInputDefaultsToToday(t *testing.T) {
+	now := mustRFC3339(t, "2026-06-17T09:30:00Z")
+	q, err := ResolveQuery(QueryInput{}, now)
+	require.NoError(t, err)
+	assert.Equal(t, mustRFC3339(t, "2026-06-17T00:00:00Z"), q.RangeStart)
+	assert.Equal(t, mustRFC3339(t, "2026-06-18T00:00:00Z"), q.RangeEnd)
+	assert.Equal(t, BucketMinute, q.Bucket.Unit, "empty input defaults to the day preset")
+}
+
+func TestResolveQuery_PresetWeekISOMonday(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	// 2026-06-17 is a Wednesday; ISO week starts Monday 2026-06-15.
+	q, err := ResolveQuery(QueryInput{Preset: "week", Date: "2026-06-17", Timezone: "UTC"}, now)
+	require.NoError(t, err)
+	assert.Equal(t, mustRFC3339(t, "2026-06-15T00:00:00Z"), q.RangeStart)
+	assert.Equal(t, mustRFC3339(t, "2026-06-22T00:00:00Z"), q.RangeEnd)
+	assert.Equal(t, BucketHour, q.Bucket.Unit, "7d range auto-buckets hourly")
+}
+
+func TestResolveQuery_PresetMonthUTC(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	q, err := ResolveQuery(QueryInput{Preset: "month", Date: "2026-02-14", Timezone: "UTC"}, now)
+	require.NoError(t, err)
+	assert.Equal(t, mustRFC3339(t, "2026-02-01T00:00:00Z"), q.RangeStart)
+	assert.Equal(t, mustRFC3339(t, "2026-03-01T00:00:00Z"), q.RangeEnd)
+	assert.Equal(t, BucketDay, q.Bucket.Unit, "28d range auto-buckets daily")
+}
+
+func TestResolveQuery_PresetDayDSTSpringForward(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	// America/New_York springs forward 2026-03-08: local day is 23h.
+	q, err := ResolveQuery(QueryInput{Preset: "day", Date: "2026-03-08", Timezone: "America/New_York"}, now)
+	require.NoError(t, err)
+	assert.Equal(t, 23*time.Hour, q.RangeEnd.Sub(q.RangeStart), "spring-forward day is 23h")
+}
+
+func TestResolveQuery_PresetDayDSTFallBack(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	// America/New_York falls back 2026-11-01: local day is 25h.
+	q, err := ResolveQuery(QueryInput{Preset: "day", Date: "2026-11-01", Timezone: "America/New_York"}, now)
+	require.NoError(t, err)
+	assert.Equal(t, 25*time.Hour, q.RangeEnd.Sub(q.RangeStart), "fall-back day is 25h")
+}
+
+func TestResolveQuery_MonthSpanningDST(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	// March 2026 in New York spans the spring-forward; month is 31 calendar
+	// days but one hour short of 31*24h.
+	q, err := ResolveQuery(QueryInput{Preset: "month", Date: "2026-03-10", Timezone: "America/New_York"}, now)
+	require.NoError(t, err)
+	assert.Equal(t, 31*24*time.Hour-time.Hour, q.RangeEnd.Sub(q.RangeStart),
+		"March in NY is 31 days minus the lost DST hour")
+}
+
+func TestResolveBucket_Thresholds(t *testing.T) {
+	l := time.UTC
+	start := mustRFC3339(t, "2026-06-01T00:00:00Z")
+	cases := []struct {
+		name string
+		dur  time.Duration
+		unit BucketUnit
+		secs int
+	}{
+		{"exactly 36h is minute", 36 * time.Hour, BucketMinute, 300},
+		{"just over 36h is hour", 36*time.Hour + time.Second, BucketHour, 3600},
+		{"exactly 14d is hour", 14 * 24 * time.Hour, BucketHour, 3600},
+		{"just over 14d is day", 14*24*time.Hour + time.Second, BucketDay, 86400},
+		{"exactly 90d is day", 90 * 24 * time.Hour, BucketDay, 86400},
+		{"just over 90d is week", 90*24*time.Hour + time.Second, BucketWeek, 604800},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, err := ResolveBucket(start, start.Add(tc.dur), "", l)
+			require.NoError(t, err)
+			assert.Equal(t, tc.unit, spec.Unit)
+			assert.Equal(t, tc.secs, spec.NominalSeconds)
+		})
+	}
+}
+
+func TestResolveBucket_OverrideAllowList(t *testing.T) {
+	l := time.UTC
+	start := mustRFC3339(t, "2026-06-01T00:00:00Z")
+	end := start.Add(48 * time.Hour)
+	ok := map[string]BucketSpec{
+		"5m":  {BucketMinute, 300},
+		"15m": {BucketMinute, 900},
+		"1h":  {BucketHour, 3600},
+		"1d":  {BucketDay, 86400},
+		"1w":  {BucketWeek, 604800},
+	}
+	for k, want := range ok {
+		spec, err := ResolveBucket(start, end, k, l)
+		require.NoErrorf(t, err, "override %q", k)
+		assert.Equalf(t, want, spec, "override %q", k)
+	}
+	_, err := ResolveBucket(start, end, "2h", l)
+	require.Error(t, err, "off-allow-list override is rejected")
+}
+
+func TestResolveQuery_BucketCountCap(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	// 5m buckets over a full year is ~105k buckets > 2000.
+	_, err := ResolveQuery(QueryInput{
+		Preset: "custom", Timezone: "UTC",
+		From: "2026-01-01T00:00:00Z", To: "2026-12-31T00:00:00Z",
+		BucketOverride: "5m",
+	}, now)
+	require.Error(t, err, "5m over a year exceeds the 2000-bucket cap")
+}
+
+func TestResolveQuery_MaxRangeOneYear(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	_, err := ResolveQuery(QueryInput{
+		Preset: "custom", Timezone: "UTC",
+		From: "2026-01-01T00:00:00Z", To: "2027-01-02T00:00:00Z",
+	}, now)
+	require.Error(t, err, "range over one year is rejected")
+}
+
+func TestResolveQuery_FromAfterToRejected(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	_, err := ResolveQuery(QueryInput{
+		Preset: "custom", Timezone: "UTC",
+		From: "2026-06-02T00:00:00Z", To: "2026-06-01T00:00:00Z",
+	}, now)
+	require.Error(t, err, "from >= to is rejected")
+	_, err = ResolveQuery(QueryInput{
+		Preset: "custom", Timezone: "UTC",
+		From: "2026-06-01T00:00:00Z", To: "2026-06-01T00:00:00Z",
+	}, now)
+	require.Error(t, err, "zero-length range is rejected")
+}
+
+func TestResolveQuery_CustomRequiresBothBounds(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	_, err := ResolveQuery(QueryInput{Preset: "custom", Timezone: "UTC", From: "2026-06-01T00:00:00Z"}, now)
+	require.Error(t, err, "custom needs both from and to")
+}
+
+func TestResolveQuery_InvalidTimezone(t *testing.T) {
+	now := mustRFC3339(t, "2030-01-01T00:00:00Z")
+	_, err := ResolveQuery(QueryInput{Preset: "day", Date: "2026-06-16", Timezone: "Fake/Zone"}, now)
+	require.Error(t, err)
+}
+
+func TestResolveQuery_FutureRangeClamps(t *testing.T) {
+	now := mustRFC3339(t, "2026-06-16T00:00:00Z")
+	q, err := ResolveQuery(QueryInput{Preset: "day", Date: "2026-06-20", Timezone: "UTC"}, now)
+	require.NoError(t, err)
+	assert.Equal(t, q.RangeStart, q.EffectiveEnd, "fully future range clamps effective_end to range_start")
+	assert.True(t, q.Partial, "future range is partial")
+}
+
+func TestBuildBuckets_FixedDurationWithShortFinal(t *testing.T) {
+	l := time.UTC
+	start := mustRFC3339(t, "2026-06-16T10:00:00Z")
+	end := mustRFC3339(t, "2026-06-16T10:12:00Z") // 12 minutes
+	ws, err := BuildBuckets(start, end, BucketSpec{BucketMinute, 300}, l)
+	require.NoError(t, err)
+	require.Len(t, ws, 3, "12 minutes / 5 = 2 full + 1 short bucket")
+	assert.Equal(t, start, ws[0].Start)
+	assert.Equal(t, mustRFC3339(t, "2026-06-16T10:05:00Z"), ws[0].End)
+	assert.Equal(t, mustRFC3339(t, "2026-06-16T10:10:00Z"), ws[2].Start)
+	assert.Equal(t, end, ws[2].End, "final bucket clipped to range end")
+}
+
+func TestBuildBuckets_CalendarDayLocalBoundaries(t *testing.T) {
+	l := loc(t, "America/New_York")
+	// Two local days; the boundary is local midnight (04:00Z in EDT).
+	start := mustRFC3339(t, "2026-06-16T04:00:00Z")
+	end := mustRFC3339(t, "2026-06-18T04:00:00Z")
+	ws, err := BuildBuckets(start, end, BucketSpec{BucketDay, 86400}, l)
+	require.NoError(t, err)
+	require.Len(t, ws, 2)
+	assert.Equal(t, start, ws[0].Start)
+	assert.Equal(t, mustRFC3339(t, "2026-06-17T04:00:00Z"), ws[0].End,
+		"calendar day boundary is local midnight")
+	assert.Equal(t, end, ws[1].End)
+}
+
+func TestBuildBuckets_CalendarDaySpansDST(t *testing.T) {
+	l := loc(t, "America/New_York")
+	// Spring forward 2026-03-08 (23h local day) then a normal 24h day.
+	start := mustRFC3339(t, "2026-03-08T05:00:00Z") // 2026-03-08 00:00 EST
+	end := mustRFC3339(t, "2026-03-10T04:00:00Z")   // 2026-03-10 00:00 EDT
+	ws, err := BuildBuckets(start, end, BucketSpec{BucketDay, 86400}, l)
+	require.NoError(t, err)
+	require.Len(t, ws, 2)
+	assert.Equal(t, 23*time.Hour, ws[0].End.Sub(ws[0].Start), "spring-forward calendar day is 23h")
+	assert.Equal(t, 24*time.Hour, ws[1].End.Sub(ws[1].Start), "following day is 24h")
+}
+
+func TestBuildBuckets_CalendarDayFallBack25h(t *testing.T) {
+	l := loc(t, "America/New_York")
+	start := mustRFC3339(t, "2026-11-01T04:00:00Z") // 2026-11-01 00:00 EDT
+	end := mustRFC3339(t, "2026-11-02T05:00:00Z")   // 2026-11-02 00:00 EST
+	ws, err := BuildBuckets(start, end, BucketSpec{BucketDay, 86400}, l)
+	require.NoError(t, err)
+	require.Len(t, ws, 1)
+	assert.Equal(t, 25*time.Hour, ws[0].End.Sub(ws[0].Start), "fall-back calendar day is 25h")
+}
+
+func TestBuildBuckets_CalendarWeekISOMonday(t *testing.T) {
+	l := time.UTC
+	start := mustRFC3339(t, "2026-06-15T00:00:00Z") // Monday
+	end := mustRFC3339(t, "2026-06-29T00:00:00Z")   // two ISO weeks later
+	ws, err := BuildBuckets(start, end, BucketSpec{BucketWeek, 604800}, l)
+	require.NoError(t, err)
+	require.Len(t, ws, 2)
+	assert.Equal(t, mustRFC3339(t, "2026-06-22T00:00:00Z"), ws[0].End)
+}

--- a/internal/activity/sessions_test.go
+++ b/internal/activity/sessions_test.go
@@ -1,0 +1,145 @@
+package activity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionsTable_TimedAndUntimed(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	sessions := []SessionMeta{
+		{SessionID: "a", Title: "Fix bug", Project: "proj1", Agent: "claude",
+			StartedAt: "2026-06-16T10:00:00Z"},
+		{SessionID: "u", Title: "Imported", Project: "proj2", Agent: "codex",
+			StartedAt: "2026-06-16T09:00:00Z"}, // no activity, no usage
+	}
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:04:00Z", Role: "assistant", Model: "opus"},
+	}
+	usage := []UsageRow{
+		{SessionID: "a", Model: "opus", Timestamp: "2026-06-16T10:03:00Z",
+			OutputTokens: 50, Cost: 0.5, UsageDedupKey: "k1"},
+	}
+	r := Aggregate(p, sessions, act, usage)
+
+	require.Len(t, r.BySession, 2)
+	bySid := map[string]SessionRow{}
+	for _, s := range r.BySession {
+		bySid[s.SessionID] = s
+	}
+	a := bySid["a"]
+	assert.Equal(t, "timed", a.TimingQuality)
+	require.NotNil(t, a.AgentMinutes)
+	assert.InDelta(t, 4.0, *a.AgentMinutes, 1e-9)
+	assert.Equal(t, "opus", a.PrimaryModel)
+	assert.InDelta(t, 0.5, a.Cost, 1e-9)
+
+	u := bySid["u"]
+	assert.Equal(t, "untimed", u.TimingQuality)
+	assert.Nil(t, u.AgentMinutes)
+
+	assert.Equal(t, 2, r.Totals.Sessions)
+	assert.Equal(t, 1, r.Totals.UntimedSessions)
+	assert.Equal(t, 2, r.Totals.DistinctProjects)
+	require.Len(t, r.ByProject, 1) // only timed activity contributes minutes
+	assert.Equal(t, "proj1", r.ByProject[0].Key)
+}
+
+func TestSessionsTable_UntimedKeepsCost(t *testing.T) {
+	// A session with usage but no activity is untimed yet still carries cost
+	// and output tokens, and contributes to distinct-model counts.
+	p := baseParams(t, "2026-06-16", "UTC")
+	sessions := []SessionMeta{
+		{SessionID: "u", Title: "Imported", Project: "proj1", Agent: "codex"},
+	}
+	usage := []UsageRow{
+		{SessionID: "u", Model: "sonnet", Timestamp: "2026-06-16T11:00:00Z",
+			OutputTokens: 30, Cost: 0.25, UsageDedupKey: "k1"},
+	}
+	r := Aggregate(p, sessions, nil, usage)
+
+	require.Len(t, r.BySession, 1)
+	u := r.BySession[0]
+	assert.Equal(t, "untimed", u.TimingQuality)
+	assert.Nil(t, u.AgentMinutes)
+	assert.InDelta(t, 0.25, u.Cost, 1e-9)
+	assert.Equal(t, 30, u.OutputTokens)
+	assert.Equal(t, "sonnet", u.PrimaryModel)
+	assert.Equal(t, []string{"sonnet"}, u.Models)
+	assert.Equal(t, 1, r.Totals.DistinctModels)
+	// No timed minutes, but the cost rolls up into the cost breakdown (so it
+	// sums to Totals.Cost). Each row carries zero minutes and the full cost in
+	// the interactive segment (the session is not automated).
+	require.Len(t, r.ByModel, 1)
+	assert.Equal(t, "sonnet", r.ByModel[0].Key)
+	assert.InDelta(t, 0.0, r.ByModel[0].AgentMinutes, 1e-9)
+	assert.InDelta(t, 0.25, r.ByModel[0].Cost, 1e-9)
+	assert.InDelta(t, 0.25, r.ByModel[0].InteractiveCost, 1e-9)
+	require.Len(t, r.ByProject, 1)
+	assert.Equal(t, "proj1", r.ByProject[0].Key)
+	assert.InDelta(t, 0.25, r.ByProject[0].Cost, 1e-9)
+	require.Len(t, r.ByAgent, 1)
+	assert.Equal(t, "codex", r.ByAgent[0].Key)
+	assert.InDelta(t, 0.25, r.ByAgent[0].Cost, 1e-9)
+}
+
+func TestSessionsTable_MixedModelsAndUnknownDropped(t *testing.T) {
+	// A session spanning two models plus an unknown-model gap. The interval
+	// model breakdown keeps the named models, drops "unknown", and the session
+	// surfaces both named models (UI renders "mixed" when len(Models) > 1).
+	p := baseParams(t, "2026-06-16", "UTC")
+	sessions := []SessionMeta{
+		{SessionID: "a", Title: "Multi", Project: "proj1", Agent: "claude"},
+	}
+	act := []ActivityEvent{
+		{SessionID: "a", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		// gap 1->2 has no assistant model yet -> "unknown", 2 min.
+		{SessionID: "a", Ordinal: 2, Timestamp: "2026-06-16T10:02:00Z", Role: "user"},
+		// gap 2->3 attributes to opus, 2 min.
+		{SessionID: "a", Ordinal: 3, Timestamp: "2026-06-16T10:04:00Z", Role: "assistant", Model: "opus"},
+		// gap 3->4 attributes to sonnet, 4 min.
+		{SessionID: "a", Ordinal: 4, Timestamp: "2026-06-16T10:08:00Z", Role: "assistant", Model: "sonnet"},
+	}
+	r := Aggregate(p, sessions, act, nil)
+
+	require.Len(t, r.BySession, 1)
+	a := r.BySession[0]
+	assert.Equal(t, "timed", a.TimingQuality)
+	assert.Equal(t, []string{"opus", "sonnet"}, a.Models)
+	assert.Equal(t, "sonnet", a.PrimaryModel) // sonnet has the most minutes
+
+	// ByModel drops "unknown" and keeps the two named models sorted by minutes.
+	require.Len(t, r.ByModel, 2)
+	assert.Equal(t, "sonnet", r.ByModel[0].Key)
+	assert.InDelta(t, 4.0, r.ByModel[0].AgentMinutes, 1e-9)
+	assert.Equal(t, "opus", r.ByModel[1].Key)
+	assert.InDelta(t, 2.0, r.ByModel[1].AgentMinutes, 1e-9)
+	assert.Equal(t, 2, r.Totals.DistinctModels)
+}
+
+func TestSessionsTable_SortByMinutesUntimedLast(t *testing.T) {
+	// Two timed sessions (different minutes) and one untimed; rows sort by
+	// agent-minutes descending with the untimed (nil) session last.
+	p := baseParams(t, "2026-06-16", "UTC")
+	sessions := []SessionMeta{
+		{SessionID: "small", Project: "p", Agent: "claude"},
+		{SessionID: "big", Project: "p", Agent: "claude"},
+		{SessionID: "untimed", Project: "p", Agent: "claude"},
+	}
+	act := []ActivityEvent{
+		{SessionID: "small", Ordinal: 1, Timestamp: "2026-06-16T10:00:00Z", Role: "user"},
+		{SessionID: "small", Ordinal: 2, Timestamp: "2026-06-16T10:01:00Z", Role: "assistant", Model: "m"},
+		{SessionID: "big", Ordinal: 1, Timestamp: "2026-06-16T11:00:00Z", Role: "user"},
+		{SessionID: "big", Ordinal: 2, Timestamp: "2026-06-16T11:05:00Z", Role: "assistant", Model: "m"},
+	}
+	r := Aggregate(p, sessions, act, nil)
+
+	require.Len(t, r.BySession, 3)
+	assert.Equal(t, "big", r.BySession[0].SessionID)
+	assert.Equal(t, "small", r.BySession[1].SessionID)
+	assert.Equal(t, "untimed", r.BySession[2].SessionID)
+	assert.Nil(t, r.BySession[2].AgentMinutes)
+}

--- a/internal/activity/usage_test.go
+++ b/internal/activity/usage_test.go
@@ -1,0 +1,46 @@
+package activity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mustStart parses an RFC3339 string used as the range-start anchor.
+func mustStart(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return ts.UTC()
+}
+
+func TestApplyUsage_DedupAndDayFilter(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	// Same logical usage from message source and usage_events source share
+	// no claude IDs but share a dedup key -> must count once. A row outside
+	// the range is dropped without claiming a key.
+	usage := []UsageRow{
+		{SessionID: "a", Model: "m1", Timestamp: "2026-06-16T10:00:00Z",
+			OutputTokens: 100, Cost: 1.0, ClaudeMessageID: "x", ClaudeRequestID: "r"},
+		{SessionID: "a", Model: "m1", Timestamp: "2026-06-16T10:00:00Z",
+			OutputTokens: 100, Cost: 1.0, ClaudeMessageID: "x", ClaudeRequestID: "r"},
+		{SessionID: "a", Model: "m1", Timestamp: "2026-06-15T23:00:00Z",
+			OutputTokens: 999, Cost: 9.0, UsageDedupKey: "k-out"},
+	}
+	start := mustStart(t, "2026-06-16T00:00:00Z")
+	end := mustStart(t, "2026-06-17T00:00:00Z")
+	windows, err := BuildBuckets(start, end, p.Bucket, p.Loc)
+	require.NoError(t, err)
+	r := Report{Buckets: make([]Bucket, len(windows))}
+	applyUsage(&r, p, windows, start, end, usage, nil)
+	assert.Equal(t, 100, r.Totals.OutputTokens)
+	assert.InDelta(t, 1.0, r.Totals.Cost, 1e-9)
+	// A nil automated set classifies every session as interactive.
+	assert.InDelta(t, 1.0, r.Totals.InteractiveCost, 1e-9)
+	assert.InDelta(t, 0.0, r.Totals.AutomatedCost, 1e-9)
+	// 10:00 UTC -> bucket 120 (10*12).
+	assert.Equal(t, 100, r.Buckets[120].OutputTokens)
+	assert.InDelta(t, 1.0, r.Buckets[120].Cost, 1e-9)
+}

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -217,7 +217,7 @@ func (db *DB) activityReportUsage(
 			usageMessageEligibility+" AND m.session_id IN "+ph,
 			usageEventEligibility+" AND ue.session_id IN "+ph)
 		query := dailyUsageRowSelectFromRows(rowsSQL) + `
-			AND u.ts >= ? AND u.ts < ?`
+			AND u.ts >= ? AND u.ts <= ?`
 
 		args := make([]any, 0, len(chunkArgs)*2+2)
 		args = append(args, chunkArgs...) // message-where chunk

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -219,7 +219,12 @@ func (db *DB) activityReportUsage(
 	}
 	var rowsAcc []ordered
 
-	err = queryChunked(ids, func(chunk []string) error {
+	// This query binds each id chunk twice (message-where and usage-event-where)
+	// plus two time bounds, so the generic maxSQLVars chunk (bound once) would
+	// emit 2*maxSQLVars+2 > 999 variables and overflow SQLite at ~500 candidate
+	// sessions. Cap the chunk so 2*chunk+2 stays within maxSQLVars.
+	const usageVarChunk = (maxSQLVars - 2) / 2
+	err = queryChunkedSize(ids, usageVarChunk, func(chunk []string) error {
 		ph, chunkArgs := inPlaceholders(chunk)
 		// Apply the same eligibility filters as GetDailyUsage so empty
 		// token_usage, empty, and synthetic models are excluded from the

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -78,6 +78,12 @@ func (db *DB) GetActivityReport(
 // NULLIF guards the empty-string timestamp fallbacks SQLite stores so a
 // session with an empty ended_at but a valid started_at still falls back
 // correctly, matching the activity-expression convention elsewhere.
+//
+// The effective-end fallback for a session with no ended_at uses its
+// latest message timestamp before started_at, so a still-open or
+// partially-parsed session that began before the range but has messages
+// inside it is not dropped. COALESCE short-circuits, so the correlated
+// MAX subquery runs only for the rare sessions missing an ended_at.
 func (db *DB) activityReportSessions(
 	ctx context.Context, f AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
 ) ([]activity.SessionMeta, []string, error) {
@@ -99,8 +105,10 @@ func (db *DB) activityReportSessions(
 		COALESCE(s.is_automated, 0)
 	FROM sessions s
 	WHERE ` + where + `
-		AND COALESCE(NULLIF(s.ended_at, ''), NULLIF(s.started_at, ''),
-			s.created_at) >= ?
+		AND COALESCE(NULLIF(s.ended_at, ''),
+			(SELECT MAX(m.timestamp) FROM messages m
+				WHERE m.session_id = s.id AND m.timestamp != ''),
+			NULLIF(s.started_at, ''), s.created_at) >= ?
 		AND COALESCE(NULLIF(s.started_at, ''), s.created_at) < ?`
 
 	rows, err := db.getReader().QueryContext(ctx, query, args...)

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -84,9 +84,12 @@ func (db *DB) activityReportSessions(
 	where, args := f.buildWhereWithDate("", false)
 	args = append(args, rangeStartUTC, rangeEndUTC)
 
+	// Each Title candidate is NULLIF'd independently (not a nested
+	// COALESCE-then-NULLIF) so an empty display_name cannot mask a real
+	// session_name.
 	query := `SELECT
 		s.id,
-		COALESCE(NULLIF(COALESCE(s.display_name, s.session_name), ''),
+		COALESCE(NULLIF(s.display_name, ''), NULLIF(s.session_name, ''),
 			NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id),
 		s.project,
 		s.agent,

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -178,7 +178,11 @@ func (db *DB) activityReportActivity(
 // within the padded range bounds, with per-row cost computed up front
 // (mirroring GetDailyUsage) so cost logic stays in the backend. Rows
 // are ordered by (ts, session_id, message_ordinal) as the aggregator
-// requires for its first-seen-wins dedup.
+// requires for its first-seen-wins dedup. The order is computed on the
+// parsed instant, not the RFC3339 text, so a whole-second value ("...00Z")
+// and a fractional one ("...00.123Z") in the same second sort
+// chronologically (matching PostgreSQL/DuckDB); lexically '.' < 'Z' would
+// otherwise invert them and let SQLite keep a different duplicate row.
 func (db *DB) activityReportUsage(
 	ctx context.Context, ids []string, lowerBound, upperBound string,
 ) ([]activity.UsageRow, error) {
@@ -192,13 +196,14 @@ func (db *DB) activityReportUsage(
 		return nil, fmt.Errorf("loading pricing: %w", err)
 	}
 
-	// Accumulate the per-row dedup ordinal alongside the mapped row so we
-	// can impose one global (ts, session_id, ordinal) order across all
+	// Accumulate the parsed ts and dedup ordinal alongside each mapped row so
+	// we can impose one global (ts, session_id, ordinal) order across all
 	// chunks. The same (claude_message_id, claude_request_id) can recur in
 	// different sessions (resumed/forked) and thus different chunks, so
 	// per-chunk ordering is not enough for the aggregator's first-seen dedup.
 	type ordered struct {
 		row     activity.UsageRow
+		ts      time.Time
 		ordinal int64
 	}
 	var rowsAcc []ordered
@@ -236,7 +241,9 @@ func (db *DB) activityReportUsage(
 			if r.messageOrdinal.Valid {
 				ord = r.messageOrdinal.Int64
 			}
+			parsedTS, _ := parseTimestamp(r.ts)
 			rowsAcc = append(rowsAcc, ordered{
+				ts:      parsedTS,
 				ordinal: ord,
 				row: activity.UsageRow{
 					SessionID:       r.sessionID,
@@ -258,8 +265,8 @@ func (db *DB) activityReportUsage(
 
 	sort.SliceStable(rowsAcc, func(i, j int) bool {
 		a, b := rowsAcc[i], rowsAcc[j]
-		if a.row.Timestamp != b.row.Timestamp {
-			return a.row.Timestamp < b.row.Timestamp
+		if !a.ts.Equal(b.ts) {
+			return a.ts.Before(b.ts)
 		}
 		if a.row.SessionID != b.row.SessionID {
 			return a.row.SessionID < b.row.SessionID

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -1,0 +1,274 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.kenn.io/agentsview/internal/activity"
+)
+
+// activityReportRangeBoundsUTC returns the exact [start, end) UTC bounds
+// of the resolved range `q` as zone-less strings. It generalizes the old
+// per-day window helper so the candidate-session predicate selects exactly
+// the sessions whose window intersects the range, with no padding slop.
+//
+// The layout omits the zone suffix deliberately. SQLite compares timestamp
+// TEXT lexicographically; a Z-suffixed bound sorts a sub-second value
+// (".123Z") before a whole-second bound ("Z") because '.' < 'Z', dropping
+// sessions in the first sub-second of the range. A zone-less bound is a
+// strict prefix of every stored RFC3339Nano-UTC value at that second, so
+// whole-second and fractional values both compare correctly.
+// PostgreSQL/DuckDB compare parsed instants and keep the zone in their own
+// copies of this helper; this divergence makes SQLite match their
+// already-correct boundary behavior.
+func activityReportRangeBoundsUTC(q activity.Query) (string, string) {
+	const boundLayout = "2006-01-02T15:04:05"
+	return q.RangeStart.UTC().Format(boundLayout),
+		q.RangeEnd.UTC().Format(boundLayout)
+}
+
+// GetActivityReport assembles a concurrency- and usage-oriented report
+// for the resolved range `q`. It runs three fetches scoped to the SAME
+// candidate session-ID set so the concurrency timeline, sessions table,
+// and usage totals stay mutually consistent (no orphan usage rows), then
+// hands the in-memory streams to activity.Aggregate.
+//
+// The filter `f` is honored as-is: callers that want one-shot or
+// automated sessions included must pass them through with the
+// corresponding exclusions disabled.
+func (db *DB) GetActivityReport(
+	ctx context.Context, f AnalyticsFilter, q activity.Query,
+) (activity.Report, error) {
+	rangeStartUTC, rangeEndUTC := activityReportRangeBoundsUTC(q)
+	lowerBound := paddedUTCBound(q.RangeStart.UTC().Format(time.RFC3339), -14)
+	upperBound := paddedUTCBound(q.RangeEnd.UTC().Format(time.RFC3339), 14)
+
+	sessions, ids, err := db.activityReportSessions(
+		ctx, f, rangeStartUTC, rangeEndUTC)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	acts, err := db.activityReportActivity(ctx, ids)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	usage, err := db.activityReportUsage(ctx, ids, lowerBound, upperBound)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	return activity.Aggregate(activity.Params{
+		RangeStart:    q.RangeStart,
+		RangeEnd:      q.RangeEnd,
+		Loc:           q.Loc,
+		EffectiveEnd:  q.EffectiveEnd,
+		Partial:       q.Partial,
+		GapCapSeconds: q.GapCapSeconds,
+		Bucket:        q.Bucket,
+	}, sessions, acts, usage), nil
+}
+
+// activityReportSessions returns the candidate sessions whose window
+// overlaps the exact range [rangeStartUTC, rangeEndUTC), plus their
+// IDs. The ID set defines the scope for the activity and usage fetches.
+// NULLIF guards the empty-string timestamp fallbacks SQLite stores so a
+// session with an empty ended_at but a valid started_at still falls back
+// correctly, matching the activity-expression convention elsewhere.
+func (db *DB) activityReportSessions(
+	ctx context.Context, f AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
+) ([]activity.SessionMeta, []string, error) {
+	where, args := f.buildWhereWithDate("", false)
+	args = append(args, rangeStartUTC, rangeEndUTC)
+
+	query := `SELECT
+		s.id,
+		COALESCE(NULLIF(COALESCE(s.display_name, s.session_name), ''),
+			NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id),
+		s.project,
+		s.agent,
+		s.machine,
+		COALESCE(s.started_at, ''),
+		COALESCE(s.ended_at, ''),
+		COALESCE(s.is_automated, 0)
+	FROM sessions s
+	WHERE ` + where + `
+		AND COALESCE(NULLIF(s.ended_at, ''), NULLIF(s.started_at, ''),
+			s.created_at) >= ?
+		AND COALESCE(NULLIF(s.started_at, ''), s.created_at) < ?`
+
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"querying activity report sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []activity.SessionMeta
+	var ids []string
+	for rows.Next() {
+		var s activity.SessionMeta
+		if err := rows.Scan(
+			&s.SessionID, &s.Title, &s.Project, &s.Agent,
+			&s.Machine, &s.StartedAt, &s.EndedAt, &s.IsAutomated,
+		); err != nil {
+			return nil, nil, fmt.Errorf(
+				"scanning activity report session: %w", err)
+		}
+		sessions = append(sessions, s)
+		ids = append(ids, s.SessionID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf(
+			"iterating activity report sessions: %w", err)
+	}
+	return sessions, ids, nil
+}
+
+// activityReportActivity returns every timestamped message for the
+// candidate sessions, ordered for the aggregator's per-session
+// interval walk.
+func (db *DB) activityReportActivity(
+	ctx context.Context, ids []string,
+) ([]activity.ActivityEvent, error) {
+	var out []activity.ActivityEvent
+	if len(ids) == 0 {
+		return out, nil
+	}
+	err := queryChunked(ids, func(chunk []string) error {
+		ph, args := inPlaceholders(chunk)
+		query := `SELECT session_id, ordinal, role,
+			COALESCE(timestamp, ''), model
+		FROM messages
+		WHERE session_id IN ` + ph + `
+			AND timestamp IS NOT NULL
+			AND timestamp != ''
+		ORDER BY session_id, ordinal`
+
+		rows, err := db.getReader().QueryContext(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf(
+				"querying activity report activity: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var e activity.ActivityEvent
+			if err := rows.Scan(
+				&e.SessionID, &e.Ordinal, &e.Role,
+				&e.Timestamp, &e.Model,
+			); err != nil {
+				return fmt.Errorf(
+					"scanning activity report activity: %w", err)
+			}
+			out = append(out, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// activityReportUsage returns the usage rows for the candidate sessions
+// within the padded range bounds, with per-row cost computed up front
+// (mirroring GetDailyUsage) so cost logic stays in the backend. Rows
+// are ordered by (ts, session_id, message_ordinal) as the aggregator
+// requires for its first-seen-wins dedup.
+func (db *DB) activityReportUsage(
+	ctx context.Context, ids []string, lowerBound, upperBound string,
+) ([]activity.UsageRow, error) {
+	var out []activity.UsageRow
+	if len(ids) == 0 {
+		return out, nil
+	}
+
+	pricing, err := db.loadPricingMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading pricing: %w", err)
+	}
+
+	// Accumulate the per-row dedup ordinal alongside the mapped row so we
+	// can impose one global (ts, session_id, ordinal) order across all
+	// chunks. The same (claude_message_id, claude_request_id) can recur in
+	// different sessions (resumed/forked) and thus different chunks, so
+	// per-chunk ordering is not enough for the aggregator's first-seen dedup.
+	type ordered struct {
+		row     activity.UsageRow
+		ordinal int64
+	}
+	var rowsAcc []ordered
+
+	err = queryChunked(ids, func(chunk []string) error {
+		ph, chunkArgs := inPlaceholders(chunk)
+		// Apply the same eligibility filters as GetDailyUsage so empty
+		// token_usage, empty, and synthetic models are excluded from the
+		// daily totals and dedup, keeping parity with the Usage dashboard.
+		rowsSQL := dailyUsageRowsSQLWithWhere(
+			usageMessageEligibility+" AND m.session_id IN "+ph,
+			usageEventEligibility+" AND ue.session_id IN "+ph)
+		query := dailyUsageRowSelectFromRows(rowsSQL) + `
+			AND u.ts >= ? AND u.ts < ?`
+
+		args := make([]any, 0, len(chunkArgs)*2+2)
+		args = append(args, chunkArgs...) // message-where chunk
+		args = append(args, chunkArgs...) // usage-event-where chunk
+		args = append(args, lowerBound, upperBound)
+
+		rows, err := db.getReader().QueryContext(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("querying activity report usage: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			r, scanErr := scanDailyUsageRow(rows)
+			if scanErr != nil {
+				return fmt.Errorf(
+					"scanning activity report usage: %w", scanErr)
+			}
+			_, outputTok, _, _, cost, _ := dailyUsageAmounts(r, pricing)
+			ord := int64(-1)
+			if r.messageOrdinal.Valid {
+				ord = r.messageOrdinal.Int64
+			}
+			rowsAcc = append(rowsAcc, ordered{
+				ordinal: ord,
+				row: activity.UsageRow{
+					SessionID:       r.sessionID,
+					Model:           r.model,
+					Timestamp:       r.ts,
+					OutputTokens:    outputTok,
+					Cost:            cost,
+					ClaudeMessageID: r.claudeMessageID,
+					ClaudeRequestID: r.claudeRequestID,
+					UsageDedupKey:   r.usageDedupKey,
+				},
+			})
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.SliceStable(rowsAcc, func(i, j int) bool {
+		a, b := rowsAcc[i], rowsAcc[j]
+		if a.row.Timestamp != b.row.Timestamp {
+			return a.row.Timestamp < b.row.Timestamp
+		}
+		if a.row.SessionID != b.row.SessionID {
+			return a.row.SessionID < b.row.SessionID
+		}
+		return a.ordinal < b.ordinal
+	})
+	out = make([]activity.UsageRow, len(rowsAcc))
+	for i, o := range rowsAcc {
+		out[i] = o.row
+	}
+	return out, nil
+}

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -1,0 +1,335 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/activity"
+)
+
+func reportSessionIDs(sessions []activity.SessionRow) map[string]struct{} {
+	out := make(map[string]struct{}, len(sessions))
+	for _, s := range sessions {
+		out[s.SessionID] = struct{}{}
+	}
+	return out
+}
+
+// dayQuery resolves a single-day "day" Query for date/tz against a fixed
+// far-future now, so the candidate range is the full local day and the
+// report is never partial regardless of the wall clock.
+func dayQuery(t *testing.T, date, tz string) activity.Query {
+	t.Helper()
+	now, err := time.Parse(time.RFC3339, "2030-01-01T00:00:00Z")
+	require.NoError(t, err)
+	q, err := activity.ResolveQuery(
+		activity.QueryInput{Preset: "day", Date: date, Timezone: tz}, now)
+	require.NoError(t, err)
+	return q
+}
+
+func seedMessage(
+	t *testing.T, d *DB, sid string, ordinal int, role, ts, model string,
+) {
+	t.Helper()
+	insertMessages(t, d, Message{
+		SessionID: sid,
+		Ordinal:   ordinal,
+		Role:      role,
+		Content:   "x",
+		Timestamp: ts,
+		Model:     model,
+	})
+}
+
+func TestGetActivityReport_BasicConcurrency(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	// Two overlapping sessions on 2026-06-16 (UTC), each two messages.
+	// started_at/ended_at are set explicitly so the candidate-session
+	// window anchors on the target day regardless of the wall clock; a
+	// created_at fallback would drift to the prior/next day when the
+	// suite runs near UTC midnight.
+	insertSession(t, d, "a", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:00:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:02:00Z")
+	})
+	seedMessage(t, d, "a", 1, "user", "2026-06-16T10:00:00Z", "")
+	seedMessage(t, d, "a", 2, "assistant", "2026-06-16T10:02:00Z", "opus")
+	insertSession(t, d, "b", "proj2", func(s *Session) {
+		s.Agent = "codex"
+		s.StartedAt = Ptr("2026-06-16T10:01:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:03:00Z")
+	})
+	seedMessage(t, d, "b", 1, "user", "2026-06-16T10:01:00Z", "")
+	seedMessage(t, d, "b", 2, "assistant", "2026-06-16T10:03:00Z", "gpt5")
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.Peak.Agents)
+	assert.Equal(t, 2, r.Totals.Sessions)
+	assert.GreaterOrEqual(t, len(r.ByModel), 2)
+}
+
+func TestGetActivityReport_UsageCostAndTokens(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "s1", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:30:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:30:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:  "s1",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "x",
+		Timestamp:  "2026-06-16T10:30:00Z",
+		Model:      "claude-sonnet-4-20250514",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.Totals.Sessions)
+	assert.Equal(t, 500, r.Totals.OutputTokens)
+	// Cost = (1000*3 + 500*15) / 1e6 = 0.0105
+	assert.InDelta(t, 0.0105, r.Totals.Cost, 1e-9)
+}
+
+// TestGetActivityReport_ExcludesOtherDays confirms the candidate-session
+// window and the usage ts-bounds keep a session whose only activity
+// falls outside the target day from contributing to that day.
+func TestGetActivityReport_ExcludesOtherDays(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "today", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:00:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:02:00Z")
+	})
+	seedMessage(t, d, "today", 1, "user", "2026-06-16T10:00:00Z", "")
+	seedMessage(t, d, "today", 2, "assistant", "2026-06-16T10:02:00Z", "opus")
+
+	insertSession(t, d, "yesterday", "proj2", func(s *Session) {
+		s.Agent = "codex"
+		s.StartedAt = Ptr("2026-06-10T10:00:00Z")
+		s.EndedAt = Ptr("2026-06-10T10:02:00Z")
+	})
+	seedMessage(t, d, "yesterday", 1, "user", "2026-06-10T10:00:00Z", "")
+	seedMessage(t, d, "yesterday", 2, "assistant", "2026-06-10T10:02:00Z", "gpt5")
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	// Only the in-day session has timed intervals on 2026-06-16.
+	assert.Equal(t, 1, r.Peak.Agents)
+	require.Len(t, r.ByAgent, 1)
+	assert.Equal(t, "claude", r.ByAgent[0].Key)
+}
+
+// TestGetActivityReport_PriorDayWithinPadExcluded confirms the candidate
+// window uses the EXACT local day, not the +/-14h padded bounds: a
+// session that began and ended on the prior day but lands inside the
+// pad must NOT appear as an untimed session in the target day's report.
+func TestGetActivityReport_PriorDayWithinPadExcluded(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "today", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:00:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:02:00Z")
+	})
+	seedMessage(t, d, "today", 1, "user", "2026-06-16T10:00:00Z", "")
+	seedMessage(t, d, "today", 2, "assistant", "2026-06-16T10:02:00Z", "opus")
+
+	// Prior-day session at 2026-06-15T12:00Z: within the old -14h pad
+	// (2026-06-15T10:00Z) but outside the exact 2026-06-16 UTC window.
+	insertSession(t, d, "prior", "proj2", func(s *Session) {
+		s.Agent = "codex"
+		s.StartedAt = Ptr("2026-06-15T12:00:00Z")
+		s.EndedAt = Ptr("2026-06-15T12:05:00Z")
+	})
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	ids := reportSessionIDs(r.BySession)
+	assert.Contains(t, ids, "today")
+	assert.NotContains(t, ids, "prior", "prior-day session must not leak in")
+	assert.Equal(t, 1, r.Totals.Sessions)
+	assert.Equal(t, 0, r.Totals.UntimedSessions)
+}
+
+// TestGetActivityReport_UntimedSessionOnDayIncluded confirms a session
+// that started on the target day but has no timestamped messages still
+// appears in the report as an untimed candidate.
+func TestGetActivityReport_UntimedSessionOnDayIncluded(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "untimed", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T09:00:00Z")
+	})
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	ids := reportSessionIDs(r.BySession)
+	assert.Contains(t, ids, "untimed")
+	assert.Equal(t, 1, r.Totals.UntimedSessions)
+}
+
+// TestGetActivityReport_EmptyStringEndedAtIncluded confirms the overlap
+// predicate uses NULLIF so a session with an empty-string ended_at but a
+// valid started_at on the target day is not excluded by COALESCE
+// treating an empty string as a real upper bound.
+func TestGetActivityReport_EmptyStringEndedAtIncluded(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "empty-end", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T09:00:00Z")
+		s.EndedAt = Ptr("")
+	})
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	ids := reportSessionIDs(r.BySession)
+	assert.Contains(t, ids, "empty-end", "empty ended_at must fall back to started_at")
+}
+
+// TestGetActivityReport_SubSecondDayStartIncluded confirms a session whose
+// only activity lands in the first sub-second of the day is not dropped by
+// SQLite's lexicographic TEXT comparison. A stored RFC3339Nano value like
+// "2026-06-14T00:00:00.123Z" sorts before a Z-suffixed day-start bound
+// ("2026-06-14T00:00:00Z") because '.' < 'Z', so a Z-suffixed bound would
+// wrongly exclude it. The zone-less day bound fixes that.
+func TestGetActivityReport_SubSecondDayStartIncluded(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "subsec", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-14T00:00:00.123Z")
+		s.EndedAt = Ptr("2026-06-14T00:00:00.123Z")
+	})
+	seedMessage(t, d, "subsec", 0, "user", "2026-06-14T00:00:00.123Z", "")
+	seedMessage(t, d, "subsec", 1, "assistant", "2026-06-14T00:00:00.456Z", "opus")
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	ids := reportSessionIDs(r.BySession)
+	assert.Contains(t, ids, "subsec",
+		"first-sub-second session must not be dropped by the day-start bound")
+	assert.GreaterOrEqual(t, r.Totals.Sessions, 1)
+}
+
+// TestGetActivityReport_ExcludesIneligibleUsage confirms the usage union
+// applies the same eligibility filters as GetDailyUsage: a message with
+// an empty model and empty token_usage must not inflate the day totals.
+func TestGetActivityReport_ExcludesIneligibleUsage(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "s1", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:30:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:31:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:  "s1",
+		Ordinal:    0,
+		Role:       "assistant",
+		Content:    "x",
+		Timestamp:  "2026-06-16T10:30:00Z",
+		Model:      "claude-sonnet-4-20250514",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+	// Ineligible: a synthetic-model message carrying real token_usage.
+	// usageMessageEligibility drops m.model == '<synthetic>', so these
+	// tokens must NOT leak into the day totals even though the blob is
+	// non-empty.
+	insertMessages(t, d, Message{
+		SessionID:  "s1",
+		Ordinal:    1,
+		Role:       "assistant",
+		Content:    "y",
+		Timestamp:  "2026-06-16T10:31:00Z",
+		Model:      "<synthetic>",
+		TokenUsage: json.RawMessage(`{"input_tokens":9000,"output_tokens":7000}`),
+	})
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens, "synthetic message excluded")
+	assert.InDelta(t, 0.0105, r.Totals.Cost, 1e-9)
+}
+
+// TestGetActivityReport_HourlyRange exercises a multi-day custom range so
+// the bucket auto-policy selects hourly buckets, and confirms the fetch
+// window spans the whole range: a session whose only activity falls on the
+// middle day populates the hourly bucket that contains it.
+func TestGetActivityReport_HourlyRange(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "mid", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-17T10:00:00Z")
+		s.EndedAt = Ptr("2026-06-17T10:30:00Z")
+	})
+	seedMessage(t, d, "mid", 1, "user", "2026-06-17T10:00:00Z", "")
+	seedMessage(t, d, "mid", 2, "assistant", "2026-06-17T10:30:00Z", "opus")
+
+	// 3-day span -> hourly buckets per the auto policy.
+	now, err := time.Parse(time.RFC3339, "2030-01-01T00:00:00Z")
+	require.NoError(t, err)
+	q, err := activity.ResolveQuery(activity.QueryInput{
+		Preset: "custom", Timezone: "UTC",
+		From: "2026-06-16T00:00:00Z", To: "2026-06-19T00:00:00Z",
+	}, now)
+	require.NoError(t, err)
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"}, q)
+	require.NoError(t, err)
+	assert.Equal(t, "hour", r.BucketUnit)
+	assert.Equal(t, 72, r.BucketCount, "3 days of hourly buckets")
+	// The 30-min gap caps to 5 min and lands in the 2026-06-17T10:00 bucket.
+	var found bool
+	for _, b := range r.Buckets {
+		if b.Start == "2026-06-17T10:00:00Z" {
+			found = true
+			assert.Equal(t, "2026-06-17T11:00:00Z", b.End)
+			assert.InDelta(t, 5.0, b.AgentMinutes, 1e-9,
+				"mid-range hourly bucket is populated")
+		}
+	}
+	assert.True(t, found, "the 2026-06-17T10:00 hourly bucket must be present")
+}

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -382,3 +382,31 @@ func TestGetActivityReport_UsageDedupSubSecondOrder(t *testing.T) {
 	assert.Equal(t, 500, r.Totals.OutputTokens,
 		"first-seen dedup keeps the chronologically earlier whole-second row")
 }
+
+// TestGetActivityReport_TitleSkipsEmptyDisplayName confirms the Title fallback
+// null-checks each candidate independently: an empty (non-NULL) display_name
+// must not mask a real session_name. A nested COALESCE(display_name,
+// session_name) would return '' and be NULLIF'd away, wrongly skipping to
+// first_message. RenameSession stores a literal '' (only nil clears to NULL),
+// so this reproduces a session renamed to "" that still has a session_name.
+func TestGetActivityReport_TitleSkipsEmptyDisplayName(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.SessionName = Ptr("real-session-name")
+		s.FirstMessage = Ptr("first message text")
+		s.StartedAt = Ptr("2026-06-16T10:00:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:02:00Z")
+	})
+	require.NoError(t, d.RenameSession("s", Ptr("")))
+	seedMessage(t, d, "s", 1, "user", "2026-06-16T10:00:00Z", "")
+	seedMessage(t, d, "s", 2, "assistant", "2026-06-16T10:02:00Z", "opus")
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	require.Len(t, r.BySession, 1)
+	assert.Equal(t, "real-session-name", r.BySession[0].Title,
+		"empty display_name must not mask the real session_name")
+}

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -333,3 +333,52 @@ func TestGetActivityReport_HourlyRange(t *testing.T) {
 	}
 	assert.True(t, found, "the 2026-06-17T10:00 hourly bucket must be present")
 }
+
+// TestGetActivityReport_UsageDedupSubSecondOrder confirms the SQLite usage
+// stream is ordered by the PARSED instant, not the RFC3339 text. A
+// resumed/forked pair shares one (claude_message_id, claude_request_id) dedup
+// key in the same second: one whole-second instant ("...00Z", 500 output
+// tokens) and one fractional ("...00.123Z", 9000). Lexically "...00.123Z"
+// sorts before "...00Z" ('.' < 'Z'), so a TEXT sort would keep the 9000 row;
+// chronologically the whole-second row is first. First-seen-wins dedup must
+// keep the 500 row, matching PostgreSQL/DuckDB which order on the parsed time.
+func TestGetActivityReport_UsageDedupSubSecondOrder(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "earlier", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:30:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:30:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "earlier", Ordinal: 0, Role: "assistant", Content: "x",
+		Timestamp:       "2026-06-16T10:30:00Z",
+		Model:           "claude-sonnet-4-20250514",
+		ClaudeMessageID: "m-dup", ClaudeRequestID: "r-dup",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+	insertSession(t, d, "later", "proj2", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:30:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:30:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "later", Ordinal: 0, Role: "assistant", Content: "x",
+		Timestamp:       "2026-06-16T10:30:00.123Z",
+		Model:           "claude-sonnet-4-20250514",
+		ClaudeMessageID: "m-dup", ClaudeRequestID: "r-dup",
+		TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":9000}`),
+	})
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens,
+		"first-seen dedup keeps the chronologically earlier whole-second row")
+}

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -3,9 +3,11 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
+	sqlite3 "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -516,4 +518,76 @@ func TestGetActivityReport_AutomationFilterAndSessionSplit(t *testing.T) {
 			}
 		})
 	}
+}
+
+// forceReaderVarLimit pins the reader pool to a single connection and lowers
+// its SQLITE_LIMIT_VARIABLE_NUMBER to mimic older SQLite builds, whose limit is
+// the documented 999 rather than the modern default (32766). Every read through
+// d.getReader() then reuses this one constrained connection, so a query that
+// binds too many variables fails exactly as it would on those builds.
+func forceReaderVarLimit(t *testing.T, d *DB, limit int) {
+	t.Helper()
+	reader := d.rawReader()
+	reader.SetMaxOpenConns(1)
+	reader.SetMaxIdleConns(1)
+	conn, err := reader.Conn(context.Background())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+	require.NoError(t, conn.Raw(func(dc any) error {
+		sc, ok := dc.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("reader conn is %T, want *sqlite3.SQLiteConn", dc)
+		}
+		sc.SetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, limit)
+		return nil
+	}))
+}
+
+// TestGetActivityReport_ManySessionsWithinSQLiteVarLimit reproduces the older
+// SQLite 999-variable limit on the reader pool, then builds a report whose
+// candidate set exceeds it. The usage fetch binds each id chunk twice (the
+// message-where and usage-event-where subqueries) plus two time bounds, so a
+// generic maxSQLVars chunk would emit 2*maxSQLVars+2 = 1002 variables and fail
+// on such builds. The fetch must instead chunk small enough to stay within the
+// limit while still aggregating usage across every chunk.
+func TestGetActivityReport_ManySessionsWithinSQLiteVarLimit(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	// More candidate sessions than maxSQLVars, so the usage fetch must chunk.
+	const n = maxSQLVars + 50
+	for i := range n {
+		sid := fmt.Sprintf("s%04d", i)
+		insertSession(t, d, sid, "proj1", func(s *Session) {
+			s.Agent = "claude"
+			s.StartedAt = Ptr("2026-06-16T10:00:00Z")
+			s.EndedAt = Ptr("2026-06-16T10:01:00Z")
+		})
+		insertMessages(t, d, Message{
+			SessionID:  sid,
+			Ordinal:    0,
+			Role:       "assistant",
+			Content:    "x",
+			Timestamp:  "2026-06-16T10:00:00Z",
+			Model:      "claude-sonnet-4-20250514",
+			TokenUsage: json.RawMessage(`{"input_tokens":100,"output_tokens":10}`),
+		})
+	}
+
+	forceReaderVarLimit(t, d, 999)
+
+	// Guard: prove the lowered limit is live on the pool, so a setup that
+	// failed to constrain it cannot mask the regression checked below.
+	overLimitPh, overLimitArgs := inPlaceholders(make([]string, 1001))
+	_, probeErr := d.getReader().QueryContext(
+		ctx, "SELECT 1 WHERE '' IN "+overLimitPh, overLimitArgs...)
+	require.Error(t, probeErr, "reader variable limit was not constrained")
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Len(t, reportSessionIDs(r.BySession), n,
+		"every candidate session survives id chunking")
+	assert.Positive(t, r.Totals.OutputTokens,
+		"usage aggregated across all id chunks")
 }

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -437,3 +437,83 @@ func TestGetActivityReport_OpenSessionWithInRangeMessageIncluded(t *testing.T) {
 		"open session active in-range must not be dropped by the started_at fallback")
 	assert.Equal(t, 1, r.Totals.Sessions)
 }
+
+// TestGetActivityReport_AutomationFilterAndSessionSplit confirms the
+// AnalyticsFilter automation class selects the right sessions and that the
+// Totals carry the automated/interactive session-count split. "all" keeps
+// both classes; ExcludeAutomated keeps only interactive sessions;
+// ExcludeInteractive (the mirror predicate) keeps only automated ones.
+func TestGetActivityReport_AutomationFilterAndSessionSplit(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	// Two automated (roborev-style) sessions and one interactive, all timed
+	// on 2026-06-16 so each is a candidate for that day's report. Automated
+	// sessions are classified the way the sync path does it: a single-turn
+	// session whose first message matches a known automated prompt prefix.
+	for _, id := range []string{"auto1", "auto2"} {
+		start := "2026-06-16T10:00:00Z"
+		end := "2026-06-16T10:02:00Z"
+		insertSession(t, d, id, "proj1", func(s *Session) {
+			s.Agent = "claude"
+			s.FirstMessage = Ptr("You are a code reviewer.")
+			s.UserMessageCount = 1
+			s.StartedAt = Ptr(start)
+			s.EndedAt = Ptr(end)
+		})
+		seedMessage(t, d, id, 1, "user", start, "")
+		seedMessage(t, d, id, 2, "assistant", end, "opus")
+	}
+	insertSession(t, d, "human", "proj2", func(s *Session) {
+		s.Agent = "codex"
+		s.StartedAt = Ptr("2026-06-16T12:00:00Z")
+		s.EndedAt = Ptr("2026-06-16T12:02:00Z")
+	})
+	seedMessage(t, d, "human", 1, "user", "2026-06-16T12:00:00Z", "")
+	seedMessage(t, d, "human", 2, "assistant", "2026-06-16T12:02:00Z", "gpt5")
+
+	tests := []struct {
+		name            string
+		filter          AnalyticsFilter
+		wantAutomated   int
+		wantInteractive int
+		wantIDs         []string
+	}{
+		{
+			name:            "all keeps both classes",
+			filter:          AnalyticsFilter{Timezone: "UTC"},
+			wantAutomated:   2,
+			wantInteractive: 1,
+			wantIDs:         []string{"auto1", "auto2", "human"},
+		},
+		{
+			name:            "exclude automated keeps interactive only",
+			filter:          AnalyticsFilter{Timezone: "UTC", ExcludeAutomated: true},
+			wantAutomated:   0,
+			wantInteractive: 1,
+			wantIDs:         []string{"human"},
+		},
+		{
+			name:            "exclude interactive keeps automated only",
+			filter:          AnalyticsFilter{Timezone: "UTC", ExcludeInteractive: true},
+			wantAutomated:   2,
+			wantInteractive: 0,
+			wantIDs:         []string{"auto1", "auto2"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := d.GetActivityReport(ctx, tc.filter,
+				dayQuery(t, "2026-06-16", "UTC"))
+			require.NoError(t, err)
+			assert.Equal(t, len(tc.wantIDs), r.Totals.Sessions)
+			assert.Equal(t, tc.wantAutomated, r.Totals.AutomatedSessions)
+			assert.Equal(t, tc.wantInteractive, r.Totals.InteractiveSessions)
+			ids := reportSessionIDs(r.BySession)
+			require.Len(t, ids, len(tc.wantIDs))
+			for _, id := range tc.wantIDs {
+				assert.Contains(t, ids, id)
+			}
+		})
+	}
+}

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -410,3 +410,30 @@ func TestGetActivityReport_TitleSkipsEmptyDisplayName(t *testing.T) {
 	assert.Equal(t, "real-session-name", r.BySession[0].Title,
 		"empty display_name must not mask the real session_name")
 }
+
+// TestGetActivityReport_OpenSessionWithInRangeMessageIncluded confirms a
+// still-open session (no ended_at) that started before the range but has a
+// message inside it is not dropped. The effective-end fallback uses the
+// session's latest message timestamp, not started_at, so the overlap
+// predicate sees the in-range activity. Without the fix, ended_at falls back
+// to the pre-range started_at and the session vanishes from the report.
+func TestGetActivityReport_OpenSessionWithInRangeMessageIncluded(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	// Started the day before and never closed (no ended_at), active in-range.
+	insertSession(t, d, "open", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-15T23:00:00Z")
+	})
+	seedMessage(t, d, "open", 1, "user", "2026-06-16T10:00:00Z", "")
+	seedMessage(t, d, "open", 2, "assistant", "2026-06-16T10:02:00Z", "opus")
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	ids := reportSessionIDs(r.BySession)
+	assert.Contains(t, ids, "open",
+		"open session active in-range must not be dropped by the started_at fallback")
+	assert.Equal(t, 1, r.Totals.Sessions)
+}

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -31,8 +31,19 @@ func queryChunked(
 	ids []string,
 	fn func(chunk []string) error,
 ) error {
-	for i := 0; i < len(ids); i += maxSQLVars {
-		end := min(i+maxSQLVars, len(ids))
+	return queryChunkedSize(ids, maxSQLVars, fn)
+}
+
+// queryChunkedSize is queryChunked with an explicit per-chunk size, for
+// queries that bind each ID more than once (and so need a smaller chunk to
+// keep the total bind count within SQLite's variable limit).
+func queryChunkedSize(
+	ids []string,
+	size int,
+	fn func(chunk []string) error,
+) error {
+	for i := 0; i < len(ids); i += size {
+		end := min(i+size, len(ids))
 		if err := fn(ids[i:end]); err != nil {
 			return err
 		}

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -53,8 +53,12 @@ type AnalyticsFilter struct {
 	MinUserMessages  int    // user_message_count >= N
 	ExcludeOneShot   bool   // exclude sessions with user_message_count <= 1
 	ExcludeAutomated bool   // exclude automated (roborev) sessions
-	ActiveSince      string // ISO timestamp cutoff
-	Termination      string // "", "clean", or "unclean"
+	// ExcludeInteractive is the mirror of ExcludeAutomated: it keeps only
+	// automated sessions. The two are never set together (that would match
+	// nothing); the activity report uses them for its automation filter.
+	ExcludeInteractive bool
+	ActiveSince        string // ISO timestamp cutoff
+	Termination        string // "", "clean", or "unclean"
 }
 
 // location loads the timezone or returns UTC on error.
@@ -220,6 +224,9 @@ func (f AnalyticsFilter) buildWhereWithDate(
 	}
 	if f.ExcludeAutomated {
 		preds = append(preds, "is_automated = 0")
+	}
+	if f.ExcludeInteractive {
+		preds = append(preds, "is_automated = 1")
 	}
 
 	if f.ActiveSince != "" {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -913,6 +913,20 @@ func (db *DB) createPartialIndexesLocked(w *sql.DB) error {
 	); err != nil {
 		return fmt.Errorf("dropping legacy usage index: %w", err)
 	}
+	// Rebuild the insight lookup index so it covers date_to (added for
+	// range-aware lookups). DROP/CREATE only touches the index, never the
+	// insights rows, so this is non-destructive.
+	if _, err := w.Exec(
+		`DROP INDEX IF EXISTS idx_insights_lookup`,
+	); err != nil {
+		return fmt.Errorf("recreating idx_insights_lookup: %w", err)
+	}
+	if _, err := w.Exec(
+		`CREATE INDEX IF NOT EXISTS idx_insights_lookup
+		 ON insights(type, date_from, date_to, project)`,
+	); err != nil {
+		return fmt.Errorf("recreating idx_insights_lookup: %w", err)
+	}
 	return nil
 }
 

--- a/internal/db/insights.go
+++ b/internal/db/insights.go
@@ -26,6 +26,8 @@ type InsightFilter struct {
 	Type       string // "daily_activity" or "agent_analysis"
 	Project    string // "" = no filter
 	GlobalOnly bool   // true = project IS NULL only
+	DateFrom   string // YYYY-MM-DD, "" = no filter
+	DateTo     string // YYYY-MM-DD, "" = no filter
 }
 
 const insightBaseCols = `id, type, date_from, date_to,
@@ -56,6 +58,14 @@ func buildInsightFilter(
 	} else if f.Project != "" {
 		preds = append(preds, "project = ?")
 		args = append(args, f.Project)
+	}
+	if f.DateFrom != "" {
+		preds = append(preds, "date_from >= ?")
+		args = append(args, f.DateFrom)
+	}
+	if f.DateTo != "" {
+		preds = append(preds, "date_to <= ?")
+		args = append(args, f.DateTo)
 	}
 
 	if len(preds) == 0 {

--- a/internal/db/insights_test.go
+++ b/internal/db/insights_test.go
@@ -219,6 +219,58 @@ func TestListInsights(t *testing.T) {
 	}
 }
 
+func TestListInsights_DateFilter(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	_, err := d.InsertInsight(Insight{Type: "daily_activity",
+		DateFrom: "2026-06-16", DateTo: "2026-06-16", Agent: "claude", Content: "x"})
+	require.NoError(t, err)
+	_, err = d.InsertInsight(Insight{Type: "daily_activity",
+		DateFrom: "2026-06-17", DateTo: "2026-06-17", Agent: "claude", Content: "y"})
+	require.NoError(t, err)
+
+	got, err := d.ListInsights(ctx, InsightFilter{
+		Type: "daily_activity", DateFrom: "2026-06-16", DateTo: "2026-06-16"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "2026-06-16", got[0].DateFrom)
+}
+
+func TestListInsights_DistinguishesByDateTo(t *testing.T) {
+	d := testDB(t)
+	// A single-day insight and a week insight sharing the same date_from.
+	_, err := d.InsertInsight(Insight{
+		Type: "daily_activity", DateFrom: "2026-06-15", DateTo: "2026-06-15",
+		Agent: "claude", Content: "day",
+	})
+	require.NoError(t, err)
+	_, err = d.InsertInsight(Insight{
+		Type: "daily_activity", DateFrom: "2026-06-15", DateTo: "2026-06-21",
+		Agent: "claude", Content: "week",
+	})
+	require.NoError(t, err)
+
+	got, err := d.ListInsights(context.Background(), InsightFilter{
+		Type: "daily_activity", DateFrom: "2026-06-15", DateTo: "2026-06-15",
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "filtering both bounds isolates the single-day insight")
+	assert.Equal(t, "day", got[0].Content)
+}
+
+func TestInsightsLookupIndexHasDateTo(t *testing.T) {
+	d := testDB(t)
+	rows, err := d.Reader().Query("PRAGMA index_info(idx_insights_lookup)")
+	require.NoError(t, err)
+	defer rows.Close()
+	var n int
+	for rows.Next() {
+		n++
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, 4, n, "lookup index covers type, date_from, date_to, project")
+}
+
 func TestInsights_Delete(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -253,7 +253,7 @@ CREATE TABLE IF NOT EXISTS insights (
 );
 
 CREATE INDEX IF NOT EXISTS idx_insights_lookup
-    ON insights(type, date_from, project);
+    ON insights(type, date_from, date_to, project);
 
 CREATE INDEX IF NOT EXISTS idx_insights_created
     ON insights(created_at DESC);

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1,6 +1,10 @@
 package db
 
-import "context"
+import (
+	"context"
+
+	"go.kenn.io/agentsview/internal/activity"
+)
 
 // ErrReadOnly is returned by write methods on read-only store
 // implementations (e.g. the PostgreSQL reader).
@@ -66,6 +70,7 @@ type Store interface {
 	GetAnalyticsTopSessions(ctx context.Context, f AnalyticsFilter, metric string) (TopSessionsResponse, error)
 	GetAnalyticsSignals(ctx context.Context, f AnalyticsFilter) (SignalsAnalyticsResponse, error)
 	GetTrendsTerms(ctx context.Context, f AnalyticsFilter, terms []TrendTermInput, granularity string) (TrendsTermsResponse, error)
+	GetActivityReport(ctx context.Context, f AnalyticsFilter, q activity.Query) (activity.Report, error)
 
 	// Usage (token cost).
 	GetDailyUsage(ctx context.Context, f UsageFilter) (DailyUsageResult, error)

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -1,0 +1,416 @@
+package duckdb
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// activityReportRangeBoundsUTC returns the exact [start, end) UTC bounds
+// of the resolved range `q` as RFC3339 strings. It mirrors the SQLite and
+// PostgreSQL backends so the candidate-session predicate selects exactly
+// the sessions whose window intersects the range, with no padding slop.
+// DuckDB compares parsed instants (the bounds are cast to TIMESTAMP), so
+// it keeps the zone suffix, unlike SQLite's zone-less TEXT comparison.
+func activityReportRangeBoundsUTC(q activity.Query) (string, string) {
+	return q.RangeStart.UTC().Format(time.RFC3339),
+		q.RangeEnd.UTC().Format(time.RFC3339)
+}
+
+// GetActivityReport assembles a concurrency- and usage-oriented report
+// for the resolved range `q`, reading from the DuckDB store. It mirrors
+// the SQLite (*DB).GetActivityReport and PostgreSQL
+// (*Store).GetActivityReport: three fetches scoped to the SAME candidate
+// session-ID set so the concurrency timeline, sessions table, and usage
+// totals stay mutually consistent (no orphan usage rows), then the
+// in-memory streams are handed to activity.Aggregate.
+//
+// The filter `f` is honored as-is: callers that want one-shot or
+// automated sessions included must pass them through with the
+// corresponding exclusions disabled.
+func (s *Store) GetActivityReport(
+	ctx context.Context, f db.AnalyticsFilter, q activity.Query,
+) (activity.Report, error) {
+	rangeStartUTC, rangeEndUTC := activityReportRangeBoundsUTC(q)
+	lowerBound := duckUsagePaddedUTCBound(q.RangeStart.UTC().Format(time.RFC3339), -14)
+	upperBound := duckUsagePaddedUTCBound(q.RangeEnd.UTC().Format(time.RFC3339), 14)
+
+	sessions, ids, err := s.activityReportSessions(
+		ctx, f, rangeStartUTC, rangeEndUTC)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	acts, err := s.activityReportActivity(ctx, ids)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	usage, err := s.activityReportUsage(ctx, ids, lowerBound, upperBound)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	return activity.Aggregate(activity.Params{
+		RangeStart:    q.RangeStart,
+		RangeEnd:      q.RangeEnd,
+		Loc:           q.Loc,
+		EffectiveEnd:  q.EffectiveEnd,
+		Partial:       q.Partial,
+		GapCapSeconds: q.GapCapSeconds,
+		Bucket:        q.Bucket,
+	}, sessions, acts, usage), nil
+}
+
+// activityReportSessions returns the candidate sessions whose window
+// overlaps the exact range [rangeStartUTC, rangeEndUTC), plus their
+// IDs. The ID set defines the scope for the activity and usage fetches.
+// DuckDB stores native timestamps, so the timestamp fallbacks need no
+// NULLIF guard. The Title COALESCE guards s.project with NULLIF on the
+// empty string because the project column is NOT NULL with a default of
+// the empty string here: without the guard an empty project would win the
+// fallback and yield an empty Title instead of the session id, diverging
+// from the SQLite and PostgreSQL Title expressions.
+func (s *Store) activityReportSessions(
+	ctx context.Context, f db.AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
+) ([]activity.SessionMeta, []string, error) {
+	where, args := duckBuildAnalyticsWhere(
+		f, "COALESCE(s.started_at, s.created_at)", "s.", false, false)
+	args = append(args, rangeStartUTC, rangeEndUTC)
+
+	query := `SELECT
+		s.id,
+		COALESCE(s.display_name, s.session_name, s.first_message, NULLIF(s.project, ''), s.id) AS display_name,
+		s.project,
+		s.agent,
+		s.machine,
+		s.started_at,
+		s.ended_at,
+		COALESCE(s.is_automated, false) AS is_automated
+	FROM sessions s
+	WHERE ` + where + `
+		AND COALESCE(s.ended_at, s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)
+		AND COALESCE(s.started_at, s.created_at) < CAST(? AS TIMESTAMP)`
+
+	rows, err := s.duck.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"querying duckdb activity report sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []activity.SessionMeta
+	var ids []string
+	for rows.Next() {
+		var m activity.SessionMeta
+		var startedAt, endedAt any
+		if err := rows.Scan(
+			&m.SessionID, &m.Title, &m.Project, &m.Agent,
+			&m.Machine, &startedAt, &endedAt, &m.IsAutomated,
+		); err != nil {
+			return nil, nil, fmt.Errorf(
+				"scanning duckdb activity report session: %w", err)
+		}
+		m.StartedAt = formatDBTime(startedAt)
+		m.EndedAt = formatDBTime(endedAt)
+		sessions = append(sessions, m)
+		ids = append(ids, m.SessionID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf(
+			"iterating duckdb activity report sessions: %w", err)
+	}
+	return sessions, ids, nil
+}
+
+// activityReportActivity returns every timestamped message for the
+// candidate sessions, ordered for the aggregator's per-session interval
+// walk. It is not time-bounded so cross-boundary successor messages are
+// present.
+func (s *Store) activityReportActivity(
+	ctx context.Context, ids []string,
+) ([]activity.ActivityEvent, error) {
+	var out []activity.ActivityEvent
+	if len(ids) == 0 {
+		return out, nil
+	}
+	args, placeholders := stringInArgs(ids)
+	query := `SELECT session_id, ordinal, role, timestamp, model
+		FROM messages
+		WHERE session_id IN (` + strings.Join(placeholders, ",") + `)
+			AND timestamp IS NOT NULL
+		ORDER BY session_id, ordinal`
+
+	rows, err := s.duck.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"querying duckdb activity report activity: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var e activity.ActivityEvent
+		var ts any
+		if err := rows.Scan(
+			&e.SessionID, &e.Ordinal, &e.Role, &ts, &e.Model,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"scanning duckdb activity report activity: %w", err)
+		}
+		e.Timestamp = formatDBTime(ts)
+		if e.Timestamp == "" {
+			continue
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating duckdb activity report activity: %w", err)
+	}
+	return out, nil
+}
+
+// duckActivityReportUsageRow is one scanned usage-union row before mapping
+// into an activity.UsageRow, carrying the normalized token amounts and
+// dedup keys the aggregator and per-row cost need.
+type duckActivityReportUsageRow struct {
+	sessionID       string
+	model           string
+	ts              string
+	messageOrdinal  any
+	claudeMessageID string
+	claudeRequestID string
+	usageDedupKey   string
+	inputTok        int
+	outputTok       int
+	cacheCr         int
+	cacheRd         int
+	costUSD         *float64
+}
+
+// activityReportUsage returns the usage rows for the candidate sessions
+// within the padded range bounds, with per-row cost computed up front
+// (mirroring GetDailyUsage's cost logic) so cost stays in the backend.
+// Rows are delivered as one globally ordered stream by
+// (ts, session_id, message_ordinal) as the aggregator's first-seen-wins
+// dedup requires. The ordering is computed in Go on the parsed time
+// value, not the formatted string, to avoid fractional-second lexical
+// issues.
+func (s *Store) activityReportUsage(
+	ctx context.Context, ids []string, lowerBound, upperBound string,
+) ([]activity.UsageRow, error) {
+	var out []activity.UsageRow
+	if len(ids) == 0 {
+		return out, nil
+	}
+
+	pricing, err := s.loadPricing(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading duckdb pricing: %w", err)
+	}
+
+	idArgs, placeholders := stringInArgs(ids)
+	inClause := strings.Join(placeholders, ",")
+	query := duckActivityReportUsageQuery(inClause)
+	args := make([]any, 0, len(idArgs)*2+2)
+	args = append(args, idArgs...) // message-source IN
+	args = append(args, idArgs...) // event-source IN
+	args = append(args, lowerBound, upperBound)
+
+	rows, err := s.duck.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying duckdb activity report usage: %w", err)
+	}
+	defer rows.Close()
+
+	// Accumulate the parsed ts and dedup ordinal alongside each mapped row
+	// so a single global (ts, session_id, ordinal) order can be imposed
+	// before the aggregator's first-seen dedup.
+	type ordered struct {
+		row     activity.UsageRow
+		ts      time.Time
+		ordinal int64
+	}
+	var rowsAcc []ordered
+
+	for rows.Next() {
+		var r duckActivityReportUsageRow
+		if err := rows.Scan(
+			&r.sessionID, &r.messageOrdinal, &r.ts, &r.model,
+			&r.claudeMessageID, &r.claudeRequestID, &r.usageDedupKey,
+			&r.inputTok, &r.outputTok, &r.cacheCr, &r.cacheRd, &r.costUSD,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"scanning duckdb activity report usage: %w", err)
+		}
+		tsStr := formatDBTime(r.ts)
+		_, cost := duckActivityReportRowCost(r, pricing)
+		ord := int64(-1)
+		if o, ok := duckUsageOrdinal(r.messageOrdinal); ok {
+			ord = o
+		}
+		parsedTS, _ := parseTimestamp(tsStr)
+		rowsAcc = append(rowsAcc, ordered{
+			ts:      parsedTS,
+			ordinal: ord,
+			row: activity.UsageRow{
+				SessionID:       r.sessionID,
+				Model:           r.model,
+				Timestamp:       tsStr,
+				OutputTokens:    r.outputTok,
+				Cost:            cost,
+				ClaudeMessageID: r.claudeMessageID,
+				ClaudeRequestID: r.claudeRequestID,
+				UsageDedupKey:   r.usageDedupKey,
+			},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating duckdb activity report usage: %w", err)
+	}
+
+	sort.SliceStable(rowsAcc, func(i, j int) bool {
+		a, b := rowsAcc[i], rowsAcc[j]
+		if !a.ts.Equal(b.ts) {
+			return a.ts.Before(b.ts)
+		}
+		if a.row.SessionID != b.row.SessionID {
+			return a.row.SessionID < b.row.SessionID
+		}
+		return a.ordinal < b.ordinal
+	})
+	out = make([]activity.UsageRow, len(rowsAcc))
+	for i, o := range rowsAcc {
+		out[i] = o.row
+	}
+	return out, nil
+}
+
+// duckActivityReportUsageQuery builds the per-row usage-union SQL scoped to
+// the candidate sessions. It applies the same message and usage-event
+// eligibility predicates as GetDailyUsage (empty token_usage, empty, and
+// synthetic models excluded) so the daily totals match the Usage
+// dashboard, normalizes the per-source token columns in SQL, and bounds
+// rows to the padded range window. inClause is the comma-joined "?"
+// placeholder list; it is interpolated twice (message source, event
+// source). Cost is computed per row in Go.
+func duckActivityReportUsageQuery(inClause string) string {
+	return fmt.Sprintf(`
+		WITH usage_raw AS (
+			SELECT m.session_id AS session_id, m.ordinal AS message_ordinal,
+				'message' AS source, COALESCE(m.timestamp, s.started_at) AS ts,
+				m.model AS model, m.token_usage AS token_json,
+				m.claude_message_id AS claude_message_id,
+				m.claude_request_id AS claude_request_id,
+				'' AS usage_dedup_key,
+				0 AS input_tokens, 0 AS output_tokens,
+				0 AS cache_create, 0 AS cache_read, NULL AS cost_usd
+			FROM messages m
+			JOIN sessions s ON s.id = m.session_id
+			WHERE m.token_usage != ''
+				AND m.model != ''
+				AND m.model != '<synthetic>'
+				AND s.deleted_at IS NULL
+				AND m.session_id IN (%[1]s)
+			UNION ALL
+			SELECT ue.session_id AS session_id, ue.message_ordinal AS message_ordinal,
+				ue.source AS source, COALESCE(ue.occurred_at, s.started_at) AS ts,
+				ue.model AS model, '' AS token_json,
+				'' AS claude_message_id, '' AS claude_request_id,
+				CASE
+					WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
+					ELSE ue.session_id || ':' || ue.source || ':id:' || CAST(ue.id AS VARCHAR)
+				END AS usage_dedup_key,
+				ue.input_tokens AS input_tokens, ue.output_tokens AS output_tokens,
+				ue.cache_creation_input_tokens AS cache_create,
+				ue.cache_read_input_tokens AS cache_read,
+				ue.cost_usd AS cost_usd
+			FROM usage_events ue
+			JOIN sessions s ON s.id = ue.session_id
+			WHERE ue.model != ''
+				AND s.deleted_at IS NULL
+				AND ue.session_id IN (%[1]s)
+		),
+		usage_normalized AS (
+			SELECT session_id, message_ordinal, ts, model,
+				claude_message_id, claude_request_id, usage_dedup_key,
+				CASE
+					WHEN source = 'message' THEN COALESCE(TRY_CAST(json_extract_string(token_json, '$.input_tokens') AS BIGINT), 0)
+					ELSE input_tokens
+				END AS input_tokens_norm,
+				CASE
+					WHEN source = 'message' THEN COALESCE(TRY_CAST(json_extract_string(token_json, '$.output_tokens') AS BIGINT), 0)
+					ELSE output_tokens
+				END AS output_tokens_norm,
+				CASE
+					WHEN source = 'message' THEN COALESCE(TRY_CAST(json_extract_string(token_json, '$.cache_creation_input_tokens') AS BIGINT), 0)
+					ELSE cache_create
+				END AS cache_create_norm,
+				CASE
+					WHEN source = 'message' THEN COALESCE(TRY_CAST(json_extract_string(token_json, '$.cache_read_input_tokens') AS BIGINT), 0)
+					ELSE cache_read
+				END AS cache_read_norm,
+				cost_usd
+			FROM usage_raw
+		)
+		SELECT session_id, message_ordinal, ts, model,
+			claude_message_id, claude_request_id, usage_dedup_key,
+			input_tokens_norm, output_tokens_norm,
+			cache_create_norm, cache_read_norm, cost_usd
+		FROM usage_normalized
+		WHERE ts >= CAST(? AS TIMESTAMP)
+			AND ts <= CAST(? AS TIMESTAMP)`, inClause)
+}
+
+// duckActivityReportRowCost computes one usage row's cost the same way
+// GetDailyUsage does: an explicit cost_usd wins, otherwise the per-model
+// rates price the normalized token amounts. Billable amounts equal the
+// normalized amounts when there is no explicit cost (mirroring the
+// billable_* SQL in dailyUsageAggregateRows). It returns the cache
+// savings delta and the cost.
+func duckActivityReportRowCost(
+	r duckActivityReportUsageRow, pricing map[string]duckRates,
+) (savings, cost float64) {
+	var explicitCost float64
+	var billableInput, billableOutput, billableCacheCr, billableCacheRd int
+	if r.costUSD != nil {
+		explicitCost = *r.costUSD
+	} else {
+		billableInput = r.inputTok
+		billableOutput = r.outputTok
+		billableCacheCr = r.cacheCr
+		billableCacheRd = r.cacheRd
+	}
+	cost, savings, _, _ = duckUsageAggregateCost(
+		r.model,
+		r.inputTok, r.outputTok, r.cacheCr, r.cacheRd,
+		billableInput, billableOutput, billableCacheCr, billableCacheRd,
+		explicitCost,
+		pricing,
+	)
+	return savings, cost
+}
+
+// duckUsageOrdinal extracts a non-negative message ordinal from a
+// scanned value (DuckDB returns NULL message_ordinal for some usage
+// events). ok is false when the value is NULL or not an integer.
+func duckUsageOrdinal(v any) (int64, bool) {
+	switch n := v.(type) {
+	case nil:
+		return 0, false
+	case int64:
+		return n, true
+	case int32:
+		return int64(n), true
+	case int:
+		return int64(n), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -77,6 +77,13 @@ func (s *Store) GetActivityReport(
 // fallback (those columns can be empty here, and project is NOT NULL with an
 // empty-string default), yielding the same Title as the other two backends
 // instead of a possibly-empty one.
+//
+// The effective-end fallback for a session with no ended_at uses its
+// latest message timestamp before started_at, so a still-open session
+// that began before the range but has messages inside it is not dropped,
+// matching SQLite and PostgreSQL. COALESCE short-circuits, so the
+// correlated MAX subquery runs only for the rare sessions missing an
+// ended_at.
 func (s *Store) activityReportSessions(
 	ctx context.Context, f db.AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
 ) ([]activity.SessionMeta, []string, error) {
@@ -95,7 +102,10 @@ func (s *Store) activityReportSessions(
 		COALESCE(s.is_automated, false) AS is_automated
 	FROM sessions s
 	WHERE ` + where + `
-		AND COALESCE(s.ended_at, s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)
+		AND COALESCE(s.ended_at,
+			(SELECT MAX(m.timestamp) FROM messages m
+				WHERE m.session_id = s.id AND m.timestamp IS NOT NULL),
+			s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)
 		AND COALESCE(s.started_at, s.created_at) < CAST(? AS TIMESTAMP)`
 
 	rows, err := s.duck.QueryContext(ctx, query, args...)

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -86,7 +86,7 @@ func (s *Store) activityReportSessions(
 
 	query := `SELECT
 		s.id,
-		COALESCE(NULLIF(COALESCE(s.display_name, s.session_name), ''), NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id) AS display_name,
+		COALESCE(NULLIF(s.display_name, ''), NULLIF(s.session_name, ''), NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id) AS display_name,
 		s.project,
 		s.agent,
 		s.machine,

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -71,11 +71,12 @@ func (s *Store) GetActivityReport(
 // overlaps the exact range [rangeStartUTC, rangeEndUTC), plus their
 // IDs. The ID set defines the scope for the activity and usage fetches.
 // DuckDB stores native timestamps, so the timestamp fallbacks need no
-// NULLIF guard. The Title COALESCE guards s.project with NULLIF on the
-// empty string because the project column is NOT NULL with a default of
-// the empty string here: without the guard an empty project would win the
-// fallback and yield an empty Title instead of the session id, diverging
-// from the SQLite and PostgreSQL Title expressions.
+// NULLIF guard. The Title expression mirrors the shared NULLIF/COALESCE
+// shape used by SQLite and PostgreSQL so an empty-string
+// display_name/session_name/first_message/project never wins the COALESCE
+// fallback (those columns can be empty here, and project is NOT NULL with an
+// empty-string default), yielding the same Title as the other two backends
+// instead of a possibly-empty one.
 func (s *Store) activityReportSessions(
 	ctx context.Context, f db.AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
 ) ([]activity.SessionMeta, []string, error) {
@@ -85,7 +86,7 @@ func (s *Store) activityReportSessions(
 
 	query := `SELECT
 		s.id,
-		COALESCE(s.display_name, s.session_name, s.first_message, NULLIF(s.project, ''), s.id) AS display_name,
+		COALESCE(NULLIF(COALESCE(s.display_name, s.session_name), ''), NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id) AS display_name,
 		s.project,
 		s.agent,
 		s.machine,

--- a/internal/duckdb/activityreport_test.go
+++ b/internal/duckdb/activityreport_test.go
@@ -333,3 +333,101 @@ func TestDuckGetActivityReportZeroCostKeepsPrimaryModel(t *testing.T) {
 	assert.Equal(t, "model-x", r.BySession[0].PrimaryModel,
 		"zero-cost usage must still report its known model as primary")
 }
+
+// TestDuckGetActivityReportAutomationFilterAndSessionSplit confirms the shared
+// AnalyticsFilter automation class is honored through the DuckDB analytics
+// WHERE builder and that the Totals session-count split survives the sync into
+// DuckDB. Mirrors the SQLite
+// TestGetActivityReport_AutomationFilterAndSessionSplit.
+func TestDuckGetActivityReportAutomationFilterAndSessionSplit(t *testing.T) {
+	ctx := context.Background()
+
+	// The sync path (WriteSessionBatchAtomic) classifies is_automated from the
+	// transcript: a single-turn session whose first user message matches a
+	// known automated (roborev) prompt prefix. Setting the struct flag alone
+	// would be overridden by updateSessionAutomationFromMessagesTx, so the
+	// automated sessions carry an automated first user message and a single
+	// user turn, exactly as a real roborev review session does.
+	auto1 := syncSession("auto1", "proj1", "You are a code reviewer.", "2026-06-14T10:00:00.000Z", 2)
+	auto1.Agent = "claude"
+	auto2 := syncSession("auto2", "proj1", "You are a code reviewer.", "2026-06-14T11:00:00.000Z", 2)
+	auto2.Agent = "claude"
+	human := syncSession("human", "proj2", "human first", "2026-06-14T12:00:00.000Z", 2)
+	human.Agent = "codex"
+
+	writes := []db.SessionBatchWrite{
+		{
+			Session: auto1,
+			Messages: []db.Message{
+				syncMessage("auto1", 0, "user", "You are a code reviewer.", "2026-06-14T10:00:00.000Z"),
+				syncMessage("auto1", 1, "assistant", "x", "2026-06-14T10:02:00.000Z"),
+			},
+			DataVersion: 1, ReplaceMessages: true,
+		},
+		{
+			Session: auto2,
+			Messages: []db.Message{
+				syncMessage("auto2", 0, "user", "You are a code reviewer.", "2026-06-14T11:00:00.000Z"),
+				syncMessage("auto2", 1, "assistant", "x", "2026-06-14T11:02:00.000Z"),
+			},
+			DataVersion: 1, ReplaceMessages: true,
+		},
+		{
+			Session: human,
+			Messages: []db.Message{
+				syncMessage("human", 0, "user", "u", "2026-06-14T12:00:00.000Z"),
+				syncMessage("human", 1, "assistant", "x", "2026-06-14T12:02:00.000Z"),
+			},
+			DataVersion: 1, ReplaceMessages: true,
+		},
+	}
+	store := activityReportStore(t, writes, nil)
+
+	tests := []struct {
+		name            string
+		filter          db.AnalyticsFilter
+		wantAutomated   int
+		wantInteractive int
+		wantIDs         []string
+	}{
+		{
+			name:            "all keeps both classes",
+			filter:          db.AnalyticsFilter{Timezone: "UTC"},
+			wantAutomated:   2,
+			wantInteractive: 1,
+			wantIDs:         []string{"auto1", "auto2", "human"},
+		},
+		{
+			name:            "exclude automated keeps interactive only",
+			filter:          db.AnalyticsFilter{Timezone: "UTC", ExcludeAutomated: true},
+			wantAutomated:   0,
+			wantInteractive: 1,
+			wantIDs:         []string{"human"},
+		},
+		{
+			name:            "exclude interactive keeps automated only",
+			filter:          db.AnalyticsFilter{Timezone: "UTC", ExcludeInteractive: true},
+			wantAutomated:   2,
+			wantInteractive: 0,
+			wantIDs:         []string{"auto1", "auto2"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := store.GetActivityReport(ctx, tc.filter,
+				duckDayQuery(t, "2026-06-14", "UTC"))
+			require.NoError(t, err)
+			assert.Equal(t, len(tc.wantIDs), r.Totals.Sessions)
+			assert.Equal(t, tc.wantAutomated, r.Totals.AutomatedSessions)
+			assert.Equal(t, tc.wantInteractive, r.Totals.InteractiveSessions)
+			ids := make(map[string]struct{}, len(r.BySession))
+			for _, s := range r.BySession {
+				ids[s.SessionID] = struct{}{}
+			}
+			require.Len(t, ids, len(tc.wantIDs))
+			for _, id := range tc.wantIDs {
+				assert.Contains(t, ids, id)
+			}
+		})
+	}
+}

--- a/internal/duckdb/activityreport_test.go
+++ b/internal/duckdb/activityreport_test.go
@@ -220,6 +220,42 @@ func TestDuckGetActivityReportPriorDayWithinPadExcluded(t *testing.T) {
 	assert.Equal(t, 0, r.Totals.UntimedSessions)
 }
 
+// TestDuckGetActivityReportOpenSessionWithInRangeMessageIncluded confirms a
+// still-open session (no ended_at) that started before the range but has a
+// message inside it is not dropped. The effective-end fallback uses the
+// session's latest message timestamp, not started_at, matching SQLite and
+// PostgreSQL. Mirrors the SQLite
+// TestGetActivityReport_OpenSessionWithInRangeMessageIncluded.
+func TestDuckGetActivityReportOpenSessionWithInRangeMessageIncluded(t *testing.T) {
+	ctx := context.Background()
+	// Started the day before and never closed (ended_at nil), active in-range.
+	open := syncSession("open", "proj1", "open first", "2026-06-13T23:00:00.000Z", 2)
+	open.Agent = "claude"
+	open.EndedAt = nil
+	writes := []db.SessionBatchWrite{{
+		Session: open,
+		Messages: []db.Message{
+			syncMessage("open", 0, "user", "u", "2026-06-14T10:00:00.000Z"),
+			syncMessage("open", 1, "assistant", "x", "2026-06-14T10:02:00.000Z"),
+		},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}}
+	store := activityReportStore(t, writes, nil)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	ids := make(map[string]struct{}, len(r.BySession))
+	for _, s := range r.BySession {
+		ids[s.SessionID] = struct{}{}
+	}
+	assert.Contains(t, ids, "open",
+		"open session active in-range must not be dropped by the started_at fallback")
+	assert.Equal(t, 1, r.Totals.Sessions)
+}
+
 // TestDuckGetActivityReportUsageDedupSubSecondOrder confirms DuckDB orders the
 // usage stream by the parsed instant so first-seen-wins dedup keeps the
 // chronologically earlier row when two rows share a dedup key in the same

--- a/internal/duckdb/activityreport_test.go
+++ b/internal/duckdb/activityreport_test.go
@@ -219,3 +219,81 @@ func TestDuckGetActivityReportPriorDayWithinPadExcluded(t *testing.T) {
 	assert.Equal(t, 1, r.Totals.Sessions)
 	assert.Equal(t, 0, r.Totals.UntimedSessions)
 }
+
+// TestDuckGetActivityReportUsageDedupSubSecondOrder confirms DuckDB orders the
+// usage stream by the parsed instant so first-seen-wins dedup keeps the
+// chronologically earlier row when two rows share a dedup key in the same
+// second -- one whole-second ("...00Z"), one fractional ("...00.123Z"). DuckDB
+// already sorts on the parsed time (not the formatted text), so this locks in
+// that cross-backend behavior, matching the SQLite
+// TestGetActivityReport_UsageDedupSubSecondOrder.
+func TestDuckGetActivityReportUsageDedupSubSecondOrder(t *testing.T) {
+	ctx := context.Background()
+	pricing := []db.ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}
+
+	// A resumed/forked pair shares one (claude_message_id, claude_request_id)
+	// across two sessions: the earlier whole-second instant carries 500 output
+	// tokens, the later fractional instant 9000. Dedup must keep the 500 row.
+	earlier := syncSession("earlier", "proj1", "first", "2026-06-14T10:30:00Z", 1)
+	earlierMsg := syncMessage("earlier", 0, "assistant", "x", "2026-06-14T10:30:00Z")
+	earlierMsg.Model = "claude-sonnet-4-20250514"
+	earlierMsg.ClaudeMessageID = "dup-m"
+	earlierMsg.ClaudeRequestID = "dup-r"
+	earlierMsg.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	earlierMsg.OutputTokens = 500
+
+	later := syncSession("later", "proj2", "first", "2026-06-14T10:30:00.123Z", 1)
+	laterMsg := syncMessage("later", 0, "assistant", "x", "2026-06-14T10:30:00.123Z")
+	laterMsg.Model = "claude-sonnet-4-20250514"
+	laterMsg.ClaudeMessageID = "dup-m"
+	laterMsg.ClaudeRequestID = "dup-r"
+	laterMsg.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":9000}`)
+	laterMsg.OutputTokens = 9000
+
+	writes := []db.SessionBatchWrite{
+		{Session: earlier, Messages: []db.Message{earlierMsg},
+			DataVersion: 1, ReplaceMessages: true},
+		{Session: later, Messages: []db.Message{laterMsg},
+			DataVersion: 1, ReplaceMessages: true},
+	}
+	store := activityReportStore(t, writes, pricing)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens,
+		"first-seen dedup keeps the chronologically earlier whole-second row")
+}
+
+// TestDuckGetActivityReportZeroCostKeepsPrimaryModel confirms a usage-only
+// (untimed) session whose known-model usage carries zero cost still reports
+// that model as primary through the DuckDB path, guarding the shared zero-cost
+// fallback end-to-end. Mirrors the aggregator unit test
+// TestAggregate_UsageOnlySessionZeroCostKeepsPrimaryModel.
+func TestDuckGetActivityReportZeroCostKeepsPrimaryModel(t *testing.T) {
+	ctx := context.Background()
+	sess := syncSession("u", "proj1", "first", "2026-06-14T10:30:00Z", 1)
+	msg := syncMessage("u", 0, "assistant", "x", "2026-06-14T10:30:00Z")
+	// Known model, unpriced and zero tokens -> a usage row with zero cost.
+	msg.Model = "model-x"
+	msg.TokenUsage = json.RawMessage(`{"input_tokens":0,"output_tokens":0}`)
+	msg.OutputTokens = 0
+	writes := []db.SessionBatchWrite{{
+		Session: sess, Messages: []db.Message{msg},
+		DataVersion: 1, ReplaceMessages: true,
+	}}
+	store := activityReportStore(t, writes, nil)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	require.Len(t, r.BySession, 1)
+	assert.Equal(t, "model-x", r.BySession[0].PrimaryModel,
+		"zero-cost usage must still report its known model as primary")
+}

--- a/internal/duckdb/activityreport_test.go
+++ b/internal/duckdb/activityreport_test.go
@@ -1,0 +1,221 @@
+//go:build !(windows && arm64)
+
+package duckdb
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// duckDayQuery resolves a single-day "day" Query for date/tz against a
+// fixed far-future now, so the candidate range is the full local day and
+// the report is never partial regardless of the wall clock.
+func duckDayQuery(t *testing.T, date, tz string) activity.Query {
+	t.Helper()
+	now, err := time.Parse(time.RFC3339, "2030-01-01T00:00:00Z")
+	require.NoError(t, err)
+	q, err := activity.ResolveQuery(
+		activity.QueryInput{Preset: "day", Date: date, Timezone: tz}, now)
+	require.NoError(t, err)
+	return q
+}
+
+// activityReportStore seeds the given writes into a fresh local SQLite DB,
+// pushes them into DuckDB, and returns a read-only DuckDB store, mirroring
+// newSyncedStore's sync path.
+func activityReportStore(
+	t *testing.T, writes []db.SessionBatchWrite, pricing []db.ModelPricing,
+) *Store {
+	t.Helper()
+	ctx := context.Background()
+	local := newLocalDB(t)
+	if len(pricing) > 0 {
+		require.NoError(t, local.UpsertModelPricing(pricing))
+	}
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+	syncer := newTestSync(t,
+		filepath.Join(t.TempDir(), "daily-report.duckdb"),
+		local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	return NewStoreFromDB(syncer.DB())
+}
+
+func TestDuckGetActivityReportBasicConcurrency(t *testing.T) {
+	ctx := context.Background()
+	// Two overlapping sessions on 2026-06-14 (UTC), each two timestamped
+	// messages, mirroring the SQLite and PostgreSQL parity fixtures.
+	aSession := syncSession("a", "proj1", "alpha first", "2026-06-14T10:00:00.000Z", 2)
+	aSession.Agent = "claude"
+	bSession := syncSession("b", "proj2", "beta first", "2026-06-14T10:01:00.000Z", 2)
+	bSession.Agent = "codex"
+	writes := []db.SessionBatchWrite{
+		{
+			Session: aSession,
+			Messages: []db.Message{
+				syncMessage("a", 0, "user", "u", "2026-06-14T10:00:00.000Z"),
+				syncMessage("a", 1, "assistant", "x", "2026-06-14T10:02:00.000Z"),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session: bSession,
+			Messages: []db.Message{
+				syncMessage("b", 0, "user", "u", "2026-06-14T10:01:00.000Z"),
+				syncMessage("b", 1, "assistant", "x", "2026-06-14T10:03:00.000Z"),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	}
+	store := activityReportStore(t, writes, nil)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.Peak.Agents)
+	assert.Equal(t, 2, r.Totals.Sessions)
+	assert.GreaterOrEqual(t, len(r.ByAgent), 2)
+}
+
+func TestDuckGetActivityReportUsageCostAndTokens(t *testing.T) {
+	ctx := context.Background()
+	sess := syncSession("s1", "proj1", "first", "2026-06-14T10:30:00.000Z", 1)
+	sess.Agent = "claude"
+	// Override the default token usage to a known input/output split so the
+	// cost is deterministic.
+	msg := syncMessage("s1", 0, "assistant", "x", "2026-06-14T10:30:00.000Z")
+	msg.Model = "claude-sonnet-4-20250514"
+	msg.TokenUsage = json.RawMessage(
+		`{"input_tokens":1000,"output_tokens":500}`)
+	msg.OutputTokens = 500
+	writes := []db.SessionBatchWrite{{
+		Session:         sess,
+		Messages:        []db.Message{msg},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}}
+	pricing := []db.ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}
+	store := activityReportStore(t, writes, pricing)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.Totals.Sessions)
+	assert.Equal(t, 500, r.Totals.OutputTokens)
+	// Cost = (1000*3 + 500*15) / 1e6 = 0.0105
+	assert.InDelta(t, 0.0105, r.Totals.Cost, 1e-9)
+}
+
+// TestDuckGetActivityReportExcludesIneligibleUsage confirms the DuckDB
+// usage union (the one backend that inlines its own usage CTE rather
+// than sharing dailyUsageRowsSQLWithWhere) applies the same eligibility
+// filters as GetDailyUsage: a synthetic-model message carrying real
+// token_usage must not inflate the day totals. Mirrors the PostgreSQL
+// TestPGGetActivityReportExcludesIneligibleUsage.
+func TestDuckGetActivityReportExcludesIneligibleUsage(t *testing.T) {
+	ctx := context.Background()
+	sess := syncSession("s1", "proj1", "first", "2026-06-14T10:30:00.000Z", 2)
+	sess.Agent = "claude"
+	end := "2026-06-14T10:31:00.000Z"
+	sess.EndedAt = &end
+
+	eligible := syncMessage("s1", 0, "assistant", "x", "2026-06-14T10:30:00.000Z")
+	eligible.Model = "claude-sonnet-4-20250514"
+	eligible.TokenUsage = json.RawMessage(
+		`{"input_tokens":1000,"output_tokens":500}`)
+	eligible.OutputTokens = 500
+	// Ineligible: a synthetic-model message carrying real token_usage. The
+	// usage CTE drops m.model == '<synthetic>', so these tokens must NOT leak
+	// into the day totals even though the blob is non-empty.
+	synthetic := syncMessage("s1", 1, "assistant", "y", "2026-06-14T10:31:00.000Z")
+	synthetic.Model = "<synthetic>"
+	synthetic.TokenUsage = json.RawMessage(
+		`{"input_tokens":9000,"output_tokens":7000}`)
+	synthetic.OutputTokens = 7000
+
+	writes := []db.SessionBatchWrite{{
+		Session:         sess,
+		Messages:        []db.Message{eligible, synthetic},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}}
+	pricing := []db.ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}
+	store := activityReportStore(t, writes, pricing)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens, "synthetic message excluded")
+	// Cost = (1000*3 + 500*15) / 1e6 = 0.0105
+	assert.InDelta(t, 0.0105, r.Totals.Cost, 1e-9)
+}
+
+// TestDuckGetActivityReportPriorDayWithinPadExcluded confirms the candidate
+// window uses the EXACT local day, not the +/-14h padded bounds: a
+// session that began and ended on the prior day but lands inside the pad
+// must NOT appear as an untimed session in the target day's report.
+func TestDuckGetActivityReportPriorDayWithinPadExcluded(t *testing.T) {
+	ctx := context.Background()
+	today := syncSession("today", "proj1", "today first", "2026-06-14T10:00:00.000Z", 2)
+	today.Agent = "claude"
+	prior := syncSession("prior", "proj2", "prior first", "2026-06-13T12:00:00.000Z", 1)
+	prior.Agent = "codex"
+	priorEnd := "2026-06-13T12:05:00.000Z"
+	prior.EndedAt = &priorEnd
+	writes := []db.SessionBatchWrite{
+		{
+			Session: today,
+			Messages: []db.Message{
+				syncMessage("today", 0, "user", "u", "2026-06-14T10:00:00.000Z"),
+				syncMessage("today", 1, "assistant", "x", "2026-06-14T10:02:00.000Z"),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session: prior,
+			Messages: []db.Message{
+				syncMessage("prior", 0, "user", "u", "2026-06-13T12:00:00.000Z"),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	}
+	store := activityReportStore(t, writes, nil)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	ids := make(map[string]struct{}, len(r.BySession))
+	for _, s := range r.BySession {
+		ids[s.SessionID] = struct{}{}
+	}
+	assert.Contains(t, ids, "today")
+	assert.NotContains(t, ids, "prior", "prior-day session must not leak in")
+	assert.Equal(t, 1, r.Totals.Sessions)
+	assert.Equal(t, 0, r.Totals.UntimedSessions)
+}

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -164,6 +164,9 @@ func duckBuildAnalyticsWhere(
 	if f.ExcludeAutomated {
 		preds = append(preds, q("is_automated")+" = FALSE")
 	}
+	if f.ExcludeInteractive {
+		preds = append(preds, q("is_automated")+" = TRUE")
+	}
 	if f.ActiveSince != "" {
 		activeSince := f.ActiveSince
 		if parsed, ok := parseAnalyticsTime(f.ActiveSince); ok {

--- a/internal/insight/prompt.go
+++ b/internal/insight/prompt.go
@@ -17,6 +17,7 @@ type GenerateRequest struct {
 	DateTo   string
 	Project  string
 	Prompt   string
+	Summary  *RangeSummary // non-nil only for multi-day ranges
 }
 
 // BuildPrompt queries sessions for the given date and assembles
@@ -58,6 +59,10 @@ func BuildPrompt(
 		b.WriteString("## Project: ")
 		b.WriteString(req.Project)
 		b.WriteString("\n\n")
+	}
+
+	if req.Summary != nil {
+		req.Summary.WriteTo(&b)
 	}
 
 	sessions := page.Sessions

--- a/internal/insight/prompt_test.go
+++ b/internal/insight/prompt_test.go
@@ -146,6 +146,37 @@ func TestBuildPrompt(t *testing.T) {
 			wantNot:      []string{"Date: 2025"},
 		},
 		{
+			name: "multi-day summary before sessions",
+			req: GenerateRequest{
+				Type:     "daily_activity",
+				DateFrom: "2025-01-13",
+				DateTo:   "2025-01-17",
+				Summary: &RangeSummary{
+					Sessions:    4,
+					PeakAgents:  2,
+					TopProjects: []KeyMinutes{{Key: "my-app", AgentMinutes: 90}},
+				},
+			},
+			wantContains: []string{"## Range Summary", "Peak concurrency: 2"},
+			checkPrompt: func(t *testing.T, prompt string) {
+				header := strings.Index(prompt, "## Date Range")
+				summary := strings.Index(prompt, "## Range Summary")
+				sessions := strings.Index(prompt, "## Sessions")
+				require.Positive(t, summary, "summary block present")
+				assert.Less(t, header, summary, "summary after date-range header")
+				assert.Less(t, summary, sessions, "summary before sessions block")
+			},
+		},
+		{
+			name: "single day omits summary block",
+			req: GenerateRequest{
+				Type:     "daily_activity",
+				DateFrom: "2025-01-15",
+				DateTo:   "2025-01-15",
+			},
+			wantNot: []string{"## Range Summary"},
+		},
+		{
 			name: "date range no sessions",
 			req: GenerateRequest{
 				Type:     "daily_activity",

--- a/internal/insight/summary.go
+++ b/internal/insight/summary.go
@@ -1,0 +1,113 @@
+package insight
+
+import (
+	"fmt"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/activity"
+)
+
+// RangeSummary is the deterministic, prompt-input contract derived from
+// activity.Report for multi-day ranges. Field order and formatting are
+// fixed so the same report always yields the same prompt text.
+type RangeSummary struct {
+	ActiveMinutes    float64
+	IdleMinutes      float64
+	AgentMinutes     float64
+	Sessions         int
+	DistinctProjects int
+	DistinctModels   int
+	OutputTokens     int
+	Cost             float64
+	PeakAgents       int
+	PeakAt           string       // "" when nil
+	TopProjects      []KeyMinutes // top-N by agent-minutes, deterministic order
+	TopModels        []KeyMinutes
+	TopAgents        []KeyMinutes
+}
+
+// KeyMinutes pairs a breakdown key with its agent-minutes total.
+type KeyMinutes struct {
+	Key          string
+	AgentMinutes float64
+}
+
+// SummarizeReport builds a RangeSummary from an activity.Report, taking the
+// top topN entries of each breakdown (already minutes-desc, key-asc from the
+// aggregator) so the result is deterministic.
+func SummarizeReport(r activity.Report, topN int) RangeSummary {
+	peakAt := ""
+	if r.Peak.At != nil {
+		peakAt = *r.Peak.At
+	}
+	return RangeSummary{
+		ActiveMinutes:    r.Totals.ActiveMinutes,
+		IdleMinutes:      r.Totals.IdleMinutes,
+		AgentMinutes:     r.Totals.AgentMinutes,
+		Sessions:         r.Totals.Sessions,
+		DistinctProjects: r.Totals.DistinctProjects,
+		DistinctModels:   r.Totals.DistinctModels,
+		OutputTokens:     r.Totals.OutputTokens,
+		Cost:             r.Totals.Cost,
+		PeakAgents:       r.Peak.Agents,
+		PeakAt:           peakAt,
+		TopProjects:      topKeyMinutes(r.ByProject, topN),
+		TopModels:        topKeyMinutes(r.ByModel, topN),
+		TopAgents:        topKeyMinutes(r.ByAgent, topN),
+	}
+}
+
+// topKeyMinutes copies up to topN entries from src verbatim, preserving the
+// aggregator's deterministic minutes-desc, key-asc order.
+func topKeyMinutes(src []activity.KeyMinutes, topN int) []KeyMinutes {
+	if topN < 0 {
+		topN = 0
+	}
+	out := make([]KeyMinutes, 0, min(topN, len(src)))
+	for i, km := range src {
+		if i >= topN {
+			break
+		}
+		out = append(out, KeyMinutes{Key: km.Key, AgentMinutes: km.AgentMinutes})
+	}
+	return out
+}
+
+// WriteTo renders the summary into the prompt builder deterministically. The
+// section and field order are fixed so the same RangeSummary always produces
+// the same text.
+func (s RangeSummary) WriteTo(b *strings.Builder) {
+	b.WriteString("## Range Summary\n\n")
+	fmt.Fprintf(b, "- Sessions: %d\n", s.Sessions)
+	fmt.Fprintf(b, "- Active minutes: %.1f\n", s.ActiveMinutes)
+	fmt.Fprintf(b, "- Idle minutes: %.1f\n", s.IdleMinutes)
+	fmt.Fprintf(b, "- Agent minutes: %.1f\n", s.AgentMinutes)
+	fmt.Fprintf(b, "- Distinct projects: %d\n", s.DistinctProjects)
+	fmt.Fprintf(b, "- Distinct models: %d\n", s.DistinctModels)
+	fmt.Fprintf(b, "- Output tokens: %d\n", s.OutputTokens)
+	fmt.Fprintf(b, "- Cost: %.2f\n", s.Cost)
+	fmt.Fprintf(b, "- Peak concurrency: %d", s.PeakAgents)
+	if s.PeakAt != "" {
+		fmt.Fprintf(b, " at %s", s.PeakAt)
+	}
+	b.WriteString("\n\n")
+
+	writeKeyMinutes(b, "### Top Projects", s.TopProjects)
+	writeKeyMinutes(b, "### Top Models", s.TopModels)
+	writeKeyMinutes(b, "### Top Agents", s.TopAgents)
+}
+
+// writeKeyMinutes renders a titled breakdown list, or a placeholder line when
+// the breakdown is empty, keeping the section present for determinism.
+func writeKeyMinutes(b *strings.Builder, title string, items []KeyMinutes) {
+	b.WriteString(title)
+	b.WriteString("\n\n")
+	if len(items) == 0 {
+		b.WriteString("- (none)\n\n")
+		return
+	}
+	for _, km := range items {
+		fmt.Fprintf(b, "- %s: %.1f agent-minutes\n", km.Key, km.AgentMinutes)
+	}
+	b.WriteString("\n")
+}

--- a/internal/insight/summary_test.go
+++ b/internal/insight/summary_test.go
@@ -1,0 +1,54 @@
+package insight
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/activity"
+)
+
+func sampleReport() activity.Report {
+	at := "2026-06-16T10:00:00Z"
+	return activity.Report{
+		Peak: activity.Peak{Agents: 3, At: &at},
+		Totals: activity.Totals{
+			ActiveMinutes: 120, IdleMinutes: 60, AgentMinutes: 200,
+			Sessions: 9, DistinctProjects: 2, DistinctModels: 2,
+			OutputTokens: 5000, Cost: 4.25,
+		},
+		ByProject: []activity.KeyMinutes{{Key: "alpha", AgentMinutes: 150}, {Key: "beta", AgentMinutes: 50}},
+		ByModel:   []activity.KeyMinutes{{Key: "model-x", AgentMinutes: 120}, {Key: "model-y", AgentMinutes: 80}},
+		ByAgent:   []activity.KeyMinutes{{Key: "claude", AgentMinutes: 200}},
+	}
+}
+
+func TestSummarizeReport_Deterministic(t *testing.T) {
+	r := sampleReport()
+	a := SummarizeReport(r, 10)
+	b := SummarizeReport(r, 10)
+	assert.Equal(t, a, b, "same report yields identical summary")
+	assert.Equal(t, 3, a.PeakAgents)
+	assert.Equal(t, "2026-06-16T10:00:00Z", a.PeakAt)
+	require.Len(t, a.TopProjects, 2)
+	assert.Equal(t, "alpha", a.TopProjects[0].Key)
+}
+
+func TestSummarizeReport_TopNCap(t *testing.T) {
+	r := sampleReport()
+	s := SummarizeReport(r, 1)
+	require.Len(t, s.TopProjects, 1, "topN caps the breakdown length")
+	assert.Equal(t, "alpha", s.TopProjects[0].Key)
+}
+
+func TestRangeSummary_WriteToDeterministic(t *testing.T) {
+	s := SummarizeReport(sampleReport(), 10)
+	var b1, b2 strings.Builder
+	s.WriteTo(&b1)
+	s.WriteTo(&b2)
+	assert.Equal(t, b1.String(), b2.String())
+	assert.Contains(t, b1.String(), "Peak concurrency: 3")
+	assert.Contains(t, b1.String(), "alpha")
+}

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -170,10 +170,13 @@ func init() {
 		{marker: sep + ".config" + sep + "middleman" + sep + "worktrees" + sep + "github.com" + sep, projectPart: 1, minParts: 3},
 		// ~/.codex/worktrees/$WORKTREE_ID/$REPO[/...]
 		{marker: sep + ".codex" + sep + "worktrees" + sep, projectPart: 1, minParts: 2},
-		// roborev CI: <dataDir>/ci-worktrees/$REPO/roborev-ci-<jobID>-<id>[/...].
+		// roborev CI: ~/.roborev/ci-worktrees/$REPO/roborev-ci-<jobID>-<id>[/...].
 		// roborev nests the ephemeral worktree under a repo-named parent so the
-		// owning project survives the generated leaf name.
-		{marker: sep + "ci-worktrees" + sep, projectPart: 0, minParts: 2},
+		// owning project survives the generated leaf name. Anchored to the
+		// .roborev data dir (like the tool-anchored siblings above) so an
+		// unrelated path that merely contains a "ci-worktrees" directory is not
+		// matched.
+		{marker: sep + ".roborev" + sep + "ci-worktrees" + sep, projectPart: 0, minParts: 2},
 	}
 }
 

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -170,6 +170,10 @@ func init() {
 		{marker: sep + ".config" + sep + "middleman" + sep + "worktrees" + sep + "github.com" + sep, projectPart: 1, minParts: 3},
 		// ~/.codex/worktrees/$WORKTREE_ID/$REPO[/...]
 		{marker: sep + ".codex" + sep + "worktrees" + sep, projectPart: 1, minParts: 2},
+		// roborev CI: <dataDir>/ci-worktrees/$REPO/roborev-ci-<jobID>-<id>[/...].
+		// roborev nests the ephemeral worktree under a repo-named parent so the
+		// owning project survives the generated leaf name.
+		{marker: sep + "ci-worktrees" + sep, projectPart: 0, minParts: 2},
 	}
 }
 

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -634,7 +634,7 @@ func TestExtractProjectFromCwdWithBranch(t *testing.T) {
 		{
 			name: "RoborevCIWorktree",
 			cwd: filepath.FromSlash(
-				"/data/ci-worktrees/widget/roborev-ci-101-1001",
+				"/data/.roborev/ci-worktrees/widget/roborev-ci-101-1001",
 			),
 			branch: "",
 			want:   "widget",
@@ -642,7 +642,7 @@ func TestExtractProjectFromCwdWithBranch(t *testing.T) {
 		{
 			name: "RoborevCIWorktreeDashRepoNormalized",
 			cwd: filepath.FromSlash(
-				"/data/ci-worktrees/data-pipeline/roborev-ci-102-1002",
+				"/data/.roborev/ci-worktrees/data-pipeline/roborev-ci-102-1002",
 			),
 			branch: "",
 			want:   "data_pipeline",
@@ -650,10 +650,21 @@ func TestExtractProjectFromCwdWithBranch(t *testing.T) {
 		{
 			name: "RoborevCIWorktreeSubdir",
 			cwd: filepath.FromSlash(
-				"/data/ci-worktrees/service/roborev-ci-103-1003/internal/foo",
+				"/data/.roborev/ci-worktrees/service/roborev-ci-103-1003/internal/foo",
 			),
 			branch: "",
 			want:   "service",
+		},
+		{
+			// A bare "ci-worktrees" directory NOT under .roborev is not a
+			// roborev CI worktree: the anchored marker must not fire, so the
+			// name falls back to the path basename instead of the repo part.
+			name: "CIWorktreesDirNotUnderRoborevNotMatched",
+			cwd: filepath.FromSlash(
+				"/data/work/ci-worktrees/widget/build-123",
+			),
+			branch: "",
+			want:   "build_123",
 		},
 	}
 

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -631,6 +631,30 @@ func TestExtractProjectFromCwdWithBranch(t *testing.T) {
 			branch: "fix-exited-agent-session-cleanup",
 			want:   "middleman",
 		},
+		{
+			name: "RoborevCIWorktree",
+			cwd: filepath.FromSlash(
+				"/data/ci-worktrees/widget/roborev-ci-101-1001",
+			),
+			branch: "",
+			want:   "widget",
+		},
+		{
+			name: "RoborevCIWorktreeDashRepoNormalized",
+			cwd: filepath.FromSlash(
+				"/data/ci-worktrees/data-pipeline/roborev-ci-102-1002",
+			),
+			branch: "",
+			want:   "data_pipeline",
+		},
+		{
+			name: "RoborevCIWorktreeSubdir",
+			cwd: filepath.FromSlash(
+				"/data/ci-worktrees/service/roborev-ci-103-1003/internal/foo",
+			),
+			branch: "",
+			want:   "service",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -79,9 +79,12 @@ func (s *Store) activityReportSessions(
 	lower := pb.add(rangeStartUTC)
 	upper := pb.add(rangeEndUTC)
 
+	// Each Title candidate is NULLIF'd independently (not a nested
+	// COALESCE-then-NULLIF) so an empty display_name cannot mask a real
+	// session_name.
 	query := `SELECT
 		s.id,
-		COALESCE(NULLIF(COALESCE(s.display_name, s.session_name), ''), NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id) AS display_name,
+		COALESCE(NULLIF(s.display_name, ''), NULLIF(s.session_name, ''), NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id) AS display_name,
 		s.project,
 		s.agent,
 		s.machine,

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -1,0 +1,277 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// activityReportRangeBoundsUTC returns the exact [start, end) UTC bounds
+// of the resolved range `q` as RFC3339 strings. It mirrors the SQLite and
+// DuckDB backends so the candidate-session predicate selects exactly the
+// sessions whose window intersects the range, with no padding slop.
+// PostgreSQL compares parsed instants (the bounds are cast to
+// timestamptz), so it keeps the zone suffix, unlike SQLite's zone-less
+// TEXT comparison.
+func activityReportRangeBoundsUTC(q activity.Query) (string, string) {
+	return q.RangeStart.UTC().Format(time.RFC3339),
+		q.RangeEnd.UTC().Format(time.RFC3339)
+}
+
+// GetActivityReport assembles a concurrency- and usage-oriented report
+// for the resolved range `q`, reading from the PostgreSQL store. It
+// mirrors the SQLite (*DB).GetActivityReport: three fetches scoped to the
+// SAME candidate session-ID set so the concurrency timeline, sessions
+// table, and usage totals stay mutually consistent (no orphan usage
+// rows), then the in-memory streams are handed to activity.Aggregate.
+//
+// The filter `f` is honored as-is: callers that want one-shot or
+// automated sessions included must pass them through with the
+// corresponding exclusions disabled.
+func (s *Store) GetActivityReport(
+	ctx context.Context, f db.AnalyticsFilter, q activity.Query,
+) (activity.Report, error) {
+	rangeStartUTC, rangeEndUTC := activityReportRangeBoundsUTC(q)
+	lowerBound := paddedUTCBound(q.RangeStart.UTC().Format(time.RFC3339), -14)
+	upperBound := paddedUTCBound(q.RangeEnd.UTC().Format(time.RFC3339), 14)
+
+	sessions, ids, err := s.activityReportSessions(
+		ctx, f, rangeStartUTC, rangeEndUTC)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	acts, err := s.activityReportActivity(ctx, ids)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	usage, err := s.activityReportUsage(ctx, ids, lowerBound, upperBound)
+	if err != nil {
+		return activity.Report{}, err
+	}
+
+	return activity.Aggregate(activity.Params{
+		RangeStart:    q.RangeStart,
+		RangeEnd:      q.RangeEnd,
+		Loc:           q.Loc,
+		EffectiveEnd:  q.EffectiveEnd,
+		Partial:       q.Partial,
+		GapCapSeconds: q.GapCapSeconds,
+		Bucket:        q.Bucket,
+	}, sessions, acts, usage), nil
+}
+
+// activityReportSessions returns the candidate sessions whose window
+// overlaps the exact range [rangeStartUTC, rangeEndUTC), plus their
+// IDs. The ID set defines the scope for the activity and usage fetches.
+// The display-name expression matches the one PG's usage query uses.
+func (s *Store) activityReportSessions(
+	ctx context.Context, f db.AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
+) ([]activity.SessionMeta, []string, error) {
+	pb := &paramBuilder{}
+	where := buildAnalyticsWhereWithDate(f, "", pb, false)
+	lower := pb.add(rangeStartUTC)
+	upper := pb.add(rangeEndUTC)
+
+	query := `SELECT
+		s.id,
+		COALESCE(NULLIF(COALESCE(s.display_name, s.session_name), ''), NULLIF(s.first_message, ''), NULLIF(s.project, ''), s.id) AS display_name,
+		s.project,
+		s.agent,
+		s.machine,
+		s.started_at,
+		s.ended_at,
+		COALESCE(s.is_automated, false) AS is_automated
+	FROM sessions s
+	WHERE ` + where + `
+		AND COALESCE(s.ended_at, s.started_at, s.created_at) >= ` +
+		lower + `::timestamptz
+		AND COALESCE(s.started_at, s.created_at) < ` +
+		upper + `::timestamptz`
+
+	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"querying activity report sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []activity.SessionMeta
+	var ids []string
+	for rows.Next() {
+		var m activity.SessionMeta
+		var startedAt, endedAt sql.NullTime
+		if err := rows.Scan(
+			&m.SessionID, &m.Title, &m.Project, &m.Agent,
+			&m.Machine, &startedAt, &endedAt, &m.IsAutomated,
+		); err != nil {
+			return nil, nil, fmt.Errorf(
+				"scanning activity report session: %w", err)
+		}
+		m.StartedAt = startedAtString(startedAt)
+		m.EndedAt = startedAtString(endedAt)
+		sessions = append(sessions, m)
+		ids = append(ids, m.SessionID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf(
+			"iterating activity report sessions: %w", err)
+	}
+	return sessions, ids, nil
+}
+
+// activityReportActivity returns every timestamped message for the
+// candidate sessions, ordered for the aggregator's per-session
+// interval walk.
+func (s *Store) activityReportActivity(
+	ctx context.Context, ids []string,
+) ([]activity.ActivityEvent, error) {
+	var out []activity.ActivityEvent
+	if len(ids) == 0 {
+		return out, nil
+	}
+	err := pgQueryChunked(ids, func(chunk []string) error {
+		pb := &paramBuilder{}
+		ph := pgInPlaceholders(chunk, pb)
+		query := `SELECT session_id, ordinal, role, timestamp, model
+		FROM messages
+		WHERE session_id IN ` + ph + `
+			AND timestamp IS NOT NULL
+		ORDER BY session_id, ordinal`
+
+		rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+		if err != nil {
+			return fmt.Errorf(
+				"querying activity report activity: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var e activity.ActivityEvent
+			var ts sql.NullTime
+			if err := rows.Scan(
+				&e.SessionID, &e.Ordinal, &e.Role, &ts, &e.Model,
+			); err != nil {
+				return fmt.Errorf(
+					"scanning activity report activity: %w", err)
+			}
+			if !ts.Valid {
+				continue
+			}
+			e.Timestamp = FormatISO8601(ts.Time)
+			out = append(out, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// activityReportUsage returns the usage rows for the candidate sessions
+// within the padded range bounds, with per-row cost computed up front
+// (mirroring GetDailyUsage) so cost logic stays in the backend. Rows
+// are ordered by (ts, session_id, message_ordinal) as the aggregator
+// requires for its first-seen-wins dedup.
+func (s *Store) activityReportUsage(
+	ctx context.Context, ids []string, lowerBound, upperBound string,
+) ([]activity.UsageRow, error) {
+	var out []activity.UsageRow
+	if len(ids) == 0 {
+		return out, nil
+	}
+
+	pricing, err := s.loadPricingMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading pg pricing: %w", err)
+	}
+
+	// Accumulate the dedup sort keys (ts, session_id, ordinal) alongside
+	// each mapped row so we can impose one global order across all chunks.
+	// The same (claude_message_id, claude_request_id) can recur in
+	// different sessions (resumed/forked) and thus different chunks, so
+	// per-chunk ordering is not enough for the aggregator's first-seen dedup.
+	type ordered struct {
+		row     activity.UsageRow
+		ts      time.Time
+		ordinal int64
+	}
+	var rowsAcc []ordered
+
+	err = pgQueryChunked(ids, func(chunk []string) error {
+		pb := &paramBuilder{}
+		messagePH := pgInPlaceholders(chunk, pb)
+		eventPH := pgInPlaceholders(chunk, pb)
+		// Apply the same eligibility filters as GetDailyUsage so empty
+		// token_usage, empty, and synthetic models are excluded from the
+		// daily totals and dedup, keeping parity with the Usage dashboard.
+		rowsSQL := pgDailyUsageRowsSQLWithWhere(
+			pgUsageMessageEligibility+" AND m.session_id IN "+messagePH,
+			pgUsageEventEligibility+" AND ue.session_id IN "+eventPH)
+		lower := pb.add(lowerBound)
+		upper := pb.add(upperBound)
+		query := pgDailyUsageRowSelectFromRows(rowsSQL) + `
+			AND u.ts >= ` + lower + `::timestamptz
+			AND u.ts <= ` + upper + `::timestamptz`
+
+		rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+		if err != nil {
+			return fmt.Errorf("querying activity report usage: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			r, scanErr := scanPGDailyUsageRow(rows)
+			if scanErr != nil {
+				return fmt.Errorf(
+					"scanning activity report usage: %w", scanErr)
+			}
+			_, outputTok, _, _, cost, _ := pgDailyUsageAmounts(r, pricing)
+			ord := int64(-1)
+			if r.messageOrdinal.Valid {
+				ord = r.messageOrdinal.Int64
+			}
+			rowsAcc = append(rowsAcc, ordered{
+				ts:      r.ts.Time,
+				ordinal: ord,
+				row: activity.UsageRow{
+					SessionID:       r.sessionID,
+					Model:           r.model,
+					Timestamp:       startedAtString(r.ts),
+					OutputTokens:    outputTok,
+					Cost:            cost,
+					ClaudeMessageID: r.claudeMessageID,
+					ClaudeRequestID: r.claudeRequestID,
+					UsageDedupKey:   r.usageDedupKey,
+				},
+			})
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.SliceStable(rowsAcc, func(i, j int) bool {
+		a, b := rowsAcc[i], rowsAcc[j]
+		if !a.ts.Equal(b.ts) {
+			return a.ts.Before(b.ts)
+		}
+		if a.row.SessionID != b.row.SessionID {
+			return a.row.SessionID < b.row.SessionID
+		}
+		return a.ordinal < b.ordinal
+	})
+	out = make([]activity.UsageRow, len(rowsAcc))
+	for i, o := range rowsAcc {
+		out[i] = o.row
+	}
+	return out, nil
+}

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -71,6 +71,12 @@ func (s *Store) GetActivityReport(
 // overlaps the exact range [rangeStartUTC, rangeEndUTC), plus their
 // IDs. The ID set defines the scope for the activity and usage fetches.
 // The display-name expression matches the one PG's usage query uses.
+//
+// The effective-end fallback for a session with no ended_at uses its
+// latest message timestamp before started_at, so a still-open session
+// that began before the range but has messages inside it is not dropped,
+// matching SQLite and DuckDB. COALESCE short-circuits, so the correlated
+// MAX subquery runs only for the rare sessions missing an ended_at.
 func (s *Store) activityReportSessions(
 	ctx context.Context, f db.AnalyticsFilter, rangeStartUTC, rangeEndUTC string,
 ) ([]activity.SessionMeta, []string, error) {
@@ -93,7 +99,10 @@ func (s *Store) activityReportSessions(
 		COALESCE(s.is_automated, false) AS is_automated
 	FROM sessions s
 	WHERE ` + where + `
-		AND COALESCE(s.ended_at, s.started_at, s.created_at) >= ` +
+		AND COALESCE(s.ended_at,
+			(SELECT MAX(m.timestamp) FROM messages m
+				WHERE m.session_id = s.id AND m.timestamp IS NOT NULL),
+			s.started_at, s.created_at) >= ` +
 		lower + `::timestamptz
 		AND COALESCE(s.started_at, s.created_at) < ` +
 		upper + `::timestamptz`

--- a/internal/postgres/activityreport_pgtest_test.go
+++ b/internal/postgres/activityreport_pgtest_test.go
@@ -429,3 +429,86 @@ func TestPGGetActivityReportDedupsAcrossChunks(t *testing.T) {
 	assert.Equal(t, "dup-b", shared[1].SessionID)
 	assert.Equal(t, 900, shared[1].OutputTokens)
 }
+
+// TestPGGetActivityReportAutomationFilterAndSessionSplit confirms the shared
+// AnalyticsFilter automation class is honored through the PG analytics WHERE
+// builder and that the Totals carry the automated/interactive session-count
+// split. Mirrors the SQLite
+// TestGetActivityReport_AutomationFilterAndSessionSplit.
+func TestPGGetActivityReportAutomationFilterAndSessionSplit(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_automation_test")
+	ctx := context.Background()
+
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count, is_automated
+		) VALUES
+			('auto1', 'test-machine', 'proj1', 'claude',
+			 '2026-06-16T10:00:00Z'::timestamptz,
+			 '2026-06-16T10:02:00Z'::timestamptz, 2, 1, TRUE),
+			('auto2', 'test-machine', 'proj1', 'claude',
+			 '2026-06-16T11:00:00Z'::timestamptz,
+			 '2026-06-16T11:02:00Z'::timestamptz, 2, 1, TRUE),
+			('human', 'test-machine', 'proj2', 'codex',
+			 '2026-06-16T12:00:00Z'::timestamptz,
+			 '2026-06-16T12:02:00Z'::timestamptz, 2, 1, FALSE)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model
+		) VALUES
+			('auto1', 1, 'user', 'x', '2026-06-16T10:00:00Z'::timestamptz, 1, ''),
+			('auto1', 2, 'assistant', 'x', '2026-06-16T10:02:00Z'::timestamptz, 1, 'opus'),
+			('auto2', 1, 'user', 'x', '2026-06-16T11:00:00Z'::timestamptz, 1, ''),
+			('auto2', 2, 'assistant', 'x', '2026-06-16T11:02:00Z'::timestamptz, 1, 'opus'),
+			('human', 1, 'user', 'x', '2026-06-16T12:00:00Z'::timestamptz, 1, ''),
+			('human', 2, 'assistant', 'x', '2026-06-16T12:02:00Z'::timestamptz, 1, 'gpt5')`)
+	require.NoError(t, err, "insert messages")
+
+	tests := []struct {
+		name            string
+		filter          db.AnalyticsFilter
+		wantAutomated   int
+		wantInteractive int
+		wantIDs         []string
+	}{
+		{
+			name:            "all keeps both classes",
+			filter:          db.AnalyticsFilter{Timezone: "UTC"},
+			wantAutomated:   2,
+			wantInteractive: 1,
+			wantIDs:         []string{"auto1", "auto2", "human"},
+		},
+		{
+			name:            "exclude automated keeps interactive only",
+			filter:          db.AnalyticsFilter{Timezone: "UTC", ExcludeAutomated: true},
+			wantAutomated:   0,
+			wantInteractive: 1,
+			wantIDs:         []string{"human"},
+		},
+		{
+			name:            "exclude interactive keeps automated only",
+			filter:          db.AnalyticsFilter{Timezone: "UTC", ExcludeInteractive: true},
+			wantAutomated:   2,
+			wantInteractive: 0,
+			wantIDs:         []string{"auto1", "auto2"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := store.GetActivityReport(ctx, tc.filter,
+				pgDayQuery(t, "2026-06-16", "UTC"))
+			require.NoError(t, err)
+			assert.Equal(t, len(tc.wantIDs), r.Totals.Sessions)
+			assert.Equal(t, tc.wantAutomated, r.Totals.AutomatedSessions)
+			assert.Equal(t, tc.wantInteractive, r.Totals.InteractiveSessions)
+			ids := reportSessionIDsPG(r.BySession)
+			require.Len(t, ids, len(tc.wantIDs))
+			for _, id := range tc.wantIDs {
+				assert.Contains(t, ids, id)
+			}
+		})
+	}
+}

--- a/internal/postgres/activityreport_pgtest_test.go
+++ b/internal/postgres/activityreport_pgtest_test.go
@@ -76,6 +76,50 @@ func TestPGGetActivityReport(t *testing.T) {
 	assert.GreaterOrEqual(t, len(r.ByModel), 2)
 }
 
+// TestPGGetActivityReportOpenSessionWithInRangeMessageIncluded confirms a
+// still-open session (no ended_at) that started before the range but has a
+// message inside it is not dropped. The effective-end fallback uses the
+// session's latest message timestamp, not started_at, matching SQLite and
+// DuckDB. Mirrors the SQLite
+// TestGetActivityReport_OpenSessionWithInRangeMessageIncluded.
+func TestPGGetActivityReportOpenSessionWithInRangeMessageIncluded(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_open_test")
+	ctx := context.Background()
+
+	// Started the day before, never closed (ended_at NULL), active in-range.
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES (
+			'open', 'test-machine', 'proj1', 'claude',
+			'2026-06-15T23:00:00Z'::timestamptz, NULL, 2, 1
+		)`)
+	require.NoError(t, err, "insert session")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model
+		) VALUES
+			('open', 1, 'user', 'x',
+			 '2026-06-16T10:00:00Z'::timestamptz, 1, ''),
+			('open', 2, 'assistant', 'x',
+			 '2026-06-16T10:02:00Z'::timestamptz, 1, 'opus')`)
+	require.NoError(t, err, "insert messages")
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		pgDayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	ids := make(map[string]struct{}, len(r.BySession))
+	for _, s := range r.BySession {
+		ids[s.SessionID] = struct{}{}
+	}
+	assert.Contains(t, ids, "open",
+		"open session active in-range must not be dropped by the started_at fallback")
+	assert.Equal(t, 1, r.Totals.Sessions)
+}
+
 // TestPGGetActivityReportUsageCostAndTokens exercises the PG usage
 // union + cost path: a single priced assistant message must surface
 // its output tokens and computed cost in the day totals, matching

--- a/internal/postgres/activityreport_pgtest_test.go
+++ b/internal/postgres/activityreport_pgtest_test.go
@@ -1,0 +1,387 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// pgDayQuery resolves a single-day "day" Query for date/tz against a fixed
+// far-future now, so the candidate range is the full local day and the
+// report is never partial regardless of the wall clock.
+func pgDayQuery(t *testing.T, date, tz string) activity.Query {
+	t.Helper()
+	now, err := time.Parse(time.RFC3339, "2030-01-01T00:00:00Z")
+	require.NoError(t, err)
+	q, err := activity.ResolveQuery(
+		activity.QueryInput{Preset: "day", Date: date, Timezone: tz}, now)
+	require.NoError(t, err)
+	return q
+}
+
+// seedPGDailyFixture inserts two overlapping sessions on 2026-06-16
+// (UTC), each with two timestamped messages, mirroring the SQLite
+// fixture in internal/db/activityreport_test.go.
+func seedPGDailyFixture(t *testing.T, store *Store) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES
+			('a', 'test-machine', 'proj1', 'claude',
+			 '2026-06-16T10:00:00Z'::timestamptz,
+			 '2026-06-16T10:02:00Z'::timestamptz, 2, 1),
+			('b', 'test-machine', 'proj2', 'codex',
+			 '2026-06-16T10:01:00Z'::timestamptz,
+			 '2026-06-16T10:03:00Z'::timestamptz, 2, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model
+		) VALUES
+			('a', 1, 'user', 'x',
+			 '2026-06-16T10:00:00Z'::timestamptz, 1, ''),
+			('a', 2, 'assistant', 'x',
+			 '2026-06-16T10:02:00Z'::timestamptz, 1, 'opus'),
+			('b', 1, 'user', 'x',
+			 '2026-06-16T10:01:00Z'::timestamptz, 1, ''),
+			('b', 2, 'assistant', 'x',
+			 '2026-06-16T10:03:00Z'::timestamptz, 1, 'gpt5')`)
+	require.NoError(t, err, "insert messages")
+}
+
+func TestPGGetActivityReport(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_test")
+	ctx := context.Background()
+	seedPGDailyFixture(t, store)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		pgDayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, r.Peak.Agents)
+	assert.Equal(t, 2, r.Totals.Sessions)
+	assert.GreaterOrEqual(t, len(r.ByModel), 2)
+}
+
+// TestPGGetActivityReportUsageCostAndTokens exercises the PG usage
+// union + cost path: a single priced assistant message must surface
+// its output tokens and computed cost in the day totals, matching
+// the SQLite reference behavior.
+func TestPGGetActivityReportUsageCostAndTokens(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_usage_test")
+	ctx := context.Background()
+
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('claude-sonnet-4-20250514', 3, 15, 0, 0, 'seed')`)
+	require.NoError(t, err, "insert pricing")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES (
+			's1', 'test-machine', 'proj1', 'claude',
+			'2026-06-16T10:30:00Z'::timestamptz,
+			'2026-06-16T10:30:00Z'::timestamptz, 1, 1
+		)`)
+	require.NoError(t, err, "insert session")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model, token_usage
+		) VALUES (
+			's1', 0, 'assistant', 'x',
+			'2026-06-16T10:30:00Z'::timestamptz, 1,
+			'claude-sonnet-4-20250514',
+			'{"input_tokens":1000,"output_tokens":500}'
+		)`)
+	require.NoError(t, err, "insert message")
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		pgDayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, r.Totals.Sessions)
+	assert.Equal(t, 500, r.Totals.OutputTokens)
+	// Cost = (1000*3 + 500*15) / 1e6 = 0.0105
+	assert.InDelta(t, 0.0105, r.Totals.Cost, 1e-9)
+}
+
+// TestPGGetActivityReportExcludesOtherDays confirms the candidate-session
+// window plus the usage ts-bounds keep a session whose only activity
+// falls outside the target day from contributing to that day.
+func TestPGGetActivityReportExcludesOtherDays(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_otherday_test")
+	ctx := context.Background()
+
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES
+			('today', 'test-machine', 'proj1', 'claude',
+			 '2026-06-16T10:00:00Z'::timestamptz,
+			 '2026-06-16T10:02:00Z'::timestamptz, 2, 1),
+			('yesterday', 'test-machine', 'proj2', 'codex',
+			 '2026-06-10T10:00:00Z'::timestamptz,
+			 '2026-06-10T10:02:00Z'::timestamptz, 2, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model
+		) VALUES
+			('today', 1, 'user', 'x',
+			 '2026-06-16T10:00:00Z'::timestamptz, 1, ''),
+			('today', 2, 'assistant', 'x',
+			 '2026-06-16T10:02:00Z'::timestamptz, 1, 'opus'),
+			('yesterday', 1, 'user', 'x',
+			 '2026-06-10T10:00:00Z'::timestamptz, 1, ''),
+			('yesterday', 2, 'assistant', 'x',
+			 '2026-06-10T10:02:00Z'::timestamptz, 1, 'gpt5')`)
+	require.NoError(t, err, "insert messages")
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		pgDayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	// Only the in-day session has timed intervals on 2026-06-16.
+	assert.Equal(t, 1, r.Peak.Agents)
+	require.Len(t, r.ByAgent, 1)
+	assert.Equal(t, "claude", r.ByAgent[0].Key)
+}
+
+// reportSessionIDsPG collects the session IDs present in a report's
+// BySession rows.
+func reportSessionIDsPG(sessions []activity.SessionRow) map[string]struct{} {
+	out := make(map[string]struct{}, len(sessions))
+	for _, s := range sessions {
+		out[s.SessionID] = struct{}{}
+	}
+	return out
+}
+
+// TestPGGetActivityReportPriorDayWithinPadExcluded confirms the PG
+// candidate window uses the EXACT local day, not the +/-14h padded
+// bounds: a session that began and ended on the prior day but lands
+// inside the pad must NOT appear in the target day's report.
+func TestPGGetActivityReportPriorDayWithinPadExcluded(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_pad_test")
+	ctx := context.Background()
+
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES
+			('today', 'test-machine', 'proj1', 'claude',
+			 '2026-06-16T10:00:00Z'::timestamptz,
+			 '2026-06-16T10:02:00Z'::timestamptz, 2, 1),
+			('prior', 'test-machine', 'proj2', 'codex',
+			 '2026-06-15T12:00:00Z'::timestamptz,
+			 '2026-06-15T12:05:00Z'::timestamptz, 2, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model
+		) VALUES
+			('today', 1, 'user', 'x',
+			 '2026-06-16T10:00:00Z'::timestamptz, 1, ''),
+			('today', 2, 'assistant', 'x',
+			 '2026-06-16T10:02:00Z'::timestamptz, 1, 'opus')`)
+	require.NoError(t, err, "insert messages")
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		pgDayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	ids := reportSessionIDsPG(r.BySession)
+	assert.Contains(t, ids, "today")
+	assert.NotContains(t, ids, "prior", "prior-day session must not leak in")
+	assert.Equal(t, 1, r.Totals.Sessions)
+	assert.Equal(t, 0, r.Totals.UntimedSessions)
+}
+
+// TestPGGetActivityReportExcludesIneligibleUsage confirms the PG usage
+// union applies the same eligibility filters as GetDailyUsage: a
+// synthetic-model message carrying real token_usage must not inflate
+// the day totals.
+func TestPGGetActivityReportExcludesIneligibleUsage(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_eligible_test")
+	ctx := context.Background()
+
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('claude-sonnet-4-20250514', 3, 15, 0, 0, 'seed')`)
+	require.NoError(t, err, "insert pricing")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES (
+			's1', 'test-machine', 'proj1', 'claude',
+			'2026-06-16T10:30:00Z'::timestamptz,
+			'2026-06-16T10:31:00Z'::timestamptz, 2, 1
+		)`)
+	require.NoError(t, err, "insert session")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model, token_usage
+		) VALUES
+			('s1', 0, 'assistant', 'x',
+			 '2026-06-16T10:30:00Z'::timestamptz, 1,
+			 'claude-sonnet-4-20250514',
+			 '{"input_tokens":1000,"output_tokens":500}'),
+			('s1', 1, 'assistant', 'y',
+			 '2026-06-16T10:31:00Z'::timestamptz, 1,
+			 '<synthetic>',
+			 '{"input_tokens":9000,"output_tokens":7000}')`)
+	require.NoError(t, err, "insert messages")
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		pgDayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens, "synthetic message excluded")
+	assert.InDelta(t, 0.0105, r.Totals.Cost, 1e-9)
+}
+
+// TestPGGetActivityReportDedupsAcrossChunks confirms the PG usage fetch's
+// global re-sort across maxPGVars-sized ID chunks (activityReportUsage in
+// internal/postgres/activityreport.go) orders rows by timestamp across the
+// whole candidate set, not per chunk. The aggregator's first-seen-wins
+// dedup relies on that order: the same (claude_message_id,
+// claude_request_id) can recur in two sessions (resumed/forked) that fall
+// in DIFFERENT chunks, and the globally-earliest row must survive.
+//
+// The candidate IDs are passed to activityReportUsage explicitly, so the
+// chunk split is deterministic and never depends on PostgreSQL's scan
+// order. The slice is [dup-b, 500 fillers, dup-a]: dup-b (the LATER
+// timestamp) lands in the first chunk (indices 0-499) and dup-a (the
+// EARLIER timestamp) in the second (indices 500-501). Only a global
+// re-sort by timestamp reorders the fetched rows to [dup-a, dup-b]; a
+// regression that appended per-chunk results in chunk order would yield
+// [dup-b, dup-a] and fail the ordering assertion below. The fillers are
+// placeholder IDs with no rows in the DB -- they exist only to push dup-a
+// past the 500-variable chunk boundary.
+func TestPGGetActivityReportDedupsAcrossChunks(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_chunk_test")
+	ctx := context.Background()
+
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('claude-sonnet-4-20250514', 3, 15, 0, 0, 'seed')`)
+	require.NoError(t, err, "insert pricing")
+
+	// dup-a: earlier timestamp and 500 output tokens -> the correct global
+	// survivor of the shared (claude_message_id, claude_request_id) key.
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES (
+			'dup-a', 'test-machine', 'proj1', 'claude',
+			'2026-06-16T10:00:00Z'::timestamptz,
+			'2026-06-16T10:00:00Z'::timestamptz, 1, 1
+		)`)
+	require.NoError(t, err, "insert dup-a session")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model, token_usage,
+			claude_message_id, claude_request_id
+		) VALUES (
+			'dup-a', 0, 'assistant', 'x',
+			'2026-06-16T10:00:00Z'::timestamptz, 1,
+			'claude-sonnet-4-20250514',
+			'{"input_tokens":250,"output_tokens":500}', 'M1', 'R1'
+		)`)
+	require.NoError(t, err, "insert dup-a message")
+
+	// dup-b: same dedup identity as dup-a (claude_message_id,
+	// claude_request_id) but a later timestamp and 900 output tokens; the
+	// first-seen dedup must drop it in favor of dup-a.
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES (
+			'dup-b', 'test-machine', 'proj1', 'claude',
+			'2026-06-16T10:05:00Z'::timestamptz,
+			'2026-06-16T10:05:00Z'::timestamptz, 1, 1
+		)`)
+	require.NoError(t, err, "insert dup-b session")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model, token_usage,
+			claude_message_id, claude_request_id
+		) VALUES (
+			'dup-b', 0, 'assistant', 'x',
+			'2026-06-16T10:05:00Z'::timestamptz, 1,
+			'claude-sonnet-4-20250514',
+			'{"input_tokens":450,"output_tokens":900}', 'M1', 'R1'
+		)`)
+	require.NoError(t, err, "insert dup-b message")
+
+	// Build the candidate ID slice explicitly so the chunk split is
+	// deterministic: dup-b in chunk 1 (later ts), dup-a in chunk 2 (earlier
+	// ts), forcing the shared dedup identity across the maxPGVars boundary.
+	ids := make([]string, 0, maxPGVars+2)
+	ids = append(ids, "dup-b")
+	for i := 0; i < maxPGVars; i++ {
+		ids = append(ids, fmt.Sprintf("fill-%d", i))
+	}
+	ids = append(ids, "dup-a")
+	require.Greater(t, len(ids), maxPGVars,
+		"candidate IDs must exceed one chunk to span the boundary")
+
+	lower := paddedUTCBound("2026-06-16T00:00:00Z", -14)
+	upper := paddedUTCBound("2026-06-16T23:59:59Z", 14)
+	usage, err := store.activityReportUsage(ctx, ids, lower, upper)
+	require.NoError(t, err)
+
+	// Only dup-a and dup-b carry eligible usage; the fillers have no rows.
+	var shared []activity.UsageRow
+	for _, u := range usage {
+		if u.SessionID == "dup-a" || u.SessionID == "dup-b" {
+			shared = append(shared, u)
+		}
+	}
+	require.Len(t, shared, 2,
+		"both dedup-identity rows fetched across the chunk boundary")
+	require.NotEmpty(t, shared[0].ClaudeMessageID, "rows carry a message id")
+	assert.Equal(t, shared[0].ClaudeMessageID, shared[1].ClaudeMessageID,
+		"dup-a and dup-b share claude_message_id")
+	assert.Equal(t, shared[0].ClaudeRequestID, shared[1].ClaudeRequestID,
+		"and claude_request_id, so first-seen order picks the survivor")
+	// The global re-sort by timestamp must place dup-a (10:00, fetched in
+	// the LATER chunk) before dup-b (10:05, fetched in the EARLIER chunk).
+	// A per-chunk-order regression returns [dup-b, dup-a] and fails here.
+	assert.Equal(t, "dup-a", shared[0].SessionID,
+		"earlier-timestamp row sorts first despite its later chunk")
+	assert.Equal(t, 500, shared[0].OutputTokens, "dup-a survives first-seen")
+	assert.Equal(t, "dup-b", shared[1].SessionID)
+	assert.Equal(t, 900, shared[1].OutputTokens)
+}

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -169,6 +169,9 @@ func buildAnalyticsWhereWithDate(
 	if f.ExcludeAutomated {
 		preds = append(preds, "is_automated = FALSE")
 	}
+	if f.ExcludeInteractive {
+		preds = append(preds, "is_automated = TRUE")
+	}
 	if f.ActiveSince != "" {
 		preds = append(preds,
 			"COALESCE(ended_at, started_at, created_at)"+

--- a/internal/server/activity_report_test.go
+++ b/internal/server/activity_report_test.go
@@ -241,3 +241,90 @@ func TestActivityReportEndpoint_BucketCountCap(t *testing.T) {
 	}))
 	assertStatus(t, w, http.StatusBadRequest)
 }
+
+// TestActivityReportEndpoint_AutomationFilter confirms the activity endpoint's
+// automation query param selects the requested class end to end: the default
+// and "all" keep both classes, "interactive" drops automated sessions, and
+// "automated" drops interactive ones. It also confirms the response Totals
+// carry the automated/interactive session-count split.
+func TestActivityReportEndpoint_AutomationFilter(t *testing.T) {
+	te := setup(t)
+
+	// Automated: a single-turn session whose first message matches a known
+	// automated (roborev) prompt prefix, which the classifier turns into
+	// is_automated = 1. UserMessageCount = 1 satisfies the single-turn gate.
+	autoStart, autoEnd := activityDate+"T12:00:00Z", activityDate+"T12:04:00Z"
+	te.seedSession(t, "automated", "beta", 2, func(s *db.Session) {
+		s.Agent = "codex"
+		s.StartedAt = &autoStart
+		s.EndedAt = &autoEnd
+		s.FirstMessage = new("You are a code reviewer.")
+		s.UserMessageCount = 1
+	})
+	te.seedMessages(t, "automated", 2, func(i int, m *db.Message) {
+		if i == 0 {
+			m.Content = "You are a code reviewer."
+		}
+		m.Timestamp = []string{
+			activityDate + "T12:00:00Z", activityDate + "T12:02:00Z",
+		}[i]
+	})
+
+	humanStart, humanEnd := activityDate+"T13:00:00Z", activityDate+"T13:04:00Z"
+	te.seedSession(t, "human", "alpha", 2, func(s *db.Session) {
+		s.Agent = "claude"
+		s.StartedAt = &humanStart
+		s.EndedAt = &humanEnd
+	})
+	te.seedMessages(t, "human", 2, func(i int, m *db.Message) {
+		m.Timestamp = []string{
+			activityDate + "T13:00:00Z", activityDate + "T13:02:00Z",
+		}[i]
+	})
+
+	tests := []struct {
+		name            string
+		automation      string
+		wantAutomated   int
+		wantInteractive int
+		wantIDs         []string
+	}{
+		{"default keeps both", "", 1, 1, []string{"automated", "human"}},
+		{"all keeps both", "all", 1, 1, []string{"automated", "human"}},
+		{"interactive drops automated", "interactive", 0, 1, []string{"human"}},
+		{"automated drops interactive", "automated", 1, 0, []string{"automated"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]string{
+				"preset": "day", "date": activityDate, "timezone": "UTC",
+			}
+			if tc.automation != "" {
+				params["automation"] = tc.automation
+			}
+			w := te.get(t, buildPathURL("/api/v1/activity/report", params))
+			assertStatus(t, w, http.StatusOK)
+			resp := decode[activity.Report](t, w)
+			assert.Equal(t, len(tc.wantIDs), resp.Totals.Sessions)
+			assert.Equal(t, tc.wantAutomated, resp.Totals.AutomatedSessions)
+			assert.Equal(t, tc.wantInteractive, resp.Totals.InteractiveSessions)
+			ids := make(map[string]struct{}, len(resp.BySession))
+			for _, s := range resp.BySession {
+				ids[s.SessionID] = struct{}{}
+			}
+			assert.Len(t, ids, len(tc.wantIDs))
+			for _, id := range tc.wantIDs {
+				assert.Contains(t, ids, id)
+			}
+		})
+	}
+}
+
+func TestActivityReportEndpoint_BadAutomation(t *testing.T) {
+	te := setup(t)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "day", "date": activityDate, "timezone": "UTC",
+		"automation": "bogus",
+	}))
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/internal/server/activity_report_test.go
+++ b/internal/server/activity_report_test.go
@@ -1,0 +1,243 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// activityDate is a fixed past calendar day so the activity report is
+// deterministic and complete (non-partial) regardless of wall clock.
+const activityDate = "2025-06-02"
+
+// seedActivityReportFixture seeds two sessions that overlap in wall-clock
+// on activityDate so peak concurrency is 2. Each session gets distinct,
+// increasing per-message timestamps inside the day (under the 300s gap
+// cap) so the aggregator produces active intervals; the default
+// seedMessages timestamp would yield zero activity.
+func seedActivityReportFixture(t *testing.T, te *testEnv) {
+	t.Helper()
+
+	type entry struct {
+		id, project, agent, started, ended string
+		msgTimes                           []string
+	}
+	entries := []entry{
+		{
+			id: "d1", project: "alpha", agent: "claude",
+			started: activityDate + "T10:00:00Z",
+			ended:   activityDate + "T10:08:00Z",
+			msgTimes: []string{
+				activityDate + "T10:00:00Z",
+				activityDate + "T10:02:00Z",
+				activityDate + "T10:05:00Z",
+				activityDate + "T10:07:00Z",
+			},
+		},
+		{
+			id: "d2", project: "beta", agent: "codex",
+			started: activityDate + "T10:01:00Z",
+			ended:   activityDate + "T10:09:00Z",
+			msgTimes: []string{
+				activityDate + "T10:01:00Z",
+				activityDate + "T10:03:00Z",
+				activityDate + "T10:06:00Z",
+				activityDate + "T10:08:00Z",
+			},
+		},
+	}
+
+	for _, e := range entries {
+		started, ended := e.started, e.ended
+		te.seedSession(t, e.id, e.project, len(e.msgTimes),
+			func(s *db.Session) {
+				s.Agent = e.agent
+				s.StartedAt = &started
+				s.EndedAt = &ended
+			},
+		)
+		times := e.msgTimes
+		te.seedMessages(t, e.id, len(times),
+			func(i int, m *db.Message) {
+				m.Timestamp = times[i]
+			},
+		)
+	}
+}
+
+func TestActivityReportEndpoint_Day(t *testing.T) {
+	te := setup(t)
+	seedActivityReportFixture(t, te)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "day", "date": activityDate, "timezone": "UTC",
+	}))
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[activity.Report](t, w)
+	assert.Equal(t, 2, resp.Peak.Agents)
+	assert.Equal(t, 2, resp.Totals.Sessions)
+	assert.Equal(t, "minute", resp.BucketUnit)
+	assert.False(t, resp.Partial)
+}
+
+func TestActivityReportEndpoint_Week(t *testing.T) {
+	te := setup(t)
+	seedActivityReportFixture(t, te)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "week", "date": activityDate, "timezone": "UTC",
+	}))
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[activity.Report](t, w)
+	assert.Equal(t, "hour", resp.BucketUnit, "a 7-day week auto-buckets hourly")
+	assert.Equal(t, 168, resp.BucketCount)
+}
+
+func TestActivityReportEndpoint_Month(t *testing.T) {
+	te := setup(t)
+	seedActivityReportFixture(t, te)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "month", "date": activityDate, "timezone": "UTC",
+	}))
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[activity.Report](t, w)
+	assert.Equal(t, "day", resp.BucketUnit, "a 30-day month auto-buckets daily")
+}
+
+func TestActivityReportEndpoint_Custom(t *testing.T) {
+	te := setup(t)
+	seedActivityReportFixture(t, te)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset":   "custom",
+		"from":     activityDate + "T00:00:00Z",
+		"to":       activityDate + "T23:59:59Z",
+		"timezone": "UTC",
+	}))
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[activity.Report](t, w)
+	assert.Equal(t, 2, resp.Totals.Sessions)
+}
+
+// TestActivityReportEndpoint_IncludesOneShotAndAutomated locks in the
+// activity endpoint's hardest binding constraint: unlike the sibling
+// analytics endpoints, it sets ExcludeOneShot=false and
+// ExcludeAutomated=false (see huma_routes_activity.go), so one-shot
+// (user_message_count <= 1) and automated (is_automated=1) sessions
+// MUST appear in the report. A refactor flipping those flags to match
+// the analytics defaults would drop these sessions and fail here.
+func TestActivityReportEndpoint_IncludesOneShotAndAutomated(t *testing.T) {
+	te := setup(t)
+
+	// One-shot: a single user message (user_message_count = 1).
+	started, ended := activityDate+"T11:00:00Z", activityDate+"T11:04:00Z"
+	te.seedSession(t, "oneshot", "alpha", 2, func(s *db.Session) {
+		s.Agent = "claude"
+		s.StartedAt = &started
+		s.EndedAt = &ended
+		s.UserMessageCount = 1
+	})
+	te.seedMessages(t, "oneshot", 2, func(i int, m *db.Message) {
+		m.Timestamp = []string{
+			activityDate + "T11:00:00Z", activityDate + "T11:02:00Z",
+		}[i]
+	})
+
+	// Automated: a first message matching a known automated (roborev)
+	// prompt prefix, which UpsertSession turns into is_automated = 1.
+	autoStart, autoEnd := activityDate+"T12:00:00Z", activityDate+"T12:04:00Z"
+	te.seedSession(t, "automated", "beta", 2, func(s *db.Session) {
+		s.Agent = "codex"
+		s.StartedAt = &autoStart
+		s.EndedAt = &autoEnd
+		s.FirstMessage = new("You are a code reviewer.")
+		s.UserMessageCount = 1
+	})
+	te.seedMessages(t, "automated", 2, func(i int, m *db.Message) {
+		m.Timestamp = []string{
+			activityDate + "T12:00:00Z", activityDate + "T12:02:00Z",
+		}[i]
+	})
+
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "day", "date": activityDate, "timezone": "UTC",
+	}))
+	assertStatus(t, w, http.StatusOK)
+
+	resp := decode[activity.Report](t, w)
+	ids := make(map[string]struct{}, len(resp.BySession))
+	for _, s := range resp.BySession {
+		ids[s.SessionID] = struct{}{}
+	}
+	assert.Contains(t, ids, "oneshot",
+		"one-shot session must be included (ExcludeOneShot=false)")
+	assert.Contains(t, ids, "automated",
+		"automated session must be included (ExcludeAutomated=false)")
+	assert.Equal(t, 2, resp.Totals.Sessions,
+		"both one-shot and automated sessions count toward the total")
+}
+
+func TestActivityReportEndpoint_BadDate(t *testing.T) {
+	te := setup(t)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "day", "date": "not-a-date", "timezone": "UTC",
+	}))
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestActivityReportEndpoint_BadTimezone(t *testing.T) {
+	te := setup(t)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "day", "date": activityDate, "timezone": "Fake/Zone",
+	}))
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestActivityReportEndpoint_CustomMissingBound(t *testing.T) {
+	te := setup(t)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "custom", "from": activityDate + "T00:00:00Z",
+	}))
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestActivityReportEndpoint_FromAfterTo(t *testing.T) {
+	te := setup(t)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "custom",
+		"from":   activityDate + "T12:00:00Z",
+		"to":     activityDate + "T00:00:00Z",
+	}))
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestActivityReportEndpoint_ZeroLengthRange(t *testing.T) {
+	te := setup(t)
+	ts := activityDate + "T00:00:00Z"
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "custom", "from": ts, "to": ts,
+	}))
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestActivityReportEndpoint_RangeExceedsYear(t *testing.T) {
+	te := setup(t)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "custom",
+		"from":   "2026-01-01T00:00:00Z",
+		"to":     "2027-01-02T00:00:00Z",
+	}))
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestActivityReportEndpoint_BucketCountCap(t *testing.T) {
+	te := setup(t)
+	w := te.get(t, buildPathURL("/api/v1/activity/report", map[string]string{
+		"preset": "custom",
+		"from":   "2026-01-01T00:00:00Z",
+		"to":     "2026-12-31T00:00:00Z",
+		"bucket": "5m",
+	}))
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/internal/server/huma_route_groups.go
+++ b/internal/server/huma_route_groups.go
@@ -9,6 +9,7 @@ func (s *Server) registerTypedAPIRoutes() {
 	s.registerSessionRoutes()
 	s.registerOpenersRoutes()
 	s.registerAnalyticsRoutes()
+	s.registerActivityRoutes()
 	s.registerTrendsRoutes()
 	s.registerUsageRoutes()
 	s.registerInsightsRoutes()

--- a/internal/server/huma_routes_activity.go
+++ b/internal/server/huma_routes_activity.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func (s *Server) registerActivityRoutes() {
+	group := newRouteGroup(s.api, "/api/v1/activity", "Activity")
+	get(s, group, "/report", "Get activity report", s.humaActivityReport)
+}
+
+type activityReportInput struct {
+	Preset   string `query:"preset" enum:"day,week,month,custom" doc:"Range preset"`
+	Date     string `query:"date" format:"date" doc:"Calendar day (YYYY-MM-DD) for presets"`
+	From     string `query:"from" doc:"Range start (RFC3339) for custom ranges"`
+	To       string `query:"to" doc:"Range end (RFC3339) for custom ranges"`
+	Timezone string `query:"timezone" doc:"IANA timezone name"`
+	Bucket   string `query:"bucket" enum:"5m,15m,1h,1d,1w" doc:"Timeline bucket size override"`
+	Project  string `query:"project" doc:"Filter by project"`
+	Agent    string `query:"agent" doc:"Filter by agent"`
+	Machine  string `query:"machine" doc:"Filter by machine"`
+}
+
+func (s *Server) humaActivityReport(
+	ctx context.Context, in *activityReportInput,
+) (*jsonOutput[activity.Report], error) {
+	tz := in.Timezone
+	if tz == "" {
+		tz = "UTC"
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, apiError(http.StatusBadRequest, "invalid timezone: "+tz)
+	}
+	input := activity.QueryInput{
+		Preset: in.Preset, Date: in.Date, From: in.From, To: in.To,
+		Timezone: tz, BucketOverride: in.Bucket,
+	}
+	// Presets need an anchor date; default to today in the requested
+	// timezone, matching the prior day-only handler's behavior.
+	if input.Date == "" && input.From == "" {
+		input.Date = time.Now().In(loc).Format("2006-01-02")
+	}
+	q, err := activity.ResolveQuery(input, time.Now())
+	if err != nil {
+		return nil, apiError(http.StatusBadRequest, err.Error())
+	}
+	// The activity report intentionally includes one-shot and automated
+	// sessions, unlike analytics which excludes them by default.
+	f := db.AnalyticsFilter{
+		Timezone: tz, Project: in.Project, Agent: in.Agent, Machine: in.Machine,
+		ExcludeOneShot: false, ExcludeAutomated: false,
+	}
+	r, err := s.db.GetActivityReport(ctx, f, q)
+	if err != nil {
+		if handled := handleHumaContextError(err); handled != nil {
+			return nil, handled
+		}
+		if handled := handleHumaReadOnly(err); handled != nil {
+			return nil, handled
+		}
+		return nil, internalError("activity report error", err)
+	}
+	return &jsonOutput[activity.Report]{Body: r}, nil
+}

--- a/internal/server/huma_routes_activity.go
+++ b/internal/server/huma_routes_activity.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -24,6 +25,10 @@ type activityReportInput struct {
 	Project  string `query:"project" doc:"Filter by project"`
 	Agent    string `query:"agent" doc:"Filter by agent"`
 	Machine  string `query:"machine" doc:"Filter by machine"`
+	// Automation classes the report: "all" (default) keeps both, "interactive"
+	// drops automated sessions, "automated" drops interactive ones. Empty is
+	// treated as "all"; any other value is rejected.
+	Automation string `query:"automation" default:"all" doc:"Automation class: all, interactive, or automated"`
 }
 
 func (s *Server) humaActivityReport(
@@ -50,11 +55,18 @@ func (s *Server) humaActivityReport(
 	if err != nil {
 		return nil, apiError(http.StatusBadRequest, err.Error())
 	}
-	// The activity report intentionally includes one-shot and automated
-	// sessions, unlike analytics which excludes them by default.
+	excludeAutomated, excludeInteractive, err := activityAutomationFilter(in.Automation)
+	if err != nil {
+		return nil, apiError(http.StatusBadRequest, err.Error())
+	}
+	// The activity report intentionally includes one-shot sessions, unlike
+	// analytics which excludes them by default. The automation class is the
+	// caller's choice (default "all" keeps both automated and interactive).
 	f := db.AnalyticsFilter{
 		Timezone: tz, Project: in.Project, Agent: in.Agent, Machine: in.Machine,
-		ExcludeOneShot: false, ExcludeAutomated: false,
+		ExcludeOneShot:     false,
+		ExcludeAutomated:   excludeAutomated,
+		ExcludeInteractive: excludeInteractive,
 	}
 	r, err := s.db.GetActivityReport(ctx, f, q)
 	if err != nil {
@@ -67,4 +79,26 @@ func (s *Server) humaActivityReport(
 		return nil, internalError("activity report error", err)
 	}
 	return &jsonOutput[activity.Report]{Body: r}, nil
+}
+
+// activityAutomationFilter maps the activity report's automation query value to
+// the AnalyticsFilter class exclusions. Empty and "all" keep both classes;
+// "interactive" drops automated sessions; "automated" drops interactive ones.
+// Any other value is an error so a typo surfaces as 400 rather than silently
+// returning the unfiltered report.
+func activityAutomationFilter(
+	automation string,
+) (excludeAutomated, excludeInteractive bool, err error) {
+	switch automation {
+	case "", "all":
+		return false, false, nil
+	case "interactive":
+		return true, false, nil
+	case "automated":
+		return false, true, nil
+	default:
+		return false, false, fmt.Errorf(
+			"invalid automation %q (want all, interactive, or automated)",
+			automation)
+	}
 }

--- a/internal/server/huma_routes_activity_internal_test.go
+++ b/internal/server/huma_routes_activity_internal_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestActivityAutomationFilter locks in the mapping from the activity
+// endpoint's automation query value to the AnalyticsFilter class exclusions:
+// empty and "all" keep both classes, "interactive" drops automated sessions,
+// "automated" drops interactive ones, and any other value is a 400-worthy
+// error. The two exclude flags are never both true (that would match nothing),
+// and the error case returns the safe no-exclusion default so a typo never
+// silently filters the report.
+func TestActivityAutomationFilter(t *testing.T) {
+	tests := []struct {
+		name             string
+		automation       string
+		wantExcludeAuto  bool
+		wantExcludeInter bool
+		wantErr          bool
+	}{
+		{"empty treated as all", "", false, false, false},
+		{"all keeps both", "all", false, false, false},
+		{"interactive excludes automated", "interactive", true, false, false},
+		{"automated excludes interactive", "automated", false, true, false},
+		{"unknown value errors", "bogus", false, false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			excludeAuto, excludeInter, err := activityAutomationFilter(tc.automation)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.False(t, excludeAuto, "error must not exclude automated")
+				assert.False(t, excludeInter, "error must not exclude interactive")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantExcludeAuto, excludeAuto)
+			assert.Equal(t, tc.wantExcludeInter, excludeInter)
+			assert.False(t, excludeAuto && excludeInter,
+				"the two exclusions are mutually exclusive")
+		})
+	}
+}

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -156,7 +156,11 @@ func (s *Server) humaGenerateInsight(
 			Project:  req.Project,
 			Prompt:   req.Prompt,
 		}
-		if req.DateTo > req.DateFrom {
+		// Attach the activity summary for any valid range, single day
+		// included: daily_activity insights are commonly one day and the
+		// summary (concurrency, peak, breakdowns) is exactly that day's
+		// overview. The validator above guarantees DateTo >= DateFrom.
+		if req.DateTo >= req.DateFrom {
 			summary, err := s.activityRangeSummary(hctx.Context(), req)
 			if err != nil {
 				log.Printf("insight activity summary error: %v", err)
@@ -330,10 +334,15 @@ func (s *Server) humaGenerateInsight(
 	}}, nil
 }
 
-// activityRangeSummary resolves the requested multi-day range into an activity
-// report and condenses it into a RangeSummary for the insight prompt. The
-// range is the half-open span [DateFrom 00:00 UTC, DateTo+1day 00:00 UTC), and
-// the report excludes automated sessions to match BuildPrompt's session set.
+// activityRangeSummary resolves the requested range into an activity report and
+// condenses it into a RangeSummary for the insight prompt. The range is the
+// half-open span [DateFrom 00:00 UTC, DateTo+1day 00:00 UTC). It excludes
+// automated sessions so the summary reflects the same interactive-only work
+// BuildPrompt's prompt focuses on; the two otherwise select sessions
+// differently (this uses the activity report's half-open UTC window with an
+// ended_at fallback, BuildPrompt uses ListSessions' calendar-date match on the
+// start date), so the summary is a range-level overview, not a row-for-row
+// mirror of BuildPrompt's session list.
 func (s *Server) activityRangeSummary(
 	ctx context.Context, req generateInsightRequest,
 ) (*insight.RangeSummary, error) {

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/agentsview/internal/activity"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/insight"
 	"go.kenn.io/agentsview/internal/timeutil"
@@ -27,8 +28,10 @@ func (s *Server) registerInsightsRoutes() {
 type insightType string
 
 type insightsInput struct {
-	Type    insightType `query:"type" enum:"daily_activity,agent_analysis" doc:"Insight type"`
-	Project string      `query:"project" doc:"Filter by project"`
+	Type     insightType `query:"type" enum:"daily_activity,agent_analysis" doc:"Insight type"`
+	Project  string      `query:"project" doc:"Filter by project"`
+	DateFrom string      `query:"date_from" format:"date" doc:"Filter date_from >= (YYYY-MM-DD)"`
+	DateTo   string      `query:"date_to" format:"date" doc:"Filter date_to <= (YYYY-MM-DD)"`
 }
 
 type insightsResponse struct {
@@ -43,9 +46,14 @@ func (s *Server) humaListInsights(
 	ctx context.Context,
 	in *insightsInput,
 ) (*jsonOutput[insightsResponse], error) {
+	if err := validateDateFilterValues("", in.DateFrom, in.DateTo, ""); err != nil {
+		return nil, err
+	}
 	insights, err := s.db.ListInsights(ctx, db.InsightFilter{
-		Type:    string(in.Type),
-		Project: in.Project,
+		Type:     string(in.Type),
+		Project:  in.Project,
+		DateFrom: in.DateFrom,
+		DateTo:   in.DateTo,
 	})
 	if err != nil {
 		return nil, serverError(err)
@@ -141,13 +149,22 @@ func (s *Server) humaGenerateInsight(
 		if !sendJSON("status", map[string]string{"phase": "generating"}) {
 			return
 		}
-		prompt, err := insight.BuildPrompt(hctx.Context(), s.db, insight.GenerateRequest{
+		genReq := insight.GenerateRequest{
 			Type:     req.Type,
 			DateFrom: req.DateFrom,
 			DateTo:   req.DateTo,
 			Project:  req.Project,
 			Prompt:   req.Prompt,
-		})
+		}
+		if req.DateTo > req.DateFrom {
+			summary, err := s.activityRangeSummary(hctx.Context(), req)
+			if err != nil {
+				log.Printf("insight activity summary error: %v", err)
+			} else {
+				genReq.Summary = summary
+			}
+		}
+		prompt, err := insight.BuildPrompt(hctx.Context(), s.db, genReq)
 		if err != nil {
 			log.Printf("insight prompt error: %v", err)
 			sendJSON("error", map[string]string{"message": "failed to build prompt"})
@@ -311,4 +328,37 @@ func (s *Server) humaGenerateInsight(
 		}
 		sendJSON("done", saved)
 	}}, nil
+}
+
+// activityRangeSummary resolves the requested multi-day range into an activity
+// report and condenses it into a RangeSummary for the insight prompt. The
+// range is the half-open span [DateFrom 00:00 UTC, DateTo+1day 00:00 UTC), and
+// the report excludes automated sessions to match BuildPrompt's session set.
+func (s *Server) activityRangeSummary(
+	ctx context.Context, req generateInsightRequest,
+) (*insight.RangeSummary, error) {
+	dateTo, err := time.Parse("2006-01-02", req.DateTo)
+	if err != nil {
+		return nil, fmt.Errorf("parsing date_to %q: %w", req.DateTo, err)
+	}
+	to := dateTo.AddDate(0, 0, 1).Format("2006-01-02")
+	q, err := activity.ResolveQuery(activity.QueryInput{
+		Preset:   "custom",
+		From:     req.DateFrom + "T00:00:00Z",
+		To:       to + "T00:00:00Z",
+		Timezone: "UTC",
+	}, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("resolving activity range: %w", err)
+	}
+	r, err := s.db.GetActivityReport(ctx, db.AnalyticsFilter{
+		Timezone:         "UTC",
+		Project:          req.Project,
+		ExcludeAutomated: true,
+	}, q)
+	if err != nil {
+		return nil, fmt.Errorf("activity report: %w", err)
+	}
+	summary := insight.SummarizeReport(r, 10)
+	return &summary, nil
 }

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -335,33 +335,50 @@ func (s *Server) humaGenerateInsight(
 }
 
 // activityRangeSummary resolves the requested range into an activity report and
-// condenses it into a RangeSummary for the insight prompt. The range is the
-// half-open span [DateFrom 00:00 UTC, DateTo+1day 00:00 UTC). It excludes
-// automated sessions so the summary reflects the same interactive-only work
-// BuildPrompt's prompt focuses on; the two otherwise select sessions
-// differently (this uses the activity report's half-open UTC window with an
-// ended_at fallback, BuildPrompt uses ListSessions' calendar-date match on the
-// start date), so the summary is a range-level overview, not a row-for-row
-// mirror of BuildPrompt's session list.
+// condenses it into a RangeSummary for the insight prompt. The range spans the
+// local days [DateFrom, DateTo] in req.Timezone (empty means UTC): the bounds
+// are that zone's midnights, matching the activity dashboard the dates were
+// derived from, so a non-UTC viewer's summary covers the window the dashboard
+// shows rather than a UTC-shifted one. It excludes automated sessions so the
+// summary reflects the same interactive-only work BuildPrompt's prompt focuses
+// on; the two otherwise select sessions differently (this uses the activity
+// report's half-open window with an ended_at fallback, BuildPrompt uses
+// ListSessions' calendar-date match on the start date), so the summary is a
+// range-level overview, not a row-for-row mirror of BuildPrompt's session list.
 func (s *Server) activityRangeSummary(
 	ctx context.Context, req generateInsightRequest,
 ) (*insight.RangeSummary, error) {
-	dateTo, err := time.Parse("2006-01-02", req.DateTo)
+	tz := req.Timezone
+	if tz == "" {
+		tz = "UTC"
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, fmt.Errorf("loading timezone %q: %w", tz, err)
+	}
+	// Local midnights of DateFrom and the day after DateTo bound the half-open
+	// window, expressed as absolute instants so ResolveQuery's custom-range
+	// parse keeps them exact; Timezone drives only the bucket calendar.
+	from, err := time.ParseInLocation("2006-01-02", req.DateFrom, loc)
+	if err != nil {
+		return nil, fmt.Errorf("parsing date_from %q: %w", req.DateFrom, err)
+	}
+	toDay, err := time.ParseInLocation("2006-01-02", req.DateTo, loc)
 	if err != nil {
 		return nil, fmt.Errorf("parsing date_to %q: %w", req.DateTo, err)
 	}
-	to := dateTo.AddDate(0, 0, 1).Format("2006-01-02")
+	to := toDay.AddDate(0, 0, 1)
 	q, err := activity.ResolveQuery(activity.QueryInput{
 		Preset:   "custom",
-		From:     req.DateFrom + "T00:00:00Z",
-		To:       to + "T00:00:00Z",
-		Timezone: "UTC",
+		From:     from.UTC().Format(time.RFC3339),
+		To:       to.UTC().Format(time.RFC3339),
+		Timezone: tz,
 	}, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("resolving activity range: %w", err)
 	}
 	r, err := s.db.GetActivityReport(ctx, db.AnalyticsFilter{
-		Timezone:         "UTC",
+		Timezone:         tz,
 		Project:          req.Project,
 		ExcludeAutomated: true,
 	}, q)

--- a/internal/server/insights.go
+++ b/internal/server/insights.go
@@ -17,6 +17,10 @@ type generateInsightRequest struct {
 	Project  string `json:"project,omitempty"`
 	Prompt   string `json:"prompt,omitempty"`
 	Agent    string `json:"agent,omitempty"`
+	// Timezone is the IANA zone the caller's date range is expressed in, so
+	// the attached activity summary covers the same local-day window as the
+	// activity dashboard the dates were derived from. Empty means UTC.
+	Timezone string `json:"timezone,omitempty"`
 }
 
 func insightGenerateClientMessage(

--- a/internal/server/insights_internal_test.go
+++ b/internal/server/insights_internal_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// TestActivityRangeSummaryUsesRequestTimezone confirms the insight activity
+// summary resolves its window in the request timezone, so a non-UTC viewer's
+// summary covers the same local-day window as the activity dashboard the dates
+// were derived from. A session whose only instant is 2026-06-16T02:00:00Z is
+// the local day 2026-06-15 in America/New_York (UTC-4 in June) but the UTC day
+// 2026-06-16, so the June-15 summary must include it under New York and
+// exclude it under UTC. Before the fix the window was always UTC, so the New
+// York request would have wrongly excluded the session.
+func TestActivityRangeSummaryUsesRequestTimezone(t *testing.T) {
+	srv := testServer(t, 0)
+	ctx := context.Background()
+	ts := "2026-06-16T02:00:00Z"
+	require.NoError(t, srv.db.UpsertSession(db.Session{
+		ID: "x", Project: "proj", Machine: "test", Agent: "claude",
+		StartedAt: &ts, EndedAt: &ts, MessageCount: 1,
+		RelationshipType: "root", DataVersion: 1,
+	}))
+	require.NoError(t, srv.db.ReplaceSessionMessages("x", []db.Message{{
+		SessionID: "x", Ordinal: 0, Role: "assistant", Content: "x",
+		Timestamp: ts, Model: "m1",
+	}}))
+
+	ny, err := srv.activityRangeSummary(ctx, generateInsightRequest{
+		Type: "daily_activity", DateFrom: "2026-06-15", DateTo: "2026-06-15",
+		Timezone: "America/New_York",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ny)
+	assert.Equal(t, 1, ny.Sessions,
+		"New York June-15 window covers the 02:00Z instant (22:00 local)")
+
+	utc, err := srv.activityRangeSummary(ctx, generateInsightRequest{
+		Type: "daily_activity", DateFrom: "2026-06-15", DateTo: "2026-06-15",
+		Timezone: "UTC",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, utc)
+	assert.Equal(t, 0, utc.Sessions,
+		"UTC June-15 window ends at June 16 00:00Z, before the instant")
+}

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -115,6 +115,22 @@ func TestListInsights(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 			wantBody:   "invalid type",
 		},
+		{
+			name:       "ReversedDateRange",
+			seed:       func(t *testing.T, te *testEnv) {},
+			path:       "/api/v1/insights?date_from=2026-06-17&date_to=2026-06-16",
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "date_from must not be after date_to",
+		},
+		{
+			// A non-date value is rejected with 400 before the handler runs
+			// (huma's format:"date" query validation), so only the status is
+			// asserted; the body message is owned by the framework.
+			name:       "InvalidDateFrom",
+			seed:       func(t *testing.T, te *testEnv) {},
+			path:       "/api/v1/insights?date_from=not-a-date",
+			wantStatus: http.StatusBadRequest,
+		},
 	}
 
 	for _, tt := range tests {

--- a/scripts/e2e-server.sh
+++ b/scripts/e2e-server.sh
@@ -45,26 +45,26 @@ else
       -o "$SERVER" "$ROOT/cmd/agentsview"
 fi
 
-# Run server with test DB, no sync dirs, fixed port.
-# Every agent dir must point to EMPTY_DIR to prevent
-# the server from discovering real sessions on the host.
-agent_env=(
-  "AGENTSVIEW_DATA_DIR=$TMPDIR"
-  "CLAUDE_PROJECTS_DIR=$EMPTY_DIR"
-  "CODEX_SESSIONS_DIR=$EMPTY_DIR"
-  "COPILOT_DIR=$EMPTY_DIR"
-  "GEMINI_DIR=$EMPTY_DIR"
-  "OPENCODE_DIR=$EMPTY_DIR"
-  "CURSOR_PROJECTS_DIR=$EMPTY_DIR"
-  "AMP_DIR=$EMPTY_DIR"
-  "IFLOW_DIR=$EMPTY_DIR"
-  "ZED_DIR=$EMPTY_DIR"
-  "VSCODE_COPILOT_DIR=$EMPTY_DIR"
-  "PI_DIR=$EMPTY_DIR"
-  "OPENCLAW_DIR=$EMPTY_DIR"
-  "QCLAW_DIR=$EMPTY_DIR"
-  "WORKBUDDY_PROJECTS_DIR=$EMPTY_DIR"
-)
+# Run server with test DB, no sync dirs, fixed port. Every agent dir override
+# must point at EMPTY_DIR so the server never discovers real sessions on the
+# host. The list is derived from the parser registry (the EnvVar fields in
+# internal/parser/types.go), so registering a new agent cannot silently
+# reintroduce a discovery leak by leaving its dir env var pointed at the host.
+agent_env=("AGENTSVIEW_DATA_DIR=$TMPDIR")
+while IFS= read -r agent_var; do
+  agent_env+=("$agent_var=$EMPTY_DIR")
+done < <(grep -oE 'EnvVar:[[:space:]]*"[A-Z0-9_]+"' "$ROOT/internal/parser/types.go" \
+  | grep -oE '"[A-Z0-9_]+"' | tr -d '"' | sort -u)
+
+# Sanity floor: a stale grep (e.g. types.go reformatted) would yield an empty
+# list and silently re-leak host sessions. The registry has dozens of agents;
+# far fewer than this means the parse broke, so fail loudly instead.
+min_agent_dirs=10
+if [ "${#agent_env[@]}" -le "$min_agent_dirs" ]; then
+  echo "e2e isolation: derived only $(( ${#agent_env[@]} - 1 )) agent dir" \
+    "overrides from internal/parser/types.go; registry parsing is stale" >&2
+  exit 1
+fi
 
 case "$BACKEND" in
   sqlite)


### PR DESCRIPTION
## Summary

Adds an Activity reporting view: a time-windowed dashboard over agent sessions
with summary cards, a concurrency timeline, breakdowns by project / model /
agent (with a toggle between agent-minutes and cost), a sessions table, and
generated insights. Range controls move between day, week, and month windows.

Activity is split into interactive and automated work, building on the
automated-session detection in `internal/db/automated.go`, so automated runs
(for example roborev CI) are measured separately from interactive work. The
split is surfaced throughout the frontend: the summary card, the breakdown bars,
and the concurrency peak bar stack interactive and automated segments; the
sessions table badges automated rows; and a toolbar control filters to all,
interactive, or automated. The two use a blue/orange pair that stays
distinguishable in light and dark themes and under red-green color blindness.

The report query is implemented across all three storage backends — SQLite
(`internal/db/activityreport.go`), PostgreSQL
(`internal/postgres/activityreport.go`), and DuckDB
(`internal/duckdb/activityreport.go`) — with matching shape and ordering, and is
covered by cross-backend parity tests. It is served through a huma OpenAPI route
(`internal/server/huma_routes_activity.go`) and an `activity` CLI subcommand
(`cmd/agentsview/activity.go`).

The dashboard refreshes on a fixed cadence without thrashing. A shared
`RefreshControl` component, used by the Activity, Analytics, and Usage
dashboards, owns a configurable refresh interval (default five minutes) plus a
manual refresh button and a relative "Updated Xm ago" label. SSE and sync events
only flag that newer data exists; the report refetches via the scheduler or the
button, not on every event, so a session actively writing files does not re-run
the aggregation continuously. A failed background refresh keeps the last good
report on screen instead of blanking it, while a first-load or range-change
failure still surfaces the error.

Generated insights can be produced with any supported agent CLI (claude, codex,
copilot, gemini, kiro). The inline Activity Insight panel and the standalone
Insights page share one agent selector.

A parser rule attributes CI worktree sessions (`ci-worktrees/<repo>/...`) to
their owning repository instead of the per-run scratch worktree name, so CI-run
reviews group under the repo in project breakdowns rather than fragmenting into
one project per run.

## Where to look

- `internal/activity/` — domain types, sweep-line concurrency math, and the
  automated/interactive split
- `internal/{db,postgres,duckdb}/activityreport.go` — backend-parity query
  implementations
- `internal/insight/` — insight generation: agent CLI invocation, prompt, and
  summary windowing
- `internal/server/huma_routes_activity.go`, `cmd/agentsview/activity.go` — API
  route and CLI subcommand
- `frontend/src/lib/components/activity/` — Svelte 5 page and components
  (toolbar, breakdowns, concurrency timeline, sessions table, insight panel)
- `frontend/src/lib/components/shared/RefreshControl.svelte`,
  `frontend/src/lib/utils/refresh.ts` — shared refresh control and scheduler
- `internal/parser/project.go` — ci-worktrees attribution rule

## Notes and limitations

- The automated/interactive segmentation is computed in the backend and returned
  by the API; the frontend can show the combined view or filter to one segment.
- Backend parity is maintained across SQLite, PostgreSQL, and DuckDB; the
  PostgreSQL parity tests run under the `pgtest` build tag.
- The insight agent choice is shared in memory between the Activity panel and
  the Insights page and resets to claude on reload.
