### PR TITLE
feat(parser): add Reasonix session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ agentsview auto-discovers sessions from all of these:
 | QClaw                 | `~/.qclaw/agents/`                                                                                                                                                      |
 | Qwen Code             | `~/.qwen/projects/`                                                                                                                                                     |
 | QwenPaw               | `~/.copaw/workspaces/`, `~/.qwenpaw/workspaces/`                                                                                                                        |
+| Reasonix              | `~/.reasonix/`, `%APPDATA%\\reasonix\\` (Windows)                                                                                                                       |
 | VSCode Copilot        | `~/Library/Application Support/Code/User/` (macOS)                                                                                                                      |
 | Visual Studio Copilot | `%LOCALAPPDATA%\\Temp\\VSGitHubCopilotLogs\\traces\\` (Windows), `~/Library/Caches/VSGitHubCopilotLogs/traces/` (macOS), `~/.cache/VSGitHubCopilotLogs/traces/` (Linux) |
 | Warp                  | `~/.warp/` (platform-dependent)                                                                                                                                         |

--- a/internal/parser/reasonix.go
+++ b/internal/parser/reasonix.go
@@ -1,0 +1,524 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// reasonixMessage represents a single line in a Reasonix JSONL
+// transcript.
+type reasonixMessage struct {
+	Role             string             `json:"role"`
+	Content          string             `json:"content"`
+	ReasoningContent string             `json:"reasoning_content"`
+	ToolCalls        []reasonixToolCall `json:"tool_calls"`
+	ToolCallID       string             `json:"tool_call_id"`
+}
+
+// reasonixToolCall represents a tool call in a Reasonix message.
+type reasonixToolCall struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// reasonixMetadata represents the .jsonl.meta sidecar file format.
+type reasonixMetadata struct {
+	ID            string `json:"id"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+	Scope         string `json:"scope"`
+	WorkspaceRoot string `json:"workspace_root"`
+	TopicTitle    string `json:"topic_title"`
+	Model         string `json:"model"`
+}
+
+// reasonixSessionBuilder accumulates state while scanning a
+// Reasonix JSONL session file line by line.
+type reasonixSessionBuilder struct {
+	messages     []ParsedMessage
+	firstMessage string
+	startedAt    time.Time
+	endedAt      time.Time
+	sessionID    string
+	ordinal      int
+	model        string
+}
+
+func newReasonixSessionBuilder() *reasonixSessionBuilder {
+	return &reasonixSessionBuilder{}
+}
+
+// processLine handles a single non-empty, valid JSON line.
+func (b *reasonixSessionBuilder) processLine(line string) error {
+	var msg reasonixMessage
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		return nil // skip invalid lines silently
+	}
+
+	if msg.Role == "" {
+		return nil
+	}
+
+	roleName := strings.ToLower(msg.Role)
+	if roleName == "tool" {
+		return b.processToolResult(msg)
+	}
+
+	// Extract and normalize role
+	var role RoleType
+	switch roleName {
+	case "user":
+		role = RoleUser
+	case "assistant":
+		role = RoleAssistant
+	default:
+		// Skip unsupported roles (system, tool, etc.)
+		return nil
+	}
+
+	// Normalize content
+	content := strings.TrimSpace(msg.Content)
+
+	// For assistant messages, prepend reasoning content if present
+	if role == RoleAssistant && msg.ReasoningContent != "" {
+		thinkBlock := "[Thinking]\n" + strings.TrimSpace(msg.ReasoningContent) + "\n[/Thinking]"
+		if content != "" {
+			content = thinkBlock + "\n\n" + content
+		} else {
+			content = thinkBlock
+		}
+	}
+
+	// Extract tool calls
+	hasToolUse := len(msg.ToolCalls) > 0
+	var toolCalls []ParsedToolCall
+	for _, tc := range msg.ToolCalls {
+		toolCalls = append(toolCalls, ParsedToolCall{
+			ToolUseID: tc.ID,
+			ToolName:  tc.Name,
+			Category:  NormalizeToolCategory(tc.Name),
+			InputJSON: tc.Arguments,
+		})
+	}
+
+	// Skip messages with no content and no tool calls
+	if content == "" && !hasToolUse {
+		return nil
+	}
+
+	// Update first message for user messages
+	if role == RoleUser && b.firstMessage == "" && content != "" {
+		b.firstMessage = truncate(
+			strings.ReplaceAll(content, "\n", " "), 300,
+		)
+	}
+
+	// Message ordering is tracked via ordinal; timestamps are
+	// set from metadata or file mtime after parsing completes.
+
+	b.messages = append(b.messages, ParsedMessage{
+		Ordinal:       b.ordinal,
+		Role:          role,
+		Content:       content,
+		ContentLength: len(content),
+		HasThinking:   msg.ReasoningContent != "",
+		HasToolUse:    hasToolUse,
+		ToolCalls:     toolCalls,
+		Model:         b.model,
+	})
+	b.ordinal++
+
+	return nil
+}
+
+func (b *reasonixSessionBuilder) processToolResult(
+	msg reasonixMessage,
+) error {
+	if msg.ToolCallID == "" {
+		return nil
+	}
+
+	content := msg.Content
+	quoted, err := json.Marshal(content)
+	if err != nil {
+		return nil
+	}
+
+	b.messages = append(b.messages, ParsedMessage{
+		Ordinal:       b.ordinal,
+		Role:          RoleUser,
+		Content:       "",
+		ContentLength: len(content),
+		ToolResults: []ParsedToolResult{{
+			ToolUseID:     msg.ToolCallID,
+			ContentRaw:    string(quoted),
+			ContentLength: len(content),
+		}},
+	})
+	b.ordinal++
+
+	return nil
+}
+
+// ParseReasonixSession parses a Reasonix JSONL session file.
+// Returns (nil, nil, nil, nil) if the file doesn't exist or
+// contains no user/assistant messages.
+func ParseReasonixSession(
+	path, machine string,
+) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil, nil
+		}
+		return nil, nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	lr := newLineReader(f, maxLineSize)
+	b := newReasonixSessionBuilder()
+
+	// Extract session ID from path
+	b.sessionID = sessionIDFromReasonixPath(path)
+
+	// Load metadata from .jsonl.meta sidecar if present.
+	meta, err := loadReasonixMetadata(path)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	sessionName := ""
+	cwd := ""
+	project := ""
+	if meta != nil {
+		if meta.Model != "" {
+			b.model = meta.Model
+		}
+		sessionName = strings.TrimSpace(meta.TopicTitle)
+		cwd = strings.TrimSpace(meta.WorkspaceRoot)
+		if cwd != "" {
+			project = ExtractProjectFromCwd(cwd)
+		}
+		var gotStart, gotEnd bool
+		var metaStart, metaEnd time.Time
+		if meta.CreatedAt != "" {
+			if t, err := time.Parse(time.RFC3339Nano, meta.CreatedAt); err == nil {
+				metaStart = t
+				gotStart = true
+			}
+		}
+		if meta.UpdatedAt != "" {
+			if t, err := time.Parse(time.RFC3339Nano, meta.UpdatedAt); err == nil {
+				metaEnd = t
+				gotEnd = true
+			}
+		}
+		if gotStart && gotEnd {
+			b.startedAt = metaStart
+			b.endedAt = metaEnd
+		}
+	}
+
+	// Parse JSONL lines
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		if line == "" {
+			continue
+		}
+		_ = b.processLine(line)
+	}
+
+	if err := lr.Err(); err != nil {
+		return nil, nil, nil,
+			fmt.Errorf("reading reasonix %s: %w", path, err)
+	}
+
+	// Filter: require at least one message with content.
+	hasContent := false
+	for _, m := range b.messages {
+		if m.Content != "" {
+			hasContent = true
+			break
+		}
+	}
+	if !hasContent {
+		return nil, nil, nil, nil
+	}
+
+	// Fall back to file mtime for sessions without metadata timestamps
+	if b.startedAt.IsZero() {
+		b.startedAt = info.ModTime()
+	}
+	if b.endedAt.IsZero() {
+		b.endedAt = info.ModTime()
+	}
+
+	sessionID := "reasonix:" + b.sessionID
+
+	userCount := 0
+	for _, m := range b.messages {
+		if m.Role == RoleUser && m.Content != "" {
+			userCount++
+		}
+	}
+
+	sess := &ParsedSession{
+		ID:               sessionID,
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentReasonix,
+		Cwd:              cwd,
+		FirstMessage:     b.firstMessage,
+		SessionName:      sessionName,
+		StartedAt:        b.startedAt,
+		EndedAt:          b.endedAt,
+		MessageCount:     len(b.messages),
+		UserMessageCount: userCount,
+		File: FileInfo{
+			Path:  path,
+			Size:  info.Size(),
+			Mtime: info.ModTime().UnixNano(),
+		},
+	}
+
+	accumulateMessageTokenUsage(sess, b.messages)
+
+	return sess, b.messages, nil, nil
+}
+
+// sessionIDFromReasonixPath extracts a session ID from a Reasonix
+// file path. Handles project sessions, global sessions, subagents, and archive.
+func sessionIDFromReasonixPath(path string) string {
+	base := filepath.Base(path)
+
+	// Strip .jsonl extension and .meta suffix if present
+	if cut, ok := strings.CutSuffix(base, ".jsonl"); ok {
+		base = cut
+		if cut2, ok2 := strings.CutSuffix(base, ".meta"); ok2 {
+			base = cut2
+		}
+	}
+
+	// For project/global sessions, base is already the session ID
+	// For subagents, base is like sa_20260612_105316_000000000_<hash>
+	return base
+}
+
+// loadReasonixMetadata reads the .jsonl.meta sidecar file if it exists. A
+// missing sidecar is valid, but an unreadable or malformed sidecar is returned
+// as an error so sync does not overwrite previously parsed metadata with empty
+// fields during partial writes.
+func loadReasonixMetadata(transcriptPath string) (*reasonixMetadata, error) {
+	metaPath := transcriptPath + ".meta"
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read reasonix metadata %s: %w", metaPath, err)
+	}
+
+	var meta reasonixMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parse reasonix metadata %s: %w", metaPath, err)
+	}
+
+	return &meta, nil
+}
+
+// DiscoverReasonixSessions discovers Reasonix sessions across
+// four layouts: project sessions, global sessions, global subagents,
+// and archive sessions.
+func DiscoverReasonixSessions(reasonixDir string) []DiscoveredFile {
+	if reasonixDir == "" {
+		return nil
+	}
+
+	var files []DiscoveredFile
+
+	// 1. Project sessions: {reasonixDir}/projects/{project}/sessions/*.jsonl
+	projectsDir := filepath.Join(reasonixDir, "projects")
+	if entries, err := os.ReadDir(projectsDir); err == nil {
+		for _, projectEntry := range entries {
+			if !projectEntry.IsDir() {
+				continue
+			}
+			projectName := projectEntry.Name()
+			sessionsDir := filepath.Join(
+				projectsDir, projectName, "sessions",
+			)
+			if sessEntries, err := os.ReadDir(sessionsDir); err == nil {
+				for _, sessEntry := range sessEntries {
+					if sessEntry.IsDir() {
+						// Check for {id}/{id}.jsonl inside
+						sessionID := sessEntry.Name()
+						candidate := filepath.Join(
+							sessionsDir, sessionID,
+							sessionID+".jsonl",
+						)
+						if _, err := os.Stat(candidate); err == nil {
+							files = append(files, DiscoveredFile{
+								Path:    candidate,
+								Project: projectName,
+								Agent:   AgentReasonix,
+							})
+						}
+						continue
+					}
+					if strings.HasSuffix(sessEntry.Name(), ".jsonl") &&
+						!strings.HasSuffix(sessEntry.Name(), ".meta") {
+						files = append(files, DiscoveredFile{
+							Path:    filepath.Join(sessionsDir, sessEntry.Name()),
+							Project: projectName,
+							Agent:   AgentReasonix,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// 2. Global sessions: {reasonixDir}/sessions/*.jsonl
+	globalSessDir := filepath.Join(reasonixDir, "sessions")
+	if entries, err := os.ReadDir(globalSessDir); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				// Skip subagents directory here (handled separately)
+				if entry.Name() == "subagents" {
+					continue
+				}
+				// If it's a directory, it should contain {id}.jsonl
+				sessionID := entry.Name()
+				candidate := filepath.Join(
+					globalSessDir, sessionID, sessionID+".jsonl",
+				)
+				if _, err := os.Stat(candidate); err == nil {
+					files = append(files, DiscoveredFile{
+						Path:  candidate,
+						Agent: AgentReasonix,
+					})
+				}
+			} else if strings.HasSuffix(entry.Name(), ".jsonl") &&
+				!strings.HasSuffix(entry.Name(), ".meta") {
+				// Bare {id}.jsonl files
+				path := filepath.Join(globalSessDir, entry.Name())
+				files = append(files, DiscoveredFile{
+					Path:  path,
+					Agent: AgentReasonix,
+				})
+			}
+		}
+	}
+
+	// 3. Global subagents: {reasonixDir}/sessions/subagents/*.jsonl
+	subagentsDir := filepath.Join(globalSessDir, "subagents")
+	if entries, err := os.ReadDir(subagentsDir); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() &&
+				strings.HasSuffix(entry.Name(), ".jsonl") &&
+				!strings.HasSuffix(entry.Name(), ".meta") {
+				path := filepath.Join(subagentsDir, entry.Name())
+				files = append(files, DiscoveredFile{
+					Path:  path,
+					Agent: AgentReasonix,
+				})
+			}
+		}
+	}
+
+	// 4. Archive sessions: {reasonixDir}/archive/*.jsonl
+	archiveDir := filepath.Join(reasonixDir, "archive")
+	if entries, err := os.ReadDir(archiveDir); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() &&
+				strings.HasSuffix(entry.Name(), ".jsonl") &&
+				!strings.HasSuffix(entry.Name(), ".meta") {
+				path := filepath.Join(archiveDir, entry.Name())
+				files = append(files, DiscoveredFile{
+					Path:  path,
+					Agent: AgentReasonix,
+				})
+			}
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// FindReasonixSourceFile locates a Reasonix session file by
+// session ID. Searches project, global, subagent, and archive layouts.
+func FindReasonixSourceFile(reasonixDir, rawID string) string {
+	if reasonixDir == "" || rawID == "" {
+		return ""
+	}
+
+	// Try project sessions: {reasonixDir}/projects/{project}/sessions/{id}/{id}.jsonl
+	projectsDir := filepath.Join(reasonixDir, "projects")
+	if entries, err := os.ReadDir(projectsDir); err == nil {
+		for _, projectEntry := range entries {
+			if !projectEntry.IsDir() {
+				continue
+			}
+			candidate := filepath.Join(
+				projectsDir, projectEntry.Name(), "sessions",
+				rawID, rawID+".jsonl",
+			)
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate
+			}
+			candidate = filepath.Join(
+				projectsDir, projectEntry.Name(), "sessions",
+				rawID+".jsonl",
+			)
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate
+			}
+		}
+	}
+
+	// Try global sessions: {reasonixDir}/sessions/{id}/{id}.jsonl
+	candidate := filepath.Join(
+		reasonixDir, "sessions", rawID, rawID+".jsonl",
+	)
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+
+	// Try bare global: {reasonixDir}/sessions/{id}.jsonl
+	candidate = filepath.Join(reasonixDir, "sessions", rawID+".jsonl")
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+
+	// Try subagents: {reasonixDir}/sessions/subagents/{id}.jsonl
+	candidate = filepath.Join(
+		reasonixDir, "sessions", "subagents", rawID+".jsonl",
+	)
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+
+	// Try archive: {reasonixDir}/archive/{id}.jsonl
+	candidate = filepath.Join(reasonixDir, "archive", rawID+".jsonl")
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+
+	return ""
+}

--- a/internal/parser/reasonix_test.go
+++ b/internal/parser/reasonix_test.go
@@ -1,0 +1,403 @@
+package parser
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeReasonixJSONL writes JSONL lines to a temp file and
+// returns the file path.
+func writeReasonixJSONL(
+	t *testing.T, lines ...string,
+) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test-session.jsonl")
+	content := strings.Join(lines, "\n") + "\n"
+	require.NoError(t, os.WriteFile(
+		path, []byte(content), 0o644,
+	))
+	return path
+}
+
+// writeReasonixMetadata writes a .jsonl.meta sidecar file.
+func writeReasonixMetadata(
+	t *testing.T, transcriptPath string, meta reasonixMetadata,
+) {
+	t.Helper()
+	metaPath := transcriptPath + ".meta"
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, data, 0o644))
+}
+
+func TestParseReasonixSession_Basic(t *testing.T) {
+	path := writeReasonixJSONL(t,
+		`{"role":"user","content":"Write a simple function"}`,
+		`{"role":"assistant","content":"Here's a function","reasoning_content":"I need to write a function"}`,
+	)
+
+	sess, msgs, _, err := ParseReasonixSession(path, "test-machine")
+	require.NoError(t, err)
+	require.NotNil(t, sess, "expected non-nil session")
+	require.Len(t, msgs, 2)
+
+	assert.Equal(t, AgentReasonix, sess.Agent, "agent")
+	assert.Equal(t, "test-machine", sess.Machine, "machine")
+	assert.Equal(t, "Write a simple function", sess.FirstMessage, "first_message")
+	assert.True(t, strings.Contains(sess.ID, "reasonix:"), "session ID prefix")
+
+	// Check message roles
+	assert.Equal(t, RoleUser, msgs[0].Role, "msgs[0].Role")
+	assert.Equal(t, RoleAssistant, msgs[1].Role, "msgs[1].Role")
+
+	// Check that reasoning content is included in display content
+	assert.True(t, strings.Contains(msgs[1].Content, "[Thinking]"), "thinking block in content")
+	assert.True(t, msgs[1].HasThinking, "HasThinking flag")
+}
+
+func TestParseReasonixSession_ToolCalls(t *testing.T) {
+	path := writeReasonixJSONL(t,
+		`{"role":"user","content":"Read the file"}`,
+		`{"role":"assistant","content":"I'll read it","tool_calls":[{"id":"call_1","name":"read_file","arguments":"{\"path\":\"config.json\"}"}]}`,
+	)
+
+	_, msgs, _, err := ParseReasonixSession(path, "m")
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	// Check tool call message
+	tcMsg := msgs[1]
+	assert.True(t, tcMsg.HasToolUse, "expected HasToolUse")
+	require.Len(t, tcMsg.ToolCalls, 1)
+	assert.Equal(t, "call_1", tcMsg.ToolCalls[0].ToolUseID)
+	assert.Equal(t, "read_file", tcMsg.ToolCalls[0].ToolName)
+	assert.Equal(t, `{"path":"config.json"}`, tcMsg.ToolCalls[0].InputJSON)
+}
+
+func TestParseReasonixSession_ToolResults(t *testing.T) {
+	path := writeReasonixJSONL(t,
+		`{"role":"user","content":"Read the file"}`,
+		`{"role":"assistant","content":"I'll read it","tool_calls":[{"id":"call_1","name":"read_file","arguments":"{\"path\":\"config.json\"}"}]}`,
+		`{"role":"tool","content":"file contents here","tool_call_id":"call_1"}`,
+	)
+
+	_, msgs, _, err := ParseReasonixSession(path, "m")
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+
+	resultMsg := msgs[2]
+	require.Len(t, resultMsg.ToolResults, 1)
+	assert.Equal(t, RoleUser, resultMsg.Role)
+	assert.Equal(t, "", resultMsg.Content)
+	assert.Equal(t, "call_1", resultMsg.ToolResults[0].ToolUseID)
+	assert.Equal(t, len("file contents here"), resultMsg.ToolResults[0].ContentLength)
+	assert.Equal(t, "file contents here", DecodeContent(resultMsg.ToolResults[0].ContentRaw))
+}
+
+func TestParseReasonixSession_TimestampSessionID(t *testing.T) {
+	path := writeReasonixJSONL(t,
+		`{"role":"user","content":"Hello"}`,
+	)
+
+	// Rename to match timestamp-based format
+	dir := filepath.Dir(path)
+	timestampPath := filepath.Join(dir, "20260617-081849.643965200-deepseek-v4-pro.jsonl")
+	require.NoError(t, os.Rename(path, timestampPath))
+
+	sess, _, _, err := ParseReasonixSession(timestampPath, "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "reasonix:20260617-081849.643965200-deepseek-v4-pro", sess.ID)
+}
+
+func TestParseReasonixSession_SubagentID(t *testing.T) {
+	path := writeReasonixJSONL(t,
+		`{"role":"user","content":"Subagent task"}`,
+	)
+
+	// Rename to match subagent format
+	dir := filepath.Dir(path)
+	subagentPath := filepath.Join(dir, "sa_20260612_105316_000000000_6b991b514f0a.jsonl")
+	require.NoError(t, os.Rename(path, subagentPath))
+
+	sess, _, _, err := ParseReasonixSession(subagentPath, "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "reasonix:sa_20260612_105316_000000000_6b991b514f0a", sess.ID)
+}
+
+func TestParseReasonixSession_SpaceInSessionDir(t *testing.T) {
+	baseDir := t.TempDir()
+	// Create directory with space in name
+	sessionDir := filepath.Join(baseDir, "session dir with spaces")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	path := filepath.Join(sessionDir, "20260617-081849.643965200-gpt4.jsonl")
+	content := `{"role":"user","content":"Test message"}`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	sess, _, _, err := ParseReasonixSession(path, "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	// Should extract just the filename, not the directory
+	assert.Equal(t, "reasonix:20260617-081849.643965200-gpt4", sess.ID)
+}
+
+func TestParseReasonixSession_MetadataFallback(t *testing.T) {
+	path := writeReasonixJSONL(t,
+		`{"role":"user","content":"Test"}`,
+		`{"role":"assistant","content":"Response"}`,
+	)
+
+	// Write metadata sidecar
+	meta := reasonixMetadata{
+		ID:            "test-session-id",
+		CreatedAt:     "2026-06-12T10:42:35.2672024Z",
+		UpdatedAt:     "2026-06-12T10:58:03.6456434Z",
+		TopicTitle:    "Test Session",
+		WorkspaceRoot: "/home/user/project",
+		Model:         "claude-opus-4",
+	}
+	writeReasonixMetadata(t, path, meta)
+
+	sess, _, _, err := ParseReasonixSession(path, "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Parse expected times from metadata
+	expectedStart, err := time.Parse(time.RFC3339Nano, meta.CreatedAt)
+	require.NoError(t, err)
+	expectedEnd, err := time.Parse(time.RFC3339Nano, meta.UpdatedAt)
+	require.NoError(t, err)
+
+	// Verify metadata timestamps were preserved (not overwritten by time.Now())
+	assert.Equal(t, expectedStart, sess.StartedAt, "StartedAt should match CreatedAt from metadata")
+	assert.Equal(t, expectedEnd, sess.EndedAt, "EndedAt should match UpdatedAt from metadata")
+}
+
+func TestParseReasonixSession_MetadataFields(t *testing.T) {
+	path := writeReasonixJSONL(t,
+		`{"role":"user","content":"Test"}`,
+		`{"role":"assistant","content":"Response"}`,
+	)
+	workspaceRoot := filepath.Join("workspace", "my-app")
+
+	meta := reasonixMetadata{
+		CreatedAt:     "2026-06-12T10:42:35.2672024Z",
+		UpdatedAt:     "2026-06-12T10:58:03.6456434Z",
+		TopicTitle:    "Metadata title",
+		WorkspaceRoot: workspaceRoot,
+		Model:         "claude-opus-4",
+	}
+	writeReasonixMetadata(t, path, meta)
+
+	sess, _, _, err := ParseReasonixSession(path, "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "Metadata title", sess.SessionName)
+	assert.Equal(t, workspaceRoot, sess.Cwd)
+	assert.Equal(t, "my_app", sess.Project)
+}
+
+func TestParseReasonixSession_PartialMetadataFallsBackToFileMtime(t *testing.T) {
+	tests := []struct {
+		name string
+		meta reasonixMetadata
+	}{
+		{
+			name: "missing updated_at",
+			meta: reasonixMetadata{
+				CreatedAt: "2026-06-12T10:42:35.2672024Z",
+			},
+		},
+		{
+			name: "malformed created_at",
+			meta: reasonixMetadata{
+				CreatedAt: "not-a-timestamp",
+				UpdatedAt: "2026-06-12T10:58:03.6456434Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeReasonixJSONL(t,
+				`{"role":"user","content":"Test"}`,
+				`{"role":"assistant","content":"Response"}`,
+			)
+			wantMtime := time.Date(2024, time.March, 14, 15, 9, 26, 0, time.UTC)
+			require.NoError(t, os.Chtimes(path, wantMtime, wantMtime))
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			writeReasonixMetadata(t, path, tt.meta)
+
+			sess, _, _, err := ParseReasonixSession(path, "m")
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+			assert.Equal(t, info.ModTime(), sess.StartedAt)
+			assert.Equal(t, info.ModTime(), sess.EndedAt)
+		})
+	}
+}
+
+func TestParseReasonixSession_ArchiveWithoutMeta(t *testing.T) {
+	path := writeReasonixJSONL(t,
+		`{"role":"user","content":"Archived message"}`,
+		`{"role":"assistant","content":"Archived response"}`,
+	)
+
+	// Don't write metadata sidecar - archive files often lack .meta
+
+	sess, msgs, _, err := ParseReasonixSession(path, "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 2)
+
+	// Should still parse successfully with fallback times
+	assert.NotZero(t, sess.StartedAt)
+	assert.NotZero(t, sess.EndedAt)
+}
+
+func TestDiscoverReasonixSessions_ProjectSessions(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create project session structure
+	projectDir := filepath.Join(baseDir, "projects", "my-project", "sessions")
+	sessionDir := filepath.Join(projectDir, "session-123")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	sessionFile := filepath.Join(sessionDir, "session-123.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte(`{"role":"user","content":"test"}`), 0o644))
+
+	files := DiscoverReasonixSessions(baseDir)
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionFile, files[0].Path)
+	assert.Equal(t, "my-project", files[0].Project)
+	assert.Equal(t, AgentReasonix, files[0].Agent)
+}
+
+func TestDiscoverReasonixSessions_ProjectBareSession(t *testing.T) {
+	baseDir := t.TempDir()
+
+	sessionsDir := filepath.Join(baseDir, "projects", "my-project", "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	sessionFile := filepath.Join(sessionsDir, "session-123.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte(`{"role":"user","content":"test"}`), 0o644))
+
+	files := DiscoverReasonixSessions(baseDir)
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionFile, files[0].Path)
+	assert.Equal(t, "my-project", files[0].Project)
+	assert.Equal(t, AgentReasonix, files[0].Agent)
+}
+
+func TestDiscoverReasonixSessions_GlobalSessions(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create global session (bare .jsonl)
+	sessionsDir := filepath.Join(baseDir, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	sessionFile := filepath.Join(sessionsDir, "global-session.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte(`{"role":"user","content":"test"}`), 0o644))
+
+	files := DiscoverReasonixSessions(baseDir)
+	require.Len(t, files, 1)
+	assert.Equal(t, sessionFile, files[0].Path)
+	assert.Equal(t, AgentReasonix, files[0].Agent)
+}
+
+func TestDiscoverReasonixSessions_Subagents(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create subagent session
+	subagentsDir := filepath.Join(baseDir, "sessions", "subagents")
+	require.NoError(t, os.MkdirAll(subagentsDir, 0o755))
+
+	subagentFile := filepath.Join(subagentsDir, "sa_20260612_105316_000000000_hash.jsonl")
+	require.NoError(t, os.WriteFile(subagentFile, []byte(`{"role":"user","content":"test"}`), 0o644))
+
+	files := DiscoverReasonixSessions(baseDir)
+	require.Len(t, files, 1)
+	assert.Equal(t, subagentFile, files[0].Path)
+}
+
+func TestDiscoverReasonixSessions_Archive(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create archive session
+	archiveDir := filepath.Join(baseDir, "archive")
+	require.NoError(t, os.MkdirAll(archiveDir, 0o755))
+
+	archiveFile := filepath.Join(archiveDir, "20260612-104235.267202400.jsonl")
+	require.NoError(t, os.WriteFile(archiveFile, []byte(`{"role":"user","content":"test"}`), 0o644))
+
+	files := DiscoverReasonixSessions(baseDir)
+	require.Len(t, files, 1)
+	assert.Equal(t, archiveFile, files[0].Path)
+}
+
+func TestFindReasonixSourceFile_ProjectSession(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create project session
+	projectDir := filepath.Join(baseDir, "projects", "my-project", "sessions")
+	sessionDir := filepath.Join(projectDir, "test-id")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	sessionFile := filepath.Join(sessionDir, "test-id.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte(""), 0o644))
+
+	found := FindReasonixSourceFile(baseDir, "test-id")
+	assert.Equal(t, sessionFile, found)
+}
+
+func TestFindReasonixSourceFile_ProjectBareSession(t *testing.T) {
+	baseDir := t.TempDir()
+
+	sessionsDir := filepath.Join(baseDir, "projects", "my-project", "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	sessionFile := filepath.Join(sessionsDir, "test-id.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte(""), 0o644))
+
+	found := FindReasonixSourceFile(baseDir, "test-id")
+	assert.Equal(t, sessionFile, found)
+}
+
+func TestFindReasonixSourceFile_GlobalSession(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create global session (bare)
+	sessionsDir := filepath.Join(baseDir, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	sessionFile := filepath.Join(sessionsDir, "global-id.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte(""), 0o644))
+
+	found := FindReasonixSourceFile(baseDir, "global-id")
+	assert.Equal(t, sessionFile, found)
+}
+
+func TestFindReasonixSourceFile_Archive(t *testing.T) {
+	baseDir := t.TempDir()
+
+	// Create archive session
+	archiveDir := filepath.Join(baseDir, "archive")
+	require.NoError(t, os.MkdirAll(archiveDir, 0o755))
+
+	archiveFile := filepath.Join(archiveDir, "archive-id.jsonl")
+	require.NoError(t, os.WriteFile(archiveFile, []byte(""), 0o644))
+
+	found := FindReasonixSourceFile(baseDir, "archive-id")
+	assert.Equal(t, archiveFile, found)
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -51,6 +51,7 @@ const (
 	AgentGptme          AgentType = "gptme"
 	AgentShelley        AgentType = "shelley"
 	AgentAider          AgentType = "aider"
+	AgentReasonix       AgentType = "reasonix"
 )
 
 // AgentDef describes a supported coding agent's filesystem
@@ -633,6 +634,18 @@ var Registry = []AgentDef{
 		ShallowWatch:   true,
 		DiscoverFunc:   DiscoverAiderSessions,
 		FindSourceFunc: FindAiderSourceFile,
+	},
+	{
+		Type:           AgentReasonix,
+		DisplayName:    "Reasonix",
+		EnvVar:         "REASONIX_DIR",
+		ConfigKey:      "reasonix_dirs",
+		DefaultDirs:    []string{".reasonix", "AppData/Roaming/reasonix"},
+		IDPrefix:       "reasonix:",
+		WatchSubdirs:   []string{"sessions", "archive", "projects"},
+		FileBased:      true,
+		DiscoverFunc:   DiscoverReasonixSessions,
+		FindSourceFunc: FindReasonixSourceFile,
 	},
 }
 

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -342,6 +342,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentShelley,
 		AgentVibe,
 		AgentAider,
+		AgentReasonix,
 	}
 
 	expected := make(map[AgentType]bool, len(allTypes))
@@ -1073,4 +1074,47 @@ func TestApplyUsageEventTokenTotals(t *testing.T) {
 	// Event 1 context = 1000 + 500 + 300 = 1800
 	// Event 2 context = 800 + 1200 + 100 = 2100
 	assert.Equal(t, 2100, sess.PeakContextTokens)
+}
+
+func TestReasonixRegistryEntry(t *testing.T) {
+	// Find Reasonix in the registry
+	var reasonixDef *AgentDef
+	for _, def := range Registry {
+		if def.Type == AgentReasonix {
+			reasonixDef = &def
+			break
+		}
+	}
+	require.NotNil(t, reasonixDef, "AgentReasonix must be in Registry")
+
+	// Verify basic properties
+	assert.Equal(t, AgentReasonix, reasonixDef.Type)
+	assert.Equal(t, "Reasonix", reasonixDef.DisplayName)
+	assert.Equal(t, "REASONIX_DIR", reasonixDef.EnvVar)
+	assert.Equal(t, "reasonix_dirs", reasonixDef.ConfigKey)
+	assert.Equal(t, "reasonix:", reasonixDef.IDPrefix)
+	assert.True(t, reasonixDef.FileBased)
+
+	// Verify watch subdirs
+	assert.Contains(t, reasonixDef.WatchSubdirs, "sessions")
+	assert.Contains(t, reasonixDef.WatchSubdirs, "archive")
+
+	// Verify function pointers are set
+	assert.NotNil(t, reasonixDef.DiscoverFunc, "DiscoverFunc must be set")
+	assert.NotNil(t, reasonixDef.FindSourceFunc, "FindSourceFunc must be set")
+
+	// Verify default dirs contain .reasonix and Windows path
+	assert.True(t, len(reasonixDef.DefaultDirs) > 0)
+	hasUnix := false
+	hasWindows := false
+	for _, dir := range reasonixDef.DefaultDirs {
+		if dir == ".reasonix" {
+			hasUnix = true
+		}
+		if dir == "AppData/Roaming/reasonix" {
+			hasWindows = true
+		}
+	}
+	assert.True(t, hasUnix, "DefaultDirs should contain .reasonix")
+	assert.True(t, hasWindows, "DefaultDirs should contain AppData/Roaming/reasonix")
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1164,20 +1164,8 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
-	// aider: <aiderRoot>/.../.aider.chat.history.md (rootless; any depth
-	// under the configured root).
-	if filepath.Base(path) == parser.AiderHistoryFileName() {
-		for _, aiderDir := range e.agentDirs[parser.AgentAider] {
-			if aiderDir == "" {
-				continue
-			}
-			if _, ok := isUnder(aiderDir, path); ok {
-				return parser.DiscoveredFile{
-					Path:  path,
-					Agent: parser.AgentAider,
-				}, true
-			}
-		}
+	if df, ok := e.classifyAiderPath(path); ok {
+		return df, true
 	}
 
 	// Command Code: <projectsDir>/<slugified-cwd>/<session>.jsonl
@@ -1468,6 +1456,31 @@ func (e *Engine) classifyVisualStudioCopilotPath(
 			Project: "visualstudio",
 			Agent:   parser.AgentVSCopilot,
 		}, true
+	}
+	return parser.DiscoveredFile{}, false
+}
+
+// classifyAiderPath handles Aider's rootless chat-history layout:
+//
+//	<aiderRoot>/.../.aider.chat.history.md
+//
+// extracted from classifyOnePath to stay within nilaway CFG limits.
+func (e *Engine) classifyAiderPath(
+	path string,
+) (parser.DiscoveredFile, bool) {
+	if filepath.Base(path) != parser.AiderHistoryFileName() {
+		return parser.DiscoveredFile{}, false
+	}
+	for _, aiderDir := range e.agentDirs[parser.AgentAider] {
+		if aiderDir == "" {
+			continue
+		}
+		if _, ok := isUnder(aiderDir, path); ok {
+			return parser.DiscoveredFile{
+				Path:  path,
+				Agent: parser.AgentAider,
+			}, true
+		}
 	}
 	return parser.DiscoveredFile{}, false
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -629,8 +629,19 @@ func (e *Engine) classifyOnePath(
 	if df, ok := e.classifyContainerPath(path, pathExists); ok {
 		return df, true
 	}
+	// Reasonix sidecar delete events arrive after .jsonl.meta no longer
+	// exists; classify them against the sibling transcript before the
+	// generic missing-path guard.
+	if strings.HasSuffix(path, ".jsonl.meta") {
+		if df, ok := e.classifyReasonixPath(path); ok {
+			return df, true
+		}
+	}
 	if !pathExists {
 		return parser.DiscoveredFile{}, false
+	}
+	if df, ok := e.classifyReasonixPath(path); ok {
+		return df, true
 	}
 
 	// Claude: <claudeDir>/<project>/<session>.jsonl
@@ -3069,6 +3080,13 @@ func discoveredFileMtime(
 		}
 		return vibeEffectiveInfo(file.Path, info).ModTime().UnixNano(), nil
 	}
+	if file.Agent == parser.AgentReasonix {
+		info, err := os.Stat(file.Path)
+		if err != nil {
+			return 0, err
+		}
+		return reasonixEffectiveInfo(file.Path, info).ModTime().UnixNano(), nil
+	}
 
 	info, err := os.Stat(file.Path)
 	if err != nil {
@@ -3985,6 +4003,9 @@ func (e *Engine) processFile(
 		// of staying skipped on the unchanged transcript mtime.
 		mtime = vibeEffectiveInfo(file.Path, info).ModTime().UnixNano()
 	}
+	if file.Agent == parser.AgentReasonix {
+		mtime = reasonixEffectiveInfo(file.Path, info).ModTime().UnixNano()
+	}
 	cacheSkip := e.shouldCacheSkip(file)
 
 	// Skip files cached from a previous sync (parse errors
@@ -4017,6 +4038,8 @@ func (e *Engine) processFile(
 		res = e.processCodex(file, info)
 	case parser.AgentCopilot:
 		res = e.processCopilot(file, info)
+	case parser.AgentReasonix:
+		res = e.processReasonix(file, info)
 	case parser.AgentGemini:
 		res = e.processGemini(file, info)
 	case parser.AgentOpenCode, parser.AgentKilo, parser.AgentMiMoCode:
@@ -5054,6 +5077,139 @@ func copilotEffectiveMtime(eventsPath string, info os.FileInfo) int64 {
 		}
 	}
 	return m
+}
+
+// classifyReasonixPath handles Reasonix session classification,
+// extracted from classifyOnePath to stay within nilaway limits.
+func (e *Engine) classifyReasonixPath(
+	path string,
+) (parser.DiscoveredFile, bool) {
+	sep := string(filepath.Separator)
+	for _, reasonixDir := range e.agentDirs[parser.AgentReasonix] {
+		if reasonixDir == "" {
+			continue
+		}
+		if rel, ok := isUnder(reasonixDir, path); ok {
+			// Map .jsonl.meta sidecar events to sibling .jsonl
+			if strings.HasSuffix(path, ".jsonl.meta") {
+				jsonlPath := strings.TrimSuffix(path, ".meta")
+				if _, err := os.Stat(jsonlPath); err != nil {
+					continue
+				}
+				path = jsonlPath
+				rel = strings.TrimSuffix(rel, ".meta")
+			}
+			if !strings.HasSuffix(path, ".jsonl") {
+				continue
+			}
+			parts := strings.Split(rel, sep)
+
+			// Project sessions: projects/{project}/sessions/{id}.jsonl
+			// or projects/{project}/sessions/{id}/{id}.jsonl
+			if len(parts) == 4 && parts[0] == "projects" &&
+				parts[2] == "sessions" &&
+				strings.HasSuffix(parts[3], ".jsonl") {
+				return parser.DiscoveredFile{
+					Path:    path,
+					Project: parts[1],
+					Agent:   parser.AgentReasonix,
+				}, true
+			}
+
+			// Project sessions: projects/{project}/sessions/{id}/{id}.jsonl
+			if len(parts) == 5 && parts[0] == "projects" &&
+				parts[2] == "sessions" {
+				base := strings.TrimSuffix(parts[4], ".jsonl")
+				if base != "" && parts[3] == base {
+					return parser.DiscoveredFile{
+						Path:    path,
+						Project: parts[1],
+						Agent:   parser.AgentReasonix,
+					}, true
+				}
+			}
+
+			// Global or archive sessions
+			if len(parts) == 2 {
+				if (parts[0] == "sessions" || parts[0] == "archive") &&
+					strings.HasSuffix(parts[1], ".jsonl") {
+					return parser.DiscoveredFile{
+						Path:  path,
+						Agent: parser.AgentReasonix,
+					}, true
+				}
+			}
+
+			// Nested global or subagent: sessions/{id}/{id}.jsonl or sessions/subagents/{id}.jsonl
+			if len(parts) == 3 {
+				base := strings.TrimSuffix(parts[2], ".jsonl")
+				if parts[0] == "sessions" &&
+					(parts[1] == "subagents" ||
+						parts[1] == base) {
+					if base != "" {
+						return parser.DiscoveredFile{
+							Path:  path,
+							Agent: parser.AgentReasonix,
+						}, true
+					}
+				}
+			}
+		}
+	}
+
+	return parser.DiscoveredFile{}, false
+}
+
+func (e *Engine) processReasonix(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	effectiveInfo := reasonixEffectiveInfo(file.Path, info)
+	if e.shouldSkipByPath(file.Path, effectiveInfo) {
+		return processResult{skip: true}
+	}
+
+	sess, msgs, _, err := parser.ParseReasonixSession(
+		file.Path, e.machine,
+	)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if sess == nil {
+		return processResult{}
+	}
+
+	// Use the discovered project only when metadata did not supply a
+	// project via workspace_root.
+	if file.Project != "" && sess.Project == "" {
+		sess.Project = file.Project
+	}
+
+	hash, err := ComputeFileHash(file.Path)
+	if err == nil {
+		sess.File.Hash = hash
+	}
+
+	sess.File.Size = effectiveInfo.Size()
+	sess.File.Mtime = effectiveInfo.ModTime().UnixNano()
+
+	return processResult{
+		results: []parser.ParseResult{
+			{Session: *sess, Messages: msgs},
+		},
+	}
+}
+
+func reasonixEffectiveInfo(path string, info os.FileInfo) os.FileInfo {
+	size := info.Size()
+	mtime := info.ModTime().UnixNano()
+	metaPath := path + ".meta"
+	if metaInfo, err := os.Stat(metaPath); err == nil {
+		size += metaInfo.Size()
+		if metaMtime := metaInfo.ModTime().UnixNano(); metaMtime > mtime {
+			mtime = metaMtime
+		}
+	}
+	return fakeSnapshotInfo{fSize: size, fMtime: mtime}
 }
 
 // shouldSkipCopilot is like shouldSkipByPath but uses the
@@ -7412,7 +7568,8 @@ func shouldReplaceFullParseMessages(
 		// earlier assistant tool call. An incremental append would
 		// only add the new ordinals and leave the existing tool call's
 		// result_content empty, so force a full replace.
-		pw.sess.Agent == parser.AgentVibe
+		pw.sess.Agent == parser.AgentVibe ||
+		pw.sess.Agent == parser.AgentReasonix
 }
 
 // writeIncremental appends new messages and partially updates
@@ -8355,6 +8512,13 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 		}
 		return vibeEffectiveInfo(path, info).ModTime().UnixNano()
 	}
+	if def.Type == parser.AgentReasonix {
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0
+		}
+		return reasonixEffectiveInfo(path, info).ModTime().UnixNano()
+	}
 
 	// FindSourceFile may return a virtual path (e.g. Visual Studio
 	// Copilot's <traceFile>#<conversationID>); resolve it to the
@@ -8590,6 +8754,16 @@ func (e *Engine) SyncSingleSessionContext(
 			if workspace, _, ok := strings.Cut(bareID, ":"); ok &&
 				workspace != "" {
 				file.Project = workspace
+			}
+		}
+	case parser.AgentReasonix:
+		if classified, ok := e.classifyReasonixPath(path); ok {
+			file.Project = classified.Project
+		} else {
+			if sess, _ := e.db.GetSession(ctx, sessionID); sess != nil &&
+				sess.Project != "" &&
+				!parser.NeedsProjectReparse(sess.Project) {
+				file.Project = sess.Project
 			}
 		}
 	case parser.AgentQwen:

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5,6 +5,7 @@ package sync
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -2579,6 +2580,475 @@ func TestEngine_ClassifyPathsQClawArchivedSession(t *testing.T) {
 	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
 	assert.Equal(t, archived, files[0].Path)
 	assert.Equal(t, parser.AgentQClaw, files[0].Agent)
+}
+
+func TestEngine_ClassifyOnePathReasonixProjectBareMeta(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(
+		reasonixDir, "projects", "proj", "sessions", "session-123.jsonl",
+	)
+	metaPath := sessionPath + ".meta"
+	dbtest.WriteTestFile(t, sessionPath, []byte(`{"role":"user","content":"hi"}`))
+	dbtest.WriteTestFile(t, metaPath, []byte(`{"model":"claude"}`))
+
+	got, ok := engine.classifyOnePath(metaPath, nil)
+	require.True(t, ok, "expected Reasonix sidecar to classify")
+	assert.Equal(t, sessionPath, got.Path)
+	assert.Equal(t, "proj", got.Project)
+	assert.Equal(t, parser.AgentReasonix, got.Agent)
+}
+
+func TestEngine_ClassifyOnePathReasonixDeletedMeta(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(
+		reasonixDir, "projects", "proj", "sessions", "session-123.jsonl",
+	)
+	metaPath := sessionPath + ".meta"
+	dbtest.WriteTestFile(t, sessionPath, []byte(`{"role":"user","content":"hi"}`))
+
+	got, ok := engine.classifyOnePath(metaPath, nil)
+	require.True(t, ok, "expected deleted Reasonix sidecar to classify")
+	assert.Equal(t, sessionPath, got.Path)
+	assert.Equal(t, "proj", got.Project)
+	assert.Equal(t, parser.AgentReasonix, got.Agent)
+}
+
+func TestEngine_ClassifyOnePathReasonixDeletedTranscriptIgnored(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(
+		reasonixDir, "projects", "proj", "sessions", "session-123.jsonl",
+	)
+
+	_, ok := engine.classifyOnePath(sessionPath, nil)
+	assert.False(t, ok, "expected deleted Reasonix transcript to be ignored")
+}
+
+func TestEngine_SyncPathsReasonixMetadataOnlySessionFieldUpdate(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(reasonixDir, "sessions", "session-123.jsonl")
+	metaPath := sessionPath + ".meta"
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		"{\"role\":\"user\",\"content\":\"hi\"}\n{\"role\":\"assistant\",\"content\":\"hello\"}\n",
+	), 0o644))
+
+	initialRoot := filepath.Join("workspace", "my-app")
+	initialMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Initial title",
+		"workspace_root": initialRoot,
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, initialMeta, 0o644))
+
+	engine.SyncPaths([]string{sessionPath})
+
+	got, err := db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.DisplayName)
+	require.NotNil(t, got.SessionName)
+	assert.Equal(t, "Initial title", *got.DisplayName)
+	assert.Equal(t, "Initial title", *got.SessionName)
+	assert.Equal(t, initialRoot, got.Cwd)
+	assert.Equal(t, "my_app", got.Project)
+
+	updatedRoot := filepath.Join("workspace", "renamed-app")
+	updatedMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Updated title",
+		"workspace_root": updatedRoot,
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, updatedMeta, 0o644))
+	future := time.Date(2026, time.June, 19, 2, 55, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	engine.SyncPaths([]string{metaPath})
+
+	got, err = db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.DisplayName)
+	require.NotNil(t, got.SessionName)
+	assert.Equal(t, "Updated title", *got.DisplayName)
+	assert.Equal(t, "Updated title", *got.SessionName)
+	assert.Equal(t, updatedRoot, got.Cwd)
+	assert.Equal(t, "renamed_app", got.Project)
+}
+
+func TestEngine_SyncPathsReasonixDeletedMetadataClearsSessionFields(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(reasonixDir, "sessions", "session-123.jsonl")
+	metaPath := sessionPath + ".meta"
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		"{\"role\":\"user\",\"content\":\"hi\"}\n"+
+			"{\"role\":\"assistant\",\"content\":\"hello\"}\n",
+	), 0o644))
+
+	initialRoot := filepath.Join("workspace", "my-app")
+	initialMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Initial title",
+		"workspace_root": initialRoot,
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, initialMeta, 0o644))
+
+	engine.SyncPaths([]string{sessionPath})
+
+	require.NoError(t, os.Remove(metaPath))
+	engine.SyncPaths([]string{metaPath})
+
+	got, err := db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Nil(t, got.DisplayName)
+	assert.Nil(t, got.SessionName)
+	assert.Equal(t, "", got.Cwd)
+	assert.Equal(t, "", got.Project)
+}
+
+func TestEngine_SyncSingleSessionReasonixDeletedMetadataClearsProject(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(reasonixDir, "sessions", "session-123.jsonl")
+	metaPath := sessionPath + ".meta"
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		"{\"role\":\"user\",\"content\":\"hi\"}\n"+
+			"{\"role\":\"assistant\",\"content\":\"hello\"}\n",
+	), 0o644))
+
+	initialRoot := filepath.Join("workspace", "my-app")
+	initialMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Initial title",
+		"workspace_root": initialRoot,
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, initialMeta, 0o644))
+
+	engine.SyncPaths([]string{sessionPath})
+
+	got, err := db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "my_app", got.Project)
+
+	require.NoError(t, os.Remove(metaPath))
+	require.NoError(t, db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"UPDATE sessions SET file_mtime = NULL WHERE id = ?",
+			"reasonix:session-123",
+		)
+		return err
+	}))
+
+	require.NoError(t, engine.SyncSingleSession("reasonix:session-123"))
+
+	got, err = db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "", got.Project)
+}
+
+func TestEngine_SyncPathsReasonixMalformedMetadataPreservesSessionFields(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(reasonixDir, "sessions", "session-123.jsonl")
+	metaPath := sessionPath + ".meta"
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		"{\"role\":\"user\",\"content\":\"hi\"}\n"+
+			"{\"role\":\"assistant\",\"content\":\"hello\"}\n",
+	), 0o644))
+
+	initialRoot := filepath.Join("workspace", "my-app")
+	initialMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Initial title",
+		"workspace_root": initialRoot,
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, initialMeta, 0o644))
+
+	engine.SyncPaths([]string{sessionPath})
+
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"topic_title":`), 0o644))
+	future := time.Date(2026, time.June, 19, 4, 15, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	engine.SyncPaths([]string{metaPath})
+
+	got, err := db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.DisplayName)
+	require.NotNil(t, got.SessionName)
+	assert.Equal(t, "Initial title", *got.DisplayName)
+	assert.Equal(t, "Initial title", *got.SessionName)
+	assert.Equal(t, initialRoot, got.Cwd)
+	assert.Equal(t, "my_app", got.Project)
+}
+
+func TestEngine_SyncPathsReasonixMalformedMetadataRecoveryUpdatesSession(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(reasonixDir, "sessions", "session-123.jsonl")
+	metaPath := sessionPath + ".meta"
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		"{\"role\":\"user\",\"content\":\"hi\"}\n"+
+			"{\"role\":\"assistant\",\"content\":\"hello\"}\n",
+	), 0o644))
+
+	initialRoot := filepath.Join("workspace", "my-app")
+	initialMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Initial title",
+		"workspace_root": initialRoot,
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, initialMeta, 0o644))
+
+	engine.SyncPaths([]string{sessionPath})
+
+	transcriptInfo, err := os.Stat(sessionPath)
+	require.NoError(t, err)
+	badMtime := transcriptInfo.ModTime().Add(time.Minute)
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{"topic_title":`), 0o644))
+	require.NoError(t, os.Chtimes(metaPath, badMtime, badMtime))
+	engine.SyncPaths([]string{metaPath})
+
+	updatedRoot := filepath.Join("workspace", "renamed-app")
+	updatedMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Recovered title",
+		"workspace_root": updatedRoot,
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, updatedMeta, 0o644))
+	recoveredMtime := badMtime.Add(time.Minute)
+	require.NoError(t, os.Chtimes(metaPath, recoveredMtime, recoveredMtime))
+
+	engine.SyncPaths([]string{metaPath})
+
+	got, err := db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.DisplayName)
+	require.NotNil(t, got.SessionName)
+	assert.Equal(t, "Recovered title", *got.DisplayName)
+	assert.Equal(t, "Recovered title", *got.SessionName)
+	assert.Equal(t, updatedRoot, got.Cwd)
+	assert.Equal(t, "renamed_app", got.Project)
+}
+
+func TestEngine_SyncPathsReasonixProjectLayoutMetadataProjectUpdate(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(
+		reasonixDir, "projects", "layout-name", "sessions", "session-123", "session-123.jsonl",
+	)
+	metaPath := sessionPath + ".meta"
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		"{\"role\":\"user\",\"content\":\"hi\"}\n{\"role\":\"assistant\",\"content\":\"hello\"}\n",
+	), 0o644))
+
+	initialMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Initial title",
+		"workspace_root": filepath.Join("workspace", "my-app"),
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, initialMeta, 0o644))
+
+	engine.SyncPaths([]string{sessionPath})
+
+	got, err := db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "my_app", got.Project)
+
+	updatedMeta, err := json.Marshal(map[string]string{
+		"created_at":     "2026-06-12T10:42:35.2672024Z",
+		"updated_at":     "2026-06-12T10:58:03.6456434Z",
+		"topic_title":    "Updated title",
+		"workspace_root": filepath.Join("workspace", "renamed-app"),
+		"model":          "claude-opus-4",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(metaPath, updatedMeta, 0o644))
+	future := time.Date(2026, time.June, 19, 3, 30, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(metaPath, future, future))
+
+	engine.SyncPaths([]string{metaPath})
+
+	got, err = db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "renamed_app", got.Project)
+}
+
+func TestEngine_SyncSingleSessionReasonixProjectLayoutPreservesProject(t *testing.T) {
+	db := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(
+		reasonixDir, "projects", "layout-name", "sessions",
+		"session-123", "session-123.jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		"{\"role\":\"user\",\"content\":\"hi\"}\n"+
+			"{\"role\":\"assistant\",\"content\":\"hello\"}\n",
+	), 0o644))
+
+	engine.SyncPaths([]string{sessionPath})
+
+	got, err := db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "layout-name", got.Project)
+
+	require.NoError(t, db.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"UPDATE sessions SET file_mtime = NULL WHERE id = ?",
+			"reasonix:session-123",
+		)
+		return err
+	}))
+
+	require.NoError(t, engine.SyncSingleSession("reasonix:session-123"))
+
+	got, err = db.GetSessionFull(context.Background(), "reasonix:session-123")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "layout-name", got.Project)
+}
+
+func TestEngine_SyncPathsReasonixPersistsToolResultContent(t *testing.T) {
+	database := openTestDB(t)
+	reasonixDir := t.TempDir()
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentReasonix: {reasonixDir},
+		},
+		Machine: "local",
+	})
+
+	sessionPath := filepath.Join(reasonixDir, "sessions", "tool-result.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		"{\"role\":\"user\",\"content\":\"Read the file\"}\n"+
+			"{\"role\":\"assistant\",\"content\":\"I'll read it\","+
+			"\"tool_calls\":[{\"id\":\"call_1\",\"name\":\"read_file\","+
+			"\"arguments\":\"{\\\"path\\\":\\\"config.json\\\"}\"}]}\n"+
+			"{\"role\":\"tool\",\"content\":\"file contents here\","+
+			"\"tool_call_id\":\"call_1\"}\n",
+	), 0o644))
+
+	engine.SyncPaths([]string{sessionPath})
+
+	msgs, err := database.GetAllMessages(context.Background(), "reasonix:tool-result")
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "file contents here", msgs[1].ToolCalls[0].ResultContent)
+	assert.Equal(t, len("file contents here"), msgs[1].ToolCalls[0].ResultContentLength)
 }
 
 func TestEngine_SyncSingleSessionEmitsOnSuccess(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add first-class Reasonix session discovery and parsing so Reasonix activity syncs into agentsview.
- Wire Reasonix through the sync engine's file-based parser switch, the watcher's path classifier, and the registry completeness tests so discovery reaches import on both initial sync and live file changes.

## Scope
- New parser coverage is limited to the Reasonix JSONL transcript + `.jsonl.meta` sidecar described in #720, across all four documented layouts: project sessions, global sessions, global subagents, and archive sessions.
- Project association is preserved from discovery through to the parsed session, and metadata timestamps from `.jsonl.meta` sidecars are kept when present rather than overwritten during parsing.
- No pricing, PostgreSQL-only behavior, or desktop-specific UI changes are part of this slice.

## Review Notes
- `internal/parser/reasonix.go` covers the path layout, transcript-field mapping, and metadata sidecar fallback.
- `internal/sync/engine.go` has two additions: `processReasonix` for the file processor switch, and a Reasonix branch in `classifyOnePath` for watcher-triggered syncs.
- `internal/parser/types_test.go` and `internal/parser/reasonix_test.go` cover registry guardrails, timestamp preservation, and space-containing session IDs.
- Validation ran locally with `CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled" ./internal/parser/... ./internal/sync/... -run "Reasonix|Registry" -count=1`; broader CI covers the rest of the Go matrix.

Fixes #720
