### PR TITLE
feat(usage): surface Copilot AI credits

### DIFF
--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -257,5 +257,8 @@ func renderSessionUsageHuman(w io.Writer, out *sessionUsageOutput) error {
 	} else {
 		fmt.Fprintf(w, "%s n/a\n", label("Cost"))
 	}
+	if out.AICredits > 0 {
+		fmt.Fprintf(w, "%s %.0f\n", label("AI Credits"), out.AICredits)
+	}
 	return nil
 }

--- a/cmd/agentsview/session_usage_test.go
+++ b/cmd/agentsview/session_usage_test.go
@@ -63,7 +63,7 @@ func TestRenderSessionUsageHuman_CopilotWithAICredits(t *testing.T) {
 			SessionID:         "copilot:s1",
 			Agent:             "copilot",
 			Project:           "proj",
-			TotalOutputTokens: 1000,
+			TotalOutputTokens: 2000,
 			PeakContextTokens: 5000,
 			HasTokenData:      true,
 			CostUSD:           10.00,

--- a/cmd/agentsview/session_usage_test.go
+++ b/cmd/agentsview/session_usage_test.go
@@ -57,6 +57,69 @@ func TestRenderSessionUsageHuman_NoCost(t *testing.T) {
 		"output should note unpriced model")
 }
 
+func TestRenderSessionUsageHuman_CopilotWithAICredits(t *testing.T) {
+	out := &sessionUsageOutput{
+		SessionUsage: db.SessionUsage{
+			SessionID:         "copilot:s1",
+			Agent:             "copilot",
+			Project:           "proj",
+			TotalOutputTokens: 1000,
+			PeakContextTokens: 5000,
+			HasTokenData:      true,
+			CostUSD:           10.00,
+			HasCost:           true,
+			AICredits:         1000.0,
+			Models:            []string{"gpt-4"},
+		},
+	}
+	var b strings.Builder
+	require.NoError(t, renderSessionUsageHuman(&b, out))
+	s := b.String()
+	assert.Contains(t, s, "~$10.00", "output missing cost")
+	assert.Contains(t, s, "1000", "output missing AI Credits")
+	assert.Contains(t, s, "AI Credits", "output missing AI Credits label")
+}
+
+func TestRenderSessionUsageHuman_NonCopilotNoAICredits(t *testing.T) {
+	out := &sessionUsageOutput{
+		SessionUsage: db.SessionUsage{
+			SessionID:         "claude:s1",
+			Agent:             "claude-code",
+			Project:           "proj",
+			TotalOutputTokens: 1000,
+			PeakContextTokens: 5000,
+			HasTokenData:      true,
+			CostUSD:           0.42,
+			HasCost:           true,
+			Models:            []string{"claude-opus"},
+		},
+	}
+	var b strings.Builder
+	require.NoError(t, renderSessionUsageHuman(&b, out))
+	s := b.String()
+	assert.Contains(t, s, "~$0.42", "output missing cost")
+	assert.NotContains(t, s, "AI Credits",
+		"non-Copilot sessions should not show AI Credits")
+}
+
+func TestRenderSessionUsageHuman_CopilotNoCost(t *testing.T) {
+	out := &sessionUsageOutput{
+		SessionUsage: db.SessionUsage{
+			SessionID:      "copilot:s2",
+			Agent:          "copilot",
+			HasTokenData:   true,
+			HasCost:        false,
+			AICredits:      0,
+			UnpricedModels: []string{"gpt-4"},
+		},
+	}
+	var b strings.Builder
+	require.NoError(t, renderSessionUsageHuman(&b, out))
+	s := b.String()
+	assert.NotContains(t, s, "AI Credits",
+		"unpriced Copilot sessions should not show AI Credits")
+}
+
 func TestSessionUsageJSONSchemaIncludesCostContract(t *testing.T) {
 	out := &sessionUsageOutput{
 		SessionUsage: db.SessionUsage{

--- a/frontend/src/lib/api/generated/models/DbUsageTotals.ts
+++ b/frontend/src/lib/api/generated/models/DbUsageTotals.ts
@@ -6,6 +6,7 @@ export type DbUsageTotals = {
   cacheCreationTokens: number;
   cacheReadTokens: number;
   cacheSavings: number;
+  copilotAICredits?: number;
   inputTokens: number;
   outputTokens: number;
   totalCost: number;

--- a/frontend/src/lib/api/types/usage.ts
+++ b/frontend/src/lib/api/types/usage.ts
@@ -7,6 +7,7 @@ export interface UsageTotals {
   cacheCreationTokens: number;
   cacheReadTokens: number;
   totalCost: number;
+  copilotAICredits?: number;
 }
 
 export interface ModelBreakdown {

--- a/frontend/src/lib/components/usage/UsageSummaryCards.svelte
+++ b/frontend/src/lib/components/usage/UsageSummaryCards.svelte
@@ -74,6 +74,10 @@
     return `${sign}${(c.deltaPct * 100).toFixed(0)}% vs prior`;
   });
 
+  function fmtCredits(v: number): string {
+    return String(v.toFixed(0));
+  }
+
   interface Card {
     label: string;
     value: () => string;
@@ -88,6 +92,14 @@
       sub: () => vsPrior ?? "",
       featured: true,
     },
+    ...(usage.summary?.totals.copilotAICredits
+      ? [
+          {
+            label: "Copilot AI Credits",
+            value: () => fmtCredits(usage.summary?.totals.copilotAICredits ?? 0),
+          },
+        ]
+      : []),
     {
       label: "Input Tokens",
       value: () => fmtTokens(inputTokens),

--- a/frontend/src/lib/components/usage/UsageSummaryCards.svelte
+++ b/frontend/src/lib/components/usage/UsageSummaryCards.svelte
@@ -85,65 +85,68 @@
     featured?: boolean;
   }
 
-  const cards: Card[] = [
-    {
-      label: "Total Cost",
-      value: () => fmtCost(usage.summary?.totals.totalCost ?? 0),
-      sub: () => vsPrior ?? "",
-      featured: true,
-    },
-    ...(usage.summary?.totals.copilotAICredits
-      ? [
-          {
-            label: "Copilot AI Credits",
-            value: () => fmtCredits(usage.summary?.totals.copilotAICredits ?? 0),
-          },
-        ]
-      : []),
-    {
-      label: "Input Tokens",
-      value: () => fmtTokens(inputTokens),
-      sub: () =>
-        cachedTokens > 0 ? `+${fmtTokens(cachedTokens)} cached` : "",
-    },
-    {
-      label: "Output Tokens",
-      value: () => fmtTokens(outputTokens),
-    },
-    {
-      label: "Daily Burn",
-      value: () => fmtCost(dailyBurn),
-      sub: () => "avg/day",
-    },
-    {
-      label: "Peak Day",
-      value: () => fmtCost(peak.cost),
-      sub: () => peak.date,
-    },
-    {
-      label: "Cache Hit",
-      value: () =>
-        fmtPct(usage.summary?.cacheStats.hitRate ?? 0),
-    },
-    {
-      label: "Projects",
-      value: () =>
-        String(
-          Object.keys(
-            usage.summary?.sessionCounts.byProject ?? {},
-          ).length,
-        ),
-    },
-    {
-      label: "Models",
-      value: () =>
-        String(usage.summary?.modelTotals.length ?? 0),
-    },
-    {
-      label: "Active Days",
-      value: () => String(activeDays),
-    },
-  ];
+  const cards = $derived.by(() => {
+    const baseCards: Card[] = [
+      {
+        label: "Total Cost",
+        value: () => fmtCost(usage.summary?.totals.totalCost ?? 0),
+        sub: () => vsPrior ?? "",
+        featured: true,
+      },
+      ...(usage.summary?.totals.copilotAICredits
+        ? [
+            {
+              label: "Copilot AI Credits",
+              value: () => fmtCredits(usage.summary?.totals.copilotAICredits ?? 0),
+            },
+          ]
+        : []),
+      {
+        label: "Input Tokens",
+        value: () => fmtTokens(inputTokens),
+        sub: () =>
+          cachedTokens > 0 ? `+${fmtTokens(cachedTokens)} cached` : "",
+      },
+      {
+        label: "Output Tokens",
+        value: () => fmtTokens(outputTokens),
+      },
+      {
+        label: "Daily Burn",
+        value: () => fmtCost(dailyBurn),
+        sub: () => "avg/day",
+      },
+      {
+        label: "Peak Day",
+        value: () => fmtCost(peak.cost),
+        sub: () => peak.date,
+      },
+      {
+        label: "Cache Hit",
+        value: () =>
+          fmtPct(usage.summary?.cacheStats.hitRate ?? 0),
+      },
+      {
+        label: "Projects",
+        value: () =>
+          String(
+            Object.keys(
+              usage.summary?.sessionCounts.byProject ?? {},
+            ).length,
+          ),
+      },
+      {
+        label: "Models",
+        value: () =>
+          String(usage.summary?.modelTotals.length ?? 0),
+      },
+      {
+        label: "Active Days",
+        value: () => String(activeDays),
+      },
+    ];
+    return baseCards;
+  });
 </script>
 
 <div class="summary-cards">

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -872,6 +872,7 @@ type UsageTotals struct {
 	CacheCreationTokens int     `json:"cacheCreationTokens"`
 	CacheReadTokens     int     `json:"cacheReadTokens"`
 	TotalCost           float64 `json:"totalCost"`
+	CopilotAICredits    float64 `json:"copilotAICredits,omitempty"`
 	// CacheSavings is the net dollar delta vs an uncached run:
 	// cache reads save (input_rate - cache_read_rate) per token,
 	// cache creations cost (input_rate - cache_creation_rate)
@@ -1202,6 +1203,16 @@ func (db *DB) GetDailyUsage(
 			daily = []DailyUsageEntry{}
 		}
 		totals.CacheSavings = totalSavings
+
+		var copilotCost float64
+		for key, b := range accum {
+			if key.agent == "copilot" {
+				copilotCost += b.cost
+			}
+		}
+		if copilotCost > 0 {
+			totals.CopilotAICredits = copilotCost / 0.01
+		}
 		sessionCounts := NewUsageSessionCounts(seenSessions)
 		return DailyUsageResult{
 			Daily:         daily,
@@ -1364,6 +1375,19 @@ func (db *DB) GetDailyUsage(
 	}
 
 	totals.CacheSavings = totalSavings
+
+	var copilotCost float64
+	for _, d := range daily {
+		for _, ab := range d.AgentBreakdowns {
+			if ab.Agent == "copilot" {
+				copilotCost += ab.Cost
+			}
+		}
+	}
+	if copilotCost > 0 {
+		totals.CopilotAICredits = copilotCost / 0.01
+	}
+
 	sessionCounts := NewUsageSessionCounts(seenSessions)
 	return DailyUsageResult{
 		Daily:         daily,
@@ -1548,6 +1572,7 @@ type SessionUsage struct {
 	HasTokenData      bool     `json:"has_token_data"`
 	CostUSD           float64  `json:"cost_usd"`
 	HasCost           bool     `json:"has_cost"`
+	AICredits         float64  `json:"ai_credits,omitempty"`
 	Models            []string `json:"models"`
 	UnpricedModels    []string `json:"unpriced_models,omitempty"`
 }
@@ -1681,6 +1706,9 @@ func (db *DB) GetSessionUsage(
 	}
 	if out.HasCost {
 		out.CostUSD = cost
+	}
+	if sess.Agent == "copilot" && out.HasCost {
+		out.AICredits = cost / 0.01
 	}
 	if len(unpricedSet) > 0 {
 		out.UnpricedModels = sortedSetKeys(unpricedSet)

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -13,6 +13,10 @@ import (
 	pricingpkg "go.kenn.io/agentsview/internal/pricing"
 )
 
+func IsCopilotAgent(agent string) bool {
+	return agent == "copilot" || agent == "vscode-copilot" || agent == "visualstudio-copilot"
+}
+
 func lookupModelRates(
 	pricing map[string]modelRates, model string,
 ) (modelRates, bool) {
@@ -1206,7 +1210,7 @@ func (db *DB) GetDailyUsage(
 
 		var copilotCost float64
 		for key, b := range accum {
-			if key.agent == "copilot" {
+			if IsCopilotAgent(key.agent) {
 				copilotCost += b.cost
 			}
 		}
@@ -1379,7 +1383,7 @@ func (db *DB) GetDailyUsage(
 	var copilotCost float64
 	for _, d := range daily {
 		for _, ab := range d.AgentBreakdowns {
-			if ab.Agent == "copilot" {
+			if IsCopilotAgent(ab.Agent) {
 				copilotCost += ab.Cost
 			}
 		}
@@ -1707,7 +1711,7 @@ func (db *DB) GetSessionUsage(
 	if out.HasCost {
 		out.CostUSD = cost
 	}
-	if sess.Agent == "copilot" && out.HasCost {
+	if IsCopilotAgent(sess.Agent) && out.HasCost {
 		out.AICredits = cost / 0.01
 	}
 	if len(unpricedSet) > 0 {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -2320,3 +2320,90 @@ func TestGetSessionUsage_NotFound(t *testing.T) {
 	requireNoError(t, err, "GetSessionUsage")
 	assert.Nil(t, u, "usage")
 }
+
+// TestGetDailyUsage_CopilotAICreditsComputed verifies AI credits are computed
+// from priced Copilot usage: costUSD / 0.01.
+func TestGetDailyUsage_CopilotAICreditsComputed(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:         "gpt-4",
+		InputPerMTok:         15.0,
+		OutputPerMTok:        60.0,
+		CacheCreationPerMTok: 15.0,
+		CacheReadPerMTok:     6.0,
+	}}))
+
+	insertSession(t, d, "copilot:aicredits", "proj", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2024-06-15T10:00:00Z")
+		s.EndedAt = new("2024-06-15T11:00:00Z")
+	})
+
+	insertMessages(t, d, Message{
+		SessionID: "copilot:aicredits",
+		Ordinal:   0,
+		Role:      "assistant",
+		Timestamp: "2024-06-15T10:30:00Z",
+		Model:     "gpt-4",
+		TokenUsage: json.RawMessage(`{
+			"input_tokens": 1000,
+			"output_tokens": 500
+		}`),
+	})
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	})
+	requireNoError(t, err, "GetDailyUsage")
+
+	wantCost := (1000*15.0 + 500*60.0) / 1_000_000
+	wantCredits := wantCost / 0.01
+	assert.InDelta(t, wantCost, result.Totals.TotalCost, 1e-9, "TotalCost")
+	assert.InDelta(t, wantCredits, result.Totals.CopilotAICredits, 1e-6, "CopilotAICredits")
+}
+
+// TestGetDailyUsage_NoAICreditsNonCopilot verifies non-Copilot agents do
+// not emit CopilotAICredits even when priced.
+func TestGetDailyUsage_NoAICreditsNonCopilot(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:         "claude-opus-4-6",
+		InputPerMTok:         3.0,
+		OutputPerMTok:        15.0,
+		CacheCreationPerMTok: 3.75,
+		CacheReadPerMTok:     0.30,
+	}}))
+
+	insertSession(t, d, "claude:nocredits", "proj", func(s *Session) {
+		s.Agent = "claude-code"
+		s.StartedAt = new("2024-06-15T10:00:00Z")
+		s.EndedAt = new("2024-06-15T11:00:00Z")
+	})
+
+	insertMessages(t, d, Message{
+		SessionID: "claude:nocredits",
+		Ordinal:   0,
+		Role:      "assistant",
+		Timestamp: "2024-06-15T10:30:00Z",
+		Model:     "claude-opus-4-6",
+		TokenUsage: json.RawMessage(`{
+			"input_tokens": 1000,
+			"output_tokens": 500
+		}`),
+	})
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From: "2024-06-01",
+		To:   "2024-06-30",
+	})
+	requireNoError(t, err, "GetDailyUsage")
+
+	wantCost := (1000*3.0 + 500*15.0) / 1_000_000
+	assert.InDelta(t, wantCost, result.Totals.TotalCost, 1e-9, "TotalCost")
+	assert.Equal(t, 0.0, result.Totals.CopilotAICredits, "CopilotAICredits should be 0")
+}

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -2331,11 +2331,8 @@ func (s *Store) GetDailyUsage(
 	result.Totals.TotalCost = roundCost(result.Totals.TotalCost)
 
 	var copilotCost float64
-	for _, day := range days {
-		if day == nil {
-			continue
-		}
-		if b, ok := day.agents["copilot"]; ok {
+	for key, b := range accum {
+		if key.agent == "copilot" {
 			copilotCost += b.cost
 		}
 	}

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -2329,6 +2329,20 @@ func (s *Store) GetDailyUsage(
 	}
 	result.Totals.CacheSavings = roundCost(totalSavings)
 	result.Totals.TotalCost = roundCost(result.Totals.TotalCost)
+
+	var copilotCost float64
+	for _, day := range days {
+		if day == nil {
+			continue
+		}
+		if b, ok := day.agents["copilot"]; ok {
+			copilotCost += b.cost
+		}
+	}
+	if copilotCost > 0 {
+		result.Totals.CopilotAICredits = copilotCost / 0.01
+	}
+
 	if result.Daily == nil {
 		result.Daily = []db.DailyUsageEntry{}
 	}
@@ -2556,6 +2570,9 @@ func (s *Store) GetSessionUsage(
 	if len(unpriced) == 0 && hasRows {
 		out.HasCost = true
 		out.CostUSD = roundCost(totalCost)
+	}
+	if sess.Agent == "copilot" && out.HasCost && out.CostUSD > 0 {
+		out.AICredits = out.CostUSD / 0.01
 	}
 	return out, nil
 }

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -2332,7 +2332,7 @@ func (s *Store) GetDailyUsage(
 
 	var copilotCost float64
 	for key, b := range accum {
-		if key.agent == "copilot" {
+		if db.IsCopilotAgent(key.agent) {
 			copilotCost += b.cost
 		}
 	}
@@ -2568,7 +2568,7 @@ func (s *Store) GetSessionUsage(
 		out.HasCost = true
 		out.CostUSD = roundCost(totalCost)
 	}
-	if sess.Agent == "copilot" && out.HasCost && out.CostUSD > 0 {
+	if db.IsCopilotAgent(sess.Agent) && out.HasCost && out.CostUSD > 0 {
 		out.AICredits = out.CostUSD / 0.01
 	}
 	return out, nil

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -889,6 +889,9 @@ func (s *Store) GetSessionUsage(
 	if out.HasCost {
 		out.CostUSD = cost
 	}
+	if sess.Agent == "copilot" && out.HasCost {
+		out.AICredits = cost / 0.01
+	}
 	if len(unpricedSet) > 0 {
 		out.UnpricedModels = sortedStringSetKeys(unpricedSet)
 	}
@@ -1114,6 +1117,17 @@ func (s *Store) GetDailyUsage(
 			daily = []db.DailyUsageEntry{}
 		}
 		totals.CacheSavings = totalSavings
+
+		var copilotCost float64
+		for key, b := range accum {
+			if key.agent == "copilot" {
+				copilotCost += b.cost
+			}
+		}
+		if copilotCost > 0 {
+			totals.CopilotAICredits = copilotCost / 0.01
+		}
+
 		sessionCounts := db.NewUsageSessionCounts(seenSessions)
 		return db.DailyUsageResult{
 			Daily:         daily,
@@ -1261,6 +1275,19 @@ func (s *Store) GetDailyUsage(
 		daily = []db.DailyUsageEntry{}
 	}
 	totals.CacheSavings = totalSavings
+
+	var copilotCost float64
+	for _, d := range daily {
+		for _, ab := range d.AgentBreakdowns {
+			if ab.Agent == "copilot" {
+				copilotCost += ab.Cost
+			}
+		}
+	}
+	if copilotCost > 0 {
+		totals.CopilotAICredits = copilotCost / 0.01
+	}
+
 	sessionCounts := db.NewUsageSessionCounts(seenSessions)
 	return db.DailyUsageResult{
 		Daily:         daily,

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -889,7 +889,7 @@ func (s *Store) GetSessionUsage(
 	if out.HasCost {
 		out.CostUSD = cost
 	}
-	if sess.Agent == "copilot" && out.HasCost {
+	if db.IsCopilotAgent(sess.Agent) && out.HasCost {
 		out.AICredits = cost / 0.01
 	}
 	if len(unpricedSet) > 0 {
@@ -1120,7 +1120,7 @@ func (s *Store) GetDailyUsage(
 
 		var copilotCost float64
 		for key, b := range accum {
-			if key.agent == "copilot" {
+			if db.IsCopilotAgent(key.agent) {
 				copilotCost += b.cost
 			}
 		}
@@ -1279,7 +1279,7 @@ func (s *Store) GetDailyUsage(
 	var copilotCost float64
 	for _, d := range daily {
 		for _, ab := range d.AgentBreakdowns {
-			if ab.Agent == "copilot" {
+			if db.IsCopilotAgent(ab.Agent) {
 				copilotCost += ab.Cost
 			}
 		}

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -460,9 +460,9 @@ func TestStoreGetSessionUsage_CopilotAICreditsComputed(t *testing.T) {
 
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO usage_events (
-			session_id, model, input_tokens, output_tokens, cost_usd, ts
+			session_id, source, model, input_tokens, output_tokens, cost_usd, occurred_at
 		) VALUES (
-			'copilot:s1', 'gpt-4', 1000, 500, 0.10, '2026-03-12T10:00:00Z'::timestamptz
+			'copilot:s1', 'api', 'gpt-4', 1000, 500, 0.10, '2026-03-12T10:00:00Z'::timestamptz
 		)`)
 	require.NoError(t, err, "insert usage event")
 
@@ -490,9 +490,9 @@ func TestStoreGetSessionUsage_CopilotNoAICreditsUnpriced(t *testing.T) {
 
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO usage_events (
-			session_id, model, input_tokens, output_tokens, ts
+			session_id, source, model, input_tokens, output_tokens, occurred_at
 		) VALUES (
-			'copilot:s2', 'local-model', 1000, 500, '2026-03-12T10:00:00Z'::timestamptz
+			'copilot:s2', 'api', 'local-model', 1000, 500, '2026-03-12T10:00:00Z'::timestamptz
 		)`)
 	require.NoError(t, err, "insert usage event")
 

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -443,3 +443,62 @@ func TestPushFallsBackToBuiltinPricingWhenLocalTableEmpty(t *testing.T) {
 	assert.Contains(t, joined, "claude-sonnet-4-20250514",
 		"fallback pricing not synced")
 }
+
+func TestStoreGetSessionUsage_CopilotAICreditsComputed(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_copilot_credits_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES (
+			'copilot:s1', 'test-machine', 'proj', 'copilot',
+			'2026-03-12T10:00:00Z'::timestamptz, 1, 1
+		)`)
+	require.NoError(t, err, "insert session")
+
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO usage_events (
+			session_id, model, input_tokens, output_tokens, cost_usd, ts
+		) VALUES (
+			'copilot:s1', 'gpt-4', 1000, 500, 0.10, '2026-03-12T10:00:00Z'::timestamptz
+		)`)
+	require.NoError(t, err, "insert usage event")
+
+	u, err := store.GetSessionUsage(ctx, "copilot:s1")
+	require.NoError(t, err, "GetSessionUsage")
+	require.NotNil(t, u, "usage is nil")
+	assert.True(t, u.HasCost, "HasCost")
+	assert.Equal(t, 0.10, u.CostUSD, "CostUSD")
+	assert.Equal(t, 10.0, u.AICredits, "AICredits")
+}
+
+func TestStoreGetSessionUsage_CopilotNoAICreditsUnpriced(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_copilot_unpriced_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES (
+			'copilot:s2', 'test-machine', 'proj', 'copilot',
+			'2026-03-12T10:00:00Z'::timestamptz, 1, 1
+		)`)
+	require.NoError(t, err, "insert session")
+
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO usage_events (
+			session_id, model, input_tokens, output_tokens, ts
+		) VALUES (
+			'copilot:s2', 'local-model', 1000, 500, '2026-03-12T10:00:00Z'::timestamptz
+		)`)
+	require.NoError(t, err, "insert usage event")
+
+	u, err := store.GetSessionUsage(ctx, "copilot:s2")
+	require.NoError(t, err, "GetSessionUsage")
+	require.NotNil(t, u, "usage is nil")
+	assert.False(t, u.HasCost, "HasCost should be false")
+	assert.Equal(t, 0.0, u.AICredits, "AICredits should be 0 when unpriced")
+}

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -284,6 +284,7 @@ type sessionUsageResponse struct {
 	HasTokenData      bool     `json:"has_token_data"`
 	CostUSD           float64  `json:"cost_usd"`
 	HasCost           bool     `json:"has_cost"`
+	AICredits         float64  `json:"ai_credits,omitempty"`
 	Models            []string `json:"models"`
 	UnpricedModels    []string `json:"unpriced_models"`
 	ServerRunning     bool     `json:"server_running"`
@@ -321,6 +322,7 @@ func newSessionUsageHumaResponse(usage *db.SessionUsage) sessionUsageResponse {
 		HasTokenData:      usage.HasTokenData,
 		CostUSD:           usage.CostUSD,
 		HasCost:           usage.HasCost,
+		AICredits:         usage.AICredits,
 		Models:            usage.Models,
 		UnpricedModels:    unpricedModels,
 		ServerRunning:     true,


### PR DESCRIPTION
## Summary
- Add GitHub Copilot AI-credit estimates on top of the existing priced usage path so Copilot sessions can be read in GitHub's own billing unit.
- Surface the new metric in `session usage` CLI output, the session usage API endpoint, and the usage dashboard without changing how non-Copilot agents are priced.

## Scope
- The implementation reuses the existing cost estimate and current GitHub Docs conversion rate (`1 AI credit = $0.01 USD`); it does not invent a second pricing engine.
- This slice does not attempt to expose AI credits for non-Copilot agents or for partially unpriced Copilot rows.
- Both SQLite and PostgreSQL usage readers are updated to keep backend parity.

## Review Notes
- The derivation lives in the DB / PG usage readers (`GetDailyUsage`, `GetSessionUsage`); the CLI, API route, and Svelte card are presentation layers.
- The API route in `huma_routes_sessions.go` threads `AICredits` through the bespoke `sessionUsageResponse` so the HTTP endpoint exposes it alongside the CLI.
- The Svelte dashboard card uses `$derived.by()` to recompute reactively when usage data loads.
- Validation ran locally with `CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled" ./cmd/agentsview ./internal/db ./internal/postgres -run "SessionUsage|Usage" -count=1`; broader CI covers the remaining suites.

Fixes #723
