### PR TITLE
Persist Codex and OpenCode cwd for Git worktree mapping

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -29,6 +29,10 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 48: the Codex and OpenCode parsers now persist cwd.
+// Existing Codex and OpenCode rows need re-parsing so worktree
+// project mappings can be applied to those sessions.
+//
 // Bumped to 47: the Visual Studio Copilot trace parser now
 // persists per-chat model and token usage from gen_ai.usage
 // attributes. Existing Visual Studio Copilot rows need re-parsing
@@ -224,7 +228,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 47
+const dataVersion = 48
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -588,9 +588,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionVisualStudioCopilotUsage(t *testing.T) {
-	assert.Equal(t, 47, CurrentDataVersion(),
-		"Visual Studio Copilot usage parsing requires a data version bump")
+func TestCurrentDataVersionCodexOpenCodeCwd(t *testing.T) {
+	assert.Equal(t, 48, CurrentDataVersion(),
+		"Codex and OpenCode cwd parsing requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1360,6 +1360,7 @@ func ParseCodexSession(
 		Project:           b.project,
 		Machine:           machine,
 		Agent:             AgentCodex,
+		Cwd:               b.cwd,
 		FirstMessage:      b.firstMessage,
 		SessionName:       LookupCodexThreadName(path, b.sessionID),
 		StartedAt:         b.startedAt,

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -47,6 +47,7 @@ func TestParseCodexSession_Basic(t *testing.T) {
 
 	require.NotNil(t, sess)
 	assert.Equal(t, "codex:abc-123", sess.ID)
+	assert.Equal(t, "/Users/alice/code/my-api", sess.Cwd)
 	assert.Equal(t, 2, len(msgs))
 	assertSessionMeta(t, sess, "codex:abc-123", "my_api", AgentCodex)
 }

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -600,6 +600,7 @@ func buildOpenCodeParsedSession(
 		Project:          project,
 		Machine:          machine,
 		Agent:            AgentOpenCode,
+		Cwd:              worktree,
 		ParentSessionID:  parentID,
 		FirstMessage:     firstMsg,
 		StartedAt:        startedAt,

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -176,6 +176,7 @@ func TestParseOpenCodeDB_StandardSession(t *testing.T) {
 	assertEq(t, "Agent", s.Session.Agent, AgentOpenCode)
 	assertEq(t, "Machine", s.Session.Machine, "testmachine")
 	assertEq(t, "Project", s.Session.Project, "myapp")
+	assertEq(t, "Cwd", s.Session.Cwd, "/home/user/code/myapp")
 	assertEq(t, "MessageCount", s.Session.MessageCount, 2)
 	assertEq(t, "FirstMessage", s.Session.FirstMessage, "Test Session")
 
@@ -286,6 +287,7 @@ func TestParseOpenCodeFile_StorageSession(t *testing.T) {
 	assertEq(t, "ID", sess.ID, "opencode:ses_storage")
 	assertEq(t, "Agent", sess.Agent, AgentOpenCode)
 	assertEq(t, "Project", sess.Project, "myapp")
+	assertEq(t, "Cwd", sess.Cwd, "/home/user/code/myapp")
 	assertEq(t, "Machine", sess.Machine, "testmachine")
 	assertEq(t, "MessageCount", sess.MessageCount, 2)
 	assertEq(t, "FirstMessage", sess.FirstMessage, "Storage Session")


### PR DESCRIPTION
## Rationale

Git worktree sessions can show up as separate projects like `worktree1`, `worktree2`, or `.bare` instead of the repository they belong to.

AgentsView already has project mappings for this case, but those mappings depend on a persisted session `cwd`. Codex and OpenCode parsed the working directory well enough to infer a project, but did not store it on the session, so AgentsView project mappings could not map Git worktree imports.

## What Changed

- Persist Codex `cwd` from session metadata.
- Persist OpenCode worktree/directory as session `cwd`.
- Bump the parser data version so existing Codex/OpenCode rows reparse.
- Add parser assertions for persisted `cwd`.

## Tested

- `go test ./internal/parser`
- `go test ./internal/parser ./internal/db`
- `go test ./internal/sync -run Worktree`
- Verified against a copied local archive that `worktree1`, `worktree2`, etc. were remapped to their configured projects.
