### PR TITLE
[codex] dedupe duplicate Claude sync sources

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2376,6 +2376,7 @@ func (e *Engine) syncAllLocked(
 	}
 
 	if !since.IsZero() {
+		all = e.dedupeClaudeDiscoveredFiles(all)
 		all = e.filterFilesByMtime(all, since)
 	}
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -434,7 +434,9 @@ func (e *Engine) classifyPaths(
 			files = append(files, df)
 		}
 	}
-	return dedupeDiscoveredFiles(files)
+	files = e.expandClaudeDuplicateCandidates(files)
+	files = dedupeDiscoveredFiles(files)
+	return e.dedupeClaudeDiscoveredFiles(files)
 }
 
 func dedupeDiscoveredFiles(
@@ -489,6 +491,44 @@ func preferDiscoveredFile(
 		}
 	}
 	return false
+}
+
+func (e *Engine) expandClaudeDuplicateCandidates(
+	files []parser.DiscoveredFile,
+) []parser.DiscoveredFile {
+	sessionIDs := make(map[string]struct{})
+	seen := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		seen[string(file.Agent)+"\x00"+file.Path] = struct{}{}
+		if file.Agent != parser.AgentClaude {
+			continue
+		}
+		sessionID := claudeSessionIDFromPath(file.Path)
+		if sessionID == "" {
+			continue
+		}
+		sessionIDs[sessionID] = struct{}{}
+	}
+	if len(sessionIDs) == 0 {
+		return files
+	}
+
+	out := files
+	for _, claudeDir := range e.agentDirs[parser.AgentClaude] {
+		for _, candidate := range parser.DiscoverClaudeProjects(claudeDir) {
+			sessionID := claudeSessionIDFromPath(candidate.Path)
+			if _, ok := sessionIDs[sessionID]; !ok {
+				continue
+			}
+			key := string(candidate.Agent) + "\x00" + candidate.Path
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, candidate)
+		}
+	}
+	return out
 }
 
 func codexLayoutForPath(path string) parser.CodexLayout {
@@ -2911,7 +2951,7 @@ func (e *Engine) dedupeClaudeDiscoveredFiles(
 		if file.Agent != parser.AgentClaude {
 			continue
 		}
-		sessionID := strings.TrimSuffix(filepath.Base(file.Path), ".jsonl")
+		sessionID := claudeSessionIDFromPath(file.Path)
 		if sessionID == "" {
 			continue
 		}
@@ -2935,7 +2975,7 @@ func (e *Engine) dedupeClaudeDiscoveredFiles(
 			out = append(out, file)
 			continue
 		}
-		sessionID := strings.TrimSuffix(filepath.Base(file.Path), ".jsonl")
+		sessionID := claudeSessionIDFromPath(file.Path)
 		if sessionID == "" {
 			out = append(out, file)
 			continue
@@ -2949,6 +2989,15 @@ func (e *Engine) dedupeClaudeDiscoveredFiles(
 	return out
 }
 
+func claudeSessionIDFromPath(path string) string {
+	name := filepath.Base(path)
+	sessionID, ok := strings.CutSuffix(name, ".jsonl")
+	if !ok {
+		return ""
+	}
+	return sessionID
+}
+
 func (e *Engine) pickPreferredClaudeDiscoveredFile(
 	sessionID string, candidates []parser.DiscoveredFile,
 ) parser.DiscoveredFile {
@@ -2960,13 +3009,13 @@ func (e *Engine) pickPreferredClaudeDiscoveredFile(
 	storedPath := e.db.GetSessionFilePath(fullID)
 	if storedPath != "" {
 		for _, candidate := range candidates {
-			if candidate.Path != storedPath {
+			if e.effectiveSourcePath(candidate.Path) != storedPath {
 				continue
 			}
 			if e.claudeSourceMatchesStored(fullID, candidate.Path) {
 				best := candidate
 				for _, competing := range candidates {
-					if competing.Path == storedPath ||
+					if e.effectiveSourcePath(competing.Path) == storedPath ||
 						!claudeCandidateHasAppendProgress(competing, candidate) {
 						continue
 					}
@@ -3004,6 +3053,13 @@ func (e *Engine) claudeSourceMatchesStored(
 		return false
 	}
 	return e.db.GetSessionDataVersion(sessionID) >= db.CurrentDataVersion()
+}
+
+func (e *Engine) effectiveSourcePath(path string) string {
+	if e.pathRewriter != nil {
+		return e.pathRewriter(path)
+	}
+	return path
 }
 
 func claudeCandidateHasAppendProgress(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2380,6 +2380,7 @@ func (e *Engine) syncAllLocked(
 	}
 
 	all = dedupeDiscoveredFiles(all)
+	all = e.dedupeClaudeDiscoveredFiles(all)
 	all = e.filterShadowedLegacyKiroFiles(all)
 
 	verbose := onProgress == nil
@@ -2899,6 +2900,120 @@ func discoveredFileMtime(
 	}
 
 	return info.ModTime().UnixNano(), nil
+}
+
+func (e *Engine) dedupeClaudeDiscoveredFiles(
+	files []parser.DiscoveredFile,
+) []parser.DiscoveredFile {
+	bySessionID := make(map[string][]parser.DiscoveredFile)
+	for _, file := range files {
+		if file.Agent != parser.AgentClaude {
+			continue
+		}
+		sessionID := strings.TrimSuffix(filepath.Base(file.Path), ".jsonl")
+		if sessionID == "" {
+			continue
+		}
+		bySessionID[sessionID] = append(bySessionID[sessionID], file)
+	}
+	if len(bySessionID) == 0 {
+		return files
+	}
+
+	preferred := make(map[string]parser.DiscoveredFile, len(bySessionID))
+	for sessionID, candidates := range bySessionID {
+		preferred[sessionID] = e.pickPreferredClaudeDiscoveredFile(
+			sessionID, candidates,
+		)
+	}
+
+	out := files[:0]
+	seen := make(map[string]struct{}, len(preferred))
+	for _, file := range files {
+		if file.Agent != parser.AgentClaude {
+			out = append(out, file)
+			continue
+		}
+		sessionID := strings.TrimSuffix(filepath.Base(file.Path), ".jsonl")
+		if sessionID == "" {
+			out = append(out, file)
+			continue
+		}
+		if _, ok := seen[sessionID]; ok {
+			continue
+		}
+		seen[sessionID] = struct{}{}
+		out = append(out, preferred[sessionID])
+	}
+	return out
+}
+
+func (e *Engine) pickPreferredClaudeDiscoveredFile(
+	sessionID string, candidates []parser.DiscoveredFile,
+) parser.DiscoveredFile {
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+
+	fullID := e.idPrefix + sessionID
+	storedPath := e.db.GetSessionFilePath(fullID)
+	if storedPath != "" {
+		for _, candidate := range candidates {
+			if candidate.Path != storedPath {
+				continue
+			}
+			if e.claudeSourceMatchesStored(fullID, candidate.Path) {
+				return candidate
+			}
+		}
+	}
+
+	best := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if preferClaudeDiscoveredFile(candidate, best) {
+			best = candidate
+		}
+	}
+	return best
+}
+
+func (e *Engine) claudeSourceMatchesStored(
+	sessionID, path string,
+) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	storedSize, storedMtime, ok := e.db.GetSessionFileInfo(sessionID)
+	if !ok {
+		return false
+	}
+	if storedSize != info.Size() ||
+		storedMtime != info.ModTime().UnixNano() {
+		return false
+	}
+	return e.db.GetSessionDataVersion(sessionID) >= db.CurrentDataVersion()
+}
+
+func preferClaudeDiscoveredFile(
+	candidate, current parser.DiscoveredFile,
+) bool {
+	candidateInfo, candidateErr := os.Stat(candidate.Path)
+	currentInfo, currentErr := os.Stat(current.Path)
+	switch {
+	case candidateErr == nil && currentErr != nil:
+		return true
+	case candidateErr != nil && currentErr == nil:
+		return false
+	case candidateErr == nil && currentErr == nil:
+		if candidateInfo.Size() != currentInfo.Size() {
+			return candidateInfo.Size() > currentInfo.Size()
+		}
+		if !candidateInfo.ModTime().Equal(currentInfo.ModTime()) {
+			return candidateInfo.ModTime().After(currentInfo.ModTime())
+		}
+	}
+	return candidate.Path < current.Path
 }
 
 // zedDBCompositeMtime returns the maximum mtime across the Zed

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2963,7 +2963,17 @@ func (e *Engine) pickPreferredClaudeDiscoveredFile(
 				continue
 			}
 			if e.claudeSourceMatchesStored(fullID, candidate.Path) {
-				return candidate
+				best := candidate
+				for _, competing := range candidates {
+					if competing.Path == storedPath ||
+						!claudeCandidateHasAppendProgress(competing, candidate) {
+						continue
+					}
+					if preferClaudeDiscoveredFile(competing, best) {
+						best = competing
+					}
+				}
+				return best
 			}
 		}
 	}
@@ -2993,6 +3003,17 @@ func (e *Engine) claudeSourceMatchesStored(
 		return false
 	}
 	return e.db.GetSessionDataVersion(sessionID) >= db.CurrentDataVersion()
+}
+
+func claudeCandidateHasAppendProgress(
+	candidate, current parser.DiscoveredFile,
+) bool {
+	candidateInfo, candidateErr := os.Stat(candidate.Path)
+	currentInfo, currentErr := os.Stat(current.Path)
+	if candidateErr != nil || currentErr != nil {
+		return false
+	}
+	return candidateInfo.Size() > currentInfo.Size()
 }
 
 func preferClaudeDiscoveredFile(

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1293,6 +1293,42 @@ func TestSyncAllClaudeDuplicateLiveGrowthBeatsUnchangedStoredArchive(t *testing.
 	assertMessageContent(t, env.db, "duplicate-grow", "initial message", "live follow-up")
 }
 
+func TestSyncAllSinceClaudeDuplicateTouchedStaleDoesNotBeatPreferred(t *testing.T) {
+	liveDir := t.TempDir()
+	archiveDir := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{liveDir, archiveDir}))
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "same logical session").
+		String()
+	livePath := env.writeSession(
+		t, liveDir, filepath.Join("proj-live", "duplicate-since.jsonl"), content,
+	)
+	archivePath := env.writeSession(
+		t, archiveDir, filepath.Join("proj-archive", "duplicate-since.jsonl"), content,
+	)
+	baseTime := time.Now().Add(-3 * time.Hour)
+	preferredTime := baseTime.Add(time.Hour)
+	require.NoError(t, os.Chtimes(archivePath, baseTime, baseTime))
+	require.NoError(t, os.Chtimes(livePath, preferredTime, preferredTime))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("duplicate-since"))
+
+	cutoff := preferredTime.Add(time.Hour)
+	touchedArchive := cutoff.Add(time.Minute)
+	require.NoError(t, os.Chtimes(archivePath, touchedArchive, touchedArchive))
+
+	stats := env.engine.SyncAllSince(context.Background(), cutoff, nil)
+	assert.Zero(t, stats.Synced, "stale duplicate must not be re-synced")
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("duplicate-since"))
+	assertMessageContent(t, env.db, "duplicate-since", "same logical session")
+}
+
 func TestSyncEngineSkipCache(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1209,6 +1209,47 @@ func TestSyncEngineHashSkip(t *testing.T) {
 	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1 + 0, Synced: 1, Skipped: 0})
 }
 
+func TestSyncAllDedupesClaudeSourcesBySessionID(t *testing.T) {
+	liveDir := t.TempDir()
+	archiveDir := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{liveDir, archiveDir}))
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "same logical session").
+		String()
+	livePath := env.writeSession(
+		t, liveDir, filepath.Join("proj-live", "duplicate.jsonl"), content,
+	)
+	archivePath := env.writeSession(
+		t, archiveDir, filepath.Join("proj-archive", "duplicate.jsonl"), content,
+	)
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, older, older))
+	require.NoError(t, os.Chtimes(livePath, newer, newer))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	liveInfo, err := os.Stat(livePath)
+	require.NoError(t, err)
+	storedSize, storedMtime, ok := env.db.GetSessionFileInfo("duplicate")
+	require.True(t, ok, "file info not stored")
+	assert.Equal(t, liveInfo.Size(), storedSize)
+	assert.Equal(t, liveInfo.ModTime().UnixNano(), storedMtime)
+
+	touchedArchive := newer.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, touchedArchive, touchedArchive))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        0,
+		Skipped:       1,
+	})
+}
+
 func TestSyncEngineSkipCache(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1250,6 +1250,49 @@ func TestSyncAllDedupesClaudeSourcesBySessionID(t *testing.T) {
 	})
 }
 
+func TestSyncAllClaudeDuplicateLiveGrowthBeatsUnchangedStoredArchive(t *testing.T) {
+	liveDir := t.TempDir()
+	archiveDir := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{liveDir, archiveDir}))
+
+	initial := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "initial message").
+		String()
+	livePath := env.writeSession(
+		t, liveDir, filepath.Join("proj-live", "duplicate-grow.jsonl"), initial,
+	)
+	archivePath := env.writeSession(
+		t, archiveDir, filepath.Join("proj-archive", "duplicate-grow.jsonl"), initial,
+	)
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	require.NoError(t, os.Chtimes(livePath, older, older))
+	require.NoError(t, os.Chtimes(archivePath, newer, newer))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Equal(t, archivePath, env.db.GetSessionFilePath("duplicate-grow"))
+
+	f, err := os.OpenFile(livePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZeroS5, "live follow-up").
+		String())
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("duplicate-grow"))
+	assertMessageContent(t, env.db, "duplicate-grow", "initial message", "live follow-up")
+}
+
 func TestSyncEngineSkipCache(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1329,6 +1329,89 @@ func TestSyncAllSinceClaudeDuplicateTouchedStaleDoesNotBeatPreferred(t *testing.
 	assertMessageContent(t, env.db, "duplicate-since", "same logical session")
 }
 
+func TestSyncPathsClaudeDuplicateTouchedStaleDoesNotBeatPreferred(t *testing.T) {
+	liveDir := t.TempDir()
+	archiveDir := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{liveDir, archiveDir}))
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "same logical session").
+		String()
+	livePath := env.writeSession(
+		t, liveDir, filepath.Join("proj-live", "duplicate-watch.jsonl"), content,
+	)
+	archivePath := env.writeSession(
+		t, archiveDir, filepath.Join("proj-archive", "duplicate-watch.jsonl"), content,
+	)
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, older, older))
+	require.NoError(t, os.Chtimes(livePath, newer, newer))
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("duplicate-watch"))
+
+	touchedArchive := newer.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, touchedArchive, touchedArchive))
+
+	env.engine.SyncPaths([]string{archivePath})
+	assert.Zero(t, env.engine.LastSyncStats().Synced,
+		"stale watcher duplicate must not be re-synced")
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("duplicate-watch"))
+	assertMessageContent(t, env.db, "duplicate-watch", "same logical session")
+}
+
+func TestSyncAllClaudeDuplicatePathRewriterKeepsStoredPreferred(t *testing.T) {
+	liveDir := t.TempDir()
+	archiveDir := t.TempDir()
+	database := dbtest.OpenTestDB(t)
+	rewriter := func(path string) string {
+		return "host:" + path
+	}
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {liveDir, archiveDir},
+		},
+		Machine:      "remote-host",
+		IDPrefix:     "host~",
+		PathRewriter: rewriter,
+	})
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "same logical session").
+		String()
+	livePath := filepath.Join(liveDir, "proj-live", "duplicate-remote.jsonl")
+	archivePath := filepath.Join(archiveDir, "proj-archive", "duplicate-remote.jsonl")
+	dbtest.WriteTestFile(t, livePath, []byte(content))
+	dbtest.WriteTestFile(t, archivePath, []byte(content))
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, older, older))
+	require.NoError(t, os.Chtimes(livePath, newer, newer))
+
+	runSyncAndAssert(t, engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+		Skipped:       0,
+	})
+	assert.Equal(t, rewriter(livePath), database.GetSessionFilePath("host~duplicate-remote"))
+
+	touchedArchive := newer.Add(time.Second)
+	require.NoError(t, os.Chtimes(archivePath, touchedArchive, touchedArchive))
+
+	runSyncAndAssert(t, engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        0,
+		Skipped:       1,
+	})
+	assert.Equal(t, rewriter(livePath), database.GetSessionFilePath("host~duplicate-remote"))
+	assertMessageContent(t, database, "host~duplicate-remote", "same logical session")
+}
+
 func TestSyncEngineSkipCache(t *testing.T) {
 	env := setupTestEnv(t)
 


### PR DESCRIPTION
This changes full-file sync discovery so duplicate Claude transcript paths collapse to one logical source before worker parsing.

When live Claude roots and archived roots contain the same session ID, the sync engine now keeps the already stored matching source when possible and otherwise chooses a deterministic largest/newest source. That prevents duplicate physical files from making the same logical session dirty on every full sync pass.

The regression covers overlapping Claude roots with the same session filename and verifies the second full sync converges to a skip instead of reparsing another duplicate.
