### PR TITLE
[codex] scope unwatched root polling

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"syscall"
 	"time"
 	_ "time/tzdata"
@@ -514,62 +515,7 @@ func startFileWatcher(
 		return func() {}, []string{"all"}
 	}
 
-	type watchRoot struct {
-		dir     string
-		root    string // actual path passed to WatchRecursive
-		shallow bool   // use shallow watch (root only)
-	}
-
-	var roots []watchRoot
-	seenRoots := make(map[string]struct{})
-	addRoot := func(r watchRoot) {
-		if _, ok := seenRoots[r.root]; ok {
-			return
-		}
-		seenRoots[r.root] = struct{}{}
-		roots = append(roots, r)
-	}
-	for _, def := range parser.Registry {
-		if !def.FileBased {
-			continue
-		}
-		for _, d := range cfg.ResolveDirs(def.Type) {
-			if def.ShallowWatchRootsFunc != nil {
-				for _, watchDir := range def.ShallowWatchRootsFunc(d) {
-					if _, err := os.Stat(watchDir); err == nil {
-						addRoot(watchRoot{d, watchDir, true})
-					}
-				}
-			}
-			if def.WatchRootsFunc != nil {
-				watchDirs := def.WatchRootsFunc(d)
-				if len(watchDirs) == 0 {
-					unwatchedDirs = append(unwatchedDirs, d)
-					continue
-				}
-				for _, watchDir := range watchDirs {
-					if _, err := os.Stat(watchDir); err == nil {
-						addRoot(watchRoot{d, watchDir, def.ShallowWatch})
-						continue
-					}
-					unwatchedDirs = append(unwatchedDirs, d)
-				}
-				continue
-			}
-			if len(def.WatchSubdirs) == 0 {
-				if _, err := os.Stat(d); err == nil {
-					addRoot(watchRoot{d, d, def.ShallowWatch})
-				}
-				continue
-			}
-			for _, sub := range def.WatchSubdirs {
-				watchDir := filepath.Join(d, sub)
-				if _, err := os.Stat(watchDir); err == nil {
-					addRoot(watchRoot{d, watchDir, def.ShallowWatch})
-				}
-			}
-		}
-	}
+	roots, unwatchedDirs := collectWatchRoots(cfg)
 
 	var totalWatched int
 	var shallowWatched int
@@ -580,7 +526,7 @@ func startFileWatcher(
 				shallowWatched++
 				totalWatched++
 			} else {
-				unwatchedDirs = append(unwatchedDirs, r.dir)
+				unwatchedDirs = append(unwatchedDirs, r.dirs...)
 			}
 			continue
 		}
@@ -589,13 +535,13 @@ func startFileWatcher(
 		remaining -= result.Watched
 		if result.Unwatched > 0 || result.BudgetExhausted ||
 			result.ResourceExhausted || result.Err != nil {
-			unwatchedDirs = append(unwatchedDirs, r.dir)
+			unwatchedDirs = append(unwatchedDirs, r.dirs...)
 			log.Printf(
 				"Couldn't watch %d directories under %s, will poll every %s",
-				result.Unwatched, r.dir, unwatchedPollInterval,
+				result.Unwatched, r.root, unwatchedPollInterval,
 			)
 			if result.Err != nil {
-				log.Printf("watching %s: %v", r.dir, result.Err)
+				log.Printf("watching %s: %v", r.root, result.Err)
 			}
 		}
 	}
@@ -619,6 +565,72 @@ func startFileWatcher(
 	}
 	watcher.Start()
 	return watcher.Stop, unwatchedDirs
+}
+
+type watchRoot struct {
+	dirs    []string
+	root    string // actual path passed to WatchRecursive
+	shallow bool   // use shallow watch (root only)
+}
+
+func collectWatchRoots(cfg config.Config) (roots []watchRoot, unwatchedDirs []string) {
+	rootIndexes := make(map[string]int)
+	addRoot := func(dir, root string, shallow bool) {
+		if idx, ok := rootIndexes[root]; ok {
+			if !slices.Contains(roots[idx].dirs, dir) {
+				roots[idx].dirs = append(roots[idx].dirs, dir)
+			}
+			return
+		}
+		rootIndexes[root] = len(roots)
+		roots = append(roots, watchRoot{
+			dirs:    []string{dir},
+			root:    root,
+			shallow: shallow,
+		})
+	}
+	for _, def := range parser.Registry {
+		if !def.FileBased {
+			continue
+		}
+		for _, d := range cfg.ResolveDirs(def.Type) {
+			if def.ShallowWatchRootsFunc != nil {
+				for _, watchDir := range def.ShallowWatchRootsFunc(d) {
+					if _, err := os.Stat(watchDir); err == nil {
+						addRoot(d, watchDir, true)
+					}
+				}
+			}
+			if def.WatchRootsFunc != nil {
+				watchDirs := def.WatchRootsFunc(d)
+				if len(watchDirs) == 0 {
+					unwatchedDirs = append(unwatchedDirs, d)
+					continue
+				}
+				for _, watchDir := range watchDirs {
+					if _, err := os.Stat(watchDir); err == nil {
+						addRoot(d, watchDir, def.ShallowWatch)
+						continue
+					}
+					unwatchedDirs = append(unwatchedDirs, d)
+				}
+				continue
+			}
+			if len(def.WatchSubdirs) == 0 {
+				if _, err := os.Stat(d); err == nil {
+					addRoot(d, d, def.ShallowWatch)
+				}
+				continue
+			}
+			for _, sub := range def.WatchSubdirs {
+				watchDir := filepath.Join(d, sub)
+				if _, err := os.Stat(watchDir); err == nil {
+					addRoot(d, watchDir, def.ShallowWatch)
+				}
+			}
+		}
+	}
+	return roots, unwatchedDirs
 }
 
 func startPeriodicSync(

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -31,11 +31,12 @@ var (
 )
 
 const (
-	periodicSyncInterval  = 15 * time.Minute
-	telemetryPingInterval = 24 * time.Hour
-	unwatchedPollInterval = 2 * time.Minute
-	watcherDebounce       = 500 * time.Millisecond
-	recursiveWatchBudget  = 8192
+	periodicSyncInterval      = 15 * time.Minute
+	telemetryPingInterval     = 24 * time.Hour
+	unwatchedPollInterval     = 2 * time.Minute
+	unwatchedPollSafetyMargin = 5 * time.Second
+	watcherDebounce           = 500 * time.Millisecond
+	recursiveWatchBudget      = 8192
 )
 
 func main() {
@@ -282,7 +283,7 @@ func runServe(cfg config.Config) {
 		)
 		defer stopWatcher()
 		if len(unwatchedDirs) > 0 {
-			go startUnwatchedPoll(engine)
+			go startUnwatchedPoll(engine, unwatchedDirs)
 		}
 	}
 
@@ -659,11 +660,26 @@ func recomputePendingSessions(
 	}
 }
 
-func startUnwatchedPoll(engine *sync.Engine) {
+type unwatchedPollSyncer interface {
+	LastSyncStartedAt() time.Time
+	SyncRootsSince(
+		context.Context, []string, time.Time, sync.ProgressFunc,
+	) sync.SyncStats
+}
+
+func startUnwatchedPoll(engine unwatchedPollSyncer, roots []string) {
 	ticker := time.NewTicker(unwatchedPollInterval)
 	defer ticker.Stop()
 	for range ticker.C {
 		log.Println("Polling unwatched directories...")
-		engine.SyncAll(context.Background(), nil)
+		pollUnwatchedRootsOnce(engine, roots)
 	}
+}
+
+func pollUnwatchedRootsOnce(engine unwatchedPollSyncer, roots []string) {
+	since := engine.LastSyncStartedAt()
+	if !since.IsZero() {
+		since = since.Add(-unwatchedPollSafetyMargin)
+	}
+	engine.SyncRootsSince(context.Background(), roots, since, nil)
 }

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -32,12 +32,11 @@ var (
 )
 
 const (
-	periodicSyncInterval      = 15 * time.Minute
-	telemetryPingInterval     = 24 * time.Hour
-	unwatchedPollInterval     = 2 * time.Minute
-	unwatchedPollSafetyMargin = 5 * time.Second
-	watcherDebounce           = 500 * time.Millisecond
-	recursiveWatchBudget      = 8192
+	periodicSyncInterval  = 15 * time.Minute
+	telemetryPingInterval = 24 * time.Hour
+	unwatchedPollInterval = 2 * time.Minute
+	watcherDebounce       = 500 * time.Millisecond
+	recursiveWatchBudget  = 8192
 )
 
 func main() {
@@ -673,7 +672,6 @@ func recomputePendingSessions(
 }
 
 type unwatchedPollSyncer interface {
-	LastSyncStartedAt() time.Time
 	SyncRootsSince(
 		context.Context, []string, time.Time, sync.ProgressFunc,
 	) sync.SyncStats
@@ -689,9 +687,5 @@ func startUnwatchedPoll(engine unwatchedPollSyncer, roots []string) {
 }
 
 func pollUnwatchedRootsOnce(engine unwatchedPollSyncer, roots []string) {
-	since := engine.LastSyncStartedAt()
-	if !since.IsZero() {
-		since = since.Add(-unwatchedPollSafetyMargin)
-	}
-	engine.SyncRootsSince(context.Background(), roots, since, nil)
+	engine.SyncRootsSince(context.Background(), roots, time.Time{}, nil)
 }

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"log"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,6 +225,41 @@ func TestTruncateLogFileSymlink(t *testing.T) {
 	data, err := os.ReadFile(target)
 	require.NoError(t, err, "read target")
 	assert.Len(t, data, 1024, "symlink target was truncated")
+}
+
+type fakeUnwatchedPollSyncer struct {
+	lastSyncStartedAt time.Time
+	roots             []string
+	since             time.Time
+	calls             int
+}
+
+func (f *fakeUnwatchedPollSyncer) LastSyncStartedAt() time.Time {
+	return f.lastSyncStartedAt
+}
+
+func (f *fakeUnwatchedPollSyncer) SyncRootsSince(
+	ctx context.Context, roots []string, since time.Time,
+	onProgress sync.ProgressFunc,
+) sync.SyncStats {
+	f.calls++
+	f.roots = append([]string(nil), roots...)
+	f.since = since
+	return sync.SyncStats{}
+}
+
+func TestPollUnwatchedRootsOnceUsesScopedIncrementalSync(t *testing.T) {
+	lastSyncStartedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	fake := &fakeUnwatchedPollSyncer{
+		lastSyncStartedAt: lastSyncStartedAt,
+	}
+	roots := []string{"/tmp/claude", "/tmp/codex"}
+
+	pollUnwatchedRootsOnce(fake, roots)
+
+	assert.Equal(t, 1, fake.calls)
+	assert.Equal(t, roots, fake.roots)
+	assert.Equal(t, lastSyncStartedAt.Add(-unwatchedPollSafetyMargin), fake.since)
 }
 
 func TestResyncCoversSignals(t *testing.T) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -229,14 +229,11 @@ func TestTruncateLogFileSymlink(t *testing.T) {
 }
 
 type fakeUnwatchedPollSyncer struct {
-	lastSyncStartedAt time.Time
-	roots             []string
-	since             time.Time
-	calls             int
-}
-
-func (f *fakeUnwatchedPollSyncer) LastSyncStartedAt() time.Time {
-	return f.lastSyncStartedAt
+	roots     []string
+	since     time.Time
+	calls     int
+	callRoots [][]string
+	callSince []time.Time
 }
 
 func (f *fakeUnwatchedPollSyncer) SyncRootsSince(
@@ -246,21 +243,23 @@ func (f *fakeUnwatchedPollSyncer) SyncRootsSince(
 	f.calls++
 	f.roots = append([]string(nil), roots...)
 	f.since = since
+	f.callRoots = append(f.callRoots, append([]string(nil), roots...))
+	f.callSince = append(f.callSince, since)
 	return sync.SyncStats{}
 }
 
-func TestPollUnwatchedRootsOnceUsesScopedIncrementalSync(t *testing.T) {
-	lastSyncStartedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
-	fake := &fakeUnwatchedPollSyncer{
-		lastSyncStartedAt: lastSyncStartedAt,
-	}
+func TestPollUnwatchedRootsOnceUsesScopedFullSync(t *testing.T) {
+	fake := &fakeUnwatchedPollSyncer{}
 	roots := []string{"/tmp/claude", "/tmp/codex"}
 
 	pollUnwatchedRootsOnce(fake, roots)
+	pollUnwatchedRootsOnce(fake, roots)
 
-	assert.Equal(t, 1, fake.calls)
-	assert.Equal(t, roots, fake.roots)
-	assert.Equal(t, lastSyncStartedAt.Add(-unwatchedPollSafetyMargin), fake.since)
+	require.Equal(t, 2, fake.calls)
+	assert.Equal(t, roots, fake.callRoots[0])
+	assert.True(t, fake.callSince[0].IsZero(), "first poll cutoff = %v", fake.callSince[0])
+	assert.Equal(t, roots, fake.callRoots[1])
+	assert.True(t, fake.callSince[1].IsZero(), "second poll cutoff = %v", fake.callSince[1])
 }
 
 func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
 )
 
@@ -260,6 +261,26 @@ func TestPollUnwatchedRootsOnceUsesScopedIncrementalSync(t *testing.T) {
 	assert.Equal(t, 1, fake.calls)
 	assert.Equal(t, roots, fake.roots)
 	assert.Equal(t, lastSyncStartedAt.Add(-unwatchedPollSafetyMargin), fake.since)
+}
+
+func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "codex-state")
+	require.NoError(t, os.Mkdir(parent, 0o755), "mkdir parent")
+
+	sessionsDir := filepath.Join(parent, "sessions")
+	archivedDir := filepath.Join(parent, "archived_sessions")
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {sessionsDir, archivedDir},
+		},
+	}
+
+	roots, unwatchedDirs := collectWatchRoots(cfg)
+
+	require.Empty(t, unwatchedDirs, "unwatched dirs before watcher setup")
+	require.Len(t, roots, 1, "shared watch root should be represented once")
+	assert.Equal(t, parent, roots[0].root)
+	assert.ElementsMatch(t, []string{sessionsDir, archivedDir}, roots[0].dirs)
 }
 
 func TestResyncCoversSignals(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1965,7 +1965,7 @@ func (e *Engine) ResyncAll(
 	e.openCodeArchiveStore = origDB
 	e.db = newDB
 	stats = e.syncAllLocked(
-		ctx, onProgress, time.Time{}, nil, syncWriteBulk,
+		ctx, onProgress, time.Time{}, nil, syncWriteBulk, true,
 	)
 	e.db = origDB // restore immediately
 	e.openCodeArchiveStore = nil
@@ -2321,7 +2321,7 @@ func (e *Engine) SyncAll(
 	}()
 	defer e.syncMu.Unlock()
 	stats = e.syncAllLocked(
-		ctx, onProgress, time.Time{}, nil, syncWriteDefault,
+		ctx, onProgress, time.Time{}, nil, syncWriteDefault, true,
 	)
 	return
 }
@@ -2344,7 +2344,7 @@ func (e *Engine) SyncAllSince(
 	}()
 	defer e.syncMu.Unlock()
 	stats = e.syncAllLocked(
-		ctx, onProgress, since, nil, syncWriteDefault,
+		ctx, onProgress, since, nil, syncWriteDefault, true,
 	)
 	return
 }
@@ -2363,9 +2363,9 @@ func (e *Engine) SyncRootsSince(
 		}
 	}()
 	defer e.syncMu.Unlock()
+	scope := newRootSyncScope(roots)
 	stats = e.syncAllLocked(
-		ctx, onProgress, since, newRootSyncScope(roots),
-		syncWriteDefault,
+		ctx, onProgress, since, scope, syncWriteDefault, scope == nil,
 	)
 	return
 }
@@ -2437,13 +2437,15 @@ func samePathOrDescendant(path, root string) bool {
 
 func (e *Engine) syncAllLocked(
 	ctx context.Context, onProgress ProgressFunc, since time.Time,
-	scope *rootSyncScope, writeMode syncWriteMode,
+	scope *rootSyncScope, writeMode syncWriteMode, recordSyncState bool,
 ) SyncStats {
 	if ctx.Err() != nil {
 		return SyncStats{Aborted: true}
 	}
 
-	e.recordSyncStarted()
+	if recordSyncState {
+		e.recordSyncStarted()
+	}
 	e.phaseStats.Reset()
 
 	t0 := time.Now()
@@ -2855,7 +2857,9 @@ func (e *Engine) syncAllLocked(
 	e.lastSyncStats = stats
 	e.mu.Unlock()
 
-	e.recordSyncFinished()
+	if recordSyncState {
+		e.recordSyncFinished()
+	}
 	// Emission happens in SyncAll / SyncAllSince after syncMu is
 	// released; syncAllLocked runs under the caller's lock.
 	return stats

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2471,7 +2471,7 @@ func (e *Engine) syncAllLocked(
 	}
 
 	all = dedupeDiscoveredFiles(all)
-	all = e.filterShadowedLegacyKiroFiles(all, scope)
+	all = e.filterShadowedLegacyKiroFiles(all)
 
 	verbose := onProgress == nil
 
@@ -3167,13 +3167,10 @@ func (e *Engine) countDBBackedSessions(
 }
 
 func (e *Engine) filterShadowedLegacyKiroFiles(
-	files []parser.DiscoveredFile, scope *rootSyncScope,
+	files []parser.DiscoveredFile,
 ) []parser.DiscoveredFile {
 	currentIDs := make(map[string]struct{})
 	for _, dir := range e.agentDirs[parser.AgentKiro] {
-		if !scope.includes(dir) {
-			continue
-		}
 		for id := range parser.KiroSQLiteSessionIDs(dir) {
 			currentIDs[id] = struct{}{}
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1965,7 +1965,7 @@ func (e *Engine) ResyncAll(
 	e.openCodeArchiveStore = origDB
 	e.db = newDB
 	stats = e.syncAllLocked(
-		ctx, onProgress, time.Time{}, syncWriteBulk,
+		ctx, onProgress, time.Time{}, nil, syncWriteBulk,
 	)
 	e.db = origDB // restore immediately
 	e.openCodeArchiveStore = nil
@@ -2321,7 +2321,7 @@ func (e *Engine) SyncAll(
 	}()
 	defer e.syncMu.Unlock()
 	stats = e.syncAllLocked(
-		ctx, onProgress, time.Time{}, syncWriteDefault,
+		ctx, onProgress, time.Time{}, nil, syncWriteDefault,
 	)
 	return
 }
@@ -2344,14 +2344,108 @@ func (e *Engine) SyncAllSince(
 	}()
 	defer e.syncMu.Unlock()
 	stats = e.syncAllLocked(
-		ctx, onProgress, since, syncWriteDefault,
+		ctx, onProgress, since, nil, syncWriteDefault,
 	)
 	return
 }
 
+// SyncRootsSince syncs only configured roots matching the given
+// root paths whose mtimes are at or after the given cutoff. Passing
+// "all" in roots is equivalent to SyncAllSince.
+func (e *Engine) SyncRootsSince(
+	ctx context.Context, roots []string, since time.Time,
+	onProgress ProgressFunc,
+) (stats SyncStats) {
+	e.syncMu.Lock()
+	defer func() {
+		if stats.Synced > 0 {
+			e.emit("sessions")
+		}
+	}()
+	defer e.syncMu.Unlock()
+	stats = e.syncAllLocked(
+		ctx, onProgress, since, newRootSyncScope(roots),
+		syncWriteDefault,
+	)
+	return
+}
+
+type rootSyncScope struct {
+	roots []string
+}
+
+func newRootSyncScope(roots []string) *rootSyncScope {
+	if len(roots) == 0 {
+		return nil
+	}
+	scope := &rootSyncScope{}
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		if root == "all" {
+			return nil
+		}
+		scope.roots = append(scope.roots, cleanRootPath(root))
+	}
+	if len(scope.roots) == 0 {
+		return nil
+	}
+	return scope
+}
+
+func (s *rootSyncScope) includes(dir string) bool {
+	if s == nil {
+		return true
+	}
+	if dir == "" {
+		return false
+	}
+	cleaned := cleanRootPath(dir)
+	for _, root := range s.roots {
+		if samePathOrDescendant(cleaned, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *rootSyncScope) includesAny(dirs []string) bool {
+	if s == nil {
+		return true
+	}
+	for _, dir := range dirs {
+		if s.includes(dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanRootPath(path string) string {
+	cleaned := filepath.Clean(path)
+	abs, err := filepath.Abs(cleaned)
+	if err != nil {
+		return cleaned
+	}
+	return abs
+}
+
+func samePathOrDescendant(path, root string) bool {
+	if path == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 func (e *Engine) syncAllLocked(
 	ctx context.Context, onProgress ProgressFunc, since time.Time,
-	writeMode syncWriteMode,
+	scope *rootSyncScope, writeMode syncWriteMode,
 ) SyncStats {
 	if ctx.Err() != nil {
 		return SyncStats{Aborted: true}
@@ -2369,6 +2463,9 @@ func (e *Engine) syncAllLocked(
 			continue
 		}
 		for _, d := range e.agentDirs[def.Type] {
+			if !scope.includes(d) {
+				continue
+			}
 			found := def.DiscoverFunc(d)
 			counts[def.Type] += len(found)
 			all = append(all, found...)
@@ -2408,7 +2505,7 @@ func (e *Engine) syncAllLocked(
 
 	progressTotal := len(all)
 	if onProgress != nil {
-		progressTotal += e.countDBBackedSessions(ctx)
+		progressTotal += e.countDBBackedSessions(ctx, scope)
 		onProgress(Progress{
 			Phase:         PhaseSyncing,
 			SessionsTotal: progressTotal,
@@ -2460,7 +2557,10 @@ func (e *Engine) syncAllLocked(
 
 	// Sync current Kiro CLI sessions (SQLite-backed).
 	tKiro := time.Now()
-	kiroPending := e.syncKiroSQLite(ctx)
+	var kiroPending []pendingWrite
+	if scope.includesAny(e.agentDirs[parser.AgentKiro]) {
+		kiroPending = e.syncKiroSQLite(ctx)
+	}
 	if len(kiroPending) > 0 {
 		stats.TotalSessions += len(kiroPending)
 		tWrite := time.Now()
@@ -2506,7 +2606,10 @@ func (e *Engine) syncAllLocked(
 			time.Since(tKiro).Round(time.Millisecond),
 		)
 	}
-	advanceDBProgress(e.countDBBackedProgressTotal(parser.AgentKiro), kiroPending)
+	advanceDBProgress(
+		e.countDBBackedProgressTotal(parser.AgentKiro, scope),
+		kiroPending,
+	)
 
 	if ctx.Err() != nil {
 		stats.Aborted = true
@@ -2517,31 +2620,40 @@ func (e *Engine) syncAllLocked(
 	// Uses full replace because these messages can change in place
 	// (streaming updates, tool result pairing). Kilo is a fork of
 	// OpenCode and shares the same SQLite-backed sync.
-	if e.syncOpenCodeFormatAgent(
-		ctx, parser.AgentOpenCode, "opencode",
-		writeMode, verbose, &stats, advanceDBProgress,
-	) {
-		stats.Aborted = true
-		return stats
+	if scope.includesAny(e.agentDirs[parser.AgentOpenCode]) {
+		if e.syncOpenCodeFormatAgent(
+			ctx, parser.AgentOpenCode, "opencode",
+			writeMode, verbose, scope, &stats, advanceDBProgress,
+		) {
+			stats.Aborted = true
+			return stats
+		}
 	}
-	if e.syncOpenCodeFormatAgent(
-		ctx, parser.AgentKilo, "kilo",
-		writeMode, verbose, &stats, advanceDBProgress,
-	) {
-		stats.Aborted = true
-		return stats
+	if scope.includesAny(e.agentDirs[parser.AgentKilo]) {
+		if e.syncOpenCodeFormatAgent(
+			ctx, parser.AgentKilo, "kilo",
+			writeMode, verbose, scope, &stats, advanceDBProgress,
+		) {
+			stats.Aborted = true
+			return stats
+		}
 	}
-	if e.syncOpenCodeFormatAgent(
-		ctx, parser.AgentMiMoCode, "mimocode",
-		writeMode, verbose, &stats, advanceDBProgress,
-	) {
-		stats.Aborted = true
-		return stats
+	if scope.includesAny(e.agentDirs[parser.AgentMiMoCode]) {
+		if e.syncOpenCodeFormatAgent(
+			ctx, parser.AgentMiMoCode, "mimocode",
+			writeMode, verbose, scope, &stats, advanceDBProgress,
+		) {
+			stats.Aborted = true
+			return stats
+		}
 	}
 
 	// Sync Warp sessions (DB-backed, not file-based).
 	tWarp := time.Now()
-	warpPending := e.syncWarp(ctx)
+	var warpPending []pendingWrite
+	if scope.includesAny(e.agentDirs[parser.AgentWarp]) {
+		warpPending = e.syncWarp(ctx)
+	}
 	if len(warpPending) > 0 {
 		stats.TotalSessions += len(warpPending)
 		tWrite := time.Now()
@@ -2588,7 +2700,10 @@ func (e *Engine) syncAllLocked(
 			time.Since(tWarp).Round(time.Millisecond),
 		)
 	}
-	advanceDBProgress(e.countDBBackedProgressTotal(parser.AgentWarp), warpPending)
+	advanceDBProgress(
+		e.countDBBackedProgressTotal(parser.AgentWarp, scope),
+		warpPending,
+	)
 
 	if ctx.Err() != nil {
 		stats.Aborted = true
@@ -2597,7 +2712,10 @@ func (e *Engine) syncAllLocked(
 
 	// Sync Forge sessions (DB-backed, not file-based).
 	tForge := time.Now()
-	forgePending := e.syncForge(ctx)
+	var forgePending []pendingWrite
+	if scope.includesAny(e.agentDirs[parser.AgentForge]) {
+		forgePending = e.syncForge(ctx)
+	}
 	if len(forgePending) > 0 {
 		stats.TotalSessions += len(forgePending)
 		tWrite := time.Now()
@@ -2644,7 +2762,10 @@ func (e *Engine) syncAllLocked(
 			time.Since(tForge).Round(time.Millisecond),
 		)
 	}
-	advanceDBProgress(e.countDBBackedProgressTotal(parser.AgentForge), forgePending)
+	advanceDBProgress(
+		e.countDBBackedProgressTotal(parser.AgentForge, scope),
+		forgePending,
+	)
 
 	if ctx.Err() != nil {
 		stats.Aborted = true
@@ -2653,7 +2774,10 @@ func (e *Engine) syncAllLocked(
 
 	// Sync Piebald sessions (DB-backed, not file-based).
 	tPiebald := time.Now()
-	piebaldPending := e.syncPiebald(ctx)
+	var piebaldPending []pendingWrite
+	if scope.includesAny(e.agentDirs[parser.AgentPiebald]) {
+		piebaldPending = e.syncPiebald(ctx)
+	}
 	if len(piebaldPending) > 0 {
 		stats.TotalSessions += len(piebaldPending)
 		tWrite := time.Now()
@@ -2697,7 +2821,10 @@ func (e *Engine) syncAllLocked(
 			time.Since(tPiebald).Round(time.Millisecond),
 		)
 	}
-	advanceDBProgress(e.countDBBackedProgressTotal(parser.AgentPiebald), piebaldPending)
+	advanceDBProgress(
+		e.countDBBackedProgressTotal(parser.AgentPiebald, scope),
+		piebaldPending,
+	)
 
 	if ctx.Err() != nil {
 		stats.Aborted = true
@@ -2998,10 +3125,12 @@ func (e *Engine) countOneOpenCodeFormatSessions(
 	return count
 }
 
-func (e *Engine) countDBBackedProgressTotal(agent parser.AgentType) int {
+func (e *Engine) countDBBackedProgressTotal(
+	agent parser.AgentType, scope *rootSyncScope,
+) int {
 	total := 0
 	for _, dir := range e.agentDirs[agent] {
-		if dir == "" {
+		if dir == "" || !scope.includes(dir) {
 			continue
 		}
 		switch agent {
@@ -3020,52 +3149,23 @@ func (e *Engine) countDBBackedProgressTotal(agent parser.AgentType) int {
 	return total
 }
 
-func (e *Engine) countDBBackedSessions(ctx context.Context) int {
+func (e *Engine) countDBBackedSessions(
+	ctx context.Context, scope *rootSyncScope,
+) int {
 	if ctx.Err() != nil {
 		return 0
 	}
 	total := 0
-	for _, dir := range e.agentDirs[parser.AgentKiro] {
-		if dir == "" {
-			continue
-		}
-		total += e.countOneKiroSQLiteSessions(dir)
-	}
-	for _, dir := range e.agentDirs[parser.AgentOpenCode] {
-		if dir == "" {
-			continue
-		}
-		total += e.countOneOpenCodeFormatSessions(parser.AgentOpenCode, dir)
-	}
-	for _, dir := range e.agentDirs[parser.AgentKilo] {
-		if dir == "" {
-			continue
-		}
-		total += e.countOneOpenCodeFormatSessions(parser.AgentKilo, dir)
-	}
-	for _, dir := range e.agentDirs[parser.AgentMiMoCode] {
-		if dir == "" {
-			continue
-		}
-		total += e.countOneOpenCodeFormatSessions(parser.AgentMiMoCode, dir)
-	}
-	for _, dir := range e.agentDirs[parser.AgentWarp] {
-		if dir == "" {
-			continue
-		}
-		total += e.countOneWarpSessions(dir)
-	}
-	for _, dir := range e.agentDirs[parser.AgentForge] {
-		if dir == "" {
-			continue
-		}
-		total += e.countOneForgeSessions(dir)
-	}
-	for _, dir := range e.agentDirs[parser.AgentPiebald] {
-		if dir == "" {
-			continue
-		}
-		total += e.countOnePiebaldSessions(dir)
+	for _, agent := range []parser.AgentType{
+		parser.AgentKiro,
+		parser.AgentOpenCode,
+		parser.AgentKilo,
+		parser.AgentMiMoCode,
+		parser.AgentWarp,
+		parser.AgentForge,
+		parser.AgentPiebald,
+	} {
+		total += e.countDBBackedProgressTotal(agent, scope)
 	}
 	return total
 }
@@ -3279,7 +3379,8 @@ func (e *Engine) syncOneOpenCodeFormat(
 // context was cancelled so the caller can mark the sync aborted.
 func (e *Engine) syncOpenCodeFormatAgent(
 	ctx context.Context, agent parser.AgentType, label string,
-	writeMode syncWriteMode, verbose bool, stats *SyncStats,
+	writeMode syncWriteMode, verbose bool, scope *rootSyncScope,
+	stats *SyncStats,
 	advanceDBProgress func(total int, pending []pendingWrite),
 ) bool {
 	start := time.Now()
@@ -3330,7 +3431,7 @@ func (e *Engine) syncOpenCodeFormatAgent(
 			label, time.Since(start).Round(time.Millisecond),
 		)
 	}
-	advanceDBProgress(e.countDBBackedProgressTotal(agent), pending)
+	advanceDBProgress(e.countDBBackedProgressTotal(agent, scope), pending)
 	return ctx.Err() != nil
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2402,24 +2402,16 @@ func (s *rootSyncScope) includes(dir string) bool {
 		return false
 	}
 	cleaned := cleanRootPath(dir)
-	for _, root := range s.roots {
-		if samePathOrDescendant(cleaned, root) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(s.roots, func(root string) bool {
+		return samePathOrDescendant(cleaned, root)
+	})
 }
 
 func (s *rootSyncScope) includesAny(dirs []string) bool {
 	if s == nil {
 		return true
 	}
-	for _, dir := range dirs {
-		if s.includes(dir) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(dirs, s.includes)
 }
 
 func cleanRootPath(path string) string {
@@ -2477,7 +2469,7 @@ func (e *Engine) syncAllLocked(
 	}
 
 	all = dedupeDiscoveredFiles(all)
-	all = e.filterShadowedLegacyKiroFiles(all)
+	all = e.filterShadowedLegacyKiroFiles(all, scope)
 
 	verbose := onProgress == nil
 
@@ -2559,7 +2551,7 @@ func (e *Engine) syncAllLocked(
 	tKiro := time.Now()
 	var kiroPending []pendingWrite
 	if scope.includesAny(e.agentDirs[parser.AgentKiro]) {
-		kiroPending = e.syncKiroSQLite(ctx)
+		kiroPending = e.syncKiroSQLite(ctx, scope)
 	}
 	if len(kiroPending) > 0 {
 		stats.TotalSessions += len(kiroPending)
@@ -2652,7 +2644,7 @@ func (e *Engine) syncAllLocked(
 	tWarp := time.Now()
 	var warpPending []pendingWrite
 	if scope.includesAny(e.agentDirs[parser.AgentWarp]) {
-		warpPending = e.syncWarp(ctx)
+		warpPending = e.syncWarp(ctx, scope)
 	}
 	if len(warpPending) > 0 {
 		stats.TotalSessions += len(warpPending)
@@ -2714,7 +2706,7 @@ func (e *Engine) syncAllLocked(
 	tForge := time.Now()
 	var forgePending []pendingWrite
 	if scope.includesAny(e.agentDirs[parser.AgentForge]) {
-		forgePending = e.syncForge(ctx)
+		forgePending = e.syncForge(ctx, scope)
 	}
 	if len(forgePending) > 0 {
 		stats.TotalSessions += len(forgePending)
@@ -2776,7 +2768,7 @@ func (e *Engine) syncAllLocked(
 	tPiebald := time.Now()
 	var piebaldPending []pendingWrite
 	if scope.includesAny(e.agentDirs[parser.AgentPiebald]) {
-		piebaldPending = e.syncPiebald(ctx)
+		piebaldPending = e.syncPiebald(ctx, scope)
 	}
 	if len(piebaldPending) > 0 {
 		stats.TotalSessions += len(piebaldPending)
@@ -3171,10 +3163,13 @@ func (e *Engine) countDBBackedSessions(
 }
 
 func (e *Engine) filterShadowedLegacyKiroFiles(
-	files []parser.DiscoveredFile,
+	files []parser.DiscoveredFile, scope *rootSyncScope,
 ) []parser.DiscoveredFile {
 	currentIDs := make(map[string]struct{})
 	for _, dir := range e.agentDirs[parser.AgentKiro] {
+		if !scope.includes(dir) {
+			continue
+		}
 		for id := range parser.KiroSQLiteSessionIDs(dir) {
 			currentIDs[id] = struct{}{}
 		}
@@ -3253,14 +3248,14 @@ func (e *Engine) countOneKiroSQLiteSessions(dir string) int {
 }
 
 func (e *Engine) syncKiroSQLite(
-	ctx context.Context,
+	ctx context.Context, scope *rootSyncScope,
 ) []pendingWrite {
 	var allPending []pendingWrite
 	for _, dir := range e.agentDirs[parser.AgentKiro] {
 		if ctx.Err() != nil {
 			break
 		}
-		if dir == "" {
+		if dir == "" || !scope.includes(dir) {
 			continue
 		}
 		allPending = append(
@@ -3321,14 +3316,14 @@ func (e *Engine) syncOneKiroSQLite(
 // time_updated to detect changes, so only modified sessions are fully
 // parsed. Returns pending writes.
 func (e *Engine) syncOpenCodeFormat(
-	ctx context.Context, agent parser.AgentType,
+	ctx context.Context, agent parser.AgentType, scope *rootSyncScope,
 ) []pendingWrite {
 	var allPending []pendingWrite
 	for _, dir := range e.agentDirs[agent] {
 		if ctx.Err() != nil {
 			break
 		}
-		if dir == "" {
+		if dir == "" || !scope.includes(dir) {
 			continue
 		}
 		allPending = append(
@@ -3384,7 +3379,7 @@ func (e *Engine) syncOpenCodeFormatAgent(
 	advanceDBProgress func(total int, pending []pendingWrite),
 ) bool {
 	start := time.Now()
-	pending := e.syncOpenCodeFormat(ctx, agent)
+	pending := e.syncOpenCodeFormat(ctx, agent, scope)
 	if len(pending) > 0 {
 		stats.TotalSessions += len(pending)
 		tWrite := time.Now()
@@ -8628,14 +8623,14 @@ func (e *Engine) countOneWarpSessions(dir string) int {
 // Uses per-conversation last_modified_at to detect changes,
 // so only modified conversations are fully parsed.
 func (e *Engine) syncWarp(
-	ctx context.Context,
+	ctx context.Context, scope *rootSyncScope,
 ) []pendingWrite {
 	var allPending []pendingWrite
 	for _, dir := range e.agentDirs[parser.AgentWarp] {
 		if ctx.Err() != nil {
 			break
 		}
-		if dir == "" {
+		if dir == "" || !scope.includes(dir) {
 			continue
 		}
 		allPending = append(
@@ -8763,14 +8758,14 @@ func (e *Engine) countOneForgeSessions(dir string) int {
 
 // syncForge syncs sessions from Forge SQLite databases.
 func (e *Engine) syncForge(
-	ctx context.Context,
+	ctx context.Context, scope *rootSyncScope,
 ) []pendingWrite {
 	var allPending []pendingWrite
 	for _, dir := range e.agentDirs[parser.AgentForge] {
 		if ctx.Err() != nil {
 			break
 		}
-		if dir == "" {
+		if dir == "" || !scope.includes(dir) {
 			continue
 		}
 		allPending = append(allPending, e.syncOneForge(ctx, dir)...)
@@ -8886,14 +8881,14 @@ func (e *Engine) countOnePiebaldSessions(dir string) int {
 
 // syncPiebald syncs sessions from Piebald SQLite databases.
 func (e *Engine) syncPiebald(
-	ctx context.Context,
+	ctx context.Context, scope *rootSyncScope,
 ) []pendingWrite {
 	var allPending []pendingWrite
 	for _, dir := range e.agentDirs[parser.AgentPiebald] {
 		if ctx.Err() != nil {
 			break
 		}
-		if dir == "" {
+		if dir == "" || !scope.includes(dir) {
 			continue
 		}
 		allPending = append(allPending, e.syncOnePiebald(ctx, dir)...)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3169,6 +3169,10 @@ func (e *Engine) countDBBackedSessions(
 func (e *Engine) filterShadowedLegacyKiroFiles(
 	files []parser.DiscoveredFile,
 ) []parser.DiscoveredFile {
+	if !hasLegacyKiroCandidates(files) {
+		return files
+	}
+
 	currentIDs := make(map[string]struct{})
 	for _, dir := range e.agentDirs[parser.AgentKiro] {
 		for id := range parser.KiroSQLiteSessionIDs(dir) {
@@ -3193,6 +3197,16 @@ func (e *Engine) filterShadowedLegacyKiroFiles(
 		out = append(out, file)
 	}
 	return out
+}
+
+func hasLegacyKiroCandidates(files []parser.DiscoveredFile) bool {
+	for _, file := range files {
+		if file.Agent == parser.AgentKiro &&
+			filepath.Base(file.Path) != "data.sqlite3" {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *Engine) isShadowedLegacyKiroPath(path string) bool {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -7253,6 +7253,44 @@ func TestSyncRootsSinceScopesDiscoveredFiles(t *testing.T) {
 	assert.Equal(t, "root b", *page.Sessions[0].FirstMessage)
 }
 
+func TestSyncRootsSinceScopesOpenCodeSQLiteRoots(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	env := setupTestEnv(t, WithOpenCodeDirs([]string{rootA, rootB}))
+
+	ocA := createOpenCodeDB(t, rootA)
+	ocA.addProject(t, "proj-a", "/home/user/code/root-a")
+	ocA.addSession(t, "oc-root-a", "proj-a", 1704067200000, 1704067205000)
+	ocA.addMessage(t, "msg-a-user", "oc-root-a", "user", 1704067200000)
+	ocA.addTextPart(
+		t, "part-a-user", "oc-root-a", "msg-a-user", "root a",
+		1704067200000,
+	)
+
+	ocB := createOpenCodeDB(t, rootB)
+	ocB.addProject(t, "proj-b", "/home/user/code/root-b")
+	ocB.addSession(t, "oc-root-b", "proj-b", 1704067200000, 1704067205000)
+	ocB.addMessage(t, "msg-b-user", "oc-root-b", "user", 1704067200000)
+	ocB.addTextPart(
+		t, "part-b-user", "oc-root-b", "msg-b-user", "root b",
+		1704067200000,
+	)
+
+	stats := env.engine.SyncRootsSince(
+		context.Background(), []string{rootB}, time.Time{}, nil,
+	)
+	assert.Equal(t, 1, stats.TotalSessions, "total sessions")
+	assert.Equal(t, 1, stats.Synced, "synced sessions")
+
+	page, err := env.db.ListSessions(
+		context.Background(), db.SessionFilter{Limit: 10},
+	)
+	require.NoError(t, err, "list sessions")
+	require.Len(t, page.Sessions, 1, "sessions")
+	require.NotNil(t, page.Sessions[0].FirstMessage, "first message")
+	assert.Equal(t, "root b", *page.Sessions[0].FirstMessage)
+}
+
 func TestSyncAll_PersistsStartedAndFinishedAt(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -334,6 +334,28 @@ func TestSyncEngineKiroSQLiteCurrentStoreShadowsLegacy(t *testing.T) {
 	require.Contains(t, *sess.FilePath, "data.sqlite3#overlap-session", "legacy event replaced sqlite-backed session: %+v", sess)
 }
 
+func TestSyncRootsSinceKiroLegacyShadowedBySQLiteOutsideScope(t *testing.T) {
+	legacyRoot := t.TempDir()
+	sqliteRoot := t.TempDir()
+	env := setupTestEnv(t, WithKiroDirs([]string{legacyRoot, sqliteRoot}))
+
+	ks := createKiroSQLiteDB(t, sqliteRoot)
+	ks.addSession(
+		t, "/home/user/code/current-kiro", "overlap-session",
+		readKiroSQLiteFixture(t, "overlap_payload.json"),
+		1779015600000, 1779015610000,
+	)
+	writeLegacyKiroSession(
+		t, legacyRoot, "overlap-session",
+		"legacy should not be imported",
+	)
+
+	stats := env.engine.SyncRootsSince(
+		context.Background(), []string{legacyRoot}, time.Time{}, nil,
+	)
+	assert.Equal(t, 0, stats.TotalSessions, "total sessions")
+}
+
 func TestSyncEngineKiroLegacyOnlySyncPath(t *testing.T) {
 	env := setupTestEnv(t)
 	writeLegacyKiroSession(

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -7291,6 +7291,45 @@ func TestSyncRootsSinceScopesOpenCodeSQLiteRoots(t *testing.T) {
 	assert.Equal(t, "root b", *page.Sessions[0].FirstMessage)
 }
 
+func TestSyncRootsSinceDoesNotAdvanceGlobalWatermark(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{rootA, rootB}))
+
+	watermark := time.Now().Add(-24 * time.Hour).UTC()
+	require.NoError(t, env.db.SetSyncState(
+		"last_sync_started_at",
+		watermark.Format(time.RFC3339Nano),
+	), "seed last_sync_started_at")
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "root a").
+		String()
+	pathA := env.writeSession(
+		t, rootA, filepath.Join("proj-a", "root-a.jsonl"), content,
+	)
+	fileTime := watermark.Add(time.Hour)
+	require.NoError(t, os.Chtimes(pathA, fileTime, fileTime), "chtimes root a")
+
+	env.engine.SyncRootsSince(
+		context.Background(), []string{rootB}, watermark, nil,
+	)
+
+	stats := env.engine.SyncAllSince(
+		context.Background(), env.engine.LastSyncStartedAt(), nil,
+	)
+	assert.Equal(t, 1, stats.TotalSessions, "total sessions")
+	assert.Equal(t, 1, stats.Synced, "synced sessions")
+
+	page, err := env.db.ListSessions(
+		context.Background(), db.SessionFilter{Limit: 10},
+	)
+	require.NoError(t, err, "list sessions")
+	require.Len(t, page.Sessions, 1, "sessions")
+	require.NotNil(t, page.Sessions[0].FirstMessage, "first message")
+	assert.Equal(t, "root a", *page.Sessions[0].FirstMessage)
+}
+
 func TestSyncAll_PersistsStartedAndFinishedAt(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -7212,6 +7212,47 @@ func TestSyncAllSince_FiltersByMtime(t *testing.T) {
 	_ = newPath
 }
 
+func TestSyncRootsSinceScopesDiscoveredFiles(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{rootA, rootB}))
+
+	contentA := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "root a").
+		String()
+	pathA := env.writeSession(
+		t, rootA, filepath.Join("proj-a", "root-a.jsonl"), contentA,
+	)
+
+	contentB := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "root b").
+		String()
+	pathB := env.writeSession(
+		t, rootB, filepath.Join("proj-b", "root-b.jsonl"), contentB,
+	)
+
+	longAgo := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(pathA, longAgo, longAgo), "chtimes root a")
+	require.NoError(t, os.Chtimes(pathB, longAgo, longAgo), "chtimes root b")
+
+	cutoff := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(pathB, time.Now(), time.Now()), "touch root b")
+
+	stats := env.engine.SyncRootsSince(
+		context.Background(), []string{rootB}, cutoff, nil,
+	)
+	assert.Equal(t, 1, stats.TotalSessions, "total sessions")
+	assert.Equal(t, 1, stats.Synced, "synced sessions")
+
+	page, err := env.db.ListSessions(
+		context.Background(), db.SessionFilter{Limit: 10},
+	)
+	require.NoError(t, err, "list sessions")
+	require.Len(t, page.Sessions, 1, "sessions")
+	require.NotNil(t, page.Sessions[0].FirstMessage, "first message")
+	assert.Equal(t, "root b", *page.Sessions[0].FirstMessage)
+}
+
 func TestSyncAll_PersistsStartedAndFinishedAt(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -48,6 +48,46 @@ func (f fakeFileInfo) ModTime() time.Time {
 func (f fakeFileInfo) IsDir() bool { return false }
 func (f fakeFileInfo) Sys() any    { return nil }
 
+func TestHasLegacyKiroCandidates(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []parser.DiscoveredFile
+		want  bool
+	}{
+		{
+			name: "empty",
+			want: false,
+		},
+		{
+			name: "non-kiro files",
+			files: []parser.DiscoveredFile{
+				{Agent: parser.AgentClaude, Path: "/tmp/claude/session.jsonl"},
+			},
+			want: false,
+		},
+		{
+			name: "kiro sqlite database source",
+			files: []parser.DiscoveredFile{
+				{Agent: parser.AgentKiro, Path: "/tmp/kiro/data.sqlite3"},
+			},
+			want: false,
+		},
+		{
+			name: "legacy kiro jsonl",
+			files: []parser.DiscoveredFile{
+				{Agent: parser.AgentKiro, Path: "/tmp/kiro/session.jsonl"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasLegacyKiroCandidates(tt.files))
+		})
+	}
+}
+
 func TestFilterEmptyMessages(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -83,7 +83,7 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 	// fan one db path out to every contained session under forceParse.
 	files = append(files, e.parseDiffDatabaseSources(resolved)...)
 	files = dedupeDiscoveredFiles(files)
-	files = e.filterShadowedLegacyKiroFiles(files)
+	files = e.filterShadowedLegacyKiroFiles(files, nil)
 
 	// Newest first by source mtime (composite stats for virtual
 	// paths), tie-broken by path so the --limit sample is stable.

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -83,7 +83,7 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 	// fan one db path out to every contained session under forceParse.
 	files = append(files, e.parseDiffDatabaseSources(resolved)...)
 	files = dedupeDiscoveredFiles(files)
-	files = e.filterShadowedLegacyKiroFiles(files, nil)
+	files = e.filterShadowedLegacyKiroFiles(files)
 
 	// Newest first by source mtime (composite stats for virtual
 	// paths), tie-broken by path so the --limit sample is stable.


### PR DESCRIPTION
This PR stops the unwatched-root fallback from re-running a global sync every two minutes.

It adds SyncRootsSince, which keeps the existing incremental mtime cutoff behavior while limiting discovery to the roots reported as unwatched by the file watcher. The existing full sync and full resync paths remain unscoped.

The startup poller now uses the recorded last-sync start time with a small safety margin, so watcher-budget exhaustion polls only the affected roots. The watcher-unavailable all sentinel still falls back to the previous global behavior.