### PR TITLE
feat(session list): add --sort/--reverse (and ?order_by/?descending)

### DIFF
--- a/cmd/agentsview/session_list.go
+++ b/cmd/agentsview/session_list.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/db"
@@ -25,6 +26,8 @@ func newSessionListCommand() *cobra.Command {
 		hasSecret                               bool
 		cursor                                  string
 		limit                                   int
+		sort                                    string
+		reverse                                 bool
 	)
 	cmd := &cobra.Command{
 		Use:          "list",
@@ -58,9 +61,16 @@ func newSessionListCommand() *cobra.Command {
 				HasSecret:        hasSecret,
 				Cursor:           cursor,
 				Limit:            limit,
+				OrderBy:          sort,
 			}
 			if cmd.Flags().Changed("min-tool-failures") {
 				f.MinToolFailures = &minToolFailures
+			}
+			// --reverse flips the sort key's canonical direction; leave
+			// Descending nil otherwise so the default applies.
+			if cmd.Flags().Changed("reverse") {
+				d := db.SortDefaultDescending(sort) != reverse
+				f.Descending = &d
 			}
 
 			list, err := svc.List(cmd.Context(), f)
@@ -118,6 +128,10 @@ func newSessionListCommand() *cobra.Command {
 			"Maximum sessions to return (default %d, max %d)",
 			db.DefaultSessionLimit, db.MaxSessionLimit,
 		))
+	flags.StringVar(&sort, "sort", "recent",
+		"Sort by: "+strings.Join(db.SortKeys(), ", "))
+	flags.BoolVarP(&reverse, "reverse", "r", false,
+		"Reverse the sort direction")
 
 	return cmd
 }

--- a/cmd/agentsview/sort_test.go
+++ b/cmd/agentsview/sort_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// sessionListIDs decodes `session list --format json` output into ordered IDs.
+func sessionListIDs(t *testing.T, out string) []string {
+	t.Helper()
+	var got struct {
+		Sessions []struct {
+			ID string `json:"id"`
+		} `json:"sessions"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got),
+		"stdout should be valid JSON: %q", out)
+	ids := make([]string, len(got.Sessions))
+	for i, s := range got.Sessions {
+		ids[i] = s.ID
+	}
+	return ids
+}
+
+func TestSessionList_SortAndReverse(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedSessionWithOpts(t, dataDir, "lo", "p", func(s *db.Session) { s.MessageCount = 2 })
+	seedSessionWithOpts(t, dataDir, "mid", "p", func(s *db.Session) { s.MessageCount = 5 })
+	seedSessionWithOpts(t, dataDir, "hi", "p", func(s *db.Session) { s.MessageCount = 9 })
+
+	// --sort messages defaults to ascending.
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--sort", "messages", "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"lo", "mid", "hi"}, sessionListIDs(t, out))
+
+	// --reverse flips it to descending.
+	out, err = executeCommand(newRootCommand(),
+		"session", "list", "--sort", "messages", "--reverse", "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"hi", "mid", "lo"}, sessionListIDs(t, out))
+
+	// -r is the shorthand for --reverse.
+	out, err = executeCommand(newRootCommand(),
+		"session", "list", "--sort", "messages", "-r", "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"hi", "mid", "lo"}, sessionListIDs(t, out))
+}
+
+func TestSessionList_InvalidSort(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedSession(t, dataDir, "s-a", "p")
+
+	_, err := executeCommand(newRootCommand(),
+		"session", "list", "--sort", "bogus", "--format", "json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid sort")
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2240,17 +2240,17 @@ func TestGetSessionFull(t *testing.T) {
 
 func TestCursorEncodeDecode(t *testing.T) {
 	d := testDB(t)
-	encoded := d.EncodeCursor(tsZero, "session-1")
+	encoded := d.EncodeCursor(SessionCursor{EndedAt: tsZero, ID: "session-1"})
 	cur, err := d.DecodeCursor(encoded)
 	requireNoError(t, err, "DecodeCursor")
 	assert.Equal(t, tsZero, cur.EndedAt, "EndedAt")
 	assert.Equal(t, "session-1", cur.ID, "ID")
 
-	encodedWithTotal := d.EncodeCursor(
-		tsZero,
-		"session-1",
-		123,
-	)
+	encodedWithTotal := d.EncodeCursor(SessionCursor{
+		EndedAt: tsZero,
+		ID:      "session-1",
+		Total:   123,
+	})
 	cur, err = d.DecodeCursor(encodedWithTotal)
 	requireNoError(t, err, "DecodeCursor with total")
 	assert.Equal(t, 123, cur.Total, "Total")
@@ -2259,7 +2259,7 @@ func TestCursorEncodeDecode(t *testing.T) {
 func TestCursorTampering(t *testing.T) {
 	d := testDB(t)
 	// 1. Create a valid signed cursor
-	original := d.EncodeCursor(tsZero, "s1", 100)
+	original := d.EncodeCursor(SessionCursor{EndedAt: tsZero, ID: "s1", Total: 100})
 
 	parts := strings.Split(original, ".")
 	require.Len(t, parts, 2, "expected 2 parts (payload.sig)")
@@ -2330,15 +2330,15 @@ func TestCursorSecretConcurrency(t *testing.T) {
 					)
 					d.SetCursorSecret(secret)
 				case 1:
-					d.EncodeCursor(
-						tsZero,
-						fmt.Sprintf("s-%d-%d", id, j),
-						42,
-					)
+					d.EncodeCursor(SessionCursor{
+						EndedAt: tsZero,
+						ID:      fmt.Sprintf("s-%d-%d", id, j),
+						Total:   42,
+					})
 				case 2:
-					encoded := d.EncodeCursor(
-						tsZero, "s1",
-					)
+					encoded := d.EncodeCursor(SessionCursor{
+						EndedAt: tsZero, ID: "s1",
+					})
 					// Decode may fail if secret rotated
 					// between encode and decode; that's OK.
 					_, err := d.DecodeCursor(encoded)
@@ -2360,7 +2360,7 @@ func TestSetCursorSecretDefensiveCopy(t *testing.T) {
 	secret := []byte("my-secret-key-for-testing-copy!!")
 	d.SetCursorSecret(secret)
 
-	encoded := d.EncodeCursor(tsZero, "s1")
+	encoded := d.EncodeCursor(SessionCursor{EndedAt: tsZero, ID: "s1"})
 
 	// Mutate the original slice — should not affect the DB.
 	for i := range secret {

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -255,9 +255,10 @@ func (d QueryDialect) timestampExpr(col string) string {
 
 // OrderByClause renders the session-list ordering for a resolved sort and
 // direction, with id as a same-direction tie-breaker so keyset pagination is
-// deterministic.
-func (b *QueryBuilder) OrderByClause(sp SessionSort, desc bool) string {
-	orderExpr := sp.orderExpr(b.dialect, desc)
+// deterministic. The sort expression may add bind parameters (secrets sort), so
+// callers must render this at its textual position.
+func (b *QueryBuilder) OrderByClause(sp SessionSort, desc bool, f SessionFilter) string {
+	orderExpr := sp.orderExpr(b, desc, f)
 	dir := "ASC"
 	if desc {
 		dir = "DESC"
@@ -273,9 +274,9 @@ func (b *QueryBuilder) OrderByClause(sp SessionSort, desc bool) string {
 // per dialect for the column's kind; it must already be the Go type produced by
 // SessionSort.CursorPredicateValue.
 func (b *QueryBuilder) CursorPredicate(
-	sp SessionSort, desc bool, value any, id string,
+	sp SessionSort, desc bool, f SessionFilter, value any, id string,
 ) string {
-	orderExpr := sp.orderExpr(b.dialect, desc)
+	orderExpr := sp.orderExpr(b, desc, f)
 	op := ">"
 	if desc {
 		op = "<"

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -28,16 +28,22 @@ const (
 // ORM: callers still own SELECTs, JOINs, backend-specific search paths, and
 // table schemas.
 type QueryDialect struct {
-	name                        string
-	placeholderStyle            placeholderStyle
-	trueLiteral                 string
-	falseLiteral                string
-	dateExpr                    string
-	dateParam                   func(string) string
-	activityExpr                string
-	activityParam               func(string) string
-	cursorActivityExpr          string
-	cursorParam                 func(string) string
+	name               string
+	placeholderStyle   placeholderStyle
+	trueLiteral        string
+	falseLiteral       string
+	dateExpr           string
+	dateParam          func(string) string
+	activityExpr       string
+	activityParam      func(string) string
+	cursorActivityExpr string
+	cursorParam        func(string) string
+	// castCursor wraps a placeholder with the type cast a keyset cursor value of
+	// the given kind needs in this dialect.
+	castCursor func(string, valueKind) string
+	// emptyStringIsNull is true for backends (SQLite) that store unset
+	// timestamps as empty strings rather than SQL NULL.
+	emptyStringIsNull           bool
 	terminationExpr             string
 	terminationKind             timestampKind
 	caseInsensitiveLike         string
@@ -62,6 +68,8 @@ func SQLiteQueryDialect() QueryDialect {
 		activityParam:          func(ph string) string { return ph },
 		cursorActivityExpr:     "COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at)",
 		cursorParam:            func(ph string) string { return ph },
+		castCursor:             func(ph string, _ valueKind) string { return ph },
+		emptyStringIsNull:      true,
 		terminationExpr:        activityExprSQLite,
 		terminationKind:        timestampUnixSeconds,
 		caseInsensitiveLike:    "LIKE",
@@ -93,6 +101,7 @@ func PostgresQueryDialect() QueryDialect {
 		cursorParam: func(ph string) string {
 			return ph + "::timestamptz"
 		},
+		castCursor:             pgCastCursor,
 		terminationExpr:        "COALESCE(ended_at, started_at, created_at)",
 		terminationKind:        timestampTimestamptz,
 		caseInsensitiveLike:    "ILIKE",
@@ -124,6 +133,7 @@ func DuckDBQueryDialect() QueryDialect {
 		cursorParam: func(ph string) string {
 			return "CAST(" + ph + " AS TIMESTAMP)"
 		},
+		castCursor:             duckCastCursor,
 		terminationExpr:        "COALESCE(ended_at, started_at, created_at)",
 		terminationKind:        timestampCast,
 		caseInsensitiveLike:    "ILIKE",
@@ -205,6 +215,77 @@ func (b *QueryBuilder) CursorBeforePredicate(cur SessionCursor) string {
 	ea := b.dialect.cursorParam(b.Add(cur.EndedAt))
 	id := b.Add(cur.ID)
 	return "(" + b.dialect.cursorActivityExpr + ", id) < (" + ea + ", " + id + ")"
+}
+
+func pgCastCursor(ph string, kind valueKind) string {
+	switch kind {
+	case kindTimestamp:
+		return ph + "::timestamptz"
+	case kindInt:
+		return ph + "::bigint"
+	case kindReal:
+		return ph + "::double precision"
+	default:
+		return ph
+	}
+}
+
+func duckCastCursor(ph string, kind valueKind) string {
+	switch kind {
+	case kindTimestamp:
+		return "CAST(" + ph + " AS TIMESTAMP)"
+	case kindInt:
+		return "CAST(" + ph + " AS BIGINT)"
+	case kindReal:
+		return "CAST(" + ph + " AS DOUBLE)"
+	default:
+		return ph
+	}
+}
+
+// timestampExpr returns a column reference that treats unset timestamps as NULL.
+// SQLite stores empty strings for missing timestamps; other backends use real
+// NULLs, so the column reference passes through unchanged.
+func (d QueryDialect) timestampExpr(col string) string {
+	if d.emptyStringIsNull {
+		return "NULLIF(" + col + ", '')"
+	}
+	return col
+}
+
+// OrderByClause renders the session-list ordering for a resolved sort and
+// direction, with id as a same-direction tie-breaker so keyset pagination is
+// deterministic.
+func (b *QueryBuilder) OrderByClause(sp SessionSort, desc bool) string {
+	orderExpr := sp.orderExpr(b.dialect, desc)
+	dir := "ASC"
+	if desc {
+		dir = "DESC"
+	}
+	if orderExpr == "id" {
+		return "ORDER BY id " + dir
+	}
+	return "ORDER BY " + orderExpr + " " + dir + ", id " + dir
+}
+
+// CursorPredicate renders the keyset pagination predicate matching an
+// OrderByClause built from the same sort and direction. The bound value is cast
+// per dialect for the column's kind; it must already be the Go type produced by
+// SessionSort.CursorPredicateValue.
+func (b *QueryBuilder) CursorPredicate(
+	sp SessionSort, desc bool, value any, id string,
+) string {
+	orderExpr := sp.orderExpr(b.dialect, desc)
+	op := ">"
+	if desc {
+		op = "<"
+	}
+	if orderExpr == "id" {
+		return "id " + op + " " + b.dialect.castCursor(b.Add(id), kindText)
+	}
+	vp := b.dialect.castCursor(b.Add(value), sp.kind)
+	ip := b.Add(id)
+	return "(" + orderExpr + ", id) " + op + " (" + vp + ", " + ip + ")"
 }
 
 // LimitOffset renders a parameterized LIMIT/OFFSET clause.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -203,20 +203,25 @@ type Session struct {
 	CreatedAt         string  `json:"created_at"`
 }
 
-// SessionCursor is the opaque pagination token.
+// SessionCursor is the opaque pagination token. EndedAt carries the
+// recent-activity value for the default sort (and legacy cursors); Sort/Desc/
+// Value generalize keyset pagination to any --sort column. New fields are
+// additive so cursors minted before they existed still decode as recent.
 type SessionCursor struct {
 	EndedAt string `json:"e"`
 	ID      string `json:"i"`
 	Total   int    `json:"t,omitempty"`
+	// Sort is the sort key the cursor was minted under ("" = legacy recent).
+	Sort string `json:"k,omitempty"`
+	// Desc is the direction the cursor was minted under.
+	Desc bool `json:"d,omitempty"`
+	// Value is the sort column's value for the page's last row, encoded as a
+	// string and re-typed per the sort's kind when comparing.
+	Value string `json:"v,omitempty"`
 }
 
-// EncodeCursor returns a base64-encoded cursor string.
-func (db *DB) EncodeCursor(endedAt, id string, total ...int) string {
-	t := 0
-	if len(total) > 0 {
-		t = total[0]
-	}
-	c := SessionCursor{EndedAt: endedAt, ID: id, Total: t}
+// EncodeCursor returns a base64-encoded, HMAC-signed cursor string.
+func (db *DB) EncodeCursor(c SessionCursor) string {
 	data, _ := json.Marshal(c)
 
 	db.cursorMu.RLock()
@@ -314,6 +319,11 @@ type SessionFilter struct {
 	//   "unclean"    → only sessions with status IN
 	//                  ('tool_call_pending', 'truncated')
 	Termination string
+	// OrderBy selects the sort column ("" = recent activity, the default).
+	// Valid keys are enumerated by SortKeys / ValidSortKey.
+	OrderBy string
+	// Descending overrides the sort key's canonical direction when non-nil.
+	Descending *bool
 }
 
 // activeWindow is the freshness window for "active" sessions
@@ -425,6 +435,10 @@ func (db *DB) ListSessions(
 
 	where, args := buildSessionFilter(f)
 
+	dialect := SQLiteQueryDialect()
+	sp, _ := SessionSortFor(f.OrderBy)
+	desc := sp.ResolveDescending(f.Descending)
+
 	var total int
 	var cur SessionCursor
 	if f.Cursor != "" {
@@ -450,21 +464,22 @@ func (db *DB) ListSessions(
 
 	// Paginated results
 	cursorArgs := append([]any{}, args...)
-	pageBuilder := NewQueryBuilder(SQLiteQueryDialect(), len(args))
+	pageBuilder := NewQueryBuilder(dialect, len(args))
 	cursorWhere := where
 	if f.Cursor != "" {
-		cursorWhere += " AND " +
-			pageBuilder.CursorBeforePredicate(cur)
+		val, err := sp.CursorPredicateValue(cur, desc)
+		if err != nil {
+			return SessionPage{}, err
+		}
+		cursorWhere += " AND " + pageBuilder.CursorPredicate(
+			sp, desc, val, cur.ID,
+		)
 	}
 
 	query := "SELECT " + sessionBaseCols +
-		" FROM sessions WHERE " + cursorWhere + `
-		ORDER BY COALESCE(
-			NULLIF(ended_at, ''),
-			NULLIF(started_at, ''),
-			created_at
-		) DESC, id DESC
-		` + pageBuilder.Limit(f.Limit+1)
+		" FROM sessions WHERE " + cursorWhere + " " +
+		pageBuilder.OrderByClause(sp, desc) + " " +
+		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 
 	rows, err := db.getReader().QueryContext(ctx, query, cursorArgs...)
@@ -483,14 +498,9 @@ func (db *DB) ListSessions(
 	if len(sessions) > f.Limit {
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
-		ea := last.CreatedAt
-		if last.StartedAt != nil && *last.StartedAt != "" {
-			ea = *last.StartedAt
-		}
-		if last.EndedAt != nil && *last.EndedAt != "" {
-			ea = *last.EndedAt
-		}
-		page.NextCursor = db.EncodeCursor(ea, last.ID, total)
+		page.NextCursor = db.EncodeCursor(
+			sp.NextCursor(&last, desc, total),
+		)
 	}
 
 	return page, nil
@@ -720,7 +730,9 @@ func (db *DB) getSidebarSessionIndexPage(
 	if len(roots) > f.Limit {
 		selected = roots[:f.Limit]
 		last := selected[f.Limit-1]
-		index.NextCursor = db.EncodeCursor(last.activity, last.id, total)
+		index.NextCursor = db.EncodeCursor(SessionCursor{
+			EndedAt: last.activity, ID: last.id, Total: total,
+		})
 	}
 
 	cteParts := make([]string, 0, len(selected))

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -472,13 +472,13 @@ func (db *DB) ListSessions(
 			return SessionPage{}, err
 		}
 		cursorWhere += " AND " + pageBuilder.CursorPredicate(
-			sp, desc, val, cur.ID,
+			sp, desc, f, val, cur.ID,
 		)
 	}
 
 	query := "SELECT " + sessionBaseCols +
 		" FROM sessions WHERE " + cursorWhere + " " +
-		pageBuilder.OrderByClause(sp, desc) + " " +
+		pageBuilder.OrderByClause(sp, desc, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 
@@ -499,7 +499,7 @@ func (db *DB) ListSessions(
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
 		page.NextCursor = db.EncodeCursor(
-			sp.NextCursor(&last, desc, total),
+			sp.NextCursor(&last, desc, total, f),
 		)
 	}
 

--- a/internal/db/sort.go
+++ b/internal/db/sort.go
@@ -1,0 +1,297 @@
+// ABOUTME: session-list sort registry — maps the public --sort/?order_by keys
+// ABOUTME: to dialect-aware ORDER BY expressions and keyset cursor values.
+package db
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// valueKind classifies a sort column's value so the keyset cursor can bind it
+// with the right Go type and per-dialect cast. SQLite relies on this to avoid
+// type-affinity surprises (an integer column compared against a bound string
+// always sorts below it); PostgreSQL relies on it for ::bigint / ::timestamptz
+// casts on numbered placeholders.
+type valueKind int
+
+const (
+	kindTimestamp valueKind = iota // ISO-8601 text / timestamptz
+	kindInt
+	kindReal
+	kindText
+)
+
+// Sentinels make a nullable sort column non-null inside the keyset comparison
+// so the row-value predicate is always well-defined and NULLs land last in both
+// directions, identically across backends. They sit far outside any real value;
+// the SQL literal and the Go value must be numerically equal (string form is
+// internal to the cursor token).
+const (
+	sentinelIntDescSQL  = "-9223372036854775808" // math.MinInt64
+	sentinelIntAscSQL   = "9223372036854775807"  // math.MaxInt64
+	sentinelRealDescSQL = "-1e18"
+	sentinelRealAscSQL  = "1e18"
+)
+
+// SessionSort describes one orderable column for `session list`. It is exported
+// so the PostgreSQL and DuckDB stores render ordering and keyset pagination from
+// this single source of truth rather than duplicating ORDER BY strings.
+type SessionSort struct {
+	key               string
+	kind              valueKind
+	defaultDescending bool
+	// nullable marks columns with no natural non-null fallback (health,
+	// context-pressure); their order expression is wrapped in a direction-aware
+	// sentinel COALESCE so NULLs sort last.
+	nullable bool
+	// baseExpr returns the (possibly nullable) SQL expression for this sort in
+	// the given dialect. Timestamp sorts use the dialect's empty-string-aware
+	// wrapping; everything else is a plain column name shared across backends.
+	baseExpr func(d QueryDialect) string
+	// value returns the row's sort value formatted as the cursor stores it, plus
+	// ok=false when the underlying column is NULL.
+	value func(s *Session) (string, bool)
+}
+
+// orderExpr renders the non-null SQL expression used in both ORDER BY and the
+// keyset cursor predicate for the resolved direction.
+func (sp SessionSort) orderExpr(d QueryDialect, desc bool) string {
+	e := sp.baseExpr(d)
+	if sp.nullable {
+		e = "COALESCE(" + e + ", " + sentinelLiteral(sp.kind, desc) + ")"
+	}
+	return e
+}
+
+// cursorValue returns the string-encoded comparison value for a page's last
+// row, substituting the matching sentinel when the column is NULL.
+func (sp SessionSort) cursorValue(s *Session, desc bool) string {
+	if v, ok := sp.value(s); ok {
+		return v
+	}
+	return sentinelGoString(sp.kind, desc)
+}
+
+// ResolveDescending returns the effective direction: the key's canonical default
+// unless the caller supplied an explicit override.
+func (sp SessionSort) ResolveDescending(descending *bool) bool {
+	if descending != nil {
+		return *descending
+	}
+	return sp.defaultDescending
+}
+
+// NextCursor builds the pagination token for a page's last row under the
+// resolved sort and direction.
+func (sp SessionSort) NextCursor(last *Session, desc bool, total int) SessionCursor {
+	v := sp.cursorValue(last, desc)
+	cur := SessionCursor{
+		ID:    last.ID,
+		Total: total,
+		Sort:  sp.key,
+		Desc:  desc,
+		Value: v,
+	}
+	if sp.key == defaultSortKey {
+		// Keep the legacy field populated so default-sort cursors remain
+		// decodable by older readers during a rollout.
+		cur.EndedAt = v
+	}
+	return cur
+}
+
+// CursorPredicateValue validates a decoded cursor against the resolved sort and
+// returns the typed value the keyset predicate must bind. A cursor minted under
+// a different sort/direction, or with an unparseable value, is rejected as an
+// invalid cursor rather than silently producing wrong pages.
+func (sp SessionSort) CursorPredicateValue(cur SessionCursor, desc bool) (any, error) {
+	if !sp.cursorMatches(cur, desc) {
+		return nil, fmt.Errorf("%w: sort mismatch", ErrInvalidCursor)
+	}
+	raw := cur.Value
+	if cur.Sort == "" {
+		raw = cur.EndedAt
+	}
+	v, err := typedCursorValue(raw, sp.kind)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCursor, err)
+	}
+	return v, nil
+}
+
+// cursorMatches reports whether a decoded cursor was minted under the resolved
+// sort and direction. Legacy cursors (no Sort) are only valid for the default
+// recent-descending order they were always created under.
+func (sp SessionSort) cursorMatches(cur SessionCursor, desc bool) bool {
+	if cur.Sort == "" {
+		return sp.key == defaultSortKey && desc
+	}
+	return cur.Sort == sp.key && cur.Desc == desc
+}
+
+func sentinelLiteral(kind valueKind, desc bool) string {
+	switch kind {
+	case kindReal:
+		if desc {
+			return sentinelRealDescSQL
+		}
+		return sentinelRealAscSQL
+	default:
+		if desc {
+			return sentinelIntDescSQL
+		}
+		return sentinelIntAscSQL
+	}
+}
+
+// sentinelGoString returns the cursor-encoded form of the sentinel, numerically
+// equal to sentinelLiteral so a NULL row's cursor compares equal to a NULL row's
+// COALESCE result on the next page.
+func sentinelGoString(kind valueKind, desc bool) string {
+	switch kind {
+	case kindReal:
+		if desc {
+			return strconv.FormatFloat(-1e18, 'g', -1, 64)
+		}
+		return strconv.FormatFloat(1e18, 'g', -1, 64)
+	default:
+		if desc {
+			return strconv.FormatInt(math.MinInt64, 10)
+		}
+		return strconv.FormatInt(math.MaxInt64, 10)
+	}
+}
+
+// typedCursorValue parses a cursor's string value into the Go type the keyset
+// comparison must bind for this kind. A malformed value is reported so callers
+// can surface ErrInvalidCursor rather than a query error.
+func typedCursorValue(value string, kind valueKind) (any, error) {
+	switch kind {
+	case kindInt:
+		return strconv.ParseInt(value, 10, 64)
+	case kindReal:
+		return strconv.ParseFloat(value, 64)
+	default:
+		return value, nil
+	}
+}
+
+func tsValue(s *Session) (string, bool) {
+	v := s.CreatedAt
+	if s.StartedAt != nil && *s.StartedAt != "" {
+		v = *s.StartedAt
+	}
+	if s.EndedAt != nil && *s.EndedAt != "" {
+		v = *s.EndedAt
+	}
+	return v, true
+}
+
+func startedValue(s *Session) (string, bool) {
+	if s.StartedAt != nil && *s.StartedAt != "" {
+		return *s.StartedAt, true
+	}
+	return s.CreatedAt, true
+}
+
+func intValue(get func(*Session) int) func(*Session) (string, bool) {
+	return func(s *Session) (string, bool) {
+		return strconv.Itoa(get(s)), true
+	}
+}
+
+func recentExpr(d QueryDialect) string {
+	return "COALESCE(" + d.timestampExpr("ended_at") + ", " +
+		d.timestampExpr("started_at") + ", created_at)"
+}
+
+func startedExpr(d QueryDialect) string {
+	return "COALESCE(" + d.timestampExpr("started_at") + ", created_at)"
+}
+
+func plainExpr(col string) func(QueryDialect) string {
+	return func(QueryDialect) string { return col }
+}
+
+// sessionSorts is the allow-list of session-list sort keys, in display order.
+// The ordering is kept in sync with the huma `order_by` enum tag by
+// TestSortKeysMatchHumaEnum.
+var sessionSorts = []SessionSort{
+	{key: "recent", kind: kindTimestamp, defaultDescending: true, baseExpr: recentExpr, value: tsValue},
+	{key: "started", kind: kindTimestamp, baseExpr: startedExpr, value: startedValue},
+	{key: "messages", kind: kindInt, baseExpr: plainExpr("message_count"), value: intValue(func(s *Session) int { return s.MessageCount })},
+	{key: "user-messages", kind: kindInt, baseExpr: plainExpr("user_message_count"), value: intValue(func(s *Session) int { return s.UserMessageCount })},
+	{key: "output-tokens", kind: kindInt, baseExpr: plainExpr("total_output_tokens"), value: intValue(func(s *Session) int { return s.TotalOutputTokens })},
+	{key: "peak-context", kind: kindInt, baseExpr: plainExpr("peak_context_tokens"), value: intValue(func(s *Session) int { return s.PeakContextTokens })},
+	{key: "failures", kind: kindInt, baseExpr: plainExpr("tool_failure_signal_count"), value: intValue(func(s *Session) int { return s.ToolFailureSignalCount })},
+	{key: "retries", kind: kindInt, baseExpr: plainExpr("tool_retry_count"), value: intValue(func(s *Session) int { return s.ToolRetryCount })},
+	{key: "edit-churn", kind: kindInt, baseExpr: plainExpr("edit_churn_count"), value: intValue(func(s *Session) int { return s.EditChurnCount })},
+	{key: "compactions", kind: kindInt, baseExpr: plainExpr("compaction_count"), value: intValue(func(s *Session) int { return s.CompactionCount })},
+	{key: "context-pressure", kind: kindReal, nullable: true, baseExpr: plainExpr("context_pressure_max"), value: func(s *Session) (string, bool) {
+		if s.ContextPressureMax == nil {
+			return "", false
+		}
+		return strconv.FormatFloat(*s.ContextPressureMax, 'g', -1, 64), true
+	}},
+	{key: "health", kind: kindInt, nullable: true, baseExpr: plainExpr("health_score"), value: func(s *Session) (string, bool) {
+		if s.HealthScore == nil {
+			return "", false
+		}
+		return strconv.Itoa(*s.HealthScore), true
+	}},
+	{key: "secrets", kind: kindInt, baseExpr: plainExpr("secret_leak_count"), value: intValue(func(s *Session) int { return s.SecretLeakCount })},
+	{key: "id", kind: kindText, baseExpr: plainExpr("id"), value: func(s *Session) (string, bool) { return s.ID, true }},
+}
+
+var sessionSortByKey = func() map[string]SessionSort {
+	m := make(map[string]SessionSort, len(sessionSorts))
+	for _, s := range sessionSorts {
+		m[s.key] = s
+	}
+	return m
+}()
+
+// defaultSortKey is the sort applied when OrderBy is empty; it preserves the
+// historical most-recent-activity-first behavior.
+const defaultSortKey = "recent"
+
+// SessionSortFor resolves a sort key (empty means the default). ok is false for
+// unknown keys; callers that have not pre-validated should treat that as the
+// default rather than erroring, so the store never panics on bad input.
+func SessionSortFor(key string) (SessionSort, bool) {
+	if key == "" {
+		return sessionSortByKey[defaultSortKey], true
+	}
+	sp, ok := sessionSortByKey[key]
+	if !ok {
+		return sessionSortByKey[defaultSortKey], false
+	}
+	return sp, true
+}
+
+// ValidSortKey reports whether key is an accepted session-list sort (empty is
+// accepted and means the default).
+func ValidSortKey(key string) bool {
+	if key == "" {
+		return true
+	}
+	_, ok := sessionSortByKey[key]
+	return ok
+}
+
+// SortDefaultDescending returns the canonical direction for a sort key, used by
+// the CLI to translate --reverse (flip) into an absolute Descending value.
+func SortDefaultDescending(key string) bool {
+	sp, _ := SessionSortFor(key)
+	return sp.defaultDescending
+}
+
+// SortKeys returns the accepted sort keys in display order.
+func SortKeys() []string {
+	keys := make([]string, len(sessionSorts))
+	for i, s := range sessionSorts {
+		keys[i] = s.key
+	}
+	return keys
+}

--- a/internal/db/sort.go
+++ b/internal/db/sort.go
@@ -5,6 +5,7 @@ package db
 import (
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 )
 
@@ -45,19 +46,23 @@ type SessionSort struct {
 	// context-pressure); their order expression is wrapped in a direction-aware
 	// sentinel COALESCE so NULLs sort last.
 	nullable bool
-	// baseExpr returns the (possibly nullable) SQL expression for this sort in
-	// the given dialect. Timestamp sorts use the dialect's empty-string-aware
-	// wrapping; everything else is a plain column name shared across backends.
-	baseExpr func(d QueryDialect) string
+	// expr renders the (possibly nullable) SQL expression for this sort. It
+	// receives the builder so the secrets sort can add bind parameters for its
+	// version-aware CASE, and the filter so it can mirror the active scanner
+	// rule versions. Timestamp sorts use the dialect's empty-string-aware
+	// wrapping; most sorts are a plain column name shared across backends.
+	expr func(b *QueryBuilder, f SessionFilter) string
 	// value returns the row's sort value formatted as the cursor stores it, plus
-	// ok=false when the underlying column is NULL.
-	value func(s *Session) (string, bool)
+	// ok=false when the underlying column is NULL. It receives the filter so the
+	// secrets sort encodes the same version-gated value it sorts by.
+	value func(s *Session, f SessionFilter) (string, bool)
 }
 
 // orderExpr renders the non-null SQL expression used in both ORDER BY and the
-// keyset cursor predicate for the resolved direction.
-func (sp SessionSort) orderExpr(d QueryDialect, desc bool) string {
-	e := sp.baseExpr(d)
+// keyset cursor predicate for the resolved direction. It may add bind
+// parameters to b, so callers must render it at its textual position.
+func (sp SessionSort) orderExpr(b *QueryBuilder, desc bool, f SessionFilter) string {
+	e := sp.expr(b, f)
 	if sp.nullable {
 		e = "COALESCE(" + e + ", " + sentinelLiteral(sp.kind, desc) + ")"
 	}
@@ -66,8 +71,8 @@ func (sp SessionSort) orderExpr(d QueryDialect, desc bool) string {
 
 // cursorValue returns the string-encoded comparison value for a page's last
 // row, substituting the matching sentinel when the column is NULL.
-func (sp SessionSort) cursorValue(s *Session, desc bool) string {
-	if v, ok := sp.value(s); ok {
+func (sp SessionSort) cursorValue(s *Session, desc bool, f SessionFilter) string {
+	if v, ok := sp.value(s, f); ok {
 		return v
 	}
 	return sentinelGoString(sp.kind, desc)
@@ -84,8 +89,8 @@ func (sp SessionSort) ResolveDescending(descending *bool) bool {
 
 // NextCursor builds the pagination token for a page's last row under the
 // resolved sort and direction.
-func (sp SessionSort) NextCursor(last *Session, desc bool, total int) SessionCursor {
-	v := sp.cursorValue(last, desc)
+func (sp SessionSort) NextCursor(last *Session, desc bool, total int, f SessionFilter) SessionCursor {
+	v := sp.cursorValue(last, desc, f)
 	cur := SessionCursor{
 		ID:    last.ID,
 		Total: total,
@@ -177,7 +182,7 @@ func typedCursorValue(value string, kind valueKind) (any, error) {
 	}
 }
 
-func tsValue(s *Session) (string, bool) {
+func tsValue(s *Session, _ SessionFilter) (string, bool) {
 	v := s.CreatedAt
 	if s.StartedAt != nil && *s.StartedAt != "" {
 		v = *s.StartedAt
@@ -188,60 +193,83 @@ func tsValue(s *Session) (string, bool) {
 	return v, true
 }
 
-func startedValue(s *Session) (string, bool) {
+func startedValue(s *Session, _ SessionFilter) (string, bool) {
 	if s.StartedAt != nil && *s.StartedAt != "" {
 		return *s.StartedAt, true
 	}
 	return s.CreatedAt, true
 }
 
-func intValue(get func(*Session) int) func(*Session) (string, bool) {
-	return func(s *Session) (string, bool) {
+func intValue(get func(*Session) int) func(*Session, SessionFilter) (string, bool) {
+	return func(s *Session, _ SessionFilter) (string, bool) {
 		return strconv.Itoa(get(s)), true
 	}
 }
 
-func recentExpr(d QueryDialect) string {
-	return "COALESCE(" + d.timestampExpr("ended_at") + ", " +
-		d.timestampExpr("started_at") + ", created_at)"
+func recentExpr(b *QueryBuilder, _ SessionFilter) string {
+	return "COALESCE(" + b.dialect.timestampExpr("ended_at") + ", " +
+		b.dialect.timestampExpr("started_at") + ", created_at)"
 }
 
-func startedExpr(d QueryDialect) string {
-	return "COALESCE(" + d.timestampExpr("started_at") + ", created_at)"
+func startedExpr(b *QueryBuilder, _ SessionFilter) string {
+	return "COALESCE(" + b.dialect.timestampExpr("started_at") + ", created_at)"
 }
 
-func plainExpr(col string) func(QueryDialect) string {
-	return func(QueryDialect) string { return col }
+func plainExpr(col string) func(*QueryBuilder, SessionFilter) string {
+	return func(*QueryBuilder, SessionFilter) string { return col }
+}
+
+// secretsExpr orders by the same secret count the service layer displays: when
+// active scanner rule versions are known, counts from stale versions are gated
+// to 0 (matching hideStaleSecretCount), so sessions shown with 0 secrets do not
+// rank above sessions with current findings. With no versions (raw db callers),
+// it falls back to the raw column, mirroring the HasSecret filter's convention.
+func secretsExpr(b *QueryBuilder, f SessionFilter) string {
+	versions := nonEmpty(f.SecretsRulesVersions)
+	if len(versions) == 0 {
+		return "secret_leak_count"
+	}
+	return "CASE WHEN " + inPredicate("secrets_rules_version", versions, b) +
+		" THEN secret_leak_count ELSE 0 END"
+}
+
+func secretsValue(s *Session, f SessionFilter) (string, bool) {
+	n := s.SecretLeakCount
+	versions := nonEmpty(f.SecretsRulesVersions)
+	if len(versions) > 0 && !slices.Contains(versions, s.SecretsRulesVersion) {
+		n = 0
+	}
+	return strconv.Itoa(n), true
 }
 
 // sessionSorts is the allow-list of session-list sort keys, in display order.
 // The ordering is kept in sync with the huma `order_by` enum tag by
 // TestSortKeysMatchHumaEnum.
 var sessionSorts = []SessionSort{
-	{key: "recent", kind: kindTimestamp, defaultDescending: true, baseExpr: recentExpr, value: tsValue},
-	{key: "started", kind: kindTimestamp, baseExpr: startedExpr, value: startedValue},
-	{key: "messages", kind: kindInt, baseExpr: plainExpr("message_count"), value: intValue(func(s *Session) int { return s.MessageCount })},
-	{key: "user-messages", kind: kindInt, baseExpr: plainExpr("user_message_count"), value: intValue(func(s *Session) int { return s.UserMessageCount })},
-	{key: "output-tokens", kind: kindInt, baseExpr: plainExpr("total_output_tokens"), value: intValue(func(s *Session) int { return s.TotalOutputTokens })},
-	{key: "peak-context", kind: kindInt, baseExpr: plainExpr("peak_context_tokens"), value: intValue(func(s *Session) int { return s.PeakContextTokens })},
-	{key: "failures", kind: kindInt, baseExpr: plainExpr("tool_failure_signal_count"), value: intValue(func(s *Session) int { return s.ToolFailureSignalCount })},
-	{key: "retries", kind: kindInt, baseExpr: plainExpr("tool_retry_count"), value: intValue(func(s *Session) int { return s.ToolRetryCount })},
-	{key: "edit-churn", kind: kindInt, baseExpr: plainExpr("edit_churn_count"), value: intValue(func(s *Session) int { return s.EditChurnCount })},
-	{key: "compactions", kind: kindInt, baseExpr: plainExpr("compaction_count"), value: intValue(func(s *Session) int { return s.CompactionCount })},
-	{key: "context-pressure", kind: kindReal, nullable: true, baseExpr: plainExpr("context_pressure_max"), value: func(s *Session) (string, bool) {
+	{key: "recent", kind: kindTimestamp, defaultDescending: true, expr: recentExpr, value: tsValue},
+	{key: "started", kind: kindTimestamp, expr: startedExpr, value: startedValue},
+	{key: "messages", kind: kindInt, expr: plainExpr("message_count"), value: intValue(func(s *Session) int { return s.MessageCount })},
+	{key: "user-messages", kind: kindInt, expr: plainExpr("user_message_count"), value: intValue(func(s *Session) int { return s.UserMessageCount })},
+	{key: "output-tokens", kind: kindInt, expr: plainExpr("total_output_tokens"), value: intValue(func(s *Session) int { return s.TotalOutputTokens })},
+	{key: "peak-context", kind: kindInt, expr: plainExpr("peak_context_tokens"), value: intValue(func(s *Session) int { return s.PeakContextTokens })},
+	{key: "failures", kind: kindInt, expr: plainExpr("tool_failure_signal_count"), value: intValue(func(s *Session) int { return s.ToolFailureSignalCount })},
+	{key: "retries", kind: kindInt, expr: plainExpr("tool_retry_count"), value: intValue(func(s *Session) int { return s.ToolRetryCount })},
+	{key: "edit-churn", kind: kindInt, expr: plainExpr("edit_churn_count"), value: intValue(func(s *Session) int { return s.EditChurnCount })},
+	{key: "compactions", kind: kindInt, expr: plainExpr("compaction_count"), value: intValue(func(s *Session) int { return s.CompactionCount })},
+	{key: "context-pressure", kind: kindReal, nullable: true, expr: plainExpr("context_pressure_max"), value: func(s *Session, _ SessionFilter) (string, bool) {
 		if s.ContextPressureMax == nil {
 			return "", false
 		}
 		return strconv.FormatFloat(*s.ContextPressureMax, 'g', -1, 64), true
 	}},
-	{key: "health", kind: kindInt, nullable: true, baseExpr: plainExpr("health_score"), value: func(s *Session) (string, bool) {
+	{key: "health", kind: kindInt, nullable: true, expr: plainExpr("health_score"), value: func(s *Session, _ SessionFilter) (string, bool) {
 		if s.HealthScore == nil {
 			return "", false
 		}
 		return strconv.Itoa(*s.HealthScore), true
 	}},
-	{key: "secrets", kind: kindInt, baseExpr: plainExpr("secret_leak_count"), value: intValue(func(s *Session) int { return s.SecretLeakCount })},
-	{key: "id", kind: kindText, baseExpr: plainExpr("id"), value: func(s *Session) (string, bool) { return s.ID, true }},
+	{key: "secrets", kind: kindInt, expr: secretsExpr, value: secretsValue},
+	{key: "id", kind: kindText, expr: plainExpr("id"), value: func(s *Session, _ SessionFilter) (string, bool) { return s.ID, true }},
 }
 
 var sessionSortByKey = func() map[string]SessionSort {

--- a/internal/db/sort_test.go
+++ b/internal/db/sort_test.go
@@ -373,9 +373,10 @@ func TestListSessions_CursorSortMismatch(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidCursor, "flipped-direction cursor")
 }
 
-// TestListSessions_LegacyCursorRecent confirms a default-sort cursor still
-// paginates the recent order (backward compatibility for cursors minted before
-// the sort fields existed).
+// TestListSessions_LegacyCursorRecent confirms a cursor minted in the old shape
+// (only EndedAt/ID/Total, no Sort/Desc/Value) still paginates the recent order.
+// This exercises the cur.Sort == "" backward-compatibility path directly, rather
+// than a cursor produced by the current implementation.
 func TestListSessions_LegacyCursorRecent(t *testing.T) {
 	d := testDB(t)
 	for i := 1; i <= 4; i++ {
@@ -386,10 +387,20 @@ func TestListSessions_LegacyCursorRecent(t *testing.T) {
 	page1, err := d.ListSessions(context.Background(), SessionFilter{Limit: 2})
 	require.NoError(t, err)
 	require.Equal(t, []string{"rc4", "rc3"}, idsOf(page1.Sessions))
-	require.NotEmpty(t, page1.NextCursor)
+
+	// Mint a legacy-shaped cursor by hand: no Sort/Desc/Value fields, just the
+	// activity timestamp + id + total a pre-sort build would have produced.
+	legacy := d.EncodeCursor(SessionCursor{
+		EndedAt: "2024-03-01T00:00:00Z",
+		ID:      "rc3",
+		Total:   page1.Total,
+	})
+	cur, err := d.DecodeCursor(legacy)
+	require.NoError(t, err)
+	require.Empty(t, cur.Sort, "legacy cursor must carry no sort key")
 
 	page2, err := d.ListSessions(context.Background(), SessionFilter{
-		Limit: 2, Cursor: page1.NextCursor,
+		Limit: 2, Cursor: legacy,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"rc2", "rc1"}, idsOf(page2.Sessions))

--- a/internal/db/sort_test.go
+++ b/internal/db/sort_test.go
@@ -1,0 +1,470 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// listSortedIDs returns the session IDs in the order ListSessions returns them.
+func listSortedIDs(t *testing.T, d *DB, f SessionFilter) []string {
+	t.Helper()
+	page, err := d.ListSessions(context.Background(), f)
+	require.NoError(t, err, "ListSessions")
+	ids := make([]string, len(page.Sessions))
+	for i, s := range page.Sessions {
+		ids[i] = s.ID
+	}
+	return ids
+}
+
+// TestListSessions_SortAscDesc covers each sort key in both directions using an
+// explicit absolute Descending so the default-direction logic is exercised
+// separately (TestListSessions_SortDefaultDirection).
+func TestListSessions_SortAscDesc(t *testing.T) {
+	cases := []struct {
+		name    string
+		orderBy string
+		setup   func(t *testing.T, d *DB)
+		// wantAsc is the order with Descending=false; desc is its reverse.
+		wantAsc []string
+	}{
+		{
+			name:    "recent",
+			orderBy: "recent",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "r-old", "p", func(s *Session) { s.EndedAt = Ptr("2024-01-01T00:00:00Z") })
+				insertSession(t, d, "r-mid", "p", func(s *Session) { s.EndedAt = Ptr("2024-02-01T00:00:00Z") })
+				insertSession(t, d, "r-new", "p", func(s *Session) { s.EndedAt = Ptr("2024-03-01T00:00:00Z") })
+			},
+			wantAsc: []string{"r-old", "r-mid", "r-new"},
+		},
+		{
+			name:    "started",
+			orderBy: "started",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "s-old", "p", func(s *Session) { s.StartedAt = Ptr("2024-01-01T00:00:00Z") })
+				insertSession(t, d, "s-mid", "p", func(s *Session) { s.StartedAt = Ptr("2024-02-01T00:00:00Z") })
+				insertSession(t, d, "s-new", "p", func(s *Session) { s.StartedAt = Ptr("2024-03-01T00:00:00Z") })
+			},
+			wantAsc: []string{"s-old", "s-mid", "s-new"},
+		},
+		{
+			name:    "messages",
+			orderBy: "messages",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "m1", "p", func(s *Session) { s.MessageCount = 1 })
+				insertSession(t, d, "m5", "p", func(s *Session) { s.MessageCount = 5 })
+				insertSession(t, d, "m9", "p", func(s *Session) { s.MessageCount = 9 })
+			},
+			wantAsc: []string{"m1", "m5", "m9"},
+		},
+		{
+			name:    "user-messages",
+			orderBy: "user-messages",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "u1", "p", func(s *Session) { s.UserMessageCount = 1 })
+				insertSession(t, d, "u4", "p", func(s *Session) { s.UserMessageCount = 4 })
+				insertSession(t, d, "u8", "p", func(s *Session) { s.UserMessageCount = 8 })
+			},
+			wantAsc: []string{"u1", "u4", "u8"},
+		},
+		{
+			name:    "output-tokens",
+			orderBy: "output-tokens",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "o100", "p", func(s *Session) { s.TotalOutputTokens = 100 })
+				insertSession(t, d, "o500", "p", func(s *Session) { s.TotalOutputTokens = 500 })
+				insertSession(t, d, "o900", "p", func(s *Session) { s.TotalOutputTokens = 900 })
+			},
+			wantAsc: []string{"o100", "o500", "o900"},
+		},
+		{
+			name:    "peak-context",
+			orderBy: "peak-context",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "pc1", "p", func(s *Session) { s.PeakContextTokens = 1000 })
+				insertSession(t, d, "pc2", "p", func(s *Session) { s.PeakContextTokens = 2000 })
+				insertSession(t, d, "pc3", "p", func(s *Session) { s.PeakContextTokens = 3000 })
+			},
+			wantAsc: []string{"pc1", "pc2", "pc3"},
+		},
+		{
+			name:    "failures",
+			orderBy: "failures",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "f0", "p")
+				insertSession(t, d, "f3", "p")
+				updateSignals(t, d, "f3", SessionSignalUpdate{ToolFailureSignalCount: 3})
+				insertSession(t, d, "f7", "p")
+				updateSignals(t, d, "f7", SessionSignalUpdate{ToolFailureSignalCount: 7})
+			},
+			wantAsc: []string{"f0", "f3", "f7"},
+		},
+		{
+			name:    "retries",
+			orderBy: "retries",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "rt0", "p")
+				insertSession(t, d, "rt2", "p")
+				updateSignals(t, d, "rt2", SessionSignalUpdate{ToolRetryCount: 2})
+				insertSession(t, d, "rt6", "p")
+				updateSignals(t, d, "rt6", SessionSignalUpdate{ToolRetryCount: 6})
+			},
+			wantAsc: []string{"rt0", "rt2", "rt6"},
+		},
+		{
+			name:    "edit-churn",
+			orderBy: "edit-churn",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "ec0", "p")
+				insertSession(t, d, "ec4", "p")
+				updateSignals(t, d, "ec4", SessionSignalUpdate{EditChurnCount: 4})
+				insertSession(t, d, "ec8", "p")
+				updateSignals(t, d, "ec8", SessionSignalUpdate{EditChurnCount: 8})
+			},
+			wantAsc: []string{"ec0", "ec4", "ec8"},
+		},
+		{
+			name:    "compactions",
+			orderBy: "compactions",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "c0", "p")
+				insertSession(t, d, "c1", "p")
+				updateSignals(t, d, "c1", SessionSignalUpdate{CompactionCount: 1})
+				insertSession(t, d, "c5", "p")
+				updateSignals(t, d, "c5", SessionSignalUpdate{CompactionCount: 5})
+			},
+			wantAsc: []string{"c0", "c1", "c5"},
+		},
+		{
+			name:    "context-pressure",
+			orderBy: "context-pressure",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "cp2", "p")
+				updateSignals(t, d, "cp2", SessionSignalUpdate{ContextPressureMax: Ptr(0.2)})
+				insertSession(t, d, "cp5", "p")
+				updateSignals(t, d, "cp5", SessionSignalUpdate{ContextPressureMax: Ptr(0.5)})
+				insertSession(t, d, "cp9", "p")
+				updateSignals(t, d, "cp9", SessionSignalUpdate{ContextPressureMax: Ptr(0.9)})
+			},
+			wantAsc: []string{"cp2", "cp5", "cp9"},
+		},
+		{
+			name:    "health",
+			orderBy: "health",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "h20", "p")
+				updateSignals(t, d, "h20", SessionSignalUpdate{HealthScore: Ptr(20)})
+				insertSession(t, d, "h60", "p")
+				updateSignals(t, d, "h60", SessionSignalUpdate{HealthScore: Ptr(60)})
+				insertSession(t, d, "h95", "p")
+				updateSignals(t, d, "h95", SessionSignalUpdate{HealthScore: Ptr(95)})
+			},
+			wantAsc: []string{"h20", "h60", "h95"},
+		},
+		{
+			name:    "secrets",
+			orderBy: "secrets",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "sec0", "p")
+				insertSession(t, d, "sec2", "p")
+				require.NoError(t, d.ReplaceSessionSecretFindings("sec2", nil, 2, "v1"))
+				insertSession(t, d, "sec5", "p")
+				require.NoError(t, d.ReplaceSessionSecretFindings("sec5", nil, 5, "v1"))
+			},
+			wantAsc: []string{"sec0", "sec2", "sec5"},
+		},
+		{
+			name:    "id",
+			orderBy: "id",
+			setup: func(t *testing.T, d *DB) {
+				insertSession(t, d, "id-a", "p")
+				insertSession(t, d, "id-b", "p")
+				insertSession(t, d, "id-c", "p")
+			},
+			wantAsc: []string{"id-a", "id-b", "id-c"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := testDB(t)
+			tc.setup(t, d)
+
+			gotAsc := listSortedIDs(t, d, filterWith(func(f *SessionFilter) {
+				f.OrderBy = tc.orderBy
+				f.Descending = Ptr(false)
+			}))
+			assert.Equal(t, tc.wantAsc, gotAsc, "ascending order")
+
+			wantDesc := reversed(tc.wantAsc)
+			gotDesc := listSortedIDs(t, d, filterWith(func(f *SessionFilter) {
+				f.OrderBy = tc.orderBy
+				f.Descending = Ptr(true)
+			}))
+			assert.Equal(t, wantDesc, gotDesc, "descending order")
+		})
+	}
+}
+
+func reversed(in []string) []string {
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[len(in)-1-i] = v
+	}
+	return out
+}
+
+// TestListSessions_SortDefaultDirection verifies OrderBy with a nil Descending
+// uses the sort key's canonical default: recent is descending (most recent
+// first, the historical behavior), every other key is ascending.
+func TestListSessions_SortDefaultDirection(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "a", "p", func(s *Session) {
+		s.EndedAt = Ptr("2024-01-01T00:00:00Z")
+		s.MessageCount = 1
+	})
+	insertSession(t, d, "b", "p", func(s *Session) {
+		s.EndedAt = Ptr("2024-02-01T00:00:00Z")
+		s.MessageCount = 9
+	})
+
+	// recent default: newest first.
+	assert.Equal(t, []string{"b", "a"},
+		listSortedIDs(t, d, filterWith(func(f *SessionFilter) { f.OrderBy = "recent" })))
+	// empty OrderBy behaves like recent.
+	assert.Equal(t, []string{"b", "a"},
+		listSortedIDs(t, d, filterWith(func(f *SessionFilter) {})))
+	// messages default: ascending (fewest first).
+	assert.Equal(t, []string{"a", "b"},
+		listSortedIDs(t, d, filterWith(func(f *SessionFilter) { f.OrderBy = "messages" })))
+}
+
+// TestListSessions_SortPaginationWalk paginates through a non-default sort and
+// asserts the full ordered set is returned exactly once.
+func TestListSessions_SortPaginationWalk(t *testing.T) {
+	d := testDB(t)
+	const n = 7
+	for i := 1; i <= n; i++ {
+		insertSession(t, d, fmt.Sprintf("p%02d", i), "p", func(s *Session) {
+			s.MessageCount = i * 3
+		})
+	}
+
+	for _, desc := range []bool{false, true} {
+		t.Run(fmt.Sprintf("desc=%v", desc), func(t *testing.T) {
+			var got []string
+			seen := map[string]bool{}
+			cursor := ""
+			for pages := 0; ; pages++ {
+				require.LessOrEqual(t, pages, n+1, "pagination did not terminate")
+				page, err := d.ListSessions(context.Background(), SessionFilter{
+					Limit:      2,
+					OrderBy:    "messages",
+					Descending: Ptr(desc),
+					Cursor:     cursor,
+				})
+				require.NoError(t, err, "ListSessions page")
+				for _, s := range page.Sessions {
+					require.False(t, seen[s.ID], "duplicate %s", s.ID)
+					seen[s.ID] = true
+					got = append(got, s.ID)
+				}
+				if page.NextCursor == "" {
+					break
+				}
+				cursor = page.NextCursor
+			}
+
+			want := make([]string, n)
+			for i := 1; i <= n; i++ {
+				want[i-1] = fmt.Sprintf("p%02d", i)
+			}
+			if desc {
+				want = reversed(want)
+			}
+			assert.Equal(t, want, got, "walked order")
+		})
+	}
+}
+
+// TestListSessions_SortNullsLast verifies nullable sorts (health) place NULL
+// rows last in both directions and that keyset pagination crosses the NULL
+// boundary without dropping or duplicating rows.
+func TestListSessions_SortNullsLast(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "h10", "p")
+	updateSignals(t, d, "h10", SessionSignalUpdate{HealthScore: Ptr(10)})
+	insertSession(t, d, "h90", "p")
+	updateSignals(t, d, "h90", SessionSignalUpdate{HealthScore: Ptr(90)})
+	insertSession(t, d, "hnull-a", "p") // health_score NULL
+	insertSession(t, d, "hnull-b", "p") // health_score NULL
+
+	// Ascending: non-null ascending, NULLs last (id ascending among NULLs).
+	assert.Equal(t, []string{"h10", "h90", "hnull-a", "hnull-b"},
+		listSortedIDs(t, d, filterWith(func(f *SessionFilter) {
+			f.OrderBy = "health"
+			f.Descending = Ptr(false)
+		})))
+	// Descending: non-null descending, NULLs still last (id descending among NULLs).
+	assert.Equal(t, []string{"h90", "h10", "hnull-b", "hnull-a"},
+		listSortedIDs(t, d, filterWith(func(f *SessionFilter) {
+			f.OrderBy = "health"
+			f.Descending = Ptr(true)
+		})))
+
+	// Paginate one row at a time to exercise the sentinel keyset across the
+	// null boundary.
+	var got []string
+	cursor := ""
+	for {
+		page, err := d.ListSessions(context.Background(), SessionFilter{
+			Limit: 1, OrderBy: "health", Descending: Ptr(false), Cursor: cursor,
+		})
+		require.NoError(t, err)
+		for _, s := range page.Sessions {
+			got = append(got, s.ID)
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	assert.Equal(t, []string{"h10", "h90", "hnull-a", "hnull-b"}, got, "paginated null walk")
+}
+
+// TestListSessions_CursorSortMismatch rejects a cursor reused under a different
+// sort or direction, while accepting it under the same ordering.
+func TestListSessions_CursorSortMismatch(t *testing.T) {
+	d := testDB(t)
+	for i := 1; i <= 4; i++ {
+		insertSession(t, d, fmt.Sprintf("x%d", i), "p", func(s *Session) {
+			s.MessageCount = i
+		})
+	}
+
+	page, err := d.ListSessions(context.Background(), SessionFilter{
+		Limit: 2, OrderBy: "messages", Descending: Ptr(false),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, page.NextCursor, "expected a next cursor")
+	cursor := page.NextCursor
+
+	// Same sort + direction: accepted.
+	_, err = d.ListSessions(context.Background(), SessionFilter{
+		Limit: 2, OrderBy: "messages", Descending: Ptr(false), Cursor: cursor,
+	})
+	require.NoError(t, err, "same sort should accept cursor")
+
+	// Different sort key: rejected.
+	_, err = d.ListSessions(context.Background(), SessionFilter{
+		Limit: 2, OrderBy: "failures", Descending: Ptr(false), Cursor: cursor,
+	})
+	require.ErrorIs(t, err, ErrInvalidCursor, "cross-sort cursor")
+
+	// Same sort, flipped direction: rejected.
+	_, err = d.ListSessions(context.Background(), SessionFilter{
+		Limit: 2, OrderBy: "messages", Descending: Ptr(true), Cursor: cursor,
+	})
+	require.ErrorIs(t, err, ErrInvalidCursor, "flipped-direction cursor")
+}
+
+// TestListSessions_LegacyCursorRecent confirms a default-sort cursor still
+// paginates the recent order (backward compatibility for cursors minted before
+// the sort fields existed).
+func TestListSessions_LegacyCursorRecent(t *testing.T) {
+	d := testDB(t)
+	for i := 1; i <= 4; i++ {
+		insertSession(t, d, fmt.Sprintf("rc%d", i), "p", func(s *Session) {
+			s.EndedAt = Ptr(fmt.Sprintf("2024-0%d-01T00:00:00Z", i))
+		})
+	}
+	page1, err := d.ListSessions(context.Background(), SessionFilter{Limit: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"rc4", "rc3"}, idsOf(page1.Sessions))
+	require.NotEmpty(t, page1.NextCursor)
+
+	page2, err := d.ListSessions(context.Background(), SessionFilter{
+		Limit: 2, Cursor: page1.NextCursor,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rc2", "rc1"}, idsOf(page2.Sessions))
+}
+
+func idsOf(sessions []Session) []string {
+	ids := make([]string, len(sessions))
+	for i, s := range sessions {
+		ids[i] = s.ID
+	}
+	return ids
+}
+
+// TestListSessions_SecretsSortVersionGated checks that the secrets sort matches
+// the displayed (version-gated) count, and that gating flows through the keyset
+// cursor on a paginated request.
+func TestListSessions_SecretsSortVersionGated(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "sec-cur", "p")
+	require.NoError(t, d.ReplaceSessionSecretFindings("sec-cur", nil, 5, "v1"))
+	insertSession(t, d, "sec-stale", "p")
+	require.NoError(t, d.ReplaceSessionSecretFindings("sec-stale", nil, 9, "old"))
+	insertSession(t, d, "sec-none", "p")
+
+	// With active version v1: the stale count (9) gates to 0, so the
+	// current-version session (5) ranks first descending.
+	gated := listSortedIDs(t, d, filterWith(func(f *SessionFilter) {
+		f.OrderBy = "secrets"
+		f.Descending = Ptr(true)
+		f.SecretsRulesVersions = []string{"v1"}
+	}))
+	require.Len(t, gated, 3)
+	assert.Equal(t, "sec-cur", gated[0], "current-version session ranks first")
+
+	// Without active versions: raw counts, so the stale 9 ranks first.
+	raw := listSortedIDs(t, d, filterWith(func(f *SessionFilter) {
+		f.OrderBy = "secrets"
+		f.Descending = Ptr(true)
+	}))
+	assert.Equal(t, "sec-stale", raw[0], "raw counts rank stale 9 first")
+
+	// Paginated, gated: the cursor must carry the gated value so the
+	// current-version session still leads and pages do not duplicate.
+	var got []string
+	seen := map[string]bool{}
+	cursor := ""
+	for {
+		page, err := d.ListSessions(context.Background(), SessionFilter{
+			Limit:                1,
+			OrderBy:              "secrets",
+			Descending:           Ptr(true),
+			SecretsRulesVersions: []string{"v1"},
+			Cursor:               cursor,
+		})
+		require.NoError(t, err)
+		for _, s := range page.Sessions {
+			require.False(t, seen[s.ID], "duplicate %s", s.ID)
+			seen[s.ID] = true
+			got = append(got, s.ID)
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	require.Len(t, got, 3)
+	assert.Equal(t, "sec-cur", got[0], "paginated gated order leads with current-version session")
+}
+
+func TestValidSortKeyAndDefaultDirection(t *testing.T) {
+	assert.True(t, ValidSortKey(""), "empty key is valid (default)")
+	assert.True(t, ValidSortKey("failures"))
+	assert.False(t, ValidSortKey("bogus"))
+
+	assert.True(t, SortDefaultDescending("recent"), "recent defaults descending")
+	assert.True(t, SortDefaultDescending(""), "empty key defaults to recent (descending)")
+	assert.False(t, SortDefaultDescending("messages"), "non-recent keys default ascending")
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -18,7 +18,7 @@ func (errReadOnly) Error() string { return "not available in remote mode" }
 type Store interface {
 	// Cursor pagination.
 	SetCursorSecret(secret []byte)
-	EncodeCursor(endedAt, id string, total ...int) string
+	EncodeCursor(c SessionCursor) string
 	DecodeCursor(s string) (SessionCursor, error)
 
 	// Sessions.

--- a/internal/duckdb/sort_test.go
+++ b/internal/duckdb/sort_test.go
@@ -1,0 +1,119 @@
+//go:build !(windows && arm64)
+
+package duckdb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func sortStrPtr(s string) *string { return &s }
+func sortIntPtr(i int) *int       { return &i }
+
+// syncedStoreFromWrites seeds a local SQLite DB with the given batch writes and
+// returns a DuckDB store mirroring it, so sort/keyset SQL can be exercised
+// against the DuckDB dialect (CAST placeholders, COALESCE sentinel).
+func syncedStoreFromWrites(t *testing.T, writes []db.SessionBatchWrite) *Store {
+	t.Helper()
+	ctx := context.Background()
+	local := newLocalDB(t)
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+	syncer := newTestSync(t,
+		filepath.Join(t.TempDir(), "mirror.duckdb"), local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	return NewStoreFromDB(syncer.DB())
+}
+
+func sortSeedSession(id, project, ts string, signals db.SessionSignalUpdate) db.SessionBatchWrite {
+	return db.SessionBatchWrite{
+		Session: db.Session{
+			ID:               id,
+			Project:          project,
+			Machine:          "test-machine",
+			Agent:            "claude",
+			StartedAt:        sortStrPtr(ts),
+			EndedAt:          sortStrPtr(ts),
+			MessageCount:     2,
+			UserMessageCount: 2,
+			RelationshipType: "root",
+		},
+		Signals:         signals,
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}
+}
+
+func duckWalk(t *testing.T, store *Store, f db.SessionFilter) []string {
+	t.Helper()
+	ctx := context.Background()
+	var got []string
+	seen := map[string]bool{}
+	cursor := ""
+	for {
+		f.Cursor = cursor
+		page, err := store.ListSessions(ctx, f)
+		require.NoError(t, err)
+		for _, s := range page.Sessions {
+			require.False(t, seen[s.ID], "duplicate %s", s.ID)
+			seen[s.ID] = true
+			got = append(got, s.ID)
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	return got
+}
+
+// TestDuckDBSort_SecretsVersioned mirrors the SQLite secrets-sort behavior on
+// DuckDB, including the gating CASE inside ORDER BY and the keyset cursor.
+func TestDuckDBSort_SecretsVersioned(t *testing.T) {
+	store := syncedStoreFromWrites(t, []db.SessionBatchWrite{
+		sortSeedSession("sec-cur", "sec", "2026-03-01T00:00:00Z", db.SessionSignalUpdate{
+			SecretLeakCount: 5, SecretsRulesVersion: "v1",
+		}),
+		sortSeedSession("sec-stale", "sec", "2026-03-02T00:00:00Z", db.SessionSignalUpdate{
+			SecretLeakCount: 9, SecretsRulesVersion: "old",
+		}),
+		sortSeedSession("sec-none", "sec", "2026-03-03T00:00:00Z", db.SessionSignalUpdate{}),
+	})
+
+	desc := true
+	walked := duckWalk(t, store, db.SessionFilter{
+		Project:              "sec",
+		OrderBy:              "secrets",
+		Descending:           &desc,
+		SecretsRulesVersions: []string{"v1"},
+		Limit:                1,
+	})
+	require.Len(t, walked, 3)
+	require.Equal(t, "sec-cur", walked[0],
+		"current-version session leads once the stale 9 is gated to 0")
+}
+
+// TestDuckDBSort_NullsLast mirrors the nullable-sort (health) behavior on
+// DuckDB: NULLs sort last and pagination crosses the sentinel boundary.
+func TestDuckDBSort_NullsLast(t *testing.T) {
+	store := syncedStoreFromWrites(t, []db.SessionBatchWrite{
+		sortSeedSession("h20", "health", "2026-03-01T00:00:00Z", db.SessionSignalUpdate{
+			HealthScore: sortIntPtr(20),
+		}),
+		sortSeedSession("h80", "health", "2026-03-02T00:00:00Z", db.SessionSignalUpdate{
+			HealthScore: sortIntPtr(80),
+		}),
+		sortSeedSession("hnull", "health", "2026-03-03T00:00:00Z", db.SessionSignalUpdate{}),
+	})
+
+	walked := duckWalk(t, store, db.SessionFilter{
+		Project: "health", OrderBy: "health", Limit: 1,
+	})
+	require.Equal(t, []string{"h20", "h80", "hnull"}, walked)
+}

--- a/internal/duckdb/sort_test.go
+++ b/internal/duckdb/sort_test.go
@@ -12,9 +12,6 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-func sortStrPtr(s string) *string { return &s }
-func sortIntPtr(i int) *int       { return &i }
-
 // syncedStoreFromWrites seeds a local SQLite DB with the given batch writes and
 // returns a DuckDB store mirroring it, so sort/keyset SQL can be exercised
 // against the DuckDB dialect (CAST placeholders, COALESCE sentinel).
@@ -38,8 +35,8 @@ func sortSeedSession(id, project, ts string, signals db.SessionSignalUpdate) db.
 			Project:          project,
 			Machine:          "test-machine",
 			Agent:            "claude",
-			StartedAt:        sortStrPtr(ts),
-			EndedAt:          sortStrPtr(ts),
+			StartedAt:        new(ts),
+			EndedAt:          new(ts),
 			MessageCount:     2,
 			UserMessageCount: 2,
 			RelationshipType: "root",
@@ -104,10 +101,10 @@ func TestDuckDBSort_SecretsVersioned(t *testing.T) {
 func TestDuckDBSort_NullsLast(t *testing.T) {
 	store := syncedStoreFromWrites(t, []db.SessionBatchWrite{
 		sortSeedSession("h20", "health", "2026-03-01T00:00:00Z", db.SessionSignalUpdate{
-			HealthScore: sortIntPtr(20),
+			HealthScore: new(20),
 		}),
 		sortSeedSession("h80", "health", "2026-03-02T00:00:00Z", db.SessionSignalUpdate{
-			HealthScore: sortIntPtr(80),
+			HealthScore: new(80),
 		}),
 		sortSeedSession("hnull", "health", "2026-03-03T00:00:00Z", db.SessionSignalUpdate{}),
 	})

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -239,11 +239,11 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		if err != nil {
 			return db.SessionPage{}, err
 		}
-		cursorWhere += " AND " + pageBuilder.CursorPredicate(sp, desc, val, cur.ID)
+		cursorWhere += " AND " + pageBuilder.CursorPredicate(sp, desc, f, val, cur.ID)
 	}
 	query := "SELECT " + duckSessionCols +
 		" FROM sessions WHERE " + cursorWhere + " " +
-		pageBuilder.OrderByClause(sp, desc) + " " +
+		pageBuilder.OrderByClause(sp, desc, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 	rows, err := s.duck.QueryContext(ctx, query, cursorArgs...)
@@ -259,7 +259,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 	if len(sessions) > f.Limit {
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
-		page.NextCursor = s.EncodeCursor(sp.NextCursor(&last, desc, total))
+		page.NextCursor = s.EncodeCursor(sp.NextCursor(&last, desc, total, f))
 	}
 	return page, nil
 }

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -154,12 +154,7 @@ func formatDBTime(v any) string {
 	}
 }
 
-func (s *Store) EncodeCursor(endedAt, id string, total ...int) string {
-	t := 0
-	if len(total) > 0 {
-		t = total[0]
-	}
-	c := db.SessionCursor{EndedAt: endedAt, ID: id, Total: t}
+func (s *Store) EncodeCursor(c db.SessionCursor) string {
 	data, _ := json.Marshal(c)
 	s.cursorMu.RLock()
 	secret := append([]byte(nil), s.cursorSecret...)
@@ -216,6 +211,8 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		f.Limit = db.DefaultSessionLimit
 	}
 	where, args := db.BuildSessionFilterSQL(f, db.DuckDBQueryDialect())
+	sp, _ := db.SessionSortFor(f.OrderBy)
+	desc := sp.ResolveDescending(f.Descending)
 	total := 0
 	var cur db.SessionCursor
 	if f.Cursor != "" {
@@ -238,12 +235,16 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 	pageBuilder := db.NewQueryBuilder(db.DuckDBQueryDialect(), len(args))
 	cursorWhere := where
 	if f.Cursor != "" {
-		cursorWhere += " AND " + pageBuilder.CursorBeforePredicate(cur)
+		val, err := sp.CursorPredicateValue(cur, desc)
+		if err != nil {
+			return db.SessionPage{}, err
+		}
+		cursorWhere += " AND " + pageBuilder.CursorPredicate(sp, desc, val, cur.ID)
 	}
 	query := "SELECT " + duckSessionCols +
-		" FROM sessions WHERE " + cursorWhere + `
-		ORDER BY COALESCE(ended_at, started_at, created_at) DESC, id DESC
-		` + pageBuilder.Limit(f.Limit+1)
+		" FROM sessions WHERE " + cursorWhere + " " +
+		pageBuilder.OrderByClause(sp, desc) + " " +
+		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 	rows, err := s.duck.QueryContext(ctx, query, cursorArgs...)
 	if err != nil {
@@ -258,14 +259,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 	if len(sessions) > f.Limit {
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
-		ea := last.CreatedAt
-		if last.StartedAt != nil && *last.StartedAt != "" {
-			ea = *last.StartedAt
-		}
-		if last.EndedAt != nil && *last.EndedAt != "" {
-			ea = *last.EndedAt
-		}
-		page.NextCursor = s.EncodeCursor(ea, last.ID, total)
+		page.NextCursor = s.EncodeCursor(sp.NextCursor(&last, desc, total))
 	}
 	return page, nil
 }

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -58,6 +58,22 @@ func duckContractSessionsCursorsAndMetadata(
 	require.Equal(t, 2, next.Total)
 	require.Equal(t, []string{fixture.alphaID}, duckSessionIDs(next.Sessions))
 
+	// Sorting by a non-default column (messages, ascending by default) and its
+	// keyset cursor must render on DuckDB: beta has 1 message, alpha has 2.
+	byMsgs, err := store.ListSessions(ctx, db.SessionFilter{OrderBy: "messages", Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, []string{fixture.betaID, fixture.alphaID}, duckSessionIDs(byMsgs.Sessions))
+
+	msgPage1, err := store.ListSessions(ctx, db.SessionFilter{OrderBy: "messages", Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, []string{fixture.betaID}, duckSessionIDs(msgPage1.Sessions))
+	require.NotEmpty(t, msgPage1.NextCursor)
+	msgPage2, err := store.ListSessions(ctx, db.SessionFilter{
+		OrderBy: "messages", Limit: 1, Cursor: msgPage1.NextCursor,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{fixture.alphaID}, duckSessionIDs(msgPage2.Sessions))
+
 	alpha, err := store.GetSession(ctx, fixture.alphaID)
 	require.NoError(t, err)
 	require.NotNil(t, alpha)

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -373,13 +373,13 @@ func (s *Store) ListSessions(
 			return db.SessionPage{}, err
 		}
 		cursorWhere += " AND " + pageBuilder.CursorPredicate(
-			sp, desc, val, cur.ID,
+			sp, desc, f, val, cur.ID,
 		)
 	}
 
 	query := "SELECT " + pgSessionCols +
 		" FROM sessions WHERE " + cursorWhere + " " +
-		pageBuilder.OrderByClause(sp, desc) + " " +
+		pageBuilder.OrderByClause(sp, desc, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 
@@ -404,7 +404,7 @@ func (s *Store) ListSessions(
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
 		page.NextCursor = s.EncodeCursor(
-			sp.NextCursor(&last, desc, total),
+			sp.NextCursor(&last, desc, total, f),
 		)
 	}
 

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -242,14 +242,7 @@ func buildPGSessionBaseFilter(
 }
 
 // EncodeCursor returns a base64-encoded, HMAC-signed cursor.
-func (s *Store) EncodeCursor(
-	endedAt, id string, total ...int,
-) string {
-	t := 0
-	if len(total) > 0 {
-		t = total[0]
-	}
-	c := db.SessionCursor{EndedAt: endedAt, ID: id, Total: t}
+func (s *Store) EncodeCursor(c db.SessionCursor) string {
 	data, _ := json.Marshal(c)
 
 	s.cursorMu.RLock()
@@ -345,6 +338,10 @@ func (s *Store) ListSessions(
 
 	where, args := buildPGSessionFilter(f)
 
+	dialect := db.PostgresQueryDialect()
+	sp, _ := db.SessionSortFor(f.OrderBy)
+	desc := sp.ResolveDescending(f.Descending)
+
 	var total int
 	var cur db.SessionCursor
 	if f.Cursor != "" {
@@ -368,21 +365,22 @@ func (s *Store) ListSessions(
 	}
 
 	cursorArgs := append([]any{}, args...)
-	pageBuilder := db.NewQueryBuilder(
-		db.PostgresQueryDialect(), len(args),
-	)
+	pageBuilder := db.NewQueryBuilder(dialect, len(args))
 	cursorWhere := where
 	if f.Cursor != "" {
-		cursorWhere += " AND " +
-			pageBuilder.CursorBeforePredicate(cur)
+		val, err := sp.CursorPredicateValue(cur, desc)
+		if err != nil {
+			return db.SessionPage{}, err
+		}
+		cursorWhere += " AND " + pageBuilder.CursorPredicate(
+			sp, desc, val, cur.ID,
+		)
 	}
 
 	query := "SELECT " + pgSessionCols +
-		" FROM sessions WHERE " + cursorWhere + `
-		ORDER BY COALESCE(
-			ended_at, started_at, created_at
-		) DESC, id DESC
-		` + pageBuilder.Limit(f.Limit+1)
+		" FROM sessions WHERE " + cursorWhere + " " +
+		pageBuilder.OrderByClause(sp, desc) + " " +
+		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 
 	rows, err := s.pg.QueryContext(
@@ -405,14 +403,9 @@ func (s *Store) ListSessions(
 	if len(sessions) > f.Limit {
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
-		ea := last.CreatedAt
-		if last.StartedAt != nil && *last.StartedAt != "" {
-			ea = *last.StartedAt
-		}
-		if last.EndedAt != nil && *last.EndedAt != "" {
-			ea = *last.EndedAt
-		}
-		page.NextCursor = s.EncodeCursor(ea, last.ID, total)
+		page.NextCursor = s.EncodeCursor(
+			sp.NextCursor(&last, desc, total),
+		)
 	}
 
 	return page, nil
@@ -619,9 +612,11 @@ func (s *Store) getSidebarSessionIndexPage(
 	if len(roots) > f.Limit {
 		selected = roots[:f.Limit]
 		last := selected[f.Limit-1]
-		index.NextCursor = s.EncodeCursor(
-			FormatISO8601(last.activity), last.id, total,
-		)
+		index.NextCursor = s.EncodeCursor(db.SessionCursor{
+			EndedAt: FormatISO8601(last.activity),
+			ID:      last.id,
+			Total:   total,
+		})
 	}
 
 	page := db.NewQueryBuilder(db.PostgresQueryDialect(), 0)

--- a/internal/postgres/sessions_pgtest_test.go
+++ b/internal/postgres/sessions_pgtest_test.go
@@ -192,7 +192,7 @@ func TestListSessions_SortSecretsVersioned(t *testing.T) {
 	gated, err := store.ListSessions(ctx, db.SessionFilter{
 		Project:              "sec-test",
 		OrderBy:              "secrets",
-		Descending:           boolPtr(true),
+		Descending:           new(true),
 		SecretsRulesVersions: []string{"v1"},
 		Limit:                10,
 	})
@@ -208,7 +208,7 @@ func TestListSessions_SortSecretsVersioned(t *testing.T) {
 		page, err := store.ListSessions(ctx, db.SessionFilter{
 			Project:              "sec-test",
 			OrderBy:              "secrets",
-			Descending:           boolPtr(true),
+			Descending:           new(true),
 			SecretsRulesVersions: []string{"v1"},
 			Limit:                1,
 			Cursor:               cursor,
@@ -271,5 +271,3 @@ func TestListSessions_SortNullsLast(t *testing.T) {
 	// Ascending with NULLs last, paginated across the sentinel boundary.
 	require.Equal(t, []string{"h20", "h80", "hnull"}, walked)
 }
-
-func boolPtr(b bool) *bool { return &b }

--- a/internal/postgres/sessions_pgtest_test.go
+++ b/internal/postgres/sessions_pgtest_test.go
@@ -94,3 +94,61 @@ func TestListSessions_HasSecret(t *testing.T) {
 			"stale secret session included in versioned HasSecret results")
 	}
 }
+
+// TestListSessions_Sort verifies a non-default sort and its keyset cursor render
+// correctly on PostgreSQL (numbered placeholders, ::bigint cast). Scoped to a
+// unique project so the schema's seed session does not interfere.
+func TestListSessions_Sort(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, ended_at, message_count, user_message_count)
+		VALUES
+			('sort-a', 'm', 'sort-test', 'claude', 'a',
+			 '2026-03-01T00:00:00Z'::timestamptz, '2026-03-01T00:10:00Z'::timestamptz, 3, 1),
+			('sort-b', 'm', 'sort-test', 'claude', 'b',
+			 '2026-03-02T00:00:00Z'::timestamptz, '2026-03-02T00:10:00Z'::timestamptz, 9, 1),
+			('sort-c', 'm', 'sort-test', 'claude', 'c',
+			 '2026-03-03T00:00:00Z'::timestamptz, '2026-03-03T00:10:00Z'::timestamptz, 6, 1)
+	`)
+	require.NoError(t, err, "seeding sort sessions")
+
+	ctx := context.Background()
+	ids := func(sessions []db.Session) []string {
+		out := make([]string, len(sessions))
+		for i, s := range sessions {
+			out[i] = s.ID
+		}
+		return out
+	}
+
+	// messages ascending (the default for non-recent sorts).
+	asc, err := store.ListSessions(ctx, db.SessionFilter{
+		Project: "sort-test", OrderBy: "messages", Limit: 10,
+	})
+	require.NoError(t, err, "ListSessions sort asc")
+	require.Equal(t, []string{"sort-a", "sort-c", "sort-b"}, ids(asc.Sessions))
+
+	// Paginated walk one row at a time exercises the ::bigint keyset cursor.
+	var walked []string
+	cursor := ""
+	for {
+		page, err := store.ListSessions(ctx, db.SessionFilter{
+			Project: "sort-test", OrderBy: "messages", Limit: 1, Cursor: cursor,
+		})
+		require.NoError(t, err, "ListSessions sort page")
+		walked = append(walked, ids(page.Sessions)...)
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	require.Equal(t, []string{"sort-a", "sort-c", "sort-b"}, walked)
+}

--- a/internal/postgres/sessions_pgtest_test.go
+++ b/internal/postgres/sessions_pgtest_test.go
@@ -152,3 +152,124 @@ func TestListSessions_Sort(t *testing.T) {
 	}
 	require.Equal(t, []string{"sort-a", "sort-c", "sort-b"}, walked)
 }
+
+// TestListSessions_SortSecretsVersioned verifies the version-gated secrets sort
+// renders on PostgreSQL, where the gating CASE places numbered placeholders
+// inside both ORDER BY and the keyset cursor predicate.
+func TestListSessions_SortSecretsVersioned(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, ended_at, message_count, user_message_count,
+			 secret_leak_count, secrets_rules_version)
+		VALUES
+			('sec-cur', 'm', 'sec-test', 'claude', 'a',
+			 '2026-03-01T00:00:00Z'::timestamptz, '2026-03-01T00:10:00Z'::timestamptz, 2, 1, 5, 'v1'),
+			('sec-stale', 'm', 'sec-test', 'claude', 'b',
+			 '2026-03-02T00:00:00Z'::timestamptz, '2026-03-02T00:10:00Z'::timestamptz, 2, 1, 9, 'old'),
+			('sec-none', 'm', 'sec-test', 'claude', 'c',
+			 '2026-03-03T00:00:00Z'::timestamptz, '2026-03-03T00:10:00Z'::timestamptz, 2, 1, 0, '')
+	`)
+	require.NoError(t, err, "seeding secret sessions")
+
+	ctx := context.Background()
+	ids := func(sessions []db.Session) []string {
+		out := make([]string, len(sessions))
+		for i, s := range sessions {
+			out[i] = s.ID
+		}
+		return out
+	}
+
+	// With v1 active, the stale 9 gates to 0, so the current-version 5 leads.
+	gated, err := store.ListSessions(ctx, db.SessionFilter{
+		Project:              "sec-test",
+		OrderBy:              "secrets",
+		Descending:           boolPtr(true),
+		SecretsRulesVersions: []string{"v1"},
+		Limit:                10,
+	})
+	require.NoError(t, err, "ListSessions secrets gated")
+	require.Equal(t, "sec-cur", ids(gated.Sessions)[0])
+
+	// Paginate one at a time so the gating CASE also renders in the cursor
+	// predicate; the current-version session must still lead with no dupes.
+	var walked []string
+	seen := map[string]bool{}
+	cursor := ""
+	for {
+		page, err := store.ListSessions(ctx, db.SessionFilter{
+			Project:              "sec-test",
+			OrderBy:              "secrets",
+			Descending:           boolPtr(true),
+			SecretsRulesVersions: []string{"v1"},
+			Limit:                1,
+			Cursor:               cursor,
+		})
+		require.NoError(t, err, "ListSessions secrets page")
+		for _, s := range page.Sessions {
+			require.False(t, seen[s.ID], "duplicate %s", s.ID)
+			seen[s.ID] = true
+			walked = append(walked, s.ID)
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	require.Len(t, walked, 3)
+	require.Equal(t, "sec-cur", walked[0])
+}
+
+// TestListSessions_SortNullsLast verifies a nullable sort (health) places NULL
+// rows last on PostgreSQL and paginates across the sentinel boundary.
+func TestListSessions_SortNullsLast(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, ended_at, message_count, user_message_count, health_score)
+		VALUES
+			('h20', 'm', 'null-test', 'claude', 'a',
+			 '2026-03-01T00:00:00Z'::timestamptz, '2026-03-01T00:10:00Z'::timestamptz, 2, 1, 20),
+			('h80', 'm', 'null-test', 'claude', 'b',
+			 '2026-03-02T00:00:00Z'::timestamptz, '2026-03-02T00:10:00Z'::timestamptz, 2, 1, 80),
+			('hnull', 'm', 'null-test', 'claude', 'c',
+			 '2026-03-03T00:00:00Z'::timestamptz, '2026-03-03T00:10:00Z'::timestamptz, 2, 1, NULL)
+	`)
+	require.NoError(t, err, "seeding health sessions")
+
+	ctx := context.Background()
+	var walked []string
+	cursor := ""
+	for {
+		page, err := store.ListSessions(ctx, db.SessionFilter{
+			Project: "null-test", OrderBy: "health", Limit: 1, Cursor: cursor,
+		})
+		require.NoError(t, err, "ListSessions health page")
+		for _, s := range page.Sessions {
+			walked = append(walked, s.ID)
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	// Ascending with NULLs last, paginated across the sentinel boundary.
+	require.Equal(t, []string{"h20", "h80", "hnull"}, walked)
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -128,6 +128,32 @@ func optionalIntValue(p optionalIntParam) *int {
 	return &p.Value
 }
 
+// optionalBoolParam distinguishes an omitted query param from an explicit
+// false, so a sort key's canonical direction is used unless ?descending is set.
+type optionalBoolParam struct {
+	Value bool
+	IsSet bool
+}
+
+func (p optionalBoolParam) Schema(r huma.Registry) *huma.Schema {
+	return huma.SchemaFromType(r, reflect.TypeFor[bool]())
+}
+
+func (p *optionalBoolParam) Receiver() reflect.Value {
+	return reflect.ValueOf(p).Elem().FieldByName("Value")
+}
+
+func (p *optionalBoolParam) OnParamSet(isSet bool, _ any) {
+	p.IsSet = isSet
+}
+
+func optionalBoolValue(p optionalBoolParam) *bool {
+	if !p.IsSet {
+		return nil
+	}
+	return &p.Value
+}
+
 const ctxKeyHumaRequestInfo contextKey = 100
 
 func humaRequestInfoMiddleware(ctx huma.Context, next func(huma.Context)) {

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -55,29 +55,35 @@ type messageDirection string
 
 type markdownDepth string
 
+// sessionOrderBy is the allow-listed session-list sort field. The enum tag is
+// kept in sync with db.SortKeys() by TestSortKeysMatchHumaEnum.
+type sessionOrderBy string
+
 type sessionFilterInput struct {
-	Project          string           `query:"project" doc:"Filter by project"`
-	ExcludeProject   string           `query:"exclude_project" doc:"Exclude a project"`
-	Machine          string           `query:"machine" doc:"Filter by machine"`
-	Agent            string           `query:"agent" doc:"Filter by agent"`
-	Date             string           `query:"date" format:"date" doc:"Filter to a single YYYY-MM-DD date"`
-	DateFrom         string           `query:"date_from" format:"date" doc:"Filter start date"`
-	DateTo           string           `query:"date_to" format:"date" doc:"Filter end date"`
-	ActiveSince      string           `query:"active_since" format:"date-time" doc:"Filter sessions active since this RFC3339 timestamp"`
-	MinMessages      int              `query:"min_messages" minimum:"0" doc:"Minimum total message count"`
-	MaxMessages      int              `query:"max_messages" minimum:"0" doc:"Maximum total message count"`
-	MinUserMessages  int              `query:"min_user_messages" minimum:"0" doc:"Minimum user message count"`
-	IncludeOneShot   bool             `query:"include_one_shot" doc:"Include one-shot sessions"`
-	IncludeAutomated bool             `query:"include_automated" doc:"Include automated sessions"`
-	IncludeChildren  bool             `query:"include_children" doc:"Include child sessions"`
-	Outcome          string           `query:"outcome" doc:"Filter by detected outcome"`
-	HealthGrade      string           `query:"health_grade" doc:"Filter by health grade"`
-	Cursor           string           `query:"cursor" doc:"Opaque pagination cursor"`
-	Limit            int              `query:"limit" minimum:"0" doc:"Maximum number of results"`
-	Termination      string           `query:"termination" doc:"Filter by termination reason"`
-	MinToolFailures  optionalIntParam `query:"min_tool_failures" minimum:"0" doc:"Minimum tool failure count"`
-	HasSecret        bool             `query:"has_secret" doc:"Filter sessions with secret findings"`
-	Starred          bool             `query:"starred" doc:"Filter sessions by starred status"`
+	Project          string            `query:"project" doc:"Filter by project"`
+	ExcludeProject   string            `query:"exclude_project" doc:"Exclude a project"`
+	Machine          string            `query:"machine" doc:"Filter by machine"`
+	Agent            string            `query:"agent" doc:"Filter by agent"`
+	Date             string            `query:"date" format:"date" doc:"Filter to a single YYYY-MM-DD date"`
+	DateFrom         string            `query:"date_from" format:"date" doc:"Filter start date"`
+	DateTo           string            `query:"date_to" format:"date" doc:"Filter end date"`
+	ActiveSince      string            `query:"active_since" format:"date-time" doc:"Filter sessions active since this RFC3339 timestamp"`
+	MinMessages      int               `query:"min_messages" minimum:"0" doc:"Minimum total message count"`
+	MaxMessages      int               `query:"max_messages" minimum:"0" doc:"Maximum total message count"`
+	MinUserMessages  int               `query:"min_user_messages" minimum:"0" doc:"Minimum user message count"`
+	IncludeOneShot   bool              `query:"include_one_shot" doc:"Include one-shot sessions"`
+	IncludeAutomated bool              `query:"include_automated" doc:"Include automated sessions"`
+	IncludeChildren  bool              `query:"include_children" doc:"Include child sessions"`
+	Outcome          string            `query:"outcome" doc:"Filter by detected outcome"`
+	HealthGrade      string            `query:"health_grade" doc:"Filter by health grade"`
+	Cursor           string            `query:"cursor" doc:"Opaque pagination cursor"`
+	Limit            int               `query:"limit" minimum:"0" doc:"Maximum number of results"`
+	Termination      string            `query:"termination" doc:"Filter by termination reason"`
+	MinToolFailures  optionalIntParam  `query:"min_tool_failures" minimum:"0" doc:"Minimum tool failure count"`
+	HasSecret        bool              `query:"has_secret" doc:"Filter sessions with secret findings"`
+	Starred          bool              `query:"starred" doc:"Filter sessions by starred status"`
+	OrderBy          sessionOrderBy    `query:"order_by" enum:"recent,started,messages,user-messages,output-tokens,peak-context,failures,retries,edit-churn,compactions,context-pressure,health,secrets,id" default:"recent" doc:"Sort field"`
+	Descending       optionalBoolParam `query:"descending" doc:"Sort descending; overrides the sort field's default direction"`
 }
 
 type messageListInput struct {
@@ -119,6 +125,8 @@ func (in *sessionFilterInput) listFilter() (service.ListFilter, error) {
 		Termination:      in.Termination,
 		HasSecret:        in.HasSecret,
 		Starred:          in.Starred,
+		OrderBy:          string(in.OrderBy),
+		Descending:       optionalBoolValue(in.Descending),
 	}
 	if in.MinToolFailures.IsSet {
 		filter.MinToolFailures = &in.MinToolFailures.Value

--- a/internal/server/sort_http_test.go
+++ b/internal/server/sort_http_test.go
@@ -1,0 +1,42 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func orderedSessionIDs(sessions []db.Session) []string {
+	ids := make([]string, len(sessions))
+	for i, s := range sessions {
+		ids[i] = s.ID
+	}
+	return ids
+}
+
+// TestListSessions_OrderBy exercises the ?order_by / ?descending query params
+// and rejection of an out-of-enum value.
+func TestListSessions_OrderBy(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s-lo", "p", 2)
+	te.seedSession(t, "s-hi", "p", 9)
+
+	// order_by=messages defaults to ascending.
+	w := te.get(t, "/api/v1/sessions?order_by=messages")
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[sessionListResponse](t, w)
+	assert.Equal(t, []string{"s-lo", "s-hi"}, orderedSessionIDs(resp.Sessions))
+
+	// descending=true flips the order.
+	w = te.get(t, "/api/v1/sessions?order_by=messages&descending=true")
+	assertStatus(t, w, http.StatusOK)
+	resp = decode[sessionListResponse](t, w)
+	assert.Equal(t, []string{"s-hi", "s-lo"}, orderedSessionIDs(resp.Sessions))
+
+	// An out-of-enum order_by is rejected (Huma 422 remapped to 400).
+	w = te.get(t, "/api/v1/sessions?order_by=bogus")
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/internal/server/sort_internal_test.go
+++ b/internal/server/sort_internal_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// TestSortKeysMatchHumaEnum guards the hard-coded order_by enum tag against
+// drift from the shared sort registry.
+func TestSortKeysMatchHumaEnum(t *testing.T) {
+	field, ok := reflect.TypeFor[sessionFilterInput]().FieldByName("OrderBy")
+	require.True(t, ok, "sessionFilterInput.OrderBy field")
+	enum := field.Tag.Get("enum")
+	require.NotEmpty(t, enum, "order_by enum tag")
+	assert.Equal(t, db.SortKeys(), strings.Split(enum, ","),
+		"order_by enum must match db.SortKeys()")
+}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -106,6 +106,12 @@ func (b *directBackend) List(
 			"list: invalid active_since %q: use RFC3339", f.ActiveSince,
 		)
 	}
+	if !db.ValidSortKey(f.OrderBy) {
+		return nil, fmt.Errorf(
+			"list: invalid sort %q: must be one of %s",
+			f.OrderBy, strings.Join(db.SortKeys(), ", "),
+		)
+	}
 	// Match the HTTP handler's clampLimit semantics: values over
 	// MaxSessionLimit clamp to the max, not reset to the default.
 	if f.Limit > db.MaxSessionLimit {
@@ -153,6 +159,8 @@ func listFilterToDB(f ListFilter) db.SessionFilter {
 		HasSecret:            f.HasSecret,
 		Starred:              f.Starred,
 		SecretsRulesVersions: secrets.ActiveRulesVersions(),
+		OrderBy:              f.OrderBy,
+		Descending:           f.Descending,
 	}
 	if f.Outcome != "" {
 		filter.Outcome = strings.Split(f.Outcome, ",")

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -128,6 +128,10 @@ func filterToQuery(f ListFilter) url.Values {
 	if f.Limit > 0 {
 		q.Set("limit", strconv.Itoa(f.Limit))
 	}
+	setIfNotEmpty("order_by", f.OrderBy)
+	if f.Descending != nil {
+		q.Set("descending", strconv.FormatBool(*f.Descending))
+	}
 	return q
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -136,6 +136,10 @@ type ListFilter struct {
 	Starred          bool   `json:"starred,omitempty"`
 	Cursor           string `json:"cursor,omitempty"`
 	Limit            int    `json:"limit,omitempty"`
+	// OrderBy selects the sort column ("" = recent activity). Descending
+	// overrides the sort key's canonical direction when non-nil.
+	OrderBy    string `json:"order_by,omitempty"`
+	Descending *bool  `json:"descending,omitempty"`
 }
 
 // MessageFilter mirrors GET /api/v1/sessions/{id}/messages query params.


### PR DESCRIPTION
Adds `--sort <field>` and `--reverse`/`-r` to `agentsview session list`, with the matching `?order_by=…&descending=…` query params on `GET /api/v1/sessions`. Closes #729.

Sort keys: `recent` (default), `started`, `messages`, `user-messages`, `output-tokens`, `peak-context`, `failures`, `retries`, `edit-churn`, `compactions`, `context-pressure`, `health`, `secrets`, `id`. `recent` defaults to descending (today's behavior); the rest default to ascending. `--reverse` flips the key's default; on the HTTP side `descending` sets the direction absolutely (omitted → the key's default).

## How it works

Rather than special-casing each sort, this introduces a single sort registry (`internal/db/sort.go`) mapping each key to a dialect-aware, non-null ORDER BY expression and a typed keyset cursor value, and lifts `ORDER BY` + the keyset predicate into `QueryBuilder` (`OrderByClause` / `CursorPredicate`). SQLite, PostgreSQL, and DuckDB now render ordering from one definition instead of the three duplicated inline `ORDER BY COALESCE(...) DESC, id DESC` strings that were there before.

Pagination works under every sort: `SessionCursor` carries `(sort, direction, value)`, the value is re-typed per column kind (with `::bigint`/`::timestamptz`/`::double precision` casts on PostgreSQL), and nullable sorts (`health`, `context-pressure`) use a direction-aware sentinel `COALESCE` so NULLs sort last identically on every backend. A cursor reused under a different sort or direction is rejected as invalid; cursors minted before these fields existed still decode as recent-descending.

The `secrets` sort is version-gated to match the count the API actually displays (`hideStaleSecretCount`): when active scanner-rule versions are known, counts from stale versions are treated as 0, so a session shown with "0 secrets" can't rank above one with current findings.

## Scope / tradeoffs

- **No new indexes.** At local-archive scale a scan+sort is sub-millisecond; adding ~10 single-column indexes would tax every write and bloat the DB. Straightforward follow-up if profiling shows a need.
- **Sidebar index left unchanged** — this is scoped to `session list`, and the sidebar has its own recent-activity ordering.
- The diff is larger than a minimal flag patch because ordering/pagination is generalized across all three backends rather than bolted onto the default sort; the upside is the removal of the duplicated per-backend ORDER BY strings.

## Where to look

`internal/db/sort.go` (registry + cursor helpers), `internal/db/query_dialect.go` (`OrderByClause`/`CursorPredicate`, per-kind casts), the three `ListSessions` implementations (`internal/db`, `internal/postgres`, `internal/duckdb`), `internal/server/huma_routes_sessions.go` (query params), and `cmd/agentsview/session_list.go` (flags).
