### PR TITLE
feat(parser): add aider session parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ agentsview auto-discovers sessions from all of these:
 
 | Agent                 | Session Directory                                                                                                                                                       |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Aider                 | `<repo>/.aider.chat.history.md` (per repo; bounded scan of `~`, set `AIDER_DIR` to scope)                                                                               |
 | Amp                   | `~/.local/share/amp/threads/`                                                                                                                                           |
 | Antigravity           | `~/.gemini/antigravity/`                                                                                                                                                |
 | Antigravity CLI       | `~/.gemini/antigravity-cli/` (see note below)                                                                                                                           |
@@ -309,6 +310,29 @@ agentsview auto-discovers sessions from all of these:
 
 Each directory can be overridden with an environment variable. See the
 [configuration docs](https://agentsview.io/configuration/) for details.
+
+### Aider: per-repo Markdown logs
+
+Aider has no central session store; it writes one `.aider.chat.history.md`
+Markdown log per repository, and one log accumulates many runs (one per `aider`
+launch, delimited by `# aider chat started at ...` headers). agentsview indexes
+**each run as its own session**.
+
+Discovery is a bounded, symlink-safe walk of your home directory: it descends at
+most four levels below `~`, skips vendor/build/VCS directories by name
+(`node_modules`, `target`, `.git`, `Library`, `go`, `.cargo`, and similar), and
+stops after a two-second wall-clock budget so a large home tree cannot stall the
+scan. **A repository whose `.aider.chat.history.md` sits more than four levels
+under `~`, or outside your home directory, will not be found by the default
+scan.** Point `AIDER_DIR` (or the `aider_dirs` config key) at that code root to
+index it and to scope and speed up the walk. The live file watcher only watches
+the home root shallowly (registering it recursively would inotify the entire
+home tree); new repos are picked up by the periodic sync, which runs every 15
+minutes.
+
+Because the format is Markdown-derived, roles are reconstructed from line
+prefixes and there are no per-message timestamps; a run's start time comes from
+its `# aider chat started at ...` header (written in local time, assumed UTC).
 
 ### Antigravity CLI: high-resolution transcripts
 

--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/config"
@@ -69,6 +70,33 @@ func newSessionExportCommand() *cobra.Command {
 			// same repository.
 			if historyPath, idx, ok :=
 				parser.ParseAiderVirtualPath(storedPath); ok {
+				rawID, ok := rawAiderSessionID(id)
+				if !ok {
+					return fmt.Errorf(
+						"stale aider source for session %s: invalid aider session id",
+						id,
+					)
+				}
+				if got, ok := parser.AiderRawIDAt(historyPath, idx); !ok || got != rawID {
+					if _, statErr := os.Stat(historyPath); statErr != nil {
+						if os.IsNotExist(statErr) {
+							return fmt.Errorf(
+								"source file not found: %s", historyPath,
+							)
+						}
+						return statErr
+					}
+					resolved, found := parser.AiderVirtualPathForRawID(
+						historyPath, rawID,
+					)
+					if !found {
+						return fmt.Errorf(
+							"stale aider source for session %s: %s no longer contains the archived run",
+							id, historyPath,
+						)
+					}
+					historyPath, idx, _ = parser.ParseAiderVirtualPath(resolved)
+				}
 				err := parser.WriteAiderRunMarkdown(
 					cmd.OutOrStdout(), historyPath, idx,
 				)
@@ -109,4 +137,14 @@ func newSessionExportCommand() *cobra.Command {
 			return err
 		},
 	}
+}
+
+func rawAiderSessionID(sessionID string) (string, bool) {
+	def, ok := parser.AgentByPrefix(sessionID)
+	if !ok || def.Type != parser.AgentAider {
+		return "", false
+	}
+	_, rawID := parser.StripHostPrefix(sessionID)
+	rawID = strings.TrimPrefix(rawID, def.IDPrefix)
+	return rawID, rawID != ""
 }

--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -63,6 +63,22 @@ func newSessionExportCommand() *cobra.Command {
 					"source file not found for session %s", id,
 				)
 			}
+			// Aider stores many repo runs in one Markdown history file,
+			// with sessions keyed by a <history>#<idx> virtual path.
+			// Export only the selected run, not sibling runs from the
+			// same repository.
+			if historyPath, idx, ok :=
+				parser.ParseAiderVirtualPath(storedPath); ok {
+				err := parser.WriteAiderRunMarkdown(
+					cmd.OutOrStdout(), historyPath, idx,
+				)
+				if errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf(
+						"source file not found: %s", historyPath,
+					)
+				}
+				return err
+			}
 			// A Visual Studio Copilot trace file holds spans for several
 			// conversations, so streaming the whole file would disclose
 			// unrelated conversations. Filter to the requested conversation.

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -690,8 +690,10 @@ func TestSessionExport_AiderVirtualPathStreamsOnlySelectedRun(t *testing.T) {
 	require.NoError(t, os.WriteFile(
 		history, []byte("ignored preamble\n"+run0+run1+run2), 0o600,
 	))
+	rawID, ok := parser.AiderRawIDAt(history, 1)
+	require.True(t, ok, "run 1 raw ID")
 
-	seedSessionWithOpts(t, dataDir, "s-aider", "repo",
+	seedSessionWithOpts(t, dataDir, "aider:"+rawID, "repo",
 		func(s *db.Session) {
 			s.Agent = string(parser.AgentAider)
 			vp := parser.AiderVirtualPath(history, 1)
@@ -699,11 +701,47 @@ func TestSessionExport_AiderVirtualPathStreamsOnlySelectedRun(t *testing.T) {
 		})
 
 	out, err := executeCommand(newRootCommand(),
-		"session", "export", "s-aider")
+		"session", "export", "aider:"+rawID)
 	require.NoError(t, err)
 	assert.Equal(t, run1, out)
 	assert.NotContains(t, out, "first prompt")
 	assert.NotContains(t, out, "third prompt")
+}
+
+func TestSessionExport_AiderStaleIndexReResolvesBySessionID(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	history := filepath.Join(repo, parser.AiderHistoryFileName())
+	run0 := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### first prompt\nanswer one\n"
+	run1 := "# aider chat started at 2026-06-09 15:30:00\n" +
+		"#### second prompt\nanswer two\n"
+	require.NoError(t, os.WriteFile(history, []byte(run0+run1), 0o600))
+	rawID, ok := parser.AiderRawIDAt(history, 1)
+	require.True(t, ok, "run 1 raw ID")
+
+	seedSessionWithOpts(t, dataDir, "aider:"+rawID, "repo",
+		func(s *db.Session) {
+			s.Agent = string(parser.AgentAider)
+			vp := parser.AiderVirtualPath(history, 1)
+			s.FilePath = &vp
+		})
+
+	inserted := "# aider chat started at 2026-06-09 13:00:00\n" +
+		"#### inserted prompt\ninserted answer\n"
+	require.NoError(t, os.WriteFile(
+		history, []byte(inserted+run0+run1), 0o600,
+	))
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "export", "aider:"+rawID)
+	require.NoError(t, err)
+	assert.Equal(t, run1, out)
+	assert.NotContains(t, out, "inserted prompt")
+	assert.NotContains(t, out, "first prompt")
 }
 
 func TestSessionExport_FailsWhenSourceMissing(t *testing.T) {

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestSessionHelp_ShowsSubcommands(t *testing.T) {
@@ -671,6 +672,38 @@ func TestSessionExport_StreamsFromDisk(t *testing.T) {
 		"session", "export", "s-1")
 	require.NoError(t, err)
 	assert.Equal(t, body, out)
+}
+
+func TestSessionExport_AiderVirtualPathStreamsOnlySelectedRun(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	history := filepath.Join(repo, parser.AiderHistoryFileName())
+	run0 := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### first prompt\nanswer one\n"
+	run1 := "# aider chat started at 2026-06-09 15:30:00\n" +
+		"#### second prompt\nanswer two\n"
+	run2 := "# aider chat started at 2026-06-09 16:45:00\n" +
+		"#### third prompt\nanswer three\n"
+	require.NoError(t, os.WriteFile(
+		history, []byte("ignored preamble\n"+run0+run1+run2), 0o600,
+	))
+
+	seedSessionWithOpts(t, dataDir, "s-aider", "repo",
+		func(s *db.Session) {
+			s.Agent = string(parser.AgentAider)
+			vp := parser.AiderVirtualPath(history, 1)
+			s.FilePath = &vp
+		})
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "export", "s-aider")
+	require.NoError(t, err)
+	assert.Equal(t, run1, out)
+	assert.NotContains(t, out, "first prompt")
+	assert.NotContains(t, out, "third prompt")
 }
 
 func TestSessionExport_FailsWhenSourceMissing(t *testing.T) {

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -1,0 +1,626 @@
+package parser
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Aider stores one Markdown chat log per repository at
+// <repo>/.aider.chat.history.md. A single file accumulates many runs
+// (one per aider process launch), each delimited by a
+// "# aider chat started at <ts>" header (the only single-"#" line aider
+// writes). The format is Markdown-derived, so roles are reconstructed
+// from line prefixes (lower fidelity than the JSONL agents):
+//
+//   - "#### <text>"           -> a user prompt (Markdown h4).
+//   - plain text after a turn -> assistant response.
+//   - "> <text>"              -> aider tool/edit output (every aider
+//     tool/warning/error line is blockquoted).
+//
+// aider records no per-message timestamps, so Message.Timestamp is the
+// zero time for every message; a run's StartedAt is its own header
+// (local naive time, assumed UTC, so it may be offset by the user's
+// timezone) and there is no reliable EndedAt, so StartedAt is reused.
+//
+// Each run is indexed as its own session (mirroring the upstream
+// sessiondex Rust adapter, which emits one session per run via a
+// path#idx key). agentsview already supports multiple sessions per
+// physical file via the virtual-path fan-out pattern used by Shelley and
+// Zed, so aider reuses it: DiscoverAiderSessions returns the single
+// physical file and the sync engine fans it out to one ParseResult per
+// run. A run with no parseable turns (e.g. a header-only run) yields no
+// session. Edited files are best-effort, taken from aider's own
+// "Applied edit to" / "Creating empty file" lines. A leading "> "
+// blockquote inside assistant prose is a known, rare misclassification,
+// accepted and documented (mirrors the upstream adapter).
+
+const (
+	aiderIDPrefix     = "aider:"
+	aiderHistoryFile  = ".aider.chat.history.md"
+	aiderHeaderPrefix = "# aider chat started at "
+	aiderTimeLayout   = "2006-01-02 15:04:05"
+	aiderVPathSep     = "#"
+
+	// aiderMaxWalkDepth bounds the rootless discovery walk. aider history
+	// files sit at repository roots, rarely more than a few levels deep.
+	aiderMaxWalkDepth = 4
+	// aiderMaxFiles and aiderMaxDirs cap the walk so a pathological tree
+	// cannot stall discovery.
+	aiderMaxFiles = 5000
+	aiderMaxDirs  = 50000
+	// aiderWalkBudget bounds the wall-clock cost of the rootless discovery
+	// walk, mirroring the upstream Rust adapter's WALK_BUDGET_SECS. A walk
+	// that exceeds it stops early and returns whatever it found so far.
+	aiderWalkBudget = 2 * time.Second
+)
+
+// aiderSkipDirs are directory names never descended into during
+// discovery. Matched by exact name, never "all dotdirs", mirroring the
+// upstream Rust adapter's skip-set.
+var aiderSkipDirs = map[string]struct{}{
+	".git":         {},
+	"node_modules": {},
+	"target":       {},
+	".cache":       {},
+	"Library":      {},
+	"go":           {},
+	".cargo":       {},
+	".rustup":      {},
+	".npm":         {},
+	".pnpm-store":  {},
+	".gradle":      {},
+	".m2":          {},
+	"vendor":       {},
+	"dist":         {},
+	"build":        {},
+	".venv":        {},
+	"venv":         {},
+	"__pycache__":  {},
+	".svn":         {},
+	".hg":          {},
+}
+
+// AiderHistoryFileName returns the fixed Markdown filename aider writes
+// per repo (".aider.chat.history.md"). The sync engine uses it to match
+// watched files back to the aider agent.
+func AiderHistoryFileName() string { return aiderHistoryFile }
+
+// aiderRun is one aider launch within a history file: a run header
+// timestamp plus the raw body lines that follow it (until the next
+// header). rawHeader is the verbatim timestamp string from the header,
+// retained so the session ID can hash the header even when it is
+// unparseable.
+type aiderRun struct {
+	started   time.Time
+	hasTime   bool
+	rawHeader string
+	body      string
+}
+
+// parseAiderTimestamp parses aider's header timestamp
+// "%Y-%m-%d %H:%M:%S" (local naive, no timezone) and assumes UTC. The
+// shared parseTimestamp is RFC3339-oriented and would reject these, so
+// aider gets its own narrow parser. ok is false for empty or unparseable
+// input.
+func parseAiderTimestamp(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(aiderTimeLayout, s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+// splitAiderRuns splits a history file into runs on the
+// "# aider chat started at " header (the only single-"#" line aider
+// writes). Bytes before the first header belong to no run and are
+// dropped. A header with no body keeps its slot, so positional run order
+// never shifts when new runs are appended. CRLF endings are tolerated.
+func splitAiderRuns(content string) []aiderRun {
+	var runs []aiderRun
+	var cur *aiderRun
+	for _, raw := range strings.Split(content, "\n") {
+		line := strings.TrimSuffix(raw, "\r")
+		if ts, ok := strings.CutPrefix(line, aiderHeaderPrefix); ok {
+			if cur != nil {
+				runs = append(runs, *cur)
+			}
+			started, hasTime := parseAiderTimestamp(ts)
+			cur = &aiderRun{
+				started:   started,
+				hasTime:   hasTime,
+				rawHeader: strings.TrimSpace(ts),
+			}
+			continue
+		}
+		if cur != nil {
+			cur.body += line + "\n"
+		}
+		// lines before the first header (cur == nil) are dropped.
+	}
+	if cur != nil {
+		runs = append(runs, *cur)
+	}
+	return runs
+}
+
+// pushUniqueAider appends the trimmed path to v if it is non-empty and
+// not already present (preserves first-seen order, de-duplicates).
+func pushUniqueAider(v []string, s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return v
+	}
+	for _, existing := range v {
+		if existing == s {
+			return v
+		}
+	}
+	return append(v, s)
+}
+
+// parseAiderTurns reconstructs turns from a single run body. It is an
+// anchored state machine, not per-line role guessing:
+//
+//   - "#### " (or a bare "####")    -> user channel.
+//   - "> " (or a bare ">")          -> tool channel.
+//   - blank lines                   -> continue the current channel.
+//   - everything else               -> assistant channel (the default).
+//
+// A message is emitted whenever the channel switches. Tool output is
+// surfaced as assistant transcript content because agentsview has no
+// dedicated tool role. Edited files come from "Applied edit to" and
+// "Creating empty file" tool lines (relative paths), de-duplicated;
+// "Did not apply edit ... (--dry-run)" and "Skipping edits to ..."
+// contribute nothing.
+func parseAiderTurns(body string) ([]ParsedMessage, []string) {
+	const (
+		chanNone = iota
+		chanUser
+		chanAssistant
+		chanTool
+	)
+
+	var (
+		messages []ParsedMessage
+		touched  []string
+		curChan  = chanNone
+		buf      []string
+		ordinal  int
+	)
+
+	flush := func() {
+		if curChan == chanNone {
+			buf = buf[:0]
+			return
+		}
+		text := strings.TrimSpace(strings.Join(buf, "\n"))
+		buf = buf[:0]
+		// Keep empty user turns (aider writes "#### " for empty input);
+		// drop empty assistant/tool noise.
+		if text == "" && curChan != chanUser {
+			return
+		}
+		role := RoleAssistant
+		if curChan == chanUser {
+			role = RoleUser
+		}
+		messages = append(messages, ParsedMessage{
+			Ordinal:       ordinal,
+			Role:          role,
+			Content:       text,
+			ContentLength: len(text),
+		})
+		ordinal++
+	}
+
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSuffix(raw, "\r")
+
+		var lineChan int
+		var content string
+		switch {
+		case strings.HasPrefix(line, "#### "):
+			lineChan = chanUser
+			content = strings.TrimRight(line[len("#### "):], " \t")
+		case line == "####":
+			lineChan = chanUser
+		case strings.HasPrefix(line, "> "):
+			lineChan = chanTool
+			content = line[len("> "):]
+			if p, ok := strings.CutPrefix(content, "Applied edit to "); ok {
+				touched = pushUniqueAider(touched, p)
+			} else if p, ok := strings.CutPrefix(content, "Creating empty file "); ok {
+				touched = pushUniqueAider(touched, p)
+			}
+		case line == ">":
+			lineChan = chanTool
+		case strings.TrimSpace(line) == "":
+			// blank: continue the current channel.
+			if curChan != chanNone {
+				buf = append(buf, "")
+			}
+			continue
+		default:
+			lineChan = chanAssistant
+			content = line
+		}
+
+		if lineChan != curChan {
+			flush()
+			curChan = lineChan
+		}
+		buf = append(buf, content)
+	}
+	flush()
+	return messages, touched
+}
+
+// AiderVirtualPath gives a single run within a history file a stable
+// source identity for the AgentsView archive: "<historyPath>#<idx>",
+// where idx is the run's positional index in the file. Mirrors
+// ShelleyVirtualPath.
+func AiderVirtualPath(path string, idx int) string {
+	return path + aiderVPathSep + strconv.Itoa(idx)
+}
+
+// ParseAiderVirtualPath splits a virtual aider source path back into its
+// physical history-file path and run index. It validates that the base
+// name is the aider history file and the index is a non-negative
+// integer, so a real path (no "#") or any other "#"-bearing path is
+// rejected. Mirrors ParseShelleyVirtualPath.
+func ParseAiderVirtualPath(path string) (string, int, bool) {
+	sep := strings.LastIndex(path, aiderVPathSep)
+	if sep < 0 {
+		return "", 0, false
+	}
+	physical, idxStr := path[:sep], path[sep+1:]
+	if filepath.Base(physical) != aiderHistoryFile || idxStr == "" {
+		return "", 0, false
+	}
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 0 {
+		return "", 0, false
+	}
+	return physical, idx, true
+}
+
+// aiderAbsPath returns the absolute form of path, falling back to the
+// input when it cannot be resolved. Used so the session ID hashes a
+// stable absolute identity.
+func aiderAbsPath(path string) string {
+	if a, err := filepath.Abs(path); err == nil {
+		return a
+	}
+	return path
+}
+
+// aiderRawID derives a stable session raw ID for one run. aider has no
+// session id of its own, so the identity is the absolute history-file
+// path plus the run's header-timestamp string plus an ordinal among the
+// runs in that file that share the same header string. Hashing the header
+// rather than the bare run index keeps IDs stable across the common
+// mutations: appending a run, or removing/inserting a run with a DIFFERENT
+// header, never re-keys other runs. The ordinal (not the absolute run
+// index) is what is hashed, so a fresh-timestamp append leaves every
+// earlier run's ID untouched.
+//
+// Residual limitation: when two or more runs in one file share a
+// byte-identical header timestamp (aider headers have 1-second
+// resolution, so this requires same-second runs in the same repo -- e.g.
+// scripted/parallel invocations or a restart within the same second), the
+// ordinal disambiguates them by position. Removing or inserting-before an
+// earlier same-header run therefore re-keys its later same-header
+// siblings. This is an accepted residual given its rarity; it is pinned by
+// TestAiderSameHeaderEarlyRemovalRekeysSiblings. The "aider:" prefix is
+// added by the session ID.
+func aiderRawID(absPath, rawHeader string, equalHeaderOrdinal int) string {
+	var b strings.Builder
+	b.WriteString(absPath)
+	b.WriteByte(0)
+	b.WriteString(rawHeader)
+	b.WriteByte(0)
+	b.WriteString(strconv.Itoa(equalHeaderOrdinal))
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// aiderEqualHeaderOrdinals returns, for each run, its ordinal among the
+// runs that share its exact header string. The first run with a given
+// header gets 0, the second 1, and so on. This is what keeps IDs stable
+// across appends: only equal-header runs disambiguate by position, so a
+// new run with a fresh timestamp leaves every earlier run's ordinal
+// untouched.
+func aiderEqualHeaderOrdinals(runs []aiderRun) []int {
+	ordinals := make([]int, len(runs))
+	seen := make(map[string]int, len(runs))
+	for i, run := range runs {
+		ordinals[i] = seen[run.rawHeader]
+		seen[run.rawHeader]++
+	}
+	return ordinals
+}
+
+// AiderRunMeta describes one run within a history file: its virtual
+// source path, positional index, and parsed start time. The sync engine
+// fans a physical file out into one session per meta.
+type AiderRunMeta struct {
+	VirtualPath string
+	Idx         int
+	Started     time.Time
+}
+
+// ListAiderRunMetas reads a history file once and returns one meta per
+// run it contains, in file order. It mirrors the per-conversation meta
+// listers (e.g. ListShelleyConversationMetas) so the engine can fan a
+// single physical file out into per-run sessions. Runs with no parseable
+// header still get a meta slot so their positional index stays stable;
+// the per-run parse drops runs with no messages. Returns nil for an
+// unreadable or run-less file.
+func ListAiderRunMetas(path string) ([]AiderRunMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	runs := splitAiderRuns(string(data))
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	metas := make([]AiderRunMeta, 0, len(runs))
+	for idx, run := range runs {
+		metas = append(metas, AiderRunMeta{
+			VirtualPath: AiderVirtualPath(path, idx),
+			Idx:         idx,
+			Started:     run.started,
+		})
+	}
+	return metas, nil
+}
+
+// buildAiderRunSession builds a single per-run session from one run's
+// body and metadata. Returns (nil, nil) when the run has no parseable
+// turns so the caller skips it cleanly.
+func buildAiderRunSession(
+	path, machine string,
+	info os.FileInfo,
+	run aiderRun,
+	idx, equalHeaderOrdinal int,
+) (*ParsedSession, []ParsedMessage) {
+	messages, _ := parseAiderTurns(run.body)
+	// Edited files (parseAiderTurns' second return) are not surfaced as a
+	// structured session field: agentsview has no per-session edited-files
+	// column, and aider's own "Applied edit to ..." lines are preserved
+	// verbatim in the assistant transcript content. The extraction is kept
+	// and unit-tested at the parseAiderTurns level for parity with the
+	// upstream adapter.
+	if len(messages) == 0 {
+		return nil, nil
+	}
+
+	var (
+		firstMsg  string
+		userCount int
+	)
+	for _, m := range messages {
+		if m.Role != RoleUser || m.Content == "" {
+			continue
+		}
+		userCount++
+		if firstMsg == "" {
+			firstMsg = truncate(strings.ReplaceAll(m.Content, "\n", " "), 300)
+		}
+	}
+
+	project := GetProjectName(filepath.Base(filepath.Dir(path)))
+	if project == "" {
+		project = "unknown"
+	}
+
+	absPath := aiderAbsPath(path)
+	// A run has no reliable end time (aider writes no per-message
+	// timestamps and no run-end marker), so EndedAt mirrors StartedAt.
+	sess := &ParsedSession{
+		ID: aiderIDPrefix +
+			aiderRawID(absPath, run.rawHeader, equalHeaderOrdinal),
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentAider,
+		FirstMessage:     firstMsg,
+		StartedAt:        run.started,
+		EndedAt:          run.started,
+		MessageCount:     len(messages),
+		UserMessageCount: userCount,
+		File: FileInfo{
+			Path:  AiderVirtualPath(path, idx),
+			Size:  info.Size(),
+			Mtime: info.ModTime().UnixNano(),
+		},
+	}
+	accumulateMessageTokenUsage(sess, messages)
+	return sess, messages
+}
+
+// ParseAiderRun parses a single run (by positional index) out of a
+// history file into one session. The physical file is read and split on
+// every call; callers parsing every run of a file should prefer
+// ParseAiderRuns, which reads the file once. Returns (nil, nil, nil)
+// when the run does not exist or has no parseable turns.
+func ParseAiderRun(
+	path string, idx int, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	runs := splitAiderRuns(string(data))
+	if idx < 0 || idx >= len(runs) {
+		return nil, nil, nil
+	}
+	ordinals := aiderEqualHeaderOrdinals(runs)
+	sess, msgs := buildAiderRunSession(
+		path, machine, info, runs[idx], idx, ordinals[idx],
+	)
+	if sess == nil {
+		return nil, nil, nil
+	}
+	return sess, msgs, nil
+}
+
+// ParseAiderRuns reads a history file once and parses every run into its
+// own ParseResult, in file order. Runs with no parseable turns are
+// dropped. Returns nil for an unreadable or run-less file. This is the
+// fan-out entry point used by the sync engine; ParseAiderRun is the
+// single-run lookup used when resolving one virtual path.
+func ParseAiderRuns(path, machine string) ([]ParseResult, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	runs := splitAiderRuns(string(data))
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	ordinals := aiderEqualHeaderOrdinals(runs)
+	var results []ParseResult
+	for idx, run := range runs {
+		sess, msgs := buildAiderRunSession(
+			path, machine, info, run, idx, ordinals[idx],
+		)
+		if sess == nil {
+			continue
+		}
+		results = append(results, ParseResult{Session: *sess, Messages: msgs})
+	}
+	return results, nil
+}
+
+// DiscoverAiderSessions walks root looking for .aider.chat.history.md
+// files. aider is rootless (no central store), so this is a bounded,
+// depth-capped, symlink-safe walk: it descends at most aiderMaxWalkDepth
+// levels, never follows symlinks, skips a fixed set of large vendor /
+// build / VCS directories by exact name, and opens only the exact
+// filename. A wall-clock budget (aiderWalkBudget) stops the walk early
+// on a pathological tree. The walk is best-effort and silent: permission
+// errors, over-cap trees, and a blown budget are skipped rather than
+// surfaced, so a partial scan still indexes whatever it found. Each
+// discovered physical file is fanned out into one session per run by the
+// sync engine.
+func DiscoverAiderSessions(root string) []DiscoveredFile {
+	if root == "" {
+		return nil
+	}
+	rootDepth := strings.Count(filepath.Clean(root), string(os.PathSeparator))
+
+	var files []DiscoveredFile
+	dirCount := 0
+	start := time.Now()
+	_ = filepath.WalkDir(root, func(
+		path string, d os.DirEntry, err error,
+	) error {
+		// Wall-clock budget: stop the whole walk once it is exceeded,
+		// returning whatever was found so far. Mirrors the upstream Rust
+		// adapter's WALK_BUDGET_SECS.
+		if time.Since(start) >= aiderWalkBudget {
+			return filepath.SkipAll
+		}
+		if err != nil {
+			// Unreadable entry: skip it (and its subtree if a dir) but
+			// keep walking the rest of the tree.
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			// Never follow symlinked directories.
+			if d.Type()&os.ModeSymlink != 0 {
+				return filepath.SkipDir
+			}
+			if path != root {
+				if _, skip := aiderSkipDirs[d.Name()]; skip {
+					return filepath.SkipDir
+				}
+			}
+			depth := strings.Count(
+				filepath.Clean(path), string(os.PathSeparator),
+			) - rootDepth
+			if depth >= aiderMaxWalkDepth {
+				return filepath.SkipDir
+			}
+			dirCount++
+			if dirCount > aiderMaxDirs {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != aiderHistoryFile {
+			return nil
+		}
+		// Skip symlinked files; only index real history files.
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		files = append(files, DiscoveredFile{
+			Path:  path,
+			Agent: AgentAider,
+		})
+		if len(files) >= aiderMaxFiles {
+			return filepath.SkipAll
+		}
+		return nil
+	})
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+// FindAiderSourceFile resolves a single aider run's virtual source path
+// ("<historyPath>#<idx>") from a root directory and a raw session ID (the
+// per-run hash). It re-runs the bounded discovery walk to find candidate
+// history files, then, for each, reads and splits it once to recompute
+// the per-run IDs and match rawID. It returns the matching virtual path,
+// or "" when nothing under root produces rawID. The physical file is
+// stat-ed via os.Stat (not re-walked) for the per-run parse downstream.
+func FindAiderSourceFile(root, rawID string) string {
+	if root == "" || rawID == "" {
+		return ""
+	}
+	for _, f := range DiscoverAiderSessions(root) {
+		data, err := os.ReadFile(f.Path)
+		if err != nil {
+			continue
+		}
+		runs := splitAiderRuns(string(data))
+		if len(runs) == 0 {
+			continue
+		}
+		absPath := aiderAbsPath(f.Path)
+		ordinals := aiderEqualHeaderOrdinals(runs)
+		for idx, run := range runs {
+			if aiderRawID(absPath, run.rawHeader, ordinals[idx]) == rawID {
+				return AiderVirtualPath(f.Path, idx)
+			}
+		}
+	}
+	return ""
+}

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -89,6 +89,29 @@ var aiderSkipDirs = map[string]struct{}{
 	".hg":          {},
 }
 
+// AiderDiscoverySkipDirNames returns the directory basenames pruned by Aider
+// discovery. Remote SSH discovery uses this to mirror local discovery semantics.
+func AiderDiscoverySkipDirNames() []string {
+	names := make([]string, 0, len(aiderSkipDirs))
+	for name := range aiderSkipDirs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// AiderDiscoveryMaxWalkDepth returns the maximum directory depth local Aider
+// discovery descends below the configured root.
+func AiderDiscoveryMaxWalkDepth() int { return aiderMaxWalkDepth }
+
+// AiderDiscoveryMaxFiles returns the maximum number of Aider history files
+// local discovery returns from one configured root.
+func AiderDiscoveryMaxFiles() int { return aiderMaxFiles }
+
+// AiderDiscoveryMaxDirs returns the maximum number of directories local Aider
+// discovery visits below one configured root.
+func AiderDiscoveryMaxDirs() int { return aiderMaxDirs }
+
 // AiderHistoryFileName returns the fixed Markdown filename aider writes
 // per repo (".aider.chat.history.md"). The sync engine uses it to match
 // watched files back to the aider agent.
@@ -429,6 +452,32 @@ func AiderRawIDAt(historyPath string, idx int) (string, bool) {
 	return aiderRawID(aiderAbsPath(historyPath), runs[idx].rawHeader, ordinals[idx]), true
 }
 
+// AiderVirtualPathForRawID resolves rawID to its current positional virtual
+// path within one physical history file. This is used when a previously stored
+// "<history>#<idx>" path has gone stale because an earlier run was inserted or
+// removed after the last sync.
+func AiderVirtualPathForRawID(historyPath, rawID string) (string, bool) {
+	if historyPath == "" || rawID == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(historyPath)
+	if err != nil {
+		return "", false
+	}
+	runs := splitAiderRuns(string(data))
+	if len(runs) == 0 {
+		return "", false
+	}
+	absPath := aiderAbsPath(historyPath)
+	ordinals := aiderEqualHeaderOrdinals(runs)
+	for idx, run := range runs {
+		if aiderRawID(absPath, run.rawHeader, ordinals[idx]) == rawID {
+			return AiderVirtualPath(historyPath, idx), true
+		}
+	}
+	return "", false
+}
+
 // AiderRunMeta describes one run within a history file: its virtual
 // source path, positional index, and parsed start time. The sync engine
 // fans a physical file out into one session per meta. HasMessages reports
@@ -735,20 +784,8 @@ func FindAiderSourceFile(root, rawID string) string {
 		return ""
 	}
 	for _, f := range DiscoverAiderSessions(root) {
-		data, err := os.ReadFile(f.Path)
-		if err != nil {
-			continue
-		}
-		runs := splitAiderRuns(string(data))
-		if len(runs) == 0 {
-			continue
-		}
-		absPath := aiderAbsPath(f.Path)
-		ordinals := aiderEqualHeaderOrdinals(runs)
-		for idx, run := range runs {
-			if aiderRawID(absPath, run.rawHeader, ordinals[idx]) == rawID {
-				return AiderVirtualPath(f.Path, idx)
-			}
+		if path, ok := AiderVirtualPathForRawID(f.Path, rawID); ok {
+			return path
 		}
 	}
 	return ""

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -129,12 +129,21 @@ func parseAiderTimestamp(s string) (time.Time, bool) {
 func splitAiderRuns(content string) []aiderRun {
 	var runs []aiderRun
 	var cur *aiderRun
+	// Accumulate the current run's body in a Builder rather than repeatedly
+	// reallocating cur.body, so a large history file stays linear, not
+	// quadratic, in copy cost.
+	var body strings.Builder
+	flush := func() {
+		if cur != nil {
+			cur.body = body.String()
+			runs = append(runs, *cur)
+		}
+	}
 	for _, raw := range strings.Split(content, "\n") {
 		line := strings.TrimSuffix(raw, "\r")
 		if ts, ok := strings.CutPrefix(line, aiderHeaderPrefix); ok {
-			if cur != nil {
-				runs = append(runs, *cur)
-			}
+			flush()
+			body.Reset()
 			started, hasTime := parseAiderTimestamp(ts)
 			cur = &aiderRun{
 				started:   started,
@@ -144,13 +153,12 @@ func splitAiderRuns(content string) []aiderRun {
 			continue
 		}
 		if cur != nil {
-			cur.body += line + "\n"
+			body.WriteString(line)
+			body.WriteByte('\n')
 		}
 		// lines before the first header (cur == nil) are dropped.
 	}
-	if cur != nil {
-		runs = append(runs, *cur)
-	}
+	flush()
 	return runs
 }
 

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -161,6 +162,57 @@ func splitAiderRuns(content string) []aiderRun {
 	}
 	flush()
 	return runs
+}
+
+func aiderRunSourceRange(content string, idx int) (int, int, bool) {
+	if idx < 0 {
+		return 0, 0, false
+	}
+	runIdx := -1
+	start := -1
+	lineStart := 0
+	for lineStart <= len(content) {
+		lineEnd := len(content)
+		if rel := strings.IndexByte(content[lineStart:], '\n'); rel >= 0 {
+			lineEnd = lineStart + rel
+		}
+		if strings.HasPrefix(content[lineStart:lineEnd], aiderHeaderPrefix) {
+			runIdx++
+			if runIdx == idx {
+				start = lineStart
+			} else if runIdx == idx+1 && start >= 0 {
+				return start, lineStart, true
+			}
+		}
+		if lineEnd == len(content) {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+	if start >= 0 {
+		return start, len(content), true
+	}
+	return 0, 0, false
+}
+
+// WriteAiderRunMarkdown streams the raw Markdown source for one run in a shared
+// aider history file. It preserves the selected run's header and body, drops any
+// preamble before the first run, and never emits sibling runs from the same
+// repository history.
+func WriteAiderRunMarkdown(w io.Writer, historyPath string, idx int) error {
+	data, err := os.ReadFile(historyPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", historyPath, err)
+	}
+	start, end, ok := aiderRunSourceRange(string(data), idx)
+	if !ok {
+		return fmt.Errorf(
+			"aider run %d not found in %s: %w",
+			idx, historyPath, os.ErrNotExist,
+		)
+	}
+	_, err = w.Write(data[start:end])
+	return err
 }
 
 // pushUniqueAider appends the trimmed path to v if it is non-empty and

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -380,11 +380,16 @@ func AiderRawIDAt(historyPath string, idx int) (string, bool) {
 
 // AiderRunMeta describes one run within a history file: its virtual
 // source path, positional index, and parsed start time. The sync engine
-// fans a physical file out into one session per meta.
+// fans a physical file out into one session per meta. HasMessages reports
+// whether the run has parseable turns and so produces a session row;
+// header-only runs keep a meta slot (to hold their positional index) but
+// HasMessages is false, so the engine's unchanged-check does not expect a
+// stored row for them.
 type AiderRunMeta struct {
 	VirtualPath string
 	Idx         int
 	Started     time.Time
+	HasMessages bool
 }
 
 // ListAiderRunMetas reads a history file once and returns one meta per
@@ -392,8 +397,8 @@ type AiderRunMeta struct {
 // listers (e.g. ListShelleyConversationMetas) so the engine can fan a
 // single physical file out into per-run sessions. Runs with no parseable
 // header still get a meta slot so their positional index stays stable;
-// the per-run parse drops runs with no messages. Returns nil for an
-// unreadable or run-less file.
+// the per-run parse drops runs with no messages (flagged via HasMessages).
+// Returns nil for an unreadable or run-less file.
 func ListAiderRunMetas(path string) ([]AiderRunMeta, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -405,20 +410,38 @@ func ListAiderRunMetas(path string) ([]AiderRunMeta, error) {
 	}
 	metas := make([]AiderRunMeta, 0, len(runs))
 	for idx, run := range runs {
+		msgs, _ := parseAiderTurns(run.body)
 		metas = append(metas, AiderRunMeta{
 			VirtualPath: AiderVirtualPath(path, idx),
 			Idx:         idx,
 			Started:     run.started,
+			HasMessages: len(msgs) > 0,
 		})
 	}
 	return metas, nil
 }
 
+// aiderIdentityPath returns the path whose absolute form seeds the run's
+// session ID hash. When idPath is non-empty it is used verbatim (it is
+// already a canonical identity, e.g. the remote physical history path), so
+// the ID stays stable across syncs that read the file from a different
+// location. When idPath is empty the on-disk path's absolute form is used,
+// preserving the original local behavior exactly.
+func aiderIdentityPath(path, idPath string) string {
+	if idPath != "" {
+		return idPath
+	}
+	return aiderAbsPath(path)
+}
+
 // buildAiderRunSession builds a single per-run session from one run's
 // body and metadata. Returns (nil, nil) when the run has no parseable
-// turns so the caller skips it cleanly.
+// turns so the caller skips it cleanly. idPath, when non-empty, is the
+// canonical identity path used to derive the stable session ID (see
+// aiderIdentityPath); the on-disk path is still used for the stored virtual
+// File.Path and for reading the file.
 func buildAiderRunSession(
-	path, machine string,
+	path, idPath, machine string,
 	info os.FileInfo,
 	run aiderRun,
 	idx, equalHeaderOrdinal int,
@@ -453,12 +476,12 @@ func buildAiderRunSession(
 		project = "unknown"
 	}
 
-	absPath := aiderAbsPath(path)
+	identity := aiderIdentityPath(path, idPath)
 	// A run has no reliable end time (aider writes no per-message
 	// timestamps and no run-end marker), so EndedAt mirrors StartedAt.
 	sess := &ParsedSession{
 		ID: aiderIDPrefix +
-			aiderRawID(absPath, run.rawHeader, equalHeaderOrdinal),
+			aiderRawID(identity, run.rawHeader, equalHeaderOrdinal),
 		Project:          project,
 		Machine:          machine,
 		Agent:            AgentAider,
@@ -485,6 +508,17 @@ func buildAiderRunSession(
 func ParseAiderRun(
 	path string, idx int, machine string,
 ) (*ParsedSession, []ParsedMessage, error) {
+	return ParseAiderRunWithID(path, "", idx, machine)
+}
+
+// ParseAiderRunWithID is ParseAiderRun with an explicit canonical identity
+// path used to derive the stable session ID. idPath should be the run's
+// canonical physical history path (e.g. the remote path during SSH sync);
+// pass "" to fall back to the on-disk path, which is the local behavior.
+// The file is always read from path; only the ID hash uses idPath.
+func ParseAiderRunWithID(
+	path, idPath string, idx int, machine string,
+) (*ParsedSession, []ParsedMessage, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
@@ -499,7 +533,7 @@ func ParseAiderRun(
 	}
 	ordinals := aiderEqualHeaderOrdinals(runs)
 	sess, msgs := buildAiderRunSession(
-		path, machine, info, runs[idx], idx, ordinals[idx],
+		path, idPath, machine, info, runs[idx], idx, ordinals[idx],
 	)
 	if sess == nil {
 		return nil, nil, nil
@@ -513,6 +547,18 @@ func ParseAiderRun(
 // fan-out entry point used by the sync engine; ParseAiderRun is the
 // single-run lookup used when resolving one virtual path.
 func ParseAiderRuns(path, machine string) ([]ParseResult, error) {
+	return ParseAiderRunsWithID(path, "", machine)
+}
+
+// ParseAiderRunsWithID is ParseAiderRuns with an explicit canonical
+// identity path used to derive stable session IDs for every run. idPath
+// should be the file's canonical physical history path (e.g. the remote
+// path during SSH sync, where path is a random temp extraction dir); pass
+// "" to fall back to the on-disk path, which is the local behavior. The
+// file is always read from path; only the per-run ID hash uses idPath, so
+// the IDs stay stable across syncs that extract the file to a different
+// temp location.
+func ParseAiderRunsWithID(path, idPath, machine string) ([]ParseResult, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, fmt.Errorf("stat %s: %w", path, err)
@@ -529,7 +575,7 @@ func ParseAiderRuns(path, machine string) ([]ParseResult, error) {
 	var results []ParseResult
 	for idx, run := range runs {
 		sess, msgs := buildAiderRunSession(
-			path, machine, info, run, idx, ordinals[idx],
+			path, idPath, machine, info, run, idx, ordinals[idx],
 		)
 		if sess == nil {
 			continue

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -139,7 +140,7 @@ func splitAiderRuns(content string) []aiderRun {
 			runs = append(runs, *cur)
 		}
 	}
-	for _, raw := range strings.Split(content, "\n") {
+	for raw := range strings.SplitSeq(content, "\n") {
 		line := strings.TrimSuffix(raw, "\r")
 		if ts, ok := strings.CutPrefix(line, aiderHeaderPrefix); ok {
 			flush()
@@ -169,10 +170,8 @@ func pushUniqueAider(v []string, s string) []string {
 	if s == "" {
 		return v
 	}
-	for _, existing := range v {
-		if existing == s {
-			return v
-		}
+	if slices.Contains(v, s) {
+		return v
 	}
 	return append(v, s)
 }
@@ -232,7 +231,7 @@ func parseAiderTurns(body string) ([]ParsedMessage, []string) {
 		ordinal++
 	}
 
-	for _, raw := range strings.Split(body, "\n") {
+	for raw := range strings.SplitSeq(body, "\n") {
 		line := strings.TrimSuffix(raw, "\r")
 
 		var lineChan int

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -351,6 +351,25 @@ func aiderEqualHeaderOrdinals(runs []aiderRun) []int {
 	return ordinals
 }
 
+// AiderRawIDAt recomputes the raw session ID (the per-run hash, without the
+// "aider:" prefix) of the run at positional index idx in a history file. It
+// returns ("", false) when the file is unreadable or idx is out of range.
+// Callers use it to validate that a stored "<historyPath>#<idx>" virtual
+// path still points at the run they expect: the index is positional, so an
+// inserted or removed earlier run can shift it onto a different session.
+func AiderRawIDAt(historyPath string, idx int) (string, bool) {
+	data, err := os.ReadFile(historyPath)
+	if err != nil {
+		return "", false
+	}
+	runs := splitAiderRuns(string(data))
+	if idx < 0 || idx >= len(runs) {
+		return "", false
+	}
+	ordinals := aiderEqualHeaderOrdinals(runs)
+	return aiderRawID(aiderAbsPath(historyPath), runs[idx].rawHeader, ordinals[idx]), true
+}
+
 // AiderRunMeta describes one run within a history file: its virtual
 // source path, positional index, and parsed start time. The sync engine
 // fans a physical file out into one session per meta.
@@ -562,7 +581,12 @@ func DiscoverAiderSessions(root string) []DiscoveredFile {
 			depth := strings.Count(
 				filepath.Clean(path), string(os.PathSeparator),
 			) - rootDepth
-			if depth >= aiderMaxWalkDepth {
+			// Skip descent BELOW the cap, but still visit files in a
+			// directory AT the cap, so a history file exactly
+			// aiderMaxWalkDepth levels under the root is discovered (the
+			// documented N-level scan). A `>=` test would skip the
+			// max-depth directory before its files were seen.
+			if depth > aiderMaxWalkDepth {
 				return filepath.SkipDir
 			}
 			dirCount++

--- a/internal/parser/aider_test.go
+++ b/internal/parser/aider_test.go
@@ -213,6 +213,72 @@ func TestAiderEqualHeaderRunsGetStableDistinctIDs(t *testing.T) {
 	assert.Equal(t, r1[1].Session.ID, r2[1].Session.ID)
 }
 
+// TestAiderSessionIDStableAcrossExtractionDirs is the MEDIUM-1 regression
+// test for SSH sync. During remote sync the history file is extracted to a
+// RANDOM local temp dir, so hashing the on-disk path would re-key the run on
+// every sync. Passing a canonical identity path (the remote physical path)
+// to ParseAiderRunsWithID must produce the SAME ID regardless of where the
+// file physically lives, while the plain on-disk parse (local behavior)
+// produces DIFFERENT IDs for the two locations.
+func TestAiderSessionIDStableAcrossExtractionDirs(t *testing.T) {
+	content := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### first prompt\nanswer one\n" +
+		"# aider chat started at 2026-06-09 15:30:00\n" +
+		"#### second prompt\nanswer two\n"
+
+	// Two distinct on-disk locations standing in for two sync runs that
+	// extract the same remote file under different random temp dirs.
+	writeAt := func(t *testing.T) string {
+		t.Helper()
+		repo := filepath.Join(t.TempDir(), "myrepo")
+		require.NoError(t, os.MkdirAll(repo, 0o755))
+		p := filepath.Join(repo, ".aider.chat.history.md")
+		require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+		return p
+	}
+	pathA := writeAt(t)
+	pathB := writeAt(t)
+	require.NotEqual(t, pathA, pathB, "the two extraction paths must differ")
+
+	// The canonical identity is the remote physical path, the same for both
+	// syncs regardless of the temp extraction dir.
+	const identity = "host:/home/wes/myrepo/.aider.chat.history.md"
+
+	withIDa, err := ParseAiderRunsWithID(pathA, identity, "m")
+	require.NoError(t, err)
+	require.Len(t, withIDa, 2)
+	withIDb, err := ParseAiderRunsWithID(pathB, identity, "m")
+	require.NoError(t, err)
+	require.Len(t, withIDb, 2)
+
+	assert.Equal(t, withIDa[0].Session.ID, withIDb[0].Session.ID,
+		"identical identity path must yield a stable ID across temp dirs")
+	assert.Equal(t, withIDa[1].Session.ID, withIDb[1].Session.ID,
+		"identical identity path must yield a stable ID across temp dirs")
+
+	// Sanity: the ID is derived from the identity path, not the temp path.
+	// Without an identity path (local behavior), the two extraction paths
+	// produce DIFFERENT IDs -- exactly the instability the identity path
+	// fixes. ParseAiderRuns is the empty-identity passthrough.
+	localA, err := ParseAiderRuns(pathA, "m")
+	require.NoError(t, err)
+	require.Len(t, localA, 2)
+	localB, err := ParseAiderRuns(pathB, "m")
+	require.NoError(t, err)
+	require.Len(t, localB, 2)
+	assert.NotEqual(t, localA[0].Session.ID, localB[0].Session.ID,
+		"without an identity path the temp path leaks into the ID")
+	assert.NotEqual(t, withIDa[0].Session.ID, localA[0].Session.ID,
+		"identity-path ID differs from on-disk-path ID")
+
+	// ParseAiderRunWithID (single-run) must agree with the fan-out variant.
+	single, _, err := ParseAiderRunWithID(pathB, identity, 0, "m")
+	require.NoError(t, err)
+	require.NotNil(t, single)
+	assert.Equal(t, withIDa[0].Session.ID, single.ID,
+		"single-run identity ID must match the fan-out identity ID")
+}
+
 // TestAiderSameHeaderEarlyRemovalRekeysSiblings pins the documented residual
 // limitation of the ordinal disambiguator: when multiple runs share a
 // byte-identical header timestamp, removing an earlier same-header run shifts
@@ -486,6 +552,12 @@ func TestListAiderRunMetas(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, i, idx)
 	}
+	// HasMessages flags content-bearing runs: the first two runs have turns,
+	// the trailing header-only run does not. The engine's unchanged-check
+	// uses this to avoid expecting a stored row for header-only runs.
+	assert.True(t, metas[0].HasMessages, "run 0 has turns")
+	assert.True(t, metas[1].HasMessages, "run 1 has turns")
+	assert.False(t, metas[2].HasMessages, "header-only run produces no session")
 }
 
 // TestAiderRegistryUsesShallowWatch pins the watcher fix: aider's

--- a/internal/parser/aider_test.go
+++ b/internal/parser/aider_test.go
@@ -1,0 +1,530 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureAider is the path to the golden fixture derived from a real
+// .aider.chat.history.md file. It holds three runs: two with content and
+// a trailing header-only run with no body.
+func fixtureAider() string {
+	return filepath.Join(
+		"testdata", "aider", "myrepo", ".aider.chat.history.md",
+	)
+}
+
+// TestParseAiderRunsPerRun asserts the per-run fan-out: the multi-run
+// fixture yields one session per run that has parseable turns, each with
+// its own StartedAt and FirstMessage. The header-only trailing run
+// contributes no session.
+func TestParseAiderRunsPerRun(t *testing.T) {
+	results, err := ParseAiderRuns(fixtureAider(), "testmachine")
+	require.NoError(t, err)
+	// Three runs in the file, but the trailing header-only run has no
+	// turns, so only two sessions are emitted.
+	require.Len(t, results, 2, "one session per content-bearing run")
+
+	r0, r1 := results[0], results[1]
+
+	// Both runs share project/machine/agent but are distinct sessions.
+	for _, r := range results {
+		assert.Equal(t, AgentAider, r.Session.Agent)
+		assert.Equal(t, "testmachine", r.Session.Machine)
+		assert.Equal(t, "myrepo", r.Session.Project)
+		assert.Contains(t, r.Session.ID, "aider:")
+	}
+	assert.NotEqual(t, r0.Session.ID, r1.Session.ID,
+		"distinct runs get distinct session IDs")
+
+	// Run 0: header 14:01:00, first prompt "add a retry to the webhook",
+	// two user prompts ("add a retry..." and "Step 1").
+	assert.Equal(t,
+		time.Date(2026, 6, 9, 14, 1, 0, 0, time.UTC), r0.Session.StartedAt)
+	assert.Equal(t, r0.Session.StartedAt, r0.Session.EndedAt,
+		"a run has no separate end time")
+	assert.Contains(t, r0.Session.FirstMessage, "add a retry to the webhook")
+	assert.Equal(t, 2, r0.Session.UserMessageCount)
+
+	// Run 1: header 15:30:00, its own first prompt and message stream.
+	assert.Equal(t,
+		time.Date(2026, 6, 9, 15, 30, 0, 0, time.UTC), r1.Session.StartedAt)
+	assert.Contains(t,
+		r1.Session.FirstMessage, "make the timeout configurable")
+	assert.Equal(t, 1, r1.Session.UserMessageCount)
+
+	// The message streams are per-run, not flattened: run 1 must not carry
+	// run 0's prompt.
+	require.NotEmpty(t, r1.Messages)
+	for _, m := range r1.Messages {
+		assert.NotContains(t, m.Content, "add a retry to the webhook")
+	}
+
+	// Run 0 roles, in order. "#### Step 1" is an aider USER prompt (a fresh
+	// user channel), not an assistant heading: aider only ever writes
+	// "#### " for user input. The "> " lines are tool output, surfaced as
+	// assistant transcript content (agentsview has no tool role).
+	roles := make([]RoleType, len(r0.Messages))
+	for i, m := range r0.Messages {
+		roles[i] = m.Role
+	}
+	assert.Equal(t, []RoleType{
+		RoleUser,      // add a retry to the webhook
+		RoleAssistant, // I'll add exponential backoff ... Here is the plan:
+		RoleUser,      // Step 1
+		RoleAssistant, // Wrap the call in a loop.
+		RoleAssistant, // > Applied edit ... (tool block, surfaced as assistant)
+	}, roles)
+	assert.Equal(t, "add a retry to the webhook", r0.Messages[0].Content)
+	assert.Contains(t, r0.Messages[1].Content, "exponential backoff")
+	assert.Contains(t, r0.Messages[1].Content, "Here is the plan:")
+
+	// No per-message timestamps in aider's markdown format.
+	for _, r := range results {
+		for _, m := range r.Messages {
+			assert.True(t, m.Timestamp.IsZero())
+		}
+	}
+}
+
+// TestParseAiderRunSingle parses one run out of a file by index.
+func TestParseAiderRunSingle(t *testing.T) {
+	sess, msgs, err := ParseAiderRun(fixtureAider(), 1, "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NotEmpty(t, msgs)
+	assert.Contains(t, sess.FirstMessage, "make the timeout configurable")
+	assert.Equal(t,
+		time.Date(2026, 6, 9, 15, 30, 0, 0, time.UTC), sess.StartedAt)
+
+	// The trailing header-only run (index 2) yields no session.
+	sess2, msgs2, err := ParseAiderRun(fixtureAider(), 2, "m")
+	require.NoError(t, err)
+	assert.Nil(t, sess2)
+	assert.Empty(t, msgs2)
+
+	// Out-of-range indices are tolerated, not errors.
+	sess3, _, err := ParseAiderRun(fixtureAider(), 99, "m")
+	require.NoError(t, err)
+	assert.Nil(t, sess3)
+}
+
+// TestAiderSessionIDStableOnAppend is the core regression test for
+// MUST-FIX 1's ID scheme: appending a new run to a file must not change
+// any earlier run's session ID. A bare positional index would re-key
+// later runs when an early run is removed; hashing the header plus an
+// equal-header ordinal keeps each ID pinned to its own run.
+func TestAiderSessionIDStableOnAppend(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "myrepo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	path := filepath.Join(repo, ".aider.chat.history.md")
+
+	base := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### first prompt\nanswer one\n" +
+		"# aider chat started at 2026-06-09 15:30:00\n" +
+		"#### second prompt\nanswer two\n"
+	require.NoError(t, os.WriteFile(path, []byte(base), 0o644))
+
+	before, err := ParseAiderRuns(path, "m")
+	require.NoError(t, err)
+	require.Len(t, before, 2)
+	id0, id1 := before[0].Session.ID, before[1].Session.ID
+
+	// Append a third run with a fresh timestamp.
+	appended := base +
+		"# aider chat started at 2026-06-09 16:45:00\n" +
+		"#### third prompt\nanswer three\n"
+	require.NoError(t, os.WriteFile(path, []byte(appended), 0o644))
+
+	after, err := ParseAiderRuns(path, "m")
+	require.NoError(t, err)
+	require.Len(t, after, 3)
+
+	assert.Equal(t, id0, after[0].Session.ID,
+		"appending a run must not re-key the first run")
+	assert.Equal(t, id1, after[1].Session.ID,
+		"appending a run must not re-key the second run")
+	assert.NotEqual(t, id0, after[2].Session.ID)
+	assert.NotEqual(t, id1, after[2].Session.ID)
+}
+
+// TestAiderSessionIDStableOnEarlyRemoval asserts that removing an early
+// run does not re-key the runs that follow it (the bare-positional-index
+// failure mode).
+func TestAiderSessionIDStableOnEarlyRemoval(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "myrepo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	path := filepath.Join(repo, ".aider.chat.history.md")
+
+	run0 := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### first prompt\nanswer one\n"
+	run1 := "# aider chat started at 2026-06-09 15:30:00\n" +
+		"#### second prompt\nanswer two\n"
+	require.NoError(t, os.WriteFile(path, []byte(run0+run1), 0o644))
+
+	before, err := ParseAiderRuns(path, "m")
+	require.NoError(t, err)
+	require.Len(t, before, 2)
+	secondID := before[1].Session.ID
+
+	// Remove the first run; the second run is now positionally index 0 but
+	// must keep its original ID.
+	require.NoError(t, os.WriteFile(path, []byte(run1), 0o644))
+	after, err := ParseAiderRuns(path, "m")
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	assert.Equal(t, secondID, after[0].Session.ID,
+		"removing an earlier run must not re-key a later run")
+}
+
+// TestAiderEqualHeaderRunsGetStableDistinctIDs covers the rare case of two
+// runs with identical header timestamps: they must get distinct, stable
+// IDs disambiguated by their ordinal among equal-header runs.
+func TestAiderEqualHeaderRunsGetStableDistinctIDs(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "myrepo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	path := filepath.Join(repo, ".aider.chat.history.md")
+
+	content := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### prompt a\nanswer a\n" +
+		"# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### prompt b\nanswer b\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	r1, err := ParseAiderRuns(path, "m")
+	require.NoError(t, err)
+	require.Len(t, r1, 2)
+	assert.NotEqual(t, r1[0].Session.ID, r1[1].Session.ID,
+		"equal-header runs disambiguate by ordinal")
+
+	// Stable across re-parse.
+	r2, err := ParseAiderRuns(path, "m")
+	require.NoError(t, err)
+	require.Len(t, r2, 2)
+	assert.Equal(t, r1[0].Session.ID, r2[0].Session.ID)
+	assert.Equal(t, r1[1].Session.ID, r2[1].Session.ID)
+}
+
+// TestAiderSameHeaderEarlyRemovalRekeysSiblings pins the documented residual
+// limitation of the ordinal disambiguator: when multiple runs share a
+// byte-identical header timestamp, removing an earlier same-header run shifts
+// the ordinals of the later same-header siblings and therefore re-keys their
+// IDs. A same-second collision in one repo is rare; this test exists so the
+// behavior is explicit and any future change to the scheme is a conscious one.
+func TestAiderSameHeaderEarlyRemovalRekeysSiblings(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "myrepo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	path := filepath.Join(repo, ".aider.chat.history.md")
+
+	hdr := "# aider chat started at 2026-06-09 14:01:00\n"
+	runA := hdr + "#### prompt a\nanswer a\n"
+	runB := hdr + "#### prompt b\nanswer b\n"
+	runC := hdr + "#### prompt c\nanswer c\n"
+	require.NoError(t, os.WriteFile(path, []byte(runA+runB+runC), 0o644))
+
+	before, err := ParseAiderRuns(path, "m")
+	require.NoError(t, err)
+	require.Len(t, before, 3)
+	idB := before[1].Session.ID
+
+	// Remove the first same-header run; runs b and c each shift down one
+	// equal-header ordinal.
+	require.NoError(t, os.WriteFile(path, []byte(runB+runC), 0o644))
+	after, err := ParseAiderRuns(path, "m")
+	require.NoError(t, err)
+	require.Len(t, after, 2)
+
+	// Documented residual: run b, now ordinal 0, takes the former ordinal-0
+	// ID, so its ID changes. A unique-header run keeps its ID instead
+	// (see TestAiderSessionIDStableOnEarlyRemoval).
+	assert.NotEqual(t, idB, after[0].Session.ID,
+		"same-header early removal re-keys later siblings (accepted residual)")
+}
+
+func TestParseAiderTimestamp(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want time.Time
+		ok   bool
+	}{
+		{
+			name: "valid naive local assumed UTC",
+			in:   "2026-06-09 14:01:00",
+			want: time.Date(2026, 6, 9, 14, 1, 0, 0, time.UTC),
+			ok:   true,
+		},
+		{"trailing space tolerated", "2026-06-09 14:01:00 ",
+			time.Date(2026, 6, 9, 14, 1, 0, 0, time.UTC), true},
+		{"garbage rejected", "not a date", time.Time{}, false},
+		{"empty rejected", "", time.Time{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := parseAiderTimestamp(c.in)
+			assert.Equal(t, c.ok, ok)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestSplitAiderRuns(t *testing.T) {
+	content := "junk before any header\n" +
+		"# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### hi\n" +
+		"answer\n" +
+		"# aider chat started at 2026-06-09 15:00:00\n" +
+		"# aider chat started at 2026-06-09 16:00:00\n" +
+		"#### again\n"
+
+	runs := splitAiderRuns(content)
+	require.Len(t, runs, 3, "empty middle run keeps its slot")
+
+	first, ok := parseAiderTimestamp("2026-06-09 14:01:00")
+	require.True(t, ok)
+	assert.Equal(t, first, runs[0].started)
+	assert.Equal(t, "2026-06-09 14:01:00", runs[0].rawHeader)
+	assert.Contains(t, runs[0].body, "#### hi")
+	assert.Empty(t, runs[1].body, "header-only run has empty body")
+
+	// Bytes before the first header are dropped.
+	for _, r := range runs {
+		assert.NotContains(t, r.body, "junk before any header")
+	}
+}
+
+func TestParseAiderTurnsToolAndEditedFiles(t *testing.T) {
+	body := "#### fix the bug\n" +
+		"Here is the fix.\n" +
+		"Some prose.\n" +
+		"> Applied edit to src/a.py\n" +
+		"> Applied edit to src/a.py\n" +
+		"> Creating empty file src/b.py\n" +
+		"> Did not apply edit to src/c.py (--dry-run)\n" +
+		"> Skipping edits to src/d.py\n"
+
+	msgs, touched := parseAiderTurns(body)
+
+	roles := make([]RoleType, len(msgs))
+	for i, m := range msgs {
+		roles[i] = m.Role
+	}
+	// user, assistant prose, then the tool block surfaced as assistant.
+	assert.Equal(t,
+		[]RoleType{RoleUser, RoleAssistant, RoleAssistant}, roles)
+	assert.Equal(t, "fix the bug", msgs[0].Content)
+	assert.Contains(t, msgs[1].Content, "Here is the fix.")
+	assert.Contains(t, msgs[2].Content, "Applied edit to src/a.py")
+
+	// Dedup; dry-run and skip lines contribute nothing.
+	assert.Equal(t, []string{"src/a.py", "src/b.py"}, touched)
+
+	for _, m := range msgs {
+		assert.True(t, m.Timestamp.IsZero())
+	}
+}
+
+func TestParseAiderTurnsBlankLinesDoNotSplit(t *testing.T) {
+	body := "#### q\n" +
+		"para one\n" +
+		"\n" +
+		"para two\n"
+	msgs, _ := parseAiderTurns(body)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Contains(t, msgs[1].Content, "para one")
+	assert.Contains(t, msgs[1].Content, "para two")
+}
+
+func TestParseAiderRunsEmptyAndGarbage(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name      string
+		content   string
+		wantCount int
+	}{
+		{"empty file", "", 0},
+		{"only preamble, no header", "some text\nwith no header\n", 0},
+		{"header-only run, no body", "# aider chat started at 2026-06-09 14:01:00\n", 0},
+		{
+			name:      "garbage header timestamp still indexed",
+			content:   "# aider chat started at not-a-real-date\n#### hello\nhi\n",
+			wantCount: 1,
+		},
+		{
+			name: "crlf line endings",
+			content: "# aider chat started at 2026-06-09 14:01:00\r\n" +
+				"#### crlf prompt\r\nanswer\r\n",
+			wantCount: 1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repo := filepath.Join(dir, c.name)
+			require.NoError(t, os.MkdirAll(repo, 0o755))
+			path := filepath.Join(repo, ".aider.chat.history.md")
+			require.NoError(t,
+				os.WriteFile(path, []byte(c.content), 0o644))
+
+			results, err := ParseAiderRuns(path, "m")
+			require.NoError(t, err) // never panics, never hard-errors
+			assert.Len(t, results, c.wantCount)
+		})
+	}
+}
+
+func TestAiderVirtualPathRoundTrip(t *testing.T) {
+	hist := filepath.Join("repo", ".aider.chat.history.md")
+	vp := AiderVirtualPath(hist, 3)
+	assert.Equal(t, hist+"#3", vp)
+
+	gotPath, gotIdx, ok := ParseAiderVirtualPath(vp)
+	require.True(t, ok)
+	assert.Equal(t, hist, gotPath)
+	assert.Equal(t, 3, gotIdx)
+
+	// Non-virtual / invalid inputs are rejected.
+	cases := []string{
+		hist,                 // real path, no "#"
+		"repo/other.md#0",    // wrong base name
+		hist + "#",           // empty index
+		hist + "#-1",         // negative index
+		hist + "#notanumber", // non-numeric index
+		"plain/path",         // no separator at all
+	}
+	for _, in := range cases {
+		_, _, ok := ParseAiderVirtualPath(in)
+		assert.False(t, ok, "should reject %q", in)
+	}
+}
+
+func TestListAiderRunMetas(t *testing.T) {
+	metas, err := ListAiderRunMetas(fixtureAider())
+	require.NoError(t, err)
+	// Three runs -> three metas (one per slot, including the header-only
+	// trailing run, so positional indices stay stable).
+	require.Len(t, metas, 3)
+	assert.Equal(t, 0, metas[0].Idx)
+	assert.Equal(t, 1, metas[1].Idx)
+	assert.Equal(t, 2, metas[2].Idx)
+	assert.Equal(t,
+		time.Date(2026, 6, 9, 14, 1, 0, 0, time.UTC), metas[0].Started)
+	assert.Equal(t,
+		time.Date(2026, 6, 9, 15, 30, 0, 0, time.UTC), metas[1].Started)
+	for i, m := range metas {
+		_, idx, ok := ParseAiderVirtualPath(m.VirtualPath)
+		require.True(t, ok)
+		assert.Equal(t, i, idx)
+	}
+}
+
+// TestAiderRegistryUsesShallowWatch pins the watcher fix: aider's
+// DefaultDirs [""] resolves to $HOME, so a recursive live watch there
+// would inotify-register the entire home tree (the watcher walk ignores
+// the discovery skip-set and depth cap). ShallowWatch must stay true so
+// the watcher registers only the root and relies on the periodic sync.
+func TestAiderRegistryUsesShallowWatch(t *testing.T) {
+	def, ok := AgentByType(AgentAider)
+	require.True(t, ok, "AgentAider missing from Registry")
+	assert.True(t, def.ShallowWatch,
+		"aider must watch the home root shallowly, not recurse all of $HOME")
+	// The shallow-watch contract relies on no static subdir or custom
+	// watch-roots wiring overriding it.
+	assert.Empty(t, def.WatchSubdirs)
+	assert.Nil(t, def.WatchRootsFunc)
+}
+
+func TestDiscoverAiderSessions(t *testing.T) {
+	root := t.TempDir()
+
+	// A repo with a history file at its root.
+	repo := filepath.Join(root, "proj")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, ".aider.chat.history.md"),
+		[]byte("# aider chat started at 2026-06-09 14:01:00\n"), 0o644))
+	// A sibling non-matching file must never be picked up.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "README.md"), []byte("x\n"), 0o644))
+
+	// A history file buried in a skipped dir must be ignored.
+	skip := filepath.Join(repo, "node_modules", "dep")
+	require.NoError(t, os.MkdirAll(skip, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skip, ".aider.chat.history.md"),
+		[]byte("# aider chat started at 2026-06-09 14:01:00\n"), 0o644))
+
+	files := DiscoverAiderSessions(root)
+	require.Len(t, files, 1, "found repo file, skipped node_modules")
+	assert.Equal(t, AgentAider, files[0].Agent)
+	assert.Equal(t, aiderHistoryFile, filepath.Base(files[0].Path))
+
+	// Empty root is tolerated.
+	assert.Empty(t, DiscoverAiderSessions(""))
+}
+
+// TestAiderWalkBudget documents the wall-clock budget (MUST-FIX 3,
+// ported from the Rust adapter's WALK_BUDGET_SECS) and confirms a normal
+// discovery walk completes well within it. The budget is checked inside
+// the WalkDir callback and returns filepath.SkipAll once exceeded.
+func TestAiderWalkBudget(t *testing.T) {
+	assert.Equal(t, 2*time.Second, aiderWalkBudget,
+		"budget mirrors the Rust adapter's WALK_BUDGET_SECS")
+
+	root := t.TempDir()
+	// A small but multi-level tree with one history file.
+	deep := filepath.Join(root, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(deep, ".aider.chat.history.md"),
+		[]byte("# aider chat started at 2026-06-09 14:01:00\n#### hi\nok\n"),
+		0o644))
+
+	start := time.Now()
+	files := DiscoverAiderSessions(root)
+	elapsed := time.Since(start)
+	assert.Less(t, elapsed, aiderWalkBudget,
+		"a normal walk finishes well under budget")
+	require.Len(t, files, 1)
+}
+
+func TestFindAiderSourceFile(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "myrepo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	hist := filepath.Join(repo, ".aider.chat.history.md")
+	content := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### first\nanswer one\n" +
+		"# aider chat started at 2026-06-09 15:30:00\n" +
+		"#### second\nanswer two\n"
+	require.NoError(t, os.WriteFile(hist, []byte(content), 0o644))
+
+	// Parse the runs to learn the real per-run raw IDs.
+	results, err := ParseAiderRuns(hist, "m")
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	for i, r := range results {
+		rawID := r.Session.ID[len(aiderIDPrefix):]
+		found := FindAiderSourceFile(root, rawID)
+		require.NotEmpty(t, found, "run %d should resolve", i)
+		gotPath, gotIdx, ok := ParseAiderVirtualPath(found)
+		require.True(t, ok)
+		assert.Equal(t, aiderHistoryFile, filepath.Base(gotPath))
+		assert.Equal(t, i, gotIdx, "run %d resolves to run index %d", i, i)
+	}
+
+	assert.Empty(t, FindAiderSourceFile(root, "nonexistent-id"))
+	assert.Empty(t, FindAiderSourceFile("", "anything"))
+}

--- a/internal/parser/aider_test.go
+++ b/internal/parser/aider_test.go
@@ -250,6 +250,65 @@ func TestAiderSameHeaderEarlyRemovalRekeysSiblings(t *testing.T) {
 		"same-header early removal re-keys later siblings (accepted residual)")
 }
 
+// TestDiscoverAiderFindsFilesAtMaxDepth pins the depth-cap fix: a history
+// file whose parent directory is exactly aiderMaxWalkDepth (4) levels under
+// the root must be discovered, while one a level deeper must not. A `>=`
+// test skipped the max-depth directory before its files were seen.
+func TestDiscoverAiderFindsFilesAtMaxDepth(t *testing.T) {
+	root := t.TempDir()
+	atCap := filepath.Join(root, "a", "b", "c", "d")        // parent depth 4
+	tooDeep := filepath.Join(root, "a", "b", "c", "d", "e") // parent depth 5
+	require.NoError(t, os.MkdirAll(atCap, 0o755))
+	require.NoError(t, os.MkdirAll(tooDeep, 0o755))
+	hist := "# aider chat started at 2026-06-09 14:01:00\n#### p\nans\n"
+	atCapFile := filepath.Join(atCap, ".aider.chat.history.md")
+	tooDeepFile := filepath.Join(tooDeep, ".aider.chat.history.md")
+	require.NoError(t, os.WriteFile(atCapFile, []byte(hist), 0o644))
+	require.NoError(t, os.WriteFile(tooDeepFile, []byte(hist), 0o644))
+
+	var paths []string
+	for _, f := range DiscoverAiderSessions(root) {
+		paths = append(paths, f.Path)
+	}
+	assert.Contains(t, paths, atCapFile,
+		"a history file at the max walk depth must be discovered")
+	assert.NotContains(t, paths, tooDeepFile,
+		"a history file below the max walk depth must not be discovered")
+}
+
+// TestAiderRawIDAtDetectsShiftedIndex pins that a stored positional
+// "<history>#<idx>" path is validated by recomputed ID: after an earlier run
+// is removed, the stale index no longer recomputes to a run, and the session
+// re-resolves to the run's new index by raw ID (the engine fast-path
+// correctness fix).
+func TestAiderRawIDAtDetectsShiftedIndex(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "myrepo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	path := filepath.Join(repo, ".aider.chat.history.md")
+
+	run0 := "# aider chat started at 2026-06-09 14:01:00\n#### first\nans1\n"
+	run1 := "# aider chat started at 2026-06-09 15:30:00\n#### second\nans2\n"
+	require.NoError(t, os.WriteFile(path, []byte(run0+run1), 0o644))
+
+	// run1's raw ID, as stored under the virtual path "<path>#1".
+	id1, ok := AiderRawIDAt(path, 1)
+	require.True(t, ok)
+	_, ok = AiderRawIDAt(path, 5)
+	assert.False(t, ok, "out-of-range index returns false")
+
+	// Remove the first run; index 1 is now out of range, so the stored
+	// positional path can no longer be trusted by recomputed ID.
+	require.NoError(t, os.WriteFile(path, []byte(run1), 0o644))
+	_, ok = AiderRawIDAt(path, 1)
+	assert.False(t, ok, "stale index 1 no longer recomputes to a run")
+
+	// Re-resolution by raw ID finds run1 at its new index 0.
+	resolved := FindAiderSourceFile(dir, id1)
+	assert.Equal(t, AiderVirtualPath(path, 0), resolved,
+		"re-resolving by raw ID locates the run at its shifted index")
+}
+
 func TestParseAiderTimestamp(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/parser/testdata/aider/myrepo/.aider.chat.history.md
+++ b/internal/parser/testdata/aider/myrepo/.aider.chat.history.md
@@ -1,0 +1,25 @@
+
+# aider chat started at 2026-06-09 14:01:00
+
+#### add a retry to the webhook
+I'll add exponential backoff to the webhook handler.
+
+Here is the plan:
+
+#### Step 1
+Wrap the call in a loop.
+
+> Applied edit to src/webhook.py
+> Applied edit to src/webhook.py
+> Creating empty file src/retry.py
+> Did not apply edit to src/skip.py (--dry-run)
+> Skipping edits to src/other.py
+
+# aider chat started at 2026-06-09 15:30:00
+
+#### make the timeout configurable
+Done. The timeout now reads from the environment.
+
+> Applied edit to src/config.py
+
+# aider chat started at 2026-06-09 16:00:00

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -50,6 +50,7 @@ const (
 	AgentQwenPaw        AgentType = "qwenpaw"
 	AgentGptme          AgentType = "gptme"
 	AgentShelley        AgentType = "shelley"
+	AgentAider          AgentType = "aider"
 )
 
 // AgentDef describes a supported coding agent's filesystem
@@ -606,6 +607,32 @@ var Registry = []AgentDef{
 		FileBased:      true,
 		DiscoverFunc:   DiscoverVibeSessions,
 		FindSourceFunc: FindVibeSourceFile,
+	},
+	{
+		// Aider has no central session store. It writes one Markdown
+		// chat log per repo at <repo>/.aider.chat.history.md. There is
+		// no canonical home dir, so discovery defaults to a bounded,
+		// symlink-safe walk of $HOME (DefaultDirs below); point
+		// AIDER_DIR (or the aider_dirs config key) at a narrower code
+		// root to scope and speed up the scan. The walk is depth-capped,
+		// time-budgeted, and skips vendor/build/VCS directories by name.
+		//
+		// ShallowWatch is true: DefaultDirs [""] resolves to $HOME, and a
+		// recursive live watch there would inotify-register the entire home
+		// tree (the watcher walk ignores the discovery skip-set and depth
+		// cap). Watch the root only and rely on the 15-minute periodic
+		// sync to pick up new repos' history files; aider history is
+		// append-mostly, so this is an acceptable latency tradeoff.
+		Type:           AgentAider,
+		DisplayName:    "Aider",
+		EnvVar:         "AIDER_DIR",
+		ConfigKey:      "aider_dirs",
+		DefaultDirs:    []string{""},
+		IDPrefix:       "aider:",
+		FileBased:      true,
+		ShallowWatch:   true,
+		DiscoverFunc:   DiscoverAiderSessions,
+		FindSourceFunc: FindAiderSourceFile,
 	},
 }
 

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -341,6 +341,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentQwenPaw,
 		AgentShelley,
 		AgentVibe,
+		AgentAider,
 	}
 
 	expected := make(map[AgentType]bool, len(allTypes))

--- a/internal/parser/visualstudio_copilot.go
+++ b/internal/parser/visualstudio_copilot.go
@@ -85,11 +85,15 @@ func IsVisualStudioCopilotTraceFile(path string) bool {
 // ResolveSourceFilePath maps a stored session source path to a path that can
 // be opened on disk. Visual Studio Copilot stores a
 // <traceFile>#<conversationID> virtual path whose conversations share one
-// physical trace file; every other agent stores a real path, returned
-// unchanged.
+// physical trace file, and aider stores a <historyFile>#<runIdx> virtual
+// path whose runs share one physical history file; both resolve to the
+// physical file. Every other agent stores a real path, returned unchanged.
 func ResolveSourceFilePath(storedPath string) string {
 	if tracePath, _, ok := ParseVisualStudioCopilotVirtualPath(storedPath); ok {
 		return tracePath
+	}
+	if historyPath, _, ok := ParseAiderVirtualPath(storedPath); ok {
+		return historyPath
 	}
 	return storedPath
 }

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 
 	"go.kenn.io/agentsview/internal/parser"
@@ -12,6 +13,8 @@ import (
 // an extra file (not an agent directory) to include in the transfer. It
 // is not a valid agent type, so parseResolvedDirs routes it separately.
 const resolveFilePrefix = "@file"
+
+const resolveRecordSep = "\x00"
 
 func aiderSkipDirCasePattern() string {
 	return strings.Join(parser.AiderDiscoverySkipDirNames(), "|")
@@ -34,7 +37,7 @@ func buildAiderResolveSnippet(envVar string) string {
 			"[ \"$av_aider_files\" -ge %d ] && return; "+
 			"[ \"$av_aider_dirs\" -ge %d ] && return; "+
 			"elif [ -f \"$av_entry\" ] && [ \"$av_base\" = '%s' ]; then "+
-			"echo \"%s:$av_entry\"; "+
+			"printf '%%s\\000' \"%s:$av_entry\"; "+
 			"av_aider_files=$((av_aider_files + 1)); "+
 			"[ \"$av_aider_files\" -ge %d ] && return; "+
 			"fi; "+
@@ -100,7 +103,8 @@ func buildResolveScript() string {
 				dirExpr = fmt.Sprintf("${%s:-%s}", def.EnvVar, defaultDir)
 			}
 			fmt.Fprintf(&b,
-				"dir=\"%s\"; [ -d \"$dir\" ] && echo \"%s:$dir\"\n",
+				"dir=\"%s\"; [ -d \"$dir\" ] && "+
+					"printf '%%s\\000' \"%s:$dir\"\n",
 				dirExpr, string(def.Type),
 			)
 			// Codex stores renameable session titles in
@@ -110,7 +114,8 @@ func buildResolveScript() string {
 			if def.Type == parser.AgentCodex {
 				fmt.Fprintf(&b,
 					"idx=\"${dir%%/*}/%s\"; "+
-						"[ -f \"$idx\" ] && echo \"%s:$idx\"\n",
+						"[ -f \"$idx\" ] && "+
+						"printf '%%s\\000' \"%s:$idx\"\n",
 					parser.CodexSessionIndexFilename,
 					resolveFilePrefix,
 				)
@@ -124,23 +129,26 @@ func buildResolveScript() string {
 }
 
 // parseResolvedDirs parses script output into a map of agent type to transfer
-// target paths plus a deduplicated list of extra files (lines tagged with
-// resolveFilePrefix). Most agent targets are directories; Aider targets are
-// individual .aider.chat.history.md files. Skips empty lines and entries with
-// empty values.
+// target paths plus a deduplicated list of extra files (records tagged with
+// resolveFilePrefix). Generated resolver output is NUL-delimited so remote
+// paths containing newlines cannot inject extra records; newline-delimited input
+// is accepted only for older tests and defensive compatibility. Most agent
+// targets are directories; Aider targets are individual .aider.chat.history.md
+// files. Skips empty records, empty values, and values containing record
+// separators.
 func parseResolvedDirs(
 	output string,
 ) (map[parser.AgentType][]string, []string) {
 	dirs := make(map[parser.AgentType][]string)
 	var extraFiles []string
 	seenFile := make(map[string]struct{})
-	for line := range strings.SplitSeq(output, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	for _, record := range resolveOutputRecords(output) {
+		record = strings.TrimSpace(record)
+		if record == "" {
 			continue
 		}
-		key, value, ok := strings.Cut(line, ":")
-		if !ok || value == "" {
+		key, value, ok := strings.Cut(record, ":")
+		if !ok || invalidResolvedPath(value) {
 			continue
 		}
 		if key == resolveFilePrefix {
@@ -152,9 +160,24 @@ func parseResolvedDirs(
 			continue
 		}
 		at := parser.AgentType(key)
+		if at == parser.AgentAider &&
+			path.Base(value) != parser.AiderHistoryFileName() {
+			continue
+		}
 		dirs[at] = append(dirs[at], value)
 	}
 	return dirs, extraFiles
+}
+
+func resolveOutputRecords(output string) []string {
+	if strings.Contains(output, resolveRecordSep) {
+		return strings.Split(output, resolveRecordSep)
+	}
+	return strings.Split(output, "\n")
+}
+
+func invalidResolvedPath(value string) bool {
+	return value == "" || strings.ContainsAny(value, "\x00\r\n")
 }
 
 // resolveDirs runs the resolve script on the remote host via SSH and

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -13,6 +13,52 @@ import (
 // is not a valid agent type, so parseResolvedDirs routes it separately.
 const resolveFilePrefix = "@file"
 
+func aiderSkipDirCasePattern() string {
+	return strings.Join(parser.AiderDiscoverySkipDirNames(), "|")
+}
+
+func buildAiderResolveSnippet(envVar string) string {
+	return fmt.Sprintf(
+		"av_aider_walk() { "+
+			"[ \"$av_aider_files\" -ge %d ] && return; "+
+			"[ \"$av_aider_dirs\" -ge %d ] && return; "+
+			"for av_entry in \"$1\"/* \"$1\"/.[!.]* \"$1\"/..?*; do "+
+			"[ -e \"$av_entry\" ] || continue; "+
+			"[ -L \"$av_entry\" ] && continue; "+
+			"av_base=${av_entry##*/}; "+
+			"if [ -d \"$av_entry\" ]; then "+
+			"case \"$av_base\" in %s) continue;; esac; "+
+			"[ \"$2\" -ge %d ] && continue; "+
+			"av_aider_dirs=$((av_aider_dirs + 1)); "+
+			"av_aider_walk \"$av_entry\" $(($2 + 1)); "+
+			"[ \"$av_aider_files\" -ge %d ] && return; "+
+			"[ \"$av_aider_dirs\" -ge %d ] && return; "+
+			"elif [ -f \"$av_entry\" ] && [ \"$av_base\" = '%s' ]; then "+
+			"echo \"%s:$av_entry\"; "+
+			"av_aider_files=$((av_aider_files + 1)); "+
+			"[ \"$av_aider_files\" -ge %d ] && return; "+
+			"fi; "+
+			"done; "+
+			"}; "+
+			"dir=\"${%s:-}\"; "+
+			"case \"$dir\" in \"\"|\"$HOME\"|\"$HOME/\") ;; "+
+			"*) if [ -d \"$dir\" ]; then "+
+			"av_aider_files=0; av_aider_dirs=1; "+
+			"av_aider_walk \"$dir\" 0; "+
+			"fi;; esac\n",
+		parser.AiderDiscoveryMaxFiles(),
+		parser.AiderDiscoveryMaxDirs(),
+		aiderSkipDirCasePattern(),
+		parser.AiderDiscoveryMaxWalkDepth(),
+		parser.AiderDiscoveryMaxFiles(),
+		parser.AiderDiscoveryMaxDirs(),
+		parser.AiderHistoryFileName(),
+		string(parser.AgentAider),
+		parser.AiderDiscoveryMaxFiles(),
+		envVar,
+	)
+}
+
 // buildResolveScript generates a shell script that echoes each file-based
 // agent's resolved transfer target on the remote host. Output format:
 // "agentType:path\n" per agent target, plus "@file:path\n" lines for sibling
@@ -43,16 +89,7 @@ func buildResolveScript() string {
 			// whole-home scan or tar.
 			if def.Type == parser.AgentAider && rel == "" {
 				if def.EnvVar != "" {
-					fmt.Fprintf(&b,
-						"dir=\"${%s:-}\"; "+
-							"case \"$dir\" in \"\"|\"$HOME\"|\"$HOME/\") ;; "+
-							"*) if [ -d \"$dir\" ]; then "+
-							"find \"$dir\" -type f -name '%s' -print | sort | "+
-							"while IFS= read -r f; do echo \"%s:$f\"; done; "+
-							"fi;; esac\n",
-						def.EnvVar, parser.AiderHistoryFileName(),
-						string(def.Type),
-					)
+					b.WriteString(buildAiderResolveSnippet(def.EnvVar))
 				}
 				continue
 			}

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -13,10 +13,10 @@ import (
 // is not a valid agent type, so parseResolvedDirs routes it separately.
 const resolveFilePrefix = "@file"
 
-// buildResolveScript generates a shell script that echoes each
-// file-based agent's resolved directory on the remote host.
-// Output format: "agentType:dir\n" per agent, plus "@file:path\n"
-// lines for sibling metadata files such as Codex's session_index.jsonl.
+// buildResolveScript generates a shell script that echoes each file-based
+// agent's resolved transfer target on the remote host. Output format:
+// "agentType:path\n" per agent target, plus "@file:path\n" lines for sibling
+// metadata files such as Codex's session_index.jsonl.
 //
 // Only includes agents where FileBased is true and DiscoverFunc
 // is non-nil. For each agent with an EnvVar, the script checks
@@ -31,22 +31,27 @@ func buildResolveScript() string {
 		for _, rel := range def.DefaultDirs {
 			// Aider's only default dir is "" (the bare home directory):
 			// it has no central store and discovers history files by a
-			// bounded, depth-capped walk of $HOME. The remote resolver has
-			// no such bound -- it tars every resolved dir wholesale -- so
-			// emitting the "" default would archive the entire remote
-			// $HOME. Skip aider's bare-home default and only transfer when
-			// AIDER_DIR explicitly scopes it to a narrower code root. Local
-			// sync is unaffected: it walks DefaultDirs via DiscoverFunc, not
-			// this script. The shell guard below also drops AIDER_DIR if it
-			// is set to literal "$HOME" (or "$HOME/"), so an unscoped
-			// override cannot reintroduce the whole-home tar.
+			// bounded, depth-capped walk of $HOME. The remote resolver emits
+			// tar targets, so emitting the "" default would archive the
+			// entire remote $HOME. Skip aider's bare-home default. When
+			// AIDER_DIR explicitly scopes discovery to a code root, emit only
+			// discovered .aider.chat.history.md files as tar targets instead
+			// of the whole source tree. Local sync is unaffected: it walks
+			// DefaultDirs via DiscoverFunc, not this script. The shell guard
+			// below also drops AIDER_DIR if it is set to literal "$HOME" (or
+			// "$HOME/"), so an unscoped override cannot reintroduce a
+			// whole-home scan or tar.
 			if def.Type == parser.AgentAider && rel == "" {
 				if def.EnvVar != "" {
 					fmt.Fprintf(&b,
 						"dir=\"${%s:-}\"; "+
 							"case \"$dir\" in \"\"|\"$HOME\"|\"$HOME/\") ;; "+
-							"*) [ -d \"$dir\" ] && echo \"%s:$dir\";; esac\n",
-						def.EnvVar, string(def.Type),
+							"*) if [ -d \"$dir\" ]; then "+
+							"find \"$dir\" -type f -name '%s' -print | sort | "+
+							"while IFS= read -r f; do echo \"%s:$f\"; done; "+
+							"fi;; esac\n",
+						def.EnvVar, parser.AiderHistoryFileName(),
+						string(def.Type),
 					)
 				}
 				continue
@@ -81,10 +86,11 @@ func buildResolveScript() string {
 	return b.String()
 }
 
-// parseResolvedDirs parses script output into a map of agent type to
-// directory paths plus a deduplicated list of extra files (lines tagged
-// with resolveFilePrefix). Skips empty lines and entries with empty
-// values.
+// parseResolvedDirs parses script output into a map of agent type to transfer
+// target paths plus a deduplicated list of extra files (lines tagged with
+// resolveFilePrefix). Most agent targets are directories; Aider targets are
+// individual .aider.chat.history.md files. Skips empty lines and entries with
+// empty values.
 func parseResolvedDirs(
 	output string,
 ) (map[parser.AgentType][]string, []string) {

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -29,6 +29,28 @@ func buildResolveScript() string {
 			continue
 		}
 		for _, rel := range def.DefaultDirs {
+			// Aider's only default dir is "" (the bare home directory):
+			// it has no central store and discovers history files by a
+			// bounded, depth-capped walk of $HOME. The remote resolver has
+			// no such bound -- it tars every resolved dir wholesale -- so
+			// emitting the "" default would archive the entire remote
+			// $HOME. Skip aider's bare-home default and only transfer when
+			// AIDER_DIR explicitly scopes it to a narrower code root. Local
+			// sync is unaffected: it walks DefaultDirs via DiscoverFunc, not
+			// this script. The shell guard below also drops AIDER_DIR if it
+			// is set to literal "$HOME" (or "$HOME/"), so an unscoped
+			// override cannot reintroduce the whole-home tar.
+			if def.Type == parser.AgentAider && rel == "" {
+				if def.EnvVar != "" {
+					fmt.Fprintf(&b,
+						"dir=\"${%s:-}\"; "+
+							"case \"$dir\" in \"\"|\"$HOME\"|\"$HOME/\") ;; "+
+							"*) [ -d \"$dir\" ] && echo \"%s:$dir\";; esac\n",
+						def.EnvVar, string(def.Type),
+					)
+				}
+				continue
+			}
 			defaultDir := "$HOME/" + rel
 			dirExpr := defaultDir
 			if def.EnvVar != "" {

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -110,6 +110,74 @@ func TestResolveScriptSkipsMissingCodexIndex(t *testing.T) {
 		"no extra files when session_index.jsonl is absent")
 }
 
+// TestResolveScriptSkipsAiderHomeDefault verifies the resolve script does
+// NOT emit aider's bare-$HOME default. Aider's only default dir is "" (the
+// home directory); the remote resolver tars every emitted dir wholesale, so
+// emitting it would archive the entire remote $HOME. With AIDER_DIR unset,
+// the script must produce no aider dir even when a history file exists at
+// home root. Runs the real script through sh against a temp HOME.
+func TestResolveScriptSkipsAiderHomeDefault(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, ".aider.chat.history.md"),
+		[]byte("# aider chat started at 2024-01-01 00:00:00\n"),
+		0o644,
+	), "write history")
+
+	script := buildResolveScript()
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = []string{"HOME=" + home}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "resolve script failed: output: %s", out)
+
+	dirs, _ := parseResolvedDirs(string(out))
+	assert.Empty(t, dirs[parser.AgentAider],
+		"aider bare-$HOME default must not be resolved for remote tar, got %v",
+		dirs[parser.AgentAider])
+	// Guard against $HOME ever appearing as a tar target via aider.
+	assert.NotContains(t, string(out), "aider:"+home,
+		"aider must not resolve to the whole home dir")
+}
+
+// TestResolveScriptAiderScopedByEnv verifies that an explicit AIDER_DIR
+// scopes aider's remote transfer to that directory (the intended use), so
+// remote sync still works when the user points AIDER_DIR at a code root.
+func TestResolveScriptAiderScopedByEnv(t *testing.T) {
+	home := t.TempDir()
+	codeRoot := filepath.Join(home, "code")
+	require.NoError(t, os.MkdirAll(codeRoot, 0o755), "mkdir code root")
+
+	script := buildResolveScript()
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = []string{"HOME=" + home, "AIDER_DIR=" + codeRoot}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "resolve script failed: output: %s", out)
+
+	dirs, _ := parseResolvedDirs(string(out))
+	assert.Equal(t, []string{codeRoot}, dirs[parser.AgentAider],
+		"explicit AIDER_DIR must scope aider's remote transfer")
+}
+
+// TestResolveScriptAiderRejectsHomeOverride verifies that setting AIDER_DIR
+// to literal $HOME (the very thing the home-default skip prevents) is also
+// dropped, so an unscoped override cannot reintroduce a whole-home tar.
+func TestResolveScriptAiderRejectsHomeOverride(t *testing.T) {
+	home := t.TempDir()
+
+	script := buildResolveScript()
+	for _, override := range []string{home, home + "/"} {
+		cmd := exec.Command("sh", "-c", script)
+		cmd.Env = []string{"HOME=" + home, "AIDER_DIR=" + override}
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "resolve script failed: output: %s", out)
+
+		dirs, _ := parseResolvedDirs(string(out))
+		assert.Empty(t, dirs[parser.AgentAider],
+			"AIDER_DIR=%q (== $HOME) must not resolve to a whole-home tar, got %v",
+			override, dirs[parser.AgentAider])
+	}
+}
+
 func TestParseResolvedDirs(t *testing.T) {
 	input := "claude:/home/wes/.claude/projects\n" +
 		"codex:/home/wes/.codex/sessions\n" +

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -157,6 +157,14 @@ func TestResolveScriptAiderScopedByEnvFindsHistoryFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoA, "source.go"), []byte("package main\n"), 0o644,
 	))
+	skippedDir := filepath.Join(codeRoot, "node_modules", "dep")
+	require.NoError(t, os.MkdirAll(skippedDir, 0o755), "mkdir skipped dir")
+	skippedHistory := filepath.Join(skippedDir, parser.AiderHistoryFileName())
+	require.NoError(t, os.WriteFile(skippedHistory, []byte("# aider\n"), 0o644))
+	deepDir := filepath.Join(codeRoot, "a", "b", "c", "d", "e")
+	require.NoError(t, os.MkdirAll(deepDir, 0o755), "mkdir deep dir")
+	deepHistory := filepath.Join(deepDir, parser.AiderHistoryFileName())
+	require.NoError(t, os.WriteFile(deepHistory, []byte("# aider\n"), 0o644))
 
 	script := buildResolveScript()
 	cmd := exec.Command("sh", "-c", script)
@@ -169,6 +177,10 @@ func TestResolveScriptAiderScopedByEnvFindsHistoryFiles(t *testing.T) {
 		"explicit AIDER_DIR must resolve only aider history files")
 	assert.NotContains(t, dirs[parser.AgentAider], codeRoot,
 		"AIDER_DIR itself must not become a tar target")
+	assert.NotContains(t, dirs[parser.AgentAider], skippedHistory,
+		"remote aider discovery must prune local-discovery skip dirs")
+	assert.NotContains(t, dirs[parser.AgentAider], deepHistory,
+		"remote aider discovery must enforce the local depth cap")
 }
 
 // TestResolveScriptAiderRejectsHomeOverride verifies that setting AIDER_DIR

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -23,7 +23,7 @@ func TestBuildResolveScript(t *testing.T) {
 		if def.FileBased || def.DiscoverFunc != nil {
 			continue
 		}
-		marker := "echo \"" + string(def.Type) + ":"
+		marker := "\"" + string(def.Type) + ":"
 		assert.NotContains(t, script, marker,
 			"non-file-based agent %s in script", def.Type)
 	}
@@ -33,7 +33,7 @@ func TestBuildResolveScript(t *testing.T) {
 		if !def.FileBased || def.DiscoverFunc == nil {
 			continue
 		}
-		marker := "echo \"" + string(def.Type) + ":"
+		marker := "\"" + string(def.Type) + ":"
 		assert.Contains(t, script, marker,
 			"file-based agent %s missing from script", def.Type)
 	}
@@ -183,6 +183,30 @@ func TestResolveScriptAiderScopedByEnvFindsHistoryFiles(t *testing.T) {
 		"remote aider discovery must enforce the local depth cap")
 }
 
+func TestResolveScriptAiderNewlinePathCannotInjectTarget(t *testing.T) {
+	home := t.TempDir()
+	codeRoot := filepath.Join(home, "code")
+	injected := "/home/victim/" + parser.AiderHistoryFileName()
+	maliciousDir := filepath.Join(codeRoot, "repo\naider:", "home", "victim")
+	require.NoError(t, os.MkdirAll(maliciousDir, 0o755), "mkdir malicious dir")
+	maliciousHistory := filepath.Join(maliciousDir, parser.AiderHistoryFileName())
+	require.NoError(t, os.WriteFile(maliciousHistory, []byte("# aider\n"), 0o644))
+
+	script := buildResolveScript()
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = []string{"HOME=" + home, "AIDER_DIR=" + codeRoot}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "resolve script failed: output: %s", out)
+
+	dirs, _ := parseResolvedDirs(string(out))
+	assert.NotContains(t, dirs[parser.AgentAider], injected,
+		"newline-bearing repository paths must not inject a second transfer target")
+	for _, target := range dirs[parser.AgentAider] {
+		assert.NotContains(t, target, "\n",
+			"aider transfer target must not contain record separators")
+	}
+}
+
 // TestResolveScriptAiderRejectsHomeOverride verifies that setting AIDER_DIR
 // to literal $HOME (the very thing the home-default skip prevents) is also
 // dropped, so an unscoped override cannot reintroduce a whole-home tar.
@@ -224,6 +248,21 @@ func TestParseResolvedDirs(t *testing.T) {
 	assert.Len(t, dirs, 3)
 
 	// The duplicate index file line is deduplicated.
+	assert.Equal(t,
+		[]string{"/home/wes/.codex/session_index.jsonl"}, extraFiles)
+}
+
+func TestParseResolvedDirsNULRecords(t *testing.T) {
+	input := "claude:/home/wes/.claude/projects\x00" +
+		"aider:/home/wes/code/repo/.aider.chat.history.md\x00" +
+		"@file:/home/wes/.codex/session_index.jsonl\x00"
+
+	dirs, extraFiles := parseResolvedDirs(input)
+
+	assert.Equal(t, []string{"/home/wes/.claude/projects"}, dirs[parser.AgentClaude])
+	assert.Equal(t,
+		[]string{"/home/wes/code/repo/.aider.chat.history.md"},
+		dirs[parser.AgentAider])
 	assert.Equal(t,
 		[]string{"/home/wes/.codex/session_index.jsonl"}, extraFiles)
 }

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -139,13 +139,24 @@ func TestResolveScriptSkipsAiderHomeDefault(t *testing.T) {
 		"aider must not resolve to the whole home dir")
 }
 
-// TestResolveScriptAiderScopedByEnv verifies that an explicit AIDER_DIR
-// scopes aider's remote transfer to that directory (the intended use), so
-// remote sync still works when the user points AIDER_DIR at a code root.
-func TestResolveScriptAiderScopedByEnv(t *testing.T) {
+// TestResolveScriptAiderScopedByEnvFindsHistoryFiles verifies that an explicit
+// AIDER_DIR discovers only aider history files for transfer. The remote sync
+// treats resolved entries as tar targets, so emitting the code root would
+// archive the entire repository instead of just .aider.chat.history.md files.
+func TestResolveScriptAiderScopedByEnvFindsHistoryFiles(t *testing.T) {
 	home := t.TempDir()
 	codeRoot := filepath.Join(home, "code")
-	require.NoError(t, os.MkdirAll(codeRoot, 0o755), "mkdir code root")
+	repoA := filepath.Join(codeRoot, "repo-a")
+	repoB := filepath.Join(codeRoot, "nested", "repo-b")
+	require.NoError(t, os.MkdirAll(repoA, 0o755), "mkdir repo A")
+	require.NoError(t, os.MkdirAll(repoB, 0o755), "mkdir repo B")
+	historyA := filepath.Join(repoA, parser.AiderHistoryFileName())
+	historyB := filepath.Join(repoB, parser.AiderHistoryFileName())
+	require.NoError(t, os.WriteFile(historyA, []byte("# aider\n"), 0o644))
+	require.NoError(t, os.WriteFile(historyB, []byte("# aider\n"), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoA, "source.go"), []byte("package main\n"), 0o644,
+	))
 
 	script := buildResolveScript()
 	cmd := exec.Command("sh", "-c", script)
@@ -154,8 +165,10 @@ func TestResolveScriptAiderScopedByEnv(t *testing.T) {
 	require.NoError(t, err, "resolve script failed: output: %s", out)
 
 	dirs, _ := parseResolvedDirs(string(out))
-	assert.Equal(t, []string{codeRoot}, dirs[parser.AgentAider],
-		"explicit AIDER_DIR must scope aider's remote transfer")
+	assert.ElementsMatch(t, []string{historyA, historyB}, dirs[parser.AgentAider],
+		"explicit AIDER_DIR must resolve only aider history files")
+	assert.NotContains(t, dirs[parser.AgentAider], codeRoot,
+		"AIDER_DIR itself must not become a tar target")
 }
 
 // TestResolveScriptAiderRejectsHomeOverride verifies that setting AIDER_DIR

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -173,17 +174,21 @@ func TestResolveScriptAiderScopedByEnvFindsHistoryFiles(t *testing.T) {
 	require.NoError(t, err, "resolve script failed: output: %s", out)
 
 	dirs, _ := parseResolvedDirs(string(out))
-	assert.ElementsMatch(t, []string{historyA, historyB}, dirs[parser.AgentAider],
+	aiderTargets := slashPaths(dirs[parser.AgentAider])
+	assert.ElementsMatch(t, []string{filepath.ToSlash(historyA), filepath.ToSlash(historyB)}, aiderTargets,
 		"explicit AIDER_DIR must resolve only aider history files")
-	assert.NotContains(t, dirs[parser.AgentAider], codeRoot,
+	assert.NotContains(t, aiderTargets, filepath.ToSlash(codeRoot),
 		"AIDER_DIR itself must not become a tar target")
-	assert.NotContains(t, dirs[parser.AgentAider], skippedHistory,
+	assert.NotContains(t, aiderTargets, filepath.ToSlash(skippedHistory),
 		"remote aider discovery must prune local-discovery skip dirs")
-	assert.NotContains(t, dirs[parser.AgentAider], deepHistory,
+	assert.NotContains(t, aiderTargets, filepath.ToSlash(deepHistory),
 		"remote aider discovery must enforce the local depth cap")
 }
 
 func TestResolveScriptAiderNewlinePathCannotInjectTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows path APIs reject embedded newlines; this regression covers POSIX remote shell output")
+	}
 	home := t.TempDir()
 	codeRoot := filepath.Join(home, "code")
 	injected := "/home/victim/" + parser.AiderHistoryFileName()
@@ -205,6 +210,14 @@ func TestResolveScriptAiderNewlinePathCannotInjectTarget(t *testing.T) {
 		assert.NotContains(t, target, "\n",
 			"aider transfer target must not contain record separators")
 	}
+}
+
+func slashPaths(paths []string) []string {
+	out := make([]string, len(paths))
+	for i, p := range paths {
+		out[i] = filepath.ToSlash(p)
+	}
+	return out
 }
 
 // TestResolveScriptAiderRejectsHomeOverride verifies that setting AIDER_DIR

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7781,6 +7781,8 @@ func (e *Engine) FindSourceFile(sessionID string) string {
 		}
 	}
 
+	bareID := strings.TrimPrefix(rawID, def.IDPrefix)
+
 	// Prefer stored file_path — it's authoritative and handles
 	// cases where the session ID doesn't match the filename.
 	// Resolve virtual paths (e.g. Visual Studio Copilot's
@@ -7788,12 +7790,20 @@ func (e *Engine) FindSourceFile(sessionID string) string {
 	// return the stored path so downstream parsing stays scoped to
 	// the requested conversation rather than the whole trace file.
 	if fp := e.db.GetSessionFilePath(sessionID); fp != "" {
-		if _, err := os.Stat(parser.ResolveSourceFilePath(fp)); err == nil {
+		if historyPath, idx, ok := parser.ParseAiderVirtualPath(fp); ok {
+			// aider's stored "<historyPath>#<idx>" is positional: an
+			// inserted or removed earlier run shifts the index onto a
+			// different session. Only trust the stored path when run idx
+			// still recomputes to the requested raw ID; otherwise fall
+			// through to FindSourceFunc, which re-resolves by raw ID.
+			if got, ok := parser.AiderRawIDAt(historyPath, idx); ok && got == bareID {
+				return fp
+			}
+		} else if _, err := os.Stat(parser.ResolveSourceFilePath(fp)); err == nil {
 			return fp
 		}
 	}
 
-	bareID := strings.TrimPrefix(rawID, def.IDPrefix)
 	for _, d := range e.agentDirs[def.Type] {
 		if f := def.FindSourceFunc(d, bareID); f != "" {
 			return f

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5681,6 +5681,30 @@ func (e *Engine) processGptme(
 	}
 }
 
+// aiderFileUnchanged reports whether a physical aider history file is
+// unchanged since the last sync. Aider sessions are stored under virtual
+// "<history>#<idx>" paths, so the generic shouldSkipByPath (which looks the
+// physical path up in the DB) never matches and would re-parse, re-hash, and
+// re-write every run on every full/periodic sync. Mirror the per-virtual-path
+// skip the other multi-session agents use (cf. kiroSQLitePendingSessionIDs):
+// if any run's stored row matches this file's mtime at the current data
+// version, the file has not changed and the whole fan-out can be skipped.
+func (e *Engine) aiderFileUnchanged(path string, info os.FileInfo) bool {
+	metas, err := parser.ListAiderRunMetas(path)
+	if err != nil {
+		return false
+	}
+	mtime := info.ModTime().UnixNano()
+	for _, m := range metas {
+		_, storedMtime, ok := e.db.GetFileInfoByPath(m.VirtualPath)
+		if ok && storedMtime == mtime &&
+			e.db.GetDataVersionByPath(m.VirtualPath) >= db.CurrentDataVersion() {
+			return true
+		}
+	}
+	return false
+}
+
 func (e *Engine) processAider(
 	file parser.DiscoveredFile, info os.FileInfo,
 ) processResult {
@@ -5703,7 +5727,7 @@ func (e *Engine) processAider(
 		}
 	}
 
-	if e.shouldSkipByPath(file.Path, info) {
+	if e.aiderFileUnchanged(file.Path, info) {
 		return processResult{skip: true}
 	}
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1113,6 +1113,22 @@ func (e *Engine) classifyOnePath(
 		}
 	}
 
+	// aider: <aiderRoot>/.../.aider.chat.history.md (rootless; any depth
+	// under the configured root).
+	if filepath.Base(path) == parser.AiderHistoryFileName() {
+		for _, aiderDir := range e.agentDirs[parser.AgentAider] {
+			if aiderDir == "" {
+				continue
+			}
+			if _, ok := isUnder(aiderDir, path); ok {
+				return parser.DiscoveredFile{
+					Path:  path,
+					Agent: parser.AgentAider,
+				}, true
+			}
+		}
+	}
+
 	// Command Code: <projectsDir>/<slugified-cwd>/<session>.jsonl
 	for _, commandCodeDir := range e.agentDirs[parser.AgentCommandCode] {
 		if commandCodeDir == "" {
@@ -3631,6 +3647,10 @@ func (e *Engine) processFile(
 			statPath = dbPath
 		} else if tracePath, _, ok := parser.ParseVisualStudioCopilotVirtualPath(file.Path); ok {
 			statPath = tracePath
+		} else if historyPath, _, ok := parser.ParseAiderVirtualPath(file.Path); ok {
+			// aider stores "<historyFile>#<runIdx>"; stat the physical file
+			// so SyncSingleSession (live watcher / on-demand re-sync) works.
+			statPath = historyPath
 		}
 		info, err = os.Stat(statPath)
 	}
@@ -3751,6 +3771,8 @@ func (e *Engine) processFile(
 		res = e.processQwenPaw(file, info)
 	case parser.AgentGptme:
 		res = e.processGptme(file, info)
+	case parser.AgentAider:
+		res = e.processAider(file, info)
 	default:
 		res = processResult{
 			err: fmt.Errorf(
@@ -3801,6 +3823,16 @@ func (e *Engine) shouldCacheSkip(
 		}
 		if _, _, ok :=
 			parser.ParseVisualStudioCopilotVirtualPath(file.Path); ok {
+			return false
+		}
+	}
+	if file.Agent == parser.AgentAider {
+		// A virtual aider path ("<historyFile>#<runIdx>") resolves to one
+		// run inside a shared physical file; let processAider own it so the
+		// generic per-file mtime cache cannot stand in for the per-run parse.
+		// The physical history file itself keeps the generic mtime skip: any
+		// write bumps the file mtime and re-parses every run.
+		if _, _, ok := parser.ParseAiderVirtualPath(file.Path); ok {
 			return false
 		}
 	}
@@ -5646,6 +5678,54 @@ func (e *Engine) processGptme(
 		results: []parser.ParseResult{
 			{Session: *sess, Messages: msgs},
 		},
+	}
+}
+
+func (e *Engine) processAider(
+	file parser.DiscoveredFile, info os.FileInfo,
+) processResult {
+	// Virtual path "<historyFile>#<runIdx>": parse that one run only. Used
+	// when re-syncing a single session by its source path.
+	if historyPath, idx, ok := parser.ParseAiderVirtualPath(file.Path); ok {
+		sess, msgs, err := parser.ParseAiderRun(historyPath, idx, e.machine)
+		if err != nil {
+			return processResult{err: err}
+		}
+		if sess == nil {
+			return processResult{}
+		}
+		if hash, err := ComputeFileHash(historyPath); err == nil {
+			sess.File.Hash = hash
+		}
+		return processResult{
+			results:      []parser.ParseResult{{Session: *sess, Messages: msgs}},
+			forceReplace: true,
+		}
+	}
+
+	if e.shouldSkipByPath(file.Path, info) {
+		return processResult{skip: true}
+	}
+
+	// Physical history file: fan it out into one session per run. The file
+	// is read and split once. The whole file shares one content hash, so
+	// any write re-parses every run (acceptable: aider history is
+	// append-mostly and a single capped read).
+	results, err := parser.ParseAiderRuns(file.Path, e.machine)
+	if err != nil {
+		return processResult{err: err}
+	}
+	if len(results) == 0 {
+		return processResult{}
+	}
+	if hash, err := ComputeFileHash(file.Path); err == nil {
+		for i := range results {
+			results[i].Session.File.Hash = hash
+		}
+	}
+	return processResult{
+		results:      results,
+		forceReplace: true,
 	}
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5714,9 +5714,13 @@ func (e *Engine) aiderFileUnchanged(path string, info os.FileInfo) bool {
 			continue
 		}
 		expected++
-		storedSize, storedMtime, ok := e.db.GetFileInfoByPath(m.VirtualPath)
+		lookupPath := m.VirtualPath
+		if e.pathRewriter != nil {
+			lookupPath = e.pathRewriter(lookupPath)
+		}
+		storedSize, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
 		if !ok || storedSize != size || storedMtime != mtime ||
-			e.db.GetDataVersionByPath(m.VirtualPath) < current {
+			e.db.GetDataVersionByPath(lookupPath) < current {
 			// This run is missing or stale: do not skip the file, so the
 			// fan-out re-parses and repairs every run. The size is compared
 			// alongside mtime so a same-mtime append/truncate (which leaves

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5686,23 +5686,57 @@ func (e *Engine) processGptme(
 // "<history>#<idx>" paths, so the generic shouldSkipByPath (which looks the
 // physical path up in the DB) never matches and would re-parse, re-hash, and
 // re-write every run on every full/periodic sync. Mirror the per-virtual-path
-// skip the other multi-session agents use (cf. kiroSQLitePendingSessionIDs):
-// if any run's stored row matches this file's mtime at the current data
-// version, the file has not changed and the whole fan-out can be skipped.
+// skip the other multi-session agents use (cf. kiroSQLitePendingSessionIDs).
+//
+// The whole file is skipped only when EVERY expected run row is known
+// current: each run meta's virtual path must have a stored row whose mtime
+// matches this file's and whose data version is current. If any run row is
+// missing (e.g. a previous batch wrote only some runs, or a new run was
+// appended whose row does not exist yet) or stale (an older data version, or
+// resynced after a data-version bump while siblings were not), the file is
+// re-parsed so the remaining sessions are repaired. Skipping on the first
+// matching row would strand those runs forever. A run-less or unreadable
+// file is treated as changed (never skipped) so it is retried.
 func (e *Engine) aiderFileUnchanged(path string, info os.FileInfo) bool {
 	metas, err := parser.ListAiderRunMetas(path)
-	if err != nil {
+	if err != nil || len(metas) == 0 {
 		return false
 	}
 	mtime := info.ModTime().UnixNano()
+	current := db.CurrentDataVersion()
+	expected := 0
 	for _, m := range metas {
+		// Header-only runs produce no session row, so the fan-out never
+		// writes one for them; do not expect a stored row.
+		if !m.HasMessages {
+			continue
+		}
+		expected++
 		_, storedMtime, ok := e.db.GetFileInfoByPath(m.VirtualPath)
-		if ok && storedMtime == mtime &&
-			e.db.GetDataVersionByPath(m.VirtualPath) >= db.CurrentDataVersion() {
-			return true
+		if !ok || storedMtime != mtime ||
+			e.db.GetDataVersionByPath(m.VirtualPath) < current {
+			// This run is missing or stale: do not skip the file, so the
+			// fan-out re-parses and repairs every run.
+			return false
 		}
 	}
-	return false
+	// Skip only when at least one run was expected and all expected run rows
+	// are current. A file whose runs all lack turns produces no sessions, so
+	// there is nothing to skip-and-strand; re-parse it (cheap, capped read).
+	return expected > 0
+}
+
+// aiderIdentityPath returns the canonical history-file path used to derive
+// stable aider session IDs. During remote SSH sync the file is read from a
+// random temp extraction dir, so hashing the on-disk path would re-key the
+// run on every sync; rewriting it to its canonical remote path keeps the ID
+// stable. Returns "" for local sync (no pathRewriter), which makes the
+// parser fall back to the on-disk path -- the original local behavior.
+func (e *Engine) aiderIdentityPath(historyPath string) string {
+	if e.pathRewriter == nil {
+		return ""
+	}
+	return e.pathRewriter(historyPath)
 }
 
 func (e *Engine) processAider(
@@ -5711,7 +5745,9 @@ func (e *Engine) processAider(
 	// Virtual path "<historyFile>#<runIdx>": parse that one run only. Used
 	// when re-syncing a single session by its source path.
 	if historyPath, idx, ok := parser.ParseAiderVirtualPath(file.Path); ok {
-		sess, msgs, err := parser.ParseAiderRun(historyPath, idx, e.machine)
+		sess, msgs, err := parser.ParseAiderRunWithID(
+			historyPath, e.aiderIdentityPath(historyPath), idx, e.machine,
+		)
 		if err != nil {
 			return processResult{err: err}
 		}
@@ -5735,7 +5771,9 @@ func (e *Engine) processAider(
 	// is read and split once. The whole file shares one content hash, so
 	// any write re-parses every run (acceptable: aider history is
 	// append-mostly and a single capped read).
-	results, err := parser.ParseAiderRuns(file.Path, e.machine)
+	results, err := parser.ParseAiderRunsWithID(
+		file.Path, e.aiderIdentityPath(file.Path), e.machine,
+	)
 	if err != nil {
 		return processResult{err: err}
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5689,9 +5689,10 @@ func (e *Engine) processGptme(
 // skip the other multi-session agents use (cf. kiroSQLitePendingSessionIDs).
 //
 // The whole file is skipped only when EVERY expected run row is known
-// current: each run meta's virtual path must have a stored row whose mtime
-// matches this file's and whose data version is current. If any run row is
-// missing (e.g. a previous batch wrote only some runs, or a new run was
+// current: each run meta's virtual path must have a stored row whose size and
+// mtime match this file's and whose data version is current. Size is checked
+// alongside mtime so a same-mtime append/truncate is not wrongly skipped. If
+// any run row is missing (e.g. a previous batch wrote only some runs, or a new run was
 // appended whose row does not exist yet) or stale (an older data version, or
 // resynced after a data-version bump while siblings were not), the file is
 // re-parsed so the remaining sessions are repaired. Skipping on the first
@@ -5703,6 +5704,7 @@ func (e *Engine) aiderFileUnchanged(path string, info os.FileInfo) bool {
 		return false
 	}
 	mtime := info.ModTime().UnixNano()
+	size := info.Size()
 	current := db.CurrentDataVersion()
 	expected := 0
 	for _, m := range metas {
@@ -5712,11 +5714,13 @@ func (e *Engine) aiderFileUnchanged(path string, info os.FileInfo) bool {
 			continue
 		}
 		expected++
-		_, storedMtime, ok := e.db.GetFileInfoByPath(m.VirtualPath)
-		if !ok || storedMtime != mtime ||
+		storedSize, storedMtime, ok := e.db.GetFileInfoByPath(m.VirtualPath)
+		if !ok || storedSize != size || storedMtime != mtime ||
 			e.db.GetDataVersionByPath(m.VirtualPath) < current {
 			// This run is missing or stale: do not skip the file, so the
-			// fan-out re-parses and repairs every run.
+			// fan-out re-parses and repairs every run. The size is compared
+			// alongside mtime so a same-mtime append/truncate (which leaves
+			// new or removed runs unsynced) is never wrongly skipped.
 			return false
 		}
 	}
@@ -5763,7 +5767,9 @@ func (e *Engine) processAider(
 		}
 	}
 
-	if e.aiderFileUnchanged(file.Path, info) {
+	// parse-diff: !e.forceParse disables the stored-state skip so a forced
+	// reparse re-reads already-synced aider files instead of skipping them.
+	if !e.forceParse && e.aiderFileUnchanged(file.Path, info) {
 		return processResult{skip: true}
 	}
 

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1428,12 +1428,13 @@ func writeAiderHistory(t *testing.T) string {
 }
 
 // insertAiderRunRow stores a session row for one aider virtual run path at
-// the given mtime and data version, mirroring what a real fan-out write
+// the given size, mtime, and data version, mirroring what a real fan-out write
 // produces. data_version is stamped separately because UpsertSession does
-// not persist it.
+// not persist it. The stored size must match the history file's reported size
+// for aiderFileUnchanged to treat the run as current.
 func insertAiderRunRow(
 	t *testing.T, database *db.DB,
-	virtualPath string, mtime int64, dataVersion int,
+	virtualPath string, size, mtime int64, dataVersion int,
 ) {
 	t.Helper()
 	id := "aider:" + virtualPath
@@ -1443,7 +1444,7 @@ func insertAiderRunRow(
 		Machine:   "local",
 		Agent:     string(parser.AgentAider),
 		FilePath:  strPtr(virtualPath),
-		FileSize:  int64Ptr(1),
+		FileSize:  int64Ptr(size),
 		FileMtime: int64Ptr(mtime),
 	}))
 	require.NoError(t, database.SetSessionDataVersion(id, dataVersion))
@@ -1456,6 +1457,7 @@ func insertAiderRunRow(
 // after a data-version bump, so they would never be repaired.
 func TestAiderFileUnchangedRequiresAllRuns(t *testing.T) {
 	const mtime = int64(1_700_000_000_000_000_000)
+	const size = int64(4096)
 	cur := db.CurrentDataVersion()
 
 	metasFor := func(t *testing.T, path string) []parser.AiderRunMeta {
@@ -1476,11 +1478,11 @@ func TestAiderFileUnchangedRequiresAllRuns(t *testing.T) {
 		metas := metasFor(t, path)
 		// Both content runs have a current row. The header-only run has none,
 		// and must not block the skip.
-		insertAiderRunRow(t, database, metas[0].VirtualPath, mtime, cur)
-		insertAiderRunRow(t, database, metas[1].VirtualPath, mtime, cur)
+		insertAiderRunRow(t, database, metas[0].VirtualPath, size, mtime, cur)
+		insertAiderRunRow(t, database, metas[1].VirtualPath, size, mtime, cur)
 
 		e := &Engine{db: database}
-		got := e.aiderFileUnchanged(path, fakeFileInfo{mtime: mtime})
+		got := e.aiderFileUnchanged(path, fakeFileInfo{size: size, mtime: mtime})
 		assert.True(t, got, "file with all run rows current must be skipped")
 	})
 
@@ -1490,10 +1492,10 @@ func TestAiderFileUnchangedRequiresAllRuns(t *testing.T) {
 		metas := metasFor(t, path)
 		// Only the FIRST content run was written (a partial batch). Under the
 		// old any-match logic this stranded the second run forever.
-		insertAiderRunRow(t, database, metas[0].VirtualPath, mtime, cur)
+		insertAiderRunRow(t, database, metas[0].VirtualPath, size, mtime, cur)
 
 		e := &Engine{db: database}
-		got := e.aiderFileUnchanged(path, fakeFileInfo{mtime: mtime})
+		got := e.aiderFileUnchanged(path, fakeFileInfo{size: size, mtime: mtime})
 		assert.False(t, got,
 			"a missing run row must force a re-parse to repair it")
 	})
@@ -1502,13 +1504,13 @@ func TestAiderFileUnchangedRequiresAllRuns(t *testing.T) {
 		database := openTestDB(t)
 		path := writeAiderHistory(t)
 		metas := metasFor(t, path)
-		insertAiderRunRow(t, database, metas[0].VirtualPath, mtime, cur)
+		insertAiderRunRow(t, database, metas[0].VirtualPath, size, mtime, cur)
 		// The second run was resynced under an OLDER data version while the
 		// first is current. The file must still re-parse.
-		insertAiderRunRow(t, database, metas[1].VirtualPath, mtime, cur-1)
+		insertAiderRunRow(t, database, metas[1].VirtualPath, size, mtime, cur-1)
 
 		e := &Engine{db: database}
-		got := e.aiderFileUnchanged(path, fakeFileInfo{mtime: mtime})
+		got := e.aiderFileUnchanged(path, fakeFileInfo{size: size, mtime: mtime})
 		assert.False(t, got,
 			"a stale data-version run row must force a re-parse")
 	})
@@ -1517,14 +1519,82 @@ func TestAiderFileUnchangedRequiresAllRuns(t *testing.T) {
 		database := openTestDB(t)
 		path := writeAiderHistory(t)
 		metas := metasFor(t, path)
-		insertAiderRunRow(t, database, metas[0].VirtualPath, mtime, cur)
-		insertAiderRunRow(t, database, metas[1].VirtualPath, mtime-1, cur)
+		insertAiderRunRow(t, database, metas[0].VirtualPath, size, mtime, cur)
+		insertAiderRunRow(t, database, metas[1].VirtualPath, size, mtime-1, cur)
 
 		e := &Engine{db: database}
-		got := e.aiderFileUnchanged(path, fakeFileInfo{mtime: mtime})
+		got := e.aiderFileUnchanged(path, fakeFileInfo{size: size, mtime: mtime})
 		assert.False(t, got,
 			"a run row with a different mtime must force a re-parse")
 	})
+
+	t.Run("one run row stale size -> do not skip", func(t *testing.T) {
+		database := openTestDB(t)
+		path := writeAiderHistory(t)
+		metas := metasFor(t, path)
+		insertAiderRunRow(t, database, metas[0].VirtualPath, size, mtime, cur)
+		// The second run row has the SAME mtime but a different stored size,
+		// modeling a same-mtime append/truncate. Ignoring size would wrongly
+		// skip the file and strand the appended/removed runs.
+		insertAiderRunRow(t, database, metas[1].VirtualPath, size-1, mtime, cur)
+
+		e := &Engine{db: database}
+		got := e.aiderFileUnchanged(path, fakeFileInfo{size: size, mtime: mtime})
+		assert.False(t, got,
+			"a run row with a different size must force a re-parse")
+	})
+}
+
+// TestProcessAiderForceParseReparsesUnchangedFile is the forced-reparse
+// regression test: under forceParse (parse-diff), processAider must NOT take
+// the aiderFileUnchanged skip even when every run row is current, so a forced
+// run re-reads already-synced aider files instead of stranding them.
+func TestProcessAiderForceParseReparsesUnchangedFile(t *testing.T) {
+	database := openTestDB(t)
+	path := writeAiderHistory(t)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	// processAider stats the real file, so the stored rows must carry the
+	// file's actual size and mtime for the unchanged-skip to fire.
+	size := info.Size()
+	mtime := info.ModTime().UnixNano()
+	cur := db.CurrentDataVersion()
+
+	metas, err := parser.ListAiderRunMetas(path)
+	require.NoError(t, err)
+	require.Len(t, metas, 3)
+	// Mark every content-bearing run as current so the non-forced path skips.
+	insertAiderRunRow(t, database, metas[0].VirtualPath, size, mtime, cur)
+	insertAiderRunRow(t, database, metas[1].VirtualPath, size, mtime, cur)
+
+	file := parser.DiscoveredFile{Path: path, Agent: parser.AgentAider}
+
+	// Sanity: without forceParse the unchanged file is skipped.
+	normal := &Engine{db: database, machine: "local"}
+	skipRes := normal.processAider(file, info)
+	require.True(t, skipRes.skip,
+		"without forceParse an unchanged aider file must be skipped")
+	require.Empty(t, skipRes.results)
+
+	// With forceParse the file must be reparsed, not skipped.
+	forced := &Engine{db: database, machine: "local", forceParse: true}
+	forcedRes := forced.processAider(file, info)
+	require.NoError(t, forcedRes.err)
+	assert.False(t, forcedRes.skip,
+		"forceParse must reparse an unchanged aider file, not skip it")
+	assert.Len(t, forcedRes.results, 2,
+		"forced reparse must fan out one result per content-bearing run")
+}
+
+// TestStripVirtualSourceSuffixAider verifies that an aider
+// <history>#<runIdx> virtual path strips back to its physical history file,
+// so parse-diff missing-run and parse-error reporting keys on the on-disk
+// file rather than the run-scoped virtual path.
+func TestStripVirtualSourceSuffixAider(t *testing.T) {
+	historyPath := "/home/user/myrepo/" + parser.AiderHistoryFileName()
+	virtual := parser.AiderVirtualPath(historyPath, 3)
+	assert.Equal(t, historyPath, stripVirtualSourceSuffix(virtual),
+		"the run-index suffix must strip to the physical history path")
 }
 
 func TestToDBSessionStoresSessionName(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1409,6 +1409,124 @@ func TestShouldSkipByPathWithRewriter(t *testing.T) {
 	assert.False(t, got2, "shouldSkipByPath without rewriter should return false")
 }
 
+// writeAiderHistory writes a two-content-run plus one header-only-run
+// history file under a fresh repo dir and returns its path. The header-only
+// trailing run produces no session, exercising the HasMessages path of
+// aiderFileUnchanged.
+func writeAiderHistory(t *testing.T) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "myrepo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	path := filepath.Join(repo, parser.AiderHistoryFileName())
+	content := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### first prompt\nanswer one\n" +
+		"# aider chat started at 2026-06-09 15:30:00\n" +
+		"#### second prompt\nanswer two\n" +
+		"# aider chat started at 2026-06-09 16:45:00\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+// insertAiderRunRow stores a session row for one aider virtual run path at
+// the given mtime and data version, mirroring what a real fan-out write
+// produces. data_version is stamped separately because UpsertSession does
+// not persist it.
+func insertAiderRunRow(
+	t *testing.T, database *db.DB,
+	virtualPath string, mtime int64, dataVersion int,
+) {
+	t.Helper()
+	id := "aider:" + virtualPath
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:        id,
+		Project:   "myrepo",
+		Machine:   "local",
+		Agent:     string(parser.AgentAider),
+		FilePath:  strPtr(virtualPath),
+		FileSize:  int64Ptr(1),
+		FileMtime: int64Ptr(mtime),
+	}))
+	require.NoError(t, database.SetSessionDataVersion(id, dataVersion))
+}
+
+// TestAiderFileUnchangedRequiresAllRuns is the MEDIUM-2 regression test:
+// aiderFileUnchanged must skip a file only when EVERY content-bearing run
+// row is current. Skipping on the first matching row (the old behavior)
+// would strand runs that a partial batch never wrote or that went stale
+// after a data-version bump, so they would never be repaired.
+func TestAiderFileUnchangedRequiresAllRuns(t *testing.T) {
+	const mtime = int64(1_700_000_000_000_000_000)
+	cur := db.CurrentDataVersion()
+
+	metasFor := func(t *testing.T, path string) []parser.AiderRunMeta {
+		t.Helper()
+		metas, err := parser.ListAiderRunMetas(path)
+		require.NoError(t, err)
+		// Two content-bearing runs plus one header-only run.
+		require.Len(t, metas, 3)
+		require.True(t, metas[0].HasMessages)
+		require.True(t, metas[1].HasMessages)
+		require.False(t, metas[2].HasMessages)
+		return metas
+	}
+
+	t.Run("all runs current -> skip", func(t *testing.T) {
+		database := openTestDB(t)
+		path := writeAiderHistory(t)
+		metas := metasFor(t, path)
+		// Both content runs have a current row. The header-only run has none,
+		// and must not block the skip.
+		insertAiderRunRow(t, database, metas[0].VirtualPath, mtime, cur)
+		insertAiderRunRow(t, database, metas[1].VirtualPath, mtime, cur)
+
+		e := &Engine{db: database}
+		got := e.aiderFileUnchanged(path, fakeFileInfo{mtime: mtime})
+		assert.True(t, got, "file with all run rows current must be skipped")
+	})
+
+	t.Run("one run row missing -> do not skip", func(t *testing.T) {
+		database := openTestDB(t)
+		path := writeAiderHistory(t)
+		metas := metasFor(t, path)
+		// Only the FIRST content run was written (a partial batch). Under the
+		// old any-match logic this stranded the second run forever.
+		insertAiderRunRow(t, database, metas[0].VirtualPath, mtime, cur)
+
+		e := &Engine{db: database}
+		got := e.aiderFileUnchanged(path, fakeFileInfo{mtime: mtime})
+		assert.False(t, got,
+			"a missing run row must force a re-parse to repair it")
+	})
+
+	t.Run("one run row stale data version -> do not skip", func(t *testing.T) {
+		database := openTestDB(t)
+		path := writeAiderHistory(t)
+		metas := metasFor(t, path)
+		insertAiderRunRow(t, database, metas[0].VirtualPath, mtime, cur)
+		// The second run was resynced under an OLDER data version while the
+		// first is current. The file must still re-parse.
+		insertAiderRunRow(t, database, metas[1].VirtualPath, mtime, cur-1)
+
+		e := &Engine{db: database}
+		got := e.aiderFileUnchanged(path, fakeFileInfo{mtime: mtime})
+		assert.False(t, got,
+			"a stale data-version run row must force a re-parse")
+	})
+
+	t.Run("one run row stale mtime -> do not skip", func(t *testing.T) {
+		database := openTestDB(t)
+		path := writeAiderHistory(t)
+		metas := metasFor(t, path)
+		insertAiderRunRow(t, database, metas[0].VirtualPath, mtime, cur)
+		insertAiderRunRow(t, database, metas[1].VirtualPath, mtime-1, cur)
+
+		e := &Engine{db: database}
+		got := e.aiderFileUnchanged(path, fakeFileInfo{mtime: mtime})
+		assert.False(t, got,
+			"a run row with a different mtime must force a re-parse")
+	})
+}
+
 func TestToDBSessionStoresSessionName(t *testing.T) {
 	pw := pendingWrite{sess: parser.ParsedSession{
 		ID:           "commandcode:test",

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1486,6 +1486,26 @@ func TestAiderFileUnchangedRequiresAllRuns(t *testing.T) {
 		assert.True(t, got, "file with all run rows current must be skipped")
 	})
 
+	t.Run("rewritten remote run rows current -> skip", func(t *testing.T) {
+		database := openTestDB(t)
+		path := writeAiderHistory(t)
+		metas := metasFor(t, path)
+		rewriter := func(p string) string {
+			return "host:" + p
+		}
+		// Remote sync stores the rewritten virtual run path, not the temp
+		// extraction path returned by ListAiderRunMetas.
+		insertAiderRunRow(t, database,
+			rewriter(metas[0].VirtualPath), size, mtime, cur)
+		insertAiderRunRow(t, database,
+			rewriter(metas[1].VirtualPath), size, mtime, cur)
+
+		e := &Engine{db: database, pathRewriter: rewriter}
+		got := e.aiderFileUnchanged(path, fakeFileInfo{size: size, mtime: mtime})
+		assert.True(t, got,
+			"remote file with all rewritten run rows current must be skipped")
+	})
+
 	t.Run("one run row missing -> do not skip", func(t *testing.T) {
 		database := openTestDB(t)
 		path := writeAiderHistory(t)

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -338,11 +338,15 @@ func sortAndLimitParseDiffFiles(
 // stripVirtualSourceSuffix maps a stored file_path to its on-disk base
 // file by removing the "#rawID" suffix that Kiro, Zed, OpenCode, Kilo,
 // MiMoCode, and Shelley SQLite-backed sessions append to their shared database
-// path, and the "#conversationID" suffix Visual Studio Copilot appends to its
-// shared trace file.
+// path, the "#conversationID" suffix Visual Studio Copilot appends to its
+// shared trace file, and the "#runIdx" suffix aider appends to its shared
+// history file.
 func stripVirtualSourceSuffix(path string) string {
 	if tracePath, _, ok := parser.ParseVisualStudioCopilotVirtualPath(path); ok {
 		return tracePath
+	}
+	if historyPath, _, ok := parser.ParseAiderVirtualPath(path); ok {
+		return historyPath
 	}
 	if dbPath, _, ok := parser.ParseKiroSQLiteVirtualPath(path); ok {
 		return dbPath


### PR DESCRIPTION
## Summary

Adds an `aider` session parser. aider stores per-repo chat history as Markdown at `<repo>/.aider.chat.history.md`, where each file accumulates multiple `# aider chat started at ...` runs.

## What it does

- Splits a history file into one session per run, using the existing virtual-path fan-out (`<historyFile>#<runIdx>`) already used by the Shelley and Zed parsers, so a physical file maps to multiple sessions rather than one flattened blob.
- Parses `####` user prompts, assistant prose, and `> ` tool/edit lines. aider has no tool role in agentsview, so tool/edit lines surface as assistant transcript content (the `> Applied edit to ...` lines are preserved verbatim), mirroring the gptme parser.
- Discovers history files with a bounded, time-budgeted (2s) rootless walk under a configurable root — default `$HOME`, override via `AIDER_DIR` / `aider_dirs` — with a skip-set and a depth cap. The agent uses a shallow file watch so it does not recursively watch the whole home directory; new runs are picked up by the periodic sync.

## Identity and limitations

- Session IDs derive from the history-file path, the run's header timestamp, and an ordinal among same-header runs, so appends and different-header edits never re-key existing sessions. Residual: runs that share a byte-identical header timestamp (same repo, same second) disambiguate by position, so removing an earlier same-header run re-keys its later same-header siblings — rare given aider's 1-second header resolution, and pinned by a test.
- Per the multi-session-per-file model (same as Shelley/Zed), a run removed from a still-present file is reconciled on the next full resync rather than incrementally.

## Where to look

`internal/parser/aider.go` (parser + discovery), `internal/sync/engine.go` (`processAider` fan-out and the virtual-path stat resolution that lets a single session re-sync via the live watcher), `internal/parser/types.go` (registry entry, shallow watch).
