### PR TITLE
fix(activity): normalize filter chevrons

### DIFF
--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -8,6 +8,7 @@
   import { events } from "../../stores/events.svelte.js";
   import RefreshControl from "../shared/RefreshControl.svelte";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
+  import { ChevronDownIcon } from "../../icons.js";
   import RangeControl from "./RangeControl.svelte";
   import RangeNavigator from "./RangeNavigator.svelte";
   import SummaryCards from "./SummaryCards.svelte";
@@ -103,40 +104,64 @@
       onselect={onProjectSelect}
     />
 
-    <select
-      class="filter-select"
-      value={activity.agent}
-      onchange={onAgentChange}
-      aria-label="Filter by agent"
-    >
-      <option value="">All Agents</option>
-      {#each activity.agents as a}
-        <option value={a.name}>{a.name}</option>
-      {/each}
-    </select>
+    <div class="filter-select-wrap">
+      <select
+        class="filter-select"
+        value={activity.agent}
+        onchange={onAgentChange}
+        aria-label="Filter by agent"
+      >
+        <option value="">All Agents</option>
+        {#each activity.agents as a}
+          <option value={a.name}>{a.name}</option>
+        {/each}
+      </select>
+      <ChevronDownIcon
+        class="filter-select-chevron"
+        size="12"
+        strokeWidth="2.2"
+        aria-hidden="true"
+      />
+    </div>
 
-    <select
-      class="filter-select"
-      value={activity.machine}
-      onchange={onMachineChange}
-      aria-label="Filter by machine"
-    >
-      <option value="">All Machines</option>
-      {#each activity.machines as m}
-        <option value={m}>{m}</option>
-      {/each}
-    </select>
+    <div class="filter-select-wrap">
+      <select
+        class="filter-select"
+        value={activity.machine}
+        onchange={onMachineChange}
+        aria-label="Filter by machine"
+      >
+        <option value="">All Machines</option>
+        {#each activity.machines as m}
+          <option value={m}>{m}</option>
+        {/each}
+      </select>
+      <ChevronDownIcon
+        class="filter-select-chevron"
+        size="12"
+        strokeWidth="2.2"
+        aria-hidden="true"
+      />
+    </div>
 
-    <select
-      class="filter-select"
-      value={activity.automation}
-      onchange={onAutomationChange}
-      aria-label="Filter by automation"
-    >
-      <option value="all">All Sessions</option>
-      <option value="interactive">Interactive</option>
-      <option value="automated">Automated</option>
-    </select>
+    <div class="filter-select-wrap">
+      <select
+        class="filter-select"
+        value={activity.automation}
+        onchange={onAutomationChange}
+        aria-label="Filter by automation"
+      >
+        <option value="all">All Sessions</option>
+        <option value="interactive">Interactive</option>
+        <option value="automated">Automated</option>
+      </select>
+      <ChevronDownIcon
+        class="filter-select-chevron"
+        size="12"
+        strokeWidth="2.2"
+        aria-hidden="true"
+      />
+    </div>
 
     <div class="refresh-slot">
       <RefreshControl
@@ -224,20 +249,45 @@
     flex-shrink: 0;
   }
 
+  .filter-select-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-secondary);
+  }
+
   .filter-select {
+    appearance: none;
+    -webkit-appearance: none;
     height: 26px;
-    padding: 0 8px;
+    padding: 0 28px 0 8px;
     background: var(--bg-inset);
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
     font-size: 11px;
-    color: var(--text-secondary);
+    color: inherit;
     cursor: pointer;
+  }
+
+  .filter-select:hover {
+    border-color: var(--border-default);
   }
 
   .filter-select:focus {
     outline: none;
     border-color: var(--accent-blue);
+  }
+
+  :global(.filter-select-chevron) {
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    width: 12px;
+    height: 12px;
+    color: currentColor;
+    opacity: 0.72;
+    pointer-events: none;
+    transform: translateY(-50%);
   }
 
   /* Push the shared refresh control to the right edge of the toolbar, matching

--- a/frontend/src/lib/components/activity/ActivityPage.test.ts
+++ b/frontend/src/lib/components/activity/ActivityPage.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vite-plus/test";
+import source from "./ActivityPage.svelte?raw";
+
+describe("ActivityPage filter controls", () => {
+  it("uses explicit chevrons instead of browser-native select arrows", () => {
+    const selectWrapCount = source.match(/class="filter-select-wrap"/g)?.length ?? 0;
+    const selectChevronCount = source.match(/class="filter-select-chevron"/g)?.length ?? 0;
+    const filterSelectStyles = source.match(/\.filter-select\s*{[^}]+}/)?.[0] ?? "";
+
+    expect(selectWrapCount).toBe(3);
+    expect(selectChevronCount).toBe(3);
+    expect(filterSelectStyles).toContain("appearance: none");
+  });
+});

--- a/frontend/src/lib/components/layout/ProjectTypeahead.svelte
+++ b/frontend/src/lib/components/layout/ProjectTypeahead.svelte
@@ -140,7 +140,7 @@
   {:else}
     <button class="typeahead-trigger" onclick={openDropdown} title="Select project">
       <span class="typeahead-value">{displayValue}</span>
-      <ChevronDownIcon class="typeahead-chevron" size="10" strokeWidth="2" aria-hidden="true" />
+      <ChevronDownIcon class="typeahead-chevron" size="12" strokeWidth="2.2" aria-hidden="true" />
     </button>
   {/if}
 </div>
@@ -187,7 +187,10 @@
 
   :global(.typeahead-chevron) {
     flex-shrink: 0;
-    opacity: 0.5;
+    width: 12px;
+    height: 12px;
+    color: currentColor;
+    opacity: 0.72;
   }
 
   .typeahead-input {


### PR DESCRIPTION
Fixes the activity filter toolbar chevrons so the project typeahead and native selects render as one consistent control family. The old toolbar mixed a Lucide icon with browser-native select arrows, which made the chevrons look mismatched in dark mode.

Changes:
- Hide platform-native select arrows in the activity toolbar and render explicit `ChevronDownIcon` icons instead.
- Match the project typeahead chevron to the same 12px size, stroke weight, color, and opacity treatment.
- Add a regression test that locks the toolbar to explicit chevrons for the three native selects.

Screenshots:

Before:

![codex-clipboard-OYWALD.png](https://github.com/user-attachments/assets/ba9b5051-9a8f-4a71-9637-e8a1dcde23e2)

After:

![codex-clipboard-5fzGER.png](https://github.com/user-attachments/assets/af2b30bc-093e-47fc-b001-14698f3251d7)

Reviewers should start with `frontend/src/lib/components/activity/ActivityPage.svelte`, then check `frontend/src/lib/components/layout/ProjectTypeahead.svelte` for the shared icon sizing.
