### PR TITLE
fix(activity): align refresh control with filters

### DIFF
--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -163,14 +163,12 @@
       />
     </div>
 
-    <div class="refresh-slot">
-      <RefreshControl
-        lastUpdatedAt={activity.lastUpdatedAt}
-        busy={activity.loading}
-        onRefresh={() => activity.load({ background: true })}
-        label="Refresh activity"
-      />
-    </div>
+    <RefreshControl
+      lastUpdatedAt={activity.lastUpdatedAt}
+      busy={activity.loading}
+      onRefresh={() => activity.load({ background: true })}
+      label="Refresh activity"
+    />
   </div>
 
   <div class="activity-content">
@@ -288,14 +286,6 @@
     opacity: 0.72;
     pointer-events: none;
     transform: translateY(-50%);
-  }
-
-  /* Push the shared refresh control to the right edge of the toolbar, matching
-     the Analytics/Usage refresh affordance. */
-  .refresh-slot {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
   }
 
   .activity-content {

--- a/frontend/src/lib/components/activity/ActivityPage.test.ts
+++ b/frontend/src/lib/components/activity/ActivityPage.test.ts
@@ -12,3 +12,12 @@ describe("ActivityPage filter controls", () => {
     expect(filterSelectStyles).toContain("appearance: none");
   });
 });
+
+describe("ActivityPage refresh control layout", () => {
+  it("keeps the shared refresh control inline with the toolbar filters", () => {
+    expect(source).toContain("<RefreshControl");
+    expect(source).toContain("activity.lastUpdatedAt");
+    expect(source).not.toContain("refresh-slot");
+    expect(source).not.toContain("margin-left: auto");
+  });
+});


### PR DESCRIPTION
## Summary

Aligns the Activity toolbar refresh control with the filter controls so it matches the Analytics and Usage views instead of sitting at the far right edge of the toolbar.

## Changes

- Removes the Activity-specific refresh wrapper that forced `margin-left: auto`.
- Keeps the shared `RefreshControl` directly in the toolbar flow after the session filter.
- Adds a regression test that guards against reintroducing the right-aligned wrapper.

## Visuals

Before:

![before activity toolbar refresh placement](https://github.com/user-attachments/assets/ddfd7635-e781-4e9a-8539-cd8cef366da3)

After:

![after activity toolbar refresh placement](https://github.com/user-attachments/assets/a8f53fb8-516a-4c4d-8252-87830c12cd21)
