### PR TITLE
Distinguish global sync action

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -7,6 +7,7 @@
     CheckIcon,
     CloudUploadIcon,
     CopyIcon,
+    DatabaseBackupIcon,
     DownloadIcon,
     EllipsisIcon,
     FunnelIcon,
@@ -21,7 +22,6 @@
     MenuIcon,
     MoonIcon,
     MoreHorizontalIcon,
-    RefreshCwIcon,
     SearchIcon,
     SettingsIcon,
     SunIcon,
@@ -665,14 +665,15 @@
     {/if}
 
     <button
-      class="header-btn"
+      class="header-btn sync-btn"
       class:syncing={sync.syncing}
       onclick={() => sync.triggerSync()}
       disabled={sync.syncing}
       title={sync.readOnly ? "Refresh data (r)" : "Sync sessions (r)"}
       aria-label={sync.readOnly ? "Refresh data" : "Sync sessions"}
     >
-      <RefreshCwIcon size="14" strokeWidth="2" aria-hidden="true" />
+      <DatabaseBackupIcon size="14" strokeWidth="2" aria-hidden="true" />
+      <span class="sync-label">Sync</span>
     </button>
 
     <button
@@ -1114,7 +1115,20 @@
   }
 
   .header-btn.syncing {
+    color: var(--text-secondary);
+  }
+
+  .header-btn.syncing :global(svg) {
     animation: spin 1s linear infinite;
+  }
+
+  .sync-btn {
+    width: auto;
+    min-width: 56px;
+    gap: 5px;
+    padding: 0 9px;
+    font-size: 11px;
+    font-weight: 500;
   }
 
   /* ── Import button (icon + label) ── */

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -170,4 +170,19 @@ describe("AppHeader export actions", () => {
     expect(shortcutsButton).not.toBeNull();
     expect(shortcutsButton?.title).toBe("Keyboard shortcuts (?)");
   });
+
+  it("distinguishes global sync from page refresh controls", async () => {
+    component = mount(AppHeader, { target: document.body });
+    await tick();
+
+    const syncButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Sync sessions"]',
+    );
+
+    expect(syncButton).not.toBeNull();
+    expect(syncButton?.textContent?.trim()).toBe("Sync");
+    expect(
+      syncButton?.querySelector("svg.lucide-database-backup"),
+    ).not.toBeNull();
+  });
 });

--- a/frontend/src/lib/icons.test.ts
+++ b/frontend/src/lib/icons.test.ts
@@ -20,6 +20,7 @@ const approvedIconNames = [
   "CodeIcon",
   "CloudUploadIcon",
   "CopyIcon",
+  "DatabaseBackupIcon",
   "DownloadIcon",
   "EllipsisIcon",
   "EllipsisVerticalIcon",

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -14,6 +14,7 @@ export { default as ClockIcon } from "@lucide/svelte/icons/clock";
 export { default as CodeIcon } from "@lucide/svelte/icons/code";
 export { default as CloudUploadIcon } from "@lucide/svelte/icons/cloud-upload";
 export { default as CopyIcon } from "@lucide/svelte/icons/copy";
+export { default as DatabaseBackupIcon } from "@lucide/svelte/icons/database-backup";
 export { default as DownloadIcon } from "@lucide/svelte/icons/download";
 export { default as EllipsisIcon } from "@lucide/svelte/icons/ellipsis";
 export { default as EllipsisVerticalIcon } from "@lucide/svelte/icons/ellipsis-vertical";


### PR DESCRIPTION
## Summary

The global header sync action no longer looks like a duplicate of page-level refresh controls. It now uses a database-backup icon with a visible Sync label, while dashboard refresh controls keep the refresh glyph and freshness status.

![codex-clipboard-I1Dzea.png](https://github.com/user-attachments/assets/767de90a-bcef-4a24-9289-3c95efb55c87)

## Changes

- Replaces the global header refresh glyph with Lucide's database-backup icon and a compact Sync label.
- Keeps the existing sync behavior, disabled state, keyboard hint, and read-only title text unchanged.
- Adds the database-backup icon to the approved icon barrel and covers the header treatment with a DOM test.

## Reviewer Notes

The relevant UI surface is `frontend/src/lib/components/layout/AppHeader.svelte`; the shared page-level `RefreshControl` is intentionally unchanged so dashboard freshness controls remain visually distinct.
