### PR TITLE
Yoke date ranges across panels

### DIFF
--- a/frontend/e2e/insights-quality.spec.ts
+++ b/frontend/e2e/insights-quality.spec.ts
@@ -127,7 +127,17 @@ test.describe("Insights quality rollout", () => {
     await page.keyboard.press("Escape");
     await expect(savedInsight).toBeVisible();
     await savedInsight.click();
-    await expect(page).toHaveURL(/\/insights\?insight=42$/);
+    await expect(page).toHaveURL(/\/insights\?.*insight=42/);
+    const selectedInsightUrl = new URL(page.url());
+    expect(selectedInsightUrl.pathname).toBe("/insights");
+    expect(selectedInsightUrl.searchParams.get("insight")).toBe("42");
+    expect(selectedInsightUrl.searchParams.get("window_days")).toBe("365");
+    expect(selectedInsightUrl.searchParams.get("date_from")).toMatch(
+      /^\d{4}-\d{2}-\d{2}$/,
+    );
+    expect(selectedInsightUrl.searchParams.get("date_to")).toMatch(
+      /^\d{4}-\d{2}-\d{2}$/,
+    );
 
     await expect(
       page.locator(".generated-detail .badge", {
@@ -172,7 +182,17 @@ test.describe("Insights quality rollout", () => {
         (window as unknown as { __copiedInsightLink?: string })
           .__copiedInsightLink,
     );
-    expect(copied).toBe(`${new URL(page.url()).origin}/insights?insight=42`);
+    const copiedUrl = new URL(copied!);
+    expect(copiedUrl.origin).toBe(selectedInsightUrl.origin);
+    expect(copiedUrl.pathname).toBe("/insights");
+    expect(copiedUrl.searchParams.get("insight")).toBe("42");
+    expect(copiedUrl.searchParams.get("window_days")).toBe("365");
+    expect(copiedUrl.searchParams.get("date_from")).toBe(
+      selectedInsightUrl.searchParams.get("date_from"),
+    );
+    expect(copiedUrl.searchParams.get("date_to")).toBe(
+      selectedInsightUrl.searchParams.get("date_to"),
+    );
 
     await page.goto("/insights?insight=42");
     await expect(

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -222,15 +222,70 @@
     messageListRef?.scrollToOrdinal(ordinal);
   }
 
+  const SESSION_ANALYTICS_WINDOW_PARAM = "window_days";
+
   /** True when URL params contain session filter keys (deep-link). */
   const SESSION_FILTER_KEYS = new Set([
-    "project", "machine", "agent", "date", "date_from", "date_to",
+    "project", "machine", "agent", "termination",
+    "date", "date_from", "date_to",
     "active_since", "exclude_project", "min_messages", "max_messages",
     "min_user_messages", "include_one_shot", "include_automated",
+    "window_days",
   ]);
   function hasFilterParams(params: Record<string, string>): boolean {
     return Object.keys(params).some((k) => SESSION_FILTER_KEYS.has(k));
   }
+
+  function hasFixedSessionDateParams(
+    params: Record<string, string>,
+  ): boolean {
+    return !!params["date"] || !!params["date_from"] || !!params["date_to"];
+  }
+
+  function isValidWindowDaysParam(raw: string | undefined): raw is string {
+    if (!raw) return false;
+    const n = Number.parseInt(raw, 10);
+    return Number.isInteger(n) && n > 0 && String(n) === raw;
+  }
+
+  function sessionRouteParamsForFilters(
+    filterParams: Record<string, string>,
+    currentParams: Record<string, string>,
+  ): Record<string, string> {
+    const next = { ...filterParams };
+    const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
+    if (
+      !hasFixedSessionDateParams(next) &&
+      isValidWindowDaysParam(windowDays)
+    ) {
+      next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays;
+    }
+    return next;
+  }
+
+  function currentSessionRouteParams(
+    currentParams: Record<string, string>,
+  ): Record<string, string> {
+    const next: Record<string, string> = {};
+    for (const key of SESSION_FILTER_KEYS) {
+      const value = currentParams[key];
+      if (value !== undefined) {
+        next[key] = value;
+      }
+    }
+    return next;
+  }
+
+  function sessionRouteParamsForDetailExit(
+    filterParams: Record<string, string>,
+    currentParams: Record<string, string>,
+  ): Record<string, string> {
+    const currentRouteParams = currentSessionRouteParams(currentParams);
+    if (hasFilterParams(currentRouteParams)) return currentRouteParams;
+    return sessionRouteParamsForFilters(filterParams, currentParams);
+  }
+
+  let lastDetailFilterParamsSignature: string | null = $state(null);
 
   // React to route changes: reload sessions and apply URL params.
   // Only apply URL deep-link params (initFromParams) when the URL
@@ -299,13 +354,50 @@
   $effect(() => {
     const activeId = sessions.activeSessionId;
     const currentUrlSessionId = router.sessionId;
+    const filterParams = filtersToParams(sessions.filters);
+    const filterParamsSignature = JSON.stringify(filterParams);
     untrack(() => {
-      if (router.route !== "sessions") return;
-      if (activeId === currentUrlSessionId) return;
+      if (router.route !== "sessions") {
+        lastDetailFilterParamsSignature = null;
+        return;
+      }
       if (activeId) {
-        router.navigateToSession(activeId);
+        const nextParams = sessionRouteParamsForFilters(
+          filterParams,
+          router.params,
+        );
+        if (activeId === currentUrlSessionId) {
+          if (
+            lastDetailFilterParamsSignature !== null &&
+            lastDetailFilterParamsSignature !== filterParamsSignature &&
+            !filterParamsEqual(router.params, nextParams)
+          ) {
+            router.replaceParams(nextParams);
+          }
+          lastDetailFilterParamsSignature = filterParamsSignature;
+          return;
+        }
+        router.navigateToSession(activeId, nextParams);
+        lastDetailFilterParamsSignature = filterParamsSignature;
       } else {
-        router.navigateFromSession(filtersToParams(sessions.filters));
+        if (currentUrlSessionId === null) {
+          lastDetailFilterParamsSignature = null;
+          return;
+        }
+        const filterChangedOnDetail =
+          lastDetailFilterParamsSignature !== null &&
+          lastDetailFilterParamsSignature !== filterParamsSignature;
+        const nextParams = filterChangedOnDetail
+          ? sessionRouteParamsForFilters(
+              filterParams,
+              router.params,
+            )
+          : sessionRouteParamsForDetailExit(
+              filterParams,
+              router.params,
+            );
+        router.navigateFromSession(nextParams);
+        lastDetailFilterParamsSignature = null;
       }
     });
   });
@@ -329,7 +421,10 @@
   // the URL with localStorage-restored filters.
   $effect(() => {
     const route = router.route;
-    const newParams = filtersToParams(sessions.filters);
+    const newParams = sessionRouteParamsForFilters(
+      filtersToParams(sessions.filters),
+      router.params,
+    );
     untrack(() => {
       if (route !== "sessions") return;
       if (router.sessionId) return;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -248,6 +248,17 @@
     return Number.isInteger(n) && n > 0 && String(n) === raw;
   }
 
+  function fixedSessionDateParamsEqual(
+    a: Record<string, string>,
+    b: Record<string, string>,
+  ): boolean {
+    return (
+      (a["date"] ?? "") === (b["date"] ?? "") &&
+      (a["date_from"] ?? "") === (b["date_from"] ?? "") &&
+      (a["date_to"] ?? "") === (b["date_to"] ?? "")
+    );
+  }
+
   function sessionRouteParamsForFilters(
     filterParams: Record<string, string>,
     currentParams: Record<string, string>,
@@ -255,7 +266,10 @@
     const next = { ...filterParams };
     const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
     if (
-      !hasFixedSessionDateParams(next) &&
+      (
+        !hasFixedSessionDateParams(next) ||
+        fixedSessionDateParamsEqual(next, currentParams)
+      ) &&
       isValidWindowDaysParam(windowDays)
     ) {
       next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -37,6 +37,12 @@
   import { setupVisibilityHealthCheck } from "./lib/utils/health.js";
   import { registerShortcuts } from "./lib/utils/keyboard.js";
   import { shouldAutoSwitchTranscriptModeToNormal } from "./lib/utils/transcript-mode.js";
+  import {
+    filterParamsEqual,
+    hasFilterParams,
+    sessionRouteParamsForDetailExit,
+    sessionRouteParamsForFilters,
+  } from "./lib/stores/sessionRouteParams.js";
 
   let globalAuthToken: string = $state("");
 
@@ -222,90 +228,6 @@
     messageListRef?.scrollToOrdinal(ordinal);
   }
 
-  const SESSION_ANALYTICS_WINDOW_PARAM = "window_days";
-
-  /** True when URL params contain session filter keys (deep-link). */
-  const SESSION_FILTER_KEYS = new Set([
-    "project", "machine", "agent", "termination",
-    "date", "date_from", "date_to",
-    "active_since", "exclude_project", "min_messages", "max_messages",
-    "min_user_messages", "include_one_shot", "include_automated",
-    "window_days",
-  ]);
-  function hasFilterParams(params: Record<string, string>): boolean {
-    return Object.keys(params).some((k) => SESSION_FILTER_KEYS.has(k));
-  }
-
-  function hasFixedSessionDateParams(
-    params: Record<string, string>,
-  ): boolean {
-    return !!params["date"] || !!params["date_from"] || !!params["date_to"];
-  }
-
-  function isValidWindowDaysParam(raw: string | undefined): raw is string {
-    if (!raw) return false;
-    const n = Number.parseInt(raw, 10);
-    return Number.isInteger(n) && n > 0 && String(n) === raw;
-  }
-
-  function fixedSessionDateParamsEqual(
-    a: Record<string, string>,
-    b: Record<string, string>,
-  ): boolean {
-    return (
-      (a["date"] ?? "") === (b["date"] ?? "") &&
-      (a["date_from"] ?? "") === (b["date_from"] ?? "") &&
-      (a["date_to"] ?? "") === (b["date_to"] ?? "")
-    );
-  }
-
-  function shouldPreserveSessionWindowDays(
-    nextParams: Record<string, string>,
-    currentParams: Record<string, string>,
-  ): boolean {
-    const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
-    if (!isValidWindowDaysParam(windowDays)) return false;
-    return (
-      !hasFixedSessionDateParams(nextParams) ||
-      !hasFixedSessionDateParams(currentParams) ||
-      fixedSessionDateParamsEqual(nextParams, currentParams)
-    );
-  }
-
-  function sessionRouteParamsForFilters(
-    filterParams: Record<string, string>,
-    currentParams: Record<string, string>,
-  ): Record<string, string> {
-    const next = { ...filterParams };
-    const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
-    if (shouldPreserveSessionWindowDays(next, currentParams)) {
-      next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays!;
-    }
-    return next;
-  }
-
-  function currentSessionRouteParams(
-    currentParams: Record<string, string>,
-  ): Record<string, string> {
-    const next: Record<string, string> = {};
-    for (const key of SESSION_FILTER_KEYS) {
-      const value = currentParams[key];
-      if (value !== undefined) {
-        next[key] = value;
-      }
-    }
-    return next;
-  }
-
-  function sessionRouteParamsForDetailExit(
-    filterParams: Record<string, string>,
-    currentParams: Record<string, string>,
-  ): Record<string, string> {
-    const currentRouteParams = currentSessionRouteParams(currentParams);
-    if (hasFilterParams(currentRouteParams)) return currentRouteParams;
-    return sessionRouteParamsForFilters(filterParams, currentParams);
-  }
-
   let lastDetailFilterParamsSignature: string | null = $state(null);
 
   // React to route changes: reload sessions and apply URL params.
@@ -422,18 +344,6 @@
       }
     });
   });
-
-  // Compare only filter keys so sticky params (e.g. desktop)
-  // don't cause spurious replaceParams calls.
-  function filterParamsEqual(
-    a: Record<string, string>,
-    b: Record<string, string>,
-  ): boolean {
-    for (const k of SESSION_FILTER_KEYS) {
-      if ((a[k] ?? "") !== (b[k] ?? "")) return false;
-    }
-    return true;
-  }
 
   // URL write-back: keep query string in sync with filter state
   // when on /sessions with no session selected, so users can

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -33,6 +33,7 @@
   import { starred } from "./lib/stores/starred.svelte.js";
   import { pins } from "./lib/stores/pins.svelte.js";
   import { settings } from "./lib/stores/settings.svelte.js";
+  import { yokedDates } from "./lib/stores/yokedDates.svelte.js";
   import { setAuthToken, getAuthToken, setServerUrl, getBase } from "./lib/api/runtime.js";
   import { setupVisibilityHealthCheck } from "./lib/utils/health.js";
   import { registerShortcuts } from "./lib/utils/keyboard.js";
@@ -40,6 +41,7 @@
   import {
     filterParamsEqual,
     hasFilterParams,
+    sessionDateIntentCleared,
     sessionRouteParamsForDetailExit,
     sessionRouteParamsForFilters,
   } from "./lib/stores/sessionRouteParams.js";
@@ -228,6 +230,14 @@
     messageListRef?.scrollToOrdinal(ordinal);
   }
 
+  function clearYokeForClearedSessionDates(
+    nextParams: Record<string, string>,
+  ): void {
+    if (sessionDateIntentCleared(router.params, nextParams)) {
+      yokedDates.clear();
+    }
+  }
+
   let lastDetailFilterParamsSignature: string | null = $state(null);
 
   // React to route changes: reload sessions and apply URL params.
@@ -315,11 +325,13 @@
             lastDetailFilterParamsSignature !== filterParamsSignature &&
             !filterParamsEqual(router.params, nextParams)
           ) {
+            clearYokeForClearedSessionDates(nextParams);
             router.replaceParams(nextParams);
           }
           lastDetailFilterParamsSignature = filterParamsSignature;
           return;
         }
+        clearYokeForClearedSessionDates(nextParams);
         router.navigateToSession(activeId, nextParams);
         lastDetailFilterParamsSignature = filterParamsSignature;
       } else {
@@ -339,6 +351,7 @@
               filterParams,
               router.params,
             );
+        clearYokeForClearedSessionDates(nextParams);
         router.navigateFromSession(nextParams);
         lastDetailFilterParamsSignature = null;
       }
@@ -360,6 +373,7 @@
       if (route !== "sessions") return;
       if (router.sessionId) return;
       if (filterParamsEqual(router.params, newParams)) return;
+      clearYokeForClearedSessionDates(newParams);
       router.replaceParams(newParams);
     });
   });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -259,20 +259,27 @@
     );
   }
 
+  function shouldPreserveSessionWindowDays(
+    nextParams: Record<string, string>,
+    currentParams: Record<string, string>,
+  ): boolean {
+    const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
+    if (!isValidWindowDaysParam(windowDays)) return false;
+    return (
+      !hasFixedSessionDateParams(nextParams) ||
+      !hasFixedSessionDateParams(currentParams) ||
+      fixedSessionDateParamsEqual(nextParams, currentParams)
+    );
+  }
+
   function sessionRouteParamsForFilters(
     filterParams: Record<string, string>,
     currentParams: Record<string, string>,
   ): Record<string, string> {
     const next = { ...filterParams };
     const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
-    if (
-      (
-        !hasFixedSessionDateParams(next) ||
-        fixedSessionDateParamsEqual(next, currentParams)
-      ) &&
-      isValidWindowDaysParam(windowDays)
-    ) {
-      next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays;
+    if (shouldPreserveSessionWindowDays(next, currentParams)) {
+      next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays!;
     }
     return next;
   }

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -31,6 +31,25 @@ describe("App session URL date state", () => {
     );
   });
 
+  it("preserves rolling intent when materialized date bounds still match", () => {
+    const helperStart = source.indexOf(
+      "function sessionRouteParamsForFilters",
+    );
+    const helperEnd = source.indexOf(
+      "\n\n  function currentSessionRouteParams",
+      helperStart,
+    );
+    const helperBlock = source.slice(helperStart, helperEnd);
+
+    expect(source).toContain("function fixedSessionDateParamsEqual");
+    expect(helperBlock).toContain(
+      "!hasFixedSessionDateParams(next) ||\n        fixedSessionDateParamsEqual(next, currentParams)",
+    );
+    expect(helperBlock).toContain(
+      "next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays;",
+    );
+  });
+
   it("preserves rolling window dates when entering session detail", () => {
     const syncUrlIndex = source.indexOf("// Sync active session to URL.");
     const navigateFromSessionIndex = source.indexOf(

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vite-plus/test";
+import source from "./App.svelte?raw";
+
+describe("App session URL date state", () => {
+  it("treats rolling window and termination as sessions route params", () => {
+    const filterKeysIndex = source.indexOf("const SESSION_FILTER_KEYS");
+    const hasFilterParamsIndex = source.indexOf(
+      "function hasFilterParams",
+      filterKeysIndex,
+    );
+    const filterKeysBlock = source.slice(
+      filterKeysIndex,
+      hasFilterParamsIndex,
+    );
+
+    expect(filterKeysBlock).toContain('"window_days"');
+    expect(filterKeysBlock).toContain('"termination"');
+  });
+
+  it("preserves rolling window dates when writing sessions URLs", () => {
+    expect(source).toContain("sessionRouteParamsForFilters(");
+    expect(source).toContain("router.navigateFromSession(nextParams)");
+    expect(source).toContain(
+      "const newParams = sessionRouteParamsForFilters(",
+    );
+    expect(source).not.toContain(
+      "navigateFromSession(filtersToParams(sessions.filters))",
+    );
+    expect(source).not.toContain(
+      "const newParams = filtersToParams(sessions.filters);",
+    );
+  });
+
+  it("preserves rolling window dates when entering session detail", () => {
+    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
+    const navigateFromSessionIndex = source.indexOf(
+      "router.navigateFromSession",
+      syncUrlIndex,
+    );
+    const activeSessionBranch = source.slice(
+      syncUrlIndex,
+      navigateFromSessionIndex,
+    );
+
+    expect(activeSessionBranch).toContain(
+      "const nextParams = sessionRouteParamsForFilters(",
+    );
+    expect(activeSessionBranch).toContain(
+      "router.navigateToSession(activeId, nextParams)",
+    );
+    expect(activeSessionBranch).not.toContain(
+      "router.navigateToSession(activeId);",
+    );
+  });
+
+  it("preserves direct detail URL params when leaving session detail", () => {
+    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
+    const navigateFromSessionIndex = source.indexOf(
+      "router.navigateFromSession",
+      syncUrlIndex,
+    );
+    const inactiveSessionBranch = source.slice(
+      navigateFromSessionIndex - 260,
+      navigateFromSessionIndex + 80,
+    );
+
+    expect(source).toContain("function sessionRouteParamsForDetailExit");
+    expect(source).toContain("function currentSessionRouteParams");
+    expect(inactiveSessionBranch).toContain(
+      ": sessionRouteParamsForDetailExit(",
+    );
+    expect(inactiveSessionBranch).toContain(
+      "router.navigateFromSession(nextParams)",
+    );
+  });
+
+  it("prefers direct detail URL params over saved filters on exit", () => {
+    const helperStart = source.indexOf(
+      "function sessionRouteParamsForDetailExit",
+    );
+    const helperEnd = source.indexOf(
+      "\n\n  let lastDetailFilterParamsSignature",
+      helperStart,
+    );
+    const helperBlock = source.slice(helperStart, helperEnd);
+
+    expect(helperBlock).toContain(
+      "const currentRouteParams = currentSessionRouteParams(currentParams);",
+    );
+    expect(helperBlock).toContain(
+      "if (hasFilterParams(currentRouteParams)) return currentRouteParams;",
+    );
+  });
+
+  it("updates detail URL params after explicit filter changes", () => {
+    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
+    const syncUrlEnd = source.indexOf(
+      "\n\n  // Compare only filter keys",
+      syncUrlIndex,
+    );
+    const syncUrlBlock = source.slice(syncUrlIndex, syncUrlEnd);
+
+    expect(source).toContain(
+      "let lastDetailFilterParamsSignature: string | null = $state(null);",
+    );
+    expect(syncUrlBlock).toContain("const filterParams = filtersToParams(");
+    expect(syncUrlBlock).toContain(
+      "lastDetailFilterParamsSignature !== null &&",
+    );
+    expect(syncUrlBlock).toContain("router.replaceParams(nextParams);");
+    expect(syncUrlBlock).toContain(
+      "lastDetailFilterParamsSignature = filterParamsSignature;",
+    );
+  });
+
+  it("does not preserve stale detail params after filter changes", () => {
+    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
+    const syncUrlEnd = source.indexOf(
+      "\n\n  // Compare only filter keys",
+      syncUrlIndex,
+    );
+    const syncUrlBlock = source.slice(syncUrlIndex, syncUrlEnd);
+
+    expect(syncUrlBlock).toContain("const filterChangedOnDetail =");
+    expect(syncUrlBlock).toContain(
+      "filterChangedOnDetail\n          ? sessionRouteParamsForFilters(",
+    );
+    expect(syncUrlBlock).toContain(
+      ": sessionRouteParamsForDetailExit(",
+    );
+  });
+
+  it("clears detail filter signatures outside session detail routes", () => {
+    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
+    const syncUrlEnd = source.indexOf(
+      "\n\n  // Compare only filter keys",
+      syncUrlIndex,
+    );
+    const syncUrlBlock = source.slice(syncUrlIndex, syncUrlEnd);
+
+    expect(syncUrlBlock).toContain(
+      'if (router.route !== "sessions") {\n        lastDetailFilterParamsSignature = null;',
+    );
+    expect(syncUrlBlock).toContain(
+      "if (currentUrlSessionId === null) {\n          lastDetailFilterParamsSignature = null;",
+    );
+  });
+});

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,20 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 import source from "./App.svelte?raw";
+import { SESSION_FILTER_KEYS } from "./lib/stores/sessionRouteParams.js";
 
 describe("App session URL date state", () => {
   it("treats rolling window and termination as sessions route params", () => {
-    const filterKeysIndex = source.indexOf("const SESSION_FILTER_KEYS");
-    const hasFilterParamsIndex = source.indexOf(
-      "function hasFilterParams",
-      filterKeysIndex,
-    );
-    const filterKeysBlock = source.slice(
-      filterKeysIndex,
-      hasFilterParamsIndex,
-    );
-
-    expect(filterKeysBlock).toContain('"window_days"');
-    expect(filterKeysBlock).toContain('"termination"');
+    expect(SESSION_FILTER_KEYS.has("window_days")).toBe(true);
+    expect(SESSION_FILTER_KEYS.has("termination")).toBe(true);
   });
 
   it("preserves rolling window dates when writing sessions URLs", () => {
@@ -28,42 +19,6 @@ describe("App session URL date state", () => {
     );
     expect(source).not.toContain(
       "const newParams = filtersToParams(sessions.filters);",
-    );
-  });
-
-  it("preserves rolling intent when materialized date bounds still match", () => {
-    const helperStart = source.indexOf(
-      "function shouldPreserveSessionWindowDays",
-    );
-    const helperEnd = source.indexOf(
-      "\n\n  function sessionRouteParamsForFilters",
-      helperStart,
-    );
-    const helperBlock = source.slice(helperStart, helperEnd);
-
-    expect(source).toContain("function fixedSessionDateParamsEqual");
-    expect(helperBlock).toContain(
-      "fixedSessionDateParamsEqual(nextParams, currentParams)",
-    );
-    expect(source).toContain(
-      "next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays!;",
-    );
-  });
-
-  it("preserves direct rolling links during first materialized date writeback", () => {
-    const helperStart = source.indexOf(
-      "function shouldPreserveSessionWindowDays",
-    );
-    const helperEnd = source.indexOf(
-      "\n\n  function sessionRouteParamsForFilters",
-      helperStart,
-    );
-    const helperBlock = source.slice(helperStart, helperEnd);
-
-    expect(helperStart).toBeGreaterThan(-1);
-    expect(helperBlock).toContain("!hasFixedSessionDateParams(currentParams)");
-    expect(helperBlock).toContain(
-      "fixedSessionDateParamsEqual(nextParams, currentParams)",
     );
   });
 
@@ -100,31 +55,12 @@ describe("App session URL date state", () => {
       navigateFromSessionIndex + 80,
     );
 
-    expect(source).toContain("function sessionRouteParamsForDetailExit");
-    expect(source).toContain("function currentSessionRouteParams");
+    expect(source).toContain("sessionRouteParamsForDetailExit");
     expect(inactiveSessionBranch).toContain(
       ": sessionRouteParamsForDetailExit(",
     );
     expect(inactiveSessionBranch).toContain(
       "router.navigateFromSession(nextParams)",
-    );
-  });
-
-  it("prefers direct detail URL params over saved filters on exit", () => {
-    const helperStart = source.indexOf(
-      "function sessionRouteParamsForDetailExit",
-    );
-    const helperEnd = source.indexOf(
-      "\n\n  let lastDetailFilterParamsSignature",
-      helperStart,
-    );
-    const helperBlock = source.slice(helperStart, helperEnd);
-
-    expect(helperBlock).toContain(
-      "const currentRouteParams = currentSessionRouteParams(currentParams);",
-    );
-    expect(helperBlock).toContain(
-      "if (hasFilterParams(currentRouteParams)) return currentRouteParams;",
     );
   });
 

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "vite-plus/test";
 import source from "./App.svelte?raw";
 import { SESSION_FILTER_KEYS } from "./lib/stores/sessionRouteParams.js";
 
+function appSourceSlice(startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
 describe("App session URL date state", () => {
   it("treats rolling window and termination as sessions route params", () => {
     expect(SESSION_FILTER_KEYS.has("window_days")).toBe(true);
@@ -65,12 +73,10 @@ describe("App session URL date state", () => {
   });
 
   it("updates detail URL params after explicit filter changes", () => {
-    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
-    const syncUrlEnd = source.indexOf(
-      "\n\n  // Compare only filter keys",
-      syncUrlIndex,
+    const syncUrlBlock = appSourceSlice(
+      "// Sync active session to URL.",
+      "\n\n  // URL write-back",
     );
-    const syncUrlBlock = source.slice(syncUrlIndex, syncUrlEnd);
 
     expect(source).toContain(
       "let lastDetailFilterParamsSignature: string | null = $state(null);",
@@ -86,12 +92,10 @@ describe("App session URL date state", () => {
   });
 
   it("does not preserve stale detail params after filter changes", () => {
-    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
-    const syncUrlEnd = source.indexOf(
-      "\n\n  // Compare only filter keys",
-      syncUrlIndex,
+    const syncUrlBlock = appSourceSlice(
+      "// Sync active session to URL.",
+      "\n\n  // URL write-back",
     );
-    const syncUrlBlock = source.slice(syncUrlIndex, syncUrlEnd);
 
     expect(syncUrlBlock).toContain("const filterChangedOnDetail =");
     expect(syncUrlBlock).toContain(
@@ -103,12 +107,10 @@ describe("App session URL date state", () => {
   });
 
   it("clears detail filter signatures outside session detail routes", () => {
-    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
-    const syncUrlEnd = source.indexOf(
-      "\n\n  // Compare only filter keys",
-      syncUrlIndex,
+    const syncUrlBlock = appSourceSlice(
+      "// Sync active session to URL.",
+      "\n\n  // URL write-back",
     );
-    const syncUrlBlock = source.slice(syncUrlIndex, syncUrlEnd);
 
     expect(syncUrlBlock).toContain(
       'if (router.route !== "sessions") {\n        lastDetailFilterParamsSignature = null;',

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -33,20 +33,37 @@ describe("App session URL date state", () => {
 
   it("preserves rolling intent when materialized date bounds still match", () => {
     const helperStart = source.indexOf(
-      "function sessionRouteParamsForFilters",
+      "function shouldPreserveSessionWindowDays",
     );
     const helperEnd = source.indexOf(
-      "\n\n  function currentSessionRouteParams",
+      "\n\n  function sessionRouteParamsForFilters",
       helperStart,
     );
     const helperBlock = source.slice(helperStart, helperEnd);
 
     expect(source).toContain("function fixedSessionDateParamsEqual");
     expect(helperBlock).toContain(
-      "!hasFixedSessionDateParams(next) ||\n        fixedSessionDateParamsEqual(next, currentParams)",
+      "fixedSessionDateParamsEqual(nextParams, currentParams)",
     );
+    expect(source).toContain(
+      "next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays!;",
+    );
+  });
+
+  it("preserves direct rolling links during first materialized date writeback", () => {
+    const helperStart = source.indexOf(
+      "function shouldPreserveSessionWindowDays",
+    );
+    const helperEnd = source.indexOf(
+      "\n\n  function sessionRouteParamsForFilters",
+      helperStart,
+    );
+    const helperBlock = source.slice(helperStart, helperEnd);
+
+    expect(helperStart).toBeGreaterThan(-1);
+    expect(helperBlock).toContain("!hasFixedSessionDateParams(currentParams)");
     expect(helperBlock).toContain(
-      "next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays;",
+      "fixedSessionDateParamsEqual(nextParams, currentParams)",
     );
   });
 

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -106,6 +106,28 @@ describe("App session URL date state", () => {
     );
   });
 
+  it("clears stored yoke when session date params are removed while analytics is unmounted", () => {
+    const syncUrlBlock = appSourceSlice(
+      "// Sync active session to URL.",
+      "\n\n  // URL write-back",
+    );
+    const writeBackBlock = appSourceSlice(
+      "// URL write-back",
+      "\n\n  function showAbout",
+    );
+
+    expect(source).toContain("import { yokedDates");
+    expect(source).toContain("function clearYokeForClearedSessionDates");
+    expect(source).toContain("sessionDateIntentCleared(");
+    expect(source).toContain("yokedDates.clear();");
+    expect(syncUrlBlock).toContain(
+      "clearYokeForClearedSessionDates(nextParams);",
+    );
+    expect(writeBackBlock).toContain(
+      "clearYokeForClearedSessionDates(newParams);",
+    );
+  });
+
   it("clears detail filter signatures outside session detail routes", () => {
     const syncUrlBlock = appSourceSlice(
       "// Sync active session to URL.",

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, untrack } from "svelte";
   import {
     activity,
     localDateStr,
@@ -7,9 +7,22 @@
   } from "../../stores/activity.svelte.js";
   import { events } from "../../stores/events.svelte.js";
   import { sync } from "../../stores/sync.svelte.js";
+  import { router } from "../../stores/router.svelte.js";
+  import {
+    yokedDates,
+    panelDateState,
+    rangeToActivityParams,
+    type PanelDateState,
+  } from "../../stores/yokedDates.svelte.js";
   import RefreshControl from "../shared/RefreshControl.svelte";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
   import { ChevronDownIcon } from "../../icons.js";
+  import {
+    addDays,
+    endOfMonth,
+    startOfIsoWeek,
+    startOfMonth,
+  } from "../../utils/dates.js";
   import RangePicker from "../shared/RangePicker.svelte";
   import {
     resolveRange,
@@ -35,6 +48,10 @@
       ? localDateStr(new Date(new Date(activity.report.range_end).getTime() - 1))
       : "",
   );
+  const activityPanelDate = $derived(currentActivityPanelDate());
+  const activityDateSignature = $derived(dateSignature(activityPanelDate));
+  let activityYokeReady = $state(false);
+  let lastActivityDateSignature = "";
 
   // Page-local drill-down: clicking a Concurrency bucket filters the sessions
   // table to the sessions active in that slot. Deliberately not URL-synced — it
@@ -57,25 +74,125 @@
 
   // The activity store is the source of truth: day/week/month map to a calendar
   // period anchored on `date`; custom maps to from/to. Relative windows have no
-  // native equivalent here, so applyRange resolves them to a pinned custom range.
+  // native API equivalent here, so applyRange sends concrete dates while the
+  // URL keeps `window_days` to preserve rolling intent across reloads.
   const rangeSelection = $derived.by((): RangeSelection => {
     if (activity.preset === "custom") {
+      if (activity.rollingWindowDays !== null) {
+        return { mode: "relative", days: activity.rollingWindowDays };
+      }
       return { mode: "custom", from: activity.from, to: activity.to };
     }
     return { mode: "calendar", unit: activity.preset, anchor: activity.date };
   });
 
   function applyRange(sel: RangeSelection) {
+    let yokeState: PanelDateState | null = null;
     if (sel.mode === "calendar") {
       activity.setPreset(sel.unit);
       activity.setDate(sel.anchor);
     } else {
       const range = resolveRange(sel, earliestSession);
-      activity.setPreset("custom");
-      activity.setFrom(range.from);
-      activity.setTo(range.to);
+      yokeState = yokeStateForSelection(sel, range);
+      activity.setCustomRange(
+        range.from,
+        range.to,
+        yokeState?.mode === "rolling"
+          ? yokeState.windowDays ?? null
+          : null,
+      );
+    }
+    if (yokeState) {
+      yokedDates.updateFromPanel(yokeState);
+      lastActivityDateSignature = dateSignature(
+        currentActivityPanelDate(),
+      );
     }
     activity.load();
+  }
+
+  function yokeStateForSelection(
+    sel: RangeSelection,
+    range: { from: string; to: string },
+  ): PanelDateState | null {
+    if (sel.mode === "relative" && sel.days > 0) {
+      return panelDateState(range.from, range.to, {
+        mode: "rolling",
+        windowDays: sel.days,
+      });
+    }
+    return panelDateState(range.from, range.to, { mode: "fixed" });
+  }
+
+  function currentActivityPanelDate(): PanelDateState | null {
+    if (activity.preset === "custom") {
+      if (activity.rollingWindowDays !== null) {
+        return panelDateState(activity.from, activity.to, {
+          mode: "rolling",
+          windowDays: activity.rollingWindowDays,
+        });
+      }
+      return panelDateState(activity.from, activity.to, { mode: "fixed" });
+    }
+    if (activity.preset === "week") {
+      const from = startOfIsoWeek(activity.date);
+      return panelDateState(from, addDays(from, 6), {
+        mode: "fixed",
+      });
+    }
+    if (activity.preset === "month") {
+      const from = startOfMonth(activity.date);
+      return panelDateState(from, endOfMonth(from), {
+        mode: "fixed",
+      });
+    }
+    return panelDateState(activity.date, activity.date, { mode: "fixed" });
+  }
+
+  function dateSignature(state: PanelDateState | null): string {
+    if (!state) return "";
+    return [
+      state.mode ?? "fixed",
+      state.windowDays ?? "",
+      state.from,
+      state.to,
+    ].join(":");
+  }
+
+  function hasActivityDateParams(params: Record<string, string>): boolean {
+    return (
+      !!params.preset ||
+      !!params.date ||
+      !!params.from ||
+      !!params.to ||
+      !!params.window_days
+    );
+  }
+
+  function applyActivityPanelDate(state: PanelDateState): void {
+    activity.setCustomRange(
+      state.from,
+      state.to,
+      state.mode === "rolling" ? state.windowDays ?? null : null,
+    );
+  }
+
+  function seedActivityYoke(): void {
+    if (hasActivityDateParams(router.params)) {
+      const state = currentActivityPanelDate();
+      if (state) yokedDates.updateFromPanel(state);
+      return;
+    }
+
+    const seed = yokedDates.seedForPanel();
+    const params = seed ? rangeToActivityParams(seed) : {};
+    const state = panelDateState(params.from ?? "", params.to ?? "", {
+      mode: params.window_days ? "rolling" : "fixed",
+      windowDays: params.window_days
+        ? Number.parseInt(params.window_days, 10)
+        : undefined,
+    });
+    if (state) applyActivityPanelDate(state);
   }
 
   function onProjectSelect(value: string) {
@@ -107,6 +224,9 @@
     // Idempotent; loads the activity filter option lists with one-shot
     // and automated sessions included, matching the activity report.
     activity.loadFilterOptions();
+    seedActivityYoke();
+    lastActivityDateSignature = dateSignature(currentActivityPanelDate());
+    activityYokeReady = true;
     // The page owns the initial load. attach() above ran hydrateFromUrl, so the
     // range/filters are set before this first load. RefreshControl handles the
     // periodic refresh after that.
@@ -120,6 +240,17 @@
       detach();
       unsubEvents();
     };
+  });
+
+  $effect(() => {
+    const state = activityPanelDate;
+    const signature = activityDateSignature;
+    untrack(() => {
+      if (!activityYokeReady || !state) return;
+      if (signature === lastActivityDateSignature) return;
+      lastActivityDateSignature = signature;
+      yokedDates.updateFromPanel(state);
+    });
   });
 </script>
 

--- a/frontend/src/lib/components/activity/ActivityPage.test.ts
+++ b/frontend/src/lib/components/activity/ActivityPage.test.ts
@@ -21,3 +21,41 @@ describe("ActivityPage refresh control layout", () => {
     expect(source).not.toContain("margin-left: auto");
   });
 });
+
+describe("ActivityPage date yoke controls", () => {
+  it("updates shared yoke state from the unified range picker", () => {
+    expect(source).toContain("<RangePicker");
+    expect(source).toContain("seedActivityYoke");
+    expect(source).toContain("yokedDates.updateFromPanel");
+  });
+
+  it("yokes week and month selections using resolved period starts", () => {
+    expect(source).toContain("startOfIsoWeek(activity.date)");
+    expect(source).toContain("startOfMonth(activity.date)");
+    expect(source).not.toContain(
+      "panelDateState(activity.date, addDays(activity.date, 6)",
+    );
+    expect(source).not.toContain(
+      "panelDateState(activity.date, endOfMonth(activity.date)",
+    );
+  });
+
+  it("preserves relative range selections as rolling yoke state", () => {
+    const applyIndex = source.indexOf("function applyRange");
+    const helperIndex = source.indexOf("function yokeStateForSelection");
+    const applyBlock = source.slice(applyIndex, helperIndex);
+
+    expect(helperIndex).toBeGreaterThan(applyIndex);
+    expect(source).toContain('mode: "rolling"');
+    expect(source).toContain("windowDays: sel.days");
+    expect(applyBlock).toContain("yokeStateForSelection(sel, range)");
+    expect(applyBlock).toContain("lastActivityDateSignature = dateSignature");
+  });
+
+  it("preserves rolling window intent in activity URLs", () => {
+    expect(source).toContain("activity.rollingWindowDays");
+    expect(source).toContain("activity.setCustomRange");
+    expect(source).toContain("params.window_days");
+    expect(source).toContain('mode: "relative", days: activity.rollingWindowDays');
+  });
+});

--- a/frontend/src/lib/components/analytics/ActivityTimeline.svelte
+++ b/frontend/src/lib/components/analytics/ActivityTimeline.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { analytics } from "../../stores/analytics.svelte.js";
+  import { addDays, endOfMonth } from "../../utils/dates.js";
 
   const BAR_HEIGHT = 120;
   const LABEL_HEIGHT = 20;
@@ -9,6 +10,12 @@
   const BAR_GAP = 2;
 
   type Metric = "messages" | "sessions";
+  interface Props {
+    onDateRangeChange?: (from: string, to: string) => void;
+  }
+
+  let { onDateRangeChange }: Props = $props();
+
   let metric = $state<Metric>("messages");
 
   let containerEl = $state<HTMLDivElement | null>(null);
@@ -125,24 +132,6 @@
     };
   }
 
-  function addDays(dateStr: string, n: number): string {
-    const d = new Date(dateStr + "T00:00:00");
-    d.setDate(d.getDate() + n);
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    return `${y}-${m}-${day}`;
-  }
-
-  function endOfMonth(dateStr: string): string {
-    const d = new Date(dateStr + "T00:00:00");
-    d.setMonth(d.getMonth() + 1, 0);
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    return `${y}-${m}-${day}`;
-  }
-
   function handleBarClick(
     bar: (typeof chart.bars)[number],
   ) {
@@ -151,10 +140,18 @@
     if (g === "day") {
       analytics.selectDate(bar.date);
     } else if (g === "week") {
-      analytics.setDateRange(bar.date, addDays(bar.date, 6));
+      commitDateRange(bar.date, addDays(bar.date, 6));
     } else if (g === "month") {
-      analytics.setDateRange(bar.date, endOfMonth(bar.date));
+      commitDateRange(bar.date, endOfMonth(bar.date));
     }
+  }
+
+  function commitDateRange(from: string, to: string) {
+    if (onDateRangeChange) {
+      onDateRangeChange(from, to);
+      return;
+    }
+    analytics.setDateRange(from, to);
   }
 
   function handleBarLeave() {

--- a/frontend/src/lib/components/analytics/AgentComparison.svelte
+++ b/frontend/src/lib/components/analytics/AgentComparison.svelte
@@ -122,7 +122,7 @@
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
           class="table-row"
-          onclick={() => router.navigate("sessions", { agent: agent.name })}
+          onclick={() => router.navigateToSessions({ agent: agent.name })}
         >
           <span class="col-agent">{agent.name}</span>
           <span class="col-num">

--- a/frontend/src/lib/components/analytics/AgentComparison.test.ts
+++ b/frontend/src/lib/components/analytics/AgentComparison.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vite-plus/test";
+import source from "./AgentComparison.svelte?raw";
+
+describe("AgentComparison drilldowns", () => {
+  it("preserves current session route params when navigating to agents", () => {
+    expect(source).toContain("router.navigateToSessions({ agent: agent.name })");
+    expect(source).not.toContain('router.navigate("sessions"');
+  });
+});

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -110,6 +110,8 @@
       return JSON.stringify({
         mode: state.mode,
         windowDays: state.windowDays ?? null,
+        from: state.from,
+        to: state.to,
       });
     }
     if (state) {
@@ -118,6 +120,8 @@
         date: params["date"] ?? "",
         dateFrom: params["date_from"] ?? "",
         dateTo: params["date_to"] ?? "",
+        from: state.from,
+        to: state.to,
       });
     }
     if (hasSessionDateParams(params)) {
@@ -142,14 +146,17 @@
   ): boolean {
     const before = JSON.stringify(filtersToParams(sessions.filters));
     clearSessionDateFilters();
-    if (state.mode !== "rolling") {
-      const range = panelStateToRange(state, Date.now());
-      if (range) {
-        const params = rangeToSessionParams(range);
-        sessions.filters.date = params["date"] ?? "";
-        sessions.filters.dateFrom = params["date_from"] ?? "";
-        sessions.filters.dateTo = params["date_to"] ?? "";
-      }
+    const range = panelStateToRange(
+      state.mode === "rolling"
+        ? { ...state, mode: "fixed", windowDays: undefined }
+        : state,
+      Date.now(),
+    );
+    if (range) {
+      const params = rangeToSessionParams(range);
+      sessions.filters.date = params["date"] ?? "";
+      sessions.filters.dateFrom = params["date_from"] ?? "";
+      sessions.filters.dateTo = params["date_to"] ?? "";
     }
     const after = JSON.stringify(filtersToParams(sessions.filters));
     return before !== after;
@@ -330,15 +337,15 @@
         earliest: earliestSession,
       });
       const hasDateParams = hasSessionDateParams(params);
-      const windowDays = fixedState || hasDateParams
-        ? null
-        : parseSessionAnalyticsWindowDays(
-            params[SESSION_ANALYTICS_WINDOW_PARAM],
-          );
-      let state: PanelDateState | null = fixedState;
+      const windowDays = parseSessionAnalyticsWindowDays(
+        params[SESSION_ANALYTICS_WINDOW_PARAM],
+      );
+      let state: PanelDateState | null = null;
 
-      if (!state && windowDays !== null) {
+      if (windowDays !== null) {
         state = rollingPanelDate(windowDays);
+      } else {
+        state = fixedState;
       }
 
       const firstRun = !analyticsDateUrlInitRan;

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -169,6 +169,7 @@
   }
 
   function writeSessionDateParams(state: PanelDateState): void {
+    analyticsDateYokeCleared = false;
     const sessionChanged = syncSessionFiltersForDateState(state);
     const params = filtersToParams(sessions.filters);
     delete params[SESSION_ANALYTICS_WINDOW_PARAM];
@@ -217,7 +218,7 @@
   function refreshAnalytics(): Promise<void> {
     const refresh = analytics.fetchAll();
     const state = currentAnalyticsPanelDate();
-    if (state) {
+    if (state && !analyticsDateYokeCleared) {
       yokedDates.updateFromPanel(state);
       writeSessionDateParams(state);
     }
@@ -255,6 +256,7 @@
   let analyticsDateUrlInitRan = $state(false);
   let analyticsDateUrlInitComplete = $state(false);
   let lastAnalyticsDateUrlSignature: string | null = $state(null);
+  let analyticsDateYokeCleared = $state(false);
 
   onMount(() => {
     // The URL-date effect owns the initial load so deep links and stored yoke
@@ -409,6 +411,7 @@
           }
         } else if (dateChanged && sessionDateFiltersAreClear()) {
           yokedDates.clear();
+          analyticsDateYokeCleared = true;
         } else if (dateChanged) {
           state = rollingPanelDate(analytics.windowDays);
           if (state) {
@@ -416,6 +419,7 @@
             const sessionChanged =
               syncSessionFiltersForDateState(state);
             yokedDates.updateFromPanel(state);
+            analyticsDateYokeCleared = false;
             if (sessionChanged) sessions.load();
           }
         }
@@ -434,6 +438,7 @@
         changed = applyAnalyticsPanelDate(state);
         sessionChanged = syncSessionFiltersForDateState(state);
         yokedDates.updateFromPanel(state);
+        analyticsDateYokeCleared = false;
       }
       if (changed || firstRun) {
         analytics.fetchAll();

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -21,12 +21,27 @@
   import ActiveFilters from "./ActiveFilters.svelte";
   import SessionFilterControl from "../filters/SessionFilterControl.svelte";
   import { analytics } from "../../stores/analytics.svelte.js";
-  import { sessions } from "../../stores/sessions.svelte.js";
+  import {
+    sessions,
+    filtersToParams,
+  } from "../../stores/sessions.svelte.js";
   import { events } from "../../stores/events.svelte.js";
   import { ui } from "../../stores/ui.svelte.js";
   import { sync } from "../../stores/sync.svelte.js";
+  import { router } from "../../stores/router.svelte.js";
+  import {
+    yokedDates,
+    panelDateState,
+    panelStateToRange,
+    rangeToSessionParams,
+    sessionParamsToPanelDate,
+    type PanelDateState,
+  } from "../../stores/yokedDates.svelte.js";
+  import { rollingRange } from "../../utils/dates.js";
   import { exportAnalyticsCSV } from "../../utils/csv-export.js";
   import RefreshControl from "../shared/RefreshControl.svelte";
+
+  const SESSION_ANALYTICS_WINDOW_PARAM = "window_days";
 
   const earliestSession = $derived(sync.stats?.earliest_session ?? null);
 
@@ -43,10 +58,143 @@
   function applyRange(sel: RangeSelection) {
     if (sel.mode === "relative" && sel.days > 0) {
       analytics.setRollingWindow(sel.days);
+      const state = panelDateState(analytics.from, analytics.to, {
+        mode: "rolling",
+        windowDays: sel.days,
+      });
+      if (state) {
+        yokedDates.updateFromPanel(state);
+        writeSessionDateParams(state);
+      }
     } else {
       const range = resolveRange(sel, earliestSession);
       analytics.setDateRange(range.from, range.to);
+      const state = panelDateState(range.from, range.to, {
+        mode: "fixed",
+      });
+      if (state) {
+        yokedDates.updateFromPanel(state);
+        writeSessionDateParams(state);
+      }
     }
+  }
+
+  function parseSessionAnalyticsWindowDays(
+    raw: string | undefined,
+  ): number | null {
+    if (!raw) return null;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isInteger(n) || n <= 0 || String(n) !== raw) {
+      return null;
+    }
+    return n;
+  }
+
+  function hasSessionDateParams(params: Record<string, string>): boolean {
+    return !!params["date"] || !!params["date_from"] || !!params["date_to"];
+  }
+
+  function rollingPanelDate(days: number): PanelDateState | null {
+    const range = rollingRange(days);
+    return panelDateState(range.from, range.to, {
+      mode: "rolling",
+      windowDays: days,
+    });
+  }
+
+  function sessionAnalyticsDateUrlSignature(
+    params: Record<string, string>,
+    state: PanelDateState | null,
+  ): string {
+    if (state?.mode === "rolling") {
+      return JSON.stringify({
+        mode: state.mode,
+        windowDays: state.windowDays ?? null,
+      });
+    }
+    if (state) {
+      return JSON.stringify({
+        mode: state.mode,
+        date: params["date"] ?? "",
+        dateFrom: params["date_from"] ?? "",
+        dateTo: params["date_to"] ?? "",
+      });
+    }
+    if (hasSessionDateParams(params)) {
+      return JSON.stringify({
+        mode: "invalid",
+        date: params["date"] ?? "",
+        dateFrom: params["date_from"] ?? "",
+        dateTo: params["date_to"] ?? "",
+      });
+    }
+    return JSON.stringify({ mode: "none" });
+  }
+
+  function clearSessionDateFilters(): void {
+    sessions.filters.date = "";
+    sessions.filters.dateFrom = "";
+    sessions.filters.dateTo = "";
+  }
+
+  function syncSessionFiltersForDateState(
+    state: PanelDateState,
+  ): boolean {
+    const before = JSON.stringify(filtersToParams(sessions.filters));
+    clearSessionDateFilters();
+    if (state.mode !== "rolling") {
+      const range = panelStateToRange(state, Date.now());
+      if (range) {
+        const params = rangeToSessionParams(range);
+        sessions.filters.date = params["date"] ?? "";
+        sessions.filters.dateFrom = params["date_from"] ?? "";
+        sessions.filters.dateTo = params["date_to"] ?? "";
+      }
+    }
+    const after = JSON.stringify(filtersToParams(sessions.filters));
+    return before !== after;
+  }
+
+  function writeSessionDateParams(state: PanelDateState): void {
+    const sessionChanged = syncSessionFiltersForDateState(state);
+    const params = filtersToParams(sessions.filters);
+    delete params[SESSION_ANALYTICS_WINDOW_PARAM];
+    if (state.mode === "rolling" && state.windowDays) {
+      params[SESSION_ANALYTICS_WINDOW_PARAM] = String(state.windowDays);
+    }
+    router.replaceParams(params);
+    if (sessionChanged) sessions.load();
+  }
+
+  function analyticsPanelDateSignature(): string {
+    return JSON.stringify({
+      from: analytics.from,
+      to: analytics.to,
+      isPinned: analytics.isPinned,
+      windowDays: analytics.windowDays,
+      selectedDate: analytics.selectedDate,
+      selectedDow: analytics.selectedDow,
+      selectedHour: analytics.selectedHour,
+    });
+  }
+
+  function applyAnalyticsPanelDate(state: PanelDateState): boolean {
+    const before = analyticsPanelDateSignature();
+    if (state.mode === "rolling" && state.windowDays) {
+      analytics.applyRollingWindow(state.windowDays);
+    } else {
+      analytics.applyDateRange(state.from, state.to);
+    }
+    const after = analyticsPanelDateSignature();
+    return before !== after;
+  }
+
+  function handleDateRangeChange(from: string, to: string) {
+    const state = panelDateState(from, to, { mode: "fixed" });
+    if (!state) return;
+    analytics.setDateRange(from, to);
+    yokedDates.updateFromPanel(state);
+    writeSessionDateParams(state);
   }
 
   function shortTz(tz: string): string {
@@ -69,13 +217,16 @@
   }
 
   let unsubEvents: (() => void) | undefined;
+  let analyticsDateUrlInitRan = $state(false);
+  let analyticsDateUrlInitComplete = $state(false);
+  let lastAnalyticsDateUrlSignature: string | null = $state(null);
 
   onMount(() => {
-    // The page owns the initial load; RefreshControl handles the periodic
-    // refresh after that. SSE events only flag new data -- refetching on every
-    // event would thrash the aggregation -- so refetching stays bounded to the
-    // RefreshControl scheduler and its manual button.
-    analytics.fetchAll();
+    // The URL-date effect owns the initial load so deep links and stored yoke
+    // ranges are applied before the first analytics request. RefreshControl
+    // handles the periodic refresh after that. SSE events only flag new data --
+    // refetching on every event would thrash the aggregation -- so refetching
+    // stays bounded to the RefreshControl scheduler and its manual button.
     unsubEvents = events.subscribe(() => analytics.markNewData());
   });
 
@@ -163,9 +314,97 @@
       changed = true;
     }
 
-    if (changed) {
+    if (changed && analyticsDateUrlInitComplete) {
       untrack(() => analytics.fetchAll());
     }
+  });
+
+  $effect(() => {
+    const route = router.route;
+    const params = router.params;
+    untrack(() => {
+      if (route !== "sessions") return;
+
+      const fixedState = sessionParamsToPanelDate(params);
+      const hasDateParams = hasSessionDateParams(params);
+      const windowDays = fixedState || hasDateParams
+        ? null
+        : parseSessionAnalyticsWindowDays(
+            params[SESSION_ANALYTICS_WINDOW_PARAM],
+          );
+      let state: PanelDateState | null = fixedState;
+
+      if (!state && windowDays !== null) {
+        state = rollingPanelDate(windowDays);
+      }
+
+      const firstRun = !analyticsDateUrlInitRan;
+      const dateSignature = sessionAnalyticsDateUrlSignature(
+        params,
+        state,
+      );
+      const dateChanged = firstRun ||
+        lastAnalyticsDateUrlSignature !== dateSignature;
+
+      if (!state) {
+        if (hasDateParams) {
+          if (firstRun) {
+            analytics.fetchAll();
+          }
+          lastAnalyticsDateUrlSignature = dateSignature;
+          analyticsDateUrlInitRan = true;
+          analyticsDateUrlInitComplete = true;
+          return;
+        }
+        let changed = false;
+        if (firstRun) {
+          const seed = yokedDates.seedForPanel();
+          state = seed
+            ? panelDateState(seed.from, seed.to, {
+                mode: seed.mode,
+                windowDays: seed.windowDays,
+              })
+            : null;
+          if (state) {
+            changed = applyAnalyticsPanelDate(state);
+            writeSessionDateParams(state);
+          }
+        } else if (dateChanged) {
+          state = rollingPanelDate(analytics.windowDays);
+          if (state) {
+            changed = applyAnalyticsPanelDate(state);
+            const sessionChanged =
+              syncSessionFiltersForDateState(state);
+            yokedDates.updateFromPanel(state);
+            if (sessionChanged) sessions.load();
+          }
+        }
+        if (changed || firstRun) {
+          analytics.fetchAll();
+        }
+        lastAnalyticsDateUrlSignature = dateSignature;
+        analyticsDateUrlInitRan = true;
+        analyticsDateUrlInitComplete = true;
+        return;
+      }
+
+      let changed = false;
+      let sessionChanged = false;
+      if (dateChanged) {
+        changed = applyAnalyticsPanelDate(state);
+        sessionChanged = syncSessionFiltersForDateState(state);
+        yokedDates.updateFromPanel(state);
+      }
+      if (changed || firstRun) {
+        analytics.fetchAll();
+      }
+      if (sessionChanged && !firstRun) {
+        sessions.load();
+      }
+      lastAnalyticsDateUrlSignature = dateSignature;
+      analyticsDateUrlInitRan = true;
+      analyticsDateUrlInitComplete = true;
+    });
   });
 
   onDestroy(() => {
@@ -229,7 +468,7 @@
             </span>
           </h3>
         </div>
-        <ActivityTimeline />
+        <ActivityTimeline onDateRangeChange={handleDateRangeChange} />
         <div class="chart-divider"></div>
         <HourOfWeekHeatmap />
       </div>

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -147,6 +147,17 @@
       !sessions.filters.dateTo;
   }
 
+  function analyticsDateYokeIsClear(): boolean {
+    return (
+      !hasSessionDateParams(router.params) &&
+      parseSessionAnalyticsWindowDays(
+        router.params[SESSION_ANALYTICS_WINDOW_PARAM],
+      ) === null &&
+      sessionDateFiltersAreClear() &&
+      yokedDates.range === null
+    );
+  }
+
   function syncSessionFiltersForDateState(
     state: PanelDateState,
   ): boolean {
@@ -169,7 +180,6 @@
   }
 
   function writeSessionDateParams(state: PanelDateState): void {
-    analyticsDateYokeCleared = false;
     const sessionChanged = syncSessionFiltersForDateState(state);
     const params = filtersToParams(sessions.filters);
     delete params[SESSION_ANALYTICS_WINDOW_PARAM];
@@ -218,7 +228,7 @@
   function refreshAnalytics(): Promise<void> {
     const refresh = analytics.fetchAll();
     const state = currentAnalyticsPanelDate();
-    if (state && !analyticsDateYokeCleared) {
+    if (state && !analyticsDateYokeIsClear()) {
       yokedDates.updateFromPanel(state);
       writeSessionDateParams(state);
     }
@@ -256,7 +266,6 @@
   let analyticsDateUrlInitRan = $state(false);
   let analyticsDateUrlInitComplete = $state(false);
   let lastAnalyticsDateUrlSignature: string | null = $state(null);
-  let analyticsDateYokeCleared = $state(false);
 
   onMount(() => {
     // The URL-date effect owns the initial load so deep links and stored yoke
@@ -411,7 +420,6 @@
           }
         } else if (dateChanged && sessionDateFiltersAreClear()) {
           yokedDates.clear();
-          analyticsDateYokeCleared = true;
         } else if (dateChanged) {
           state = rollingPanelDate(analytics.windowDays);
           if (state) {
@@ -419,7 +427,6 @@
             const sessionChanged =
               syncSessionFiltersForDateState(state);
             yokedDates.updateFromPanel(state);
-            analyticsDateYokeCleared = false;
             if (sessionChanged) sessions.load();
           }
         }
@@ -438,7 +445,6 @@
         changed = applyAnalyticsPanelDate(state);
         sessionChanged = syncSessionFiltersForDateState(state);
         yokedDates.updateFromPanel(state);
-        analyticsDateYokeCleared = false;
       }
       if (changed || firstRun) {
         analytics.fetchAll();

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -141,6 +141,12 @@
     sessions.filters.dateTo = "";
   }
 
+  function sessionDateFiltersAreClear(): boolean {
+    return !sessions.filters.date &&
+      !sessions.filters.dateFrom &&
+      !sessions.filters.dateTo;
+  }
+
   function syncSessionFiltersForDateState(
     state: PanelDateState,
   ): boolean {
@@ -401,6 +407,8 @@
             changed = applyAnalyticsPanelDate(state);
             writeSessionDateParams(state);
           }
+        } else if (dateChanged && sessionDateFiltersAreClear()) {
+          yokedDates.clear();
         } else if (dateChanged) {
           state = rollingPanelDate(analytics.windowDays);
           if (state) {

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -196,6 +196,28 @@
     return before !== after;
   }
 
+  function currentAnalyticsPanelDate(): PanelDateState | null {
+    if (!analytics.isPinned) {
+      return panelDateState(analytics.from, analytics.to, {
+        mode: "rolling",
+        windowDays: analytics.windowDays,
+      });
+    }
+    return panelDateState(analytics.from, analytics.to, {
+      mode: "fixed",
+    });
+  }
+
+  function refreshAnalytics(): Promise<void> {
+    const refresh = analytics.fetchAll();
+    const state = currentAnalyticsPanelDate();
+    if (state) {
+      yokedDates.updateFromPanel(state);
+      writeSessionDateParams(state);
+    }
+    return refresh;
+  }
+
   function handleDateRangeChange(from: string, to: string) {
     const state = panelDateState(from, to, { mode: "fixed" });
     if (!state) return;
@@ -443,7 +465,7 @@
     <RefreshControl
       lastUpdatedAt={analytics.lastUpdatedAt}
       busy={analytics.isQuerying}
-      onRefresh={() => analytics.fetchAll()}
+      onRefresh={refreshAnalytics}
       label="Refresh analytics"
     />
     <button class="export-btn" onclick={handleExportCSV}>

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -322,10 +322,13 @@
   $effect(() => {
     const route = router.route;
     const params = router.params;
+    const earliestSession = sync.stats?.earliest_session ?? undefined;
     untrack(() => {
       if (route !== "sessions") return;
 
-      const fixedState = sessionParamsToPanelDate(params);
+      const fixedState = sessionParamsToPanelDate(params, {
+        earliest: earliestSession,
+      });
       const hasDateParams = hasSessionDateParams(params);
       const windowDays = fixedState || hasDateParams
         ? null

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -45,6 +45,21 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(source).toContain("writeSessionDateParams");
   });
 
+  it("refreshes analytics through date-aware session writeback", () => {
+    const helperStart = source.indexOf("function refreshAnalytics");
+    const helperEnd = source.indexOf(
+      "\n\n  function handleDateRangeChange",
+      helperStart,
+    );
+    const helperBlock = source.slice(helperStart, helperEnd);
+
+    expect(helperStart).toBeGreaterThan(-1);
+    expect(helperBlock).toContain("analytics.fetchAll()");
+    expect(helperBlock).toContain("writeSessionDateParams(state)");
+    expect(source).toContain("onRefresh={refreshAnalytics}");
+    expect(source).not.toContain("onRefresh={() => analytics.fetchAll()}");
+  });
+
   it("applies URL and yoke dates before the initial analytics fetch", () => {
     const onMountIndex = source.indexOf("onMount(() =>");
     const firstEffectAfterMount = source.indexOf("$effect(() =>", onMountIndex);

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -104,6 +104,10 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(sessions.filters.dateTo).toBe("");
     expect(yokedDates.range).toBeNull();
 
+    unmount(component);
+    component = mount(AnalyticsPage, { target: document.body });
+    await flushEffects();
+
     const refresh = document.querySelector<HTMLButtonElement>(
       'button[aria-label="Refresh analytics"]',
     );

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -38,4 +38,113 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(queryProgress).not.toContain("position: sticky");
     expect(queryProgress).not.toContain("margin:");
   });
+
+  it("preserves rolling sessions analytics URLs with window_days", () => {
+    expect(source).toContain('"window_days"');
+    expect(source).toContain("parseSessionAnalyticsWindowDays");
+    expect(source).toContain("writeSessionDateParams");
+  });
+
+  it("applies URL and yoke dates before the initial analytics fetch", () => {
+    const onMountIndex = source.indexOf("onMount(() =>");
+    const firstEffectAfterMount = source.indexOf("$effect(() =>", onMountIndex);
+    const onMountBlock = source.slice(onMountIndex, firstEffectAfterMount);
+
+    expect(onMountBlock).not.toContain("analytics.fetchAll();");
+    expect(source).toContain("const firstRun = !analyticsDateUrlInitRan");
+    expect(source).toContain("if (changed || firstRun)");
+  });
+
+  it("routes timeline range selections through the shared date-change path", () => {
+    expect(source).toContain(
+      "<ActivityTimeline onDateRangeChange={handleDateRangeChange} />",
+    );
+  });
+
+  it("only seeds saved yoke dates during initial URL hydration", () => {
+    const seedIndex = source.indexOf("const seed = yokedDates.seedForPanel()");
+    const guardedSeedIndex = source.indexOf(
+      "if (firstRun) {\n          const seed = yokedDates.seedForPanel()",
+    );
+
+    expect(seedIndex).toBeGreaterThan(-1);
+    expect(guardedSeedIndex).toBeGreaterThan(-1);
+  });
+
+  it("treats drill-down clears as analytics date changes", () => {
+    const signatureStart = source.indexOf(
+      "function analyticsPanelDateSignature",
+    );
+    const signatureEnd = source.indexOf(
+      "\n\n  function applyAnalyticsPanelDate",
+      signatureStart,
+    );
+    const signatureBlock = source.slice(signatureStart, signatureEnd);
+    const applyStart = source.indexOf("function applyAnalyticsPanelDate");
+    const applyEnd = source.indexOf(
+      "\n\n  function handleDateRangeChange",
+      applyStart,
+    );
+    const applyBlock = source.slice(applyStart, applyEnd);
+
+    expect(signatureStart).toBeGreaterThan(-1);
+    expect(signatureBlock).toContain("selectedDate: analytics.selectedDate");
+    expect(signatureBlock).toContain("selectedDow: analytics.selectedDow");
+    expect(signatureBlock).toContain("selectedHour: analytics.selectedHour");
+    expect(applyBlock).toContain(
+      "const before = analyticsPanelDateSignature();",
+    );
+    expect(applyBlock).toContain(
+      "const after = analyticsPanelDateSignature();",
+    );
+  });
+
+  it("only applies analytics URL dates when the date signature changes", () => {
+    const helperStart = source.indexOf(
+      "function sessionAnalyticsDateUrlSignature",
+    );
+    const helperEnd = source.indexOf(
+      "\n\n  function clearSessionDateFilters",
+      helperStart,
+    );
+    const helperBlock = source.slice(helperStart, helperEnd);
+    const effectStart = source.indexOf("const dateSignature =");
+    const effectEnd = source.indexOf(
+      "\n\n  onDestroy",
+      effectStart,
+    );
+    const effectBlock = source.slice(effectStart, effectEnd);
+
+    expect(helperStart).toBeGreaterThan(-1);
+    expect(helperBlock).toContain("state.mode");
+    expect(helperBlock).toContain("state.windowDays");
+    expect(source).toContain(
+      "let lastAnalyticsDateUrlSignature: string | null = $state(null);",
+    );
+    expect(effectBlock).toContain(
+      "const dateChanged = firstRun ||\n        lastAnalyticsDateUrlSignature !== dateSignature;",
+    );
+    expect(effectBlock).toContain("if (dateChanged) {");
+    expect(effectBlock).toContain("changed = applyAnalyticsPanelDate(state);");
+    expect(effectBlock).toContain(
+      "lastAnalyticsDateUrlSignature = dateSignature;",
+    );
+  });
+
+  it("resets analytics to rolling dates when URL date params are removed", () => {
+    const noStateStart = source.indexOf("if (!state) {");
+    const noStateEnd = source.indexOf(
+      "\n\n      let changed = false;\n      let sessionChanged = false;",
+      noStateStart,
+    );
+    const noStateBlock = source.slice(noStateStart, noStateEnd);
+
+    expect(noStateBlock).toContain("else if (dateChanged) {");
+    expect(noStateBlock).toContain(
+      "state = rollingPanelDate(analytics.windowDays);",
+    );
+    expect(noStateBlock).toContain(
+      "changed = applyAnalyticsPanelDate(state);",
+    );
+  });
 });

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -1,7 +1,110 @@
-import { describe, expect, it } from "vite-plus/test";
+// @vitest-environment jsdom
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { mount, tick, unmount } from "svelte";
+import { analytics } from "../../stores/analytics.svelte.js";
+import { router } from "../../stores/router.svelte.js";
+import { sessions } from "../../stores/sessions.svelte.js";
+import { yokedDates } from "../../stores/yokedDates.svelte.js";
 import source from "./AnalyticsPage.svelte?raw";
+// @ts-ignore
+import AnalyticsPage from "./AnalyticsPage.svelte";
+
+async function flushEffects() {
+  await tick();
+  await Promise.resolve();
+  await tick();
+}
+
+let component: ReturnType<typeof mount> | undefined;
+
+afterEach(() => {
+  if (component) {
+    unmount(component);
+    component = undefined;
+  }
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+  localStorage.clear();
+  window.history.replaceState(null, "", "/");
+  router.route = "sessions";
+  router.params = {};
+  router.sessionId = null;
+  analytics.isPinned = false;
+  analytics.windowDays = 365;
+  analytics.from = "";
+  analytics.to = "";
+  analytics.selectedDate = null;
+  analytics.selectedDow = null;
+  analytics.selectedHour = null;
+  sessions.filters.date = "";
+  sessions.filters.dateFrom = "";
+  sessions.filters.dateTo = "";
+  yokedDates.clear();
+});
 
 describe("AnalyticsPage refresh behavior", () => {
+  it("does not rematerialize rolling dates after cleared session date params", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-20T12:00:00"));
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(analytics, "fetchAll").mockResolvedValue();
+    vi.spyOn(sessions, "load").mockResolvedValue();
+
+    window.history.replaceState(
+      null,
+      "",
+      "/sessions?window_days=30&date_from=2026-05-21&date_to=2026-06-20",
+    );
+    router.route = "sessions";
+    router.sessionId = null;
+    router.params = {
+      window_days: "30",
+      date_from: "2026-05-21",
+      date_to: "2026-06-20",
+    };
+    analytics.windowDays = 30;
+    analytics.isPinned = false;
+    analytics.from = "2026-05-21";
+    analytics.to = "2026-06-20";
+    sessions.filters.date = "";
+    sessions.filters.dateFrom = "2026-05-21";
+    sessions.filters.dateTo = "2026-06-20";
+    yokedDates.updateFromPanel({
+      from: "2026-05-21",
+      to: "2026-06-20",
+      mode: "rolling",
+      windowDays: 30,
+    });
+
+    component = mount(AnalyticsPage, { target: document.body });
+    await flushEffects();
+
+    sessions.filters.date = "";
+    sessions.filters.dateFrom = "";
+    sessions.filters.dateTo = "";
+    router.params = {};
+    await flushEffects();
+
+    expect(sessions.filters.date).toBe("");
+    expect(sessions.filters.dateFrom).toBe("");
+    expect(sessions.filters.dateTo).toBe("");
+    expect(yokedDates.range).toBeNull();
+  });
+
   it("does not refresh analytical scans from SSE updates", () => {
     expect(source).not.toContain("subscribeDebounced");
     // SSE only flags new data; the periodic refetch lives in RefreshControl.
@@ -149,7 +252,7 @@ describe("AnalyticsPage refresh behavior", () => {
     );
   });
 
-  it("resets analytics to rolling dates when URL date params are removed", () => {
+  it("does not use the rolling fallback when cleared session date filters remove URL dates", () => {
     const noStateStart = source.indexOf("if (!state) {");
     const noStateEnd = source.indexOf(
       "\n\n      let changed = false;\n      let sessionChanged = false;",
@@ -157,7 +260,11 @@ describe("AnalyticsPage refresh behavior", () => {
     );
     const noStateBlock = source.slice(noStateStart, noStateEnd);
 
-    expect(noStateBlock).toContain("else if (dateChanged) {");
+    expect(noStateBlock).toContain(
+      "dateChanged && sessionDateFiltersAreClear()",
+    );
+    expect(noStateBlock).toContain("yokedDates.clear();");
+    expect(noStateBlock).toContain("} else if (dateChanged) {");
     expect(noStateBlock).toContain(
       "state = rollingPanelDate(analytics.windowDays);",
     );

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -103,6 +103,18 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(sessions.filters.dateFrom).toBe("");
     expect(sessions.filters.dateTo).toBe("");
     expect(yokedDates.range).toBeNull();
+
+    const refresh = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Refresh analytics"]',
+    );
+    expect(refresh).not.toBeNull();
+    refresh!.click();
+    await flushEffects();
+
+    expect(sessions.filters.date).toBe("");
+    expect(sessions.filters.dateFrom).toBe("");
+    expect(sessions.filters.dateTo).toBe("");
+    expect(yokedDates.range).toBeNull();
   });
 
   it("does not refresh analytical scans from SSE updates", () => {

--- a/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.test.ts
@@ -118,6 +118,9 @@ describe("AnalyticsPage refresh behavior", () => {
     expect(helperStart).toBeGreaterThan(-1);
     expect(helperBlock).toContain("state.mode");
     expect(helperBlock).toContain("state.windowDays");
+    expect(helperBlock).toContain("from: state.from");
+    expect(helperBlock).toContain("to: state.to");
+    expect(source).toContain("syncSessionFiltersForDateState(state)");
     expect(source).toContain(
       "let lastAnalyticsDateUrlSignature: string | null = $state(null);",
     );

--- a/frontend/src/lib/components/analytics/SessionShape.svelte
+++ b/frontend/src/lib/components/analytics/SessionShape.svelte
@@ -55,7 +55,7 @@
     if (max !== undefined) {
       params["max_messages"] = String(max);
     }
-    router.navigate("sessions", params);
+    router.navigateToSessions(params, ["min_messages", "max_messages"]);
   }
 </script>
 

--- a/frontend/src/lib/components/analytics/SessionShape.test.ts
+++ b/frontend/src/lib/components/analytics/SessionShape.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vite-plus/test";
+import source from "./SessionShape.svelte?raw";
+
+describe("SessionShape drilldowns", () => {
+  it("preserves current session route params when navigating to buckets", () => {
+    expect(source).toContain(
+      'router.navigateToSessions(params, ["min_messages", "max_messages"])',
+    );
+    expect(source).not.toContain('router.navigate("sessions", params)');
+  });
+});

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -36,8 +36,11 @@
 
   function handleSessionClick(id: string) {
     let needInvalidate = false;
+    const params: Record<string, string> = {};
+    const clearParams: string[] = [];
     if (analytics.includeOneShot && !sessions.filters.includeOneShot) {
       sessions.filters.includeOneShot = true;
+      clearParams.push("include_one_shot");
       needInvalidate = true;
     }
     if (
@@ -45,10 +48,20 @@
       !sessions.filters.includeAutomated
     ) {
       sessions.filters.includeAutomated = true;
+      params.include_automated = "true";
+      clearParams.push("include_automated");
       needInvalidate = true;
     }
     if (needInvalidate) {
       sessions.invalidateFilterCaches();
+    }
+    if (clearParams.length > 0 || Object.keys(params).length > 0) {
+      router.navigateToSession(
+        id,
+        Object.keys(params).length > 0 ? params : undefined,
+        clearParams,
+      );
+      return;
     }
     router.navigateToSession(id);
   }

--- a/frontend/src/lib/components/analytics/TopSessions.test.ts
+++ b/frontend/src/lib/components/analytics/TopSessions.test.ts
@@ -47,6 +47,9 @@ describe("TopSessions", () => {
     analytics.errors = savedErrors;
     sessions.filters.includeOneShot = false;
     sessions.filters.termination = "";
+    router.route = "sessions";
+    router.params = {};
+    router.sessionId = null;
     window.history.replaceState(null, "", "/");
     // Clear any orphaned DOM left behind by tests that fail
     // before their unmount call.
@@ -100,7 +103,41 @@ describe("TopSessions", () => {
 
     expect(sessions.filters.includeOneShot).toBe(true);
     expect(cacheSpy).toHaveBeenCalledOnce();
-    expect(navSpy).toHaveBeenCalledWith("sess-1");
+    expect(navSpy).toHaveBeenCalledWith(
+      "sess-1",
+      undefined,
+      ["include_one_shot"],
+    );
+
+    unmount(component);
+  });
+
+  it("drops stale one-shot URL state when opening a one-shot result", async () => {
+    navSpy.mockRestore();
+    window.history.replaceState(
+      null,
+      "",
+      "/sessions?include_one_shot=false&window_days=14",
+    );
+    router.route = "sessions";
+    router.sessionId = null;
+    router.params = {
+      include_one_shot: "false",
+      window_days: "14",
+    };
+    analytics.includeOneShot = true;
+    sessions.filters.includeOneShot = false;
+    const component = mountWithData();
+    await tick();
+
+    clickRow();
+    await tick();
+
+    expect(window.location.pathname).toBe(
+      "/sessions/sess-1",
+    );
+    expect(window.location.search).toContain("window_days=14");
+    expect(window.location.search).not.toContain("include_one_shot=false");
 
     unmount(component);
   });

--- a/frontend/src/lib/components/filters/SessionActiveFilters.svelte
+++ b/frontend/src/lib/components/filters/SessionActiveFilters.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { sessions } from "../../stores/sessions.svelte.js";
+  import { router } from "../../stores/router.svelte.js";
+  import { hasSessionDateIntent } from "../../stores/sessionRouteParams.js";
   import {
     agentColor,
     agentLabel,
@@ -58,7 +60,9 @@
 
   function clearAll() {
     sessions.filters.project = "";
-    sessions.clearSessionFilters();
+    sessions.clearSessionFilters({
+      clearDateYoke: hasSessionDateIntent(router.params),
+    });
     onClearProjects?.();
     onClearModels?.();
   }

--- a/frontend/src/lib/components/filters/SessionActiveFilters.svelte
+++ b/frontend/src/lib/components/filters/SessionActiveFilters.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { sessions } from "../../stores/sessions.svelte.js";
   import { router } from "../../stores/router.svelte.js";
-  import { hasSessionDateIntent } from "../../stores/sessionRouteParams.js";
+  import { hasSessionRouteDateIntent } from "../../stores/sessionRouteParams.js";
   import {
     agentColor,
     agentLabel,
@@ -61,7 +61,10 @@
   function clearAll() {
     sessions.filters.project = "";
     sessions.clearSessionFilters({
-      clearDateYoke: hasSessionDateIntent(router.params),
+      clearDateYoke: hasSessionRouteDateIntent(
+        router.route,
+        router.params,
+      ),
     });
     onClearProjects?.();
     onClearModels?.();

--- a/frontend/src/lib/components/filters/SessionFilterControl.svelte
+++ b/frontend/src/lib/components/filters/SessionFilterControl.svelte
@@ -2,7 +2,7 @@
   import type { Snippet } from "svelte";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { router } from "../../stores/router.svelte.js";
-  import { hasSessionDateIntent } from "../../stores/sessionRouteParams.js";
+  import { hasSessionRouteDateIntent } from "../../stores/sessionRouteParams.js";
   import { starred } from "../../stores/starred.svelte.js";
   import {
     agentColor,
@@ -113,7 +113,10 @@
   function clearFilters() {
     onClearGroupMode?.();
     onClearExtra?.();
-    const clearDateYoke = hasSessionDateIntent(router.params);
+    const clearDateYoke = hasSessionRouteDateIntent(
+      router.route,
+      router.params,
+    );
     if (sessions.hasActiveFilters && starred.filterOnly) {
       if (showStarred) starred.filterOnly = false;
       sessions.clearSessionFilters({ clearDateYoke });

--- a/frontend/src/lib/components/filters/SessionFilterControl.svelte
+++ b/frontend/src/lib/components/filters/SessionFilterControl.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { sessions } from "../../stores/sessions.svelte.js";
+  import { router } from "../../stores/router.svelte.js";
+  import { hasSessionDateIntent } from "../../stores/sessionRouteParams.js";
   import { starred } from "../../stores/starred.svelte.js";
   import {
     agentColor,
@@ -111,11 +113,12 @@
   function clearFilters() {
     onClearGroupMode?.();
     onClearExtra?.();
+    const clearDateYoke = hasSessionDateIntent(router.params);
     if (sessions.hasActiveFilters && starred.filterOnly) {
       if (showStarred) starred.filterOnly = false;
-      sessions.clearSessionFilters();
+      sessions.clearSessionFilters({ clearDateYoke });
     } else if (sessions.hasActiveFilters) {
-      sessions.clearSessionFilters();
+      sessions.clearSessionFilters({ clearDateYoke });
     } else if (showStarred && starred.filterOnly) {
       starred.filterOnly = false;
       sessions.load();

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -8,7 +8,16 @@
   import { sync } from "../../stores/sync.svelte.js";
   import { events } from "../../stores/events.svelte.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
+  import {
+    yokedDates,
+    panelDateState,
+    panelStateToRange,
+    rangeToInsightParams,
+    rangeToPanelDate,
+    type PanelDateState,
+  } from "../../stores/yokedDates.svelte.js";
   import { renderMarkdown } from "../../utils/markdown.js";
+  import { rollingRange } from "../../utils/dates.js";
   import { scoreToGrade } from "../../utils/grade.js";
   import { agentLabel } from "../../utils/agents.js";
   import { AnalyticsService } from "../../api/generated/index.js";
@@ -39,6 +48,12 @@
   } from "./qualityPatterns.js";
 
   const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+  const INSIGHTS_WINDOW_PARAM = "window_days";
+  const INSIGHTS_DATE_PARAM_KEYS = [
+    INSIGHTS_WINDOW_PARAM,
+    "date_from",
+    "date_to",
+  ] as const;
   type AnalyticsParams = Parameters<
     typeof AnalyticsService.getApiV1AnalyticsSignals
   >[0];
@@ -138,12 +153,129 @@
   ];
 
   function applyRange(sel: RangeSelection) {
+    let state: PanelDateState | null = null;
     if (sel.mode === "relative" && sel.days > 0) {
       analytics.setRollingWindow(sel.days);
+      state = panelDateState(analytics.from, analytics.to, {
+        mode: "rolling",
+        windowDays: sel.days,
+      });
     } else {
       const range = resolveRange(sel, earliestSession);
       analytics.setDateRange(range.from, range.to);
+      state = panelDateState(range.from, range.to, { mode: "fixed" });
     }
+    updateYokeFromInsights(state);
+  }
+
+  function parseInsightWindowDays(raw: string | undefined): number | null {
+    if (!raw) return null;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isInteger(n) || n <= 0 || String(n) !== raw) {
+      return null;
+    }
+    return n;
+  }
+
+  function insightParamsToPanelDate(
+    params: Record<string, string>,
+  ): PanelDateState | null {
+    const windowDays = parseInsightWindowDays(params[INSIGHTS_WINDOW_PARAM]);
+    if (windowDays !== null) {
+      const range = rollingRange(windowDays);
+      return panelDateState(range.from, range.to, {
+        mode: "rolling",
+        windowDays,
+      });
+    }
+    return panelDateState(
+      params.date_from ?? "",
+      params.date_to ?? "",
+      { mode: "fixed" },
+    );
+  }
+
+  function hasInsightDateParams(
+    params: Record<string, string>,
+  ): boolean {
+    return !!params.date_from || !!params.date_to ||
+      !!params[INSIGHTS_WINDOW_PARAM];
+  }
+
+  function applyInsightPanelDate(state: PanelDateState): boolean {
+    const before = JSON.stringify({
+      from: analytics.from,
+      to: analytics.to,
+      isPinned: analytics.isPinned,
+      windowDays: analytics.windowDays,
+    });
+    if (state.mode === "rolling" && state.windowDays) {
+      analytics.applyRollingWindow(state.windowDays);
+    } else {
+      analytics.applyDateRange(state.from, state.to);
+    }
+    const after = JSON.stringify({
+      from: analytics.from,
+      to: analytics.to,
+      isPinned: analytics.isPinned,
+      windowDays: analytics.windowDays,
+    });
+    return before !== after;
+  }
+
+  function currentInsightPanelDate(): PanelDateState | null {
+    if (!analytics.isPinned) {
+      return panelDateState(analytics.from, analytics.to, {
+        mode: "rolling",
+        windowDays: analytics.windowDays,
+      });
+    }
+    return panelDateState(analytics.from, analytics.to, {
+      mode: "fixed",
+    });
+  }
+
+  function paramsWithInsightDate(
+    state: PanelDateState | null = currentInsightPanelDate(),
+    extra: Record<string, string> = {},
+  ): Record<string, string> {
+    const nextParams = { ...router.params };
+    for (const key of INSIGHTS_DATE_PARAM_KEYS) {
+      delete nextParams[key];
+    }
+    if (state) {
+      const range = panelStateToRange(state, Date.now());
+      if (range) {
+        Object.assign(nextParams, rangeToInsightParams(range));
+      }
+    }
+    return { ...nextParams, ...extra };
+  }
+
+  function writeInsightDateParams(state: PanelDateState): void {
+    router.replaceParams(paramsWithInsightDate(state));
+  }
+
+  function updateYokeFromInsights(state: PanelDateState | null): void {
+    if (!state) return;
+    yokedDates.updateFromPanel(state);
+    writeInsightDateParams(state);
+  }
+
+  function seedInsightsYoke(): void {
+    const urlState = insightParamsToPanelDate(router.params);
+    if (urlState) {
+      applyInsightPanelDate(urlState);
+      yokedDates.updateFromPanel(urlState);
+      return;
+    }
+    if (hasInsightDateParams(router.params)) return;
+
+    const seed = yokedDates.seedForPanel();
+    const state = seed ? rangeToPanelDate(seed) : null;
+    if (!state) return;
+    applyInsightPanelDate(state);
+    writeInsightDateParams(state);
   }
 
   function fetchInsightSignals() {
@@ -297,8 +429,14 @@
 
   function insightLinkPath(id: number): string {
     const params = new URLSearchParams();
+    const dateParams = paramsWithInsightDate();
     if (Object.hasOwn(router.params, "desktop")) {
       params.set("desktop", router.params.desktop ?? "");
+    }
+    for (const [key, value] of Object.entries(dateParams)) {
+      if (key !== "desktop" && key !== "insight") {
+        params.set(key, value);
+      }
     }
     params.set("insight", String(id));
     return `${getBasePath()}/insights?${params.toString()}`;
@@ -323,12 +461,18 @@
 
   function selectGeneratedInsight(id: number) {
     insights.select(id);
-    router.replaceParams({ insight: String(id) });
+    router.replaceParams(
+      paramsWithInsightDate(currentInsightPanelDate(), {
+        insight: String(id),
+      }),
+    );
   }
 
   function selectGeneratedTask(clientId: string) {
     insights.selectTask(clientId);
-    router.replaceParams({});
+    const params = paramsWithInsightDate();
+    delete params.insight;
+    router.replaceParams(params);
   }
 
   function selectedInsightFromRoute(): number | null {
@@ -464,6 +608,7 @@
   }
 
   onMount(() => {
+    seedInsightsYoke();
     sessions.loadProjects();
     sessions.loadAgents();
     fetchInsightSignals();
@@ -1063,7 +1208,9 @@
                     onclick={() => {
                       if (insights.selectedItem) {
                         insights.deleteItem(insights.selectedItem.id);
-                        router.replaceParams({});
+                        const params = paramsWithInsightDate();
+                        delete params.insight;
+                        router.replaceParams(params);
                       }
                     }}
                     title="Delete generated insight"

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -305,7 +305,10 @@
   }
 
   function handleAutomatedScopeChange(value: string) {
-    analytics.setAutomatedScope(value as AutomatedScope);
+    const scope = value as AutomatedScope;
+    analytics.automatedScope = scope;
+    analytics.includeAutomated = scope !== "human";
+    fetchInsightSignals();
   }
 
   function handlePromptChange(e: Event) {

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -280,6 +280,10 @@
 
   function fetchInsightSignals() {
     analytics.fetchSignalsForInsights();
+    const state = currentInsightPanelDate();
+    if (state?.mode === "rolling") {
+      updateYokeFromInsights(state);
+    }
   }
 
   function handleProjectChange(value: string) {

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -69,4 +69,16 @@ describe("InsightsPage date yoke controls", () => {
     expect(source).toContain("delete nextParams[key]");
     expect(source).toContain("paramsWithInsightDate");
   });
+
+  it("refreshes rolling insight URL/yoke bounds after signal fetches", () => {
+    const fetchIndex = source.indexOf("function fetchInsightSignals");
+    const nextHandlerIndex = source.indexOf(
+      "\n\n  function handleProjectChange",
+      fetchIndex,
+    );
+    const fetchBlock = source.slice(fetchIndex, nextHandlerIndex);
+
+    expect(fetchBlock).toContain("analytics.fetchSignalsForInsights()");
+    expect(fetchBlock).toContain("updateYokeFromInsights(state)");
+  });
 });

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -81,4 +81,18 @@ describe("InsightsPage date yoke controls", () => {
     expect(fetchBlock).toContain("analytics.fetchSignalsForInsights()");
     expect(fetchBlock).toContain("updateYokeFromInsights(state)");
   });
+
+  it("routes automated scope changes through the insight refresh wrapper", () => {
+    const handlerIndex = source.indexOf(
+      "function handleAutomatedScopeChange",
+    );
+    const nextHandlerIndex = source.indexOf(
+      "\n\n  function handlePromptChange",
+      handlerIndex,
+    );
+    const handlerBlock = source.slice(handlerIndex, nextHandlerIndex);
+
+    expect(handlerBlock).toContain("fetchInsightSignals()");
+    expect(handlerBlock).not.toContain("analytics.setAutomatedScope");
+  });
 });

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -32,3 +32,41 @@ describe("InsightsPage sidebar filter sync", () => {
     expect(source).toContain("fetchInsightSignals()");
   });
 });
+
+describe("InsightsPage date yoke controls", () => {
+  it("updates and seeds shared yoke state from the unified range picker", () => {
+    expect(source).toContain("<RangePicker");
+    expect(source).toContain("updateYokeFromInsights");
+    expect(source).toContain("seedInsightsYoke");
+    expect(source).toContain("rangeToPanelDate(seed)");
+  });
+
+  it("lets insight URL dates override stored yoke dates", () => {
+    expect(source).toContain("insightParamsToPanelDate(router.params)");
+    expect(source).toContain("hasInsightDateParams(router.params)");
+    expect(source).toContain("paramsWithInsightDate");
+    expect(source).toContain("rangeToInsightParams(range)");
+  });
+
+  it("preserves relative range selections as rolling yoke state", () => {
+    const applyIndex = source.indexOf("function applyRange");
+    const parseIndex = source.indexOf(
+      "function parseInsightWindowDays",
+      applyIndex,
+    );
+    const applyBlock = source.slice(applyIndex, parseIndex);
+
+    expect(source).toContain('mode: "rolling"');
+    expect(source).toContain("windowDays: sel.days");
+    expect(applyBlock).toContain("analytics.setRollingWindow(sel.days)");
+    expect(applyBlock).toContain("updateYokeFromInsights(state)");
+  });
+
+  it("preserves rolling window intent in insight URLs", () => {
+    expect(source).toContain('const INSIGHTS_WINDOW_PARAM = "window_days"');
+    expect(source).toContain("parseInsightWindowDays");
+    expect(source).toContain("rollingRange(windowDays)");
+    expect(source).toContain("delete nextParams[key]");
+    expect(source).toContain("paramsWithInsightDate");
+  });
+});

--- a/frontend/src/lib/components/shared/dateRangeSelector.ts
+++ b/frontend/src/lib/components/shared/dateRangeSelector.ts
@@ -1,3 +1,9 @@
+import {
+  daysAgo,
+  localDateStr,
+  today,
+} from "../../utils/dates.js";
+
 export interface DateRange {
   from: string;
   to: string;
@@ -16,21 +22,10 @@ export const DATE_RANGE_PRESETS: DateRangePreset[] = [
   { label: "All", days: 0 },
 ];
 
-export function localDateStr(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-export function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return localDateStr(d);
-}
+export { daysAgo, localDateStr };
 
 export function todayStr(): string {
-  return localDateStr(new Date());
+  return today();
 }
 
 export function allFromDate(earliestSession: string | null | undefined): string {

--- a/frontend/src/lib/components/trends/TrendsPage.svelte
+++ b/frontend/src/lib/components/trends/TrendsPage.svelte
@@ -183,6 +183,8 @@
   }
 
   async function resetTerms() {
+    materializeRollingWindow();
+    writeUrl();
     await trends.resetTerms();
     writeUrl();
   }

--- a/frontend/src/lib/components/trends/TrendsPage.svelte
+++ b/frontend/src/lib/components/trends/TrendsPage.svelte
@@ -3,6 +3,13 @@
   import { trends } from "../../stores/trends.svelte.js";
   import { getBasePath } from "../../stores/router.svelte.js";
   import { sync } from "../../stores/sync.svelte.js";
+  import {
+    yokedDates,
+    panelDateState,
+    rangeToPanelDate,
+    type PanelDateState,
+  } from "../../stores/yokedDates.svelte.js";
+  import { rollingRange } from "../../utils/dates.js";
   import type { TrendsGranularity } from "../../api/types.js";
   import { ChartColumnIcon, ChevronDownIcon } from "../../icons.js";
   import RangePicker from "../shared/RangePicker.svelte";
@@ -28,8 +35,11 @@
     "var(--trend-indigo)",
     "var(--trend-black)",
   ] as const;
+  const TREND_WINDOW_PARAM = "window_days";
 
   let activeTerm: string | null = $state(null);
+  let trendsWindowDays: number | null = $state(null);
+  const trendsPanelDate = $derived(currentTrendsPanelDate());
 
   const GRANULARITIES: TrendsGranularity[] = ["day", "week", "month"];
   let groupByOpen = $state(false);
@@ -58,18 +68,37 @@
     return value === "day" || value === "week" || value === "month";
   }
 
-  function applyQueryParams() {
+  function parseTrendWindowDays(raw: string | null): number | null {
+    if (!raw) return null;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isInteger(n) || n <= 0 || String(n) !== raw) {
+      return null;
+    }
+    return n;
+  }
+
+  function applyQueryParams(): boolean {
     const q = new URLSearchParams(window.location.search);
     const from = q.get("from");
     const to = q.get("to");
+    const windowDays = parseTrendWindowDays(q.get(TREND_WINDOW_PARAM));
     const granularity = q.get("granularity");
     const normalized = q.get("normalized");
     const terms = q.getAll("term").map((s) => s.trim()).filter(Boolean);
-    if (from) trends.from = from;
-    if (to) trends.to = to;
+    if (windowDays !== null) {
+      const range = rollingRange(windowDays);
+      trends.from = range.from;
+      trends.to = range.to;
+      trendsWindowDays = windowDays;
+    } else {
+      if (from) trends.from = from;
+      if (to) trends.to = to;
+      trendsWindowDays = null;
+    }
     if (isGranularity(granularity)) trends.granularity = granularity;
     trends.normalized = normalized === "true";
     if (terms.length > 0) trends.termText = terms.join("\n");
+    return windowDays !== null || q.has("from") || q.has("to");
   }
 
   function writeUrl() {
@@ -80,6 +109,9 @@
     }
     q.set("from", trends.from);
     q.set("to", trends.to);
+    if (trendsWindowDays !== null) {
+      q.set(TREND_WINDOW_PARAM, String(trendsWindowDays));
+    }
     q.set("granularity", trends.granularity);
     if (trends.normalized) {
       q.set("normalized", "true");
@@ -100,15 +132,36 @@
 
   const earliestSession = $derived(sync.stats?.earliest_session ?? null);
 
-  const rangeSelection = $derived(
-    selectionFromRange(trends.from, trends.to, earliestSession),
-  );
+  const rangeSelection = $derived.by((): RangeSelection => {
+    if (trendsWindowDays !== null) {
+      return { mode: "relative", days: trendsWindowDays };
+    }
+    return selectionFromRange(trends.from, trends.to, earliestSession);
+  });
 
   async function applyRange(sel: RangeSelection) {
     const range = resolveRange(sel, earliestSession);
     trends.from = range.from;
     trends.to = range.to;
+    const yokeState = yokeStateForSelection(sel, range);
+    trendsWindowDays = yokeState?.mode === "rolling"
+      ? yokeState.windowDays ?? null
+      : null;
+    updateYokeFromTrends(yokeState);
     await refresh();
+  }
+
+  function yokeStateForSelection(
+    sel: RangeSelection,
+    range: { from: string; to: string },
+  ): PanelDateState | null {
+    if (sel.mode === "relative" && sel.days > 0) {
+      return panelDateState(range.from, range.to, {
+        mode: "rolling",
+        windowDays: sel.days,
+      });
+    }
+    return panelDateState(range.from, range.to, { mode: "fixed" });
   }
 
   function setNormalized(event: Event) {
@@ -126,8 +179,40 @@
     await refresh();
   }
 
+  function currentTrendsPanelDate(): PanelDateState | null {
+    if (trendsWindowDays !== null) {
+      return panelDateState(trends.from, trends.to, {
+        mode: "rolling",
+        windowDays: trendsWindowDays,
+      });
+    }
+    return panelDateState(trends.from, trends.to, { mode: "fixed" });
+  }
+
+  function updateYokeFromTrends(
+    state: PanelDateState | null = trendsPanelDate,
+  ): void {
+    if (state) yokedDates.updateFromPanel(state);
+  }
+
+  function seedTrendsYoke(): void {
+    const seed = yokedDates.seedForPanel();
+    const state = seed ? rangeToPanelDate(seed) : null;
+    if (!state) return;
+    trends.from = state.from;
+    trends.to = state.to;
+    trendsWindowDays = state.mode === "rolling"
+      ? state.windowDays ?? null
+      : null;
+  }
+
   onMount(() => {
-    applyQueryParams();
+    const hasDateParams = applyQueryParams();
+    if (hasDateParams) {
+      updateYokeFromTrends();
+    } else {
+      seedTrendsYoke();
+    }
     writeUrl();
     trends.fetchTerms();
     document.addEventListener("click", onGroupByDocClick);

--- a/frontend/src/lib/components/trends/TrendsPage.svelte
+++ b/frontend/src/lib/components/trends/TrendsPage.svelte
@@ -125,7 +125,20 @@
     window.history.replaceState(null, "", url);
   }
 
+  function materializeRollingWindow(): void {
+    if (trendsWindowDays === null) return;
+    const range = rollingRange(trendsWindowDays);
+    if (trends.from === range.from && trends.to === range.to) return;
+    trends.from = range.from;
+    trends.to = range.to;
+    updateYokeFromTrends(panelDateState(range.from, range.to, {
+      mode: "rolling",
+      windowDays: trendsWindowDays,
+    }));
+  }
+
   async function refresh() {
+    materializeRollingWindow();
     writeUrl();
     await trends.fetchTerms();
   }

--- a/frontend/src/lib/components/trends/TrendsPage.test.ts
+++ b/frontend/src/lib/components/trends/TrendsPage.test.ts
@@ -194,6 +194,42 @@ describe("TrendsPage", () => {
     expect(window.location.search).toContain("window_days=30");
   });
 
+  it("recomputes rolling windows before manual refresh", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-19T12:00:00"));
+    window.history.replaceState(
+      null,
+      "",
+      "/trends?window_days=30&from=2026-01-01&to=2026-01-31",
+    );
+
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    vi.setSystemTime(new Date("2026-06-20T12:00:00"));
+    const refresh = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((b) => b.textContent?.trim() === "Refresh");
+    expect(refresh).not.toBeNull();
+    refresh!.click();
+    await flushPromises();
+
+    expect(mocks.getApiV1TrendsTerms).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        from: "2026-05-21",
+        to: "2026-06-20",
+      }),
+    );
+    expect(window.location.search).toContain("from=2026-05-21");
+    expect(window.location.search).toContain("to=2026-06-20");
+    expect(yokedDates.range).toMatchObject({
+      from: "2026-05-21",
+      to: "2026-06-20",
+      mode: "rolling",
+      windowDays: 30,
+    });
+  });
+
   it("updates shared yoke state from range selections", () => {
     expect(source).toContain("<RangePicker");
     expect(source).toContain("updateYokeFromTrends");

--- a/frontend/src/lib/components/trends/TrendsPage.test.ts
+++ b/frontend/src/lib/components/trends/TrendsPage.test.ts
@@ -9,7 +9,9 @@ import {
 } from "vite-plus/test";
 import { mount, tick, unmount } from "svelte";
 import { trends } from "../../stores/trends.svelte.js";
+import { yokedDates } from "../../stores/yokedDates.svelte.js";
 import type { TrendsTermsResponse } from "../../api/types.js";
+import source from "./TrendsPage.svelte?raw";
 
 const mocks = vi.hoisted(() => ({
   getApiV1TrendsTerms: vi.fn(),
@@ -70,6 +72,8 @@ describe("TrendsPage", () => {
     trends.response = null;
     trends.loading.terms = false;
     trends.errors.terms = null;
+    yokedDates.range = null;
+    localStorage.clear();
     window.history.replaceState(null, "", "/trends");
   });
 
@@ -80,6 +84,7 @@ describe("TrendsPage", () => {
     }
     document.body.innerHTML = "";
     window.history.replaceState(null, "", "/");
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -142,6 +147,57 @@ describe("TrendsPage", () => {
     await flushPromises();
 
     expect(document.body.textContent).toContain("one per line");
+  });
+
+  it("seeds bare trends URLs from the saved yoke range", async () => {
+    yokedDates.updateFromPanel({
+      from: "2024-02-01",
+      to: "2024-02-07",
+      mode: "fixed",
+    });
+
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    expect(mocks.getApiV1TrendsTerms).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        from: "2024-02-01",
+        to: "2024-02-07",
+      }),
+    );
+    expect(window.location.search).toContain("from=2024-02-01");
+    expect(window.location.search).toContain("to=2024-02-07");
+  });
+
+  it("hydrates rolling window URLs before fixed date params", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-19T12:00:00"));
+    window.history.replaceState(
+      null,
+      "",
+      "/trends?window_days=30&from=2026-01-01&to=2026-01-31",
+    );
+
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    expect(mocks.getApiV1TrendsTerms).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        from: "2026-05-20",
+        to: "2026-06-19",
+      }),
+    );
+    expect(yokedDates.range).toMatchObject({
+      mode: "rolling",
+      windowDays: 30,
+    });
+    expect(window.location.search).toContain("window_days=30");
+  });
+
+  it("updates shared yoke state from range selections", () => {
+    expect(source).toContain("<RangePicker");
+    expect(source).toContain("updateYokeFromTrends");
+    expect(source).toContain("rangeToPanelDate(seed)");
   });
 
   it("shows chart loading status while trends are computing", async () => {
@@ -293,5 +349,27 @@ describe("TrendsPage", () => {
       "background: var(--trend-slate);",
       "background: var(--trend-red);",
     ]);
+  });
+});
+
+describe("TrendsPage date yoke controls", () => {
+  it("preserves relative range selections as rolling yoke state", () => {
+    const applyIndex = source.indexOf("async function applyRange");
+    const helperIndex = source.indexOf("function yokeStateForSelection");
+    const applyBlock = source.slice(applyIndex, helperIndex);
+
+    expect(helperIndex).toBeGreaterThan(applyIndex);
+    expect(source).toContain('mode: "rolling"');
+    expect(source).toContain("windowDays: sel.days");
+    expect(applyBlock).toContain("yokeStateForSelection(sel, range)");
+    expect(applyBlock).toContain("updateYokeFromTrends(yokeState)");
+  });
+
+  it("preserves rolling window intent in trends URLs", () => {
+    expect(source).toContain('const TREND_WINDOW_PARAM = "window_days"');
+    expect(source).toContain("parseTrendWindowDays");
+    expect(source).toContain("rollingRange(windowDays)");
+    expect(source).toContain("q.set(TREND_WINDOW_PARAM");
+    expect(source).toContain("trendsWindowDays !== null");
   });
 });

--- a/frontend/src/lib/components/trends/TrendsPage.test.ts
+++ b/frontend/src/lib/components/trends/TrendsPage.test.ts
@@ -230,6 +230,36 @@ describe("TrendsPage", () => {
     });
   });
 
+  it("recomputes rolling windows before reset", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-06-19T12:00:00"));
+    window.history.replaceState(
+      null,
+      "",
+      "/trends?window_days=30&from=2026-01-01&to=2026-01-31",
+    );
+
+    component = mount(TrendsPage, { target: document.body });
+    await flushPromises();
+
+    vi.setSystemTime(new Date("2026-06-20T12:00:00"));
+    const reset = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((b) => b.textContent?.trim() === "Reset");
+    expect(reset).not.toBeNull();
+    reset!.click();
+    await flushPromises();
+
+    expect(mocks.getApiV1TrendsTerms).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        from: "2026-05-21",
+        to: "2026-06-20",
+      }),
+    );
+    expect(window.location.search).toContain("from=2026-05-21");
+    expect(window.location.search).toContain("to=2026-06-20");
+  });
+
   it("updates shared yoke state from range selections", () => {
     expect(source).toContain("<RangePicker");
     expect(source).toContain("updateYokeFromTrends");

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -30,6 +30,11 @@
   import SessionActiveFilters from "../filters/SessionActiveFilters.svelte";
   import FilterDropdown from "./FilterDropdown.svelte";
   import RefreshControl from "../shared/RefreshControl.svelte";
+  import {
+    yokedDates,
+    panelDateState,
+    type PanelDateState,
+  } from "../../stores/yokedDates.svelte.js";
 
   let mounted = false;
   let unsubEvents: (() => void) | undefined;
@@ -56,9 +61,16 @@
   function applyRange(sel: RangeSelection) {
     if (sel.mode === "relative" && sel.days > 0) {
       usage.setRollingWindow(sel.days);
+      updateYokeFromUsage(panelDateState(usage.from, usage.to, {
+        mode: "rolling",
+        windowDays: sel.days,
+      }));
     } else {
       const range = resolveRange(sel, earliestSession);
       usage.setDateRange(range.from, range.to);
+      updateYokeFromUsage(panelDateState(range.from, range.to, {
+        mode: "fixed",
+      }));
     }
   }
 
@@ -114,6 +126,30 @@
   const sessionFilterSignature = $derived(
     JSON.stringify(sessionUrlParams),
   );
+  function applyUsagePanelDate(state: PanelDateState): boolean {
+    const before = JSON.stringify({
+      from: usage.from,
+      to: usage.to,
+      isPinned: usage.isPinned,
+      windowDays: usage.windowDays,
+    });
+    if (state.mode === "rolling" && state.windowDays) {
+      usage.applyRollingWindow(state.windowDays);
+    } else {
+      usage.applyDateRange(state.from, state.to);
+    }
+    const after = JSON.stringify({
+      from: usage.from,
+      to: usage.to,
+      isPinned: usage.isPinned,
+      windowDays: usage.windowDays,
+    });
+    return before !== after;
+  }
+
+  function updateYokeFromUsage(state: PanelDateState | null): void {
+    if (state) yokedDates.updateFromPanel(state);
+  }
 
   // URL-init: seed store filters from URL params when landing
   // on /usage with a deep-link. A bare /usage preserves the
@@ -126,11 +162,22 @@
   const SESSION_FILTER_KEYS = new Set([
     "project", "machine", "agent",
     "termination",
-    "date", "date_from", "date_to",
     "active_since", "exclude_project",
     "min_messages", "max_messages", "min_user_messages",
     "include_one_shot", "include_automated",
   ]);
+  function usageSupportedSessionParams(
+    params: Record<string, string>,
+  ): Record<string, string> {
+    const supported: Record<string, string> = {};
+    for (const [key, value] of Object.entries(params)) {
+      if (SESSION_FILTER_KEYS.has(key)) {
+        supported[key] = value;
+      }
+    }
+    return supported;
+  }
+
   let urlInitRan = $state(false);
   let urlWritebackReady = $state(false);
   let initialFetchDone = $state(false);
@@ -141,14 +188,15 @@
       if (route !== "usage") return;
       const hasDateParam = !!params["from"] || !!params["to"];
       const parsedWindowDays = parseWindowDays(params["window_days"]);
-      const hasFilterKeys = Object.keys(params).some(
-        (k) =>
-          USAGE_FILTER_KEYS.has(k) ||
-          SESSION_FILTER_KEYS.has(k),
+      const supportedSessionParams =
+        usageSupportedSessionParams(params);
+      const hasSessionFilterKeys =
+        Object.keys(supportedSessionParams).length > 0;
+      const hasUsageFilterKeys = Object.keys(params).some(
+        (k) => USAGE_FILTER_KEYS.has(k),
       );
-      const hasSessionFilterKeys = Object.keys(params).some(
-        (k) => SESSION_FILTER_KEYS.has(k),
-      );
+      const hasFilterKeys =
+        hasUsageFilterKeys || hasSessionFilterKeys;
 
       let changed = false;
       let sessionChanged = false;
@@ -161,13 +209,40 @@
         changed = true;
       }
 
+      if (!hasDateParam && parsedWindowDays === null) {
+        const seed = yokedDates.seedForPanel();
+        const state = seed
+          ? panelDateState(seed.from, seed.to, {
+              mode: seed.mode,
+              windowDays: seed.windowDays,
+            })
+          : null;
+        if (state) {
+          changed = applyUsagePanelDate(state) || changed;
+        }
+      }
+
       // Apply rolling window from URL when present and the URL is
       // not pinning a specific date range.
       if (!hasDateParam && parsedWindowDays !== null) {
-        if (usage.windowDays !== parsedWindowDays) {
-          usage.windowDays = parsedWindowDays;
-          changed = true;
-        }
+        const stateBefore = JSON.stringify({
+          from: usage.from,
+          to: usage.to,
+          isPinned: usage.isPinned,
+          windowDays: usage.windowDays,
+        });
+        usage.applyRollingWindow(parsedWindowDays);
+        const stateAfter = JSON.stringify({
+          from: usage.from,
+          to: usage.to,
+          isPinned: usage.isPinned,
+          windowDays: usage.windowDays,
+        });
+        changed = stateBefore !== stateAfter || changed;
+        updateYokeFromUsage(panelDateState(usage.from, usage.to, {
+          mode: "rolling",
+          windowDays: parsedWindowDays,
+        }));
       }
 
       if (!hasFilterKeys) {
@@ -179,7 +254,7 @@
       }
       if (hasSessionFilterKeys) {
         const nextSessionParams = filtersToParams(
-          parseFiltersFromParams(params),
+          parseFiltersFromParams(supportedSessionParams),
         );
         const currentSessionParams = filtersToParams(
           sessions.filters,
@@ -188,17 +263,20 @@
           JSON.stringify(nextSessionParams) !==
           JSON.stringify(currentSessionParams)
         ) {
-          sessions.initFromParams(params);
+          sessions.initFromParams(supportedSessionParams);
           sessionChanged = true;
         }
       }
-      if (params["from"] && params["from"] !== usage.from) {
-        usage.from = params["from"];
-        changed = true;
-      }
-      if (params["to"] && params["to"] !== usage.to) {
-        usage.to = params["to"];
-        changed = true;
+      if (hasDateParam) {
+        const state = panelDateState(
+          params["from"] ?? usage.from,
+          params["to"] ?? usage.to,
+          { mode: "fixed" },
+        );
+        if (state) {
+          changed = applyUsagePanelDate(state) || changed;
+          updateYokeFromUsage(state);
+        }
       }
       const newExProject = splitExcludeProjectParam(
         params["exclude_project"],

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -44,4 +44,52 @@ describe("UsagePage refresh behavior", () => {
     expect(queryProgress).not.toContain("position: sticky");
     expect(queryProgress).not.toContain("margin:");
   });
+
+  it("updates shared yoke state from usage range selections", () => {
+    expect(source).toContain("<RangePicker");
+    expect(source).toContain("function applyRange");
+    expect(source).toContain("updateYokeFromUsage");
+    expect(source).toContain("yokedDates.updateFromPanel");
+  });
+
+  it("seeds bare usage URLs from shared yoked dates", () => {
+    expect(source).toContain("const seed = yokedDates.seedForPanel()");
+    expect(source).toContain("applyUsagePanelDate(state)");
+    expect(source).toContain("usage.applyRollingWindow");
+    expect(source).toContain("usage.applyDateRange");
+  });
+
+  it("hydrates supported termination filters from usage URLs", () => {
+    const filterKeysIndex = source.indexOf("const SESSION_FILTER_KEYS");
+    const urlInitIndex = source.indexOf("let urlInitRan", filterKeysIndex);
+    const filterKeysBlock = source.slice(filterKeysIndex, urlInitIndex);
+
+    expect(filterKeysBlock).toContain('"termination"');
+  });
+
+  it("does not hydrate session-only date filters from usage URLs", () => {
+    const filterKeysIndex = source.indexOf("const SESSION_FILTER_KEYS");
+    const urlInitIndex = source.indexOf("let urlInitRan", filterKeysIndex);
+    const filterKeysBlock = source.slice(filterKeysIndex, urlInitIndex);
+
+    expect(filterKeysBlock).not.toContain('"date"');
+    expect(filterKeysBlock).not.toContain('"date_from"');
+    expect(filterKeysBlock).not.toContain('"date_to"');
+  });
+
+  it("sanitizes mixed usage URL session params before hydrating", () => {
+    const initStart = source.indexOf("if (hasSessionFilterKeys)");
+    const initEnd = source.indexOf("if (hasDateParam)", initStart);
+    const initBlock = source.slice(initStart, initEnd);
+
+    expect(source).toContain("function usageSupportedSessionParams");
+    expect(initBlock).toContain(
+      "parseFiltersFromParams(supportedSessionParams)",
+    );
+    expect(initBlock).toContain(
+      "sessions.initFromParams(supportedSessionParams)",
+    );
+    expect(initBlock).not.toContain("parseFiltersFromParams(params)");
+    expect(initBlock).not.toContain("sessions.initFromParams(params)");
+  });
 });

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -4,6 +4,9 @@ import { ActivityService, MetadataService } from "../api/generated/index";
 import { configureGeneratedClient } from "../api/runtime.js";
 import { sync } from "./sync.svelte.js";
 import { router } from "./router.svelte.js";
+import { localDateStr, rollingRange } from "../utils/dates.js";
+
+export { localDateStr };
 
 type Preset = "day" | "week" | "month" | "custom";
 
@@ -22,11 +25,13 @@ const AUTOMATIONS: ReadonlySet<string> = new Set<Automation>([
   "automated",
 ]);
 
-export function localDateStr(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
+function parseWindowDays(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n <= 0 || String(n) !== raw) {
+    return null;
+  }
+  return n;
 }
 
 /**
@@ -45,6 +50,7 @@ class ActivityStore {
   date: string = $state(localDateStr(new Date()));
   from = $state("");
   to = $state("");
+  rollingWindowDays: number | null = $state(null);
   bucket = $state("");
   project: string = $state("");
   agent: string = $state("");
@@ -267,12 +273,23 @@ class ActivityStore {
    * This is the single hydration path, run on mount and on popstate.
    */
   hydrateFromUrl(params: Record<string, string>) {
-    this.preset = PRESETS.has(params.preset ?? "")
-      ? (params.preset as Preset)
-      : "day";
-    this.date = params.date || localDateStr(new Date());
-    this.from = params.from ?? "";
-    this.to = params.to ?? "";
+    const windowDays = parseWindowDays(params.window_days);
+    if (windowDays !== null) {
+      const range = rollingRange(windowDays);
+      this.preset = "custom";
+      this.date = range.to;
+      this.from = range.from;
+      this.to = range.to;
+      this.rollingWindowDays = windowDays;
+    } else {
+      this.preset = PRESETS.has(params.preset ?? "")
+        ? (params.preset as Preset)
+        : "day";
+      this.date = params.date || localDateStr(new Date());
+      this.from = params.from ?? "";
+      this.to = params.to ?? "";
+      this.rollingWindowDays = null;
+    }
     this.bucket = params.bucket ?? "";
     this.project = params.project ?? "";
     this.agent = params.agent ?? "";
@@ -295,6 +312,9 @@ class ActivityStore {
     if (this.preset === "custom") {
       if (this.from) p.from = this.from;
       if (this.to) p.to = this.to;
+      if (this.rollingWindowDays !== null) {
+        p.window_days = String(this.rollingWindowDays);
+      }
     } else {
       if (this.date) p.date = this.date;
     }
@@ -308,6 +328,9 @@ class ActivityStore {
 
   setPreset(p: Preset) {
     this.preset = p;
+    if (p !== "custom") {
+      this.rollingWindowDays = null;
+    }
     if (p === "custom") {
       // Seed a 1-day range from the current anchor so selecting Custom shows a
       // valid range immediately instead of erroring on empty from/to bounds.
@@ -319,16 +342,34 @@ class ActivityStore {
 
   setDate(date: string) {
     this.date = date;
+    if (this.preset !== "custom") {
+      this.rollingWindowDays = null;
+    }
     this.writeUrl();
   }
 
   setFrom(d: string) {
     this.from = d;
+    this.rollingWindowDays = null;
     this.writeUrl();
   }
 
   setTo(d: string) {
     this.to = d;
+    this.rollingWindowDays = null;
+    this.writeUrl();
+  }
+
+  setCustomRange(
+    from: string,
+    to: string,
+    rollingWindowDays: number | null = null,
+  ) {
+    this.preset = "custom";
+    this.date = from;
+    this.from = from;
+    this.to = to;
+    this.rollingWindowDays = rollingWindowDays;
     this.writeUrl();
   }
 

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -101,8 +101,24 @@ class ActivityStore {
     this.hasNewData = true;
   }
 
+  private materializeRollingWindow(): boolean {
+    if (this.preset !== "custom" || this.rollingWindowDays === null) {
+      return false;
+    }
+    const range = rollingRange(this.rollingWindowDays);
+    if (this.from === range.from && this.to === range.to) {
+      return false;
+    }
+    this.from = range.from;
+    this.to = range.to;
+    return true;
+  }
+
   async load({ background = false }: { background?: boolean } = {}) {
     const v = ++this.loadVersion;
+    if (this.materializeRollingWindow()) {
+      this.writeUrl();
+    }
     // A custom range needs both bounds. With only one present (a cleared date
     // input or a partial deep link) the backend rejects the request, so hold
     // the current view until both are set instead of flashing an error.

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -425,6 +425,26 @@ describe("url state", () => {
     expect(activity.agent).toBe("claude");
   });
 
+  it("hydrates rolling URL state from window_days before fixed dates", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date("2026-06-19T12:00:00"));
+      activity.hydrateFromUrl({
+        preset: "custom",
+        from: "2026-01-01",
+        to: "2026-01-31",
+        window_days: "30",
+      });
+
+      expect(activity.preset).toBe("custom");
+      expect(activity.from).toBe("2026-05-20");
+      expect(activity.to).toBe("2026-06-19");
+      expect(activity.rollingWindowDays).toBe(30);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("defaults preset to day and date to today when absent", () => {
     activity.hydrateFromUrl({});
     expect(activity.preset).toBe("day");
@@ -474,6 +494,27 @@ describe("url state", () => {
     expect(last.preset).toBe("week");
     expect(last.date).toBe("2026-06-16");
     expect("project" in last).toBe(false);
+  });
+
+  it("writes and clears rolling window URL intent for custom ranges", () => {
+    const spy = routerMod.router.replaceParams as ReturnType<typeof vi.fn>;
+    activity.setCustomRange("2026-05-20", "2026-06-19", 30);
+    spy.mockClear();
+
+    activity.writeUrl();
+    const rolling = spy.mock.calls.at(-1)![0] as Record<string, string>;
+    expect(rolling).toEqual({
+      preset: "custom",
+      from: "2026-05-20",
+      to: "2026-06-19",
+      window_days: "30",
+    });
+
+    spy.mockClear();
+    activity.setFrom("2026-05-21");
+    const fixed = spy.mock.calls.at(-1)![0] as Record<string, string>;
+    expect(fixed.from).toBe("2026-05-21");
+    expect("window_days" in fixed).toBe(false);
   });
 
   it("hydrates the automation class from params", () => {

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -201,6 +201,39 @@ describe("load", () => {
     expect(activity.lastUpdatedAt).toBe(stampedAt);
   });
 
+  it("recomputes rolling custom ranges before refreshing", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date("2026-06-19T12:00:00"));
+      activity.setCustomRange("2026-05-20", "2026-06-19", 30);
+      const replaceParams =
+        routerMod.router.replaceParams as ReturnType<typeof vi.fn>;
+      replaceParams.mockClear();
+      api.getActivityReport.mockResolvedValue(makeReport());
+
+      vi.setSystemTime(new Date("2026-06-20T12:00:00"));
+      await activity.load({ background: true });
+
+      const arg = api.getActivityReport.mock.calls.at(-1)![0];
+      expect(arg.from).toBe(
+        new Date("2026-05-21T00:00:00").toISOString(),
+      );
+      expect(arg.to).toBe(
+        new Date("2026-06-21T00:00:00").toISOString(),
+      );
+      expect(activity.from).toBe("2026-05-21");
+      expect(activity.to).toBe("2026-06-20");
+      expect(replaceParams.mock.calls.at(-1)?.[0]).toMatchObject({
+        preset: "custom",
+        from: "2026-05-21",
+        to: "2026-06-20",
+        window_days: "30",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("surfaces the error when a background refresh fails before any report", async () => {
     // No successful load yet, so report is null and there is nothing to keep.
     api.getActivityReport.mockRejectedValueOnce(new Error("first load down"));

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -19,6 +19,7 @@ import {
 } from "../api/runtime.js";
 import { sessions } from "./sessions.svelte.js";
 import { perf, type PerfEntryStatus } from "./perf.svelte.js";
+import { daysAgo, today } from "../utils/dates.js";
 
 type AnalyticsParams = Parameters<
   typeof AnalyticsService.getApiV1AnalyticsSummary
@@ -35,23 +36,6 @@ type TopSessionsParams = Parameters<
 export type Granularity = NonNullable<ActivityParams["granularity"]>;
 export type HeatmapMetric = NonNullable<HeatmapParams["metric"]>;
 export type TopSessionsMetric = NonNullable<TopSessionsParams["metric"]>;
-
-function localDateStr(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return localDateStr(d);
-}
-
-function today(): string {
-  return localDateStr(new Date());
-}
 
 type Panel =
   | "summary"
@@ -736,23 +720,31 @@ class AnalyticsStore {
     this.fetchTopSessions();
   }
 
-  setDateRange(from: string, to: string) {
+  applyDateRange(from: string, to: string) {
     this.isPinned = true;
     this.from = from;
     this.to = to;
     this.selectedDate = null;
     this.selectedDow = null;
     this.selectedHour = null;
-    this.fetchAll();
   }
 
-  setRollingWindow(days: number) {
+  applyRollingWindow(days: number) {
     this.windowDays = days;
     this.isPinned = false;
     this.selectedDate = null;
     this.selectedDow = null;
     this.selectedHour = null;
     this.rollDates();
+  }
+
+  setDateRange(from: string, to: string) {
+    this.applyDateRange(from, to);
+    this.fetchAll();
+  }
+
+  setRollingWindow(days: number) {
+    this.applyRollingWindow(days);
     this.fetchAll();
   }
 

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -709,6 +709,7 @@ class AnalyticsStore {
   }
 
   async fetchSignalsForInsights() {
+    this.rollDates();
     this.selectedDate = null;
     this.selectedDow = null;
     this.selectedHour = null;

--- a/frontend/src/lib/stores/analytics.test.ts
+++ b/frontend/src/lib/stores/analytics.test.ts
@@ -911,6 +911,7 @@ describe("AnalyticsStore rolling default date range", () => {
     const { analytics } = await loadAnalyticsStore();
     analytics.from = "2026-04-01";
     analytics.to = "2026-04-30";
+    analytics.isPinned = true;
     analytics.selectedDate = "2026-04-12";
     analytics.selectedDow = 2;
     analytics.selectedHour = 16;
@@ -930,6 +931,24 @@ describe("AnalyticsStore rolling default date range", () => {
       expect.not.objectContaining({
         dow: expect.anything(),
         hour: expect.anything(),
+      }),
+    );
+  });
+
+  it("fetchSignalsForInsights re-derives rolling dates before fetching", async () => {
+    const { analytics } = await loadAnalyticsStore();
+    analytics.setRollingWindow(7);
+    vi.clearAllMocks();
+
+    vi.setSystemTime(new Date("2026-04-26T12:00:00"));
+    await analytics.fetchSignalsForInsights();
+
+    expect(analytics.from).toBe("2026-04-19");
+    expect(analytics.to).toBe("2026-04-26");
+    expect(analyticsService.getApiV1AnalyticsSignals).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        from: "2026-04-19",
+        to: "2026-04-26",
       }),
     );
   });

--- a/frontend/src/lib/stores/insights.svelte.ts
+++ b/frontend/src/lib/stores/insights.svelte.ts
@@ -17,13 +17,7 @@ import {
   type GenerateInsightHandle,
   type InsightLogEvent,
 } from "../api/client.js";
-
-function localDateStr(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
+import { localDateStr } from "../utils/dates.js";
 
 export interface InsightTask {
   clientId: string;

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -67,6 +67,23 @@ export function parsePath(): {
 
 /** Params that are not part of routing but must survive navigations. */
 const STICKY_PARAMS = new Set(["desktop"]);
+const SESSION_ROUTE_PARAMS = new Set([
+  "project",
+  "machine",
+  "agent",
+  "termination",
+  "date",
+  "date_from",
+  "date_to",
+  "active_since",
+  "exclude_project",
+  "min_messages",
+  "max_messages",
+  "min_user_messages",
+  "include_one_shot",
+  "include_automated",
+  "window_days",
+]);
 
 export class RouterStore {
   route: Route = $state("sessions");
@@ -136,14 +153,39 @@ export class RouterStore {
     return qs ? `${full}?${qs}` : full;
   }
 
+  #sessionRouteParams(): Record<string, string> {
+    if (this.route !== "sessions") return {};
+    const params: Record<string, string> = {};
+    for (const [key, value] of Object.entries(this.params)) {
+      if (SESSION_ROUTE_PARAMS.has(key)) {
+        params[key] = value;
+      }
+    }
+    return params;
+  }
+
+  #sessionEntryParams(
+    params: Record<string, string> | undefined,
+    clearParams: Iterable<string> = [],
+  ): Record<string, string> {
+    const current = this.#sessionRouteParams();
+    for (const key of clearParams) {
+      delete current[key];
+    }
+    return {
+      ...current,
+      ...(params ?? {}),
+    };
+  }
+
   /** Build an href for a session link (includes sticky params). */
   buildSessionHref(
     id: string,
-    params: Record<string, string> = {},
+    params?: Record<string, string>,
   ): string {
     return this.#buildUrl(
       `/sessions/${encodeURIComponent(id)}`,
-      params,
+      this.#sessionEntryParams(params),
     );
   }
 
@@ -166,17 +208,29 @@ export class RouterStore {
     return true;
   }
 
+  navigateToSessions(
+    params: Record<string, string> = {},
+    clearParams: Iterable<string> = [],
+  ): boolean {
+    return this.navigate(
+      "sessions",
+      this.#sessionEntryParams(params, clearParams),
+    );
+  }
+
   navigateToSession(
     id: string,
-    params: Record<string, string> = {},
+    params?: Record<string, string>,
+    clearParams: Iterable<string> = [],
   ) {
+    const nextParams = this.#sessionEntryParams(params, clearParams);
     const url = this.#buildUrl(
       `/sessions/${encodeURIComponent(id)}`,
-      params,
+      nextParams,
     );
-    this.#updateSticky(params);
+    this.#updateSticky(nextParams);
     this.route = "sessions";
-    this.params = { ...this.#stickyParams, ...params };
+    this.params = { ...this.#stickyParams, ...nextParams };
     this.sessionId = id;
     window.history.pushState(null, "", url);
   }

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -212,6 +212,78 @@ describe("RouterStore", () => {
     expect(window.location.search).toBe("?msg=last");
   });
 
+  it("navigateToSession preserves session route params from the sessions view", () => {
+    setURL(
+      "/sessions?window_days=14&project=myproj&termination=unclean&msg=stale",
+    );
+    store = new RouterStore();
+    store.navigateToSession("abc-123");
+
+    expect(window.location.pathname).toBe(
+      "/sessions/abc-123",
+    );
+    expect(window.location.search).toContain("window_days=14");
+    expect(window.location.search).toContain("project=myproj");
+    expect(window.location.search).toContain("termination=unclean");
+    expect(window.location.search).not.toContain("msg=stale");
+  });
+
+  it("navigateToSession can clear stale preserved route params", () => {
+    setURL(
+      "/sessions?window_days=14&project=myproj&include_one_shot=false",
+    );
+    store = new RouterStore();
+    store.navigateToSession("abc-123", undefined, ["include_one_shot"]);
+
+    expect(window.location.pathname).toBe(
+      "/sessions/abc-123",
+    );
+    expect(window.location.search).toContain("window_days=14");
+    expect(window.location.search).toContain("project=myproj");
+    expect(window.location.search).not.toContain("include_one_shot=false");
+  });
+
+  it("navigateToSessions preserves session route params for drilldowns", () => {
+    setURL(
+      "/sessions?date_from=2026-01-01&date_to=2026-01-31&project=myproj",
+    );
+    store = new RouterStore();
+    store.navigateToSessions({ agent: "codex" });
+
+    expect(window.location.pathname).toBe("/sessions");
+    expect(window.location.search).toContain("date_from=2026-01-01");
+    expect(window.location.search).toContain("date_to=2026-01-31");
+    expect(window.location.search).toContain("project=myproj");
+    expect(window.location.search).toContain("agent=codex");
+  });
+
+  it("navigateToSessions can clear preserved route params for drilldowns", () => {
+    setURL(
+      "/sessions?date_from=2026-01-01&date_to=2026-01-31&min_messages=10&max_messages=50",
+    );
+    store = new RouterStore();
+    store.navigateToSessions(
+      { min_messages: "100" },
+      ["min_messages", "max_messages"],
+    );
+
+    expect(window.location.search).toContain("date_from=2026-01-01");
+    expect(window.location.search).toContain("date_to=2026-01-31");
+    expect(window.location.search).toContain("min_messages=100");
+    expect(window.location.search).not.toContain("max_messages=50");
+  });
+
+  it("navigateToSession does not preserve params from non-session routes", () => {
+    setURL("/usage?from=2026-01-01&to=2026-01-07");
+    store = new RouterStore();
+    store.navigateToSession("abc-123");
+
+    expect(window.location.pathname).toBe(
+      "/sessions/abc-123",
+    );
+    expect(window.location.search).toBe("");
+  });
+
   it("navigateFromSession returns to /sessions", () => {
     setURL("/sessions/abc-123");
     store = new RouterStore();
@@ -368,5 +440,19 @@ describe("RouterStore", () => {
     store = new RouterStore();
     const href = store.buildSessionHref("abc-123");
     expect(href).toBe("/sessions/abc-123");
+  });
+
+  it("buildSessionHref preserves session route params from the sessions view", () => {
+    setURL(
+      "/sessions?window_days=14&project=myproj&termination=unclean&msg=stale",
+    );
+    store = new RouterStore();
+    const href = store.buildSessionHref("abc-123");
+
+    expect(href).toContain("/sessions/abc-123?");
+    expect(href).toContain("window_days=14");
+    expect(href).toContain("project=myproj");
+    expect(href).toContain("termination=unclean");
+    expect(href).not.toContain("msg=stale");
   });
 });

--- a/frontend/src/lib/stores/sessionRouteParams.test.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   SESSION_FILTER_KEYS,
+  sessionDateIntentCleared,
   sessionRouteParamsForDetailExit,
   sessionRouteParamsForFilters,
 } from "./sessionRouteParams.js";
@@ -100,6 +101,25 @@ describe("session route params", () => {
     );
 
     expect(params).toEqual({ project: "agentsview" });
+  });
+
+  it("detects removed session date intent", () => {
+    expect(sessionDateIntentCleared(
+      {
+        date_from: "2026-05-21",
+        date_to: "2026-06-20",
+        window_days: "30",
+      },
+      { project: "agentsview" },
+    )).toBe(true);
+    expect(sessionDateIntentCleared(
+      { window_days: "30" },
+      { window_days: "30", project: "agentsview" },
+    )).toBe(false);
+    expect(sessionDateIntentCleared(
+      { project: "agentsview" },
+      { project: "agentsview" },
+    )).toBe(false);
   });
 
   it("prefers direct detail URL params over saved filters on exit", () => {

--- a/frontend/src/lib/stores/sessionRouteParams.test.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  SESSION_FILTER_KEYS,
+  sessionRouteParamsForDetailExit,
+  sessionRouteParamsForFilters,
+} from "./sessionRouteParams.js";
+
+describe("session route params", () => {
+  it("preserves rolling intent when materialized date bounds still match", () => {
+    const params = sessionRouteParamsForFilters(
+      {
+        date_from: "2026-05-21",
+        date_to: "2026-06-20",
+        project: "agentsview",
+      },
+      {
+        date_from: "2026-05-21",
+        date_to: "2026-06-20",
+        window_days: "30",
+      },
+      new Date(2026, 5, 20, 12),
+    );
+
+    expect(params).toEqual({
+      date_from: "2026-05-21",
+      date_to: "2026-06-20",
+      project: "agentsview",
+      window_days: "30",
+    });
+  });
+
+  it("preserves direct rolling links during first materialized date writeback", () => {
+    const params = sessionRouteParamsForFilters(
+      {
+        date_from: "2026-05-21",
+        date_to: "2026-06-20",
+      },
+      { window_days: "30" },
+      new Date(2026, 5, 20, 12),
+    );
+
+    expect(params).toEqual({
+      date_from: "2026-05-21",
+      date_to: "2026-06-20",
+      window_days: "30",
+    });
+  });
+
+  it("preserves stale materialized rolling links after date rollover", () => {
+    const params = sessionRouteParamsForFilters(
+      {
+        date_from: "2026-05-21",
+        date_to: "2026-06-20",
+      },
+      {
+        date_from: "2026-05-20",
+        date_to: "2026-06-19",
+        window_days: "30",
+      },
+      new Date(2026, 5, 20, 12),
+    );
+
+    expect(params).toEqual({
+      date_from: "2026-05-21",
+      date_to: "2026-06-20",
+      window_days: "30",
+    });
+  });
+
+  it("does not preserve rolling intent for unrelated fixed dates", () => {
+    const params = sessionRouteParamsForFilters(
+      {
+        date_from: "2026-01-01",
+        date_to: "2026-01-31",
+      },
+      {
+        date_from: "2026-05-20",
+        date_to: "2026-06-19",
+        window_days: "30",
+      },
+      new Date(2026, 5, 20, 12),
+    );
+
+    expect(params).toEqual({
+      date_from: "2026-01-01",
+      date_to: "2026-01-31",
+    });
+  });
+
+  it("prefers direct detail URL params over saved filters on exit", () => {
+    const params = sessionRouteParamsForDetailExit(
+      { project: "saved", agent: "codex" },
+      { project: "direct", window_days: "14", msg: "stale" },
+    );
+
+    expect(params).toEqual({
+      project: "direct",
+      window_days: "14",
+    });
+  });
+
+  it("tracks rolling window and termination as session route params", () => {
+    expect(SESSION_FILTER_KEYS.has("window_days")).toBe(true);
+    expect(SESSION_FILTER_KEYS.has("termination")).toBe(true);
+  });
+});

--- a/frontend/src/lib/stores/sessionRouteParams.test.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   SESSION_FILTER_KEYS,
+  hasSessionRouteDateIntent,
   sessionDateIntentCleared,
   sessionRouteParamsForDetailExit,
   sessionRouteParamsForFilters,
@@ -120,6 +121,18 @@ describe("session route params", () => {
       { project: "agentsview" },
       { project: "agentsview" },
     )).toBe(false);
+  });
+
+  it("only treats window_days as session date intent on sessions routes", () => {
+    expect(hasSessionRouteDateIntent("sessions", {
+      window_days: "30",
+    })).toBe(true);
+    expect(hasSessionRouteDateIntent("usage", {
+      window_days: "30",
+    })).toBe(false);
+    expect(hasSessionRouteDateIntent("insights", {
+      window_days: "30",
+    })).toBe(false);
   });
 
   it("prefers direct detail URL params over saved filters on exit", () => {

--- a/frontend/src/lib/stores/sessionRouteParams.test.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.test.ts
@@ -87,6 +87,21 @@ describe("session route params", () => {
     });
   });
 
+  it("drops rolling intent when materialized date filters are cleared", () => {
+    const params = sessionRouteParamsForFilters(
+      { project: "agentsview" },
+      {
+        date_from: "2026-05-21",
+        date_to: "2026-06-20",
+        window_days: "30",
+        project: "agentsview",
+      },
+      new Date(2026, 5, 20, 12),
+    );
+
+    expect(params).toEqual({ project: "agentsview" });
+  });
+
   it("prefers direct detail URL params over saved filters on exit", () => {
     const params = sessionRouteParamsForDetailExit(
       { project: "saved", agent: "codex" },

--- a/frontend/src/lib/stores/sessionRouteParams.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.ts
@@ -38,6 +38,13 @@ export function hasSessionDateIntent(
     !!params[SESSION_ANALYTICS_WINDOW_PARAM];
 }
 
+export function hasSessionRouteDateIntent(
+  route: string,
+  params: Record<string, string>,
+): boolean {
+  return route === "sessions" && hasSessionDateIntent(params);
+}
+
 export function sessionDateIntentCleared(
   currentParams: Record<string, string>,
   nextParams: Record<string, string>,

--- a/frontend/src/lib/stores/sessionRouteParams.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.ts
@@ -68,9 +68,10 @@ function shouldPreserveSessionWindowDays(
 ): boolean {
   const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
   if (!isValidWindowDaysParam(windowDays)) return false;
+  const nextHasFixedDates = hasFixedSessionDateParams(nextParams);
+  const currentHasFixedDates = hasFixedSessionDateParams(currentParams);
   return (
-    !hasFixedSessionDateParams(nextParams) ||
-    !hasFixedSessionDateParams(currentParams) ||
+    (!nextHasFixedDates && !currentHasFixedDates) ||
     fixedSessionDateParamsMatchRollingWindow(nextParams, windowDays, now) ||
     fixedSessionDateParamsEqual(nextParams, currentParams)
   );

--- a/frontend/src/lib/stores/sessionRouteParams.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.ts
@@ -1,0 +1,122 @@
+import { rollingRange } from "../utils/dates.js";
+
+export const SESSION_ANALYTICS_WINDOW_PARAM = "window_days";
+
+/** True when URL params contain session filter keys (deep-link). */
+export const SESSION_FILTER_KEYS: ReadonlySet<string> = new Set([
+  "project",
+  "machine",
+  "agent",
+  "termination",
+  "date",
+  "date_from",
+  "date_to",
+  "active_since",
+  "exclude_project",
+  "min_messages",
+  "max_messages",
+  "min_user_messages",
+  "include_one_shot",
+  "include_automated",
+  SESSION_ANALYTICS_WINDOW_PARAM,
+]);
+
+export function hasFilterParams(params: Record<string, string>): boolean {
+  return Object.keys(params).some((k) => SESSION_FILTER_KEYS.has(k));
+}
+
+function hasFixedSessionDateParams(
+  params: Record<string, string>,
+): boolean {
+  return !!params["date"] || !!params["date_from"] || !!params["date_to"];
+}
+
+function isValidWindowDaysParam(raw: string | undefined): raw is string {
+  if (!raw) return false;
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) && n > 0 && String(n) === raw;
+}
+
+function fixedSessionDateParamsEqual(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  return (
+    (a["date"] ?? "") === (b["date"] ?? "") &&
+    (a["date_from"] ?? "") === (b["date_from"] ?? "") &&
+    (a["date_to"] ?? "") === (b["date_to"] ?? "")
+  );
+}
+
+function fixedSessionDateParamsMatchRollingWindow(
+  params: Record<string, string>,
+  windowDays: string,
+  now: Date,
+): boolean {
+  const range = rollingRange(Number.parseInt(windowDays, 10), now);
+  return (
+    !params["date"] &&
+    (params["date_from"] ?? "") === range.from &&
+    (params["date_to"] ?? "") === range.to
+  );
+}
+
+function shouldPreserveSessionWindowDays(
+  nextParams: Record<string, string>,
+  currentParams: Record<string, string>,
+  now: Date,
+): boolean {
+  const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
+  if (!isValidWindowDaysParam(windowDays)) return false;
+  return (
+    !hasFixedSessionDateParams(nextParams) ||
+    !hasFixedSessionDateParams(currentParams) ||
+    fixedSessionDateParamsMatchRollingWindow(nextParams, windowDays, now) ||
+    fixedSessionDateParamsEqual(nextParams, currentParams)
+  );
+}
+
+export function sessionRouteParamsForFilters(
+  filterParams: Record<string, string>,
+  currentParams: Record<string, string>,
+  now: Date = new Date(),
+): Record<string, string> {
+  const next = { ...filterParams };
+  const windowDays = currentParams[SESSION_ANALYTICS_WINDOW_PARAM];
+  if (shouldPreserveSessionWindowDays(next, currentParams, now)) {
+    next[SESSION_ANALYTICS_WINDOW_PARAM] = windowDays!;
+  }
+  return next;
+}
+
+export function currentSessionRouteParams(
+  currentParams: Record<string, string>,
+): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const key of SESSION_FILTER_KEYS) {
+    const value = currentParams[key];
+    if (value !== undefined) {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+export function sessionRouteParamsForDetailExit(
+  filterParams: Record<string, string>,
+  currentParams: Record<string, string>,
+): Record<string, string> {
+  const currentRouteParams = currentSessionRouteParams(currentParams);
+  if (hasFilterParams(currentRouteParams)) return currentRouteParams;
+  return sessionRouteParamsForFilters(filterParams, currentParams);
+}
+
+export function filterParamsEqual(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  for (const k of SESSION_FILTER_KEYS) {
+    if ((a[k] ?? "") !== (b[k] ?? "")) return false;
+  }
+  return true;
+}

--- a/frontend/src/lib/stores/sessionRouteParams.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.ts
@@ -31,7 +31,7 @@ function hasFixedSessionDateParams(
   return !!params["date"] || !!params["date_from"] || !!params["date_to"];
 }
 
-function hasSessionDateIntent(
+export function hasSessionDateIntent(
   params: Record<string, string>,
 ): boolean {
   return hasFixedSessionDateParams(params) ||

--- a/frontend/src/lib/stores/sessionRouteParams.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.ts
@@ -31,6 +31,21 @@ function hasFixedSessionDateParams(
   return !!params["date"] || !!params["date_from"] || !!params["date_to"];
 }
 
+function hasSessionDateIntent(
+  params: Record<string, string>,
+): boolean {
+  return hasFixedSessionDateParams(params) ||
+    !!params[SESSION_ANALYTICS_WINDOW_PARAM];
+}
+
+export function sessionDateIntentCleared(
+  currentParams: Record<string, string>,
+  nextParams: Record<string, string>,
+): boolean {
+  return hasSessionDateIntent(currentParams) &&
+    !hasSessionDateIntent(nextParams);
+}
+
 function isValidWindowDaysParam(raw: string | undefined): raw is string {
   if (!raw) return false;
   const n = Number.parseInt(raw, 10);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -17,6 +17,7 @@ import type {
 import { sync } from "./sync.svelte.js";
 import { events } from "./events.svelte.js";
 import { starred } from "./starred.svelte.js";
+import { yokedDates } from "./yokedDates.svelte.js";
 
 type SidebarIndexParams = Parameters<
   typeof SessionsService.getApiV1SessionsSidebarIndex
@@ -24,6 +25,9 @@ type SidebarIndexParams = Parameters<
 type MetadataParams = Parameters<
   typeof MetadataService.getApiV1Projects
 >[0];
+type ClearSessionFiltersOptions = {
+  clearDateYoke?: boolean;
+};
 
 const SESSION_PAGE_SIZE = 500;
 const SIDEBAR_HYDRATION_CONCURRENCY = 6;
@@ -146,6 +150,10 @@ export function filtersToParams(
   if (!f.includeOneShot) p["include_one_shot"] = "false";
   if (f.includeAutomated) p["include_automated"] = "true";
   return p;
+}
+
+function hasDateFilters(f: Filters): boolean {
+  return !!(f.date || f.dateFrom || f.dateTo);
 }
 
 export function splitExcludeProjectParam(
@@ -1012,10 +1020,13 @@ class SessionsStore {
     );
   }
 
-  clearSessionFilters() {
+  clearSessionFilters(options: ClearSessionFiltersOptions = {}) {
     const project = this.filters.project;
     const wasOneShot = this.filters.includeOneShot;
     const wasAutomated = this.filters.includeAutomated;
+    if (options.clearDateYoke || hasDateFilters(this.filters)) {
+      yokedDates.clear();
+    }
     this.filters = { ...defaultFilters(), project };
     this.setActiveSession(null);
     if (wasOneShot !== this.filters.includeOneShot || wasAutomated) {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -14,6 +14,7 @@ import {
   splitExcludeProjectParam,
 } from "./sessions.svelte.js";
 import { starred } from "./starred.svelte.js";
+import { yokedDates } from "./yokedDates.svelte.js";
 import type { Filters } from "./sessions.svelte.js";
 import type { Session } from "../api/types.js";
 import { callGenerated } from "../api/runtime.js";
@@ -197,6 +198,7 @@ describe("SessionsStore", () => {
     mockSidebarIndex();
     starred.filterOnly = false;
     starred.ids = new Set();
+    yokedDates.clear();
     sessions = createSessionsStore();
   });
 
@@ -1381,6 +1383,82 @@ describe("SessionsStore", () => {
 
       expect(sessions.filters.project).toBe("myproj");
       expect(sessions.hasActiveFilters).toBe(false);
+    });
+
+    it("clears the date yoke before clearing the active session", () => {
+      sessions.activeSessionId = "session-1";
+      sessions.filters.dateFrom = "2025-05-01";
+      sessions.filters.dateTo = "2025-05-31";
+      yokedDates.updateFromPanel({
+        from: "2025-05-01",
+        to: "2025-05-31",
+        mode: "rolling",
+        windowDays: 30,
+      });
+      expect(yokedDates.range).not.toBeNull();
+
+      const store = sessions as unknown as {
+        setActiveSession: (id: string | null) => void;
+      };
+      const setActiveSession = store.setActiveSession.bind(sessions);
+      const spy = vi
+        .spyOn(store, "setActiveSession")
+        .mockImplementation((id) => {
+          expect(yokedDates.range).toBeNull();
+          setActiveSession(id);
+        });
+
+      sessions.clearSessionFilters();
+
+      expect(spy).toHaveBeenCalledWith(null);
+      expect(sessions.activeSessionId).toBeNull();
+      expect(yokedDates.range).toBeNull();
+    });
+
+    it("clears the date yoke before clearing the active session when requested by route intent", () => {
+      sessions.activeSessionId = "session-1";
+      sessions.filters.agent = "codex";
+      yokedDates.updateFromPanel({
+        from: "2025-05-01",
+        to: "2025-05-31",
+        mode: "rolling",
+        windowDays: 30,
+      });
+      expect(yokedDates.range).not.toBeNull();
+
+      const store = sessions as unknown as {
+        setActiveSession: (id: string | null) => void;
+      };
+      const setActiveSession = store.setActiveSession.bind(sessions);
+      const spy = vi
+        .spyOn(store, "setActiveSession")
+        .mockImplementation((id) => {
+          expect(yokedDates.range).toBeNull();
+          setActiveSession(id);
+        });
+
+      sessions.clearSessionFilters({ clearDateYoke: true });
+
+      expect(spy).toHaveBeenCalledWith(null);
+      expect(sessions.activeSessionId).toBeNull();
+      expect(yokedDates.range).toBeNull();
+    });
+
+    it("keeps the date yoke for non-date filter clears without route date intent", () => {
+      sessions.filters.agent = "codex";
+      yokedDates.updateFromPanel({
+        from: "2025-05-01",
+        to: "2025-05-31",
+        mode: "fixed",
+      });
+
+      sessions.clearSessionFilters();
+
+      expect(yokedDates.range).toMatchObject({
+        from: "2025-05-01",
+        to: "2025-05-31",
+        mode: "fixed",
+      });
     });
   });
 

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -10,6 +10,7 @@ import {
 } from "../api/runtime.js";
 import { sessions } from "./sessions.svelte.js";
 import { perf, type PerfEntryStatus } from "./perf.svelte.js";
+import { daysAgo, today } from "../utils/dates.js";
 
 type UsageParams = Parameters<typeof UsageService.getApiV1UsageSummary>[0];
 type UsagePanel = "summary" | "comparison" | "topSessions";
@@ -79,23 +80,6 @@ function saveToggles(t: Toggles): void {
   } catch {
     // localStorage full or unavailable — silently skip.
   }
-}
-
-function localDateStr(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-function daysAgo(n: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  return localDateStr(d);
-}
-
-function today(): string {
-  return localDateStr(new Date());
 }
 
 const DEFAULT_WINDOW_DAYS = 30;
@@ -263,17 +247,25 @@ class UsageStore {
     return p;
   }
 
-  setDateRange(from: string, to: string) {
+  applyDateRange(from: string, to: string) {
     this.isPinned = true;
     this.from = from;
     this.to = to;
+  }
+
+  applyRollingWindow(days: number) {
+    this.windowDays = days;
+    this.isPinned = false;
+    this.rollDates();
+  }
+
+  setDateRange(from: string, to: string) {
+    this.applyDateRange(from, to);
     this.fetchAll();
   }
 
   setRollingWindow(days: number) {
-    this.windowDays = days;
-    this.isPinned = false;
-    this.rollDates();
+    this.applyRollingWindow(days);
     this.fetchAll();
   }
 
@@ -692,6 +684,11 @@ export function buildUsageUrlParams(
 }
 
 const CSV_MERGE_URL_KEYS = new Set(["exclude_project"]);
+const SESSION_DATE_URL_KEYS = new Set([
+  "date",
+  "date_from",
+  "date_to",
+]);
 
 export function mergeUsageAndSessionUrlParams(
   usageParams: Record<string, string>,
@@ -699,6 +696,7 @@ export function mergeUsageAndSessionUrlParams(
 ): Record<string, string> {
   const params = { ...usageParams };
   for (const [key, value] of Object.entries(sessionParams)) {
+    if (SESSION_DATE_URL_KEYS.has(key)) continue;
     if (CSV_MERGE_URL_KEYS.has(key) && params[key]) {
       params[key] = joinCsvParts(params[key], value);
     } else {

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -887,6 +887,51 @@ describe("mergeUsageAndSessionUrlParams", () => {
       machine: "host-a",
     });
   });
+
+  it("omits hidden session date params from usage URLs", async () => {
+    const { mergeUsageAndSessionUrlParams } = await loadStore();
+
+    expect(
+      mergeUsageAndSessionUrlParams(
+        {
+          from: "2026-02-01",
+          to: "2026-02-07",
+        },
+        {
+          date: "2026-01-15",
+          date_from: "2026-01-01",
+          date_to: "2026-01-31",
+          project: "agentsview",
+        },
+      ),
+    ).toEqual({
+      from: "2026-02-01",
+      to: "2026-02-07",
+      project: "agentsview",
+    });
+  });
+
+  it("preserves supported termination params in usage URLs", async () => {
+    const { mergeUsageAndSessionUrlParams } = await loadStore();
+
+    expect(
+      mergeUsageAndSessionUrlParams(
+        {
+          from: "2026-02-01",
+          to: "2026-02-07",
+        },
+        {
+          termination: "unclean",
+          project: "agentsview",
+        },
+      ),
+    ).toEqual({
+      from: "2026-02-01",
+      to: "2026-02-07",
+      termination: "unclean",
+      project: "agentsview",
+    });
+  });
 });
 
 describe("parseWindowDays", () => {

--- a/frontend/src/lib/stores/yokedDates.svelte.ts
+++ b/frontend/src/lib/stores/yokedDates.svelte.ts
@@ -1,0 +1,320 @@
+import { parseLocalDate, rollingRange } from "../utils/dates.js";
+
+export type YokedDateMode = "fixed" | "rolling";
+
+export interface PanelDateState {
+  from: string;
+  to: string;
+  mode?: YokedDateMode;
+  windowDays?: number;
+}
+
+export interface YokedDateRange {
+  from: string;
+  to: string;
+  mode: YokedDateMode;
+  windowDays?: number;
+  updatedAt: number;
+}
+
+export interface StoredYokedDates {
+  version: 1;
+  range: YokedDateRange | null;
+}
+
+export const YOKED_DATES_STORAGE_KEY = "yoked-dates";
+
+const STORAGE_VERSION = 1;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ACTIVITY_MAX_CUSTOM_RANGE_MS = 365 * 24 * 60 * 60 * 1000;
+
+function getLocalStorage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isDateString(value: unknown): value is string {
+  return typeof value === "string" && DATE_RE.test(value);
+}
+
+function validWindowDays(value: unknown): number | undefined {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function copyRange(range: YokedDateRange): YokedDateRange {
+  return range.windowDays === undefined
+    ? {
+        from: range.from,
+        to: range.to,
+        mode: range.mode,
+        updatedAt: range.updatedAt,
+      }
+    : {
+        from: range.from,
+        to: range.to,
+        mode: range.mode,
+        windowDays: range.windowDays,
+        updatedAt: range.updatedAt,
+      };
+}
+
+function parseStoredRange(value: unknown): YokedDateRange | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const range = value as Partial<YokedDateRange>;
+  if (
+    !isDateString(range.from) ||
+    !isDateString(range.to) ||
+    range.from > range.to ||
+    (range.mode !== "fixed" && range.mode !== "rolling") ||
+    typeof range.updatedAt !== "number" ||
+    !Number.isFinite(range.updatedAt)
+  ) {
+    return null;
+  }
+
+  if (range.mode === "rolling") {
+    const windowDays = validWindowDays(range.windowDays);
+    if (windowDays === undefined) return null;
+    return {
+      from: range.from,
+      to: range.to,
+      mode: "rolling",
+      windowDays,
+      updatedAt: range.updatedAt,
+    };
+  }
+
+  return {
+    from: range.from,
+    to: range.to,
+    mode: "fixed",
+    updatedAt: range.updatedAt,
+  };
+}
+
+function parseStored(value: unknown): StoredYokedDates | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const stored = value as Partial<StoredYokedDates>;
+  if (stored.version !== STORAGE_VERSION) {
+    return null;
+  }
+  if (stored.range === null) {
+    return {
+      version: STORAGE_VERSION,
+      range: null,
+    };
+  }
+  const range = parseStoredRange(stored.range);
+  if (!range) return null;
+  return {
+    version: STORAGE_VERSION,
+    range,
+  };
+}
+
+export function panelDateState(
+  from: string,
+  to: string,
+  options: { mode?: YokedDateMode; windowDays?: number } = {},
+): PanelDateState | null {
+  if (!isDateString(from) || !isDateString(to) || from > to) {
+    return null;
+  }
+
+  const mode = options.mode ?? "fixed";
+  if (mode === "rolling") {
+    const windowDays = validWindowDays(options.windowDays);
+    if (windowDays === undefined) return null;
+    return { from, to, mode, windowDays };
+  }
+
+  if (mode !== "fixed") return null;
+  return { from, to, mode };
+}
+
+export function panelStateToRange(
+  current: PanelDateState,
+  updatedAt: number,
+): YokedDateRange | null {
+  const state = panelDateState(current.from, current.to, {
+    mode: current.mode,
+    windowDays: current.windowDays,
+  });
+  if (!state || !Number.isFinite(updatedAt)) return null;
+  return state.mode === "rolling"
+    ? {
+        from: state.from,
+        to: state.to,
+        mode: "rolling",
+        windowDays: state.windowDays,
+        updatedAt,
+      }
+    : {
+        from: state.from,
+        to: state.to,
+        mode: "fixed",
+        updatedAt,
+    };
+}
+
+export function rangeToPanelDate(
+  range: YokedDateRange,
+  now: Date = new Date(),
+): PanelDateState | null {
+  if (range.mode === "rolling") {
+    const windowDays = validWindowDays(range.windowDays);
+    if (windowDays === undefined) return null;
+    const rangeDates = rollingRange(windowDays, now);
+    return panelDateState(rangeDates.from, rangeDates.to, {
+      mode: "rolling",
+      windowDays,
+    });
+  }
+
+  return panelDateState(range.from, range.to, { mode: "fixed" });
+}
+
+export function sessionParamsToPanelDate(
+  params: Record<string, string>,
+): PanelDateState | null {
+  if (params["date"]) {
+    return panelDateState(params["date"], params["date"], {
+      mode: "fixed",
+    });
+  }
+  if (params["date_from"] && params["date_to"]) {
+    return panelDateState(params["date_from"], params["date_to"], {
+      mode: "fixed",
+    });
+  }
+  return null;
+}
+
+export function rangeToSessionParams(
+  range: YokedDateRange,
+): Record<string, string> {
+  if (range.mode === "rolling" && range.windowDays) {
+    return { window_days: String(range.windowDays) };
+  }
+  if (range.mode === "fixed" && range.from === range.to) {
+    return { date: range.from };
+  }
+  return {
+    date_from: range.from,
+    date_to: range.to,
+  };
+}
+
+export function rangeToActivityParams(
+  range: YokedDateRange,
+  now: Date = new Date(),
+): Record<string, string> {
+  const state = rangeToPanelDate(range, now);
+  if (!state) return {};
+  if (!activityCustomRangeWithinLimit(state.from, state.to)) return {};
+  const params: Record<string, string> = {
+    preset: "custom",
+    from: state.from,
+    to: state.to,
+  };
+  if (state.mode === "rolling" && state.windowDays) {
+    params.window_days = String(state.windowDays);
+  }
+  return params;
+}
+
+function activityCustomRangeWithinLimit(from: string, to: string): boolean {
+  const start = parseLocalDate(from);
+  const inclusiveEnd = parseLocalDate(to);
+  if (!start || !inclusiveEnd) return false;
+
+  // Activity sends date-only custom ranges as [from, to + 1 day), and the
+  // backend rejects anything wider than 365 * 24h.
+  const exclusiveEnd = new Date(inclusiveEnd);
+  exclusiveEnd.setDate(exclusiveEnd.getDate() + 1);
+  const durationMs = exclusiveEnd.getTime() - start.getTime();
+  return durationMs > 0 && durationMs <= ACTIVITY_MAX_CUSTOM_RANGE_MS;
+}
+
+export function rangeToInsightParams(
+  range: YokedDateRange,
+): Record<string, string> {
+  const state = rangeToPanelDate(range);
+  if (!state) return {};
+  const params: Record<string, string> = {
+    date_from: state.from,
+    date_to: state.to,
+  };
+  if (state.mode === "rolling" && state.windowDays) {
+    params.window_days = String(state.windowDays);
+  }
+  return params;
+}
+
+export class YokedDatesStore {
+  range: YokedDateRange | null = $state(null);
+
+  constructor(
+    private readonly storage: Storage | null = getLocalStorage(),
+    private readonly now: () => number = () => Date.now(),
+  ) {
+    this.hydrate();
+  }
+
+  hydrate(): void {
+    if (!this.storage) return;
+    try {
+      const raw = this.storage.getItem(YOKED_DATES_STORAGE_KEY);
+      if (!raw) return;
+      const stored = parseStored(JSON.parse(raw));
+      if (!stored) return;
+      this.range = stored.range ? copyRange(stored.range) : null;
+    } catch {
+      this.range = null;
+    }
+  }
+
+  updateFromPanel(current: PanelDateState): void {
+    const range = panelStateToRange(current, this.now());
+    if (!range) return;
+    this.range = range;
+    this.persist();
+  }
+
+  seedForPanel(): YokedDateRange | null {
+    if (!this.range) return null;
+    return copyRange(this.range);
+  }
+
+  private persist(): void {
+    if (!this.storage) return;
+    const stored: StoredYokedDates = {
+      version: STORAGE_VERSION,
+      range: this.range ? copyRange(this.range) : null,
+    };
+    try {
+      this.storage.setItem(
+        YOKED_DATES_STORAGE_KEY,
+        JSON.stringify(stored),
+      );
+    } catch {
+      // Storage can be unavailable or full; current-tab state still works.
+    }
+  }
+}
+
+export const yokedDates = new YokedDatesStore();

--- a/frontend/src/lib/stores/yokedDates.svelte.ts
+++ b/frontend/src/lib/stores/yokedDates.svelte.ts
@@ -310,6 +310,11 @@ export class YokedDatesStore {
     this.persist();
   }
 
+  clear(): void {
+    this.range = null;
+    this.persist();
+  }
+
   seedForPanel(): YokedDateRange | null {
     if (!this.range) return null;
     return copyRange(this.range);

--- a/frontend/src/lib/stores/yokedDates.svelte.ts
+++ b/frontend/src/lib/stores/yokedDates.svelte.ts
@@ -40,6 +40,12 @@ function isDateString(value: unknown): value is string {
   return typeof value === "string" && DATE_RE.test(value);
 }
 
+function dateOnly(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const candidate = value.slice(0, 10);
+  return DATE_RE.test(candidate) ? candidate : undefined;
+}
+
 function validWindowDays(value: unknown): number | undefined {
   if (
     typeof value !== "number" ||
@@ -198,8 +204,14 @@ export function sessionParamsToPanelDate(
     });
   }
   if (params["date_from"] || params["date_to"]) {
-    const from = params["date_from"] ?? bounds.earliest ?? params["date_to"]!;
-    const to = params["date_to"] ?? bounds.latest ?? today();
+    const from =
+      dateOnly(params["date_from"]) ??
+      dateOnly(bounds.earliest) ??
+      dateOnly(params["date_to"])!;
+    const to =
+      dateOnly(params["date_to"]) ??
+      dateOnly(bounds.latest) ??
+      today();
     return panelDateState(from, to, {
       mode: "fixed",
     });

--- a/frontend/src/lib/stores/yokedDates.svelte.ts
+++ b/frontend/src/lib/stores/yokedDates.svelte.ts
@@ -1,4 +1,4 @@
-import { parseLocalDate, rollingRange } from "../utils/dates.js";
+import { parseLocalDate, rollingRange, today } from "../utils/dates.js";
 
 export type YokedDateMode = "fixed" | "rolling";
 
@@ -190,14 +190,17 @@ export function rangeToPanelDate(
 
 export function sessionParamsToPanelDate(
   params: Record<string, string>,
+  bounds: { earliest?: string; latest?: string } = {},
 ): PanelDateState | null {
   if (params["date"]) {
     return panelDateState(params["date"], params["date"], {
       mode: "fixed",
     });
   }
-  if (params["date_from"] && params["date_to"]) {
-    return panelDateState(params["date_from"], params["date_to"], {
+  if (params["date_from"] || params["date_to"]) {
+    const from = params["date_from"] ?? bounds.earliest ?? params["date_to"]!;
+    const to = params["date_to"] ?? bounds.latest ?? today();
+    return panelDateState(from, to, {
       mode: "fixed",
     });
   }

--- a/frontend/src/lib/stores/yokedDates.test.ts
+++ b/frontend/src/lib/stores/yokedDates.test.ts
@@ -202,7 +202,7 @@ describe("yoked date adapters", () => {
     expect(
       sessionParamsToPanelDate(
         { date_to: "2026-06-07" },
-        { earliest: "2026-05-01" },
+        { earliest: "2026-05-01T14:30:00Z" },
       ),
     ).toEqual({
       from: "2026-05-01",

--- a/frontend/src/lib/stores/yokedDates.test.ts
+++ b/frontend/src/lib/stores/yokedDates.test.ts
@@ -182,6 +182,43 @@ describe("yoked date adapters", () => {
     });
   });
 
+  it("maps a sessions lower date bound to a range ending today", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date("2026-06-19T12:00:00"));
+      expect(
+        sessionParamsToPanelDate({ date_from: "2026-06-01" }),
+      ).toEqual({
+        from: "2026-06-01",
+        to: "2026-06-19",
+        mode: "fixed",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("maps a sessions upper date bound using an available earliest date", () => {
+    expect(
+      sessionParamsToPanelDate(
+        { date_to: "2026-06-07" },
+        { earliest: "2026-05-01" },
+      ),
+    ).toEqual({
+      from: "2026-05-01",
+      to: "2026-06-07",
+      mode: "fixed",
+    });
+  });
+
+  it("maps a sessions upper date bound to a same-day range without an earliest date", () => {
+    expect(sessionParamsToPanelDate({ date_to: "2026-06-07" })).toEqual({
+      from: "2026-06-07",
+      to: "2026-06-07",
+      mode: "fixed",
+    });
+  });
+
   it("rejects incomplete and inverted panel ranges", () => {
     expect(panelDateState("", "2026-06-07")).toBeNull();
     expect(panelDateState("2026-06-08", "2026-06-07")).toBeNull();

--- a/frontend/src/lib/stores/yokedDates.test.ts
+++ b/frontend/src/lib/stores/yokedDates.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  YokedDatesStore,
+  panelDateState,
+  panelStateToRange,
+  rangeToActivityParams,
+  rangeToInsightParams,
+  rangeToPanelDate,
+  rangeToSessionParams,
+  sessionParamsToPanelDate,
+} from "./yokedDates.svelte.js";
+
+function fakeStorage(initial: Record<string, string> = {}): Storage {
+  const data = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(data.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    setItem(key: string, value: string) {
+      data.set(key, value);
+    },
+  };
+}
+
+describe("YokedDatesStore", () => {
+  it("defaults to no stored range", () => {
+    const store = new YokedDatesStore(fakeStorage());
+
+    expect(store.range).toBeNull();
+  });
+
+  it("hydrates valid stored state", () => {
+    const storage = fakeStorage({
+      "yoked-dates": JSON.stringify({
+        version: 1,
+        range: {
+          from: "2026-06-01",
+          to: "2026-06-07",
+          mode: "rolling",
+          windowDays: 7,
+          updatedAt: 123,
+        },
+      }),
+    });
+
+    const store = new YokedDatesStore(storage);
+
+    expect(store.range).toEqual({
+      from: "2026-06-01",
+      to: "2026-06-07",
+      mode: "rolling",
+      windowDays: 7,
+      updatedAt: 123,
+    });
+  });
+
+  it("ignores malformed stored state", () => {
+    const storage = fakeStorage({ "yoked-dates": "not json" });
+
+    const store = new YokedDatesStore(storage);
+
+    expect(store.range).toBeNull();
+  });
+
+  it("ignores unsupported storage versions", () => {
+    const storage = fakeStorage({
+      "yoked-dates": JSON.stringify({
+        version: 2,
+        range: {
+          from: "2026-06-01",
+          to: "2026-06-07",
+          mode: "fixed",
+          updatedAt: 123,
+        },
+      }),
+    });
+
+    const store = new YokedDatesStore(storage);
+
+    expect(store.range).toBeNull();
+  });
+
+  it("writes panel changes unconditionally without an enabled flag", () => {
+    const storage = fakeStorage();
+    const store = new YokedDatesStore(storage, () => 123);
+
+    store.updateFromPanel({
+      from: "2026-06-01",
+      to: "2026-06-07",
+    });
+
+    expect(store.range).toEqual({
+      from: "2026-06-01",
+      to: "2026-06-07",
+      mode: "fixed",
+      updatedAt: 123,
+    });
+    expect(JSON.parse(storage.getItem("yoked-dates") ?? "{}")).toEqual({
+      version: 1,
+      range: {
+        from: "2026-06-01",
+        to: "2026-06-07",
+        mode: "fixed",
+        updatedAt: 123,
+      },
+    });
+  });
+
+  it("hydrates legacy disabled state as an always-linked range", () => {
+    const store = new YokedDatesStore(fakeStorage({
+      "yoked-dates": JSON.stringify({
+        version: 1,
+        enabled: false,
+        range: {
+          from: "2026-06-01",
+          to: "2026-06-07",
+          mode: "fixed",
+          updatedAt: 456,
+        },
+      }),
+    }));
+
+    expect(store.range).toEqual({
+      from: "2026-06-01",
+      to: "2026-06-07",
+      mode: "fixed",
+      updatedAt: 456,
+    });
+  });
+
+  it("preserves rolling window intent when writing from a panel", () => {
+    const store = new YokedDatesStore(fakeStorage(), () => 789);
+
+    store.updateFromPanel({
+      from: "2026-05-21",
+      to: "2026-06-19",
+      mode: "rolling",
+      windowDays: 30,
+    });
+
+    expect(store.range).toEqual({
+      from: "2026-05-21",
+      to: "2026-06-19",
+      mode: "rolling",
+      windowDays: 30,
+      updatedAt: 789,
+    });
+  });
+});
+
+describe("yoked date adapters", () => {
+  it("maps a sessions single date to a same-day range", () => {
+    expect(sessionParamsToPanelDate({ date: "2026-06-19" })).toEqual({
+      from: "2026-06-19",
+      to: "2026-06-19",
+      mode: "fixed",
+    });
+  });
+
+  it("maps sessions date bounds to a range", () => {
+    expect(
+      sessionParamsToPanelDate({
+        date_from: "2026-06-01",
+        date_to: "2026-06-07",
+      }),
+    ).toEqual({
+      from: "2026-06-01",
+      to: "2026-06-07",
+      mode: "fixed",
+    });
+  });
+
+  it("rejects incomplete and inverted panel ranges", () => {
+    expect(panelDateState("", "2026-06-07")).toBeNull();
+    expect(panelDateState("2026-06-08", "2026-06-07")).toBeNull();
+    expect(
+      panelStateToRange(
+        { from: "2026-06-08", to: "2026-06-07" },
+        123,
+      ),
+    ).toBeNull();
+  });
+
+  it("serializes same-day sessions ranges as date", () => {
+    expect(
+      rangeToSessionParams({
+        from: "2026-06-19",
+        to: "2026-06-19",
+        mode: "fixed",
+        updatedAt: 123,
+      }),
+    ).toEqual({ date: "2026-06-19" });
+  });
+
+  it("serializes panel-specific fixed ranges", () => {
+    const range = {
+      from: "2026-06-01",
+      to: "2026-06-07",
+      mode: "fixed" as const,
+      updatedAt: 123,
+    };
+
+    expect(rangeToSessionParams(range)).toEqual({
+      date_from: "2026-06-01",
+      date_to: "2026-06-07",
+    });
+    expect(rangeToActivityParams(range)).toEqual({
+      preset: "custom",
+      from: "2026-06-01",
+      to: "2026-06-07",
+    });
+    expect(rangeToInsightParams(range)).toEqual({
+      date_from: "2026-06-01",
+      date_to: "2026-06-07",
+    });
+  });
+
+  it("skips Activity params for yoke ranges beyond the Activity max span", () => {
+    expect(
+      rangeToActivityParams({
+        from: "2025-06-19",
+        to: "2026-06-19",
+        mode: "fixed",
+        updatedAt: 123,
+      }),
+    ).toEqual({});
+
+    expect(
+      rangeToActivityParams(
+        {
+          from: "2025-06-19",
+          to: "2026-06-19",
+          mode: "rolling",
+          windowDays: 365,
+          updatedAt: 123,
+        },
+        new Date("2026-06-19T12:00:00"),
+      ),
+    ).toEqual({});
+
+    expect(
+      rangeToActivityParams({
+        from: "2025-06-20",
+        to: "2026-06-19",
+        mode: "fixed",
+        updatedAt: 123,
+      }),
+    ).toEqual({
+      preset: "custom",
+      from: "2025-06-20",
+      to: "2026-06-19",
+    });
+  });
+
+  it("serializes rolling session ranges as rolling URL intent", () => {
+    const range = {
+      from: "2026-05-20",
+      to: "2026-06-19",
+      mode: "rolling" as const,
+      windowDays: 30,
+      updatedAt: 123,
+    };
+
+    expect(rangeToSessionParams(range)).toEqual({
+      window_days: "30",
+    });
+  });
+
+  it("serializes rolling panel routes with rolling URL intent", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date("2026-06-19T12:00:00"));
+      const range = {
+        from: "2026-05-20",
+        to: "2026-06-19",
+        mode: "rolling" as const,
+        windowDays: 30,
+        updatedAt: 123,
+      };
+
+      expect(rangeToActivityParams(range)).toEqual({
+        preset: "custom",
+        from: "2026-05-20",
+        to: "2026-06-19",
+        window_days: "30",
+      });
+      expect(rangeToInsightParams(range)).toEqual({
+        date_from: "2026-05-20",
+        date_to: "2026-06-19",
+        window_days: "30",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("materializes rolling ranges against the current day", () => {
+    expect(
+      rangeToPanelDate(
+        {
+          from: "2026-05-20",
+          to: "2026-06-19",
+          mode: "rolling",
+          windowDays: 30,
+          updatedAt: 123,
+        },
+        new Date("2026-07-04T12:00:00"),
+      ),
+    ).toEqual({
+      from: "2026-06-04",
+      to: "2026-07-04",
+      mode: "rolling",
+      windowDays: 30,
+    });
+  });
+});

--- a/frontend/src/lib/utils/dates.test.ts
+++ b/frontend/src/lib/utils/dates.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { daysAgo, localDateStr, today } from "./dates.js";
+import {
+  addDays,
+  daysAgo,
+  endOfMonth,
+  localDateStr,
+  parseLocalDate,
+  rollingRange,
+  startOfIsoWeek,
+  startOfMonth,
+  today,
+} from "./dates.js";
 
 describe("date helpers", () => {
   afterEach(() => vi.useRealTimers());
@@ -13,5 +23,25 @@ describe("date helpers", () => {
     vi.setSystemTime(new Date(2024, 5, 10, 12, 0, 0));
     expect(today()).toBe("2024-06-10");
     expect(daysAgo(7)).toBe("2024-06-03");
+  });
+
+  it("computes rolling ranges from an explicit clock", () => {
+    expect(rollingRange(30, new Date(2024, 5, 10, 12, 0, 0))).toEqual({
+      from: "2024-05-11",
+      to: "2024-06-10",
+    });
+  });
+
+  it("parses and offsets local date strings", () => {
+    expect(parseLocalDate("2024-02-03")?.getDate()).toBe(3);
+    expect(parseLocalDate("not-a-date")).toBeNull();
+    expect(addDays("2024-02-27", 2)).toBe("2024-02-29");
+    expect(endOfMonth("2024-02-03")).toBe("2024-02-29");
+  });
+
+  it("expands anchored activity presets to backend-equivalent local bounds", () => {
+    expect(startOfIsoWeek("2026-06-17")).toBe("2026-06-15");
+    expect(startOfIsoWeek("2026-06-21")).toBe("2026-06-15");
+    expect(startOfMonth("2026-02-14")).toBe("2026-02-01");
   });
 });

--- a/frontend/src/lib/utils/dates.ts
+++ b/frontend/src/lib/utils/dates.ts
@@ -14,3 +14,49 @@ export function daysAgo(n: number): string {
 export function today(): string {
   return localDateStr(new Date());
 }
+
+export function rollingRange(
+  days: number,
+  now: Date = new Date(),
+): { from: string; to: string } {
+  const to = new Date(now);
+  const from = new Date(to);
+  from.setDate(from.getDate() - days);
+  return {
+    from: localDateStr(from),
+    to: localDateStr(to),
+  };
+}
+
+export function parseLocalDate(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const d = new Date(value + "T00:00:00");
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function addDays(value: string, days: number): string {
+  const d = parseLocalDate(value);
+  if (!d) return "";
+  d.setDate(d.getDate() + days);
+  return localDateStr(d);
+}
+
+export function startOfIsoWeek(value: string): string {
+  const d = parseLocalDate(value);
+  if (!d) return "";
+  const offset = (d.getDay() + 6) % 7;
+  d.setDate(d.getDate() - offset);
+  return localDateStr(d);
+}
+
+export function startOfMonth(value: string): string {
+  const d = parseLocalDate(value);
+  if (!d) return "";
+  return localDateStr(new Date(d.getFullYear(), d.getMonth(), 1));
+}
+
+export function endOfMonth(value: string): string {
+  const d = parseLocalDate(value);
+  if (!d) return "";
+  return localDateStr(new Date(d.getFullYear(), d.getMonth() + 1, 0));
+}


### PR DESCRIPTION
This PR adds persisted date yoking across date-aware panels so selecting a date range in sessions analytics, usage, activity, trends, or insights carries across the rest of the viewer. Date yoking is now unconditional: there is no toggle, no opt-out UI, and no persisted enabled flag.

The frontend now has a shared yoke-date store that persists the current range in localStorage, plus URL/yoke precedence rules per panel. Explicit URL date params still win over stored yoke state, bare routes seed from the stored yoke range, and analytics/usage initial fetches wait until URL/yoke date state has been applied.

The UI work removes the old link-button affordance from the top date controls and leaves the existing date pickers/presets as the only visible date controls. Shared local date helpers keep rolling and fixed range materialization consistent across panels, including sessions `window_days` URLs and activity week/month period bounds.

Activity adopts only yoked ranges its backend can represent exactly. Longer ranges such as a 1y analytics/usage yoke are left on Activity's current range instead of being silently clipped or causing Activity's one-year custom-range limit to reject the first load.

Reviewers should start with `frontend/src/lib/stores/yokedDates.svelte.ts`, `frontend/src/App.svelte`, and the page integrations under `frontend/src/lib/components/{analytics,usage,activity,trends,insights}/`.
