### PR TITLE
fix(frontend): align read-only header refresh label

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -673,7 +673,7 @@
       aria-label={sync.readOnly ? "Refresh data" : "Sync sessions"}
     >
       <DatabaseBackupIcon size="14" strokeWidth="2" aria-hidden="true" />
-      <span class="sync-label">Sync</span>
+      <span class="sync-label">{sync.readOnly ? "Refresh" : "Sync"}</span>
     </button>
 
     <button

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../utils/clipboard.js", () => ({
 }));
 
 import { sessions } from "../../stores/sessions.svelte.js";
+import { sync } from "../../stores/sync.svelte.js";
 import { ui } from "../../stores/ui.svelte.js";
 import type { Session } from "../../api/types.js";
 
@@ -58,6 +59,7 @@ describe("AppHeader export actions", () => {
     vi.clearAllMocks();
     sessions.activeSessionId = "sess-123";
     sessions.sessions = [testSession()];
+    sync.serverVersion = null;
     ui.isMobileViewport = false;
     ui.followLatest = false;
   });
@@ -183,6 +185,28 @@ describe("AppHeader export actions", () => {
     expect(syncButton?.textContent?.trim()).toBe("Sync");
     expect(
       syncButton?.querySelector("svg.lucide-database-backup"),
+    ).not.toBeNull();
+  });
+
+  it("labels read-only global refresh with the refresh action", async () => {
+    sync.serverVersion = {
+      version: "dev",
+      commit: "unknown",
+      build_date: "",
+      read_only: true,
+    };
+
+    component = mount(AppHeader, { target: document.body });
+    await tick();
+
+    const refreshButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Refresh data"]',
+    );
+
+    expect(refreshButton).not.toBeNull();
+    expect(refreshButton?.textContent?.trim()).toBe("Refresh");
+    expect(
+      refreshButton?.querySelector("svg.lucide-database-backup"),
     ).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #743. The global header action now keeps its visible label aligned with the read-only refresh behavior while preserving the visual distinction added in #743.

## Changes

- Shows `Refresh` instead of `Sync` for read-only backends, matching the existing title and aria label.
- Keeps the database-backup icon treatment from #743 so the global action remains distinct from page-level refresh controls.
- Adds a component regression test for the read-only header label.