### PR TITLE
Run NilAway on pre-push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ make dev            # Run Go server in dev mode
 make frontend       # Build frontend SPA only
 make frontend-dev   # Run Vite dev server, use alongside make dev
 make install        # Build and install to ~/.local/bin or GOPATH
-make install-hooks  # Install pre-commit git hooks
+make install-hooks  # Install pre-commit and pre-push git hooks
 ```
 
 ## Testing

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ release-linux-amd64: frontend
 		-ldflags="$(LDFLAGS_RELEASE)" -trimpath \
 		-o dist/agentsview-linux-amd64 ./cmd/agentsview
 
-# Install pre-commit hooks via prek
+# Install pre-commit and pre-push hooks via prek
 install-hooks:
 	@if ! command -v prek >/dev/null 2>&1; then \
 		echo "prek not found. Install with: brew install prek" >&2; \
@@ -421,4 +421,4 @@ help:
 	@echo ""
 	@echo "  release        - Release build for current platform"
 	@echo "  clean          - Remove build artifacts"
-	@echo "  install-hooks  - Install pre-commit git hooks"
+	@echo "  install-hooks  - Install pre-commit and pre-push git hooks"

--- a/README.md
+++ b/README.md
@@ -490,8 +490,9 @@ default fixture is 1,000 sessions and 64,000 messages; use
 When the Docker CLI uses a non-default socket, export `DOCKER_HOST` for that
 socket before running the benchmark.
 
-Pre-commit hooks via [prek](https://github.com/j178/prek): run `make lint-tools`
-and `make install-hooks` after cloning (requires `prek` and `uv`).
+Pre-commit and pre-push hooks via [prek](https://github.com/j178/prek): run
+`make lint-tools` and `make install-hooks` after cloning (requires `prek` and
+`uv`).
 
 ### Project Layout
 

--- a/hook_config_test.go
+++ b/hook_config_test.go
@@ -1,0 +1,53 @@
+package agentsview_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type prekConfig struct {
+	DefaultInstallHookTypes []string   `toml:"default_install_hook_types"`
+	Repos                   []prekRepo `toml:"repos"`
+}
+
+type prekRepo struct {
+	Hooks []prekHook `toml:"hooks"`
+}
+
+type prekHook struct {
+	ID     string   `toml:"id"`
+	Stages []string `toml:"stages"`
+}
+
+func TestNilAwayHookRunsOnlyOnPrePush(t *testing.T) {
+	contents, err := os.ReadFile("prek.toml")
+	require.NoError(t, err)
+
+	var config prekConfig
+	require.NoError(t, toml.Unmarshal(contents, &config))
+
+	assert.Contains(t, config.DefaultInstallHookTypes, "pre-commit")
+	assert.Contains(t, config.DefaultInstallHookTypes, "pre-push")
+
+	hook := findPrekHook(t, config, "nilaway")
+	assert.Equal(t, []string{"pre-push"}, hook.Stages)
+}
+
+func findPrekHook(t *testing.T, config prekConfig, id string) prekHook {
+	t.Helper()
+
+	for _, repo := range config.Repos {
+		for _, hook := range repo.Hooks {
+			if hook.ID == id {
+				return hook
+			}
+		}
+	}
+
+	require.Failf(t, "missing prek hook", "hook ID %q was not found", id)
+	return prekHook{}
+}

--- a/prek.toml
+++ b/prek.toml
@@ -1,4 +1,6 @@
 minimum_prek_version = "0.3.6"
+default_install_hook_types = ["pre-commit", "pre-push"]
+default_stages = ["pre-commit"]
 
 [[repos]]
 repo = "local"
@@ -16,6 +18,7 @@ id = "nilaway"
 name = "NilAway"
 language = "system"
 entry = "make nilaway"
+stages = ["pre-push"]
 types = ["go"]
 pass_filenames = false
 always_run = true


### PR DESCRIPTION
Moves the NilAway prek hook off the default pre-commit stage and onto pre-push, while keeping pre-commit as the default stage for the existing lightweight hooks. The hook installer now provisions both pre-commit and pre-push shims by default.

Adds a regression test that parses prek.toml and asserts NilAway is pre-push-only, so future hook config changes cannot silently move it back to pre-commit. Updates developer docs and help text to describe both installed hook stages.