### PR TITLE
Add JSONL source set helper

### DIFF
--- a/internal/parser/directory_jsonl_source_set.go
+++ b/internal/parser/directory_jsonl_source_set.go
@@ -1,0 +1,59 @@
+package parser
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// DirectoryJSONLSourceSet constrains JSONL sources to the common
+// <root>/<project>/<session>.<ext> shape while keeping JSONLSourceSet's source
+// methods available through embedding.
+type DirectoryJSONLSourceSet struct {
+	JSONLSourceSet
+}
+
+// newDirectoryJSONLSourceSet returns a JSONL source helper for providers whose
+// transcripts live one project directory below each configured root. The
+// returned helper is always recursive enough to classify watched project files,
+// but it rejects root-level and deeper nested files through IncludePath.
+func newDirectoryJSONLSourceSet(
+	provider AgentType,
+	roots []string,
+	opts ...jsonlOption,
+) DirectoryJSONLSourceSet {
+	var options JSONLSourceSetOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	userIncludePath := options.IncludePath
+	options.Recursive = true
+	options.IncludePath = func(root, path string) bool {
+		if !isDirectoryJSONLPath(root, path) {
+			return false
+		}
+		return userIncludePath == nil || userIncludePath(root, path)
+	}
+	if options.ProjectHint == nil {
+		options.ProjectHint = func(root, path string) string {
+			return directoryJSONLProjectFromPath(path)
+		}
+	}
+	return DirectoryJSONLSourceSet{
+		JSONLSourceSet: jsonlSourceSetFromOptions(provider, roots, options),
+	}
+}
+
+func isDirectoryJSONLPath(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	return len(parts) == 2 &&
+		parts[0] != "" && parts[0] != "." && parts[0] != ".." &&
+		parts[1] != "" && parts[1] != "." && parts[1] != ".."
+}
+
+func directoryJSONLProjectFromPath(path string) string {
+	return filepath.Base(filepath.Dir(path))
+}

--- a/internal/parser/file_identity_unix.go
+++ b/internal/parser/file_identity_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package parser
+
+import (
+	"os"
+	"syscall"
+)
+
+func sourceFileIdentity(info os.FileInfo) (inode, device uint64) {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return uint64(stat.Ino), uint64(stat.Dev)
+	}
+	return 0, 0
+}

--- a/internal/parser/file_identity_windows.go
+++ b/internal/parser/file_identity_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package parser
+
+import "os"
+
+func sourceFileIdentity(info os.FileInfo) (inode, device uint64) {
+	return 0, 0
+}

--- a/internal/parser/jsonl_source_set.go
+++ b/internal/parser/jsonl_source_set.go
@@ -1,0 +1,793 @@
+package parser
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// JSONLSource is the in-memory payload JSONLSourceSet stores in SourceRef.
+type JSONLSource struct {
+	Root    string
+	Path    string
+	RelPath string
+}
+
+// JSONLSourceSetOptions configures the reusable JSONL source helper.
+type JSONLSourceSetOptions struct {
+	// Recursive enables traversal and changed-path classification below each
+	// configured root. When false, only direct child files are sources.
+	Recursive bool
+	// Extensions defaults to .jsonl. Matching is case-sensitive to mirror
+	// legacy parser discovery.
+	Extensions []string
+	// Hash includes a full content hash in SourceFingerprint. Providers should
+	// leave this false unless size/mtime freshness is insufficient.
+	Hash bool
+	// FollowSymlinkDirs treats symlinks to directories as directories while
+	// discovering recursive roots. Providers should enable it only when legacy
+	// discovery followed symlinked session directories; targets may be outside
+	// the configured root, so provider IncludePath filters should constrain the
+	// accepted source shape when that matters.
+	FollowSymlinkDirs bool
+	// FollowSymlinkFiles treats symlinks to regular files as sources. Providers
+	// should enable it when legacy discovery accepted matching symlinked files
+	// and the parser reads through the symlink target.
+	FollowSymlinkFiles bool
+	// DescendPath is a directory predicate for recursive discovery. It is also
+	// applied to source ancestors during direct source classification so
+	// changed-path events cannot accept paths discovery would have pruned.
+	DescendPath func(root, path string) bool
+	// IncludePath is a path-only source predicate. It runs before Include and is
+	// also used for deleted/renamed changed paths where os.FileInfo is
+	// unavailable.
+	IncludePath func(root, path string) bool
+	// Include is a source predicate for existing files. It is not called for
+	// deleted/renamed changed paths.
+	Include func(path string, info os.FileInfo) bool
+	// Key must be stable across process restarts and unique within a provider
+	// when every physical source should be parsed. If duplicates exist,
+	// discovery keeps the first configured root/traversal result.
+	Key func(root, path string) string
+	// DisplayPath is human-readable. When FingerprintKey is not set, it also
+	// becomes the persisted freshness key.
+	DisplayPath func(root, path string) string
+	// FingerprintKey is the persisted lookup and freshness identity. Override it
+	// when DisplayPath is not the stable value that should survive a provider
+	// migration.
+	FingerprintKey func(root, path string) string
+	// ProjectHint is display metadata only.
+	ProjectHint func(root, path string) string
+	// SessionIDFromPath returns the raw session ID used by FindSource fallback
+	// lookups. It should not include the provider ID prefix.
+	SessionIDFromPath func(root, path string) string
+	// LookupIDValid reports whether a raw session ID is shaped like an ID this
+	// provider could resolve, gating the FindSource discovery fallback. It
+	// defaults to IsValidSessionID. Providers whose SessionIDFromPath emits
+	// composite IDs (for example subagent IDs containing separators that
+	// IsValidSessionID rejects) supply their own validator so those lookups are
+	// not dropped before the comparison loop.
+	LookupIDValid func(rawID string) bool
+	// RawSessionIDForLookup normalizes a raw session ID before the FindSource
+	// discovery comparison. Providers whose stored IDs carry a suffix the
+	// discovered filename stem lacks (for example iFlow subagent IDs) reduce it
+	// to the base ID here so the comparison still matches. It runs after
+	// providerFindRequestWithRawSessionID and before the LookupIDValid gate.
+	RawSessionIDForLookup func(rawID string) string
+	// RawSessionIDSourceFiles reconstructs candidate file paths from a raw
+	// session ID for providers whose IDs encode the on-disk layout rather than
+	// being a discoverable filename stem. FindSource resolves each candidate
+	// through the same path->SourceRef machinery as a stored path and returns
+	// the first that exists, before falling through to the discovery scan. The
+	// closure iterates the provided roots itself and applies its own ID
+	// validation.
+	RawSessionIDSourceFiles func(roots []string, rawID string) []string
+	// StoredPathFallbackRoot resolves the configured root for a stored source
+	// path that is not under any current root, returning false to decline. It
+	// lets a provider honor a DB-recorded file_path whose root was removed or
+	// was a custom location by reconstructing the implicit root so the path
+	// still resolves to a SourceRef. FindSource consults it after the in-root
+	// path lookup misses.
+	StoredPathFallbackRoot func(storedPath string) (string, bool)
+	// ParseFile parses one discovered source file into zero or more sessions
+	// plus the IDs of any sessions to exclude. Empty results with no exclusions
+	// is a clean no-session. It is what makes JSONLSourceSet a full SourceSet
+	// (its Parse method); leave it nil for discovery-only embedders that supply
+	// their own Parse. ctx and req.Machine are supplied by sourceSetProvider.
+	ParseFile jsonlParseFileFunc
+	// ForceReplace marks every non-empty parse outcome from ParseFile as a full
+	// replacement of the source's existing sessions, for providers whose
+	// transcripts are rewritten wholesale rather than appended.
+	ForceReplace bool
+}
+
+// JSONLSourceSet discovers, watches, locates, and fingerprints JSONL-like
+// transcript files. With a ParseFile option it is also a full SourceSet;
+// without one it is a discovery helper that providers compose as a named field
+// and forward the methods they support. Missing or unreadable roots and
+// subdirectories are treated as empty, matching legacy discovery's lenient
+// local-filesystem behavior.
+type JSONLSourceSet struct {
+	provider   AgentType
+	roots      []string
+	options    JSONLSourceSetOptions
+	extensions []string
+}
+
+// newJSONLSourceSet builds a JSONL source set for a provider's roots from
+// functional options. Every option has a zero-value default, so callers state
+// only what differs.
+func newJSONLSourceSet(
+	provider AgentType,
+	roots []string,
+	opts ...jsonlOption,
+) JSONLSourceSet {
+	var options JSONLSourceSetOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return jsonlSourceSetFromOptions(provider, roots, options)
+}
+
+// jsonlSourceSetFromOptions is the shared constructor used by newJSONLSourceSet
+// and newDirectoryJSONLSourceSet once options have been resolved.
+func jsonlSourceSetFromOptions(
+	provider AgentType,
+	roots []string,
+	options JSONLSourceSetOptions,
+) JSONLSourceSet {
+	return JSONLSourceSet{
+		provider:   provider,
+		roots:      cleanJSONLRoots(roots),
+		options:    options,
+		extensions: normalizeJSONLExtensions(options.Extensions),
+	}
+}
+
+// Discover returns stable, deduped source references for configured roots.
+func (s JSONLSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(root)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		if err := s.discoverDir(ctx, root, root, &sources, seen); err != nil {
+			return nil, err
+		}
+	}
+	sortJSONLSources(sources)
+	return sources, nil
+}
+
+// WatchPlan returns one watch root for each configured JSONL root.
+func (s JSONLSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
+	roots := make([]WatchRoot, 0, len(s.roots))
+	globs := s.includeGlobs()
+	for _, root := range s.roots {
+		roots = append(roots, WatchRoot{
+			Path:         root,
+			Recursive:    s.options.Recursive,
+			IncludeGlobs: append([]string(nil), globs...),
+			DebounceKey:  string(s.provider) + ":jsonl:" + root,
+		})
+	}
+	return WatchPlan{Roots: roots}, nil
+}
+
+// SourcesForChangedPath maps a filesystem event path back to JSONL sources.
+func (s JSONLSourceSet) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	source, ok, err := s.sourceForPath(ctx, req.Path)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		if !jsonlMissingPathFallbackAllowed(req) {
+			return nil, nil
+		}
+		source, ok, err = s.sourceForMissingPath(ctx, req.Path)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, nil
+		}
+	}
+	if req.WatchRoot != "" {
+		root := filepath.Clean(req.WatchRoot)
+		src := source.Opaque.(JSONLSource)
+		if !samePath(root, src.Root) {
+			return nil, nil
+		}
+	}
+	return []SourceRef{source}, nil
+}
+
+// FindSource resolves persisted source hints or a raw filename-stem session ID.
+func (s JSONLSourceSet) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, stored := range []string{req.StoredFilePath, req.FingerprintKey} {
+		if stored == "" {
+			continue
+		}
+		source, ok, err := s.sourceForPath(ctx, stored)
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		if ok {
+			return source, true, nil
+		}
+		if s.options.StoredPathFallbackRoot != nil {
+			if root, ok := s.options.StoredPathFallbackRoot(stored); ok {
+				if source, ok := s.sourceRefFromPath(
+					root, filepath.Clean(stored),
+				); ok {
+					return source, true, nil
+				}
+			}
+		}
+	}
+	if s.options.RawSessionIDForLookup != nil && req.RawSessionID != "" {
+		req.RawSessionID = s.options.RawSessionIDForLookup(req.RawSessionID)
+	}
+	if req.RawSessionID != "" && s.options.RawSessionIDSourceFiles != nil {
+		for _, candidate := range s.options.RawSessionIDSourceFiles(
+			s.roots, req.RawSessionID,
+		) {
+			source, ok, err := s.sourceForPath(ctx, candidate)
+			if err != nil {
+				return SourceRef{}, false, err
+			}
+			if ok {
+				return source, true, nil
+			}
+		}
+	}
+	validRawID := req.RawSessionID != "" && s.lookupIDValid(req.RawSessionID)
+	if req.FingerprintKey == "" && !validRawID {
+		return SourceRef{}, false, nil
+	}
+	sources, err := s.Discover(ctx)
+	if err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, source := range sources {
+		if req.FingerprintKey != "" && source.FingerprintKey == req.FingerprintKey {
+			return source, true, nil
+		}
+		if !validRawID {
+			continue
+		}
+		src := source.Opaque.(JSONLSource)
+		if s.sessionID(src.Root, src.Path) == req.RawSessionID {
+			return source, true, nil
+		}
+	}
+	return SourceRef{}, false, nil
+}
+
+// Fingerprint returns the filesystem freshness identity for a JSONL source.
+func (s JSONLSourceSet) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceFingerprint{}, err
+	}
+	path, ok, err := s.pathFromSource(ctx, source)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	if !ok {
+		return SourceFingerprint{}, fmt.Errorf("jsonl source path unavailable")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", path)
+	}
+	inode, device := sourceFileIdentity(info)
+	fingerprint := SourceFingerprint{
+		Key: firstNonEmptyJSONLString(
+			source.FingerprintKey,
+			source.Key,
+			path,
+		),
+		Size:    info.Size(),
+		MTimeNS: info.ModTime().UnixNano(),
+		Inode:   inode,
+		Device:  device,
+	}
+	if s.options.Hash {
+		hash, err := hashJSONLSourceFile(path)
+		if err != nil {
+			return SourceFingerprint{}, err
+		}
+		fingerprint.Hash = hash
+	}
+	return fingerprint, nil
+}
+
+// Parse resolves the request's source to a file and parses it via the ParseFile
+// option, making JSONLSourceSet a full SourceSet. It mirrors the single-file
+// base's parse semantics: empty results with no exclusions is a clean
+// no-session skip. sourceSetProvider resolves req.Machine before calling in.
+func (s JSONLSourceSet) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	if err := ctx.Err(); err != nil {
+		return ParseOutcome{}, err
+	}
+	if s.options.ParseFile == nil {
+		return ParseOutcome{}, fmt.Errorf(
+			"%s: JSONLSourceSet has no ParseFile configured", s.provider,
+		)
+	}
+	path, ok, err := s.pathFromSource(ctx, req.Source)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if !ok {
+		return ParseOutcome{}, fmt.Errorf(
+			"%s source path unavailable", s.provider,
+		)
+	}
+	results, excluded, err := s.options.ParseFile(ctx, path, req)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if len(results) == 0 && len(excluded) == 0 {
+		return ParseOutcome{
+			ResultSetComplete: true,
+			SkipReason:        SkipNoSession,
+		}, nil
+	}
+	out := make([]ParseResultOutcome, 0, len(results))
+	for i := range results {
+		out = append(out, ParseResultOutcome{
+			Result:      results[i],
+			DataVersion: DataVersionCurrent,
+		})
+	}
+	return ParseOutcome{
+		Results:            out,
+		ExcludedSessionIDs: excluded,
+		ResultSetComplete:  true,
+		ForceReplace:       s.options.ForceReplace,
+	}, nil
+}
+
+var (
+	_ SourceSet = JSONLSourceSet{}
+	_ SourceSet = DirectoryJSONLSourceSet{}
+)
+
+func (s JSONLSourceSet) discoverDir(
+	ctx context.Context,
+	root string,
+	dir string,
+	sources *[]SourceRef,
+	seen map[string]struct{},
+) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return nil
+	}
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		path := filepath.Join(dir, entry.Name())
+		if s.shouldDescend(entry, dir) {
+			if s.options.Recursive && s.descendPathIncluded(root, path) {
+				if err := s.discoverDir(
+					ctx, root, path, sources, seen,
+				); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		info, err := s.sourceFileInfo(entry, path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		source, ok := s.sourceRef(root, path, info)
+		if !ok {
+			continue
+		}
+		addJSONLSource(source, sources, seen)
+	}
+	return nil
+}
+
+func (s JSONLSourceSet) shouldDescend(entry os.DirEntry, dir string) bool {
+	if entry.IsDir() {
+		return true
+	}
+	return s.options.FollowSymlinkDirs && isDirOrSymlink(entry, dir)
+}
+
+func (s JSONLSourceSet) sourceFileInfo(
+	entry os.DirEntry,
+	path string,
+) (os.FileInfo, error) {
+	info, err := entry.Info()
+	if err != nil {
+		return nil, err
+	}
+	if !s.options.FollowSymlinkFiles || info.Mode()&os.ModeSymlink == 0 {
+		return info, nil
+	}
+	return os.Stat(path)
+}
+
+func (s JSONLSourceSet) sourceForPath(
+	ctx context.Context,
+	path string,
+) (SourceRef, bool, error) {
+	path = filepath.Clean(path)
+	info, err := s.sourcePathInfo(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return SourceRef{}, false, nil
+	}
+	for _, root := range s.roots {
+		if !s.pathAllowedByRoot(root, path) {
+			continue
+		}
+		if !s.sourcePathAllowedByDescendPath(root, path) {
+			continue
+		}
+		if !s.pathIncluded(root, path) {
+			continue
+		}
+		source, ok := s.sourceRef(root, path, info)
+		if !ok {
+			return SourceRef{}, false, nil
+		}
+		return s.discoveredSourceForCandidate(ctx, source)
+	}
+	return SourceRef{}, false, nil
+}
+
+func (s JSONLSourceSet) sourcePathInfo(path string) (os.FileInfo, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !s.options.FollowSymlinkFiles || info.Mode()&os.ModeSymlink == 0 {
+		return info, nil
+	}
+	return os.Stat(path)
+}
+
+func (s JSONLSourceSet) sourceForMissingPath(
+	ctx context.Context,
+	path string,
+) (SourceRef, bool, error) {
+	path = filepath.Clean(path)
+	for _, root := range s.roots {
+		if !s.pathAllowedByRoot(root, path) {
+			continue
+		}
+		if !s.sourcePathAllowedByDescendPath(root, path) {
+			continue
+		}
+		if !s.matchesExtension(path) || !s.pathIncluded(root, path) {
+			continue
+		}
+		source, ok := s.sourceRefFromPath(root, path)
+		if !ok {
+			return SourceRef{}, false, nil
+		}
+		return s.discoveredSourceForCandidate(ctx, source)
+	}
+	return SourceRef{}, false, nil
+}
+
+func jsonlMissingPathFallbackAllowed(req ChangedPathRequest) bool {
+	if req.Path == "" {
+		return false
+	}
+	if _, err := os.Lstat(req.Path); err == nil {
+		return false
+	} else if os.IsNotExist(err) {
+		return true
+	}
+	switch strings.ToLower(req.EventKind) {
+	case "remove", "removed", "delete", "deleted", "rename", "renamed":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s JSONLSourceSet) pathAllowedByRoot(root, path string) bool {
+	if s.options.Recursive {
+		return pathIsUnderRoot(path, root)
+	}
+	return samePath(filepath.Dir(path), root)
+}
+
+func (s JSONLSourceSet) sourceRef(
+	root string,
+	path string,
+	info os.FileInfo,
+) (SourceRef, bool) {
+	if !s.matchesExtension(path) {
+		return SourceRef{}, false
+	}
+	if !s.pathIncluded(root, path) {
+		return SourceRef{}, false
+	}
+	if s.options.Include != nil && !s.options.Include(path, info) {
+		return SourceRef{}, false
+	}
+	return s.sourceRefFromPath(root, path)
+}
+
+func (s JSONLSourceSet) sourceRefFromPath(
+	root string,
+	path string,
+) (SourceRef, bool) {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return SourceRef{}, false
+	}
+	displayPath := firstNonEmptyJSONLString(
+		callPathFunc(s.options.DisplayPath, root, path),
+		path,
+	)
+	fingerprintKey := firstNonEmptyJSONLString(
+		callPathFunc(s.options.FingerprintKey, root, path),
+		displayPath,
+	)
+	key := firstNonEmptyJSONLString(
+		callPathFunc(s.options.Key, root, path),
+		displayPath,
+	)
+	return SourceRef{
+		Provider:       s.provider,
+		Key:            key,
+		DisplayPath:    displayPath,
+		FingerprintKey: fingerprintKey,
+		ProjectHint:    callPathFunc(s.options.ProjectHint, root, path),
+		Opaque: JSONLSource{
+			Root:    root,
+			Path:    path,
+			RelPath: rel,
+		},
+	}, true
+}
+
+func (s JSONLSourceSet) discoveredSourceForCandidate(
+	ctx context.Context,
+	candidate SourceRef,
+) (SourceRef, bool, error) {
+	discovered, err := s.Discover(ctx)
+	if err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, source := range discovered {
+		if source.Provider == candidate.Provider && source.Key == candidate.Key {
+			return source, true, nil
+		}
+	}
+	return candidate, true, nil
+}
+
+func (s JSONLSourceSet) pathIncluded(root, path string) bool {
+	return s.options.IncludePath == nil || s.options.IncludePath(root, path)
+}
+
+func (s JSONLSourceSet) descendPathIncluded(root, path string) bool {
+	return s.options.DescendPath == nil || s.options.DescendPath(root, path)
+}
+
+func (s JSONLSourceSet) sourcePathAllowedByDescendPath(root, path string) bool {
+	if s.options.DescendPath == nil {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	dir := filepath.Dir(rel)
+	if dir == "." {
+		return true
+	}
+	current := root
+	for part := range strings.SplitSeq(dir, string(filepath.Separator)) {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+		current = filepath.Join(current, part)
+		if !s.descendPathIncluded(root, current) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s JSONLSourceSet) matchesExtension(path string) bool {
+	ext := filepath.Ext(path)
+	return slices.Contains(s.extensions, ext)
+}
+
+func (s JSONLSourceSet) includeGlobs() []string {
+	globs := make([]string, 0, len(s.extensions))
+	for _, ext := range s.extensions {
+		globs = append(globs, "*"+ext)
+	}
+	return globs
+}
+
+func (s JSONLSourceSet) sessionID(root, path string) string {
+	if s.options.SessionIDFromPath != nil {
+		return s.options.SessionIDFromPath(root, path)
+	}
+	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+}
+
+func (s JSONLSourceSet) lookupIDValid(rawID string) bool {
+	if s.options.LookupIDValid != nil {
+		return s.options.LookupIDValid(rawID)
+	}
+	return IsValidSessionID(rawID)
+}
+
+func (s JSONLSourceSet) pathFromSource(
+	ctx context.Context,
+	source SourceRef,
+) (string, bool, error) {
+	switch src := source.Opaque.(type) {
+	case JSONLSource:
+		if src.Path != "" {
+			return src.Path, true, nil
+		}
+	case *JSONLSource:
+		if src != nil && src.Path != "" {
+			return src.Path, true, nil
+		}
+	}
+	for _, candidate := range []string{
+		source.DisplayPath,
+		source.FingerprintKey,
+		source.Key,
+	} {
+		if ref, ok, err := s.sourceForPath(ctx, candidate); err != nil {
+			return "", false, err
+		} else if ok {
+			src := ref.Opaque.(JSONLSource)
+			return src.Path, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func cleanJSONLRoots(roots []string) []string {
+	cleaned := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		cleaned = append(cleaned, filepath.Clean(root))
+	}
+	return cleaned
+}
+
+func normalizeJSONLExtensions(exts []string) []string {
+	if len(exts) == 0 {
+		return []string{".jsonl"}
+	}
+	seen := make(map[string]struct{}, len(exts))
+	normalized := make([]string, 0, len(exts))
+	for _, ext := range exts {
+		if ext == "" {
+			continue
+		}
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
+		if _, ok := seen[ext]; ok {
+			continue
+		}
+		seen[ext] = struct{}{}
+		normalized = append(normalized, ext)
+	}
+	if len(normalized) == 0 {
+		return []string{".jsonl"}
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func addJSONLSource(
+	source SourceRef,
+	sources *[]SourceRef,
+	seen map[string]struct{},
+) bool {
+	key := string(source.Provider) + "\x00" + source.Key
+	if _, ok := seen[key]; ok {
+		return false
+	}
+	seen[key] = struct{}{}
+	*sources = append(*sources, source)
+	return true
+}
+
+func sortJSONLSources(sources []SourceRef) {
+	sort.Slice(sources, func(i, j int) bool {
+		if sources[i].DisplayPath != sources[j].DisplayPath {
+			return sources[i].DisplayPath < sources[j].DisplayPath
+		}
+		return sources[i].Key < sources[j].Key
+	})
+}
+
+func callPathFunc(fn func(root, path string) string, root, path string) string {
+	if fn == nil {
+		return ""
+	}
+	return fn(root, path)
+}
+
+func pathIsUnderRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != "." && rel != ".." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func samePath(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func firstNonEmptyJSONLString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func hashJSONLSourceFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash %s: %w", path, err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/internal/parser/jsonl_source_set_options.go
+++ b/internal/parser/jsonl_source_set_options.go
@@ -1,0 +1,139 @@
+package parser
+
+import (
+	"context"
+	"os"
+)
+
+// jsonlParseFileFunc parses one discovered source file into zero or more
+// sessions plus the IDs of any sessions to exclude.
+type jsonlParseFileFunc func(
+	ctx context.Context, path string, req ParseRequest,
+) ([]ParseResult, []string, error)
+
+// jsonlOption configures a JSONLSourceSet (or DirectoryJSONLSourceSet) at
+// construction. Options compose left to right; a later option of the same kind
+// overwrites an earlier one. Every field has a sensible zero value, so a source
+// set only states what differs from the default.
+type jsonlOption func(*JSONLSourceSetOptions)
+
+// --- discovery shape ---
+
+// withRecursive traverses subdirectories below each root rather than only the
+// direct children.
+func withRecursive() jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.Recursive = true }
+}
+
+// withExtensions restricts sources to the given file extensions (default
+// .jsonl). Matching is case-sensitive to mirror legacy discovery.
+func withExtensions(exts ...string) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.Extensions = exts }
+}
+
+// withContentHashing includes a full content hash in the source fingerprint.
+// Use only when size/mtime freshness is insufficient.
+func withContentHashing() jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.Hash = true }
+}
+
+// withSymlinkFollowing treats symlinks to both directories and regular files as
+// traversable/source candidates. It is the common bundle for providers whose
+// legacy discovery followed symlinked session trees.
+func withSymlinkFollowing() jsonlOption {
+	return func(o *JSONLSourceSetOptions) {
+		o.FollowSymlinkDirs = true
+		o.FollowSymlinkFiles = true
+	}
+}
+
+// withFollowSymlinkFiles treats symlinks to regular files as sources.
+func withFollowSymlinkFiles() jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.FollowSymlinkFiles = true }
+}
+
+// withDescendPath gates which directories recursive discovery descends into and
+// which source ancestors a changed path may sit under.
+func withDescendPath(fn func(root, path string) bool) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.DescendPath = fn }
+}
+
+// withIncludePath sets the path-only source predicate, also used for
+// deleted/renamed changed paths where os.FileInfo is unavailable.
+func withIncludePath(fn func(root, path string) bool) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.IncludePath = fn }
+}
+
+// withInclude sets a source predicate for existing files that also sees the
+// os.FileInfo. It is not called for deleted/renamed changed paths.
+func withInclude(fn func(path string, info os.FileInfo) bool) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.Include = fn }
+}
+
+// --- identity / metadata ---
+
+// withKey sets the stable per-source dedup key.
+func withKey(fn func(root, path string) string) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.Key = fn }
+}
+
+// withFingerprintKey overrides the persisted lookup/freshness identity when the
+// display path is not the value that should survive a provider migration.
+func withFingerprintKey(fn func(root, path string) string) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.FingerprintKey = fn }
+}
+
+// withProjectHint sets display-only project metadata for a source.
+func withProjectHint(fn func(root, path string) string) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.ProjectHint = fn }
+}
+
+// withSessionIDFromPath sets the raw (unprefixed) session ID used by FindSource
+// fallback lookups.
+func withSessionIDFromPath(fn func(root, path string) string) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.SessionIDFromPath = fn }
+}
+
+// --- lookup ---
+
+// withLookupIDValid overrides the IsValidSessionID gate for the FindSource
+// discovery fallback, for providers whose IDs carry separators it rejects.
+func withLookupIDValid(fn func(rawID string) bool) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.LookupIDValid = fn }
+}
+
+// withRawSessionIDForLookup normalizes a raw session ID before the FindSource
+// discovery comparison.
+func withRawSessionIDForLookup(fn func(rawID string) string) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.RawSessionIDForLookup = fn }
+}
+
+// withRawSessionIDSourceFiles reconstructs candidate file paths from a raw
+// session ID for providers whose IDs encode the on-disk layout.
+func withRawSessionIDSourceFiles(
+	fn func(roots []string, rawID string) []string,
+) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.RawSessionIDSourceFiles = fn }
+}
+
+// withStoredPathFallbackRoot resolves the configured root for a stored source
+// path that is not under any current root.
+func withStoredPathFallbackRoot(
+	fn func(storedPath string) (string, bool),
+) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.StoredPathFallbackRoot = fn }
+}
+
+// --- parse ---
+
+// withParseFile makes the source set a full SourceSet by supplying its parse
+// step. Leave it unset for discovery-only embedders that supply their own Parse.
+func withParseFile(fn jsonlParseFileFunc) jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.ParseFile = fn }
+}
+
+// withForceReplace marks every non-empty ParseFile outcome as a full
+// replacement of the source's existing sessions.
+func withForceReplace() jsonlOption {
+	return func(o *JSONLSourceSetOptions) { o.ForceReplace = true }
+}

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -1,0 +1,447 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+)
+
+// multi_session_container.go provides a reusable source-set, provider, and
+// factory for agents whose physical source is a *container* of many sessions
+// surfaced to the engine as virtual per-member paths. Shelley (one SQLite DB ->
+// many conversations) and Aider (one history file -> many runs) are the first
+// two providers built on it; Zed, Kiro, OpenCode, and the other multi-session
+// containers can follow.
+//
+// All agent-specific behavior is supplied through functional options (with*()),
+// so a new special case is added as a new option rather than by widening a
+// constructor or growing an interface.
+
+// multiSessionSource is the engine-visible Opaque payload for a container
+// source. MemberID == "" means the source is the whole container (fan out every
+// member on parse); a non-empty MemberID identifies a single member.
+type multiSessionSource struct {
+	Root      string
+	Path      string
+	Container string
+	MemberID  string
+}
+
+// multiSessionMatch is what a classifier or member lookup resolves to: the
+// canonical source path (a container path or a virtual member path) plus the
+// physical container and, for a member, its ID. ProjectHint is surfaced on the
+// SourceRef for providers that attribute a project at discovery time.
+type multiSessionMatch struct {
+	Path        string
+	Container   string
+	MemberID    string
+	ProjectHint string
+}
+
+type multiSessionConfig struct {
+	// discoverContainers returns the physical container paths under one root;
+	// each becomes a whole-container source that fans out on parse.
+	discoverContainers func(root string) []string
+	// discoverSources returns fully-formed matches under one root, for providers
+	// that surface individual members (or a mix of members and containers) at
+	// discovery time rather than one source per container. Mutually exclusive
+	// with discoverContainers.
+	discoverSources func(root string) []multiSessionMatch
+	// watchRoots returns the provider WatchPlan roots for the configured roots.
+	watchRoots func(roots []string) []WatchRoot
+	// classifyPath maps a stored or changed path to its container/member.
+	// allowMissing relaxes existence checks so a deleted container (or a sibling
+	// such as a SQLite WAL file) still classifies for changed-path tombstones.
+	classifyPath func(root, path string, allowMissing bool) (multiSessionMatch, bool)
+	// findMember resolves a raw session ID to its member match under one root.
+	findMember func(root, rawID string) (multiSessionMatch, bool)
+	// storedPathFallback resolves a stored path that classifyPath could not
+	// match directly (for example a canonical remote-sync path that must be
+	// mapped back onto a local container). Optional.
+	storedPathFallback func(root, path string) (multiSessionMatch, bool)
+	// fingerprint returns the source freshness fingerprint (Size/MTime/Hash);
+	// the base supplies the Key.
+	fingerprint func(src multiSessionSource) (SourceFingerprint, error)
+	// parseContainer parses every member of a container into one result each.
+	// The full ParseRequest is passed so a closure can read req.Machine and
+	// per-request hints such as req.Source.ProjectHint.
+	parseContainer func(src multiSessionSource, req ParseRequest) ([]ParseResult, error)
+	// parseMember parses a single member; a nil result is a clean no-session.
+	parseMember func(src multiSessionSource, req ParseRequest) (*ParseResult, error)
+	// memberPresent reports whether a source still exists for RequireFreshSource
+	// lookups. Optional; the default treats every source as present.
+	memberPresent func(src multiSessionSource) bool
+	// stampContainerHash stamps the request fingerprint hash onto every fanned
+	// out container result (used when all members share the container's content
+	// hash). Member parses are always stamped.
+	stampContainerHash bool
+}
+
+type multiSessionOption func(*multiSessionConfig)
+
+func withContainerDiscovery(fn func(root string) []string) multiSessionOption {
+	return func(c *multiSessionConfig) { c.discoverContainers = fn }
+}
+
+func withSourceDiscovery(
+	fn func(root string) []multiSessionMatch,
+) multiSessionOption {
+	return func(c *multiSessionConfig) { c.discoverSources = fn }
+}
+
+func withWatchRoots(fn func(roots []string) []WatchRoot) multiSessionOption {
+	return func(c *multiSessionConfig) { c.watchRoots = fn }
+}
+
+func withChangedPathClassifier(
+	fn func(root, path string, allowMissing bool) (multiSessionMatch, bool),
+) multiSessionOption {
+	return func(c *multiSessionConfig) { c.classifyPath = fn }
+}
+
+func withMemberLookup(
+	fn func(root, rawID string) (multiSessionMatch, bool),
+) multiSessionOption {
+	return func(c *multiSessionConfig) { c.findMember = fn }
+}
+
+func withStoredPathFallback(
+	fn func(root, path string) (multiSessionMatch, bool),
+) multiSessionOption {
+	return func(c *multiSessionConfig) { c.storedPathFallback = fn }
+}
+
+func withFingerprint(
+	fn func(src multiSessionSource) (SourceFingerprint, error),
+) multiSessionOption {
+	return func(c *multiSessionConfig) { c.fingerprint = fn }
+}
+
+func withContainerParse(
+	fn func(src multiSessionSource, req ParseRequest) ([]ParseResult, error),
+) multiSessionOption {
+	return func(c *multiSessionConfig) { c.parseContainer = fn }
+}
+
+func withMemberParse(
+	fn func(src multiSessionSource, req ParseRequest) (*ParseResult, error),
+) multiSessionOption {
+	return func(c *multiSessionConfig) { c.parseMember = fn }
+}
+
+func withMemberPresence(fn func(src multiSessionSource) bool) multiSessionOption {
+	return func(c *multiSessionConfig) { c.memberPresent = fn }
+}
+
+func withContainerHashStamping() multiSessionOption {
+	return func(c *multiSessionConfig) { c.stampContainerHash = true }
+}
+
+func newMultiSessionContainerSourceSet(
+	agent AgentType,
+	roots []string,
+	opts ...multiSessionOption,
+) multiSessionContainerSourceSet {
+	cfg := multiSessionConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	switch {
+	case cfg.discoverContainers == nil && cfg.discoverSources == nil:
+		panic("multi-session container: missing withContainerDiscovery or withSourceDiscovery")
+	case cfg.watchRoots == nil:
+		panic("multi-session container: missing withWatchRoots")
+	case cfg.classifyPath == nil:
+		panic("multi-session container: missing withChangedPathClassifier")
+	case cfg.findMember == nil:
+		panic("multi-session container: missing withMemberLookup")
+	case cfg.fingerprint == nil:
+		panic("multi-session container: missing withFingerprint")
+	case cfg.parseContainer == nil:
+		panic("multi-session container: missing withContainerParse")
+	case cfg.parseMember == nil:
+		panic("multi-session container: missing withMemberParse")
+	}
+	return multiSessionContainerSourceSet{
+		agent: agent,
+		roots: cleanJSONLRoots(roots),
+		cfg:   cfg,
+	}
+}
+
+type multiSessionContainerSourceSet struct {
+	agent AgentType
+	roots []string
+	cfg   multiSessionConfig
+}
+
+func (s multiSessionContainerSourceSet) Discover(
+	ctx context.Context,
+) ([]SourceRef, error) {
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for _, match := range s.discoverMatches(root) {
+			if match.Path == "" {
+				continue
+			}
+			addJSONLSource(s.sourceRef(root, match), &sources, seen)
+		}
+	}
+	sortJSONLSources(sources)
+	return sources, nil
+}
+
+// discoverMatches yields the discovery matches for one root: either the
+// member-level matches from withSourceDiscovery, or one whole-container match
+// per path from withContainerDiscovery.
+func (s multiSessionContainerSourceSet) discoverMatches(
+	root string,
+) []multiSessionMatch {
+	if s.cfg.discoverSources != nil {
+		return s.cfg.discoverSources(root)
+	}
+	containers := s.cfg.discoverContainers(root)
+	out := make([]multiSessionMatch, 0, len(containers))
+	for _, container := range containers {
+		if container == "" {
+			continue
+		}
+		out = append(out, multiSessionMatch{Path: container, Container: container})
+	}
+	return out
+}
+
+func (s multiSessionContainerSourceSet) WatchPlan(
+	context.Context,
+) (WatchPlan, error) {
+	return WatchPlan{Roots: s.cfg.watchRoots(s.roots)}, nil
+}
+
+func (s multiSessionContainerSourceSet) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for _, root := range s.roots {
+		if match, ok := s.cfg.classifyPath(root, req.Path, true); ok {
+			return []SourceRef{s.sourceRef(root, match)}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s multiSessionContainerSourceSet) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, path := range []string{req.StoredFilePath, req.FingerprintKey} {
+		if path == "" {
+			continue
+		}
+		for _, root := range s.roots {
+			match, ok := s.cfg.classifyPath(root, path, false)
+			if !ok {
+				continue
+			}
+			source := s.sourceRef(root, match)
+			if req.RequireFreshSource && !s.memberPresent(match.toSource(root)) {
+				continue
+			}
+			return source, true, nil
+		}
+		if s.cfg.storedPathFallback != nil {
+			for _, root := range s.roots {
+				if match, ok := s.cfg.storedPathFallback(root, path); ok {
+					return s.sourceRef(root, match), true, nil
+				}
+			}
+		}
+	}
+	if req.RawSessionID == "" {
+		return SourceRef{}, false, nil
+	}
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return SourceRef{}, false, err
+		}
+		if match, ok := s.cfg.findMember(root, req.RawSessionID); ok {
+			return s.sourceRef(root, match), true, nil
+		}
+	}
+	return SourceRef{}, false, nil
+}
+
+func (s multiSessionContainerSourceSet) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceFingerprint{}, err
+	}
+	src, ok := s.sourceFromRef(source)
+	if !ok {
+		return SourceFingerprint{}, fmt.Errorf("%s source path unavailable", s.agent)
+	}
+	fingerprint, err := s.cfg.fingerprint(src)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	fingerprint.Key = firstNonEmptyJSONLString(
+		source.FingerprintKey, source.Key, src.Path,
+	)
+	return fingerprint, nil
+}
+
+func (s multiSessionContainerSourceSet) parse(
+	src multiSessionSource, req ParseRequest,
+) (ParseOutcome, error) {
+	fingerprintHash := req.Fingerprint.Hash
+	if src.MemberID != "" {
+		result, err := s.cfg.parseMember(src, req)
+		if err != nil {
+			return ParseOutcome{}, err
+		}
+		if result == nil {
+			return multiSessionSkipOutcome(), nil
+		}
+		if fingerprintHash != "" {
+			result.Session.File.Hash = fingerprintHash
+		}
+		return ParseOutcome{
+			Results: []ParseResultOutcome{{
+				Result:      *result,
+				DataVersion: DataVersionCurrent,
+			}},
+			ResultSetComplete: true,
+			ForceReplace:      true,
+		}, nil
+	}
+
+	results, err := s.cfg.parseContainer(src, req)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if len(results) == 0 {
+		return multiSessionSkipOutcome(), nil
+	}
+	out := make([]ParseResultOutcome, 0, len(results))
+	for i := range results {
+		if fingerprintHash != "" && s.cfg.stampContainerHash {
+			results[i].Session.File.Hash = fingerprintHash
+		}
+		out = append(out, ParseResultOutcome{
+			Result:      results[i],
+			DataVersion: DataVersionCurrent,
+		})
+	}
+	return ParseOutcome{
+		Results:           out,
+		ResultSetComplete: true,
+		ForceReplace:      true,
+	}, nil
+}
+
+func multiSessionSkipOutcome() ParseOutcome {
+	return ParseOutcome{
+		ResultSetComplete: true,
+		ForceReplace:      true,
+		SkipReason:        SkipNoSession,
+	}
+}
+
+func (s multiSessionContainerSourceSet) memberPresent(src multiSessionSource) bool {
+	if s.cfg.memberPresent == nil {
+		return true
+	}
+	return s.cfg.memberPresent(src)
+}
+
+func (s multiSessionContainerSourceSet) sourceRef(
+	root string, match multiSessionMatch,
+) SourceRef {
+	return SourceRef{
+		Provider:       s.agent,
+		Key:            match.Path,
+		DisplayPath:    match.Path,
+		FingerprintKey: match.Path,
+		ProjectHint:    match.ProjectHint,
+		Opaque:         match.toSource(root),
+	}
+}
+
+func (m multiSessionMatch) toSource(root string) multiSessionSource {
+	return multiSessionSource{
+		Root:      root,
+		Path:      m.Path,
+		Container: m.Container,
+		MemberID:  m.MemberID,
+	}
+}
+
+func (s multiSessionContainerSourceSet) sourceFromRef(
+	source SourceRef,
+) (multiSessionSource, bool) {
+	switch src := source.Opaque.(type) {
+	case multiSessionSource:
+		return src, src.Container != "" && src.Path != ""
+	case *multiSessionSource:
+		if src != nil && src.Container != "" && src.Path != "" {
+			return *src, true
+		}
+	}
+	for _, candidate := range []string{
+		source.DisplayPath, source.FingerprintKey, source.Key,
+	} {
+		if candidate == "" {
+			continue
+		}
+		for _, root := range s.roots {
+			if match, ok := s.cfg.classifyPath(root, candidate, false); ok {
+				return match.toSource(root), true
+			}
+		}
+	}
+	return multiSessionSource{}, false
+}
+
+var _ SourceSet = multiSessionContainerSourceSet{}
+
+// Parse resolves the request's source and parses it: a member source yields one
+// result, a container source fans out every member. It satisfies the SourceSet
+// interface; sourceSetProvider applies the request/config machine fallback
+// before calling in, so req.Machine is already resolved here.
+func (s multiSessionContainerSourceSet) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	if err := ctx.Err(); err != nil {
+		return ParseOutcome{}, err
+	}
+	src, ok := s.sourceFromRef(req.Source)
+	if !ok {
+		return ParseOutcome{}, fmt.Errorf("%s source path unavailable", s.agent)
+	}
+	return s.parse(src, req)
+}
+
+// newMultiSessionProviderFactory builds a ProviderFactory for a multi-session
+// container provider. It is a thin adapter over the generic sourceSetFactory;
+// the build closure constructs the agent's configured source set.
+func newMultiSessionProviderFactory(
+	def AgentDef,
+	caps Capabilities,
+	build func(cfg ProviderConfig) multiSessionContainerSourceSet,
+) ProviderFactory {
+	return newSourceSetFactory(
+		def, caps,
+		func(cfg ProviderConfig) SourceSet { return build(cfg) },
+	)
+}

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -199,6 +199,7 @@ type FindSourceRequest struct {
 	StoredFilePath     string
 	FingerprintKey     string
 	RequireFreshSource bool
+	PreferStoredSource bool
 }
 
 // SourceFingerprint is the provider-normalized source freshness identity.

--- a/internal/parser/provider_lookup.go
+++ b/internal/parser/provider_lookup.go
@@ -1,0 +1,37 @@
+package parser
+
+import "strings"
+
+func providerFindRequestWithRawSessionID(
+	def AgentDef,
+	req FindSourceRequest,
+) FindSourceRequest {
+	if req.RawSessionID != "" {
+		req.RawSessionID = providerNormalizeRawSessionID(def, req.RawSessionID)
+		return req
+	}
+	req.RawSessionID = providerRawSessionIDFromFull(def, req.FullSessionID)
+	return req
+}
+
+func providerNormalizeRawSessionID(def AgentDef, id string) string {
+	_, id = StripHostPrefix(id)
+	if def.IDPrefix != "" && strings.HasPrefix(id, def.IDPrefix) {
+		return strings.TrimPrefix(id, def.IDPrefix)
+	}
+	return id
+}
+
+func providerRawSessionIDFromFull(def AgentDef, id string) string {
+	if id == "" {
+		return ""
+	}
+	_, rawID := StripHostPrefix(id)
+	if def.IDPrefix == "" {
+		return rawID
+	}
+	if !strings.HasPrefix(rawID, def.IDPrefix) {
+		return ""
+	}
+	return strings.TrimPrefix(rawID, def.IDPrefix)
+}

--- a/internal/parser/sibling_metadata_source_set.go
+++ b/internal/parser/sibling_metadata_source_set.go
@@ -1,0 +1,206 @@
+package parser
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SiblingMetadataSourceSetOptions configures companion files that should map
+// back to a primary JSONL source.
+type SiblingMetadataSourceSetOptions struct {
+	SiblingGlobs         []string
+	SiblingPaths         func(root, sourcePath string) []string
+	SourcePathForSibling func(root, siblingPath string) (string, bool)
+}
+
+// SiblingMetadataSourceSet extends JSONLSourceSet for source layouts where a
+// primary transcript file has sibling metadata files that affect freshness.
+type SiblingMetadataSourceSet struct {
+	JSONLSourceSet
+	siblingOptions SiblingMetadataSourceSetOptions
+}
+
+// NewSiblingMetadataSourceSet returns a JSONL source helper with sibling
+// metadata event and fingerprint support.
+func NewSiblingMetadataSourceSet(
+	provider AgentType,
+	roots []string,
+	options JSONLSourceSetOptions,
+	siblingOptions SiblingMetadataSourceSetOptions,
+) SiblingMetadataSourceSet {
+	return SiblingMetadataSourceSet{
+		JSONLSourceSet: jsonlSourceSetFromOptions(provider, roots, options),
+		siblingOptions: siblingOptions,
+	}
+}
+
+func (s SiblingMetadataSourceSet) WatchPlan(ctx context.Context) (WatchPlan, error) {
+	plan, err := s.JSONLSourceSet.WatchPlan(ctx)
+	if err != nil {
+		return WatchPlan{}, err
+	}
+	for i := range plan.Roots {
+		plan.Roots[i].IncludeGlobs = append(
+			plan.Roots[i].IncludeGlobs,
+			s.siblingOptions.SiblingGlobs...,
+		)
+	}
+	return plan, nil
+}
+
+func (s SiblingMetadataSourceSet) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	sources, err := s.JSONLSourceSet.SourcesForChangedPath(ctx, req)
+	if err != nil || len(sources) > 0 {
+		return sources, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if s.siblingOptions.SourcePathForSibling == nil {
+		return nil, nil
+	}
+	for _, root := range s.roots {
+		if req.WatchRoot != "" && !samePath(req.WatchRoot, root) {
+			continue
+		}
+		sourcePath, ok := s.siblingOptions.SourcePathForSibling(root, req.Path)
+		if !ok {
+			continue
+		}
+		source, ok, err := s.sourceForPath(ctx, sourcePath)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return []SourceRef{source}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s SiblingMetadataSourceSet) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceFingerprint{}, err
+	}
+	resolved, ok, err := s.sourceFromRef(ctx, source)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	if !ok {
+		return SourceFingerprint{}, fmt.Errorf("sibling metadata source path unavailable")
+	}
+	src := resolved.Opaque.(JSONLSource)
+	path := src.Path
+	info, err := os.Stat(path)
+	if err != nil {
+		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", path)
+	}
+	fingerprint := SourceFingerprint{
+		Key:     firstNonEmptyJSONLString(source.FingerprintKey, source.Key, path),
+		Size:    info.Size(),
+		MTimeNS: info.ModTime().UnixNano(),
+	}
+	h := sha256.New()
+	if err := addSiblingMetadataFingerprintPart(h, "source", path, info); err != nil {
+		return SourceFingerprint{}, err
+	}
+	if s.siblingOptions.SiblingPaths != nil {
+		for _, siblingPath := range s.siblingOptions.SiblingPaths(src.Root, path) {
+			siblingInfo, err := siblingMetadataFileInfo(siblingPath)
+			if err != nil {
+				return SourceFingerprint{}, err
+			}
+			if siblingInfo == nil {
+				continue
+			}
+			fingerprint.Size += siblingInfo.Size()
+			if siblingMTime := siblingInfo.ModTime().UnixNano(); siblingMTime > fingerprint.MTimeNS {
+				fingerprint.MTimeNS = siblingMTime
+			}
+			if err := addSiblingMetadataFingerprintPart(
+				h, "sibling", siblingPath, siblingInfo,
+			); err != nil {
+				return SourceFingerprint{}, err
+			}
+		}
+	}
+	fingerprint.Hash = fmt.Sprintf("%x", h.Sum(nil))
+	return fingerprint, nil
+}
+
+func (s SiblingMetadataSourceSet) sourceFromRef(
+	ctx context.Context,
+	source SourceRef,
+) (SourceRef, bool, error) {
+	switch src := source.Opaque.(type) {
+	case JSONLSource:
+		if src.Root != "" && src.Path != "" {
+			return source, true, nil
+		}
+	case *JSONLSource:
+		if src != nil && src.Root != "" && src.Path != "" {
+			source.Opaque = *src
+			return source, true, nil
+		}
+	}
+	for _, candidate := range []string{
+		source.DisplayPath,
+		source.FingerprintKey,
+		source.Key,
+	} {
+		if ref, ok, err := s.sourceForPath(ctx, candidate); err != nil {
+			return SourceRef{}, false, err
+		} else if ok {
+			return ref, true, nil
+		}
+	}
+	return SourceRef{}, false, nil
+}
+
+func siblingMetadataFileInfo(path string) (os.FileInfo, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return nil, nil
+	}
+	return info, nil
+}
+
+func addSiblingMetadataFingerprintPart(
+	h interface{ Write([]byte) (int, error) },
+	label string,
+	path string,
+	info os.FileInfo,
+) error {
+	hash, err := hashJSONLSourceFile(path)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(
+		h,
+		"%s:%s:%d:%d:%s\n",
+		label,
+		filepath.Base(path),
+		info.Size(),
+		info.ModTime().UnixNano(),
+		hash,
+	)
+	return nil
+}

--- a/internal/parser/single_file_source_set.go
+++ b/internal/parser/single_file_source_set.go
@@ -1,0 +1,355 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+)
+
+// single_file_source_set.go provides a reusable SourceSet for providers whose
+// physical source is a single file that parses into exactly one session: no
+// virtual member paths and no fan-out. Reasonix (transcript + .jsonl.meta
+// sidecar) is the first provider built on it; the other sidecar-fingerprint
+// providers (vibe, commandcode, ...) can follow.
+//
+// Like multiSessionContainerSourceSet, all agent-specific behavior is supplied
+// through functional options (withFile*()), and the type implements SourceSet
+// so it plugs into newSourceSetFactory. The composite/sidecar fingerprint
+// variance lives entirely inside each provider's withFileFingerprint closure,
+// so the base stays agnostic about sidecars until a shared helper is warranted.
+
+// singleFileSource is the engine-visible Opaque payload for a single-file
+// source: one physical file under a configured root.
+type singleFileSource struct {
+	Root string
+	Path string
+}
+
+// singleFileMatch is what discovery, classification, and lookup resolve to: the
+// canonical source path plus an optional project hint surfaced on the SourceRef.
+type singleFileMatch struct {
+	Path        string
+	ProjectHint string
+}
+
+func (m singleFileMatch) toSource(root string) singleFileSource {
+	return singleFileSource{Root: root, Path: m.Path}
+}
+
+type singleFileConfig struct {
+	// discoverFiles returns the source files under one root.
+	discoverFiles func(root string) []singleFileMatch
+	// watchRoots returns the provider WatchPlan roots for the configured roots.
+	watchRoots func(roots []string) []WatchRoot
+	// classifyPath maps a stored or changed path (including a sidecar event) to
+	// its source. allowMissing relaxes existence checks for changed-path
+	// tombstones.
+	classifyPath func(root, path string, allowMissing bool) (singleFileMatch, bool)
+	// findFile resolves a raw session ID to its source under one root.
+	findFile func(root, rawID string) (singleFileMatch, bool)
+	// fingerprint returns the source freshness fingerprint (Size/MTime/Hash);
+	// the base supplies the Key. Sidecar/composite folding lives here.
+	fingerprint func(src singleFileSource) (SourceFingerprint, error)
+	// parseFile parses the single file into zero or more sessions plus the IDs
+	// of any sessions to exclude (remove). Empty results with no exclusions is a
+	// clean no-session. The full ParseRequest is passed so the closure can apply
+	// its own fingerprint stamping and project-hint fallback.
+	parseFile func(src singleFileSource, req ParseRequest) ([]ParseResult, []string, error)
+	// alwaysComplete reports the result set as complete even when parseFile
+	// yields nothing, instead of emitting SkipNoSession. Providers whose parse
+	// drives session removal through exclusions (cowork) set this.
+	alwaysComplete bool
+}
+
+type singleFileOption func(*singleFileConfig)
+
+func withFileDiscovery(
+	fn func(root string) []singleFileMatch,
+) singleFileOption {
+	return func(c *singleFileConfig) { c.discoverFiles = fn }
+}
+
+func withFileWatchRoots(
+	fn func(roots []string) []WatchRoot,
+) singleFileOption {
+	return func(c *singleFileConfig) { c.watchRoots = fn }
+}
+
+func withFileChangedPathClassifier(
+	fn func(root, path string, allowMissing bool) (singleFileMatch, bool),
+) singleFileOption {
+	return func(c *singleFileConfig) { c.classifyPath = fn }
+}
+
+func withFileLookup(
+	fn func(root, rawID string) (singleFileMatch, bool),
+) singleFileOption {
+	return func(c *singleFileConfig) { c.findFile = fn }
+}
+
+func withFileFingerprint(
+	fn func(src singleFileSource) (SourceFingerprint, error),
+) singleFileOption {
+	return func(c *singleFileConfig) { c.fingerprint = fn }
+}
+
+func withFileParse(
+	fn func(src singleFileSource, req ParseRequest) ([]ParseResult, []string, error),
+) singleFileOption {
+	return func(c *singleFileConfig) { c.parseFile = fn }
+}
+
+// withAlwaysCompleteResultSet reports the result set as complete even when a
+// parse yields no sessions, instead of skipping. Used by providers whose parse
+// removes sessions via exclusions.
+func withAlwaysCompleteResultSet() singleFileOption {
+	return func(c *singleFileConfig) { c.alwaysComplete = true }
+}
+
+func newSingleFileSourceSet(
+	agent AgentType,
+	roots []string,
+	opts ...singleFileOption,
+) singleFileSourceSet {
+	cfg := singleFileConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	switch {
+	case cfg.discoverFiles == nil:
+		panic("single-file source set: missing withFileDiscovery")
+	case cfg.watchRoots == nil:
+		panic("single-file source set: missing withFileWatchRoots")
+	case cfg.classifyPath == nil:
+		panic("single-file source set: missing withFileChangedPathClassifier")
+	case cfg.findFile == nil:
+		panic("single-file source set: missing withFileLookup")
+	case cfg.fingerprint == nil:
+		panic("single-file source set: missing withFileFingerprint")
+	case cfg.parseFile == nil:
+		panic("single-file source set: missing withFileParse")
+	}
+	return singleFileSourceSet{
+		agent: agent,
+		roots: cleanJSONLRoots(roots),
+		cfg:   cfg,
+	}
+}
+
+type singleFileSourceSet struct {
+	agent AgentType
+	roots []string
+	cfg   singleFileConfig
+}
+
+var _ SourceSet = singleFileSourceSet{}
+
+func (s singleFileSourceSet) Discover(
+	ctx context.Context,
+) ([]SourceRef, error) {
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for _, match := range s.cfg.discoverFiles(root) {
+			if match.Path == "" {
+				continue
+			}
+			addJSONLSource(s.sourceRef(root, match), &sources, seen)
+		}
+	}
+	sortJSONLSources(sources)
+	return sources, nil
+}
+
+func (s singleFileSourceSet) WatchPlan(
+	context.Context,
+) (WatchPlan, error) {
+	return WatchPlan{Roots: s.cfg.watchRoots(s.roots)}, nil
+}
+
+func (s singleFileSourceSet) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	allowMissing := jsonlMissingPathFallbackAllowed(req)
+	// A watch event may originate from a configured root or one of its watched
+	// subdirectories; resolve it back to the owning configured root before
+	// classifying, so per-subdir watches attribute correctly.
+	if req.WatchRoot != "" {
+		watchRoot := filepath.Clean(req.WatchRoot)
+		for _, configured := range s.roots {
+			if watchRoot == configured || samePath(watchRoot, configured) ||
+				pathUnderRoot(configured, watchRoot) {
+				if match, ok := s.cfg.classifyPath(configured, req.Path, allowMissing); ok {
+					return []SourceRef{s.sourceRef(configured, match)}, nil
+				}
+				return nil, nil
+			}
+		}
+		return nil, nil
+	}
+	for _, root := range s.roots {
+		if match, ok := s.cfg.classifyPath(root, req.Path, allowMissing); ok {
+			return []SourceRef{s.sourceRef(root, match)}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s singleFileSourceSet) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, path := range []string{req.StoredFilePath, req.FingerprintKey} {
+		if path == "" {
+			continue
+		}
+		for _, root := range s.roots {
+			if match, ok := s.cfg.classifyPath(root, path, false); ok {
+				return s.sourceRef(root, match), true, nil
+			}
+		}
+	}
+	if req.RawSessionID == "" {
+		return SourceRef{}, false, nil
+	}
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return SourceRef{}, false, err
+		}
+		if match, ok := s.cfg.findFile(root, req.RawSessionID); ok {
+			return s.sourceRef(root, match), true, nil
+		}
+	}
+	return SourceRef{}, false, nil
+}
+
+func (s singleFileSourceSet) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceFingerprint{}, err
+	}
+	src, ok := s.sourceFromRef(source)
+	if !ok {
+		return SourceFingerprint{}, fmt.Errorf(
+			"%s source path unavailable", s.agent,
+		)
+	}
+	fingerprint, err := s.cfg.fingerprint(src)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	fingerprint.Key = firstNonEmptyJSONLString(
+		source.FingerprintKey, source.Key, src.Path,
+	)
+	return fingerprint, nil
+}
+
+// Parse resolves the request's source and parses its single file into one
+// session. It satisfies the SourceSet interface; sourceSetProvider applies the
+// request/config machine fallback before calling in, so req.Machine is already
+// resolved here.
+func (s singleFileSourceSet) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	if err := ctx.Err(); err != nil {
+		return ParseOutcome{}, err
+	}
+	src, ok := s.sourceFromRef(req.Source)
+	if !ok {
+		return ParseOutcome{}, fmt.Errorf("%s source path unavailable", s.agent)
+	}
+	results, excluded, err := s.cfg.parseFile(src, req)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if !s.cfg.alwaysComplete && len(results) == 0 && len(excluded) == 0 {
+		return ParseOutcome{
+			ResultSetComplete: true,
+			SkipReason:        SkipNoSession,
+		}, nil
+	}
+	out := make([]ParseResultOutcome, 0, len(results))
+	for i := range results {
+		out = append(out, ParseResultOutcome{
+			Result:      results[i],
+			DataVersion: DataVersionCurrent,
+		})
+	}
+	return ParseOutcome{
+		Results:            out,
+		ExcludedSessionIDs: excluded,
+		ResultSetComplete:  true,
+	}, nil
+}
+
+func (s singleFileSourceSet) sourceRef(
+	root string, match singleFileMatch,
+) SourceRef {
+	return SourceRef{
+		Provider:       s.agent,
+		Key:            match.Path,
+		DisplayPath:    match.Path,
+		FingerprintKey: match.Path,
+		ProjectHint:    match.ProjectHint,
+		Opaque:         match.toSource(root),
+	}
+}
+
+func (s singleFileSourceSet) sourceFromRef(
+	source SourceRef,
+) (singleFileSource, bool) {
+	switch src := source.Opaque.(type) {
+	case singleFileSource:
+		return src, src.Path != ""
+	case *singleFileSource:
+		if src != nil && src.Path != "" {
+			return *src, true
+		}
+	}
+	for _, candidate := range []string{
+		source.DisplayPath, source.FingerprintKey, source.Key,
+	} {
+		if candidate == "" {
+			continue
+		}
+		for _, root := range s.roots {
+			if match, ok := s.cfg.classifyPath(root, candidate, false); ok {
+				return match.toSource(root), true
+			}
+		}
+	}
+	return singleFileSource{}, false
+}
+
+// newSingleFileProviderFactory builds a ProviderFactory for a single-file
+// provider. It is a thin adapter over the generic sourceSetFactory; the build
+// closure constructs the agent's configured source set.
+func newSingleFileProviderFactory(
+	def AgentDef,
+	caps Capabilities,
+	build func(cfg ProviderConfig) singleFileSourceSet,
+) ProviderFactory {
+	return newSourceSetFactory(
+		def, caps,
+		func(cfg ProviderConfig) SourceSet { return build(cfg) },
+	)
+}
+
+// pathUnderRoot reports whether candidate is root itself or nested under it.
+func pathUnderRoot(root, candidate string) bool {
+	_, ok := relUnder(filepath.Clean(root), filepath.Clean(candidate))
+	return ok
+}

--- a/internal/parser/source_set.go
+++ b/internal/parser/source_set.go
@@ -1,0 +1,126 @@
+package parser
+
+import "context"
+
+// source_set.go provides the generic plumbing shared by every reusable
+// source-set base. A SourceSet owns source resolution and parsing for one
+// provider; sourceSetProvider wraps any SourceSet into a full Provider, and
+// sourceSetFactory builds those providers from an AgentDef + Capabilities + a
+// per-config constructor.
+//
+// The point is that a base such as multiSessionContainerSourceSet (or
+// singleFileSourceSet) implements SourceSet once and reuses this factory and
+// this delegating provider, instead of each base re-hand-rolling the
+// Definition/Capabilities/NewProvider factory and the six forwarding provider
+// methods. Provider-level concerns that every provider shares -- folding the
+// raw session ID into FindSource requests, and the request/config machine
+// fallback for Parse -- live here so the SourceSet implementations stay focused
+// on agent-specific source logic.
+
+// SourceSet is the source-resolution and parse core that a Provider delegates
+// to. It is the Provider interface minus the Definition/Capabilities/config
+// plumbing (supplied by sourceSetProvider) and minus ParseIncremental (which
+// falls through to the ProviderBase "unsupported" default until a base needs
+// it).
+type SourceSet interface {
+	Discover(context.Context) ([]SourceRef, error)
+	WatchPlan(context.Context) (WatchPlan, error)
+	SourcesForChangedPath(
+		context.Context, ChangedPathRequest,
+	) ([]SourceRef, error)
+	FindSource(context.Context, FindSourceRequest) (SourceRef, bool, error)
+	Fingerprint(context.Context, SourceRef) (SourceFingerprint, error)
+	Parse(context.Context, ParseRequest) (ParseOutcome, error)
+}
+
+// sourceSetProvider adapts a SourceSet to the Provider interface. It supplies
+// the AgentDef/Capabilities/config carried by ProviderBase, forwards the source
+// methods to the SourceSet, and applies the two provider-level normalizations
+// every provider performs: raw-session-ID injection on FindSource and the
+// machine fallback on Parse. ParseIncremental is inherited from ProviderBase
+// (unsupported) until a base opts in.
+type sourceSetProvider struct {
+	ProviderBase
+	sources SourceSet
+}
+
+func (p *sourceSetProvider) Discover(ctx context.Context) ([]SourceRef, error) {
+	return p.sources.Discover(ctx)
+}
+
+func (p *sourceSetProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
+	return p.sources.WatchPlan(ctx)
+}
+
+func (p *sourceSetProvider) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *sourceSetProvider) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	return p.sources.FindSource(
+		ctx, providerFindRequestWithRawSessionID(p.Def, req),
+	)
+}
+
+func (p *sourceSetProvider) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *sourceSetProvider) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	req.Machine = firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
+	return p.sources.Parse(ctx, req)
+}
+
+// sourceSetFactory is the generic ProviderFactory for any SourceSet-backed
+// provider. build constructs the SourceSet from the cloned per-provider config
+// (roots, machine, path rewriter), so a base captures whatever config it needs
+// in a closure rather than threading it through a struct.
+type sourceSetFactory struct {
+	def   AgentDef
+	caps  Capabilities
+	build func(cfg ProviderConfig) SourceSet
+}
+
+func newSourceSetFactory(
+	def AgentDef,
+	caps Capabilities,
+	build func(cfg ProviderConfig) SourceSet,
+) ProviderFactory {
+	return sourceSetFactory{
+		def:   cloneAgentDef(def),
+		caps:  caps,
+		build: build,
+	}
+}
+
+func (f sourceSetFactory) Definition() AgentDef {
+	return cloneAgentDef(f.def)
+}
+
+func (f sourceSetFactory) Capabilities() Capabilities {
+	return f.caps
+}
+
+func (f sourceSetFactory) NewProvider(cfg ProviderConfig) Provider {
+	cfg = cfg.Clone()
+	return &sourceSetProvider{
+		ProviderBase: ProviderBase{
+			Def:    cloneAgentDef(f.def),
+			Caps:   f.caps,
+			Config: cfg,
+		},
+		sources: f.build(cfg),
+	}
+}

--- a/internal/parser/sqlite_fanout_source_set.go
+++ b/internal/parser/sqlite_fanout_source_set.go
@@ -1,0 +1,353 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SQLiteFanoutSessionMeta describes one logical session inside a shared SQLite
+// database source.
+type SQLiteFanoutSessionMeta struct {
+	SessionID   string
+	VirtualPath string
+	FileMtime   int64
+}
+
+// SQLiteFanoutSourceSetOptions configures SQLite fan-out source discovery.
+// FindDB returns the canonical SQLite database path for a root. Discovery,
+// virtual source lookup, changed-path fan-out, and watch planning all use that
+// path as the source of truth. If FindDB returns an empty path, the helper falls
+// back to <root>/<DBName> so stored tombstone virtual paths still resolve.
+type SQLiteFanoutSourceSetOptions struct {
+	DBName   string
+	FindDB   func(root string) string
+	ListMeta func(dbPath string) ([]SQLiteFanoutSessionMeta, error)
+}
+
+// SQLiteFanoutSource is the in-memory payload stored in SQLite fan-out
+// SourceRefs.
+type SQLiteFanoutSource struct {
+	Root      string
+	DBPath    string
+	SessionID string
+}
+
+// SQLiteFanoutSourceSet discovers one SourceRef per logical session inside a
+// shared SQLite database file.
+type SQLiteFanoutSourceSet struct {
+	provider AgentType
+	roots    []string
+	options  SQLiteFanoutSourceSetOptions
+}
+
+func NewSQLiteFanoutSourceSet(
+	provider AgentType,
+	roots []string,
+	options SQLiteFanoutSourceSetOptions,
+) SQLiteFanoutSourceSet {
+	return SQLiteFanoutSourceSet{
+		provider: provider,
+		roots:    cleanJSONLRoots(roots),
+		options:  options,
+	}
+}
+
+func (s SQLiteFanoutSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		dbPath := s.findDB(root)
+		if dbPath == "" {
+			continue
+		}
+		metas, err := s.listMeta(dbPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, meta := range metas {
+			addJSONLSource(s.newSourceRef(root, dbPath, meta), &sources, seen)
+		}
+	}
+	sortJSONLSources(sources)
+	return sources, nil
+}
+
+func (s SQLiteFanoutSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
+	roots := make([]WatchRoot, 0, len(s.roots))
+	for _, root := range s.roots {
+		dbPath := s.canonicalDBPath(root)
+		if dbPath == "" {
+			continue
+		}
+		dbName := filepath.Base(dbPath)
+		roots = append(roots, WatchRoot{
+			Path:         filepath.Dir(dbPath),
+			Recursive:    false,
+			IncludeGlobs: []string{dbName, dbName + "-wal", dbName + "-shm"},
+			DebounceKey:  string(s.provider) + ":sqlite:" + dbPath,
+		})
+	}
+	return WatchPlan{Roots: roots}, nil
+}
+
+func (s SQLiteFanoutSourceSet) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for _, root := range s.roots {
+		if req.WatchRoot != "" && !s.watchRootMatches(root, req.WatchRoot) {
+			continue
+		}
+		if ref, ok := s.sourceRef(root, req.Path, true); ok {
+			return []SourceRef{ref}, nil
+		}
+		dbPath, ok := s.dbPathForEvent(root, req.Path)
+		if !ok {
+			continue
+		}
+		metas, err := s.listMeta(dbPath)
+		if err != nil {
+			return nil, err
+		}
+		sources := make([]SourceRef, 0, len(metas))
+		seen := make(map[string]struct{}, len(metas))
+		for _, meta := range metas {
+			addJSONLSource(s.newSourceRef(root, dbPath, meta), &sources, seen)
+		}
+		for _, storedPath := range req.StoredSourcePaths {
+			ref, ok := s.sourceRef(root, storedPath, true)
+			if !ok {
+				continue
+			}
+			src := ref.Opaque.(SQLiteFanoutSource)
+			if samePath(src.DBPath, dbPath) {
+				addJSONLSource(ref, &sources, seen)
+			}
+		}
+		sortJSONLSources(sources)
+		return sources, nil
+	}
+	return nil, nil
+}
+
+func (s SQLiteFanoutSourceSet) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	freshStoredSource := req.RequireFreshSource &&
+		(req.StoredFilePath != "" || req.FingerprintKey != "")
+	for _, path := range []string{req.StoredFilePath, req.FingerprintKey} {
+		if path == "" {
+			continue
+		}
+		for _, root := range s.roots {
+			source, ok := s.sourceRef(root, path, true)
+			if !ok {
+				continue
+			}
+			src := source.Opaque.(SQLiteFanoutSource)
+			if req.RawSessionID != "" && src.SessionID != req.RawSessionID {
+				continue
+			}
+			if req.RequireFreshSource {
+				fresh, err := s.sourceExists(src)
+				if err != nil {
+					return SourceRef{}, false, err
+				}
+				if !fresh {
+					continue
+				}
+			}
+			return source, true, nil
+		}
+	}
+	if freshStoredSource || req.RawSessionID == "" {
+		return SourceRef{}, false, nil
+	}
+	for _, root := range s.roots {
+		dbPath := s.findDB(root)
+		if dbPath == "" {
+			continue
+		}
+		metas, err := s.listMeta(dbPath)
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		for _, meta := range metas {
+			if meta.SessionID == req.RawSessionID {
+				return s.newSourceRef(root, dbPath, meta), true, nil
+			}
+		}
+	}
+	return SourceRef{}, false, nil
+}
+
+func (s SQLiteFanoutSourceSet) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceFingerprint{}, err
+	}
+	src, ok := s.sourceFromRef(source)
+	if !ok {
+		return SourceFingerprint{}, fmt.Errorf("%s sqlite fan-out source path unavailable", s.provider)
+	}
+	key := firstNonEmptyJSONLString(source.FingerprintKey, source.Key, src.virtualPath())
+	if _, err := os.Stat(src.DBPath); err != nil {
+		if os.IsNotExist(err) {
+			return SourceFingerprint{Key: key}, nil
+		}
+		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", src.DBPath, err)
+	}
+	metas, err := s.listMeta(src.DBPath)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	for _, meta := range metas {
+		if meta.SessionID == src.SessionID {
+			return SourceFingerprint{Key: key, MTimeNS: meta.FileMtime}, nil
+		}
+	}
+	return SourceFingerprint{Key: key}, nil
+}
+
+func (s SQLiteFanoutSourceSet) sourceFromRef(
+	source SourceRef,
+) (SQLiteFanoutSource, bool) {
+	switch src := source.Opaque.(type) {
+	case SQLiteFanoutSource:
+		return src, src.DBPath != "" && src.SessionID != ""
+	case *SQLiteFanoutSource:
+		if src != nil && src.DBPath != "" && src.SessionID != "" {
+			return *src, true
+		}
+	}
+	for _, candidate := range []string{source.DisplayPath, source.FingerprintKey, source.Key} {
+		for _, root := range s.roots {
+			if ref, ok := s.sourceRef(root, candidate, true); ok {
+				return ref.Opaque.(SQLiteFanoutSource), true
+			}
+		}
+	}
+	return SQLiteFanoutSource{}, false
+}
+
+func (s SQLiteFanoutSourceSet) sourceExists(src SQLiteFanoutSource) (bool, error) {
+	if !IsRegularFile(src.DBPath) {
+		return false, nil
+	}
+	metas, err := s.listMeta(src.DBPath)
+	if err != nil {
+		return false, err
+	}
+	for _, meta := range metas {
+		if meta.SessionID == src.SessionID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s SQLiteFanoutSourceSet) sourceRef(
+	root, path string,
+	allowMissing bool,
+) (SourceRef, bool) {
+	root = filepath.Clean(root)
+	dbPath, sessionID, ok := ParseVirtualSourcePathForBase(path, s.options.DBName)
+	canonicalDBPath := s.canonicalDBPath(root)
+	if !ok || canonicalDBPath == "" || !samePath(dbPath, canonicalDBPath) {
+		return SourceRef{}, false
+	}
+	if !allowMissing && !IsRegularFile(dbPath) {
+		return SourceRef{}, false
+	}
+	return s.newSourceRef(root, dbPath, SQLiteFanoutSessionMeta{
+		SessionID:   sessionID,
+		VirtualPath: VirtualSourcePath(dbPath, sessionID),
+	}), true
+}
+
+func (s SQLiteFanoutSourceSet) dbPathForEvent(root, path string) (string, bool) {
+	path = filepath.Clean(path)
+	dbPath := s.canonicalDBPath(root)
+	if dbPath == "" || !samePath(filepath.Dir(path), filepath.Dir(dbPath)) {
+		return "", false
+	}
+	base := filepath.Base(path)
+	dbName := filepath.Base(dbPath)
+	if base == dbName || base == dbName+"-wal" || base == dbName+"-shm" {
+		return dbPath, true
+	}
+	return "", false
+}
+
+func (s SQLiteFanoutSourceSet) watchRootMatches(root, watchRoot string) bool {
+	if samePath(watchRoot, root) {
+		return true
+	}
+	dbPath := s.canonicalDBPath(root)
+	return dbPath != "" && samePath(watchRoot, filepath.Dir(dbPath))
+}
+
+func (s SQLiteFanoutSourceSet) newSourceRef(
+	root, dbPath string,
+	meta SQLiteFanoutSessionMeta,
+) SourceRef {
+	virtualPath := firstNonEmptyJSONLString(
+		meta.VirtualPath,
+		VirtualSourcePath(dbPath, meta.SessionID),
+	)
+	return SourceRef{
+		Provider:       s.provider,
+		Key:            virtualPath,
+		DisplayPath:    virtualPath,
+		FingerprintKey: virtualPath,
+		Opaque: SQLiteFanoutSource{
+			Root:      root,
+			DBPath:    dbPath,
+			SessionID: meta.SessionID,
+		},
+	}
+}
+
+func (s SQLiteFanoutSourceSet) findDB(root string) string {
+	if s.options.FindDB == nil {
+		return ""
+	}
+	return s.options.FindDB(root)
+}
+
+func (s SQLiteFanoutSourceSet) canonicalDBPath(root string) string {
+	if dbPath := s.findDB(root); dbPath != "" {
+		return filepath.Clean(dbPath)
+	}
+	if s.options.DBName == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Clean(root), s.options.DBName)
+}
+
+func (s SQLiteFanoutSourceSet) listMeta(
+	dbPath string,
+) ([]SQLiteFanoutSessionMeta, error) {
+	if s.options.ListMeta == nil {
+		return nil, nil
+	}
+	return s.options.ListMeta(dbPath)
+}
+
+func (s SQLiteFanoutSource) virtualPath() string {
+	return VirtualSourcePath(s.DBPath, s.SessionID)
+}

--- a/internal/parser/virtual_source_path.go
+++ b/internal/parser/virtual_source_path.go
@@ -1,0 +1,38 @@
+package parser
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// VirtualSourcePath identifies one logical source inside a shared physical
+// container path, for example one conversation row inside a SQLite database.
+func VirtualSourcePath(containerPath, sourceID string) string {
+	return containerPath + "#" + sourceID
+}
+
+// ParseVirtualSourcePath splits a path created by VirtualSourcePath.
+func ParseVirtualSourcePath(path string) (string, string, bool) {
+	idx := strings.LastIndex(path, "#")
+	if idx < 0 {
+		return "", "", false
+	}
+	containerPath, sourceID := path[:idx], path[idx+1:]
+	if containerPath == "" || sourceID == "" {
+		return "", "", false
+	}
+	return containerPath, sourceID, true
+}
+
+// ParseVirtualSourcePathForBase splits a virtual source path and verifies that
+// the physical container has the expected base filename.
+func ParseVirtualSourcePathForBase(
+	path string,
+	baseName string,
+) (string, string, bool) {
+	containerPath, sourceID, ok := ParseVirtualSourcePath(path)
+	if !ok || filepath.Base(containerPath) != baseName {
+		return "", "", false
+	}
+	return containerPath, sourceID, true
+}


### PR DESCRIPTION
Adds a reusable JSONL source-set helper for the provider migration. The helper discovers stable sorted source refs, produces watch plans, maps changed paths back to sources, resolves persisted file-path hints or raw filename-stem IDs, and fingerprints source files with optional content hashes.

This helper is intentionally not a Provider. Migrated providers can compose it as a named field and forward only the source methods they support, keeping source behavior explicit while avoiding repeated JSONL discovery and lookup implementations.