### PR TITLE
feat(parser): migrate claude provider

### DIFF
--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -56,24 +56,17 @@ type claudeQueuedCommand struct {
 	timestamp time.Time
 }
 
-// ParseClaudeSession parses a Claude Code JSONL session file.
-// Returns one or more ParseResult structs (multiple when forks
-// are detected in the uuid/parentUuid DAG).
-func ParseClaudeSession(
-	path, project, machine string,
-) ([]ParseResult, error) {
-	results, _, err := ParseClaudeSessionWithExclusions(
-		path, project, machine,
-	)
-	return results, err
-}
-
-// ParseClaudeSessionWithExclusions parses a Claude Code JSONL
-// session file and also returns session IDs intentionally excluded
-// from the archive, such as content-free /usage probes. Sync uses
-// those IDs during full resync so orphan preservation does not
-// restore rows the current parser deliberately dropped.
-func ParseClaudeSessionWithExclusions(
+// claudeParseWithExclusions parses a Claude Code JSONL session file
+// and also returns session IDs intentionally excluded from the
+// archive, such as content-free /usage probes. Sync uses those IDs
+// during full resync so orphan preservation does not restore rows the
+// current parser deliberately dropped. This is the provider-owned
+// parse body shared by the Claude provider (both its discovered-session
+// Parse path and its ParseUploadedTranscript entry) and the Cowork
+// parser (which reuses the Claude transcript format); it carries no
+// legacy entrypoint naming so the provider can call it without shimming
+// a Parse* free function.
+func claudeParseWithExclusions(
 	path, project, machine string,
 ) ([]ParseResult, []string, error) {
 	info, err := os.Stat(path)
@@ -366,15 +359,17 @@ func lastAssistantStopReason(messages []ParsedMessage) string {
 	return ""
 }
 
-// ParseClaudeSessionFrom parses only new lines from a Claude
-// JSONL file starting at the given byte offset. Returns only
-// the newly parsed messages (with ordinals starting at
-// startOrdinal) and the latest timestamp. Fork detection is
-// skipped — new entries are processed linearly. Used for
-// incremental re-parsing of append-only session files.
-// ErrDAGDetected is returned by ParseClaudeSessionFrom when
-// appended lines contain uuid fields that require DAG-aware
-// fork detection, which incremental parsing cannot handle.
+// claudeParseSessionFrom parses only new lines from a Claude JSONL
+// file starting at the given byte offset. Returns only the newly
+// parsed messages (with ordinals starting at startOrdinal) and the
+// latest timestamp. Fork detection is skipped — new entries are
+// processed linearly. Used by the Claude provider for incremental
+// re-parsing of append-only session files. ErrDAGDetected is returned
+// when appended lines contain uuid fields that require DAG-aware fork
+// detection, which incremental parsing cannot handle. This is the
+// provider-owned incremental body; it carries no legacy entrypoint
+// naming so the provider can call it without shimming a Parse* free
+// function.
 var ErrDAGDetected = fmt.Errorf(
 	"incremental parse: DAG uuid detected",
 )
@@ -387,7 +382,7 @@ var ErrClaudeIncrementalNeedsFullParse = fmt.Errorf(
 	"incremental parse: appended Claude lines require full parse",
 )
 
-func ParseClaudeSessionFrom(
+func claudeParseSessionFrom(
 	path string,
 	offset int64,
 	startOrdinal int,
@@ -726,7 +721,7 @@ func extractMessagesFrom(
 		}
 
 		if e.entryType == "user" {
-			if subtype := ClassifyClaudeSystemMessage(text); subtype != "" {
+			if subtype := classifyClaudeSystemMessage(text); subtype != "" {
 				// Preserve Role=user so analytics that compute
 				// turn-cycle/throughput on role alone (see
 				// internal/db/analytics.go) don't count these as
@@ -1666,7 +1661,7 @@ func extractMessages(entries []dagEntry) (
 		// stays "user" so role-keyed analytics continue to treat
 		// these as inputs, not assistant replies.
 		if e.entryType == "user" {
-			if subtype := ClassifyClaudeSystemMessage(text); subtype != "" {
+			if subtype := classifyClaudeSystemMessage(text); subtype != "" {
 				messages = append(messages, ParsedMessage{
 					Ordinal:          ordinal,
 					Role:             RoleUser,
@@ -2079,14 +2074,14 @@ func extractCompactSummary(line string) string {
 	return content.Str
 }
 
-// ClassifyClaudeSystemMessage inspects a user-entry content string and
+// classifyClaudeSystemMessage inspects a user-entry content string and
 // returns the matched system subtype (e.g. "continuation", "resume"),
 // or "" if the content is an ordinary user message.
 //
 // Non-caveat <local-command-*> envelopes (stdout/stderr surrounds for
 // local command output) are treated as regular noise and return "";
 // only the caveat variant is a semantic "resume" marker.
-func ClassifyClaudeSystemMessage(content string) string {
+func classifyClaudeSystemMessage(content string) string {
 	trimmed := strings.TrimLeftFunc(content, func(r rune) bool {
 		return r == '\uFEFF' || unicode.IsSpace(r)
 	})

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -22,7 +22,7 @@ func runClaudeParserTest(t *testing.T, fileName, content string) (ParsedSession,
 		fileName = "test.jsonl"
 	}
 	path := createTestFile(t, fileName, content)
-	results, err := ParseClaudeSession(path, "my_app", "local")
+	results, err := parseClaudeSession(path, "my_app", "local")
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
 	return results[0].Session, results[0].Messages
@@ -31,7 +31,7 @@ func runClaudeParserTest(t *testing.T, fileName, content string) (ParsedSession,
 func callParseClaudeSessionFrom(
 	path string, offset int64, startOrdinal int, lastEntryUUID string,
 ) ([]ParsedMessage, time.Time, int64, error) {
-	fn := reflect.ValueOf(ParseClaudeSessionFrom)
+	fn := reflect.ValueOf(claudeParseSessionFrom)
 	args := []reflect.Value{
 		reflect.ValueOf(path),
 		reflect.ValueOf(offset),
@@ -68,7 +68,7 @@ func TestParseClaudeSession_UsageProbe(t *testing.T) {
 	parse := func(t *testing.T, content string) []ParseResult {
 		t.Helper()
 		path := createTestFile(t, "probe.jsonl", content)
-		results, err := ParseClaudeSession(path, "ClaudeProbe", "local")
+		results, err := parseClaudeSession(path, "ClaudeProbe", "local")
 		require.NoError(t, err)
 		return results
 	}
@@ -516,7 +516,7 @@ func TestParseClaudeSessionFrom_Incremental(t *testing.T) {
 	path := createTestFile(t, "inc-claude.jsonl", initial)
 
 	// Full parse to get baseline.
-	results, err := ParseClaudeSession(path, "proj", "local")
+	results, err := parseClaudeSession(path, "proj", "local")
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
 	assert.Equal(t, 2, len(results[0].Messages))
@@ -978,7 +978,7 @@ func TestParseClaudeSession_ResolvesPersistedToolResultOutput(
 	sessionPath := filepath.Join(dir, "project", "parent-session.jsonl")
 	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
 
-	results, err := ParseClaudeSession(sessionPath, "project", "local")
+	results, err := parseClaudeSession(sessionPath, "project", "local")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Len(t, results[0].Messages, 3)
@@ -1016,7 +1016,7 @@ func TestParseClaudeSession_PersistedToolResultDoesNotOverwriteSiblings(
 	sessionPath := filepath.Join(dir, "project", "parent-session.jsonl")
 	require.NoError(t, os.WriteFile(sessionPath, []byte(content), 0o644))
 
-	results, err := ParseClaudeSession(sessionPath, "project", "local")
+	results, err := parseClaudeSession(sessionPath, "project", "local")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Len(t, results[0].Messages, 3)
@@ -1406,7 +1406,7 @@ func TestParseClaudeSession_ExtractsMessageIDAndRequestID(t *testing.T) {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	results, err := ParseClaudeSession(path, "proj", "m")
+	results, err := parseClaudeSession(path, "proj", "m")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -1779,7 +1779,7 @@ func TestClassifyClaudeSystemMessage(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := ClassifyClaudeSystemMessage(c.content)
+			got := classifyClaudeSystemMessage(c.content)
 			assert.Equal(t, c.expected, got)
 		})
 	}

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -1,0 +1,542 @@
+package parser
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var _ Provider = (*claudeProvider)(nil)
+
+type claudeProviderFactory struct {
+	def AgentDef
+}
+
+func newClaudeProviderFactory(def AgentDef) ProviderFactory {
+	return claudeProviderFactory{def: cloneAgentDef(def)}
+}
+
+func (f claudeProviderFactory) Definition() AgentDef {
+	return cloneAgentDef(f.def)
+}
+
+func (f claudeProviderFactory) Capabilities() Capabilities {
+	return claudeProviderCapabilities()
+}
+
+func (f claudeProviderFactory) NewProvider(cfg ProviderConfig) Provider {
+	cfg = cfg.Clone()
+	return &claudeProvider{
+		ProviderBase: ProviderBase{
+			Def:    cloneAgentDef(f.def),
+			Caps:   claudeProviderCapabilities(),
+			Config: cfg,
+		},
+		sources: newClaudeSourceSet(cfg.Roots),
+	}
+}
+
+type claudeProvider struct {
+	ProviderBase
+	sources claudeSourceSet
+}
+
+func (p *claudeProvider) Discover(ctx context.Context) ([]SourceRef, error) {
+	return p.sources.Discover(ctx)
+}
+
+func (p *claudeProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
+	return p.sources.WatchPlan(ctx)
+}
+
+func (p *claudeProvider) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *claudeProvider) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	req = providerFindRequestWithRawSessionID(p.Def, req)
+	return p.sources.FindSource(ctx, req)
+}
+
+func (p *claudeProvider) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *claudeProvider) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	if err := ctx.Err(); err != nil {
+		return ParseOutcome{}, err
+	}
+	path, ok := p.sources.pathFromSource(req.Source)
+	if !ok {
+		return ParseOutcome{}, fmt.Errorf("claude source path unavailable")
+	}
+	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
+	project := claudeProviderProject(ctx, req.Source.ProjectHint, path)
+	results, excludedIDs, err := claudeParseWithExclusions(path, project, machine)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if req.Fingerprint.Hash != "" {
+		for i := range results {
+			results[i].Session.File.Hash = req.Fingerprint.Hash
+		}
+	}
+	InferRelationshipTypes(results)
+	out := make([]ParseResultOutcome, 0, len(results))
+	for _, result := range results {
+		out = append(out, ParseResultOutcome{
+			Result:      result,
+			DataVersion: DataVersionCurrent,
+		})
+	}
+	return ParseOutcome{
+		Results:            out,
+		ExcludedSessionIDs: excludedIDs,
+		ResultSetComplete:  true,
+	}, nil
+}
+
+// ClaudeUploadParser is implemented by the Claude provider to parse a
+// standalone, out-of-root Claude transcript file (such as an HTTP upload)
+// under a caller-supplied project name. Uploads do not live under a
+// configured root, so the normal discovery/source-resolution path does not
+// apply; callers obtain this via NewProvider(AgentClaude, ...) and a type
+// assertion.
+type ClaudeUploadParser interface {
+	// ParseUploadedTranscript parses the transcript at path and files the
+	// resulting sessions under project. The project is authoritative: unlike
+	// the discovered-session Parse path, it is not overridden by any cwd
+	// recorded in the transcript, because an upload is filed under a
+	// user-chosen project rather than a workspace path on this machine.
+	ParseUploadedTranscript(path, project, machine string) ([]ParseResult, error)
+}
+
+func (p *claudeProvider) ParseUploadedTranscript(
+	path, project, machine string,
+) ([]ParseResult, error) {
+	machine = firstNonEmptyJSONLString(machine, p.Config.Machine)
+	results, _, err := claudeParseWithExclusions(path, project, machine)
+	if err != nil {
+		return nil, err
+	}
+	InferRelationshipTypes(results)
+	return results, nil
+}
+
+func (p *claudeProvider) ParseIncremental(
+	ctx context.Context,
+	req IncrementalRequest,
+) (IncrementalOutcome, IncrementalStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return IncrementalOutcome{}, IncrementalUnsupported, err
+	}
+	path, ok := p.sources.pathFromSource(req.Source)
+	if !ok {
+		return IncrementalOutcome{}, IncrementalUnsupported,
+			fmt.Errorf("claude source path unavailable")
+	}
+	if req.Offset > 0 && req.Fingerprint.Size < req.Offset {
+		return IncrementalOutcome{ForceReplace: true},
+			IncrementalNeedsFullParse, nil
+	}
+	if req.Fingerprint.Size == req.Offset {
+		return IncrementalOutcome{}, IncrementalNoNewData, nil
+	}
+	newMsgs, endedAt, consumed, err := claudeParseSessionFrom(
+		path,
+		req.Offset,
+		req.StartOrdinal,
+		req.LastEntryUUID,
+	)
+	if err != nil {
+		if IsIncrementalFullParseFallback(err) || errorsIsClaudeDAG(err) {
+			return IncrementalOutcome{ForceReplace: IsIncrementalFullParseFallback(err)},
+				IncrementalNeedsFullParse, nil
+		}
+		return IncrementalOutcome{}, IncrementalNeedsFullParse, err
+	}
+	if len(newMsgs) == 0 {
+		if consumed > 0 {
+			return IncrementalOutcome{
+				SessionID:     req.SessionID,
+				EndedAt:       endedAt,
+				ConsumedBytes: consumed,
+			}, IncrementalApplied, nil
+		}
+		return IncrementalOutcome{}, IncrementalNoNewData, nil
+	}
+	totalOut, peakCtx, hasTotalOut, hasPeakCtx := claudeProviderTokenTotals(newMsgs)
+	return IncrementalOutcome{
+		SessionID:            req.SessionID,
+		Messages:             newMsgs,
+		EndedAt:              endedAt,
+		ConsumedBytes:        consumed,
+		MessageCount:         len(newMsgs),
+		UserMessageCount:     claudeProviderUserMessageCount(newMsgs),
+		TotalOutputTokens:    totalOut,
+		PeakContextTokens:    peakCtx,
+		HasTotalOutputTokens: hasTotalOut,
+		HasPeakContextTokens: hasPeakCtx,
+	}, IncrementalApplied, nil
+}
+
+type claudeSource struct {
+	Root string
+	Path string
+}
+
+type claudeSourceSet struct {
+	roots []string
+}
+
+func newClaudeSourceSet(roots []string) claudeSourceSet {
+	return claudeSourceSet{roots: cleanJSONLRoots(roots)}
+}
+
+func (s claudeSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for _, file := range ClaudeProjectSessionFiles(root) {
+			source, ok := s.sourceRef(root, file.Path)
+			if !ok {
+				continue
+			}
+			addJSONLSource(source, &sources, seen)
+		}
+	}
+	sortJSONLSources(sources)
+	return sources, nil
+}
+
+func (s claudeSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
+	roots := make([]WatchRoot, 0, len(s.roots))
+	for _, root := range s.roots {
+		roots = append(roots, WatchRoot{
+			Path:         root,
+			Recursive:    true,
+			IncludeGlobs: []string{"*.jsonl"},
+			DebounceKey:  string(AgentClaude) + ":projects:" + root,
+		})
+	}
+	return WatchPlan{Roots: roots}, nil
+}
+
+func (s claudeSourceSet) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// The legacy classifier resolved Claude paths purely from their
+	// project/session shape and only treated a stat failure as
+	// "missing" when it was a definitive IsNotExist. A transient stat
+	// error (for example a parent directory the watcher cannot read this
+	// instant) must still classify so the change is not silently dropped.
+	// Fall back to path-shape classification whenever the path is not
+	// known to be absent.
+	allowMissing := jsonlMissingPathFallbackAllowed(req) ||
+		claudeChangedPathPresentButUnstatable(req.Path)
+	if req.WatchRoot != "" {
+		root := filepath.Clean(req.WatchRoot)
+		if !s.hasRoot(root) {
+			return nil, nil
+		}
+		source, ok := s.sourceForChangedPath(root, req.Path, allowMissing)
+		if !ok {
+			return nil, nil
+		}
+		return []SourceRef{source}, nil
+	}
+	for _, root := range s.roots {
+		source, ok := s.sourceForChangedPath(root, req.Path, allowMissing)
+		if ok {
+			return []SourceRef{source}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s claudeSourceSet) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, path := range []string{req.StoredFilePath, req.FingerprintKey} {
+		if path == "" {
+			continue
+		}
+		for _, root := range s.roots {
+			if source, ok := s.sourceForPath(root, path); ok {
+				return source, true, nil
+			}
+		}
+	}
+	if req.RawSessionID == "" {
+		return SourceRef{}, false, nil
+	}
+	for _, root := range s.roots {
+		path := claudeFindSourceFile(root, req.RawSessionID)
+		if path == "" {
+			continue
+		}
+		if source, ok := s.sourceRef(root, path); ok {
+			return source, true, nil
+		}
+	}
+	return SourceRef{}, false, nil
+}
+
+func (s claudeSourceSet) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceFingerprint{}, err
+	}
+	path, ok := s.pathFromSource(source)
+	if !ok {
+		return SourceFingerprint{}, fmt.Errorf("claude source path unavailable")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", path)
+	}
+	hash, err := hashJSONLSourceFile(path)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	inode, device := sourceFileIdentity(info)
+	return SourceFingerprint{
+		Key:     firstNonEmptyJSONLString(source.FingerprintKey, source.Key, path),
+		Size:    info.Size(),
+		MTimeNS: info.ModTime().UnixNano(),
+		Inode:   inode,
+		Device:  device,
+		Hash:    hash,
+	}, nil
+}
+
+func (s claudeSourceSet) pathFromSource(source SourceRef) (string, bool) {
+	switch src := source.Opaque.(type) {
+	case claudeSource:
+		return src.Path, src.Path != ""
+	case *claudeSource:
+		if src != nil && src.Path != "" {
+			return src.Path, true
+		}
+	}
+	for _, candidate := range []string{
+		source.DisplayPath,
+		source.FingerprintKey,
+		source.Key,
+	} {
+		for _, root := range s.roots {
+			if ref, ok := s.sourceForPath(root, candidate); ok {
+				src := ref.Opaque.(claudeSource)
+				return src.Path, true
+			}
+		}
+	}
+	return "", false
+}
+
+func (s claudeSourceSet) sourceForPath(root, path string) (SourceRef, bool) {
+	return s.sourceForChangedPath(root, path, false)
+}
+
+func (s claudeSourceSet) sourceForChangedPath(
+	root,
+	path string,
+	allowMissing bool,
+) (SourceRef, bool) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	if allowMissing {
+		return s.sourceRefFromPath(root, path)
+	}
+	return s.sourceRef(root, path)
+}
+
+func (s claudeSourceSet) sourceRef(root, path string) (SourceRef, bool) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	if !IsRegularFile(path) {
+		return SourceRef{}, false
+	}
+	return s.sourceRefFromPath(root, path)
+}
+
+func (s claudeSourceSet) sourceRefFromPath(root, path string) (SourceRef, bool) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	project, ok := claudeProjectHintFromPath(root, path)
+	if !ok {
+		return SourceRef{}, false
+	}
+	return SourceRef{
+		Provider:       AgentClaude,
+		Key:            path,
+		DisplayPath:    path,
+		FingerprintKey: path,
+		ProjectHint:    project,
+		Opaque: claudeSource{
+			Root: root,
+			Path: path,
+		},
+	}, true
+}
+
+func (s claudeSourceSet) hasRoot(root string) bool {
+	for _, configured := range s.roots {
+		if samePath(root, configured) {
+			return true
+		}
+	}
+	return false
+}
+
+// claudeChangedPathPresentButUnstatable reports whether a changed path
+// resolves to something on disk that cannot be stat'd right now for a
+// reason other than not existing (for example a parent directory with no
+// read/exec permission). In that case the legacy classifier still
+// recognized the path by shape, so the provider must classify it too.
+func claudeChangedPathPresentButUnstatable(path string) bool {
+	if path == "" {
+		return false
+	}
+	if IsRegularFile(path) {
+		return false
+	}
+	_, err := os.Lstat(path)
+	if err == nil {
+		// Present (lstat succeeded) but not a regular file via Stat,
+		// e.g. stat blocked by parent-directory permissions.
+		return true
+	}
+	return !os.IsNotExist(err)
+}
+
+func claudeProjectHintFromPath(root, path string) (string, bool) {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil || rel == "." || rel == "" {
+		return "", false
+	}
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return "", false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) == 2 && strings.HasSuffix(parts[1], ".jsonl") {
+		stem := strings.TrimSuffix(parts[1], ".jsonl")
+		if strings.HasPrefix(stem, "agent-") {
+			return "", false
+		}
+		return parts[0], true
+	}
+	if len(parts) >= 4 && parts[2] == "subagents" &&
+		strings.HasSuffix(parts[len(parts)-1], ".jsonl") {
+		stem := strings.TrimSuffix(parts[len(parts)-1], ".jsonl")
+		if strings.HasPrefix(stem, "agent-") {
+			return parts[0], true
+		}
+	}
+	return "", false
+}
+
+func claudeProviderProject(ctx context.Context, projectHint, path string) string {
+	project := GetProjectName(projectHint)
+	cwd, gitBranch := ExtractClaudeProjectHints(path)
+	if cwd != "" {
+		if p := ExtractProjectFromCwdWithBranchContext(ctx, cwd, gitBranch); p != "" {
+			project = p
+		}
+	}
+	return project
+}
+
+func errorsIsClaudeDAG(err error) bool {
+	return err == ErrDAGDetected
+}
+
+func claudeProviderUserMessageCount(msgs []ParsedMessage) int {
+	count := 0
+	for _, msg := range msgs {
+		if msg.Role == RoleUser && !msg.IsSystem && len(msg.ToolResults) == 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func claudeProviderTokenTotals(
+	msgs []ParsedMessage,
+) (totalOut int, peakCtx int, hasTotalOut bool, hasPeakCtx bool) {
+	for _, msg := range msgs {
+		msgHasCtx, msgHasOut := msg.TokenPresence()
+		if msgHasOut {
+			totalOut += msg.OutputTokens
+			hasTotalOut = true
+		}
+		if msgHasCtx && (!hasPeakCtx || msg.ContextTokens > peakCtx) {
+			peakCtx = msg.ContextTokens
+			hasPeakCtx = true
+		}
+	}
+	return totalOut, peakCtx, hasTotalOut, hasPeakCtx
+}
+
+func claudeProviderCapabilities() Capabilities {
+	return Capabilities{
+		Source: SourceCapabilities{
+			DiscoverSources:      CapabilitySupported,
+			WatchSources:         CapabilitySupported,
+			ClassifyChangedPath:  CapabilitySupported,
+			FindSource:           CapabilitySupported,
+			CompositeFingerprint: CapabilitySupported,
+			IncrementalAppend:    CapabilitySupported,
+			MultiSessionSource:   CapabilitySupported,
+			PerSessionErrors:     CapabilityNotApplicable,
+			ExcludedSessions:     CapabilitySupported,
+			ForceReplaceOnParse:  CapabilitySupported,
+		},
+		Content: ContentCapabilities{
+			FirstMessage:         CapabilitySupported,
+			SessionName:          CapabilitySupported,
+			Cwd:                  CapabilitySupported,
+			GitBranch:            CapabilitySupported,
+			Relationships:        CapabilitySupported,
+			Subagents:            CapabilitySupported,
+			Thinking:             CapabilitySupported,
+			ToolCalls:            CapabilitySupported,
+			ToolResults:          CapabilitySupported,
+			PerMessageTokenUsage: CapabilitySupported,
+			TerminationStatus:    CapabilitySupported,
+			MalformedLineCount:   CapabilitySupported,
+			Model:                CapabilitySupported,
+			StopReason:           CapabilitySupported,
+		},
+	}
+}

--- a/internal/parser/claude_provider_test.go
+++ b/internal/parser/claude_provider_test.go
@@ -1,0 +1,350 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+func TestClaudeProviderFactoryReplacesLegacyAdapter(t *testing.T) {
+	factory, ok := ProviderFactoryByType(AgentClaude)
+	require.True(t, ok)
+	require.NotNil(t, factory)
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{t.TempDir()},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	require.NotNil(t, provider)
+}
+
+func TestClaudeProviderSourceMethods(t *testing.T) {
+	root := t.TempDir()
+	projectDir := "-Users-dev-code-demo"
+	sessionID := "session-main"
+	sourcePath := filepath.Join(root, projectDir, sessionID+".jsonl")
+	subagentPath := filepath.Join(
+		root,
+		projectDir,
+		sessionID,
+		"subagents",
+		"workflows",
+		"wf-123",
+		"agent-worker.jsonl",
+	)
+	writeSourceFile(t, sourcePath, claudeProviderFixture("main question"))
+	writeSourceFile(t, subagentPath, claudeProviderFixture("subagent question"))
+	writeSourceFile(
+		t,
+		filepath.Join(root, projectDir, sessionID, "subagents", "not-agent.jsonl"),
+		claudeProviderFixture("ignored"),
+	)
+	writeSourceFile(t, filepath.Join(root, projectDir, "agent-root.jsonl"), claudeProviderFixture("ignored"))
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, root, plan.Roots[0].Path)
+	assert.True(t, plan.Roots[0].Recursive)
+	assert.Equal(t, []string{"*.jsonl"}, plan.Roots[0].IncludeGlobs)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 2)
+	assert.ElementsMatch(t, []string{sourcePath, subagentPath}, []string{
+		discovered[0].DisplayPath,
+		discovered[1].DisplayPath,
+	})
+	for _, source := range discovered {
+		assert.Equal(t, AgentClaude, source.Provider)
+		assert.Equal(t, projectDir, source.ProjectHint)
+	}
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		FullSessionID: "remote~" + sessionID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, sourcePath, found.DisplayPath)
+
+	found, ok, err = provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "agent-worker",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, subagentPath, found.DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), found)
+	require.NoError(t, err)
+	assert.Equal(t, subagentPath, fingerprint.Key)
+	assert.Positive(t, fingerprint.Size)
+	assert.Positive(t, fingerprint.MTimeNS)
+	assert.NotEmpty(t, fingerprint.Hash)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: subagentPath, EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, subagentPath, changed[0].DisplayPath)
+
+	require.NoError(t, os.Remove(sourcePath))
+	changed, err = provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: sourcePath, EventKind: "remove", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, sourcePath, changed[0].DisplayPath)
+
+	require.NoError(t, os.Remove(subagentPath))
+	changed, err = provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: subagentPath, EventKind: "rename", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, subagentPath, changed[0].DisplayPath)
+
+	ignored, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:      filepath.Join(root, projectDir, "agent-root.jsonl"),
+			EventKind: "write",
+			WatchRoot: root,
+		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, ignored)
+}
+
+func TestClaudeProviderDiscoversSymlinkedProjectDirectory(t *testing.T) {
+	root := t.TempDir()
+	targetRoot := t.TempDir()
+	projectDir := "-Users-dev-code-demo"
+	sessionID := "session-main"
+	targetProject := filepath.Join(targetRoot, projectDir)
+	sourceProject := filepath.Join(root, projectDir)
+	sourcePath := filepath.Join(sourceProject, sessionID+".jsonl")
+	subagentPath := filepath.Join(
+		sourceProject,
+		sessionID,
+		"subagents",
+		"jobs",
+		"job-1",
+		"agent-linked.jsonl",
+	)
+	writeSourceFile(
+		t,
+		filepath.Join(targetProject, sessionID+".jsonl"),
+		claudeProviderFixture("from symlink"),
+	)
+	writeSourceFile(
+		t,
+		filepath.Join(targetProject, sessionID, "subagents", "jobs", "job-1", "agent-linked.jsonl"),
+		claudeProviderFixture("from symlink subagent"),
+	)
+	if err := os.Symlink(targetProject, sourceProject); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 2)
+	assert.ElementsMatch(t, []string{sourcePath, subagentPath}, sourceDisplayPaths(discovered))
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: sessionID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, sourcePath, found.DisplayPath)
+
+	found, ok, err = provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "agent-linked",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, subagentPath, found.DisplayPath)
+}
+
+func TestClaudeProviderParse(t *testing.T) {
+	root := t.TempDir()
+	projectDir := "-Users-dev-code-demo"
+	sessionID := "session-main"
+	sourcePath := filepath.Join(root, projectDir, sessionID+".jsonl")
+	writeSourceFile(t, sourcePath, claudeProviderFixture("parse question"))
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      sources[0],
+		Fingerprint: SourceFingerprint{Key: sourcePath, Hash: "abc123"},
+	})
+	require.NoError(t, err)
+	require.True(t, outcome.ResultSetComplete)
+	require.False(t, outcome.ForceReplace)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0]
+	assert.Equal(t, DataVersionCurrent, result.DataVersion)
+	assert.Equal(t, sessionID, result.Result.Session.ID)
+	assert.Equal(t, AgentClaude, result.Result.Session.Agent)
+	assert.Equal(t, "demo", result.Result.Session.Project)
+	assert.Equal(t, "devbox", result.Result.Session.Machine)
+	assert.Equal(t, sourcePath, result.Result.Session.File.Path)
+	assert.Equal(t, "abc123", result.Result.Session.File.Hash)
+	assert.Equal(t, "parse question", result.Result.Session.FirstMessage)
+	assert.Len(t, result.Result.Messages, 2)
+}
+
+func TestClaudeProviderParseIncremental(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "-Users-dev-code-demo", "inc.jsonl")
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello world", tsEarly),
+		testjsonl.ClaudeAssistantJSON("hi there", tsEarlyS1),
+	)
+	writeSourceFile(t, sourcePath, initial)
+	info, err := os.Stat(sourcePath)
+	require.NoError(t, err)
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("follow up", tsEarlyS5),
+		testjsonl.ClaudeAssistantJSON("got it", tsLate),
+	)
+	f, err := os.OpenFile(sourcePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	currentInfo, err := os.Stat(sourcePath)
+	require.NoError(t, err)
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "inc",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	outcome, status, err := provider.ParseIncremental(
+		context.Background(),
+		IncrementalRequest{
+			Source:       source,
+			Fingerprint:  SourceFingerprint{Key: sourcePath, Size: currentInfo.Size()},
+			SessionID:    "inc",
+			Offset:       info.Size(),
+			StartOrdinal: 2,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, IncrementalApplied, status)
+	assert.Equal(t, "inc", outcome.SessionID)
+	assert.Equal(t, int64(len(appended)), outcome.ConsumedBytes)
+	require.Len(t, outcome.Messages, 2)
+	assert.Equal(t, 2, outcome.Messages[0].Ordinal)
+	assert.Equal(t, RoleUser, outcome.Messages[0].Role)
+	assert.Contains(t, outcome.Messages[0].Content, "follow up")
+	assert.Equal(t, 3, outcome.Messages[1].Ordinal)
+	assert.Equal(t, RoleAssistant, outcome.Messages[1].Role)
+	assert.Contains(t, outcome.Messages[1].Content, "got it")
+}
+
+func TestClaudeProviderParseIncrementalTruncatedNeedsFullParse(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "-Users-dev-code-demo", "truncated.jsonl")
+	initial := claudeProviderFixture("hello world")
+	writeSourceFile(t, sourcePath, initial)
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "truncated",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	outcome, status, err := provider.ParseIncremental(
+		context.Background(),
+		IncrementalRequest{
+			Source:      source,
+			Fingerprint: SourceFingerprint{Key: sourcePath, Size: int64(len(initial) / 2)},
+			SessionID:   "truncated",
+			Offset:      int64(len(initial)),
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, IncrementalNeedsFullParse, status)
+	assert.True(t, outcome.ForceReplace)
+}
+
+func TestClaudeProviderParseIncrementalEmptyTruncationNeedsFullParse(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "-Users-dev-code-demo", "empty-truncated.jsonl")
+	initial := claudeProviderFixture("hello world")
+	writeSourceFile(t, sourcePath, initial)
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "empty-truncated",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	outcome, status, err := provider.ParseIncremental(
+		context.Background(),
+		IncrementalRequest{
+			Source:      source,
+			Fingerprint: SourceFingerprint{Key: sourcePath, Size: 0},
+			SessionID:   "empty-truncated",
+			Offset:      int64(len(initial)),
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, IncrementalNeedsFullParse, status)
+	assert.True(t, outcome.ForceReplace)
+}
+
+func claudeProviderFixture(firstMessage string) string {
+	return testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(firstMessage, tsEarly),
+		testjsonl.ClaudeAssistantJSON("Done.", tsEarlyS1),
+	)
+}

--- a/internal/parser/claude_subagent_test.go
+++ b/internal/parser/claude_subagent_test.go
@@ -15,7 +15,7 @@ func parseAndGetToolCalls(t *testing.T, filename string, lines []string) []Parse
 	t.Helper()
 	content := strings.Join(lines, "\n")
 	path := createTestFile(t, filename, content)
-	results, err := ParseClaudeSession(path, "proj", "local")
+	results, err := parseClaudeSession(path, "proj", "local")
 	require.NoError(t, err, "ParseClaudeSession")
 	require.NotEmpty(t, results, "no results")
 

--- a/internal/parser/claude_test.go
+++ b/internal/parser/claude_test.go
@@ -238,7 +238,7 @@ func TestParseClaudeSession_Metadata(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			results, err := ParseClaudeSession(
+			results, err := parseClaudeSession(
 				path, "proj", "local",
 			)
 			require.NoError(t, err)
@@ -309,7 +309,7 @@ func TestParseClaudeSession_MetadataOnForkSessions(
 	err := os.WriteFile(path, []byte(content.String()), 0o644)
 	require.NoError(t, err)
 
-	results, err := ParseClaudeSession(path, "proj", "local")
+	results, err := parseClaudeSession(path, "proj", "local")
 	require.NoError(t, err)
 	require.Len(t, results, 2, "expected main + fork result")
 
@@ -357,7 +357,7 @@ func TestParseClaudeSession_LinearMetadata(t *testing.T) {
 	err := os.WriteFile(path, []byte(content), 0o644)
 	require.NoError(t, err)
 
-	results, err := ParseClaudeSession(path, "proj", "local")
+	results, err := parseClaudeSession(path, "proj", "local")
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -470,7 +470,7 @@ func TestClaudeRenameSetsDisplayName(t *testing.T) {
 			err := os.WriteFile(path, []byte(sb.String()), 0o644)
 			require.NoError(t, err)
 
-			results, err := ParseClaudeSession(path, "proj", "local")
+			results, err := parseClaudeSession(path, "proj", "local")
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 			assert.Equal(t, tc.wantDisplay, results[0].Session.SessionName)

--- a/internal/parser/cowork.go
+++ b/internal/parser/cowork.go
@@ -382,7 +382,7 @@ func extractCoworkAITitle(transcriptPath string) string {
 // the cowork namespace: agent type, "cowork:"-prefixed IDs, the session
 // title, and metadata-derived timestamps for transcripts that carry none.
 // Returns parsed results plus session IDs the parser intentionally
-// excluded (prefixed), matching ParseClaudeSessionWithExclusions.
+// excluded (prefixed), matching the Claude transcript parser.
 func ParseCoworkSession(
 	transcriptPath, machine string,
 ) ([]ParseResult, []string, error) {
@@ -390,7 +390,7 @@ func ParseCoworkSession(
 	meta := readCoworkMeta(metaPath)
 	project := coworkProjectName(meta)
 
-	results, excluded, err := ParseClaudeSessionWithExclusions(
+	results, excluded, err := claudeParseWithExclusions(
 		transcriptPath, project, machine,
 	)
 	if err != nil {

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -445,9 +445,13 @@ func ResolveCodexShallowWatchRoots(root string) []string {
 	return []string{parent}
 }
 
-// DiscoverClaudeProjects finds all project directories under the
-// Claude projects dir and returns their JSONL session files.
-func DiscoverClaudeProjects(projectsDir string) []DiscoveredFile {
+// ClaudeProjectSessionFiles finds all project directories under the
+// Claude projects dir and returns their JSONL session files. It is the
+// provider-owned enumeration body shared by the Claude provider source
+// set (full-sync discovery) and the engine's duplicate-candidate
+// expansion. The name carries no legacy entrypoint verb so the
+// provider can call it without shimming a Discover* free function.
+func ClaudeProjectSessionFiles(projectsDir string) []DiscoveredFile {
 	entries, err := os.ReadDir(projectsDir)
 	if err != nil {
 		return nil
@@ -572,9 +576,12 @@ func DiscoverCodexSessions(sessionsDir string) []DiscoveredFile {
 	return files
 }
 
-// FindClaudeSourceFile finds the original JSONL file for a Claude
-// session ID by searching all project directories.
-func FindClaudeSourceFile(
+// claudeFindSourceFile finds the original JSONL file for a Claude
+// session ID by searching all project directories. It is the
+// provider-owned lookup body used by the Claude provider source set's
+// FindSource. The name carries no legacy entrypoint verb so the
+// provider can call it without shimming a Find* free function.
+func claudeFindSourceFile(
 	projectsDir, sessionID string,
 ) string {
 	if !IsValidSessionID(sessionID) {
@@ -603,7 +610,7 @@ func FindClaudeSourceFile(
 	// <project>/<session>/subagents/**/agent-<id>.jsonl
 	if strings.HasPrefix(sessionID, "agent-") {
 		for _, entry := range entries {
-			if !entry.IsDir() {
+			if !isDirOrSymlink(entry, projectsDir) {
 				continue
 			}
 			projDir := filepath.Join(

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -141,7 +141,7 @@ func TestDiscoverClaudeProjects(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			setupFileSystem(t, dir, tt.files)
-			files := DiscoverClaudeProjects(dir)
+			files := ClaudeProjectSessionFiles(dir)
 
 			assertDiscoveredFiles(t, files, tt.wantFiles, AgentClaude)
 
@@ -156,7 +156,7 @@ func TestDiscoverClaudeProjects(t *testing.T) {
 
 	t.Run("Nonexistent", func(t *testing.T) {
 		dir := filepath.Join(t.TempDir(), "does-not-exist")
-		files := DiscoverClaudeProjects(dir)
+		files := ClaudeProjectSessionFiles(dir)
 		assert.Nil(t, files, "expected nil")
 	})
 }
@@ -307,7 +307,7 @@ func TestFindClaudeSourceFile(t *testing.T) {
 			dir := t.TempDir()
 			setupFileSystem(t, dir, tt.files)
 
-			got := FindClaudeSourceFile(dir, tt.targetID)
+			got := claudeFindSourceFile(dir, tt.targetID)
 			want := ""
 			if tt.wantFile != "" {
 				want = filepath.Join(dir, tt.wantFile)
@@ -321,8 +321,8 @@ func TestFindClaudeSourceFile(t *testing.T) {
 		dir := t.TempDir()
 		tests := []string{"", "../etc/passwd", "a/b", "a b"}
 		for _, id := range tests {
-			got := FindClaudeSourceFile(dir, id)
-			assert.Emptyf(t, got, "FindClaudeSourceFile(%q)", id)
+			got := claudeFindSourceFile(dir, id)
+			assert.Emptyf(t, got, "claudeFindSourceFile(%q)", id)
 		}
 	})
 }
@@ -1048,7 +1048,7 @@ func TestFindClaudeSourceFile_Symlink(t *testing.T) {
 		t.Skipf("symlink not supported: %v", err)
 	}
 
-	got := FindClaudeSourceFile(searchDir, "sess-abc")
+	got := claudeFindSourceFile(searchDir, "sess-abc")
 	require.NotEmpty(t, got, "expected to find session via symlink")
 	assert.Equal(t, linkDir, filepath.Dir(got),
 		"expected path through symlink")

--- a/internal/parser/fork_test.go
+++ b/internal/parser/fork_test.go
@@ -14,7 +14,7 @@ import (
 func parseTestContent(t *testing.T, name, content string, expectedLen int) []ParseResult {
 	t.Helper()
 	path := createTestFile(t, name, content)
-	results, err := ParseClaudeSession(path, "proj", "local")
+	results, err := parseClaudeSession(path, "proj", "local")
 	require.NoError(t, err, "ParseClaudeSession")
 	require.Len(t, results, expectedLen)
 	return results

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -790,7 +790,7 @@ func TestClaudeSessionTimestampSemantics(t *testing.T) {
 		buf := captureLog(t)
 
 		path := createTestFile(t, "ts-long-invalid.jsonl", content)
-		_, err := ParseClaudeSession(
+		_, err := parseClaudeSession(
 			path, "proj", "local",
 		)
 		require.NoError(t, err, "ParseClaudeSession")
@@ -969,7 +969,7 @@ func TestCodexUserMessageCount(t *testing.T) {
 	)
 
 	path := createTestFile(t, "codex-umc.jsonl", content)
-	sess, msgs, err := ParseCodexSession(path, "local", false)
+	sess, msgs, err := parseCodexTestSession(t, path, "local", false)
 	require.NoError(t, err, "ParseCodexSession")
 	require.NotNil(t, sess, "session")
 	require.Len(t, msgs, 4, "messages")
@@ -983,7 +983,7 @@ func TestCodexSessionTimestampSemantics(t *testing.T) {
 		path := createTestFile(t, "codex-ts-invalid.jsonl", content)
 		buf := captureLog(t)
 
-		sess, msgs, err := ParseCodexSession(
+		sess, msgs, err := parseCodexTestSession(t,
 			path, "local", false,
 		)
 		require.NoError(t, err, "ParseCodexSession")
@@ -1002,7 +1002,7 @@ func TestCodexSessionTimestampSemantics(t *testing.T) {
 		path := createTestFile(t, "codex-ts-long-invalid.jsonl", content)
 		buf := captureLog(t)
 
-		_, _, err := ParseCodexSession(
+		_, _, err := parseCodexTestSession(t,
 			path, "local", false,
 		)
 		require.NoError(t, err, "ParseCodexSession")
@@ -1038,7 +1038,7 @@ func TestParseCodexSessionOversizedLineSkipped(t *testing.T) {
 	// skipping from the re-emitted-prompt dedup.
 	content := meta + firstLine + oversizedLine + secondLine
 	path := createTestFile(t, "oversized.jsonl", content)
-	sess, msgs, err := ParseCodexSession(
+	sess, msgs, err := parseCodexTestSession(t,
 		path, "local", false,
 	)
 	require.NoError(t, err, "unexpected error")
@@ -1083,7 +1083,7 @@ func TestParseCodexSession_WorktreeBranchFallback(t *testing.T) {
 		`{"type":"response_item","timestamp":"2024-01-01T00:00:01Z","payload":{"role":"user","content":[{"type":"input_text","text":"hello"}]}}` + "\n"
 	path := createTestFile(t, "codex-worktree.jsonl", content)
 
-	sess, _, err := ParseCodexSession(path, "local", false)
+	sess, _, err := parseCodexTestSession(t, path, "local", false)
 	require.NoError(t, err, "ParseCodexSession")
 	require.NotNil(t, sess, "session")
 	assert.Equal(t, "agentsview", sess.Project, "project")
@@ -1230,10 +1230,10 @@ func TestGeminiUserMessageCount(t *testing.T) {
 	)
 
 	path := createTestFile(t, "gemini-umc.json", content)
-	sess, msgs, err := ParseGeminiSession(
-		path, "my_project", "local",
+	sess, msgs, err := parseGeminiTestSession(
+		t, path, "my_project", "local",
 	)
-	require.NoError(t, err, "ParseGeminiSession")
+	require.NoError(t, err, "parseGeminiTestSession")
 	require.NotNil(t, sess, "session")
 	require.Len(t, msgs, 4, "messages")
 	assert.Equal(t, 2, sess.UserMessageCount, "UserMessageCount")
@@ -1303,7 +1303,7 @@ func TestClaudeUserMessageCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			path := createTestFile(t, "test.jsonl", tt.content)
-			results, err := ParseClaudeSession(
+			results, err := parseClaudeSession(
 				path, "test-proj", "local",
 			)
 			require.NoError(t, err, "ParseClaudeSession")
@@ -1324,7 +1324,7 @@ func TestParseClaudeToolResults(t *testing.T) {
 	content := strings.Join(lines, "\n") + "\n"
 	path := createTestFile(t, "tool-results.jsonl", content)
 
-	results, err := ParseClaudeSession(path, "test-project", "local")
+	results, err := parseClaudeSession(path, "test-project", "local")
 	require.NoError(t, err, "ParseClaudeSession")
 	require.NotEmpty(t, results, "ParseClaudeSession returned no results")
 	msgs := results[0].Messages

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -279,6 +279,11 @@ type IncrementalRequest struct {
 	Offset       int64
 	StartOrdinal int
 	Machine      string
+	// LastEntryUUID is the UUID of the last entry stored for this
+	// session, used by DAG-aware parsers (Claude) to detect when an
+	// appended tail forks away from the stored tip and must trigger a
+	// full reparse instead of a naive append.
+	LastEntryUUID string
 }
 
 // IncrementalOutcome is the append-only parse output.
@@ -349,6 +354,8 @@ func providerFactoryForDef(def AgentDef) ProviderFactory {
 	switch def.Type {
 	case AgentAmp:
 		return newAmpProviderFactory(def)
+	case AgentClaude:
+		return newClaudeProviderFactory(def)
 	case AgentCommandCode:
 		return newCommandCodeProviderFactory(def)
 	case AgentCortex:

--- a/internal/parser/provider_migration.go
+++ b/internal/parser/provider_migration.go
@@ -17,7 +17,7 @@ const (
 )
 
 var providerMigrationModes = map[AgentType]ProviderMigrationMode{
-	AgentClaude:         ProviderMigrationLegacyOnly,
+	AgentClaude:         ProviderMigrationProviderAuthoritative,
 	AgentCowork:         ProviderMigrationLegacyOnly,
 	AgentCodex:          ProviderMigrationLegacyOnly,
 	AgentCopilot:        ProviderMigrationLegacyOnly,

--- a/internal/parser/provider_shim_scan_test.go
+++ b/internal/parser/provider_shim_scan_test.go
@@ -49,7 +49,6 @@ var providerNeutralEntrypoints = map[string]bool{
 var pendingShimProviderFiles = map[string]bool{
 	"antigravity_cli_provider.go":      true,
 	"antigravity_provider.go":          true,
-	"claude_provider.go":               true,
 	"codex_provider.go":                true,
 	"copilot_provider.go":              true,
 	"cowork_provider.go":               true,

--- a/internal/parser/test_helpers_test.go
+++ b/internal/parser/test_helpers_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"strings"
 	"testing"
@@ -11,6 +12,43 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// parseChatGPTExport parses a ChatGPT export through the ChatGPT import-only
+// provider. It is the test harness replacement for the former
+// ParseChatGPTExport free function.
+func parseChatGPTExport(
+	dir string,
+	assets AssetResolver,
+	onConversation func(ParseResult) error,
+) error {
+	p, ok := NewProvider(AgentChatGPT, ProviderConfig{})
+	if !ok {
+		return fmt.Errorf("chatgpt provider unavailable")
+	}
+	exporter, ok := p.(ChatGPTExportParser)
+	if !ok {
+		return fmt.Errorf("chatgpt provider does not support exports")
+	}
+	return exporter.ParseChatGPTExport(dir, assets, onConversation)
+}
+
+// parseClaudeAIExport parses a Claude.ai export through the Claude.ai
+// import-only provider. It is the test harness replacement for the former
+// ParseClaudeAIExport free function.
+func parseClaudeAIExport(
+	r io.Reader,
+	onConversation func(ParseResult) error,
+) error {
+	p, ok := NewProvider(AgentClaudeAI, ProviderConfig{})
+	if !ok {
+		return fmt.Errorf("claude.ai provider unavailable")
+	}
+	exporter, ok := p.(ClaudeAIExportParser)
+	if !ok {
+		return fmt.Errorf("claude.ai provider does not support exports")
+	}
+	return exporter.ParseClaudeAIExport(r, onConversation)
+}
 
 // Timestamp constants for test data.
 const (
@@ -145,10 +183,28 @@ func parseClaudeTestFile(
 ) (ParsedSession, []ParsedMessage) {
 	t.Helper()
 	path := createTestFile(t, name, content)
-	results, err := ParseClaudeSession(
+	results, err := parseClaudeSession(
 		path, project, "local",
 	)
-	require.NoError(t, err, "ParseClaudeSession")
-	require.NotEmpty(t, results, "ParseClaudeSession returned no results")
+	require.NoError(t, err, "parseClaudeSession")
+	require.NotEmpty(t, results, "parseClaudeSession returned no results")
 	return results[0].Session, results[0].Messages
+}
+
+// parseClaudeSession parses a standalone Claude transcript through the Claude
+// provider's upload entry point, honoring the explicit project. It is the
+// test harness replacement for the former ParseClaudeSession free function,
+// exercising the same provider-owned parse body that production uploads use.
+func parseClaudeSession(
+	path, project, machine string,
+) ([]ParseResult, error) {
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{Machine: machine})
+	if !ok {
+		return nil, fmt.Errorf("claude provider unavailable")
+	}
+	uploader, ok := provider.(ClaudeUploadParser)
+	if !ok {
+		return nil, fmt.Errorf("claude provider does not support upload parsing")
+	}
+	return uploader.ParseUploadedTranscript(path, project, machine)
 }

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -96,15 +96,13 @@ type AgentDef struct {
 // used for iteration in config, sync, and watcher setup.
 var Registry = []AgentDef{
 	{
-		Type:           AgentClaude,
-		DisplayName:    "Claude Code",
-		EnvVar:         "CLAUDE_PROJECTS_DIR",
-		ConfigKey:      "claude_project_dirs",
-		DefaultDirs:    []string{".claude/projects"},
-		IDPrefix:       "",
-		FileBased:      true,
-		DiscoverFunc:   DiscoverClaudeProjects,
-		FindSourceFunc: FindClaudeSourceFile,
+		Type:        AgentClaude,
+		DisplayName: "Claude Code",
+		EnvVar:      "CLAUDE_PROJECTS_DIR",
+		ConfigKey:   "claude_project_dirs",
+		DefaultDirs: []string{".claude/projects"},
+		IDPrefix:    "",
+		FileBased:   true,
 	},
 	{
 		Type:           AgentCowork,

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -861,7 +861,21 @@ func (s *Server) humaUploadSession(
 		return nil, apiError(http.StatusInternalServerError, "failed to save upload")
 	}
 	defer func() { _ = os.RemoveAll(upload.tempDir) }()
-	results, err := parser.ParseClaudeSession(upload.tempPath, project, machine)
+	provider, ok := parser.NewProvider(
+		parser.AgentClaude, parser.ProviderConfig{Machine: machine},
+	)
+	if !ok {
+		return nil, apiError(http.StatusInternalServerError,
+			"claude provider unavailable")
+	}
+	uploader, ok := provider.(parser.ClaudeUploadParser)
+	if !ok {
+		return nil, apiError(http.StatusInternalServerError,
+			"claude provider does not support uploads")
+	}
+	results, err := uploader.ParseUploadedTranscript(
+		upload.tempPath, project, machine,
+	)
 	if err != nil {
 		return nil, apiError(http.StatusBadRequest,
 			fmt.Sprintf("parsing session: %v", err))
@@ -869,7 +883,6 @@ func (s *Server) humaUploadSession(
 	if len(results) == 0 {
 		return nil, apiError(http.StatusBadRequest, "no sessions parsed from upload")
 	}
-	parser.InferRelationshipTypes(results)
 	for i := range results {
 		results[i].Session.File.Path = upload.finalPath
 	}

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -67,14 +67,15 @@ func buildAiderResolveSnippet(envVar string) string {
 // "agentType:path\n" per agent target, plus "@file:path\n" lines for sibling
 // metadata files such as Codex's session_index.jsonl.
 //
-// Only includes agents where FileBased is true and DiscoverFunc
-// is non-nil. For each agent with an EnvVar, the script checks
-// the env var first and falls back to the default dir. Dirs (and
+// Only includes file-based agents that have on-disk sources to
+// resolve: either a legacy DiscoverFunc or a provider facade that has
+// left legacy-only mode. For each agent with an EnvVar, the script
+// checks the env var first and falls back to the default dir. Dirs (and
 // files) that don't exist on the remote are skipped.
 func buildResolveScript() string {
 	var b strings.Builder
 	for _, def := range parser.Registry {
-		if !def.FileBased || def.DiscoverFunc == nil {
+		if !resolveAgentHasOnDiskSource(def) {
 			continue
 		}
 		if def.Type == parser.AgentAider {
@@ -118,6 +119,28 @@ func buildResolveScript() string {
 	// path doesn't exist, which would make sh exit non-zero.
 	b.WriteString("true\n")
 	return b.String()
+}
+
+// resolveAgentHasOnDiskSource reports whether a file-based agent has
+// on-disk sources the resolve script should probe: either a legacy
+// DiscoverFunc or a provider facade that has left legacy-only mode.
+// Provider-migrated agents drop their DiscoverFunc but still have a
+// configurable directory, so they must stay in the remote resolve set.
+func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
+	if !def.FileBased {
+		return false
+	}
+	if def.DiscoverFunc != nil {
+		return true
+	}
+	switch parser.ProviderMigrationModes()[def.Type] {
+	case parser.ProviderMigrationShadowCompare,
+		parser.ProviderMigrationProviderAuthoritative:
+		_, ok := parser.ProviderFactoryByType(def.Type)
+		return ok
+	default:
+		return false
+	}
 }
 
 // parseResolvedDirs parses script output into a map of agent type to transfer

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -837,7 +837,7 @@ func (e *Engine) expandClaudeDuplicateCandidates(
 
 	out := files
 	for _, claudeDir := range e.agentDirs[parser.AgentClaude] {
-		for _, candidate := range parser.DiscoverClaudeProjects(claudeDir) {
+		for _, candidate := range parser.ClaudeProjectSessionFiles(claudeDir) {
 			sessionID := claudeSessionIDFromPath(candidate.Path)
 			if _, ok := sessionIDs[sessionID]; !ok {
 				continue
@@ -949,49 +949,12 @@ func (e *Engine) classifyOnePath(
 		return df, true
 	}
 
-	// Claude: <claudeDir>/<project>/<session>.jsonl
-	//     or: <claudeDir>/<project>/<session>/subagents/**/agent-<id>.jsonl
-	for _, claudeDir := range e.agentDirs[parser.AgentClaude] {
-		if claudeDir == "" {
-			continue
-		}
-		if rel, ok := isUnder(claudeDir, path); ok {
-			if !strings.HasSuffix(path, ".jsonl") {
-				continue
-			}
-			parts := strings.Split(rel, sep)
-
-			// Standard session: project/session.jsonl
-			if len(parts) == 2 {
-				stem := strings.TrimSuffix(
-					filepath.Base(path), ".jsonl",
-				)
-				if strings.HasPrefix(stem, "agent-") {
-					continue
-				}
-				return parser.DiscoveredFile{
-					Path:    path,
-					Project: parts[0],
-					Agent:   parser.AgentClaude,
-				}, true
-			}
-
-			// Subagent: project/session/subagents/**/agent-*.jsonl
-			if len(parts) >= 4 && parts[2] == "subagents" {
-				stem := strings.TrimSuffix(
-					parts[len(parts)-1], ".jsonl",
-				)
-				if !strings.HasPrefix(stem, "agent-") {
-					continue
-				}
-				return parser.DiscoveredFile{
-					Path:    path,
-					Project: parts[0],
-					Agent:   parser.AgentClaude,
-				}, true
-			}
-		}
-	}
+	// Claude change-path classification is provider-authoritative; the
+	// Claude provider's SourcesForChangedPath reproduces the
+	// <claudeDir>/<project>/<session>.jsonl and
+	// <claudeDir>/<project>/<session>/subagents/**/agent-<id>.jsonl
+	// shapes, so the legacy block was removed when Claude was folded
+	// onto its provider.
 
 	// Cowork: <coworkDir>/<orgId>/<workspaceId>/local_<uuid>/.claude/
 	//   projects/<enc>/<cliSessionId>.jsonl (transcript), or the sibling
@@ -4157,8 +4120,6 @@ func (e *Engine) processFile(
 
 	var res processResult
 	switch file.Agent {
-	case parser.AgentClaude:
-		res = e.processClaude(ctx, file, info)
 	case parser.AgentCowork:
 		res = e.processCowork(file, info)
 	case parser.AgentCodex:
@@ -4253,6 +4214,30 @@ func (e *Engine) processProviderFile(
 		}, true
 	}
 
+	// SyncSingleSession resolves a single session by ID and carries the
+	// caller-preferred project (typically the DB-preserved value, so a
+	// user override is not reverted) on file.Project without an explicit
+	// ProviderSource. Provider FindSource re-derives ProjectHint from the
+	// path, so honor the caller's project as the hint in that case. Full
+	// discovery and changed-path classification always supply
+	// file.ProviderSource, whose ProjectHint stays authoritative.
+	if file.ProviderSource == nil && file.Project != "" {
+		source.ProjectHint = file.Project
+	}
+
+	// DB-freshness skip for single-session JSONL providers (Claude):
+	// when the stored session's size, mtime, and data version already
+	// match the source and its project does not need reparse, skip the
+	// parse entirely. This reproduces the legacy process arm's
+	// shouldSkipFile gate so an unchanged session is not re-parsed on
+	// every full sync.
+	if mtime, fresh := e.providerSingleSessionFresh(ctx, provider, source, file); fresh {
+		return processResult{
+			skip:  true,
+			mtime: mtime,
+		}, true
+	}
+
 	fingerprint, err := provider.Fingerprint(ctx, source)
 	if err != nil {
 		return processResult{err: err}, true
@@ -4272,6 +4257,21 @@ func (e *Engine) processProviderFile(
 			}, true
 		}
 	}
+
+	// Append-only incremental parse for already-synced JSONL files.
+	// When the incremental path declines but signals forceReplace,
+	// carry the flag onto the full parse so the write path replaces
+	// stored messages instead of appending on top of stale rows.
+	incRes, incOK := e.tryProviderIncrementalAppend(
+		ctx, provider, source, file, fingerprint,
+	)
+	if incOK {
+		incRes.mtime = fingerprint.MTimeNS
+		incRes.cacheSkip = cacheSkip
+		incRes.cacheKey = cacheKey
+		return incRes, true
+	}
+	incForceReplace := incRes.forceReplace
 
 	outcome, err := provider.Parse(ctx, parser.ParseRequest{
 		Source:      source,
@@ -4320,9 +4320,15 @@ func (e *Engine) processProviderFile(
 		cacheSkip:             cacheSkip,
 		cacheKey:              cacheKey,
 		noCacheSkip:           !cleanCache,
-		forceReplace:          outcome.ForceReplace,
+		forceReplace:          outcome.ForceReplace || incForceReplace,
 		suppressPresenceSweep: !outcome.ResultSetComplete,
 	}
+	// Incremental-append providers (Claude) need the stored file
+	// identity so a later sync can detect an atomic file replacement
+	// (new inode/device) and fall back to a full parse instead of
+	// appending on top of stale state. Match the legacy process arm,
+	// which stamped inode/device from the source file stat.
+	e.stampProviderFileIdentity(provider, source, res.results)
 	for _, result := range outcome.Results {
 		if result.DataVersion == parser.DataVersionNeedsRetry {
 			if res.retrySessionIDs == nil {
@@ -4832,80 +4838,6 @@ func (f fakeSnapshotInfo) ModTime() time.Time {
 func (f fakeSnapshotInfo) IsDir() bool { return false }
 func (f fakeSnapshotInfo) Sys() any    { return nil }
 
-func (e *Engine) processClaude(
-	ctx context.Context,
-	file parser.DiscoveredFile, info os.FileInfo,
-) processResult {
-
-	sessionID := strings.TrimSuffix(info.Name(), ".jsonl")
-
-	if e.shouldSkipFile(sessionID, info) {
-		sess, _ := e.db.GetSession(
-			ctx, e.idPrefix+sessionID,
-		)
-		if sess != nil &&
-			sess.Project != "" &&
-			!parser.NeedsProjectReparse(sess.Project) {
-			return processResult{skip: true}
-		}
-	}
-
-	// Try incremental parse for append-only JSONL files
-	// that have already been synced. When the incremental path
-	// declines but signals forceReplace (e.g. cross-sync split
-	// recovery), carry the flag onto the full-parse result so the
-	// write path uses ReplaceSessionMessages.
-	res, ok := e.tryIncrementalJSONL(
-		file, info, parser.AgentClaude,
-		parser.ParseClaudeSessionFrom,
-	)
-	if ok {
-		return res
-	}
-	forceReplace := res.forceReplace
-
-	// Determine project name from cwd if possible
-	project := parser.GetProjectName(file.Project)
-	cwd, gitBranch := parser.ExtractClaudeProjectHints(
-		file.Path,
-	)
-	if cwd != "" {
-		if p := parser.ExtractProjectFromCwdWithBranchContext(
-			ctx, cwd, gitBranch,
-		); p != "" {
-			project = p
-		}
-	}
-
-	results, excludedIDs, err := parser.ParseClaudeSessionWithExclusions(
-		file.Path, project, e.machine,
-	)
-	if err != nil {
-		return processResult{err: err}
-	}
-
-	inode, device := getFileIdentity(info)
-	for i := range results {
-		results[i].Session.File.Inode = inode
-		results[i].Session.File.Device = device
-	}
-
-	hash, err := ComputeFileHash(file.Path)
-	if err == nil {
-		for i := range results {
-			results[i].Session.File.Hash = hash
-		}
-	}
-
-	parser.InferRelationshipTypes(results)
-
-	return processResult{
-		results:            results,
-		excludedSessionIDs: excludedIDs,
-		forceReplace:       forceReplace,
-	}
-}
-
 // processCowork parses a Claude Desktop "cowork" (local agent mode)
 // session. The transcript is a standard Claude Code JSONL file nested
 // inside the cowork session directory, so the work is delegated to the
@@ -4948,6 +4880,173 @@ func (e *Engine) processCowork(
 		results:            results,
 		excludedSessionIDs: excludedIDs,
 	}
+}
+
+// providerSingleSessionFresh reports whether a single-session JSONL
+// provider's source (Claude) maps to a stored session that is already
+// up to date: the source size and mtime match what is stored, the row
+// is at the current parser data version, and its project does not need
+// reparse. It reproduces the legacy Claude process arm's shouldSkipFile
+// gate so an unchanged session is skipped instead of re-parsed every
+// full sync. Providers without incremental append, multi-session
+// sources, or sources that are not a single physical file are never
+// considered fresh here and always fall through to the full parse.
+func (e *Engine) providerSingleSessionFresh(
+	ctx context.Context,
+	provider parser.Provider,
+	source parser.SourceRef,
+	file parser.DiscoveredFile,
+) (int64, bool) {
+	// Match the legacy shouldSkipFile gate, which keyed off the
+	// engine-wide forceParse (parse-diff) flag only. A per-file
+	// ForceParse (set by SyncSingleSession to bypass the error skip
+	// cache) must not defeat the DB-freshness skip: an unchanged session
+	// is still skipped so a single-session resync does not, for example,
+	// reapply a worktree project mapping to a file that has not changed.
+	if e.forceParse {
+		return 0, false
+	}
+	// Claude is the single-physical-file provider that takes the
+	// append-only incremental path. Its source stem is the session ID,
+	// so DB freshness can be checked by that ID even though a DAG fork
+	// can later split the file into several sessions.
+	if provider.Capabilities().Source.IncrementalAppend !=
+		parser.CapabilitySupported {
+		return 0, false
+	}
+	path := providerDiscoveredPath(source)
+	if path == "" {
+		return 0, false
+	}
+	sessionID := claudeSessionIDFromPath(path)
+	if sessionID == "" {
+		return 0, false
+	}
+	lookupPath := path
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(path)
+	}
+	info, err := os.Stat(lookupPath)
+	if err != nil {
+		info, err = os.Stat(path)
+		if err != nil {
+			return 0, false
+		}
+	}
+	if !e.shouldSkipFile(sessionID, info) {
+		return 0, false
+	}
+	sess, _ := e.db.GetSession(ctx, e.idPrefix+sessionID)
+	return info.ModTime().UnixNano(), sess != nil &&
+		sess.Project != "" &&
+		!parser.NeedsProjectReparse(sess.Project)
+}
+
+// stampProviderFileIdentity copies the source file's inode and device onto
+// every parsed result for an incremental-append provider (Claude). The
+// legacy process arm stamped this identity from the source stat so the
+// incremental path can later detect an atomic file replacement and fall
+// back to a full parse. Providers whose source is not a single physical
+// file, or that do not support incremental append, are left untouched.
+func (e *Engine) stampProviderFileIdentity(
+	provider parser.Provider,
+	source parser.SourceRef,
+	results []parser.ParseResult,
+) {
+	if provider.Capabilities().Source.IncrementalAppend !=
+		parser.CapabilitySupported {
+		return
+	}
+	path := providerDiscoveredPath(source)
+	if path == "" {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	inode, device := getFileIdentity(info)
+	for i := range results {
+		results[i].Session.File.Inode = inode
+		results[i].Session.File.Device = device
+	}
+}
+
+// tryProviderIncrementalAppend reproduces the legacy incremental-append
+// sync path for a provider-authoritative agent that supports append-only
+// incremental parsing (Claude). The provider owns the byte-offset parse
+// via ParseIncremental, but the engine still owns the DB-aware
+// bookkeeping (session lookup, data-version and identity guards, ordinal
+// resume, cross-sync split detection, and cumulative counters), so this
+// drives the shared tryIncrementalJSONL with an adapter that calls the
+// provider. Returns (result, true) when the incremental path produced a
+// terminal result, or (result, false) to fall through to the full
+// provider parse (carrying any forceReplace signal).
+func (e *Engine) tryProviderIncrementalAppend(
+	ctx context.Context,
+	provider parser.Provider,
+	source parser.SourceRef,
+	file parser.DiscoveredFile,
+	fingerprint parser.SourceFingerprint,
+) (processResult, bool) {
+	// Match the legacy tryIncrementalJSONL gate, which suppressed append
+	// deltas only under the engine-wide forceParse (parse-diff) flag. A
+	// per-file ForceParse does not disable incremental append.
+	if e.forceParse {
+		return processResult{}, false
+	}
+	if provider.Capabilities().Source.IncrementalAppend !=
+		parser.CapabilitySupported {
+		return processResult{}, false
+	}
+	path := providerDiscoveredPath(source)
+	if path == "" {
+		return processResult{}, false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return processResult{}, false
+	}
+
+	parseFn := func(
+		_ string, offset int64, startOrdinal int, lastEntryUUID string,
+	) ([]parser.ParsedMessage, time.Time, int64, error) {
+		outcome, status, perr := provider.ParseIncremental(
+			ctx,
+			parser.IncrementalRequest{
+				Source:        source,
+				Fingerprint:   fingerprint,
+				SessionID:     e.idPrefix + claudeSessionIDFromPath(path),
+				Offset:        offset,
+				StartOrdinal:  startOrdinal,
+				Machine:       e.machine,
+				LastEntryUUID: lastEntryUUID,
+			},
+		)
+		if perr != nil {
+			return nil, time.Time{}, 0, perr
+		}
+		switch status {
+		case parser.IncrementalNeedsFullParse:
+			if outcome.ForceReplace {
+				// Signal the shared helper to fall back to a
+				// full parse that replaces stored messages.
+				return nil, time.Time{}, 0,
+					parser.ErrClaudeIncrementalNeedsFullParse
+			}
+			// A plain full-parse fallback (e.g. DAG detected):
+			// return a non-fallback error so the helper runs a
+			// normal full parse without forceReplace.
+			return nil, time.Time{}, 0, parser.ErrDAGDetected
+		case parser.IncrementalNoNewData:
+			return nil, time.Time{}, 0, nil
+		default:
+			return outcome.Messages, outcome.EndedAt,
+				outcome.ConsumedBytes, nil
+		}
+	}
+
+	return e.tryIncrementalJSONL(file, info, file.Agent, parseFn)
 }
 
 // incrementalParseFunc reads new JSONL lines from a file
@@ -5008,9 +5107,6 @@ func (e *Engine) tryIncrementalJSONL(
 	}
 
 	currentSize := info.Size()
-	if currentSize <= inc.FileSize {
-		return processResult{}, false
-	}
 
 	// A prior sync that stored no message rows has no safe append
 	// boundary. Rewritten files can grow in place and keep the same
@@ -5037,8 +5133,22 @@ func (e *Engine) tryIncrementalJSONL(
 				inc.FileInode, curInode,
 				inc.FileDevice, curDevice,
 			)
-			return processResult{}, false
+			return processResult{forceReplace: true}, false
 		}
+	}
+	if currentSize < inc.FileSize {
+		log.Printf(
+			"incremental %s %s: file truncated from %d to %d, full parse",
+			agent, file.Path, inc.FileSize, currentSize,
+		)
+		return processResult{forceReplace: true}, false
+	}
+	if currentSize == inc.FileSize {
+		log.Printf(
+			"incremental %s %s: file size unchanged at %d but changed since last sync, full parse",
+			agent, file.Path, currentSize,
+		)
+		return processResult{forceReplace: true}, false
 	}
 
 	// Persist the same effective file_mtime a full parse would store. For

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -7285,6 +7285,106 @@ func TestIncrementalSync_ClaudeFileReplaced(t *testing.T) {
 	assert.Equal(t, newInfo.Size(), *full.FileSize, "file_size = %v, want %d (full-parse size)", *full.FileSize, newInfo.Size())
 }
 
+func TestIncrementalSync_ClaudeTruncatedFileReplacesStoredMessages(t *testing.T) {
+	env := setupTestEnv(t)
+
+	original := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsZero),
+		testjsonl.ClaudeAssistantJSON("stale assistant", tsZeroS5),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "truncated-replace.jsonl", original,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "truncated-replace", 2)
+
+	replacement := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("replacement", tsZero),
+	)
+	require.Less(t, len(replacement), len(original), "replacement must truncate file")
+	require.NoError(t, os.WriteFile(path, []byte(replacement), 0o644), "write truncated replacement")
+
+	env.engine.SyncPaths([]string{path})
+
+	assertSessionMessageCount(t, env.db, "truncated-replace", 1)
+	msgs := fetchMessages(t, env.db, "truncated-replace")
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "replacement", msgs[0].Content)
+}
+
+func TestIncrementalSync_ClaudeSameSizeFileReplaceUsesFullParse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("identity tracking is a no-op on Windows")
+	}
+	env := setupTestEnv(t)
+
+	original := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsZero),
+		testjsonl.ClaudeAssistantJSON("alpha", tsZeroS5),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "same-size-replace.jsonl", original,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	replacement := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("third", tsZero),
+		testjsonl.ClaudeAssistantJSON("bravo", tsZeroS5),
+	)
+	require.Len(t, replacement, len(original), "replacement fixture must keep same byte size")
+	tmp := path + ".tmp"
+	require.NoError(t, os.WriteFile(tmp, []byte(replacement), 0o644), "write replacement")
+	require.NoError(t, os.Rename(tmp, path), "rename replacement")
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "same-size-replace")
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "third", msgs[0].Content)
+	assert.Equal(t, "bravo", msgs[1].Content)
+}
+
+func TestIncrementalSync_ClaudeSameSizeInPlaceRewriteClearsStaleRows(t *testing.T) {
+	env := setupTestEnv(t)
+
+	original := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsZero),
+		testjsonl.ClaudeAssistantJSON("stale assistant", tsZeroS5),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "same-size-in-place.jsonl", original,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "same-size-in-place", 2)
+
+	replacement := ""
+	for padding := range 4096 {
+		candidate := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON(
+				"replacement"+strings.Repeat("x", padding),
+				tsZero,
+			),
+		)
+		if len(candidate) == len(original) {
+			replacement = candidate
+			break
+		}
+	}
+	require.NotEmpty(t, replacement, "failed to build same-size replacement fixture")
+	require.Len(t, replacement, len(original), "replacement fixture must keep same byte size")
+
+	require.NoError(t, os.WriteFile(path, []byte(replacement), 0o644), "write in-place replacement")
+	now := time.Now().Add(time.Second)
+	require.NoError(t, os.Chtimes(path, now, now), "bump replacement mtime")
+
+	env.engine.SyncPaths([]string{path})
+
+	assertSessionMessageCount(t, env.db, "same-size-in-place", 1)
+	msgs := fetchMessages(t, env.db, "same-size-in-place")
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0].Content, "replacement")
+}
+
 // TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse covers
 // the cross-sync split case: the first sync stores a partial assistant
 // snapshot (one of several streaming snapshots) and the next sync

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2770,10 +2770,14 @@ func TestEngine_ClassifyOnePathClaudeStatPermissionErrorStillClassifies(
 		_ = os.Chmod(projectDir, 0o755)
 	}()
 
-	got, ok := engine.classifyOnePath(path, nil)
-	require.True(t, ok, "expected path to classify despite stat permission error")
-	assert.Equal(t, path, got.Path)
-	assert.Equal(t, parser.AgentClaude, got.Agent)
+	// Claude is provider-authoritative, so classification flows through
+	// the provider's changed-path handling rather than the legacy
+	// classifyOnePath Claude block. A transient stat-permission error
+	// must still classify the path by shape so the change is not dropped.
+	files := engine.classifyPaths([]string{path})
+	require.Len(t, files, 1, "expected path to classify despite stat permission error")
+	assert.Equal(t, path, files[0].Path)
+	assert.Equal(t, parser.AgentClaude, files[0].Agent)
 }
 
 func TestEngine_ClassifyPathsDedupesOpenCodeChildPaths(t *testing.T) {

--- a/internal/sync/provider_shadow_caller_test.go
+++ b/internal/sync/provider_shadow_caller_test.go
@@ -16,6 +16,10 @@ import (
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
+// The generic shadow-compare/legacy-coexistence mechanism is exercised through
+// the Cowork agent, which remains legacy-only and reuses the Claude transcript
+// format. Claude itself is now provider-authoritative, so it no longer has a
+// legacy processFile arm to observe in shadow.
 func TestProcessFileShadowObservesProviderWithoutReplacingLegacy(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "-Users-dev-code-demo", "shadow-caller.jsonl")
@@ -36,8 +40,8 @@ func TestProcessFileShadowObservesProviderWithoutReplacingLegacy(t *testing.T) {
 		0o644,
 	))
 
-	legacyResults, legacyExcluded, err := parser.ParseClaudeSessionWithExclusions(
-		sourcePath, "demo", "devbox",
+	legacyResults, legacyExcluded, err := parser.ParseCoworkSession(
+		sourcePath, "devbox",
 	)
 	require.NoError(t, err)
 	require.Len(t, legacyResults, 1)
@@ -51,7 +55,7 @@ func TestProcessFileShadowObservesProviderWithoutReplacingLegacy(t *testing.T) {
 	providerResult.Session.File.Hash = hash
 
 	source := parser.SourceRef{
-		Provider:       parser.AgentClaude,
+		Provider:       parser.AgentCowork,
 		Key:            sourcePath,
 		DisplayPath:    sourcePath,
 		FingerprintKey: sourcePath,
@@ -61,8 +65,8 @@ func TestProcessFileShadowObservesProviderWithoutReplacingLegacy(t *testing.T) {
 		shadowTestProvider: shadowTestProvider{
 			ProviderBase: parser.ProviderBase{
 				Def: parser.AgentDef{
-					Type:        parser.AgentClaude,
-					DisplayName: "Claude Code",
+					Type:        parser.AgentCowork,
+					DisplayName: "Claude Cowork",
 				},
 			},
 			fingerprint: parser.SourceFingerprint{
@@ -83,14 +87,14 @@ func TestProcessFileShadowObservesProviderWithoutReplacingLegacy(t *testing.T) {
 	var comparisons []ProviderShadowComparison
 	engine := NewEngine(dbtest.OpenTestDB(t), EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
-			parser.AgentClaude: {root},
+			parser.AgentCowork: {root},
 		},
 		Machine: "devbox",
 		ProviderFactories: []parser.ProviderFactory{
 			shadowCallerFactory{provider: provider},
 		},
 		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-			parser.AgentClaude: parser.ProviderMigrationShadowCompare,
+			parser.AgentCowork: parser.ProviderMigrationShadowCompare,
 		},
 		ProviderShadowRecorder: func(comparison ProviderShadowComparison) {
 			comparisons = append(comparisons, comparison)
@@ -99,13 +103,13 @@ func TestProcessFileShadowObservesProviderWithoutReplacingLegacy(t *testing.T) {
 
 	result := engine.processFile(context.Background(), parser.DiscoveredFile{
 		Path:  sourcePath,
-		Agent: parser.AgentClaude,
+		Agent: parser.AgentCowork,
 	})
 
 	require.NoError(t, result.err)
 	require.Len(t, result.results, 1)
-	assert.Equal(t, "shadow-caller", result.results[0].Session.ID)
-	assert.Equal(t, parser.AgentClaude, result.results[0].Session.Agent)
+	assert.Equal(t, "cowork:shadow-caller", result.results[0].Session.ID)
+	assert.Equal(t, parser.AgentCowork, result.results[0].Session.Agent)
 	require.Len(t, comparisons, 1)
 	assert.NoError(t, comparisons[0].Err)
 	assert.Empty(t, comparisons[0].Mismatches)
@@ -257,8 +261,8 @@ func TestProcessFileShadowUsesChangedPathProviderSource(t *testing.T) {
 		0o644,
 	))
 
-	legacyResults, legacyExcluded, err := parser.ParseClaudeSessionWithExclusions(
-		sourcePath, "demo", "devbox",
+	legacyResults, legacyExcluded, err := parser.ParseCoworkSession(
+		sourcePath, "devbox",
 	)
 	require.NoError(t, err)
 	require.Len(t, legacyResults, 1)
@@ -272,7 +276,7 @@ func TestProcessFileShadowUsesChangedPathProviderSource(t *testing.T) {
 	providerResult.Session.File.Hash = hash
 
 	changedSource := parser.SourceRef{
-		Provider:       parser.AgentClaude,
+		Provider:       parser.AgentCowork,
 		Key:            "changed-path-source",
 		DisplayPath:    sourcePath,
 		FingerprintKey: sourcePath,
@@ -283,8 +287,8 @@ func TestProcessFileShadowUsesChangedPathProviderSource(t *testing.T) {
 		shadowTestProvider: shadowTestProvider{
 			ProviderBase: parser.ProviderBase{
 				Def: parser.AgentDef{
-					Type:        parser.AgentClaude,
-					DisplayName: "Claude Code",
+					Type:        parser.AgentCowork,
+					DisplayName: "Claude Cowork",
 				},
 			},
 			fingerprint: parser.SourceFingerprint{
@@ -305,14 +309,14 @@ func TestProcessFileShadowUsesChangedPathProviderSource(t *testing.T) {
 	var comparisons []ProviderShadowComparison
 	engine := NewEngine(dbtest.OpenTestDB(t), EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
-			parser.AgentClaude: {root},
+			parser.AgentCowork: {root},
 		},
 		Machine: "devbox",
 		ProviderFactories: []parser.ProviderFactory{
 			shadowCallerFactory{provider: provider},
 		},
 		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-			parser.AgentClaude: parser.ProviderMigrationShadowCompare,
+			parser.AgentCowork: parser.ProviderMigrationShadowCompare,
 		},
 		ProviderShadowRecorder: func(comparison ProviderShadowComparison) {
 			comparisons = append(comparisons, comparison)
@@ -321,7 +325,7 @@ func TestProcessFileShadowUsesChangedPathProviderSource(t *testing.T) {
 
 	result := engine.processFile(context.Background(), parser.DiscoveredFile{
 		Path:           sourcePath,
-		Agent:          parser.AgentClaude,
+		Agent:          parser.AgentCowork,
 		ForceParse:     true,
 		ProviderSource: &changedSource,
 	})
@@ -566,27 +570,27 @@ func TestProcessFileShadowRecordsCachedSkipAsNotComparable(t *testing.T) {
 		shadowTestProvider: shadowTestProvider{
 			ProviderBase: parser.ProviderBase{
 				Def: parser.AgentDef{
-					Type:        parser.AgentClaude,
-					DisplayName: "Claude Code",
+					Type:        parser.AgentCowork,
+					DisplayName: "Claude Cowork",
 				},
 			},
 		},
 		source: parser.SourceRef{
-			Provider: parser.AgentClaude,
+			Provider: parser.AgentCowork,
 			Key:      sourcePath,
 		},
 	}
 	var comparisons []ProviderShadowComparison
 	engine := NewEngine(dbtest.OpenTestDB(t), EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
-			parser.AgentClaude: {root},
+			parser.AgentCowork: {root},
 		},
 		Machine: "devbox",
 		ProviderFactories: []parser.ProviderFactory{
 			shadowCallerFactory{provider: provider},
 		},
 		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-			parser.AgentClaude: parser.ProviderMigrationShadowCompare,
+			parser.AgentCowork: parser.ProviderMigrationShadowCompare,
 		},
 		ProviderShadowRecorder: func(comparison ProviderShadowComparison) {
 			comparisons = append(comparisons, comparison)
@@ -598,7 +602,7 @@ func TestProcessFileShadowRecordsCachedSkipAsNotComparable(t *testing.T) {
 
 	result := engine.processFile(context.Background(), parser.DiscoveredFile{
 		Path:  sourcePath,
-		Agent: parser.AgentClaude,
+		Agent: parser.AgentCowork,
 	})
 
 	require.True(t, result.skip)
@@ -689,6 +693,76 @@ func TestProcessFileProviderAuthoritativeUsesInjectedProvider(t *testing.T) {
 	assert.Equal(t, info.ModTime().UnixNano(), result.mtime)
 	assert.True(t, result.forceReplace)
 	assert.Equal(t, []string{"fingerprint", "parse"}, provider.calls)
+}
+
+func TestProcessFileProviderAuthoritativeSkipsFreshClaudeBeforeFingerprint(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "-Users-dev-code-demo", "fresh.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sourcePath), 0o755))
+	require.NoError(t, os.WriteFile(sourcePath, []byte("{}\n"), 0o644))
+	info, err := os.Stat(sourcePath)
+	require.NoError(t, err)
+
+	source := parser.SourceRef{
+		Provider:       parser.AgentClaude,
+		Key:            sourcePath,
+		DisplayPath:    sourcePath,
+		FingerprintKey: sourcePath,
+		ProjectHint:    "demo",
+	}
+	provider := &shadowCallerProvider{
+		shadowTestProvider: shadowTestProvider{
+			ProviderBase: parser.ProviderBase{
+				Def: parser.AgentDef{
+					Type:        parser.AgentClaude,
+					DisplayName: "Claude Code",
+				},
+				Caps: parser.Capabilities{
+					Source: parser.SourceCapabilities{
+						IncrementalAppend: parser.CapabilitySupported,
+					},
+				},
+			},
+		},
+		source: source,
+	}
+	database := dbtest.OpenTestDB(t)
+	filePath := sourcePath
+	fileSize := info.Size()
+	fileMtime := info.ModTime().UnixNano()
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:        "fresh",
+		Project:   "demo",
+		Machine:   "devbox",
+		Agent:     string(parser.AgentClaude),
+		FilePath:  &filePath,
+		FileSize:  &fileSize,
+		FileMtime: &fileMtime,
+	}))
+	require.NoError(t, database.SetSessionDataVersion("fresh", db.CurrentDataVersion()))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine: "devbox",
+		ProviderFactories: []parser.ProviderFactory{
+			shadowCallerFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentClaude: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+
+	result := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  sourcePath,
+		Agent: parser.AgentClaude,
+	})
+
+	require.NoError(t, result.err)
+	assert.True(t, result.skip)
+	assert.Equal(t, fileMtime, result.mtime)
+	assert.Empty(t, provider.calls)
+	assert.Equal(t, sourcePath, provider.findRequest.StoredFilePath)
 }
 
 func TestProcessFileProviderAuthoritativeKeepsRetryStatePerResult(t *testing.T) {


### PR DESCRIPTION
Claude now uses a concrete provider for regular project transcripts and nested subagent transcripts. The provider keeps recursive project discovery, symlinked project directories, standard and subagent lookup, changed-path classification, content hashing, project normalization, excluded-session reporting, and relationship inference.

The provider also exposes Claude's existing incremental append parser as an optional provider capability so linear JSONL growth can continue to avoid full reparses while full-parse fallback remains available for DAG or row-rewrite cases.