### PR TITLE
feat(session list): per-key sort direction for --sort / ?order_by

### DIFF
--- a/cmd/agentsview/session_list.go
+++ b/cmd/agentsview/session_list.go
@@ -61,17 +61,27 @@ func newSessionListCommand() *cobra.Command {
 				HasSecret:        hasSecret,
 				Cursor:           cursor,
 				Limit:            limit,
-				OrderBy:          sort,
 			}
 			if cmd.Flags().Changed("min-tool-failures") {
 				f.MinToolFailures = &minToolFailures
 			}
-			// --reverse flips the sort key's canonical direction; leave
-			// Descending nil otherwise so the default applies.
-			if cmd.Flags().Changed("reverse") {
-				d := db.SortDefaultDescending(sort) != reverse
-				f.Descending = &d
+			// Parse the multi-key sort spec; --reverse flips the natural
+			// direction of any term left without an explicit :asc/:desc, which
+			// is folded into the canonical spec string so the wire form fully
+			// captures the ordering.
+			keys, err := db.ParseSortSpec(sort)
+			if err != nil {
+				return fmt.Errorf("invalid sort %q: %w", sort, err)
 			}
+			if reverse {
+				for i := range keys {
+					if keys[i].Descending == nil {
+						d := !db.SortDefaultDescending(keys[i].Key)
+						keys[i].Descending = &d
+					}
+				}
+			}
+			f.OrderBy = db.FormatSortSpec(keys)
 
 			list, err := svc.List(cmd.Context(), f)
 			if err != nil {
@@ -129,9 +139,12 @@ func newSessionListCommand() *cobra.Command {
 			db.DefaultSessionLimit, db.MaxSessionLimit,
 		))
 	flags.StringVar(&sort, "sort", "recent",
-		"Sort by: "+strings.Join(db.SortKeys(), ", "))
+		"Sort by a comma-separated list of keys, each optionally key:asc or "+
+			"key:desc (e.g. messages:desc,started:asc). Keys: "+
+			strings.Join(db.SortKeys(), ", "))
 	flags.BoolVarP(&reverse, "reverse", "r", false,
-		"Reverse the sort direction")
+		"Reverse the natural direction of sort keys that have no explicit "+
+			":asc/:desc suffix")
 
 	return cmd
 }

--- a/cmd/agentsview/session_list.go
+++ b/cmd/agentsview/session_list.go
@@ -73,6 +73,11 @@ func newSessionListCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("invalid sort %q: %w", sort, err)
 			}
+			// An empty spec means the implicit default; materialize it so
+			// --reverse has a term to flip instead of silently no-opping.
+			if len(keys) == 0 {
+				keys = []db.SortKey{{Key: db.DefaultSortKey()}}
+			}
 			if reverse {
 				for i := range keys {
 					if keys[i].Descending == nil {

--- a/cmd/agentsview/sort_test.go
+++ b/cmd/agentsview/sort_test.go
@@ -53,6 +53,36 @@ func TestSessionList_SortAndReverse(t *testing.T) {
 	assert.Equal(t, []string{"hi", "mid", "lo"}, sessionListIDs(t, out))
 }
 
+func TestSessionList_MultiKeySort(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedSessionWithOpts(t, dataDir, "a", "p", func(s *db.Session) {
+		s.MessageCount = 1
+		s.StartedAt = new("2024-03-01T00:00:00Z")
+	})
+	seedSessionWithOpts(t, dataDir, "b", "p", func(s *db.Session) {
+		s.MessageCount = 1
+		s.StartedAt = new("2024-01-01T00:00:00Z")
+	})
+	seedSessionWithOpts(t, dataDir, "c", "p", func(s *db.Session) {
+		s.MessageCount = 2
+		s.StartedAt = new("2024-02-01T00:00:00Z")
+	})
+
+	// Per-key directions: messages asc, then started desc.
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--sort", "messages:asc,started:desc", "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, sessionListIDs(t, out))
+
+	// --reverse flips only the unsuffixed key (messages -> desc); the explicit
+	// started:asc is left untouched.
+	out, err = executeCommand(newRootCommand(),
+		"session", "list", "--sort", "messages,started:asc", "-r", "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"c", "b", "a"}, sessionListIDs(t, out))
+}
+
 func TestSessionList_InvalidSort(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)

--- a/cmd/agentsview/sort_test.go
+++ b/cmd/agentsview/sort_test.go
@@ -83,6 +83,32 @@ func TestSessionList_MultiKeySort(t *testing.T) {
 	assert.Equal(t, []string{"c", "b", "a"}, sessionListIDs(t, out))
 }
 
+// TestSessionList_EmptySortReverse guards the edge where --sort is explicitly
+// cleared: --reverse must still flip the implicit default recent sort (to
+// ascending) rather than silently no-opping.
+func TestSessionList_EmptySortReverse(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedSessionWithOpts(t, dataDir, "old", "p", func(s *db.Session) {
+		s.EndedAt = new("2024-01-01T00:00:00Z")
+	})
+	seedSessionWithOpts(t, dataDir, "new", "p", func(s *db.Session) {
+		s.EndedAt = new("2024-03-01T00:00:00Z")
+	})
+
+	// Default recent is newest-first.
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--sort", "", "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"new", "old"}, sessionListIDs(t, out))
+
+	// --reverse on the empty (default) sort flips recent to oldest-first.
+	out, err = executeCommand(newRootCommand(),
+		"session", "list", "--sort", "", "--reverse", "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"old", "new"}, sessionListIDs(t, out))
+}
+
 func TestSessionList_InvalidSort(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -388,8 +388,8 @@ func TestGetActivityReport_UsageDedupSubSecondOrder(t *testing.T) {
 // TestGetActivityReport_TitleSkipsEmptyDisplayName confirms the Title fallback
 // null-checks each candidate independently: an empty (non-NULL) display_name
 // must not mask a real session_name. A nested COALESCE(display_name,
-// session_name) would return '' and be NULLIF'd away, wrongly skipping to
-// first_message. RenameSession stores a literal '' (only nil clears to NULL),
+// session_name) would return ” and be NULLIF'd away, wrongly skipping to
+// first_message. RenameSession stores a literal ” (only nil clears to NULL),
 // so this reproduces a session renamed to "" that still has a session_name.
 func TestGetActivityReport_TitleSkipsEmptyDisplayName(t *testing.T) {
 	d := testDB(t)

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -388,8 +388,8 @@ func TestGetActivityReport_UsageDedupSubSecondOrder(t *testing.T) {
 // TestGetActivityReport_TitleSkipsEmptyDisplayName confirms the Title fallback
 // null-checks each candidate independently: an empty (non-NULL) display_name
 // must not mask a real session_name. A nested COALESCE(display_name,
-// session_name) would return ” and be NULLIF'd away, wrongly skipping to
-// first_message. RenameSession stores a literal ” (only nil clears to NULL),
+// session_name) would return '' and be NULLIF'd away, wrongly skipping to
+// first_message. RenameSession stores a literal '' (only nil clears to NULL),
 // so this reproduces a session renamed to "" that still has a session_name.
 func TestGetActivityReport_TitleSkipsEmptyDisplayName(t *testing.T) {
 	d := testDB(t)

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -290,7 +290,7 @@ func (b *QueryBuilder) CursorPredicate(
 	clauses := make([]string, 0, len(cols))
 	for j := range cols {
 		parts := make([]string, 0, j+1)
-		for i := 0; i < j; i++ {
+		for i := range j {
 			e := cols[i].Sort.orderExpr(b, cols[i].Desc, f)
 			vp := b.dialect.castCursor(b.Add(vals[i]), cols[i].Sort.kind)
 			parts = append(parts, e+" = "+vp)

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -253,40 +253,65 @@ func (d QueryDialect) timestampExpr(col string) string {
 	return col
 }
 
-// OrderByClause renders the session-list ordering for a resolved sort and
-// direction, with id as a same-direction tie-breaker so keyset pagination is
-// deterministic. The sort expression may add bind parameters (secrets sort), so
+// OrderByClause renders the session-list ordering for the resolved sort terms,
+// each in its own direction, with id appended as a unique same-direction
+// tie-breaker (unless id is already a sort term) so keyset pagination is
+// deterministic. Sort expressions may add bind parameters (the secrets sort), so
 // callers must render this at its textual position.
-func (b *QueryBuilder) OrderByClause(sp SessionSort, desc bool, f SessionFilter) string {
-	orderExpr := sp.orderExpr(b, desc, f)
-	dir := "ASC"
-	if desc {
-		dir = "DESC"
+func (b *QueryBuilder) OrderByClause(rs []ResolvedSort, f SessionFilter) string {
+	cols := appendIDTiebreaker(rs)
+	parts := make([]string, len(cols))
+	for i, c := range cols {
+		parts[i] = c.Sort.orderExpr(b, c.Desc, f) + " " + orderDirSQL(c.Desc)
 	}
-	if orderExpr == "id" {
-		return "ORDER BY id " + dir
-	}
-	return "ORDER BY " + orderExpr + " " + dir + ", id " + dir
+	return "ORDER BY " + strings.Join(parts, ", ")
 }
 
 // CursorPredicate renders the keyset pagination predicate matching an
-// OrderByClause built from the same sort and direction. The bound value is cast
-// per dialect for the column's kind; it must already be the Go type produced by
-// SessionSort.CursorPredicateValue.
+// OrderByClause built from the same sort terms. Because per-key directions may
+// differ, the predicate is the lexicographic expansion
+//
+//	(c1 OP1 v1) OR (c1 = v1 AND c2 OP2 v2) OR ...
+//
+// rather than a single row-value comparison (which is only valid when every
+// column shares one direction). Each value is bound and cast per dialect for its
+// column kind, and must already be the Go type produced by CursorPredicateValues
+// (one value per resolved term, in order). Sort expressions are re-rendered for
+// each clause they appear in so any bind parameters they add (the secrets sort)
+// stay positionally aligned across dialects.
 func (b *QueryBuilder) CursorPredicate(
-	sp SessionSort, desc bool, f SessionFilter, value any, id string,
+	rs []ResolvedSort, f SessionFilter, values []any, id string,
 ) string {
-	orderExpr := sp.orderExpr(b, desc, f)
-	op := ">"
+	cols := appendIDTiebreaker(rs)
+	vals := values
+	if len(cols) > len(rs) {
+		vals = append(append(make([]any, 0, len(cols)), values...), id)
+	}
+	clauses := make([]string, 0, len(cols))
+	for j := range cols {
+		parts := make([]string, 0, j+1)
+		for i := 0; i < j; i++ {
+			e := cols[i].Sort.orderExpr(b, cols[i].Desc, f)
+			vp := b.dialect.castCursor(b.Add(vals[i]), cols[i].Sort.kind)
+			parts = append(parts, e+" = "+vp)
+		}
+		op := ">"
+		if cols[j].Desc {
+			op = "<"
+		}
+		e := cols[j].Sort.orderExpr(b, cols[j].Desc, f)
+		vp := b.dialect.castCursor(b.Add(vals[j]), cols[j].Sort.kind)
+		parts = append(parts, e+" "+op+" "+vp)
+		clauses = append(clauses, "("+strings.Join(parts, " AND ")+")")
+	}
+	return "(" + strings.Join(clauses, " OR ") + ")"
+}
+
+func orderDirSQL(desc bool) string {
 	if desc {
-		op = "<"
+		return "DESC"
 	}
-	if orderExpr == "id" {
-		return "id " + op + " " + b.dialect.castCursor(b.Add(id), kindText)
-	}
-	vp := b.dialect.castCursor(b.Add(value), sp.kind)
-	ip := b.Add(id)
-	return "(" + orderExpr + ", id) " + op + " (" + vp + ", " + ip + ")"
+	return "ASC"
 }
 
 // LimitOffset renders a parameterized LIMIT/OFFSET clause.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -218,6 +218,33 @@ type SessionCursor struct {
 	// Value is the sort column's value for the page's last row, encoded as a
 	// string and re-typed per the sort's kind when comparing.
 	Value string `json:"v,omitempty"`
+	// Keys carries one keyset term per column for multi-key sorts. When present
+	// it is authoritative; the single-key Sort/Desc/Value (and EndedAt) fields
+	// are only populated for single-key sorts so older readers still decode.
+	Keys []SessionCursorKey `json:"ks,omitempty"`
+}
+
+// SessionCursorKey is one column's keyset term inside a multi-key cursor: the
+// sort key it was minted under, its direction, and the page's last-row value
+// (re-typed per the sort's kind when comparing).
+type SessionCursorKey struct {
+	Sort  string `json:"k"`
+	Desc  bool   `json:"d,omitempty"`
+	Value string `json:"v,omitempty"`
+}
+
+// resolvedKeys returns the cursor's keyset terms, synthesizing the single-key
+// list from the legacy fields when the multi-key Keys slice is absent. A cursor
+// with neither Keys nor Sort is a pre-sort legacy token, valid only for the
+// default recent-descending order it was always minted under.
+func (cur SessionCursor) resolvedKeys() []SessionCursorKey {
+	if len(cur.Keys) > 0 {
+		return cur.Keys
+	}
+	if cur.Sort != "" {
+		return []SessionCursorKey{{Sort: cur.Sort, Desc: cur.Desc, Value: cur.Value}}
+	}
+	return []SessionCursorKey{{Sort: defaultSortKey, Desc: true, Value: cur.EndedAt}}
 }
 
 // EncodeCursor returns a base64-encoded, HMAC-signed cursor string.
@@ -319,10 +346,17 @@ type SessionFilter struct {
 	//   "unclean"    → only sessions with status IN
 	//                  ('tool_call_pending', 'truncated')
 	Termination string
-	// OrderBy selects the sort column ("" = recent activity, the default).
-	// Valid keys are enumerated by SortKeys / ValidSortKey.
+	// Sort is the ordered, structured sort specification: each term is a sort
+	// key with an optional per-key direction. When non-empty it is the canonical
+	// source of ordering and takes precedence over OrderBy/Descending. This is
+	// the field new callers should set to express per-key sort direction.
+	Sort []SortKey
+	// OrderBy is the legacy single-key shorthand, kept for existing callers. It
+	// accepts the same comma-separated "key:dir" spec ParseSortSpec parses and is
+	// used only when Sort is empty. "" means recent activity, the default.
 	OrderBy string
-	// Descending overrides the sort key's canonical direction when non-nil.
+	// Descending is the legacy fallback direction applied to OrderBy terms that
+	// carry no explicit direction. Used only when Sort is empty.
 	Descending *bool
 }
 
@@ -436,8 +470,7 @@ func (db *DB) ListSessions(
 	where, args := buildSessionFilter(f)
 
 	dialect := SQLiteQueryDialect()
-	sp, _ := SessionSortFor(f.OrderBy)
-	desc := sp.ResolveDescending(f.Descending)
+	rs := ResolveSort(f)
 
 	var total int
 	var cur SessionCursor
@@ -467,18 +500,18 @@ func (db *DB) ListSessions(
 	pageBuilder := NewQueryBuilder(dialect, len(args))
 	cursorWhere := where
 	if f.Cursor != "" {
-		val, err := sp.CursorPredicateValue(cur, desc)
+		vals, err := CursorPredicateValues(cur, rs)
 		if err != nil {
 			return SessionPage{}, err
 		}
 		cursorWhere += " AND " + pageBuilder.CursorPredicate(
-			sp, desc, f, val, cur.ID,
+			rs, f, vals, cur.ID,
 		)
 	}
 
 	query := "SELECT " + sessionBaseCols +
 		" FROM sessions WHERE " + cursorWhere + " " +
-		pageBuilder.OrderByClause(sp, desc, f) + " " +
+		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 
@@ -499,7 +532,7 @@ func (db *DB) ListSessions(
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
 		page.NextCursor = db.EncodeCursor(
-			sp.NextCursor(&last, desc, total, f),
+			NextSessionCursor(&last, rs, total, f),
 		)
 	}
 

--- a/internal/db/sort.go
+++ b/internal/db/sort.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"slices"
 	"strconv"
+	"strings"
 )
 
 // valueKind classifies a sort column's value so the keyset cursor can bind it
@@ -87,52 +88,200 @@ func (sp SessionSort) ResolveDescending(descending *bool) bool {
 	return sp.defaultDescending
 }
 
-// NextCursor builds the pagination token for a page's last row under the
-// resolved sort and direction.
-func (sp SessionSort) NextCursor(last *Session, desc bool, total int, f SessionFilter) SessionCursor {
-	v := sp.cursorValue(last, desc, f)
-	cur := SessionCursor{
-		ID:    last.ID,
-		Total: total,
-		Sort:  sp.key,
-		Desc:  desc,
-		Value: v,
+// SortKey is one ordered sort term for a SessionFilter: a registry key with an
+// optional direction override. A nil Descending means the key's canonical
+// default direction applies (recent is descending; every other key ascending).
+type SortKey struct {
+	Key        string
+	Descending *bool
+}
+
+// ResolvedSort pairs a registered SessionSort with the concrete direction
+// resolved for one term, after applying any per-key override or fallback.
+type ResolvedSort struct {
+	Sort SessionSort
+	Desc bool
+}
+
+// ParseSortSpec parses the public sort specification used by --sort and
+// ?order_by: a comma-separated list of terms, each "key" or "key:asc"/"key:desc".
+// An empty spec yields no terms (callers apply the default). Unknown keys,
+// unknown direction tokens, duplicate keys, and empty terms are reported as
+// errors so the service layer can reject bad input with a clear message.
+func ParseSortSpec(spec string) ([]SortKey, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return nil, nil
 	}
-	if sp.key == defaultSortKey {
-		// Keep the legacy field populated so default-sort cursors remain
-		// decodable by older readers during a rollout.
-		cur.EndedAt = v
+	parts := strings.Split(spec, ",")
+	keys := make([]SortKey, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("empty sort term")
+		}
+		key := part
+		var dir *bool
+		if i := strings.IndexByte(part, ':'); i >= 0 {
+			key = strings.TrimSpace(part[:i])
+			switch strings.TrimSpace(part[i+1:]) {
+			case "asc":
+				d := false
+				dir = &d
+			case "desc":
+				d := true
+				dir = &d
+			default:
+				return nil, fmt.Errorf(
+					"invalid sort direction in %q: want asc or desc", part)
+			}
+		}
+		if _, ok := sessionSortByKey[key]; !ok {
+			return nil, fmt.Errorf("unknown sort key %q", key)
+		}
+		if seen[key] {
+			return nil, fmt.Errorf("duplicate sort key %q", key)
+		}
+		seen[key] = true
+		keys = append(keys, SortKey{Key: key, Descending: dir})
+	}
+	return keys, nil
+}
+
+// FormatSortSpec renders sort terms back into the canonical --sort/?order_by
+// string. A term with an explicit direction renders "key:asc"/"key:desc"; a term
+// left at its canonical default renders the bare key.
+func FormatSortSpec(keys []SortKey) string {
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		switch {
+		case k.Descending == nil:
+			parts[i] = k.Key
+		case *k.Descending:
+			parts[i] = k.Key + ":desc"
+		default:
+			parts[i] = k.Key + ":asc"
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+// ApplyFallbackDirection fills in the direction of any term left unspecified
+// (the legacy descending param / single-key default). Terms that carry an
+// explicit per-key direction are untouched. A nil fallback leaves every
+// unspecified term at its canonical default.
+func ApplyFallbackDirection(keys []SortKey, descending *bool) []SortKey {
+	if descending == nil {
+		return keys
+	}
+	out := make([]SortKey, len(keys))
+	for i, k := range keys {
+		if k.Descending == nil {
+			d := *descending
+			k.Descending = &d
+		}
+		out[i] = k
+	}
+	return out
+}
+
+// ResolveSort turns a filter's sort specification into the ordered list of
+// columns the query is sorted by. The structured Sort field wins; otherwise the
+// legacy OrderBy string (folded with Descending) is parsed. Unknown or duplicate
+// keys are dropped defensively so a store never panics on unvalidated input, and
+// an empty result falls back to the default recent sort. Callers that must
+// reject bad input (the service layer) should validate via ParseSortSpec first.
+func ResolveSort(f SessionFilter) []ResolvedSort {
+	terms := f.Sort
+	if len(terms) == 0 {
+		parsed, err := ParseSortSpec(f.OrderBy)
+		if err != nil {
+			parsed = nil
+		}
+		terms = ApplyFallbackDirection(parsed, f.Descending)
+	}
+	rs := make([]ResolvedSort, 0, len(terms))
+	seen := make(map[string]bool, len(terms))
+	for _, t := range terms {
+		sp, ok := sessionSortByKey[t.Key]
+		if !ok || seen[sp.key] {
+			continue
+		}
+		seen[sp.key] = true
+		rs = append(rs, ResolvedSort{Sort: sp, Desc: sp.ResolveDescending(t.Descending)})
+	}
+	if len(rs) == 0 {
+		sp := sessionSortByKey[defaultSortKey]
+		rs = append(rs, ResolvedSort{Sort: sp, Desc: sp.defaultDescending})
+	}
+	return rs
+}
+
+// appendIDTiebreaker ensures the ordered columns end with the unique id column
+// so keyset pagination is deterministic. When id is already an explicit sort
+// term the list is returned unchanged; otherwise id is appended in the last
+// term's direction (the tie-breaker behavior id has always had).
+func appendIDTiebreaker(rs []ResolvedSort) []ResolvedSort {
+	for _, r := range rs {
+		if r.Sort.key == "id" {
+			return rs
+		}
+	}
+	out := make([]ResolvedSort, len(rs), len(rs)+1)
+	copy(out, rs)
+	return append(out, ResolvedSort{Sort: sessionSortByKey["id"], Desc: rs[len(rs)-1].Desc})
+}
+
+// NextSessionCursor builds the pagination token for a page's last row under the
+// resolved multi-key sort. Each sort term contributes a typed keyset value. For
+// a single-key sort the legacy Sort/Desc/Value fields (and EndedAt for the
+// default recent sort) are also populated so cursors stay decodable by readers
+// from before multi-key sorting existed.
+func NextSessionCursor(last *Session, rs []ResolvedSort, total int, f SessionFilter) SessionCursor {
+	cur := SessionCursor{ID: last.ID, Total: total}
+	cur.Keys = make([]SessionCursorKey, len(rs))
+	for i, r := range rs {
+		cur.Keys[i] = SessionCursorKey{
+			Sort:  r.Sort.key,
+			Desc:  r.Desc,
+			Value: r.Sort.cursorValue(last, r.Desc, f),
+		}
+	}
+	if len(rs) == 1 {
+		k := cur.Keys[0]
+		cur.Sort = k.Sort
+		cur.Desc = k.Desc
+		cur.Value = k.Value
+		if k.Sort == defaultSortKey && k.Desc {
+			cur.EndedAt = k.Value
+		}
 	}
 	return cur
 }
 
-// CursorPredicateValue validates a decoded cursor against the resolved sort and
-// returns the typed value the keyset predicate must bind. A cursor minted under
-// a different sort/direction, or with an unparseable value, is rejected as an
-// invalid cursor rather than silently producing wrong pages.
-func (sp SessionSort) CursorPredicateValue(cur SessionCursor, desc bool) (any, error) {
-	if !sp.cursorMatches(cur, desc) {
+// CursorPredicateValues validates a decoded cursor against the resolved sort and
+// returns the typed keyset values, one per term, that the predicate must bind. A
+// cursor minted under a different sort (different keys, order, or directions), or
+// carrying an unparseable value, is rejected as an invalid cursor rather than
+// silently producing wrong pages.
+func CursorPredicateValues(cur SessionCursor, rs []ResolvedSort) ([]any, error) {
+	keys := cur.resolvedKeys()
+	if len(keys) != len(rs) {
 		return nil, fmt.Errorf("%w: sort mismatch", ErrInvalidCursor)
 	}
-	raw := cur.Value
-	if cur.Sort == "" {
-		raw = cur.EndedAt
+	vals := make([]any, len(rs))
+	for i, r := range rs {
+		if keys[i].Sort != r.Sort.key || keys[i].Desc != r.Desc {
+			return nil, fmt.Errorf("%w: sort mismatch", ErrInvalidCursor)
+		}
+		v, err := typedCursorValue(keys[i].Value, r.Sort.kind)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidCursor, err)
+		}
+		vals[i] = v
 	}
-	v, err := typedCursorValue(raw, sp.kind)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidCursor, err)
-	}
-	return v, nil
-}
-
-// cursorMatches reports whether a decoded cursor was minted under the resolved
-// sort and direction. Legacy cursors (no Sort) are only valid for the default
-// recent-descending order they were always created under.
-func (sp SessionSort) cursorMatches(cur SessionCursor, desc bool) bool {
-	if cur.Sort == "" {
-		return sp.key == defaultSortKey && desc
-	}
-	return cur.Sort == sp.key && cur.Desc == desc
+	return vals, nil
 }
 
 func sentinelLiteral(kind valueKind, desc bool) string {

--- a/internal/db/sort.go
+++ b/internal/db/sort.go
@@ -213,7 +213,14 @@ func ResolveSort(f SessionFilter) []ResolvedSort {
 	}
 	if len(rs) == 0 {
 		sp := sessionSortByKey[defaultSortKey]
-		rs = append(rs, ResolvedSort{Sort: sp, Desc: sp.defaultDescending})
+		desc := sp.defaultDescending
+		// Preserve the single-key behavior where a legacy Descending override
+		// applies to the implicit default recent key (e.g. descending=false with
+		// no order_by means recent ascending).
+		if len(f.Sort) == 0 && f.Descending != nil {
+			desc = *f.Descending
+		}
+		rs = append(rs, ResolvedSort{Sort: sp, Desc: desc})
 	}
 	return rs
 }

--- a/internal/db/sort.go
+++ b/internal/db/sort.go
@@ -123,9 +123,9 @@ func ParseSortSpec(spec string) ([]SortKey, error) {
 		}
 		key := part
 		var dir *bool
-		if i := strings.IndexByte(part, ':'); i >= 0 {
-			key = strings.TrimSpace(part[:i])
-			switch strings.TrimSpace(part[i+1:]) {
+		if before, after, ok := strings.Cut(part, ":"); ok {
+			key = strings.TrimSpace(before)
+			switch strings.TrimSpace(after) {
 			case "asc":
 				d := false
 				dir = &d

--- a/internal/db/sort.go
+++ b/internal/db/sort.go
@@ -399,8 +399,8 @@ func secretsValue(s *Session, f SessionFilter) (string, bool) {
 }
 
 // sessionSorts is the allow-list of session-list sort keys, in display order.
-// The ordering is kept in sync with the huma `order_by` enum tag by
-// TestSortKeysMatchHumaEnum.
+// The keys here are kept documented on the huma order_by param by
+// TestSortKeysDocumented / TestSortKeysDocOmitsStaleKeys (internal/server).
 var sessionSorts = []SessionSort{
 	{key: "recent", kind: kindTimestamp, defaultDescending: true, expr: recentExpr, value: tsValue},
 	{key: "started", kind: kindTimestamp, expr: startedExpr, value: startedValue},
@@ -439,6 +439,11 @@ var sessionSortByKey = func() map[string]SessionSort {
 // defaultSortKey is the sort applied when OrderBy is empty; it preserves the
 // historical most-recent-activity-first behavior.
 const defaultSortKey = "recent"
+
+// DefaultSortKey returns the sort key applied when no sort is requested. The CLI
+// uses it to materialize the implicit default so --reverse can flip it even when
+// --sort is empty.
+func DefaultSortKey() string { return defaultSortKey }
 
 // SessionSortFor resolves a sort key (empty means the default). ok is false for
 // unknown keys; callers that have not pre-validated should treat that as the

--- a/internal/db/sort_multikey_test.go
+++ b/internal/db/sort_multikey_test.go
@@ -167,6 +167,15 @@ func TestResolveSort(t *testing.T) {
 		rs := ResolveSort(SessionFilter{Sort: []SortKey{{Key: "bogus"}}})
 		assert.Equal(t, []string{"recent:desc"}, keys(rs))
 	})
+
+	t.Run("legacy descending applies to implicit default recent", func(t *testing.T) {
+		// descending=false with no order_by means recent ascending (the
+		// single-key behavior before multi-key sorting).
+		rs := ResolveSort(SessionFilter{Descending: &asc})
+		assert.Equal(t, []string{"recent:asc"}, keys(rs))
+		rs = ResolveSort(SessionFilter{Descending: &desc})
+		assert.Equal(t, []string{"recent:desc"}, keys(rs))
+	})
 }
 
 // TestListSessions_MultiKeySort verifies a mixed-direction multi-key sort

--- a/internal/db/sort_multikey_test.go
+++ b/internal/db/sort_multikey_test.go
@@ -1,0 +1,386 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSortSpec(t *testing.T) {
+	asc, desc := false, true
+	cases := []struct {
+		name    string
+		spec    string
+		want    []SortKey
+		wantErr string
+	}{
+		{name: "empty yields no terms", spec: "", want: nil},
+		{name: "whitespace only", spec: "  ", want: nil},
+		{
+			name: "single bare key",
+			spec: "messages",
+			want: []SortKey{{Key: "messages"}},
+		},
+		{
+			name: "single key with desc",
+			spec: "messages:desc",
+			want: []SortKey{{Key: "messages", Descending: &desc}},
+		},
+		{
+			name: "multi key mixed directions",
+			spec: "messages:desc,started:asc",
+			want: []SortKey{
+				{Key: "messages", Descending: &desc},
+				{Key: "started", Descending: &asc},
+			},
+		},
+		{
+			name: "mixed suffixed and bare with spaces",
+			spec: " messages , started:asc ",
+			want: []SortKey{
+				{Key: "messages"},
+				{Key: "started", Descending: &asc},
+			},
+		},
+		{name: "unknown key", spec: "bogus", wantErr: "unknown sort key"},
+		{name: "unknown key in list", spec: "messages,bogus", wantErr: "unknown sort key"},
+		{name: "bad direction", spec: "messages:up", wantErr: "invalid sort direction"},
+		{name: "duplicate key", spec: "messages,messages:asc", wantErr: "duplicate sort key"},
+		{name: "empty term", spec: "messages,,started", wantErr: "empty sort term"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseSortSpec(tc.spec)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestFormatSortSpec(t *testing.T) {
+	asc, desc := false, true
+	got := FormatSortSpec([]SortKey{
+		{Key: "recent"},
+		{Key: "messages", Descending: &desc},
+		{Key: "started", Descending: &asc},
+	})
+	assert.Equal(t, "recent,messages:desc,started:asc", got)
+
+	// ParseSortSpec(FormatSortSpec(x)) round-trips a parsed spec.
+	orig := "messages:desc,started:asc,id"
+	parsed, err := ParseSortSpec(orig)
+	require.NoError(t, err)
+	assert.Equal(t, orig, FormatSortSpec(parsed))
+}
+
+func TestApplyFallbackDirection(t *testing.T) {
+	asc, desc := false, true
+
+	// nil fallback leaves terms untouched.
+	in := []SortKey{{Key: "messages"}, {Key: "started", Descending: &asc}}
+	assert.Equal(t, in, ApplyFallbackDirection(in, nil))
+
+	// A fallback fills only the terms without an explicit direction.
+	out := ApplyFallbackDirection(
+		[]SortKey{{Key: "messages"}, {Key: "started", Descending: &asc}},
+		&desc,
+	)
+	require.Len(t, out, 2)
+	require.NotNil(t, out[0].Descending)
+	assert.True(t, *out[0].Descending, "bare term takes the fallback")
+	require.NotNil(t, out[1].Descending)
+	assert.False(t, *out[1].Descending, "explicit term is untouched")
+
+	// The input slice is not mutated.
+	assert.Nil(t, in[0].Descending)
+}
+
+func TestResolveSort(t *testing.T) {
+	asc, desc := false, true
+	keys := func(rs []ResolvedSort) []string {
+		out := make([]string, len(rs))
+		for i, r := range rs {
+			d := "asc"
+			if r.Desc {
+				d = "desc"
+			}
+			out[i] = r.Sort.key + ":" + d
+		}
+		return out
+	}
+
+	t.Run("empty defaults to recent desc", func(t *testing.T) {
+		assert.Equal(t, []string{"recent:desc"}, keys(ResolveSort(SessionFilter{})))
+	})
+
+	t.Run("structured Sort wins over OrderBy", func(t *testing.T) {
+		rs := ResolveSort(SessionFilter{
+			Sort:    []SortKey{{Key: "messages", Descending: &desc}},
+			OrderBy: "started",
+		})
+		assert.Equal(t, []string{"messages:desc"}, keys(rs))
+	})
+
+	t.Run("structured multi-key with per-key direction", func(t *testing.T) {
+		rs := ResolveSort(SessionFilter{Sort: []SortKey{
+			{Key: "messages", Descending: &desc},
+			{Key: "started", Descending: &asc},
+		}})
+		assert.Equal(t, []string{"messages:desc", "started:asc"}, keys(rs))
+	})
+
+	t.Run("bare term uses canonical default", func(t *testing.T) {
+		rs := ResolveSort(SessionFilter{Sort: []SortKey{
+			{Key: "recent"},   // canonical desc
+			{Key: "messages"}, // canonical asc
+		}})
+		assert.Equal(t, []string{"recent:desc", "messages:asc"}, keys(rs))
+	})
+
+	t.Run("legacy OrderBy string + Descending fallback", func(t *testing.T) {
+		rs := ResolveSort(SessionFilter{
+			OrderBy:    "messages,started:asc",
+			Descending: &desc,
+		})
+		// messages is bare -> fallback desc; started is explicit asc.
+		assert.Equal(t, []string{"messages:desc", "started:asc"}, keys(rs))
+	})
+
+	t.Run("unknown and duplicate keys dropped defensively", func(t *testing.T) {
+		rs := ResolveSort(SessionFilter{Sort: []SortKey{
+			{Key: "messages"},
+			{Key: "bogus"},
+			{Key: "messages", Descending: &desc},
+		}})
+		assert.Equal(t, []string{"messages:asc"}, keys(rs))
+	})
+
+	t.Run("all-invalid falls back to default", func(t *testing.T) {
+		rs := ResolveSort(SessionFilter{Sort: []SortKey{{Key: "bogus"}}})
+		assert.Equal(t, []string{"recent:desc"}, keys(rs))
+	})
+}
+
+// TestListSessions_MultiKeySort verifies a mixed-direction multi-key sort
+// (messages ascending, then started descending) orders rows correctly, with the
+// id tie-breaker following the last term's direction. Both the structured Sort
+// field and the OrderBy string spell out the same ordering and must agree.
+func TestListSessions_MultiKeySort(t *testing.T) {
+	asc, desc := false, true
+	seed := func(t *testing.T) *DB {
+		d := testDB(t)
+		insertSession(t, d, "mk-a", "p", func(s *Session) {
+			s.MessageCount = 1
+			s.StartedAt = Ptr("2024-03-01T00:00:00Z")
+		})
+		insertSession(t, d, "mk-b", "p", func(s *Session) {
+			s.MessageCount = 1
+			s.StartedAt = Ptr("2024-01-01T00:00:00Z")
+		})
+		insertSession(t, d, "mk-c", "p", func(s *Session) {
+			s.MessageCount = 2
+			s.StartedAt = Ptr("2024-02-01T00:00:00Z")
+		})
+		insertSession(t, d, "mk-d", "p", func(s *Session) {
+			s.MessageCount = 2
+			s.StartedAt = Ptr("2024-05-01T00:00:00Z")
+		})
+		insertSession(t, d, "mk-e", "p", func(s *Session) {
+			s.MessageCount = 1
+			s.StartedAt = Ptr("2024-03-01T00:00:00Z") // ties mk-a on (messages, started)
+		})
+		return d
+	}
+
+	// messages asc, started desc, id desc (tie-breaker follows last term):
+	//   msgs=1: started desc -> {a,e}(03), b(01); a/e tie -> id desc -> e,a
+	//   msgs=2: started desc -> d(05), c(02)
+	want := []string{"mk-e", "mk-a", "mk-b", "mk-d", "mk-c"}
+
+	t.Run("structured Sort", func(t *testing.T) {
+		d := seed(t)
+		got := listSortedIDs(t, d, filterWith(func(f *SessionFilter) {
+			f.Sort = []SortKey{
+				{Key: "messages", Descending: &asc},
+				{Key: "started", Descending: &desc},
+			}
+		}))
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("OrderBy string", func(t *testing.T) {
+		d := seed(t)
+		got := listSortedIDs(t, d, filterWith(func(f *SessionFilter) {
+			f.OrderBy = "messages:asc,started:desc"
+		}))
+		assert.Equal(t, want, got)
+	})
+}
+
+// TestListSessions_MultiKeyPaginationWalk is the core keyset-correctness test:
+// paginating one row at a time through a mixed-direction multi-key sort with
+// ties must return the full ordered set exactly once.
+func TestListSessions_MultiKeyPaginationWalk(t *testing.T) {
+	asc, desc := false, true
+	d := testDB(t)
+	// 12 sessions across 3 message buckets with repeated started timestamps so
+	// every keyset level (value compare, equality + next compare, id tie-break)
+	// is exercised during the walk.
+	type row struct {
+		id      string
+		msgs    int
+		started string
+	}
+	rows := []row{
+		{"w01", 1, "2024-01-01T00:00:00Z"},
+		{"w02", 1, "2024-01-01T00:00:00Z"},
+		{"w03", 1, "2024-02-01T00:00:00Z"},
+		{"w04", 2, "2024-01-01T00:00:00Z"},
+		{"w05", 2, "2024-03-01T00:00:00Z"},
+		{"w06", 2, "2024-03-01T00:00:00Z"},
+		{"w07", 2, "2024-03-01T00:00:00Z"},
+		{"w08", 3, "2024-02-01T00:00:00Z"},
+		{"w09", 3, "2024-02-01T00:00:00Z"},
+		{"w10", 3, "2024-04-01T00:00:00Z"},
+		{"w11", 3, "2024-01-01T00:00:00Z"},
+		{"w12", 1, "2024-02-01T00:00:00Z"},
+	}
+	for _, r := range rows {
+		insertSession(t, d, r.id, "p", func(s *Session) {
+			s.MessageCount = r.msgs
+			s.StartedAt = Ptr(r.started)
+		})
+	}
+
+	sortKeys := []SortKey{
+		{Key: "messages", Descending: &asc},
+		{Key: "started", Descending: &desc},
+	}
+
+	// Full-listing order is the reference; the paginated walk must reproduce it.
+	want := listSortedIDs(t, d, filterWith(func(f *SessionFilter) { f.Sort = sortKeys }))
+	require.Len(t, want, len(rows))
+
+	var got []string
+	seen := map[string]bool{}
+	cursor := ""
+	for pages := 0; ; pages++ {
+		require.LessOrEqual(t, pages, len(rows)+1, "pagination did not terminate")
+		page, err := d.ListSessions(context.Background(), SessionFilter{
+			Limit:  1,
+			Sort:   sortKeys,
+			Cursor: cursor,
+		})
+		require.NoError(t, err, "ListSessions page")
+		for _, s := range page.Sessions {
+			require.False(t, seen[s.ID], "duplicate %s", s.ID)
+			seen[s.ID] = true
+			got = append(got, s.ID)
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	assert.Equal(t, want, got, "paginated walk matches full listing")
+}
+
+// TestListSessions_MultiKeyCursorMismatch rejects a multi-key cursor reused under
+// any different sort list (fewer keys, different order, or a flipped direction)
+// and accepts it under the identical list.
+func TestListSessions_MultiKeyCursorMismatch(t *testing.T) {
+	asc, desc := false, true
+	d := testDB(t)
+	for i := 1; i <= 4; i++ {
+		insertSession(t, d, fmt.Sprintf("mm%d", i), "p", func(s *Session) {
+			s.MessageCount = i
+			s.StartedAt = Ptr(fmt.Sprintf("2024-0%d-01T00:00:00Z", i))
+		})
+	}
+	base := []SortKey{
+		{Key: "messages", Descending: &asc},
+		{Key: "started", Descending: &desc},
+	}
+	page, err := d.ListSessions(context.Background(), SessionFilter{Limit: 2, Sort: base})
+	require.NoError(t, err)
+	require.NotEmpty(t, page.NextCursor)
+	cursor := page.NextCursor
+
+	cases := []struct {
+		name string
+		sort []SortKey
+		ok   bool
+	}{
+		{name: "identical", sort: base, ok: true},
+		{name: "fewer keys", sort: []SortKey{{Key: "messages", Descending: &asc}}},
+		{name: "swapped order", sort: []SortKey{
+			{Key: "started", Descending: &desc},
+			{Key: "messages", Descending: &asc},
+		}},
+		{name: "flipped direction", sort: []SortKey{
+			{Key: "messages", Descending: &asc},
+			{Key: "started", Descending: &asc},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := d.ListSessions(context.Background(), SessionFilter{
+				Limit: 2, Sort: tc.sort, Cursor: cursor,
+			})
+			if tc.ok {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, ErrInvalidCursor)
+		})
+	}
+}
+
+// TestNextSessionCursor_LegacyFields confirms a single-key cursor still
+// populates the legacy Sort/Desc/Value (and EndedAt for recent) fields for
+// pre-multi-key readers, while a multi-key cursor populates only Keys.
+func TestNextSessionCursor_LegacyFields(t *testing.T) {
+	last := &Session{ID: "z", EndedAt: Ptr("2024-05-01T00:00:00Z"), MessageCount: 7}
+
+	t.Run("single key recent populates legacy + EndedAt", func(t *testing.T) {
+		rs := ResolveSort(SessionFilter{}) // recent desc
+		cur := NextSessionCursor(last, rs, 3, SessionFilter{})
+		require.Len(t, cur.Keys, 1)
+		assert.Equal(t, "recent", cur.Keys[0].Sort)
+		assert.Equal(t, "recent", cur.Sort)
+		assert.True(t, cur.Desc)
+		assert.Equal(t, cur.Keys[0].Value, cur.Value)
+		assert.Equal(t, cur.Keys[0].Value, cur.EndedAt, "recent populates legacy EndedAt")
+	})
+
+	t.Run("single key non-recent leaves EndedAt empty", func(t *testing.T) {
+		asc := false
+		rs := ResolveSort(SessionFilter{Sort: []SortKey{{Key: "messages", Descending: &asc}}})
+		cur := NextSessionCursor(last, rs, 3, SessionFilter{})
+		require.Len(t, cur.Keys, 1)
+		assert.Equal(t, "messages", cur.Sort)
+		assert.Equal(t, "7", cur.Value)
+		assert.Empty(t, cur.EndedAt, "non-recent single key does not set EndedAt")
+	})
+
+	t.Run("multi key populates only Keys", func(t *testing.T) {
+		asc, desc := false, true
+		rs := ResolveSort(SessionFilter{Sort: []SortKey{
+			{Key: "messages", Descending: &asc},
+			{Key: "recent", Descending: &desc},
+		}})
+		cur := NextSessionCursor(last, rs, 3, SessionFilter{})
+		require.Len(t, cur.Keys, 2)
+		assert.Empty(t, cur.Sort, "multi-key leaves legacy Sort empty")
+		assert.Empty(t, cur.Value)
+		assert.Empty(t, cur.EndedAt)
+	})
+}

--- a/internal/db/sort_render_test.go
+++ b/internal/db/sort_render_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolvedFor builds the resolved sort terms for a spec string, for renderer
+// tests that need the []ResolvedSort the stores pass to the query builder.
+func resolvedFor(t *testing.T, spec string) []ResolvedSort {
+	t.Helper()
+	keys, err := ParseSortSpec(spec)
+	require.NoError(t, err)
+	return ResolveSort(SessionFilter{Sort: keys})
+}
+
+// TestOrderByClause_MultiKey locks the multi-column ORDER BY rendering,
+// including the implicit id tie-breaker in the last term's direction.
+func TestOrderByClause_MultiKey(t *testing.T) {
+	rs := resolvedFor(t, "messages:asc,started:desc")
+
+	b := NewQueryBuilder(SQLiteQueryDialect(), 0)
+	assert.Equal(t,
+		"ORDER BY message_count ASC, "+
+			"COALESCE(NULLIF(started_at, ''), created_at) DESC, id DESC",
+		b.OrderByClause(rs, SessionFilter{}))
+
+	bpg := NewQueryBuilder(PostgresQueryDialect(), 0)
+	assert.Equal(t,
+		"ORDER BY message_count ASC, "+
+			"COALESCE(started_at, created_at) DESC, id DESC",
+		bpg.OrderByClause(rs, SessionFilter{}))
+}
+
+// TestOrderByClause_IDOnly keeps the single id-sort form free of a duplicate id
+// tie-breaker.
+func TestOrderByClause_IDOnly(t *testing.T) {
+	rs := resolvedFor(t, "id:desc")
+	b := NewQueryBuilder(SQLiteQueryDialect(), 0)
+	assert.Equal(t, "ORDER BY id DESC", b.OrderByClause(rs, SessionFilter{}))
+}
+
+// TestCursorPredicate_MultiKey locks the lexicographic OR-expansion that backs
+// keyset pagination under mixed per-key directions, plus the per-kind casts.
+func TestCursorPredicate_MultiKey(t *testing.T) {
+	rs := resolvedFor(t, "messages:asc,started:desc")
+	values := []any{int64(5), "2024-01-01T00:00:00Z"}
+
+	b := NewQueryBuilder(SQLiteQueryDialect(), 0)
+	gotSQLite := b.CursorPredicate(rs, SessionFilter{}, values, "sid")
+	assert.Equal(t,
+		"((message_count > ?) OR "+
+			"(message_count = ? AND "+
+			"COALESCE(NULLIF(started_at, ''), created_at) < ?) OR "+
+			"(message_count = ? AND "+
+			"COALESCE(NULLIF(started_at, ''), created_at) = ? AND id < ?))",
+		gotSQLite)
+	// Six bound params: one comparison at level 0, two at level 1, three at
+	// level 2 (the id tie-break being the last).
+	assert.Len(t, b.Args(), 6)
+
+	bpg := NewQueryBuilder(PostgresQueryDialect(), 0)
+	gotPG := bpg.CursorPredicate(rs, SessionFilter{}, values, "sid")
+	assert.Equal(t,
+		"((message_count > $1::bigint) OR "+
+			"(message_count = $2::bigint AND "+
+			"COALESCE(started_at, created_at) < $3::timestamptz) OR "+
+			"(message_count = $4::bigint AND "+
+			"COALESCE(started_at, created_at) = $5::timestamptz AND id < $6))",
+		gotPG)
+}
+
+// TestCursorPredicate_SingleKeyEquivalentToRowValue documents that the
+// single-key OR-expansion is the logical equivalent of the previous row-value
+// comparison: value-compare OR (equal AND id-compare).
+func TestCursorPredicate_SingleKeyRecent(t *testing.T) {
+	rs := resolvedFor(t, "recent:desc")
+	b := NewQueryBuilder(SQLiteQueryDialect(), 0)
+	got := b.CursorPredicate(rs, SessionFilter{}, []any{"2024-05-01T00:00:00Z"}, "sid")
+	activity := "COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at)"
+	assert.Equal(t,
+		"(("+activity+" < ?) OR ("+activity+" = ? AND id < ?))",
+		got)
+}

--- a/internal/duckdb/sort_test.go
+++ b/internal/duckdb/sort_test.go
@@ -96,6 +96,55 @@ func TestDuckDBSort_SecretsVersioned(t *testing.T) {
 		"current-version session leads once the stale 9 is gated to 0")
 }
 
+func multiKeySeed(id string, msgs int, started string) db.SessionBatchWrite {
+	return db.SessionBatchWrite{
+		Session: db.Session{
+			ID:               id,
+			Project:          "mk",
+			Machine:          "test-machine",
+			Agent:            "claude",
+			StartedAt:        new(started),
+			MessageCount:     msgs,
+			UserMessageCount: 2,
+			RelationshipType: "root",
+		},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}
+}
+
+// TestDuckDBSort_MultiKey mirrors the SQLite mixed-direction multi-key behavior
+// on DuckDB (CAST cursor placeholders, lexicographic OR-expansion): messages
+// ascending, then started descending, with the id tie-break following the last
+// term's direction. The paginated walk must equal the full-listing order.
+func TestDuckDBSort_MultiKey(t *testing.T) {
+	store := syncedStoreFromWrites(t, []db.SessionBatchWrite{
+		multiKeySeed("mk-a", 1, "2024-03-01T00:00:00Z"),
+		multiKeySeed("mk-b", 1, "2024-01-01T00:00:00Z"),
+		multiKeySeed("mk-c", 2, "2024-02-01T00:00:00Z"),
+		multiKeySeed("mk-d", 2, "2024-05-01T00:00:00Z"),
+		multiKeySeed("mk-e", 1, "2024-03-01T00:00:00Z"), // ties mk-a
+	})
+	asc, desc := false, true
+	sortKeys := []db.SortKey{
+		{Key: "messages", Descending: &asc},
+		{Key: "started", Descending: &desc},
+	}
+
+	full, err := store.ListSessions(context.Background(), db.SessionFilter{
+		Project: "mk", Sort: sortKeys, Limit: 100,
+	})
+	require.NoError(t, err)
+	want := make([]string, len(full.Sessions))
+	for i, s := range full.Sessions {
+		want[i] = s.ID
+	}
+	require.Equal(t, []string{"mk-e", "mk-a", "mk-b", "mk-d", "mk-c"}, want)
+
+	walked := duckWalk(t, store, db.SessionFilter{Project: "mk", Sort: sortKeys, Limit: 1})
+	require.Equal(t, want, walked, "paginated walk matches full listing")
+}
+
 // TestDuckDBSort_NullsLast mirrors the nullable-sort (health) behavior on
 // DuckDB: NULLs sort last and pagination crosses the sentinel boundary.
 func TestDuckDBSort_NullsLast(t *testing.T) {

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -211,8 +211,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		f.Limit = db.DefaultSessionLimit
 	}
 	where, args := db.BuildSessionFilterSQL(f, db.DuckDBQueryDialect())
-	sp, _ := db.SessionSortFor(f.OrderBy)
-	desc := sp.ResolveDescending(f.Descending)
+	rs := db.ResolveSort(f)
 	total := 0
 	var cur db.SessionCursor
 	if f.Cursor != "" {
@@ -235,15 +234,15 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 	pageBuilder := db.NewQueryBuilder(db.DuckDBQueryDialect(), len(args))
 	cursorWhere := where
 	if f.Cursor != "" {
-		val, err := sp.CursorPredicateValue(cur, desc)
+		vals, err := db.CursorPredicateValues(cur, rs)
 		if err != nil {
 			return db.SessionPage{}, err
 		}
-		cursorWhere += " AND " + pageBuilder.CursorPredicate(sp, desc, f, val, cur.ID)
+		cursorWhere += " AND " + pageBuilder.CursorPredicate(rs, f, vals, cur.ID)
 	}
 	query := "SELECT " + duckSessionCols +
 		" FROM sessions WHERE " + cursorWhere + " " +
-		pageBuilder.OrderByClause(sp, desc, f) + " " +
+		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 	rows, err := s.duck.QueryContext(ctx, query, cursorArgs...)
@@ -259,7 +258,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 	if len(sessions) > f.Limit {
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
-		page.NextCursor = s.EncodeCursor(sp.NextCursor(&last, desc, total, f))
+		page.NextCursor = s.EncodeCursor(db.NextSessionCursor(&last, rs, total, f))
 	}
 	return page, nil
 }

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -339,8 +339,7 @@ func (s *Store) ListSessions(
 	where, args := buildPGSessionFilter(f)
 
 	dialect := db.PostgresQueryDialect()
-	sp, _ := db.SessionSortFor(f.OrderBy)
-	desc := sp.ResolveDescending(f.Descending)
+	rs := db.ResolveSort(f)
 
 	var total int
 	var cur db.SessionCursor
@@ -368,18 +367,18 @@ func (s *Store) ListSessions(
 	pageBuilder := db.NewQueryBuilder(dialect, len(args))
 	cursorWhere := where
 	if f.Cursor != "" {
-		val, err := sp.CursorPredicateValue(cur, desc)
+		vals, err := db.CursorPredicateValues(cur, rs)
 		if err != nil {
 			return db.SessionPage{}, err
 		}
 		cursorWhere += " AND " + pageBuilder.CursorPredicate(
-			sp, desc, f, val, cur.ID,
+			rs, f, vals, cur.ID,
 		)
 	}
 
 	query := "SELECT " + pgSessionCols +
 		" FROM sessions WHERE " + cursorWhere + " " +
-		pageBuilder.OrderByClause(sp, desc, f) + " " +
+		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
 
@@ -404,7 +403,7 @@ func (s *Store) ListSessions(
 		page.Sessions = sessions[:f.Limit]
 		last := page.Sessions[f.Limit-1]
 		page.NextCursor = s.EncodeCursor(
-			sp.NextCursor(&last, desc, total, f),
+			db.NextSessionCursor(&last, rs, total, f),
 		)
 	}
 

--- a/internal/postgres/sessions_pgtest_test.go
+++ b/internal/postgres/sessions_pgtest_test.go
@@ -153,6 +153,73 @@ func TestListSessions_Sort(t *testing.T) {
 	require.Equal(t, []string{"sort-a", "sort-c", "sort-b"}, walked)
 }
 
+// TestListSessions_SortMultiKey verifies a mixed-direction multi-key sort on
+// PostgreSQL, where the lexicographic OR-expansion places ::bigint and
+// ::timestamptz casts on the equality and comparison clauses. The paginated walk
+// must match the full listing.
+func TestListSessions_SortMultiKey(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions
+			(id, machine, project, agent, first_message,
+			 started_at, message_count, user_message_count)
+		VALUES
+			('mk-a', 'm', 'mk', 'claude', 'a', '2024-03-01T00:00:00Z'::timestamptz, 1, 2),
+			('mk-b', 'm', 'mk', 'claude', 'b', '2024-01-01T00:00:00Z'::timestamptz, 1, 2),
+			('mk-c', 'm', 'mk', 'claude', 'c', '2024-02-01T00:00:00Z'::timestamptz, 2, 2),
+			('mk-d', 'm', 'mk', 'claude', 'd', '2024-05-01T00:00:00Z'::timestamptz, 2, 2),
+			('mk-e', 'm', 'mk', 'claude', 'e', '2024-03-01T00:00:00Z'::timestamptz, 1, 2)
+	`)
+	require.NoError(t, err, "seeding multi-key sessions")
+
+	ctx := context.Background()
+	ids := func(sessions []db.Session) []string {
+		out := make([]string, len(sessions))
+		for i, s := range sessions {
+			out[i] = s.ID
+		}
+		return out
+	}
+	asc, desc := false, true
+	sortKeys := []db.SortKey{
+		{Key: "messages", Descending: &asc},
+		{Key: "started", Descending: &desc},
+	}
+
+	full, err := store.ListSessions(ctx, db.SessionFilter{
+		Project: "mk", Sort: sortKeys, Limit: 100,
+	})
+	require.NoError(t, err, "ListSessions multi-key")
+	want := ids(full.Sessions)
+	require.Equal(t, []string{"mk-e", "mk-a", "mk-b", "mk-d", "mk-c"}, want)
+
+	var walked []string
+	seen := map[string]bool{}
+	cursor := ""
+	for {
+		page, err := store.ListSessions(ctx, db.SessionFilter{
+			Project: "mk", Sort: sortKeys, Limit: 1, Cursor: cursor,
+		})
+		require.NoError(t, err, "ListSessions multi-key page")
+		for _, s := range page.Sessions {
+			require.False(t, seen[s.ID], "duplicate %s", s.ID)
+			seen[s.ID] = true
+			walked = append(walked, s.ID)
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	require.Equal(t, want, walked, "paginated walk matches full listing")
+}
+
 // TestListSessions_SortSecretsVersioned verifies the version-gated secrets sort
 // renders on PostgreSQL, where the gating CASE places numbered placeholders
 // inside both ORDER BY and the keyset cursor predicate.

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -137,6 +137,12 @@ func (in *sessionFilterInput) dbFilter(includeChildren bool) (db.SessionFilter, 
 	if err := validateDateFilterValues(in.Date, in.DateFrom, in.DateTo, in.ActiveSince); err != nil {
 		return db.SessionFilter{}, err
 	}
+	// The order_by param is shared with the list route via this struct; reject
+	// malformed specs here too (the dropped enum used to guard every route),
+	// even though the sidebar index applies its own ordering and ignores it.
+	if _, err := db.ParseSortSpec(in.OrderBy); err != nil {
+		return db.SessionFilter{}, apiError(http.StatusBadRequest, "invalid order_by: "+err.Error())
+	}
 	limit := 0
 	if in.Limit > 0 {
 		limit = clampLimit(in.Limit, db.DefaultSessionLimit, db.MaxSessionLimit)

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -55,10 +55,6 @@ type messageDirection string
 
 type markdownDepth string
 
-// sessionOrderBy is the allow-listed session-list sort field. The enum tag is
-// kept in sync with db.SortKeys() by TestSortKeysMatchHumaEnum.
-type sessionOrderBy string
-
 type sessionFilterInput struct {
 	Project          string            `query:"project" doc:"Filter by project"`
 	ExcludeProject   string            `query:"exclude_project" doc:"Exclude a project"`
@@ -82,8 +78,8 @@ type sessionFilterInput struct {
 	MinToolFailures  optionalIntParam  `query:"min_tool_failures" minimum:"0" doc:"Minimum tool failure count"`
 	HasSecret        bool              `query:"has_secret" doc:"Filter sessions with secret findings"`
 	Starred          bool              `query:"starred" doc:"Filter sessions by starred status"`
-	OrderBy          sessionOrderBy    `query:"order_by" enum:"recent,started,messages,user-messages,output-tokens,peak-context,failures,retries,edit-churn,compactions,context-pressure,health,secrets,id" default:"recent" doc:"Sort field"`
-	Descending       optionalBoolParam `query:"descending" doc:"Sort descending; overrides the sort field's default direction"`
+	OrderBy          string            `query:"order_by" default:"recent" doc:"Sort order: a comma-separated list of keys, each optionally suffixed :asc or :desc (e.g. messages:desc,started:asc). A key with no suffix uses the descending param, then its natural direction. Valid keys: recent, started, messages, user-messages, output-tokens, peak-context, failures, retries, edit-churn, compactions, context-pressure, health, secrets, id."`
+	Descending       optionalBoolParam `query:"descending" doc:"Default sort direction for keys in order_by that carry no explicit :asc/:desc suffix"`
 }
 
 type messageListInput struct {
@@ -101,6 +97,9 @@ type searchSessionInput struct {
 func (in *sessionFilterInput) listFilter() (service.ListFilter, error) {
 	if err := validateDateFilterValues(in.Date, in.DateFrom, in.DateTo, in.ActiveSince); err != nil {
 		return service.ListFilter{}, err
+	}
+	if _, err := db.ParseSortSpec(in.OrderBy); err != nil {
+		return service.ListFilter{}, apiError(http.StatusBadRequest, "invalid order_by: "+err.Error())
 	}
 	limit := clampLimit(in.Limit, db.DefaultSessionLimit, db.MaxSessionLimit)
 	filter := service.ListFilter{
@@ -125,7 +124,7 @@ func (in *sessionFilterInput) listFilter() (service.ListFilter, error) {
 		Termination:      in.Termination,
 		HasSecret:        in.HasSecret,
 		Starred:          in.Starred,
-		OrderBy:          string(in.OrderBy),
+		OrderBy:          in.OrderBy,
 		Descending:       optionalBoolValue(in.Descending),
 	}
 	if in.MinToolFailures.IsSet {

--- a/internal/server/sort_http_multikey_test.go
+++ b/internal/server/sort_http_multikey_test.go
@@ -103,3 +103,18 @@ func TestListSessions_OrderBy_Invalid(t *testing.T) {
 		})
 	}
 }
+
+// TestSidebarIndex_OrderByInvalid confirms the sidebar-index route, which shares
+// the session-filter input struct, also rejects a malformed order_by rather than
+// silently accepting and ignoring it (the dropped enum used to guard both routes).
+func TestSidebarIndex_OrderByInvalid(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "p", 3)
+
+	w := te.get(t, "/api/v1/sessions/sidebar-index?order_by=bogus")
+	assertStatus(t, w, http.StatusBadRequest)
+
+	// A valid spec is still accepted even though the sidebar applies its own order.
+	w = te.get(t, "/api/v1/sessions/sidebar-index?order_by=messages:desc")
+	assertStatus(t, w, http.StatusOK)
+}

--- a/internal/server/sort_http_multikey_test.go
+++ b/internal/server/sort_http_multikey_test.go
@@ -1,0 +1,105 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// sessionListPage decodes the list response including the pagination cursor,
+// which sessionListResponse omits.
+type sessionListPage struct {
+	Sessions   []db.Session `json:"sessions"`
+	NextCursor string       `json:"next_cursor"`
+	Total      int          `json:"total"`
+}
+
+// seedForMultiKey inserts three sessions whose (messages, started) values make
+// a two-key sort with mixed directions observable.
+func seedForMultiKey(t *testing.T, te *testEnv) {
+	t.Helper()
+	te.seedSession(t, "mk-a", "p", 1, func(s *db.Session) {
+		s.StartedAt = new("2024-03-01T00:00:00Z")
+	})
+	te.seedSession(t, "mk-b", "p", 1, func(s *db.Session) {
+		s.StartedAt = new("2024-01-01T00:00:00Z")
+	})
+	te.seedSession(t, "mk-c", "p", 2, func(s *db.Session) {
+		s.StartedAt = new("2024-02-01T00:00:00Z")
+	})
+}
+
+// TestListSessions_OrderBy_MultiKey exercises the comma-separated key:dir spec
+// and the descending fallback for unsuffixed keys over HTTP.
+func TestListSessions_OrderBy_MultiKey(t *testing.T) {
+	t.Run("explicit per-key directions", func(t *testing.T) {
+		te := setup(t)
+		seedForMultiKey(t, te)
+		// messages asc, then started desc.
+		w := te.get(t, "/api/v1/sessions?order_by=messages:asc,started:desc")
+		assertStatus(t, w, http.StatusOK)
+		resp := decode[sessionListResponse](t, w)
+		assert.Equal(t, []string{"mk-a", "mk-b", "mk-c"}, orderedSessionIDs(resp.Sessions))
+	})
+
+	t.Run("descending fallback fills unsuffixed key", func(t *testing.T) {
+		te := setup(t)
+		seedForMultiKey(t, te)
+		// messages (bare -> descending via param), then started:asc explicit.
+		w := te.get(t, "/api/v1/sessions?order_by=messages,started:asc&descending=true")
+		assertStatus(t, w, http.StatusOK)
+		resp := decode[sessionListResponse](t, w)
+		assert.Equal(t, []string{"mk-c", "mk-b", "mk-a"}, orderedSessionIDs(resp.Sessions))
+	})
+}
+
+// TestListSessions_OrderBy_MultiKeyPagination walks a multi-key sort one page at
+// a time and asserts the keyset cursor reproduces the full-listing order.
+func TestListSessions_OrderBy_MultiKeyPagination(t *testing.T) {
+	te := setup(t)
+	seedForMultiKey(t, te)
+
+	full := te.get(t, "/api/v1/sessions?order_by=messages:asc,started:desc")
+	assertStatus(t, full, http.StatusOK)
+	want := orderedSessionIDs(decode[sessionListPage](t, full).Sessions)
+
+	var got []string
+	cursor := ""
+	for i := 0; i < len(want)+1; i++ {
+		url := "/api/v1/sessions?order_by=messages:asc,started:desc&limit=1"
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		w := te.get(t, url)
+		assertStatus(t, w, http.StatusOK)
+		resp := decode[sessionListPage](t, w)
+		got = append(got, orderedSessionIDs(resp.Sessions)...)
+		if resp.NextCursor == "" {
+			break
+		}
+		cursor = resp.NextCursor
+	}
+	assert.Equal(t, want, got)
+}
+
+// TestListSessions_OrderBy_Invalid rejects malformed order_by specs with 400.
+func TestListSessions_OrderBy_Invalid(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "p", 3)
+
+	for _, spec := range []string{
+		"bogus",             // unknown key
+		"messages,bogus",    // unknown key in list
+		"messages:up",       // bad direction token
+		"messages,messages", // duplicate key
+		"messages,,started", // empty term
+	} {
+		t.Run(spec, func(t *testing.T) {
+			w := te.get(t, "/api/v1/sessions?order_by="+spec)
+			assertStatus(t, w, http.StatusBadRequest)
+		})
+	}
+}

--- a/internal/server/sort_internal_test.go
+++ b/internal/server/sort_internal_test.go
@@ -11,35 +11,22 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-// TestSortKeysDocumented guards the order_by doc string against drift from the
-// shared sort registry: every accepted sort key must be named in the parameter
-// documentation so the OpenAPI surface lists the full allow-list (the enum tag
-// could no longer express the comma-separated key:dir spec).
-func TestSortKeysDocumented(t *testing.T) {
+// TestSortKeysMatchDoc guards the order_by doc string against drift from the
+// shared sort registry. It parses the "Valid keys:" clause into exact tokens and
+// requires them to equal db.SortKeys() in order, so a key omitted from the clause
+// cannot be masked by the example text earlier in the doc, and a stale key left
+// after a rename is caught too. This replaces the enum-sync guard that the dropped
+// order_by enum tag used to provide.
+func TestSortKeysMatchDoc(t *testing.T) {
 	field, ok := reflect.TypeFor[sessionFilterInput]().FieldByName("OrderBy")
 	require.True(t, ok, "sessionFilterInput.OrderBy field")
 	doc := field.Tag.Get("doc")
-	require.NotEmpty(t, doc, "order_by doc tag")
-	for _, key := range db.SortKeys() {
-		assert.Contains(t, doc, key, "order_by doc must mention sort key %q", key)
-	}
-}
-
-// TestSortKeysDocOmitsStaleKeys is the inverse guard: the "Valid keys:" clause
-// should not name a key that no longer exists in the registry (a stale entry
-// left after a rename).
-func TestSortKeysDocOmitsStaleKeys(t *testing.T) {
-	field, _ := reflect.TypeFor[sessionFilterInput]().FieldByName("OrderBy")
-	doc := field.Tag.Get("doc")
 	_, after, found := strings.Cut(doc, "Valid keys:")
-	require.True(t, found, "doc should enumerate valid keys")
-	valid := make(map[string]bool, len(db.SortKeys()))
-	for _, k := range db.SortKeys() {
-		valid[k] = true
-	}
-	for _, tok := range strings.FieldsFunc(after, func(r rune) bool {
+	require.True(t, found, "order_by doc must enumerate keys after 'Valid keys:'")
+
+	keys := strings.FieldsFunc(after, func(r rune) bool {
 		return r == ',' || r == ' ' || r == '.'
-	}) {
-		assert.True(t, valid[tok], "doc lists unknown sort key %q", tok)
-	}
+	})
+	assert.Equal(t, db.SortKeys(), keys,
+		"order_by 'Valid keys:' clause must list exactly db.SortKeys() in order")
 }

--- a/internal/server/sort_internal_test.go
+++ b/internal/server/sort_internal_test.go
@@ -11,13 +11,35 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-// TestSortKeysMatchHumaEnum guards the hard-coded order_by enum tag against
-// drift from the shared sort registry.
-func TestSortKeysMatchHumaEnum(t *testing.T) {
+// TestSortKeysDocumented guards the order_by doc string against drift from the
+// shared sort registry: every accepted sort key must be named in the parameter
+// documentation so the OpenAPI surface lists the full allow-list (the enum tag
+// could no longer express the comma-separated key:dir spec).
+func TestSortKeysDocumented(t *testing.T) {
 	field, ok := reflect.TypeFor[sessionFilterInput]().FieldByName("OrderBy")
 	require.True(t, ok, "sessionFilterInput.OrderBy field")
-	enum := field.Tag.Get("enum")
-	require.NotEmpty(t, enum, "order_by enum tag")
-	assert.Equal(t, db.SortKeys(), strings.Split(enum, ","),
-		"order_by enum must match db.SortKeys()")
+	doc := field.Tag.Get("doc")
+	require.NotEmpty(t, doc, "order_by doc tag")
+	for _, key := range db.SortKeys() {
+		assert.Contains(t, doc, key, "order_by doc must mention sort key %q", key)
+	}
+}
+
+// TestSortKeysDocOmitsStaleKeys is the inverse guard: the "Valid keys:" clause
+// should not name a key that no longer exists in the registry (a stale entry
+// left after a rename).
+func TestSortKeysDocOmitsStaleKeys(t *testing.T) {
+	field, _ := reflect.TypeFor[sessionFilterInput]().FieldByName("OrderBy")
+	doc := field.Tag.Get("doc")
+	_, after, found := strings.Cut(doc, "Valid keys:")
+	require.True(t, found, "doc should enumerate valid keys")
+	valid := make(map[string]bool, len(db.SortKeys()))
+	for _, k := range db.SortKeys() {
+		valid[k] = true
+	}
+	for _, tok := range strings.FieldsFunc(after, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '.'
+	}) {
+		assert.True(t, valid[tok], "doc lists unknown sort key %q", tok)
+	}
 }

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -106,10 +106,10 @@ func (b *directBackend) List(
 			"list: invalid active_since %q: use RFC3339", f.ActiveSince,
 		)
 	}
-	if !db.ValidSortKey(f.OrderBy) {
+	if _, err := db.ParseSortSpec(f.OrderBy); err != nil {
 		return nil, fmt.Errorf(
-			"list: invalid sort %q: must be one of %s",
-			f.OrderBy, strings.Join(db.SortKeys(), ", "),
+			"list: invalid sort %q: %v (valid keys: %s)",
+			f.OrderBy, err, strings.Join(db.SortKeys(), ", "),
 		)
 	}
 	// Match the HTTP handler's clampLimit semantics: values over
@@ -159,9 +159,17 @@ func listFilterToDB(f ListFilter) db.SessionFilter {
 		HasSecret:            f.HasSecret,
 		Starred:              f.Starred,
 		SecretsRulesVersions: secrets.ActiveRulesVersions(),
-		OrderBy:              f.OrderBy,
-		Descending:           f.Descending,
 	}
+	// Parse the public sort spec into the structured, per-key form. The spec is
+	// validated in List before this runs, so a parse error here is treated
+	// defensively as the default sort. The legacy Descending param fills the
+	// direction of any term that carries no explicit :asc/:desc suffix; it is
+	// also carried through so an empty order_by + descending still flips the
+	// implicit default recent key.
+	if keys, err := db.ParseSortSpec(f.OrderBy); err == nil {
+		filter.Sort = db.ApplyFallbackDirection(keys, f.Descending)
+	}
+	filter.Descending = f.Descending
 	if f.Outcome != "" {
 		filter.Outcome = strings.Split(f.Outcome, ",")
 	}


### PR DESCRIPTION
Follow-up to #739. On that PR, @cpcloud asked whether sort direction could be specified per key rather than forcing one direction for all sort keys, given the `SessionFilter` abstraction. This implements that.

## What changed

`order_by` (and `--sort`) now accept a comma-separated list of sort keys, each optionally suffixed `:asc` or `:desc`:

```
GET /api/v1/sessions?order_by=messages:desc,started:asc
agentsview session list --sort messages:desc,started:asc
```

Different keys can sort in different directions. A key with no suffix takes its direction from the `descending` param (HTTP) or `--reverse` (CLI), then from its own natural default; an explicit `:asc`/`:desc` always wins. The single-key forms (`order_by=messages&descending=true`, `--sort messages -r`) behave exactly as before, and existing pagination cursors keep working.

## How it works

`SessionFilter` gains a structured `Sort []SortKey` (each key plus an optional direction); `OrderBy`/`Descending` remain as the single-key shorthand and parse fallback. `OrderByClause` and `CursorPredicate` now render N columns from one definition shared by SQLite, PostgreSQL, and DuckDB.

The keyset pagination predicate becomes the lexicographic OR-expansion -- `(c1 OPdir1 v1) OR (c1 = v1 AND c2 OPdir2 v2) OR ...` -- because a single row-value tuple comparison is only valid when every column shares one direction; mixed per-key directions require the expansion. The `id` tie-breaker follows the last sort term's direction (appended unless `id` is already a term). Cursors carry a per-key `Keys` list; legacy and single-key cursors still decode, and a cursor reused under a different sort list (different keys, order, or any direction) is rejected as an invalid cursor rather than silently paging wrong rows.

The `order_by` enum was replaced by free-form parsing with server-side validation (unknown key, bad direction token, duplicate key, empty term -> 400), shared by the list and sidebar-index routes; the valid keys are enumerated in the param doc.

## Where to look

- `internal/db/sort.go` -- sort registry, `ParseSortSpec`/`ResolveSort`, cursor helpers
- `internal/db/query_dialect.go` -- `OrderByClause` / `CursorPredicate` OR-expansion
- the three `ListSessions` implementations (`internal/db`, `internal/postgres`, `internal/duckdb`)
- `internal/server/huma_routes_sessions.go`, `internal/service/direct.go`, `cmd/agentsview/session_list.go`

## Limitations / possible follow-ups

- No new indexes (same scoping as #739); at local-archive scale a scan+sort is sub-millisecond.
- The CLI has no `--descending` flag mirroring HTTP's absolute `descending` fallback -- `--reverse` flips each bare key's own natural direction instead. Easy to add if transport symmetry is wanted.