### PR TITLE
fix(duckdb): guard against negative call_index when attaching tool calls

### DIFF
--- a/internal/duckdb/messages.go
+++ b/internal/duckdb/messages.go
@@ -136,7 +136,10 @@ func (s *Store) attachToolCalls(ctx context.Context, msgs []db.Message) error {
 			&tc.ResultContent, &tc.SubagentSessionID); err != nil {
 			return err
 		}
-		if i, ok := index[ordinal]; ok {
+		// A negative call_index (corrupt or malformed mirror row) would
+		// skip the grow loop and panic on the [callIndex] assignment, so
+		// guard it the same way the Postgres store does.
+		if i, ok := index[ordinal]; ok && callIndex >= 0 {
 			for len(msgs[i].ToolCalls) <= callIndex {
 				msgs[i].ToolCalls = append(msgs[i].ToolCalls, db.ToolCall{})
 			}
@@ -176,7 +179,7 @@ func (s *Store) attachToolResultEvents(
 			return err
 		}
 		ev.Timestamp = formatDBTime(ts)
-		if i, ok := index[ordinal]; ok && callIndex < len(msgs[i].ToolCalls) {
+		if i, ok := index[ordinal]; ok && callIndex >= 0 && callIndex < len(msgs[i].ToolCalls) {
 			msgs[i].ToolCalls[callIndex].ResultEvents = append(
 				msgs[i].ToolCalls[callIndex].ResultEvents, ev,
 			)

--- a/internal/duckdb/messages_test.go
+++ b/internal/duckdb/messages_test.go
@@ -1,0 +1,53 @@
+//go:build !(windows && arm64)
+
+package duckdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAllMessagesSkipsNegativeCallIndex guards against a panic when the
+// DuckDB mirror holds a tool_calls or tool_result_events row with a negative
+// call_index (a corrupt or malformed mirror row). Such a row would skip the
+// grow loop / pass the upper-bound check and index ToolCalls[-1], crashing
+// message loading with "index out of range [-1]". The Postgres store already
+// guards callIndex < 0; the DuckDB store must behave the same way.
+func TestGetAllMessagesSkipsNegativeCallIndex(t *testing.T) {
+	ctx := context.Background()
+	store, fixture := newSyncedStore(t)
+
+	// alpha message ordinal 1 has exactly one real tool call ("search").
+	// Inject malformed rows with call_index = -1 for that same message.
+	_, err := store.duck.ExecContext(ctx, `
+		INSERT INTO tool_calls (
+			id, message_id, session_id, tool_name, category,
+			call_index, tool_use_id
+		)
+		SELECT 90001, m.id, m.session_id, 'bad', 'other', -1, 'bad-tool'
+		FROM messages m
+		WHERE m.session_id = ? AND m.ordinal = 1`, fixture.alphaID)
+	require.NoError(t, err)
+
+	_, err = store.duck.ExecContext(ctx, `
+		INSERT INTO tool_result_events (
+			id, session_id, tool_call_message_ordinal, call_index,
+			source, status, content, content_length, event_index
+		) VALUES (90002, ?, 1, -1, 'tool', 'complete', 'bad', 3, 0)`,
+		fixture.alphaID)
+	require.NoError(t, err)
+
+	// Must not panic; the negative-index rows are simply skipped.
+	msgs, err := store.GetAllMessages(ctx, fixture.alphaID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	// The valid tool call and its result event are preserved intact.
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "search", msgs[1].ToolCalls[0].ToolName)
+	require.Len(t, msgs[1].ToolCalls[0].ResultEvents, 1)
+	assert.Equal(t, "duck result", msgs[1].ToolCalls[0].ResultEvents[0].Content)
+}


### PR DESCRIPTION
## Summary

Fixes a potential `index out of range [-1]` panic in the DuckDB store when the mirror contains a `tool_calls` or `tool_result_events` row with a **negative `call_index`** (a corrupt or malformed mirror row). A single bad row currently crashes message loading for the entire session.

## The bug

`attachToolCalls` grows `msgs[i].ToolCalls` until its length exceeds `callIndex`, then assigns by index:

```go
if i, ok := index[ordinal]; ok {
    for len(msgs[i].ToolCalls) <= callIndex {
        msgs[i].ToolCalls = append(msgs[i].ToolCalls, db.ToolCall{})
    }
    msgs[i].ToolCalls[callIndex] = tc   // callIndex == -1 -> panic
}
```

When `callIndex` is negative, `len(...) <= callIndex` is immediately false, the grow loop never runs, and the assignment indexes `ToolCalls[-1]` → panic.

`attachToolResultEvents` has the same gap — its guard `callIndex < len(msgs[i].ToolCalls)` is true for any negative index, so it also indexes `ToolCalls[-1]`.

The schema allows it: `call_index INTEGER NOT NULL DEFAULT 0` has no positivity constraint.

## Why this matters

The sibling **Postgres** store already guards against exactly this (`internal/postgres/messages.go`):

```go
if callIndex < 0 || callIndex >= len(msgs[idx].ToolCalls) {
    continue
}
```

The DuckDB store was missing the `callIndex < 0` half. This change brings the two stores to parity so a malformed row is skipped instead of crashing the session view.

## Changes

- `internal/duckdb/messages.go`: skip rows with a negative `call_index` in both `attachToolCalls` and `attachToolResultEvents`.
- `internal/duckdb/messages_test.go`: regression test that injects negative-`call_index` rows and asserts message loading no longer panics while the valid tool call and its result event are preserved.

## Test plan

- `go test ./internal/duckdb/ -run TestGetAllMessagesSkipsNegativeCallIndex`
- Existing duckdb store tests remain green.
