### PR TITLE
feat(pricing): bundle LiteLLM snapshot as offline fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
@@ -129,6 +130,9 @@ jobs:
           update: false
           install: mingw-w64-x86_64-gcc
           path-type: inherit
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Run Go tests
         run: go test -tags "fts5" ./... -v -count=1
@@ -183,11 +187,15 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Test with coverage
         run: go test -tags "fts5" -coverprofile=coverage.out ./...
@@ -224,11 +232,15 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Run PostgreSQL integration tests
         run: make test-postgres-ci
@@ -272,6 +284,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
@@ -294,6 +307,9 @@ jobs:
         run: |
           rm -rf internal/web/dist
           cp -r frontend/dist internal/web/dist
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Pre-build Go binaries
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Compute image build metadata
         id: vars
@@ -57,7 +65,8 @@ jobs:
             org.opencontainers.image.title=agentsview
             org.opencontainers.image.description=Local web viewer for AI agent sessions
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/msys2-update-check.yml
+++ b/.github/workflows/msys2-update-check.yml
@@ -15,11 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Setup MinGW (with updates)
         uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,14 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Trust git checkout
+        shell: bash
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git status --short >/dev/null
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
@@ -45,6 +52,9 @@ jobs:
         run: |
           rm -rf internal/web/dist
           cp -r frontend/dist internal/web/dist
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Build
         shell: bash
@@ -106,6 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
@@ -125,6 +136,9 @@ jobs:
         run: |
           rm -rf internal/web/dist
           cp -r frontend/dist internal/web/dist
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Setup MinGW (Windows amd64)
         if: matrix.goos == 'windows' && matrix.goarch == 'amd64'

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_DATE=
 
+RUN go run ./internal/pricing/cmd/litellm-snapshot -restore
+
 RUN CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -tags fts5 -trimpath -buildvcs=false \
       -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LDFLAGS_RELEASE := $(LDFLAGS) -s -w
 DESKTOP_DIST_DIR := dist/desktop
 GOLANGCI_LINT_VERSION ?= v2.11.4
 CUSTOM_GCL := ./custom-gcl
+PRICING_SNAPSHOT_FILE := internal/pricing/snapshot/litellm_snapshot.json.gz
 
 GOPATH_FIRST := $(shell go env GOPATH | cut -d: -f1)
 AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
@@ -19,7 +20,7 @@ AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
 	elif [ -x "$(GOPATH_FIRST)/bin/air" ]; then printf "%s" "$(GOPATH_FIRST)/bin/air"; \
 	fi)
 
-.PHONY: build build-release install frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy test test-short bench-backends test-postgres test-postgres-ci postgres-up postgres-down test-ssh test-ssh-ci ssh-up ssh-down e2e e2e-duckdb vet lint lint-ci lint-golangci lint-golangci-ci nilaway nilaway-golangci-build lint-tools tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir dev-snapshot help
+.PHONY: build build-release install frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy test test-short bench-backends test-postgres test-postgres-ci postgres-up postgres-down test-ssh test-ssh-ci ssh-up ssh-down e2e e2e-duckdb vet lint lint-ci lint-golangci lint-golangci-ci nilaway nilaway-golangci-build lint-tools tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir pricing-snapshot dev-snapshot help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -29,13 +30,18 @@ ensure-embed-dir:
 			'keep embed dir for generated frontend assets' \
 			> internal/web/dist/.keep
 
-# Build the binary (debug, with embedded frontend)
-build: frontend
+# Restore the generated LiteLLM fallback snapshot from its artifact branch.
+# Pinned ref, SHA256, and branch are compiled into the snapshot tool.
+pricing-snapshot:
+	go run ./internal/pricing/cmd/litellm-snapshot -restore
+
+# Build the binary (debug, with embedded pricing snapshot and frontend)
+build: pricing-snapshot frontend
 	CGO_ENABLED=1 go build -tags fts5 -ldflags="$(LDFLAGS)" -o agentsview ./cmd/agentsview
 	@chmod +x agentsview
 
 # Build with optimizations (release)
-build-release: frontend
+build-release: pricing-snapshot frontend
 	CGO_ENABLED=1 go build -tags fts5 -ldflags="$(LDFLAGS_RELEASE)" -trimpath -o agentsview ./cmd/agentsview
 	@chmod +x agentsview
 
@@ -137,7 +143,7 @@ air-install:
 
 # Run Go server in dev mode with live reload (use with frontend-dev).
 # Edits to .go files trigger a rebuild + restart via air.
-dev: ensure-embed-dir check-air
+dev: pricing-snapshot ensure-embed-dir check-air
 	"$(AIR_BIN)" -c .air.toml -- $(ARGS)
 
 # Run the Tauri desktop wrapper in development mode
@@ -215,11 +221,11 @@ desktop-linux-appimage:
 desktop-app: desktop-macos-app
 
 # Run tests
-test: ensure-embed-dir
+test: pricing-snapshot ensure-embed-dir
 	go test -tags "fts5" ./... -v -count=1
 
 # Run fast tests only
-test-short: ensure-embed-dir
+test-short: pricing-snapshot ensure-embed-dir
 	go test -tags "fts5" ./... -short -count=1
 
 # Compare db.Store read-query performance across SQLite, DuckDB, and PostgreSQL.
@@ -227,7 +233,7 @@ test-short: ensure-embed-dir
 BENCH_BACKENDS_FLAGS ?= -bench . -run '^$$' -benchmem
 BENCH_BACKENDS_SESSIONS ?= 1000
 BENCH_BACKENDS_MESSAGES_PER_SESSION ?= 64
-bench-backends: ensure-embed-dir
+bench-backends: pricing-snapshot ensure-embed-dir
 	AGENTSVIEW_BENCH_SESSIONS=$(BENCH_BACKENDS_SESSIONS) \
 		AGENTSVIEW_BENCH_MESSAGES_PER_SESSION=$(BENCH_BACKENDS_MESSAGES_PER_SESSION) \
 		CGO_ENABLED=1 go test -tags "fts5,benchdb" ./internal/backendbench $(BENCH_BACKENDS_FLAGS)
@@ -241,14 +247,14 @@ postgres-down:
 	docker compose -f docker-compose.test.yml down
 
 # Run PostgreSQL integration tests (starts postgres automatically)
-test-postgres: ensure-embed-dir postgres-up
+test-postgres: pricing-snapshot ensure-embed-dir postgres-up
 	@echo "Waiting for postgres to be ready..."
 	@sleep 2
 	TEST_PG_URL="postgres://agentsview_test:agentsview_test_password@localhost:5433/agentsview_test?sslmode=disable" \
 		CGO_ENABLED=1 go test -tags "fts5,pgtest" -v ./internal/postgres/... ./internal/activity/... -count=1
 
 # PostgreSQL integration tests for CI (postgres already running as service)
-test-postgres-ci: ensure-embed-dir
+test-postgres-ci: pricing-snapshot ensure-embed-dir
 	CGO_ENABLED=1 go test -tags "fts5,pgtest" -v ./internal/postgres/... ./internal/activity/... -count=1
 
 # Start test SSH container
@@ -262,13 +268,13 @@ ssh-down:
 	docker compose -f docker-compose.test.yml down sshd
 
 # Run SSH integration tests (starts sshd automatically)
-test-ssh: ensure-embed-dir ssh-up
+test-ssh: pricing-snapshot ensure-embed-dir ssh-up
 	TEST_SSH_HOST=localhost TEST_SSH_PORT=2222 TEST_SSH_USER=testuser \
 		TEST_SSH_KEY=$(CURDIR)/testdata/ssh/test_key \
 		CGO_ENABLED=1 go test -tags "fts5,sshtest" -v ./internal/ssh/... -count=1
 
 # SSH integration tests for CI (sshd already running)
-test-ssh-ci: ensure-embed-dir
+test-ssh-ci: pricing-snapshot ensure-embed-dir
 	CGO_ENABLED=1 go test -tags "fts5,sshtest" -v ./internal/ssh/... -count=1
 
 # Run Playwright E2E tests
@@ -281,14 +287,14 @@ e2e-duckdb:
 		e2e/duckdb-backend.spec.ts e2e/session-list.spec.ts --project=chromium
 
 # Vet
-vet: ensure-embed-dir
+vet: pricing-snapshot ensure-embed-dir
 	go vet -tags fts5 ./...
 
 # Lint Go code and auto-fix where possible (local development)
 lint: lint-golangci nilaway
 
 # Run golangci-lint with auto-fixes for local development.
-lint-golangci: ensure-embed-dir
+lint-golangci: pricing-snapshot ensure-embed-dir
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "golangci-lint not found. Install with: make lint-tools" >&2; \
 		exit 1; \
@@ -299,7 +305,7 @@ lint-golangci: ensure-embed-dir
 lint-ci: lint-golangci-ci nilaway
 
 # Run golangci-lint without auto-fixes for CI.
-lint-golangci-ci: ensure-embed-dir
+lint-golangci-ci: pricing-snapshot ensure-embed-dir
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "golangci-lint not found. Install with: make lint-tools" >&2; \
 		exit 1; \
@@ -325,7 +331,7 @@ nilaway-golangci-build:
 		golangci-lint custom --version "$(GOLANGCI_LINT_VERSION)" --name custom-gcl
 
 # Run NilAway through the custom golangci-lint module plugin.
-nilaway: ensure-embed-dir nilaway-golangci-build
+nilaway: pricing-snapshot ensure-embed-dir nilaway-golangci-build
 	$(CUSTOM_GCL) run --config .golangci.nilaway.yml ./...
 
 # Install pinned local lint tools.
@@ -333,12 +339,13 @@ lint-tools:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 # Tidy dependencies
-tidy:
+tidy: pricing-snapshot
 	go mod tidy
 
 # Clean build artifacts
 clean:
 	rm -f agentsview agentsv
+	rm -f $(PRICING_SNAPSHOT_FILE)
 	rm -rf internal/web/dist dist/ tmp/
 	mkdir -p internal/web/dist
 	printf '%s\n' \
@@ -373,26 +380,26 @@ docs-deploy:
 	vercel deploy docs --prod
 
 # Build release binary for current platform (CGO required for sqlite3)
-release: frontend
+release: pricing-snapshot frontend
 	mkdir -p dist
 	CGO_ENABLED=1 go build -tags fts5 \
 		-ldflags="$(LDFLAGS_RELEASE)" -trimpath \
 		-o dist/agentsview-$$(go env GOOS)-$$(go env GOARCH) ./cmd/agentsview
 
 # Cross-compile targets (require CC set to target cross-compiler)
-release-darwin-arm64: frontend
+release-darwin-arm64: pricing-snapshot frontend
 	mkdir -p dist
 	GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build -tags fts5 \
 		-ldflags="$(LDFLAGS_RELEASE)" -trimpath \
 		-o dist/agentsview-darwin-arm64 ./cmd/agentsview
 
-release-darwin-amd64: frontend
+release-darwin-amd64: pricing-snapshot frontend
 	mkdir -p dist
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -tags fts5 \
 		-ldflags="$(LDFLAGS_RELEASE)" -trimpath \
 		-o dist/agentsview-darwin-amd64 ./cmd/agentsview
 
-release-linux-amd64: frontend
+release-linux-amd64: pricing-snapshot frontend
 	mkdir -p dist
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags fts5 \
 		-ldflags="$(LDFLAGS_RELEASE)" -trimpath \
@@ -412,6 +419,7 @@ help:
 	@echo ""
 	@echo "  build          - Build with embedded frontend"
 	@echo "  build-release  - Release build (optimized, stripped)"
+	@echo "  pricing-snapshot - Restore LiteLLM snapshot from artifact branch"
 	@echo "  install        - Build and install to ~/.local/bin or GOPATH"
 	@echo ""
 	@echo "  dev            - Run Go server with live reload via air (use with frontend-dev)"

--- a/build_script_test.go
+++ b/build_script_test.go
@@ -236,6 +236,34 @@ func installWindowsBuildStubs(t *testing.T, root string) buildStubs {
 	t.Helper()
 
 	stubs := newBuildStubs(t, root)
+	writeExecutable(t, filepath.Join(stubs.binDir, "go.ps1"), `Add-Content -Path $env:CALL_LOG -Value ("go " + ($args -join " "))
+if ($args.Length -gt 0 -and $args[0] -eq "run") {
+  if ($env:RESTORE_FAIL -eq "1") { exit 42 }
+  exit 0
+}
+if ($args.Length -gt 0 -and $args[0] -eq "build") {
+  $out = $null
+  for ($i = 0; $i -lt $args.Length - 1; $i++) {
+    if ($args[$i] -eq "-o") {
+      $out = $args[$i+1]
+      break
+    }
+  }
+  if ($out) {
+    $dir = [System.IO.Path]::GetDirectoryName($out)
+    if ($dir) {
+      New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    Set-Content -Path $out -Value @'
+@echo off
+echo built-binary %*>> "%CALL_LOG%"
+exit /b 0
+'@ -NoNewline
+  }
+  exit 0
+}
+exit 0
+`)
 	writeExecutable(t, filepath.Join(stubs.binDir, "go.cmd"), `@echo off
 echo go %*>> "%CALL_LOG%"
 if "%1"=="run" (
@@ -265,6 +293,13 @@ if "%1"=="build" (
 )
 exit /b 0
 `)
+	writeExecutable(t, filepath.Join(stubs.binDir, "npm.ps1"), `Add-Content -Path $env:CALL_LOG -Value ("npm " + ($args -join " "))
+if ($args.Length -ge 2 -and $args[0] -eq "run" -and $args[1] -eq "build") {
+  New-Item -ItemType Directory -Path dist -Force | Out-Null
+  Set-Content -Path "dist/index.html" -Value "ok" -NoNewline
+}
+exit 0
+`)
 	writeExecutable(t, filepath.Join(stubs.binDir, "npm.cmd"), `@echo off
 echo npm %*>> "%CALL_LOG%"
 if "%1"=="run" if "%2"=="build" (
@@ -272,6 +307,18 @@ if "%1"=="run" if "%2"=="build" (
   echo ok>dist\index.html
 )
 exit /b 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "git.ps1"), `$joined = $args -join " "
+Add-Content -Path $env:CALL_LOG -Value ("git " + $joined)
+if ($joined -like "*describe*") {
+  Write-Output "v1.2.3-4-gabcdef"
+  exit 0
+}
+if ($joined -like "*rev-parse*") {
+  Write-Output "abcdef1"
+  exit 0
+}
+exit 0
 `)
 	writeExecutable(t, filepath.Join(stubs.binDir, "git.cmd"), `@echo off
 echo git %*>> "%CALL_LOG%"
@@ -285,9 +332,17 @@ echo %* | findstr /C:"rev-parse" >nul && (
 )
 exit /b 0
 `)
+	writeExecutable(t, filepath.Join(stubs.binDir, "rustc.ps1"), `if ($args.Length -gt 0 -and $args[0] -eq "-vV") {
+  Write-Output "host: x86_64-pc-windows-msvc"
+}
+exit 0
+`)
 	writeExecutable(t, filepath.Join(stubs.binDir, "rustc.cmd"), `@echo off
 if "%1"=="-vV" echo host: x86_64-pc-windows-msvc
 exit /b 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "cargo.ps1"), `Add-Content -Path $env:CALL_LOG -Value ("cargo " + ($args -join " "))
+exit 0
 `)
 	writeExecutable(t, filepath.Join(stubs.binDir, "cargo.cmd"), `@echo off
 echo cargo %*>> "%CALL_LOG%"

--- a/build_script_test.go
+++ b/build_script_test.go
@@ -1,0 +1,501 @@
+package agentsview_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevBackendBuildRestoresPricingSnapshotBeforeBuild(t *testing.T) {
+	requireUnixShell(t)
+
+	root := t.TempDir()
+	installRepoFile(t, root, "scripts/dev-backend-build.sh", 0o755)
+	stubs := installUnixBuildStubs(t, root)
+
+	out, err := runInWorkspace(t, root, stubs.env(), "bash", "scripts/dev-backend-build.sh")
+	require.NoError(t, err, "%s", out)
+
+	events := stubs.events(t)
+	assertEventOrder(t, events,
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore",
+		"go build -tags fts5",
+	)
+	require.FileExists(t, filepath.Join(root, "tmp", "agentsview"))
+}
+
+func TestDevBackendBuildStopsWhenPricingSnapshotRestoreFails(t *testing.T) {
+	requireUnixShell(t)
+
+	root := t.TempDir()
+	installRepoFile(t, root, "scripts/dev-backend-build.sh", 0o755)
+	stubs := installUnixBuildStubs(t, root)
+
+	out, err := runInWorkspace(
+		t,
+		root,
+		stubs.env("RESTORE_FAIL=1"),
+		"bash",
+		"scripts/dev-backend-build.sh",
+	)
+	require.Error(t, err, "script should fail when snapshot restore fails: %s", out)
+
+	events := stubs.events(t)
+	assertEventContains(t, events,
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore")
+	assertNoEventContains(t, events, "go build")
+}
+
+func TestE2EServerRestoresPricingSnapshotBeforeServerBuild(t *testing.T) {
+	requireUnixShell(t)
+
+	root := t.TempDir()
+	installRepoFile(t, root, "scripts/e2e-server.sh", 0o755)
+	writeE2EWorkspace(t, root)
+	fixture := writeFixtureBinary(t, root)
+	stubs := installUnixBuildStubs(t, root)
+
+	out, err := runInWorkspace(
+		t,
+		root,
+		stubs.env("E2E_PREBUILT_FIXTURE="+fixture),
+		"bash",
+		"scripts/e2e-server.sh",
+	)
+	require.NoError(t, err, "%s", out)
+
+	assertEventOrder(t, stubs.events(t),
+		"fixture -out",
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore",
+		"npm run build",
+		"go build -tags fts5,kit_posthog_disabled",
+		"built-binary serve --port 8090 --no-browser",
+	)
+}
+
+func TestE2EServerRestoresPricingSnapshotBeforeFixtureBuild(t *testing.T) {
+	requireUnixShell(t)
+
+	root := t.TempDir()
+	installRepoFile(t, root, "scripts/e2e-server.sh", 0o755)
+	writeE2EWorkspace(t, root)
+	server := writeServerBinary(t, root)
+	stubs := installUnixBuildStubs(t, root)
+
+	out, err := runInWorkspace(
+		t,
+		root,
+		stubs.env("E2E_PREBUILT_SERVER="+server),
+		"bash",
+		"scripts/e2e-server.sh",
+	)
+	require.NoError(t, err, "%s", out)
+
+	assertEventOrder(t, stubs.events(t),
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore",
+		"go build -tags fts5,kit_posthog_disabled",
+		"built-binary -out",
+		"server serve --port 8090 --no-browser",
+	)
+}
+
+func TestE2EServerStopsWhenPricingSnapshotRestoreFails(t *testing.T) {
+	requireUnixShell(t)
+
+	root := t.TempDir()
+	installRepoFile(t, root, "scripts/e2e-server.sh", 0o755)
+	writeE2EWorkspace(t, root)
+	fixture := writeFixtureBinary(t, root)
+	stubs := installUnixBuildStubs(t, root)
+
+	out, err := runInWorkspace(
+		t,
+		root,
+		stubs.env("E2E_PREBUILT_FIXTURE="+fixture, "RESTORE_FAIL=1"),
+		"bash",
+		"scripts/e2e-server.sh",
+	)
+	require.Error(t, err, "script should fail when snapshot restore fails: %s", out)
+
+	events := stubs.events(t)
+	assertEventContains(t, events,
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore")
+	assertNoEventContains(t, events, "go build")
+}
+
+func TestDesktopDevPowerShellStopsWhenPricingSnapshotRestoreFails(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("PowerShell native command failure handling is Windows-specific")
+	}
+	requireCommand(t, "pwsh")
+
+	root := t.TempDir()
+	installRepoFile(t, root, "scripts/desktop-dev.ps1", 0o755)
+	writeDesktopDevWorkspace(t, root)
+	stubs := installWindowsBuildStubs(t, root)
+
+	out, err := runInWorkspace(
+		t,
+		root,
+		stubs.env("RESTORE_FAIL=1"),
+		"pwsh",
+		"-NoProfile",
+		"-ExecutionPolicy",
+		"Bypass",
+		"-File",
+		filepath.Join(root, "scripts", "desktop-dev.ps1"),
+	)
+	require.Error(t, err, "script should fail when snapshot restore fails: %s", out)
+
+	events := stubs.events(t)
+	assertEventContains(t, events,
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore")
+	assertNoEventContains(t, events, "go build")
+}
+
+type buildStubs struct {
+	binDir  string
+	logPath string
+}
+
+func installUnixBuildStubs(t *testing.T, root string) buildStubs {
+	t.Helper()
+
+	stubs := newBuildStubs(t, root)
+	writeExecutable(t, filepath.Join(stubs.binDir, "go"), `#!/bin/sh
+set -eu
+printf 'go %s\n' "$*" >> "$CALL_LOG"
+if [ "${1:-}" = "run" ] && [ "${2:-}" = "./internal/pricing/cmd/litellm-snapshot" ]; then
+  if [ "${RESTORE_FAIL:-}" = "1" ]; then exit 42; fi
+  exit 0
+fi
+if [ "${1:-}" = "build" ]; then
+  out=""
+  prev=""
+  for arg in "$@"; do
+    if [ "$prev" = "-o" ]; then
+      out="$arg"
+      break
+    fi
+    prev="$arg"
+  done
+  if [ -n "$out" ]; then
+    mkdir -p "$(dirname "$out")"
+    cat > "$out" <<'EOS'
+#!/bin/sh
+printf 'built-binary %s\n' "$*" >> "$CALL_LOG"
+exit 0
+EOS
+    chmod +x "$out"
+  fi
+  exit 0
+fi
+exit 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "npm"), `#!/bin/sh
+set -eu
+printf 'npm %s\n' "$*" >> "$CALL_LOG"
+if [ "${1:-}" = "run" ] && [ "${2:-}" = "build" ]; then
+  mkdir -p dist
+  printf 'ok\n' > dist/index.html
+fi
+exit 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "git"), `#!/bin/sh
+set -eu
+printf 'git %s\n' "$*" >> "$CALL_LOG"
+case " $* " in
+  *" describe "*) printf 'v1.2.3-4-gabcdef\n' ;;
+  *" rev-parse "*) printf 'abcdef1\n' ;;
+esac
+exit 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "rustc"), `#!/bin/sh
+set -eu
+if [ "${1:-}" = "-vV" ]; then
+  printf 'host: x86_64-unknown-linux-gnu\n'
+fi
+exit 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "cargo"), `#!/bin/sh
+set -eu
+printf 'cargo %s\n' "$*" >> "$CALL_LOG"
+exit 0
+`)
+	return stubs
+}
+
+func installWindowsBuildStubs(t *testing.T, root string) buildStubs {
+	t.Helper()
+
+	stubs := newBuildStubs(t, root)
+	writeExecutable(t, filepath.Join(stubs.binDir, "go.cmd"), `@echo off
+echo go %*>> "%CALL_LOG%"
+if "%1"=="run" (
+  if "%RESTORE_FAIL%"=="1" exit /b 42
+  exit /b 0
+)
+if "%1"=="build" (
+  set "out="
+  set "next="
+:go_loop
+  if "%~1"=="" goto go_after
+  if defined next (
+    set "out=%~1"
+    set "next="
+  ) else if "%~1"=="-o" (
+    set "next=1"
+  )
+  shift
+  goto go_loop
+:go_after
+  if not "%out%"=="" (
+    echo @echo off>"%out%"
+    echo echo built-binary %%*^>^> "%%CALL_LOG%%">>"%out%"
+    echo exit /b 0>>"%out%"
+  )
+  exit /b 0
+)
+exit /b 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "npm.cmd"), `@echo off
+echo npm %*>> "%CALL_LOG%"
+if "%1"=="run" if "%2"=="build" (
+  if not exist dist mkdir dist
+  echo ok>dist\index.html
+)
+exit /b 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "git.cmd"), `@echo off
+echo git %*>> "%CALL_LOG%"
+echo %* | findstr /C:"describe" >nul && (
+  echo v1.2.3-4-gabcdef
+  exit /b 0
+)
+echo %* | findstr /C:"rev-parse" >nul && (
+  echo abcdef1
+  exit /b 0
+)
+exit /b 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "rustc.cmd"), `@echo off
+if "%1"=="-vV" echo host: x86_64-pc-windows-msvc
+exit /b 0
+`)
+	writeExecutable(t, filepath.Join(stubs.binDir, "cargo.cmd"), `@echo off
+echo cargo %*>> "%CALL_LOG%"
+exit /b 0
+`)
+	return stubs
+}
+
+func newBuildStubs(t *testing.T, root string) buildStubs {
+	t.Helper()
+
+	binDir := filepath.Join(root, "stub-bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	logPath := filepath.Join(root, "calls.log")
+	require.NoError(t, os.WriteFile(logPath, nil, 0o644))
+	return buildStubs{binDir: binDir, logPath: logPath}
+}
+
+func (s buildStubs) env(extra ...string) []string {
+	env := envWithout("PATH", "CALL_LOG")
+	env = append(env, "PATH="+s.binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	env = append(env, "CALL_LOG="+s.logPath)
+	return append(env, extra...)
+}
+
+func (s buildStubs) events(t *testing.T) []string {
+	t.Helper()
+
+	raw, err := os.ReadFile(s.logPath)
+	require.NoError(t, err)
+	normalized := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	return strings.FieldsFunc(normalized, func(r rune) bool { return r == '\n' })
+}
+
+func writeE2EWorkspace(t *testing.T, root string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "frontend"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal", "parser"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal", "web"), 0o755))
+
+	var registry strings.Builder
+	registry.WriteString("package parser\n\nvar agentDirs = []struct{ EnvVar string }{\n")
+	for i := range 12 {
+		fmt.Fprintf(&registry, "\t{EnvVar: \"AGENT_%02d_DIR\"},\n", i)
+	}
+	registry.WriteString("}\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "internal", "parser", "types.go"),
+		[]byte(registry.String()),
+		0o644,
+	))
+}
+
+func writeDesktopDevWorkspace(t *testing.T, root string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module test\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "frontend"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal", "web"), 0o755))
+	tauriDir := filepath.Join(root, "desktop", "src-tauri")
+	require.NoError(t, os.MkdirAll(tauriDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tauriDir, "tauri.conf.json"),
+		[]byte(`{"version": "0.0.0"}`),
+		0o644,
+	))
+}
+
+func writeFixtureBinary(t *testing.T, root string) string {
+	t.Helper()
+
+	fixture := filepath.Join(root, "fixture")
+	writeExecutable(t, fixture, `#!/bin/sh
+set -eu
+printf 'fixture %s\n' "$*" >> "$CALL_LOG"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -out|-duckdb-out)
+      shift
+      mkdir -p "$(dirname "$1")"
+      printf 'fixture\n' > "$1"
+      ;;
+  esac
+  shift || true
+done
+exit 0
+`)
+	return fixture
+}
+
+func writeServerBinary(t *testing.T, root string) string {
+	t.Helper()
+
+	server := filepath.Join(root, "server")
+	writeExecutable(t, server, `#!/bin/sh
+set -eu
+printf 'server %s\n' "$*" >> "$CALL_LOG"
+exit 0
+`)
+	return server
+}
+
+func installRepoFile(t *testing.T, root, rel string, mode os.FileMode) {
+	t.Helper()
+
+	data, err := os.ReadFile(rel)
+	require.NoError(t, err)
+	dst := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+	require.NoError(t, os.WriteFile(dst, data, mode))
+}
+
+func writeExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o755))
+}
+
+func runInWorkspace(
+	t *testing.T,
+	root string,
+	env []string,
+	name string,
+	args ...string,
+) ([]byte, error) {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = root
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+func requireUnixShell(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("bash script behavior tests run on Unix")
+	}
+	requireCommand(t, "bash")
+}
+
+func requireCommand(t *testing.T, name string) string {
+	t.Helper()
+
+	path, err := exec.LookPath(name)
+	if err != nil {
+		t.Skipf("%s not found on PATH", name)
+	}
+	return path
+}
+
+func assertEventOrder(t *testing.T, events []string, wants ...string) {
+	t.Helper()
+
+	start := 0
+	for _, want := range wants {
+		found := -1
+		for i := start; i < len(events); i++ {
+			if strings.Contains(events[i], want) {
+				found = i
+				break
+			}
+		}
+		require.NotEqual(t, -1, found,
+			"event containing %q not found after index %d in %v", want, start, events)
+		start = found + 1
+	}
+}
+
+func assertEventContains(t *testing.T, events []string, want string) {
+	t.Helper()
+
+	for _, event := range events {
+		if strings.Contains(event, want) {
+			return
+		}
+	}
+	assert.Failf(t, "missing event", "event containing %q not found in %v", want, events)
+}
+
+func assertNoEventContains(t *testing.T, events []string, unwanted string) {
+	t.Helper()
+
+	for _, event := range events {
+		assert.NotContains(t, event, unwanted)
+	}
+}
+
+func envWithout(keys ...string) []string {
+	drop := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		drop[key] = struct{}{}
+	}
+
+	var env []string
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			env = append(env, entry)
+			continue
+		}
+		if _, found := drop[key]; found {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
+}

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -62,6 +62,107 @@ func TestCIDocsJobRunsFullDocsCheck(t *testing.T) {
 	assert.Equal(t, "make docs-check", checkStep.Run)
 }
 
+func TestReleaseWorkflowRestoresPricingSnapshotBeforeGoBuild(t *testing.T) {
+	contents, err := os.ReadFile(".github/workflows/release.yml")
+	require.NoError(t, err)
+
+	var workflow githubWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	for _, jobName := range []string{"build-linux", "build"} {
+		job, ok := workflow.Jobs[jobName]
+		require.True(t, ok, "%s job must exist", jobName)
+
+		restoreIndex, restoreStep := findWorkflowStep(t, job, "Restore pricing snapshot")
+		buildIndex, buildStep := findWorkflowStep(t, job, "Build")
+		require.Less(t, restoreIndex, buildIndex,
+			"%s must restore pricing snapshot before building", jobName)
+
+		if jobName == "build-linux" {
+			trustIndex, trustStep := findWorkflowStep(t, job, "Trust git checkout")
+			require.Less(t, trustIndex, restoreIndex,
+				"%s must trust the checkout before restoring the snapshot", jobName)
+			assert.Contains(t, trustStep.Run, `safe.directory "$GITHUB_WORKSPACE"`)
+			assert.Contains(t, trustStep.Run, "git status")
+		}
+
+		assertSnapshotRestoreStep(t, restoreStep)
+		assert.Contains(t, buildStep.Run, "go build")
+	}
+}
+
+func TestCIWorkflowRestoresPricingSnapshotBeforeGoTests(t *testing.T) {
+	contents, err := os.ReadFile(".github/workflows/ci.yml")
+	require.NoError(t, err)
+
+	var workflow githubWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	cases := []struct {
+		jobName   string
+		buildStep string
+	}{
+		{"test", "Run Go tests"},
+		{"coverage", "Test with coverage"},
+		{"integration", "Run PostgreSQL integration tests"},
+		{"e2e", "Pre-build Go binaries"},
+	}
+
+	for _, tc := range cases {
+		job, ok := workflow.Jobs[tc.jobName]
+		require.True(t, ok, "%s job must exist", tc.jobName)
+
+		restoreIndex, restoreStep := findWorkflowStep(t, job, "Restore pricing snapshot")
+		buildIndex, _ := findWorkflowStep(t, job, tc.buildStep)
+		require.Less(t, restoreIndex, buildIndex,
+			"%s must restore pricing snapshot before %s", tc.jobName, tc.buildStep)
+
+		assertSnapshotRestoreStep(t, restoreStep)
+	}
+}
+
+func TestMSYS2UpdateWorkflowRestoresPricingSnapshotBeforeGoTests(t *testing.T) {
+	contents, err := os.ReadFile(".github/workflows/msys2-update-check.yml")
+	require.NoError(t, err)
+
+	var workflow githubWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	job, ok := workflow.Jobs["windows-update-check"]
+	require.True(t, ok, "windows-update-check job must exist")
+
+	restoreIndex, restoreStep := findWorkflowStep(t, job, "Restore pricing snapshot")
+	testIndex, _ := findWorkflowStep(t, job, "Run Go tests")
+	require.Less(t, restoreIndex, testIndex,
+		"msys2 update check must restore pricing snapshot before tests")
+
+	assertSnapshotRestoreStep(t, restoreStep)
+}
+
+func TestDockerWorkflowRestoresPricingSnapshotBeforeImageBuild(t *testing.T) {
+	contents, err := os.ReadFile(".github/workflows/docker.yml")
+	require.NoError(t, err)
+
+	var workflow githubWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	job, ok := workflow.Jobs["build-and-push"]
+	require.True(t, ok, "build-and-push job must exist")
+
+	restoreIndex, restoreStep := findWorkflowStep(t, job, "Restore pricing snapshot")
+	buildIndex, _ := findWorkflowStep(t, job, "Build and push Docker image")
+	require.Less(t, restoreIndex, buildIndex,
+		"docker workflow must restore pricing snapshot before image build")
+
+	assertSnapshotRestoreStep(t, restoreStep)
+}
+
+func assertSnapshotRestoreStep(t *testing.T, step githubWorkflowStep) {
+	t.Helper()
+
+	assert.Equal(t, "go run ./internal/pricing/cmd/litellm-snapshot -restore", step.Run)
+}
+
 func findWorkflowStep(
 	t *testing.T,
 	job githubWorkflowJob,

--- a/desktop/scripts/prepare-sidecar.sh
+++ b/desktop/scripts/prepare-sidecar.sh
@@ -120,6 +120,13 @@ patch_tauri_version() {
   echo "Patched tauri.conf.json version to $semver"
 }
 
+restore_pricing_snapshot() {
+  (
+    cd "$REPO_ROOT"
+    go run ./internal/pricing/cmd/litellm-snapshot -restore
+  )
+}
+
 install_frontend_deps() {
   npm ci
 }
@@ -164,6 +171,7 @@ main() {
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "${tmp_dir:-}"' EXIT
   build_bin="$tmp_dir/agentsview$ext"
+  restore_pricing_snapshot
 
   (
     cd "$REPO_ROOT"

--- a/desktop_sidecar_test.go
+++ b/desktop_sidecar_test.go
@@ -1,0 +1,62 @@
+package agentsview_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareSidecarRestoresPricingSnapshotBeforeBuild(t *testing.T) {
+	requireUnixShell(t)
+
+	root := t.TempDir()
+	installRepoFile(t, root, "desktop/scripts/prepare-sidecar.sh", 0o755)
+	writeDesktopDevWorkspace(t, root)
+	stubs := installUnixBuildStubs(t, root)
+
+	out, err := runInWorkspace(
+		t,
+		root,
+		stubs.env("AGENTSVIEW_VERSION=v1.2.3"),
+		"bash",
+		"desktop/scripts/prepare-sidecar.sh",
+	)
+	require.NoError(t, err, "%s", out)
+
+	assertEventOrder(t, stubs.events(t),
+		"npm run build",
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore",
+		"go build -tags fts5",
+	)
+	require.FileExists(t, filepath.Join(
+		root,
+		"desktop",
+		"src-tauri",
+		"binaries",
+		"agentsview-x86_64-unknown-linux-gnu",
+	))
+}
+
+func TestPrepareSidecarStopsWhenPricingSnapshotRestoreFails(t *testing.T) {
+	requireUnixShell(t)
+
+	root := t.TempDir()
+	installRepoFile(t, root, "desktop/scripts/prepare-sidecar.sh", 0o755)
+	writeDesktopDevWorkspace(t, root)
+	stubs := installUnixBuildStubs(t, root)
+
+	out, err := runInWorkspace(
+		t,
+		root,
+		stubs.env("AGENTSVIEW_VERSION=v1.2.3", "RESTORE_FAIL=1"),
+		"bash",
+		"desktop/scripts/prepare-sidecar.sh",
+	)
+	require.Error(t, err, "script should fail when snapshot restore fails: %s", out)
+
+	events := stubs.events(t)
+	assertEventContains(t, events,
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore")
+	assertNoEventContains(t, events, "go build")
+}

--- a/dockerfile_test.go
+++ b/dockerfile_test.go
@@ -1,0 +1,26 @@
+package agentsview_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerfileRequiresPricingSnapshotBeforeBuild(t *testing.T) {
+	contents, err := os.ReadFile("Dockerfile")
+	require.NoError(t, err)
+
+	dockerfile := string(contents)
+	restoreIndex := strings.Index(dockerfile,
+		"go run ./internal/pricing/cmd/litellm-snapshot -restore")
+	buildIndex := strings.Index(dockerfile, "go build -tags fts5")
+	require.NotEqual(t, -1, restoreIndex,
+		"Dockerfile must restore the pricing snapshot")
+	require.NotEqual(t, -1, buildIndex,
+		"Dockerfile must build agentsview")
+	assert.Less(t, restoreIndex, buildIndex,
+		"Dockerfile must restore the pricing snapshot before compiling")
+}

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -21,23 +21,41 @@ func (s *Sync) syncModelPricing(ctx context.Context) error {
 	if len(prices) == 0 {
 		prices = duckFallbackPricingRows()
 	}
+	if len(prices) == 0 {
+		return nil
+	}
+	tx, err := s.duck.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning duckdb pricing sync: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(model_pattern) DO UPDATE SET
+			input_per_mtok = excluded.input_per_mtok,
+			output_per_mtok = excluded.output_per_mtok,
+			cache_creation_per_mtok = excluded.cache_creation_per_mtok,
+			cache_read_per_mtok = excluded.cache_read_per_mtok,
+			updated_at = excluded.updated_at`)
+	if err != nil {
+		return fmt.Errorf("preparing duckdb pricing sync: %w", err)
+	}
+	defer stmt.Close()
 	for _, p := range prices {
-		if _, err := s.duck.ExecContext(ctx, `
-			INSERT INTO model_pricing (
-				model_pattern, input_per_mtok, output_per_mtok,
-				cache_creation_per_mtok, cache_read_per_mtok, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?)
-			ON CONFLICT(model_pattern) DO UPDATE SET
-				input_per_mtok = excluded.input_per_mtok,
-				output_per_mtok = excluded.output_per_mtok,
-				cache_creation_per_mtok = excluded.cache_creation_per_mtok,
-				cache_read_per_mtok = excluded.cache_read_per_mtok,
-				updated_at = excluded.updated_at`,
+		if _, err := stmt.ExecContext(ctx,
 			p.ModelPattern, p.InputPerMTok, p.OutputPerMTok,
 			p.CacheCreationPerMTok, p.CacheReadPerMTok, p.UpdatedAt,
 		); err != nil {
 			return fmt.Errorf("syncing model pricing %q: %w", p.ModelPattern, err)
 		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing duckdb pricing sync: %w", err)
 	}
 	return nil
 }

--- a/internal/pricing/catalog/litellm.go
+++ b/internal/pricing/catalog/litellm.go
@@ -1,0 +1,92 @@
+package catalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const litellmURL = "https://raw.githubusercontent.com/" +
+	"BerriAI/litellm/main/" +
+	"model_prices_and_context_window.json"
+
+// ModelPricing holds per-model token pricing in cost per million tokens.
+type ModelPricing struct {
+	ModelPattern         string
+	InputPerMTok         float64
+	OutputPerMTok        float64
+	CacheCreationPerMTok float64
+	CacheReadPerMTok     float64
+}
+
+type litellmEntry struct {
+	InputCost         *float64 `json:"input_cost_per_token"`
+	OutputCost        *float64 `json:"output_cost_per_token"`
+	CacheCreationCost *float64 `json:"cache_creation_input_token_cost"`
+	CacheReadCost     *float64 `json:"cache_read_input_token_cost"`
+	Provider          string   `json:"litellm_provider"`
+}
+
+const perMTok = 1_000_000
+
+// FetchLiteLLMPricing downloads the LiteLLM pricing JSON
+// and parses it into ModelPricing entries.
+func FetchLiteLLMPricing() ([]ModelPricing, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(litellmURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching litellm pricing: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"fetching litellm pricing: status %d", resp.StatusCode,
+		)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading litellm response: %w", err)
+	}
+
+	return ParseLiteLLMPricing(data)
+}
+
+// ParseLiteLLMPricing parses the LiteLLM JSON map into
+// ModelPricing entries. Per-token costs are converted to
+// per-million-token costs. Entries missing both input and
+// output cost are skipped.
+func ParseLiteLLMPricing(
+	data []byte,
+) ([]ModelPricing, error) {
+	var raw map[string]litellmEntry
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing litellm JSON: %w", err)
+	}
+
+	var prices []ModelPricing
+	for model, entry := range raw {
+		if entry.InputCost == nil && entry.OutputCost == nil {
+			continue
+		}
+		p := ModelPricing{ModelPattern: model}
+		if entry.InputCost != nil {
+			p.InputPerMTok = *entry.InputCost * perMTok
+		}
+		if entry.OutputCost != nil {
+			p.OutputPerMTok = *entry.OutputCost * perMTok
+		}
+		if entry.CacheCreationCost != nil {
+			p.CacheCreationPerMTok =
+				*entry.CacheCreationCost * perMTok
+		}
+		if entry.CacheReadCost != nil {
+			p.CacheReadPerMTok = *entry.CacheReadCost * perMTok
+		}
+		prices = append(prices, p)
+	}
+	return prices, nil
+}

--- a/internal/pricing/cmd/litellm-snapshot/main.go
+++ b/internal/pricing/cmd/litellm-snapshot/main.go
@@ -1,0 +1,573 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/pricing/catalog"
+)
+
+var defaultOutputPath = filepath.FromSlash(
+	"internal/pricing/snapshot/litellm_snapshot.json.gz",
+)
+
+const (
+	defaultSnapshotRef     = "97c961ef945546cf463faed5de0d5521b302adcf"
+	defaultSnapshotSHA256  = "bef918527f538fed72c8f17b711dfbced1ca7f8964d3624174b3d101c6e21435"
+	defaultSnapshotBranch  = "litellm-pricing-snapshot"
+	defaultSnapshotFile    = "litellm_snapshot.json.gz"
+	defaultSnapshotBaseURL = "https://raw.githubusercontent.com/kenn-io/agentsview"
+)
+
+const maxSnapshotCompressedBytes = 1 << 20
+const maxSnapshotJSONBytes = 8 << 20
+const maxSnapshotModels = 100_000
+
+type snapshotBundle struct {
+	Version string                 `json:"version"`
+	Models  []catalog.ModelPricing `json:"models"`
+}
+
+func main() {
+	outPath := flag.String("out", defaultOutputPath, "output snapshot file path")
+	validatePath := flag.String("validate", "", "validate a snapshot file and exit")
+	restore := flag.Bool("restore", false, "restore a snapshot from a git artifact commit")
+	restoreRef := flag.String("ref", defaultSnapshotRef, "git commit containing the snapshot artifact")
+	restoreFile := flag.String("snapshot-file", defaultSnapshotFile, "snapshot path within the artifact commit")
+	restoreSHA256 := flag.String("sha256", defaultSnapshotSHA256, "expected snapshot SHA256")
+	restoreBranch := flag.String("branch", defaultSnapshotBranch, "artifact branch to fetch when ref is missing")
+	restoreURL := flag.String("url", defaultSnapshotURL(), "snapshot URL to use when git restore is unavailable")
+	flag.Parse()
+
+	if *validatePath != "" {
+		if err := validateSnapshotFile(*validatePath); err != nil {
+			panic(err)
+		}
+		fmt.Printf("validated %s\n", *validatePath)
+		return
+	}
+	if *restore {
+		if err := restoreSnapshotFile(
+			*outPath,
+			*restoreRef,
+			*restoreFile,
+			*restoreSHA256,
+			*restoreBranch,
+			*restoreURL,
+		); err != nil {
+			panic(err)
+		}
+		return
+	}
+
+	prices, err := catalog.FetchLiteLLMPricing()
+	if err != nil {
+		panic(err)
+	}
+
+	prices = appendModelOverlay(prices)
+	sort.Slice(prices, func(i, j int) bool {
+		return prices[i].ModelPattern < prices[j].ModelPattern
+	})
+
+	modelsJSON, err := json.Marshal(prices)
+	if err != nil {
+		panic(err)
+	}
+
+	version := computeVersion(modelsJSON)
+	bundle := snapshotBundle{
+		Version: version,
+		Models:  prices,
+	}
+
+	raw, err := json.Marshal(bundle)
+	if err != nil {
+		panic(err)
+	}
+
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	if _, err := gz.Write(raw); err != nil {
+		panic(err)
+	}
+	if err := gz.Close(); err != nil {
+		panic(err)
+	}
+
+	if err := os.WriteFile(*outPath, compressed.Bytes(), 0o644); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("wrote %s\n", *outPath)
+	fmt.Printf("snapshot version: %s\n", version)
+	fmt.Printf("models: %d\n", len(prices))
+}
+
+func computeVersion(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return "litellm-" + hex.EncodeToString(sum[:])[:12]
+}
+
+func defaultSnapshotURL() string {
+	return defaultSnapshotBaseURL + "/" + defaultSnapshotRef + "/" + defaultSnapshotFile
+}
+
+func validateSnapshotFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat snapshot: %w", err)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("empty snapshot")
+	}
+	if info.Size() > maxSnapshotCompressedBytes {
+		return fmt.Errorf(
+			"compressed snapshot exceeds %d bytes",
+			maxSnapshotCompressedBytes,
+		)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening snapshot: %w", err)
+	}
+	defer file.Close()
+
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("creating reader: %w", err)
+	}
+	defer reader.Close()
+
+	raw, err := readLimitedSnapshotJSON(reader, maxSnapshotJSONBytes)
+	if err != nil {
+		return fmt.Errorf("decompressing snapshot: %w", err)
+	}
+
+	var snapshot snapshotBundle
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return fmt.Errorf("parsing snapshot json: %w", err)
+	}
+	if snapshot.Version == "" {
+		return fmt.Errorf("missing snapshot version")
+	}
+	if len(snapshot.Models) == 0 {
+		return fmt.Errorf("missing snapshot models")
+	}
+	if len(snapshot.Models) > maxSnapshotModels {
+		return fmt.Errorf("snapshot models exceed %d entries", maxSnapshotModels)
+	}
+	for _, model := range snapshot.Models {
+		if strings.TrimSpace(model.ModelPattern) == "" {
+			return fmt.Errorf("snapshot contains model with empty pattern")
+		}
+	}
+
+	return nil
+}
+
+func restoreSnapshotFile(
+	outPath,
+	ref,
+	snapshotPath,
+	expectedSHA256,
+	branch,
+	snapshotURL string,
+) error {
+	if ref == "" {
+		return fmt.Errorf("missing artifact ref")
+	}
+	if snapshotPath == "" {
+		return fmt.Errorf("missing artifact snapshot path")
+	}
+	if expectedSHA256 == "" {
+		return fmt.Errorf("missing expected snapshot SHA256")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("creating snapshot directory: %w", err)
+	}
+
+	if _, err := os.Stat(outPath); err == nil {
+		actual, err := sha256File(outPath)
+		if err != nil {
+			return fmt.Errorf("hashing existing snapshot: %w", err)
+		}
+		if actual == expectedSHA256 {
+			if err := validateSnapshotFile(outPath); err != nil {
+				return fmt.Errorf("validating existing snapshot: %w", err)
+			}
+			fmt.Printf("Using existing %s\n", outPath)
+			return nil
+		}
+		fmt.Printf(
+			"Replacing %s: expected %s, got %s\n",
+			outPath,
+			expectedSHA256,
+			actual,
+		)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking existing snapshot: %w", err)
+	}
+
+	tmp := outPath + ".tmp"
+	if err := os.Remove(tmp); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing stale temp snapshot: %w", err)
+	}
+	defer os.Remove(tmp)
+
+	if err := restoreSnapshotFileFromGit(tmp, ref, snapshotPath, branch); err != nil {
+		if snapshotURL == "" {
+			return err
+		}
+		if removeErr := os.Remove(tmp); removeErr != nil && !os.IsNotExist(removeErr) {
+			return fmt.Errorf("removing failed git snapshot: %w", removeErr)
+		}
+		if downloadErr := downloadSnapshotFile(tmp, snapshotURL); downloadErr != nil {
+			return fmt.Errorf(
+				"restoring snapshot from git failed: %w; downloading snapshot failed: %v",
+				err,
+				downloadErr,
+			)
+		}
+	}
+
+	actual, err := sha256File(tmp)
+	if err != nil {
+		return fmt.Errorf("hashing restored snapshot: %w", err)
+	}
+	if actual != expectedSHA256 {
+		return fmt.Errorf(
+			"snapshot SHA256 mismatch: expected %s, got %s",
+			expectedSHA256,
+			actual,
+		)
+	}
+	if err := validateSnapshotFile(tmp); err != nil {
+		return fmt.Errorf("validating restored snapshot: %w", err)
+	}
+
+	if err := os.Rename(tmp, outPath); err != nil {
+		if removeErr := os.Remove(outPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return fmt.Errorf("replacing existing snapshot: %w", removeErr)
+		}
+		if renameErr := os.Rename(tmp, outPath); renameErr != nil {
+			return fmt.Errorf("moving snapshot into place: %w", renameErr)
+		}
+	}
+
+	fmt.Printf("Restored %s\n", outPath)
+	return nil
+}
+
+func restoreSnapshotFileFromGit(tmp, ref, snapshotPath, branch string) error {
+	if err := ensureGitCommit(ref, branch); err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("creating temp snapshot: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd := exec.Command("git", "show", ref+":"+snapshotPath)
+	cmd.Stdout = file
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	closeErr := file.Close()
+	if runErr != nil {
+		return fmt.Errorf(
+			"reading snapshot from git: %w: %s",
+			runErr,
+			strings.TrimSpace(stderr.String()),
+		)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing temp snapshot: %w", closeErr)
+	}
+
+	return nil
+}
+
+func downloadSnapshotFile(tmp, snapshotURL string) error {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(snapshotURL)
+	if err != nil {
+		return fmt.Errorf("requesting snapshot: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("snapshot download returned status %d", resp.StatusCode)
+	}
+
+	file, err := os.OpenFile(tmp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("creating temp snapshot: %w", err)
+	}
+	written, copyErr := io.Copy(file, io.LimitReader(resp.Body, maxSnapshotCompressedBytes+1))
+	closeErr := file.Close()
+	if copyErr != nil {
+		return fmt.Errorf("writing downloaded snapshot: %w", copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing temp snapshot: %w", closeErr)
+	}
+	if written > maxSnapshotCompressedBytes {
+		return fmt.Errorf(
+			"downloaded snapshot exceeds %d bytes",
+			maxSnapshotCompressedBytes,
+		)
+	}
+
+	return nil
+}
+
+func ensureGitCommit(ref, branch string) error {
+	if gitCommand("cat-file", "-e", ref+"^{commit}") == nil {
+		return nil
+	}
+
+	if err := fetchGitRef(ref); err == nil {
+		if gitCommand("cat-file", "-e", ref+"^{commit}") == nil {
+			return nil
+		}
+	}
+
+	if branch == "" {
+		return fmt.Errorf("artifact ref %s is not available locally", ref)
+	}
+
+	if err := fetchGitRef(branch + ":refs/remotes/origin/" + branch); err != nil {
+		return err
+	}
+	if err := gitCommand("cat-file", "-e", ref+"^{commit}"); err != nil {
+		return fmt.Errorf("artifact ref %s is not available after fetch: %w", ref, err)
+	}
+	return nil
+}
+
+func fetchGitRef(refspec string) error {
+	cmd := exec.Command("git", "fetch", "--depth=1", "origin", refspec)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf(
+			"fetching snapshot ref %s: %w: %s",
+			refspec,
+			err,
+			strings.TrimSpace(string(out)),
+		)
+	}
+	return nil
+}
+
+func gitCommand(args ...string) error {
+	cmd := exec.Command("git", args...)
+	return cmd.Run()
+}
+
+func sha256File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func readLimitedSnapshotJSON(reader io.Reader, limit int64) ([]byte, error) {
+	limited := io.LimitReader(reader, limit+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(raw)) > limit {
+		return nil, fmt.Errorf("decompressed snapshot exceeds %d bytes", limit)
+	}
+	return raw, nil
+}
+
+func appendModelOverlay(models []catalog.ModelPricing) []catalog.ModelPricing {
+	present := make(map[string]struct{}, len(models))
+	for _, price := range models {
+		present[price.ModelPattern] = struct{}{}
+	}
+
+	overlay := map[string]catalog.ModelPricing{
+		"claude-opus-4-6": {
+			ModelPattern:         "claude-opus-4-6",
+			InputPerMTok:         5.0,
+			OutputPerMTok:        25.0,
+			CacheCreationPerMTok: 6.25,
+			CacheReadPerMTok:     0.50,
+		},
+		"claude-opus-4-7": {
+			ModelPattern:         "claude-opus-4-7",
+			InputPerMTok:         5.0,
+			OutputPerMTok:        25.0,
+			CacheCreationPerMTok: 6.25,
+			CacheReadPerMTok:     0.50,
+		},
+		"claude-opus-4-8": {
+			ModelPattern:         "claude-opus-4-8",
+			InputPerMTok:         5.0,
+			OutputPerMTok:        25.0,
+			CacheCreationPerMTok: 6.25,
+			CacheReadPerMTok:     0.50,
+		},
+		"claude-opus-4-20250514": {
+			ModelPattern:         "claude-opus-4-20250514",
+			InputPerMTok:         15.0,
+			OutputPerMTok:        75.0,
+			CacheCreationPerMTok: 18.75,
+			CacheReadPerMTok:     1.50,
+		},
+		"claude-fable-5": {
+			ModelPattern:         "claude-fable-5",
+			InputPerMTok:         10.0,
+			OutputPerMTok:        50.0,
+			CacheCreationPerMTok: 12.50,
+			CacheReadPerMTok:     1.00,
+		},
+		"claude-sonnet-4-6": {
+			ModelPattern:         "claude-sonnet-4-6",
+			InputPerMTok:         3.0,
+			OutputPerMTok:        15.0,
+			CacheCreationPerMTok: 3.75,
+			CacheReadPerMTok:     0.30,
+		},
+		"claude-sonnet-4-20250514": {
+			ModelPattern:         "claude-sonnet-4-20250514",
+			InputPerMTok:         3.0,
+			OutputPerMTok:        15.0,
+			CacheCreationPerMTok: 3.75,
+			CacheReadPerMTok:     0.30,
+		},
+		"claude-sonnet-4-5-20250514": {
+			ModelPattern:         "claude-sonnet-4-5-20250514",
+			InputPerMTok:         3.0,
+			OutputPerMTok:        15.0,
+			CacheCreationPerMTok: 3.75,
+			CacheReadPerMTok:     0.30,
+		},
+		"claude-haiku-4-5-20251001": {
+			ModelPattern:         "claude-haiku-4-5-20251001",
+			InputPerMTok:         1.0,
+			OutputPerMTok:        5.0,
+			CacheCreationPerMTok: 1.25,
+			CacheReadPerMTok:     0.10,
+		},
+		"claude-haiku-3-5-20241022": {
+			ModelPattern:         "claude-haiku-3-5-20241022",
+			InputPerMTok:         0.80,
+			OutputPerMTok:        4.0,
+			CacheCreationPerMTok: 1.0,
+			CacheReadPerMTok:     0.08,
+		},
+		"gpt-5.5": {
+			ModelPattern:     "gpt-5.5",
+			InputPerMTok:     5.0,
+			OutputPerMTok:    30.0,
+			CacheReadPerMTok: 0.50,
+		},
+		"gpt-5.4": {
+			ModelPattern:     "gpt-5.4",
+			InputPerMTok:     2.50,
+			OutputPerMTok:    15.0,
+			CacheReadPerMTok: 0.25,
+		},
+		"gpt-5.4-mini": {
+			ModelPattern:     "gpt-5.4-mini",
+			InputPerMTok:     0.75,
+			OutputPerMTok:    4.50,
+			CacheReadPerMTok: 0.075,
+		},
+		"gpt-5.4-nano": {
+			ModelPattern:     "gpt-5.4-nano",
+			InputPerMTok:     0.20,
+			OutputPerMTok:    1.25,
+			CacheReadPerMTok: 0.02,
+		},
+		"gpt-5.3-codex": {
+			ModelPattern:     "gpt-5.3-codex",
+			InputPerMTok:     1.75,
+			OutputPerMTok:    14.0,
+			CacheReadPerMTok: 0.175,
+		},
+		"gpt-5.2-codex": {
+			ModelPattern:     "gpt-5.2-codex",
+			InputPerMTok:     1.75,
+			OutputPerMTok:    14.0,
+			CacheReadPerMTok: 0.175,
+		},
+		"gpt-5.1-codex-max": {
+			ModelPattern:     "gpt-5.1-codex-max",
+			InputPerMTok:     1.25,
+			OutputPerMTok:    10.0,
+			CacheReadPerMTok: 0.125,
+		},
+		"mistral-large": {
+			ModelPattern:  "mistral-large",
+			InputPerMTok:  4.0,
+			OutputPerMTok: 4.0,
+		},
+		"mistral-large-3": {
+			ModelPattern:         "mistral-large-3",
+			InputPerMTok:         4.0,
+			OutputPerMTok:        4.0,
+			CacheCreationPerMTok: 4.0,
+			CacheReadPerMTok:     0.30,
+		},
+		"mistral-medium": {
+			ModelPattern:  "mistral-medium",
+			InputPerMTok:  2.75,
+			OutputPerMTok: 2.75,
+		},
+		"mistral-medium-3": {
+			ModelPattern:  "mistral-medium-3",
+			InputPerMTok:  2.75,
+			OutputPerMTok: 2.75,
+		},
+		"mistral-medium-3.5": {
+			ModelPattern:         "mistral-medium-3.5",
+			InputPerMTok:         1.5,
+			OutputPerMTok:        7.5,
+			CacheCreationPerMTok: 1.5,
+			CacheReadPerMTok:     0.25,
+		},
+		"openrouter/owl-alpha": {
+			ModelPattern:  "openrouter/owl-alpha",
+			InputPerMTok:  0,
+			OutputPerMTok: 0,
+		},
+	}
+
+	out := make([]catalog.ModelPricing, len(models))
+	copy(out, models)
+	for modelPattern, price := range overlay {
+		if _, ok := present[modelPattern]; ok {
+			continue
+		}
+		out = append(out, price)
+	}
+	return out
+}

--- a/internal/pricing/cmd/litellm-snapshot/main_test.go
+++ b/internal/pricing/cmd/litellm-snapshot/main_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/pricing/catalog"
+)
+
+func TestAppendModelOverlay_FillsGaps(t *testing.T) {
+	base := []catalog.ModelPricing{
+		{ModelPattern: "existing-model", InputPerMTok: 1.0, OutputPerMTok: 2.0},
+	}
+	result := appendModelOverlay(base)
+
+	byPattern := make(map[string]catalog.ModelPricing)
+	for _, p := range result {
+		byPattern[p.ModelPattern] = p
+	}
+
+	assert.Contains(t, byPattern, "existing-model", "base model preserved")
+	assert.Contains(t, byPattern, "claude-opus-4-8", "overlay model appended")
+	assert.Contains(t, byPattern, "gpt-5.5", "overlay model appended")
+}
+
+func TestAppendModelOverlay_DoesNotOverwriteExisting(t *testing.T) {
+	base := []catalog.ModelPricing{
+		{ModelPattern: "claude-opus-4-8", InputPerMTok: 99.0, OutputPerMTok: 99.0},
+	}
+	result := appendModelOverlay(base)
+
+	var count int
+	for _, p := range result {
+		if p.ModelPattern == "claude-opus-4-8" {
+			count++
+			assert.Equal(t, 99.0, p.InputPerMTok, "existing rate preserved")
+		}
+	}
+	require.Equal(t, 1, count, "no duplicate entries for existing model")
+}
+
+func TestComputeVersion_Deterministic(t *testing.T) {
+	data := []byte(`[{"ModelPattern":"test","InputPerMTok":1}]`)
+	v1 := computeVersion(data)
+	v2 := computeVersion(data)
+	assert.Equal(t, v1, v2)
+	assert.Regexp(t, `^litellm-[0-9a-f]{12}$`, v1)
+}
+
+func TestComputeVersion_DifferentInputDifferentHash(t *testing.T) {
+	v1 := computeVersion([]byte(`[{"ModelPattern":"a"}]`))
+	v2 := computeVersion([]byte(`[{"ModelPattern":"b"}]`))
+	assert.NotEqual(t, v1, v2)
+}
+
+func TestDefaultOutputPathTargetsIgnoredSnapshot(t *testing.T) {
+	assert.Equal(
+		t,
+		"internal/pricing/snapshot/litellm_snapshot.json.gz",
+		filepath.ToSlash(defaultOutputPath),
+	)
+}
+
+func TestDefaultSnapshotConstantsNonEmpty(t *testing.T) {
+	assert.NotEmpty(t, defaultSnapshotRef, "pinned ref must be set")
+	assert.Len(t, defaultSnapshotRef, 40, "pinned ref must be a full SHA-1")
+	assert.NotEmpty(t, defaultSnapshotSHA256, "pinned SHA256 must be set")
+	assert.Len(t, defaultSnapshotSHA256, 64, "pinned SHA256 must be a hex-encoded SHA-256")
+	assert.NotEmpty(t, defaultSnapshotBranch, "pinned branch must be set")
+	assert.NotEmpty(t, defaultSnapshotFile, "pinned file must be set")
+}
+
+func TestFileURLForPathUsesFileScheme(t *testing.T) {
+	dir := t.TempDir()
+	abs, err := filepath.Abs(dir)
+	require.NoError(t, err)
+
+	got := fileURLForPath(dir)
+	assert.True(t, strings.HasPrefix(got, "file://"), got)
+	assert.NotContains(t, got, "\\")
+	if filepath.VolumeName(abs) != "" {
+		assert.True(t, strings.HasPrefix(got, "file:///"), got)
+	}
+}
+
+func TestFileURLPathForAbsPrefixesWindowsDrivePaths(t *testing.T) {
+	assert.Equal(t, "/C:/Users/test/repo", fileURLPathForAbs("C:/Users/test/repo", "C:"))
+	assert.Equal(t, "/tmp/repo", fileURLPathForAbs("/tmp/repo", ""))
+}
+
+func TestValidateSnapshotFileAcceptsValidSnapshot(t *testing.T) {
+	path := writeSnapshotFile(t, []byte(`{
+		"version": "litellm-test",
+		"models": [{"ModelPattern": "test-model", "InputPerMTok": 1}]
+	}`))
+
+	require.NoError(t, validateSnapshotFile(path))
+}
+
+func TestValidateSnapshotFileRejectsInvalidGzip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snapshot.json.gz")
+	require.NoError(t, os.WriteFile(path, []byte("not gzip"), 0o644))
+
+	err := validateSnapshotFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating reader")
+}
+
+func TestValidateSnapshotFileRejectsEmptyModels(t *testing.T) {
+	path := writeSnapshotFile(t, []byte(`{
+		"version": "litellm-test",
+		"models": []
+	}`))
+
+	err := validateSnapshotFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing snapshot models")
+}
+
+func TestValidateSnapshotFileRejectsOversizedDecompressedPayload(t *testing.T) {
+	path := writeSnapshotFile(t, bytes.Repeat(
+		[]byte(" "),
+		maxSnapshotJSONBytes+1,
+	))
+
+	err := validateSnapshotFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decompressed snapshot exceeds")
+}
+
+func TestRestoreSnapshotFileRestoresPinnedArtifact(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "Test")
+
+	source := filepath.Join(repo, "litellm_snapshot.json.gz")
+	require.NoError(t, os.WriteFile(source, gzipSnapshot(t, []byte(`{
+		"version": "litellm-test",
+		"models": [{"ModelPattern": "test-model", "InputPerMTok": 1}]
+	}`)), 0o644))
+	runGit(t, repo, "add", "litellm_snapshot.json.gz")
+	runGit(t, repo, "commit", "-m", "snapshot")
+	ref := runGit(t, repo, "rev-parse", "HEAD")
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repo))
+	defer func() {
+		require.NoError(t, os.Chdir(cwd))
+	}()
+
+	out := filepath.Join(repo, "out", "snapshot.json.gz")
+	require.NoError(t, restoreSnapshotFile(
+		out,
+		ref,
+		"litellm_snapshot.json.gz",
+		sha256FileForTest(t, source),
+		"unused-snapshot-branch",
+		"",
+	))
+
+	require.FileExists(t, out)
+	require.NoError(t, validateSnapshotFile(out))
+	assert.Equal(t, sha256FileForTest(t, source), sha256FileForTest(t, out))
+}
+
+func TestRestoreSnapshotFileFetchesPinnedArtifactAfterBranchAdvances(t *testing.T) {
+	remote := t.TempDir()
+	runGit(t, remote, "init")
+	runGit(t, remote, "config", "user.email", "test@example.com")
+	runGit(t, remote, "config", "user.name", "Test")
+	runGit(t, remote, "config", "uploadpack.allowReachableSHA1InWant", "true")
+
+	source := filepath.Join(remote, "litellm_snapshot.json.gz")
+	require.NoError(t, os.WriteFile(source, gzipSnapshot(t, []byte(`{
+		"version": "litellm-old",
+		"models": [{"ModelPattern": "old-model", "InputPerMTok": 1}]
+	}`)), 0o644))
+	runGit(t, remote, "add", "litellm_snapshot.json.gz")
+	runGit(t, remote, "commit", "-m", "old snapshot")
+	oldRef := runGit(t, remote, "rev-parse", "HEAD")
+	oldSHA := sha256FileForTest(t, source)
+
+	require.NoError(t, os.WriteFile(source, gzipSnapshot(t, []byte(`{
+		"version": "litellm-new",
+		"models": [{"ModelPattern": "new-model", "InputPerMTok": 2}]
+	}`)), 0o644))
+	runGit(t, remote, "add", "litellm_snapshot.json.gz")
+	runGit(t, remote, "commit", "-m", "new snapshot")
+	branch := runGit(t, remote, "branch", "--show-current")
+
+	clone := filepath.Join(t.TempDir(), "clone")
+	runGit(t, "", "clone", "--depth=1", fileURLForPath(remote), clone)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(clone))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(cwd))
+	})
+
+	out := filepath.Join(clone, "out", "snapshot.json.gz")
+	require.NoError(t, restoreSnapshotFile(
+		out,
+		oldRef,
+		"litellm_snapshot.json.gz",
+		oldSHA,
+		branch,
+		"",
+	))
+
+	assert.Equal(t, oldSHA, sha256FileForTest(t, out))
+}
+
+func TestRestoreSnapshotFileDownloadsPinnedArtifactWithoutGitCheckout(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "litellm_snapshot.json.gz")
+	require.NoError(t, os.WriteFile(source, gzipSnapshot(t, []byte(`{
+		"version": "litellm-url",
+		"models": [{"ModelPattern": "url-model", "InputPerMTok": 1}]
+	}`)), 0o644))
+	sourceSHA := sha256FileForTest(t, source)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/litellm_snapshot.json.gz", r.URL.Path)
+		http.ServeFile(w, r, source)
+	}))
+	t.Cleanup(server.Close)
+
+	workspace := t.TempDir()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workspace))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(cwd))
+	})
+
+	out := filepath.Join(workspace, "snapshot", "litellm_snapshot.json.gz")
+	require.NoError(t, restoreSnapshotFile(
+		out,
+		"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		"litellm_snapshot.json.gz",
+		sourceSHA,
+		"unused-snapshot-branch",
+		server.URL+"/litellm_snapshot.json.gz",
+	))
+
+	assert.Equal(t, sourceSHA, sha256FileForTest(t, out))
+	require.NoError(t, validateSnapshotFile(out))
+}
+
+func writeSnapshotFile(t *testing.T, data []byte) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "snapshot.json.gz")
+	require.NoError(t, os.WriteFile(path, gzipSnapshot(t, data), 0o644))
+	return path
+}
+
+func gzipSnapshot(t *testing.T, data []byte) []byte {
+	t.Helper()
+
+	var out bytes.Buffer
+	writer := gzip.NewWriter(&out)
+	_, err := writer.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return out.Bytes()
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed:\n%s", args, out)
+	return string(bytes.TrimSpace(out))
+}
+
+func fileURLForPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		panic(err)
+	}
+	return (&url.URL{
+		Scheme: "file",
+		Path:   fileURLPathForAbs(filepath.ToSlash(abs), filepath.VolumeName(abs)),
+	}).String()
+}
+
+func fileURLPathForAbs(abs, volumeName string) string {
+	if volumeName != "" && !strings.HasPrefix(abs, "/") {
+		return "/" + abs
+	}
+	return abs
+}
+
+func sha256FileForTest(t *testing.T, path string) string {
+	t.Helper()
+
+	sum, err := sha256File(path)
+	require.NoError(t, err)
+	return sum
+}

--- a/internal/pricing/fallback.go
+++ b/internal/pricing/fallback.go
@@ -1,164 +1,160 @@
 package pricing
 
-// FallbackVersion must be bumped whenever FallbackPricing
-// rates change so the startup seeder knows to re-upsert.
-const FallbackVersion = "2026-06-16.1"
+import (
+	"bytes"
+	"compress/gzip"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"slices"
+	"strings"
+	"sync"
+)
 
-// FallbackPricing returns hardcoded pricing for key Claude
-// models. Used when the LiteLLM fetch fails.
-// Prices in USD per million tokens, current as of 2026-05.
+const fallbackVersionUnknown = "0"
+const litellmSnapshotPath = "snapshot/litellm_snapshot.json.gz"
+const maxFallbackSnapshotCompressedBytes = 1 << 20
+const maxFallbackSnapshotJSONBytes = 8 << 20
+const maxFallbackSnapshotModels = 100_000
+
+//go:generate go run ./cmd/litellm-snapshot -out snapshot/litellm_snapshot.json.gz
+
+//go:embed snapshot/litellm_snapshot.json.gz
+var litellmSnapshotFS embed.FS
+
+type litellmFallbackSnapshot struct {
+	Version string         `json:"version"`
+	Models  []ModelPricing `json:"models"`
+}
+
+var (
+	fallbackPricingErr  error
+	fallbackPricing     []ModelPricing
+	fallbackPricingOnce sync.Once
+)
+
+// FallbackVersion is derived from the embedded snapshot; regenerate litellm_snapshot.json.gz to change it.
+var FallbackVersion = fallbackVersionUnknown
+
+func init() {
+	fallbackPricingOnce.Do(initFallbackPricing)
+}
+
+// FallbackPricing returns offline pricing from the embedded LiteLLM snapshot.
+// Data is copied for caller safety and deterministic DB seeding.
 func FallbackPricing() []ModelPricing {
-	return []ModelPricing{
-		// Current model names (used by Claude Code / Codex)
-		{
-			ModelPattern:         "claude-sonnet-4-6",
-			InputPerMTok:         3.0,
-			OutputPerMTok:        15.0,
-			CacheCreationPerMTok: 3.75,
-			CacheReadPerMTok:     0.30,
-		},
-		{
-			ModelPattern:         "claude-opus-4-6",
-			InputPerMTok:         5.0,
-			OutputPerMTok:        25.0,
-			CacheCreationPerMTok: 6.25,
-			CacheReadPerMTok:     0.50,
-		},
-		{
-			ModelPattern:         "claude-opus-4-7",
-			InputPerMTok:         5.0,
-			OutputPerMTok:        25.0,
-			CacheCreationPerMTok: 6.25,
-			CacheReadPerMTok:     0.50,
-		},
-		{
-			// Opus 4.8 launched at the Opus 4.6/4.7 rates and is
-			// not yet in the LiteLLM catalog, so it ships here so
-			// usage is priced until LiteLLM adds it.
-			ModelPattern:         "claude-opus-4-8",
-			InputPerMTok:         5.0,
-			OutputPerMTok:        25.0,
-			CacheCreationPerMTok: 6.25,
-			CacheReadPerMTok:     0.50,
-		},
-		{
-			// Fable 5 launched at double the Opus 4.8 rates and is
-			// not yet in the LiteLLM catalog, so it ships here so
-			// usage is priced until LiteLLM adds it.
-			ModelPattern:         "claude-fable-5",
-			InputPerMTok:         10.0,
-			OutputPerMTok:        50.0,
-			CacheCreationPerMTok: 12.50,
-			CacheReadPerMTok:     1.0,
-		},
-		{
-			ModelPattern:         "claude-haiku-4-5-20251001",
-			InputPerMTok:         1.0,
-			OutputPerMTok:        5.0,
-			CacheCreationPerMTok: 1.25,
-			CacheReadPerMTok:     0.10,
-		},
-		// Codex / OpenAI models
-		{
-			ModelPattern:     "gpt-5.5",
-			InputPerMTok:     5.0,
-			OutputPerMTok:    30.0,
-			CacheReadPerMTok: 0.50,
-		},
-		{
-			ModelPattern:  "gpt-5.4",
-			InputPerMTok:  2.50,
-			OutputPerMTok: 15.0,
-		},
-		{
-			ModelPattern:  "gpt-5.2-codex",
-			InputPerMTok:  1.75,
-			OutputPerMTok: 14.0,
-		},
-		{
-			ModelPattern:  "gpt-5.3-codex",
-			InputPerMTok:  1.75,
-			OutputPerMTok: 14.0,
-		},
-		{
-			ModelPattern:  "gpt-5.4-mini",
-			InputPerMTok:  0.75,
-			OutputPerMTok: 4.50,
-		},
-		{
-			ModelPattern:  "gpt-5.4-nano",
-			InputPerMTok:  0.20,
-			OutputPerMTok: 1.25,
-		},
-		{
-			ModelPattern:  "gpt-5.1-codex-max",
-			InputPerMTok:  1.25,
-			OutputPerMTok: 10.0,
-		},
-		// Older model names (still in some session logs)
-		{
-			ModelPattern:         "claude-sonnet-4-20250514",
-			InputPerMTok:         3.0,
-			OutputPerMTok:        15.0,
-			CacheCreationPerMTok: 3.75,
-			CacheReadPerMTok:     0.30,
-		},
-		{
-			ModelPattern:         "claude-sonnet-4-5-20250514",
-			InputPerMTok:         3.0,
-			OutputPerMTok:        15.0,
-			CacheCreationPerMTok: 3.75,
-			CacheReadPerMTok:     0.30,
-		},
-		{
-			ModelPattern:         "claude-opus-4-20250514",
-			InputPerMTok:         15.0,
-			OutputPerMTok:        75.0,
-			CacheCreationPerMTok: 18.75,
-			CacheReadPerMTok:     1.50,
-		},
-		{
-			ModelPattern:         "claude-haiku-3-5-20241022",
-			InputPerMTok:         0.80,
-			OutputPerMTok:        4.0,
-			CacheCreationPerMTok: 1.0,
-			CacheReadPerMTok:     0.08,
-		},
-		// Free OpenRouter model
-		{
-			ModelPattern:  "openrouter/owl-alpha",
-			InputPerMTok:  0,
-			OutputPerMTok: 0,
-		},
-		// Mistral models (Mistral Vibe)
-		{
-			ModelPattern:  "mistral-medium",
-			InputPerMTok:  2.75,
-			OutputPerMTok: 2.75,
-		},
-		{
-			ModelPattern:  "mistral-medium-3",
-			InputPerMTok:  2.75,
-			OutputPerMTok: 2.75,
-		},
-		{
-			ModelPattern:         "mistral-medium-3.5",
-			InputPerMTok:         1.5,
-			OutputPerMTok:        7.5,
-			CacheCreationPerMTok: 1.5,
-			CacheReadPerMTok:     0.25,
-		},
-		{
-			ModelPattern:  "mistral-large",
-			InputPerMTok:  4.0,
-			OutputPerMTok: 4.0,
-		},
-		{
-			ModelPattern:         "mistral-large-3",
-			InputPerMTok:         4.0,
-			OutputPerMTok:        4.0,
-			CacheCreationPerMTok: 4.0,
-			CacheReadPerMTok:     0.30,
-		},
+	fallbackPricingOnce.Do(initFallbackPricing)
+	if fallbackPricingErr != nil {
+		panic(fallbackPricingErr)
 	}
+
+	pricing := make([]ModelPricing, len(fallbackPricing))
+	copy(pricing, fallbackPricing)
+	return pricing
+}
+
+func initFallbackPricing() {
+	snapshot, err := decodeFallbackSnapshot()
+	if err != nil {
+		fallbackPricingErr = fmt.Errorf("loading liteLLM snapshot: %w", err)
+		FallbackVersion = fallbackVersionUnknown
+		log.Panicf("pricing: %v", fallbackPricingErr)
+	}
+
+	fallbackPricing = slices.Clone(snapshot.Models)
+	FallbackVersion = snapshot.Version
+}
+
+func decodeFallbackSnapshot() (litellmFallbackSnapshot, error) {
+	return decodeFallbackSnapshotFromFS(litellmSnapshotFS)
+}
+
+func decodeFallbackSnapshotFromFS(fsys fs.FS) (litellmFallbackSnapshot, error) {
+	blob, err := fs.ReadFile(fsys, litellmSnapshotPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"embedded LiteLLM snapshot is missing; run make pricing-snapshot",
+		)
+	}
+	if err != nil {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"reading snapshot: %w", err,
+		)
+	}
+	if len(blob) == 0 {
+		return litellmFallbackSnapshot{}, fmt.Errorf("empty snapshot")
+	}
+	if len(blob) > maxFallbackSnapshotCompressedBytes {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"compressed snapshot exceeds %d bytes",
+			maxFallbackSnapshotCompressedBytes,
+		)
+	}
+
+	reader, err := gzip.NewReader(bytes.NewReader(blob))
+	if err != nil {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"creating reader: %w", err,
+		)
+	}
+	defer reader.Close()
+
+	raw, err := readLimitedSnapshot(reader, maxFallbackSnapshotJSONBytes)
+	if err != nil {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"decompressing snapshot: %w", err,
+		)
+	}
+
+	var snapshot litellmFallbackSnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"parsing snapshot json: %w", err,
+		)
+	}
+	if snapshot.Version == "" {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"missing snapshot version",
+		)
+	}
+	if len(snapshot.Models) == 0 {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"missing snapshot models",
+		)
+	}
+	if len(snapshot.Models) > maxFallbackSnapshotModels {
+		return litellmFallbackSnapshot{}, fmt.Errorf(
+			"snapshot models exceed %d entries",
+			maxFallbackSnapshotModels,
+		)
+	}
+	for _, model := range snapshot.Models {
+		if strings.TrimSpace(model.ModelPattern) == "" {
+			return litellmFallbackSnapshot{}, fmt.Errorf(
+				"snapshot contains model with empty pattern",
+			)
+		}
+	}
+
+	slices.SortFunc(snapshot.Models, func(a, b ModelPricing) int {
+		return strings.Compare(a.ModelPattern, b.ModelPattern)
+	})
+
+	return snapshot, nil
+}
+
+func readLimitedSnapshot(reader io.Reader, limit int64) ([]byte, error) {
+	limited := io.LimitReader(reader, limit+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(raw)) > limit {
+		return nil, fmt.Errorf("decompressed snapshot exceeds %d bytes", limit)
+	}
+	return raw, nil
 }

--- a/internal/pricing/fallback_test.go
+++ b/internal/pricing/fallback_test.go
@@ -1,14 +1,18 @@
 package pricing
 
 import (
+	"bytes"
+	"compress/gzip"
+	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFallbackPricing_Opus46Rates(t *testing.T) {
-	prices := FallbackPricing()
+	prices := requireEmbeddedFallbackPricing(t)
 	var got *ModelPricing
 	for i := range prices {
 		if prices[i].ModelPattern == "claude-opus-4-6" {
@@ -30,7 +34,7 @@ func TestFallbackPricing_Opus46Rates(t *testing.T) {
 }
 
 func TestFallbackPricing_Opus47Rates(t *testing.T) {
-	prices := FallbackPricing()
+	prices := requireEmbeddedFallbackPricing(t)
 	var got *ModelPricing
 	for i := range prices {
 		if prices[i].ModelPattern == "claude-opus-4-7" {
@@ -54,7 +58,7 @@ func TestFallbackPricing_Opus47Rates(t *testing.T) {
 }
 
 func TestFallbackPricing_Opus48Rates(t *testing.T) {
-	prices := FallbackPricing()
+	prices := requireEmbeddedFallbackPricing(t)
 	var got *ModelPricing
 	for i := range prices {
 		if prices[i].ModelPattern == "claude-opus-4-8" {
@@ -78,7 +82,7 @@ func TestFallbackPricing_Opus48Rates(t *testing.T) {
 }
 
 func TestFallbackPricing_Fable5Rates(t *testing.T) {
-	prices := FallbackPricing()
+	prices := requireEmbeddedFallbackPricing(t)
 	var got *ModelPricing
 	for i := range prices {
 		if prices[i].ModelPattern == "claude-fable-5" {
@@ -103,7 +107,7 @@ func TestFallbackPricing_Fable5Rates(t *testing.T) {
 
 func TestFallbackPricing_HermesModels(t *testing.T) {
 	byPattern := make(map[string]ModelPricing)
-	for _, p := range FallbackPricing() {
+	for _, p := range requireEmbeddedFallbackPricing(t) {
 		byPattern[p.ModelPattern] = p
 	}
 
@@ -121,4 +125,196 @@ func TestFallbackPricing_HermesModels(t *testing.T) {
 	require.True(t, ok, "openrouter/owl-alpha entry missing from FallbackPricing")
 	assert.Zero(t, owl.InputPerMTok)
 	assert.Zero(t, owl.OutputPerMTok)
+}
+
+func TestFallbackPricing_Deterministic(t *testing.T) {
+	first := requireEmbeddedFallbackPricing(t)
+	second := FallbackPricing()
+
+	assert.Equal(t, first, second, "FallbackPricing should be deterministic")
+}
+
+func TestFallbackPricing_SortedByModelPattern(t *testing.T) {
+	prices := requireEmbeddedFallbackPricing(t)
+	require.Greater(t, len(prices), 0, "FallbackPricing returned empty")
+
+	for i := 1; i < len(prices); i++ {
+		prev := prices[i-1].ModelPattern
+		cur := prices[i].ModelPattern
+		assert.False(
+			t,
+			strings.Compare(prev, cur) > 0,
+			"fallback pricing should be sorted for model pattern: %q before %q", prev, cur,
+		)
+	}
+}
+
+func TestFallbackVersion_TracksEmbeddedSnapshot(t *testing.T) {
+	snapshot := requireEmbeddedFallbackSnapshot(t)
+	assert.Equal(t, snapshot.Version, FallbackVersion)
+	assert.NotEmpty(t, FallbackVersion, "fallback version should not be empty")
+	assert.True(t, strings.HasPrefix(FallbackVersion, "litellm-"),
+		"fallback version should start with litellm- prefix, got %q", FallbackVersion)
+	assert.Len(t, FallbackVersion, len("litellm-")+12,
+		"fallback version should be litellm- plus 12-char hex digest")
+}
+
+func TestFallbackPricing_GuaranteedModels(t *testing.T) {
+	byPattern := make(map[string]struct{})
+	for _, p := range requireEmbeddedFallbackPricing(t) {
+		byPattern[p.ModelPattern] = struct{}{}
+	}
+
+	guaranteed := []string{
+		"claude-sonnet-4-6",
+		"claude-opus-4-6",
+		"claude-opus-4-7",
+		"claude-opus-4-8",
+		"claude-fable-5",
+		"claude-haiku-4-5-20251001",
+		"claude-sonnet-4-20250514",
+		"claude-sonnet-4-5-20250514",
+		"claude-opus-4-20250514",
+		"claude-haiku-3-5-20241022",
+		"gpt-5.5",
+		"gpt-5.4",
+		"gpt-5.2-codex",
+		"gpt-5.3-codex",
+		"gpt-5.4-mini",
+		"gpt-5.4-nano",
+		"gpt-5.1-codex-max",
+		"openrouter/owl-alpha",
+		"mistral-large",
+		"mistral-large-3",
+		"mistral-medium",
+		"mistral-medium-3",
+		"mistral-medium-3.5",
+	}
+
+	for _, model := range guaranteed {
+		_, ok := byPattern[model]
+		assert.True(t, ok, "model %q must be present in FallbackPricing", model)
+	}
+}
+
+func TestFallbackPricing_OverlayOnlyRates(t *testing.T) {
+	byPattern := make(map[string]ModelPricing)
+	for _, p := range requireEmbeddedFallbackPricing(t) {
+		byPattern[p.ModelPattern] = p
+	}
+
+	cases := []struct {
+		model  string
+		input  float64
+		output float64
+	}{
+		{"gpt-5.4-mini", 0.75, 4.50},
+		{"gpt-5.4-nano", 0.20, 1.25},
+		{"claude-haiku-3-5-20241022", 0.80, 4.0},
+		{"mistral-medium-3.5", 1.5, 7.5},
+		{"gpt-5.3-codex", 1.75, 14.0},
+	}
+
+	for _, tc := range cases {
+		got, ok := byPattern[tc.model]
+		require.True(t, ok, "%s missing", tc.model)
+		assert.InDelta(t, tc.input, got.InputPerMTok, 0.001, "%s input rate", tc.model)
+		assert.InDelta(t, tc.output, got.OutputPerMTok, 0.001, "%s output rate", tc.model)
+	}
+}
+
+func TestDecodeFallbackSnapshotFromFS(t *testing.T) {
+	snapshot := []byte(`{
+		"version": "litellm-test",
+		"models": [
+			{"ModelPattern": "z-model", "InputPerMTok": 2},
+			{"ModelPattern": "a-model", "InputPerMTok": 1}
+		]
+	}`)
+
+	fsys := fstest.MapFS{
+		"snapshot/litellm_snapshot.json.gz": &fstest.MapFile{
+			Data: gzipData(t, snapshot),
+		},
+	}
+
+	got, err := decodeFallbackSnapshotFromFS(fsys)
+	require.NoError(t, err)
+
+	assert.Equal(t, "litellm-test", got.Version)
+	require.Len(t, got.Models, 2)
+	assert.Equal(t, "a-model", got.Models[0].ModelPattern)
+	assert.Equal(t, "z-model", got.Models[1].ModelPattern)
+}
+
+func TestDecodeFallbackSnapshotFromFS_MissingSnapshot(t *testing.T) {
+	fsys := fstest.MapFS{
+		"snapshot/.keep": &fstest.MapFile{
+			Data: []byte("keep embed dir for generated pricing snapshot\n"),
+		},
+	}
+
+	_, err := decodeFallbackSnapshotFromFS(fsys)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "embedded LiteLLM snapshot is missing")
+	assert.Contains(t, err.Error(), "make pricing-snapshot")
+}
+
+func TestDecodeFallbackSnapshotFromFS_RejectsOversizedDecompressedPayload(t *testing.T) {
+	fsys := fstest.MapFS{
+		"snapshot/litellm_snapshot.json.gz": &fstest.MapFile{
+			Data: gzipData(t, bytes.Repeat(
+				[]byte(" "),
+				maxFallbackSnapshotJSONBytes+1,
+			)),
+		},
+	}
+
+	_, err := decodeFallbackSnapshotFromFS(fsys)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decompressed snapshot exceeds")
+}
+
+func TestDecodeFallbackSnapshotFromFS_RejectsEmptyModels(t *testing.T) {
+	snapshot := []byte(`{
+		"version": "litellm-test",
+		"models": []
+	}`)
+
+	fsys := fstest.MapFS{
+		"snapshot/litellm_snapshot.json.gz": &fstest.MapFile{
+			Data: gzipData(t, snapshot),
+		},
+	}
+
+	_, err := decodeFallbackSnapshotFromFS(fsys)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing snapshot models")
+}
+
+func gzipData(t *testing.T, data []byte) []byte {
+	t.Helper()
+
+	var out bytes.Buffer
+	writer := gzip.NewWriter(&out)
+	_, err := writer.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return out.Bytes()
+}
+
+func requireEmbeddedFallbackPricing(t *testing.T) []ModelPricing {
+	t.Helper()
+
+	prices := FallbackPricing()
+	require.NotEmpty(t, prices, "FallbackPricing returned empty")
+	return prices
+}
+
+func requireEmbeddedFallbackSnapshot(t *testing.T) litellmFallbackSnapshot {
+	t.Helper()
+
+	snapshot, err := decodeFallbackSnapshot()
+	require.NoError(t, err, "decodeFallbackSnapshot failed")
+	return snapshot
 }

--- a/internal/pricing/litellm.go
+++ b/internal/pricing/litellm.go
@@ -1,94 +1,22 @@
 package pricing
 
-import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"time"
-)
-
-const litellmURL = "https://raw.githubusercontent.com/" +
-	"BerriAI/litellm/main/" +
-	"model_prices_and_context_window.json"
+import "go.kenn.io/agentsview/internal/pricing/catalog"
 
 // ModelPricing holds per-model token pricing in cost per
 // million tokens. Separate from db.ModelPricing — the CLI
 // command converts between the two.
-type ModelPricing struct {
-	ModelPattern         string
-	InputPerMTok         float64
-	OutputPerMTok        float64
-	CacheCreationPerMTok float64
-	CacheReadPerMTok     float64
-}
-
-type litellmEntry struct {
-	InputCost         *float64 `json:"input_cost_per_token"`
-	OutputCost        *float64 `json:"output_cost_per_token"`
-	CacheCreationCost *float64 `json:"cache_creation_input_token_cost"`
-	CacheReadCost     *float64 `json:"cache_read_input_token_cost"`
-	Provider          string   `json:"litellm_provider"`
-}
-
-const perMTok = 1_000_000
+type ModelPricing = catalog.ModelPricing
 
 // FetchLiteLLMPricing downloads the LiteLLM pricing JSON
 // and parses it into ModelPricing entries.
 func FetchLiteLLMPricing() ([]ModelPricing, error) {
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(litellmURL)
-	if err != nil {
-		return nil, fmt.Errorf("fetching litellm pricing: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(
-			"fetching litellm pricing: status %d", resp.StatusCode,
-		)
-	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading litellm response: %w", err)
-	}
-
-	return ParseLiteLLMPricing(data)
+	return catalog.FetchLiteLLMPricing()
 }
 
 // ParseLiteLLMPricing parses the LiteLLM JSON map into
 // ModelPricing entries. Per-token costs are converted to
 // per-million-token costs. Entries missing both input and
 // output cost are skipped.
-func ParseLiteLLMPricing(
-	data []byte,
-) ([]ModelPricing, error) {
-	var raw map[string]litellmEntry
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parsing litellm JSON: %w", err)
-	}
-
-	var prices []ModelPricing
-	for model, entry := range raw {
-		if entry.InputCost == nil && entry.OutputCost == nil {
-			continue
-		}
-		p := ModelPricing{ModelPattern: model}
-		if entry.InputCost != nil {
-			p.InputPerMTok = *entry.InputCost * perMTok
-		}
-		if entry.OutputCost != nil {
-			p.OutputPerMTok = *entry.OutputCost * perMTok
-		}
-		if entry.CacheCreationCost != nil {
-			p.CacheCreationPerMTok =
-				*entry.CacheCreationCost * perMTok
-		}
-		if entry.CacheReadCost != nil {
-			p.CacheReadPerMTok = *entry.CacheReadCost * perMTok
-		}
-		prices = append(prices, p)
-	}
-	return prices, nil
+func ParseLiteLLMPricing(data []byte) ([]ModelPricing, error) {
+	return catalog.ParseLiteLLMPricing(data)
 }

--- a/internal/pricing/litellm_test.go
+++ b/internal/pricing/litellm_test.go
@@ -91,8 +91,7 @@ func TestParseLiteLLMPricingSkipsNoCost(t *testing.T) {
 }
 
 func TestFallbackPricing(t *testing.T) {
-	prices := FallbackPricing()
-	require.NotEmpty(t, prices, "FallbackPricing returned empty")
+	prices := requireEmbeddedFallbackPricing(t)
 
 	required := map[string]bool{
 		"claude-sonnet-4-6":         false,

--- a/internal/pricing/snapshot/.gitignore
+++ b/internal/pricing/snapshot/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/makefile_test.go
+++ b/makefile_test.go
@@ -1,0 +1,103 @@
+package agentsview_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeBuildRestoresPricingSnapshot(t *testing.T) {
+	contents, err := os.ReadFile("Makefile")
+	require.NoError(t, err)
+
+	deps := makefileTargetDeps(t, string(contents), "build")
+	assert.Contains(t, deps, "pricing-snapshot")
+	assert.Contains(t, deps, "frontend")
+}
+
+func TestMakeTestTargetsRestorePricingSnapshot(t *testing.T) {
+	contents, err := os.ReadFile("Makefile")
+	require.NoError(t, err)
+
+	for _, target := range []string{
+		"test",
+		"test-short",
+		"test-postgres",
+		"test-postgres-ci",
+		"test-ssh",
+		"test-ssh-ci",
+	} {
+		deps := makefileTargetDeps(t, string(contents), target)
+		assert.Contains(t, deps, "pricing-snapshot", "%s", target)
+	}
+}
+
+func TestMakePricingSnapshotDelegatesToSnapshotTool(t *testing.T) {
+	contents, err := os.ReadFile("Makefile")
+	require.NoError(t, err)
+
+	recipe := makefileTargetRecipe(t, string(contents), "pricing-snapshot")
+	assert.Contains(t, recipe, "go run ./internal/pricing/cmd/litellm-snapshot -restore")
+}
+
+func TestMakeDevRestoresPricingSnapshot(t *testing.T) {
+	contents, err := os.ReadFile("Makefile")
+	require.NoError(t, err)
+
+	deps := makefileTargetDeps(t, string(contents), "dev")
+	assert.Contains(t, deps, "pricing-snapshot")
+}
+
+func TestMakeTidyRestoresPricingSnapshot(t *testing.T) {
+	contents, err := os.ReadFile("Makefile")
+	require.NoError(t, err)
+
+	deps := makefileTargetDeps(t, string(contents), "tidy")
+	assert.Contains(t, deps, "pricing-snapshot")
+}
+
+func makefileTargetDeps(t *testing.T, contents, target string) []string {
+	t.Helper()
+
+	prefix := target + ":"
+	for line := range strings.SplitSeq(contents, "\n") {
+		if after, ok := strings.CutPrefix(line, prefix); ok {
+			return strings.Fields(strings.TrimSpace(after))
+		}
+	}
+
+	require.Failf(t, "missing make target", "target %q was not found", target)
+	return nil
+}
+
+func makefileTargetRecipe(t *testing.T, contents, target string) string {
+	t.Helper()
+
+	lines := strings.Split(contents, "\n")
+	var out []string
+	inTarget := false
+	prefix := target + ":"
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			inTarget = true
+			continue
+		}
+		if !inTarget {
+			continue
+		}
+		if line == "" {
+			out = append(out, line)
+			continue
+		}
+		if !strings.HasPrefix(line, "\t") {
+			break
+		}
+		out = append(out, line)
+	}
+
+	require.NotEmpty(t, out, "target %q recipe not found", target)
+	return strings.Join(out, "\n")
+}

--- a/scripts/desktop-dev.ps1
+++ b/scripts/desktop-dev.ps1
@@ -122,6 +122,10 @@ if (-not $SkipBuild) {
     $env:CGO_ENABLED = "1"
     Push-Location $RepoRoot
     try {
+        go run ./internal/pricing/cmd/litellm-snapshot -restore
+        if ($LASTEXITCODE -ne 0) {
+            throw "pricing snapshot restore failed with exit code $LASTEXITCODE"
+        }
         go build -tags fts5 -ldflags $ldflags -o agentsview.exe ./cmd/agentsview
     } finally {
         Pop-Location

--- a/scripts/dev-backend-build.sh
+++ b/scripts/dev-backend-build.sh
@@ -21,5 +21,7 @@ LDFLAGS="-X main.version=${VERSION} \
          -X main.commit=${COMMIT} \
          -X main.buildDate=${BUILD_DATE}"
 
+go run ./internal/pricing/cmd/litellm-snapshot -restore
+
 CGO_ENABLED=1 go build -tags fts5 -ldflags="${LDFLAGS}" \
   -o ./tmp/agentsview ./cmd/agentsview

--- a/scripts/e2e-server.sh
+++ b/scripts/e2e-server.sh
@@ -15,11 +15,22 @@ mkdir -p "$EMPTY_DIR"
 # otherwise build from source (local dev).
 FIXTURE="${E2E_PREBUILT_FIXTURE:-}"
 SERVER="${E2E_PREBUILT_SERVER:-}"
+PRICING_SNAPSHOT_RESTORED=0
+
+restore_pricing_snapshot() {
+    if [ "$PRICING_SNAPSHOT_RESTORED" -eq 1 ]; then
+        return
+    fi
+
+    (cd "$ROOT" && go run ./internal/pricing/cmd/litellm-snapshot -restore)
+    PRICING_SNAPSHOT_RESTORED=1
+}
 
 if [ -n "$FIXTURE" ] && [ -f "$FIXTURE" ] && [ -x "$FIXTURE" ]; then
     echo "Using pre-built fixture: $FIXTURE"
 else
     echo "Building test fixture..."
+    restore_pricing_snapshot
     FIXTURE="$TMPDIR/testfixture"
     CGO_ENABLED=1 go build -tags "fts5,kit_posthog_disabled" \
       -o "$FIXTURE" "$ROOT/cmd/testfixture"
@@ -34,6 +45,7 @@ if [ -n "$SERVER" ] && [ -f "$SERVER" ] && [ -x "$SERVER" ]; then
     echo "Using pre-built server: $SERVER"
 else
     echo "Building server..."
+    restore_pricing_snapshot
     SERVER="$TMPDIR/agentsview"
     cd "$ROOT/frontend" && npm run build
     rm -rf "$ROOT/internal/web/dist"


### PR DESCRIPTION
## Summary
- replace the hand-maintained pricing fallback slice with a sorted LiteLLM snapshot that is decoded through the existing `pricing.FallbackPricing()` and `FallbackVersion` API surface
- keep SQLite, PostgreSQL, DuckDB, CLI usage, and startup refresh consumers on the same fallback source while preserving the existing async refresh behavior
- move the generated `litellm_snapshot.json.gz` out of the normal branch history and store it on the `litellm-pricing-snapshot` orphan artifact branch
- add `make pricing-snapshot` to restore the ignored generated snapshot from that branch, and make `make build`, `make build-release`, `make install`, and release targets embed it before compiling
- update the GitHub tag release workflow to restore the pricing snapshot before its direct `go build` commands, so production releases fail early instead of silently shipping without embedded offline pricing
- keep the snapshot generator responsible for fetching LiteLLM, applying explicit legacy/current overlays, sorting output, computing a deterministic version hash, and writing the gzipped asset under `internal/pricing/snapshot/`
- batch DuckDB fallback pricing upserts so the larger offline fallback does not push Windows DuckDB package tests past their timeout

## Notes
- clean source checkouts stay small because the generated `.json.gz` remains ignored and lives outside the main branch history
- the orphan branch artifact is intentionally tiny and Git-addressable; normal build and release paths restore it automatically before embedding
- explicit overlays remain limited to known models or aliases absent from the current LiteLLM catalog but still needed for existing sessions, including newer Claude/OpenAI/Mistral names and `openrouter/owl-alpha`
- backend pricing behavior remains shared through `pricing.FallbackPricing()`, with no backend-specific fallback divergence
- a raw manual `go build` from a clean checkout can still compile without the snapshot, but supported Makefile and GitHub release build paths embed it

Closes #315
