### PR TITLE
docs: clarify forwarded dev access

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -517,7 +517,7 @@ description: Release history for AgentsView
   returns a descriptive `403` body and logs a breadcrumb; the
   frontend Settings load surfaces the same actionable
   `--public-url` hint instead of a generic forbidden error. See
-  [Remote Access](/remote-access/#forwarded-host-rejections).
+  [Remote Access](/remote-access/#forwarded-dev-environments).
 - Update `agy-reader` install documentation to the current module
   root command: `go install github.com/mjacobs/agy-reader@latest`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,16 +13,16 @@ On macOS, the easiest install is via Homebrew Cask:
 brew install --cask agentsview
 ```
 
-On Windows and Linux (and as an alternative on macOS),
-download the latest `.dmg`, `.exe`, or `.AppImage` from
-[GitHub Releases](https://github.com/kenn-io/agentsview/releases).
-The desktop app is fully bundled — no CLI or dependencies needed —
-and includes built-in auto-update support.
+On Windows and Linux (and as an alternative on macOS), download the latest
+`.dmg`, `.exe`, or `.AppImage` from
+[GitHub Releases](https://github.com/kenn-io/agentsview/releases). The desktop
+app is fully bundled — no CLI or dependencies needed — and includes built-in
+auto-update support.
 
 !!! note
-    The desktop app and CLI share the same data directory
-    (`~/.agentsview/`), so you can use one or both. They are fully
-    complementary, not mutually exclusive.
+
+    The desktop app and CLI share the same data directory (`~/.agentsview/`), so you
+    can use one or both. They are fully complementary, not mutually exclusive.
 
 ### pip / uvx
 
@@ -31,9 +31,8 @@ pip install agentsview    # install permanently
 uvx agentsview            # or run without installing
 ```
 
-Platform-specific wheels are published to PyPI for Linux
-(x86_64, aarch64), macOS (x86_64, arm64), and Windows
-(x86_64, arm64).
+Platform-specific wheels are published to PyPI for Linux (x86_64, aarch64),
+macOS (x86_64, arm64), and Windows (x86_64, arm64).
 
 ### Shell Script
 
@@ -47,16 +46,15 @@ curl -fsSL https://agentsview.io/install.sh | bash
 powershell -ExecutionPolicy ByPass -c "irm https://agentsview.io/install.ps1 | iex"
 ```
 
-The installer detects your OS and architecture, downloads the latest
-release from GitHub Releases, verifies the SHA-256 checksum, and
-installs the binary.
+The installer detects your OS and architecture, downloads the latest release
+from GitHub Releases, verifies the SHA-256 checksum, and installs the binary.
 
 !!! note
-    On Windows on ARM, the installer uses the native `arm64` build when one
-    is available and otherwise falls back to the `x86_64` build, which runs
-    under Windows' built-in x64 emulation. To get a native binary on a
-    release that predates arm64 support, [build from
-    source](#build-from-source).
+
+    On Windows on ARM, the installer uses the native `arm64` build when one is
+    available and otherwise falls back to the `x86_64` build, which runs under
+    Windows' built-in x64 emulation. To get a native binary on a release that
+    predates arm64 support, [build from source](#build-from-source).
 
 ### Build from source
 
@@ -70,17 +68,18 @@ make install  # installs to ~/.local/bin
 ```
 
 !!! note
-    CGO is required for the SQLite driver. The `fts5` build tag
-    enables full-text search.
+
+    CGO is required for the SQLite driver. The `fts5` build tag enables full-text
+    search.
 
 #### Windows on ARM
 
-`make` isn't available on Windows, and CGO needs a C compiler that
-targets `aarch64`. Install [Go for
-Windows/ARM64](https://go.dev/dl/), [Node.js](https://nodejs.org/), and
-the aarch64 [llvm-mingw](https://github.com/mstorsjo/llvm-mingw/releases)
-toolchain (a self-contained clang + runtime; no Visual Studio or Windows
-SDK required), then build manually in PowerShell:
+`make` isn't available on Windows, and CGO needs a C compiler that targets
+`aarch64`. Install [Go for Windows/ARM64](https://go.dev/dl/),
+[Node.js](https://nodejs.org/), and the aarch64
+[llvm-mingw](https://github.com/mstorsjo/llvm-mingw/releases) toolchain (a
+self-contained clang + runtime; no Visual Studio or Windows SDK required), then
+build manually in PowerShell:
 
 ```powershell
 git clone https://github.com/kenn-io/agentsview.git
@@ -96,15 +95,14 @@ $env:CC = "C:\path\to\llvm-mingw\bin\aarch64-w64-mingw32-clang.exe"
 go build -tags fts5 -o agentsview.exe ./cmd/agentsview
 ```
 
-The resulting `agentsview.exe` is a native ARM64 binary. Most users
-don't need this — the installer and PyPI wheels ship native arm64 builds
-— but it's useful for development or to run unreleased changes.
+The resulting `agentsview.exe` is a native ARM64 binary. Most users don't need
+this — the installer and PyPI wheels ship native arm64 builds — but it's useful
+for development or to run unreleased changes.
 
 ### Docker
 
-Multi-arch images for `linux/amd64` and `linux/arm64` are
-published to GitHub Container Registry on every tagged release
-and on pushes to main:
+Multi-arch images for `linux/amd64` and `linux/arm64` are published to GitHub
+Container Registry on every tagged release and on pushes to main:
 
 ```bash
 docker run --rm -p 127.0.0.1:8080:8080 \
@@ -114,35 +112,31 @@ docker run --rm -p 127.0.0.1:8080:8080 \
   ghcr.io/kenn-io/agentsview:latest
 ```
 
-The container's entrypoint runs `agentsview serve` by default.
-Set `PG_SERVE=1` to switch to `agentsview pg serve` instead — the
-same image powers both modes.
+The container's entrypoint runs `agentsview serve` by default. Set `PG_SERVE=1`
+to switch to `agentsview pg serve` instead — the same image powers both modes.
 
-A containerized AgentsView only sees agent sessions from
-directories you explicitly bind-mount into the container. Mount
-each agent's session root read-only and point the matching
-[directory env var](/configuration/#session-discovery) at it.
-The data volume (`/data`) is owned by root inside the container,
-so prefer a named Docker volume over a host bind mount, or
-pre-create the host directory with the desired ownership.
+A containerized AgentsView only sees agent sessions from directories you
+explicitly bind-mount into the container. Mount each agent's session root
+read-only and point the matching
+[directory env var](/configuration/#session-discovery) at it. The data volume
+(`/data`) is owned by root inside the container, so prefer a named Docker volume
+over a host bind mount, or pre-create the host directory with the desired
+ownership.
 
 A production-style Compose example lives in the repo at
 [`docker-compose.prod.yaml`](https://github.com/kenn-io/agentsview/blob/main/docker-compose.prod.yaml).
-It persists `/data` in a named volume, mounts Claude, Codex,
-and OpenCode session roots read-only, and publishes the UI on
-`127.0.0.1:8080`:
+It persists `/data` in a named volume, mounts Claude, Codex, and OpenCode
+session roots read-only, and publishes the UI on `127.0.0.1:8080`:
 
 ```bash
 docker compose -f docker-compose.prod.yaml up -d
 ```
 
-The example publishes the UI on loopback only. To expose it
-beyond the host, also enable bearer-token
-[authentication](/remote-access/#authentication) and publish the
-port intentionally.
+The example publishes the UI on loopback only. To expose it beyond the host,
+also enable bearer-token [authentication](/remote-access/#authentication) and
+publish the port intentionally.
 
-For a PostgreSQL-backed deployment, point the container at your
-shared database:
+For a PostgreSQL-backed deployment, point the container at your shared database:
 
 ```bash
 docker run --rm -p 127.0.0.1:8080:8080 \
@@ -153,8 +147,8 @@ docker run --rm -p 127.0.0.1:8080:8080 \
 
 ## Run
 
-The desktop app handles startup automatically — just open
-the app. CLI users start the server manually:
+The desktop app handles startup automatically — just open the app. CLI users
+start the server manually:
 
 ```bash
 agentsview serve
@@ -163,14 +157,14 @@ agentsview serve
 This will:
 
 1. Initialize the SQLite database at `~/.agentsview/sessions.db`
-2. Discover and sync sessions from all [supported agents](/configuration/#session-discovery)
-3. Start watching session directories for changes
-4. Launch the web UI at `http://127.0.0.1:8080`
+1. Discover and sync sessions from all
+    [supported agents](/configuration/#session-discovery)
+1. Start watching session directories for changes
+1. Launch the web UI at `http://127.0.0.1:8080`
 
-Open `http://127.0.0.1:8080` in your browser. Pass
-`--no-browser` to disable automatic browser launch. To keep the
-server running after your shell exits, start it in managed
-background mode:
+Open `http://127.0.0.1:8080` in your browser. Pass `--no-browser` to disable
+automatic browser launch. To keep the server running after your shell exits,
+start it in managed background mode:
 
 ```bash
 agentsview serve --background
@@ -188,6 +182,17 @@ agentsview serve --host 0.0.0.0 --port 3000
 agentsview serve --no-browser  # Disable browser auto-open
 agentsview serve --background  # Run as a managed background server
 ```
+
+!!! tip "Forwarded development environments"
+
+    If you open AgentsView through exe.dev, Codespaces, Coder, WSL2, SSH port
+    forwarding, or a reverse proxy, restart the CLI with `--public-url` set to the
+    exact browser origin: `agentsview serve --public-url https://<vm>.exe.xyz`.
+
+    A dashboard flash followed by a settings or API error usually means the server
+    rejected the forwarded host or origin. It is not a missing auth token unless
+    `/api/v1/settings` returns `401`. See
+    [Remote Access](/remote-access/#forwarded-dev-environments).
 
 Point to custom session directories with environment variables:
 
@@ -246,4 +251,5 @@ Once running, the web UI provides:
 - **Full-text search** across all message content
 - **Analytics** including activity heatmaps, tool usage, and velocity charts
 - **Activity reporting** with concurrency, agent-minutes, cost, and session rows
-- **Session export** to standalone HTML, markdown export links for agent handoff, or GitHub Gist
+- **Session export** to standalone HTML, markdown export links for agent
+    handoff, or GitHub Gist

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -3,15 +3,13 @@ title: Remote Access
 description: Access AgentsView from other devices on your network
 ---
 
-AgentsView binds to `127.0.0.1` by default, so only your local
-machine can reach it. To make the UI available from other devices,
-you need to do two things:
+AgentsView binds to `127.0.0.1` by default, so only your local machine can reach
+it. To make the UI available from other devices, you need to do two things:
 
 - listen on a non-loopback address or put the server behind a proxy
 - require a bearer token for API access
 
-In current releases, bearer-token auth is controlled by
-`require_auth`.
+In current releases, bearer-token auth is controlled by `require_auth`.
 
 ## Quick Setup
 
@@ -27,25 +25,24 @@ Then start the server on a non-loopback interface:
 agentsview serve --host 0.0.0.0
 ```
 
-When this command runs inside WSL, AgentsView advertises the WSL
-`eth0` address instead of `127.0.0.1` so the printed URL is usable
-from the Windows host and nearby LAN clients. An explicit
-`--public-url` still takes precedence.
+When this command runs inside WSL, AgentsView advertises the WSL `eth0` address
+instead of `127.0.0.1` so the printed URL is usable from the Windows host and
+nearby LAN clients. An explicit `--public-url` still takes precedence.
 
-When auth is enabled, AgentsView generates a token if needed and
-prints it on startup:
+When auth is enabled, AgentsView generates a token if needed and prints it on
+startup:
 
 ```
 Auth enabled. Token: <token>
 ```
 
-Open `http://<your-ip>:8080` from another device and configure the
-token in the frontend, or send it in an `Authorization` header.
+Open `http://<your-ip>:8080` from another device and configure the token in the
+frontend, or send it in an `Authorization` header.
 
 !!! note
-    Older configs may still use `remote_access = true`. AgentsView
-    still reads that legacy key, but new setups should use
-    `require_auth = true`.
+
+    Older configs may still use `remote_access = true`. AgentsView still reads that
+    legacy key, but new setups should use `require_auth = true`.
 
 ## Authentication
 
@@ -55,21 +52,20 @@ When `require_auth` is enabled, all `/api/` requests must include:
 Authorization: Bearer <token>
 ```
 
-The token is stored in `config.toml` as `auth_token`. It is
-generated automatically the first time auth is enabled, so you do
-not need to mint one manually.
+The token is stored in `config.toml` as `auth_token`. It is generated
+automatically the first time auth is enabled, so you do not need to mint one
+manually.
 
-Auth is enforced on API routes, not on static assets. That means a
-browser can load the HTML shell, but API requests fail with `401`
-until the correct token is supplied.
+Auth is enforced on API routes, not on static assets. That means a browser can
+load the HTML shell, but API requests fail with `401` until the correct token is
+supplied.
 
-When `require_auth` is disabled, normal local loopback use remains
-ungated.
+When `require_auth` is disabled, normal local loopback use remains ungated.
 
 ## SSE Endpoints
 
-The SSE endpoints also accept `?token=<token>` because browser
-`EventSource` cannot set custom headers:
+The SSE endpoints also accept `?token=<token>` because browser `EventSource`
+cannot set custom headers:
 
 ```text
 http://<host>:8080/api/v1/events?token=<token>
@@ -80,8 +76,8 @@ Use header-based auth for normal API calls whenever possible.
 
 ## Public URL And Trusted Origins
 
-When you access AgentsView through a hostname or reverse proxy,
-tell the server about the public URL:
+When you access AgentsView through a hostname or reverse proxy, tell the server
+about the public URL:
 
 ```bash
 agentsview serve --public-url https://agents.example.com
@@ -111,42 +107,67 @@ public_origins = [
 ]
 ```
 
-### Forwarded-Host Rejections
+### Forwarded Dev Environments
 
-AgentsView validates the request `Host` header before serving API
-requests. That protects local loopback servers from DNS-rebinding
-attacks, but it also means SSH port forwards, reverse proxies, WSL2,
-Codespaces, Coder, and similar remote development environments must
-use a trusted public URL or origin.
+AgentsView validates the request `Host` header before serving API requests. That
+protects local loopback servers from DNS-rebinding attacks, but it also means
+SSH port forwards, reverse proxies, WSL2, Codespaces, Coder, and similar remote
+development environments must use a trusted public URL or origin.
 
-When the browser sends an untrusted `Host`, current releases return
-`403 Forbidden` with a response body that explains the rejected host,
-the allowed set, and the `--public-url` fix. The Settings page shows
-the same actionable message instead of prompting for an auth token.
-A short breadcrumb is also written to the server debug log.
+Static assets can still load in these environments because the HTML shell is
+intentionally less strict than `/api/` routes. The dashboard may appear briefly,
+then `/api/v1/settings` or another API request can fail with `403 Forbidden` if
+the browser `Host` is the forwarded hostname rather than one of the local
+allowed hosts.
 
 Restart the server with the exact origin you open in the browser:
 
 ```bash
-# Browser opens http://127.0.0.1:18080 via:
-# ssh -L 18080:127.0.0.1:8080 host
-agentsview serve --public-url http://127.0.0.1:18080
+# exe.dev browser URL: https://<vm>.exe.xyz
+agentsview serve --public-url https://<vm>.exe.xyz
 
-# Browser opens a forwarded workspace hostname
-agentsview serve --public-url https://your-workspace.example.dev
+# ssh -L 18080:127.0.0.1:8080 host
+# Browser opens http://127.0.0.1:18080
+agentsview serve --public-url http://127.0.0.1:18080
+```
+
+`--public-url` must match the browser origin exactly, including the scheme,
+hostname, and non-default port. When the browser sends an untrusted `Host`,
+current releases return `403 Forbidden` with a response body that explains the
+rejected host, the allowed set, and the `--public-url` fix. The Settings page
+shows the same actionable message instead of prompting for an auth token. A
+short breadcrumb is also written to the server debug log.
+
+### Troubleshooting Forwarded Access
+
+If the UI flashes and then the dashboard or settings page fails, check the
+`/api/v1/settings` request in browser devtools:
+
+| Symptom or check                              | Meaning                                    | Fix                                                                          |
+| --------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------- |
+| `/api/v1/settings` returns `401 Unauthorized` | Bearer-token auth is enabled               | Use the token printed by the server or stored in `~/.agentsview/config.toml` |
+| `/api/v1/settings` returns `403 Forbidden`    | The browser host or origin was rejected    | Restart with `agentsview serve --public-url <exact-browser-origin>`          |
+| `/api/v1/settings` goes to an unexpected host | The frontend has a saved remote server URL | Clear `localStorage.getItem("agentsview-server-url")` for this site          |
+
+To clear an unintended saved server URL, run this in the browser console and
+reload:
+
+```js
+localStorage.removeItem("agentsview-server-url")
+location.reload()
 ```
 
 ## Managed Caddy Mode
 
-AgentsView can manage a [Caddy](https://caddyserver.com) reverse
-proxy for TLS-terminated access. The AgentsView backend stays on
-loopback while Caddy handles the public socket.
+AgentsView can manage a [Caddy](https://caddyserver.com) reverse proxy for
+TLS-terminated access. The AgentsView backend stays on loopback while Caddy
+handles the public socket.
 
 !!! warning "Enable auth first"
-    Managed Caddy exposes a public endpoint. Set `require_auth = true`
-    in `~/.agentsview/config.toml` before starting the server, or the
-    proxy will front an unauthenticated API. See [Quick
-    Setup](#quick-setup).
+
+    Managed Caddy exposes a public endpoint. Set `require_auth = true` in
+    `~/.agentsview/config.toml` before starting the server, or the proxy will front
+    an unauthenticated API. See [Quick Setup](#quick-setup).
 
 ```bash
 agentsview serve \
@@ -156,25 +177,25 @@ agentsview serve \
   --tls-key /path/to/key.pem
 ```
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--proxy` | | Proxy mode — currently `caddy` |
-| `--caddy-bin` | `caddy` | Path to the Caddy binary |
-| `--proxy-bind-host` | `127.0.0.1` | Interface for Caddy to bind |
-| `--public-port` | `8443` | External port for the public URL |
-| `--tls-cert` | | TLS certificate file path |
-| `--tls-key` | | TLS key file path |
-| `--allowed-subnet` | | Client CIDR allowlist (repeatable or comma-separated) |
+| Flag                | Default     | Description                                           |
+| ------------------- | ----------- | ----------------------------------------------------- |
+| `--proxy`           |             | Proxy mode — currently `caddy`                        |
+| `--caddy-bin`       | `caddy`     | Path to the Caddy binary                              |
+| `--proxy-bind-host` | `127.0.0.1` | Interface for Caddy to bind                           |
+| `--public-port`     | `8443`      | External port for the public URL                      |
+| `--tls-cert`        |             | TLS certificate file path                             |
+| `--tls-key`         |             | TLS key file path                                     |
+| `--allowed-subnet`  |             | Client CIDR allowlist (repeatable or comma-separated) |
 
-Caddy must already be installed and available on `PATH` unless you
-override it with `--caddy-bin`.
+Caddy must already be installed and available on `PATH` unless you override it
+with `--caddy-bin`.
 
 ### Subnet Allowlists
 
-When using a non-loopback bind host for Caddy, restrict access to
-specific networks. Subnet allowlists complement bearer-token auth
-rather than replacing it — `require_auth = true` should still be
-set before binding Caddy off loopback.
+When using a non-loopback bind host for Caddy, restrict access to specific
+networks. Subnet allowlists complement bearer-token auth rather than replacing
+it — `require_auth = true` should still be set before binding Caddy off
+loopback.
 
 ```bash
 agentsview serve \
@@ -188,8 +209,8 @@ Requests from outside the allowed subnets receive `403`.
 
 ## Settings Page
 
-Remote access can also be configured from the Settings page. The
-**Remote Access** section lets you:
+Remote access can also be configured from the Settings page. The **Remote
+Access** section lets you:
 
 - toggle `require_auth`
 - view the auto-generated auth token
@@ -197,23 +218,22 @@ Remote access can also be configured from the Settings page. The
 
 ![Settings remote access](/assets/generated/screenshots/settings-remote.png)
 
-Changes that affect bind or auth behavior may require a server
-restart.
+Changes that affect bind or auth behavior may require a server restart.
 
 ## CLI Flags Reference
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--host` | `127.0.0.1` | Interface to bind |
-| `--public-url` | | Public URL for hostname or proxy access |
-| `--public-origin` | | Trusted browser origin (repeatable/comma-separated) |
-| `--proxy` | | Managed proxy mode (`caddy`) |
-| `--caddy-bin` | `caddy` | Caddy binary path |
-| `--proxy-bind-host` | `127.0.0.1` | Interface for managed proxy |
-| `--public-port` | `8443` | External port for managed proxy |
-| `--tls-cert` | | TLS certificate path |
-| `--tls-key` | | TLS key path |
-| `--allowed-subnet` | | Client CIDR allowlist (repeatable/comma-separated) |
+| Flag                | Default     | Description                                         |
+| ------------------- | ----------- | --------------------------------------------------- |
+| `--host`            | `127.0.0.1` | Interface to bind                                   |
+| `--public-url`      |             | Public URL for hostname or proxy access             |
+| `--public-origin`   |             | Trusted browser origin (repeatable/comma-separated) |
+| `--proxy`           |             | Managed proxy mode (`caddy`)                        |
+| `--caddy-bin`       | `caddy`     | Caddy binary path                                   |
+| `--proxy-bind-host` | `127.0.0.1` | Interface for managed proxy                         |
+| `--public-port`     | `8443`      | External port for managed proxy                     |
+| `--tls-cert`        |             | TLS certificate path                                |
+| `--tls-key`         |             | TLS key path                                        |
+| `--allowed-subnet`  |             | Client CIDR allowlist (repeatable/comma-separated)  |
 
 ## Config File Reference
 
@@ -235,20 +255,20 @@ tls_key = "/path/to/key.pem"
 allowed_subnets = ["192.168.1.0/24"]
 ```
 
-| Field | Description |
-|-------|-------------|
-| `require_auth` | Require bearer-token authentication for API access |
-| `auth_token` | Auto-generated 256-bit bearer token |
-| `public_url` | Public URL for host/origin validation |
-| `public_origins` | Additional trusted CORS origins |
-| `proxy.mode` | Managed proxy mode (`caddy`) |
-| `proxy.bin` | Path to proxy binary |
-| `proxy.bind_host` | Interface for proxy to bind |
-| `proxy.public_port` | External port for proxy |
-| `proxy.tls_cert` | TLS certificate path |
-| `proxy.tls_key` | TLS key path |
-| `proxy.allowed_subnets` | CIDR allowlist for proxy connections |
+| Field                   | Description                                        |
+| ----------------------- | -------------------------------------------------- |
+| `require_auth`          | Require bearer-token authentication for API access |
+| `auth_token`            | Auto-generated 256-bit bearer token                |
+| `public_url`            | Public URL for host/origin validation              |
+| `public_origins`        | Additional trusted CORS origins                    |
+| `proxy.mode`            | Managed proxy mode (`caddy`)                       |
+| `proxy.bin`             | Path to proxy binary                               |
+| `proxy.bind_host`       | Interface for proxy to bind                        |
+| `proxy.public_port`     | External port for proxy                            |
+| `proxy.tls_cert`        | TLS certificate path                               |
+| `proxy.tls_key`         | TLS key path                                       |
+| `proxy.allowed_subnets` | CIDR allowlist for proxy connections               |
 
 For LAN access you still need a non-loopback bind such as
-`agentsview serve --host 0.0.0.0`. `require_auth` controls API
-auth; it does not change the bind address by itself.
+`agentsview serve --host 0.0.0.0`. `require_auth` controls API auth; it does not
+change the bind address by itself.


### PR DESCRIPTION
Issue #562 turned out to be a forwarded-host validation path rather than missing authentication configuration. The docs now point users running through exe.dev, SSH forwarding, WSL2, Codespaces, Coder, or reverse proxies at the exact-origin `--public-url` fix before they need to debug the settings API request themselves.

The remote access page also distinguishes the likely `/api/v1/settings` outcomes: `401` means bearer-token auth is active, `403` means the browser host or origin was rejected, and an unexpected target usually means the frontend has a saved remote server URL. This keeps the auth-token guidance separate from the forwarded development environment workflow.

Closes #562.