### PR TITLE
fix(parser): avoid protected home dirs in aider discovery

### DIFF
--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -89,6 +89,16 @@ var aiderSkipDirs = map[string]struct{}{
 	".hg":          {},
 }
 
+// aiderProtectedHomeDirs are first-level home folders that trigger macOS
+// privacy prompts when a desktop app enumerates them. Aider's default root is
+// $HOME, so the best-effort discovery walk must not enter these folders unless
+// the user explicitly configures one of them as the Aider root.
+var aiderProtectedHomeDirs = map[string]struct{}{
+	"Desktop":   {},
+	"Documents": {},
+	"Downloads": {},
+}
+
 // AiderDiscoverySkipDirNames returns the directory basenames pruned by Aider
 // discovery. Remote SSH discovery uses this to mirror local discovery semantics.
 func AiderDiscoverySkipDirNames() []string {
@@ -700,6 +710,7 @@ func DiscoverAiderSessions(root string) []DiscoveredFile {
 	if root == "" {
 		return nil
 	}
+	skipProtectedHomeDirs := aiderRootIsHome(root)
 	rootDepth := strings.Count(filepath.Clean(root), string(os.PathSeparator))
 
 	var files []DiscoveredFile
@@ -727,14 +738,19 @@ func DiscoverAiderSessions(root string) []DiscoveredFile {
 			if d.Type()&os.ModeSymlink != 0 {
 				return filepath.SkipDir
 			}
+			depth := strings.Count(
+				filepath.Clean(path), string(os.PathSeparator),
+			) - rootDepth
+			if skipProtectedHomeDirs && depth == 1 {
+				if _, skip := aiderProtectedHomeDirs[d.Name()]; skip {
+					return filepath.SkipDir
+				}
+			}
 			if path != root {
 				if _, skip := aiderSkipDirs[d.Name()]; skip {
 					return filepath.SkipDir
 				}
 			}
-			depth := strings.Count(
-				filepath.Clean(path), string(os.PathSeparator),
-			) - rootDepth
 			// Skip descent BELOW the cap, but still visit files in a
 			// directory AT the cap, so a history file exactly
 			// aiderMaxWalkDepth levels under the root is discovered (the
@@ -770,6 +786,14 @@ func DiscoverAiderSessions(root string) []DiscoveredFile {
 		return files[i].Path < files[j].Path
 	})
 	return files
+}
+
+func aiderRootIsHome(root string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	return filepath.Clean(root) == filepath.Clean(home)
 }
 
 // FindAiderSourceFile resolves a single aider run's virtual source path

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -710,7 +711,7 @@ func DiscoverAiderSessions(root string) []DiscoveredFile {
 	if root == "" {
 		return nil
 	}
-	skipProtectedHomeDirs := aiderRootIsHome(root)
+	skipProtectedHomeDirs := aiderShouldSkipProtectedHomeDirs(root, aiderHomeDir(), runtime.GOOS)
 	rootDepth := strings.Count(filepath.Clean(root), string(os.PathSeparator))
 
 	var files []DiscoveredFile
@@ -788,9 +789,16 @@ func DiscoverAiderSessions(root string) []DiscoveredFile {
 	return files
 }
 
-func aiderRootIsHome(root string) bool {
+func aiderHomeDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
+		return ""
+	}
+	return home
+}
+
+func aiderShouldSkipProtectedHomeDirs(root, home, goos string) bool {
+	if goos != "darwin" || root == "" || home == "" {
 		return false
 	}
 	return filepath.Clean(root) == filepath.Clean(home)

--- a/internal/parser/aider_test.go
+++ b/internal/parser/aider_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -605,7 +606,21 @@ func TestDiscoverAiderSessions(t *testing.T) {
 	assert.Empty(t, DiscoverAiderSessions(""))
 }
 
+func TestAiderShouldSkipProtectedHomeDirsOnlyOnDarwinHomeRoot(t *testing.T) {
+	home := filepath.Join(string(os.PathSeparator), "home", "user")
+
+	assert.True(t, aiderShouldSkipProtectedHomeDirs(home, home, "darwin"))
+	assert.False(t, aiderShouldSkipProtectedHomeDirs(home, home, "linux"))
+	assert.False(t, aiderShouldSkipProtectedHomeDirs(home, home, "windows"))
+	assert.False(t,
+		aiderShouldSkipProtectedHomeDirs(filepath.Join(home, "Documents"), home, "darwin"),
+		"explicit protected roots are user-scoped opt-ins")
+}
+
 func TestDiscoverAiderSessionsSkipsMacOSProtectedDirs(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS TCC protected-directory pruning is Darwin-only")
+	}
 	root := t.TempDir()
 	t.Setenv("HOME", root)
 	for _, name := range []string{"Desktop", "Documents", "Downloads"} {

--- a/internal/parser/aider_test.go
+++ b/internal/parser/aider_test.go
@@ -605,6 +605,36 @@ func TestDiscoverAiderSessions(t *testing.T) {
 	assert.Empty(t, DiscoverAiderSessions(""))
 }
 
+func TestDiscoverAiderSessionsSkipsMacOSProtectedDirs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	for _, name := range []string{"Desktop", "Documents", "Downloads"} {
+		protectedRepo := filepath.Join(root, name, "proj")
+		require.NoError(t, os.MkdirAll(protectedRepo, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(protectedRepo, ".aider.chat.history.md"),
+			[]byte("# aider chat started at 2026-06-09 14:01:00\n"), 0o644))
+	}
+
+	files := DiscoverAiderSessions(root)
+	assert.Empty(t, files, "default home discovery must not enter macOS TCC-protected folders")
+}
+
+func TestDiscoverAiderSessionsAllowsExplicitProtectedRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	documentsRoot := filepath.Join(home, "Documents")
+	repo := filepath.Join(documentsRoot, "proj")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, ".aider.chat.history.md"),
+		[]byte("# aider chat started at 2026-06-09 14:01:00\n"), 0o644))
+
+	files := DiscoverAiderSessions(documentsRoot)
+	require.Len(t, files, 1, "explicit Aider roots should still be scanned")
+	assert.Equal(t, filepath.Join(repo, ".aider.chat.history.md"), files[0].Path)
+}
+
 // TestAiderWalkBudget documents the wall-clock budget (MUST-FIX 3,
 // ported from the Rust adapter's WALK_BUDGET_SECS) and confirms a normal
 // discovery walk completes well within it. The budget is checked inside


### PR DESCRIPTION
Aider discovery defaults to walking the user's home directory because Aider does not keep a central session store. In the desktop app that meant a normal launch could enumerate macOS Files and Folders protected locations and prompt for access to personal folders before the user had opted into that scope.

This keeps the default home-root Aider scan out of top-level Desktop, Documents, and Downloads while preserving explicit opt-in behavior: if a user configures AIDER_DIR or aider_dirs inside one of those folders, that scoped root is still indexed. The tradeoff is that unconfigured Aider histories under those protected folders will no longer be discovered implicitly, which is preferable to surprising broad filesystem permission prompts on startup.