### PR TITLE
fix(ui): stop Ctrl+K palette from reselecting input on every keystroke

### DIFF
--- a/frontend/src/lib/components/command-palette/CommandPalette.svelte
+++ b/frontend/src/lib/components/command-palette/CommandPalette.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { SearchIcon } from "../../icons.js";
-  import { tick, onDestroy } from "svelte";
+  import { tick, onDestroy, untrack } from "svelte";
   import { ui } from "../../stores/ui.svelte.js";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { searchStore } from "../../stores/search.svelte.js";
@@ -133,7 +133,7 @@
   $effect(() => {
     if (inputRef) {
       inputRef.focus();
-      if (inputValue) {
+      if (untrack(() => inputValue)) {
         inputRef.select();
       }
     }

--- a/frontend/src/lib/components/command-palette/CommandPalette.test.ts
+++ b/frontend/src/lib/components/command-palette/CommandPalette.test.ts
@@ -258,6 +258,40 @@ describe("CommandPalette", () => {
     unmount(component);
   });
 
+  it("does not reselect typed text after each keystroke (#795)", async () => {
+    const component = mount(CommandPalette, { target: document.body });
+    await tick();
+
+    const input = document.querySelector<HTMLInputElement>(".palette-input")!;
+
+    function typeChar(char: string) {
+      const start = input.selectionStart ?? input.value.length;
+      const end = input.selectionEnd ?? input.value.length;
+      input.value =
+        input.value.slice(0, start) + char + input.value.slice(end);
+      input.setSelectionRange(start + 1, start + 1);
+      input.dispatchEvent(
+        new InputEvent("input", { bubbles: true, inputType: "insertText", data: char }),
+      );
+    }
+
+    typeChar("a");
+    await tick();
+
+    expect(input.value).toBe("a");
+    expect(input.selectionStart).toBe(1);
+    expect(input.selectionEnd).toBe(1);
+
+    typeChar("b");
+    await tick();
+
+    expect(input.value).toBe("ab");
+    expect(input.selectionStart).toBe(2);
+    expect(input.selectionEnd).toBe(2);
+
+    unmount(component);
+  });
+
   it("search result click navigates to the session route", async () => {
     mockSearchStore.results = [
       {


### PR DESCRIPTION
The focus/select `$effect` in `CommandPalette.svelte` reads `inputValue` reactively, so it re-runs on every keystroke and calls `inputRef.select()` each time — selecting all text and causing the next character to overwrite the previous one. Wrapping the `inputValue` read in `untrack()` keeps the select-all behavior on palette open (when `inputRef` first becomes available) while letting subsequent keystrokes accumulate normally.

Frontend-only, one component touched. No backend, store, or style changes.

`svelte-check` passes cleanly (712 files, 0 errors).

Fixes #795