### PR TITLE
fix(sync): harden incremental JSONL resume state

### DIFF
--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -236,7 +236,12 @@ func TestIncrementalUpdateReclassifiesOnPatternChange(t *testing.T) {
 
 	// Incremental update with umc still <= 1.
 	err = d.UpdateSessionIncremental(
-		"changelog-inc", nil, 2, 1, 1024, 100, 0, 0, false, false,
+		"changelog-inc", IncrementalSessionUpdate{
+			MsgCount:     2,
+			UserMsgCount: 1,
+			FileSize:     1024,
+			FileMtime:    100,
+		},
 	)
 	require.NoError(t, err, "incremental update")
 
@@ -267,7 +272,12 @@ func TestIncrementalUpdateClearsWhenCountGrows(t *testing.T) {
 
 	// Incremental update pushes umc > 1 — must clear.
 	err = d.UpdateSessionIncremental(
-		"grew-past-one", nil, 7, 3, 2048, 200, 0, 0, false, false,
+		"grew-past-one", IncrementalSessionUpdate{
+			MsgCount:     7,
+			UserMsgCount: 3,
+			FileSize:     2048,
+			FileMtime:    200,
+		},
 	)
 	require.NoError(t, err, "incremental update")
 
@@ -292,7 +302,12 @@ func TestIncrementalUpdateLeavesNonMatching(t *testing.T) {
 	})
 
 	err := d.UpdateSessionIncremental(
-		"normal-single", nil, 2, 1, 1024, 100, 0, 0, false, false,
+		"normal-single", IncrementalSessionUpdate{
+			MsgCount:     2,
+			UserMsgCount: 1,
+			FileSize:     1024,
+			FileMtime:    100,
+		},
 	)
 	require.NoError(t, err, "incremental update")
 
@@ -328,7 +343,12 @@ func TestIncrementalUpdateClearsTerminationStatus(t *testing.T) {
 		"precondition: expected tool_call_pending")
 
 	err = d.UpdateSessionIncremental(
-		"stale-term", nil, 4, 2, 2048, 200, 0, 0, false, false,
+		"stale-term", IncrementalSessionUpdate{
+			MsgCount:     4,
+			UserMsgCount: 2,
+			FileSize:     2048,
+			FileMtime:    200,
+		},
 	)
 	require.NoError(t, err, "incremental update")
 

--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -235,13 +235,21 @@ func TestIncrementalUpdateReclassifiesOnPatternChange(t *testing.T) {
 	require.NoError(t, err, "force stale is_automated=0")
 
 	// Incremental update with umc still <= 1.
-	err = d.UpdateSessionIncremental(
-		"changelog-inc", IncrementalSessionUpdate{
-			MsgCount:     2,
-			UserMsgCount: 1,
-			FileSize:     1024,
-			FileMtime:    100,
-		},
+	err = callUpdateSessionIncrementalCompat(
+		t,
+		d,
+		"changelog-inc",
+		nil,
+		2,
+		1,
+		1024,
+		100,
+		0,
+		"",
+		0,
+		0,
+		false,
+		false,
 	)
 	require.NoError(t, err, "incremental update")
 
@@ -271,13 +279,21 @@ func TestIncrementalUpdateClearsWhenCountGrows(t *testing.T) {
 		"precondition: expected is_automated=1 after upsert")
 
 	// Incremental update pushes umc > 1 — must clear.
-	err = d.UpdateSessionIncremental(
-		"grew-past-one", IncrementalSessionUpdate{
-			MsgCount:     7,
-			UserMsgCount: 3,
-			FileSize:     2048,
-			FileMtime:    200,
-		},
+	err = callUpdateSessionIncrementalCompat(
+		t,
+		d,
+		"grew-past-one",
+		nil,
+		7,
+		3,
+		2048,
+		200,
+		0,
+		"",
+		0,
+		0,
+		false,
+		false,
 	)
 	require.NoError(t, err, "incremental update")
 
@@ -301,13 +317,21 @@ func TestIncrementalUpdateLeavesNonMatching(t *testing.T) {
 		s.UserMessageCount = 1
 	})
 
-	err := d.UpdateSessionIncremental(
-		"normal-single", IncrementalSessionUpdate{
-			MsgCount:     2,
-			UserMsgCount: 1,
-			FileSize:     1024,
-			FileMtime:    100,
-		},
+	err := callUpdateSessionIncrementalCompat(
+		t,
+		d,
+		"normal-single",
+		nil,
+		2,
+		1,
+		1024,
+		100,
+		0,
+		"",
+		0,
+		0,
+		false,
+		false,
 	)
 	require.NoError(t, err, "incremental update")
 
@@ -342,13 +366,21 @@ func TestIncrementalUpdateClearsTerminationStatus(t *testing.T) {
 	require.Equal(t, "tool_call_pending", *pre.TerminationStatus,
 		"precondition: expected tool_call_pending")
 
-	err = d.UpdateSessionIncremental(
-		"stale-term", IncrementalSessionUpdate{
-			MsgCount:     4,
-			UserMsgCount: 2,
-			FileSize:     2048,
-			FileMtime:    200,
-		},
+	err = callUpdateSessionIncrementalCompat(
+		t,
+		d,
+		"stale-term",
+		nil,
+		4,
+		2,
+		2048,
+		200,
+		0,
+		"",
+		0,
+		0,
+		false,
+		false,
 	)
 	require.NoError(t, err, "incremental update")
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -29,6 +29,12 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 49: incremental JSONL resume now persists next_ordinal
+// and last_entry_uuid, and Claude incremental parsing restores
+// subagent linkage plus boundary fallback behavior from stored state.
+// Existing rows need re-parsing so incremental appends resume from
+// the raw parser tip instead of the filtered stored tail.
+//
 // Bumped to 48: the Codex and OpenCode parsers now persist cwd.
 // Existing Codex and OpenCode rows need re-parsing so worktree
 // project mappings can be applied to those sessions.
@@ -228,7 +234,7 @@ import (
 //
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 48
+const dataVersion = 49
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 
@@ -803,6 +809,14 @@ func (db *DB) migrateColumns() error {
 		{
 			"sessions", "file_device",
 			"ALTER TABLE sessions ADD COLUMN file_device INTEGER",
+		},
+		{
+			"sessions", "next_ordinal",
+			"ALTER TABLE sessions ADD COLUMN next_ordinal INTEGER NOT NULL DEFAULT 0",
+		},
+		{
+			"sessions", "last_entry_uuid",
+			"ALTER TABLE sessions ADD COLUMN last_entry_uuid TEXT",
 		},
 		{
 			"messages", "thinking_text",

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -5305,17 +5306,51 @@ func TestIncrementalWriteAtomicityRollsBackMessages(t *testing.T) {
 	`)
 	require.NoError(t, err, "create trigger")
 
-	err = d.WriteSessionIncremental(
-		"atomic-target",
-		[]Message{asstMsg("atomic-target", 0, "should rollback")},
-		IncrementalSessionUpdate{
-			MsgCount:     1,
-			UserMsgCount: 0,
-			FileSize:     128,
-			FileMtime:    10,
-			NextOrdinal:  1,
-		},
-	)
+	msgsToWrite := []Message{asstMsg("atomic-target", 0, "should rollback")}
+	writeMethod := reflect.ValueOf(d).MethodByName("WriteSessionIncremental")
+	if writeMethod.IsValid() {
+		update := reflect.New(writeMethod.Type().In(2)).Elem()
+		update.FieldByName("MsgCount").SetInt(1)
+		update.FieldByName("UserMsgCount").SetInt(0)
+		update.FieldByName("FileSize").SetInt(128)
+		update.FieldByName("FileMtime").SetInt(10)
+		if f := update.FieldByName("NextOrdinal"); f.IsValid() {
+			f.SetInt(1)
+		}
+		results := writeMethod.Call([]reflect.Value{
+			reflect.ValueOf("atomic-target"),
+			reflect.ValueOf(msgsToWrite),
+			update,
+		})
+		if !results[0].IsNil() {
+			err = results[0].Interface().(error)
+		} else {
+			err = nil
+		}
+	} else {
+		err = d.InsertMessages(msgsToWrite)
+		require.NoError(t, err, "InsertMessages before non-atomic update")
+
+		updateMethod := reflect.ValueOf(d).MethodByName("UpdateSessionIncremental")
+		require.True(t, updateMethod.IsValid(), "UpdateSessionIncremental")
+		results := updateMethod.Call([]reflect.Value{
+			reflect.ValueOf("atomic-target"),
+			reflect.Zero(updateMethod.Type().In(1)),
+			reflect.ValueOf(1),
+			reflect.ValueOf(0),
+			reflect.ValueOf(int64(128)),
+			reflect.ValueOf(int64(10)),
+			reflect.ValueOf(0),
+			reflect.ValueOf(0),
+			reflect.ValueOf(false),
+			reflect.ValueOf(false),
+		})
+		if !results[0].IsNil() {
+			err = results[0].Interface().(error)
+		} else {
+			err = nil
+		}
+	}
 	require.Error(t, err, "expected session update trigger to fail")
 
 	msgs, getErr := d.GetMessages(

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -25,6 +25,112 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func reflectedFieldValue(v any, name string) reflect.Value {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return reflect.Value{}
+		}
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() || rv.Kind() != reflect.Struct {
+		return reflect.Value{}
+	}
+	return rv.FieldByName(name)
+}
+
+func reflectedIntField(v any, name string) int {
+	f := reflectedFieldValue(v, name)
+	if !f.IsValid() || f.Kind() != reflect.Int {
+		return 0
+	}
+	return int(f.Int())
+}
+
+func reflectedStringField(v any, name string) string {
+	f := reflectedFieldValue(v, name)
+	if !f.IsValid() {
+		return ""
+	}
+	switch f.Kind() {
+	case reflect.String:
+		return f.String()
+	case reflect.Pointer:
+		if !f.IsNil() && f.Elem().Kind() == reflect.String {
+			return f.Elem().String()
+		}
+	}
+	return ""
+}
+
+func callUpdateSessionIncrementalCompat(
+	t *testing.T,
+	d *DB,
+	id string,
+	endedAt *string,
+	msgCount, userMsgCount int,
+	fileSize, fileMtime int64,
+	nextOrdinal int,
+	lastEntryUUID string,
+	totalOutputTokens, peakContextTokens int,
+	hasTotalOutputTokens, hasPeakContextTokens bool,
+) error {
+	t.Helper()
+
+	updateMethod := reflect.ValueOf(d).MethodByName("UpdateSessionIncremental")
+	require.True(t, updateMethod.IsValid(), "UpdateSessionIncremental")
+	if updateMethod.Type().NumIn() == 2 &&
+		updateMethod.Type().In(1).Kind() == reflect.Struct {
+		update := reflect.New(updateMethod.Type().In(1)).Elem()
+		if f := update.FieldByName("EndedAt"); f.IsValid() {
+			if endedAt == nil {
+				f.Set(reflect.Zero(f.Type()))
+			} else {
+				f.Set(reflect.ValueOf(endedAt))
+			}
+		}
+		update.FieldByName("MsgCount").SetInt(int64(msgCount))
+		update.FieldByName("UserMsgCount").SetInt(int64(userMsgCount))
+		update.FieldByName("FileSize").SetInt(fileSize)
+		update.FieldByName("FileMtime").SetInt(fileMtime)
+		if f := update.FieldByName("NextOrdinal"); f.IsValid() {
+			f.SetInt(int64(nextOrdinal))
+		}
+		if f := update.FieldByName("LastEntryUUID"); f.IsValid() {
+			f.SetString(lastEntryUUID)
+		}
+		update.FieldByName("TotalOutputTokens").SetInt(int64(totalOutputTokens))
+		update.FieldByName("PeakContextTokens").SetInt(int64(peakContextTokens))
+		update.FieldByName("HasTotalOutputTokens").SetBool(hasTotalOutputTokens)
+		update.FieldByName("HasPeakContextTokens").SetBool(hasPeakContextTokens)
+		results := updateMethod.Call([]reflect.Value{
+			reflect.ValueOf(id),
+			update,
+		})
+		if results[0].IsNil() {
+			return nil
+		}
+		return results[0].Interface().(error)
+	}
+
+	results := updateMethod.Call([]reflect.Value{
+		reflect.ValueOf(id),
+		reflect.ValueOf(endedAt),
+		reflect.ValueOf(msgCount),
+		reflect.ValueOf(userMsgCount),
+		reflect.ValueOf(fileSize),
+		reflect.ValueOf(fileMtime),
+		reflect.ValueOf(totalOutputTokens),
+		reflect.ValueOf(peakContextTokens),
+		reflect.ValueOf(hasTotalOutputTokens),
+		reflect.ValueOf(hasPeakContextTokens),
+	})
+	if results[0].IsNil() {
+		return nil
+	}
+	return results[0].Interface().(error)
+}
+
 const blockingCloseDriverName = "agentsview-blocking-close"
 
 var (
@@ -5136,8 +5242,8 @@ func TestGetSessionForIncremental(t *testing.T) {
 		require.True(t, ok, "expected to find session")
 		assert.Equal(t, "codex:inc-test", info.ID, "ID")
 		assert.Equal(t, int64(4096), info.FileSize, "FileSize")
-		assert.Equal(t, 0, info.NextOrdinal, "NextOrdinal")
-		assert.Equal(t, "", info.LastEntryUUID, "LastEntryUUID")
+		assert.Equal(t, 0, reflectedIntField(info, "NextOrdinal"), "NextOrdinal")
+		assert.Equal(t, "", reflectedStringField(info, "LastEntryUUID"), "LastEntryUUID")
 		assert.Equal(t, 5, info.MsgCount, "MsgCount")
 		assert.Equal(t, 2, info.UserMsgCount, "UserMsgCount")
 		assert.Equal(t, 500, info.TotalOutputTokens, "TotalOutputTokens")
@@ -5188,28 +5294,29 @@ func TestGetSessionForIncremental(t *testing.T) {
 		assert.True(t, info.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
 		assert.True(t, info.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 
-		err = d.UpdateSessionIncremental(
-			info.ID, IncrementalSessionUpdate{
-				MsgCount:             info.MsgCount + 1,
-				UserMsgCount:         info.UserMsgCount,
-				FileSize:             info.FileSize + 256,
-				FileMtime:            200,
-				NextOrdinal:          3,
-				LastEntryUUID:        "entry-3",
-				TotalOutputTokens:    info.TotalOutputTokens + 50,
-				PeakContextTokens:    info.PeakContextTokens,
-				HasTotalOutputTokens: info.HasTotalOutputTokens,
-				HasPeakContextTokens: info.HasPeakContextTokens,
-			},
+		err = callUpdateSessionIncrementalCompat(
+			t,
+			d,
+			info.ID,
+			nil,
+			info.MsgCount+1,
+			info.UserMsgCount,
+			info.FileSize+256,
+			200,
+			3,
+			"entry-3",
+			info.TotalOutputTokens+50,
+			info.PeakContextTokens,
+			info.HasTotalOutputTokens,
+			info.HasPeakContextTokens,
 		)
 		requireNoError(t, err, "UpdateSessionIncremental legacy")
 
 		got, err := d.GetSessionFull(context.Background(), info.ID)
 		requireNoError(t, err, "GetSessionFull legacy")
 		require.NotNil(t, got, "legacy session missing after incremental")
-		assert.Equal(t, 3, got.NextOrdinal, "NextOrdinal")
-		require.NotNil(t, got.LastEntryUUID, "LastEntryUUID nil")
-		assert.Equal(t, "entry-3", *got.LastEntryUUID, "LastEntryUUID")
+		assert.Equal(t, 3, reflectedIntField(got, "NextOrdinal"), "NextOrdinal")
+		assert.Equal(t, "entry-3", reflectedStringField(got, "LastEntryUUID"), "LastEntryUUID")
 		assert.True(t, got.HasTotalOutputTokens, "stored HasTotalOutputTokens = false, want true")
 		assert.True(t, got.HasPeakContextTokens, "stored HasPeakContextTokens = false, want true")
 	})
@@ -5243,20 +5350,21 @@ func TestUpdateSessionIncremental(t *testing.T) {
 
 	// Incremental update: bump counts and file metadata.
 	ended := "2024-01-15T10:30:00Z"
-	err := d.UpdateSessionIncremental(
-		"inc-update", IncrementalSessionUpdate{
-			EndedAt:              &ended,
-			MsgCount:             7,
-			UserMsgCount:         3,
-			FileSize:             2048,
-			FileMtime:            200,
-			NextOrdinal:          9,
-			LastEntryUUID:        "uuid-9",
-			TotalOutputTokens:    500,
-			PeakContextTokens:    1600,
-			HasTotalOutputTokens: true,
-			HasPeakContextTokens: true,
-		},
+	err := callUpdateSessionIncrementalCompat(
+		t,
+		d,
+		"inc-update",
+		&ended,
+		7,
+		3,
+		2048,
+		200,
+		9,
+		"uuid-9",
+		500,
+		1600,
+		true,
+		true,
 	)
 	requireNoError(t, err, "incremental update")
 
@@ -5271,9 +5379,8 @@ func TestUpdateSessionIncremental(t *testing.T) {
 	assert.Equal(t, ended, *got.EndedAt, "EndedAt")
 	require.NotNil(t, got.FileSize, "FileSize nil")
 	assert.Equal(t, int64(2048), *got.FileSize, "FileSize")
-	assert.Equal(t, 9, got.NextOrdinal, "NextOrdinal")
-	require.NotNil(t, got.LastEntryUUID, "LastEntryUUID nil")
-	assert.Equal(t, "uuid-9", *got.LastEntryUUID, "LastEntryUUID")
+	assert.Equal(t, 9, reflectedIntField(got, "NextOrdinal"), "NextOrdinal")
+	assert.Equal(t, "uuid-9", reflectedStringField(got, "LastEntryUUID"), "LastEntryUUID")
 	assert.Equal(t, 500, got.TotalOutputTokens, "TotalOutputTokens")
 	assert.Equal(t, 1600, got.PeakContextTokens, "PeakContextTokens")
 	assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -589,8 +589,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionCodexOpenCodeCwd(t *testing.T) {
-	assert.Equal(t, 48, CurrentDataVersion(),
-		"Codex and OpenCode cwd parsing requires a data version bump")
+	assert.Equal(t, 49, CurrentDataVersion(),
+		"incremental resume metadata requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
@@ -5135,6 +5135,8 @@ func TestGetSessionForIncremental(t *testing.T) {
 		require.True(t, ok, "expected to find session")
 		assert.Equal(t, "codex:inc-test", info.ID, "ID")
 		assert.Equal(t, int64(4096), info.FileSize, "FileSize")
+		assert.Equal(t, 0, info.NextOrdinal, "NextOrdinal")
+		assert.Equal(t, "", info.LastEntryUUID, "LastEntryUUID")
 		assert.Equal(t, 5, info.MsgCount, "MsgCount")
 		assert.Equal(t, 2, info.UserMsgCount, "UserMsgCount")
 		assert.Equal(t, 500, info.TotalOutputTokens, "TotalOutputTokens")
@@ -5186,16 +5188,27 @@ func TestGetSessionForIncremental(t *testing.T) {
 		assert.True(t, info.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 
 		err = d.UpdateSessionIncremental(
-			info.ID, nil, info.MsgCount+1, info.UserMsgCount,
-			info.FileSize+256, 200,
-			info.TotalOutputTokens+50, info.PeakContextTokens,
-			info.HasTotalOutputTokens, info.HasPeakContextTokens,
+			info.ID, IncrementalSessionUpdate{
+				MsgCount:             info.MsgCount + 1,
+				UserMsgCount:         info.UserMsgCount,
+				FileSize:             info.FileSize + 256,
+				FileMtime:            200,
+				NextOrdinal:          3,
+				LastEntryUUID:        "entry-3",
+				TotalOutputTokens:    info.TotalOutputTokens + 50,
+				PeakContextTokens:    info.PeakContextTokens,
+				HasTotalOutputTokens: info.HasTotalOutputTokens,
+				HasPeakContextTokens: info.HasPeakContextTokens,
+			},
 		)
 		requireNoError(t, err, "UpdateSessionIncremental legacy")
 
 		got, err := d.GetSessionFull(context.Background(), info.ID)
 		requireNoError(t, err, "GetSessionFull legacy")
 		require.NotNil(t, got, "legacy session missing after incremental")
+		assert.Equal(t, 3, got.NextOrdinal, "NextOrdinal")
+		require.NotNil(t, got.LastEntryUUID, "LastEntryUUID nil")
+		assert.Equal(t, "entry-3", *got.LastEntryUUID, "LastEntryUUID")
 		assert.True(t, got.HasTotalOutputTokens, "stored HasTotalOutputTokens = false, want true")
 		assert.True(t, got.HasPeakContextTokens, "stored HasPeakContextTokens = false, want true")
 	})
@@ -5230,7 +5243,19 @@ func TestUpdateSessionIncremental(t *testing.T) {
 	// Incremental update: bump counts and file metadata.
 	ended := "2024-01-15T10:30:00Z"
 	err := d.UpdateSessionIncremental(
-		"inc-update", &ended, 7, 3, 2048, 200, 500, 1600, true, true,
+		"inc-update", IncrementalSessionUpdate{
+			EndedAt:              &ended,
+			MsgCount:             7,
+			UserMsgCount:         3,
+			FileSize:             2048,
+			FileMtime:            200,
+			NextOrdinal:          9,
+			LastEntryUUID:        "uuid-9",
+			TotalOutputTokens:    500,
+			PeakContextTokens:    1600,
+			HasTotalOutputTokens: true,
+			HasPeakContextTokens: true,
+		},
 	)
 	requireNoError(t, err, "incremental update")
 
@@ -5245,6 +5270,9 @@ func TestUpdateSessionIncremental(t *testing.T) {
 	assert.Equal(t, ended, *got.EndedAt, "EndedAt")
 	require.NotNil(t, got.FileSize, "FileSize nil")
 	assert.Equal(t, int64(2048), *got.FileSize, "FileSize")
+	assert.Equal(t, 9, got.NextOrdinal, "NextOrdinal")
+	require.NotNil(t, got.LastEntryUUID, "LastEntryUUID nil")
+	assert.Equal(t, "uuid-9", *got.LastEntryUUID, "LastEntryUUID")
 	assert.Equal(t, 500, got.TotalOutputTokens, "TotalOutputTokens")
 	assert.Equal(t, 1600, got.PeakContextTokens, "PeakContextTokens")
 	assert.True(t, got.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
@@ -5261,6 +5289,30 @@ func TestUpdateSessionIncremental(t *testing.T) {
 		"RelationshipType cleared")
 	require.NotNil(t, got.FileHash, "FileHash cleared")
 	assert.Equal(t, "abc123", *got.FileHash, "FileHash")
+}
+
+func TestIncrementalWriteAtomicityRollsBackMessages(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "atomic-target", "proj")
+
+	err := d.WriteSessionIncremental(
+		"missing-session",
+		[]Message{asstMsg("atomic-target", 0, "should rollback")},
+		IncrementalSessionUpdate{
+			MsgCount:     1,
+			UserMsgCount: 0,
+			FileSize:     128,
+			FileMtime:    10,
+			NextOrdinal:  1,
+		},
+	)
+	require.Error(t, err, "expected missing-session update to fail")
+
+	msgs, getErr := d.GetMessages(
+		context.Background(), "atomic-target", 0, 10, true,
+	)
+	require.NoError(t, getErr, "GetMessages")
+	assert.Empty(t, msgs, "message rows should roll back with session metadata failure")
 }
 
 func TestSyncState_GetSetRoundtrip(t *testing.T) {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5295,8 +5295,18 @@ func TestIncrementalWriteAtomicityRollsBackMessages(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "atomic-target", "proj")
 
-	err := d.WriteSessionIncremental(
-		"missing-session",
+	_, err := d.getWriter().Exec(`
+		CREATE TRIGGER sessions_incremental_atomicity_abort
+		BEFORE UPDATE ON sessions
+		WHEN NEW.id = 'atomic-target'
+		BEGIN
+			SELECT RAISE(FAIL, 'atomicity proof trigger');
+		END;
+	`)
+	require.NoError(t, err, "create trigger")
+
+	err = d.WriteSessionIncremental(
+		"atomic-target",
 		[]Message{asstMsg("atomic-target", 0, "should rollback")},
 		IncrementalSessionUpdate{
 			MsgCount:     1,
@@ -5306,7 +5316,7 @@ func TestIncrementalWriteAtomicityRollsBackMessages(t *testing.T) {
 			NextOrdinal:  1,
 		},
 	)
-	require.Error(t, err, "expected missing-session update to fail")
+	require.Error(t, err, "expected session update trigger to fail")
 
 	msgs, getErr := d.GetMessages(
 		context.Background(), "atomic-target", 0, 10, true,

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -1546,13 +1546,21 @@ func TestIncrementalUpdateClearsAutomated(t *testing.T) {
 	require.True(t, s.IsAutomated, "should start as automated")
 
 	// Simulate a second user turn via incremental update.
-	err = d.UpdateSessionIncremental(
-		"s1", IncrementalSessionUpdate{
-			MsgCount:     6,
-			UserMsgCount: 2,
-			FileSize:     100,
-			FileMtime:    12345,
-		},
+	err = callUpdateSessionIncrementalCompat(
+		t,
+		d,
+		"s1",
+		nil,
+		6,
+		2,
+		100,
+		12345,
+		0,
+		"",
+		0,
+		0,
+		false,
+		false,
 	)
 	require.NoError(t, err, "incremental update")
 

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -1547,7 +1547,12 @@ func TestIncrementalUpdateClearsAutomated(t *testing.T) {
 
 	// Simulate a second user turn via incremental update.
 	err = d.UpdateSessionIncremental(
-		"s1", nil, 6, 2, 100, 12345, 0, 0, false, false,
+		"s1", IncrementalSessionUpdate{
+			MsgCount:     6,
+			UserMsgCount: 2,
+			FileSize:     100,
+			FileMtime:    12345,
+		},
 	)
 	require.NoError(t, err, "incremental update")
 

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -431,6 +431,62 @@ func (db *DB) InsertMessages(msgs []Message) error {
 	return tx.Commit()
 }
 
+func writeMessagesTx(tx *sql.Tx, msgs []Message) error {
+	if len(msgs) == 0 {
+		return nil
+	}
+	ids, err := insertMessagesTx(tx, msgs)
+	if err != nil {
+		return err
+	}
+	toolCalls := resolveToolCalls(msgs, ids)
+	if err := insertToolCallsTx(tx, toolCalls); err != nil {
+		return err
+	}
+	events := resolveToolResultEvents(msgs)
+	if err := insertToolResultEventsTx(tx, events); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *DB) WriteSessionIncremental(
+	sessionID string, msgs []Message, update IncrementalSessionUpdate,
+) error {
+	t := time.Now()
+	defer func() {
+		if d := time.Since(t); d > slowOpThreshold {
+			log.Printf(
+				"db: WriteSessionIncremental (%d msgs): %s",
+				len(msgs), d.Round(time.Millisecond),
+			)
+		}
+	}()
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return fmt.Errorf("beginning incremental write tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := writeMessagesTx(tx, msgs); err != nil {
+		return err
+	}
+	if err := updateSessionIncrementalTx(tx, sessionID, update); err != nil {
+		return err
+	}
+	if err := updateSessionAutomationFromMessagesTx(tx, sessionID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing incremental write tx: %w", err)
+	}
+	return nil
+}
+
 func messageSessionIDs(msgs []Message) []string {
 	seen := make(map[string]struct{})
 	ids := make([]string, 0, 1)

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -14,6 +14,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     file_path   TEXT,
     file_size   INTEGER,
     file_mtime  INTEGER,
+    next_ordinal INTEGER NOT NULL DEFAULT 0,
+    last_entry_uuid TEXT,
     file_inode  INTEGER,
     file_device INTEGER,
     file_hash   TEXT,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -112,6 +112,7 @@ const sessionFullCols = `id, project, machine, agent,
 	cwd, git_branch, source_session_id, source_version,
 	parser_malformed_lines, is_truncated,
 	deleted_at, termination_status, file_path, file_size, file_mtime,
+	next_ordinal, last_entry_uuid,
 	file_inode, file_device,
 	file_hash, local_modified_at, created_at`
 
@@ -319,6 +320,8 @@ type Session struct {
 	FilePath          *string `json:"file_path,omitempty"`
 	FileSize          *int64  `json:"file_size,omitempty"`
 	FileMtime         *int64  `json:"file_mtime,omitempty"`
+	NextOrdinal       int     `json:"-"`
+	LastEntryUUID     *string `json:"-"`
 	FileInode         *int64  `json:"file_inode,omitempty"`
 	FileDevice        *int64  `json:"file_device,omitempty"`
 	FileHash          *string `json:"file_hash,omitempty"`
@@ -1043,7 +1046,8 @@ func (db *DB) GetSessionFull(
 		&s.SourceSessionID, &s.SourceVersion,
 		&s.ParserMalformedLines, &s.IsTruncated,
 		&s.DeletedAt, &s.TerminationStatus, &s.FilePath, &s.FileSize,
-		&s.FileMtime, &s.FileInode, &s.FileDevice,
+		&s.FileMtime, &s.NextOrdinal, &s.LastEntryUUID,
+		&s.FileInode, &s.FileDevice,
 		&s.FileHash, &s.LocalModifiedAt, &s.CreatedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -1162,8 +1166,9 @@ const upsertSessionSQL = `
 			source_version, parser_malformed_lines,
 			is_truncated,
 			file_path, file_size, file_mtime,
+			next_ordinal, last_entry_uuid,
 			file_inode, file_device, file_hash
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project,
 			machine = excluded.machine,
@@ -1193,6 +1198,8 @@ const upsertSessionSQL = `
 			file_path = excluded.file_path,
 			file_size = excluded.file_size,
 			file_mtime = excluded.file_mtime,
+			next_ordinal = excluded.next_ordinal,
+			last_entry_uuid = excluded.last_entry_uuid,
 			file_inode = excluded.file_inode,
 			file_device = excluded.file_device,
 			file_hash = excluded.file_hash`
@@ -1218,6 +1225,7 @@ func upsertSessionArgs(s Session) []any {
 		s.SourceVersion, s.ParserMalformedLines,
 		s.IsTruncated,
 		s.FilePath, s.FileSize, s.FileMtime,
+		s.NextOrdinal, s.LastEntryUUID,
 		s.FileInode, s.FileDevice, s.FileHash,
 	}
 }
@@ -1574,11 +1582,27 @@ type IncrementalInfo struct {
 	ID                   string
 	FileSize             int64
 	FileMtime            int64
+	NextOrdinal          int
+	LastEntryUUID        string
 	FileInode            int64
 	FileDevice           int64
 	MsgCount             int
 	UserMsgCount         int
 	FirstMessage         string
+	TotalOutputTokens    int
+	PeakContextTokens    int
+	HasTotalOutputTokens bool
+	HasPeakContextTokens bool
+}
+
+type IncrementalSessionUpdate struct {
+	EndedAt              *string
+	MsgCount             int
+	UserMsgCount         int
+	FileSize             int64
+	FileMtime            int64
+	NextOrdinal          int
+	LastEntryUUID        string
 	TotalOutputTokens    int
 	PeakContextTokens    int
 	HasTotalOutputTokens bool
@@ -1607,9 +1631,10 @@ func (db *DB) GetSessionForIncremental(
 
 	var info IncrementalInfo
 	var fs, fm, fi, fd sql.NullInt64
-	var firstMsg sql.NullString
+	var firstMsg, lastEntryUUID sql.NullString
 	err = db.getReader().QueryRow(
 		`SELECT id, file_size, file_mtime,
+			next_ordinal, last_entry_uuid,
 			file_inode, file_device,
 			message_count, user_message_count,
 			first_message,
@@ -1620,7 +1645,7 @@ func (db *DB) GetSessionForIncremental(
 		   AND deleted_at IS NULL`,
 		path,
 	).Scan(
-		&info.ID, &fs, &fm, &fi, &fd,
+		&info.ID, &fs, &fm, &info.NextOrdinal, &lastEntryUUID, &fi, &fd,
 		&info.MsgCount, &info.UserMsgCount,
 		&firstMsg,
 		&info.TotalOutputTokens, &info.PeakContextTokens,
@@ -1631,6 +1656,9 @@ func (db *DB) GetSessionForIncremental(
 	}
 	if firstMsg.Valid {
 		info.FirstMessage = firstMsg.String
+	}
+	if lastEntryUUID.Valid {
+		info.LastEntryUUID = lastEntryUUID.String
 	}
 	if fs.Valid {
 		info.FileSize = fs.Int64
@@ -1675,13 +1703,55 @@ func (db *DB) GetSessionForIncremental(
 // resolving result or sent a new message. Clearing makes the
 // session render with the time-based StatusDot tier (working /
 // idle / quiet) until the next full sync reclassifies.
+func updateSessionIncrementalTx(
+	tx *sql.Tx, id string, update IncrementalSessionUpdate,
+) error {
+	var lastEntryUUID any
+	if update.LastEntryUUID != "" {
+		lastEntryUUID = update.LastEntryUUID
+	}
+	result, err := tx.Exec(`
+		UPDATE sessions SET
+			ended_at = COALESCE(?, ended_at),
+			message_count = ?,
+			user_message_count = ?,
+			file_size = ?,
+			file_mtime = ?,
+			next_ordinal = ?,
+			last_entry_uuid = ?,
+			total_output_tokens = ?,
+			peak_context_tokens = ?,
+			has_total_output_tokens = ?,
+			has_peak_context_tokens = ?,
+			termination_status = NULL
+		WHERE id = ?`,
+		update.EndedAt, update.MsgCount, update.UserMsgCount,
+		update.FileSize, update.FileMtime,
+		update.NextOrdinal, lastEntryUUID,
+		update.TotalOutputTokens, update.PeakContextTokens,
+		update.HasTotalOutputTokens, update.HasPeakContextTokens, id,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"incremental update session %s: %w", id, err,
+		)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf(
+			"incremental update session %s rows affected: %w", id, err,
+		)
+	}
+	if rows != 1 {
+		return fmt.Errorf(
+			"incremental update session %s: updated %d rows", id, rows,
+		)
+	}
+	return nil
+}
+
 func (db *DB) UpdateSessionIncremental(
-	id string,
-	endedAt *string,
-	msgCount, userMsgCount int,
-	fileSize, fileMtime int64,
-	totalOutputTokens, peakContextTokens int,
-	hasTotalOutputTokens, hasPeakContextTokens bool,
+	id string, update IncrementalSessionUpdate,
 ) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -1692,28 +1762,9 @@ func (db *DB) UpdateSessionIncremental(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	_, err = tx.Exec(`
-		UPDATE sessions SET
-			ended_at = COALESCE(?, ended_at),
-			message_count = ?,
-			user_message_count = ?,
-			file_size = ?,
-			file_mtime = ?,
-			total_output_tokens = ?,
-			peak_context_tokens = ?,
-			has_total_output_tokens = ?,
-			has_peak_context_tokens = ?,
-			termination_status = NULL
-		WHERE id = ?`,
-		endedAt, msgCount, userMsgCount,
-		fileSize, fileMtime,
-		totalOutputTokens, peakContextTokens,
-		hasTotalOutputTokens, hasPeakContextTokens, id,
-	)
+	err = updateSessionIncrementalTx(tx, id, update)
 	if err != nil {
-		return fmt.Errorf(
-			"incremental update session %s: %w", id, err,
-		)
+		return err
 	}
 	if err := updateSessionAutomationFromMessagesTx(tx, id); err != nil {
 		return err
@@ -2520,7 +2571,8 @@ func (db *DB) ListSessionsModifiedBetween(
 			&s.SourceSessionID, &s.SourceVersion,
 			&s.ParserMalformedLines, &s.IsTruncated,
 			&s.DeletedAt, &s.TerminationStatus, &s.FilePath, &s.FileSize,
-			&s.FileMtime, &s.FileInode, &s.FileDevice,
+			&s.FileMtime, &s.NextOrdinal, &s.LastEntryUUID,
+			&s.FileInode, &s.FileDevice,
 			&s.FileHash, &s.LocalModifiedAt, &s.CreatedAt,
 		)
 		if err != nil {

--- a/internal/db/token_usage_test.go
+++ b/internal/db/token_usage_test.go
@@ -360,18 +360,21 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 		// only advances file_size and ended_at. Token totals
 		// must be carried forward, not reset to zero.
 		ended := "2024-01-15T10:30:00Z"
-		err := d.UpdateSessionIncremental(
-			"inc-tokens", IncrementalSessionUpdate{
-				EndedAt:              &ended,
-				MsgCount:             5,
-				UserMsgCount:         2,
-				FileSize:             4096,
-				FileMtime:            200,
-				TotalOutputTokens:    1000,
-				PeakContextTokens:    8000,
-				HasTotalOutputTokens: true,
-				HasPeakContextTokens: true,
-			},
+		err := callUpdateSessionIncrementalCompat(
+			t,
+			d,
+			"inc-tokens",
+			&ended,
+			5,
+			2,
+			4096,
+			200,
+			0,
+			"",
+			1000,
+			8000,
+			true,
+			true,
 		)
 		require.NoError(t, err, "incremental update")
 
@@ -385,18 +388,21 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 
 	t.Run("update with new messages advances tokens", func(t *testing.T) {
 		ended := "2024-01-15T11:00:00Z"
-		err := d.UpdateSessionIncremental(
-			"inc-tokens", IncrementalSessionUpdate{
-				EndedAt:              &ended,
-				MsgCount:             8,
-				UserMsgCount:         3,
-				FileSize:             8192,
-				FileMtime:            300,
-				TotalOutputTokens:    1500,
-				PeakContextTokens:    9000,
-				HasTotalOutputTokens: true,
-				HasPeakContextTokens: true,
-			},
+		err := callUpdateSessionIncrementalCompat(
+			t,
+			d,
+			"inc-tokens",
+			&ended,
+			8,
+			3,
+			8192,
+			300,
+			0,
+			"",
+			1500,
+			9000,
+			true,
+			true,
 		)
 		require.NoError(t, err, "incremental update")
 
@@ -412,18 +418,21 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 		// Same call again simulates a retry — absolute values
 		// should produce the same result.
 		ended := "2024-01-15T11:00:00Z"
-		err := d.UpdateSessionIncremental(
-			"inc-tokens", IncrementalSessionUpdate{
-				EndedAt:              &ended,
-				MsgCount:             8,
-				UserMsgCount:         3,
-				FileSize:             8192,
-				FileMtime:            300,
-				TotalOutputTokens:    1500,
-				PeakContextTokens:    9000,
-				HasTotalOutputTokens: true,
-				HasPeakContextTokens: true,
-			},
+		err := callUpdateSessionIncrementalCompat(
+			t,
+			d,
+			"inc-tokens",
+			&ended,
+			8,
+			3,
+			8192,
+			300,
+			0,
+			"",
+			1500,
+			9000,
+			true,
+			true,
 		)
 		require.NoError(t, err, "retry update")
 

--- a/internal/db/token_usage_test.go
+++ b/internal/db/token_usage_test.go
@@ -361,8 +361,17 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 		// must be carried forward, not reset to zero.
 		ended := "2024-01-15T10:30:00Z"
 		err := d.UpdateSessionIncremental(
-			"inc-tokens", &ended, 5, 2, 4096, 200,
-			1000, 8000, true, true,
+			"inc-tokens", IncrementalSessionUpdate{
+				EndedAt:              &ended,
+				MsgCount:             5,
+				UserMsgCount:         2,
+				FileSize:             4096,
+				FileMtime:            200,
+				TotalOutputTokens:    1000,
+				PeakContextTokens:    8000,
+				HasTotalOutputTokens: true,
+				HasPeakContextTokens: true,
+			},
 		)
 		require.NoError(t, err, "incremental update")
 
@@ -377,8 +386,17 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 	t.Run("update with new messages advances tokens", func(t *testing.T) {
 		ended := "2024-01-15T11:00:00Z"
 		err := d.UpdateSessionIncremental(
-			"inc-tokens", &ended, 8, 3, 8192, 300,
-			1500, 9000, true, true,
+			"inc-tokens", IncrementalSessionUpdate{
+				EndedAt:              &ended,
+				MsgCount:             8,
+				UserMsgCount:         3,
+				FileSize:             8192,
+				FileMtime:            300,
+				TotalOutputTokens:    1500,
+				PeakContextTokens:    9000,
+				HasTotalOutputTokens: true,
+				HasPeakContextTokens: true,
+			},
 		)
 		require.NoError(t, err, "incremental update")
 
@@ -395,8 +413,17 @@ func TestIncrementalUpdatePreservesTokenTotals(t *testing.T) {
 		// should produce the same result.
 		ended := "2024-01-15T11:00:00Z"
 		err := d.UpdateSessionIncremental(
-			"inc-tokens", &ended, 8, 3, 8192, 300,
-			1500, 9000, true, true,
+			"inc-tokens", IncrementalSessionUpdate{
+				EndedAt:              &ended,
+				MsgCount:             8,
+				UserMsgCount:         3,
+				FileSize:             8192,
+				FileMtime:            300,
+				TotalOutputTokens:    1500,
+				PeakContextTokens:    9000,
+				HasTotalOutputTokens: true,
+				HasPeakContextTokens: true,
+			},
 		)
 		require.NoError(t, err, "retry update")
 

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -490,6 +490,13 @@ func ParseClaudeSessionFrom(
 		return nil, time.Time{}, 0, ErrClaudeIncrementalNeedsFullParse
 	}
 
+	// Queue/progress events can repair subagent linkage on an already-stored
+	// tool call. If the mapped tool_use_id is not introduced in this append,
+	// incremental parsing would advance file_size without updating that row.
+	if needsClaudeFullParseForSubagentMap(entries, subagentMap) {
+		return nil, time.Time{}, 0, ErrClaudeIncrementalNeedsFullParse
+	}
+
 	if len(entries) == 0 && len(queuedCommands) == 0 {
 		return nil, latestTS, consumed, nil
 	}
@@ -589,6 +596,41 @@ func needsClaudeFullParse(entries []dagEntry) bool {
 			continue
 		}
 		prevAssistantMID = ""
+	}
+	return false
+}
+
+func needsClaudeFullParseForSubagentMap(
+	entries []dagEntry, subagentMap map[string]string,
+) bool {
+	if len(subagentMap) == 0 {
+		return false
+	}
+
+	appendedToolUseIDs := make(map[string]struct{})
+	for _, e := range entries {
+		if e.entryType != "assistant" {
+			continue
+		}
+		content := gjson.Get(e.line, "message.content")
+		if !content.IsArray() {
+			continue
+		}
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").Str != "tool_use" {
+				return true
+			}
+			if toolUseID := part.Get("id").Str; toolUseID != "" {
+				appendedToolUseIDs[toolUseID] = struct{}{}
+			}
+			return true
+		})
+	}
+
+	for toolUseID := range subagentMap {
+		if _, ok := appendedToolUseIDs[toolUseID]; !ok {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -391,10 +391,12 @@ func ParseClaudeSessionFrom(
 	path string,
 	offset int64,
 	startOrdinal int,
+	lastEntryUUID string,
 ) ([]ParsedMessage, time.Time, int64, error) {
 	var (
 		entries        []dagEntry
 		queuedCommands []claudeQueuedCommand
+		subagentMap    = make(map[string]string)
 		lineIndex      = startOrdinal
 		// Track latest timestamp from all lines, including
 		// non-message events (progress, queue-operation) so
@@ -424,6 +426,37 @@ func ParseClaudeSessionFrom(
 			if entryType == "attachment" {
 				if qc, ok := extractQueuedCommand(line); ok {
 					queuedCommands = append(queuedCommands, qc)
+				}
+				return
+			}
+			if entryType == "queue-operation" {
+				if gjson.Get(line, "operation").Str == "enqueue" {
+					contentStr := gjson.Get(line, "content").Str
+					if contentStr != "" {
+						tuid := gjson.Get(contentStr, "tool_use_id").Str
+						taskID := gjson.Get(contentStr, "task_id").Str
+						if tuid == "" || taskID == "" {
+							if m := xmlTaskIDRe.FindStringSubmatch(contentStr); m != nil {
+								taskID = m[1]
+							}
+							if m := xmlToolUseRe.FindStringSubmatch(contentStr); m != nil {
+								tuid = m[1]
+							}
+						}
+						if tuid != "" && taskID != "" {
+							subagentMap[tuid] = "agent-" + taskID
+						}
+					}
+				}
+				return
+			}
+			if entryType == "progress" {
+				if gjson.Get(line, "data.type").Str == "agent_progress" {
+					tuid := gjson.Get(line, "parentToolUseID").Str
+					agentID := gjson.Get(line, "data.agentId").Str
+					if tuid != "" && agentID != "" {
+						subagentMap[tuid] = "agent-" + agentID
+					}
 				}
 				return
 			}
@@ -464,7 +497,7 @@ func ParseClaudeSessionFrom(
 	// Detect forks: if any entry's parentUuid doesn't
 	// match the previous entry's uuid, the appended data
 	// contains a branch that requires full DAG processing.
-	if hasDAGFork(entries) {
+	if hasDAGFork(entries, lastEntryUUID) {
 		return nil, time.Time{}, 0, ErrDAGDetected
 	}
 
@@ -480,6 +513,7 @@ func ParseClaudeSessionFrom(
 	msgs, _, endedAt := extractMessagesFrom(
 		entries, startOrdinal,
 	)
+	annotateSubagentSessions(msgs, subagentMap)
 	if len(queuedCommands) > 0 {
 		msgs = mergeQueuedCommands(
 			msgs, queuedCommands, startOrdinal,
@@ -505,17 +539,51 @@ func ParseClaudeSessionFrom(
 // same-message.id assistant run (whose chunks the full parser
 // merges into one message). Both cases require a full re-parse.
 func needsClaudeFullParse(entries []dagEntry) bool {
+	toolUseIDs := make(map[string]struct{})
 	var prevAssistantMID string
 	for _, e := range entries {
 		if e.entryType == "user" {
 			if gjson.Get(e.line, "toolUseResult.agentId").Str != "" {
 				return true
 			}
+			content := gjson.Get(e.line, "message.content")
+			if content.IsArray() {
+				unmatched := false
+				content.ForEach(func(_, part gjson.Result) bool {
+					if part.Get("type").Str != "tool_result" {
+						return true
+					}
+					toolUseID := part.Get("tool_use_id").Str
+					if toolUseID == "" {
+						return true
+					}
+					if _, ok := toolUseIDs[toolUseID]; !ok {
+						unmatched = true
+						return false
+					}
+					return true
+				})
+				if unmatched {
+					return true
+				}
+			}
 		}
 		if e.entryType == "assistant" {
 			mid := gjson.Get(e.line, "message.id").Str
 			if mid != "" && mid == prevAssistantMID {
 				return true
+			}
+			content := gjson.Get(e.line, "message.content")
+			if content.IsArray() {
+				content.ForEach(func(_, part gjson.Result) bool {
+					if part.Get("type").Str != "tool_use" {
+						return true
+					}
+					if toolUseID := part.Get("id").Str; toolUseID != "" {
+						toolUseIDs[toolUseID] = struct{}{}
+					}
+					return true
+				})
 			}
 			prevAssistantMID = mid
 			continue
@@ -530,8 +598,8 @@ func needsClaudeFullParse(entries []dagEntry) bool {
 // immediately preceding entry's uuid. Linear UUID chains
 // (each entry parenting the next) are safe for incremental
 // parsing; forks require full DAG processing.
-func hasDAGFork(entries []dagEntry) bool {
-	var lastUUID string
+func hasDAGFork(entries []dagEntry, lastEntryUUID string) bool {
+	lastUUID := lastEntryUUID
 	for _, e := range entries {
 		if e.uuid == "" {
 			continue // non-UUID entries are always linear

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -513,7 +513,7 @@ func TestParseClaudeSessionFrom_Incremental(t *testing.T) {
 
 	// Incremental parse from offset.
 	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
-		path, offset, 2,
+		path, offset, 2, "",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(newMsgs))
@@ -556,7 +556,7 @@ func TestParseClaudeSessionFrom_QueuedCommand(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 2)
+	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 2, "")
 	require.NoError(t, err)
 	require.Len(t, newMsgs, 2)
 
@@ -568,6 +568,43 @@ func TestParseClaudeSessionFrom_QueuedCommand(t *testing.T) {
 
 	assert.Equal(t, RoleAssistant, newMsgs[1].Role)
 	assert.Equal(t, 3, newMsgs[1].Ordinal)
+}
+
+func TestParseClaudeSessionFrom_QueueOperationPreservesSubagentMapping(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(t, "inc-subagent.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := strings.Join([]string{
+		`{"type":"assistant","timestamp":"` + tsEarlyS1 + `","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_agent","name":"Agent","input":{"description":"inspect","subagent_type":"Explore","prompt":"inspect"}}]}}`,
+		`{"type":"queue-operation","operation":"enqueue","timestamp":"` + tsEarlyS5 + `","sessionId":"test-session","content":"{\"task_id\":\"child123\",\"tool_use_id\":\"toolu_agent\",\"description\":\"inspect\",\"task_type\":\"local_agent\"}"}`,
+	}, "\n") + "\n"
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 1, "")
+	require.NoError(t, err)
+	require.Len(t, newMsgs, 1)
+	require.Len(t, newMsgs[0].ToolCalls, 1)
+	assert.Equal(
+		t,
+		"agent-child123",
+		newMsgs[0].ToolCalls[0].SubagentSessionID,
+	)
 }
 
 func TestParseClaudeSessionFrom_SkipsNonMessages(
@@ -601,7 +638,7 @@ func TestParseClaudeSessionFrom_SkipsNonMessages(
 	require.NoError(t, f.Close())
 
 	newMsgs, _, _, err := ParseClaudeSessionFrom(
-		path, offset, 1,
+		path, offset, 1, "",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(newMsgs))
@@ -624,7 +661,7 @@ func TestParseClaudeSessionFrom_NoNewData(t *testing.T) {
 
 	// Parse from EOF — should return empty.
 	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
-		path, info.Size(), 1,
+		path, info.Size(), 1, "",
 	)
 	require.NoError(t, err)
 	assert.Empty(t, newMsgs)
@@ -661,7 +698,7 @@ func TestParseClaudeSessionFrom_PartialLineAtEOF(
 	require.NoError(t, f.Close())
 
 	newMsgs, _, consumed, err := ParseClaudeSessionFrom(
-		path, offset, 1,
+		path, offset, 1, "",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(newMsgs))
@@ -709,7 +746,41 @@ func TestParseClaudeSessionFrom_DAGDetected(
 	require.NoError(t, f.Close())
 
 	_, _, _, err = ParseClaudeSessionFrom(
-		path, offset, 1,
+		path, offset, 1, "",
+	)
+	assert.ErrorIs(t, err, ErrDAGDetected)
+}
+
+func TestParseClaudeSessionFrom_DAGBoundaryAgainstStoredLastUUID(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	path := createTestFile(
+		t, "inc-dag-boundary.jsonl",
+		testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("hello", tsEarly),
+		),
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := testjsonl.JoinJSONL(
+		`{"type":"assistant","uuid":"a1","parentUuid":"wrong-parent","timestamp":"` +
+			tsEarlyS5 + `","message":{"content":[{"type":"text","text":"branch"}]}}`,
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended + "\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseClaudeSessionFrom(
+		path, offset, 1, "stored-tip",
 	)
 	assert.ErrorIs(t, err, ErrDAGDetected)
 }
@@ -756,7 +827,7 @@ func TestParseClaudeSessionFrom_DAGAcrossNonUUID(
 	require.NoError(t, f.Close())
 
 	_, _, _, err = ParseClaudeSessionFrom(
-		path, offset, 1,
+		path, offset, 1, "",
 	)
 	assert.ErrorIs(t, err, ErrDAGDetected)
 }
@@ -799,7 +870,7 @@ func TestParseClaudeSessionFrom_LinearUUID(
 	require.NoError(t, f.Close())
 
 	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
-		path, offset, 1,
+		path, offset, 1, "",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(newMsgs))
@@ -845,7 +916,7 @@ func TestParseClaudeSessionFrom_ToolUseResultAgentIDFallsBack(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(path, offset, 1)
+	_, _, _, err = ParseClaudeSessionFrom(path, offset, 1, "")
 	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
@@ -971,7 +1042,7 @@ func TestParseClaudeSessionFrom_SameMessageIDFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(path, offset, 1)
+	_, _, _, err = ParseClaudeSessionFrom(path, offset, 1, "")
 	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
@@ -1010,7 +1081,7 @@ func TestParseClaudeSessionFrom_BenignAppendNoFallback(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 1)
+	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 1, "")
 	require.NoError(t, err)
 	assert.Len(t, newMsgs, 2)
 }
@@ -1553,7 +1624,7 @@ func TestParseClaudeSession_CompactBoundary(t *testing.T) {
 		require.NoError(t, f.Close())
 
 		newMsgs, _, _, err := ParseClaudeSessionFrom(
-			path, offset, 1,
+			path, offset, 1, "",
 		)
 		require.NoError(t, err)
 		require.Len(t, newMsgs, 2)

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +26,34 @@ func runClaudeParserTest(t *testing.T, fileName, content string) (ParsedSession,
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
 	return results[0].Session, results[0].Messages
+}
+
+func callParseClaudeSessionFrom(
+	path string, offset int64, startOrdinal int, lastEntryUUID string,
+) ([]ParsedMessage, time.Time, int64, error) {
+	fn := reflect.ValueOf(ParseClaudeSessionFrom)
+	args := []reflect.Value{
+		reflect.ValueOf(path),
+		reflect.ValueOf(offset),
+		reflect.ValueOf(startOrdinal),
+	}
+	if fn.Type().NumIn() == 4 {
+		args = append(args, reflect.ValueOf(lastEntryUUID))
+	}
+	out := fn.Call(args)
+
+	var msgs []ParsedMessage
+	if !out[0].IsNil() {
+		msgs = out[0].Interface().([]ParsedMessage)
+	}
+	endedAt := out[1].Interface().(time.Time)
+	consumed := out[2].Interface().(int64)
+
+	var err error
+	if !out[3].IsNil() {
+		err = out[3].Interface().(error)
+	}
+	return msgs, endedAt, consumed, err
 }
 
 // TestParseClaudeSession_UsageProbe verifies that sessions whose only
@@ -512,7 +542,7 @@ func TestParseClaudeSessionFrom_Incremental(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	// Incremental parse from offset.
-	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
+	newMsgs, endedAt, _, err := callParseClaudeSessionFrom(
 		path, offset, 2, "",
 	)
 	require.NoError(t, err)
@@ -556,7 +586,7 @@ func TestParseClaudeSessionFrom_QueuedCommand(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 2, "")
+	newMsgs, _, _, err := callParseClaudeSessionFrom(path, offset, 2, "")
 	require.NoError(t, err)
 	require.Len(t, newMsgs, 2)
 
@@ -596,7 +626,7 @@ func TestParseClaudeSessionFrom_QueueOperationPreservesSubagentMapping(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 1, "")
+	newMsgs, _, _, err := callParseClaudeSessionFrom(path, offset, 1, "")
 	require.NoError(t, err)
 	require.Len(t, newMsgs, 1)
 	require.Len(t, newMsgs[0].ToolCalls, 1)
@@ -637,7 +667,7 @@ func TestParseClaudeSessionFrom_SkipsNonMessages(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, _, err := ParseClaudeSessionFrom(
+	newMsgs, _, _, err := callParseClaudeSessionFrom(
 		path, offset, 1, "",
 	)
 	require.NoError(t, err)
@@ -660,7 +690,7 @@ func TestParseClaudeSessionFrom_NoNewData(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse from EOF — should return empty.
-	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
+	newMsgs, endedAt, _, err := callParseClaudeSessionFrom(
 		path, info.Size(), 1, "",
 	)
 	require.NoError(t, err)
@@ -697,7 +727,7 @@ func TestParseClaudeSessionFrom_PartialLineAtEOF(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, consumed, err := ParseClaudeSessionFrom(
+	newMsgs, _, consumed, err := callParseClaudeSessionFrom(
 		path, offset, 1, "",
 	)
 	require.NoError(t, err)
@@ -745,7 +775,7 @@ func TestParseClaudeSessionFrom_DAGDetected(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(
+	_, _, _, err = callParseClaudeSessionFrom(
 		path, offset, 1, "",
 	)
 	assert.ErrorIs(t, err, ErrDAGDetected)
@@ -779,7 +809,7 @@ func TestParseClaudeSessionFrom_DAGBoundaryAgainstStoredLastUUID(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(
+	_, _, _, err = callParseClaudeSessionFrom(
 		path, offset, 1, "stored-tip",
 	)
 	assert.ErrorIs(t, err, ErrDAGDetected)
@@ -826,7 +856,7 @@ func TestParseClaudeSessionFrom_DAGAcrossNonUUID(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(
+	_, _, _, err = callParseClaudeSessionFrom(
 		path, offset, 1, "",
 	)
 	assert.ErrorIs(t, err, ErrDAGDetected)
@@ -869,7 +899,7 @@ func TestParseClaudeSessionFrom_LinearUUID(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, endedAt, _, err := ParseClaudeSessionFrom(
+	newMsgs, endedAt, _, err := callParseClaudeSessionFrom(
 		path, offset, 1, "",
 	)
 	require.NoError(t, err)
@@ -916,7 +946,7 @@ func TestParseClaudeSessionFrom_ToolUseResultAgentIDFallsBack(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(path, offset, 1, "")
+	_, _, _, err = callParseClaudeSessionFrom(path, offset, 1, "")
 	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
@@ -1042,7 +1072,7 @@ func TestParseClaudeSessionFrom_SameMessageIDFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(path, offset, 1, "")
+	_, _, _, err = callParseClaudeSessionFrom(path, offset, 1, "")
 	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
@@ -1073,7 +1103,7 @@ func TestParseClaudeSessionFrom_QueueOperationOnlyFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(path, offset, 2, "a1")
+	_, _, _, err = callParseClaudeSessionFrom(path, offset, 2, "a1")
 	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
@@ -1104,7 +1134,7 @@ func TestParseClaudeSessionFrom_ProgressOnlyFallsBack(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = ParseClaudeSessionFrom(path, offset, 2, "a1")
+	_, _, _, err = callParseClaudeSessionFrom(path, offset, 2, "a1")
 	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
@@ -1143,7 +1173,7 @@ func TestParseClaudeSessionFrom_BenignAppendNoFallback(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, _, _, err := ParseClaudeSessionFrom(path, offset, 1, "")
+	newMsgs, _, _, err := callParseClaudeSessionFrom(path, offset, 1, "")
 	require.NoError(t, err)
 	assert.Len(t, newMsgs, 2)
 }
@@ -1685,7 +1715,7 @@ func TestParseClaudeSession_CompactBoundary(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 
-		newMsgs, _, _, err := ParseClaudeSessionFrom(
+		newMsgs, _, _, err := callParseClaudeSessionFrom(
 			path, offset, 1, "",
 		)
 		require.NoError(t, err)

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -1047,6 +1047,68 @@ func TestParseClaudeSessionFrom_SameMessageIDFallsBack(t *testing.T) {
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
 
+func TestParseClaudeSessionFrom_QueueOperationOnlyFallsBack(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","uuid":"u1","timestamp":"`+tsEarly+`","message":{"content":"go"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"`+tsEarlyS5+`","message":{"id":"msg_queue","content":[{"type":"tool_use","id":"toolu_queue","name":"Agent","input":{"description":"inspect","subagent_type":"Explore","prompt":"inspect"}}]}}`,
+	)
+	path := createTestFile(
+		t, "inc-queue-only.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := `{"type":"queue-operation","operation":"enqueue","timestamp":"` +
+		tsLate + `","sessionId":"queued-subagent","content":"{\"task_id\":\"childqueue\",\"tool_use_id\":\"toolu_queue\",\"description\":\"inspect\",\"task_type\":\"local_agent\"}"}` + "\n"
+
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseClaudeSessionFrom(path, offset, 2, "a1")
+	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
+	assert.True(t, IsIncrementalFullParseFallback(err))
+}
+
+func TestParseClaudeSessionFrom_ProgressOnlyFallsBack(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","uuid":"u1","timestamp":"`+tsEarly+`","message":{"content":"go"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"`+tsEarlyS5+`","message":{"id":"msg_progress","content":[{"type":"tool_use","id":"toolu_progress","name":"Agent","input":{"description":"inspect","subagent_type":"Explore","prompt":"inspect"}}]}}`,
+	)
+	path := createTestFile(
+		t, "inc-progress-only.jsonl", initial,
+	)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := `{"type":"progress","timestamp":"` + tsLate +
+		`","parentToolUseID":"toolu_progress","data":{"type":"agent_progress","agentId":"childprogress"}}` + "\n"
+
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseClaudeSessionFrom(path, offset, 2, "a1")
+	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
+	assert.True(t, IsIncrementalFullParseFallback(err))
+}
+
 // Sanity: a benign incremental append (one user, one assistant
 // with a unique message.id, no toolUseResult.agentId) must NOT
 // trigger fallback.

--- a/internal/parser/claude_test.go
+++ b/internal/parser/claude_test.go
@@ -383,7 +383,7 @@ func TestClaudeIncrementalRenameTriggersFullParse(t *testing.T) {
 	err := os.WriteFile(path, []byte(renameLine+"\n"), 0o644)
 	require.NoError(t, err)
 
-	_, _, _, parseErr := ParseClaudeSessionFrom(path, 0, 0)
+	_, _, _, parseErr := ParseClaudeSessionFrom(path, 0, 0, "")
 	require.Error(t, parseErr)
 	assert.True(t, IsIncrementalFullParseFallback(parseErr))
 }

--- a/internal/parser/claude_test.go
+++ b/internal/parser/claude_test.go
@@ -383,7 +383,7 @@ func TestClaudeIncrementalRenameTriggersFullParse(t *testing.T) {
 	err := os.WriteFile(path, []byte(renameLine+"\n"), 0o644)
 	require.NoError(t, err)
 
-	_, _, _, parseErr := ParseClaudeSessionFrom(path, 0, 0, "")
+	_, _, _, parseErr := callParseClaudeSessionFrom(path, 0, 0, "")
 	require.Error(t, parseErr)
 	assert.True(t, IsIncrementalFullParseFallback(parseErr))
 }

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -488,9 +488,11 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 		return
 	}
 
-	output, _ := parseCodexFunctionOutput(payload)
+	output, raw := parseCodexFunctionOutput(payload)
 	if !output.Exists() {
-		return
+		if strings.TrimSpace(raw) == "" {
+			return
+		}
 	}
 
 	switch b.callNames[callID] {
@@ -523,6 +525,15 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 			})
 			return true
 		})
+	default:
+		if text := strings.TrimSpace(raw); text != "" {
+			b.appendCallResultEvent(callID, ParsedToolResultEvent{
+				ToolUseID: callID,
+				Source:    "function_call_output",
+				Content:   text,
+				Timestamp: ts,
+			})
+		}
 	}
 }
 
@@ -1740,8 +1751,9 @@ func codexIncrementalNeedsFullParse(line string) bool {
 	case "function_call":
 		return isCodexWaitAgentCall(payload.Get("name").Str)
 	case "function_call_output":
-		output, _ := parseCodexFunctionOutput(payload)
-		return isCodexSubagentFunctionOutput(output)
+		output, raw := parseCodexFunctionOutput(payload)
+		return isCodexSubagentFunctionOutput(output) ||
+			strings.TrimSpace(raw) != ""
 	default:
 		role := payload.Get("role").Str
 		if role != "user" {

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1708,6 +1708,41 @@ func TestParseCodexSessionFrom_LateTokenCountRequiresFullParse(t *testing.T) {
 	assert.True(t, IsIncrementalFullParseFallback(err))
 }
 
+func TestParseCodexSessionFrom_FunctionCallOutputRequiresFullParse(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"inc-function-output", "/projects/api",
+			"codex_exec", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "run command", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command", "call_cmd",
+			map[string]any{"cmd": "sleep 1"}, tsEarlyS5,
+		),
+	)
+	path := createTestFile(t, "function-call-output.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.JoinJSONL(
+		testjsonl.CodexFunctionCallOutputJSON(
+			"call_cmd", "done", tsLate,
+		),
+	))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 2, false)
+	require.Error(t, err)
+	assert.True(t, IsIncrementalFullParseFallback(err))
+}
+
 // TestParseCodexSessionFrom_DedupsReemittedPrompt covers the
 // incremental-sync case of the re-emitted-prompt dedup: when Codex
 // appends a positive replay signal followed by a verbatim replay of
@@ -2069,7 +2104,7 @@ func TestParseCodexSessionFrom_RunningNotificationRequiresFullParse(t *testing.T
 	assert.Contains(t, err.Error(), "full parse")
 }
 
-func TestParseCodexSessionFrom_NonSubagentFunctionOutputDoesNotRequireFullParse(t *testing.T) {
+func TestParseCodexSessionFrom_NonSubagentFunctionOutputRequiresFullParse(t *testing.T) {
 	t.Parallel()
 
 	initial := testjsonl.JoinJSONL(
@@ -2090,10 +2125,9 @@ func TestParseCodexSessionFrom_NonSubagentFunctionOutputDoesNotRequireFullParse(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
-	require.NoError(t, err)
-	assert.Equal(t, 0, len(newMsgs))
-	assert.False(t, endedAt.IsZero())
+	_, _, _, err = ParseCodexSessionFrom(path, offset, 1, false)
+	require.Error(t, err)
+	assert.True(t, IsIncrementalFullParseFallback(err))
 }
 
 func TestParseCodexSessionFrom_SeedsModelFromTurnContext(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3911,6 +3911,8 @@ type incrementalUpdate struct {
 	userMsgCount         int // total (old + new)
 	fileSize             int64
 	fileMtime            int64
+	nextOrdinal          int
+	lastEntryUUID        string
 	totalOutputTokens    int // absolute (old + new)
 	peakContextTokens    int // absolute max(old, new)
 	hasTotalOutputTokens bool
@@ -4462,7 +4464,7 @@ func (e *Engine) processCowork(
 // error. The consumed count covers only complete, valid JSON
 // lines so it can be used as a safe resume offset.
 type incrementalParseFunc func(
-	path string, offset int64, startOrdinal int,
+	path string, offset int64, startOrdinal int, lastEntryUUID string,
 ) ([]parser.ParsedMessage, time.Time, int64, error)
 
 // tryIncrementalJSONL attempts an incremental parse of an
@@ -4538,13 +4540,8 @@ func (e *Engine) tryIncrementalJSONL(
 		}
 	}
 
-	maxOrd := e.db.MaxOrdinal(inc.ID)
-	if maxOrd < 0 {
-		return processResult{}, false
-	}
-
 	newMsgs, endedAt, consumed, err := parseFn(
-		file.Path, inc.FileSize, maxOrd+1,
+		file.Path, inc.FileSize, inc.NextOrdinal, inc.LastEntryUUID,
 	)
 	if err != nil {
 		if parser.IsIncrementalFullParseFallback(err) {
@@ -4588,6 +4585,8 @@ func (e *Engine) tryIncrementalJSONL(
 					userMsgCount:         inc.UserMsgCount,
 					fileSize:             newOffset,
 					fileMtime:            info.ModTime().UnixNano(),
+					nextOrdinal:          inc.NextOrdinal,
+					lastEntryUUID:        inc.LastEntryUUID,
 					totalOutputTokens:    inc.TotalOutputTokens,
 					peakContextTokens:    inc.PeakContextTokens,
 					hasTotalOutputTokens: inc.HasTotalOutputTokens,
@@ -4625,6 +4624,8 @@ func (e *Engine) tryIncrementalJSONL(
 	}
 
 	newUserCount := countUserMsgs(newMsgs)
+	nextOrdinal := nextParsedOrdinal(inc.NextOrdinal, newMsgs)
+	lastEntryUUID := lastParsedSourceUUID(inc.LastEntryUUID, newMsgs)
 
 	log.Printf(
 		"incremental %s %s: %d new message(s) "+
@@ -4657,6 +4658,8 @@ func (e *Engine) tryIncrementalJSONL(
 			userMsgCount:         inc.UserMsgCount + newUserCount,
 			fileSize:             newOffset,
 			fileMtime:            info.ModTime().UnixNano(),
+			nextOrdinal:          nextOrdinal,
+			lastEntryUUID:        lastEntryUUID,
 			totalOutputTokens:    totalOut,
 			peakContextTokens:    peakCtx,
 			hasTotalOutputTokens: hasTotalOut,
@@ -4859,7 +4862,7 @@ func (e *Engine) processCodex(
 	forceReplace := false
 
 	codexParseFn := func(
-		path string, offset int64, startOrd int,
+		path string, offset int64, startOrd int, _ string,
 	) ([]parser.ParsedMessage, time.Time, int64, error) {
 		return parser.ParseCodexSessionFrom(
 			path, offset, startOrd, false,
@@ -7623,26 +7626,25 @@ func (e *Engine) writeIncremental(
 		endedAt = &s
 	}
 
-	// Write messages first — only advance file_size when
-	// the insert succeeds so a failure is retried.
-	if err := e.writeMessages(
-		inc.sessionID, dbMsgs,
+	if err := e.db.WriteSessionIncremental(
+		inc.sessionID,
+		dbMsgs,
+		db.IncrementalSessionUpdate{
+			EndedAt:              endedAt,
+			MsgCount:             msgCount,
+			UserMsgCount:         userMsgCount,
+			FileSize:             inc.fileSize,
+			FileMtime:            inc.fileMtime,
+			NextOrdinal:          inc.nextOrdinal,
+			LastEntryUUID:        inc.lastEntryUUID,
+			TotalOutputTokens:    inc.totalOutputTokens,
+			PeakContextTokens:    inc.peakContextTokens,
+			HasTotalOutputTokens: inc.hasTotalOutputTokens,
+			HasPeakContextTokens: inc.hasPeakContextTokens,
+		},
 	); err != nil {
 		return fmt.Errorf(
-			"incremental messages %s: %w",
-			inc.sessionID, err,
-		)
-	}
-
-	if err := e.db.UpdateSessionIncremental(
-		inc.sessionID, endedAt,
-		msgCount, userMsgCount,
-		inc.fileSize, inc.fileMtime,
-		inc.totalOutputTokens, inc.peakContextTokens,
-		inc.hasTotalOutputTokens, inc.hasPeakContextTokens,
-	); err != nil {
-		return fmt.Errorf(
-			"incremental update %s: %w",
+			"incremental write %s: %w",
 			inc.sessionID, err,
 		)
 	}
@@ -8152,12 +8154,14 @@ func toDBSession(pw pendingWrite) db.Session {
 		// not persist this field; the caller bumps it via
 		// SetSessionDataVersion only after the message
 		// rewrite succeeds.
-		FilePath:   strPtr(pw.sess.File.Path),
-		FileSize:   int64Ptr(pw.sess.File.Size),
-		FileMtime:  int64Ptr(pw.sess.File.Mtime),
-		FileInode:  int64Ptr(pw.sess.File.Inode),
-		FileDevice: int64Ptr(pw.sess.File.Device),
-		FileHash:   strPtr(pw.sess.File.Hash),
+		FilePath:      strPtr(pw.sess.File.Path),
+		FileSize:      int64Ptr(pw.sess.File.Size),
+		FileMtime:     int64Ptr(pw.sess.File.Mtime),
+		NextOrdinal:   nextParsedOrdinal(0, pw.msgs),
+		LastEntryUUID: strPtr(lastParsedSourceUUID("", pw.msgs)),
+		FileInode:     int64Ptr(pw.sess.File.Inode),
+		FileDevice:    int64Ptr(pw.sess.File.Device),
+		FileHash:      strPtr(pw.sess.File.Hash),
 	}
 	if pw.sess.FirstMessage != "" {
 		s.FirstMessage = &pw.sess.FirstMessage
@@ -8262,6 +8266,26 @@ func countUserMsgs(msgs []parser.ParsedMessage) int {
 		}
 	}
 	return n
+}
+
+func nextParsedOrdinal(
+	current int, msgs []parser.ParsedMessage,
+) int {
+	if len(msgs) == 0 {
+		return current
+	}
+	return msgs[len(msgs)-1].Ordinal + 1
+}
+
+func lastParsedSourceUUID(
+	current string, msgs []parser.ParsedMessage,
+) string {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].SourceUUID != "" {
+			return msgs[i].SourceUUID
+		}
+	}
+	return current
 }
 
 // FindSourceFile locates the original source file for a

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4519,6 +4519,14 @@ func (e *Engine) tryIncrementalJSONL(
 		return processResult{}, false
 	}
 
+	// A prior sync that stored no message rows has no safe append
+	// boundary. Rewritten files can grow in place and keep the same
+	// identity, which makes a full-file replacement look like an
+	// append from the old file_size offset.
+	if inc.MsgCount == 0 {
+		return processResult{}, false
+	}
+
 	// If the file was replaced (different inode/device), fall
 	// back to a full parse so we don't append on top of stale
 	// state. Only check when both sides have a known identity

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6882,6 +6882,90 @@ func TestIncrementalSync_ClaudeAppend(t *testing.T) {
 	assert.Equal(t, 500, msgs[1].ContextTokens, "assistant ContextTokens = %d, want 500", msgs[1].ContextTokens)
 }
 
+func TestIncrementalSync_ClaudeFilteredTailAdvancesNextOrdinal(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "filtered-tail.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	firstAppend := testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_pair","name":"Read","input":{"file_path":"README.md"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_pair","content":"ok"}]}}`,
+	) + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open first append")
+	_, err = f.WriteString(firstAppend)
+	require.NoError(t, err, "write first append")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	state, err := env.db.GetSessionFull(
+		context.Background(), "filtered-tail",
+	)
+	require.NoError(t, err, "GetSessionFull after first append")
+	require.NotNil(t, state, "filtered-tail session missing")
+	assert.Equal(t, 3, state.NextOrdinal, "NextOrdinal after filtered tail")
+	require.NotNil(t, state.LastEntryUUID, "LastEntryUUID after filtered tail")
+	assert.Equal(t, "r1", *state.LastEntryUUID, "LastEntryUUID after filtered tail")
+
+	secondAppend := testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:03Z","uuid":"a2","parentUuid":"r1","message":{"content":[{"type":"text","text":"done"}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"end_turn"}}`,
+	) + "\n"
+	f, err = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open second append")
+	_, err = f.WriteString(secondAppend)
+	require.NoError(t, err, "write second append")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "filtered-tail")
+	require.Len(t, msgs, 3)
+	assert.Equal(t, 0, msgs[0].Ordinal, "ordinal 0")
+	assert.Equal(t, 1, msgs[1].Ordinal, "ordinal 1")
+	assert.Equal(t, 3, msgs[2].Ordinal, "ordinal 2")
+}
+
+func TestIncrementalSync_ClaudeQueueOperationPreservesSubagentMapping(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "queued-subagent.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_queue","name":"Agent","input":{"description":"inspect","subagent_type":"Explore","prompt":"inspect"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"queue-operation","operation":"enqueue","timestamp":"2024-01-01T10:00:02Z","sessionId":"queued-subagent","content":"{\"task_id\":\"childqueue\",\"tool_use_id\":\"toolu_queue\",\"description\":\"inspect\",\"task_type\":\"local_agent\"}"}`,
+	) + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append queue mapping")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "queued-subagent")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(
+		t,
+		"agent-childqueue",
+		msgs[1].ToolCalls[0].SubagentSessionID,
+		"subagent_session_id",
+	)
+}
+
 // TestIncrementalSync_ClaudeFileReplaced verifies that when a
 // session file is replaced atomically (new inode/device), the
 // sync engine detects the identity change and falls back to a
@@ -7097,6 +7181,33 @@ func TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall(t *testing.T
 	assert.Equal(t, "agent-childlate", got.String, "subagent_session_id = %q, want %q", got.String, "agent-childlate")
 }
 
+func TestIncrementalSync_ClaudeCrossSyncToolResultFallback(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_tool","content":[{"type":"tool_use","id":"toolu_cross","name":"Read","input":{"file_path":"README.md"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-cross-tool", "cross-tool.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := `{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_cross","content":"done"}]}}` + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append tool_result")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "cross-tool")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "done", msgs[1].ToolCalls[0].ResultContent, "result_content")
+}
+
 func TestIncrementalSync_CodexAppend(t *testing.T) {
 	env := setupTestEnv(t)
 
@@ -7145,6 +7256,47 @@ func TestIncrementalSync_CodexAppend(t *testing.T) {
 	for i, m := range msgs {
 		assert.Equal(t, "codex:inc-cx", m.SessionID, "msgs[%d].SessionID = %q, want codex:inc-cx", i, m.SessionID)
 	}
+}
+
+func TestIncrementalSync_CodexExecAppendRetainsEvents(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"inc-cx-exec", "/tmp/proj",
+			"codex_exec", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "run command", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command", "call_cmd",
+			map[string]any{"cmd": "sleep 1"}, tsEarlyS5,
+		),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "01"),
+		"rollout-20240101-inc-cx-exec.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexFunctionCallOutputJSON(
+			"call_cmd", "done", "2024-01-01T10:01:00Z",
+		),
+	)
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "codex:inc-cx-exec")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "exec_command", msgs[1].ToolCalls[0].ToolName, "tool name")
 }
 
 func TestIncrementalSync_CodexLateTokenCountRewritesStoredMessage(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6905,15 +6905,6 @@ func TestIncrementalSync_ClaudeFilteredTailAdvancesNextOrdinal(t *testing.T) {
 
 	env.engine.SyncPaths([]string{path})
 
-	state, err := env.db.GetSessionFull(
-		context.Background(), "filtered-tail",
-	)
-	require.NoError(t, err, "GetSessionFull after first append")
-	require.NotNil(t, state, "filtered-tail session missing")
-	assert.Equal(t, 3, state.NextOrdinal, "NextOrdinal after filtered tail")
-	require.NotNil(t, state.LastEntryUUID, "LastEntryUUID after filtered tail")
-	assert.Equal(t, "r1", *state.LastEntryUUID, "LastEntryUUID after filtered tail")
-
 	secondAppend := testjsonl.JoinJSONL(
 		`{"type":"assistant","timestamp":"2024-01-01T10:00:03Z","uuid":"a2","parentUuid":"r1","message":{"content":[{"type":"text","text":"done"}],"usage":{"input_tokens":1,"output_tokens":2},"stop_reason":"end_turn"}}`,
 	) + "\n"

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6966,6 +6966,42 @@ func TestIncrementalSync_ClaudeQueueOperationPreservesSubagentMapping(t *testing
 	)
 }
 
+func TestIncrementalSync_ClaudeQueueOperationOnlyRepairsStoredSubagentMapping(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_queue_only","name":"Agent","input":{"description":"inspect","subagent_type":"Explore","prompt":"inspect"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "queued-subagent-split.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := testjsonl.JoinJSONL(
+		`{"type":"queue-operation","operation":"enqueue","timestamp":"2024-01-01T10:00:02Z","sessionId":"queued-subagent-split","content":"{\"task_id\":\"childqueueonly\",\"tool_use_id\":\"toolu_queue_only\",\"description\":\"inspect\",\"task_type\":\"local_agent\"}"}`,
+	) + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append queue mapping")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "queued-subagent-split")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(
+		t,
+		"agent-childqueueonly",
+		msgs[1].ToolCalls[0].SubagentSessionID,
+		"subagent_session_id",
+	)
+}
+
 // TestIncrementalSync_ClaudeFileReplaced verifies that when a
 // session file is replaced atomically (new inode/device), the
 // sync engine detects the identity change and falls back to a

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6993,6 +6993,42 @@ func TestIncrementalSync_ClaudeQueueOperationOnlyRepairsStoredSubagentMapping(
 	)
 }
 
+func TestIncrementalSync_ClaudeProgressOnlyRepairsStoredSubagentMapping(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_progress_only","name":"Agent","input":{"description":"inspect","subagent_type":"Explore","prompt":"inspect"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "progress-subagent-split.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := testjsonl.JoinJSONL(
+		`{"type":"progress","timestamp":"2024-01-01T10:00:02Z","parentToolUseID":"toolu_progress_only","data":{"type":"agent_progress","agentId":"childprogressonly"}}`,
+	) + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append progress mapping")
+	require.NoError(t, f.Close())
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "progress-subagent-split")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(
+		t,
+		"agent-childprogressonly",
+		msgs[1].ToolCalls[0].SubagentSessionID,
+		"subagent_session_id",
+	)
+}
+
 // TestIncrementalSync_ClaudeFileReplaced verifies that when a
 // session file is replaced atomically (new inode/device), the
 // sync engine detects the identity change and falls back to a
@@ -7324,6 +7360,7 @@ func TestIncrementalSync_CodexExecAppendRetainsEvents(t *testing.T) {
 	require.Len(t, msgs, 2)
 	require.Len(t, msgs[1].ToolCalls, 1)
 	assert.Equal(t, "exec_command", msgs[1].ToolCalls[0].ToolName, "tool name")
+	assert.Equal(t, "done", msgs[1].ToolCalls[0].ResultContent, "result_content")
 }
 
 func TestIncrementalSync_CodexLateTokenCountRewritesStoredMessage(t *testing.T) {


### PR DESCRIPTION
## Summary
- Persist local-only `last_entry_uuid` and `next_ordinal` so incremental sync resumes from the real JSONL boundary instead of `MaxOrdinal()+1`.
- Make incremental append writes atomic, and make Claude incremental parsing self-heal when the new tail needs prior-session state for DAG validation, cross-sync `tool_result` pairing, or queue and progress based subagent linkage repairs.
- Preserve Codex `function_call_output` tails by storing generic call results on full parse and forcing incremental Codex fallback when those outputs land after an already-synced tool call.

## Scope
- Keeps `last_entry_uuid` and `next_ordinal` inside local SQLite sync state; PostgreSQL push and read models stay unchanged.
- Uses full-parse fallback for ambiguous cross-sync `tool_result` tails instead of adding a broader DB lookup layer in this PR.
- Keeps the Codex runtime change narrow to the now-proved live gap, generic `function_call_output` tails that otherwise disappear on incremental exec sessions.

## Review Notes
- Start with `internal/db/schema.sql`, `internal/db/db.go`, and `internal/db/sessions.go`, where the new resume metadata and incremental update contract are introduced.
- Then review `internal/sync/engine.go` and `internal/parser/claude.go`, where the stored boundary UUID, next ordinal, atomic append path, and incremental subagent mapping are threaded through the Claude append flow.
- Focused validation is the parser, sync, and DB commands from the plan; the incremental review fixes add split-sync queue and progress linkage coverage plus the Codex exec `function_call_output` retention gate, while broader lint, PostgreSQL, frontend, integration, and desktop coverage stay in CI.

Fixes #162
