### PR TITLE
fix(db): reuse FTS-safe large-session deletes

### DIFF
--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -554,43 +554,50 @@ func replaceSessionMessagesTx(
 		return err
 	}
 
-	if _, err := tx.Exec(
-		"DELETE FROM tool_calls WHERE session_id = ?",
-		sessionID,
-	); err != nil {
-		return fmt.Errorf("deleting old tool_calls: %w", err)
-	}
-	if _, err := tx.Exec(
-		"DELETE FROM tool_result_events WHERE session_id = ?",
-		sessionID,
-	); err != nil {
-		return fmt.Errorf(
-			"deleting old tool_result_events: %w", err,
-		)
+	if err := deleteSessionMessagesTx(tx, sessionID); err != nil {
+		return err
 	}
 
-	// FTS5 is optional (the module may be missing in the runtime).
-	// Probe sqlite_master so the bulk-delete + trigger-swap dance
-	// only runs when there's actually an FTS table to maintain.
+	if len(msgs) > 0 {
+		ids, err := insertMessagesTx(tx, msgs)
+		if err != nil {
+			return err
+		}
+		toolCalls := resolveToolCalls(msgs, ids)
+		if err := insertToolCallsTx(tx, toolCalls); err != nil {
+			return err
+		}
+		events := resolveToolResultEvents(msgs)
+		if err := insertToolResultEventsTx(tx, events); err != nil {
+			return err
+		}
+	}
+
+	return restorePinsTx(tx, sessionID, pins)
+}
+
+func sessionHasFTSTx(tx *sql.Tx) (bool, error) {
 	var ftsCount int
 	if err := tx.QueryRow(
 		`SELECT count(*) FROM sqlite_master
 		 WHERE type='table' AND name='messages_fts'`,
 	).Scan(&ftsCount); err != nil {
-		return fmt.Errorf("probing fts table: %w", err)
+		return false, fmt.Errorf("probing fts table: %w", err)
 	}
-	hasFTS := ftsCount > 0
+	return ftsCount > 0, nil
+}
+
+func deleteSessionMessageRowsTx(
+	tx *sql.Tx, sessionID string,
+) error {
+	hasFTS, err := sessionHasFTSTx(tx)
+	if err != nil {
+		return err
+	}
 
 	if hasFTS {
-		// Bulk-delete the FTS index entries up-front in a single SQL
-		// statement, then drop the per-row messages_ad trigger so the
-		// upcoming DELETE FROM messages doesn't re-fire the FTS5
-		// 'delete' command for every row. With large sessions
-		// (thousands of rows where a single content blob can be many
-		// MB) the per-row trigger path is dominated by FTS
-		// tokenization and stalls the writer for minutes; the bulk
-		// INSERT...SELECT path is effectively flat. The trigger is
-		// restored before the transaction is allowed to commit.
+		// Bulk-delete the FTS entries first so the later row delete
+		// does not re-tokenize large message blobs through messages_ad.
 		if _, err := tx.Exec(
 			`INSERT INTO messages_fts(messages_fts, rowid, content)
 			 SELECT 'delete', id, content
@@ -615,23 +622,25 @@ func replaceSessionMessagesTx(
 			return fmt.Errorf("restoring messages_ad trigger: %w", err)
 		}
 	}
+	return nil
+}
 
-	if len(msgs) > 0 {
-		ids, err := insertMessagesTx(tx, msgs)
-		if err != nil {
-			return err
-		}
-		toolCalls := resolveToolCalls(msgs, ids)
-		if err := insertToolCallsTx(tx, toolCalls); err != nil {
-			return err
-		}
-		events := resolveToolResultEvents(msgs)
-		if err := insertToolResultEventsTx(tx, events); err != nil {
-			return err
-		}
+func deleteSessionMessagesTx(tx *sql.Tx, sessionID string) error {
+	if _, err := tx.Exec(
+		"DELETE FROM tool_calls WHERE session_id = ?",
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("deleting old tool_calls: %w", err)
 	}
-
-	return restorePinsTx(tx, sessionID, pins)
+	if _, err := tx.Exec(
+		"DELETE FROM tool_result_events WHERE session_id = ?",
+		sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"deleting old tool_result_events: %w", err,
+		)
+	}
+	return deleteSessionMessageRowsTx(tx, sessionID)
 }
 
 // ReplaceSessionContent atomically replaces a session's messages, signal

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 const largeSessionPerfCeiling = 10 * time.Second
+const crossSessionNeighborCount = 40
+const crossSessionToolCallsPerNeighbor = 250
+const crossSessionToolCallTotal = crossSessionNeighborCount * crossSessionToolCallsPerNeighbor
 
 func largeSessionMessages(sessionID, blobToken string) []Message {
 	const n = 1000
@@ -36,24 +39,39 @@ func largeSessionMessages(sessionID, blobToken string) []Message {
 func seedCrossSessionFKGrowth(t *testing.T, d *DB, sessionID string) {
 	t.Helper()
 
-	insertSession(t, d, sessionID, "proj")
-	insertMessages(t, d, userMsg(sessionID, 0, "neighbor"))
-	msgs, err := d.GetAllMessages(context.Background(), sessionID)
-	require.NoError(t, err, "GetAllMessages neighbor")
-	require.Len(t, msgs, 1)
-	_, err = d.PinMessage(sessionID, msgs[0].ID, nil)
-	require.NoError(t, err, "PinMessage neighbor")
+	type neighborSeed struct {
+		sessionID string
+		messageID int64
+	}
+
+	seeds := make([]neighborSeed, 0, crossSessionNeighborCount)
+	for i := range crossSessionNeighborCount {
+		neighborID := sessionID + "-" + strconv.Itoa(i)
+		insertSession(t, d, neighborID, "proj")
+		insertMessages(t, d, userMsg(neighborID, 0, "neighbor"))
+		msgs, err := d.GetAllMessages(context.Background(), neighborID)
+		require.NoError(t, err, "GetAllMessages neighbor %s", neighborID)
+		require.Len(t, msgs, 1)
+		_, err = d.PinMessage(neighborID, msgs[0].ID, nil)
+		require.NoError(t, err, "PinMessage neighbor %s", neighborID)
+		seeds = append(seeds, neighborSeed{
+			sessionID: neighborID,
+			messageID: msgs[0].ID,
+		})
+	}
 
 	require.NoError(t, d.Update(func(tx *sql.Tx) error {
-		for i := range 2000 {
-			if _, err := tx.Exec(
-				`INSERT INTO tool_calls
-				 (message_id, session_id, tool_name, category, tool_use_id)
-				 VALUES (?, ?, ?, ?, ?)`,
-				msgs[0].ID, sessionID, "Read", "Read",
-				"neighbor-tool-"+strconv.Itoa(i),
-			); err != nil {
-				return err
+		for _, seed := range seeds {
+			for i := range crossSessionToolCallsPerNeighbor {
+				if _, err := tx.Exec(
+					`INSERT INTO tool_calls
+					 (message_id, session_id, tool_name, category, tool_use_id)
+					 VALUES (?, ?, ?, ?, ?)`,
+					seed.messageID, seed.sessionID, "Read", "Read",
+					seed.sessionID+"-tool-"+strconv.Itoa(i),
+				); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -70,6 +88,36 @@ func assertNoFTSLeak(t *testing.T, d *DB, token string) {
 	).Scan(&leaked)
 	require.NoError(t, err, "fts leak check")
 	assert.Zero(t, leaked, "FTS still contains rows matching %q", token)
+}
+
+func poisonMessagesDeleteTrigger(t *testing.T, d *DB) {
+	t.Helper()
+
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		if _, err := tx.Exec("DROP TRIGGER IF EXISTS messages_ad"); err != nil {
+			return err
+		}
+		_, err := tx.Exec(`
+			CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+				SELECT RAISE(FAIL, 'poison messages_ad fired');
+			END`)
+		return err
+	}), "poison messages_ad trigger")
+}
+
+func requireMessagesDeleteTriggerRestored(t *testing.T, d *DB) {
+	t.Helper()
+
+	var triggerSQL string
+	err := d.getReader().QueryRow(
+		`SELECT sql FROM sqlite_master
+		 WHERE type = 'trigger' AND name = 'messages_ad'`,
+	).Scan(&triggerSQL)
+	require.NoError(t, err, "read messages_ad trigger")
+	assert.NotContains(t, triggerSQL, "poison messages_ad fired",
+		"messages_ad trigger was not restored")
+	assert.Contains(t, triggerSQL, "INSERT INTO messages_fts",
+		"messages_ad trigger no longer matches the canonical FTS delete path")
 }
 
 func TestInsertAndGetMessage_ThinkingText(t *testing.T) {
@@ -385,6 +433,7 @@ func TestWriteSessionBatch_ReplaceMessagesLargeSession(t *testing.T) {
 	insertSession(t, d, targetID, "proj")
 	insertMessages(t, d, largeSessionMessages(targetID, blobToken)...)
 	seedCrossSessionFKGrowth(t, d, "batch-neighbor")
+	poisonMessagesDeleteTrigger(t, d)
 
 	repl := make([]Message, 0, 10)
 	for i := range 10 {
@@ -416,14 +465,16 @@ func TestWriteSessionBatch_ReplaceMessagesLargeSession(t *testing.T) {
 	require.NoError(t, err, "GetAllMessages after batch replace")
 	require.Len(t, got, len(repl), "after batch replace")
 	assertNoFTSLeak(t, d, blobToken)
+	requireMessagesDeleteTriggerRestored(t, d)
 
 	var neighborToolCalls int
 	err = d.getReader().QueryRow(
-		"SELECT count(*) FROM tool_calls WHERE session_id = ?",
-		"batch-neighbor",
+		"SELECT count(*) FROM tool_calls WHERE session_id LIKE ?",
+		"batch-neighbor-%",
 	).Scan(&neighborToolCalls)
 	require.NoError(t, err, "neighbor tool_calls count")
-	assert.Equal(t, 2000, neighborToolCalls, "neighbor tool_calls count")
+	assert.Equal(t, crossSessionToolCallTotal, neighborToolCalls,
+		"neighbor tool_calls count")
 }
 
 // TestMessageReadsTolerateNullTimestamp pins NULL-timestamp robustness

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,65 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const largeSessionPerfCeiling = 10 * time.Second
+
+func largeSessionMessages(sessionID, blobToken string) []Message {
+	const n = 1000
+	msgs := make([]Message, 0, n)
+	for i := range n {
+		msgs = append(msgs, userMsg(sessionID, i, "small"))
+	}
+	big := strings.Repeat(blobToken+" ", 5*1024*1024/len(blobToken+" "))
+	msgs[n/2] = Message{
+		SessionID:     sessionID,
+		Ordinal:       n / 2,
+		Role:          "assistant",
+		Content:       big,
+		ContentLength: len(big),
+		Timestamp:     tsZero,
+	}
+	return msgs
+}
+
+func seedCrossSessionFKGrowth(t *testing.T, d *DB, sessionID string) {
+	t.Helper()
+
+	insertSession(t, d, sessionID, "proj")
+	insertMessages(t, d, userMsg(sessionID, 0, "neighbor"))
+	msgs, err := d.GetAllMessages(context.Background(), sessionID)
+	require.NoError(t, err, "GetAllMessages neighbor")
+	require.Len(t, msgs, 1)
+	_, err = d.PinMessage(sessionID, msgs[0].ID, nil)
+	require.NoError(t, err, "PinMessage neighbor")
+
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		for i := range 2000 {
+			if _, err := tx.Exec(
+				`INSERT INTO tool_calls
+				 (message_id, session_id, tool_name, category, tool_use_id)
+				 VALUES (?, ?, ?, ?, ?)`,
+				msgs[0].ID, sessionID, "Read", "Read",
+				"neighbor-tool-"+strconv.Itoa(i),
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}), "seed neighbor tool_calls")
+}
+
+func assertNoFTSLeak(t *testing.T, d *DB, token string) {
+	t.Helper()
+	var leaked int
+	err := d.getReader().QueryRow(
+		`SELECT count(*) FROM messages_fts
+		 WHERE messages_fts MATCH ?`,
+		token,
+	).Scan(&leaked)
+	require.NoError(t, err, "fts leak check")
+	assert.Zero(t, leaked, "FTS still contains rows matching %q", token)
+}
 
 func TestInsertAndGetMessage_ThinkingText(t *testing.T) {
 	t.Parallel()
@@ -282,25 +342,9 @@ func TestReplaceSessionMessages_LargeSession(t *testing.T) {
 	d := testDB(t)
 	requireFTS(t, d)
 	const sessionID = "perf-large"
+	const blobToken = "ftsreplxxx"
 	insertSession(t, d, sessionID, "proj")
-
-	const n = 1000
-	msgs := make([]Message, 0, n)
-	for i := range n {
-		msgs = append(msgs, userMsg(sessionID, i, "small"))
-	}
-	// One ~5MB content blob in the middle of the stream — the
-	// pathological case that blew up the per-row FTS delete path.
-	big := strings.Repeat("x ", 5*1024*1024/2)
-	msgs[n/2] = Message{
-		SessionID:     sessionID,
-		Ordinal:       n / 2,
-		Role:          "assistant",
-		Content:       big,
-		ContentLength: len(big),
-		Timestamp:     tsZero,
-	}
-	insertMessages(t, d, msgs...)
+	insertMessages(t, d, largeSessionMessages(sessionID, blobToken)...)
 
 	// Replace with a different small set so the delete path has to
 	// remove all 1000 rows including the 5MB blob.
@@ -312,7 +356,7 @@ func TestReplaceSessionMessages_LargeSession(t *testing.T) {
 	require.NoError(t, d.ReplaceSessionMessages(sessionID, repl),
 		"ReplaceSessionMessages")
 	elapsed := time.Since(start)
-	require.LessOrEqual(t, elapsed, 10*time.Second,
+	require.LessOrEqual(t, elapsed, largeSessionPerfCeiling,
 		"ReplaceSessionMessages took %s, want < 10s (per-row FTS trigger regression?)",
 		elapsed.Round(time.Millisecond))
 
@@ -325,14 +369,61 @@ func TestReplaceSessionMessages_LargeSession(t *testing.T) {
 	// session rows. Should be zero. If the messages_ad trigger
 	// restoration failed silently or the bulk-delete INSERT...SELECT
 	// got skipped, stale tokens would still resolve here.
-	var leaked int
+	assertNoFTSLeak(t, d, blobToken)
+}
+
+func TestWriteSessionBatch_ReplaceMessagesLargeSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping perf test in -short mode")
+	}
+	t.Parallel()
+	d := testDB(t)
+	requireFTS(t, d)
+
+	const targetID = "batch-large"
+	const blobToken = "ftsbatchyyy"
+	insertSession(t, d, targetID, "proj")
+	insertMessages(t, d, largeSessionMessages(targetID, blobToken)...)
+	seedCrossSessionFKGrowth(t, d, "batch-neighbor")
+
+	repl := make([]Message, 0, 10)
+	for i := range 10 {
+		repl = append(repl, userMsg(targetID, i, "after"))
+	}
+	start := time.Now()
+	result, err := d.WriteSessionBatch([]SessionBatchWrite{{
+		Session: Session{
+			ID:               targetID,
+			Project:          "proj",
+			Machine:          defaultMachine,
+			Agent:            defaultAgent,
+			MessageCount:     len(repl),
+			UserMessageCount: len(repl),
+		},
+		Messages:        repl,
+		DataVersion:     CurrentDataVersion(),
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err, "WriteSessionBatch")
+	elapsed := time.Since(start)
+	require.Equal(t, 1, result.WrittenSessions, "WrittenSessions")
+	require.Equal(t, len(repl), result.WrittenMessages, "WrittenMessages")
+	require.LessOrEqual(t, elapsed, largeSessionPerfCeiling,
+		"WriteSessionBatch replace took %s, want < 10s (per-row FTS trigger regression?)",
+		elapsed.Round(time.Millisecond))
+
+	got, err := d.GetAllMessages(context.Background(), targetID)
+	require.NoError(t, err, "GetAllMessages after batch replace")
+	require.Len(t, got, len(repl), "after batch replace")
+	assertNoFTSLeak(t, d, blobToken)
+
+	var neighborToolCalls int
 	err = d.getReader().QueryRow(
-		`SELECT count(*) FROM messages_fts
-		 WHERE messages_fts MATCH 'xxx'`,
-	).Scan(&leaked)
-	require.NoError(t, err, "fts leak check")
-	assert.Zero(t, leaked,
-		"FTS still contains rows matching 'xxx' from deleted blob")
+		"SELECT count(*) FROM tool_calls WHERE session_id = ?",
+		"batch-neighbor",
+	).Scan(&neighborToolCalls)
+	require.NoError(t, err, "neighbor tool_calls count")
+	assert.Equal(t, 2000, neighborToolCalls, "neighbor tool_calls count")
 }
 
 // TestMessageReadsTolerateNullTimestamp pins NULL-timestamp robustness

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -288,30 +288,6 @@ func writeOneSessionBatchTx(
 	return len(msgs), nil
 }
 
-func deleteSessionMessagesTx(tx *sql.Tx, sessionID string) error {
-	if _, err := tx.Exec(
-		"DELETE FROM tool_calls WHERE session_id = ?",
-		sessionID,
-	); err != nil {
-		return fmt.Errorf("deleting old tool_calls: %w", err)
-	}
-	if _, err := tx.Exec(
-		"DELETE FROM tool_result_events WHERE session_id = ?",
-		sessionID,
-	); err != nil {
-		return fmt.Errorf(
-			"deleting old tool_result_events: %w", err,
-		)
-	}
-	if _, err := tx.Exec(
-		"DELETE FROM messages WHERE session_id = ?",
-		sessionID,
-	); err != nil {
-		return fmt.Errorf("deleting old messages: %w", err)
-	}
-	return nil
-}
-
 func maxOrdinalTx(tx *sql.Tx, sessionID string) (int, error) {
 	var n sql.NullInt64
 	err := tx.QueryRow(

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1991,20 +1991,26 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	res, err := tx.Exec(
+		`UPDATE sessions
+		 SET deleted_at = deleted_at
+		 WHERE id = ? AND deleted_at IS NOT NULL`,
+		id,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"locking trashed session %s: %w", id, err,
+		)
+	}
+	locked, _ := res.RowsAffected()
+	if locked == 0 {
+		return 0, nil
+	}
 	aliasIDs, err := sessionAliasIDsTx(
 		tx, "id = ? AND deleted_at IS NOT NULL", id,
 	)
 	if err != nil {
 		return 0, err
-	}
-	ids, err := sessionIDsTx(
-		tx, "id = ? AND deleted_at IS NOT NULL", id,
-	)
-	if err != nil {
-		return 0, err
-	}
-	if len(ids) == 0 {
-		return 0, nil
 	}
 	if err := deleteSessionMessagesTx(tx, id); err != nil {
 		return 0, fmt.Errorf(
@@ -2013,7 +2019,7 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 		)
 	}
 
-	res, err := tx.Exec(
+	res, err = tx.Exec(
 		"DELETE FROM sessions WHERE id = ? AND deleted_at IS NOT NULL",
 		id,
 	)
@@ -2368,6 +2374,14 @@ func (db *DB) EmptyTrash() (int, error) {
 		return 0, fmt.Errorf("begin empty-trash tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(
+		`UPDATE sessions
+		 SET deleted_at = deleted_at
+		 WHERE deleted_at IS NOT NULL`,
+	); err != nil {
+		return 0, fmt.Errorf("locking trashed sessions: %w", err)
+	}
 
 	aliasIDs, err := sessionAliasIDsTx(tx, "deleted_at IS NOT NULL")
 	if err != nil {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1102,10 +1102,32 @@ func (db *DB) HasTrashedSessionByFilePath(path, agent string) bool {
 func (db *DB) PurgeExcludedSessions() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	_, err := db.getWriter().Exec(
-		"DELETE FROM sessions WHERE id IN (SELECT id FROM excluded_sessions)",
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return fmt.Errorf("begin purge excluded tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	ids, err := sessionIDsTx(
+		tx, "id IN (SELECT id FROM excluded_sessions)",
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if err := deleteSessionMessagesTx(tx, id); err != nil {
+			return fmt.Errorf(
+				"pre-deleting excluded session %s messages: %w",
+				id, err,
+			)
+		}
+	}
+	if _, err := tx.Exec(
+		"DELETE FROM sessions WHERE id IN (SELECT id FROM excluded_sessions)",
+	); err != nil {
+		return fmt.Errorf("purging excluded sessions: %w", err)
+	}
+	return tx.Commit()
 }
 
 // DeleteParserExcludedSessions removes rows that the current parser
@@ -1129,6 +1151,12 @@ func (db *DB) DeleteParserExcludedSessions(ids []string) (int, error) {
 	for _, id := range ids {
 		if id == "" {
 			continue
+		}
+		if err := deleteSessionMessagesTx(tx, id); err != nil {
+			return 0, fmt.Errorf(
+				"pre-deleting parser-excluded session %s messages: %w",
+				id, err,
+			)
 		}
 		res, err := tx.Exec(
 			"DELETE FROM sessions WHERE id = ?", id,
@@ -1842,6 +1870,12 @@ func (db *DB) DeleteSession(id string) error {
 	if err != nil {
 		return err
 	}
+	if err := deleteSessionMessagesTx(tx, id); err != nil {
+		return fmt.Errorf(
+			"pre-deleting session %s messages: %w",
+			id, err,
+		)
+	}
 
 	res, err := tx.Exec(
 		"DELETE FROM sessions WHERE id = ?", id,
@@ -1900,6 +1934,30 @@ func sessionAliasIDsTx(tx *sql.Tx, where string, args ...any) ([]string, error) 
 	return aliases, nil
 }
 
+func sessionIDsTx(tx *sql.Tx, where string, args ...any) ([]string, error) {
+	rows, err := tx.Query(
+		"SELECT id FROM sessions WHERE "+where,
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("loading session ids: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning session id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating session ids: %w", err)
+	}
+	return ids, nil
+}
+
 func vibeFallbackAliasID(id, agent string, filePath sql.NullString) string {
 	if agent != "vibe" || !filePath.Valid || filePath.String == "" {
 		return ""
@@ -1939,8 +1997,22 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+	ids, err := sessionIDsTx(
+		tx, "id = ? AND deleted_at IS NOT NULL", id,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	if err := deleteSessionMessagesTx(tx, id); err != nil {
+		return 0, fmt.Errorf(
+			"pre-deleting trashed session %s messages: %w",
+			id, err,
+		)
+	}
 
-	// Only delete if the session is currently trashed.
 	res, err := tx.Exec(
 		"DELETE FROM sessions WHERE id = ? AND deleted_at IS NOT NULL",
 		id,
@@ -1949,9 +2021,6 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 		return 0, fmt.Errorf("deleting trashed session %s: %w", id, err)
 	}
 	n, _ := res.RowsAffected()
-	if n == 0 {
-		return 0, nil
-	}
 
 	// Record in exclusion list so sync doesn't re-import.
 	if err := excludeSessionIDTx(tx, id); err != nil {
@@ -2304,6 +2373,10 @@ func (db *DB) EmptyTrash() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	ids, err := sessionIDsTx(tx, "deleted_at IS NOT NULL")
+	if err != nil {
+		return 0, err
+	}
 
 	// Record all trashed session IDs before deleting.
 	if _, err := tx.Exec(
@@ -2316,6 +2389,14 @@ func (db *DB) EmptyTrash() (int, error) {
 		if err := excludeSessionIDTx(tx, aliasID); err != nil {
 			return 0, fmt.Errorf(
 				"excluding trashed session alias %s: %w", aliasID, err,
+			)
+		}
+	}
+	for _, id := range ids {
+		if err := deleteSessionMessagesTx(tx, id); err != nil {
+			return 0, fmt.Errorf(
+				"pre-deleting trashed session %s messages: %w",
+				id, err,
 			)
 		}
 	}
@@ -2382,6 +2463,14 @@ func (db *DB) DeleteSessions(ids []string) (int, error) {
 			if err := excludeSessionIDTx(tx, aliasID); err != nil {
 				return 0, fmt.Errorf(
 					"excluding batch session alias %s: %w", aliasID, err,
+				)
+			}
+		}
+		for _, id := range batch {
+			if err := deleteSessionMessagesTx(tx, id); err != nil {
+				return 0, fmt.Errorf(
+					"pre-deleting batch session %s messages: %w",
+					id, err,
 				)
 			}
 		}

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -22,6 +22,7 @@ func TestDeleteSession_LargeSessionFTSDelete(t *testing.T) {
 	insertSession(t, d, targetID, "proj")
 	insertMessages(t, d, largeSessionMessages(targetID, blobToken)...)
 	seedCrossSessionFKGrowth(t, d, "delete-neighbor")
+	poisonMessagesDeleteTrigger(t, d)
 
 	start := time.Now()
 	require.NoError(t, d.DeleteSession(targetID), "DeleteSession")
@@ -32,14 +33,16 @@ func TestDeleteSession_LargeSessionFTSDelete(t *testing.T) {
 
 	requireSessionGone(t, d, targetID)
 	assertNoFTSLeak(t, d, blobToken)
+	requireMessagesDeleteTriggerRestored(t, d)
 
 	var neighborPins int
 	err := d.getReader().QueryRow(
-		"SELECT count(*) FROM pinned_messages WHERE session_id = ?",
-		"delete-neighbor",
+		"SELECT count(*) FROM pinned_messages WHERE session_id LIKE ?",
+		"delete-neighbor-%",
 	).Scan(&neighborPins)
 	require.NoError(t, err, "neighbor pins count")
-	assert.Equal(t, 1, neighborPins, "neighbor pins count")
+	assert.Equal(t, crossSessionNeighborCount, neighborPins,
+		"neighbor pins count")
 }
 
 func TestFindSessionIDsByPartial(t *testing.T) {

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -9,6 +9,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDeleteSession_LargeSessionFTSDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping perf test in -short mode")
+	}
+	t.Parallel()
+	d := testDB(t)
+	requireFTS(t, d)
+
+	const targetID = "delete-large"
+	const blobToken = "ftsdeletezzz"
+	insertSession(t, d, targetID, "proj")
+	insertMessages(t, d, largeSessionMessages(targetID, blobToken)...)
+	seedCrossSessionFKGrowth(t, d, "delete-neighbor")
+
+	start := time.Now()
+	require.NoError(t, d.DeleteSession(targetID), "DeleteSession")
+	elapsed := time.Since(start)
+	require.LessOrEqual(t, elapsed, largeSessionPerfCeiling,
+		"DeleteSession took %s, want < 10s (per-row FTS trigger regression?)",
+		elapsed.Round(time.Millisecond))
+
+	requireSessionGone(t, d, targetID)
+	assertNoFTSLeak(t, d, blobToken)
+
+	var neighborPins int
+	err := d.getReader().QueryRow(
+		"SELECT count(*) FROM pinned_messages WHERE session_id = ?",
+		"delete-neighbor",
+	).Scan(&neighborPins)
+	require.NoError(t, err, "neighbor pins count")
+	assert.Equal(t, 1, neighborPins, "neighbor pins count")
+}
+
 func TestFindSessionIDsByPartial(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "abcdef-1111-2222", "proj")


### PR DESCRIPTION
## Summary
- Extract the session-scoped FTS-safe delete sequence from `ReplaceSessionMessages` and reuse it in the remaining live large-session delete paths.
- Route `WriteSessionBatch` replace mode and the direct session-delete helpers through that shared helper, and lock trashed-session candidates before message pre-delete so restore races cannot strand live sessions without messages.
- Add focused regressions that poison `messages_ad` and seed cross-session child-row growth, so the remaining delete paths now fail on `upstream/main` and pass on this branch.

## Scope
- No schema changes; the FK-supporting indexes from `#359` stay as they are.
- Keeps SQLite and PostgreSQL behavior aligned by confining the FTS-specific logic to the existing SQLite guard path.
- Leaves the suggested schema audit and `agentsview doctor` diagnostics out of this PR so the target stays on the live delete surfaces.

## Review Notes
- Start with `internal/db/messages.go`, where the reusable helper now owns the single FTS bulk-delete and trigger-drop or restore sequence.
- Then review `internal/db/session_batch.go` and `internal/db/sessions.go`, where batch replace and the direct session-delete paths are rerouted through that helper without changing exclusion-list semantics.
- The trashed-session flows in `internal/db/sessions.go` now take their conditional write lock before message pre-delete, so `DeleteSessionIfTrashed` and `EmptyTrash` keep their old atomicity while using the shared helper.
- Focused validation:
  - `CGO_ENABLED=1 go test -tags "fts5,kit_posthog_disabled" ./internal/db -run "Test(ReplaceSessionMessages_LargeSession|WriteSessionBatch_ReplaceMessagesLargeSession|DeleteSession_LargeSessionFTSDelete|DeleteSessionIfTrashed|DeleteSession|DeleteSessions|DeleteSessionNonExistentNoGhostExclusion|DeleteSessionsMixedBatchNoGhostExclusion|EmptyTrashExcludes|WriteSessionBatchCommitsGoodRowsAndSkipsBadRows)" -count=1`
  - `go vet ./internal/db/...`

Fixes #360
