### PR TITLE
feat(session list): resume table and --resume/--active mode

### DIFF
--- a/cmd/agentsview/session_list.go
+++ b/cmd/agentsview/session_list.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/db"
@@ -28,6 +31,7 @@ func newSessionListCommand() *cobra.Command {
 		limit                                   int
 		sort                                    string
 		reverse                                 bool
+		resume, active                          bool
 	)
 	cmd := &cobra.Command{
 		Use:          "list",
@@ -65,6 +69,17 @@ func newSessionListCommand() *cobra.Command {
 			if cmd.Flags().Changed("min-tool-failures") {
 				f.MinToolFailures = &minToolFailures
 			}
+			// --resume / --active surface only recently-active sessions for
+			// quick relaunch: push a now-15m active_since window to the
+			// service so the limit is applied after the filter, and let the
+			// default recent sort keep newest-first ordering. An explicit
+			// --active-since takes precedence so callers can widen or narrow
+			// the window.
+			now := time.Now()
+			if (resume || active) && !cmd.Flags().Changed("active-since") {
+				f.ActiveSince = now.Add(-resumeActiveWindow).
+					UTC().Format(time.RFC3339)
+			}
 			// Parse the multi-key sort spec; --reverse flips the natural
 			// direction of any term left without an explicit :asc/:desc, which
 			// is folded into the canonical spec string so the wire form fully
@@ -95,7 +110,9 @@ func newSessionListCommand() *cobra.Command {
 			if outputFormat(cmd) == "json" {
 				return json.NewEncoder(cmd.OutOrStdout()).Encode(list)
 			}
-			return printSessionListHuman(cmd.OutOrStdout(), list)
+			home, _ := os.UserHomeDir()
+			return printSessionListHuman(
+				cmd.OutOrStdout(), list, now, home)
 		},
 	}
 
@@ -150,32 +167,56 @@ func newSessionListCommand() *cobra.Command {
 	flags.BoolVarP(&reverse, "reverse", "r", false,
 		"Reverse the natural direction of sort keys that have no explicit "+
 			":asc/:desc suffix")
+	flags.BoolVar(&resume, "resume", false,
+		fmt.Sprintf("Show only sessions active within the last %d minutes, "+
+			"newest first, for quick resume",
+			int(resumeActiveWindow.Minutes())))
+	flags.BoolVar(&active, "active", false,
+		"Alias for --resume")
 
 	return cmd
 }
 
-// printSessionListHuman writes a compact columnar summary of the
-// session list, with a trailing hint when another page is
-// available. Prints "(no sessions)" for empty lists.
+// sessionNameWidth caps the NAME column so a long first message can't
+// push the trailing CWD column off the right edge of the terminal.
+const sessionNameWidth = 44
+
+// printSessionListHuman writes a resume-oriented table of the session
+// list: an in-flight marker for recently-active sessions, the humanized
+// AGE since last activity, AGENT, PROJECT, BRANCH, MSGS, NAME, and a
+// ~-collapsed CWD. now and home are passed in so output is deterministic
+// under test. A trailing hint is printed when another page is available.
+// Prints "(no sessions)" for empty lists. Every session-derived string is
+// run through sanitizeTerminal so untrusted DB rows cannot drive terminal
+// escape sequences.
 func printSessionListHuman(
-	w io.Writer, list *service.SessionList,
+	w io.Writer, list *service.SessionList, now time.Time, home string,
 ) error {
 	if len(list.Sessions) == 0 {
 		fmt.Fprintln(w, "(no sessions)")
 		return nil
 	}
-	fmt.Fprintf(w, "%-40s  %-20s  %-15s  %s\n",
-		"ID", "PROJECT", "AGENT", "STARTED")
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "\tAGE\tAGENT\tPROJECT\tBRANCH\tMSGS\tNAME\tCWD")
 	for _, s := range list.Sessions {
-		started := "-"
-		if s.StartedAt != nil && len(*s.StartedAt) >= 16 {
-			started = (*s.StartedAt)[:16]
+		marker := ""
+		if isSessionRecentlyActive(s, now) {
+			marker = activeMarker
 		}
-		fmt.Fprintf(w, "%-40s  %-20s  %-15s  %s\n",
-			sanitizeTerminal(s.ID),
-			sanitizeTerminal(s.Project),
-			sanitizeTerminal(s.Agent),
-			sanitizeTerminal(started))
+		name := truncName(sessionDisplayName(s), sessionNameWidth)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+			marker,
+			humanizeSessionAge(s, now),
+			sanitizeTerminal(orEmDash(s.Agent)),
+			sanitizeTerminal(orEmDash(s.Project)),
+			sanitizeTerminal(orEmDash(s.GitBranch)),
+			s.MessageCount,
+			sanitizeTerminal(name),
+			sanitizeTerminal(collapseHome(s.Cwd, home)),
+		)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
 	}
 	if list.NextCursor != "" {
 		// Cursor is an opaque server-minted string. Sanitize too

--- a/cmd/agentsview/session_list.go
+++ b/cmd/agentsview/session_list.go
@@ -182,13 +182,14 @@ func newSessionListCommand() *cobra.Command {
 const sessionNameWidth = 44
 
 // printSessionListHuman writes a resume-oriented table of the session
-// list: an in-flight marker for recently-active sessions, the humanized
-// AGE since last activity, AGENT, PROJECT, BRANCH, MSGS, NAME, and a
-// ~-collapsed CWD. now and home are passed in so output is deterministic
-// under test. A trailing hint is printed when another page is available.
-// Prints "(no sessions)" for empty lists. Every session-derived string is
-// run through sanitizeTerminal so untrusted DB rows cannot drive terminal
-// escape sequences.
+// list: an in-flight marker for recently-active sessions, the full session
+// ID (the copyable handle for `session get`/`messages`/`usage`), the
+// humanized AGE since last activity, AGENT, PROJECT, BRANCH, MSGS, NAME,
+// and a ~-collapsed CWD. now and home are passed in so output is
+// deterministic under test. A trailing hint is printed when another page is
+// available. Prints "(no sessions)" for empty lists. Every session-derived
+// string is run through sanitizeTerminal so untrusted DB rows cannot drive
+// terminal escape sequences.
 func printSessionListHuman(
 	w io.Writer, list *service.SessionList, now time.Time, home string,
 ) error {
@@ -197,15 +198,16 @@ func printSessionListHuman(
 		return nil
 	}
 	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(tw, "\tAGE\tAGENT\tPROJECT\tBRANCH\tMSGS\tNAME\tCWD")
+	fmt.Fprintln(tw, "\tID\tAGE\tAGENT\tPROJECT\tBRANCH\tMSGS\tNAME\tCWD")
 	for _, s := range list.Sessions {
 		marker := ""
 		if isSessionRecentlyActive(s, now) {
 			marker = activeMarker
 		}
 		name := truncName(sessionDisplayName(s), sessionNameWidth)
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
 			marker,
+			sanitizeTerminal(s.ID),
 			humanizeSessionAge(s, now),
 			sanitizeTerminal(orEmDash(s.Agent)),
 			sanitizeTerminal(orEmDash(s.Project)),

--- a/cmd/agentsview/session_list_render.go
+++ b/cmd/agentsview/session_list_render.go
@@ -23,8 +23,11 @@ const resumeActiveWindow = 15 * time.Minute
 const activeMarker = "●"
 
 // sessionActivityTime returns a session's last-activity time: EndedAt if
-// present and parseable, else StartedAt, else the zero time. Timestamps are
-// stored as RFC3339/RFC3339Nano strings, so both layouts are accepted.
+// present and parseable, else StartedAt, else CreatedAt, else the zero time.
+// Timestamps are stored as RFC3339/RFC3339Nano strings, so both layouts are
+// accepted. CreatedAt is the final fallback so AGE and the in-flight marker
+// agree with the backend active_since filter and recent sort, which fall back
+// to COALESCE(ended_at, started_at, created_at).
 func sessionActivityTime(s db.Session) time.Time {
 	for _, ts := range []*string{s.EndedAt, s.StartedAt} {
 		if ts == nil {
@@ -33,6 +36,9 @@ func sessionActivityTime(s db.Session) time.Time {
 		if t, ok := parseSessionTime(*ts); ok {
 			return t
 		}
+	}
+	if t, ok := parseSessionTime(s.CreatedAt); ok {
+		return t
 	}
 	return time.Time{}
 }

--- a/cmd/agentsview/session_list_render.go
+++ b/cmd/agentsview/session_list_render.go
@@ -1,6 +1,7 @@
 // ABOUTME: human-mode rendering helpers for `session list` — the
-// ABOUTME: resume-oriented table (AGE, in-flight marker, BRANCH, MSGS,
-// ABOUTME: NAME, ~-collapsed CWD) and the field formatters it relies on.
+// ABOUTME: resume-oriented table (in-flight marker, ID, AGE, AGENT,
+// ABOUTME: PROJECT, BRANCH, MSGS, NAME, ~-collapsed CWD) and the field
+// ABOUTME: formatters it relies on.
 package main
 
 import (

--- a/cmd/agentsview/session_list_render.go
+++ b/cmd/agentsview/session_list_render.go
@@ -1,0 +1,159 @@
+// ABOUTME: human-mode rendering helpers for `session list` — the
+// ABOUTME: resume-oriented table (AGE, in-flight marker, BRANCH, MSGS,
+// ABOUTME: NAME, ~-collapsed CWD) and the field formatters it relies on.
+package main
+
+import (
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// resumeActiveWindow flags a session as in-flight when its last activity
+// is within this window of now. It mirrors agentsview-mcp's activeWindow:
+// recent activity means the session is resumable right now, so it gets the
+// in-flight marker and `--resume`/`--active` surface it.
+const resumeActiveWindow = 15 * time.Minute
+
+// activeMarker is the in-flight dot rendered for recently-active sessions.
+const activeMarker = "●"
+
+// sessionActivityTime returns a session's last-activity time: EndedAt if
+// present and parseable, else StartedAt, else the zero time. Timestamps are
+// stored as RFC3339/RFC3339Nano strings, so both layouts are accepted.
+func sessionActivityTime(s db.Session) time.Time {
+	for _, ts := range []*string{s.EndedAt, s.StartedAt} {
+		if ts == nil {
+			continue
+		}
+		if t, ok := parseSessionTime(*ts); ok {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// parseSessionTime parses an RFC3339 or RFC3339Nano timestamp.
+func parseSessionTime(s string) (time.Time, bool) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// isSessionRecentlyActive reports whether the session's last activity is
+// within resumeActiveWindow of now. A timestamp slightly in the future
+// (clock skew, or a live session whose last activity is momentarily ahead
+// of our clock) counts as active, matching the "now" label humanizeAge
+// gives it.
+func isSessionRecentlyActive(s db.Session, now time.Time) bool {
+	t := sessionActivityTime(s)
+	if t.IsZero() {
+		return false
+	}
+	return now.Sub(t) < resumeActiveWindow
+}
+
+// humanizeSessionAge renders a session's last-activity time relative to
+// now: seconds/minutes/hours/days for the recent past, an absolute month
+// and day beyond a week, and an em dash when no timestamp is available.
+func humanizeSessionAge(s db.Session, now time.Time) string {
+	t := sessionActivityTime(s)
+	if t.IsZero() {
+		return emDash
+	}
+	d := now.Sub(t)
+	switch {
+	case d < 0:
+		return "now"
+	case d < time.Minute:
+		return strconv.Itoa(int(d.Seconds())) + "s"
+	case d < time.Hour:
+		return strconv.Itoa(int(d.Minutes())) + "m"
+	case d < 24*time.Hour:
+		return strconv.Itoa(int(d.Hours())) + "h"
+	case d < 7*24*time.Hour:
+		return strconv.Itoa(int(d/(24*time.Hour))) + "d"
+	default:
+		return t.Format("Jan 02")
+	}
+}
+
+// sessionDisplayName is the session's human label: DisplayName when set,
+// otherwise the first message.
+func sessionDisplayName(s db.Session) string {
+	if s.DisplayName != nil && *s.DisplayName != "" {
+		return *s.DisplayName
+	}
+	if s.FirstMessage != nil {
+		return *s.FirstMessage
+	}
+	return ""
+}
+
+// emDash stands in for empty optional fields (codex sessions have no cwd
+// or branch) so a column reads as intentionally-absent, not blank.
+const emDash = "—"
+
+// orEmDash returns s, or an em dash when s is blank.
+func orEmDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return emDash
+	}
+	return s
+}
+
+// collapseHome rewrites a home-prefixed cwd to ~ form for a compact,
+// relaunch-friendly path. A blank cwd becomes an em dash.
+func collapseHome(cwd, home string) string {
+	if strings.TrimSpace(cwd) == "" {
+		return emDash
+	}
+	if home != "" {
+		if cwd == home {
+			return "~"
+		}
+		if strings.HasPrefix(cwd, home+"/") {
+			return "~" + cwd[len(home):]
+		}
+	}
+	return cwd
+}
+
+// truncName collapses internal whitespace and trims to max runes, adding
+// an ellipsis when it cut anything.
+func truncName(s string, max int) string {
+	t, cut := truncateRunes(collapseWhitespace(s), max)
+	if cut {
+		return t + "…"
+	}
+	return t
+}
+
+// collapseWhitespace folds runs of whitespace (including newlines) into a
+// single space so a multi-line first message stays on one table row.
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// truncateRunes cuts s to at most max runes on a rune boundary, returning
+// the (possibly shortened) string and whether truncation occurred.
+func truncateRunes(s string, max int) (string, bool) {
+	if max <= 0 || utf8.RuneCountInString(s) <= max {
+		return s, false
+	}
+	n := 0
+	for i := range s {
+		if n == max {
+			return s[:i], true
+		}
+		n++
+	}
+	return s, false
+}

--- a/cmd/agentsview/session_list_render_test.go
+++ b/cmd/agentsview/session_list_render_test.go
@@ -193,9 +193,15 @@ func TestPrintSessionListHuman(t *testing.T) {
 		&out, listFixture(home), renderNow, home))
 	s := out.String()
 
-	// Header carries the enriched columns.
-	for _, col := range []string{"AGE", "AGENT", "PROJECT", "BRANCH", "MSGS", "NAME", "CWD"} {
+	// Header carries the enriched columns, with ID restored as the first
+	// data column so every row has a copyable handle.
+	for _, col := range []string{"ID", "AGE", "AGENT", "PROJECT", "BRANCH", "MSGS", "NAME", "CWD"} {
 		assert.Contains(t, s, col)
+	}
+
+	// Every row carries its full, untruncated session ID.
+	for _, id := range []string{"s_live", "s_codex", "s_old"} {
+		assert.Contains(t, s, id)
 	}
 
 	// The live session (1m ago) is flagged in-flight; the codex session

--- a/cmd/agentsview/session_list_render_test.go
+++ b/cmd/agentsview/session_list_render_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
+)
+
+// renderNow is the reference clock the table tests render against.
+var renderNow = time.Date(2026, 6, 19, 23, 18, 0, 0, time.UTC)
+
+func TestHumanizeSessionAge(t *testing.T) {
+	t.Parallel()
+	mk := func(d time.Duration) db.Session {
+		return db.Session{EndedAt: new(renderNow.Add(-d).Format(time.RFC3339))}
+	}
+	tests := []struct {
+		name string
+		sess db.Session
+		want string
+	}{
+		{"seconds", mk(30 * time.Second), "30s"},
+		{"minutes", mk(5 * time.Minute), "5m"},
+		{"hours", mk(3 * time.Hour), "3h"},
+		{"days", mk(2 * 24 * time.Hour), "2d"},
+		{
+			"absolute beyond a week",
+			db.Session{EndedAt: new("2026-01-02T08:00:00Z")},
+			"Jan 02",
+		},
+		{"no timestamp", db.Session{}, emDash},
+		{
+			"falls back to started_at",
+			db.Session{StartedAt: new("2026-06-19T23:10:00Z")},
+			"8m",
+		},
+		{
+			"future clock skew reads as now",
+			db.Session{EndedAt: new(renderNow.Add(5 * time.Second).Format(time.RFC3339))},
+			"now",
+		},
+		{
+			"RFC3339Nano timestamp parses",
+			db.Session{EndedAt: new(renderNow.Add(-time.Hour).Format(time.RFC3339Nano))},
+			"1h",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, humanizeSessionAge(tc.sess, renderNow))
+		})
+	}
+}
+
+func TestIsSessionRecentlyActive(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		sess db.Session
+		want bool
+	}{
+		{
+			"just now",
+			db.Session{EndedAt: new(renderNow.Add(-time.Minute).Format(time.RFC3339))},
+			true,
+		},
+		{
+			"future clock skew counts as active",
+			db.Session{EndedAt: new(renderNow.Add(5 * time.Second).Format(time.RFC3339))},
+			true,
+		},
+		{
+			"beyond the window",
+			db.Session{EndedAt: new(renderNow.Add(-30 * time.Minute).Format(time.RFC3339))},
+			false,
+		},
+		{"no timestamp", db.Session{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isSessionRecentlyActive(tc.sess, renderNow))
+		})
+	}
+}
+
+func TestCollapseHome(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, cwd, home, want string
+	}{
+		{"under home", "/home/u/p", "/home/u", "~/p"},
+		{"exactly home", "/home/u", "/home/u", "~"},
+		{"outside home", "/other/p", "/home/u", "/other/p"},
+		{"empty becomes em dash", "", "/home/u", emDash},
+		{"shared prefix only is not collapsed", "/home/user2/p", "/home/u", "/home/user2/p"},
+		{"empty home left intact", "/srv/app", "", "/srv/app"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, collapseHome(tc.cwd, tc.home))
+		})
+	}
+}
+
+func TestTruncName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, in string
+		max      int
+		want     string
+	}{
+		{"short kept", "hello", 10, "hello"},
+		{"truncated with ellipsis", "abcdefghij", 5, "abcde…"},
+		{"whitespace collapsed", "a  b\nc", 10, "a b c"},
+		{"multibyte boundary", "héllo wörld", 5, "héllo…"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, truncName(tc.in, tc.max))
+		})
+	}
+}
+
+func TestSessionDisplayName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "display", sessionDisplayName(db.Session{
+		DisplayName: new("display"), FirstMessage: new("first"),
+	}))
+	assert.Equal(t, "first", sessionDisplayName(db.Session{
+		FirstMessage: new("first"),
+	}))
+	assert.Equal(t, "", sessionDisplayName(db.Session{}))
+	// An empty display name falls through to the first message.
+	assert.Equal(t, "first", sessionDisplayName(db.Session{
+		DisplayName: new(""), FirstMessage: new("first"),
+	}))
+}
+
+func TestOrEmDash(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "main", orEmDash("main"))
+	assert.Equal(t, emDash, orEmDash(""))
+	assert.Equal(t, emDash, orEmDash("   "))
+}
+
+// listFixture builds a SessionList with a live claude session, an older one
+// in the home dir, and a codex session that (like real codex rows) has no
+// cwd or branch.
+func listFixture(home string) *service.SessionList {
+	return &service.SessionList{
+		Total: 619,
+		Sessions: []db.Session{
+			{
+				ID: "s_live", Project: "monitoring", Agent: "claude",
+				GitBranch:    "main",
+				FirstMessage: new("build monitoring dashboards\nfor the homelab"),
+				MessageCount: 87,
+				StartedAt:    new("2026-06-19T23:00:00Z"),
+				EndedAt:      new("2026-06-19T23:17:00Z"),
+				Cwd:          "/srv/monitoring",
+			},
+			{
+				ID: "s_codex", Project: "agentsview", Agent: "codex",
+				FirstMessage: new("You are a code reviewer"),
+				MessageCount: 28,
+				StartedAt:    new("2026-06-19T22:00:00Z"),
+				EndedAt:      new("2026-06-19T22:00:23Z"),
+			},
+			{
+				ID: "s_old", Project: "vault", Agent: "claude",
+				GitBranch:    "main",
+				FirstMessage: new("refactor vault notes"),
+				MessageCount: 26,
+				StartedAt:    new("2026-06-19T19:50:00Z"),
+				EndedAt:      new("2026-06-19T20:10:00Z"),
+				Cwd:          home + "/vault",
+			},
+		},
+	}
+}
+
+func TestPrintSessionListHuman(t *testing.T) {
+	t.Parallel()
+	const home = "/home/u"
+	var out bytes.Buffer
+	require.NoError(t, printSessionListHuman(
+		&out, listFixture(home), renderNow, home))
+	s := out.String()
+
+	// Header carries the enriched columns.
+	for _, col := range []string{"AGE", "AGENT", "PROJECT", "BRANCH", "MSGS", "NAME", "CWD"} {
+		assert.Contains(t, s, col)
+	}
+
+	// The live session (1m ago) is flagged in-flight; the codex session
+	// (~78m ago) and old session (~3h ago) are not.
+	assert.Contains(t, s, activeMarker)
+	assert.Equal(t, 1, strings.Count(s, activeMarker), "only the live row is in-flight")
+	assert.Contains(t, s, "1m") // 23:18 - 23:17
+
+	// Missing codex cwd/branch render as an em dash, not blank.
+	assert.Contains(t, s, emDash)
+
+	// Home-prefixed cwd collapses to ~; the newline in a name is collapsed.
+	assert.Contains(t, s, "~/vault")
+	assert.Contains(t, s, "build monitoring dashboards for the homelab")
+
+	// Message counts are present.
+	assert.Contains(t, s, "87")
+
+	// Footer hint only appears when there is a next page.
+	assert.NotContains(t, s, "--cursor")
+}
+
+func TestPrintSessionListHumanNextCursor(t *testing.T) {
+	t.Parallel()
+	list := listFixture("/home/u")
+	list.NextCursor = "opaque-token"
+	var out bytes.Buffer
+	require.NoError(t, printSessionListHuman(&out, list, renderNow, "/home/u"))
+	assert.Contains(t, out.String(), "More results: --cursor opaque-token")
+}
+
+func TestPrintSessionListHumanEmpty(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	require.NoError(t, printSessionListHuman(
+		&out, &service.SessionList{}, renderNow, "/home/u"))
+	assert.Equal(t, "(no sessions)\n", out.String())
+}
+
+func TestPrintSessionListHumanSanitizesUntrustedFields(t *testing.T) {
+	t.Parallel()
+	list := &service.SessionList{
+		Sessions: []db.Session{{
+			ID: "s1", Project: "p", Agent: "claude",
+			GitBranch:    "ma\x1bin",
+			FirstMessage: new("hi\x1b[31m there"),
+			Cwd:          "/srv\x07/app",
+		}},
+	}
+	var out bytes.Buffer
+	require.NoError(t, printSessionListHuman(&out, list, renderNow, "/home/u"))
+	s := out.String()
+	assert.NotContains(t, s, "\x1b")
+	assert.NotContains(t, s, "\x07")
+	assert.Contains(t, s, "main")
+	assert.Contains(t, s, "/srv/app")
+}

--- a/cmd/agentsview/session_list_render_test.go
+++ b/cmd/agentsview/session_list_render_test.go
@@ -89,6 +89,28 @@ func TestIsSessionRecentlyActive(t *testing.T) {
 	}
 }
 
+func TestSessionActivityTimeCreatedAtFallback(t *testing.T) {
+	t.Parallel()
+	// A session with only created_at (no ended_at/started_at) can be
+	// returned by --resume because the backend active_since filter falls
+	// back to created_at; AGE/the marker must agree by using it too.
+	created := renderNow.Add(-2 * time.Minute)
+	s := db.Session{CreatedAt: created.Format(time.RFC3339)}
+	got := sessionActivityTime(s)
+	assert.False(t, got.IsZero(), "created_at must be the final fallback")
+	assert.WithinDuration(t, created, got, time.Second)
+	assert.True(t, isSessionRecentlyActive(s, renderNow),
+		"a recently-created session must render as active for --resume")
+
+	// ended_at still takes precedence over created_at.
+	ended := renderNow.Add(-time.Minute)
+	s2 := db.Session{
+		EndedAt:   new(ended.Format(time.RFC3339)),
+		CreatedAt: renderNow.Add(-time.Hour).Format(time.RFC3339),
+	}
+	assert.WithinDuration(t, ended, sessionActivityTime(s2), time.Second)
+}
+
 func TestCollapseHome(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/agentsview/session_list_resume_test.go
+++ b/cmd/agentsview/session_list_resume_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// seedActivity seeds a session whose last activity (ended_at) is `ago`
+// before now, so the --resume/--active window can be exercised against a
+// real clock. user_message_count stays >= 2 to clear the default
+// one-shot filter.
+func seedActivity(t *testing.T, dataDir, id string, ago time.Duration) {
+	t.Helper()
+	ts := time.Now().Add(-ago).UTC().Format(time.RFC3339)
+	seedSessionWithOpts(t, dataDir, id, "p", func(s *db.Session) {
+		s.StartedAt = new(ts)
+		s.EndedAt = new(ts)
+	})
+}
+
+func TestSessionList_ResumeFiltersToActiveWindow(t *testing.T) {
+	for _, flag := range []string{"--resume", "--active"} {
+		t.Run(flag, func(t *testing.T) {
+			dataDir := t.TempDir()
+			t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+			seedActivity(t, dataDir, "fresh", 2*time.Minute)
+			seedActivity(t, dataDir, "stale", 2*time.Hour)
+
+			out, err := executeCommand(newRootCommand(),
+				"session", "list", flag, "--format", "json")
+			require.NoError(t, err)
+
+			// Only the session inside the 15m window survives, newest first.
+			assert.Equal(t, []string{"fresh"}, sessionListIDs(t, out))
+		})
+	}
+}
+
+func TestSessionList_NoResumeShowsAll(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedActivity(t, dataDir, "fresh", 2*time.Minute)
+	seedActivity(t, dataDir, "stale", 2*time.Hour)
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--format", "json")
+	require.NoError(t, err)
+
+	// Without --resume both sessions are listed (recency order).
+	assert.Equal(t, []string{"fresh", "stale"}, sessionListIDs(t, out))
+}
+
+// TestSessionList_ResumeRespectsExplicitActiveSince guards that an explicit
+// --active-since is not clobbered by --resume: the caller can widen the
+// window to include older sessions.
+func TestSessionList_ResumeRespectsExplicitActiveSince(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedActivity(t, dataDir, "fresh", 2*time.Minute)
+	seedActivity(t, dataDir, "stale", 2*time.Hour)
+
+	wide := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+	out, err := executeCommand(newRootCommand(),
+		"session", "list", "--resume", "--active-since", wide, "--format", "json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"fresh", "stale"}, sessionListIDs(t, out))
+}
+
+func TestSessionList_ResumeHumanOutput(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	seedActivity(t, dataDir, "fresh", 2*time.Minute)
+	seedActivity(t, dataDir, "stale", 2*time.Hour)
+
+	out, err := executeCommand(newRootCommand(), "session", "list", "--resume")
+	require.NoError(t, err)
+	// Enriched human header is present and the in-flight marker is shown
+	// for the recently-active row.
+	assert.Contains(t, out, "AGE")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, activeMarker)
+	assert.NotContains(t, out, "stale")
+}

--- a/cmd/agentsview/session_list_resume_test.go
+++ b/cmd/agentsview/session_list_resume_test.go
@@ -80,9 +80,12 @@ func TestSessionList_ResumeHumanOutput(t *testing.T) {
 	out, err := executeCommand(newRootCommand(), "session", "list", "--resume")
 	require.NoError(t, err)
 	// Enriched human header is present and the in-flight marker is shown
-	// for the recently-active row.
+	// for the recently-active row. The ID column keeps a copyable handle
+	// for the surfaced session.
+	assert.Contains(t, out, "ID")
 	assert.Contains(t, out, "AGE")
 	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "fresh")
 	assert.Contains(t, out, activeMarker)
 	assert.NotContains(t, out, "stale")
 }


### PR DESCRIPTION
Enriches the `agentsview session list` human output into a resume-oriented table and adds a `--resume` mode (with `--active` as an alias).

## What it does

The human table now shows an in-flight marker, a humanized AGE (last activity), and AGENT / PROJECT / BRANCH / MSGS / NAME / `~`-collapsed CWD, rendered via the new `cmd/agentsview/session_list_render.go`. `--resume` / `--active` set `ListFilter.ActiveSince` to now−15m so the service applies the active window before the limit, surfacing recently-active sessions for quick resume.

## Notes

Built on the existing `--sort` / `--reverse` scaffolding and reuses the data already returned by `svc.List` (no new queries, columns, or indexes), so backend behavior is unchanged across SQLite/PostgreSQL/DuckDB. Every untrusted field is run through `sanitizeTerminal`; the JSON/machine output path is untouched. The renderer was ported from a standalone `agentsview-mcp` CLI that prototyped this view.

Reviewers: `cmd/agentsview/session_list.go` (flag wiring) and `cmd/agentsview/session_list_render.go` (rendering helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qDj5kCrsxw1RgpLiLaZka
