### PR TITLE
feat(parse-diff): classify live-write skew as raced, not changed

### DIFF
--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -299,6 +299,7 @@ func renderParseDiffReport(
 	renderParseDiffFieldCounts(w, r.FieldCounts)
 	renderParseDiffParseErrors(w, r.Sessions)
 	renderParseDiffChanged(w, r.Sessions, verbose)
+	renderParseDiffRaced(w, r.Sessions, verbose)
 	if verbose {
 		renderParseDiffPendingResync(w, r.Sessions)
 	}
@@ -379,6 +380,8 @@ func renderParseDiffSummary(w io.Writer, t sync.ParseDiffTotals) {
 		"(no stored row; sync would add them)")
 	line("Skipped", t.Skipped,
 		"(source not re-parsed: missing, remote, trashed, or not sampled)")
+	line("Raced", t.Raced,
+		"(source changed mid-run; inconclusive, not counted as drift)")
 	line("Excluded by parser", t.ExcludedByParser,
 		"(parser intentionally drops these; sync would delete them)")
 	line("Parse errors", t.ParseErrors,
@@ -442,6 +445,53 @@ func renderParseDiffChanged(
 	}
 	tw.Flush()
 	if extra := len(changed) - len(shown); extra > 0 {
+		fmt.Fprintf(w, "  ... (%d more; use --verbose or --json)\n",
+			extra)
+	}
+	fmt.Fprintln(w)
+}
+
+// renderParseDiffRaced lists sessions whose would-be change was
+// reclassified as a live-write skew: the on-disk source advanced past
+// the snapshot mtime, so the change is a torn comparison rather than
+// parser drift. These never trip --fail-on-change, but surfacing them
+// tells the operator a comparison was inconclusive and the run should
+// be repeated against a quiescent archive. Compact by default; verbose
+// shows the masked field diffs.
+func renderParseDiffRaced(
+	w io.Writer, sessions []sync.SessionDiff, verbose bool,
+) {
+	var raced []sync.SessionDiff
+	for _, s := range sessions {
+		if s.Class == sync.DiffRaced {
+			raced = append(raced, s)
+		}
+	}
+	if len(raced) == 0 {
+		return
+	}
+	fmt.Fprintln(w,
+		"Raced sessions (source changed mid-run; not counted as drift)")
+	if verbose {
+		for _, s := range raced {
+			renderParseDiffSessionVerbose(w, s)
+		}
+		fmt.Fprintln(w)
+		return
+	}
+	shown := raced
+	if len(shown) > parseDiffChangedCap {
+		shown = shown[:parseDiffChangedCap]
+	}
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	for _, s := range shown {
+		fmt.Fprintf(tw, "  %s\t%s\t%s\n",
+			sanitizeTerminal(s.Agent),
+			sanitizeTerminal(shortID(s.SessionID)),
+			sanitizeTerminal(parseDiffFieldSummary(s.Fields)))
+	}
+	tw.Flush()
+	if extra := len(raced) - len(shown); extra > 0 {
 		fmt.Fprintf(w, "  ... (%d more; use --verbose or --json)\n",
 			extra)
 	}

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -4,12 +4,15 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -229,6 +232,21 @@ func TestParseDiffExitFailure(t *testing.T) {
 		{
 			name:         "parse error fails without stderr note",
 			totals:       sync.ParseDiffTotals{Examined: 1, Identical: 1, ParseErrors: 1},
+			failOnChange: true,
+			wantFail:     true,
+		},
+		{
+			name: "raced sessions alone do not fail",
+			totals: sync.ParseDiffTotals{
+				Examined: 3, Identical: 2, Raced: 1,
+			},
+			failOnChange: true,
+		},
+		{
+			name: "a real change still fails alongside raced sessions",
+			totals: sync.ParseDiffTotals{
+				Examined: 4, Identical: 2, Changed: 1, Raced: 1,
+			},
 			failOnChange: true,
 			wantFail:     true,
 		},
@@ -665,8 +683,13 @@ func TestParseDiff_JSONSessionsAndDBPath(t *testing.T) {
 // phantom stored row keeps the test independent of the parser's session
 // ID derivation.
 func TestDoParseDiff_FailOnChangeDirections(t *testing.T) {
-	dataDir := testDataDir(t)
-	t.Setenv("HOME", t.TempDir())
+	// Isolate every other agent's directory env var to a temp path so an
+	// inherited dir from the developer or CI environment cannot be scanned and
+	// trip --fail-on-change with an unrelated parse error. The data dir and
+	// Claude dir are then overridden to the paths this test controls.
+	isolateParseDiffEnv(t)
+	dataDir := os.Getenv("AGENTSVIEW_DATA_DIR")
+	require.NotEmpty(t, dataDir)
 	claudeDir := t.TempDir()
 	t.Setenv("CLAUDE_PROJECTS_DIR", claudeDir)
 
@@ -708,4 +731,138 @@ func TestDoParseDiff_FailOnChangeDirections(t *testing.T) {
 	})
 	assert.False(t, notFailed,
 		"without --fail-on-change the same drift must not fail")
+}
+
+// TestDoParseDiff_RacedSessionDoesNotFail is the end-to-end exit-code
+// proof of the live-write skew guard: a stored row whose source file
+// advanced past its snapshot file_mtime mid-run is reclassified raced,
+// so --fail-on-change exits clean even though the content diverged.
+// Staged through a real sync so the row's id, file_path, and file_mtime
+// are exactly what the parser derives, then drifted and the source mtime
+// pushed forward to simulate a daemon write after the snapshot.
+func TestDoParseDiff_RacedSessionDoesNotFail(t *testing.T) {
+	// Isolate every other agent's directory env var to a temp path so an
+	// inherited dir from the developer or CI environment cannot be scanned and
+	// trip --fail-on-change with an unrelated parse error. The data dir and
+	// Claude dir are then overridden to the paths this test controls.
+	isolateParseDiffEnv(t)
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_PROJECTS_DIR", claudeDir)
+
+	projDir := filepath.Join(claudeDir, "-home-proj")
+	require.NoError(t, os.MkdirAll(projDir, 0o755))
+	srcPath := filepath.Join(projDir, "raced-session.jsonl")
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "hello").
+		AddClaudeAssistant("2026-01-01T00:00:01Z", "hi").
+		String()
+	require.NoError(t, os.WriteFile(srcPath, []byte(content), 0o644))
+
+	dbPath := filepath.Join(dataDir, "sessions.db")
+	d, err := db.Open(dbPath)
+	require.NoError(t, err)
+	engine := sync.NewEngine(d, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeDir},
+		},
+		Machine: "local",
+	})
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced, "one session synced")
+
+	// Find the synced session id so the drift targets the real row.
+	rows, err := d.ListSessionsModifiedBetween(
+		context.Background(), "", "", nil, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "exactly one stored session")
+	sessionID := rows[0].ID
+
+	// Drift the stored row so a fresh parse reports a real change, then
+	// push the source mtime past the recorded snapshot file_mtime.
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		_, uerr := tx.Exec(
+			"UPDATE sessions SET first_message = ? WHERE id = ?",
+			"drifted first message", sessionID,
+		)
+		return uerr
+	}))
+	require.NoError(t, d.Close())
+
+	future := time.Now().Add(48 * time.Hour)
+	require.NoError(t, os.Chtimes(srcPath, future, future),
+		"advance source mtime past the snapshot")
+
+	var racedBuf bytes.Buffer
+	racedFailed := doParseDiff(ParseDiffConfig{
+		FailOnChange: true, Stdout: &racedBuf, Stderr: &racedBuf,
+	})
+	assert.False(t, racedFailed,
+		"a raced session must not trip --fail-on-change")
+	assert.Contains(t, racedBuf.String(), "Raced",
+		"the summary must surface the raced session")
+}
+
+// TestDoParseDiff_UntouchedDriftStillFails is the negative control for
+// the skew guard: the same staged drift WITHOUT advancing the source
+// mtime stays a genuine change and trips --fail-on-change, proving the
+// guard never masks a real regression on an untouched file.
+func TestDoParseDiff_UntouchedDriftStillFails(t *testing.T) {
+	// Isolate every other agent's directory env var to a temp path so an
+	// inherited dir from the developer or CI environment cannot be scanned and
+	// trip --fail-on-change with an unrelated parse error. The data dir and
+	// Claude dir are then overridden to the paths this test controls.
+	isolateParseDiffEnv(t)
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	claudeDir := t.TempDir()
+	t.Setenv("CLAUDE_PROJECTS_DIR", claudeDir)
+
+	projDir := filepath.Join(claudeDir, "-home-proj")
+	require.NoError(t, os.MkdirAll(projDir, 0o755))
+	srcPath := filepath.Join(projDir, "drift-session.jsonl")
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "hello").
+		AddClaudeAssistant("2026-01-01T00:00:01Z", "hi").
+		String()
+	require.NoError(t, os.WriteFile(srcPath, []byte(content), 0o644))
+
+	dbPath := filepath.Join(dataDir, "sessions.db")
+	d, err := db.Open(dbPath)
+	require.NoError(t, err)
+	engine := sync.NewEngine(d, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeDir},
+		},
+		Machine: "local",
+	})
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced, "one session synced")
+
+	rows, err := d.ListSessionsModifiedBetween(
+		context.Background(), "", "", nil, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	sessionID := rows[0].ID
+
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		_, uerr := tx.Exec(
+			"UPDATE sessions SET first_message = ? WHERE id = ?",
+			"drifted first message", sessionID,
+		)
+		return uerr
+	}))
+	require.NoError(t, d.Close())
+
+	// Source mtime is left untouched: the change is genuine drift.
+	var buf bytes.Buffer
+	failed := doParseDiff(ParseDiffConfig{
+		FailOnChange: true, Stdout: &buf, Stderr: &buf,
+	})
+	assert.True(t, failed,
+		"untouched-source drift must still trip --fail-on-change")
+	assert.Contains(t, buf.String(), "sessions changed")
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1632,6 +1632,7 @@ type IncrementalSessionUpdate struct {
 	UserMsgCount         int
 	FileSize             int64
 	FileMtime            int64
+	FileHash             *string
 	NextOrdinal          int
 	LastEntryUUID        string
 	TotalOutputTokens    int
@@ -1712,7 +1713,7 @@ func (db *DB) GetSessionForIncremental(
 
 // UpdateSessionIncremental updates only the fields that change
 // during an incremental append: ended_at, message_count,
-// user_message_count, file_size, file_mtime, and token
+// user_message_count, file_size, file_mtime, optional file_hash, and token
 // aggregates. All values are absolute (not deltas) so the
 // update is idempotent on retry.
 //
@@ -1748,6 +1749,7 @@ func updateSessionIncrementalTx(
 			user_message_count = ?,
 			file_size = ?,
 			file_mtime = ?,
+			file_hash = COALESCE(?, file_hash),
 			next_ordinal = ?,
 			last_entry_uuid = ?,
 			total_output_tokens = ?,
@@ -1758,6 +1760,7 @@ func updateSessionIncrementalTx(
 		WHERE id = ?`,
 		update.EndedAt, update.MsgCount, update.UserMsgCount,
 		update.FileSize, update.FileMtime,
+		update.FileHash,
 		update.NextOrdinal, lastEntryUUID,
 		update.TotalOutputTokens, update.PeakContextTokens,
 		update.HasTotalOutputTokens, update.HasPeakContextTokens, id,

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1642,6 +1642,14 @@ func (s *codexIncrementalSeed) observeUserMessage(
 	}
 }
 
+// CodexTranscriptConsumedSize returns the byte offset after the last complete,
+// valid JSON line in a Codex transcript. Bytes after this offset are ignored by
+// the Codex JSONL parser, so partial trailing writes are not part of the parsed
+// source snapshot.
+func CodexTranscriptConsumedSize(path string) (int64, error) {
+	return readJSONLFrom(path, 0, func(line string) {})
+}
+
 // ParseCodexSessionFrom parses only new lines from a Codex
 // JSONL file starting at the given byte offset. Returns only
 // the newly parsed messages (with ordinals starting at

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -6906,6 +6906,11 @@ func computeFinalStreak(calls []signals.ToolCallRow) int {
 func (e *Engine) RecomputeSignals(
 	ctx context.Context, sessionID string,
 ) error {
+	if e.refuseWriteInForceParse("RecomputeSignals") {
+		return errors.New(
+			"RecomputeSignals refused on report-only parse-diff engine",
+		)
+	}
 	return e.recomputeSignalsFromDB(ctx, sessionID)
 }
 
@@ -10109,6 +10114,11 @@ func (e *Engine) ScanSecrets(
 	ctx context.Context, in SecretScanInput,
 	progress func(SecretScanProgress),
 ) (SecretScanSummary, error) {
+	if e.refuseWriteInForceParse("ScanSecrets") {
+		return SecretScanSummary{}, errors.New(
+			"ScanSecrets refused on report-only parse-diff engine",
+		)
+	}
 	ver := secrets.RulesVersion()
 	ids, err := e.db.SecretScanCandidates(ctx, db.SecretScanCandidateFilter{
 		CurrentVersion: ver, OnlyStale: in.Backfill,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4815,7 +4815,7 @@ func (e *Engine) tryIncrementalJSONL(
 	newOffset := inc.FileSize + consumed
 	var incHash string
 	if agent == parser.AgentCodex {
-		if hash, err := ComputeFileHash(file.Path); err == nil {
+		if hash, err := ComputeFileHashPrefix(file.Path, newOffset); err == nil {
 			incHash = hash
 		}
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4116,6 +4116,7 @@ type incrementalUpdate struct {
 	userMsgCount         int // total (old + new)
 	fileSize             int64
 	fileMtime            int64
+	fileHash             string
 	nextOrdinal          int
 	lastEntryUUID        string
 	totalOutputTokens    int // absolute (old + new)
@@ -4812,6 +4813,12 @@ func (e *Engine) tryIncrementalJSONL(
 	// info.Size(), so partial lines at EOF are retried on
 	// the next sync.
 	newOffset := inc.FileSize + consumed
+	var incHash string
+	if agent == parser.AgentCodex {
+		if hash, err := ComputeFileHash(file.Path); err == nil {
+			incHash = hash
+		}
+	}
 
 	if len(newMsgs) == 0 {
 		// No new messages, but advance the offset past
@@ -4828,6 +4835,7 @@ func (e *Engine) tryIncrementalJSONL(
 					userMsgCount:         inc.UserMsgCount,
 					fileSize:             newOffset,
 					fileMtime:            incMtime,
+					fileHash:             incHash,
 					nextOrdinal:          inc.NextOrdinal,
 					lastEntryUUID:        inc.LastEntryUUID,
 					totalOutputTokens:    inc.TotalOutputTokens,
@@ -4901,6 +4909,7 @@ func (e *Engine) tryIncrementalJSONL(
 			userMsgCount:         inc.UserMsgCount + newUserCount,
 			fileSize:             newOffset,
 			fileMtime:            incMtime,
+			fileHash:             incHash,
 			nextOrdinal:          nextOrdinal,
 			lastEntryUUID:        lastEntryUUID,
 			totalOutputTokens:    totalOut,
@@ -7844,8 +7853,9 @@ func shouldReplaceFullParseMessages(
 
 // writeIncremental appends new messages and partially updates
 // session metadata without overwriting columns that are not
-// recomputed during incremental parsing (e.g. file_hash,
-// parent_session_id, relationship_type).
+// recomputed during incremental parsing (e.g. parent_session_id,
+// relationship_type). Codex refreshes file_hash because parse-diff
+// uses it as the transcript fingerprint for raced-skew detection.
 func (e *Engine) writeIncremental(
 	inc *incrementalUpdate,
 ) error {
@@ -7879,6 +7889,7 @@ func (e *Engine) writeIncremental(
 			UserMsgCount:         userMsgCount,
 			FileSize:             inc.fileSize,
 			FileMtime:            inc.fileMtime,
+			FileHash:             strPtr(inc.fileHash),
 			NextOrdinal:          inc.nextOrdinal,
 			LastEntryUUID:        inc.lastEntryUUID,
 			TotalOutputTokens:    inc.totalOutputTokens,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -121,6 +121,30 @@ type Engine struct {
 // returns.
 func (e *Engine) PhaseStats() *PhaseStats { return &e.phaseStats }
 
+// refuseWriteInForceParse guards the public sync entrypoints against an
+// engine created by NewDiffEngine, whose forceParse mode exists purely
+// for report-only re-parsing. Such an engine is also Ephemeral, so a
+// write would persist nothing useful, but it would still rewrite or
+// re-derive archive rows -- exactly what the report-only contract
+// promises not to do. Rather than widen the read-only surface into a
+// separate interface (which would change NewDiffEngine's return type and
+// break ParseDiff callers), the write entrypoints refuse and log when
+// forceParse is set. A real sync engine never sets forceParse, so this
+// is a no-op for every production caller.
+//
+// It returns true when the caller must abort. op names the refused
+// entrypoint for the log line.
+func (e *Engine) refuseWriteInForceParse(op string) bool {
+	if !e.forceParse {
+		return false
+	}
+	log.Printf(
+		"sync: refusing %s on a report-only (parse-diff) engine; "+
+			"forceParse engines never write", op,
+	)
+	return true
+}
+
 // codexExecMigrationKey is the pg_sync_state flag that
 // records whether the one-time cleanup of legacy codex_exec
 // skip cache entries has already run on this database.
@@ -392,6 +416,9 @@ type syncJob struct {
 // Paths that don't match known session file patterns are
 // silently ignored.
 func (e *Engine) SyncPaths(paths []string) {
+	if e.refuseWriteInForceParse("SyncPaths") {
+		return
+	}
 	files := e.classifyPaths(paths)
 	if len(files) == 0 {
 		return
@@ -1951,6 +1978,9 @@ const resyncTempSuffix = "-resync"
 func (e *Engine) ResyncAll(
 	ctx context.Context, onProgress ProgressFunc,
 ) (stats SyncStats) {
+	if e.refuseWriteInForceParse("ResyncAll") {
+		return SyncStats{}
+	}
 	e.syncMu.Lock()
 	// Defers LIFO: Unlock runs before emit.
 	defer func() {
@@ -2564,6 +2594,9 @@ func (e *Engine) RunExclusive(work func() error) error {
 func (e *Engine) SyncAll(
 	ctx context.Context, onProgress ProgressFunc,
 ) (stats SyncStats) {
+	if e.refuseWriteInForceParse("SyncAll") {
+		return SyncStats{}
+	}
 	e.syncMu.Lock()
 	// Defers run LIFO: Unlock runs before the emit closure so
 	// Emitter implementations cannot widen the syncMu critical
@@ -2591,6 +2624,9 @@ func (e *Engine) SyncAll(
 func (e *Engine) SyncAllSince(
 	ctx context.Context, since time.Time, onProgress ProgressFunc,
 ) (stats SyncStats) {
+	if e.refuseWriteInForceParse("SyncAllSince") {
+		return SyncStats{}
+	}
 	e.syncMu.Lock()
 	defer func() {
 		if stats.Synced > 0 {
@@ -2612,6 +2648,9 @@ func (e *Engine) SyncRootsSince(
 	ctx context.Context, roots []string, since time.Time,
 	onProgress ProgressFunc,
 ) (stats SyncStats) {
+	if e.refuseWriteInForceParse("SyncRootsSince") {
+		return SyncStats{}
+	}
 	e.syncMu.Lock()
 	defer func() {
 		if stats.Synced > 0 {
@@ -4730,6 +4769,20 @@ func (e *Engine) tryIncrementalJSONL(
 		}
 	}
 
+	// Persist the same effective file_mtime a full parse would store. For
+	// Codex that folds in session_index.jsonl (parser.CodexEffectiveMtime),
+	// exactly as ParseCodexSession sets File.Mtime; a full sync of the same
+	// file stores that effective value. Keeping the incremental write on the
+	// same basis means parse-diff's raced guard -- which reads the freshly
+	// parsed effective File.Mtime -- compares against a matching stored
+	// file_mtime no matter whether the last write was incremental or full,
+	// and shouldSkipCodex's storedMtime==effectiveMtime fast path stays
+	// accurate. Plain JSONL agents (Claude/Gemini) keep the raw stat.
+	incMtime := info.ModTime().UnixNano()
+	if agent == parser.AgentCodex {
+		incMtime = parser.CodexEffectiveMtime(file.Path, incMtime)
+	}
+
 	newMsgs, endedAt, consumed, err := parseFn(
 		file.Path, inc.FileSize, inc.NextOrdinal, inc.LastEntryUUID,
 	)
@@ -4774,7 +4827,7 @@ func (e *Engine) tryIncrementalJSONL(
 					msgCount:             inc.MsgCount,
 					userMsgCount:         inc.UserMsgCount,
 					fileSize:             newOffset,
-					fileMtime:            info.ModTime().UnixNano(),
+					fileMtime:            incMtime,
 					nextOrdinal:          inc.NextOrdinal,
 					lastEntryUUID:        inc.LastEntryUUID,
 					totalOutputTokens:    inc.TotalOutputTokens,
@@ -4847,7 +4900,7 @@ func (e *Engine) tryIncrementalJSONL(
 			msgCount:             inc.MsgCount + len(newMsgs),
 			userMsgCount:         inc.UserMsgCount + newUserCount,
 			fileSize:             newOffset,
-			fileMtime:            info.ModTime().UnixNano(),
+			fileMtime:            incMtime,
 			nextOrdinal:          nextOrdinal,
 			lastEntryUUID:        lastEntryUUID,
 			totalOutputTokens:    totalOut,
@@ -4890,25 +4943,13 @@ func (e *Engine) shouldSkipCodex(
 		!e.codexIndexSessionNameChanged(path)
 }
 
-// codexIndexMtimeChanged returns true when session_index.jsonl is newer
-// than the stored DB mtime, meaning a title rename happened since the
-// last parse, regardless of whether the session file itself also changed.
-func (e *Engine) codexIndexMtimeChanged(path string) bool {
-	indexMtime := parser.CodexEffectiveMtime(path, 0)
-	if indexMtime == 0 {
-		return false
-	}
-	lookupPath := path
-	if e.pathRewriter != nil {
-		lookupPath = e.pathRewriter(path)
-	}
-	_, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
-	if !ok {
-		return false
-	}
-	return indexMtime > storedMtime && e.codexIndexSessionNameChanged(path)
-}
-
+// codexIndexNeedsRefreshSince reports whether a Codex session whose transcript
+// predates the cutoff still needs a refresh because its session_index.jsonl
+// title changed at or after the cutoff. It compares the index title to the
+// stored session_name directly rather than gating on indexMtime > storedMtime:
+// the incremental write folds the index mtime into the stored file_mtime, so a
+// title-only rename whose index mtime is <= that stored value would otherwise
+// be filtered out and the stale title would never resolve.
 func (e *Engine) codexIndexNeedsRefreshSince(
 	path string, cutoffNs int64,
 ) bool {
@@ -4920,11 +4961,10 @@ func (e *Engine) codexIndexNeedsRefreshSince(
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
 	}
-	_, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
-	if !ok {
+	if _, _, ok := e.db.GetFileInfoByPath(lookupPath); !ok {
 		return false
 	}
-	return indexMtime > storedMtime && e.codexIndexSessionNameChanged(path)
+	return e.codexIndexSessionNameChanged(path)
 }
 
 func (e *Engine) codexIndexSessionNameChanged(path string) bool {
@@ -5066,8 +5106,15 @@ func (e *Engine) processCodex(
 		file, info, parser.AgentCodex, codexParseFn,
 	); ok {
 		if !projectNeedsReparse {
-			indexMtimeChanged := e.codexIndexMtimeChanged(file.Path)
-			if !indexMtimeChanged {
+			// Force a full parse whenever the index title differs from the
+			// stored session_name. A mtime gate (indexMtime > storedMtime) is
+			// not enough here: the incremental write folds the index mtime into
+			// the stored file_mtime, so a later rename whose index mtime is <=
+			// that stored value slips past the gate. shouldSkipCodex's
+			// storedMtime==effectiveMtime fast path would then skip the refresh
+			// forever, stranding the stale title. Comparing the name directly
+			// closes that window.
+			if !e.codexIndexSessionNameChanged(file.Path) {
 				return res
 			}
 			// The index title changed, so a full parse still needs to refresh
@@ -8794,6 +8841,12 @@ func (e *Engine) SyncSingleSession(sessionID string) (err error) {
 func (e *Engine) SyncSingleSessionContext(
 	ctx context.Context, sessionID string,
 ) (err error) {
+	if e.refuseWriteInForceParse("SyncSingleSession") {
+		return fmt.Errorf(
+			"cannot sync session %s on a report-only (parse-diff) engine",
+			sessionID,
+		)
+	}
 	e.syncMu.Lock()
 	preserved := false
 	// Defers run LIFO: unlock runs first (releasing syncMu), then

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2547,6 +2547,9 @@ func (e *Engine) SyncThenRun(
 	onProgress ProgressFunc,
 	work func(forceFull bool) error,
 ) (stats SyncStats, err error) {
+	if e.refuseWriteInForceParse("SyncThenRun") {
+		return SyncStats{}, nil
+	}
 	e.syncMu.Lock()
 	// Defers run LIFO: Unlock runs before emit.
 	defer func() {
@@ -2585,6 +2588,11 @@ func (e *Engine) SyncThenRun(
 // sync and resync operations. Use this for daemon-owned maintenance operations
 // that must serialize with sync but should not force a local sync first.
 func (e *Engine) RunExclusive(work func() error) error {
+	if e.refuseWriteInForceParse("RunExclusive") {
+		return errors.New(
+			"RunExclusive refused on report-only parse-diff engine",
+		)
+	}
 	e.syncMu.Lock()
 	defer e.syncMu.Unlock()
 	return work()

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2274,6 +2274,74 @@ func TestSyncAllSinceCodexRefreshesSessionNameFromIndex(t *testing.T) {
 	}
 }
 
+// TestSyncAllSinceCodexIndexRenameBelowStoredMtimeRefreshesName covers the
+// quick-sync sibling of the incremental masking race: a title-only index rename
+// whose mtime lands at/after the cutoff but at or below the stored (index-folded)
+// file_mtime must still refresh the session_name. codexIndexNeedsRefreshSince
+// must compare the title directly instead of gating on indexMtime > storedMtime.
+func TestSyncAllSinceCodexIndexRenameBelowStoredMtimeRefreshesName(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e1"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Rename me").
+		String()
+	path := env.writeCodexSession(
+		t,
+		filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl",
+		content,
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original title","updated_at":"2026-06-11T17:34:20Z"}`+"\n",
+		uuid,
+	), 0o644))
+
+	// Transcript is well before the cutoff; the index is newer, so the initial
+	// parse stores the high index mtime as the effective file_mtime.
+	transcriptTime := time.Now().Add(-3 * time.Hour)
+	highIndexTime := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime), "chtimes initial session")
+	require.NoError(t, os.Chtimes(indexPath, highIndexTime, highIndexTime), "chtimes initial index")
+
+	env.engine.SyncAll(context.Background(), nil)
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "expected Codex session to sync")
+	require.NotNil(t, sess.SessionName, "expected session_name to be imported")
+	require.Equal(t, "Original title", *sess.SessionName)
+	require.NotNil(t, sess.FileMtime, "expected stored file_mtime")
+	require.Equal(t, highIndexTime.UnixNano(), *sess.FileMtime,
+		"expected stored file_mtime to fold in the higher index mtime")
+
+	// Rename the index with an mtime that is after the cutoff but BELOW the
+	// stored file_mtime. The old indexMtime > storedMtime gate would filter this
+	// out of the quick sync, stranding the stale title.
+	cutoff := time.Now().Add(-1 * time.Hour)
+	lowIndexTime := time.Now().Add(-45 * time.Minute)
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2026-06-11T18:00:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, lowIndexTime, lowIndexTime), "chtimes renamed index")
+
+	stats := env.engine.SyncAllSince(context.Background(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced, "SyncAllSince synced = %d, want 1", stats.Synced)
+
+	sess, err = env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull after rename")
+	require.NotNil(t, sess, "expected renamed Codex session to remain")
+	if assert.NotNil(t, sess.SessionName, "expected renamed session_name") {
+		assert.Equal(t, "Renamed title", *sess.SessionName)
+	}
+}
+
 func TestSyncAllSinceCodexIndexRefreshOnlySyncsRenamedSession(t *testing.T) {
 	root := t.TempDir()
 	codexDir := filepath.Join(root, "sessions")
@@ -7408,6 +7476,83 @@ func TestIncrementalSync_CodexAppend(t *testing.T) {
 	}
 }
 
+// TestIncrementalSync_CodexStoresEffectiveMtime pins that the incremental
+// append path persists the same session_index.jsonl-folded effective mtime a
+// full Codex parse stores (parser.CodexEffectiveMtime). Without it an
+// incrementally-synced Codex session would carry the plain rollout mtime,
+// leaving the stored file_mtime on a different basis than the effective
+// File.Mtime parse-diff's raced guard reads -- which would let an index newer
+// than the rollout mask genuine transcript drift as raced.
+func TestIncrementalSync_CodexStoresEffectiveMtime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229e1"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/tmp/proj", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "01"),
+		"rollout-2024-01-01T10-00-00-"+uuid+".jsonl", initial,
+	)
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, []byte(
+		`{"id":"`+uuid+`","thread_name":"Title",`+
+			`"updated_at":"2024-01-01T10:00:00Z"}`+"\n",
+	), 0o644))
+	base := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(path, base, base), "chtimes initial session")
+	require.NoError(t, os.Chtimes(indexPath, base, base), "chtimes initial index")
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 1)
+
+	// Append an assistant message so the next sync takes the incremental
+	// append path (the title is unchanged, so no index-rename full parse).
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("assistant", "world", tsEarlyS5),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, f.Close())
+	require.NoError(t, err, "append")
+
+	// Push the index strictly past the rollout so the effective mtime differs
+	// from the plain rollout mtime.
+	rollTime := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, os.Chtimes(path, rollTime, rollTime), "chtimes rollout")
+	require.NoError(t, os.Chtimes(
+		indexPath, rollTime.Add(time.Hour), rollTime.Add(time.Hour),
+	), "chtimes index")
+
+	env.engine.SyncPaths([]string{path})
+
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 2)
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "session present")
+	require.NotNil(t, sess.FileMtime, "file_mtime stored")
+
+	// Compare against re-stats (not the requested Chtimes values) so the
+	// assertion is robust to filesystem mtime granularity.
+	idxInfo, err := os.Stat(indexPath)
+	require.NoError(t, err, "stat index")
+	rollInfo, err := os.Stat(path)
+	require.NoError(t, err, "stat rollout")
+	assert.Equal(t, idxInfo.ModTime().UnixNano(), *sess.FileMtime,
+		"incremental Codex write stores the index-folded effective mtime")
+	assert.Greater(t, *sess.FileMtime, rollInfo.ModTime().UnixNano(),
+		"effective mtime exceeds the plain rollout mtime")
+}
+
 func TestIncrementalSync_CodexExecAppendRetainsEvents(t *testing.T) {
 	env := setupTestEnv(t)
 
@@ -7580,6 +7725,93 @@ func TestIncrementalSync_CodexLateTokenCountWithIndexRenameRewritesStoredMessage
 	assert.NotEmpty(t, msgs[1].TokenUsage)
 	assert.Equal(t, 250, msgs[1].OutputTokens)
 	assert.Equal(t, 100_000, msgs[1].ContextTokens)
+}
+
+// TestIncrementalSync_CodexIndexRenameBelowStoredMtimeRefreshesName covers a
+// stale-title race introduced by folding the session_index.jsonl mtime into the
+// incremental write's stored file_mtime. The initial parse stores a high
+// effective mtime (the index mtime is newer than the transcript). A later index
+// rename whose mtime is <= that stored value cannot be detected by a
+// indexMtime > storedMtime gate, so the incremental path must compare the
+// session name directly and fall back to a full parse, otherwise
+// shouldSkipCodex's storedMtime==effectiveMtime fast path would strand the
+// stale title on every subsequent sync.
+func TestIncrementalSync_CodexIndexRenameBelowStoredMtimeRefreshesName(t *testing.T) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e1"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/tmp/proj", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexTurnContextJSON("gpt-5.5", tsEarlyS1),
+		testjsonl.CodexMsgJSON("user", "first", tsEarlyS1),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "01"),
+		"rollout-2024-01-01T10-00-00-"+uuid+".jsonl",
+		initial,
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Original title","updated_at":"2024-01-01T10:00:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+
+	// The transcript is older than the index, so the initial parse stores the
+	// index mtime as the effective file_mtime.
+	transcriptTime := time.Now().Add(-2 * time.Hour)
+	highIndexTime := time.Now().Add(-30 * time.Minute)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime), "chtimes initial session")
+	require.NoError(t, os.Chtimes(indexPath, highIndexTime, highIndexTime), "chtimes initial index")
+
+	env.engine.SyncAll(context.Background(), nil)
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "expected Codex session to sync")
+	require.NotNil(t, sess.SessionName, "expected session_name to be imported")
+	require.Equal(t, "Original title", *sess.SessionName)
+	require.NotNil(t, sess.FileMtime, "expected stored file_mtime")
+	require.Equal(t, highIndexTime.UnixNano(), *sess.FileMtime,
+		"expected stored file_mtime to fold in the higher index mtime")
+
+	// Append to the transcript (an incremental update) and rename the index with
+	// an mtime BELOW the stored file_mtime. effectiveMtime never exceeds the
+	// stored value, so only a direct session-name comparison can catch the
+	// rename.
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("assistant", "second", tsEarlyS5),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append")
+	require.NoError(t, f.Close())
+
+	appendTime := time.Now().Add(-90 * time.Minute)
+	lowIndexTime := time.Now().Add(-45 * time.Minute)
+	require.NoError(t, os.Chtimes(path, appendTime, appendTime), "chtimes appended session")
+	require.NoError(t, os.WriteFile(indexPath, fmt.Appendf(nil,
+		`{"id":"%s","thread_name":"Renamed title","updated_at":"2024-01-01T10:01:00Z"}`+"\n",
+		uuid,
+	), 0o644))
+	require.NoError(t, os.Chtimes(indexPath, lowIndexTime, lowIndexTime), "chtimes renamed index")
+
+	env.engine.SyncPaths([]string{path})
+
+	sess, err = env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull after rename")
+	require.NotNil(t, sess, "expected Codex session to remain")
+	if assert.NotNil(t, sess.SessionName, "expected renamed session_name") {
+		assert.Equal(t, "Renamed title", *sess.SessionName)
+	}
+	// The incremental append must still have landed.
+	msgs := fetchMessages(t, env.db, "codex:"+uuid)
+	require.Len(t, msgs, 2)
 }
 
 func TestIncrementalSync_CodexSubagentAppendFallsBackToFullParse(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -7551,6 +7552,57 @@ func TestIncrementalSync_CodexStoresEffectiveMtime(t *testing.T) {
 		"incremental Codex write stores the index-folded effective mtime")
 	assert.Greater(t, *sess.FileMtime, rollInfo.ModTime().UnixNano(),
 		"effective mtime exceeds the plain rollout mtime")
+}
+
+func TestIncrementalSync_CodexHashMatchesConsumedPrefix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	env := setupTestEnv(t)
+
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229e4"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/tmp/proj", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "01"),
+		"rollout-2024-01-01T10-00-00-"+uuid+".jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 1)
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("assistant", "world", tsEarlyS5),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append complete message")
+	_, err = f.WriteString(`{"timestamp":"2024-01-01T10:00:10Z"`)
+	require.NoError(t, err, "append partial trailing JSON")
+	require.NoError(t, f.Close(), "close after append")
+
+	env.engine.SyncPaths([]string{path})
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 2)
+
+	sess, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "session present")
+	require.NotNil(t, sess.FileSize, "file_size stored")
+	require.NotNil(t, sess.FileHash, "file_hash stored")
+
+	live, err := os.ReadFile(path)
+	require.NoError(t, err, "read live transcript")
+	require.Less(t, *sess.FileSize, int64(len(live)),
+		"partial trailing JSON should remain outside the consumed prefix")
+	prefix := live[:*sess.FileSize]
+	sum := sha256.Sum256(prefix)
+	wantHash := fmt.Sprintf("%x", sum[:])
+	assert.Equal(t, wantHash, *sess.FileHash,
+		"incremental Codex hash must match the consumed file_size prefix")
 }
 
 func TestIncrementalSync_CodexExecAppendRetainsEvents(t *testing.T) {

--- a/internal/sync/hash.go
+++ b/internal/sync/hash.go
@@ -29,3 +29,24 @@ func ComputeFileHash(path string) (string, error) {
 	}
 	return hash, nil
 }
+
+// ComputeFileHashPrefix returns the SHA-256 hex digest of the first size bytes
+// of the file at path. It returns an error if the file is shorter than size.
+func ComputeFileHashPrefix(path string, size int64) (string, error) {
+	if size < 0 {
+		return "", fmt.Errorf("hashing %s: negative prefix size %d", path, size)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.CopyN(h, f, size); err != nil {
+		return "", fmt.Errorf(
+			"hashing first %d bytes of %s: %w", size, path, err,
+		)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -471,6 +471,29 @@ func parseDiffLiveMtime(
 	})
 }
 
+// parseDiffCodexTranscriptChangedSinceStored reports whether the Codex
+// transcript file itself differs from the archived source fingerprint. Codex
+// rows persist file_mtime on an index-folded basis so title changes can
+// invalidate sync caches, but parse-diff's raced guard uses transcript-only
+// live mtimes to avoid letting the global session_index.jsonl mask unrelated
+// parser drift. When the index-folded stored mtime is newer than a later
+// transcript write, the mtime comparison alone cannot prove the write; the
+// transcript fingerprint can.
+func parseDiffCodexTranscriptChangedSinceStored(
+	stored *db.Session, parsed parser.ParsedSession,
+) bool {
+	if stored == nil || parsed.Agent != parser.AgentCodex {
+		return false
+	}
+	if stored.FileHash != nil && parsed.File.Hash != "" {
+		return *stored.FileHash != parsed.File.Hash
+	}
+	if stored.FileSize != nil {
+		return *stored.FileSize != parsed.File.Size
+	}
+	return false
+}
+
 // parseDiffCollectFile folds one worker result into the report.
 func (e *Engine) parseDiffCollectFile(
 	ctx context.Context,
@@ -579,7 +602,10 @@ func (e *Engine) parseDiffCollectFile(
 		// the value is floored by the parsed File.Mtime so a source
 		// rewritten with an older mtime mid-run still reads as raced;
 		// Codex skips that floor because the parsed File.Mtime also folds
-		// in the shared index. The guard runs only for
+		// in the shared index. If that same index-folded stored mtime hides
+		// a newer transcript mtime, Codex falls back to the transcript
+		// hash/size fingerprint to prove the source file changed. The
+		// guard runs only for
 		// reliable, literal-file sources (see
 		// parseDiffSourceReliableForRaced); virtual and DB-backed sources
 		// are gated out and keep their real changed/unchanged verdict. A
@@ -605,6 +631,10 @@ func (e *Engine) parseDiffCollectFile(
 			raced = parseDiffSourceRaced(
 				storedMtime, liveMtime, liveOK,
 			)
+			if !raced && liveOK &&
+				parseDiffCodexTranscriptChangedSinceStored(stored, pw.sess) {
+				raced = true
+			}
 		}
 
 		class, reason := classifyParseDiffSession(

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -472,13 +472,13 @@ func parseDiffLiveMtime(
 }
 
 // parseDiffCodexTranscriptChangedSinceStored reports whether the Codex
-// transcript file itself differs from the archived parsed source fingerprint.
+// transcript's parsed byte boundary differs from the archived source snapshot.
 // Codex rows persist file_mtime on an index-folded basis so title changes can
 // invalidate sync caches, but parse-diff's raced guard uses transcript-only
 // live mtimes to avoid letting the global session_index.jsonl mask unrelated
 // parser drift. When the index-folded stored mtime is newer than a later
-// transcript write, the mtime comparison alone cannot prove the write; the
-// transcript fingerprint can.
+// transcript append, the mtime comparison alone cannot prove the write; the
+// parser-consumed JSONL boundary can.
 func parseDiffCodexTranscriptChangedSinceStored(
 	stored *db.Session, parsed parser.ParsedSession,
 ) bool {
@@ -486,30 +486,12 @@ func parseDiffCodexTranscriptChangedSinceStored(
 		return false
 	}
 	if stored.FileSize == nil {
-		if stored.FileHash != nil && parsed.File.Hash != "" {
-			return *stored.FileHash != parsed.File.Hash
-		}
 		return false
 	}
 
 	storedSize := *stored.FileSize
 	if parsed.File.Size == storedSize {
-		if stored.FileHash != nil && parsed.File.Hash != "" {
-			return *stored.FileHash != parsed.File.Hash
-		}
 		return false
-	}
-
-	if stored.FileHash != nil {
-		livePrefixHash, err := ComputeFileHashPrefix(
-			parsed.File.Path, storedSize,
-		)
-		if err != nil {
-			return true
-		}
-		if livePrefixHash != *stored.FileHash {
-			return true
-		}
 	}
 
 	consumedSize, err := parser.CodexTranscriptConsumedSize(parsed.File.Path)

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -472,13 +472,16 @@ func parseDiffLiveMtime(
 }
 
 // parseDiffCodexTranscriptChangedSinceStored reports whether the Codex
-// transcript's parsed byte boundary differs from the archived source snapshot.
-// Codex rows persist file_mtime on an index-folded basis so title changes can
-// invalidate sync caches, but parse-diff's raced guard uses transcript-only
-// live mtimes to avoid letting the global session_index.jsonl mask unrelated
-// parser drift. When the index-folded stored mtime is newer than a later
-// transcript append, the mtime comparison alone cannot prove the write; the
-// parser-consumed JSONL boundary can.
+// transcript differs from the archived source snapshot on a size basis Codex
+// has historically stored. Full parses store the raw file size, while
+// incremental parses can store only the parser-consumed JSONL boundary when a
+// partial line trails the file. Codex rows persist file_mtime on an
+// index-folded basis so title changes can invalidate sync caches, but
+// parse-diff's raced guard uses transcript-only live mtimes to avoid letting the
+// global session_index.jsonl mask unrelated parser drift. When the index-folded
+// stored mtime is newer than a later transcript append, the mtime comparison
+// alone cannot prove the write; the live raw size or parser-consumed JSONL
+// boundary can.
 func parseDiffCodexTranscriptChangedSinceStored(
 	stored *db.Session, parsed parser.ParsedSession,
 ) bool {
@@ -490,6 +493,14 @@ func parseDiffCodexTranscriptChangedSinceStored(
 	}
 
 	storedSize := *stored.FileSize
+	info, err := os.Stat(parsed.File.Path)
+	if err != nil {
+		return true
+	}
+	if info.Size() == storedSize {
+		return false
+	}
+
 	consumedSize, err := parser.CodexTranscriptConsumedSize(parsed.File.Path)
 	if err != nil {
 		return true

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -180,8 +180,13 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 		report, storedSessions, resolvedSet,
 		len(opts.Agents) == 0, cutPaths, visited,
 	)
+	// Raced sessions were compared against a fresh parse just like the
+	// others, so they count toward Examined; they are simply not counted
+	// as drift. Keeping them in Examined also keeps VacuousResync honest:
+	// a run with comparable (raced) sessions is not "all pending resync".
 	report.Totals.Examined = report.Totals.Identical +
-		report.Totals.Changed + report.Totals.PendingResync
+		report.Totals.Changed + report.Totals.PendingResync +
+		report.Totals.Raced
 
 	sort.Slice(report.Sessions, func(i, j int) bool {
 		a, b := report.Sessions[i], report.Sessions[j]
@@ -369,6 +374,103 @@ func stripVirtualSourceSuffix(path string) string {
 	return path
 }
 
+// parseDiffSourceReliableForRaced reports whether a session's live source
+// mtime can be compared against the stored file_mtime on an apples-to-apples
+// basis, gating the live-write skew (raced) reclassification.
+//
+// The raced guard reclassifies a would-be DiffChanged as DiffRaced when the
+// live source mtime is newer than the stored per-session file_mtime. The live
+// mtime it consults is resolved by parseDiffLiveMtime at collect time, using
+// only mtime sources that are safe per-session race signals. For agents with
+// session-specific sibling files, it recomputes the same effective basis a real
+// sync would persist; for Codex, it deliberately uses the transcript mtime
+// instead of the global session_index.jsonl mtime so unrelated title/index
+// writes cannot mask transcript parser drift.
+//
+// Even so, two source shapes are deliberately held OUT of the raced guard so
+// it fails CLOSED rather than risk masking genuine parser drift:
+//
+//   - Virtual-path sources (Aider "#runIdx", Kiro/Zed/OpenCode/Kilo/MiMoCode
+//     "#rawID", Shelley, Visual Studio Copilot "#conversationID"). Many
+//     sessions fan out of ONE physical source, so the source mtime is NOT a
+//     per-session signal. A shared DB's rows can carry advanced updated_at
+//     values, and Aider's File.Mtime is the whole .aider.chat.history.md
+//     file's mtime shared by every run in it -- appending a new run bumps it
+//     for all runs -- so a newer mtime does not mean THIS session's parsed
+//     content was torn. Including them would mask genuine drift on untouched
+//     siblings; instead they keep their real changed/unchanged verdict (see
+//     TestParseDiffDBBackedSourceNotMaskedAsRaced).
+//   - Agents that are not plain file-based (no on-disk literal file at all).
+//
+// Detecting either makes the source unreliable, so the caller skips the raced
+// guard entirely. This never masks genuine drift for those agents, while plain
+// file-based agents reading a literal file still get the real race protection.
+func parseDiffSourceReliableForRaced(
+	agent parser.AgentType, sourcePath string,
+) bool {
+	// A virtual path carries a recognized "#..." suffix; stripping changes
+	// the string only for such paths. The stored file_mtime for these is a
+	// per-row/composite value, not trusted as a mid-run race signal.
+	if stripVirtualSourceSuffix(sourcePath) != sourcePath {
+		return false
+	}
+	// Only plain file-based agents (FileBased with a DiscoverFunc, the same
+	// on-disk-source condition resolveParseDiffAgents uses) read a literal
+	// file whose mtime populated file_mtime. An unknown or DB-backed agent has
+	// no such basis.
+	def, ok := parser.AgentByType(agent)
+	if !ok {
+		return false
+	}
+	return def.FileBased && def.DiscoverFunc != nil
+}
+
+// parseDiffLiveMtime resolves a session's live source mtime for the raced
+// guard, re-stat'd at collect time (after the worker finished reading) and
+// recomputing the agent-aware mtime that is safe to use as a per-session race
+// signal. Computing it now -- rather than trusting the parser's pre-read
+// File.Mtime -- catches a sibling-file write that landed after the parser's own
+// stat but before classification when that sibling is session-specific:
+//
+//   - Codex deliberately uses the transcript mtime only. Its
+//     session_index.jsonl is global to every Codex session, so an unrelated
+//     title/index write must not mask transcript-derived parser drift.
+//   - OpenHands folds base_state.json/TASKS.json/events/* (OpenHandsSnapshot).
+//   - Copilot folds workspace.yaml (copilotEffectiveMtime).
+//
+// Every other reliable agent is handled by discoveredFileMtime, which already
+// recomputes their effective mtime at stat time (Cowork/CommandCode/Vibe/
+// Reasonix/Antigravity/...). Only literal-file sources reach here -- virtual
+// and DB-backed sources are gated out by parseDiffSourceReliableForRaced -- so
+// the OpenCode-format storage children (virtual "#rawID" paths) never apply.
+func parseDiffLiveMtime(
+	agent parser.AgentType, path string,
+) (int64, error) {
+	switch agent {
+	case parser.AgentCodex:
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0, err
+		}
+		return info.ModTime().UnixNano(), nil
+	case parser.AgentOpenHands:
+		snapshot, err := parser.OpenHandsSnapshot(path)
+		if err != nil {
+			return 0, err
+		}
+		return snapshot.Mtime, nil
+	case parser.AgentCopilot:
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0, err
+		}
+		return copilotEffectiveMtime(path, info), nil
+	}
+	return discoveredFileMtime(parser.DiscoveredFile{
+		Path: path, Agent: agent,
+	})
+}
+
 // parseDiffCollectFile folds one worker result into the report.
 func (e *Engine) parseDiffCollectFile(
 	ctx context.Context,
@@ -408,6 +510,18 @@ func (e *Engine) parseDiffCollectFile(
 			report.Totals.ParseErrors++
 		}
 		return nil
+	}
+
+	// Count how many parsed sessions in this job map to each source path. A
+	// source shared by more than one session -- e.g. Hermes' state.db, which
+	// fans out to every session in the archive under one literal path -- has
+	// an mtime that is not a per-session signal: touching it for one session
+	// would race-mask genuine drift on its siblings. Those are skipped by the
+	// raced guard below (count > 1) and keep their real changed/unchanged
+	// verdict, failing closed the same way virtual fan-out sources do.
+	sourceSessionCount := make(map[string]int, len(job.results))
+	for _, pr := range job.results {
+		sourceSessionCount[pr.Session.File.Path]++
 	}
 
 	for _, pr := range job.results {
@@ -450,6 +564,49 @@ func (e *Engine) parseDiffCollectFile(
 			}
 		}
 
+		// Only consult the skew guard when there is a real change to
+		// reclassify; an identical or pending-resync session is unaffected
+		// by a mid-run write. A nil stored row leaves storedMtime nil.
+		//
+		// The live mtime is parseDiffLiveMtime, re-computed NOW after
+		// the worker finished reading, using only mtimes that are safe
+		// per-session race signals. Re-stat'ing at collect time catches
+		// session-specific sibling-file writes such as OpenHands'
+		// events/*.json and Copilot's workspace.yaml that landed after
+		// the parser's own stat but before classification; Codex uses
+		// the transcript mtime only because its session_index.jsonl is a
+		// global file shared by every Codex session. For other agents,
+		// the value is floored by the parsed File.Mtime so a source
+		// rewritten with an older mtime mid-run still reads as raced;
+		// Codex skips that floor because the parsed File.Mtime also folds
+		// in the shared index. The guard runs only for
+		// reliable, literal-file sources (see
+		// parseDiffSourceReliableForRaced); virtual and DB-backed sources
+		// are gated out and keep their real changed/unchanged verdict. A
+		// re-stat error -- the source was replaced/removed mid-run -- is
+		// treated as unreadable -> raced, matching the conservative
+		// re-stat policy.
+		raced := false
+		if realDiffs > 0 && compare &&
+			sourceSessionCount[pw.sess.File.Path] == 1 &&
+			parseDiffSourceReliableForRaced(pw.sess.Agent, pw.sess.File.Path) {
+			var storedMtime *int64
+			if stored != nil {
+				storedMtime = stored.FileMtime
+			}
+			liveMtime, err := parseDiffLiveMtime(
+				pw.sess.Agent, pw.sess.File.Path,
+			)
+			liveOK := err == nil
+			if liveOK && pw.sess.Agent != parser.AgentCodex &&
+				pw.sess.File.Mtime > liveMtime {
+				liveMtime = pw.sess.File.Mtime
+			}
+			raced = parseDiffSourceRaced(
+				storedMtime, liveMtime, liveOK,
+			)
+		}
+
 		class, reason := classifyParseDiffSession(
 			pw.needsRetry,
 			ok,
@@ -457,6 +614,7 @@ func (e *Engine) parseDiffCollectFile(
 			stored != nil && stored.DeletedAt != nil,
 			stored != nil && stored.DataVersion < db.CurrentDataVersion(),
 			realDiffs,
+			raced,
 		)
 
 		entry := SessionDiff{
@@ -493,6 +651,13 @@ func (e *Engine) parseDiffCollectFile(
 					report.FieldCounts[f.Field]++
 				}
 			}
+			report.Sessions = append(report.Sessions, entry)
+		case DiffRaced:
+			// Inconclusive (live-write skew): listed for visibility with
+			// its field diffs attached for drill-down, but excluded from
+			// FieldCounts and from HasFailures so --fail-on-change stays
+			// trustworthy.
+			report.Totals.Raced++
 			report.Sessions = append(report.Sessions, entry)
 		case DiffSkipped:
 			// A re-parsed but trashed session: counted with the rest

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -490,18 +490,11 @@ func parseDiffCodexTranscriptChangedSinceStored(
 	}
 
 	storedSize := *stored.FileSize
-	if parsed.File.Size == storedSize {
-		return false
-	}
-
 	consumedSize, err := parser.CodexTranscriptConsumedSize(parsed.File.Path)
 	if err != nil {
 		return true
 	}
-	if consumedSize != storedSize {
-		return true
-	}
-	return false
+	return consumedSize != storedSize
 }
 
 // parseDiffCollectFile folds one worker result into the report.

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -472,8 +472,8 @@ func parseDiffLiveMtime(
 }
 
 // parseDiffCodexTranscriptChangedSinceStored reports whether the Codex
-// transcript file itself differs from the archived source fingerprint. Codex
-// rows persist file_mtime on an index-folded basis so title changes can
+// transcript file itself differs from the archived parsed source fingerprint.
+// Codex rows persist file_mtime on an index-folded basis so title changes can
 // invalidate sync caches, but parse-diff's raced guard uses transcript-only
 // live mtimes to avoid letting the global session_index.jsonl mask unrelated
 // parser drift. When the index-folded stored mtime is newer than a later
@@ -485,11 +485,39 @@ func parseDiffCodexTranscriptChangedSinceStored(
 	if stored == nil || parsed.Agent != parser.AgentCodex {
 		return false
 	}
-	if stored.FileHash != nil && parsed.File.Hash != "" {
-		return *stored.FileHash != parsed.File.Hash
+	if stored.FileSize == nil {
+		if stored.FileHash != nil && parsed.File.Hash != "" {
+			return *stored.FileHash != parsed.File.Hash
+		}
+		return false
 	}
-	if stored.FileSize != nil {
-		return *stored.FileSize != parsed.File.Size
+
+	storedSize := *stored.FileSize
+	if parsed.File.Size == storedSize {
+		if stored.FileHash != nil && parsed.File.Hash != "" {
+			return *stored.FileHash != parsed.File.Hash
+		}
+		return false
+	}
+
+	if stored.FileHash != nil {
+		livePrefixHash, err := ComputeFileHashPrefix(
+			parsed.File.Path, storedSize,
+		)
+		if err != nil {
+			return true
+		}
+		if livePrefixHash != *stored.FileHash {
+			return true
+		}
+	}
+
+	consumedSize, err := parser.CodexTranscriptConsumedSize(parsed.File.Path)
+	if err != nil {
+		return true
+	}
+	if consumedSize != storedSize {
+		return true
 	}
 	return false
 }

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -1190,10 +1190,15 @@ func compareUsageEvents(
 //   - hasStored / storedTrashed: archive row state.
 //   - pendingResync: stored data_version is behind the binary.
 //   - realDiffs: count of non-informational field diffs.
+//   - raced: the on-disk source advanced past the snapshot mtime, so a
+//     would-be change is a torn comparison against live content rather
+//     than parser drift. Only meaningful when realDiffs > 0; an
+//     unchanged session is identical regardless of a mid-run write.
 func classifyParseDiffSession(
 	needsRetry, prepared, hasStored, storedTrashed,
 	pendingResync bool,
 	realDiffs int,
+	raced bool,
 ) (DiffClass, string) {
 	switch {
 	case needsRetry:
@@ -1212,9 +1217,46 @@ func classifyParseDiffSession(
 		return DiffSkipped, "trashed in archive"
 	case pendingResync:
 		return DiffPendingResync, ""
+	case realDiffs > 0 && raced:
+		// A change against a source the daemon (or an active session)
+		// rewrote after the snapshot: inconclusive, not parser drift.
+		return DiffRaced, "source file changed after snapshot (live-write skew)"
 	case realDiffs > 0:
 		return DiffChanged, ""
 	default:
 		return DiffIdentical, ""
 	}
+}
+
+// parseDiffSourceRaced reports whether the on-disk source file moved
+// past the snapshot's stored file_mtime, so a detected change is a torn
+// comparison against live content rather than parser drift.
+//
+// Both sides are nanoseconds: storedMtime is the file_mtime column the
+// last sync recorded, and liveMtime is the freshly parsed session's
+// File.Mtime -- the same agent-aware effective value this parse would
+// persist. A direct integer comparison is therefore exact -- there is no
+// text-timestamp truncation here, so a sub-millisecond move is real, not
+// a rounding artifact.
+//
+// The verdict is conservative to avoid a false regression:
+//   - liveOK false (the parse produced no usable mtime, e.g. File.Mtime
+//     was never set): ambiguous -> raced.
+//   - storedMtime nil (the archive row has no file_mtime to anchor to):
+//     ambiguous -> raced.
+//   - liveMtime > storedMtime: the file was written after the snapshot
+//     -> raced.
+//   - liveMtime <= storedMtime: the file was demonstrably not touched
+//     after the snapshot -> NOT raced; a change there is genuine and
+//     must not be masked.
+func parseDiffSourceRaced(
+	storedMtime *int64, liveMtime int64, liveOK bool,
+) bool {
+	if !liveOK {
+		return true
+	}
+	if storedMtime == nil {
+		return true
+	}
+	return liveMtime > *storedMtime
 }

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1458,6 +1460,7 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 		storedTrashed bool
 		pendingResync bool
 		realDiffs     int
+		raced         bool
 		wantClass     DiffClass
 		wantReason    string
 	}{
@@ -1465,6 +1468,7 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 			name:       "needs retry wins over everything",
 			needsRetry: true, prepared: false, hasStored: true,
 			storedTrashed: true, pendingResync: true, realDiffs: 3,
+			raced:      true,
 			wantClass:  DiffNeedsRetry,
 			wantReason: "transient low-fidelity parse; differences expected",
 		},
@@ -1493,9 +1497,26 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 			wantClass: DiffPendingResync,
 		},
 		{
+			name:     "pending resync wins over raced",
+			prepared: true, hasStored: true, pendingResync: true,
+			realDiffs: 2, raced: true,
+			wantClass: DiffPendingResync,
+		},
+		{
+			name:     "raced wins over changed when source moved",
+			prepared: true, hasStored: true, realDiffs: 1, raced: true,
+			wantClass:  DiffRaced,
+			wantReason: "source file changed after snapshot (live-write skew)",
+		},
+		{
 			name:     "real diffs mean changed",
 			prepared: true, hasStored: true, realDiffs: 1,
 			wantClass: DiffChanged,
+		},
+		{
+			name:     "raced flag is inert without a real diff",
+			prepared: true, hasStored: true, realDiffs: 0, raced: true,
+			wantClass: DiffIdentical,
 		},
 		{
 			name:     "no real diffs mean identical",
@@ -1508,9 +1529,190 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 			class, reason := classifyParseDiffSession(
 				tt.needsRetry, tt.prepared, tt.hasStored,
 				tt.storedTrashed, tt.pendingResync, tt.realDiffs,
+				tt.raced,
 			)
 			assert.Equal(t, tt.wantClass, class)
 			assert.Equal(t, tt.wantReason, reason)
+		})
+	}
+}
+
+// TestParseDiffSourceRaced pins the conservative mtime-skew verdict: a
+// source that moved past the snapshot mtime (or whose mtime cannot be
+// resolved) is raced; one that is demonstrably at or before the snapshot
+// is not, so a genuine change there is never masked.
+func TestParseDiffSourceRaced(t *testing.T) {
+	mtime := func(v int64) *int64 { return &v }
+	tests := []struct {
+		name        string
+		storedMtime *int64
+		liveMtime   int64
+		liveOK      bool
+		want        bool
+	}{
+		{
+			name:        "live mtime advanced past snapshot is raced",
+			storedMtime: mtime(1000), liveMtime: 2000, liveOK: true,
+			want: true,
+		},
+		{
+			name:        "live mtime equal to snapshot is not raced",
+			storedMtime: mtime(1000), liveMtime: 1000, liveOK: true,
+			want: false,
+		},
+		{
+			name:        "live mtime before snapshot is not raced",
+			storedMtime: mtime(2000), liveMtime: 1000, liveOK: true,
+			want: false,
+		},
+		{
+			name:        "one nanosecond advance is raced (no truncation)",
+			storedMtime: mtime(1000), liveMtime: 1001, liveOK: true,
+			want: true,
+		},
+		{
+			name:        "unreadable source is conservatively raced",
+			storedMtime: mtime(1000), liveMtime: 0, liveOK: false,
+			want: true,
+		},
+		{
+			name:        "missing stored mtime is conservatively raced",
+			storedMtime: nil, liveMtime: 1000, liveOK: true,
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDiffSourceRaced(
+				tt.storedMtime, tt.liveMtime, tt.liveOK,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestParseDiffLiveMtimeIgnoresCodexIndex pins that Codex's raced guard uses
+// the transcript mtime, not the global session_index.jsonl mtime. The index is
+// shared by every Codex session, so an unrelated title/index write is not a
+// per-session signal that transcript-derived diffs raced with live content.
+func TestParseDiffLiveMtimeIgnoresCodexIndex(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions", "2024", "01", "01")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	rollout := filepath.Join(sessionsDir, "rollout-x.jsonl")
+	require.NoError(t, os.WriteFile(rollout, []byte("{}\n"), 0o644))
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, []byte("{}\n"), 0o644))
+
+	// Index not newer than the rollout: raced mtime is the rollout's.
+	base := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(rollout, base, base), "chtimes rollout")
+	require.NoError(t, os.Chtimes(indexPath, base, base), "chtimes index")
+
+	m1, err := parseDiffLiveMtime(parser.AgentCodex, rollout)
+	require.NoError(t, err)
+	rollInfo, err := os.Stat(rollout)
+	require.NoError(t, err)
+	assert.Equal(t, rollInfo.ModTime().UnixNano(), m1,
+		"codex raced mtime is the rollout's when the index is not newer")
+
+	// A sibling write advances the global index past the rollout AFTER the
+	// first resolution; the Codex raced resolver must keep reporting the
+	// transcript mtime.
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, os.Chtimes(indexPath, future, future), "advance index")
+	m2, err := parseDiffLiveMtime(parser.AgentCodex, rollout)
+	require.NoError(t, err)
+	assert.Equal(t, rollInfo.ModTime().UnixNano(), m2,
+		"codex raced mtime ignores the advanced session_index.jsonl")
+	assert.Equal(t, m1, m2, "the global index write is not observed")
+}
+
+// TestParseDiffSourceReliableForRaced pins the reliability gate that decides
+// whether the live-write skew (raced) reclassification may run for a session.
+// Only plain file-based agents reading a literal on-disk file have a live
+// mtime that is basis-matching with the stored file_mtime; every virtual-path
+// or DB-backed source must be treated as unreliable so the raced guard is
+// skipped and genuine parser drift is never masked.
+func TestParseDiffSourceReliableForRaced(t *testing.T) {
+	// Each virtual-path constructor is paired with a basename its parser
+	// accepts; stripVirtualSourceSuffix only recognizes the real shapes.
+	kiroPath := parser.KiroSQLiteVirtualPath(
+		"/data/data.sqlite3", "kiro_sess",
+	)
+	zedPath := parser.ZedSQLiteVirtualPath("/data/threads.db", "zed_thread")
+	shelleyPath := parser.ShelleyVirtualPath(
+		"/data/shelley.db", "shelley_conv",
+	)
+	vsCopilotPath := parser.VisualStudioCopilotVirtualPath(
+		"/traces/20260612T194439_abc_VSGitHubCopilot_traces.jsonl",
+		"conv_1",
+	)
+	tests := []struct {
+		name  string
+		agent parser.AgentType
+		path  string
+		want  bool
+	}{
+		{
+			name:  "plain file-based literal path is reliable",
+			agent: parser.AgentClaude,
+			path:  "/projects/proj/session.jsonl",
+			want:  true,
+		},
+		{
+			name:  "another plain file-based literal path is reliable",
+			agent: parser.AgentCodex,
+			path:  "/sessions/2026/06/rollout.jsonl",
+			want:  true,
+		},
+		{
+			name:  "aider virtual run-index path is unreliable",
+			agent: parser.AgentAider,
+			path:  parser.AiderVirtualPath("/repo/.aider.chat.history.md", 3),
+			want:  false,
+		},
+		{
+			name:  "kiro shared-db virtual path is unreliable",
+			agent: parser.AgentKiro,
+			path:  kiroPath,
+			want:  false,
+		},
+		{
+			name:  "zed shared-db virtual path is unreliable",
+			agent: parser.AgentZed,
+			path:  zedPath,
+			want:  false,
+		},
+		{
+			name:  "shelley shared-db virtual path is unreliable",
+			agent: parser.AgentShelley,
+			path:  shelleyPath,
+			want:  false,
+		},
+		{
+			name:  "visual studio copilot virtual path is unreliable",
+			agent: parser.AgentVSCopilot,
+			path:  vsCopilotPath,
+			want:  false,
+		},
+		{
+			name:  "db-backed agent on a literal path is unreliable",
+			agent: parser.AgentForge,
+			path:  "/forge/store.db",
+			want:  false,
+		},
+		{
+			name:  "unknown agent is unreliable",
+			agent: parser.AgentType("does-not-exist"),
+			path:  "/anywhere/file.jsonl",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDiffSourceReliableForRaced(tt.agent, tt.path)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1548,6 +1750,15 @@ func TestParseDiffReportHasFailures(t *testing.T) {
 				NeedsRetry: 2, NewOnDisk: 3,
 				ExcludedByParser: 1, InformationalOnly: 5,
 			},
+		},
+		{
+			name:   "raced sessions alone do not fail",
+			totals: ParseDiffTotals{Examined: 3, Identical: 2, Raced: 1},
+		},
+		{
+			name:   "a real change still fails alongside raced sessions",
+			totals: ParseDiffTotals{Changed: 1, Raced: 2},
+			want:   true,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -1628,6 +1628,29 @@ func TestParseDiffLiveMtimeIgnoresCodexIndex(t *testing.T) {
 	assert.Equal(t, m1, m2, "the global index write is not observed")
 }
 
+func TestParseDiffCodexTranscriptChangedRecomputesConsumedSize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout-x.jsonl")
+	initial := "{}\n"
+	require.NoError(t, os.WriteFile(path, []byte(initial), 0o644))
+	storedSize := int64(len(initial))
+	stored := &db.Session{FileSize: &storedSize}
+	parsed := parser.ParsedSession{
+		Agent: parser.AgentCodex,
+		File: parser.FileInfo{
+			Path: path,
+			Size: storedSize,
+		},
+	}
+
+	require.NoError(t, os.WriteFile(
+		path, []byte(initial+`{"appended":true}`+"\n"), 0o644,
+	))
+
+	assert.True(t,
+		parseDiffCodexTranscriptChangedSinceStored(stored, parsed),
+		"collect-time Codex race check must not trust the parser's stale size")
+}
+
 // TestParseDiffSourceReliableForRaced pins the reliability gate that decides
 // whether the live-write skew (raced) reclassification may run for a session.
 // Only plain file-based agents reading a literal on-disk file have a live

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1438,6 +1438,82 @@ func TestParseDiffCodexIndexSkewDoesNotMaskTranscriptDrift(t *testing.T) {
 		"transcript drift must trip --fail-on-change")
 }
 
+// TestParseDiffCodexTranscriptSkewUsesTranscriptStoredMtime pins the other
+// Codex mtime basis: the raced guard must compare the transcript-only live
+// mtime against the transcript-only stored mtime. Stored file_mtime still folds
+// in session_index.jsonl for normal sync invalidation, and that index mtime can
+// be newer than both transcript mtimes; it must not prevent a later transcript
+// write from being classified DiffRaced.
+func TestParseDiffCodexTranscriptSkewUsesTranscriptStoredMtime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229e2"
+	original := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Add tests").
+		AddCodexMessage(tsEarlyS5, "assistant", "Adding coverage.").
+		String()
+	sessionPath := env.writeCodexSession(
+		t, filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl", original,
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, []byte(
+		`{"id":"`+uuid+`","thread_name":"Codex title",`+
+			`"updated_at":"2026-06-11T17:34:20Z"}`+"\n",
+	), 0o644))
+	transcriptSnapshot := time.Now().Add(-4 * time.Hour)
+	transcriptWrite := time.Now().Add(-3 * time.Hour)
+	indexSnapshot := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(
+		sessionPath, transcriptSnapshot, transcriptSnapshot,
+	), "chtimes session snapshot")
+	require.NoError(t, os.Chtimes(indexPath, indexSnapshot, indexSnapshot),
+		"chtimes index snapshot")
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	stored, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, stored, "stored Codex session")
+	require.NotNil(t, stored.FileMtime, "stored file_mtime")
+	assert.Equal(t, indexSnapshot.UnixNano(), *stored.FileMtime,
+		"stored file_mtime should be index-folded")
+
+	changed := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Changed prompt").
+		AddCodexMessage(tsEarlyS5, "assistant", "Adding coverage.").
+		String()
+	require.NoError(t, os.WriteFile(sessionPath, []byte(changed), 0o644),
+		"rewrite transcript")
+	require.NoError(t, os.Chtimes(sessionPath, transcriptWrite, transcriptWrite),
+		"advance transcript below index-folded stored mtime")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentCodex},
+	})
+
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Raced: 1},
+		report.Totals, "transcript write should be raced")
+	assert.Empty(t, report.FieldCounts,
+		"raced field diffs must not count as parser drift")
+	raced := findSessionDiff(report, "codex:"+uuid)
+	require.NotNil(t, raced, "codex session not listed")
+	assert.Equal(t, sync.DiffRaced, raced.Class, "raced class")
+	assert.False(t, report.HasFailures(),
+		"transcript write skew must not trip --fail-on-change")
+}
+
 // writeHermesFanoutStateDB writes a Hermes state.db at <root>/state.db holding
 // two sessions (each one user message) and no sibling transcripts, so both
 // sessions resolve to the SAME shared state.db File.Path -- the literal-path

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1701,6 +1701,22 @@ func TestParseDiffEngineRefusesWrites(t *testing.T) {
 	assert.Equal(t, sync.SyncStats{},
 		diffEngine.SyncRootsSince(ctx, nil, time.Time{}, nil),
 		"SyncRootsSince on a report-only engine must be a no-op")
+	stats, err := diffEngine.SyncThenRun(
+		ctx, false, nil, func(forceFull bool) error {
+			return env.db.UpsertSession(db.Session{
+				ID: "sync-then-run-wrote",
+			})
+		},
+	)
+	require.NoError(t, err,
+		"SyncThenRun on a report-only engine should refuse cleanly")
+	assert.Equal(t, sync.SyncStats{}, stats,
+		"SyncThenRun on a report-only engine must be a no-op")
+	require.Error(t, diffEngine.RunExclusive(func() error {
+		return env.db.UpsertSession(db.Session{
+			ID: "run-exclusive-wrote",
+		})
+	}), "RunExclusive on a report-only engine must error")
 	require.Error(t, diffEngine.SyncSingleSession("claude:pd-guard"),
 		"SyncSingleSession on a report-only engine must error")
 

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1514,6 +1514,62 @@ func TestParseDiffCodexTranscriptSkewUsesTranscriptStoredMtime(t *testing.T) {
 		"transcript write skew must not trip --fail-on-change")
 }
 
+// TestParseDiffCodexIncrementalAppendDoesNotLookRaced covers the stable-source
+// side of the Codex transcript fingerprint fallback. A Codex incremental append
+// advances the stored source snapshot, so later parser drift against that
+// unchanged transcript must remain DiffChanged rather than being hidden as a
+// stale-fingerprint race.
+func TestParseDiffCodexIncrementalAppendDoesNotLookRaced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	env := setupTestEnv(t)
+
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229e3"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/tmp/proj", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl", initial,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("assistant", "world", tsEarlyS5),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, f.Close(), "close after append")
+	require.NoError(t, err, "append")
+	env.engine.SyncPaths([]string{path})
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 2)
+
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "codex:"+uuid)
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentCodex},
+	})
+
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Changed: 1},
+		report.Totals, "unchanged-source drift must stay changed")
+	assert.Equal(t, 1, report.FieldCounts[sync.FieldFirstMessage],
+		"first_message drift must be counted")
+	changed := findSessionDiff(report, "codex:"+uuid)
+	require.NotNil(t, changed, "codex session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class, "changed class")
+	assert.True(t, report.HasFailures(),
+		"stable-source parser drift must trip --fail-on-change")
+}
+
 // writeHermesFanoutStateDB writes a Hermes state.db at <root>/state.db holding
 // two sessions (each one user message) and no sibling transcripts, so both
 // sessions resolve to the SAME shared state.db File.Path -- the literal-path

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -555,6 +555,15 @@ func TestParseDiffBypassesSkipLayers(t *testing.T) {
 		Examined: 1, Identical: 1,
 	}, report.Totals, "totals before append")
 
+	// Capture the original mtime so the append can be replayed without
+	// tripping the live-write skew guard: appending advances the file
+	// mtime past the stored snapshot, which would (correctly) classify
+	// the diff as raced. Restoring the mtime keeps this test focused on
+	// the skip-layer bypass and the message_count CHANGE detection; the
+	// raced path has dedicated coverage in TestParseDiffRacedSourceSkew.
+	origInfo, err := os.Stat(path)
+	require.NoError(t, err, "stat source before append")
+
 	// Append one more message without syncing. The incremental
 	// append path would normally absorb this; a full re-parse must
 	// surface it as a message count change instead.
@@ -566,6 +575,9 @@ func TestParseDiffBypassesSkipLayers(t *testing.T) {
 	) + "\n")
 	require.NoError(t, err, "append message line")
 	require.NoError(t, f.Close(), "close session file")
+	require.NoError(t,
+		os.Chtimes(path, origInfo.ModTime(), origInfo.ModTime()),
+		"restore source mtime so the change is not classified raced")
 
 	report = runParseDiff(t, env, sync.ParseDiffOptions{})
 	assert.Equal(t, 1, report.FilesExamined, "files examined")
@@ -1141,6 +1153,437 @@ func TestParseDiffKiloSQLitePerSessionError(t *testing.T) {
 	assert.Contains(t, errEntry.FilePath, "kilo.db#bad-session",
 		"error attributed to the per-session virtual path")
 	assert.True(t, report.HasFailures(), "HasFailures")
+}
+
+// TestParseDiffRacedSourceSkew is the end-to-end live-write skew guard:
+// a stored row that drifted from its source is normally DiffChanged, but
+// when the on-disk source advances past the snapshot file_mtime mid-run
+// (simulating a daemon or active session rewriting the file after the
+// snapshot) the change is inconclusive and must be reclassified DiffRaced
+// without tripping --fail-on-change. A control session whose source was
+// not touched stays a real DiffChanged so a genuine regression is never
+// masked.
+func TestParseDiffRacedSourceSkew(t *testing.T) {
+	env := setupTestEnv(t)
+
+	racedPath := env.writeClaudeSession(t, "test-proj", "pd-raced.jsonl",
+		parseDiffClaudeContent("raced prompt", "raced reply"))
+	env.writeClaudeSession(t, "test-proj", "pd-control.jsonl",
+		parseDiffClaudeContent("control prompt", "control reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2, Synced: 2,
+	})
+
+	// Drift the stored rows so a re-parse of the unchanged source content
+	// would report a real first_message change for both.
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-raced")
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-control")
+
+	// Simulate a mid-run write to pd-raced's source only: push its mtime
+	// well past the stored snapshot file_mtime. The content is unchanged,
+	// so the comparison still detects the seeded drift, but the advanced
+	// mtime marks the comparison as a torn read. pd-control is left
+	// untouched, so its drift stays a genuine change.
+	future := time.Now().Add(48 * time.Hour)
+	require.NoError(t, os.Chtimes(racedPath, future, future),
+		"advance raced source mtime")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 2, Changed: 1, Raced: 1,
+	}, report.Totals, "totals")
+	// Only the untouched-source change is counted as drift; the raced
+	// session's masked field diff is excluded from FieldCounts.
+	assert.Equal(t, map[string]int{sync.FieldFirstMessage: 1},
+		report.FieldCounts,
+		"only the genuine change contributes to FieldCounts")
+
+	raced := findSessionDiff(report, "pd-raced")
+	require.NotNil(t, raced, "raced session not listed")
+	assert.Equal(t, sync.DiffRaced, raced.Class, "raced class")
+	assert.NotEmpty(t, raced.Reason, "raced reason")
+	// The would-be change is attached for drill-down even though it is
+	// not counted, so an operator can see what the skew masked.
+	assert.Contains(t, sessionDiffFieldNames(raced, true),
+		sync.FieldFirstMessage,
+		"raced field diff attached for drill-down")
+
+	changed := findSessionDiff(report, "pd-control")
+	require.NotNil(t, changed, "control session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class,
+		"untouched-source drift stays changed")
+	assert.Contains(t, sessionDiffFieldNames(changed, false),
+		sync.FieldFirstMessage, "control change field")
+
+	// The run fails because of the genuine change, not the raced one.
+	assert.True(t, report.HasFailures(),
+		"the untouched-source change must still trip --fail-on-change")
+}
+
+// TestParseDiffRacedAloneDoesNotFail isolates the gate contract: a run
+// whose only drift is masked by a live-write skew classifies raced and
+// must NOT trip --fail-on-change, so a concurrent daemon write can never
+// turn a vet run red on its own.
+func TestParseDiffRacedAloneDoesNotFail(t *testing.T) {
+	env := setupTestEnv(t)
+
+	racedPath := env.writeClaudeSession(t, "test-proj", "pd-solo.jsonl",
+		parseDiffClaudeContent("solo prompt", "solo reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-solo")
+	future := time.Now().Add(48 * time.Hour)
+	require.NoError(t, os.Chtimes(racedPath, future, future),
+		"advance raced source mtime")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Raced: 1,
+	}, report.Totals, "totals")
+	assert.Empty(t, report.FieldCounts,
+		"raced field diffs must be excluded from FieldCounts")
+	assert.False(t, report.HasFailures(),
+		"a raced session alone must not trip --fail-on-change")
+}
+
+// TestParseDiffRacedDoesNotMaskCleanRun proves the skew guard never
+// invents a raced session out of an identical comparison: advancing the
+// source mtime of a session whose stored rows still match the parse
+// leaves it identical, not raced (the raced reclass only applies when
+// there is a real change to mask).
+func TestParseDiffRacedDoesNotMaskCleanRun(t *testing.T) {
+	env := setupTestEnv(t)
+
+	path := env.writeClaudeSession(t, "test-proj", "pd-clean.jsonl",
+		parseDiffClaudeContent("clean prompt", "clean reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	// Advance the mtime without changing content: the comparison is still
+	// identical, so the session must remain identical despite the skew.
+	future := time.Now().Add(72 * time.Hour)
+	require.NoError(t, os.Chtimes(path, future, future), "advance mtime")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Identical: 1,
+	}, report.Totals, "an unchanged session must stay identical, not raced")
+	assert.False(t, report.HasFailures(), "clean run")
+}
+
+// TestParseDiffDBBackedSourceNotMaskedAsRaced pins the reliability gate for
+// composite, DB-backed sources. Many Kiro sessions share ONE data.sqlite3, and
+// the live mtime the skew guard could observe (a composite db stat or per-row
+// updated_at) is NOT a basis-matching stat of a literal file whose mtime
+// populated file_mtime. Because that comparison is unreliable, the raced
+// reclassification must NOT apply to these sources at all -- even when a
+// session's row updated_at advanced past its snapshot, a detected drift stays a
+// genuine DiffChanged rather than being masked as DiffRaced. This fails CLOSED:
+// real parser regressions on DB-backed agents are never hidden from
+// --fail-on-change.
+func TestParseDiffDBBackedSourceNotMaskedAsRaced(t *testing.T) {
+	env := setupTestEnv(t)
+	ks := createKiroSQLiteDB(t, env.kiroDir)
+	const (
+		advancedID  = "kiro-advanced"
+		quiescentID = "kiro-quiescent"
+	)
+	// Both sessions share the same payload content and the same initial
+	// updated_at, so each is stored with the same per-session snapshot
+	// file_mtime (updated_at * 1e6).
+	payload := readKiroSQLiteFixture(t, "standard_payload.json")
+	const initialUpdatedAt = int64(1779012030000)
+	ks.addSession(
+		t, "/home/user/code/kiro-app", advancedID,
+		payload, 1779012000000, initialUpdatedAt,
+	)
+	ks.addSession(
+		t, "/home/user/code/kiro-app", quiescentID,
+		payload, 1779012000000, initialUpdatedAt,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2, Synced: 2,
+	})
+
+	// Seed real parser drift in the archive for BOTH sessions so a
+	// re-parse of the unchanged payload detects a first_message change.
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "kiro:"+advancedID)
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "kiro:"+quiescentID)
+
+	// Advance ONLY one session's row updated_at past its snapshot. Under the
+	// old per-session raced check this would have masked the advanced session
+	// as DiffRaced; the reliability gate now skips the raced check for this
+	// DB-backed (virtual-path) source entirely, so the drift stays genuine.
+	ks.updateSession(t, advancedID, payload, initialUpdatedAt+60000)
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentKiro},
+	})
+
+	// Neither session is masked as raced: a DB-backed source has no
+	// basis-matching live mtime, so both genuine drifts are reported as
+	// changes and --fail-on-change fires.
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 2, Changed: 2,
+	}, report.Totals, "DB-backed drift must not be masked as raced")
+	// Both seeded first_message drifts are counted; the advanced session's
+	// updated_at bump additionally surfaces its ended_at change. Under the old
+	// raced reclassification the advanced session (and all its field diffs)
+	// would have been masked, hiding genuine drift from --fail-on-change.
+	assert.Equal(t, map[string]int{
+		sync.FieldFirstMessage: 2,
+		sync.FieldEndedAt:      1,
+	}, report.FieldCounts,
+		"genuine drift on DB-backed sources is no longer masked")
+
+	advanced := findSessionDiff(report, "kiro:"+advancedID)
+	require.NotNil(t, advanced, "advanced session not listed")
+	assert.Equal(t, sync.DiffChanged, advanced.Class,
+		"advanced DB-backed drift stays changed, not raced")
+	assert.Contains(t, sessionDiffFieldNames(advanced, false),
+		sync.FieldFirstMessage, "advanced field")
+
+	quiescent := findSessionDiff(report, "kiro:"+quiescentID)
+	require.NotNil(t, quiescent, "quiescent session not listed")
+	assert.Equal(t, sync.DiffChanged, quiescent.Class,
+		"untouched-source drift stays changed")
+	assert.Contains(t, sessionDiffFieldNames(quiescent, false),
+		sync.FieldFirstMessage, "quiescent field")
+
+	assert.True(t, report.HasFailures(),
+		"genuine DB-backed drift must trip --fail-on-change")
+}
+
+// TestParseDiffCodexIndexSkewDoesNotMaskTranscriptDrift pins that Codex's
+// shared session_index.jsonl mtime is not a per-session raced signal for
+// transcript-derived diffs. Advancing ONLY the index past the snapshot leaves
+// the transcript untouched; seeded first_message drift must stay DiffChanged
+// so --fail-on-change cannot pass because some unrelated title/index write
+// advanced the global index.
+func TestParseDiffCodexIndexSkewDoesNotMaskTranscriptDrift(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir}))
+
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229e1"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Add tests").
+		AddCodexMessage(tsEarlyS5, "assistant", "Adding coverage.").
+		String()
+	sessionPath := env.writeCodexSession(
+		t, filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl", content,
+	)
+
+	indexPath := filepath.Join(root, "session_index.jsonl")
+	require.NoError(t, os.WriteFile(indexPath, []byte(
+		`{"id":"`+uuid+`","thread_name":"Codex title",`+
+			`"updated_at":"2026-06-11T17:34:20Z"}`+"\n",
+	), 0o644))
+	// Pin both files to one past instant so the stored snapshot file_mtime
+	// (max of transcript and index) is that instant for both.
+	base := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(sessionPath, base, base), "chtimes session")
+	require.NoError(t, os.Chtimes(indexPath, base, base), "chtimes index")
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	// Seed real parser drift in the archive so a re-parse of the unchanged
+	// transcript reports a first_message change to reclassify.
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "codex:"+uuid)
+
+	// Advance ONLY the index past the snapshot; the transcript is untouched.
+	// CodexEffectiveMtime folds the index in, but that global index mtime is
+	// not evidence that this session's transcript-derived first_message diff
+	// raced with a live write.
+	future := time.Now().Add(48 * time.Hour)
+	require.NoError(t, os.Chtimes(indexPath, future, future),
+		"advance index mtime")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentCodex},
+	})
+
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Changed: 1},
+		report.Totals, "index-only skew must not mask transcript drift")
+	assert.Equal(t, 1, report.FieldCounts[sync.FieldFirstMessage],
+		"first_message drift must remain counted")
+	changed := findSessionDiff(report, "codex:"+uuid)
+	require.NotNil(t, changed, "codex session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class, "changed class")
+	assert.True(t, report.HasFailures(),
+		"transcript drift must trip --fail-on-change")
+}
+
+// writeHermesFanoutStateDB writes a Hermes state.db at <root>/state.db holding
+// two sessions (each one user message) and no sibling transcripts, so both
+// sessions resolve to the SAME shared state.db File.Path -- the literal-path
+// fan-out shape.
+func writeHermesFanoutStateDB(t *testing.T, root string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", filepath.Join(root, "state.db"))
+	require.NoError(t, err, "open hermes state.db")
+	defer conn.Close()
+	_, err = conn.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY, source TEXT NOT NULL, user_id TEXT,
+			model TEXT, model_config TEXT, system_prompt TEXT,
+			parent_session_id TEXT, started_at REAL NOT NULL, ended_at REAL,
+			end_reason TEXT, message_count INTEGER DEFAULT 0,
+			tool_call_count INTEGER DEFAULT 0, input_tokens INTEGER DEFAULT 0,
+			output_tokens INTEGER DEFAULT 0, cache_read_tokens INTEGER DEFAULT 0,
+			cache_write_tokens INTEGER DEFAULT 0, reasoning_tokens INTEGER DEFAULT 0,
+			billing_provider TEXT, billing_base_url TEXT, billing_mode TEXT,
+			estimated_cost_usd REAL, actual_cost_usd REAL, cost_status TEXT,
+			cost_source TEXT, pricing_version TEXT, title TEXT,
+			api_call_count INTEGER DEFAULT 0
+		);
+		CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL,
+			role TEXT NOT NULL, content TEXT, tool_call_id TEXT, tool_calls TEXT,
+			tool_name TEXT, timestamp REAL NOT NULL, token_count INTEGER,
+			finish_reason TEXT, reasoning TEXT, reasoning_content TEXT,
+			reasoning_details TEXT, codex_reasoning_items TEXT,
+			codex_message_items TEXT
+		);
+		INSERT INTO sessions (id, source, model, started_at, ended_at, message_count, title)
+			VALUES ('alpha', 'discord', 'gpt-5.5', 1778767200.0, 1778767800.0, 1, 'Alpha');
+		INSERT INTO sessions (id, source, model, started_at, ended_at, message_count, title)
+			VALUES ('beta', 'discord', 'gpt-5.5', 1778768200.0, 1778768800.0, 1, 'Beta');
+		INSERT INTO messages (session_id, role, content, timestamp)
+			VALUES ('alpha', 'user', 'alpha prompt', 1778767210.0);
+		INSERT INTO messages (session_id, role, content, timestamp)
+			VALUES ('beta', 'user', 'beta prompt', 1778768210.0);
+	`)
+	require.NoError(t, err, "seed hermes state.db")
+}
+
+// TestParseDiffHermesSharedStateDBNotMaskedAsRaced pins the literal-path
+// fan-out gate. Many Hermes sessions resolve to one shared state.db File.Path,
+// so its mtime is not a per-session signal: a write that advances state.db for
+// any session would, without the fan-out guard, race-mask genuine drift on
+// every sibling. Both sessions must therefore stay DiffChanged (fail closed),
+// not DiffRaced, even though the shared source mtime advanced past the snapshot.
+func TestParseDiffHermesSharedStateDBNotMaskedAsRaced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	writeHermesFanoutStateDB(t, root)
+
+	database := dbtest.OpenTestDB(t)
+	cfg := sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		Machine: "local",
+	}
+	engine := sync.NewEngine(database, cfg)
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 2, stats.Synced, "expected both Hermes sessions synced")
+
+	// Seed real parser drift in the archive for BOTH sessions so a re-parse
+	// of the unchanged state.db reports a first_message change.
+	for _, id := range []string{"hermes:alpha", "hermes:beta"} {
+		require.NoError(t, database.Update(func(tx *sql.Tx) error {
+			_, err := tx.Exec(
+				"UPDATE sessions SET first_message = ? WHERE id = ?",
+				"drifted first message", id,
+			)
+			return err
+		}), "drift %s", id)
+	}
+
+	// Advance the shared state.db mtime well past the stored snapshot, as a
+	// concurrent write to any session would.
+	future := time.Now().Add(48 * time.Hour)
+	require.NoError(t, os.Chtimes(
+		filepath.Join(root, "state.db"), future, future,
+	), "advance state.db mtime")
+
+	report, err := sync.NewDiffEngine(database, cfg).ParseDiff(
+		context.Background(),
+		sync.ParseDiffOptions{Agents: []parser.AgentType{parser.AgentHermes}},
+	)
+	require.NoError(t, err, "ParseDiff")
+	require.NotNil(t, report)
+
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 2, Changed: 2},
+		report.Totals, "shared-source drift must not be masked as raced")
+	for _, id := range []string{"hermes:alpha", "hermes:beta"} {
+		sd := findSessionDiff(report, id)
+		require.NotNil(t, sd, "%s not listed", id)
+		assert.Equal(t, sync.DiffChanged, sd.Class,
+			"%s stays changed, not raced", id)
+	}
+	assert.True(t, report.HasFailures(),
+		"genuine shared-source drift must trip --fail-on-change")
+}
+
+// TestParseDiffEngineRefusesWrites proves sub-item (4): the report-only
+// engine NewDiffEngine returns must refuse the write entrypoints
+// (SyncAll/ResyncAll and friends) so a forceParse engine can never be
+// driven into rewriting the archive. The refusal is a no-op (zero stats,
+// nil error) and persists nothing.
+func TestParseDiffEngineRefusesWrites(t *testing.T) {
+	env := setupTestEnv(t)
+
+	path := env.writeClaudeSession(t, "test-proj", "pd-guard.jsonl",
+		parseDiffClaudeContent("guard prompt", "guard reply"))
+
+	diffEngine := newParseDiffEngine(env)
+	ctx := context.Background()
+
+	assert.Equal(t, sync.SyncStats{}, diffEngine.SyncAll(ctx, nil),
+		"SyncAll on a report-only engine must be a no-op")
+	assert.Equal(t, sync.SyncStats{}, diffEngine.ResyncAll(ctx, nil),
+		"ResyncAll on a report-only engine must be a no-op")
+	assert.Equal(t, sync.SyncStats{},
+		diffEngine.SyncAllSince(ctx, time.Time{}, nil),
+		"SyncAllSince on a report-only engine must be a no-op")
+	assert.Equal(t, sync.SyncStats{},
+		diffEngine.SyncRootsSince(ctx, nil, time.Time{}, nil),
+		"SyncRootsSince on a report-only engine must be a no-op")
+	require.Error(t, diffEngine.SyncSingleSession("claude:pd-guard"),
+		"SyncSingleSession on a report-only engine must error")
+
+	// Nothing was written despite a discoverable source on disk.
+	require.FileExists(t, path)
+	all, err := env.db.ListSessionsModifiedBetween(ctx, "", "", nil, nil)
+	require.NoError(t, err, "list sessions")
+	assert.Empty(t, all,
+		"refused writes must not persist any session rows")
+
+	// The real sync engine (forceParse off) still syncs the same source,
+	// proving the guard is scoped to report-only engines only.
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
 }
 
 func TestParseDiffPresenceSweep(t *testing.T) {

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1570,6 +1570,59 @@ func TestParseDiffCodexIncrementalAppendDoesNotLookRaced(t *testing.T) {
 		"stable-source parser drift must trip --fail-on-change")
 }
 
+func TestParseDiffCodexIncrementalPartialTailDoesNotLookRaced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	env := setupTestEnv(t)
+
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229e4"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/tmp/proj", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl", initial,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("assistant", "world", tsEarlyS5),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append complete message")
+	_, err = f.WriteString(`{"timestamp":"2024-01-01T10:00:10Z"`)
+	require.NoError(t, err, "append partial trailing JSON")
+	require.NoError(t, f.Close(), "close after append")
+	env.engine.SyncPaths([]string{path})
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 2)
+
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "codex:"+uuid)
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentCodex},
+	})
+
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Changed: 1},
+		report.Totals, "unchanged consumed prefix drift must stay changed")
+	assert.Equal(t, 1, report.FieldCounts[sync.FieldFirstMessage],
+		"first_message drift must be counted")
+	changed := findSessionDiff(report, "codex:"+uuid)
+	require.NotNil(t, changed, "codex session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class, "changed class")
+	assert.True(t, report.HasFailures(),
+		"stable-source parser drift must trip --fail-on-change")
+}
+
 // writeHermesFanoutStateDB writes a Hermes state.db at <root>/state.db holding
 // two sessions (each one user message) and no sibling transcripts, so both
 // sessions resolve to the SAME shared state.db File.Path -- the literal-path

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1634,6 +1634,58 @@ func TestParseDiffCodexLegacyStaleIncrementalHashDoesNotLookRaced(t *testing.T) 
 		"stable-source parser drift must trip --fail-on-change")
 }
 
+func TestParseDiffCodexFullParsePartialTailDoesNotLookRaced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	env := setupTestEnv(t)
+
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229e6"
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/tmp/proj", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	) + `{"timestamp":"2024-01-01T10:00:10Z"`
+	path := env.writeCodexSession(
+		t, filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl", content,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 1)
+
+	stored, err := env.db.GetSessionFull(
+		context.Background(), "codex:"+uuid,
+	)
+	require.NoError(t, err, "GetSessionFull after full parse")
+	require.NotNil(t, stored, "stored session after full parse")
+	require.NotNil(t, stored.FileSize, "stored file_size")
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat transcript")
+	assert.Equal(t, info.Size(), *stored.FileSize,
+		"full Codex parse stores raw file size including ignored tail")
+
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "codex:"+uuid)
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentCodex},
+	})
+
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Changed: 1},
+		report.Totals, "unchanged full-parse partial tail drift must stay changed")
+	assert.Equal(t, 1, report.FieldCounts[sync.FieldFirstMessage],
+		"first_message drift must be counted")
+	changed := findSessionDiff(report, "codex:"+uuid)
+	require.NotNil(t, changed, "codex session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class, "changed class")
+	assert.True(t, report.HasFailures(),
+		"stable-source parser drift must trip --fail-on-change")
+}
+
 func TestParseDiffCodexIncrementalPartialTailDoesNotLookRaced(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1570,6 +1570,70 @@ func TestParseDiffCodexIncrementalAppendDoesNotLookRaced(t *testing.T) {
 		"stable-source parser drift must trip --fail-on-change")
 }
 
+func TestParseDiffCodexLegacyStaleIncrementalHashDoesNotLookRaced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	env := setupTestEnv(t)
+
+	const uuid = "019eb791-cf7d-75c1-8439-9ed74c1229e5"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/tmp/proj", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	)
+	path := env.writeCodexSession(
+		t, filepath.Join("2026", "06", "11"),
+		"rollout-2026-06-11T12-44-06-"+uuid+".jsonl", initial,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+	beforeAppend, err := env.db.GetSessionFull(
+		context.Background(), "codex:"+uuid,
+	)
+	require.NoError(t, err, "GetSessionFull before append")
+	require.NotNil(t, beforeAppend, "session before append")
+	require.NotNil(t, beforeAppend.FileHash, "file_hash before append")
+	staleHash := *beforeAppend.FileHash
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("assistant", "world", tsEarlyS5),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, f.Close(), "close after append")
+	require.NoError(t, err, "append")
+	env.engine.SyncPaths([]string{path})
+	assertSessionMessageCount(t, env.db, "codex:"+uuid, 2)
+
+	// Simulate a current data-version archive written by the legacy
+	// incremental path: size/mtime advanced, but file_hash stayed on the
+	// previous full-parse snapshot.
+	mutateDB(t, env,
+		"UPDATE sessions SET file_hash = ? WHERE id = ?",
+		staleHash, "codex:"+uuid)
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "codex:"+uuid)
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentCodex},
+	})
+
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Changed: 1},
+		report.Totals, "legacy stale hash drift must stay changed")
+	assert.Equal(t, 1, report.FieldCounts[sync.FieldFirstMessage],
+		"first_message drift must be counted")
+	changed := findSessionDiff(report, "codex:"+uuid)
+	require.NotNil(t, changed, "codex session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class, "changed class")
+	assert.True(t, report.HasFailures(),
+		"stable-source parser drift must trip --fail-on-change")
+}
+
 func TestParseDiffCodexIncrementalPartialTailDoesNotLookRaced(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1686,7 +1686,10 @@ func TestParseDiffEngineRefusesWrites(t *testing.T) {
 	env := setupTestEnv(t)
 
 	path := env.writeClaudeSession(t, "test-proj", "pd-guard.jsonl",
-		parseDiffClaudeContent("guard prompt", "guard reply"))
+		parseDiffClaudeContent(
+			"guard prompt with AKIA7QHWN2DKR4FYPLJM",
+			"guard reply",
+		))
 
 	diffEngine := newParseDiffEngine(env)
 	ctx := context.Background()
@@ -1732,6 +1735,40 @@ func TestParseDiffEngineRefusesWrites(t *testing.T) {
 	runSyncAndAssert(t, env.engine, sync.SyncStats{
 		TotalSessions: 1, Synced: 1,
 	})
+
+	const sessionID = "pd-guard"
+	mutateDB(t, env,
+		"UPDATE sessions SET secret_leak_count = 0, "+
+			"secrets_rules_version = '', quality_signal_version = 0"+
+			" WHERE id = ?", sessionID)
+	mutateDB(t, env,
+		"DELETE FROM secret_findings WHERE session_id = ?", sessionID)
+	require.Error(t, diffEngine.RecomputeSignals(ctx, sessionID),
+		"RecomputeSignals on a report-only engine must error")
+	mutateDB(t, env,
+		"UPDATE sessions SET secret_leak_count = 0, "+
+			"secrets_rules_version = '', quality_signal_version = 0"+
+			" WHERE id = ?", sessionID)
+	mutateDB(t, env,
+		"DELETE FROM secret_findings WHERE session_id = ?", sessionID)
+	_, err = diffEngine.ScanSecrets(
+		ctx, sync.SecretScanInput{Backfill: true}, nil,
+	)
+	require.Error(t, err,
+		"ScanSecrets on a report-only engine must error")
+	stored, err := env.db.GetSessionFull(ctx, sessionID)
+	require.NoError(t, err, "GetSessionFull after refused scans")
+	require.NotNil(t, stored, "stored session after refused scans")
+	assert.Zero(t, stored.SecretLeakCount,
+		"refused scans must not update secret_leak_count")
+	assert.Empty(t, stored.SecretsRulesVersion,
+		"refused scans must not update secrets_rules_version")
+	assert.Nil(t, stored.StoredQualitySignals(),
+		"refused recompute must not update quality signals")
+	findings, err := env.db.SessionSecretFindings(ctx, sessionID)
+	require.NoError(t, err, "SessionSecretFindings after refused scans")
+	assert.Empty(t, findings,
+		"refused scans must not persist secret findings")
 }
 
 func TestParseDiffPresenceSweep(t *testing.T) {

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -39,6 +39,21 @@ const (
 	// trashed, import-only agent, database-backed agent, not sampled
 	// (--limit), or not discovered.
 	DiffSkipped DiffClass = "skipped"
+	// DiffRaced: the comparison detected a non-informational change, but
+	// the on-disk source file's mtime advanced past the snapshot's stored
+	// file_mtime, so the file was written after the last sync recorded it.
+	// The "change" is therefore a torn comparison against live content (a
+	// concurrent daemon or active session), not a parser regression, and
+	// is inconclusive. Raced sessions are reported but never counted as a
+	// failure: --fail-on-change must not trip on them. Classification is
+	// deliberately conservative -- when the mtime relationship is
+	// ambiguous (missing stored mtime, unreadable source) a would-be
+	// change is treated as raced rather than risk a false regression --
+	// but a change is only ever reclassified when the file was not
+	// demonstrably untouched. Scope: the guard reclassifies the per-file
+	// compare path only; the presence sweep (a stored ID a clean parse no
+	// longer emits) is a separate signal and is not yet skew-guarded.
+	DiffRaced DiffClass = "raced"
 )
 
 // Compared-field names. Used as FieldDiff.Field values and
@@ -141,6 +156,10 @@ type ParseDiffTotals struct {
 	ExcludedByParser int `json:"excluded_by_parser"`
 	NeedsRetry       int `json:"transient_needs_retry"`
 	Skipped          int `json:"skipped"`
+	// Raced counts sessions whose would-be change was reclassified
+	// because the on-disk source advanced past the snapshot mtime. They
+	// are inconclusive (live-write skew), so HasFailures excludes them.
+	Raced int `json:"raced"`
 	// InformationalOnly counts sessions classified identical whose only
 	// diffs are informational. Included in Identical.
 	InformationalOnly int `json:"informational_only"`
@@ -171,6 +190,9 @@ type ParseDiffReport struct {
 
 // HasFailures reports whether --fail-on-change should exit non-zero:
 // real per-session changes or files the current binary cannot parse.
+// Raced sessions are deliberately excluded -- a change masked by a
+// live-write skew is inconclusive, not a parser regression, so it must
+// not trip the gate.
 func (r *ParseDiffReport) HasFailures() bool {
 	return r.Totals.Changed > 0 || r.Totals.ParseErrors > 0
 }


### PR DESCRIPTION
`parse-diff` re-parses on-disk sources and compares them against stored rows, so a parser change's effect can be gated in CI with `--fail-on-change`. Two things made that gate untrustworthy; this PR fixes both, plus a Codex title-refresh gap the work surfaced.

## Live-write skew classified as `raced`

`parse-diff` snapshots stored rows, then re-parses sources; a daemon or an active session writing the archive mid-run produced torn comparisons reported as `changed`, tripping `--fail-on-change` on a write unrelated to the parser. After each per-file compare, the source mtime is re-stat'd (the same agent-aware nanosecond value sync stores in `file_mtime`) and compared against the snapshot's `Session.FileMtime`; a file written after the snapshot is classified `raced` instead of `changed`. Raced sessions are excluded from `--fail-on-change`, so a concurrent write no longer fails the run, while a genuine change on a demonstrably untouched file still does. Classification is conservative (unreadable source or missing stored mtime → raced) but never masks a real change.

## Report-only engine write guard

`NewDiffEngine` returns the full `*Engine`, which still exposed `SyncAll`/`ResyncAll`, so a report-only/force-parse engine could in principle be driven into a write path. `refuseWriteInForceParse` now guards those entrypoints as a no-op when `forceParse` is set (only `NewDiffEngine` sets it). Additive; no existing write behavior changes.

## Codex title refresh (surfaced by this work)

To keep the raced guard consistent, the incremental write now folds the `session_index.jsonl` mtime into the stored `file_mtime`, exactly as a full parse does. That raised the stored watermark on the append path and exposed a latent gap: a title-only index rename whose mtime lands at or below the stored value was filtered out by an `indexMtime > storedMtime` gate (in both the incremental and `SyncAllSince` quick-sync paths), leaving the title stale behind `shouldSkipCodex`'s fast path. Both paths now compare the index title to the stored `session_name` directly. The broader "mtime-watermark conflates transcript + title" class is tracked as a follow-up.

## Scope

Covers the parse-diff v2 sub-items for live-write skew and the write-path guard, plus the Codex title-refresh fixes above. Incremental-append skew detection and DB-backed coverage for Warp/Forge/Piebald remain for a follow-up.

Reviewers: `internal/sync/parsediff.go`, `internal/sync/parsediff_compare.go`, `internal/sync/parsediff_report.go`, and the Codex paths in `internal/sync/engine.go`.
