### PR TITLE
fix(parser): parse native kimi code records

### DIFF
--- a/internal/parser/kimi.go
+++ b/internal/parser/kimi.go
@@ -223,10 +223,10 @@ func kimiIDComponentsValid(components ...string) bool {
 	return true
 }
 
-// ParseKimiSession parses a Kimi wire.jsonl file.
-// Wire.jsonl contains one JSON object per line with message types:
-// metadata, TurnBegin, StepBegin, ContentPart, ToolCall,
-// ToolResult, StatusUpdate, TurnEnd.
+// ParseKimiSession parses a Kimi wire.jsonl file. Legacy Kimi CLI
+// sessions store nested message.type records (TurnBegin, ContentPart,
+// ToolCall, ToolResult, StatusUpdate, TurnEnd). Kimi Code sessions store
+// top-level records (turn.prompt, context.append_loop_event, usage.record).
 func ParseKimiSession(
 	path, project, machine string,
 ) (*ParsedSession, []ParsedMessage, error) {
@@ -257,10 +257,18 @@ func ParseKimiSession(
 
 		// Accumulate content parts and tool calls for the
 		// current assistant turn.
-		pendingText     []string
-		pendingToolCall []ParsedToolCall
-		hasThinking     bool
-		hasToolUse      bool
+		pendingText             []string
+		pendingThinkingText     []string
+		pendingToolCall         []ParsedToolCall
+		pendingModel            string
+		pendingTokenUsage       json.RawMessage
+		pendingContextTokens    int
+		pendingOutputTokens     int
+		pendingHasContextTokens bool
+		pendingHasOutputTokens  bool
+		pendingStopReason       string
+		hasThinking             bool
+		hasToolUse              bool
 
 		// Track token usage from StatusUpdate.
 		totalOutputTokens    int
@@ -272,36 +280,54 @@ func ParseKimiSession(
 		// turn timestamp (latest seen).
 		currentTS time.Time
 		pendingTS time.Time
+
+		currentModel string
 	)
+
+	resetAssistantTurn := func() {
+		pendingText = nil
+		pendingThinkingText = nil
+		pendingToolCall = nil
+		pendingModel = ""
+		pendingTokenUsage = nil
+		pendingContextTokens = 0
+		pendingOutputTokens = 0
+		pendingHasContextTokens = false
+		pendingHasOutputTokens = false
+		pendingStopReason = ""
+		pendingTS = time.Time{}
+		hasThinking = false
+		hasToolUse = false
+	}
 
 	flushAssistantTurn := func() {
 		content := strings.Join(pendingText, "\n")
 		if strings.TrimSpace(content) == "" &&
 			len(pendingToolCall) == 0 {
-			pendingText = nil
-			pendingToolCall = nil
-			pendingTS = time.Time{}
-			hasThinking = false
-			hasToolUse = false
+			resetAssistantTurn()
 			return
 		}
 
 		messages = append(messages, ParsedMessage{
-			Ordinal:       ordinal,
-			Role:          RoleAssistant,
-			Content:       content,
-			Timestamp:     pendingTS,
-			HasThinking:   hasThinking,
-			HasToolUse:    hasToolUse,
-			ContentLength: len(content),
-			ToolCalls:     pendingToolCall,
+			Ordinal:          ordinal,
+			Role:             RoleAssistant,
+			Content:          content,
+			ThinkingText:     strings.Join(pendingThinkingText, "\n"),
+			Timestamp:        pendingTS,
+			HasThinking:      hasThinking,
+			HasToolUse:       hasToolUse,
+			ContentLength:    len(content),
+			ToolCalls:        pendingToolCall,
+			Model:            pendingModel,
+			TokenUsage:       pendingTokenUsage,
+			ContextTokens:    pendingContextTokens,
+			OutputTokens:     pendingOutputTokens,
+			HasContextTokens: pendingHasContextTokens,
+			HasOutputTokens:  pendingHasOutputTokens,
+			StopReason:       pendingStopReason,
 		})
 		ordinal++
-		pendingText = nil
-		pendingToolCall = nil
-		pendingTS = time.Time{}
-		hasThinking = false
-		hasToolUse = false
+		resetAssistantTurn()
 	}
 
 	for {
@@ -314,15 +340,9 @@ func ParseKimiSession(
 		}
 
 		root := gjson.Parse(line)
+		recordType := root.Get("type").Str
 
-		// Top-level "type" = "metadata" line.
-		if root.Get("type").Str == "metadata" {
-			continue
-		}
-
-		ts := root.Get("timestamp")
-		if ts.Type == gjson.Number {
-			t := time.Unix(int64(ts.Float()), int64((ts.Float()-float64(int64(ts.Float())))*1e9))
+		if t, ok := kimiRecordTimestamp(root); ok {
 			if startTime.IsZero() || t.Before(startTime) {
 				startTime = t
 			}
@@ -332,8 +352,197 @@ func ParseKimiSession(
 			currentTS = t
 		}
 
+		// Top-level "type" = "metadata" line.
+		if recordType == "metadata" {
+			continue
+		}
+
 		msgType := root.Get("message.type").Str
 		payload := root.Get("message.payload")
+
+		if msgType == "" && recordType != "" {
+			switch recordType {
+			case "config.update":
+				if model := root.Get("modelAlias").Str; model != "" {
+					currentModel = model
+				}
+
+			case "turn.prompt", "turn.steer":
+				flushAssistantTurn()
+
+				userText := kimiContentPartsText(root.Get("input"))
+				if userText == "" {
+					continue
+				}
+
+				if firstMessage == "" {
+					firstMessage = truncate(
+						strings.ReplaceAll(userText, "\n", " "),
+						300,
+					)
+				}
+
+				messages = append(messages, ParsedMessage{
+					Ordinal:       ordinal,
+					Role:          RoleUser,
+					Content:       userText,
+					Timestamp:     currentTS,
+					ContentLength: len(userText),
+				})
+				ordinal++
+
+			case "context.append_loop_event":
+				event := root.Get("event")
+				switch event.Get("type").Str {
+				case "content.part":
+					part := event.Get("part")
+					contentType := part.Get("type").Str
+					switch contentType {
+					case "text":
+						text := part.Get("text").Str
+						if text != "" {
+							if pendingTS.IsZero() {
+								pendingTS = currentTS
+							}
+							pendingText = append(pendingText, text)
+						}
+					case "think":
+						think := part.Get("think").Str
+						if think == "" {
+							think = part.Get("text").Str
+						}
+						if think != "" {
+							if pendingTS.IsZero() {
+								pendingTS = currentTS
+							}
+							hasThinking = true
+							pendingThinkingText = append(
+								pendingThinkingText, think,
+							)
+							pendingText = append(pendingText,
+								"[Thinking]\n"+think+"\n[/Thinking]")
+						}
+					}
+
+				case "tool.call":
+					if pendingTS.IsZero() {
+						pendingTS = currentTS
+					}
+					hasToolUse = true
+					fnName := event.Get("name").Str
+					fnArgs := kimiRawJSON(event.Get("args"))
+					toolID := event.Get("toolCallId").Str
+
+					tc := ParsedToolCall{
+						ToolUseID: toolID,
+						ToolName:  fnName,
+						Category:  NormalizeToolCategory(fnName),
+						InputJSON: fnArgs,
+						SkillName: inferToolSkillName(
+							fnName, fnArgs,
+						),
+					}
+					pendingToolCall = append(pendingToolCall, tc)
+
+					argsResult := kimiJSONResult(event.Get("args"))
+					pendingText = append(pendingText,
+						formatKimiToolUse(fnName, argsResult))
+
+				case "tool.result":
+					flushAssistantTurn()
+
+					toolCallID := event.Get("toolCallId").Str
+					result := event.Get("result")
+					isError := result.Get("isError").Bool()
+					output := extractKimiToolOutput(result.Get("output"))
+					if output == "" {
+						output = result.Get("message").Str
+					}
+					if isError && output == "" {
+						output = "[error]"
+					}
+
+					quoted, err := json.Marshal(output)
+					if err != nil {
+						continue
+					}
+
+					messages = append(messages, ParsedMessage{
+						Ordinal:   ordinal,
+						Role:      RoleUser,
+						Timestamp: currentTS,
+						ToolResults: []ParsedToolResult{{
+							ToolUseID:     toolCallID,
+							ContentRaw:    string(quoted),
+							ContentLength: len(output),
+						}},
+					})
+					ordinal++
+
+				case "step.end":
+					if pendingModel == "" {
+						pendingModel = currentModel
+					}
+					pendingStopReason = event.Get("finishReason").Str
+					if usage := event.Get("usage"); usage.Exists() {
+						tokenUsage, outputTokens, contextTokens,
+							hasOutput, hasContext :=
+							kimiNativeTokenUsage(usage)
+						pendingTokenUsage = tokenUsage
+						pendingOutputTokens = outputTokens
+						pendingContextTokens = contextTokens
+						pendingHasOutputTokens = hasOutput
+						pendingHasContextTokens = hasContext
+						if hasOutput {
+							hasTotalOutputTokens = true
+							totalOutputTokens += outputTokens
+						}
+						if hasContext {
+							hasPeakContextTokens = true
+							if contextTokens > peakContextTokens {
+								peakContextTokens = contextTokens
+							}
+						}
+					}
+					flushAssistantTurn()
+
+				case "step.begin":
+					// Informational; no action needed.
+				}
+
+			case "usage.record":
+				if model := root.Get("model").Str; model != "" {
+					currentModel = model
+				}
+				if usage := root.Get("usage"); usage.Exists() &&
+					len(messages) > 0 {
+					last := &messages[len(messages)-1]
+					if last.Role == RoleAssistant &&
+						len(last.TokenUsage) == 0 {
+						tokenUsage, outputTokens, contextTokens,
+							hasOutput, hasContext :=
+							kimiNativeTokenUsage(usage)
+						last.Model = currentModel
+						last.TokenUsage = tokenUsage
+						last.OutputTokens = outputTokens
+						last.ContextTokens = contextTokens
+						last.HasOutputTokens = hasOutput
+						last.HasContextTokens = hasContext
+						if hasOutput {
+							hasTotalOutputTokens = true
+							totalOutputTokens += outputTokens
+						}
+						if hasContext {
+							hasPeakContextTokens = true
+							if contextTokens > peakContextTokens {
+								peakContextTokens = contextTokens
+							}
+						}
+					}
+				}
+			}
+			continue
+		}
 
 		switch msgType {
 		case "TurnBegin":
@@ -396,6 +605,9 @@ func ParseKimiSession(
 						pendingTS = currentTS
 					}
 					hasThinking = true
+					pendingThinkingText = append(
+						pendingThinkingText, think,
+					)
 					pendingText = append(pendingText,
 						"[Thinking]\n"+think+"\n[/Thinking]")
 				}
@@ -415,6 +627,9 @@ func ParseKimiSession(
 				ToolName:  fnName,
 				Category:  NormalizeToolCategory(fnName),
 				InputJSON: fnArgs,
+				SkillName: inferToolSkillName(
+					fnName, fnArgs,
+				),
 			}
 			pendingToolCall = append(pendingToolCall, tc)
 
@@ -522,6 +737,107 @@ func ParseKimiSession(
 	}
 
 	return sess, messages, nil
+}
+
+func kimiRecordTimestamp(root gjson.Result) (time.Time, bool) {
+	if ts := root.Get("timestamp"); ts.Type == gjson.Number {
+		sec := int64(ts.Float())
+		nsec := int64((ts.Float() - float64(sec)) * 1e9)
+		return time.Unix(sec, nsec), true
+	}
+	if ts := root.Get("time"); ts.Type == gjson.Number {
+		return time.UnixMilli(ts.Int()), true
+	}
+	if ts := root.Get("created_at"); ts.Type == gjson.Number {
+		return time.UnixMilli(ts.Int()), true
+	}
+	return time.Time{}, false
+}
+
+func kimiContentPartsText(parts gjson.Result) string {
+	if !parts.IsArray() {
+		return ""
+	}
+	var out []string
+	parts.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").Str == "text" {
+			if text := part.Get("text").Str; text != "" {
+				out = append(out, text)
+			}
+		}
+		return true
+	})
+	return strings.Join(out, "\n")
+}
+
+func kimiRawJSON(value gjson.Result) string {
+	if !value.Exists() {
+		return ""
+	}
+	if value.Type == gjson.String && gjson.Valid(value.Str) {
+		return value.Str
+	}
+	return value.Raw
+}
+
+func kimiJSONResult(value gjson.Result) gjson.Result {
+	raw := kimiRawJSON(value)
+	if gjson.Valid(raw) {
+		return gjson.Parse(raw)
+	}
+	return value
+}
+
+func kimiNativeTokenUsage(
+	usage gjson.Result,
+) (json.RawMessage, int, int, bool, bool) {
+	var (
+		inputOther          int
+		output              int
+		inputCacheRead      int
+		inputCacheCreate    int
+		hasInputOther       bool
+		hasOutput           bool
+		hasInputCacheRead   bool
+		hasInputCacheCreate bool
+	)
+
+	if f := usage.Get("inputOther"); f.Exists() {
+		inputOther = int(f.Int())
+		hasInputOther = true
+	}
+	if f := usage.Get("output"); f.Exists() {
+		output = int(f.Int())
+		hasOutput = true
+	}
+	if f := usage.Get("inputCacheRead"); f.Exists() {
+		inputCacheRead = int(f.Int())
+		hasInputCacheRead = true
+	}
+	if f := usage.Get("inputCacheCreation"); f.Exists() {
+		inputCacheCreate = int(f.Int())
+		hasInputCacheCreate = true
+	}
+
+	if !hasInputOther && !hasOutput && !hasInputCacheRead &&
+		!hasInputCacheCreate {
+		return nil, 0, 0, false, false
+	}
+
+	normalized := map[string]int{
+		"input_tokens":                inputOther,
+		"output_tokens":               output,
+		"cache_read_input_tokens":     inputCacheRead,
+		"cache_creation_input_tokens": inputCacheCreate,
+	}
+	raw, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, 0, 0, false, false
+	}
+
+	contextTokens := inputOther + inputCacheRead + inputCacheCreate
+	hasContext := hasInputOther || hasInputCacheRead || hasInputCacheCreate
+	return raw, output, contextTokens, hasOutput, hasContext
 }
 
 // extractKimiToolOutput extracts text from a Kimi tool result

--- a/internal/parser/kimi_test.go
+++ b/internal/parser/kimi_test.go
@@ -545,6 +545,111 @@ func TestParseKimiSession_NewLayoutSessionID(t *testing.T) {
 	assertMessage(t, msgs[1], RoleAssistant, "Hi there!")
 }
 
+func TestParseKimiSession_NativeKimiCodeEvents(t *testing.T) {
+	path := writeKimiCodeWireJSONL(t,
+		"wd_myproject_a1b2c3d4", "session_uuid-1234", "main",
+		[]string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1782012661212}`,
+			`{"type":"config.update","modelAlias":"kimi-code/kimi-for-coding","thinkingLevel":"high","time":1782012661213}`,
+			`{"type":"turn.prompt","input":[{"type":"text","text":"hello"}],"origin":{"kind":"user"},"time":1782012666987}`,
+			`{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"hello"}],"toolCalls":[],"origin":{"kind":"user"}},"time":1782012666987}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"667ba233-c6d8-4939-b777-a5035ecc4215","turnId":"0","step":1},"time":1782012666989}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"1160b8b3-c0a6-436f-91db-ef737cd736cd","turnId":"0","step":1,"stepUuid":"667ba233-c6d8-4939-b777-a5035ecc4215","part":{"type":"think","think":"The user said hello. This is a simple greeting."}},"time":1782012668557}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"c379acc8-aaad-41bb-af8a-b478829e38f7","turnId":"0","step":1,"stepUuid":"667ba233-c6d8-4939-b777-a5035ecc4215","part":{"type":"text","text":"Hello! How can I help you today?"}},"time":1782012668558}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"667ba233-c6d8-4939-b777-a5035ecc4215","turnId":"0","step":1,"usage":{"inputOther":1598,"output":37,"inputCacheRead":14592,"inputCacheCreation":0},"finishReason":"end_turn","llmFirstTokenLatencyMs":1169,"llmStreamDurationMs":396},"time":1782012668558}`,
+			`{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":1598,"output":37,"inputCacheRead":14592,"inputCacheCreation":0},"usageScope":"turn","time":1782012668558}`,
+		},
+	)
+
+	sess, msgs, err := ParseKimiSession(path, "myproject", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assertSessionMeta(t, sess,
+		"kimi:wd_myproject_a1b2c3d4:main:session_uuid-1234",
+		"myproject", AgentKimi,
+	)
+	assert.Equal(t, "hello", sess.FirstMessage)
+	assertMessageCount(t, sess.MessageCount, 2)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, 37, sess.TotalOutputTokens)
+	assert.Equal(t, 16190, sess.PeakContextTokens)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+
+	require.Len(t, msgs, 2)
+	assertMessage(t, msgs[0], RoleUser, "hello")
+	assertTimestamp(t, msgs[0].Timestamp,
+		time.UnixMilli(1782012666987))
+
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.True(t, msgs[1].HasThinking)
+	assert.Contains(t, msgs[1].Content, "[Thinking]")
+	assert.Contains(t, msgs[1].Content, "simple greeting")
+	assert.Contains(t, msgs[1].Content,
+		"Hello! How can I help you today?")
+	assert.Equal(t, "kimi-code/kimi-for-coding", msgs[1].Model)
+	assert.Equal(t, "end_turn", msgs[1].StopReason)
+	assert.True(t, msgs[1].HasOutputTokens)
+	assert.True(t, msgs[1].HasContextTokens)
+	assert.Equal(t, 37, msgs[1].OutputTokens)
+	assert.Equal(t, 16190, msgs[1].ContextTokens)
+	assert.JSONEq(t,
+		`{"input_tokens":1598,"output_tokens":37,"cache_read_input_tokens":14592,"cache_creation_input_tokens":0}`,
+		string(msgs[1].TokenUsage),
+	)
+	assertTimestamp(t, msgs[1].Timestamp,
+		time.UnixMilli(1782012668557))
+}
+
+func TestParseKimiSession_NativeKimiCodeToolCall(t *testing.T) {
+	path := writeKimiCodeWireJSONL(t,
+		"wd_myproject_a1b2c3d4", "session_uuid-tool", "main",
+		[]string{
+			`{"type":"metadata","protocol_version":"1.4","created_at":1782012661212}`,
+			`{"type":"config.update","modelAlias":"kimi-code/kimi-for-coding","time":1782012661213}`,
+			`{"type":"turn.prompt","input":[{"type":"text","text":"List files"}],"origin":{"kind":"user"},"time":1782012666987}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-1","turnId":"0","step":1},"time":1782012666989}`,
+			`{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"call-event","turnId":"0","step":1,"stepUuid":"step-1","toolCallId":"tool_1","name":"Bash","args":{"command":"ls","description":"List files"}},"time":1782012667000}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-1","turnId":"0","step":1,"usage":{"inputOther":10,"output":3,"inputCacheRead":20,"inputCacheCreation":0},"finishReason":"tool_use"},"time":1782012667001}`,
+			`{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"call-event","toolCallId":"tool_1","result":{"output":"main.go\nREADME.md","isError":false}},"time":1782012667002}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"step-2","turnId":"0","step":2},"time":1782012667003}`,
+			`{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part-1","turnId":"0","step":2,"stepUuid":"step-2","part":{"type":"text","text":"Found the files."}},"time":1782012667004}`,
+			`{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"step-2","turnId":"0","step":2,"usage":{"inputOther":30,"output":4,"inputCacheRead":40,"inputCacheCreation":5},"finishReason":"end_turn"},"time":1782012667005}`,
+		},
+	)
+
+	sess, msgs, err := ParseKimiSession(path, "myproject", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.Equal(t, 7, sess.TotalOutputTokens)
+	assert.Equal(t, 75, sess.PeakContextTokens)
+
+	require.Len(t, msgs, 4)
+	assertMessage(t, msgs[0], RoleUser, "List files")
+	require.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.True(t, msgs[1].HasToolUse)
+	assert.Contains(t, msgs[1].Content, "[Bash: List files]")
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "tool_1", msgs[1].ToolCalls[0].ToolUseID)
+	assert.Equal(t, "Bash", msgs[1].ToolCalls[0].ToolName)
+	assert.JSONEq(t, `{"command":"ls","description":"List files"}`,
+		msgs[1].ToolCalls[0].InputJSON)
+	assert.Equal(t, "tool_use", msgs[1].StopReason)
+
+	require.Equal(t, RoleUser, msgs[2].Role)
+	require.Len(t, msgs[2].ToolResults, 1)
+	assert.Equal(t, "tool_1", msgs[2].ToolResults[0].ToolUseID)
+	assert.Equal(t, "main.go\nREADME.md",
+		DecodeContent(msgs[2].ToolResults[0].ContentRaw))
+
+	assertMessage(t, msgs[3], RoleAssistant, "Found the files.")
+	assert.Equal(t, "end_turn", msgs[3].StopReason)
+	assert.Equal(t, 4, msgs[3].OutputTokens)
+	assert.Equal(t, 75, msgs[3].ContextTokens)
+}
+
 func TestParseKimiSession_NewLayout_AgentZero(t *testing.T) {
 	path := writeKimiCodeWireJSONL(t,
 		"wd_myproject_a1b2c3d4", "session_uuid-5678", "agent-0",

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8288,9 +8288,9 @@ func nextParsedOrdinal(
 func lastParsedSourceUUID(
 	current string, msgs []parser.ParsedMessage,
 ) string {
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].SourceUUID != "" {
-			return msgs[i].SourceUUID
+	for _, v := range slices.Backward(msgs) {
+		if v.SourceUUID != "" {
+			return v.SourceUUID
 		}
 	}
 	return current


### PR DESCRIPTION
Kimi Code 0.18 writes `wire.jsonl` as top-level agent records such as `turn.prompt`, `context.append_loop_event`, and `usage.record`, while the existing Kimi parser only understood the older nested Kimi CLI `message.type` envelope. That meant `.kimi-code` files could be discovered but still produced no parsed session because every native record missed the parser dispatch key.

This teaches the Kimi parser to normalize native Kimi Code turns, assistant content, thinking, tool calls, tool results, step usage, and model attribution into the same session/message model used by legacy Kimi sessions. The parser treats `usage.record` as a fallback when `step.end` did not already carry usage so turn-level accounting is available without double-counting the issue sample.

One mechanical `golangci-lint --fix` rewrite in the sync engine is included because the installed pre-commit hook applies it repo-wide and would otherwise leave the tree dirty during commit.

Fixes #796