### PR TITLE
Reject archives from newer agentsview binaries

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,6 +21,36 @@ const (
 	groupUsage = "usage"
 	groupMeta  = "meta"
 )
+
+const dataVersionTooNewExitCode = 3
+
+type cliExitError struct {
+	code int
+	err  error
+}
+
+func (e *cliExitError) Error() string {
+	return e.err.Error()
+}
+
+func (e *cliExitError) Unwrap() error {
+	return e.err
+}
+
+func withExitCode(err error, code int) error {
+	if err == nil {
+		return nil
+	}
+	return &cliExitError{code: code, err: err}
+}
+
+func exitCodeFromError(err error) int {
+	var exitErr *cliExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.code
+	}
+	return 1
+}
 
 func newRootCommand() *cobra.Command {
 	var showVersion bool
@@ -99,7 +130,11 @@ func newServeCommand() *cobra.Command {
 		Args:         cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if checkDataVersion {
-				return runServeDataVersionCheck(mustLoadConfig(cmd))
+				cfg, err := config.LoadReadOnly()
+				if err != nil {
+					return err
+				}
+				return runServeDataVersionCheck(cfg)
 			}
 			if background {
 				// Acquire the launch lock before loading config; config
@@ -132,7 +167,11 @@ func newServeCommand() *cobra.Command {
 }
 
 func runServeDataVersionCheck(cfg config.Config) error {
-	return db.CheckDataVersion(cfg.DBPath)
+	err := db.CheckDataVersion(cfg.DBPath)
+	if db.IsDataVersionTooNew(err) {
+		return withExitCode(err, dataVersionTooNewExitCode)
+	}
+	return err
 }
 
 func newServeStatusCommand() *cobra.Command {

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -90,21 +90,26 @@ func newRootCommand() *cobra.Command {
 
 func newServeCommand() *cobra.Command {
 	var background bool
+	var checkDataVersion bool
 	cmd := &cobra.Command{
 		Use:          "serve",
 		Short:        "Start server",
 		GroupID:      groupCore,
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if checkDataVersion {
+				return runServeDataVersionCheck(mustLoadConfig(cmd))
+			}
 			if background {
 				// Acquire the launch lock before loading config; config
 				// loading writes config.toml and must be single-writer
 				// across concurrent launches.
 				runServeBackgroundCommand(cmd)
-				return
+				return nil
 			}
 			runServe(mustLoadConfig(cmd))
+			return nil
 		},
 	}
 	cmd.Flags().BoolVar(
@@ -113,10 +118,21 @@ func newServeCommand() *cobra.Command {
 		false,
 		"Start server in the background and return to the shell",
 	)
+	cmd.Flags().BoolVar(
+		&checkDataVersion,
+		"check-data-version",
+		false,
+		"Check whether the configured database is compatible with this binary",
+	)
+	_ = cmd.Flags().MarkHidden("check-data-version")
 	config.RegisterServePFlags(cmd.Flags())
 	cmd.AddCommand(newServeStatusCommand())
 	cmd.AddCommand(newServeStopCommand())
 	return cmd
+}
+
+func runServeDataVersionCheck(cfg config.Config) error {
+	return db.CheckDataVersion(cfg.DBPath)
 }
 
 func newServeStatusCommand() *cobra.Command {

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -132,9 +132,23 @@ func TestServeCheckDataVersionRejectsNewerDatabase(t *testing.T) {
 
 	out, err := executeCommand(newRootCommand(), "serve", "--check-data-version")
 	require.Error(t, err, "preflight should reject newer archive")
+	assert.Equal(t, dataVersionTooNewExitCode, exitCodeFromError(err))
 	assert.Empty(t, out)
 	assert.Contains(t, err.Error(), "database data version")
 	assert.Contains(t, err.Error(), "is newer than this agentsview binary")
+}
+
+func TestServeCheckDataVersionDoesNotCreateConfig(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+
+	out, err := executeCommand(newRootCommand(), "serve", "--check-data-version")
+
+	require.NoError(t, err, "preflight with no database")
+	assert.Empty(t, out)
+	_, statErr := os.Stat(filepath.Join(dataDir, "config.toml"))
+	require.ErrorIs(t, statErr, os.ErrNotExist,
+		"preflight must not create config.toml")
 }
 
 func TestRootNoArgsShowsHelp(t *testing.T) {

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -136,6 +136,7 @@ func TestServeCheckDataVersionRejectsNewerDatabase(t *testing.T) {
 	assert.Empty(t, out)
 	assert.Contains(t, err.Error(), "database data version")
 	assert.Contains(t, err.Error(), "is newer than this agentsview binary")
+	assert.Contains(t, err.Error(), `Run "agentsview update"`)
 }
 
 func TestServeCheckDataVersionDoesNotCreateConfig(t *testing.T) {

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func executeCommand(root *cobra.Command, args ...string) (string, error) {
@@ -108,6 +112,29 @@ func TestOpenAPICommandEmitsSpec(t *testing.T) {
 	assert.Contains(t, spec.Paths["/api/v1/sessions"], "get")
 	require.Contains(t, spec.Paths, "/api/v1/sessions/{id}/rename")
 	assert.Contains(t, spec.Paths["/api/v1/sessions/{id}/rename"], "patch")
+}
+
+func TestServeCheckDataVersionRejectsNewerDatabase(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	dbPath := filepath.Join(dataDir, "sessions.db")
+
+	database, err := db.Open(dbPath)
+	require.NoError(t, err, "open db")
+	require.NoError(t, database.Close(), "close db")
+
+	futureVersion := db.CurrentDataVersion() + 10
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err, "raw sqlite open")
+	_, err = conn.Exec(fmt.Sprintf("PRAGMA user_version = %d", futureVersion))
+	require.NoError(t, err, "set future user_version")
+	require.NoError(t, conn.Close(), "close raw sqlite")
+
+	out, err := executeCommand(newRootCommand(), "serve", "--check-data-version")
+	require.Error(t, err, "preflight should reject newer archive")
+	assert.Empty(t, out)
+	assert.Contains(t, err.Error(), "database data version")
+	assert.Contains(t, err.Error(), "is newer than this agentsview binary")
 }
 
 func TestRootNoArgsShowsHelp(t *testing.T) {

--- a/cmd/agentsview/doctor.go
+++ b/cmd/agentsview/doctor.go
@@ -399,7 +399,7 @@ func doctorLikelyCause(
 		return "SQLite user_version is stale; inspect debug.log for resync aborts or failures"
 	}
 	if *report.UserVersion > currentVersion {
-		return "SQLite user_version is newer than this binary; upgrade agentsview before serving or syncing"
+		return "SQLite user_version is newer than this binary. Run \"agentsview update\" or install the latest AgentsView release before serving or syncing"
 	}
 	return "data-version resync is not expected; Running initial sync... is normal incremental startup work"
 }

--- a/cmd/agentsview/doctor.go
+++ b/cmd/agentsview/doctor.go
@@ -302,6 +302,9 @@ func doctorStartupDecision(
 	if *report.UserVersion < currentVersion {
 		return "full data-version resync required"
 	}
+	if *report.UserVersion > currentVersion {
+		return "refuse startup (database requires newer agentsview)"
+	}
 	return "normal initial sync (no data-version resync)"
 }
 
@@ -394,6 +397,9 @@ func doctorLikelyCause(
 			return "one or more configured agent roots are missing; resync may be aborting during discovery"
 		}
 		return "SQLite user_version is stale; inspect debug.log for resync aborts or failures"
+	}
+	if *report.UserVersion > currentVersion {
+		return "SQLite user_version is newer than this binary; upgrade agentsview before serving or syncing"
 	}
 	return "data-version resync is not expected; Running initial sync... is normal incremental startup work"
 }

--- a/cmd/agentsview/doctor_test.go
+++ b/cmd/agentsview/doctor_test.go
@@ -87,6 +87,35 @@ func TestDoctorSyncStaleDatabaseReportsLikelyAbortedResync(t *testing.T) {
 		"Likely cause: previous data-version resync likely aborted before completion")
 }
 
+func TestDoctorSyncNewerDatabaseReportsRefusedStartup(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	dbPath := filepath.Join(dataDir, "sessions.db")
+
+	database, err := db.Open(dbPath)
+	require.NoError(t, err, "open db")
+	require.NoError(t, database.Close(), "close db")
+
+	futureVersion := db.CurrentDataVersion() + 10
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err, "raw sqlite open")
+	_, err = conn.Exec(fmt.Sprintf("PRAGMA user_version = %d", futureVersion))
+	require.NoError(t, err, "set future user_version")
+	require.NoError(t, conn.Close(), "close raw sqlite")
+
+	out, err := executeCommand(newRootCommand(), "doctor", "sync")
+	require.NoError(t, err, "doctor sync")
+
+	assert.Contains(t, out,
+		fmt.Sprintf("SQLite user_version: %d", futureVersion))
+	assert.Contains(t, out,
+		fmt.Sprintf("Binary data version: %d", db.CurrentDataVersion()))
+	assert.Contains(t, out,
+		"Startup sync decision: refuse startup (database requires newer agentsview)")
+	assert.Contains(t, out,
+		"Likely cause: SQLite user_version is newer than this binary")
+}
+
 func TestDoctorSyncReportStatErrorDoesNotRenderAsMissingDatabase(t *testing.T) {
 	report := doctorSyncReport{
 		Config: config.Config{

--- a/cmd/agentsview/doctor_test.go
+++ b/cmd/agentsview/doctor_test.go
@@ -114,6 +114,7 @@ func TestDoctorSyncNewerDatabaseReportsRefusedStartup(t *testing.T) {
 		"Startup sync decision: refuse startup (database requires newer agentsview)")
 	assert.Contains(t, out,
 		"Likely cause: SQLite user_version is newer than this binary")
+	assert.Contains(t, out, `Run "agentsview update"`)
 }
 
 func TestDoctorSyncReportStatErrorDoesNotRenderAsMissingDatabase(t *testing.T) {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -48,7 +48,9 @@ func main() {
 	secrets.EnableFixtureDeny()
 
 	if err := executeCLI(); err != nil {
-		fatal("%v", err)
+		code := exitCodeFromError(err)
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(code)
 	}
 }
 

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -296,6 +296,11 @@ func runPGServe(appCfg config.Config, basePath string) {
 			"Drop and recreate the PG schema, then run "+
 			"'agentsview pg push --full' to repopulate.", err)
 	}
+	if err := postgres.CheckDataVersionCompat(
+		ctx, store.DB(),
+	); err != nil {
+		fatal("pg serve: %v", err)
+	}
 
 	rtOpts := serveRuntimeOptions{
 		Mode:          "pg-serve",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(125);
 const LOGIN_SHELL_ENV_TIMEOUT: Duration = Duration::from_secs(3);
 const UPDATE_SIDECAR_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+const DATA_VERSION_TOO_NEW_EXIT_CODE: i32 = 3;
 // Delay after navigating to the backend before probing whether the
 // Linux WebKitGTK web content process is actually alive. Gives the
 // process time to spawn so we don't false-positive on slow startup.
@@ -91,8 +92,8 @@ pub fn run() {
                 }
                 Err(DataVersionPreflightError::TooNew(message)) => {
                     let window = main_window(app)?;
-                    show_preflight_error(
-                        &window,
+                    spawn_preflight_error_render(
+                        window,
                         "AgentsView needs an update",
                         format!(
                             "{message}. AgentsView cannot open this archive with the bundled backend."
@@ -106,8 +107,8 @@ pub fn run() {
                 }
                 Err(DataVersionPreflightError::Failed(message)) => {
                     let window = main_window(app)?;
-                    show_preflight_error(
-                        &window,
+                    spawn_preflight_error_render(
+                        window,
                         "AgentsView could not verify the archive",
                         format!(
                             "Database compatibility check failed: {message}. The backend was not started."
@@ -257,9 +258,7 @@ fn classify_data_version_preflight_exit(
 
     let message = combined_preflight_output(stdout, stderr)
         .unwrap_or_else(|| format!("data version preflight exited with code {code:?}"));
-    if message.contains("database data version")
-        && message.contains("is newer than this agentsview binary")
-    {
+    if code == Some(DATA_VERSION_TOO_NEW_EXIT_CODE) {
         return Err(DataVersionPreflightError::TooNew(message));
     }
     Err(DataVersionPreflightError::Failed(message))
@@ -956,14 +955,42 @@ fn main_window_from_handle(handle: &AppHandle) -> Result<WebviewWindow, DynError
         .ok_or_else(|| io::Error::other("missing main window").into())
 }
 
+fn spawn_preflight_error_render(window: WebviewWindow, title: &str, message: &str) {
+    let title = title.to_string();
+    let message = message.to_string();
+    thread::spawn(move || {
+        let deadline = Instant::now() + READY_TIMEOUT;
+        while Instant::now() < deadline {
+            if window.eval(preflight_error_ready_probe()).is_ok() {
+                show_preflight_error(&window, title.as_str(), message.as_str());
+                return;
+            }
+            thread::sleep(READY_POLL_INTERVAL);
+        }
+        eprintln!("[agentsview] timed out waiting to render data-version preflight error");
+    });
+}
+
+fn preflight_error_ready_probe() -> &'static str {
+    "if (!document.querySelector('h1') || !document.getElementById('status')) { \
+        throw new Error('loading') \
+    }"
+}
+
 fn show_preflight_error(window: &WebviewWindow, title: &str, message: &str) {
+    let script = preflight_error_script(title, message);
+    let _ = window.eval(script.as_str());
+}
+
+fn preflight_error_script(title: &str, message: &str) -> String {
     let title = js_string_literal(title);
     let message = js_string_literal(message);
-    let script = format!(
+    format!(
         "(function() {{\
             var h = document.querySelector('h1');\
             if (h) h.textContent = {title};\
-            if (window.__setStatus) window.__setStatus({message});\
+            var status = document.getElementById('status');\
+            if (status) status.textContent = {message};\
             var meter = document.querySelector('.meter');\
             if (meter) meter.style.display = 'none';\
             var stages = document.querySelector('.stage-list');\
@@ -971,8 +998,7 @@ fn show_preflight_error(window: &WebviewWindow, title: &str, message: &str) {
             var foot = document.querySelector('.foot');\
             if (foot) foot.textContent = 'Use Check for Updates from the AgentsView menu after updating manually.';\
         }})()"
-    );
-    let _ = window.eval(script.as_str());
+    )
 }
 
 fn js_string_literal(value: &str) -> String {
@@ -1723,18 +1749,15 @@ mod tests {
     #[test]
     fn classify_data_version_preflight_exit_detects_too_new_database() {
         let err = classify_data_version_preflight_exit(
-            Some(1),
+            Some(DATA_VERSION_TOO_NEW_EXIT_CODE),
             "",
-            "fatal: database data version 59 is newer than this agentsview binary's data version 49",
+            "fatal: archive is too new",
         )
         .expect_err("expected too-new error");
 
         assert_eq!(
             err,
-            DataVersionPreflightError::TooNew(
-                "fatal: database data version 59 is newer than this agentsview binary's data version 49"
-                    .to_string()
-            )
+            DataVersionPreflightError::TooNew("fatal: archive is too new".to_string())
         );
     }
 
@@ -1748,6 +1771,42 @@ mod tests {
             err,
             DataVersionPreflightError::Failed("fatal: loading config: bad toml".to_string())
         );
+    }
+
+    #[test]
+    fn classify_data_version_preflight_exit_does_not_parse_error_prose() {
+        let err = classify_data_version_preflight_exit(
+            Some(1),
+            "",
+            "fatal: database data version 59 is newer than this agentsview binary's data version 49",
+        )
+        .expect_err("expected generic failure");
+
+        assert_eq!(
+            err,
+            DataVersionPreflightError::Failed(
+                "fatal: database data version 59 is newer than this agentsview binary's data version 49"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn preflight_error_script_updates_dom_directly() {
+        let script = preflight_error_script("Needs update", "Archive is too new");
+
+        assert!(script.contains("document.querySelector('h1')"));
+        assert!(script.contains("document.getElementById('status')"));
+        assert!(!script.contains("window.__setStatus"));
+    }
+
+    #[test]
+    fn preflight_error_ready_probe_requires_loading_dom() {
+        let probe = preflight_error_ready_probe();
+
+        assert!(probe.contains("document.querySelector('h1')"));
+        assert!(probe.contains("document.getElementById('status')"));
+        assert!(probe.contains("throw new Error"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -960,10 +960,10 @@ fn spawn_preflight_error_render(window: WebviewWindow, title: &str, message: &st
     let message = message.to_string();
     let footer = footer.to_string();
     thread::spawn(move || {
+        let script = preflight_error_script(title.as_str(), message.as_str(), footer.as_str());
         let deadline = Instant::now() + READY_TIMEOUT;
         while Instant::now() < deadline {
-            if window.eval(preflight_error_ready_probe()).is_ok() {
-                show_preflight_error(&window, title.as_str(), message.as_str(), footer.as_str());
+            if window.eval(script.as_str()).is_ok() {
                 return;
             }
             thread::sleep(READY_POLL_INTERVAL);
@@ -972,26 +972,20 @@ fn spawn_preflight_error_render(window: WebviewWindow, title: &str, message: &st
     });
 }
 
-fn preflight_error_ready_probe() -> &'static str {
-    "if (!document.querySelector('h1') || !document.getElementById('status')) { \
-        throw new Error('loading') \
-    }"
-}
-
-fn show_preflight_error(window: &WebviewWindow, title: &str, message: &str, footer: &str) {
-    let script = preflight_error_script(title, message, footer);
-    let _ = window.eval(script.as_str());
-}
-
 fn preflight_error_script(title: &str, message: &str, footer: &str) -> String {
     let title = js_string_literal(title);
     let message = js_string_literal(message);
     let footer = js_string_literal(footer);
+    let retry_ms = READY_POLL_INTERVAL.as_millis();
     format!(
-        "(function() {{\
+        "(function renderPreflightError() {{\
             var h = document.querySelector('h1');\
-            if (h) h.textContent = {title};\
             var status = document.getElementById('status');\
+            if (!h || !status) {{\
+                window.setTimeout(renderPreflightError, {retry_ms});\
+                return;\
+            }}\
+            if (h) h.textContent = {title};\
             if (status) status.textContent = {message};\
             var meter = document.querySelector('.meter');\
             if (meter) meter.style.display = 'none';\
@@ -1828,12 +1822,12 @@ mod tests {
     }
 
     #[test]
-    fn preflight_error_ready_probe_requires_loading_dom() {
-        let probe = preflight_error_ready_probe();
+    fn preflight_error_script_polls_until_loading_dom_exists() {
+        let script = preflight_error_script("Needs update", "Archive is too new", "Footer");
 
-        assert!(probe.contains("document.querySelector('h1')"));
-        assert!(probe.contains("document.getElementById('status')"));
-        assert!(probe.contains("throw new Error"));
+        assert!(script.contains("function renderPreflightError"));
+        assert!(script.contains("setTimeout(renderPreflightError"));
+        assert!(script.contains("if (!h || !status)"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -91,14 +91,13 @@ pub fn run() {
                     schedule_auto_update_check(app.handle().clone());
                 }
                 Err(DataVersionPreflightError::TooNew(message)) => {
+                    eprintln!("[agentsview] data version preflight rejected archive: {message}");
                     let window = main_window(app)?;
                     spawn_preflight_error_render(
                         window,
                         "AgentsView needs an update",
-                        format!(
-                            "{message}. AgentsView cannot open this archive with the bundled backend."
-                        )
-                        .as_str(),
+                        too_new_archive_status_message(message.as_str()).as_str(),
+                        too_new_archive_footer_message(),
                     );
                     let handle = app.handle().clone();
                     tauri::async_runtime::spawn(async move {
@@ -114,6 +113,7 @@ pub fn run() {
                             "Database compatibility check failed: {message}. The backend was not started."
                         )
                         .as_str(),
+                        "Close and reopen AgentsView after fixing the issue.",
                     );
                 }
             }
@@ -955,14 +955,15 @@ fn main_window_from_handle(handle: &AppHandle) -> Result<WebviewWindow, DynError
         .ok_or_else(|| io::Error::other("missing main window").into())
 }
 
-fn spawn_preflight_error_render(window: WebviewWindow, title: &str, message: &str) {
+fn spawn_preflight_error_render(window: WebviewWindow, title: &str, message: &str, footer: &str) {
     let title = title.to_string();
     let message = message.to_string();
+    let footer = footer.to_string();
     thread::spawn(move || {
         let deadline = Instant::now() + READY_TIMEOUT;
         while Instant::now() < deadline {
             if window.eval(preflight_error_ready_probe()).is_ok() {
-                show_preflight_error(&window, title.as_str(), message.as_str());
+                show_preflight_error(&window, title.as_str(), message.as_str(), footer.as_str());
                 return;
             }
             thread::sleep(READY_POLL_INTERVAL);
@@ -977,14 +978,15 @@ fn preflight_error_ready_probe() -> &'static str {
     }"
 }
 
-fn show_preflight_error(window: &WebviewWindow, title: &str, message: &str) {
-    let script = preflight_error_script(title, message);
+fn show_preflight_error(window: &WebviewWindow, title: &str, message: &str, footer: &str) {
+    let script = preflight_error_script(title, message, footer);
     let _ = window.eval(script.as_str());
 }
 
-fn preflight_error_script(title: &str, message: &str) -> String {
+fn preflight_error_script(title: &str, message: &str, footer: &str) -> String {
     let title = js_string_literal(title);
     let message = js_string_literal(message);
+    let footer = js_string_literal(footer);
     format!(
         "(function() {{\
             var h = document.querySelector('h1');\
@@ -996,9 +998,19 @@ fn preflight_error_script(title: &str, message: &str) -> String {
             var stages = document.querySelector('.stage-list');\
             if (stages) stages.style.display = 'none';\
             var foot = document.querySelector('.foot');\
-            if (foot) foot.textContent = 'Use Check for Updates from the AgentsView menu after updating manually.';\
+            if (foot) foot.textContent = {footer};\
         }})()"
     )
+}
+
+fn too_new_archive_status_message(_detail: &str) -> String {
+    "This session archive was updated by a newer version of AgentsView. \
+     Update the app before opening it so your data is not read or synced by an older version."
+        .to_string()
+}
+
+fn too_new_archive_footer_message() -> &'static str {
+    "AgentsView is checking for updates now. If no update appears, use Check for Updates from the AgentsView menu or install the latest release manually."
 }
 
 fn js_string_literal(value: &str) -> String {
@@ -1792,11 +1804,26 @@ mod tests {
     }
 
     #[test]
+    fn too_new_archive_status_message_is_user_facing() {
+        let message = too_new_archive_status_message(
+            "fatal: database data version 59 is newer than this agentsview binary's data version 49",
+        );
+        let footer = too_new_archive_footer_message();
+
+        assert!(message.contains("updated by a newer version of AgentsView"));
+        assert!(!message.contains("database data version"));
+        assert!(!message.contains("bundled backend"));
+        assert!(footer.contains("checking for updates now"));
+        assert!(footer.contains("Check for Updates"));
+    }
+
+    #[test]
     fn preflight_error_script_updates_dom_directly() {
-        let script = preflight_error_script("Needs update", "Archive is too new");
+        let script = preflight_error_script("Needs update", "Archive is too new", "Footer");
 
         assert!(script.contains("document.querySelector('h1')"));
         assert!(script.contains("document.getElementById('status')"));
+        assert!(script.contains("querySelector('.foot')"));
         assert!(!script.contains("window.__setStatus"));
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -83,9 +83,39 @@ pub fn run() {
         .plugin(init_navigation_guard_plugin())
         .manage(SidecarState::default())
         .setup(|app| {
-            launch_backend(app)?;
             setup_menu(app)?;
-            schedule_auto_update_check(app.handle().clone());
+            match tauri::async_runtime::block_on(run_data_version_preflight(app.handle())) {
+                Ok(()) => {
+                    launch_backend(app)?;
+                    schedule_auto_update_check(app.handle().clone());
+                }
+                Err(DataVersionPreflightError::TooNew(message)) => {
+                    let window = main_window(app)?;
+                    show_preflight_error(
+                        &window,
+                        "AgentsView needs an update",
+                        format!(
+                            "{message}. AgentsView cannot open this archive with the bundled backend."
+                        )
+                        .as_str(),
+                    );
+                    let handle = app.handle().clone();
+                    tauri::async_runtime::spawn(async move {
+                        check_for_updates(&handle, false).await;
+                    });
+                }
+                Err(DataVersionPreflightError::Failed(message)) => {
+                    let window = main_window(app)?;
+                    show_preflight_error(
+                        &window,
+                        "AgentsView could not verify the archive",
+                        format!(
+                            "Database compatibility check failed: {message}. The backend was not started."
+                        )
+                        .as_str(),
+                    );
+                }
+            }
             Ok(())
         })
         .build(tauri::generate_context!())
@@ -164,6 +194,87 @@ fn sidecar_args(port: &str) -> Vec<String> {
         "--port".to_string(),
         port.to_string(),
     ]
+}
+
+fn data_version_preflight_args() -> Vec<String> {
+    vec!["serve".to_string(), "--check-data-version".to_string()]
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum DataVersionPreflightError {
+    TooNew(String),
+    Failed(String),
+}
+
+async fn run_data_version_preflight(app: &AppHandle) -> Result<(), DataVersionPreflightError> {
+    let mut command = app
+        .shell()
+        .sidecar("agentsview")
+        .map_err(|err| DataVersionPreflightError::Failed(err.to_string()))?;
+    for (key, value) in sidecar_env() {
+        command = command.env(key, value);
+    }
+
+    let (mut rx, _child) = command
+        .args(data_version_preflight_args())
+        .spawn()
+        .map_err(|err| DataVersionPreflightError::Failed(err.to_string()))?;
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    while let Some(event) = rx.recv().await {
+        match event {
+            CommandEvent::Stdout(bytes) => {
+                stdout.push_str(String::from_utf8_lossy(&bytes).as_ref());
+            }
+            CommandEvent::Stderr(bytes) => {
+                stderr.push_str(String::from_utf8_lossy(&bytes).as_ref());
+            }
+            CommandEvent::Terminated(payload) => {
+                return classify_data_version_preflight_exit(payload.code, &stdout, &stderr);
+            }
+            CommandEvent::Error(err) => {
+                stderr.push_str(err.as_str());
+                stderr.push('\n');
+            }
+            _ => {}
+        }
+    }
+
+    Err(DataVersionPreflightError::Failed(
+        "data version preflight ended without an exit status".to_string(),
+    ))
+}
+
+fn classify_data_version_preflight_exit(
+    code: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+) -> Result<(), DataVersionPreflightError> {
+    if code == Some(0) {
+        return Ok(());
+    }
+
+    let message = combined_preflight_output(stdout, stderr)
+        .unwrap_or_else(|| format!("data version preflight exited with code {code:?}"));
+    if message.contains("database data version")
+        && message.contains("is newer than this agentsview binary")
+    {
+        return Err(DataVersionPreflightError::TooNew(message));
+    }
+    Err(DataVersionPreflightError::Failed(message))
+}
+
+fn combined_preflight_output(stdout: &str, stderr: &str) -> Option<String> {
+    let stderr = stderr.trim();
+    if !stderr.is_empty() {
+        return Some(stderr.to_string());
+    }
+    let stdout = stdout.trim();
+    if !stdout.is_empty() {
+        return Some(stdout.to_string());
+    }
+    None
 }
 
 fn init_navigation_guard_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
@@ -843,6 +954,29 @@ fn main_window_from_handle(handle: &AppHandle) -> Result<WebviewWindow, DynError
     handle
         .get_webview_window("main")
         .ok_or_else(|| io::Error::other("missing main window").into())
+}
+
+fn show_preflight_error(window: &WebviewWindow, title: &str, message: &str) {
+    let title = js_string_literal(title);
+    let message = js_string_literal(message);
+    let script = format!(
+        "(function() {{\
+            var h = document.querySelector('h1');\
+            if (h) h.textContent = {title};\
+            if (window.__setStatus) window.__setStatus({message});\
+            var meter = document.querySelector('.meter');\
+            if (meter) meter.style.display = 'none';\
+            var stages = document.querySelector('.stage-list');\
+            if (stages) stages.style.display = 'none';\
+            var foot = document.querySelector('.foot');\
+            if (foot) foot.textContent = 'Use Check for Updates from the AgentsView menu after updating manually.';\
+        }})()"
+    );
+    let _ = window.eval(script.as_str());
+}
+
+fn js_string_literal(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
 }
 
 fn desktop_redirect_url(port: u16) -> String {
@@ -1567,6 +1701,52 @@ mod tests {
                 "--port".to_string(),
                 "18080".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn data_version_preflight_args_use_serve_check() {
+        assert_eq!(
+            data_version_preflight_args(),
+            vec!["serve".to_string(), "--check-data-version".to_string()]
+        );
+    }
+
+    #[test]
+    fn classify_data_version_preflight_exit_accepts_success() {
+        assert_eq!(
+            classify_data_version_preflight_exit(Some(0), "", ""),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn classify_data_version_preflight_exit_detects_too_new_database() {
+        let err = classify_data_version_preflight_exit(
+            Some(1),
+            "",
+            "fatal: database data version 59 is newer than this agentsview binary's data version 49",
+        )
+        .expect_err("expected too-new error");
+
+        assert_eq!(
+            err,
+            DataVersionPreflightError::TooNew(
+                "fatal: database data version 59 is newer than this agentsview binary's data version 49"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn classify_data_version_preflight_exit_keeps_generic_failures_separate() {
+        let err =
+            classify_data_version_preflight_exit(Some(1), "", "fatal: loading config: bad toml")
+                .expect_err("expected preflight failure");
+
+        assert_eq!(
+            err,
+            DataVersionPreflightError::Failed("fatal: loading config: bad toml".to_string())
         );
     }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -264,7 +264,7 @@ type DataVersionTooNewError struct {
 
 func (e *DataVersionTooNewError) Error() string {
 	return fmt.Sprintf(
-		"database data version %d is newer than this agentsview binary's data version %d; upgrade agentsview before serving or syncing",
+		"database data version %d is newer than this agentsview binary's data version %d. Run \"agentsview update\" or install the latest AgentsView release before serving or syncing this archive",
 		e.DatabaseVersion, e.BinaryVersion,
 	)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -255,6 +255,26 @@ const (
 // the WAL because another connection still had pages pinned.
 var ErrWALCheckpointBusy = errors.New("wal checkpoint busy")
 
+// DataVersionTooNewError reports that an archive was written by a newer
+// agentsview parser than the current binary understands.
+type DataVersionTooNewError struct {
+	DatabaseVersion int
+	BinaryVersion   int
+}
+
+func (e *DataVersionTooNewError) Error() string {
+	return fmt.Sprintf(
+		"database data version %d is newer than this agentsview binary's data version %d; upgrade agentsview before serving or syncing",
+		e.DatabaseVersion, e.BinaryVersion,
+	)
+}
+
+// IsDataVersionTooNew reports whether err wraps DataVersionTooNewError.
+func IsDataVersionTooNew(err error) bool {
+	var tooNew *DataVersionTooNewError
+	return errors.As(err, &tooNew)
+}
+
 // ClassifierHashKey is the shared SQLite stats / PG sync_metadata key
 // under which the current is_automated classifier hash is stored.
 // Exported so the postgres package and the classifier rebuild CLI
@@ -442,7 +462,7 @@ func Open(path string) (*DB, error) {
 
 	schemaStale, dataStale, err := probeDatabase(path)
 	if err != nil {
-		return nil, fmt.Errorf("checking schema: %w", err)
+		return nil, fmt.Errorf("checking database: %w", err)
 	}
 	if schemaStale {
 		if err := dropDatabase(path); err != nil {
@@ -483,6 +503,14 @@ func Open(path string) (*DB, error) {
 	return d, nil
 }
 
+// CheckDataVersion verifies that the database file, when present, was not
+// written by a newer agentsview binary. Older data versions are compatible
+// with startup because callers can run the normal non-destructive resync path.
+func CheckDataVersion(path string) error {
+	_, _, err := probeDatabase(path)
+	return err
+}
+
 // probeDatabase checks an existing database for schema and
 // data staleness. Returns (schemaStale, dataStale, err).
 // schemaStale means required columns are missing and the DB
@@ -508,6 +536,17 @@ func probeDatabase(
 	}
 	defer conn.Close()
 
+	version, err := readUserVersion(conn)
+	if err != nil {
+		return false, false, err
+	}
+	if version > dataVersion {
+		return false, false, &DataVersionTooNewError{
+			DatabaseVersion: version,
+			BinaryVersion:   dataVersion,
+		}
+	}
+
 	schema, err := needsSchemaRebuild(conn)
 	if err != nil {
 		return false, false, err
@@ -516,11 +555,7 @@ func probeDatabase(
 		return true, false, nil
 	}
 
-	data, err := needsDataResync(conn)
-	if err != nil {
-		return false, false, err
-	}
-	return false, data, nil
+	return false, version < dataVersion, nil
 }
 
 // needsSchemaRebuild probes for required columns that may be
@@ -558,20 +593,17 @@ func needsSchemaRebuild(conn *sql.DB) (bool, error) {
 	return false, nil
 }
 
-// needsDataResync checks whether user_version is behind the
-// current dataVersion, indicating parser changes that require
-// re-processing existing files.
-func needsDataResync(conn *sql.DB) (bool, error) {
+func readUserVersion(conn *sql.DB) (int, error) {
 	var version int
 	err := conn.QueryRow(
 		"PRAGMA user_version",
 	).Scan(&version)
 	if err != nil {
-		return false, fmt.Errorf(
+		return 0, fmt.Errorf(
 			"probing data version: %w", err,
 		)
 	}
-	return version < dataVersion, nil
+	return version, nil
 }
 
 // migrateColumns adds columns introduced by this branch to

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -791,7 +791,7 @@ func TestOpenPreservesDataAtCurrentVersion(t *testing.T) {
 	require.Len(t, page.Sessions, 1, "expected 1 session preserved, got")
 }
 
-func TestOpenDoesNotDowngradeUserVersion(t *testing.T) {
+func TestOpenRejectsNewerDataVersion(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.db")
 
@@ -808,20 +808,23 @@ func TestOpenDoesNotDowngradeUserVersion(t *testing.T) {
 	d.Close()
 
 	// Reopen with current (lower) dataVersion.
-	d2, err := Open(path)
-	requireNoError(t, err, "reopen")
-	defer d2.Close()
+	d2, openErr := Open(path)
+	require.Nil(t, d2, "newer database must not open")
+	require.Error(t, openErr, "newer database must be rejected")
 
 	var version int
-	err = d2.getWriter().QueryRow(
+	conn, err := sql.Open("sqlite3", path)
+	requireNoError(t, err, "raw sqlite open")
+	defer conn.Close()
+	err = conn.QueryRow(
 		"PRAGMA user_version",
 	).Scan(&version)
 	requireNoError(t, err, "read version")
 
 	assert.Equal(t, futureVersion, version,
-		"user_version should not downgrade")
-	assert.False(t, d2.NeedsResync(),
-		"NeedsResync should be false for higher version")
+		"user_version should not be mutated")
+	assert.True(t, IsDataVersionTooNew(openErr),
+		"expected too-new data version error")
 }
 
 func TestOpenProbeErrorPropagates(t *testing.T) {
@@ -853,8 +856,8 @@ func TestOpenProbeErrorPropagates(t *testing.T) {
 		require.Error(t, err, "expected error")
 		assert.ErrorIs(t, err, fs.ErrPermission,
 			"expected permission error")
-		assert.Contains(t, err.Error(), "checking schema",
-			"expected 'checking schema' wrapper")
+		assert.Contains(t, err.Error(), "checking database",
+			"expected database compatibility wrapper")
 	})
 
 	t.Run("ProbeReadError", func(t *testing.T) {
@@ -875,8 +878,8 @@ func TestOpenProbeErrorPropagates(t *testing.T) {
 		_, err = Open(path)
 		require.Error(t, err, "expected error")
 		assert.True(t,
-			strings.Contains(err.Error(), "checking schema") ||
-				strings.Contains(err.Error(), "probing schema"),
+			strings.Contains(err.Error(), "checking database") ||
+				strings.Contains(err.Error(), "probing data version"),
 			"unexpected error: %v", err)
 	})
 }

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -73,6 +73,10 @@ func (s *Sync) Push(
 	start := time.Now()
 	var result PushResult
 
+	if err := CheckDataVersionCompat(ctx, s.pg); err != nil {
+		return result, err
+	}
+
 	if err := s.normalizeSyncTimestamps(ctx); err != nil {
 		return result, err
 	}

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -280,6 +280,9 @@ func EnsureSchema(
 	if err != nil {
 		return fmt.Errorf("invalid schema name: %w", err)
 	}
+	if err := CheckDataVersionCompat(ctx, db); err != nil {
+		return err
+	}
 	step := time.Now()
 	if _, err := db.ExecContext(ctx,
 		"CREATE SCHEMA IF NOT EXISTS "+quoted,
@@ -1520,7 +1523,7 @@ func CheckDataVersionCompat(ctx context.Context, pg *sql.DB) error {
 		`SELECT COALESCE(MAX(data_version), 0) FROM sessions`,
 	).Scan(&version)
 	if err != nil {
-		if isUndefinedTable(err) {
+		if isUndefinedTable(err) || isUndefinedColumn(err) {
 			return nil
 		}
 		return fmt.Errorf("checking PG data version: %w", err)

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -1511,6 +1511,29 @@ func CheckSchemaCompat(
 	return nil
 }
 
+// CheckDataVersionCompat rejects PG datasets containing rows written by a
+// newer agentsview parser. PG does not have SQLite's global user_version, so
+// the highest session data_version is the compatibility marker.
+func CheckDataVersionCompat(ctx context.Context, pg *sql.DB) error {
+	var version int
+	err := pg.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(data_version), 0) FROM sessions`,
+	).Scan(&version)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return nil
+		}
+		return fmt.Errorf("checking PG data version: %w", err)
+	}
+	if version > db.CurrentDataVersion() {
+		return &db.DataVersionTooNewError{
+			DatabaseVersion: version,
+			BinaryVersion:   db.CurrentDataVersion(),
+		}
+	}
+	return nil
+}
+
 // IsReadOnlyError returns true when the error indicates a PG
 // read-only or insufficient-privilege condition (SQLSTATE 25006
 // or 42501). Uses pgconn.PgError for reliable SQLSTATE matching.

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"io"
 	"strings"
 	"sync"
@@ -34,6 +35,7 @@ type schemaProbeState struct {
 	currentSchema       string
 	existingColumnNames map[string][]string
 	maxDataVersion      int
+	maxDataVersionErr   error
 }
 
 var (
@@ -141,6 +143,9 @@ func (c *schemaProbeConn) QueryContext(
 			columns: []string{"value"},
 		}, nil
 	case strings.Contains(normalized, "max(data_version)"):
+		if c.state.maxDataVersionErr != nil {
+			return nil, c.state.maxDataVersionErr
+		}
 		return &schemaProbeRows{
 			columns: []string{"max"},
 			values:  [][]driver.Value{{int64(c.state.maxDataVersion)}},
@@ -191,6 +196,12 @@ func (s *schemaProbeState) alterTableExecCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.alterTableExecs)
+}
+
+func (s *schemaProbeState) execCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.execs)
 }
 
 func (s *schemaProbeState) executedSQL() string {
@@ -256,6 +267,31 @@ func TestCheckDataVersionCompatRejectsNewerPGRows(t *testing.T) {
 	require.Error(t, err, "newer PG data version must be rejected")
 	assert.True(t, localdb.IsDataVersionTooNew(err),
 		"expected too-new data version error")
+}
+
+func TestCheckDataVersionCompatAllowsMissingDataVersionColumn(t *testing.T) {
+	pg, state := newSchemaProbeDB(t, nil)
+	state.maxDataVersionErr = errors.New(
+		`ERROR: column "data_version" does not exist (SQLSTATE 42703)`,
+	)
+
+	err := CheckDataVersionCompat(context.Background(), pg)
+
+	require.NoError(t, err,
+		"legacy PG schemas without sessions.data_version should migrate")
+}
+
+func TestEnsureSchemaChecksDataVersionBeforeDDL(t *testing.T) {
+	pg, state := newSchemaProbeDB(t, nil)
+	state.maxDataVersion = localdb.CurrentDataVersion() + 10
+
+	err := EnsureSchema(context.Background(), pg, "agentsview")
+
+	require.Error(t, err, "newer PG data version must be rejected")
+	assert.True(t, localdb.IsDataVersionTooNew(err),
+		"expected too-new data version error")
+	assert.Equal(t, 0, state.execCount(),
+		"EnsureSchema must not mutate PG before data-version refusal")
 }
 
 func TestEnsureSchemaCreatesAnalyticsCoveringIndexes(t *testing.T) {

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	localdb "go.kenn.io/agentsview/internal/db"
 )
 
 type schemaProbeDriver struct{}
@@ -32,6 +33,7 @@ type schemaProbeState struct {
 	alterTableExecs     []string
 	currentSchema       string
 	existingColumnNames map[string][]string
+	maxDataVersion      int
 }
 
 var (
@@ -138,6 +140,11 @@ func (c *schemaProbeConn) QueryContext(
 		return &schemaProbeRows{
 			columns: []string{"value"},
 		}, nil
+	case strings.Contains(normalized, "max(data_version)"):
+		return &schemaProbeRows{
+			columns: []string{"max"},
+			values:  [][]driver.Value{{int64(c.state.maxDataVersion)}},
+		}, nil
 	case strings.Contains(normalized, "select id, first_message"):
 		return &schemaProbeRows{
 			columns: []string{
@@ -238,6 +245,17 @@ func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
 
 	assert.Equal(t, 1, state.informationQueryCount(),
 		"information_schema.columns queries")
+}
+
+func TestCheckDataVersionCompatRejectsNewerPGRows(t *testing.T) {
+	pg, state := newSchemaProbeDB(t, nil)
+	state.maxDataVersion = localdb.CurrentDataVersion() + 10
+
+	err := CheckDataVersionCompat(context.Background(), pg)
+
+	require.Error(t, err, "newer PG data version must be rejected")
+	assert.True(t, localdb.IsDataVersionTooNew(err),
+		"expected too-new data version error")
 }
 
 func TestEnsureSchemaCreatesAnalyticsCoveringIndexes(t *testing.T) {

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -22,6 +22,15 @@ func isUndefinedTable(err error) bool {
 	return strings.Contains(err.Error(), "42P01")
 }
 
+// isUndefinedColumn returns true when a query references a column
+// that does not exist (PG SQLSTATE 42703).
+func isUndefinedColumn(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "42703")
+}
+
 // Sync manages push-only sync from local SQLite to a remote
 // PostgreSQL database.
 type Sync struct {


### PR DESCRIPTION
Shared agentsview archives can be opened by the desktop sidecar, the standalone CLI, and PostgreSQL sync clients. Older binaries previously treated a database stamped by a newer binary as compatible, which left stale parser and schema assumptions free to serve or write data they might not understand.

This makes the data-version boundary explicit across the supported storage paths: SQLite archives and PostgreSQL-backed sessions that are newer than the running binary are rejected before serving or syncing, and doctor reports the skew clearly. The desktop app now runs the bundled Go preflight before launching its backend so it can surface the blocked state and offer the existing update path instead of starting a dead or unsafe backend.

The desktop preflight intentionally reuses Go compatibility logic rather than duplicating SQLite semantics in Rust. A stable exit code separates the too-new archive case from generic launch failures, and the loading-screen error render waits for the DOM so users see guidance even when the backend never starts.

Reviewers should start with internal/db/db.go for the compatibility boundary, cmd/agentsview/cli.go and cmd/agentsview/doctor.go for command behavior, internal/postgres for PostgreSQL parity, and desktop/src-tauri/src/lib.rs for the app preflight and update flow.