### PR TITLE
docs: add 0.34.2 release notes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,52 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
+## 0.34.2
+<small>2026-06-22</small>
+
+**New features**
+
+- Show **detailed resync progress** while full resyncs are running,
+  so the UI can report the current phase instead of only showing a
+  generic syncing state.
+- Add a **resume-focused session table** to
+  `agentsview session list`, including `--resume` and `--active`
+  modes for quickly finding recently active sessions.
+
+**Improvements**
+
+- Add **native session links in the sidebar** when an agent exposes
+  a supported resume target.
+- Redesign the **supported agents docs grid** as uniform clickable
+  chips.
+
+**Bug fixes**
+
+- Handle **search terms with operator characters** without returning
+  server errors.
+- Parse **native Kimi Code records** correctly.
+- Improve **incremental JSONL resume reliability**.
+- Make **large-session deletes safer** for full-text search cleanup.
+- Prevent **Ctrl+K command palette input** from reselecting text on
+  every keystroke.
+- Avoid **DuckDB tool-call attachment failures** from invalid
+  negative call indexes.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for detailed
+  resync progress, native Kimi Code record parsing, and the supported
+  agents docs grid redesign.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for the
+  resume-focused session table and search operator-character fix.
+- Thanks to [Rod Boev](https://github.com/rodboev) for native sidebar
+  session links, incremental JSONL resume reliability, safer
+  large-session full-text cleanup, and the Ctrl+K palette input fix.
+- Thanks to [MirzaSamadAhmedBaig](https://github.com/Mirza-Samad-Ahmed-Baig)
+  for the DuckDB negative call-index fix.
+
+---
+
 ## 0.34.1
 <small>2026-06-21</small>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -638,6 +638,7 @@ auto-detection, and every subcommand.
 ```bash
 agentsview session get <id>              # metadata + signals
 agentsview session list [flags]          # filtered list
+agentsview session list --resume         # recently-active resume table
 agentsview session messages <id>         # paginated messages
 agentsview session tool-calls <id>       # flat tool-call list
 agentsview session export <id>           # stream raw source file
@@ -663,6 +664,13 @@ Use [`agentsview health`](#agentsview-health) for a human-first
 signal view and [Session API](/session-api/) for the full
 programmatic contract, including transport behavior and markdown
 export details.
+
+`agentsview session list` renders a resume-oriented human table by
+default, including a recently-active marker, session ID, age, agent,
+project, branch, message count, title, and working directory. Pass
+`--resume` or its `--active` alias to show sessions active in the
+last 15 minutes; combine either flag with `--active-since <RFC3339>`
+to choose a wider or narrower window.
 
 ---
 

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -168,6 +168,8 @@ One-shot and automated sessions are excluded by default. Use the
 | `--date-from`         | `date_from`         | `YYYY-MM-DD`                      |
 | `--date-to`           | `date_to`           | `YYYY-MM-DD`                      |
 | `--active-since`      | `active_since`      | RFC3339 timestamp                 |
+| `--resume`            | `active_since`      | CLI shortcut for sessions active in the last 15 minutes |
+| `--active`            | `active_since`      | Alias for `--resume`              |
 | `--min-messages`      | `min_messages`      | int                               |
 | `--max-messages`      | `max_messages`      | int                               |
 | `--min-user-messages` | `min_user_messages` | int                               |
@@ -190,9 +192,17 @@ Sort keys are `recent`, `started`, `messages`, `user-messages`,
 default ascending unless `--reverse`, `descending=true`, or an
 explicit suffix overrides them.
 
+Human CLI output is formatted for resuming work: it shows the full
+session ID, age, agent, project, branch, message count, title, and
+working directory, with a marker on sessions active in the last 15
+minutes. `--resume` and `--active` set `active_since` to that
+15-minute window unless `--active-since` is supplied explicitly.
+HTTP callers should pass `active_since` directly.
+
 Examples:
 
 ```bash
+agentsview session list --resume
 agentsview session list --sort messages:desc,started:asc
 agentsview session list --sort health --reverse
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -339,6 +339,10 @@ Each session item shows:
 - **Relative time** — "2h ago", "Mon", "Dec 1"
 - **User prompt count** — number of user messages in the session
 
+When a session has a native resume target, the sidebar also exposes
+a direct native session link so supported agents can reopen their own
+session instead of only navigating inside AgentsView.
+
 ### Session Status Indicator
 
 As of 0.27.0, the small dot at the left edge of each session
@@ -912,6 +916,10 @@ For Claude sessions on macOS, a **Claude Desktop** option
 appears at the bottom of the resume menu. It opens the session
 in Claude Desktop's Code tab via the `claude://resume` URL
 scheme.
+
+The `agentsview session list --resume` and `--active` CLI modes use
+the same recent-activity signal to produce a compact terminal table
+for picking up in-flight work.
 
 These actions let you quickly pick up where you left off
 without manually navigating to the project directory.


### PR DESCRIPTION
Adds the 0.34.2 changelog entry for the just-cut release, including contributor acknowledgements in the same style as prior releases.

Also updates the user-facing CLI, session API, and usage docs so the new resume-focused `session list --resume` / `--active` modes and sidebar native session-link behavior are discoverable from the published documentation.