### PR TITLE
ci: verify docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,28 @@ jobs:
         run: npm test
         working-directory: frontend
 
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41  # v7.1.2
+
+      - name: Install docs check tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
+      - name: Run docs check
+        run: make docs-check
+
   test:
     name: Go Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -20,6 +20,7 @@ type githubWorkflowJob struct {
 type githubWorkflowStep struct {
 	Name string `yaml:"name"`
 	Run  string `yaml:"run"`
+	Uses string `yaml:"uses"`
 }
 
 func TestWindowsDesktopUpdateTestsRetryCargoNetworkFailures(t *testing.T) {
@@ -41,6 +42,24 @@ func TestWindowsDesktopUpdateTestsRetryCargoNetworkFailures(t *testing.T) {
 	assert.Contains(t, fetchStep.Run, "$LASTEXITCODE")
 	assert.Contains(t, fetchStep.Run, "Start-Sleep")
 	assert.Contains(t, testStep.Run, "cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml --lib install_downloaded_update")
+}
+
+func TestCIDocsJobRunsFullDocsCheck(t *testing.T) {
+	contents, err := os.ReadFile(".github/workflows/ci.yml")
+	require.NoError(t, err)
+
+	var workflow githubWorkflow
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+
+	job, ok := workflow.Jobs["docs"]
+	require.True(t, ok, "docs job must exist")
+
+	uvIndex, uvStep := findWorkflowStep(t, job, "Set up uv")
+	checkIndex, checkStep := findWorkflowStep(t, job, "Run docs check")
+	require.Less(t, uvIndex, checkIndex, "uv must be installed before docs check")
+
+	assert.Contains(t, uvStep.Uses, "astral-sh/setup-uv")
+	assert.Equal(t, "make docs-check", checkStep.Run)
 }
 
 func findWorkflowStep(


### PR DESCRIPTION
The documentation site now lives in this repository, but the main CI workflow was not exercising the migrated Zensical build path. That made docs source issues, asset hydration failures, built-site regressions, and Vercel redirect mistakes easy to miss until deployment or a manual maintainer check.

This adds a dedicated docs CI job that runs the existing `make docs-check` entrypoint with uv available, so CI follows the same full path maintainers use locally. A workflow guard test keeps the job wired to that entrypoint and avoids silently falling back to the no-uv skip path.