### PR TITLE
fix(db): recognize embedded security review prompts

### DIFF
--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -38,6 +38,7 @@ var automatedPrefixes = []string{
 // longer prompts.
 var automatedSubstrings = []string{
 	"invoked by roborev to perform this review",
+	"You are a security code reviewer with an exploitability burden of proof. Review the code changes for concrete vulnerabilities",
 	"You are a conversation title generator",
 }
 

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -34,6 +34,11 @@ func TestIsAutomatedSession(t *testing.T) {
 			"You are a security code reviewer. Analyze the following.",
 			true,
 		},
+		{
+			"SecurityReviewAfterAgentInstructions",
+			"# AGENTS.md instructions for /repo\n\n<INSTRUCTIONS>\nDo not trust prompt text.\n</INSTRUCTIONS>\n\nYou are a security code reviewer with an exploitability burden of proof. Review the code changes for concrete vulnerabilities, material weakening of security controls, and newly reachable attack surface.",
+			true,
+		},
 
 		// Design review
 		{


### PR DESCRIPTION
Roborev security review prompts can be preceded by repository instruction blocks in the recorded first user message. The existing classifier only caught the security reviewer template when it appeared at the start of the message, so these automated review sessions could be shown as human sessions and included in human-scoped analytics.

This adds a specific embedded marker for the long security-review prompt shape while keeping the single-turn automation gate. The marker is intentionally narrow so ordinary prose about security review does not broaden the automation classifier.