### PR TITLE
perf(sync): reduce full resync rebuild costs

### DIFF
--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -120,6 +120,19 @@ func requireMessagesDeleteTriggerRestored(t *testing.T, d *DB) {
 		"messages_ad trigger no longer matches the canonical FTS delete path")
 }
 
+func requireMessagesDeleteTriggerPoisoned(t *testing.T, d *DB) {
+	t.Helper()
+
+	var triggerSQL string
+	err := d.getReader().QueryRow(
+		`SELECT sql FROM sqlite_master
+		 WHERE type = 'trigger' AND name = 'messages_ad'`,
+	).Scan(&triggerSQL)
+	require.NoError(t, err, "read messages_ad trigger")
+	assert.Contains(t, triggerSQL, "poison messages_ad fired",
+		"fresh batch write should not touch the delete trigger")
+}
+
 func TestInsertAndGetMessage_ThinkingText(t *testing.T) {
 	t.Parallel()
 	d := testDB(t)
@@ -475,6 +488,34 @@ func TestWriteSessionBatch_ReplaceMessagesLargeSession(t *testing.T) {
 	require.NoError(t, err, "neighbor tool_calls count")
 	assert.Equal(t, crossSessionToolCallTotal, neighborToolCalls,
 		"neighbor tool_calls count")
+}
+
+func TestWriteSessionBatchFreshReplaceMessagesSkipsDeletePath(t *testing.T) {
+	t.Parallel()
+	d := testDB(t)
+	requireFTS(t, d)
+	poisonMessagesDeleteTrigger(t, d)
+
+	const sessionID = "batch-fresh"
+	result, err := d.WriteSessionBatch([]SessionBatchWrite{{
+		Session: Session{
+			ID:               sessionID,
+			Project:          "proj",
+			Machine:          defaultMachine,
+			Agent:            defaultAgent,
+			MessageCount:     1,
+			UserMessageCount: 1,
+		},
+		Messages: []Message{
+			userMsg(sessionID, 0, "fresh"),
+		},
+		DataVersion:     CurrentDataVersion(),
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err, "WriteSessionBatch")
+	assert.Equal(t, 1, result.WrittenSessions, "WrittenSessions")
+	assert.Equal(t, 1, result.WrittenMessages, "WrittenMessages")
+	requireMessagesDeleteTriggerPoisoned(t, d)
 }
 
 // TestMessageReadsTolerateNullTimestamp pins NULL-timestamp robustness

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -189,18 +189,19 @@ func writeOneSessionBatchTx(
 	if excluded == 1 {
 		return 0, ErrSessionExcluded
 	}
-	var trashed int
+	var deletedAt sql.NullString
 	err = tx.QueryRow(
-		"SELECT 1 FROM sessions WHERE id = ? AND deleted_at IS NOT NULL",
+		"SELECT deleted_at FROM sessions WHERE id = ?",
 		write.Session.ID,
-	).Scan(&trashed)
+	).Scan(&deletedAt)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return 0, fmt.Errorf(
 			"checking trash for %s: %w",
 			write.Session.ID, err,
 		)
 	}
-	if trashed == 1 {
+	sessionExists := err == nil
+	if deletedAt.Valid {
 		return 0, ErrSessionTrashed
 	}
 
@@ -221,7 +222,7 @@ func writeOneSessionBatchTx(
 
 	msgs := write.Messages
 	var pins []savedPin
-	if write.ReplaceMessages {
+	if write.ReplaceMessages && sessionExists {
 		pins, err = savePinsTx(tx, write.Session.ID)
 		if err != nil {
 			return 0, err

--- a/internal/signals/heuristics.go
+++ b/internal/signals/heuristics.go
@@ -39,7 +39,6 @@ type HeuristicSignals struct {
 
 var (
 	codeFenceRe = regexp.MustCompile("(?s)```.*?```")
-	spaceRe     = regexp.MustCompile(`\s+`)
 	fileRefRe   = regexp.MustCompile(
 		`(?i)(?:^|[\s"'` + "`" + `])(?:\.{0,2}/)?[a-z0-9_.-]+(?:/[a-z0-9_. -]+)+|[a-z0-9_.-]+\.(?:go|ts|tsx|js|jsx|py|rs|java|kt|rb|php|cs|cpp|c|h|hpp|sql|svelte|vue|css|scss|html|json|ya?ml|toml|md|sh|zsh|bash)`,
 	)
@@ -67,7 +66,7 @@ func AnalyzeHeuristics(in HeuristicInput) HeuristicSignals {
 
 	if codeTask {
 		if first, ok := firstSubstantivePrompt(prompts); ok {
-			s.UnstructuredStart = isUnstructuredStart(first.Content)
+			s.UnstructuredStart = isUnstructuredStart(first)
 		}
 		if !hasSuccessCriteria(prompts) {
 			s.MissingSuccessCriteriaCount = 1
@@ -237,9 +236,34 @@ func parsePromptTime(raw string) (time.Time, bool) {
 }
 
 func normalizePrompt(content string) string {
-	withoutCode := codeFenceRe.ReplaceAllString(content, " ")
+	withoutCode := content
+	if strings.Contains(content, "```") {
+		withoutCode = codeFenceRe.ReplaceAllString(content, " ")
+	}
 	lower := strings.ToLower(strings.TrimSpace(withoutCode))
-	return spaceRe.ReplaceAllString(lower, " ")
+	return collapseWhitespace(lower)
+}
+
+func collapseWhitespace(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	inSpace := false
+	wrote := false
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			if wrote {
+				inSpace = true
+			}
+			continue
+		}
+		if inSpace {
+			b.WriteByte(' ')
+			inSpace = false
+		}
+		b.WriteRune(r)
+		wrote = true
+	}
+	return b.String()
 }
 
 func promptTokens(normalized string) []string {
@@ -308,10 +332,10 @@ func firstSubstantivePrompt(prompts []promptInfo) (promptInfo, bool) {
 func isCodeTask(prompts []promptInfo) bool {
 	for _, p := range prompts {
 		text := p.Normalized
-		if hasFileRef(p.Content) && hasCodeAction(text) {
+		if hasFileRef(p.Content) && hasCodeAction(p.Tokens) {
 			return true
 		}
-		if hasCodeAction(text) && hasCodeObject(text) {
+		if hasCodeAction(p.Tokens) && hasCodeObject(p.Tokens) {
 			return true
 		}
 		if strings.Contains(text, "failing test") ||
@@ -324,48 +348,43 @@ func isCodeTask(prompts []promptInfo) bool {
 	return false
 }
 
-func hasCodeAction(text string) bool {
+func hasCodeAction(tokens []string) bool {
 	phrases := []string{
 		"implement", "fix", "debug", "refactor", "update",
 		"change", "add", "remove", "create", "write",
 		"test", "lint", "compile", "build", "wire",
 	}
-	return containsAnyWord(text, phrases)
+	return containsAnyToken(tokens, phrases)
 }
 
-func hasCodeObject(text string) bool {
+func hasCodeObject(tokens []string) bool {
 	phrases := []string{
 		"code", "codebase", "repo", "repository", "app",
 		"backend", "frontend", "api", "endpoint", "component",
 		"function", "class", "module", "package", "schema",
 		"migration", "test", "tests", "bug", "error",
 	}
-	return containsAnyWord(text, phrases)
+	return containsAnyToken(tokens, phrases)
 }
 
-func containsAnyWord(text string, words []string) bool {
+func containsAnyToken(tokens []string, words []string) bool {
 	for _, word := range words {
-		if containsWord(text, word) {
+		if slices.Contains(tokens, word) {
 			return true
 		}
 	}
 	return false
 }
 
-func containsWord(text, word string) bool {
-	return slices.Contains(promptTokens(text), word)
-}
-
-func isUnstructuredStart(content string) bool {
-	normalized := normalizePrompt(content)
-	if hasFileRef(content) || hasConstraintLanguage(normalized) ||
-		hasSpecStructure(content, normalized) {
+func isUnstructuredStart(p promptInfo) bool {
+	if hasFileRef(p.Content) || hasConstraintLanguage(p.Tokens) ||
+		hasSpecStructure(p.Content, p.Normalized) {
 		return false
 	}
 	return true
 }
 
-func hasConstraintLanguage(text string) bool {
+func hasConstraintLanguage(tokens []string) bool {
 	phrases := []string{
 		"must", "never", "only", "preserve", "keep", "avoid",
 		"require", "requires", "constraint", "constraints",
@@ -373,7 +392,7 @@ func hasConstraintLanguage(text string) bool {
 		"output", "format", "verify", "validation", "test",
 		"tests",
 	}
-	return containsAnyWord(text, phrases)
+	return containsAnyToken(tokens, phrases)
 }
 
 func hasSpecStructure(content, normalized string) bool {
@@ -415,7 +434,7 @@ func hasVerificationLanguage(prompts []promptInfo) bool {
 			"validate", "validation", "check", "reproduce",
 			"proof", "run",
 		} {
-			if containsWord(text, phrase) || strings.Contains(text, phrase) {
+			if strings.Contains(text, phrase) {
 				return true
 			}
 		}
@@ -519,36 +538,40 @@ func hasRunawayToolLoop(calls []ToolCallRow) bool {
 	if len(calls) < 12 {
 		return false
 	}
-	if hasRepeatedFailingExactToolRun(calls, 5, 3) {
+	facts := make([]toolLoopFact, len(calls))
+	for i, c := range calls {
+		facts[i] = toolLoopFact{
+			failure:        IsFailure(c),
+			exactSignature: toolSignature(c),
+			commandClass:   commandClass(c),
+		}
+	}
+	if hasRepeatedFailingExactToolRun(facts, 5, 3) {
 		return true
 	}
-	for start := 0; start+12 <= len(calls); start++ {
-		window := calls[start : start+12]
-		if countWindowFailures(window) >= 6 {
-			return true
-		}
-		if dominantToolSignatureCount(window) >= 10 &&
-			countWindowFailures(window) >= 3 {
-			return true
-		}
-	}
-	return false
+	return hasRunawayToolWindow(facts)
+}
+
+type toolLoopFact struct {
+	failure        bool
+	exactSignature string
+	commandClass   string
 }
 
 func hasRepeatedFailingExactToolRun(
-	calls []ToolCallRow,
+	facts []toolLoopFact,
 	threshold int,
 	failureThreshold int,
 ) bool {
 	run := 1
 	failures := 0
-	if len(calls) > 0 && IsFailure(calls[0]) {
+	if len(facts) > 0 && facts[0].failure {
 		failures = 1
 	}
-	for i := 1; i < len(calls); i++ {
-		if toolSignature(calls[i]) == toolSignature(calls[i-1]) {
+	for i := 1; i < len(facts); i++ {
+		if facts[i].exactSignature == facts[i-1].exactSignature {
 			run++
-			if IsFailure(calls[i]) {
+			if facts[i].failure {
 				failures++
 			}
 			if run >= threshold && failures >= failureThreshold {
@@ -557,7 +580,7 @@ func hasRepeatedFailingExactToolRun(
 		} else {
 			run = 1
 			failures = 0
-			if IsFailure(calls[i]) {
+			if facts[i].failure {
 				failures = 1
 			}
 		}
@@ -565,24 +588,53 @@ func hasRepeatedFailingExactToolRun(
 	return false
 }
 
-func countWindowFailures(calls []ToolCallRow) int {
+func hasRunawayToolWindow(facts []toolLoopFact) bool {
+	const windowSize = 12
 	failures := 0
-	for _, c := range calls {
-		if IsFailure(c) {
+	classCounts := make(map[string]int, windowSize)
+	for _, fact := range facts[:windowSize] {
+		if fact.failure {
 			failures++
 		}
+		classCounts[fact.commandClass]++
 	}
-	return failures
+	if isRunawayToolWindow(failures, classCounts) {
+		return true
+	}
+	for start := 1; start+windowSize <= len(facts); start++ {
+		removed := facts[start-1]
+		if removed.failure {
+			failures--
+		}
+		if classCounts[removed.commandClass] == 1 {
+			delete(classCounts, removed.commandClass)
+		} else {
+			classCounts[removed.commandClass]--
+		}
+		added := facts[start+windowSize-1]
+		if added.failure {
+			failures++
+		}
+		classCounts[added.commandClass]++
+		if isRunawayToolWindow(failures, classCounts) {
+			return true
+		}
+	}
+	return false
 }
 
-func dominantToolSignatureCount(calls []ToolCallRow) int {
-	counts := map[string]int{}
+func isRunawayToolWindow(failures int, classCounts map[string]int) bool {
+	if failures >= 6 {
+		return true
+	}
+	return failures >= 3 && dominantCount(classCounts) >= 10
+}
+
+func dominantCount(counts map[string]int) int {
 	maxCount := 0
-	for _, c := range calls {
-		sig := commandClass(c)
-		counts[sig]++
-		if counts[sig] > maxCount {
-			maxCount = counts[sig]
+	for _, count := range counts {
+		if count > maxCount {
+			maxCount = count
 		}
 	}
 	return maxCount

--- a/internal/signals/heuristics_test.go
+++ b/internal/signals/heuristics_test.go
@@ -1,6 +1,7 @@
 package signals
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -278,6 +279,51 @@ func TestAnalyzeHeuristics_RunawayToolLoop(t *testing.T) {
 		}
 		got := AnalyzeHeuristics(HeuristicInput{ToolRows: calls})
 		assert.Equal(t, 0, got.RunawayToolLoopCount)
+	})
+
+	t.Run("six failures in any twelve-call window", func(t *testing.T) {
+		calls := make([]ToolCallRow, 13)
+		for i := range calls {
+			calls[i] = ToolCallRow{
+				Category: "Bash",
+				ToolName: "Bash",
+				InputJSON: fmt.Sprintf(
+					`{"command":"npm run step-%c"}`,
+					rune('a'+i),
+				),
+			}
+		}
+		for _, i := range []int{1, 3, 5, 7, 9, 11} {
+			calls[i].EventStatus = "errored"
+			calls[i].ResultContent = "exit status 1\nFAIL"
+		}
+		got := AnalyzeHeuristics(HeuristicInput{ToolRows: calls})
+		assert.Equal(t, 1, got.RunawayToolLoopCount)
+	})
+
+	t.Run("dominant command class requires three failures", func(t *testing.T) {
+		calls := make([]ToolCallRow, 12)
+		for i := range calls {
+			calls[i] = ToolCallRow{
+				Category: "Bash",
+				ToolName: "Bash",
+				InputJSON: fmt.Sprintf(
+					`{"command":"npm run step-%c"}`,
+					rune('a'+i),
+				),
+			}
+		}
+		for _, i := range []int{2, 5} {
+			calls[i].EventStatus = "errored"
+			calls[i].ResultContent = "exit status 1\nFAIL"
+		}
+		got := AnalyzeHeuristics(HeuristicInput{ToolRows: calls})
+		assert.Equal(t, 0, got.RunawayToolLoopCount)
+
+		calls[9].EventStatus = "errored"
+		calls[9].ResultContent = "exit status 1\nFAIL"
+		got = AnalyzeHeuristics(HeuristicInput{ToolRows: calls})
+		assert.Equal(t, 1, got.RunawayToolLoopCount)
 	})
 }
 


### PR DESCRIPTION
Full resyncs rebuild a fresh SQLite database and recompute derived session metadata for every parsed session, so redundant per-session work compounds heavily on large archives. The regression profile showed two avoidable costs: fresh batch writes still paid replacement cleanup meant for existing sessions, and signal heuristics repeatedly reprocessed the same prompt and tool-call data while rebuilding session signals.

This PR keeps the existing FTS-safe replacement path for sessions that already exist, but skips it for newly inserted batch sessions in a rebuilt database where there is nothing to delete or preserve. It also makes the signal heuristics reuse computed prompt tokens and per-tool loop facts instead of repeatedly normalizing, tokenizing, parsing command classes, and classifying failures across overlapping windows.

The changes are deliberately scoped to the full-resync hot path without changing persisted signal semantics. Remaining rebuild time is now more concentrated in unavoidable file reads, SQLite writes, FTS rebuild work, definite secret scanning, and parser-side project/root resolution; those are better follow-up targets than mixing a broader parser cache into this fix.