### PR TITLE
docs: add 0.34.3 release notes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,23 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
+## 0.34.3
+<small>2026-06-22</small>
+
+**Improvements**
+
+- Make **full resync rebuilds** more efficient, reducing sync cost for
+  large archives.
+- Update documentation for the latest **command, usage, and session API**
+  changes.
+
+**Bug fixes**
+
+- Recognize **embedded security review prompts** correctly in stored
+  messages.
+
+---
+
 ## 0.34.2
 <small>2026-06-22</small>
 


### PR DESCRIPTION
The patch release has already been cut, so the published changelog needs to reflect what users get in 0.34.3. Without this entry, the docs would jump from 0.34.2 to later work and miss the release context for full resync efficiency, documentation coverage updates, and embedded security review prompt recognition.

Reviewers should look at the wording in the changelog entry for accuracy against the shipped patch release notes.