### PR TITLE
fix(sync): reparse stale roborev CI projects

### DIFF
--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1822,6 +1822,22 @@ func (db *DB) GetFileInfoByPath(
 	return s.Int64, m.Int64, true
 }
 
+// GetProjectByPath returns the stored project for the newest
+// non-deleted session matching file_path.
+func (db *DB) GetProjectByPath(path string) (project string, ok bool) {
+	err := db.getReader().QueryRow(
+		"SELECT project FROM sessions"+
+			" WHERE file_path = ?"+
+			" AND deleted_at IS NULL"+
+			" ORDER BY file_mtime DESC LIMIT 1",
+		path,
+	).Scan(&project)
+	if err != nil {
+		return "", false
+	}
+	return project, true
+}
+
 // GetFileHashByPath returns the stored file_hash for the session
 // matching file_path, preferring the most recently modified row.
 // The bool is false when no row exists or the column is NULL. Used

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -106,6 +106,7 @@ func TestNeedsProjectReparse(t *testing.T) {
 		{"_var_folders_xx_temp", true},
 		{"_private_tmp_build", true},
 		{"_tmp_workspace", true},
+		{"roborev_ci_28293_3831737461", true},
 		{"normal_var_project", false},
 	}
 

--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -790,6 +790,9 @@ func isDefaultBranchToken(branch string) bool {
 // NeedsProjectReparse checks if a stored project name looks like
 // an un-decoded encoded path that should be re-extracted.
 func NeedsProjectReparse(project string) bool {
+	if strings.HasPrefix(project, "roborev_ci_") {
+		return true
+	}
 	bad := []string{
 		"_Users", "_home", "_private", "_tmp", "_var",
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4989,7 +4989,6 @@ func (e *Engine) processCodex(
 		return processResult{skip: true}
 	}
 
-	indexMtimeChanged := e.codexIndexMtimeChanged(file.Path)
 	projectNeedsReparse := e.pathNeedsProjectReparse(file.Path)
 	forceReplace := false
 
@@ -5000,10 +4999,11 @@ func (e *Engine) processCodex(
 			path, offset, startOrd, false,
 		)
 	}
-	if !projectNeedsReparse {
-		if res, ok := e.tryIncrementalJSONL(
-			file, info, parser.AgentCodex, codexParseFn,
-		); ok {
+	if res, ok := e.tryIncrementalJSONL(
+		file, info, parser.AgentCodex, codexParseFn,
+	); ok {
+		if !projectNeedsReparse {
+			indexMtimeChanged := e.codexIndexMtimeChanged(file.Path)
 			if !indexMtimeChanged {
 				return res
 			}
@@ -5012,9 +5012,9 @@ func (e *Engine) processCodex(
 			// appended bytes so existing rows rewritten by the full parse are not
 			// dropped by the append-only write path.
 			forceReplace = res.forceReplace
-		} else {
-			forceReplace = res.forceReplace
 		}
+	} else {
+		forceReplace = res.forceReplace
 	}
 
 	sess, msgs, err := parser.ParseCodexSession(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4793,6 +4793,10 @@ func (e *Engine) shouldSkipCodex(
 	if !ok || storedSize != info.Size() {
 		return false
 	}
+	if project, ok := e.db.GetProjectByPath(lookupPath); ok &&
+		parser.NeedsProjectReparse(project) {
+		return false
+	}
 	if e.db.GetDataVersionByPath(lookupPath) <
 		db.CurrentDataVersion() {
 		return false

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4141,10 +4141,14 @@ func (e *Engine) processFile(
 		cachedMtime, cached := e.skipCache[file.Path]
 		e.skipMu.RUnlock()
 		if cached && cachedMtime == mtime {
-			return processResult{
-				skip:      true,
-				mtime:     mtime,
-				cacheSkip: true,
+			if e.cachedPathNeedsProjectReparse(file.Path) {
+				e.clearSkip(file.Path)
+			} else {
+				return processResult{
+					skip:      true,
+					mtime:     mtime,
+					cacheSkip: true,
+				}
 			}
 		}
 	}
@@ -4231,6 +4235,18 @@ func (e *Engine) processFile(
 	res.cacheSkip = cacheSkip
 	res.mtime = mtime
 	return res
+}
+
+func (e *Engine) cachedPathNeedsProjectReparse(path string) bool {
+	if e == nil || e.db == nil {
+		return false
+	}
+	lookupPath := path
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(path)
+	}
+	project, ok := e.db.GetProjectByPath(lookupPath)
+	return ok && parser.NeedsProjectReparse(project)
 }
 
 func (e *Engine) shouldCacheSkip(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4141,7 +4141,7 @@ func (e *Engine) processFile(
 		cachedMtime, cached := e.skipCache[file.Path]
 		e.skipMu.RUnlock()
 		if cached && cachedMtime == mtime {
-			if e.cachedPathNeedsProjectReparse(file.Path) {
+			if e.pathNeedsProjectReparse(file.Path) {
 				e.clearSkip(file.Path)
 			} else {
 				return processResult{
@@ -4237,7 +4237,7 @@ func (e *Engine) processFile(
 	return res
 }
 
-func (e *Engine) cachedPathNeedsProjectReparse(path string) bool {
+func (e *Engine) pathNeedsProjectReparse(path string) bool {
 	if e == nil || e.db == nil {
 		return false
 	}
@@ -4990,6 +4990,7 @@ func (e *Engine) processCodex(
 	}
 
 	indexMtimeChanged := e.codexIndexMtimeChanged(file.Path)
+	projectNeedsReparse := e.pathNeedsProjectReparse(file.Path)
 	forceReplace := false
 
 	codexParseFn := func(
@@ -4999,19 +5000,21 @@ func (e *Engine) processCodex(
 			path, offset, startOrd, false,
 		)
 	}
-	if res, ok := e.tryIncrementalJSONL(
-		file, info, parser.AgentCodex, codexParseFn,
-	); ok {
-		if !indexMtimeChanged {
-			return res
+	if !projectNeedsReparse {
+		if res, ok := e.tryIncrementalJSONL(
+			file, info, parser.AgentCodex, codexParseFn,
+		); ok {
+			if !indexMtimeChanged {
+				return res
+			}
+			// The index title changed, so a full parse still needs to refresh
+			// session metadata. Keep any fallback signal discovered while probing
+			// appended bytes so existing rows rewritten by the full parse are not
+			// dropped by the append-only write path.
+			forceReplace = res.forceReplace
+		} else {
+			forceReplace = res.forceReplace
 		}
-		// The index title changed, so a full parse still needs to refresh
-		// session metadata. Keep any fallback signal discovered while probing
-		// appended bytes so existing rows rewritten by the full parse are not
-		// dropped by the append-only write path.
-		forceReplace = res.forceReplace
-	} else {
-		forceReplace = res.forceReplace
 	}
 
 	sess, msgs, err := parser.ParseCodexSession(

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1448,6 +1448,78 @@ func TestProcessFileSkipCacheReparsesStaleCodexProject(t *testing.T) {
 	assert.Equal(t, "agentsview", res.results[0].Session.Project)
 }
 
+func TestProcessCodexAppendedStaleProjectDoesFullReparse(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "rollout-2026-06-21T18-59-38-abc.jsonl")
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"abc",
+			"/home/roborev/.roborev/ci-worktrees/agentsview/roborev-ci-28293-3831737461",
+			"user",
+			"2024-01-01T10:00:00Z",
+		),
+		testjsonl.CodexMsgJSON("user", "review this", "2024-01-01T10:00:01Z"),
+	)
+	require.NoError(t, os.WriteFile(path, []byte(initial), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat initial codex fixture")
+
+	sess := db.Session{
+		ID:               "host~codex:abc",
+		Project:          "roborev_ci_28293_3831737461",
+		Machine:          "host",
+		Agent:            "codex",
+		FirstMessage:     strPtr("review this"),
+		MessageCount:     1,
+		UserMessageCount: 1,
+		FilePath:         strPtr("host:" + path),
+		FileSize:         int64Ptr(info.Size()),
+		FileMtime:        int64Ptr(info.ModTime().UnixNano()),
+		NextOrdinal:      1,
+	}
+	require.NoError(t, database.UpsertSession(sess))
+	require.NoError(t, database.SetSessionDataVersion(
+		sess.ID, db.CurrentDataVersion(),
+	))
+	require.NoError(t, database.InsertMessages([]db.Message{
+		{
+			SessionID: "host~codex:abc",
+			Ordinal:   0,
+			Role:      "user",
+			Content:   "review this",
+		},
+	}))
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	require.NoError(t, err, "open codex fixture for append")
+	_, err = f.WriteString(testjsonl.CodexMsgJSON(
+		"assistant", "done", "2024-01-01T10:00:02Z",
+	) + "\n")
+	require.NoError(t, err, "append codex fixture")
+	require.NoError(t, f.Close(), "close codex fixture")
+	info, err = os.Stat(path)
+	require.NoError(t, err, "stat appended codex fixture")
+
+	e := &Engine{
+		db:       database,
+		idPrefix: "host~",
+		pathRewriter: func(path string) string {
+			return "host:" + path
+		},
+	}
+
+	res := e.processCodex(parser.DiscoveredFile{
+		Agent: parser.AgentCodex,
+		Path:  path,
+	}, info)
+	require.NoError(t, res.err)
+	require.Nil(t, res.incremental,
+		"stale project metadata must force full parse even when file appended")
+	require.Len(t, res.results, 1)
+	assert.Equal(t, "agentsview", res.results[0].Session.Project)
+}
+
 func TestCollectAndBatchPrefixesParserExcludedIDs(t *testing.T) {
 	database := openTestDB(t)
 	ctx := context.Background()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1397,6 +1397,57 @@ func TestShouldSkipCodexReparsesStaleProject(t *testing.T) {
 		"stale generated roborev CI projects must be reparsed")
 }
 
+func TestProcessFileSkipCacheReparsesStaleCodexProject(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "rollout-2026-06-21T18-59-38-abc.jsonl")
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"abc",
+			"/home/roborev/.roborev/ci-worktrees/agentsview/roborev-ci-28293-3831737461",
+			"user",
+			"2024-01-01T10:00:00Z",
+		),
+		testjsonl.CodexMsgJSON("user", "review this", "2024-01-01T10:00:01Z"),
+	)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat codex fixture")
+
+	sess := db.Session{
+		ID:        "host~codex:abc",
+		Project:   "roborev_ci_28293_3831737461",
+		Machine:   "host",
+		Agent:     "codex",
+		FilePath:  strPtr("host:" + path),
+		FileSize:  int64Ptr(info.Size()),
+		FileMtime: int64Ptr(info.ModTime().UnixNano()),
+	}
+	require.NoError(t, database.UpsertSession(sess))
+	require.NoError(t, database.SetSessionDataVersion(
+		sess.ID, db.CurrentDataVersion(),
+	))
+
+	e := &Engine{
+		db:        database,
+		idPrefix:  "host~",
+		skipCache: map[string]int64{path: info.ModTime().UnixNano()},
+		pathRewriter: func(path string) string {
+			return "host:" + path
+		},
+	}
+
+	res := e.processFile(context.Background(), parser.DiscoveredFile{
+		Agent: parser.AgentCodex,
+		Path:  path,
+	})
+	require.NoError(t, res.err)
+	require.False(t, res.skip,
+		"remote skip cache must not hide stale generated roborev CI projects")
+	require.Len(t, res.results, 1)
+	assert.Equal(t, "agentsview", res.results[0].Session.Project)
+}
+
 func TestCollectAndBatchPrefixesParserExcludedIDs(t *testing.T) {
 	database := openTestDB(t)
 	ctx := context.Background()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1520,6 +1520,98 @@ func TestProcessCodexAppendedStaleProjectDoesFullReparse(t *testing.T) {
 	assert.Equal(t, "agentsview", res.results[0].Session.Project)
 }
 
+func TestProcessCodexAppendedStaleProjectCarriesForceReplace(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "rollout-2026-06-21T18-59-38-abc.jsonl")
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			"abc",
+			"/home/roborev/.roborev/ci-worktrees/agentsview/roborev-ci-28293-3831737461",
+			"user",
+			"2024-01-01T10:00:00Z",
+		),
+		testjsonl.CodexMsgJSON("user", "run command", "2024-01-01T10:00:01Z"),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"exec_command",
+			"call_cmd",
+			map[string]any{"cmd": "go test"},
+			"2024-01-01T10:00:02Z",
+		),
+	)
+	require.NoError(t, os.WriteFile(path, []byte(initial), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat initial codex fixture")
+
+	sess := db.Session{
+		ID:               "host~codex:abc",
+		Project:          "roborev_ci_28293_3831737461",
+		Machine:          "host",
+		Agent:            "codex",
+		FirstMessage:     strPtr("run command"),
+		MessageCount:     2,
+		UserMessageCount: 1,
+		FilePath:         strPtr("host:" + path),
+		FileSize:         int64Ptr(info.Size()),
+		FileMtime:        int64Ptr(info.ModTime().UnixNano()),
+		NextOrdinal:      2,
+	}
+	require.NoError(t, database.UpsertSession(sess))
+	require.NoError(t, database.SetSessionDataVersion(
+		sess.ID, db.CurrentDataVersion(),
+	))
+	require.NoError(t, database.InsertMessages([]db.Message{
+		{
+			SessionID: "host~codex:abc",
+			Ordinal:   0,
+			Role:      "user",
+			Content:   "run command",
+		},
+		{
+			SessionID: "host~codex:abc",
+			Ordinal:   1,
+			Role:      "assistant",
+			ToolCalls: []db.ToolCall{
+				{
+					ToolUseID: "call_cmd",
+					ToolName:  "exec_command",
+					InputJSON: `{"cmd":"go test"}`,
+				},
+			},
+		},
+	}))
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	require.NoError(t, err, "open codex fixture for append")
+	_, err = f.WriteString(testjsonl.CodexFunctionCallOutputJSON(
+		"call_cmd", `{"status":"ok"}`, "2024-01-01T10:00:03Z",
+	) + "\n")
+	require.NoError(t, err, "append codex fixture")
+	require.NoError(t, f.Close(), "close codex fixture")
+	info, err = os.Stat(path)
+	require.NoError(t, err, "stat appended codex fixture")
+
+	e := &Engine{
+		db:       database,
+		idPrefix: "host~",
+		pathRewriter: func(path string) string {
+			return "host:" + path
+		},
+	}
+
+	res := e.processCodex(parser.DiscoveredFile{
+		Agent: parser.AgentCodex,
+		Path:  path,
+	}, info)
+	require.NoError(t, res.err)
+	require.Nil(t, res.incremental,
+		"stale project metadata must force full parse even when file appended")
+	require.Len(t, res.results, 1)
+	assert.Equal(t, "agentsview", res.results[0].Session.Project)
+	assert.True(t, res.forceReplace,
+		"fallback-triggering appended data must replace existing messages")
+}
+
 func TestCollectAndBatchPrefixesParserExcludedIDs(t *testing.T) {
 	database := openTestDB(t)
 	ctx := context.Background()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1364,6 +1364,39 @@ func TestShouldSkipFileWithIDPrefix(t *testing.T) {
 	assert.False(t, got2, "shouldSkipFile without prefix should return false")
 }
 
+func TestShouldSkipCodexReparsesStaleProject(t *testing.T) {
+	database := openTestDB(t)
+	path := filepath.Join(t.TempDir(), "rollout-2026-06-21T18-59-38-abc.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat codex fixture")
+
+	sess := db.Session{
+		ID:        "host~codex:abc",
+		Project:   "roborev_ci_28293_3831737461",
+		Machine:   "host",
+		Agent:     "codex",
+		FilePath:  strPtr("host:" + path),
+		FileSize:  int64Ptr(info.Size()),
+		FileMtime: int64Ptr(info.ModTime().UnixNano()),
+	}
+	require.NoError(t, database.UpsertSession(sess))
+	require.NoError(t, database.SetSessionDataVersion(
+		sess.ID, db.CurrentDataVersion(),
+	))
+
+	e := &Engine{
+		db:       database,
+		idPrefix: "host~",
+		pathRewriter: func(path string) string {
+			return "host:" + path
+		},
+	}
+
+	assert.False(t, e.shouldSkipCodex(path, info),
+		"stale generated roborev CI projects must be reparsed")
+}
+
 func TestCollectAndBatchPrefixesParserExcludedIDs(t *testing.T) {
 	database := openTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
Remote roborev CI sessions can be stored under generated worktree project names when an older sync imports them before the project resolver has a chance to recover the owning repository. Once those rows exist, unchanged remote files may be skipped by both the Codex path metadata check and the remote mtime skip cache, leaving the generated project names visible indefinitely.

This change treats generated roborev CI project names as stale project metadata and makes the path-based Codex and remote-cache skip paths consult that stale-project signal before skipping. The next host sync can then reparse affected sessions and collapse them back to the owning repository instead of preserving the generated worktree name.

The test coverage uses synthetic host/path fixtures and avoids real machine names or local archive paths.