### PR TITLE
ci: group GitHub Actions Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,11 @@
   },
   "packageRules": [
     {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions dependencies",
+      "groupSlug": "github-actions-dependencies"
+    },
+    {
       "matchManagers": ["gomod"],
       "groupName": "Go dependencies",
       "groupSlug": "go-dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,9 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions dependencies",
-      "groupSlug": "github-actions-dependencies"
+      "groupSlug": "github-actions-dependencies",
+      "separateMajorMinor": false,
+      "separateMultipleMajor": false
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
Renovate already batches Go and JavaScript dependency updates, but GitHub Actions updates were still fanning out into separate dashboard entries and pending-check items. That made routine workflow maintenance noisier than the other dependency ecosystems.

This config gives the `github-actions` manager the same grouped treatment and disables Renovate's major-release splitting within that group, so action updates can land as a single GitHub Actions dependency update instead of separate major/minor branches.

The stability-delay behavior remains in place for normal dependency updates; vulnerability alerts still bypass that delay through the existing override.

<sup>generated by a clanker</sup>