### PR TITLE
fix(sync): avoid Music prompts during Aider scan

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -505,12 +505,12 @@ func printSyncProgress(p sync.Progress) {
 		if p.Hint != "" {
 			detail += " - " + p.Hint
 		}
-		fmt.Printf("\r  %s", detail)
+		fmt.Printf("\r  %s\x1b[K", detail)
 		return
 	}
 	if p.SessionsTotal > 0 {
 		fmt.Printf(
-			"\r  %d/%d sessions (%.0f%%) · %d messages",
+			"\r  %d/%d sessions (%.0f%%) · %d messages\x1b[K",
 			p.SessionsDone, p.SessionsTotal,
 			p.Percent(), p.MessagesIndexed,
 		)

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
+	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
 func TestRunRemoteHosts_AttemptsAllAndCollectsFailures(t *testing.T) {
@@ -75,4 +77,20 @@ func TestSyncLocalAndRemotes_ResyncForcesRemoteFull(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrintSyncProgressClearsShorterOverwrites(t *testing.T) {
+	out := captureStdout(t, func() {
+		printSyncProgress(agentsync.Progress{
+			Detail: "Rebuilding search index",
+			Hint:   "Rebuilding the search index may take a while on large archives.",
+		})
+		printSyncProgress(agentsync.Progress{
+			Detail: "Swapping rebuilt database into place",
+		})
+	})
+
+	require.GreaterOrEqual(t, strings.Count(out, "\x1b[K"), 2,
+		"each carriage-return progress line must clear stale text")
+	assert.Contains(t, out, "\r  Swapping rebuilt database into place\x1b[K")
 }

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -238,7 +238,7 @@ func ensureFreshData(
 func printSyncProgressStderr(p sync.Progress) {
 	if p.SessionsTotal > 0 {
 		fmt.Fprintf(os.Stderr,
-			"\r  %d/%d sessions (%.0f%%) · %d messages",
+			"\r  %d/%d sessions (%.0f%%) · %d messages\x1b[K",
 			p.SessionsDone, p.SessionsTotal,
 			p.Percent(), p.MessagesIndexed,
 		)

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -98,6 +98,7 @@ var aiderProtectedHomeDirs = map[string]struct{}{
 	"Desktop":   {},
 	"Documents": {},
 	"Downloads": {},
+	"Music":     {},
 }
 
 // AiderDiscoverySkipDirNames returns the directory basenames pruned by Aider

--- a/internal/parser/aider_test.go
+++ b/internal/parser/aider_test.go
@@ -623,7 +623,7 @@ func TestDiscoverAiderSessionsSkipsMacOSProtectedDirs(t *testing.T) {
 	}
 	root := t.TempDir()
 	t.Setenv("HOME", root)
-	for _, name := range []string{"Desktop", "Documents", "Downloads"} {
+	for _, name := range []string{"Desktop", "Documents", "Downloads", "Music"} {
 		protectedRepo := filepath.Join(root, name, "proj")
 		require.NoError(t, os.MkdirAll(protectedRepo, 0o755))
 		require.NoError(t, os.WriteFile(


### PR DESCRIPTION
Aider has no central session store, so agentsview defaults to a bounded home-directory scan to find `.aider.chat.history.md` files. The macOS protected-folder guard added in 3d070cae covered Desktop, Documents, and Downloads, but missed `~/Music`, which can still trigger the Apple Music/media-library privacy prompt from terminal apps during `agentsview sync`.

This extends the default home scan pruning to `~/Music` while preserving explicit opt-in behavior when a user configures Aider directly inside a protected folder. It also clears terminal progress lines before shorter resync phase messages are written, so long search-index hints do not visually bleed into later status lines.