### PR TITLE
Fix stale usage daily refresh and reduce pricing overhead

### DIFF
--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -279,23 +279,27 @@ func printSyncSummaryStderr(stats sync.SyncStats, t time.Time) {
 // every restart while still propagating corrected fallback
 // rates when the binary is upgraded.
 func seedPricing(database *db.DB) {
+	if err := seedFallbackPricing(database); err != nil {
+		log.Printf("pricing seed: %v", err)
+	}
+	go refreshPricingFromLiteLLM(database)
+}
+
+func seedFallbackPricing(database *db.DB) error {
 	const metaKey = "_fallback_version"
 	stored, err := database.GetPricingMeta(metaKey)
 	if err != nil {
-		log.Printf("pricing seed: %v", err)
+		return err
 	}
-	if stored != pricing.FallbackVersion {
-		if err := upsertPricing(
-			database, pricing.FallbackPricing(),
-		); err != nil {
-			log.Printf("pricing seed: %v", err)
-		} else if err := database.SetPricingMeta(
-			metaKey, pricing.FallbackVersion,
-		); err != nil {
-			log.Printf("pricing seed: %v", err)
-		}
+	if stored == pricing.FallbackVersion {
+		return nil
 	}
-	go refreshPricingFromLiteLLM(database)
+	if err := upsertPricing(
+		database, pricing.FallbackPricing(),
+	); err != nil {
+		return err
+	}
+	return database.SetPricingMeta(metaKey, pricing.FallbackVersion)
 }
 
 // refreshPricingFromLiteLLM fetches the upstream LiteLLM
@@ -371,25 +375,30 @@ func refreshPricingIfStale(
 }
 
 func ensurePricing(database *db.DB, offline bool) {
-	var prices []pricing.ModelPricing
-
-	if offline {
-		prices = pricing.FallbackPricing()
-	} else {
-		var err error
-		prices, err = pricing.FetchLiteLLMPricing()
-		if err != nil {
-			fmt.Fprintf(os.Stderr,
-				"warning: pricing fetch failed: %v"+
-					"; using fallback\n", err)
-			prices = pricing.FallbackPricing()
-		}
-	}
-
-	if err := upsertPricing(database, prices); err != nil {
+	if _, err := ensurePricingWithFetcher(
+		database, offline, pricing.FetchLiteLLMPricing, time.Now(),
+	); err != nil {
 		fmt.Fprintf(os.Stderr,
-			"warning: pricing upsert failed: %v\n", err)
+			"warning: pricing refresh failed: %v\n", err)
 	}
+}
+
+func ensurePricingWithFetcher(
+	database *db.DB, offline bool,
+	fetch func() ([]pricing.ModelPricing, error),
+	now time.Time,
+) (bool, error) {
+	if offline {
+		return false, upsertPricing(database, pricing.FallbackPricing())
+	}
+
+	if err := seedFallbackPricing(database); err != nil {
+		return false, err
+	}
+
+	return refreshPricingIfStale(
+		database, fetch, pricingRefreshCooldown, now,
+	)
 }
 
 // upsertPricing copies pricing rows into the db.ModelPricing

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -309,3 +309,34 @@ func TestRefreshPricingIfStale_FetchFailureRecordsAttempt(t *testing.T) {
 		t.Error("second call should be suppressed by cooldown")
 	}
 }
+
+func TestEnsurePricingWithFetcherSkipsFetchWithinCooldown(t *testing.T) {
+	d := newTestDB(t)
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+
+	prev := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	require.NoError(t, d.SetPricingMeta(pricingRefreshMetaKey, prev))
+
+	called := false
+	refreshed, err := ensurePricingWithFetcher(
+		d, false, func() ([]pricing.ModelPricing, error) {
+			called = true
+			return []pricing.ModelPricing{{
+				ModelPattern:  "network-only-model",
+				InputPerMTok:  1,
+				OutputPerMTok: 1,
+			}}, nil
+		}, now,
+	)
+	require.NoError(t, err)
+	assert.False(t, refreshed)
+	assert.False(t, called, "fetch should not run within cooldown")
+
+	fallback, err := d.GetModelPricing("gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, fallback, "fallback pricing should be seeded")
+
+	networkOnly, err := d.GetModelPricing("network-only-model")
+	require.NoError(t, err)
+	assert.Nil(t, networkOnly, "cooldown should prevent network upsert")
+}

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -206,6 +206,7 @@ func (db *DB) activityReportUsage(
 	if err != nil {
 		return nil, fmt.Errorf("loading pricing: %w", err)
 	}
+	rateResolver := newModelRateResolver(pricing)
 
 	// Accumulate the parsed ts and dedup ordinal alongside each mapped row so
 	// we can impose one global (ts, session_id, ordinal) order across all
@@ -252,7 +253,7 @@ func (db *DB) activityReportUsage(
 				return fmt.Errorf(
 					"scanning activity report usage: %w", scanErr)
 			}
-			_, outputTok, _, _, cost, _ := dailyUsageAmounts(r, pricing)
+			_, outputTok, _, _, cost, _ := dailyUsageAmounts(r, rateResolver)
 			ord := int64(-1)
 			if r.messageOrdinal.Valid {
 				ord = r.messageOrdinal.Int64

--- a/internal/db/pricing_match_test.go
+++ b/internal/db/pricing_match_test.go
@@ -30,3 +30,24 @@ func TestLookupModelRates_DotDashFallback(t *testing.T) {
 	_, ok = lookupModelRates(pricing, "gpt-5.5")
 	assert.False(t, ok, "unknown model stays unpriced")
 }
+
+func TestModelRateResolverCachesResolvedModels(t *testing.T) {
+	pricing := map[string]modelRates{
+		"gemini-3.5-flash": {input: 1.25, output: 10},
+	}
+	resolver := newModelRateResolver(pricing)
+
+	first, ok := resolver.lookup("Gemini 3.5 Flash (High)")
+	require.True(t, ok)
+	assert.Equal(t, 1.25, first.input)
+
+	second, ok := resolver.lookup("Gemini 3.5 Flash (High)")
+	require.True(t, ok)
+	assert.Equal(t, first, second)
+
+	_, ok = resolver.lookup("unknown-model")
+	assert.False(t, ok)
+
+	_, ok = resolver.lookup("unknown-model")
+	assert.False(t, ok)
+}

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -23,6 +23,37 @@ func lookupModelRates(
 	return pricingpkg.Resolve(pricing, model)
 }
 
+type modelRateResolution struct {
+	rates modelRates
+	ok    bool
+}
+
+type modelRateResolver struct {
+	pricing map[string]modelRates
+	cache   map[string]modelRateResolution
+}
+
+func newModelRateResolver(
+	pricing map[string]modelRates,
+) *modelRateResolver {
+	return &modelRateResolver{
+		pricing: pricing,
+		cache:   make(map[string]modelRateResolution),
+	}
+}
+
+func (r *modelRateResolver) lookup(model string) (modelRates, bool) {
+	if r == nil {
+		return modelRates{}, false
+	}
+	if cached, ok := r.cache[model]; ok {
+		return cached.rates, cached.ok
+	}
+	rates, ok := lookupModelRates(r.pricing, model)
+	r.cache[model] = modelRateResolution{rates: rates, ok: ok}
+	return rates, ok
+}
+
 // UsageFilter controls the date range, agent, and timezone
 // for daily usage aggregation queries.
 type UsageFilter struct {
@@ -796,7 +827,7 @@ func scanDailyUsageRow(rows *sql.Rows) (dailyUsageScanRow, error) {
 }
 
 func dailyUsageAmounts(
-	r dailyUsageScanRow, pricing map[string]modelRates,
+	r dailyUsageScanRow, pricing *modelRateResolver,
 ) (inputTok, outputTok, cacheCrTok, cacheRdTok int, cost, savings float64) {
 	if r.usageSource == "message" {
 		usage := gjson.Parse(r.tokenJSON)
@@ -813,7 +844,7 @@ func dailyUsageAmounts(
 		cacheRdTok = r.cacheReadInputTokens
 	}
 
-	rates, _ := lookupModelRates(pricing, r.model)
+	rates, _ := pricing.lookup(r.model)
 	if r.costUSD.Valid {
 		cost = r.costUSD.Float64
 	} else {
@@ -1032,6 +1063,7 @@ func (db *DB) GetDailyUsage(
 		return DailyUsageResult{},
 			fmt.Errorf("loading pricing: %w", err)
 	}
+	rateResolver := newModelRateResolver(pricing)
 
 	// Filter on usage timestamp (not only session started_at) so
 	// long-lived sessions that span date boundaries are included.
@@ -1121,7 +1153,7 @@ func (db *DB) GetDailyUsage(
 		}
 
 		inputTok, outputTok, cacheCrTok, cacheRdTok, cost, savings :=
-			dailyUsageAmounts(r, pricing)
+			dailyUsageAmounts(r, rateResolver)
 		totalSavings += savings
 
 		key := accumKey{
@@ -1484,6 +1516,7 @@ func (db *DB) GetTopSessionsByCost(
 		return nil,
 			fmt.Errorf("loading pricing: %w", err)
 	}
+	rateResolver := newModelRateResolver(pricing)
 
 	query, args := topSessionsUsageRowQuery(f)
 	// Deterministic order so the dedup "winner" (the session
@@ -1556,7 +1589,7 @@ func (db *DB) GetTopSessionsByCost(
 		}
 
 		inputTok, outputTok, cacheCrTok, cacheRdTok, cost, _ :=
-			dailyUsageAmounts(r, pricing)
+			dailyUsageAmounts(r, rateResolver)
 
 		sa, ok := accum[r.sessionID]
 		if !ok {

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -204,6 +204,7 @@ func (s *Store) activityReportUsage(
 	if err != nil {
 		return nil, fmt.Errorf("loading pg pricing: %w", err)
 	}
+	rateResolver := newModelRateResolver(pricing)
 
 	// Accumulate the dedup sort keys (ts, session_id, ordinal) alongside
 	// each mapped row so we can impose one global order across all chunks.
@@ -245,7 +246,7 @@ func (s *Store) activityReportUsage(
 				return fmt.Errorf(
 					"scanning activity report usage: %w", scanErr)
 			}
-			_, outputTok, _, _, cost, _ := pgDailyUsageAmounts(r, pricing)
+			_, outputTok, _, _, cost, _ := pgDailyUsageAmounts(r, rateResolver)
 			ord := int64(-1)
 			if r.messageOrdinal.Valid {
 				ord = r.messageOrdinal.Int64

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -33,6 +33,37 @@ func lookupModelRates(
 	return pricing.Resolve(prices, model)
 }
 
+type modelRateResolution struct {
+	rates modelRates
+	ok    bool
+}
+
+type modelRateResolver struct {
+	prices map[string]modelRates
+	cache  map[string]modelRateResolution
+}
+
+func newModelRateResolver(
+	prices map[string]modelRates,
+) *modelRateResolver {
+	return &modelRateResolver{
+		prices: prices,
+		cache:  make(map[string]modelRateResolution),
+	}
+}
+
+func (r *modelRateResolver) lookup(model string) (modelRates, bool) {
+	if r == nil {
+		return modelRates{}, false
+	}
+	if cached, ok := r.cache[model]; ok {
+		return cached.rates, cached.ok
+	}
+	rates, ok := lookupModelRates(r.prices, model)
+	r.cache[model] = modelRateResolution{rates: rates, ok: ok}
+	return rates, ok
+}
+
 func fallbackPricingRows() []db.ModelPricing {
 	src := pricing.FallbackPricing()
 	out := make([]db.ModelPricing, len(src))

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -714,7 +714,7 @@ func scanPGDailyUsageRow(rows *sql.Rows) (pgDailyUsageScanRow, error) {
 }
 
 func pgDailyUsageAmounts(
-	r pgDailyUsageScanRow, pricing map[string]modelRates,
+	r pgDailyUsageScanRow, pricing *modelRateResolver,
 ) (inputTok, outputTok, cacheCrTok, cacheRdTok int, cost, savings float64) {
 	if r.usageSource == "message" {
 		usage := gjson.Parse(r.tokenJSON)
@@ -729,7 +729,7 @@ func pgDailyUsageAmounts(
 		cacheRdTok = r.cacheReadInputTokens
 	}
 
-	rates, _ := lookupModelRates(pricing, r.model)
+	rates, _ := pricing.lookup(r.model)
 	if r.costUSD.Valid {
 		cost = r.costUSD.Float64
 	} else {
@@ -972,6 +972,7 @@ func (s *Store) GetDailyUsage(
 		return db.DailyUsageResult{},
 			fmt.Errorf("loading pg pricing: %w", err)
 	}
+	rateResolver := newModelRateResolver(pricing)
 
 	pb := &paramBuilder{}
 	query := pgUsageRowQuery(pb, f)
@@ -1045,7 +1046,7 @@ func (s *Store) GetDailyUsage(
 		}
 
 		inputTok, outputTok, cacheCrTok, cacheRdTok, cost, savings :=
-			pgDailyUsageAmounts(r, pricing)
+			pgDailyUsageAmounts(r, rateResolver)
 		totalSavings += savings
 
 		key := accumKey{
@@ -1365,6 +1366,7 @@ func (s *Store) GetTopSessionsByCost(
 	if err != nil {
 		return nil, fmt.Errorf("loading pg pricing: %w", err)
 	}
+	rateResolver := newModelRateResolver(pricing)
 
 	pb := &paramBuilder{}
 	query := pgTopSessionsUsageRowQuery(pb, f)
@@ -1421,7 +1423,7 @@ func (s *Store) GetTopSessionsByCost(
 		}
 
 		inputTok, outputTok, cacheCrTok, cacheRdTok, cost, _ :=
-			pgDailyUsageAmounts(r, pricing)
+			pgDailyUsageAmounts(r, rateResolver)
 
 		sa, ok := accum[r.sessionID]
 		if !ok {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3138,7 +3138,8 @@ func discoveredFileMtime(
 		}
 	}
 	if isOpenCodeFormatStorageAgent(file.Agent) {
-		if isOpenCodeFormatSQLiteVirtualPath(file.Agent, file.Path) {
+		if isOpenCodeFormatSQLiteVirtualPath(file.Agent, file.Path) ||
+			isOpenCodeFormatStoragePath(file.Agent, file.Path) {
 			return openCodeFormatSourceMtime(
 				file.Agent, file.Path,
 			)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -4404,21 +4404,23 @@ func TestResyncAllAllowsKiloSQLiteOnlySessions(t *testing.T) {
 	)
 }
 
-func TestSyncAllSinceOpenCodeStorageRequiresSessionMtime(t *testing.T) {
+func TestSyncAllSinceOpenCodeStoragePicksUpUsagePartUpdate(t *testing.T) {
 	env := setupTestEnv(t)
 	oc := createOpenCodeStorageFixture(t, env.opencodeDir)
 
 	sessionPath := oc.addSession(
-		t, "global", "oc-since-child",
-		"/home/user/code/myapp", "Since Child",
+		t, "global", "oc-since-usage-part",
+		"/home/user/code/myapp", "Since Usage Part",
 		1704067200000, 1704067205000,
 	)
 	oc.addMessage(
-		t, "oc-since-child", "msg-a1", "assistant",
-		1704067201000, nil,
+		t, "oc-since-usage-part", "msg-a1", "assistant",
+		1704067201000, map[string]any{
+			"modelID": "Gemini 3.5 Flash (High)",
+		},
 	)
-	partPath := oc.addTextPart(
-		t, "oc-since-child", "msg-a1", "part-a1",
+	oc.addTextPart(
+		t, "oc-since-usage-part", "msg-a1", "part-a1",
 		"initial reply", 1704067201000,
 	)
 
@@ -4434,28 +4436,43 @@ func TestSyncAllSinceOpenCodeStorageRequiresSessionMtime(t *testing.T) {
 	sessionMtime := info.ModTime()
 	future := cutoff.Add(2 * time.Second)
 
-	err = os.WriteFile(partPath, []byte(
-		`{"id":"part-a1","sessionID":"oc-since-child","messageID":"msg-a1","type":"text","text":"updated reply","time":{"created":1704067201000}}`,
-	), 0o644)
-	require.NoError(t, err, "rewrite part")
-	require.NoError(t, os.Chtimes(partPath, future, future), "chtimes part")
+	usagePartPath := oc.writeJSON(t, filepath.Join(
+		env.opencodeDir, "storage", "part", "msg-a1", "part-finish.json",
+	), map[string]any{
+		"id":        "part-finish",
+		"sessionID": "oc-since-usage-part",
+		"messageID": "msg-a1",
+		"type":      "step-finish",
+		"tokens": map[string]any{
+			"input":  123,
+			"output": 45,
+			"cache": map[string]any{
+				"read":  67,
+				"write": 89,
+			},
+		},
+		"time": map[string]any{
+			"created": int64(1704067201000),
+		},
+	})
+	require.NoError(t, os.Chtimes(usagePartPath, future, future), "chtimes usage part")
 	require.NoError(t, os.Chtimes(sessionPath, sessionMtime, sessionMtime), "restore session mtime")
 
 	stats := env.engine.SyncAllSince(context.Background(), cutoff, nil)
-	require.Equal(t, 0, stats.Synced, "SyncAllSince synced = %d, want 0", stats.Synced)
-	assertMessageContent(
-		t, env.db, "opencode:oc-since-child",
-		"initial reply",
-	)
-
-	require.NoError(t, os.Chtimes(sessionPath, future, future), "chtimes session path")
-
-	stats = env.engine.SyncAllSince(context.Background(), cutoff, nil)
 	require.Equal(t, 1, stats.Synced, "SyncAllSince synced = %d, want 1", stats.Synced)
-	assertMessageContent(
-		t, env.db, "opencode:oc-since-child",
-		"updated reply",
-	)
+
+	daily, err := env.db.GetDailyUsage(context.Background(), db.UsageFilter{
+		From:     "2024-01-01",
+		To:       "2024-01-01",
+		Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetDailyUsage")
+	require.Len(t, daily.Daily, 1, "daily rows")
+	assert.Equal(t, 123, daily.Totals.InputTokens)
+	assert.Equal(t, 45, daily.Totals.OutputTokens)
+	assert.Equal(t, 67, daily.Totals.CacheReadTokens)
+	assert.Equal(t, 89, daily.Totals.CacheCreationTokens)
+	assert.Equal(t, []string{"Gemini 3.5 Flash (High)"}, daily.Daily[0].ModelsUsed)
 }
 
 func TestSyncAllOpenCodeStorageSkipsUnchangedSessions(t *testing.T) {


### PR DESCRIPTION
`agentsview usage daily` could stay stale for OpenCode-format storage sessions because quick sync filtered by the parent session JSON mtime. Usage details can arrive later in child part files, so users had to run a manual full sync before daily totals reflected the latest rows.

The CLI path also paid avoidable per-run work: it fetched the LiteLLM pricing catalog synchronously on every daily usage invocation, and large usage windows repeatedly canonicalized the same small set of model names while pricing hundreds of thousands of rows. This keeps fallback pricing available locally, respects the existing pricing refresh cooldown, and caches pricing resolution per reported model for each aggregation.

This is not the whole performance answer for large local archives. Profiling still shows a fixed open/init cost and substantial SQLite row-stepping time, so a daemon-backed CLI that keeps the database open and serves usage queries remains the right next architectural step.