### PR TITLE
fix(sync): avoid photo media prompts during Aider scan

### DIFF
--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -98,7 +98,10 @@ var aiderProtectedHomeDirs = map[string]struct{}{
 	"Desktop":   {},
 	"Documents": {},
 	"Downloads": {},
+	"Movies":    {},
 	"Music":     {},
+	"Photos":    {},
+	"Pictures":  {},
 }
 
 // AiderDiscoverySkipDirNames returns the directory basenames pruned by Aider

--- a/internal/parser/aider_test.go
+++ b/internal/parser/aider_test.go
@@ -617,13 +617,36 @@ func TestAiderShouldSkipProtectedHomeDirsOnlyOnDarwinHomeRoot(t *testing.T) {
 		"explicit protected roots are user-scoped opt-ins")
 }
 
+func TestAiderProtectedHomeDirsCoversMacOSTCCPrompts(t *testing.T) {
+	for _, name := range []string{
+		"Desktop",
+		"Documents",
+		"Downloads",
+		"Movies",
+		"Music",
+		"Photos",
+		"Pictures",
+	} {
+		_, ok := aiderProtectedHomeDirs[name]
+		assert.True(t, ok, "%s should be pruned from default home discovery", name)
+	}
+}
+
 func TestDiscoverAiderSessionsSkipsMacOSProtectedDirs(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("macOS TCC protected-directory pruning is Darwin-only")
 	}
 	root := t.TempDir()
 	t.Setenv("HOME", root)
-	for _, name := range []string{"Desktop", "Documents", "Downloads", "Music"} {
+	for _, name := range []string{
+		"Desktop",
+		"Documents",
+		"Downloads",
+		"Movies",
+		"Music",
+		"Photos",
+		"Pictures",
+	} {
 		protectedRepo := filepath.Join(root, name, "proj")
 		require.NoError(t, os.MkdirAll(protectedRepo, 0o755))
 		require.NoError(t, os.WriteFile(

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -26,6 +26,17 @@ type gistResponse struct {
 	} `json:"owner"`
 }
 
+func githubHTTPClient(timeout time.Duration) *http.Client {
+	transport := http.DefaultTransport
+	if base, ok := http.DefaultTransport.(*http.Transport); ok {
+		transport = base.Clone()
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+}
+
 func createGist(
 	ctx context.Context,
 	token, filename, description, content string,
@@ -65,7 +76,7 @@ func createGistWithURL(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "agentsview")
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := githubHTTPClient(30 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("github request failed: %w", err)
@@ -106,7 +117,7 @@ func validateGithubTokenWithURL(
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	req.Header.Set("User-Agent", "agentsview")
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := githubHTTPClient(10 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("validating token: %w", err)

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1304,4 +1305,11 @@ func TestValidateGithubToken(t *testing.T) {
 			assert.Equal(t, tt.wantLogin, login)
 		})
 	}
+}
+
+func TestGithubHTTPClientUsesIsolatedTransport(t *testing.T) {
+	client := githubHTTPClient(10 * time.Second)
+	require.NotNil(t, client.Transport)
+	assert.NotSame(t, http.DefaultTransport, client.Transport,
+		"github API clients must not share the package default transport")
 }


### PR DESCRIPTION
Aider discovery has to do a bounded home-directory scan because Aider does not keep a central session index. The previous protected-folder guard avoided Desktop, Documents, Downloads, and Music, but the same implicit scan can still trip macOS privacy prompts around photo and video media locations such as Photos, Pictures, and Movies.

This expands the first-level home-directory pruning for the implicit macOS Aider scan while preserving explicit opt-in behavior when a user configures Aider directly inside one of those locations. Reviewers should treat this as completing the TCC avoidance class rather than another one-off folder patch.