### PR TITLE
fix(session): keep pg reads opt-in

### DIFF
--- a/cmd/agentsview/classifier.go
+++ b/cmd/agentsview/classifier.go
@@ -39,14 +39,16 @@ func newClassifierCommand() *cobra.Command {
 }
 
 func newClassifierRebuildCommand() *cobra.Command {
-	return &cobra.Command{
+	var includePG bool
+	cmd := &cobra.Command{
 		Use:   "rebuild",
 		Short: "Force is_automated re-backfill on next open",
 		Long: "Clears the stored classifier hash so the next " +
 			"db.Open runs a full is_automated backfill. " +
 			"Use after editing [automated] prefixes in " +
 			"config.toml or after a downgrade-then-upgrade " +
-			"cycle that left flags stale.",
+			"cycle that left flags stale. Pass --pg to also " +
+			"clear the configured PostgreSQL sync store.",
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,10 +65,15 @@ func newClassifierRebuildCommand() *cobra.Command {
 				return err
 			}
 			return runClassifierRebuild(
-				cmd.Context(), cfg, cmd.OutOrStdout(),
+				cmd.Context(), cfg, cmd.OutOrStdout(), includePG,
 			)
 		},
 	}
+	cmd.Flags().BoolVar(
+		&includePG, "pg", false,
+		"also clear the configured PostgreSQL sync store",
+	)
+	return cmd
 }
 
 // guardClassifierRebuild rejects when the SQLite write lock
@@ -90,12 +97,12 @@ func guardClassifierRebuild(tr transport) error {
 	return nil
 }
 
-// runClassifierRebuild prints the loaded user-prefix list,
-// deletes the classifier hash from SQLite stats, and (if PG
-// is configured) deletes it from PG sync_metadata. Returns
-// an error on PG delete failure when PG is configured.
+// runClassifierRebuild prints the loaded user-prefix list, deletes the
+// classifier hash from SQLite stats, and optionally deletes it from PG
+// sync_metadata. Returns an error on PG delete failure when PG cleanup is
+// explicitly requested.
 func runClassifierRebuild(
-	ctx context.Context, cfg config.Config, out io.Writer,
+	ctx context.Context, cfg config.Config, out io.Writer, includePG bool,
 ) error {
 	prefixes := db.UserAutomationPrefixes()
 	fmt.Fprintf(out,
@@ -110,11 +117,16 @@ func runClassifierRebuild(
 		return fmt.Errorf("clearing SQLite hash: %w", err)
 	}
 
-	pgCfg, err := cfg.ResolvePG()
-	if err != nil {
-		return fmt.Errorf("resolving pg config: %w", err)
-	}
-	if pgCfg.URL != "" {
+	if includePG {
+		pgCfg, err := cfg.ResolvePG()
+		if err != nil {
+			return fmt.Errorf("resolving pg config: %w", err)
+		}
+		if pgCfg.URL == "" {
+			return errors.New(
+				"pg url not configured; set AGENTSVIEW_PG_URL or [pg].url",
+			)
+		}
 		if err := clearPGClassifierHash(ctx, cfg, pgCfg); err != nil {
 			return fmt.Errorf(
 				"clearing PG hash: %w (SQLite was cleared "+

--- a/cmd/agentsview/classifier_test.go
+++ b/cmd/agentsview/classifier_test.go
@@ -85,7 +85,7 @@ func TestClassifierRebuildClearsSQLiteHash(t *testing.T) {
 		"precondition: expected stored hash, got empty")
 
 	require.NoError(t, runClassifierRebuild(
-		context.Background(), cfg, &bytes.Buffer{},
+		context.Background(), cfg, &bytes.Buffer{}, false,
 	), "rebuild")
 
 	assert.Empty(t, readStoredHash(t, cfg.DBPath),
@@ -106,7 +106,7 @@ func TestClassifierRebuildPrintsLoadedPrefixes(t *testing.T) {
 
 	out := &bytes.Buffer{}
 	require.NoError(t, runClassifierRebuild(
-		context.Background(), cfg, out,
+		context.Background(), cfg, out, false,
 	), "rebuild")
 	got := out.String()
 	for _, p := range prefixes {
@@ -144,11 +144,29 @@ func TestClassifierRebuildAllowsDirectWritable(t *testing.T) {
 	assert.NoError(t, guardClassifierRebuild(tr))
 }
 
-// TestClassifierRebuildHardFailsOnPGUnreachable confirms
-// that when PG is configured (pg.url non-empty) and the
-// connection fails, runClassifierRebuild returns an error
-// instead of silently skipping the PG delete.
-func TestClassifierRebuildHardFailsOnPGUnreachable(t *testing.T) {
+// TestClassifierRebuildSkipsConfiguredPGByDefault confirms that
+// configured sync PG is not touched by the local recovery command
+// unless the caller explicitly opts in.
+func TestClassifierRebuildSkipsConfiguredPGByDefault(t *testing.T) {
+	dir := classifierTestEnv(t, nil)
+	cfg, err := config.LoadMinimal()
+	require.NoError(t, err, "load")
+	cfg.DBPath = filepath.Join(dir, "sessions.db")
+	cfg.PG.URL = "postgres://nobody:nobody@127.0.0.1:1/nonexistent?sslmode=disable&connect_timeout=2"
+	cfg.PG.AllowInsecure = true
+	applyClassifierConfig(cfg)
+	seedHash(t, cfg)
+
+	require.NoError(t, runClassifierRebuild(
+		context.Background(), cfg, &bytes.Buffer{}, false,
+	), "configured PG must be ignored unless --pg is requested")
+}
+
+// TestClassifierRebuildPGFlagHardFailsOnPGUnreachable confirms
+// that when PG cleanup is explicitly requested and the connection
+// fails, runClassifierRebuild returns an error instead of silently
+// skipping the PG delete.
+func TestClassifierRebuildPGFlagHardFailsOnPGUnreachable(t *testing.T) {
 	dir := classifierTestEnv(t, nil)
 	cfg, err := config.LoadMinimal()
 	require.NoError(t, err, "load")
@@ -162,7 +180,7 @@ func TestClassifierRebuildHardFailsOnPGUnreachable(t *testing.T) {
 	seedHash(t, cfg)
 
 	err = runClassifierRebuild(
-		context.Background(), cfg, &bytes.Buffer{},
+		context.Background(), cfg, &bytes.Buffer{}, true,
 	)
 	require.Error(t, err, "expected error for unreachable PG")
 	assert.True(t,
@@ -190,7 +208,7 @@ func TestClassifierRebuildSkipsPGWhenNotConfigured(t *testing.T) {
 	seedHash(t, cfg)
 
 	require.NoError(t, runClassifierRebuild(
-		context.Background(), cfg, &bytes.Buffer{},
+		context.Background(), cfg, &bytes.Buffer{}, false,
 	), "unexpected error when PG unconfigured")
 }
 

--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -151,8 +151,7 @@ func resolveWritableService(
 func resolvePGReadConfig(
 	cmd *cobra.Command, cfg config.Config,
 ) (config.PGConfig, bool, error) {
-	requested := pgReadRequested(cmd)
-	if !requested && cfg.PG.URL == "" {
+	if !pgReadRequested(cmd) {
 		return config.PGConfig{}, false, nil
 	}
 	pgCfg, err := cfg.ResolvePG()

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -1250,7 +1250,7 @@ func TestSessionUsage_PGFlagUsesPGStore(t *testing.T) {
 	assert.False(t, out.ServerRunning)
 }
 
-func TestSessionUsage_PGEnvResolvesBareSessionID(t *testing.T) {
+func TestSessionUsage_PGFlagResolvesBareSessionID(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
@@ -1294,7 +1294,7 @@ func TestSessionUsage_PGEnvResolvesBareSessionID(t *testing.T) {
 	assert.Equal(t, 42, out.TotalOutputTokens)
 }
 
-func TestSessionUsage_PGEnvResolvesColonBearingRawSessionID(t *testing.T) {
+func TestSessionUsage_PGFlagResolvesColonBearingRawSessionID(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -351,7 +351,7 @@ func TestSessionList_PGFlagUsesPGReadStore(t *testing.T) {
 	assert.True(t, cleanupCalled, "expected PG store cleanup")
 }
 
-func TestSessionList_PGEnvUsesPGReadStore(t *testing.T) {
+func TestSessionList_ConfiguredPGWithoutFlagUsesSQLite(t *testing.T) {
 	localDir := t.TempDir()
 	remoteDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", localDir)
@@ -362,13 +362,14 @@ func TestSessionList_PGEnvUsesPGReadStore(t *testing.T) {
 
 	remoteDB, err := db.Open(filepath.Join(remoteDir, "sessions.db"))
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = remoteDB.Close() })
 	var gotPG config.PGConfig
 	orig := openPGReadStore
 	openPGReadStore = func(
 		_ config.Config, pgCfg config.PGConfig,
 	) (db.Store, func(), error) {
 		gotPG = pgCfg
-		return remoteDB, func() { require.NoError(t, remoteDB.Close()) }, nil
+		return remoteDB, func() {}, nil
 	}
 	t.Cleanup(func() {
 		openPGReadStore = orig
@@ -386,9 +387,8 @@ func TestSessionList_PGEnvUsesPGReadStore(t *testing.T) {
 		"stdout should be valid JSON: %q", out)
 	assert.Equal(t, 1, got.Total)
 	require.Len(t, got.Sessions, 1)
-	assert.Equal(t, "pg-session", got.Sessions[0]["id"])
-	assert.Equal(t, "postgres://example.test/from-env", gotPG.URL)
-	assert.Equal(t, "agentsview", gotPG.Schema)
+	assert.Equal(t, "local-session", got.Sessions[0]["id"])
+	assert.Empty(t, gotPG.URL, "configured PG sync URL must not select PG reads")
 }
 
 func TestSessionList_PGFlagRequiresURL(t *testing.T) {
@@ -413,7 +413,7 @@ func TestSessionList_DefaultDoesNotOpenPGStore(t *testing.T) {
 	openPGReadStore = func(
 		config.Config, config.PGConfig,
 	) (db.Store, func(), error) {
-		t.Fatal("openPGReadStore should not be called without --pg or PG URL")
+		t.Fatal("openPGReadStore should not be called without --pg")
 		return nil, nil, nil
 	}
 	t.Cleanup(func() {
@@ -1142,7 +1142,68 @@ func TestSessionUsage_ServerHTTPClientHasTimeout(t *testing.T) {
 	assert.Less(t, elapsed, 150*time.Millisecond)
 }
 
-func TestSessionUsage_PGEnvUsesPGStore(t *testing.T) {
+func TestSessionUsage_ConfiguredPGWithoutFlagUsesSQLite(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+
+	localDB, err := db.Open(filepath.Join(dataDir, "sessions.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { localDB.Close() })
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:                   "local-session",
+		Project:              "local-project",
+		Machine:              "local-host",
+		Agent:                "codex",
+		MessageCount:         2,
+		UserMessageCount:     2,
+		TotalOutputTokens:    24,
+		HasTotalOutputTokens: true,
+	}))
+
+	pgDB, err := db.Open(filepath.Join(dataDir, "pg.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { pgDB.Close() })
+	require.NoError(t, pgDB.UpsertSession(db.Session{
+		ID:                   "pg-session",
+		Project:              "pg-project",
+		Machine:              "pg-host",
+		Agent:                "codex",
+		MessageCount:         2,
+		UserMessageCount:     2,
+		TotalOutputTokens:    42,
+		HasTotalOutputTokens: true,
+	}))
+
+	opened := false
+	orig := openPGReadStore
+	openPGReadStore = func(
+		_ config.Config, pgCfg config.PGConfig,
+	) (db.Store, func(), error) {
+		opened = true
+		assert.Equal(t, "postgres://example.test/agentsview", pgCfg.URL)
+		return pgDB, func() {}, nil
+	}
+	t.Cleanup(func() { openPGReadStore = orig })
+
+	root := newRootCommand()
+	args := []string{"session", "usage", "local-session"}
+	cmd, _, err := root.Find(args)
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(nil))
+
+	out, code, err := sessionUsageDataForCommand(cmd, "local-session")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.False(t, opened, "configured PG sync URL must not select PG reads")
+	assert.Equal(t, tokenUseExitOK, code)
+	assert.Equal(t, "local-session", out.SessionID)
+	assert.Equal(t, "local-project", out.Project)
+	assert.Equal(t, 24, out.TotalOutputTokens)
+	assert.False(t, out.ServerRunning)
+}
+
+func TestSessionUsage_PGFlagUsesPGStore(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
 	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
@@ -1173,15 +1234,15 @@ func TestSessionUsage_PGEnvUsesPGStore(t *testing.T) {
 	t.Cleanup(func() { openPGReadStore = orig })
 
 	root := newRootCommand()
-	args := []string{"session", "usage", "pg-session"}
+	args := []string{"session", "usage", "pg-session", "--pg"}
 	cmd, _, err := root.Find(args)
 	require.NoError(t, err)
-	require.NoError(t, cmd.ParseFlags(nil))
+	require.NoError(t, cmd.ParseFlags(args[3:]))
 
 	out, code, err := sessionUsageDataForCommand(cmd, "pg-session")
 	require.NoError(t, err)
 	require.NotNil(t, out)
-	assert.True(t, opened, "expected session usage to open PG store")
+	assert.True(t, opened, "expected session usage --pg to open PG store")
 	assert.Equal(t, tokenUseExitOK, code)
 	assert.Equal(t, "pg-session", out.SessionID)
 	assert.Equal(t, "pg-project", out.Project)
@@ -1219,10 +1280,10 @@ func TestSessionUsage_PGEnvResolvesBareSessionID(t *testing.T) {
 	t.Cleanup(func() { openPGReadStore = orig })
 
 	root := newRootCommand()
-	args := []string{"session", "usage", bareID}
+	args := []string{"session", "usage", bareID, "--pg"}
 	cmd, _, err := root.Find(args)
 	require.NoError(t, err)
-	require.NoError(t, cmd.ParseFlags(nil))
+	require.NoError(t, cmd.ParseFlags(args[3:]))
 
 	out, code, err := sessionUsageDataForCommand(cmd, bareID)
 	require.NoError(t, err)
@@ -1263,10 +1324,10 @@ func TestSessionUsage_PGEnvResolvesColonBearingRawSessionID(t *testing.T) {
 	t.Cleanup(func() { openPGReadStore = orig })
 
 	root := newRootCommand()
-	args := []string{"session", "usage", rawID}
+	args := []string{"session", "usage", rawID, "--pg"}
 	cmd, _, err := root.Find(args)
 	require.NoError(t, err)
-	require.NoError(t, cmd.ParseFlags(nil))
+	require.NoError(t, cmd.ParseFlags(args[3:]))
 
 	out, code, err := sessionUsageDataForCommand(cmd, rawID)
 	require.NoError(t, err)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -654,11 +654,11 @@ target an explicit running daemon, `AGENTSVIEW_SERVER_TOKEN` or
 `--server-token-file <path>` when that daemon requires auth, or
 `--pg` to read from configured PostgreSQL.
 
-When `AGENTSVIEW_PG_URL` or `[pg].url` is configured, read commands
-use PostgreSQL by default. Pass `--pg` to require PostgreSQL and
-fail fast if no connection URL is available. Mutating commands such
-as `session sync` and local-only raw source export continue to use
-the local archive.
+`AGENTSVIEW_PG_URL` and `[pg].url` are sync configuration only; they
+do not change the default read path. Read commands use local SQLite
+unless `--pg` is supplied, in which case they fail fast if no
+connection URL is available. Mutating commands such as `session sync`
+and local-only raw source export continue to use the local archive.
 
 Use [`agentsview health`](#agentsview-health) for a human-first
 signal view and [Session API](/session-api/) for the full

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -81,9 +81,8 @@ the token does not appear in process arguments.
 `--pg` opens the configured PostgreSQL read store directly. It is
 useful for automation running away from the UI server, but it is
 read-only: `session sync` and `session export` reject it. If
-`AGENTSVIEW_PG_URL` or `[pg].url` is configured, read commands use
-PostgreSQL by default; pass local SQLite commands from an environment
-without that setting when you need the local archive specifically.
+`AGENTSVIEW_PG_URL` or `[pg].url` is configured, read commands still
+use local SQLite unless `--pg` is supplied.
 
 ## Common flags
 
@@ -544,8 +543,7 @@ The command uses the local SQLite archive plus an on-demand
 sync when no daemon is running (with a 30-second wait if a
 startup lock is held). With `--server`, it calls
 `GET /api/v1/sessions/{id}/usage` on the explicit daemon. With
-`--pg` or configured PostgreSQL, it reads usage from the shared
-PostgreSQL store.
+`--pg`, it reads usage from the shared PostgreSQL store.
 
 Pricing comes from the same `model_pricing` table and
 [custom pricing overrides](/token-usage/#custom-model-pricing)


### PR DESCRIPTION
A configured PostgreSQL URL is sync configuration, not a default transport choice for ordinary local commands. Auto-selecting PG made local workflows depend on remote schema state, which broke callers like roborev token-cost capture even though they only needed SQLite-backed session usage.

This keeps `agentsview session` reads on the local SQLite archive unless `--pg` is supplied, while preserving explicit PostgreSQL reads for callers that ask for them. A follow-up audit found the hidden classifier recovery command had the same implicit PG behavior for shared sync metadata, so `classifier rebuild` is also local by default and requires `--pg` before touching the configured PostgreSQL store.

The command and session API docs now describe `[pg]` / `AGENTSVIEW_PG_URL` as sync configuration rather than an implicit read transport.