### PR TITLE
feat(frontend): enrich tool summaries and add skim layout

### DIFF
--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -20,6 +20,7 @@
     hasVisibleSegments,
   } from "../../utils/content-parser.js";
   import { isSystemMessage } from "../../utils/messages.js";
+  import { resolveMessageLayout } from "../../utils/message-layout.js";
   import { inSessionSearch } from "../../stores/inSessionSearch.svelte.js";
   import { sessionActivity } from "../../stores/sessionActivity.svelte.js";
   import SessionFindBar from "./SessionFindBar.svelte";
@@ -519,6 +520,10 @@
       ? inSessionSearch.query
       : "",
   );
+
+  let effectiveLayout = $derived(
+    resolveMessageLayout(ui.messageLayout, highlightQuery !== ""),
+  );
 </script>
 
 {#if !sessions.activeSessionId}
@@ -535,7 +540,7 @@
 {:else}
   <SessionFindBar />
   <div
-    class="message-list-scroll layout-{ui.messageLayout}"
+    class="message-list-scroll layout-{effectiveLayout}"
     bind:this={containerRef}
     data-session-id={sessions.activeSessionId}
     data-messages-session-id={messages.sessionId}
@@ -713,5 +718,63 @@
   .layout-stream :global(.text-content) {
     font-size: 14px;
     line-height: 1.75;
+  }
+
+  /* ── Skim layout ── */
+  .layout-skim {
+    padding: 0;
+  }
+
+  .layout-skim .virtual-row {
+    padding: 0;
+  }
+
+  .layout-skim :global(.message-header) {
+    display: none;
+  }
+
+  .layout-skim :global(.tool-block) {
+    border-left: none;
+    border-radius: 0;
+  }
+
+  .layout-skim :global(.tool-chevron) {
+    display: none;
+  }
+
+  /* Keep the one-line summary, but make the header non-interactive so a
+     click cannot silently toggle hidden collapse state (which would
+     surprise the user on switching back to a full layout). Row selection
+     still works via the virtual-row wrapper behind the header. */
+  .layout-skim :global(.tool-header) {
+    padding: 1px 12px;
+    pointer-events: none;
+  }
+
+  .layout-skim :global(.tool-meta),
+  .layout-skim :global(.tool-content),
+  .layout-skim :global(.diff-view),
+  .layout-skim :global(.output-header),
+  .layout-skim :global(.history-header),
+  .layout-skim :global(.result-history),
+  .layout-skim :global(.show-more-btn) {
+    display: none;
+  }
+
+  .layout-skim :global(.tool-group-header),
+  .layout-skim :global(.pg-header) {
+    display: none;
+  }
+
+  .layout-skim :global(.tool-group),
+  .layout-skim :global(.parallel-group) {
+    border: none;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+  }
+
+  .layout-skim :global(.subagent-inline) {
+    display: none;
   }
 </style>

--- a/frontend/src/lib/components/content/ToolBlock.svelte
+++ b/frontend/src/lib/components/content/ToolBlock.svelte
@@ -9,6 +9,7 @@
   } from "../../utils/tool-params.js";
   import { applyHighlight, escapeHTML } from "../../utils/highlight.js";
   import { ChevronRightIcon } from "../../icons.js";
+  import { summarizeToolCall } from "../../utils/tool-summary.js";
 
   interface Props {
     content: string;
@@ -123,68 +124,14 @@
     }
   });
 
-  let previewLine = $derived.by(() => {
-    // Tool-specific summaries take precedence over the first line of
-    // content, which for these tools is a generic header (e.g.
-    // "[Todo List]") that hides the meaningful info.
-    const toolName = toolCall?.tool_name;
-    if (toolName === "TodoWrite") {
-      const todos = inputParams?.todos;
-      if (Array.isArray(todos) && todos.length) {
-        const target =
-          todos.find((t) => t?.status === "in_progress") ??
-          todos[todos.length - 1];
-        const text = target?.content ? String(target.content) : "";
-        if (text) return `→ ${text}`.slice(0, 100);
-      }
-    } else if (toolName === "TaskCreate" && inputParams?.subject) {
-      return String(inputParams.subject).slice(0, 100);
-    } else if (toolName === "TaskUpdate") {
-      const parts: string[] = [];
-      if (inputParams?.taskId != null) parts.push(`#${inputParams.taskId}`);
-      if (inputParams?.status) parts.push(String(inputParams.status));
-      if (inputParams?.subject) parts.push(String(inputParams.subject));
-      if (parts.length) return parts.join(" · ").slice(0, 100);
-    } else if (toolName === "Skill" || toolName === "skill") {
-      const skill = inputParams?.skill ?? inputParams?.name;
-      if (skill) return String(skill).slice(0, 100);
-    } else if (toolName === "ToolSearch") {
-      const query = inputParams?.query;
-      if (query) {
-        const firstLine = String(query).split("\n")[0] ?? "";
-        return firstLine.slice(0, 100);
-      }
-    } else if (
-      toolName === "Task" ||
-      toolName === "Agent" ||
-      toolCall?.category === "Task" ||
-      (toolName?.includes("subagent") ?? false)
-    ) {
-      const desc = inputParams?.description ?? inputParams?.prompt;
-      if (desc) {
-        const firstLine = String(desc).split("\n")[0] ?? "";
-        return firstLine.slice(0, 100);
-      }
-    }
+  /** Structured one-line summary from input_json/result_content (ungated). */
+  let structuredSummary = $derived(
+    toolCall ? summarizeToolCall(toolCall) : null,
+  );
 
-    const line = content.split("\n")[0]?.slice(0, 100) ?? "";
-    if (line) return line;
-    // For Bash tools, surface the command in the collapsed header so
-    // codex exec_command (cmd) and Claude Bash (command) are both
-    // legible without expanding the block.
-    const cmd = inputParams?.command ?? inputParams?.cmd;
-    if (cmd) {
-      const firstLine = String(cmd).split("\n")[0] ?? "";
-      return `$ ${firstLine}`.slice(0, 100);
-    }
-    // For Edit/Write/Read with no content, show file path as preview
-    const filePath =
-      inputParams?.file_path ?? inputParams?.path ?? inputParams?.filePath;
-    if (filePath) return String(filePath).slice(0, 100);
-    // For glob/search tools, show pattern
-    if (inputParams?.pattern) return String(inputParams.pattern).slice(0, 100);
-    return "";
-  });
+  /** Legacy fallback: first line of display content, shown collapsed-only
+   *  when no structured summary is available. */
+  let legacyPreview = $derived(content.split("\n")[0]?.slice(0, 100) ?? "");
 
   /** For Task tool calls, extract key metadata fields */
   let taskMeta = $derived.by(() => {
@@ -324,8 +271,10 @@
     {#if label}
       <span class="tool-label">{label}</span>
     {/if}
-    {#if collapsed && previewLine}
-      <span class="tool-preview">{previewLine}</span>
+    {#if structuredSummary}
+      <span class="tool-preview">{structuredSummary}</span>
+    {:else if collapsed && legacyPreview}
+      <span class="tool-preview">{legacyPreview}</span>
     {/if}
     {#if durationLabel}
       <span

--- a/frontend/src/lib/components/content/ToolBlock.test.ts
+++ b/frontend/src/lib/components/content/ToolBlock.test.ts
@@ -566,7 +566,7 @@ describe("ToolBlock collapsed preview", () => {
     expect(preview!.textContent).toBe("$ cat <<EOF");
   });
 
-  it("prefers explicit content over command fallback", async () => {
+  it("prefers the structured command summary over display content", async () => {
     const toolCall: ToolCall = {
       tool_name: "exec_command",
       category: "Bash",
@@ -579,7 +579,74 @@ describe("ToolBlock collapsed preview", () => {
     await tick();
 
     const preview = document.querySelector(".tool-header .tool-preview");
-    expect(preview!.textContent).toBe("$ from content");
+    expect(preview!.textContent).toBe("$ from json");
+  });
+
+  it("keeps the structured summary visible after expanding (ungated)", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "Read",
+      category: "Read",
+      input_json: JSON.stringify({ file_path: "README.md" }),
+      result_content: "line one\nline two",
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "Read", toolCall },
+    });
+    await tick();
+
+    const before = document.querySelector(".tool-header .tool-preview");
+    expect(before!.textContent).toBe("README.md (2 lines)");
+
+    document.querySelector<HTMLButtonElement>(".tool-header")!.click();
+    await tick();
+
+    const after = document.querySelector(".tool-header .tool-preview");
+    expect(after).not.toBeNull();
+    expect(after!.textContent).toBe("README.md (2 lines)");
+  });
+
+  it("shows the +added -removed suffix for an Edit", async () => {
+    const toolCall: ToolCall = {
+      tool_name: "Edit",
+      category: "Edit",
+      input_json: JSON.stringify({
+        file_path: "main.go",
+        old_string: "a",
+        new_string: "a\nb\nc",
+      }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "", label: "Edit", toolCall },
+    });
+    await tick();
+
+    const preview = document.querySelector(".tool-header .tool-preview");
+    expect(preview!.textContent).toBe("main.go (+3 -1)");
+  });
+
+  it("keeps the legacy first-line preview collapsed-only", async () => {
+    // "mystery" with no recognized fields makes summarizeToolCall return
+    // null, so the legacy content-first-line preview is the only thing
+    // rendered — and it must stay gated on the collapsed state.
+    const toolCall: ToolCall = {
+      tool_name: "mystery",
+      input_json: JSON.stringify({ foo: 1 }),
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "plain first line", label: "mystery", toolCall },
+    });
+    await tick();
+
+    const collapsed = document.querySelector(".tool-header .tool-preview");
+    expect(collapsed!.textContent).toBe("plain first line");
+
+    document.querySelector<HTMLButtonElement>(".tool-header")!.click();
+    await tick();
+
+    expect(document.querySelector(".tool-header .tool-preview")).toBeNull();
   });
 
   it("shows in-progress todo content for TodoWrite", async () => {

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     ActivityIcon,
+    AlignJustifyIcon,
     ArrowDownIcon,
     ArrowDownWideNarrowIcon,
     ArrowUpNarrowWideIcon,
@@ -261,8 +262,10 @@
     <LayoutListIcon {size} strokeWidth="2" aria-hidden="true" />
   {:else if ui.messageLayout === "compact"}
     <ListCollapseIcon {size} strokeWidth="2" aria-hidden="true" />
-  {:else}
+  {:else if ui.messageLayout === "stream"}
     <LogsIcon {size} strokeWidth="2" aria-hidden="true" />
+  {:else}
+    <AlignJustifyIcon {size} strokeWidth="2" aria-hidden="true" />
   {/if}
 {/snippet}
 

--- a/frontend/src/lib/components/settings/AppearanceSettings.svelte
+++ b/frontend/src/lib/components/settings/AppearanceSettings.svelte
@@ -11,6 +11,7 @@
     { value: "default", label: "Default" },
     { value: "compact", label: "Compact" },
     { value: "stream", label: "Stream" },
+    { value: "skim", label: "Skim" },
   ];
 
   const BLOCK_LABELS: Record<BlockType, string> = {

--- a/frontend/src/lib/icons.test.ts
+++ b/frontend/src/lib/icons.test.ts
@@ -5,6 +5,7 @@ import * as icons from "./icons.ts";
 
 const approvedIconNames = [
   "ActivityIcon",
+  "AlignJustifyIcon",
   "ArrowDownIcon",
   "ArrowDownWideNarrowIcon",
   "ArrowUpIcon",

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -1,4 +1,5 @@
 export { default as ActivityIcon } from "@lucide/svelte/icons/activity";
+export { default as AlignJustifyIcon } from "@lucide/svelte/icons/align-justify";
 export { default as ArrowDownIcon } from "@lucide/svelte/icons/arrow-down";
 export { default as ArrowDownWideNarrowIcon } from "@lucide/svelte/icons/arrow-down-wide-narrow";
 export { default as ArrowUpIcon } from "@lucide/svelte/icons/arrow-up";

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -5,7 +5,7 @@ import {
 } from "../components/layout/sidebar-width.js";
 
 type Theme = "light" | "dark";
-export type MessageLayout = "default" | "compact" | "stream";
+export type MessageLayout = "default" | "compact" | "stream" | "skim";
 export type TranscriptMode = "normal" | "focused";
 type ModalType =
   | "about"
@@ -93,6 +93,7 @@ const VALID_LAYOUTS: MessageLayout[] = [
   "default",
   "compact",
   "stream",
+  "skim",
 ];
 function readStoredTheme(): Theme | null {
   if (

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -640,6 +640,9 @@ describe("UIStore", () => {
       expect(ui.messageLayout).toBe("stream");
 
       ui.cycleLayout();
+      expect(ui.messageLayout).toBe("skim");
+
+      ui.cycleLayout();
       expect(ui.messageLayout).toBe("default");
     });
   });

--- a/frontend/src/lib/utils/message-layout.test.ts
+++ b/frontend/src/lib/utils/message-layout.test.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Unit tests for the skim-during-search layout guard.
+import { describe, it, expect } from "vite-plus/test";
+import { resolveMessageLayout } from "./message-layout.js";
+
+describe("resolveMessageLayout", () => {
+  it("returns skim when no highlight is active", () => {
+    expect(resolveMessageLayout("skim", false)).toBe("skim");
+  });
+
+  it("falls back to default when a highlight is active in skim", () => {
+    expect(resolveMessageLayout("skim", true)).toBe("default");
+  });
+
+  it("leaves non-skim layouts unchanged while searching", () => {
+    expect(resolveMessageLayout("stream", true)).toBe("stream");
+    expect(resolveMessageLayout("compact", true)).toBe("compact");
+    expect(resolveMessageLayout("default", true)).toBe("default");
+  });
+
+  it("leaves non-skim layouts unchanged without search", () => {
+    expect(resolveMessageLayout("stream", false)).toBe("stream");
+  });
+});

--- a/frontend/src/lib/utils/message-layout.ts
+++ b/frontend/src/lib/utils/message-layout.ts
@@ -1,0 +1,16 @@
+// ABOUTME: Resolves the message layout class, suspending skim during search.
+import type { MessageLayout } from "../stores/ui.svelte.js";
+
+/**
+ * Resolve the layout actually applied to the transcript. Skim hides
+ * auto-expanded search matches, so while a highlight query is active it
+ * falls back to the full "default" layout; every other layout is returned
+ * unchanged.
+ */
+export function resolveMessageLayout(
+  layout: MessageLayout,
+  highlightActive: boolean,
+): MessageLayout {
+  if (layout === "skim" && highlightActive) return "default";
+  return layout;
+}

--- a/frontend/src/lib/utils/tool-summary.test.ts
+++ b/frontend/src/lib/utils/tool-summary.test.ts
@@ -1,0 +1,465 @@
+// ABOUTME: Table-driven unit tests for summarizeToolCall.
+import { describe, it, expect } from "vite-plus/test";
+import type { ToolCall } from "../api/types.js";
+import { summarizeToolCall } from "./tool-summary.js";
+
+function call(partial: Partial<ToolCall>): ToolCall {
+  return { tool_name: "Tool", ...partial };
+}
+
+describe("summarizeToolCall", () => {
+  it("returns null for malformed input_json", () => {
+    expect(
+      summarizeToolCall(
+        call({ tool_name: "Read", category: "Read", input_json: "{not json" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when input_json is absent", () => {
+    expect(summarizeToolCall(call({ tool_name: "Read", category: "Read" }))).toBeNull();
+  });
+
+  it("returns null when no structured fields are present", () => {
+    expect(
+      summarizeToolCall(
+        call({ tool_name: "mystery", input_json: JSON.stringify({ foo: 1 }) }),
+      ),
+    ).toBeNull();
+  });
+
+  describe("Bash", () => {
+    it("shows the command", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Bash",
+            category: "Bash",
+            input_json: JSON.stringify({ command: "git status" }),
+          }),
+        ),
+      ).toBe("$ git status");
+    });
+
+    it("reads the codex cmd key", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "exec_command",
+            category: "Bash",
+            input_json: JSON.stringify({ cmd: "ls -la" }),
+          }),
+        ),
+      ).toBe("$ ls -la");
+    });
+
+    it("uses only the first line of a multiline command", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Bash",
+            category: "Bash",
+            input_json: JSON.stringify({ command: "cat <<EOF\nhello\nEOF" }),
+          }),
+        ),
+      ).toBe("$ cat <<EOF");
+    });
+
+    it("never adds a suffix for Bash", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Bash",
+            category: "Bash",
+            input_json: JSON.stringify({ command: "ls" }),
+            result_content: "a\nb\nc",
+          }),
+        ),
+      ).toBe("$ ls");
+    });
+  });
+
+  describe("Read", () => {
+    it("appends a line count from result_content", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Read",
+            category: "Read",
+            input_json: JSON.stringify({ file_path: "README.md" }),
+            result_content: "line one\nline two",
+          }),
+        ),
+      ).toBe("README.md (2 lines)");
+    });
+
+    it("counts a blank line inside the file", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Read",
+            category: "Read",
+            input_json: JSON.stringify({ file_path: "a.txt" }),
+            result_content: "one\n\nthree",
+          }),
+        ),
+      ).toBe("a.txt (3 lines)");
+    });
+
+    it("ignores a single trailing newline", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Read",
+            category: "Read",
+            input_json: JSON.stringify({ file_path: "a.txt" }),
+            result_content: "one\ntwo\n",
+          }),
+        ),
+      ).toBe("a.txt (2 lines)");
+    });
+
+    it("omits the suffix when result_content is missing", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Read",
+            category: "Read",
+            input_json: JSON.stringify({ file_path: "README.md" }),
+          }),
+        ),
+      ).toBe("README.md");
+    });
+
+    it("returns null when no file path is present", () => {
+      expect(
+        summarizeToolCall(
+          call({ tool_name: "Read", category: "Read", input_json: JSON.stringify({}) }),
+        ),
+      ).toBeNull();
+    });
+
+    it("omits the suffix when the file reads as zero lines", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Read",
+            category: "Read",
+            input_json: JSON.stringify({ file_path: "a.txt" }),
+            result_content: "\n",
+          }),
+        ),
+      ).toBe("a.txt");
+    });
+  });
+
+  describe("Edit", () => {
+    it("shows +added -removed line counts", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Edit",
+            category: "Edit",
+            input_json: JSON.stringify({
+              file_path: "main.go",
+              old_string: "a\nb",
+              new_string: "a\nb\nc\nd",
+            }),
+          }),
+        ),
+      ).toBe("main.go (+4 -2)");
+    });
+
+    it("counts a single-line replacement as +1 -1", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Edit",
+            category: "Edit",
+            input_json: JSON.stringify({
+              file_path: "main.go",
+              old_string: "old",
+              new_string: "new",
+            }),
+          }),
+        ),
+      ).toBe("main.go (+1 -1)");
+    });
+
+    it("treats an empty old_string (insertion) as -0", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Edit",
+            category: "Edit",
+            input_json: JSON.stringify({
+              file_path: "main.go",
+              old_string: "",
+              new_string: "added",
+            }),
+          }),
+        ),
+      ).toBe("main.go (+1 -0)");
+    });
+
+    it("omits counts for a patch-only Edit input", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "ApplyPatch",
+            category: "Edit",
+            input_json: JSON.stringify({ path: "src/app.ts", patch: "@@ -1 +1 @@" }),
+          }),
+        ),
+      ).toBe("src/app.ts");
+    });
+
+    it("returns null when no file field is present", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "apply_patch",
+            category: "Edit",
+            input_json: JSON.stringify({ patch_file: "/p.diff" }),
+          }),
+        ),
+      ).toBeNull();
+    });
+
+    it("omits the count for a no-op (both strings empty)", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Edit",
+            category: "Edit",
+            input_json: JSON.stringify({
+              file_path: "main.go",
+              old_string: "",
+              new_string: "",
+            }),
+          }),
+        ),
+      ).toBe("main.go");
+    });
+  });
+
+  describe("Write", () => {
+    it("shows the +N content line count", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Write",
+            category: "Write",
+            input_json: JSON.stringify({ file_path: "out.txt", content: "a\nb\nc" }),
+          }),
+        ),
+      ).toBe("out.txt (+3)");
+    });
+
+    it("ignores a single trailing newline in content", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Write",
+            category: "Write",
+            input_json: JSON.stringify({ file_path: "out.txt", content: "a\nb\n" }),
+          }),
+        ),
+      ).toBe("out.txt (+2)");
+    });
+
+    it("omits the suffix when content is absent", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Write",
+            category: "Write",
+            input_json: JSON.stringify({ file_path: "out.txt" }),
+          }),
+        ),
+      ).toBe("out.txt");
+    });
+
+    it("omits the suffix when content is an empty string", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Write",
+            category: "Write",
+            input_json: JSON.stringify({ file_path: "out.txt", content: "" }),
+          }),
+        ),
+      ).toBe("out.txt");
+    });
+  });
+
+  describe("Grep", () => {
+    it("counts matches from newline-separated output", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Grep",
+            category: "Grep",
+            input_json: JSON.stringify({ pattern: "TODO" }),
+            result_content: "a.go:1:TODO\nb.go:2:TODO\nc.go:9:TODO",
+          }),
+        ),
+      ).toBe("TODO (3 matches)");
+    });
+
+    it("omits the count when output_mode is count", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Grep",
+            category: "Grep",
+            input_json: JSON.stringify({ pattern: "TODO", output_mode: "count" }),
+            result_content: "a.go:4\nb.go:2",
+          }),
+        ),
+      ).toBe("TODO");
+    });
+
+    it("omits the count for blank/noisy output", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Grep",
+            category: "Grep",
+            input_json: JSON.stringify({ pattern: "TODO" }),
+            result_content: "\n\n",
+          }),
+        ),
+      ).toBe("TODO");
+    });
+
+    it("omits the count when result_content is missing", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Grep",
+            category: "Grep",
+            input_json: JSON.stringify({ pattern: "TODO" }),
+          }),
+        ),
+      ).toBe("TODO");
+    });
+  });
+
+  describe("Glob", () => {
+    it("counts files from newline-separated output", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Glob",
+            category: "Glob",
+            input_json: JSON.stringify({ pattern: "**/*.ts" }),
+            result_content: "a.ts\nb.ts",
+          }),
+        ),
+      ).toBe("**/*.ts (2 files)");
+    });
+
+    it("omits the count for blank output", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Glob",
+            category: "Glob",
+            input_json: JSON.stringify({ pattern: "**/*.ts" }),
+            result_content: "   ",
+          }),
+        ),
+      ).toBe("**/*.ts");
+    });
+  });
+
+  describe("special tools", () => {
+    it("summarizes the in-progress todo", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "TodoWrite",
+            input_json: JSON.stringify({
+              todos: [
+                { content: "done", status: "completed" },
+                { content: "now", status: "in_progress" },
+              ],
+            }),
+          }),
+        ),
+      ).toBe("→ now");
+    });
+
+    it("falls back to the last todo when none are in progress", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "TodoWrite",
+            input_json: JSON.stringify({
+              todos: [
+                { content: "one", status: "completed" },
+                { content: "two", status: "completed" },
+              ],
+            }),
+          }),
+        ),
+      ).toBe("→ two");
+    });
+
+    it("summarizes a TaskUpdate", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "TaskUpdate",
+            input_json: JSON.stringify({
+              taskId: 29,
+              status: "in_progress",
+              subject: "Rebuild",
+            }),
+          }),
+        ),
+      ).toBe("#29 · in_progress · Rebuild");
+    });
+
+    it("summarizes a Skill by name", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Skill",
+            input_json: JSON.stringify({ skill: "review-branch" }),
+          }),
+        ),
+      ).toBe("review-branch");
+    });
+
+    it("summarizes a Task by description", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "Task",
+            category: "Task",
+            input_json: JSON.stringify({
+              subagent_type: "Explore",
+              description: "Explore the repo",
+            }),
+          }),
+        ),
+      ).toBe("Explore the repo");
+    });
+  });
+
+  describe("generic structured fallback", () => {
+    it("shows a known file path for an unrecognized category", () => {
+      expect(
+        summarizeToolCall(
+          call({
+            tool_name: "custom",
+            category: "Other",
+            input_json: JSON.stringify({ file_path: "/etc/hosts" }),
+          }),
+        ),
+      ).toBe("/etc/hosts");
+    });
+  });
+});

--- a/frontend/src/lib/utils/tool-summary.ts
+++ b/frontend/src/lib/utils/tool-summary.ts
@@ -1,0 +1,180 @@
+// ABOUTME: Builds a structured one-line summary for a tool call header.
+// ABOUTME: Pure; reads input_json + result_content, conservative on counts.
+import type { ToolCall } from "../api/types.js";
+
+const MAX = 100;
+
+/** Count lines, ignoring a single trailing newline. "" -> 0, "a\nb\n" -> 2. */
+function countLines(s: string): number {
+  if (s === "") return 0;
+  const body = s.endsWith("\n") ? s.slice(0, -1) : s;
+  return body === "" ? 0 : body.split("\n").length;
+}
+
+/** Count non-empty lines, or null when empty/blank (used for result lists). */
+function countResultLines(s: string | undefined): number | null {
+  if (!s) return null;
+  let n = 0;
+  for (const line of s.split("\n")) {
+    if (line.trim() !== "") n += 1;
+  }
+  return n > 0 ? n : null;
+}
+
+function firstLine(s: string): string {
+  return (s.split("\n")[0] ?? "").slice(0, MAX);
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+type Params = Record<string, unknown>;
+
+function parseParams(toolCall: ToolCall): Params | null {
+  if (!toolCall.input_json) return null;
+  try {
+    const parsed: unknown = JSON.parse(toolCall.input_json);
+    return parsed && typeof parsed === "object" ? (parsed as Params) : null;
+  } catch {
+    return null;
+  }
+}
+
+function fileArg(p: Params): string | null {
+  return (
+    asString(p.file_path) ??
+    asString(p.path) ??
+    asString(p.filePath) ??
+    asString(p.file)
+  );
+}
+
+function todoSummary(p: Params): string | null {
+  const todos = p.todos;
+  if (!Array.isArray(todos) || todos.length === 0) return null;
+  const items = todos as Array<{ content?: unknown; status?: unknown }>;
+  const target =
+    items.find((t) => t?.status === "in_progress") ?? items[items.length - 1];
+  const text = asString(target?.content);
+  return text ? `→ ${text}`.slice(0, MAX) : null;
+}
+
+function specialSummary(name: string, p: Params): string | null {
+  if (name === "TodoWrite") return todoSummary(p);
+  if (name === "TaskCreate") {
+    const subject = asString(p.subject);
+    return subject ? subject.slice(0, MAX) : null;
+  }
+  if (name === "TaskUpdate") {
+    const parts: string[] = [];
+    if (p.taskId != null) parts.push(`#${String(p.taskId)}`);
+    const status = asString(p.status);
+    if (status) parts.push(status);
+    const subject = asString(p.subject);
+    if (subject) parts.push(subject);
+    return parts.length ? parts.join(" · ").slice(0, MAX) : null;
+  }
+  if (name === "Skill" || name === "skill") {
+    const skill = asString(p.skill) ?? asString(p.name);
+    return skill ? skill.slice(0, MAX) : null;
+  }
+  if (name === "ToolSearch") {
+    const query = asString(p.query);
+    return query ? firstLine(query) : null;
+  }
+  return null;
+}
+
+function isTaskCall(name: string, cat: string | undefined): boolean {
+  return (
+    name === "Task" ||
+    name === "Agent" ||
+    cat === "Task" ||
+    name.includes("subagent")
+  );
+}
+
+/**
+ * Build a structured one-line summary for a tool call header, or null when
+ * only a generic first-body-line preview is possible. Pure: parses
+ * input_json and reads result_content; never throws.
+ */
+export function summarizeToolCall(toolCall: ToolCall): string | null {
+  const p = parseParams(toolCall);
+  if (!p) return null;
+
+  const name = toolCall.tool_name;
+  const cat = toolCall.category;
+
+  const special = specialSummary(name, p);
+  if (special) return special;
+
+  if (isTaskCall(name, cat)) {
+    const desc = asString(p.description) ?? asString(p.prompt);
+    return desc ? firstLine(desc) : null;
+  }
+
+  const key = cat || name;
+
+  if (key === "Bash") {
+    const cmd = asString(p.command) ?? asString(p.cmd);
+    return cmd ? `$ ${firstLine(cmd)}` : null;
+  }
+  if (key === "Read") {
+    const file = fileArg(p);
+    if (!file) return null;
+    const lines = toolCall.result_content
+      ? countLines(toolCall.result_content)
+      : 0;
+    const suffix = lines > 0 ? ` (${lines} lines)` : "";
+    return `${file.slice(0, MAX)}${suffix}`;
+  }
+  if (key === "Edit") {
+    const file = fileArg(p);
+    if (!file) return null;
+    const oldS = p.old_string ?? p.oldString;
+    const newS = p.new_string ?? p.newString;
+    let suffix = "";
+    if (typeof oldS === "string" && typeof newS === "string") {
+      const added = countLines(newS);
+      const removed = countLines(oldS);
+      if (added > 0 || removed > 0) suffix = ` (+${added} -${removed})`;
+    }
+    return `${file.slice(0, MAX)}${suffix}`;
+  }
+  if (key === "Write") {
+    const file = fileArg(p);
+    if (!file) return null;
+    const added = typeof p.content === "string" ? countLines(p.content) : 0;
+    const suffix = added > 0 ? ` (+${added})` : "";
+    return `${file.slice(0, MAX)}${suffix}`;
+  }
+  if (key === "Grep") {
+    const pattern = asString(p.pattern) ?? asString(p.query);
+    if (!pattern) return null;
+    let suffix = "";
+    if (p.output_mode !== "count") {
+      const n = countResultLines(toolCall.result_content);
+      if (n != null) suffix = ` (${n} matches)`;
+    }
+    return `${pattern.slice(0, MAX)}${suffix}`;
+  }
+  if (key === "Glob") {
+    const pattern = asString(p.pattern);
+    if (!pattern) return null;
+    const n = countResultLines(toolCall.result_content);
+    const suffix = n != null ? ` (${n} files)` : "";
+    return `${pattern.slice(0, MAX)}${suffix}`;
+  }
+
+  // Generic structured fallback: any tool exposing a known key arg.
+  const file = fileArg(p);
+  if (file) return file.slice(0, MAX);
+  const cmd = asString(p.command) ?? asString(p.cmd);
+  if (cmd) return `$ ${firstLine(cmd)}`;
+  const pattern = asString(p.pattern);
+  if (pattern) return pattern.slice(0, MAX);
+
+  return null;
+}


### PR DESCRIPTION
Two related transcript-readability changes. Frontend only; no API, DB, or schema change.

## Enriched tool summaries

A new pure util `summarizeToolCall` (`frontend/src/lib/utils/tool-summary.ts`) builds a structured one-line header for each tool call and adds result-derived suffixes: Read `(N lines)`, Edit `(+A -B)`, Write `(+N)`, Grep `(N matches)`, Glob `(N files)`. Counts are emitted only when they parse with confidence — non-zero, one trailing newline ignored, and Grep `output_mode=count` suppressed. `ToolBlock.svelte` renders this summary whether the block is collapsed or expanded, and falls back to the prior first-body-line preview (collapsed-only) when the util returns null.

This changes one prior behavior: the structured summary now takes precedence over the display content's first line, so a Bash header shows `$ <input command>` even when display content exists. The one ToolBlock test that asserted the old precedence is updated.

## Skim layout

Adds a fourth `messageLayout`, `skim`, to the default/compact/stream cycle (store, settings, and header icon). `.layout-skim` (in `MessageList.svelte`) collapses each tool call to its one-liner, flattens tool-group and parallel-group chrome, hides nested subagent transcripts, and sets `pointer-events: none` on tool headers so a click cannot toggle hidden collapse state (row selection still works via the row wrapper). A pure helper `resolveMessageLayout` suspends skim back to the full layout while an in-session search highlight is active, so matches stay expanded.

## Where to look

- `frontend/src/lib/utils/tool-summary.ts` — summary construction and conservative counts (+ table-driven tests).
- `frontend/src/lib/components/content/ToolBlock.svelte` — ungated summary, collapsed-only legacy fallback.
- `frontend/src/lib/components/content/MessageList.svelte` — `.layout-skim` CSS and the effective-layout search guard.
- `frontend/src/lib/utils/message-layout.ts` — the skim-during-search guard.

The skim CSS hiding is not unit-tested (jsdom does not compute styles from `<style>` blocks, matching the existing untested compact/stream layouts); the search-guard logic is covered by `resolveMessageLayout` unit tests.