### PR TITLE
feat(frontend): add initial i18n support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,8 @@ GitHub Actions service container in `.github/workflows/ci.yml`.
 - Prefer stdlib over external dependencies.
 - Tests should be fast and isolated.
 - No emojis in code or output.
+- For frontend UI work, read `DESIGN.md` before adding or changing controls,
+  styling, or reusable components.
 - Use `mdformat --wrap 80` to format Markdown files when mdformat and
   `mdformat-tables` are available.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,38 @@
+# Design System
+
+agentsview is a dense local-first product UI. The interface should use a small,
+consistent component vocabulary rather than one-off styling for each new
+control.
+
+## Component Rules
+
+- Before adding any interactive frontend control, search
+  `frontend/src/lib/components` for an existing component that already covers
+  the behavior.
+- Prefer existing shared components over native controls with local CSS.
+- Do not add new hand-styled native `<select>` controls. Use the shared
+  typeahead/combobox components for single-choice selectors unless there is a
+  documented reason the native control is required.
+- Do not introduce component-specific control chrome such as `.foo-select`,
+  manual select chevrons, or one-off input/button height and padding rules when
+  a shared control or token should own the styling.
+- If a new control pattern is genuinely needed, add or extend a shared
+  component first, then use it from feature components.
+
+## Current Shared Controls
+
+- `frontend/src/lib/components/layout/OptionTypeahead.svelte` is the default
+  compact single-select/typeahead control for bounded option lists.
+- `frontend/src/lib/components/layout/ProjectTypeahead.svelte` wraps
+  `OptionTypeahead` for project selection.
+- `frontend/src/lib/components/shared/RangePicker.svelte` owns date range
+  selection.
+- `frontend/src/lib/components/shared/RefreshControl.svelte` owns refresh
+  actions and freshness display.
+- `frontend/src/lib/components/settings/SettingsSection.svelte` owns settings
+  section framing.
+
+## Legacy Exceptions
+
+Some existing activity components still contain native `<select>` controls and
+manual control CSS. Treat those as legacy debt, not precedent for new work.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -22,3 +22,14 @@ https://viteplus.dev/guide/.
   `vp env doctor` and include its output when asking for help.
 
 <!--VITE PLUS END-->
+
+## Frontend UI Rules
+
+- Read the root `DESIGN.md` before adding or changing controls, styling, or
+  reusable components.
+- Before adding an interactive control, search `src/lib/components` for an
+  existing shared component.
+- Do not add new hand-styled native `<select>` controls. Use the shared
+  typeahead/combobox components for single-choice selectors unless the native
+  control is explicitly justified.
+- Existing native selects are legacy exceptions, not examples to copy.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "@tanstack/virtual-core": "3.17.0",
         "dompurify": "3.4.11",
         "marked": "18.0.5",
-        "shiki": "4.2.0"
+        "shiki": "4.2.0",
+        "svelte-i18n": "^4.0.1"
       },
       "devDependencies": {
         "@playwright/test": "1.60.0",
@@ -306,6 +307,57 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmmirror.com/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmmirror.com/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmmirror.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmmirror.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmmirror.com/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1970,6 +2022,22 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cli-color": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/cli-color/-/cli-color-2.0.4.tgz",
+      "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.64",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2013,6 +2081,19 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -2031,14 +2112,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2118,11 +2197,78 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmmirror.com/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmmirror.com/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
       "license": "MIT"
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/esrap": {
       "version": "2.2.9",
@@ -2139,6 +2285,31 @@
         "@typescript-eslint/types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmmirror.com/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmmirror.com/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/fdir": {
@@ -2188,6 +2359,18 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmmirror.com/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "license": "MIT"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -2277,11 +2460,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmmirror.com/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmmirror.com/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT"
     },
     "node_modules/is-reference": {
@@ -2654,6 +2855,15 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -2712,6 +2922,25 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmmirror.com/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
@@ -2816,7 +3045,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2857,6 +3085,12 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3233,7 +3467,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mri": "^1.1.0"
@@ -3392,12 +3625,465 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/svelte-i18n": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/svelte-i18n/-/svelte-i18n-4.0.1.tgz",
+      "integrity": "sha512-jaykGlGT5PUaaq04JWbJREvivlCnALtT+m87Kbm0fxyYHynkQaxQMnIKHLm2WeIuBRoljzwgyvz0Z6/CMwfdmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-color": "^2.0.3",
+        "deepmerge": "^4.2.2",
+        "esbuild": "^0.19.2",
+        "estree-walker": "^2",
+        "intl-messageformat": "^10.5.3",
+        "sade": "^1.8.1",
+        "tiny-glob": "^0.2.9"
+      },
+      "bin": {
+        "svelte-i18n": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmmirror.com/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmmirror.com/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "license": "MIT",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3508,6 +4194,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmmirror.com/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/typescript": {
       "version": "6.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "@tanstack/virtual-core": "3.17.0",
     "dompurify": "3.4.11",
     "marked": "18.0.5",
-    "shiki": "4.2.0"
+    "shiki": "4.2.0",
+    "svelte-i18n": "^4.0.1"
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",
@@ -33,8 +34,8 @@
     "svelte-check": "4.6.0",
     "typescript": "6.0.3",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.24",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.24",
-    "vite-plus": "0.1.24"
+    "vite-plus": "0.1.24",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.24"
   },
   "overrides": {
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.24",

--- a/frontend/src/lib/components/activity/ActivityPage.test.ts
+++ b/frontend/src/lib/components/activity/ActivityPage.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import source from "./ActivityPage.svelte?raw";
 
-describe("ActivityPage filter controls", () => {
-  it("uses explicit chevrons instead of browser-native select arrows", () => {
-    const selectWrapCount = source.match(/class="filter-select-wrap"/g)?.length ?? 0;
-    const selectChevronCount = source.match(/class="filter-select-chevron"/g)?.length ?? 0;
-    const filterSelectStyles = source.match(/\.filter-select\s*{[^}]+}/)?.[0] ?? "";
-
-    expect(selectWrapCount).toBe(3);
-    expect(selectChevronCount).toBe(3);
-    expect(filterSelectStyles).toContain("appearance: none");
-  });
-});
-
 describe("ActivityPage refresh control layout", () => {
   it("keeps the shared refresh control inline with the toolbar filters", () => {
     expect(source).toContain("<RefreshControl");

--- a/frontend/src/lib/components/component-source-guard.test.ts
+++ b/frontend/src/lib/components/component-source-guard.test.ts
@@ -1,0 +1,55 @@
+// @ts-ignore -- @types/node is not in devDependencies; harmless at runtime.
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+// @ts-ignore -- @types/node is not in devDependencies; harmless at runtime.
+import { relative, resolve } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const componentsRoot = resolve(
+  // @ts-ignore -- import.meta.dirname is Node 20.11+, in the supported range.
+  import.meta.dirname,
+);
+
+const legacyNativeSelectAllowlist = new Set([
+  "activity/ActivityInsight.svelte",
+  "activity/ActivityPage.svelte",
+  "activity/ConcurrencyTimeline.svelte",
+]);
+
+function svelteFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry: any) => {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory()) return svelteFiles(path);
+    if (entry.isFile() && entry.name.endsWith(".svelte")) return [path];
+    return [];
+  });
+}
+
+describe("component source guardrails", () => {
+  it("keeps new native select controls out of component source", () => {
+    const offenders = svelteFiles(componentsRoot).flatMap((path) => {
+      const rel = relative(componentsRoot, path);
+      if (legacyNativeSelectAllowlist.has(rel)) return [];
+
+      const source = readFileSync(path, "utf8");
+      return /<select\b/.test(source) ? [rel] : [];
+    }).sort();
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the legacy select allowlist honest", () => {
+    const missing = Array.from(legacyNativeSelectAllowlist).filter((rel) => {
+      const path = `${componentsRoot}/${rel}`;
+      return !existsSync(path);
+    });
+
+    expect(missing).toEqual([]);
+
+    const stale = Array.from(legacyNativeSelectAllowlist).filter((rel) => {
+      const source = readFileSync(`${componentsRoot}/${rel}`, "utf8");
+      return !/<select\b/.test(source);
+    });
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/frontend/src/lib/components/settings/LanguageSettings.svelte
+++ b/frontend/src/lib/components/settings/LanguageSettings.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
   import {
-    LOCALE_STORAGE_KEY,
     SUPPORTED_LOCALES,
     chooseInitialLocale,
     setLocale,
@@ -10,14 +9,7 @@
   import SettingsSection from "./SettingsSection.svelte";
 
   function currentLocale(): SupportedLocale {
-    try {
-      const raw = localStorage.getItem(LOCALE_STORAGE_KEY);
-      return SUPPORTED_LOCALES.includes(raw as SupportedLocale)
-        ? raw as SupportedLocale
-        : chooseInitialLocale();
-    } catch {
-      return chooseInitialLocale();
-    }
+    return chooseInitialLocale();
   }
 
   let selectedLocale = $state<SupportedLocale>(currentLocale());

--- a/frontend/src/lib/components/settings/LanguageSettings.svelte
+++ b/frontend/src/lib/components/settings/LanguageSettings.svelte
@@ -6,6 +6,9 @@
     setLocale,
     type SupportedLocale,
   } from "../../i18n/index.js";
+  import OptionTypeahead, {
+    type TypeaheadOption,
+  } from "../layout/OptionTypeahead.svelte";
   import SettingsSection from "./SettingsSection.svelte";
 
   function currentLocale(): SupportedLocale {
@@ -14,12 +17,22 @@
 
   let selectedLocale = $state<SupportedLocale>(currentLocale());
 
-  function handleLocaleChange(event: Event) {
-    const value = (event.currentTarget as HTMLSelectElement)
-      .value as SupportedLocale;
-    if (!SUPPORTED_LOCALES.includes(value)) return;
-    selectedLocale = value;
-    setLocale(value);
+  const localeOptions: TypeaheadOption[] = $derived([
+    {
+      name: "en",
+      label: $_("settings.language.english"),
+    },
+    {
+      name: "zh-CN",
+      label: $_("settings.language.simplifiedChinese"),
+    },
+  ]);
+
+  function handleLocaleSelect(value: string) {
+    if (!SUPPORTED_LOCALES.includes(value as SupportedLocale)) return;
+    const locale = value as SupportedLocale;
+    selectedLocale = locale;
+    setLocale(locale);
   }
 </script>
 
@@ -29,19 +42,15 @@
 >
   <div class="setting-row">
     <span class="setting-label">{$_("settings.language.label")}</span>
-    <div class="select-wrap">
-      <select
-        class="language-select"
-        aria-label={$_("settings.language.label")}
-        value={selectedLocale}
-        onchange={handleLocaleChange}
-      >
-        <option value="en">{$_("settings.language.english")}</option>
-        <option value="zh-CN">
-          {$_("settings.language.simplifiedChinese")}
-        </option>
-      </select>
-    </div>
+    <OptionTypeahead
+      options={localeOptions}
+      value={selectedLocale}
+      fallbackLabel={$_("settings.language.english")}
+      placeholder={$_("settings.language.label")}
+      title={$_("settings.language.label")}
+      emptyLabel={$_("settings.language.noResults")}
+      onselect={handleLocaleSelect}
+    />
   </div>
 </SettingsSection>
 
@@ -58,26 +67,5 @@
     font-weight: 500;
     color: var(--text-secondary);
     white-space: nowrap;
-  }
-
-  .select-wrap {
-    position: relative;
-  }
-
-  .language-select {
-    height: 28px;
-    padding: 0 28px 0 10px;
-    border-radius: var(--radius-sm);
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--text-secondary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    cursor: pointer;
-  }
-
-  .language-select:focus {
-    outline: none;
-    border-color: var(--accent-blue);
   }
 </style>

--- a/frontend/src/lib/components/settings/LanguageSettings.svelte
+++ b/frontend/src/lib/components/settings/LanguageSettings.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { _ } from "svelte-i18n";
+  import {
+    LOCALE_STORAGE_KEY,
+    SUPPORTED_LOCALES,
+    chooseInitialLocale,
+    setLocale,
+    type SupportedLocale,
+  } from "../../i18n/index.js";
+  import SettingsSection from "./SettingsSection.svelte";
+
+  function currentLocale(): SupportedLocale {
+    try {
+      const raw = localStorage.getItem(LOCALE_STORAGE_KEY);
+      return SUPPORTED_LOCALES.includes(raw as SupportedLocale)
+        ? raw as SupportedLocale
+        : chooseInitialLocale();
+    } catch {
+      return chooseInitialLocale();
+    }
+  }
+
+  let selectedLocale = $state<SupportedLocale>(currentLocale());
+
+  function handleLocaleChange(event: Event) {
+    const value = (event.currentTarget as HTMLSelectElement)
+      .value as SupportedLocale;
+    if (!SUPPORTED_LOCALES.includes(value)) return;
+    selectedLocale = value;
+    setLocale(value);
+  }
+</script>
+
+<SettingsSection
+  title={$_("settings.language.title")}
+  description={$_("settings.language.description")}
+>
+  <div class="setting-row">
+    <span class="setting-label">{$_("settings.language.label")}</span>
+    <div class="select-wrap">
+      <select
+        class="language-select"
+        aria-label={$_("settings.language.label")}
+        value={selectedLocale}
+        onchange={handleLocaleChange}
+      >
+        <option value="en">{$_("settings.language.english")}</option>
+        <option value="zh-CN">
+          {$_("settings.language.simplifiedChinese")}
+        </option>
+      </select>
+    </div>
+  </div>
+</SettingsSection>
+
+<style>
+  .setting-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .setting-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    white-space: nowrap;
+  }
+
+  .select-wrap {
+    position: relative;
+  }
+
+  .language-select {
+    height: 28px;
+    padding: 0 28px 0 10px;
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    cursor: pointer;
+  }
+
+  .language-select:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+  }
+</style>

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -4,10 +4,12 @@
   import { sync } from "../../stores/sync.svelte.js";
   import { ui } from "../../stores/ui.svelte.js";
   import { setAuthToken, getAuthToken, setServerUrl, isRemoteConnection } from "../../api/runtime.js";
+  import { _ } from "svelte-i18n";
   import AppearanceSettings from "./AppearanceSettings.svelte";
   import AgentDirSettings from "./AgentDirSettings.svelte";
   import TerminalSettings from "./TerminalSettings.svelte";
   import GithubSettings from "./GithubSettings.svelte";
+  import LanguageSettings from "./LanguageSettings.svelte";
   import RemoteSettings from "./RemoteSettings.svelte";
   import WorktreeMappingSettings from "./WorktreeMappingSettings.svelte";
 
@@ -28,11 +30,11 @@
 
 <div class="settings-page">
   <div class="settings-header">
-    <h2 class="settings-title">Settings</h2>
+    <h2 class="settings-title">{$_("settings.title")}</h2>
   </div>
 
   {#if settings.loading || !settings.loaded}
-    <div class="settings-loading">Loading settings...</div>
+    <div class="settings-loading">{$_("settings.loading")}</div>
   {:else if settings.needsAuth}
     <div class="auth-prompt">
       <h3 class="auth-title">Authentication Required</h3>
@@ -86,6 +88,7 @@
     </div>
   {:else}
     <div class="settings-sections">
+      <LanguageSettings />
       <AppearanceSettings />
       <AgentDirSettings />
       <TerminalSettings />

--- a/frontend/src/lib/components/settings/SettingsPage.test.ts
+++ b/frontend/src/lib/components/settings/SettingsPage.test.ts
@@ -5,6 +5,7 @@ import { mount, tick, unmount } from "svelte";
 import SettingsPage from "./SettingsPage.svelte";
 import { SettingsService } from "../../api/generated/index";
 import { settings } from "../../stores/settings.svelte.js";
+import { initI18n, LOCALE_STORAGE_KEY } from "../../i18n/index.js";
 
 vi.mock("../../api/runtime.js", async (importOriginal) => {
   const orig =
@@ -38,6 +39,8 @@ const settingsService = SettingsService as unknown as {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
+  initI18n();
   settings.loading = false;
   settings.loaded = false;
   settings.needsAuth = false;
@@ -82,6 +85,42 @@ describe("SettingsPage", () => {
     expect(
       settingsService.getApiV1SettingsWorktreeMappings,
     ).not.toHaveBeenCalled();
+
+    unmount(component);
+  });
+
+  it("lets users switch the interface language", async () => {
+    settingsService.getApiV1Settings.mockResolvedValue({
+      agent_dirs: {},
+      github_configured: false,
+      host: "127.0.0.1",
+      port: 8080,
+      read_only: false,
+      require_auth: false,
+      terminal: { mode: "auto" },
+    });
+    settingsService.getApiV1SettingsWorktreeMappings.mockResolvedValue({
+      mappings: [],
+    });
+
+    const component = mount(SettingsPage, {
+      target: document.body,
+    });
+    await tick();
+    await tick();
+
+    const select = document.body.querySelector(
+      'select[aria-label="Interface language"]',
+    ) as HTMLSelectElement | null;
+    expect(select).toBeTruthy();
+    expect(document.body.textContent).toContain("Settings");
+
+    select!.value = "zh-CN";
+    select!.dispatchEvent(new Event("change", { bubbles: true }));
+    await tick();
+
+    expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("zh-CN");
+    expect(document.body.textContent).toContain("设置");
 
     unmount(component);
   });

--- a/frontend/src/lib/components/settings/SettingsPage.test.ts
+++ b/frontend/src/lib/components/settings/SettingsPage.test.ts
@@ -109,14 +109,27 @@ describe("SettingsPage", () => {
     await tick();
     await tick();
 
-    const select = document.body.querySelector(
-      'select[aria-label="Interface language"]',
-    ) as HTMLSelectElement | null;
-    expect(select).toBeTruthy();
+    expect(
+      document.body.querySelector('select[aria-label="Interface language"]'),
+    ).toBeNull();
     expect(document.body.textContent).toContain("Settings");
 
-    select!.value = "zh-CN";
-    select!.dispatchEvent(new Event("change", { bubbles: true }));
+    const trigger = document.body.querySelector(
+      'button[title="Interface language"]',
+    ) as HTMLButtonElement | null;
+    expect(trigger).toBeTruthy();
+
+    trigger!.click();
+    await tick();
+
+    const option = Array.from(
+      document.body.querySelectorAll('[role="option"]'),
+    ).find((el) => el.textContent?.includes("Simplified Chinese"));
+    expect(option).toBeTruthy();
+
+    (option as HTMLElement).dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true }),
+    );
     await tick();
 
     expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("zh-CN");

--- a/frontend/src/lib/i18n/i18n.test.ts
+++ b/frontend/src/lib/i18n/i18n.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, beforeEach, vi } from "vite-plus/test";
+
+import {
+  DEFAULT_LOCALE,
+  LOCALE_STORAGE_KEY,
+  SUPPORTED_LOCALES,
+  chooseInitialLocale,
+  normalizeLocale,
+} from "./index.js";
+
+describe("i18n locale selection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes supported locale variants", () => {
+    expect(normalizeLocale("en-US")).toBe("en");
+    expect(normalizeLocale("zh-Hans-CN")).toBe("zh-CN");
+    expect(normalizeLocale("zh-cn")).toBe("zh-CN");
+  });
+
+  it("falls back to English for unsupported locales", () => {
+    expect(normalizeLocale("fr-FR")).toBe(DEFAULT_LOCALE);
+    expect(normalizeLocale("")).toBe(DEFAULT_LOCALE);
+  });
+
+  it("uses the stored locale before browser languages", () => {
+    localStorage.setItem(LOCALE_STORAGE_KEY, "zh-CN");
+    vi.stubGlobal("navigator", {
+      languages: ["en-US"],
+      language: "en-US",
+    });
+
+    expect(chooseInitialLocale()).toBe("zh-CN");
+  });
+
+  it("uses the browser language when no stored locale exists", () => {
+    vi.stubGlobal("navigator", {
+      languages: ["zh-CN", "en-US"],
+      language: "en-US",
+    });
+
+    expect(chooseInitialLocale()).toBe("zh-CN");
+  });
+
+  it("respects browser language priority", () => {
+    vi.stubGlobal("navigator", {
+      languages: ["en-US", "zh-CN"],
+      language: "zh-CN",
+    });
+
+    expect(chooseInitialLocale()).toBe("en");
+  });
+
+  it("falls back to English when browser languages are unsupported", () => {
+    vi.stubGlobal("navigator", {
+      languages: ["fr-FR"],
+      language: "fr-FR",
+    });
+
+    expect(chooseInitialLocale()).toBe("en");
+  });
+
+  it("keeps the supported locale list explicit", () => {
+    expect(SUPPORTED_LOCALES).toEqual(["en", "zh-CN"]);
+  });
+});

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -17,13 +17,7 @@ type MessageDictionary = {
 };
 
 export function normalizeLocale(value: string | null | undefined): SupportedLocale {
-  const normalized = value?.trim().toLowerCase();
-  if (!normalized) return DEFAULT_LOCALE;
-  if (normalized === "en" || normalized.startsWith("en-")) return "en";
-  if (normalized === "zh-cn" || normalized.startsWith("zh-hans")) {
-    return "zh-CN";
-  }
-  return DEFAULT_LOCALE;
+  return matchingLocale(value) ?? DEFAULT_LOCALE;
 }
 
 function matchingLocale(value: string | null | undefined): SupportedLocale | null {

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -1,0 +1,84 @@
+import {
+  addMessages,
+  init,
+  locale,
+} from "svelte-i18n";
+
+import en from "./locales/en.json";
+import zhCN from "./locales/zh-CN.json";
+
+export const DEFAULT_LOCALE = "en";
+export const LOCALE_STORAGE_KEY = "agentsview-locale";
+export const SUPPORTED_LOCALES = ["en", "zh-CN"] as const;
+
+export type SupportedLocale = typeof SUPPORTED_LOCALES[number];
+type MessageDictionary = {
+  [key: string]: MessageDictionary | string | Array<string | MessageDictionary> | null;
+};
+
+export function normalizeLocale(value: string | null | undefined): SupportedLocale {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return DEFAULT_LOCALE;
+  if (normalized === "en" || normalized.startsWith("en-")) return "en";
+  if (normalized === "zh-cn" || normalized.startsWith("zh-hans")) {
+    return "zh-CN";
+  }
+  return DEFAULT_LOCALE;
+}
+
+function matchingLocale(value: string | null | undefined): SupportedLocale | null {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "en" || normalized.startsWith("en-")) return "en";
+  if (normalized === "zh-cn" || normalized.startsWith("zh-hans")) {
+    return "zh-CN";
+  }
+  return null;
+}
+
+function storedLocale(): SupportedLocale | null {
+  try {
+    const raw = localStorage?.getItem(LOCALE_STORAGE_KEY);
+    if (raw && SUPPORTED_LOCALES.includes(raw as SupportedLocale)) {
+      return raw as SupportedLocale;
+    }
+  } catch {
+    // Ignore storage failures and fall back to browser detection.
+  }
+  return null;
+}
+
+function browserLocales(): string[] {
+  if (typeof navigator === "undefined") return [];
+  const languages = Array.isArray(navigator.languages)
+    ? navigator.languages
+    : [];
+  return [...languages, navigator.language].filter(Boolean);
+}
+
+export function chooseInitialLocale(): SupportedLocale {
+  const stored = storedLocale();
+  if (stored) return stored;
+  const browserLocale = browserLocales()
+    .map(matchingLocale)
+    .find((value): value is SupportedLocale => value !== null);
+  return browserLocale ?? DEFAULT_LOCALE;
+}
+
+export function setLocale(value: SupportedLocale) {
+  locale.set(value);
+  try {
+    localStorage?.setItem(LOCALE_STORAGE_KEY, value);
+  } catch {
+    // Ignore storage failures; the active in-memory locale still changes.
+  }
+}
+
+export function initI18n() {
+  addMessages("en", en as MessageDictionary);
+  addMessages("zh-CN", zhCN as MessageDictionary);
+  init({
+    fallbackLocale: DEFAULT_LOCALE,
+    initialLocale: chooseInitialLocale(),
+  });
+}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -1,0 +1,13 @@
+{
+  "settings": {
+    "title": "Settings",
+    "loading": "Loading settings...",
+    "language": {
+      "title": "Language",
+      "description": "Choose the interface language.",
+      "label": "Interface language",
+      "english": "English",
+      "simplifiedChinese": "Simplified Chinese"
+    }
+  }
+}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -7,7 +7,8 @@
       "description": "Choose the interface language.",
       "label": "Interface language",
       "english": "English",
-      "simplifiedChinese": "Simplified Chinese"
+      "simplifiedChinese": "Simplified Chinese",
+      "noResults": "No languages found"
     }
   }
 }

--- a/frontend/src/lib/i18n/locales/zh-CN.json
+++ b/frontend/src/lib/i18n/locales/zh-CN.json
@@ -1,0 +1,13 @@
+{
+  "settings": {
+    "title": "设置",
+    "loading": "正在加载设置...",
+    "language": {
+      "title": "语言",
+      "description": "选择界面语言。",
+      "label": "界面语言",
+      "english": "English",
+      "simplifiedChinese": "简体中文"
+    }
+  }
+}

--- a/frontend/src/lib/i18n/locales/zh-CN.json
+++ b/frontend/src/lib/i18n/locales/zh-CN.json
@@ -7,7 +7,8 @@
       "description": "选择界面语言。",
       "label": "界面语言",
       "english": "English",
-      "simplifiedChinese": "简体中文"
+      "simplifiedChinese": "简体中文",
+      "noResults": "未找到语言"
     }
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import { mount } from "svelte";
 import App from "./App.svelte";
 import "./app.css";
+import { initI18n } from "./lib/i18n/index.js";
 import { installPerfFetchInstrumentation } from "./lib/stores/perf.svelte.js";
 
 const target = document.getElementById("app");
@@ -10,5 +11,6 @@ if (!target) {
 }
 
 installPerfFetchInstrumentation();
+initI18n();
 
 mount(App, { target });


### PR DESCRIPTION
Adds the first slice of frontend internationalization support for the Svelte UI.

This introduces `svelte-i18n`, English and Simplified Chinese locale dictionaries, browser-language detection with local preference persistence, and a language selector in Settings. The initial translated surface is intentionally small so reviewers can evaluate the i18n shape before larger UI string extraction work follows.

Technical identifiers such as agent names, model names, CLI flags, API paths, config keys, and user session content remain untranslated.

Closes #652.
