### PR TITLE
docs: add 0.34.5 release notes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,20 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
+## 0.34.5
+<small>2026-06-23</small>
+
+**Bug fixes**
+
+- Keep **PostgreSQL session reads** opt-in instead of enabling them
+  unexpectedly.
+
+**Documentation**
+
+- Refresh **command and session API docs** for current behavior.
+
+---
+
 ## 0.34.4
 <small>2026-06-22</small>
 


### PR DESCRIPTION
The 0.34.5 patch release changes a subtle but important operator-facing behavior: PostgreSQL session reads stay opt-in, while the command and session API docs describe the current behavior. The changelog needs to make that release boundary visible so users do not infer that a configured PostgreSQL URL changes ordinary local reads by default.

The previous release history stopped at 0.34.4, which left the shipped PostgreSQL opt-in fix and documentation refresh without a durable release summary. This PR closes that gap for readers scanning the published docs.