### PR TITLE
ci: surface stale desktop release state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           bash scripts/install_test.sh
           bash scripts/check_desktop_release_health_test.sh
+          bash scripts/check_desktop_release_health_from_event_test.sh
 
   test:
     name: Go Test (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,18 @@ jobs:
       - name: Run docs check
         run: make docs-check
 
+  scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run shell script tests
+        run: |
+          bash scripts/install_test.sh
+          bash scripts/check_desktop_release_health_test.sh
+
   test:
     name: Go Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/desktop-release-health.yml
+++ b/.github/workflows/desktop-release-health.yml
@@ -1,0 +1,39 @@
+name: Desktop Release Health
+
+on:
+  workflow_run:
+    workflows:
+      - Desktop Release
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to check, for example v0.34.5
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check Desktop Updater State
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Check desktop release health
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION: >-
+            ${{ github.event.workflow_run.conclusion || 'success' }}
+        run: |
+          tag="${{ github.event.inputs.tag || github.event.workflow_run.head_branch }}"
+          bash scripts/check_desktop_release_health.sh "$tag"

--- a/.github/workflows/desktop-release-health.yml
+++ b/.github/workflows/desktop-release-health.yml
@@ -32,8 +32,4 @@ jobs:
       - name: Check desktop release health
         env:
           GH_TOKEN: ${{ github.token }}
-          DESKTOP_RELEASE_HEALTH_TAG: >-
-            ${{ github.event.inputs.tag || github.event.workflow_run.head_branch }}
-          DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION: >-
-            ${{ github.event.workflow_run.conclusion || 'success' }}
-        run: bash scripts/check_desktop_release_health.sh "$DESKTOP_RELEASE_HEALTH_TAG"
+        run: bash scripts/check_desktop_release_health_from_event.sh

--- a/.github/workflows/desktop-release-health.yml
+++ b/.github/workflows/desktop-release-health.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Check desktop release health
         env:
           GH_TOKEN: ${{ github.token }}
+          DESKTOP_RELEASE_HEALTH_TAG: >-
+            ${{ github.event.inputs.tag || github.event.workflow_run.head_branch }}
           DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION: >-
             ${{ github.event.workflow_run.conclusion || 'success' }}
-        run: |
-          tag="${{ github.event.inputs.tag || github.event.workflow_run.head_branch }}"
-          bash scripts/check_desktop_release_health.sh "$tag"
+        run: bash scripts/check_desktop_release_health.sh "$DESKTOP_RELEASE_HEALTH_TAG"

--- a/.github/workflows/desktop-release-health.yml
+++ b/.github/workflows/desktop-release-health.yml
@@ -30,6 +30,4 @@ jobs:
           persist-credentials: false
 
       - name: Check desktop release health
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: bash scripts/check_desktop_release_health_from_event.sh

--- a/scripts/check_desktop_release_health.sh
+++ b/scripts/check_desktop_release_health.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 tag="${1:-}"
 repo="${GITHUB_REPOSITORY:-kenn-io/agentsview}"
 workflow_conclusion="${DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION:-success}"
-assets_file="${DESKTOP_RELEASE_HEALTH_ASSETS_FILE:-}"
-updater_assets_file="${DESKTOP_RELEASE_HEALTH_UPDATER_ASSETS_FILE:-}"
 manifest_file="${DESKTOP_RELEASE_HEALTH_MANIFEST_FILE:-}"
 
 error() {
@@ -25,28 +23,6 @@ if [ "$workflow_conclusion" != "success" ]; then
     exit 1
 fi
 
-if [ -n "$assets_file" ]; then
-    assets="$(cat "$assets_file")"
-else
-    assets="$(gh release view "$tag" --repo "$repo" --json assets --jq '.assets[].name')"
-fi
-
-required_assets=(
-    "AgentsView_${version}_aarch64.AppImage"
-    "AgentsView_${version}_aarch64.dmg"
-    "AgentsView_${version}_amd64.AppImage"
-    "AgentsView_${version}_x64-setup.exe"
-    "AgentsView_${version}_x64.dmg"
-    "SHA256SUMS-desktop"
-)
-
-for asset in "${required_assets[@]}"; do
-    if ! grep -Fxq "$asset" <<<"$assets"; then
-        error "missing desktop release asset: $asset"
-        exit 1
-    fi
-done
-
 if [ -n "$manifest_file" ]; then
     manifest="$(cat "$manifest_file")"
 else
@@ -58,35 +34,5 @@ if [ "$manifest_version" != "$version" ]; then
     error "updater manifest version ${manifest_version:-<empty>} does not match expected $version"
     exit 1
 fi
-
-if [ -n "$updater_assets_file" ]; then
-    updater_assets="$(cat "$updater_assets_file")"
-else
-    updater_assets="$(gh release view updater --repo "$repo" --json assets --jq '.assets[].name')"
-fi
-
-updater_url_prefix="https://github.com/${repo}/releases/download/updater/"
-
-for platform in darwin-aarch64 darwin-x86_64 windows-x86_64 linux-x86_64; do
-    url="$(jq -r --arg platform "$platform" '.platforms[$platform].url // ""' <<<"$manifest")"
-    signature="$(jq -r --arg platform "$platform" '.platforms[$platform].signature // ""' <<<"$manifest")"
-    if [ -z "$url" ] || [ -z "$signature" ]; then
-        error "updater manifest missing url or signature for $platform"
-        exit 1
-    fi
-    if [[ "$url" != "$updater_url_prefix"* ]]; then
-        error "unexpected updater URL for $platform: $url"
-        exit 1
-    fi
-    asset="${url#"$updater_url_prefix"}"
-    if [ -z "$asset" ] || [[ "$asset" == */* ]]; then
-        error "unexpected updater URL asset for $platform: $url"
-        exit 1
-    fi
-    if ! grep -Fxq "$asset" <<<"$updater_assets"; then
-        error "manifest URL asset is missing from updater release: $asset"
-        exit 1
-    fi
-done
 
 echo "Desktop release health OK for $tag"

--- a/scripts/check_desktop_release_health.sh
+++ b/scripts/check_desktop_release_health.sh
@@ -12,8 +12,8 @@ error() {
     echo "::error::$*" >&2
 }
 
-if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    error "expected release tag like v0.34.5, got '${tag:-<empty>}'"
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+    error "expected release tag like v0.34.5 or v0.34.5-rc.1, got '${tag:-<empty>}'"
     exit 1
 fi
 

--- a/scripts/check_desktop_release_health.sh
+++ b/scripts/check_desktop_release_health.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 tag="${1:-}"
 repo="${GITHUB_REPOSITORY:-kenn-io/agentsview}"
-workflow_conclusion="${DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION:-success}"
+workflow_conclusion="${DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION-success}"
 manifest_file="${DESKTOP_RELEASE_HEALTH_MANIFEST_FILE:-}"
 
 error() {
@@ -19,7 +19,7 @@ fi
 version="${tag#v}"
 
 if [ "$workflow_conclusion" != "success" ]; then
-    error "Desktop Release workflow concluded ${workflow_conclusion} for ${tag}"
+    error "Desktop Release workflow concluded ${workflow_conclusion:-<empty>} for ${tag}"
     exit 1
 fi
 

--- a/scripts/check_desktop_release_health.sh
+++ b/scripts/check_desktop_release_health.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Verify that a tag's desktop release and updater manifest are in sync.
+set -euo pipefail
+
+tag="${1:-}"
+repo="${GITHUB_REPOSITORY:-kenn-io/agentsview}"
+workflow_conclusion="${DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION:-success}"
+assets_file="${DESKTOP_RELEASE_HEALTH_ASSETS_FILE:-}"
+manifest_file="${DESKTOP_RELEASE_HEALTH_MANIFEST_FILE:-}"
+
+error() {
+    echo "::error::$*" >&2
+}
+
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    error "expected release tag like v0.34.5, got '${tag:-<empty>}'"
+    exit 1
+fi
+
+version="${tag#v}"
+
+if [ "$workflow_conclusion" != "success" ]; then
+    error "Desktop Release workflow concluded ${workflow_conclusion} for ${tag}"
+    exit 1
+fi
+
+if [ -n "$assets_file" ]; then
+    assets="$(cat "$assets_file")"
+else
+    assets="$(gh release view "$tag" --repo "$repo" --json assets --jq '.assets[].name')"
+fi
+
+required_assets=(
+    "AgentsView_${version}_aarch64.AppImage"
+    "AgentsView_${version}_aarch64.dmg"
+    "AgentsView_${version}_amd64.AppImage"
+    "AgentsView_${version}_x64-setup.exe"
+    "AgentsView_${version}_x64.dmg"
+    "SHA256SUMS-desktop"
+)
+
+for asset in "${required_assets[@]}"; do
+    if ! grep -Fxq "$asset" <<<"$assets"; then
+        error "missing desktop release asset: $asset"
+        exit 1
+    fi
+done
+
+if [ -n "$manifest_file" ]; then
+    manifest="$(cat "$manifest_file")"
+else
+    manifest="$(curl -fsSL "https://github.com/${repo}/releases/download/updater/latest.json")"
+fi
+
+manifest_version="$(jq -r '.version // ""' <<<"$manifest")"
+if [ "$manifest_version" != "$version" ]; then
+    error "updater manifest version ${manifest_version:-<empty>} does not match expected $version"
+    exit 1
+fi
+
+for platform in darwin-aarch64 darwin-x86_64 windows-x86_64 linux-x86_64; do
+    url="$(jq -r --arg platform "$platform" '.platforms[$platform].url // ""' <<<"$manifest")"
+    signature="$(jq -r --arg platform "$platform" '.platforms[$platform].signature // ""' <<<"$manifest")"
+    if [ -z "$url" ] || [ -z "$signature" ]; then
+        error "updater manifest missing url or signature for $platform"
+        exit 1
+    fi
+done
+
+echo "Desktop release health OK for $tag"

--- a/scripts/check_desktop_release_health.sh
+++ b/scripts/check_desktop_release_health.sh
@@ -6,6 +6,7 @@ tag="${1:-}"
 repo="${GITHUB_REPOSITORY:-kenn-io/agentsview}"
 workflow_conclusion="${DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION:-success}"
 assets_file="${DESKTOP_RELEASE_HEALTH_ASSETS_FILE:-}"
+updater_assets_file="${DESKTOP_RELEASE_HEALTH_UPDATER_ASSETS_FILE:-}"
 manifest_file="${DESKTOP_RELEASE_HEALTH_MANIFEST_FILE:-}"
 
 error() {
@@ -58,11 +59,32 @@ if [ "$manifest_version" != "$version" ]; then
     exit 1
 fi
 
+if [ -n "$updater_assets_file" ]; then
+    updater_assets="$(cat "$updater_assets_file")"
+else
+    updater_assets="$(gh release view updater --repo "$repo" --json assets --jq '.assets[].name')"
+fi
+
+updater_url_prefix="https://github.com/${repo}/releases/download/updater/"
+
 for platform in darwin-aarch64 darwin-x86_64 windows-x86_64 linux-x86_64; do
     url="$(jq -r --arg platform "$platform" '.platforms[$platform].url // ""' <<<"$manifest")"
     signature="$(jq -r --arg platform "$platform" '.platforms[$platform].signature // ""' <<<"$manifest")"
     if [ -z "$url" ] || [ -z "$signature" ]; then
         error "updater manifest missing url or signature for $platform"
+        exit 1
+    fi
+    if [[ "$url" != "$updater_url_prefix"* ]]; then
+        error "unexpected updater URL for $platform: $url"
+        exit 1
+    fi
+    asset="${url#"$updater_url_prefix"}"
+    if [ -z "$asset" ] || [[ "$asset" == */* ]]; then
+        error "unexpected updater URL asset for $platform: $url"
+        exit 1
+    fi
+    if ! grep -Fxq "$asset" <<<"$updater_assets"; then
+        error "manifest URL asset is missing from updater release: $asset"
         exit 1
     fi
 done

--- a/scripts/check_desktop_release_health_from_event.sh
+++ b/scripts/check_desktop_release_health_from_event.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Derive desktop release health inputs from the GitHub event payload.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+event_name="${GITHUB_EVENT_NAME:-}"
+event_path="${GITHUB_EVENT_PATH:-}"
+
+if [ -z "$event_path" ] || [ ! -f "$event_path" ]; then
+    echo "::error::GITHUB_EVENT_PATH is not set or does not exist" >&2
+    exit 1
+fi
+
+case "$event_name" in
+    workflow_dispatch)
+        tag="$(jq -r '.inputs.tag // ""' "$event_path")"
+        conclusion="success"
+        ;;
+    workflow_run)
+        tag="$(jq -r '.workflow_run.head_branch // ""' "$event_path")"
+        conclusion="$(jq -r '.workflow_run.conclusion // ""' "$event_path")"
+        ;;
+    *)
+        echo "::error::unsupported event for desktop release health: ${event_name:-<empty>}" >&2
+        exit 1
+        ;;
+esac
+
+DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION="$conclusion" \
+    "$SCRIPT_DIR/check_desktop_release_health.sh" "$tag"

--- a/scripts/check_desktop_release_health_from_event_test.sh
+++ b/scripts/check_desktop_release_health_from_event_test.sh
@@ -51,8 +51,15 @@ AgentsView_${version}_x64-setup.exe
 AgentsView_${version}_x64.dmg
 SHA256SUMS-desktop
 EOF
+    cat >"$dir/updater-assets.txt" <<EOF
+AgentsView_aarch64.app.tar.gz
+AgentsView_x86_64.app.tar.gz
+AgentsView_${version}_x64-setup.nsis.zip
+AgentsView_${version}_amd64.AppImage.tar.gz
+latest.json
+EOF
     cat >"$dir/latest.json" <<EOF
-{"version":"${version}","platforms":{"darwin-aarch64":{"url":"u","signature":"s"},"darwin-x86_64":{"url":"u","signature":"s"},"windows-x86_64":{"url":"u","signature":"s"},"linux-x86_64":{"url":"u","signature":"s"}}}
+{"version":"${version}","platforms":{"darwin-aarch64":{"url":"https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_aarch64.app.tar.gz","signature":"s"},"darwin-x86_64":{"url":"https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz","signature":"s"},"windows-x86_64":{"url":"https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_${version}_x64-setup.nsis.zip","signature":"s"},"linux-x86_64":{"url":"https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_${version}_amd64.AppImage.tar.gz","signature":"s"}}}
 EOF
 }
 
@@ -61,6 +68,7 @@ run_wrapper() {
     GITHUB_EVENT_NAME="$event_name" \
     GITHUB_EVENT_PATH="$event_file" \
     DESKTOP_RELEASE_HEALTH_ASSETS_FILE="$dir/assets.txt" \
+    DESKTOP_RELEASE_HEALTH_UPDATER_ASSETS_FILE="$dir/updater-assets.txt" \
     DESKTOP_RELEASE_HEALTH_MANIFEST_FILE="$dir/latest.json" \
     "$WRAPPER"
 }

--- a/scripts/check_desktop_release_health_from_event_test.sh
+++ b/scripts/check_desktop_release_health_from_event_test.sh
@@ -78,6 +78,15 @@ assert_success \
     "workflow_run tag event passes validated tag" \
     run_wrapper "$tmp" "workflow_run" "$tmp/workflow-run.json"
 
+write_fixture "$tmp" "0.0.1-staging.1"
+cat >"$tmp/workflow-run-prerelease.json" <<'EOF'
+{"workflow_run":{"event":"push","head_branch":"v0.0.1-staging.1","conclusion":"success"}}
+EOF
+assert_success \
+    "workflow_run prerelease tag passes validated tag" \
+    run_wrapper "$tmp" "workflow_run" "$tmp/workflow-run-prerelease.json"
+write_fixture "$tmp" "0.34.5"
+
 cat >"$tmp/manual.json" <<'EOF'
 {"inputs":{"tag":"v0.34.5"}}
 EOF

--- a/scripts/check_desktop_release_health_from_event_test.sh
+++ b/scripts/check_desktop_release_health_from_event_test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Tests for deriving desktop release health inputs from GitHub event payloads.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/check_desktop_release_health_from_event.sh"
+
+PASS=0
+FAIL=0
+
+assert_success() {
+    local desc="$1"
+    shift
+    if "$@" >/tmp/check-desktop-release-health-event-test.out 2>&1; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        cat /tmp/check-desktop-release-health-event-test.out
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_failure_contains() {
+    local desc="$1" expected="$2"
+    shift 2
+    if "$@" >/tmp/check-desktop-release-health-event-test.out 2>&1; then
+        echo "  FAIL: $desc"
+        echo "    expected failure containing: $expected"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if grep -Fq "$expected" /tmp/check-desktop-release-health-event-test.out; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected output containing: $expected"
+        cat /tmp/check-desktop-release-health-event-test.out
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+write_fixture() {
+    local dir="$1" version="$2"
+    cat >"$dir/assets.txt" <<EOF
+AgentsView_${version}_aarch64.AppImage
+AgentsView_${version}_aarch64.dmg
+AgentsView_${version}_amd64.AppImage
+AgentsView_${version}_x64-setup.exe
+AgentsView_${version}_x64.dmg
+SHA256SUMS-desktop
+EOF
+    cat >"$dir/latest.json" <<EOF
+{"version":"${version}","platforms":{"darwin-aarch64":{"url":"u","signature":"s"},"darwin-x86_64":{"url":"u","signature":"s"},"windows-x86_64":{"url":"u","signature":"s"},"linux-x86_64":{"url":"u","signature":"s"}}}
+EOF
+}
+
+run_wrapper() {
+    local dir="$1" event_name="$2" event_file="$3"
+    GITHUB_EVENT_NAME="$event_name" \
+    GITHUB_EVENT_PATH="$event_file" \
+    DESKTOP_RELEASE_HEALTH_ASSETS_FILE="$dir/assets.txt" \
+    DESKTOP_RELEASE_HEALTH_MANIFEST_FILE="$dir/latest.json" \
+    "$WRAPPER"
+}
+
+echo "=== desktop release health event wrapper ==="
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" /tmp/check-desktop-release-health-event-test.out' EXIT
+write_fixture "$tmp" "0.34.5"
+
+cat >"$tmp/workflow-run.json" <<'EOF'
+{"workflow_run":{"event":"push","head_branch":"v0.34.5","conclusion":"success"}}
+EOF
+assert_success \
+    "workflow_run tag event passes validated tag" \
+    run_wrapper "$tmp" "workflow_run" "$tmp/workflow-run.json"
+
+cat >"$tmp/manual.json" <<'EOF'
+{"inputs":{"tag":"v0.34.5"}}
+EOF
+assert_success \
+    "manual dispatch input passes validated tag" \
+    run_wrapper "$tmp" "workflow_dispatch" "$tmp/manual.json"
+
+cat >"$tmp/malicious.json" <<'EOF'
+{"workflow_run":{"event":"push","head_branch":"v0.34.5; echo injected","conclusion":"success"}}
+EOF
+assert_failure_contains \
+    "malformed event tag is rejected" \
+    "expected release tag like v0.34.5" \
+    run_wrapper "$tmp" "workflow_run" "$tmp/malicious.json"
+
+cat >"$tmp/failed.json" <<'EOF'
+{"workflow_run":{"event":"push","head_branch":"v0.34.5","conclusion":"failure"}}
+EOF
+assert_failure_contains \
+    "failed workflow_run conclusion is propagated" \
+    "Desktop Release workflow concluded failure for v0.34.5" \
+    run_wrapper "$tmp" "workflow_run" "$tmp/failed.json"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/check_desktop_release_health_from_event_test.sh
+++ b/scripts/check_desktop_release_health_from_event_test.sh
@@ -43,23 +43,8 @@ assert_failure_contains() {
 
 write_fixture() {
     local dir="$1" version="$2"
-    cat >"$dir/assets.txt" <<EOF
-AgentsView_${version}_aarch64.AppImage
-AgentsView_${version}_aarch64.dmg
-AgentsView_${version}_amd64.AppImage
-AgentsView_${version}_x64-setup.exe
-AgentsView_${version}_x64.dmg
-SHA256SUMS-desktop
-EOF
-    cat >"$dir/updater-assets.txt" <<EOF
-AgentsView_aarch64.app.tar.gz
-AgentsView_x86_64.app.tar.gz
-AgentsView_${version}_x64-setup.nsis.zip
-AgentsView_${version}_amd64.AppImage.tar.gz
-latest.json
-EOF
     cat >"$dir/latest.json" <<EOF
-{"version":"${version}","platforms":{"darwin-aarch64":{"url":"https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_aarch64.app.tar.gz","signature":"s"},"darwin-x86_64":{"url":"https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz","signature":"s"},"windows-x86_64":{"url":"https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_${version}_x64-setup.nsis.zip","signature":"s"},"linux-x86_64":{"url":"https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_${version}_amd64.AppImage.tar.gz","signature":"s"}}}
+{"version":"${version}"}
 EOF
 }
 
@@ -67,8 +52,6 @@ run_wrapper() {
     local dir="$1" event_name="$2" event_file="$3"
     GITHUB_EVENT_NAME="$event_name" \
     GITHUB_EVENT_PATH="$event_file" \
-    DESKTOP_RELEASE_HEALTH_ASSETS_FILE="$dir/assets.txt" \
-    DESKTOP_RELEASE_HEALTH_UPDATER_ASSETS_FILE="$dir/updater-assets.txt" \
     DESKTOP_RELEASE_HEALTH_MANIFEST_FILE="$dir/latest.json" \
     "$WRAPPER"
 }

--- a/scripts/check_desktop_release_health_from_event_test.sh
+++ b/scripts/check_desktop_release_health_from_event_test.sh
@@ -101,6 +101,27 @@ assert_failure_contains \
     "Desktop Release workflow concluded failure for v0.34.5" \
     run_wrapper "$tmp" "workflow_run" "$tmp/failed.json"
 
+cat >"$tmp/missing-conclusion.json" <<'EOF'
+{"workflow_run":{"event":"push","head_branch":"v0.34.5"}}
+EOF
+assert_failure_contains \
+    "missing workflow_run conclusion fails closed" \
+    "Desktop Release workflow concluded <empty> for v0.34.5" \
+    run_wrapper "$tmp" "workflow_run" "$tmp/missing-conclusion.json"
+
+cat >"$tmp/unsupported.json" <<'EOF'
+{"inputs":{"tag":"v0.34.5"}}
+EOF
+assert_failure_contains \
+    "unsupported event fails" \
+    "unsupported event for desktop release health: schedule" \
+    run_wrapper "$tmp" "schedule" "$tmp/unsupported.json"
+
+assert_failure_contains \
+    "missing event path fails" \
+    "GITHUB_EVENT_PATH is not set or does not exist" \
+    run_wrapper "$tmp" "workflow_dispatch" "$tmp/missing.json"
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts/check_desktop_release_health_test.sh
+++ b/scripts/check_desktop_release_health_test.sh
@@ -51,14 +51,21 @@ AgentsView_${version}_x64-setup.exe
 AgentsView_${version}_x64.dmg
 SHA256SUMS-desktop
 EOF
+    cat >"$dir/updater-assets.txt" <<EOF
+AgentsView_aarch64.app.tar.gz
+AgentsView_x86_64.app.tar.gz
+AgentsView_${manifest_version}_x64-setup.nsis.zip
+AgentsView_${manifest_version}_amd64.AppImage.tar.gz
+latest.json
+EOF
     cat >"$dir/latest.json" <<EOF
 {
   "version": "${manifest_version}",
   "platforms": {
-    "darwin-aarch64": {"url": "https://example.test/AgentsView_aarch64.app.tar.gz", "signature": "sig"},
-    "darwin-x86_64": {"url": "https://example.test/AgentsView_x86_64.app.tar.gz", "signature": "sig"},
-    "windows-x86_64": {"url": "https://example.test/AgentsView_${manifest_version}_x64-setup.nsis.zip", "signature": "sig"},
-    "linux-x86_64": {"url": "https://example.test/AgentsView_${manifest_version}_amd64.AppImage.tar.gz", "signature": "sig"}
+    "darwin-aarch64": {"url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_aarch64.app.tar.gz", "signature": "sig"},
+    "darwin-x86_64": {"url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz", "signature": "sig"},
+    "windows-x86_64": {"url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_${manifest_version}_x64-setup.nsis.zip", "signature": "sig"},
+    "linux-x86_64": {"url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_${manifest_version}_amd64.AppImage.tar.gz", "signature": "sig"}
   }
 }
 EOF
@@ -67,6 +74,7 @@ EOF
 run_checker() {
     local dir="$1" tag="$2" conclusion="${3:-success}"
     DESKTOP_RELEASE_HEALTH_ASSETS_FILE="$dir/assets.txt" \
+    DESKTOP_RELEASE_HEALTH_UPDATER_ASSETS_FILE="$dir/updater-assets.txt" \
     DESKTOP_RELEASE_HEALTH_MANIFEST_FILE="$dir/latest.json" \
     DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION="$conclusion" \
     "$CHECKER" "$tag"
@@ -102,6 +110,21 @@ mv "$tmp/assets-next.txt" "$tmp/assets.txt"
 assert_failure_contains \
     "missing desktop asset fails" \
     "missing desktop release asset: AgentsView_0.34.5_x64-setup.exe" \
+    run_checker "$tmp" "v0.34.5"
+
+write_fixture "$tmp" "0.34.5" "0.34.5"
+perl -0pi -e 's|github.com/kenn-io/agentsview/releases/download/updater|github.com/evil/agentsview/releases/download/updater|' "$tmp/latest.json"
+assert_failure_contains \
+    "wrong updater repo URL fails" \
+    "unexpected updater URL for darwin-aarch64" \
+    run_checker "$tmp" "v0.34.5"
+
+write_fixture "$tmp" "0.34.5" "0.34.5"
+grep -v 'AgentsView_0.34.5_x64-setup.nsis.zip' "$tmp/updater-assets.txt" >"$tmp/updater-assets-next.txt"
+mv "$tmp/updater-assets-next.txt" "$tmp/updater-assets.txt"
+assert_failure_contains \
+    "missing updater asset fails" \
+    "manifest URL asset is missing from updater release: AgentsView_0.34.5_x64-setup.nsis.zip" \
     run_checker "$tmp" "v0.34.5"
 
 echo

--- a/scripts/check_desktop_release_health_test.sh
+++ b/scripts/check_desktop_release_health_test.sh
@@ -43,38 +43,13 @@ assert_failure_contains() {
 
 write_fixture() {
     local dir="$1" version="$2" manifest_version="$3"
-    cat >"$dir/assets.txt" <<EOF
-AgentsView_${version}_aarch64.AppImage
-AgentsView_${version}_aarch64.dmg
-AgentsView_${version}_amd64.AppImage
-AgentsView_${version}_x64-setup.exe
-AgentsView_${version}_x64.dmg
-SHA256SUMS-desktop
-EOF
-    cat >"$dir/updater-assets.txt" <<EOF
-AgentsView_aarch64.app.tar.gz
-AgentsView_x86_64.app.tar.gz
-AgentsView_${manifest_version}_x64-setup.nsis.zip
-AgentsView_${manifest_version}_amd64.AppImage.tar.gz
-latest.json
-EOF
     cat >"$dir/latest.json" <<EOF
-{
-  "version": "${manifest_version}",
-  "platforms": {
-    "darwin-aarch64": {"url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_aarch64.app.tar.gz", "signature": "sig"},
-    "darwin-x86_64": {"url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz", "signature": "sig"},
-    "windows-x86_64": {"url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_${manifest_version}_x64-setup.nsis.zip", "signature": "sig"},
-    "linux-x86_64": {"url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_${manifest_version}_amd64.AppImage.tar.gz", "signature": "sig"}
-  }
-}
+{"version":"${manifest_version}"}
 EOF
 }
 
 run_checker() {
     local dir="$1" tag="$2" conclusion="${3:-success}"
-    DESKTOP_RELEASE_HEALTH_ASSETS_FILE="$dir/assets.txt" \
-    DESKTOP_RELEASE_HEALTH_UPDATER_ASSETS_FILE="$dir/updater-assets.txt" \
     DESKTOP_RELEASE_HEALTH_MANIFEST_FILE="$dir/latest.json" \
     DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION="$conclusion" \
     "$CHECKER" "$tag"
@@ -102,29 +77,6 @@ write_fixture "$tmp" "0.34.5" "0.34.4"
 assert_failure_contains \
     "stale updater manifest fails" \
     "updater manifest version 0.34.4 does not match expected 0.34.5" \
-    run_checker "$tmp" "v0.34.5"
-
-write_fixture "$tmp" "0.34.5" "0.34.5"
-grep -v 'x64-setup.exe' "$tmp/assets.txt" >"$tmp/assets-next.txt"
-mv "$tmp/assets-next.txt" "$tmp/assets.txt"
-assert_failure_contains \
-    "missing desktop asset fails" \
-    "missing desktop release asset: AgentsView_0.34.5_x64-setup.exe" \
-    run_checker "$tmp" "v0.34.5"
-
-write_fixture "$tmp" "0.34.5" "0.34.5"
-perl -0pi -e 's|github.com/kenn-io/agentsview/releases/download/updater|github.com/evil/agentsview/releases/download/updater|' "$tmp/latest.json"
-assert_failure_contains \
-    "wrong updater repo URL fails" \
-    "unexpected updater URL for darwin-aarch64" \
-    run_checker "$tmp" "v0.34.5"
-
-write_fixture "$tmp" "0.34.5" "0.34.5"
-grep -v 'AgentsView_0.34.5_x64-setup.nsis.zip' "$tmp/updater-assets.txt" >"$tmp/updater-assets-next.txt"
-mv "$tmp/updater-assets-next.txt" "$tmp/updater-assets.txt"
-assert_failure_contains \
-    "missing updater asset fails" \
-    "manifest URL asset is missing from updater release: AgentsView_0.34.5_x64-setup.nsis.zip" \
     run_checker "$tmp" "v0.34.5"
 
 echo

--- a/scripts/check_desktop_release_health_test.sh
+++ b/scripts/check_desktop_release_health_test.sh
@@ -80,6 +80,11 @@ write_fixture "$tmp" "0.34.5" "0.34.5"
 
 assert_success "healthy desktop release passes" run_checker "$tmp" "v0.34.5"
 
+write_fixture "$tmp" "0.0.1-staging.1" "0.0.1-staging.1"
+assert_success \
+    "semver prerelease desktop release passes" \
+    run_checker "$tmp" "v0.0.1-staging.1"
+
 assert_failure_contains \
     "failed desktop workflow is loud" \
     "Desktop Release workflow concluded failure for v0.34.5" \

--- a/scripts/check_desktop_release_health_test.sh
+++ b/scripts/check_desktop_release_health_test.sh
@@ -42,7 +42,7 @@ assert_failure_contains() {
 }
 
 write_fixture() {
-    local dir="$1" version="$2" manifest_version="$3"
+    local dir="$1" manifest_version="$2"
     cat >"$dir/latest.json" <<EOF
 {"version":"${manifest_version}"}
 EOF
@@ -59,11 +59,11 @@ echo "=== desktop release health ==="
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp" /tmp/check-desktop-release-health-test.out' EXIT
-write_fixture "$tmp" "0.34.5" "0.34.5"
+write_fixture "$tmp" "0.34.5"
 
 assert_success "healthy desktop release passes" run_checker "$tmp" "v0.34.5"
 
-write_fixture "$tmp" "0.0.1-staging.1" "0.0.1-staging.1"
+write_fixture "$tmp" "0.0.1-staging.1"
 assert_success \
     "semver prerelease desktop release passes" \
     run_checker "$tmp" "v0.0.1-staging.1"
@@ -73,7 +73,7 @@ assert_failure_contains \
     "Desktop Release workflow concluded failure for v0.34.5" \
     run_checker "$tmp" "v0.34.5" "failure"
 
-write_fixture "$tmp" "0.34.5" "0.34.4"
+write_fixture "$tmp" "0.34.4"
 assert_failure_contains \
     "stale updater manifest fails" \
     "updater manifest version 0.34.4 does not match expected 0.34.5" \

--- a/scripts/check_desktop_release_health_test.sh
+++ b/scripts/check_desktop_release_health_test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Tests for the desktop release health checker.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$SCRIPT_DIR/check_desktop_release_health.sh"
+
+PASS=0
+FAIL=0
+
+assert_success() {
+    local desc="$1"
+    shift
+    if "$@" >/tmp/check-desktop-release-health-test.out 2>&1; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        cat /tmp/check-desktop-release-health-test.out
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_failure_contains() {
+    local desc="$1" expected="$2"
+    shift 2
+    if "$@" >/tmp/check-desktop-release-health-test.out 2>&1; then
+        echo "  FAIL: $desc"
+        echo "    expected failure containing: $expected"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if grep -Fq "$expected" /tmp/check-desktop-release-health-test.out; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected output containing: $expected"
+        cat /tmp/check-desktop-release-health-test.out
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+write_fixture() {
+    local dir="$1" version="$2" manifest_version="$3"
+    cat >"$dir/assets.txt" <<EOF
+AgentsView_${version}_aarch64.AppImage
+AgentsView_${version}_aarch64.dmg
+AgentsView_${version}_amd64.AppImage
+AgentsView_${version}_x64-setup.exe
+AgentsView_${version}_x64.dmg
+SHA256SUMS-desktop
+EOF
+    cat >"$dir/latest.json" <<EOF
+{
+  "version": "${manifest_version}",
+  "platforms": {
+    "darwin-aarch64": {"url": "https://example.test/AgentsView_aarch64.app.tar.gz", "signature": "sig"},
+    "darwin-x86_64": {"url": "https://example.test/AgentsView_x86_64.app.tar.gz", "signature": "sig"},
+    "windows-x86_64": {"url": "https://example.test/AgentsView_${manifest_version}_x64-setup.nsis.zip", "signature": "sig"},
+    "linux-x86_64": {"url": "https://example.test/AgentsView_${manifest_version}_amd64.AppImage.tar.gz", "signature": "sig"}
+  }
+}
+EOF
+}
+
+run_checker() {
+    local dir="$1" tag="$2" conclusion="${3:-success}"
+    DESKTOP_RELEASE_HEALTH_ASSETS_FILE="$dir/assets.txt" \
+    DESKTOP_RELEASE_HEALTH_MANIFEST_FILE="$dir/latest.json" \
+    DESKTOP_RELEASE_HEALTH_WORKFLOW_CONCLUSION="$conclusion" \
+    "$CHECKER" "$tag"
+}
+
+echo "=== desktop release health ==="
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" /tmp/check-desktop-release-health-test.out' EXIT
+write_fixture "$tmp" "0.34.5" "0.34.5"
+
+assert_success "healthy desktop release passes" run_checker "$tmp" "v0.34.5"
+
+assert_failure_contains \
+    "failed desktop workflow is loud" \
+    "Desktop Release workflow concluded failure for v0.34.5" \
+    run_checker "$tmp" "v0.34.5" "failure"
+
+write_fixture "$tmp" "0.34.5" "0.34.4"
+assert_failure_contains \
+    "stale updater manifest fails" \
+    "updater manifest version 0.34.4 does not match expected 0.34.5" \
+    run_checker "$tmp" "v0.34.5"
+
+write_fixture "$tmp" "0.34.5" "0.34.5"
+grep -v 'x64-setup.exe' "$tmp/assets.txt" >"$tmp/assets-next.txt"
+mv "$tmp/assets-next.txt" "$tmp/assets.txt"
+assert_failure_contains \
+    "missing desktop asset fails" \
+    "missing desktop release asset: AgentsView_0.34.5_x64-setup.exe" \
+    run_checker "$tmp" "v0.34.5"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Desktop auto-update can stay behind even when the ordinary release workflow succeeds, because CLI artifacts and desktop updater artifacts are published through different paths. The 0.34.5 release made that gap visible: the release existed, but the updater manifest still advertised the previous version, so the failure was easy to miss unless someone inspected the Desktop Release workflow directly.

This adds an independent Desktop Release Health workflow that runs after Desktop Release completes. It intentionally does not gate or block release publication, but it creates a visible failed check when the desktop workflow failed or when the permanent updater manifest has not advanced to the tag version.

The checker stays deliberately small: it validates the release tag shape, reads the workflow conclusion through the event payload wrapper, and compares `latest.json` against the tag. Fixture-based shell tests cover the failure modes without turning the health check into a second release verifier.