### PR TITLE
fix(usage): dedupe replayed continued-session rows

### DIFF
--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -56,8 +56,10 @@ type UsageRow struct {
 	Timestamp       string // ts, RFC3339 or ""
 	OutputTokens    int
 	Cost            float64
+	Agent           string
 	ClaudeMessageID string
 	ClaudeRequestID string
+	SourceUUID      string
 	UsageDedupKey   string
 }
 
@@ -518,6 +520,33 @@ type usageAgg struct {
 	models       map[string]float64 // model -> cost (for primary/mixed)
 }
 
+type usageDedupToken struct {
+	kind  string
+	value string
+}
+
+func usageDedupTokenForRow(u UsageRow) (usageDedupToken, bool) {
+	if u.ClaudeMessageID != "" && u.ClaudeRequestID != "" {
+		return usageDedupToken{
+			kind:  "claude",
+			value: u.ClaudeMessageID + ":" + u.ClaudeRequestID,
+		}, true
+	}
+	if u.Agent != "" && u.SourceUUID != "" {
+		return usageDedupToken{
+			kind:  "source",
+			value: u.Agent + ":" + u.SourceUUID,
+		}, true
+	}
+	if u.UsageDedupKey != "" {
+		return usageDedupToken{
+			kind:  "usage",
+			value: u.UsageDedupKey,
+		}, true
+	}
+	return usageDedupToken{}, false
+}
+
 // dedupUsage filters usage rows to the range and applies the two-tier,
 // first-seen-wins dedup that mirrors GetDailyUsage. Rows arrive pre-sorted by
 // (ts, session_id, COALESCE(message_ordinal,-1)). The half-open instant filter
@@ -526,8 +555,7 @@ type usageAgg struct {
 // dedup key, matching the activity/bucket clipping Aggregate applies. For a
 // full range effEnd == end, so nothing extra is excluded.
 func dedupUsage(start, end, effEnd time.Time, usage []UsageRow) []UsageRow {
-	type dk struct{ a, b string }
-	seen := map[dk]struct{}{}
+	seen := map[usageDedupToken]struct{}{}
 	out := make([]UsageRow, 0, len(usage))
 	for _, u := range usage {
 		t, ok := parseTS(u.Timestamp)
@@ -537,14 +565,7 @@ func dedupUsage(start, end, effEnd time.Time, usage []UsageRow) []UsageRow {
 		if !t.Before(effEnd) {
 			continue // partial range: rows at/after as_of never claim a key
 		}
-		if u.ClaudeMessageID != "" && u.ClaudeRequestID != "" {
-			k := dk{u.ClaudeMessageID, u.ClaudeRequestID}
-			if _, dup := seen[k]; dup {
-				continue
-			}
-			seen[k] = struct{}{}
-		} else if u.UsageDedupKey != "" {
-			k := dk{"usage", u.UsageDedupKey}
+		if k, ok := usageDedupTokenForRow(u); ok {
 			if _, dup := seen[k]; dup {
 				continue
 			}

--- a/internal/activity/usage_test.go
+++ b/internal/activity/usage_test.go
@@ -44,3 +44,25 @@ func TestApplyUsage_DedupAndDayFilter(t *testing.T) {
 	assert.Equal(t, 100, r.Buckets[120].OutputTokens)
 	assert.InDelta(t, 1.0, r.Buckets[120].Cost, 1e-9)
 }
+
+func TestApplyUsage_DedupBySourceUUIDFallback(t *testing.T) {
+	p := baseParams(t, "2026-06-16", "UTC")
+	usage := []UsageRow{
+		{SessionID: "earlier", Model: "m1", Timestamp: "2026-06-16T10:00:00Z",
+			OutputTokens: 500, Cost: 5.0, Agent: "claude",
+			ClaudeMessageID: "dup-m", SourceUUID: "src-dup"},
+		{SessionID: "later", Model: "m1", Timestamp: "2026-06-16T10:01:00Z",
+			OutputTokens: 900, Cost: 9.0, Agent: "claude",
+			ClaudeMessageID: "dup-m", SourceUUID: "src-dup"},
+	}
+	start := mustStart(t, "2026-06-16T00:00:00Z")
+	end := mustStart(t, "2026-06-17T00:00:00Z")
+	windows, err := BuildBuckets(start, end, p.Bucket, p.Loc)
+	require.NoError(t, err)
+	r := Report{Buckets: make([]Bucket, len(windows))}
+	applyUsage(&r, p, windows, start, end, usage, nil)
+	assert.Equal(t, 500, r.Totals.OutputTokens)
+	assert.InDelta(t, 5.0, r.Totals.Cost, 1e-9)
+	assert.Equal(t, 500, r.Buckets[120].OutputTokens)
+	assert.InDelta(t, 5.0, r.Buckets[120].Cost, 1e-9)
+}

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -268,8 +268,10 @@ func (db *DB) activityReportUsage(
 					Timestamp:       r.ts,
 					OutputTokens:    outputTok,
 					Cost:            cost,
+					Agent:           r.agent,
 					ClaudeMessageID: r.claudeMessageID,
 					ClaudeRequestID: r.claudeRequestID,
+					SourceUUID:      r.sourceUUID,
 					UsageDedupKey:   r.usageDedupKey,
 				},
 			})

--- a/internal/db/activityreport_test.go
+++ b/internal/db/activityreport_test.go
@@ -385,6 +385,57 @@ func TestGetActivityReport_UsageDedupSubSecondOrder(t *testing.T) {
 		"first-seen dedup keeps the chronologically earlier whole-second row")
 }
 
+func TestGetActivityReport_UsageDedupFallsBackToSourceUUID(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "earlier", "proj1", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:30:00Z")
+		s.EndedAt = Ptr("2026-06-16T10:30:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:       "earlier",
+		Ordinal:         0,
+		Role:            "assistant",
+		Content:         "x",
+		Timestamp:       "2026-06-16T10:30:00Z",
+		Model:           "claude-sonnet-4-20250514",
+		ClaudeMessageID: "m-dup",
+		ClaudeRequestID: "",
+		SourceUUID:      "src-dup",
+		TokenUsage:      json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+	})
+	insertSession(t, d, "later", "proj2", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = Ptr("2026-06-16T10:30:01Z")
+		s.EndedAt = Ptr("2026-06-16T10:30:01Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID:       "later",
+		Ordinal:         0,
+		Role:            "assistant",
+		Content:         "x",
+		Timestamp:       "2026-06-16T10:30:01Z",
+		Model:           "claude-sonnet-4-20250514",
+		ClaudeMessageID: "m-dup",
+		ClaudeRequestID: "",
+		SourceUUID:      "src-dup",
+		TokenUsage:      json.RawMessage(`{"input_tokens":1000,"output_tokens":900}`),
+	})
+
+	r, err := d.GetActivityReport(ctx, AnalyticsFilter{Timezone: "UTC"},
+		dayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens,
+		"incomplete Claude pairs fall back to source_uuid dedup in activity reports")
+}
+
 // TestGetActivityReport_TitleSkipsEmptyDisplayName confirms the Title fallback
 // null-checks each candidate independently: an empty (non-NULL) display_name
 // must not mask a real session_name. A nested COALESCE(display_name,

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -249,10 +249,11 @@ func (f UsageFilter) location() *time.Location {
 //
 // Note: this does NOT filter by s.relationship_type. Duplicate
 // messages across fork/subagent boundaries are handled by the
-// per-query claude_message_id + claude_request_id dedup in
-// GetDailyUsage, which is more precise than a blanket exclusion:
-// a fork session can legitimately contribute unique-keyed messages
-// that should still be counted (see
+// per-query usage dedup in GetDailyUsage, which prefers the
+// Claude message/request pair and falls back to persisted source
+// identity when the pair is incomplete. That is more precise than
+// a blanket exclusion: a fork session can legitimately contribute
+// unique-keyed messages that should still be counted (see
 // TestGetDailyUsage_DedupesByClaudeMessageAndRequestID).
 const usageMessageEligibility = `
     m.token_usage != ''
@@ -292,6 +293,7 @@ SELECT
 	'' AS cost_source,
 	m.claude_message_id,
 	m.claude_request_id,
+	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
 	s.agent,
@@ -325,6 +327,7 @@ SELECT
 	ue.cost_source,
 	'' AS claude_message_id,
 	'' AS claude_request_id,
+	'' AS source_uuid,
 	CASE
 		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
@@ -367,6 +370,7 @@ SELECT
 	NULL AS cost_usd,
 	m.claude_message_id,
 	m.claude_request_id,
+	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
 	s.agent
@@ -390,6 +394,7 @@ SELECT
 	ue.cost_usd,
 	'' AS claude_message_id,
 	'' AS claude_request_id,
+	'' AS source_uuid,
 	CASE
 		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
@@ -415,6 +420,7 @@ SELECT
 	NULL AS cost_usd,
 	m.claude_message_id,
 	m.claude_request_id,
+	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
 	s.agent
@@ -437,6 +443,7 @@ SELECT
 	ue.cost_usd,
 	'' AS claude_message_id,
 	'' AS claude_request_id,
+	'' AS source_uuid,
 	CASE
 		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
@@ -472,7 +479,8 @@ message_timestamp_rows AS MATERIALIZED (
 		m.model,
 		m.token_usage,
 		m.claude_message_id,
-		m.claude_request_id
+		m.claude_request_id,
+		m.source_uuid
 	FROM messages m
 	WHERE ` + messageTimestampWhere + `
 ),
@@ -541,6 +549,7 @@ type usageScanRow struct {
 	costSource               string
 	claudeMessageID          string
 	claudeRequestID          string
+	sourceUUID               string
 	usageDedupKey            string
 	project                  string
 	agent                    string
@@ -567,6 +576,7 @@ type dailyUsageScanRow struct {
 	costUSD                  sql.NullFloat64
 	claudeMessageID          string
 	claudeRequestID          string
+	sourceUUID               string
 	usageDedupKey            string
 	project                  string
 	agent                    string
@@ -598,6 +608,7 @@ SELECT
 	u.cost_source,
 	u.claude_message_id,
 	u.claude_request_id,
+	u.source_uuid,
 	u.usage_dedup_key,
 	u.project,
 	u.agent,
@@ -635,6 +646,7 @@ SELECT
 	u.cost_usd,
 	u.claude_message_id,
 	u.claude_request_id,
+	u.source_uuid,
 	u.usage_dedup_key,
 	u.project,
 	u.agent
@@ -789,6 +801,7 @@ func scanUsageRow(rows *sql.Rows) (usageScanRow, error) {
 		&r.costSource,
 		&r.claudeMessageID,
 		&r.claudeRequestID,
+		&r.sourceUUID,
 		&r.usageDedupKey,
 		&r.project,
 		&r.agent,
@@ -819,6 +832,7 @@ func scanDailyUsageRow(rows *sql.Rows) (dailyUsageScanRow, error) {
 		&r.costUSD,
 		&r.claudeMessageID,
 		&r.claudeRequestID,
+		&r.sourceUUID,
 		&r.usageDedupKey,
 		&r.project,
 		&r.agent,
@@ -860,6 +874,35 @@ func dailyUsageAmounts(
 		(rates.input - rates.cacheCreation) / 1_000_000
 	savings = readDelta + crDelta
 	return
+}
+
+type usageDedupToken struct {
+	kind  string
+	value string
+}
+
+func usageDedupTokenForRow(
+	usageSource, agent, claudeMessageID, claudeRequestID, sourceUUID, usageDedupKey string,
+) (usageDedupToken, bool) {
+	if claudeMessageID != "" && claudeRequestID != "" {
+		return usageDedupToken{
+			kind:  "claude",
+			value: claudeMessageID + ":" + claudeRequestID,
+		}, true
+	}
+	if usageSource == "message" && agent != "" && sourceUUID != "" {
+		return usageDedupToken{
+			kind:  "source",
+			value: agent + ":" + sourceUUID,
+		}, true
+	}
+	if usageDedupKey != "" {
+		return usageDedupToken{
+			kind:  "usage",
+			value: usageDedupKey,
+		}, true
+	}
+	return usageDedupToken{}, false
 }
 
 func (db *DB) loadTopSessionMetadata(
@@ -1097,10 +1140,7 @@ func (db *DB) GetDailyUsage(
 
 	accum := make(map[accumKey]*bucket)
 
-	type dedupKey struct {
-		msgID, reqID string
-	}
-	seen := make(map[dedupKey]struct{})
+	seen := make(map[usageDedupToken]struct{})
 	seenSessions := make(map[string]UsageSessionInfo)
 
 	// totalSavings is the running sum of per-message cache
@@ -1128,17 +1168,10 @@ func (db *DB) GetDailyUsage(
 		// Dedup AFTER the date filter so out-of-range rows
 		// (pulled in by the ±14h timezone padding) don't mark
 		// a key as seen and suppress the in-range duplicate.
-		if r.claudeMessageID != "" && r.claudeRequestID != "" {
-			key := dedupKey{
-				msgID: r.claudeMessageID,
-				reqID: r.claudeRequestID,
-			}
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-		} else if r.usageDedupKey != "" {
-			key := dedupKey{msgID: "usage", reqID: r.usageDedupKey}
+		if key, ok := usageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
 			if _, dup := seen[key]; dup {
 				continue
 			}
@@ -1544,13 +1577,10 @@ func (db *DB) GetTopSessionsByCost(
 	// Track insertion order for stable iteration.
 	var order []string
 
-	// Dedup duplicate Claude messages across fork/subagent
+	// Dedup duplicate usage rows across fork/subagent
 	// boundaries so per-session totals match the aggregate
 	// totals from GetDailyUsage. Same key and ordering rules.
-	type dedupKey struct {
-		msgID, reqID string
-	}
-	seen := make(map[dedupKey]struct{})
+	seen := make(map[usageDedupToken]struct{})
 
 	for rows.Next() {
 		r, err := scanDailyUsageRow(rows)
@@ -1571,17 +1601,10 @@ func (db *DB) GetTopSessionsByCost(
 		// Dedup AFTER the date filter, matching GetDailyUsage,
 		// so out-of-range rows pulled in by the ±14h padding
 		// don't claim a key and suppress the in-range duplicate.
-		if r.claudeMessageID != "" && r.claudeRequestID != "" {
-			key := dedupKey{
-				msgID: r.claudeMessageID,
-				reqID: r.claudeRequestID,
-			}
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-		} else if r.usageDedupKey != "" {
-			key := dedupKey{msgID: "usage", reqID: r.usageDedupKey}
+		if key, ok := usageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
 			if _, dup := seen[key]; dup {
 				continue
 			}
@@ -1748,22 +1771,17 @@ func (db *DB) GetSessionUsage(
 	modelsSet := make(map[string]struct{})
 	unpricedSet := make(map[string]struct{})
 
-	type dedupKey struct{ msgID, reqID string }
-	seen := make(map[dedupKey]struct{})
+	seen := make(map[usageDedupToken]struct{})
 
 	for rows.Next() {
 		r, scanErr := scanUsageRow(rows)
 		if scanErr != nil {
 			return nil, fmt.Errorf("scanning session usage row: %w", scanErr)
 		}
-		if r.claudeMessageID != "" && r.claudeRequestID != "" {
-			key := dedupKey{r.claudeMessageID, r.claudeRequestID}
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-		} else if r.usageDedupKey != "" {
-			key := dedupKey{"usage", r.usageDedupKey}
+		if key, ok := usageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
 			if _, dup := seen[key]; dup {
 				continue
 			}
@@ -1885,17 +1903,12 @@ func (db *DB) GetUsageSessionCounts(
 	}
 	seen := make(map[string]sessInfo)
 
-	// Claude message dedup mirrors GetDailyUsage: if a session
-	// only qualifies because of messages that are duplicates of
-	// an earlier session's rows (fork/subagent replays), that
-	// session should NOT be counted. Otherwise sessionCounts
-	// would disagree with the deduped token totals — a fork
-	// with zero unique messages would inflate the count even
-	// though it contributes zero cost.
-	type dedupKey struct {
-		msgID, reqID string
-	}
-	dedup := make(map[dedupKey]struct{})
+	// Usage dedup mirrors GetDailyUsage: if a session only
+	// qualifies because of rows that duplicate an earlier
+	// session's usage (fork/subagent replays), that session
+	// should NOT be counted. Otherwise sessionCounts would
+	// disagree with the deduped token totals.
+	dedup := make(map[usageDedupToken]struct{})
 
 	for rows.Next() {
 		r, err := scanDailyUsageRow(rows)
@@ -1915,17 +1928,10 @@ func (db *DB) GetUsageSessionCounts(
 
 		// Dedup AFTER the date filter, matching the other two
 		// queries so ±14h padding rows don't claim keys.
-		if r.claudeMessageID != "" && r.claudeRequestID != "" {
-			key := dedupKey{
-				msgID: r.claudeMessageID,
-				reqID: r.claudeRequestID,
-			}
-			if _, dup := dedup[key]; dup {
-				continue
-			}
-			dedup[key] = struct{}{}
-		} else if r.usageDedupKey != "" {
-			key := dedupKey{msgID: "usage", reqID: r.usageDedupKey}
+		if key, ok := usageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
 			if _, dup := dedup[key]; dup {
 				continue
 			}

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -703,6 +703,65 @@ func TestGetDailyUsage_DedupesByClaudeMessageAndRequestID(t *testing.T) {
 	assert.Equal(t, 55000, day.CacheReadTokens, "cache_rd")
 }
 
+func TestGetDailyUsage_DedupesBySourceUUIDWhenClaudePairIncomplete(t *testing.T) {
+	d := testDB(t)
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:         "claude-opus-4-6",
+		InputPerMTok:         15.0,
+		OutputPerMTok:        75.0,
+		CacheCreationPerMTok: 18.75,
+		CacheReadPerMTok:     1.50,
+	}}), "seed pricing")
+
+	insertSession(t, d, "s-main", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2026-04-10T10:00:00Z")
+		s.EndedAt = new("2026-04-10T10:05:00Z")
+	})
+	insertSession(t, d, "s-fork", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2026-04-10T10:01:00Z")
+		s.EndedAt = new("2026-04-10T10:06:00Z")
+		s.ParentSessionID = new("s-main")
+		s.RelationshipType = "fork"
+	})
+
+	shared := json.RawMessage(`{"input_tokens":100,"output_tokens":500,"cache_creation_input_tokens":1000,"cache_read_input_tokens":50000}`)
+	unique := json.RawMessage(`{"input_tokens":20,"output_tokens":80,"cache_creation_input_tokens":200,"cache_read_input_tokens":5000}`)
+
+	insertMessages(t, d,
+		Message{
+			SessionID: "s-main", Ordinal: 0,
+			Role: "assistant", Timestamp: "2026-04-10T10:02:00Z",
+			Model: "claude-opus-4-6", TokenUsage: shared,
+			ClaudeMessageID: "msg_dup", SourceUUID: "source_dup",
+		},
+		Message{
+			SessionID: "s-fork", Ordinal: 0,
+			Role: "assistant", Timestamp: "2026-04-10T10:02:00Z",
+			Model: "claude-opus-4-6", TokenUsage: shared,
+			ClaudeMessageID: "msg_dup", SourceUUID: "source_dup",
+		},
+		Message{
+			SessionID: "s-fork", Ordinal: 1,
+			Role: "assistant", Timestamp: "2026-04-10T10:03:00Z",
+			Model: "claude-opus-4-6", TokenUsage: unique,
+			ClaudeMessageID: "msg_uniq", SourceUUID: "source_uniq",
+		},
+	)
+
+	result, err := d.GetDailyUsage(context.Background(), UsageFilter{
+		From: "2026-04-10", To: "2026-04-10", Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetDailyUsage")
+	require.Len(t, result.Daily, 1, "daily entries =")
+	day := result.Daily[0]
+	assert.Equal(t, 120, day.InputTokens, "input")
+	assert.Equal(t, 580, day.OutputTokens, "output")
+	assert.Equal(t, 1200, day.CacheCreationTokens, "cache_cr")
+	assert.Equal(t, 55000, day.CacheReadTokens, "cache_rd")
+}
+
 func TestGetDailyUsage_MissingDedupKeysCountedEveryTime(t *testing.T) {
 	d := testDB(t)
 	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
@@ -1374,6 +1433,79 @@ func TestGetTopSessionsByCost_DedupesByClaudeMessageAndRequestID(
 	assert.Equal(t, 4730, total, "sum of per-session totals")
 }
 
+func TestGetTopSessionsByCost_DedupesBySourceUUIDWhenClaudePairIncomplete(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	requireNoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:         "claude-sonnet",
+		InputPerMTok:         3.0,
+		OutputPerMTok:        15.0,
+		CacheCreationPerMTok: 3.75,
+		CacheReadPerMTok:     0.30,
+	}}), "UpsertModelPricing")
+
+	insertSession(t, d, "s-parent", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2024-06-15T10:00:00Z")
+	})
+	insertSession(t, d, "s-fork", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2024-06-15T10:01:00Z")
+		s.ParentSessionID = new("s-parent")
+		s.RelationshipType = "fork"
+	})
+
+	shared := json.RawMessage(
+		`{"input_tokens":1000,"output_tokens":500,` +
+			`"cache_creation_input_tokens":200,` +
+			`"cache_read_input_tokens":3000}`)
+	unique := json.RawMessage(
+		`{"input_tokens":10,"output_tokens":20,` +
+			`"cache_creation_input_tokens":0,` +
+			`"cache_read_input_tokens":0}`)
+
+	insertMessages(t, d, Message{
+		SessionID: "s-parent", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:02:00Z",
+		Model: "claude-sonnet", TokenUsage: shared,
+		ClaudeMessageID: "msg_dup", SourceUUID: "source_dup",
+	})
+	insertMessages(t, d, Message{
+		SessionID: "s-fork", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:03:00Z",
+		Model: "claude-sonnet", TokenUsage: shared,
+		ClaudeMessageID: "msg_dup", SourceUUID: "source_dup",
+	})
+	insertMessages(t, d, Message{
+		SessionID: "s-fork", Ordinal: 1,
+		Role: "assistant", Timestamp: "2024-06-15T10:04:00Z",
+		Model: "claude-sonnet", TokenUsage: unique,
+		ClaudeMessageID: "msg_uniq", SourceUUID: "source_uniq",
+	})
+
+	top, err := d.GetTopSessionsByCost(ctx, UsageFilter{
+		From: "2024-06-15", To: "2024-06-15", Timezone: "UTC",
+	}, 20)
+	requireNoError(t, err, "GetTopSessionsByCost")
+
+	require.Len(t, top, 2, "len")
+	byID := map[string]TopSessionEntry{}
+	for _, e := range top {
+		byID[e.SessionID] = e
+	}
+
+	parent, ok := byID["s-parent"]
+	require.True(t, ok, "s-parent missing from top sessions")
+	assert.Equal(t, 4700, parent.TotalTokens, "parent.TotalTokens")
+
+	fork, ok := byID["s-fork"]
+	require.True(t, ok, "s-fork missing from top sessions")
+	assert.Equal(t, 30, fork.TotalTokens, "fork.TotalTokens want 30")
+}
+
 func TestGetTopSessionsByCostLimit(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
@@ -1552,6 +1684,48 @@ func TestGetUsageSessionCounts_DedupesByClaudeMessageAndRequestID(
 
 	assert.Equal(t, 1, counts.Total,
 		"Total want 1 (fork should dedup out)")
+	assert.Equal(t, 1, counts.ByProject["proj"], "ByProject[proj]")
+	assert.Equal(t, 1, counts.ByAgent["claude"], "ByAgent[claude]")
+}
+
+func TestGetUsageSessionCounts_DedupesBySourceUUIDWhenClaudePairIncomplete(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "s-parent", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2024-06-15T10:00:00Z")
+	})
+	insertSession(t, d, "s-fork", "proj", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2024-06-15T10:01:00Z")
+		s.ParentSessionID = new("s-parent")
+		s.RelationshipType = "fork"
+	})
+
+	shared := json.RawMessage(`{"input_tokens":100,"output_tokens":50}`)
+
+	insertMessages(t, d, Message{
+		SessionID: "s-parent", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:02:00Z",
+		Model: "claude-sonnet", TokenUsage: shared,
+		ClaudeMessageID: "msg_dup", SourceUUID: "source_dup",
+	})
+	insertMessages(t, d, Message{
+		SessionID: "s-fork", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:03:00Z",
+		Model: "claude-sonnet", TokenUsage: shared,
+		ClaudeMessageID: "msg_dup", SourceUUID: "source_dup",
+	})
+
+	counts, err := d.GetUsageSessionCounts(ctx, UsageFilter{
+		From: "2024-06-15", To: "2024-06-15", Timezone: "UTC",
+	})
+	requireNoError(t, err, "GetUsageSessionCounts")
+
+	assert.Equal(t, 1, counts.Total, "Total want 1 (fork should dedup out)")
 	assert.Equal(t, 1, counts.ByProject["proj"], "ByProject[proj]")
 	assert.Equal(t, 1, counts.ByAgent["claude"], "ByAgent[claude]")
 }
@@ -2408,6 +2582,34 @@ func TestGetSessionUsage_DedupesDuplicateClaudeRows(t *testing.T) {
 	u, err := d.GetSessionUsage(ctx, "claude:s6")
 	requireNoError(t, err, "GetSessionUsage")
 	// One row priced at 1000*5/1e6 + 500*25/1e6 = 0.0175; deduped, not 0.035.
+	assert.InDelta(t, 0.0175, u.CostUSD, 1e-9, "CostUSD want 0.0175 (deduped)")
+	assert.True(t, u.HasCost, "HasCost = false, want true")
+}
+
+func TestGetSessionUsage_DedupesBySourceUUIDWhenClaudePairIncomplete(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedOpusPricing(t, d)
+	insertSession(t, d, "claude:s7", "proj", func(s *Session) {
+		s.Agent = "claude-code"
+		s.StartedAt = new("2026-05-20T10:00:00Z")
+	})
+	insertMessages(t, d,
+		Message{
+			SessionID: "claude:s7", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-05-20T10:30:00Z", Model: "claude-opus-4-6",
+			ClaudeMessageID: "msg-1", SourceUUID: "source-1",
+			TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+		},
+		Message{
+			SessionID: "claude:s7", Ordinal: 1, Role: "assistant",
+			Timestamp: "2026-05-20T10:31:00Z", Model: "claude-opus-4-6",
+			ClaudeMessageID: "msg-1", SourceUUID: "source-1",
+			TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
+		},
+	)
+	u, err := d.GetSessionUsage(ctx, "claude:s7")
+	requireNoError(t, err, "GetSessionUsage")
 	assert.InDelta(t, 0.0175, u.CostUSD, 1e-9, "CostUSD want 0.0175 (deduped)")
 	assert.True(t, u.HasCost, "HasCost = false, want true")
 }

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -191,11 +191,14 @@ func (s *Store) activityReportActivity(
 // dedup keys the aggregator and per-row cost need.
 type duckActivityReportUsageRow struct {
 	sessionID       string
+	source          string
 	model           string
 	ts              string
 	messageOrdinal  any
+	agent           string
 	claudeMessageID string
 	claudeRequestID string
+	sourceUUID      string
 	usageDedupKey   string
 	inputTok        int
 	outputTok       int
@@ -252,8 +255,9 @@ func (s *Store) activityReportUsage(
 	for rows.Next() {
 		var r duckActivityReportUsageRow
 		if err := rows.Scan(
-			&r.sessionID, &r.messageOrdinal, &r.ts, &r.model,
-			&r.claudeMessageID, &r.claudeRequestID, &r.usageDedupKey,
+			&r.sessionID, &r.messageOrdinal, &r.ts, &r.source, &r.model,
+			&r.agent, &r.claudeMessageID, &r.claudeRequestID, &r.sourceUUID,
+			&r.usageDedupKey,
 			&r.inputTok, &r.outputTok, &r.cacheCr, &r.cacheRd, &r.costUSD,
 		); err != nil {
 			return nil, fmt.Errorf(
@@ -275,8 +279,10 @@ func (s *Store) activityReportUsage(
 				Timestamp:       tsStr,
 				OutputTokens:    r.outputTok,
 				Cost:            cost,
+				Agent:           r.agent,
 				ClaudeMessageID: r.claudeMessageID,
 				ClaudeRequestID: r.claudeRequestID,
+				SourceUUID:      r.sourceUUID,
 				UsageDedupKey:   r.usageDedupKey,
 			},
 		})
@@ -317,8 +323,10 @@ func duckActivityReportUsageQuery(inClause string) string {
 			SELECT m.session_id AS session_id, m.ordinal AS message_ordinal,
 				'message' AS source, COALESCE(m.timestamp, s.started_at) AS ts,
 				m.model AS model, m.token_usage AS token_json,
+				s.agent AS agent,
 				m.claude_message_id AS claude_message_id,
 				m.claude_request_id AS claude_request_id,
+				m.source_uuid AS source_uuid,
 				'' AS usage_dedup_key,
 				0 AS input_tokens, 0 AS output_tokens,
 				0 AS cache_create, 0 AS cache_read, NULL AS cost_usd
@@ -333,7 +341,9 @@ func duckActivityReportUsageQuery(inClause string) string {
 			SELECT ue.session_id AS session_id, ue.message_ordinal AS message_ordinal,
 				ue.source AS source, COALESCE(ue.occurred_at, s.started_at) AS ts,
 				ue.model AS model, '' AS token_json,
+				s.agent AS agent,
 				'' AS claude_message_id, '' AS claude_request_id,
+				'' AS source_uuid,
 				CASE
 					WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
 					ELSE ue.session_id || ':' || ue.source || ':id:' || CAST(ue.id AS VARCHAR)
@@ -349,8 +359,8 @@ func duckActivityReportUsageQuery(inClause string) string {
 				AND ue.session_id IN (%[1]s)
 		),
 		usage_normalized AS (
-			SELECT session_id, message_ordinal, ts, model,
-				claude_message_id, claude_request_id, usage_dedup_key,
+			SELECT session_id, message_ordinal, ts, source, model, agent,
+				claude_message_id, claude_request_id, source_uuid, usage_dedup_key,
 				CASE
 					WHEN source = 'message' THEN COALESCE(TRY_CAST(json_extract_string(token_json, '$.input_tokens') AS BIGINT), 0)
 					ELSE input_tokens
@@ -370,8 +380,8 @@ func duckActivityReportUsageQuery(inClause string) string {
 				cost_usd
 			FROM usage_raw
 		)
-		SELECT session_id, message_ordinal, ts, model,
-			claude_message_id, claude_request_id, usage_dedup_key,
+		SELECT session_id, message_ordinal, ts, source, model, agent,
+			claude_message_id, claude_request_id, source_uuid, usage_dedup_key,
 			input_tokens_norm, output_tokens_norm,
 			cache_create_norm, cache_read_norm, cost_usd
 		FROM usage_normalized

--- a/internal/duckdb/activityreport_test.go
+++ b/internal/duckdb/activityreport_test.go
@@ -306,6 +306,48 @@ func TestDuckGetActivityReportUsageDedupSubSecondOrder(t *testing.T) {
 		"first-seen dedup keeps the chronologically earlier whole-second row")
 }
 
+func TestDuckGetActivityReportUsageDedupFallsBackToSourceUUID(t *testing.T) {
+	ctx := context.Background()
+	pricing := []db.ModelPricing{{
+		ModelPattern:  "claude-sonnet-4-20250514",
+		InputPerMTok:  3.0,
+		OutputPerMTok: 15.0,
+	}}
+
+	earlier := syncSession("earlier", "proj1", "first", "2026-06-14T10:30:00Z", 1)
+	earlier.Agent = "claude"
+	earlierMsg := syncMessage("earlier", 0, "assistant", "x", "2026-06-14T10:30:00Z")
+	earlierMsg.Model = "claude-sonnet-4-20250514"
+	earlierMsg.ClaudeMessageID = "dup-m"
+	earlierMsg.SourceUUID = "src-dup"
+	earlierMsg.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	earlierMsg.OutputTokens = 500
+
+	later := syncSession("later", "proj2", "first", "2026-06-14T10:30:01Z", 1)
+	later.Agent = "claude"
+	laterMsg := syncMessage("later", 0, "assistant", "x", "2026-06-14T10:30:01Z")
+	laterMsg.Model = "claude-sonnet-4-20250514"
+	laterMsg.ClaudeMessageID = "dup-m"
+	laterMsg.SourceUUID = "src-dup"
+	laterMsg.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":900}`)
+	laterMsg.OutputTokens = 900
+
+	writes := []db.SessionBatchWrite{
+		{Session: earlier, Messages: []db.Message{earlierMsg},
+			DataVersion: 1, ReplaceMessages: true},
+		{Session: later, Messages: []db.Message{laterMsg},
+			DataVersion: 1, ReplaceMessages: true},
+	}
+	store := activityReportStore(t, writes, pricing)
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-06-14", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens,
+		"incomplete Claude pairs fall back to source_uuid dedup in activity reports")
+}
+
 // TestDuckGetActivityReportZeroCostKeepsPrimaryModel confirms a usage-only
 // (untimed) session whose known-model usage carries zero cost still reports
 // that model as primary through the DuckDB path, guarding the shared zero-cost

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -2204,6 +2204,7 @@ func duckUsageRawSQL(f db.UsageFilter, sessionID string) (string, []any) {
 			m.model AS model, m.token_usage AS token_json,
 			m.claude_message_id AS claude_message_id,
 			m.claude_request_id AS claude_request_id,
+			m.source_uuid AS source_uuid,
 			'' AS usage_dedup_key,
 			0 AS input_tokens, 0 AS output_tokens,
 			0 AS cache_create, 0 AS cache_read, NULL AS cost_usd,
@@ -2220,6 +2221,7 @@ func duckUsageRawSQL(f db.UsageFilter, sessionID string) (string, []any) {
 			ue.source AS source, COALESCE(ue.occurred_at, s.started_at) AS ts,
 			ue.model AS model, '' AS token_json,
 			'' AS claude_message_id, '' AS claude_request_id,
+			'' AS source_uuid,
 			CASE
 				WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
 				ELSE ue.session_id || ':' || ue.source || ':id:' || CAST(ue.id AS VARCHAR)
@@ -2299,6 +2301,8 @@ func duckUsageCTE(f db.UsageFilter, sessionID string) (string, []any) {
 				CASE
 					WHEN claude_message_id != '' AND claude_request_id != ''
 						THEN 'claude:' || claude_message_id || ':' || claude_request_id
+					WHEN source = 'message' AND agent != '' AND source_uuid != ''
+						THEN 'source:' || agent || ':' || source_uuid
 					WHEN usage_dedup_key != ''
 						THEN 'usage:' || usage_dedup_key
 					ELSE 'row:' || session_id || ':' || source || ':' ||

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -1697,6 +1697,68 @@ func TestUsageDedupesClaudeMessageIDs(t *testing.T) {
 	assert.Equal(t, []string{"claude-test"}, sessionUsage.Models)
 }
 
+func TestUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern:  "claude-test",
+		InputPerMTok:  3,
+		OutputPerMTok: 15,
+	}}))
+
+	first := syncMessage("duck-usage-source-a", 0, "assistant", "shared usage", "2026-01-13T00:00:00.000Z")
+	first.ClaudeMessageID = "shared-message"
+	first.SourceUUID = "shared-source"
+	second := syncMessage("duck-usage-source-b", 0, "assistant", "replayed usage", "2026-01-13T00:01:00.000Z")
+	second.ClaudeMessageID = "shared-message"
+	second.SourceUUID = "shared-source"
+
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{
+			Session:         syncSession("duck-usage-source-a", "alpha", "usage a", "2026-01-13T00:00:00.000Z", 1),
+			Messages:        []db.Message{first},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session:         syncSession("duck-usage-source-b", "beta", "usage b", "2026-01-13T00:01:00.000Z", 1),
+			Messages:        []db.Message{second},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	})
+	require.NoError(t, err)
+
+	syncer := newTestSync(t, filepath.Join(t.TempDir(), "usage-source.duckdb"), local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+	filter := db.UsageFilter{From: "2026-01-01", To: "2026-01-31"}
+
+	daily, err := store.GetDailyUsage(ctx, filter)
+	require.NoError(t, err)
+	assert.Equal(t, 1, daily.Totals.InputTokens)
+	assert.Equal(t, 2, daily.Totals.OutputTokens)
+
+	top, err := store.GetTopSessionsByCost(ctx, filter, 10)
+	require.NoError(t, err)
+	require.Len(t, top, 1)
+	assert.Equal(t, "duck-usage-source-a", top[0].SessionID)
+
+	counts, err := store.GetUsageSessionCounts(ctx, filter)
+	require.NoError(t, err)
+	assert.Equal(t, 1, counts.Total)
+	assert.Equal(t, 1, counts.ByProject["alpha"])
+	assert.NotContains(t, counts.ByProject, "beta")
+
+	sessionUsage, err := store.GetSessionUsage(ctx, "duck-usage-source-b")
+	require.NoError(t, err)
+	require.NotNil(t, sessionUsage)
+	assert.True(t, sessionUsage.HasCost)
+	assert.InDelta(t, 0.000033, sessionUsage.CostUSD, 0.000001)
+	assert.Equal(t, []string{"claude-test"}, sessionUsage.Models)
+}
+
 func TestUsageDedupPrefersInRangeDuplicate(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -260,8 +260,10 @@ func (s *Store) activityReportUsage(
 					Timestamp:       startedAtString(r.ts),
 					OutputTokens:    outputTok,
 					Cost:            cost,
+					Agent:           r.agent,
 					ClaudeMessageID: r.claudeMessageID,
 					ClaudeRequestID: r.claudeRequestID,
+					SourceUUID:      r.sourceUUID,
 					UsageDedupKey:   r.usageDedupKey,
 				},
 			})

--- a/internal/postgres/activityreport_pgtest_test.go
+++ b/internal/postgres/activityreport_pgtest_test.go
@@ -430,6 +430,53 @@ func TestPGGetActivityReportDedupsAcrossChunks(t *testing.T) {
 	assert.Equal(t, 900, shared[1].OutputTokens)
 }
 
+func TestPGGetActivityReportUsageDedupFallsBackToSourceUUID(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_daily_report_sourceuuid_test")
+	ctx := context.Background()
+
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('claude-sonnet-4-20250514', 3, 15, 0, 0, 'seed')`)
+	require.NoError(t, err, "insert pricing")
+
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES
+			('earlier', 'test-machine', 'proj1', 'claude',
+			 '2026-06-16T10:30:00Z'::timestamptz,
+			 '2026-06-16T10:30:00Z'::timestamptz, 1, 1),
+			('later', 'test-machine', 'proj2', 'claude',
+			 '2026-06-16T10:30:01Z'::timestamptz,
+			 '2026-06-16T10:30:01Z'::timestamptz, 1, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp,
+			content_length, model, token_usage,
+			claude_message_id, source_uuid
+		) VALUES
+			('earlier', 0, 'assistant', 'x',
+			 '2026-06-16T10:30:00Z'::timestamptz, 1,
+			 'claude-sonnet-4-20250514',
+			 '{"input_tokens":1000,"output_tokens":500}', 'M1', 'SRC1'),
+			('later', 0, 'assistant', 'x',
+			 '2026-06-16T10:30:01Z'::timestamptz, 1,
+			 'claude-sonnet-4-20250514',
+			 '{"input_tokens":1000,"output_tokens":900}', 'M1', 'SRC1')`)
+	require.NoError(t, err, "insert messages")
+
+	r, err := store.GetActivityReport(
+		ctx, db.AnalyticsFilter{Timezone: "UTC"},
+		pgDayQuery(t, "2026-06-16", "UTC"))
+	require.NoError(t, err)
+	assert.Equal(t, 500, r.Totals.OutputTokens,
+		"incomplete Claude pairs fall back to source_uuid dedup in activity reports")
+}
+
 // TestPGGetActivityReportAutomationFilterAndSessionSplit confirms the shared
 // AnalyticsFilter automation class is honored through the PG analytics WHERE
 // builder and that the Totals carry the automated/interactive session-count

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -212,6 +212,7 @@ SELECT
 	'' AS cost_source,
 	m.claude_message_id,
 	m.claude_request_id,
+	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
 	s.agent,
@@ -244,6 +245,7 @@ SELECT
 	ue.cost_source,
 	'' AS claude_message_id,
 	'' AS claude_request_id,
+	'' AS source_uuid,
 	CASE
 		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
@@ -285,6 +287,7 @@ SELECT
 	NULL::double precision AS cost_usd,
 	m.claude_message_id,
 	m.claude_request_id,
+	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
 	s.agent
@@ -308,6 +311,7 @@ SELECT
 	ue.cost_usd,
 	'' AS claude_message_id,
 	'' AS claude_request_id,
+	'' AS source_uuid,
 	CASE
 		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
@@ -333,6 +337,7 @@ SELECT
 	NULL::double precision AS cost_usd,
 	m.claude_message_id,
 	m.claude_request_id,
+	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
 	s.agent
@@ -355,6 +360,7 @@ SELECT
 	ue.cost_usd,
 	'' AS claude_message_id,
 	'' AS claude_request_id,
+	'' AS source_uuid,
 	CASE
 		WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
@@ -390,7 +396,8 @@ message_timestamp_rows AS MATERIALIZED (
 		m.model,
 		m.token_usage,
 		m.claude_message_id,
-		m.claude_request_id
+		m.claude_request_id,
+		m.source_uuid
 	FROM messages m
 	WHERE ` + messageTimestampWhere + `
 ),
@@ -459,6 +466,7 @@ type pgUsageScanRow struct {
 	costSource               string
 	claudeMessageID          string
 	claudeRequestID          string
+	sourceUUID               string
 	usageDedupKey            string
 	project                  string
 	agent                    string
@@ -484,6 +492,7 @@ type pgDailyUsageScanRow struct {
 	costUSD                  sql.NullFloat64
 	claudeMessageID          string
 	claudeRequestID          string
+	sourceUUID               string
 	usageDedupKey            string
 	project                  string
 	agent                    string
@@ -515,6 +524,7 @@ SELECT
 	u.cost_source,
 	u.claude_message_id,
 	u.claude_request_id,
+	u.source_uuid,
 	u.usage_dedup_key,
 	u.project,
 	u.agent,
@@ -551,6 +561,7 @@ SELECT
 	u.cost_usd,
 	u.claude_message_id,
 	u.claude_request_id,
+	u.source_uuid,
 	u.usage_dedup_key,
 	u.project,
 	u.agent
@@ -677,6 +688,7 @@ func scanPGUsageRow(rows *sql.Rows) (pgUsageScanRow, error) {
 		&r.costSource,
 		&r.claudeMessageID,
 		&r.claudeRequestID,
+		&r.sourceUUID,
 		&r.usageDedupKey,
 		&r.project,
 		&r.agent,
@@ -706,6 +718,7 @@ func scanPGDailyUsageRow(rows *sql.Rows) (pgDailyUsageScanRow, error) {
 		&r.costUSD,
 		&r.claudeMessageID,
 		&r.claudeRequestID,
+		&r.sourceUUID,
 		&r.usageDedupKey,
 		&r.project,
 		&r.agent,
@@ -744,6 +757,35 @@ func pgDailyUsageAmounts(
 		(rates.input - rates.cacheCreation) / 1_000_000
 	savings = readDelta + createDelta
 	return
+}
+
+type pgUsageDedupToken struct {
+	kind  string
+	value string
+}
+
+func pgUsageDedupTokenForRow(
+	usageSource, agent, claudeMessageID, claudeRequestID, sourceUUID, usageDedupKey string,
+) (pgUsageDedupToken, bool) {
+	if claudeMessageID != "" && claudeRequestID != "" {
+		return pgUsageDedupToken{
+			kind:  "claude",
+			value: claudeMessageID + ":" + claudeRequestID,
+		}, true
+	}
+	if usageSource == "message" && agent != "" && sourceUUID != "" {
+		return pgUsageDedupToken{
+			kind:  "source",
+			value: agent + ":" + sourceUUID,
+		}, true
+	}
+	if usageDedupKey != "" {
+		return pgUsageDedupToken{
+			kind:  "usage",
+			value: usageDedupKey,
+		}, true
+	}
+	return pgUsageDedupToken{}, false
 }
 
 func pgSessionRowCost(
@@ -880,11 +922,7 @@ func (s *Store) GetSessionUsage(
 	modelsSet := make(map[string]struct{})
 	unpricedSet := make(map[string]struct{})
 
-	type dedupKey struct {
-		msgID string
-		reqID string
-	}
-	seen := make(map[dedupKey]struct{})
+	seen := make(map[pgUsageDedupToken]struct{})
 
 	for rows.Next() {
 		r, scanErr := scanPGUsageRow(rows)
@@ -892,20 +930,10 @@ func (s *Store) GetSessionUsage(
 			return nil,
 				fmt.Errorf("scanning pg session usage row: %w", scanErr)
 		}
-		if r.claudeMessageID != "" && r.claudeRequestID != "" {
-			key := dedupKey{
-				msgID: r.claudeMessageID,
-				reqID: r.claudeRequestID,
-			}
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-		} else if r.usageDedupKey != "" {
-			key := dedupKey{
-				msgID: "usage",
-				reqID: r.usageDedupKey,
-			}
+		if key, ok := pgUsageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
 			if _, dup := seen[key]; dup {
 				continue
 			}
@@ -999,13 +1027,8 @@ func (s *Store) GetDailyUsage(
 		cacheRd   int
 		cost      float64
 	}
-	type dedupKey struct {
-		msgID string
-		reqID string
-	}
-
 	accum := make(map[accumKey]*bucket)
-	seen := make(map[dedupKey]struct{})
+	seen := make(map[pgUsageDedupToken]struct{})
 	seenSessions := make(map[string]db.UsageSessionInfo)
 	var totalSavings float64
 
@@ -1024,14 +1047,10 @@ func (s *Store) GetDailyUsage(
 			continue
 		}
 
-		if r.claudeMessageID != "" && r.claudeRequestID != "" {
-			key := dedupKey{msgID: r.claudeMessageID, reqID: r.claudeRequestID}
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-		} else if r.usageDedupKey != "" {
-			key := dedupKey{msgID: "usage", reqID: r.usageDedupKey}
+		if key, ok := pgUsageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
 			if _, dup := seen[key]; dup {
 				continue
 			}
@@ -1384,14 +1403,10 @@ func (s *Store) GetTopSessionsByCost(
 		totalTokens int
 		cost        float64
 	}
-	type dedupKey struct {
-		msgID string
-		reqID string
-	}
 
 	accum := make(map[string]*sessAccum)
 	var order []string
-	seen := make(map[dedupKey]struct{})
+	seen := make(map[pgUsageDedupToken]struct{})
 
 	for rows.Next() {
 		r, err := scanPGDailyUsageRow(rows)
@@ -1408,14 +1423,10 @@ func (s *Store) GetTopSessionsByCost(
 			continue
 		}
 
-		if r.claudeMessageID != "" && r.claudeRequestID != "" {
-			key := dedupKey{msgID: r.claudeMessageID, reqID: r.claudeRequestID}
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-		} else if r.usageDedupKey != "" {
-			key := dedupKey{msgID: "usage", reqID: r.usageDedupKey}
+		if key, ok := pgUsageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
 			if _, dup := seen[key]; dup {
 				continue
 			}
@@ -1503,13 +1514,9 @@ func (s *Store) GetUsageSessionCounts(
 		project string
 		agent   string
 	}
-	type dedupKey struct {
-		msgID string
-		reqID string
-	}
 
 	seen := make(map[string]sessInfo)
-	dedup := make(map[dedupKey]struct{})
+	dedup := make(map[pgUsageDedupToken]struct{})
 
 	for rows.Next() {
 		r, err := scanPGDailyUsageRow(rows)
@@ -1526,14 +1533,10 @@ func (s *Store) GetUsageSessionCounts(
 			continue
 		}
 
-		if r.claudeMessageID != "" && r.claudeRequestID != "" {
-			key := dedupKey{msgID: r.claudeMessageID, reqID: r.claudeRequestID}
-			if _, dup := dedup[key]; dup {
-				continue
-			}
-			dedup[key] = struct{}{}
-		} else if r.usageDedupKey != "" {
-			key := dedupKey{msgID: "usage", reqID: r.usageDedupKey}
+		if key, ok := pgUsageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
 			if _, dup := dedup[key]; dup {
 				continue
 			}

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -123,6 +123,54 @@ func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
 	assert.Greater(t, day.TotalCost, 0.0)
 }
 
+func TestStoreGetDailyUsageDedupesBySourceUUIDWhenClaudePairIncomplete(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_source_uuid_daily_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('test-model-source-daily', 1, 2, 3, 0.5, 'seed')`)
+	require.NoError(t, err, "insert pricing")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES
+			('usage-source-daily-001', 'test-machine', 'proj-a', 'claude',
+			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
+			('usage-source-daily-002', 'test-machine', 'proj-b', 'claude',
+			 '2026-03-12T10:01:00Z'::timestamptz, 1, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage, claude_message_id, claude_request_id, source_uuid
+		) VALUES
+			('usage-source-daily-001', 0, 'assistant', 'one',
+			 '2026-03-12T10:00:00Z'::timestamptz, 3,
+			 'test-model-source-daily',
+			 '{"input_tokens":1000000,"output_tokens":500000,"cache_creation_input_tokens":250000,"cache_read_input_tokens":250000}',
+			 'msg-1', '', 'source-1'),
+			('usage-source-daily-002', 0, 'assistant', 'two',
+			 '2026-03-12T10:01:00Z'::timestamptz, 3,
+			 'test-model-source-daily',
+			 '{"input_tokens":1000000,"output_tokens":500000,"cache_creation_input_tokens":250000,"cache_read_input_tokens":250000}',
+			 'msg-1', '', 'source-1')`)
+	require.NoError(t, err, "insert messages")
+
+	result, err := store.GetDailyUsage(ctx, db.UsageFilter{
+		From:     "2026-03-12",
+		To:       "2026-03-12",
+		Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetDailyUsage")
+	require.Len(t, result.Daily, 1)
+	assert.Equal(t, 1000000, result.Daily[0].InputTokens)
+	assert.Equal(t, 500000, result.Daily[0].OutputTokens)
+}
+
 func TestStoreGetSessionUsagePricedModel(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_session_usage_priced_test")
 
@@ -170,6 +218,48 @@ func TestStoreGetSessionUsagePricedModel(t *testing.T) {
 	assert.InDelta(t, 0.01134, got.CostUSD, 1e-9)
 	assert.Equal(t, []string{"gpt-5.1"}, got.Models)
 	assert.Empty(t, got.UnpricedModels)
+}
+
+func TestStoreGetSessionUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_session_usage_source_uuid_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('claude-opus-4-6', 5, 25, 6.25, 0.5, 'seed')`)
+	require.NoError(t, err, "insert pricing")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES (
+			'claude:usage-source', 'test-machine', 'proj', 'claude-code',
+			'2026-03-12T10:00:00Z'::timestamptz, 2, 1
+		)`)
+	require.NoError(t, err, "insert session")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage, claude_message_id, claude_request_id, source_uuid
+		) VALUES
+			('claude:usage-source', 0, 'assistant', 'one',
+			 '2026-03-12T10:00:00Z'::timestamptz, 3,
+			 'claude-opus-4-6', '{"input_tokens":1000,"output_tokens":500}',
+			 'msg-1', '', 'source-1'),
+			('claude:usage-source', 1, 'assistant', 'two',
+			 '2026-03-12T10:01:00Z'::timestamptz, 3,
+			 'claude-opus-4-6', '{"input_tokens":1000,"output_tokens":500}',
+			 'msg-1', '', 'source-1')`)
+	require.NoError(t, err, "insert messages")
+
+	got, err := store.GetSessionUsage(ctx, "claude:usage-source")
+	require.NoError(t, err, "GetSessionUsage")
+	require.NotNil(t, got, "GetSessionUsage result")
+	assert.True(t, got.HasCost)
+	assert.InDelta(t, 0.0175, got.CostUSD, 1e-9)
+	assert.Equal(t, []string{"claude-opus-4-6"}, got.Models)
 }
 
 func TestStoreGetSessionUsageNoTokenRowsKeepsMetadata(t *testing.T) {
@@ -250,6 +340,49 @@ func TestStoreGetTopSessionsByCostDedupesClaudeKeys(t *testing.T) {
 	assert.Equal(t, "usage-top-001", top[0].SessionID)
 }
 
+func TestStoreGetTopSessionsByCostDedupesSourceUUIDFallback(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_top_source_uuid_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('test-model-top-source', 1, 0, 0, 0, 'seed')`)
+	require.NoError(t, err, "insert pricing")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES
+			('usage-top-source-001', 'test-machine', 'proj-a', 'claude',
+			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
+			('usage-top-source-002', 'test-machine', 'proj-b', 'claude',
+			 '2026-03-12T10:01:00Z'::timestamptz, 1, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage, claude_message_id, claude_request_id, source_uuid
+		) VALUES
+			('usage-top-source-001', 0, 'assistant', 'one',
+			 '2026-03-12T10:00:00Z'::timestamptz, 3,
+			 'test-model-top-source', '{"input_tokens":1000000}', 'msg-1', '', 'source-1'),
+			('usage-top-source-002', 0, 'assistant', 'two',
+			 '2026-03-12T10:01:00Z'::timestamptz, 3,
+			 'test-model-top-source', '{"input_tokens":1000000}', 'msg-1', '', 'source-1')`)
+	require.NoError(t, err, "insert messages")
+
+	top, err := store.GetTopSessionsByCost(ctx, db.UsageFilter{
+		From:     "2026-03-12",
+		To:       "2026-03-12",
+		Timezone: "UTC",
+	}, 20)
+	require.NoError(t, err, "GetTopSessionsByCost")
+	require.Len(t, top, 1)
+	assert.Equal(t, "usage-top-source-001", top[0].SessionID)
+}
+
 func TestStoreGetUsageSessionCountsDedupesClaudeKeys(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_usage_counts_test")
 
@@ -275,6 +408,45 @@ func TestStoreGetUsageSessionCountsDedupesClaudeKeys(t *testing.T) {
 			('usage-counts-002', 0, 'assistant', 'two',
 			 '2026-03-12T10:01:00Z'::timestamptz, 3,
 			 'test-model-counts', '{"input_tokens":1}', 'msg-1', 'req-1')`)
+	require.NoError(t, err, "insert messages")
+
+	counts, err := store.GetUsageSessionCounts(ctx, db.UsageFilter{
+		From:     "2026-03-12",
+		To:       "2026-03-12",
+		Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetUsageSessionCounts")
+	assert.Equal(t, 1, counts.Total)
+	assert.Equal(t, 1, counts.ByProject["proj-a"])
+	_, ok := counts.ByProject["proj-b"]
+	assert.False(t, ok, "proj-b should have been deduped out: %#v", counts.ByProject)
+}
+
+func TestStoreGetUsageSessionCountsDedupesSourceUUIDFallback(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_counts_source_uuid_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES
+			('usage-counts-source-001', 'test-machine', 'proj-a', 'claude',
+			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
+			('usage-counts-source-002', 'test-machine', 'proj-b', 'claude',
+			 '2026-03-12T10:01:00Z'::timestamptz, 1, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage, claude_message_id, claude_request_id, source_uuid
+		) VALUES
+			('usage-counts-source-001', 0, 'assistant', 'one',
+			 '2026-03-12T10:00:00Z'::timestamptz, 3,
+			 'test-model-counts', '{"input_tokens":1}', 'msg-1', '', 'source-1'),
+			('usage-counts-source-002', 0, 'assistant', 'two',
+			 '2026-03-12T10:01:00Z'::timestamptz, 3,
+			 'test-model-counts', '{"input_tokens":1}', 'msg-1', '', 'source-1')`)
 	require.NoError(t, err, "insert messages")
 
 	counts, err := store.GetUsageSessionCounts(ctx, db.UsageFilter{

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -130,6 +130,7 @@ func (c *usageProbeConn) QueryContext(
 				"cost_usd",
 				"claude_message_id",
 				"claude_request_id",
+				"source_uuid",
 				"usage_dedup_key",
 				"project",
 				"agent",
@@ -160,6 +161,7 @@ func usageProbeUsageRow(
 		nil,
 		"msg-dup",
 		"req-dup",
+		"",
 		"",
 		project,
 		agent,
@@ -195,6 +197,22 @@ func TestPGGetDailyUsageReturnsDedupedSessionCounts(t *testing.T) {
 	assert.Equal(t, 1, result.SessionCounts.ByAgent["claude"])
 	assert.Zero(t, result.SessionCounts.ByProject["proj-b"])
 	assert.Zero(t, result.SessionCounts.ByAgent["codex"])
+}
+
+func TestPGUsageDedupTokenForRowFallsBackToSourceUUIDWhenClaudePairIncomplete(t *testing.T) {
+	got, ok := pgUsageDedupTokenForRow(
+		"message",
+		"claude-code",
+		"msg-dup",
+		"",
+		"source-dup",
+		"",
+	)
+	require.True(t, ok, "expected source_uuid fallback key")
+	assert.Equal(t, pgUsageDedupToken{
+		kind:  "source",
+		value: "claude-code:source-dup",
+	}, got)
 }
 
 func TestPGUsageRowQueryPushesDateBoundsIntoUnion(t *testing.T) {


### PR DESCRIPTION
Continued Claude sessions can still inflate usage totals when replayed history rows do not carry a complete `messageId:requestId` pair. Current main already deduplicates rows that have both Claude identifiers, but replayed rows that only preserve the shared source identity still fall through and count once per file.

This change keeps the existing Claude pair as the preferred usage key and adds a narrower fallback for replayed message rows that lack a complete pair. SQLite, PostgreSQL, and DuckDB now use the same precedence in usage aggregation and activity reports, so daily totals, top-session rankings, per-session usage, and activity-report cost totals stay aligned. The scope stays in usage accounting and activity-report dedup, without adding schema columns or parser changes.

Review the shared dedup-key selection first. The important behavior is that complete Claude pairs keep their current semantics, incomplete replay rows deduplicate by persisted source identity, and rows that still lack every stable key continue to count individually.

Fixes #307
