### PR TITLE
fix(postgres): reset push watermarks on target changes

### DIFF
--- a/internal/postgres/connect.go
+++ b/internal/postgres/connect.go
@@ -2,7 +2,9 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
@@ -195,6 +197,35 @@ func Open(
 		)
 	}
 	return db, nil
+}
+
+func pgTargetFingerprint(dsn, schema string) (string, error) {
+	if dsn == "" {
+		return "", fmt.Errorf("postgres URL is required")
+	}
+	cfg, err := pgconn.ParseConfig(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parsing pg connection string: %w", err)
+	}
+
+	host := cfg.Host
+	if host != "" && !strings.HasPrefix(host, "/") {
+		host = strings.ToLower(host)
+	}
+
+	fields := []string{
+		"v1",
+		host,
+		fmt.Sprintf("%d", cfg.Port),
+		cfg.Database,
+		cfg.User,
+		schema,
+	}
+	h := sha256.New()
+	for _, field := range fields {
+		fmt.Fprintf(h, "%d:%s", len(field), field)
+	}
+	return "v1:" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // appendConnParams injects key=value connection parameters into

--- a/internal/postgres/connect.go
+++ b/internal/postgres/connect.go
@@ -208,18 +208,21 @@ func pgTargetFingerprint(dsn, schema string) (string, error) {
 		return "", fmt.Errorf("parsing pg connection string: %w", err)
 	}
 
-	host := cfg.Host
-	if host != "" && !strings.HasPrefix(host, "/") {
-		host = strings.ToLower(host)
-	}
-
 	fields := []string{
 		"v1",
-		host,
-		fmt.Sprintf("%d", cfg.Port),
 		cfg.Database,
 		cfg.User,
 		schema,
+	}
+	appendTargetEndpoint := func(host string, port uint16) {
+		if host != "" && !strings.HasPrefix(host, "/") {
+			host = strings.ToLower(host)
+		}
+		fields = append(fields, host, fmt.Sprintf("%d", port))
+	}
+	appendTargetEndpoint(cfg.Host, cfg.Port)
+	for _, fallback := range cfg.Fallbacks {
+		appendTargetEndpoint(fallback.Host, fallback.Port)
 	}
 	h := sha256.New()
 	for _, field := range fields {

--- a/internal/postgres/connect_test.go
+++ b/internal/postgres/connect_test.go
@@ -182,6 +182,19 @@ func TestPGTargetFingerprint(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, base, samePasswordChanged)
 
+	baseWithFallback, err := pgTargetFingerprint(
+		"postgres://alice:secret@db.example.com:5432/agents?sslmode=require&application_name=agentsview&host=db.example.com,standby-a.example.com&port=5432,6432",
+		"agentsview",
+	)
+	assert.NoError(t, err)
+
+	sameFallbackNoiseChanged, err := pgTargetFingerprint(
+		"postgres://alice:new-secret@db.example.com:5432/agents?sslmode=require&application_name=other&host=DB.EXAMPLE.COM,standby-a.example.com&port=5432,6432",
+		"agentsview",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, baseWithFallback, sameFallbackNoiseChanged)
+
 	cases := []struct {
 		name   string
 		dsn    string
@@ -207,13 +220,27 @@ func TestPGTargetFingerprint(t *testing.T) {
 			dsn:    "postgres://alice:secret@db.example.com:5432/agents?sslmode=require",
 			schema: "agentsview_alt",
 		},
+		{
+			name:   "fallback host change",
+			dsn:    "postgres://alice:secret@db.example.com:5432/agents?sslmode=require&host=db.example.com,standby-b.example.com&port=5432,6432",
+			schema: "agentsview",
+		},
+		{
+			name:   "fallback port change",
+			dsn:    "postgres://alice:secret@db.example.com:5432/agents?sslmode=require&host=db.example.com,standby-a.example.com&port=5432,7432",
+			schema: "agentsview",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := pgTargetFingerprint(tc.dsn, tc.schema)
 			assert.NoError(t, err)
-			assert.NotEqual(t, base, got)
+			wantDifferentFrom := base
+			if tc.name == "fallback host change" || tc.name == "fallback port change" {
+				wantDifferentFrom = baseWithFallback
+			}
+			assert.NotEqual(t, wantDifferentFrom, got)
 		})
 	}
 }

--- a/internal/postgres/connect_test.go
+++ b/internal/postgres/connect_test.go
@@ -167,3 +167,53 @@ func TestQuoteIdentifier(t *testing.T) {
 		})
 	}
 }
+
+func TestPGTargetFingerprint(t *testing.T) {
+	base, err := pgTargetFingerprint(
+		"postgres://alice:secret@db.example.com:5432/agents?sslmode=require&application_name=agentsview",
+		"agentsview",
+	)
+	assert.NoError(t, err)
+
+	samePasswordChanged, err := pgTargetFingerprint(
+		"postgres://alice:new-secret@db.example.com:5432/agents?sslmode=require&application_name=other",
+		"agentsview",
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, base, samePasswordChanged)
+
+	cases := []struct {
+		name   string
+		dsn    string
+		schema string
+	}{
+		{
+			name:   "host change",
+			dsn:    "postgres://alice:secret@db2.example.com:5432/agents?sslmode=require",
+			schema: "agentsview",
+		},
+		{
+			name:   "database change",
+			dsn:    "postgres://alice:secret@db.example.com:5432/agents_archive?sslmode=require",
+			schema: "agentsview",
+		},
+		{
+			name:   "user change",
+			dsn:    "postgres://bob:secret@db.example.com:5432/agents?sslmode=require",
+			schema: "agentsview",
+		},
+		{
+			name:   "schema change",
+			dsn:    "postgres://alice:secret@db.example.com:5432/agents?sslmode=require",
+			schema: "agentsview_alt",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pgTargetFingerprint(tc.dsn, tc.schema)
+			assert.NoError(t, err)
+			assert.NotEqual(t, base, got)
+		})
+	}
+}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -19,7 +19,10 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-const lastPushBoundaryStateKey = "last_push_boundary_state"
+const (
+	lastPushBoundaryStateKey     = "last_push_boundary_state"
+	lastPushTargetFingerprintKey = "pg_target_fingerprint_v1"
+)
 
 // pushMarkerIDStateKey names the local sync-state entry holding this DB's
 // stable push-marker identifier. pushMarkerKeyPrefix prefixes that identifier
@@ -87,6 +90,32 @@ func (s *Sync) Push(
 			"reading last_push_at: %w", err,
 		)
 	}
+	storedTargetFingerprint, err := s.local.GetSyncState(
+		lastPushTargetFingerprintKey,
+	)
+	if err != nil {
+		return result, fmt.Errorf(
+			"reading %s: %w",
+			lastPushTargetFingerprintKey, err,
+		)
+	}
+	pushStateCleared := false
+	if reset, reason := pushTargetState(
+		lastPush,
+		storedTargetFingerprint,
+		s.targetFingerprint,
+	); reset {
+		log.Printf(
+			"pgsync: %s; clearing local push watermark state",
+			reason,
+		)
+		if err := clearPushState(s.local); err != nil {
+			return result, err
+		}
+		lastPush = ""
+		full = true
+		pushStateCleared = true
+	}
 	markerID, err := s.pushMarkerID()
 	if err != nil {
 		return result, err
@@ -114,10 +143,11 @@ func (s *Sync) Push(
 		// When a filtered full push runs, clear persisted
 		// watermark and boundary state so the next
 		// unfiltered push also starts from scratch.
-		if s.isFiltered() {
+		if s.isFiltered() && !pushStateCleared {
 			if err := clearPushState(s.local); err != nil {
 				return result, err
 			}
+			pushStateCleared = true
 		}
 	}
 
@@ -145,10 +175,11 @@ func (s *Sync) Push(
 			// Filtered push against a reset PG: clear
 			// watermark and boundary state so the next
 			// unfiltered push also starts from scratch.
-			if s.isFiltered() {
+			if s.isFiltered() && !pushStateCleared {
 				if err := clearPushState(s.local); err != nil {
 					return result, err
 				}
+				pushStateCleared = true
 			}
 		}
 	}
@@ -274,6 +305,11 @@ func (s *Sync) Push(
 				return result, err
 			}
 		}
+		if err := persistPushTargetFingerprint(
+			s.local, s.targetFingerprint,
+		); err != nil {
+			return result, err
+		}
 		if err := s.writePushMarker(
 			ctx, markerID, markerMachine, markerMachineAliases,
 		); err != nil {
@@ -370,6 +406,11 @@ func (s *Sync) Push(
 		); err != nil {
 			return result, err
 		}
+	}
+	if err := persistPushTargetFingerprint(
+		s.local, s.targetFingerprint,
+	); err != nil {
+		return result, err
 	}
 
 	// Write the push marker only after the push and local finalization
@@ -753,6 +794,38 @@ func clearPushState(local syncStateStore) error {
 		)
 	}
 	return nil
+}
+
+func persistPushTargetFingerprint(
+	local syncStateStore,
+	fingerprint string,
+) error {
+	if err := local.SetSyncState(
+		lastPushTargetFingerprintKey,
+		fingerprint,
+	); err != nil {
+		return fmt.Errorf(
+			"updating %s: %w",
+			lastPushTargetFingerprintKey, err,
+		)
+	}
+	return nil
+}
+
+func pushTargetState(
+	lastPush, storedTargetFingerprint, currentTargetFingerprint string,
+) (bool, string) {
+	if lastPush == "" {
+		return false, ""
+	}
+	if storedTargetFingerprint == "" {
+		return true,
+			"local watermark exists without a stored PG target fingerprint"
+	}
+	if storedTargetFingerprint != currentTargetFingerprint {
+		return true, "PG target fingerprint changed"
+	}
+	return false, ""
 }
 
 func readBoundaryAndFingerprints(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -99,9 +99,19 @@ func (s *Sync) Push(
 			lastPushTargetFingerprintKey, err,
 		)
 	}
+	boundaryState, err := s.local.GetSyncState(
+		lastPushBoundaryStateKey,
+	)
+	if err != nil {
+		return result, fmt.Errorf(
+			"reading %s: %w",
+			lastPushBoundaryStateKey, err,
+		)
+	}
 	pushStateCleared := false
 	if reset, reason := pushTargetState(
 		lastPush,
+		boundaryState,
 		storedTargetFingerprint,
 		s.targetFingerprint,
 	); reset {
@@ -811,14 +821,18 @@ func persistPushTargetFingerprint(
 }
 
 func pushTargetState(
-	lastPush, storedTargetFingerprint, currentTargetFingerprint string,
+	lastPush, boundaryState,
+	storedTargetFingerprint, currentTargetFingerprint string,
 ) (bool, string) {
-	if lastPush == "" || currentTargetFingerprint == "" {
+	if currentTargetFingerprint == "" {
+		return false, ""
+	}
+	if lastPush == "" && boundaryState == "" {
 		return false, ""
 	}
 	if storedTargetFingerprint == "" {
 		return true,
-			"local watermark exists without a stored PG target fingerprint"
+			"local push state exists without a stored PG target fingerprint"
 	}
 	if storedTargetFingerprint != currentTargetFingerprint {
 		return true, "PG target fingerprint changed"

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -147,7 +147,6 @@ func (s *Sync) Push(
 			if err := clearPushState(s.local); err != nil {
 				return result, err
 			}
-			pushStateCleared = true
 		}
 	}
 
@@ -179,7 +178,6 @@ func (s *Sync) Push(
 				if err := clearPushState(s.local); err != nil {
 					return result, err
 				}
-				pushStateCleared = true
 			}
 		}
 	}
@@ -815,7 +813,7 @@ func persistPushTargetFingerprint(
 func pushTargetState(
 	lastPush, storedTargetFingerprint, currentTargetFingerprint string,
 ) (bool, string) {
-	if lastPush == "" {
+	if lastPush == "" || currentTargetFingerprint == "" {
 		return false, ""
 	}
 	if storedTargetFingerprint == "" {

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -433,6 +433,7 @@ func TestPushTargetState(t *testing.T) {
 	tests := []struct {
 		name       string
 		lastPush   string
+		boundary   string
 		stored     string
 		current    string
 		wantReset  bool
@@ -456,7 +457,14 @@ func TestPushTargetState(t *testing.T) {
 			lastPush:   "2026-03-11T12:34:56.123Z",
 			current:    "v1:new",
 			wantReset:  true,
-			wantReason: "local watermark exists without a stored PG target fingerprint",
+			wantReason: "local push state exists without a stored PG target fingerprint",
+		},
+		{
+			name:       "legacy filtered boundary without fingerprint resets",
+			boundary:   `{"cutoff":"2026-03-11T12:34:56.123Z","fingerprints":{"sess-001":"fp"}}`,
+			current:    "v1:new",
+			wantReset:  true,
+			wantReason: "local push state exists without a stored PG target fingerprint",
 		},
 		{
 			name:       "changed target resets",
@@ -473,12 +481,27 @@ func TestPushTargetState(t *testing.T) {
 			current:   "v1:same",
 			wantReset: false,
 		},
+		{
+			name:      "filtered boundary keeps same target state",
+			boundary:  `{"cutoff":"2026-03-11T12:34:56.123Z","fingerprints":{"sess-001":"fp"}}`,
+			stored:    "v1:same",
+			current:   "v1:same",
+			wantReset: false,
+		},
+		{
+			name:       "filtered boundary resets on target change",
+			boundary:   `{"cutoff":"2026-03-11T12:34:56.123Z","fingerprints":{"sess-001":"fp"}}`,
+			stored:     "v1:old",
+			current:    "v1:new",
+			wantReset:  true,
+			wantReason: "PG target fingerprint changed",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			gotReset, gotReason := pushTargetState(
-				tc.lastPush, tc.stored, tc.current,
+				tc.lastPush, tc.boundary, tc.stored, tc.current,
 			)
 			assert.Equal(t, tc.wantReset, gotReset)
 			assert.Equal(t, tc.wantReason, gotReason)

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -445,6 +445,13 @@ func TestPushTargetState(t *testing.T) {
 			wantReset: false,
 		},
 		{
+			name:      "missing runtime fingerprint skips reset",
+			lastPush:  "2026-03-11T12:34:56.123Z",
+			stored:    "v1:old",
+			current:   "",
+			wantReset: false,
+		},
+		{
 			name:       "legacy watermark without fingerprint resets",
 			lastPush:   "2026-03-11T12:34:56.123Z",
 			current:    "v1:new",

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -429,6 +429,56 @@ func TestFinalizePushStatePersistsEmptyBoundary(
 	assert.Empty(t, state.Fingerprints)
 }
 
+func TestPushTargetState(t *testing.T) {
+	tests := []struct {
+		name       string
+		lastPush   string
+		stored     string
+		current    string
+		wantReset  bool
+		wantReason string
+	}{
+		{
+			name:      "first push has no reset",
+			stored:    "",
+			current:   "v1:new",
+			wantReset: false,
+		},
+		{
+			name:       "legacy watermark without fingerprint resets",
+			lastPush:   "2026-03-11T12:34:56.123Z",
+			current:    "v1:new",
+			wantReset:  true,
+			wantReason: "local watermark exists without a stored PG target fingerprint",
+		},
+		{
+			name:       "changed target resets",
+			lastPush:   "2026-03-11T12:34:56.123Z",
+			stored:     "v1:old",
+			current:    "v1:new",
+			wantReset:  true,
+			wantReason: "PG target fingerprint changed",
+		},
+		{
+			name:      "same target keeps watermark",
+			lastPush:  "2026-03-11T12:34:56.123Z",
+			stored:    "v1:same",
+			current:   "v1:same",
+			wantReset: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotReset, gotReason := pushTargetState(
+				tc.lastPush, tc.stored, tc.current,
+			)
+			assert.Equal(t, tc.wantReset, gotReset)
+			assert.Equal(t, tc.wantReason, gotReason)
+		})
+	}
+}
+
 func TestFinalizePushStateMergesPriorFingerprints(
 	t *testing.T,
 ) {

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -34,10 +34,11 @@ func isUndefinedColumn(err error) bool {
 // Sync manages push-only sync from local SQLite to a remote
 // PostgreSQL database.
 type Sync struct {
-	pg      *sql.DB
-	local   *db.DB
-	machine string
-	schema  string
+	pg                *sql.DB
+	local             *db.DB
+	machine           string
+	schema            string
+	targetFingerprint string
 
 	// Project filtering for push scope.
 	projects        []string
@@ -93,14 +94,22 @@ func New(
 	if err != nil {
 		return nil, err
 	}
+	targetFingerprint, err := pgTargetFingerprint(pgURL, schema)
+	if err != nil {
+		pg.Close()
+		return nil, fmt.Errorf(
+			"computing pg target fingerprint: %w", err,
+		)
+	}
 
 	return &Sync{
-		pg:              pg,
-		local:           local,
-		machine:         machine,
-		schema:          schema,
-		projects:        opts.Projects,
-		excludeProjects: opts.ExcludeProjects,
+		pg:                pg,
+		local:             local,
+		machine:           machine,
+		schema:            schema,
+		targetFingerprint: targetFingerprint,
+		projects:          opts.Projects,
+		excludeProjects:   opts.ExcludeProjects,
 	}, nil
 }
 

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -34,6 +34,16 @@ func cleanPGSchema(t *testing.T, pgURL string) {
 	)
 }
 
+func cleanNamedPGSchema(t *testing.T, pgURL, schema string) {
+	t.Helper()
+	pg, err := sql.Open("pgx", pgURL)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+	quoted, err := quoteIdentifier(schema)
+	require.NoError(t, err, "quote schema")
+	_, _ = pg.Exec("DROP SCHEMA IF EXISTS " + quoted + " CASCADE")
+}
+
 func TestEnsureSchemaIdempotent(t *testing.T) {
 	pgURL := testPGURL(t)
 	cleanPGSchema(t, pgURL)
@@ -690,6 +700,82 @@ func TestPushDetectsSchemaReset(t *testing.T) {
 	assert.Equal(t, 1, r2.SessionsPushed,
 		"should auto-detect schema reset")
 	assert.Equal(t, 1, r2.MessagesPushed)
+}
+
+func TestPushDetectsPGTargetChange(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanNamedPGSchema(t, pgURL, "agentsview_a")
+	cleanNamedPGSchema(t, pgURL, "agentsview_b")
+	t.Cleanup(func() {
+		cleanNamedPGSchema(t, pgURL, "agentsview_a")
+		cleanNamedPGSchema(t, pgURL, "agentsview_b")
+	})
+
+	local := testDB(t)
+	ctx := context.Background()
+
+	insertSession := func(id, createdAt string) {
+		require.NoError(t, local.UpsertSession(db.Session{
+			ID:           id,
+			Project:      "target-change",
+			Machine:      "local",
+			Agent:        "claude",
+			CreatedAt:    createdAt,
+			MessageCount: 1,
+		}), "upsert session %s", id)
+		require.NoError(t, local.InsertMessages([]db.Message{{
+			SessionID:     id,
+			Ordinal:       0,
+			Role:          "user",
+			Content:       "hello " + id,
+			ContentLength: len("hello " + id),
+			Timestamp:     createdAt,
+		}}), "insert message %s", id)
+	}
+
+	insertSession("sess-target-001", "2026-03-11T12:00:00Z")
+
+	syncA, err := New(
+		pgURL, "agentsview_a", local,
+		"test-machine", true,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "creating sync A")
+	defer syncA.Close()
+
+	syncB, err := New(
+		pgURL, "agentsview_b", local,
+		"test-machine", true,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "creating sync B")
+	defer syncB.Close()
+
+	r1, err := syncA.Push(ctx, false, nil)
+	require.NoError(t, err, "initial push to schema A")
+	require.Equal(t, 1, r1.SessionsPushed)
+
+	r2, err := syncB.Push(ctx, false, nil)
+	require.NoError(t, err, "initial push to schema B")
+	require.Equal(t, 1, r2.SessionsPushed)
+
+	insertSession("sess-target-002", "2026-03-11T12:10:00Z")
+
+	r3, err := syncA.Push(ctx, false, nil)
+	require.NoError(t, err, "incremental push back to schema A")
+	require.GreaterOrEqual(t, r3.SessionsPushed, 1)
+
+	r4, err := syncB.Push(ctx, false, nil)
+	require.NoError(t, err, "switch back to populated schema B")
+	require.Equal(t, 2, r4.SessionsPushed)
+
+	var count int
+	err = syncB.DB().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sessions WHERE id = $1",
+		"sess-target-002",
+	).Scan(&count)
+	require.NoError(t, err, "counting repushed session")
+	assert.Equal(t, 1, count)
 }
 
 func TestPushFullAfterSchemaDropRecreatesSchema(

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -778,6 +778,79 @@ func TestPushDetectsPGTargetChange(t *testing.T) {
 	assert.Equal(t, 1, count)
 }
 
+func TestPushDetectsPGTargetChangeAfterFilteredPush(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanNamedPGSchema(t, pgURL, "agentsview_filtered_a")
+	cleanNamedPGSchema(t, pgURL, "agentsview_filtered_b")
+	t.Cleanup(func() {
+		cleanNamedPGSchema(t, pgURL, "agentsview_filtered_a")
+		cleanNamedPGSchema(t, pgURL, "agentsview_filtered_b")
+	})
+
+	local := testDB(t)
+	ctx := context.Background()
+
+	const project = "alpha"
+	const createdAt = "2026-03-11T12:00:00Z"
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:           "sess-filtered-target-001",
+		Project:      project,
+		Machine:      "local",
+		Agent:        "claude",
+		CreatedAt:    createdAt,
+		MessageCount: 1,
+	}), "upsert session")
+	require.NoError(t, local.InsertMessages([]db.Message{{
+		SessionID:     "sess-filtered-target-001",
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "hello filtered target",
+		ContentLength: len("hello filtered target"),
+		Timestamp:     createdAt,
+	}}), "insert message")
+
+	filteredA, err := New(
+		pgURL, "agentsview_filtered_a", local,
+		"test-machine", true,
+		SyncOptions{Projects: []string{project}},
+	)
+	require.NoError(t, err, "creating filtered sync A")
+	defer filteredA.Close()
+
+	unfilteredB, err := New(
+		pgURL, "agentsview_filtered_b", local,
+		"test-machine", true,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "creating unfiltered sync B")
+	defer unfilteredB.Close()
+
+	r1, err := filteredA.Push(ctx, false, nil)
+	require.NoError(t, err, "filtered push to schema A")
+	require.Equal(t, 1, r1.SessionsPushed)
+
+	lastPush, err := local.GetSyncState("last_push_at")
+	require.NoError(t, err, "reading filtered watermark")
+	assert.Empty(t, lastPush, "filtered push should keep last_push_at empty")
+
+	boundaryState, err := local.GetSyncState(lastPushBoundaryStateKey)
+	require.NoError(t, err, "reading filtered boundary state")
+	require.NotEmpty(t, boundaryState,
+		"filtered push should persist boundary fingerprints")
+
+	r2, err := unfilteredB.Push(ctx, false, nil)
+	require.NoError(t, err, "push to schema B after filtered target change")
+	require.Equal(t, 1, r2.SessionsPushed)
+
+	var count int
+	err = unfilteredB.DB().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sessions WHERE id = $1",
+		"sess-filtered-target-001",
+	).Scan(&count)
+	require.NoError(t, err, "counting session in schema B")
+	assert.Equal(t, 1, count)
+}
+
 func TestPushFullAfterSchemaDropRecreatesSchema(
 	t *testing.T,
 ) {


### PR DESCRIPTION
`pg push` still treats its local incremental watermark as if it belonged to one timeless PostgreSQL destination. A brand-new target already forces a repush because its push marker is missing, but switching back to a previously used populated database or schema can still reuse the old watermark and silently skip sessions that never reached the current target.

This change stores a versioned fingerprint for the effective PostgreSQL target, including schema, next to the existing push watermark state. When the fingerprint changes, `pg push` clears only the persisted push watermark and boundary state before selecting sessions, so the new target gets a full repush instead of inheriting stale incremental state.

The scope stays inside `internal/postgres`. Status remains informational, config semantics stay singular, and the new fingerprint is designed to be reusable later if multi-target push work namespaces watermarks per destination. Focused local validation covered `go test ./internal/postgres -count=1`, the new fingerprint and target-state unit slice, tagged pgtest compile, and `go vet ./internal/postgres`. The env-backed pgtest regression for live target switching is in the diff but was not run locally because `TEST_PG_URL` is unset in this environment.

Fixes #186
