### PR TITLE
feat(ui): add UI text-size scaling and high-contrast mode

### DIFF
--- a/frontend/e2e/appearance-a11y.spec.ts
+++ b/frontend/e2e/appearance-a11y.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+import { SessionsPage } from "./pages/sessions-page";
+
+function readZoom(page: import("@playwright/test").Page): Promise<string> {
+  return page.evaluate(() =>
+    document.documentElement.style.getPropertyValue("zoom"),
+  );
+}
+
+test.describe("Appearance accessibility", () => {
+  test("text size scales the UI on web without horizontal overflow", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("agentsview-font-scale", "130");
+    });
+    const sp = new SessionsPage(page);
+    await sp.goto();
+
+    expect(await readZoom(page)).toBe("1.3");
+
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(2);
+
+    await sp.selectFirstSession();
+    await expect(sp.messageRows.first()).toBeVisible();
+  });
+
+  test("text size at 90% renders and scrolls the transcript", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("agentsview-font-scale", "90");
+    });
+    const sp = new SessionsPage(page);
+    await sp.goto();
+
+    expect(await readZoom(page)).toBe("0.9");
+
+    await sp.selectFirstSession();
+    await expect(sp.messageRows.first()).toBeVisible();
+  });
+
+  test("desktop window zoom and text size compose multiplicatively", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("agentsview-zoom-level", "150");
+      localStorage.setItem("agentsview-font-scale", "120");
+    });
+    await page.goto("/?desktop");
+    const sp = new SessionsPage(page);
+    await expect(sp.sessionItems.first()).toBeVisible({ timeout: 5_000 });
+
+    expect(await readZoom(page)).toBe("1.8");
+  });
+
+  test("high contrast applies the root class and overrides tokens", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("theme", "light");
+      localStorage.setItem("agentsview-high-contrast", "true");
+    });
+    const sp = new SessionsPage(page);
+    await sp.goto();
+
+    const hasClass = await page.evaluate(() =>
+      document.documentElement.classList.contains("high-contrast"),
+    );
+    expect(hasClass).toBe(true);
+
+    // Browsers may normalize #000000 to #000; compare after stripping
+    // leading # and zero-padding each channel to 6 hex digits.
+    const textPrimary = await page.evaluate((): string => {
+      const raw = getComputedStyle(document.documentElement)
+        .getPropertyValue("--text-primary")
+        .trim();
+      // Expand shorthand #rgb → #rrggbb before comparing.
+      if (/^#[0-9a-fA-F]{3}$/.test(raw)) {
+        return "#" + raw[1]!.repeat(2) + raw[2]!.repeat(2) + raw[3]!.repeat(2);
+      }
+      return raw;
+    });
+    expect(textPrimary).toBe("#000000");
+  });
+});

--- a/frontend/e2e/appearance-a11y.spec.ts
+++ b/frontend/e2e/appearance-a11y.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Locator } from "@playwright/test";
 import { SessionsPage } from "./pages/sessions-page";
 
 function readZoom(page: import("@playwright/test").Page): Promise<string> {
@@ -32,6 +32,28 @@ function parseRgb(value: string): [number, number, number] {
     throw new Error(`Expected rgb() color, got ${value}`);
   }
   return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+async function elementColors(locator: Locator): Promise<{
+  background: string;
+  foreground: string;
+}> {
+  return locator.evaluate((element) => {
+    const styles = getComputedStyle(element);
+    return {
+      background: styles.backgroundColor,
+      foreground: styles.color,
+    };
+  });
+}
+
+function expectReadableContrast(colors: {
+  background: string;
+  foreground: string;
+}) {
+  expect(
+    contrastRatio(parseRgb(colors.foreground), parseRgb(colors.background)),
+  ).toBeGreaterThanOrEqual(4.5);
 }
 
 test.describe("Appearance accessibility", () => {
@@ -126,7 +148,7 @@ test.describe("Appearance accessibility", () => {
     const sp = new SessionsPage(page);
     await sp.goto();
 
-    const colors = await page.evaluate(() => {
+    const primaryButtonColors = await page.evaluate(() => {
       const panel = document.createElement("div");
       panel.className = "modal-panel";
       panel.innerHTML = '<button class="modal-btn modal-btn-primary">Save</button>';
@@ -140,9 +162,15 @@ test.describe("Appearance accessibility", () => {
       panel.remove();
       return result;
     });
+    expectReadableContrast(primaryButtonColors);
 
-    expect(
-      contrastRatio(parseRgb(colors.foreground), parseRgb(colors.background)),
-    ).toBeGreaterThanOrEqual(4.5);
+    await sp.selectFirstSession();
+    const agentBadge = page.locator(".agent-badge").first();
+    await expect(agentBadge).toBeVisible();
+    expectReadableContrast(await elementColors(agentBadge));
+
+    const userRoleIcon = page.locator(".role-icon", { hasText: "U" }).first();
+    await expect(userRoleIcon).toBeVisible();
+    expectReadableContrast(await elementColors(userRoleIcon));
   });
 });

--- a/frontend/e2e/appearance-a11y.spec.ts
+++ b/frontend/e2e/appearance-a11y.spec.ts
@@ -169,8 +169,29 @@ test.describe("Appearance accessibility", () => {
     await expect(agentBadge).toBeVisible();
     expectReadableContrast(await elementColors(agentBadge));
 
+    const nonBlueAgentBadgeColors = await page.evaluate(() => {
+      const badge = document.createElement("span");
+      badge.className = "agent-badge";
+      badge.style.background = "var(--accent-green)";
+      badge.style.color = "var(--accent-green-foreground)";
+      badge.textContent = "Codex";
+      document.body.append(badge);
+      const styles = getComputedStyle(badge);
+      const result = {
+        background: styles.backgroundColor,
+        foreground: styles.color,
+      };
+      badge.remove();
+      return result;
+    });
+    expectReadableContrast(nonBlueAgentBadgeColors);
+
     const userRoleIcon = page.locator(".role-icon", { hasText: "U" }).first();
     await expect(userRoleIcon).toBeVisible();
     expectReadableContrast(await elementColors(userRoleIcon));
+
+    const assistantRoleIcon = page.locator(".role-icon", { hasText: "A" }).first();
+    await expect(assistantRoleIcon).toBeVisible();
+    expectReadableContrast(await elementColors(assistantRoleIcon));
   });
 });

--- a/frontend/e2e/appearance-a11y.spec.ts
+++ b/frontend/e2e/appearance-a11y.spec.ts
@@ -7,6 +7,33 @@ function readZoom(page: import("@playwright/test").Page): Promise<string> {
   );
 }
 
+function luminance([r, g, b]: [number, number, number]): number {
+  const [rr, gg, bb] = [r, g, b].map((channel) => {
+    const value = channel / 255;
+    return value <= 0.03928
+      ? value / 12.92
+      : Math.pow((value + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rr! + 0.7152 * gg! + 0.0722 * bb!;
+}
+
+function contrastRatio(
+  foreground: [number, number, number],
+  background: [number, number, number],
+): number {
+  const lighter = Math.max(luminance(foreground), luminance(background));
+  const darker = Math.min(luminance(foreground), luminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function parseRgb(value: string): [number, number, number] {
+  const match = value.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match) {
+    throw new Error(`Expected rgb() color, got ${value}`);
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
 test.describe("Appearance accessibility", () => {
   test("text size scales the UI on web without horizontal overflow", async ({
     page,
@@ -87,5 +114,35 @@ test.describe("Appearance accessibility", () => {
       return raw;
     });
     expect(textPrimary).toBe("#000000");
+  });
+
+  test("dark high contrast keeps accent-filled controls readable", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("theme", "dark");
+      localStorage.setItem("agentsview-high-contrast", "true");
+    });
+    const sp = new SessionsPage(page);
+    await sp.goto();
+
+    const colors = await page.evaluate(() => {
+      const panel = document.createElement("div");
+      panel.className = "modal-panel";
+      panel.innerHTML = '<button class="modal-btn modal-btn-primary">Save</button>';
+      document.body.append(panel);
+      const button = panel.querySelector("button")!;
+      const styles = getComputedStyle(button);
+      const result = {
+        background: styles.backgroundColor,
+        foreground: styles.color,
+      };
+      panel.remove();
+      return result;
+    });
+
+    expect(
+      contrastRatio(parseRgb(colors.foreground), parseRgb(colors.background)),
+    ).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -676,7 +676,7 @@
     border-radius: 6px;
     font-size: 13px;
     font-weight: 500;
-    color: white;
+    color: var(--accent-blue-foreground);
     background: var(--accent-blue);
     border: none;
     cursor: pointer;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -123,6 +123,34 @@
   color-scheme: dark;
 }
 
+/* High contrast — overrides neutral text/border tokens (and
+   --accent-blue, which also colors links and the focus ring) to
+   clear WCAG AA. Semantic/identity tokens (--cat-*, --slow-*,
+   --running-*, --status-waiting, --user-bg, data-viz palettes) are
+   intentionally left unchanged so meaning is preserved. */
+:root.high-contrast {
+  --text-primary: #000000;
+  --text-secondary: #2a2f3a;
+  --text-muted: #44495a;
+  --border-default: #6b7080;
+  --border-muted: #7d8290;
+  --accent-blue: #0a47c2;
+}
+
+:root.dark.high-contrast {
+  --text-primary: #ffffff;
+  --text-secondary: #d4d8e0;
+  --text-muted: #b8bdc9;
+  --border-default: #8a8f9e;
+  --border-muted: #6e7282;
+  --accent-blue: #8ab8ff;
+}
+
+:root.high-contrast :focus-visible {
+  outline-width: 3px;
+  outline-offset: 2px;
+}
+
 html,
 body {
   height: 100%;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -19,7 +19,6 @@
   --text-secondary: #555b6e;
   --text-muted: #878ea0;
   --accent-blue: #2563eb;
-  --accent-blue-foreground: #ffffff;
   --accent-rose: #e11d48;
   --accent-purple: #7c3aed;
   --accent-amber: #d97706;
@@ -35,6 +34,23 @@
   --accent-pink: #ec4899;
   --accent-lime: #65a30d;
   --accent-cyan: #0891b2;
+  --accent-violet: #7c3aed;
+  --accent-blue-foreground: #ffffff;
+  --accent-rose-foreground: #ffffff;
+  --accent-purple-foreground: #ffffff;
+  --accent-amber-foreground: #07111f;
+  --accent-green-foreground: #07111f;
+  --accent-coral-foreground: #07111f;
+  --accent-black-foreground: #ffffff;
+  --accent-teal-foreground: #07111f;
+  --accent-red-foreground: #ffffff;
+  --accent-indigo-foreground: #000000;
+  --accent-orange-foreground: #07111f;
+  --accent-sky-foreground: #07111f;
+  --accent-pink-foreground: #07111f;
+  --accent-lime-foreground: #07111f;
+  --accent-cyan-foreground: #07111f;
+  --accent-violet-foreground: #ffffff;
   /* Tool-category color map (see internal/parser/taxonomy.go for normalized values) */
   --cat-read:  #4a7ba8; /* Read, Grep, Glob */
   --cat-edit:  #5a8b3a; /* Edit, Write */
@@ -90,7 +106,6 @@
   --text-secondary: #9ea5b4;
   --text-muted: #6c7385;
   --accent-blue: #60a5fa;
-  --accent-blue-foreground: #07111f;
   --accent-rose: #fb7185;
   --accent-purple: #a78bfa;
   --accent-amber: #fbbf24;
@@ -106,6 +121,23 @@
   --accent-pink: #f472b6;
   --accent-lime: #a3e635;
   --accent-cyan: #22d3ee;
+  --accent-violet: #a78bfa;
+  --accent-blue-foreground: #07111f;
+  --accent-rose-foreground: #07111f;
+  --accent-purple-foreground: #07111f;
+  --accent-amber-foreground: #07111f;
+  --accent-green-foreground: #07111f;
+  --accent-coral-foreground: #07111f;
+  --accent-black-foreground: #07111f;
+  --accent-teal-foreground: #07111f;
+  --accent-red-foreground: #07111f;
+  --accent-indigo-foreground: #07111f;
+  --accent-orange-foreground: #07111f;
+  --accent-sky-foreground: #07111f;
+  --accent-pink-foreground: #07111f;
+  --accent-lime-foreground: #07111f;
+  --accent-cyan-foreground: #07111f;
+  --accent-violet-foreground: #07111f;
   /* Lighter champagne for dark mode — keeps the same warm-gold
      identity without disappearing into the dark surface. */
   --status-waiting: #d4b878;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -19,6 +19,7 @@
   --text-secondary: #555b6e;
   --text-muted: #878ea0;
   --accent-blue: #2563eb;
+  --accent-blue-foreground: #ffffff;
   --accent-rose: #e11d48;
   --accent-purple: #7c3aed;
   --accent-amber: #d97706;
@@ -89,6 +90,7 @@
   --text-secondary: #9ea5b4;
   --text-muted: #6c7385;
   --accent-blue: #60a5fa;
+  --accent-blue-foreground: #07111f;
   --accent-rose: #fb7185;
   --accent-purple: #a78bfa;
   --accent-amber: #fbbf24;
@@ -124,7 +126,7 @@
 }
 
 /* High contrast — overrides neutral text/border tokens (and
-   --accent-blue, which also colors links and the focus ring) to
+   --accent-blue, which colors links, focus rings, and filled accents) to
    clear WCAG AA. Semantic/identity tokens (--cat-*, --slow-*,
    --running-*, --status-waiting, --user-bg, data-viz palettes) are
    intentionally left unchanged so meaning is preserved. */
@@ -194,7 +196,7 @@ body {
 /* Selection */
 ::selection {
   background: var(--accent-blue);
-  color: white;
+  color: var(--accent-blue-foreground);
 }
 
 /* Focus visible */
@@ -344,7 +346,7 @@ mark.search-highlight--current {
 
 .modal-panel .modal-btn-primary {
   background: var(--accent-blue);
-  color: white;
+  color: var(--accent-blue-foreground);
   border-color: var(--accent-blue);
 }
 

--- a/frontend/src/lib/components/activity/ActivityInsight.svelte
+++ b/frontend/src/lib/components/activity/ActivityInsight.svelte
@@ -356,7 +356,7 @@
     font-size: 11px;
     font-weight: 600;
     background: var(--accent-blue);
-    color: white;
+    color: var(--accent-blue-foreground);
     letter-spacing: 0.01em;
     transition: opacity 0.12s, transform 0.1s, box-shadow 0.12s;
     box-shadow: 0 1px 2px rgba(37, 99, 235, 0.2);

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -485,6 +485,6 @@
 
   .retry-btn:hover {
     background: var(--accent-red);
-    color: #fff;
+    color: var(--accent-red-foreground);
   }
 </style>

--- a/frontend/src/lib/components/activity/Breakdowns.svelte
+++ b/frontend/src/lib/components/activity/Breakdowns.svelte
@@ -273,7 +273,7 @@
 
   .metric-btn.active {
     background: var(--accent-blue);
-    color: #fff;
+    color: var(--accent-blue-foreground);
   }
 
   .metric-btn + .metric-btn {

--- a/frontend/src/lib/components/analytics/SummaryCards.svelte
+++ b/frontend/src/lib/components/analytics/SummaryCards.svelte
@@ -156,6 +156,6 @@
 
   .retry-btn:hover {
     background: var(--accent-red);
-    color: #fff;
+    color: var(--accent-red-foreground);
   }
 </style>

--- a/frontend/src/lib/components/component-source-guard.test.ts
+++ b/frontend/src/lib/components/component-source-guard.test.ts
@@ -40,6 +40,20 @@ function oneOffControlStyleOffenders(source: string): string[] {
   });
 }
 
+function accentFillForegroundOffenders(source: string): string[] {
+  return styleBlocks(source).flatMap((style) => {
+    return Array.from(style.matchAll(/([^{}]+)\{([^{}]*)\}/g)).flatMap((match) => {
+      const selector = (match[1] ?? "").trim().replace(/\s+/g, " ");
+      const block = match[2] ?? "";
+      const hasAccentFill = /background\s*:\s*var\(--accent-[a-z]+/.test(block);
+      const hasHardCodedWhite = /color\s*:\s*(?:white|#fff(?:fff)?)\b/i.test(block);
+      return hasAccentFill && hasHardCodedWhite
+        ? [`${selector}: hard-coded white foreground on accent fill`]
+        : [];
+    });
+  });
+}
+
 describe("component source guardrails", () => {
   it("keeps new native select controls out of component source", () => {
     const offenders = svelteFiles(componentsRoot)
@@ -59,6 +73,18 @@ describe("component source guardrails", () => {
         const rel = relative(componentsRoot, path);
         const source = readFileSync(path, "utf8");
         return oneOffControlStyleOffenders(source).map((reason) => `${rel}: ${reason}`);
+      })
+      .sort((a, b) => a.localeCompare(b));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps accent-filled component styles on foreground tokens", () => {
+    const offenders = svelteFiles(componentsRoot)
+      .flatMap((path) => {
+        const rel = relative(componentsRoot, path);
+        const source = readFileSync(path, "utf8");
+        return accentFillForegroundOffenders(source).map((reason) => `${rel}: ${reason}`);
       })
       .sort((a, b) => a.localeCompare(b));
 

--- a/frontend/src/lib/components/content/CallGroup.svelte
+++ b/frontend/src/lib/components/content/CallGroup.svelte
@@ -155,4 +155,11 @@
     opacity: 0.3;
     transition: opacity 0.18s;
   }
+  :global(.high-contrast) .cgroup .cg-h-label,
+  :global(.high-contrast) .cgroup .cg-h-dur {
+    color: var(--text-secondary);
+  }
+  :global(.high-contrast) .cgroup .cg-rail::before {
+    background: var(--border-default);
+  }
 </style>

--- a/frontend/src/lib/components/content/CallRow.svelte
+++ b/frontend/src/lib/components/content/CallRow.svelte
@@ -233,4 +233,12 @@
       transform: scaleX(1);
     }
   }
+  :global(.high-contrast) .call .ca,
+  :global(.high-contrast) .call .cd.muted,
+  :global(.high-contrast) .call .chev {
+    color: var(--text-secondary);
+  }
+  :global(.high-contrast) .call.expanded .chev {
+    color: var(--text-primary);
+  }
 </style>

--- a/frontend/src/lib/components/content/MessageContent.svelte
+++ b/frontend/src/lib/components/content/MessageContent.svelte
@@ -161,6 +161,9 @@
   let accentColor = $derived(
     isUser ? "var(--accent-blue)" : "var(--accent-purple)",
   );
+  let accentForeground = $derived(
+    isUser ? "var(--accent-blue-foreground)" : "#ffffff",
+  );
 
   let roleBg = $derived(
     isUser ? "var(--user-bg)" : "var(--assistant-bg)",
@@ -300,6 +303,7 @@
     <span
       class="role-icon"
       style:background={accentColor}
+      style:color={accentForeground}
     >
       {roleIcon}
     </span>

--- a/frontend/src/lib/components/content/MessageContent.svelte
+++ b/frontend/src/lib/components/content/MessageContent.svelte
@@ -162,7 +162,7 @@
     isUser ? "var(--accent-blue)" : "var(--accent-purple)",
   );
   let accentForeground = $derived(
-    isUser ? "var(--accent-blue-foreground)" : "#ffffff",
+    isUser ? "var(--accent-blue-foreground)" : "var(--accent-purple-foreground)",
   );
 
   let roleBg = $derived(

--- a/frontend/src/lib/components/content/MessageContent.test.ts
+++ b/frontend/src/lib/components/content/MessageContent.test.ts
@@ -103,6 +103,9 @@ describe("MessageContent", () => {
     expect(document.querySelector(".role-label")?.textContent?.trim()).toBe(
       "用户",
     );
+    expect(document.querySelector(".role-icon")?.getAttribute("style")).toContain(
+      "var(--accent-blue-foreground)",
+    );
     const copyButton = document.querySelector<HTMLButtonElement>(
       "button.copy-btn",
     );

--- a/frontend/src/lib/components/content/MessageContent.test.ts
+++ b/frontend/src/lib/components/content/MessageContent.test.ts
@@ -143,6 +143,23 @@ describe("MessageContent", () => {
     unmount(component);
   });
 
+  it("uses the assistant accent foreground for assistant role icons", async () => {
+    const component = mount(MessageContent, {
+      target: document.body,
+      props: {
+        message: makeMessage({ role: "assistant" }),
+      },
+    });
+
+    await tick();
+
+    expect(document.querySelector(".role-icon")?.getAttribute("style")).toContain(
+      "var(--accent-purple-foreground)",
+    );
+
+    unmount(component);
+  });
+
   it("renders an explicit missing token placeholder when context tokens are absent", async () => {
     const component = mount(MessageContent, {
       target: document.body,

--- a/frontend/src/lib/components/content/SubagentCalls.svelte
+++ b/frontend/src/lib/components/content/SubagentCalls.svelte
@@ -136,4 +136,7 @@
     flex-direction: column;
     gap: 1px;
   }
+  :global(.high-contrast) .sa-expand .sa-eh-meta {
+    color: var(--text-secondary);
+  }
 </style>

--- a/frontend/src/lib/components/filters/SessionFilterControl.svelte
+++ b/frontend/src/lib/components/filters/SessionFilterControl.svelte
@@ -7,6 +7,7 @@
   import { starred } from "../../stores/starred.svelte.js";
   import {
     agentColor,
+    agentForeground,
     agentLabel,
   } from "../../utils/agents.js";
   import type { GroupMode } from "../sidebar/session-list-utils.js";
@@ -283,6 +284,7 @@
           class="agent-select-row"
           class:selected={!sessions.filters.agent}
           style:--agent-color={"var(--accent-blue)"}
+          style:--agent-foreground={"var(--accent-blue-foreground)"}
           onclick={() => sessions.setAgentFilter("")}
         >
           <span
@@ -302,6 +304,7 @@
             class="agent-select-row"
             class:selected
             style:--agent-color={agentColor(agent.name)}
+            style:--agent-foreground={agentForeground(agent.name)}
             onclick={() =>
               sessions.toggleAgentFilter(agent.name)}
           >
@@ -350,6 +353,7 @@
               class="agent-select-row"
               class:selected
               style:--agent-color={"var(--accent-blue)"}
+              style:--agent-foreground={"var(--accent-blue-foreground)"}
               onclick={() =>
                 sessions.toggleMachineFilter(machine)}
             >
@@ -601,6 +605,7 @@
   .agent-check.on {
     background: var(--agent-color, var(--accent-blue));
     border-color: var(--agent-color, var(--accent-blue));
+    color: var(--agent-foreground, #ffffff);
   }
 
   .agent-dot-mini {

--- a/frontend/src/lib/components/filters/SessionFilterControl.svelte
+++ b/frontend/src/lib/components/filters/SessionFilterControl.svelte
@@ -596,7 +596,7 @@
     border: 1.5px solid var(--border-default);
     flex-shrink: 0;
     transition: background 0.1s, border-color 0.1s;
-    color: white;
+    color: var(--agent-foreground, var(--accent-blue-foreground));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -605,7 +605,7 @@
   .agent-check.on {
     background: var(--agent-color, var(--accent-blue));
     border-color: var(--agent-color, var(--accent-blue));
-    color: var(--agent-foreground, #ffffff);
+    color: var(--agent-foreground, var(--accent-blue-foreground));
   }
 
   .agent-dot-mini {

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -1891,7 +1891,7 @@
     height: 30px;
     padding: 0 12px;
     background: var(--accent-purple);
-    color: white;
+    color: var(--accent-purple-foreground);
     border-radius: var(--radius-sm);
     font-size: 12px;
     font-weight: 700;

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -2098,7 +2098,7 @@
     height: 26px;
     padding: 0 10px;
     background: var(--accent-blue);
-    color: white;
+    color: var(--accent-blue-foreground);
     border-radius: var(--radius-sm);
     font-size: 12px;
     font-weight: 700;

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -983,7 +983,7 @@
     height: 11px;
     border-radius: 50%;
     background: var(--accent-amber);
-    color: white;
+    color: var(--accent-amber-foreground);
     font-size: 7px;
     font-weight: 700;
     display: flex;

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -23,7 +23,11 @@
   } from "../../api/generated/index";
   import { configureGeneratedClient } from "../../api/runtime.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
-  import { agentColor, agentLabel } from "../../utils/agents.js";
+  import {
+    agentColor,
+    agentForeground,
+    agentLabel,
+  } from "../../utils/agents.js";
   import { formatCost, formatTokenUsage } from "../../utils/format.js";
   import { normalizeMessagePreview } from "../../utils/messages.js";
   import { getGradeStyle, getGradeLabel } from "../../utils/grade.js";
@@ -549,6 +553,7 @@
       <span
         class="agent-badge"
         style:background={agentColor(session.agent)}
+        style:color={agentForeground(session.agent)}
       >{agentLabel(session.agent)}</span>
       {#if session.started_at}
         <span class="session-time">

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -281,6 +281,9 @@ describe("SessionBreadcrumb", () => {
     expect(badge?.getAttribute("style")).toContain(
       "var(--accent-blue)",
     );
+    expect(badge?.getAttribute("style")).toContain(
+      "var(--accent-blue-foreground)",
+    );
 
     unmount(component);
   });

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -263,6 +263,9 @@ describe("SessionBreadcrumb", () => {
     expect(badge?.getAttribute("style")).toContain(
       "var(--accent-rose)",
     );
+    expect(badge?.getAttribute("style")).toContain(
+      "var(--accent-rose-foreground)",
+    );
 
     unmount(component);
   });

--- a/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
@@ -198,7 +198,7 @@
     border-radius: var(--radius-sm);
     font-size: 12px;
     font-weight: 500;
-    color: white;
+    color: var(--accent-red-foreground);
     background: var(--accent-red, #d32f2f);
     border: none;
     cursor: pointer;

--- a/frontend/src/lib/components/pinned/PinnedPage.svelte
+++ b/frontend/src/lib/components/pinned/PinnedPage.svelte
@@ -223,7 +223,7 @@
 
   .pin-count {
     background: var(--accent-blue);
-    color: white;
+    color: var(--accent-blue-foreground);
     font-size: 11px;
     font-weight: 600;
     padding: 1px 7px;
@@ -301,6 +301,7 @@
 
   .role-badge.user {
     background: var(--accent-blue);
+    color: var(--accent-blue-foreground);
   }
 
   .pin-agent {

--- a/frontend/src/lib/components/pinned/PinnedPage.svelte
+++ b/frontend/src/lib/components/pinned/PinnedPage.svelte
@@ -293,7 +293,7 @@
     justify-content: center;
     font-size: 9px;
     font-weight: 700;
-    color: white;
+    color: var(--accent-purple-foreground);
     flex-shrink: 0;
     line-height: 1;
     background: var(--accent-purple);

--- a/frontend/src/lib/components/settings/AppearanceSettings.svelte
+++ b/frontend/src/lib/components/settings/AppearanceSettings.svelte
@@ -3,6 +3,7 @@
   import {
     ui,
     ALL_BLOCK_TYPES,
+    FONT_SCALE_STEPS,
     type BlockType,
     type MessageLayout,
   } from "../../stores/ui.svelte.js";
@@ -35,6 +36,13 @@
   </div>
 
   <div class="setting-row">
+    <span class="setting-label">High contrast</span>
+    <button class="setting-toggle" onclick={() => ui.toggleHighContrast()}>
+      {ui.highContrast ? "On" : "Off"}
+    </button>
+  </div>
+
+  <div class="setting-row">
     <span class="setting-label">Message layout</span>
     <div class="setting-options">
       {#each LAYOUT_OPTIONS as opt}
@@ -44,6 +52,21 @@
           onclick={() => ui.setLayout(opt.value)}
         >
           {opt.label}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div class="setting-row">
+    <span class="setting-label">Text size</span>
+    <div class="setting-options">
+      {#each FONT_SCALE_STEPS as step}
+        <button
+          class="option-btn"
+          class:active={ui.fontScale === step}
+          onclick={() => ui.setFontScale(step)}
+        >
+          {step}%
         </button>
       {/each}
     </div>

--- a/frontend/src/lib/components/settings/AppearanceSettings.test.ts
+++ b/frontend/src/lib/components/settings/AppearanceSettings.test.ts
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+
+import AppearanceSettings from "./AppearanceSettings.svelte";
+import { ui } from "../../stores/ui.svelte.js";
+
+describe("AppearanceSettings", () => {
+  afterEach(() => {
+    ui.setFontScale(100);
+    if (ui.highContrast) ui.toggleHighContrast();
+    cleanup();
+  });
+
+  it("renders five text-size options and marks the active scale", () => {
+    ui.setFontScale(110);
+    const { getByRole } = render(AppearanceSettings);
+    for (const pct of [90, 100, 110, 120, 130]) {
+      expect(getByRole("button", { name: `${pct}%` })).toBeTruthy();
+    }
+    expect(
+      getByRole("button", { name: "110%" }).classList.contains("active"),
+    ).toBe(true);
+  });
+
+  it("changes the font scale when an option is clicked", async () => {
+    const { getByRole } = render(AppearanceSettings);
+    await fireEvent.click(getByRole("button", { name: "120%" }));
+    expect(ui.fontScale).toBe(120);
+  });
+
+  it("toggles high contrast", async () => {
+    const { getByRole } = render(AppearanceSettings);
+    expect(ui.highContrast).toBe(false);
+    await fireEvent.click(getByRole("button", { name: "Off" }));
+    expect(ui.highContrast).toBe(true);
+  });
+});

--- a/frontend/src/lib/components/settings/GithubSettings.svelte
+++ b/frontend/src/lib/components/settings/GithubSettings.svelte
@@ -116,7 +116,7 @@
     border-radius: var(--radius-sm);
     font-size: 12px;
     font-weight: 500;
-    color: white;
+    color: var(--accent-blue-foreground);
     background: var(--accent-blue);
     border: none;
     cursor: pointer;

--- a/frontend/src/lib/components/settings/RemoteSettings.svelte
+++ b/frontend/src/lib/components/settings/RemoteSettings.svelte
@@ -256,7 +256,7 @@
 
   .toggle-btn.active {
     background: var(--accent-green, #22c55e);
-    color: white;
+    color: var(--accent-green-foreground);
     border-color: transparent;
   }
 
@@ -377,7 +377,7 @@
   }
 
   .disconnect-btn {
-    color: white;
+    color: var(--accent-red-foreground);
     background: var(--accent-red, #ef4444);
   }
 

--- a/frontend/src/lib/components/settings/RemoteSettings.svelte
+++ b/frontend/src/lib/components/settings/RemoteSettings.svelte
@@ -372,7 +372,7 @@
   }
 
   .connect-btn {
-    color: white;
+    color: var(--accent-blue-foreground);
     background: var(--accent-blue);
   }
 

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -251,7 +251,7 @@
     border-radius: var(--radius-sm);
     font-size: 13px;
     font-weight: 500;
-    color: white;
+    color: var(--accent-blue-foreground);
     background: var(--accent-blue);
     border: none;
     cursor: pointer;

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -184,7 +184,7 @@
     border-radius: var(--radius-sm);
     font-size: 12px;
     font-weight: 500;
-    color: white;
+    color: var(--accent-blue-foreground);
     background: var(--accent-blue);
     border: none;
     cursor: pointer;

--- a/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
+++ b/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
@@ -366,7 +366,7 @@
   .primary-btn {
     border-color: var(--accent-blue);
     background: var(--accent-blue);
-    color: white;
+    color: var(--accent-blue-foreground);
   }
 
   .danger {

--- a/frontend/src/lib/components/shared/RangePicker.svelte
+++ b/frontend/src/lib/components/shared/RangePicker.svelte
@@ -404,7 +404,7 @@
 
   .pill.active {
     background: var(--accent-blue);
-    color: #fff;
+    color: var(--accent-blue-foreground);
   }
 
   .stepper {

--- a/frontend/src/lib/components/trends/TrendsPage.svelte
+++ b/frontend/src/lib/components/trends/TrendsPage.svelte
@@ -449,7 +449,7 @@
   .primary {
     background: var(--accent-blue);
     border-color: var(--accent-blue);
-    color: white;
+    color: var(--accent-blue-foreground);
   }
 
   .primary:hover:not(:disabled) {

--- a/frontend/src/lib/components/usage/UsageSummaryCards.svelte
+++ b/frontend/src/lib/components/usage/UsageSummaryCards.svelte
@@ -254,6 +254,6 @@
 
   .retry-btn:hover {
     background: var(--accent-red);
-    color: #fff;
+    color: var(--accent-red-foreground);
   }
 </style>

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -75,6 +75,10 @@ const ZOOM_STEPS = [
   67, 75, 80, 90, 100, 110, 125, 150, 175, 200,
 ];
 const ZOOM_DEFAULT = 100;
+const FONT_SCALE_KEY = "agentsview-font-scale";
+const HIGH_CONTRAST_KEY = "agentsview-high-contrast";
+export const FONT_SCALE_STEPS = [90, 100, 110, 120, 130];
+const FONT_SCALE_DEFAULT = 100;
 
 function readStoredZoom(): number {
   if (!IS_DESKTOP) return ZOOM_DEFAULT;
@@ -89,6 +93,20 @@ function readStoredZoom(): number {
   }
   return ZOOM_DEFAULT;
 }
+
+function readStoredFontScale(): number {
+  try {
+    const raw = localStorage?.getItem(FONT_SCALE_KEY);
+    if (raw) {
+      const val = Number(raw);
+      if (FONT_SCALE_STEPS.includes(val)) return val;
+    }
+  } catch {
+    // ignore
+  }
+  return FONT_SCALE_DEFAULT;
+}
+
 const VALID_LAYOUTS: MessageLayout[] = [
   "default",
   "compact",
@@ -172,6 +190,10 @@ class UIStore {
   pendingScrollSession: string | null = $state(null);
 
   zoomLevel: number = $state(readStoredZoom());
+  fontScale: number = $state(readStoredFontScale());
+  highContrast: boolean = $state(
+    readStoredBool(HIGH_CONTRAST_KEY, false),
+  );
 
   sidebarOpen: boolean = $state(true);
   isMobileViewport: boolean = $state(false);
@@ -240,17 +262,52 @@ class UIStore {
         }
       });
 
+      // Apply the composed root zoom: font scale (web and desktop)
+      // multiplied by the desktop window zoom (desktop only). "zoom"
+      // is non-standard but supported in WebKit/Chromium.
       $effect(() => {
-        if (!IS_DESKTOP) return;
-        // "zoom" is non-standard but supported in WebKit/Chromium
+        const desktopZoom = IS_DESKTOP ? this.zoomLevel / 100 : 1;
+        const scale = this.fontScale / 100;
+        const effective =
+          Math.round(desktopZoom * scale * 10000) / 10000;
         (
           document.documentElement.style as unknown as
             Record<string, string>
-        ).zoom = String(this.zoomLevel / 100);
+        ).zoom = String(effective);
+      });
+
+      // Persist the desktop window zoom (desktop only).
+      $effect(() => {
+        if (!IS_DESKTOP) return;
+        try {
+          localStorage?.setItem(ZOOM_KEY, String(this.zoomLevel));
+        } catch {
+          // ignore
+        }
+      });
+
+      // Persist the font scale (web and desktop).
+      $effect(() => {
         try {
           localStorage?.setItem(
-            ZOOM_KEY,
-            String(this.zoomLevel),
+            FONT_SCALE_KEY,
+            String(this.fontScale),
+          );
+        } catch {
+          // ignore
+        }
+      });
+
+      // Apply and persist high contrast.
+      $effect(() => {
+        document.documentElement.classList.toggle(
+          "high-contrast",
+          this.highContrast,
+        );
+        try {
+          localStorage?.setItem(
+            HIGH_CONTRAST_KEY,
+            String(this.highContrast),
           );
         } catch {
           // ignore
@@ -448,6 +505,16 @@ class UIStore {
 
   resetZoom() {
     this.zoomLevel = ZOOM_DEFAULT;
+  }
+
+  setFontScale(scale: number) {
+    if (FONT_SCALE_STEPS.includes(scale)) {
+      this.fontScale = scale;
+    }
+  }
+
+  toggleHighContrast() {
+    this.highContrast = !this.highContrast;
   }
 
   toggleSidebar() {

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -719,4 +719,183 @@ describe("UIStore", () => {
       }
     });
   });
+
+  describe("fontScale", () => {
+    beforeEach(() => {
+      ui.setFontScale(100);
+    });
+
+    it("defaults to 100", () => {
+      expect(ui.fontScale).toBe(100);
+    });
+
+    it("sets a valid step", () => {
+      ui.setFontScale(130);
+      expect(ui.fontScale).toBe(130);
+    });
+
+    it("ignores values outside the allowed steps", () => {
+      ui.setFontScale(120);
+      ui.setFontScale(145);
+      expect(ui.fontScale).toBe(120);
+      ui.setFontScale(0);
+      expect(ui.fontScale).toBe(120);
+    });
+
+    it("applies font scale as root zoom on web", async () => {
+      const original = globalThis.localStorage;
+      Object.defineProperty(globalThis, "localStorage", {
+        value: { getItem: vi.fn(() => null), setItem: vi.fn() },
+        writable: true,
+        configurable: true,
+      });
+      try {
+        // @ts-expect-error -- query string busts module cache
+        const mod = await import("./ui.svelte.js?webFontScale");
+        mod.ui.setFontScale(110);
+        await tick();
+        expect(
+          document.documentElement.style.getPropertyValue("zoom"),
+        ).toBe("1.1");
+      } finally {
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+
+    it("composes desktop window zoom with font scale", async () => {
+      const original = globalThis.localStorage;
+      Object.defineProperty(globalThis, "localStorage", {
+        value: { getItem: vi.fn(() => null), setItem: vi.fn() },
+        writable: true,
+        configurable: true,
+      });
+      window.history.replaceState({}, "", "/?desktop");
+      try {
+        // @ts-expect-error -- query string busts module cache
+        const mod = await import("./ui.svelte.js?desktopCompose");
+        mod.ui.zoomLevel = 200;
+        mod.ui.setFontScale(110);
+        await tick();
+        expect(
+          document.documentElement.style.getPropertyValue("zoom"),
+        ).toBe("2.2");
+      } finally {
+        window.history.replaceState({}, "", "/");
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+
+    it("persists font scale changes", async () => {
+      const original = globalThis.localStorage;
+      const setItem = vi.fn();
+      Object.defineProperty(globalThis, "localStorage", {
+        value: { getItem: vi.fn(() => null), setItem },
+        writable: true,
+        configurable: true,
+      });
+      try {
+        // @ts-expect-error -- query string busts module cache
+        const mod = await import("./ui.svelte.js?persistFontScale");
+        setItem.mockClear();
+        mod.ui.setFontScale(120);
+        await tick();
+        expect(setItem).toHaveBeenCalledWith(
+          "agentsview-font-scale",
+          "120",
+        );
+      } finally {
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+
+    it("falls back to 100 for an invalid stored font scale", async () => {
+      const original = globalThis.localStorage;
+      Object.defineProperty(globalThis, "localStorage", {
+        value: {
+          getItem: vi.fn((key: string) =>
+            key === "agentsview-font-scale" ? "145" : null,
+          ),
+          setItem: vi.fn(),
+        },
+        writable: true,
+        configurable: true,
+      });
+      try {
+        // @ts-expect-error -- query string busts module cache
+        const mod = await import("./ui.svelte.js?badFontScale");
+        expect(mod.ui.fontScale).toBe(100);
+      } finally {
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+  });
+
+  describe("highContrast", () => {
+    beforeEach(() => {
+      if (ui.highContrast) ui.toggleHighContrast();
+    });
+
+    it("defaults to false", () => {
+      expect(ui.highContrast).toBe(false);
+    });
+
+    it("toggles the value", () => {
+      ui.toggleHighContrast();
+      expect(ui.highContrast).toBe(true);
+      ui.toggleHighContrast();
+      expect(ui.highContrast).toBe(false);
+    });
+
+    it("toggles the root class and persists", async () => {
+      const original = globalThis.localStorage;
+      const setItem = vi.fn();
+      Object.defineProperty(globalThis, "localStorage", {
+        value: { getItem: vi.fn(() => null), setItem },
+        writable: true,
+        configurable: true,
+      });
+      try {
+        // @ts-expect-error -- query string busts module cache
+        const mod = await import("./ui.svelte.js?highContrastToggle");
+        setItem.mockClear();
+        mod.ui.toggleHighContrast();
+        await tick();
+        expect(
+          document.documentElement.classList.contains("high-contrast"),
+        ).toBe(true);
+        expect(setItem).toHaveBeenCalledWith(
+          "agentsview-high-contrast",
+          "true",
+        );
+        mod.ui.toggleHighContrast();
+        await tick();
+        expect(
+          document.documentElement.classList.contains("high-contrast"),
+        ).toBe(false);
+      } finally {
+        document.documentElement.classList.remove("high-contrast");
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+  });
 });

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -121,13 +121,15 @@ describe("agentColor", () => {
 });
 
 describe("agentForeground", () => {
-  it("uses the accent foreground for blue-filled agents", () => {
-    expect(agentForeground("claude")).toBe(
-      "var(--accent-blue-foreground)",
-    );
-    expect(agentForeground("visualstudio-copilot")).toBe(
-      "var(--accent-blue-foreground)",
-    );
+  it("returns the matching foreground token for every known agent fill", () => {
+    for (const agent of KNOWN_AGENTS) {
+      const color = agentColor(agent.name);
+      const token = color.match(/^var\(--accent-([a-z]+)\)$/)?.[1];
+      expect(token, `${agent.name} color token`).toBeTruthy();
+      expect(agentForeground(agent.name)).toBe(
+        `var(--accent-${token}-foreground)`,
+      );
+    }
   });
 
   it("uses the accent foreground for unknown fallback agents", () => {
@@ -137,8 +139,11 @@ describe("agentForeground", () => {
     expect(agentForeground("")).toBe("var(--accent-blue-foreground)");
   });
 
-  it("keeps white foregrounds for non-blue agent fills", () => {
-    expect(agentForeground("codex")).toBe("#ffffff");
+  it("uses non-blue accent foregrounds for non-blue agent fills", () => {
+    expect(agentForeground("codex")).toBe("var(--accent-green-foreground)");
+    expect(agentForeground("opencode")).toBe(
+      "var(--accent-purple-foreground)",
+    );
   });
 });
 

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vite-plus/test";
 import {
   KNOWN_AGENTS,
   agentColor,
+  agentForeground,
   agentLabel,
 } from "./agents.js";
 
@@ -116,6 +117,28 @@ describe("agentColor", () => {
       "var(--accent-blue)",
     );
     expect(agentColor("")).toBe("var(--accent-blue)");
+  });
+});
+
+describe("agentForeground", () => {
+  it("uses the accent foreground for blue-filled agents", () => {
+    expect(agentForeground("claude")).toBe(
+      "var(--accent-blue-foreground)",
+    );
+    expect(agentForeground("visualstudio-copilot")).toBe(
+      "var(--accent-blue-foreground)",
+    );
+  });
+
+  it("uses the accent foreground for unknown fallback agents", () => {
+    expect(agentForeground("unknown")).toBe(
+      "var(--accent-blue-foreground)",
+    );
+    expect(agentForeground("")).toBe("var(--accent-blue-foreground)");
+  });
+
+  it("keeps white foregrounds for non-blue agent fills", () => {
+    expect(agentForeground("codex")).toBe("#ffffff");
   });
 });
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -70,18 +70,36 @@ const agentColorMap = new Map(
   KNOWN_AGENTS.map((a) => [a.name, a.color]),
 );
 
-const blueFillColor = "var(--accent-blue)";
-const blueFillForeground = "var(--accent-blue-foreground)";
-const defaultFillForeground = "#ffffff";
+const defaultFillColor = "var(--accent-blue)";
+const accentForegroundMap = new Map([
+  ["var(--accent-blue)", "var(--accent-blue-foreground)"],
+  ["var(--accent-rose)", "var(--accent-rose-foreground)"],
+  ["var(--accent-purple)", "var(--accent-purple-foreground)"],
+  ["var(--accent-amber)", "var(--accent-amber-foreground)"],
+  ["var(--accent-green)", "var(--accent-green-foreground)"],
+  ["var(--accent-coral)", "var(--accent-coral-foreground)"],
+  ["var(--accent-black)", "var(--accent-black-foreground)"],
+  ["var(--accent-teal)", "var(--accent-teal-foreground)"],
+  ["var(--accent-red)", "var(--accent-red-foreground)"],
+  ["var(--accent-indigo)", "var(--accent-indigo-foreground)"],
+  ["var(--accent-orange)", "var(--accent-orange-foreground)"],
+  ["var(--accent-sky)", "var(--accent-sky-foreground)"],
+  ["var(--accent-pink)", "var(--accent-pink-foreground)"],
+  ["var(--accent-lime)", "var(--accent-lime-foreground)"],
+  ["var(--accent-cyan)", "var(--accent-cyan-foreground)"],
+  ["var(--accent-violet)", "var(--accent-violet-foreground)"],
+]);
 
 export function agentColor(agent: string): string {
-  return agentColorMap.get(agent) ?? blueFillColor;
+  return agentColorMap.get(agent) ?? defaultFillColor;
+}
+
+export function accentForeground(color: string): string {
+  return accentForegroundMap.get(color) ?? "var(--accent-blue-foreground)";
 }
 
 export function agentForeground(agent: string): string {
-  return agentColor(agent) === blueFillColor
-    ? blueFillForeground
-    : defaultFillForeground;
+  return accentForeground(agentColor(agent));
 }
 
 export function agentLabel(agent: string): string {

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -70,8 +70,18 @@ const agentColorMap = new Map(
   KNOWN_AGENTS.map((a) => [a.name, a.color]),
 );
 
+const blueFillColor = "var(--accent-blue)";
+const blueFillForeground = "var(--accent-blue-foreground)";
+const defaultFillForeground = "#ffffff";
+
 export function agentColor(agent: string): string {
-  return agentColorMap.get(agent) ?? "var(--accent-blue)";
+  return agentColorMap.get(agent) ?? blueFillColor;
+}
+
+export function agentForeground(agent: string): string {
+  return agentColor(agent) === blueFillColor
+    ? blueFillForeground
+    : defaultFillForeground;
 }
 
 export function agentLabel(agent: string): string {


### PR DESCRIPTION
Adds two Settings -> Appearance accessibility controls, both persisted in localStorage. Frontend-only.

## Text size (90-130%)

A uniform UI scale that reuses the existing root-zoom mechanism: one effect sets `document.documentElement.style.zoom` to the font scale composed with the desktop window zoom -- `(IS_DESKTOP ? zoomLevel/100 : 1) * (fontScale/100)`, rounded to 4 decimals. On the web only the font scale applies; on desktop the two multiply. `agentsview-font-scale` persists everywhere; the desktop `agentsview-zoom-level` stays desktop-only.

## High contrast

A `high-contrast` root class (composing with light/dark) drives `:root.high-contrast` and `:root.dark.high-contrast` overrides of the neutral text/border tokens and `--accent-blue`, plus a strengthened focus ring. Every overridden token clears WCAG AA against the real backgrounds. The shell and the token-driven majority of the transcript are covered by the token overrides; the three literal-colored transcript components (CallGroup, SubagentCalls, CallRow) get colocated `:global(.high-contrast)` overrides. Data-visualization palettes and category identity colors (`--cat-*`) are left unchanged so their encoded meaning is preserved.

## Where to look

- `frontend/src/lib/stores/ui.svelte.ts` -- state, setters, the composed-zoom and high-contrast effects, and the persistence split.
- `frontend/src/app.css` -- high-contrast token overrides and focus ring.
- `frontend/src/lib/components/settings/AppearanceSettings.svelte` -- the controls.

## Note

This branch and #821 both edit `ui.svelte.ts` in adjacent regions; whichever merges second may need a small conflict resolution.