### PR TITLE
feat: batch select and delete sessions in sidebar

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -551,7 +551,7 @@
         if (!last) return;
         btn.disabled = true;
         try {
-          await sessions.restoreSession(last.id);
+          await sessions.restoreRecentlyDeleted(last);
         } catch {
           // restore failed — toast will remain
         } finally {

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -141,4 +141,16 @@ describe("App session URL date state", () => {
       "if (currentUrlSessionId === null) {\n          lastDetailFilterParamsSignature = null;",
     );
   });
+
+  it("restores the full recently deleted batch from the undo toast", () => {
+    const undoBlock = appSourceSlice(
+      "{#if sessions.recentlyDeleted.length > 0}",
+      "\n  </div>\n{/if}",
+    );
+
+    expect(undoBlock).toContain(
+      "await sessions.restoreRecentlyDeleted(last);",
+    );
+    expect(undoBlock).not.toContain("await sessions.restoreSession(last.id);");
+  });
 });

--- a/frontend/src/lib/api/generated/models/BatchDeleteInputBody.ts
+++ b/frontend/src/lib/api/generated/models/BatchDeleteInputBody.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type BatchDeleteInputBody = {
+  /**
+   * Session IDs to soft-delete
+   */
+  session_ids: Array<string>;
+};

--- a/frontend/src/lib/api/generated/services/SessionsService.ts
+++ b/frontend/src/lib/api/generated/services/SessionsService.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { BatchDeleteInputBody } from '../models/BatchDeleteInputBody';
 import type { DbSession } from '../models/DbSession';
 import type { DbSessionActivityResponse } from '../models/DbSessionActivityResponse';
 import type { DbSessionTiming } from '../models/DbSessionTiming';
@@ -1179,6 +1180,36 @@ export class SessionsService {
         403: `Forbidden`,
         404: `Not Found`,
         409: `Conflict`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
+  /**
+   * Batch delete sessions
+   * @returns void
+   * @throws ApiError
+   */
+  public static postApiV1SessionsBatchDelete({
+    requestBody,
+  }: {
+    requestBody: BatchDeleteInputBody,
+  }): CancelablePromise<void> {
+    return __request(OpenAPI, {
+      method: 'POST',
+      url: '/api/v1/sessions/batch-delete',
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
         500: `Internal Server Error`,
         501: `Not Implemented`,
         502: `Bad Gateway`,

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -49,6 +49,10 @@
     hasSubagents?: boolean;
     /** Whether the group contains teammate children. */
     hasTeammates?: boolean;
+    /** Whether multi-select mode is active in the sidebar. */
+    selectMode?: boolean;
+    /** Whether this item is currently selected in multi-select mode. */
+    selected?: boolean;
   }
 
   let {
@@ -65,6 +69,8 @@
     isLastChild = false,
     hasSubagents = false,
     hasTeammates = false,
+    selectMode = false,
+    selected = false,
   }: Props = $props();
 
   let isActive = $derived.by(() => {
@@ -253,7 +259,17 @@
     if (target.closest("a, button, input")) {
       return;
     }
-    sessions.selectSession(session.id);
+    if (selectMode) {
+      sessions.toggleSelection(session.id);
+    } else {
+      sessions.selectSession(session.id);
+    }
+  }
+
+  function handleSelectClick(e: MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    sessions.toggleSelection(session.id);
   }
 
   $effect(() => {
@@ -306,7 +322,11 @@
     }
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      sessions.selectSession(session.id);
+      if (selectMode) {
+        sessions.toggleSelection(session.id);
+      } else {
+        sessions.selectSession(session.id);
+      }
     }
   }}
   oncontextmenu={handleContextMenu}
@@ -330,6 +350,23 @@
     <span class="tree-dash"></span>
   {:else}
     <span class="tree-spacer"></span>
+  {/if}
+
+  {#if selectMode}
+    <button
+      type="button"
+      class="select-checkbox"
+      class:checked={selected}
+      onclick={handleSelectClick}
+      tabindex="-1"
+      aria-label={selected ? "Deselect session" : "Select session"}
+    >
+      {#if selected}
+        <svg width="10" height="10" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+          <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      {/if}
+    </button>
   {/if}
 
   <StatusDot {session} {groupSessions} size={6} />
@@ -744,5 +781,29 @@
 
   :global(.context-menu .context-menu-item.danger:hover) {
     background: color-mix(in srgb, var(--accent-red, #e55) 10%, transparent);
+  }
+
+  .select-checkbox {
+    all: unset;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    border: 1.5px solid var(--border-default);
+    border-radius: 3px;
+    cursor: pointer;
+    color: white;
+    transition: background 0.1s, border-color 0.1s;
+  }
+
+  .select-checkbox:hover {
+    border-color: var(--accent-blue);
+  }
+
+  .select-checkbox.checked {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
   }
 </style>

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -239,7 +239,11 @@
       return;
     }
     e.preventDefault();
-    sessions.selectSession(session.id);
+    if (selectMode) {
+      sessions.toggleSelection(session.id);
+    } else {
+      sessions.selectSession(session.id);
+    }
   }
 
   function handleRowClick(e: MouseEvent) {

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -12,6 +12,7 @@
     UserRoundIcon,
     UsersRoundIcon,
   } from "../../icons.js";
+  import { TrashIcon, CheckIcon } from "../../icons.js";
   import { formatNumber } from "../../utils/format.js";
   import { agentColor } from "../../utils/agents.js";
   import {
@@ -313,6 +314,39 @@
     }
   });
 
+  let batchDeleting = $state(false);
+
+  let allVisibleSessionIds = $derived(
+    groups.flatMap((g) => g.sessions.map((s) => s.id)),
+  );
+
+  let allSelected = $derived(
+    allVisibleSessionIds.length > 0 &&
+    allVisibleSessionIds.every((id) => sessions.selectedIds.has(id)),
+  );
+
+  async function handleBatchDelete() {
+    if (batchDeleting) return;
+    const ids = [...sessions.selectedIds];
+    if (ids.length === 0) return;
+    batchDeleting = true;
+    try {
+      await sessions.batchDeleteSessions(ids);
+    } catch {
+      // silently fail
+    } finally {
+      batchDeleting = false;
+    }
+  }
+
+  function handleSelectAllVisible() {
+    if (allSelected) {
+      sessions.clearSelection();
+    } else {
+      sessions.selectAll(allVisibleSessionIds);
+    }
+  }
+
   function handleScroll() {
     if (!containerRef) return;
     if (scrollRaf !== null) return;
@@ -428,6 +462,15 @@
     {#if sessions.loading}
       <span class="loading-indicator">{m.sidebar_loading()}</span>
     {/if}
+    <button
+      class="select-toggle-btn"
+      class:active={sessions.selectMode}
+      onclick={() => sessions.toggleSelectMode()}
+      title={sessions.selectMode ? "Exit multi-select" : "Multi-select"}
+      aria-label={sessions.selectMode ? "Exit multi-select" : "Multi-select"}
+    >
+      <CheckIcon size="12" strokeWidth="2" aria-hidden="true" />
+    </button>
     <SessionFilterControl
       {groupMode}
       onToggleGroupByAgent={toggleGroupByAgent}
@@ -470,6 +513,37 @@
     {/snippet}
   </div>
 </div>
+
+{#if sessions.selectMode}
+  <div class="batch-toolbar">
+    <button
+      class="batch-select-all-btn"
+      onclick={handleSelectAllVisible}
+      title={allSelected ? "Clear selection" : "Select all visible"}
+    >
+      {allSelected ? "Clear" : "All"}
+    </button>
+    <span class="batch-count">
+      {sessions.selectedIds.size} selected
+    </span>
+    <button
+      class="batch-delete-btn"
+      onclick={handleBatchDelete}
+      disabled={sessions.selectedIds.size === 0 || batchDeleting}
+      title="Move selected sessions to trash"
+    >
+      <TrashIcon size="11" strokeWidth="2" aria-hidden="true" />
+      {batchDeleting ? "Deleting..." : "Delete"}
+    </button>
+    <button
+      class="batch-cancel-btn"
+      onclick={() => sessions.toggleSelectMode()}
+      title="Exit multi-select"
+    >
+      Cancel
+    </button>
+  </div>
+{/if}
 
 <div
   class="session-list-scroll"
@@ -553,6 +627,8 @@
             compact
             depth={item.depth ?? 1}
             isLastChild={item.isLastChild ?? false}
+            selectMode={sessions.selectMode}
+            selected={sessions.selectedIds.has(item.session.id)}
           />
         {:else if item.group}
           {@const primary = item.group.sessions.find(
@@ -580,6 +656,8 @@
               depth={0}
               hasSubagents={groupHasSubagents}
               hasTeammates={groupHasTeammates}
+              selectMode={sessions.selectMode}
+              selected={primary ? sessions.selectedIds.has(primary.id) : false}
             />
           {/if}
         {/if}
@@ -815,6 +893,101 @@
     font-size: 9px;
     color: var(--text-muted);
     font-weight: 500;
+  }
+
+  .select-toggle-btn {
+    all: unset;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.1s, background 0.1s;
+  }
+
+  .select-toggle-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-secondary);
+  }
+
+  .select-toggle-btn.active {
+    color: var(--accent-blue);
+    background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
+  }
+
+  .batch-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 10px;
+    border-bottom: 1px solid var(--border-muted);
+    background: color-mix(in srgb, var(--accent-blue) 5%, var(--bg-inset));
+    flex-shrink: 0;
+  }
+
+  .batch-select-all-btn {
+    all: unset;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  .batch-select-all-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .batch-count {
+    flex: 1;
+    font-size: 10px;
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .batch-delete-btn {
+    all: unset;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    font-weight: 600;
+    color: white;
+    background: var(--accent-red, #d32f2f);
+    padding: 3px 8px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+
+  .batch-delete-btn:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .batch-delete-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .batch-cancel-btn {
+    all: unset;
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+  }
+
+  .batch-cancel-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
   }
 
 </style>

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -332,10 +332,13 @@
     allVisibleSessionIds.length > 0 &&
     allVisibleSessionIds.every((id) => sessions.selectedIds.has(id)),
   );
+  let visibleSelectedSessionIds = $derived(
+    allVisibleSessionIds.filter((id) => sessions.selectedIds.has(id)),
+  );
 
   async function handleBatchDelete() {
     if (batchDeleting) return;
-    const ids = [...sessions.selectedIds];
+    const ids = visibleSelectedSessionIds;
     if (ids.length === 0) return;
     batchDeleting = true;
     try {
@@ -532,12 +535,12 @@
       {allSelected ? "Clear" : "All"}
     </button>
     <span class="batch-count">
-      {sessions.selectedIds.size} selected
+      {visibleSelectedSessionIds.length} selected
     </span>
     <button
       class="batch-delete-btn"
       onclick={handleBatchDelete}
-      disabled={sessions.selectedIds.size === 0 || batchDeleting}
+      disabled={visibleSelectedSessionIds.length === 0 || batchDeleting}
       title="Move selected sessions to trash"
     >
       <TrashIcon size="11" strokeWidth="2" aria-hidden="true" />
@@ -967,7 +970,7 @@
     gap: 4px;
     font-size: 10px;
     font-weight: 600;
-    color: white;
+    color: var(--bg-surface);
     background: var(--accent-red, #d32f2f);
     padding: 3px 8px;
     border-radius: var(--radius-sm);

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -316,9 +316,17 @@
 
   let batchDeleting = $state(false);
 
-  let allVisibleSessionIds = $derived(
-    groups.flatMap((g) => g.sessions.map((s) => s.id)),
-  );
+  let allVisibleSessionIds = $derived.by(() => {
+    const ids: string[] = [];
+    const seen = new Set<string>();
+    for (const item of renderDisplayItems) {
+      const session = sessionForItem(item);
+      if (!session || seen.has(session.id)) continue;
+      seen.add(session.id);
+      ids.push(session.id);
+    }
+    return ids;
+  });
 
   let allSelected = $derived(
     allVisibleSessionIds.length > 0 &&

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -81,6 +81,8 @@ describe("SessionList filter dropdown", () => {
     sessions.activeSessionId = null;
     sessions.nextCursor = null;
     sessions.loading = false;
+    sessions.selectedIds = new Set();
+    sessions.selectMode = false;
     sessions.sidebarIndexVersion++;
     sessions.hydratedSessionsByVersion = new Map([
       [sessions.sidebarIndexVersion, new Map()],
@@ -225,6 +227,8 @@ describe("SessionList visible hydration", () => {
     sessions.activeSessionId = null;
     sessions.nextCursor = null;
     sessions.loading = false;
+    sessions.selectedIds = new Set();
+    sessions.selectMode = false;
     sessions.sidebarIndexVersion++;
     sessions.hydratedSessionsByVersion = new Map([
       [sessions.sidebarIndexVersion, new Map()],
@@ -645,6 +649,53 @@ describe("SessionList visible hydration", () => {
     await tick();
 
     expect(document.querySelectorAll(".group-hint-icon")).toHaveLength(1);
+  });
+
+  it("selects only rendered session rows when selecting all visible", async () => {
+    sessions.sessions = [
+      makeSession({
+        id: "parent",
+        display_name: "Parent session",
+        started_at: "2024-01-01T00:00:00Z",
+        ended_at: "2024-01-01T00:01:00Z",
+        is_index_only: false,
+      }),
+      makeSession({
+        id: "child",
+        parent_session_id: "parent",
+        display_name: "Visible continuation",
+        started_at: "2024-01-01T00:02:00Z",
+        ended_at: "2024-01-01T00:03:00Z",
+        is_index_only: false,
+      }),
+    ];
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    expect(
+      document.querySelector<HTMLElement>('[data-session-id="child"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector<HTMLElement>('[data-session-id="parent"]'),
+    ).toBeNull();
+
+    const selectModeButton = document.querySelector<HTMLButtonElement>(
+      ".select-toggle-btn",
+    );
+    expect(selectModeButton).not.toBeNull();
+    selectModeButton!.click();
+    await tick();
+
+    const selectAllButton = document.querySelector<HTMLButtonElement>(
+      ".batch-select-all-btn",
+    );
+    expect(selectAllButton).not.toBeNull();
+    selectAllButton!.click();
+    await tick();
+
+    expect([...sessions.selectedIds]).toEqual(["child"]);
   });
 
   it("does not auto-page when saved grouping starts collapsed", async () => {

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -738,6 +738,58 @@ describe("SessionList visible hydration", () => {
     expect([...sessions.selectedIds]).toEqual(["child"]);
   });
 
+  it("deletes only selected rows that are still rendered", async () => {
+    sessions.sessions = [
+      makeSession({
+        id: "visible",
+        display_name: "Visible session",
+        is_index_only: false,
+      }),
+      makeSession({
+        id: "hidden",
+        display_name: "Hidden session",
+        is_index_only: false,
+      }),
+    ];
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
+    const batchDelete = vi
+      .spyOn(sessions, "batchDeleteSessions")
+      .mockResolvedValue(undefined);
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    const selectModeButton = document.querySelector<HTMLButtonElement>(
+      ".select-toggle-btn",
+    );
+    expect(selectModeButton).not.toBeNull();
+    selectModeButton!.click();
+    await tick();
+
+    const selectAllButton = document.querySelector<HTMLButtonElement>(
+      ".batch-select-all-btn",
+    );
+    expect(selectAllButton).not.toBeNull();
+    selectAllButton!.click();
+    await tick();
+    expect([...sessions.selectedIds]).toEqual(["visible", "hidden"]);
+
+    sessions.sessions = sessions.sessions.filter((s) => s.id !== "hidden");
+    await tick();
+
+    expect(document.querySelector('[data-session-id="hidden"]')).toBeNull();
+    expect(document.body.textContent).toContain("1 selected");
+
+    const deleteButton = document.querySelector<HTMLButtonElement>(
+      ".batch-delete-btn",
+    );
+    expect(deleteButton).not.toBeNull();
+    deleteButton!.click();
+    await tick();
+
+    expect(batchDelete).toHaveBeenCalledWith(["visible"]);
+  });
+
   it("does not auto-page when saved grouping starts collapsed", async () => {
     localStorage.setItem(STORAGE_KEY_GROUP, "agent");
     sessions.sessions = Array.from({ length: 30 }, (_, i) =>

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -538,6 +538,46 @@ describe("SessionList visible hydration", () => {
     expect(selectSession).toHaveBeenCalledWith("keyboard-session");
   });
 
+  it("toggles selection from the session link in select mode", async () => {
+    const selectSession = vi
+      .spyOn(sessions, "selectSession")
+      .mockImplementation(() => {});
+    sessions.sessions = [
+      makeSession({
+        id: "link-select-session",
+        display_name: "Link selection target",
+        is_index_only: false,
+      }),
+    ];
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(
+      undefined,
+    );
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    const selectModeButton = document.querySelector<HTMLButtonElement>(
+      ".select-toggle-btn",
+    );
+    expect(selectModeButton).not.toBeNull();
+    selectModeButton!.click();
+    await tick();
+
+    const link = document.querySelector<HTMLAnchorElement>(
+      ".session-info-link",
+    );
+    expect(link).not.toBeNull();
+    const click = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    link!.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(selectSession).not.toHaveBeenCalled();
+    expect([...sessions.selectedIds]).toEqual(["link-select-session"]);
+  });
+
   it("keeps the non-link parts of the row selectable", async () => {
     const selectSession = vi
       .spyOn(sessions, "selectSession")

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1138,12 +1138,21 @@ class SessionsStore {
     const ids = [...deleted.ids];
     if (ids.length === 0) return;
     configureGeneratedClient();
+    const failed: string[] = [];
     for (const id of ids) {
-      await SessionsService.postApiV1SessionsIdRestore({ id });
+      try {
+        await SessionsService.postApiV1SessionsIdRestore({ id });
+      } catch {
+        failed.push(id);
+      }
     }
-    this.clearRecentlyDeletedBatch(deleted);
+    this.updateRecentlyDeletedBatch(deleted, failed);
     this.invalidateFilterCaches();
     await this.load();
+    if (failed.length > 0) {
+      const noun = failed.length === 1 ? "session" : "sessions";
+      throw new Error(`Failed to restore ${failed.length} ${noun}`);
+    }
   }
 
   private get metadataParams(): MetadataParams {
@@ -1172,12 +1181,14 @@ class SessionsStore {
   /** Remove one or all entries from the undo toast list. */
   clearRecentlyDeleted(id?: string) {
     if (id) {
-      this.recentlyDeleted = this.recentlyDeleted.filter((d) => {
-        if (d.ids.includes(id)) {
+      this.recentlyDeleted = this.recentlyDeleted.flatMap((d) => {
+        if (!d.ids.includes(id)) return [d];
+        const ids = d.ids.filter((deletedId) => deletedId !== id);
+        if (ids.length === 0) {
           clearTimeout(d.timer);
-          return false;
+          return [];
         }
-        return true;
+        return [{ ...d, ids }];
       });
     } else {
       for (const d of this.recentlyDeleted) clearTimeout(d.timer);
@@ -1185,11 +1196,18 @@ class SessionsStore {
     }
   }
 
-  private clearRecentlyDeletedBatch(deleted: RecentlyDeletedSessions) {
-    clearTimeout(deleted.timer);
-    this.recentlyDeleted = this.recentlyDeleted.filter(
-      (d) => d.key !== deleted.key,
-    );
+  private updateRecentlyDeletedBatch(
+    deleted: RecentlyDeletedSessions,
+    ids: string[],
+  ) {
+    this.recentlyDeleted = this.recentlyDeleted.flatMap((d) => {
+      if (d.key !== deleted.key) return [d];
+      if (ids.length === 0) {
+        clearTimeout(d.timer);
+        return [];
+      }
+      return [{ ...d, ids: [...ids] }];
+    });
   }
 
   async renameSession(id: string, displayName: string | null) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -28,6 +28,9 @@ type MetadataParams = Parameters<
 type ClearSessionFiltersOptions = {
   clearDateYoke?: boolean;
 };
+type LoadOptions = {
+  force?: boolean;
+};
 
 const SESSION_PAGE_SIZE = 500;
 const SIDEBAR_HYDRATION_CONCURRENCY = 6;
@@ -355,7 +358,7 @@ class SessionsStore {
     this.setActiveSession(null);
   }
 
-  async load() {
+  async load(options: LoadOptions = {}) {
     saveFilters(this.filters);
 
     const params = {
@@ -364,6 +367,7 @@ class SessionsStore {
     };
     const signature = JSON.stringify(params);
     if (
+      !options.force &&
       this.sidebarLoadPromise !== null &&
       this.sidebarLoadSignature === signature
     ) {
@@ -1123,7 +1127,7 @@ class SessionsStore {
     this.selectedIds = new Set();
     this.selectMode = false;
     this.invalidateFilterCaches();
-    await this.load();
+    await this.load({ force: true });
   }
 
   async restoreSession(id: string) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -68,6 +68,12 @@ export interface SessionGroup {
   endedAt: string | null;
 }
 
+export interface RecentlyDeletedSessions {
+  key: number;
+  ids: string[];
+  timer: ReturnType<typeof setTimeout>;
+}
+
 export interface Filters {
   project: string;
   machine: string;
@@ -1035,9 +1041,23 @@ class SessionsStore {
     this.load();
   }
 
-  /** Recently deleted session IDs for undo toast. */
-  recentlyDeleted: { id: string; timer: ReturnType<typeof setTimeout> }[] =
-    $state([]);
+  /** Recently deleted session batches for undo toast. */
+  recentlyDeleted: RecentlyDeletedSessions[] = $state([]);
+  private recentlyDeletedNextKey = 0;
+
+  private addRecentlyDeleted(ids: string[]) {
+    if (ids.length === 0) return;
+    const key = this.recentlyDeletedNextKey++;
+    const timer = setTimeout(() => {
+      this.recentlyDeleted = this.recentlyDeleted.filter(
+        (d) => d.key !== key,
+      );
+    }, 10_000);
+    this.recentlyDeleted = [
+      ...this.recentlyDeleted,
+      { key, ids: [...ids], timer },
+    ];
+  }
 
   /** Multi-select state for batch operations. */
   selectedIds: Set<string> = $state(new Set());
@@ -1080,12 +1100,7 @@ class SessionsStore {
     if (this.activeSessionId === id) {
       this.setActiveSession(null);
     }
-    const timer = setTimeout(() => {
-      this.recentlyDeleted = this.recentlyDeleted.filter(
-        (d) => d.id !== id,
-      );
-    }, 10_000);
-    this.recentlyDeleted = [...this.recentlyDeleted, { id, timer }];
+    this.addRecentlyDeleted([id]);
     this.invalidateFilterCaches();
   }
 
@@ -1105,14 +1120,7 @@ class SessionsStore {
     if (this.activeSessionId && idSet.has(this.activeSessionId)) {
       this.setActiveSession(null);
     }
-    for (const id of ids) {
-      const timer = setTimeout(() => {
-        this.recentlyDeleted = this.recentlyDeleted.filter(
-          (d) => d.id !== id,
-        );
-      }, 10_000);
-      this.recentlyDeleted = [...this.recentlyDeleted, { id, timer }];
-    }
+    this.addRecentlyDeleted(ids);
     this.selectedIds = new Set();
     this.selectMode = false;
     this.invalidateFilterCaches();
@@ -1122,6 +1130,18 @@ class SessionsStore {
     configureGeneratedClient();
     await SessionsService.postApiV1SessionsIdRestore({ id });
     this.clearRecentlyDeleted(id);
+    this.invalidateFilterCaches();
+    await this.load();
+  }
+
+  async restoreRecentlyDeleted(deleted: RecentlyDeletedSessions) {
+    const ids = [...deleted.ids];
+    if (ids.length === 0) return;
+    configureGeneratedClient();
+    for (const id of ids) {
+      await SessionsService.postApiV1SessionsIdRestore({ id });
+    }
+    this.clearRecentlyDeletedBatch(deleted);
     this.invalidateFilterCaches();
     await this.load();
   }
@@ -1153,7 +1173,7 @@ class SessionsStore {
   clearRecentlyDeleted(id?: string) {
     if (id) {
       this.recentlyDeleted = this.recentlyDeleted.filter((d) => {
-        if (d.id === id) {
+        if (d.ids.includes(id)) {
           clearTimeout(d.timer);
           return false;
         }
@@ -1163,6 +1183,13 @@ class SessionsStore {
       for (const d of this.recentlyDeleted) clearTimeout(d.timer);
       this.recentlyDeleted = [];
     }
+  }
+
+  private clearRecentlyDeletedBatch(deleted: RecentlyDeletedSessions) {
+    clearTimeout(deleted.timer);
+    this.recentlyDeleted = this.recentlyDeleted.filter(
+      (d) => d.key !== deleted.key,
+    );
   }
 
   async renameSession(id: string, displayName: string | null) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1153,7 +1153,7 @@ class SessionsStore {
     }
     this.updateRecentlyDeletedBatch(deleted, failed);
     this.invalidateFilterCaches();
-    await this.load();
+    await this.load({ force: true });
     if (failed.length > 0) {
       const noun = failed.length === 1 ? "session" : "sessions";
       throw new Error(`Failed to restore ${failed.length} ${noun}`);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1116,12 +1116,6 @@ class SessionsStore {
       requestBody: { session_ids: ids },
     });
     const idSet = new Set(ids);
-    const before = this.sessions.length;
-    this.sessions = this.sessions.filter((s) => !idSet.has(s.id));
-    const removed = before - this.sessions.length;
-    if (removed > 0) {
-      this.total = Math.max(0, this.total - removed);
-    }
     if (this.activeSessionId && idSet.has(this.activeSessionId)) {
       this.setActiveSession(null);
     }
@@ -1129,6 +1123,7 @@ class SessionsStore {
     this.selectedIds = new Set();
     this.selectMode = false;
     this.invalidateFilterCaches();
+    await this.load();
   }
 
   async restoreSession(id: string) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -33,6 +33,7 @@ const SESSION_PAGE_SIZE = 500;
 const SIDEBAR_HYDRATION_CONCURRENCY = 6;
 const LIVE_REFRESH_DEBOUNCE_MS = 300;
 const SAFETY_NET_REFRESH_MS = 5 * 60 * 1000;
+const RECENTLY_DELETED_TTL_MS = 10_000;
 
 export interface SessionGroupInput {
   id: string;
@@ -1045,14 +1046,18 @@ class SessionsStore {
   recentlyDeleted: RecentlyDeletedSessions[] = $state([]);
   private recentlyDeletedNextKey = 0;
 
-  private addRecentlyDeleted(ids: string[]) {
-    if (ids.length === 0) return;
-    const key = this.recentlyDeletedNextKey++;
-    const timer = setTimeout(() => {
+  private newRecentlyDeletedTimer(key: number) {
+    return setTimeout(() => {
       this.recentlyDeleted = this.recentlyDeleted.filter(
         (d) => d.key !== key,
       );
-    }, 10_000);
+    }, RECENTLY_DELETED_TTL_MS);
+  }
+
+  private addRecentlyDeleted(ids: string[]) {
+    if (ids.length === 0) return;
+    const key = this.recentlyDeletedNextKey++;
+    const timer = this.newRecentlyDeletedTimer(key);
     this.recentlyDeleted = [
       ...this.recentlyDeleted,
       { key, ids: [...ids], timer },
@@ -1138,6 +1143,7 @@ class SessionsStore {
     const ids = [...deleted.ids];
     if (ids.length === 0) return;
     configureGeneratedClient();
+    clearTimeout(deleted.timer);
     const failed: string[] = [];
     for (const id of ids) {
       try {
@@ -1206,7 +1212,13 @@ class SessionsStore {
         clearTimeout(d.timer);
         return [];
       }
-      return [{ ...d, ids: [...ids] }];
+      return [
+        {
+          ...d,
+          ids: [...ids],
+          timer: this.newRecentlyDeletedTimer(d.key),
+        },
+      ];
     });
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1039,6 +1039,35 @@ class SessionsStore {
   recentlyDeleted: { id: string; timer: ReturnType<typeof setTimeout> }[] =
     $state([]);
 
+  /** Multi-select state for batch operations. */
+  selectedIds: Set<string> = $state(new Set());
+  selectMode: boolean = $state(false);
+
+  toggleSelectMode() {
+    this.selectMode = !this.selectMode;
+    if (!this.selectMode) {
+      this.selectedIds = new Set();
+    }
+  }
+
+  toggleSelection(id: string) {
+    const next = new Set(this.selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    this.selectedIds = next;
+  }
+
+  selectAll(ids: string[]) {
+    this.selectedIds = new Set(ids);
+  }
+
+  clearSelection() {
+    this.selectedIds = new Set();
+  }
+
   async deleteSession(id: string) {
     configureGeneratedClient();
     await SessionsService.deleteApiV1SessionsId({ id });
@@ -1057,6 +1086,35 @@ class SessionsStore {
       );
     }, 10_000);
     this.recentlyDeleted = [...this.recentlyDeleted, { id, timer }];
+    this.invalidateFilterCaches();
+  }
+
+  async batchDeleteSessions(ids: string[]) {
+    if (ids.length === 0) return;
+    configureGeneratedClient();
+    await SessionsService.postApiV1SessionsBatchDelete({
+      requestBody: { session_ids: ids },
+    });
+    const idSet = new Set(ids);
+    const before = this.sessions.length;
+    this.sessions = this.sessions.filter((s) => !idSet.has(s.id));
+    const removed = before - this.sessions.length;
+    if (removed > 0) {
+      this.total = Math.max(0, this.total - removed);
+    }
+    if (this.activeSessionId && idSet.has(this.activeSessionId)) {
+      this.setActiveSession(null);
+    }
+    for (const id of ids) {
+      const timer = setTimeout(() => {
+        this.recentlyDeleted = this.recentlyDeleted.filter(
+          (d) => d.id !== id,
+        );
+      }, 10_000);
+      this.recentlyDeleted = [...this.recentlyDeleted, { id, timer }];
+    }
+    this.selectedIds = new Set();
+    this.selectMode = false;
     this.invalidateFilterCaches();
   }
 

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -772,11 +772,21 @@ describe("SessionsStore", () => {
     });
 
     it("batch delete creates one undo entry for the whole batch", async () => {
-      mockSidebarIndex([
-        makeSkinnyRow({ id: "remove-a" }),
-        makeSkinnyRow({ id: "remove-b" }),
-        makeSkinnyRow({ id: "keep-me" }),
-      ]);
+      vi.mocked(api.getSidebarSessionIndex)
+        .mockResolvedValueOnce({
+          sessions: [
+            makeSkinnyRow({ id: "remove-a" }),
+            makeSkinnyRow({ id: "remove-b" }),
+            makeSkinnyRow({ id: "keep-me" }),
+          ],
+          total: 3,
+          next_cursor: null,
+        })
+        .mockResolvedValueOnce({
+          sessions: [makeSkinnyRow({ id: "keep-me" })],
+          total: 1,
+          next_cursor: null,
+        });
       vi.mocked(api.batchDeleteSessions).mockResolvedValue(undefined);
       vi.mocked(api.getProjects).mockResolvedValue({ projects: [] });
       vi.mocked(api.getAgents).mockResolvedValue({ agents: [] });
@@ -796,6 +806,38 @@ describe("SessionsStore", () => {
         "remove-a",
         "remove-b",
       ]);
+    });
+
+    it("reloads sidebar totals after deleting child rows", async () => {
+      vi.mocked(api.getSidebarSessionIndex)
+        .mockResolvedValueOnce({
+          sessions: [
+            makeSkinnyRow({ id: "parent" }),
+            makeSkinnyRow({
+              id: "child",
+              parent_session_id: "parent",
+            }),
+          ],
+          total: 1,
+          next_cursor: null,
+        })
+        .mockResolvedValueOnce({
+          sessions: [makeSkinnyRow({ id: "parent" })],
+          total: 1,
+          next_cursor: null,
+        });
+      vi.mocked(api.batchDeleteSessions).mockResolvedValue(undefined);
+      vi.mocked(api.getProjects).mockResolvedValue({ projects: [] });
+      vi.mocked(api.getAgents).mockResolvedValue({ agents: [] });
+      vi.mocked((api as any).getMachines).mockResolvedValue({ machines: [] });
+
+      await sessions.load();
+      await sessions.batchDeleteSessions(["child"]);
+
+      expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(2);
+      expect(sessions.sessions.map((s) => s.id)).toEqual(["parent"]);
+      expect(sessions.total).toBe(1);
+      expect(sessions.recentlyDeleted[0]!.ids).toEqual(["child"]);
     });
 
     it("restore reloads the sidebar index", async () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -811,6 +811,20 @@ describe("SessionsStore", () => {
       expect(sessions.sessions.map((s) => s.id)).toEqual(["after"]);
     });
 
+    it("removes only one id from a recently deleted batch", () => {
+      const timer = setTimeout(() => {}, 10_000);
+      sessions.recentlyDeleted = [
+        { key: 1, ids: ["restore-a", "restore-b"], timer },
+      ];
+
+      sessions.clearRecentlyDeleted("restore-a");
+
+      expect(sessions.recentlyDeleted).toHaveLength(1);
+      expect(sessions.recentlyDeleted[0]!.ids).toEqual(["restore-b"]);
+
+      sessions.clearRecentlyDeleted();
+    });
+
     it("restores all sessions from one recently deleted batch", async () => {
       const timer = setTimeout(() => {}, 10_000);
       sessions.recentlyDeleted = [
@@ -834,6 +848,44 @@ describe("SessionsStore", () => {
       );
       expect(sessions.recentlyDeleted).toEqual([]);
       expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps only failed ids when batch undo partially fails", async () => {
+      const timer = setTimeout(() => {}, 10_000);
+      sessions.recentlyDeleted = [
+        {
+          key: 1,
+          ids: ["restore-a", "restore-b", "restore-c"],
+          timer,
+        },
+      ];
+      vi.mocked((api as any).restoreSession)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("restore failed"))
+        .mockResolvedValueOnce(undefined);
+      mockSidebarIndex([makeSkinnyRow({ id: "restore-b" })]);
+
+      await expect(
+        sessions.restoreRecentlyDeleted(sessions.recentlyDeleted[0]!),
+      ).rejects.toThrow("Failed to restore 1 session");
+
+      expect((api as any).restoreSession).toHaveBeenNthCalledWith(
+        1,
+        "restore-a",
+      );
+      expect((api as any).restoreSession).toHaveBeenNthCalledWith(
+        2,
+        "restore-b",
+      );
+      expect((api as any).restoreSession).toHaveBeenNthCalledWith(
+        3,
+        "restore-c",
+      );
+      expect(sessions.recentlyDeleted).toHaveLength(1);
+      expect(sessions.recentlyDeleted[0]!.ids).toEqual(["restore-b"]);
+      expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(1);
+
+      sessions.clearRecentlyDeleted();
     });
   });
 

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -935,6 +935,52 @@ describe("SessionsStore", () => {
       expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(1);
     });
 
+    it("does not reuse a post-delete in-flight sidebar load after batch undo", async () => {
+      let resolveDeleteReload!: (value: {
+        sessions: SkinnySessionRow[];
+        total: number;
+        next_cursor?: string | null;
+      }) => void;
+      vi.mocked(api.getSidebarSessionIndex)
+        .mockReturnValueOnce(new Promise((resolve) => {
+          resolveDeleteReload = resolve;
+        }))
+        .mockResolvedValueOnce({
+          sessions: [makeSkinnyRow({ id: "restore-me" })],
+          total: 1,
+          next_cursor: null,
+        });
+      vi.mocked(api.batchDeleteSessions).mockResolvedValue(undefined);
+      vi.mocked((api as any).restoreSession).mockResolvedValue(undefined);
+      vi.mocked(api.getProjects).mockResolvedValue({ projects: [] });
+      vi.mocked(api.getAgents).mockResolvedValue({ agents: [] });
+      vi.mocked((api as any).getMachines).mockResolvedValue({ machines: [] });
+
+      const deletePromise = sessions.batchDeleteSessions(["restore-me"]);
+      await vi.waitFor(() => {
+        expect(sessions.recentlyDeleted).toHaveLength(1);
+        expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(1);
+      });
+
+      const restorePromise = sessions.restoreRecentlyDeleted(
+        sessions.recentlyDeleted[0]!,
+      );
+
+      await vi.waitFor(() => {
+        expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(2);
+      });
+
+      resolveDeleteReload({
+        sessions: [],
+        total: 0,
+        next_cursor: null,
+      });
+      await Promise.all([deletePromise, restorePromise]);
+
+      expect(sessions.sessions.map((s) => s.id)).toEqual(["restore-me"]);
+      expect(sessions.total).toBe(1);
+    });
+
     it("keeps only failed ids when batch undo partially fails", async () => {
       const timer = setTimeout(() => {}, 10_000);
       sessions.recentlyDeleted = [

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -27,6 +27,7 @@ const api = vi.hoisted(() => ({
   getAgents: vi.fn(),
   getMachines: vi.fn(),
   deleteSession: vi.fn(),
+  batchDeleteSessions: vi.fn(),
   restoreSession: vi.fn(),
   renameSession: vi.fn(),
   getStats: vi.fn().mockResolvedValue({
@@ -71,6 +72,9 @@ vi.mock("../api/generated/index", () => ({
     ),
     getApiV1SessionsId: vi.fn(({ id }) => api.getSession(id)),
     deleteApiV1SessionsId: vi.fn(({ id }) => api.deleteSession(id)),
+    postApiV1SessionsBatchDelete: vi.fn(({ requestBody }) =>
+      api.batchDeleteSessions(requestBody.session_ids)
+    ),
     postApiV1SessionsIdRestore: vi.fn(({ id }) => api.restoreSession(id)),
     patchApiV1SessionsIdRename: vi.fn(({ id, requestBody }) =>
       api.renameSession(id, requestBody.display_name)
@@ -767,6 +771,33 @@ describe("SessionsStore", () => {
       expect((api as any).getMachines).toHaveBeenCalled();
     });
 
+    it("batch delete creates one undo entry for the whole batch", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "remove-a" }),
+        makeSkinnyRow({ id: "remove-b" }),
+        makeSkinnyRow({ id: "keep-me" }),
+      ]);
+      vi.mocked(api.batchDeleteSessions).mockResolvedValue(undefined);
+      vi.mocked(api.getProjects).mockResolvedValue({ projects: [] });
+      vi.mocked(api.getAgents).mockResolvedValue({ agents: [] });
+      vi.mocked((api as any).getMachines).mockResolvedValue({ machines: [] });
+
+      await sessions.load();
+      await sessions.batchDeleteSessions(["remove-a", "remove-b"]);
+
+      expect(api.batchDeleteSessions).toHaveBeenCalledWith([
+        "remove-a",
+        "remove-b",
+      ]);
+      expect(sessions.sessions.map((s) => s.id)).toEqual(["keep-me"]);
+      expect(sessions.total).toBe(1);
+      expect(sessions.recentlyDeleted).toHaveLength(1);
+      expect(sessions.recentlyDeleted[0]!.ids).toEqual([
+        "remove-a",
+        "remove-b",
+      ]);
+    });
+
     it("restore reloads the sidebar index", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "before" })]);
       vi.mocked((api as any).restoreSession).mockResolvedValue(undefined);
@@ -778,6 +809,31 @@ describe("SessionsStore", () => {
       expect((api as any).restoreSession).toHaveBeenCalledWith("before");
       expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(2);
       expect(sessions.sessions.map((s) => s.id)).toEqual(["after"]);
+    });
+
+    it("restores all sessions from one recently deleted batch", async () => {
+      const timer = setTimeout(() => {}, 10_000);
+      sessions.recentlyDeleted = [
+        { key: 1, ids: ["restore-a", "restore-b"], timer },
+      ];
+      vi.mocked((api as any).restoreSession).mockResolvedValue(undefined);
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "restore-a" }),
+        makeSkinnyRow({ id: "restore-b" }),
+      ]);
+
+      await sessions.restoreRecentlyDeleted(sessions.recentlyDeleted[0]!);
+
+      expect((api as any).restoreSession).toHaveBeenNthCalledWith(
+        1,
+        "restore-a",
+      );
+      expect((api as any).restoreSession).toHaveBeenNthCalledWith(
+        2,
+        "restore-b",
+      );
+      expect(sessions.recentlyDeleted).toEqual([]);
+      expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -840,6 +840,49 @@ describe("SessionsStore", () => {
       expect(sessions.recentlyDeleted[0]!.ids).toEqual(["child"]);
     });
 
+    it("does not reuse a pre-delete in-flight sidebar load after batch delete", async () => {
+      let resolveStaleLoad!: (value: {
+        sessions: SkinnySessionRow[];
+        total: number;
+        next_cursor?: string | null;
+      }) => void;
+      vi.mocked(api.getSidebarSessionIndex)
+        .mockReturnValueOnce(new Promise((resolve) => {
+          resolveStaleLoad = resolve;
+        }))
+        .mockResolvedValueOnce({
+          sessions: [makeSkinnyRow({ id: "keep-me" })],
+          total: 1,
+          next_cursor: null,
+        });
+      vi.mocked(api.batchDeleteSessions).mockResolvedValue(undefined);
+      vi.mocked(api.getProjects).mockResolvedValue({ projects: [] });
+      vi.mocked(api.getAgents).mockResolvedValue({ agents: [] });
+      vi.mocked((api as any).getMachines).mockResolvedValue({ machines: [] });
+
+      const staleLoad = sessions.load();
+      await Promise.resolve();
+
+      const deletePromise = sessions.batchDeleteSessions(["remove-me"]);
+
+      await vi.waitFor(() => {
+        expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(2);
+      });
+
+      resolveStaleLoad({
+        sessions: [
+          makeSkinnyRow({ id: "remove-me" }),
+          makeSkinnyRow({ id: "keep-me" }),
+        ],
+        total: 2,
+        next_cursor: null,
+      });
+      await Promise.all([staleLoad, deletePromise]);
+
+      expect(sessions.sessions.map((s) => s.id)).toEqual(["keep-me"]);
+      expect(sessions.total).toBe(1);
+    });
+
     it("restore reloads the sidebar index", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "before" })]);
       vi.mocked((api as any).restoreSession).mockResolvedValue(undefined);

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -887,6 +887,42 @@ describe("SessionsStore", () => {
 
       sessions.clearRecentlyDeleted();
     });
+
+    it("keeps failed ids retryable if the original timer expires during batch undo", async () => {
+      vi.useFakeTimers();
+      try {
+        const timer = setTimeout(() => {
+          sessions.recentlyDeleted = sessions.recentlyDeleted.filter(
+            (d) => d.key !== 1,
+          );
+        }, 10_000);
+        sessions.recentlyDeleted = [
+          { key: 1, ids: ["restore-a"], timer },
+        ];
+        vi.mocked((api as any).restoreSession).mockImplementation(
+          async () => {
+            vi.advanceTimersByTime(10_000);
+            throw new Error("restore failed");
+          },
+        );
+        mockSidebarIndex([makeSkinnyRow({ id: "restore-a" })]);
+
+        await expect(
+          sessions.restoreRecentlyDeleted(sessions.recentlyDeleted[0]!),
+        ).rejects.toThrow("Failed to restore 1 session");
+
+        expect(sessions.recentlyDeleted).toHaveLength(1);
+        expect(sessions.recentlyDeleted[0]!.ids).toEqual(["restore-a"]);
+
+        vi.advanceTimersByTime(9_999);
+        expect(sessions.recentlyDeleted).toHaveLength(1);
+
+        vi.advanceTimersByTime(1);
+        expect(sessions.recentlyDeleted).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("parseFiltersFromParams", () => {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4733,6 +4733,34 @@ func TestDeleteSessionIfTrashed(t *testing.T) {
 	assert.Equal(t, int64(0), n, "nonexistent: rows=")
 }
 
+func TestSoftDeleteSessions(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "s1", "proj")
+	insertSession(t, d, "s2", "proj")
+	insertSession(t, d, "s3", "proj")
+
+	// Pre-trash s3 so we can verify it's not double-counted.
+	require.NoError(t, d.SoftDeleteSession("s3"), "pre-trash s3")
+
+	n, err := d.SoftDeleteSessions([]string{"s1", "s2", "s3", "nonexistent"})
+	require.NoError(t, err, "SoftDeleteSessions")
+	assert.Equal(t, 2, n, "should soft-delete 2 new sessions")
+
+	// All three should now be trashed.
+	for _, id := range []string{"s1", "s2", "s3"} {
+		s, err := d.GetSession(ctx, id)
+		require.NoError(t, err, "GetSession", id)
+		assert.Nil(t, s, "trashed session should not be visible:", id)
+	}
+
+	// Empty input is a no-op.
+	n, err = d.SoftDeleteSessions(nil)
+	require.NoError(t, err, "SoftDeleteSessions nil")
+	assert.Equal(t, 0, n, "empty: rows=")
+}
+
 func TestMetadataQueriesExcludeTrashed(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2382,6 +2382,55 @@ func (db *DB) SoftDeleteSession(id string) error {
 	return err
 }
 
+// SoftDeleteSessions marks multiple sessions as deleted by setting
+// deleted_at. Sessions that are already soft-deleted are skipped.
+// Returns the count of newly deleted rows.
+func (db *DB) SoftDeleteSessions(ids []string) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return 0, fmt.Errorf("beginning soft-delete tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	total := 0
+	const batchSize = 500
+	for i := 0; i < len(ids); i += batchSize {
+		end := min(i+batchSize, len(ids))
+		batch := ids[i:end]
+
+		args := make([]any, len(batch))
+		for j, id := range batch {
+			args[j] = id
+		}
+		placeholders := strings.Repeat(",?", len(batch))[1:]
+
+		res, err := tx.Exec(
+			`UPDATE sessions
+			 SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+			     local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+			 WHERE id IN (`+placeholders+`) AND deleted_at IS NULL`,
+			args...,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("soft-deleting batch: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		total += int(n)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("committing soft-delete tx: %w", err)
+	}
+	return total, nil
+}
+
 // RestoreSession clears deleted_at, making the session visible again.
 // Returns the number of rows affected (0 if session doesn't exist
 // or is not in trash).

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -100,6 +100,7 @@ type Store interface {
 	// Session management (local-only; PG returns ErrReadOnly).
 	RenameSession(id string, displayName *string) error
 	SoftDeleteSession(id string) error
+	SoftDeleteSessions(ids []string) (int, error)
 	RestoreSession(id string) (int64, error)
 	DeleteSessionIfTrashed(id string) (int64, error)
 	ListTrashedSessions(ctx context.Context) ([]Session, error)

--- a/internal/duckdb/stubs.go
+++ b/internal/duckdb/stubs.go
@@ -17,6 +17,7 @@ func (s *Store) GetCachedInsight(_ context.Context, _ string) (*db.Insight, erro
 }
 func (s *Store) RenameSession(_ string, _ *string) error        { return db.ErrReadOnly }
 func (s *Store) SoftDeleteSession(_ string) error               { return db.ErrReadOnly }
+func (s *Store) SoftDeleteSessions(_ []string) (int, error)     { return 0, db.ErrReadOnly }
 func (s *Store) RestoreSession(_ string) (int64, error)         { return 0, db.ErrReadOnly }
 func (s *Store) DeleteSessionIfTrashed(_ string) (int64, error) { return 0, db.ErrReadOnly }
 func (s *Store) ListTrashedSessions(_ context.Context) ([]db.Session, error) {

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -124,6 +124,11 @@ func (s *Store) SoftDeleteSession(_ string) error {
 	return db.ErrReadOnly
 }
 
+// SoftDeleteSessions is not supported in read-only mode.
+func (s *Store) SoftDeleteSessions(_ []string) (int, error) {
+	return 0, db.ErrReadOnly
+}
+
 // RestoreSession is not supported in read-only mode.
 func (s *Store) RestoreSession(_ string) (int64, error) {
 	return 0, db.ErrReadOnly

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -44,6 +44,7 @@ func (s *Server) registerSessionRoutes() {
 	post(s, group, "/sessions/{id}/open", "Open session directory", s.humaOpenSession)
 	post(s, group, "/sessions/upload", "Upload a session export", s.humaUploadSession)
 	patch(s, group, "/sessions/{id}/rename", "Rename session", s.humaRenameSession)
+	post(s, group, "/sessions/batch-delete", "Batch delete sessions", s.humaBatchDeleteSessions)
 	deleteRoute(s, group, "/sessions/{id}", "Delete session", s.humaDeleteSession)
 	post(s, group, "/sessions/{id}/restore", "Restore session", s.humaRestoreSession)
 	deleteRoute(s, group, "/sessions/{id}/permanent", "Permanently delete session", s.humaPermanentDeleteSession)
@@ -592,6 +593,28 @@ func (s *Server) humaDeleteSession(
 			return nil, handled
 		}
 		return nil, internalError("soft delete session", err)
+	}
+	return &noContentOutput{Status: http.StatusNoContent}, nil
+}
+
+type batchDeleteInput struct {
+	Body struct {
+		SessionIDs []string `json:"session_ids" required:"true" doc:"Session IDs to soft-delete"`
+	}
+}
+
+func (s *Server) humaBatchDeleteSessions(
+	_ context.Context,
+	in *batchDeleteInput,
+) (*noContentOutput, error) {
+	if len(in.Body.SessionIDs) == 0 {
+		return &noContentOutput{Status: http.StatusNoContent}, nil
+	}
+	if _, err := s.db.SoftDeleteSessions(in.Body.SessionIDs); err != nil {
+		if handled := handleHumaReadOnly(err); handled != nil {
+			return nil, handled
+		}
+		return nil, internalError("batch delete sessions", err)
 	}
 	return &noContentOutput{Status: http.StatusNoContent}, nil
 }


### PR DESCRIPTION
## Summary

Add multi-select batch delete functionality to the session sidebar, allowing users to select and delete multiple sessions at once instead of deleting them one by one.

Ref #281

## Changes

**Backend:**
- New `SoftDeleteSessions(ids []string)` DB method for batch soft-delete in a single transaction (batches of 500)
- New `POST /api/v1/sessions/batch-delete` endpoint accepting `{ session_ids: [...] }`, following the existing bulk-star pattern
- Read-only stubs added for PG and DuckDB stores
- Store interface updated with `SoftDeleteSessions`

**Frontend:**
- Multi-select toggle button in the session list header (checkmark icon)
- Per-item checkboxes when select mode is active; clicking items toggles selection instead of navigation
- Batch toolbar showing selection count with `Delete` and `Cancel` buttons, plus `All/Clear` for select-all
- `batchDeleteSessions(ids)` store method calls the new endpoint, updates local state, tracks undo toast entries, and exits select mode automatically

**Tests:**
- `TestSoftDeleteSessions` covering normal batch, pre-deleted skip, empty input, and non-existent IDs