### PR TITLE
feat(config): add per-remote sync interval

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -813,7 +813,9 @@ func startPeriodicSync(
 	if validRemotes {
 		for _, rh := range cfg.RemoteHosts {
 			if rh.Interval > 0 {
-				go startRemoteHostSync(cfg, database, engine, rh, emitter)
+				go startRemoteHostSync(
+					cfg, database, engine, rh, emitter, idleTracker,
+				)
 			}
 		}
 	}
@@ -834,6 +836,7 @@ func startRemoteHostSync(
 	engine *sync.Engine,
 	rh config.RemoteHost,
 	emitter sync.Emitter,
+	idleTracker *server.IdleTracker,
 ) {
 	syncFn := remoteHostSyncFunc(
 		cfg, database, engine, rh,
@@ -841,7 +844,7 @@ func startRemoteHostSync(
 			return rs.Run(ctx)
 		},
 	)
-	runRemoteHostSyncLoop(rh.Host, rh.Interval, syncFn, emitter, nil)
+	runRemoteHostSyncLoop(rh.Host, rh.Interval, syncFn, emitter, idleTracker, nil)
 }
 
 type remoteSyncExclusiveRunner interface {
@@ -882,7 +885,14 @@ func remoteHostSyncFunc(
 // runRemoteHostSyncLoop drives the per-host sync ticker. syncFn returns
 // the number of sessions synced so we only emit when data changed.
 // When done is non-nil, closing it stops the loop.
-func runRemoteHostSyncLoop(host string, interval time.Duration, syncFn func() (int, error), emitter sync.Emitter, done <-chan struct{}) {
+func runRemoteHostSyncLoop(
+	host string,
+	interval time.Duration,
+	syncFn func() (int, error),
+	emitter sync.Emitter,
+	idleTracker *server.IdleTracker,
+	done <-chan struct{},
+) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -892,7 +902,17 @@ func runRemoteHostSyncLoop(host string, interval time.Duration, syncFn func() (i
 		case <-ticker.C:
 		}
 		log.Printf("Running scheduled remote sync for %s...", host)
-		synced, err := syncFn()
+		finishWork, ok := idleTracker.BeginWork()
+		if !ok {
+			log.Printf("scheduled remote sync %s skipped: daemon is shutting down", host)
+			continue
+		}
+		var synced int
+		var err error
+		func() {
+			defer finishWork()
+			synced, err = syncFn()
+		}()
 		if err != nil {
 			log.Printf("scheduled remote sync %s: %v", host, err)
 			continue

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/agentsview/internal/secrets"
 	"go.kenn.io/agentsview/internal/server"
 	"go.kenn.io/agentsview/internal/signals"
+	"go.kenn.io/agentsview/internal/ssh"
 	"go.kenn.io/agentsview/internal/sync"
 	"go.kenn.io/agentsview/internal/telemetry"
 )
@@ -208,7 +209,12 @@ func runServe(cfg config.Config) {
 			}
 		})
 
-		go startPeriodicSync(engine, database, idleTracker)
+		validRemotes := true
+		if err := cfg.ValidateRemoteHosts(); err != nil {
+			log.Printf("warning: remote_hosts config invalid, skipping periodic remote sync: %v", err)
+			validRemotes = false
+		}
+		go startPeriodicSync(cfg, engine, database, idleTracker, validRemotes, broadcaster)
 	}
 
 	// Seed model_pricing after any resync swap so the new DB
@@ -797,8 +803,20 @@ func collectWatchRoots(cfg config.Config) (roots []watchRoot, unwatchedDirs []st
 }
 
 func startPeriodicSync(
-	engine *sync.Engine, database *db.DB, idleTracker *server.IdleTracker,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	idleTracker *server.IdleTracker,
+	validRemotes bool,
+	emitter sync.Emitter,
 ) {
+	if validRemotes {
+		for _, rh := range cfg.RemoteHosts {
+			if rh.Interval > 0 {
+				go startRemoteHostSync(cfg, database, rh, emitter)
+			}
+		}
+	}
 	ticker := time.NewTicker(periodicSyncInterval)
 	defer ticker.Stop()
 	for range ticker.C {
@@ -807,6 +825,46 @@ func startPeriodicSync(
 			engine.SyncAll(context.Background(), nil)
 			recomputePendingSessions(engine, database)
 		})
+	}
+}
+
+func startRemoteHostSync(cfg config.Config, database *db.DB, rh config.RemoteHost, emitter sync.Emitter) {
+	syncFn := func() (int, error) {
+		rs := &ssh.RemoteSync{
+			Host:                    rh.Host,
+			User:                    rh.User,
+			Port:                    rh.Port,
+			Full:                    false,
+			DB:                      database,
+			BlockedResultCategories: cfg.ResultContentBlockedCategories,
+		}
+		stats, err := rs.Run(context.Background())
+		return stats.SessionsSynced, err
+	}
+	runRemoteHostSyncLoop(rh.Host, rh.Interval, syncFn, emitter, nil)
+}
+
+// runRemoteHostSyncLoop drives the per-host sync ticker. syncFn returns
+// the number of sessions synced so we only emit when data changed.
+// When done is non-nil, closing it stops the loop.
+func runRemoteHostSyncLoop(host string, interval time.Duration, syncFn func() (int, error), emitter sync.Emitter, done <-chan struct{}) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+		}
+		log.Printf("Running scheduled remote sync for %s...", host)
+		synced, err := syncFn()
+		if err != nil {
+			log.Printf("scheduled remote sync %s: %v", host, err)
+			continue
+		}
+		if synced > 0 && emitter != nil {
+			emitter.Emit("remote")
+		}
 	}
 }
 

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -813,7 +813,7 @@ func startPeriodicSync(
 	if validRemotes {
 		for _, rh := range cfg.RemoteHosts {
 			if rh.Interval > 0 {
-				go startRemoteHostSync(cfg, database, rh, emitter)
+				go startRemoteHostSync(cfg, database, engine, rh, emitter)
 			}
 		}
 	}
@@ -828,20 +828,55 @@ func startPeriodicSync(
 	}
 }
 
-func startRemoteHostSync(cfg config.Config, database *db.DB, rh config.RemoteHost, emitter sync.Emitter) {
-	syncFn := func() (int, error) {
-		rs := &ssh.RemoteSync{
-			Host:                    rh.Host,
-			User:                    rh.User,
-			Port:                    rh.Port,
-			Full:                    false,
-			DB:                      database,
-			BlockedResultCategories: cfg.ResultContentBlockedCategories,
+func startRemoteHostSync(
+	cfg config.Config,
+	database *db.DB,
+	engine *sync.Engine,
+	rh config.RemoteHost,
+	emitter sync.Emitter,
+) {
+	syncFn := remoteHostSyncFunc(
+		cfg, database, engine, rh,
+		func(ctx context.Context, rs *ssh.RemoteSync) (ssh.SyncStats, error) {
+			return rs.Run(ctx)
+		},
+	)
+	runRemoteHostSyncLoop(rh.Host, rh.Interval, syncFn, emitter, nil)
+}
+
+type remoteSyncExclusiveRunner interface {
+	RunExclusive(func() error) error
+}
+
+type remoteSyncRunner func(context.Context, *ssh.RemoteSync) (ssh.SyncStats, error)
+
+func remoteHostSyncFunc(
+	cfg config.Config,
+	database *db.DB,
+	runner remoteSyncExclusiveRunner,
+	rh config.RemoteHost,
+	runRemote remoteSyncRunner,
+) func() (int, error) {
+	return func() (int, error) {
+		if runner == nil {
+			return 0, fmt.Errorf("scheduled remote sync missing exclusive runner")
 		}
-		stats, err := rs.Run(context.Background())
+		var stats ssh.SyncStats
+		err := runner.RunExclusive(func() error {
+			rs := &ssh.RemoteSync{
+				Host:                    rh.Host,
+				User:                    rh.User,
+				Port:                    rh.Port,
+				Full:                    false,
+				DB:                      database,
+				BlockedResultCategories: cfg.ResultContentBlockedCategories,
+			}
+			var err error
+			stats, err = runRemote(context.Background(), rs)
+			return err
+		})
 		return stats.SessionsSynced, err
 	}
-	runRemoteHostSyncLoop(rh.Host, rh.Interval, syncFn, emitter, nil)
 }
 
 // runRemoteHostSyncLoop drives the per-host sync ticker. syncFn returns

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -870,7 +870,7 @@ func remoteHostSyncFunc(
 				Host:                    rh.Host,
 				User:                    rh.User,
 				Port:                    rh.Port,
-				Full:                    false,
+				Full:                    database.NeedsResync(),
 				DB:                      database,
 				BlockedResultCategories: cfg.ResultContentBlockedCategories,
 			}

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -863,7 +863,7 @@ func runRemoteHostSyncLoop(host string, interval time.Duration, syncFn func() (i
 			continue
 		}
 		if synced > 0 && emitter != nil {
-			emitter.Emit("remote")
+			emitter.Emit("sessions")
 		}
 	}
 }

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -214,7 +214,7 @@ func runServe(cfg config.Config) {
 			log.Printf("warning: remote_hosts config invalid, skipping periodic remote sync: %v", err)
 			validRemotes = false
 		}
-		go startPeriodicSync(cfg, engine, database, idleTracker, validRemotes, broadcaster)
+		go startPeriodicSync(ctx, cfg, engine, database, idleTracker, validRemotes, broadcaster)
 	}
 
 	// Seed model_pricing after any resync swap so the new DB
@@ -803,6 +803,7 @@ func collectWatchRoots(cfg config.Config) (roots []watchRoot, unwatchedDirs []st
 }
 
 func startPeriodicSync(
+	ctx context.Context,
 	cfg config.Config,
 	engine *sync.Engine,
 	database *db.DB,
@@ -814,23 +815,29 @@ func startPeriodicSync(
 		for _, rh := range cfg.RemoteHosts {
 			if rh.Interval > 0 {
 				go startRemoteHostSync(
-					cfg, database, engine, rh, emitter, idleTracker,
+					ctx, cfg, database, engine, rh, emitter, idleTracker,
 				)
 			}
 		}
 	}
 	ticker := time.NewTicker(periodicSyncInterval)
 	defer ticker.Stop()
-	for range ticker.C {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
 		log.Println("Running scheduled sync...")
 		idleTracker.Do(func() {
-			engine.SyncAll(context.Background(), nil)
+			engine.SyncAll(ctx, nil)
 			recomputePendingSessions(engine, database)
 		})
 	}
 }
 
 func startRemoteHostSync(
+	ctx context.Context,
 	cfg config.Config,
 	database *db.DB,
 	engine *sync.Engine,
@@ -839,12 +846,12 @@ func startRemoteHostSync(
 	idleTracker *server.IdleTracker,
 ) {
 	syncFn := remoteHostSyncFunc(
-		cfg, database, engine, rh,
+		ctx, cfg, database, engine, rh,
 		func(ctx context.Context, rs *ssh.RemoteSync) (ssh.SyncStats, error) {
 			return rs.Run(ctx)
 		},
 	)
-	runRemoteHostSyncLoop(rh.Host, rh.Interval, syncFn, emitter, idleTracker, nil)
+	runRemoteHostSyncLoop(ctx, rh.Host, rh.Interval, syncFn, emitter, idleTracker, nil)
 }
 
 type remoteSyncExclusiveRunner interface {
@@ -854,6 +861,7 @@ type remoteSyncExclusiveRunner interface {
 type remoteSyncRunner func(context.Context, *ssh.RemoteSync) (ssh.SyncStats, error)
 
 func remoteHostSyncFunc(
+	ctx context.Context,
 	cfg config.Config,
 	database *db.DB,
 	runner remoteSyncExclusiveRunner,
@@ -875,7 +883,7 @@ func remoteHostSyncFunc(
 				BlockedResultCategories: cfg.ResultContentBlockedCategories,
 			}
 			var err error
-			stats, err = runRemote(context.Background(), rs)
+			stats, err = runRemote(ctx, rs)
 			return err
 		})
 		return stats.SessionsSynced, err
@@ -886,6 +894,7 @@ func remoteHostSyncFunc(
 // the number of sessions synced so we only emit when data changed.
 // When done is non-nil, closing it stops the loop.
 func runRemoteHostSyncLoop(
+	ctx context.Context,
 	host string,
 	interval time.Duration,
 	syncFn func() (int, error),
@@ -897,6 +906,8 @@ func runRemoteHostSyncLoop(
 	defer ticker.Stop()
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case <-done:
 			return
 		case <-ticker.C:

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"log"
 	"os"
@@ -331,6 +332,45 @@ func TestRemoteHostSyncFuncSerializesWithEngineExclusiveLock(t *testing.T) {
 	case <-time.After(time.Second):
 		require.FailNow(t, "exclusive operation did not finish")
 	}
+}
+
+func TestRemoteHostSyncFuncForcesFullWhenDatabaseNeedsResync(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, database.Close())
+
+	raw, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = raw.Exec("PRAGMA user_version = 0")
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	database, err = db.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	require.True(t, database.NeedsResync())
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{},
+		Machine:   "local",
+	})
+
+	var gotFull bool
+	syncFn := remoteHostSyncFunc(
+		config.Config{},
+		database,
+		engine,
+		config.RemoteHost{Host: "test-host"},
+		func(_ context.Context, rs *ssh.RemoteSync) (ssh.SyncStats, error) {
+			gotFull = rs.Full
+			return ssh.SyncStats{}, nil
+		},
+	)
+
+	_, err = syncFn()
+
+	require.NoError(t, err)
+	assert.True(t, gotFull, "scheduled remote sync should force full when DB needs resync")
 }
 
 func TestStartRemoteHostSync_TracksRemoteWorkForIdleReaper(t *testing.T) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -268,7 +268,12 @@ type scopedEmitter struct {
 	scopes chan string
 }
 
-func (e *scopedEmitter) Emit(scope string) { e.scopes <- scope }
+func (e *scopedEmitter) Emit(scope string) {
+	select {
+	case e.scopes <- scope:
+	default:
+	}
+}
 
 func TestStartRemoteHostSync_EmitsSessionsScopeAfterSuccess(t *testing.T) {
 	em := &scopedEmitter{scopes: make(chan string, 1)}

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/ssh"
 	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
@@ -262,6 +264,72 @@ func TestStartRemoteHostSync_EmitsAfterSuccess(t *testing.T) {
 	<-exited
 
 	assert.Positive(t, em.count.Load(), "emitter should have been called at least once")
+}
+
+func TestRemoteHostSyncFuncSerializesWithEngineExclusiveLock(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{},
+		Machine:   "local",
+	})
+
+	remoteEntered := make(chan struct{})
+	releaseRemote := make(chan struct{})
+	syncFn := remoteHostSyncFunc(
+		config.Config{},
+		database,
+		engine,
+		config.RemoteHost{Host: "test-host"},
+		func(context.Context, *ssh.RemoteSync) (ssh.SyncStats, error) {
+			close(remoteEntered)
+			<-releaseRemote
+			return ssh.SyncStats{}, nil
+		},
+	)
+
+	syncErr := make(chan error, 1)
+	go func() {
+		_, err := syncFn()
+		syncErr <- err
+	}()
+
+	select {
+	case <-remoteEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "remote sync did not enter")
+	}
+
+	exclusiveEntered := make(chan struct{})
+	exclusiveErr := make(chan error, 1)
+	go func() {
+		exclusiveErr <- engine.RunExclusive(func() error {
+			close(exclusiveEntered)
+			return nil
+		})
+	}()
+
+	select {
+	case <-exclusiveEntered:
+		assert.Fail(t, "exclusive operation overlapped scheduled remote sync")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseRemote)
+
+	select {
+	case err := <-syncErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "scheduled remote sync did not finish")
+	}
+	select {
+	case err := <-exclusiveErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "exclusive operation did not finish")
+	}
 }
 
 type scopedEmitter struct {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -16,6 +16,7 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/server"
 	"go.kenn.io/agentsview/internal/ssh"
 	agentsync "go.kenn.io/agentsview/internal/sync"
 )
@@ -255,7 +256,7 @@ func TestStartRemoteHostSync_EmitsAfterSuccess(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, em, done)
+		runRemoteHostSyncLoop("test-host", interval, syncFn, em, nil, done)
 		close(exited)
 	}()
 
@@ -332,6 +333,53 @@ func TestRemoteHostSyncFuncSerializesWithEngineExclusiveLock(t *testing.T) {
 	}
 }
 
+func TestStartRemoteHostSync_TracksRemoteWorkForIdleReaper(t *testing.T) {
+	idleFired := make(chan struct{})
+	idleTracker := server.NewIdleTracker(20*time.Millisecond, func() {
+		close(idleFired)
+	})
+	ctx := t.Context()
+
+	syncEntered := make(chan struct{}, 1)
+	releaseSync := make(chan struct{})
+	syncFn := func() (int, error) {
+		select {
+		case syncEntered <- struct{}{}:
+		default:
+		}
+		<-releaseSync
+		return 1, nil
+	}
+
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		runRemoteHostSyncLoop("test-host", time.Millisecond, syncFn, nil, idleTracker, done)
+		close(exited)
+	}()
+
+	select {
+	case <-syncEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "remote sync did not enter")
+	}
+	go idleTracker.Run(ctx)
+
+	select {
+	case <-idleFired:
+		require.FailNow(t, "idle tracker fired while remote sync was active")
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	close(releaseSync)
+	close(done)
+	select {
+	case <-exited:
+	case <-time.After(time.Second):
+		require.FailNow(t, "remote sync loop did not exit")
+	}
+}
+
 type scopedEmitter struct {
 	scopes chan string
 }
@@ -351,7 +399,7 @@ func TestStartRemoteHostSync_EmitsSessionsScopeAfterSuccess(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, em, done)
+		runRemoteHostSyncLoop("test-host", interval, syncFn, em, nil, done)
 		close(exited)
 	}()
 
@@ -373,7 +421,7 @@ func TestStartRemoteHostSync_NoEmitOnZeroSynced(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, em, done)
+		runRemoteHostSyncLoop("test-host", interval, syncFn, em, nil, done)
 		close(exited)
 	}()
 
@@ -392,7 +440,7 @@ func TestStartRemoteHostSync_NoEmitOnError(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, em, done)
+		runRemoteHostSyncLoop("test-host", interval, syncFn, em, nil, done)
 		close(exited)
 	}()
 
@@ -410,7 +458,7 @@ func TestStartRemoteHostSync_NilEmitterSafe(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, nil, done)
+		runRemoteHostSyncLoop("test-host", interval, syncFn, nil, nil, done)
 		close(exited)
 	}()
 

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -264,6 +264,34 @@ func TestStartRemoteHostSync_EmitsAfterSuccess(t *testing.T) {
 	assert.Positive(t, em.count.Load(), "emitter should have been called at least once")
 }
 
+type scopedEmitter struct {
+	scopes chan string
+}
+
+func (e *scopedEmitter) Emit(scope string) { e.scopes <- scope }
+
+func TestStartRemoteHostSync_EmitsSessionsScopeAfterSuccess(t *testing.T) {
+	em := &scopedEmitter{scopes: make(chan string, 1)}
+	syncFn := func() (int, error) { return 3, nil }
+
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	interval := 10 * time.Millisecond
+	go func() {
+		runRemoteHostSyncLoop("test-host", interval, syncFn, em, done)
+		close(exited)
+	}()
+
+	select {
+	case scope := <-em.scopes:
+		assert.Equal(t, "sessions", scope)
+	case <-time.After(3 * interval):
+		require.FailNow(t, "timed out waiting for remote sync event")
+	}
+	close(done)
+	<-exited
+}
+
 func TestStartRemoteHostSync_NoEmitOnZeroSynced(t *testing.T) {
 	em := &fakeEmitter{}
 	syncFn := func() (int, error) { return 0, nil }

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/parser"
-	"go.kenn.io/agentsview/internal/sync"
+	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
 func TestMustLoadConfig(t *testing.T) {
@@ -192,14 +194,14 @@ type fakeUnwatchedPollSyncer struct {
 
 func (f *fakeUnwatchedPollSyncer) SyncRootsSince(
 	ctx context.Context, roots []string, since time.Time,
-	onProgress sync.ProgressFunc,
-) sync.SyncStats {
+	onProgress agentsync.ProgressFunc,
+) agentsync.SyncStats {
 	f.calls++
 	f.roots = append([]string(nil), roots...)
 	f.since = since
 	f.callRoots = append(f.callRoots, append([]string(nil), roots...))
 	f.callSince = append(f.callSince, since)
-	return sync.SyncStats{}
+	return agentsync.SyncStats{}
 }
 
 func TestPollUnwatchedRootsOnceUsesScopedFullSync(t *testing.T) {
@@ -236,21 +238,101 @@ func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
 	assert.ElementsMatch(t, []string{sessionsDir, archivedDir}, roots[0].dirs)
 }
 
+// fakeEmitter records Emit calls; safe for concurrent use.
+type fakeEmitter struct {
+	count atomic.Int64
+}
+
+func (f *fakeEmitter) Emit(_ string) { f.count.Add(1) }
+
+func TestStartRemoteHostSync_EmitsAfterSuccess(t *testing.T) {
+	em := &fakeEmitter{}
+	syncFn := func() (int, error) { return 3, nil }
+
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	interval := 10 * time.Millisecond
+	go func() {
+		runRemoteHostSyncLoop("test-host", interval, syncFn, em, done)
+		close(exited)
+	}()
+
+	time.Sleep(3 * interval)
+	close(done)
+	<-exited
+
+	assert.Positive(t, em.count.Load(), "emitter should have been called at least once")
+}
+
+func TestStartRemoteHostSync_NoEmitOnZeroSynced(t *testing.T) {
+	em := &fakeEmitter{}
+	syncFn := func() (int, error) { return 0, nil }
+
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	interval := 10 * time.Millisecond
+	go func() {
+		runRemoteHostSyncLoop("test-host", interval, syncFn, em, done)
+		close(exited)
+	}()
+
+	time.Sleep(3 * interval)
+	close(done)
+	<-exited
+
+	assert.Zero(t, em.count.Load(), "emitter should not fire when no sessions synced")
+}
+
+func TestStartRemoteHostSync_NoEmitOnError(t *testing.T) {
+	em := &fakeEmitter{}
+	syncFn := func() (int, error) { return 0, errors.New("ssh failure") }
+
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	interval := 10 * time.Millisecond
+	go func() {
+		runRemoteHostSyncLoop("test-host", interval, syncFn, em, done)
+		close(exited)
+	}()
+
+	time.Sleep(3 * interval)
+	close(done)
+	<-exited
+
+	assert.Zero(t, em.count.Load(), "emitter should not fire when sync fails")
+}
+
+func TestStartRemoteHostSync_NilEmitterSafe(t *testing.T) {
+	syncFn := func() (int, error) { return 1, nil }
+
+	done := make(chan struct{})
+	exited := make(chan struct{})
+	interval := 10 * time.Millisecond
+	go func() {
+		runRemoteHostSyncLoop("test-host", interval, syncFn, nil, done)
+		close(exited)
+	}()
+
+	time.Sleep(2 * interval)
+	close(done)
+	<-exited
+}
+
 func TestResyncCoversSignals(t *testing.T) {
 	tests := []struct {
 		name     string
-		stats    sync.SyncStats
+		stats    agentsync.SyncStats
 		fellBack bool
 		want     bool
 	}{
 		{
 			name:  "clean resync no orphans covers signals",
-			stats: sync.SyncStats{Synced: 5},
+			stats: agentsync.SyncStats{Synced: 5},
 			want:  true,
 		},
 		{
 			name: "fell back to incremental sync needs backfill",
-			stats: sync.SyncStats{
+			stats: agentsync.SyncStats{
 				Synced: 2, Aborted: true,
 			},
 			fellBack: true,
@@ -258,14 +340,14 @@ func TestResyncCoversSignals(t *testing.T) {
 		},
 		{
 			name: "orphans copied need backfill",
-			stats: sync.SyncStats{
+			stats: agentsync.SyncStats{
 				Synced: 5, OrphanedCopied: 3,
 			},
 			want: false,
 		},
 		{
 			name: "orphans copied even with fallback false",
-			stats: sync.SyncStats{
+			stats: agentsync.SyncStats{
 				Synced: 0, OrphanedCopied: 1,
 			},
 			want: false,

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -257,7 +257,7 @@ func TestStartRemoteHostSync_EmitsAfterSuccess(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, em, nil, done)
+		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, em, nil, done)
 		close(exited)
 	}()
 
@@ -280,6 +280,7 @@ func TestRemoteHostSyncFuncSerializesWithEngineExclusiveLock(t *testing.T) {
 	remoteEntered := make(chan struct{})
 	releaseRemote := make(chan struct{})
 	syncFn := remoteHostSyncFunc(
+		context.Background(),
 		config.Config{},
 		database,
 		engine,
@@ -334,6 +335,32 @@ func TestRemoteHostSyncFuncSerializesWithEngineExclusiveLock(t *testing.T) {
 	}
 }
 
+func TestRemoteHostSyncFuncUsesCallerContext(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{},
+		Machine:   "local",
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	syncFn := remoteHostSyncFunc(
+		ctx,
+		config.Config{},
+		database,
+		engine,
+		config.RemoteHost{Host: "test-host"},
+		func(runCtx context.Context, _ *ssh.RemoteSync) (ssh.SyncStats, error) {
+			return ssh.SyncStats{}, runCtx.Err()
+		},
+	)
+
+	_, err = syncFn()
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestRemoteHostSyncFuncForcesFullWhenDatabaseNeedsResync(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	database, err := db.Open(dbPath)
@@ -357,6 +384,7 @@ func TestRemoteHostSyncFuncForcesFullWhenDatabaseNeedsResync(t *testing.T) {
 
 	var gotFull bool
 	syncFn := remoteHostSyncFunc(
+		context.Background(),
 		config.Config{},
 		database,
 		engine,
@@ -394,7 +422,7 @@ func TestStartRemoteHostSync_TracksRemoteWorkForIdleReaper(t *testing.T) {
 	done := make(chan struct{})
 	exited := make(chan struct{})
 	go func() {
-		runRemoteHostSyncLoop("test-host", time.Millisecond, syncFn, nil, idleTracker, done)
+		runRemoteHostSyncLoop(ctx, "test-host", time.Millisecond, syncFn, nil, idleTracker, done)
 		close(exited)
 	}()
 
@@ -420,6 +448,40 @@ func TestStartRemoteHostSync_TracksRemoteWorkForIdleReaper(t *testing.T) {
 	}
 }
 
+func TestStartRemoteHostSync_ExitsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	exited := make(chan struct{})
+	syncCalled := make(chan struct{}, 1)
+	go func() {
+		runRemoteHostSyncLoop(
+			ctx,
+			"test-host",
+			time.Hour,
+			func() (int, error) {
+				syncCalled <- struct{}{}
+				return 0, nil
+			},
+			nil,
+			nil,
+			nil,
+		)
+		close(exited)
+	}()
+
+	cancel()
+
+	select {
+	case <-exited:
+	case <-time.After(time.Second):
+		require.FailNow(t, "remote sync loop did not exit after context cancel")
+	}
+	select {
+	case <-syncCalled:
+		require.FailNow(t, "sync ran before context cancel")
+	default:
+	}
+}
+
 type scopedEmitter struct {
 	scopes chan string
 }
@@ -439,7 +501,7 @@ func TestStartRemoteHostSync_EmitsSessionsScopeAfterSuccess(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, em, nil, done)
+		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, em, nil, done)
 		close(exited)
 	}()
 
@@ -461,7 +523,7 @@ func TestStartRemoteHostSync_NoEmitOnZeroSynced(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, em, nil, done)
+		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, em, nil, done)
 		close(exited)
 	}()
 
@@ -480,7 +542,7 @@ func TestStartRemoteHostSync_NoEmitOnError(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, em, nil, done)
+		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, em, nil, done)
 		close(exited)
 	}()
 
@@ -498,7 +560,7 @@ func TestStartRemoteHostSync_NilEmitterSafe(t *testing.T) {
 	exited := make(chan struct{})
 	interval := 10 * time.Millisecond
 	go func() {
-		runRemoteHostSyncLoop("test-host", interval, syncFn, nil, nil, done)
+		runRemoteHostSyncLoop(context.Background(), "test-host", interval, syncFn, nil, nil, done)
 		close(exited)
 	}()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,12 +98,14 @@ type CustomModelRate struct {
 }
 
 // RemoteHost describes one SSH target for config-driven
-// `agentsview sync` fan-out. Host is required; User and Port are
-// optional (Port 0 means the ssh default of 22).
+// `agentsview sync` fan-out. Host is required; User, Port, and
+// Interval are optional (Port 0 means the ssh default of 22;
+// zero/empty Interval disables periodic remote sync for this host).
 type RemoteHost struct {
-	Host string `toml:"host" json:"host"`
-	User string `toml:"user,omitempty" json:"user,omitempty"`
-	Port int    `toml:"port,omitempty" json:"port,omitempty"`
+	Host     string        `toml:"host" json:"host"`
+	User     string        `toml:"user,omitempty" json:"user,omitempty"`
+	Port     int           `toml:"port,omitempty" json:"port,omitempty"`
+	Interval time.Duration `toml:"interval,omitempty" json:"interval,omitempty"`
 }
 
 // Config holds all application configuration.
@@ -214,6 +216,11 @@ func (c Config) ValidateRemoteHosts() error {
 			problems = append(problems,
 				fmt.Sprintf("entry %d (%q): invalid port %d",
 					i+1, h.Host, h.Port))
+		}
+		if h.Interval < 0 {
+			problems = append(problems,
+				fmt.Sprintf("entry %d (%q): invalid interval %s",
+					i+1, h.Host, h.Interval))
 		}
 		// Remote sync namespaces sessions and the skip cache by
 		// host alone (see ssh.RemoteSync), so two entries sharing a
@@ -648,9 +655,10 @@ func (c *Config) applyConfigTOML(data string) error {
 		hosts := make([]RemoteHost, len(file.RemoteHosts))
 		for i, h := range file.RemoteHosts {
 			hosts[i] = RemoteHost{
-				Host: strings.TrimSpace(h.Host),
-				User: strings.TrimSpace(h.User),
-				Port: h.Port,
+				Host:     strings.TrimSpace(h.Host),
+				User:     strings.TrimSpace(h.User),
+				Port:     h.Port,
+				Interval: h.Interval,
 			}
 		}
 		c.RemoteHosts = hosts

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1202,6 +1202,7 @@ func TestLoadFile_RemoteHosts(t *testing.T) {
 host = "devbox1"
 user = "jesse"
 port = 22
+interval = "5m"
 
 [[remote_hosts]]
 host = "  laptop2  "
@@ -1210,7 +1211,9 @@ host = "  laptop2  "
 	cfg := f.LoadMinimal(t)
 
 	require.Len(t, cfg.RemoteHosts, 2)
-	assert.Equal(t, RemoteHost{Host: "devbox1", User: "jesse", Port: 22}, cfg.RemoteHosts[0])
+	assert.Equal(t, RemoteHost{Host: "devbox1", User: "jesse", Port: 22, Interval: 5 * time.Minute}, cfg.RemoteHosts[0])
+	assert.Equal(t, 5*time.Minute, cfg.RemoteHosts[0].Interval)
+	assert.Equal(t, time.Duration(0), cfg.RemoteHosts[1].Interval)
 	// host is trimmed at load so validation and SSH see the same value
 	assert.Equal(t, RemoteHost{Host: "laptop2"}, cfg.RemoteHosts[1])
 }
@@ -1238,6 +1241,8 @@ func TestValidateRemoteHosts(t *testing.T) {
 		{"option shaped host", []RemoteHost{{Host: "-oProxyCommand=sh"}}, []string{"host must not begin with '-'"}},
 		{"option shaped user", []RemoteHost{{Host: "box", User: "-lroot"}}, []string{"user must not begin with '-'"}},
 		{"none configured", nil, nil},
+		{"negative interval", []RemoteHost{{Host: "a", Interval: -1}}, []string{"invalid interval"}},
+		{"zero interval ok", []RemoteHost{{Host: "a", Interval: 0}}, nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -235,12 +235,12 @@ func (s *Server) authorizeRemoteSyncHosts(
 		return hosts, nil
 	}
 
-	allowed := make(map[config.RemoteHost]struct{}, len(s.cfg.RemoteHosts))
+	allowed := make(map[remoteHostIdentity]struct{}, len(s.cfg.RemoteHosts))
 	for _, h := range s.cfg.RemoteHosts {
-		allowed[h] = struct{}{}
+		allowed[remoteHostIdentityFrom(h)] = struct{}{}
 	}
 	for _, h := range hosts {
-		if _, ok := allowed[h]; !ok {
+		if _, ok := allowed[remoteHostIdentityFrom(h)]; !ok {
 			return nil, apiError(
 				http.StatusForbidden,
 				fmt.Sprintf(
@@ -251,6 +251,20 @@ func (s *Server) authorizeRemoteSyncHosts(
 		}
 	}
 	return hosts, nil
+}
+
+type remoteHostIdentity struct {
+	Host string
+	User string
+	Port int
+}
+
+func remoteHostIdentityFrom(h config.RemoteHost) remoteHostIdentity {
+	return remoteHostIdentity{
+		Host: h.Host,
+		User: h.User,
+		Port: h.Port,
+	}
 }
 
 func (s *Server) runRemoteSyncRequest(

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -501,3 +501,35 @@ func TestHumaSyncRemotesAllowsNonLocalConfiguredExactHost(t *testing.T) {
 	assert.Equal(t, allowed.User, got.User)
 	assert.Equal(t, allowed.Port, got.Port)
 }
+
+func TestHumaSyncRemotesAllowsNonLocalConfiguredHostIgnoringInterval(t *testing.T) {
+	allowed := config.RemoteHost{
+		Host:     "allowed-box",
+		User:     "alice",
+		Port:     2222,
+		Interval: 5 * time.Minute,
+	}
+	requested := config.RemoteHost{
+		Host: "allowed-box",
+		User: "alice",
+		Port: 2222,
+	}
+	f := newSyncRouteFixture(t, withRemoteHosts(allowed))
+
+	var got *ssh.RemoteSync
+	stubRunRemoteSync(t, func(
+		_ context.Context,
+		rs *ssh.RemoteSync,
+	) (ssh.SyncStats, error) {
+		got = rs
+		return ssh.SyncStats{SessionsSynced: 1, SessionsTotal: 1}, nil
+	})
+	w := postRemoteSync(t, f.handler, []config.RemoteHost{requested},
+		withRemoteAddr("192.168.1.50:1234"))
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.NotNil(t, got)
+	assert.Equal(t, requested.Host, got.Host)
+	assert.Equal(t, requested.User, got.User)
+	assert.Equal(t, requested.Port, got.Port)
+}


### PR DESCRIPTION
The serve daemon already runs a local sync every fifteen minutes, but the `[[remote_hosts]]` entries introduced in #600 are only ever pulled by the one-shot `agentsview sync` command, so a long-running daemon never refreshes data from configured remotes on its own. Users running the dashboard as a persistent service have to drive remote pulls out-of-band with cron or a wrapper script, which is exactly the kind of scheduling the daemon is otherwise responsible for.

This adds an optional `interval` field to each `[[remote_hosts]]` entry, expressed as a duration string such as `"5m"` or `"1h"`. The field is decoded natively the same way `events_coalesce_interval` is, and it defaults to zero, which means "do not periodically sync this host." Configs written before this change behave exactly as they do today, and nothing starts pulling from a remote unless the user explicitly sets an interval.

On the daemon side, the periodic sync routine now launches one lightweight ticker goroutine per remote host that has a positive interval, each calling the same single-host sync path the CLI uses, in incremental mode, logging any failure without disturbing the others or the local periodic sync. After a successful remote sync pass, the goroutine emits a `data_changed` SSE event through the serve broadcaster so connected UI clients pick up the new data immediately rather than waiting for the next local periodic sync. The emitter is threaded as a `sync.Emitter` interface to keep the dependency direction clean; the CLI path continues to run without one. The remote host list is validated before these goroutines start; if validation fails the daemon logs a warning and keeps serving with local sync intact rather than refusing to start. The existing fifteen-minute local sync loop is left untouched, and because per-host remote sync reuses the already-tested `runRemoteSyncOnce` path, the new surface area is the configuration field, its validation, the scheduling glue, and the emit-on-success behavior.

Tests cover loading the new field from a config file, validating the negative-interval case, and the emit-on-success/no-emit-on-error/nil-emitter behavior of the sync loop.

Closes #412