### PR TITLE
fix(parser): compute per-turn Gemini context tokens as delta

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -237,9 +237,10 @@ import (
 // classification, so historical skill usage is backfilled on
 // re-parse.)
 //
+// (51: Gemini cumulative-to-delta token reparse.)
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 50
+const dataVersion = 51
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -696,8 +696,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionSanitizedMessageShape(t *testing.T) {
-	assert.Equal(t, 50, CurrentDataVersion(),
-		"sanitized message and session shape requires a data version bump")
+	assert.Equal(t, 51, CurrentDataVersion(),
+		"Gemini cumulative-to-delta reparse requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -276,19 +276,46 @@ func parseGeminiMessage(
 	}, true
 }
 
-func applyGeminiContextDeltas(messages []ParsedMessage) {
-	prev := 0
+func applyGeminiCumulativeDeltas(messages []ParsedMessage) {
+	var prevInput, prevCached int
 	for i := range messages {
 		if !messages[i].HasContextTokens {
 			continue
 		}
-		cumulative := messages[i].ContextTokens
-		delta := cumulative - prev
-		if delta < 0 {
-			delta = cumulative
+
+		var usage struct {
+			Input  int `json:"input_tokens"`
+			Output int `json:"output_tokens"`
+			Cached int `json:"cache_read_input_tokens"`
 		}
-		messages[i].ContextTokens = delta
-		prev = cumulative
+		if messages[i].TokenUsage != nil {
+			_ = json.Unmarshal(messages[i].TokenUsage, &usage)
+		}
+
+		inputDelta := usage.Input - prevInput
+		cachedDelta := usage.Cached - prevCached
+		if inputDelta < 0 {
+			inputDelta = usage.Input
+		}
+		if cachedDelta < 0 {
+			cachedDelta = usage.Cached
+		}
+
+		messages[i].ContextTokens = inputDelta + cachedDelta
+
+		if messages[i].TokenUsage != nil {
+			payload := map[string]int{
+				"input_tokens":            inputDelta,
+				"output_tokens":           usage.Output,
+				"cache_read_input_tokens": cachedDelta,
+			}
+			if raw, err := json.Marshal(payload); err == nil {
+				messages[i].TokenUsage = raw
+			}
+		}
+
+		prevInput = usage.Input
+		prevCached = usage.Cached
 	}
 }
 
@@ -300,7 +327,7 @@ func buildGeminiSession(
 	firstMessage string,
 	messages []ParsedMessage,
 ) *ParsedSession {
-	applyGeminiContextDeltas(messages)
+	applyGeminiCumulativeDeltas(messages)
 	var userCount int
 	for _, m := range messages {
 		if m.Role == RoleUser && m.Content != "" {

--- a/internal/parser/gemini.go
+++ b/internal/parser/gemini.go
@@ -276,6 +276,22 @@ func parseGeminiMessage(
 	}, true
 }
 
+func applyGeminiContextDeltas(messages []ParsedMessage) {
+	prev := 0
+	for i := range messages {
+		if !messages[i].HasContextTokens {
+			continue
+		}
+		cumulative := messages[i].ContextTokens
+		delta := cumulative - prev
+		if delta < 0 {
+			delta = cumulative
+		}
+		messages[i].ContextTokens = delta
+		prev = cumulative
+	}
+}
+
 func buildGeminiSession(
 	path, project, machine string,
 	info os.FileInfo,
@@ -284,6 +300,7 @@ func buildGeminiSession(
 	firstMessage string,
 	messages []ParsedMessage,
 ) *ParsedSession {
+	applyGeminiContextDeltas(messages)
 	var userCount int
 	for _, m := range messages {
 		if m.Role == RoleUser && m.Content != "" {

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -281,12 +281,18 @@ func TestParseGeminiSession_TokenUsage(t *testing.T) {
 		assert.Empty(t, msgs[0].TokenUsage)
 
 		// First assistant message (a1): input=1500, cached=100,
-		// output=200, thoughts=50
+		// output=200, thoughts=50; deltas equal cumulative (first turn).
 		assert.Equal(t, 1600, msgs[1].ContextTokens)
 		assert.Equal(t, 250, msgs[1].OutputTokens)
 		assert.True(t, msgs[1].HasContextTokens)
 		assert.True(t, msgs[1].HasOutputTokens)
 		assert.NotEmpty(t, msgs[1].TokenUsage)
+		assert.Equal(t, int64(1500),
+			gjson.GetBytes(msgs[1].TokenUsage, "input_tokens").Int())
+		assert.Equal(t, int64(250),
+			gjson.GetBytes(msgs[1].TokenUsage, "output_tokens").Int())
+		assert.Equal(t, int64(100),
+			gjson.GetBytes(msgs[1].TokenUsage, "cache_read_input_tokens").Int())
 
 		// Second user message has no tokens
 		assert.Equal(t, 0, msgs[2].ContextTokens)
@@ -294,12 +300,20 @@ func TestParseGeminiSession_TokenUsage(t *testing.T) {
 		assert.False(t, msgs[2].HasContextTokens)
 		assert.False(t, msgs[2].HasOutputTokens)
 
-		// Second assistant message (a2): cumulative=2050, delta from 1600
-		assert.Equal(t, 450, msgs[3].ContextTokens)
+		// Second assistant message (a2): input=2000, cached=50;
+		// cached went down from 100 so it resets, inputDelta=500,
+		// cachedDelta=50, ContextTokens=550.
+		assert.Equal(t, 550, msgs[3].ContextTokens)
 		assert.Equal(t, 400, msgs[3].OutputTokens)
 		assert.True(t, msgs[3].HasContextTokens)
 		assert.True(t, msgs[3].HasOutputTokens)
 		assert.NotEmpty(t, msgs[3].TokenUsage)
+		assert.Equal(t, int64(500),
+			gjson.GetBytes(msgs[3].TokenUsage, "input_tokens").Int())
+		assert.Equal(t, int64(400),
+			gjson.GetBytes(msgs[3].TokenUsage, "output_tokens").Int())
+		assert.Equal(t, int64(50),
+			gjson.GetBytes(msgs[3].TokenUsage, "cache_read_input_tokens").Int())
 
 		// Session totals
 		assert.Equal(t, 650, sess.TotalOutputTokens)
@@ -507,15 +521,17 @@ func TestParseGeminiSession_ContextTokensDelta(t *testing.T) {
 		assert.False(t, msgs[0].HasContextTokens)
 		assert.False(t, msgs[2].HasContextTokens)
 
-		// gemini msg 0 (answer one): cumulative=10000, delta from 0 = 10000
+		// gemini msg 0 (answer one): input=10000, cached=0, deltas=10000+0
 		assert.Equal(t, 10000, msgs[1].ContextTokens)
-		// gemini msg 1 (answer two): cumulative=25000, delta from 10000 = 15000
+		// gemini msg 1 (answer two): input=22000, cached=3000,
+		// inputDelta=12000, cachedDelta=3000, total=15000
 		assert.Equal(t, 15000, msgs[3].ContextTokens)
-		// gemini msg 2 (answer three): cumulative=60000, delta from 25000 = 35000
-		assert.Equal(t, 35000, msgs[4].ContextTokens)
+		// gemini msg 2 (answer three): input=60000, cached=0;
+		// cached reset (3000->0), inputDelta=38000, cachedDelta=0, total=38000
+		assert.Equal(t, 38000, msgs[4].ContextTokens)
 
 		// PeakContextTokens is the largest delta, not the final cumulative
-		assert.Equal(t, 35000, sess.PeakContextTokens)
+		assert.Equal(t, 38000, sess.PeakContextTokens)
 	})
 
 	t.Run("counter reset clamps to cumulative", func(t *testing.T) {

--- a/internal/parser/gemini_parser_test.go
+++ b/internal/parser/gemini_parser_test.go
@@ -294,9 +294,8 @@ func TestParseGeminiSession_TokenUsage(t *testing.T) {
 		assert.False(t, msgs[2].HasContextTokens)
 		assert.False(t, msgs[2].HasOutputTokens)
 
-		// Second assistant message (a2): input=2000, cached=50,
-		// output=300, thoughts=100
-		assert.Equal(t, 2050, msgs[3].ContextTokens)
+		// Second assistant message (a2): cumulative=2050, delta from 1600
+		assert.Equal(t, 450, msgs[3].ContextTokens)
 		assert.Equal(t, 400, msgs[3].OutputTokens)
 		assert.True(t, msgs[3].HasContextTokens)
 		assert.True(t, msgs[3].HasOutputTokens)
@@ -304,7 +303,7 @@ func TestParseGeminiSession_TokenUsage(t *testing.T) {
 
 		// Session totals
 		assert.Equal(t, 650, sess.TotalOutputTokens)
-		assert.Equal(t, 2050, sess.PeakContextTokens)
+		assert.Equal(t, 1600, sess.PeakContextTokens)
 		assert.True(t, sess.HasTotalOutputTokens)
 		assert.True(t, sess.HasPeakContextTokens)
 	})
@@ -489,5 +488,63 @@ func TestParseGeminiSession_EdgeCases(t *testing.T) {
 		path := createTestFile(t, "session.json", content)
 		_, _, err := ParseGeminiSession(path, "my_project", "local")
 		assert.Error(t, err)
+	})
+}
+
+func TestParseGeminiSession_ContextTokensDelta(t *testing.T) {
+	t.Run("multi-turn increasing cumulative", func(t *testing.T) {
+		content := `{"sessionId":"sess-ctx-delta","startTime":"2026-04-23T16:12:42.783Z","lastUpdated":"2026-04-23T16:13:42.783Z","messages":[
+  {"type":"user","timestamp":"2026-04-23T16:12:43Z","content":[{"text":"first question"}]},
+  {"type":"gemini","timestamp":"2026-04-23T16:12:45Z","content":"answer one","tokens":{"input":10000,"output":50,"cached":0}},
+  {"type":"user","timestamp":"2026-04-23T16:12:50Z","content":[{"text":"second question"}]},
+  {"type":"gemini","timestamp":"2026-04-23T16:12:55Z","content":"answer two","tokens":{"input":22000,"output":80,"cached":3000}},
+  {"type":"gemini","timestamp":"2026-04-23T16:13:05Z","content":"answer three","tokens":{"input":60000,"output":120,"cached":0}}
+]}`
+		sess, msgs := runGeminiParserTest(t, content)
+
+		// user messages have no tokens
+		require.Len(t, msgs, 5)
+		assert.False(t, msgs[0].HasContextTokens)
+		assert.False(t, msgs[2].HasContextTokens)
+
+		// gemini msg 0 (answer one): cumulative=10000, delta from 0 = 10000
+		assert.Equal(t, 10000, msgs[1].ContextTokens)
+		// gemini msg 1 (answer two): cumulative=25000, delta from 10000 = 15000
+		assert.Equal(t, 15000, msgs[3].ContextTokens)
+		// gemini msg 2 (answer three): cumulative=60000, delta from 25000 = 35000
+		assert.Equal(t, 35000, msgs[4].ContextTokens)
+
+		// PeakContextTokens is the largest delta, not the final cumulative
+		assert.Equal(t, 35000, sess.PeakContextTokens)
+	})
+
+	t.Run("counter reset clamps to cumulative", func(t *testing.T) {
+		content := `{"sessionId":"sess-ctx-reset","startTime":"2026-04-23T16:12:42.783Z","lastUpdated":"2026-04-23T16:13:42.783Z","messages":[
+  {"type":"user","timestamp":"2026-04-23T16:12:43Z","content":[{"text":"first"}]},
+  {"type":"gemini","timestamp":"2026-04-23T16:12:45Z","content":"reply one","tokens":{"input":10000,"output":50,"cached":0}},
+  {"type":"user","timestamp":"2026-04-23T16:12:50Z","content":[{"text":"second"}]},
+  {"type":"gemini","timestamp":"2026-04-23T16:12:55Z","content":"reply two","tokens":{"input":25000,"output":80,"cached":0}},
+  {"type":"user","timestamp":"2026-04-23T16:13:00Z","content":[{"text":"third"}]},
+  {"type":"gemini","timestamp":"2026-04-23T16:13:05Z","content":"reply three","tokens":{"input":5000,"output":120,"cached":0}}
+]}`
+		_, msgs := runGeminiParserTest(t, content)
+
+		require.Len(t, msgs, 6)
+		// deltas: 10000, 15000, 5000 (reset clamps to cumulative)
+		assert.Equal(t, 10000, msgs[1].ContextTokens)
+		assert.Equal(t, 15000, msgs[3].ContextTokens)
+		assert.Equal(t, 5000, msgs[5].ContextTokens)
+	})
+
+	t.Run("no token field", func(t *testing.T) {
+		content := `{"sessionId":"sess-ctx-no-tokens","startTime":"2026-04-23T16:12:42.783Z","lastUpdated":"2026-04-23T16:12:50.783Z","messages":[
+  {"type":"user","timestamp":"2026-04-23T16:12:43Z","content":[{"text":"hello"}]},
+  {"type":"gemini","timestamp":"2026-04-23T16:12:45Z","content":"hi there"}
+]}`
+		_, msgs := runGeminiParserTest(t, content)
+
+		require.Len(t, msgs, 2)
+		assert.False(t, msgs[1].HasContextTokens)
+		assert.Equal(t, 0, msgs[1].ContextTokens)
 	})
 }


### PR DESCRIPTION
Gemini CLI records `tokens.input` as a monotonically increasing cumulative total, a running sum of every input token consumed up to that point in the session rather than the input for a single turn. The parser copies that raw cumulative value straight into each message's context size at `internal/parser/gemini.go:269` (`ContextTokens: tok.Input + tok.Cached`) and into the normalized `TokenUsage` JSON via `normalizedGeminiTokenUsage`, so the displayed per-turn context window and the per-message usage/cost data both inflate steadily across the session: a tenth message that actually consumed roughly fifteen thousand context tokens is shown using the full running total of every prior turn. The same value also feeds the session-level peak, which `accumulateMessageTokenUsage` derives as the maximum `ContextTokens` across messages, so the reported peak context is simply the final cumulative figure rather than the largest real per-turn window.

This computes the per-turn values as deltas across both surfaces. A single pass (`applyGeminiCumulativeDeltas`) walks each session's messages in order and, for every message that carries token counts, parses the cumulative `input` and `cached` values from `TokenUsage`, computes independent per-field deltas, rebuilds `TokenUsage` with the corrected values, and derives `ContextTokens` from the individual deltas. Output tokens are already per-turn in Gemini and stay untouched. Each field resets independently when its cumulative count decreases (context compaction), treating the current value as a fresh baseline rather than emitting a negative size. The pass runs as the first step of `buildGeminiSession`, before token aggregation, so per-message context sizes, per-message usage/cost JSON, and the session peak are all computed from the corrected per-turn values. The parser callers and `parseGeminiMessage` keep their existing shapes; the cumulative-to-delta conversion is centralized in one place that both the single-document and JSONL session paths already flow through.

A parser test synthesizes an inline Gemini session with increasing cumulative input and cached counts and asserts that each message reports per-turn deltas in both `ContextTokens` and `TokenUsage`, and that the session peak reflects the largest delta rather than the final running total.

Closes #348