### PR TITLE
feat(frontend): add control chrome guard

### DIFF
--- a/frontend/src/lib/components/activity/ActivityInsight.svelte
+++ b/frontend/src/lib/components/activity/ActivityInsight.svelte
@@ -12,6 +12,9 @@
   import { highlightCodeFences } from "../../utils/highlight-fences.js";
   import type { Insight, InsightsResponse, AgentName } from "../../api/types.js";
   import { LightbulbIcon, PlusIcon } from "../../icons.js";
+  import OptionTypeahead, {
+    type TypeaheadOption,
+  } from "../layout/OptionTypeahead.svelte";
 
   let {
     dateFrom,
@@ -62,6 +65,13 @@
         ? "Waiting for server version"
         : "Generate insight",
   );
+  const agentOptions: TypeaheadOption[] = [
+    { name: "claude", label: "Claude", displayLabel: "Claude" },
+    { name: "codex", label: "Codex", displayLabel: "Codex" },
+    { name: "copilot", label: "Copilot", displayLabel: "Copilot" },
+    { name: "gemini", label: "Gemini", displayLabel: "Gemini" },
+    { name: "kiro", label: "Kiro", displayLabel: "Kiro" },
+  ];
 
   function abortGeneration() {
     handle?.abort();
@@ -111,8 +121,8 @@
 
   // The agent choice is shared with the standalone Insights page via the
   // insights store, so picking one here and there stays in sync.
-  function onAgentChange(e: Event) {
-    insights.setAgent((e.currentTarget as HTMLSelectElement).value as AgentName);
+  function onAgentChange(value: string) {
+    insights.setAgent(value as AgentName);
   }
 
   function handleGenerate() {
@@ -175,20 +185,18 @@
   </header>
 
   {#snippet agentPicker()}
-    <select
-      class="agent-select"
-      value={insights.agent}
-      onchange={onAgentChange}
-      disabled={generationUnavailable}
-      title="Agent CLI used to generate the insight"
-      aria-label="Insight agent"
-    >
-      <option value="claude">Claude</option>
-      <option value="codex">Codex</option>
-      <option value="copilot">Copilot</option>
-      <option value="gemini">Gemini</option>
-      <option value="kiro">Kiro</option>
-    </select>
+    <div class="agent-typeahead">
+      <OptionTypeahead
+        options={agentOptions}
+        value={insights.agent}
+        disabled={generationUnavailable}
+        title="Agent CLI used to generate the insight"
+        fallbackLabel={insights.agent}
+        placeholder="Insight agent"
+        emptyLabel="No matching agents"
+        onselect={onAgentChange}
+      />
+    </div>
   {/snippet}
 
   {#if loading}
@@ -331,26 +339,11 @@
     gap: 8px;
   }
 
-  .agent-select {
-    height: 28px;
-    padding: 0 6px;
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    color: var(--text-secondary);
-    cursor: pointer;
-    transition: border-color 0.15s;
-  }
-
-  .agent-select:focus {
-    outline: none;
-    border-color: var(--accent-blue);
-  }
-
-  .agent-select:disabled {
-    opacity: 0.45;
-    cursor: default;
+  .agent-typeahead {
+    --typeahead-min-width: 96px;
+    --typeahead-max-width: 112px;
+    --typeahead-control-height: 28px;
+    --typeahead-control-padding: 0 6px;
   }
 
   .generate-btn {

--- a/frontend/src/lib/components/activity/ActivityInsight.test.ts
+++ b/frontend/src/lib/components/activity/ActivityInsight.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import { render, screen, fireEvent } from "@testing-library/svelte";
 import { tick } from "svelte";
 
@@ -29,8 +29,10 @@ vi.mock("../../stores/sync.svelte.js", () => ({
 }));
 vi.mock("../../stores/insights.svelte.js", () => ({
   insights: {
-    setType: mocks.setType, setDateFrom: mocks.setDateFrom,
-    setDateTo: mocks.setDateTo, setProject: mocks.setProject,
+    setType: mocks.setType,
+    setDateFrom: mocks.setDateFrom,
+    setDateTo: mocks.setDateTo,
+    setProject: mocks.setProject,
     setAgent: mocks.setAgent,
     get agent() {
       return mocks.agent;
@@ -62,15 +64,28 @@ describe("ActivityInsight", () => {
     render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
     await settle();
     expect(mocks.getInsights).toHaveBeenCalledWith({
-      type: "daily_activity", dateFrom: "2026-06-15", dateTo: "2026-06-21",
+      type: "daily_activity",
+      dateFrom: "2026-06-15",
+      dateTo: "2026-06-21",
     });
   });
 
   it("ignores project-scoped insights and shows the empty state", async () => {
     mocks.getInsights.mockResolvedValue({
-      insights: [{ id: 1, project: "p1", content: "scoped", type: "daily_activity",
-        date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
-        model: null, prompt: null, created_at: "2026-06-21T00:00:00Z" }],
+      insights: [
+        {
+          id: 1,
+          project: "p1",
+          content: "scoped",
+          type: "daily_activity",
+          date_from: "2026-06-15",
+          date_to: "2026-06-21",
+          agent: "claude",
+          model: null,
+          prompt: null,
+          created_at: "2026-06-21T00:00:00Z",
+        },
+      ],
     });
     render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
     await settle();
@@ -84,7 +99,10 @@ describe("ActivityInsight", () => {
     await fireEvent.click(screen.getByRole("button", { name: /generate/i }));
     expect(mocks.generateInsight).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: "daily_activity", date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
+        type: "daily_activity",
+        date_from: "2026-06-15",
+        date_to: "2026-06-21",
+        agent: "claude",
       }),
       expect.any(Function),
     );
@@ -93,9 +111,10 @@ describe("ActivityInsight", () => {
   it("lets the user choose the insight agent", async () => {
     render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
     await settle();
-    const select = screen.getByLabelText(/insight agent/i) as HTMLSelectElement;
-    expect(select.value).toBe("claude");
-    await fireEvent.change(select, { target: { value: "codex" } });
+    const trigger = screen.getByLabelText(/insight agent/i);
+    expect(trigger.textContent).toContain("Claude");
+    await fireEvent.click(trigger);
+    await fireEvent.mouseDown(screen.getByRole("option", { name: "Codex" }));
     expect(mocks.setAgent).toHaveBeenCalledWith("codex");
   });
 
@@ -124,7 +143,8 @@ describe("ActivityInsight", () => {
       }),
     });
     const { rerender } = render(ActivityInsight, {
-      dateFrom: "2026-06-15", dateTo: "2026-06-21",
+      dateFrom: "2026-06-15",
+      dateTo: "2026-06-21",
     });
     await settle();
 
@@ -139,9 +159,16 @@ describe("ActivityInsight", () => {
 
     // The aborted generation settles late; its result must not reach the panel.
     resolveStale({
-      id: 99, project: null, content: "STALE RESULT", type: "daily_activity",
-      date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
-      model: null, prompt: null, created_at: "2026-06-21T00:00:00Z",
+      id: 99,
+      project: null,
+      content: "STALE RESULT",
+      type: "daily_activity",
+      date_from: "2026-06-15",
+      date_to: "2026-06-21",
+      agent: "claude",
+      model: null,
+      prompt: null,
+      created_at: "2026-06-21T00:00:00Z",
     });
     await settle();
 
@@ -172,14 +199,28 @@ describe("ActivityInsight", () => {
     mocks.getInsights.mockResolvedValue({
       insights: [
         {
-          id: 3, project: null, content: "SINGLE DAY", type: "daily_activity",
-          date_from: "2026-06-15", date_to: "2026-06-15", agent: "claude",
-          model: null, prompt: null, created_at: "2026-06-22T00:00:00Z",
+          id: 3,
+          project: null,
+          content: "SINGLE DAY",
+          type: "daily_activity",
+          date_from: "2026-06-15",
+          date_to: "2026-06-15",
+          agent: "claude",
+          model: null,
+          prompt: null,
+          created_at: "2026-06-22T00:00:00Z",
         },
         {
-          id: 2, project: null, content: "WEEKLY ROLLUP", type: "daily_activity",
-          date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
-          model: null, prompt: null, created_at: "2026-06-21T00:00:00Z",
+          id: 2,
+          project: null,
+          content: "WEEKLY ROLLUP",
+          type: "daily_activity",
+          date_from: "2026-06-15",
+          date_to: "2026-06-21",
+          agent: "claude",
+          model: null,
+          prompt: null,
+          created_at: "2026-06-21T00:00:00Z",
         },
       ],
     });
@@ -194,9 +235,15 @@ describe("ActivityInsight", () => {
     mocks.getInsights.mockResolvedValue({
       insights: [
         {
-          id: 5, project: null, content: "summary", type: "daily_activity",
-          date_from: "2026-06-15", date_to: "2026-06-21", agent: "claude",
-          model: "claude-sonnet-4.5", prompt: null,
+          id: 5,
+          project: null,
+          content: "summary",
+          type: "daily_activity",
+          date_from: "2026-06-15",
+          date_to: "2026-06-21",
+          agent: "claude",
+          model: "claude-sonnet-4.5",
+          prompt: null,
           created_at: "2026-06-21T00:00:00Z",
         },
       ],
@@ -211,15 +258,23 @@ describe("ActivityInsight", () => {
       .mockResolvedValueOnce({
         insights: [
           {
-            id: 9, project: null, content: "A", type: "daily_activity",
-            date_from: "2026-06-01", date_to: "2026-06-07", agent: "claude",
-            model: "model-A", prompt: null, created_at: "2026-06-07T00:00:00Z",
+            id: 9,
+            project: null,
+            content: "A",
+            type: "daily_activity",
+            date_from: "2026-06-01",
+            date_to: "2026-06-07",
+            agent: "claude",
+            model: "model-A",
+            prompt: null,
+            created_at: "2026-06-07T00:00:00Z",
           },
         ],
       })
       .mockReturnValueOnce(new Promise(() => {})); // second range stays pending
     const { rerender } = render(ActivityInsight, {
-      dateFrom: "2026-06-01", dateTo: "2026-06-07",
+      dateFrom: "2026-06-01",
+      dateTo: "2026-06-07",
     });
     await settle();
     expect(document.body.textContent).toContain("model-A");

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -16,7 +16,9 @@
   } from "../../stores/yokedDates.svelte.js";
   import RefreshControl from "../shared/RefreshControl.svelte";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
-  import { ChevronDownIcon } from "../../icons.js";
+  import OptionTypeahead, {
+    type TypeaheadOption,
+  } from "../layout/OptionTypeahead.svelte";
   import {
     addDays,
     endOfMonth,
@@ -71,6 +73,48 @@
 
   const earliestSession = $derived(sync.stats?.earliest_session ?? null);
   const today = $derived(localDateStr(new Date()));
+  const agentOptions = $derived.by((): TypeaheadOption[] => [
+    {
+      name: "",
+      label: "All Agents",
+      displayLabel: "All Agents",
+    },
+    ...activity.agents.map((agent) => ({
+      name: agent.name,
+      label: `${agent.name} (${agent.session_count})`,
+      displayLabel: agent.name,
+      count: agent.session_count,
+    })),
+  ]);
+  const machineOptions = $derived.by((): TypeaheadOption[] => [
+    {
+      name: "",
+      label: "All Machines",
+      displayLabel: "All Machines",
+    },
+    ...activity.machines.map((machine) => ({
+      name: machine,
+      label: machine,
+      displayLabel: machine,
+    })),
+  ]);
+  const automationOptions: TypeaheadOption[] = [
+    {
+      name: "all",
+      label: "All Sessions",
+      displayLabel: "All Sessions",
+    },
+    {
+      name: "interactive",
+      label: "Interactive",
+      displayLabel: "Interactive",
+    },
+    {
+      name: "automated",
+      label: "Automated",
+      displayLabel: "Automated",
+    },
+  ];
 
   // The activity store is the source of truth: day/week/month map to a calendar
   // period anchored on `date`; custom maps to from/to. Relative windows have no
@@ -200,20 +244,18 @@
     activity.load();
   }
 
-  function onAgentChange(e: Event) {
-    activity.setAgent((e.currentTarget as HTMLSelectElement).value);
+  function onAgentChange(value: string) {
+    activity.setAgent(value);
     activity.load();
   }
 
-  function onMachineChange(e: Event) {
-    activity.setMachine((e.currentTarget as HTMLSelectElement).value);
+  function onMachineChange(value: string) {
+    activity.setMachine(value);
     activity.load();
   }
 
-  function onAutomationChange(e: Event) {
-    activity.setAutomation(
-      (e.currentTarget as HTMLSelectElement).value as Automation,
-    );
+  function onAutomationChange(value: string) {
+    activity.setAutomation(value as Automation);
     activity.load();
   }
 
@@ -270,62 +312,39 @@
       onselect={onProjectSelect}
     />
 
-    <div class="filter-select-wrap">
-      <select
-        class="filter-select"
+    <div class="toolbar-typeahead">
+      <OptionTypeahead
+        options={agentOptions}
         value={activity.agent}
-        onchange={onAgentChange}
-        aria-label="Filter by agent"
-      >
-        <option value="">All Agents</option>
-        {#each activity.agents as a}
-          <option value={a.name}>{a.name}</option>
-        {/each}
-      </select>
-      <ChevronDownIcon
-        class="filter-select-chevron"
-        size="12"
-        strokeWidth="2.2"
-        aria-hidden="true"
+        fallbackLabel="All Agents"
+        placeholder="Filter agents"
+        title="Filter by agent"
+        emptyLabel="No matching agents"
+        onselect={onAgentChange}
       />
     </div>
 
-    <div class="filter-select-wrap">
-      <select
-        class="filter-select"
+    <div class="toolbar-typeahead">
+      <OptionTypeahead
+        options={machineOptions}
         value={activity.machine}
-        onchange={onMachineChange}
-        aria-label="Filter by machine"
-      >
-        <option value="">All Machines</option>
-        {#each activity.machines as m}
-          <option value={m}>{m}</option>
-        {/each}
-      </select>
-      <ChevronDownIcon
-        class="filter-select-chevron"
-        size="12"
-        strokeWidth="2.2"
-        aria-hidden="true"
+        fallbackLabel="All Machines"
+        placeholder="Filter machines"
+        title="Filter by machine"
+        emptyLabel="No matching machines"
+        onselect={onMachineChange}
       />
     </div>
 
-    <div class="filter-select-wrap">
-      <select
-        class="filter-select"
+    <div class="toolbar-typeahead compact">
+      <OptionTypeahead
+        options={automationOptions}
         value={activity.automation}
-        onchange={onAutomationChange}
-        aria-label="Filter by automation"
-      >
-        <option value="all">All Sessions</option>
-        <option value="interactive">Interactive</option>
-        <option value="automated">Automated</option>
-      </select>
-      <ChevronDownIcon
-        class="filter-select-chevron"
-        size="12"
-        strokeWidth="2.2"
-        aria-hidden="true"
+        fallbackLabel="All Sessions"
+        placeholder="Filter automation"
+        title="Filter by automation"
+        emptyLabel="No automation filters"
+        onselect={onAutomationChange}
       />
     </div>
 
@@ -413,45 +432,14 @@
     flex-shrink: 0;
   }
 
-  .filter-select-wrap {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    color: var(--text-secondary);
+  .toolbar-typeahead {
+    --typeahead-min-width: 132px;
+    --typeahead-max-width: 184px;
   }
 
-  .filter-select {
-    appearance: none;
-    -webkit-appearance: none;
-    height: 26px;
-    padding: 0 28px 0 8px;
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    color: inherit;
-    cursor: pointer;
-  }
-
-  .filter-select:hover {
-    border-color: var(--border-default);
-  }
-
-  .filter-select:focus {
-    outline: none;
-    border-color: var(--accent-blue);
-  }
-
-  :global(.filter-select-chevron) {
-    position: absolute;
-    top: 50%;
-    right: 8px;
-    width: 12px;
-    height: 12px;
-    color: currentColor;
-    opacity: 0.72;
-    pointer-events: none;
-    transform: translateY(-50%);
+  .toolbar-typeahead.compact {
+    --typeahead-min-width: 118px;
+    --typeahead-max-width: 150px;
   }
 
   .activity-content {

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { Report } from "../../api/types.js";
   import { activeSessionsInSlot } from "./activeSessions.js";
+  import OptionTypeahead, {
+    type TypeaheadOption,
+  } from "../layout/OptionTypeahead.svelte";
   import type {
     ActivityBucket,
     ActivityReportInterval,
@@ -173,6 +176,11 @@
   // cost. Each metric scales to its own max so the line reads as a shape over
   // the concurrency bars, not an absolute count on the agent axis.
   let overlayMetric = $state<"none" | "tokens" | "cost">("none");
+  const overlayOptions: TypeaheadOption[] = [
+    { name: "none", label: "None", displayLabel: "None" },
+    { name: "tokens", label: "Tokens", displayLabel: "Tokens" },
+    { name: "cost", label: "Cost", displayLabel: "Cost" },
+  ];
 
   function bucketOverlayValue(b: ActivityBucket): number {
     return overlayMetric === "cost" ? b.cost : b.output_tokens;
@@ -432,6 +440,10 @@
   const svgW = $derived(plotWidth + Y_LABEL_W + rightAxisW);
   const svgH = $derived(CHART_H + STRIP_GAP + STRIP_H + X_LABEL_H);
   const stripY = $derived(CHART_H + STRIP_GAP);
+
+  function setOverlayMetric(value: string) {
+    overlayMetric = value as "none" | "tokens" | "cost";
+  }
 </script>
 
 <div class="timeline">
@@ -446,14 +458,18 @@
           <span class="swatch automated"></span>Automated
         </span>
       </div>
-      <label class="overlay-toggle">
+      <div class="overlay-toggle">
         <span>Overlay</span>
-        <select bind:value={overlayMetric} aria-label="Concurrency overlay metric">
-          <option value="none">None</option>
-          <option value="tokens">Tokens</option>
-          <option value="cost">Cost</option>
-        </select>
-      </label>
+        <OptionTypeahead
+          options={overlayOptions}
+          value={overlayMetric}
+          fallbackLabel="None"
+          placeholder="Overlay metric"
+          title="Concurrency overlay metric"
+          emptyLabel="No metrics"
+          onselect={setOverlayMetric}
+        />
+      </div>
     </div>
   </div>
 
@@ -674,18 +690,14 @@
     gap: 4px;
     font-size: 10px;
     color: var(--text-muted);
-    cursor: pointer;
   }
 
-  .overlay-toggle select {
-    height: 20px;
-    padding: 0 4px;
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    font-size: 10px;
-    color: var(--text-secondary);
-    cursor: pointer;
+  .overlay-toggle :global(.typeahead) {
+    --typeahead-min-width: 86px;
+    --typeahead-max-width: 96px;
+    --typeahead-control-height: 22px;
+    --typeahead-control-padding: 0 6px;
+    --typeahead-control-font-size: 10px;
   }
 
   .timeline-body {

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { fireEvent, render } from "@testing-library/svelte";
 import { mount, tick, unmount } from "svelte";
 import ConcurrencyTimeline from "./ConcurrencyTimeline.svelte";
@@ -14,11 +14,56 @@ function makeReport(overrides: Partial<Report> = {}): Report {
   // idx 2 (peak 3) carries a mixed split (2 interactive / 1 automated) for the
   // stacking and split-tooltip tests; idx 3 (peak 1) is all-interactive.
   const buckets = [
-    { start: "2026-06-16T00:00:00Z", end: "2026-06-16T03:00:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0, interactive_at_peak: 0, automated_at_peak: 0 },
-    { start: "2026-06-16T03:00:00Z", end: "2026-06-16T06:00:00Z", max_agents: 2, agent_minutes: 12, output_tokens: 4000, cost: 0.4, interactive_at_peak: 1, automated_at_peak: 1 },
-    { start: "2026-06-16T06:00:00Z", end: "2026-06-16T09:00:00Z", max_agents: 3, agent_minutes: 30, output_tokens: 9000, cost: 0.9, interactive_at_peak: 2, automated_at_peak: 1 },
-    { start: "2026-06-16T09:00:00Z", end: "2026-06-16T12:00:00Z", max_agents: 1, agent_minutes: 8, output_tokens: 2000, cost: 0.2, interactive_at_peak: 1, automated_at_peak: 0 },
-    { start: "2026-06-16T12:00:00Z", end: "2026-06-16T15:00:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0, interactive_at_peak: 0, automated_at_peak: 0 },
+    {
+      start: "2026-06-16T00:00:00Z",
+      end: "2026-06-16T03:00:00Z",
+      max_agents: 0,
+      agent_minutes: 0,
+      output_tokens: 0,
+      cost: 0,
+      interactive_at_peak: 0,
+      automated_at_peak: 0,
+    },
+    {
+      start: "2026-06-16T03:00:00Z",
+      end: "2026-06-16T06:00:00Z",
+      max_agents: 2,
+      agent_minutes: 12,
+      output_tokens: 4000,
+      cost: 0.4,
+      interactive_at_peak: 1,
+      automated_at_peak: 1,
+    },
+    {
+      start: "2026-06-16T06:00:00Z",
+      end: "2026-06-16T09:00:00Z",
+      max_agents: 3,
+      agent_minutes: 30,
+      output_tokens: 9000,
+      cost: 0.9,
+      interactive_at_peak: 2,
+      automated_at_peak: 1,
+    },
+    {
+      start: "2026-06-16T09:00:00Z",
+      end: "2026-06-16T12:00:00Z",
+      max_agents: 1,
+      agent_minutes: 8,
+      output_tokens: 2000,
+      cost: 0.2,
+      interactive_at_peak: 1,
+      automated_at_peak: 0,
+    },
+    {
+      start: "2026-06-16T12:00:00Z",
+      end: "2026-06-16T15:00:00Z",
+      max_agents: 0,
+      agent_minutes: 0,
+      output_tokens: 0,
+      cost: 0,
+      interactive_at_peak: 0,
+      automated_at_peak: 0,
+    },
   ];
   const report = {
     peak: { agents: 3, at: "2026-06-16T06:00:00Z" },
@@ -71,15 +116,44 @@ function popoverReport(): Report {
     bucket_count: 2,
     elapsed_bucket_count: 1,
     buckets: [
-      { start: "2026-06-16T10:00:00Z", end: "2026-06-16T10:05:00Z", max_agents: 2, agent_minutes: 4, output_tokens: 0, cost: 0 },
+      {
+        start: "2026-06-16T10:00:00Z",
+        end: "2026-06-16T10:05:00Z",
+        max_agents: 2,
+        agent_minutes: 4,
+        output_tokens: 0,
+        cost: 0,
+      },
     ],
     by_session: [
-      { session_id: "a", title: "Alpha", project: "p", agent: "claude", primary_model: "m",
-        models: ["m"], agent_minutes: 2, cost: 0, output_tokens: 0,
-        first_active: "2026-06-16T10:00:00Z", last_active: "2026-06-16T10:02:00Z", timing_quality: "timed" },
-      { session_id: "b", title: "Beta", project: "p", agent: "claude", primary_model: "m",
-        models: ["m"], agent_minutes: 2, cost: 0, output_tokens: 0,
-        first_active: "2026-06-16T10:01:00Z", last_active: "2026-06-16T10:03:00Z", timing_quality: "timed" },
+      {
+        session_id: "a",
+        title: "Alpha",
+        project: "p",
+        agent: "claude",
+        primary_model: "m",
+        models: ["m"],
+        agent_minutes: 2,
+        cost: 0,
+        output_tokens: 0,
+        first_active: "2026-06-16T10:00:00Z",
+        last_active: "2026-06-16T10:02:00Z",
+        timing_quality: "timed",
+      },
+      {
+        session_id: "b",
+        title: "Beta",
+        project: "p",
+        agent: "claude",
+        primary_model: "m",
+        models: ["m"],
+        agent_minutes: 2,
+        cost: 0,
+        output_tokens: 0,
+        first_active: "2026-06-16T10:01:00Z",
+        last_active: "2026-06-16T10:03:00Z",
+        timing_quality: "timed",
+      },
     ] as Report["by_session"],
     intervals: [
       { session_id: "a", start: "2026-06-16T10:00:00Z", end: "2026-06-16T10:01:00Z" },
@@ -100,12 +174,47 @@ function minuteReport(overrides: Partial<Report> = {}): Report {
     elapsed_bucket_count: 3,
     effective_end: "2026-06-16T00:15:00Z",
     buckets: [
-      { start: "2026-06-16T00:00:00Z", end: "2026-06-16T00:05:00Z", max_agents: 1, agent_minutes: 5, output_tokens: 10, cost: 0 },
-      { start: "2026-06-16T00:05:00Z", end: "2026-06-16T00:10:00Z", max_agents: 2, agent_minutes: 5, output_tokens: 20, cost: 0 },
-      { start: "2026-06-16T00:10:00Z", end: "2026-06-16T00:15:00Z", max_agents: 1, agent_minutes: 5, output_tokens: 5, cost: 0 },
+      {
+        start: "2026-06-16T00:00:00Z",
+        end: "2026-06-16T00:05:00Z",
+        max_agents: 1,
+        agent_minutes: 5,
+        output_tokens: 10,
+        cost: 0,
+      },
+      {
+        start: "2026-06-16T00:05:00Z",
+        end: "2026-06-16T00:10:00Z",
+        max_agents: 2,
+        agent_minutes: 5,
+        output_tokens: 20,
+        cost: 0,
+      },
+      {
+        start: "2026-06-16T00:10:00Z",
+        end: "2026-06-16T00:15:00Z",
+        max_agents: 1,
+        agent_minutes: 5,
+        output_tokens: 5,
+        cost: 0,
+      },
     ] as Report["buckets"],
     ...overrides,
   });
+}
+
+async function chooseOverlayMetric(target: HTMLElement, label: string) {
+  const trigger = target.querySelector<HTMLButtonElement>(".overlay-toggle .typeahead-trigger");
+  expect(trigger).toBeTruthy();
+  await fireEvent.click(trigger!);
+  await tick();
+
+  const option = Array.from(
+    target.querySelectorAll<HTMLElement>(".overlay-toggle .typeahead-option"),
+  ).find((el) => el.textContent?.trim() === label);
+  expect(option).toBeTruthy();
+  await fireEvent.mouseDown(option!);
+  await tick();
 }
 
 describe("ConcurrencyTimeline", () => {
@@ -157,9 +266,7 @@ describe("ConcurrencyTimeline", () => {
     const interactive = document.querySelectorAll(
       ".concurrency-seg.interactive",
     )[2] as SVGRectElement;
-    const automated = document.querySelectorAll(
-      ".concurrency-seg.automated",
-    )[2] as SVGRectElement;
+    const automated = document.querySelectorAll(".concurrency-seg.automated")[2] as SVGRectElement;
     const h = (el: SVGRectElement) => Number(el.getAttribute("height"));
     const y = (el: SVGRectElement) => Number(el.getAttribute("y"));
     // The automated cap has real height and sits above (smaller y) the taller
@@ -297,8 +404,9 @@ describe("ConcurrencyTimeline", () => {
       props: { report: popoverReport(), onSelectBucket },
     });
     await tick();
-    (target.querySelector(".slot-hit") as SVGRectElement)
-      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    (target.querySelector(".slot-hit") as SVGRectElement).dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
     await tick();
     // 3 intervals, "a" deduped to one row, sorted by earliest overlap then id.
     expect(onSelectBucket).toHaveBeenCalledWith(
@@ -315,8 +423,22 @@ describe("ConcurrencyTimeline", () => {
       bucket_count: 3,
       elapsed_bucket_count: 2,
       buckets: [
-        { start: "2026-06-16T10:00:00Z", end: "2026-06-16T10:05:00Z", max_agents: 1, agent_minutes: 1, output_tokens: 0, cost: 0 },
-        { start: "2026-06-16T10:05:00Z", end: "2026-06-16T10:10:00Z", max_agents: 0, agent_minutes: 0, output_tokens: 0, cost: 0 },
+        {
+          start: "2026-06-16T10:00:00Z",
+          end: "2026-06-16T10:05:00Z",
+          max_agents: 1,
+          agent_minutes: 1,
+          output_tokens: 0,
+          cost: 0,
+        },
+        {
+          start: "2026-06-16T10:05:00Z",
+          end: "2026-06-16T10:10:00Z",
+          max_agents: 0,
+          agent_minutes: 0,
+          output_tokens: 0,
+          cost: 0,
+        },
       ],
       by_session: [] as Report["by_session"],
       intervals: [] as Report["intervals"],
@@ -350,8 +472,9 @@ describe("ConcurrencyTimeline", () => {
       props: { report: popoverReport(), selectedBucket: 0, onSelectBucket },
     });
     await tick();
-    (target.querySelector(".slot-hit") as SVGRectElement)
-      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    (target.querySelector(".slot-hit") as SVGRectElement).dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
     await tick();
     expect(onSelectBucket).toHaveBeenCalledWith(null);
     unmount(c);
@@ -370,9 +493,7 @@ describe("ConcurrencyTimeline", () => {
     const hit = target.querySelector(".slot-hit") as SVGRectElement;
     hit.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     await tick();
-    expect(onSelectBucket).toHaveBeenCalledWith(
-      expect.objectContaining({ idx: 0 }),
-    );
+    expect(onSelectBucket).toHaveBeenCalledWith(expect.objectContaining({ idx: 0 }));
     unmount(c);
     target.remove();
   });
@@ -419,8 +540,22 @@ describe("ConcurrencyTimeline", () => {
       elapsed_bucket_count: 2,
       effective_end: "2026-06-17T00:00:00Z",
       buckets: [
-        { start: "2026-06-15T00:00:00Z", end: "2026-06-16T00:00:00Z", max_agents: 1, agent_minutes: 10, output_tokens: 1, cost: 0 },
-        { start: "2026-06-16T00:00:00Z", end: "2026-06-17T00:00:00Z", max_agents: 1, agent_minutes: 10, output_tokens: 1, cost: 0 },
+        {
+          start: "2026-06-15T00:00:00Z",
+          end: "2026-06-16T00:00:00Z",
+          max_agents: 1,
+          agent_minutes: 10,
+          output_tokens: 1,
+          cost: 0,
+        },
+        {
+          start: "2026-06-16T00:00:00Z",
+          end: "2026-06-17T00:00:00Z",
+          max_agents: 1,
+          agent_minutes: 10,
+          output_tokens: 1,
+          cost: 0,
+        },
       ] as Report["buckets"],
     });
     render(ConcurrencyTimeline, { report: r });
@@ -440,7 +575,14 @@ describe("ConcurrencyTimeline", () => {
       elapsed_bucket_count: 1,
       effective_end: "2026-06-22T00:00:00Z",
       buckets: [
-        { start: "2026-06-15T00:00:00Z", end: "2026-06-22T00:00:00Z", max_agents: 2, agent_minutes: 20, output_tokens: 100, cost: 0 },
+        {
+          start: "2026-06-15T00:00:00Z",
+          end: "2026-06-22T00:00:00Z",
+          max_agents: 2,
+          agent_minutes: 20,
+          output_tokens: 100,
+          cost: 0,
+        },
       ] as Report["buckets"],
     });
     const target = document.createElement("div");
@@ -461,9 +603,9 @@ describe("ConcurrencyTimeline", () => {
 
   it("labels minute-unit ticks with real local times", () => {
     render(ConcurrencyTimeline, { report: minuteReport() });
-    const labels = Array.from(
-      document.querySelectorAll("text.x-label"),
-    ).map((el) => el.textContent?.trim() ?? "");
+    const labels = Array.from(document.querySelectorAll("text.x-label")).map(
+      (el) => el.textContent?.trim() ?? "",
+    );
     expect(labels.length).toBeGreaterThan(0);
     // Every label is HH:MM, and a sub-hour range yields non-:00 minutes
     // rather than the old hardcoded 00/06/12/18/24 hour marks.
@@ -478,13 +620,7 @@ describe("ConcurrencyTimeline", () => {
     await tick();
     // Default metric is "none": no overlay line.
     expect(target.querySelector(".overlay-line")).toBeNull();
-    const select = target.querySelector(
-      ".overlay-toggle select",
-    ) as HTMLSelectElement;
-    expect(select).toBeTruthy();
-    select.value = "cost";
-    select.dispatchEvent(new Event("change", { bubbles: true }));
-    await tick();
+    await chooseOverlayMetric(target, "Cost");
     expect(target.querySelector(".overlay-line")).toBeTruthy();
     unmount(c);
     target.remove();
@@ -496,26 +632,19 @@ describe("ConcurrencyTimeline", () => {
     const c = mount(ConcurrencyTimeline, { target, props: { report: makeReport() } });
     await tick();
 
-    const select = target.querySelector(
-      ".overlay-toggle select",
-    ) as HTMLSelectElement;
-    select.value = "cost";
-    select.dispatchEvent(new Event("change", { bubbles: true }));
-    await tick();
+    await chooseOverlayMetric(target, "Cost");
 
-    const labels = Array.from(
-      target.querySelectorAll("text.overlay-y-label"),
-    ).map((el) => el.textContent?.trim() ?? "");
+    const labels = Array.from(target.querySelectorAll("text.overlay-y-label")).map(
+      (el) => el.textContent?.trim() ?? "",
+    );
     expect(labels).toContain("$0.90");
     expect(labels).toContain("$0.00");
 
-    select.value = "tokens";
-    select.dispatchEvent(new Event("change", { bubbles: true }));
-    await tick();
+    await chooseOverlayMetric(target, "Tokens");
 
-    const tokenLabels = Array.from(
-      target.querySelectorAll("text.overlay-y-label"),
-    ).map((el) => el.textContent?.trim() ?? "");
+    const tokenLabels = Array.from(target.querySelectorAll("text.overlay-y-label")).map(
+      (el) => el.textContent?.trim() ?? "",
+    );
     expect(tokenLabels).toContain("9k");
 
     unmount(c);

--- a/frontend/src/lib/components/component-source-guard.test.ts
+++ b/frontend/src/lib/components/component-source-guard.test.ts
@@ -1,5 +1,5 @@
 // @ts-ignore -- @types/node is not in devDependencies; harmless at runtime.
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 // @ts-ignore -- @types/node is not in devDependencies; harmless at runtime.
 import { relative, resolve } from "node:path";
 import { describe, expect, it } from "vite-plus/test";
@@ -8,12 +8,6 @@ const componentsRoot = resolve(
   // @ts-ignore -- import.meta.dirname is Node 20.11+, in the supported range.
   import.meta.dirname,
 );
-
-const legacyNativeSelectAllowlist = new Set([
-  "activity/ActivityInsight.svelte",
-  "activity/ActivityPage.svelte",
-  "activity/ConcurrencyTimeline.svelte",
-]);
 
 function svelteFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry: any) => {
@@ -24,32 +18,50 @@ function svelteFiles(dir: string): string[] {
   });
 }
 
+function styleBlocks(source: string): string[] {
+  return Array.from(source.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/g)).map(
+    (match) => match[1] ?? "",
+  );
+}
+
+function oneOffControlStyleOffenders(source: string): string[] {
+  return styleBlocks(source).flatMap((style) => {
+    const offenders: string[] = [];
+    if (/\.[A-Za-z0-9_-]+-select(?=[\s:{,.#>+~[])/.test(style)) {
+      offenders.push("component-specific *-select selector");
+    }
+    if (/\.[A-Za-z0-9_-]+-select-chevron(?=[\s:{,.#>+~[])/.test(style)) {
+      offenders.push("manual select chevron selector");
+    }
+    if (/(?:^|\s)-?(?:webkit-)?appearance\s*:\s*none\b/.test(style)) {
+      offenders.push("manual native control appearance reset");
+    }
+    return offenders;
+  });
+}
+
 describe("component source guardrails", () => {
   it("keeps new native select controls out of component source", () => {
-    const offenders = svelteFiles(componentsRoot).flatMap((path) => {
-      const rel = relative(componentsRoot, path);
-      if (legacyNativeSelectAllowlist.has(rel)) return [];
-
-      const source = readFileSync(path, "utf8");
-      return /<select\b/.test(source) ? [rel] : [];
-    }).sort();
+    const offenders = svelteFiles(componentsRoot)
+      .flatMap((path) => {
+        const rel = relative(componentsRoot, path);
+        const source = readFileSync(path, "utf8");
+        return /<select\b/.test(source) ? [rel] : [];
+      })
+      .sort((a, b) => a.localeCompare(b));
 
     expect(offenders).toEqual([]);
   });
 
-  it("keeps the legacy select allowlist honest", () => {
-    const missing = Array.from(legacyNativeSelectAllowlist).filter((rel) => {
-      const path = `${componentsRoot}/${rel}`;
-      return !existsSync(path);
-    });
+  it("keeps one-off select chrome out of component styles", () => {
+    const offenders = svelteFiles(componentsRoot)
+      .flatMap((path) => {
+        const rel = relative(componentsRoot, path);
+        const source = readFileSync(path, "utf8");
+        return oneOffControlStyleOffenders(source).map((reason) => `${rel}: ${reason}`);
+      })
+      .sort((a, b) => a.localeCompare(b));
 
-    expect(missing).toEqual([]);
-
-    const stale = Array.from(legacyNativeSelectAllowlist).filter((rel) => {
-      const source = readFileSync(`${componentsRoot}/${rel}`, "utf8");
-      return !/<select\b/.test(source);
-    });
-
-    expect(stale).toEqual([]);
+    expect(offenders).toEqual([]);
   });
 });

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -1274,17 +1274,6 @@
     max-width: 720px;
   }
 
-  .agent-select {
-    height: 28px;
-    min-width: 112px;
-    border: 1px solid var(--border-muted);
-    background: var(--bg-inset);
-    border-radius: var(--radius-sm);
-    color: var(--text-secondary);
-    padding: 0 6px;
-    font-size: 12px;
-  }
-
   .toolbar-scope {
     display: flex;
     align-items: center;

--- a/frontend/src/lib/components/layout/OptionTypeahead.svelte
+++ b/frontend/src/lib/components/layout/OptionTypeahead.svelte
@@ -15,6 +15,7 @@
     placeholder: string;
     title: string;
     emptyLabel: string;
+    disabled?: boolean;
     onselect: (value: string) => void;
   }
 
@@ -25,6 +26,7 @@
     placeholder,
     title,
     emptyLabel,
+    disabled = false,
     onselect,
   }: Props = $props();
 
@@ -49,6 +51,7 @@
   );
 
   async function openDropdown() {
+    if (disabled) return;
     query = "";
     open = true;
     highlightIndex = 0;
@@ -135,6 +138,7 @@
       onkeydown={handleKeydown}
       onblur={handleBlur}
       {placeholder}
+      {disabled}
       aria-label={placeholder}
       autocomplete="off"
     />
@@ -158,7 +162,13 @@
       {/each}
     </ul>
   {:else}
-    <button class="typeahead-trigger" onclick={openDropdown} {title}>
+    <button
+      class="typeahead-trigger"
+      onclick={openDropdown}
+      {title}
+      {disabled}
+      aria-label={placeholder}
+    >
       <span class="typeahead-value">{displayValue}</span>
       <svg
         class="typeahead-chevron"
@@ -182,16 +192,16 @@
   }
 
   .typeahead-trigger {
-    height: 26px;
+    height: var(--typeahead-control-height, 26px);
     width: 100%;
     display: flex;
     align-items: center;
     gap: 4px;
-    padding: 0 8px;
+    padding: var(--typeahead-control-padding, 0 8px);
     background: var(--bg-inset);
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
-    font-size: 11px;
+    font-size: var(--typeahead-control-font-size, 11px);
     color: var(--text-secondary);
     cursor: pointer;
     transition: border-color 0.15s;
@@ -207,6 +217,11 @@
     border-color: var(--accent-blue);
   }
 
+  .typeahead-trigger:disabled {
+    opacity: 0.55;
+    cursor: default;
+  }
+
   .typeahead-value {
     flex: 1;
     overflow: hidden;
@@ -220,13 +235,13 @@
   }
 
   .typeahead-input {
-    height: 26px;
+    height: var(--typeahead-control-height, 26px);
     width: 100%;
-    padding: 0 8px;
+    padding: var(--typeahead-control-padding, 0 8px);
     background: var(--bg-inset);
     border: 1px solid var(--accent-blue);
     border-radius: var(--radius-sm);
-    font-size: 11px;
+    font-size: var(--typeahead-control-font-size, 11px);
     color: var(--text-primary);
     outline: none;
     box-sizing: border-box;

--- a/frontend/src/lib/components/layout/OptionTypeahead.test.ts
+++ b/frontend/src/lib/components/layout/OptionTypeahead.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vite-plus/test";
+import { mount, unmount } from "svelte";
+// @ts-ignore
+import OptionTypeahead from "./OptionTypeahead.svelte";
+
+describe("OptionTypeahead", () => {
+  it("keeps a disabled trigger closed", () => {
+    const onselect = vi.fn();
+    const component = mount(OptionTypeahead, {
+      target: document.body,
+      props: {
+        options: [{ name: "codex", label: "Codex" }],
+        value: "codex",
+        fallbackLabel: "Codex",
+        placeholder: "Pick agent",
+        title: "Agent",
+        emptyLabel: "No agents",
+        disabled: true,
+        onselect,
+      },
+    });
+
+    const trigger = document.querySelector<HTMLButtonElement>(".typeahead-trigger");
+    expect(trigger).not.toBeNull();
+    expect(trigger!.disabled).toBe(true);
+
+    trigger!.click();
+
+    expect(document.querySelector(".typeahead-input")).toBeNull();
+    expect(onselect).not.toHaveBeenCalled();
+
+    void unmount(component);
+  });
+});


### PR DESCRIPTION
Frontend control styling had no deterministic guard because legacy activity native selects still required local CSS. This migrates those selectors to the shared OptionTypeahead and extends the source guard so future Svelte components cannot introduce native selects, component-specific *-select selectors, manual select chevrons, or appearance resets.

Reviewers should expect new selector controls to use shared control APIs and sizing variables instead of local chrome. The guard intentionally has no legacy CSS allowlist now that the existing debt is removed.

Closes #823