### PR TITLE
refactor(frontend): pluralize reading-control counts via paraglide

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -154,22 +154,64 @@
   "message_content_unpinned": "Unpinned",
   "message_content_pinned": "Pinned",
   "message_content_running_duration": "running {duration}+",
-  "message_content_turn_summary": "turn {duration} · {count} {unit}",
-  "message_content_running_turn_summary": "running {duration}+ · {count} {unit}",
-  "message_content_call_singular": "call",
-  "message_content_call_plural": "calls",
-  "tool_call_group_call_count_singular": "1 tool call",
-  "tool_call_group_call_count_plural": "{count} tool calls",
+  "message_content_turn_summary": [
+    {
+      "declarations": ["input count", "input duration", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "turn {duration} · {count} call",
+        "countPlural=other": "turn {duration} · {count} calls"
+      }
+    }
+  ],
+  "message_content_running_turn_summary": [
+    {
+      "declarations": ["input count", "input duration", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "running {duration}+ · {count} call",
+        "countPlural=other": "running {duration}+ · {count} calls"
+      }
+    }
+  ],
+  "tool_call_group_call_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{count} tool call",
+        "countPlural=other": "{count} tool calls"
+      }
+    }
+  ],
   "tool_call_group_copy_tool_calls": "Copy tool calls",
   "tool_call_group_copied_tool_calls": "Copied tool calls",
   "tool_call_group_copied": "Copied!",
   "tool_call_group_running_duration": "running {duration}+",
   "parallel_group_label": "parallel",
-  "parallel_group_call_count": "{count} calls",
+  "parallel_group_call_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{count} call",
+        "countPlural=other": "{count} calls"
+      }
+    }
+  ],
   "parallel_group_each_duration": "≤ {duration} each",
   "parallel_group_running": "running...",
   "subagent_inline_label": "Subagent session",
-  "subagent_inline_message_count": "{count} messages",
+  "subagent_inline_message_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{count} message",
+        "countPlural=other": "{count} messages"
+      }
+    }
+  ],
   "subagent_inline_open_as_full_session": "Open as full session",
   "subagent_inline_open_session": "Open session",
   "subagent_inline_failed_to_load": "Failed to load",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -154,22 +154,59 @@
   "message_content_unpinned": "已取消固定",
   "message_content_pinned": "已固定",
   "message_content_running_duration": "运行中 {duration}+",
-  "message_content_turn_summary": "turn {duration} · {count} 次调用",
-  "message_content_running_turn_summary": "运行中 {duration}+ · {count} 次调用",
-  "message_content_call_singular": "call",
-  "message_content_call_plural": "calls",
-  "tool_call_group_call_count_singular": "1 次 tool call",
-  "tool_call_group_call_count_plural": "{count} 次 tool call",
+  "message_content_turn_summary": [
+    {
+      "declarations": ["input count", "input duration", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "turn {duration} · {count} 次调用"
+      }
+    }
+  ],
+  "message_content_running_turn_summary": [
+    {
+      "declarations": ["input count", "input duration", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "运行中 {duration}+ · {count} 次调用"
+      }
+    }
+  ],
+  "tool_call_group_call_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "{count} 次 tool call"
+      }
+    }
+  ],
   "tool_call_group_copy_tool_calls": "复制 tool calls",
   "tool_call_group_copied_tool_calls": "Tool calls 已复制",
   "tool_call_group_copied": "已复制！",
   "tool_call_group_running_duration": "运行中 {duration}+",
   "parallel_group_label": "并行",
-  "parallel_group_call_count": "{count} 次调用",
+  "parallel_group_call_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "{count} 次调用"
+      }
+    }
+  ],
   "parallel_group_each_duration": "每个 ≤ {duration}",
   "parallel_group_running": "运行中...",
   "subagent_inline_label": "Subagent 会话",
-  "subagent_inline_message_count": "{count} 条消息",
+  "subagent_inline_message_count": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "{count} 条消息"
+      }
+    }
+  ],
   "subagent_inline_open_as_full_session": "作为完整会话打开",
   "subagent_inline_open_session": "打开会话",
   "subagent_inline_failed_to_load": "加载失败",

--- a/frontend/src/lib/components/content/MessageContent.svelte
+++ b/frontend/src/lib/components/content/MessageContent.svelte
@@ -225,12 +225,6 @@
     return turn != null && turn.duration_ms == null;
   }
 
-  function callUnit(count: number): string {
-    return count === 1
-      ? m.message_content_call_singular()
-      : m.message_content_call_plural();
-  }
-
   /** Build the chip payload for an assistant turn. Returns null
    *  when the message has no tool calls or timing isn't loaded. */
   let turnSummary = $derived.by(() => {
@@ -241,8 +235,7 @@
       return {
         text: m.message_content_turn_summary({
           duration: formatDuration(turn.duration_ms),
-          count: String(calls),
-          unit: callUnit(calls),
+          count: calls,
         }),
         slow: false,
         running: false,
@@ -257,8 +250,7 @@
       return {
         text: m.message_content_running_turn_summary({
           duration: formatDuration(elapsed),
-          count: String(calls),
-          unit: callUnit(calls),
+          count: calls,
         }),
         slow: false,
         running: true,

--- a/frontend/src/lib/components/content/ParallelGroup.svelte
+++ b/frontend/src/lib/components/content/ParallelGroup.svelte
@@ -38,7 +38,7 @@
   <div class="pg-header">
     <span class="pg-label">{m.parallel_group_label()}</span>
     <span class="pg-count">{m.parallel_group_call_count({
-      count: String(toolCalls.length),
+      count: toolCalls.length,
     })}</span>
     <span class="pg-spacer"></span>
     {#if isRunning}

--- a/frontend/src/lib/components/content/SubagentInline.svelte
+++ b/frontend/src/lib/components/content/SubagentInline.svelte
@@ -71,7 +71,7 @@
   let messageCountLabel = $derived(
     tokenSourceSession
       ? m.subagent_inline_message_count({
-          count: String(tokenSourceSession.message_count),
+          count: tokenSourceSession.message_count,
         })
       : null,
   );

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -51,13 +51,7 @@
     messages.reduce((n, m) => n + messageToolCount(m), 0),
   );
 
-  let label = $derived(
-    totalCalls === 1
-      ? m.tool_call_group_call_count_singular()
-      : m.tool_call_group_call_count_plural({
-          count: String(totalCalls),
-        }),
-  );
+  let label = $derived(m.tool_call_group_call_count({ count: totalCalls }));
 
   /** Index turn timings by message id for O(1) lookup. */
   let turnByMessage = $derived.by(() => {

--- a/frontend/src/lib/i18n/i18n.test.ts
+++ b/frontend/src/lib/i18n/i18n.test.ts
@@ -86,6 +86,29 @@ describe("i18n locale selection", () => {
     expect(m.status_bar_sessions({ count: "12" })).toBe("12 个会话");
   });
 
+  it("selects cardinal plural variants per locale", () => {
+    runtime.setLocale("en", { reload: false });
+    expect(m.tool_call_group_call_count({ count: 1 })).toBe("1 tool call");
+    expect(m.tool_call_group_call_count({ count: 3 })).toBe("3 tool calls");
+    expect(m.parallel_group_call_count({ count: 1 })).toBe("1 call");
+    expect(m.parallel_group_call_count({ count: 2 })).toBe("2 calls");
+    expect(m.subagent_inline_message_count({ count: 1 })).toBe("1 message");
+    expect(m.subagent_inline_message_count({ count: 5 })).toBe("5 messages");
+    expect(
+      m.message_content_turn_summary({ count: 1, duration: "2m 1s" }),
+    ).toBe("turn 2m 1s · 1 call");
+    expect(
+      m.message_content_turn_summary({ count: 4, duration: "2m 1s" }),
+    ).toBe("turn 2m 1s · 4 calls");
+
+    // Simplified Chinese has no plural distinction, so a single variant
+    // serves every count.
+    runtime.setLocale("zh-CN", { reload: false });
+    expect(m.tool_call_group_call_count({ count: 1 })).toBe("1 次 tool call");
+    expect(m.tool_call_group_call_count({ count: 3 })).toBe("3 次 tool call");
+    expect(m.subagent_inline_message_count({ count: 1 })).toBe("1 条消息");
+  });
+
   it("sets the Paraglide runtime locale with its default reload behavior", () => {
     const setParaglideLocale = vi
       .spyOn(runtime, "setLocale")


### PR DESCRIPTION
Follow-up to #839, which merged before this cleanup landed.

The session reading-control count labels did their own pluralization in JS: a `callUnit` helper, paired `_singular`/`_plural` messages, and a `totalCalls === 1` ternary in `ToolCallGroup`. That bakes English's two-form (one/other) assumption into the call sites, so other locales can't express their own plural rules — Simplified Chinese, which has no count-based plural distinction, was forced to ship duplicate identical "singular" and "plural" strings.

This moves the cardinal selection into the Paraglide message variants (`local countPlural = count: plural`). English declares `one`/`other`; zh-CN declares the single form it actually needs. Counts are now passed as numbers so `Intl.PluralRules` picks the category. `parallel_group_call_count` and `subagent_inline_message_count`, which previously always rendered the plural form, are pluralized too.

Reviewers: the substance is in `messages/en.json` and `messages/zh-CN.json`; the four components just drop their manual plural logic and pass a numeric `count`.

Duration formatting deliberately stays in the `formatDuration` helper — Paraglide only ships `datetime`/`relativetime`/`number` matchers, none of which produce the compact elapsed-time format ("2m 30s") these controls use.

Out of scope: relative timestamps (`formatRelativeTime`, the sidebar "5m ago" labels) are still hardcoded English and not routed through i18n at all; localizing those is a separate follow-up.

<sup>generated by a clanker</sup>