### PR TITLE
feat(mcp): add `agentsview mcp` read-only MCP server over the SessionService seam

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -99,6 +99,7 @@ func newRootCommand() *cobra.Command {
 	root.AddCommand(newPGCommand())
 	root.AddCommand(newDuckDBCommand())
 	root.AddCommand(newSessionCommand())
+	root.AddCommand(newMCPCommand())
 	root.AddCommand(newStatsCommand())
 	root.AddCommand(newParseDiffCommand())
 	root.AddCommand(newClassifierCommand())

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -1,0 +1,145 @@
+// ABOUTME: `agentsview mcp` subcommand — serves the read-only MCP tools
+// ABOUTME: over the SessionService seam (stdio by default, or HTTP).
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	mcpserver "go.kenn.io/agentsview/internal/mcp"
+)
+
+func newMCPCommand() *cobra.Command {
+	var httpAddr string
+	var httpAllowInsecure bool
+
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Run an MCP server exposing read-only session retrieval tools",
+		Long: `Start an MCP (Model Context Protocol) server over stdio (default) or
+StreamableHTTP, exposing read-only tools for searching and reading
+recorded agent sessions: search_sessions, list_sessions,
+get_session_overview, get_messages, search_content, and
+get_usage_summary.
+
+The server reads through the same path as the CLI: it talks to a running
+agentsview daemon over HTTP when one is discoverable (or --server/--pg),
+and otherwise opens the local SQLite archive read-only.
+
+Add to your MCP client config (e.g. Claude Desktop):
+  {
+    "mcpServers": {
+      "agentsview": {
+        "command": "agentsview",
+        "args": ["mcp"]
+      }
+    }
+  }`,
+		GroupID:      groupData,
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			svc, cleanup, err := resolveService(cmd)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			// The CLI runs commands with a plain context (no signal
+			// handling), so install our own: a long-lived MCP server must
+			// shut down cleanly on SIGINT/SIGTERM.
+			ctx, stop := signal.NotifyContext(
+				cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			opts := mcpserver.ServeOptions{Service: svc, Version: version}
+
+			if httpAddr != "" {
+				addr, err := normalizeMCPHTTPAddr(httpAddr, httpAllowInsecure)
+				if err != nil {
+					return err
+				}
+				return mcpserver.ServeHTTP(ctx, opts, addr)
+			}
+			return mcpserver.ServeStdio(ctx, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&httpAddr, "http", "",
+		"Serve over StreamableHTTP on this address (e.g. 127.0.0.1:8085) "+
+			"instead of stdio. Bare port forms (':8085', '8085') bind to "+
+			"loopback only; non-loopback hosts require --http-allow-insecure.")
+	cmd.Flags().BoolVar(&httpAllowInsecure, "http-allow-insecure", false,
+		"Allow --http to bind a non-loopback address. The MCP server has no "+
+			"built-in authentication, so any reachable client can read your "+
+			"sessions. Only set this on trusted networks (Tailscale, VPN-only) "+
+			"or behind an authenticating reverse proxy.")
+
+	// Transport-selection flags, mirroring the `session` command, so the
+	// MCP server can target a remote daemon or PostgreSQL read store.
+	cmd.Flags().String("server", "", "Remote daemon URL")
+	cmd.Flags().String("server-token-file", "",
+		"File containing bearer token for explicit --server requests")
+	cmd.Flags().Bool("pg", false,
+		"Read session data from configured PostgreSQL")
+
+	return cmd
+}
+
+// normalizeMCPHTTPAddr canonicalises a --http argument and rejects values
+// that would expose the unauthenticated MCP server on a non-loopback
+// interface unless the user has explicitly opted in.
+//
+// Forms accepted:
+//   - "8085"            -> "127.0.0.1:8085" (loopback)
+//   - ":8085"           -> "127.0.0.1:8085" (loopback; Go's default would be
+//     all-interfaces, which is the footgun this guards against)
+//   - "127.0.0.1:8085"  -> unchanged (loopback, allowed)
+//   - "[::1]:8085"      -> unchanged (loopback, allowed)
+//   - "192.168.1.5:8085", "0.0.0.0:8085", "host.local:8085" -> rejected
+//     unless allowInsecure is set
+func normalizeMCPHTTPAddr(addr string, allowInsecure bool) (string, error) {
+	trimmed := strings.TrimSpace(addr)
+	if trimmed == "" {
+		return "", errors.New("--http requires an address")
+	}
+
+	// Bare port: "8085" or ":8085".
+	if !strings.Contains(trimmed, ":") {
+		if _, convErr := strconv.Atoi(trimmed); convErr == nil {
+			return "127.0.0.1:" + trimmed, nil
+		}
+		return "", fmt.Errorf("--http %q: not a port and not host:port", trimmed)
+	}
+	if strings.HasPrefix(trimmed, ":") {
+		return "127.0.0.1" + trimmed, nil
+	}
+
+	host, _, splitErr := net.SplitHostPort(trimmed)
+	if splitErr != nil {
+		return "", fmt.Errorf("--http %q: %w", trimmed, splitErr)
+	}
+
+	// isLoopbackHost (shared with managed_caddy.go) treats an empty host as
+	// NOT loopback, which guards the "[]:8085" footgun where an empty host
+	// passes net.SplitHostPort yet binds to all interfaces.
+	if isLoopbackHost(host) {
+		return trimmed, nil
+	}
+	if !allowInsecure {
+		return "", fmt.Errorf(
+			"--http %q: refusing to bind a non-loopback address without "+
+				"--http-allow-insecure (the MCP server has no built-in "+
+				"authentication; only opt in on trusted networks or behind "+
+				"an authenticating reverse proxy)", trimmed)
+	}
+	return trimmed, nil
+}

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -11,12 +11,14 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/spf13/cobra"
 
 	"go.kenn.io/agentsview/internal/config"
 	mcpserver "go.kenn.io/agentsview/internal/mcp"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func newMCPCommand() *cobra.Command {
@@ -32,9 +34,10 @@ recorded agent sessions: search_sessions, list_sessions,
 get_session_overview, get_messages, search_content, and
 get_usage_summary.
 
-The server reads through the same path as the CLI: it talks to a running
-agentsview daemon over HTTP when one is discoverable (or --server/--pg),
-and otherwise opens the local SQLite archive read-only.
+The server reads through the daemon path. By default each tool call talks to
+the local agentsview daemon, starting it when needed so a long-lived MCP server
+can recover after the daemon exits due to idleness. Use --server to target an
+explicit daemon URL.
 
 Add to your MCP client config (e.g. Claude Desktop):
   {
@@ -49,7 +52,7 @@ Add to your MCP client config (e.g. Claude Desktop):
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			svc, cleanup, err := resolveService(cmd)
+			svc, cleanup, err := resolveMCPService(cmd)
 			if err != nil {
 				return err
 			}
@@ -115,15 +118,204 @@ Add to your MCP client config (e.g. Claude Desktop):
 			"every request. Only expose it on trusted networks (Tailscale, "+
 			"VPN-only) or behind an authenticating reverse proxy.")
 
-	// Transport-selection flags, mirroring the `session` command, so the
-	// MCP server can target a remote daemon or PostgreSQL read store.
+	// Transport-selection flags, mirroring the `session` command where
+	// applicable. MCP requires a daemon-backed service, so --pg is
+	// retained only to produce a specific error instead of silently
+	// opening PostgreSQL directly.
 	cmd.Flags().String("server", "", "Remote daemon URL")
 	cmd.Flags().String("server-token-file", "",
 		"File containing bearer token for explicit --server requests")
 	cmd.Flags().Bool("pg", false,
-		"Read session data from configured PostgreSQL")
+		"Unsupported for MCP; run pg serve and use --server instead")
 
 	return cmd
+}
+
+// resolveMCPService constructs the SessionService used by the long-lived
+// MCP server. The implicit local path is intentionally daemon-only and
+// lazy: every operation re-resolves the daemon transport so a tool call can
+// wake the daemon after it exits due to idleness.
+func resolveMCPService(
+	cmd *cobra.Command,
+) (service.SessionService, func(), error) {
+	remote, _ := cmd.Flags().GetString("server")
+	if remote != "" {
+		if pgReadRequested(cmd) {
+			return nil, nil, errors.New(
+				"--server and --pg are mutually exclusive",
+			)
+		}
+		token, err := explicitServerToken(cmd)
+		if err != nil {
+			return nil, nil, err
+		}
+		return service.NewHTTPBackend(remote, token, false),
+			func() {}, nil
+	}
+	if pgReadRequested(cmd) {
+		return nil, nil, errors.New(
+			"agentsview mcp requires a daemon; --pg opens PostgreSQL " +
+				"directly. Run 'agentsview pg serve' and pass --server, " +
+				"or omit --pg to use the local daemon",
+		)
+	}
+	cfg, err := config.LoadPFlags(cmd.Flags())
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading config: %w", err)
+	}
+	return newMCPDaemonService(cfg), func() {}, nil
+}
+
+type mcpDaemonService struct {
+	mu  sync.Mutex
+	cfg config.Config
+}
+
+func newMCPDaemonService(cfg config.Config) service.SessionService {
+	return &mcpDaemonService{cfg: cfg}
+}
+
+func (s *mcpDaemonService) daemonService(
+	ctx context.Context,
+) (service.SessionService, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cfg := s.cfg
+	tr, err := ensureTransportContext(
+		ctx, &cfg, transportIntentArchiveWrite, 0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if tr.Mode != transportHTTP {
+		return nil, errors.New(
+			"agentsview mcp requires a daemon; refusing direct archive access",
+		)
+	}
+	s.cfg.AuthToken = cfg.AuthToken
+	return service.NewHTTPBackend(tr.URL, cfg.AuthToken, tr.ReadOnly), nil
+}
+
+func (s *mcpDaemonService) Get(
+	ctx context.Context, id string,
+) (*service.SessionDetail, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.Get(ctx, id)
+}
+
+func (s *mcpDaemonService) List(
+	ctx context.Context, f service.ListFilter,
+) (*service.SessionList, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.List(ctx, f)
+}
+
+func (s *mcpDaemonService) Messages(
+	ctx context.Context, id string, f service.MessageFilter,
+) (*service.MessageList, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.Messages(ctx, id, f)
+}
+
+func (s *mcpDaemonService) ToolCalls(
+	ctx context.Context, id string,
+) (*service.ToolCallList, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.ToolCalls(ctx, id)
+}
+
+func (s *mcpDaemonService) Sync(
+	ctx context.Context, in service.SyncInput,
+) (*service.SessionDetail, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.Sync(ctx, in)
+}
+
+func (s *mcpDaemonService) Watch(
+	ctx context.Context, id string,
+) (<-chan service.Event, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.Watch(ctx, id)
+}
+
+func (s *mcpDaemonService) Stats(
+	ctx context.Context, f service.StatsFilter,
+) (*service.SessionStats, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.Stats(ctx, f)
+}
+
+func (s *mcpDaemonService) Search(
+	ctx context.Context, req service.SearchRequest,
+) (*service.SessionSearchResult, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.Search(ctx, req)
+}
+
+func (s *mcpDaemonService) SearchContent(
+	ctx context.Context, req service.ContentSearchRequest,
+) (*service.ContentSearchResult, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.SearchContent(ctx, req)
+}
+
+func (s *mcpDaemonService) UsageSummary(
+	ctx context.Context, req service.UsageRequest,
+) (*service.UsageSummaryResult, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.UsageSummary(ctx, req)
+}
+
+func (s *mcpDaemonService) ListSecrets(
+	ctx context.Context, f service.SecretListFilter,
+) (*service.SecretFindingList, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.ListSecrets(ctx, f)
+}
+
+func (s *mcpDaemonService) ScanSecrets(
+	ctx context.Context, in service.SecretScanInput,
+	progress func(service.SecretScanProgress),
+) (*service.SecretScanSummary, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.ScanSecrets(ctx, in, progress)
 }
 
 // mcpListenerAuth decides the bearer token the MCP HTTP listener must

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -78,6 +78,14 @@ Add to your MCP client config (e.g. Claude Desktop):
 				if err != nil {
 					return fmt.Errorf("loading config: %w", err)
 				}
+				// Provision a token when auth is required but none exists
+				// yet, matching serve/pg/duckdb so enabling require_auth is
+				// sufficient for first-time authenticated startup.
+				if cfg.RequireAuth && cfg.AuthToken == "" {
+					if err := cfg.EnsureAuthToken(); err != nil {
+						return fmt.Errorf("provisioning auth token: %w", err)
+					}
+				}
 				token, err := mcpListenerAuth(addr, cfg.AuthToken)
 				if err != nil {
 					return err

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -62,14 +63,22 @@ Add to your MCP client config (e.g. Claude Desktop):
 
 			opts := mcpserver.ServeOptions{Service: svc, Version: version}
 
+			var serveErr error
 			if httpAddr != "" {
 				addr, err := normalizeMCPHTTPAddr(httpAddr, httpAllowInsecure)
 				if err != nil {
 					return err
 				}
-				return mcpserver.ServeHTTP(ctx, opts, addr)
+				serveErr = mcpserver.ServeHTTP(ctx, opts, addr)
+			} else {
+				serveErr = mcpserver.ServeStdio(ctx, opts)
 			}
-			return mcpserver.ServeStdio(ctx, opts)
+			// A SIGINT/SIGTERM-triggered shutdown cancels ctx; that is a
+			// clean stop, not a failure, so it should not exit non-zero.
+			if errors.Is(serveErr, context.Canceled) {
+				return nil
+			}
+			return serveErr
 		},
 	}
 

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"go.kenn.io/agentsview/internal/config"
 	mcpserver "go.kenn.io/agentsview/internal/mcp"
 )
 
@@ -69,6 +70,19 @@ Add to your MCP client config (e.g. Claude Desktop):
 				if err != nil {
 					return err
 				}
+				// A non-loopback listener must be authenticated, or it is
+				// an unauthenticated remote read surface over the session
+				// archive. Loopback binds stay local-trust (no listener
+				// auth), matching the daemon.
+				cfg, err := config.LoadPFlags(cmd.Flags())
+				if err != nil {
+					return fmt.Errorf("loading config: %w", err)
+				}
+				token, err := mcpListenerAuth(addr, cfg.AuthToken)
+				if err != nil {
+					return err
+				}
+				opts.Token = token
 				serveErr = mcpserver.ServeHTTP(ctx, opts, addr)
 			} else {
 				serveErr = mcpserver.ServeStdio(ctx, opts)
@@ -87,10 +101,11 @@ Add to your MCP client config (e.g. Claude Desktop):
 			"instead of stdio. Bare port forms (':8085', '8085') bind to "+
 			"loopback only; non-loopback hosts require --http-allow-insecure.")
 	cmd.Flags().BoolVar(&httpAllowInsecure, "http-allow-insecure", false,
-		"Allow --http to bind a non-loopback address. The MCP server has no "+
-			"built-in authentication, so any reachable client can read your "+
-			"sessions. Only set this on trusted networks (Tailscale, VPN-only) "+
-			"or behind an authenticating reverse proxy.")
+		"Allow --http to bind a non-loopback address. A non-loopback bind "+
+			"requires a configured auth token (auth_token in config.toml, or "+
+			"enable require_auth) and then enforces Authorization: Bearer on "+
+			"every request. Only expose it on trusted networks (Tailscale, "+
+			"VPN-only) or behind an authenticating reverse proxy.")
 
 	// Transport-selection flags, mirroring the `session` command, so the
 	// MCP server can target a remote daemon or PostgreSQL read store.
@@ -101,6 +116,30 @@ Add to your MCP client config (e.g. Claude Desktop):
 		"Read session data from configured PostgreSQL")
 
 	return cmd
+}
+
+// mcpListenerAuth decides the bearer token the MCP HTTP listener must
+// enforce for the given (already-normalized) bind address. A loopback
+// bind is local-trust and runs without listener auth (empty token). A
+// non-loopback bind must be authenticated: it returns the configured
+// token, or an error when none is set, so the network-reachable surface
+// is never unauthenticated.
+func mcpListenerAuth(addr, configuredToken string) (string, error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", fmt.Errorf("parsing --http address %q: %w", addr, err)
+	}
+	if isLoopbackHost(host) {
+		return "", nil
+	}
+	if configuredToken == "" {
+		return "", fmt.Errorf(
+			"--http %q is non-loopback but no auth token is configured; set "+
+				"auth_token in config.toml (or enable require_auth) so the MCP "+
+				"server requires Authorization: Bearer, or bind a loopback address",
+			addr)
+	}
+	return configuredToken, nil
 }
 
 // normalizeMCPHTTPAddr canonicalises a --http argument and rejects values

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -86,7 +86,7 @@ Add to your MCP client config (e.g. Claude Desktop):
 						return fmt.Errorf("provisioning auth token: %w", err)
 					}
 				}
-				token, err := mcpListenerAuth(addr, cfg.AuthToken)
+				token, err := mcpListenerAuth(addr, cfg.AuthToken, cfg.RequireAuth)
 				if err != nil {
 					return err
 				}
@@ -127,24 +127,28 @@ Add to your MCP client config (e.g. Claude Desktop):
 }
 
 // mcpListenerAuth decides the bearer token the MCP HTTP listener must
-// enforce for the given (already-normalized) bind address. A loopback
-// bind is local-trust and runs without listener auth (empty token). A
-// non-loopback bind must be authenticated: it returns the configured
-// token, or an error when none is set, so the network-reachable surface
-// is never unauthenticated.
-func mcpListenerAuth(addr, configuredToken string) (string, error) {
+// enforce for the given (already-normalized) bind address. A loopback bind
+// is local-trust and runs without listener auth (empty token) UNLESS
+// require_auth is set, which forces authentication on every bind so a
+// forwarded loopback port (reverse proxy, SSH tunnel) is never an
+// unauthenticated surface. A non-loopback bind, or any bind under
+// require_auth, must be authenticated: it returns the configured token, or
+// an error when none is set, so the network-reachable surface is never
+// unauthenticated.
+func mcpListenerAuth(addr, configuredToken string, requireAuth bool) (string, error) {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", fmt.Errorf("parsing --http address %q: %w", addr, err)
 	}
-	if isLoopbackHost(host) {
+	if isLoopbackHost(host) && !requireAuth {
 		return "", nil
 	}
 	if configuredToken == "" {
 		return "", fmt.Errorf(
-			"--http %q is non-loopback but no auth token is configured; set "+
+			"--http %q requires an auth token but none is configured; set "+
 				"auth_token in config.toml (or enable require_auth) so the MCP "+
-				"server requires Authorization: Bearer, or bind a loopback address",
+				"server enforces Authorization: Bearer, or bind a loopback "+
+				"address without require_auth",
 			addr)
 	}
 	return configuredToken, nil

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -118,15 +118,14 @@ Add to your MCP client config (e.g. Claude Desktop):
 			"every request. Only expose it on trusted networks (Tailscale, "+
 			"VPN-only) or behind an authenticating reverse proxy.")
 
-	// Transport-selection flags, mirroring the `session` command where
-	// applicable. MCP requires a daemon-backed service, so --pg is
-	// retained only to produce a specific error instead of silently
-	// opening PostgreSQL directly.
+	// Transport-selection flags, mirroring the `session` command.
+	// Implicit local SQLite reads are daemon-backed; explicit --server
+	// and --pg select their requested remote/read-store backends.
 	cmd.Flags().String("server", "", "Remote daemon URL")
 	cmd.Flags().String("server-token-file", "",
 		"File containing bearer token for explicit --server requests")
 	cmd.Flags().Bool("pg", false,
-		"Unsupported for MCP; run pg serve and use --server instead")
+		"Read session data from configured PostgreSQL")
 
 	return cmd
 }
@@ -152,16 +151,16 @@ func resolveMCPService(
 		return service.NewHTTPBackend(remote, token, false),
 			func() {}, nil
 	}
-	if pgReadRequested(cmd) {
-		return nil, nil, errors.New(
-			"agentsview mcp requires a daemon; --pg opens PostgreSQL " +
-				"directly. Run 'agentsview pg serve' and pass --server, " +
-				"or omit --pg to use the local daemon",
-		)
-	}
 	cfg, err := config.LoadPFlags(cmd.Flags())
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %w", err)
+	}
+	pgCfg, usePG, err := resolvePGReadConfig(cmd, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	if usePG {
+		return newPGReadService(cfg, pgCfg)
 	}
 	return newMCPDaemonService(cfg), func() {}, nil
 }

--- a/cmd/agentsview/mcp_test.go
+++ b/cmd/agentsview/mcp_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeMCPHTTPAddr(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		addr          string
+		allowInsecure bool
+		want          string
+		wantErr       bool
+	}{
+		{"empty", "", false, "", true},
+		{"bare port", "8085", false, "127.0.0.1:8085", false},
+		{"colon port", ":8085", false, "127.0.0.1:8085", false},
+		{"explicit loopback v4", "127.0.0.1:8085", false, "127.0.0.1:8085", false},
+		{"explicit loopback v6", "[::1]:8085", false, "[::1]:8085", false},
+		{"localhost", "localhost:8085", false, "localhost:8085", false},
+		{"non-loopback rejected", "192.168.1.5:8085", false, "", true},
+		{"all-interfaces rejected", "0.0.0.0:8085", false, "", true},
+		{"non-loopback opted in", "192.168.1.5:8085", true, "192.168.1.5:8085", false},
+		{"all-interfaces opted in", "0.0.0.0:8085", true, "0.0.0.0:8085", false},
+		{"not a port", "notaport", false, "", true},
+		// Empty host with a port still binds all interfaces, so it must be
+		// rejected without the opt-in.
+		{"empty host footgun", "[]:8085", false, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := normalizeMCPHTTPAddr(tc.addr, tc.allowInsecure)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNewMCPCommand_Wiring(t *testing.T) {
+	t.Parallel()
+	cmd := newMCPCommand()
+	assert.Equal(t, "mcp", cmd.Use)
+	assert.Equal(t, groupData, cmd.GroupID)
+	assert.True(t, cmd.SilenceUsage)
+
+	for _, name := range []string{
+		"http", "http-allow-insecure", "server", "server-token-file", "pg",
+	} {
+		assert.NotNil(t, cmd.Flags().Lookup(name), "missing flag --%s", name)
+	}
+}
+
+func TestRootCommand_RegistersMCP(t *testing.T) {
+	t.Parallel()
+	root := newRootCommand()
+	var found bool
+	for _, c := range root.Commands() {
+		if c.Use == "mcp" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "root command should register the mcp subcommand")
+}

--- a/cmd/agentsview/mcp_test.go
+++ b/cmd/agentsview/mcp_test.go
@@ -117,17 +117,35 @@ func TestRootCommand_RegistersMCP(t *testing.T) {
 	assert.True(t, found, "root command should register the mcp subcommand")
 }
 
-func TestResolveMCPServiceRejectsPG(t *testing.T) {
-	t.Parallel()
+func TestResolveMCPServicePGFlagUsesPGReadStore(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+	remoteDir := t.TempDir()
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+	t.Setenv("AGENTSVIEW_PG_SCHEMA", "custom_schema")
+	seedSession(t, dataDir, "local-session", "local")
+	seedSession(t, remoteDir, "pg-session", "remote")
+
+	remoteDB, err := db.Open(filepath.Join(remoteDir, "sessions.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = remoteDB.Close() })
+	stub := stubPGReadStore(t, remoteDB)
+	forbidStartBackgroundServeForTransport(t,
+		"agentsview mcp --pg must use the PG read store, not the daemon")
+
 	cmd := newMCPCommand()
 	cmd.SetArgs([]string{"--pg"})
 	require.NoError(t, cmd.ParseFlags([]string{"--pg"}))
 
 	svc, cleanup, err := resolveMCPService(cmd)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--pg")
-	assert.Nil(t, svc)
-	assert.Nil(t, cleanup)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	res, err := svc.List(context.Background(), service.ListFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, res.Sessions, 1)
+	assert.Equal(t, "pg-session", res.Sessions[0].ID)
+	assert.Equal(t, "postgres://example.test/agentsview", stub.PG.URL)
+	assert.Equal(t, "custom_schema", stub.PG.Schema)
 }
 
 func TestMCPDaemonServiceStartsDaemonForEachOperation(t *testing.T) {

--- a/cmd/agentsview/mcp_test.go
+++ b/cmd/agentsview/mcp_test.go
@@ -45,6 +45,27 @@ func TestNormalizeMCPHTTPAddr(t *testing.T) {
 	}
 }
 
+func TestMCPListenerAuth(t *testing.T) {
+	t.Parallel()
+	// Loopback never requires listener auth, even when a token exists.
+	tok, err := mcpListenerAuth("127.0.0.1:8085", "")
+	require.NoError(t, err)
+	assert.Empty(t, tok)
+	tok, err = mcpListenerAuth("[::1]:8085", "abc")
+	require.NoError(t, err)
+	assert.Empty(t, tok, "loopback bind does not enforce a token")
+
+	// Non-loopback with a token enforces it.
+	tok, err = mcpListenerAuth("192.168.1.5:8085", "abc")
+	require.NoError(t, err)
+	assert.Equal(t, "abc", tok)
+
+	// Non-loopback without a token is refused (no unauthenticated remote surface).
+	_, err = mcpListenerAuth("192.168.1.5:8085", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth token")
+}
+
 func TestNewMCPCommand_Wiring(t *testing.T) {
 	t.Parallel()
 	cmd := newMCPCommand()

--- a/cmd/agentsview/mcp_test.go
+++ b/cmd/agentsview/mcp_test.go
@@ -1,10 +1,22 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func TestNormalizeMCPHTTPAddr(t *testing.T) {
@@ -103,4 +115,64 @@ func TestRootCommand_RegistersMCP(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "root command should register the mcp subcommand")
+}
+
+func TestResolveMCPServiceRejectsPG(t *testing.T) {
+	t.Parallel()
+	cmd := newMCPCommand()
+	cmd.SetArgs([]string{"--pg"})
+	require.NoError(t, cmd.ParseFlags([]string{"--pg"}))
+
+	svc, cleanup, err := resolveMCPService(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--pg")
+	assert.Nil(t, svc)
+	assert.Nil(t, cleanup)
+}
+
+func TestMCPDaemonServiceStartsDaemonForEachOperation(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := config.Config{
+		DataDir: dataDir,
+		DBPath:  filepath.Join(dataDir, "sessions.db"),
+	}
+	var starts int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/sessions", r.URL.Path)
+		assert.Equal(t, "7", r.URL.Query().Get("limit"))
+		_ = json.NewEncoder(w).Encode(service.SessionList{
+			Sessions: []db.Session{{ID: "from-daemon", Agent: "codex"}},
+			Total:    1,
+		})
+	}))
+	t.Cleanup(ts.Close)
+	host, port := splitTestServerURL(t, ts.URL)
+	stubStartBackgroundServeForTransport(t, func(
+		context.Context, *config.Config, time.Duration,
+	) (*DaemonRuntime, error) {
+		starts++
+		return &DaemonRuntime{Host: host, Port: port}, nil
+	})
+
+	svc := newMCPDaemonService(cfg)
+	for range 2 {
+		res, err := svc.List(context.Background(), service.ListFilter{Limit: 7})
+		require.NoError(t, err)
+		require.Len(t, res.Sessions, 1)
+		assert.Equal(t, "from-daemon", res.Sessions[0].ID)
+	}
+	assert.Equal(t, 2, starts)
+	assert.NoFileExists(t, cfg.DBPath)
+}
+
+func splitTestServerURL(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, raw, nil)
+	require.NoError(t, err)
+	host, portText, err := net.SplitHostPort(req.URL.Host)
+	require.NoError(t, err)
+	var port int
+	_, err = fmt.Sscanf(portText, "%d", &port)
+	require.NoError(t, err)
+	return host, port
 }

--- a/cmd/agentsview/mcp_test.go
+++ b/cmd/agentsview/mcp_test.go
@@ -47,21 +47,33 @@ func TestNormalizeMCPHTTPAddr(t *testing.T) {
 
 func TestMCPListenerAuth(t *testing.T) {
 	t.Parallel()
-	// Loopback never requires listener auth, even when a token exists.
-	tok, err := mcpListenerAuth("127.0.0.1:8085", "")
+	// Loopback without require_auth is local-trust: no listener auth, even
+	// when a token happens to be configured.
+	tok, err := mcpListenerAuth("127.0.0.1:8085", "", false)
 	require.NoError(t, err)
 	assert.Empty(t, tok)
-	tok, err = mcpListenerAuth("[::1]:8085", "abc")
+	tok, err = mcpListenerAuth("[::1]:8085", "abc", false)
 	require.NoError(t, err)
-	assert.Empty(t, tok, "loopback bind does not enforce a token")
+	assert.Empty(t, tok, "loopback bind does not enforce a token without require_auth")
+
+	// require_auth forces auth even on loopback, so a forwarded port is
+	// never an unauthenticated surface.
+	tok, err = mcpListenerAuth("127.0.0.1:8085", "abc", true)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", tok, "require_auth enforces the token on loopback")
+
+	// require_auth on loopback without a token is refused.
+	_, err = mcpListenerAuth("127.0.0.1:8085", "", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth token")
 
 	// Non-loopback with a token enforces it.
-	tok, err = mcpListenerAuth("192.168.1.5:8085", "abc")
+	tok, err = mcpListenerAuth("192.168.1.5:8085", "abc", false)
 	require.NoError(t, err)
 	assert.Equal(t, "abc", tok)
 
 	// Non-loopback without a token is refused (no unauthenticated remote surface).
-	_, err = mcpListenerAuth("192.168.1.5:8085", "")
+	_, err = mcpListenerAuth("192.168.1.5:8085", "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "auth token")
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -714,7 +714,8 @@ to choose a wider or narrower window.
 Run a read-only Model Context Protocol server for assistant clients
 that can call MCP tools. The server exposes session search, listing,
 overview, message retrieval, content search, and usage-summary tools
-over the same service layer used by the CLI and HTTP API.
+over the same service layer used by the CLI and HTTP API. See
+[MCP Server](/mcp/) for setup examples and operational guidance.
 
 ```bash
 agentsview mcp

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -737,10 +737,10 @@ directly.
 
 Use `--server <url>` to point at an explicit running daemon. When the
 daemon requires auth, provide `AGENTSVIEW_SERVER_TOKEN` or
-`--server-token-file <path>`. To serve PostgreSQL-backed data, run
+`--server-token-file <path>`. Use `--pg` to read from configured
+PostgreSQL directly, or run
 [`agentsview pg serve`](/pg-sync/#agentsview-pg-serve) and pass its
-URL with `--server`; `--pg` is not supported by `agentsview mcp`
-because it bypasses the daemon policy.
+URL with `--server`.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -748,6 +748,7 @@ because it bypasses the daemon policy.
 | `--http-allow-insecure` | `false` | Allow non-loopback HTTP binds; requires bearer auth |
 | `--server <url>` | | Explicit daemon URL for MCP tool calls |
 | `--server-token-file <path>` | | Bearer token file for an explicit daemon URL |
+| `--pg` | `false` | Read from configured PostgreSQL |
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -709,6 +709,47 @@ to choose a wider or narrower window.
 
 ---
 
+### `agentsview mcp`
+
+Run a read-only Model Context Protocol server for assistant clients
+that can call MCP tools. The server exposes session search, listing,
+overview, message retrieval, content search, and usage-summary tools
+over the same service layer used by the CLI and HTTP API.
+
+```bash
+agentsview mcp
+agentsview mcp --http 127.0.0.1:8085
+agentsview mcp --server http://127.0.0.1:8080
+```
+
+By default, `agentsview mcp` speaks stdio, which is the expected
+transport for local MCP clients such as Claude Desktop, Claude Code,
+and Codex. `--http <addr>` serves StreamableHTTP instead. Bare ports
+and `:PORT` values bind to `127.0.0.1`; non-loopback binds require
+`--http-allow-insecure` plus a configured bearer token.
+
+Local MCP mode is daemon-backed. Each tool call resolves the local
+AgentsView daemon and starts it when needed, so a long-lived MCP
+server can keep working after the daemon exits due to idleness. The
+MCP server does not fall back to opening the local SQLite archive
+directly.
+
+Use `--server <url>` to point at an explicit running daemon. When the
+daemon requires auth, provide `AGENTSVIEW_SERVER_TOKEN` or
+`--server-token-file <path>`. To serve PostgreSQL-backed data, run
+[`agentsview pg serve`](/pg-sync/#agentsview-pg-serve) and pass its
+URL with `--server`; `--pg` is not supported by `agentsview mcp`
+because it bypasses the daemon policy.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--http <addr>` | | Serve StreamableHTTP instead of stdio |
+| `--http-allow-insecure` | `false` | Allow non-loopback HTTP binds; requires bearer auth |
+| `--server <url>` | | Explicit daemon URL for MCP tool calls |
+| `--server-token-file <path>` | | Bearer token file for an explicit daemon URL |
+
+---
+
 ### `agentsview secrets`
 
 Scan for and list detected secret leaks across sessions, with

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,169 @@
+---
+title: MCP Server
+description: Connect assistant clients to your AgentsView session history with MCP
+---
+
+The `agentsview mcp` command runs a read-only
+[Model Context Protocol](https://modelcontextprotocol.io) server. MCP-capable
+assistant clients can use it to search prior sessions, inspect a session before
+opening it, fetch message slices, search raw content, and summarize token usage
+without leaving the assistant.
+
+## When To Use It
+
+Use the MCP server when you want a coding assistant to answer questions such as:
+
+- "Have I solved this error before?"
+- "Find prior sessions in this repository about the deploy pipeline."
+- "Open the relevant messages around this search hit."
+- "Summarize recent token usage for this project."
+
+The tools are read-only. They expose session history and usage data, but they do
+not mutate the archive or resync files directly.
+
+## Quick Start
+
+For local desktop-style MCP clients, use stdio:
+
+```json
+{
+  "mcpServers": {
+    "agentsview": {
+      "command": "agentsview",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Restart or reload your MCP client after adding the server. Once connected, the
+client will see these tools:
+
+| Tool                   | Purpose                                            |
+| ---------------------- | -------------------------------------------------- |
+| `search_sessions`      | Full-text search across recorded sessions          |
+| `list_sessions`        | List recent or filtered sessions                   |
+| `get_session_overview` | Fetch metadata and a compact message preview       |
+| `get_messages`         | Read paginated message bodies from one session     |
+| `search_content`       | Exact string or regex search over raw session text |
+| `get_usage_summary`    | Aggregate token and cost usage                     |
+
+## Daemon-Backed Reads
+
+Local MCP mode talks to the AgentsView daemon. Each tool call resolves the local
+daemon and starts it when needed, so a long-lived MCP server keeps working even
+after the daemon exits due to idleness.
+
+The MCP server does not open the local SQLite archive directly. This keeps MCP
+reads on the same daemon policy as the desktop app and avoids a long-running MCP
+process holding its own archive handle.
+
+If you need to disable daemon auto-start for general CLI work with
+`AGENTSVIEW_NO_DAEMON=1`, do not use local MCP mode for that archive. Start the
+daemon yourself and connect with `--server`, or stop the MCP server.
+
+## Explicit Daemon URLs
+
+Use `--server` when the daemon is already running or when you want to target a
+specific host:
+
+```json
+{
+  "mcpServers": {
+    "agentsview": {
+      "command": "agentsview",
+      "args": ["mcp", "--server", "http://127.0.0.1:8080"]
+    }
+  }
+}
+```
+
+If that daemon requires bearer auth, set `AGENTSVIEW_SERVER_TOKEN` in the MCP
+client environment or pass `--server-token-file <path>`:
+
+```json
+{
+  "mcpServers": {
+    "agentsview": {
+      "command": "agentsview",
+      "args": [
+        "mcp",
+        "--server",
+        "https://agents.example.com",
+        "--server-token-file",
+        "/Users/me/.agentsview/token"
+      ]
+    }
+  }
+}
+```
+
+The local config `auth_token` is not sent to explicit `--server` URLs. This
+prevents accidentally leaking a local daemon token to another host.
+
+## PostgreSQL-Backed MCP
+
+`agentsview mcp --pg` is not supported. The MCP server requires a daemon-backed
+service, and `--pg` would open PostgreSQL directly.
+
+To expose PostgreSQL-backed session history over MCP, run a read-only PostgreSQL
+daemon and point MCP at it:
+
+```bash
+agentsview pg serve --port 8085
+```
+
+```json
+{
+  "mcpServers": {
+    "agentsview": {
+      "command": "agentsview",
+      "args": ["mcp", "--server", "http://127.0.0.1:8085"]
+    }
+  }
+}
+```
+
+See [PostgreSQL Sync](/pg-sync/) for configuring `pg push` and `pg serve`.
+
+## StreamableHTTP Mode
+
+stdio is the default and safest choice for local MCP clients. Use StreamableHTTP
+only when your client needs an HTTP MCP endpoint:
+
+```bash
+agentsview mcp --http 127.0.0.1:8085
+```
+
+Bare ports and `:PORT` values bind to loopback:
+
+```bash
+agentsview mcp --http 8085   # same as 127.0.0.1:8085
+agentsview mcp --http :8085  # same as 127.0.0.1:8085
+```
+
+Non-loopback binds require an explicit opt-in:
+
+```bash
+agentsview mcp --http 0.0.0.0:8085 --http-allow-insecure
+```
+
+When the HTTP listener is reachable beyond loopback, AgentsView requires a
+configured bearer token and enforces `Authorization: Bearer <token>` on every
+request. If `require_auth` is enabled, loopback HTTP binds also require bearer
+auth so forwarded ports are not accidentally unauthenticated.
+
+## Security Notes
+
+The MCP server can reveal prompts, assistant responses, tool output, file paths,
+project names, and usage totals. Treat it like access to your session archive.
+
+- Prefer stdio for local assistant clients.
+- Prefer loopback HTTP binds unless the endpoint is behind a trusted network or
+  authenticating proxy.
+- Use bearer tokens for any non-loopback or forwarded HTTP endpoint.
+- Remember that MCP tools are read-only, but the data they expose may still be
+  sensitive.
+
+For every flag, see [`agentsview mcp`](/commands/#agentsview-mcp) in the CLI
+reference.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -103,11 +103,25 @@ prevents accidentally leaking a local daemon token to another host.
 
 ## PostgreSQL-Backed MCP
 
-`agentsview mcp --pg` is not supported. The MCP server requires a daemon-backed
-service, and `--pg` would open PostgreSQL directly.
+If `[pg]` or `AGENTSVIEW_PG_URL` is configured, pass `--pg` to read from
+PostgreSQL directly:
 
-To expose PostgreSQL-backed session history over MCP, run a read-only PostgreSQL
-daemon and point MCP at it:
+```json
+{
+  "mcpServers": {
+    "agentsview": {
+      "command": "agentsview",
+      "args": ["mcp", "--pg"]
+    }
+  }
+}
+```
+
+This is useful when the MCP server should read the shared PostgreSQL archive
+without relying on a local SQLite daemon.
+
+You can also expose PostgreSQL-backed session history through a read-only
+PostgreSQL daemon and point MCP at it:
 
 ```bash
 agentsview pg serve --port 8085

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -16,6 +16,7 @@ nav = [
   {"Usage Guide" = "usage.md"},
   {"Activity" = "activity.md"},
   {"Session Intelligence" = "session-intelligence.md"},
+  {"MCP Server" = "mcp.md"},
   {"Token Usage & Costs" = "token-usage.md"},
   {"Chat Import" = "chat-import.md"},
   {"Session Insights" = "insights.md"},

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/klauspost/compress v1.18.6
 	github.com/mattn/go-sqlite3 v1.14.45
+	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/spf13/cobra v1.10.2
@@ -26,6 +27,7 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -58,6 +60,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -81,11 +84,14 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/posthog/posthog-go v1.12.6 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
@@ -95,9 +101,9 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/goccy/go-json v0.10.6 h1:p8HrPJzOakx/mn/bQtjgNjdTcN+/S6FcG2CTtQOrHVU=
 github.com/goccy/go-json v0.10.6/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/flatbuffers v25.12.19+incompatible h1:haMV2JRRJCe1998HeW/p0X9UaMTK6SDo0ffLn2+DbLs=
@@ -84,6 +86,8 @@ github.com/google/flatbuffers v25.12.19+incompatible/go.mod h1:1AeVuKshWv4vARoZa
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -142,6 +146,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -158,6 +164,10 @@ github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:Om
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
@@ -190,6 +200,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
@@ -219,6 +231,8 @@ golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7
 golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -53,6 +53,32 @@ func SystemPrefixSQL(contentCol, roleCol string) string {
 		strings.Join(parts, " OR ") + "))"
 }
 
+// systemPrefixTrimCutset is the leading-whitespace set SystemPrefixSQL's
+// LTRIM strips: ASCII whitespace, BOM, and the Unicode spaces. Kept
+// identical so the Go and SQL system-prefix checks agree.
+const systemPrefixTrimCutset = " \t\n\v\f\r" +
+	"\u0085\u00A0\u1680" +
+	"\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A" +
+	"\u2028\u2029\u202F\u205F\u3000\uFEFF"
+
+// IsSystemPrefixed reports whether a user-role message is a system-injected
+// message identified by a SystemMsgPrefixes prefix. It is the Go equivalent
+// of SystemPrefixSQL for callers that filter in Go rather than SQL: only
+// user-role messages match, and leading whitespace is trimmed with the same
+// cutset before the case-sensitive prefix comparison.
+func IsSystemPrefixed(content, role string) bool {
+	if role != "user" {
+		return false
+	}
+	trimmed := strings.TrimLeft(content, systemPrefixTrimCutset)
+	for _, p := range SystemMsgPrefixes {
+		if strings.HasPrefix(trimmed, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // SearchResult holds a session-level match with the best-ranked snippet.
 type SearchResult struct {
 	SessionID      string  `json:"session_id"`

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsSystemPrefixed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		content string
+		role    string
+		want    bool
+	}{
+		{"plain user message", "fix the build", "user", false},
+		{"continued-session prefix", SystemMsgPrefixes[0] + " from a prior run", "user", true},
+		{"task-notification prefix", "<task-notification>done</task-notification>", "user", true},
+		{"leading whitespace then prefix", "\n\t  <command-name>/foo", "user", true},
+		{"bom then prefix", "\uFEFF<command-message>x", "user", true},
+		{"assistant role is never system-prefixed", SystemMsgPrefixes[0], "assistant", false},
+		{"prefix mid-content does not match", "see <task-notification> later", "user", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsSystemPrefixed(tc.content, tc.role))
+		})
+	}
+}
+
 func TestSearch(t *testing.T) {
 	d := testDB(t)
 	requireFTS(t, d)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -122,16 +122,19 @@ func ServeStdio(ctx context.Context, opts ServeOptions) error {
 
 // isCleanStdioShutdown reports whether a Run error represents the normal
 // end of a stdio session (client disconnect or signal) rather than a
-// failure. When stdin closes while requests are in flight, the SDK
-// surfaces the internal jsonrpc2 "server is closing" wire error, which it
-// neither exports nor wraps in an errors.Is-traversable way - so that one
-// case is matched on its stable message. A stdio MCP server that loses
-// its client has simply finished its job.
+// failure. A stdio MCP server that loses its client has simply finished
+// its job. When stdin closes while requests are in flight, the SDK
+// surfaces the internal jsonrpc2 "server is closing" wire error: it is
+// not the exported mcp.ErrConnectionClosed and does not wrap io.EOF in an
+// errors.Is-traversable way, so that specific case is matched on its
+// stable message as a last resort.
 func isCleanStdioShutdown(err error) bool {
 	if err == nil {
 		return true
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, io.EOF) {
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, mcp.ErrConnectionClosed) {
 		return true
 	}
 	msg := err.Error()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -114,6 +114,20 @@ func newServer(opts ServeOptions) *mcp.Server {
 	return s
 }
 
+// newHTTPHandler builds the StreamableHTTP handler with its protections.
+// Passing nil options keeps the SDK's default DNS-rebinding protection
+// (DisableLocalhostProtection stays false): a request arriving on a
+// loopback address with a non-loopback Host header is rejected 403,
+// which blocks a malicious web page from reaching a loopback MCP server
+// via DNS rebinding. withBearerAuth then adds token auth for non-loopback
+// binds (see the command layer).
+func newHTTPHandler(opts ServeOptions) http.Handler {
+	srv := newServer(opts)
+	var handler http.Handler = mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return srv }, nil)
+	return withBearerAuth(handler, opts.Token)
+}
+
 // withBearerAuth wraps next so every request must present
 // "Authorization: Bearer <token>". When token is empty the handler is
 // returned unwrapped (loopback binds run without listener auth). The
@@ -173,11 +187,7 @@ func isCleanStdioShutdown(err error) bool {
 // calls can finish. addr must already be validated as a safe bind
 // address (see the cmd layer's loopback guard).
 func ServeHTTP(ctx context.Context, opts ServeOptions, addr string) error {
-	srv := newServer(opts)
-	var handler http.Handler = mcp.NewStreamableHTTPHandler(
-		func(*http.Request) *mcp.Server { return srv }, nil)
-	handler = withBearerAuth(handler, opts.Token)
-	httpServer := &http.Server{Addr: addr, Handler: handler}
+	httpServer := &http.Server{Addr: addr, Handler: newHTTPHandler(opts)}
 	fmt.Fprintf(os.Stderr, "agentsview mcp: serving on %s\n", addr)
 
 	errCh := make(chan error, 1)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,151 @@
+// ABOUTME: Builds and serves the agentsview MCP server (stdio or
+// ABOUTME: StreamableHTTP) over the six read-only retrieval tools.
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/agentsview/internal/service"
+)
+
+// Tool names. The same constant is used to register a tool and to refer
+// to it in tests.
+const (
+	ToolSearchSessions     = "search_sessions"
+	ToolListSessions       = "list_sessions"
+	ToolGetSessionOverview = "get_session_overview"
+	ToolGetMessages        = "get_messages"
+	ToolSearchContent      = "search_content"
+	ToolGetUsageSummary    = "get_usage_summary"
+)
+
+// ServeOptions configures the MCP server. Service is required; Version is
+// reported in the server's implementation info; Now is injectable so
+// tests can control the self-reference exclusion window (defaults to
+// time.Now).
+type ServeOptions struct {
+	Service service.SessionService
+	Version string
+	Now     func() time.Time
+}
+
+// newServer builds an MCP server with all six read-only tools
+// registered. Shared by the stdio and StreamableHTTP transports.
+func newServer(opts ServeOptions) *mcp.Server {
+	version := opts.Version
+	if version == "" {
+		version = "dev"
+	}
+	s := mcp.NewServer(&mcp.Implementation{
+		Name:    "agentsview",
+		Title:   "agentsview session history",
+		Version: version,
+	}, nil)
+
+	t := &toolset{svc: opts.Service, now: opts.Now}
+	readOnly := &mcp.ToolAnnotations{ReadOnlyHint: true}
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: ToolSearchSessions,
+		Description: "Full-text search across all recorded AI agent sessions (Claude Code, Codex, Gemini, " +
+			"Antigravity, and others) from every project and machine. Returns ranked snippets with a " +
+			"match_ordinal usable with get_messages to read the surrounding conversation. Use this to " +
+			"answer questions like 'have I solved this before?' or to find prior work on a topic. " +
+			"Every term must appear (AND); wrap the query in double quotes for an exact phrase. " +
+			"Sessions active in the last 10 minutes (including the current conversation) are excluded " +
+			"unless include_active is set.",
+		Annotations: readOnly,
+	}, t.searchSessions)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: ToolListSessions,
+		Description: "List recorded agent sessions with filters (project, agent, machine, date range). " +
+			"Returns compact metadata rows, newest first. Use search_sessions instead when looking for " +
+			"specific content.",
+		Annotations: readOnly,
+	}, t.listSessions)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: ToolGetSessionOverview,
+		Description: "Cheap summary of one session: metadata, the opening user message, and the last few " +
+			"conversation messages. Call this before get_messages to decide whether a session is relevant.",
+		Annotations: readOnly,
+	}, t.sessionOverview)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: ToolGetMessages,
+		Description: "Read a slice of one session's transcript, paginated by message ordinal. Defaults " +
+			"return only user and assistant messages, each truncated to 2000 characters; truncated " +
+			"messages are flagged so you can re-fetch with a higher max_chars_per_message.",
+		Annotations: readOnly,
+	}, t.getMessages)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: ToolSearchContent,
+		Description: "Exact substring or regex search over raw session text, including tool inputs and results. " +
+			"Slower but more precise than search_sessions; use it for error messages, identifiers, or " +
+			"code fragments. Matches from the last 10 minutes (including the current conversation) are " +
+			"excluded unless include_active is set.",
+		Annotations: readOnly,
+	}, t.searchContent)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: ToolGetUsageSummary,
+		Description: "Aggregate token usage and cost across all agents: totals plus per-day breakdown, " +
+			"filterable by project, agent, machine, and date range.",
+		Annotations: readOnly,
+	}, t.usageSummary)
+
+	return s
+}
+
+// ServeStdio runs the MCP server over stdio. It blocks until stdin is
+// closed or ctx is cancelled.
+func ServeStdio(ctx context.Context, opts ServeOptions) error {
+	if err := newServer(opts).Run(ctx, &mcp.StdioTransport{}); err != nil {
+		return fmt.Errorf("serve MCP over stdio: %w", err)
+	}
+	return nil
+}
+
+// ServeHTTP runs the MCP server over StreamableHTTP on addr. When ctx is
+// cancelled the HTTP server is shut down gracefully so in-flight tool
+// calls can finish. addr must already be validated as a safe bind
+// address (see the cmd layer's loopback guard).
+func ServeHTTP(ctx context.Context, opts ServeOptions, addr string) error {
+	srv := newServer(opts)
+	handler := mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return srv }, nil)
+	httpServer := &http.Server{Addr: addr, Handler: handler}
+	fmt.Fprintf(os.Stderr, "agentsview mcp: serving on %s\n", addr)
+
+	errCh := make(chan error, 1)
+	go func() {
+		err := httpServer.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		// Graceful shutdown with a short bound; in-flight tool calls
+		// usually finish in milliseconds, so 10s is plenty.
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(), 10*time.Second)
+		defer cancel()
+		_ = httpServer.Shutdown(shutdownCtx)
+		return ctx.Err()
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,6 +4,7 @@ package mcp
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"io"
@@ -36,6 +37,11 @@ type ServeOptions struct {
 	Service service.SessionService
 	Version string
 	Now     func() time.Time
+	// Token, when non-empty, requires every StreamableHTTP request to
+	// carry "Authorization: Bearer <Token>". It has no effect on stdio.
+	// The command layer sets it for non-loopback HTTP binds so the
+	// network-reachable surface is never unauthenticated.
+	Token string
 }
 
 // newServer builds an MCP server with all six read-only tools
@@ -108,6 +114,26 @@ func newServer(opts ServeOptions) *mcp.Server {
 	return s
 }
 
+// withBearerAuth wraps next so every request must present
+// "Authorization: Bearer <token>". When token is empty the handler is
+// returned unwrapped (loopback binds run without listener auth). The
+// comparison is constant-time to avoid leaking the token via timing.
+func withBearerAuth(next http.Handler, token string) http.Handler {
+	if token == "" {
+		return next
+	}
+	want := []byte("Bearer " + token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := []byte(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeCompare(got, want) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // ServeStdio runs the MCP server over stdio. It blocks until stdin is
 // closed (the client disconnected) or ctx is cancelled, both of which are
 // the normal end of life for a stdio server and return nil. Only an
@@ -148,8 +174,9 @@ func isCleanStdioShutdown(err error) bool {
 // address (see the cmd layer's loopback guard).
 func ServeHTTP(ctx context.Context, opts ServeOptions, addr string) error {
 	srv := newServer(opts)
-	handler := mcp.NewStreamableHTTPHandler(
+	var handler http.Handler = mcp.NewStreamableHTTPHandler(
 		func(*http.Request) *mcp.Server { return srv }, nil)
+	handler = withBearerAuth(handler, opts.Token)
 	httpServer := &http.Server{Addr: addr, Handler: handler}
 	fmt.Fprintf(os.Stderr, "agentsview mcp: serving on %s\n", addr)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -107,12 +109,34 @@ func newServer(opts ServeOptions) *mcp.Server {
 }
 
 // ServeStdio runs the MCP server over stdio. It blocks until stdin is
-// closed or ctx is cancelled.
+// closed (the client disconnected) or ctx is cancelled, both of which are
+// the normal end of life for a stdio server and return nil. Only an
+// unexpected transport failure is surfaced as an error.
 func ServeStdio(ctx context.Context, opts ServeOptions) error {
-	if err := newServer(opts).Run(ctx, &mcp.StdioTransport{}); err != nil {
-		return fmt.Errorf("serve MCP over stdio: %w", err)
+	err := newServer(opts).Run(ctx, &mcp.StdioTransport{})
+	if isCleanStdioShutdown(err) {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("serve MCP over stdio: %w", err)
+}
+
+// isCleanStdioShutdown reports whether a Run error represents the normal
+// end of a stdio session (client disconnect or signal) rather than a
+// failure. When stdin closes while requests are in flight, the SDK
+// surfaces the internal jsonrpc2 "server is closing" wire error, which it
+// neither exports nor wraps in an errors.Is-traversable way - so that one
+// case is matched on its stable message. A stdio MCP server that loses
+// its client has simply finished its job.
+func isCleanStdioShutdown(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, io.EOF) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "server is closing") ||
+		strings.Contains(msg, "connection closed")
 }
 
 // ServeHTTP runs the MCP server over StreamableHTTP on addr. When ctx is

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/service"
+)
+
+// newInMemoryPair connects a real MCP client to srv over an in-memory
+// transport, returning both sessions. The caller closes the client and
+// waits on the server session.
+func newInMemoryPair(
+	t *testing.T, srv *mcp.Server,
+) (*mcp.ServerSession, *mcp.ClientSession) {
+	t.Helper()
+	ctx := context.Background()
+	st, ct := mcp.NewInMemoryTransports()
+	ss, err := srv.Connect(ctx, st, nil)
+	require.NoError(t, err)
+	client := mcp.NewClient(
+		&mcp.Implementation{Name: "test-client", Version: "v0"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	require.NoError(t, err)
+	return ss, cs
+}
+
+func callParams(name string, args map[string]any) *mcp.CallToolParams {
+	return &mcp.CallToolParams{Name: name, Arguments: args}
+}
+
+func TestNewServer_RegistersSixReadOnlyTools(t *testing.T) {
+	d := dbtest.OpenTestDB(t)
+	srv := newServer(ServeOptions{
+		Service: service.NewDirectBackend(d, nil),
+		Now:     func() time.Time { return fixedNow },
+	})
+	require.NotNil(t, srv)
+
+	st, ct := newInMemoryPair(t, srv)
+	tools, err := ct.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, tools.Tools, 6)
+	for _, tl := range tools.Tools {
+		require.NotNil(t, tl.Annotations, "tool %s missing annotations", tl.Name)
+		require.True(t, tl.Annotations.ReadOnlyHint,
+			"tool %s should be annotated read-only", tl.Name)
+	}
+	require.NoError(t, ct.Close())
+	require.NoError(t, st.Wait())
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2,10 +2,14 @@ package mcp
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/dbtest"
@@ -53,4 +57,55 @@ func TestNewServer_RegistersSixReadOnlyTools(t *testing.T) {
 	}
 	require.NoError(t, ct.Close())
 	require.NoError(t, st.Wait())
+}
+
+func TestIsCleanStdioShutdown(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isCleanStdioShutdown(nil))
+	assert.True(t, isCleanStdioShutdown(context.Canceled))
+	assert.True(t, isCleanStdioShutdown(io.EOF))
+	assert.True(t, isCleanStdioShutdown(fmt.Errorf("wrap: %w", io.EOF)))
+	assert.True(t, isCleanStdioShutdown(errors.New("server is closing: EOF")))
+	assert.True(t, isCleanStdioShutdown(errors.New("connection closed")))
+	assert.False(t, isCleanStdioShutdown(errors.New("boom")))
+	assert.False(t, isCleanStdioShutdown(errors.New("open db: permission denied")))
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+// TestServeStdio_ClientDisconnectIsClean drives a full session over an
+// IOTransport and then closes the input pipe (an abrupt stdin EOF, as
+// when a client process exits). Whatever Run returns - nil or the SDK's
+// "server is closing" error, which races on timing - must be classified
+// as a clean shutdown. This guards against an SDK message change silently
+// turning client disconnects into fatal exits.
+func TestServeStdio_ClientDisconnectIsClean(t *testing.T) {
+	d := dbtest.OpenTestDB(t)
+	msgs := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"x","version":"0"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list"}
+`
+	// Retry to exercise both the nil and the "server is closing" race
+	// outcomes; both must be recognized as clean.
+	for i := 0; i < 30; i++ {
+		srv := newServer(ServeOptions{
+			Service: service.NewDirectBackend(d, nil),
+			Now:     func() time.Time { return fixedNow },
+		})
+		pr, pw := io.Pipe()
+		tr := &mcp.IOTransport{Reader: pr, Writer: nopWriteCloser{io.Discard}}
+		done := make(chan error, 1)
+		go func() { done <- srv.Run(context.Background(), tr) }()
+		_, _ = io.WriteString(pw, msgs)
+		require.NoError(t, pw.Close())
+		select {
+		case err := <-done:
+			assert.True(t, isCleanStdioShutdown(err),
+				"client disconnect must be clean, got %v", err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("server did not return after client disconnect")
+		}
+	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -108,6 +110,34 @@ func TestServeStdio_ClientDisconnectIsClean(t *testing.T) {
 			t.Fatal("server did not return after client disconnect")
 		}
 	}
+}
+
+func TestWithBearerAuth(t *testing.T) {
+	t.Parallel()
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	req := func(auth string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/", nil)
+		if auth != "" {
+			r.Header.Set("Authorization", auth)
+		}
+		return r
+	}
+	serve := func(h http.Handler, auth string) int {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req(auth))
+		return rec.Code
+	}
+
+	// Empty token -> no auth wrapper, request passes through.
+	assert.Equal(t, http.StatusOK, serve(withBearerAuth(ok, ""), ""))
+
+	h := withBearerAuth(ok, "s3cret")
+	assert.Equal(t, http.StatusUnauthorized, serve(h, ""), "missing header")
+	assert.Equal(t, http.StatusUnauthorized, serve(h, "Bearer wrong"), "wrong token")
+	assert.Equal(t, http.StatusUnauthorized, serve(h, "s3cret"), "missing Bearer prefix")
+	assert.Equal(t, http.StatusOK, serve(h, "Bearer s3cret"), "correct token")
 }
 
 // TestServeHTTP_ShutsDownOnContextCancel verifies the StreamableHTTP

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -138,6 +139,40 @@ func TestWithBearerAuth(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, serve(h, "Bearer wrong"), "wrong token")
 	assert.Equal(t, http.StatusUnauthorized, serve(h, "s3cret"), "missing Bearer prefix")
 	assert.Equal(t, http.StatusOK, serve(h, "Bearer s3cret"), "correct token")
+}
+
+// TestHTTPHandler_DNSRebindingProtection guards the SDK's built-in
+// localhost protection: a request reaching a loopback listener with a
+// non-loopback Host header (the DNS-rebinding signature) must be
+// rejected. This is regression coverage in case an SDK upgrade flips the
+// default or DisableLocalhostProtection is ever set.
+func TestHTTPHandler_DNSRebindingProtection(t *testing.T) {
+	t.Parallel()
+	d := dbtest.OpenTestDB(t)
+	ts := httptest.NewServer(newHTTPHandler(ServeOptions{
+		Service: service.NewDirectBackend(d, nil),
+	}))
+	t.Cleanup(ts.Close)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"x","version":"0"}}}`
+	do := func(host string) int {
+		req, err := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(body))
+		require.NoError(t, err)
+		if host != "" {
+			req.Host = host
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusForbidden, do("evil.example:1234"),
+		"spoofed non-loopback Host must be rejected (DNS rebinding)")
+	assert.NotEqual(t, http.StatusForbidden, do(""),
+		"legit loopback Host must pass the rebinding check")
 }
 
 // TestServeHTTP_ShutsDownOnContextCancel verifies the StreamableHTTP

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -89,7 +89,7 @@ func TestServeStdio_ClientDisconnectIsClean(t *testing.T) {
 `
 	// Retry to exercise both the nil and the "server is closing" race
 	// outcomes; both must be recognized as clean.
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		srv := newServer(ServeOptions{
 			Service: service.NewDirectBackend(d, nil),
 			Now:     func() time.Time { return fixedNow },
@@ -107,5 +107,26 @@ func TestServeStdio_ClientDisconnectIsClean(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("server did not return after client disconnect")
 		}
+	}
+}
+
+// TestServeHTTP_ShutsDownOnContextCancel verifies the StreamableHTTP
+// serve path tears down gracefully when its context is cancelled,
+// returning context.Canceled (which the command treats as a clean exit).
+func TestServeHTTP_ShutsDownOnContextCancel(t *testing.T) {
+	d := dbtest.OpenTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- ServeHTTP(ctx, ServeOptions{
+			Service: service.NewDirectBackend(d, nil),
+		}, "127.0.0.1:0")
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("ServeHTTP did not return after context cancel")
 	}
 }

--- a/internal/mcp/shape.go
+++ b/internal/mcp/shape.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"slices"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -115,10 +116,5 @@ func roleAllowed(role string, roles []string) bool {
 	if len(roles) == 0 {
 		return role == "user" || role == "assistant"
 	}
-	for _, r := range roles {
-		if role == r {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(roles, role)
 }

--- a/internal/mcp/shape.go
+++ b/internal/mcp/shape.go
@@ -1,0 +1,124 @@
+// ABOUTME: Response-shaping helpers shared by the MCP tools: limit
+// ABOUTME: clamping, rune-safe truncation, FTS query building, the
+// ABOUTME: self-reference exclusion window, and the role filter.
+package mcp
+
+import (
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	// activeExclusionWindow is how recently a session must have been
+	// active for search tools to exclude it by default. This keeps an
+	// agent from retrieving its own in-progress conversation (which
+	// agentsview syncs in near-real-time) and chasing its tail.
+	activeExclusionWindow = 10 * time.Minute
+
+	defaultMaxCharsPerMessage = 2000
+	maxMaxCharsPerMessage     = 20000
+	defaultMessageLimit       = 20
+	maxMessageLimit           = 100
+	defaultSearchLimit        = 10
+	maxSearchLimit            = 30
+	defaultListLimit          = 20
+	maxListLimit              = 100
+
+	// overviewTailFetch is how many trailing messages the overview
+	// tool fetches to find the last few non-system, role-allowed ones.
+	overviewTailFetch = 10
+	// overviewLastMessages is how many surfaced messages the overview
+	// returns.
+	overviewLastMessages = 3
+	// overviewMaxChars caps each surfaced overview message.
+	overviewMaxChars = 500
+	// nameMaxChars caps session display names in list/search results.
+	nameMaxChars = 200
+)
+
+// truncate cuts s to at most max runes on a rune boundary, returning
+// the (possibly shortened) string and whether truncation occurred.
+func truncate(s string, max int) (string, bool) {
+	if max <= 0 || utf8.RuneCountInString(s) <= max {
+		return s, false
+	}
+	n := 0
+	for i := range s {
+		if n == max {
+			return s[:i], true
+		}
+		n++
+	}
+	return s, false
+}
+
+// clampLimit normalizes a requested page size into [1, max], using
+// def when the request is unset or out of range.
+func clampLimit(requested, def, max int) int {
+	if requested <= 0 || requested > max {
+		return def
+	}
+	return requested
+}
+
+// buildSearchQuery turns a user's search input into an FTS5 expression
+// that is safe and useful to hand to the agentsview search layer. Two
+// sharp edges bite a naive caller: bare punctuation in a token (the
+// hyphen in "agentsview-mcp", a colon in "foo:bar", a stray paren) is
+// parsed as query syntax and raises an error, and an unquoted multi-word
+// query is matched as a single exact phrase, so natural-language input
+// quietly returns nothing.
+//
+// We quote each whitespace-separated term, escaping any embedded quote by
+// doubling it. Quoting makes punctuation literal inside the term, and
+// space-separated quoted phrases combine under FTS5's implicit AND - so
+// every term must appear without demanding an exact phrase. The leading
+// quote also makes db.PrepareFTSQuery pass the query through unchanged
+// instead of re-wrapping it as a phrase.
+//
+// A query the caller already opened with a double quote is treated as a
+// deliberate FTS expression (including an explicit "exact phrase") and is
+// passed through untouched.
+func buildSearchQuery(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.HasPrefix(raw, `"`) {
+		return raw
+	}
+	var b strings.Builder
+	for i, term := range strings.Fields(raw) {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteByte('"')
+		b.WriteString(strings.ReplaceAll(term, `"`, `""`))
+		b.WriteByte('"')
+	}
+	return b.String()
+}
+
+// isActiveSince reports whether an RFC3339 timestamp falls within the
+// exclusion window ending at now. Unparseable or empty timestamps are
+// treated as not active, so such results are kept.
+func isActiveSince(ts string, now time.Time) bool {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return false
+	}
+	return now.Sub(t) < activeExclusionWindow
+}
+
+// roleAllowed reports whether a message role passes the filter. An empty
+// filter allows user and assistant messages only; tool dumps and system
+// messages must be requested explicitly.
+func roleAllowed(role string, roles []string) bool {
+	if len(roles) == 0 {
+		return role == "user" || role == "assistant"
+	}
+	for _, r := range roles {
+		if role == r {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/shape_test.go
+++ b/internal/mcp/shape_test.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildSearchQuery(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, raw, want string
+	}{
+		{"single word quoted", "login", `"login"`},
+		{"multi-word AND", "fix bug", `"fix" "bug"`},
+		{"hyphen token literal", "agentsview-mcp", `"agentsview-mcp"`},
+		{"colon token literal", "status:500", `"status:500"`},
+		{"embedded quote doubled", `say"hi`, `"say""hi"`},
+		{"leading quote passthrough", `"fix bug"`, `"fix bug"`},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, buildSearchQuery(tc.raw))
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+	s, cut := truncate("hello", 10)
+	assert.Equal(t, "hello", s)
+	assert.False(t, cut)
+
+	s, cut = truncate("hello world", 5)
+	assert.Equal(t, "hello", s)
+	assert.True(t, cut)
+
+	// Rune-boundary safe: multibyte runes are not split.
+	s, cut = truncate("héllo", 2)
+	assert.True(t, cut)
+	assert.Equal(t, "hé", s)
+
+	s, cut = truncate("anything", 0)
+	assert.Equal(t, "anything", s)
+	assert.False(t, cut, "max<=0 means no truncation")
+}
+
+func TestClampLimit(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 20, clampLimit(0, 20, 100), "unset -> default")
+	assert.Equal(t, 20, clampLimit(-5, 20, 100), "negative -> default")
+	assert.Equal(t, 50, clampLimit(50, 20, 100), "in range -> as-is")
+	assert.Equal(t, 20, clampLimit(1000, 20, 100), "over max -> default")
+}
+
+func TestIsActiveSince(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	assert.True(t, isActiveSince("2024-06-15T11:55:00Z", now), "5 min ago is active")
+	assert.False(t, isActiveSince("2024-06-15T11:00:00Z", now), "1 h ago is not active")
+	assert.False(t, isActiveSince("", now), "empty is not active")
+	assert.False(t, isActiveSince("garbage", now), "unparseable is not active")
+}
+
+func TestRoleAllowed(t *testing.T) {
+	t.Parallel()
+	assert.True(t, roleAllowed("user", nil))
+	assert.True(t, roleAllowed("assistant", nil))
+	assert.False(t, roleAllowed("tool", nil), "default excludes tool")
+	assert.False(t, roleAllowed("system", nil), "default excludes system")
+	assert.True(t, roleAllowed("tool", []string{"tool"}), "explicit allows tool")
+	assert.False(t, roleAllowed("user", []string{"tool"}), "explicit filter excludes others")
+}
+
+func TestStrval(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", strval(nil))
+	v := "x"
+	assert.Equal(t, "x", strval(&v))
+}
+
+// Guard against accidental whitespace regressions in the multi-term query
+// builder.
+func TestBuildSearchQuery_NoTrailingSpace(t *testing.T) {
+	t.Parallel()
+	got := buildSearchQuery("a b c")
+	assert.False(t, strings.HasSuffix(got, " "))
+	assert.Equal(t, `"a" "b" "c"`, got)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -258,7 +258,7 @@ func (t *toolset) sessionOverview(
 
 type getMessagesIn struct {
 	SessionID          string   `json:"session_id" jsonschema:"The session to read."`
-	From               int      `json:"from,omitempty" jsonschema:"Ordinal to start from (e.g. match_ordinal from search_sessions)."`
+	From               *int     `json:"from,omitempty" jsonschema:"Ordinal to start from (e.g. match_ordinal from search_sessions). Ordinal 0 is a valid anchor (the first message)."`
 	Direction          string   `json:"direction,omitempty" jsonschema:"asc (default, oldest first) or desc (newest first)."`
 	Limit              int      `json:"limit,omitempty" jsonschema:"Max messages, default 20, max 100."`
 	Roles              []string `json:"roles,omitempty" jsonschema:"Roles to include, e.g. tool. Default: user and assistant only. System messages are always excluded."`
@@ -284,16 +284,12 @@ type getMessagesOut struct {
 func (t *toolset) getMessages(
 	ctx context.Context, _ *mcp.CallToolRequest, in getMessagesIn,
 ) (*mcp.CallToolResult, getMessagesOut, error) {
-	// Only pin an anchor when the caller supplied one. From is a plain
-	// int, so 0 is indistinguishable from "omitted"; leaving it nil lets
-	// the service default desc to newest-first and asc to oldest-first.
-	var from *int
-	if in.From > 0 {
-		f := in.From
-		from = &f
-	}
+	// From is a *int so an explicit ordinal 0 (a valid match_ordinal)
+	// anchors at the first message rather than being mistaken for
+	// "omitted". A nil From lets the service default: desc to
+	// newest-first, asc to oldest-first.
 	res, err := t.svc.Messages(ctx, in.SessionID, service.MessageFilter{
-		From:      from,
+		From:      in.From,
 		Direction: in.Direction,
 		Limit:     clampLimit(in.Limit, defaultMessageLimit, maxMessageLimit),
 	})

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -261,7 +261,7 @@ type getMessagesIn struct {
 	From               int      `json:"from,omitempty" jsonschema:"Ordinal to start from (e.g. match_ordinal from search_sessions)."`
 	Direction          string   `json:"direction,omitempty" jsonschema:"asc (default, oldest first) or desc (newest first)."`
 	Limit              int      `json:"limit,omitempty" jsonschema:"Max messages, default 20, max 100."`
-	Roles              []string `json:"roles,omitempty" jsonschema:"Roles to include. Default: user and assistant only (no tool or system messages)."`
+	Roles              []string `json:"roles,omitempty" jsonschema:"Roles to include, e.g. tool. Default: user and assistant only. System messages are always excluded."`
 	MaxCharsPerMessage int      `json:"max_chars_per_message,omitempty" jsonschema:"Truncate each message to this many characters, default 2000, max 20000."`
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -51,6 +51,32 @@ func sessionActivity(s db.Session) string {
 	return s.CreatedAt
 }
 
+// isSystemMessage reports whether a message is system content that
+// get_messages and the overview tail must never surface: the persisted
+// is_system flag, or a legacy system prefix on a user message (the prefix
+// rule catches older sessions parsed before is_system was backfilled).
+func isSystemMessage(m db.Message) bool {
+	return m.IsSystem || db.IsSystemPrefixed(m.Content, m.Role)
+}
+
+// lookupActivity returns a session's activity timestamp (ended_at, then
+// started_at, then created_at) via the service, cached per call so each
+// session is fetched at most once. ok is false when the lookup fails, so
+// callers can pick their own fallback.
+func (t *toolset) lookupActivity(
+	ctx context.Context, id string, cache map[string]string,
+) (string, bool) {
+	if a, ok := cache[id]; ok {
+		return a, true
+	}
+	if d, err := t.svc.Get(ctx, id); err == nil && d != nil {
+		a := sessionActivity(d.Session)
+		cache[id] = a
+		return a, true
+	}
+	return "", false
+}
+
 // --- search_sessions ---
 
 type searchSessionsIn struct {
@@ -92,11 +118,23 @@ func (t *toolset) searchSessions(
 		return nil, searchSessionsOut{}, err
 	}
 	now := t.clock()
+	activity := make(map[string]string)
 	out := searchSessionsOut{Results: make([]sessionHit, 0, len(res.Results))}
 	for _, r := range res.Results {
-		if !in.IncludeActive && isActiveSince(r.SessionEndedAt, now) {
-			out.ExcludedActive++
-			continue
+		if !in.IncludeActive {
+			act := r.SessionEndedAt
+			if act == "" {
+				// Search results COALESCE only ended_at/started_at; a current,
+				// timestampless session has an empty SessionEndedAt, so fall
+				// back to created_at via a lookup like search_content does.
+				if a, ok := t.lookupActivity(ctx, r.SessionID, activity); ok {
+					act = a
+				}
+			}
+			if isActiveSince(act, now) {
+				out.ExcludedActive++
+				continue
+			}
 		}
 		name, _ := truncate(r.Name, nameMaxChars)
 		out.Results = append(out.Results, sessionHit{
@@ -252,7 +290,7 @@ func (t *toolset) sessionOverview(
 		return nil, sessionOverviewOut{}, err
 	}
 	for _, m := range msgs.Messages {
-		if m.IsSystem || !roleAllowed(m.Role, nil) {
+		if isSystemMessage(m) || !roleAllowed(m.Role, nil) {
 			continue
 		}
 		content, cut := truncate(m.Content, overviewMaxChars)
@@ -316,7 +354,7 @@ func (t *toolset) getMessages(
 		in.MaxCharsPerMessage, defaultMaxCharsPerMessage, maxMaxCharsPerMessage)
 	out := getMessagesOut{Messages: make([]messageOut, 0, len(res.Messages))}
 	for _, m := range res.Messages {
-		if m.IsSystem || !roleAllowed(m.Role, in.Roles) {
+		if isSystemMessage(m) || !roleAllowed(m.Role, in.Roles) {
 			out.Filtered++
 			continue
 		}
@@ -396,16 +434,11 @@ func (t *toolset) searchContent(
 	out := searchContentOut{Matches: make([]contentMatch, 0, len(res.Matches))}
 	for _, m := range res.Matches {
 		if !in.IncludeActive {
-			ts, ok := activity[m.SessionID]
+			ts, ok := t.lookupActivity(ctx, m.SessionID, activity)
 			if !ok {
-				if d, gerr := t.svc.Get(ctx, m.SessionID); gerr == nil && d != nil {
-					ts = sessionActivity(d.Session)
-					activity[m.SessionID] = ts
-				} else {
-					// Lookup failed: fall back to the match timestamp so the
-					// guard degrades to its prior behavior rather than erroring.
-					ts = m.Timestamp
-				}
+				// Lookup failed: fall back to the match timestamp so the
+				// guard degrades to its prior behavior rather than erroring.
+				ts = m.Timestamp
 			}
 			if isActiveSince(ts, now) {
 				out.ExcludedActive++

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -35,6 +35,16 @@ func strval(p *string) string {
 	return *p
 }
 
+// sessionActivity returns a session's most-recent activity timestamp,
+// preferring ended_at and falling back to started_at -- the same notion
+// search results expose as SessionEndedAt. Empty when neither is set.
+func sessionActivity(s db.Session) string {
+	if ts := strval(s.EndedAt); ts != "" {
+		return ts
+	}
+	return strval(s.StartedAt)
+}
+
 // --- search_sessions ---
 
 type searchSessionsIn struct {
@@ -333,7 +343,7 @@ type searchContentIn struct {
 	DateTo        string `json:"date_to,omitempty" jsonschema:"Only sessions on or before this date (YYYY-MM-DD)."`
 	Limit         int    `json:"limit,omitempty" jsonschema:"Max matches, default 10, max 30."`
 	Cursor        int    `json:"cursor,omitempty" jsonschema:"Pagination cursor from a previous next_cursor."`
-	IncludeActive bool   `json:"include_active,omitempty" jsonschema:"Include matches from the last 10 minutes. Default false: the conversation you are in right now is also recorded, so without this exclusion you would find yourself."`
+	IncludeActive bool   `json:"include_active,omitempty" jsonschema:"Include matches from sessions active in the last 10 minutes. Default false: the conversation you are in right now is also recorded, so without this exclusion you would find yourself."`
 }
 
 type contentMatch struct {
@@ -370,11 +380,31 @@ func (t *toolset) searchContent(
 		return nil, searchContentOut{}, err
 	}
 	now := t.clock()
+	// The self-reference guard excludes matches from sessions active in the
+	// last 10 minutes. A match carries only its own timestamp, but a
+	// long-running session can match on an old message while still being
+	// active now, so exclude by the session's activity (ended_at, falling
+	// back to started_at) like search_sessions does -- not by the match
+	// timestamp. Activity is looked up once per session and cached.
+	activity := make(map[string]string, len(res.Matches))
 	out := searchContentOut{Matches: make([]contentMatch, 0, len(res.Matches))}
 	for _, m := range res.Matches {
-		if !in.IncludeActive && isActiveSince(m.Timestamp, now) {
-			out.ExcludedActive++
-			continue
+		if !in.IncludeActive {
+			ts, ok := activity[m.SessionID]
+			if !ok {
+				if d, gerr := t.svc.Get(ctx, m.SessionID); gerr == nil && d != nil {
+					ts = sessionActivity(d.Session)
+					activity[m.SessionID] = ts
+				} else {
+					// Lookup failed: fall back to the match timestamp so the
+					// guard degrades to its prior behavior rather than erroring.
+					ts = m.Timestamp
+				}
+			}
+			if isActiveSince(ts, now) {
+				out.ExcludedActive++
+				continue
+			}
 		}
 		out.Matches = append(out.Matches, contentMatch{
 			SessionID: m.SessionID, Project: m.Project, Agent: m.Agent,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -36,13 +36,19 @@ func strval(p *string) string {
 }
 
 // sessionActivity returns a session's most-recent activity timestamp,
-// preferring ended_at and falling back to started_at -- the same notion
-// search results expose as SessionEndedAt. Empty when neither is set.
+// mirroring the DB's canonical activity expression: prefer ended_at, then
+// started_at (each only when non-empty), then created_at. created_at is
+// always set, so a freshly created/synced session with no parsed start/end
+// is still treated as active rather than slipping past the self-reference
+// guard.
 func sessionActivity(s db.Session) string {
 	if ts := strval(s.EndedAt); ts != "" {
 		return ts
 	}
-	return strval(s.StartedAt)
+	if ts := strval(s.StartedAt); ts != "" {
+		return ts
+	}
+	return s.CreatedAt
 }
 
 // --- search_sessions ---

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -314,7 +314,7 @@ type getMessagesIn struct {
 	SessionID          string   `json:"session_id" jsonschema:"The session to read."`
 	From               *int     `json:"from,omitempty" jsonschema:"Ordinal to start from (e.g. match_ordinal from search_sessions). Ordinal 0 is a valid anchor (the first message)."`
 	Direction          string   `json:"direction,omitempty" jsonschema:"asc (default, oldest first) or desc (newest first)."`
-	Limit              int      `json:"limit,omitempty" jsonschema:"Max messages, default 20, max 100."`
+	Limit              int      `json:"limit,omitempty" jsonschema:"Max messages scanned, default 20, max 100. System/tool messages are filtered after this limit, so a page can return fewer; use next_from to continue."`
 	Roles              []string `json:"roles,omitempty" jsonschema:"Roles to include, e.g. tool. Default: user and assistant only. System messages are always excluded."`
 	MaxCharsPerMessage int      `json:"max_chars_per_message,omitempty" jsonschema:"Truncate each message to this many characters, default 2000, max 20000."`
 }
@@ -333,6 +333,11 @@ type messageOut struct {
 type getMessagesOut struct {
 	Messages []messageOut `json:"messages"`
 	Filtered int          `json:"filtered,omitempty"`
+	// NextFrom is the from anchor for the next page when more messages may
+	// remain. It is set off the last scanned ordinal (not the last visible
+	// one), so paging stays reliable even though filtering can make a page
+	// return fewer than the limit. An empty follow-up result means the end.
+	NextFrom *int `json:"next_from,omitempty"`
 }
 
 func (t *toolset) getMessages(
@@ -342,10 +347,11 @@ func (t *toolset) getMessages(
 	// anchors at the first message rather than being mistaken for
 	// "omitted". A nil From lets the service default: desc to
 	// newest-first, asc to oldest-first.
+	limit := clampLimit(in.Limit, defaultMessageLimit, maxMessageLimit)
 	res, err := t.svc.Messages(ctx, in.SessionID, service.MessageFilter{
 		From:      in.From,
 		Direction: in.Direction,
-		Limit:     clampLimit(in.Limit, defaultMessageLimit, maxMessageLimit),
+		Limit:     limit,
 	})
 	if err != nil {
 		return nil, getMessagesOut{}, err
@@ -372,6 +378,20 @@ func (t *toolset) getMessages(
 			mo.FullLength = m.ContentLength
 		}
 		out.Messages = append(out.Messages, mo)
+	}
+	// A full raw page means more rows may remain. Anchor next_from just past
+	// the last scanned ordinal in the scan direction (asc moves up, desc
+	// moves down) so the caller can continue; the From anchor is inclusive,
+	// so +/-1 avoids re-returning the boundary message.
+	if limit > 0 && len(res.Messages) == limit {
+		last := res.Messages[len(res.Messages)-1].Ordinal
+		next := last + 1
+		if in.Direction == "desc" {
+			next = last - 1
+		}
+		if next >= 0 {
+			out.NextFrom = &next
+		}
 	}
 	return nil, out, nil
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,424 @@
+// ABOUTME: The six read-only MCP tools, implemented as thin adapters
+// ABOUTME: over service.SessionService (the same seam the CLI and HTTP
+// ABOUTME: handlers use).
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
+)
+
+// toolset holds the dependencies shared by every tool handler. now is
+// injectable so tests can control the self-reference exclusion window.
+type toolset struct {
+	svc service.SessionService
+	now func() time.Time
+}
+
+func (t *toolset) clock() time.Time {
+	if t.now != nil {
+		return t.now()
+	}
+	return time.Now()
+}
+
+func strval(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// --- search_sessions ---
+
+type searchSessionsIn struct {
+	Query         string `json:"query" jsonschema:"Search terms across all agent sessions. Every term must appear (AND), not an exact phrase; wrap the whole query in double quotes for an exact phrase, e.g. \"build failed\". Punctuation in a term (hyphens, colons) is handled safely."`
+	Project       string `json:"project,omitempty" jsonschema:"Restrict to one project (repo/directory name)."`
+	Sort          string `json:"sort,omitempty" jsonschema:"relevance (default) or recency."`
+	Limit         int    `json:"limit,omitempty" jsonschema:"Max results, default 10, max 30."`
+	Cursor        int    `json:"cursor,omitempty" jsonschema:"Pagination cursor from a previous next_cursor."`
+	IncludeActive bool   `json:"include_active,omitempty" jsonschema:"Include sessions active in the last 10 minutes. Default false: the conversation you are in right now is also recorded, so without this exclusion you would find yourself."`
+}
+
+type sessionHit struct {
+	SessionID    string `json:"session_id"`
+	Project      string `json:"project,omitempty"`
+	Agent        string `json:"agent"`
+	Name         string `json:"name"`
+	EndedAt      string `json:"ended_at"`
+	Snippet      string `json:"snippet"`
+	MatchOrdinal int    `json:"match_ordinal"`
+}
+
+type searchSessionsOut struct {
+	Results        []sessionHit `json:"results"`
+	NextCursor     *int         `json:"next_cursor,omitempty"`
+	ExcludedActive int          `json:"excluded_active,omitempty"`
+}
+
+func (t *toolset) searchSessions(
+	ctx context.Context, _ *mcp.CallToolRequest, in searchSessionsIn,
+) (*mcp.CallToolResult, searchSessionsOut, error) {
+	res, err := t.svc.Search(ctx, service.SearchRequest{
+		Query:   buildSearchQuery(in.Query),
+		Project: in.Project,
+		Sort:    in.Sort,
+		Cursor:  in.Cursor,
+		Limit:   clampLimit(in.Limit, defaultSearchLimit, maxSearchLimit),
+	})
+	if err != nil {
+		return nil, searchSessionsOut{}, err
+	}
+	now := t.clock()
+	out := searchSessionsOut{Results: make([]sessionHit, 0, len(res.Results))}
+	for _, r := range res.Results {
+		if !in.IncludeActive && isActiveSince(r.SessionEndedAt, now) {
+			out.ExcludedActive++
+			continue
+		}
+		name, _ := truncate(r.Name, nameMaxChars)
+		out.Results = append(out.Results, sessionHit{
+			SessionID:    r.SessionID,
+			Project:      r.Project,
+			Agent:        r.Agent,
+			Name:         name,
+			EndedAt:      r.SessionEndedAt,
+			Snippet:      r.Snippet,
+			MatchOrdinal: r.Ordinal,
+		})
+	}
+	if res.NextCursor > 0 && len(res.Results) > 0 {
+		nc := res.NextCursor
+		out.NextCursor = &nc
+	}
+	return nil, out, nil
+}
+
+// --- list_sessions ---
+
+type listSessionsIn struct {
+	Project          string `json:"project,omitempty" jsonschema:"Filter by project name."`
+	Agent            string `json:"agent,omitempty" jsonschema:"Filter by agent (e.g. claude, codex, gemini, antigravity)."`
+	Machine          string `json:"machine,omitempty" jsonschema:"Filter by machine name."`
+	DateFrom         string `json:"date_from,omitempty" jsonschema:"Only sessions on or after this date (YYYY-MM-DD)."`
+	DateTo           string `json:"date_to,omitempty" jsonschema:"Only sessions on or before this date (YYYY-MM-DD)."`
+	ActiveSince      string `json:"active_since,omitempty" jsonschema:"Only sessions active since this RFC3339 timestamp."`
+	IncludeAutomated bool   `json:"include_automated,omitempty" jsonschema:"Include automated (non-interactive) sessions."`
+	Limit            int    `json:"limit,omitempty" jsonschema:"Max results, default 20, max 100."`
+	Cursor           string `json:"cursor,omitempty" jsonschema:"Pagination cursor from a previous next_cursor."`
+}
+
+type sessionRow struct {
+	SessionID        string `json:"session_id"`
+	Project          string `json:"project,omitempty"`
+	Machine          string `json:"machine,omitempty"`
+	Agent            string `json:"agent"`
+	Name             string `json:"name"`
+	StartedAt        string `json:"started_at"`
+	EndedAt          string `json:"ended_at"`
+	MessageCount     int    `json:"message_count"`
+	UserMessageCount int    `json:"user_message_count"`
+	OutputTokens     int64  `json:"output_tokens,omitempty"`
+	Outcome          string `json:"outcome,omitempty"`
+	HealthGrade      string `json:"health_grade,omitempty"`
+	GitBranch        string `json:"git_branch,omitempty"`
+}
+
+type listSessionsOut struct {
+	Sessions   []sessionRow `json:"sessions"`
+	Total      int          `json:"total"`
+	NextCursor string       `json:"next_cursor,omitempty"`
+}
+
+func (t *toolset) listSessions(
+	ctx context.Context, _ *mcp.CallToolRequest, in listSessionsIn,
+) (*mcp.CallToolResult, listSessionsOut, error) {
+	res, err := t.svc.List(ctx, service.ListFilter{
+		Project:          in.Project,
+		Agent:            in.Agent,
+		Machine:          in.Machine,
+		DateFrom:         in.DateFrom,
+		DateTo:           in.DateTo,
+		ActiveSince:      in.ActiveSince,
+		IncludeAutomated: in.IncludeAutomated,
+		Cursor:           in.Cursor,
+		Limit:            clampLimit(in.Limit, defaultListLimit, maxListLimit),
+	})
+	if err != nil {
+		return nil, listSessionsOut{}, err
+	}
+	out := listSessionsOut{
+		Sessions:   make([]sessionRow, 0, len(res.Sessions)),
+		Total:      res.Total,
+		NextCursor: res.NextCursor,
+	}
+	for _, s := range res.Sessions {
+		out.Sessions = append(out.Sessions, toSessionRow(s))
+	}
+	return nil, out, nil
+}
+
+func toSessionRow(s db.Session) sessionRow {
+	name := strval(s.DisplayName)
+	if name == "" {
+		name = strval(s.FirstMessage)
+	}
+	name, _ = truncate(name, nameMaxChars)
+	return sessionRow{
+		SessionID:        s.ID,
+		Project:          s.Project,
+		Machine:          s.Machine,
+		Agent:            s.Agent,
+		Name:             name,
+		StartedAt:        strval(s.StartedAt),
+		EndedAt:          strval(s.EndedAt),
+		MessageCount:     s.MessageCount,
+		UserMessageCount: s.UserMessageCount,
+		OutputTokens:     int64(s.TotalOutputTokens),
+		Outcome:          s.Outcome,
+		HealthGrade:      strval(s.HealthGrade),
+		GitBranch:        s.GitBranch,
+	}
+}
+
+// --- get_session_overview ---
+
+type sessionOverviewIn struct {
+	SessionID string `json:"session_id" jsonschema:"The session to summarize."`
+}
+
+type overviewMessage struct {
+	Ordinal   int    `json:"ordinal"`
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+type sessionOverviewOut struct {
+	Session      sessionRow        `json:"session"`
+	CWD          string            `json:"cwd,omitempty"`
+	IsAutomated  bool              `json:"is_automated"`
+	FirstMessage string            `json:"first_message"`
+	LastMessages []overviewMessage `json:"last_messages"`
+}
+
+func (t *toolset) sessionOverview(
+	ctx context.Context, _ *mcp.CallToolRequest, in sessionOverviewIn,
+) (*mcp.CallToolResult, sessionOverviewOut, error) {
+	detail, err := t.svc.Get(ctx, in.SessionID)
+	if err != nil {
+		return nil, sessionOverviewOut{}, err
+	}
+	if detail == nil {
+		return nil, sessionOverviewOut{}, fmt.Errorf(
+			"session not found: %s", in.SessionID)
+	}
+	out := sessionOverviewOut{
+		Session:      toSessionRow(detail.Session),
+		CWD:          detail.Cwd,
+		IsAutomated:  detail.IsAutomated,
+		FirstMessage: strval(detail.FirstMessage),
+	}
+	// Tail of the conversation: how did it end? desc returns
+	// newest-first; collect the newest few then restore chronological
+	// order for display.
+	msgs, err := t.svc.Messages(ctx, in.SessionID, service.MessageFilter{
+		Direction: "desc",
+		Limit:     overviewTailFetch,
+	})
+	if err != nil {
+		return nil, sessionOverviewOut{}, err
+	}
+	for _, m := range msgs.Messages {
+		if m.IsSystem || !roleAllowed(m.Role, nil) {
+			continue
+		}
+		content, cut := truncate(m.Content, overviewMaxChars)
+		out.LastMessages = append(out.LastMessages, overviewMessage{
+			Ordinal: m.Ordinal, Role: m.Role, Content: content, Truncated: cut,
+		})
+		if len(out.LastMessages) == overviewLastMessages {
+			break
+		}
+	}
+	for i, j := 0, len(out.LastMessages)-1; i < j; i, j = i+1, j-1 {
+		out.LastMessages[i], out.LastMessages[j] =
+			out.LastMessages[j], out.LastMessages[i]
+	}
+	return nil, out, nil
+}
+
+// --- get_messages ---
+
+type getMessagesIn struct {
+	SessionID          string   `json:"session_id" jsonschema:"The session to read."`
+	From               int      `json:"from,omitempty" jsonschema:"Ordinal to start from (e.g. match_ordinal from search_sessions)."`
+	Direction          string   `json:"direction,omitempty" jsonschema:"asc (default, oldest first) or desc (newest first)."`
+	Limit              int      `json:"limit,omitempty" jsonschema:"Max messages, default 20, max 100."`
+	Roles              []string `json:"roles,omitempty" jsonschema:"Roles to include. Default: user and assistant only (no tool or system messages)."`
+	MaxCharsPerMessage int      `json:"max_chars_per_message,omitempty" jsonschema:"Truncate each message to this many characters, default 2000, max 20000."`
+}
+
+type messageOut struct {
+	Ordinal    int    `json:"ordinal"`
+	Role       string `json:"role"`
+	Content    string `json:"content"`
+	Timestamp  string `json:"timestamp,omitempty"`
+	Model      string `json:"model,omitempty"`
+	HasToolUse bool   `json:"has_tool_use,omitempty"`
+	FullLength int    `json:"full_length,omitempty"`
+	Truncated  bool   `json:"truncated,omitempty"`
+}
+
+type getMessagesOut struct {
+	Messages []messageOut `json:"messages"`
+	Filtered int          `json:"filtered,omitempty"`
+}
+
+func (t *toolset) getMessages(
+	ctx context.Context, _ *mcp.CallToolRequest, in getMessagesIn,
+) (*mcp.CallToolResult, getMessagesOut, error) {
+	// Only pin an anchor when the caller supplied one. From is a plain
+	// int, so 0 is indistinguishable from "omitted"; leaving it nil lets
+	// the service default desc to newest-first and asc to oldest-first.
+	var from *int
+	if in.From > 0 {
+		f := in.From
+		from = &f
+	}
+	res, err := t.svc.Messages(ctx, in.SessionID, service.MessageFilter{
+		From:      from,
+		Direction: in.Direction,
+		Limit:     clampLimit(in.Limit, defaultMessageLimit, maxMessageLimit),
+	})
+	if err != nil {
+		return nil, getMessagesOut{}, err
+	}
+	maxChars := clampLimit(
+		in.MaxCharsPerMessage, defaultMaxCharsPerMessage, maxMaxCharsPerMessage)
+	out := getMessagesOut{Messages: make([]messageOut, 0, len(res.Messages))}
+	for _, m := range res.Messages {
+		if m.IsSystem || !roleAllowed(m.Role, in.Roles) {
+			out.Filtered++
+			continue
+		}
+		content, cut := truncate(m.Content, maxChars)
+		mo := messageOut{
+			Ordinal:    m.Ordinal,
+			Role:       m.Role,
+			Content:    content,
+			Timestamp:  m.Timestamp,
+			Model:      m.Model,
+			HasToolUse: m.HasToolUse,
+			Truncated:  cut,
+		}
+		if cut {
+			mo.FullLength = m.ContentLength
+		}
+		out.Messages = append(out.Messages, mo)
+	}
+	return nil, out, nil
+}
+
+// --- search_content ---
+
+type searchContentIn struct {
+	Pattern       string `json:"pattern" jsonschema:"Exact substring or regex to find across message text and tool inputs/results."`
+	Mode          string `json:"mode,omitempty" jsonschema:"substring (default) or regex."`
+	Project       string `json:"project,omitempty" jsonschema:"Restrict to one project."`
+	Agent         string `json:"agent,omitempty" jsonschema:"Restrict to one agent."`
+	DateFrom      string `json:"date_from,omitempty" jsonschema:"Only sessions on or after this date (YYYY-MM-DD)."`
+	DateTo        string `json:"date_to,omitempty" jsonschema:"Only sessions on or before this date (YYYY-MM-DD)."`
+	Limit         int    `json:"limit,omitempty" jsonschema:"Max matches, default 10, max 30."`
+	Cursor        int    `json:"cursor,omitempty" jsonschema:"Pagination cursor from a previous next_cursor."`
+	IncludeActive bool   `json:"include_active,omitempty" jsonschema:"Include matches from the last 10 minutes. Default false: the conversation you are in right now is also recorded, so without this exclusion you would find yourself."`
+}
+
+type contentMatch struct {
+	SessionID string `json:"session_id"`
+	Project   string `json:"project,omitempty"`
+	Agent     string `json:"agent"`
+	Location  string `json:"location" jsonschema:"Where the match occurred: one of message, tool_input, or tool_result."`
+	Role      string `json:"role,omitempty"`
+	Ordinal   int    `json:"ordinal"`
+	Timestamp string `json:"timestamp"`
+	Snippet   string `json:"snippet"`
+}
+
+type searchContentOut struct {
+	Matches        []contentMatch `json:"matches"`
+	NextCursor     *int           `json:"next_cursor,omitempty"`
+	ExcludedActive int            `json:"excluded_active,omitempty"`
+}
+
+func (t *toolset) searchContent(
+	ctx context.Context, _ *mcp.CallToolRequest, in searchContentIn,
+) (*mcp.CallToolResult, searchContentOut, error) {
+	res, err := t.svc.SearchContent(ctx, service.ContentSearchRequest{
+		Pattern:  in.Pattern,
+		Mode:     in.Mode,
+		Project:  in.Project,
+		Agent:    in.Agent,
+		DateFrom: in.DateFrom,
+		DateTo:   in.DateTo,
+		Limit:    clampLimit(in.Limit, defaultSearchLimit, maxSearchLimit),
+		Cursor:   in.Cursor,
+	})
+	if err != nil {
+		return nil, searchContentOut{}, err
+	}
+	now := t.clock()
+	out := searchContentOut{Matches: make([]contentMatch, 0, len(res.Matches))}
+	for _, m := range res.Matches {
+		if !in.IncludeActive && isActiveSince(m.Timestamp, now) {
+			out.ExcludedActive++
+			continue
+		}
+		out.Matches = append(out.Matches, contentMatch{
+			SessionID: m.SessionID, Project: m.Project, Agent: m.Agent,
+			Location: m.Location, Role: m.Role, Ordinal: m.Ordinal,
+			Timestamp: m.Timestamp, Snippet: m.Snippet,
+		})
+	}
+	if res.NextCursor > 0 && len(res.Matches) > 0 {
+		nc := res.NextCursor
+		out.NextCursor = &nc
+	}
+	return nil, out, nil
+}
+
+// --- get_usage_summary ---
+
+type usageSummaryIn struct {
+	From    string `json:"from,omitempty" jsonschema:"Range start date (YYYY-MM-DD)."`
+	To      string `json:"to,omitempty" jsonschema:"Range end date (YYYY-MM-DD)."`
+	Project string `json:"project,omitempty" jsonschema:"Filter by project."`
+	Agent   string `json:"agent,omitempty" jsonschema:"Filter by agent."`
+	Machine string `json:"machine,omitempty" jsonschema:"Filter by machine."`
+}
+
+func (t *toolset) usageSummary(
+	ctx context.Context, _ *mcp.CallToolRequest, in usageSummaryIn,
+) (*mcp.CallToolResult, *service.UsageSummaryResult, error) {
+	res, err := t.svc.UsageSummary(ctx, service.UsageRequest{
+		From:    in.From,
+		To:      in.To,
+		Project: in.Project,
+		Agent:   in.Agent,
+		Machine: in.Machine,
+		// The usage summary surface counts one-shot sessions by default
+		// (matching the REST endpoint), since cost analysis wants every
+		// session, not just multi-turn ones.
+		IncludeOneShot: true,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -377,7 +377,7 @@ func TestGetMessages_DescAndFromAnchor(t *testing.T) {
 	// asc anchored at ordinal 2 -> starts at 2, ascending.
 	from := 2
 	_, asc, err := ts.getMessages(context.Background(), nil, getMessagesIn{
-		SessionID: "s1", Direction: "asc", From: from,
+		SessionID: "s1", Direction: "asc", From: &from,
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, asc.Messages)
@@ -385,6 +385,32 @@ func TestGetMessages_DescAndFromAnchor(t *testing.T) {
 	for i := 1; i < len(asc.Messages); i++ {
 		assert.Less(t, asc.Messages[i-1].Ordinal, asc.Messages[i].Ordinal)
 	}
+}
+
+// Ordinal 0 is a valid anchor (search_sessions can return match_ordinal 0),
+// so from:0 must be honored, not treated as "omitted". With desc it anchors
+// at ordinal 0 -- returning only that message -- rather than falling back to
+// newest-first.
+func TestGetMessages_FromZeroAnchors(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 2
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, "m0"),
+		dbtest.AsstMsg("s1", 1, "m1"),
+		dbtest.UserMsg("s1", 2, "m2"),
+	}))
+
+	zero := 0
+	_, out, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1", Direction: "desc", From: &zero,
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1)
+	assert.Equal(t, 0, out.Messages[0].Ordinal,
+		"from:0 anchors at ordinal 0, not newest-first")
 }
 
 // TestServer_EndToEnd connects a real MCP client to the server over an

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -593,6 +593,40 @@ func TestGetMessages_NextFromCursor(t *testing.T) {
 	assert.Equal(t, 2, *dpage.NextFrom)
 }
 
+// next_from must advance past the last SCANNED ordinal, not the last visible
+// one, so a filtered message at the page boundary is not re-scanned on the
+// next page. The raw page fills the limit but a system message is filtered,
+// making the visible page shorter than the limit.
+func TestGetMessages_NextFromUsesScannedNotVisible(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 2
+		ended := "2024-06-15T10:00:00Z"
+		s.EndedAt = &ended
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, "v0"),
+		{
+			SessionID: "s1", Ordinal: 1, Role: "system",
+			Content: "sys", IsSystem: true, ContentLength: 3,
+		},
+		dbtest.UserMsg("s1", 2, "v2"),
+	}))
+
+	// asc, limit 2: raw page = ordinals 0,1; ordinal 1 (system) is filtered.
+	_, out, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1", Direction: "asc", Limit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1, "filtered system message shortens the page")
+	assert.Equal(t, 0, out.Messages[0].Ordinal)
+	assert.Equal(t, 1, out.Filtered)
+	require.NotNil(t, out.NextFrom)
+	assert.Equal(t, 2, *out.NextFrom,
+		"next_from advances past scanned ordinal 1, not visible ordinal 0")
+}
+
 // search_sessions must exclude a session active now even when its search
 // result carries no ended_at/started_at (empty SessionEndedAt), by falling
 // back to created_at like search_content -- mirroring the canonical

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1,0 +1,263 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/service"
+)
+
+// fixedNow is the deterministic clock used in tests so the 10-minute
+// self-reference exclusion window is reproducible.
+var fixedNow = time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+
+func newTestToolset(t *testing.T) (*toolset, *db.DB) {
+	t.Helper()
+	d := dbtest.OpenTestDB(t)
+	return &toolset{
+		svc: service.NewDirectBackend(d, nil),
+		now: func() time.Time { return fixedNow },
+	}, d
+}
+
+func seedFTSSession(t *testing.T, d *db.DB, id, project, content, endedAt string) {
+	t.Helper()
+	dbtest.SeedSession(t, d, id, project, func(s *db.Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		ended := endedAt
+		s.EndedAt = &ended
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg(id, 0, content),
+	}))
+}
+
+func TestSearchSessions_ReturnsHitsWithOrdinal(t *testing.T) {
+	ts, d := newTestToolset(t)
+	if !d.HasFTS() {
+		t.Skip("FTS not available")
+	}
+	seedFTSSession(t, d, "s1", "proj-a",
+		"the quick brown fox", "2024-06-15T10:00:00Z")
+	seedFTSSession(t, d, "s2", "proj-b",
+		"lazy dogs", "2024-06-15T10:00:00Z")
+
+	_, out, err := ts.searchSessions(context.Background(), nil, searchSessionsIn{
+		Query: "fox",
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Results, 1)
+	assert.Equal(t, "s1", out.Results[0].SessionID)
+	assert.Equal(t, "proj-a", out.Results[0].Project)
+	assert.Zero(t, out.ExcludedActive)
+}
+
+func TestSearchSessions_ExcludesRecentlyActive(t *testing.T) {
+	ts, d := newTestToolset(t)
+	if !d.HasFTS() {
+		t.Skip("FTS not available")
+	}
+	// s1 ended an hour before fixedNow -> kept; s2 ended 5 min before -> excluded.
+	seedFTSSession(t, d, "s1", "proj", "shared term alpha", "2024-06-15T11:00:00Z")
+	seedFTSSession(t, d, "s2", "proj", "shared term alpha", "2024-06-15T11:55:00Z")
+
+	out := mustSearch(t, ts, searchSessionsIn{Query: "alpha"})
+	require.Len(t, out.Results, 1)
+	assert.Equal(t, "s1", out.Results[0].SessionID)
+	assert.Equal(t, 1, out.ExcludedActive)
+
+	// With include_active, the recent one is returned too.
+	withActive := mustSearch(t, ts, searchSessionsIn{Query: "alpha", IncludeActive: true})
+	assert.Len(t, withActive.Results, 2)
+	assert.Zero(t, withActive.ExcludedActive)
+}
+
+func mustSearch(t *testing.T, ts *toolset, in searchSessionsIn) searchSessionsOut {
+	t.Helper()
+	_, out, err := ts.searchSessions(context.Background(), nil, in)
+	require.NoError(t, err)
+	return out
+}
+
+func TestListSessions_ReturnsRows(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "a-1", "proj-a", func(s *db.Session) {
+		s.MessageCount = 4
+		s.UserMessageCount = 2
+	})
+	dbtest.SeedSession(t, d, "b-1", "proj-b", func(s *db.Session) {
+		s.MessageCount = 4
+		s.UserMessageCount = 2
+	})
+
+	_, out, err := ts.listSessions(context.Background(), nil, listSessionsIn{
+		Project: "proj-a",
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Sessions, 1)
+	assert.Equal(t, "a-1", out.Sessions[0].SessionID)
+	assert.Equal(t, "proj-a", out.Sessions[0].Project)
+}
+
+func TestGetSessionOverview_ChronologicalTail(t *testing.T) {
+	ts, d := newTestToolset(t)
+	cwd := "/home/u/proj"
+	first := "open the door"
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 4
+		s.UserMessageCount = 2
+		s.Cwd = cwd
+		s.FirstMessage = &first
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, "open the door"),
+		dbtest.AsstMsg("s1", 1, "opening"),
+		dbtest.UserMsg("s1", 2, "now close it"),
+		dbtest.AsstMsg("s1", 3, "closed"),
+	}))
+
+	_, out, err := ts.sessionOverview(context.Background(), nil, sessionOverviewIn{
+		SessionID: "s1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "s1", out.Session.SessionID)
+	assert.Equal(t, cwd, out.CWD)
+	assert.Equal(t, "open the door", out.FirstMessage)
+	require.NotEmpty(t, out.LastMessages)
+	// Tail is restored to chronological (ascending) ordinal order.
+	for i := 1; i < len(out.LastMessages); i++ {
+		assert.Less(t, out.LastMessages[i-1].Ordinal, out.LastMessages[i].Ordinal)
+	}
+	// The very last message is surfaced.
+	assert.Equal(t, "closed", out.LastMessages[len(out.LastMessages)-1].Content)
+}
+
+func TestGetSessionOverview_NotFound(t *testing.T) {
+	ts, _ := newTestToolset(t)
+	_, _, err := ts.sessionOverview(context.Background(), nil, sessionOverviewIn{
+		SessionID: "nope",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetMessages_RoleFilterAndTruncation(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	long := make([]byte, 50)
+	for i := range long {
+		long[i] = 'x'
+	}
+	sysMsg := db.Message{
+		SessionID: "s1", Ordinal: 1, Role: "system",
+		Content: "system noise", IsSystem: true, ContentLength: len("system noise"),
+	}
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, string(long)),
+		sysMsg,
+		dbtest.AsstMsg("s1", 2, "short reply"),
+	}))
+
+	_, out, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID:          "s1",
+		MaxCharsPerMessage: 10,
+	})
+	require.NoError(t, err)
+	// system message filtered out; user+assistant kept.
+	require.Len(t, out.Messages, 2)
+	assert.Equal(t, 1, out.Filtered, "the system message is filtered")
+	// The 50-char user message is truncated to 10 with FullLength set.
+	first := out.Messages[0]
+	assert.True(t, first.Truncated)
+	assert.Equal(t, 50, first.FullLength)
+	assert.Len(t, first.Content, 10)
+}
+
+func TestSearchContent_SubstringMatch(t *testing.T) {
+	ts, d := newTestToolset(t)
+	// Not a one-shot: content search excludes one-shot sessions by default.
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 2
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, "error code DEADBEEF here"),
+		dbtest.AsstMsg("s1", 1, "looking into it"),
+	}))
+
+	_, out, err := ts.searchContent(context.Background(), nil, searchContentIn{
+		Pattern: "DEADBEEF",
+		Mode:    "substring",
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Matches, 1)
+	assert.Equal(t, "s1", out.Matches[0].SessionID)
+}
+
+func TestUsageSummary_EmptyRange(t *testing.T) {
+	ts, _ := newTestToolset(t)
+	_, out, err := ts.usageSummary(context.Background(), nil, usageSummaryIn{
+		From: "2024-06-01", To: "2024-06-03",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "2024-06-01", out.From)
+	assert.Equal(t, "2024-06-03", out.To)
+}
+
+// TestServer_EndToEnd connects a real MCP client to the server over an
+// in-memory transport and calls a tool, validating registration, schema
+// inference, and the structured-output round-trip through the SDK.
+func TestServer_EndToEnd(t *testing.T) {
+	d := dbtest.OpenTestDB(t)
+	if !d.HasFTS() {
+		t.Skip("FTS not available")
+	}
+	seedFTSSession(t, d, "s1", "proj", "unique end-to-end marker", "2024-01-01T10:00:00Z")
+
+	srv := newServer(ServeOptions{
+		Service: service.NewDirectBackend(d, nil),
+		Now:     func() time.Time { return fixedNow },
+	})
+
+	ctx := context.Background()
+	st, ct := newInMemoryPair(t, srv)
+
+	tools, err := ct.ListTools(ctx, nil)
+	require.NoError(t, err)
+	names := make([]string, 0, len(tools.Tools))
+	for _, tl := range tools.Tools {
+		names = append(names, tl.Name)
+	}
+	assert.ElementsMatch(t, []string{
+		ToolSearchSessions, ToolListSessions, ToolGetSessionOverview,
+		ToolGetMessages, ToolSearchContent, ToolGetUsageSummary,
+	}, names)
+
+	res, err := ct.CallTool(ctx, callParams("search_sessions", map[string]any{
+		"query": "marker",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "tool returned error")
+
+	var out searchSessionsOut
+	raw, err := json.Marshal(res.StructuredContent)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &out))
+	require.Len(t, out.Results, 1)
+	assert.Equal(t, "s1", out.Results[0].SessionID)
+
+	require.NoError(t, ct.Close())
+	require.NoError(t, st.Wait())
+}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -533,6 +533,66 @@ func TestGetMessages_ExcludesSystemPrefixedUserMessage(t *testing.T) {
 	assert.Equal(t, 1, out.Filtered, "the system-prefixed user message is filtered")
 }
 
+// get_messages returns next_from when a full page may have more rows, so a
+// client can page reliably even when filtering shortens a page. next_from
+// is anchored on the last scanned ordinal, and the final partial page omits
+// it.
+func TestGetMessages_NextFromCursor(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 5
+		s.UserMessageCount = 3
+		ended := "2024-06-15T10:00:00Z"
+		s.EndedAt = &ended
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, "m0"),
+		dbtest.AsstMsg("s1", 1, "m1"),
+		dbtest.UserMsg("s1", 2, "m2"),
+		dbtest.AsstMsg("s1", 3, "m3"),
+		dbtest.UserMsg("s1", 4, "m4"),
+	}))
+
+	// asc page 1: ordinals 0,1 -> next_from 2.
+	_, p1, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1", Direction: "asc", Limit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, p1.Messages, 2)
+	assert.Equal(t, 0, p1.Messages[0].Ordinal)
+	require.NotNil(t, p1.NextFrom)
+	assert.Equal(t, 2, *p1.NextFrom)
+
+	// asc page 2 from the cursor: ordinals 2,3 -> next_from 4.
+	_, p2, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1", Direction: "asc", Limit: 2, From: p1.NextFrom,
+	})
+	require.NoError(t, err)
+	require.Len(t, p2.Messages, 2)
+	assert.Equal(t, 2, p2.Messages[0].Ordinal)
+	require.NotNil(t, p2.NextFrom)
+	assert.Equal(t, 4, *p2.NextFrom)
+
+	// asc final page: ordinal 4 only; partial page has no next cursor.
+	_, p3, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1", Direction: "asc", Limit: 2, From: p2.NextFrom,
+	})
+	require.NoError(t, err)
+	require.Len(t, p3.Messages, 1)
+	assert.Equal(t, 4, p3.Messages[0].Ordinal)
+	assert.Nil(t, p3.NextFrom, "final partial page omits next_from")
+
+	// desc page 1 from newest: ordinals 4,3 -> next_from 2 (anchor moves down).
+	_, dpage, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1", Direction: "desc", Limit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, dpage.Messages, 2)
+	assert.Equal(t, 4, dpage.Messages[0].Ordinal)
+	require.NotNil(t, dpage.NextFrom)
+	assert.Equal(t, 2, *dpage.NextFrom)
+}
+
 // search_sessions must exclude a session active now even when its search
 // result carries no ended_at/started_at (empty SessionEndedAt), by falling
 // back to created_at like search_content -- mirroring the canonical

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -504,6 +504,68 @@ func TestGetMessages_FromZeroAnchors(t *testing.T) {
 		"from:0 anchors at ordinal 0, not newest-first")
 }
 
+// get_messages promises system messages are always excluded. Legacy
+// sessions store system-injected messages as user-role rows without the
+// is_system flag, identified only by a content prefix; those must be
+// excluded too, not just is_system rows.
+func TestGetMessages_ExcludesSystemPrefixedUserMessage(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, "real question"),
+		// User role, is_system not set, but a system content prefix.
+		{
+			SessionID: "s1", Ordinal: 1, Role: "user",
+			Content:       "<task-notification>done</task-notification>",
+			ContentLength: 44,
+		},
+	}))
+
+	_, out, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1",
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1)
+	assert.Equal(t, "real question", out.Messages[0].Content)
+	assert.Equal(t, 1, out.Filtered, "the system-prefixed user message is filtered")
+}
+
+// search_sessions must exclude a session active now even when its search
+// result carries no ended_at/started_at (empty SessionEndedAt), by falling
+// back to created_at like search_content -- mirroring the canonical
+// activity expression.
+func TestSearchSessions_TimestamplessExcludedByCreatedAt(t *testing.T) {
+	d := dbtest.OpenTestDB(t)
+	if !d.HasFTS() {
+		t.Skip("FTS not available")
+	}
+	ts := &toolset{svc: service.NewDirectBackend(d, nil), now: time.Now}
+	// No ended_at/started_at; created_at defaults to now, so it is active.
+	dbtest.SeedSession(t, d, "fresh", "proj", func(s *db.Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("fresh", 0, "uniquesearchmarker here"),
+	}))
+
+	_, out, err := ts.searchSessions(context.Background(), nil, searchSessionsIn{
+		Query: "uniquesearchmarker",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, out.Results)
+	assert.Equal(t, 1, out.ExcludedActive)
+
+	_, all, err := ts.searchSessions(context.Background(), nil, searchSessionsIn{
+		Query: "uniquesearchmarker", IncludeActive: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, all.Results, 1)
+}
+
 // TestServer_EndToEnd connects a real MCP client to the server over an
 // in-memory transport and calls a tool, validating registration, schema
 // inference, and the structured-output round-trip through the SDK.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -97,7 +97,7 @@ func TestSearchSessions_Pagination(t *testing.T) {
 	}
 	// Six sessions all matching "pageterm", with increasing ended_at so
 	// recency ordering is deterministic. All old enough to not be excluded.
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		id := "p" + string(rune('0'+i))
 		ended := "2024-06-1" + string(rune('0'+i)) + "T10:00:00Z"
 		seedFTSSession(t, d, id, "proj", "pageterm body", ended)

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -216,6 +216,104 @@ func TestUsageSummary_EmptyRange(t *testing.T) {
 	assert.Equal(t, "2024-06-03", out.To)
 }
 
+// recordingService captures the request a tool builds, so MCP-layer
+// request mapping can be asserted without a full backend. Unused methods
+// fall through to the embedded nil interface (never called by the tools
+// under test).
+type recordingService struct {
+	service.SessionService
+	lastUsage service.UsageRequest
+}
+
+func (r *recordingService) UsageSummary(
+	_ context.Context, req service.UsageRequest,
+) (*service.UsageSummaryResult, error) {
+	r.lastUsage = req
+	return &service.UsageSummaryResult{From: req.From, To: req.To}, nil
+}
+
+// get_usage_summary must request one-shot sessions (matching the REST
+// /usage/summary default), since cost analysis wants every session.
+func TestUsageSummary_RequestsOneShotSessions(t *testing.T) {
+	t.Parallel()
+	rec := &recordingService{}
+	ts := &toolset{svc: rec, now: func() time.Time { return fixedNow }}
+	_, _, err := ts.usageSummary(context.Background(), nil, usageSummaryIn{
+		From: "2024-06-01", To: "2024-06-02", Project: "p", Agent: "claude",
+	})
+	require.NoError(t, err)
+	assert.True(t, rec.lastUsage.IncludeOneShot,
+		"usage summary should include one-shot sessions")
+	assert.Equal(t, "p", rec.lastUsage.Project)
+	assert.Equal(t, "claude", rec.lastUsage.Agent)
+}
+
+// search_content excludes one-shot sessions by default, matching the
+// standalone/REST behavior. (Tracked as a possible follow-up: expose an
+// include_one_shot opt-in so single-exchange sessions can be searched.)
+func TestSearchContent_ExcludesOneShotByDefault(t *testing.T) {
+	ts, d := newTestToolset(t)
+	// One-shot (UserMessageCount=1) with the marker.
+	dbtest.SeedSession(t, d, "one", "proj", func(s *db.Session) {
+		s.MessageCount = 1
+		s.UserMessageCount = 1
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("one", 0, "marker ZEBRA42"),
+	}))
+	// Multi-turn with the same marker.
+	dbtest.SeedSession(t, d, "multi", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 2
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("multi", 0, "marker ZEBRA42"),
+		dbtest.AsstMsg("multi", 1, "ok"),
+	}))
+
+	_, out, err := ts.searchContent(context.Background(), nil, searchContentIn{
+		Pattern: "ZEBRA42", Mode: "substring",
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Matches, 1, "one-shot session should be excluded")
+	assert.Equal(t, "multi", out.Matches[0].SessionID)
+}
+
+func TestGetMessages_DescAndFromAnchor(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 5
+		s.UserMessageCount = 3
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, "m0"),
+		dbtest.AsstMsg("s1", 1, "m1"),
+		dbtest.UserMsg("s1", 2, "m2"),
+		dbtest.AsstMsg("s1", 3, "m3"),
+		dbtest.UserMsg("s1", 4, "m4"),
+	}))
+
+	// desc with no anchor -> newest first.
+	_, desc, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1", Direction: "desc",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, desc.Messages)
+	assert.Equal(t, 4, desc.Messages[0].Ordinal, "desc returns newest first")
+
+	// asc anchored at ordinal 2 -> starts at 2, ascending.
+	from := 2
+	_, asc, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1", Direction: "asc", From: from,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, asc.Messages)
+	assert.Equal(t, 2, asc.Messages[0].Ordinal, "asc honors the from anchor")
+	for i := 1; i < len(asc.Messages); i++ {
+		assert.Less(t, asc.Messages[i-1].Ordinal, asc.Messages[i].Ordinal)
+	}
+}
+
 // TestServer_EndToEnd connects a real MCP client to the server over an
 // in-memory transport and calls a tool, validating registration, schema
 // inference, and the structured-output round-trip through the SDK.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -278,6 +278,58 @@ func TestSearchContent_SubstringMatch(t *testing.T) {
 	assert.Equal(t, "s1", out.Matches[0].SessionID)
 }
 
+// search_content's self-reference guard must exclude matches from sessions
+// that are active now, even when the matching message itself is old. A
+// long-running current session can match on a stale line; excluding by the
+// match timestamp alone would leak it. Exclusion is by session activity,
+// like search_sessions.
+func TestSearchContent_ExcludesActiveSessionWithOldMatch(t *testing.T) {
+	ts, d := newTestToolset(t)
+	// Active session: ended one minute before now, but its matching message
+	// is two hours old.
+	dbtest.SeedSession(t, d, "active", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 2
+		ended := "2024-06-15T11:59:00Z"
+		s.EndedAt = &ended
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{{
+		SessionID: "active", Ordinal: 0, Role: "user",
+		Content: "old needle here", ContentLength: len("old needle here"),
+		Timestamp: "2024-06-15T10:00:00Z",
+	}}))
+	// Idle session: ended two hours before now.
+	dbtest.SeedSession(t, d, "idle", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 2
+		ended := "2024-06-15T10:00:00Z"
+		s.EndedAt = &ended
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{{
+		SessionID: "idle", Ordinal: 0, Role: "user",
+		Content: "idle needle here", ContentLength: len("idle needle here"),
+		Timestamp: "2024-06-15T10:00:00Z",
+	}}))
+
+	// Default (include_active=false): the active session is excluded despite
+	// its old match; only the idle session is returned.
+	_, out, err := ts.searchContent(context.Background(), nil, searchContentIn{
+		Pattern: "needle", Mode: "substring",
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Matches, 1)
+	assert.Equal(t, "idle", out.Matches[0].SessionID)
+	assert.Equal(t, 1, out.ExcludedActive)
+
+	// include_active=true returns both, excluding nothing.
+	_, all, err := ts.searchContent(context.Background(), nil, searchContentIn{
+		Pattern: "needle", Mode: "substring", IncludeActive: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, all.Matches, 2)
+	assert.Equal(t, 0, all.ExcludedActive)
+}
+
 func TestUsageSummary_EmptyRange(t *testing.T) {
 	ts, _ := newTestToolset(t)
 	_, out, err := ts.usageSummary(context.Background(), nil, usageSummaryIn{

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -219,6 +219,44 @@ func TestGetMessages_RoleFilterAndTruncation(t *testing.T) {
 	assert.Len(t, first.Content, 10)
 }
 
+// Even when a caller explicitly allow-lists the "system" role, get_messages
+// must still drop IsSystem-flagged messages: the schema promises system
+// messages are always excluded. The IsSystem gate short-circuits ahead of the
+// role allowlist, so an allow-listed assistant message comes through while the
+// equally allow-listed system message stays filtered. This pins the
+// security-relevant ordering against a future change that let an explicit
+// roles request surface system content.
+func TestGetMessages_ExplicitSystemRoleStillFiltered(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("s1", 0, "hello"),
+		{
+			SessionID: "s1", Ordinal: 1, Role: "system",
+			Content: "system noise", IsSystem: true, ContentLength: len("system noise"),
+		},
+		dbtest.AsstMsg("s1", 2, "short reply"),
+	}))
+
+	_, out, err := ts.getMessages(context.Background(), nil, getMessagesIn{
+		SessionID: "s1",
+		Roles:     []string{"system", "assistant"},
+	})
+	require.NoError(t, err)
+	// The allow-listed assistant message is returned; the system message is
+	// not, even though "system" was also allow-listed. The user message is
+	// filtered because its role is not in the allowlist.
+	require.Len(t, out.Messages, 1)
+	assert.Equal(t, "assistant", out.Messages[0].Role)
+	for _, m := range out.Messages {
+		assert.NotEqual(t, "system", m.Role, "system messages must never be returned")
+	}
+	assert.Equal(t, 2, out.Filtered)
+}
+
 func TestSearchContent_SubstringMatch(t *testing.T) {
 	ts, d := newTestToolset(t)
 	// Not a one-shot: content search excludes one-shot sessions by default.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -260,9 +260,12 @@ func TestGetMessages_ExplicitSystemRoleStillFiltered(t *testing.T) {
 func TestSearchContent_SubstringMatch(t *testing.T) {
 	ts, d := newTestToolset(t)
 	// Not a one-shot: content search excludes one-shot sessions by default.
+	// An explicit old ended_at keeps it out of the active-session guard.
 	dbtest.SeedSession(t, d, "s1", "proj", func(s *db.Session) {
 		s.MessageCount = 3
 		s.UserMessageCount = 2
+		ended := "2024-06-15T10:00:00Z"
+		s.EndedAt = &ended
 	})
 	require.NoError(t, d.InsertMessages([]db.Message{
 		dbtest.UserMsg("s1", 0, "error code DEADBEEF here"),
@@ -330,6 +333,40 @@ func TestSearchContent_ExcludesActiveSessionWithOldMatch(t *testing.T) {
 	assert.Equal(t, 0, all.ExcludedActive)
 }
 
+// A freshly created/synced session can have no parsed ended_at or started_at
+// yet, only created_at. Its activity must fall back to created_at so a
+// current timestampless session is still excluded by the default guard,
+// rather than resolving to an empty timestamp and leaking through. Uses a
+// real clock because created_at is set to now by the DB at insert.
+func TestSearchContent_TimestamplessSessionExcludedByCreatedAt(t *testing.T) {
+	d := dbtest.OpenTestDB(t)
+	ts := &toolset{svc: service.NewDirectBackend(d, nil), now: time.Now}
+	// StartedAt and EndedAt are left nil on purpose; created_at defaults to
+	// now in the schema, so the session is active.
+	dbtest.SeedSession(t, d, "fresh", "proj", func(s *db.Session) {
+		s.MessageCount = 3
+		s.UserMessageCount = 2
+	})
+	require.NoError(t, d.InsertMessages([]db.Message{
+		dbtest.UserMsg("fresh", 0, "needle in a fresh session"),
+	}))
+
+	// Default guard excludes the still-active session despite no start/end.
+	_, out, err := ts.searchContent(context.Background(), nil, searchContentIn{
+		Pattern: "needle", Mode: "substring",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, out.Matches)
+	assert.Equal(t, 1, out.ExcludedActive)
+
+	// include_active=true surfaces it.
+	_, all, err := ts.searchContent(context.Background(), nil, searchContentIn{
+		Pattern: "needle", Mode: "substring", IncludeActive: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, all.Matches, 1)
+}
+
 func TestUsageSummary_EmptyRange(t *testing.T) {
 	ts, _ := newTestToolset(t)
 	_, out, err := ts.usageSummary(context.Background(), nil, usageSummaryIn{
@@ -386,10 +423,12 @@ func TestSearchContent_ExcludesOneShotByDefault(t *testing.T) {
 	require.NoError(t, d.InsertMessages([]db.Message{
 		dbtest.UserMsg("one", 0, "marker ZEBRA42"),
 	}))
-	// Multi-turn with the same marker.
+	// Multi-turn with the same marker; old ended_at keeps it inactive.
 	dbtest.SeedSession(t, d, "multi", "proj", func(s *db.Session) {
 		s.MessageCount = 3
 		s.UserMessageCount = 2
+		ended := "2024-06-15T10:00:00Z"
+		s.EndedAt = &ended
 	})
 	require.NoError(t, d.InsertMessages([]db.Message{
 		dbtest.UserMsg("multi", 0, "marker ZEBRA42"),

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -87,6 +87,41 @@ func mustSearch(t *testing.T, ts *toolset, in searchSessionsIn) searchSessionsOu
 	return out
 }
 
+// TestSearchSessions_Pagination walks the int cursor end to end: a first
+// page sets next_cursor, and feeding it back returns the following,
+// non-overlapping page.
+func TestSearchSessions_Pagination(t *testing.T) {
+	ts, d := newTestToolset(t)
+	if !d.HasFTS() {
+		t.Skip("FTS not available")
+	}
+	// Six sessions all matching "pageterm", with increasing ended_at so
+	// recency ordering is deterministic. All old enough to not be excluded.
+	for i := 0; i < 6; i++ {
+		id := "p" + string(rune('0'+i))
+		ended := "2024-06-1" + string(rune('0'+i)) + "T10:00:00Z"
+		seedFTSSession(t, d, id, "proj", "pageterm body", ended)
+	}
+
+	page1 := mustSearch(t, ts, searchSessionsIn{Query: "pageterm", Sort: "recency", Limit: 2})
+	require.Len(t, page1.Results, 2)
+	require.NotNil(t, page1.NextCursor, "first page should set next_cursor")
+
+	page2 := mustSearch(t, ts, searchSessionsIn{
+		Query: "pageterm", Sort: "recency", Limit: 2, Cursor: *page1.NextCursor,
+	})
+	require.Len(t, page2.Results, 2)
+
+	seen := map[string]bool{}
+	for _, r := range page1.Results {
+		seen[r.SessionID] = true
+	}
+	for _, r := range page2.Results {
+		assert.False(t, seen[r.SessionID],
+			"page 2 must not repeat page 1 (overlap on %s)", r.SessionID)
+	}
+}
+
 func TestListSessions_ReturnsRows(t *testing.T) {
 	ts, d := newTestToolset(t)
 	dbtest.SeedSession(t, d, "a-1", "proj-a", func(s *db.Session) {

--- a/internal/service/search_test.go
+++ b/internal/service/search_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -111,6 +112,31 @@ func TestHTTPBackend_Search_Roundtrip(t *testing.T) {
 	require.NotNil(t, res)
 	require.Len(t, res.Results, 1)
 	assert.Equal(t, "s1", res.Results[0].SessionID)
+}
+
+// The HTTP backend must forward all search params to the daemon's
+// /api/v1/search endpoint with the expected query-key names.
+func TestHTTPBackend_Search_SendsParams(t *testing.T) {
+	t.Parallel()
+	var got url.Values
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			got = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[],"next":0}`))
+		}))
+	t.Cleanup(srv.Close)
+	svc := service.NewHTTPBackend(srv.URL, "", false)
+
+	_, err := svc.Search(context.Background(), service.SearchRequest{
+		Query: "needle", Project: "proj", Sort: "recency", Cursor: 7, Limit: 5,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "needle", got.Get("q"))
+	assert.Equal(t, "proj", got.Get("project"))
+	assert.Equal(t, "recency", got.Get("sort"))
+	assert.Equal(t, "7", got.Get("cursor"))
+	assert.Equal(t, "5", got.Get("limit"))
 }
 
 // A daemon without an FTS index responds 501; the HTTP backend maps that

--- a/internal/service/usage_internal_test.go
+++ b/internal/service/usage_internal_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestComputeCacheStats_SavingsPassThrough(t *testing.T) {
+	t.Parallel()
 	// SavingsVsUncached is computed per-model in the DB layer;
 	// computeCacheStats just forwards totals.CacheSavings. Verify the
 	// pass-through at the positive, negative, and zero boundaries so a
@@ -23,6 +24,7 @@ func TestComputeCacheStats_SavingsPassThrough(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			cs := computeCacheStats(db.UsageTotals{CacheSavings: tc.in})
 			assert.InDelta(t, tc.in, cs.SavingsVsUncached, 1e-9)
 		})


### PR DESCRIPTION
## Summary

Adds an `agentsview mcp` subcommand that runs a read-only [MCP](https://modelcontextprotocol.io) server exposing six session-retrieval tools, so MCP clients (Claude Desktop, Claude Code, Codex, etc.) can search and read recorded agent sessions without leaving their assistant.

The six tools are thin adapters over `service.SessionService` — the same seam the CLI and HTTP handlers use, merged in #834:

- `search_sessions` — keyword/FTS session search with cursor pagination
- `list_sessions` — recent sessions, filterable
- `get_session_overview` — per-session metadata and message index
- `get_messages` — message bodies for a session (anchored, directional)
- `search_content` — exact-string/regex content search across messages
- `get_usage_summary` — token/cost rollups

## Backend policy

`agentsview mcp` is daemon-backed for local SQLite reads. In the default local mode, each tool call resolves the local agentsview daemon and starts it when needed, so a long-lived MCP server can keep serving after the daemon exits due to idleness. It does not fall back to opening the local SQLite archive directly.

Explicit backend selection remains opt-in:

- `--server <url>` targets a chosen daemon over HTTP, with `AGENTSVIEW_SERVER_TOKEN` or `--server-token-file` for authenticated daemons.
- `--pg` reads from the configured PostgreSQL store directly, using the same PG read-service path as `agentsview session --pg`.
- PostgreSQL-backed reads can also be exposed by running `agentsview pg serve` and passing that daemon URL with `--server`.

## Security posture

The archive holds prompts, tool output, file paths, and usage, so the network surface is locked down by default:

- **Read-only.** Every tool is annotated read-only; there are no mutating tools.
- **Loopback default.** stdio is the default transport. `--http` runs StreamableHTTP, and `normalizeMCPHTTPAddr` maps bare/":"-prefixed ports to `127.0.0.1` and refuses non-loopback binds unless `--http-allow-insecure` is set. The empty-host case (`[]:8085`, which would otherwise bind all interfaces) is treated as non-loopback on purpose.
- **Bearer auth for non-loopback binds.** A non-loopback listener requires a configured token (`auth_token`, or `require_auth`, which provisions one via `EnsureAuthToken` to match serve/pg/duckdb) and enforces `Authorization: Bearer` on every request with a constant-time compare. Without a token the command refuses to start.
- **Loopback require_auth.** When `require_auth` is set, even loopback MCP HTTP binds enforce bearer auth, so forwarded loopback ports are not accidentally unauthenticated.
- **DNS-rebinding guard.** The SDK's localhost protection is left enabled (rejecting loopback requests that carry a non-loopback `Host` header with a 403), made explicit in `newHTTPHandler` and pinned by a regression test.

Both transports install a SIGINT/SIGTERM context (the CLI runs commands without one) and classify client disconnect and signal cancellation as clean shutdowns, so a normal stop exits zero rather than printing a fatal line.

## Dependencies

Adds `github.com/modelcontextprotocol/go-sdk` (the official Go MCP SDK) plus its transitive deps (`google/jsonschema-go`, `yosida95/uritemplate`, `segmentio/*`, `golang.org/x/oauth2`). There is no stdlib MCP implementation, and hand-rolling the JSON-RPC/StreamableHTTP transport and schema generation would be substantially more code to carry; the SDK is the minimal, canonical choice. `go mod tidy` also promotes `gopkg.in/yaml.v3` from indirect to direct — that is an incidental correction of a pre-existing mislabel (`ci_workflow_test.go` already imports it directly), not a newly introduced dependency.

## Documentation

Adds a dedicated Zensical `MCP Server` user guide with MCP client configuration examples, daemon wake-up behavior, explicit daemon targeting, direct `--pg` PostgreSQL mode, HTTP mode, auth expectations, and the `pg serve` alternative for PostgreSQL-backed MCP reads. The CLI reference now links to that guide while retaining the command-level flag summary.

## Where to look

- `internal/mcp/tools.go`, `internal/mcp/shape.go` — tool handlers and response shaping; confirm all reads go through `SessionService`.
- `cmd/agentsview/mcp.go` — command wiring, lazy daemon-backed local service resolution, `--pg` read service resolution, `normalizeMCPHTTPAddr`, and `mcpListenerAuth`.
- `internal/mcp/server.go` — server construction, bearer enforcement (`withBearerAuth`), and `newHTTPHandler` (DNS-rebinding guard).
- `docs/mcp.md`, `docs/zensical.toml`, `docs/commands.md` — user-facing Zensical guide, nav entry, and CLI reference link.

## Limitations

- HTTP auth is a single shared bearer token (same model as the daemon); there are no per-client credentials or scopes.
- `get_messages` always drops `IsSystem`-flagged messages (intentional noise suppression); the role filter is for opting into tool messages, not for retrieving system messages.