### PR TITLE
fix(parser): collapse bare roborev CI worktrees

### DIFF
--- a/internal/parser/project.go
+++ b/internal/parser/project.go
@@ -152,12 +152,15 @@ func extractProjectFromCwdWithBranch(
 // manager directory conventions. projectPart is the zero-based
 // component after marker that contains the owning project name.
 type worktreeLayout struct {
-	marker      string
-	projectPart int
-	minParts    int
+	marker              string
+	projectPart         int
+	minParts            int
+	roborevCIBareLayout bool
 }
 
 var worktreeLayouts []worktreeLayout
+
+const roborevCIBareProject = "roborev_ci"
 
 func init() {
 	sep := string(filepath.Separator)
@@ -176,7 +179,10 @@ func init() {
 		// .roborev data dir (like the tool-anchored siblings above) so an
 		// unrelated path that merely contains a "ci-worktrees" directory is not
 		// matched.
-		{marker: sep + ".roborev" + sep + "ci-worktrees" + sep, projectPart: 0, minParts: 2},
+		{
+			marker:      sep + ".roborev" + sep + "ci-worktrees" + sep,
+			projectPart: 0, minParts: 2, roborevCIBareLayout: true,
+		},
 	}
 }
 
@@ -190,6 +196,9 @@ func projectFromWorktreeLayout(path string) string {
 			continue
 		}
 		parts := strings.Split(rest, string(filepath.Separator))
+		if layout.roborevCIBareLayout && isRoborevCIWorktreeLeaf(parts[0]) {
+			return roborevCIBareProject
+		}
 		if len(parts) < layout.minParts {
 			continue
 		}
@@ -200,6 +209,27 @@ func projectFromWorktreeLayout(path string) string {
 		return project
 	}
 	return ""
+}
+
+func isRoborevCIWorktreeLeaf(name string) bool {
+	rest, ok := strings.CutPrefix(name, "roborev-ci-")
+	if !ok {
+		return false
+	}
+	job, id, ok := strings.Cut(rest, "-")
+	if !ok || job == "" || id == "" {
+		return false
+	}
+	return allASCIIDigits(job) && allASCIIDigits(id)
+}
+
+func allASCIIDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // autofsMountSource is indirected so tests can supply fixture

--- a/internal/parser/project_git_test.go
+++ b/internal/parser/project_git_test.go
@@ -640,6 +640,14 @@ func TestExtractProjectFromCwdWithBranch(t *testing.T) {
 			want:   "widget",
 		},
 		{
+			name: "RoborevCIWorktreeBareGeneratedLeaf",
+			cwd: filepath.FromSlash(
+				"/data/.roborev/ci-worktrees/roborev-ci-101-1001",
+			),
+			branch: "",
+			want:   "roborev_ci",
+		},
+		{
 			name: "RoborevCIWorktreeDashRepoNormalized",
 			cwd: filepath.FromSlash(
 				"/data/.roborev/ci-worktrees/data-pipeline/roborev-ci-102-1002",


### PR DESCRIPTION
Roborev CI poller sessions from remote hosts can run Codex from generated `.roborev/ci-worktrees/roborev-ci-<job>-<id>` directories that do not include a repo-named parent. The previous resolver only handled the repo-parent layout, so stale-project reparsing still preserved one activity project per generated worktree.

This changes the bare generated roborev CI layout to resolve to a stable `roborev_ci` project while keeping the existing repo-parent behavior for worktrees that still expose the owning repository. That keeps Activity project breakdowns and filters from filling with one-off CI worktree names, with the tradeoff that truly bare paths cannot recover the original repository name because it is not present in the cwd.

Reviewers should focus on `internal/parser/project.go` and the worktree layout cases in `internal/parser/project_git_test.go`.