### PR TITLE
fix(postgres): fail blocked pg push and surface push errors

### DIFF
--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -177,14 +177,20 @@ func printPGPushProgress(p postgres.PushProgress) {
 }
 
 func writePGPushSummary(w io.Writer, result postgres.PushResult) {
+	dur := result.Duration.Round(time.Millisecond)
+	errSuffix := ""
+	if result.Errors > 0 {
+		errSuffix = fmt.Sprintf(", %d error(s)", result.Errors)
+	}
 	if result.SkippedConflicts > 0 {
 		fmt.Fprintf(
 			w,
-			"Pushed %d sessions, %d messages, skipped %d ownership conflict(s) in %s\n",
+			"Pushed %d sessions, %d messages, skipped %d ownership conflict(s)%s in %s\n",
 			result.SessionsPushed,
 			result.MessagesPushed,
 			result.SkippedConflicts,
-			result.Duration.Round(time.Millisecond),
+			errSuffix,
+			dur,
 		)
 		fmt.Fprintf(
 			w,
@@ -195,10 +201,11 @@ func writePGPushSummary(w io.Writer, result postgres.PushResult) {
 	}
 	fmt.Fprintf(
 		w,
-		"Pushed %d sessions, %d messages in %s\n",
+		"Pushed %d sessions, %d messages%s in %s\n",
 		result.SessionsPushed,
 		result.MessagesPushed,
-		result.Duration.Round(time.Millisecond),
+		errSuffix,
+		dur,
 	)
 }
 

--- a/cmd/agentsview/pg_test.go
+++ b/cmd/agentsview/pg_test.go
@@ -394,3 +394,74 @@ func TestWritePGPushSummaryIncludesSkippedConflicts(t *testing.T) {
 	assert.Contains(t, got,
 		"Warning: skipped 2 session(s) owned by another PostgreSQL push marker")
 }
+
+func TestWritePGPushSummaryReportsErrorCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		result      postgres.PushResult
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "conflicts with errors",
+			result: postgres.PushResult{
+				SessionsPushed:   3,
+				MessagesPushed:   9,
+				SkippedConflicts: 2,
+				Errors:           4,
+				Duration:         1500 * time.Millisecond,
+			},
+			wantContain: []string{
+				"Pushed 3 sessions, 9 messages, skipped 2 ownership conflict(s), 4 error(s) in 1.5s",
+				"Warning: skipped 2 session(s) owned by another PostgreSQL push marker",
+			},
+		},
+		{
+			name: "conflicts without errors omits error count",
+			result: postgres.PushResult{
+				SessionsPushed:   3,
+				MessagesPushed:   9,
+				SkippedConflicts: 2,
+				Duration:         1500 * time.Millisecond,
+			},
+			wantContain: []string{
+				"Pushed 3 sessions, 9 messages, skipped 2 ownership conflict(s) in 1.5s",
+			},
+			wantAbsent: []string{"error(s)"},
+		},
+		{
+			name: "errors without conflicts",
+			result: postgres.PushResult{
+				SessionsPushed: 5,
+				MessagesPushed: 12,
+				Errors:         1,
+				Duration:       2 * time.Second,
+			},
+			wantContain: []string{"Pushed 5 sessions, 12 messages, 1 error(s) in 2s"},
+			wantAbsent:  []string{"ownership conflict"},
+		},
+		{
+			name: "clean run omits error count",
+			result: postgres.PushResult{
+				SessionsPushed: 5,
+				MessagesPushed: 12,
+				Duration:       2 * time.Second,
+			},
+			wantContain: []string{"Pushed 5 sessions, 12 messages in 2s"},
+			wantAbsent:  []string{"error(s)", "ownership conflict"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			writePGPushSummary(&out, tt.result)
+			got := out.String()
+			for _, want := range tt.wantContain {
+				assert.Contains(t, got, want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, got, absent)
+			}
+		})
+	}
+}

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -333,9 +333,6 @@ func (d *DB) CopySyncStateFrom(sourcePath string) error {
 		}
 		return fmt.Errorf("probing pg_sync_state table: %w", err)
 	}
-	if tableExists != 1 {
-		return nil
-	}
 
 	_, err = conn.ExecContext(ctx, `
 		INSERT OR REPLACE INTO main.pg_sync_state (key, value)
@@ -385,9 +382,6 @@ func (d *DB) CopyExcludedSessionsFrom(
 			return nil
 		}
 		return fmt.Errorf("probing excluded_sessions table: %w", err)
-	}
-	if tableExists != 1 {
-		return nil
 	}
 
 	_, err = conn.ExecContext(ctx, `

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1387,22 +1387,28 @@ func (s *Sync) pushSession(
 		return err
 	}
 	if rowsAffected, rowsErr := result.RowsAffected(); rowsErr == nil && rowsAffected == 0 {
-		currentOwnerMarker := existingOwnerMarker.String
-		currentMachine := existingMachine.String
 		refreshErr := tx.QueryRowContext(ctx,
 			`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sess.ID,
 		).Scan(&existingMachine, &existingOwnerMarker)
-		if refreshErr == nil {
-			currentOwnerMarker = existingOwnerMarker.String
-			currentMachine = existingMachine.String
+		if refreshErr != nil {
+			// The guarded upsert changed no rows and we cannot
+			// re-read the current owner, so we cannot prove this
+			// pusher owns the session. Surface the error instead of
+			// reporting a blocked write as success, so the caller's
+			// retry path handles it rather than pushing messages for
+			// a row this pusher did not write.
+			return fmt.Errorf(
+				"re-reading session %s ownership after blocked upsert: %w",
+				sess.ID, refreshErr,
+			)
 		}
-		if refreshErr == nil && !sameSessionOwner(
-			currentOwnerMarker, currentMachine, markerID, pushedMachine,
-			legacyMarkerMachines,
+		if !sameSessionOwner(
+			existingOwnerMarker.String, existingMachine.String,
+			markerID, pushedMachine, legacyMarkerMachines,
 		) {
 			log.Printf(
 				"pgsync: session %s: skipping — already owned by machine %q, this pusher is %q; sync from the origin machine to update",
-				sess.ID, currentMachine, pushedMachine,
+				sess.ID, existingMachine.String, pushedMachine,
 			)
 			return errSessionOwnershipConflict
 		}


### PR DESCRIPTION
Three small correctness/cleanup fixes flagged by a roborev review of the
pg-push ownership guard (#724), each as its own commit.

- `pushSession` previously treated a guarded upsert that changed no rows as a
  successful push when the follow-up ownership re-read failed — it returned
  `nil`, and the caller then pushed messages for a session row this pusher
  never wrote or owned. It now returns the wrapped re-read error so the
  caller's retry path handles the unprovable state.
- `writePGPushSummary` omitted `PushResult.Errors` in both its conflict and
  clean branches, so a CLI push that recorded errors alongside skipped
  conflicts reported only the skips. It now appends `, N error(s)` when errors
  occurred, matching `logPGWatchPushResult`.
- Removed two unreachable `tableExists != 1` guards in the orphaned-DB copy
  helpers: the probe selects a literal `1` and already handles `sql.ErrNoRows`
  for a missing table, so `Scan` can only ever yield `1`. The review flagged
  the `pg_sync_state` copy; the identical `excluded_sessions` guard is removed
  for consistency.

Reviewers: the behavior change is the `pushSession` error path in
`internal/postgres/push.go`; the other two commits are reporting parity and
dead-code removal.
