### PR TITLE
fix(desktop): use native desktop zoom on Windows

### DIFF
--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -4,6 +4,7 @@
   "description": "Capability for the main window",
   "windows": ["main"],
   "permissions": [
-    "core:default"
+    "core:default",
+    "core:webview:allow-set-webview-zoom"
   ]
 }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -2,6 +2,11 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
+  "remote": {
+    "urls": [
+      "http://127.0.0.1:*"
+    ]
+  },
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1973,6 +1973,7 @@ fn version_response_looks_valid(response: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
     use std::collections::HashMap;
     #[cfg(unix)]
     use std::os::unix::ffi::OsStrExt;
@@ -2289,6 +2290,24 @@ mode:    writable
         let localhost_name =
             Url::parse("http://localhost:18080/").expect("valid localhost-name url");
         assert!(!is_allowed_navigation_url(&localhost_name, Some(18080)));
+    }
+
+    #[test]
+    fn default_capability_grants_zoom_to_the_sidecar_origin() {
+        let capability: Value = serde_json::from_str(include_str!("../capabilities/default.json"))
+            .expect("capability json parses");
+
+        assert_eq!(capability["windows"], serde_json::json!(["main"]));
+        assert_eq!(
+            capability["remote"]["urls"],
+            serde_json::json!(["http://127.0.0.1:*"])
+        );
+        assert!(capability["permissions"]
+            .as_array()
+            .expect("permissions array")
+            .contains(&Value::String(
+                "core:webview:allow-set-webview-zoom".to_string()
+            )));
     }
 
     #[test]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -7,6 +7,7 @@
     "frontendDist": "../ui"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "label": "main",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "minWidth": 1024,
         "minHeight": 700,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "zoomHotkeysEnabled": false
       }
     ],
     "security": {

--- a/frontend/e2e/appearance-a11y.spec.ts
+++ b/frontend/e2e/appearance-a11y.spec.ts
@@ -94,7 +94,7 @@ test.describe("Appearance accessibility", () => {
     await expect(sp.messageRows.first()).toBeVisible();
   });
 
-  test("desktop window zoom and text size compose multiplicatively", async ({
+  test("desktop window zoom stays separate from text size in the browser", async ({
     page,
   }) => {
     await page.addInitScript(() => {
@@ -105,7 +105,7 @@ test.describe("Appearance accessibility", () => {
     const sp = new SessionsPage(page);
     await expect(sp.sessionItems.first()).toBeVisible({ timeout: 5_000 });
 
-    expect(await readZoom(page)).toBe("1.8");
+    expect(await readZoom(page)).toBe("1.2");
   });
 
   test("high contrast applies the root class and overrides tokens", async ({

--- a/frontend/e2e/appearance-a11y.spec.ts
+++ b/frontend/e2e/appearance-a11y.spec.ts
@@ -105,7 +105,7 @@ test.describe("Appearance accessibility", () => {
     const sp = new SessionsPage(page);
     await expect(sp.sessionItems.first()).toBeVisible({ timeout: 5_000 });
 
-    expect(await readZoom(page)).toBe("1.2");
+    expect(await readZoom(page)).toBe("1.8");
   });
 
   test("high contrast applies the root class and overrides tokens", async ({

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -90,17 +90,33 @@ type DesktopTauriBridge = {
   };
 };
 
-function syncDesktopZoom(scaleFactor: number) {
+function currentDesktopWebviewWindow():
+  | DesktopTauriWebviewWindow
+  | undefined {
   if (!IS_DESKTOP || typeof window === "undefined") return;
   const tauri =
     (window as Window & { __TAURI__?: DesktopTauriBridge })
       .__TAURI__;
-  const webview =
-    tauri?.webviewWindow?.getCurrentWebviewWindow?.();
-  if (!webview) return;
+  return tauri?.webviewWindow?.getCurrentWebviewWindow?.();
+}
+
+function syncDesktopZoom(scaleFactor: number): boolean {
+  const webview = currentDesktopWebviewWindow();
+  if (!webview) return false;
   void webview.setZoom(scaleFactor).catch(() => {
     // ignore
   });
+  return true;
+}
+
+function composedRootZoom(
+  fontScale: number, zoomLevel: number,
+): string {
+  let scale = fontScale / 100;
+  if (IS_DESKTOP && !currentDesktopWebviewWindow()) {
+    scale *= zoomLevel / 100;
+  }
+  return String(scale);
 }
 
 function readStoredZoom(): number {
@@ -286,13 +302,15 @@ class UIStore {
       });
 
       // Apply the root font scale in the document; desktop zoom
-      // itself is handled by the native webview bridge.
+      // falls back to CSS when the native webview bridge is absent.
       $effect(() => {
-        const scale = this.fontScale / 100;
         (
           document.documentElement.style as unknown as
             Record<string, string>
-        ).zoom = String(scale);
+        ).zoom = composedRootZoom(
+          this.fontScale,
+          this.zoomLevel,
+        );
       });
 
       // Persist the desktop window zoom (desktop only).

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -80,6 +80,29 @@ const HIGH_CONTRAST_KEY = "agentsview-high-contrast";
 export const FONT_SCALE_STEPS = [90, 100, 110, 120, 130];
 const FONT_SCALE_DEFAULT = 100;
 
+type DesktopTauriWebviewWindow = {
+  setZoom(scaleFactor: number): Promise<void>;
+};
+
+type DesktopTauriBridge = {
+  webviewWindow?: {
+    getCurrentWebviewWindow?: () => DesktopTauriWebviewWindow;
+  };
+};
+
+function syncDesktopZoom(scaleFactor: number) {
+  if (!IS_DESKTOP || typeof window === "undefined") return;
+  const tauri =
+    (window as Window & { __TAURI__?: DesktopTauriBridge })
+      .__TAURI__;
+  const webview =
+    tauri?.webviewWindow?.getCurrentWebviewWindow?.();
+  if (!webview) return;
+  void webview.setZoom(scaleFactor).catch(() => {
+    // ignore
+  });
+}
+
 function readStoredZoom(): number {
   if (!IS_DESKTOP) return ZOOM_DEFAULT;
   try {
@@ -262,27 +285,28 @@ class UIStore {
         }
       });
 
-      // Apply the composed root zoom: font scale (web and desktop)
-      // multiplied by the desktop window zoom (desktop only). "zoom"
-      // is non-standard but supported in WebKit/Chromium.
+      // Apply the root font scale in the document; desktop zoom
+      // itself is handled by the native webview bridge.
       $effect(() => {
-        const desktopZoom = IS_DESKTOP ? this.zoomLevel / 100 : 1;
         const scale = this.fontScale / 100;
-        const effective =
-          Math.round(desktopZoom * scale * 10000) / 10000;
         (
           document.documentElement.style as unknown as
             Record<string, string>
-        ).zoom = String(effective);
+        ).zoom = String(scale);
       });
 
       // Persist the desktop window zoom (desktop only).
       $effect(() => {
-        if (!IS_DESKTOP) return;
-        try {
-          localStorage?.setItem(ZOOM_KEY, String(this.zoomLevel));
-        } catch {
-          // ignore
+        if (IS_DESKTOP) {
+          syncDesktopZoom(this.zoomLevel / 100);
+          try {
+            localStorage?.setItem(
+              ZOOM_KEY,
+              String(this.zoomLevel),
+            );
+          } catch {
+            // ignore
+          }
         }
       });
 

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -225,6 +225,41 @@ describe("UIStore", () => {
         }
       }
     });
+
+    it("falls back to CSS zoom on desktop pages without the Tauri bridge", async () => {
+      const tauriWindow = window as Window & {
+        __TAURI__?: unknown;
+      };
+      const originalUrl = window.location.href;
+      const hadTauri = Object.prototype.hasOwnProperty.call(
+        tauriWindow,
+        "__TAURI__",
+      );
+      const originalTauri = tauriWindow.__TAURI__;
+      delete tauriWindow.__TAURI__;
+      window.history.replaceState({}, "", "?desktop");
+
+      try {
+        // @ts-expect-error -- cache bust for fresh UIStore
+        const mod = await import("./ui.svelte.js?desktopCssFallback");
+        mod.ui.zoomLevel = 200;
+        mod.ui.setFontScale(110);
+        await tick();
+
+        expect(
+          document.documentElement.style.getPropertyValue("zoom"),
+        ).toBe("2.2");
+      } finally {
+        window.history.replaceState({}, "", originalUrl);
+        if (hadTauri) {
+          Object.defineProperty(tauriWindow, "__TAURI__", {
+            value: originalTauri,
+            writable: true,
+            configurable: true,
+          });
+        }
+      }
+    });
   });
 
   describe("theme initialization", () => {

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -159,6 +159,60 @@ describe("UIStore", () => {
     });
   });
 
+  describe("desktop zoom bridge", () => {
+    it("calls the native webview zoom bridge without changing the step ladder", async () => {
+      const tauriWindow = window as Window & {
+        __TAURI__?: unknown;
+      };
+      const originalUrl = window.location.href;
+      const hadTauri = Object.prototype.hasOwnProperty.call(
+        tauriWindow,
+        "__TAURI__",
+      );
+      const originalTauri = tauriWindow.__TAURI__;
+      const setZoom = vi.fn(() => Promise.resolve());
+      const getCurrentWebviewWindow = vi.fn(() => ({
+        setZoom,
+      }));
+
+      Object.defineProperty(tauriWindow, "__TAURI__", {
+        value: {
+          webviewWindow: {
+            getCurrentWebviewWindow,
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+      window.history.replaceState({}, "", "?desktop");
+
+      try {
+        // @ts-expect-error -- cache bust for fresh UIStore
+        const mod = await import("./ui.svelte.js?desktopZoomBridge");
+        await tick();
+        setZoom.mockClear();
+
+        mod.ui.zoomIn();
+        await tick();
+
+        expect(mod.ui.zoomLevel).toBe(110);
+        expect(getCurrentWebviewWindow).toHaveBeenCalled();
+        expect(setZoom).toHaveBeenLastCalledWith(1.1);
+      } finally {
+        window.history.replaceState({}, "", originalUrl);
+        if (hadTauri) {
+          Object.defineProperty(tauriWindow, "__TAURI__", {
+            value: originalTauri,
+            writable: true,
+            configurable: true,
+          });
+        } else {
+          delete tauriWindow.__TAURI__;
+        }
+      }
+    });
+  });
+
   describe("theme initialization", () => {
     it("should fall back to light when stored theme is absent", () => {
       expect(ui.theme).toBeDefined();

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -836,8 +836,28 @@ describe("UIStore", () => {
 
     it("composes desktop window zoom with font scale", async () => {
       const original = globalThis.localStorage;
+      const tauriWindow = window as Window & {
+        __TAURI__?: unknown;
+      };
+      const hadTauri = Object.prototype.hasOwnProperty.call(
+        tauriWindow,
+        "__TAURI__",
+      );
+      const originalTauri = tauriWindow.__TAURI__;
+      const setZoom = vi.fn(() => Promise.resolve());
       Object.defineProperty(globalThis, "localStorage", {
         value: { getItem: vi.fn(() => null), setItem: vi.fn() },
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(tauriWindow, "__TAURI__", {
+        value: {
+          webviewWindow: {
+            getCurrentWebviewWindow: () => ({
+              setZoom,
+            }),
+          },
+        },
         writable: true,
         configurable: true,
       });
@@ -850,7 +870,8 @@ describe("UIStore", () => {
         await tick();
         expect(
           document.documentElement.style.getPropertyValue("zoom"),
-        ).toBe("2.2");
+        ).toBe("1.1");
+        expect(setZoom).toHaveBeenLastCalledWith(2);
       } finally {
         window.history.replaceState({}, "", "/");
         Object.defineProperty(globalThis, "localStorage", {
@@ -858,6 +879,15 @@ describe("UIStore", () => {
           writable: true,
           configurable: true,
         });
+        if (hadTauri) {
+          Object.defineProperty(tauriWindow, "__TAURI__", {
+            value: originalTauri,
+            writable: true,
+            configurable: true,
+          });
+        } else {
+          delete tauriWindow.__TAURI__;
+        }
       }
     });
 

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -160,7 +160,7 @@ describe("UIStore", () => {
   });
 
   describe("desktop zoom bridge", () => {
-    it("calls the native webview zoom bridge without changing the step ladder", async () => {
+    it("routes desktop zoom steps through the native webview bridge", async () => {
       const tauriWindow = window as Window & {
         __TAURI__?: unknown;
       };
@@ -198,6 +198,20 @@ describe("UIStore", () => {
         expect(mod.ui.zoomLevel).toBe(110);
         expect(getCurrentWebviewWindow).toHaveBeenCalled();
         expect(setZoom).toHaveBeenLastCalledWith(1.1);
+
+        mod.ui.zoomOut();
+        await tick();
+
+        expect(mod.ui.zoomLevel).toBe(100);
+        expect(setZoom).toHaveBeenLastCalledWith(1);
+
+        mod.ui.zoomIn();
+        await tick();
+        mod.ui.resetZoom();
+        await tick();
+
+        expect(mod.ui.zoomLevel).toBe(100);
+        expect(setZoom).toHaveBeenLastCalledWith(1);
       } finally {
         window.history.replaceState({}, "", originalUrl);
         if (hadTauri) {


### PR DESCRIPTION
Windows desktop zoom is still being applied by writing CSS `zoom` onto the document root, even though the desktop controls and shortcuts all flow through the shared zoom store. That leaves the Tauri shell with a DOM-scale workaround instead of native webview zoom, which matches the rendering bug reported in #166.

This change keeps the existing zoom steps, persistence, and desktop-only affordances, but swaps the apply path to the native Tauri webview zoom API and disables the underlying WebView2 zoom accelerators so the shared store remains the single source of truth on Windows. Browser behavior, zoom step values, and unrelated desktop shell plumbing stay unchanged.

Review should focus on the desktop-only bridge in the UI store, the narrow Tauri config change if it lands, and the regression test that proves base never calls the native zoom bridge while head does. Local validation stays narrow to the touched frontend store and typecheck path; CI can cover the broader matrix.

Fixes #166
