### PR TITLE
feat(pi): preserve Pi message tree lineage

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -53,7 +53,7 @@ import (
 // titles from session_index.jsonl. Existing Codex rows need
 // re-parsing so their titles reflect later renames.
 //
-// Bumped to 44: the Pi parser now persists per-message
+// Bumped to 52: the Pi parser now persists per-message
 // source_uuid and source_parent_uuid lineage. Existing Pi rows need
 // re-parsing so stored message trees gain the new lineage anchors.
 //
@@ -241,10 +241,11 @@ import (
 // classification, so historical skill usage is backfilled on
 // re-parse.)
 //
+// (52: Pi source lineage reparse.)
 // (51: Gemini cumulative-to-delta token reparse.)
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 51
+const dataVersion = 52
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -29,6 +29,7 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+<<<<<<< HEAD
 // Bumped to 50: parser-derived text is sanitized for PostgreSQL
 // parity and fingerprints. Existing rows need re-parsing so stored
 // message/session shape, timestamps, roles, token counts, and content
@@ -53,11 +54,20 @@ import (
 // titles from session_index.jsonl. Existing Codex rows need
 // re-parsing so their titles reflect later renames.
 //
+// Bumped to 44: the Pi parser now persists per-message
+// source_uuid and source_parent_uuid lineage. Existing Pi rows need
+// re-parsing so stored message trees gain the new lineage anchors.
+//
 // Bumped to 44: the VSCode Copilot parser now extracts per-turn
 // token usage (promptTokens/outputTokens) and the resolved model from
 // result.metadata into usage events, session output totals, and peak
 // context, so existing VSCode Copilot rows need re-parsing to gain
 // usage and cost.
+=======
+// Bumped to 44: the Pi parser now persists per-message
+// source_uuid and source_parent_uuid lineage. Existing Pi rows need
+// re-parsing so stored message trees gain the new lineage anchors.
+>>>>>>> 2642fa09 (fix(db): force Pi lineage backfill on resync (#368))
 //
 // Bumped to 43: the Pi parser now persists cwd from the
 // session header. Existing Pi rows need re-parsing so their cwd column

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -29,7 +29,6 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-<<<<<<< HEAD
 // Bumped to 50: parser-derived text is sanitized for PostgreSQL
 // parity and fingerprints. Existing rows need re-parsing so stored
 // message/session shape, timestamps, roles, token counts, and content
@@ -63,11 +62,6 @@ import (
 // result.metadata into usage events, session output totals, and peak
 // context, so existing VSCode Copilot rows need re-parsing to gain
 // usage and cost.
-=======
-// Bumped to 44: the Pi parser now persists per-message
-// source_uuid and source_parent_uuid lineage. Existing Pi rows need
-// re-parsing so stored message trees gain the new lineage anchors.
->>>>>>> 2642fa09 (fix(db): force Pi lineage backfill on resync (#368))
 //
 // Bumped to 43: the Pi parser now persists cwd from the
 // session header. Existing Pi rows need re-parsing so their cwd column

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -696,7 +696,7 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionSanitizedMessageShape(t *testing.T) {
-	assert.Equal(t, 51, CurrentDataVersion(),
+	assert.Equal(t, 52, CurrentDataVersion(),
 		"current parser data version must stay bumped past the Pi lineage reparse")
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -697,7 +697,7 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 
 func TestCurrentDataVersionSanitizedMessageShape(t *testing.T) {
 	assert.Equal(t, 51, CurrentDataVersion(),
-		"Gemini cumulative-to-delta reparse requires a data version bump")
+		"current parser data version must stay bumped past the Pi lineage reparse")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -105,6 +105,15 @@ func parsePiLikeSession(
 		userCount    int
 		currentModel string
 	)
+	// Pi emits metadata rows that stay in the tree, so bridge them to the
+	// nearest visible ancestor before assigning SourceParentUUID.
+	visibleAncestorByID := map[string]string{}
+	resolveVisibleAncestor := func(id string) string {
+		if id == "" {
+			return ""
+		}
+		return visibleAncestorByID[id]
+	}
 
 	for {
 		line, ok := lr.next()
@@ -120,6 +129,8 @@ func parsePiLikeSession(
 		if entryType == "" {
 			continue
 		}
+		entryID := gjson.Get(line, "id").Str
+		parentID := gjson.Get(line, "parentId").Str
 
 		// If any message entry has an id field, this is a V2 session.
 		if isV1 && gjson.Get(line, "id").Str != "" {
@@ -131,7 +142,10 @@ func parsePiLikeSession(
 			role := gjson.Get(line, "message.role").Str
 			switch role {
 			case "user":
-				msg := parsePiUserMessage(line, ordinal)
+				sourceParentUUID := resolveVisibleAncestor(parentID)
+				msg := parsePiUserMessage(
+					line, ordinal, entryID, sourceParentUUID,
+				)
 				if msg == nil {
 					continue
 				}
@@ -142,11 +156,18 @@ func parsePiLikeSession(
 					)
 				}
 				messages = append(messages, *msg)
+				if entryID != "" {
+					visibleAncestorByID[entryID] = entryID
+				}
 				ordinal++
 				userCount++
 
 			case "assistant":
-				msg := parsePiAssistantMessage(line, ordinal, currentModel)
+				sourceParentUUID := resolveVisibleAncestor(parentID)
+				msg := parsePiAssistantMessage(
+					line, ordinal, currentModel, entryID,
+					sourceParentUUID,
+				)
 				if msg == nil {
 					continue
 				}
@@ -154,34 +175,68 @@ func parsePiLikeSession(
 					currentModel = msg.Model
 				}
 				messages = append(messages, *msg)
+				if entryID != "" {
+					visibleAncestorByID[entryID] = entryID
+				}
 				ordinal++
 
 			case "toolResult":
-				msg := parsePiToolResultMessage(line, ordinal)
+				sourceParentUUID := resolveVisibleAncestor(parentID)
+				msg := parsePiToolResultMessage(
+					line, ordinal, entryID, sourceParentUUID,
+				)
 				if msg == nil {
 					continue
 				}
 				messages = append(messages, *msg)
+				if entryID != "" {
+					visibleAncestorByID[entryID] = entryID
+				}
 				ordinal++
 
 			default:
+				if entryID != "" {
+					visibleAncestorByID[entryID] = resolveVisibleAncestor(
+						parentID,
+					)
+				}
 				// skip silently
 			}
 
 		case "model_change":
+			if entryID != "" {
+				visibleAncestorByID[entryID] = resolveVisibleAncestor(
+					parentID,
+				)
+			}
 			if id := gjson.Get(line, "modelId").Str; id != "" {
 				currentModel = id
 			}
 
 		case "compaction":
+			if entryID != "" {
+				visibleAncestorByID[entryID] = resolveVisibleAncestor(
+					parentID,
+				)
+			}
 			continue
 
 		case "session_info":
+			if entryID != "" {
+				visibleAncestorByID[entryID] = resolveVisibleAncestor(
+					parentID,
+				)
+			}
 			if name := gjson.Get(line, "name"); name.Exists() {
 				sessionName = name.Str
 			}
 
 		default:
+			if entryID != "" {
+				visibleAncestorByID[entryID] = resolveVisibleAncestor(
+					parentID,
+				)
+			}
 			// skip silently (e.g., thinking_level_change)
 		}
 	}
@@ -237,7 +292,9 @@ func parsePiLikeSession(
 
 // parsePiUserMessage parses a message entry with role="user".
 // Returns nil if the entry is malformed.
-func parsePiUserMessage(line string, ordinal int) *ParsedMessage {
+func parsePiUserMessage(
+	line string, ordinal int, sourceUUID, sourceParentUUID string,
+) *ParsedMessage {
 	content := gjson.Get(line, "message.content")
 
 	var text string
@@ -259,11 +316,14 @@ func parsePiUserMessage(line string, ordinal int) *ParsedMessage {
 	ts := piTimestamp(line)
 
 	return &ParsedMessage{
-		Ordinal:       ordinal,
-		Role:          RoleUser,
-		Content:       text,
-		Timestamp:     ts,
-		ContentLength: len(text),
+		Ordinal:          ordinal,
+		Role:             RoleUser,
+		SourceType:       "user",
+		SourceUUID:       sourceUUID,
+		SourceParentUUID: sourceParentUUID,
+		Content:          text,
+		Timestamp:        ts,
+		ContentLength:    len(text),
 	}
 }
 
@@ -272,7 +332,8 @@ func parsePiUserMessage(line string, ordinal int) *ParsedMessage {
 // recent model id seen (from a prior assistant message or
 // model_change entry), used when this message has no inline model.
 func parsePiAssistantMessage(
-	line string, ordinal int, fallbackModel string,
+	line string, ordinal int, fallbackModel, sourceUUID,
+	sourceParentUUID string,
 ) *ParsedMessage {
 	var (
 		parts       []string
@@ -329,14 +390,17 @@ func parsePiAssistantMessage(
 	ts := piTimestamp(line)
 
 	pm := &ParsedMessage{
-		Ordinal:       ordinal,
-		Role:          RoleAssistant,
-		Content:       content,
-		Timestamp:     ts,
-		HasThinking:   hasThinking,
-		HasToolUse:    hasToolUse,
-		ContentLength: len(content),
-		ToolCalls:     toolCalls,
+		Ordinal:          ordinal,
+		Role:             RoleAssistant,
+		SourceType:       "assistant",
+		SourceUUID:       sourceUUID,
+		SourceParentUUID: sourceParentUUID,
+		Content:          content,
+		Timestamp:        ts,
+		HasThinking:      hasThinking,
+		HasToolUse:       hasToolUse,
+		ContentLength:    len(content),
+		ToolCalls:        toolCalls,
 	}
 	applyPiTokenUsage(pm, line, fallbackModel)
 	return pm
@@ -410,7 +474,9 @@ func applyPiTokenUsage(
 
 // parsePiToolResultMessage parses a message entry with role="toolResult".
 // Returns nil if the entry is malformed.
-func parsePiToolResultMessage(line string, ordinal int) *ParsedMessage {
+func parsePiToolResultMessage(
+	line string, ordinal int, sourceUUID, sourceParentUUID string,
+) *ParsedMessage {
 	toolUseID := gjson.Get(line, "message.toolCallId").Str
 	content := gjson.Get(line, "message.content")
 	contentLen := toolResultContentLength(content)
@@ -418,9 +484,12 @@ func parsePiToolResultMessage(line string, ordinal int) *ParsedMessage {
 	ts := piTimestamp(line)
 
 	return &ParsedMessage{
-		Ordinal:   ordinal,
-		Role:      RoleUser,
-		Timestamp: ts,
+		Ordinal:          ordinal,
+		Role:             RoleUser,
+		SourceType:       "toolResult",
+		SourceUUID:       sourceUUID,
+		SourceParentUUID: sourceParentUUID,
+		Timestamp:        ts,
 		ToolResults: []ParsedToolResult{
 			{
 				ToolUseID:     toolUseID,

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -190,7 +190,7 @@ func parsePiLikeSession(
 				}
 				messages = append(messages, *msg)
 				if entryID != "" {
-					visibleAncestorByID[entryID] = entryID
+					visibleAncestorByID[entryID] = sourceParentUUID
 				}
 				ordinal++
 

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -214,12 +214,18 @@ func parsePiLikeSession(
 			}
 
 		case "compaction":
-			if entryID != "" {
-				visibleAncestorByID[entryID] = resolveVisibleAncestor(
-					parentID,
-				)
+			sourceParentUUID := resolveVisibleAncestor(parentID)
+			msg := parsePiCompactionMessage(
+				line, ordinal, entryID, sourceParentUUID,
+			)
+			if msg == nil {
+				continue
 			}
-			continue
+			messages = append(messages, *msg)
+			if entryID != "" {
+				visibleAncestorByID[entryID] = entryID
+			}
+			ordinal++
 
 		case "session_info":
 			if entryID != "" {
@@ -497,6 +503,26 @@ func parsePiToolResultMessage(
 				ContentRaw:    content.Raw,
 			},
 		},
+	}
+}
+
+func parsePiCompactionMessage(
+	line string, ordinal int, sourceUUID, sourceParentUUID string,
+) *ParsedMessage {
+	summary := gjson.Get(line, "summary").Str
+	ts := parseTimestamp(gjson.Get(line, "timestamp").Str)
+	return &ParsedMessage{
+		Ordinal:           ordinal,
+		Role:              RoleAssistant,
+		Content:           summary,
+		Timestamp:         ts,
+		IsSystem:          true,
+		ContentLength:     len(summary),
+		SourceType:        "system",
+		SourceSubtype:     "compact_boundary",
+		SourceUUID:        sourceUUID,
+		SourceParentUUID:  sourceParentUUID,
+		IsCompactBoundary: true,
 	}
 }
 

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -133,7 +133,7 @@ func parsePiLikeSession(
 		parentID := gjson.Get(line, "parentId").Str
 
 		// If any message entry has an id field, this is a V2 session.
-		if isV1 && gjson.Get(line, "id").Str != "" {
+		if isV1 && entryID != "" {
 			isV1 = false
 		}
 

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -402,22 +402,32 @@ func TestParsePiSession_MessageLineageContinuity(t *testing.T) {
 		`{"type":"compaction","id":"cmp-1","parentId":"mc-1","timestamp":"2025-01-01T10:00:04Z","summary":"# compacted","firstKeptEntryIndex":0,"tokensBefore":5000}`,
 		`{"type":"message","id":"u2","parentId":"cmp-1","timestamp":"2025-01-01T10:00:05Z","message":{"role":"user","content":"after compaction"}}`,
 		`{"type":"message","id":"a2","parentId":"u2","timestamp":"2025-01-01T10:00:06Z","message":{"role":"assistant","content":"reply"}}`,
+		`{"type":"message","id":"t1","parentId":"a2","timestamp":"2025-01-01T10:00:07Z","message":{"role":"toolResult","toolCallId":"toolu_42","content":"tool output"}}`,
 		"",
 	}, "\n")
 
 	sess, msgs := runPiParserTest(t, content)
 
 	assert.Equal(t, "Checkpoint", sess.SessionName)
-	require.Len(t, msgs, 3)
+	require.Len(t, msgs, 4)
 
 	assert.Equal(t, "u1", msgs[0].SourceUUID)
 	assert.Empty(t, msgs[0].SourceParentUUID)
+	assert.Equal(t, "user", msgs[0].SourceType)
 
 	assert.Equal(t, "u2", msgs[1].SourceUUID)
 	assert.Equal(t, "u1", msgs[1].SourceParentUUID)
+	assert.Equal(t, "user", msgs[1].SourceType)
 
 	assert.Equal(t, "a2", msgs[2].SourceUUID)
 	assert.Equal(t, "u2", msgs[2].SourceParentUUID)
+	assert.Equal(t, "assistant", msgs[2].SourceType)
+
+	assert.Equal(t, "t1", msgs[3].SourceUUID)
+	assert.Equal(t, "a2", msgs[3].SourceParentUUID)
+	assert.Equal(t, "toolResult", msgs[3].SourceType)
+	require.Len(t, msgs[3].ToolResults, 1)
+	assert.Equal(t, "toolu_42", msgs[3].ToolResults[0].ToolUseID)
 }
 
 // TestParsePiSession_IOError verifies that I/O errors encountered after the

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -403,13 +403,14 @@ func TestParsePiSession_MessageLineageContinuity(t *testing.T) {
 		`{"type":"message","id":"u2","parentId":"cmp-1","timestamp":"2025-01-01T10:00:05Z","message":{"role":"user","content":"after compaction"}}`,
 		`{"type":"message","id":"a2","parentId":"u2","timestamp":"2025-01-01T10:00:06Z","message":{"role":"assistant","content":"reply"}}`,
 		`{"type":"message","id":"t1","parentId":"a2","timestamp":"2025-01-01T10:00:07Z","message":{"role":"toolResult","toolCallId":"toolu_42","content":"tool output"}}`,
+		`{"type":"message","id":"a3","parentId":"t1","timestamp":"2025-01-01T10:00:08Z","message":{"role":"assistant","content":"after tool result"}}`,
 		"",
 	}, "\n")
 
 	sess, msgs := runPiParserTest(t, content)
 
 	assert.Equal(t, "Checkpoint", sess.SessionName)
-	require.Len(t, msgs, 4)
+	require.Len(t, msgs, 5)
 
 	assert.Equal(t, "u1", msgs[0].SourceUUID)
 	assert.Empty(t, msgs[0].SourceParentUUID)
@@ -428,6 +429,10 @@ func TestParsePiSession_MessageLineageContinuity(t *testing.T) {
 	assert.Equal(t, "toolResult", msgs[3].SourceType)
 	require.Len(t, msgs[3].ToolResults, 1)
 	assert.Equal(t, "toolu_42", msgs[3].ToolResults[0].ToolUseID)
+
+	assert.Equal(t, "a3", msgs[4].SourceUUID)
+	assert.Equal(t, "a2", msgs[4].SourceParentUUID)
+	assert.Equal(t, "assistant", msgs[4].SourceType)
 }
 
 // TestParsePiSession_IOError verifies that I/O errors encountered after the

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -699,7 +699,7 @@ func TestParsePiSession_TokenUsageFromFixture(t *testing.T) {
 
 	var assistants []ParsedMessage
 	for _, m := range msgs {
-		if m.Role == RoleAssistant {
+		if m.Role == RoleAssistant && m.SourceType == "assistant" {
 			assistants = append(assistants, m)
 		}
 	}

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -353,6 +353,26 @@ func TestParsePiSession_V1Session(t *testing.T) {
 	assert.Equal(t, "pi:v1-session", sess.ID, "PRSR-09: V1 session ID from filename")
 }
 
+func TestParsePiSession_V1MessageLineageStaysEmpty(t *testing.T) {
+	content := strings.Join([]string{
+		`{"type":"session","timestamp":"2025-01-01T10:00:00Z","cwd":"/Users/alice/code/v1-project"}`,
+		`{"type":"message","timestamp":"2025-01-01T10:00:01Z","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+		`{"type":"message","timestamp":"2025-01-01T10:00:02Z","message":{"role":"assistant","content":"ok"}}`,
+		"",
+	}, "\n")
+
+	path := createTestFile(t, "v1-lineage.jsonl", content)
+	sess, msgs, err := ParsePiSession(path, "v1_project", "local")
+	require.NoError(t, err)
+
+	assert.Equal(t, "pi:v1-lineage", sess.ID)
+	require.Len(t, msgs, 2)
+	for _, msg := range msgs {
+		assert.Empty(t, msg.SourceUUID)
+		assert.Empty(t, msg.SourceParentUUID)
+	}
+}
+
 // TestParsePiSession_BranchedFrom verifies the exact ParentSessionID value
 // extracted from the branchedFrom field (PRSR-10).
 func TestParsePiSession_BranchedFrom(t *testing.T) {
@@ -371,6 +391,33 @@ func TestParsePiSession_BranchedFrom(t *testing.T) {
 			"PRSR-10: basename of branchedFrom without .jsonl extension, prefixed",
 		)
 	})
+}
+
+func TestParsePiSession_MessageLineageContinuity(t *testing.T) {
+	content := strings.Join([]string{
+		`{"type":"session","version":3,"id":"tree-sess","timestamp":"2025-01-01T10:00:00Z","cwd":"/Users/alice/code/my-project"}`,
+		`{"type":"message","id":"u1","parentId":null,"timestamp":"2025-01-01T10:00:01Z","message":{"role":"user","content":"root"}}`,
+		`{"type":"session_info","id":"info-1","parentId":"u1","timestamp":"2025-01-01T10:00:02Z","name":"Checkpoint"}`,
+		`{"type":"model_change","id":"mc-1","parentId":"info-1","timestamp":"2025-01-01T10:00:03Z","provider":"anthropic","modelId":"claude-opus-4-5"}`,
+		`{"type":"compaction","id":"cmp-1","parentId":"mc-1","timestamp":"2025-01-01T10:00:04Z","summary":"# compacted","firstKeptEntryIndex":0,"tokensBefore":5000}`,
+		`{"type":"message","id":"u2","parentId":"cmp-1","timestamp":"2025-01-01T10:00:05Z","message":{"role":"user","content":"after compaction"}}`,
+		`{"type":"message","id":"a2","parentId":"u2","timestamp":"2025-01-01T10:00:06Z","message":{"role":"assistant","content":"reply"}}`,
+		"",
+	}, "\n")
+
+	sess, msgs := runPiParserTest(t, content)
+
+	assert.Equal(t, "Checkpoint", sess.SessionName)
+	require.Len(t, msgs, 3)
+
+	assert.Equal(t, "u1", msgs[0].SourceUUID)
+	assert.Empty(t, msgs[0].SourceParentUUID)
+
+	assert.Equal(t, "u2", msgs[1].SourceUUID)
+	assert.Equal(t, "u1", msgs[1].SourceParentUUID)
+
+	assert.Equal(t, "a2", msgs[2].SourceUUID)
+	assert.Equal(t, "u2", msgs[2].SourceParentUUID)
 }
 
 // TestParsePiSession_IOError verifies that I/O errors encountered after the

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -291,8 +291,8 @@ func TestParsePiSession_ThinkingBlocks(t *testing.T) {
 	})
 }
 
-// TestParsePiSession_UserMessageCount verifies that model_change and
-// compaction entries are skipped entirely and do not inflate user counts.
+// TestParsePiSession_UserMessageCount verifies that metadata entries do
+// not inflate user counts even when compactions persist as system rows.
 func TestParsePiSession_UserMessageCount(t *testing.T) {
 	fixturePath := createTestFile(
 		t, "pi-session.jsonl",
@@ -301,8 +301,8 @@ func TestParsePiSession_UserMessageCount(t *testing.T) {
 	sess, _, err := ParsePiSession(fixturePath, "", "local")
 	require.NoError(t, err)
 
-	// The fixture has 2 real user messages. model_change and compaction
-	// entries are skipped entirely and never enter the messages slice.
+	// The fixture has 2 real user messages. Metadata rows must not count
+	// as user messages.
 	assert.Equal(t, 2, sess.UserMessageCount,
 		"UserMessageCount must only count real user messages")
 }
@@ -410,29 +410,37 @@ func TestParsePiSession_MessageLineageContinuity(t *testing.T) {
 	sess, msgs := runPiParserTest(t, content)
 
 	assert.Equal(t, "Checkpoint", sess.SessionName)
-	require.Len(t, msgs, 5)
+	require.Len(t, msgs, 6)
 
 	assert.Equal(t, "u1", msgs[0].SourceUUID)
 	assert.Empty(t, msgs[0].SourceParentUUID)
 	assert.Equal(t, "user", msgs[0].SourceType)
 
-	assert.Equal(t, "u2", msgs[1].SourceUUID)
+	assert.Equal(t, "cmp-1", msgs[1].SourceUUID)
 	assert.Equal(t, "u1", msgs[1].SourceParentUUID)
-	assert.Equal(t, "user", msgs[1].SourceType)
+	assert.Equal(t, "system", msgs[1].SourceType)
+	assert.Equal(t, "compact_boundary", msgs[1].SourceSubtype)
+	assert.True(t, msgs[1].IsSystem)
+	assert.True(t, msgs[1].IsCompactBoundary)
+	assert.Equal(t, "# compacted", msgs[1].Content)
 
-	assert.Equal(t, "a2", msgs[2].SourceUUID)
-	assert.Equal(t, "u2", msgs[2].SourceParentUUID)
-	assert.Equal(t, "assistant", msgs[2].SourceType)
+	assert.Equal(t, "u2", msgs[2].SourceUUID)
+	assert.Equal(t, "cmp-1", msgs[2].SourceParentUUID)
+	assert.Equal(t, "user", msgs[2].SourceType)
 
-	assert.Equal(t, "t1", msgs[3].SourceUUID)
-	assert.Equal(t, "a2", msgs[3].SourceParentUUID)
-	assert.Equal(t, "toolResult", msgs[3].SourceType)
-	require.Len(t, msgs[3].ToolResults, 1)
-	assert.Equal(t, "toolu_42", msgs[3].ToolResults[0].ToolUseID)
+	assert.Equal(t, "a2", msgs[3].SourceUUID)
+	assert.Equal(t, "u2", msgs[3].SourceParentUUID)
+	assert.Equal(t, "assistant", msgs[3].SourceType)
 
-	assert.Equal(t, "a3", msgs[4].SourceUUID)
+	assert.Equal(t, "t1", msgs[4].SourceUUID)
 	assert.Equal(t, "a2", msgs[4].SourceParentUUID)
-	assert.Equal(t, "assistant", msgs[4].SourceType)
+	assert.Equal(t, "toolResult", msgs[4].SourceType)
+	require.Len(t, msgs[4].ToolResults, 1)
+	assert.Equal(t, "toolu_42", msgs[4].ToolResults[0].ToolUseID)
+
+	assert.Equal(t, "a3", msgs[5].SourceUUID)
+	assert.Equal(t, "a2", msgs[5].SourceParentUUID)
+	assert.Equal(t, "assistant", msgs[5].SourceType)
 }
 
 // TestParsePiSession_IOError verifies that I/O errors encountered after the


### PR DESCRIPTION
Pi transcripts already carry a real message tree, but the current parser only keeps the header-level `branchedFrom` session parent and drops the per-entry `id` and `parentId` lineage. That leaves Pi branches flattened inside a session even though agentsview already has lineage fields in the message model, the database, and the session tree UI.

This change keeps the scope in the Pi parser and its tests. Parsed Pi messages now carry source UUID lineage, Pi compactions persist as compact-boundary system rows so parent links stay resolvable across checkpoints, and other skipped metadata rows bridge forward to the nearest visible ancestor. Session-level `ParentSessionID` still comes only from `branchedFrom`, so the work stays inside session-tree enrichment rather than changing cross-session relationships.

The shape follows the path already used by Claude DAG parsing, which keeps the review surface narrow and matches the repository's existing lineage contract instead of inventing a Pi-only interpretation. It also carries forward the issue's original request and the maintainer's explicit go-ahead without pulling in unrelated Pi migration work.

Fixes #368
