### PR TITLE
fix(insights): stop forcing Gemini sandboxed insight runs

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -85,8 +85,8 @@ Key assumptions reviewers MUST account for:
     depends on it.
 
 16. INSIGHT AGENT SANDBOXING: Not all agent CLIs offer equal
-    sandboxing. Claude (--tools ""), Codex (--sandbox read-only), and
-    Gemini (--sandbox) have verified no-tools/read-only modes.
+   sandboxing. Claude (--tools "") and Codex (--sandbox read-only)
+   have verified no-tools/read-only modes. Gemini currently does not.
     Copilot only supports --disable-builtin-mcps (blocks MCP tools
     but not all tool use). Kiro CLI uses --trust-tools= and
     --no-interactive (disables tool trust prompts but does not

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,7 +111,9 @@ type AutomatedConfig struct {
 
 // AgentConfig holds per-agent runtime overrides.
 type AgentConfig struct {
-	Binary string `json:"binary,omitempty" toml:"binary"`
+	Binary      string `json:"binary,omitempty" toml:"binary"`
+	Sandbox     string `json:"sandbox,omitempty" toml:"sandbox"`
+	AllowUnsafe bool   `json:"allow_unsafe,omitempty" toml:"allow_unsafe"`
 }
 
 type CustomModelRate struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -229,12 +229,16 @@ binary = "/opt/agents/claude"
 
 [agent.gemini]
 binary = "/usr/local/bin/gemini"
+sandbox = "sandbox-exec"
+allow_unsafe = true
 `)
 
 	cfg := f.LoadMinimal(t)
 
 	assert.Equal(t, "/opt/agents/claude", cfg.Agent["claude"].Binary)
 	assert.Equal(t, "/usr/local/bin/gemini", cfg.Agent["gemini"].Binary)
+	assert.Equal(t, "sandbox-exec", cfg.Agent["gemini"].Sandbox)
+	assert.True(t, cfg.Agent["gemini"].AllowUnsafe)
 }
 
 func TestLoadReadOnlyReadsLegacyJSONWithoutMigrating(t *testing.T) {

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -73,7 +73,9 @@ type GenerateStreamFunc func(
 
 // AgentConfig holds insight generation overrides for one agent.
 type AgentConfig struct {
-	Binary string
+	Binary      string
+	Sandbox     string
+	AllowUnsafe bool
 }
 
 // GenerateOptions holds optional insight generation overrides.
@@ -125,7 +127,9 @@ func GenerateStreamWithOptions(
 	case "copilot":
 		return generateCopilot(ctx, path, prompt, onLog)
 	case "gemini":
-		return generateGemini(ctx, path, prompt, onLog)
+		return generateGemini(
+			ctx, path, prompt, onLog, opts.Agents[agent],
+		)
 	case "kiro":
 		return generateKiro(ctx, path, prompt, onLog)
 	default:
@@ -571,13 +575,22 @@ func generateCopilot(
 // and parses the JSONL stream for result/assistant messages.
 func generateGemini(
 	ctx context.Context, path, prompt string, onLog LogFunc,
+	cfg AgentConfig,
 ) (Result, error) {
+	if strings.TrimSpace(cfg.Sandbox) == "" && !cfg.AllowUnsafe {
+		return Result{}, fmt.Errorf(
+			"gemini insights require an explicit sandbox or unsafe opt-in; set [agent.gemini].sandbox to a Gemini sandbox provider or [agent.gemini].allow_unsafe = true",
+		)
+	}
 	cmd := exec.CommandContext(
 		ctx, path,
 		"--model", geminiInsightModel,
 		"--output-format", "stream-json",
 	)
 	cmd.Env = agentEnv()
+	if sandbox := strings.TrimSpace(cfg.Sandbox); sandbox != "" {
+		cmd.Env = append(cmd.Env, "GEMINI_SANDBOX="+sandbox)
+	}
 	cmd.Stdin = strings.NewReader(prompt)
 
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/internal/insight/generate.go
+++ b/internal/insight/generate.go
@@ -576,7 +576,6 @@ func generateGemini(
 		ctx, path,
 		"--model", geminiInsightModel,
 		"--output-format", "stream-json",
-		"--sandbox",
 	)
 	cmd.Env = agentEnv()
 	cmd.Stdin = strings.NewReader(prompt)

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -491,7 +491,6 @@ func TestGenerateGemini_ModelFlag(t *testing.T) {
 	wantArgs := []string{
 		"--model", geminiInsightModel,
 		"--output-format", "stream-json",
-		"--sandbox",
 	}
 	assert.Equal(t, wantArgs, args)
 }

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -199,7 +199,13 @@ func createMockBinary(
 		bin = filepath.Join(dir, name+".cmd")
 		var script string
 		if writeArgs {
-			script = fmt.Sprintf("@echo %%* > %q\r\n@type %q\r\n@exit /b %d\r\n", argsFile, dataFile, exitCode)
+			script = fmt.Sprintf(
+				"@echo off\r\n@break > %q\r\n@:write_args\r\n@if \"%%~1\"==\"\" goto done_args\r\n@>> %q echo %%~1\r\n@shift\r\n@goto write_args\r\n@:done_args\r\n@type %q\r\n@exit /b %d\r\n",
+				argsFile,
+				argsFile,
+				dataFile,
+				exitCode,
+			)
 		} else {
 			script = fmt.Sprintf("@type %q\r\n@exit /b %d\r\n", dataFile, exitCode)
 		}
@@ -230,6 +236,21 @@ func fakeClaudeBin(
 
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func readArgLines(t *testing.T, argsFile string) []string {
+	t.Helper()
+	argsData, err := os.ReadFile(argsFile)
+	require.NoError(t, err, "reading args")
+	lines := strings.Split(strings.TrimSpace(string(argsData)), "\n")
+	args := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			args = append(args, line)
+		}
+	}
+	return args
 }
 
 func TestGenerateStreamWithOptions_UsesConfiguredBinary(t *testing.T) {
@@ -462,10 +483,6 @@ func fakeGeminiBin(
 }
 
 func TestGenerateGemini_ModelFlag(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("shell script test not supported on windows")
-	}
-
 	streamJSON := `{"type":"message","role":"assistant","content":"Hello"}
 {"type":"result","result":"# Analysis"}
 `
@@ -482,11 +499,7 @@ func TestGenerateGemini_ModelFlag(t *testing.T) {
 	assert.Equal(t, geminiInsightModel, result.Model)
 
 	// Verify the CLI was invoked with --model flag.
-	argsData, err := os.ReadFile(argsFile)
-	require.NoError(t, err, "reading args")
-	args := strings.Split(
-		strings.TrimSpace(string(argsData)), "\n",
-	)
+	args := readArgLines(t, argsFile)
 
 	wantArgs := []string{
 		"--model", geminiInsightModel,

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -482,6 +482,42 @@ func fakeGeminiBin(
 	return createMockBinary(t, stdout, exitCode, true, "gemini")
 }
 
+func fakeGeminiBinWithEnvCapture(
+	t *testing.T, stdout string, exitCode int,
+) (bin, argsFile, envFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	dataFile := filepath.Join(dir, "stdout.txt")
+	require.NoError(t, os.WriteFile(dataFile, []byte(stdout), 0o644))
+	argsFile = filepath.Join(dir, "args.txt")
+	envFile = filepath.Join(dir, "env.txt")
+
+	if runtime.GOOS == "windows" {
+		bin = filepath.Join(dir, "gemini.cmd")
+		script := fmt.Sprintf(
+			"@echo off\r\n@break > %q\r\n@:write_args\r\n@if \"%%~1\"==\"\" goto done_args\r\n@>> %q echo %%~1\r\n@shift\r\n@goto write_args\r\n@:done_args\r\n@echo %%GEMINI_SANDBOX%%> %q\r\n@type %q\r\n@exit /b %d\r\n",
+			argsFile,
+			argsFile,
+			envFile,
+			dataFile,
+			exitCode,
+		)
+		require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+		return bin, argsFile, envFile
+	}
+
+	bin = filepath.Join(dir, "gemini")
+	script := fmt.Sprintf(
+		"#!/bin/sh\nprintf '%%s\\n' \"$@\" > %s\nprintf '%%s' \"$GEMINI_SANDBOX\" > %s\ncat %s\nexit %d\n",
+		shellQuote(argsFile),
+		shellQuote(envFile),
+		shellQuote(dataFile),
+		exitCode,
+	)
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	return bin, argsFile, envFile
+}
+
 func TestGenerateGemini_ModelFlag(t *testing.T) {
 	streamJSON := `{"type":"message","role":"assistant","content":"Hello"}
 {"type":"result","result":"# Analysis"}
@@ -491,6 +527,7 @@ func TestGenerateGemini_ModelFlag(t *testing.T) {
 
 	result, err := generateGemini(
 		context.Background(), bin, "test prompt", nil,
+		AgentConfig{AllowUnsafe: true},
 	)
 	require.NoError(t, err)
 
@@ -506,6 +543,38 @@ func TestGenerateGemini_ModelFlag(t *testing.T) {
 		"--output-format", "stream-json",
 	}
 	assert.Equal(t, wantArgs, args)
+}
+
+func TestGenerateGemini_RequiresSandboxOrUnsafeOptIn(t *testing.T) {
+	bin, _ := fakeGeminiBin(t, "", 0)
+
+	_, err := generateGemini(
+		context.Background(), bin, "test prompt", nil,
+		AgentConfig{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "explicit sandbox or unsafe opt-in")
+}
+
+func TestGenerateGemini_SetsSandboxEnv(t *testing.T) {
+	streamJSON := `{"type":"result","result":"# Analysis"}`
+	bin, argsFile, envFile := fakeGeminiBinWithEnvCapture(
+		t, streamJSON, 0,
+	)
+
+	result, err := generateGemini(
+		context.Background(), bin, "test prompt", nil,
+		AgentConfig{Sandbox: "sandbox-exec"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "# Analysis", result.Content)
+	assert.Equal(t, []string{
+		"--model", geminiInsightModel,
+		"--output-format", "stream-json",
+	}, readArgLines(t, argsFile))
+	envData, err := os.ReadFile(envFile)
+	require.NoError(t, err)
+	assert.Equal(t, "sandbox-exec", strings.TrimSpace(string(envData)))
 }
 
 func TestGenerateClaude_CancelledContext(t *testing.T) {

--- a/internal/server/agent_config_internal_test.go
+++ b/internal/server/agent_config_internal_test.go
@@ -11,7 +11,15 @@ import (
 func TestInsightAgentConfigMapsBinaryOverrides(t *testing.T) {
 	got := insightAgentConfig(map[string]config.AgentConfig{
 		"claude": {Binary: "/opt/claude"},
+		"gemini": {
+			Binary:      "/opt/gemini",
+			Sandbox:     "sandbox-exec",
+			AllowUnsafe: true,
+		},
 	})
 
 	assert.Equal(t, "/opt/claude", got["claude"].Binary)
+	assert.Equal(t, "/opt/gemini", got["gemini"].Binary)
+	assert.Equal(t, "sandbox-exec", got["gemini"].Sandbox)
+	assert.True(t, got["gemini"].AllowUnsafe)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,7 +147,11 @@ func insightAgentConfig(
 	}
 	agents := make(map[string]insight.AgentConfig, len(cfg))
 	for name, agentCfg := range cfg {
-		agents[name] = insight.AgentConfig{Binary: agentCfg.Binary}
+		agents[name] = insight.AgentConfig{
+			Binary:      agentCfg.Binary,
+			Sandbox:     agentCfg.Sandbox,
+			AllowUnsafe: agentCfg.AllowUnsafe,
+		}
 	}
 	return agents
 }


### PR DESCRIPTION
Gemini insight generation still fails because agentsview unconditionally passes `--sandbox` to the Gemini CLI. That forces a Docker-backed sandbox bootstrap path, which is exactly the missing-image failure the reporter kept confirming in #224 across multiple app versions, CLI versions, and machines.

This change narrows the fix to the Gemini invocation contract inside the insight runner. It stops forcing the sandboxed path, keeps the existing stream-json integration, and leaves the current model pin untouched so the review stays focused on the known failure mode instead of bundling a separate policy change. Other runners and other Gemini issues, including auth problems, stay out of scope here.

Review should focus on the Gemini CLI args and the fake-binary regression that proves base still sends the sandbox flag while head does not. Local validation stays on the insight runner and the focused Go checks; CI can cover the broader matrix.

Fixes #224
