### PR TITLE
fix(sync): stream remote progress through daemon

### DIFF
--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -179,8 +179,13 @@ func useDaemonForSync(tr transport) bool {
 
 func daemonProgressPrinter() (sync.ProgressFunc, func()) {
 	var resyncProgress *resyncProgressPrinter
+	var printedInline bool
 	onProgress := func(p sync.Progress) {
 		if p.Resync {
+			if printedInline {
+				fmt.Println()
+				printedInline = false
+			}
 			if resyncProgress == nil {
 				resyncProgress = newResyncProgressPrinter(os.Stdout, time.Now)
 			}
@@ -191,12 +196,19 @@ func daemonProgressPrinter() (sync.ProgressFunc, func()) {
 			resyncProgress.Finish()
 			resyncProgress = nil
 		}
+		if formatSyncProgress(p) != "" {
+			printedInline = true
+		}
 		printSyncProgress(p)
 	}
 	finish := func() {
 		if resyncProgress != nil {
 			resyncProgress.Finish()
 			resyncProgress = nil
+		}
+		if printedInline {
+			fmt.Println()
+			printedInline = false
 		}
 	}
 	return onProgress, finish

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -405,6 +405,35 @@ func TestDoSyncRemoteHostUsesDaemonRouteWhenWritableDaemonRunning(t *testing.T) 
 	env.assertNoLocalDB(t)
 }
 
+func TestDoSyncRemoteHostPrintsDaemonProgress(t *testing.T) {
+	env := newSyncCLIEnv(t)
+
+	ts := remoteSyncRouteTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/sync/remotes", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, err := io.WriteString(w,
+			"event: progress\n"+
+				"data: {\"detail\":\"Resolving agent directories on devbox\"}\n\n"+
+				"event: done\n"+
+				"data: {\"failures\":[]}\n\n",
+		)
+		require.NoError(t, err)
+	})
+	registerSyncRouteTestRuntime(t, env.DataDir, ts.URL)
+
+	var hadFailures bool
+	out := captureStdout(t, func() {
+		hadFailures = doSync(SyncConfig{Host: "devbox"})
+	})
+
+	require.False(t, hadFailures)
+	assert.Contains(t, out, "Running sync with remotes via daemon...")
+	assert.Contains(t, out, "Resolving agent directories on devbox")
+	assert.True(t, strings.HasSuffix(out, "\n"), "progress output should finish on a newline")
+	env.assertNoLocalDB(t)
+}
+
 func TestRunDaemonRemoteSyncTrimsBaseURLTrailingSlash(t *testing.T) {
 	ts := remoteSyncRouteTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/v1/sync/remotes", r.URL.Path)

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -296,7 +296,7 @@ func (s *Server) runRemoteSyncRequest(
 	var remoteStats ssh.SyncStats
 	run := func(full bool) {
 		failures, remoteStats = s.runRemoteSyncHosts(
-			ctx, local, req.Hosts, full,
+			ctx, local, req.Hosts, full, progress,
 		)
 	}
 	if req.IncludeLocal {
@@ -325,6 +325,7 @@ func (s *Server) runRemoteSyncHosts(
 	local *db.DB,
 	hosts []config.RemoteHost,
 	full bool,
+	progress func(syncpkg.Progress),
 ) ([]remoteSyncFailure, ssh.SyncStats) {
 	failures := make([]remoteSyncFailure, 0)
 	var totals ssh.SyncStats
@@ -336,6 +337,7 @@ func (s *Server) runRemoteSyncHosts(
 			Full:                    full,
 			DB:                      local,
 			BlockedResultCategories: s.cfg.ResultContentBlockedCategories,
+			Progress:                progress,
 		}
 		stats, err := runRemoteSync(ctx, rs)
 		totals.SessionsSynced += stats.SessionsSynced

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -429,6 +429,34 @@ func TestHumaSyncRemotesStreamsLocalProgress(t *testing.T) {
 	assert.Contains(t, body, `"local_stats"`)
 }
 
+func TestHumaSyncRemotesStreamsRemoteProgress(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	stubRunRemoteSync(t, func(
+		_ context.Context,
+		rs *ssh.RemoteSync,
+	) (ssh.SyncStats, error) {
+		require.NotNil(t, rs.Progress)
+		rs.Progress(syncpkg.Progress{
+			Detail: "Resolving agent directories on alpha",
+		})
+		return ssh.SyncStats{SessionsSynced: 1, SessionsTotal: 1}, nil
+	})
+
+	w := serveJSON(t, f.handler, http.MethodPost, "/api/v1/sync/remotes",
+		remoteSyncRequest{
+			Hosts: []config.RemoteHost{{Host: "alpha"}},
+		},
+		withAccept("text/event-stream"),
+	)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/event-stream")
+	body := w.Body.String()
+	assert.Contains(t, body, "event: progress")
+	assert.Contains(t, body, "Resolving agent directories on alpha")
+	assert.Contains(t, body, "event: done")
+}
+
 func TestRunRemoteSyncRequestSerializesNoSyncRemoteWrites(t *testing.T) {
 	f := newSyncRouteFixture(t)
 	engine := f.srv.syncEngineForLocal(f.db)

--- a/internal/ssh/sync.go
+++ b/internal/ssh/sync.go
@@ -111,6 +111,7 @@ type RemoteSync struct {
 	DB                      *db.DB
 	SSHOpts                 []string // extra args passed to ssh (e.g. -i keyfile)
 	BlockedResultCategories []string
+	Progress                sync.ProgressFunc
 }
 
 // Run executes the full remote sync flow: resolve dirs,
@@ -121,6 +122,7 @@ func (rs *RemoteSync) Run(
 ) (SyncStats, error) {
 	var stats SyncStats
 
+	rs.reportProgress("Resolving agent directories on " + rs.Host)
 	fmt.Printf(
 		"Resolving agent directories on %s...\n", rs.Host,
 	)
@@ -133,10 +135,15 @@ func (rs *RemoteSync) Run(
 		)
 	}
 	if len(dirs) == 0 {
+		rs.reportProgress("No agent directories found on " + rs.Host)
 		fmt.Printf("No agent directories found on %s\n", rs.Host)
 		return stats, nil
 	}
 
+	rs.reportProgress(fmt.Sprintf(
+		"Downloading session data from %s (%d agents)",
+		rs.Host, len(dirs),
+	))
 	fmt.Printf(
 		"Downloading session data from %s (%d agents)...\n",
 		rs.Host, len(dirs),
@@ -150,6 +157,7 @@ func (rs *RemoteSync) Run(
 		)
 	}
 	defer os.RemoveAll(tmpDir)
+	rs.reportProgress("Download complete")
 	fmt.Printf("Download complete.\n")
 
 	// Build engine AgentDirs pointing at temp dir equivalents
@@ -220,6 +228,12 @@ func (rs *RemoteSync) Run(
 	lastPrint := t0
 	var lastProgress sync.Progress
 	progress := func(p sync.Progress) {
+		if p.Detail == "" {
+			p.Detail = "Processing sessions from " + rs.Host
+		}
+		if rs.Progress != nil {
+			rs.Progress(p)
+		}
 		lastProgress = p
 		now := time.Now()
 		if now.Sub(lastPrint) < 500*time.Millisecond {
@@ -280,5 +294,24 @@ func (rs *RemoteSync) Run(
 		fmt.Printf(" (%d failed)", stats.Failed)
 	}
 	fmt.Println()
+	rs.reportProgress(remoteSyncSummary(rs.Host, stats))
 	return stats, nil
+}
+
+func (rs *RemoteSync) reportProgress(detail string) {
+	if rs.Progress == nil {
+		return
+	}
+	rs.Progress(sync.Progress{Detail: detail})
+}
+
+func remoteSyncSummary(host string, stats SyncStats) string {
+	summary := fmt.Sprintf("Synced %d sessions from %s", stats.SessionsSynced, host)
+	if stats.Skipped > 0 {
+		summary += fmt.Sprintf(" (%d unchanged)", stats.Skipped)
+	}
+	if stats.Failed > 0 {
+		summary += fmt.Sprintf(" (%d failed)", stats.Failed)
+	}
+	return summary
 }


### PR DESCRIPTION
Remote sync now often runs inside the background daemon, so the old direct `fmt.Printf` feedback from the SSH sync path could disappear into daemon logs instead of reaching the invoking CLI. That made `agentsview sync --host ...` look idle while the daemon resolved directories, downloaded transcripts, and processed sessions.

This keeps the daemon-owned write path while forwarding remote sync progress through the existing streamed sync response. The direct SSH sync status messages are mirrored into structured progress events, and the CLI finalizes streamed inline progress with a newline so successful remote-only runs leave the terminal prompt clean.

Review should focus on the progress callback added to `ssh.RemoteSync`, the `/api/v1/sync/remotes` streaming path, and the CLI progress finalization behavior.