### PR TITLE
feat(insights): add export and publish for generated insights

### DIFF
--- a/frontend/src/lib/api/client-markdown-export.test.ts
+++ b/frontend/src/lib/api/client-markdown-export.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
-import { getMarkdownExportUrl } from "./client.js";
+import {
+  getInsightMarkdownExportUrl,
+  getMarkdownExportUrl,
+} from "./client.js";
 
 const storage = {
   getItem: vi.fn().mockReturnValue(""),
@@ -29,6 +32,12 @@ describe("markdown export URLs", () => {
     );
     expect(getMarkdownExportUrl("sess-123", 1)).toBe(
       "/api/v1/sessions/sess-123/md?depth=1",
+    );
+  });
+
+  it("builds markdown export URL for an insight", () => {
+    expect(getInsightMarkdownExportUrl(42)).toBe(
+      "/api/v1/insights/42/md",
     );
   });
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -315,6 +315,10 @@ export function getExportUrl(sessionId: string): string {
   return `${getBase()}/sessions/${sessionId}/export`;
 }
 
+export function getInsightExportUrl(insightId: number): string {
+  return `${getBase()}/insights/${insightId}/export`;
+}
+
 /** Get markdown export URL for a session, with optional child depth. */
 export function getMarkdownExportUrl(
   sessionId: string,
@@ -330,10 +334,34 @@ export function getMarkdownExportUrl(
   return `${url.pathname}${url.search}`;
 }
 
+export function getInsightMarkdownExportUrl(
+  insightId: number,
+): string {
+  return `${getBase()}/insights/${insightId}/md`;
+}
+
 /** Download a session export using fetch with auth headers,
  *  avoiding token leakage in the URL for remote connections. */
 export async function downloadExport(sessionId: string): Promise<void> {
-  const url = getExportUrl(sessionId);
+  await downloadAuthenticatedExport(
+    getExportUrl(sessionId),
+    `session-${sessionId}.html`,
+  );
+}
+
+export async function downloadInsightExport(
+  insightId: number,
+): Promise<void> {
+  await downloadAuthenticatedExport(
+    getInsightExportUrl(insightId),
+    `insight-${insightId}.html`,
+  );
+}
+
+async function downloadAuthenticatedExport(
+  url: string,
+  fallbackFilename: string,
+): Promise<void> {
   const token = getAuthToken();
   if (!token) {
     // Local connection — simple navigation is fine.
@@ -353,7 +381,7 @@ export async function downloadExport(sessionId: string): Promise<void> {
   // Extract filename from Content-Disposition if available.
   const cd = res.headers.get("Content-Disposition");
   const match = cd?.match(/filename="?([^"]+)"?/);
-  a.download = match?.[1] ?? `session-${sessionId}.md`;
+  a.download = match?.[1] ?? fallbackFilename;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);

--- a/frontend/src/lib/api/generated/services/InsightsService.ts
+++ b/frontend/src/lib/api/generated/services/InsightsService.ts
@@ -5,6 +5,7 @@
 import type { DbInsight } from '../models/DbInsight';
 import type { GenerateInsightRequest } from '../models/GenerateInsightRequest';
 import type { InsightsResponse } from '../models/InsightsResponse';
+import type { PublishResponse } from '../models/PublishResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -143,6 +144,116 @@ export class InsightsService {
       url: '/api/v1/insights/{id}',
       path: {
         'id': id,
+      },
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
+  /**
+   * Export insight as HTML
+   * @returns string OK
+   * @throws ApiError
+   */
+  public static getApiV1InsightsIdExport({
+    id,
+  }: {
+    /**
+     * Numeric ID
+     */
+    id: number,
+  }): CancelablePromise<string> {
+    return __request(OpenAPI, {
+      method: 'GET',
+      url: '/api/v1/insights/{id}/export',
+      path: {
+        'id': id,
+      },
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
+  /**
+   * Export insight as Markdown
+   * @returns string OK
+   * @throws ApiError
+   */
+  public static getApiV1InsightsIdMd({
+    id,
+  }: {
+    /**
+     * Numeric ID
+     */
+    id: number,
+  }): CancelablePromise<string> {
+    return __request(OpenAPI, {
+      method: 'GET',
+      url: '/api/v1/insights/{id}/md',
+      path: {
+        'id': id,
+      },
+      errors: {
+        400: `Bad Request`,
+        401: `Unauthorized`,
+        403: `Forbidden`,
+        404: `Not Found`,
+        409: `Conflict`,
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+        502: `Bad Gateway`,
+        503: `Service Unavailable`,
+        504: `Gateway Timeout`,
+      },
+    });
+  }
+  /**
+   * Publish insight
+   * @returns PublishResponse OK
+   * @throws ApiError
+   */
+  public static postApiV1InsightsIdPublish({
+    id,
+    secret,
+  }: {
+    /**
+     * Insight ID
+     */
+    id: number,
+    /**
+     * Create a secret gist instead of a public one
+     */
+    secret?: boolean,
+  }): CancelablePromise<PublishResponse> {
+    return __request(OpenAPI, {
+      method: 'POST',
+      url: '/api/v1/insights/{id}/publish',
+      path: {
+        'id': id,
+      },
+      query: {
+        'secret': secret,
       },
       errors: {
         400: `Bad Request`,

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -8,6 +8,7 @@
   import { sessions } from "../../stores/sessions.svelte.js";
   import { sync } from "../../stores/sync.svelte.js";
   import { events } from "../../stores/events.svelte.js";
+  import { downloadInsightExport } from "../../api/client.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
   import {
     yokedDates,
@@ -615,6 +616,25 @@
     return "";
   }
 
+  async function handleInsightExport() {
+    if (!insights.selectedItem) return;
+    try {
+      await downloadInsightExport(insights.selectedItem.id);
+    } catch (error) {
+      console.error("Insight export failed:", error);
+    }
+  }
+
+  function openInsightPublish(secret: boolean) {
+    if (!insights.selectedItem) return;
+    ui.publishSecret = secret;
+    ui.setPublishTarget({
+      kind: "insight",
+      id: insights.selectedItem.id,
+    });
+    ui.activeModal = "publish";
+  }
+
   onMount(() => {
     seedInsightsYoke();
     sessions.loadProjects();
@@ -1192,6 +1212,27 @@
                   {/if}
                 </div>
                 <div class="generated-actions">
+                  <button
+                    class="header-action"
+                    type="button"
+                    onclick={handleInsightExport}
+                  >
+                    Export
+                  </button>
+                  <button
+                    class="header-action"
+                    type="button"
+                    onclick={() => openInsightPublish(false)}
+                  >
+                    Publish
+                  </button>
+                  <button
+                    class="header-action subtle"
+                    type="button"
+                    onclick={() => openInsightPublish(true)}
+                  >
+                    Secret
+                  </button>
                   <CopyButton
                     class="insight-link-copy"
                     copied={copiedInsightLinkId === insights.selectedItem.id}
@@ -1863,18 +1904,42 @@
     text-transform: uppercase;
   }
 
-  .generated-focus {
-    width: 100%;
-    border: 1px solid var(--border-muted);
-    background: var(--bg-inset);
+  .badge-blue {
+    background: var(--accent-blue);
+  }
+
+  .badge-purple {
+    background: var(--accent-purple);
+  }
+
+  .badge-red {
+    background: var(--accent-red);
+  }
+
+  .header-date {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    letter-spacing: -0.01em;
+  }
+
+  .delete-btn {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     border-radius: var(--radius-sm);
     color: var(--text-primary);
     font-size: 12px;
   }
 
   .generated-focus {
+    width: 100%;
     min-height: 30px;
     max-height: 76px;
+    border: 1px solid var(--border-muted);
+    background: var(--bg-inset);
     padding: 7px 8px;
     resize: vertical;
     line-height: 1.35;
@@ -1944,6 +2009,44 @@
   }
 
   .generated-list button.error-task span {
+    color: var(--accent-red);
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .header-action {
+    height: 28px;
+    padding: 0 10px;
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    transition: background 0.12s, color 0.12s,
+      border-color 0.12s;
+  }
+
+  .header-action:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+    border-color: var(--border-default);
+  }
+
+  .header-action.subtle {
+    color: var(--text-muted);
+  }
+
+  .delete-btn:hover {
+    background: color-mix(
+      in srgb,
+      var(--accent-red) 10%,
+      transparent
+    );
     color: var(--accent-red);
   }
 

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -1,4 +1,16 @@
-import { describe, expect, it } from "vite-plus/test";
+// @vitest-environment jsdom
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { mount, tick, unmount } from "svelte";
+import { ui } from "../../stores/ui.svelte.js";
+// @ts-ignore
+import InsightsPage from "./InsightsPage.svelte";
 import source from "./InsightsPage.svelte?raw";
 
 describe("InsightsPage sidebar filter sync", () => {
@@ -94,5 +106,167 @@ describe("InsightsPage date yoke controls", () => {
 
     expect(handlerBlock).toContain("fetchInsightSignals()");
     expect(handlerBlock).not.toContain("analytics.setAutomatedScope");
+  });
+});
+
+const mocks = vi.hoisted(() => ({
+  downloadInsightExport: vi.fn().mockResolvedValue(undefined),
+  deleteItem: vi.fn(),
+  loadInsights: vi.fn(),
+  loadProjects: vi.fn(),
+}));
+
+const state = vi.hoisted(() => {
+  const selectedInsight = {
+    id: 42,
+    type: "daily_activity",
+    date_from: "2026-06-24",
+    date_to: "2026-06-24",
+    project: "agentsview",
+    agent: "claude",
+    model: "sonnet",
+    content: "# Insight\n\n- Shipped change",
+    created_at: "2026-06-24T12:00:00Z",
+  };
+
+  return {
+    selectedInsight,
+    insightsStore: {
+      type: "daily_activity",
+      dateFrom: "2026-06-24",
+      dateTo: "2026-06-24",
+      project: "",
+      agent: "claude",
+      promptText: "",
+      tasks: [],
+      items: [selectedInsight],
+      selectedId: 42,
+      selectedTaskId: null,
+      selectedTask: undefined,
+      selectedItem: selectedInsight,
+      loading: false,
+      generatingCount: 0,
+      load: mocks.loadInsights,
+      setType: vi.fn(),
+      setDateFrom: vi.fn(),
+      setDateTo: vi.fn(),
+      setProject: vi.fn(),
+      setAgent: vi.fn(),
+      generate: vi.fn(),
+      select: vi.fn(),
+      selectTask: vi.fn(),
+      cancelAll: vi.fn(),
+      cancelTask: vi.fn(),
+      dismissTask: vi.fn(),
+      deleteItem: mocks.deleteItem,
+    },
+  };
+});
+
+vi.mock("../../api/client.js", () => ({
+  downloadInsightExport: mocks.downloadInsightExport,
+}));
+
+vi.mock("../../stores/insights.svelte.js", () => ({
+  insights: state.insightsStore,
+}));
+
+vi.mock("../../stores/sessions.svelte.js", () => ({
+  sessions: {
+    projects: [],
+    loadProjects: mocks.loadProjects,
+  },
+}));
+
+vi.mock("../../stores/sync.svelte.js", () => ({
+  sync: {
+    serverVersion: { read_only: false },
+  },
+}));
+
+vi.mock("../../utils/markdown.js", () => ({
+  renderMarkdown: (content: string) => content,
+}));
+
+vi.mock("../../utils/highlight-fences.js", () => ({
+  highlightCodeFences: () => ({
+    destroy() {},
+  }),
+}));
+
+describe("InsightsPage selected insight actions", () => {
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ui.activeModal = null;
+    ui.publishSecret = false;
+    ui.clearPublishTarget();
+    state.insightsStore.selectedItem = state.selectedInsight;
+    state.insightsStore.selectedId = state.selectedInsight.id;
+    state.insightsStore.items = [state.selectedInsight];
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = undefined;
+    }
+    document.body.innerHTML = "";
+  });
+
+  it("exports the selected insight", async () => {
+    component = mount(InsightsPage, { target: document.body });
+    await tick();
+
+    const exportButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.trim() === "Export");
+    expect(exportButton).toBeDefined();
+
+    exportButton!.click();
+    await tick();
+
+    expect(mocks.downloadInsightExport).toHaveBeenCalledWith(42);
+  });
+
+  it("opens the shared publish modal for the selected insight", async () => {
+    component = mount(InsightsPage, { target: document.body });
+    await tick();
+
+    const publishButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.trim() === "Publish");
+    expect(publishButton).toBeDefined();
+
+    publishButton!.click();
+    await tick();
+
+    expect(ui.activeModal).toBe("publish");
+    expect(ui.publishSecret).toBe(false);
+    expect(ui.publishTarget).toEqual({
+      kind: "insight",
+      id: 42,
+    });
+  });
+
+  it("can target a secret insight publish", async () => {
+    component = mount(InsightsPage, { target: document.body });
+    await tick();
+
+    const secretButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.trim() === "Secret");
+    expect(secretButton).toBeDefined();
+
+    secretButton!.click();
+    await tick();
+
+    expect(ui.activeModal).toBe("publish");
+    expect(ui.publishSecret).toBe(true);
+    expect(ui.publishTarget).toEqual({
+      kind: "insight",
+      id: 42,
+    });
   });
 });

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -112,6 +112,7 @@ describe("InsightsPage date yoke controls", () => {
 const mocks = vi.hoisted(() => ({
   downloadInsightExport: vi.fn().mockResolvedValue(undefined),
   deleteItem: vi.fn(),
+  loadAgents: vi.fn(),
   loadInsights: vi.fn(),
   loadProjects: vi.fn(),
 }));
@@ -173,7 +174,19 @@ vi.mock("../../stores/insights.svelte.js", () => ({
 
 vi.mock("../../stores/sessions.svelte.js", () => ({
   sessions: {
+    agents: [],
+    filters: {
+      project: "",
+      machine: "",
+      agent: "",
+      termination: "",
+      recentlyActive: false,
+      minUserMessages: 0,
+      includeOneShot: false,
+      includeAutomated: true,
+    },
     projects: [],
+    loadAgents: mocks.loadAgents,
     loadProjects: mocks.loadProjects,
   },
 }));
@@ -183,6 +196,16 @@ vi.mock("../../stores/sync.svelte.js", () => ({
     serverVersion: { read_only: false },
   },
 }));
+
+vi.mock("../../paraglide/messages.js", () => {
+  const stub = new Proxy({}, {
+    get(_target, prop) {
+      if (prop === "m") return stub;
+      return () => String(prop);
+    },
+  });
+  return stub;
+});
 
 vi.mock("../../utils/markdown.js", () => ({
   renderMarkdown: (content: string) => content,

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -115,6 +115,7 @@ const mocks = vi.hoisted(() => ({
   loadAgents: vi.fn(),
   loadInsights: vi.fn(),
   loadProjects: vi.fn(),
+  watchEvents: vi.fn(() => ({ close() {} })),
 }));
 
 const state = vi.hoisted(() => {
@@ -166,6 +167,7 @@ const state = vi.hoisted(() => {
 
 vi.mock("../../api/client.js", () => ({
   downloadInsightExport: mocks.downloadInsightExport,
+  watchEvents: mocks.watchEvents,
 }));
 
 vi.mock("../../stores/insights.svelte.js", () => ({

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -133,7 +133,10 @@
   }
 
   function openPublish(secret: boolean) {
+    const id = sessions.activeSessionId;
+    if (!id) return;
     ui.publishSecret = secret;
+    ui.setPublishTarget({ kind: "session", id });
     ui.activeModal = "publish";
     showPublishMenu = false;
     showOverflow = false;

--- a/frontend/src/lib/components/modals/PublishModal.svelte
+++ b/frontend/src/lib/components/modals/PublishModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import { m } from "../../i18n/index.js";
   import { ui } from "../../stores/ui.svelte.js";
   import { sessions } from "../../stores/sessions.svelte.js";
@@ -17,17 +18,28 @@
   let tokenInput: string = $state("");
   let errorMessage: string = $state("");
   let result: PublishResponse | null = $state(null);
+  let closed = false;
 
-  function publishTargetLabel() {
-    return ui.publishTarget?.kind === "insight"
-      ? "insight"
-      : "session";
+  const target = ui.publishTarget ??
+    (sessions.activeSessionId
+      ? { kind: "session" as const, id: sessions.activeSessionId }
+      : null);
+  const publishSecret = ui.publishSecret;
+
+  function isClosed() {
+    return closed || ui.activeModal !== "publish";
+  }
+
+  function closeModal() {
+    closed = true;
+    ui.activeModal = null;
   }
 
   async function init() {
     try {
       configureGeneratedClient();
       const config = await ConfigService.getApiV1ConfigGithub();
+      if (isClosed()) return;
       if (config.configured) {
         await doPublish();
       } else {
@@ -48,8 +60,10 @@
       await ConfigService.postApiV1ConfigGithub({
         requestBody: { token },
       });
+      if (isClosed()) return;
       await doPublish();
     } catch (err) {
+      if (isClosed()) return;
       errorMessage =
         err instanceof Error ? err.message : "Failed to save token";
       view = "error";
@@ -57,29 +71,30 @@
   }
 
   async function doPublish() {
-    const target = ui.publishTarget;
-    if (target?.kind === "insight") {
+    if (isClosed()) return;
+    if (!target) {
+      errorMessage = "No session selected";
+      view = "error";
+      return;
+    }
+
+    if (target.kind === "insight") {
       view = "progress";
       try {
         configureGeneratedClient();
         result =
           await InsightsService.postApiV1InsightsIdPublish({
             id: target.id,
-            secret: ui.publishSecret,
+            secret: publishSecret,
           }) as unknown as PublishResponse;
+        if (isClosed()) return;
         view = "success";
       } catch (err) {
+        if (isClosed()) return;
         errorMessage =
           err instanceof Error ? err.message : "Publish failed";
         view = "error";
       }
-      return;
-    }
-
-    const sessionId = sessions.activeSessionId;
-    if (!sessionId) {
-      errorMessage = "No session selected";
-      view = "error";
       return;
     }
 
@@ -88,11 +103,13 @@
       configureGeneratedClient();
       result =
         await SessionsService.postApiV1SessionsIdPublish({
-          id: sessionId,
-          secret: ui.publishSecret,
+          id: target.id,
+          secret: publishSecret,
         }) as unknown as PublishResponse;
+      if (isClosed()) return;
       view = "success";
     } catch (err) {
+      if (isClosed()) return;
       errorMessage =
         err instanceof Error ? err.message : "Publish failed";
       view = "error";
@@ -109,9 +126,13 @@
         "modal-overlay",
       )
     ) {
-      ui.activeModal = null;
+      closeModal();
     }
   }
+
+  onDestroy(() => {
+    closed = true;
+  });
 
   init();
 </script>
@@ -121,17 +142,17 @@
   class="modal-overlay"
   onclick={handleOverlayClick}
   onkeydown={(e) => {
-    if (e.key === "Escape") ui.activeModal = null;
+    if (e.key === "Escape") closeModal();
   }}
 >
   <div class="modal-panel publish-panel">
     <div class="modal-header">
       <h3 class="modal-title">
-        {ui.publishSecret ? m.publish_title_secret() : m.publish_title_public()}
+        {publishSecret ? m.publish_title_secret() : m.publish_title_public()}
       </h3>
       <button
         class="modal-close"
-        onclick={() => ui.activeModal = null}
+        onclick={closeModal}
         title={m.publish_close()}
         aria-label={m.publish_close()}
       >
@@ -175,7 +196,7 @@
         <div class="progress-view">
           <div class="modal-spinner"></div>
           <p>
-            {ui.publishSecret ? m.publish_creating_secret() : m.publish_creating_public()}
+            {publishSecret ? m.publish_creating_secret() : m.publish_creating_public()}
           </p>
         </div>
 
@@ -230,7 +251,7 @@
             </button>
             <button
               class="modal-btn"
-              onclick={() => ui.activeModal = null}
+              onclick={closeModal}
             >
               {m.publish_close_btn()}
             </button>
@@ -249,7 +270,7 @@
             </button>
             <button
               class="modal-btn"
-              onclick={() => ui.activeModal = null}
+              onclick={closeModal}
             >
               {m.publish_close_btn()}
             </button>

--- a/frontend/src/lib/components/modals/PublishModal.svelte
+++ b/frontend/src/lib/components/modals/PublishModal.svelte
@@ -4,6 +4,7 @@
   import { sessions } from "../../stores/sessions.svelte.js";
   import {
     ConfigService,
+    InsightsService,
     SessionsService,
   } from "../../api/generated/index";
   import { configureGeneratedClient } from "../../api/runtime.js";
@@ -16,6 +17,12 @@
   let tokenInput: string = $state("");
   let errorMessage: string = $state("");
   let result: PublishResponse | null = $state(null);
+
+  function publishTargetLabel() {
+    return ui.publishTarget?.kind === "insight"
+      ? "insight"
+      : "session";
+  }
 
   async function init() {
     try {
@@ -50,8 +57,27 @@
   }
 
   async function doPublish() {
-    const id = sessions.activeSessionId;
-    if (!id) {
+    const target = ui.publishTarget;
+    if (target?.kind === "insight") {
+      view = "progress";
+      try {
+        configureGeneratedClient();
+        result =
+          await InsightsService.postApiV1InsightsIdPublish({
+            id: target.id,
+            secret: ui.publishSecret,
+          }) as unknown as PublishResponse;
+        view = "success";
+      } catch (err) {
+        errorMessage =
+          err instanceof Error ? err.message : "Publish failed";
+        view = "error";
+      }
+      return;
+    }
+
+    const sessionId = sessions.activeSessionId;
+    if (!sessionId) {
       errorMessage = "No session selected";
       view = "error";
       return;
@@ -62,7 +88,7 @@
       configureGeneratedClient();
       result =
         await SessionsService.postApiV1SessionsIdPublish({
-          id,
+          id: sessionId,
           secret: ui.publishSecret,
         }) as unknown as PublishResponse;
       view = "success";

--- a/frontend/src/lib/components/modals/PublishModal.test.ts
+++ b/frontend/src/lib/components/modals/PublishModal.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { mount, tick, unmount } from "svelte";
+import { ui } from "../../stores/ui.svelte.js";
+// @ts-ignore
+import PublishModal from "./PublishModal.svelte";
+
+const services = vi.hoisted(() => {
+  type Config = { configured: boolean };
+  const state = {
+    resolveConfig: (_config: Config) => {},
+    configPromise: Promise.resolve({ configured: true }),
+    configureGeneratedClient: vi.fn(),
+    getApiV1ConfigGithub: vi.fn(),
+    postApiV1ConfigGithub: vi.fn(),
+    postApiV1InsightsIdPublish: vi.fn(),
+    postApiV1SessionsIdPublish: vi.fn(),
+  };
+
+  function deferConfig() {
+    state.configPromise = new Promise<Config>((resolve) => {
+      state.resolveConfig = resolve;
+    });
+    state.getApiV1ConfigGithub.mockImplementation(
+      () => state.configPromise,
+    );
+  }
+
+  return {
+    configureGeneratedClient: state.configureGeneratedClient,
+    getApiV1ConfigGithub: state.getApiV1ConfigGithub,
+    postApiV1ConfigGithub: state.postApiV1ConfigGithub,
+    postApiV1InsightsIdPublish:
+      state.postApiV1InsightsIdPublish,
+    postApiV1SessionsIdPublish:
+      state.postApiV1SessionsIdPublish,
+    resolveConfig(config: Config) {
+      state.resolveConfig(config);
+    },
+    deferConfig,
+  };
+});
+
+const sessionState = vi.hoisted(() => ({
+  sessions: {
+    activeSessionId: "session-123",
+  },
+}));
+
+vi.mock("../../api/runtime.js", () => ({
+  configureGeneratedClient: services.configureGeneratedClient,
+}));
+
+vi.mock("../../api/generated/index", () => ({
+  ConfigService: {
+    getApiV1ConfigGithub: services.getApiV1ConfigGithub,
+    postApiV1ConfigGithub: services.postApiV1ConfigGithub,
+  },
+  InsightsService: {
+    postApiV1InsightsIdPublish:
+      services.postApiV1InsightsIdPublish,
+  },
+  SessionsService: {
+    postApiV1SessionsIdPublish:
+      services.postApiV1SessionsIdPublish,
+  },
+}));
+
+vi.mock("../../stores/sessions.svelte.js", () => ({
+  sessions: sessionState.sessions,
+}));
+
+async function flushAsync() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await tick();
+}
+
+describe("PublishModal", () => {
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    services.configureGeneratedClient.mockClear();
+    services.getApiV1ConfigGithub.mockClear();
+    services.postApiV1ConfigGithub.mockReset();
+    services.postApiV1ConfigGithub.mockResolvedValue({});
+    services.postApiV1InsightsIdPublish.mockReset();
+    services.postApiV1InsightsIdPublish.mockResolvedValue({
+      gist_url: "https://gist.github.com/insight",
+      view_url: "https://gist.github.com/insight/view",
+    });
+    services.postApiV1SessionsIdPublish.mockReset();
+    services.postApiV1SessionsIdPublish.mockResolvedValue({
+      gist_url: "https://gist.github.com/session",
+      view_url: "https://gist.github.com/session/view",
+    });
+    services.deferConfig();
+    sessionState.sessions.activeSessionId = "session-123";
+    ui.activeModal = null;
+    ui.clearPublishTarget();
+    ui.publishSecret = false;
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = undefined;
+    }
+    ui.activeModal = null;
+    ui.clearPublishTarget();
+    ui.publishSecret = false;
+    document.body.innerHTML = "";
+  });
+
+  it("does not publish the active session after an insight publish closes during setup", async () => {
+    ui.setPublishTarget({ kind: "insight", id: 42 });
+    ui.publishSecret = true;
+    ui.activeModal = "publish";
+
+    component = mount(PublishModal, { target: document.body });
+    await tick();
+    expect(services.getApiV1ConfigGithub).toHaveBeenCalledTimes(1);
+
+    ui.activeModal = null;
+    await tick();
+    unmount(component);
+    component = undefined;
+
+    services.resolveConfig({ configured: true });
+    await flushAsync();
+
+    expect(
+      services.postApiV1InsightsIdPublish,
+    ).not.toHaveBeenCalled();
+    expect(
+      services.postApiV1SessionsIdPublish,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -8,7 +8,6 @@ type Theme = "light" | "dark";
 export type MessageLayout = "default" | "compact" | "stream" | "skim";
 export type TranscriptMode = "normal" | "focused";
 export type PublishTarget =
-  | { kind: "session"; id: string }
   | { kind: "insight"; id: number }
   | null;
 type ModalType =

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -8,6 +8,7 @@ type Theme = "light" | "dark";
 export type MessageLayout = "default" | "compact" | "stream" | "skim";
 export type TranscriptMode = "normal" | "focused";
 export type PublishTarget =
+  | { kind: "session"; id: string }
   | { kind: "insight"; id: number }
   | null;
 type ModalType =

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -7,6 +7,10 @@ import {
 type Theme = "light" | "dark";
 export type MessageLayout = "default" | "compact" | "stream" | "skim";
 export type TranscriptMode = "normal" | "focused";
+export type PublishTarget =
+  | { kind: "session"; id: string }
+  | { kind: "insight"; id: number }
+  | null;
 type ModalType =
   | "about"
   | "commandPalette"
@@ -224,6 +228,7 @@ class UIStore {
   activeModal: ModalType = $state(null);
   /** Whether the next gist publish should be secret instead of public. */
   publishSecret: boolean = $state(false);
+  publishTarget: PublishTarget = $state(null);
   selectedOrdinal: number | null = $state(null);
   pendingScrollOrdinal: number | null = $state(null);
   pendingScrollSession: string | null = $state(null);
@@ -389,6 +394,12 @@ class UIStore {
         }
       });
 
+      $effect(() => {
+        if (this.activeModal !== "publish") {
+          this.publishTarget = null;
+        }
+      });
+
       // Initialize sidebar based on viewport width
       if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
         const mq = window.matchMedia("(min-width: 768px)");
@@ -494,6 +505,14 @@ class UIStore {
 
   setSidebarWidth(width: number) {
     this.sidebarWidth = clampStoredSidebarWidth(width);
+  }
+
+  setPublishTarget(target: Exclude<PublishTarget, null>) {
+    this.publishTarget = target;
+  }
+
+  clearPublishTarget() {
+    this.publishTarget = null;
   }
 
   selectOrdinal(ordinal: number) {

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -17,6 +17,8 @@ import { ui } from "./ui.svelte.js";
 describe("UIStore", () => {
   beforeEach(() => {
     ui.activeModal = null;
+    ui.clearPublishTarget();
+    ui.publishSecret = false;
     ui.selectedOrdinal = null;
     ui.pendingScrollOrdinal = null;
     ui.followLatest = false;
@@ -42,6 +44,31 @@ describe("UIStore", () => {
 
       ui.activeModal = "publish";
       expect(ui.activeModal).toBe("publish");
+    });
+  });
+
+  describe("publishTarget", () => {
+    it("defaults to null", () => {
+      expect(ui.publishTarget).toBeNull();
+    });
+
+    it("stores the selected publish target", () => {
+      ui.setPublishTarget({ kind: "insight", id: 42 });
+      expect(ui.publishTarget).toEqual({
+        kind: "insight",
+        id: 42,
+      });
+    });
+
+    it("clears the publish target when publish modal closes", async () => {
+      ui.setPublishTarget({ kind: "insight", id: 42 });
+      ui.activeModal = "publish";
+      await tick();
+
+      ui.activeModal = null;
+      await tick();
+
+      expect(ui.publishTarget).toBeNull();
     });
   });
 

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -60,6 +60,14 @@ describe("UIStore", () => {
       });
     });
 
+    it("stores a selected session publish target", () => {
+      ui.setPublishTarget({ kind: "session", id: "sess-123" });
+      expect(ui.publishTarget).toEqual({
+        kind: "session",
+        id: "sess-123",
+      });
+    });
+
     it("clears the publish target when publish modal closes", async () => {
       ui.setPublishTarget({ kind: "insight", id: 42 });
       ui.activeModal = "publish";

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -107,6 +107,21 @@ describe("registerShortcuts", () => {
     });
   });
 
+  describe("Publish shortcut", () => {
+    it("opens publish modal with the active session target", () => {
+      sessions.activeSessionId = "sess-123";
+
+      fireKey("p");
+
+      expect(ui.activeModal).toBe("publish");
+      expect(ui.publishSecret).toBe(false);
+      expect(ui.publishTarget).toEqual({
+        kind: "session",
+        id: "sess-123",
+      });
+    });
+  });
+
   describe("modal blocks other shortcuts", () => {
     it("should block navigation when modal is open", () => {
       ui.activeModal = "commandPalette";

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -174,8 +174,10 @@ export function registerShortcuts(
         }
       },
       p: () => {
-        if (sessions.activeSessionId) {
+        const id = sessions.activeSessionId;
+        if (id) {
           ui.publishSecret = false;
+          ui.setPublishTarget({ kind: "session", id });
           ui.activeModal = "publish";
         }
       },

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -158,8 +158,22 @@ type exportMessage struct {
 	FocusedHidden bool
 }
 
+type insightExportData struct {
+	Title       string
+	Type        string
+	Project     string
+	DateRange   string
+	Agent       string
+	Model       string
+	CreatedAt   string
+	ContentHTML template.HTML
+}
+
 var exportTmpl = template.Must(
 	template.New("export").Parse(exportTemplateStr))
+
+var insightExportTmpl = template.Must(
+	template.New("insight-export").Parse(insightExportTemplateStr))
 
 const exportTemplateStr = `<!DOCTYPE html>
 <html lang="en">
@@ -419,16 +433,173 @@ footer a:hover { text-decoration: underline; }
 <footer>Exported from <a href="https://github.com/kenn-io/agentsview">agentsview</a></footer>
 </body></html>`
 
+const insightExportTemplateStr = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{.Title}}</title>
+<style>
+:root {
+  --bg-primary: #f7f7fa;
+  --bg-surface: #ffffff;
+  --bg-inset: #edeef3;
+  --border-default: #dfe1e8;
+  --border-muted: #e8eaf0;
+  --text-primary: #1a1d26;
+  --text-secondary: #5a6070;
+  --text-muted: #8b92a0;
+  --accent-blue: #2563eb;
+  --accent-purple: #7c3aed;
+  --accent-amber: #d97706;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Noto Sans", Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", "Fira Code",
+    "Fira Mono", Menlo, Consolas, monospace;
+  color-scheme: light;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+main {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+}
+header {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 20px 24px;
+  margin-bottom: 20px;
+}
+h1 {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.chip {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--bg-inset);
+}
+.content {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content p,
+.content ul,
+.content ol,
+.content blockquote,
+.content pre {
+  margin-bottom: 12px;
+}
+.content code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-sm);
+  padding: 0.15em 0.4em;
+}
+.content pre {
+  background: #1e1e2e;
+  color: #cdd6f4;
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  overflow-x: auto;
+}
+.content pre code {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+}
+.thinking-block {
+  border-left: 2px solid var(--accent-purple);
+  background: #f5f3ff;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  padding: 8px 14px 12px;
+  margin: 8px 0;
+  font-style: italic;
+  color: var(--text-secondary);
+}
+.thinking-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-purple);
+  margin-bottom: 4px;
+  font-style: normal;
+}
+.tool-block {
+  border-left: 2px solid var(--accent-amber);
+  background: #fffbf0;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  padding: 6px 10px;
+  margin: 8px 0;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+footer {
+  max-width: 860px;
+  margin: 0 auto 32px;
+  padding: 0 20px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+footer a {
+  color: var(--accent-blue);
+  text-decoration: none;
+}
+</style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>{{.Title}}</h1>
+    <div class="meta">
+      <span class="chip">{{.Type}}</span>
+      <span class="chip">{{.Project}}</span>
+      <span class="chip">{{.DateRange}}</span>
+      <span class="chip">{{.Agent}}</span>
+      {{if .Model}}<span class="chip">{{.Model}}</span>{{end}}
+      {{if .CreatedAt}}<span class="chip">{{.CreatedAt}}</span>{{end}}
+    </div>
+  </header>
+  <article class="content">{{.ContentHTML}}</article>
+</main>
+<footer>Exported from <a href="https://github.com/kenn-io/agentsview">agentsview</a></footer>
+</body>
+</html>`
+
 func generateExportHTML(
 	session *db.Session, msgs []db.Message,
 ) string {
-	agentDisplay := string(session.Agent)
-	if def, ok := parser.AgentByType(
-		parser.AgentType(session.Agent),
-	); ok {
-		agentDisplay = def.DisplayName
-	}
-
 	startedAt := ""
 	if session.StartedAt != nil {
 		startedAt = formatTimestamp(*session.StartedAt)
@@ -436,7 +607,7 @@ func generateExportHTML(
 
 	data := exportData{
 		Project:      session.Project,
-		Agent:        agentDisplay,
+		Agent:        agentDisplayName(session.Agent),
 		MessageCount: session.MessageCount,
 		StartedAt:    startedAt,
 		Messages:     make([]exportMessage, len(msgs)),
@@ -469,6 +640,32 @@ func generateExportHTML(
 		return fmt.Sprintf("template error: %s", err)
 	}
 	return b.String()
+}
+
+func generateInsightExportHTML(insight *db.Insight) string {
+	data := insightExportData{
+		Title:       insightExportTitle(insight),
+		Type:        insightTypeLabel(insight.Type),
+		Project:     insightProjectLabel(insight.Project),
+		DateRange:   insightDateRangeLabel(insight.DateFrom, insight.DateTo),
+		Agent:       agentDisplayName(insight.Agent),
+		Model:       strings.TrimSpace(derefString(insight.Model)),
+		CreatedAt:   formatTimestamp(insight.CreatedAt),
+		ContentHTML: template.HTML(formatContentForExport(insight.Content)),
+	}
+
+	var b strings.Builder
+	if err := insightExportTmpl.Execute(&b, data); err != nil {
+		return fmt.Sprintf("template error: %s", err)
+	}
+	return b.String()
+}
+
+func agentDisplayName(agent string) string {
+	if def, ok := parser.AgentByType(parser.AgentType(agent)); ok {
+		return def.DisplayName
+	}
+	return agent
 }
 
 var (
@@ -609,6 +806,101 @@ func formatDateShort(ts *string) string {
 func sanitizeFilename(name string) string {
 	re := regexp.MustCompile(`[^\w.\-]`)
 	return re.ReplaceAllString(name, "_")
+}
+
+func insightExportStem(insight *db.Insight) string {
+	dateRange := strings.ReplaceAll(insight.DateFrom, "-", "")
+	if insight.DateTo != "" && insight.DateTo != insight.DateFrom {
+		dateRange += "-" + strings.ReplaceAll(insight.DateTo, "-", "")
+	}
+	return sanitizeFilename(fmt.Sprintf(
+		"insight-%s-%s-%s",
+		insight.Type,
+		insightProjectLabel(insight.Project),
+		dateRange,
+	))
+}
+
+func insightExportHTMLFilename(insight *db.Insight) string {
+	return insightExportStem(insight) + ".html"
+}
+
+func insightExportMarkdownFilename(insight *db.Insight) string {
+	return insightExportStem(insight) + ".md"
+}
+
+func insightExportTitle(insight *db.Insight) string {
+	return fmt.Sprintf(
+		"%s Insight",
+		insightTypeLabel(insight.Type),
+	)
+}
+
+func insightPublishDescription(insight *db.Insight) string {
+	return fmt.Sprintf(
+		"Insight: %s - %s - %s",
+		insightTypeLabel(insight.Type),
+		insightProjectLabel(insight.Project),
+		insightDateRangeLabel(insight.DateFrom, insight.DateTo),
+	)
+}
+
+func insightTypeLabel(insightType string) string {
+	switch insightType {
+	case "daily_activity":
+		return "Daily Activity"
+	case "agent_analysis":
+		return "Agent Analysis"
+	default:
+		return strings.ReplaceAll(insightType, "_", " ")
+	}
+}
+
+func insightProjectLabel(project *string) string {
+	value := strings.TrimSpace(derefString(project))
+	if value == "" {
+		return "global"
+	}
+	return value
+}
+
+func insightDateRangeLabel(dateFrom, dateTo string) string {
+	if dateTo == "" || dateTo == dateFrom {
+		return dateFrom
+	}
+	return dateFrom + " to " + dateTo
+}
+
+func publishExportHTML(
+	ctx context.Context,
+	token, filename, description, htmlContent string,
+	public bool,
+) (*publishResponse, error) {
+	gist, err := createGist(ctx, token, filename, description, htmlContent, public)
+	if err != nil {
+		return nil, err
+	}
+	if gist.ID == "" || gist.HTMLURL == "" {
+		return nil, fmt.Errorf("GitHub API returned incomplete gist data")
+	}
+	encoded := urlPathEscape(filename)
+	rawURL := fmt.Sprintf(
+		"https://gist.githubusercontent.com/%s/%s/raw/%s",
+		gist.Owner.Login, gist.ID, encoded,
+	)
+	return &publishResponse{
+		GistID:  gist.ID,
+		GistURL: gist.HTMLURL,
+		ViewURL: "https://htmlpreview.github.io/?" + rawURL,
+		RawURL:  rawURL,
+	}, nil
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
 
 func truncateStr(s string, max int) string {

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -21,6 +21,9 @@ func (s *Server) registerInsightsRoutes() {
 
 	get(s, group, "", "List insights", s.humaListInsights)
 	get(s, group, "/{id}", "Get insight", s.humaGetInsight)
+	raw(s, group, http.MethodGet, "/{id}/export", "Export insight as HTML", s.humaExportInsight)
+	raw(s, group, http.MethodGet, "/{id}/md", "Export insight as Markdown", s.humaMarkdownInsight)
+	post(s, group, "/{id}/publish", "Publish insight", s.humaPublishInsight)
 	deleteRoute(s, group, "/{id}", "Delete insight", s.humaDeleteInsight)
 	stream(s, group, http.MethodPost, "/generate", "Generate insight", s.humaGenerateInsight)
 }
@@ -40,6 +43,11 @@ type insightsResponse struct {
 
 type generateInsightInput struct {
 	Body generateInsightRequest
+}
+
+type publishInsightInput struct {
+	ID     int64 `path:"id" required:"true" doc:"Insight ID"`
+	Secret bool  `query:"secret" doc:"Create a secret gist instead of a public one"`
 }
 
 func (s *Server) humaListInsights(
@@ -80,16 +88,82 @@ func (s *Server) humaGetInsight(
 	return &jsonOutput[*db.Insight]{Body: result}, nil
 }
 
+func (s *Server) insightByID(
+	ctx context.Context,
+	id int64,
+) (*db.Insight, error) {
+	result, err := s.db.GetInsight(ctx, id)
+	if err != nil {
+		return nil, serverError(err)
+	}
+	if result == nil {
+		return nil, apiError(http.StatusNotFound, "insight not found")
+	}
+	return result, nil
+}
+
+func (s *Server) humaExportInsight(
+	ctx context.Context,
+	in *intIDPathInput,
+) (*bytesOutput, error) {
+	insight, err := s.insightByID(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &bytesOutput{
+		ContentType:        "text/html; charset=utf-8",
+		ContentDisposition: fmt.Sprintf(`attachment; filename="%s"`, insightExportHTMLFilename(insight)),
+		Body:               []byte(generateInsightExportHTML(insight)),
+	}, nil
+}
+
+func (s *Server) humaMarkdownInsight(
+	ctx context.Context,
+	in *intIDPathInput,
+) (*bytesOutput, error) {
+	insight, err := s.insightByID(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &bytesOutput{
+		ContentType:        "text/markdown; charset=utf-8",
+		ContentDisposition: fmt.Sprintf(`inline; filename="%s"`, insightExportMarkdownFilename(insight)),
+		Body:               []byte(insight.Content),
+	}, nil
+}
+
+func (s *Server) humaPublishInsight(
+	ctx context.Context,
+	in *publishInsightInput,
+) (*jsonOutput[publishResponse], error) {
+	token := s.githubToken()
+	if token == "" {
+		return nil, apiError(http.StatusUnauthorized, "GitHub token not configured")
+	}
+	insight, err := s.insightByID(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := publishExportHTML(
+		ctx,
+		token,
+		insightExportHTMLFilename(insight),
+		insightPublishDescription(insight),
+		generateInsightExportHTML(insight),
+		!in.Secret,
+	)
+	if err != nil {
+		return nil, apiError(http.StatusBadGateway, err.Error())
+	}
+	return &jsonOutput[publishResponse]{Body: *resp}, nil
+}
+
 func (s *Server) humaDeleteInsight(
 	ctx context.Context,
 	in *intIDPathInput,
 ) (*noContentOutput, error) {
-	existing, err := s.db.GetInsight(ctx, in.ID)
-	if err != nil {
-		return nil, serverError(err)
-	}
-	if existing == nil {
-		return nil, apiError(http.StatusNotFound, "insight not found")
+	if _, err := s.insightByID(ctx, in.ID); err != nil {
+		return nil, err
 	}
 	if err := s.db.DeleteInsight(in.ID); err != nil {
 		if handled := handleHumaReadOnly(err); handled != nil {

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -34,6 +34,14 @@ type failFirstWriteRecorder struct {
 	flushed bool
 }
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(
+	req *http.Request,
+) (*http.Response, error) {
+	return f(req)
+}
+
 func newFailFirstWriteRecorder() *failFirstWriteRecorder {
 	return &failFirstWriteRecorder{
 		header: make(http.Header),
@@ -165,6 +173,124 @@ func TestGetInsight_Found(t *testing.T) {
 	r := decode[db.Insight](t, w)
 	require.Equal(t, id, r.ID)
 	assert.Equal(t, "daily_activity", r.Type)
+}
+
+func TestInsightExportHTML(t *testing.T) {
+	te := setup(t)
+	id := te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"),
+		func(insight *db.Insight) {
+			insight.Content = "# Insight\n\n- published finding"
+		},
+	)
+
+	w := te.get(t, fmt.Sprintf("/api/v1/insights/%d/export", id))
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/html")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".html")
+	assertBodyContains(t, w, "Daily Activity Insight")
+	assertBodyContains(t, w, "# Insight")
+	assertBodyContains(t, w, "my-app")
+}
+
+func TestInsightMarkdownExport(t *testing.T) {
+	te := setup(t)
+	content := "# Insight\n\n- stored markdown"
+	id := te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"),
+		func(insight *db.Insight) {
+			insight.Content = content
+		},
+	)
+
+	w := te.get(t, fmt.Sprintf("/api/v1/insights/%d/md", id))
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/markdown")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "inline")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".md")
+	assert.Equal(t, content, w.Body.String())
+}
+
+func TestInsightPublish(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		te := setup(t)
+		te.srv.SetGithubToken("fake-token")
+		id := te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"),
+			func(insight *db.Insight) {
+				insight.Content = "# Insight\n\n- publish me"
+			},
+		)
+
+		originalTransport := http.DefaultTransport
+		http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, http.MethodPost, req.Method)
+			require.Equal(t, "https://api.github.com/gists", req.URL.String())
+			require.Equal(t, "token fake-token", req.Header.Get("Authorization"))
+
+			var payload struct {
+				Description string `json:"description"`
+				Public      bool   `json:"public"`
+				Files       map[string]struct {
+					Content string `json:"content"`
+				} `json:"files"`
+			}
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.Equal(t, "Insight: Daily Activity - my-app - 2025-01-15", payload.Description)
+			assert.False(t, payload.Public)
+			require.Contains(t, payload.Files, "insight-daily_activity-my-app-20250115.html")
+			assert.Contains(t,
+				payload.Files["insight-daily_activity-my-app-20250115.html"].Content,
+				"Daily Activity Insight",
+			)
+			assert.Contains(t,
+				payload.Files["insight-daily_activity-my-app-20250115.html"].Content,
+				"# Insight",
+			)
+
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"gist123","html_url":"https://gist.github.com/octocat/gist123","owner":{"login":"octocat"}}`,
+				)),
+			}, nil
+		})
+		t.Cleanup(func() {
+			http.DefaultTransport = originalTransport
+		})
+
+		w := te.post(t, fmt.Sprintf("/api/v1/insights/%d/publish?secret=true", id), "{}")
+		assertStatus(t, w, http.StatusOK)
+
+		resp := decode[map[string]string](t, w)
+		assert.Equal(t, "gist123", resp["gist_id"])
+		assert.Equal(t, "https://gist.github.com/octocat/gist123", resp["gist_url"])
+		assert.Equal(t,
+			"https://gist.githubusercontent.com/octocat/gist123/raw/insight-daily_activity-my-app-20250115.html",
+			resp["raw_url"],
+		)
+		assert.Equal(t,
+			"https://htmlpreview.github.io/?https://gist.githubusercontent.com/octocat/gist123/raw/insight-daily_activity-my-app-20250115.html",
+			resp["view_url"],
+		)
+	})
+
+	t.Run("NoToken", func(t *testing.T) {
+		te := setup(t)
+		id := te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"))
+
+		w := te.post(t, fmt.Sprintf("/api/v1/insights/%d/publish", id), "{}")
+		assertStatus(t, w, http.StatusUnauthorized)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		te := setup(t)
+		te.srv.SetGithubToken("fake-token")
+
+		w := te.post(t, "/api/v1/insights/99999/publish", "{}")
+		assertStatus(t, w, http.StatusNotFound)
+	})
 }
 
 func TestGenerateInsight_Validation(t *testing.T) {
@@ -1576,16 +1702,21 @@ func (te *testEnv) seedInsight(
 	t *testing.T,
 	typ, date string,
 	project *string,
+	opts ...func(*db.Insight),
 ) int64 {
 	t.Helper()
-	id, err := te.db.InsertInsight(db.Insight{
+	insight := db.Insight{
 		Type:     typ,
 		DateFrom: date,
 		DateTo:   date,
 		Project:  project,
 		Agent:    "claude",
 		Content:  "Test insight content",
-	})
+	}
+	for _, opt := range opts {
+		opt(&insight)
+	}
+	id, err := te.db.InsertInsight(insight)
 	require.NoError(t, err)
 	return id
 }


### PR DESCRIPTION
Insights can be generated and reviewed today, but they still stop at a dead end once selected. The insight API only exposes list, get, delete, and generate, and the selected insight pane only shows metadata plus delete, so there is no built-in way to export an insight or publish it the way sessions already can.

This change adds the per-insight surface that sessions already have: HTML export, markdown export, and GitHub Gist publish for a single selected insight. The backend should reuse the existing export and gist helpers so token handling, public versus secret publish behavior, error mapping, and filename sanitization stay consistent, and the frontend should extend the current export helpers and shared publish modal instead of forking a second publish flow. Scope stays intentionally narrow to a selected insight, with no bulk export, CLI work, MCP exposure, or docs-only follow-up folded into the patch.

Reviewers should focus on the shared export and publish plumbing, especially that the new routes stay aligned with the existing session behavior and that the shared publish modal still behaves correctly when opened from both sessions and insights. Focused server coverage for the new routes and focused frontend coverage for the detail-pane actions and publish-target state should be enough here, and CI can carry the broader matrix.

Fixes #67
