### PR TITLE
feat(parser): record Antigravity producing-version from schema fingerprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         run: go run ./internal/pricing/cmd/litellm-snapshot -restore
 
       - name: Run Go tests
-        run: go test -tags "fts5" ./... -v -count=1
+        run: go test -tags "fts5" ./... -v -count=1 -timeout=20m
         env:
           CGO_ENABLED: "1"
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from "@playwright/test";
 
+const isCI = process.env.CI === "true";
+
 export default defineConfig({
   testDir: "e2e",
-  timeout: 20_000,
+  timeout: isCI ? 45_000 : 20_000,
   retries: 0,
   use: {
     baseURL: "http://127.0.0.1:8090",

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -241,6 +241,10 @@ import (
 // classification, so historical skill usage is backfilled on
 // re-parse.)
 //
+// (54: Antigravity .db sessions record a schema-fingerprint
+// source_version. Re-parsing populates source_version on existing
+// Antigravity IDE and CLI rows so "which agy release produced this
+// session" is queryable instead of blank.)
 // (53: Recent Edits tool-call file_path extraction. Re-parsing
 // populates tool_calls.file_path for edit/write calls -- including
 // Kiro raw-diff inputs the JSON-only SQL backfill cannot recover --
@@ -250,7 +254,7 @@ import (
 // (51: Gemini cumulative-to-delta token reparse.)
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 53
+const dataVersion = 54
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -696,8 +696,8 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionSanitizedMessageShape(t *testing.T) {
-	assert.Equal(t, 53, CurrentDataVersion(),
-		"Recent Edits tool-call file_path extraction requires a data version bump")
+	assert.Equal(t, 54, CurrentDataVersion(),
+		"Antigravity source_version backfill requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -129,6 +129,11 @@ func ParseAntigravitySession(
 	}
 	defer db.Close()
 
+	// Schema-fingerprint label for the producing agy build. Computed from
+	// the open DB so IDE and CLI classify identically; empty when the
+	// schema cannot be read.
+	sourceVersion := antigravitySourceVersion(db)
+
 	messages, usageEvents, err := loadAntigravitySteps(db)
 	if err != nil {
 		return nil, nil, nil, err
@@ -200,6 +205,7 @@ func ParseAntigravitySession(
 		EndedAt:          endedAt,
 		MessageCount:     len(messages),
 		UserMessageCount: userCount,
+		SourceVersion:    sourceVersion,
 		File: FileInfo{
 			Path:  path,
 			Size:  size,
@@ -232,6 +238,11 @@ type antigravityStepLoadResult struct {
 	messages     []ParsedMessage
 	usageEvents  []ParsedUsageEvent
 	rawStepCount int
+	// sourceVersion is the schema-fingerprint label of the .db, set by the
+	// CLI loader while the DB is open. The IDE path computes it directly
+	// from its own handle via antigravitySourceVersion, so both classify
+	// identically.
+	sourceVersion string
 }
 
 type antigravityStepKind int

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -192,8 +192,13 @@ func ParseAntigravityCLISessionWithStatus(
 	var messages []ParsedMessage
 	var usageEvents []ParsedUsageEvent
 	var hasTrajectory bool
+	// sourceVersion is the schema-fingerprint label of the .db source; it
+	// stays empty for legacy .pb and sidecar-only sessions where no schema
+	// is available, so SourceVersion is never fabricated.
+	var sourceVersion string
 	if ext == ".db" {
 		dbResult, dbErr := loadAntigravityCLIDBSteps(path)
+		sourceVersion = dbResult.sourceVersion
 		// gen_metadata token usage describes the session's actual
 		// consumption no matter which transcript source wins below.
 		// The sidecar also extracts generatorMetadata usage, but
@@ -364,6 +369,7 @@ func ParseAntigravityCLISessionWithStatus(
 		EndedAt:          endedAt,
 		MessageCount:     len(messages),
 		UserMessageCount: userCount,
+		SourceVersion:    sourceVersion,
 		File: FileInfo{
 			Path:  path,
 			Size:  size,
@@ -395,7 +401,14 @@ func loadAntigravityCLIDBSteps(
 		)
 	}
 	defer db.Close()
-	return loadAntigravityStepsWithRawCount(db)
+	result, err := loadAntigravityStepsWithRawCount(db)
+	if err != nil {
+		return result, err
+	}
+	// Schema-fingerprint label for the producing agy build, derived from the
+	// same shared helper the IDE path uses so both classify identically.
+	result.sourceVersion = antigravitySourceVersion(db)
+	return result, nil
 }
 
 func mergeAntigravityDBHistoryMessages(

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -401,13 +401,18 @@ func loadAntigravityCLIDBSteps(
 		)
 	}
 	defer db.Close()
+	// Schema-fingerprint label for the producing agy build, derived from the
+	// same shared helper the IDE path uses so both classify identically.
+	// Computed before step loading so a readable schema still carries the
+	// agy-schema marker even when the step query fails and the parser falls
+	// back to the trajectory sidecar (antigravitySourceVersion returns "" when
+	// the schema itself is unreadable, so an undecodable .db is never labeled).
+	sourceVersion := antigravitySourceVersion(db)
 	result, err := loadAntigravityStepsWithRawCount(db)
+	result.sourceVersion = sourceVersion
 	if err != nil {
 		return result, err
 	}
-	// Schema-fingerprint label for the producing agy build, derived from the
-	// same shared helper the IDE path uses so both classify identically.
-	result.sourceVersion = antigravitySourceVersion(db)
 	return result, nil
 }
 

--- a/internal/parser/antigravity_version.go
+++ b/internal/parser/antigravity_version.go
@@ -1,0 +1,116 @@
+package parser
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"strconv"
+)
+
+// Antigravity session databases carry no literal product version: PRAGMA
+// user_version is a schema marker (1), not a dotted release, and neither the
+// .db nor ~/.gemini state records the producing agy build. The only stable
+// discriminator is the SQLite SCHEMA FINGERPRINT -- a sha256 over the database's
+// CREATE statements (from sqlite_master) plus user_version. One schema spans
+// several agy dot releases, so the fingerprint maps to a release range label.
+//
+// The fingerprint algorithm is kept byte-for-byte identical to agy-reader's
+// agy-format-audit recorder (skills/agy-format-audit/scripts/audit_format.sh):
+//
+//	{ sqlite3 SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY type, name
+//	  sqlite3 PRAGMA user_version } | sha256sum
+//
+// so labels seeded from agy-reader's COMPATIBILITY.md match real databases.
+
+// antigravitySchemaPrefixLen is the number of leading hex characters of the
+// full sha256 fingerprint kept for matching and for the unknown-schema marker.
+// Short enough to keep labels well under 64 chars, long enough to stay unique.
+const antigravitySchemaPrefixLen = 12
+
+// antigravitySchemaVersions maps a short schema-fingerprint prefix to a known
+// agy release-range label. Seeded from agy-reader COMPATIBILITY.md and verified
+// against real ~/.gemini/antigravity[-cli] databases. Keys are the first
+// antigravitySchemaPrefixLen hex chars of the full sha256.
+//
+// Full fingerprints (for traceability):
+//   - sha256:1ca98426f561fe73223c8620a238405030fdb3014444d970e1300a6009f72f43
+//     user_version=1, 7 tables (battle_mode_infos, executor_metadata,
+//     gen_metadata, parent_references, steps, trajectory_meta,
+//     trajectory_metadata_blob), indices idx_steps_status, idx_steps_step_type
+//     == agy 1.0.7-1.0.10.
+var antigravitySchemaVersions = map[string]string{
+	"1ca98426f561": "1.0.7-1.0.10",
+}
+
+// antigravitySchemaUnknownPrefix tags an unrecognized schema fingerprint so new
+// agy schemas stay visible in source_version (e.g. "agy-schema:abc123def456").
+const antigravitySchemaUnknownPrefix = "agy-schema:"
+
+// antigravitySchemaFingerprint computes the full hex sha256 schema fingerprint
+// for an open Antigravity SQLite database. It mirrors the agy-reader audit
+// recorder byte-for-byte: every non-null sqlite_master sql value ordered by
+// (type, name), each followed by a newline, then the decimal user_version
+// followed by a newline. Returns ("", err) when the schema cannot be read.
+func antigravitySchemaFingerprint(db *sql.DB) (string, error) {
+	rows, err := db.Query(
+		`SELECT sql FROM sqlite_master ` +
+			`WHERE sql IS NOT NULL ORDER BY type, name`,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	h := sha256.New()
+	for rows.Next() {
+		var stmt string
+		if err := rows.Scan(&stmt); err != nil {
+			return "", err
+		}
+		h.Write([]byte(stmt))
+		h.Write([]byte{'\n'})
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+
+	var userVersion int64
+	if err := db.QueryRow(`PRAGMA user_version`).Scan(&userVersion); err != nil {
+		return "", err
+	}
+	h.Write([]byte(strconv.FormatInt(userVersion, 10)))
+	h.Write([]byte{'\n'})
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// antigravitySchemaLabel maps a full hex fingerprint to a short source_version
+// label: a known release range, or an "agy-schema:<prefix>" marker for an
+// unrecognized (newer) schema. Returns "" for an empty fingerprint so callers
+// can leave SourceVersion blank when no schema was available.
+func antigravitySchemaLabel(fingerprint string) string {
+	if fingerprint == "" {
+		return ""
+	}
+	prefix := fingerprint
+	if len(prefix) > antigravitySchemaPrefixLen {
+		prefix = prefix[:antigravitySchemaPrefixLen]
+	}
+	if label, ok := antigravitySchemaVersions[prefix]; ok {
+		return label
+	}
+	return antigravitySchemaUnknownPrefix + prefix
+}
+
+// antigravitySourceVersion derives the source_version label for an open
+// Antigravity database, shared by the IDE (.db) and CLI (.db) parse paths so
+// both classify identically. Returns "" when the schema cannot be read, so a
+// sidecar-only or undecodable session leaves SourceVersion empty rather than
+// fabricating a label.
+func antigravitySourceVersion(db *sql.DB) string {
+	fp, err := antigravitySchemaFingerprint(db)
+	if err != nil {
+		return ""
+	}
+	return antigravitySchemaLabel(fp)
+}

--- a/internal/parser/antigravity_version_test.go
+++ b/internal/parser/antigravity_version_test.go
@@ -1,0 +1,290 @@
+package parser
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// agyBaselineCreateStatements are the exact CREATE statements of the verified
+// agy 1.0.7-1.0.10 schema (user_version=1, 7 tables, 2 indices), copied
+// byte-for-byte from a real ~/.gemini/antigravity-cli database. Executing them
+// verbatim makes sqlite_master store identical sql text, so the Go fingerprint
+// reproduces agy-reader's recorded sha256:1ca98426...f72f43.
+var agyBaselineCreateStatements = []string{
+	"CREATE TABLE `trajectory_meta` (`trajectory_id` text,`cascade_id` text," +
+		"`trajectory_type` integer,`source` integer,PRIMARY KEY (`trajectory_id`))",
+	"CREATE TABLE `steps` (`idx` integer,`step_type` integer NOT NULL DEFAULT 0," +
+		"`status` integer NOT NULL DEFAULT 0," +
+		"`has_subtrajectory` numeric NOT NULL DEFAULT false," +
+		"`metadata` blob,`error_details` blob,`permissions` blob," +
+		"`task_details` blob,`render_info` blob,`step_payload` blob," +
+		"`step_format` integer NOT NULL DEFAULT 0,PRIMARY KEY (`idx`))",
+	"CREATE TABLE `gen_metadata` (`idx` integer,`data` blob," +
+		"`size` integer NOT NULL DEFAULT 0,PRIMARY KEY (`idx`))",
+	"CREATE TABLE `executor_metadata` (`idx` integer,`data` blob,PRIMARY KEY (`idx`))",
+	"CREATE TABLE `parent_references` (`idx` integer,`data` blob,PRIMARY KEY (`idx`))",
+	"CREATE TABLE `trajectory_metadata_blob` (`id` text DEFAULT \"main\"," +
+		"`data` blob,PRIMARY KEY (`id`))",
+	"CREATE TABLE `battle_mode_infos` (`idx` integer,`data` blob,PRIMARY KEY (`idx`))",
+	"CREATE INDEX `idx_steps_status` ON `steps`(`status`)",
+	"CREATE INDEX `idx_steps_step_type` ON `steps`(`step_type`)",
+}
+
+// createAntigravityBaselineSchemaDB writes a .db whose schema fingerprint
+// matches the verified agy 1.0.7-1.0.10 baseline. It executes the real CREATE
+// statements verbatim and sets user_version=1, then seeds two decodable steps
+// so the parser produces a usable session.
+func createAntigravityBaselineSchemaDB(t *testing.T, path string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open")
+	defer db.Close()
+	for _, stmt := range agyBaselineCreateStatements {
+		mustExec(t, db, stmt)
+	}
+	mustExec(t, db, "PRAGMA user_version = 1")
+
+	tsEarly := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000000},
+	})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{num: 17, wire: pbWireBytes, bytes: []byte("user prompt text goes here")},
+	})
+	tsLate := encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1779000100},
+	})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsLate},
+		{num: 17, wire: pbWireBytes, bytes: []byte("assistant reply content body")},
+	})
+	mustExec(t, db,
+		"INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)",
+		0, 14, userPayload)
+	mustExec(t, db,
+		"INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)",
+		1, 17, asstPayload)
+}
+
+// openSchemaDB opens a fresh SQLite db at path and returns a handle the caller
+// must close. The db is created by running each statement in stmts plus
+// user_version.
+func openSchemaDB(
+	t *testing.T, path string, userVersion int, stmts ...string,
+) *sql.DB {
+	t.Helper()
+	build, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open for build")
+	for _, stmt := range stmts {
+		_, err := build.Exec(stmt)
+		require.NoError(t, err, "exec %q", stmt)
+	}
+	_, err = build.Exec("PRAGMA user_version = " + itoa(userVersion))
+	require.NoError(t, err, "set user_version")
+	require.NoError(t, build.Close(), "close build")
+
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "reopen")
+	return db
+}
+
+const agyBaselineFullFingerprint = "1ca98426f561fe73223c8620a238405030fdb3014444d970e1300a6009f72f43"
+
+func TestAntigravitySchemaLabel(t *testing.T) {
+	tests := []struct {
+		name        string
+		fingerprint string
+		want        string
+	}{
+		{
+			name:        "known baseline maps to release range",
+			fingerprint: agyBaselineFullFingerprint,
+			want:        "1.0.7-1.0.10",
+		},
+		{
+			name:        "unknown fingerprint becomes agy-schema marker",
+			fingerprint: "deadbeefcafe0000111122223333444455556666777788889999aaaabbbbcccc",
+			want:        "agy-schema:deadbeefcafe",
+		},
+		{
+			name:        "empty fingerprint yields empty label",
+			fingerprint: "",
+			want:        "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := antigravitySchemaLabel(tt.fingerprint)
+			assert.Equal(t, tt.want, got)
+			if got != "" {
+				assert.LessOrEqual(t, len(got), 63,
+					"label must stay under 64 chars")
+			}
+		})
+	}
+}
+
+// TestAntigravitySchemaFingerprintBaseline verifies the Go fingerprint of the
+// real baseline schema matches agy-reader's recorded sha256, so the
+// known-label mapping actually fires on real databases.
+func TestAntigravitySchemaFingerprintBaseline(t *testing.T) {
+	dir := t.TempDir()
+	stmts := append([]string{}, agyBaselineCreateStatements...)
+	db := openSchemaDB(t, filepath.Join(dir, "baseline.db"), 1, stmts...)
+	defer db.Close()
+
+	fp, err := antigravitySchemaFingerprint(db)
+	require.NoError(t, err)
+	assert.Equal(t, agyBaselineFullFingerprint, fp,
+		"Go fingerprint must equal agy-reader recorded sha256")
+	assert.Equal(t, "1.0.7-1.0.10", antigravitySchemaLabel(fp))
+}
+
+func TestAntigravitySchemaFingerprintCases(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		userVersion int
+		stmts       []string
+		wantLabel   string
+	}{
+		{
+			name:        "baseline schema known label",
+			userVersion: 1,
+			stmts:       agyBaselineCreateStatements,
+			wantLabel:   "1.0.7-1.0.10",
+		},
+		{
+			name:        "extra table yields unknown marker",
+			userVersion: 1,
+			stmts: append(append([]string{}, agyBaselineCreateStatements...),
+				"CREATE TABLE `future_widget` (`idx` integer,`data` blob,"+
+					"PRIMARY KEY (`idx`))"),
+			wantLabel: "", // checked as marker prefix below
+		},
+		{
+			name:        "bumped user_version yields unknown marker",
+			userVersion: 2,
+			stmts:       agyBaselineCreateStatements,
+			wantLabel:   "",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, itoa(i)+".db")
+			db := openSchemaDB(t, path, tt.userVersion, tt.stmts...)
+			defer db.Close()
+
+			fp, err := antigravitySchemaFingerprint(db)
+			require.NoError(t, err)
+			label := antigravitySchemaLabel(fp)
+
+			if tt.wantLabel != "" {
+				assert.Equal(t, tt.wantLabel, label)
+			} else {
+				assert.True(t,
+					strings.HasPrefix(label, antigravitySchemaUnknownPrefix),
+					"mutated schema should produce unknown marker, got %q",
+					label)
+				assert.NotEqual(t, agyBaselineFullFingerprint, fp,
+					"mutated schema must not reuse baseline fingerprint")
+			}
+		})
+	}
+}
+
+// TestAntigravitySchemaFingerprintDeterministic asserts the same schema always
+// produces the same fingerprint across independent databases.
+func TestAntigravitySchemaFingerprintDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	stmts := append([]string{}, agyBaselineCreateStatements...)
+
+	db1 := openSchemaDB(t, filepath.Join(dir, "a.db"), 1, stmts...)
+	defer db1.Close()
+	db2 := openSchemaDB(t, filepath.Join(dir, "b.db"), 1, stmts...)
+	defer db2.Close()
+
+	fp1, err := antigravitySchemaFingerprint(db1)
+	require.NoError(t, err)
+	fp2, err := antigravitySchemaFingerprint(db2)
+	require.NoError(t, err)
+	assert.Equal(t, fp1, fp2, "identical schema must hash identically")
+}
+
+// TestAntigravityIDESourceVersionBaseline verifies the IDE parser stamps the
+// schema-fingerprint label when the .db matches the baseline schema.
+func TestAntigravityIDESourceVersionBaseline(t *testing.T) {
+	root := t.TempDir()
+	id := "aaaaaaaa-1111-2222-3333-444444444444"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityBaselineSchemaDB(t, dbPath)
+
+	sess, _, _, err := ParseAntigravitySession(dbPath, "/tmp/proj", "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "1.0.7-1.0.10", sess.SourceVersion)
+}
+
+// TestAntigravityCLISourceVersionBaseline verifies the CLI .db parse path
+// stamps the same label as the IDE path for the baseline schema.
+func TestAntigravityCLISourceVersionBaseline(t *testing.T) {
+	root := t.TempDir()
+	id := "bbbbbbbb-1111-2222-3333-444444444444"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityBaselineSchemaDB(t, dbPath)
+
+	sess, _, err := ParseAntigravityCLISession(dbPath, "/tmp/proj", "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "1.0.7-1.0.10", sess.SourceVersion)
+}
+
+// TestAntigravityIDESourceVersionUnknownSchema verifies that a .db with a
+// non-baseline schema (the minimal 2-table test schema, no user_version)
+// gets an agy-schema:<hex> marker rather than a fabricated release.
+func TestAntigravityIDESourceVersionUnknownSchema(t *testing.T) {
+	root := t.TempDir()
+	id := "cccccccc-1111-2222-3333-444444444444"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath)
+
+	sess, _, _, err := ParseAntigravitySession(dbPath, "/tmp/proj", "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.True(t,
+		strings.HasPrefix(sess.SourceVersion, antigravitySchemaUnknownPrefix),
+		"non-baseline schema should yield unknown marker, got %q",
+		sess.SourceVersion)
+}
+
+// TestAntigravityCLIPBSourceVersionEmpty verifies that a legacy .pb session
+// (no .db schema available) leaves SourceVersion empty rather than fabricating.
+func TestAntigravityCLIPBSourceVersionEmpty(t *testing.T) {
+	root := t.TempDir()
+	id := "dddddddd-1111-2222-3333-444444444444"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	pbPath := filepath.Join(root, "conversations", id+".pb")
+	mustWrite(t, pbPath, []byte("encrypted-placeholder"))
+	mustWrite(t, filepath.Join(root, "history.jsonl"),
+		[]byte(`{"display":"pb prompt","timestamp":1779000000000,`+
+			`"workspace":"/tmp/pb-proj","conversationId":"`+id+`"}`))
+
+	sess, _, err := ParseAntigravityCLISession(pbPath, "/tmp/pb-proj", "m")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Empty(t, sess.SourceVersion,
+		"sidecar-only/.pb session must not fabricate SourceVersion")
+}

--- a/internal/parser/antigravity_version_test.go
+++ b/internal/parser/antigravity_version_test.go
@@ -269,6 +269,31 @@ func TestAntigravityIDESourceVersionUnknownSchema(t *testing.T) {
 		sess.SourceVersion)
 }
 
+// TestAntigravityCLIDBStepsCarriesSourceVersionOnStepError verifies that a CLI
+// .db whose schema is readable but whose steps query fails still returns the
+// schema-fingerprint label. Without this the parser falls back to the
+// trajectory sidecar and persists a session with an empty SourceVersion,
+// silently losing the agy-schema marker for an unrecognized (newer) schema.
+func TestAntigravityCLIDBStepsCarriesSourceVersionOnStepError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nosteps.db")
+	// A readable schema with NO steps table: the fingerprint query over
+	// sqlite_master succeeds, but loadAntigravityStepsWithRawCount's
+	// `SELECT ... FROM steps` fails. The lone table also makes the schema
+	// non-baseline, so the expected label is an agy-schema:<prefix> marker.
+	db := openSchemaDB(t, path, 1,
+		"CREATE TABLE `trajectory_meta` (`trajectory_id` text,"+
+			"PRIMARY KEY (`trajectory_id`))")
+	require.NoError(t, db.Close())
+
+	result, err := loadAntigravityCLIDBSteps(path)
+	require.Error(t, err, "missing steps table must fail the step query")
+	assert.True(t,
+		strings.HasPrefix(result.sourceVersion, antigravitySchemaUnknownPrefix),
+		"readable schema must still yield an agy-schema marker, got %q",
+		result.sourceVersion)
+}
+
 // TestAntigravityCLIPBSourceVersionEmpty verifies that a legacy .pb session
 // (no .db schema available) leaves SourceVersion empty rather than fabricating.
 func TestAntigravityCLIPBSourceVersionEmpty(t *testing.T) {


### PR DESCRIPTION
Antigravity sessions carry no literal product version, so a new dot release silently misparses until a symptom surfaces. This records a producing-version label per Antigravity session, derived from the SQLite schema fingerprint (a sha256 over the database's CREATE statements plus `user_version`), stored in the existing `sessions.source_version` column. One schema spans several agy dot releases, so the fingerprint maps to a release-range label; an unrecognized (newer) schema is tagged `agy-schema:<prefix>` so it stays visible instead of being silently decoded with heuristics tuned for an older payload. Even without gating decode on it, having the version recorded turns "which release broke this" from archaeology into a query.

The fingerprint algorithm is byte-for-byte identical to agy-reader's format-audit recorder, so labels seeded from agy-reader's compatibility notes match real databases. Both the IDE (`.db`) and CLI (`.db`) parse paths share one helper so they classify identically; legacy `.pb` and sidecar-only sessions leave `source_version` empty rather than fabricating a label. The label is computed as soon as the `.db` opens, so a readable schema still carries its marker even when the step query fails and the parser falls back to the trajectory sidecar.

`dataVersion` is bumped to 54 so existing Antigravity rows get `source_version` backfilled through the normal non-destructive resync, not just newly synced sessions.

Where to look:
- `internal/parser/antigravity_version.go` — schema fingerprint + label mapping (known release ranges vs the `agy-schema:` unknown marker).
- `internal/parser/antigravity.go`, `internal/parser/antigravity_cli.go` — IDE and CLI wiring through the shared helper.
- `internal/db/db.go` — `dataVersion` bump and bump-log entry.

Version-gating of decode heuristics and a decode-confidence signal that keys off the unknown-schema marker are deferred follow-ups.