### PR TITLE
fix(sync): detect Codex title-only renames in full sync regardless of index mtime

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4956,14 +4956,26 @@ func (e *Engine) shouldSkipCodex(
 		db.CurrentDataVersion() {
 		return false
 	}
-	fileMtime := info.ModTime().UnixNano()
-	effectiveMtime := parser.CodexEffectiveMtime(path, fileMtime)
-	if storedMtime == effectiveMtime {
-		return true
+	// A Codex title lives in session_index.jsonl, not the transcript, so a
+	// title-only rename can change the title with no transcript signal. Detect
+	// it directly rather than inferring it from an mtime inequality: the index
+	// mtime is folded into the stored watermark, so a later rename whose index
+	// mtime lands at or below that watermark is invisible to a mtime compare,
+	// and the old storedMtime==effectiveMtime fast path skipped without ever
+	// consulting the title. codexIndexSessionNameChanged reads the live title
+	// (cached per index file) and the stored name; a cheaper stored-name lookup
+	// to keep this fully off the hot skip path is a deferred follow-up.
+	if e.codexIndexSessionNameChanged(path) {
+		return false // title changed -> re-parse to refresh metadata
 	}
-	return effectiveMtime > storedMtime &&
-		fileMtime <= storedMtime &&
-		!e.codexIndexSessionNameChanged(path)
+	// Title verified unchanged: skip when the transcript itself is unchanged.
+	// Compare the bare file mtime, not the index-folded effective mtime -- the
+	// stored watermark may already include a folded index mtime, and a later
+	// bump of the shared session_index.jsonl (e.g. another session's rename)
+	// lifts every session's effective mtime; with the title confirmed
+	// unchanged, that rise must not force a needless reparse.
+	fileMtime := info.ModTime().UnixNano()
+	return fileMtime <= storedMtime
 }
 
 // codexIndexNeedsRefreshSince reports whether a Codex session whose transcript

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -3969,3 +3969,116 @@ func TestConvertToolCallsFilePathAndCallIndex(t *testing.T) {
 	assert.Equal(t, "", got[2].FilePath)
 	assert.Equal(t, 2, got[2].CallIndex)
 }
+
+// codexRenameFixture is a seeded Codex session whose stored file_mtime is the
+// folded index-mtime watermark, used to exercise title-rename detection in
+// shouldSkipCodex.
+type codexRenameFixture struct {
+	e              *Engine
+	path           string
+	info           os.FileInfo
+	effectiveMtime int64
+	root           string
+	uuid           string
+}
+
+// writeCodexIndexForTest writes the session_index.jsonl mapping uuid -> title
+// at indexMtime, the file shouldSkipCodex's title check reads.
+func writeCodexIndexForTest(
+	t *testing.T, root, uuid, title string, indexMtime time.Time,
+) string {
+	t.Helper()
+	idxPath := filepath.Join(root, parser.CodexSessionIndexFilename)
+	line := `{"id":"` + uuid + `","thread_name":"` + title + `"}` + "\n"
+	require.NoError(t, os.WriteFile(idxPath, []byte(line), 0o600))
+	require.NoError(t, os.Chtimes(idxPath, indexMtime, indexMtime))
+	return idxPath
+}
+
+// seedCodexRenameCase stores a Codex session whose file_mtime watermark is the
+// folded index mtime (the index is newer than the transcript). That is the
+// exact shape where a later title-only rename whose index mtime lands at or
+// below the watermark is invisible to an mtime comparison.
+func seedCodexRenameCase(t *testing.T, database *db.DB) codexRenameFixture {
+	t.Helper()
+	root := t.TempDir()
+	const uuid = "11111111-2222-3333-4444-555555555555"
+	sessDir := filepath.Join(root, "sessions", "2026", "06", "21")
+	require.NoError(t, os.MkdirAll(sessDir, 0o755))
+	path := filepath.Join(sessDir, "rollout-2026-06-21T18-59-38-"+uuid+".jsonl")
+
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/home/user/code/api", "user", "2026-06-21T18:59:38Z",
+		),
+		testjsonl.CodexMsgJSON("user", "review this", "2026-06-21T18:59:39Z"),
+	)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	transcriptMtime := time.Unix(1_700_000_000, 0)
+	require.NoError(t, os.Chtimes(path, transcriptMtime, transcriptMtime))
+	origIndexMtime := transcriptMtime.Add(time.Hour)
+	writeCodexIndexForTest(t, root, uuid, "Original Title", origIndexMtime)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat codex fixture")
+	effectiveMtime := parser.CodexEffectiveMtime(path, info.ModTime().UnixNano())
+	require.Equal(t, origIndexMtime.UnixNano(), effectiveMtime,
+		"folded watermark should be the index mtime")
+
+	sess := db.Session{
+		ID:          "host~codex:" + uuid,
+		Project:     "api",
+		Machine:     "host",
+		Agent:       "codex",
+		SessionName: strPtr("Original Title"),
+		FilePath:    strPtr("host:" + path),
+		FileSize:    int64Ptr(info.Size()),
+		FileMtime:   int64Ptr(effectiveMtime),
+	}
+	require.NoError(t, database.UpsertSession(sess))
+	require.NoError(t, database.SetSessionDataVersion(
+		sess.ID, db.CurrentDataVersion(),
+	))
+
+	e := &Engine{
+		db:       database,
+		idPrefix: "host~",
+		pathRewriter: func(p string) string {
+			return "host:" + p
+		},
+	}
+	return codexRenameFixture{
+		e: e, path: path, info: info,
+		effectiveMtime: effectiveMtime, root: root, uuid: uuid,
+	}
+}
+
+// TestShouldSkipCodexTitleRenameBelowStoredMtimeDoesNotSkip pins the masking
+// fix: a title-only rename whose folded index mtime is at or below the stored
+// watermark used to be skipped by shouldSkipCodex's storedMtime==effectiveMtime
+// fast path, which never consulted the title. The direct title check must now
+// force a reparse while an unchanged session still hits the skip path.
+func TestShouldSkipCodexTitleRenameBelowStoredMtimeDoesNotSkip(t *testing.T) {
+	database := openTestDB(t)
+	f := seedCodexRenameCase(t, database)
+
+	// Control: nothing changed -> hot path still skips.
+	assert.True(t, f.e.shouldSkipCodex(f.path, f.info),
+		"unchanged transcript and title must still skip")
+
+	// Title-only rename whose index mtime lands at or below the stored
+	// watermark. The transcript bytes are untouched, so the old mtime gate
+	// would skip; the mtime-independent title check must catch it.
+	writeCodexIndexForTest(t, f.root, f.uuid, "Renamed Title",
+		time.Unix(0, f.effectiveMtime))
+	renamedEff := parser.CodexEffectiveMtime(f.path, f.info.ModTime().UnixNano())
+	require.LessOrEqual(t, renamedEff, f.effectiveMtime,
+		"renamed index mtime must be at or below the stored watermark")
+	require.Equal(t, "Renamed Title",
+		parser.LookupCodexThreadName(f.path, f.uuid),
+		"live index must report the renamed title")
+
+	assert.False(t, f.e.shouldSkipCodex(f.path, f.info),
+		"title-only rename at or below stored watermark must not skip")
+}


### PR DESCRIPTION
A Codex session's title lives in `session_index.jsonl`, separate from its transcript, and the index mtime is folded into the stored `file_mtime` watermark. `shouldSkipCodex`'s `storedMtime == effectiveMtime` fast path skipped a file without ever consulting the title, so a later title-only rename whose folded index mtime landed at or below the stored watermark was masked on a full sync — the renamed title never resolved in the archive until the transcript itself changed.

This checks the live index title against the stored `session_name` directly before deciding to skip, then skips only when the bare transcript mtime is unchanged. Comparing the bare file mtime rather than the folded effective mtime means an unrelated bump of the shared `session_index.jsonl` (another session's rename touches the same file) no longer forces a needless reparse once the title is confirmed unchanged.

The incremental and `SyncAllSince` quick-sync paths already detect title renames this way; this closes the remaining full-sync entry point.

Where to look:
- `internal/sync/engine.go` — `shouldSkipCodex`.

Follow-up (not in this PR): `codexIndexSessionNameChanged` loads the full session row via `GetSessionFull` on the skip path; a cheaper stored-name-only lookup would keep the title check fully off the hot path.