### PR TITLE
Use gh auth token for Gist publishing fallback

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -894,7 +894,7 @@ agentsview help
 | `AGENTSVIEW_DUCKDB_URL` | | Remote Quack endpoint URL for `duckdb serve` |
 | `AGENTSVIEW_DUCKDB_TOKEN` | | Quack authentication token |
 | `AGENTSVIEW_DUCKDB_MACHINE` | | Machine name for DuckDB push |
-| `AGENTSVIEW_GITHUB_TOKEN` | | GitHub token used for Gist publishing and `agentsview stats` PR aggregation |
+| `AGENTSVIEW_GITHUB_TOKEN` | | GitHub token used for local Gist publishing fallback and `agentsview stats` PR aggregation |
 | `AGENTSVIEW_DISABLE_UPDATE_CHECK` | | Set to `1` to disable the update check |
 | `AGENTSVIEW_NO_DAEMON` | | Set to `1`, `true`, `yes`, or `on` to disable CLI daemon auto-start |
 | `AGENTSVIEW_DAEMON_IDLE_TIMEOUT` | `20m` | Override idle self-shutdown duration for detached background daemons |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -894,7 +894,7 @@ agentsview help
 | `AGENTSVIEW_DUCKDB_URL` | | Remote Quack endpoint URL for `duckdb serve` |
 | `AGENTSVIEW_DUCKDB_TOKEN` | | Quack authentication token |
 | `AGENTSVIEW_DUCKDB_MACHINE` | | Machine name for DuckDB push |
-| `AGENTSVIEW_GITHUB_TOKEN` | | GitHub token used by `agentsview stats` for PR aggregation |
+| `AGENTSVIEW_GITHUB_TOKEN` | | GitHub token used for Gist publishing and `agentsview stats` PR aggregation |
 | `AGENTSVIEW_DISABLE_UPDATE_CHECK` | | Set to `1` to disable the update check |
 | `AGENTSVIEW_NO_DAEMON` | | Set to `1`, `true`, `yes`, or `on` to disable CLI daemon auto-start |
 | `AGENTSVIEW_DAEMON_IDLE_TIMEOUT` | `20m` | Override idle self-shutdown duration for detached background daemons |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,12 +68,13 @@ cursor_admin_api_key = "key_xxxxx"
 | `[custom_model_pricing]` | Per-model price overrides for usage reports — see [Custom Model Pricing](/token-usage/#custom-model-pricing) |
 
 The `cursor_secret` is generated automatically on first run.
-For Gist publishing, AgentsView first uses a saved `github_token`,
-then `AGENTSVIEW_GITHUB_TOKEN`, then `gh auth token` from the
-GitHub CLI. Local users usually only need to run `gh auth login`.
-The saved `github_token` can still be set via the web UI Settings
-page or the API endpoint `POST /api/v1/config/github` when you
-want AgentsView to use a specific token. Remote access fields can
+For Gist publishing, AgentsView first uses a saved `github_token`.
+For local browser requests, if no token is saved, it then tries
+`AGENTSVIEW_GITHUB_TOKEN` and then `gh auth token` from the GitHub
+CLI. Local users usually only need to run `gh auth login`. For
+remote or proxied access, save a `github_token` via the web UI
+Settings page or the API endpoint `POST /api/v1/config/github`
+when you want AgentsView to publish gists. Remote access fields can
 be configured via the Settings page or CLI flags — see
 [Remote Access](/remote-access/) for details.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,6 @@ on first run. It stores persistent settings that survive restarts.
 
 ```toml
 cursor_secret = "base64-encoded-secret"
-github_token = "ghp_xxxxx"
 require_auth = true
 cursor_admin_api_key = "key_xxxxx"
 ```
@@ -54,7 +53,7 @@ cursor_admin_api_key = "key_xxxxx"
 | `cursor_admin_api_key` | Cursor Admin API key used by `agentsview usage cursor` |
 | `cursor_admin_email` | Optional default Cursor Admin usage filter by member email |
 | `cursor_admin_user_id` | Optional default Cursor Admin usage filter by member user ID |
-| `github_token` | GitHub personal access token for Gist publishing |
+| `github_token` | Optional saved GitHub token for Gist publishing |
 | `result_content_blocked_categories` | Tool categories whose result content is not stored (default: `["Read", "Glob"]`) |
 | `require_auth` | Require bearer-token authentication for API access |
 | `auth_token` | Auto-generated 256-bit bearer token for remote access |
@@ -69,10 +68,14 @@ cursor_admin_api_key = "key_xxxxx"
 | `[custom_model_pricing]` | Per-model price overrides for usage reports — see [Custom Model Pricing](/token-usage/#custom-model-pricing) |
 
 The `cursor_secret` is generated automatically on first run.
-The `github_token` can be set via the web UI Settings page or
-the API endpoint `POST /api/v1/config/github`. Remote access
-fields can be configured via the Settings page or CLI flags —
-see [Remote Access](/remote-access/) for details.
+For Gist publishing, AgentsView first uses a saved `github_token`,
+then `AGENTSVIEW_GITHUB_TOKEN`, then `gh auth token` from the
+GitHub CLI. Local users usually only need to run `gh auth login`.
+The saved `github_token` can still be set via the web UI Settings
+page or the API endpoint `POST /api/v1/config/github` when you
+want AgentsView to use a specific token. Remote access fields can
+be configured via the Settings page or CLI flags — see
+[Remote Access](/remote-access/) for details.
 
 !!! note
     Older configs may still contain `remote_access = true`. AgentsView

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -161,7 +161,8 @@ That includes:
 - lines added and removed
 - files changed
 
-Pull-request counts are optional:
+Pull-request counts are optional and use the same fallback order as
+Gist publishing:
 
 - If `AGENTSVIEW_GITHUB_TOKEN` is set, AgentsView uses it.
 - Otherwise it tries `gh auth token`.

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -161,8 +161,8 @@ That includes:
 - lines added and removed
 - files changed
 
-Pull-request counts are optional and use the same fallback order as
-Gist publishing:
+Pull-request counts are optional and use CLI-oriented GitHub token
+sources:
 
 - If `AGENTSVIEW_GITHUB_TOKEN` is set, AgentsView uses it.
 - Otherwise it tries `gh auth token`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -991,10 +991,15 @@ publishing. If no token is saved in AgentsView and
 uses that token to create the gist. Run `gh auth login` once if
 the GitHub CLI is not authenticated yet.
 
-If neither a saved token nor `gh auth token` is available, the
-publish modal prompts for a GitHub personal access token with the
-`gist` scope. That token is saved to your config file and reused
-for future publishes.
+For remote or proxied AgentsView access, save a GitHub token in
+AgentsView before publishing. Remote requests do not use the server
+process environment or GitHub CLI credential as a fallback.
+
+If neither a saved token, `AGENTSVIEW_GITHUB_TOKEN`, nor
+`gh auth token` is available for local publishing, the publish
+modal prompts for a GitHub personal access token with the `gist`
+scope. That token is saved to your config file and reused for
+future publishes.
 
 !!! warning
     Secret gists are unlisted, not access-controlled: they don't

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -985,9 +985,16 @@ Gist**. The `p` shortcut publishes publicly.
 
 ![Publish modal](/assets/generated/screenshots/publish-modal.png)
 
-On first use, you'll be prompted to enter a GitHub personal
-access token with the `gist` scope. The token is saved to your
-config file and reused for future publishes.
+AgentsView prefers your existing GitHub CLI login for local
+publishing. If no token is saved in AgentsView and
+`AGENTSVIEW_GITHUB_TOKEN` is not set, it runs `gh auth token` and
+uses that token to create the gist. Run `gh auth login` once if
+the GitHub CLI is not authenticated yet.
+
+If neither a saved token nor `gh auth token` is available, the
+publish modal prompts for a GitHub personal access token with the
+`gist` scope. That token is saved to your config file and reused
+for future publishes.
 
 !!! warning
     Secret gists are unlisted, not access-controlled: they don't

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -111,6 +111,9 @@ func resolveGitHubToken(ctx context.Context, configured string) string {
 	if token := strings.TrimSpace(configured); token != "" {
 		return token
 	}
+	if !isLocalhostContext(ctx) {
+		return ""
+	}
 	if token := strings.TrimSpace(os.Getenv("AGENTSVIEW_GITHUB_TOKEN")); token != "" {
 		return token
 	}

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -8,6 +8,8 @@ import (
 	"html/template"
 	"io"
 	"net/http"
+	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -24,6 +26,12 @@ type gistResponse struct {
 	Owner   struct {
 		Login string `json:"login"`
 	} `json:"owner"`
+}
+
+var ghAuthTokenOutput = func(ctx context.Context) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "gh", "auth", "token")
+	cmd.Stderr = io.Discard
+	return cmd.Output()
 }
 
 func githubHTTPClient(timeout time.Duration) *http.Client {
@@ -97,6 +105,23 @@ func createGistWithURL(
 		return nil, fmt.Errorf("parsing github response: %w", err)
 	}
 	return &result, nil
+}
+
+func resolveGitHubToken(ctx context.Context, configured string) string {
+	if token := strings.TrimSpace(configured); token != "" {
+		return token
+	}
+	if token := strings.TrimSpace(os.Getenv("AGENTSVIEW_GITHUB_TOKEN")); token != "" {
+		return token
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	out, err := ghAuthTokenOutput(cctx)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func validateGithubToken(ctx context.Context, token string) (string, error) {

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -1235,8 +1235,13 @@ func TestResolveGitHubToken(t *testing.T) {
 	originalGhAuthTokenOutput := ghAuthTokenOutput
 	t.Cleanup(func() { ghAuthTokenOutput = originalGhAuthTokenOutput })
 
+	localCtx := context.WithValue(context.Background(), ctxKeyHumaRequestInfo,
+		requestInfo{RemoteAddr: "127.0.0.1:1234"})
+	remoteCtx := context.WithValue(context.Background(), ctxKeyHumaRequestInfo,
+		requestInfo{RemoteAddr: "127.0.0.1:1234", Forwarded: true})
 	tests := []struct {
 		name       string
+		ctx        context.Context
 		configured string
 		env        string
 		ghOutput   string
@@ -1245,6 +1250,7 @@ func TestResolveGitHubToken(t *testing.T) {
 	}{
 		{
 			name:       "ConfiguredTokenWins",
+			ctx:        localCtx,
 			configured: " saved-token ",
 			env:        "env-token",
 			ghOutput:   "gh-token\n",
@@ -1252,19 +1258,43 @@ func TestResolveGitHubToken(t *testing.T) {
 		},
 		{
 			name:     "EnvFallback",
+			ctx:      localCtx,
 			env:      " env-token ",
 			ghOutput: "gh-token\n",
 			want:     "env-token",
 		},
 		{
 			name:     "GitHubCLIFallback",
+			ctx:      localCtx,
 			ghOutput: "gh-token\n",
 			want:     "gh-token",
 		},
 		{
 			name:  "MissingSources",
+			ctx:   localCtx,
 			ghErr: errors.New("gh missing"),
 			want:  "",
+		},
+		{
+			name:       "ConfiguredTokenAllowedForRemoteContext",
+			ctx:        remoteCtx,
+			configured: " saved-token ",
+			env:        "env-token",
+			ghOutput:   "gh-token\n",
+			want:       "saved-token",
+		},
+		{
+			name:     "EnvFallbackDeniedForRemoteContext",
+			ctx:      remoteCtx,
+			env:      " env-token ",
+			ghOutput: "gh-token\n",
+			want:     "",
+		},
+		{
+			name:     "GitHubCLIFallbackDeniedForRemoteContext",
+			ctx:      remoteCtx,
+			ghOutput: "gh-token\n",
+			want:     "",
 		},
 	}
 
@@ -1278,7 +1308,7 @@ func TestResolveGitHubToken(t *testing.T) {
 				return []byte(tt.ghOutput), nil
 			}
 
-			got := resolveGitHubToken(context.Background(), tt.configured)
+			got := resolveGitHubToken(tt.ctx, tt.configured)
 
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -1231,6 +1231,60 @@ func TestCreateGistVisibility(t *testing.T) {
 	}
 }
 
+func TestResolveGitHubToken(t *testing.T) {
+	originalGhAuthTokenOutput := ghAuthTokenOutput
+	t.Cleanup(func() { ghAuthTokenOutput = originalGhAuthTokenOutput })
+
+	tests := []struct {
+		name       string
+		configured string
+		env        string
+		ghOutput   string
+		ghErr      error
+		want       string
+	}{
+		{
+			name:       "ConfiguredTokenWins",
+			configured: " saved-token ",
+			env:        "env-token",
+			ghOutput:   "gh-token\n",
+			want:       "saved-token",
+		},
+		{
+			name:     "EnvFallback",
+			env:      " env-token ",
+			ghOutput: "gh-token\n",
+			want:     "env-token",
+		},
+		{
+			name:     "GitHubCLIFallback",
+			ghOutput: "gh-token\n",
+			want:     "gh-token",
+		},
+		{
+			name:  "MissingSources",
+			ghErr: errors.New("gh missing"),
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AGENTSVIEW_GITHUB_TOKEN", tt.env)
+			ghAuthTokenOutput = func(context.Context) ([]byte, error) {
+				if tt.ghErr != nil {
+					return nil, tt.ghErr
+				}
+				return []byte(tt.ghOutput), nil
+			}
+
+			got := resolveGitHubToken(context.Background(), tt.configured)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestValidateGithubToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/huma_routes_config.go
+++ b/internal/server/huma_routes_config.go
@@ -73,11 +73,11 @@ func (b terminalConfigBody) config() config.TerminalConfig {
 }
 
 func (s *Server) humaGetGithubConfig(
-	_ context.Context,
+	ctx context.Context,
 	_ *emptyInput,
 ) (*jsonOutput[githubConfigResponse], error) {
 	return &jsonOutput[githubConfigResponse]{
-		Body: githubConfigResponse{Configured: s.githubToken() != ""},
+		Body: githubConfigResponse{Configured: s.githubToken(ctx) != ""},
 	}, nil
 }
 

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -136,7 +136,7 @@ func (s *Server) humaPublishInsight(
 	ctx context.Context,
 	in *publishInsightInput,
 ) (*jsonOutput[publishResponse], error) {
-	token := s.githubToken()
+	token := s.githubToken(ctx)
 	if token == "" {
 		return nil, apiError(http.StatusUnauthorized, "GitHub token not configured")
 	}

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -504,7 +504,7 @@ func (s *Server) humaPublishSession(
 	ctx context.Context,
 	in *publishSessionInput,
 ) (*jsonOutput[publishResponse], error) {
-	token := s.githubToken()
+	token := s.githubToken(ctx)
 	if token == "" {
 		return nil, apiError(http.StatusUnauthorized, "GitHub token not configured")
 	}

--- a/internal/server/huma_routes_settings.go
+++ b/internal/server/huma_routes_settings.go
@@ -61,6 +61,7 @@ func (s *Server) humaGetSettings(
 	if tc.Mode == "" {
 		tc.Mode = string(terminalModeAuto)
 	}
+	githubToken := s.cfg.GithubToken
 	resp := settingsResponse{
 		AgentDirs: dirs,
 		Terminal: terminalResponse{
@@ -68,16 +69,16 @@ func (s *Server) humaGetSettings(
 			CustomBin:  tc.CustomBin,
 			CustomArgs: tc.CustomArgs,
 		},
-		GithubConfigured: s.cfg.GithubToken != "",
-		Host:             s.cfg.Host,
-		Port:             s.cfg.Port,
-		RequireAuth:      s.cfg.RequireAuth,
-		ReadOnly:         s.db.ReadOnly(),
+		Host:        s.cfg.Host,
+		Port:        s.cfg.Port,
+		RequireAuth: s.cfg.RequireAuth,
+		ReadOnly:    s.db.ReadOnly(),
 	}
 	if isLocalhostContext(ctx) {
 		resp.AuthToken = s.cfg.AuthToken
 	}
 	s.mu.RUnlock()
+	resp.GithubConfigured = resolveGitHubToken(ctx, githubToken) != ""
 	return &jsonOutput[settingsResponse]{Body: resp}, nil
 }
 

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -277,6 +277,8 @@ func TestInsightPublish(t *testing.T) {
 	})
 
 	t.Run("NoToken", func(t *testing.T) {
+		t.Setenv("AGENTSVIEW_GITHUB_TOKEN", "")
+		t.Setenv("PATH", t.TempDir())
 		te := setup(t)
 		id := te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"))
 

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -286,6 +286,23 @@ func TestInsightPublish(t *testing.T) {
 		assertStatus(t, w, http.StatusUnauthorized)
 	})
 
+	t.Run("ForwardedRequestDoesNotUseGitHubCLIAuthTokenFallback", func(t *testing.T) {
+		useGitHubCLIAuthTokenStub(t)
+		te := setup(t)
+		id := te.seedInsight(t, "daily_activity", "2025-01-15", new("my-app"))
+
+		req := httptest.NewRequest(http.MethodPost,
+			fmt.Sprintf("/api/v1/insights/%d/publish", id),
+			strings.NewReader("{}"))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Origin", "http://127.0.0.1:0")
+		req.Header.Set("X-Forwarded-For", "203.0.113.10")
+		w := httptest.NewRecorder()
+		te.handler.ServeHTTP(w, req)
+
+		assertStatus(t, w, http.StatusUnauthorized)
+	})
+
 	t.Run("NotFound", func(t *testing.T) {
 		te := setup(t)
 		te.srv.SetGithubToken("fake-token")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -346,11 +346,12 @@ func (s *Server) SetGithubToken(token string) {
 	s.cfg.GithubToken = token
 }
 
-// githubToken returns the current GitHub token (thread-safe).
-func (s *Server) githubToken() string {
+// githubToken returns the configured GitHub token or a fallback token
+// from the process environment / GitHub CLI (thread-safe).
+func (s *Server) githubToken(ctx context.Context) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.cfg.GithubToken
+	return resolveGitHubToken(ctx, s.cfg.GithubToken)
 }
 
 // Handler returns the http.Handler with middleware applied.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -14,8 +14,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	stdlibsync "sync"
@@ -2878,11 +2878,20 @@ func TestGetSettings_UsesGitHubCLIAuthTokenFallback(t *testing.T) {
 
 func useGitHubCLIAuthTokenStub(t *testing.T) {
 	t.Helper()
-	if _, err := exec.LookPath("sh"); err != nil {
-		t.Skipf("sh not available on PATH: %v", err)
-	}
 	t.Setenv("AGENTSVIEW_GITHUB_TOKEN", "")
 	binDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		ghPath := filepath.Join(binDir, "gh.cmd")
+		require.NoError(t, os.WriteFile(ghPath, []byte(`@echo off
+if "%1"=="auth" if "%2"=="token" (
+  echo gh-token-from-cli
+  exit /b 0
+)
+exit /b 1
+`), 0o644))
+		t.Setenv("PATH", binDir)
+		return
+	}
 	ghPath := filepath.Join(binDir, "gh")
 	require.NoError(t, os.WriteFile(ghPath, []byte(`#!/bin/sh
 if [ "$1" = "auth" ] && [ "$2" = "token" ]; then

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -1091,6 +1092,10 @@ type syncStatusResponse struct {
 
 type githubConfigResponse struct {
 	Configured bool `json:"configured"`
+}
+
+type settingsConfigResponse struct {
+	GithubConfigured bool `json:"github_configured"`
 }
 
 type uploadResponse struct {
@@ -2669,6 +2674,8 @@ func TestAuthRequiredProtectsPing(t *testing.T) {
 }
 
 func TestGetGithubConfig(t *testing.T) {
+	t.Setenv("AGENTSVIEW_GITHUB_TOKEN", "")
+	t.Setenv("PATH", t.TempDir())
 	te := setup(t)
 
 	w := te.get(t, "/api/v1/config/github")
@@ -2839,11 +2846,52 @@ func TestMarkdownSessionExport_DepthAllRecurses(t *testing.T) {
 }
 
 func TestPublishSession_NoToken(t *testing.T) {
+	t.Setenv("AGENTSVIEW_GITHUB_TOKEN", "")
+	t.Setenv("PATH", t.TempDir())
 	te := setup(t)
 	te.seedSession(t, "s1", "my-app", 3)
 
 	w := te.post(t, "/api/v1/sessions/s1/publish", "{}")
 	assertStatus(t, w, http.StatusUnauthorized)
+}
+
+func TestGetGithubConfig_UsesGitHubCLIAuthTokenFallback(t *testing.T) {
+	useGitHubCLIAuthTokenStub(t)
+	te := setup(t)
+
+	w := te.get(t, "/api/v1/config/github")
+
+	assertStatus(t, w, http.StatusOK)
+	assert.JSONEq(t, `{"configured":true}`, w.Body.String())
+}
+
+func TestGetSettings_UsesGitHubCLIAuthTokenFallback(t *testing.T) {
+	useGitHubCLIAuthTokenStub(t)
+	te := setup(t)
+
+	w := te.get(t, "/api/v1/settings")
+
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[settingsConfigResponse](t, w)
+	assert.True(t, resp.GithubConfigured)
+}
+
+func useGitHubCLIAuthTokenStub(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh not available on PATH: %v", err)
+	}
+	t.Setenv("AGENTSVIEW_GITHUB_TOKEN", "")
+	binDir := t.TempDir()
+	ghPath := filepath.Join(binDir, "gh")
+	require.NoError(t, os.WriteFile(ghPath, []byte(`#!/bin/sh
+if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+  printf 'gh-token-from-cli\n'
+  exit 0
+fi
+exit 1
+`), 0o755))
+	t.Setenv("PATH", binDir)
 }
 
 func TestSetGithubConfig_InvalidInput(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -828,6 +828,10 @@ func withRemoteAddr(addr string) requestOpt {
 	return func(r *http.Request) { r.RemoteAddr = addr }
 }
 
+func withHeader(name, value string) requestOpt {
+	return func(r *http.Request) { r.Header.Set(name, value) }
+}
+
 func withBearer(token string) requestOpt {
 	return func(r *http.Request) {
 		r.Header.Set("Authorization", "Bearer "+token)
@@ -2865,6 +2869,29 @@ func TestGetGithubConfig_UsesGitHubCLIAuthTokenFallback(t *testing.T) {
 	assert.JSONEq(t, `{"configured":true}`, w.Body.String())
 }
 
+func TestGetGithubConfig_DoesNotUseGitHubCLIAuthTokenFallbackForForwardedRequest(t *testing.T) {
+	useGitHubCLIAuthTokenStub(t)
+	te := setup(t)
+
+	w := te.wrappedRequest(http.MethodGet, "/api/v1/config/github",
+		withHeader("X-Forwarded-For", "203.0.113.10"))
+
+	assertStatus(t, w, http.StatusOK)
+	assert.JSONEq(t, `{"configured":false}`, w.Body.String())
+}
+
+func TestGetGithubConfig_UsesSavedGitHubTokenForForwardedRequest(t *testing.T) {
+	useGitHubCLIAuthTokenStub(t)
+	te := setup(t)
+	te.srv.SetGithubToken("saved-token")
+
+	w := te.wrappedRequest(http.MethodGet, "/api/v1/config/github",
+		withHeader("X-Forwarded-For", "203.0.113.10"))
+
+	assertStatus(t, w, http.StatusOK)
+	assert.JSONEq(t, `{"configured":true}`, w.Body.String())
+}
+
 func TestGetSettings_UsesGitHubCLIAuthTokenFallback(t *testing.T) {
 	useGitHubCLIAuthTokenStub(t)
 	te := setup(t)
@@ -2874,6 +2901,22 @@ func TestGetSettings_UsesGitHubCLIAuthTokenFallback(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 	resp := decode[settingsConfigResponse](t, w)
 	assert.True(t, resp.GithubConfigured)
+}
+
+func TestPublishSession_DoesNotUseGitHubCLIAuthTokenFallbackForForwardedRequest(t *testing.T) {
+	useGitHubCLIAuthTokenStub(t)
+	te := setup(t)
+	te.seedSession(t, "s1", "my-app", 3)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/s1/publish",
+		strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	w := httptest.NewRecorder()
+	te.handler.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusUnauthorized)
 }
 
 func useGitHubCLIAuthTokenStub(t *testing.T) {


### PR DESCRIPTION
Local Gist publishing should not force users to paste and persist a personal access token when the GitHub CLI already has an authenticated token available. That CLI token is usually the safer local default because it keeps credential ownership with GitHub CLI instead of adding another saved secret to AgentsView.

This keeps saved `github_token` values as the highest-precedence source so existing configurations and intentional overrides continue to behave the same. When no saved token exists, AgentsView now falls back to `AGENTSVIEW_GITHUB_TOKEN` and then `gh auth token`, and both the publish modal and Settings status treat those fallback sources as configured.

The docs now describe `gh auth login` as the normal local setup path, while keeping the saved-token flow available for users who need AgentsView to use a specific token.