### PR TITLE
feat(sync): surface parser anomaly signals in the sync summary

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -650,6 +651,7 @@ func printSyncSummary(stats sync.SyncStats, t time.Time) {
 	summary += fmt.Sprintf(
 		" in %s\n", time.Since(t).Round(time.Millisecond),
 	)
+	summary += formatAnomalySummary(stats.Anomalies)
 	fmt.Print(summary)
 	for _, w := range stats.Warnings {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
@@ -750,6 +752,62 @@ func resyncProgressDisplayLabel(p sync.Progress) string {
 		return p.Detail
 	}
 	return p.Detail + " - " + p.Hint
+}
+
+// formatAnomalySummary renders the parser/sanitizer anomaly section of a
+// sync summary. It returns an empty string on a clean run so the section
+// is omitted entirely; otherwise it returns a concise, indented block
+// listing per-agent parser malformed lines and the central-validation fix
+// counts observed during the run.
+func formatAnomalySummary(a sync.AnomalyStats) string {
+	if a.IsZero() {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Parser anomalies (this run):\n")
+	if a.MalformedLinesTotal > 0 {
+		fmt.Fprintf(&b,
+			"  malformed lines: %d total\n", a.MalformedLinesTotal,
+		)
+		for _, agent := range slices.Sorted(
+			maps.Keys(a.MalformedLinesByAgent),
+		) {
+			fmt.Fprintf(&b,
+				"    %s: %d\n", agent, a.MalformedLinesByAgent[agent],
+			)
+		}
+	}
+	if !a.Sanitize.IsZero() {
+		fmt.Fprintf(&b,
+			"  sanitized fields: %d total\n", a.Sanitize.Total(),
+		)
+		for _, line := range sanitizeBreakdownLines(a.Sanitize) {
+			b.WriteString("    " + line + "\n")
+		}
+	}
+	return b.String()
+}
+
+// sanitizeBreakdownLines returns the non-zero per-category sanitize counts
+// as "label: n" lines in a fixed, deterministic order.
+func sanitizeBreakdownLines(s sync.SanitizeStats) []string {
+	cats := []struct {
+		label string
+		count int
+	}{
+		{"control chars stripped", s.ControlCharsStripped},
+		{"model clamped", s.ModelClamped},
+		{"tokens clamped", s.TokensClamped},
+		{"role coerced", s.RoleCoerced},
+		{"timestamps blanked", s.TimestampsBlanked},
+	}
+	var out []string
+	for _, c := range cats {
+		if c.count > 0 {
+			out = append(out, fmt.Sprintf("%s: %d", c.label, c.count))
+		}
+	}
+	return out
 }
 
 func printSyncProgress(p sync.Progress) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -636,4 +637,123 @@ func TestFinishInitialResyncSkipsMarkerWhenSignalsNeedBackfill(t *testing.T) {
 	finishInitialResync(marker, false)
 
 	assert.Equal(t, 0, marker.calls)
+}
+
+func TestFormatAnomalySummary(t *testing.T) {
+	tests := []struct {
+		name        string
+		anomalies   agentsync.AnomalyStats
+		wantEmpty   bool
+		wantContain []string
+		wantOmit    []string
+	}{
+		{
+			name:      "clean run omits the section",
+			anomalies: agentsync.AnomalyStats{},
+			wantEmpty: true,
+		},
+		{
+			name: "malformed lines only",
+			anomalies: agentsync.AnomalyStats{
+				MalformedLinesByAgent: map[string]int{
+					"claude": 3, "codex": 1,
+				},
+				MalformedLinesTotal: 4,
+			},
+			wantContain: []string{
+				"Parser anomalies (this run):",
+				"malformed lines: 4 total",
+				"claude: 3",
+				"codex: 1",
+			},
+			wantOmit: []string{"sanitized fields"},
+		},
+		{
+			name: "sanitize fixes only, zero categories omitted",
+			anomalies: agentsync.AnomalyStats{
+				Sanitize: agentsync.SanitizeStats{
+					ControlCharsStripped: 2,
+					ModelClamped:         1,
+				},
+			},
+			wantContain: []string{
+				"sanitized fields: 3 total",
+				"control chars stripped: 2",
+				"model clamped: 1",
+			},
+			wantOmit: []string{
+				"malformed lines",
+				"tokens clamped",
+				"role coerced",
+				"timestamps blanked",
+			},
+		},
+		{
+			name: "both sections present",
+			anomalies: agentsync.AnomalyStats{
+				MalformedLinesByAgent: map[string]int{"gemini": 7},
+				MalformedLinesTotal:   7,
+				Sanitize: agentsync.SanitizeStats{
+					TokensClamped:     4,
+					TimestampsBlanked: 1,
+				},
+			},
+			wantContain: []string{
+				"malformed lines: 7 total",
+				"gemini: 7",
+				"sanitized fields: 5 total",
+				"tokens clamped: 4",
+				"timestamps blanked: 1",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatAnomalySummary(tc.anomalies)
+			if tc.wantEmpty {
+				assert.Empty(t, got)
+				return
+			}
+			for _, want := range tc.wantContain {
+				assert.Contains(t, got, want)
+			}
+			for _, omit := range tc.wantOmit {
+				assert.NotContains(t, got, omit)
+			}
+		})
+	}
+}
+
+func TestPrintSyncSummaryAnomalySection(t *testing.T) {
+	t.Run("clean run omits anomaly section", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			printSyncSummary(agentsync.SyncStats{Synced: 3}, time.Now())
+		})
+		assert.Contains(t, out, "Sync complete: 3 sessions synced")
+		assert.NotContains(t, out, "Parser anomalies")
+	})
+
+	t.Run("non-zero anomalies print the section", func(t *testing.T) {
+		stats := agentsync.SyncStats{
+			Synced: 2,
+			Anomalies: agentsync.AnomalyStats{
+				MalformedLinesByAgent: map[string]int{"claude": 5},
+				MalformedLinesTotal:   5,
+				Sanitize: agentsync.SanitizeStats{
+					ControlCharsStripped: 2,
+				},
+			},
+		}
+		out := captureStdout(t, func() {
+			printSyncSummary(stats, time.Now())
+		})
+		assert.Contains(t, out, "Parser anomalies (this run):")
+		assert.Contains(t, out, "malformed lines: 5 total")
+		assert.Contains(t, out, "claude: 5")
+		assert.Contains(t, out, "control chars stripped: 2")
+		// Anomaly section follows the one-line summary.
+		idx := strings.Index(out, "Sync complete")
+		anomalyIdx := strings.Index(out, "Parser anomalies")
+		assert.Less(t, idx, anomalyIdx)
+	})
 }

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -264,6 +264,7 @@ func printSyncSummaryStderr(stats sync.SyncStats, t time.Time) {
 	summary += fmt.Sprintf(
 		" in %s\n", time.Since(t).Round(time.Millisecond),
 	)
+	summary += formatAnomalySummary(stats.Anomalies)
 	fmt.Fprint(os.Stderr, summary)
 	for _, w := range stats.Warnings {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7402,7 +7402,9 @@ func (e *Engine) prepareSessionWrite(
 	// agent for the sync summary's anomaly section.
 	vs := validateAndSanitize(&s, msgs, nil)
 	e.anomalies.recordSanitize(vs)
-	e.anomalies.recordMalformedLines(s.Agent, s.ParserMalformedLines)
+	e.anomalies.recordMalformedLines(
+		s.Agent, pw.sess.File.Path, s.ParserMalformedLines,
+	)
 
 	// A per-row token clamp must not leave an inflated value stranded in a
 	// row-derived session total while the row that produced it was clamped.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -118,6 +118,12 @@ type Engine struct {
 	// write path. Exposed via PhaseStats() so a CLI driver can log the
 	// totals after a sync pass completes.
 	phaseStats PhaseStats
+
+	// anomalies accumulates per-run parser/sanitizer anomaly signals
+	// recorded at the write seam (prepareSessionWrite, writeIncremental,
+	// toDBUsageEvents). Reset at the start of each sync run and folded
+	// into the returned SyncStats before the run completes.
+	anomalies anomalyAccumulator
 }
 
 // PhaseStats returns the engine's phase counter. The values reflect only
@@ -445,11 +451,13 @@ func (e *Engine) SyncPaths(paths []string) {
 	defer e.clearCurrentProgress()
 	e.resetS3CodexIndexCache()
 
+	e.anomalies.reset()
 	results := e.startWorkers(context.Background(), files)
 	stats = e.collectAndBatch(
 		context.Background(), results, len(files), len(files), nil,
 		syncWriteDefault,
 	)
+	e.anomalies.applyTo(&stats)
 	e.persistSkipCache()
 
 	e.mu.Lock()
@@ -2757,7 +2765,7 @@ func samePathOrDescendant(path, root string) bool {
 func (e *Engine) syncAllLocked(
 	ctx context.Context, onProgress ProgressFunc, since time.Time,
 	scope *rootSyncScope, writeMode syncWriteMode, recordSyncState bool,
-) SyncStats {
+) (stats SyncStats) {
 	if ctx.Err() != nil {
 		return SyncStats{Aborted: true}
 	}
@@ -2767,6 +2775,10 @@ func (e *Engine) syncAllLocked(
 	}
 	e.phaseStats.Reset()
 	e.resetS3CodexIndexCache()
+	e.anomalies.reset()
+	// Fold the per-run anomaly accumulator into the returned stats on
+	// every exit path so the CLI sync summary can surface them.
+	defer func() { e.anomalies.applyTo(&stats) }()
 
 	t0 := time.Now()
 
@@ -2829,7 +2841,7 @@ func (e *Engine) syncAllLocked(
 
 	tWorkers := time.Now()
 	results := e.startWorkers(ctx, all)
-	stats := e.collectAndBatch(
+	stats = e.collectAndBatch(
 		ctx, results, len(all), progressTotal, onProgress, writeMode,
 	)
 	if verbose {
@@ -3171,9 +3183,15 @@ func (e *Engine) syncAllLocked(
 		MessagesIndexed: stats.messagesIndexed,
 	})
 
+	// Store the anomaly-folded stats so LastSyncStats (UI) matches the
+	// value returned to the CLI summary. The deferred applyTo only reads
+	// the accumulator, so folding a separate copy here does not
+	// double-count.
+	persisted := stats
+	e.anomalies.applyTo(&persisted)
 	e.mu.Lock()
 	e.lastSync = time.Now()
-	e.lastSyncStats = stats
+	e.lastSyncStats = persisted
 	e.mu.Unlock()
 
 	if recordSyncState {
@@ -7284,7 +7302,7 @@ func (e *Engine) writeBatch(
 			continue
 		}
 		if err := e.db.ReplaceSessionUsageEvents(
-			s.ID, toDBUsageEvents(s.ID, pw.usageEvents),
+			s.ID, e.usageEventsForWrite(s.ID, pw.usageEvents),
 		); err != nil {
 			log.Printf(
 				"write usage events for %s: %v",
@@ -7379,9 +7397,12 @@ func (e *Engine) prepareSessionWrite(
 		s.PeakContextTokens == evtPeak
 
 	// Central validation/sanitization pass: every session write flows
-	// through here so all agents are covered uniformly. Stats are discarded
-	// for now; a later anomaly-counter task will surface them.
-	_ = validateAndSanitize(&s, msgs, nil)
+	// through here so all agents are covered uniformly. The returned fix
+	// counts and the parser malformed-line count are accumulated per
+	// agent for the sync summary's anomaly section.
+	vs := validateAndSanitize(&s, msgs, nil)
+	e.anomalies.recordSanitize(vs)
+	e.anomalies.recordMalformedLines(s.Agent, s.ParserMalformedLines)
 
 	// A per-row token clamp must not leave an inflated value stranded in a
 	// row-derived session total while the row that produced it was clamped.
@@ -8097,7 +8118,7 @@ func (e *Engine) writeBatchBulk(
 		writes = append(writes, db.SessionBatchWrite{
 			Session:         s,
 			Messages:        msgs,
-			UsageEvents:     toDBUsageEvents(s.ID, pw.usageEvents),
+			UsageEvents:     e.usageEventsForWrite(s.ID, pw.usageEvents),
 			Signals:         update,
 			Findings:        findings,
 			DataVersion:     dataVersionForWrite(pw),
@@ -8175,8 +8196,9 @@ func (e *Engine) writeIncremental(
 	)
 	// The incremental append path bypasses prepareSessionWrite, so run
 	// the central validation/sanitization pass on the new message rows
-	// here to keep coverage uniform across write paths.
-	_ = validateAndSanitize(nil, dbMsgs, nil)
+	// here to keep coverage uniform across write paths. The fix counts
+	// feed the sync summary's anomaly section.
+	e.anomalies.recordSanitize(validateAndSanitize(nil, dbMsgs, nil))
 
 	// Adjust counts for blocked-category filtering.
 	newTotal, newUser := postFilterCounts(dbMsgs)
@@ -8333,7 +8355,7 @@ func (e *Engine) writeSessionFullWithResolver(
 		return err
 	}
 	if err := e.db.ReplaceSessionUsageEvents(
-		s.ID, toDBUsageEvents(s.ID, pw.usageEvents),
+		s.ID, e.usageEventsForWrite(s.ID, pw.usageEvents),
 	); err != nil {
 		log.Printf(
 			"replace usage events for %s: %v",
@@ -8805,10 +8827,12 @@ func toDBMessages(pw pendingWrite, blocked map[string]bool) []db.Message {
 
 // toDBUsageEvents converts parser usage events for one session.
 // sessionID is the final ID after remote rewrites; parser-stamped
-// event session IDs predate the idPrefix and are ignored.
+// event session IDs predate the idPrefix and are ignored. It returns the
+// fix counts from the central validation/sanitization pass so write paths
+// can surface them in the sync summary; diagnostic callers may discard.
 func toDBUsageEvents(
 	sessionID string, events []parser.ParsedUsageEvent,
-) []db.UsageEvent {
+) ([]db.UsageEvent, validationStats) {
 	out := make([]db.UsageEvent, 0, len(events))
 	for _, ev := range events {
 		out = append(out, db.UsageEvent{
@@ -8830,8 +8854,18 @@ func toDBUsageEvents(
 	}
 	// Route usage events through the central validation/sanitization
 	// pass so they get the same treatment as messages and sessions at
-	// every call site. Stats are discarded for now.
-	_ = validateAndSanitize(nil, nil, out)
+	// every call site.
+	return out, validateAndSanitize(nil, nil, out)
+}
+
+// usageEventsForWrite converts usage events for a session about to be
+// written and records the central-validation fix counts in the per-run
+// anomaly accumulator for the sync summary.
+func (e *Engine) usageEventsForWrite(
+	sessionID string, events []parser.ParsedUsageEvent,
+) []db.UsageEvent {
+	out, vs := toDBUsageEvents(sessionID, events)
+	e.anomalies.recordSanitize(vs)
 	return out
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8200,6 +8200,22 @@ func (e *Engine) writeIncremental(
 	// the central validation/sanitization pass on the new message rows
 	// here to keep coverage uniform across write paths. The fix counts
 	// feed the sync summary's anomaly section.
+	//
+	// Deliberately only sanitize fixes are recorded here, not malformed-line
+	// counts. A malformed JSONL line appended to an actively-syncing file is
+	// skipped by the incremental reader, and incrementalParseFunc carries no
+	// malformed-line count, so surfacing it on this path would require
+	// threading a new return value through the incremental parser API across
+	// every append-only agent. That is intentionally out of scope for this
+	// best-effort, only-when-nonzero diagnostic: the value is still parsed and
+	// persisted, and the next full sync (the periodic pass, or any
+	// parser-version bump that forces a full resync) re-derives the
+	// malformed-line count for the file. The incremental path therefore
+	// under-reports a brand-new summary signal by at most one full-sync
+	// interval; it never loses stored data and is not a regression on any
+	// prior behavior (no malformed-line count was surfaced anywhere before
+	// this feature). Full malformed-line coverage on the incremental path is a
+	// deferred follow-up.
 	e.anomalies.recordSanitize(validateAndSanitize(nil, dbMsgs, nil))
 
 	// Adjust counts for blocked-category filtering.

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1514,8 +1514,17 @@ func TestSyncEngineSkipCache(t *testing.T) {
 		"not json at all\x00\x01",
 	)
 
+	// The deliberately malformed content yields one parser malformed
+	// line, which the sync summary now surfaces per agent.
+	malformed := sync.AnomalyStats{
+		MalformedLinesByAgent: map[string]int{"claude": 1},
+		MalformedLinesTotal:   1,
+	}
+
 	// First sync — file parsed (empty session stored)
-	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1, Synced: 1, Skipped: 0})
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1, Skipped: 0, Anomalies: malformed,
+	})
 
 	// Second sync — unchanged mtime, should be skipped
 	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 0 + 1, Synced: 0, Skipped: 1})
@@ -1525,7 +1534,9 @@ func TestSyncEngineSkipCache(t *testing.T) {
 	os.Chtimes(path, time.Now(), time.Now())
 
 	// Third sync — mtime changed → re-synced (harmless)
-	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1 + 0, Synced: 1, Skipped: 0})
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1 + 0, Synced: 1, Skipped: 0, Anomalies: malformed,
+	})
 }
 
 func TestSyncEngineFileAppend(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -892,7 +892,7 @@ func TestToDBUsageEventsStampsFinalSessionID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toDBUsageEvents(tt.sessionID, tt.events)
+			got, _ := toDBUsageEvents(tt.sessionID, tt.events)
 			require.Len(t, got, len(tt.wantIDs))
 			for i, ev := range got {
 				assert.Equal(t, tt.wantIDs[i], ev.SessionID)
@@ -904,7 +904,7 @@ func TestToDBUsageEventsStampsFinalSessionID(t *testing.T) {
 func TestToDBUsageEventsPreservesSessionSummaryTokenUpperBounds(t *testing.T) {
 	rawInput := maxPlausibleTokens + 250_000
 	rawOutput := maxPlausibleTokens + 500_000
-	got := toDBUsageEvents("hermes:summary", []parser.ParsedUsageEvent{
+	got, _ := toDBUsageEvents("hermes:summary", []parser.ParsedUsageEvent{
 		{
 			Source:                   "session",
 			Model:                    "gpt-5.4",

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -585,7 +585,7 @@ func (e *Engine) parseDiffCollectFile(
 		compare := ok && !pw.needsRetry &&
 			stored != nil && stored.DeletedAt == nil
 		if compare {
-			events := toDBUsageEvents(id, pw.usageEvents)
+			events, _ := toDBUsageEvents(id, pw.usageEvents)
 			var err error
 			fields, err = e.compareStoredSession(
 				ctx, stored, prepared, msgs, events,

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -1142,7 +1142,7 @@ func TestCompareStoredSessionRoundTrip(t *testing.T) {
 
 	prepared, msgs, ok := e.prepareSessionWrite(pw, nil)
 	require.True(t, ok)
-	events := toDBUsageEvents(prepared.ID, pw.usageEvents)
+	events, _ := toDBUsageEvents(prepared.ID, pw.usageEvents)
 
 	stored := pdFetchStored(t, d, prepared.ID)
 	diffs, err := e.compareStoredSession(

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -61,7 +61,7 @@ type SyncStats struct {
 	// surfaced in the CLI sync summary. These are live per-run counters
 	// (reset each sync), not persisted state. A zero value means a clean
 	// run and is omitted from the summary.
-	Anomalies AnomalyStats `json:"anomalies,omitempty"`
+	Anomalies AnomalyStats `json:"anomalies,omitzero"`
 
 	filesOK             int // unexported: file-level success counter
 	filesDiscovered     int // file-based total, excludes DB-backed agents
@@ -86,7 +86,7 @@ type AnomalyStats struct {
 
 	// Sanitize aggregates the central validation/sanitization fix counts
 	// across every session, message, and usage event written this run.
-	Sanitize SanitizeStats `json:"sanitize,omitempty"`
+	Sanitize SanitizeStats `json:"sanitize,omitzero"`
 }
 
 // SanitizeStats mirrors the per-category fix counts produced by the central

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -1,5 +1,7 @@
 package sync
 
+import gosync "sync"
+
 // Phase describes the current sync phase.
 type Phase string
 
@@ -55,11 +57,147 @@ type SyncStats struct {
 	Warnings       []string `json:"warnings,omitempty"`
 	Aborted        bool     `json:"aborted,omitempty"`
 
+	// Anomalies aggregates per-run parser/sanitizer anomaly signals
+	// surfaced in the CLI sync summary. These are live per-run counters
+	// (reset each sync), not persisted state. A zero value means a clean
+	// run and is omitted from the summary.
+	Anomalies AnomalyStats `json:"anomalies,omitempty"`
+
 	filesOK             int // unexported: file-level success counter
 	filesDiscovered     int // file-based total, excludes DB-backed agents
 	messagesIndexed     int // unexported: progress message counter
 	parserExcludedFiles int // file-level intentional parser exclusions
 	parserExcludedIDs   []string
+}
+
+// AnomalyStats aggregates parser-output anomaly signals observed during a
+// single sync run. It surfaces numbers that already exist or are already
+// computed but were previously discarded: per-agent parser malformed-line
+// counts (parser_malformed_lines) and the per-category counts returned by
+// the central validateAndSanitize pass. It is a per-run summary only; no
+// new persisted columns back it.
+type AnomalyStats struct {
+	// MalformedLinesByAgent maps an agent type to the total number of
+	// parser malformed lines reported by sessions of that agent in this
+	// run. Only non-zero agents are present.
+	MalformedLinesByAgent map[string]int `json:"malformed_lines_by_agent,omitempty"`
+	// MalformedLinesTotal is the grand total across all agents.
+	MalformedLinesTotal int `json:"malformed_lines_total,omitempty"`
+
+	// Sanitize aggregates the central validation/sanitization fix counts
+	// across every session, message, and usage event written this run.
+	Sanitize SanitizeStats `json:"sanitize,omitempty"`
+}
+
+// SanitizeStats mirrors the per-category fix counts produced by the central
+// validateAndSanitize pass, accumulated across a full sync run. It is the
+// exported, summary-facing form of the internal validationStats so the CLI
+// summary can render it.
+type SanitizeStats struct {
+	ControlCharsStripped int `json:"control_chars_stripped,omitempty"`
+	ModelClamped         int `json:"model_clamped,omitempty"`
+	TokensClamped        int `json:"tokens_clamped,omitempty"`
+	RoleCoerced          int `json:"role_coerced,omitempty"`
+	TimestampsBlanked    int `json:"timestamps_blanked,omitempty"`
+}
+
+// Total returns the sum of all sanitize fix counts.
+func (s SanitizeStats) Total() int {
+	return s.ControlCharsStripped + s.ModelClamped + s.TokensClamped +
+		s.RoleCoerced + s.TimestampsBlanked
+}
+
+// IsZero reports whether no sanitize fixes were recorded.
+func (s SanitizeStats) IsZero() bool {
+	return s.Total() == 0
+}
+
+// IsZero reports whether the run observed no anomalies at all, so the CLI
+// summary can omit the anomaly section entirely on clean runs.
+func (a AnomalyStats) IsZero() bool {
+	return a.MalformedLinesTotal == 0 && a.Sanitize.IsZero()
+}
+
+// RecordMalformedLines attributes n parser malformed lines to the given
+// agent and updates the grand total. A zero count is ignored so clean
+// agents do not appear in the per-agent breakdown.
+func (a *AnomalyStats) RecordMalformedLines(agent string, n int) {
+	if n <= 0 {
+		return
+	}
+	if a.MalformedLinesByAgent == nil {
+		a.MalformedLinesByAgent = make(map[string]int)
+	}
+	a.MalformedLinesByAgent[agent] += n
+	a.MalformedLinesTotal += n
+}
+
+// addSanitize accumulates the per-category counts from one
+// validateAndSanitize pass into the aggregate.
+func (a *AnomalyStats) addSanitize(v validationStats) {
+	a.Sanitize.ControlCharsStripped += v.ControlCharsStripped
+	a.Sanitize.ModelClamped += v.ModelClamped
+	a.Sanitize.TokensClamped += v.TokensClamped
+	a.Sanitize.RoleCoerced += v.RoleCoerced
+	a.Sanitize.TimestampsBlanked += v.TimestampsBlanked
+}
+
+// merge folds another AnomalyStats into the receiver.
+func (a *AnomalyStats) merge(o AnomalyStats) {
+	for agent, n := range o.MalformedLinesByAgent {
+		a.RecordMalformedLines(agent, n)
+	}
+	a.Sanitize.ControlCharsStripped += o.Sanitize.ControlCharsStripped
+	a.Sanitize.ModelClamped += o.Sanitize.ModelClamped
+	a.Sanitize.TokensClamped += o.Sanitize.TokensClamped
+	a.Sanitize.RoleCoerced += o.Sanitize.RoleCoerced
+	a.Sanitize.TimestampsBlanked += o.Sanitize.TimestampsBlanked
+}
+
+// anomalyAccumulator is the engine's per-run, concurrency-safe sink for
+// anomaly signals recorded at the write seam (prepareSessionWrite,
+// writeIncremental, and the usage-event conversion path). It mirrors the
+// phaseStats accumulator pattern: reset at the start of a sync run and
+// folded into the returned SyncStats before the run completes. Although the
+// write path is serialized under syncMu today, the mutex keeps recording
+// safe if a future caller writes from multiple goroutines.
+type anomalyAccumulator struct {
+	mu    gosync.Mutex
+	stats AnomalyStats
+}
+
+// reset clears the accumulator at the start of a sync run.
+func (a *anomalyAccumulator) reset() {
+	a.mu.Lock()
+	a.stats = AnomalyStats{}
+	a.mu.Unlock()
+}
+
+// recordMalformedLines accumulates parser malformed lines for an agent.
+func (a *anomalyAccumulator) recordMalformedLines(agent string, n int) {
+	if n <= 0 {
+		return
+	}
+	a.mu.Lock()
+	a.stats.RecordMalformedLines(agent, n)
+	a.mu.Unlock()
+}
+
+// recordSanitize accumulates one validateAndSanitize pass's fix counts.
+func (a *anomalyAccumulator) recordSanitize(v validationStats) {
+	if (v == validationStats{}) {
+		return
+	}
+	a.mu.Lock()
+	a.stats.addSanitize(v)
+	a.mu.Unlock()
+}
+
+// applyTo folds the accumulated anomalies into the given SyncStats.
+func (a *anomalyAccumulator) applyTo(s *SyncStats) {
+	a.mu.Lock()
+	s.Anomalies.merge(a.stats)
+	a.mu.Unlock()
 }
 
 // RecordSkip increments the skipped session counter.

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -164,23 +164,44 @@ func (a *AnomalyStats) merge(o AnomalyStats) {
 type anomalyAccumulator struct {
 	mu    gosync.Mutex
 	stats AnomalyStats
+	// malformedFiles tracks source paths whose malformed-line count has
+	// already been recorded this run, so a file that forks into several
+	// sessions counts its malformed lines once. Reset each run.
+	malformedFiles map[string]bool
 }
 
 // reset clears the accumulator at the start of a sync run.
 func (a *anomalyAccumulator) reset() {
 	a.mu.Lock()
 	a.stats = AnomalyStats{}
+	a.malformedFiles = nil
 	a.mu.Unlock()
 }
 
-// recordMalformedLines accumulates parser malformed lines for an agent.
-func (a *anomalyAccumulator) recordMalformedLines(agent string, n int) {
+// recordMalformedLines accumulates an agent's parser malformed-line count for
+// one source file. A single source file can fork into several sessions (e.g.
+// Claude subagents) that each carry the same source-level count, so the count
+// is recorded once per non-empty source path to avoid multiplying a single
+// malformed line across the fork. Sessions with no source path (DB-backed
+// agents) are recorded as-is.
+func (a *anomalyAccumulator) recordMalformedLines(
+	agent, sourcePath string, n int,
+) {
 	if n <= 0 {
 		return
 	}
 	a.mu.Lock()
+	defer a.mu.Unlock()
+	if sourcePath != "" {
+		if a.malformedFiles[sourcePath] {
+			return
+		}
+		if a.malformedFiles == nil {
+			a.malformedFiles = make(map[string]bool)
+		}
+		a.malformedFiles[sourcePath] = true
+	}
 	a.stats.RecordMalformedLines(agent, n)
-	a.mu.Unlock()
 }
 
 // recordSanitize accumulates one validateAndSanitize pass's fix counts.

--- a/internal/sync/progress_test.go
+++ b/internal/sync/progress_test.go
@@ -109,10 +109,10 @@ func TestAnomalyAccumulator_Aggregate(t *testing.T) {
 
 	// Two sessions of one agent, one of another, plus sanitize fixes
 	// from messages and usage events across the run.
-	acc.recordMalformedLines("claude", 4)
-	acc.recordMalformedLines("codex", 1)
-	acc.recordMalformedLines("claude", 2)
-	acc.recordMalformedLines("gemini", 0) // ignored
+	acc.recordMalformedLines("claude", "a.jsonl", 4)
+	acc.recordMalformedLines("codex", "b.jsonl", 1)
+	acc.recordMalformedLines("claude", "c.jsonl", 2)
+	acc.recordMalformedLines("gemini", "d.jsonl", 0) // ignored
 
 	acc.recordSanitize(validationStats{ControlCharsStripped: 3, RoleCoerced: 1})
 	acc.recordSanitize(validationStats{ModelClamped: 2, TokensClamped: 5})
@@ -134,9 +134,35 @@ func TestAnomalyAccumulator_Aggregate(t *testing.T) {
 	assert.False(t, stats.Anomalies.IsZero())
 }
 
+// TestAnomalyAccumulator_DedupesMalformedLinesPerSourceFile verifies a source
+// file that forks into several sessions counts its malformed lines once, while
+// distinct files and empty-path (DB-backed) sessions still accumulate.
+func TestAnomalyAccumulator_DedupesMalformedLinesPerSourceFile(t *testing.T) {
+	var acc anomalyAccumulator
+	acc.reset()
+
+	// Three forked sessions of one Claude file all carry the same count.
+	acc.recordMalformedLines("claude", "fork.jsonl", 2)
+	acc.recordMalformedLines("claude", "fork.jsonl", 2)
+	acc.recordMalformedLines("claude", "fork.jsonl", 2)
+	// A different source file counts independently.
+	acc.recordMalformedLines("claude", "other.jsonl", 5)
+	// Empty path (DB-backed agent) is not deduped.
+	acc.recordMalformedLines("warp", "", 1)
+	acc.recordMalformedLines("warp", "", 1)
+
+	var stats SyncStats
+	acc.applyTo(&stats)
+	assert.Equal(t, 2+5, stats.Anomalies.MalformedLinesByAgent["claude"],
+		"forked file counted once; distinct file added")
+	assert.Equal(t, 2, stats.Anomalies.MalformedLinesByAgent["warp"],
+		"empty-path sessions are not deduped")
+	assert.Equal(t, 9, stats.Anomalies.MalformedLinesTotal)
+}
+
 func TestAnomalyAccumulator_ResetClears(t *testing.T) {
 	var acc anomalyAccumulator
-	acc.recordMalformedLines("claude", 9)
+	acc.recordMalformedLines("claude", "x.jsonl", 9)
 	acc.recordSanitize(validationStats{TimestampsBlanked: 1})
 	acc.reset()
 

--- a/internal/sync/progress_test.go
+++ b/internal/sync/progress_test.go
@@ -48,6 +48,128 @@ func TestSyncStats_RecordSynced(t *testing.T) {
 	}
 }
 
+func TestAnomalyStats_RecordMalformedLines(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []struct {
+			agent string
+			n     int
+		}
+		wantByAgent map[string]int
+		wantTotal   int
+	}{
+		{
+			name:        "clean run records nothing",
+			wantByAgent: nil,
+			wantTotal:   0,
+		},
+		{
+			name: "zero and negative counts are ignored",
+			records: []struct {
+				agent string
+				n     int
+			}{
+				{"claude", 0},
+				{"codex", -3},
+			},
+			wantByAgent: nil,
+			wantTotal:   0,
+		},
+		{
+			name: "per-agent breakdown plus grand total",
+			records: []struct {
+				agent string
+				n     int
+			}{
+				{"claude", 2},
+				{"codex", 5},
+				{"claude", 3},
+			},
+			wantByAgent: map[string]int{"claude": 5, "codex": 5},
+			wantTotal:   10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a AnomalyStats
+			for _, r := range tt.records {
+				a.RecordMalformedLines(r.agent, r.n)
+			}
+			assert.Equal(t, tt.wantByAgent, a.MalformedLinesByAgent)
+			assert.Equal(t, tt.wantTotal, a.MalformedLinesTotal)
+		})
+	}
+}
+
+func TestAnomalyAccumulator_Aggregate(t *testing.T) {
+	var acc anomalyAccumulator
+	acc.reset()
+
+	// Two sessions of one agent, one of another, plus sanitize fixes
+	// from messages and usage events across the run.
+	acc.recordMalformedLines("claude", 4)
+	acc.recordMalformedLines("codex", 1)
+	acc.recordMalformedLines("claude", 2)
+	acc.recordMalformedLines("gemini", 0) // ignored
+
+	acc.recordSanitize(validationStats{ControlCharsStripped: 3, RoleCoerced: 1})
+	acc.recordSanitize(validationStats{ModelClamped: 2, TokensClamped: 5})
+	acc.recordSanitize(validationStats{}) // no-op
+
+	var stats SyncStats
+	acc.applyTo(&stats)
+
+	assert.Equal(t, 7, stats.Anomalies.MalformedLinesTotal)
+	assert.Equal(t, map[string]int{"claude": 6, "codex": 1},
+		stats.Anomalies.MalformedLinesByAgent)
+	assert.Equal(t, SanitizeStats{
+		ControlCharsStripped: 3,
+		ModelClamped:         2,
+		TokensClamped:        5,
+		RoleCoerced:          1,
+	}, stats.Anomalies.Sanitize)
+	assert.Equal(t, 11, stats.Anomalies.Sanitize.Total())
+	assert.False(t, stats.Anomalies.IsZero())
+}
+
+func TestAnomalyAccumulator_ResetClears(t *testing.T) {
+	var acc anomalyAccumulator
+	acc.recordMalformedLines("claude", 9)
+	acc.recordSanitize(validationStats{TimestampsBlanked: 1})
+	acc.reset()
+
+	var stats SyncStats
+	acc.applyTo(&stats)
+	assert.True(t, stats.Anomalies.IsZero())
+	assert.Zero(t, stats.Anomalies.MalformedLinesTotal)
+	assert.Nil(t, stats.Anomalies.MalformedLinesByAgent)
+}
+
+func TestAnomalyStats_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		a    AnomalyStats
+		want bool
+	}{
+		{"empty", AnomalyStats{}, true},
+		{
+			name: "malformed only",
+			a:    AnomalyStats{MalformedLinesTotal: 1},
+			want: false,
+		},
+		{
+			name: "sanitize only",
+			a:    AnomalyStats{Sanitize: SanitizeStats{ModelClamped: 1}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.a.IsZero())
+		})
+	}
+}
+
 func TestProgress_Percent(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/sync/progress_test.go
+++ b/internal/sync/progress_test.go
@@ -1,9 +1,11 @@
 package sync
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSyncStats_RecordSkip(t *testing.T) {
@@ -203,4 +205,28 @@ func TestProgress_Percent(t *testing.T) {
 			assert.InDelta(t, tt.want, got, 1e-4)
 		})
 	}
+}
+
+// TestSyncStatsJSONOmitsZeroAnomalies verifies the anomaly JSON fields use
+// omitzero semantics: a clean run emits no "anomalies" object at all, and a
+// run with only malformed-line counts omits the empty nested "sanitize"
+// object. Plain omitempty cannot do this for struct-valued fields.
+func TestSyncStatsJSONOmitsZeroAnomalies(t *testing.T) {
+	clean, err := json.Marshal(SyncStats{Synced: 3})
+	require.NoError(t, err)
+	assert.NotContains(t, string(clean), "anomalies",
+		"a clean run must not emit an empty anomalies object")
+
+	malformedOnly, err := json.Marshal(SyncStats{
+		Anomalies: AnomalyStats{
+			MalformedLinesByAgent: map[string]int{"claude": 2},
+			MalformedLinesTotal:   2,
+		},
+	})
+	require.NoError(t, err)
+	got := string(malformedOnly)
+	assert.Contains(t, got, "malformed_lines_total",
+		"malformed counts must still serialize")
+	assert.NotContains(t, got, "sanitize",
+		"malformed-only run must not emit an empty sanitize object")
 }


### PR DESCRIPTION
Format drift in reverse-engineered parsers (Antigravity especially) has no early-warning signal today: the pg-push NUL failure ran many times before anyone noticed via an exit code, and garbage model names sat visible-but-unnoticed in the Usage view for days. This surfaces two anomaly signals that were already being computed but never shown, as a concise, only-when-nonzero "Parser anomalies (this run)" section in the CLI sync summary (both stdout and stderr variants).

The two signals:
- **Per-agent `parser_malformed_lines`** — already parsed, stored on the session row, and pushed to Postgres, but never displayed anywhere.
- **Central `validateAndSanitize` fix counts** — control chars stripped, model/token clamps, role coercions, blanked timestamps — previously computed at the write seam and discarded (`_ = validateAndSanitize(...)`).

The change is additive: it does not alter how anything parses, stores, or renders. The counts are folded into `SyncStats` via a per-run engine accumulator at the write seam (`prepareSessionWrite`, `writeIncremental`, usage-event conversion), reset each run. No new persisted columns or schema changes. Malformed-line counts are deduped per source file, since one transcript can fork into several sessions (e.g. Claude subagents) that each carry the same source-level count. The anomaly JSON fields use `omitzero` so a clean run emits nothing.

Known limitation (documented at the `writeIncremental` seam): malformed-line counts are recorded on full-parse paths but not on the incremental append path. `incrementalParseFunc` carries no malformed-line count, and surfacing it would require threading a new return through the incremental parser API across every append-only agent. Because this is a best-effort, only-when-nonzero diagnostic whose value is still parsed, persisted, and re-derived by the next full sync, the incremental path under-reports the new summary signal by at most one full-sync interval — no stored data is lost. Full incremental coverage is a deferred follow-up. Sanitize fixes are recorded on the incremental path since they are already computed there.

Where to look:
- `internal/sync/progress.go` — `AnomalyStats`/`SanitizeStats` and the per-run accumulator.
- `internal/sync/engine.go` — recording at the write seams.
- `cmd/agentsview/main.go` — `formatAnomalySummary` rendering.