### PR TITLE
fix(analytics): surface active duration in top sessions (#83)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -391,6 +391,8 @@
   "analytics_top_sessions_by_messages": "By Messages",
   "analytics_top_sessions_by_duration": "By Duration",
   "analytics_top_sessions_by_output_tokens": "By Output Tokens",
+  "analytics_top_sessions_active_duration": "Active duration",
+  "analytics_top_sessions_total_duration": "{duration} total",
   "analytics_projects_title": "Projects",
   "analytics_project_messages": [
     {

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -385,6 +385,8 @@
   "analytics_top_sessions_by_messages": "按消息数",
   "analytics_top_sessions_by_duration": "按时长",
   "analytics_top_sessions_by_output_tokens": "按输出 token",
+  "analytics_top_sessions_active_duration": "活跃时长",
+  "analytics_top_sessions_total_duration": "总计 {duration}",
   "analytics_projects_title": "项目",
   "analytics_project_messages": [
     {

--- a/frontend/src/lib/api/generated/models/DbTopSession.ts
+++ b/frontend/src/lib/api/generated/models/DbTopSession.ts
@@ -5,6 +5,7 @@
 export type DbTopSession = {
   display_name?: string;
   duration_min: number;
+  active_duration_min: number;
   ended_at?: string;
   first_message: string | null;
   id: string;

--- a/frontend/src/lib/api/types/analytics.ts
+++ b/frontend/src/lib/api/types/analytics.ts
@@ -139,6 +139,7 @@ export interface TopSession {
   message_count: number;
   output_tokens: number;
   duration_min: number;
+  active_duration_min: number;
   /** ISO timestamps used by the StatusDot component to compute
    * the active/stale/unclean tier — the column needs the same
    * recency inputs as the sidebar list. */

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -39,8 +39,9 @@
     activeMin: number,
     totalMin: number,
   ): string {
-    const totalText = ` (${formatDuration(totalMin)} total)`;
-    return `${formatDuration(activeMin)}${totalText}`;
+    return `${formatDuration(activeMin)} (${m.analytics_top_sessions_total_duration({
+      duration: formatDuration(totalMin),
+    })})`;
   }
 
   function handleSessionClick(id: string) {
@@ -164,7 +165,7 @@
             {#if analytics.topMetric === "duration"}
               <span
                 class="session-metric-primary"
-                title="Active duration"
+                title={m.analytics_top_sessions_active_duration()}
               >
                 {formatDurationWithTotal(
                   session.active_duration_min,

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -35,6 +35,14 @@
     return m > 0 ? `${h}h ${m}m` : `${h}h`;
   }
 
+  function formatDurationWithTotal(
+    activeMin: number,
+    totalMin: number,
+  ): string {
+    const totalText = ` (${formatDuration(totalMin)} total)`;
+    return `${formatDuration(activeMin)}${totalText}`;
+  }
+
   function handleSessionClick(id: string) {
     let needInvalidate = false;
     const params: Record<string, string> = {};
@@ -154,7 +162,15 @@
           </div>
           <span class="session-metric">
             {#if analytics.topMetric === "duration"}
-              {formatDuration(session.duration_min)}
+              <span
+                class="session-metric-primary"
+                title="Active duration"
+              >
+                {formatDurationWithTotal(
+                  session.active_duration_min,
+                  session.duration_min,
+                )}
+              </span>
             {:else if analytics.topMetric === "output_tokens"}
               {formatTokenCount(session.output_tokens)}
             {:else}
@@ -322,8 +338,12 @@
     font-weight: 500;
     font-family: var(--font-mono);
     color: var(--accent-blue);
-    min-width: 36px;
+    min-width: 86px;
     text-align: right;
+  }
+
+  .session-metric-primary {
+    display: inline-block;
   }
 
   .empty {

--- a/frontend/src/lib/components/analytics/TopSessions.test.ts
+++ b/frontend/src/lib/components/analytics/TopSessions.test.ts
@@ -67,6 +67,7 @@ describe("TopSessions", () => {
           message_count: 10,
           output_tokens: 0,
           duration_min: 5,
+          active_duration_min: 5,
         },
       ],
     };
@@ -184,6 +185,7 @@ describe("TopSessions", () => {
           message_count: 10,
           output_tokens: 0,
           duration_min: 5,
+          active_duration_min: 5,
         },
       ],
     };
@@ -208,6 +210,44 @@ describe("TopSessions", () => {
     unmount(component);
   });
 
+  it("shows active duration as primary with total duration context", async () => {
+    // @ts-ignore — topMetric is a reactive store field
+    analytics.topMetric = "duration";
+    analytics.topSessions = {
+      metric: "duration",
+      sessions: [
+        {
+          id: "sess-1",
+          project: "proj",
+          first_message: "hello",
+          message_count: 10,
+          output_tokens: 0,
+          duration_min: 120,
+          active_duration_min: 2.5,
+        },
+      ],
+    };
+    // @ts-ignore — loading is reactive state
+    analytics.loading = {
+      ...analytics.loading,
+      topSessions: false,
+    };
+    // @ts-ignore
+    analytics.errors = {
+      ...analytics.errors,
+      topSessions: null,
+    };
+
+    const component = mount(TopSessions, { target: document.body });
+    await tick();
+
+    expect(
+      document.querySelector(".session-metric")?.textContent?.trim(),
+    ).toBe("3m (2h total)");
+
+    unmount(component);
+  });
+
   describe("status column", () => {
     function mountWithFourStates() {
       analytics.topSessions = {
@@ -220,6 +260,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: "clean",
           },
           {
@@ -229,6 +270,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: "tool_call_pending",
           },
           {
@@ -238,6 +280,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: "truncated",
           },
           {
@@ -247,6 +290,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: null,
           },
         ],
@@ -323,6 +367,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: "clean",
           },
         ],

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -4481,13 +4481,18 @@ func (db *DB) getAnalyticsTopSessionsGo(
 		orderExpr = "message_count DESC, id ASC"
 	}
 
+	limitClause := " LIMIT 200"
+	if f.HasTimeFilter() || needsGoSort {
+		limitClause = ""
+	}
+
 	query := `SELECT id, ` + dateCol + `, project,
 		first_message,
 		COALESCE(display_name, session_name) AS display_name,
 		message_count, total_output_tokens,
 		started_at, ended_at, termination_status
 		FROM sessions WHERE ` + where +
-		` ORDER BY ` + orderExpr + ` LIMIT 200`
+		` ORDER BY ` + orderExpr + limitClause
 
 	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -4333,13 +4333,14 @@ func round1(v float64) float64 {
 
 // TopSession holds summary info for a ranked session.
 type TopSession struct {
-	ID           string  `json:"id"`
-	Project      string  `json:"project"`
-	FirstMessage *string `json:"first_message"`
-	DisplayName  *string `json:"display_name,omitempty"`
-	MessageCount int     `json:"message_count"`
-	OutputTokens int     `json:"output_tokens"`
-	DurationMin  float64 `json:"duration_min"`
+	ID                string  `json:"id"`
+	Project           string  `json:"project"`
+	FirstMessage      *string `json:"first_message"`
+	DisplayName       *string `json:"display_name,omitempty"`
+	MessageCount      int     `json:"message_count"`
+	OutputTokens      int     `json:"output_tokens"`
+	DurationMin       float64 `json:"duration_min"`
+	ActiveDurationMin float64 `json:"active_duration_min"`
 	// StartedAt and EndedAt are included so the frontend can
 	// derive a recency-based status tier — the StatusDot in the
 	// Top Sessions column needs the same time window inputs as
@@ -4372,14 +4373,34 @@ func (db *DB) GetAnalyticsTopSessions(
 
 	durationExpr := `ROUND((julianday(ended_at) -
 		julianday(started_at)) * 1440, 1)`
+	activeDurationExpr := `
+		ROUND((
+			SELECT COALESCE(SUM(
+				CASE
+					WHEN inner2.has_tool_use = 0 OR inner2.delta_ms <= 0 THEN NULL
+					ELSE inner2.delta_ms
+				END), 0) / 60000.0
+			FROM (
+				SELECT CAST(
+				  ROUND(
+					(julianday(COALESCE(LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
+					  sessions.ended_at)) - julianday(m2.timestamp)) * 86400000
+					) AS INTEGER
+				) AS delta_ms,
+				m2.has_tool_use
+			FROM messages m2
+				WHERE m2.session_id = sessions.id
+			) inner2), 1)`
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
+	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
+	needsGoSort := metric == "duration"
 	var orderExpr string
 	switch metric {
 	case "output_tokens":
 		where += " AND has_total_output_tokens = TRUE"
 		orderExpr = "total_output_tokens DESC, id ASC"
 	case "duration":
-		orderExpr = durationExpr + " DESC, id ASC"
+		orderExpr = activeDurationSelectExpr + " DESC, id ASC"
 		where += " AND NULLIF(started_at, '') IS NOT NULL" +
 			" AND NULLIF(ended_at, '') IS NOT NULL" +
 			" AND julianday(ended_at) >= julianday(started_at)"
@@ -4391,6 +4412,7 @@ func (db *DB) GetAnalyticsTopSessions(
 	query := `SELECT id, project, first_message,
 		COALESCE(display_name, session_name) AS display_name,
 		message_count, total_output_tokens, ` + durationSelectExpr + `,
+		` + activeDurationSelectExpr + `,
 		started_at, ended_at, termination_status
 		FROM sessions WHERE ` + where +
 		` ORDER BY ` + orderExpr + ` LIMIT 10`
@@ -4409,6 +4431,7 @@ func (db *DB) GetAnalyticsTopSessions(
 			&row.ID, &row.Project, &row.FirstMessage,
 			&row.DisplayName, &row.MessageCount,
 			&row.OutputTokens, &row.DurationMin,
+			&row.ActiveDurationMin,
 			&row.StartedAt, &row.EndedAt,
 			&row.TerminationStatus,
 		); err != nil {
@@ -4421,6 +4444,8 @@ func (db *DB) GetAnalyticsTopSessions(
 		return TopSessionsResponse{},
 			fmt.Errorf("iterating top sessions: %w", err)
 	}
+	sessions := rankTopSessions(resp.Sessions, needsGoSort)
+	resp.Sessions = sessions
 	return resp, nil
 }
 
@@ -4441,6 +4466,7 @@ func (db *DB) getAnalyticsTopSessionsGo(
 	}
 
 	var orderExpr string
+	needsGoSort := metric == "duration"
 	switch metric {
 	case "output_tokens":
 		where += " AND has_total_output_tokens = TRUE"
@@ -4484,6 +4510,17 @@ func (db *DB) getAnalyticsTopSessionsGo(
 			return TopSessionsResponse{},
 				fmt.Errorf("scanning top session: %w", err)
 		}
+		var activeDurationMin float64
+		if metric == "duration" {
+			var err error
+			activeDurationMin, err = db.activeDurationMinForSession(
+				ctx, id,
+			)
+			if err != nil {
+				return TopSessionsResponse{},
+					fmt.Errorf("querying top session active duration: %w", err)
+			}
+		}
 		date := localDate(ts, loc)
 		if !inDateRange(date, f.From, f.To) {
 			continue
@@ -4508,6 +4545,7 @@ func (db *DB) getAnalyticsTopSessionsGo(
 			MessageCount:      mc,
 			OutputTokens:      outputTokens,
 			DurationMin:       durMin,
+			ActiveDurationMin: activeDurationMin,
 			StartedAt:         startedAt,
 			EndedAt:           endedAt,
 			TerminationStatus: termStatus,
@@ -4521,6 +4559,7 @@ func (db *DB) getAnalyticsTopSessionsGo(
 	if sessions == nil {
 		sessions = []TopSession{}
 	}
+	sessions = rankTopSessions(sessions, needsGoSort)
 	if len(sessions) > 10 {
 		sessions = sessions[:10]
 	}
@@ -4529,4 +4568,24 @@ func (db *DB) getAnalyticsTopSessionsGo(
 		Metric:   metric,
 		Sessions: sessions,
 	}, nil
+}
+
+func rankTopSessions(sessions []TopSession, needsGoSort bool) []TopSession {
+	if sessions == nil {
+		return []TopSession{}
+	}
+	if needsGoSort && len(sessions) > 1 {
+		sort.SliceStable(sessions, func(i, j int) bool {
+			if sessions[i].ActiveDurationMin != sessions[j].ActiveDurationMin {
+				return sessions[i].ActiveDurationMin >
+					sessions[j].ActiveDurationMin
+			}
+			return sessions[i].ID < sessions[j].ID
+		})
+	}
+	for i := range sessions {
+		sessions[i].DurationMin = round1(sessions[i].DurationMin)
+		sessions[i].ActiveDurationMin = round1(sessions[i].ActiveDurationMin)
+	}
+	return sessions
 }

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -4374,7 +4374,7 @@ func (db *DB) GetAnalyticsTopSessions(
 	durationExpr := `ROUND((julianday(ended_at) -
 		julianday(started_at)) * 1440, 1)`
 	activeDurationExpr := `
-		ROUND((
+		(
 			SELECT COALESCE(SUM(
 				CASE
 					WHEN inner2.has_tool_use = 0 OR inner2.delta_ms <= 0 THEN NULL
@@ -4390,7 +4390,7 @@ func (db *DB) GetAnalyticsTopSessions(
 				m2.has_tool_use
 			FROM messages m2
 				WHERE m2.session_id = sessions.id
-			) inner2), 1)`
+			) inner2)`
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
 	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
 	needsGoSort := metric == "duration"

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1859,6 +1859,69 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		}
 	})
 
+	t.Run("ByDurationRanksByActiveDuration", func(t *testing.T) {
+		insertSession(t, d, "wall-dominant", "project-gamma", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-02T09:00:00Z")
+			s.EndedAt = Ptr("2024-06-02T11:00:00Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("wall-dominant", 0, "noop", "2024-06-02T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"wall-dominant",
+					1,
+					"idle wait",
+					"2024-06-02T10:59:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt(
+				"wall-dominant",
+				2,
+				"done",
+				"2024-06-02T11:00:00Z",
+			),
+		)
+
+		insertSession(t, d, "actively-working", "project-gamma", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-02T09:30:00Z")
+			s.EndedAt = Ptr("2024-06-02T09:50:00Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("actively-working", 0, "start", "2024-06-02T09:30:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"actively-working",
+					1,
+					"tooling",
+					"2024-06-02T09:35:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("actively-working", 2, "finish", "2024-06-02T09:50:00Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(
+			ctx, baseFilter(), "duration",
+		)
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		assert.Equal(t, "duration", resp.Metric, "Metric")
+		require.NotEmpty(t, resp.Sessions, "sessions")
+		assert.Equal(t, "actively-working", resp.Sessions[0].ID, "top session by active duration")
+		assert.Equal(t, 20.0, resp.Sessions[0].DurationMin, "active total duration")
+		assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin, "active duration")
+		assert.Equal(t, 120.0, resp.Sessions[1].DurationMin, "wall-only duration")
+		assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin, "idle active duration")
+	})
+
 	t.Run("DefaultMetric", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "",

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1922,6 +1922,63 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin, "idle active duration")
 	})
 
+	t.Run("ByDurationKeepsNearTieOrderBeforeDisplayRounding", func(t *testing.T) {
+		insertSession(t, d, "near-tie-longer", "project-precision", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-03T09:00:00Z")
+			s.EndedAt = Ptr("2024-06-03T09:10:02.400Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("near-tie-longer", 0, "start", "2024-06-03T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"near-tie-longer",
+					1,
+					"tooling",
+					"2024-06-03T09:00:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("near-tie-longer", 2, "finish", "2024-06-03T09:10:02.400Z"),
+		)
+
+		insertSession(t, d, "near-tie-shorter", "project-precision", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-03T09:00:00Z")
+			s.EndedAt = Ptr("2024-06-03T09:10:01.800Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("near-tie-shorter", 0, "start", "2024-06-03T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"near-tie-shorter",
+					1,
+					"tooling",
+					"2024-06-03T09:00:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("near-tie-shorter", 2, "finish", "2024-06-03T09:10:01.800Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project: "project-precision",
+			From:    "2024-06-03",
+			To:      "2024-06-03",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.Len(t, resp.Sessions, 2, "precision sessions")
+		assert.Equal(t, "near-tie-longer", resp.Sessions[0].ID, "raw active duration should decide the rank")
+		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "display rounding")
+		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin, "display rounding")
+	})
+
 	t.Run("ByDurationRanksByActiveDurationInGoFallback", func(t *testing.T) {
 		for i := range 201 {
 			id := fmt.Sprintf("dst-wall-%03d", i)
@@ -1980,6 +2037,175 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		require.NotEmpty(t, resp.Sessions, "sessions")
 		assert.Equal(t, "dst-actively-working", resp.Sessions[0].ID, "top session by active duration in fallback")
 		assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin, "fallback active duration")
+	})
+
+	t.Run("ByDurationKeepsNearTieOrderInGoFallback", func(t *testing.T) {
+		insertSession(t, d, "dst-near-tie-longer", "project-dst-precision", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:00:00Z")
+			s.EndedAt = Ptr("2026-03-10T09:10:02.400Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-near-tie-longer", 0, "start", "2026-03-10T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-near-tie-longer",
+					1,
+					"tooling",
+					"2026-03-10T09:00:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-near-tie-longer", 2, "finish", "2026-03-10T09:10:02.400Z"),
+		)
+
+		insertSession(t, d, "dst-near-tie-shorter", "project-dst-precision", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:00:00Z")
+			s.EndedAt = Ptr("2026-03-10T09:10:01.800Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-near-tie-shorter", 0, "start", "2026-03-10T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-near-tie-shorter",
+					1,
+					"tooling",
+					"2026-03-10T09:00:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-near-tie-shorter", 2, "finish", "2026-03-10T09:10:01.800Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project:  "project-dst-precision",
+			From:     "2026-03-01",
+			To:       "2026-03-31",
+			Timezone: "America/New_York",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.Len(t, resp.Sessions, 2, "fallback precision sessions")
+		assert.Equal(t, "dst-near-tie-longer", resp.Sessions[0].ID, "fallback should keep raw active ordering")
+		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "fallback display rounding")
+		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin, "fallback display rounding")
+	})
+
+	t.Run("ByDurationSortsBeforeRoundingInSQLiteSQL", func(t *testing.T) {
+		insertSession(t, d, "sql-round-a", "project-round-sql", func(s *Session) {
+			s.StartedAt = Ptr("2026-04-05T09:59:00.000Z")
+			s.EndedAt = Ptr("2026-04-05T10:10:02.400Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("sql-round-a", 0, "start", "2026-04-05T09:59:00.000Z"),
+			func() Message {
+				m := asstMsgAt(
+					"sql-round-a",
+					1,
+					"tool",
+					"2026-04-05T10:00:00.000Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("sql-round-a", 2, "finish", "2026-04-05T10:10:02.400Z"),
+		)
+		insertSession(t, d, "sql-round-b", "project-round-sql", func(s *Session) {
+			s.StartedAt = Ptr("2026-04-05T09:59:00.000Z")
+			s.EndedAt = Ptr("2026-04-05T10:10:03.600Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("sql-round-b", 0, "start", "2026-04-05T09:59:00.000Z"),
+			func() Message {
+				m := asstMsgAt(
+					"sql-round-b",
+					1,
+					"tool",
+					"2026-04-05T10:00:00.000Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("sql-round-b", 2, "finish", "2026-04-05T10:10:03.600Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project: "project-round-sql",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.Len(t, resp.Sessions, 2)
+		assert.Equal(t, "sql-round-b", resp.Sessions[0].ID, "10.06 must rank ahead of 10.04 before rounding")
+		assert.Equal(t, 10.1, resp.Sessions[0].ActiveDurationMin)
+		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin)
+	})
+
+	t.Run("ByDurationSortsBeforeRoundingInGoFallback", func(t *testing.T) {
+		insertSession(t, d, "dst-round-a", "project-round-fallback", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:59:00.000Z")
+			s.EndedAt = Ptr("2026-03-10T10:10:02.400Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-round-a", 0, "start", "2026-03-10T09:59:00.000Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-round-a",
+					1,
+					"tool",
+					"2026-03-10T10:00:00.000Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-round-a", 2, "finish", "2026-03-10T10:10:02.400Z"),
+		)
+		insertSession(t, d, "dst-round-b", "project-round-fallback", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:59:00.000Z")
+			s.EndedAt = Ptr("2026-03-10T10:10:03.600Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-round-b", 0, "start", "2026-03-10T09:59:00.000Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-round-b",
+					1,
+					"tool",
+					"2026-03-10T10:00:00.000Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-round-b", 2, "finish", "2026-03-10T10:10:03.600Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project:  "project-round-fallback",
+			From:     "2026-03-01",
+			To:       "2026-03-31",
+			Timezone: "America/New_York",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.Len(t, resp.Sessions, 2)
+		assert.Equal(t, "dst-round-b", resp.Sessions[0].ID, "fallback must rank 10.06 ahead of 10.04 before rounding")
+		assert.Equal(t, 10.1, resp.Sessions[0].ActiveDurationMin)
+		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin)
 	})
 
 	t.Run("DefaultMetric", func(t *testing.T) {

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1922,6 +1922,66 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin, "idle active duration")
 	})
 
+	t.Run("ByDurationRanksByActiveDurationInGoFallback", func(t *testing.T) {
+		for i := range 201 {
+			id := fmt.Sprintf("dst-wall-%03d", i)
+			insertSession(t, d, id, "project-dst", func(s *Session) {
+				s.StartedAt = Ptr("2026-03-10T09:00:00Z")
+				s.EndedAt = Ptr("2026-03-10T11:00:00Z")
+				s.MessageCount = 3
+			})
+			insertMessages(
+				t,
+				d,
+				userMsgAt(id, 0, "noop", "2026-03-10T09:00:00Z"),
+				func() Message {
+					m := asstMsgAt(
+						id,
+						1,
+						"idle wait",
+						"2026-03-10T10:59:00Z",
+					)
+					m.HasToolUse = true
+					return m
+				}(),
+				userMsgAt(id, 2, "done", "2026-03-10T11:00:00Z"),
+			)
+		}
+
+		insertSession(t, d, "dst-actively-working", "project-dst", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:30:00Z")
+			s.EndedAt = Ptr("2026-03-10T09:50:00Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-actively-working", 0, "start", "2026-03-10T09:30:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-actively-working",
+					1,
+					"tooling",
+					"2026-03-10T09:35:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-actively-working", 2, "finish", "2026-03-10T09:50:00Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project:  "project-dst",
+			From:     "2026-03-01",
+			To:       "2026-03-31",
+			Timezone: "America/New_York",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.NotEmpty(t, resp.Sessions, "sessions")
+		assert.Equal(t, "dst-actively-working", resp.Sessions[0].ID, "top session by active duration in fallback")
+		assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin, "fallback active duration")
+	})
+
 	t.Run("DefaultMetric", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "",

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"math"
 	"sort"
 	"strings"
 	"time"
@@ -239,7 +238,7 @@ func activeDurationMinFromTurns(turns []TurnRow) float64 {
 		}
 		totalMs += *t.DurationMs
 	}
-	return math.Round(float64(totalMs)/6000) / 10
+	return float64(totalMs) / 60000
 }
 
 func (db *DB) activeDurationMinForSession(

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -228,6 +229,27 @@ func (db *DB) queryCallRows(
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+func activeDurationMinFromTurns(turns []TurnRow) float64 {
+	var totalMs int64
+	for _, t := range turns {
+		if !t.HasToolUse || t.DurationMs == nil || *t.DurationMs <= 0 {
+			continue
+		}
+		totalMs += *t.DurationMs
+	}
+	return math.Round(float64(totalMs)/6000) / 10
+}
+
+func (db *DB) activeDurationMinForSession(
+	ctx context.Context, sessionID string,
+) (float64, error) {
+	turns, err := db.queryTurnRows(ctx, sessionID)
+	if err != nil {
+		return 0, err
+	}
+	return activeDurationMinFromTurns(turns), nil
 }
 
 // AssembleTiming stitches scanned per-turn and per-call rows plus

--- a/internal/db/timing_test.go
+++ b/internal/db/timing_test.go
@@ -116,6 +116,20 @@ func TestGetSessionTiming_NoToolUseHasNoTurnDuration(t *testing.T) {
 	assert.Equal(t, 0, got.TurnCount, "TurnCount")
 }
 
+func TestActiveDurationMinFromTurnsKeepsRawMinutePrecision(t *testing.T) {
+	tenMinutesTwoPointFourSeconds := int64(602_400)
+	ignoredNegative := int64(-1_000)
+	turns := []TurnRow{
+		{HasToolUse: true, DurationMs: &tenMinutesTwoPointFourSeconds},
+		{HasToolUse: true, DurationMs: &ignoredNegative},
+		{HasToolUse: false, DurationMs: &tenMinutesTwoPointFourSeconds},
+	}
+
+	got := activeDurationMinFromTurns(turns)
+
+	assert.InDelta(t, 10.04, got, 0.000001)
+}
+
 func TestGetSessionTiming_MarshalsEmptyCollectionsAsArrays(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -1678,11 +1678,34 @@ func (s *Store) GetAnalyticsTopSessions(
 		f, "COALESCE(s.started_at, s.created_at)", "s.", true, true)
 	durationExpr := "(epoch(s.ended_at) - epoch(s.started_at)) / 60.0"
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
+	activeDurationExpr := `
+		ROUND((
+			SELECT COALESCE(SUM(
+				CASE
+					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
+						THEN inner2.delta_ms
+					ELSE NULL
+				END), 0) / 60000.0
+			FROM (
+				SELECT CAST(
+					ROUND(epoch(
+						COALESCE(
+							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
+							s.ended_at
+						) - m2.timestamp
+					) * 1000) AS BIGINT
+				) AS delta_ms,
+				m2.has_tool_use
+				FROM messages m2
+				WHERE m2.session_id = s.id
+			) inner2
+		), 1)`
+	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
 	orderExpr := "s.message_count DESC, s.id ASC"
 	switch metric {
 	case "duration":
 		where += " AND s.started_at IS NOT NULL AND s.ended_at IS NOT NULL AND s.ended_at >= s.started_at"
-		orderExpr = durationExpr + " DESC, s.id ASC"
+		orderExpr = activeDurationSelectExpr + " DESC, s.id ASC"
 	case "output_tokens":
 		where += " AND s.has_total_output_tokens = TRUE"
 		orderExpr = "s.total_output_tokens DESC, s.id ASC"
@@ -1690,6 +1713,7 @@ func (s *Store) GetAnalyticsTopSessions(
 	query := `
 		SELECT s.id, s.project, s.first_message, s.message_count,
 			s.total_output_tokens, ` + durationSelectExpr + ` AS duration_min,
+			` + activeDurationSelectExpr + ` AS active_duration_min,
 			s.started_at, s.ended_at, s.termination_status
 		FROM sessions s
 		WHERE ` + where + `
@@ -1707,7 +1731,8 @@ func (s *Store) GetAnalyticsTopSessions(
 		var startedRaw, endedRaw any
 		if err := rows.Scan(
 			&row.ID, &row.Project, &row.FirstMessage, &row.MessageCount,
-			&row.OutputTokens, &row.DurationMin, &startedRaw, &endedRaw,
+			&row.OutputTokens, &row.DurationMin, &row.ActiveDurationMin,
+			&startedRaw, &endedRaw,
 			&row.TerminationStatus,
 		); err != nil {
 			return db.TopSessionsResponse{}, fmt.Errorf("scanning duckdb analytics top session: %w", err)

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -1679,7 +1679,7 @@ func (s *Store) GetAnalyticsTopSessions(
 	durationExpr := "(epoch(s.ended_at) - epoch(s.started_at)) / 60.0"
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
 	activeDurationExpr := `
-		ROUND((
+		(
 			SELECT COALESCE(SUM(
 				CASE
 					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
@@ -1699,7 +1699,7 @@ func (s *Store) GetAnalyticsTopSessions(
 				FROM messages m2
 				WHERE m2.session_id = s.id
 			) inner2
-		), 1)`
+		)`
 	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
 	orderExpr := "s.message_count DESC, s.id ASC"
 	switch metric {
@@ -1741,6 +1741,8 @@ func (s *Store) GetAnalyticsTopSessions(
 		endedAt := formatDBTime(endedRaw)
 		row.StartedAt = &startedAt
 		row.EndedAt = &endedAt
+		row.DurationMin = round1(row.DurationMin)
+		row.ActiveDurationMin = round1(row.ActiveDurationMin)
 		out.Sessions = append(out.Sessions, row)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -706,6 +706,94 @@ func TestAnalyticsTopSessionsFiltersMetricEligibility(t *testing.T) {
 	assert.Equal(t, "messages", unknown.Metric)
 }
 
+func TestAnalyticsTopSessionsDurationUsesActiveDuration(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	wallSession := syncSession(
+		"duck-wall-dominant", "alpha", "wall session",
+		"2026-01-20T09:00:00.000Z", 3,
+	)
+	wallEndedAt := "2026-01-20T11:00:00.000Z"
+	wallSession.EndedAt = &wallEndedAt
+	activeSession := syncSession(
+		"duck-actively-working", "alpha", "active session",
+		"2026-01-20T09:30:00.000Z", 3,
+	)
+	activeEndedAt := "2026-01-20T09:50:00.000Z"
+	activeSession.EndedAt = &activeEndedAt
+	writes := []db.SessionBatchWrite{
+		{
+			Session: wallSession,
+			Messages: []db.Message{
+				syncMessage(
+					"duck-wall-dominant", 0, "user", "wall start",
+					"2026-01-20T09:00:00.000Z",
+				),
+				syncMessage(
+					"duck-wall-dominant", 1, "assistant", "wall tool",
+					"2026-01-20T10:59:00.000Z",
+					db.ToolCall{
+						ToolName:  "Read",
+						Category:  "Read",
+						ToolUseID: "duck-wall-tool",
+						InputJSON: `{"file_path":"README.md"}`,
+					},
+				),
+				syncMessage(
+					"duck-wall-dominant", 2, "user", "wall finish",
+					"2026-01-20T11:00:00.000Z",
+				),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session: activeSession,
+			Messages: []db.Message{
+				syncMessage(
+					"duck-actively-working", 0, "user", "active start",
+					"2026-01-20T09:30:00.000Z",
+				),
+				syncMessage(
+					"duck-actively-working", 1, "assistant", "active tool",
+					"2026-01-20T09:35:00.000Z",
+					db.ToolCall{
+						ToolName:  "Edit",
+						Category:  "Write",
+						ToolUseID: "duck-active-tool",
+						InputJSON: `{"file_path":"main.go"}`,
+					},
+				),
+				syncMessage(
+					"duck-actively-working", 2, "user", "active finish",
+					"2026-01-20T09:50:00.000Z",
+				),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	}
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+
+	syncer := newTestSync(t, filepath.Join(t.TempDir(), "top-active.duckdb"), local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+
+	store := NewStoreFromDB(syncer.DB())
+	filter := db.AnalyticsFilter{From: "2026-01-20", To: "2026-01-20"}
+	resp, err := store.GetAnalyticsTopSessions(ctx, filter, "duration")
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 2)
+
+	assert.Equal(t, "duck-actively-working", resp.Sessions[0].ID)
+	assert.Equal(t, 20.0, resp.Sessions[0].DurationMin)
+	assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin)
+	assert.Equal(t, "duck-wall-dominant", resp.Sessions[1].ID)
+	assert.Equal(t, 120.0, resp.Sessions[1].DurationMin)
+	assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin)
+}
+
 func TestAnalyticsProjectsPopulateDailyTrendAndSortByMessages(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -1283,7 +1283,7 @@ func (s *Store) GetAnalyticsSessionShape(
 	}
 
 	query := `SELECT ` + pgDateCol + `,
-		EXTRACT(EPOCH FROM ended_at - started_at)
+		COALESCE(EXTRACT(EPOCH FROM ended_at - started_at), 0)
 			AS duration_sec,
 		message_count, id FROM sessions WHERE ` + where
 

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2229,13 +2229,13 @@ func (s *Store) GetAnalyticsTopSessions(
 				END), 0) / 60000.0
 			FROM (
 				SELECT CAST(
-					(round(EXTRACT(EPOCH FROM (
+					round(EXTRACT(EPOCH FROM (
 						COALESCE(
 							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
 							sessions.ended_at
 						) - m2.timestamp
-					)) * 1000) AS BIGINT
-				) AS delta_ms,
+					)) * 1000
+				AS BIGINT) AS delta_ms,
 				m2.has_tool_use
 				FROM messages m2
 				WHERE m2.session_id = sessions.id

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2226,7 +2226,7 @@ func (s *Store) GetAnalyticsTopSessions(
 					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
 						THEN inner2.delta_ms
 					ELSE NULL
-				END), 0) / 60.0
+				END), 0) / 60000.0
 			FROM (
 				SELECT CAST(
 					(round(EXTRACT(EPOCH FROM (

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -1283,7 +1283,7 @@ func (s *Store) GetAnalyticsSessionShape(
 	}
 
 	query := `SELECT ` + pgDateCol + `,
-		COALESCE(EXTRACT(EPOCH FROM ended_at - started_at), 0)
+		EXTRACT(EPOCH FROM ended_at - started_at)
 			AS duration_sec,
 		message_count, id FROM sessions WHERE ` + where
 
@@ -2217,7 +2217,7 @@ func (s *Store) GetAnalyticsTopSessions(
 		first_message,
 		COALESCE(display_name, session_name) AS display_name,
 		message_count, total_output_tokens,
-		EXTRACT(EPOCH FROM ended_at - started_at)
+		COALESCE(EXTRACT(EPOCH FROM ended_at - started_at), 0)
 			AS duration_sec,
 		COALESCE(
 		  (

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2234,7 +2234,7 @@ func (s *Store) GetAnalyticsTopSessions(
 							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
 							sessions.ended_at
 						) - m2.timestamp
-					)) * 1000
+					)) * 1000)
 				AS BIGINT) AS delta_ms,
 				m2.has_tool_use
 				FROM messages m2

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2219,6 +2219,28 @@ func (s *Store) GetAnalyticsTopSessions(
 		message_count, total_output_tokens,
 		EXTRACT(EPOCH FROM ended_at - started_at)
 			AS duration_sec,
+		COALESCE(
+		  (
+			SELECT COALESCE(SUM(
+				CASE
+					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
+						THEN inner2.delta_ms
+					ELSE NULL
+				END), 0) / 60.0
+			FROM (
+				SELECT CAST(
+					(round(EXTRACT(EPOCH FROM (
+						COALESCE(
+							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
+							sessions.ended_at
+						) - m2.timestamp
+					)) * 1000) AS BIGINT
+				) AS delta_ms,
+				m2.has_tool_use
+				FROM messages m2
+				WHERE m2.session_id = sessions.id
+			) inner2
+		), 0) AS active_duration_min,
 		started_at, ended_at,
 		termination_status
 		FROM sessions WHERE ` + where +
@@ -2242,11 +2264,11 @@ func (s *Store) GetAnalyticsTopSessions(
 		var startedAt, endedAt *time.Time
 		var firstMsg, displayName, termStatus *string
 		var mc, outputTokens int
-		var durationSec *float64
+		var durationSec, activeDurationMin float64
 		if err := rows.Scan(
 			&id, &ts, &project, &firstMsg,
 			&displayName, &mc, &outputTokens,
-			&durationSec, &startedAt, &endedAt,
+			&durationSec, &activeDurationMin, &startedAt, &endedAt,
 			&termStatus,
 		); err != nil {
 			return db.TopSessionsResponse{},
@@ -2261,12 +2283,7 @@ func (s *Store) GetAnalyticsTopSessions(
 		if timeIDs != nil && !timeIDs[id] {
 			continue
 		}
-		durMin := 0.0
-		if durationSec != nil {
-			durMin = *durationSec / 60.0
-		} else if needsGoSort {
-			continue
-		}
+		durMin := durationSec / 60.0
 		var startedStr, endedStr *string
 		if startedAt != nil {
 			s := FormatISO8601(*startedAt)
@@ -2284,6 +2301,7 @@ func (s *Store) GetAnalyticsTopSessions(
 			MessageCount:      mc,
 			OutputTokens:      outputTokens,
 			DurationMin:       durMin,
+			ActiveDurationMin: activeDurationMin,
 			StartedAt:         startedStr,
 			EndedAt:           endedStr,
 			TerminationStatus: termStatus,
@@ -2629,8 +2647,8 @@ func (s *Store) populateFrustrationMarkers(
 	})
 }
 
-// rankTopSessions sorts sessions by duration (if
-// needsGoSort), truncates to top 10, and rounds DurationMin.
+// rankTopSessions sorts sessions by active duration (if
+// needsGoSort), truncates to top 10, and rounds duration fields.
 func rankTopSessions(
 	sessions []db.TopSession, needsGoSort bool,
 ) []db.TopSession {
@@ -2639,10 +2657,10 @@ func rankTopSessions(
 	}
 	if needsGoSort && len(sessions) > 1 {
 		sort.SliceStable(sessions, func(i, j int) bool {
-			if sessions[i].DurationMin !=
-				sessions[j].DurationMin {
-				return sessions[i].DurationMin >
-					sessions[j].DurationMin
+			if sessions[i].ActiveDurationMin !=
+				sessions[j].ActiveDurationMin {
+				return sessions[i].ActiveDurationMin >
+					sessions[j].ActiveDurationMin
 			}
 			return sessions[i].ID < sessions[j].ID
 		})
@@ -2653,6 +2671,8 @@ func rankTopSessions(
 	for i := range sessions {
 		sessions[i].DurationMin = math.Round(
 			sessions[i].DurationMin*10) / 10
+		sessions[i].ActiveDurationMin = math.Round(
+			sessions[i].ActiveDurationMin*10) / 10
 	}
 	return sessions
 }

--- a/internal/postgres/analytics_pgtest_test.go
+++ b/internal/postgres/analytics_pgtest_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestRankTopSessions_DurationSort(t *testing.T) {
 	sessions := []db.TopSession{
-		{ID: "a", DurationMin: 10.0},
-		{ID: "b", DurationMin: 30.0},
-		{ID: "c", DurationMin: 20.0},
+		{ID: "a", ActiveDurationMin: 10.0},
+		{ID: "b", ActiveDurationMin: 30.0},
+		{ID: "c", ActiveDurationMin: 20.0},
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 3)
@@ -24,9 +24,9 @@ func TestRankTopSessions_DurationSort(t *testing.T) {
 
 func TestRankTopSessions_DurationTieBreaker(t *testing.T) {
 	sessions := []db.TopSession{
-		{ID: "z", DurationMin: 5.0},
-		{ID: "a", DurationMin: 5.0},
-		{ID: "m", DurationMin: 5.0},
+		{ID: "z", ActiveDurationMin: 5.0},
+		{ID: "a", ActiveDurationMin: 5.0},
+		{ID: "m", ActiveDurationMin: 5.0},
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 3)
@@ -37,27 +37,39 @@ func TestRankTopSessions_DurationTieBreaker(t *testing.T) {
 
 func TestRankTopSessions_NearTiePrecision(t *testing.T) {
 	sessions := []db.TopSession{
-		{ID: "a", DurationMin: 10.04},
-		{ID: "b", DurationMin: 10.06},
+		{ID: "a", ActiveDurationMin: 10.04},
+		{ID: "b", ActiveDurationMin: 10.06},
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 2)
 	assert.Equal(t, "b", got[0].ID, "10.06 > 10.04")
-	assert.Equal(t, 10.1, got[0].DurationMin)
-	assert.Equal(t, 10.0, got[1].DurationMin)
+	assert.Equal(t, 10.1, got[0].ActiveDurationMin)
+	assert.Equal(t, 10.0, got[1].ActiveDurationMin)
 }
 
 func TestRankTopSessions_TruncatesTo10(t *testing.T) {
 	sessions := make([]db.TopSession, 15)
 	for i := range sessions {
 		sessions[i] = db.TopSession{
-			ID:          string(rune('a' + i)),
-			DurationMin: float64(i),
+			ID:                string(rune('a' + i)),
+			ActiveDurationMin: float64(i),
 		}
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 10)
-	assert.Equal(t, 14.0, got[0].DurationMin)
+	assert.Equal(t, 14.0, got[0].ActiveDurationMin)
+}
+
+func TestRankTopSessions_UsesActiveDurationForSort(t *testing.T) {
+	sessions := []db.TopSession{
+		{ID: "wall", DurationMin: 120.0, ActiveDurationMin: 1.0},
+		{ID: "active", DurationMin: 10.0, ActiveDurationMin: 15.0},
+	}
+	got := rankTopSessions(sessions, true)
+	require.Len(t, got, 2)
+	assert.Equal(t, "active", got[0].ID)
+	assert.Equal(t, 15.0, got[0].ActiveDurationMin)
+	assert.Equal(t, 120.0, got[1].DurationMin)
 }
 
 func TestRankTopSessions_NoSortForMessages(t *testing.T) {
@@ -81,11 +93,11 @@ func TestRankTopSessions_NilInput(t *testing.T) {
 
 func TestRankTopSessions_RoundsForDisplay(t *testing.T) {
 	sessions := []db.TopSession{
-		{ID: "a", DurationMin: 12.349},
-		{ID: "b", DurationMin: 12.351},
+		{ID: "a", ActiveDurationMin: 12.349},
+		{ID: "b", ActiveDurationMin: 12.351},
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 2)
-	assert.Equal(t, 12.4, got[0].DurationMin)
-	assert.Equal(t, 12.3, got[1].DurationMin)
+	assert.Equal(t, 12.4, got[0].ActiveDurationMin)
+	assert.Equal(t, 12.3, got[1].ActiveDurationMin)
 }

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -1152,6 +1152,53 @@ func TestStoreAnalyticsTopSessionsDisplayName(t *testing.T) {
 	assert.Equal(t, "User renamed title", *custom.DisplayName)
 }
 
+func TestStoreAnalyticsTopSessionsMessagesAllowRunningSessions(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, first_message,
+			started_at, ended_at, message_count,
+			user_message_count
+		) VALUES
+			('pg-running-session', 'test-machine', 'test-project',
+			 'claude', 'still running',
+			 '2026-03-12T13:00:00Z'::timestamptz,
+			 NULL,
+			 12, 3),
+			('pg-finished-session', 'test-machine', 'test-project',
+			 'claude', 'finished',
+			 '2026-03-12T11:00:00Z'::timestamptz,
+			 '2026-03-12T11:30:00Z'::timestamptz,
+			 10, 2)
+	`)
+	require.NoError(t, err, "inserting top sessions")
+
+	top, err := store.GetAnalyticsTopSessions(
+		context.Background(),
+		db.AnalyticsFilter{
+			From: "2026-03-12",
+			To:   "2026-03-12",
+		},
+		"messages",
+	)
+	require.NoError(t, err, "GetAnalyticsTopSessions")
+
+	byID := map[string]db.TopSession{}
+	for _, session := range top.Sessions {
+		byID[session.ID] = session
+	}
+
+	running, ok := byID["pg-running-session"]
+	require.True(t, ok, "running session missing from top sessions")
+	assert.Equal(t, 0.0, running.DurationMin)
+}
+
 func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 	pgURL := testPGURL(t)
 


### PR DESCRIPTION
Top Sessions currently ranks by wall-clock duration, computed as the gap between `started_at` and `ended_at`. That overstates sessions left idle, a terminal left open overnight dominates the ranking even if actual tool work lasted only a few minutes. The underlying per-turn timing data already exists and powers the per-session timing endpoint, but the analytics aggregation path never uses it.

This change adds an explicit `active_duration_min` field to the Top Sessions contract, computed from the same tool-turn timing semantics the repo already uses elsewhere, and switches the duration ranking to use that active value across the SQLite, PostgreSQL, and DuckDB analytics backends. The existing `duration_min` field stays populated so total session time remains visible to users as secondary context, which keeps the “show both” part of the issue intact.

On the frontend, the duration view now reads as active or tool time, uses the active value as the primary metric, keeps total duration available alongside it, and routes the new tooltip text through the existing Paraglide message surface. Focused backend regression tests cover the case where wall-clock duration and active duration disagree, the SQLite DST fallback path, DuckDB parity, PostgreSQL running-session null handling, and the ranking helper, while the Top Sessions frontend test proves the new display contract.

Fixes #83
