### PR TITLE
fix(analytics): define top-session active duration as clamped idle gaps (alt to #867)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -391,6 +391,8 @@
   "analytics_top_sessions_by_messages": "By Messages",
   "analytics_top_sessions_by_duration": "By Duration",
   "analytics_top_sessions_by_output_tokens": "By Output Tokens",
+  "analytics_top_sessions_active_duration": "Active duration",
+  "analytics_top_sessions_total_duration": "{duration} total",
   "analytics_projects_title": "Projects",
   "analytics_project_messages": [
     {

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -385,6 +385,8 @@
   "analytics_top_sessions_by_messages": "按消息数",
   "analytics_top_sessions_by_duration": "按时长",
   "analytics_top_sessions_by_output_tokens": "按输出 token",
+  "analytics_top_sessions_active_duration": "活跃时长",
+  "analytics_top_sessions_total_duration": "总计 {duration}",
   "analytics_projects_title": "项目",
   "analytics_project_messages": [
     {

--- a/frontend/src/lib/api/generated/models/DbTopSession.ts
+++ b/frontend/src/lib/api/generated/models/DbTopSession.ts
@@ -5,6 +5,7 @@
 export type DbTopSession = {
   display_name?: string;
   duration_min: number;
+  active_duration_min: number;
   ended_at?: string;
   first_message: string | null;
   id: string;

--- a/frontend/src/lib/api/types/analytics.ts
+++ b/frontend/src/lib/api/types/analytics.ts
@@ -139,6 +139,7 @@ export interface TopSession {
   message_count: number;
   output_tokens: number;
   duration_min: number;
+  active_duration_min: number;
   /** ISO timestamps used by the StatusDot component to compute
    * the active/stale/unclean tier — the column needs the same
    * recency inputs as the sidebar list. */

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -39,8 +39,9 @@
     activeMin: number,
     totalMin: number,
   ): string {
-    const totalText = ` (${formatDuration(totalMin)} total)`;
-    return `${formatDuration(activeMin)}${totalText}`;
+    return `${formatDuration(activeMin)} (${m.analytics_top_sessions_total_duration({
+      duration: formatDuration(totalMin),
+    })})`;
   }
 
   function handleSessionClick(id: string) {
@@ -164,7 +165,7 @@
             {#if analytics.topMetric === "duration"}
               <span
                 class="session-metric-primary"
-                title="Active duration"
+                title={m.analytics_top_sessions_active_duration()}
               >
                 {formatDurationWithTotal(
                   session.active_duration_min,

--- a/frontend/src/lib/components/analytics/TopSessions.svelte
+++ b/frontend/src/lib/components/analytics/TopSessions.svelte
@@ -35,6 +35,14 @@
     return m > 0 ? `${h}h ${m}m` : `${h}h`;
   }
 
+  function formatDurationWithTotal(
+    activeMin: number,
+    totalMin: number,
+  ): string {
+    const totalText = ` (${formatDuration(totalMin)} total)`;
+    return `${formatDuration(activeMin)}${totalText}`;
+  }
+
   function handleSessionClick(id: string) {
     let needInvalidate = false;
     const params: Record<string, string> = {};
@@ -154,7 +162,15 @@
           </div>
           <span class="session-metric">
             {#if analytics.topMetric === "duration"}
-              {formatDuration(session.duration_min)}
+              <span
+                class="session-metric-primary"
+                title="Active duration"
+              >
+                {formatDurationWithTotal(
+                  session.active_duration_min,
+                  session.duration_min,
+                )}
+              </span>
             {:else if analytics.topMetric === "output_tokens"}
               {formatTokenCount(session.output_tokens)}
             {:else}
@@ -322,8 +338,12 @@
     font-weight: 500;
     font-family: var(--font-mono);
     color: var(--accent-blue);
-    min-width: 36px;
+    min-width: 86px;
     text-align: right;
+  }
+
+  .session-metric-primary {
+    display: inline-block;
   }
 
   .empty {

--- a/frontend/src/lib/components/analytics/TopSessions.test.ts
+++ b/frontend/src/lib/components/analytics/TopSessions.test.ts
@@ -67,6 +67,7 @@ describe("TopSessions", () => {
           message_count: 10,
           output_tokens: 0,
           duration_min: 5,
+          active_duration_min: 5,
         },
       ],
     };
@@ -184,6 +185,7 @@ describe("TopSessions", () => {
           message_count: 10,
           output_tokens: 0,
           duration_min: 5,
+          active_duration_min: 5,
         },
       ],
     };
@@ -208,6 +210,44 @@ describe("TopSessions", () => {
     unmount(component);
   });
 
+  it("shows active duration as primary with total duration context", async () => {
+    // @ts-ignore — topMetric is a reactive store field
+    analytics.topMetric = "duration";
+    analytics.topSessions = {
+      metric: "duration",
+      sessions: [
+        {
+          id: "sess-1",
+          project: "proj",
+          first_message: "hello",
+          message_count: 10,
+          output_tokens: 0,
+          duration_min: 120,
+          active_duration_min: 2.5,
+        },
+      ],
+    };
+    // @ts-ignore — loading is reactive state
+    analytics.loading = {
+      ...analytics.loading,
+      topSessions: false,
+    };
+    // @ts-ignore
+    analytics.errors = {
+      ...analytics.errors,
+      topSessions: null,
+    };
+
+    const component = mount(TopSessions, { target: document.body });
+    await tick();
+
+    expect(
+      document.querySelector(".session-metric")?.textContent?.trim(),
+    ).toBe("3m (2h total)");
+
+    unmount(component);
+  });
+
   describe("status column", () => {
     function mountWithFourStates() {
       analytics.topSessions = {
@@ -220,6 +260,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: "clean",
           },
           {
@@ -229,6 +270,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: "tool_call_pending",
           },
           {
@@ -238,6 +280,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: "truncated",
           },
           {
@@ -247,6 +290,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: null,
           },
         ],
@@ -323,6 +367,7 @@ describe("TopSessions", () => {
             message_count: 1,
             output_tokens: 0,
             duration_min: 0,
+            active_duration_min: 0,
             termination_status: "clean",
           },
         ],

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -2581,7 +2581,9 @@ func processSessionVelocity(
 	toolCount int,
 ) {
 	const maxCycleSec = 1800.0
-	const maxGapSec = 300.0
+	// Shared with the Top Sessions "active duration" SQL so the two
+	// "active" definitions stay in lockstep.
+	const maxGapSec = ActiveGapCapSec
 
 	for _, a := range accums {
 		a.sessions++
@@ -4356,6 +4358,18 @@ type TopSessionsResponse struct {
 	Sessions []TopSession `json:"sessions"`
 }
 
+// ActiveGapCapSec and ActiveGapCapMs bound how much a single
+// inter-message gap can contribute to "active" time: a gap below the cap
+// (5 minutes) counts in full -- model generation, tool execution, or a
+// quick human turnaround -- while anything longer is treated as idle
+// beyond the cap. Defined once and shared by the velocity "active
+// minutes" metric and the Top Sessions "active duration" SQL so the two
+// definitions cannot drift. timing_test.go asserts the two stay equal.
+const (
+	ActiveGapCapSec = 300.0
+	ActiveGapCapMs  = 300_000
+)
+
 // GetAnalyticsTopSessions returns the top 10 sessions by the
 // given metric ("messages", "duration", or "output_tokens")
 // within the filter.
@@ -4373,24 +4387,24 @@ func (db *DB) GetAnalyticsTopSessions(
 
 	durationExpr := `ROUND((julianday(ended_at) -
 		julianday(started_at)) * 1440, 1)`
-	activeDurationExpr := `
+	activeDurationExpr := fmt.Sprintf(`
 		(
 			SELECT COALESCE(SUM(
 				CASE
-					WHEN inner2.has_tool_use = 0 OR inner2.delta_ms <= 0 THEN NULL
+					WHEN inner2.delta_ms <= 0 THEN 0
+					WHEN inner2.delta_ms > %[1]d THEN %[1]d
 					ELSE inner2.delta_ms
 				END), 0) / 60000.0
 			FROM (
 				SELECT CAST(
 				  ROUND(
-					(julianday(COALESCE(LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
-					  sessions.ended_at)) - julianday(m2.timestamp)) * 86400000
+					(julianday(LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal))
+					  - julianday(m2.timestamp)) * 86400000
 					) AS INTEGER
-				) AS delta_ms,
-				m2.has_tool_use
+				) AS delta_ms
 			FROM messages m2
 				WHERE m2.session_id = sessions.id
-			) inner2)`
+			) inner2)`, ActiveGapCapMs)
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
 	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
 	needsGoSort := metric == "duration"

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -4497,8 +4497,9 @@ func (db *DB) getAnalyticsTopSessionsGo(
 	case "duration":
 		orderExpr = `(julianday(ended_at) -
 			julianday(started_at)) * 1440 DESC, id ASC`
-		where += " AND started_at IS NOT NULL" +
-			" AND ended_at IS NOT NULL"
+		where += " AND NULLIF(started_at, '') IS NOT NULL" +
+			" AND NULLIF(ended_at, '') IS NOT NULL" +
+			" AND julianday(ended_at) >= julianday(started_at)"
 	default:
 		metric = "messages"
 		orderExpr = "message_count DESC, id ASC"

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -4370,6 +4370,32 @@ const (
 	ActiveGapCapMs  = 300_000
 )
 
+// sqliteActiveDurationExpr builds the correlated-subquery SQL that computes a
+// session's active duration in minutes: the sum of consecutive inter-message
+// gaps with each gap capped at ActiveGapCapMs. sessionIDCol is the outer
+// reference to correlate on (for example "sessions.id"). Shared by the in-SQL
+// and timezone-aware Go fallback Top Sessions paths so the two cannot drift.
+func sqliteActiveDurationExpr(sessionIDCol string) string {
+	return fmt.Sprintf(`
+		(
+			SELECT COALESCE(SUM(
+				CASE
+					WHEN inner2.delta_ms <= 0 THEN 0
+					WHEN inner2.delta_ms > %[1]d THEN %[1]d
+					ELSE inner2.delta_ms
+				END), 0) / 60000.0
+			FROM (
+				SELECT CAST(
+				  ROUND(
+					(julianday(LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal))
+					  - julianday(m2.timestamp)) * 86400000
+					) AS INTEGER
+				) AS delta_ms
+			FROM messages m2
+				WHERE m2.session_id = %[2]s
+			) inner2)`, ActiveGapCapMs, sessionIDCol)
+}
+
 // GetAnalyticsTopSessions returns the top 10 sessions by the
 // given metric ("messages", "duration", or "output_tokens")
 // within the filter.
@@ -4387,26 +4413,9 @@ func (db *DB) GetAnalyticsTopSessions(
 
 	durationExpr := `ROUND((julianday(ended_at) -
 		julianday(started_at)) * 1440, 1)`
-	activeDurationExpr := fmt.Sprintf(`
-		(
-			SELECT COALESCE(SUM(
-				CASE
-					WHEN inner2.delta_ms <= 0 THEN 0
-					WHEN inner2.delta_ms > %[1]d THEN %[1]d
-					ELSE inner2.delta_ms
-				END), 0) / 60000.0
-			FROM (
-				SELECT CAST(
-				  ROUND(
-					(julianday(LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal))
-					  - julianday(m2.timestamp)) * 86400000
-					) AS INTEGER
-				) AS delta_ms
-			FROM messages m2
-				WHERE m2.session_id = sessions.id
-			) inner2)`, ActiveGapCapMs)
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
-	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
+	activeDurationSelectExpr := "COALESCE(" +
+		sqliteActiveDurationExpr("sessions.id") + ", 0)"
 	needsGoSort := metric == "duration"
 	var orderExpr string
 	switch metric {
@@ -4500,10 +4509,23 @@ func (db *DB) getAnalyticsTopSessionsGo(
 		limitClause = ""
 	}
 
+	// Active duration is only consumed for the duration metric. Compute it
+	// in the outer query (matching the in-SQL path) rather than issuing a
+	// per-row follow-up query: the per-row form held the outer rows iterator
+	// open while acquiring a second reader connection for each row, an
+	// unbounded N+1 that could exhaust the capped reader pool and deadlock
+	// under concurrent requests.
+	activeDurationSelectExpr := "0.0"
+	if needsGoSort {
+		activeDurationSelectExpr = "COALESCE(" +
+			sqliteActiveDurationExpr("sessions.id") + ", 0)"
+	}
+
 	query := `SELECT id, ` + dateCol + `, project,
 		first_message,
 		COALESCE(display_name, session_name) AS display_name,
 		message_count, total_output_tokens,
+		` + activeDurationSelectExpr + ` AS active_duration_min,
 		started_at, ended_at, termination_status
 		FROM sessions WHERE ` + where +
 		` ORDER BY ` + orderExpr + limitClause
@@ -4521,24 +4543,15 @@ func (db *DB) getAnalyticsTopSessionsGo(
 		var firstMsg, displayName, startedAt, endedAt *string
 		var termStatus *string
 		var mc, outputTokens int
+		var activeDurationMin float64
 		if err := rows.Scan(
 			&id, &ts, &project, &firstMsg,
 			&displayName, &mc, &outputTokens,
+			&activeDurationMin,
 			&startedAt, &endedAt, &termStatus,
 		); err != nil {
 			return TopSessionsResponse{},
 				fmt.Errorf("scanning top session: %w", err)
-		}
-		var activeDurationMin float64
-		if metric == "duration" {
-			var err error
-			activeDurationMin, err = db.activeDurationMinForSession(
-				ctx, id,
-			)
-			if err != nil {
-				return TopSessionsResponse{},
-					fmt.Errorf("querying top session active duration: %w", err)
-			}
 		}
 		date := localDate(ts, loc)
 		if !inDateRange(date, f.From, f.To) {

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -4481,13 +4481,18 @@ func (db *DB) getAnalyticsTopSessionsGo(
 		orderExpr = "message_count DESC, id ASC"
 	}
 
+	limitClause := " LIMIT 200"
+	if f.HasTimeFilter() || needsGoSort {
+		limitClause = ""
+	}
+
 	query := `SELECT id, ` + dateCol + `, project,
 		first_message,
 		COALESCE(display_name, session_name) AS display_name,
 		message_count, total_output_tokens,
 		started_at, ended_at, termination_status
 		FROM sessions WHERE ` + where +
-		` ORDER BY ` + orderExpr + ` LIMIT 200`
+		` ORDER BY ` + orderExpr + limitClause
 
 	rows, err := db.getReader().QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -4333,13 +4333,14 @@ func round1(v float64) float64 {
 
 // TopSession holds summary info for a ranked session.
 type TopSession struct {
-	ID           string  `json:"id"`
-	Project      string  `json:"project"`
-	FirstMessage *string `json:"first_message"`
-	DisplayName  *string `json:"display_name,omitempty"`
-	MessageCount int     `json:"message_count"`
-	OutputTokens int     `json:"output_tokens"`
-	DurationMin  float64 `json:"duration_min"`
+	ID                string  `json:"id"`
+	Project           string  `json:"project"`
+	FirstMessage      *string `json:"first_message"`
+	DisplayName       *string `json:"display_name,omitempty"`
+	MessageCount      int     `json:"message_count"`
+	OutputTokens      int     `json:"output_tokens"`
+	DurationMin       float64 `json:"duration_min"`
+	ActiveDurationMin float64 `json:"active_duration_min"`
 	// StartedAt and EndedAt are included so the frontend can
 	// derive a recency-based status tier — the StatusDot in the
 	// Top Sessions column needs the same time window inputs as
@@ -4372,14 +4373,34 @@ func (db *DB) GetAnalyticsTopSessions(
 
 	durationExpr := `ROUND((julianday(ended_at) -
 		julianday(started_at)) * 1440, 1)`
+	activeDurationExpr := `
+		ROUND((
+			SELECT COALESCE(SUM(
+				CASE
+					WHEN inner2.has_tool_use = 0 OR inner2.delta_ms <= 0 THEN NULL
+					ELSE inner2.delta_ms
+				END), 0) / 60000.0
+			FROM (
+				SELECT CAST(
+				  ROUND(
+					(julianday(COALESCE(LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
+					  sessions.ended_at)) - julianday(m2.timestamp)) * 86400000
+					) AS INTEGER
+				) AS delta_ms,
+				m2.has_tool_use
+			FROM messages m2
+				WHERE m2.session_id = sessions.id
+			) inner2), 1)`
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
+	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
+	needsGoSort := metric == "duration"
 	var orderExpr string
 	switch metric {
 	case "output_tokens":
 		where += " AND has_total_output_tokens = TRUE"
 		orderExpr = "total_output_tokens DESC, id ASC"
 	case "duration":
-		orderExpr = durationExpr + " DESC, id ASC"
+		orderExpr = activeDurationSelectExpr + " DESC, id ASC"
 		where += " AND NULLIF(started_at, '') IS NOT NULL" +
 			" AND NULLIF(ended_at, '') IS NOT NULL" +
 			" AND julianday(ended_at) >= julianday(started_at)"
@@ -4391,6 +4412,7 @@ func (db *DB) GetAnalyticsTopSessions(
 	query := `SELECT id, project, first_message,
 		COALESCE(display_name, session_name) AS display_name,
 		message_count, total_output_tokens, ` + durationSelectExpr + `,
+		` + activeDurationSelectExpr + `,
 		started_at, ended_at, termination_status
 		FROM sessions WHERE ` + where +
 		` ORDER BY ` + orderExpr + ` LIMIT 10`
@@ -4409,6 +4431,7 @@ func (db *DB) GetAnalyticsTopSessions(
 			&row.ID, &row.Project, &row.FirstMessage,
 			&row.DisplayName, &row.MessageCount,
 			&row.OutputTokens, &row.DurationMin,
+			&row.ActiveDurationMin,
 			&row.StartedAt, &row.EndedAt,
 			&row.TerminationStatus,
 		); err != nil {
@@ -4421,6 +4444,8 @@ func (db *DB) GetAnalyticsTopSessions(
 		return TopSessionsResponse{},
 			fmt.Errorf("iterating top sessions: %w", err)
 	}
+	sessions := rankTopSessions(resp.Sessions, needsGoSort)
+	resp.Sessions = sessions
 	return resp, nil
 }
 
@@ -4441,6 +4466,7 @@ func (db *DB) getAnalyticsTopSessionsGo(
 	}
 
 	var orderExpr string
+	needsGoSort := metric == "duration"
 	switch metric {
 	case "output_tokens":
 		where += " AND has_total_output_tokens = TRUE"
@@ -4484,6 +4510,17 @@ func (db *DB) getAnalyticsTopSessionsGo(
 			return TopSessionsResponse{},
 				fmt.Errorf("scanning top session: %w", err)
 		}
+		var activeDurationMin float64
+		if metric == "duration" {
+			var err error
+			activeDurationMin, err = db.activeDurationMinForSession(
+				ctx, id,
+			)
+			if err != nil {
+				return TopSessionsResponse{},
+					fmt.Errorf("querying top session active duration: %w", err)
+			}
+		}
 		date := localDate(ts, loc)
 		if !inDateRange(date, f.From, f.To) {
 			continue
@@ -4508,6 +4545,7 @@ func (db *DB) getAnalyticsTopSessionsGo(
 			MessageCount:      mc,
 			OutputTokens:      outputTokens,
 			DurationMin:       durMin,
+			ActiveDurationMin: activeDurationMin,
 			StartedAt:         startedAt,
 			EndedAt:           endedAt,
 			TerminationStatus: termStatus,
@@ -4521,6 +4559,7 @@ func (db *DB) getAnalyticsTopSessionsGo(
 	if sessions == nil {
 		sessions = []TopSession{}
 	}
+	sessions = rankTopSessions(sessions, needsGoSort)
 	if len(sessions) > 10 {
 		sessions = sessions[:10]
 	}
@@ -4529,4 +4568,24 @@ func (db *DB) getAnalyticsTopSessionsGo(
 		Metric:   metric,
 		Sessions: sessions,
 	}, nil
+}
+
+func rankTopSessions(sessions []TopSession, needsGoSort bool) []TopSession {
+	if sessions == nil {
+		return []TopSession{}
+	}
+	if needsGoSort && len(sessions) > 1 {
+		sort.SliceStable(sessions, func(i, j int) bool {
+			if sessions[i].ActiveDurationMin != sessions[j].ActiveDurationMin {
+				return sessions[i].ActiveDurationMin >
+					sessions[j].ActiveDurationMin
+			}
+			return sessions[i].ID < sessions[j].ID
+		})
+	}
+	for i := range sessions {
+		sessions[i].DurationMin = round1(sessions[i].DurationMin)
+		sessions[i].ActiveDurationMin = round1(sessions[i].ActiveDurationMin)
+	}
+	return sessions
 }

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -4374,7 +4374,7 @@ func (db *DB) GetAnalyticsTopSessions(
 	durationExpr := `ROUND((julianday(ended_at) -
 		julianday(started_at)) * 1440, 1)`
 	activeDurationExpr := `
-		ROUND((
+		(
 			SELECT COALESCE(SUM(
 				CASE
 					WHEN inner2.has_tool_use = 0 OR inner2.delta_ms <= 0 THEN NULL
@@ -4390,7 +4390,7 @@ func (db *DB) GetAnalyticsTopSessions(
 				m2.has_tool_use
 			FROM messages m2
 				WHERE m2.session_id = sessions.id
-			) inner2), 1)`
+			) inner2)`
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
 	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
 	needsGoSort := metric == "duration"

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -2128,6 +2128,120 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "fallback clamped active duration")
 	})
 
+	t.Run("ByDurationExcludesReversedAndEmptyTimestamps", func(t *testing.T) {
+		// A reversed (ended < started) or empty-timestamp session can
+		// still accumulate positive message-gap active duration, so
+		// without an eligibility guard it would rank into the duration
+		// list. The SQL path must reject both, matching DuckDB and the Go
+		// fallback.
+		insertSession(t, d, "elig-valid", "project-elig-sql", func(s *Session) {
+			s.StartedAt = Ptr("2024-07-01T09:00:00Z")
+			s.EndedAt = Ptr("2024-07-01T09:30:00Z")
+			s.MessageCount = 2
+		})
+		insertMessages(
+			t, d,
+			userMsgAt("elig-valid", 0, "start", "2024-07-01T09:00:00Z"),
+			asstMsgAt("elig-valid", 1, "work", "2024-07-01T09:03:00Z"),
+		)
+
+		insertSession(t, d, "elig-reversed", "project-elig-sql", func(s *Session) {
+			s.StartedAt = Ptr("2024-07-01T10:00:00Z")
+			s.EndedAt = Ptr("2024-07-01T09:00:00Z")
+			s.MessageCount = 2
+		})
+		insertMessages(
+			t, d,
+			userMsgAt("elig-reversed", 0, "start", "2024-07-01T09:00:00Z"),
+			asstMsgAt("elig-reversed", 1, "work", "2024-07-01T09:04:00Z"),
+		)
+
+		insertSession(t, d, "elig-empty", "project-elig-sql", func(s *Session) {
+			s.StartedAt = Ptr("")
+			s.EndedAt = Ptr("")
+			s.MessageCount = 2
+		})
+		insertMessages(
+			t, d,
+			userMsgAt("elig-empty", 0, "start", "2024-07-01T09:00:00Z"),
+			asstMsgAt("elig-empty", 1, "work", "2024-07-01T09:04:00Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(
+			ctx, AnalyticsFilter{Project: "project-elig-sql"}, "duration",
+		)
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		var ids []string
+		for _, s := range resp.Sessions {
+			ids = append(ids, s.ID)
+		}
+		assert.Equal(t, []string{"elig-valid"}, ids,
+			"reversed and empty duration rows must be excluded")
+	})
+
+	t.Run("ByDurationExcludesReversedAndEmptyTimestampsInGoFallback", func(t *testing.T) {
+		// Same eligibility guard as the SQL path, but the timezone filter
+		// forces the Go fallback ranking path. Parity matters because the
+		// ranking is by message-gap active duration, which stays positive
+		// regardless of reversed or missing wall-clock timestamps.
+		insertSession(t, d, "elig-fb-valid", "project-elig-fb", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-12T09:00:00Z")
+			s.EndedAt = Ptr("2026-03-12T09:30:00Z")
+			s.MessageCount = 2
+		})
+		insertMessages(
+			t, d,
+			userMsgAt("elig-fb-valid", 0, "start", "2026-03-12T09:00:00Z"),
+			asstMsgAt("elig-fb-valid", 1, "work", "2026-03-12T09:03:00Z"),
+		)
+
+		insertSession(t, d, "elig-fb-reversed", "project-elig-fb", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-12T10:00:00Z")
+			s.EndedAt = Ptr("2026-03-12T09:00:00Z")
+			s.MessageCount = 2
+		})
+		insertMessages(
+			t, d,
+			userMsgAt("elig-fb-reversed", 0, "start", "2026-03-12T09:00:00Z"),
+			asstMsgAt("elig-fb-reversed", 1, "work", "2026-03-12T09:04:00Z"),
+		)
+
+		insertSession(t, d, "elig-fb-empty", "project-elig-fb", func(s *Session) {
+			s.StartedAt = Ptr("")
+			s.EndedAt = Ptr("")
+			s.MessageCount = 2
+		})
+		insertMessages(
+			t, d,
+			userMsgAt("elig-fb-empty", 0, "start", "2026-03-12T09:00:00Z"),
+			asstMsgAt("elig-fb-empty", 1, "work", "2026-03-12T09:04:00Z"),
+		)
+		// created_at is not bound by UpsertSession and otherwise defaults
+		// to insertion time, which the date filter would drop before the
+		// eligibility guard is reached. Pin it into the filter window so
+		// this row genuinely exercises the empty-timestamp NULLIF guard
+		// rather than being excluded by the date range.
+		_, err := d.getWriter().Exec(
+			"UPDATE sessions SET created_at = ? WHERE id = ?",
+			"2026-03-12T00:00:00Z", "elig-fb-empty",
+		)
+		require.NoError(t, err, "pin elig-fb-empty created_at")
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project:  "project-elig-fb",
+			From:     "2026-03-01",
+			To:       "2026-03-31",
+			Timezone: "America/New_York",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		var ids []string
+		for _, s := range resp.Sessions {
+			ids = append(ids, s.ID)
+		}
+		assert.Equal(t, []string{"elig-fb-valid"}, ids,
+			"reversed and empty duration rows must be excluded in fallback")
+	})
+
 	t.Run("DefaultMetric", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "",

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1859,6 +1859,69 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		}
 	})
 
+	t.Run("ByDurationRanksByActiveDuration", func(t *testing.T) {
+		insertSession(t, d, "wall-dominant", "project-gamma", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-02T09:00:00Z")
+			s.EndedAt = Ptr("2024-06-02T11:00:00Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("wall-dominant", 0, "noop", "2024-06-02T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"wall-dominant",
+					1,
+					"idle wait",
+					"2024-06-02T10:59:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt(
+				"wall-dominant",
+				2,
+				"done",
+				"2024-06-02T11:00:00Z",
+			),
+		)
+
+		insertSession(t, d, "actively-working", "project-gamma", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-02T09:30:00Z")
+			s.EndedAt = Ptr("2024-06-02T09:50:00Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("actively-working", 0, "start", "2024-06-02T09:30:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"actively-working",
+					1,
+					"tooling",
+					"2024-06-02T09:35:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("actively-working", 2, "finish", "2024-06-02T09:50:00Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(
+			ctx, baseFilter(), "duration",
+		)
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		assert.Equal(t, "duration", resp.Metric, "Metric")
+		require.NotEmpty(t, resp.Sessions, "sessions")
+		assert.Equal(t, "actively-working", resp.Sessions[0].ID, "top session by active duration")
+		assert.Equal(t, 20.0, resp.Sessions[0].DurationMin, "active total duration")
+		assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin, "active duration")
+		assert.Equal(t, 120.0, resp.Sessions[1].DurationMin, "wall-only duration")
+		assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin, "idle active duration")
+	})
+
 	t.Run("DefaultMetric", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "",

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1922,6 +1922,63 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin, "idle active duration")
 	})
 
+	t.Run("ByDurationKeepsNearTieOrderBeforeDisplayRounding", func(t *testing.T) {
+		insertSession(t, d, "near-tie-longer", "project-precision", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-03T09:00:00Z")
+			s.EndedAt = Ptr("2024-06-03T09:10:02.400Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("near-tie-longer", 0, "start", "2024-06-03T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"near-tie-longer",
+					1,
+					"tooling",
+					"2024-06-03T09:00:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("near-tie-longer", 2, "finish", "2024-06-03T09:10:02.400Z"),
+		)
+
+		insertSession(t, d, "near-tie-shorter", "project-precision", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-03T09:00:00Z")
+			s.EndedAt = Ptr("2024-06-03T09:10:01.800Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("near-tie-shorter", 0, "start", "2024-06-03T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"near-tie-shorter",
+					1,
+					"tooling",
+					"2024-06-03T09:00:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("near-tie-shorter", 2, "finish", "2024-06-03T09:10:01.800Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project: "project-precision",
+			From:    "2024-06-03",
+			To:      "2024-06-03",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.Len(t, resp.Sessions, 2, "precision sessions")
+		assert.Equal(t, "near-tie-longer", resp.Sessions[0].ID, "raw active duration should decide the rank")
+		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "display rounding")
+		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin, "display rounding")
+	})
+
 	t.Run("ByDurationRanksByActiveDurationInGoFallback", func(t *testing.T) {
 		for i := range 201 {
 			id := fmt.Sprintf("dst-wall-%03d", i)
@@ -1980,6 +2037,175 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		require.NotEmpty(t, resp.Sessions, "sessions")
 		assert.Equal(t, "dst-actively-working", resp.Sessions[0].ID, "top session by active duration in fallback")
 		assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin, "fallback active duration")
+	})
+
+	t.Run("ByDurationKeepsNearTieOrderInGoFallback", func(t *testing.T) {
+		insertSession(t, d, "dst-near-tie-longer", "project-dst-precision", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:00:00Z")
+			s.EndedAt = Ptr("2026-03-10T09:10:02.400Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-near-tie-longer", 0, "start", "2026-03-10T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-near-tie-longer",
+					1,
+					"tooling",
+					"2026-03-10T09:00:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-near-tie-longer", 2, "finish", "2026-03-10T09:10:02.400Z"),
+		)
+
+		insertSession(t, d, "dst-near-tie-shorter", "project-dst-precision", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:00:00Z")
+			s.EndedAt = Ptr("2026-03-10T09:10:01.800Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-near-tie-shorter", 0, "start", "2026-03-10T09:00:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-near-tie-shorter",
+					1,
+					"tooling",
+					"2026-03-10T09:00:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-near-tie-shorter", 2, "finish", "2026-03-10T09:10:01.800Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project:  "project-dst-precision",
+			From:     "2026-03-01",
+			To:       "2026-03-31",
+			Timezone: "America/New_York",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.Len(t, resp.Sessions, 2, "fallback precision sessions")
+		assert.Equal(t, "dst-near-tie-longer", resp.Sessions[0].ID, "fallback should keep raw active ordering")
+		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "fallback display rounding")
+		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin, "fallback display rounding")
+	})
+
+	t.Run("ByDurationSortsBeforeRoundingInSQLiteSQL", func(t *testing.T) {
+		insertSession(t, d, "sql-round-a", "project-round-sql", func(s *Session) {
+			s.StartedAt = Ptr("2026-04-05T09:59:00.000Z")
+			s.EndedAt = Ptr("2026-04-05T10:10:02.400Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("sql-round-a", 0, "start", "2026-04-05T09:59:00.000Z"),
+			func() Message {
+				m := asstMsgAt(
+					"sql-round-a",
+					1,
+					"tool",
+					"2026-04-05T10:00:00.000Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("sql-round-a", 2, "finish", "2026-04-05T10:10:02.400Z"),
+		)
+		insertSession(t, d, "sql-round-b", "project-round-sql", func(s *Session) {
+			s.StartedAt = Ptr("2026-04-05T09:59:00.000Z")
+			s.EndedAt = Ptr("2026-04-05T10:10:03.600Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("sql-round-b", 0, "start", "2026-04-05T09:59:00.000Z"),
+			func() Message {
+				m := asstMsgAt(
+					"sql-round-b",
+					1,
+					"tool",
+					"2026-04-05T10:00:00.000Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("sql-round-b", 2, "finish", "2026-04-05T10:10:03.600Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project: "project-round-sql",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.Len(t, resp.Sessions, 2)
+		assert.Equal(t, "sql-round-b", resp.Sessions[0].ID, "10.06 must rank ahead of 10.04 before rounding")
+		assert.Equal(t, 10.1, resp.Sessions[0].ActiveDurationMin)
+		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin)
+	})
+
+	t.Run("ByDurationSortsBeforeRoundingInGoFallback", func(t *testing.T) {
+		insertSession(t, d, "dst-round-a", "project-round-fallback", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:59:00.000Z")
+			s.EndedAt = Ptr("2026-03-10T10:10:02.400Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-round-a", 0, "start", "2026-03-10T09:59:00.000Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-round-a",
+					1,
+					"tool",
+					"2026-03-10T10:00:00.000Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-round-a", 2, "finish", "2026-03-10T10:10:02.400Z"),
+		)
+		insertSession(t, d, "dst-round-b", "project-round-fallback", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:59:00.000Z")
+			s.EndedAt = Ptr("2026-03-10T10:10:03.600Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-round-b", 0, "start", "2026-03-10T09:59:00.000Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-round-b",
+					1,
+					"tool",
+					"2026-03-10T10:00:00.000Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-round-b", 2, "finish", "2026-03-10T10:10:03.600Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project:  "project-round-fallback",
+			From:     "2026-03-01",
+			To:       "2026-03-31",
+			Timezone: "America/New_York",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.Len(t, resp.Sessions, 2)
+		assert.Equal(t, "dst-round-b", resp.Sessions[0].ID, "fallback must rank 10.06 ahead of 10.04 before rounding")
+		assert.Equal(t, 10.1, resp.Sessions[0].ActiveDurationMin)
+		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin)
 	})
 
 	t.Run("DefaultMetric", func(t *testing.T) {

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1922,6 +1922,66 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin, "idle active duration")
 	})
 
+	t.Run("ByDurationRanksByActiveDurationInGoFallback", func(t *testing.T) {
+		for i := range 201 {
+			id := fmt.Sprintf("dst-wall-%03d", i)
+			insertSession(t, d, id, "project-dst", func(s *Session) {
+				s.StartedAt = Ptr("2026-03-10T09:00:00Z")
+				s.EndedAt = Ptr("2026-03-10T11:00:00Z")
+				s.MessageCount = 3
+			})
+			insertMessages(
+				t,
+				d,
+				userMsgAt(id, 0, "noop", "2026-03-10T09:00:00Z"),
+				func() Message {
+					m := asstMsgAt(
+						id,
+						1,
+						"idle wait",
+						"2026-03-10T10:59:00Z",
+					)
+					m.HasToolUse = true
+					return m
+				}(),
+				userMsgAt(id, 2, "done", "2026-03-10T11:00:00Z"),
+			)
+		}
+
+		insertSession(t, d, "dst-actively-working", "project-dst", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:30:00Z")
+			s.EndedAt = Ptr("2026-03-10T09:50:00Z")
+			s.MessageCount = 3
+		})
+		insertMessages(
+			t,
+			d,
+			userMsgAt("dst-actively-working", 0, "start", "2026-03-10T09:30:00Z"),
+			func() Message {
+				m := asstMsgAt(
+					"dst-actively-working",
+					1,
+					"tooling",
+					"2026-03-10T09:35:00Z",
+				)
+				m.HasToolUse = true
+				return m
+			}(),
+			userMsgAt("dst-actively-working", 2, "finish", "2026-03-10T09:50:00Z"),
+		)
+
+		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
+			Project:  "project-dst",
+			From:     "2026-03-01",
+			To:       "2026-03-31",
+			Timezone: "America/New_York",
+		}, "duration")
+		require.NoError(t, err, "GetAnalyticsTopSessions")
+		require.NotEmpty(t, resp.Sessions, "sessions")
+		assert.Equal(t, "dst-actively-working", resp.Sessions[0].ID, "top session by active duration in fallback")
+		assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin, "fallback active duration")
+	})
+
 	t.Run("DefaultMetric", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTopSessions(
 			ctx, baseFilter(), "",

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -1910,61 +1910,50 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		)
 
 		resp, err := d.GetAnalyticsTopSessions(
-			ctx, baseFilter(), "duration",
+			ctx, AnalyticsFilter{Project: "project-gamma"}, "duration",
 		)
 		require.NoError(t, err, "GetAnalyticsTopSessions")
 		assert.Equal(t, "duration", resp.Metric, "Metric")
-		require.NotEmpty(t, resp.Sessions, "sessions")
+		require.Len(t, resp.Sessions, 2, "sessions")
 		assert.Equal(t, "actively-working", resp.Sessions[0].ID, "top session by active duration")
 		assert.Equal(t, 20.0, resp.Sessions[0].DurationMin, "active total duration")
-		assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin, "active duration")
+		// 5 min user->asst gap + a 15 min gap capped at the 5 min idle
+		// cap = 10.
+		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "active duration")
 		assert.Equal(t, 120.0, resp.Sessions[1].DurationMin, "wall-only duration")
-		assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin, "idle active duration")
+		// 119 min idle gap capped to 5 + a 1 min gap = 6, so the
+		// mostly-idle 2-hour session ranks below the engaged 20-min one.
+		assert.Equal(t, 6.0, resp.Sessions[1].ActiveDurationMin, "idle active duration")
 	})
 
 	t.Run("ByDurationKeepsNearTieOrderBeforeDisplayRounding", func(t *testing.T) {
+		// Two sessions whose active durations differ only below the
+		// display-rounding granularity (2.504 vs 2.496 min). Both render
+		// as "2.5", but the raw value must decide the rank. The single
+		// gap stays under the 5 min idle cap so the clamp does not
+		// flatten the sub-second difference.
 		insertSession(t, d, "near-tie-longer", "project-precision", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-03T09:00:00Z")
-			s.EndedAt = Ptr("2024-06-03T09:10:02.400Z")
-			s.MessageCount = 3
+			s.StartedAt = Ptr("2024-06-03T09:00:00.000Z")
+			s.EndedAt = Ptr("2024-06-03T09:02:30.240Z")
+			s.MessageCount = 2
 		})
 		insertMessages(
 			t,
 			d,
-			userMsgAt("near-tie-longer", 0, "start", "2024-06-03T09:00:00Z"),
-			func() Message {
-				m := asstMsgAt(
-					"near-tie-longer",
-					1,
-					"tooling",
-					"2024-06-03T09:00:00Z",
-				)
-				m.HasToolUse = true
-				return m
-			}(),
-			userMsgAt("near-tie-longer", 2, "finish", "2024-06-03T09:10:02.400Z"),
+			userMsgAt("near-tie-longer", 0, "start", "2024-06-03T09:00:00.000Z"),
+			asstMsgAt("near-tie-longer", 1, "work", "2024-06-03T09:02:30.240Z"),
 		)
 
 		insertSession(t, d, "near-tie-shorter", "project-precision", func(s *Session) {
-			s.StartedAt = Ptr("2024-06-03T09:00:00Z")
-			s.EndedAt = Ptr("2024-06-03T09:10:01.800Z")
-			s.MessageCount = 3
+			s.StartedAt = Ptr("2024-06-03T09:00:00.000Z")
+			s.EndedAt = Ptr("2024-06-03T09:02:29.760Z")
+			s.MessageCount = 2
 		})
 		insertMessages(
 			t,
 			d,
-			userMsgAt("near-tie-shorter", 0, "start", "2024-06-03T09:00:00Z"),
-			func() Message {
-				m := asstMsgAt(
-					"near-tie-shorter",
-					1,
-					"tooling",
-					"2024-06-03T09:00:00Z",
-				)
-				m.HasToolUse = true
-				return m
-			}(),
-			userMsgAt("near-tie-shorter", 2, "finish", "2024-06-03T09:10:01.800Z"),
+			userMsgAt("near-tie-shorter", 0, "start", "2024-06-03T09:00:00.000Z"),
+			asstMsgAt("near-tie-shorter", 1, "work", "2024-06-03T09:02:29.760Z"),
 		)
 
 		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
@@ -1975,8 +1964,8 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		require.NoError(t, err, "GetAnalyticsTopSessions")
 		require.Len(t, resp.Sessions, 2, "precision sessions")
 		assert.Equal(t, "near-tie-longer", resp.Sessions[0].ID, "raw active duration should decide the rank")
-		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "display rounding")
-		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin, "display rounding")
+		assert.Equal(t, 2.5, resp.Sessions[0].ActiveDurationMin, "display rounding")
+		assert.Equal(t, 2.5, resp.Sessions[1].ActiveDurationMin, "display rounding")
 	})
 
 	t.Run("ByDurationRanksByActiveDurationInGoFallback", func(t *testing.T) {
@@ -2036,52 +2025,35 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		require.NoError(t, err, "GetAnalyticsTopSessions")
 		require.NotEmpty(t, resp.Sessions, "sessions")
 		assert.Equal(t, "dst-actively-working", resp.Sessions[0].ID, "top session by active duration in fallback")
-		assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin, "fallback active duration")
+		// 5 + 5 (15 min gap capped at the 5 min idle cap) = 10.
+		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "fallback active duration")
 	})
 
 	t.Run("ByDurationKeepsNearTieOrderInGoFallback", func(t *testing.T) {
+		// Same near-tie invariant as the SQLite SQL case, but the
+		// timezone filter forces the Go fallback ranking path.
 		insertSession(t, d, "dst-near-tie-longer", "project-dst-precision", func(s *Session) {
-			s.StartedAt = Ptr("2026-03-10T09:00:00Z")
-			s.EndedAt = Ptr("2026-03-10T09:10:02.400Z")
-			s.MessageCount = 3
+			s.StartedAt = Ptr("2026-03-10T09:00:00.000Z")
+			s.EndedAt = Ptr("2026-03-10T09:02:30.240Z")
+			s.MessageCount = 2
 		})
 		insertMessages(
 			t,
 			d,
-			userMsgAt("dst-near-tie-longer", 0, "start", "2026-03-10T09:00:00Z"),
-			func() Message {
-				m := asstMsgAt(
-					"dst-near-tie-longer",
-					1,
-					"tooling",
-					"2026-03-10T09:00:00Z",
-				)
-				m.HasToolUse = true
-				return m
-			}(),
-			userMsgAt("dst-near-tie-longer", 2, "finish", "2026-03-10T09:10:02.400Z"),
+			userMsgAt("dst-near-tie-longer", 0, "start", "2026-03-10T09:00:00.000Z"),
+			asstMsgAt("dst-near-tie-longer", 1, "work", "2026-03-10T09:02:30.240Z"),
 		)
 
 		insertSession(t, d, "dst-near-tie-shorter", "project-dst-precision", func(s *Session) {
-			s.StartedAt = Ptr("2026-03-10T09:00:00Z")
-			s.EndedAt = Ptr("2026-03-10T09:10:01.800Z")
-			s.MessageCount = 3
+			s.StartedAt = Ptr("2026-03-10T09:00:00.000Z")
+			s.EndedAt = Ptr("2026-03-10T09:02:29.760Z")
+			s.MessageCount = 2
 		})
 		insertMessages(
 			t,
 			d,
-			userMsgAt("dst-near-tie-shorter", 0, "start", "2026-03-10T09:00:00Z"),
-			func() Message {
-				m := asstMsgAt(
-					"dst-near-tie-shorter",
-					1,
-					"tooling",
-					"2026-03-10T09:00:00Z",
-				)
-				m.HasToolUse = true
-				return m
-			}(),
-			userMsgAt("dst-near-tie-shorter", 2, "finish", "2026-03-10T09:10:01.800Z"),
+			userMsgAt("dst-near-tie-shorter", 0, "start", "2026-03-10T09:00:00.000Z"),
+			asstMsgAt("dst-near-tie-shorter", 1, "work", "2026-03-10T09:02:29.760Z"),
 		)
 
 		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
@@ -2093,119 +2065,67 @@ func TestGetAnalyticsTopSessions(t *testing.T) {
 		require.NoError(t, err, "GetAnalyticsTopSessions")
 		require.Len(t, resp.Sessions, 2, "fallback precision sessions")
 		assert.Equal(t, "dst-near-tie-longer", resp.Sessions[0].ID, "fallback should keep raw active ordering")
-		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "fallback display rounding")
-		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin, "fallback display rounding")
+		assert.Equal(t, 2.5, resp.Sessions[0].ActiveDurationMin, "fallback display rounding")
+		assert.Equal(t, 2.5, resp.Sessions[1].ActiveDurationMin, "fallback display rounding")
 	})
 
-	t.Run("ByDurationSortsBeforeRoundingInSQLiteSQL", func(t *testing.T) {
-		insertSession(t, d, "sql-round-a", "project-round-sql", func(s *Session) {
-			s.StartedAt = Ptr("2026-04-05T09:59:00.000Z")
-			s.EndedAt = Ptr("2026-04-05T10:10:02.400Z")
-			s.MessageCount = 3
+	t.Run("ByDurationCapsLongGapsAndCountsGeneration", func(t *testing.T) {
+		// No tool calls anywhere: under the old tool-execution-only
+		// definition this session scored 0. The clamp counts every gap
+		// -- model generation included -- and bounds the one long idle
+		// gap at the 5 min cap: 4 (gen) + 60->5 (idle cap) + 1 = 10.
+		insertSession(t, d, "clamp-mixed", "project-clamp-sql", func(s *Session) {
+			s.StartedAt = Ptr("2024-06-04T09:00:00Z")
+			s.EndedAt = Ptr("2024-06-04T10:05:00Z")
+			s.MessageCount = 4
 		})
 		insertMessages(
 			t,
 			d,
-			userMsgAt("sql-round-a", 0, "start", "2026-04-05T09:59:00.000Z"),
-			func() Message {
-				m := asstMsgAt(
-					"sql-round-a",
-					1,
-					"tool",
-					"2026-04-05T10:00:00.000Z",
-				)
-				m.HasToolUse = true
-				return m
-			}(),
-			userMsgAt("sql-round-a", 2, "finish", "2026-04-05T10:10:02.400Z"),
-		)
-		insertSession(t, d, "sql-round-b", "project-round-sql", func(s *Session) {
-			s.StartedAt = Ptr("2026-04-05T09:59:00.000Z")
-			s.EndedAt = Ptr("2026-04-05T10:10:03.600Z")
-			s.MessageCount = 3
-		})
-		insertMessages(
-			t,
-			d,
-			userMsgAt("sql-round-b", 0, "start", "2026-04-05T09:59:00.000Z"),
-			func() Message {
-				m := asstMsgAt(
-					"sql-round-b",
-					1,
-					"tool",
-					"2026-04-05T10:00:00.000Z",
-				)
-				m.HasToolUse = true
-				return m
-			}(),
-			userMsgAt("sql-round-b", 2, "finish", "2026-04-05T10:10:03.600Z"),
+			userMsgAt("clamp-mixed", 0, "start", "2024-06-04T09:00:00Z"),
+			asstMsgAt("clamp-mixed", 1, "thinking", "2024-06-04T09:04:00Z"),
+			userMsgAt("clamp-mixed", 2, "back", "2024-06-04T10:04:00Z"),
+			asstMsgAt("clamp-mixed", 3, "reply", "2024-06-04T10:05:00Z"),
 		)
 
 		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
-			Project: "project-round-sql",
+			Project: "project-clamp-sql",
 		}, "duration")
 		require.NoError(t, err, "GetAnalyticsTopSessions")
-		require.Len(t, resp.Sessions, 2)
-		assert.Equal(t, "sql-round-b", resp.Sessions[0].ID, "10.06 must rank ahead of 10.04 before rounding")
-		assert.Equal(t, 10.1, resp.Sessions[0].ActiveDurationMin)
-		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin)
+		require.Len(t, resp.Sessions, 1, "clamp session")
+		assert.Equal(t, "clamp-mixed", resp.Sessions[0].ID)
+		assert.Equal(t, 65.0, resp.Sessions[0].DurationMin, "wall duration")
+		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "clamped active duration")
 	})
 
-	t.Run("ByDurationSortsBeforeRoundingInGoFallback", func(t *testing.T) {
-		insertSession(t, d, "dst-round-a", "project-round-fallback", func(s *Session) {
-			s.StartedAt = Ptr("2026-03-10T09:59:00.000Z")
-			s.EndedAt = Ptr("2026-03-10T10:10:02.400Z")
-			s.MessageCount = 3
+	t.Run("ByDurationCapsLongGapsAndCountsGenerationInGoFallback", func(t *testing.T) {
+		// Same clamp + generation accounting as the SQLite SQL case,
+		// exercised through the timezone-aware Go fallback path.
+		insertSession(t, d, "dst-clamp-mixed", "project-clamp-fallback", func(s *Session) {
+			s.StartedAt = Ptr("2026-03-10T09:00:00Z")
+			s.EndedAt = Ptr("2026-03-10T10:05:00Z")
+			s.MessageCount = 4
 		})
 		insertMessages(
 			t,
 			d,
-			userMsgAt("dst-round-a", 0, "start", "2026-03-10T09:59:00.000Z"),
-			func() Message {
-				m := asstMsgAt(
-					"dst-round-a",
-					1,
-					"tool",
-					"2026-03-10T10:00:00.000Z",
-				)
-				m.HasToolUse = true
-				return m
-			}(),
-			userMsgAt("dst-round-a", 2, "finish", "2026-03-10T10:10:02.400Z"),
-		)
-		insertSession(t, d, "dst-round-b", "project-round-fallback", func(s *Session) {
-			s.StartedAt = Ptr("2026-03-10T09:59:00.000Z")
-			s.EndedAt = Ptr("2026-03-10T10:10:03.600Z")
-			s.MessageCount = 3
-		})
-		insertMessages(
-			t,
-			d,
-			userMsgAt("dst-round-b", 0, "start", "2026-03-10T09:59:00.000Z"),
-			func() Message {
-				m := asstMsgAt(
-					"dst-round-b",
-					1,
-					"tool",
-					"2026-03-10T10:00:00.000Z",
-				)
-				m.HasToolUse = true
-				return m
-			}(),
-			userMsgAt("dst-round-b", 2, "finish", "2026-03-10T10:10:03.600Z"),
+			userMsgAt("dst-clamp-mixed", 0, "start", "2026-03-10T09:00:00Z"),
+			asstMsgAt("dst-clamp-mixed", 1, "thinking", "2026-03-10T09:04:00Z"),
+			userMsgAt("dst-clamp-mixed", 2, "back", "2026-03-10T10:04:00Z"),
+			asstMsgAt("dst-clamp-mixed", 3, "reply", "2026-03-10T10:05:00Z"),
 		)
 
 		resp, err := d.GetAnalyticsTopSessions(ctx, AnalyticsFilter{
-			Project:  "project-round-fallback",
+			Project:  "project-clamp-fallback",
 			From:     "2026-03-01",
 			To:       "2026-03-31",
 			Timezone: "America/New_York",
 		}, "duration")
 		require.NoError(t, err, "GetAnalyticsTopSessions")
-		require.Len(t, resp.Sessions, 2)
-		assert.Equal(t, "dst-round-b", resp.Sessions[0].ID, "fallback must rank 10.06 ahead of 10.04 before rounding")
-		assert.Equal(t, 10.1, resp.Sessions[0].ActiveDurationMin)
-		assert.Equal(t, 10.0, resp.Sessions[1].ActiveDurationMin)
+		require.Len(t, resp.Sessions, 1, "fallback clamp session")
+		assert.Equal(t, "dst-clamp-mixed", resp.Sessions[0].ID)
+		assert.Equal(t, 65.0, resp.Sessions[0].DurationMin, "wall duration")
+		assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin, "fallback clamped active duration")
 	})
 
 	t.Run("DefaultMetric", func(t *testing.T) {

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -229,38 +228,6 @@ func (db *DB) queryCallRows(
 		out = append(out, r)
 	}
 	return out, rows.Err()
-}
-
-// activeDurationMinForSession returns a session's active duration in
-// minutes: the sum of consecutive inter-message gaps with each gap
-// capped at ActiveGapCapMs. This mirrors the velocity "active minutes"
-// computation and the Top Sessions active-duration SQL expression, so
-// the timezone-aware Go fallback ranking path reports the same number as
-// the in-SQL path. A gap below the cap counts in full; longer stretches
-// are bounded as idle.
-func (db *DB) activeDurationMinForSession(
-	ctx context.Context, sessionID string,
-) (float64, error) {
-	row := db.getReader().QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT COALESCE(SUM(
-			CASE
-				WHEN t.delta_ms <= 0 THEN 0
-				WHEN t.delta_ms > %[1]d THEN %[1]d
-				ELSE t.delta_ms
-			END), 0) / 60000.0
-		FROM (
-			SELECT CAST(ROUND(
-				(julianday(LEAD(m.timestamp) OVER (ORDER BY m.ordinal))
-				  - julianday(m.timestamp)) * 86400000
-			) AS INTEGER) AS delta_ms
-			FROM messages m
-			WHERE m.session_id = ?
-		) t`, ActiveGapCapMs), sessionID)
-	var v float64
-	if err := row.Scan(&v); err != nil {
-		return 0, err
-	}
-	return v, nil
 }
 
 // AssembleTiming stitches scanned per-turn and per-call rows plus

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"math"
 	"sort"
 	"strings"
 	"time"
@@ -239,7 +238,7 @@ func activeDurationMinFromTurns(turns []TurnRow) float64 {
 		}
 		totalMs += *t.DurationMs
 	}
-	return math.Round(float64(totalMs)/6000) / 10
+	return float64(totalMs) / 60000
 }
 
 func (db *DB) activeDurationMinForSession(

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -230,25 +231,36 @@ func (db *DB) queryCallRows(
 	return out, rows.Err()
 }
 
-func activeDurationMinFromTurns(turns []TurnRow) float64 {
-	var totalMs int64
-	for _, t := range turns {
-		if !t.HasToolUse || t.DurationMs == nil || *t.DurationMs <= 0 {
-			continue
-		}
-		totalMs += *t.DurationMs
-	}
-	return float64(totalMs) / 60000
-}
-
+// activeDurationMinForSession returns a session's active duration in
+// minutes: the sum of consecutive inter-message gaps with each gap
+// capped at ActiveGapCapMs. This mirrors the velocity "active minutes"
+// computation and the Top Sessions active-duration SQL expression, so
+// the timezone-aware Go fallback ranking path reports the same number as
+// the in-SQL path. A gap below the cap counts in full; longer stretches
+// are bounded as idle.
 func (db *DB) activeDurationMinForSession(
 	ctx context.Context, sessionID string,
 ) (float64, error) {
-	turns, err := db.queryTurnRows(ctx, sessionID)
-	if err != nil {
+	row := db.getReader().QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT COALESCE(SUM(
+			CASE
+				WHEN t.delta_ms <= 0 THEN 0
+				WHEN t.delta_ms > %[1]d THEN %[1]d
+				ELSE t.delta_ms
+			END), 0) / 60000.0
+		FROM (
+			SELECT CAST(ROUND(
+				(julianday(LEAD(m.timestamp) OVER (ORDER BY m.ordinal))
+				  - julianday(m.timestamp)) * 86400000
+			) AS INTEGER) AS delta_ms
+			FROM messages m
+			WHERE m.session_id = ?
+		) t`, ActiveGapCapMs), sessionID)
+	var v float64
+	if err := row.Scan(&v); err != nil {
 		return 0, err
 	}
-	return activeDurationMinFromTurns(turns), nil
+	return v, nil
 }
 
 // AssembleTiming stitches scanned per-turn and per-call rows plus

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -228,6 +229,27 @@ func (db *DB) queryCallRows(
 		out = append(out, r)
 	}
 	return out, rows.Err()
+}
+
+func activeDurationMinFromTurns(turns []TurnRow) float64 {
+	var totalMs int64
+	for _, t := range turns {
+		if !t.HasToolUse || t.DurationMs == nil || *t.DurationMs <= 0 {
+			continue
+		}
+		totalMs += *t.DurationMs
+	}
+	return math.Round(float64(totalMs)/6000) / 10
+}
+
+func (db *DB) activeDurationMinForSession(
+	ctx context.Context, sessionID string,
+) (float64, error) {
+	turns, err := db.queryTurnRows(ctx, sessionID)
+	if err != nil {
+		return 0, err
+	}
+	return activeDurationMinFromTurns(turns), nil
 }
 
 // AssembleTiming stitches scanned per-turn and per-call rows plus

--- a/internal/db/timing_test.go
+++ b/internal/db/timing_test.go
@@ -116,6 +116,20 @@ func TestGetSessionTiming_NoToolUseHasNoTurnDuration(t *testing.T) {
 	assert.Equal(t, 0, got.TurnCount, "TurnCount")
 }
 
+func TestActiveDurationMinFromTurnsKeepsRawMinutePrecision(t *testing.T) {
+	tenMinutesTwoPointFourSeconds := int64(602_400)
+	ignoredNegative := int64(-1_000)
+	turns := []TurnRow{
+		{HasToolUse: true, DurationMs: &tenMinutesTwoPointFourSeconds},
+		{HasToolUse: true, DurationMs: &ignoredNegative},
+		{HasToolUse: false, DurationMs: &tenMinutesTwoPointFourSeconds},
+	}
+
+	got := activeDurationMinFromTurns(turns)
+
+	assert.InDelta(t, 10.04, got, 0.000001)
+}
+
 func TestGetSessionTiming_MarshalsEmptyCollectionsAsArrays(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/db/timing_test.go
+++ b/internal/db/timing_test.go
@@ -116,18 +116,14 @@ func TestGetSessionTiming_NoToolUseHasNoTurnDuration(t *testing.T) {
 	assert.Equal(t, 0, got.TurnCount, "TurnCount")
 }
 
-func TestActiveDurationMinFromTurnsKeepsRawMinutePrecision(t *testing.T) {
-	tenMinutesTwoPointFourSeconds := int64(602_400)
-	ignoredNegative := int64(-1_000)
-	turns := []TurnRow{
-		{HasToolUse: true, DurationMs: &tenMinutesTwoPointFourSeconds},
-		{HasToolUse: true, DurationMs: &ignoredNegative},
-		{HasToolUse: false, DurationMs: &tenMinutesTwoPointFourSeconds},
-	}
-
-	got := activeDurationMinFromTurns(turns)
-
-	assert.InDelta(t, 10.04, got, 0.000001)
+// TestActiveGapCapConstantsAgree guards the two spellings of the active
+// gap cap against drifting apart: the velocity metric uses the seconds
+// form and the active-duration SQL uses the milliseconds form.
+func TestActiveGapCapConstantsAgree(t *testing.T) {
+	assert.Equal(
+		t, ActiveGapCapMs, int(ActiveGapCapSec*1000),
+		"ActiveGapCapMs must equal ActiveGapCapSec in milliseconds",
+	)
 }
 
 func TestGetSessionTiming_MarshalsEmptyCollectionsAsArrays(t *testing.T) {

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -1678,11 +1678,34 @@ func (s *Store) GetAnalyticsTopSessions(
 		f, "COALESCE(s.started_at, s.created_at)", "s.", true, true)
 	durationExpr := "(epoch(s.ended_at) - epoch(s.started_at)) / 60.0"
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
+	activeDurationExpr := `
+		ROUND((
+			SELECT COALESCE(SUM(
+				CASE
+					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
+						THEN inner2.delta_ms
+					ELSE NULL
+				END), 0) / 60000.0
+			FROM (
+				SELECT CAST(
+					ROUND(epoch(
+						COALESCE(
+							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
+							s.ended_at
+						) - m2.timestamp
+					) * 1000) AS BIGINT
+				) AS delta_ms,
+				m2.has_tool_use
+				FROM messages m2
+				WHERE m2.session_id = s.id
+			) inner2
+		), 1)`
+	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
 	orderExpr := "s.message_count DESC, s.id ASC"
 	switch metric {
 	case "duration":
 		where += " AND s.started_at IS NOT NULL AND s.ended_at IS NOT NULL AND s.ended_at >= s.started_at"
-		orderExpr = durationExpr + " DESC, s.id ASC"
+		orderExpr = activeDurationSelectExpr + " DESC, s.id ASC"
 	case "output_tokens":
 		where += " AND s.has_total_output_tokens = TRUE"
 		orderExpr = "s.total_output_tokens DESC, s.id ASC"
@@ -1690,6 +1713,7 @@ func (s *Store) GetAnalyticsTopSessions(
 	query := `
 		SELECT s.id, s.project, s.first_message, s.message_count,
 			s.total_output_tokens, ` + durationSelectExpr + ` AS duration_min,
+			` + activeDurationSelectExpr + ` AS active_duration_min,
 			s.started_at, s.ended_at, s.termination_status
 		FROM sessions s
 		WHERE ` + where + `
@@ -1707,7 +1731,8 @@ func (s *Store) GetAnalyticsTopSessions(
 		var startedRaw, endedRaw any
 		if err := rows.Scan(
 			&row.ID, &row.Project, &row.FirstMessage, &row.MessageCount,
-			&row.OutputTokens, &row.DurationMin, &startedRaw, &endedRaw,
+			&row.OutputTokens, &row.DurationMin, &row.ActiveDurationMin,
+			&startedRaw, &endedRaw,
 			&row.TerminationStatus,
 		); err != nil {
 			return db.TopSessionsResponse{}, fmt.Errorf("scanning duckdb analytics top session: %w", err)

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -1556,7 +1556,9 @@ func processDuckSessionVelocity(
 	toolCount int,
 ) {
 	const maxCycleSec = 1800.0
-	const maxGapSec = 300.0
+	// Shared with the Top Sessions "active duration" SQL so the two
+	// "active" definitions stay in lockstep.
+	const maxGapSec = db.ActiveGapCapSec
 
 	for _, acc := range accums {
 		acc.sessions++
@@ -1678,28 +1680,25 @@ func (s *Store) GetAnalyticsTopSessions(
 		f, "COALESCE(s.started_at, s.created_at)", "s.", true, true)
 	durationExpr := "(epoch(s.ended_at) - epoch(s.started_at)) / 60.0"
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
-	activeDurationExpr := `
+	activeDurationExpr := fmt.Sprintf(`
 		(
 			SELECT COALESCE(SUM(
 				CASE
-					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
-						THEN inner2.delta_ms
-					ELSE NULL
+					WHEN inner2.delta_ms <= 0 THEN 0
+					WHEN inner2.delta_ms > %[1]d THEN %[1]d
+					ELSE inner2.delta_ms
 				END), 0) / 60000.0
 			FROM (
 				SELECT CAST(
 					ROUND(epoch(
-						COALESCE(
-							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
-							s.ended_at
-						) - m2.timestamp
+						LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal)
+						- m2.timestamp
 					) * 1000) AS BIGINT
-				) AS delta_ms,
-				m2.has_tool_use
+				) AS delta_ms
 				FROM messages m2
 				WHERE m2.session_id = s.id
 			) inner2
-		)`
+		)`, db.ActiveGapCapMs)
 	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
 	orderExpr := "s.message_count DESC, s.id ASC"
 	switch metric {

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -1679,7 +1679,7 @@ func (s *Store) GetAnalyticsTopSessions(
 	durationExpr := "(epoch(s.ended_at) - epoch(s.started_at)) / 60.0"
 	durationSelectExpr := "COALESCE(" + durationExpr + ", 0)"
 	activeDurationExpr := `
-		ROUND((
+		(
 			SELECT COALESCE(SUM(
 				CASE
 					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
@@ -1699,7 +1699,7 @@ func (s *Store) GetAnalyticsTopSessions(
 				FROM messages m2
 				WHERE m2.session_id = s.id
 			) inner2
-		), 1)`
+		)`
 	activeDurationSelectExpr := "COALESCE(" + activeDurationExpr + ", 0)"
 	orderExpr := "s.message_count DESC, s.id ASC"
 	switch metric {
@@ -1741,6 +1741,8 @@ func (s *Store) GetAnalyticsTopSessions(
 		endedAt := formatDBTime(endedRaw)
 		row.StartedAt = &startedAt
 		row.EndedAt = &endedAt
+		row.DurationMin = round1(row.DurationMin)
+		row.ActiveDurationMin = round1(row.ActiveDurationMin)
 		out.Sessions = append(out.Sessions, row)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -788,10 +788,13 @@ func TestAnalyticsTopSessionsDurationUsesActiveDuration(t *testing.T) {
 
 	assert.Equal(t, "duck-actively-working", resp.Sessions[0].ID)
 	assert.Equal(t, 20.0, resp.Sessions[0].DurationMin)
-	assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin)
+	// 5 min user->asst gap + a 15 min gap capped at the 5 min idle
+	// cap = 10.
+	assert.Equal(t, 10.0, resp.Sessions[0].ActiveDurationMin)
 	assert.Equal(t, "duck-wall-dominant", resp.Sessions[1].ID)
 	assert.Equal(t, 120.0, resp.Sessions[1].DurationMin)
-	assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin)
+	// 119 min idle gap capped to 5 + a 1 min gap = 6.
+	assert.Equal(t, 6.0, resp.Sessions[1].ActiveDurationMin)
 }
 
 func TestAnalyticsProjectsPopulateDailyTrendAndSortByMessages(t *testing.T) {

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -706,6 +706,94 @@ func TestAnalyticsTopSessionsFiltersMetricEligibility(t *testing.T) {
 	assert.Equal(t, "messages", unknown.Metric)
 }
 
+func TestAnalyticsTopSessionsDurationUsesActiveDuration(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	wallSession := syncSession(
+		"duck-wall-dominant", "alpha", "wall session",
+		"2026-01-20T09:00:00.000Z", 3,
+	)
+	wallEndedAt := "2026-01-20T11:00:00.000Z"
+	wallSession.EndedAt = &wallEndedAt
+	activeSession := syncSession(
+		"duck-actively-working", "alpha", "active session",
+		"2026-01-20T09:30:00.000Z", 3,
+	)
+	activeEndedAt := "2026-01-20T09:50:00.000Z"
+	activeSession.EndedAt = &activeEndedAt
+	writes := []db.SessionBatchWrite{
+		{
+			Session: wallSession,
+			Messages: []db.Message{
+				syncMessage(
+					"duck-wall-dominant", 0, "user", "wall start",
+					"2026-01-20T09:00:00.000Z",
+				),
+				syncMessage(
+					"duck-wall-dominant", 1, "assistant", "wall tool",
+					"2026-01-20T10:59:00.000Z",
+					db.ToolCall{
+						ToolName:  "Read",
+						Category:  "Read",
+						ToolUseID: "duck-wall-tool",
+						InputJSON: `{"file_path":"README.md"}`,
+					},
+				),
+				syncMessage(
+					"duck-wall-dominant", 2, "user", "wall finish",
+					"2026-01-20T11:00:00.000Z",
+				),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session: activeSession,
+			Messages: []db.Message{
+				syncMessage(
+					"duck-actively-working", 0, "user", "active start",
+					"2026-01-20T09:30:00.000Z",
+				),
+				syncMessage(
+					"duck-actively-working", 1, "assistant", "active tool",
+					"2026-01-20T09:35:00.000Z",
+					db.ToolCall{
+						ToolName:  "Edit",
+						Category:  "Write",
+						ToolUseID: "duck-active-tool",
+						InputJSON: `{"file_path":"main.go"}`,
+					},
+				),
+				syncMessage(
+					"duck-actively-working", 2, "user", "active finish",
+					"2026-01-20T09:50:00.000Z",
+				),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	}
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+
+	syncer := newTestSync(t, filepath.Join(t.TempDir(), "top-active.duckdb"), local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+
+	store := NewStoreFromDB(syncer.DB())
+	filter := db.AnalyticsFilter{From: "2026-01-20", To: "2026-01-20"}
+	resp, err := store.GetAnalyticsTopSessions(ctx, filter, "duration")
+	require.NoError(t, err)
+	require.Len(t, resp.Sessions, 2)
+
+	assert.Equal(t, "duck-actively-working", resp.Sessions[0].ID)
+	assert.Equal(t, 20.0, resp.Sessions[0].DurationMin)
+	assert.Equal(t, 15.0, resp.Sessions[0].ActiveDurationMin)
+	assert.Equal(t, "duck-wall-dominant", resp.Sessions[1].ID)
+	assert.Equal(t, 120.0, resp.Sessions[1].DurationMin)
+	assert.Equal(t, 1.0, resp.Sessions[1].ActiveDurationMin)
+}
+
 func TestAnalyticsProjectsPopulateDailyTrendAndSortByMessages(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -1283,7 +1283,7 @@ func (s *Store) GetAnalyticsSessionShape(
 	}
 
 	query := `SELECT ` + pgDateCol + `,
-		EXTRACT(EPOCH FROM ended_at - started_at)
+		COALESCE(EXTRACT(EPOCH FROM ended_at - started_at), 0)
 			AS duration_sec,
 		message_count, id FROM sessions WHERE ` + where
 

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2229,13 +2229,13 @@ func (s *Store) GetAnalyticsTopSessions(
 				END), 0) / 60000.0
 			FROM (
 				SELECT CAST(
-					(round(EXTRACT(EPOCH FROM (
+					round(EXTRACT(EPOCH FROM (
 						COALESCE(
 							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
 							sessions.ended_at
 						) - m2.timestamp
-					)) * 1000) AS BIGINT
-				) AS delta_ms,
+					)) * 1000
+				AS BIGINT) AS delta_ms,
 				m2.has_tool_use
 				FROM messages m2
 				WHERE m2.session_id = sessions.id

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2007,7 +2007,9 @@ func (s *Store) GetAnalyticsVelocity(
 	byComplexity := make(map[string]*velocityAccumulator)
 
 	const maxCycleSec = 1800.0
-	const maxGapSec = 300.0
+	// Shared with the Top Sessions "active duration" SQL so the two
+	// "active" definitions stay in lockstep.
+	const maxGapSec = db.ActiveGapCapSec
 
 	for _, sid := range sessionIDs {
 		info := sessionMap[sid]
@@ -2213,34 +2215,33 @@ func (s *Store) GetAnalyticsTopSessions(
 	if f.HasTimeFilter() || needsGoSort {
 		limitClause = ""
 	}
+	activeDurationSelectExpr := fmt.Sprintf(`COALESCE(
+		  (
+			SELECT COALESCE(SUM(
+				CASE
+					WHEN inner2.delta_ms <= 0 THEN 0
+					WHEN inner2.delta_ms > %[1]d THEN %[1]d
+					ELSE inner2.delta_ms
+				END), 0) / 60000.0
+			FROM (
+				SELECT CAST(
+					round(EXTRACT(EPOCH FROM (
+						LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal)
+						- m2.timestamp
+					)) * 1000)
+				AS BIGINT) AS delta_ms
+				FROM messages m2
+				WHERE m2.session_id = sessions.id
+			) inner2
+		), 0)`, db.ActiveGapCapMs)
+
 	query := `SELECT id, ` + pgDateCol + `, project,
 		first_message,
 		COALESCE(display_name, session_name) AS display_name,
 		message_count, total_output_tokens,
 		COALESCE(EXTRACT(EPOCH FROM ended_at - started_at), 0)
 			AS duration_sec,
-		COALESCE(
-		  (
-			SELECT COALESCE(SUM(
-				CASE
-					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
-						THEN inner2.delta_ms
-					ELSE NULL
-				END), 0) / 60000.0
-			FROM (
-				SELECT CAST(
-					round(EXTRACT(EPOCH FROM (
-						COALESCE(
-							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
-							sessions.ended_at
-						) - m2.timestamp
-					)) * 1000)
-				AS BIGINT) AS delta_ms,
-				m2.has_tool_use
-				FROM messages m2
-				WHERE m2.session_id = sessions.id
-			) inner2
-		), 0) AS active_duration_min,
+		` + activeDurationSelectExpr + ` AS active_duration_min,
 		started_at, ended_at,
 		termination_status
 		FROM sessions WHERE ` + where +

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2206,7 +2206,8 @@ func (s *Store) GetAnalyticsTopSessions(
 		orderExpr = "total_output_tokens DESC, id ASC"
 	case "duration":
 		where += " AND started_at IS NOT NULL" +
-			" AND ended_at IS NOT NULL"
+			" AND ended_at IS NOT NULL" +
+			" AND ended_at >= started_at"
 	default:
 		metric = "messages"
 	}

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2226,7 +2226,7 @@ func (s *Store) GetAnalyticsTopSessions(
 					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
 						THEN inner2.delta_ms
 					ELSE NULL
-				END), 0) / 60.0
+				END), 0) / 60000.0
 			FROM (
 				SELECT CAST(
 					(round(EXTRACT(EPOCH FROM (

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -1283,7 +1283,7 @@ func (s *Store) GetAnalyticsSessionShape(
 	}
 
 	query := `SELECT ` + pgDateCol + `,
-		COALESCE(EXTRACT(EPOCH FROM ended_at - started_at), 0)
+		EXTRACT(EPOCH FROM ended_at - started_at)
 			AS duration_sec,
 		message_count, id FROM sessions WHERE ` + where
 
@@ -2217,7 +2217,7 @@ func (s *Store) GetAnalyticsTopSessions(
 		first_message,
 		COALESCE(display_name, session_name) AS display_name,
 		message_count, total_output_tokens,
-		EXTRACT(EPOCH FROM ended_at - started_at)
+		COALESCE(EXTRACT(EPOCH FROM ended_at - started_at), 0)
 			AS duration_sec,
 		COALESCE(
 		  (

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2234,7 +2234,7 @@ func (s *Store) GetAnalyticsTopSessions(
 							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
 							sessions.ended_at
 						) - m2.timestamp
-					)) * 1000
+					)) * 1000)
 				AS BIGINT) AS delta_ms,
 				m2.has_tool_use
 				FROM messages m2

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2219,6 +2219,28 @@ func (s *Store) GetAnalyticsTopSessions(
 		message_count, total_output_tokens,
 		EXTRACT(EPOCH FROM ended_at - started_at)
 			AS duration_sec,
+		COALESCE(
+		  (
+			SELECT COALESCE(SUM(
+				CASE
+					WHEN inner2.has_tool_use AND inner2.delta_ms > 0
+						THEN inner2.delta_ms
+					ELSE NULL
+				END), 0) / 60.0
+			FROM (
+				SELECT CAST(
+					(round(EXTRACT(EPOCH FROM (
+						COALESCE(
+							LEAD(m2.timestamp) OVER (ORDER BY m2.ordinal),
+							sessions.ended_at
+						) - m2.timestamp
+					)) * 1000) AS BIGINT
+				) AS delta_ms,
+				m2.has_tool_use
+				FROM messages m2
+				WHERE m2.session_id = sessions.id
+			) inner2
+		), 0) AS active_duration_min,
 		started_at, ended_at,
 		termination_status
 		FROM sessions WHERE ` + where +
@@ -2242,11 +2264,11 @@ func (s *Store) GetAnalyticsTopSessions(
 		var startedAt, endedAt *time.Time
 		var firstMsg, displayName, termStatus *string
 		var mc, outputTokens int
-		var durationSec *float64
+		var durationSec, activeDurationMin float64
 		if err := rows.Scan(
 			&id, &ts, &project, &firstMsg,
 			&displayName, &mc, &outputTokens,
-			&durationSec, &startedAt, &endedAt,
+			&durationSec, &activeDurationMin, &startedAt, &endedAt,
 			&termStatus,
 		); err != nil {
 			return db.TopSessionsResponse{},
@@ -2261,12 +2283,7 @@ func (s *Store) GetAnalyticsTopSessions(
 		if timeIDs != nil && !timeIDs[id] {
 			continue
 		}
-		durMin := 0.0
-		if durationSec != nil {
-			durMin = *durationSec / 60.0
-		} else if needsGoSort {
-			continue
-		}
+		durMin := durationSec / 60.0
 		var startedStr, endedStr *string
 		if startedAt != nil {
 			s := FormatISO8601(*startedAt)
@@ -2284,6 +2301,7 @@ func (s *Store) GetAnalyticsTopSessions(
 			MessageCount:      mc,
 			OutputTokens:      outputTokens,
 			DurationMin:       durMin,
+			ActiveDurationMin: activeDurationMin,
 			StartedAt:         startedStr,
 			EndedAt:           endedStr,
 			TerminationStatus: termStatus,
@@ -2629,8 +2647,8 @@ func (s *Store) populateFrustrationMarkers(
 	})
 }
 
-// rankTopSessions sorts sessions by duration (if
-// needsGoSort), truncates to top 10, and rounds DurationMin.
+// rankTopSessions sorts sessions by active duration (if
+// needsGoSort), truncates to top 10, and rounds duration fields.
 func rankTopSessions(
 	sessions []db.TopSession, needsGoSort bool,
 ) []db.TopSession {
@@ -2639,10 +2657,10 @@ func rankTopSessions(
 	}
 	if needsGoSort && len(sessions) > 1 {
 		sort.SliceStable(sessions, func(i, j int) bool {
-			if sessions[i].DurationMin !=
-				sessions[j].DurationMin {
-				return sessions[i].DurationMin >
-					sessions[j].DurationMin
+			if sessions[i].ActiveDurationMin !=
+				sessions[j].ActiveDurationMin {
+				return sessions[i].ActiveDurationMin >
+					sessions[j].ActiveDurationMin
 			}
 			return sessions[i].ID < sessions[j].ID
 		})
@@ -2653,6 +2671,8 @@ func rankTopSessions(
 	for i := range sessions {
 		sessions[i].DurationMin = math.Round(
 			sessions[i].DurationMin*10) / 10
+		sessions[i].ActiveDurationMin = math.Round(
+			sessions[i].ActiveDurationMin*10) / 10
 	}
 	return sessions
 }

--- a/internal/postgres/analytics_pgtest_test.go
+++ b/internal/postgres/analytics_pgtest_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestRankTopSessions_DurationSort(t *testing.T) {
 	sessions := []db.TopSession{
-		{ID: "a", DurationMin: 10.0},
-		{ID: "b", DurationMin: 30.0},
-		{ID: "c", DurationMin: 20.0},
+		{ID: "a", ActiveDurationMin: 10.0},
+		{ID: "b", ActiveDurationMin: 30.0},
+		{ID: "c", ActiveDurationMin: 20.0},
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 3)
@@ -24,9 +24,9 @@ func TestRankTopSessions_DurationSort(t *testing.T) {
 
 func TestRankTopSessions_DurationTieBreaker(t *testing.T) {
 	sessions := []db.TopSession{
-		{ID: "z", DurationMin: 5.0},
-		{ID: "a", DurationMin: 5.0},
-		{ID: "m", DurationMin: 5.0},
+		{ID: "z", ActiveDurationMin: 5.0},
+		{ID: "a", ActiveDurationMin: 5.0},
+		{ID: "m", ActiveDurationMin: 5.0},
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 3)
@@ -37,27 +37,39 @@ func TestRankTopSessions_DurationTieBreaker(t *testing.T) {
 
 func TestRankTopSessions_NearTiePrecision(t *testing.T) {
 	sessions := []db.TopSession{
-		{ID: "a", DurationMin: 10.04},
-		{ID: "b", DurationMin: 10.06},
+		{ID: "a", ActiveDurationMin: 10.04},
+		{ID: "b", ActiveDurationMin: 10.06},
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 2)
 	assert.Equal(t, "b", got[0].ID, "10.06 > 10.04")
-	assert.Equal(t, 10.1, got[0].DurationMin)
-	assert.Equal(t, 10.0, got[1].DurationMin)
+	assert.Equal(t, 10.1, got[0].ActiveDurationMin)
+	assert.Equal(t, 10.0, got[1].ActiveDurationMin)
 }
 
 func TestRankTopSessions_TruncatesTo10(t *testing.T) {
 	sessions := make([]db.TopSession, 15)
 	for i := range sessions {
 		sessions[i] = db.TopSession{
-			ID:          string(rune('a' + i)),
-			DurationMin: float64(i),
+			ID:                string(rune('a' + i)),
+			ActiveDurationMin: float64(i),
 		}
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 10)
-	assert.Equal(t, 14.0, got[0].DurationMin)
+	assert.Equal(t, 14.0, got[0].ActiveDurationMin)
+}
+
+func TestRankTopSessions_UsesActiveDurationForSort(t *testing.T) {
+	sessions := []db.TopSession{
+		{ID: "wall", DurationMin: 120.0, ActiveDurationMin: 1.0},
+		{ID: "active", DurationMin: 10.0, ActiveDurationMin: 15.0},
+	}
+	got := rankTopSessions(sessions, true)
+	require.Len(t, got, 2)
+	assert.Equal(t, "active", got[0].ID)
+	assert.Equal(t, 15.0, got[0].ActiveDurationMin)
+	assert.Equal(t, 120.0, got[1].DurationMin)
 }
 
 func TestRankTopSessions_NoSortForMessages(t *testing.T) {
@@ -81,11 +93,11 @@ func TestRankTopSessions_NilInput(t *testing.T) {
 
 func TestRankTopSessions_RoundsForDisplay(t *testing.T) {
 	sessions := []db.TopSession{
-		{ID: "a", DurationMin: 12.349},
-		{ID: "b", DurationMin: 12.351},
+		{ID: "a", ActiveDurationMin: 12.349},
+		{ID: "b", ActiveDurationMin: 12.351},
 	}
 	got := rankTopSessions(sessions, true)
 	require.Len(t, got, 2)
-	assert.Equal(t, 12.4, got[0].DurationMin)
-	assert.Equal(t, 12.3, got[1].DurationMin)
+	assert.Equal(t, 12.4, got[0].ActiveDurationMin)
+	assert.Equal(t, 12.3, got[1].ActiveDurationMin)
 }

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -1152,6 +1152,53 @@ func TestStoreAnalyticsTopSessionsDisplayName(t *testing.T) {
 	assert.Equal(t, "User renamed title", *custom.DisplayName)
 }
 
+func TestStoreAnalyticsTopSessionsMessagesAllowRunningSessions(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, first_message,
+			started_at, ended_at, message_count,
+			user_message_count
+		) VALUES
+			('pg-running-session', 'test-machine', 'test-project',
+			 'claude', 'still running',
+			 '2026-03-12T13:00:00Z'::timestamptz,
+			 NULL,
+			 12, 3),
+			('pg-finished-session', 'test-machine', 'test-project',
+			 'claude', 'finished',
+			 '2026-03-12T11:00:00Z'::timestamptz,
+			 '2026-03-12T11:30:00Z'::timestamptz,
+			 10, 2)
+	`)
+	require.NoError(t, err, "inserting top sessions")
+
+	top, err := store.GetAnalyticsTopSessions(
+		context.Background(),
+		db.AnalyticsFilter{
+			From: "2026-03-12",
+			To:   "2026-03-12",
+		},
+		"messages",
+	)
+	require.NoError(t, err, "GetAnalyticsTopSessions")
+
+	byID := map[string]db.TopSession{}
+	for _, session := range top.Sessions {
+		byID[session.ID] = session
+	}
+
+	running, ok := byID["pg-running-session"]
+	require.True(t, ok, "running session missing from top sessions")
+	assert.Equal(t, 0.0, running.DurationMin)
+}
+
 func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 	pgURL := testPGURL(t)
 

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -1199,6 +1199,72 @@ func TestStoreAnalyticsTopSessionsMessagesAllowRunningSessions(t *testing.T) {
 	assert.Equal(t, 0.0, running.DurationMin)
 }
 
+func TestStoreAnalyticsTopSessionsDurationUsesClampedActiveDuration(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	// Unique date so only these two sessions match the filter,
+	// regardless of what other tests leave behind in the schema.
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, first_message,
+			started_at, ended_at, message_count, user_message_count
+		) VALUES
+			('pg-clamp-wall', 'test-machine', 'clamp-parity',
+			 'claude', 'wall start',
+			 '2027-07-15T09:00:00Z'::timestamptz,
+			 '2027-07-15T11:00:00Z'::timestamptz,
+			 3, 2),
+			('pg-clamp-active', 'test-machine', 'clamp-parity',
+			 'claude', 'active start',
+			 '2027-07-15T09:30:00Z'::timestamptz,
+			 '2027-07-15T09:50:00Z'::timestamptz,
+			 3, 2)
+	`)
+	require.NoError(t, err, "inserting sessions")
+
+	_, err = store.DB().Exec(`
+		INSERT INTO messages
+			(session_id, ordinal, role, content, timestamp) VALUES
+			('pg-clamp-wall', 0, 'user', 'noop',
+			 '2027-07-15T09:00:00Z'::timestamptz),
+			('pg-clamp-wall', 1, 'assistant', 'idle wait',
+			 '2027-07-15T10:59:00Z'::timestamptz),
+			('pg-clamp-wall', 2, 'user', 'done',
+			 '2027-07-15T11:00:00Z'::timestamptz),
+			('pg-clamp-active', 0, 'user', 'start',
+			 '2027-07-15T09:30:00Z'::timestamptz),
+			('pg-clamp-active', 1, 'assistant', 'tooling',
+			 '2027-07-15T09:35:00Z'::timestamptz),
+			('pg-clamp-active', 2, 'user', 'finish',
+			 '2027-07-15T09:50:00Z'::timestamptz)
+	`)
+	require.NoError(t, err, "inserting messages")
+
+	top, err := store.GetAnalyticsTopSessions(
+		context.Background(),
+		db.AnalyticsFilter{From: "2027-07-15", To: "2027-07-15"},
+		"duration",
+	)
+	require.NoError(t, err, "GetAnalyticsTopSessions")
+	require.Len(t, top.Sessions, 2)
+
+	// Active duration ranks ahead of wall: the engaged 20-min session
+	// (5 min gap + a 15 min gap capped at the 5 min idle cap = 10)
+	// beats the mostly-idle 2-hour session (119 min capped to 5 + a
+	// 1 min gap = 6). Generation gaps count even with no tool calls.
+	assert.Equal(t, "pg-clamp-active", top.Sessions[0].ID)
+	assert.Equal(t, 20.0, top.Sessions[0].DurationMin)
+	assert.Equal(t, 10.0, top.Sessions[0].ActiveDurationMin)
+	assert.Equal(t, "pg-clamp-wall", top.Sessions[1].ID)
+	assert.Equal(t, 120.0, top.Sessions[1].DurationMin)
+	assert.Equal(t, 6.0, top.Sessions[1].ActiveDurationMin)
+}
+
 func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 	pgURL := testPGURL(t)
 

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -1265,6 +1265,67 @@ func TestStoreAnalyticsTopSessionsDurationUsesClampedActiveDuration(t *testing.T
 	assert.Equal(t, 6.0, top.Sessions[1].ActiveDurationMin)
 }
 
+func TestStoreAnalyticsTopSessionsDurationExcludesReversedTimestamps(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	// A reversed session (ended_at < started_at) still accumulates
+	// positive message-gap active duration, so without an eligibility
+	// guard it would rank into the duration list ordered by active
+	// duration. PostgreSQL must reject it, matching SQLite and DuckDB.
+	// (Empty-string timestamps are not representable in timestamptz
+	// columns, so only the reversed case applies on this backend.)
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, first_message,
+			started_at, ended_at, message_count, user_message_count
+		) VALUES
+			('pg-elig-valid', 'test-machine', 'elig-parity',
+			 'claude', 'valid start',
+			 '2027-08-20T09:00:00Z'::timestamptz,
+			 '2027-08-20T09:30:00Z'::timestamptz,
+			 2, 1),
+			('pg-elig-reversed', 'test-machine', 'elig-parity',
+			 'claude', 'reversed start',
+			 '2027-08-20T10:00:00Z'::timestamptz,
+			 '2027-08-20T09:00:00Z'::timestamptz,
+			 2, 1)
+	`)
+	require.NoError(t, err, "inserting sessions")
+
+	_, err = store.DB().Exec(`
+		INSERT INTO messages
+			(session_id, ordinal, role, content, timestamp) VALUES
+			('pg-elig-valid', 0, 'user', 'start',
+			 '2027-08-20T09:00:00Z'::timestamptz),
+			('pg-elig-valid', 1, 'assistant', 'work',
+			 '2027-08-20T09:03:00Z'::timestamptz),
+			('pg-elig-reversed', 0, 'user', 'start',
+			 '2027-08-20T09:00:00Z'::timestamptz),
+			('pg-elig-reversed', 1, 'assistant', 'work',
+			 '2027-08-20T09:04:00Z'::timestamptz)
+	`)
+	require.NoError(t, err, "inserting messages")
+
+	top, err := store.GetAnalyticsTopSessions(
+		context.Background(),
+		db.AnalyticsFilter{From: "2027-08-20", To: "2027-08-20"},
+		"duration",
+	)
+	require.NoError(t, err, "GetAnalyticsTopSessions")
+
+	ids := []string{}
+	for _, session := range top.Sessions {
+		ids = append(ids, session.ID)
+	}
+	assert.Equal(t, []string{"pg-elig-valid"}, ids,
+		"reversed duration row must be excluded")
+}
+
 func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
 	pgURL := testPGURL(t)
 


### PR DESCRIPTION
Alternative to #867. This branch is built on @rodboev's commits (kept in
the history, so the original work and authorship are preserved); it changes
only how "active duration" is computed.

## What changed

#867 computes a session's active duration by summing only the gaps that
*follow* a tool-use message. That captures tool-execution latency but
discards all model generation and thinking time — including the time spent
before the first tool call — so a session that reasons for minutes and then
fires one quick tool is scored as nearly idle.

This branch instead defines active duration the same way the existing
velocity "active minutes" metric already does: the sum of consecutive
inter-message gaps, with each gap capped at 5 minutes. Every gap counts —
model generation, tool execution, and quick human turnarounds — and only
stretches longer than the cap are bounded as idle.

## Why

Message timestamps alone can't tell a 20-minute subagent run from a
20-minute coffee break; both are one long gap. Capping each gap fails
gracefully in both directions (a long idle gap and a long active gap each
contribute at most 5 minutes) instead of guessing, and it keeps the metric
robust to messy data: resumed sessions, machine sleep, and API stalls
produce the largest gaps, and those would otherwise dominate the sum.

It also unifies the definition. The 5-minute cap is hoisted to a single
shared constant (`db.ActiveGapCapSec` / `ActiveGapCapMs`) used by both the
velocity metric and Top Sessions, so the two "active" numbers on the
dashboard can't drift; a test asserts the seconds and milliseconds forms
agree.

## Tradeoff

A genuinely long active operation — a 15-minute test run, a 20-minute
subagent — is also capped at 5 minutes, so it is undercounted. That is the
deliberate cost of not guessing whether a long gap was work or idle; the
error is bounded and symmetric.

## Where to look

- `internal/db/analytics.go` — shared constant, SQLite active-duration SQL,
  and the velocity metric now sourcing the same cap.
- `internal/db/timing.go` — SQLite Go fallback (timezone-aware ranking path)
  running the same clamp.
- `internal/postgres/analytics.go`, `internal/duckdb/analytics_usage.go` —
  PostgreSQL and DuckDB twins.

All three SQL backends drop the `has_tool_use` filter and the trailing gap
to `ended_at` so the value matches the velocity computation.

<sup>generated by a clanker</sup>
