### PR TITLE
feat(docs): publish raw markdown route companions

### DIFF
--- a/docs/scripts/check_built_site.py
+++ b/docs/scripts/check_built_site.py
@@ -16,7 +16,10 @@ ROUTES = [
     "/",
     "/quickstart/",
     "/usage/",
+    "/activity/",
+    "/recent-edits/",
     "/session-intelligence/",
+    "/mcp/",
     "/token-usage/",
     "/chat-import/",
     "/insights/",
@@ -196,6 +199,12 @@ def route_to_file(route: str) -> pathlib.Path:
     return SITE / route.strip("/") / "index.html"
 
 
+def route_to_markdown_file(route: str) -> pathlib.Path:
+    if route == "/":
+        return SITE / "index.md"
+    return SITE / f"{route.strip('/')}.md"
+
+
 def is_local_file_path(path: str) -> bool:
     return pathlib.PurePosixPath(path).suffix != ""
 
@@ -351,6 +360,9 @@ def main() -> None:
         path = route_to_file(route)
         if not path.exists():
             fail(f"missing route {route}: {path}")
+        markdown_path = route_to_markdown_file(route)
+        if not markdown_path.exists():
+            fail(f"missing route markdown {route}: {markdown_path}")
 
     if not (SITE / "404.html").exists():
         fail("missing 404.html")

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -11,6 +11,12 @@ shift || true
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 docs_root="$script_dir"
 site_dir="${AGENTSVIEW_DOCS_SITE_DIR:-site}"
+site_output_dir="$docs_root/$site_dir"
+case "$site_dir" in
+  /*)
+    site_output_dir="$site_dir"
+    ;;
+esac
 
 if [[ -n "${VIRTUAL_ENV:-}" && -x "$VIRTUAL_ENV/bin/zensical" ]]; then
   zensical_bin="$VIRTUAL_ENV/bin/zensical"
@@ -89,6 +95,15 @@ tmp_config_base=""
     -cf - .
 ) | (cd "$tmp_docs" && tar -xf -)
 
+copy_route_markdown_pages() {
+  mkdir -p "$site_output_dir"
+  find "$site_output_dir" -maxdepth 1 -type f -name '*.md' -delete
+  find "$tmp_docs" -maxdepth 1 -type f -name '*.md' ! -name 'README.md' -print0 |
+    while IFS= read -r -d '' source; do
+      cp "$source" "$site_output_dir/$(basename "$source")"
+    done
+}
+
 awk -v docs_dir="$tmp_docs_name" -v site_dir="$site_dir" '
   $0 == "docs_dir = \"docs\"" {
     print "docs_dir = \"" docs_dir "\""
@@ -104,6 +119,7 @@ awk -v docs_dir="$tmp_docs_name" -v site_dir="$site_dir" '
 case "$command_name" in
   build)
     (cd "$docs_root" && "$zensical_bin" build --strict --config-file "$tmp_config_name" "$@")
+    copy_route_markdown_pages
     ;;
   serve)
     (cd "$docs_root" && "$zensical_bin" serve --config-file "$tmp_config_name" "$@")

--- a/scripts/docs_assets_test.go
+++ b/scripts/docs_assets_test.go
@@ -189,6 +189,24 @@ func TestCheckDocsRequiresRipgrepForMediaReferenceChecks(t *testing.T) {
 	assert.Contains(t, string(output), "rg not found")
 }
 
+func TestBuiltSiteCheckRequiresMarkdownCompanions(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+
+	checkScript := installScript(t, repo, filepath.Join("docs", "scripts", "check_built_site.py"))
+	writeMinimalBuiltDocsSite(t, filepath.Join(repo, "docs", "site"))
+
+	pythonPath, err := exec.LookPath("python3")
+	require.NoError(t, err)
+	cmd := exec.Command(pythonPath, checkScript)
+	cmd.Dir = filepath.Join(repo, "docs")
+	output, err := cmd.CombinedOutput()
+
+	require.Error(t, err, string(output))
+	assert.Contains(t, string(output), "missing route markdown /")
+}
+
 func installScript(t *testing.T, repo, scriptRel string) string {
 	t.Helper()
 	script, err := os.ReadFile(filepath.Join("..", scriptRel))
@@ -197,6 +215,74 @@ func installScript(t *testing.T, repo, scriptRel string) string {
 	require.NoError(t, os.MkdirAll(filepath.Dir(scriptPath), 0o755))
 	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
 	return scriptPath
+}
+
+func writeMinimalBuiltDocsSite(t *testing.T, siteDir string) {
+	t.Helper()
+	routes := []string{
+		"/",
+		"/quickstart/",
+		"/usage/",
+		"/activity/",
+		"/recent-edits/",
+		"/session-intelligence/",
+		"/mcp/",
+		"/token-usage/",
+		"/chat-import/",
+		"/insights/",
+		"/commands/",
+		"/stats/",
+		"/session-api/",
+		"/configuration/",
+		"/remote-access/",
+		"/pg-sync/",
+		"/duckdb/",
+		"/changelog/",
+	}
+	for _, route := range routes {
+		path := filepath.Join(siteDir, strings.Trim(route, "/"), "index.html")
+		if route == "/" {
+			path = filepath.Join(siteDir, "index.html")
+		}
+		ids := []string{}
+		switch route {
+		case "/configuration/":
+			ids = append(ids, "session-discovery")
+		case "/token-usage/":
+			ids = append(ids, "how-it-compares-to-ccusage")
+		case "/session-api/":
+			ids = append(ids, "agentsview-session-usage")
+		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(minimalDocsHTML(ids)), 0o644))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(siteDir, "404.html"), []byte(minimalDocsHTML(nil)), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(siteDir, "sitemap.xml"),
+		[]byte("<urlset><url><loc>https://agentsview.io/</loc></url></urlset>\n"),
+		0o644,
+	))
+}
+
+func minimalDocsHTML(ids []string) string {
+	var b strings.Builder
+	b.WriteString(`<!doctype html><html><head>`)
+	b.WriteString(`<meta property="og:image" content="https://agentsview.io/assets/static/og-image.png">`)
+	b.WriteString(`<meta property="og:image:width" content="1200">`)
+	b.WriteString(`<meta property="og:image:height" content="630">`)
+	b.WriteString(`<meta property="og:type" content="website">`)
+	b.WriteString(`<meta property="og:site_name" content="AgentsView">`)
+	b.WriteString(`<meta name="twitter:card" content="summary_large_image">`)
+	b.WriteString(`<meta name="twitter:image" content="https://agentsview.io/assets/static/og-image.png">`)
+	b.WriteString(`</head><body>`)
+	b.WriteString(`<a class="agentsview-discord-link" aria-label="Join Discord" href="https://discord.gg/fDnmxB8Wkq">Discord</a>`)
+	for _, id := range ids {
+		b.WriteString(`<h2 id="`)
+		b.WriteString(id)
+		b.WriteString(`">Heading</h2>`)
+	}
+	b.WriteString(`</body></html>`)
+	return b.String()
 }
 
 func envWithout(names ...string) []string {


### PR DESCRIPTION
Expose raw authored markdown alongside the rendered docs so users and agents can fetch deployed documentation without scraping HTML or depending on GitHub raw URLs. The markdown files are copied from the same public docs input used for the rendered site, which keeps internal maintainer docs excluded and keeps `.md` responses tied to the deployed commit.

The built-site validation now treats markdown companions as part of the public docs contract, so future docs route changes cannot silently omit the agent-friendly form.