### PR TITLE
fix(sync): repair persisted Codex goal-context rows

### DIFF
--- a/frontend/src/lib/utils/messages.test.ts
+++ b/frontend/src/lib/utils/messages.test.ts
@@ -58,6 +58,11 @@ describe("isSystemMessage", () => {
     ["command-name", "<command-name>/commit</command-name>"],
     ["local-command", "<local-command-output>ok</local-command-output>"],
     ["stop hook", "Stop hook feedback: blocked"],
+    ["legacy goal context", "\n\t<goal_context>state</goal_context>"],
+    [
+      "codex internal goal context",
+      '  <codex_internal_context source="goal">state',
+    ],
   ])("detects prefix-based system message: %s", (_label, content) => {
     expect(isSystemMessage(msg({ content }))).toBe(true);
   });

--- a/frontend/src/lib/utils/messages.test.ts
+++ b/frontend/src/lib/utils/messages.test.ts
@@ -63,6 +63,14 @@ describe("isSystemMessage", () => {
       "codex internal goal context",
       '  <codex_internal_context source="goal">state',
     ],
+    [
+      "codex internal goal context with attr before source",
+      '<codex_internal_context foo="bar" source="goal">state',
+    ],
+    [
+      "codex internal goal context with attr after source",
+      '<codex_internal_context source="goal" foo="bar">state',
+    ],
   ])("detects prefix-based system message: %s", (_label, content) => {
     expect(isSystemMessage(msg({ content }))).toBe(true);
   });
@@ -71,6 +79,23 @@ describe("isSystemMessage", () => {
     expect(
       isSystemMessage(msg({ content: "This session is great" })),
     ).toBe(false);
+  });
+
+  it.each([
+    [
+      "non-goal internal context",
+      '<codex_internal_context source="other">state',
+    ],
+    [
+      "data-source attribute",
+      '<codex_internal_context data-source="goal">state',
+    ],
+    [
+      "missing closing tag delimiter",
+      '<codex_internal_context source="goal" state',
+    ],
+  ])("does not detect non-goal codex context: %s", (_label, content) => {
+    expect(isSystemMessage(msg({ content }))).toBe(false);
   });
 
   it.each([

--- a/frontend/src/lib/utils/messages.ts
+++ b/frontend/src/lib/utils/messages.ts
@@ -8,6 +8,8 @@ const SYSTEM_MSG_PREFIXES = [
   "<command-name>",
   "<local-command-",
   "Stop hook feedback:",
+  "<goal_context>",
+  '<codex_internal_context source="goal">',
 ];
 
 // Subtypes the Claude parser promotes into visible system messages

--- a/frontend/src/lib/utils/messages.ts
+++ b/frontend/src/lib/utils/messages.ts
@@ -8,9 +8,11 @@ const SYSTEM_MSG_PREFIXES = [
   "<command-name>",
   "<local-command-",
   "Stop hook feedback:",
-  "<goal_context>",
-  '<codex_internal_context source="goal">',
 ];
+
+const LEGACY_GOAL_CONTEXT_PREFIX = "<goal_context>";
+const CODEX_INTERNAL_CONTEXT_TAG_PREFIX = "<codex_internal_context";
+const GOAL_CONTEXT_SOURCE_ATTR_RE = /(?:^|\s)source="goal"(?:\s|\/|$)/;
 
 // Subtypes the Claude parser promotes into visible system messages
 // that the SPA renders via SystemBoundaryCard. These must pass
@@ -41,7 +43,25 @@ export function isSystemMessage(m: Message): boolean {
   if (m.is_system) return true;
   if (m.role !== "user") return false;
   const trimmed = m.content.trim();
-  return SYSTEM_MSG_PREFIXES.some((p) => trimmed.startsWith(p));
+  return (
+    isGoalContextMessage(trimmed) ||
+    SYSTEM_MSG_PREFIXES.some((p) => trimmed.startsWith(p))
+  );
+}
+
+function isGoalContextMessage(trimmedContent: string): boolean {
+  if (trimmedContent.startsWith(LEGACY_GOAL_CONTEXT_PREFIX)) {
+    return true;
+  }
+  if (!trimmedContent.startsWith(CODEX_INTERNAL_CONTEXT_TAG_PREFIX)) {
+    return false;
+  }
+  const tagEnd = trimmedContent.indexOf(">");
+  if (tagEnd < 0) {
+    return false;
+  }
+  const openTag = trimmedContent.slice(0, tagEnd);
+  return GOAL_CONTEXT_SOURCE_ATTR_RE.test(openTag);
 }
 
 /**

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -245,6 +245,9 @@ import (
 // backfill. Re-parsing persists estimated usage events for existing
 // aggregate-only Kimi sessions and preserves explicit native event
 // model names instead of the proxy fallback.)
+// (56: Codex goal-continuation context wrappers are filtered from
+// persisted messages and user_message_count. Existing Codex rows need
+// re-parsing so synthetic /goal continuation records are removed.)
 // (54: Antigravity .db sessions record a schema-fingerprint
 // source_version. Re-parsing populates source_version on existing
 // Antigravity IDE and CLI rows so "which agy release produced this
@@ -258,7 +261,7 @@ import (
 // (51: Gemini cumulative-to-delta token reparse.)
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 55
+const dataVersion = 56
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -696,8 +696,13 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionKimiUsageEvents(t *testing.T) {
-	assert.Equal(t, 55, CurrentDataVersion(),
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 55,
 		"Kimi persisted usage events require a data version bump")
+}
+
+func TestCurrentDataVersionGoalContextFiltering(t *testing.T) {
+	assert.Equal(t, 56, CurrentDataVersion(),
+		"Codex goal-context filtering requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -12,10 +13,10 @@ const (
 	snippetTokenLength = 32
 )
 
-// SystemMsgPrefixes lists content prefixes that identify system-injected
-// user messages. These are excluded from search results even when the
-// is_system column has not been backfilled (e.g. Claude sessions parsed
-// before schema version 2). Keep in sync with the frontend list in
+// SystemMsgPrefixes lists non-goal content prefixes that identify
+// system-injected user messages. These are excluded from search results even
+// when the is_system column has not been backfilled (e.g. Claude sessions
+// parsed before schema version 2). Keep in sync with the frontend list in
 // frontend/src/lib/utils/messages.ts.
 var SystemMsgPrefixes = []string{
 	"This session is being continued",
@@ -25,9 +26,17 @@ var SystemMsgPrefixes = []string{
 	"<command-name>",
 	"<local-command-",
 	"Stop hook feedback:",
-	"<goal_context>",
-	`<codex_internal_context source="goal">`,
 }
+
+const (
+	legacyGoalContextPrefix        = "<goal_context>"
+	codexInternalContextTagPrefix  = "<codex_internal_context"
+	goalContextSourceAttr          = `source="goal"`
+	goalContextSourceAttrSQLPrefix = ` source="goal"`
+)
+
+var goalContextSourceAttrRe = regexp.MustCompile(`(?:^|\s)` +
+	regexp.QuoteMeta(goalContextSourceAttr) + `(?:\s|/|$)`)
 
 // IsGoalContextPrefixed reports whether a user-role message is a legacy
 // Codex /goal continuation wrapper that may already be stored in older
@@ -37,40 +46,116 @@ func IsGoalContextPrefixed(content, role string) bool {
 		return false
 	}
 	trimmed := strings.TrimLeft(content, systemPrefixTrimCutset)
-	if strings.HasPrefix(trimmed, "<goal_context>") {
+	if strings.HasPrefix(trimmed, legacyGoalContextPrefix) {
 		return true
 	}
-	if strings.HasPrefix(trimmed, "<codex_internal_context") {
+	if strings.HasPrefix(trimmed, codexInternalContextTagPrefix) {
 		openTag, _, ok := strings.Cut(trimmed, ">")
-		return ok && strings.Contains(openTag, `source="goal"`)
+		return ok && goalContextSourceAttrRe.MatchString(openTag)
 	}
 	return false
 }
 
+type systemPrefixSQLDialect int
+
+const (
+	systemPrefixSQLite systemPrefixSQLDialect = iota
+	systemPrefixPostgres
+	systemPrefixDuckDB
+)
+
 // SystemPrefixSQL returns a SQL clause that excludes user messages
-// matching any system prefix. The column alias for content must be
-// passed (e.g. "m.content" or "m2.content"). Uses case-sensitive
-// substr comparison, which behaves identically on SQLite and
-// PostgreSQL (unlike LIKE, which is case-insensitive on SQLite).
+// matching any system prefix. The column alias for content must be passed
+// (e.g. "m.content" or "m2.content"). Uses case-sensitive substr and
+// position checks instead of LIKE, which is case-insensitive on SQLite.
 func SystemPrefixSQL(contentCol, roleCol string) string {
+	return systemPrefixSQL(contentCol, roleCol, systemPrefixSQLite)
+}
+
+// PostgresSystemPrefixSQL is the PostgreSQL form of SystemPrefixSQL.
+func PostgresSystemPrefixSQL(contentCol, roleCol string) string {
+	return systemPrefixSQL(contentCol, roleCol, systemPrefixPostgres)
+}
+
+// DuckDBSystemPrefixSQL is the DuckDB form of SystemPrefixSQL.
+func DuckDBSystemPrefixSQL(contentCol, roleCol string) string {
+	return systemPrefixSQL(contentCol, roleCol, systemPrefixDuckDB)
+}
+
+func systemPrefixSQL(
+	contentCol, roleCol string, dialect systemPrefixSQLDialect,
+) string {
 	// LTRIM strips the same whitespace as Go's strings.TrimSpace,
 	// JS .trim(), and the parser's isSystem helpers: ASCII whitespace,
 	// BOM (U+FEFF), and Unicode
 	// spaces (U+0085, U+00A0, U+1680, U+2000–U+200A, U+2028,
-	// U+2029, U+202F, U+205F, U+3000). Both SQLite and PostgreSQL
+	// U+2029, U+202F, U+205F, U+3000). SQLite, PostgreSQL, and DuckDB
 	// handle multi-byte UTF-8 characters in the trim set correctly.
-	trimmed := "LTRIM(" + contentCol + ", ' \t\n\v\f\r" +
+	trimmed := systemPrefixSQLTrimmed(contentCol)
+	parts := make([]string, 0, len(SystemMsgPrefixes)+1)
+	for _, p := range SystemMsgPrefixes {
+		parts = append(parts, fmt.Sprintf(
+			"substr(%s, 1, %d) = '%s'", trimmed, len(p), p,
+		))
+	}
+	parts = append(parts, goalContextPrefixSQL(trimmed, dialect))
+	return "NOT (" + roleCol + " = 'user' AND (" +
+		strings.Join(parts, " OR ") + "))"
+}
+
+func systemPrefixSQLTrimmed(contentCol string) string {
+	return "LTRIM(" + contentCol + ", ' \t\n\v\f\r" +
 		"\u0085\u00A0\u1680" +
 		"\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A" +
 		"\u2028\u2029\u202F\u205F\u3000\uFEFF')"
-	parts := make([]string, len(SystemMsgPrefixes))
-	for i, p := range SystemMsgPrefixes {
-		parts[i] = fmt.Sprintf(
-			"substr(%s, 1, %d) = '%s'", trimmed, len(p), p,
-		)
+}
+
+func goalContextPrefixSQL(trimmed string, dialect systemPrefixSQLDialect) string {
+	legacy := fmt.Sprintf("substr(%s, 1, %d) = '%s'",
+		trimmed, len(legacyGoalContextPrefix), legacyGoalContextPrefix)
+	current := fmt.Sprintf(
+		"(substr(%[1]s, 1, %[2]d) = '%[3]s' AND %[4]s)",
+		trimmed, len(codexInternalContextTagPrefix),
+		codexInternalContextTagPrefix,
+		goalContextSourceAttrSQL(openingTagSQL(trimmed, dialect), dialect),
+	)
+	return "(" + legacy + " OR " + current + ")"
+}
+
+func openingTagSQL(trimmed string, dialect systemPrefixSQLDialect) string {
+	return fmt.Sprintf("substr(%s, 1, %s)",
+		trimmed, sqlPosition(dialect, ">", trimmed))
+}
+
+func goalContextSourceAttrSQL(
+	openTag string, dialect systemPrefixSQLDialect,
+) string {
+	normalized := openTag
+	for _, ws := range []string{"\t", "\n", "\v", "\f", "\r"} {
+		normalized = fmt.Sprintf("replace(%s, '%s', ' ')", normalized, ws)
 	}
-	return "NOT (" + roleCol + " = 'user' AND (" +
-		strings.Join(parts, " OR ") + "))"
+	checks := []string{
+		sqlContains(dialect, normalized, goalContextSourceAttrSQLPrefix+" "),
+		sqlContains(dialect, normalized, goalContextSourceAttrSQLPrefix+">"),
+		sqlContains(dialect, normalized, goalContextSourceAttrSQLPrefix+"/>"),
+	}
+	return "(" + strings.Join(checks, " OR ") + ")"
+}
+
+func sqlContains(
+	dialect systemPrefixSQLDialect, haystack, needle string,
+) string {
+	return sqlPosition(dialect, needle, haystack) + " > 0"
+}
+
+func sqlPosition(
+	dialect systemPrefixSQLDialect, needle, haystack string,
+) string {
+	quotedNeedle := "'" + needle + "'"
+	if dialect == systemPrefixPostgres {
+		return fmt.Sprintf("POSITION(%s IN %s)", quotedNeedle, haystack)
+	}
+	return fmt.Sprintf("instr(%s, %s)", haystack, quotedNeedle)
 }
 
 // systemPrefixTrimCutset is the leading-whitespace set SystemPrefixSQL's
@@ -89,6 +174,9 @@ const systemPrefixTrimCutset = " \t\n\v\f\r" +
 func IsSystemPrefixed(content, role string) bool {
 	if role != "user" {
 		return false
+	}
+	if IsGoalContextPrefixed(content, role) {
+		return true
 	}
 	trimmed := strings.TrimLeft(content, systemPrefixTrimCutset)
 	for _, p := range SystemMsgPrefixes {

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -29,6 +29,24 @@ var SystemMsgPrefixes = []string{
 	`<codex_internal_context source="goal">`,
 }
 
+// IsGoalContextPrefixed reports whether a user-role message is a legacy
+// Codex /goal continuation wrapper that may already be stored in older
+// archives or read-only stores.
+func IsGoalContextPrefixed(content, role string) bool {
+	if role != "user" {
+		return false
+	}
+	trimmed := strings.TrimLeft(content, systemPrefixTrimCutset)
+	if strings.HasPrefix(trimmed, "<goal_context>") {
+		return true
+	}
+	if strings.HasPrefix(trimmed, "<codex_internal_context") {
+		openTag, _, ok := strings.Cut(trimmed, ">")
+		return ok && strings.Contains(openTag, `source="goal"`)
+	}
+	return false
+}
+
 // SystemPrefixSQL returns a SQL clause that excludes user messages
 // matching any system prefix. The column alias for content must be
 // passed (e.g. "m.content" or "m2.content"). Uses case-sensitive

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -25,6 +25,8 @@ var SystemMsgPrefixes = []string{
 	"<command-name>",
 	"<local-command-",
 	"Stop hook feedback:",
+	"<goal_context>",
+	`<codex_internal_context source="goal">`,
 }
 
 // SystemPrefixSQL returns a SQL clause that excludes user messages

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -24,6 +24,10 @@ func TestIsSystemPrefixed(t *testing.T) {
 		{"bom then prefix", "\uFEFF<command-message>x", "user", true},
 		{"legacy goal context prefix", "\n\t<goal_context>state</goal_context>", "user", true},
 		{"codex internal goal context prefix", `<codex_internal_context source="goal">state`, "user", true},
+		{"codex goal context with attr before source", `<codex_internal_context foo="bar" source="goal">state`, "user", true},
+		{"codex goal context with attr after source", `<codex_internal_context source="goal" foo="bar">state`, "user", true},
+		{"codex non-goal internal context", `<codex_internal_context source="other">state`, "user", false},
+		{"codex data-source attr is not goal", `<codex_internal_context data-source="goal">state`, "user", false},
 		{"assistant role is never system-prefixed", SystemMsgPrefixes[0], "assistant", false},
 		{"prefix mid-content does not match", "see <task-notification> later", "user", false},
 	}
@@ -47,7 +51,11 @@ func TestIsGoalContextPrefixed(t *testing.T) {
 		{"legacy wrapper with whitespace", "\n\t<goal_context>state", "user", true},
 		{"current wrapper", `<codex_internal_context source="goal">state`, "user", true},
 		{"current wrapper with extra attrs", `<codex_internal_context foo="bar" source="goal">state`, "user", true},
+		{"current wrapper with attrs after source", `<codex_internal_context source="goal" foo="bar">state`, "user", true},
+		{"current wrapper with newline before source", "<codex_internal_context\nsource=\"goal\">state", "user", true},
 		{"non goal internal context", `<codex_internal_context source="other">state`, "user", false},
+		{"data-source attr is not goal", `<codex_internal_context data-source="goal">state`, "user", false},
+		{"missing closing tag delimiter", `<codex_internal_context source="goal" state`, "user", false},
 		{"non goal prefix", "This session is being continued from a previous run", "user", false},
 		{"assistant role ignored", "<goal_context>state</goal_context>", "assistant", false},
 	}
@@ -57,6 +65,46 @@ func TestIsGoalContextPrefixed(t *testing.T) {
 			assert.Equal(t, tc.want, IsGoalContextPrefixed(tc.content, tc.role))
 		})
 	}
+}
+
+func TestSystemPrefixSQL(t *testing.T) {
+	d := testDB(t)
+	rows, err := d.getReader().QueryContext(context.Background(), `
+		WITH candidates(label, role, content) AS (
+			VALUES
+				('normal', 'user', 'regular message'),
+				('assistant-goal', 'assistant', '<codex_internal_context source="goal">state'),
+				('legacy-goal', 'user', '<goal_context>state</goal_context>'),
+				('current-goal', 'user', '<codex_internal_context source="goal">state'),
+				('attr-before-source', 'user', '<codex_internal_context foo="bar" source="goal">state'),
+				('attr-after-source', 'user', '<codex_internal_context source="goal" foo="bar">state'),
+				('newline-before-source', 'user', '<codex_internal_context
+source="goal">state'),
+				('self-closing-goal', 'user', '<codex_internal_context source="goal"/>state'),
+				('non-goal-internal', 'user', '<codex_internal_context source="other">state'),
+				('data-source', 'user', '<codex_internal_context data-source="goal">state'),
+				('missing-close', 'user', '<codex_internal_context source="goal" state')
+		)
+		SELECT label FROM candidates
+		WHERE `+SystemPrefixSQL("content", "role")+`
+		ORDER BY label`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var label string
+		require.NoError(t, rows.Scan(&label))
+		got = append(got, label)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{
+		"assistant-goal",
+		"data-source",
+		"missing-close",
+		"non-goal-internal",
+		"normal",
+	}, got)
 }
 
 func TestSearch(t *testing.T) {

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -22,6 +22,8 @@ func TestIsSystemPrefixed(t *testing.T) {
 		{"task-notification prefix", "<task-notification>done</task-notification>", "user", true},
 		{"leading whitespace then prefix", "\n\t  <command-name>/foo", "user", true},
 		{"bom then prefix", "\uFEFF<command-message>x", "user", true},
+		{"legacy goal context prefix", "\n\t<goal_context>state</goal_context>", "user", true},
+		{"codex internal goal context prefix", `<codex_internal_context source="goal">state`, "user", true},
 		{"assistant role is never system-prefixed", SystemMsgPrefixes[0], "assistant", false},
 		{"prefix mid-content does not match", "see <task-notification> later", "user", false},
 	}

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -35,6 +35,30 @@ func TestIsSystemPrefixed(t *testing.T) {
 	}
 }
 
+func TestIsGoalContextPrefixed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		content string
+		role    string
+		want    bool
+	}{
+		{"legacy wrapper", "<goal_context>state</goal_context>", "user", true},
+		{"legacy wrapper with whitespace", "\n\t<goal_context>state", "user", true},
+		{"current wrapper", `<codex_internal_context source="goal">state`, "user", true},
+		{"current wrapper with extra attrs", `<codex_internal_context foo="bar" source="goal">state`, "user", true},
+		{"non goal internal context", `<codex_internal_context source="other">state`, "user", false},
+		{"non goal prefix", "This session is being continued from a previous run", "user", false},
+		{"assistant role ignored", "<goal_context>state</goal_context>", "assistant", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsGoalContextPrefixed(tc.content, tc.role))
+		})
+	}
+}
+
 func TestSearch(t *testing.T) {
 	d := testDB(t)
 	requireFTS(t, d)

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -1954,7 +1954,7 @@ func (s *Store) GetTrendsTerms(
 		WHERE s.deleted_at IS NULL
 			AND m.role IN ('user', 'assistant')
 			AND m.is_system = FALSE
-			AND `+db.SystemPrefixSQL("m.content", "m.role"))
+			AND `+db.DuckDBSystemPrefixSQL("m.content", "m.role"))
 	if err != nil {
 		return db.TrendsTermsResponse{}, err
 	}

--- a/internal/duckdb/messages.go
+++ b/internal/duckdb/messages.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
@@ -390,14 +389,5 @@ func timingMillis(start, end string) (int64, bool) {
 }
 
 func hasSystemPrefix(msg db.Message) bool {
-	if msg.Role != "user" {
-		return false
-	}
-	content := strings.TrimSpace(msg.Content)
-	for _, prefix := range db.SystemMsgPrefixes {
-		if strings.HasPrefix(content, prefix) {
-			return true
-		}
-	}
-	return false
+	return db.IsSystemPrefixed(msg.Content, msg.Role)
 }

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -602,7 +602,7 @@ func (s *Store) Search(ctx context.Context, f db.SearchFilter) (db.SearchPage, e
 			WHERE `+msgTermPredicate+`
 				AND s.deleted_at IS NULL
 				AND m.is_system = FALSE
-				AND `+db.SystemPrefixSQL("m.content", "m.role")+`
+				AND `+db.DuckDBSystemPrefixSQL("m.content", "m.role")+`
 				`+project+`
 		),
 		msg_matches AS (
@@ -632,7 +632,7 @@ func (s *Store) Search(ctx context.Context, f db.SearchFilter) (db.SearchPage, e
 					SELECT 1 FROM messages mx
 					WHERE mx.session_id = s.id
 						AND mx.is_system = FALSE
-						AND `+db.SystemPrefixSQL("mx.content", "mx.role")+`
+						AND `+db.DuckDBSystemPrefixSQL("mx.content", "mx.role")+`
 				)
 				AND s.id NOT IN (SELECT session_id FROM msg_matches)
 				`+nameProject+`
@@ -690,7 +690,7 @@ func (s *Store) SearchSession(ctx context.Context, sessionID, query string) ([]i
 			AND tre.call_index = tc.call_index
 		WHERE m.session_id = ?
 			AND m.is_system = FALSE
-			AND `+db.SystemPrefixSQL("m.content", "m.role")+`
+			AND `+db.DuckDBSystemPrefixSQL("m.content", "m.role")+`
 			AND (m.content ILIKE ? ESCAPE '\'
 				OR tc.result_content ILIKE ? ESCAPE '\'
 				OR tre.content ILIKE ? ESCAPE '\')
@@ -811,7 +811,7 @@ func (s *Store) collectContentSubstringMatches(
 		case "messages":
 			sysPred := "TRUE"
 			if f.ExcludeSystem {
-				sysPred = "m.is_system = FALSE AND " + db.SystemPrefixSQL("m.content", "m.role")
+				sysPred = "m.is_system = FALSE AND " + db.DuckDBSystemPrefixSQL("m.content", "m.role")
 			}
 			contentPred := addSearchArgs("m.content")
 			branches = append(branches, `
@@ -1049,7 +1049,7 @@ func (s *Store) collectContentSource(
 			args = append(args, pattern)
 		}
 		if f.ExcludeSystem {
-			query += " AND m.is_system = FALSE AND " + db.SystemPrefixSQL("m.content", "m.role")
+			query += " AND m.is_system = FALSE AND " + db.DuckDBSystemPrefixSQL("m.content", "m.role")
 		}
 		orderBy = "m.session_id, m.ordinal, COALESCE(m.id, 0)"
 	case "tool_input":

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -30,6 +31,11 @@ const (
 var errCodexIncrementalNeedsFullParse = errors.New(
 	"codex incremental event requires full parse",
 )
+
+const codexGoalContextSourceAttr = `source="goal"`
+
+var codexGoalContextSourceAttrRe = regexp.MustCompile(`(?:^|\s)` +
+	regexp.QuoteMeta(codexGoalContextSourceAttr) + `(?:\s|/|$)`)
 
 var codexSessionIndexCache = struct {
 	mu      sync.Mutex
@@ -1767,7 +1773,7 @@ func isCodexGoalContext(content string) bool {
 	}
 	if strings.HasPrefix(trimmed, "<codex_internal_context") {
 		openTag, _, ok := strings.Cut(trimmed, ">")
-		return ok && strings.Contains(openTag, `source="goal"`)
+		return ok && codexGoalContextSourceAttrRe.MatchString(openTag)
 	}
 	return false
 }

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1739,23 +1739,15 @@ func IsIncrementalFullParseFallback(err error) bool {
 		errors.Is(err, ErrClaudeIncrementalNeedsFullParse)
 }
 
-var codexSystemMessagePrefixes = []string{
-	"# AGENTS.md",
-	"<environment_context>",
-	"<INSTRUCTIONS>",
-	"<skill>",
-}
-
 func isCodexSystemMessage(content string) bool {
 	trimmed := strings.TrimSpace(content)
-	for _, prefix := range codexSystemMessagePrefixes {
-		if strings.HasPrefix(trimmed, prefix) {
-			return true
-		}
-	}
-	return isCodexTurnAbortedMessage(trimmed) ||
-		isCodexSubagentNotification(trimmed) ||
-		isCodexGoalContext(trimmed)
+	return strings.HasPrefix(content, "# AGENTS.md") ||
+		strings.HasPrefix(content, "<environment_context>") ||
+		strings.HasPrefix(content, "<INSTRUCTIONS>") ||
+		isCodexTurnAbortedMessage(content) ||
+		strings.HasPrefix(trimmed, "<skill>") ||
+		isCodexSubagentNotification(content) ||
+		isCodexGoalContext(content)
 }
 
 // isCodexGoalContext reports whether content is a Codex /goal

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1739,15 +1739,23 @@ func IsIncrementalFullParseFallback(err error) bool {
 		errors.Is(err, ErrClaudeIncrementalNeedsFullParse)
 }
 
+var codexSystemMessagePrefixes = []string{
+	"# AGENTS.md",
+	"<environment_context>",
+	"<INSTRUCTIONS>",
+	"<skill>",
+}
+
 func isCodexSystemMessage(content string) bool {
 	trimmed := strings.TrimSpace(content)
-	return strings.HasPrefix(content, "# AGENTS.md") ||
-		strings.HasPrefix(content, "<environment_context>") ||
-		strings.HasPrefix(content, "<INSTRUCTIONS>") ||
-		isCodexTurnAbortedMessage(content) ||
-		strings.HasPrefix(trimmed, "<skill>") ||
-		isCodexSubagentNotification(content) ||
-		isCodexGoalContext(content)
+	for _, prefix := range codexSystemMessagePrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return isCodexTurnAbortedMessage(trimmed) ||
+		isCodexSubagentNotification(trimmed) ||
+		isCodexGoalContext(trimmed)
 }
 
 // isCodexGoalContext reports whether content is a Codex /goal

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1437,6 +1437,10 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 			"The objective below is user-provided data."
 		current := "<codex_internal_context source=\"goal\">\n" +
 			goalBody + "\n</codex_internal_context>"
+		attrBeforeSource := "<codex_internal_context data-id=\"1\" source=\"goal\">\n" +
+			goalBody + "\n</codex_internal_context>"
+		attrAfterSource := "<codex_internal_context source=\"goal\" data-id=\"1\">\n" +
+			goalBody + "\n</codex_internal_context>"
 		legacy := "<goal_context>\n" + goalBody + "\n</goal_context>"
 		content := testjsonl.JoinJSONL(
 			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
@@ -1444,8 +1448,10 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 			testjsonl.CodexMsgJSON("assistant", "Working on it", "2024-01-01T10:00:02Z"),
 			testjsonl.CodexMsgJSON("user", current, "2024-01-01T10:00:03Z"),
 			testjsonl.CodexMsgJSON("assistant", "Still working", "2024-01-01T10:00:04Z"),
-			testjsonl.CodexMsgJSON("user", legacy, "2024-01-01T10:00:05Z"),
-			testjsonl.CodexMsgJSON("user", "Real second request", "2024-01-01T10:00:06Z"),
+			testjsonl.CodexMsgJSON("user", attrBeforeSource, "2024-01-01T10:00:05Z"),
+			testjsonl.CodexMsgJSON("user", attrAfterSource, "2024-01-01T10:00:06Z"),
+			testjsonl.CodexMsgJSON("user", legacy, "2024-01-01T10:00:07Z"),
+			testjsonl.CodexMsgJSON("user", "Real second request", "2024-01-01T10:00:08Z"),
 		)
 		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
 		require.NotNil(t, sess)
@@ -1456,6 +1462,43 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 		assert.Equal(t, "Real second request", msgs[3].Content)
 		assert.Equal(t, 2, sess.UserMessageCount,
 			"goal continuation context must not count as user turns")
+	})
+
+	t.Run("keeps non-goal codex internal contexts", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			content string
+		}{
+			{
+				name: "data source goal",
+				content: "<codex_internal_context data-source=\"goal\">\n" +
+					"Preserve this internal context.\n</codex_internal_context>",
+			},
+			{
+				name: "other source",
+				content: "<codex_internal_context source=\"tool\">\n" +
+					"Preserve this internal context.\n</codex_internal_context>",
+			},
+			{
+				name: "no source",
+				content: "<codex_internal_context data-id=\"1\">\n" +
+					"Preserve this internal context.\n</codex_internal_context>",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				content := testjsonl.JoinJSONL(
+					testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
+					testjsonl.CodexMsgJSON("user", tc.content, tsEarlyS1),
+				)
+				sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+				require.NotNil(t, sess)
+				require.Len(t, msgs, 1)
+				assert.Equal(t, tc.content, msgs[0].Content)
+				assert.Equal(t, 1, sess.UserMessageCount,
+					"non-goal internal contexts must count as user turns")
+			})
+		}
 	})
 
 	// Only the structured goal wrapper is system content; a real user

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1398,6 +1398,34 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 		assert.Equal(t, "Actual user message", msgs[0].Content)
 	})
 
+	t.Run("skips goal continuation context wrappers", func(t *testing.T) {
+		currentGoal := "<codex_internal_context source=\"goal\">\n" +
+			"Continue working toward the active thread goal.\n" +
+			"</codex_internal_context>"
+		legacyGoal := "<goal_context>\n" +
+			"Continue working toward the active thread goal.\n" +
+			"</goal_context>"
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "\n\t"+currentGoal, tsEarlyS1),
+			testjsonl.CodexMsgJSON("user", "Actual user message", "2024-01-01T10:00:02Z"),
+			testjsonl.CodexMsgJSON("assistant", "Assistant reply", "2024-01-01T10:00:03Z"),
+			testjsonl.CodexMsgJSON("user", "  "+legacyGoal, "2024-01-01T10:00:04Z"),
+			testjsonl.CodexMsgJSON("user", "Follow-up user message", "2024-01-01T10:00:05Z"),
+		)
+		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+		require.NotNil(t, sess)
+		require.Len(t, msgs, 3)
+		assert.Equal(t, "Actual user message", sess.FirstMessage)
+		assert.Equal(t, 2, sess.UserMessageCount)
+		assert.Equal(t, RoleUser, msgs[0].Role)
+		assert.Equal(t, "Actual user message", msgs[0].Content)
+		assert.Equal(t, RoleAssistant, msgs[1].Role)
+		assert.Equal(t, "Assistant reply", msgs[1].Content)
+		assert.Equal(t, RoleUser, msgs[2].Role)
+		assert.Equal(t, "Follow-up user message", msgs[2].Content)
+	})
+
 	// Codex injects skill template content as role=user JSONL
 	// entries when the model invokes a skill. These look like
 	// follow-up user turns to a naive count, which inflates
@@ -2139,6 +2167,41 @@ func TestParseCodexSessionFrom_SystemMessageDoesNotRequireFullParse(t *testing.T
 	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(newMsgs))
+	assert.False(t, endedAt.IsZero())
+}
+
+func TestParseCodexSessionFrom_GoalContextDoesNotRequireFullParse(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON("inc-goal", "/tmp", "codex_cli_rs", tsEarly),
+		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
+	)
+	path := createTestFile(t, "codex-goal-inc.jsonl", initial)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	currentGoal := "<codex_internal_context source=\"goal\">\n" +
+		"Continue working toward the active thread goal.\n" +
+		"</codex_internal_context>"
+	legacyGoal := "<goal_context>\n" +
+		"Continue working toward the active thread goal.\n" +
+		"</goal_context>"
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.JoinJSONL(
+		testjsonl.CodexMsgJSON("user", currentGoal, tsEarlyS5),
+		testjsonl.CodexMsgJSON("user", "\n  "+legacyGoal, tsLate),
+	))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
+	require.NoError(t, err)
+	assert.Empty(t, newMsgs)
 	assert.False(t, endedAt.IsZero())
 }
 

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1398,34 +1398,6 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 		assert.Equal(t, "Actual user message", msgs[0].Content)
 	})
 
-	t.Run("skips goal continuation context wrappers", func(t *testing.T) {
-		currentGoal := "<codex_internal_context source=\"goal\">\n" +
-			"Continue working toward the active thread goal.\n" +
-			"</codex_internal_context>"
-		legacyGoal := "<goal_context>\n" +
-			"Continue working toward the active thread goal.\n" +
-			"</goal_context>"
-		content := testjsonl.JoinJSONL(
-			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
-			testjsonl.CodexMsgJSON("user", "\n\t"+currentGoal, tsEarlyS1),
-			testjsonl.CodexMsgJSON("user", "Actual user message", "2024-01-01T10:00:02Z"),
-			testjsonl.CodexMsgJSON("assistant", "Assistant reply", "2024-01-01T10:00:03Z"),
-			testjsonl.CodexMsgJSON("user", "  "+legacyGoal, "2024-01-01T10:00:04Z"),
-			testjsonl.CodexMsgJSON("user", "Follow-up user message", "2024-01-01T10:00:05Z"),
-		)
-		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
-		require.NotNil(t, sess)
-		require.Len(t, msgs, 3)
-		assert.Equal(t, "Actual user message", sess.FirstMessage)
-		assert.Equal(t, 2, sess.UserMessageCount)
-		assert.Equal(t, RoleUser, msgs[0].Role)
-		assert.Equal(t, "Actual user message", msgs[0].Content)
-		assert.Equal(t, RoleAssistant, msgs[1].Role)
-		assert.Equal(t, "Assistant reply", msgs[1].Content)
-		assert.Equal(t, RoleUser, msgs[2].Role)
-		assert.Equal(t, "Follow-up user message", msgs[2].Content)
-	})
-
 	// Codex injects skill template content as role=user JSONL
 	// entries when the model invokes a skill. These look like
 	// follow-up user turns to a naive count, which inflates
@@ -2167,41 +2139,6 @@ func TestParseCodexSessionFrom_SystemMessageDoesNotRequireFullParse(t *testing.T
 	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(newMsgs))
-	assert.False(t, endedAt.IsZero())
-}
-
-func TestParseCodexSessionFrom_GoalContextDoesNotRequireFullParse(t *testing.T) {
-	t.Parallel()
-
-	initial := testjsonl.JoinJSONL(
-		testjsonl.CodexSessionMetaJSON("inc-goal", "/tmp", "codex_cli_rs", tsEarly),
-		testjsonl.CodexMsgJSON("user", "hello", tsEarlyS1),
-	)
-	path := createTestFile(t, "codex-goal-inc.jsonl", initial)
-
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	offset := info.Size()
-
-	currentGoal := "<codex_internal_context source=\"goal\">\n" +
-		"Continue working toward the active thread goal.\n" +
-		"</codex_internal_context>"
-	legacyGoal := "<goal_context>\n" +
-		"Continue working toward the active thread goal.\n" +
-		"</goal_context>"
-
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
-	require.NoError(t, err)
-	_, err = f.WriteString(testjsonl.JoinJSONL(
-		testjsonl.CodexMsgJSON("user", currentGoal, tsEarlyS5),
-		testjsonl.CodexMsgJSON("user", "\n  "+legacyGoal, tsLate),
-	))
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-
-	newMsgs, endedAt, _, err := ParseCodexSessionFrom(path, offset, 1, false)
-	require.NoError(t, err)
-	assert.Empty(t, newMsgs)
 	assert.False(t, endedAt.IsZero())
 }
 

--- a/internal/postgres/activity.go
+++ b/internal/postgres/activity.go
@@ -25,7 +25,7 @@ func (s *Store) GetSessionActivity(
 
 	// 2. Visible-message filter (same as SQLite).
 	visFilter := "m.is_system = FALSE AND " +
-		db.SystemPrefixSQL("m.content", "m.role")
+		db.PostgresSystemPrefixSQL("m.content", "m.role")
 
 	// 3. Get min/max timestamps from visible messages.
 	// PG stores timestamp as TIMESTAMPTZ, so scan into *time.Time.

--- a/internal/postgres/messages.go
+++ b/internal/postgres/messages.go
@@ -114,7 +114,7 @@ func (s *Store) SearchSession(
 			AND tc.message_ordinal = m.ordinal
 		WHERE m.session_id = $1
 			AND m.is_system = FALSE
-			AND `+db.SystemPrefixSQL("m.content", "m.role")+`
+			AND `+db.PostgresSystemPrefixSQL("m.content", "m.role")+`
 			AND (m.content ILIKE $2
 				OR tc.result_content ILIKE $2)
 		ORDER BY m.ordinal ASC`,
@@ -244,7 +244,7 @@ func (s *Store) Search(
 			WHERE %s
 				AND s.deleted_at IS NULL
 				AND m.is_system = FALSE
-				AND `+db.SystemPrefixSQL("m.content", "m.role")+`
+				AND `+db.PostgresSystemPrefixSQL("m.content", "m.role")+`
 				%s
 			ORDER BY m.session_id,
 				POSITION(LOWER($2) IN LOWER(m.content)) ASC,
@@ -274,7 +274,7 @@ func (s *Store) Search(
 					SELECT 1 FROM messages mx
 					WHERE mx.session_id = s.id
 					  AND mx.is_system = FALSE
-					  AND `+db.SystemPrefixSQL("mx.content", "mx.role")+`
+					  AND `+db.PostgresSystemPrefixSQL("mx.content", "mx.role")+`
 				)
 				AND s.id NOT IN (SELECT session_id FROM msg_matches)
 				%s

--- a/internal/postgres/search_content.go
+++ b/internal/postgres/search_content.go
@@ -123,7 +123,7 @@ func pgMessagesBranch(
 	sysPred := "TRUE"
 	if f.ExcludeSystem {
 		sysPred = "m.is_system = FALSE AND " +
-			db.SystemPrefixSQL("m.content", "m.role")
+			db.PostgresSystemPrefixSQL("m.content", "m.role")
 	}
 
 	// Select the full content; the snippet is windowed and redacted in Go.
@@ -398,7 +398,7 @@ func pgMessagesCandidateBranch(
 	sysPred := "TRUE"
 	if f.ExcludeSystem {
 		sysPred = "m.is_system = FALSE AND " +
-			db.SystemPrefixSQL("m.content", "m.role")
+			db.PostgresSystemPrefixSQL("m.content", "m.role")
 	}
 
 	return fmt.Sprintf(`

--- a/internal/postgres/trends.go
+++ b/internal/postgres/trends.go
@@ -45,7 +45,7 @@ func (s *Store) GetTrendsTerms(
 		WHERE ` + where + `
 			AND m.role IN ('user', 'assistant')
 			AND m.is_system = FALSE
-			AND ` + db.SystemPrefixSQL("m.content", "m.role")
+			AND ` + db.PostgresSystemPrefixSQL("m.content", "m.role")
 
 	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
 	if err != nil {

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -628,6 +628,8 @@ footer a {
 func generateExportHTML(
 	session *db.Session, msgs []db.Message,
 ) string {
+	msgs = filterExportHTMLMessages(msgs)
+
 	startedAt := ""
 	if session.StartedAt != nil {
 		startedAt = formatTimestamp(*session.StartedAt)
@@ -636,7 +638,7 @@ func generateExportHTML(
 	data := exportData{
 		Project:      session.Project,
 		Agent:        agentDisplayName(session.Agent),
-		MessageCount: session.MessageCount,
+		MessageCount: len(msgs),
 		StartedAt:    startedAt,
 		Messages:     make([]exportMessage, len(msgs)),
 	}
@@ -668,6 +670,17 @@ func generateExportHTML(
 		return fmt.Sprintf("template error: %s", err)
 	}
 	return b.String()
+}
+
+func filterExportHTMLMessages(msgs []db.Message) []db.Message {
+	filtered := make([]db.Message, 0, len(msgs))
+	for _, m := range msgs {
+		if db.IsSystemPrefixed(m.Content, m.Role) {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
 }
 
 func generateInsightExportHTML(insight *db.Insight) string {
@@ -752,7 +765,8 @@ func focusedExportOrdinals(msgs []db.Message) map[int]bool {
 			continue
 		}
 
-		if m.IsSystem || isThinkingOnly(m.Content) {
+		if m.IsSystem || db.IsSystemPrefixed(m.Content, m.Role) ||
+			isThinkingOnly(m.Content) {
 			continue
 		}
 

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -675,7 +675,7 @@ func generateExportHTML(
 func filterExportHTMLMessages(msgs []db.Message) []db.Message {
 	filtered := make([]db.Message, 0, len(msgs))
 	for _, m := range msgs {
-		if db.IsSystemPrefixed(m.Content, m.Role) {
+		if db.IsGoalContextPrefixed(m.Content, m.Role) {
 			continue
 		}
 		filtered = append(filtered, m)
@@ -765,7 +765,7 @@ func focusedExportOrdinals(msgs []db.Message) map[int]bool {
 			continue
 		}
 
-		if m.IsSystem || db.IsSystemPrefixed(m.Content, m.Role) ||
+		if m.IsSystem || db.IsGoalContextPrefixed(m.Content, m.Role) ||
 			isThinkingOnly(m.Content) {
 			continue
 		}

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -550,6 +550,39 @@ func TestGenerateExportHTML_OmitsGoalContextRows(t *testing.T) {
 	})
 }
 
+func TestGenerateExportHTML_PreservesNonGoalSystemPrefixedRows(t *testing.T) {
+	t.Parallel()
+	session := testSession(func(s *db.Session) {
+		s.MessageCount = 3
+	})
+	msgs := []db.Message{
+		{
+			SessionID: "test-id", Ordinal: 0,
+			Role: "user", Content: "This session is being continued from a previous conversation.",
+			Timestamp: "2025-01-15T10:00:00Z",
+		},
+		{
+			SessionID: "test-id", Ordinal: 1,
+			Role: "user", Content: "<task-notification>done</task-notification>",
+			Timestamp: "2025-01-15T10:00:01Z",
+		},
+		{
+			SessionID: "test-id", Ordinal: 2,
+			Role: "user", Content: "Stop hook feedback: blocked",
+			Timestamp: "2025-01-15T10:00:02Z",
+		},
+	}
+
+	html := generateExportHTML(session, msgs)
+
+	assertContainsAll(t, html, []string{
+		"3 messages",
+		"This session is being continued from a previous conversation.",
+		"&lt;task-notification&gt;done&lt;/task-notification&gt;",
+		"Stop hook feedback: blocked",
+	})
+}
+
 func TestFocusedExportOrdinals(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -655,6 +688,20 @@ func TestFocusedExportOrdinals(t *testing.T) {
 				exportAssistantMsg(4, "final"),
 			},
 			want: []int{0, 4},
+		},
+		{
+			name: "keeps non-goal system-prefixed user rows",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				{
+					SessionID: "test-id",
+					Ordinal:   1,
+					Role:      "user",
+					Content:   "Stop hook feedback: blocked",
+				},
+				exportAssistantMsg(2, "answer"),
+			},
+			want: []int{0, 1, 2},
 		},
 		{
 			name: "keeps answer before compact boundary",

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -503,7 +503,7 @@ func TestGenerateExportHTML_OmitsGoalContextRows(t *testing.T) {
 	session := testSession(func(s *db.Session) {
 		s.MessageCount = 4
 	})
-	currentGoal := "<codex_internal_context source=\"goal\">\n" +
+	currentGoal := "<codex_internal_context foo=\"bar\" source=\"goal\">\n" +
 		"Continue working toward the active thread goal.\n" +
 		"</codex_internal_context>"
 	legacyGoal := "<goal_context>\n" +
@@ -677,7 +677,7 @@ func TestFocusedExportOrdinals(t *testing.T) {
 					SessionID: "test-id",
 					Ordinal:   2,
 					Role:      "user",
-					Content:   `<codex_internal_context source="goal">state`,
+					Content:   `<codex_internal_context foo="bar" source="goal">state`,
 				},
 				{
 					SessionID: "test-id",

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -498,6 +498,58 @@ func TestGenerateExportHTML_TranscriptModeControls(t *testing.T) {
 	})
 }
 
+func TestGenerateExportHTML_OmitsGoalContextRows(t *testing.T) {
+	t.Parallel()
+	session := testSession(func(s *db.Session) {
+		s.MessageCount = 4
+	})
+	currentGoal := "<codex_internal_context source=\"goal\">\n" +
+		"Continue working toward the active thread goal.\n" +
+		"</codex_internal_context>"
+	legacyGoal := "<goal_context>\n" +
+		"Continue working toward the active thread goal.\n" +
+		"</goal_context>"
+	msgs := []db.Message{
+		{
+			SessionID: "test-id", Ordinal: 0,
+			Role: "user", Content: "Actual user message",
+			Timestamp: "2025-01-15T10:00:00Z",
+		},
+		{
+			SessionID: "test-id", Ordinal: 1,
+			Role: "user", Content: "\n\t" + currentGoal,
+			Timestamp: "2025-01-15T10:00:01Z",
+		},
+		{
+			SessionID: "test-id", Ordinal: 2,
+			Role: "user", Content: "  " + legacyGoal,
+			Timestamp: "2025-01-15T10:00:02Z",
+		},
+		{
+			SessionID: "test-id", Ordinal: 3,
+			Role: "assistant", Content: "Assistant reply",
+			Timestamp: "2025-01-15T10:00:03Z",
+		},
+	}
+
+	html := generateExportHTML(session, msgs)
+
+	assertContainsAll(t, html, []string{
+		"2 messages",
+		`class="message user" data-ordinal="0"`,
+		`class="message assistant" data-ordinal="3"`,
+		"Actual user message",
+		"Assistant reply",
+	})
+	assertContainsNone(t, html, []string{
+		`data-ordinal="1"`,
+		`data-ordinal="2"`,
+		"<codex_internal_context",
+		"<goal_context>",
+		"Continue working toward the active thread goal.",
+	})
+}
+
 func TestFocusedExportOrdinals(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -582,6 +634,27 @@ func TestFocusedExportOrdinals(t *testing.T) {
 				exportUserMsg(4),
 			},
 			want: []int{0, 1, 4},
+		},
+		{
+			name: "ignores system-prefixed goal contexts",
+			msgs: []db.Message{
+				exportUserMsg(0),
+				exportAssistantMsg(1, "draft"),
+				{
+					SessionID: "test-id",
+					Ordinal:   2,
+					Role:      "user",
+					Content:   `<codex_internal_context source="goal">state`,
+				},
+				{
+					SessionID: "test-id",
+					Ordinal:   3,
+					Role:      "user",
+					Content:   "\n\t<goal_context>state</goal_context>",
+				},
+				exportAssistantMsg(4, "final"),
+			},
+			want: []int{0, 4},
 		},
 		{
 			name: "keeps answer before compact boundary",


### PR DESCRIPTION
Refinement on top of #886 / 9bee8a3c, which already taught the Codex parser to classify `/goal` continuation envelopes as system content for newly parsed sessions.

This PR handles the archive and compatibility side of that fix. It bumps the parser data version to 56 on top of main's version-55 Kimi usage-event bump, so existing source-backed Codex sessions are non-destructively re-parsed and old stored `/goal` rows are removed from message lists and user-turn counts instead of remaining in persistent SQLite archives.

It also adds read-path fallbacks for legacy rows that may still exist before reparse, or in rows that cannot be re-emitted from source files. Backend system-prefix filtering now uses a dedicated Codex goal-context predicate plus SQLite/PostgreSQL/DuckDB SQL variants, while frontend system-message detection and HTML/focused export use the same wrapper semantics. Both the current `<codex_internal_context ... source="goal">` form, including extra attributes, and the older `<goal_context>` wrapper stay out of search, transcript filtering, and exported sessions.

The main tradeoff is the data-version bump: multi-host PostgreSQL deployments should upgrade `pg serve` and all pushers together, because older agentsview binaries reject rows written by a newer parser data version.