### PR TITLE
fix(frontend): polish remaining zh-CN localization

### DIFF
--- a/frontend/e2e/pages/sessions-page.ts
+++ b/frontend/e2e/pages/sessions-page.ts
@@ -14,6 +14,7 @@ export class SessionsPage {
   readonly sortButton: Locator;
   readonly projectTypeahead: Locator;
   readonly sessionListHeader: Locator;
+  readonly sessionCount: Locator;
 
   readonly analyticsPage: Locator;
   readonly analyticsToolbar: Locator;
@@ -27,6 +28,7 @@ export class SessionsPage {
     this.sortButton = page.getByLabel("Toggle sort order");
     this.projectTypeahead = page.locator(".typeahead");
     this.sessionListHeader = page.locator(".session-list-header");
+    this.sessionCount = this.sessionListHeader.locator(".session-count");
     this.analyticsPage = page.locator(".analytics-page");
     this.analyticsToolbar = page.locator(".analytics-toolbar");
     this.exportBtn = page.locator(".export-btn");

--- a/frontend/e2e/termination.spec.ts
+++ b/frontend/e2e/termination.spec.ts
@@ -27,9 +27,7 @@ test.describe("session termination status", () => {
 
     // The fixture has exactly one unclean session.
     await expect(sp.sessionItems).toHaveCount(1);
-    await expect(sp.sessionListHeader).toContainText(
-      "1 sessions",
-    );
+    await expect(sp.sessionCount).toHaveText("1 session");
 
     // Surviving session renders the unclean StatusDot.
     await expect(

--- a/frontend/e2e/virtual-list.spec.ts
+++ b/frontend/e2e/virtual-list.spec.ts
@@ -89,10 +89,9 @@ test.describe("Virtual list behavior", () => {
 
     // Wait for filtered results to render before checking
     // scroll position — on CI the re-render can be slow.
-    await expect(sp.sessionListHeader).toContainText(
-      "1 sessions",
-      { timeout: 5_000 },
-    );
+    await expect(sp.sessionCount).toHaveText("1 session", {
+      timeout: 5_000,
+    });
 
     await expect
       .poll(() => getScrollTop(sp.sessionListScroll), {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -67,9 +67,54 @@
   "header_actions_settings": "Settings",
   "header_actions_keyboard_shortcuts": "Keyboard shortcuts",
   "header_actions_keyboard_shortcuts_shortcut": "Keyboard shortcuts (?)",
-  "status_bar_sessions": "{count} sessions",
-  "status_bar_messages": "{count} messages",
-  "status_bar_projects": "{count} projects",
+  "status_bar_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} session",
+        "countPlural=other": "{countLabel} sessions"
+      }
+    }
+  ],
+  "status_bar_messages": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} message",
+        "countPlural=other": "{countLabel} messages"
+      }
+    }
+  ],
+  "status_bar_projects": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} project",
+        "countPlural=other": "{countLabel} projects"
+      }
+    }
+  ],
   "status_bar_open_performance_debug": "Open performance debug",
   "status_bar_perf": "Perf",
   "status_bar_remote_unreachable_title": "Can't reach the remote server. Open settings to check the URL, token, or disconnect.",
@@ -248,8 +293,49 @@
   "compact_boundary_title": "Context window compacted at this point",
   "compact_boundary_label": "Context compacted",
   "compact_boundary_show_full_summary": "Show full summary",
-  "sidebar_session_count": "{count} sessions",
+  "sidebar_session_count": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} session",
+        "countPlural=other": "{countLabel} sessions"
+      }
+    }
+  ],
   "sidebar_loading": "loading",
+  "sidebar_multi_select": "Multi-select",
+  "sidebar_exit_multi_select": "Exit multi-select",
+  "sidebar_select_all_visible": "Select all visible",
+  "sidebar_clear_selection": "Clear selection",
+  "sidebar_batch_clear": "Clear",
+  "sidebar_batch_all": "All",
+  "sidebar_selected_count": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} selected",
+        "countPlural=other": "{countLabel} selected"
+      }
+    }
+  ],
+  "sidebar_move_selected_to_trash": "Move selected sessions to trash",
+  "sidebar_deleting": "Deleting...",
+  "sidebar_delete": "Delete",
+  "sidebar_cancel": "Cancel",
   "sidebar_status": "Status",
   "sidebar_active": "Active",
   "sidebar_active_title": "Last activity within 10 minutes",
@@ -287,6 +373,8 @@
   "sidebar_filters_clear_filters": "Clear filters",
   "sidebar_row_expand": "Expand",
   "sidebar_row_collapse": "Collapse",
+  "sidebar_row_select_session": "Select session",
+  "sidebar_row_deselect_session": "Deselect session",
   "sidebar_row_star_session": "Star session",
   "sidebar_row_unstar_session": "Unstar session",
   "sidebar_row_rename": "Rename",
@@ -599,6 +687,9 @@
   "usage_top_sessions_by_cost": "Top Sessions by Cost",
   "settings_title": "Settings",
   "settings_loading": "Loading settings...",
+  "settings_resync_title_unavailable": "Full resync unavailable in read-only mode",
+  "settings_resync_unavailable_hint": "Unavailable while connected to a read-only backend",
+  "settings_resync_hint": "Re-scan all session files from scratch",
   "settings_language_title": "Language",
   "settings_language_description": "Choose the interface language.",
   "settings_language_label": "Interface language",
@@ -649,7 +740,22 @@
   "activity_int_auto_short": "{int} int / {auto} auto",
   "activity_peak_label": "peak {count}",
   "activity_agent_min_value": "{value} agent-min",
-  "activity_output_tokens_value": "{count} output tokens",
+  "activity_output_tokens_value": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} output token",
+        "countPlural=other": "{countLabel} output tokens"
+      }
+    }
+  ],
   "activity_concurrency": "Concurrency",
   "activity_overlay": "Overlay",
   "activity_overlay_metric": "Concurrency overlay metric",
@@ -791,6 +897,104 @@
   "status_dot_stale": "Flagged session, idle for 10–60 minutes",
   "status_dot_unclean": "Terminated mid tool call (or file truncated)",
   "call_row_toggle_subagent_calls": "Toggle sub-agent calls",
+  "call_row_running_duration": "running {duration}+",
+  "call_group_parallel_label": "parallel",
+  "call_group_parallel_call_count": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} call",
+        "countPlural=other": "{countLabel} calls"
+      }
+    }
+  ],
+  "subagent_calls_label": "↳ sub-agent",
+  "subagent_calls_summary": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "input duration",
+        "input running",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural",
+        "running"
+      ],
+      "match": {
+        "countPlural=one,running=true": "{countLabel} call · running {duration}+",
+        "countPlural=other,running=true": "{countLabel} calls · running {duration}+",
+        "countPlural=one,running=false": "{countLabel} call · {duration}",
+        "countPlural=other,running=false": "{countLabel} calls · {duration}"
+      }
+    }
+  ],
+  "activity_lane_activity": "activity",
+  "activity_lane_message_count": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} message",
+        "countPlural=other": "{countLabel} messages"
+      }
+    }
+  ],
+  "session_vitals_title": "Analysis",
+  "session_vitals_subtitle": "Session vital signs",
+  "session_vitals_close": "Close session analysis",
+  "session_vitals_session": "Session",
+  "session_vitals_running": "running",
+  "session_vitals_running_duration": "running {duration}+",
+  "session_vitals_tool_calls": "tool calls",
+  "session_vitals_tool_time": "tool time",
+  "session_vitals_slowest_call": "slowest call",
+  "session_vitals_jump_to_call": "Jump to call",
+  "session_vitals_turns": "turns",
+  "session_vitals_subagents": "sub-agents",
+  "session_vitals_time_spent": "Time spent",
+  "session_vitals_clear_category_filter": "clear category filter",
+  "session_vitals_completed_turns_hint": "completed turns · click to highlight",
+  "session_vitals_timeline": "Timeline",
+  "session_vitals_click_marks_to_scroll": "click marks to scroll",
+  "session_vitals_jump_to_turn": "Jump to {category} turn at {time}",
+  "session_vitals_calls": "Calls",
+  "session_vitals_calls_summary": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "input runningCount",
+        "local countPlural = count: plural",
+        "local runningPlural = runningCount: plural"
+      ],
+      "selectors": [
+        "countPlural",
+        "runningPlural"
+      ],
+      "match": {
+        "countPlural=one,runningPlural=one": "{countLabel} call · {runningCount} running",
+        "countPlural=other,runningPlural=one": "{countLabel} calls · {runningCount} running",
+        "countPlural=one,runningPlural=other": "{countLabel} call",
+        "countPlural=other,runningPlural=other": "{countLabel} calls"
+      }
+    }
+  ],
+  "session_vitals_now": "now",
   "code_block_copy": "Copy code block",
   "code_block_copy_title": "Copy code",
   "common_copied": "Copied!",
@@ -915,7 +1119,22 @@
   "insights_page_sessions_computed": "sessions computed",
   "insights_page_score_distribution": "Score distribution",
   "insights_page_pct_affected": "{pct}% affected",
-  "insights_page_driver_sessions": "{count} sessions",
+  "insights_page_driver_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} session",
+        "countPlural=other": "{countLabel} sessions"
+      }
+    }
+  ],
   "insights_page_session_evidence": "Session evidence",
   "insights_page_close": "Close",
   "insights_page_loading_examples": "Loading examples...",
@@ -1169,7 +1388,22 @@
   "trash_title": "Trash",
   "trash_emptying": "Emptying...",
   "trash_empty_trash": "Empty Trash",
-  "trash_msgs": "{count} msgs",
+  "trash_msgs": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{countLabel} msg",
+        "countPlural=other": "{countLabel} msgs"
+      }
+    }
+  ],
   "trash_deleted_ago": "deleted {time}",
   "trash_restore_session": "Restore session",
   "trash_restore": "Restore",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -316,22 +316,7 @@
   "sidebar_clear_selection": "Clear selection",
   "sidebar_batch_clear": "Clear",
   "sidebar_batch_all": "All",
-  "sidebar_selected_count": [
-    {
-      "declarations": [
-        "input count",
-        "input countLabel",
-        "local countPlural = count: plural"
-      ],
-      "selectors": [
-        "countPlural"
-      ],
-      "match": {
-        "countPlural=one": "{countLabel} selected",
-        "countPlural=other": "{countLabel} selected"
-      }
-    }
-  ],
+  "sidebar_selected_count": "{countLabel} selected",
   "sidebar_move_selected_to_trash": "Move selected sessions to trash",
   "sidebar_deleting": "Deleting...",
   "sidebar_delete": "Delete",
@@ -740,6 +725,7 @@
   "activity_int_auto_short": "{int} int / {auto} auto",
   "activity_peak_label": "peak {count}",
   "activity_agent_min_value": "{value} agent-min",
+  "activity_no_sessions_selected_slot": "No sessions active in the selected slot.",
   "activity_output_tokens_value": [
     {
       "declarations": [
@@ -1247,6 +1233,8 @@
   "resync_failed": "Failed: {count}",
   "resync_close_btn": "Close",
   "resync_retry": "Retry",
+  "resync_error_read_only": "Full resync is unavailable for read-only backends.",
+  "resync_error_in_progress": "A sync is already in progress.",
   "shortcuts_open_command_palette": "Open command palette",
   "shortcuts_find_in_session": "Find in session",
   "shortcuts_close_palette": "Close palette / modal / find",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -307,21 +307,7 @@
   "sidebar_clear_selection": "清除选择",
   "sidebar_batch_clear": "清除",
   "sidebar_batch_all": "全部",
-  "sidebar_selected_count": [
-    {
-      "declarations": [
-        "input count",
-        "input countLabel",
-        "local countPlural = count: plural"
-      ],
-      "selectors": [
-        "countPlural"
-      ],
-      "match": {
-        "countPlural=other": "已选择 {countLabel} 个"
-      }
-    }
-  ],
+  "sidebar_selected_count": "已选择 {countLabel} 个",
   "sidebar_move_selected_to_trash": "将选中的会话移至回收站",
   "sidebar_deleting": "正在删除...",
   "sidebar_delete": "删除",
@@ -720,6 +706,7 @@
   "activity_int_auto_short": "{int} 交互 / {auto} 自动",
   "activity_peak_label": "峰值 {count}",
   "activity_agent_min_value": "{value} 代理分钟",
+  "activity_no_sessions_selected_slot": "所选时段内没有活跃会话。",
   "activity_output_tokens_value": [
     {
       "declarations": [
@@ -930,23 +917,23 @@
     }
   ],
   "session_vitals_title": "分析",
-  "session_vitals_subtitle": "会话生命体征",
+  "session_vitals_subtitle": "会话指标",
   "session_vitals_close": "关闭会话分析",
   "session_vitals_session": "会话",
   "session_vitals_running": "运行中",
   "session_vitals_running_duration": "运行中 {duration}+",
-  "session_vitals_tool_calls": "tool calls",
-  "session_vitals_tool_time": "tool 时间",
+  "session_vitals_tool_calls": "工具调用",
+  "session_vitals_tool_time": "工具耗时",
   "session_vitals_slowest_call": "最慢调用",
   "session_vitals_jump_to_call": "跳转到调用",
-  "session_vitals_turns": "turns",
+  "session_vitals_turns": "回合",
   "session_vitals_subagents": "sub-agents",
   "session_vitals_time_spent": "耗时分布",
   "session_vitals_clear_category_filter": "清除分类筛选",
-  "session_vitals_completed_turns_hint": "已完成 turns · 点击高亮",
+  "session_vitals_completed_turns_hint": "已完成回合 · 点击高亮显示",
   "session_vitals_timeline": "时间线",
   "session_vitals_click_marks_to_scroll": "点击标记滚动",
-  "session_vitals_jump_to_turn": "跳转到 {category} turn，时间 {time}",
+  "session_vitals_jump_to_turn": "跳转到 {time} 的 {category} 回合",
   "session_vitals_calls": "调用",
   "session_vitals_calls_summary": [
     {
@@ -1219,6 +1206,8 @@
   "resync_failed": "失败：{count}",
   "resync_close_btn": "关闭",
   "resync_retry": "重试",
+  "resync_error_read_only": "只读后端不支持完整重新同步。",
+  "resync_error_in_progress": "同步已在进行中。",
   "shortcuts_open_command_palette": "打开命令面板",
   "shortcuts_find_in_session": "在会话中查找",
   "shortcuts_close_palette": "关闭面板 / 弹窗 / 查找",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -67,9 +67,51 @@
   "header_actions_settings": "设置",
   "header_actions_keyboard_shortcuts": "键盘快捷键",
   "header_actions_keyboard_shortcuts_shortcut": "键盘快捷键 (?)",
-  "status_bar_sessions": "{count} 个会话",
-  "status_bar_messages": "{count} 条消息",
-  "status_bar_projects": "{count} 个项目",
+  "status_bar_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 个会话"
+      }
+    }
+  ],
+  "status_bar_messages": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 条消息"
+      }
+    }
+  ],
+  "status_bar_projects": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 个项目"
+      }
+    }
+  ],
   "status_bar_open_performance_debug": "打开性能调试",
   "status_bar_perf": "性能",
   "status_bar_remote_unreachable_title": "无法连接远程服务器。打开设置检查 URL、token 或断开连接。",
@@ -243,8 +285,47 @@
   "compact_boundary_title": "上下文窗口在此处被压缩",
   "compact_boundary_label": "上下文已压缩",
   "compact_boundary_show_full_summary": "显示完整摘要",
-  "sidebar_session_count": "{count} 个会话",
+  "sidebar_session_count": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 个会话"
+      }
+    }
+  ],
   "sidebar_loading": "加载中",
+  "sidebar_multi_select": "多选",
+  "sidebar_exit_multi_select": "退出多选",
+  "sidebar_select_all_visible": "选择所有可见会话",
+  "sidebar_clear_selection": "清除选择",
+  "sidebar_batch_clear": "清除",
+  "sidebar_batch_all": "全部",
+  "sidebar_selected_count": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "已选择 {countLabel} 个"
+      }
+    }
+  ],
+  "sidebar_move_selected_to_trash": "将选中的会话移至回收站",
+  "sidebar_deleting": "正在删除...",
+  "sidebar_delete": "删除",
+  "sidebar_cancel": "取消",
   "sidebar_status": "状态",
   "sidebar_active": "活跃",
   "sidebar_active_title": "10 分钟内有活动",
@@ -282,6 +363,8 @@
   "sidebar_filters_clear_filters": "清除筛选器",
   "sidebar_row_expand": "展开",
   "sidebar_row_collapse": "折叠",
+  "sidebar_row_select_session": "选择会话",
+  "sidebar_row_deselect_session": "取消选择会话",
   "sidebar_row_star_session": "固定会话",
   "sidebar_row_unstar_session": "取消固定会话",
   "sidebar_row_rename": "重命名",
@@ -584,6 +667,9 @@
   "usage_top_sessions_by_cost": "按成本排序的热门会话",
   "settings_title": "设置",
   "settings_loading": "正在加载设置...",
+  "settings_resync_title_unavailable": "只读模式下无法完整重新同步",
+  "settings_resync_unavailable_hint": "连接到只读后端时不可用",
+  "settings_resync_hint": "从头重新扫描所有会话文件",
   "settings_language_title": "语言",
   "settings_language_description": "选择界面语言。",
   "settings_language_label": "界面语言",
@@ -634,7 +720,21 @@
   "activity_int_auto_short": "{int} 交互 / {auto} 自动",
   "activity_peak_label": "峰值 {count}",
   "activity_agent_min_value": "{value} 代理分钟",
-  "activity_output_tokens_value": "{count} 输出 Token",
+  "activity_output_tokens_value": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 输出 Token"
+      }
+    }
+  ],
   "activity_concurrency": "并发",
   "activity_overlay": "叠加",
   "activity_overlay_metric": "并发叠加指标",
@@ -776,6 +876,98 @@
   "status_dot_stale": "已标记会话，空闲 10–60 分钟",
   "status_dot_unclean": "在工具调用中途终止（或文件被截断）",
   "call_row_toggle_subagent_calls": "切换子代理调用",
+  "call_row_running_duration": "运行中 {duration}+",
+  "call_group_parallel_label": "并行",
+  "call_group_parallel_call_count": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 次调用"
+      }
+    }
+  ],
+  "subagent_calls_label": "↳ sub-agent",
+  "subagent_calls_summary": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "input duration",
+        "input running",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural",
+        "running"
+      ],
+      "match": {
+        "countPlural=other,running=true": "{countLabel} 次调用 · 运行中 {duration}+",
+        "countPlural=other,running=false": "{countLabel} 次调用 · {duration}"
+      }
+    }
+  ],
+  "activity_lane_activity": "活动",
+  "activity_lane_message_count": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 条消息"
+      }
+    }
+  ],
+  "session_vitals_title": "分析",
+  "session_vitals_subtitle": "会话生命体征",
+  "session_vitals_close": "关闭会话分析",
+  "session_vitals_session": "会话",
+  "session_vitals_running": "运行中",
+  "session_vitals_running_duration": "运行中 {duration}+",
+  "session_vitals_tool_calls": "tool calls",
+  "session_vitals_tool_time": "tool 时间",
+  "session_vitals_slowest_call": "最慢调用",
+  "session_vitals_jump_to_call": "跳转到调用",
+  "session_vitals_turns": "turns",
+  "session_vitals_subagents": "sub-agents",
+  "session_vitals_time_spent": "耗时分布",
+  "session_vitals_clear_category_filter": "清除分类筛选",
+  "session_vitals_completed_turns_hint": "已完成 turns · 点击高亮",
+  "session_vitals_timeline": "时间线",
+  "session_vitals_click_marks_to_scroll": "点击标记滚动",
+  "session_vitals_jump_to_turn": "跳转到 {category} turn，时间 {time}",
+  "session_vitals_calls": "调用",
+  "session_vitals_calls_summary": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "input runningCount",
+        "local countPlural = count: plural",
+        "local runningPlural = runningCount: plural"
+      ],
+      "selectors": [
+        "countPlural",
+        "runningPlural"
+      ],
+      "match": {
+        "countPlural=other,runningPlural=one": "{countLabel} 次调用 · {runningCount} 个运行中",
+        "countPlural=other,runningPlural=other": "{countLabel} 次调用"
+      }
+    }
+  ],
+  "session_vitals_now": "现在",
   "code_block_copy": "复制代码块",
   "code_block_copy_title": "复制代码",
   "common_copied": "已复制！",
@@ -900,7 +1092,21 @@
   "insights_page_sessions_computed": "个已计算会话",
   "insights_page_score_distribution": "评分分布",
   "insights_page_pct_affected": "{pct}% 受影响",
-  "insights_page_driver_sessions": "{count} 个会话",
+  "insights_page_driver_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 个会话"
+      }
+    }
+  ],
   "insights_page_session_evidence": "会话证据",
   "insights_page_close": "关闭",
   "insights_page_loading_examples": "正在加载示例...",
@@ -1154,7 +1360,21 @@
   "trash_title": "回收站",
   "trash_emptying": "正在清空...",
   "trash_empty_trash": "清空回收站",
-  "trash_msgs": "{count} 条消息",
+  "trash_msgs": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{countLabel} 条消息"
+      }
+    }
+  ],
   "trash_deleted_ago": "{time} 删除",
   "trash_restore_session": "恢复会话",
   "trash_restore": "恢复",

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -389,11 +389,11 @@
       <div class="status error">
         <span>{activity.error}</span>
         <button class="retry-btn" onclick={() => activity.load()}>
-          Retry
+          {m.shared_retry()}
         </button>
       </div>
     {:else}
-      <div class="status">No data for this period.</div>
+      <div class="status">{m.shared_no_data_for_period()}</div>
     {/if}
 
     <!-- Range-scoped, not report-filter-scoped: kept outside the loading/error

--- a/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
+++ b/frontend/src/lib/components/activity/ConcurrencyTimeline.svelte
@@ -114,7 +114,10 @@
       text:
         `${fmtBucketRange(b)} · ${m.activity_peak_label({ count: b.max_agents })}${peakSplit} · ` +
         `${m.activity_agent_min_value({ value: b.agent_minutes.toFixed(1) })} · ` +
-        `${m.activity_output_tokens_value({ count: b.output_tokens.toLocaleString() })} · ` +
+        `${m.activity_output_tokens_value({
+          count: b.output_tokens,
+          countLabel: b.output_tokens.toLocaleString(),
+        })} · ` +
         `$${b.cost.toFixed(2)}`,
     };
   }

--- a/frontend/src/lib/components/activity/SessionsTable.svelte
+++ b/frontend/src/lib/components/activity/SessionsTable.svelte
@@ -289,8 +289,8 @@
   {:else}
     <div class="empty">
       {filterSet
-        ? "No sessions active in the selected slot."
-        : "No sessions in range."}
+        ? m.activity_no_sessions_selected_slot()
+        : m.shared_no_sessions_in_range()}
     </div>
   {/if}
 </div>

--- a/frontend/src/lib/components/activity/SessionsTable.test.ts
+++ b/frontend/src/lib/components/activity/SessionsTable.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mount, tick, unmount } from "svelte";
 import SessionsTable from "./SessionsTable.svelte";
+import { m } from "../../i18n/index.js";
 import { router } from "../../stores/router.svelte.js";
 import type { Report } from "../../api/types.js";
 import type { ActivitySessionRow } from "../../api/generated/index";
@@ -243,7 +244,7 @@ describe("SessionsTable", () => {
 
     expect(document.querySelectorAll(".session-row").length).toBe(0);
     expect(document.querySelector(".empty")?.textContent).toContain(
-      "No sessions active in the selected slot",
+      m.activity_no_sessions_selected_slot(),
     );
     expect(document.querySelector(".filter-badge")).toBeTruthy();
 

--- a/frontend/src/lib/components/content/ActivityLane.svelte
+++ b/frontend/src/lib/components/content/ActivityLane.svelte
@@ -4,6 +4,7 @@
      positioned `.activity-bar` per populated bucket. Click-to-scroll uses
      `ui.scrollToOrdinal`, matching ActivityMinimap's behavior. -->
 <script lang="ts">
+  import { m } from "../../i18n/index.js";
   import { sessionActivity } from "../../stores/sessionActivity.svelte.js";
   import { ui } from "../../stores/ui.svelte.js";
   import type { SessionActivityBucket } from "../../api/types/session-activity.js";
@@ -63,7 +64,10 @@
   function barTitle(bucket: SessionActivityBucket): string {
     const range = `${formatTime(bucket.start_time)}–${formatTime(bucket.end_time)}`;
     const total = bucket.user_count + bucket.assistant_count;
-    return `${range} · ${total} message${total === 1 ? "" : "s"}`;
+    return `${range} · ${m.activity_lane_message_count({
+      count: total,
+      countLabel: String(total),
+    })}`;
   }
 
   function handleBarClick(bucket: SessionActivityBucket) {
@@ -76,7 +80,7 @@
 </script>
 
 <div class="lane-row">
-  <span class="lane-label">activity</span>
+  <span class="lane-label">{m.activity_lane_activity()}</span>
   <span class="lane-track activity">
     {#if chart}
       {#each chart.bars as bar (bar.index)}

--- a/frontend/src/lib/components/content/CallGroup.svelte
+++ b/frontend/src/lib/components/content/CallGroup.svelte
@@ -1,7 +1,9 @@
 <!-- ABOUTME: Visual grouping for parallel calls in the Calls section — left rail + header chip + member CallRows. -->
 <script lang="ts">
+  import { m } from "../../i18n/index.js";
   import type { CallTiming } from "../../api/types/timing.js";
   import { formatDuration } from "../../utils/duration.js";
+  import { formatNumber } from "../../utils/format.js";
   import CallRow from "./CallRow.svelte";
 
   interface Props {
@@ -54,7 +56,12 @@
   <div class="cg-rail"></div>
   <div class="cg-members">
     <div class="cg-header">
-      <span class="cg-h-label">parallel · {calls.length} calls</span>
+      <span class="cg-h-label">
+        {m.call_group_parallel_label()} · {m.call_group_parallel_call_count({
+          count: calls.length,
+          countLabel: formatNumber(calls.length),
+        })}
+      </span>
       <span class="cg-h-bar-wrap">
         <span class="cg-h-bar" style="width: {headerBarPct}%"></span>
       </span>

--- a/frontend/src/lib/components/content/CallRow.svelte
+++ b/frontend/src/lib/components/content/CallRow.svelte
@@ -44,7 +44,9 @@
   let durationLabel = $derived.by(() => {
     if (isLive) {
       const elapsed = liveDurationMs ?? call.duration_ms ?? 0;
-      return `running ${formatDuration(elapsed)}+`;
+      return m.call_row_running_duration({
+        duration: formatDuration(elapsed),
+      });
     }
     if (call.duration_ms == null) {
       return sharedDurationLabel ?? "—";

--- a/frontend/src/lib/components/content/CallRow_CallGroup.test.ts
+++ b/frontend/src/lib/components/content/CallRow_CallGroup.test.ts
@@ -13,6 +13,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 // @ts-ignore -- @types/node is not in devDependencies; harmless at runtime.
 import { resolve } from "node:path";
 import type { CallTiming } from "../../api/types/timing.js";
+import { m } from "../../i18n/index.js";
 // @ts-ignore
 import CallRow from "./CallRow.svelte";
 // @ts-ignore
@@ -132,7 +133,7 @@ describe("CallRow", () => {
 
     expect(html).toMatch(hasClasses("cbar", "live"));
     expect(html).toMatch(hasClasses("cd", "live"));
-    expect(html).toContain("running 4.0s+");
+    expect(html).toContain(m.call_row_running_duration({ duration: "4.0s" }));
 
     unmount(c);
   });
@@ -162,7 +163,7 @@ describe("CallRow", () => {
     expect(html).not.toMatch(hasClasses("chev", "spacer"));
     expect(html).toContain("var(--cat-task)");
     // a11y: chevron carries aria-label and aria-expanded.
-    expect(html).toContain('aria-label="Toggle sub-agent calls"');
+    expect(html).toContain(`aria-label="${m.call_row_toggle_subagent_calls()}"`);
     expect(html).toContain('aria-expanded="true"');
 
     unmount(c);
@@ -263,7 +264,10 @@ describe("CallGroup", () => {
     expect(html).toMatch(hasClasses("cg-members"));
     expect(html).toMatch(hasClasses("cg-header"));
     expect(html).toMatch(hasClasses("cg-h-label"));
-    expect(html).toContain("parallel · 3 calls");
+    expect(html).toContain(`${m.call_group_parallel_label()} · ${m.call_group_parallel_call_count({
+      count: 3,
+      countLabel: "3",
+    })}`);
     expect(html).toMatch(hasClasses("cg-h-bar-wrap"));
     expect(html).toMatch(hasClasses("cg-h-bar"));
     expect(html).toContain("width: 70%");

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -7,6 +7,8 @@
   import { categoryToken } from "../../utils/categoryToken.js";
   import { displayToolName } from "../../utils/toolDisplay.js";
   import { ui } from "../../stores/ui.svelte.js";
+  import { m } from "../../i18n/index.js";
+  import { formatNumber } from "../../utils/format.js";
   import type {
     CallTiming,
     SessionTiming,
@@ -216,7 +218,7 @@
     const dur =
       turn.duration_ms != null
         ? formatDuration(turn.duration_ms)
-        : "running";
+        : m.session_vitals_running();
     return `${turn.primary_category} · ${dur}`;
   }
 
@@ -228,14 +230,14 @@
 <div class="vital">
   <header class="vital-titlebar">
     <div>
-      <div class="vital-title">Analysis</div>
-      <div class="vital-subtitle">Session vital signs</div>
+      <div class="vital-title">{m.session_vitals_title()}</div>
+      <div class="vital-subtitle">{m.session_vitals_subtitle()}</div>
     </div>
     <button
       type="button"
       class="vital-close"
-      title="Close session analysis"
-      aria-label="Close session analysis"
+      title={m.session_vitals_close()}
+      aria-label={m.session_vitals_close()}
       onclick={() => ui.closeVitals()}
     >
       <XIcon size="12" strokeWidth="2.4" aria-hidden="true" />
@@ -245,10 +247,10 @@
   {#if timing}
     <section class="v-section">
       <header class="v-h">
-        <span>Session</span>
+        <span>{m.session_vitals_session()}</span>
         <span class="v-meta" class:live={timing.running}>
           {#if timing.running}
-            running {formatDuration(timing.total_duration_ms)}+
+            {m.session_vitals_running_duration({ duration: formatDuration(timing.total_duration_ms) })}
           {:else}
             {formatDuration(timing.total_duration_ms)}
           {/if}
@@ -256,23 +258,23 @@
       </header>
       <div class="stat-grid">
         <div>
-          <div class="lbl">tool calls</div>
+          <div class="lbl">{m.session_vitals_tool_calls()}</div>
           <div class="val">{timing.tool_call_count}</div>
         </div>
         <div>
-          <div class="lbl">tool time</div>
+          <div class="lbl">{m.session_vitals_tool_time()}</div>
           <div class="val" class:live={timing.running}>
             {formatDuration(timing.tool_duration_ms)}{timing.running ? "+" : ""}
           </div>
         </div>
         <div>
-          <div class="lbl">slowest call</div>
+          <div class="lbl">{m.session_vitals_slowest_call()}</div>
           {#if timing.slowest_call}
             {@const slowest = timing.slowest_call}
             <button
               type="button"
               class="val slow val-link"
-              title="Jump to call"
+              title={m.session_vitals_jump_to_call()}
               onclick={() => scrollToCall(slowest)}
             >
               {displayToolName(slowest)} · {formatDuration(slowest.duration_ms ?? 0)}
@@ -282,11 +284,11 @@
           {/if}
         </div>
         <div>
-          <div class="lbl">turns</div>
+          <div class="lbl">{m.session_vitals_turns()}</div>
           <div class="val">{timing.turn_count}</div>
         </div>
         <div>
-          <div class="lbl">sub-agents</div>
+          <div class="lbl">{m.session_vitals_subagents()}</div>
           <div class="val">{timing.subagent_count}</div>
         </div>
       </div>
@@ -295,20 +297,20 @@
     {#if timing.by_category.length > 0}
       <section class="v-section">
         <header class="v-h">
-          <span>Time spent</span>
+          <span>{m.session_vitals_time_spent()}</span>
           {#if categoryFilter}
             <button
               class="filter-chip"
               style="color: {categoryToken(categoryFilter)}; border-color: {categoryToken(categoryFilter)};"
               onclick={() => (categoryFilter = null)}
-              aria-label="clear category filter"
+              aria-label={m.session_vitals_clear_category_filter()}
             >
               {categoryFilter}<span class="x">
                 <XIcon size="10" strokeWidth="2.4" aria-hidden="true" />
               </span>
             </button>
           {:else}
-            <span class="v-meta">completed turns · click to highlight</span>
+            <span class="v-meta">{m.session_vitals_completed_turns_hint()}</span>
           {/if}
         </header>
         {#each timing.by_category as cat (cat.category)}
@@ -338,12 +340,12 @@
     {#if timing.turns.length > 0}
       <section class="v-section">
         <header class="v-h">
-          <span>Timeline</span>
-          <span class="v-meta">click marks to scroll</span>
+          <span>{m.session_vitals_timeline()}</span>
+          <span class="v-meta">{m.session_vitals_click_marks_to_scroll()}</span>
         </header>
 
         <div class="lane-row">
-          <span class="lane-label">turns</span>
+          <span class="lane-label">{m.session_vitals_turns()}</span>
           <span class="lane-track">
             {#each timing.turns as t (t.message_id)}
               {@const isLive = t.duration_ms == null}
@@ -357,7 +359,10 @@
                 title={turnTitle(t)}
                 onclick={() => scrollToTurn(t)}
                 type="button"
-                aria-label="Jump to {t.primary_category} turn at {t.started_at}"
+                aria-label={m.session_vitals_jump_to_turn({
+                  category: t.primary_category,
+                  time: t.started_at,
+                })}
               ></button>
             {/each}
           </span>
@@ -383,7 +388,10 @@
                   title={turnTitle(t)}
                   onclick={() => scrollToTurn(t)}
                   type="button"
-                  aria-label="Jump to {cat.category} turn at {t.started_at}"
+                  aria-label={m.session_vitals_jump_to_turn({
+                    category: cat.category,
+                    time: t.started_at,
+                  })}
                 ></button>
               {/each}
             </span>
@@ -411,11 +419,13 @@
     {#if timing.turns.length > 0}
       <section class="v-section">
         <header class="v-h">
-          <span>Calls</span>
+          <span>{m.session_vitals_calls()}</span>
           <span class="v-meta">
-            {timing.tool_call_count} call{timing.tool_call_count === 1
-              ? ""
-              : "s"}{timing.running ? " · 1 running" : ""}
+            {m.session_vitals_calls_summary({
+              count: timing.tool_call_count,
+              countLabel: formatNumber(timing.tool_call_count),
+              runningCount: timing.running ? 1 : 0,
+            })}
           </span>
         </header>
         <div class="scale-axis">
@@ -429,7 +439,7 @@
           >
           <span class:now={timing.running}
             >{timing.running
-              ? "now"
+              ? m.session_vitals_now()
               : formatDuration(timing.total_duration_ms)}</span
           >
         </div>

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -35,6 +35,7 @@ vi.mock("../../api/timing.js", () => ({
 
 import { ui } from "../../stores/ui.svelte.js";
 import { sessionTiming } from "../../stores/sessionTiming.svelte.js";
+import { m } from "../../i18n/index.js";
 // @ts-ignore
 import SessionVitals from "./SessionVitals.svelte";
 
@@ -65,11 +66,11 @@ describe("SessionVitals", () => {
     await tick();
 
     const closeButton = document.querySelector<HTMLButtonElement>(
-      'button[aria-label="Close session analysis"]',
+      `button[aria-label="${m.session_vitals_close()}"]`,
     );
 
     expect(closeButton).not.toBeNull();
-    expect(closeButton?.title).toBe("Close session analysis");
+    expect(closeButton?.title).toBe(m.session_vitals_close());
 
     closeButton!.click();
     await tick();

--- a/frontend/src/lib/components/content/SubagentCalls.svelte
+++ b/frontend/src/lib/components/content/SubagentCalls.svelte
@@ -1,11 +1,13 @@
 <!-- ABOUTME: Inline-expansion of a sub-agent session's call list inside the parent Calls section. -->
 <script lang="ts">
+  import { m } from "../../i18n/index.js";
   import type {
     SessionTiming,
     CallTiming,
     TurnTiming,
   } from "../../api/types/timing.js";
   import { formatDuration } from "../../utils/duration.js";
+  import { formatNumber } from "../../utils/format.js";
   import { liveTick } from "../../stores/liveTick.svelte.js";
   import CallRow from "./CallRow.svelte";
   import CallGroup from "./CallGroup.svelte";
@@ -57,15 +59,15 @@
 
 <div class="sa-expand">
   <div class="sa-eh">
-    <span class="sa-eh-label">↳ sub-agent</span>
-    <span class="sa-eh-meta"
-      >{timing.tool_call_count} call{timing.tool_call_count === 1
-        ? ""
-        : "s"} ·
-      {timing.running ? "running " : ""}{formatDuration(
-        timing.total_duration_ms,
-      )}{timing.running ? "+" : ""}</span
-    >
+    <span class="sa-eh-label">{m.subagent_calls_label()}</span>
+    <span class="sa-eh-meta">
+      {m.subagent_calls_summary({
+        count: timing.tool_call_count,
+        countLabel: formatNumber(timing.tool_call_count),
+        duration: formatDuration(timing.total_duration_ms),
+        running: timing.running ? "true" : "false",
+      })}
+    </span>
   </div>
   <div class="calls">
     {#each timing.turns as turn, i (turn.message_id)}

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -937,7 +937,10 @@
                     <strong>
                       {driver.total}{driver.unit ?? ""}
                     </strong>
-                    <em>{m.insights_page_driver_sessions({ count: driver.sessions })}</em>
+                    <em>{m.insights_page_driver_sessions({
+                      count: driver.sessions,
+                      countLabel: driver.sessions.toLocaleString(),
+                    })}</em>
                     <small>{calibrationLabel(String(driver.id))}</small>
                   </button>
                 {/each}

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -75,11 +75,20 @@
 <footer class="status-bar">
   <div class="status-left">
     {#if sync.stats}
-      <span>{m.status_bar_sessions({ count: formatNumber(sync.stats.session_count) })}</span>
+      <span>{m.status_bar_sessions({
+        count: sync.stats.session_count,
+        countLabel: formatNumber(sync.stats.session_count),
+      })}</span>
       <span class="sep">&middot;</span>
-      <span>{m.status_bar_messages({ count: formatNumber(sync.stats.message_count) })}</span>
+      <span>{m.status_bar_messages({
+        count: sync.stats.message_count,
+        countLabel: formatNumber(sync.stats.message_count),
+      })}</span>
       <span class="sep">&middot;</span>
-      <span>{m.status_bar_projects({ count: formatNumber(sync.stats.project_count) })}</span>
+      <span>{m.status_bar_projects({
+        count: sync.stats.project_count,
+        countLabel: formatNumber(sync.stats.project_count),
+      })}</span>
     {/if}
   </div>
 

--- a/frontend/src/lib/components/modals/ResyncModal.svelte
+++ b/frontend/src/lib/components/modals/ResyncModal.svelte
@@ -11,8 +11,7 @@
 
   function startResync() {
     if (sync.readOnly) {
-      errorMessage =
-        "Full resync is unavailable for read-only backends.";
+      errorMessage = m.resync_error_read_only();
       view = "error";
       return;
     }
@@ -28,7 +27,7 @@
     if (started) {
       view = "progress";
     } else if (!errorMessage) {
-      errorMessage = "A sync is already in progress.";
+      errorMessage = m.resync_error_in_progress();
       view = "error";
     }
   }

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -37,16 +37,15 @@
     <div class="settings-loading">{m.settings_loading()}</div>
   {:else if settings.needsAuth}
     <div class="auth-prompt">
-      <h3 class="auth-title">Authentication Required</h3>
+      <h3 class="auth-title">{m.app_auth_title()}</h3>
       <p class="auth-description">
-        This server requires an auth token. Enter the token displayed
-        on the server's console or settings page.
+        {m.app_auth_description()}
       </p>
       <div class="auth-field">
         <input
           class="auth-input"
           type="password"
-          placeholder="Paste auth token"
+          placeholder={m.app_auth_placeholder()}
           bind:value={authTokenInput}
           onkeydown={(e) => { if (e.key === "Enter") handleAuthSubmit(); }}
         />
@@ -55,7 +54,7 @@
           disabled={!authTokenInput.trim()}
           onclick={handleAuthSubmit}
         >
-          Authenticate
+          {m.app_auth_authenticate()}
         </button>
       </div>
       <button
@@ -67,7 +66,7 @@
           settings.load();
         }}
       >
-        Disconnect and reset
+        {m.app_auth_disconnect_reset()}
       </button>
     </div>
   {:else if settings.error}
@@ -80,9 +79,9 @@
             setAuthToken("");
             setServerUrl("");
             window.location.reload();
-          }}
-        >
-          Disconnect and reset
+        }}
+      >
+          {m.app_auth_disconnect_reset()}
         </button>
       {/if}
     </div>
@@ -104,15 +103,15 @@
           }}
           disabled={sync.readOnly}
           title={sync.readOnly
-            ? "Full resync unavailable in read-only mode"
-            : "Full resync"}
+            ? m.settings_resync_title_unavailable()
+            : m.resync_title()}
         >
-          Full Resync
+          {m.resync_title()}
         </button>
         <span class="settings-actions-hint">
           {sync.readOnly
-            ? "Unavailable while connected to a read-only backend"
-            : "Re-scan all session files from scratch"}
+            ? m.settings_resync_unavailable_hint()
+            : m.settings_resync_hint()}
         </span>
       </div>
     </div>

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -363,7 +363,9 @@
       class:checked={selected}
       onclick={handleSelectClick}
       tabindex="-1"
-      aria-label={selected ? "Deselect session" : "Select session"}
+      aria-label={selected
+        ? m.sidebar_row_deselect_session()
+        : m.sidebar_row_select_session()}
     >
       {#if selected}
         <svg width="10" height="10" viewBox="0 0 12 12" fill="none" aria-hidden="true">

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -467,7 +467,10 @@
 
 <div class="session-list-header">
   <span class="session-count">
-    {m.sidebar_session_count({ count: formatNumber(totalCount) })}
+    {m.sidebar_session_count({
+      count: totalCount,
+      countLabel: formatNumber(totalCount),
+    })}
   </span>
   <div class="header-actions">
     {#if sessions.loading}
@@ -477,8 +480,8 @@
       class="select-toggle-btn"
       class:active={sessions.selectMode}
       onclick={() => sessions.toggleSelectMode()}
-      title={sessions.selectMode ? "Exit multi-select" : "Multi-select"}
-      aria-label={sessions.selectMode ? "Exit multi-select" : "Multi-select"}
+      title={sessions.selectMode ? m.sidebar_exit_multi_select() : m.sidebar_multi_select()}
+      aria-label={sessions.selectMode ? m.sidebar_exit_multi_select() : m.sidebar_multi_select()}
     >
       <CheckIcon size="12" strokeWidth="2" aria-hidden="true" />
     </button>
@@ -530,28 +533,31 @@
     <button
       class="batch-select-all-btn"
       onclick={handleSelectAllVisible}
-      title={allSelected ? "Clear selection" : "Select all visible"}
+      title={allSelected ? m.sidebar_clear_selection() : m.sidebar_select_all_visible()}
     >
-      {allSelected ? "Clear" : "All"}
+      {allSelected ? m.sidebar_batch_clear() : m.sidebar_batch_all()}
     </button>
     <span class="batch-count">
-      {visibleSelectedSessionIds.length} selected
+      {m.sidebar_selected_count({
+        count: visibleSelectedSessionIds.length,
+        countLabel: formatNumber(visibleSelectedSessionIds.length),
+      })}
     </span>
     <button
       class="batch-delete-btn"
       onclick={handleBatchDelete}
       disabled={visibleSelectedSessionIds.length === 0 || batchDeleting}
-      title="Move selected sessions to trash"
+      title={m.sidebar_move_selected_to_trash()}
     >
       <TrashIcon size="11" strokeWidth="2" aria-hidden="true" />
-      {batchDeleting ? "Deleting..." : "Delete"}
+      {batchDeleting ? m.sidebar_deleting() : m.sidebar_delete()}
     </button>
     <button
       class="batch-cancel-btn"
       onclick={() => sessions.toggleSelectMode()}
-      title="Exit multi-select"
+      title={m.sidebar_exit_multi_select()}
     >
-      Cancel
+      {m.sidebar_cancel()}
     </button>
   </div>
 {/if}

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -539,7 +539,6 @@
     </button>
     <span class="batch-count">
       {m.sidebar_selected_count({
-        count: visibleSelectedSessionIds.length,
         countLabel: formatNumber(visibleSelectedSessionIds.length),
       })}
     </span>

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -15,7 +15,7 @@ import sessionItemSource from "./SessionItem.svelte?raw";
 import { sessions } from "../../stores/sessions.svelte.js";
 import type { Session } from "../../api/types.js";
 import { starred } from "../../stores/starred.svelte.js";
-import { setLocale } from "../../i18n/index.js";
+import { m, setLocale } from "../../i18n/index.js";
 import {
   ITEM_HEIGHT,
   OVERSCAN,
@@ -198,6 +198,17 @@ describe("SessionList filter dropdown", () => {
     expect(document.body.textContent).toContain("重命名");
     expect(document.body.textContent).toContain("在新标签页打开");
     expect(document.body.textContent).toContain("删除");
+
+    sessions.selectMode = true;
+    sessions.selectedIds = new Set(["translated-session"]);
+    await tick();
+
+    expect(document.body.textContent).toContain("已选择 1 个");
+    const batchSelectButton = document.querySelector<HTMLButtonElement>(
+      ".batch-select-all-btn",
+    );
+    expect(batchSelectButton?.textContent?.trim()).toBe("清除");
+    expect(document.body.textContent).toContain("取消");
   });
 });
 
@@ -778,7 +789,10 @@ describe("SessionList visible hydration", () => {
     await tick();
 
     expect(document.querySelector('[data-session-id="hidden"]')).toBeNull();
-    expect(document.body.textContent).toContain("1 selected");
+    expect(document.body.textContent).toContain(m.sidebar_selected_count({
+      count: 1,
+      countLabel: "1",
+    }));
 
     const deleteButton = document.querySelector<HTMLButtonElement>(
       ".batch-delete-btn",

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -790,7 +790,6 @@ describe("SessionList visible hydration", () => {
 
     expect(document.querySelector('[data-session-id="hidden"]')).toBeNull();
     expect(document.body.textContent).toContain(m.sidebar_selected_count({
-      count: 1,
       countLabel: "1",
     }));
 

--- a/frontend/src/lib/components/trash/TrashPage.svelte
+++ b/frontend/src/lib/components/trash/TrashPage.svelte
@@ -111,7 +111,10 @@
             <div class="trash-card-meta">
               <span class="trash-agent">{session.agent}</span>
               <span class="trash-project">{session.project}</span>
-              <span class="trash-msgs">{m.trash_msgs({ count: session.user_message_count })}</span>
+              <span class="trash-msgs">{m.trash_msgs({
+                count: session.user_message_count,
+                countLabel: session.user_message_count.toLocaleString(),
+              })}</span>
               {#if session.deleted_at}
                 <span class="trash-deleted">{m.trash_deleted_ago({ time: formatRelativeTime(session.deleted_at) })}</span>
               {/if}

--- a/frontend/src/lib/i18n/i18n.test.ts
+++ b/frontend/src/lib/i18n/i18n.test.ts
@@ -80,11 +80,17 @@ describe("i18n locale selection", () => {
   it("renders generated Paraglide messages for each supported locale", () => {
     runtime.setLocale("en", { reload: false });
     expect(m.nav_sessions()).toBe("Sessions");
-    expect(m.status_bar_sessions({ count: "12" })).toBe("12 sessions");
+    expect(m.status_bar_sessions({
+      count: 12,
+      countLabel: "12",
+    })).toBe("12 sessions");
 
     runtime.setLocale("zh-CN", { reload: false });
     expect(m.nav_sessions()).toBe("会话");
-    expect(m.status_bar_sessions({ count: "12" })).toBe("12 个会话");
+    expect(m.status_bar_sessions({
+      count: 12,
+      countLabel: "12",
+    })).toBe("12 个会话");
   });
 
   it("selects cardinal plural variants per locale", () => {
@@ -93,6 +99,18 @@ describe("i18n locale selection", () => {
     expect(m.tool_call_group_call_count({ count: 3 })).toBe("3 tool calls");
     expect(m.parallel_group_call_count({ count: 1 })).toBe("1 call");
     expect(m.parallel_group_call_count({ count: 2 })).toBe("2 calls");
+    expect(m.status_bar_sessions({
+      count: 1,
+      countLabel: "1",
+    })).toBe("1 session");
+    expect(m.sidebar_session_count({
+      count: 2,
+      countLabel: "2",
+    })).toBe("2 sessions");
+    expect(m.trash_msgs({
+      count: 1,
+      countLabel: "1",
+    })).toBe("1 msg");
     expect(m.subagent_inline_message_count({ count: 1 })).toBe("1 message");
     expect(m.subagent_inline_message_count({ count: 5 })).toBe("5 messages");
     expect(


### PR DESCRIPTION
## Summary

- Localizes remaining Settings auth/resync, Session Vital Signs, vitals call rows, and sidebar multi-select UI copy through Paraglide.
- Converts remaining count-sensitive labels on status/sidebar/activity/insights/trash surfaces to plural-aware messages with separate formatted display labels.
- Refines zh-CN Session Vital Signs terminology and keeps agent names, tool names, file paths, commands, and session content unchanged.

## Screenshots

zh-CN Session Vital Signs:

![zh-CN Session Vital Signs](https://gist.githubusercontent.com/icatw/4e09831b383cdaf55e2482c79a449f4c/raw/session-vitals-zh-cn.png)

zh-CN Settings resync area:

![zh-CN Settings resync area](https://gist.githubusercontent.com/icatw/4e09831b383cdaf55e2482c79a449f4c/raw/settings-resync-zh-cn.png)

zh-CN sidebar multi-select toolbar:

![zh-CN sidebar multi-select toolbar](https://gist.githubusercontent.com/icatw/4e09831b383cdaf55e2482c79a449f4c/raw/sidebar-batch-toolbar-zh-cn.png)

zh-CN Activity empty slot:

![zh-CN Activity empty slot](https://gist.githubusercontent.com/icatw/4e09831b383cdaf55e2482c79a449f4c/raw/activity-empty-slot-zh-cn.png)

English switchback smoke:

![English Session Vital Signs](https://gist.githubusercontent.com/icatw/4e09831b383cdaf55e2482c79a449f4c/raw/session-vitals-en.png)
