### PR TITLE
Preserve XML-style prompt tags in markdown rendering

### DIFF
--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -348,6 +348,32 @@ describe("renderMarkdown", () => {
       expect(img).not.toBeNull();
       expect(img!.hasAttribute("onerror")).toBe(false);
     });
+
+    it("does not escape custom tags inside inline code spans", () => {
+      const dom = parseHTML(
+        renderMarkdown("`<policy>keep tags</policy>`"),
+      );
+      const code = dom.querySelector("p > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("<policy>keep tags</policy>");
+    });
+
+    it("does not escape custom tags inside fenced code blocks", () => {
+      const dom = parseHTML(
+        renderMarkdown("```\n<policy>keep tags</policy>\n```"),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("<policy>keep tags</policy>\n");
+    });
+
+    it("keeps markdown angle autolinks intact", () => {
+      const dom = parseHTML(renderMarkdown("<https://example.com>"));
+      const link = dom.querySelector("p > a");
+      expect(link).not.toBeNull();
+      expect(link!.textContent).toBe("https://example.com");
+      expect(link!.getAttribute("href")).toBe("https://example.com");
+    });
   });
 
   describe("Claude Code shell shortcuts", () => {
@@ -487,6 +513,17 @@ describe("renderMarkdown", () => {
       expect(code!.textContent).toMatch(
         /^\n\nbody\n/,
       );
+    });
+
+    it("leaves custom tags inside bash output literal", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "<bash-stdout><policy>keep tags</policy></bash-stdout>",
+        ),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("<policy>keep tags</policy>\n");
     });
   });
 

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -374,6 +374,17 @@ describe("renderMarkdown", () => {
       expect(link!.textContent).toBe("https://example.com");
       expect(link!.getAttribute("href")).toBe("https://example.com");
     });
+
+    it("preserves namespaced prompt tags as literal text", () => {
+      const dom = parseHTML(
+        renderMarkdown("<foo:bar>keep tags</foo:bar>"),
+      );
+      const p = dom.querySelector("p");
+      expect(p).not.toBeNull();
+      expect(p!.innerHTML).toContain("&lt;foo:bar&gt;");
+      expect(p!.innerHTML).toContain("&lt;/foo:bar&gt;");
+      expect(p!.textContent).toContain("<foo:bar>keep tags</foo:bar>");
+    });
   });
 
   describe("Claude Code shell shortcuts", () => {
@@ -473,6 +484,35 @@ describe("renderMarkdown", () => {
       expect(code!.textContent).toBe(
         "<bash-input>echo hi</bash-input>\n",
       );
+    });
+
+    it("leaves wrappers inside indented code blocks alone", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "    <bash-input>echo hi</bash-input>",
+        ),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("<bash-input>echo hi</bash-input>\n");
+    });
+
+    it("leaves custom tags inside longer-closing fences alone", () => {
+      const dom = parseHTML(
+        renderMarkdown("~~~\n<policy>keep tags</policy>\n~~~~"),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("<policy>keep tags</policy>\n");
+    });
+
+    it("leaves custom tags inside unclosed fences alone", () => {
+      const dom = parseHTML(
+        renderMarkdown("~~~\n<policy>keep tags</policy>"),
+      );
+      const code = dom.querySelector("pre > code");
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe("<policy>keep tags</policy>\n");
     });
 
     it("tags the input block with language-shell", () => {

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -324,6 +324,32 @@ describe("renderMarkdown", () => {
     );
   });
 
+  describe("custom XML-style prompt tags", () => {
+    it("preserves non-HTML prompt tags as literal text", () => {
+      const dom = parseHTML(
+        renderMarkdown(
+          "<policy><rule importance=\"high\">keep tags</rule></policy>",
+        ),
+      );
+      const p = dom.querySelector("p");
+      expect(p).not.toBeNull();
+      expect(p!.innerHTML).toContain("&lt;policy&gt;");
+      expect(p!.innerHTML).toContain("&lt;rule importance=\"high\"&gt;");
+      expect(p!.innerHTML).toContain("&lt;/rule&gt;");
+      expect(p!.innerHTML).toContain("&lt;/policy&gt;");
+      expect(p!.textContent).toContain(
+        "<policy><rule importance=\"high\">keep tags</rule></policy>",
+      );
+    });
+
+    it("keeps standard HTML on the sanitize path", () => {
+      const dom = parseHTML(renderMarkdown("<img src=x onerror=\"alert(1)\">"));
+      const img = dom.querySelector("img");
+      expect(img).not.toBeNull();
+      expect(img!.hasAttribute("onerror")).toBe(false);
+    });
+  });
+
   describe("Claude Code shell shortcuts", () => {
     it("renders <bash-input> as a shell code block with ! prefix", () => {
       const dom = parseHTML(

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -395,6 +395,17 @@ describe("renderMarkdown", () => {
       expect(link!.getAttribute("href")).toBe("https://example.com");
       expect(link!.textContent).toBe("<policy>read</policy>");
     });
+
+    it("preserves custom tags inside GFM table cells", () => {
+      const dom = parseHTML(
+        renderMarkdown("| A |\n| --- |\n| <policy>keep tags</policy> |"),
+      );
+      const cell = dom.querySelector("tbody td");
+      expect(cell).not.toBeNull();
+      expect(cell!.innerHTML).toContain("&lt;policy&gt;");
+      expect(cell!.innerHTML).toContain("&lt;/policy&gt;");
+      expect(cell!.textContent).toBe("<policy>keep tags</policy>");
+    });
   });
 
   describe("Claude Code shell shortcuts", () => {

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -385,6 +385,16 @@ describe("renderMarkdown", () => {
       expect(p!.innerHTML).toContain("&lt;/foo:bar&gt;");
       expect(p!.textContent).toContain("<foo:bar>keep tags</foo:bar>");
     });
+
+    it("keeps markdown links with custom-tag labels clickable", () => {
+      const dom = parseHTML(
+        renderMarkdown("[<policy>read</policy>](https://example.com)"),
+      );
+      const link = dom.querySelector("p > a");
+      expect(link).not.toBeNull();
+      expect(link!.getAttribute("href")).toBe("https://example.com");
+      expect(link!.textContent).toBe("<policy>read</policy>");
+    });
   });
 
   describe("Claude Code shell shortcuts", () => {

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -249,6 +249,15 @@ function escapeTokenValue(value: unknown): unknown {
   if (isMarkdownToken(value)) {
     return escapeCustomXmlToken(value);
   }
+  if (value && typeof value === "object") {
+    const next = {
+      ...(value as Record<string, unknown>),
+    };
+    for (const [key, entry] of Object.entries(next)) {
+      next[key] = escapeTokenValue(entry);
+    }
+    return next;
+  }
   return value;
 }
 

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -2,6 +2,123 @@ import { Marked, type TokenizerExtension } from "marked";
 import DOMPurify from "dompurify";
 import { LRUCache } from "./cache.js";
 
+const KNOWN_HTML_TAGS = new Set([
+  "a",
+  "abbr",
+  "address",
+  "area",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "base",
+  "bdi",
+  "bdo",
+  "blockquote",
+  "body",
+  "br",
+  "button",
+  "canvas",
+  "caption",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "data",
+  "datalist",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "embed",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hgroup",
+  "hr",
+  "html",
+  "i",
+  "iframe",
+  "img",
+  "input",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "map",
+  "mark",
+  "menu",
+  "meta",
+  "meter",
+  "nav",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "picture",
+  "pre",
+  "progress",
+  "q",
+  "rp",
+  "rt",
+  "ruby",
+  "s",
+  "samp",
+  "script",
+  "section",
+  "select",
+  "slot",
+  "small",
+  "source",
+  "span",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "svg",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "track",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "wbr",
+]);
+
+const XML_TAG_ESCAPE_RE = /<\/?([A-Za-z][A-Za-z0-9:_-]*)(?:"[^"]*"|'[^']*'|[^"'<>])*?>/g;
+
 /** Build a marked tokenizer extension that consumes a Claude Code
  *  shell-shortcut wrapper tag and emits a `code` token directly.
  *  Because this runs at the lexer level, occurrences of the tag
@@ -74,13 +191,28 @@ function resolveAssetURLs(text: string): string {
   );
 }
 
+function escapeCustomXmlTags(text: string): string {
+  return text.replace(XML_TAG_ESCAPE_RE, (tag, rawName: string) => {
+    const name = rawName.toLowerCase();
+    if (
+      KNOWN_HTML_TAGS.has(name) ||
+      name === "bash-input" ||
+      name === "bash-stdout" ||
+      name === "bash-stderr"
+    ) {
+      return tag;
+    }
+    return tag.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  });
+}
+
 export function renderMarkdown(text: string): string {
   if (!text) return "";
 
   const cached = cache.get(text);
   if (cached !== undefined) return cached;
 
-  const resolved = resolveAssetURLs(text);
+  const resolved = escapeCustomXmlTags(resolveAssetURLs(text));
 
   // Trim trailing whitespace — with breaks:true, trailing
   // newlines become <br> tags that add invisible height.

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -118,24 +118,19 @@ const KNOWN_HTML_TAGS = new Set([
 ]);
 
 const XML_TAG_ESCAPE_RE = /<\/?([A-Za-z][A-Za-z0-9:_-]*)(?:"[^"]*"|'[^']*'|[^"'<>])*?>/g;
-const BASH_WRAPPER_BLOCK_RE =
-  /<bash-(input|stdout|stderr)>[\s\S]*?<\/bash-\1>/g;
-const FENCED_CODE_BLOCK_RE =
-  /(^|\n)(?: {0,3})(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n(?: {0,3})\2[ \t]*(?=\n|$)/g;
-const INLINE_CODE_SPAN_RE = /(`+)([\s\S]*?)\1/g;
-const AUTOLINK_RE =
-  /<(?:[A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\s]+|[^\s<>@]+@[^\s<>]+)>/g;
 
-type ProtectedRange = {
-  start: number;
-  end: number;
+type MarkdownToken = {
+  type: string;
+  raw?: string;
+  text?: string;
+  escaped?: boolean;
+  [key: string]: unknown;
 };
 
 /** Build a marked tokenizer extension that consumes a Claude Code
  *  shell-shortcut wrapper tag and emits a `code` token directly.
  *  Because this runs at the lexer level, occurrences of the tag
- *  inside a fenced code block are never reached — marked has
- *  already consumed those characters as a `code` token. */
+ *  inside markdown code blocks never reach the extension. */
 function bashWrapperExtension(
   name: string,
   tag: string,
@@ -156,12 +151,8 @@ function bashWrapperExtension(
       if (!m) return undefined;
       const captured = m[1] ?? "";
       if (!captured.trim()) {
-        // Drop empty wrappers entirely (common for stdout/stderr).
         return { type: "space", raw: m[0] };
       }
-      // Preserve the captured whitespace verbatim — code blocks
-      // are expected to render shell output exactly, including
-      // indentation and trailing blank lines.
       return {
         type: "code",
         raw: m[0],
@@ -203,90 +194,93 @@ function resolveAssetURLs(text: string): string {
   );
 }
 
-function escapeCustomXmlTagsSegment(text: string): string {
-  return text.replace(XML_TAG_ESCAPE_RE, (tag, rawName: string) => {
-    const name = rawName.toLowerCase();
-    if (
-      KNOWN_HTML_TAGS.has(name) ||
-      name === "bash-input" ||
-      name === "bash-stdout" ||
-      name === "bash-stderr"
-    ) {
-      return tag;
-    }
-    return tag.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  });
+function isPreservedHtmlTag(name: string): boolean {
+  return (
+    KNOWN_HTML_TAGS.has(name) ||
+    name === "bash-input" ||
+    name === "bash-stdout" ||
+    name === "bash-stderr"
+  );
 }
 
-function collectProtectedRanges(
-  text: string,
-  patterns: RegExp[],
-): ProtectedRange[] {
-  const matches: ProtectedRange[] = [];
-
-  for (const pattern of patterns) {
-    const re = new RegExp(pattern.source, pattern.flags);
-    let match: RegExpExecArray | null;
-    while ((match = re.exec(text)) !== null) {
-      const raw = match[0];
-      if (!raw) {
-        re.lastIndex += 1;
-        continue;
-      }
-      matches.push({
-        start: match.index,
-        end: match.index + raw.length,
-      });
-    }
-  }
-
-  matches.sort((a, b) => a.start - b.start || b.end - a.end);
-
-  const merged: ProtectedRange[] = [];
-  for (const match of matches) {
-    const last = merged[merged.length - 1];
-    if (!last || match.start >= last.end) {
-      merged.push(match);
-      continue;
-    }
-    if (match.end > last.end) {
-      last.end = match.end;
-    }
-  }
-
-  return merged;
+function escapeTagBrackets(text: string): string {
+  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function escapeCustomXmlTags(text: string): string {
-  const protectedRanges = collectProtectedRanges(text, [
-    BASH_WRAPPER_BLOCK_RE,
-    FENCED_CODE_BLOCK_RE,
-    INLINE_CODE_SPAN_RE,
-    AUTOLINK_RE,
-  ]);
+function isProtectedAutolink(raw: string): boolean {
+  const inner = raw.slice(1, -1);
+  return (
+    /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(inner) ||
+    /^mailto:/i.test(inner) ||
+    /^[^\s<>@]+@[^\s<>]+$/.test(inner)
+  );
+}
 
-  if (protectedRanges.length === 0) {
-    return escapeCustomXmlTagsSegment(text);
+function shouldEscapeCustomXmlLiteral(raw: string | undefined): boolean {
+  if (!raw || isProtectedAutolink(raw)) {
+    return false;
   }
 
-  let cursor = 0;
-  let result = "";
-
-  for (const range of protectedRanges) {
-    if (cursor < range.start) {
-      result += escapeCustomXmlTagsSegment(
-        text.slice(cursor, range.start),
-      );
-    }
-    result += text.slice(range.start, range.end);
-    cursor = range.end;
+  const match = XML_TAG_ESCAPE_RE.exec(raw);
+  XML_TAG_ESCAPE_RE.lastIndex = 0;
+  if (!match) {
+    return false;
   }
 
-  if (cursor < text.length) {
-    result += escapeCustomXmlTagsSegment(text.slice(cursor));
+  const name = match[1]?.toLowerCase() ?? "";
+  return !isPreservedHtmlTag(name);
+}
+
+function toEscapedTextToken(raw: string): MarkdownToken {
+  return {
+    type: "text",
+    raw,
+    text: escapeTagBrackets(raw),
+    escaped: true,
+  };
+}
+
+function isMarkdownToken(value: unknown): value is MarkdownToken {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "type" in (value as Record<string, unknown>),
+  );
+}
+
+function escapeTokenValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => escapeTokenValue(entry));
+  }
+  if (isMarkdownToken(value)) {
+    return escapeCustomXmlToken(value);
+  }
+  return value;
+}
+
+function escapeCustomXmlToken(token: MarkdownToken): MarkdownToken {
+  if (
+    (token.type === "html" || token.type === "link") &&
+    shouldEscapeCustomXmlLiteral(token.raw)
+  ) {
+    return toEscapedTextToken(token.raw!);
   }
 
-  return result;
+  const next: MarkdownToken = { ...token };
+  for (const [key, value] of Object.entries(next)) {
+    next[key] = escapeTokenValue(value);
+  }
+
+  return next;
+}
+
+function escapeCustomXmlTokens(tokens: MarkdownToken[]): MarkdownToken[] {
+  return tokens.map((token) => escapeCustomXmlToken(token));
+}
+
+function escapeCustomXmlTags(text: string): MarkdownToken[] {
+  const tokens = parser.lexer(text.trimEnd()) as MarkdownToken[];
+  return escapeCustomXmlTokens(tokens);
 }
 
 export function renderMarkdown(text: string): string {
@@ -296,10 +290,7 @@ export function renderMarkdown(text: string): string {
   if (cached !== undefined) return cached;
 
   const resolved = escapeCustomXmlTags(resolveAssetURLs(text));
-
-  // Trim trailing whitespace — with breaks:true, trailing
-  // newlines become <br> tags that add invisible height.
-  const html = parser.parse(resolved.trimEnd()) as string;
+  const html = parser.parser(resolved) as string;
   const safe = DOMPurify.sanitize(html);
 
   cache.set(text, safe);

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -118,6 +118,18 @@ const KNOWN_HTML_TAGS = new Set([
 ]);
 
 const XML_TAG_ESCAPE_RE = /<\/?([A-Za-z][A-Za-z0-9:_-]*)(?:"[^"]*"|'[^']*'|[^"'<>])*?>/g;
+const BASH_WRAPPER_BLOCK_RE =
+  /<bash-(input|stdout|stderr)>[\s\S]*?<\/bash-\1>/g;
+const FENCED_CODE_BLOCK_RE =
+  /(^|\n)(?: {0,3})(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n(?: {0,3})\2[ \t]*(?=\n|$)/g;
+const INLINE_CODE_SPAN_RE = /(`+)([\s\S]*?)\1/g;
+const AUTOLINK_RE =
+  /<(?:[A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\s]+|[^\s<>@]+@[^\s<>]+)>/g;
+
+type ProtectedRange = {
+  start: number;
+  end: number;
+};
 
 /** Build a marked tokenizer extension that consumes a Claude Code
  *  shell-shortcut wrapper tag and emits a `code` token directly.
@@ -191,7 +203,7 @@ function resolveAssetURLs(text: string): string {
   );
 }
 
-function escapeCustomXmlTags(text: string): string {
+function escapeCustomXmlTagsSegment(text: string): string {
   return text.replace(XML_TAG_ESCAPE_RE, (tag, rawName: string) => {
     const name = rawName.toLowerCase();
     if (
@@ -204,6 +216,77 @@ function escapeCustomXmlTags(text: string): string {
     }
     return tag.replace(/</g, "&lt;").replace(/>/g, "&gt;");
   });
+}
+
+function collectProtectedRanges(
+  text: string,
+  patterns: RegExp[],
+): ProtectedRange[] {
+  const matches: ProtectedRange[] = [];
+
+  for (const pattern of patterns) {
+    const re = new RegExp(pattern.source, pattern.flags);
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text)) !== null) {
+      const raw = match[0];
+      if (!raw) {
+        re.lastIndex += 1;
+        continue;
+      }
+      matches.push({
+        start: match.index,
+        end: match.index + raw.length,
+      });
+    }
+  }
+
+  matches.sort((a, b) => a.start - b.start || b.end - a.end);
+
+  const merged: ProtectedRange[] = [];
+  for (const match of matches) {
+    const last = merged[merged.length - 1];
+    if (!last || match.start >= last.end) {
+      merged.push(match);
+      continue;
+    }
+    if (match.end > last.end) {
+      last.end = match.end;
+    }
+  }
+
+  return merged;
+}
+
+function escapeCustomXmlTags(text: string): string {
+  const protectedRanges = collectProtectedRanges(text, [
+    BASH_WRAPPER_BLOCK_RE,
+    FENCED_CODE_BLOCK_RE,
+    INLINE_CODE_SPAN_RE,
+    AUTOLINK_RE,
+  ]);
+
+  if (protectedRanges.length === 0) {
+    return escapeCustomXmlTagsSegment(text);
+  }
+
+  let cursor = 0;
+  let result = "";
+
+  for (const range of protectedRanges) {
+    if (cursor < range.start) {
+      result += escapeCustomXmlTagsSegment(
+        text.slice(cursor, range.start),
+      );
+    }
+    result += text.slice(range.start, range.end);
+    cursor = range.end;
+  }
+
+  if (cursor < text.length) {
+    result += escapeCustomXmlTagsSegment(text.slice(cursor));
+  }
+
+  return result;
 }
 
 export function renderMarkdown(text: string): string {

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -253,8 +253,13 @@ function escapeTokenValue(value: unknown): unknown {
 }
 
 function escapeCustomXmlToken(token: MarkdownToken): MarkdownToken {
+  if (token.type === "html" && shouldEscapeCustomXmlLiteral(token.raw)) {
+    return toEscapedTextToken(token.raw!);
+  }
+
   if (
-    (token.type === "html" || token.type === "link") &&
+    token.type === "link" &&
+    token.raw?.startsWith("<") &&
     shouldEscapeCustomXmlLiteral(token.raw)
   ) {
     return toEscapedTextToken(token.raw!);

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { Marked, type TokenizerExtension } from "marked";
+import { Marked, type Token, type TokenizerExtension } from "marked";
 import DOMPurify from "dompurify";
 import { LRUCache } from "./cache.js";
 
@@ -119,13 +119,7 @@ const KNOWN_HTML_TAGS = new Set([
 
 const XML_TAG_ESCAPE_RE = /<\/?([A-Za-z][A-Za-z0-9:_-]*)(?:"[^"]*"|'[^']*'|[^"'<>])*?>/g;
 
-type MarkdownToken = {
-  type: string;
-  raw?: string;
-  text?: string;
-  escaped?: boolean;
-  [key: string]: unknown;
-};
+type MarkdownToken = Token & Record<string, unknown>;
 
 /** Build a marked tokenizer extension that consumes a Claude Code
  *  shell-shortcut wrapper tag and emits a `code` token directly.


### PR DESCRIPTION
## Summary
- escape non-HTML XML-style prompt tags before markdown parsing
- keep real HTML tags and the existing bash pseudo-tags on the current sanitize/render path
- add coverage for literal XML prompt tags and sanitized HTML

Closes https://github.com/kenn-io/agentsview/issues/336

## Testing
- npm test -- markdown.test.ts
