### PR TITLE
fix(server): avoid fixed-port race in server tests

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -801,6 +801,27 @@ func localInterfaceIPs() map[string]bool {
 // ListenAndServe starts the HTTP server.
 func (s *Server) ListenAndServe() error {
 	addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
+	listenCtx := context.Background()
+	if s.baseCtx != nil {
+		listenCtx = s.baseCtx
+	}
+	ln, err := daemon.Listen(
+		listenCtx,
+		daemon.Endpoint{
+			Network: daemon.NetworkTCP,
+			Address: addr,
+		},
+		daemon.WithRuntimeStore(daemon.RuntimeStore{Dir: s.dataDir}),
+	)
+	if err != nil {
+		return err
+	}
+	return s.Serve(ln)
+}
+
+// Serve starts the HTTP server on an existing listener.
+func (s *Server) Serve(ln net.Listener) error {
+	addr := ln.Addr().String()
 	srv := &http.Server{
 		Addr:        addr,
 		Handler:     s.Handler(),
@@ -817,22 +838,6 @@ func (s *Server) ListenAndServe() error {
 	s.httpSrv = srv
 	s.mu.Unlock()
 	log.Printf("Starting server at http://%s", addr)
-
-	listenCtx := context.Background()
-	if s.baseCtx != nil {
-		listenCtx = s.baseCtx
-	}
-	ln, err := daemon.Listen(
-		listenCtx,
-		daemon.Endpoint{
-			Network: daemon.NetworkTCP,
-			Address: addr,
-		},
-		daemon.WithRuntimeStore(daemon.RuntimeStore{Dir: s.dataDir}),
-	)
-	if err != nil {
-		return err
-	}
 	return srv.Serve(ln)
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	stdlibsync "sync"
 	"testing"
@@ -345,13 +346,15 @@ func hostLiteral(host string) string {
 // base URL. The server is shut down when the test finishes.
 func (te *testEnv) listenAndServe(t *testing.T) string {
 	t.Helper()
-	port := server.FindAvailablePort("127.0.0.1", 40000)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
 	te.srv.SetPort(port)
 
 	var serveErr error
 	done := make(chan struct{})
 	go func() {
-		serveErr = te.srv.ListenAndServe()
+		serveErr = te.srv.Serve(ln)
 		close(done)
 	}()
 
@@ -389,6 +392,49 @@ func (te *testEnv) listenAndServe(t *testing.T) string {
 	})
 
 	return fmt.Sprintf("http://127.0.0.1:%d", port)
+}
+
+func TestListenAndServeUsesAvailablePortOutsideFixedRange(t *testing.T) {
+	listeners := make([]net.Listener, 0, 100)
+	for port := 40000; port < 40100; port++ {
+		addr := fmt.Sprintf("127.0.0.1:%d", port)
+		ln, err := net.Listen("tcp", addr)
+		if err == nil {
+			listeners = append(listeners, ln)
+			continue
+		}
+
+		conn, dialErr := net.DialTimeout(
+			"tcp", addr, 50*time.Millisecond,
+		)
+		if dialErr != nil {
+			for _, ln := range listeners {
+				require.NoError(t, ln.Close())
+			}
+			t.Skipf("port %d is neither bindable nor reachable: %v", port, err)
+		}
+		require.NoError(t, conn.Close())
+	}
+	t.Cleanup(func() {
+		for _, ln := range listeners {
+			require.NoError(t, ln.Close())
+		}
+	})
+
+	te := setup(t)
+	baseURL := te.listenAndServe(t)
+	parsedBaseURL, err := url.Parse(baseURL)
+	require.NoError(t, err)
+	_, portText, err := net.SplitHostPort(parsedBaseURL.Host)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	require.False(t, port >= 40000 && port < 40100)
+
+	resp, err := http.Get(baseURL + "/api/v1/version")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func (te *testEnv) seedSession(


### PR DESCRIPTION
The Ubuntu CI job on main failed because the real-server test helper selected a port by probing the fixed 40000 range, closing that probe listener, and then starting the server later. That left the test exposed to runner port contention and could make TestServerTimeouts fail before it reached the timeout behavior it was meant to exercise.

This changes the helper path to reserve an OS-assigned loopback listener until the HTTP server takes over, while preserving the same server shutdown path through a shared Serve entry point. A regression test keeps the old fixed range occupied so future changes do not reintroduce the same bind race.