### PR TITLE
fix(postgres): scope filtered push watermarks

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -578,7 +578,7 @@ func newPGPushCommand() *cobra.Command {
 }
 
 func newPGStatusCommand() *cobra.Command {
-	var allTargets bool
+	var cfg PGStatusConfig
 	cmd := &cobra.Command{
 		Use:          "status [target]",
 		Short:        "Show PG sync status",
@@ -589,13 +589,16 @@ func newPGStatusCommand() *cobra.Command {
 			if len(args) == 1 {
 				targetName = args[0]
 			}
-			if err := runPGStatus(targetName, allTargets); err != nil {
+			if err := runPGStatus(targetName, cfg); err != nil {
 				return fmt.Errorf("pg status: %w", err)
 			}
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&allTargets, "all", false, "Show status for every configured PG target")
+	cmd.Flags().BoolVar(&cfg.AllTargets, "all", false, "Show status for every configured PG target")
+	cmd.Flags().StringVar(&cfg.ProjectsFlag, "projects", "", "Comma-separated list of projects whose push status to show")
+	cmd.Flags().StringVar(&cfg.ExcludeProjects, "exclude-projects", "", "Comma-separated list of excluded projects whose push status to show")
+	cmd.Flags().BoolVar(&cfg.AllProjects, "all-projects", false, "Ignore configured project filters for this status")
 	return cmd
 }
 

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -85,6 +85,18 @@ func TestDuckDBPushHelpShowsProjectFlags(t *testing.T) {
 	}
 }
 
+func TestPGStatusHelpShowsProjectFlags(t *testing.T) {
+	help, err := executeCommand(newRootCommand(), "pg", "status", "--help")
+	require.NoError(t, err, "Execute")
+	for _, want := range []string{
+		"--projects",
+		"--exclude-projects",
+		"--all-projects",
+	} {
+		assert.Contains(t, help, want)
+	}
+}
+
 func TestDuckDBQuackServeHelpShowsSafetyFlags(t *testing.T) {
 	help, err := executeCommand(newRootCommand(), "duckdb", "quack", "serve", "--help")
 	require.NoError(t, err, "Execute")

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -298,6 +298,8 @@ func runPGStatusTarget(
 		lastPush, err = postgres.ReadLastPushAt(
 			database,
 			target.SyncStateTarget,
+			target.PG.Projects,
+			target.PG.ExcludeProjects,
 			target.MigrateLegacySyncState,
 		)
 		if err != nil {

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -30,6 +30,13 @@ type PGPushConfig struct {
 	Interval        time.Duration
 }
 
+type PGStatusConfig struct {
+	AllTargets      bool
+	ProjectsFlag    string
+	ExcludeProjects string
+	AllProjects     bool
+}
+
 type pgTargetSelection struct {
 	Name                   string
 	PG                     config.PGConfig
@@ -209,10 +216,7 @@ func writePGPushSummary(w io.Writer, result postgres.PushResult) {
 	)
 }
 
-func runPGStatus(
-	targetName string,
-	allTargets bool,
-) error {
+func runPGStatus(targetName string, cfg PGStatusConfig) error {
 	appCfg, err := config.LoadMinimal()
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
@@ -223,7 +227,7 @@ func runPGStatus(
 	setupLogFile(appCfg.DataDir)
 
 	targets, err := resolvePGTargetSelections(
-		appCfg, targetName, allTargets,
+		appCfg, targetName, cfg.AllTargets,
 	)
 	if err != nil {
 		return err
@@ -250,7 +254,7 @@ func runPGStatus(
 			}
 			fmt.Printf("Target: %s\n", target.label())
 		}
-		if err := runPGStatusTarget(database, appCfg, target); err != nil {
+		if err := runPGStatusTarget(database, appCfg, target, cfg); err != nil {
 			if len(targets) == 1 {
 				return err
 			}
@@ -279,6 +283,7 @@ func runPGStatusTarget(
 	database *db.DB,
 	appCfg config.Config,
 	target pgTargetSelection,
+	cfg PGStatusConfig,
 ) error {
 	target, err := resolvePGTargetConfig(appCfg, target)
 	if err != nil {
@@ -286,6 +291,17 @@ func runPGStatusTarget(
 	}
 	if target.PG.URL == "" {
 		return fmt.Errorf("url not configured")
+	}
+	projects, excludeProjects, err := resolvePushProjects(
+		target.PG,
+		PGPushConfig{
+			ProjectsFlag:    cfg.ProjectsFlag,
+			ExcludeProjects: cfg.ExcludeProjects,
+			AllProjects:     cfg.AllProjects,
+		},
+	)
+	if err != nil {
+		return err
 	}
 
 	ctx, stop := signal.NotifyContext(
@@ -298,8 +314,8 @@ func runPGStatusTarget(
 		lastPush, err = postgres.ReadLastPushAt(
 			database,
 			target.SyncStateTarget,
-			target.PG.Projects,
-			target.PG.ExcludeProjects,
+			projects,
+			excludeProjects,
 			target.MigrateLegacySyncState,
 		)
 		if err != nil {

--- a/cmd/agentsview/pg_service.go
+++ b/cmd/agentsview/pg_service.go
@@ -215,9 +215,15 @@ func readServiceLastPush(
 		return "", err
 	}
 	target := targets[0]
+	target, err = resolvePGTargetConfig(appCfg, target)
+	if err != nil {
+		return "", err
+	}
 	return postgres.ReadLastPushAt(
 		database,
 		target.SyncStateTarget,
+		target.PG.Projects,
+		target.PG.ExcludeProjects,
 		target.MigrateLegacySyncState,
 	)
 }

--- a/cmd/agentsview/pg_test.go
+++ b/cmd/agentsview/pg_test.go
@@ -187,7 +187,7 @@ machine_name = "workbox"
 url = "postgres://archive"
 `)
 
-	err := runPGStatus("archive", false)
+	err := runPGStatus("archive", PGStatusConfig{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pg connection to archive permits plaintext")
 	assert.Contains(t, err.Error(), "allow_insecure = true under [pg] or [pg.NAME]")
@@ -213,7 +213,7 @@ url = "postgres://archive"
 		0o600,
 	))
 
-	err := runPGStatus("archive", false)
+	err := runPGStatus("archive", PGStatusConfig{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pg connection to archive permits plaintext")
 	assert.Contains(t, err.Error(), "allow_insecure = true under [pg] or [pg.NAME]")
@@ -266,7 +266,7 @@ machine_name = "workbox"
 url = "postgres://archive"
 `)
 
-	err := runPGStatus("", true)
+	err := runPGStatus("", PGStatusConfig{AllTargets: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "2 pg target(s) failed")
 	assert.Contains(t, err.Error(), "work (default): expanding url: environment variable(s) not set: BROKEN_WORK_TARGET")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -461,8 +461,15 @@ for details on how filtering interacts with the push watermark.
 Show PostgreSQL sync status.
 
 ```bash
-agentsview pg status [target] [--all]
+agentsview pg status [target] [flags]
 ```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--all` | `false` | Show status for every configured PostgreSQL target |
+| `--projects` | | Comma-separated projects whose push status to show |
+| `--exclude-projects` | | Comma-separated excluded projects whose push status to show |
+| `--all-projects` | `false` | Ignore configured project filters for this status |
 
 ---
 

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -232,13 +232,18 @@ filter).
 Show the current sync state.
 
 ```bash
-agentsview pg status [target]
+agentsview pg status [target] [flags]
 agentsview pg status --all
+agentsview pg status --projects alpha,beta
 ```
 
 Without a target name, `pg status` uses the effective default target.
 Pass one named target explicitly to inspect that destination, or use
 `--all` to print every configured target sequentially.
+
+Use the same `--projects`, `--exclude-projects`, or `--all-projects`
+filter flags as `pg push` to inspect the matching filtered or
+unfiltered watermark.
 
 Output:
 

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -189,12 +189,17 @@ CLI flags override config values. Use
 [`agentsview projects`](/commands/#agentsview-projects) to list
 available project names.
 
-!!! warning
-    Filtered pushes do not advance the global push watermark
-    because it covers all projects. This means the query window
-    for subsequent filtered pushes grows over time. Run an
-    unfiltered `pg push` (or `pg push --all-projects`)
-    periodically to reset the watermark.
+Filtered pushes keep their own local push watermark for each
+target/filter set. For example, repeated
+`agentsview pg push --projects alpha,beta` runs use a different
+watermark from unfiltered pushes and from
+`agentsview pg push --projects gamma`. This keeps allow-list pushes
+incremental without advancing the unfiltered/global cursor.
+
+After upgrading from an older version, the first filtered push for a
+given project set may still scan the matching local sessions once to
+seed that scoped watermark. Later pushes with the same filter set use
+the scoped watermark.
 
 #### Curation Metadata
 

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -422,6 +422,11 @@ func (s *Sync) Push(
 // pgPushMarkerMachineState reports whether this host's push marker is present
 // in PG and returns the current machine plus legacy machine aliases stored with
 // the marker.
+//
+// Scoped marker keys are authoritative for reset detection. If a scoped marker
+// is missing, legacy unscoped marker metadata is still returned as alias
+// history so ownerless rows from older agentsview versions can be adopted after
+// a machine rename.
 // A missing marker while the local watermark is set means PG was reset (schema
 // dropped or recreated) since this host last pushed, so a full re-push is
 // needed. Counting rows by machine cannot detect this reliably: another host
@@ -432,36 +437,78 @@ func (s *Sync) Push(
 func (s *Sync) pgPushMarkerMachineState(
 	ctx context.Context, markerID string,
 ) (string, []string, bool, error) {
-	var machine string
-	err := s.pg.QueryRowContext(ctx,
-		`SELECT value FROM sync_metadata WHERE key = $1`,
-		s.pushMarkerMetadataKey(pushMarkerKeyPrefix, markerID),
-	).Scan(&machine)
+	markerKey := s.pushMarkerMetadataKey(pushMarkerKeyPrefix, markerID)
+	machine, markerExists, err := s.pgPushMarkerMetadataValue(
+		ctx, markerKey,
+	)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return "", nil, false, nil
-		}
-		if isUndefinedTable(err) {
-			return "", nil, false, nil
-		}
 		return "", nil, false, fmt.Errorf(
 			"checking pg push marker: %w", err,
 		)
 	}
-	aliases, err := s.pgPushMarkerMachineAliases(ctx, markerID)
+	if markerExists {
+		aliases, err := s.pgPushMarkerMachineAliases(
+			ctx,
+			s.pushMarkerMetadataKey(
+				pushMarkerMachineAliasesKeyPrefix, markerID,
+			),
+		)
+		if err != nil {
+			return "", nil, false, err
+		}
+		return machine, aliases, true, nil
+	}
+	if s.syncStateTarget == "" {
+		return "", nil, false, nil
+	}
+
+	legacyMachine, legacyMarkerExists, err := s.pgPushMarkerMetadataValue(
+		ctx, pushMarkerKeyPrefix+markerID,
+	)
+	if err != nil {
+		return "", nil, false, fmt.Errorf(
+			"checking legacy pg push marker: %w", err,
+		)
+	}
+	aliases, err := s.pgPushMarkerMachineAliases(
+		ctx, pushMarkerMachineAliasesKeyPrefix+markerID,
+	)
 	if err != nil {
 		return "", nil, false, err
 	}
-	return machine, aliases, true, nil
+	if !legacyMarkerExists && len(aliases) == 0 {
+		return "", nil, false, nil
+	}
+	return legacyMachine, aliases, false, nil
+}
+
+func (s *Sync) pgPushMarkerMetadataValue(
+	ctx context.Context, key string,
+) (string, bool, error) {
+	var value string
+	err := s.pg.QueryRowContext(ctx,
+		`SELECT value FROM sync_metadata WHERE key = $1`,
+		key,
+	).Scan(&value)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, nil
+		}
+		if isUndefinedTable(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return value, true, nil
 }
 
 func (s *Sync) pgPushMarkerMachineAliases(
-	ctx context.Context, markerID string,
+	ctx context.Context, key string,
 ) ([]string, error) {
 	var raw string
 	err := s.pg.QueryRowContext(ctx,
 		`SELECT value FROM sync_metadata WHERE key = $1`,
-		s.pushMarkerMetadataKey(pushMarkerMachineAliasesKeyPrefix, markerID),
+		key,
 	).Scan(&raw)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -285,19 +285,13 @@ func (s *Sync) Push(
 
 	if len(sessions) == 0 {
 		if s.isFiltered() {
-			// Filtered pushes must not advance the global
-			// watermark but should still update fingerprints
-			// so repeated filtered runs stay incremental.
-			// Use cutoff as the boundary key when lastPush
-			// is empty (--full/PG reset) so that the next
-			// filtered run can match fingerprints.
-			boundaryKey := lastPush
-			if boundaryKey == "" {
-				boundaryKey = cutoff
-			}
-			if err := writePushBoundaryState(
-				state, boundaryKey, sessions,
+			// Filtered pushes use filter-scoped sync state, so
+			// they can advance their own watermark without
+			// moving the unfiltered/global cursor.
+			if err := finalizeFilteredPushState(
+				state, lastPush, cutoff, sessions,
 				priorFingerprints, sessionFingerprints,
+				result.Errors,
 			); err != nil {
 				return result, err
 			}
@@ -373,21 +367,13 @@ func (s *Sync) Push(
 	}
 
 	if s.isFiltered() {
-		// Filtered pushes update fingerprints for pushed
-		// sessions so subsequent filtered runs stay
-		// incremental, but do not advance the global
-		// watermark past sessions from other projects.
-		// Use cutoff as the boundary key when lastPush is
-		// empty (--full/PG reset) so the next filtered
-		// run can match fingerprints instead of
-		// re-pushing everything.
-		boundaryKey := lastPush
-		if boundaryKey == "" {
-			boundaryKey = cutoff
-		}
-		if err := writePushBoundaryState(
-			state, boundaryKey, pushed,
+		// Filtered pushes use filter-scoped sync state, so
+		// they can advance their own watermark without moving
+		// the unfiltered/global cursor.
+		if err := finalizeFilteredPushState(
+			state, lastPush, cutoff, pushed,
 			priorFingerprints, sessionFingerprints,
+			result.Errors,
 		); err != nil {
 			return result, err
 		}
@@ -783,11 +769,28 @@ func finalizePushState(
 	)
 }
 
-// clearPushState resets the watermark and boundary state so that
-// the next push starts from scratch. Used when a filtered push
-// runs --full or detects a PG reset, to avoid leaving stale
-// state that would cause the next unfiltered push to skip
-// sessions.
+func finalizeFilteredPushState(
+	local syncStateStore,
+	lastPush, cutoff string,
+	sessions []db.Session,
+	priorFingerprints map[string]string,
+	sessionFingerprints map[string]string,
+	errors int,
+) error {
+	finalizeCutoff := cutoff
+	var mergedFingerprints map[string]string
+	if errors > 0 {
+		finalizeCutoff = lastPush
+		mergedFingerprints = priorFingerprints
+	}
+	return finalizePushState(
+		local, finalizeCutoff, sessions,
+		mergedFingerprints, sessionFingerprints,
+	)
+}
+
+// clearPushState resets the active watermark and boundary state so
+// that the next push for this sync-state scope starts from scratch.
 func clearPushState(local syncStateStore) error {
 	if err := local.SetSyncState(
 		lastPushBoundaryStateKey, "",

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -153,14 +153,17 @@ func (s *Sync) Push(
 		}
 	}
 
-	// Coherence check: if the local watermark says we've pushed
-	// before but this host's push marker is gone from PG, the PG side
-	// was reset (schema dropped, DB recreated, etc.). Force a full
-	// push so all sessions are re-synced.
-	if lastPush != "" {
+	// Coherence check: if local push state says we've pushed before
+	// but this host's push marker is gone from PG, the PG side was
+	// reset (schema dropped, DB recreated, etc.). Force a full push
+	// so fingerprint-matched sessions are not skipped while missing
+	// from PG. Boundary state counts here too: a partial first push
+	// can leave last_push_at empty while still caching fingerprints
+	// for successfully pushed sessions.
+	if lastPush != "" || boundaryState != "" {
 		if !markerExists {
 			log.Printf(
-				"pgsync: local watermark set but PG push marker " +
+				"pgsync: local push state set but PG push marker " +
 					"missing; PG was reset, forcing full push",
 			)
 			lastPush = ""

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -168,7 +168,9 @@ func (s *Sync) Push(
 			)
 			lastPush = ""
 			full = true
-			legacyMarkerMachines = nil
+			if len(legacyMarkerMachines) == 0 {
+				legacyMarkerMachines = nil
+			}
 			s.schemaMu.Lock()
 			s.schemaDone = false
 			s.schemaMu.Unlock()
@@ -512,6 +514,9 @@ func (s *Sync) pgPushMarkerMachineAliases(
 	).Scan(&raw)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		if isUndefinedTable(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -25,8 +25,8 @@ const (
 )
 
 // pushMarkerIDStateKey names the local sync-state entry holding this DB's
-// stable push-marker identifier. pushMarkerKeyPrefix prefixes that identifier
-// to form the PG sync_metadata key under which the marker row is stored.
+// stable push-marker identifier. The push-marker prefixes form PG
+// sync_metadata keys for reset-detection marker rows.
 const (
 	pushMarkerIDStateKey              = "pg_push_marker_id"
 	pushMarkerKeyPrefix               = "push_marker:"
@@ -432,7 +432,7 @@ func (s *Sync) pgPushMarkerMachineState(
 	var machine string
 	err := s.pg.QueryRowContext(ctx,
 		`SELECT value FROM sync_metadata WHERE key = $1`,
-		pushMarkerKeyPrefix+markerID,
+		s.pushMarkerMetadataKey(pushMarkerKeyPrefix, markerID),
 	).Scan(&machine)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -458,7 +458,7 @@ func (s *Sync) pgPushMarkerMachineAliases(
 	var raw string
 	err := s.pg.QueryRowContext(ctx,
 		`SELECT value FROM sync_metadata WHERE key = $1`,
-		pushMarkerMachineAliasesKeyPrefix+markerID,
+		s.pushMarkerMetadataKey(pushMarkerMachineAliasesKeyPrefix, markerID),
 	).Scan(&raw)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -503,7 +503,7 @@ func (s *Sync) writePushMarker(
 		`INSERT INTO sync_metadata (key, value)
 		 VALUES ($1, $2)
 		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
-		pushMarkerKeyPrefix+markerID, s.machine,
+		s.pushMarkerMetadataKey(pushMarkerKeyPrefix, markerID), s.machine,
 	); err != nil {
 		_ = tx.Rollback()
 		return fmt.Errorf("writing pg push marker: %w", err)
@@ -512,7 +512,8 @@ func (s *Sync) writePushMarker(
 		`INSERT INTO sync_metadata (key, value)
 		 VALUES ($1, $2)
 		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
-		pushMarkerMachineAliasesKeyPrefix+markerID, string(aliasesJSON),
+		s.pushMarkerMetadataKey(pushMarkerMachineAliasesKeyPrefix, markerID),
+		string(aliasesJSON),
 	); err != nil {
 		_ = tx.Rollback()
 		return fmt.Errorf("writing pg push marker machine aliases: %w", err)
@@ -521,6 +522,14 @@ func (s *Sync) writePushMarker(
 		return fmt.Errorf("committing pg push marker: %w", err)
 	}
 	return nil
+}
+
+func (s *Sync) pushMarkerMetadataKey(prefix, markerID string) string {
+	if s.syncStateTarget == "" {
+		return prefix + markerID
+	}
+	sum := sha256.Sum256([]byte(s.syncStateTarget))
+	return prefix + markerID + ":scope:" + hex.EncodeToString(sum[:8])
 }
 
 func pushMarkerLegacyMachines(machine string, aliases []string) []string {

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -1396,6 +1396,9 @@ func TestFilteredPushAdoptsOwnerlessRowsFromLegacyUnscopedMarker(t *testing.T) {
 		syncStateTarget: scope,
 		projects:        projects,
 	}
+	require.NoError(t, sync.effectiveSyncState().SetSyncState(
+		"last_push_at", "2025-12-31T00:00:00.000Z",
+	), "seed scoped local push state")
 
 	const sessID = "legacy-filtered-previous-machine-1"
 	require.NoError(t, localDB.UpsertSession(db.Session{
@@ -1426,7 +1429,7 @@ func TestFilteredPushAdoptsOwnerlessRowsFromLegacyUnscopedMarker(t *testing.T) {
 	`, sessID, "host-a", "", "proj", "claude")
 	require.NoError(t, err, "seed ownerless legacy session")
 
-	res, err := sync.Push(ctx, true, nil)
+	res, err := sync.Push(ctx, false, nil)
 	require.NoError(t, err, "Push")
 	assert.Zero(t, res.Errors, "push should report no failed sessions")
 	assert.Zero(t, res.SkippedConflicts,

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -1363,6 +1363,101 @@ func TestPushAdoptsOwnerlessRowsFromPreviousMarkerMachine(t *testing.T) {
 	assert.Equal(t, markerID, ownerMarker)
 }
 
+func TestFilteredPushAdoptsOwnerlessRowsFromLegacyUnscopedMarker(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_filtered_legacy_marker_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	const markerID = "legacy-marker-filtered-1"
+	require.NoError(t, localDB.SetSyncState("pg_push_marker_id", markerID),
+		"seed local push marker")
+
+	projects := []string{"proj"}
+	scope := pushSyncStateScope("team-target", projects, nil)
+	sync := &Sync{
+		pg:              pg,
+		local:           localDB,
+		syncState:       newScopedSyncStateStore(localDB, scope, false),
+		machine:         "host-b",
+		schema:          schema,
+		schemaDone:      true,
+		syncStateTarget: scope,
+		projects:        projects,
+	}
+
+	const sessID = "legacy-filtered-previous-machine-1"
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:           sessID,
+		Project:      "proj",
+		Machine:      "host-b",
+		Agent:        "claude",
+		MessageCount: 1,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+	}), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     sessID,
+		Ordinal:       0,
+		Role:          "assistant",
+		Content:       "hello",
+		ContentLength: 5,
+	}}), "InsertMessages")
+
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sync_metadata (key, value)
+		VALUES ($1, $2)
+	`, pushMarkerKeyPrefix+markerID, "host-a")
+	require.NoError(t, err, "seed legacy unscoped marker machine")
+	_, err = pg.ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, owner_marker, project, agent, created_at
+		) VALUES ($1, $2, $3, $4, $5, NOW())
+	`, sessID, "host-a", "", "proj", "claude")
+	require.NoError(t, err, "seed ownerless legacy session")
+
+	res, err := sync.Push(ctx, true, nil)
+	require.NoError(t, err, "Push")
+	assert.Zero(t, res.Errors, "push should report no failed sessions")
+	assert.Zero(t, res.SkippedConflicts,
+		"legacy unscoped marker machine should be used as an alias")
+	assert.Equal(t, 1, res.SessionsPushed,
+		"legacy row should be counted as pushed")
+
+	var machine, ownerMarker string
+	require.NoError(t, pg.QueryRow(
+		`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sessID,
+	).Scan(&machine, &ownerMarker), "reading adopted row")
+	assert.Equal(t, "host-b", machine)
+	assert.Equal(t, markerID, ownerMarker)
+
+	var markerMachine string
+	require.NoError(t, pg.QueryRow(
+		`SELECT value FROM sync_metadata WHERE key = $1`,
+		sync.pushMarkerMetadataKey(pushMarkerKeyPrefix, markerID),
+	).Scan(&markerMachine), "reading scoped marker machine")
+	assert.Equal(t, "host-b", markerMachine)
+
+	var aliases string
+	require.NoError(t, pg.QueryRow(
+		`SELECT value FROM sync_metadata WHERE key = $1`,
+		sync.pushMarkerMetadataKey(
+			pushMarkerMachineAliasesKeyPrefix, markerID,
+		),
+	).Scan(&aliases), "reading scoped marker aliases")
+	assert.JSONEq(t, `["host-a"]`, aliases)
+}
+
 func TestPushReportsSkippedConflicts(t *testing.T) {
 	pgURL := testPGURL(t)
 

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -464,6 +464,50 @@ func TestFinalizePushStatePersistsEmptyBoundary(
 	assert.Empty(t, state.Fingerprints)
 }
 
+func TestFinalizeFilteredPushStateAdvancesScopedWatermark(
+	t *testing.T,
+) {
+	const cutoff = "2026-03-11T12:34:56.123Z"
+
+	store := &syncStateStoreStub{}
+	require.NoError(t, finalizeFilteredPushState(
+		store, "", cutoff, nil, nil, map[string]string{}, 0,
+	))
+	assert.Equal(t, cutoff, store.values["last_push_at"])
+
+	raw := store.values[lastPushBoundaryStateKey]
+	require.NotEmpty(t, raw, "last_push_boundary_state should be written")
+
+	var state pushBoundaryState
+	require.NoError(t, json.Unmarshal([]byte(raw), &state))
+	assert.Equal(t, cutoff, state.Cutoff)
+	assert.Empty(t, state.Fingerprints)
+}
+
+func TestFinalizeFilteredPushStateKeepsWatermarkOnErrors(
+	t *testing.T,
+) {
+	const lastPush = "2026-03-11T12:00:00.000Z"
+	const cutoff = "2026-03-11T12:34:56.123Z"
+
+	store := &syncStateStoreStub{}
+	require.NoError(t, finalizeFilteredPushState(
+		store, lastPush, cutoff, nil,
+		map[string]string{"sess-001": "fp-001"},
+		map[string]string{},
+		1,
+	))
+	assert.Equal(t, lastPush, store.values["last_push_at"])
+
+	raw := store.values[lastPushBoundaryStateKey]
+	require.NotEmpty(t, raw, "last_push_boundary_state should be written")
+
+	var state pushBoundaryState
+	require.NoError(t, json.Unmarshal([]byte(raw), &state))
+	assert.Equal(t, lastPush, state.Cutoff)
+	assert.Equal(t, "fp-001", state.Fingerprints["sess-001"])
+}
+
 func TestPushTargetState(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -216,6 +216,12 @@ func New(
 	if local == nil {
 		return nil, fmt.Errorf("local db is required")
 	}
+	if err := ValidateProjectFilters(
+		opts.Projects,
+		opts.ExcludeProjects,
+	); err != nil {
+		return nil, err
+	}
 
 	pg, err := Open(pgURL, schema, allowInsecure)
 	if err != nil {
@@ -258,6 +264,16 @@ func hasProjectFilter(projects, excludeProjects []string) bool {
 	return len(projects) > 0 || len(excludeProjects) > 0
 }
 
+// ValidateProjectFilters rejects ambiguous include/exclude project filters.
+func ValidateProjectFilters(projects, excludeProjects []string) error {
+	if len(projects) > 0 && len(excludeProjects) > 0 {
+		return fmt.Errorf(
+			"projects and exclude_projects are mutually exclusive",
+		)
+	}
+	return nil
+}
+
 func pushSyncStateScope(
 	target string,
 	projects, excludeProjects []string,
@@ -266,19 +282,20 @@ func pushSyncStateScope(
 		return target
 	}
 
-	kind := "include"
-	values := normalizeProjectFilterValues(projects)
-	if len(projects) == 0 {
-		kind = "exclude"
-		values = normalizeProjectFilterValues(excludeProjects)
-	}
+	includeValues := normalizeProjectFilterValues(projects)
+	excludeValues := normalizeProjectFilterValues(excludeProjects)
 
 	sum := sha256.New()
 	writeSyncScopeField(sum, "target")
 	writeSyncScopeField(sum, target)
-	writeSyncScopeField(sum, "kind")
-	writeSyncScopeField(sum, kind)
-	for _, value := range values {
+	writeSyncScopeField(sum, "include")
+	writeSyncScopeField(sum, fmt.Sprintf("%d", len(includeValues)))
+	for _, value := range includeValues {
+		writeSyncScopeField(sum, value)
+	}
+	writeSyncScopeField(sum, "exclude")
+	writeSyncScopeField(sum, fmt.Sprintf("%d", len(excludeValues)))
+	for _, value := range excludeValues {
 		writeSyncScopeField(sum, value)
 	}
 	fingerprint := hex.EncodeToString(sum.Sum(nil)[:8])

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -2,9 +2,12 @@ package postgres
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"sync"
 
@@ -225,29 +228,96 @@ func New(
 			"computing pg target fingerprint: %w", err,
 		)
 	}
+	syncStateScope := pushSyncStateScope(
+		opts.SyncStateTarget,
+		opts.Projects,
+		opts.ExcludeProjects,
+	)
+	migrateLegacySyncState := opts.MigrateLegacySyncState &&
+		!hasProjectFilter(opts.Projects, opts.ExcludeProjects)
 
 	return &Sync{
 		pg:    pg,
 		local: local,
 		syncState: newScopedSyncStateStore(
 			local,
-			opts.SyncStateTarget,
-			opts.MigrateLegacySyncState,
+			syncStateScope,
+			migrateLegacySyncState,
 		),
 		machine:                machine,
 		schema:                 schema,
 		targetFingerprint:      targetFingerprint,
-		syncStateTarget:        opts.SyncStateTarget,
-		migrateLegacySyncState: opts.MigrateLegacySyncState,
+		syncStateTarget:        syncStateScope,
+		migrateLegacySyncState: migrateLegacySyncState,
 		projects:               opts.Projects,
 		excludeProjects:        opts.ExcludeProjects,
 	}, nil
 }
 
+func hasProjectFilter(projects, excludeProjects []string) bool {
+	return len(projects) > 0 || len(excludeProjects) > 0
+}
+
+func pushSyncStateScope(
+	target string,
+	projects, excludeProjects []string,
+) string {
+	if !hasProjectFilter(projects, excludeProjects) {
+		return target
+	}
+
+	kind := "include"
+	values := normalizeProjectFilterValues(projects)
+	if len(projects) == 0 {
+		kind = "exclude"
+		values = normalizeProjectFilterValues(excludeProjects)
+	}
+
+	sum := sha256.New()
+	writeSyncScopeField(sum, "target")
+	writeSyncScopeField(sum, target)
+	writeSyncScopeField(sum, "kind")
+	writeSyncScopeField(sum, kind)
+	for _, value := range values {
+		writeSyncScopeField(sum, value)
+	}
+	fingerprint := hex.EncodeToString(sum.Sum(nil)[:8])
+	if target == "" {
+		return "project-filter:" + fingerprint
+	}
+	return target + ":project-filter:" + fingerprint
+}
+
+func normalizeProjectFilterValues(values []string) []string {
+	out := append([]string{}, values...)
+	sort.Strings(out)
+	return slicesCompact(out)
+}
+
+func slicesCompact(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	write := 1
+	for _, value := range values[1:] {
+		if value == values[write-1] {
+			continue
+		}
+		values[write] = value
+		write++
+	}
+	return values[:write]
+}
+
+func writeSyncScopeField(sum interface{ Write([]byte) (int, error) }, value string) {
+	_, _ = fmt.Fprintf(sum, "%d:", len(value))
+	_, _ = sum.Write([]byte(value))
+}
+
 // isFiltered reports whether push scope is restricted by
 // project include/exclude filters.
 func (s *Sync) isFiltered() bool {
-	return len(s.projects) > 0 || len(s.excludeProjects) > 0
+	return hasProjectFilter(s.projects, s.excludeProjects)
 }
 
 // DB returns the underlying PostgreSQL connection pool.
@@ -289,7 +359,8 @@ func (s *Sync) Status(
 	ctx context.Context,
 ) (SyncStatus, error) {
 	lastPush, err := ReadLastPushAt(
-		s.local, s.syncStateTarget, s.migrateLegacySyncState,
+		s.local, s.syncStateTarget, nil, nil,
+		s.migrateLegacySyncState,
 	)
 	if err != nil {
 		log.Printf(
@@ -379,24 +450,28 @@ func readStatus(
 func ReadLastPushAt(
 	local SyncStateStore,
 	target string,
+	projects, excludeProjects []string,
 	migrateLegacy bool,
 ) (string, error) {
 	if local == nil {
 		return "", fmt.Errorf("local sync state is required")
 	}
-	if target == "" {
+	scope := pushSyncStateScope(target, projects, excludeProjects)
+	if scope == "" {
 		return local.GetSyncState("last_push_at")
 	}
 	store := newScopedSyncStateStore(
 		local,
-		target,
+		scope,
 		false,
 	)
 	lastPush, err := store.GetSyncState("last_push_at")
 	if err != nil {
 		return "", err
 	}
-	if lastPush != "" || !migrateLegacy {
+	if lastPush != "" ||
+		!migrateLegacy ||
+		hasProjectFilter(projects, excludeProjects) {
 		return lastPush, nil
 	}
 	return local.GetSyncState("last_push_at")

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -1255,6 +1255,84 @@ func TestPushFilteredByProject(t *testing.T) {
 	assert.Equal(t, 0, r3.SessionsPushed)
 }
 
+func TestFilteredPushAfterResetDoesNotMaskUnfilteredResetRecovery(t *testing.T) {
+	pgURL := testPGURL(t)
+	const schema = "agentsview_filtered_reset_marker"
+	cleanNamedPGSchema(t, pgURL, schema)
+	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
+
+	local := testDB(t)
+	ctx := context.Background()
+
+	for _, s := range []db.Session{
+		{
+			ID: "reset-alpha", Project: "alpha",
+			Machine: "local", Agent: "claude",
+			CreatedAt:    "2026-03-11T12:00:00Z",
+			MessageCount: 1,
+		},
+		{
+			ID: "reset-beta", Project: "beta",
+			Machine: "local", Agent: "claude",
+			CreatedAt:    "2026-03-11T12:05:00Z",
+			MessageCount: 1,
+		},
+	} {
+		require.NoError(t, local.UpsertSession(s), "upsert %s", s.ID)
+		require.NoError(t, local.InsertMessages([]db.Message{{
+			SessionID: s.ID,
+			Ordinal:   0,
+			Role:      "user",
+			Content:   "msg " + s.ID,
+			Timestamp: s.CreatedAt,
+		}}), "insert message %s", s.ID)
+	}
+
+	unfiltered, err := New(
+		pgURL, schema, local,
+		"test-machine", true,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "creating unfiltered sync")
+	defer unfiltered.Close()
+
+	r1, err := unfiltered.Push(ctx, false, nil)
+	require.NoError(t, err, "initial unfiltered push")
+	require.Equal(t, 2, r1.SessionsPushed)
+
+	cleanNamedPGSchema(t, pgURL, schema)
+
+	filtered, err := New(
+		pgURL, schema, local,
+		"test-machine", true,
+		SyncOptions{Projects: []string{"alpha"}},
+	)
+	require.NoError(t, err, "creating filtered sync")
+	defer filtered.Close()
+
+	r2, err := filtered.Push(ctx, false, nil)
+	require.NoError(t, err, "filtered push after reset")
+	require.Equal(t, 1, r2.SessionsPushed)
+
+	unfilteredAfterReset, err := New(
+		pgURL, schema, local,
+		"test-machine", true,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "creating unfiltered sync after reset")
+	defer unfilteredAfterReset.Close()
+
+	_, err = unfilteredAfterReset.Push(ctx, false, nil)
+	require.NoError(t, err, "unfiltered push after filtered reset")
+
+	var count int
+	err = unfilteredAfterReset.DB().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sessions WHERE project IN ('alpha', 'beta')",
+	).Scan(&count)
+	require.NoError(t, err, "counting restored sessions")
+	assert.Equal(t, 2, count)
+}
+
 func TestPushExcludeProject(t *testing.T) {
 	pgURL := testPGURL(t)
 	cleanPGSchema(t, pgURL)

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -969,6 +969,43 @@ func TestPushFullAfterSchemaDropRecreatesSchema(
 	assert.Equal(t, 1, r2.SessionsPushed)
 }
 
+func TestScopedPushFullAfterSchemaDropRecreatesSchema(
+	t *testing.T,
+) {
+	pgURL := testPGURL(t)
+	const schema = "agentsview_scoped_full_drop"
+	cleanNamedPGSchema(t, pgURL, schema)
+	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
+
+	local := testDB(t)
+	ps, err := New(
+		pgURL, schema, local,
+		"test-machine", true,
+		SyncOptions{Projects: []string{"proj"}},
+	)
+	require.NoError(t, err, "creating sync")
+	ctx := context.Background()
+
+	sess := db.Session{
+		ID:        "sess-scoped-full-drop",
+		Project:   "proj",
+		Machine:   "test-machine",
+		Agent:     "claude",
+		CreatedAt: "2026-03-11T12:00:00.000Z",
+	}
+	require.NoError(t, local.UpsertSession(sess), "upsert session")
+
+	r1, err := ps.Push(ctx, false, nil)
+	require.NoError(t, err, "initial push")
+	require.Equal(t, 1, r1.SessionsPushed)
+
+	cleanNamedPGSchema(t, pgURL, schema)
+
+	r2, err := ps.Push(ctx, true, nil)
+	require.NoError(t, err, "scoped full push after drop")
+	assert.Equal(t, 1, r2.SessionsPushed)
+}
+
 func TestPushBatchesMultipleSessions(t *testing.T) {
 	pgURL := testPGURL(t)
 	cleanPGSchema(t, pgURL)

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -1333,6 +1333,100 @@ func TestFilteredPushAfterResetDoesNotMaskUnfilteredResetRecovery(t *testing.T) 
 	assert.Equal(t, 2, count)
 }
 
+func TestFilteredPartialPushDetectsResetWithEmptyWatermark(t *testing.T) {
+	pgURL := testPGURL(t)
+	const schema = "agentsview_filtered_partial_reset"
+	cleanNamedPGSchema(t, pgURL, schema)
+	t.Cleanup(func() { cleanNamedPGSchema(t, pgURL, schema) })
+
+	local := testDB(t)
+	ctx := context.Background()
+
+	for _, s := range []db.Session{
+		{
+			ID: "partial-good", Project: "alpha",
+			Machine: "local", Agent: "claude",
+			CreatedAt:    "2026-03-11T12:00:00Z",
+			MessageCount: 1,
+		},
+		{
+			ID: "partial-bad", Project: "alpha",
+			Machine: "local", Agent: "claude",
+			CreatedAt:    "2026-03-11T12:05:00Z",
+			MessageCount: 1,
+		},
+	} {
+		require.NoError(t, local.UpsertSession(s), "upsert %s", s.ID)
+		require.NoError(t, local.InsertMessages([]db.Message{{
+			SessionID: s.ID,
+			Ordinal:   0,
+			Role:      "user",
+			Content:   "msg " + s.ID,
+			Timestamp: s.CreatedAt,
+		}}), "insert message %s", s.ID)
+	}
+
+	filtered, err := New(
+		pgURL, schema, local,
+		"test-machine", true,
+		SyncOptions{Projects: []string{"alpha"}},
+	)
+	require.NoError(t, err, "creating filtered sync")
+	defer filtered.Close()
+	require.NoError(t, filtered.EnsureSchema(ctx), "ensure schema")
+
+	quotedSchema, err := quoteIdentifier(schema)
+	require.NoError(t, err, "quote schema")
+	_, err = filtered.DB().ExecContext(ctx, fmt.Sprintf(`
+		CREATE OR REPLACE FUNCTION %[1]s.fail_partial_bad()
+		RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			IF NEW.id = 'partial-bad' THEN
+				RAISE EXCEPTION 'forced partial push failure';
+			END IF;
+			RETURN NEW;
+		END;
+		$$;
+		CREATE TRIGGER fail_partial_bad
+		BEFORE INSERT OR UPDATE ON %[1]s.sessions
+		FOR EACH ROW EXECUTE FUNCTION %[1]s.fail_partial_bad();
+	`, quotedSchema))
+	require.NoError(t, err, "install partial failure trigger")
+
+	r1, err := filtered.Push(ctx, false, nil)
+	require.NoError(t, err, "initial partial filtered push")
+	require.Equal(t, 1, r1.SessionsPushed)
+	require.Equal(t, 1, r1.Errors)
+
+	scopedLastPush, err := filtered.effectiveSyncState().GetSyncState("last_push_at")
+	require.NoError(t, err, "reading scoped watermark")
+	require.Empty(t, scopedLastPush)
+	boundaryState, err := filtered.effectiveSyncState().GetSyncState(lastPushBoundaryStateKey)
+	require.NoError(t, err, "reading scoped boundary state")
+	require.NotEmpty(t, boundaryState)
+
+	cleanNamedPGSchema(t, pgURL, schema)
+
+	filteredAfterReset, err := New(
+		pgURL, schema, local,
+		"test-machine", true,
+		SyncOptions{Projects: []string{"alpha"}},
+	)
+	require.NoError(t, err, "creating filtered sync after reset")
+	defer filteredAfterReset.Close()
+
+	r2, err := filteredAfterReset.Push(ctx, false, nil)
+	require.NoError(t, err, "filtered push after reset")
+	require.Equal(t, 2, r2.SessionsPushed)
+
+	var count int
+	err = filteredAfterReset.DB().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sessions WHERE project = 'alpha'",
+	).Scan(&count)
+	require.NoError(t, err, "counting restored filtered sessions")
+	assert.Equal(t, 2, count)
+}
+
 func TestPushExcludeProject(t *testing.T) {
 	pgURL := testPGURL(t)
 	cleanPGSchema(t, pgURL)

--- a/internal/postgres/sync_test.go
+++ b/internal/postgres/sync_test.go
@@ -904,9 +904,15 @@ func TestPushDetectsPGTargetChangeAfterFilteredPush(t *testing.T) {
 
 	lastPush, err := local.GetSyncState("last_push_at")
 	require.NoError(t, err, "reading filtered watermark")
-	assert.Empty(t, lastPush, "filtered push should keep last_push_at empty")
+	assert.Empty(t, lastPush,
+		"filtered push should keep global last_push_at empty")
 
-	boundaryState, err := local.GetSyncState(lastPushBoundaryStateKey)
+	scopedLastPush, err := filteredA.effectiveSyncState().GetSyncState("last_push_at")
+	require.NoError(t, err, "reading filtered scoped watermark")
+	assert.NotEmpty(t, scopedLastPush,
+		"filtered push should advance scoped last_push_at")
+
+	boundaryState, err := filteredA.effectiveSyncState().GetSyncState(lastPushBoundaryStateKey)
 	require.NoError(t, err, "reading filtered boundary state")
 	require.NotEmpty(t, boundaryState,
 		"filtered push should persist boundary fingerprints")
@@ -1340,10 +1346,12 @@ func TestPushFilteredFullIsIncremental(t *testing.T) {
 	require.NoError(t, err, "reading watermark")
 	assert.Empty(t, wm, "watermark after filtered --full")
 
+	scopedWM, err := ps.effectiveSyncState().GetSyncState("last_push_at")
+	require.NoError(t, err, "reading scoped watermark")
+	assert.NotEmpty(t, scopedWM, "scoped watermark after filtered --full")
+
 	// Boundary fingerprints must have been written.
-	bs, err := local.GetSyncState(
-		"last_push_boundary_state",
-	)
+	bs, err := ps.effectiveSyncState().GetSyncState(lastPushBoundaryStateKey)
 	require.NoError(t, err, "reading boundary state")
 	require.NotEmpty(t, bs, "boundary state empty after filtered --full")
 

--- a/internal/postgres/sync_unit_test.go
+++ b/internal/postgres/sync_unit_test.go
@@ -161,6 +161,11 @@ func TestPushSyncStateScopeIncludesProjectFilters(t *testing.T) {
 		nil,
 		[]string{"alpha", "beta"},
 	)
+	includeAExcludeB := pushSyncStateScope(
+		"work",
+		[]string{"alpha"},
+		[]string{"beta"},
+	)
 	defaultIncludeAB := pushSyncStateScope(
 		"",
 		[]string{"alpha", "beta"},
@@ -171,7 +176,28 @@ func TestPushSyncStateScopeIncludesProjectFilters(t *testing.T) {
 	assert.NotEmpty(t, includeAB)
 	assert.NotEqual(t, "work", includeAB)
 	assert.NotEqual(t, includeAB, excludeAB)
+	assert.NotEqual(t, pushSyncStateScope("work", []string{"alpha"}, nil),
+		includeAExcludeB)
 	assert.NotEqual(t, includeAB, defaultIncludeAB)
+}
+
+func TestNewRejectsIncludeAndExcludeProjects(t *testing.T) {
+	local := testDB(t)
+
+	_, err := New(
+		"postgres://user:pass@127.0.0.1:1/db?sslmode=disable",
+		"agentsview",
+		local,
+		"test-machine",
+		true,
+		SyncOptions{
+			Projects:        []string{"alpha"},
+			ExcludeProjects: []string{"beta"},
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"projects and exclude_projects are mutually exclusive")
 }
 
 func TestReadLastPushAtUsesProjectFilterScope(t *testing.T) {

--- a/internal/postgres/sync_unit_test.go
+++ b/internal/postgres/sync_unit_test.go
@@ -141,3 +141,86 @@ func TestScopedSyncStateStoreLegacyModeUsesUnscopedKeys(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "2026-03-11T12:34:56.123Z", got)
 }
+
+func TestPushSyncStateScopeIncludesProjectFilters(t *testing.T) {
+	assert.Equal(t, "", pushSyncStateScope("", nil, nil))
+	assert.Equal(t, "work", pushSyncStateScope("work", nil, nil))
+
+	includeAB := pushSyncStateScope(
+		"work",
+		[]string{"beta", "alpha"},
+		nil,
+	)
+	includeBA := pushSyncStateScope(
+		"work",
+		[]string{"alpha", "beta"},
+		nil,
+	)
+	excludeAB := pushSyncStateScope(
+		"work",
+		nil,
+		[]string{"alpha", "beta"},
+	)
+	defaultIncludeAB := pushSyncStateScope(
+		"",
+		[]string{"alpha", "beta"},
+		nil,
+	)
+
+	assert.Equal(t, includeAB, includeBA)
+	assert.NotEmpty(t, includeAB)
+	assert.NotEqual(t, "work", includeAB)
+	assert.NotEqual(t, includeAB, excludeAB)
+	assert.NotEqual(t, includeAB, defaultIncludeAB)
+}
+
+func TestReadLastPushAtUsesProjectFilterScope(t *testing.T) {
+	local := testDB(t)
+
+	require.NoError(t, local.SetSyncState(
+		"last_push_at:work",
+		"2026-03-11T12:00:00.000Z",
+	))
+	filterScope := pushSyncStateScope(
+		"work",
+		[]string{"alpha", "beta"},
+		nil,
+	)
+	require.NoError(t, local.SetSyncState(
+		"last_push_at:"+filterScope,
+		"2026-03-11T13:00:00.000Z",
+	))
+
+	got, err := ReadLastPushAt(
+		local,
+		"work",
+		[]string{"beta", "alpha"},
+		nil,
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-03-11T13:00:00.000Z", got)
+}
+
+func TestReadLastPushAtDoesNotMigrateLegacyStateForProjectFilter(t *testing.T) {
+	local := testDB(t)
+
+	require.NoError(t, local.SetSyncState(
+		"last_push_at",
+		"2026-03-11T12:00:00.000Z",
+	))
+
+	got, err := ReadLastPushAt(
+		local,
+		"",
+		[]string{"alpha"},
+		nil,
+		true,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	legacyValue, err := local.GetSyncState("last_push_at")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-03-11T12:00:00.000Z", legacyValue)
+}

--- a/internal/server/huma_routes_push.go
+++ b/internal/server/huma_routes_push.go
@@ -76,6 +76,12 @@ func (s *Server) humaPGPush(
 	ctx context.Context,
 	in *daemonPushInput,
 ) (*pgPushOutput, error) {
+	if err := postgres.ValidateProjectFilters(
+		in.Body.Projects,
+		in.Body.ExcludeProjects,
+	); err != nil {
+		return nil, apiError(http.StatusBadRequest, err.Error())
+	}
 	local, err := s.localPushTarget()
 	if err != nil {
 		return nil, err

--- a/internal/server/huma_routes_push_internal_test.go
+++ b/internal/server/huma_routes_push_internal_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -86,6 +87,24 @@ func TestPGPushConfigRequestOverrideSkipsDaemonEnvResolution(t *testing.T) {
 	assert.Equal(t, "postgres://user:pass@host/db", got.URL)
 	assert.Equal(t, "mirror", got.Schema)
 	assert.Equal(t, "laptop", got.MachineName)
+}
+
+func TestPGPushRejectsIncludeAndExcludeProjects(t *testing.T) {
+	s := testServerWithConfig(config.Config{})
+
+	_, err := s.humaPGPush(context.Background(), &daemonPushInput{
+		Body: daemonPushRequest{
+			Projects:        []string{"alpha"},
+			ExcludeProjects: []string{"beta"},
+		},
+	})
+	require.Error(t, err)
+
+	var statusErr interface{ GetStatus() int }
+	require.ErrorAs(t, err, &statusErr)
+	assert.Equal(t, http.StatusBadRequest, statusErr.GetStatus())
+	assert.Contains(t, err.Error(),
+		"projects and exclude_projects are mutually exclusive")
 }
 
 func TestDuckDBPushConfigRequestOverrideSkipsDaemonEnvResolution(t *testing.T) {


### PR DESCRIPTION
Filtered PostgreSQL pushes are used by default-deny allow-list pipelines, but the previous global-only watermark model left those workflows unable to advance a cursor safely. Repeated `pg push --projects ...` runs had to keep scanning the full included project set, while the documented unfiltered workaround would publish projects the operator intentionally excluded.

This changes filtered pushes to track `last_push_at` and boundary fingerprints under a deterministic target/filter-set scope. The unfiltered/global cursor remains untouched, so allow-list pushes can become incremental without making later unfiltered pushes skip unrelated projects. Legacy global state is not migrated into filtered scopes because old state has no filter metadata; the first filtered run for a project set after upgrade seeds the new scoped watermark.

`pg status` now accepts the same project filter flags as `pg push` so ad hoc filtered workflows can inspect the matching scoped watermark instead of seeing only the global status. The PG sync docs describe the scoped watermark behavior and the one-time upgrade consequence.

Reviewers should focus on the sync-state scope construction, filtered push finalization, and the decision not to migrate legacy/global watermarks into project-filtered scopes.

Fixes #891
