### PR TITLE
docs: document JetBrains Copilot exporter workflow (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,26 @@ Because the format is Markdown-derived, roles are reconstructed from line
 prefixes and there are no per-message timestamps; a run's start time comes from
 its `# aider chat started at ...` header (written in local time, assumed UTC).
 
+### JetBrains Copilot via exporter
+
+JetBrains IDEs store Copilot chat in a Nitrite database that agentsview does not read directly. The supported path today is to export those sessions to Copilot JSONL with [copilot-jetbrains-exporter](https://github.com/MCBoarder289/copilot-jetbrains-exporter), then point agentsview at that output directory.
+
+```bash
+# Export JetBrains Copilot sessions to JSONL
+copilot-jetbrains-exporter --output ~/.copilot/jetbrains-sessions
+
+# Tell agentsview to index the exported sessions
+export COPILOT_DIR=~/.copilot/jetbrains-sessions
+```
+
+Or in `~/.agentsview/config.toml`:
+
+```toml
+copilot_dirs = ["~/.copilot/jetbrains-sessions"]
+```
+
+Re-run the exporter after new JetBrains Copilot sessions if you want agentsview to pick up fresh conversations from that source.
+
 ### Antigravity CLI: high-resolution transcripts
 
 Antigravity CLI sessions now appear in two on-disk formats. Newer releases store

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -771,7 +771,7 @@ func writeRootHelp(w io.Writer, root *cobra.Command) {
 	fmt.Fprintln(w, "Environment variables:")
 	fmt.Fprintln(w, "  CLAUDE_PROJECTS_DIR     Claude Code projects directory")
 	fmt.Fprintln(w, "  CODEX_SESSIONS_DIR      Codex sessions directory")
-	fmt.Fprintln(w, "  COPILOT_DIR             Copilot CLI directory")
+	fmt.Fprintln(w, "  COPILOT_DIR             Copilot sessions or exported JetBrains Copilot directory")
 	fmt.Fprintln(w, "  GEMINI_DIR              Gemini CLI directory")
 	fmt.Fprintln(w, "  OPENCODE_DIR            OpenCode data directory")
 	fmt.Fprintln(w, "  CURSOR_PROJECTS_DIR     Cursor projects directory")

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -72,6 +72,13 @@ func TestRootHelpShowsDuckDBEnvironment(t *testing.T) {
 	assert.NotContains(t, help, "env-token")
 }
 
+func TestRootHelpDocumentsCopilotExportDir(t *testing.T) {
+	help, err := executeCommand(newRootCommand(), "--help")
+	require.NoError(t, err, "Execute")
+	assert.Contains(t, help,
+		"COPILOT_DIR             Copilot sessions or exported JetBrains Copilot directory")
+}
+
 func TestDuckDBPushHelpShowsProjectFlags(t *testing.T) {
 	help, err := executeCommand(newRootCommand(), "duckdb", "push", "--help")
 	require.NoError(t, err, "Execute")


### PR DESCRIPTION
Agentsview can already show JetBrains Copilot sessions today through the exporter workflow discussed on issue #104, but the repo's own docs and CLI help never say that plainly. This PR documents the supported path instead of implying native JetBrains database parsing is still missing.

The change stays narrow to discoverability. It adds a README note for the `copilot-jetbrains-exporter` flow and updates the root `COPILOT_DIR` help text so users can point agentsview at exported JetBrains Copilot JSONL without guessing which directory knob to use. The parser and sync behavior stay unchanged because the repo already supports the exported JSONL layout.

The only code change is the root help text and its regression coverage in `cmd/agentsview`, so reviewers can focus on whether the documented workflow matches the issue-thread direction and the existing Copilot parser surface.

Fixes #104
