### PR TITLE
fix(frontend): localize remaining UI copy

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -289,6 +289,28 @@
   "subagent_inline_failed_to_load": "Failed to load",
   "subagent_inline_loading": "Loading...",
   "subagent_inline_no_messages": "No messages",
+  "skill_block_label": "Skill: {name}",
+  "tool_block_output": "output",
+  "tool_block_history": "history",
+  "tool_block_status_label": "status:",
+  "tool_block_source_label": "source:",
+  "tool_block_agent_label": "agent:",
+  "tool_block_show_less": "show less",
+  "tool_block_show_all_lines": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "show all {count} line",
+        "countPlural=other": "show all {count} lines"
+      }
+    }
+  ],
   "thinking_block_label": "Thinking",
   "compact_boundary_title": "Context window compacted at this point",
   "compact_boundary_label": "Context compacted",
@@ -394,6 +416,41 @@
   "shared_range_next_period": "Next period",
   "shared_range_from": "From",
   "shared_range_to": "To",
+  "shared_range_tab_relative": "Relative",
+  "shared_range_tab_calendar": "Calendar",
+  "shared_range_tab_custom": "Custom",
+  "shared_range_preset_all": "All",
+  "shared_range_preset_all_time": "All time",
+  "shared_range_preset_last_year": "Last year",
+  "shared_range_calendar_day": "Day",
+  "shared_range_calendar_week": "Week",
+  "shared_range_calendar_month": "Month",
+  "shared_range_week_of": "Week of {date}",
+  "shared_range_custom_range": "Custom range",
+  "shared_range_last_days": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "Last {count} day",
+        "countPlural=other": "Last {count} days"
+      }
+    }
+  ],
+  "shared_refresh_not_updated": "Not updated",
+  "shared_refresh_just_now": "Updated just now",
+  "shared_refresh_minutes_ago": "Updated {count}m ago",
+  "shared_refresh_hours_ago": "Updated {count}h ago",
+  "shared_refresh_days_ago": "Updated {count}d ago",
+  "shared_relative_just_now": "just now",
+  "shared_relative_minutes_ago": "{count}m ago",
+  "shared_relative_hours_ago": "{count}h ago",
+  "shared_relative_days_ago": "{count}d ago",
   "shared_retry": "Retry",
   "shared_refresh": "Refresh",
   "shared_no_data": "No data",
@@ -401,6 +458,7 @@
   "shared_no_sessions_in_range": "No sessions in range",
   "shared_none": "None",
   "shared_other": "Other",
+  "shared_unknown": "unknown",
   "analytics_refresh": "Refresh analytics",
   "analytics_export_csv": "Export CSV",
   "analytics_activity_by_day_hour": "Activity by Day and Hour",
@@ -1105,6 +1163,83 @@
   "insights_page_sessions_computed": "sessions computed",
   "insights_page_score_distribution": "Score distribution",
   "insights_page_pct_affected": "{pct}% affected",
+  "insights_pattern_recommendation_rationale": [
+    {
+      "declarations": [
+        "input affected",
+        "input total",
+        "local totalPlural = total: plural"
+      ],
+      "selectors": [
+        "totalPlural"
+      ],
+      "match": {
+        "totalPlural=one": "{affected} of {total} session has this deterministic pattern.",
+        "totalPlural=other": "{affected} of {total} sessions have this deterministic pattern."
+      }
+    }
+  ],
+  "insights_pattern_recommendation_fallback": "This recommendation is derived from fixed deterministic mappings.",
+  "insights_pattern_prompt_title": "Prompt maturity",
+  "insights_pattern_prompt_summary": "Task framing and acceptance evidence. Short prompts are context only.",
+  "insights_pattern_short_task_starts": "Short task starts",
+  "insights_pattern_unstructured_starts": "Unstructured starts",
+  "insights_pattern_missing_success_criteria": "Missing success criteria",
+  "insights_pattern_missing_verification_path": "Missing targeted verification path",
+  "insights_pattern_repeated_prompts": "Repeated prompts",
+  "insights_pattern_no_phase3": "No Phase 3 prompt-quality computations are available for this range.",
+  "insights_pattern_prompt_severity_description": "{severityDescription} Weak prompt-only markers do not set severity by themselves.",
+  "insights_pattern_score_pressure_proxy": "Score-pressure proxy",
+  "insights_pattern_comparison_groups": "Comparison groups",
+  "insights_pattern_prompt_action": "Open the linked examples before changing prompts; tune only signals with poor outcome lift.",
+  "insights_pattern_context_title": "Context health",
+  "insights_pattern_context_summary": "Code-context gaps, compactions, mid-task context loss, and high context pressure.",
+  "insights_pattern_sessions_with_compaction": "Sessions with compaction",
+  "insights_pattern_mid_task_compactions": "Mid-task compactions",
+  "insights_pattern_high_context_pressure": "High context pressure",
+  "insights_pattern_missing_code_context": "Missing code context",
+  "insights_pattern_context_action": "Split or summarize work before context pressure and mid-task compactions accumulate.",
+  "insights_pattern_workflow_title": "Workflow hygiene",
+  "insights_pattern_workflow_summary": "Errored, abandoned, frustrated, and repeated failing tool-cycle sessions.",
+  "insights_pattern_repeated_failing_tool_cycles": "Repeated failing tool cycles",
+  "insights_pattern_frustration_markers": "Frustration markers",
+  "insights_pattern_errored_outcomes": "Errored outcomes",
+  "insights_pattern_abandoned_outcomes": "Abandoned outcomes",
+  "insights_pattern_completed_outcomes": "Completed outcomes",
+  "insights_pattern_errored_or_abandoned_sessions": "errored or abandoned sessions",
+  "insights_pattern_interrupted_sessions": "Interrupted sessions",
+  "insights_pattern_workflow_action": "Review errored and abandoned workflows before tuning less severe prompt signals.",
+  "insights_pattern_tool_title": "Tool reliability",
+  "insights_pattern_tool_summary": "Tool failures, retries, and edit churn counted directly from session tool events.",
+  "insights_pattern_failure_signals": "Failure signals",
+  "insights_pattern_retries": "Retries",
+  "insights_pattern_edit_churn": "Edit churn",
+  "insights_pattern_average_failure_signals": "Average failure signals",
+  "insights_pattern_tool_action": "Inspect sessions with repeated failures or retries and fix brittle tool-use paths.",
+  "insights_pattern_no_computed": "No computed sessions for this pattern.",
+  "insights_pattern_none_fire": "No sessions currently fire this pattern.",
+  "insights_pattern_critical_description": "Critical means at least 35% of computed sessions fire the pattern.",
+  "insights_pattern_warning_description": "Warning means at least 18% of computed sessions fire the pattern.",
+  "insights_pattern_watch_description": "Watch means the pattern is present but below the warning threshold.",
+  "insights_pattern_points_below_average": "points below 100 average score",
+  "insights_pattern_unassigned_project": "Unassigned project",
+  "insights_pattern_example_detail": [
+    {
+      "declarations": [
+        "input count",
+        "input completedRate",
+        "input failureSignals",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} session, {completedRate}% completed, {failureSignals} avg failures",
+        "countPlural=other": "{count} sessions, {completedRate}% completed, {failureSignals} avg failures"
+      }
+    }
+  ],
   "insights_page_driver_sessions": [
     {
       "declarations": [
@@ -1222,6 +1357,9 @@
   "publish_open_in_browser": "Open in Browser",
   "publish_close_btn": "Close",
   "publish_retry": "Retry",
+  "publish_save_token_failed": "Failed to save token",
+  "publish_no_session_selected": "No session selected",
+  "publish_failed": "Publish failed",
   "resync_title": "Full Resync",
   "resync_close": "Close resync dialog",
   "resync_confirm_text": "Re-parse all session files from scratch. Existing sessions will be updated in place — no data is deleted. Use this after upgrading or when sessions appear incorrect.",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -34,10 +34,10 @@
   "header_transcript_visibility": "Block 可见性",
   "header_transcript_show_all": "全部显示",
   "header_transcript_blocks_user": "用户消息",
-  "header_transcript_blocks_assistant": "Assistant 文本",
-  "header_transcript_blocks_thinking": "Thinking blocks",
-  "header_transcript_blocks_tool": "Tool calls",
-  "header_transcript_blocks_code": "Code blocks",
+  "header_transcript_blocks_assistant": "助手文本",
+  "header_transcript_blocks_thinking": "思考块",
+  "header_transcript_blocks_tool": "工具调用",
+  "header_transcript_blocks_code": "代码块",
   "header_actions_follow_latest": "跟随最新消息",
   "header_actions_toggle_sort": "切换排序 (o)",
   "header_actions_cycle_layout": "切换布局：{layout} (l)",
@@ -184,7 +184,7 @@
   "code_block_copied_code_block": "代码块已复制",
   "code_block_copy_code": "复制代码",
   "code_block_copied": "已复制！",
-  "message_content_role_assistant": "Assistant",
+  "message_content_role_assistant": "助手",
   "message_content_role_agent": "Agent",
   "message_content_role_teammate": "队友",
   "message_content_role_user": "用户",
@@ -281,7 +281,28 @@
   "subagent_inline_failed_to_load": "加载失败",
   "subagent_inline_loading": "正在加载...",
   "subagent_inline_no_messages": "无消息",
-  "thinking_block_label": "Thinking",
+  "skill_block_label": "技能：{name}",
+  "tool_block_output": "输出",
+  "tool_block_history": "历史",
+  "tool_block_status_label": "状态：",
+  "tool_block_source_label": "来源：",
+  "tool_block_agent_label": "agent：",
+  "tool_block_show_less": "收起",
+  "tool_block_show_all_lines": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "显示全部 {count} 行"
+      }
+    }
+  ],
+  "thinking_block_label": "思考",
   "compact_boundary_title": "上下文窗口在此处被压缩",
   "compact_boundary_label": "上下文已压缩",
   "compact_boundary_show_full_summary": "显示完整摘要",
@@ -385,6 +406,40 @@
   "shared_range_next_period": "下一个周期",
   "shared_range_from": "从",
   "shared_range_to": "到",
+  "shared_range_tab_relative": "相对",
+  "shared_range_tab_calendar": "日历",
+  "shared_range_tab_custom": "自定义",
+  "shared_range_preset_all": "全部",
+  "shared_range_preset_all_time": "全部时间",
+  "shared_range_preset_last_year": "最近一年",
+  "shared_range_calendar_day": "日",
+  "shared_range_calendar_week": "周",
+  "shared_range_calendar_month": "月",
+  "shared_range_week_of": "{date}所在周",
+  "shared_range_custom_range": "自定义范围",
+  "shared_range_last_days": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "最近 {count} 天"
+      }
+    }
+  ],
+  "shared_refresh_not_updated": "未更新",
+  "shared_refresh_just_now": "刚刚更新",
+  "shared_refresh_minutes_ago": "{count} 分钟前更新",
+  "shared_refresh_hours_ago": "{count} 小时前更新",
+  "shared_refresh_days_ago": "{count} 天前更新",
+  "shared_relative_just_now": "刚刚",
+  "shared_relative_minutes_ago": "{count} 分钟前",
+  "shared_relative_hours_ago": "{count} 小时前",
+  "shared_relative_days_ago": "{count} 天前",
   "shared_retry": "重试",
   "shared_refresh": "刷新",
   "shared_no_data": "无数据",
@@ -392,6 +447,7 @@
   "shared_no_sessions_in_range": "此范围内无会话",
   "shared_none": "无",
   "shared_other": "其他",
+  "shared_unknown": "未知",
   "analytics_refresh": "刷新分析",
   "analytics_export_csv": "导出 CSV",
   "analytics_activity_by_day_hour": "按日期和小时查看活动",
@@ -1079,6 +1135,81 @@
   "insights_page_sessions_computed": "个已计算会话",
   "insights_page_score_distribution": "评分分布",
   "insights_page_pct_affected": "{pct}% 受影响",
+  "insights_pattern_recommendation_rationale": [
+    {
+      "declarations": [
+        "input affected",
+        "input total",
+        "local totalPlural = total: plural"
+      ],
+      "selectors": [
+        "totalPlural"
+      ],
+      "match": {
+        "totalPlural=other": "{total} 个会话中有 {affected} 个触发此确定性模式。"
+      }
+    }
+  ],
+  "insights_pattern_recommendation_fallback": "此建议来自固定的确定性映射。",
+  "insights_pattern_prompt_title": "提示词成熟度",
+  "insights_pattern_prompt_summary": "任务描述和验收证据。短提示词仅作为上下文参考。",
+  "insights_pattern_short_task_starts": "短任务开场",
+  "insights_pattern_unstructured_starts": "结构不清的开场",
+  "insights_pattern_missing_success_criteria": "缺少成功标准",
+  "insights_pattern_missing_verification_path": "缺少针对性验证路径",
+  "insights_pattern_repeated_prompts": "重复提示词",
+  "insights_pattern_no_phase3": "此范围内没有第 3 阶段提示词质量计算。",
+  "insights_pattern_prompt_severity_description": "{severityDescription} 弱提示词标记本身不会决定严重程度。",
+  "insights_pattern_score_pressure_proxy": "分数压力代理指标",
+  "insights_pattern_comparison_groups": "对比分组",
+  "insights_pattern_prompt_action": "修改提示词前先打开关联示例；只调整结果提升较差的信号。",
+  "insights_pattern_context_title": "上下文健康度",
+  "insights_pattern_context_summary": "代码上下文缺口、压缩、任务中途上下文丢失和高上下文压力。",
+  "insights_pattern_sessions_with_compaction": "包含压缩的会话",
+  "insights_pattern_mid_task_compactions": "任务中途压缩",
+  "insights_pattern_high_context_pressure": "上下文压力高",
+  "insights_pattern_missing_code_context": "缺少代码上下文",
+  "insights_pattern_context_action": "在上下文压力和任务中途压缩累积前，先拆分或总结工作。",
+  "insights_pattern_workflow_title": "工作流规范",
+  "insights_pattern_workflow_summary": "错误、放弃、受挫以及重复失败工具循环的会话。",
+  "insights_pattern_repeated_failing_tool_cycles": "重复失败的工具循环",
+  "insights_pattern_frustration_markers": "受挫标记",
+  "insights_pattern_errored_outcomes": "错误结果",
+  "insights_pattern_abandoned_outcomes": "放弃结果",
+  "insights_pattern_completed_outcomes": "完成结果",
+  "insights_pattern_errored_or_abandoned_sessions": "错误或放弃的会话",
+  "insights_pattern_interrupted_sessions": "中断会话",
+  "insights_pattern_workflow_action": "先检查错误和放弃的工作流，再调整较轻微的提示词信号。",
+  "insights_pattern_tool_title": "工具可靠性",
+  "insights_pattern_tool_summary": "直接从会话工具事件统计工具失败、重试和编辑返工。",
+  "insights_pattern_failure_signals": "失败信号",
+  "insights_pattern_retries": "重试",
+  "insights_pattern_edit_churn": "编辑返工",
+  "insights_pattern_average_failure_signals": "平均失败信号",
+  "insights_pattern_tool_action": "检查反复失败或重试的会话，并修复脆弱的工具使用路径。",
+  "insights_pattern_no_computed": "此模式没有已计算会话。",
+  "insights_pattern_none_fire": "当前没有会话触发此模式。",
+  "insights_pattern_critical_description": "严重表示至少 35% 的已计算会话触发此模式。",
+  "insights_pattern_warning_description": "警告表示至少 18% 的已计算会话触发此模式。",
+  "insights_pattern_watch_description": "关注表示此模式存在，但低于警告阈值。",
+  "insights_pattern_points_below_average": "低于 100 平均分的点数",
+  "insights_pattern_unassigned_project": "未分配项目",
+  "insights_pattern_example_detail": [
+    {
+      "declarations": [
+        "input count",
+        "input completedRate",
+        "input failureSignals",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{count} 个会话，{completedRate}% 已完成，平均 {failureSignals} 个失败信号"
+      }
+    }
+  ],
   "insights_page_driver_sessions": [
     {
       "declarations": [
@@ -1195,6 +1326,9 @@
   "publish_open_in_browser": "在浏览器中打开",
   "publish_close_btn": "关闭",
   "publish_retry": "重试",
+  "publish_save_token_failed": "保存令牌失败",
+  "publish_no_session_selected": "未选择会话",
+  "publish_failed": "发布失败",
   "resync_title": "完整重新同步",
   "resync_close": "关闭重新同步对话框",
   "resync_confirm_text": "从头重新解析所有会话文件。现有会话将就地更新 —— 不会删除任何数据。在升级后或会话显示异常时使用。",

--- a/frontend/src/lib/components/content/MessageContent.test.ts
+++ b/frontend/src/lib/components/content/MessageContent.test.ts
@@ -121,6 +121,35 @@ describe("MessageContent", () => {
     unmount(component);
   });
 
+  it("localizes assistant role and thinking block labels", async () => {
+    setLocale("zh-CN");
+    const component = mount(MessageContent, {
+      target: document.body,
+      props: {
+        message: makeMessage({
+          id: 2,
+          role: "assistant",
+          content: "[Thinking]\nInternal reasoning.\n[/Thinking]\n\nVisible response.",
+          content_length: 61,
+          has_thinking: true,
+          thinking_text: "Internal reasoning.",
+        }),
+      },
+    });
+
+    await tick();
+
+    expect(document.querySelector(".role-label")?.textContent?.trim()).toBe(
+      "助手",
+    );
+    expect(document.querySelector(".thinking-label")?.textContent?.trim()).toBe(
+      "思考",
+    );
+    expect(document.body.textContent).toContain("Visible response.");
+
+    unmount(component);
+  });
+
   it("renders compact token totals when both token metrics are reported", async () => {
     const component = mount(MessageContent, {
       target: document.body,

--- a/frontend/src/lib/components/content/SkillBlock.svelte
+++ b/frontend/src/lib/components/content/SkillBlock.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { m } from "../../i18n/index.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { highlightCodeFences } from "../../utils/highlight-fences.js";
   import { ChevronRightIcon } from "../../icons.js";
@@ -28,7 +29,9 @@
     <span class="skill-chevron" class:open={!collapsed}>
       <ChevronRightIcon size="10" strokeWidth="2.4" aria-hidden="true" />
     </span>
-    <span class="skill-label">Skill: {name ?? "unknown"}</span>
+    <span class="skill-label">
+      {m.skill_block_label({ name: name ?? m.shared_unknown() })}
+    </span>
     {#if collapsed && previewLine}
       <span class="skill-preview">{previewLine}</span>
     {/if}

--- a/frontend/src/lib/components/content/SkillBlock.test.ts
+++ b/frontend/src/lib/components/content/SkillBlock.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { mount, unmount, tick } from "svelte";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { setLocale } from "../../i18n/index.js";
+
+// @ts-ignore
+import SkillBlock from "./SkillBlock.svelte";
+
+describe("SkillBlock", () => {
+  let component: ReturnType<typeof mount> | undefined;
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    document.body.innerHTML = "";
+    setLocale("en");
+  });
+
+  it("localizes the label fallback", async () => {
+    setLocale("zh-CN");
+
+    component = mount(SkillBlock, {
+      target: document.body,
+      props: { content: "Use the project guidance." },
+    });
+    await tick();
+
+    expect(document.querySelector(".skill-label")?.textContent).toBe("技能：未知");
+  });
+});

--- a/frontend/src/lib/components/content/ToolBlock.svelte
+++ b/frontend/src/lib/components/content/ToolBlock.svelte
@@ -7,6 +7,7 @@
     extractToolParamMeta,
     generateFallbackContent,
   } from "../../utils/tool-params.js";
+  import { m } from "../../i18n/index.js";
   import { applyHighlight, escapeHTML } from "../../utils/highlight.js";
   import { ChevronRightIcon } from "../../icons.js";
   import { summarizeToolCall } from "../../utils/tool-summary.js";
@@ -241,6 +242,12 @@
     }
     return { text: raw, isLong, totalLines: lines.length };
   });
+  let showAllLinesLabel = $derived.by(() => {
+    if (!displayContent.isLong) return "";
+    return m.tool_block_show_all_lines({
+      count: displayContent.totalLines ?? 0,
+    });
+  });
 
   let isDiff = $derived.by(() => {
     const text = fallbackContent ?? content ?? "";
@@ -315,7 +322,9 @@
             contentFullyExpanded = !contentFullyExpanded;
           }}
         >
-          {contentFullyExpanded ? "show less" : `show all ${displayContent.totalLines} lines`}
+          {contentFullyExpanded
+            ? m.tool_block_show_less()
+            : showAllLinesLabel}
         </button>
       {/if}
     {/if}
@@ -333,7 +342,7 @@
         <span class="tool-chevron" class:open={!outputCollapsed}>
           <ChevronRightIcon size="10" strokeWidth="2.4" aria-hidden="true" />
         </span>
-        <span class="output-label">output</span>
+        <span class="output-label">{m.tool_block_output()}</span>
         {#if outputCollapsed && outputPreviewLine}
           <span class="tool-preview">{outputPreviewLine}</span>
         {/if}
@@ -356,7 +365,7 @@
         <span class="tool-chevron" class:open={!historyCollapsed}>
           <ChevronRightIcon size="10" strokeWidth="2.4" aria-hidden="true" />
         </span>
-        <span class="output-label">history</span>
+        <span class="output-label">{m.tool_block_history()}</span>
         {#if historyCollapsed && historyPreviewLine}
           <span class="tool-preview">{historyPreviewLine}</span>
         {/if}
@@ -367,16 +376,16 @@
             <div class="result-event">
               <div class="result-event-meta">
                 <span class="meta-tag">
-                  <span class="meta-label">status:</span>
+                  <span class="meta-label">{m.tool_block_status_label()}</span>
                   {event.status}
                 </span>
                 <span class="meta-tag">
-                  <span class="meta-label">source:</span>
+                  <span class="meta-label">{m.tool_block_source_label()}</span>
                   {event.source}
                 </span>
                 {#if event.agent_id}
                   <span class="meta-tag">
-                    <span class="meta-label">agent:</span>
+                    <span class="meta-label">{m.tool_block_agent_label()}</span>
                     {event.agent_id}
                   </span>
                 {/if}

--- a/frontend/src/lib/components/content/ToolBlock.test.ts
+++ b/frontend/src/lib/components/content/ToolBlock.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, afterEach } from "vite-plus/test";
 import { mount, unmount, tick } from "svelte";
 import type { ToolCall } from "../../api/types.js";
+import { setLocale } from "../../i18n/index.js";
 
 vi.mock("./SubagentInline.svelte", () => ({
   default: {},
@@ -18,6 +19,7 @@ describe("ToolBlock output section", () => {
   afterEach(() => {
     if (component) unmount(component);
     document.body.innerHTML = "";
+    setLocale("en");
   });
 
   it("does not render output-header when toolCall has no result_content", async () => {
@@ -162,6 +164,69 @@ describe("ToolBlock output section", () => {
     await tick();
 
     expect(document.querySelector(".history-header")).not.toBeNull();
+  });
+
+  it("localizes output, history, and result event metadata labels", async () => {
+    setLocale("zh-CN");
+    const toolCall: ToolCall = {
+      tool_name: "wait",
+      category: "Other",
+      result_content: "latest summary",
+      result_events: [
+        {
+          source: "wait_output",
+          status: "completed",
+          content: "Finished successfully",
+          content_length: 21,
+          agent_id: "agent-1",
+          event_index: 0,
+        },
+      ],
+    };
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content: "some input", toolCall },
+    });
+    await tick();
+
+    document.querySelector<HTMLButtonElement>(".tool-header")!.click();
+    await tick();
+    document.querySelector<HTMLButtonElement>(".history-header")!.click();
+    await tick();
+
+    expect(document.querySelector(".output-header .output-label")?.textContent)
+      .toBe("输出");
+    expect(document.querySelector(".history-header .output-label")?.textContent)
+      .toBe("历史");
+    expect(
+      Array.from(document.querySelectorAll(".meta-label"))
+        .map((node) => node.textContent),
+    ).toEqual(["状态：", "来源：", "agent："]);
+  });
+
+  it("localizes long content expansion controls", async () => {
+    setLocale("zh-CN");
+    const content = Array.from(
+      { length: 22 },
+      (_, i) => `line ${i + 1}`,
+    ).join("\n");
+    component = mount(ToolBlock, {
+      target: document.body,
+      props: { content },
+    });
+    await tick();
+
+    document.querySelector<HTMLButtonElement>(".tool-header")!.click();
+    await tick();
+
+    const showMore = document.querySelector<HTMLButtonElement>(".show-more-btn");
+    expect(showMore?.textContent?.trim()).toBe("显示全部 22 行");
+
+    showMore!.click();
+    await tick();
+
+    expect(document.querySelector(".show-more-btn")?.textContent?.trim())
+      .toBe("收起");
   });
 
   it("expands event history and shows chronological event content", async () => {

--- a/frontend/src/lib/components/insights/qualityPatterns.test.ts
+++ b/frontend/src/lib/components/insights/qualityPatterns.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { setLocale } from "../../i18n/index.js";
 import type { SignalsAnalyticsResponse } from "../../api/types.js";
 import {
   buildQualityPatterns,
@@ -400,5 +401,28 @@ describe("quality pattern transforms", () => {
     expect(buildQualityPatterns(belowWarning)[0]?.severity).toBe("watch");
     expect(buildQualityPatterns(warning)[0]?.severity).toBe("warning");
     expect(buildQualityPatterns(critical)[0]?.severity).toBe("critical");
+  });
+
+  it("localizes quality pattern labels and descriptions", () => {
+    setLocale("zh-CN");
+
+    const patterns = buildQualityPatterns(makeSignals());
+    const prompt = patterns[0]!;
+    const context = patterns[1]!;
+    const workflow = patterns[2]!;
+    const tool = patterns[3]!;
+    const recommendation = buildRuleBasedRecommendations(patterns)[0]!;
+
+    expect(prompt.title).toBe("提示词成熟度");
+    expect(prompt.summary).toContain("任务描述");
+    expect(prompt.drivers.map((driver) => driver.label)).toContain("缺少成功标准");
+    expect(prompt.trendLabel).toBe("分数压力代理指标");
+    expect(prompt.trend[0]!.label).toBe("低于 100 平均分的点数");
+    expect(context.drivers.map((driver) => driver.label)).toContain("上下文压力高");
+    expect(workflow.drivers.map((driver) => driver.label)).toContain("错误结果");
+    expect(tool.trendLabel).toBe("平均失败信号");
+    expect(recommendation.rationale).toContain("确定性模式");
+
+    setLocale("en");
   });
 });

--- a/frontend/src/lib/components/insights/qualityPatterns.ts
+++ b/frontend/src/lib/components/insights/qualityPatterns.ts
@@ -3,6 +3,7 @@ import type {
   SignalsAnalyticsResponse,
   SignalsTrendBucket,
 } from "../../api/types.js";
+import { m } from "../../i18n/index.js";
 
 export type QualityPatternSeverity =
   | "clear"
@@ -146,8 +147,11 @@ export function buildRuleBasedRecommendations(
       label: pattern.action,
       rationale:
         pattern.affectedSessions > 0
-          ? `${pattern.affectedSessions} of ${pattern.totalSessions} sessions have this deterministic pattern.`
-          : "This recommendation is derived from fixed deterministic mappings.",
+          ? m.insights_pattern_recommendation_rationale({
+            affected: pattern.affectedSessions,
+            total: pattern.totalSessions,
+          })
+          : m.insights_pattern_recommendation_fallback(),
     }));
 }
 
@@ -162,35 +166,35 @@ function promptMaturityPattern(
   const drivers: QualityPatternDriver[] = [
     signalDriver(
       "short_prompt_count",
-      "Short task starts",
+      m.insights_pattern_short_task_starts(),
       totals,
       sessions,
       "weak",
     ),
     signalDriver(
       "unstructured_start",
-      "Unstructured starts",
+      m.insights_pattern_unstructured_starts(),
       totals,
       sessions,
       "contextual",
     ),
     signalDriver(
       "missing_success_criteria_count",
-      "Missing success criteria",
+      m.insights_pattern_missing_success_criteria(),
       totals,
       sessions,
       "contextual",
     ),
     signalDriver(
       "missing_verification_count",
-      "Missing targeted verification path",
+      m.insights_pattern_missing_verification_path(),
       totals,
       sessions,
       "weak",
     ),
     signalDriver(
       "duplicate_prompt_count",
-      "Repeated prompts",
+      m.insights_pattern_repeated_prompts(),
       totals,
       sessions,
       "contextual",
@@ -203,24 +207,24 @@ function promptMaturityPattern(
 
   return {
     id: "prompt_maturity",
-    title: "Prompt maturity",
-    summary:
-      "Task framing and acceptance evidence. Short prompts are context only.",
+    title: m.insights_pattern_prompt_title(),
+    summary: m.insights_pattern_prompt_summary(),
     severity: computed === 0
       ? "unavailable"
       : severityFromRatio(affected, computed),
     severityDescription: computed === 0
-      ? "No Phase 3 prompt-quality computations are available for this range."
-      : severityDescription(affected, computed) +
-        " Weak prompt-only markers do not set severity by themselves.",
+      ? m.insights_pattern_no_phase3()
+      : m.insights_pattern_prompt_severity_description({
+        severityDescription: severityDescription(affected, computed),
+      }),
     affectedSessions: affected,
     totalSessions: computed,
     drivers,
-    trendLabel: "Score-pressure proxy",
+    trendLabel: m.insights_pattern_score_pressure_proxy(),
     trend: scorePressureTrend(signals.trend),
     examples: topAgentExamples(signals),
-    examplesLabel: "Comparison groups",
-    action: "Open the linked examples before changing prompts; tune only signals with poor outcome lift.",
+    examplesLabel: m.insights_pattern_comparison_groups(),
+    action: m.insights_pattern_prompt_action(),
   };
 }
 
@@ -235,25 +239,25 @@ function contextHealthPattern(
   const drivers: QualityPatternDriver[] = [
     {
       id: "sessions_with_compaction",
-      label: "Sessions with compaction",
+      label: m.insights_pattern_sessions_with_compaction(),
       total: h.sessions_with_compaction,
       sessions: h.sessions_with_compaction,
     },
     {
       id: "mid_task_compaction_count",
-      label: "Mid-task compactions",
+      label: m.insights_pattern_mid_task_compactions(),
       total: h.mid_task_compaction_count,
       sessions: h.sessions_with_mid_task_compaction,
     },
     {
       id: "high_pressure_sessions",
-      label: "High context pressure",
+      label: m.insights_pattern_high_context_pressure(),
       total: h.high_pressure_sessions,
       sessions: h.high_pressure_sessions,
     },
     signalDriver(
       "no_code_context_count",
-      "Missing code context",
+      m.insights_pattern_missing_code_context(),
       totals,
       sessions,
     ),
@@ -262,19 +266,18 @@ function contextHealthPattern(
 
   return {
     id: "context_health",
-    title: "Context health",
-    summary:
-      "Code-context gaps, compactions, mid-task context loss, and high context pressure.",
+    title: m.insights_pattern_context_title(),
+    summary: m.insights_pattern_context_summary(),
     severity: severityFromRatio(affected, total),
     severityDescription: severityDescription(affected, total),
     affectedSessions: affected,
     totalSessions: total,
     drivers,
-    trendLabel: "Score-pressure proxy",
+    trendLabel: m.insights_pattern_score_pressure_proxy(),
     trend: scorePressureTrend(signals.trend),
     examples: topProjectExamples(signals),
-    examplesLabel: "Comparison groups",
-    action: "Split or summarize work before context pressure and mid-task compactions accumulate.",
+    examplesLabel: m.insights_pattern_comparison_groups(),
+    action: m.insights_pattern_context_action(),
   };
 }
 
@@ -291,14 +294,14 @@ function workflowHygienePattern(
   const interrupted = errored + abandoned;
   const runawayDriver = signalDriver(
     "runaway_tool_loop_count",
-    "Repeated failing tool cycles",
+    m.insights_pattern_repeated_failing_tool_cycles(),
     totals,
     sessions,
     "strong",
   );
   const frustrationDriver = signalDriver(
     "frustration_marker_count",
-    "Frustration markers",
+    m.insights_pattern_frustration_markers(),
     totals,
     sessions,
     "contextual",
@@ -311,9 +314,8 @@ function workflowHygienePattern(
 
   return {
     id: "workflow_hygiene",
-    title: "Workflow hygiene",
-    summary:
-      "Errored, abandoned, frustrated, and repeated failing tool-cycle sessions.",
+    title: m.insights_pattern_workflow_title(),
+    summary: m.insights_pattern_workflow_summary(),
     severity: severityFromRatio(affected, total),
     severityDescription: severityDescription(affected, total),
     affectedSessions: affected,
@@ -321,19 +323,19 @@ function workflowHygienePattern(
     drivers: [
       {
         id: "outcome_errored",
-        label: "Errored outcomes",
+        label: m.insights_pattern_errored_outcomes(),
         total: errored,
         sessions: errored,
       },
       {
         id: "outcome_abandoned",
-        label: "Abandoned outcomes",
+        label: m.insights_pattern_abandoned_outcomes(),
         total: abandoned,
         sessions: abandoned,
       },
       {
         id: "outcome_completed",
-        label: "Completed outcomes",
+        label: m.insights_pattern_completed_outcomes(),
         total: outcomes.completed ?? 0,
         sessions: outcomes.completed ?? 0,
       },
@@ -343,13 +345,13 @@ function workflowHygienePattern(
     trend: signals.trend.map((t) => ({
       date: t.date,
       value: t.errored + t.abandoned,
-      label: "errored or abandoned sessions",
+      label: m.insights_pattern_errored_or_abandoned_sessions(),
       score: t.avg_health_score,
     })),
-    trendLabel: "Interrupted sessions",
+    trendLabel: m.insights_pattern_interrupted_sessions(),
     examples: topAgentExamples(signals),
-    examplesLabel: "Comparison groups",
-    action: "Review errored and abandoned workflows before tuning less severe prompt signals.",
+    examplesLabel: m.insights_pattern_comparison_groups(),
+    action: m.insights_pattern_workflow_action(),
   };
 }
 
@@ -361,7 +363,7 @@ function toolReliabilityPattern(
   const drivers: QualityPatternDriver[] = [
     {
       id: "tool_failure_signals",
-      label: "Failure signals",
+      label: m.insights_pattern_failure_signals(),
       total: h.total_failure_signals,
       sessions: toolDriverSessions(
         signals,
@@ -371,7 +373,7 @@ function toolReliabilityPattern(
     },
     {
       id: "tool_retries",
-      label: "Retries",
+      label: m.insights_pattern_retries(),
       total: h.total_retries,
       sessions: toolDriverSessions(
         signals,
@@ -381,7 +383,7 @@ function toolReliabilityPattern(
     },
     {
       id: "edit_churn",
-      label: "Edit churn",
+      label: m.insights_pattern_edit_churn(),
       total: h.total_edit_churn,
       sessions: toolDriverSessions(
         signals,
@@ -394,9 +396,8 @@ function toolReliabilityPattern(
 
   return {
     id: "tool_reliability",
-    title: "Tool reliability",
-    summary:
-      "Tool failures, retries, and edit churn counted directly from session tool events.",
+    title: m.insights_pattern_tool_title(),
+    summary: m.insights_pattern_tool_summary(),
     severity: severityFromRatio(affected, total),
     severityDescription: severityDescription(affected, total),
     affectedSessions: affected,
@@ -405,13 +406,13 @@ function toolReliabilityPattern(
     trend: signals.trend.map((t) => ({
       date: t.date,
       value: t.avg_failure_signals,
-      label: "average failure signals",
+      label: m.insights_pattern_average_failure_signals(),
       score: t.avg_health_score,
     })),
-    trendLabel: "Average failure signals",
+    trendLabel: m.insights_pattern_average_failure_signals(),
     examples: topProjectExamples(signals),
-    examplesLabel: "Comparison groups",
-    action: "Inspect sessions with repeated failures or retries and fix brittle tool-use paths.",
+    examplesLabel: m.insights_pattern_comparison_groups(),
+    action: m.insights_pattern_tool_action(),
   };
 }
 
@@ -467,16 +468,16 @@ function severityFromRatio(
 }
 
 function severityDescription(affected: number, total: number): string {
-  if (total <= 0) return "No computed sessions for this pattern.";
+  if (total <= 0) return m.insights_pattern_no_computed();
   const ratio = affected / total;
-  if (ratio === 0) return "No sessions currently fire this pattern.";
+  if (ratio === 0) return m.insights_pattern_none_fire();
   if (ratio >= QUALITY_PATTERN_SEVERITY_THRESHOLDS.criticalRatio) {
-    return "Critical means at least 35% of computed sessions fire the pattern.";
+    return m.insights_pattern_critical_description();
   }
   if (ratio >= QUALITY_PATTERN_SEVERITY_THRESHOLDS.warningRatio) {
-    return "Warning means at least 18% of computed sessions fire the pattern.";
+    return m.insights_pattern_warning_description();
   }
-  return "Watch means the pattern is present but below the warning threshold.";
+  return m.insights_pattern_watch_description();
 }
 
 function scorePressureTrend(trend: SignalsTrendBucket[]) {
@@ -486,7 +487,7 @@ function scorePressureTrend(trend: SignalsTrendBucket[]) {
       t.avg_health_score == null
         ? 0
         : Math.max(0, Math.round(100 - t.avg_health_score)),
-    label: "points below 100 average score",
+    label: m.insights_pattern_points_below_average(),
     score: t.avg_health_score,
   }));
 }
@@ -503,8 +504,12 @@ function topProjectExamples(
     })
     .slice(0, 3)
     .map((row) => ({
-      label: row.project || "Unassigned project",
-      detail: `${row.session_count} sessions, ${Math.round(row.completed_rate)}% completed, ${row.avg_failure_signals.toFixed(1)} avg failures`,
+      label: row.project || m.insights_pattern_unassigned_project(),
+      detail: m.insights_pattern_example_detail({
+        count: row.session_count,
+        completedRate: Math.round(row.completed_rate),
+        failureSignals: row.avg_failure_signals.toFixed(1),
+      }),
       score: row.avg_health_score,
     }));
 }
@@ -522,7 +527,11 @@ function topAgentExamples(
     .slice(0, 3)
     .map((row) => ({
       label: row.agent,
-      detail: `${row.session_count} sessions, ${Math.round(row.completed_rate)}% completed, ${row.avg_failure_signals.toFixed(1)} avg failures`,
+      detail: m.insights_pattern_example_detail({
+        count: row.session_count,
+        completedRate: Math.round(row.completed_rate),
+        failureSignals: row.avg_failure_signals.toFixed(1),
+      }),
       score: row.avg_health_score,
     }));
 }

--- a/frontend/src/lib/components/modals/PublishModal.svelte
+++ b/frontend/src/lib/components/modals/PublishModal.svelte
@@ -65,7 +65,7 @@
     } catch (err) {
       if (isClosed()) return;
       errorMessage =
-        err instanceof Error ? err.message : "Failed to save token";
+        err instanceof Error ? err.message : m.publish_save_token_failed();
       view = "error";
     }
   }
@@ -73,7 +73,7 @@
   async function doPublish() {
     if (isClosed()) return;
     if (!target) {
-      errorMessage = "No session selected";
+      errorMessage = m.publish_no_session_selected();
       view = "error";
       return;
     }
@@ -92,7 +92,7 @@
       } catch (err) {
         if (isClosed()) return;
         errorMessage =
-          err instanceof Error ? err.message : "Publish failed";
+          err instanceof Error ? err.message : m.publish_failed();
         view = "error";
       }
       return;
@@ -111,7 +111,7 @@
     } catch (err) {
       if (isClosed()) return;
       errorMessage =
-        err instanceof Error ? err.message : "Publish failed";
+        err instanceof Error ? err.message : m.publish_failed();
       view = "error";
     }
   }

--- a/frontend/src/lib/components/shared/RangePicker.svelte
+++ b/frontend/src/lib/components/shared/RangePicker.svelte
@@ -43,10 +43,10 @@
     block = false,
   }: Props = $props();
 
-  const TABS: { mode: RangeMode; label: string }[] = [
-    { mode: "relative", label: "Relative" },
-    { mode: "calendar", label: "Calendar" },
-    { mode: "custom", label: "Custom" },
+  const TABS: { mode: RangeMode; label: () => string }[] = [
+    { mode: "relative", label: m.shared_range_tab_relative },
+    { mode: "calendar", label: m.shared_range_tab_calendar },
+    { mode: "custom", label: m.shared_range_tab_custom },
   ];
 
   let open = $state(false);
@@ -183,7 +183,7 @@
             aria-selected={tab === t.mode}
             onclick={() => (tab = t.mode)}
           >
-            {t.label}
+            {t.label()}
           </button>
         {/each}
       </div>
@@ -196,7 +196,7 @@
               class:active={isRelativeActive(preset.days)}
               onclick={() => applyRelative(preset.days)}
             >
-              {preset.label}
+              {preset.label()}
             </button>
           {/each}
         </div>
@@ -208,7 +208,7 @@
               class:active={calUnit === u.unit}
               onclick={() => applyCalendar(u.unit, calAnchor)}
             >
-              {u.label}
+              {u.label()}
             </button>
           {/each}
         </div>

--- a/frontend/src/lib/components/shared/rangeSelection.test.ts
+++ b/frontend/src/lib/components/shared/rangeSelection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vite-plus/test";
+import { setLocale } from "../../i18n/index.js";
 
 import {
   calendarLabel,
@@ -90,14 +91,26 @@ describe("resolveRange", () => {
 
 describe("calendarLabel", () => {
   it("labels each unit", () => {
+    setLocale("en");
     expect(calendarLabel("day", "2026-06-17")).toBe("Jun 17, 2026");
     expect(calendarLabel("week", "2026-06-17")).toBe("Week of Jun 15");
     expect(calendarLabel("month", "2026-02-14")).toBe("February 2026");
+  });
+
+  it("localizes calendar labels", () => {
+    setLocale("zh-CN");
+
+    expect(calendarLabel("day", "2026-06-17")).toBe("2026年6月17日");
+    expect(calendarLabel("week", "2026-06-17")).toBe("6月15日所在周");
+    expect(calendarLabel("month", "2026-02-14")).toBe("2026年2月");
+
+    setLocale("en");
   });
 });
 
 describe("rangeLabel", () => {
   it("labels relative presets and an unknown day count", () => {
+    setLocale("en");
     expect(rangeLabel({ mode: "relative", days: 30 })).toBe("Last 30 days");
     expect(rangeLabel({ mode: "relative", days: 0 })).toBe("All time");
     expect(rangeLabel({ mode: "relative", days: 14 })).toBe("Last 14 days");
@@ -113,6 +126,25 @@ describe("rangeLabel", () => {
     expect(
       rangeLabel({ mode: "custom", from: "2026-06-19", to: "2026-06-19" }),
     ).toBe("Jun 19");
+  });
+
+  it("localizes relative and custom range labels", () => {
+    setLocale("zh-CN");
+
+    expect(rangeLabel({ mode: "relative", days: 30 })).toBe("最近 30 天");
+    expect(rangeLabel({ mode: "relative", days: 0 })).toBe("全部时间");
+    expect(rangeLabel({ mode: "relative", days: 14 })).toBe("最近 14 天");
+    expect(
+      rangeLabel({ mode: "calendar", unit: "week", anchor: "2026-06-17" }),
+    ).toBe("6月15日所在周");
+    expect(
+      rangeLabel({ mode: "custom", from: "", to: "" }),
+    ).toBe("自定义范围");
+    expect(
+      rangeLabel({ mode: "custom", from: "2026-05-20", to: "2026-06-19" }),
+    ).toBe("5月20日 - 6月19日");
+
+    setLocale("en");
   });
 });
 

--- a/frontend/src/lib/components/shared/rangeSelection.ts
+++ b/frontend/src/lib/components/shared/rangeSelection.ts
@@ -6,6 +6,7 @@ import {
   todayStr,
   type DateRange,
 } from "./dateRangeSelector.js";
+import { formatDateTime, m } from "../../i18n/index.js";
 
 /**
  * The three ways a user can pick a range with the unified RangePicker. Every
@@ -42,34 +43,25 @@ export type RangeSelection =
 
 export interface RelativePreset {
   /** Compact pill label. */
-  label: string;
+  label: () => string;
   /** Trigger-button label. */
-  longLabel: string;
+  longLabel: () => string;
   /** Days back from today; 0 means all-time. */
   days: number;
 }
 
 export const RELATIVE_PRESETS: RelativePreset[] = [
-  { label: "7d", longLabel: "Last 7 days", days: 7 },
-  { label: "30d", longLabel: "Last 30 days", days: 30 },
-  { label: "90d", longLabel: "Last 90 days", days: 90 },
-  { label: "1y", longLabel: "Last year", days: 365 },
-  { label: "All", longLabel: "All time", days: 0 },
+  { label: () => "7d", longLabel: () => m.shared_range_last_days({ count: 7 }), days: 7 },
+  { label: () => "30d", longLabel: () => m.shared_range_last_days({ count: 30 }), days: 30 },
+  { label: () => "90d", longLabel: () => m.shared_range_last_days({ count: 90 }), days: 90 },
+  { label: () => "1y", longLabel: m.shared_range_preset_last_year, days: 365 },
+  { label: m.shared_range_preset_all, longLabel: m.shared_range_preset_all_time, days: 0 },
 ];
 
-export const CALENDAR_UNITS: { unit: CalendarUnit; label: string }[] = [
-  { unit: "day", label: "Day" },
-  { unit: "week", label: "Week" },
-  { unit: "month", label: "Month" },
-];
-
-const MONTHS_SHORT = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-];
-const MONTHS_LONG = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
+export const CALENDAR_UNITS: { unit: CalendarUnit; label: () => string }[] = [
+  { unit: "day", label: m.shared_range_calendar_day },
+  { unit: "week", label: m.shared_range_calendar_week },
+  { unit: "month", label: m.shared_range_calendar_month },
 ];
 
 /** Parse a YYYY-MM-DD date string as local midnight. */
@@ -149,33 +141,48 @@ export function resolveRange(
 export function calendarLabel(unit: CalendarUnit, anchor: string): string {
   const d = parseLocal(anchor);
   if (unit === "day") {
-    return `${MONTHS_SHORT[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+    return formatDateTime(d, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
   }
   if (unit === "month") {
-    return `${MONTHS_LONG[d.getMonth()]} ${d.getFullYear()}`;
+    return formatDateTime(d, {
+      year: "numeric",
+      month: "long",
+    });
   }
   const start = parseLocal(periodBounds("week", anchor).from);
-  return `Week of ${MONTHS_SHORT[start.getMonth()]} ${start.getDate()}`;
+  return m.shared_range_week_of({
+    date: formatDateTime(start, {
+      month: "short",
+      day: "numeric",
+    }),
+  });
 }
 
 /** Short label for the trigger button reflecting the current selection. */
 export function rangeLabel(sel: RangeSelection): string {
   if (sel.mode === "relative") {
     const preset = RELATIVE_PRESETS.find((p) => p.days === sel.days);
-    return preset ? preset.longLabel : `Last ${sel.days} days`;
+    return preset ? preset.longLabel() : m.shared_range_last_days({ count: sel.days });
   }
   if (sel.mode === "calendar") {
     return calendarLabel(sel.unit, sel.anchor);
   }
-  if (!sel.from || !sel.to) return "Custom range";
+  if (!sel.from || !sel.to) return m.shared_range_custom_range();
   const from = parseLocal(sel.from);
   const to = parseLocal(sel.to);
   if (sel.from === sel.to) {
-    return `${MONTHS_SHORT[from.getMonth()]} ${from.getDate()}`;
+    return formatDateTime(from, {
+      month: "short",
+      day: "numeric",
+    });
   }
   return (
-    `${MONTHS_SHORT[from.getMonth()]} ${from.getDate()} - ` +
-    `${MONTHS_SHORT[to.getMonth()]} ${to.getDate()}`
+    `${formatDateTime(from, { month: "short", day: "numeric" })} - ` +
+    `${formatDateTime(to, { month: "short", day: "numeric" })}`
   );
 }
 

--- a/frontend/src/lib/utils/format.test.ts
+++ b/frontend/src/lib/utils/format.test.ts
@@ -1,11 +1,51 @@
-import { describe, it, expect, beforeEach } from "vite-plus/test";
 import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { setLocale } from "../i18n/index.js";
+import {
+  formatRelativeTime,
   sanitizeSnippet,
   _resetNonceCounter,
   formatCost,
   formatTokenCount,
   formatTokenUsage,
 } from "./format.js";
+
+describe("formatRelativeTime", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setLocale("en");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setLocale("en");
+  });
+
+  it.each([
+    ["2026-06-17T12:00:00Z", "just now"],
+    ["2026-06-17T11:58:00Z", "2m ago"],
+    ["2026-06-17T09:30:00Z", "2h ago"],
+    ["2026-06-15T12:00:00Z", "2d ago"],
+  ])("formats %s in English", (value, expected) => {
+    vi.setSystemTime(new Date("2026-06-17T12:00:20Z"));
+    expect(formatRelativeTime(value)).toBe(expected);
+  });
+
+  it("localizes relative time labels", () => {
+    setLocale("zh-CN");
+    vi.setSystemTime(new Date("2026-06-17T12:00:20Z"));
+
+    expect(formatRelativeTime("2026-06-17T12:00:00Z")).toBe("刚刚");
+    expect(formatRelativeTime("2026-06-17T11:58:00Z")).toBe("2 分钟前");
+    expect(formatRelativeTime("2026-06-15T12:00:00Z")).toBe("2 天前");
+  });
+});
 
 describe("formatCost", () => {
   it.each([

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -1,3 +1,5 @@
+import { formatDateTime, m } from "../i18n/index.js";
+
 const MINUTE = 60;
 const HOUR = 3600;
 const DAY = 86400;
@@ -12,12 +14,24 @@ export function formatRelativeTime(
   const date = new Date(isoString);
   const diffSec = Math.floor((Date.now() - date.getTime()) / 1000);
 
-  if (diffSec < MINUTE) return "just now";
-  if (diffSec < HOUR) return `${Math.floor(diffSec / MINUTE)}m ago`;
-  if (diffSec < DAY) return `${Math.floor(diffSec / HOUR)}h ago`;
-  if (diffSec < WEEK) return `${Math.floor(diffSec / DAY)}d ago`;
+  if (diffSec < MINUTE) return m.shared_relative_just_now();
+  if (diffSec < HOUR) {
+    return m.shared_relative_minutes_ago({
+      count: Math.floor(diffSec / MINUTE),
+    });
+  }
+  if (diffSec < DAY) {
+    return m.shared_relative_hours_ago({
+      count: Math.floor(diffSec / HOUR),
+    });
+  }
+  if (diffSec < WEEK) {
+    return m.shared_relative_days_ago({
+      count: Math.floor(diffSec / DAY),
+    });
+  }
 
-  return date.toLocaleDateString(undefined, {
+  return formatDateTime(date, {
     month: "short",
     day: "numeric",
   });
@@ -29,7 +43,7 @@ export function formatTimestamp(
 ): string {
   if (!isoString) return "—";
   const d = new Date(isoString);
-  return d.toLocaleString(undefined, {
+  return formatDateTime(d, {
     month: "short",
     day: "numeric",
     hour: "2-digit",

--- a/frontend/src/lib/utils/refresh.test.ts
+++ b/frontend/src/lib/utils/refresh.test.ts
@@ -5,6 +5,7 @@ import {
   it,
   vi,
 } from "vite-plus/test";
+import { setLocale } from "../i18n/index.js";
 import {
   createRefreshScheduler,
   DEFAULT_REFRESH_INTERVAL_MS,
@@ -13,6 +14,10 @@ import {
 
 describe("formatRefreshAge", () => {
   const now = Date.parse("2026-06-16T12:10:00Z");
+
+  afterEach(() => {
+    setLocale("en");
+  });
 
   it.each([
     { updatedAt: null, expected: "Not updated" },
@@ -30,6 +35,20 @@ describe("formatRefreshAge", () => {
     },
   ])("returns $expected", ({ updatedAt, expected }) => {
     expect(formatRefreshAge(updatedAt, now)).toBe(expected);
+  });
+
+  it("localizes refresh age labels", () => {
+    setLocale("zh-CN");
+
+    expect(formatRefreshAge(null, now)).toBe("未更新");
+    expect(formatRefreshAge(Date.parse("2026-06-16T12:09:45Z"), now))
+      .toBe("刚刚更新");
+    expect(formatRefreshAge(Date.parse("2026-06-16T12:08:00Z"), now))
+      .toBe("2 分钟前更新");
+    expect(formatRefreshAge(Date.parse("2026-06-16T10:00:00Z"), now))
+      .toBe("2 小时前更新");
+    expect(formatRefreshAge(Date.parse("2026-06-13T10:00:00Z"), now))
+      .toBe("3 天前更新");
   });
 });
 

--- a/frontend/src/lib/utils/refresh.ts
+++ b/frontend/src/lib/utils/refresh.ts
@@ -1,3 +1,5 @@
+import { m } from "../i18n/index.js";
+
 const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
@@ -14,17 +16,23 @@ export function formatRefreshAge(
   updatedAt: number | null | undefined,
   now = Date.now(),
 ): string {
-  if (updatedAt == null) return "Not updated";
+  if (updatedAt == null) return m.shared_refresh_not_updated();
 
   const ageMs = Math.max(0, now - updatedAt);
-  if (ageMs < MINUTE_MS) return "Updated just now";
+  if (ageMs < MINUTE_MS) return m.shared_refresh_just_now();
   if (ageMs < HOUR_MS) {
-    return `Updated ${Math.floor(ageMs / MINUTE_MS)}m ago`;
+    return m.shared_refresh_minutes_ago({
+      count: Math.floor(ageMs / MINUTE_MS),
+    });
   }
   if (ageMs < DAY_MS) {
-    return `Updated ${Math.floor(ageMs / HOUR_MS)}h ago`;
+    return m.shared_refresh_hours_ago({
+      count: Math.floor(ageMs / HOUR_MS),
+    });
   }
-  return `Updated ${Math.floor(ageMs / DAY_MS)}d ago`;
+  return m.shared_refresh_days_ago({
+    count: Math.floor(ageMs / DAY_MS),
+  });
 }
 
 export function createRefreshScheduler(


### PR DESCRIPTION
Localizes remaining hard-coded frontend UI copy across shared date/refresh helpers, Insights quality pattern text, publish fallback errors, and compact content blocks.

The change keeps agent names, model names, API paths, command snippets, file paths, and rendered session/user content unchanged. Count-sensitive labels use Paraglide messages where English needs singular/plural handling.
