### PR TITLE
fix(config): honor CLAUDE_CONFIG_DIR for Claude session discovery

### DIFF
--- a/cmd/agentsview/pg_service_manager.go
+++ b/cmd/agentsview/pg_service_manager.go
@@ -59,6 +59,9 @@ func serviceRuntimeEnvVars() []string {
 		if def.EnvVar != "" {
 			vars = append(vars, def.EnvVar)
 		}
+		if def.DefaultRootEnvVar != "" {
+			vars = append(vars, def.DefaultRootEnvVar)
+		}
 	}
 	return vars
 }

--- a/cmd/agentsview/pg_service_test.go
+++ b/cmd/agentsview/pg_service_test.go
@@ -176,6 +176,7 @@ func TestSetEnvVarsAffectingService(t *testing.T) {
 	// must never appear here even when set.
 	env := map[string]string{
 		"AGENTSVIEW_PG_SCHEMA":  "staging",
+		"CLAUDE_CONFIG_DIR":     "/tmp/claude-root",
 		"CLAUDE_PROJECTS_DIR":   "/tmp/claude",
 		"AGENTSVIEW_PG_URL":     "postgres://from-env",
 		"AGENTSVIEW_PG_MACHINE": "", // set-but-empty should be ignored
@@ -186,6 +187,7 @@ func TestSetEnvVarsAffectingService(t *testing.T) {
 	}
 	got := setEnvVarsAffectingService(lookup)
 	assert.Contains(t, got, "AGENTSVIEW_PG_SCHEMA")
+	assert.Contains(t, got, "CLAUDE_CONFIG_DIR")
 	assert.Contains(t, got, "CLAUDE_PROJECTS_DIR")
 	assert.NotContains(t, got, "AGENTSVIEW_PG_URL")
 	assert.NotContains(t, got, "AGENTSVIEW_PG_MACHINE",
@@ -204,10 +206,15 @@ func TestWarnUninheritedServiceEnv(t *testing.T) {
 	assert.Empty(t, buf.String(), "no warning when nothing is set")
 
 	buf.Reset()
-	warnUninheritedServiceEnv(&buf, []string{"AGENTSVIEW_PG_SCHEMA", "CLAUDE_PROJECTS_DIR"})
+	warnUninheritedServiceEnv(&buf, []string{
+		"AGENTSVIEW_PG_SCHEMA",
+		"CLAUDE_CONFIG_DIR",
+		"CLAUDE_PROJECTS_DIR",
+	})
 	out := buf.String()
 	assert.Contains(t, out, "WARNING")
 	assert.Contains(t, out, "AGENTSVIEW_PG_SCHEMA")
+	assert.Contains(t, out, "CLAUDE_CONFIG_DIR")
 	assert.Contains(t, out, "CLAUDE_PROJECTS_DIR")
 	assert.Contains(t, out, "config.toml")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -294,7 +294,15 @@ func Default() (Config, error) {
 	agentDirSource := make(map[parser.AgentType]dirSource)
 	for _, def := range parser.Registry {
 		dirs := make([]string, len(def.DefaultDirs))
+		root := ""
+		if def.DefaultRootEnvVar != "" {
+			root = os.Getenv(def.DefaultRootEnvVar)
+		}
 		for i, rel := range def.DefaultDirs {
+			if root != "" {
+				dirs[i] = reRootDefaultDir(root, rel)
+				continue
+			}
 			dirs[i] = filepath.Join(home, rel)
 		}
 		agentDirs[def.Type] = dirs
@@ -314,6 +322,14 @@ func Default() (Config, error) {
 		EventsCoalesceInterval:         10 * time.Second,
 		Agent:                          map[string]AgentConfig{},
 	}, nil
+}
+
+func reRootDefaultDir(root, rel string) string {
+	rel = filepath.Clean(rel)
+	if _, tail, ok := strings.Cut(rel, string(filepath.Separator)); ok && tail != "" {
+		return filepath.Join(root, tail)
+	}
+	return root
 }
 
 // Load builds a Config by layering: defaults < config file < env < flags.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -665,6 +665,7 @@ func TestResolveDirs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := setupTestEnv(t)
 			writeConfig(t, dir, tt.config)
+			t.Setenv("CLAUDE_CONFIG_DIR", "")
 			if tt.envValue != "" {
 				t.Setenv("CLAUDE_PROJECTS_DIR", tt.envValue)
 			}
@@ -684,6 +685,53 @@ func TestResolveDirs(t *testing.T) {
 			assert.Equal(t, tt.wantUserConfig, cfg.IsUserConfigured(parser.AgentClaude))
 		})
 	}
+}
+
+func TestResolveDirs_ClaudeConfigDirRootEnvVar(t *testing.T) {
+	t.Run("root env re-roots implicit default", func(t *testing.T) {
+		dir := setupTestEnv(t)
+		root := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", root)
+		writeConfig(t, dir, map[string]any{})
+
+		cfg, err := LoadMinimal()
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{filepath.Join(root, "projects")},
+			cfg.ResolveDirs(parser.AgentClaude))
+		assert.False(t, cfg.IsUserConfigured(parser.AgentClaude))
+	})
+
+	t.Run("projects env beats root env", func(t *testing.T) {
+		dir := setupTestEnv(t)
+		root := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", root)
+		t.Setenv("CLAUDE_PROJECTS_DIR", "/env/override")
+		writeConfig(t, dir, map[string]any{})
+
+		cfg, err := LoadMinimal()
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"/env/override"},
+			cfg.ResolveDirs(parser.AgentClaude))
+		assert.True(t, cfg.IsUserConfigured(parser.AgentClaude))
+	})
+
+	t.Run("config file beats root env", func(t *testing.T) {
+		dir := setupTestEnv(t)
+		root := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", root)
+		writeConfig(t, dir, map[string]any{
+			"claude_project_dirs": []string{"/from/config"},
+		})
+
+		cfg, err := LoadMinimal()
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"/from/config"},
+			cfg.ResolveDirs(parser.AgentClaude))
+		assert.True(t, cfg.IsUserConfigured(parser.AgentClaude))
+	})
 }
 
 func TestResolveDataDir_DefaultAndEnvOverride(t *testing.T) {
@@ -738,6 +786,7 @@ func TestEnvOverridesConfigFile(t *testing.T) {
 
 func TestLoadFile_MalformedDirValueLogsWarning(t *testing.T) {
 	f := newConfigFixture(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
 
 	// Write a config where claude_project_dirs is a string
 	// instead of a string array.

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -59,15 +59,16 @@ const (
 // AgentDef describes a supported coding agent's filesystem
 // layout, configuration keys, and session ID conventions.
 type AgentDef struct {
-	Type         AgentType
-	DisplayName  string   // "Claude Code", "Codex", etc.
-	EnvVar       string   // env var for dir override
-	ConfigKey    string   // TOML key in config.toml ("" = none)
-	DefaultDirs  []string // paths relative to $HOME
-	IDPrefix     string   // session ID prefix ("" for Claude)
-	WatchSubdirs []string // subdirs to watch (nil = watch root)
-	ShallowWatch bool     // true = watch root only, rely on periodic sync for subdirs
-	FileBased    bool     // false for DB-backed agents
+	Type              AgentType
+	DisplayName       string   // "Claude Code", "Codex", etc.
+	EnvVar            string   // env var for dir override
+	DefaultRootEnvVar string   // env var that re-roots DefaultDirs before $HOME fallback
+	ConfigKey         string   // TOML key in config.toml ("" = none)
+	DefaultDirs       []string // paths relative to $HOME
+	IDPrefix          string   // session ID prefix ("" for Claude)
+	WatchSubdirs      []string // subdirs to watch (nil = watch root)
+	ShallowWatch      bool     // true = watch root only, rely on periodic sync for subdirs
+	FileBased         bool     // false for DB-backed agents
 
 	// DiscoverFunc finds session files under a root directory.
 	// Nil for non-file-based agents.
@@ -97,15 +98,16 @@ type AgentDef struct {
 // used for iteration in config, sync, and watcher setup.
 var Registry = []AgentDef{
 	{
-		Type:           AgentClaude,
-		DisplayName:    "Claude Code",
-		EnvVar:         "CLAUDE_PROJECTS_DIR",
-		ConfigKey:      "claude_project_dirs",
-		DefaultDirs:    []string{".claude/projects"},
-		IDPrefix:       "",
-		FileBased:      true,
-		DiscoverFunc:   DiscoverClaudeProjects,
-		FindSourceFunc: FindClaudeSourceFile,
+		Type:              AgentClaude,
+		DisplayName:       "Claude Code",
+		EnvVar:            "CLAUDE_PROJECTS_DIR",
+		DefaultRootEnvVar: "CLAUDE_CONFIG_DIR",
+		ConfigKey:         "claude_project_dirs",
+		DefaultDirs:       []string{".claude/projects"},
+		IDPrefix:          "",
+		FileBased:         true,
+		DiscoverFunc:      DiscoverClaudeProjects,
+		FindSourceFunc:    FindClaudeSourceFile,
 	},
 	{
 		Type:           AgentCowork,

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -89,16 +89,41 @@ func buildResolveScript() string {
 		}
 		for _, rel := range def.DefaultDirs {
 			defaultDir := "$HOME/" + rel
-			dirExpr := defaultDir
-			if def.EnvVar != "" {
-				// env var overrides default
-				dirExpr = fmt.Sprintf("${%s:-%s}", def.EnvVar, defaultDir)
+			if def.DefaultRootEnvVar != "" {
+				rootTail := remoteDefaultRootTail(rel)
+				fmt.Fprintf(&b, "dir=\"")
+				if def.EnvVar != "" {
+					fmt.Fprintf(&b, "${%s:-}", def.EnvVar)
+				}
+				fmt.Fprintf(&b, "\"; ")
+				fmt.Fprintf(&b, "root=\"${%s:-}\"; ", def.DefaultRootEnvVar)
+				if rootTail != "" {
+					fmt.Fprintf(&b,
+						"[ -z \"$dir\" ] && [ -n \"$root\" ] && dir=\"$root/%s\"; ",
+						rootTail,
+					)
+				} else {
+					fmt.Fprintf(&b,
+						"[ -z \"$dir\" ] && [ -n \"$root\" ] && dir=\"$root\"; ",
+					)
+				}
+				fmt.Fprintf(&b,
+					"[ -n \"$dir\" ] || dir=\"%s\"; [ -d \"$dir\" ] && "+
+						"printf '%%s\\000' \"%s:$dir\"\n",
+					defaultDir, string(def.Type),
+				)
+			} else {
+				dirExpr := defaultDir
+				if def.EnvVar != "" {
+					// env var overrides default
+					dirExpr = fmt.Sprintf("${%s:-%s}", def.EnvVar, defaultDir)
+				}
+				fmt.Fprintf(&b,
+					"dir=\"%s\"; [ -d \"$dir\" ] && "+
+						"printf '%%s\\000' \"%s:$dir\"\n",
+					dirExpr, string(def.Type),
+				)
 			}
-			fmt.Fprintf(&b,
-				"dir=\"%s\"; [ -d \"$dir\" ] && "+
-					"printf '%%s\\000' \"%s:$dir\"\n",
-				dirExpr, string(def.Type),
-			)
 			// Codex stores renameable session titles in
 			// session_index.jsonl, which sits beside (not inside)
 			// sessions/ and archived_sessions/. Emit it so renames
@@ -118,6 +143,14 @@ func buildResolveScript() string {
 	// path doesn't exist, which would make sh exit non-zero.
 	b.WriteString("true\n")
 	return b.String()
+}
+
+func remoteDefaultRootTail(rel string) string {
+	cleaned := path.Clean(rel)
+	if _, tail, ok := strings.Cut(cleaned, "/"); ok && tail != "" {
+		return tail
+	}
+	return ""
 }
 
 // parseResolvedDirs parses script output into a map of agent type to transfer

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -18,6 +18,7 @@ func TestBuildResolveScript(t *testing.T) {
 
 	// Claude has CLAUDE_PROJECTS_DIR env var — must be referenced.
 	assert.Contains(t, script, "CLAUDE_PROJECTS_DIR")
+	assert.Contains(t, script, "CLAUDE_CONFIG_DIR")
 
 	// Non-file-based agents must not appear.
 	for _, def := range parser.Registry {
@@ -38,6 +39,26 @@ func TestBuildResolveScript(t *testing.T) {
 		assert.Contains(t, script, marker,
 			"file-based agent %s missing from script", def.Type)
 	}
+}
+
+func TestResolveScriptHonorsClaudeConfigDirRoot(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".claude-personal")
+	projectsDir := filepath.Join(root, "projects")
+	require.NoError(t, os.MkdirAll(projectsDir, 0o755), "mkdir projects")
+
+	script := buildResolveScript()
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = []string{
+		"HOME=" + home,
+		"CLAUDE_CONFIG_DIR=" + root,
+	}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "resolve script failed: output: %s", out)
+
+	dirs, _ := parseResolvedDirs(string(out))
+	assert.Contains(t, dirs[parser.AgentClaude], root+"/projects")
+	assert.NotContains(t, dirs[parser.AgentClaude], home+"/.claude/projects")
 }
 
 func TestResolveScriptExitsZero(t *testing.T) {


### PR DESCRIPTION
When Claude Code runs with `CLAUDE_CONFIG_DIR` set, it stores project data under that custom root, but agentsview still looks only at the default `~/.claude/projects` path unless users also set `CLAUDE_PROJECTS_DIR`. That leaves normal discovery, usage, and stats commands blind to Claude sessions in the common "custom config dir, default projects subdir" setup, and it also leaves remote SSH discovery and pg-service install warnings out of sync with the same Claude root contract.

This change teaches the Claude implicit default to honor `CLAUDE_CONFIG_DIR` without changing the existing precedence contract. `CLAUDE_PROJECTS_DIR` still wins as the explicit path override, `claude_project_dirs` in `config.toml` still beats the implicit default, and the new behavior only re-roots the fallback path when neither stronger override is present. The env-var name stays on the Claude registry entry, config loading still owns the final path expansion, the remote SSH resolver now follows the same root-env fallback when it builds transfer targets, and `pg service install` now warns when `CLAUDE_CONFIG_DIR` would affect runtime discovery but the background service would not inherit it.

The tests cover the re-rooted default, `CLAUDE_PROJECTS_DIR` precedence, config-file precedence, the remote resolve script's Claude root-env fallback, and the pg-service warning surface, so the fix stays narrow and auditable against the existing discovery contract.

Fixes #317
