### PR TITLE
feat(postgres): implement PG serve session curation and insight persistence

### DIFF
--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -418,6 +418,14 @@ func runPGServe(appCfg config.Config, basePath string) {
 	); err != nil {
 		fatal("pg serve: %v", err)
 	}
+	if err := store.DetectInsightGenerationAvailability(
+		ctx,
+	); err != nil {
+		fatal(
+			"pg serve: probing insight generation capability: %v",
+			err,
+		)
+	}
 
 	rtOpts := serveRuntimeOptions{
 		Mode:          "pg-serve",
@@ -434,7 +442,7 @@ func runPGServe(appCfg config.Config, basePath string) {
 			Commit:                     commit,
 			BuildDate:                  buildDate,
 			ReadOnly:                   true,
-			InsightGenerationAvailable: true,
+			InsightGenerationAvailable: store.InsightGenerationAvailable(),
 		}),
 		server.WithDataDir(appCfg.DataDir),
 		server.WithBaseContext(ctx),

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -430,10 +430,11 @@ func runPGServe(appCfg config.Config, basePath string) {
 
 	opts := []server.Option{
 		server.WithVersion(server.VersionInfo{
-			Version:   version,
-			Commit:    commit,
-			BuildDate: buildDate,
-			ReadOnly:  true,
+			Version:                    version,
+			Commit:                     commit,
+			BuildDate:                  buildDate,
+			ReadOnly:                   true,
+			InsightGenerationAvailable: true,
 		}),
 		server.WithDataDir(appCfg.DataDir),
 		server.WithBaseContext(ctx),

--- a/frontend/src/lib/api/generated/models/VersionInfo.ts
+++ b/frontend/src/lib/api/generated/models/VersionInfo.ts
@@ -7,7 +7,7 @@ export type VersionInfo = {
   build_date: string;
   commit: string;
   data_version: number;
+  insight_generation_available?: boolean;
   read_only?: boolean;
   version: string;
 };
-

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -3,6 +3,7 @@ export interface VersionInfo {
   version: string;
   commit: string;
   build_date: string;
+  insight_generation_available?: boolean;
   read_only?: boolean;
 }
 

--- a/frontend/src/lib/components/activity/ActivityInsight.svelte
+++ b/frontend/src/lib/components/activity/ActivityInsight.svelte
@@ -55,12 +55,15 @@
     router.navigate("insights");
   }
 
-  const readOnly = $derived(sync.serverVersion?.read_only === true);
+  const insightGenerationAvailable = $derived(
+    sync.serverVersion?.insight_generation_available === true ||
+      sync.serverVersion?.read_only !== true,
+  );
   const generationUnavailable = $derived(
-    sync.serverVersion === null || readOnly,
+    sync.serverVersion === null || !insightGenerationAvailable,
   );
   const unavailableTitle = $derived(
-    readOnly
+    sync.serverVersion !== null && !insightGenerationAvailable
       ? m.activity_insight_unavailable_read_only()
       : sync.serverVersion === null
         ? m.activity_insight_waiting_server()

--- a/frontend/src/lib/components/activity/ActivityInsight.test.ts
+++ b/frontend/src/lib/components/activity/ActivityInsight.test.ts
@@ -13,13 +13,20 @@ const mocks = vi.hoisted(() => ({
   setAgent: vi.fn(),
   navigate: vi.fn(),
   agent: "claude" as string,
-  serverVersion: { read_only: false } as { read_only: boolean } | null,
+  serverVersion: {
+    read_only: false,
+  } as {
+    read_only: boolean;
+    insight_generation_available?: boolean;
+  } | null,
 }));
 vi.mock("../../api/generated/index", () => ({
   InsightsService: { getApiV1Insights: mocks.getInsights },
 }));
 vi.mock("../../api/runtime.js", () => ({ configureGeneratedClient: vi.fn() }));
-vi.mock("../../api/client.js", () => ({ generateInsight: mocks.generateInsight }));
+vi.mock("../../api/client.js", () => ({
+  generateInsight: mocks.generateInsight,
+}));
 vi.mock("../../stores/sync.svelte.js", () => ({
   sync: {
     get serverVersion() {
@@ -93,7 +100,10 @@ describe("ActivityInsight", () => {
   });
 
   it("generates for the current range", async () => {
-    mocks.generateInsight.mockReturnValue({ abort: vi.fn(), done: new Promise(() => {}) });
+    mocks.generateInsight.mockReturnValue({
+      abort: vi.fn(),
+      done: new Promise(() => {}),
+    });
     render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
     await settle();
     await fireEvent.click(screen.getByRole("button", { name: /generate/i }));
@@ -178,7 +188,9 @@ describe("ActivityInsight", () => {
   it("prefills the Insights page range and navigates", async () => {
     render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
     await settle();
-    const link = screen.getByRole("link", { name: /insights page|open in insights/i });
+    const link = screen.getByRole("link", {
+      name: /insights page|open in insights/i,
+    });
     await fireEvent.click(link);
     expect(mocks.setType).toHaveBeenCalledWith("daily_activity");
     expect(mocks.setDateFrom).toHaveBeenCalledWith("2026-06-15");
@@ -193,6 +205,17 @@ describe("ActivityInsight", () => {
     await settle();
     const btn = screen.getByRole("button", { name: /generate/i });
     expect(btn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("allows Generate in read-only mode when insight generation is advertised", async () => {
+    mocks.serverVersion = {
+      read_only: true,
+      insight_generation_available: true,
+    };
+    render(ActivityInsight, { dateFrom: "2026-06-15", dateTo: "2026-06-21" });
+    await settle();
+    const btn = screen.getByRole("button", { name: /generate/i });
+    expect(btn.hasAttribute("disabled")).toBe(false);
   });
 
   it("selects the exact-range insight over a newer nested one", async () => {

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -81,11 +81,12 @@
   );
   const loading = $derived(analytics.loading.signals);
   const error = $derived(analytics.errors.signals);
-  const readOnly = $derived(
-    sync.serverVersion?.read_only === true,
+  const insightGenerationAvailable = $derived(
+    sync.serverVersion?.insight_generation_available === true ||
+      sync.serverVersion?.read_only !== true,
   );
   const generationUnavailable = $derived(
-    sync.serverVersion === null || readOnly,
+    sync.serverVersion === null || !insightGenerationAvailable,
   );
   const earliestSession = $derived(sync.stats?.earliest_session ?? null);
   const rangeSelection = $derived(
@@ -1093,7 +1094,7 @@
         <button
           class="generate-action"
           disabled={generationUnavailable}
-          title={readOnly
+          title={sync.serverVersion !== null && !insightGenerationAvailable
             ? m.insights_page_generate_disabled()
             : m.insights_page_generate_title()}
           onclick={handleGenerateCanned}

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -20,15 +20,11 @@ describe("InsightsPage sidebar filter sync", () => {
     // sidebar toggle, map it to all/human, and write both fields.
     const normalized = source.replace(/\s+/g, " ");
     expect(source).toContain("sessions.filters.includeAutomated");
-    expect(normalized).toContain(
-      'headerIncludeAutomated ? "all" : "human"',
-    );
+    expect(normalized).toContain('headerIncludeAutomated ? "all" : "human"');
     expect(source).toContain(
       "analytics.includeAutomated = headerIncludeAutomated",
     );
-    expect(source).toContain(
-      "analytics.automatedScope = headerAutomatedScope",
-    );
+    expect(source).toContain("analytics.automatedScope = headerAutomatedScope");
   });
 
   it("refetches when the automated scope changes", () => {
@@ -95,9 +91,7 @@ describe("InsightsPage date yoke controls", () => {
   });
 
   it("routes automated scope changes through the insight refresh wrapper", () => {
-    const handlerIndex = source.indexOf(
-      "function handleAutomatedScopeChange",
-    );
+    const handlerIndex = source.indexOf("function handleAutomatedScopeChange");
     const nextHandlerIndex = source.indexOf(
       "\n\n  function handlePromptChange",
       handlerIndex,
@@ -165,6 +159,15 @@ const state = vi.hoisted(() => {
   };
 });
 
+const syncState = vi.hoisted(() => ({
+  serverVersion: {
+    read_only: false,
+  } as {
+    read_only: boolean;
+    insight_generation_available?: boolean;
+  },
+}));
+
 vi.mock("../../api/client.js", () => ({
   downloadInsightExport: mocks.downloadInsightExport,
   watchEvents: mocks.watchEvents,
@@ -195,17 +198,22 @@ vi.mock("../../stores/sessions.svelte.js", () => ({
 
 vi.mock("../../stores/sync.svelte.js", () => ({
   sync: {
-    serverVersion: { read_only: false },
+    get serverVersion() {
+      return syncState.serverVersion;
+    },
   },
 }));
 
 vi.mock("../../paraglide/messages.js", () => {
-  const stub = new Proxy({}, {
-    get(_target, prop) {
-      if (prop === "m") return stub;
-      return () => String(prop);
+  const stub = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === "m") return stub;
+        return () => String(prop);
+      },
     },
-  });
+  );
   return stub;
 });
 
@@ -227,6 +235,7 @@ describe("InsightsPage selected insight actions", () => {
     ui.activeModal = null;
     ui.publishSecret = false;
     ui.clearPublishTarget();
+    syncState.serverVersion = { read_only: false };
     state.insightsStore.selectedItem = state.selectedInsight;
     state.insightsStore.selectedId = state.selectedInsight.id;
     state.insightsStore.items = [state.selectedInsight];
@@ -293,5 +302,20 @@ describe("InsightsPage selected insight actions", () => {
       kind: "insight",
       id: 42,
     });
+  });
+
+  it("keeps Generate enabled for pg serve when version advertises insight writes", async () => {
+    syncState.serverVersion = {
+      read_only: true,
+      insight_generation_available: true,
+    };
+    component = mount(InsightsPage, { target: document.body });
+    await tick();
+
+    const generateButton = document.querySelector<HTMLButtonElement>(
+      "button.generate-action",
+    );
+    expect(generateButton).toBeDefined();
+    expect(generateButton!.disabled).toBe(false);
   });
 });

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -91,14 +91,14 @@ type Store interface {
 	UnpinMessage(sessionID string, messageID int64) error
 	ListPinnedMessages(ctx context.Context, sessionID string, project string) ([]PinnedMessage, error)
 
-	// Insights (local-only; PG returns ErrReadOnly).
+	// Insights.
 	ListInsights(ctx context.Context, f InsightFilter) ([]Insight, error)
 	GetInsight(ctx context.Context, id int64) (*Insight, error)
 	GetCachedInsight(ctx context.Context, cacheKey string) (*Insight, error)
 	InsertInsight(s Insight) (int64, error)
 	DeleteInsight(id int64) error
 
-	// Session management (local-only; PG returns ErrReadOnly).
+	// Session management.
 	RenameSession(id string, displayName *string) error
 	SoftDeleteSession(id string) error
 	SoftDeleteSessions(ids []string) (int, error)

--- a/internal/postgres/insights_pgtest_test.go
+++ b/internal/postgres/insights_pgtest_test.go
@@ -1,0 +1,83 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestStoreInsightCRUD(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	ctx := context.Background()
+	project := "insight-project"
+	cacheKey := "insight-cache-key"
+
+	firstID, err := store.InsertInsight(db.Insight{
+		Type:        "daily_activity",
+		DateFrom:    "2026-03-12",
+		DateTo:      "2026-03-12",
+		Project:     &project,
+		Agent:       "claude",
+		Content:     "first insight",
+		CacheKey:    cacheKey,
+		CacheStatus: "fresh",
+	})
+	require.NoError(t, err, "InsertInsight first")
+	require.NotZero(t, firstID)
+
+	time.Sleep(10 * time.Millisecond)
+
+	secondID, err := store.InsertInsight(db.Insight{
+		Type:        "daily_activity",
+		DateFrom:    "2026-03-12",
+		DateTo:      "2026-03-12",
+		Project:     &project,
+		Agent:       "claude",
+		Content:     "second insight",
+		CacheKey:    cacheKey,
+		CacheStatus: "hit",
+	})
+	require.NoError(t, err, "InsertInsight second")
+	require.NotZero(t, secondID)
+	assert.NotEqual(t, firstID, secondID)
+
+	listed, err := store.ListInsights(ctx, db.InsightFilter{
+		Type:    "daily_activity",
+		Project: project,
+	})
+	require.NoError(t, err, "ListInsights")
+	require.Len(t, listed, 2)
+	assert.Equal(t, secondID, listed[0].ID)
+	assert.Equal(t, firstID, listed[1].ID)
+
+	got, err := store.GetInsight(ctx, firstID)
+	require.NoError(t, err, "GetInsight")
+	require.NotNil(t, got)
+	assert.Equal(t, "first insight", got.Content)
+	require.NotNil(t, got.Project)
+	assert.Equal(t, project, *got.Project)
+
+	cached, err := store.GetCachedInsight(ctx, cacheKey)
+	require.NoError(t, err, "GetCachedInsight")
+	require.NotNil(t, cached)
+	assert.Equal(t, secondID, cached.ID)
+	assert.Equal(t, "hit", cached.CacheStatus)
+
+	require.NoError(t, store.DeleteInsight(firstID), "DeleteInsight first")
+	got, err = store.GetInsight(ctx, firstID)
+	require.NoError(t, err, "GetInsight after delete")
+	assert.Nil(t, got)
+}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -22,6 +22,7 @@ import (
 const (
 	lastPushBoundaryStateKey     = "last_push_boundary_state"
 	lastPushTargetFingerprintKey = "pg_target_fingerprint_v1"
+	sessionAliasBackfillStateKey = "pg_session_alias_backfill_v1"
 )
 
 // pushMarkerIDStateKey names the local sync-state entry holding this DB's
@@ -131,6 +132,18 @@ func (s *Sync) Push(
 	legacyMarkerMachines := pushMarkerLegacyMachines(
 		markerMachine, markerMachineAliases,
 	)
+	aliasBackfillNeeded := false
+	full, aliasBackfillNeeded, err = applySessionAliasBackfillRequirement(
+		state, full,
+	)
+	if err != nil {
+		return result, err
+	}
+	if aliasBackfillNeeded {
+		log.Printf(
+			"pgsync: session alias backfill marker missing; forcing full push",
+		)
+	}
 	if full {
 		lastPush = ""
 		// Caller requested a full push — the PG schema
@@ -325,6 +338,11 @@ func (s *Sync) Push(
 		); err != nil {
 			return result, err
 		}
+		if err := completeSessionAliasBackfill(
+			state, aliasBackfillNeeded, result,
+		); err != nil {
+			return result, err
+		}
 		result.Duration = time.Since(start)
 		return result, nil
 	}
@@ -421,6 +439,11 @@ func (s *Sync) Push(
 	// rather than skipping the still-missing sessions.
 	if err := s.writePushMarker(
 		ctx, markerID, markerMachine, markerMachineAliases,
+	); err != nil {
+		return result, err
+	}
+	if err := completeSessionAliasBackfill(
+		state, aliasBackfillNeeded, result,
 	); err != nil {
 		return result, err
 	}
@@ -881,6 +904,49 @@ func clearPushState(local syncStateStore) error {
 		)
 	}
 	return nil
+}
+
+func applySessionAliasBackfillRequirement(
+	local syncStateStore, full bool,
+) (bool, bool, error) {
+	needed, err := sessionAliasBackfillNeeded(local)
+	if err != nil {
+		return full, false, err
+	}
+	if !needed {
+		return full, false, nil
+	}
+	return true, true, nil
+}
+
+func sessionAliasBackfillNeeded(local syncStateStore) (bool, error) {
+	done, err := local.GetSyncState(sessionAliasBackfillStateKey)
+	if err != nil {
+		return false, fmt.Errorf(
+			"reading %s: %w", sessionAliasBackfillStateKey, err,
+		)
+	}
+	return done != "1", nil
+}
+
+func markSessionAliasBackfillDone(local syncStateStore) error {
+	if err := local.SetSyncState(
+		sessionAliasBackfillStateKey, "1",
+	); err != nil {
+		return fmt.Errorf(
+			"updating %s: %w", sessionAliasBackfillStateKey, err,
+		)
+	}
+	return nil
+}
+
+func completeSessionAliasBackfill(
+	local syncStateStore, needed bool, result PushResult,
+) error {
+	if !needed || result.Errors > 0 || result.SkippedConflicts > 0 {
+		return nil
+	}
+	return markSessionAliasBackfillDone(local)
 }
 
 func persistPushTargetFingerprint(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1147,16 +1147,21 @@ func pgSessionExcluded(
 }
 
 func deletePGSessionIfExcluded(
-	ctx context.Context, tx *sql.Tx, id string,
+	ctx context.Context, tx *sql.Tx, sess db.Session,
 ) (bool, error) {
-	excluded, err := pgSessionExcluded(ctx, tx, id)
+	excluded, err := pgSessionExcluded(ctx, tx, sess.ID)
 	if err != nil {
 		return false, err
 	}
 	if !excluded {
 		return false, nil
 	}
-	if err := deletePGExcludedSessionRows(ctx, tx, []string{id}); err != nil {
+	if err := insertPGExcludedSessionIDs(
+		ctx, tx, pgSessionAliasIDs(sess),
+	); err != nil {
+		return false, err
+	}
+	if err := deletePGExcludedSessionRows(ctx, tx, []string{sess.ID}); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -1593,9 +1598,7 @@ func (s *Sync) pushSession(
 		return err
 	}
 	if rowsAffected, rowsErr := result.RowsAffected(); rowsErr == nil && rowsAffected == 0 {
-		excluded, excludedErr := deletePGSessionIfExcluded(
-			ctx, tx, sess.ID,
-		)
+		excluded, excludedErr := deletePGSessionIfExcluded(ctx, tx, sess)
 		if excludedErr != nil {
 			return excludedErr
 		}
@@ -1628,12 +1631,15 @@ func (s *Sync) pushSession(
 			return errSessionOwnershipConflict
 		}
 	}
-	excluded, excludedErr := deletePGSessionIfExcluded(ctx, tx, sess.ID)
+	excluded, excludedErr := deletePGSessionIfExcluded(ctx, tx, sess)
 	if excludedErr != nil {
 		return excludedErr
 	}
 	if excluded {
 		return errSessionExcluded
+	}
+	if err := replacePGSessionAliases(ctx, tx, sess); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1302,8 +1302,9 @@ func (s *Sync) pushSession(
 	result, err := tx.ExecContext(ctx, `
 		INSERT INTO sessions (
 			id, machine, owner_marker, project, agent,
-			first_message, display_name, session_name,
-			created_at, started_at, ended_at, deleted_at,
+			first_message, display_name, source_display_name,
+			session_name, created_at, started_at, ended_at,
+			deleted_at, source_deleted_at,
 			message_count, user_message_count,
 			total_output_tokens, peak_context_tokens,
 			has_total_output_tokens, has_peak_context_tokens,
@@ -1330,19 +1331,19 @@ func (s *Sync) pushSession(
 			updated_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8,
-			$9, $10, $11, $12,
-			$13, $14, $15, $16,
-			$17, $18, $19, $20,
-			$21, $22, $23, $24, $25, $26, $27,
-			$28, $29,
-			$30, $31, $32, $33,
-			$34, $35, $36, $37,
-			$38,
-			$39, $40,
-			$41,
-			$42, $43, $44, $45,
-			$46, $47,
-			$48, $49, $50, $51, $52, $53, $54, $55,
+			$9, $10, $11, $12, $13, $14,
+			$15, $16, $17, $18,
+			$19, $20, $21, $22,
+			$23, $24, $25, $26, $27, $28, $29,
+			$30, $31,
+			$32, $33, $34, $35,
+			$36, $37, $38, $39,
+			$40,
+			$41, $42,
+			$43,
+			$44, $45, $46, $47,
+			$48, $49,
+			$50, $51, $52, $53, $54, $55, $56, $57,
 			NOW()
 		)
 		ON CONFLICT (id) DO UPDATE SET
@@ -1351,18 +1352,22 @@ func (s *Sync) pushSession(
 			project = EXCLUDED.project,
 			agent = EXCLUDED.agent,
 			first_message = EXCLUDED.first_message,
-			display_name = COALESCE(
-				sessions.display_name,
-				EXCLUDED.display_name
-			),
+			display_name = CASE
+				WHEN sessions.display_name IS DISTINCT FROM
+					sessions.source_display_name THEN sessions.display_name
+				ELSE EXCLUDED.display_name
+			END,
+			source_display_name = EXCLUDED.display_name,
 			session_name = EXCLUDED.session_name,
 			created_at = EXCLUDED.created_at,
 			started_at = EXCLUDED.started_at,
 			ended_at = EXCLUDED.ended_at,
-			deleted_at = COALESCE(
-				sessions.deleted_at,
-				EXCLUDED.deleted_at
-			),
+			deleted_at = CASE
+				WHEN sessions.deleted_at IS DISTINCT FROM
+					sessions.source_deleted_at THEN sessions.deleted_at
+				ELSE EXCLUDED.deleted_at
+			END,
+			source_deleted_at = EXCLUDED.deleted_at,
 			message_count = EXCLUDED.message_count,
 			user_message_count = EXCLUDED.user_message_count,
 			total_output_tokens = EXCLUDED.total_output_tokens,
@@ -1413,7 +1418,7 @@ func (s *Sync) pushSession(
 					OR sessions.machine = 'local'
 					OR sessions.machine = ''
 					OR sessions.machine IN (
-						SELECT jsonb_array_elements_text($56::jsonb)
+						SELECT jsonb_array_elements_text($58::jsonb)
 					))
 			)
 			OR sessions.owner_marker = EXCLUDED.owner_marker)
@@ -1423,18 +1428,12 @@ func (s *Sync) pushSession(
 			OR sessions.project IS DISTINCT FROM EXCLUDED.project
 			OR sessions.agent IS DISTINCT FROM EXCLUDED.agent
 			OR sessions.first_message IS DISTINCT FROM EXCLUDED.first_message
-			OR (
-				sessions.display_name IS NULL
-				AND sessions.display_name IS DISTINCT FROM EXCLUDED.display_name
-			)
+			OR sessions.source_display_name IS DISTINCT FROM EXCLUDED.display_name
 			OR sessions.session_name IS DISTINCT FROM EXCLUDED.session_name
 			OR sessions.created_at IS DISTINCT FROM EXCLUDED.created_at
 			OR sessions.started_at IS DISTINCT FROM EXCLUDED.started_at
 			OR sessions.ended_at IS DISTINCT FROM EXCLUDED.ended_at
-			OR (
-				sessions.deleted_at IS NULL
-				AND sessions.deleted_at IS DISTINCT FROM EXCLUDED.deleted_at
-			)
+			OR sessions.source_deleted_at IS DISTINCT FROM EXCLUDED.deleted_at
 			OR sessions.message_count IS DISTINCT FROM EXCLUDED.message_count
 			OR sessions.user_message_count IS DISTINCT FROM EXCLUDED.user_message_count
 			OR sessions.total_output_tokens IS DISTINCT FROM EXCLUDED.total_output_tokens
@@ -1483,10 +1482,12 @@ func (s *Sync) pushSession(
 		sess.Agent,
 		nilStr(sess.FirstMessage),
 		nilStr(sess.DisplayName),
+		nilStr(sess.DisplayName),
 		nilStr(sess.SessionName),
 		createdAt,
 		nilStrTS(sess.StartedAt),
 		nilStrTS(sess.EndedAt),
+		nilStrTS(sess.DeletedAt),
 		nilStrTS(sess.DeletedAt),
 		sess.MessageCount, sess.UserMessageCount,
 		sess.TotalOutputTokens, sess.PeakContextTokens,

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -257,6 +257,16 @@ func (s *Sync) Push(
 		}
 	}
 
+	excludedIDs, err := readPGExcludedSessionIDs(
+		ctx, s.pg, mapKeys(sessionByID),
+	)
+	if err != nil {
+		return result, err
+	}
+	for id := range excludedIDs {
+		delete(sessionByID, id)
+	}
+
 	usageFingerprints, err := s.local.UsageEventFingerprints(
 		mapKeys(sessionByID),
 	)
@@ -1044,6 +1054,47 @@ func localSessionSyncMarker(sess db.Session) string {
 		marker = sess.CreatedAt
 	}
 	return marker
+}
+
+func readPGExcludedSessionIDs(
+	ctx context.Context, pg *sql.DB, ids []string,
+) (map[string]struct{}, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	pb := &paramBuilder{}
+	placeholders := make([]string, 0, len(ids))
+	for _, id := range ids {
+		placeholders = append(placeholders, pb.add(id))
+	}
+	rows, err := pg.QueryContext(ctx,
+		`SELECT id FROM excluded_sessions
+		 WHERE id IN (`+strings.Join(placeholders, ",")+`)`,
+		pb.args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"reading pg excluded sessions: %w", err,
+		)
+	}
+	defer rows.Close()
+
+	excluded := make(map[string]struct{})
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf(
+				"scanning pg excluded session id: %w", err,
+			)
+		}
+		excluded[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating pg excluded sessions: %w", err,
+		)
+	}
+	return excluded, nil
 }
 
 // sessionPushFingerprint builds the change-detection fingerprint for a

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -258,20 +258,10 @@ func (s *Sync) Push(
 		}
 	}
 
-	excludedIDs, err := readPGExcludedSessionIDs(
-		ctx, s.pg, mapKeys(sessionByID),
-	)
-	if err != nil {
-		return result, err
-	}
-	excludedIDList := mapSetKeys(excludedIDs)
-	if err := deletePGExcludedSessionRows(
-		ctx, s.pg, excludedIDList,
+	if err := purgePGExcludedPushSessions(
+		ctx, s.pg, sessionByID,
 	); err != nil {
 		return result, err
-	}
-	for _, id := range excludedIDList {
-		delete(sessionByID, id)
 	}
 
 	usageFingerprints, err := s.local.UsageEventFingerprints(
@@ -1017,14 +1007,6 @@ func mapKeys(m map[string]db.Session) []string {
 	return keys
 }
 
-func mapSetKeys(m map[string]struct{}) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
 func localSessionSyncMarker(sess db.Session) string {
 	marker, err := NormalizeLocalSyncTimestamp(sess.CreatedAt)
 	if err != nil || marker == "" {
@@ -1113,6 +1095,53 @@ func pgExcludedSessionIDsQuery(ids []string) (string, []any) {
 			 WHERE id = ANY($1)`, []any{ids}
 }
 
+func purgePGExcludedPushSessions(
+	ctx context.Context, pg *sql.DB, sessionByID map[string]db.Session,
+) error {
+	tombstoneIDsBySession := make(map[string][]string, len(sessionByID))
+	candidateIDs := []string{}
+	for id, sess := range sessionByID {
+		tombstoneIDs := pgSessionTombstoneIDs(sess)
+		tombstoneIDsBySession[id] = tombstoneIDs
+		candidateIDs = append(candidateIDs, tombstoneIDs...)
+	}
+	excludedIDs, err := readPGExcludedSessionIDs(ctx, pg, candidateIDs)
+	if err != nil {
+		return err
+	}
+	if len(excludedIDs) == 0 {
+		return nil
+	}
+
+	purgeIDs := []string{}
+	for id, tombstoneIDs := range tombstoneIDsBySession {
+		if !hasPGExcludedSessionID(tombstoneIDs, excludedIDs) {
+			continue
+		}
+		purgeIDs = append(purgeIDs, tombstoneIDs...)
+		delete(sessionByID, id)
+	}
+	purgeIDs = uniqueNonEmptyStrings(purgeIDs)
+	if len(purgeIDs) == 0 {
+		return nil
+	}
+	if err := insertPGExcludedSessionIDs(ctx, pg, purgeIDs); err != nil {
+		return err
+	}
+	return deletePGExcludedSessionRows(ctx, pg, purgeIDs)
+}
+
+func hasPGExcludedSessionID(
+	ids []string, excluded map[string]struct{},
+) bool {
+	for _, id := range ids {
+		if _, ok := excluded[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 type pgSessionQueryer interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 }
@@ -1139,8 +1168,7 @@ func deletePGExcludedSessionRows(
 func deletePGSessionIfExcluded(
 	ctx context.Context, tx *sql.Tx, sess db.Session,
 ) (bool, error) {
-	ids := append([]string{sess.ID}, pgSessionAliasIDs(sess)...)
-	ids = uniqueNonEmptyStrings(ids)
+	ids := pgSessionTombstoneIDs(sess)
 	excluded, err := readPGExcludedSessionIDs(ctx, tx, ids)
 	if err != nil {
 		return false, err

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1146,6 +1146,22 @@ func pgSessionExcluded(
 	return excluded, nil
 }
 
+func deletePGSessionIfExcluded(
+	ctx context.Context, tx *sql.Tx, id string,
+) (bool, error) {
+	excluded, err := pgSessionExcluded(ctx, tx, id)
+	if err != nil {
+		return false, err
+	}
+	if !excluded {
+		return false, nil
+	}
+	if err := deletePGExcludedSessionRows(ctx, tx, []string{id}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // sessionPushFingerprint builds the change-detection fingerprint for a
 // session. pushedMachine is the value pushSession actually writes to PG
 // (pushedSessionMachine), not the raw sess.Machine: a "local"/empty sentinel
@@ -1474,6 +1490,10 @@ func (s *Sync) pushSession(
 					))
 			)
 			OR sessions.owner_marker = EXCLUDED.owner_marker)
+			AND NOT EXISTS (
+				SELECT 1 FROM excluded_sessions
+				WHERE id = EXCLUDED.id
+			)
 			AND (
 			sessions.machine IS DISTINCT FROM EXCLUDED.machine
 			OR sessions.owner_marker IS DISTINCT FROM EXCLUDED.owner_marker
@@ -1573,16 +1593,13 @@ func (s *Sync) pushSession(
 		return err
 	}
 	if rowsAffected, rowsErr := result.RowsAffected(); rowsErr == nil && rowsAffected == 0 {
-		excluded, excludedErr := pgSessionExcluded(ctx, tx, sess.ID)
+		excluded, excludedErr := deletePGSessionIfExcluded(
+			ctx, tx, sess.ID,
+		)
 		if excludedErr != nil {
 			return excludedErr
 		}
 		if excluded {
-			if err := deletePGExcludedSessionRows(
-				ctx, tx, []string{sess.ID},
-			); err != nil {
-				return err
-			}
 			return errSessionExcluded
 		}
 		refreshErr := tx.QueryRowContext(ctx,
@@ -1610,6 +1627,13 @@ func (s *Sync) pushSession(
 			)
 			return errSessionOwnershipConflict
 		}
+	}
+	excluded, excludedErr := deletePGSessionIfExcluded(ctx, tx, sess.ID)
+	if excludedErr != nil {
+		return excludedErr
+	}
+	if excluded {
+		return errSessionExcluded
 	}
 	return nil
 }

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1062,16 +1062,8 @@ func readPGExcludedSessionIDs(
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	pb := &paramBuilder{}
-	placeholders := make([]string, 0, len(ids))
-	for _, id := range ids {
-		placeholders = append(placeholders, pb.add(id))
-	}
-	rows, err := pg.QueryContext(ctx,
-		`SELECT id FROM excluded_sessions
-		 WHERE id IN (`+strings.Join(placeholders, ",")+`)`,
-		pb.args...,
-	)
+	query, args := pgExcludedSessionIDsQuery(ids)
+	rows, err := pg.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"reading pg excluded sessions: %w", err,
@@ -1095,6 +1087,11 @@ func readPGExcludedSessionIDs(
 		)
 	}
 	return excluded, nil
+}
+
+func pgExcludedSessionIDsQuery(ids []string) (string, []any) {
+	return `SELECT id FROM excluded_sessions
+		 WHERE id = ANY($1)`, []any{ids}
 }
 
 // sessionPushFingerprint builds the change-detection fingerprint for a

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1300,12 +1300,18 @@ func (s *Sync) pushSession(
 			project = EXCLUDED.project,
 			agent = EXCLUDED.agent,
 			first_message = EXCLUDED.first_message,
-			display_name = EXCLUDED.display_name,
+			display_name = COALESCE(
+				sessions.display_name,
+				EXCLUDED.display_name
+			),
 			session_name = EXCLUDED.session_name,
 			created_at = EXCLUDED.created_at,
 			started_at = EXCLUDED.started_at,
 			ended_at = EXCLUDED.ended_at,
-			deleted_at = EXCLUDED.deleted_at,
+			deleted_at = COALESCE(
+				sessions.deleted_at,
+				EXCLUDED.deleted_at
+			),
 			message_count = EXCLUDED.message_count,
 			user_message_count = EXCLUDED.user_message_count,
 			total_output_tokens = EXCLUDED.total_output_tokens,
@@ -1366,12 +1372,18 @@ func (s *Sync) pushSession(
 			OR sessions.project IS DISTINCT FROM EXCLUDED.project
 			OR sessions.agent IS DISTINCT FROM EXCLUDED.agent
 			OR sessions.first_message IS DISTINCT FROM EXCLUDED.first_message
-			OR sessions.display_name IS DISTINCT FROM EXCLUDED.display_name
+			OR (
+				sessions.display_name IS NULL
+				AND sessions.display_name IS DISTINCT FROM EXCLUDED.display_name
+			)
 			OR sessions.session_name IS DISTINCT FROM EXCLUDED.session_name
 			OR sessions.created_at IS DISTINCT FROM EXCLUDED.created_at
 			OR sessions.started_at IS DISTINCT FROM EXCLUDED.started_at
 			OR sessions.ended_at IS DISTINCT FROM EXCLUDED.ended_at
-			OR sessions.deleted_at IS DISTINCT FROM EXCLUDED.deleted_at
+			OR (
+				sessions.deleted_at IS NULL
+				AND sessions.deleted_at IS DISTINCT FROM EXCLUDED.deleted_at
+			)
 			OR sessions.message_count IS DISTINCT FROM EXCLUDED.message_count
 			OR sessions.user_message_count IS DISTINCT FROM EXCLUDED.user_message_count
 			OR sessions.total_output_tokens IS DISTINCT FROM EXCLUDED.total_output_tokens

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -34,6 +34,7 @@ const (
 )
 
 var errSessionOwnershipConflict = errors.New("session ownership conflict")
+var errSessionExcluded = errors.New("session excluded")
 
 type pushBoundaryState struct {
 	Cutoff       string            `json:"cutoff"`
@@ -263,7 +264,13 @@ func (s *Sync) Push(
 	if err != nil {
 		return result, err
 	}
-	for id := range excludedIDs {
+	excludedIDList := mapSetKeys(excludedIDs)
+	if err := deletePGExcludedSessionRows(
+		ctx, s.pg, excludedIDList,
+	); err != nil {
+		return result, err
+	}
+	for _, id := range excludedIDList {
 		delete(sessionByID, id)
 	}
 
@@ -755,6 +762,9 @@ func (s *Sync) pushBatchAttempt(
 				skippedConflicts++
 				continue
 			}
+			if errors.Is(err, errSessionExcluded) {
+				continue
+			}
 			log.Printf(
 				"pgsync: session %s: %v",
 				sess.ID, err,
@@ -1007,6 +1017,14 @@ func mapKeys(m map[string]db.Session) []string {
 	return keys
 }
 
+func mapSetKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 func localSessionSyncMarker(sess db.Session) string {
 	marker, err := NormalizeLocalSyncTimestamp(sess.CreatedAt)
 	if err != nil || marker == "" {
@@ -1091,7 +1109,41 @@ func readPGExcludedSessionIDs(
 
 func pgExcludedSessionIDsQuery(ids []string) (string, []any) {
 	return `SELECT id FROM excluded_sessions
-		 WHERE id = ANY($1)`, []any{ids}
+			 WHERE id = ANY($1)`, []any{ids}
+}
+
+type pgSessionExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func deletePGExcludedSessionRows(
+	ctx context.Context, pg pgSessionExecer, ids []string,
+) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if _, err := pg.ExecContext(ctx,
+		`DELETE FROM sessions WHERE id = ANY($1)`,
+		ids,
+	); err != nil {
+		return fmt.Errorf("deleting pg excluded session rows: %w", err)
+	}
+	return nil
+}
+
+func pgSessionExcluded(
+	ctx context.Context, tx *sql.Tx, id string,
+) (bool, error) {
+	var excluded bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM excluded_sessions WHERE id = $1
+		)`,
+		id,
+	).Scan(&excluded); err != nil {
+		return false, fmt.Errorf("checking pg excluded session %s: %w", id, err)
+	}
+	return excluded, nil
 }
 
 // sessionPushFingerprint builds the change-detection fingerprint for a
@@ -1326,10 +1378,11 @@ func (s *Sync) pushSession(
 			missing_verification_count, duplicate_prompt_count,
 			no_code_context_count, runaway_tool_loop_count,
 			updated_at
-		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8,
-			$9, $10, $11, $12, $13, $14,
-			$15, $16, $17, $18,
+			)
+			SELECT
+				$1, $2, $3, $4, $5, $6, $7, $8,
+				$9, $10, $11, $12, $13, $14,
+				$15, $16, $17, $18,
 			$19, $20, $21, $22,
 			$23, $24, $25, $26, $27, $28, $29,
 			$30, $31,
@@ -1340,10 +1393,12 @@ func (s *Sync) pushSession(
 			$43,
 			$44, $45, $46, $47,
 			$48, $49,
-			$50, $51, $52, $53, $54, $55, $56, $57,
-			NOW()
-		)
-		ON CONFLICT (id) DO UPDATE SET
+				$50, $51, $52, $53, $54, $55, $56, $57,
+				NOW()
+			WHERE NOT EXISTS (
+				SELECT 1 FROM excluded_sessions WHERE id = $1
+			)
+			ON CONFLICT (id) DO UPDATE SET
 			machine = EXCLUDED.machine,
 			owner_marker = EXCLUDED.owner_marker,
 			project = EXCLUDED.project,
@@ -1518,6 +1573,18 @@ func (s *Sync) pushSession(
 		return err
 	}
 	if rowsAffected, rowsErr := result.RowsAffected(); rowsErr == nil && rowsAffected == 0 {
+		excluded, excludedErr := pgSessionExcluded(ctx, tx, sess.ID)
+		if excludedErr != nil {
+			return excludedErr
+		}
+		if excluded {
+			if err := deletePGExcludedSessionRows(
+				ctx, tx, []string{sess.ID},
+			); err != nil {
+				return err
+			}
+			return errSessionExcluded
+		}
 		refreshErr := tx.QueryRowContext(ctx,
 			`SELECT machine, owner_marker FROM sessions WHERE id = $1`, sess.ID,
 		).Scan(&existingMachine, &existingOwnerMarker)

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1075,8 +1075,9 @@ func localSessionSyncMarker(sess db.Session) string {
 }
 
 func readPGExcludedSessionIDs(
-	ctx context.Context, pg *sql.DB, ids []string,
+	ctx context.Context, pg pgSessionQueryer, ids []string,
 ) (map[string]struct{}, error) {
+	ids = uniqueNonEmptyStrings(ids)
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -1112,6 +1113,10 @@ func pgExcludedSessionIDsQuery(ids []string) (string, []any) {
 			 WHERE id = ANY($1)`, []any{ids}
 }
 
+type pgSessionQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
 type pgSessionExecer interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
@@ -1131,37 +1136,22 @@ func deletePGExcludedSessionRows(
 	return nil
 }
 
-func pgSessionExcluded(
-	ctx context.Context, tx *sql.Tx, id string,
-) (bool, error) {
-	var excluded bool
-	if err := tx.QueryRowContext(ctx,
-		`SELECT EXISTS (
-			SELECT 1 FROM excluded_sessions WHERE id = $1
-		)`,
-		id,
-	).Scan(&excluded); err != nil {
-		return false, fmt.Errorf("checking pg excluded session %s: %w", id, err)
-	}
-	return excluded, nil
-}
-
 func deletePGSessionIfExcluded(
 	ctx context.Context, tx *sql.Tx, sess db.Session,
 ) (bool, error) {
-	excluded, err := pgSessionExcluded(ctx, tx, sess.ID)
+	ids := append([]string{sess.ID}, pgSessionAliasIDs(sess)...)
+	ids = uniqueNonEmptyStrings(ids)
+	excluded, err := readPGExcludedSessionIDs(ctx, tx, ids)
 	if err != nil {
 		return false, err
 	}
-	if !excluded {
+	if len(excluded) == 0 {
 		return false, nil
 	}
-	if err := insertPGExcludedSessionIDs(
-		ctx, tx, pgSessionAliasIDs(sess),
-	); err != nil {
+	if err := insertPGExcludedSessionIDs(ctx, tx, ids); err != nil {
 		return false, err
 	}
-	if err := deletePGExcludedSessionRows(ctx, tx, []string{sess.ID}); err != nil {
+	if err := deletePGExcludedSessionRows(ctx, tx, ids); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -538,6 +538,129 @@ func TestPushPreservesPGServeLocalCurationFields(t *testing.T) {
 		"source-owned fields should still update")
 }
 
+func TestPushPreservesPGServePermanentDeletes(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_preserve_pg_deletes_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const deleteIfTrashedID = "pg-delete-preserve-001"
+	const emptyTrashID = "pg-delete-preserve-002"
+	sourceRows := []db.Session{
+		{
+			ID:               deleteIfTrashedID,
+			Project:          "test-proj",
+			Machine:          "test-machine",
+			Agent:            "claude",
+			MessageCount:     1,
+			UserMessageCount: 1,
+			CreatedAt:        "2026-01-01T00:00:00Z",
+		},
+		{
+			ID:               emptyTrashID,
+			Project:          "test-proj",
+			Machine:          "test-machine",
+			Agent:            "claude",
+			MessageCount:     1,
+			UserMessageCount: 1,
+			CreatedAt:        "2026-01-01T00:00:01Z",
+		},
+	}
+	for _, sess := range sourceRows {
+		require.NoError(t, localDB.UpsertSession(sess),
+			"UpsertSession "+sess.ID)
+		require.NoError(t, localDB.InsertMessages([]db.Message{{
+			SessionID:     sess.ID,
+			Ordinal:       0,
+			Role:          "user",
+			Content:       sess.ID,
+			ContentLength: len(sess.ID),
+		}}), "InsertMessages "+sess.ID)
+	}
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push before PG permanent deletes")
+
+	store, err := NewStore(pgURL, schema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	require.NoError(t, store.SoftDeleteSession(deleteIfTrashedID),
+		"SoftDeleteSession deleteIfTrashedID")
+	deleted, err := store.DeleteSessionIfTrashed(deleteIfTrashedID)
+	require.NoError(t, err, "DeleteSessionIfTrashed")
+	assert.EqualValues(t, 1, deleted)
+
+	deletedCount, err := store.SoftDeleteSessions([]string{emptyTrashID})
+	require.NoError(t, err, "SoftDeleteSessions")
+	assert.Equal(t, 1, deletedCount)
+	emptied, err := store.EmptyTrash()
+	require.NoError(t, err, "EmptyTrash")
+	assert.Equal(t, 1, emptied)
+
+	for _, sess := range sourceRows {
+		updated := sess
+		updated.MessageCount = 2
+		require.NoError(t, localDB.UpsertSession(updated),
+			"UpsertSession updated "+sess.ID)
+		require.NoError(t, localDB.ReplaceSessionMessages(sess.ID, []db.Message{
+			{
+				SessionID:     sess.ID,
+				Ordinal:       0,
+				Role:          "user",
+				Content:       sess.ID + "-updated",
+				ContentLength: len(sess.ID + "-updated"),
+			},
+			{
+				SessionID:     sess.ID,
+				Ordinal:       1,
+				Role:          "assistant",
+				Content:       "reply",
+				ContentLength: len("reply"),
+			},
+		}), "ReplaceSessionMessages "+sess.ID)
+	}
+
+	_, err = sync.Push(ctx, true, nil)
+	require.NoError(t, err, "full Push after PG permanent deletes")
+
+	for _, sessionID := range []string{deleteIfTrashedID, emptyTrashID} {
+		var count int
+		require.NoError(t, pg.QueryRow(
+			`SELECT COUNT(*) FROM sessions WHERE id = $1`,
+			sessionID,
+		).Scan(&count), "count deleted session "+sessionID)
+		assert.Zero(t, count, "permanently deleted session should stay absent")
+	}
+
+	var excludedCount int
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM excluded_sessions
+		 WHERE id IN ($1, $2)`,
+		deleteIfTrashedID, emptyTrashID,
+	).Scan(&excludedCount), "count pg excluded sessions")
+	assert.Equal(t, 2, excludedCount)
+}
+
 // TestPushSyncsUsageEventsForZeroMessageSession verifies that a session
 // carrying token/cost accounting as a usage_event but no transcript
 // messages still has its usage_event pushed to PG. This is the shape of a

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -661,6 +661,226 @@ func TestPushPreservesPGServePermanentDeletes(t *testing.T) {
 	assert.Equal(t, 2, excludedCount)
 }
 
+func TestPushUpdatesSourceCurationFieldsWithoutPGOverride(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_source_curation_update_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const renamedID = "pg-source-curation-rename-001"
+	sourceNameOne := "Source name one"
+	sourceNameTwo := "Source name two"
+	renamed := db.Session{
+		ID:               renamedID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "claude",
+		DisplayName:      &sourceNameOne,
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(renamed), "UpsertSession renamed")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     renamedID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       renamedID,
+		ContentLength: len(renamedID),
+	}}), "InsertMessages renamed")
+
+	const restoredID = "pg-source-curation-restore-001"
+	restored := db.Session{
+		ID:               restoredID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "claude",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:01Z",
+	}
+	require.NoError(t, localDB.UpsertSession(restored), "UpsertSession restored")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     restoredID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       restoredID,
+		ContentLength: len(restoredID),
+	}}), "InsertMessages restored")
+	require.NoError(t, localDB.SoftDeleteSession(restoredID),
+		"SoftDeleteSession restored")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push initial source curation")
+
+	renamed.DisplayName = &sourceNameTwo
+	require.NoError(t, localDB.UpsertSession(renamed),
+		"UpsertSession renamed source update")
+	restoredCount, err := localDB.RestoreSession(restoredID)
+	require.NoError(t, err, "RestoreSession restoredID")
+	assert.EqualValues(t, 1, restoredCount)
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push source curation update")
+
+	var gotDisplayName sql.NullString
+	require.NoError(t, pg.QueryRow(
+		`SELECT display_name FROM sessions WHERE id = $1`,
+		renamedID,
+	).Scan(&gotDisplayName), "read renamed display_name")
+	require.True(t, gotDisplayName.Valid, "display_name should remain populated")
+	assert.Equal(t, sourceNameTwo, gotDisplayName.String)
+
+	var deletedAt sql.NullTime
+	require.NoError(t, pg.QueryRow(
+		`SELECT deleted_at FROM sessions WHERE id = $1`,
+		restoredID,
+	).Scan(&deletedAt), "read restored deleted_at")
+	assert.False(t, deletedAt.Valid, "source restore should clear deleted_at")
+}
+
+func TestPushPreservesLegacyPGCurationWithoutSourceBaseline(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_legacy_source_curation_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const renamedID = "pg-legacy-curation-rename-001"
+	sourceNameOne := "Source name one"
+	sourceNameTwo := "Source name two"
+	renamed := db.Session{
+		ID:               renamedID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "claude",
+		DisplayName:      &sourceNameOne,
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(renamed), "UpsertSession renamed")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     renamedID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       renamedID,
+		ContentLength: len(renamedID),
+	}}), "InsertMessages renamed")
+
+	const trashedID = "pg-legacy-curation-trash-001"
+	trashed := db.Session{
+		ID:               trashedID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "claude",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:01Z",
+	}
+	require.NoError(t, localDB.UpsertSession(trashed), "UpsertSession trashed")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     trashedID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       trashedID,
+		ContentLength: len(trashedID),
+	}}), "InsertMessages trashed")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push initial legacy source rows")
+
+	pgName := "PG curated name"
+	_, err = pg.Exec(
+		`UPDATE sessions
+		 SET display_name = $2,
+		     source_display_name = NULL
+		 WHERE id = $1`,
+		renamedID, pgName,
+	)
+	require.NoError(t, err, "simulate legacy PG rename")
+
+	_, err = pg.Exec(
+		`UPDATE sessions
+		 SET deleted_at = NOW(),
+		     source_deleted_at = NULL
+		 WHERE id = $1`,
+		trashedID,
+	)
+	require.NoError(t, err, "simulate legacy PG trash")
+
+	renamed.DisplayName = &sourceNameTwo
+	require.NoError(t, localDB.UpsertSession(renamed),
+		"UpsertSession renamed source update")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push legacy source curation update")
+
+	var gotDisplayName sql.NullString
+	var gotSourceDisplayName sql.NullString
+	require.NoError(t, pg.QueryRow(
+		`SELECT display_name, source_display_name
+		 FROM sessions WHERE id = $1`,
+		renamedID,
+	).Scan(&gotDisplayName, &gotSourceDisplayName),
+		"read renamed legacy curation state")
+	require.True(t, gotDisplayName.Valid, "legacy display_name should remain populated")
+	assert.Equal(t, pgName, gotDisplayName.String)
+	require.True(t, gotSourceDisplayName.Valid,
+		"legacy source_display_name should capture the source baseline")
+	assert.Equal(t, sourceNameTwo, gotSourceDisplayName.String)
+
+	var deletedAt sql.NullTime
+	var sourceDeletedAt sql.NullTime
+	require.NoError(t, pg.QueryRow(
+		`SELECT deleted_at, source_deleted_at
+		 FROM sessions WHERE id = $1`,
+		trashedID,
+	).Scan(&deletedAt, &sourceDeletedAt),
+		"read trashed legacy curation state")
+	assert.True(t, deletedAt.Valid,
+		"legacy PG delete should remain in place without a source baseline")
+	assert.False(t, sourceDeletedAt.Valid,
+		"active source row should keep a null source_deleted_at baseline")
+}
+
 // TestPushSyncsUsageEventsForZeroMessageSession verifies that a session
 // carrying token/cost accounting as a usage_event but no transcript
 // messages still has its usage_event pushed to PG. This is the shape of a

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -694,7 +694,7 @@ func TestPushUpdatesSourceCurationFieldsWithoutPGOverride(t *testing.T) {
 		Project:          "test-proj",
 		Machine:          "test-machine",
 		Agent:            "claude",
-		DisplayName:      &sourceNameOne,
+		SessionName:      &sourceNameOne,
 		MessageCount:     1,
 		UserMessageCount: 1,
 		CreatedAt:        "2026-01-01T00:00:00Z",
@@ -732,7 +732,7 @@ func TestPushUpdatesSourceCurationFieldsWithoutPGOverride(t *testing.T) {
 	_, err = sync.Push(ctx, false, nil)
 	require.NoError(t, err, "Push initial source curation")
 
-	renamed.DisplayName = &sourceNameTwo
+	renamed.SessionName = &sourceNameTwo
 	require.NoError(t, localDB.UpsertSession(renamed),
 		"UpsertSession renamed source update")
 	restoredCount, err := localDB.RestoreSession(restoredID)
@@ -791,7 +791,7 @@ func TestPushPreservesLegacyPGCurationWithoutSourceBaseline(t *testing.T) {
 		Project:          "test-proj",
 		Machine:          "test-machine",
 		Agent:            "claude",
-		DisplayName:      &sourceNameOne,
+		SessionName:      &sourceNameOne,
 		MessageCount:     1,
 		UserMessageCount: 1,
 		CreatedAt:        "2026-01-01T00:00:00Z",
@@ -846,7 +846,7 @@ func TestPushPreservesLegacyPGCurationWithoutSourceBaseline(t *testing.T) {
 	)
 	require.NoError(t, err, "simulate legacy PG trash")
 
-	renamed.DisplayName = &sourceNameTwo
+	renamed.SessionName = &sourceNameTwo
 	require.NoError(t, localDB.UpsertSession(renamed),
 		"UpsertSession renamed source update")
 

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -661,6 +661,145 @@ func TestPushPreservesPGServePermanentDeletes(t *testing.T) {
 	assert.Equal(t, 2, excludedCount)
 }
 
+func TestPushPurgesRowsForPGExcludedSessions(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_excluded_purge_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessionID = "pg-excluded-purge-001"
+	sess := db.Session{
+		ID:               sessionID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "claude",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     sessionID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "hello",
+		ContentLength: len("hello"),
+	}}), "InsertMessages")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "initial Push")
+
+	_, err = pg.Exec(
+		`INSERT INTO excluded_sessions (id) VALUES ($1)`,
+		sessionID,
+	)
+	require.NoError(t, err, "insert excluded session")
+
+	updated := sess
+	updated.MessageCount = 2
+	require.NoError(t, localDB.UpsertSession(updated), "update local session")
+	require.NoError(t, localDB.ReplaceSessionMessages(sessionID, []db.Message{
+		{
+			SessionID:     sessionID,
+			Ordinal:       0,
+			Role:          "user",
+			Content:       "hello updated",
+			ContentLength: len("hello updated"),
+		},
+		{
+			SessionID:     sessionID,
+			Ordinal:       1,
+			Role:          "assistant",
+			Content:       "reply",
+			ContentLength: len("reply"),
+		},
+	}), "ReplaceSessionMessages")
+
+	res, err := sync.Push(ctx, true, nil)
+	require.NoError(t, err, "full Push with excluded row")
+	assert.Zero(t, res.SessionsPushed)
+
+	var count int
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = $1`,
+		sessionID,
+	).Scan(&count), "count purged session")
+	assert.Zero(t, count, "excluded session row should be purged")
+}
+
+func TestPushSessionSkipsPGExcludedSession(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_session_excluded_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessionID = "pg-excluded-push-session-001"
+	_, err = pg.Exec(
+		`INSERT INTO excluded_sessions (id) VALUES ($1)`,
+		sessionID,
+	)
+	require.NoError(t, err, "insert excluded session")
+
+	tx, err := pg.BeginTx(ctx, nil)
+	require.NoError(t, err, "BeginTx")
+	markerID, err := sync.pushMarkerID()
+	require.NoError(t, err, "pushMarkerID")
+	err = sync.pushSession(ctx, tx, db.Session{
+		ID:        sessionID,
+		Project:   "test-proj",
+		Machine:   "test-machine",
+		Agent:     "claude",
+		CreatedAt: "2026-01-01T00:00:00Z",
+	}, markerID, nil)
+	require.ErrorIs(t, err, errSessionExcluded)
+	require.NoError(t, tx.Rollback(), "Rollback")
+
+	var count int
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = $1`,
+		sessionID,
+	).Scan(&count), "count skipped session")
+	assert.Zero(t, count)
+}
+
 func TestPushUpdatesSourceCurationFieldsWithoutPGOverride(t *testing.T) {
 	pgURL := testPGURL(t)
 

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -694,12 +694,13 @@ func TestPushUpdatesSourceCurationFieldsWithoutPGOverride(t *testing.T) {
 		Project:          "test-proj",
 		Machine:          "test-machine",
 		Agent:            "claude",
-		SessionName:      &sourceNameOne,
 		MessageCount:     1,
 		UserMessageCount: 1,
 		CreatedAt:        "2026-01-01T00:00:00Z",
 	}
 	require.NoError(t, localDB.UpsertSession(renamed), "UpsertSession renamed")
+	require.NoError(t, localDB.RenameSession(renamedID, &sourceNameOne),
+		"RenameSession renamed initial source name")
 	require.NoError(t, localDB.InsertMessages([]db.Message{{
 		SessionID:     renamedID,
 		Ordinal:       0,
@@ -732,9 +733,8 @@ func TestPushUpdatesSourceCurationFieldsWithoutPGOverride(t *testing.T) {
 	_, err = sync.Push(ctx, false, nil)
 	require.NoError(t, err, "Push initial source curation")
 
-	renamed.SessionName = &sourceNameTwo
-	require.NoError(t, localDB.UpsertSession(renamed),
-		"UpsertSession renamed source update")
+	require.NoError(t, localDB.RenameSession(renamedID, &sourceNameTwo),
+		"RenameSession renamed source update")
 	restoredCount, err := localDB.RestoreSession(restoredID)
 	require.NoError(t, err, "RestoreSession restoredID")
 	assert.EqualValues(t, 1, restoredCount)
@@ -791,12 +791,13 @@ func TestPushPreservesLegacyPGCurationWithoutSourceBaseline(t *testing.T) {
 		Project:          "test-proj",
 		Machine:          "test-machine",
 		Agent:            "claude",
-		SessionName:      &sourceNameOne,
 		MessageCount:     1,
 		UserMessageCount: 1,
 		CreatedAt:        "2026-01-01T00:00:00Z",
 	}
 	require.NoError(t, localDB.UpsertSession(renamed), "UpsertSession renamed")
+	require.NoError(t, localDB.RenameSession(renamedID, &sourceNameOne),
+		"RenameSession renamed initial source name")
 	require.NoError(t, localDB.InsertMessages([]db.Message{{
 		SessionID:     renamedID,
 		Ordinal:       0,
@@ -846,9 +847,8 @@ func TestPushPreservesLegacyPGCurationWithoutSourceBaseline(t *testing.T) {
 	)
 	require.NoError(t, err, "simulate legacy PG trash")
 
-	renamed.SessionName = &sourceNameTwo
-	require.NoError(t, localDB.UpsertSession(renamed),
-		"UpsertSession renamed source update")
+	require.NoError(t, localDB.RenameSession(renamedID, &sourceNameTwo),
+		"RenameSession renamed source update")
 
 	_, err = sync.Push(ctx, false, nil)
 	require.NoError(t, err, "Push legacy source curation update")

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -450,6 +450,94 @@ func TestPushSessionPreservesSourceMachine(t *testing.T) {
 	assert.Equal(t, "remote-host", got)
 }
 
+func TestPushPreservesPGServeLocalCurationFields(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_preserve_pg_curation_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const sessID = "pg-curation-preserve-001"
+	firstMessage := "source before"
+	sess := db.Session{
+		ID:               sessID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "claude",
+		FirstMessage:     &firstMessage,
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     sessID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       firstMessage,
+		ContentLength: len(firstMessage),
+	}}), "InsertMessages")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push before local PG curation")
+
+	store, err := NewStore(pgURL, schema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	renamed := "Renamed in PG serve"
+	require.NoError(t, store.RenameSession(sessID, &renamed),
+		"RenameSession")
+	require.NoError(t, store.SoftDeleteSession(sessID),
+		"SoftDeleteSession")
+
+	updatedFirstMessage := "source after"
+	sess.FirstMessage = &updatedFirstMessage
+	require.NoError(t, localDB.UpsertSession(sess),
+		"UpsertSession updated source row")
+	require.NoError(t, localDB.SetSyncState("last_push_at", ""),
+		"clearing last_push_at")
+	require.NoError(t, localDB.SetSyncState(lastPushBoundaryStateKey, ""),
+		"clearing boundary state")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push after local PG curation")
+
+	var gotDisplayName sql.NullString
+	var gotDeleted bool
+	var gotFirstMessage sql.NullString
+	require.NoError(t, pg.QueryRow(
+		`SELECT display_name, deleted_at IS NOT NULL, first_message
+		 FROM sessions WHERE id = $1`,
+		sessID,
+	).Scan(&gotDisplayName, &gotDeleted, &gotFirstMessage),
+		"reading pushed curation row")
+	require.True(t, gotDisplayName.Valid, "display_name should persist")
+	assert.Equal(t, renamed, gotDisplayName.String)
+	assert.True(t, gotDeleted, "PG-local trash state should persist")
+	require.True(t, gotFirstMessage.Valid, "first_message should remain visible")
+	assert.Equal(t, updatedFirstMessage, gotFirstMessage.String,
+		"source-owned fields should still update")
+}
+
 // TestPushSyncsUsageEventsForZeroMessageSession verifies that a session
 // carrying token/cost accounting as a usage_event but no transcript
 // messages still has its usage_event pushed to PG. This is the shape of a

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -246,7 +246,11 @@ func (c *capturePGExec) ExecContext(
 }
 
 func TestPushSessionRechecksExclusionAfterSuccessfulUpsert(t *testing.T) {
-	state := &pushSessionProbeState{excludedAfterUpsert: true}
+	state := &pushSessionProbeState{
+		existingExcluded: map[string]bool{
+			"sess-race": true,
+		},
+	}
 	pg := newPushSessionProbeDB(t, state)
 	tx, err := pg.BeginTx(context.Background(), nil)
 	require.NoError(t, err, "BeginTx")
@@ -307,8 +311,10 @@ func TestPushSessionStoresVibeFallbackAlias(t *testing.T) {
 
 func TestPushSessionExcludesVibeFallbackAliasWhenCanonicalExcluded(t *testing.T) {
 	state := &pushSessionProbeState{
-		excludedAfterUpsert: true,
-		excludedIDs:         map[string]bool{},
+		existingExcluded: map[string]bool{
+			"vibe:canonical-deleted": true,
+		},
+		excludedIDs: map[string]bool{},
 	}
 	pg := newPushSessionProbeDB(t, state)
 	tx, err := pg.BeginTx(context.Background(), nil)
@@ -341,6 +347,46 @@ func TestPushSessionExcludesVibeFallbackAliasWhenCanonicalExcluded(t *testing.T)
 	require.NoError(t, tx.Rollback(), "Rollback")
 }
 
+func TestPushSessionSkipsVibeCanonicalWhenFallbackAliasExcluded(t *testing.T) {
+	state := &pushSessionProbeState{
+		existingExcluded: map[string]bool{
+			"vibe:session_20260616_083518_ghi789": true,
+		},
+		excludedIDs: map[string]bool{},
+	}
+	pg := newPushSessionProbeDB(t, state)
+	tx, err := pg.BeginTx(context.Background(), nil)
+	require.NoError(t, err, "BeginTx")
+
+	sessionDir := filepath.Join(
+		t.TempDir(),
+		"session_20260616_083518_ghi789",
+	)
+	filePath := filepath.Join(sessionDir, "messages.jsonl")
+	syncer := &Sync{machine: "push-machine"}
+	err = syncer.pushSession(
+		context.Background(), tx,
+		db.Session{
+			ID:        "vibe:canonical-active",
+			Project:   "proj",
+			Machine:   "push-machine",
+			Agent:     "vibe",
+			CreatedAt: "2026-01-01T00:00:00Z",
+			FilePath:  &filePath,
+		},
+		"marker", nil,
+	)
+
+	require.ErrorIs(t, err, errSessionExcluded)
+	assert.True(t, state.excludedIDs["vibe:canonical-active"])
+	assert.True(t,
+		state.excludedIDs["vibe:session_20260616_083518_ghi789"],
+	)
+	assert.True(t, state.deletedExcluded,
+		"all excluded aliases should be purged from PG sessions")
+	require.NoError(t, tx.Rollback(), "Rollback")
+}
+
 type pushSessionProbeDriver struct{}
 
 type pushSessionProbeConn struct {
@@ -363,6 +409,7 @@ type pushSessionProbeState struct {
 	deletedExcluded     bool
 	aliases             map[string]string
 	excludedIDs         map[string]bool
+	existingExcluded    map[string]bool
 }
 
 var (
@@ -472,7 +519,7 @@ func (c *pushSessionProbeConn) ExecContext(
 }
 
 func (c *pushSessionProbeConn) QueryContext(
-	_ context.Context, query string, _ []driver.NamedValue,
+	_ context.Context, query string, args []driver.NamedValue,
 ) (driver.Rows, error) {
 	normalized := strings.ToLower(query)
 	c.state.mu.Lock()
@@ -483,13 +530,32 @@ func (c *pushSessionProbeConn) QueryContext(
 		return &pushSessionProbeRows{
 			columns: []string{"machine", "owner_marker"},
 		}, nil
+	case strings.Contains(normalized, "select id") &&
+		strings.Contains(normalized, "excluded_sessions") &&
+		strings.Contains(normalized, "id = any($1)"):
+		c.state.exclusionChecks++
+		values := [][]driver.Value{}
+		for _, id := range namedValueStrings(args) {
+			if c.state.existingExcluded[id] {
+				values = append(values, []driver.Value{id})
+			}
+		}
+		return &pushSessionProbeRows{
+			columns: []string{"id"},
+			values:  values,
+		}, nil
 	case strings.Contains(normalized, "select exists") &&
 		strings.Contains(normalized, "excluded_sessions"):
 		c.state.exclusionChecks++
+		excluded := c.state.excludedAfterUpsert
+		if c.state.existingExcluded != nil && len(args) > 0 {
+			id, _ := args[0].Value.(string)
+			excluded = c.state.existingExcluded[id]
+		}
 		return &pushSessionProbeRows{
 			columns: []string{"exists"},
 			values: [][]driver.Value{
-				{c.state.excludedAfterUpsert},
+				{excluded},
 			},
 		}, nil
 	default:

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -5,7 +5,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
+	"io"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -239,6 +243,176 @@ func (c *capturePGExec) ExecContext(
 	c.query = query
 	c.args = args
 	return driver.RowsAffected(0), nil
+}
+
+func TestPushSessionRechecksExclusionAfterSuccessfulUpsert(t *testing.T) {
+	state := &pushSessionProbeState{excludedAfterUpsert: true}
+	pg := newPushSessionProbeDB(t, state)
+	tx, err := pg.BeginTx(context.Background(), nil)
+	require.NoError(t, err, "BeginTx")
+
+	syncer := &Sync{machine: "push-machine"}
+	err = syncer.pushSession(
+		context.Background(), tx,
+		db.Session{
+			ID:        "sess-race",
+			Project:   "proj",
+			Machine:   "push-machine",
+			Agent:     "claude",
+			CreatedAt: "2026-01-01T00:00:00Z",
+		},
+		"marker", nil,
+	)
+
+	require.ErrorIs(t, err, errSessionExcluded)
+	assert.Equal(t, 1, state.upserts)
+	assert.Equal(t, 1, state.exclusionChecks)
+	assert.True(t, state.deletedExcluded,
+		"excluded row should be deleted after the tombstone is observed")
+	require.NoError(t, tx.Rollback(), "Rollback")
+}
+
+type pushSessionProbeDriver struct{}
+
+type pushSessionProbeConn struct {
+	state *pushSessionProbeState
+}
+
+type pushSessionProbeTx struct{}
+
+type pushSessionProbeRows struct {
+	columns []string
+	values  [][]driver.Value
+	next    int
+}
+
+type pushSessionProbeState struct {
+	mu                  sync.Mutex
+	excludedAfterUpsert bool
+	upserts             int
+	exclusionChecks     int
+	deletedExcluded     bool
+}
+
+var (
+	pushSessionProbeRegisterOnce sync.Once
+	pushSessionProbeStatesMu     sync.Mutex
+	pushSessionProbeStates       = map[string]*pushSessionProbeState{}
+)
+
+func newPushSessionProbeDB(
+	t *testing.T, state *pushSessionProbeState,
+) *sql.DB {
+	t.Helper()
+	pushSessionProbeRegisterOnce.Do(func() {
+		sql.Register("agentsview_push_session_probe", pushSessionProbeDriver{})
+	})
+	name := t.Name()
+	pushSessionProbeStatesMu.Lock()
+	pushSessionProbeStates[name] = state
+	pushSessionProbeStatesMu.Unlock()
+	t.Cleanup(func() {
+		pushSessionProbeStatesMu.Lock()
+		delete(pushSessionProbeStates, name)
+		pushSessionProbeStatesMu.Unlock()
+	})
+
+	pg, err := sql.Open("agentsview_push_session_probe", name)
+	require.NoError(t, err, "open push-session probe db")
+	t.Cleanup(func() { _ = pg.Close() })
+	return pg
+}
+
+func (pushSessionProbeDriver) Open(name string) (driver.Conn, error) {
+	pushSessionProbeStatesMu.Lock()
+	state := pushSessionProbeStates[name]
+	pushSessionProbeStatesMu.Unlock()
+	return &pushSessionProbeConn{state: state}, nil
+}
+
+func (c *pushSessionProbeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (c *pushSessionProbeConn) Close() error { return nil }
+
+func (c *pushSessionProbeConn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
+
+func (c *pushSessionProbeConn) BeginTx(
+	context.Context, driver.TxOptions,
+) (driver.Tx, error) {
+	return pushSessionProbeTx{}, nil
+}
+
+func (c *pushSessionProbeConn) CheckNamedValue(
+	*driver.NamedValue,
+) error {
+	return nil
+}
+
+func (c *pushSessionProbeConn) ExecContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Result, error) {
+	normalized := strings.ToLower(query)
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	switch {
+	case strings.Contains(normalized, "insert into sessions"):
+		c.state.upserts++
+		return driver.RowsAffected(1), nil
+	case strings.Contains(normalized, "delete from sessions") &&
+		strings.Contains(normalized, "id = any($1)"):
+		c.state.deletedExcluded = true
+		return driver.RowsAffected(1), nil
+	default:
+		return nil, errors.New("unexpected push-session probe exec")
+	}
+}
+
+func (c *pushSessionProbeConn) QueryContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Rows, error) {
+	normalized := strings.ToLower(query)
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	switch {
+	case strings.Contains(normalized, "select machine, owner_marker"):
+		return &pushSessionProbeRows{
+			columns: []string{"machine", "owner_marker"},
+		}, nil
+	case strings.Contains(normalized, "select exists") &&
+		strings.Contains(normalized, "excluded_sessions"):
+		c.state.exclusionChecks++
+		return &pushSessionProbeRows{
+			columns: []string{"exists"},
+			values: [][]driver.Value{
+				{c.state.excludedAfterUpsert},
+			},
+		}, nil
+	default:
+		return nil, errors.New("unexpected push-session probe query")
+	}
+}
+
+func (pushSessionProbeTx) Commit() error { return nil }
+
+func (pushSessionProbeTx) Rollback() error { return nil }
+
+func (r *pushSessionProbeRows) Columns() []string { return r.columns }
+
+func (r *pushSessionProbeRows) Close() error { return nil }
+
+func (r *pushSessionProbeRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.next])
+	r.next++
+	return nil
 }
 
 func TestSessionPushFingerprintDiffers(t *testing.T) {

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -387,6 +387,47 @@ func TestPushSessionSkipsVibeCanonicalWhenFallbackAliasExcluded(t *testing.T) {
 	require.NoError(t, tx.Rollback(), "Rollback")
 }
 
+func TestPurgePGExcludedPushSessionsChecksDerivedAliases(t *testing.T) {
+	state := &pushSessionProbeState{
+		existingExcluded: map[string]bool{
+			"vibe:session_20260616_083518_jkl012": true,
+		},
+		excludedIDs: map[string]bool{},
+	}
+	pg := newPushSessionProbeDB(t, state)
+
+	sessionDir := filepath.Join(
+		t.TempDir(),
+		"session_20260616_083518_jkl012",
+	)
+	filePath := filepath.Join(sessionDir, "messages.jsonl")
+	sessionByID := map[string]db.Session{
+		"vibe:canonical-unchanged": {
+			ID:        "vibe:canonical-unchanged",
+			Project:   "proj",
+			Machine:   "push-machine",
+			Agent:     "vibe",
+			CreatedAt: "2026-01-01T00:00:00Z",
+			FilePath:  &filePath,
+		},
+	}
+
+	err := purgePGExcludedPushSessions(
+		context.Background(), pg, sessionByID,
+	)
+
+	require.NoError(t, err, "purgePGExcludedPushSessions")
+	assert.Empty(t, sessionByID)
+	assert.True(t, state.excludedIDs["vibe:canonical-unchanged"])
+	assert.True(t,
+		state.excludedIDs["vibe:session_20260616_083518_jkl012"],
+	)
+	assert.True(t, state.deletedExcluded,
+		"all excluded aliases should be purged before fingerprint pruning")
+	assert.Equal(t, 1, state.exclusionChecks)
+	assert.Equal(t, 0, state.upserts)
+}
+
 type pushSessionProbeDriver struct{}
 
 type pushSessionProbeConn struct {

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -272,6 +272,75 @@ func TestPushSessionRechecksExclusionAfterSuccessfulUpsert(t *testing.T) {
 	require.NoError(t, tx.Rollback(), "Rollback")
 }
 
+func TestPushSessionStoresVibeFallbackAlias(t *testing.T) {
+	state := &pushSessionProbeState{aliases: map[string]string{}}
+	pg := newPushSessionProbeDB(t, state)
+	tx, err := pg.BeginTx(context.Background(), nil)
+	require.NoError(t, err, "BeginTx")
+
+	sessionDir := filepath.Join(
+		t.TempDir(),
+		"session_20260616_083518_abc123",
+	)
+	filePath := filepath.Join(sessionDir, "messages.jsonl")
+	syncer := &Sync{machine: "push-machine"}
+	err = syncer.pushSession(
+		context.Background(), tx,
+		db.Session{
+			ID:        "vibe:canonical-uuid",
+			Project:   "proj",
+			Machine:   "push-machine",
+			Agent:     "vibe",
+			CreatedAt: "2026-01-01T00:00:00Z",
+			FilePath:  &filePath,
+		},
+		"marker", nil,
+	)
+
+	require.NoError(t, err, "pushSession")
+	assert.Equal(t,
+		"vibe:session_20260616_083518_abc123",
+		state.aliases["vibe:canonical-uuid"],
+	)
+	require.NoError(t, tx.Rollback(), "Rollback")
+}
+
+func TestPushSessionExcludesVibeFallbackAliasWhenCanonicalExcluded(t *testing.T) {
+	state := &pushSessionProbeState{
+		excludedAfterUpsert: true,
+		excludedIDs:         map[string]bool{},
+	}
+	pg := newPushSessionProbeDB(t, state)
+	tx, err := pg.BeginTx(context.Background(), nil)
+	require.NoError(t, err, "BeginTx")
+
+	sessionDir := filepath.Join(
+		t.TempDir(),
+		"session_20260616_083518_def456",
+	)
+	filePath := filepath.Join(sessionDir, "messages.jsonl")
+	syncer := &Sync{machine: "push-machine"}
+	err = syncer.pushSession(
+		context.Background(), tx,
+		db.Session{
+			ID:        "vibe:canonical-deleted",
+			Project:   "proj",
+			Machine:   "push-machine",
+			Agent:     "vibe",
+			CreatedAt: "2026-01-01T00:00:00Z",
+			FilePath:  &filePath,
+		},
+		"marker", nil,
+	)
+
+	require.ErrorIs(t, err, errSessionExcluded)
+	assert.True(t,
+		state.excludedIDs["vibe:session_20260616_083518_def456"],
+		"excluded canonical Vibe pushes should tombstone the fallback alias",
+	)
+	require.NoError(t, tx.Rollback(), "Rollback")
+}
+
 type pushSessionProbeDriver struct{}
 
 type pushSessionProbeConn struct {
@@ -292,6 +361,8 @@ type pushSessionProbeState struct {
 	upserts             int
 	exclusionChecks     int
 	deletedExcluded     bool
+	aliases             map[string]string
+	excludedIDs         map[string]bool
 }
 
 var (
@@ -353,7 +424,7 @@ func (c *pushSessionProbeConn) CheckNamedValue(
 }
 
 func (c *pushSessionProbeConn) ExecContext(
-	_ context.Context, query string, _ []driver.NamedValue,
+	_ context.Context, query string, args []driver.NamedValue,
 ) (driver.Result, error) {
 	normalized := strings.ToLower(query)
 	c.state.mu.Lock()
@@ -366,6 +437,34 @@ func (c *pushSessionProbeConn) ExecContext(
 	case strings.Contains(normalized, "delete from sessions") &&
 		strings.Contains(normalized, "id = any($1)"):
 		c.state.deletedExcluded = true
+		return driver.RowsAffected(1), nil
+	case strings.Contains(normalized, "delete from session_aliases"):
+		if c.state.aliases != nil && len(args) > 0 {
+			if sessionID, ok := args[0].Value.(string); ok {
+				delete(c.state.aliases, sessionID)
+			}
+		}
+		return driver.RowsAffected(1), nil
+	case strings.Contains(normalized, "insert into session_aliases"):
+		if c.state.aliases != nil && len(args) > 1 {
+			sessionID, sessionOK := args[0].Value.(string)
+			aliasID, aliasOK := args[1].Value.(string)
+			if sessionOK && aliasOK {
+				c.state.aliases[sessionID] = aliasID
+			}
+		}
+		return driver.RowsAffected(1), nil
+	case strings.Contains(normalized, "insert into excluded_sessions"):
+		if c.state.excludedIDs != nil && len(args) > 0 {
+			switch ids := args[0].Value.(type) {
+			case []string:
+				for _, id := range ids {
+					c.state.excludedIDs[id] = true
+				}
+			case string:
+				c.state.excludedIDs[ids] = true
+			}
+		}
 		return driver.RowsAffected(1), nil
 	default:
 		return nil, errors.New("unexpected push-session probe exec")

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -192,6 +192,22 @@ func TestLocalSessionSyncMarkerNormalizesSecondPrecisionTimestamps(t *testing.T)
 	require.Equal(t, endedAt, got)
 }
 
+func TestPGExcludedSessionIDsQueryUsesSingleArrayParameter(t *testing.T) {
+	query, args := pgExcludedSessionIDsQuery([]string{
+		"sess-001",
+		"sess-002",
+		"sess-003",
+	})
+
+	assert.Contains(t, query, "id = ANY($1)")
+	assert.NotContains(t, query, "$2")
+	require.Len(t, args, 1)
+	assert.Equal(t,
+		[]string{"sess-001", "sess-002", "sess-003"},
+		args[0],
+	)
+}
+
 func TestSessionPushFingerprintDiffers(t *testing.T) {
 	base := db.Session{
 		ID:               "sess-001",

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -1,6 +1,9 @@
 package postgres
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"path/filepath"
 	"testing"
@@ -206,6 +209,36 @@ func TestPGExcludedSessionIDsQueryUsesSingleArrayParameter(t *testing.T) {
 		[]string{"sess-001", "sess-002", "sess-003"},
 		args[0],
 	)
+}
+
+func TestDeletePGExcludedSessionRowsUsesSingleArrayParameter(t *testing.T) {
+	execer := &capturePGExec{}
+
+	require.NoError(t, deletePGExcludedSessionRows(
+		context.Background(), execer,
+		[]string{"sess-001", "sess-002", "sess-003"},
+	))
+
+	assert.Contains(t, execer.query, "DELETE FROM sessions")
+	assert.Contains(t, execer.query, "id = ANY($1)")
+	require.Len(t, execer.args, 1)
+	assert.Equal(t,
+		[]string{"sess-001", "sess-002", "sess-003"},
+		execer.args[0],
+	)
+}
+
+type capturePGExec struct {
+	query string
+	args  []any
+}
+
+func (c *capturePGExec) ExecContext(
+	_ context.Context, query string, args ...any,
+) (sql.Result, error) {
+	c.query = query
+	c.args = args
+	return driver.RowsAffected(0), nil
 }
 
 func TestSessionPushFingerprintDiffers(t *testing.T) {

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -132,6 +132,61 @@ func TestPushMarkerIDUsesUnscopedStateAcrossNamedTargets(t *testing.T) {
 	}
 }
 
+func TestSessionAliasBackfillForcesOneFullPush(t *testing.T) {
+	store := &syncStateStoreStub{}
+
+	full, needed, err := applySessionAliasBackfillRequirement(
+		store, false,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, full, "missing alias backfill marker should force full push")
+	assert.True(t, needed)
+
+	require.NoError(t, markSessionAliasBackfillDone(store))
+
+	full, needed, err = applySessionAliasBackfillRequirement(
+		store, false,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, full,
+		"completed alias backfill should preserve incremental push")
+	assert.False(t, needed)
+
+	full, needed, err = applySessionAliasBackfillRequirement(
+		store, true,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, full, "explicit full push should stay full")
+	assert.False(t, needed)
+}
+
+func TestCompleteSessionAliasBackfillRequiresCleanPush(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		res  PushResult
+		want string
+	}{
+		{name: "clean", want: "1"},
+		{name: "errors", res: PushResult{Errors: 1}},
+		{name: "skipped conflicts", res: PushResult{SkippedConflicts: 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &syncStateStoreStub{}
+
+			err := completeSessionAliasBackfill(
+				store, true, tc.res,
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want,
+				store.values[sessionAliasBackfillStateKey])
+		})
+	}
+}
+
 func TestReadPushBoundaryStateValidity(t *testing.T) {
 	const cutoff = "2026-03-11T12:34:56.123Z"
 

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -40,11 +40,13 @@ CREATE TABLE IF NOT EXISTS sessions (
     agent              TEXT NOT NULL,
     first_message      TEXT,
     display_name       TEXT,
+    source_display_name TEXT,
     session_name       TEXT,
     created_at         TIMESTAMPTZ,
     started_at         TIMESTAMPTZ,
     ended_at           TIMESTAMPTZ,
     deleted_at         TIMESTAMPTZ,
+    source_deleted_at  TIMESTAMPTZ,
     message_count      INT NOT NULL DEFAULT 0,
     user_message_count INT NOT NULL DEFAULT 0,
     parent_session_id  TEXT,
@@ -380,6 +382,16 @@ func EnsureSchema(
 			"sessions", "created_at",
 			`created_at TIMESTAMPTZ`,
 			"adding sessions.created_at",
+		},
+		{
+			"sessions", "source_display_name",
+			`source_display_name TEXT`,
+			"adding sessions.source_display_name",
+		},
+		{
+			"sessions", "source_deleted_at",
+			`source_deleted_at TIMESTAMPTZ`,
+			"adding sessions.source_deleted_at",
 		},
 		{
 			"sessions", "total_output_tokens",
@@ -1677,10 +1689,11 @@ func checkPushSchemaCompat(ctx context.Context, db *sql.DB) error {
 	rows.Close()
 
 	rows, err = db.QueryContext(ctx,
-		`SELECT owner_marker FROM sessions LIMIT 0`)
+		`SELECT owner_marker, source_display_name, source_deleted_at
+		 FROM sessions LIMIT 0`)
 	if err != nil {
 		return fmt.Errorf(
-			"sessions table missing owner_marker: %w", err)
+			"sessions table missing push curation columns: %w", err)
 	}
 	rows.Close()
 

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -292,6 +292,35 @@ CREATE INDEX IF NOT EXISTS idx_secret_findings_session
 
 CREATE INDEX IF NOT EXISTS idx_secret_findings_rule
     ON secret_findings (rule_name);
+
+CREATE TABLE IF NOT EXISTS insights (
+    id               BIGSERIAL PRIMARY KEY,
+    type             TEXT NOT NULL DEFAULT '',
+    date_from        TEXT NOT NULL DEFAULT '',
+    date_to          TEXT NOT NULL DEFAULT '',
+    project          TEXT,
+    agent            TEXT NOT NULL DEFAULT '',
+    model            TEXT,
+    prompt           TEXT,
+    content          TEXT NOT NULL DEFAULT '',
+    kind             TEXT NOT NULL DEFAULT '',
+    schema_version   TEXT NOT NULL DEFAULT '',
+    template_id      TEXT NOT NULL DEFAULT '',
+    template_version TEXT NOT NULL DEFAULT '',
+    aggregate_hash   TEXT NOT NULL DEFAULT '',
+    cache_key        TEXT NOT NULL DEFAULT '',
+    cache_status     TEXT NOT NULL DEFAULT '',
+    provenance_json  TEXT NOT NULL DEFAULT '',
+    structured_json  TEXT NOT NULL DEFAULT '',
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_insights_lookup
+    ON insights (type, date_from, date_to, project);
+
+CREATE INDEX IF NOT EXISTS idx_insights_cache
+    ON insights (cache_key, created_at DESC)
+    WHERE cache_key <> '';
 `
 
 // EnsureSchema creates the schema (if needed), then runs
@@ -1584,6 +1613,18 @@ func CheckSchemaCompat(
 			"usage_events table missing required columns: %w",
 			err,
 		)
+	}
+	rows.Close()
+
+	rows, err = db.QueryContext(ctx,
+		`SELECT id, type, date_from, date_to, project, agent,
+			model, prompt, content, kind, schema_version,
+			template_id, template_version, aggregate_hash,
+			cache_key, cache_status, provenance_json,
+			structured_json, created_at
+		 FROM insights LIMIT 0`)
+	if err != nil {
+		return fmt.Errorf("insights table missing required columns: %w", err)
 	}
 	rows.Close()
 

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -1651,6 +1651,25 @@ func CheckSchemaCompat(
 	rows.Close()
 
 	rows, err = db.QueryContext(ctx,
+		`SELECT source_display_name, source_deleted_at
+		 FROM sessions LIMIT 0`)
+	if err != nil {
+		return fmt.Errorf(
+			"sessions table missing curation columns: %w", err,
+		)
+	}
+	rows.Close()
+
+	rows, err = db.QueryContext(ctx,
+		`SELECT id FROM excluded_sessions LIMIT 0`)
+	if err != nil {
+		return fmt.Errorf(
+			"excluded_sessions table missing required columns: %w", err,
+		)
+	}
+	rows.Close()
+
+	rows, err = db.QueryContext(ctx,
 		`SELECT call_index, file_path FROM tool_calls LIMIT 0`)
 	if err != nil {
 		return fmt.Errorf(
@@ -1787,10 +1806,10 @@ func CheckSchemaCompat(
 	return nil
 }
 
-// checkPushSchemaCompat verifies schema elements that only push needs:
-// the sync_metadata table and sessions.owner_marker. pg serve never reads
-// these, so they live outside CheckSchemaCompat (which gates read-only
-// serve startup) and are checked only on the push fast path.
+// checkPushSchemaCompat verifies schema elements that only push needs. PG serve
+// never reads sync_metadata or owner_marker, so they live outside
+// CheckSchemaCompat (which gates read-only serve startup) and are checked only
+// on the push fast path.
 func checkPushSchemaCompat(ctx context.Context, db *sql.DB) error {
 	rows, err := db.QueryContext(ctx,
 		`SELECT key, value FROM sync_metadata LIMIT 0`)
@@ -1801,27 +1820,18 @@ func checkPushSchemaCompat(ctx context.Context, db *sql.DB) error {
 	rows.Close()
 
 	rows, err = db.QueryContext(ctx,
-		`SELECT owner_marker, source_display_name, source_deleted_at
-		 FROM sessions LIMIT 0`)
+		`SELECT owner_marker FROM sessions LIMIT 0`)
 	if err != nil {
 		return fmt.Errorf(
-			"sessions table missing push curation columns: %w", err)
-	}
-	rows.Close()
-
-	rows, err = db.QueryContext(ctx,
-		`SELECT id FROM excluded_sessions LIMIT 0`)
-	if err != nil {
-		return fmt.Errorf(
-			"excluded_sessions table missing required columns: %w", err)
+			"sessions table missing push ownership columns: %w", err)
 	}
 	rows.Close()
 	return nil
 }
 
 // pushSchemaCurrent reports whether the PG schema has everything a push
-// needs. CheckSchemaCompat covers the read paths but does not require the
-// push-only sync_metadata table or sessions.owner_marker (verified by
+// needs. CheckSchemaCompat covers the read and PG serve write paths but does
+// not require push-only sync_metadata or sessions.owner_marker (verified by
 // checkPushSchemaCompat), model_pricing (always queried by syncModelPricing)
 // or cursor_usage_events (written by syncCursorUsageEvents), so probe those
 // explicitly. It also requires the cursor dedup index, which the cursor usage

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -690,6 +690,7 @@ func EnsureSchema(
 	)
 	step = time.Now()
 	tokenCoverageColumnsAdded := false
+	sourceCurationColumnsAdded := false
 	addedColumns, err := ensureColumns(ctx, db, existingColumns, alters)
 	if err != nil {
 		return err
@@ -699,6 +700,8 @@ func EnsureSchema(
 		case "has_total_output_tokens", "has_peak_context_tokens",
 			"has_context_tokens", "has_output_tokens":
 			tokenCoverageColumnsAdded = true
+		case "source_display_name", "source_deleted_at":
+			sourceCurationColumnsAdded = true
 		}
 	}
 	log.Printf(
@@ -707,6 +710,17 @@ func EnsureSchema(
 		time.Since(step).Round(time.Millisecond),
 		len(addedColumns),
 	)
+	if sourceCurationColumnsAdded {
+		step = time.Now()
+		if err := backfillSourceCurationBaselines(ctx, db); err != nil {
+			return err
+		}
+		log.Printf(
+			"pg schema: source curation baseline backfill"+
+				" completed in %s",
+			time.Since(step).Round(time.Millisecond),
+		)
+	}
 	step = time.Now()
 	if _, err := db.ExecContext(ctx,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_termination_status
@@ -1018,6 +1032,30 @@ func runSchemaDataRepairsPG(ctx context.Context, db *sql.DB) error {
 		return err
 	}
 	return markTokenCoverageRepairDone(ctx, db)
+}
+
+func backfillSourceCurationBaselines(
+	ctx context.Context, pg *sql.DB,
+) error {
+	if _, err := pg.ExecContext(ctx,
+		`UPDATE sessions
+		 SET source_display_name = display_name
+		 WHERE source_display_name IS NULL`,
+	); err != nil {
+		return fmt.Errorf(
+			"backfilling PG source display-name baselines: %w", err,
+		)
+	}
+	if _, err := pg.ExecContext(ctx,
+		`UPDATE sessions
+		 SET source_deleted_at = deleted_at
+		 WHERE source_deleted_at IS NULL`,
+	); err != nil {
+		return fmt.Errorf(
+			"backfilling PG source deleted-at baselines: %w", err,
+		)
+	}
+	return nil
 }
 
 func batchUpdateAutomatedPG(

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -181,6 +181,11 @@ CREATE TABLE IF NOT EXISTS starred_sessions (
         REFERENCES sessions(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS excluded_sessions (
+    id         TEXT PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 CREATE TABLE IF NOT EXISTS pinned_messages (
     id          BIGSERIAL PRIMARY KEY,
     session_id  TEXT NOT NULL,
@@ -1676,6 +1681,14 @@ func checkPushSchemaCompat(ctx context.Context, db *sql.DB) error {
 	if err != nil {
 		return fmt.Errorf(
 			"sessions table missing owner_marker: %w", err)
+	}
+	rows.Close()
+
+	rows, err = db.QueryContext(ctx,
+		`SELECT id FROM excluded_sessions LIMIT 0`)
+	if err != nil {
+		return fmt.Errorf(
+			"excluded_sessions table missing required columns: %w", err)
 	}
 	rows.Close()
 	return nil

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -189,6 +189,15 @@ CREATE TABLE IF NOT EXISTS excluded_sessions (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS session_aliases (
+    session_id TEXT NOT NULL,
+    alias_id   TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (session_id, alias_id),
+    FOREIGN KEY (session_id)
+        REFERENCES sessions(id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS pinned_messages (
     id          BIGSERIAL PRIMARY KEY,
     session_id  TEXT NOT NULL,
@@ -1665,6 +1674,15 @@ func CheckSchemaCompat(
 	if err != nil {
 		return fmt.Errorf(
 			"excluded_sessions table missing required columns: %w", err,
+		)
+	}
+	rows.Close()
+
+	rows, err = db.QueryContext(ctx,
+		`SELECT session_id, alias_id FROM session_aliases LIMIT 0`)
+	if err != nil {
+		return fmt.Errorf(
+			"session_aliases table missing required columns: %w", err,
 		)
 	}
 	rows.Close()

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -15,6 +15,7 @@ import (
 )
 
 const tokenCoverageRepairMetadataKey = "token_coverage_repair_v1"
+const sourceCurationBackfillMetadataKey = "source_curation_baseline_backfill_v1"
 const tokenCoverageBackfillBatchSize = 1000
 
 type columnMigration struct {
@@ -710,14 +711,23 @@ func EnsureSchema(
 		time.Since(step).Round(time.Millisecond),
 		len(addedColumns),
 	)
-	if sourceCurationColumnsAdded {
-		step = time.Now()
-		if err := backfillSourceCurationBaselines(ctx, db); err != nil {
-			return err
-		}
+	step = time.Now()
+	sourceBackfilled, err := runSourceCurationBackfill(
+		ctx, db, sourceCurationColumnsAdded,
+	)
+	if err != nil {
+		return err
+	}
+	if sourceBackfilled {
 		log.Printf(
 			"pg schema: source curation baseline backfill"+
 				" completed in %s",
+			time.Since(step).Round(time.Millisecond),
+		)
+	} else {
+		log.Printf(
+			"pg schema: source curation baseline backfill"+
+				" check completed in %s (repair skipped)",
 			time.Since(step).Round(time.Millisecond),
 		)
 	}
@@ -1021,6 +1031,9 @@ func runSchemaDataRepairsPG(ctx context.Context, db *sql.DB) error {
 	if err := backfillIsAutomatedPG(ctx, db); err != nil {
 		return err
 	}
+	if _, err := runSourceCurationBackfill(ctx, db, false); err != nil {
+		return err
+	}
 	runRepair, err := shouldRunTokenCoverageRepair(ctx, db, false)
 	if err != nil {
 		return err
@@ -1053,6 +1066,67 @@ func backfillSourceCurationBaselines(
 	); err != nil {
 		return fmt.Errorf(
 			"backfilling PG source deleted-at baselines: %w", err,
+		)
+	}
+	return nil
+}
+
+func runSourceCurationBackfill(
+	ctx context.Context, db *sql.DB, sourceCurationColumnsAdded bool,
+) (bool, error) {
+	runRepair, err := shouldRunSourceCurationBackfill(
+		ctx, db, sourceCurationColumnsAdded,
+	)
+	if err != nil {
+		return false, err
+	}
+	if !runRepair {
+		return false, nil
+	}
+	if err := backfillSourceCurationBaselines(ctx, db); err != nil {
+		return false, err
+	}
+	if err := markSourceCurationBackfillDone(ctx, db); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func shouldRunSourceCurationBackfill(
+	ctx context.Context, db *sql.DB, sourceCurationColumnsAdded bool,
+) (bool, error) {
+	if sourceCurationColumnsAdded {
+		return true, nil
+	}
+
+	var done bool
+	if err := db.QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM sync_metadata
+			WHERE key = $1
+		)`,
+		sourceCurationBackfillMetadataKey,
+	).Scan(&done); err != nil {
+		return false, fmt.Errorf(
+			"probing source curation backfill metadata: %w", err,
+		)
+	}
+	return !done, nil
+}
+
+func markSourceCurationBackfillDone(
+	ctx context.Context, db *sql.DB,
+) error {
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO sync_metadata (key, value)
+		 VALUES ($1, '1')
+		 ON CONFLICT (key) DO UPDATE
+		 SET value = EXCLUDED.value`,
+		sourceCurationBackfillMetadataKey,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"storing source curation backfill metadata: %w", err,
 		)
 	}
 	return nil

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -302,6 +302,63 @@ func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
 		"information_schema.columns queries")
 }
 
+func TestEnsureSchemaBackfillsCurationBaselinesWhenAdded(t *testing.T) {
+	existing := map[string][]string{
+		"sessions": {
+			"owner_marker",
+			"created_at", "deleted_at", "display_name",
+			"total_output_tokens", "peak_context_tokens",
+			"has_total_output_tokens",
+			"has_peak_context_tokens", "is_automated",
+			"tool_failure_signal_count", "tool_retry_count",
+			"edit_churn_count", "consecutive_failure_max",
+			"outcome", "outcome_confidence",
+			"ended_with_role", "final_failure_streak",
+			"signals_pending_since", "compaction_count",
+			"mid_task_compaction_count",
+			"context_pressure_max", "health_score",
+			"health_grade", "has_tool_calls",
+			"has_context_data", "data_version", "cwd",
+			"quality_signal_version", "short_prompt_count",
+			"unstructured_start",
+			"missing_success_criteria_count",
+			"missing_verification_count",
+			"duplicate_prompt_count", "no_code_context_count",
+			"runaway_tool_loop_count",
+			"git_branch", "source_session_id",
+			"source_version", "parser_malformed_lines",
+			"is_truncated", "termination_status",
+			"secret_leak_count", "secrets_rules_version",
+			"session_name",
+		},
+		"messages": {
+			"model", "token_usage", "context_tokens",
+			"output_tokens", "has_context_tokens",
+			"has_output_tokens", "claude_message_id",
+			"claude_request_id", "source_type",
+			"source_subtype", "source_uuid",
+			"source_parent_uuid", "is_sidechain",
+			"is_compact_boundary", "thinking_text",
+		},
+		"tool_calls": {
+			"call_index", "file_path",
+		},
+	}
+	pg, state := newSchemaProbeDB(t, existing)
+
+	require.NoError(t, EnsureSchema(context.Background(), pg, "agentsview"))
+
+	executed := strings.ToLower(state.executedSQL())
+	assert.Contains(t, executed,
+		"set source_display_name = display_name")
+	assert.Contains(t, executed,
+		"where source_display_name is null")
+	assert.Contains(t, executed,
+		"set source_deleted_at = deleted_at")
+	assert.Contains(t, executed,
+		"where source_deleted_at is null")
+}
+
 func TestCheckDataVersionCompatRejectsNewerPGRows(t *testing.T) {
 	pg, state := newSchemaProbeDB(t, nil)
 	state.maxDataVersion = localdb.CurrentDataVersion() + 10

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -36,11 +36,13 @@ type schemaProbeState struct {
 	mu                  sync.Mutex
 	informationQueries  int
 	execs               []string
+	execArgs            [][]driver.NamedValue
 	alterTableExecs     []string
 	currentSchema       string
 	existingColumnNames map[string][]string
 	existingTables      map[string]bool
 	existingIndexes     map[string]bool
+	syncMetadataKeys    map[string]bool
 	maxDataVersion      int
 	maxDataVersionErr   error
 	queryErrors         []schemaProbeQueryError
@@ -104,17 +106,31 @@ func (c *schemaProbeConn) Begin() (driver.Tx, error) {
 }
 
 func (c *schemaProbeConn) ExecContext(
-	_ context.Context, query string, _ []driver.NamedValue,
+	_ context.Context, query string, args []driver.NamedValue,
 ) (driver.Result, error) {
 	c.state.mu.Lock()
 	c.state.execs = append(c.state.execs, query)
+	c.state.execArgs = append(
+		c.state.execArgs, append([]driver.NamedValue(nil), args...),
+	)
 	c.state.mu.Unlock()
-	if strings.Contains(strings.ToLower(query), "alter table") {
+	normalized := strings.ToLower(query)
+	if strings.Contains(normalized, "alter table") {
 		c.state.mu.Lock()
 		c.state.alterTableExecs = append(
 			c.state.alterTableExecs, query,
 		)
 		c.state.mu.Unlock()
+	}
+	if strings.Contains(normalized, "insert into sync_metadata") &&
+		len(args) > 0 {
+		if key, ok := args[0].Value.(string); ok {
+			c.state.mu.Lock()
+			if c.state.syncMetadataKeys != nil {
+				c.state.syncMetadataKeys[key] = true
+			}
+			c.state.mu.Unlock()
+		}
 	}
 	return driver.RowsAffected(0), nil
 }
@@ -203,9 +219,19 @@ func (c *schemaProbeConn) QueryContext(
 		}, nil
 	case strings.Contains(normalized, "select exists") &&
 		strings.Contains(normalized, "from sync_metadata"):
+		done := true
+		if c.state.syncMetadataKeys != nil {
+			key := ""
+			if len(args) > 0 {
+				if v, ok := args[0].Value.(string); ok {
+					key = v
+				}
+			}
+			done = c.state.syncMetadataKeys[key]
+		}
 		return &schemaProbeRows{
 			columns: []string{"exists"},
-			values:  [][]driver.Value{{true}},
+			values:  [][]driver.Value{{done}},
 		}, nil
 	case strings.Contains(normalized, "select exists"):
 		return &schemaProbeRows{
@@ -252,6 +278,19 @@ func (s *schemaProbeState) executedSQL() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return strings.Join(s.execs, "\n")
+}
+
+func (s *schemaProbeState) execArgValueSeen(value string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, args := range s.execArgs {
+		for _, arg := range args {
+			if got, ok := arg.Value.(string); ok && got == value {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
@@ -357,6 +396,36 @@ func TestEnsureSchemaBackfillsCurationBaselinesWhenAdded(t *testing.T) {
 		"set source_deleted_at = deleted_at")
 	assert.Contains(t, executed,
 		"where source_deleted_at is null")
+}
+
+func TestEnsureSchemaRetriesCurationBaselineBackfillUntilMarked(t *testing.T) {
+	existing := map[string][]string{
+		"sessions": {
+			"source_display_name",
+			"source_deleted_at",
+			"has_total_output_tokens",
+			"has_peak_context_tokens",
+		},
+		"messages": {
+			"has_context_tokens",
+			"has_output_tokens",
+		},
+	}
+	pg, state := newSchemaProbeDB(t, existing)
+	state.syncMetadataKeys = map[string]bool{
+		tokenCoverageRepairMetadataKey: true,
+	}
+
+	require.NoError(t, EnsureSchema(context.Background(), pg, "agentsview"))
+
+	executed := strings.ToLower(state.executedSQL())
+	assert.Contains(t, executed,
+		"set source_display_name = display_name")
+	assert.Contains(t, executed,
+		"set source_deleted_at = deleted_at")
+	assert.True(t,
+		state.execArgValueSeen("source_curation_baseline_backfill_v1"),
+		"source curation backfill completion marker should be written")
 }
 
 func TestCheckDataVersionCompatRejectsNewerPGRows(t *testing.T) {

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -503,6 +503,34 @@ func TestCheckSchemaCompatIgnoresPushOnlySchema(t *testing.T) {
 		"read compatibility must not require push-only schema")
 }
 
+func TestCheckSchemaCompatRequiresCurationBaselineColumns(t *testing.T) {
+	pg, state := newSchemaProbeDB(t, nil)
+	state.queryErrors = []schemaProbeQueryError{{
+		contains: "source_display_name",
+		err: errors.New(
+			`ERROR: column "source_display_name" does not exist (SQLSTATE 42703)`),
+	}}
+
+	err := CheckSchemaCompat(context.Background(), pg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sessions table missing curation columns")
+}
+
+func TestCheckSchemaCompatRequiresExcludedSessions(t *testing.T) {
+	pg, state := newSchemaProbeDB(t, nil)
+	state.queryErrors = []schemaProbeQueryError{{
+		contains: "from excluded_sessions",
+		err: errors.New(
+			`ERROR: relation "excluded_sessions" does not exist (SQLSTATE 42P01)`),
+	}}
+
+	err := CheckSchemaCompat(context.Background(), pg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "excluded_sessions table missing")
+}
+
 func TestSyncEnsureSchemaRunsDDLWhenPushMetadataMissing(t *testing.T) {
 	pg, state := newSchemaProbeDB(t, map[string][]string{
 		"sessions": {

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -531,6 +531,20 @@ func TestCheckSchemaCompatRequiresExcludedSessions(t *testing.T) {
 	assert.Contains(t, err.Error(), "excluded_sessions table missing")
 }
 
+func TestCheckSchemaCompatRequiresSessionAliases(t *testing.T) {
+	pg, state := newSchemaProbeDB(t, nil)
+	state.queryErrors = []schemaProbeQueryError{{
+		contains: "from session_aliases",
+		err: errors.New(
+			`ERROR: relation "session_aliases" does not exist (SQLSTATE 42P01)`),
+	}}
+
+	err := CheckSchemaCompat(context.Background(), pg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session_aliases table missing")
+}
+
 func TestSyncEnsureSchemaRunsDDLWhenPushMetadataMissing(t *testing.T) {
 	pg, state := newSchemaProbeDB(t, map[string][]string{
 		"sessions": {

--- a/internal/postgres/session_aliases.go
+++ b/internal/postgres/session_aliases.go
@@ -46,6 +46,11 @@ func pgSessionAliasIDs(sess db.Session) []string {
 	return []string{aliasID}
 }
 
+func pgSessionTombstoneIDs(sess db.Session) []string {
+	ids := append([]string{sess.ID}, pgSessionAliasIDs(sess)...)
+	return uniqueNonEmptyStrings(ids)
+}
+
 func pgVibeFallbackAliasID(id, agent, filePath string) string {
 	if agent != "vibe" || filePath == "" {
 		return ""

--- a/internal/postgres/session_aliases.go
+++ b/internal/postgres/session_aliases.go
@@ -1,0 +1,99 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func replacePGSessionAliases(
+	ctx context.Context, tx *sql.Tx, sess db.Session,
+) error {
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM session_aliases WHERE session_id = $1`,
+		sess.ID,
+	); err != nil {
+		return fmt.Errorf("deleting pg session aliases for %s: %w", sess.ID, err)
+	}
+	for _, aliasID := range pgSessionAliasIDs(sess) {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO session_aliases (session_id, alias_id)
+			 VALUES ($1, $2)
+			 ON CONFLICT (session_id, alias_id) DO NOTHING`,
+			sess.ID, aliasID,
+		); err != nil {
+			return fmt.Errorf(
+				"storing pg session alias %s for %s: %w",
+				aliasID, sess.ID, err,
+			)
+		}
+	}
+	return nil
+}
+
+func pgSessionAliasIDs(sess db.Session) []string {
+	if sess.FilePath == nil {
+		return nil
+	}
+	aliasID := pgVibeFallbackAliasID(sess.ID, sess.Agent, *sess.FilePath)
+	if aliasID == "" {
+		return nil
+	}
+	return []string{aliasID}
+}
+
+func pgVibeFallbackAliasID(id, agent, filePath string) string {
+	if agent != "vibe" || filePath == "" {
+		return ""
+	}
+	dir := filepath.Base(filepath.Dir(filePath))
+	if !strings.HasPrefix(dir, "session_") {
+		return ""
+	}
+	fallbackID := "vibe:" + dir
+	if idx := strings.LastIndex(id, "vibe:"); idx > 0 {
+		fallbackID = id[:idx] + fallbackID
+	}
+	if fallbackID == id {
+		return ""
+	}
+	return fallbackID
+}
+
+func insertPGExcludedSessionIDs(
+	ctx context.Context, execer pgSessionExecer, ids []string,
+) error {
+	ids = uniqueNonEmptyStrings(ids)
+	if len(ids) == 0 {
+		return nil
+	}
+	if _, err := execer.ExecContext(ctx,
+		`INSERT INTO excluded_sessions (id)
+		 SELECT unnest($1::text[])
+		 ON CONFLICT (id) DO NOTHING`,
+		ids,
+	); err != nil {
+		return fmt.Errorf("recording pg excluded session ids: %w", err)
+	}
+	return nil
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/postgres/session_mgmt_pgtest_test.go
+++ b/internal/postgres/session_mgmt_pgtest_test.go
@@ -1,0 +1,99 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestStoreSessionManagementCRUD(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	ctx := context.Background()
+	project := "session-mgmt"
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, first_message,
+			started_at, ended_at, message_count,
+			user_message_count
+		) VALUES
+			('mgmt-rename', 'machine', $1, 'claude', 'rename me',
+			 '2026-03-12T10:00:00Z'::timestamptz,
+			 '2026-03-12T10:30:00Z'::timestamptz, 2, 1),
+			('mgmt-trash', 'machine', $1, 'claude', 'trash me',
+			 '2026-03-12T11:00:00Z'::timestamptz,
+			 '2026-03-12T11:30:00Z'::timestamptz, 2, 1),
+			('mgmt-delete', 'machine', $1, 'claude', 'delete me',
+			 '2026-03-12T12:00:00Z'::timestamptz,
+			 '2026-03-12T12:30:00Z'::timestamptz, 2, 1),
+			('mgmt-empty-a', 'machine', $1, 'claude', 'empty a',
+			 '2026-03-12T13:00:00Z'::timestamptz,
+			 '2026-03-12T13:30:00Z'::timestamptz, 2, 1),
+			('mgmt-empty-b', 'machine', $1, 'claude', 'empty b',
+			 '2026-03-12T14:00:00Z'::timestamptz,
+			 '2026-03-12T14:30:00Z'::timestamptz, 2, 1)
+	`, project)
+	require.NoError(t, err, "inserting session rows")
+
+	renamed := "Renamed by PG store"
+	require.NoError(t, store.RenameSession("mgmt-rename", &renamed),
+		"RenameSession")
+	sess, err := store.GetSession(ctx, "mgmt-rename")
+	require.NoError(t, err, "GetSession after rename")
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.DisplayName)
+	assert.Equal(t, renamed, *sess.DisplayName)
+
+	require.NoError(t, store.SoftDeleteSession("mgmt-trash"),
+		"SoftDeleteSession")
+	trashed, err := store.ListTrashedSessions(ctx)
+	require.NoError(t, err, "ListTrashedSessions after soft delete")
+	assert.Contains(t, sessionIDs(trashed), "mgmt-trash")
+
+	restored, err := store.RestoreSession("mgmt-trash")
+	require.NoError(t, err, "RestoreSession")
+	assert.EqualValues(t, 1, restored)
+	sess, err = store.GetSession(ctx, "mgmt-trash")
+	require.NoError(t, err, "GetSession after restore")
+	require.NotNil(t, sess)
+
+	require.NoError(t, store.SoftDeleteSession("mgmt-delete"),
+		"SoftDeleteSession delete target")
+	deleted, err := store.DeleteSessionIfTrashed("mgmt-delete")
+	require.NoError(t, err, "DeleteSessionIfTrashed")
+	assert.EqualValues(t, 1, deleted)
+	sess, err = store.GetSessionFull(ctx, "mgmt-delete")
+	require.NoError(t, err, "GetSessionFull after delete")
+	assert.Nil(t, sess)
+
+	deletedCount, err := store.SoftDeleteSessions([]string{
+		"mgmt-empty-a", "mgmt-empty-b",
+	})
+	require.NoError(t, err, "SoftDeleteSessions")
+	assert.Equal(t, 2, deletedCount)
+
+	count, err := store.EmptyTrash()
+	require.NoError(t, err, "EmptyTrash")
+	assert.Equal(t, 2, count)
+	trashed, err = store.ListTrashedSessions(ctx)
+	require.NoError(t, err, "ListTrashedSessions after empty trash")
+	assert.NotContains(t, sessionIDs(trashed), "mgmt-empty-a")
+	assert.NotContains(t, sessionIDs(trashed), "mgmt-empty-b")
+
+	assert.Equal(t, db.ErrReadOnly, store.UpsertSession(db.Session{}))
+	assert.Equal(t, db.ErrReadOnly,
+		store.ReplaceSessionMessages("mgmt-rename", nil))
+	_, err = store.WriteSessionBatchAtomic(nil)
+	assert.ErrorIs(t, err, db.ErrReadOnly)
+}

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -23,6 +23,9 @@ type Store struct {
 	cursorMu     sync.RWMutex
 	cursorSecret []byte
 
+	insightCapabilityMu        sync.RWMutex
+	insightGenerationAvailable bool
+
 	pricingMu     sync.Mutex
 	pricingLoadMu sync.Mutex
 	pricingLoad   *pricingLoad

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -56,6 +56,10 @@ func (s *Store) SetCursorSecret(secret []byte) {
 // paths stay blocked while dashboard curation uses dedicated methods.
 func (s *Store) ReadOnly() bool { return true }
 
+// InsightGenerationAvailable reports that PG serve can persist generated
+// insights even though the broader store stays read-only for ingestion.
+func (s *Store) InsightGenerationAvailable() bool { return true }
+
 // GetSessionVersion returns the message count and a compact version
 // marker for SSE change detection.
 func (s *Store) GetSessionVersion(

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -168,6 +168,16 @@ func scanPGInsight(rs pgInsightRowScanner) (db.Insight, error) {
 	return s, nil
 }
 
+func mapPGWriteError(action string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if IsReadOnlyError(err) {
+		return fmt.Errorf("%s: %w: %w", action, db.ErrReadOnly, err)
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
 func buildPGInsightFilter(
 	f db.InsightFilter, pb *paramBuilder,
 ) string {
@@ -219,7 +229,7 @@ func (s *Store) InsertInsight(insight db.Insight) (int64, error) {
 		insight.CacheStatus, insight.ProvenanceJSON, insight.StructuredJSON,
 	).Scan(&id)
 	if err != nil {
-		return 0, fmt.Errorf("inserting insight: %w", err)
+		return 0, mapPGWriteError("inserting insight", err)
 	}
 	return id, nil
 }
@@ -231,7 +241,7 @@ func (s *Store) DeleteInsight(id int64) error {
 		id,
 	)
 	if err != nil {
-		return fmt.Errorf("deleting insight %d: %w", id, err)
+		return mapPGWriteError(fmt.Sprintf("deleting insight %d", id), err)
 	}
 	return nil
 }
@@ -338,7 +348,7 @@ func (s *Store) RenameSession(
 		id, displayName,
 	)
 	if err != nil {
-		return fmt.Errorf("renaming session %s: %w", id, err)
+		return mapPGWriteError(fmt.Sprintf("renaming session %s", id), err)
 	}
 	return nil
 }
@@ -353,7 +363,9 @@ func (s *Store) SoftDeleteSession(id string) error {
 		id,
 	)
 	if err != nil {
-		return fmt.Errorf("soft deleting session %s: %w", id, err)
+		return mapPGWriteError(
+			fmt.Sprintf("soft deleting session %s", id), err,
+		)
 	}
 	return nil
 }
@@ -381,7 +393,7 @@ func (s *Store) SoftDeleteSessions(ids []string) (int, error) {
 			pb.args...,
 		)
 		if err != nil {
-			return total, fmt.Errorf("soft deleting sessions: %w", err)
+			return total, mapPGWriteError("soft deleting sessions", err)
 		}
 		n, err := res.RowsAffected()
 		if err != nil {
@@ -402,7 +414,9 @@ func (s *Store) RestoreSession(id string) (int64, error) {
 		id,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("restoring session %s: %w", id, err)
+		return 0, mapPGWriteError(
+			fmt.Sprintf("restoring session %s", id), err,
+		)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
@@ -418,8 +432,9 @@ func (s *Store) DeleteSessionIfTrashed(
 	ctx := context.Background()
 	tx, err := s.pg.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, fmt.Errorf(
-			"begin delete-if-trashed tx for %s: %w", id, err,
+		return 0, mapPGWriteError(
+			fmt.Sprintf("begin delete-if-trashed tx for %s", id),
+			err,
 		)
 	}
 	defer func() { _ = tx.Rollback() }()
@@ -431,8 +446,9 @@ func (s *Store) DeleteSessionIfTrashed(
 		id,
 	)
 	if err != nil {
-		return 0, fmt.Errorf(
-			"locking trashed session %s: %w", id, err,
+		return 0, mapPGWriteError(
+			fmt.Sprintf("locking trashed session %s", id),
+			err,
 		)
 	}
 	locked, err := res.RowsAffected()
@@ -452,8 +468,9 @@ func (s *Store) DeleteSessionIfTrashed(
 		 ON CONFLICT (id) DO NOTHING`,
 		id,
 	); err != nil {
-		return 0, fmt.Errorf(
-			"recording excluded trashed session %s: %w", id, err,
+		return 0, mapPGWriteError(
+			fmt.Sprintf("recording excluded trashed session %s", id),
+			err,
 		)
 	}
 
@@ -463,15 +480,18 @@ func (s *Store) DeleteSessionIfTrashed(
 		id,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("deleting trashed session %s: %w", id, err)
+		return 0, mapPGWriteError(
+			fmt.Sprintf("deleting trashed session %s", id), err,
+		)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
 		return 0, fmt.Errorf("counting deleted trashed session %s: %w", id, err)
 	}
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf(
-			"commit delete-if-trashed %s: %w", id, err,
+		return 0, mapPGWriteError(
+			fmt.Sprintf("commit delete-if-trashed %s", id),
+			err,
 		)
 	}
 	return n, nil
@@ -498,7 +518,7 @@ func (s *Store) EmptyTrash() (int, error) {
 	ctx := context.Background()
 	tx, err := s.pg.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, fmt.Errorf("begin empty-trash tx: %w", err)
+		return 0, mapPGWriteError("begin empty-trash tx", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
@@ -507,28 +527,30 @@ func (s *Store) EmptyTrash() (int, error) {
 		 SET deleted_at = deleted_at
 		 WHERE deleted_at IS NOT NULL`,
 	); err != nil {
-		return 0, fmt.Errorf("locking trashed sessions: %w", err)
+		return 0, mapPGWriteError("locking trashed sessions", err)
 	}
 	if _, err := tx.ExecContext(ctx,
 		`INSERT INTO excluded_sessions (id)
 		 SELECT id FROM sessions WHERE deleted_at IS NOT NULL
 		 ON CONFLICT (id) DO NOTHING`,
 	); err != nil {
-		return 0, fmt.Errorf("recording excluded trashed sessions: %w", err)
+		return 0, mapPGWriteError(
+			"recording excluded trashed sessions", err,
+		)
 	}
 
 	res, err := tx.ExecContext(ctx,
 		"DELETE FROM sessions WHERE deleted_at IS NOT NULL",
 	)
 	if err != nil {
-		return 0, fmt.Errorf("emptying trash: %w", err)
+		return 0, mapPGWriteError("emptying trash", err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
 		return 0, fmt.Errorf("counting emptied trash rows: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit empty-trash: %w", err)
+		return 0, mapPGWriteError("commit empty-trash", err)
 	}
 	return int(n), nil
 }

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -522,32 +522,20 @@ func (s *Store) EmptyTrash() (int, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE sessions
-		 SET deleted_at = deleted_at
-		 WHERE deleted_at IS NOT NULL`,
-	); err != nil {
-		return 0, mapPGWriteError("locking trashed sessions", err)
-	}
-	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO excluded_sessions (id)
-		 SELECT id FROM sessions WHERE deleted_at IS NOT NULL
-		 ON CONFLICT (id) DO NOTHING`,
-	); err != nil {
-		return 0, mapPGWriteError(
-			"recording excluded trashed sessions", err,
+	var n int64
+	if err := tx.QueryRowContext(ctx,
+		`WITH deleted AS (
+			DELETE FROM sessions
+			WHERE deleted_at IS NOT NULL
+			RETURNING id
+		), excluded AS (
+			INSERT INTO excluded_sessions (id)
+			SELECT id FROM deleted
+			ON CONFLICT (id) DO NOTHING
 		)
-	}
-
-	res, err := tx.ExecContext(ctx,
-		"DELETE FROM sessions WHERE deleted_at IS NOT NULL",
-	)
-	if err != nil {
+		SELECT COUNT(*) FROM deleted`,
+	).Scan(&n); err != nil {
 		return 0, mapPGWriteError("emptying trash", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("counting emptied trash rows: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, mapPGWriteError("commit empty-trash", err)

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -439,11 +439,8 @@ func (s *Store) DeleteSessionIfTrashed(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	res, err := tx.ExecContext(ctx,
-		`UPDATE sessions
-		 SET deleted_at = deleted_at
-		 WHERE id = $1 AND deleted_at IS NOT NULL`,
-		id,
+	sessionIDs, excludedIDs, err := readPGTrashedSessionExclusions(
+		ctx, tx, "s.id = $1 AND s.deleted_at IS NOT NULL", id,
 	)
 	if err != nil {
 		return 0, mapPGWriteError(
@@ -451,42 +448,22 @@ func (s *Store) DeleteSessionIfTrashed(
 			err,
 		)
 	}
-	locked, err := res.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf(
-			"counting locked trashed session %s: %w", id, err,
-		)
-	}
-	if locked == 0 {
+	if len(sessionIDs) == 0 {
 		return 0, nil
 	}
 
-	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO excluded_sessions (id)
-		 SELECT id FROM sessions
-		 WHERE id = $1 AND deleted_at IS NOT NULL
-		 ON CONFLICT (id) DO NOTHING`,
-		id,
-	); err != nil {
+	if err := insertPGExcludedSessionIDs(ctx, tx, excludedIDs); err != nil {
 		return 0, mapPGWriteError(
 			fmt.Sprintf("recording excluded trashed session %s", id),
 			err,
 		)
 	}
 
-	res, err = tx.ExecContext(ctx,
-		`DELETE FROM sessions
-		 WHERE id = $1 AND deleted_at IS NOT NULL`,
-		id,
-	)
+	n, err := deletePGTrashedSessionRows(ctx, tx, sessionIDs)
 	if err != nil {
 		return 0, mapPGWriteError(
 			fmt.Sprintf("deleting trashed session %s", id), err,
 		)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("counting deleted trashed session %s: %w", id, err)
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, mapPGWriteError(
@@ -522,25 +499,101 @@ func (s *Store) EmptyTrash() (int, error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	var n int64
-	if err := tx.QueryRowContext(ctx,
-		`WITH deleted AS (
-			DELETE FROM sessions
-			WHERE deleted_at IS NOT NULL
-			RETURNING id
-		), excluded AS (
-			INSERT INTO excluded_sessions (id)
-			SELECT id FROM deleted
-			ON CONFLICT (id) DO NOTHING
-		)
-		SELECT COUNT(*) FROM deleted`,
-	).Scan(&n); err != nil {
+	sessionIDs, excludedIDs, err := readPGTrashedSessionExclusions(
+		ctx, tx, "s.deleted_at IS NOT NULL",
+	)
+	if err != nil {
+		return 0, mapPGWriteError("locking trashed sessions", err)
+	}
+	if len(sessionIDs) == 0 {
+		if err := tx.Commit(); err != nil {
+			return 0, mapPGWriteError("commit empty-trash", err)
+		}
+		return 0, nil
+	}
+
+	if err := insertPGExcludedSessionIDs(ctx, tx, excludedIDs); err != nil {
+		return 0, mapPGWriteError("recording excluded trashed sessions", err)
+	}
+
+	n, err := deletePGTrashedSessionRows(ctx, tx, sessionIDs)
+	if err != nil {
 		return 0, mapPGWriteError("emptying trash", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, mapPGWriteError("commit empty-trash", err)
 	}
 	return int(n), nil
+}
+
+func readPGTrashedSessionExclusions(
+	ctx context.Context, tx *sql.Tx, where string, args ...any,
+) ([]string, []string, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT s.id, sa.alias_id
+		 FROM sessions s
+		 LEFT JOIN session_aliases sa ON sa.session_id = s.id
+		 WHERE `+where+`
+		 FOR UPDATE OF s`,
+		args...,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	sessionIDs := []string{}
+	excludedIDs := []string{}
+	sessionSeen := map[string]struct{}{}
+	excludedSeen := map[string]struct{}{}
+	for rows.Next() {
+		var id string
+		var aliasID sql.NullString
+		if err := rows.Scan(&id, &aliasID); err != nil {
+			return nil, nil, err
+		}
+		if _, ok := sessionSeen[id]; !ok {
+			sessionSeen[id] = struct{}{}
+			sessionIDs = append(sessionIDs, id)
+		}
+		if _, ok := excludedSeen[id]; !ok {
+			excludedSeen[id] = struct{}{}
+			excludedIDs = append(excludedIDs, id)
+		}
+		if !aliasID.Valid || aliasID.String == "" {
+			continue
+		}
+		if _, ok := excludedSeen[aliasID.String]; ok {
+			continue
+		}
+		excludedSeen[aliasID.String] = struct{}{}
+		excludedIDs = append(excludedIDs, aliasID.String)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return sessionIDs, excludedIDs, nil
+}
+
+func deletePGTrashedSessionRows(
+	ctx context.Context, tx *sql.Tx, ids []string,
+) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	res, err := tx.ExecContext(ctx,
+		`DELETE FROM sessions
+		 WHERE id = ANY($1) AND deleted_at IS NOT NULL`,
+		ids,
+	)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // UpsertSession is not supported in read-only mode.

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -465,6 +465,11 @@ func (s *Store) DeleteSessionIfTrashed(
 			fmt.Sprintf("deleting trashed session %s", id), err,
 		)
 	}
+	if err := deletePGExcludedSessionRows(ctx, tx, excludedIDs); err != nil {
+		return 0, mapPGWriteError(
+			fmt.Sprintf("purging excluded session aliases for %s", id), err,
+		)
+	}
 	if err := tx.Commit(); err != nil {
 		return 0, mapPGWriteError(
 			fmt.Sprintf("commit delete-if-trashed %s", id),
@@ -519,6 +524,9 @@ func (s *Store) EmptyTrash() (int, error) {
 	n, err := deletePGTrashedSessionRows(ctx, tx, sessionIDs)
 	if err != nil {
 		return 0, mapPGWriteError("emptying trash", err)
+	}
+	if err := deletePGExcludedSessionRows(ctx, tx, excludedIDs); err != nil {
+		return 0, mapPGWriteError("purging excluded trashed session aliases", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, mapPGWriteError("commit empty-trash", err)

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -98,9 +98,10 @@ func (s *Store) DetectInsightGenerationAvailability(
 func probeInsightGenerationAvailabilityTx(
 	ctx context.Context, tx *sql.Tx,
 ) (bool, error) {
-	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO insights (id) VALUES (-1)`,
-	); err != nil {
+	var id int64
+	if err := tx.QueryRowContext(ctx,
+		`INSERT INTO insights DEFAULT VALUES RETURNING id`,
+	).Scan(&id); err != nil {
 		if IsReadOnlyError(err) {
 			return false, nil
 		}

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -56,9 +56,60 @@ func (s *Store) SetCursorSecret(secret []byte) {
 // paths stay blocked while dashboard curation uses dedicated methods.
 func (s *Store) ReadOnly() bool { return true }
 
-// InsightGenerationAvailable reports that PG serve can persist generated
-// insights even though the broader store stays read-only for ingestion.
-func (s *Store) InsightGenerationAvailable() bool { return true }
+// InsightGenerationAvailable reports whether startup proved this PG role can
+// persist generated insights.
+func (s *Store) InsightGenerationAvailable() bool {
+	s.insightCapabilityMu.RLock()
+	defer s.insightCapabilityMu.RUnlock()
+	return s.insightGenerationAvailable
+}
+
+func (s *Store) setInsightGenerationAvailable(available bool) {
+	s.insightCapabilityMu.Lock()
+	defer s.insightCapabilityMu.Unlock()
+	s.insightGenerationAvailable = available
+}
+
+// DetectInsightGenerationAvailability probes whether this PG connection can
+// insert into insights. PG serve uses it to expose generate routes only when
+// the configured role can actually persist the result.
+func (s *Store) DetectInsightGenerationAvailability(
+	ctx context.Context,
+) error {
+	tx, err := s.pg.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf(
+			"beginning insight generation capability probe: %w",
+			err,
+		)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	available, err := probeInsightGenerationAvailabilityTx(
+		ctx, tx,
+	)
+	if err != nil {
+		return err
+	}
+	s.setInsightGenerationAvailable(available)
+	return nil
+}
+
+func probeInsightGenerationAvailabilityTx(
+	ctx context.Context, tx *sql.Tx,
+) (bool, error) {
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO insights (id) VALUES (-1)`,
+	); err != nil {
+		if IsReadOnlyError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf(
+			"probing insight generation capability: %w", err,
+		)
+	}
+	return true, nil
+}
 
 // GetSessionVersion returns the message count and a compact version
 // marker for SSE change detection.
@@ -363,7 +414,49 @@ func (s *Store) RestoreSession(id string) (int64, error) {
 func (s *Store) DeleteSessionIfTrashed(
 	id string,
 ) (int64, error) {
-	res, err := s.pg.Exec(
+	ctx := context.Background()
+	tx, err := s.pg.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"begin delete-if-trashed tx for %s: %w", id, err,
+		)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE sessions
+		 SET deleted_at = deleted_at
+		 WHERE id = $1 AND deleted_at IS NOT NULL`,
+		id,
+	)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"locking trashed session %s: %w", id, err,
+		)
+	}
+	locked, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf(
+			"counting locked trashed session %s: %w", id, err,
+		)
+	}
+	if locked == 0 {
+		return 0, nil
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO excluded_sessions (id)
+		 SELECT id FROM sessions
+		 WHERE id = $1 AND deleted_at IS NOT NULL
+		 ON CONFLICT (id) DO NOTHING`,
+		id,
+	); err != nil {
+		return 0, fmt.Errorf(
+			"recording excluded trashed session %s: %w", id, err,
+		)
+	}
+
+	res, err = tx.ExecContext(ctx,
 		`DELETE FROM sessions
 		 WHERE id = $1 AND deleted_at IS NOT NULL`,
 		id,
@@ -374,6 +467,11 @@ func (s *Store) DeleteSessionIfTrashed(
 	n, err := res.RowsAffected()
 	if err != nil {
 		return 0, fmt.Errorf("counting deleted trashed session %s: %w", id, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf(
+			"commit delete-if-trashed %s: %w", id, err,
+		)
 	}
 	return n, nil
 }
@@ -396,7 +494,29 @@ func (s *Store) ListTrashedSessions(
 
 // EmptyTrash permanently deletes every trashed session.
 func (s *Store) EmptyTrash() (int, error) {
-	res, err := s.pg.Exec(
+	ctx := context.Background()
+	tx, err := s.pg.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin empty-trash tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE sessions
+		 SET deleted_at = deleted_at
+		 WHERE deleted_at IS NOT NULL`,
+	); err != nil {
+		return 0, fmt.Errorf("locking trashed sessions: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO excluded_sessions (id)
+		 SELECT id FROM sessions WHERE deleted_at IS NOT NULL
+		 ON CONFLICT (id) DO NOTHING`,
+	); err != nil {
+		return 0, fmt.Errorf("recording excluded trashed sessions: %w", err)
+	}
+
+	res, err := tx.ExecContext(ctx,
 		"DELETE FROM sessions WHERE deleted_at IS NOT NULL",
 	)
 	if err != nil {
@@ -405,6 +525,9 @@ func (s *Store) EmptyTrash() (int, error) {
 	n, err := res.RowsAffected()
 	if err != nil {
 		return 0, fmt.Errorf("counting emptied trash rows: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit empty-trash: %w", err)
 	}
 	return int(n), nil
 }

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -3,6 +3,8 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strings"
 	"time"
 
 	"go.kenn.io/agentsview/internal/config"
@@ -13,7 +15,7 @@ import (
 var _ db.Store = (*Store)(nil)
 
 // NewStore opens a PostgreSQL connection using the shared Open()
-// helper and returns a read-only Store.
+// helper and returns a Store.
 // When allowInsecure is true, non-loopback connections without
 // TLS produce a warning instead of failing.
 func NewStore(
@@ -49,9 +51,9 @@ func (s *Store) SetCursorSecret(secret []byte) {
 	s.cursorSecret = append([]byte(nil), secret...)
 }
 
-// ReadOnly returns true because PG serve does not mutate synced
-// session content. Small dashboard-owned curation metadata (stars
-// and pins) is writable through dedicated methods.
+// ReadOnly returns true because PG serve still treats the remote
+// session store as remote; local file, upload, and batch-ingest
+// paths stay blocked while dashboard curation uses dedicated methods.
 func (s *Store) ReadOnly() bool { return true }
 
 // GetSessionVersion returns the message count and a compact version
@@ -76,81 +78,331 @@ func (s *Store) GetSessionVersion(
 // Unsupported write stubs (return db.ErrReadOnly)
 // ------------------------------------------------------------
 
-// InsertInsight is not supported in read-only mode.
-func (s *Store) InsertInsight(
-	_ db.Insight,
-) (int64, error) {
-	return 0, db.ErrReadOnly
+const maxPGInsights = 500
+
+type pgInsightRowScanner interface {
+	Scan(...any) error
 }
 
-// DeleteInsight is not supported in read-only mode.
-func (s *Store) DeleteInsight(_ int64) error {
-	return db.ErrReadOnly
+func scanPGInsight(rs pgInsightRowScanner) (db.Insight, error) {
+	var s db.Insight
+	var project, model, prompt sql.NullString
+	var createdAt time.Time
+	err := rs.Scan(
+		&s.ID, &s.Type, &s.DateFrom, &s.DateTo,
+		&project, &s.Agent, &model, &prompt, &s.Content,
+		&s.Kind, &s.SchemaVersion, &s.TemplateID,
+		&s.TemplateVersion, &s.AggregateHash, &s.CacheKey,
+		&s.CacheStatus, &s.ProvenanceJSON, &s.StructuredJSON,
+		&createdAt,
+	)
+	if err != nil {
+		return s, err
+	}
+	if project.Valid {
+		s.Project = &project.String
+	}
+	if model.Valid {
+		s.Model = &model.String
+	}
+	if prompt.Valid {
+		s.Prompt = &prompt.String
+	}
+	s.CreatedAt = FormatISO8601(createdAt)
+	return s, nil
 }
 
-// ListInsights returns an empty slice. Saved insights, including
-// llm_canned structured metadata, are local SQLite artifacts; remote
-// PG serve mode does not expose partial insight rows.
+func buildPGInsightFilter(
+	f db.InsightFilter, pb *paramBuilder,
+) string {
+	var preds []string
+	add := func(expr string, val any) {
+		preds = append(preds, expr+" = "+pb.add(val))
+	}
+	if f.Type != "" {
+		add("type", f.Type)
+	}
+	if f.GlobalOnly {
+		preds = append(preds, "project IS NULL")
+	} else if f.Project != "" {
+		add("project", f.Project)
+	}
+	if f.DateFrom != "" {
+		preds = append(preds, "date_from >= "+pb.add(f.DateFrom))
+	}
+	if f.DateTo != "" {
+		preds = append(preds, "date_to <= "+pb.add(f.DateTo))
+	}
+	if len(preds) == 0 {
+		return "TRUE"
+	}
+	return strings.Join(preds, " AND ")
+}
+
+// InsertInsight stores a dashboard insight in PG.
+func (s *Store) InsertInsight(insight db.Insight) (int64, error) {
+	var id int64
+	err := s.pg.QueryRow(
+		`INSERT INTO insights (
+			type, date_from, date_to, project,
+			agent, model, prompt, content,
+			kind, schema_version, template_id,
+			template_version, aggregate_hash, cache_key,
+			cache_status, provenance_json, structured_json
+		) VALUES (
+			$1, $2, $3, $4,
+			$5, $6, $7, $8,
+			$9, $10, $11,
+			$12, $13, $14,
+			$15, $16, $17
+		) RETURNING id`,
+		insight.Type, insight.DateFrom, insight.DateTo, insight.Project,
+		insight.Agent, insight.Model, insight.Prompt, insight.Content,
+		insight.Kind, insight.SchemaVersion, insight.TemplateID,
+		insight.TemplateVersion, insight.AggregateHash, insight.CacheKey,
+		insight.CacheStatus, insight.ProvenanceJSON, insight.StructuredJSON,
+	).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("inserting insight: %w", err)
+	}
+	return id, nil
+}
+
+// DeleteInsight removes a dashboard insight from PG.
+func (s *Store) DeleteInsight(id int64) error {
+	_, err := s.pg.Exec(
+		"DELETE FROM insights WHERE id = $1",
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("deleting insight %d: %w", id, err)
+	}
+	return nil
+}
+
+// ListInsights returns dashboard insights in created_at order.
 func (s *Store) ListInsights(
-	_ context.Context, _ db.InsightFilter,
+	ctx context.Context, f db.InsightFilter,
 ) ([]db.Insight, error) {
-	return []db.Insight{}, nil
+	pb := &paramBuilder{}
+	where := buildPGInsightFilter(f, pb)
+	rows, err := s.pg.QueryContext(ctx,
+		`SELECT id, type, date_from, date_to,
+			project, agent, model, prompt, content,
+			kind, schema_version, template_id,
+			template_version, aggregate_hash, cache_key,
+			cache_status, provenance_json, structured_json,
+			created_at
+		 FROM insights
+		 WHERE `+where+`
+		 ORDER BY created_at DESC, id DESC
+		 LIMIT `+fmt.Sprintf("%d", maxPGInsights),
+		pb.args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying insights: %w", err)
+	}
+	defer rows.Close()
+
+	insights := make([]db.Insight, 0)
+	for rows.Next() {
+		row, err := scanPGInsight(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning insight: %w", err)
+		}
+		insights = append(insights, row)
+	}
+	return insights, rows.Err()
 }
 
-// GetInsight returns nil because insights are local-only in PG serve mode.
+// GetInsight returns a single insight by ID.
 func (s *Store) GetInsight(
-	_ context.Context, _ int64,
+	ctx context.Context, id int64,
 ) (*db.Insight, error) {
-	return nil, nil
+	row := s.pg.QueryRowContext(ctx,
+		`SELECT id, type, date_from, date_to,
+			project, agent, model, prompt, content,
+			kind, schema_version, template_id,
+			template_version, aggregate_hash, cache_key,
+			cache_status, provenance_json, structured_json,
+			created_at
+		 FROM insights
+		 WHERE id = $1`,
+		id,
+	)
+	insight, err := scanPGInsight(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting insight %d: %w", id, err)
+	}
+	return &insight, nil
 }
 
-// GetCachedInsight returns nil in read-only remote mode; this avoids
-// returning incomplete cache/provenance metadata from PG-backed stores.
+// GetCachedInsight returns the newest insight with the cache key.
 func (s *Store) GetCachedInsight(
-	_ context.Context, _ string,
+	ctx context.Context, cacheKey string,
 ) (*db.Insight, error) {
-	return nil, nil
+	if strings.TrimSpace(cacheKey) == "" {
+		return nil, nil
+	}
+	row := s.pg.QueryRowContext(ctx,
+		`SELECT id, type, date_from, date_to,
+			project, agent, model, prompt, content,
+			kind, schema_version, template_id,
+			template_version, aggregate_hash, cache_key,
+			cache_status, provenance_json, structured_json,
+			created_at
+		 FROM insights
+		 WHERE cache_key = $1
+		 ORDER BY created_at DESC, id DESC
+		 LIMIT 1`,
+		cacheKey,
+	)
+	insight, err := scanPGInsight(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting cached insight: %w", err)
+	}
+	return &insight, nil
 }
 
-// RenameSession is not supported in read-only mode.
+// RenameSession updates the visible session name in PG.
 func (s *Store) RenameSession(
-	_ string, _ *string,
+	id string, displayName *string,
 ) error {
-	return db.ErrReadOnly
+	_, err := s.pg.Exec(
+		`UPDATE sessions
+		 SET display_name = $2,
+		     updated_at = NOW()
+		 WHERE id = $1 AND deleted_at IS NULL`,
+		id, displayName,
+	)
+	if err != nil {
+		return fmt.Errorf("renaming session %s: %w", id, err)
+	}
+	return nil
 }
 
-// SoftDeleteSession is not supported in read-only mode.
-func (s *Store) SoftDeleteSession(_ string) error {
-	return db.ErrReadOnly
+// SoftDeleteSession moves a session to the trash.
+func (s *Store) SoftDeleteSession(id string) error {
+	_, err := s.pg.Exec(
+		`UPDATE sessions
+		 SET deleted_at = NOW(),
+		     updated_at = NOW()
+		 WHERE id = $1 AND deleted_at IS NULL`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("soft deleting session %s: %w", id, err)
+	}
+	return nil
 }
 
-// SoftDeleteSessions is not supported in read-only mode.
-func (s *Store) SoftDeleteSessions(_ []string) (int, error) {
-	return 0, db.ErrReadOnly
+// SoftDeleteSessions moves multiple sessions to the trash.
+func (s *Store) SoftDeleteSessions(ids []string) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	total := 0
+	const batchSize = 500
+	for start := 0; start < len(ids); start += batchSize {
+		end := min(start+batchSize, len(ids))
+		pb := &paramBuilder{}
+		placeholders := make([]string, 0, end-start)
+		for _, id := range ids[start:end] {
+			placeholders = append(placeholders, pb.add(id))
+		}
+		res, err := s.pg.Exec(
+			`UPDATE sessions
+			 SET deleted_at = NOW(),
+			     updated_at = NOW()
+			 WHERE id IN (`+strings.Join(placeholders, ",")+
+				`) AND deleted_at IS NULL`,
+			pb.args...,
+		)
+		if err != nil {
+			return total, fmt.Errorf("soft deleting sessions: %w", err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return total, fmt.Errorf("counting soft deleted sessions: %w", err)
+		}
+		total += int(n)
+	}
+	return total, nil
 }
 
-// RestoreSession is not supported in read-only mode.
-func (s *Store) RestoreSession(_ string) (int64, error) {
-	return 0, db.ErrReadOnly
+// RestoreSession restores a trashed session.
+func (s *Store) RestoreSession(id string) (int64, error) {
+	res, err := s.pg.Exec(
+		`UPDATE sessions
+		 SET deleted_at = NULL,
+		     updated_at = NOW()
+		 WHERE id = $1 AND deleted_at IS NOT NULL`,
+		id,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("restoring session %s: %w", id, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("counting restored session %s: %w", id, err)
+	}
+	return n, nil
 }
 
-// DeleteSessionIfTrashed is not supported in read-only mode.
+// DeleteSessionIfTrashed permanently deletes a trashed session.
 func (s *Store) DeleteSessionIfTrashed(
-	_ string,
+	id string,
 ) (int64, error) {
-	return 0, db.ErrReadOnly
+	res, err := s.pg.Exec(
+		`DELETE FROM sessions
+		 WHERE id = $1 AND deleted_at IS NOT NULL`,
+		id,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("deleting trashed session %s: %w", id, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("counting deleted trashed session %s: %w", id, err)
+	}
+	return n, nil
 }
 
-// ListTrashedSessions returns an empty slice.
+// ListTrashedSessions returns trashed sessions in most-recent order.
 func (s *Store) ListTrashedSessions(
-	_ context.Context,
+	ctx context.Context,
 ) ([]db.Session, error) {
-	return []db.Session{}, nil
+	rows, err := s.pg.QueryContext(ctx,
+		"SELECT "+pgSessionCols+
+			" FROM sessions WHERE deleted_at IS NOT NULL"+
+			" ORDER BY deleted_at DESC LIMIT 500",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying trashed sessions: %w", err)
+	}
+	defer rows.Close()
+	return scanPGSessionRows(rows)
 }
 
-// EmptyTrash is not supported in read-only mode.
+// EmptyTrash permanently deletes every trashed session.
 func (s *Store) EmptyTrash() (int, error) {
-	return 0, db.ErrReadOnly
+	res, err := s.pg.Exec(
+		"DELETE FROM sessions WHERE deleted_at IS NOT NULL",
+	)
+	if err != nil {
+		return 0, fmt.Errorf("emptying trash: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("counting emptied trash rows: %w", err)
+	}
+	return int(n), nil
 }
 
 // UpsertSession is not supported in read-only mode.

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -538,9 +538,11 @@ func readPGTrashedSessionExclusions(
 	ctx context.Context, tx *sql.Tx, where string, args ...any,
 ) ([]string, []string, error) {
 	rows, err := tx.QueryContext(ctx,
-		`SELECT s.id, sa.alias_id
+		`SELECT s.id, sa.alias_id, rsa.session_id, rsaa.alias_id
 		 FROM sessions s
 		 LEFT JOIN session_aliases sa ON sa.session_id = s.id
+		 LEFT JOIN session_aliases rsa ON rsa.alias_id = s.id
+		 LEFT JOIN session_aliases rsaa ON rsaa.session_id = rsa.session_id
 		 WHERE `+where+`
 		 FOR UPDATE OF s`,
 		args...,
@@ -554,28 +556,40 @@ func readPGTrashedSessionExclusions(
 	excludedIDs := []string{}
 	sessionSeen := map[string]struct{}{}
 	excludedSeen := map[string]struct{}{}
+	addExcludedID := func(id string) {
+		if id == "" {
+			return
+		}
+		if _, ok := excludedSeen[id]; ok {
+			return
+		}
+		excludedSeen[id] = struct{}{}
+		excludedIDs = append(excludedIDs, id)
+	}
 	for rows.Next() {
 		var id string
 		var aliasID sql.NullString
-		if err := rows.Scan(&id, &aliasID); err != nil {
+		var reverseSessionID sql.NullString
+		var reverseAliasID sql.NullString
+		if err := rows.Scan(
+			&id, &aliasID, &reverseSessionID, &reverseAliasID,
+		); err != nil {
 			return nil, nil, err
 		}
 		if _, ok := sessionSeen[id]; !ok {
 			sessionSeen[id] = struct{}{}
 			sessionIDs = append(sessionIDs, id)
 		}
-		if _, ok := excludedSeen[id]; !ok {
-			excludedSeen[id] = struct{}{}
-			excludedIDs = append(excludedIDs, id)
+		addExcludedID(id)
+		if aliasID.Valid {
+			addExcludedID(aliasID.String)
 		}
-		if !aliasID.Valid || aliasID.String == "" {
-			continue
+		if reverseSessionID.Valid {
+			addExcludedID(reverseSessionID.String)
 		}
-		if _, ok := excludedSeen[aliasID.String]; ok {
-			continue
+		if reverseAliasID.Valid {
+			addExcludedID(reverseAliasID.String)
 		}
-		excludedSeen[aliasID.String] = struct{}{}
-		excludedIDs = append(excludedIDs, aliasID.String)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, nil, err

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -123,6 +124,42 @@ func TestNewStore(t *testing.T) {
 
 	assert.True(t, store.ReadOnly())
 	assert.True(t, store.HasFTS())
+}
+
+func TestDetectInsightGenerationAvailability(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	require.NoError(t, store.DetectInsightGenerationAvailability(
+		context.Background(),
+	), "DetectInsightGenerationAvailability")
+	assert.True(t, store.InsightGenerationAvailable())
+}
+
+func TestProbeInsightGenerationAvailabilityTx_ReadOnly(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	pg, err := Open(pgURL, testSchema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	tx, err := pg.BeginTx(
+		context.Background(),
+		&sql.TxOptions{ReadOnly: true},
+	)
+	require.NoError(t, err, "BeginTx")
+	defer func() { _ = tx.Rollback() }()
+
+	available, err := probeInsightGenerationAvailabilityTx(
+		context.Background(), tx,
+	)
+	require.NoError(t, err, "probeInsightGenerationAvailabilityTx")
+	assert.False(t, available)
 }
 
 func TestStoreListSessions(t *testing.T) {

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -1436,9 +1436,11 @@ func TestStoreWriteSurfaceSplitByCapability(t *testing.T) {
 	require.NoError(t, err, "GetSessionFull after permanent delete")
 	assert.Nil(t, sess)
 
-	require.NoError(t, store.SoftDeleteSessions([]string{
+	deletedCount, err := store.SoftDeleteSessions([]string{
 		emptyTrashID, batchTrashID,
-	}), "SoftDeleteSessions")
+	})
+	require.NoError(t, err, "SoftDeleteSessions")
+	assert.Equal(t, 2, deletedCount)
 	count, err := store.EmptyTrash()
 	require.NoError(t, err, "EmptyTrash")
 	assert.Equal(t, 2, count)

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -105,6 +105,14 @@ func ensureAnalyticsTokenStoreSchema(
 	require.NoError(t, err, "inserting analytics token sessions")
 }
 
+func sessionIDs(sessions []db.Session) []string {
+	ids := make([]string, 0, len(sessions))
+	for _, s := range sessions {
+		ids = append(ids, s.ID)
+	}
+	return ids
+}
+
 func TestNewStore(t *testing.T) {
 	pgURL := testPGURL(t)
 	ensureStoreSchema(t, pgURL)
@@ -1326,56 +1334,122 @@ func TestStoreAnalyticsTopSessionsDurationExcludesReversedTimestamps(t *testing.
 		"reversed duration row must be excluded")
 }
 
-func TestStoreWriteMethodsReturnReadOnly(t *testing.T) {
+func TestStoreWriteSurfaceSplitByCapability(t *testing.T) {
 	pgURL := testPGURL(t)
 
 	store, err := NewStore(pgURL, testSchema, true)
 	require.NoError(t, err, "NewStore")
 	defer store.Close()
 
-	tests := []struct {
-		name string
-		fn   func() error
-	}{
-		{"InsertInsight", func() error {
-			_, err := store.InsertInsight(db.Insight{})
-			return err
-		}},
-		{"DeleteInsight", func() error {
-			return store.DeleteInsight(1)
-		}},
-		{"RenameSession", func() error {
-			return store.RenameSession("x", nil)
-		}},
-		{"SoftDeleteSession", func() error {
-			return store.SoftDeleteSession("x")
-		}},
-		{"RestoreSession", func() error {
-			_, err := store.RestoreSession("x")
-			return err
-		}},
-		{"DeleteSessionIfTrashed", func() error {
-			_, err := store.DeleteSessionIfTrashed("x")
-			return err
-		}},
-		{"EmptyTrash", func() error {
-			_, err := store.EmptyTrash()
-			return err
-		}},
-		{"UpsertSession", func() error {
-			return store.UpsertSession(db.Session{})
-		}},
-		{"ReplaceSessionMessages", func() error {
-			return store.ReplaceSessionMessages("x", nil)
-		}},
-		{"WriteSessionBatchAtomic", func() error {
-			_, err := store.WriteSessionBatchAtomic(nil)
-			return err
-		}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, db.ErrReadOnly, tt.fn())
-		})
-	}
+	assert.True(t, store.ReadOnly())
+
+	ctx := context.Background()
+	project := "store-capability"
+	sessionID := "store-capability-001"
+	trashedID := "store-capability-002"
+	emptyTrashID := "store-capability-003"
+	batchTrashID := "store-capability-004"
+
+	insightID, err := store.InsertInsight(db.Insight{
+		Type:     "dashboard",
+		DateFrom: "2026-03-12",
+		DateTo:   "2026-03-12",
+		Project:  &project,
+		Agent:    "claude",
+		Content:  "insight content",
+		CacheKey: "capability-cache",
+	})
+	require.NoError(t, err, "InsertInsight")
+	require.NotZero(t, insightID)
+
+	insight, err := store.GetInsight(ctx, insightID)
+	require.NoError(t, err, "GetInsight")
+	require.NotNil(t, insight)
+	assert.Equal(t, project, *insight.Project)
+
+	cached, err := store.GetCachedInsight(ctx, "capability-cache")
+	require.NoError(t, err, "GetCachedInsight")
+	require.NotNil(t, cached)
+	assert.Equal(t, insightID, cached.ID)
+
+	listed, err := store.ListInsights(ctx, db.InsightFilter{
+		Type: "dashboard",
+	})
+	require.NoError(t, err, "ListInsights")
+	require.NotEmpty(t, listed)
+	assert.Equal(t, insightID, listed[0].ID)
+
+	require.NoError(t, store.DeleteInsight(insightID), "DeleteInsight")
+	insight, err = store.GetInsight(ctx, insightID)
+	require.NoError(t, err, "GetInsight after delete")
+	assert.Nil(t, insight)
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, first_message,
+			display_name, started_at, ended_at, message_count,
+			user_message_count
+		) VALUES
+			($1, 'machine', $2, 'claude', 'hello',
+			 NULL, '2026-03-12T10:00:00Z'::timestamptz,
+			 '2026-03-12T10:30:00Z'::timestamptz, 2, 1),
+			($3, 'machine', $2, 'claude', 'trash me',
+			 NULL, '2026-03-12T11:00:00Z'::timestamptz,
+			 '2026-03-12T11:30:00Z'::timestamptz, 2, 1),
+			($4, 'machine', $2, 'claude', 'empty trash me',
+			 NULL, '2026-03-12T12:00:00Z'::timestamptz,
+			 '2026-03-12T12:30:00Z'::timestamptz, 2, 1),
+			($5, 'machine', $2, 'claude', 'batch trash me',
+			 NULL, '2026-03-12T13:00:00Z'::timestamptz,
+			 '2026-03-12T13:30:00Z'::timestamptz, 2, 1)
+	`, sessionID, project, trashedID, emptyTrashID, batchTrashID)
+	require.NoError(t, err, "inserting session rows")
+
+	renamed := "Capability renamed session"
+	require.NoError(t, store.RenameSession(sessionID, &renamed),
+		"RenameSession")
+	sess, err := store.GetSession(ctx, sessionID)
+	require.NoError(t, err, "GetSession after rename")
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.DisplayName)
+	assert.Equal(t, renamed, *sess.DisplayName)
+
+	require.NoError(t, store.SoftDeleteSession(sessionID),
+		"SoftDeleteSession")
+	sess, err = store.GetSession(ctx, sessionID)
+	require.NoError(t, err, "GetSession after soft delete")
+	assert.Nil(t, sess)
+	trashed, err := store.ListTrashedSessions(ctx)
+	require.NoError(t, err, "ListTrashedSessions")
+	assert.Contains(t, sessionIDs(trashed), sessionID)
+
+	restored, err := store.RestoreSession(sessionID)
+	require.NoError(t, err, "RestoreSession")
+	assert.EqualValues(t, 1, restored)
+
+	require.NoError(t, store.SoftDeleteSession(trashedID),
+		"SoftDeleteSession trashedID")
+	deleted, err := store.DeleteSessionIfTrashed(trashedID)
+	require.NoError(t, err, "DeleteSessionIfTrashed")
+	assert.EqualValues(t, 1, deleted)
+	sess, err = store.GetSessionFull(ctx, trashedID)
+	require.NoError(t, err, "GetSessionFull after permanent delete")
+	assert.Nil(t, sess)
+
+	require.NoError(t, store.SoftDeleteSessions([]string{
+		emptyTrashID, batchTrashID,
+	}), "SoftDeleteSessions")
+	count, err := store.EmptyTrash()
+	require.NoError(t, err, "EmptyTrash")
+	assert.Equal(t, 2, count)
+	trashed, err = store.ListTrashedSessions(ctx)
+	require.NoError(t, err, "ListTrashedSessions after empty trash")
+	assert.NotContains(t, sessionIDs(trashed), emptyTrashID)
+	assert.NotContains(t, sessionIDs(trashed), batchTrashID)
+
+	assert.Equal(t, db.ErrReadOnly, store.UpsertSession(db.Session{}))
+	assert.Equal(t, db.ErrReadOnly,
+		store.ReplaceSessionMessages("x", nil))
+	_, err = store.WriteSessionBatchAtomic(nil)
+	assert.ErrorIs(t, err, db.ErrReadOnly)
 }

--- a/internal/postgres/store_unit_test.go
+++ b/internal/postgres/store_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -165,6 +166,30 @@ func TestDeleteSessionIfTrashedExcludesRecordedAliases(t *testing.T) {
 	assert.True(t, state.deleted["vibe:session_trashed"])
 }
 
+func TestDeleteSessionIfTrashedExcludesReverseAliasCanonical(t *testing.T) {
+	state := &emptyTrashProbeState{
+		sessions: map[string]bool{
+			"vibe:canonical":       false,
+			"vibe:session_trashed": true,
+		},
+		aliases: map[string][]string{
+			"vibe:canonical": {"vibe:session_trashed"},
+		},
+		excluded: map[string]bool{},
+		deleted:  map[string]bool{},
+	}
+	store := &Store{pg: newEmptyTrashProbeDB(t, state)}
+
+	count, err := store.DeleteSessionIfTrashed("vibe:session_trashed")
+
+	require.NoError(t, err, "DeleteSessionIfTrashed")
+	assert.EqualValues(t, 1, count)
+	assert.True(t, state.deleted["vibe:session_trashed"])
+	assert.True(t, state.deleted["vibe:canonical"])
+	assert.True(t, state.excluded["vibe:session_trashed"])
+	assert.True(t, state.excluded["vibe:canonical"])
+}
+
 type emptyTrashProbeDriver struct{}
 
 type emptyTrashProbeConn struct {
@@ -292,8 +317,10 @@ func (c *emptyTrashProbeConn) QueryContext(
 		c.state.sessions["concurrently-trashed"] = true
 	}
 	return &emptyTrashProbeRows{
-		columns: []string{"id", "alias_id"},
-		values:  values,
+		columns: []string{
+			"id", "alias_id", "session_id", "alias_id",
+		},
+		values: values,
 	}, nil
 }
 
@@ -322,16 +349,54 @@ func (s *emptyTrashProbeState) trashedSessionAliasRowsLocked(
 		if !trashed {
 			continue
 		}
-		aliases := s.aliases[id]
-		if len(aliases) == 0 {
-			values = append(values, []driver.Value{id, nil})
+		directAliases := s.aliases[id]
+		if len(directAliases) == 0 {
+			directAliases = []string{""}
+		}
+		reverseAliases := s.reverseAliasRowsLocked(id)
+		if len(reverseAliases) == 0 {
+			for _, aliasID := range directAliases {
+				values = append(values, []driver.Value{
+					id, nullableDriverString(aliasID), nil, nil,
+				})
+			}
 			continue
 		}
-		for _, aliasID := range aliases {
-			values = append(values, []driver.Value{id, aliasID})
+		for _, aliasID := range directAliases {
+			for _, reverseAlias := range reverseAliases {
+				values = append(values, []driver.Value{
+					id,
+					nullableDriverString(aliasID),
+					reverseAlias[0],
+					nullableDriverString(reverseAlias[1]),
+				})
+			}
 		}
 	}
 	return values
+}
+
+func (s *emptyTrashProbeState) reverseAliasRowsLocked(
+	aliasID string,
+) [][2]string {
+	rows := [][2]string{}
+	for sessionID, aliases := range s.aliases {
+		hasAlias := slices.Contains(aliases, aliasID)
+		if !hasAlias {
+			continue
+		}
+		for _, alias := range aliases {
+			rows = append(rows, [2]string{sessionID, alias})
+		}
+	}
+	return rows
+}
+
+func nullableDriverString(value string) driver.Value {
+	if value == "" {
+		return nil
+	}
+	return value
 }
 
 func (s *emptyTrashProbeState) excludeNamedValuesLocked(

--- a/internal/postgres/store_unit_test.go
+++ b/internal/postgres/store_unit_test.go
@@ -116,6 +116,10 @@ func TestEmptyTrashExcludesSameRowsItDeletes(t *testing.T) {
 			"already-trashed":      true,
 			"concurrently-trashed": false,
 		},
+		aliases: map[string][]string{
+			"already-trashed":      {"vibe:session_already_trashed"},
+			"concurrently-trashed": {"vibe:session_concurrently_trashed"},
+		},
 		excluded: map[string]bool{},
 		deleted:  map[string]bool{},
 	}
@@ -127,8 +131,32 @@ func TestEmptyTrashExcludesSameRowsItDeletes(t *testing.T) {
 	assert.Equal(t, 1, count)
 	assert.True(t, state.deleted["already-trashed"])
 	assert.True(t, state.excluded["already-trashed"])
+	assert.True(t, state.excluded["vibe:session_already_trashed"])
 	assert.False(t, state.deleted["concurrently-trashed"])
 	assert.False(t, state.excluded["concurrently-trashed"])
+	assert.False(t, state.excluded["vibe:session_concurrently_trashed"])
+}
+
+func TestDeleteSessionIfTrashedExcludesRecordedAliases(t *testing.T) {
+	state := &emptyTrashProbeState{
+		sessions: map[string]bool{
+			"trashed": true,
+		},
+		aliases: map[string][]string{
+			"trashed": {"vibe:session_trashed"},
+		},
+		excluded: map[string]bool{},
+		deleted:  map[string]bool{},
+	}
+	store := &Store{pg: newEmptyTrashProbeDB(t, state)}
+
+	count, err := store.DeleteSessionIfTrashed("trashed")
+
+	require.NoError(t, err, "DeleteSessionIfTrashed")
+	assert.EqualValues(t, 1, count)
+	assert.True(t, state.deleted["trashed"])
+	assert.True(t, state.excluded["trashed"])
+	assert.True(t, state.excluded["vibe:session_trashed"])
 }
 
 type emptyTrashProbeDriver struct{}
@@ -142,13 +170,15 @@ type emptyTrashProbeTx struct {
 }
 
 type emptyTrashProbeRows struct {
-	count int64
-	read  bool
+	columns []string
+	values  [][]driver.Value
+	next    int
 }
 
 type emptyTrashProbeState struct {
 	mu       sync.Mutex
 	sessions map[string]bool
+	aliases  map[string][]string
 	excluded map[string]bool
 	deleted  map[string]bool
 }
@@ -205,8 +235,14 @@ func (c *emptyTrashProbeConn) BeginTx(
 	return &emptyTrashProbeTx{state: c.state}, nil
 }
 
+func (c *emptyTrashProbeConn) CheckNamedValue(
+	*driver.NamedValue,
+) error {
+	return nil
+}
+
 func (c *emptyTrashProbeConn) ExecContext(
-	_ context.Context, query string, _ []driver.NamedValue,
+	_ context.Context, query string, args []driver.NamedValue,
 ) (driver.Result, error) {
 	normalized := strings.ToLower(query)
 	c.state.mu.Lock()
@@ -216,36 +252,40 @@ func (c *emptyTrashProbeConn) ExecContext(
 	case strings.Contains(normalized, "set deleted_at = deleted_at"):
 		return driver.RowsAffected(c.state.trashedCountLocked()), nil
 	case strings.Contains(normalized, "insert into excluded_sessions"):
-		c.state.excludeTrashedLocked()
-		c.state.sessions["concurrently-trashed"] = true
+		c.state.excludeNamedValuesLocked(args)
 		return driver.RowsAffected(1), nil
 	case strings.Contains(normalized, "delete from sessions") &&
+		strings.Contains(normalized, "id = any($1)") &&
 		strings.Contains(normalized, "deleted_at is not null"):
-		return driver.RowsAffected(c.state.deleteTrashedLocked()), nil
+		return driver.RowsAffected(c.state.deleteNamedValuesLocked(args)), nil
 	default:
 		return nil, errors.New("unexpected empty-trash exec")
 	}
 }
 
 func (c *emptyTrashProbeConn) QueryContext(
-	_ context.Context, query string, _ []driver.NamedValue,
+	_ context.Context, query string, args []driver.NamedValue,
 ) (driver.Rows, error) {
 	normalized := strings.ToLower(query)
-	if !strings.Contains(normalized, "with deleted as") ||
-		!strings.Contains(normalized, "delete from sessions") ||
-		!strings.Contains(normalized, "returning id") ||
-		!strings.Contains(normalized, "select id from deleted") {
+	if !strings.Contains(normalized, "left join session_aliases") ||
+		!strings.Contains(normalized, "for update of s") {
 		return nil, errors.New("unexpected empty-trash query")
 	}
 
 	c.state.mu.Lock()
 	defer c.state.mu.Unlock()
-	deleted := c.state.deleteTrashedLocked()
-	for id := range c.state.deleted {
-		c.state.excluded[id] = true
+	filterID := ""
+	if strings.Contains(normalized, "s.id = $1") && len(args) > 0 {
+		filterID, _ = args[0].Value.(string)
 	}
-	c.state.sessions["concurrently-trashed"] = true
-	return &emptyTrashProbeRows{count: deleted}, nil
+	values := c.state.trashedSessionAliasRowsLocked(filterID)
+	if _, ok := c.state.sessions["concurrently-trashed"]; ok {
+		c.state.sessions["concurrently-trashed"] = true
+	}
+	return &emptyTrashProbeRows{
+		columns: []string{"id", "alias_id"},
+		values:  values,
+	}, nil
 }
 
 func (t *emptyTrashProbeTx) Commit() error { return nil }
@@ -262,18 +302,43 @@ func (s *emptyTrashProbeState) trashedCountLocked() int64 {
 	return count
 }
 
-func (s *emptyTrashProbeState) excludeTrashedLocked() {
+func (s *emptyTrashProbeState) trashedSessionAliasRowsLocked(
+	filterID string,
+) [][]driver.Value {
+	values := [][]driver.Value{}
 	for id, trashed := range s.sessions {
-		if trashed {
-			s.excluded[id] = true
+		if filterID != "" && id != filterID {
+			continue
 		}
+		if !trashed {
+			continue
+		}
+		aliases := s.aliases[id]
+		if len(aliases) == 0 {
+			values = append(values, []driver.Value{id, nil})
+			continue
+		}
+		for _, aliasID := range aliases {
+			values = append(values, []driver.Value{id, aliasID})
+		}
+	}
+	return values
+}
+
+func (s *emptyTrashProbeState) excludeNamedValuesLocked(
+	args []driver.NamedValue,
+) {
+	for _, id := range namedValueStrings(args) {
+		s.excluded[id] = true
 	}
 }
 
-func (s *emptyTrashProbeState) deleteTrashedLocked() int64 {
+func (s *emptyTrashProbeState) deleteNamedValuesLocked(
+	args []driver.NamedValue,
+) int64 {
 	var count int64
-	for id, trashed := range s.sessions {
-		if !trashed {
+	for _, id := range namedValueStrings(args) {
+		if !s.sessions[id] {
 			continue
 		}
 		s.deleted[id] = true
@@ -283,15 +348,29 @@ func (s *emptyTrashProbeState) deleteTrashedLocked() int64 {
 	return count
 }
 
-func (r *emptyTrashProbeRows) Columns() []string { return []string{"count"} }
+func namedValueStrings(args []driver.NamedValue) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	switch value := args[0].Value.(type) {
+	case []string:
+		return value
+	case string:
+		return []string{value}
+	default:
+		return nil
+	}
+}
+
+func (r *emptyTrashProbeRows) Columns() []string { return r.columns }
 
 func (r *emptyTrashProbeRows) Close() error { return nil }
 
 func (r *emptyTrashProbeRows) Next(dest []driver.Value) error {
-	if r.read {
+	if r.next >= len(r.values) {
 		return io.EOF
 	}
-	dest[0] = r.count
-	r.read = true
+	copy(dest, r.values[r.next])
+	r.next++
 	return nil
 }

--- a/internal/postgres/store_unit_test.go
+++ b/internal/postgres/store_unit_test.go
@@ -1,10 +1,13 @@
 package postgres
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
 )
@@ -76,4 +79,28 @@ func TestPGSubstringSnippetFTSModeCentersOnFirstTerm(t *testing.T) {
 
 	assert.Contains(t, got, "quick")
 	assert.Contains(t, got, "fox")
+}
+
+func TestMapPGWriteErrorNormalizesReadOnlyPgErrors(t *testing.T) {
+	for _, code := range []string{"25006", "42501"} {
+		t.Run(code, func(t *testing.T) {
+			err := mapPGWriteError("writing test row", &pgconn.PgError{
+				Code:    code,
+				Message: "permission denied",
+			})
+
+			require.ErrorIs(t, err, db.ErrReadOnly)
+			assert.Contains(t, err.Error(), "writing test row")
+		})
+	}
+}
+
+func TestMapPGWriteErrorKeepsNonReadOnlyCause(t *testing.T) {
+	cause := errors.New("network unavailable")
+
+	err := mapPGWriteError("writing test row", cause)
+
+	require.ErrorIs(t, err, cause)
+	assert.False(t, errors.Is(err, db.ErrReadOnly))
+	assert.Contains(t, err.Error(), "writing test row")
 }

--- a/internal/postgres/store_unit_test.go
+++ b/internal/postgres/store_unit_test.go
@@ -1,8 +1,13 @@
 package postgres
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"errors"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -103,4 +108,190 @@ func TestMapPGWriteErrorKeepsNonReadOnlyCause(t *testing.T) {
 	require.ErrorIs(t, err, cause)
 	assert.False(t, errors.Is(err, db.ErrReadOnly))
 	assert.Contains(t, err.Error(), "writing test row")
+}
+
+func TestEmptyTrashExcludesSameRowsItDeletes(t *testing.T) {
+	state := &emptyTrashProbeState{
+		sessions: map[string]bool{
+			"already-trashed":      true,
+			"concurrently-trashed": false,
+		},
+		excluded: map[string]bool{},
+		deleted:  map[string]bool{},
+	}
+	store := &Store{pg: newEmptyTrashProbeDB(t, state)}
+
+	count, err := store.EmptyTrash()
+
+	require.NoError(t, err, "EmptyTrash")
+	assert.Equal(t, 1, count)
+	assert.True(t, state.deleted["already-trashed"])
+	assert.True(t, state.excluded["already-trashed"])
+	assert.False(t, state.deleted["concurrently-trashed"])
+	assert.False(t, state.excluded["concurrently-trashed"])
+}
+
+type emptyTrashProbeDriver struct{}
+
+type emptyTrashProbeConn struct {
+	state *emptyTrashProbeState
+}
+
+type emptyTrashProbeTx struct {
+	state *emptyTrashProbeState
+}
+
+type emptyTrashProbeRows struct {
+	count int64
+	read  bool
+}
+
+type emptyTrashProbeState struct {
+	mu       sync.Mutex
+	sessions map[string]bool
+	excluded map[string]bool
+	deleted  map[string]bool
+}
+
+var (
+	emptyTrashProbeRegisterOnce sync.Once
+	emptyTrashProbeStatesMu     sync.Mutex
+	emptyTrashProbeStates       = map[string]*emptyTrashProbeState{}
+)
+
+func newEmptyTrashProbeDB(
+	t *testing.T, state *emptyTrashProbeState,
+) *sql.DB {
+	t.Helper()
+	emptyTrashProbeRegisterOnce.Do(func() {
+		sql.Register("agentsview_empty_trash_probe", emptyTrashProbeDriver{})
+	})
+	name := t.Name()
+	emptyTrashProbeStatesMu.Lock()
+	emptyTrashProbeStates[name] = state
+	emptyTrashProbeStatesMu.Unlock()
+	t.Cleanup(func() {
+		emptyTrashProbeStatesMu.Lock()
+		delete(emptyTrashProbeStates, name)
+		emptyTrashProbeStatesMu.Unlock()
+	})
+
+	pg, err := sql.Open("agentsview_empty_trash_probe", name)
+	require.NoError(t, err, "open empty-trash probe db")
+	t.Cleanup(func() { _ = pg.Close() })
+	return pg
+}
+
+func (emptyTrashProbeDriver) Open(name string) (driver.Conn, error) {
+	emptyTrashProbeStatesMu.Lock()
+	state := emptyTrashProbeStates[name]
+	emptyTrashProbeStatesMu.Unlock()
+	return &emptyTrashProbeConn{state: state}, nil
+}
+
+func (c *emptyTrashProbeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (c *emptyTrashProbeConn) Close() error { return nil }
+
+func (c *emptyTrashProbeConn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
+
+func (c *emptyTrashProbeConn) BeginTx(
+	context.Context, driver.TxOptions,
+) (driver.Tx, error) {
+	return &emptyTrashProbeTx{state: c.state}, nil
+}
+
+func (c *emptyTrashProbeConn) ExecContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Result, error) {
+	normalized := strings.ToLower(query)
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	switch {
+	case strings.Contains(normalized, "set deleted_at = deleted_at"):
+		return driver.RowsAffected(c.state.trashedCountLocked()), nil
+	case strings.Contains(normalized, "insert into excluded_sessions"):
+		c.state.excludeTrashedLocked()
+		c.state.sessions["concurrently-trashed"] = true
+		return driver.RowsAffected(1), nil
+	case strings.Contains(normalized, "delete from sessions") &&
+		strings.Contains(normalized, "deleted_at is not null"):
+		return driver.RowsAffected(c.state.deleteTrashedLocked()), nil
+	default:
+		return nil, errors.New("unexpected empty-trash exec")
+	}
+}
+
+func (c *emptyTrashProbeConn) QueryContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Rows, error) {
+	normalized := strings.ToLower(query)
+	if !strings.Contains(normalized, "with deleted as") ||
+		!strings.Contains(normalized, "delete from sessions") ||
+		!strings.Contains(normalized, "returning id") ||
+		!strings.Contains(normalized, "select id from deleted") {
+		return nil, errors.New("unexpected empty-trash query")
+	}
+
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+	deleted := c.state.deleteTrashedLocked()
+	for id := range c.state.deleted {
+		c.state.excluded[id] = true
+	}
+	c.state.sessions["concurrently-trashed"] = true
+	return &emptyTrashProbeRows{count: deleted}, nil
+}
+
+func (t *emptyTrashProbeTx) Commit() error { return nil }
+
+func (t *emptyTrashProbeTx) Rollback() error { return nil }
+
+func (s *emptyTrashProbeState) trashedCountLocked() int64 {
+	var count int64
+	for _, trashed := range s.sessions {
+		if trashed {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *emptyTrashProbeState) excludeTrashedLocked() {
+	for id, trashed := range s.sessions {
+		if trashed {
+			s.excluded[id] = true
+		}
+	}
+}
+
+func (s *emptyTrashProbeState) deleteTrashedLocked() int64 {
+	var count int64
+	for id, trashed := range s.sessions {
+		if !trashed {
+			continue
+		}
+		s.deleted[id] = true
+		delete(s.sessions, id)
+		count++
+	}
+	return count
+}
+
+func (r *emptyTrashProbeRows) Columns() []string { return []string{"count"} }
+
+func (r *emptyTrashProbeRows) Close() error { return nil }
+
+func (r *emptyTrashProbeRows) Next(dest []driver.Value) error {
+	if r.read {
+		return io.EOF
+	}
+	dest[0] = r.count
+	r.read = true
+	return nil
 }

--- a/internal/postgres/store_unit_test.go
+++ b/internal/postgres/store_unit_test.go
@@ -113,8 +113,10 @@ func TestMapPGWriteErrorKeepsNonReadOnlyCause(t *testing.T) {
 func TestEmptyTrashExcludesSameRowsItDeletes(t *testing.T) {
 	state := &emptyTrashProbeState{
 		sessions: map[string]bool{
-			"already-trashed":      true,
-			"concurrently-trashed": false,
+			"already-trashed":                   true,
+			"vibe:session_already_trashed":      false,
+			"concurrently-trashed":              false,
+			"vibe:session_concurrently_trashed": false,
 		},
 		aliases: map[string][]string{
 			"already-trashed":      {"vibe:session_already_trashed"},
@@ -132,15 +134,18 @@ func TestEmptyTrashExcludesSameRowsItDeletes(t *testing.T) {
 	assert.True(t, state.deleted["already-trashed"])
 	assert.True(t, state.excluded["already-trashed"])
 	assert.True(t, state.excluded["vibe:session_already_trashed"])
+	assert.True(t, state.deleted["vibe:session_already_trashed"])
 	assert.False(t, state.deleted["concurrently-trashed"])
 	assert.False(t, state.excluded["concurrently-trashed"])
 	assert.False(t, state.excluded["vibe:session_concurrently_trashed"])
+	assert.False(t, state.deleted["vibe:session_concurrently_trashed"])
 }
 
 func TestDeleteSessionIfTrashedExcludesRecordedAliases(t *testing.T) {
 	state := &emptyTrashProbeState{
 		sessions: map[string]bool{
-			"trashed": true,
+			"trashed":              true,
+			"vibe:session_trashed": false,
 		},
 		aliases: map[string][]string{
 			"trashed": {"vibe:session_trashed"},
@@ -157,6 +162,7 @@ func TestDeleteSessionIfTrashedExcludesRecordedAliases(t *testing.T) {
 	assert.True(t, state.deleted["trashed"])
 	assert.True(t, state.excluded["trashed"])
 	assert.True(t, state.excluded["vibe:session_trashed"])
+	assert.True(t, state.deleted["vibe:session_trashed"])
 }
 
 type emptyTrashProbeDriver struct{}
@@ -257,7 +263,10 @@ func (c *emptyTrashProbeConn) ExecContext(
 	case strings.Contains(normalized, "delete from sessions") &&
 		strings.Contains(normalized, "id = any($1)") &&
 		strings.Contains(normalized, "deleted_at is not null"):
-		return driver.RowsAffected(c.state.deleteNamedValuesLocked(args)), nil
+		return driver.RowsAffected(c.state.deleteNamedTrashedLocked(args)), nil
+	case strings.Contains(normalized, "delete from sessions") &&
+		strings.Contains(normalized, "id = any($1)"):
+		return driver.RowsAffected(c.state.deleteNamedExistingLocked(args)), nil
 	default:
 		return nil, errors.New("unexpected empty-trash exec")
 	}
@@ -333,12 +342,27 @@ func (s *emptyTrashProbeState) excludeNamedValuesLocked(
 	}
 }
 
-func (s *emptyTrashProbeState) deleteNamedValuesLocked(
+func (s *emptyTrashProbeState) deleteNamedTrashedLocked(
 	args []driver.NamedValue,
 ) int64 {
 	var count int64
 	for _, id := range namedValueStrings(args) {
 		if !s.sessions[id] {
+			continue
+		}
+		s.deleted[id] = true
+		delete(s.sessions, id)
+		count++
+	}
+	return count
+}
+
+func (s *emptyTrashProbeState) deleteNamedExistingLocked(
+	args []driver.NamedValue,
+) int64 {
+	var count int64
+	for _, id := range namedValueStrings(args) {
+		if _, ok := s.sessions[id]; !ok {
 			continue
 		}
 		s.deleted[id] = true

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -50,6 +50,21 @@ type publishInsightInput struct {
 	Secret bool  `query:"secret" doc:"Create a secret gist instead of a public one"`
 }
 
+type insightGenerationCapableStore interface {
+	InsightGenerationAvailable() bool
+}
+
+func supportsInsightGeneration(store db.Store) bool {
+	if store == nil {
+		return false
+	}
+	if !store.ReadOnly() {
+		return true
+	}
+	capable, ok := store.(insightGenerationCapableStore)
+	return ok && capable.InsightGenerationAvailable()
+}
+
 func (s *Server) humaListInsights(
 	ctx context.Context,
 	in *insightsInput,
@@ -178,6 +193,10 @@ func (s *Server) humaGenerateInsight(
 	ctx context.Context,
 	in *generateInsightInput,
 ) (*huma.StreamResponse, error) {
+	if !supportsInsightGeneration(s.db) {
+		return nil, apiError(http.StatusNotImplemented,
+			"insight generation is not available in read-only mode")
+	}
 	req := in.Body
 	if !validInsightTypes[req.Type] {
 		return nil, apiError(http.StatusBadRequest,

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -178,10 +178,6 @@ func (s *Server) humaGenerateInsight(
 	ctx context.Context,
 	in *generateInsightInput,
 ) (*huma.StreamResponse, error) {
-	if s.db.ReadOnly() {
-		return nil, apiError(http.StatusNotImplemented,
-			"insight generation is not available in read-only mode")
-	}
 	req := in.Body
 	if !validInsightTypes[req.Type] {
 		return nil, apiError(http.StatusBadRequest,

--- a/internal/server/huma_routes_settings.go
+++ b/internal/server/huma_routes_settings.go
@@ -72,7 +72,7 @@ func (s *Server) humaGetSettings(
 		Host:        s.cfg.Host,
 		Port:        s.cfg.Port,
 		RequireAuth: s.cfg.RequireAuth,
-		ReadOnly:    s.engine == nil,
+		ReadOnly:    s.db.ReadOnly(),
 	}
 	if isLocalhostContext(ctx) {
 		resp.AuthToken = s.cfg.AuthToken
@@ -86,7 +86,7 @@ func (s *Server) humaUpdateSettings(
 	ctx context.Context,
 	in *settingsInput,
 ) (*jsonOutput[settingsResponse], error) {
-	if s.engine == nil {
+	if s.db.ReadOnly() {
 		return nil, apiError(http.StatusNotImplemented,
 			"settings cannot be modified in read-only mode")
 	}

--- a/internal/server/huma_routes_settings.go
+++ b/internal/server/huma_routes_settings.go
@@ -72,7 +72,7 @@ func (s *Server) humaGetSettings(
 		Host:        s.cfg.Host,
 		Port:        s.cfg.Port,
 		RequireAuth: s.cfg.RequireAuth,
-		ReadOnly:    s.db.ReadOnly(),
+		ReadOnly:    s.engine == nil,
 	}
 	if isLocalhostContext(ctx) {
 		resp.AuthToken = s.cfg.AuthToken
@@ -86,7 +86,7 @@ func (s *Server) humaUpdateSettings(
 	ctx context.Context,
 	in *settingsInput,
 ) (*jsonOutput[settingsResponse], error) {
-	if s.db.ReadOnly() {
+	if s.engine == nil {
 		return nil, apiError(http.StatusNotImplemented,
 			"settings cannot be modified in read-only mode")
 	}

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/insight"
 	"go.kenn.io/agentsview/internal/server"
@@ -40,6 +42,20 @@ func (f roundTripFunc) RoundTrip(
 	req *http.Request,
 ) (*http.Response, error) {
 	return f(req)
+}
+
+type readOnlyInsightPersistStore struct {
+	db.Store
+	insertCalls int
+}
+
+func (s *readOnlyInsightPersistStore) ReadOnly() bool { return true }
+
+func (s *readOnlyInsightPersistStore) InsertInsight(
+	insight db.Insight,
+) (int64, error) {
+	s.insertCalls++
+	return s.Store.InsertInsight(insight)
 }
 
 func newFailFirstWriteRecorder() *failFirstWriteRecorder {
@@ -356,6 +372,62 @@ func TestGenerateInsight_DefaultAgent(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 	assertBodyContains(t, w, "event: error")
 	assertBodyContains(t, w, "stub: no CLI")
+}
+
+func TestGenerateInsight_PersistsWithReadOnlyStore(t *testing.T) {
+	dir := tempDirWithRetryCleanup(t)
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	require.NoError(t, err, "opening db")
+	t.Cleanup(func() { database.Close() })
+
+	store := &readOnlyInsightPersistStore{Store: database}
+	cfg := config.Config{
+		Host:         "127.0.0.1",
+		Port:         0,
+		DataDir:      dir,
+		DBPath:       dbPath,
+		WriteTimeout: 30 * time.Second,
+	}
+	srv := server.New(cfg, store, nil, server.WithGenerateFunc(func(
+		_ context.Context, agent, _ string,
+	) (insight.Result, error) {
+		assert.Equal(t, "claude", agent)
+		return insight.Result{
+			Agent:   "claude",
+			Content: "persisted from read-only wrapper",
+		}, nil
+	}))
+	te := &testEnv{
+		srv:         srv,
+		handler:     wrapTestHandler(cfg, srv.Handler()),
+		db:          database,
+		engine:      nil,
+		broadcaster: nil,
+		dataDir:     dir,
+	}
+
+	assert.True(t, store.ReadOnly())
+
+	w := te.post(t, "/api/v1/insights/generate",
+		`{"type":"daily_activity","date_from":"2025-01-15","date_to":"2025-01-15"}`)
+	assertStatus(t, w, http.StatusOK)
+
+	events := parseSSE(w.Body.String())
+	require.NotEmpty(t, events)
+	require.Equal(t, "done", events[len(events)-1].Event)
+	assert.Equal(t, 1, store.insertCalls)
+
+	var saved db.Insight
+	require.NoError(t, json.Unmarshal([]byte(events[len(events)-1].Data), &saved))
+	assert.Equal(t, "persisted from read-only wrapper", saved.Content)
+	assert.Equal(t, "claude", saved.Agent)
+
+	stored, err := database.GetInsight(context.Background(), saved.ID)
+	require.NoError(t, err, "GetInsight after generate")
+	require.NotNil(t, stored)
+	assert.Equal(t, saved.ID, stored.ID)
+	assert.Equal(t, saved.Content, stored.Content)
 }
 
 func TestGenerateCannedInsight_RequiresExplicitOptIn(t *testing.T) {

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -51,6 +51,10 @@ type readOnlyInsightPersistStore struct {
 
 func (s *readOnlyInsightPersistStore) ReadOnly() bool { return true }
 
+func (s *readOnlyInsightPersistStore) InsightGenerationAvailable() bool {
+	return true
+}
+
 func (s *readOnlyInsightPersistStore) InsertInsight(
 	insight db.Insight,
 ) (int64, error) {
@@ -428,6 +432,43 @@ func TestGenerateInsight_PersistsWithReadOnlyStore(t *testing.T) {
 	require.NotNil(t, stored)
 	assert.Equal(t, saved.ID, stored.ID)
 	assert.Equal(t, saved.Content, stored.Content)
+}
+
+func TestGenerateInsight_StaysBlockedForReadOnlyStoreWithoutInsightWrites(t *testing.T) {
+	dir := tempDirWithRetryCleanup(t)
+	dbPath := filepath.Join(dir, "test.db")
+	database, err := db.Open(dbPath)
+	require.NoError(t, err, "opening db")
+	t.Cleanup(func() { database.Close() })
+
+	var called bool
+	cfg := config.Config{
+		Host:         "127.0.0.1",
+		Port:         0,
+		DataDir:      dir,
+		DBPath:       dbPath,
+		WriteTimeout: 30 * time.Second,
+	}
+	srv := server.New(cfg, readOnlyTestStore{Store: database}, nil, server.WithGenerateFunc(func(
+		_ context.Context, _ string, _ string,
+	) (insight.Result, error) {
+		called = true
+		return insight.Result{Agent: "claude", Content: "should not run"}, nil
+	}))
+	te := &testEnv{
+		srv:         srv,
+		handler:     wrapTestHandler(cfg, srv.Handler()),
+		db:          database,
+		engine:      nil,
+		broadcaster: nil,
+		dataDir:     dir,
+	}
+
+	w := te.post(t, "/api/v1/insights/generate",
+		`{"type":"daily_activity","date_from":"2025-01-15","date_to":"2025-01-15"}`)
+	assertStatus(t, w, http.StatusNotImplemented)
+	assertBodyContains(t, w, "read-only mode")
+	assert.False(t, called)
 }
 
 func TestGenerateCannedInsight_RequiresExplicitOptIn(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,12 +29,13 @@ import (
 
 // VersionInfo holds build-time version metadata.
 type VersionInfo struct {
-	Version     string `json:"version"`
-	Commit      string `json:"commit"`
-	BuildDate   string `json:"build_date"`
-	ReadOnly    bool   `json:"read_only,omitempty"`
-	APIVersion  int    `json:"api_version"`
-	DataVersion int    `json:"data_version"`
+	Version                    string `json:"version"`
+	Commit                     string `json:"commit"`
+	BuildDate                  string `json:"build_date"`
+	ReadOnly                   bool   `json:"read_only,omitempty"`
+	InsightGenerationAvailable bool   `json:"insight_generation_available,omitempty"`
+	APIVersion                 int    `json:"api_version"`
+	DataVersion                int    `json:"data_version"`
 }
 
 const daemonService = "agentsview"

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2173,7 +2173,7 @@ func TestCORSAllowsMutatingFromKnownOrigin(t *testing.T) {
 }
 
 func TestSyncEndpointLocalNoSyncDaemonUsesOnDemandEngine(t *testing.T) {
-	te := setupPGMode(t)
+	te := setupNoSyncMode(t)
 
 	w := te.post(t, "/api/v1/sync", "{}")
 
@@ -2182,7 +2182,7 @@ func TestSyncEndpointLocalNoSyncDaemonUsesOnDemandEngine(t *testing.T) {
 }
 
 func TestPGPushLocalNoSyncDaemonReachesConfigValidation(t *testing.T) {
-	te := setupPGMode(t)
+	te := setupNoSyncMode(t)
 
 	w := te.post(t, "/api/v1/push/pg", `{"full":false}`)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4011,9 +4011,10 @@ func TestHandleWatchSession_UnknownID_Returns404(t *testing.T) {
 
 func TestGetVersion(t *testing.T) {
 	v := server.VersionInfo{
-		Version:   "v1.2.3",
-		Commit:    "abc1234",
-		BuildDate: "2025-01-15T00:00:00Z",
+		Version:                    "v1.2.3",
+		Commit:                     "abc1234",
+		BuildDate:                  "2025-01-15T00:00:00Z",
+		InsightGenerationAvailable: true,
 	}
 	te := setupWithServerOpts(t, []server.Option{
 		server.WithVersion(v),
@@ -4035,6 +4036,7 @@ func TestGetVersion(t *testing.T) {
 			resp.BuildDate,
 		)
 	}
+	assert.True(t, resp.InsightGenerationAvailable)
 	assert.Equal(t, 1, resp.APIVersion)
 	assert.Equal(t, db.CurrentDataVersion(), resp.DataVersion)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -66,6 +66,12 @@ func withWriteTimeout(d time.Duration) setupOption {
 	return func(c *config.Config) { c.WriteTimeout = d }
 }
 
+type readOnlyTestStore struct {
+	db.Store
+}
+
+func (readOnlyTestStore) ReadOnly() bool { return true }
+
 func withPublicOrigins(origins ...string) setupOption {
 	return func(c *config.Config) {
 		c.PublicOrigins = append([]string(nil), origins...)
@@ -200,7 +206,7 @@ func setupPGMode(t *testing.T) *testEnv {
 		DBPath:       dbPath,
 		WriteTimeout: 30 * time.Second,
 	}
-	srv := server.New(cfg, database, nil)
+	srv := server.New(cfg, readOnlyTestStore{Store: database}, nil)
 
 	return &testEnv{
 		srv:         srv,
@@ -2968,6 +2974,29 @@ func TestSettingsRemainLockedInPGMode(t *testing.T) {
 	te.handler.ServeHTTP(w, req)
 	assertStatus(t, w, http.StatusNotImplemented)
 	assertBodyContains(t, w, "settings cannot be modified")
+}
+
+func TestSettingsRemainWritableInLocalNoSyncMode(t *testing.T) {
+	te := setupNoSyncMode(t)
+
+	w := te.get(t, "/api/v1/settings")
+	assertStatus(t, w, http.StatusOK)
+	type readOnlySettingsResponse struct {
+		ReadOnly bool `json:"read_only"`
+	}
+	resp := decode[readOnlySettingsResponse](t, w)
+	assert.False(t, resp.ReadOnly)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings",
+		strings.NewReader(`{"require_auth":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	w = httptest.NewRecorder()
+	te.handler.ServeHTTP(w, req)
+	assertStatus(t, w, http.StatusOK)
+
+	resp = decode[readOnlySettingsResponse](t, w)
+	assert.False(t, resp.ReadOnly)
 }
 
 func TestPublishSession_DoesNotUseGitHubCLIAuthTokenFallbackForForwardedRequest(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2949,6 +2949,27 @@ func TestGetSettings_UsesGitHubCLIAuthTokenFallback(t *testing.T) {
 	assert.True(t, resp.GithubConfigured)
 }
 
+func TestSettingsRemainLockedInPGMode(t *testing.T) {
+	te := setupPGMode(t)
+
+	w := te.get(t, "/api/v1/settings")
+	assertStatus(t, w, http.StatusOK)
+	type readOnlySettingsResponse struct {
+		ReadOnly bool `json:"read_only"`
+	}
+	resp := decode[readOnlySettingsResponse](t, w)
+	assert.True(t, resp.ReadOnly)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings",
+		strings.NewReader(`{"require_auth":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	w = httptest.NewRecorder()
+	te.handler.ServeHTTP(w, req)
+	assertStatus(t, w, http.StatusNotImplemented)
+	assertBodyContains(t, w, "settings cannot be modified")
+}
+
 func TestPublishSession_DoesNotUseGitHubCLIAuthTokenFallbackForForwardedRequest(t *testing.T) {
 	useGitHubCLIAuthTokenStub(t)
 	te := setup(t)


### PR DESCRIPTION
PG serve already supports shared stars and pins, but the rest of the dashboard curation surface still behaves as read-only. Session rename, trash, restore, empty trash, insight delete, and generated-insight persistence all route through the existing `db.Store` seam, yet the PostgreSQL adapter still returns `db.ErrReadOnly` for those methods, and the insight-generation route stops on a coarse read-only check before it can save anything.

This change fills in the remaining PG dashboard-write slice without widening scope to local-only features or other read-only backends. PostgreSQL gets the missing insight storage plus Store implementations for insight CRUD and session-management methods, and the server now treats generated-insight writes as an explicit capability: pg serve advertises it, the frontend enables the Generate controls in that mode, and plain read-only stores such as duckdb still fail fast before any generator work starts. Settings remain blocked in pg serve through the existing read-only contract, while local `serve --no-sync` stays writable because it still uses a local Store.

The tests cover the PG round trips for insight CRUD and session management, the read-only capability split on the insight route, the pg serve and local no-sync settings behavior, the pg serve version metadata that enables the frontend, and the two frontend insight entry points. Stars and pins are left untouched, and ingestion-oriented methods such as `WriteSessionBatchAtomic` remain read-only.

Closes #183
