### PR TITLE
feat(config): add substrings and exact_matches to automated session config

### DIFF
--- a/cmd/agentsview/classifier_test.go
+++ b/cmd/agentsview/classifier_test.go
@@ -33,7 +33,7 @@ type classifierFixture struct {
 // newClassifierFixture prepares a temp data dir with a minimal
 // config.toml carrying the given user prefixes, loads a minimal
 // config pointed at that dir, applies any option mutators, and
-// installs the classifier prefixes into the db singleton.
+// installs the classifier patterns into the db singleton.
 func newClassifierFixture(
 	t *testing.T, prefixes []string, opts ...func(*config.Config),
 ) classifierFixture {
@@ -49,7 +49,11 @@ func newClassifierFixture(
 	}
 	applyClassifierConfig(cfg)
 
-	t.Cleanup(func() { db.SetUserAutomationPrefixes(nil) })
+	t.Cleanup(func() {
+		db.SetUserAutomationPrefixes(nil)
+		db.SetUserAutomationSubstrings(nil)
+		db.SetUserAutomationExactMatches(nil)
+	})
 	return classifierFixture{Dir: dir, Cfg: cfg}
 }
 

--- a/cmd/agentsview/classifier_wiring.go
+++ b/cmd/agentsview/classifier_wiring.go
@@ -1,5 +1,5 @@
 // ABOUTME: applyClassifierConfig installs user-defined
-// ABOUTME: classifier prefixes into the db package singleton.
+// ABOUTME: classifier patterns into the db package singleton.
 package main
 
 import (
@@ -8,14 +8,16 @@ import (
 )
 
 // applyClassifierConfig installs user-defined classifier
-// prefixes into the db package singleton. Every command that
+// patterns into the db package singleton. Every command that
 // loads config and may open SQLite or PostgreSQL must call
 // this BEFORE db.Open / postgres.Open / postgres.NewStore /
 // postgres.New / postgres.EnsureSchema. Silent by design so
 // it's safe to call from quiet CLI paths (statusline, JSON
-// output, etc.); see db.SetUserAutomationPrefixes for
+// output, etc.); see the db.SetUserAutomation* setters for
 // rationale. The static guardrail test in
 // classifier_wiring_test.go (Task 7) enforces this rule.
 func applyClassifierConfig(cfg config.Config) {
 	db.SetUserAutomationPrefixes(cfg.Automated.Prefixes)
+	db.SetUserAutomationSubstrings(cfg.Automated.Substrings)
+	db.SetUserAutomationExactMatches(cfg.Automated.ExactMatches)
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1320,11 +1320,12 @@ description: Release history for AgentsView
   via `[custom_model_pricing.<model>]` tables in
   `~/.agentsview/config.toml`, for models not in the LiteLLM
   catalog or when you want to override the catalog's rates.
-- Add configurable [automation prefixes](/configuration/#automated-session-detection)
-  via `[automated] prefixes = [...]` in `~/.agentsview/config.toml`,
-  so single-turn sessions with first-message patterns unique to
-  your own automation get filtered from session lists and analytics
-  alongside the built-in roborev patterns.
+- Add configurable [automation patterns](/configuration/#automated-session-detection)
+  via `[automated] prefixes`, `substrings`, and `exact_matches` in
+  `~/.agentsview/config.toml`, so single-turn sessions with
+  first-message patterns unique to your own automation get filtered
+  from session lists and analytics alongside the built-in roborev
+  patterns.
 
 **Improvements**
 
@@ -1333,9 +1334,10 @@ description: Release history for AgentsView
   review combiner prompts, and AgentsView's own changelog
   generator.
 - Refresh the `is_automated` classification at startup, using a
-  classifier hash that covers built-in patterns and `[automated]
-  prefixes`, so edits to automation rules and rows imported from
-  other archives get re-labeled without a manual resync.
+  classifier hash that covers built-in patterns and configured
+  `[automated]` patterns, so edits to automation rules and rows
+  imported from other archives get re-labeled without a manual
+  resync.
 - Improve Claude first-message selection in the sidebar by
   skipping leading `/clear` and `/effort` command envelopes so
   the session preview shows the next real user message instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -497,7 +497,7 @@ the session filter dropdown opts them back in.
 
 A set of built-in patterns covers the roborev family and
 AgentsView's own internal prompts. To teach AgentsView about
-first-message prefixes unique to your own automation, add them
+first-message patterns unique to your own automation, add them
 to `~/.agentsview/config.toml`:
 
 ```toml
@@ -506,18 +506,32 @@ prefixes = [
   "You are summarizing a nightly batch run.",
   "INTERNAL-AUTOMATION:",
 ]
+substrings = [
+  "This is an automated repository maintenance run.",
+]
+exact_matches = [
+  "Nightly automation completed.",
+]
 ```
 
-User-configured entries use a case-sensitive `HasPrefix` check
-against the session's first user message. Entries are trimmed,
-deduplicated, and capped at 1024 characters; prefixes that
-duplicate a built-in pattern are silently dropped.
+User-configured entries are case-sensitive and are matched
+against the session's first user message:
+
+| Key | Match behavior |
+|-----|----------------|
+| `prefixes` | `HasPrefix` against the first user message |
+| `substrings` | `Contains` anywhere in the first user message |
+| `exact_matches` | trims the first user message, then compares the whole string |
+
+Entries are trimmed, deduplicated, and capped at 1024
+characters. Entries that duplicate a built-in pattern in the
+same category are silently dropped.
 
 **Reclassification on config change.** AgentsView stores a hash
 of the active classifier (built-in patterns + your configured
-prefixes) with the database. On startup, it rechecks stored
+patterns) with the database. On startup, it rechecks stored
 `is_automated` values against the active classifier and
-re-stamps the hash, so edits to `[automated] prefixes` apply to
+re-stamps the hash, so edits to `[automated]` patterns apply to
 history immediately — no manual resync required. The same
 backfill also corrects rows pulled in from PostgreSQL sync or
 copied from other archives.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,9 +104,11 @@ type DuckDBConfig struct {
 // AutomatedConfig holds user-supplied additions to the
 // automated-session classifier. Parse-only; all semantic
 // normalization (trim, dedupe, length cap, built-in overlap
-// drop) happens inside db.SetUserAutomationPrefixes.
+// drop) happens inside the db setters.
 type AutomatedConfig struct {
-	Prefixes []string `toml:"prefixes" json:"prefixes,omitempty"`
+	Prefixes     []string `toml:"prefixes" json:"prefixes,omitempty"`
+	Substrings   []string `toml:"substrings" json:"substrings,omitempty"`
+	ExactMatches []string `toml:"exact_matches" json:"exact_matches,omitempty"`
 }
 
 // AgentConfig holds per-agent runtime overrides.
@@ -695,6 +697,12 @@ func (c *Config) applyConfigTOML(data string) error {
 	}
 	if file.Automated.Prefixes != nil {
 		c.Automated.Prefixes = file.Automated.Prefixes
+	}
+	if file.Automated.Substrings != nil {
+		c.Automated.Substrings = file.Automated.Substrings
+	}
+	if file.Automated.ExactMatches != nil {
+		c.Automated.ExactMatches = file.Automated.ExactMatches
 	}
 	if len(file.Agent) > 0 {
 		if c.Agent == nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1334,7 +1334,7 @@ func TestResolveDuckDB_ErrorsOnMissingEnvVar(t *testing.T) {
 	requireErrorContains(t, err, "MISSING_DUCKDB_URL")
 }
 
-func TestAutomatedPrefixesRoundTrip(t *testing.T) {
+func TestAutomatedConfigRoundTrip(t *testing.T) {
 	cfg := loadPFlagsWithConfig(t, map[string]any{
 		"automated": map[string]any{
 			"prefixes": []string{
@@ -1343,22 +1343,46 @@ func TestAutomatedPrefixesRoundTrip(t *testing.T) {
 				"  ",                         // whitespace preserved here; normalization is db-side
 				"You are analyzing an essay", // duplicate preserved here too
 			},
+			"substrings": []string{
+				"invoked by roborev to perform this review",
+				"  embedded marker  ",
+				"invoked by roborev to perform this review",
+			},
+			"exact_matches": []string{
+				"Warmup",
+				"  Reply with exactly OK.  ",
+				"Warmup",
+			},
 		},
 	})
-	want := []string{
+	wantPrefixes := []string{
 		"You are analyzing an essay",
 		"You are grading quotes",
 		"  ",
 		"You are analyzing an essay",
 	}
-	assert.Equal(t, want, cfg.Automated.Prefixes)
+	wantSubstrings := []string{
+		"invoked by roborev to perform this review",
+		"  embedded marker  ",
+		"invoked by roborev to perform this review",
+	}
+	wantExactMatches := []string{
+		"Warmup",
+		"  Reply with exactly OK.  ",
+		"Warmup",
+	}
+	assert.Equal(t, wantPrefixes, cfg.Automated.Prefixes)
+	assert.Equal(t, wantSubstrings, cfg.Automated.Substrings)
+	assert.Equal(t, wantExactMatches, cfg.Automated.ExactMatches)
 }
 
-func TestAutomatedPrefixesAbsentIsNil(t *testing.T) {
+func TestAutomatedConfigAbsentIsNil(t *testing.T) {
 	cfg := loadPFlagsWithConfig(t, map[string]any{
 		"public_url": "http://example.com",
 	})
 	assert.Nil(t, cfg.Automated.Prefixes)
+	assert.Nil(t, cfg.Automated.Substrings)
+	assert.Nil(t, cfg.Automated.ExactMatches)
 }
 
 func TestLoadFile_CustomModelPricing(t *testing.T) {

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -185,10 +185,8 @@ func IsAutomatedSession(firstMessage string) bool {
 	if slices.Contains(automatedExactMatches, trimmed) {
 		return true
 	}
-	for _, exact := range exactMatches {
-		if trimmed == exact {
-			return true
-		}
+	if slices.Contains(exactMatches, trimmed) {
+		return true
 	}
 	return false
 }

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -52,53 +52,99 @@ var automatedExactMatches = []string{
 	"Reply with exactly OK.",
 }
 
-const userPrefixMaxLen = 1024
+const userPatternMaxLen = 1024
 
 var (
-	userPrefixesMu sync.RWMutex
-	userPrefixes   []string
+	userPatternsMu   sync.RWMutex
+	userPrefixes     []string
+	userSubstrings   []string
+	userExactMatches []string
 )
 
-// SetUserAutomationPrefixes replaces the user-pattern slice
+// SetUserAutomationPrefixes replaces the user-prefix slice
 // with a normalized copy of the input. Normalization (trim,
 // drop empty, length cap, dedupe within input, drop entries
 // that equal a built-in prefix) happens here so callers can
 // pass the raw list straight from config. Pass nil to clear.
-// Idempotent and silent — safe to call from quiet CLI paths
+// Idempotent and silent, safe to call from quiet CLI paths
 // (statusline, JSON output). Callers that want a startup
-// summary should read len(UserAutomationPrefixes()).
+// summary should read the relevant getter(s).
 func SetUserAutomationPrefixes(prefixes []string) {
-	cleaned := normalizeUserPrefixes(prefixes)
-	userPrefixesMu.Lock()
-	defer userPrefixesMu.Unlock()
-	userPrefixes = cleaned
+	setUserAutomationPatterns(&userPrefixes, prefixes, automatedPrefixes)
+}
+
+// SetUserAutomationSubstrings replaces the user-substring
+// slice with a normalized copy of the input. The same trim,
+// dedupe, and length rules apply; overlap filtering only
+// removes built-in substrings.
+func SetUserAutomationSubstrings(substrings []string) {
+	setUserAutomationPatterns(&userSubstrings, substrings, automatedSubstrings)
+}
+
+// SetUserAutomationExactMatches replaces the user exact-match
+// slice with a normalized copy of the input. Matching trims
+// the message before comparing against these literals.
+func SetUserAutomationExactMatches(matches []string) {
+	setUserAutomationPatterns(&userExactMatches, matches, automatedExactMatches)
 }
 
 // UserAutomationPrefixes returns a copy of the current
 // user-prefix slice. Used by ClassifierHash and tests; the
 // copy prevents callers from mutating singleton state.
 func UserAutomationPrefixes() []string {
-	userPrefixesMu.RLock()
-	defer userPrefixesMu.RUnlock()
-	return append([]string(nil), userPrefixes...)
+	return copyUserAutomationPatterns(userPrefixes)
 }
 
-// normalizeUserPrefixes applies the validation rules from the
-// design spec ("Validation behavior" section). Built-in
-// overlap is checked against the package-private
-// automatedPrefixes directly.
-func normalizeUserPrefixes(in []string) []string {
+// UserAutomationSubstrings returns a copy of the current
+// user-substring slice.
+func UserAutomationSubstrings() []string {
+	return copyUserAutomationPatterns(userSubstrings)
+}
+
+// UserAutomationExactMatches returns a copy of the current
+// user exact-match slice.
+func UserAutomationExactMatches() []string {
+	return copyUserAutomationPatterns(userExactMatches)
+}
+
+func setUserAutomationPatterns(dst *[]string, in []string, builtIns []string) {
+	cleaned := normalizeUserAutomationPatterns(in, builtIns)
+	userPatternsMu.Lock()
+	defer userPatternsMu.Unlock()
+	*dst = cleaned
+}
+
+func copyUserAutomationPatterns(src []string) []string {
+	userPatternsMu.RLock()
+	defer userPatternsMu.RUnlock()
+	return append([]string(nil), src...)
+}
+
+func snapshotUserAutomationPatterns() (
+	prefixes, substrings, exactMatches []string,
+) {
+	userPatternsMu.RLock()
+	defer userPatternsMu.RUnlock()
+	return append([]string(nil), userPrefixes...),
+		append([]string(nil), userSubstrings...),
+		append([]string(nil), userExactMatches...)
+}
+
+// normalizeUserAutomationPatterns applies the validation rules from the
+// design spec ("Validation behavior" section). Built-in overlap is checked
+// against the category-specific pattern slice directly.
+func normalizeUserAutomationPatterns(in []string, builtIns []string) []string {
 	seen := make(map[string]struct{}, len(in))
 	out := make([]string, 0, len(in))
 	for _, raw := range in {
 		s := strings.TrimSpace(raw)
-		if s == "" || len(s) > userPrefixMaxLen {
+		if s == "" || len(s) > userPatternMaxLen {
 			continue
 		}
 		if _, dup := seen[s]; dup {
 			continue
 		}
-		if slices.Contains(automatedPrefixes, s) {
+		if slices.Contains(builtIns, s) {
 			continue
 		}
 		seen[s] = struct{}{}
@@ -113,26 +159,38 @@ func normalizeUserPrefixes(in []string) []string {
 // IsAutomatedSession returns true if the first message
 // matches a known automated review/fix prompt pattern.
 func IsAutomatedSession(firstMessage string) bool {
+	prefixes, substrings, exactMatches := snapshotUserAutomationPatterns()
+
 	for _, prefix := range automatedPrefixes {
 		if strings.HasPrefix(firstMessage, prefix) {
 			return true
 		}
 	}
-	userPrefixesMu.RLock()
-	for _, prefix := range userPrefixes {
+	for _, prefix := range prefixes {
 		if strings.HasPrefix(firstMessage, prefix) {
-			userPrefixesMu.RUnlock()
 			return true
 		}
 	}
-	userPrefixesMu.RUnlock()
 	for _, sub := range automatedSubstrings {
 		if strings.Contains(firstMessage, sub) {
 			return true
 		}
 	}
+	for _, sub := range substrings {
+		if strings.Contains(firstMessage, sub) {
+			return true
+		}
+	}
 	trimmed := strings.TrimSpace(firstMessage)
-	return slices.Contains(automatedExactMatches, trimmed)
+	if slices.Contains(automatedExactMatches, trimmed) {
+		return true
+	}
+	for _, exact := range exactMatches {
+		if trimmed == exact {
+			return true
+		}
+	}
+	return false
 }
 
 // IsAutomatedTranscript classifies automation from the actual

--- a/internal/db/automated.go
+++ b/internal/db/automated.go
@@ -92,19 +92,19 @@ func SetUserAutomationExactMatches(matches []string) {
 // user-prefix slice. Used by ClassifierHash and tests; the
 // copy prevents callers from mutating singleton state.
 func UserAutomationPrefixes() []string {
-	return copyUserAutomationPatterns(userPrefixes)
+	return copyUserAutomationPatterns(&userPrefixes)
 }
 
 // UserAutomationSubstrings returns a copy of the current
 // user-substring slice.
 func UserAutomationSubstrings() []string {
-	return copyUserAutomationPatterns(userSubstrings)
+	return copyUserAutomationPatterns(&userSubstrings)
 }
 
 // UserAutomationExactMatches returns a copy of the current
 // user exact-match slice.
 func UserAutomationExactMatches() []string {
-	return copyUserAutomationPatterns(userExactMatches)
+	return copyUserAutomationPatterns(&userExactMatches)
 }
 
 func setUserAutomationPatterns(dst *[]string, in []string, builtIns []string) {
@@ -114,10 +114,10 @@ func setUserAutomationPatterns(dst *[]string, in []string, builtIns []string) {
 	*dst = cleaned
 }
 
-func copyUserAutomationPatterns(src []string) []string {
+func copyUserAutomationPatterns(src *[]string) []string {
 	userPatternsMu.RLock()
 	defer userPatternsMu.RUnlock()
-	return append([]string(nil), src...)
+	return append([]string(nil), (*src)...)
 }
 
 func snapshotUserAutomationPatterns() (

--- a/internal/db/automated_backfill_test.go
+++ b/internal/db/automated_backfill_test.go
@@ -449,7 +449,11 @@ func TestBackfillIsAutomatedBumpsLocalModifiedAt(t *testing.T) {
 // the stored hash and re-runs the backfill on next open,
 // without any manual marker bump.
 func TestBackfillIsAutomatedRerunsOnHashChange(t *testing.T) {
-	t.Cleanup(func() { SetUserAutomationPrefixes(nil) })
+	t.Cleanup(func() {
+		SetUserAutomationPrefixes(nil)
+		SetUserAutomationSubstrings(nil)
+		SetUserAutomationExactMatches(nil)
+	})
 	d := testDB(t)
 
 	// Seed a session whose first_message would match a

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -613,7 +613,7 @@ func TestUserAutomationGettersConcurrentWithSetters(t *testing.T) {
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		wg.Add(2)
 
 		go func(i int) {

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func resetUserAutomationPatterns() {
+	SetUserAutomationPrefixes(nil)
+	SetUserAutomationSubstrings(nil)
+	SetUserAutomationExactMatches(nil)
+}
+
 func TestIsAutomatedSession(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -310,6 +316,7 @@ func TestIsAutomatedSession(t *testing.T) {
 }
 
 func TestNormalizeUserPrefixes(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
 	long := strings.Repeat("a", 1025)
 	tests := []struct {
 		name string
@@ -337,15 +344,15 @@ func TestNormalizeUserPrefixes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := normalizeUserPrefixes(tt.in)
+			got := normalizeUserAutomationPatterns(tt.in, automatedPrefixes)
 			assert.Equal(t, tt.want, got,
-				"normalizeUserPrefixes(%q)", tt.in)
+				"normalizeUserAutomationPatterns(%q)", tt.in)
 		})
 	}
 }
 
 func TestIsAutomatedSessionWithUserPrefixes(t *testing.T) {
-	t.Cleanup(func() { SetUserAutomationPrefixes(nil) })
+	t.Cleanup(resetUserAutomationPatterns)
 	SetUserAutomationPrefixes([]string{
 		"You are analyzing an essay",
 		"Grade these Benn Stancil quotes",
@@ -387,13 +394,210 @@ func TestIsAutomatedSessionWithUserPrefixes(t *testing.T) {
 }
 
 func TestUserAutomationPrefixesReturnsCopy(t *testing.T) {
-	t.Cleanup(func() { SetUserAutomationPrefixes(nil) })
+	t.Cleanup(resetUserAutomationPatterns)
 	SetUserAutomationPrefixes([]string{"alpha", "beta"})
 	got := UserAutomationPrefixes()
 	if len(got) > 0 {
 		got[0] = "MUTATED"
 	}
 	again := UserAutomationPrefixes()
+	assert.NotEmpty(t, again, "singleton mutated through returned slice")
+	if len(again) > 0 {
+		assert.Equal(t, "alpha", again[0],
+			"singleton mutated through returned slice")
+	}
+}
+
+func TestNormalizeUserSubstrings(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
+	long := strings.Repeat("a", 1025)
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"Nil", nil, nil},
+		{"Empty", []string{}, nil},
+		{"AllWhitespace", []string{"   ", "\t\n"}, nil},
+		{"TrimsEachEntry", []string{"  hello  ", "world\n"}, []string{"hello", "world"}},
+		{"DropEmpty", []string{"hello", "", "  ", "world"}, []string{"hello", "world"}},
+		{"DropTooLong", []string{"hello", long}, []string{"hello"}},
+		{"DropDuplicate", []string{"a", "b", "a"}, []string{"a", "b"}},
+		{"DropDuplicateAfterTrim", []string{"a", " a "}, []string{"a"}},
+		{
+			"DropBuiltInOverlap",
+			[]string{"invoked by roborev to perform this review", "novel"},
+			[]string{"novel"},
+		},
+		{
+			"PreservesUserOrder",
+			[]string{"zeta", "alpha", "mu"},
+			[]string{"zeta", "alpha", "mu"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeUserAutomationPatterns(tt.in, automatedSubstrings)
+			assert.Equal(t, tt.want, got,
+				"normalizeUserAutomationPatterns(%q)", tt.in)
+		})
+	}
+}
+
+func TestNormalizeUserExactMatches(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
+	long := strings.Repeat("a", 1025)
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"Nil", nil, nil},
+		{"Empty", []string{}, nil},
+		{"AllWhitespace", []string{"   ", "\t\n"}, nil},
+		{"TrimsEachEntry", []string{"  hello  ", "world\n"}, []string{"hello", "world"}},
+		{"DropEmpty", []string{"hello", "", "  ", "world"}, []string{"hello", "world"}},
+		{"DropTooLong", []string{"hello", long}, []string{"hello"}},
+		{"DropDuplicate", []string{"a", "b", "a"}, []string{"a", "b"}},
+		{"DropDuplicateAfterTrim", []string{"a", " a "}, []string{"a"}},
+		{
+			"DropBuiltInOverlap",
+			[]string{"Warmup", "novel"},
+			[]string{"novel"},
+		},
+		{
+			"PreservesUserOrder",
+			[]string{"zeta", "alpha", "mu"},
+			[]string{"zeta", "alpha", "mu"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeUserAutomationPatterns(tt.in, automatedExactMatches)
+			assert.Equal(t, tt.want, got,
+				"normalizeUserAutomationPatterns(%q)", tt.in)
+		})
+	}
+}
+
+func TestIsAutomatedSessionWithUserSubstrings(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
+	SetUserAutomationSubstrings([]string{
+		"embedded marker",
+		"review the commit metadata",
+	})
+
+	tests := []struct {
+		name         string
+		firstMessage string
+		want         bool
+	}{
+		{
+			"UserSubstringMatchesInteriorText",
+			"Please note: this prompt has an embedded marker in the middle.",
+			true,
+		},
+		{
+			"UserSubstringMatchesLongerPrompt",
+			"Context here.\nPlease review the commit metadata and continue.",
+			true,
+		},
+		{
+			"UserSubstringDoesNotMatchUnrelated",
+			"How do I fix this bug?",
+			false,
+		},
+		{
+			"BuiltInSubstringStillMatches",
+			"IMPORTANT: You are being invoked by roborev to perform this review directly.",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAutomatedSession(tt.firstMessage)
+			assert.Equal(t, tt.want, got,
+				"IsAutomatedSession(%q)", tt.firstMessage)
+		})
+	}
+}
+
+func TestIsAutomatedSessionWithUserExactMatches(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
+	SetUserAutomationExactMatches([]string{
+		"Give a one-word answer: YES",
+		"Reply with a single token: NO",
+	})
+
+	tests := []struct {
+		name         string
+		firstMessage string
+		want         bool
+	}{
+		{
+			"ExactMatchWithWhitespaceTrimmed",
+			"\n Give a one-word answer: YES \t",
+			true,
+		},
+		{
+			"ExactMatchSecondLiteral",
+			"Reply with a single token: NO",
+			true,
+		},
+		{
+			"PartialMatchRejected",
+			"Give a one-word answer: YES and then explain why.",
+			false,
+		},
+		{
+			"BuiltInExactStillMatches",
+			"Warmup\n",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAutomatedSession(tt.firstMessage)
+			assert.Equal(t, tt.want, got,
+				"IsAutomatedSession(%q)", tt.firstMessage)
+		})
+	}
+}
+
+func TestIsAutomatedTranscriptSingleTurnGate(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
+	SetUserAutomationPrefixes([]string{"You are analyzing an essay"})
+
+	msg := "You are analyzing an essay about epistemology."
+	msgs := []Message{{Role: "user", Content: msg}}
+
+	assert.True(t, IsAutomatedTranscript(1, msgs, &msg))
+	assert.False(t, IsAutomatedTranscript(2, msgs, &msg))
+}
+
+func TestUserAutomationSubstringsReturnsCopy(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
+	SetUserAutomationSubstrings([]string{"alpha", "beta"})
+	got := UserAutomationSubstrings()
+	if len(got) > 0 {
+		got[0] = "MUTATED"
+	}
+	again := UserAutomationSubstrings()
+	assert.NotEmpty(t, again, "singleton mutated through returned slice")
+	if len(again) > 0 {
+		assert.Equal(t, "alpha", again[0],
+			"singleton mutated through returned slice")
+	}
+}
+
+func TestUserAutomationExactMatchesReturnsCopy(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
+	SetUserAutomationExactMatches([]string{"alpha", "beta"})
+	got := UserAutomationExactMatches()
+	if len(got) > 0 {
+		got[0] = "MUTATED"
+	}
+	again := UserAutomationExactMatches()
 	assert.NotEmpty(t, again, "singleton mutated through returned slice")
 	if len(again) > 0 {
 		assert.Equal(t, "alpha", again[0],

--- a/internal/db/automated_test.go
+++ b/internal/db/automated_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -603,4 +604,41 @@ func TestUserAutomationExactMatchesReturnsCopy(t *testing.T) {
 		assert.Equal(t, "alpha", again[0],
 			"singleton mutated through returned slice")
 	}
+}
+
+func TestUserAutomationGettersConcurrentWithSetters(t *testing.T) {
+	t.Cleanup(resetUserAutomationPatterns)
+
+	const workers = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		wg.Add(2)
+
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			if i%2 == 0 {
+				SetUserAutomationPrefixes([]string{"alpha", "beta"})
+				SetUserAutomationSubstrings([]string{"gamma"})
+				SetUserAutomationExactMatches([]string{"delta"})
+				return
+			}
+			SetUserAutomationPrefixes([]string{"epsilon"})
+			SetUserAutomationSubstrings([]string{"zeta", "eta"})
+			SetUserAutomationExactMatches([]string{"theta"})
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = UserAutomationPrefixes()
+			_ = UserAutomationSubstrings()
+			_ = UserAutomationExactMatches()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
 }

--- a/internal/db/classifier_hash.go
+++ b/internal/db/classifier_hash.go
@@ -23,18 +23,19 @@ const classifierAlgorithmVersion = 2
 
 // ClassifierHash returns a stable hex-encoded SHA-256 over
 // the algorithm version, all built-in pattern slices, and the
-// currently configured user prefixes. Inputs are sorted
+// currently configured user patterns. Inputs are sorted
 // before hashing so config order doesn't affect the result.
 // Tagged + length-prefixed encoding prevents splice
-// collisions between slice boundaries (e.g. moving an entry
-// from substrings to exact-matches must change the hash).
+// collisions between slice boundaries.
 func ClassifierHash() string {
 	h := sha256.New()
 	fmt.Fprintf(h, "v%d\n", classifierAlgorithmVersion)
 	writeSorted(h, "P", automatedPrefixes)
 	writeSorted(h, "S", automatedSubstrings)
 	writeSorted(h, "E", automatedExactMatches)
-	writeSorted(h, "U", UserAutomationPrefixes())
+	writeSorted(h, "UP", UserAutomationPrefixes())
+	writeSorted(h, "US", UserAutomationSubstrings())
+	writeSorted(h, "UE", UserAutomationExactMatches())
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/internal/db/classifier_hash_test.go
+++ b/internal/db/classifier_hash_test.go
@@ -6,8 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func resetClassifierPatterns() {
+	SetUserAutomationPrefixes(nil)
+	SetUserAutomationSubstrings(nil)
+	SetUserAutomationExactMatches(nil)
+}
+
 func TestClassifierHashStable(t *testing.T) {
-	t.Cleanup(func() { SetUserAutomationPrefixes(nil) })
+	t.Cleanup(resetClassifierPatterns)
 	SetUserAutomationPrefixes([]string{"foo", "bar"})
 	a := ClassifierHash()
 	b := ClassifierHash()
@@ -15,8 +21,8 @@ func TestClassifierHashStable(t *testing.T) {
 }
 
 func TestClassifierHashChangesWithUserPrefixes(t *testing.T) {
-	t.Cleanup(func() { SetUserAutomationPrefixes(nil) })
-	SetUserAutomationPrefixes(nil)
+	t.Cleanup(resetClassifierPatterns)
+	resetClassifierPatterns()
 	base := ClassifierHash()
 	SetUserAutomationPrefixes([]string{"You are analyzing an essay"})
 	with := ClassifierHash()
@@ -24,8 +30,28 @@ func TestClassifierHashChangesWithUserPrefixes(t *testing.T) {
 		"hash did not change when user prefixes changed")
 }
 
+func TestClassifierHashChangesWithUserSubstrings(t *testing.T) {
+	t.Cleanup(resetClassifierPatterns)
+	SetUserAutomationSubstrings(nil)
+	base := ClassifierHash()
+	SetUserAutomationSubstrings([]string{"embedded marker"})
+	with := ClassifierHash()
+	assert.NotEqual(t, base, with,
+		"hash did not change when user substrings changed")
+}
+
+func TestClassifierHashChangesWithUserExactMatches(t *testing.T) {
+	t.Cleanup(resetClassifierPatterns)
+	SetUserAutomationExactMatches(nil)
+	base := ClassifierHash()
+	SetUserAutomationExactMatches([]string{"Give a one-word answer: YES"})
+	with := ClassifierHash()
+	assert.NotEqual(t, base, with,
+		"hash did not change when user exact matches changed")
+}
+
 func TestClassifierHashOrderIndependent(t *testing.T) {
-	t.Cleanup(func() { SetUserAutomationPrefixes(nil) })
+	t.Cleanup(resetClassifierPatterns)
 	SetUserAutomationPrefixes([]string{"alpha", "beta", "gamma"})
 	a := ClassifierHash()
 	SetUserAutomationPrefixes([]string{"gamma", "alpha", "beta"})
@@ -37,13 +63,32 @@ func TestClassifierHashOrderIndependent(t *testing.T) {
 // where two different categorizations produce the same hash
 // because the tag prefix was dropped from the encoding.
 func TestClassifierHashTagSeparation(t *testing.T) {
-	t.Cleanup(func() { SetUserAutomationPrefixes(nil) })
+	t.Cleanup(resetClassifierPatterns)
 	SetUserAutomationPrefixes([]string{"Warmup"})
 	got := ClassifierHash()
-	SetUserAutomationPrefixes(nil)
+	resetClassifierPatterns()
 	bareBuiltins := ClassifierHash()
 	assert.NotEqual(t, got, bareBuiltins,
 		"user prefix 'Warmup' collided with built-in exact-match 'Warmup'")
+}
+
+func TestClassifierHashSeparatesUserCategories(t *testing.T) {
+	t.Cleanup(resetClassifierPatterns)
+
+	SetUserAutomationPrefixes([]string{"You are analyzing an essay"})
+	prefixHash := ClassifierHash()
+
+	resetClassifierPatterns()
+	SetUserAutomationSubstrings([]string{"You are analyzing an essay"})
+	substringHash := ClassifierHash()
+
+	resetClassifierPatterns()
+	SetUserAutomationExactMatches([]string{"You are analyzing an essay"})
+	exactHash := ClassifierHash()
+
+	assert.NotEqual(t, prefixHash, substringHash)
+	assert.NotEqual(t, prefixHash, exactHash)
+	assert.NotEqual(t, substringHash, exactHash)
 }
 
 // TestClassifierHashCurrentAlgoVersion is a forced-bump


### PR DESCRIPTION
Issue `#370` asks for the full literal-pattern config surface on the automated-session classifier. Prefixes were already made configurable in PR `#383`, building on the built-in classifier expansion from PR `#369`, but substrings and exact-message matches still stay hardcoded-only, which leaves users without a config-driven way to model embedded tool markers or whole-message pings.

This change adds `substrings` and `exact_matches` alongside the existing `prefixes` field, wires all three categories through the existing classifier-config entrypoint, and includes each user-configured category in `ClassifierHash()` so behavior changes still trigger the expected rebuild path. Built-in patterns remain active, and the single-turn gate stays unchanged.

The tests cover the new config round-trip, substring and exact-match semantics, hash invalidation for each new category, and preservation of the current multi-turn gate.

Fixes #370
