### PR TITLE
feat(cli): standardize --format/--json output flags across commands

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -375,7 +375,6 @@ func newImportCommand() *cobra.Command {
 }
 
 func newProjectsCommand() *cobra.Command {
-	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:          "projects",
 		Short:        "List projects with session counts",
@@ -383,10 +382,10 @@ func newProjectsCommand() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			runProjects(jsonOutput)
+			runProjects(outputFormat(cmd) == "json")
 		},
 	}
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON array")
+	registerFormatFlags(cmd.Flags())
 	return cmd
 }
 
@@ -403,11 +402,11 @@ func newHealthCommand() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			cfg.JSON = outputFormat(cmd) == "json"
 			runHealth(args, cfg)
 		},
 	}
-	cmd.Flags().BoolVar(&cfg.JSON, "json", false,
-		"Output as JSON")
+	registerFormatFlags(cmd.Flags())
 	cmd.Flags().IntVar(&cfg.Limit, "limit",
 		defaultHealthLimit,
 		"Number of sessions to list (max 500)")
@@ -439,10 +438,11 @@ func newUsageDailyCommand() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			cfg.JSON = outputFormat(cmd) == "json"
 			runUsageDaily(cfg)
 		},
 	}
-	cmd.Flags().BoolVar(&cfg.JSON, "json", false, "Output as JSON")
+	registerFormatFlags(cmd.Flags())
 	cmd.Flags().StringVar(&cfg.Since, "since", "", "Start of window (duration like 28d, or YYYY-MM-DD)")
 	cmd.Flags().StringVar(&cfg.Until, "until", "", "End of window (duration like 28d, or YYYY-MM-DD)")
 	cmd.Flags().BoolVar(&cfg.All, "all", false, "Include all history (overrides default 30-day window)")
@@ -494,6 +494,7 @@ func newActivityReportCommand() *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			cfg.JSON = outputFormat(cmd) == "json"
 			runActivityReport(cfg)
 		},
 	}
@@ -506,7 +507,7 @@ func newActivityReportCommand() *cobra.Command {
 	cmd.Flags().StringVar(&cfg.Project, "project", "", "Filter by project")
 	cmd.Flags().StringVar(&cfg.Agent, "agent", "", "Filter by agent name")
 	cmd.Flags().StringVar(&cfg.Machine, "machine", "", "Filter by machine name")
-	cmd.Flags().BoolVar(&cfg.JSON, "json", false, "Output as JSON")
+	registerFormatFlags(cmd.Flags())
 	cmd.Flags().BoolVar(&cfg.NoSync, "no-sync", false, "Skip on-demand sync before querying")
 	cmd.Flags().BoolVar(&cfg.Offline, "offline", false, "Use fallback pricing only")
 	return cmd

--- a/cmd/agentsview/output_format_test.go
+++ b/cmd/agentsview/output_format_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputFormat_Resolves(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default is human", nil, "human"},
+		{"json alias", []string{"--json"}, "json"},
+		{"format json", []string{"--format", "json"}, "json"},
+		{"format human", []string{"--format", "human"}, "human"},
+		{"json wins over format human", []string{"--json", "--format", "human"}, "json"},
+		{"explicit json false defers to format", []string{"--json=false", "--format", "json"}, "json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "x"}
+			registerFormatFlags(cmd.Flags())
+			require.NoError(t, cmd.ParseFlags(tt.args))
+			assert.Equal(t, tt.want, outputFormat(cmd))
+		})
+	}
+}
+
+func TestOutputFormat_RejectsInvalid(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{Use: "x"}
+	registerFormatFlags(cmd.Flags())
+	err := cmd.ParseFlags([]string{"--format", "yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be human or json")
+}
+
+// machineOutputCommandPaths are the commands that must accept both
+// --format and the --json alias. token-use (deprecated, JSON-only) and
+// openapi (spec-only) are deliberately excluded.
+var machineOutputCommandPaths = [][]string{
+	{"projects"},
+	{"health"},
+	{"usage", "daily"},
+	{"activity", "report"},
+	{"stats"},
+	{"secrets", "list"},
+	{"secrets", "scan"},
+	{"parse-diff"},
+	{"session", "list"},
+	{"session", "get"},
+	{"session", "messages"},
+	{"session", "tool-calls"},
+	{"session", "search"},
+	{"session", "usage"},
+	{"session", "sync"},
+}
+
+func TestMachineOutputCommands_AcceptFormatAndJSON(t *testing.T) {
+	t.Parallel()
+	for _, path := range machineOutputCommandPaths {
+		t.Run(strings.Join(path, " "), func(t *testing.T) {
+			t.Parallel()
+			for _, args := range [][]string{{"--json"}, {"--format", "json"}} {
+				root := newRootCommand()
+				cmd, _, err := root.Find(path)
+				require.NoError(t, err, "command %q should exist", path)
+				require.NoError(t, cmd.ParseFlags(args),
+					"command %q should accept %v", path, args)
+				assert.Equal(t, "json", outputFormat(cmd),
+					"command %q with %v should resolve json", path, args)
+			}
+		})
+	}
+}
+
+// TestFormatAndJSONFlagsArePaired enforces that --format and --json are
+// always registered together, so a reintroduced bare --json fails the
+// build. It does not prove a JSON command opted in at all;
+// machineOutputCommandPaths covers that.
+func TestFormatAndJSONFlagsArePaired(t *testing.T) {
+	t.Parallel()
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		// cmd.Flag resolves local and inherited persistent flags.
+		hasFormat := cmd.Flag("format") != nil
+		hasJSON := cmd.Flag("json") != nil
+		assert.Equalf(t, hasFormat, hasJSON,
+			"command %q must register --format and --json together "+
+				"(has --format=%v, has --json=%v)",
+			cmd.CommandPath(), hasFormat, hasJSON)
+		for _, sub := range cmd.Commands() {
+			walk(sub)
+		}
+	}
+	walk(newRootCommand())
+}

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -76,6 +76,7 @@ func newParseDiffCommand() *cobra.Command {
 			return err
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			cfg.JSON = outputFormat(cmd) == "json"
 			cfg.Stdout = cmd.OutOrStdout()
 			cfg.Stderr = cmd.ErrOrStderr()
 			runParseDiff(cfg)
@@ -87,8 +88,7 @@ func newParseDiffCommand() *cobra.Command {
 		"Re-parse only the N most recently modified source files (0 = all)")
 	cmd.Flags().BoolVar(&cfg.FailOnChange, "fail-on-change", false,
 		"Exit 1 when sessions changed or files failed to parse")
-	cmd.Flags().BoolVar(&cfg.JSON, "json", false,
-		"Output the full report as JSON")
+	registerFormatFlags(cmd.Flags())
 	cmd.Flags().BoolVarP(&cfg.Verbose, "verbose", "v", false,
 		"Show every field diff for every changed session")
 	return cmd

--- a/cmd/agentsview/secrets.go
+++ b/cmd/agentsview/secrets.go
@@ -23,8 +23,7 @@ func newSecretsCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmd.PersistentFlags().String("format", "human",
-		"Output format: human or json")
+	registerFormatFlags(cmd.PersistentFlags())
 	cmd.AddCommand(newSecretsListCommand())
 	cmd.AddCommand(newSecretsScanCommand())
 	return cmd

--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/service"
 )
@@ -24,14 +25,7 @@ func newSessionCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmd.PersistentFlags().String(
-		"format", "human",
-		"Output format: human or json",
-	)
-	cmd.PersistentFlags().Bool(
-		"json", false,
-		"Emit JSON output (alias for --format json)",
-	)
+	registerFormatFlags(cmd.PersistentFlags())
 	cmd.PersistentFlags().String(
 		"server", "",
 		"Remote daemon URL",
@@ -210,16 +204,55 @@ func explicitServerToken(cmd *cobra.Command) (string, error) {
 	return strings.TrimSpace(os.Getenv("AGENTSVIEW_SERVER_TOKEN")), nil
 }
 
-// outputFormat returns the requested --format flag value
-// ("human" or "json"). Defaults to "human".
+// formatFlag restricts --format to "human" or "json", so a typo fails at
+// parse time rather than silently degrading to human output. Type returns
+// the allowed values, which --help renders as `--format human|json`.
+type formatFlag string
+
+func (f *formatFlag) String() string { return string(*f) }
+
+func (f *formatFlag) Set(v string) error {
+	switch v {
+	case "human", "json":
+		*f = formatFlag(v)
+		return nil
+	default:
+		return errors.New("must be human or json")
+	}
+}
+
+func (*formatFlag) Type() string { return "human|json" }
+
+// registerFormatFlags installs the --format/--json pair shared by every
+// machine-readable command. Read the result with outputFormat.
+func registerFormatFlags(flags *pflag.FlagSet) {
+	f := formatFlag("human")
+	flags.Var(&f, "format", "Output format: human or json")
+	flags.Bool("json", false, "Emit JSON output (alias for --format json)")
+}
+
+// rejectFormatFlags errors when --format or --json was set on a command
+// that streams a fixed format: such commands inherit the pair from the
+// session group but cannot honor it.
+func rejectFormatFlags(cmd *cobra.Command, cmdName, streams string) error {
+	if cmd.Flags().Changed("format") || cmd.Flags().Changed("json") {
+		return fmt.Errorf(
+			"%s: streams %s; --format/--json not supported",
+			cmdName, streams,
+		)
+	}
+	return nil
+}
+
+// outputFormat resolves the output format to "human" or "json". The
+// --json alias wins when set; otherwise the --format value, default
+// "human".
 func outputFormat(cmd *cobra.Command) string {
-	jsonOutput, _ := cmd.Flags().GetBool("json")
-	if jsonOutput {
+	if jsonOutput, _ := cmd.Flags().GetBool("json"); jsonOutput {
 		return "json"
 	}
-	v, _ := cmd.Flags().GetString("format")
-	if v == "" {
-		return "human"
+	if f := cmd.Flag("format"); f != nil {
+		return f.Value.String()
 	}
-	return v
+	return "human"
 }

--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -27,10 +27,10 @@ func newSessionExportCommand() *cobra.Command {
 					"session export: local-only command; --server not supported",
 				)
 			}
-			if cmd.Flags().Changed("format") {
-				return fmt.Errorf(
-					"session export: streams raw bytes; --format not supported",
-				)
+			if err := rejectFormatFlags(
+				cmd, "session export", "raw bytes",
+			); err != nil {
+				return err
 			}
 			if pgReadRequested(cmd) {
 				return fmt.Errorf(

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -878,17 +878,20 @@ func TestSessionExport_FailsWhenNotInLocalArchive(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown-id")
 }
 
-// TestSessionExport_RejectsFormatFlag verifies that export refuses
-// --format because it streams raw bytes. Previously --format was a
-// silently-accepted inherited flag, which was a contract footgun
-// for scripts that expected JSON output.
+// Export inherits --format/--json from the session group but streams raw
+// bytes, so it must reject both rather than silently ignore them.
 func TestSessionExport_RejectsFormatFlag(t *testing.T) {
-	newAgentDataDir(t)
+	for _, flag := range [][]string{{"--format", "json"}, {"--json"}} {
+		t.Run(strings.Join(flag, " "), func(t *testing.T) {
+			newAgentDataDir(t)
 
-	_, err := executeCommand(newRootCommand(),
-		"session", "export", "some-id", "--format", "json")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--format not supported")
+			args := append([]string{"session", "export", "some-id"}, flag...)
+			_, err := executeCommand(newRootCommand(), args...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(),
+				"--format/--json not supported")
+		})
+	}
 }
 
 func TestSessionExport_RejectsPGFlag(t *testing.T) {
@@ -1548,6 +1551,23 @@ func TestSessionWatch_UnknownID_FailsFast(t *testing.T) {
 		"expected 'session not found' error; got: %v", err)
 	assert.Contains(t, err.Error(), "unknown-id",
 		"error should name the missing session id")
+}
+
+// Watch streams a fixed NDJSON format, so it rejects --format/--json
+// inherited from the session group. The guard fires before any service
+// resolution, so no archive setup is needed.
+func TestSessionWatch_RejectsFormatFlag(t *testing.T) {
+	for _, flag := range [][]string{{"--format", "json"}, {"--json"}} {
+		t.Run(strings.Join(flag, " "), func(t *testing.T) {
+			newAgentDataDir(t)
+
+			args := append([]string{"session", "watch", "some-id"}, flag...)
+			_, err := executeCommand(newRootCommand(), args...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(),
+				"--format/--json not supported")
+		})
+	}
 }
 
 // TestLooksLikePath covers both POSIX and Windows-style separators

--- a/cmd/agentsview/session_watch.go
+++ b/cmd/agentsview/session_watch.go
@@ -15,6 +15,11 @@ func newSessionWatchCommand() *cobra.Command {
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := rejectFormatFlags(
+				cmd, "session watch", "NDJSON",
+			); err != nil {
+				return err
+			}
 			svc, cleanup, err := resolveService(cmd)
 			if err != nil {
 				return err

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -77,8 +77,7 @@ func newStatsCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("format", "human",
-		"Output format: human or json")
+	registerFormatFlags(cmd.Flags())
 	registerStatsFlags(cmd,
 		&since, &until, &agent, &timezone,
 		&includeProjects, &excludeProjects,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -255,7 +255,8 @@ agentsview usage daily [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--json` | `false` | Emit JSON instead of a terminal table |
+| `--format` | `human` | Output format: `human` or `json` |
+| `--json` | `false` | Alias for `--format json` |
 | `--since` | `30 days ago` | Start of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive |
 | `--until` | | End of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive |
 | `--all` | `false` | Scan all history; overrides the default 30-day window |
@@ -356,7 +357,8 @@ agentsview activity report [flags]
 | `--project` | | Filter by project |
 | `--agent` | | Filter by agent name |
 | `--machine` | | Filter by machine name |
-| `--json` | `false` | Emit the full report as JSON |
+| `--format` | `human` | Output format: `human` or `json` |
+| `--json` | `false` | Alias for `--format json` |
 | `--no-sync` | `false` | Skip on-demand sync before querying |
 | `--offline` | `false` | Use fallback pricing only |
 
@@ -548,7 +550,8 @@ agentsview projects [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--json` | `false` | Output as a JSON array |
+| `--format` | `human` | Output format: `human` or `json` |
+| `--json` | `false` | Alias for `--format json` |
 
 **Examples:**
 
@@ -571,7 +574,8 @@ agentsview health [session-id] [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--json` | `false` | Output JSON instead of terminal text |
+| `--format` | `human` | Output format: `human` or `json` |
+| `--json` | `false` | Alias for `--format json` |
 | `--limit` | `20` | Number of sessions to list when no session ID is given |
 
 **Examples:**
@@ -601,6 +605,7 @@ agentsview stats [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--format` | `human` | Output format: `human` or `json` |
+| `--json` | `false` | Alias for `--format json` |
 | `--since` | `28d` | Start of window, either `YYYY-MM-DD` or a compact duration like `28d` |
 | `--until` | | End of window as `YYYY-MM-DD` |
 | `--agent` | `all` | Restrict to one agent or use `all` |
@@ -665,7 +670,8 @@ agentsview parse-diff [flags]
 | `--agent` | | Restrict to one agent; repeatable |
 | `--limit` | `0` | Maximum number of source files to inspect, newest first (`0` means all) |
 | `--fail-on-change` | `false` | Exit non-zero when changes or parse errors are found |
-| `--json` | `false` | Emit a machine-readable report |
+| `--format` | `human` | Output format: `human` or `json` |
+| `--json` | `false` | Alias for `--format json` |
 | `--verbose` / `-v` | `false` | Include more detail in the human report |
 
 **Examples:**
@@ -732,7 +738,10 @@ agentsview session usage <id>            # token usage and cost estimate
 ```
 
 Structured response commands accept `--format json`; `--json` is
-a short alias for that scripting mode. Use `--server <url>` to
+a short alias for that scripting mode. `session export` and
+`session watch` are the exceptions: they stream raw bytes and
+NDJSON respectively, so they reject `--format`/`--json`. Use
+`--server <url>` to
 target an explicit running daemon, `AGENTSVIEW_SERVER_TOKEN` or
 `--server-token-file <path>` when that daemon requires auth, or
 `--pg` to read from configured PostgreSQL.
@@ -827,6 +836,7 @@ localhost-bound daemon and emits a warning to stderr.
 | Flag | Used by | Description |
 |------|---------|-------------|
 | `--format` | both | `human` or `json` (inherited from `secrets`) |
+| `--json` | both | Alias for `--format json` (inherited from `secrets`) |
 | `--backfill` | scan | Scan only sessions not yet scanned at the current ruleset version |
 | `--project` | both | Limit to a project |
 | `--agent` | both | Limit to an agent |

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -80,8 +80,8 @@ for a writable local archive owner.
   second writer. Read commands may still fall back to direct
   read-only SQLite.
 - `session export` always runs locally regardless of daemon
-  state, and rejects `--server`, `--pg`, and `--format` because it
-  streams raw source bytes.
+  state, and rejects `--server`, `--pg`, and `--format`/`--json`
+  because it streams raw source bytes.
 
 When a discovered local daemon requires auth (`require_auth: true`),
 the CLI attaches `Authorization: Bearer <token>` using the
@@ -304,9 +304,9 @@ be a plain string (e.g. `"echo hello world"` from Codex).
 Stream the raw session source file to stdout. This is a
 **local-only** filesystem helper: the source file path is resolved
 from the local SQLite archive, never from any daemon. Both
-`--server` and `--format` are rejected with an error — the command
-also rejects `--pg`. It streams raw bytes, so structured-output
-and remote-store flags don't apply.
+`--server` and `--format`/`--json` are rejected with an error — the
+command also rejects `--pg`. It streams raw bytes, so
+structured-output and remote-store flags don't apply.
 
 ```bash
 agentsview session export <id>
@@ -394,7 +394,8 @@ agentsview session watch <id>
 Recognized `event` values today: `session_updated`, `heartbeat`.
 New events may be added; consumers should ignore unknown events.
 The command runs until interrupted (Ctrl+C) or the context is
-cancelled.
+cancelled. Like `session export`, it streams a fixed format and
+rejects `--format`/`--json`.
 
 Watch validates the session id before opening the stream. An
 unknown id fails fast with a `watch: session not found: <id>`

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -77,6 +77,7 @@ agentsview stats --agent claude --include-project my-app
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--format` | `human` | Output format: `human` or `json` |
+| `--json` | `false` | Alias for `--format json` |
 | `--since` | `28d` | Start of window, either a compact duration like `28d` or a `YYYY-MM-DD` date |
 | `--until` | now | End of window as `YYYY-MM-DD` |
 | `--agent` | `all` | Restrict to one agent, or leave as `all` |

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -452,7 +452,7 @@ Beyond raw speed, `agentsview usage`:
 ## `agentsview usage daily`
 
 Daily cost report. Outputs a tab-aligned table to stdout by
-default, or JSON with `--json`.
+default, or JSON with `--format json` (or the `--json` alias).
 
 ```bash
 agentsview usage daily [flags]
@@ -460,7 +460,8 @@ agentsview usage daily [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--json` | `false` | Emit a JSON document instead of a table |
+| `--format` | `human` | Output format: `human` or `json` |
+| `--json` | `false` | Alias for `--format json` |
 | `--since` | `30 days ago` | Start of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive |
 | `--until` |  | End of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive |
 | `--all` | `false` | Include all history; overrides the default 30-day window |


### PR DESCRIPTION
Fixes #902


Every command that emits machine-readable output now accepts the same flag
pair: `--format human|json`, with `--json` as a boolean alias for
`--format json`. Before this change the surface was split three ways, so the
same flag spelling worked on one command and failed on another:

- `--format`-only: `stats`, `secrets`
- bare `--json`-only: `projects`, `health`, `usage daily`, `activity report`,
  `parse-diff`
- JSON-only with no flag: `token-use`, `openapi`

A scripter can now use one convention everywhere, and every previously-working
`--json` invocation still works.

## How it fits together

Registration and reading are centralized so the convention can't drift again:

- `registerFormatFlags` installs the `--format`/`--json` pair. Every
  machine-readable command calls it instead of declaring its own flag.
- `formatFlag` (a `pflag.Value` enum) restricts `--format` to `human` or
  `json`.
- `outputFormat` is the single reader; `--json` wins when set, otherwise the
  `--format` value, defaulting to `human`.
- Streaming commands that can't honor a format choice reject the inherited pair
  through a shared `rejectFormatFlags` helper: `session export` (raw bytes) and
  `session watch` (NDJSON).

`token-use` (deprecated) and `openapi` (a spec dump with no human form) stay
JSON-only.

## Tradeoffs and limitations

- One behavior change goes beyond pure consistency: a mistyped `--format` value
  now errors at parse time. Previously, on the commands that already had
  `--format`, an unrecognized value silently fell back to human output, which
  is a quiet trap for a script expecting JSON. The enum surfaces it instead.
- `session export` and `session watch` inherit `--format`/`--json` from the
  `session` group's persistent flags and so still list them in `--help`, even
  though they reject them at runtime. That is a cobra inheritance limitation,
  not a new contract; the rejection and the docs make the behavior explicit.

## Where to look

- `cmd/agentsview/session.go` — the shared helpers (`registerFormatFlags`,
  `formatFlag`, `outputFormat`, `rejectFormatFlags`).
- `cmd/agentsview/cli.go`, `parse_diff.go`, `stats.go`, `secrets.go` — the
  migrated commands.
- `cmd/agentsview/session_export.go`, `session_watch.go` — the streaming
  rejections.
- `cmd/agentsview/output_format_test.go` — `TestFormatAndJSONFlagsArePaired`
  walks the command tree and fails the build if any command ever registers one
  flag without the other.
- `docs/` — command reference tables updated to show the flag pair.
