### PR TITLE
fix(usage): accept duration syntax for usage daily --since/--until

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -443,8 +443,8 @@ func newUsageDailyCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&cfg.JSON, "json", false, "Output as JSON")
-	cmd.Flags().StringVar(&cfg.Since, "since", "", "Start date (YYYY-MM-DD)")
-	cmd.Flags().StringVar(&cfg.Until, "until", "", "End date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&cfg.Since, "since", "", "Start of window (duration like 28d, or YYYY-MM-DD)")
+	cmd.Flags().StringVar(&cfg.Until, "until", "", "End of window (duration like 28d, or YYYY-MM-DD)")
 	cmd.Flags().BoolVar(&cfg.All, "all", false, "Include all history (overrides default 30-day window)")
 	cmd.Flags().StringVar(&cfg.Agent, "agent", "", "Filter by agent name")
 	cmd.Flags().BoolVar(&cfg.Breakdown, "breakdown", false, "Show per-model breakdown rows")

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -66,15 +66,46 @@ type UsageDailyConfig struct {
 	Timezone  string
 }
 
+// resolveUsageWindow resolves the raw --since/--until flags into concrete
+// inclusive YYYY-MM-DD bounds — a duration like 28d or a date, the same
+// syntax as `stats --since` — and rejects an inverted explicit window so a
+// reversed range fails loudly instead of returning an empty result.
+func resolveUsageWindow(
+	since, until string, now time.Time,
+) (string, string, error) {
+	from, err := db.ResolveWindowDate(since, now)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid --since: %w", err)
+	}
+	to, err := db.ResolveWindowDate(until, now)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid --until: %w", err)
+	}
+	// Bounds are inclusive, so from == to is a valid single day (hence >
+	// not >=). String comparison is valid because YYYY-MM-DD sorts
+	// lexically.
+	if from != "" && to != "" && from > to {
+		return "", "", fmt.Errorf(
+			"--since (%s) must not be after --until (%s)", from, to)
+	}
+	return from, to, nil
+}
+
 func runUsageDaily(cfg UsageDailyConfig) {
 	tz := cfg.Timezone
 	if tz == "" {
 		tz = localTimezone()
 	}
 
+	since, until, err := resolveUsageWindow(cfg.Since, cfg.Until, time.Now())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
 	filter := db.UsageFilter{
-		From:     cfg.Since,
-		To:       cfg.Until,
+		From:     since,
+		To:       until,
 		Agent:    cfg.Agent,
 		Timezone: tz,
 	}

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -76,23 +76,26 @@ type UsageDailyConfig struct {
 func resolveUsageWindow(
 	since, until string, now time.Time,
 ) (string, string, error) {
-	to, err := db.ResolveWindowDate(until, now)
-	if err != nil {
-		return "", "", fmt.Errorf("invalid --until: %w", err)
-	}
-	// ResolveWindowDate anchors a duration at its time argument (and
-	// ignores it for a date), so resolving --since against the resolved
-	// --until measures a duration --since back from --until.
+	// Resolve --until first and keep it as the anchor for --since:
+	// ParseWindowPoint measures a duration back from its time argument, so
+	// a duration --since is measured from the resolved --until while a date
+	// stands alone. --until open leaves the anchor at now.
 	anchor := now
-	if to != "" {
-		anchor, err = time.Parse("2006-01-02", to)
+	to := ""
+	if until != "" {
+		t, err := db.ParseWindowPoint(until, now)
 		if err != nil {
-			return "", "", err
+			return "", "", fmt.Errorf("invalid --until: %w", err)
 		}
+		anchor, to = t, t.UTC().Format("2006-01-02")
 	}
-	from, err := db.ResolveWindowDate(since, anchor)
-	if err != nil {
-		return "", "", fmt.Errorf("invalid --since: %w", err)
+	from := ""
+	if since != "" {
+		t, err := db.ParseWindowPoint(since, anchor)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid --since: %w", err)
+		}
+		from = t.UTC().Format("2006-01-02")
 	}
 	// Bounds are inclusive, so from == to is a valid single day (hence >
 	// not >=). String comparison is valid because YYYY-MM-DD sorts

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -74,8 +74,12 @@ type UsageDailyConfig struct {
 // window is rejected so a reversed range fails loudly instead of returning
 // an empty result.
 func resolveUsageWindow(
-	since, until string, now time.Time,
+	since, until string, now time.Time, loc *time.Location,
 ) (string, string, error) {
+	if loc == nil {
+		loc = time.UTC
+	}
+	now = now.In(loc)
 	// Resolve --until first and keep it as the anchor for --since:
 	// ParseWindowPoint measures a duration back from its time argument, so
 	// a duration --since is measured from the resolved --until while a date
@@ -83,19 +87,19 @@ func resolveUsageWindow(
 	anchor := now
 	to := ""
 	if until != "" {
-		t, err := db.ParseWindowPoint(until, now)
+		t, date, err := resolveUsageWindowPoint(until, now, loc)
 		if err != nil {
 			return "", "", fmt.Errorf("invalid --until: %w", err)
 		}
-		anchor, to = t, t.UTC().Format("2006-01-02")
+		anchor, to = t, date
 	}
 	from := ""
 	if since != "" {
-		t, err := db.ParseWindowPoint(since, anchor)
+		_, date, err := resolveUsageWindowPoint(since, anchor, loc)
 		if err != nil {
 			return "", "", fmt.Errorf("invalid --since: %w", err)
 		}
-		from = t.UTC().Format("2006-01-02")
+		from = date
 	}
 	// Bounds are inclusive, so from == to is a valid single day (hence >
 	// not >=). String comparison is valid because YYYY-MM-DD sorts
@@ -107,13 +111,32 @@ func resolveUsageWindow(
 	return from, to, nil
 }
 
+func resolveUsageWindowPoint(
+	raw string, anchor time.Time, loc *time.Location,
+) (time.Time, string, error) {
+	if t, err := time.ParseInLocation("2006-01-02", raw, loc); err == nil {
+		return t, raw, nil
+	}
+	t, err := db.ParseWindowPoint(raw, anchor)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	return t, t.In(loc).Format("2006-01-02"), nil
+}
+
 func runUsageDaily(cfg UsageDailyConfig) {
 	tz := cfg.Timezone
 	if tz == "" {
 		tz = localTimezone()
 	}
 
-	since, until, err := resolveUsageWindow(cfg.Since, cfg.Until, time.Now())
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: invalid --timezone: %v\n", err)
+		os.Exit(1)
+	}
+
+	since, until, err := resolveUsageWindow(cfg.Since, cfg.Until, time.Now(), loc)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -67,19 +67,32 @@ type UsageDailyConfig struct {
 }
 
 // resolveUsageWindow resolves the raw --since/--until flags into concrete
-// inclusive YYYY-MM-DD bounds — a duration like 28d or a date, the same
-// syntax as `stats --since` — and rejects an inverted explicit window so a
-// reversed range fails loudly instead of returning an empty result.
+// inclusive YYYY-MM-DD bounds. Both accept a duration like 28d or a date,
+// the same syntax as `stats`. --until resolves first; a duration --since is
+// then measured back from the resolved --until (or from now when --until is
+// open), matching how stats anchors a duration window. An inverted explicit
+// window is rejected so a reversed range fails loudly instead of returning
+// an empty result.
 func resolveUsageWindow(
 	since, until string, now time.Time,
 ) (string, string, error) {
-	from, err := db.ResolveWindowDate(since, now)
-	if err != nil {
-		return "", "", fmt.Errorf("invalid --since: %w", err)
-	}
 	to, err := db.ResolveWindowDate(until, now)
 	if err != nil {
 		return "", "", fmt.Errorf("invalid --until: %w", err)
+	}
+	// ResolveWindowDate anchors a duration at its time argument (and
+	// ignores it for a date), so resolving --since against the resolved
+	// --until measures a duration --since back from --until.
+	anchor := now
+	if to != "" {
+		anchor, err = time.Parse("2006-01-02", to)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	from, err := db.ResolveWindowDate(since, anchor)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid --since: %w", err)
 	}
 	// Bounds are inclusive, so from == to is a valid single day (hence >
 	// not >=). String comparison is valid because YYYY-MM-DD sorts

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -264,7 +264,7 @@ func TestRunUsageDailyResolvesDurationSince(t *testing.T) {
 		})
 	})
 
-	// Exact date math is pinned by TestResolveWindowDate; here we only
+	// Exact date math is pinned by TestResolveUsageWindow; here we only
 	// prove the duration resolved to a concrete date, not forwarded as
 	// "14d".
 	assert.NotEqual(t, "14d", gotFrom, "duration should be resolved, not forwarded")
@@ -284,6 +284,7 @@ func TestResolveUsageWindow(t *testing.T) {
 	}{
 		{name: "empty passes through"},
 		{name: "duration since anchors at now", since: "14d", wantFrom: "2026-04-04"},
+		{name: "Nh duration since", since: "48h", wantFrom: "2026-04-16"},
 		{name: "duration since anchors to explicit until", since: "14d",
 			until: "2026-04-10", wantFrom: "2026-03-27", wantTo: "2026-04-10"},
 		{name: "duration since anchors to duration until", since: "7d",

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -300,12 +300,52 @@ func TestResolveUsageWindow(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			from, to, err := resolveUsageWindow(tc.since, tc.until, now)
+			from, to, err := resolveUsageWindow(tc.since, tc.until, now, time.UTC)
 			if tc.wantErrSubstring != "" {
 				require.Error(t, err, "expected an error")
 				assert.Contains(t, err.Error(), tc.wantErrSubstring)
 				return
 			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantFrom, from, "from")
+			assert.Equal(t, tc.wantTo, to, "to")
+		})
+	}
+}
+
+func TestResolveUsageWindowUsesReportTimezone(t *testing.T) {
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	now := time.Date(2026, 4, 17, 19, 0, 0, 0, loc)
+
+	tests := []struct {
+		name             string
+		since, until     string
+		wantFrom, wantTo string
+	}{
+		{
+			name:     "duration since formats report local date",
+			since:    "1d",
+			wantFrom: "2026-04-16",
+		},
+		{
+			name:     "duration since anchors to until in report timezone",
+			since:    "1d",
+			until:    "2026-04-10",
+			wantFrom: "2026-04-09",
+			wantTo:   "2026-04-10",
+		},
+		{
+			name:     "explicit dates pass through unchanged",
+			since:    "2026-04-01",
+			until:    "2026-04-10",
+			wantFrom: "2026-04-01",
+			wantTo:   "2026-04-10",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			from, to, err := resolveUsageWindow(tc.since, tc.until, now, loc)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantFrom, from, "from")
 			assert.Equal(t, tc.wantTo, to, "to")

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -242,6 +242,72 @@ func TestRunUsageDailyUsesDiscoveredDaemon(t *testing.T) {
 	assertNoLocalSessionsDB(t, dataDir)
 }
 
+// TestRunUsageDailyResolvesDurationSince proves a duration --since (e.g.
+// "14d") is resolved to a concrete YYYY-MM-DD before it reaches the query
+// layer, not forwarded verbatim.
+func TestRunUsageDailyResolvesDurationSince(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+
+	var gotFrom string
+	ts := sessionUsageRuntimeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotFrom = r.URL.Query().Get("from")
+		assert.Equal(t, "true", r.URL.Query().Get("no_default_range"))
+		writeJSONResponse(w, sampleDailyUsageJSON)
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	_ = captureStdout(t, func() {
+		runUsageDaily(UsageDailyConfig{
+			JSON:     true,
+			Since:    "14d",
+			Timezone: "UTC",
+		})
+	})
+
+	// Exact date math is pinned by TestResolveWindowDate; here we only
+	// prove the duration resolved to a concrete date, not forwarded as
+	// "14d".
+	assert.NotEqual(t, "14d", gotFrom, "duration should be resolved, not forwarded")
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}$`, gotFrom,
+		"duration --since should resolve to a concrete YYYY-MM-DD date")
+	assertNoLocalSessionsDB(t, dataDir)
+}
+
+func TestResolveUsageWindow(t *testing.T) {
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name             string
+		since, until     string
+		wantFrom, wantTo string
+		wantErrSubstring string
+	}{
+		{name: "empty passes through"},
+		{name: "duration since anchors at now", since: "14d", wantFrom: "2026-04-04"},
+		{name: "dates pass through", since: "2026-04-01", until: "2026-04-10",
+			wantFrom: "2026-04-01", wantTo: "2026-04-10"},
+		{name: "equal bounds are a valid single day", since: "2026-04-10",
+			until: "2026-04-10", wantFrom: "2026-04-10", wantTo: "2026-04-10"},
+		{name: "garbage since", since: "7x", wantErrSubstring: "invalid --since"},
+		{name: "garbage until", until: "nope", wantErrSubstring: "invalid --until"},
+		{name: "inverted explicit window", since: "2026-06-20", until: "2026-06-13",
+			wantErrSubstring: "must not be after"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			from, to, err := resolveUsageWindow(tc.since, tc.until, now)
+			if tc.wantErrSubstring != "" {
+				require.Error(t, err, "expected an error")
+				assert.Contains(t, err.Error(), tc.wantErrSubstring)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantFrom, from, "from")
+			assert.Equal(t, tc.wantTo, to, "to")
+		})
+	}
+}
+
 func TestRunUsageDailyTableSkipsDaemonSessionCounts(t *testing.T) {
 	dataDir := newAgentDataDir(t)
 

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -284,6 +284,10 @@ func TestResolveUsageWindow(t *testing.T) {
 	}{
 		{name: "empty passes through"},
 		{name: "duration since anchors at now", since: "14d", wantFrom: "2026-04-04"},
+		{name: "duration since anchors to explicit until", since: "14d",
+			until: "2026-04-10", wantFrom: "2026-03-27", wantTo: "2026-04-10"},
+		{name: "duration since anchors to duration until", since: "7d",
+			until: "30d", wantFrom: "2026-03-12", wantTo: "2026-03-19"},
 		{name: "dates pass through", since: "2026-04-01", until: "2026-04-10",
 			wantFrom: "2026-04-01", wantTo: "2026-04-10"},
 		{name: "equal bounds are a valid single day", since: "2026-04-10",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -256,8 +256,8 @@ agentsview usage daily [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--json` | `false` | Emit JSON instead of a terminal table |
-| `--since` | `30 days ago` | Start date (`YYYY-MM-DD`), inclusive |
-| `--until` | | End date (`YYYY-MM-DD`), inclusive |
+| `--since` | `30 days ago` | Start of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive |
+| `--until` | | End of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive |
 | `--all` | `false` | Scan all history; overrides the default 30-day window |
 | `--agent` | | Filter by agent name |
 | `--breakdown` | `false` | Show indented per-model rows under each day |
@@ -270,6 +270,7 @@ agentsview usage daily [flags]
 ```bash
 agentsview usage daily                           # last 30 days
 agentsview usage daily --all                     # full history
+agentsview usage daily --since 14d               # last 14 days
 agentsview usage daily --since 2026-04-01 --breakdown
 agentsview usage daily --json --agent claude
 ```

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -461,8 +461,8 @@ agentsview usage daily [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--json` | `false` | Emit a JSON document instead of a table |
-| `--since` | `30 days ago` | Start date (`YYYY-MM-DD`), inclusive |
-| `--until` |  | End date (`YYYY-MM-DD`), inclusive |
+| `--since` | `30 days ago` | Start of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive |
+| `--until` |  | End of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive |
 | `--all` | `false` | Include all history; overrides the default 30-day window |
 | `--agent` |  | Filter by agent name (e.g. `claude`, `codex`) |
 | `--breakdown` | `false` | Show indented per-model sub-rows under each day |

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -343,6 +343,24 @@ func parseWindowPoint(s string, now time.Time) (time.Time, error) {
 	)
 }
 
+// ResolveWindowDate converts a window input — a compact "Nd"/"Nh" duration
+// or an absolute YYYY-MM-DD date — into a YYYY-MM-DD string the same way
+// stats' parseWindowPoint resolves a single bound: durations anchor at now,
+// dates stand alone. Empty input passes through so callers can apply their
+// own default range. Unparseable input is a hard error so `usage daily
+// --since 7d` fails loudly instead of silently producing an out-of-range
+// window.
+func ResolveWindowDate(s string, now time.Time) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	t, err := parseWindowPoint(s, now)
+	if err != nil {
+		return "", err
+	}
+	return t.UTC().Format("2006-01-02"), nil
+}
+
 // parseDurationShort recognises the compact "Nd" / "Nh" forms the
 // stats CLI advertises. Returns ok=false when s is not a compact
 // duration so callers can try the date path.

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -288,7 +288,7 @@ func windowBounds(
 ) (from, to time.Time, days int, err error) {
 	to = now
 	if f.Until != "" {
-		to, err = parseWindowPoint(f.Until, now)
+		to, err = ParseWindowPoint(f.Until, now)
 		if err != nil {
 			return time.Time{}, time.Time{}, 0,
 				fmt.Errorf("parsing until %q: %w", f.Until, err)
@@ -301,7 +301,7 @@ func windowBounds(
 		if d, ok := parseDurationShort(f.Since); ok {
 			from = to.Add(-d)
 		} else {
-			from, err = parseWindowPoint(f.Since, now)
+			from, err = ParseWindowPoint(f.Since, now)
 			if err != nil {
 				return time.Time{}, time.Time{}, 0,
 					fmt.Errorf(
@@ -328,10 +328,13 @@ func windowBounds(
 	return from, to, days, nil
 }
 
-// parseWindowPoint accepts either a duration-relative-to-now form
-// ("28d", "12h") or an absolute YYYY-MM-DD date (interpreted as
-// the start of that UTC day). Used by Since and Until.
-func parseWindowPoint(s string, now time.Time) (time.Time, error) {
+// ParseWindowPoint resolves a single window bound — a compact
+// duration-relative-to-now form ("28d", "12h") or an absolute YYYY-MM-DD
+// date (the start of that UTC day) — to an instant. A duration anchors at
+// now; passing a resolved bound as now lets a caller anchor a duration
+// against it (as usage daily anchors --since to --until). Shared by stats'
+// windowBounds and the usage CLI.
+func ParseWindowPoint(s string, now time.Time) (time.Time, error) {
 	if d, ok := parseDurationShort(s); ok {
 		return now.Add(-d), nil
 	}
@@ -341,24 +344,6 @@ func parseWindowPoint(s string, now time.Time) (time.Time, error) {
 	return time.Time{}, fmt.Errorf(
 		"expected Nd, Nh, or YYYY-MM-DD, got %q", s,
 	)
-}
-
-// ResolveWindowDate converts a window input — a compact "Nd"/"Nh" duration
-// or an absolute YYYY-MM-DD date — into a YYYY-MM-DD string the same way
-// stats' parseWindowPoint resolves a single bound: durations anchor at now,
-// dates stand alone. Empty input passes through so callers can apply their
-// own default range. Unparseable input is a hard error so `usage daily
-// --since 7d` fails loudly instead of silently producing an out-of-range
-// window.
-func ResolveWindowDate(s string, now time.Time) (string, error) {
-	if s == "" {
-		return "", nil
-	}
-	t, err := parseWindowPoint(s, now)
-	if err != nil {
-		return "", err
-	}
-	return t.UTC().Format("2006-01-02"), nil
 }
 
 // parseDurationShort recognises the compact "Nd" / "Nh" forms the

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -655,6 +655,42 @@ func TestWindowBounds(t *testing.T) {
 	})
 }
 
+func TestResolveWindowDate(t *testing.T) {
+	// Fixed reference time so duration math is deterministic.
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+
+	t.Run("empty passes through", func(t *testing.T) {
+		got, err := ResolveWindowDate("", now)
+		require.NoError(t, err, "ResolveWindowDate")
+		assert.Equal(t, "", got, "empty input")
+	})
+
+	t.Run("Nd duration anchors at now", func(t *testing.T) {
+		got, err := ResolveWindowDate("7d", now)
+		require.NoError(t, err, "ResolveWindowDate")
+		assert.Equal(t, "2026-04-11", got, "7d before 2026-04-18")
+	})
+
+	t.Run("Nh duration", func(t *testing.T) {
+		got, err := ResolveWindowDate("48h", now)
+		require.NoError(t, err, "ResolveWindowDate")
+		assert.Equal(t, "2026-04-16", got, "48h before 2026-04-18")
+	})
+
+	t.Run("bare date stands alone", func(t *testing.T) {
+		got, err := ResolveWindowDate("2026-04-01", now)
+		require.NoError(t, err, "ResolveWindowDate")
+		assert.Equal(t, "2026-04-01", got, "date passthrough")
+	})
+
+	t.Run("garbage is a hard error", func(t *testing.T) {
+		_, err := ResolveWindowDate("7x", now)
+		require.Error(t, err, "expected error for unparseable input")
+		assert.Contains(t, err.Error(), "Nd, Nh, or YYYY-MM-DD",
+			"error should name the accepted forms")
+	})
+}
+
 func TestGetSessionStats_Distributions(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -655,40 +655,36 @@ func TestWindowBounds(t *testing.T) {
 	})
 }
 
-func TestResolveWindowDate(t *testing.T) {
-	// Fixed reference time so duration math is deterministic.
+func TestParseWindowPoint(t *testing.T) {
 	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 
-	t.Run("empty passes through", func(t *testing.T) {
-		got, err := ResolveWindowDate("", now)
-		require.NoError(t, err, "ResolveWindowDate")
-		assert.Equal(t, "", got, "empty input")
-	})
-
-	t.Run("Nd duration anchors at now", func(t *testing.T) {
-		got, err := ResolveWindowDate("7d", now)
-		require.NoError(t, err, "ResolveWindowDate")
-		assert.Equal(t, "2026-04-11", got, "7d before 2026-04-18")
-	})
-
-	t.Run("Nh duration", func(t *testing.T) {
-		got, err := ResolveWindowDate("48h", now)
-		require.NoError(t, err, "ResolveWindowDate")
-		assert.Equal(t, "2026-04-16", got, "48h before 2026-04-18")
-	})
-
-	t.Run("bare date stands alone", func(t *testing.T) {
-		got, err := ResolveWindowDate("2026-04-01", now)
-		require.NoError(t, err, "ResolveWindowDate")
-		assert.Equal(t, "2026-04-01", got, "date passthrough")
-	})
-
-	t.Run("garbage is a hard error", func(t *testing.T) {
-		_, err := ResolveWindowDate("7x", now)
-		require.Error(t, err, "expected error for unparseable input")
-		assert.Contains(t, err.Error(), "Nd, Nh, or YYYY-MM-DD",
-			"error should name the accepted forms")
-	})
+	tests := []struct {
+		name             string
+		in               string
+		want             time.Time
+		wantErrSubstring string
+	}{
+		{name: "Nd duration anchors at now", in: "7d",
+			want: time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)},
+		{name: "Nh duration", in: "48h",
+			want: time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)},
+		{name: "bare date is start of UTC day", in: "2026-04-01",
+			want: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "garbage is a hard error", in: "7x",
+			wantErrSubstring: "Nd, Nh, or YYYY-MM-DD"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseWindowPoint(tc.in, now)
+			if tc.wantErrSubstring != "" {
+				require.Error(t, err, "expected an error")
+				assert.Contains(t, err.Error(), tc.wantErrSubstring)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, got.Equal(tc.want), "got %v want %v", got, tc.want)
+		})
+	}
 }
 
 func TestGetSessionStats_Distributions(t *testing.T) {


### PR DESCRIPTION
`agentsview usage daily --since/--until` accepted only `YYYY-MM-DD`. A `stats`-style duration like `7d` did not error; it flowed into the query as a malformed date and silently produced a wrong or empty window with exit 0. `stats` already accepted durations, so the two commands diverged and the `usage` path failed silently.

This resolves both bounds through a shared `db.ResolveWindowDate` (reusing the `stats` `parseWindowPoint` grammar) before the filter is built, so durations and dates work on both the direct-SQLite and daemon-HTTP paths. Unparseable input and an inverted explicit window (`--since` after `--until`) now fail loudly with a non-zero exit instead of returning silent empty output. Flag help and the `usage daily` docs are updated to match.

**Where to look:**

- `internal/db/session_stats.go` — `ResolveWindowDate`, the shared duration-or-date resolver built on the existing `stats` parser.
- `cmd/agentsview/usage.go` — `resolveUsageWindow` resolves `--until` first, anchors a duration `--since` to it, and rejects bad/inverted input; `runUsageDaily` exits non-zero on that error.
- `cmd/agentsview/cli.go`, `docs/commands.md`, `docs/token-usage.md` — help text and reference rows.

**Notes / limitations:**

- Resolution happens once at the CLI layer, so both storage backends get the same concrete date — no per-backend logic, preserving backend parity.
- A duration `--since` anchors to the resolved `--until` (or to `now` when `--until` is open), and dates stand alone — matching how `stats` resolves a window. So `--until 2026-04-10 --since 14d` yields the 14 days ending April 10.
- Scope is the `usage daily` CLI flags. The HTTP API, MCP `get_usage_summary`, and `usage cursor` still take dates only; extending duration sugar there is a separate API-design call.

Fixes #904
