### PR TITLE
fix(make): install binary via atomic rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Run shell script tests
         run: |
+          bash scripts/make_install_test.sh
           bash scripts/install_test.sh
           bash scripts/check_desktop_release_health_test.sh
           bash scripts/check_desktop_release_health_from_event_test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
 
       - name: Run shell script tests
         run: |
-          bash scripts/make_install_test.sh
           bash scripts/install_test.sh
           bash scripts/check_desktop_release_health_test.sh
           bash scripts/check_desktop_release_health_from_event_test.sh

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install: build-release
 	tmp="$$(mktemp "$$INSTALL_DIR/agentsview.tmp.XXXXXX")" || exit $$?; \
 	cleanup() { rm -f "$$tmp"; }; \
 	trap cleanup EXIT HUP INT TERM; \
-	cp agentsview "$$tmp" && mv -f "$$tmp" "$$INSTALL_DIR/agentsview"; \
+	cp agentsview "$$tmp" && chmod 755 "$$tmp" && mv -f "$$tmp" "$$INSTALL_DIR/agentsview"; \
 	status=$$?; \
 	trap - EXIT HUP INT TERM; \
 	cleanup; \

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,14 @@ build-release: pricing-snapshot frontend
 	CGO_ENABLED=1 go build -tags fts5 -ldflags="$(LDFLAGS_RELEASE)" -trimpath -o agentsview ./cmd/agentsview
 	@chmod +x agentsview
 
-# Install to ~/.local/bin, $GOBIN, or $GOPATH/bin
+# Install to ~/.local/bin, $GOBIN, or $GOPATH/bin.
+# Copy to a temp file in the destination directory, then rename into place.
+# Rename is atomic and produces a fresh inode, so overwriting the binary while
+# an old agentsview is still running does not leave the kernel validating exec
+# against stale code-signature pages (which SIGKILLs the new process on macOS).
 install: build-release
 	@if [ -d "$(HOME)/.local/bin" ]; then \
-		echo "Installing to ~/.local/bin/agentsview"; \
-		cp agentsview "$(HOME)/.local/bin/agentsview"; \
+		INSTALL_DIR="$(HOME)/.local/bin"; \
 	else \
 		INSTALL_DIR="$${GOBIN:-$$(go env GOBIN)}"; \
 		if [ -z "$$INSTALL_DIR" ]; then \
@@ -57,9 +60,10 @@ install: build-release
 			INSTALL_DIR="$$GOPATH_FIRST/bin"; \
 		fi; \
 		mkdir -p "$$INSTALL_DIR"; \
-		echo "Installing to $$INSTALL_DIR/agentsview"; \
-		cp agentsview "$$INSTALL_DIR/agentsview"; \
-	fi
+	fi; \
+	echo "Installing to $$INSTALL_DIR/agentsview"; \
+	cp agentsview "$$INSTALL_DIR/agentsview.tmp"; \
+	mv -f "$$INSTALL_DIR/agentsview.tmp" "$$INSTALL_DIR/agentsview"
 
 # Build frontend SPA and copy into embed directory
 frontend:

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,14 @@ install: build-release
 		mkdir -p "$$INSTALL_DIR"; \
 	fi; \
 	echo "Installing to $$INSTALL_DIR/agentsview"; \
-	cp agentsview "$$INSTALL_DIR/agentsview.tmp"; \
-	mv -f "$$INSTALL_DIR/agentsview.tmp" "$$INSTALL_DIR/agentsview"
+	tmp="$$(mktemp "$$INSTALL_DIR/agentsview.tmp.XXXXXX")" || exit $$?; \
+	cleanup() { rm -f "$$tmp"; }; \
+	trap cleanup EXIT HUP INT TERM; \
+	cp agentsview "$$tmp" && mv -f "$$tmp" "$$INSTALL_DIR/agentsview"; \
+	status=$$?; \
+	trap - EXIT HUP INT TERM; \
+	cleanup; \
+	exit $$status
 
 # Build frontend SPA and copy into embed directory
 frontend:

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -71,3 +71,5 @@ MOCK_CURL_EXIT=0
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]
+
+bash "$SCRIPT_DIR/make_install_test.sh"

--- a/scripts/make_install_test.sh
+++ b/scripts/make_install_test.sh
@@ -33,22 +33,22 @@ exit 1
 EOF
 chmod +x "$fakebin/go"
 
-recipe="$(
-    PATH="$fakebin:$PATH" HOME="$home" make -C "$REPO_ROOT" -n install |
+render_install_recipe() {
+    PATH="$fakebin:$PATH" HOME="$1" make -C "$REPO_ROOT" -n install |
         sed -n '/^if \[ -d /,$p'
-)"
+}
+
+recipe="$(render_install_recipe "$home")"
 
 [ -n "$recipe" ] || fail "could not extract install recipe"
-
-cp() {
-    printf 'partial binary\n' > "$2"
-    return 1
-}
-export -f cp
 
 set +e
 (
     cd "$work" || exit 1
+    cp() {
+        printf 'partial binary\n' > "$2"
+        return 1
+    }
     eval "$recipe"
 )
 status=$?
@@ -64,3 +64,32 @@ leftovers="$(find "$install_dir" -maxdepth 1 -type f -name 'agentsview.*' -print
 [ -z "$leftovers" ] || fail "temporary install files were not cleaned up: $leftovers"
 
 echo "PASS: install recipe keeps existing binary when copy fails"
+
+success_home="$tmpdir/success-home"
+success_work="$tmpdir/success-work"
+success_install_dir="$success_home/.local/bin"
+mkdir -p "$success_install_dir" "$success_work"
+printf 'old binary\n' > "$success_install_dir/agentsview"
+printf 'new binary\n' > "$success_work/agentsview"
+chmod 755 "$success_work/agentsview"
+
+success_recipe="$(render_install_recipe "$success_home")"
+[ -n "$success_recipe" ] || fail "could not extract success install recipe"
+
+(
+    cd "$success_work" || exit 1
+    eval "$success_recipe"
+)
+
+success_installed="$(cat "$success_install_dir/agentsview")"
+[ "$success_installed" = "new binary" ] ||
+    fail "successful install wrote unexpected content: $success_installed"
+
+[ -x "$success_install_dir/agentsview" ] ||
+    fail "successful install did not leave agentsview executable"
+
+success_leftovers="$(find "$success_install_dir" -maxdepth 1 -type f -name 'agentsview.*' -print)"
+[ -z "$success_leftovers" ] ||
+    fail "successful install left temporary files: $success_leftovers"
+
+echo "PASS: install recipe keeps installed binary executable"

--- a/scripts/make_install_test.sh
+++ b/scripts/make_install_test.sh
@@ -14,13 +14,27 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 home="$tmpdir/home"
 work="$tmpdir/work"
+fakebin="$tmpdir/bin"
 install_dir="$home/.local/bin"
-mkdir -p "$install_dir" "$work"
+mkdir -p "$install_dir" "$work" "$fakebin"
 printf 'old binary\n' > "$install_dir/agentsview"
 printf 'new binary\n' > "$work/agentsview"
+cat > "$fakebin/go" <<'EOF'
+#!/bin/sh
+if [ "$1" = "env" ] && [ "$2" = "GOPATH" ]; then
+    printf '%s\n' "$HOME/go"
+    exit 0
+fi
+if [ "$1" = "env" ] && [ "$2" = "GOBIN" ]; then
+    exit 0
+fi
+echo "unexpected go command: $*" >&2
+exit 1
+EOF
+chmod +x "$fakebin/go"
 
 recipe="$(
-    HOME="$home" make -C "$REPO_ROOT" -n install |
+    PATH="$fakebin:$PATH" HOME="$home" make -C "$REPO_ROOT" -n install |
         sed -n '/^if \[ -d /,$p'
 )"
 

--- a/scripts/make_install_test.sh
+++ b/scripts/make_install_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Behavioral tests for the Makefile install recipe.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+home="$tmpdir/home"
+work="$tmpdir/work"
+install_dir="$home/.local/bin"
+mkdir -p "$install_dir" "$work"
+printf 'old binary\n' > "$install_dir/agentsview"
+printf 'new binary\n' > "$work/agentsview"
+
+recipe="$(
+    HOME="$home" make -C "$REPO_ROOT" -n install |
+        sed -n '/^if \[ -d /,$p'
+)"
+
+[ -n "$recipe" ] || fail "could not extract install recipe"
+
+cp() {
+    printf 'partial binary\n' > "$2"
+    return 1
+}
+export -f cp
+
+set +e
+(
+    cd "$work" || exit 1
+    eval "$recipe"
+)
+status=$?
+set -e
+
+[ "$status" -ne 0 ] || fail "install recipe succeeded after cp failed"
+
+installed="$(cat "$install_dir/agentsview")"
+[ "$installed" = "old binary" ] ||
+    fail "failed copy replaced installed binary with: $installed"
+
+leftovers="$(find "$install_dir" -maxdepth 1 -type f -name 'agentsview.*' -print)"
+[ -z "$leftovers" ] || fail "temporary install files were not cleaned up: $leftovers"
+
+echo "PASS: install recipe keeps existing binary when copy fails"


### PR DESCRIPTION
## Problem

Running `agentsview` after a rebuild could die instantly with `zsh: killed` / exit 137 (SIGKILL), even for `agentsview --version`. The binary on disk is intact and its ad-hoc signature verifies, yet the kernel kills every exec of it.

Cause: `make install` overwrites the binary in place with `cp`, which truncates and rewrites the **same inode**. When a previous `agentsview` (e.g. a long-running `serve` / file watcher) is still running, macOS has the old binary's signed pages cached for that vnode. After the in-place overwrite the on-disk pages no longer match the cached cdhash, so the kernel refuses to exec the vnode and sends SIGKILL — with no log entry. Killing the old process or writing a fresh inode clears it.

## Fix

Install by copying to a temp file in the destination directory and then `mv`-ing it into place. Rename is atomic and produces a fresh inode, so an in-flight overwrite can never collide with a still-running process's cached code-signature pages.

The two install branches (`~/.local/bin` vs `$GOBIN`/`$GOPATH/bin`) are unified so both resolve `INSTALL_DIR` and then share the same copy+rename step.