### PR TITLE
fix(sync): show timed remote daemon progress

### DIFF
--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -199,16 +199,15 @@ func (p *remoteProgressPrinter) Print(progress sync.Progress) {
 		return
 	}
 	label := strings.TrimSpace(progress.Detail)
-	if label == "" && progress.SessionsTotal > 0 &&
-		(progress.Phase == sync.PhaseSyncing ||
-			progress.Phase == sync.PhaseDone) {
-		label = remoteLocalSyncProgressLabel
-		progress.Detail = label
-	}
 	if progress.Phase == sync.PhaseDone {
 		p.printFinalInPlaceProgress(progress)
 		p.finishCurrent()
 		return
+	}
+	if label == "" && progress.SessionsTotal > 0 &&
+		progress.Phase == sync.PhaseSyncing {
+		label = remoteLocalSyncProgressLabel
+		progress.Detail = label
 	}
 	if label == "" {
 		return

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -91,12 +91,12 @@ func doSync(cfg SyncConfig) (hadRemoteFailures bool) {
 			useDaemon := useDaemonForSync(tr)
 			if useDaemon && len(remoteHosts) > 0 {
 				fmt.Println("Running sync with remotes via daemon...")
-				onProgress, finishProgress := daemonProgressPrinter()
+				progress := newRemoteProgressPrinter(os.Stdout, time.Now)
 				failures, err := runDaemonRemoteSync(
 					context.Background(), tr, appCfg.AuthToken,
-					remoteHosts, cfg.Full, includeLocal, onProgress,
+					remoteHosts, cfg.Full, includeLocal, progress.Print,
 				)
-				finishProgress()
+				progress.Finish()
 				if err != nil {
 					fatal("daemon remote sync: %v", err)
 				}
@@ -177,41 +177,71 @@ func useDaemonForSync(tr transport) bool {
 	return true
 }
 
-func daemonProgressPrinter() (sync.ProgressFunc, func()) {
-	var resyncProgress *resyncProgressPrinter
-	var printedInline bool
-	onProgress := func(p sync.Progress) {
-		if p.Resync {
-			if printedInline {
-				fmt.Println()
-				printedInline = false
-			}
-			if resyncProgress == nil {
-				resyncProgress = newResyncProgressPrinter(os.Stdout, time.Now)
-			}
-			resyncProgress.Print(p)
-			return
-		}
-		if resyncProgress != nil {
-			resyncProgress.Finish()
-			resyncProgress = nil
-		}
-		if formatSyncProgress(p) != "" {
-			printedInline = true
-		}
-		printSyncProgress(p)
+type remoteProgressPrinter struct {
+	w        io.Writer
+	now      func() time.Time
+	label    string
+	started  time.Time
+	inPlace  bool
+	finished bool
+}
+
+func newRemoteProgressPrinter(
+	w io.Writer, now func() time.Time,
+) *remoteProgressPrinter {
+	return &remoteProgressPrinter{w: w, now: now}
+}
+
+func (p *remoteProgressPrinter) Print(progress sync.Progress) {
+	if p.finished {
+		return
 	}
-	finish := func() {
-		if resyncProgress != nil {
-			resyncProgress.Finish()
-			resyncProgress = nil
-		}
-		if printedInline {
-			fmt.Println()
-			printedInline = false
-		}
+	label := strings.TrimSpace(progress.Detail)
+	if label == "" {
+		return
 	}
-	return onProgress, finish
+	if strings.HasPrefix(label, "Synced ") {
+		p.finishCurrent()
+		fmt.Fprintf(p.w, "  %s\n", label)
+		return
+	}
+	if progress.Phase == sync.PhaseSyncing && progress.SessionsTotal > 0 {
+		if p.label != label {
+			p.finishCurrent()
+			p.label = label
+			p.started = p.now()
+		}
+		p.inPlace = true
+		fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
+		return
+	}
+	if p.label == label {
+		return
+	}
+	p.finishCurrent()
+	p.label = label
+	p.started = p.now()
+	p.inPlace = false
+	fmt.Fprintf(p.w, "  %s...\n", strings.TrimSuffix(label, "."))
+}
+
+func (p *remoteProgressPrinter) Finish() {
+	p.finished = true
+	p.finishCurrent()
+}
+
+func (p *remoteProgressPrinter) finishCurrent() {
+	if p.label == "" {
+		return
+	}
+	if p.inPlace {
+		fmt.Fprint(p.w, "\n")
+	}
+	elapsed := p.now().Sub(p.started).Round(time.Millisecond)
+	fmt.Fprintf(p.w, "  %s completed in %s\n", p.label, elapsed)
+	p.label = ""
+	p.started = time.Time{}
+	p.inPlace = false
 }
 
 // syncLocalAndRemotes runs the local sync, then the configured

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -186,6 +186,8 @@ type remoteProgressPrinter struct {
 	finished bool
 }
 
+const remoteLocalSyncProgressLabel = "Syncing local sessions"
+
 func newRemoteProgressPrinter(
 	w io.Writer, now func() time.Time,
 ) *remoteProgressPrinter {
@@ -197,6 +199,17 @@ func (p *remoteProgressPrinter) Print(progress sync.Progress) {
 		return
 	}
 	label := strings.TrimSpace(progress.Detail)
+	if label == "" && progress.SessionsTotal > 0 &&
+		(progress.Phase == sync.PhaseSyncing ||
+			progress.Phase == sync.PhaseDone) {
+		label = remoteLocalSyncProgressLabel
+		progress.Detail = label
+	}
+	if progress.Phase == sync.PhaseDone {
+		p.printFinalInPlaceProgress(progress)
+		p.finishCurrent()
+		return
+	}
 	if label == "" {
 		return
 	}
@@ -223,6 +236,18 @@ func (p *remoteProgressPrinter) Print(progress sync.Progress) {
 	p.started = p.now()
 	p.inPlace = false
 	fmt.Fprintf(p.w, "  %s...\n", strings.TrimSuffix(label, "."))
+}
+
+func (p *remoteProgressPrinter) printFinalInPlaceProgress(
+	progress sync.Progress,
+) {
+	if !p.inPlace || p.label == "" || progress.SessionsTotal == 0 {
+		return
+	}
+	if progress.Detail == "" {
+		progress.Detail = p.label
+	}
+	fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
 }
 
 func (p *remoteProgressPrinter) Finish() {

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -278,6 +278,52 @@ func TestResyncProgressPrinterRendersDoneProgressBeforeCompletion(t *testing.T) 
 		"\n  Syncing sessions into rebuilt database completed in 1s\n")
 }
 
+func TestRemoteProgressPrinterWritesTimedStepLines(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	var out bytes.Buffer
+	printer := newRemoteProgressPrinter(&out, clock)
+
+	printer.Print(agentsync.Progress{
+		Detail: "Resolving agent directories on devbox",
+	})
+	now = now.Add(150 * time.Millisecond)
+	printer.Print(agentsync.Progress{
+		Detail: "Downloading session data from devbox (3 agents)",
+	})
+	now = now.Add(2 * time.Second)
+	printer.Print(agentsync.Progress{
+		Phase:           agentsync.PhaseSyncing,
+		Detail:          "Processing sessions from devbox",
+		SessionsTotal:   10,
+		SessionsDone:    4,
+		MessagesIndexed: 40,
+	})
+	now = now.Add(350 * time.Millisecond)
+	printer.Print(agentsync.Progress{
+		Phase:           agentsync.PhaseSyncing,
+		Detail:          "Processing sessions from devbox",
+		SessionsTotal:   10,
+		SessionsDone:    10,
+		MessagesIndexed: 100,
+	})
+	now = now.Add(3 * time.Second)
+	printer.Print(agentsync.Progress{
+		Detail: "Synced 10 sessions from devbox (1 unchanged)",
+	})
+	printer.Finish()
+
+	got := out.String()
+	assert.Contains(t, got, "  Resolving agent directories on devbox...\n")
+	assert.Contains(t, got, "  Resolving agent directories on devbox completed in 150ms\n")
+	assert.Contains(t, got, "  Downloading session data from devbox (3 agents)...\n")
+	assert.Contains(t, got, "  Downloading session data from devbox (3 agents) completed in 2s\n")
+	assert.Contains(t, got, "\r  Processing sessions from devbox: 10/10 sessions (100%) · 100 messages\x1b[K")
+	assert.Contains(t, got, "\n  Processing sessions from devbox completed in 3.35s\n")
+	assert.Contains(t, got, "  Synced 10 sessions from devbox (1 unchanged)\n")
+	assert.True(t, strings.HasSuffix(got, "\n"), "remote progress should finish on a newline")
+}
+
 func TestRunLocalSyncUsesCallerContextForResync(t *testing.T) {
 	dataDir := t.TempDir()
 	dbPath := filepath.Join(dataDir, "sessions.db")

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -354,6 +354,35 @@ func TestRemoteProgressPrinterRendersLocalSyncProgressWithoutDetail(t *testing.T
 	assert.Contains(t, got, "  Resolving agent directories on devbox...\n")
 }
 
+func TestRemoteProgressPrinterKeepsResyncLabelOnDoneProgress(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	var out bytes.Buffer
+	printer := newRemoteProgressPrinter(&out, clock)
+
+	printer.Print(agentsync.Progress{
+		Phase:           agentsync.PhaseSyncing,
+		Detail:          "Syncing sessions into rebuilt database",
+		SessionsTotal:   10,
+		SessionsDone:    4,
+		MessagesIndexed: 40,
+		Resync:          true,
+	})
+	now = now.Add(250 * time.Millisecond)
+	printer.Print(agentsync.Progress{
+		Phase:           agentsync.PhaseDone,
+		SessionsTotal:   10,
+		SessionsDone:    10,
+		MessagesIndexed: 100,
+		Resync:          true,
+	})
+
+	got := out.String()
+	assert.Contains(t, got, "\r  Syncing sessions into rebuilt database: 10/10 sessions (100%) · 100 messages\x1b[K")
+	assert.NotContains(t, got, "\r  Syncing local sessions: 10/10 sessions (100%) · 100 messages\x1b[K")
+	assert.Contains(t, got, "\n  Syncing sessions into rebuilt database completed in 250ms\n")
+}
+
 func TestRunLocalSyncUsesCallerContextForResync(t *testing.T) {
 	dataDir := t.TempDir()
 	dbPath := filepath.Join(dataDir, "sessions.db")

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -324,6 +324,36 @@ func TestRemoteProgressPrinterWritesTimedStepLines(t *testing.T) {
 	assert.True(t, strings.HasSuffix(got, "\n"), "remote progress should finish on a newline")
 }
 
+func TestRemoteProgressPrinterRendersLocalSyncProgressWithoutDetail(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	var out bytes.Buffer
+	printer := newRemoteProgressPrinter(&out, clock)
+
+	printer.Print(agentsync.Progress{
+		Phase:           agentsync.PhaseSyncing,
+		SessionsTotal:   10,
+		SessionsDone:    4,
+		MessagesIndexed: 40,
+	})
+	now = now.Add(250 * time.Millisecond)
+	printer.Print(agentsync.Progress{
+		Phase:           agentsync.PhaseDone,
+		SessionsTotal:   10,
+		SessionsDone:    10,
+		MessagesIndexed: 100,
+	})
+	printer.Print(agentsync.Progress{
+		Detail: "Resolving agent directories on devbox",
+	})
+
+	got := out.String()
+	assert.Contains(t, got, "\r  Syncing local sessions: 4/10 sessions (40%) · 40 messages\x1b[K")
+	assert.Contains(t, got, "\r  Syncing local sessions: 10/10 sessions (100%) · 100 messages\x1b[K")
+	assert.Contains(t, got, "\n  Syncing local sessions completed in 250ms\n")
+	assert.Contains(t, got, "  Resolving agent directories on devbox...\n")
+}
+
 func TestRunLocalSyncUsesCallerContextForResync(t *testing.T) {
 	dataDir := t.TempDir()
 	dbPath := filepath.Join(dataDir, "sessions.db")


### PR DESCRIPTION
Remote sync through the daemon could look idle for most of the run because the CLI collapsed remote progress into an overwritten status line and left only the final summary visible. That made slow SSH, download, and processing phases hard to distinguish from a hang.

This changes the daemon-backed remote sync CLI output to keep each remote phase visible with elapsed time while preserving the inline session counter during active parsing. Reviewers should focus on the terminal-output behavior in `cmd/agentsview/sync.go`, since the daemon already emits the phase details and this change is intentionally scoped to CLI rendering.