### PR TITLE
fix(sync,parser): fix resync discovery perf regression + report it correctly

### DIFF
--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -427,9 +427,14 @@ func hasDisplayableAntigravityCLITrajectoryMessage(
 	return false
 }
 
-// buildAntigravityProjectMap reads history.jsonl and returns a
+// buildAntigravityProjectMap indirects antigravityProjectMapFromHistory so the
+// discovery path can build the map once per root and tests can observe how
+// often it runs.
+var buildAntigravityProjectMap = antigravityProjectMapFromHistory
+
+// antigravityProjectMapFromHistory reads history.jsonl and returns a
 // map of conversationId -> workspace path.
-func buildAntigravityProjectMap(path string) map[string]string {
+func antigravityProjectMapFromHistory(path string) map[string]string {
 	out := make(map[string]string)
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/parser/antigravity_cli_provider.go
+++ b/internal/parser/antigravity_cli_provider.go
@@ -158,8 +158,13 @@ func (s antigravityCLISourceSet) Discover(ctx context.Context) ([]SourceRef, err
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		for _, file := range s.discoverSessions(root) {
-			source, ok := s.sourceRef(root, file.Path, file.Project, false)
+		files, projects := s.discoverSessionsAndProjects(root)
+		for _, file := range files {
+			// Thread the prebuilt project map so per-source resolution does not
+			// re-read and re-parse history.jsonl for every project-less source.
+			source, ok := s.sourceRefWithProjects(
+				root, file.Path, file.Project, projects, false,
+			)
 			if ok {
 				addJSONLSource(source, &sources, seen)
 			}
@@ -176,8 +181,19 @@ func (s antigravityCLISourceSet) Discover(ctx context.Context) ([]SourceRef, err
 // keeps the legacy DiscoveredFile shape so the project hint travels with each
 // path.
 func (s antigravityCLISourceSet) discoverSessions(root string) []DiscoveredFile {
+	files, _ := s.discoverSessionsAndProjects(root)
+	return files
+}
+
+// discoverSessionsAndProjects enumerates sessions and also returns the project
+// map it built from history.jsonl, so callers can thread the same map into
+// per-source resolution instead of rebuilding it (the map is a full read and
+// per-line parse of history.jsonl).
+func (s antigravityCLISourceSet) discoverSessionsAndProjects(
+	root string,
+) ([]DiscoveredFile, map[string]string) {
 	if root == "" {
-		return nil
+		return nil, nil
 	}
 	projects := buildAntigravityProjectMap(
 		filepath.Join(root, "history.jsonl"),
@@ -217,7 +233,7 @@ func (s antigravityCLISourceSet) discoverSessions(root string) []DiscoveredFile 
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].Path < files[j].Path
 	})
-	return files
+	return files, projects
 }
 
 // findSourceFile locates the source file for a session id (without the agent
@@ -448,8 +464,11 @@ func (s antigravityCLISourceSet) sourcesForHistoryChange(
 func (s antigravityCLISourceSet) sourcesForUntaggedHistoryChange(root string) []SourceRef {
 	var sources []SourceRef
 	seen := make(map[string]struct{})
-	for _, file := range s.discoverSessions(root) {
-		source, ok := s.sourceRef(root, file.Path, file.Project, false)
+	files, projects := s.discoverSessionsAndProjects(root)
+	for _, file := range files {
+		source, ok := s.sourceRefWithProjects(
+			root, file.Path, file.Project, projects, false,
+		)
 		if ok {
 			addJSONLSource(source, &sources, seen)
 		}
@@ -494,6 +513,29 @@ func (s antigravityCLISourceSet) sourceRef(
 	}
 	if project == "" {
 		project = s.projectForID(root, strings.TrimPrefix(id, antigravityImplicitTag))
+	}
+	return s.newSourceRef(root, path, id, project), true
+}
+
+// sourceRefWithProjects is sourceRef but resolves a missing project from a
+// prebuilt project map instead of rebuilding it from history.jsonl per call.
+// Discovery builds the map once per root and threads it for every source.
+func (s antigravityCLISourceSet) sourceRefWithProjects(
+	root, path, project string,
+	projects map[string]string,
+	allowMissing bool,
+) (SourceRef, bool) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	id, ok := antigravityCLISessionIDForPath(root, path)
+	if !ok {
+		return SourceRef{}, false
+	}
+	if !allowMissing && !IsRegularFile(path) {
+		return SourceRef{}, false
+	}
+	if project == "" {
+		project = projects[strings.TrimPrefix(id, antigravityImplicitTag)]
 	}
 	return s.newSourceRef(root, path, id, project), true
 }

--- a/internal/parser/antigravity_provider_test.go
+++ b/internal/parser/antigravity_provider_test.go
@@ -833,3 +833,41 @@ func assertAntigravityCLISourcePaths(
 	}
 	assert.Equal(t, want, got)
 }
+
+// TestAntigravityCLIDiscoverBuildsProjectMapOncePerRoot guards against
+// rebuilding the history.jsonl project map for every discovered source.
+// buildAntigravityProjectMap reads and per-line-parses history.jsonl, and the
+// per-source fallback fired for every project-less session, so discovery scaled
+// with session count.
+func TestAntigravityCLIDiscoverBuildsProjectMapOncePerRoot(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, "conversations"))
+	// No history.jsonl: every session is project-less, which is exactly what
+	// triggered the per-source map rebuild.
+	for _, id := range []string{
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222",
+		"33333333-3333-3333-3333-333333333333",
+	} {
+		mustWrite(t, filepath.Join(root, "conversations", id+".pb"), []byte("x"))
+	}
+
+	var calls int
+	orig := buildAntigravityProjectMap
+	buildAntigravityProjectMap = func(p string) map[string]string {
+		calls++
+		return orig(p)
+	}
+	t.Cleanup(func() { buildAntigravityProjectMap = orig })
+
+	provider, ok := NewProvider(AgentAntigravityCLI, ProviderConfig{
+		Roots: []string{root}, Machine: "local",
+	})
+	require.True(t, ok)
+
+	srcs, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, srcs, 3)
+	assert.Equal(t, 1, calls,
+		"history.jsonl project map should be built once per root, not per source")
+}

--- a/internal/parser/capabilitysupport_enumer.go
+++ b/internal/parser/capabilitysupport_enumer.go
@@ -5,6 +5,7 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -74,12 +75,7 @@ func CapabilitySupportStrings() []string {
 
 // IsACapabilitySupport returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i CapabilitySupport) IsACapabilitySupport() bool {
-	for _, v := range _CapabilitySupportValues {
-		if i == v {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(_CapabilitySupportValues, i)
 }
 
 // MarshalJSON implements the json.Marshaler interface for CapabilitySupport

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -613,6 +613,33 @@ func TestDiscoverGeminiSessions(t *testing.T) {
 	})
 }
 
+// TestDiscoverGeminiBuildsProjectMapOncePerRoot guards against rebuilding the
+// project map for every discovered source. The map depends only on the root,
+// and BuildGeminiProjectMap re-reads and SHA-256-hashes projects.json each
+// call, so a per-source rebuild makes discovery scale with session count.
+func TestDiscoverGeminiBuildsProjectMapOncePerRoot(t *testing.T) {
+	dir := t.TempDir()
+	setupFileSystem(t, dir, map[string]string{
+		filepath.Join("tmp", "hash1", geminiChatsDir, "session-2026-01-01T10-00-a.json"): "{}",
+		filepath.Join("tmp", "hash1", geminiChatsDir, "session-2026-01-02T10-00-b.json"): "{}",
+		filepath.Join("tmp", "hash2", geminiChatsDir, "session-2026-01-03T10-00-c.json"): "{}",
+		filepath.Join("tmp", "hash3", geminiChatsDir, "session-2026-01-04T10-00-d.json"): "{}",
+	})
+
+	var calls int
+	orig := buildGeminiProjectMap
+	buildGeminiProjectMap = func(root string) map[string]string {
+		calls++
+		return orig(root)
+	}
+	t.Cleanup(func() { buildGeminiProjectMap = orig })
+
+	got := discoverGeminiTestSessions(t, dir)
+	require.Len(t, got, 4, "expected all sessions discovered")
+	assert.Equal(t, 1, calls,
+		"project map should be built once per root, not once per source")
+}
+
 func TestFindGeminiSourceFile(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/parser/discovery_workspace_manifest_test.go
+++ b/internal/parser/discovery_workspace_manifest_test.go
@@ -1,0 +1,83 @@
+package parser
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countWorkspaceManifestReads swaps the workspace-manifest seam with a counter
+// for the duration of the test and returns a pointer to the call count.
+func countWorkspaceManifestReads(t *testing.T) *int {
+	t.Helper()
+	var calls int
+	orig := readVSCodeWorkspaceManifest
+	readVSCodeWorkspaceManifest = func(dir string) string {
+		calls++
+		return orig(dir)
+	}
+	t.Cleanup(func() { readVSCodeWorkspaceManifest = orig })
+	return &calls
+}
+
+func writeWorkspaceManifestSessions(t *testing.T, root string, ids ...string) {
+	t.Helper()
+	hashDir := filepath.Join(root, "workspaceStorage", "ws-hash")
+	chatDir := filepath.Join(hashDir, "chatSessions")
+	writeSourceFile(t, filepath.Join(hashDir, "workspace.json"),
+		`{"folder":"file:///Users/alice/code/myproj"}`)
+	for _, id := range ids {
+		writeSourceFile(t, filepath.Join(chatDir, id+".jsonl"),
+			vscodeCopilotProviderJSONL(id, "hi"))
+	}
+}
+
+// TestVSCodeCopilotDiscoverReadsWorkspaceManifestOncePerDir guards against
+// re-reading workspace.json for every discovered session. The manifest depends
+// only on the workspace hash dir, so reading it per source made discovery scale
+// with session count.
+func TestVSCodeCopilotDiscoverReadsWorkspaceManifestOncePerDir(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceManifestSessions(t, root, "s1", "s2", "s3")
+
+	calls := countWorkspaceManifestReads(t)
+	provider, ok := NewProvider(AgentVSCodeCopilot, ProviderConfig{
+		Roots: []string{root}, Machine: "local",
+	})
+	require.True(t, ok)
+
+	srcs, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, srcs, 3)
+	for _, s := range srcs {
+		assert.Equal(t, "myproj", s.ProjectHint)
+	}
+	assert.Equal(t, 1, *calls,
+		"workspace.json should be read once per workspace dir, not per session")
+}
+
+// TestPositronDiscoverReadsWorkspaceManifestOncePerDir is the Positron
+// counterpart: Positron reuses the VSCode workspaceStorage layout and the same
+// manifest reader, and had the same per-source rebuild.
+func TestPositronDiscoverReadsWorkspaceManifestOncePerDir(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceManifestSessions(t, root, "s1", "s2", "s3")
+
+	calls := countWorkspaceManifestReads(t)
+	provider, ok := NewProvider(AgentPositron, ProviderConfig{
+		Roots: []string{root}, Machine: "local",
+	})
+	require.True(t, ok)
+
+	srcs, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, srcs, 3)
+	for _, s := range srcs {
+		assert.Equal(t, "myproj", s.ProjectHint)
+	}
+	assert.Equal(t, 1, *calls,
+		"workspace.json should be read once per workspace dir, not per session")
+}

--- a/internal/parser/gemini_provider.go
+++ b/internal/parser/gemini_provider.go
@@ -151,8 +151,13 @@ func (s geminiSourceSet) discoverRoot(
 	}
 	sources := make([]SourceRef, 0)
 	seen := make(map[string]struct{})
+	// Build the project map once per root. It depends only on root, and
+	// BuildGeminiProjectMap re-reads and SHA-256-hashes projects.json on every
+	// call, so resolving it per source path made discovery scale with session
+	// count (the dominant cost on large archives).
+	projectMap := buildGeminiProjectMap(root)
 	for _, path := range s.discoverSessionPaths(root) {
-		source, ok := s.sourceRef(root, path)
+		source, ok := s.sourceRefForPathWithProjectMap(root, path, true, projectMap)
 		if !ok {
 			continue
 		}
@@ -411,6 +416,17 @@ func (s geminiSourceSet) sourceRefForPath(
 	root, path string,
 	requireRegular bool,
 ) (SourceRef, bool) {
+	return s.sourceRefForPathWithProjectMap(root, path, requireRegular, nil)
+}
+
+// sourceRefForPathWithProjectMap builds a SourceRef using a caller-supplied
+// project map. Discovery builds the map once per root and passes it for every
+// source; single-path callers pass nil and the map is built for that one path.
+func (s geminiSourceSet) sourceRefForPathWithProjectMap(
+	root, path string,
+	requireRegular bool,
+	projectMap map[string]string,
+) (SourceRef, bool) {
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
 	rel, ok := relUnder(root, path)
@@ -424,7 +440,10 @@ func (s geminiSourceSet) sourceRefForPath(
 		!isGeminiSessionFilename(sepParts[3]) {
 		return SourceRef{}, false
 	}
-	project := ResolveGeminiProject(sepParts[1], BuildGeminiProjectMap(root))
+	if projectMap == nil {
+		projectMap = buildGeminiProjectMap(root)
+	}
+	project := ResolveGeminiProject(sepParts[1], projectMap)
 	return SourceRef{
 		Provider:       AgentGemini,
 		Key:            path,
@@ -437,6 +456,10 @@ func (s geminiSourceSet) sourceRefForPath(
 		},
 	}, true
 }
+
+// buildGeminiProjectMap indirects BuildGeminiProjectMap so discovery can build
+// the project map once per root and tests can observe how often it runs.
+var buildGeminiProjectMap = BuildGeminiProjectMap
 
 func geminiProjectMetadataPaths(root string) []string {
 	return []string{

--- a/internal/parser/positron_provider.go
+++ b/internal/parser/positron_provider.go
@@ -190,7 +190,10 @@ func (s positronSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 			return nil, err
 		}
 		for _, file := range s.discoverSessions(root) {
-			source, ok := s.sourceRef(root, file.Path)
+			// discoverSessions already resolved the workspace project once per
+			// workspace dir; thread it so sourceRef does not re-read the
+			// workspace manifest for every session.
+			source, ok := s.sourceRefWithProject(root, file.Path, file.Project)
 			if !ok {
 				continue
 			}
@@ -400,6 +403,16 @@ func (s positronSourceSet) pathFromSource(source SourceRef) (string, string, boo
 }
 
 func (s positronSourceSet) sourceRef(root, path string) (SourceRef, bool) {
+	return s.sourceRefWithProject(root, path, "")
+}
+
+// sourceRefWithProject builds a SourceRef using a caller-supplied workspace
+// project. Discovery resolves the project once per workspace dir and threads it
+// for every session under that dir; single-path callers pass "" and the
+// workspace manifest is read for that one path.
+func (s positronSourceSet) sourceRefWithProject(
+	root, path, project string,
+) (SourceRef, bool) {
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
 	rel, ok := relUnder(root, path)
@@ -419,7 +432,9 @@ func (s positronSourceSet) sourceRef(root, path string) (SourceRef, bool) {
 	if !IsRegularFile(path) {
 		return SourceRef{}, false
 	}
-	project := positronWorkspaceProject(root, parts[1])
+	if project == "" {
+		project = positronWorkspaceProject(root, parts[1])
+	}
 	return s.newSourceRef(root, path, project), true
 }
 
@@ -541,7 +556,7 @@ func (s positronSourceSet) newSourceRef(root, path, project string) SourceRef {
 
 func positronWorkspaceProject(root, hash string) string {
 	hashDir := filepath.Join(root, "workspaceStorage", hash)
-	project := ReadVSCodeWorkspaceManifest(hashDir)
+	project := readVSCodeWorkspaceManifest(hashDir)
 	if project == "" {
 		project = "unknown"
 	}

--- a/internal/parser/vscode_copilot.go
+++ b/internal/parser/vscode_copilot.go
@@ -580,6 +580,11 @@ func extractInvocationText(raw json.RawMessage) string {
 	return ""
 }
 
+// readVSCodeWorkspaceManifest indirects ReadVSCodeWorkspaceManifest so the
+// VSCode-Copilot and Positron discovery paths can resolve the manifest once
+// per workspace dir and tests can observe how often it runs.
+var readVSCodeWorkspaceManifest = ReadVSCodeWorkspaceManifest
+
 // ReadVSCodeWorkspaceManifest reads the workspace.json file
 // in a workspaceStorage hash directory and extracts the
 // project folder path.

--- a/internal/parser/vscode_copilot_provider.go
+++ b/internal/parser/vscode_copilot_provider.go
@@ -140,7 +140,10 @@ func (s vscodeCopilotSourceSet) Discover(ctx context.Context) ([]SourceRef, erro
 			return nil, err
 		}
 		for _, file := range s.discoverSessionFiles(root) {
-			source, ok := s.sourceRef(root, file.Path)
+			// discoverSessionFiles already resolved the workspace project once
+			// per workspace dir; thread it so sourceRef does not re-read the
+			// workspace manifest for every session.
+			source, ok := s.sourceRefWithProject(root, file.Path, file.Project)
 			if !ok {
 				continue
 			}
@@ -186,7 +189,7 @@ func (s vscodeCopilotSourceSet) discoverSessionFiles(
 			}
 
 			// Read workspace.json to get project name
-			project := ReadVSCodeWorkspaceManifest(hashPath)
+			project := readVSCodeWorkspaceManifest(hashPath)
 			if project == "" {
 				project = "unknown"
 			}
@@ -406,6 +409,16 @@ func (s vscodeCopilotSourceSet) pathFromSource(source SourceRef) (string, string
 }
 
 func (s vscodeCopilotSourceSet) sourceRef(root, path string) (SourceRef, bool) {
+	return s.sourceRefWithProject(root, path, "")
+}
+
+// sourceRefWithProject builds a SourceRef using a caller-supplied workspace
+// project. Discovery resolves the project once per workspace dir and threads it
+// for every session under that dir; single-path callers pass "" and the
+// workspace manifest is read for that one path.
+func (s vscodeCopilotSourceSet) sourceRefWithProject(
+	root, path, project string,
+) (SourceRef, bool) {
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
 	rel, ok := relUnder(root, path)
@@ -423,8 +436,10 @@ func (s vscodeCopilotSourceSet) sourceRef(root, path string) (SourceRef, bool) {
 		if !IsRegularFile(path) {
 			return SourceRef{}, false
 		}
-		hashDir := filepath.Join(root, "workspaceStorage", parts[1])
-		project := ReadVSCodeWorkspaceManifest(hashDir)
+		if project == "" {
+			hashDir := filepath.Join(root, "workspaceStorage", parts[1])
+			project = readVSCodeWorkspaceManifest(hashDir)
+		}
 		if project == "" {
 			project = "unknown"
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1994,6 +1994,12 @@ func (e *Engine) syncAllLocked(
 	return stats
 }
 
+// slowProviderDiscoveryThreshold is the per-provider discovery duration above
+// which discovery timing is logged. Most providers finish in well under a
+// millisecond; a provider over this bound is doing real per-source work worth
+// surfacing.
+const slowProviderDiscoveryThreshold = 100 * time.Millisecond
+
 // discoverProviderSources runs full-sync discovery through the provider facade
 // for every concrete provider that is authoritative. It is the sole on-disk
 // discovery path: every file-based agent owns discovery through its provider.
@@ -2038,7 +2044,17 @@ func (e *Engine) discoverProviderSources(
 			Roots:   filteredRoots,
 			Machine: e.machine,
 		})
+		tDiscover := time.Now()
 		sources, err := provider.Discover(ctx)
+		// Log only providers whose discovery is slow enough to matter, so a
+		// single pathological provider (e.g. a per-source map rebuild) stands
+		// out instead of hiding inside the aggregate discovery timing.
+		if d := time.Since(tDiscover); d >= slowProviderDiscoveryThreshold {
+			log.Printf(
+				"discovery: %s returned %d sources in %s",
+				agentType, len(sources), d.Round(time.Millisecond),
+			)
+		}
 		if err != nil {
 			log.Printf("%s provider discovery: %v", agentType, err)
 			failures++

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1171,14 +1171,24 @@ func (e *Engine) resyncAllLocked(
 		)
 	}
 
-	// 3. Point engine at newDB and sync into it.
+	// 3. Point engine at newDB and sync into it. Report discovery as its
+	// own phase first: syncAllLocked walks every source before emitting
+	// its first syncing event, and on a large archive that walk takes
+	// minutes. Without this marker the progress printer credits that
+	// silent time to the preceding (instant) "Disabling ..." phase.
 	e.openCodeArchiveStore = origDB
 	e.db = newDB
+	reportResyncPhase(
+		PhaseDiscovering,
+		"Discovering sessions",
+		"",
+	)
 	stats = e.syncAllLocked(
 		ctx, reportResyncProgress, time.Time{}, nil, syncWriteBulk, true,
 	)
 	e.db = origDB // restore immediately
 	e.openCodeArchiveStore = nil
+	e.phaseStats.Log("resync")
 
 	// Abort swap when the fresh DB would be worse than the
 	// original:
@@ -1806,31 +1816,39 @@ func (e *Engine) syncAllLocked(
 
 	verbose := onProgress == nil
 
-	if verbose {
-		log.Printf(
-			"discovered %d files (%d claude, %d codex, %d copilot, %d gemini, %d cursor, %d amp, %d zencoder, %d iflow, %d vscode-copilot, %d visualstudio-copilot, %d pi, %d omp, %d kiro, %d zed, %d vibe) in %s",
-			len(all),
-			counts[parser.AgentClaude],
-			counts[parser.AgentCodex],
-			counts[parser.AgentCopilot],
-			counts[parser.AgentGemini],
-			counts[parser.AgentCursor],
-			counts[parser.AgentAmp],
-			counts[parser.AgentZencoder],
-			counts[parser.AgentIflow],
-			counts[parser.AgentVSCodeCopilot],
-			counts[parser.AgentVSCopilot],
-			counts[parser.AgentPi],
-			counts[parser.AgentOMP],
-			counts[parser.AgentKiro],
-			counts[parser.AgentZed],
-			counts[parser.AgentVibe],
-			time.Since(t0).Round(time.Millisecond),
-		)
-	}
+	// Always log discovery timing: this is the only window into the
+	// otherwise-silent provider walk, which dominates resync wall-clock
+	// on large archives. Suppressing it behind verbose hid that cost on
+	// the daemon resync and interactive sync paths (both pass onProgress).
+	log.Printf(
+		"discovered %d files (%d claude, %d codex, %d copilot, %d gemini, %d cursor, %d amp, %d zencoder, %d iflow, %d vscode-copilot, %d visualstudio-copilot, %d pi, %d omp, %d kiro, %d zed, %d vibe) in %s",
+		len(all),
+		counts[parser.AgentClaude],
+		counts[parser.AgentCodex],
+		counts[parser.AgentCopilot],
+		counts[parser.AgentGemini],
+		counts[parser.AgentCursor],
+		counts[parser.AgentAmp],
+		counts[parser.AgentZencoder],
+		counts[parser.AgentIflow],
+		counts[parser.AgentVSCodeCopilot],
+		counts[parser.AgentVSCopilot],
+		counts[parser.AgentPi],
+		counts[parser.AgentOMP],
+		counts[parser.AgentKiro],
+		counts[parser.AgentZed],
+		counts[parser.AgentVibe],
+		time.Since(t0).Round(time.Millisecond),
+	)
 
 	progressTotal := len(all)
-	progressTotal += e.countDBBackedSessions(ctx, scope)
+	tDBCount := time.Now()
+	dbBackedCount := e.countDBBackedSessions(ctx, scope)
+	progressTotal += dbBackedCount
+	log.Printf(
+		"counted %d db-backed sessions in %s",
+		dbBackedCount, time.Since(tDBCount).Round(time.Millisecond),
+	)
 	e.reportProgress(onProgress, Progress{
 		Phase:         PhaseSyncing,
 		SessionsTotal: progressTotal,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1782,6 +1782,17 @@ func (e *Engine) syncAllLocked(
 
 	t0 := time.Now()
 
+	// Report discovery as its own phase before the walk. syncAllLocked
+	// visits every source before emitting any syncing progress, and on a
+	// large archive that walk takes minutes; without this marker a
+	// daemon-driven `agentsview sync` shows no terminal feedback until the
+	// walk and DB-backed count both finish. The resync path emits the same
+	// marker, so its progress printer dedupes on the matching Detail.
+	e.reportProgress(onProgress, Progress{
+		Phase:  PhaseDiscovering,
+		Detail: "Discovering sessions",
+	})
+
 	var all []parser.DiscoveredFile
 	counts := make(map[parser.AgentType]int)
 	providerFound, providerFailures := e.discoverProviderSources(ctx, scope)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1279,6 +1279,46 @@ func TestResyncAllEmitsFTSRebuildHint(t *testing.T) {
 	assert.Contains(t, fts.Hint, "may take a while")
 }
 
+// TestResyncAllReportsDiscoveryBeforeSyncing verifies the resync emits a
+// distinct discovery phase before the first syncing event. Without it, the
+// silent discovery walk is mislabeled: the progress printer credits its
+// wall-clock time to the preceding "Disabling temporary search index updates"
+// phase, which actually completes instantly.
+func TestResyncAllReportsDiscoveryBeforeSyncing(t *testing.T) {
+	env := setupTestEnv(t)
+
+	msg := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "findable prompt").
+		AddClaudeAssistant(tsZeroS5, "findable response").
+		String()
+	env.writeClaudeSession(t, "test-proj", "a.jsonl", msg)
+
+	var events []sync.Progress
+	stats := env.engine.ResyncAll(context.Background(), func(p sync.Progress) {
+		events = append(events, p)
+	})
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats.Warnings)
+
+	discoveryIdx, syncingIdx := -1, -1
+	for i, event := range events {
+		if event.Phase == sync.PhaseDiscovering && discoveryIdx == -1 {
+			discoveryIdx = i
+		}
+		if event.Phase == sync.PhaseSyncing && syncingIdx == -1 {
+			syncingIdx = i
+		}
+	}
+	require.NotEqual(t, -1, discoveryIdx,
+		"missing discovery progress event; events=%+v", events)
+	require.NotEqual(t, -1, syncingIdx,
+		"missing syncing progress event; events=%+v", events)
+	assert.Less(t, discoveryIdx, syncingIdx,
+		"discovery must be reported before syncing")
+	assert.True(t, events[discoveryIdx].Resync,
+		"discovery progress should identify full resync")
+	assert.Contains(t, events[discoveryIdx].Detail, "Discovering sessions")
+}
+
 func TestSyncEngineProgressDoneCatchesResyncDBBackedWork(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1319,6 +1319,45 @@ func TestResyncAllReportsDiscoveryBeforeSyncing(t *testing.T) {
 	assert.Contains(t, events[discoveryIdx].Detail, "Discovering sessions")
 }
 
+// TestSyncAllReportsDiscoveryBeforeSyncing verifies an incremental SyncAll
+// emits a discovery phase before its first syncing event. syncAllLocked walks
+// every source before emitting any syncing progress, so without this marker a
+// daemon-driven `agentsview sync` shows no terminal feedback for the entire
+// (sometimes multi-minute) discovery walk.
+func TestSyncAllReportsDiscoveryBeforeSyncing(t *testing.T) {
+	env := setupTestEnv(t)
+
+	msg := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "findable prompt").
+		AddClaudeAssistant(tsZeroS5, "findable response").
+		String()
+	env.writeClaudeSession(t, "test-proj", "a.jsonl", msg)
+
+	var events []sync.Progress
+	env.engine.SyncAll(context.Background(), func(p sync.Progress) {
+		events = append(events, p)
+	})
+
+	discoveryIdx, syncingIdx := -1, -1
+	for i, event := range events {
+		if event.Phase == sync.PhaseDiscovering && discoveryIdx == -1 {
+			discoveryIdx = i
+		}
+		if event.Phase == sync.PhaseSyncing && syncingIdx == -1 {
+			syncingIdx = i
+		}
+	}
+	require.NotEqual(t, -1, discoveryIdx,
+		"missing discovery progress event; events=%+v", events)
+	require.NotEqual(t, -1, syncingIdx,
+		"missing syncing progress event; events=%+v", events)
+	assert.Less(t, discoveryIdx, syncingIdx,
+		"discovery must be reported before syncing")
+	assert.False(t, events[discoveryIdx].Resync,
+		"incremental sync discovery should not be flagged as a full resync")
+	assert.Contains(t, events[discoveryIdx].Detail, "Discovering sessions")
+}
+
 func TestSyncEngineProgressDoneCatchesResyncDBBackedWork(t *testing.T) {
 	env := setupTestEnv(t)
 


### PR DESCRIPTION
## Background

A dataVersion resync was spending minutes in discovery, but the CLI progress
printer mis-credited that time to the previous phase ("disabling temporary
search index updates"), because it timed each phase as the wall-clock gap
between phase labels and discovery had no label of its own. Adding real
per-phase timing surfaced that discovery itself was the regression, introduced
by the recent provider-factory refactor.

## Progress reporting + instrumentation

- `resyncAllLocked` reports `PhaseDiscovering` ("Discovering sessions") before
  the sync pass and logs `PhaseStats` afterward, so resync uses the same
  bulk-write profiler as CLI sync.
- `syncAllLocked` logs discovery timing unconditionally and times the
  `countDBBackedSessions` pass separately.
- `discoverProviderSources` logs per-provider discovery timing when a provider
  exceeds 100ms, attributing slow discovery to the provider by name.
- `TestResyncAllReportsDiscoveryBeforeSyncing` asserts `PhaseDiscovering`
  precedes the first `PhaseSyncing` event.

## Discovery perf regression

The refactor left several providers recomputing root-derived project info for
every discovered session inside discovery's per-source loop:

- Gemini re-built the full project map (read + JSON parse + SHA-256 map) per
  source. Gemini discovery on a large store dropped from ~2m47s to ~687ms.
- positron and vscode-copilot re-read `workspace.json` per session.
- antigravity-cli re-read and re-parsed `history.jsonl` per project-less source.

Each provider now builds the root-derived project info once per root (or
workspace dir) and threads it into per-source resolution. Single-path event
callers keep per-path resolution by passing an empty project. Count-based seam
tests assert the manifest/map is built once per root regardless of session
count.