### PR TITLE
fix(import): include Claude.ai export attachments

### DIFF
--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -177,6 +177,18 @@ func upsertConversation(
 ) (importStatus, error) {
 	s := result.Session
 
+	msgs := make([]db.Message, len(result.Messages))
+	for i, m := range result.Messages {
+		msgs[i] = db.Message{
+			SessionID:     s.ID,
+			Ordinal:       m.Ordinal,
+			Role:          string(m.Role),
+			Content:       m.Content,
+			Timestamp:     m.Timestamp.UTC().Format(time.RFC3339Nano),
+			ContentLength: m.ContentLength,
+		}
+	}
+
 	existing, err := store.GetSession(ctx, s.ID)
 	if err != nil {
 		return importNew, fmt.Errorf("checking session: %w", err)
@@ -219,25 +231,20 @@ func upsertConversation(
 	if !isNew && existing != nil && existing.MessageCount == s.MessageCount {
 		newEnd := timeStr(s.EndedAt)
 		if ptrEqual(existing.EndedAt, newEnd) {
-			return importSkipped, nil
+			existingMsgs, err := store.GetAllMessages(ctx, s.ID)
+			if err != nil {
+				return importNew,
+					fmt.Errorf("loading existing messages: %w", err)
+			}
+			if sameMessages(existingMsgs, msgs) {
+				return importSkipped, nil
+			}
 		}
 	}
 
 	// Suspend FTS before first message-changing operation to
 	// avoid per-row trigger overhead during bulk work.
 	fts.suspend()
-
-	msgs := make([]db.Message, len(result.Messages))
-	for i, m := range result.Messages {
-		msgs[i] = db.Message{
-			SessionID:     s.ID,
-			Ordinal:       m.Ordinal,
-			Role:          string(m.Role),
-			Content:       m.Content,
-			Timestamp:     m.Timestamp.UTC().Format(time.RFC3339Nano),
-			ContentLength: m.ContentLength,
-		}
-	}
 
 	if err := store.ReplaceSessionMessages(s.ID, msgs); err != nil {
 		return importNew, fmt.Errorf("replacing messages: %w", err)
@@ -419,6 +426,22 @@ func ptrEqual(a, b *string) bool {
 		return false
 	}
 	return *a == *b
+}
+
+func sameMessages(existing, incoming []db.Message) bool {
+	if len(existing) != len(incoming) {
+		return false
+	}
+	for i := range existing {
+		if existing[i].Ordinal != incoming[i].Ordinal ||
+			existing[i].Role != incoming[i].Role ||
+			existing[i].Content != incoming[i].Content ||
+			existing[i].Timestamp != incoming[i].Timestamp ||
+			existing[i].ContentLength != incoming[i].ContentLength {
+			return false
+		}
+	}
+	return true
 }
 
 func strPtr(s string) *string {

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -83,6 +83,37 @@ const testConversationsWithAttachmentJSON = `[{
   ]
 }]`
 
+const testConversationsWithoutAttachmentJSON = `[{
+  "uuid": "import-test-002",
+  "name": "Attachment Chat",
+  "summary": "",
+  "created_at": "2026-02-02T09:00:00.000000Z",
+  "updated_at": "2026-02-02T09:15:00.000000Z",
+  "account": {"uuid":"acct-1"},
+  "chat_messages": [
+    {
+      "uuid":"m1",
+      "text":"Can you show me the config?",
+      "content":[{"type":"text","text":"Can you show me the config?"}],
+      "sender":"human",
+      "created_at":"2026-02-02T09:00:00.000000Z",
+      "updated_at":"2026-02-02T09:00:00.000000Z",
+      "attachments":[],
+      "files":[]
+    },
+    {
+      "uuid":"m2",
+      "text":"Sure, here it is.",
+      "content":[{"type":"text","text":"Sure, here it is."}],
+      "sender":"assistant",
+      "created_at":"2026-02-02T09:00:05.000000Z",
+      "updated_at":"2026-02-02T09:00:05.000000Z",
+      "attachments":[],
+      "files":[]
+    }
+  ]
+}]`
+
 func testDB(t *testing.T) *db.DB {
 	t.Helper()
 	d, err := db.Open(t.TempDir() + "/test.db")
@@ -132,6 +163,43 @@ func TestImportClaudeAIIncludesAttachmentContent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "Can you show me the config?", msgs[0].Content)
+	assert.Equal(
+		t,
+		"Sure, here it is.\n\n[Attachment: agent.yaml]\nmodel: claude-3.7\nmode: debug",
+		msgs[1].Content,
+	)
+}
+
+func TestImportClaudeAIReimportRefreshesAttachmentContent(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	stats, err := ImportClaudeAI(
+		ctx, d, strings.NewReader(testConversationsWithoutAttachmentJSON), nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Imported)
+
+	msgs, err := d.GetAllMessages(
+		ctx, "claude-ai:import-test-002",
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "Sure, here it is.", msgs[1].Content)
+
+	stats, err = ImportClaudeAI(
+		ctx, d, strings.NewReader(testConversationsWithAttachmentJSON), nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.Imported)
+	assert.Equal(t, 1, stats.Updated)
+	assert.Equal(t, 0, stats.Skipped)
+
+	msgs, err = d.GetAllMessages(
+		ctx, "claude-ai:import-test-002",
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
 	assert.Equal(
 		t,
 		"Sure, here it is.\n\n[Attachment: agent.yaml]\nmodel: claude-3.7\nmode: debug",

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -47,6 +47,42 @@ const testConversationsJSON = `[
   }
 ]`
 
+const testConversationsWithAttachmentJSON = `[{
+  "uuid": "import-test-002",
+  "name": "Attachment Chat",
+  "summary": "",
+  "created_at": "2026-02-02T09:00:00.000000Z",
+  "updated_at": "2026-02-02T09:15:00.000000Z",
+  "account": {"uuid":"acct-1"},
+  "chat_messages": [
+    {
+      "uuid":"m1",
+      "text":"Can you show me the config?",
+      "content":[{"type":"text","text":"Can you show me the config?"}],
+      "sender":"human",
+      "created_at":"2026-02-02T09:00:00.000000Z",
+      "updated_at":"2026-02-02T09:00:00.000000Z",
+      "attachments":[],
+      "files":[]
+    },
+    {
+      "uuid":"m2",
+      "text":"Sure, here it is.",
+      "content":[{"type":"text","text":"Sure, here it is."}],
+      "sender":"assistant",
+      "created_at":"2026-02-02T09:00:05.000000Z",
+      "updated_at":"2026-02-02T09:00:05.000000Z",
+      "attachments":[
+        {
+          "file_name":"agent.yaml",
+          "extracted_content":"model: claude-3.7\nmode: debug"
+        }
+      ],
+      "files":[]
+    }
+  ]
+}]`
+
 func testDB(t *testing.T) *db.DB {
 	t.Helper()
 	d, err := db.Open(t.TempDir() + "/test.db")
@@ -77,6 +113,30 @@ func TestImportClaudeAI(t *testing.T) {
 	msgs, err := d.GetAllMessages(ctx, "claude-ai:import-test-001")
 	require.NoError(t, err)
 	assert.Len(t, msgs, 2)
+}
+
+func TestImportClaudeAIIncludesAttachmentContent(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	stats, err := ImportClaudeAI(
+		ctx, d, strings.NewReader(testConversationsWithAttachmentJSON), nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Imported)
+	assert.Equal(t, 0, stats.Updated)
+
+	msgs, err := d.GetAllMessages(
+		ctx, "claude-ai:import-test-002",
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "Can you show me the config?", msgs[0].Content)
+	assert.Equal(
+		t,
+		"Sure, here it is.\n\n[Attachment: agent.yaml]\nmodel: claude-3.7\nmode: debug",
+		msgs[1].Content,
+	)
 }
 
 func TestImportClaudeAI_ReimportSkipsUnchanged(t *testing.T) {

--- a/internal/parser/claude_ai.go
+++ b/internal/parser/claude_ai.go
@@ -17,11 +17,12 @@ type claudeAIConversation struct {
 }
 
 type claudeAIMessage struct {
-	UUID      string          `json:"uuid"`
-	Text      string          `json:"text"`
-	Content   []claudeAIBlock `json:"content"`
-	Sender    string          `json:"sender"`
-	CreatedAt string          `json:"created_at"`
+	UUID        string               `json:"uuid"`
+	Text        string               `json:"text"`
+	Content     []claudeAIBlock      `json:"content"`
+	Sender      string               `json:"sender"`
+	CreatedAt   string               `json:"created_at"`
+	Attachments []claudeAIAttachment `json:"attachments"`
 }
 
 // claudeAIBlock represents a content block within a message.
@@ -46,6 +47,12 @@ type ClaudeAIExportParser interface {
 		r io.Reader,
 		onConversation func(ParseResult) error,
 	) error
+}
+
+// claudeAIAttachment holds content emitted by Claude attachments.
+type claudeAIAttachment struct {
+	FileName         string `json:"file_name"`
+	ExtractedContent string `json:"extracted_content"`
 }
 
 // ParseClaudeAIExport streams a Claude.ai conversations.json
@@ -97,21 +104,32 @@ func (p *claudeAIImportOnlyProvider) ParseClaudeAIExport(
 func assembleClaudeAIContent(
 	m claudeAIMessage,
 ) (content string, hasThinking bool) {
+	attachmentParts := buildClaudeAttachmentText(m.Attachments)
+
 	if len(m.Content) == 0 {
-		return m.Text, false
+		if len(attachmentParts) == 0 {
+			return m.Text, false
+		}
+
+		contentParts := make([]string, 0, 1+len(attachmentParts))
+		if m.Text != "" {
+			contentParts = append(contentParts, m.Text)
+		}
+		contentParts = append(contentParts, attachmentParts...)
+		return strings.Join(contentParts, "\n\n"), false
 	}
 
-	var parts []string
+	var contentParts []string
 	for _, b := range m.Content {
 		switch b.Type {
 		case "text":
 			if b.Text != "" {
-				parts = append(parts, b.Text)
+				contentParts = append(contentParts, b.Text)
 			}
 		case "thinking":
 			if b.Thinking != "" {
 				hasThinking = true
-				parts = append(parts,
+				contentParts = append(contentParts,
 					"[Thinking]\n"+b.Thinking+"\n[/Thinking]")
 			}
 			// tool_use, tool_result, voice_note, token_budget
@@ -119,10 +137,35 @@ func assembleClaudeAIContent(
 		}
 	}
 
-	if len(parts) == 0 {
-		return m.Text, hasThinking
+	if len(contentParts) == 0 {
+		if len(attachmentParts) == 0 {
+			return m.Text, hasThinking
+		}
+		if m.Text != "" {
+			contentParts = append(contentParts, m.Text)
+		}
 	}
-	return strings.Join(parts, "\n\n"), hasThinking
+
+	contentParts = append(contentParts, attachmentParts...)
+
+	return strings.Join(contentParts, "\n\n"), hasThinking
+}
+
+func buildClaudeAttachmentText(
+	attachments []claudeAIAttachment,
+) []string {
+	parts := make([]string, 0, len(attachments))
+	for _, a := range attachments {
+		if strings.TrimSpace(a.ExtractedContent) == "" {
+			continue
+		}
+		if a.FileName == "" {
+			parts = append(parts, a.ExtractedContent)
+			continue
+		}
+		parts = append(parts, "[Attachment: "+a.FileName+"]\n"+a.ExtractedContent)
+	}
+	return parts
 }
 
 func convertClaudeAIConversation(

--- a/internal/parser/claude_ai_test.go
+++ b/internal/parser/claude_ai_test.go
@@ -199,7 +199,7 @@ func TestParseClaudeAIExport_AttachmentContent(t *testing.T) {
 	}]`
 
 	var results []ParseResult
-	err := ParseClaudeAIExport(
+	err := parseClaudeAIExport(
 		strings.NewReader(input),
 		func(r ParseResult) error {
 			results = append(results, r)
@@ -257,7 +257,7 @@ func TestParseClaudeAIExport_AttachmentFallbackPaths(t *testing.T) {
 	}]`
 
 	var results []ParseResult
-	err := ParseClaudeAIExport(
+	err := parseClaudeAIExport(
 		strings.NewReader(input),
 		func(r ParseResult) error {
 			results = append(results, r)
@@ -321,7 +321,7 @@ func TestParseClaudeAIExport_IgnoredAttachments(t *testing.T) {
 	}]`
 
 	var results []ParseResult
-	err := ParseClaudeAIExport(
+	err := parseClaudeAIExport(
 		strings.NewReader(input),
 		func(r ParseResult) error {
 			results = append(results, r)
@@ -360,7 +360,7 @@ func TestParseClaudeAIExport_TextFallbackPreservesWhitespace(t *testing.T) {
 	}]`
 
 	var results []ParseResult
-	err := ParseClaudeAIExport(
+	err := parseClaudeAIExport(
 		strings.NewReader(input),
 		func(r ParseResult) error {
 			results = append(results, r)

--- a/internal/parser/claude_ai_test.go
+++ b/internal/parser/claude_ai_test.go
@@ -219,6 +219,68 @@ func TestParseClaudeAIExport_AttachmentContent(t *testing.T) {
 	)
 }
 
+func TestParseClaudeAIExport_AttachmentFallbackPaths(t *testing.T) {
+	input := `[{
+		"uuid": "conv-attachment-fallbacks",
+		"name": "Attachment Fallback Test",
+		"created_at": "2026-01-21T11:00:00.000000Z",
+		"updated_at": "2026-01-21T11:05:00.000000Z",
+		"account": {"uuid": "acct-1"},
+		"chat_messages": [
+			{
+				"uuid": "m1",
+				"text": "Top-level text survives.",
+				"content": [],
+				"sender": "assistant",
+				"created_at": "2026-01-21T11:00:00.000000Z",
+				"attachments": [
+					{
+						"extracted_content": "attachment with no filename"
+					}
+				]
+			},
+			{
+				"uuid": "m2",
+				"text": "Fallback text survives too.",
+				"content": [
+					{"type": "tool_use", "text": ""}
+				],
+				"sender": "assistant",
+				"created_at": "2026-01-21T11:01:00.000000Z",
+				"attachments": [
+					{
+						"extracted_content": "attachment after unsupported block"
+					}
+				]
+			}
+		]
+	}]`
+
+	var results []ParseResult
+	err := ParseClaudeAIExport(
+		strings.NewReader(input),
+		func(r ParseResult) error {
+			results = append(results, r)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	msgs := results[0].Messages
+	require.Len(t, msgs, 2)
+	assert.Equal(
+		t,
+		"Top-level text survives.\n\nattachment with no filename",
+		msgs[0].Content,
+	)
+	assert.Equal(
+		t,
+		"Fallback text survives too.\n\nattachment after unsupported block",
+		msgs[1].Content,
+	)
+}
+
 func TestParseClaudeAIExport_IgnoredAttachments(t *testing.T) {
 	input := `[{
 		"uuid": "conv-attachments-ignored",
@@ -247,7 +309,12 @@ func TestParseClaudeAIExport_IgnoredAttachments(t *testing.T) {
 				"attachments": [
 					{"file_name": "empty.txt", "extracted_content": ""},
 					{"file_name": "noop.txt", "extracted_content": "   "},
-					{"file_name": "missing.txt"}
+					{"file_name": "missing.txt"},
+					{
+						"file_name": "metadata.json",
+						"mime_type": "application/json",
+						"metadata": {"unexpected": "value"}
+					}
 				]
 			}
 		]
@@ -269,6 +336,8 @@ func TestParseClaudeAIExport_IgnoredAttachments(t *testing.T) {
 
 	assert.Equal(t, "User prompt", msgs[0].Content)
 	assert.Equal(t, "Response kept the same.", msgs[1].Content)
+	assert.NotContains(t, msgs[1].Content, "metadata.json")
+	assert.NotContains(t, msgs[1].Content, "unexpected")
 }
 
 func TestParseClaudeAIExport_TextFallbackPreservesWhitespace(t *testing.T) {

--- a/internal/parser/claude_ai_test.go
+++ b/internal/parser/claude_ai_test.go
@@ -172,6 +172,142 @@ func TestParseClaudeAIExport_ContentBlocks(t *testing.T) {
 	assert.True(t, msgs[1].HasThinking)
 }
 
+func TestParseClaudeAIExport_AttachmentContent(t *testing.T) {
+	input := `[{
+		"uuid": "conv-attachments",
+		"name": "Attachment Test",
+		"created_at": "2026-01-21T10:00:00.000000Z",
+		"updated_at": "2026-01-21T10:05:00.000000Z",
+		"account": {"uuid": "acct-1"},
+		"chat_messages": [
+			{
+				"uuid": "m1",
+				"text": "Here is the base idea.",
+				"content": [
+					{"type": "text", "text": "Here is the base idea."}
+				],
+				"sender": "assistant",
+				"created_at": "2026-01-21T10:00:00.000000Z",
+				"attachments": [
+					{
+						"file_name": "notes.md",
+						"extracted_content": "line one\nline two"
+					}
+				]
+			}
+		]
+	}]`
+
+	var results []ParseResult
+	err := ParseClaudeAIExport(
+		strings.NewReader(input),
+		func(r ParseResult) error {
+			results = append(results, r)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	msgs := results[0].Messages
+	require.Len(t, msgs, 1)
+
+	assert.Equal(
+		t,
+		"Here is the base idea.\n\n[Attachment: notes.md]\nline one\nline two",
+		msgs[0].Content,
+	)
+}
+
+func TestParseClaudeAIExport_IgnoredAttachments(t *testing.T) {
+	input := `[{
+		"uuid": "conv-attachments-ignored",
+		"name": "Attachment Ignore Test",
+		"created_at": "2026-01-22T10:00:00.000000Z",
+		"updated_at": "2026-01-22T10:05:00.000000Z",
+		"account": {"uuid": "acct-1"},
+		"chat_messages": [
+			{
+				"uuid": "m1",
+				"text": "User prompt",
+				"content": [
+					{"type": "text", "text": "User prompt"}
+				],
+				"sender": "human",
+				"created_at": "2026-01-22T10:00:00.000000Z"
+			},
+			{
+				"uuid": "m2",
+				"text": "Response kept the same.",
+				"content": [
+					{"type": "text", "text": "Response kept the same."}
+				],
+				"sender": "assistant",
+				"created_at": "2026-01-22T10:01:00.000000Z",
+				"attachments": [
+					{"file_name": "empty.txt", "extracted_content": ""},
+					{"file_name": "noop.txt", "extracted_content": "   "},
+					{"file_name": "missing.txt"}
+				]
+			}
+		]
+	}]`
+
+	var results []ParseResult
+	err := ParseClaudeAIExport(
+		strings.NewReader(input),
+		func(r ParseResult) error {
+			results = append(results, r)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	msgs := results[0].Messages
+	require.Len(t, msgs, 2)
+
+	assert.Equal(t, "User prompt", msgs[0].Content)
+	assert.Equal(t, "Response kept the same.", msgs[1].Content)
+}
+
+func TestParseClaudeAIExport_TextFallbackPreservesWhitespace(t *testing.T) {
+	input := `[{
+		"uuid": "conv-fallback",
+		"name": "Fallback Test",
+		"created_at": "2026-01-23T10:00:00.000000Z",
+		"updated_at": "2026-01-23T10:05:00.000000Z",
+		"account": {"uuid": "acct-1"},
+		"chat_messages": [
+			{
+				"uuid": "m1",
+				"text": "  keep surrounding whitespace  ",
+				"content": [],
+				"sender": "assistant",
+				"created_at": "2026-01-23T10:00:00.000000Z",
+				"attachments": []
+			}
+		]
+	}]`
+
+	var results []ParseResult
+	err := ParseClaudeAIExport(
+		strings.NewReader(input),
+		func(r ParseResult) error {
+			results = append(results, r)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].Messages, 1)
+	assert.Equal(
+		t,
+		"  keep surrounding whitespace  ",
+		results[0].Messages[0].Content,
+	)
+}
+
 func TestParseClaudeAIExport_EmptyArray(t *testing.T) {
 	var results []ParseResult
 	err := parseClaudeAIExport(


### PR DESCRIPTION
Claude.ai exports can include code suggestions and other text-bearing content in a message's `attachments` array, but the current import path only turns top-level text and supported `content` blocks into message content. That means a conversation can import successfully while the code the user expected to review never appears in agentsview, and reimporting the same archive still leaves old truncated messages behind because the unchanged-session skip path only looks at message count and `updated_at`.

The parser now decodes text-bearing Claude.ai attachments and appends recovered attachment content after the existing text and thinking assembly rules, while still ignoring empty or metadata-only attachment shapes. The importer also compares stored messages to the newly parsed output before taking the unchanged-session skip path, so reimporting an older Claude.ai archive repairs sessions that were previously missing attachment-backed content. There is no new database schema, general attachment UI, or ChatGPT import change.

The attachment follow-up comes from wesm's direction in https://github.com/kenn-io/agentsview/issues/254#issuecomment-4188824433, after PR https://github.com/kenn-io/agentsview/pull/258 shipped the base Claude.ai import path. Focused parser and importer tests cover fresh imports, same-archive reimports, the unlabeled and fallback attachment paths, and the negative space around plain text, thinking blocks, and unsupported attachments.

Fixes #254
