### PR TITLE
ci: group all GitHub Actions Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,8 @@
       "groupName": "GitHub Actions dependencies",
       "groupSlug": "github-actions-dependencies",
       "separateMajorMinor": false,
+      "separateMinorPatch": false,
+      "separateMultipleMinor": false,
       "separateMultipleMajor": false
     },
     {


### PR DESCRIPTION
Renovate already had a GitHub Actions package group, but grouped update branches can still be split by update type when the split controls are left at their defaults. That matters for the SHA-pinned workflow actions in this repo, where digest-style and version-style updates should land together instead of creating separate Renovate PRs.

This keeps the existing GitHub Actions group name and slug while making the remaining split behavior explicit, so future action updates stay grouped under the same dependency PR.

<sup>generated by a clanker</sup>