### PR TITLE
feat(insights): add in-page help affordance

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1152,6 +1152,8 @@
   "insights_page_scored_facts": "Scored facts",
   "insights_page_quality_patterns": "Quality Patterns",
   "insights_page_deterministic_counts": "Deterministic counts from persisted session signals for {range}.",
+  "insights_page_insights_help_intro": "Deterministic sections are computed from session data, while generated insights are separate context text.",
+  "insights_page_insights_help_docs": "Read Insights docs",
   "insights_page_could_not_load": "Could not load deterministic insights.",
   "insights_page_retry": "Retry",
   "insights_page_no_scored_data": "No scored quality data for this range.",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1124,6 +1124,8 @@
   "insights_page_scored_facts": "评分事实",
   "insights_page_quality_patterns": "质量模式",
   "insights_page_deterministic_counts": "基于 {range} 持久化会话信号的确定性统计。",
+  "insights_page_insights_help_intro": "确定性部分由会话数据计算得出，生成洞察是分开展示的说明文本。",
+  "insights_page_insights_help_docs": "查看 Insights 文档",
   "insights_page_could_not_load": "无法加载确定性洞察。",
   "insights_page_retry": "重试",
   "insights_page_no_scored_data": "此范围内无评分质量数据。",

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -2316,6 +2316,11 @@
       text-align: left;
     }
 
+    .section-heading p.insights-help {
+      justify-content: flex-start;
+      text-align: left;
+    }
+
     .summary-grid,
     .pattern-grid,
     .recommendation-list,

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -786,6 +786,17 @@
           </div>
           <h2 id="actions-title">{m.insights_page_deterministic_recommendations()}</h2>
         </div>
+        <p class="insights-help">
+          {m.insights_page_insights_help_intro()}
+          <a
+            href="https://www.agentsview.io/insights/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="insights-help-link"
+          >
+            {m.insights_page_insights_help_docs()}
+          </a>
+        </p>
       </div>
 
       {#if recommendations.length === 0}
@@ -1394,6 +1405,26 @@
 
   .section-heading.compact {
     align-items: center;
+  }
+
+  .section-heading p.insights-help {
+    max-width: 58ch;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 4px;
+    text-align: right;
+    line-height: 1.35;
+  }
+
+  .insights-help-link {
+    color: var(--accent-blue);
+  }
+
+  .insights-help-link:hover {
+    color: color-mix(in srgb, var(--accent-blue) 70%, var(--text-primary));
+    text-underline-offset: 2px;
   }
 
   .section-heading h2 {

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -254,7 +254,7 @@ describe("InsightsPage selected insight actions", () => {
     await tick();
 
     const helpBlock = document.querySelector("p.insights-help");
-    expect(helpBlock).toBeDefined();
+    expect(helpBlock).not.toBeNull();
     const helpText = helpBlock?.textContent ?? "";
     expect(
       helpText.includes("insights_page_insights_help_intro") ||
@@ -264,7 +264,7 @@ describe("InsightsPage selected insight actions", () => {
     const docsLink = document.querySelector<HTMLAnchorElement>(
       'a[href="https://www.agentsview.io/insights/"]',
     );
-    expect(docsLink).toBeDefined();
+    expect(docsLink).not.toBeNull();
     expect(
       (docsLink!.textContent?.includes("insights_page_insights_help_docs") ||
         docsLink!.textContent?.includes("Read Insights docs")),

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -249,6 +249,31 @@ describe("InsightsPage selected insight actions", () => {
     document.body.innerHTML = "";
   });
 
+  it("renders the deterministic-vs-generated insights help affordance", async () => {
+    component = mount(InsightsPage, { target: document.body });
+    await tick();
+
+    const helpBlock = document.querySelector("p.insights-help");
+    expect(helpBlock).toBeDefined();
+    const helpText = helpBlock?.textContent ?? "";
+    expect(
+      helpText.includes("insights_page_insights_help_intro") ||
+        helpText.includes("Deterministic sections are computed"),
+    ).toBe(true);
+
+    const docsLink = document.querySelector<HTMLAnchorElement>(
+      'a[href="https://www.agentsview.io/insights/"]',
+    );
+    expect(docsLink).toBeDefined();
+    expect(
+      (docsLink!.textContent?.includes("insights_page_insights_help_docs") ||
+        docsLink!.textContent?.includes("Read Insights docs")),
+    ).toBe(true);
+    expect(docsLink!.getAttribute("target")).toBe("_blank");
+    expect(docsLink!.getAttribute("rel")).toContain("noopener");
+    expect(docsLink!.getAttribute("rel")).toContain("noreferrer");
+  });
+
   it("exports the selected insight", async () => {
     component = mount(InsightsPage, { target: document.body });
     await tick();


### PR DESCRIPTION
The Insights page currently opens straight into filters, deterministic recommendations, quality patterns, and generated archives. That makes the page hard to interpret for first-time users even though the docs already explain the concepts and workflow.

This adds a small in-app help entry point that links to the Insights documentation and introduces the key distinction between deterministic quality facts and generated insight text. It keeps to the narrow docs/help slice `wesm` asked for in the issue thread, and it does not redesign the insights workflow, change generation behavior, or touch backend scoring.

The focused test asserts that the page exposes the docs URL and the explanatory affordance, and `npm run check` covers the localized message wiring.

Fixes #178
