### PR TITLE
fix(parser): support Visual Studio 2026 Copilot sessions

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1077,7 +1077,10 @@ func collectProviderWatchRoots(
 
 func isSymlinkPath(path string) bool {
 	info, err := os.Lstat(path)
-	return err == nil && info.Mode()&os.ModeSymlink != 0
+	if err != nil || info == nil {
+		return false
+	}
+	return info.Mode()&os.ModeSymlink != 0
 }
 
 func appendUniqueString(values []string, value string) []string {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1035,9 +1035,14 @@ func collectProviderWatchRoots(
 	added := false
 	var addedRoots []watchRoot
 	var missingRoots []string
+	var unwatchedDirs []string
 	for _, providerRoot := range plan.Roots {
 		root := filepath.Clean(providerRoot.Path)
 		if root == "" || root == "." {
+			continue
+		}
+		if providerRoot.Recursive && isSymlinkPath(root) {
+			unwatchedDirs = appendUniqueString(unwatchedDirs, dir)
 			continue
 		}
 		if _, err := os.Stat(root); err == nil {
@@ -1052,6 +1057,9 @@ func collectProviderWatchRoots(
 		missingRoots = append(missingRoots, root)
 	}
 	if !added {
+		if len(unwatchedDirs) > 0 {
+			return true, unwatchedDirs
+		}
 		return false, nil
 	}
 	// A watch target that does not exist yet but lives under an already-watched
@@ -1061,10 +1069,22 @@ func collectProviderWatchRoots(
 	// missing nested provider root.
 	for _, missing := range missingRoots {
 		if !pathCoveredByAnyWatchRootCreation(missing, addedRoots) {
-			return true, []string{dir}
+			unwatchedDirs = appendUniqueString(unwatchedDirs, dir)
 		}
 	}
-	return true, nil
+	return true, unwatchedDirs
+}
+
+func isSymlinkPath(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink != 0
+}
+
+func appendUniqueString(values []string, value string) []string {
+	if slices.Contains(values, value) {
+		return values
+	}
+	return append(values, value)
 }
 
 // pathCoveredByAnyWatchRootCreation reports whether path is covered by an

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -271,6 +271,26 @@ func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
 	assert.ElementsMatch(t, []string{sessionsDir, archivedDir}, roots[0].dirs)
 }
 
+func TestCollectWatchRootsPollsRecursiveSymlinkProviderRoot(t *testing.T) {
+	root := t.TempDir()
+	targetVSRoot := filepath.Join(t.TempDir(), "vs-target")
+	require.NoError(t, os.MkdirAll(targetVSRoot, 0o755))
+	requireSymlinkOrSkip(t, targetVSRoot, filepath.Join(root, ".VS"))
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVSCopilot: {root},
+		},
+	}
+
+	roots, unwatchedDirs := collectWatchRoots(cfg)
+
+	require.Len(t, roots, 1)
+	assert.Equal(t, root, roots[0].root)
+	assert.True(t, roots[0].shallow)
+	assert.Equal(t, []string{root}, roots[0].dirs)
+	assert.ElementsMatch(t, []string{root}, unwatchedDirs)
+}
+
 // fakeEmitter records Emit calls; safe for concurrent use.
 type fakeEmitter struct {
 	count atomic.Int64

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -274,7 +274,10 @@ func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
 func TestCollectWatchRootsPollsRecursiveSymlinkProviderRoot(t *testing.T) {
 	root := t.TempDir()
 	targetVSRoot := filepath.Join(t.TempDir(), "vs-target")
-	require.NoError(t, os.MkdirAll(targetVSRoot, 0o755))
+	sessionsRoot := filepath.Join(
+		targetVSRoot, "SampleApp", "copilot-chat", "thread", "sessions",
+	)
+	require.NoError(t, os.MkdirAll(sessionsRoot, 0o755))
 	requireSymlinkOrSkip(t, targetVSRoot, filepath.Join(root, ".VS"))
 	cfg := config.Config{
 		AgentDirs: map[parser.AgentType][]string{
@@ -284,10 +287,17 @@ func TestCollectWatchRootsPollsRecursiveSymlinkProviderRoot(t *testing.T) {
 
 	roots, unwatchedDirs := collectWatchRoots(cfg)
 
-	require.Len(t, roots, 1)
+	require.Len(t, roots, 2)
 	assert.Equal(t, root, roots[0].root)
 	assert.True(t, roots[0].shallow)
 	assert.Equal(t, []string{root}, roots[0].dirs)
+	assert.Equal(
+		t,
+		filepath.Join(root, ".VS", "SampleApp", "copilot-chat", "thread", "sessions"),
+		roots[1].root,
+	)
+	assert.True(t, roots[1].shallow)
+	assert.Equal(t, []string{root}, roots[1].dirs)
 	assert.ElementsMatch(t, []string{root}, unwatchedDirs)
 }
 

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -577,6 +577,34 @@ func TestVisualStudioCopilotProviderDeletesVS2026SessionTombstone(
 	assert.Empty(t, outcome.Results)
 }
 
+func TestVisualStudioCopilotProviderFindSourceRejectsMissingVS2026VirtualPath(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID:       conversationID,
+		StoredFilePath:     virtualPath,
+		FingerprintKey:     virtualPath,
+		RequireFreshSource: true,
+		PreferStoredSource: true,
+	})
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, found.DisplayPath)
+}
+
 func TestVisualStudioCopilotProviderRejectsOutsideVS2026SessionLayout(
 	t *testing.T,
 ) {

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -471,6 +471,58 @@ func TestVisualStudioCopilotProviderSupportsVS2026RootModes(
 	}
 }
 
+func TestVisualStudioCopilotProviderClassifiesMixedCaseVS2026Layout(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		root, ".VS", "SampleApp", "Copilot-Chat", "thread", "Sessions",
+		conversationID,
+	)
+	writeSourceFile(t, sessionPath, vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	)+"\n")
+
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+	cases := []struct {
+		name string
+		root string
+	}{
+		{name: "project root", root: root},
+		{name: ".vs root", root: filepath.Join(root, ".VS")},
+		{name: "copilot-chat root", root: filepath.Join(root, ".VS", "SampleApp", "Copilot-Chat")},
+		{name: "thread root", root: filepath.Join(root, ".VS", "SampleApp", "Copilot-Chat", "thread")},
+		{name: "sessions root", root: filepath.Join(root, ".VS", "SampleApp", "Copilot-Chat", "thread", "Sessions")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+				Roots: []string{tc.root},
+			})
+			require.True(t, ok)
+
+			changed, err := provider.SourcesForChangedPath(
+				context.Background(),
+				ChangedPathRequest{
+					Path:      sessionPath,
+					EventKind: "write",
+					WatchRoot: tc.root,
+				},
+			)
+			require.NoError(t, err)
+			require.Len(t, changed, 1)
+			assert.Equal(t, virtualPath, changed[0].DisplayPath)
+		})
+	}
+}
+
 func TestVisualStudioCopilotProviderCanonicalizesMixedLegacyAndVS2026Sources(
 	t *testing.T,
 ) {

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -569,6 +569,73 @@ func TestVisualStudioCopilotProviderDiscoversMixedCaseVS2026Layout(
 	assert.Equal(t, virtualPath, found.DisplayPath)
 }
 
+func TestVisualStudioCopilotProviderDiscoversSymlinkedVS2026Dirs(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	targetRoot := t.TempDir()
+	targetVSRoot := filepath.Join(targetRoot, "vs-data")
+	targetSolutionRoot := filepath.Join(targetVSRoot, "SampleApp")
+	targetCopilotChatRoot := filepath.Join(targetRoot, "chat-data")
+	targetThreadRoot := filepath.Join(targetCopilotChatRoot, "thread")
+	targetSessionsRoot := filepath.Join(targetRoot, "sessions-data")
+	require.NoError(t, os.MkdirAll(targetSolutionRoot, 0o755))
+	require.NoError(t, os.MkdirAll(targetThreadRoot, 0o755))
+	require.NoError(t, os.MkdirAll(targetSessionsRoot, 0o755))
+
+	vsRoot := filepath.Join(root, ".VS")
+	if err := os.Symlink(targetVSRoot, vsRoot); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	require.NoError(t, os.Symlink(
+		targetCopilotChatRoot,
+		filepath.Join(targetSolutionRoot, "Copilot-Chat"),
+	))
+	require.NoError(t, os.Symlink(
+		targetSessionsRoot,
+		filepath.Join(targetThreadRoot, "Sessions"),
+	))
+
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	writeSourceFile(t, filepath.Join(targetSessionsRoot, conversationID),
+		vsCopilotTraceLineJSON(
+			conversationID,
+			"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+			map[string]string{
+				"gen_ai.operation.name": "chat",
+				"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+			},
+		)+"\n")
+	sessionPath := filepath.Join(
+		vsRoot, "SampleApp", "Copilot-Chat", "thread", "Sessions",
+		conversationID,
+	)
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 2)
+	assert.Equal(t, vsRoot, plan.Roots[1].Path)
+	assert.True(t, plan.Roots[1].Recursive)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: conversationID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, found.DisplayPath)
+}
+
 func TestVisualStudioCopilotProviderCanonicalizesMixedLegacyAndVS2026Sources(
 	t *testing.T,
 ) {

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -417,6 +417,61 @@ func TestVisualStudioCopilotProviderCanonicalizesVS2026SessionFileIDCase(
 	)
 }
 
+func TestVisualStudioCopilotProviderTombstonesUppercaseVS2026SessionFileID(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		strings.ToUpper(conversationID),
+	)
+	writeSourceFile(t, sessionPath, vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	)+"\n")
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+
+	require.NoError(t, os.Remove(sessionPath))
+	deleted, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:              sessionPath,
+			EventKind:         "remove",
+			StoredSourcePaths: sourceDisplayPaths(discovered),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, deleted, 1)
+	assert.Equal(t, virtualPath, deleted[0].DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), deleted[0])
+	require.NoError(t, err)
+	assert.Equal(t, SourceFingerprint{Key: virtualPath}, fingerprint)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      deleted[0],
+		Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.True(t, outcome.ForceReplace)
+	assert.Equal(t, SkipNoSession, outcome.SkipReason)
+	assert.Empty(t, outcome.Results)
+}
+
 func TestVisualStudioCopilotProviderSupportsVS2026RootModes(
 	t *testing.T,
 ) {

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -752,6 +752,80 @@ func TestVisualStudioCopilotProviderDeletesVS2026SessionTombstone(
 	assert.Empty(t, outcome.Results)
 }
 
+func TestVisualStudioCopilotProviderRecanonicalizesDeletedVS2026Session(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	legacyPath := filepath.Join(
+		root,
+		"20260612T194439_257709a3_VSGitHubCopilot_traces.jsonl",
+	)
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	traceData := vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	) + "\n"
+	writeSourceFile(t, legacyPath, traceData)
+	writeSourceFile(t, sessionPath, traceData)
+
+	older := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(legacyPath, older, older))
+	require.NoError(t, os.Chtimes(sessionPath, newer, newer))
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	vsVirtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+	assert.Equal(t, vsVirtualPath, discovered[0].DisplayPath)
+
+	require.NoError(t, os.Remove(sessionPath))
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:              sessionPath,
+			EventKind:         "remove",
+			WatchRoot:         root,
+			StoredSourcePaths: []string{vsVirtualPath},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+
+	legacyVirtualPath := VisualStudioCopilotVirtualPath(legacyPath, conversationID)
+	assert.Equal(t, legacyVirtualPath, changed[0].DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), changed[0])
+	require.NoError(t, err)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      changed[0],
+		Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.True(t, outcome.ForceReplace)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(
+		t,
+		string(AgentVSCopilot)+":"+conversationID,
+		outcome.Results[0].Result.Session.ID,
+	)
+}
+
 func TestVisualStudioCopilotProviderFindSourceRejectsMissingVS2026VirtualPath(
 	t *testing.T,
 ) {

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -517,6 +517,66 @@ func TestVisualStudioCopilotProviderCanonicalizesMixedLegacyAndVS2026Sources(
 	assert.Equal(t, virtualPath, found.DisplayPath)
 }
 
+func TestVisualStudioCopilotProviderDeletesVS2026SessionTombstone(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	writeSourceFile(t, sessionPath, vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	)+"\n")
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+
+	require.NoError(t, os.Remove(sessionPath))
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:              sessionPath,
+			EventKind:         "remove",
+			WatchRoot:         root,
+			StoredSourcePaths: []string{virtualPath},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, virtualPath, changed[0].DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), changed[0])
+	require.NoError(t, err)
+	assert.Equal(t, SourceFingerprint{Key: virtualPath}, fingerprint)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      changed[0],
+		Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.True(t, outcome.ForceReplace,
+		"deleted VS 2026 session files must force-replace the archived member")
+	assert.Equal(t, SkipNoSession, outcome.SkipReason)
+	assert.Empty(t, outcome.Results)
+}
+
 func TestVisualStudioCopilotProviderRejectsOutsideVS2026SessionLayout(
 	t *testing.T,
 ) {

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -319,6 +319,136 @@ func TestVisualStudioCopilotProviderClassifiesDeletedTraceAndFansOutPhysicalTrac
 	assert.Equal(t, tracePath, deleted[0].DisplayPath)
 }
 
+func TestVisualStudioCopilotProviderSupportsVS2026RootModes(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	vsRoot := filepath.Join(root, ".vs")
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		vsRoot, "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	traceData := vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	) + "\n"
+	writeSourceFile(t, sessionPath, traceData)
+
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+	cases := []struct {
+		name string
+		root string
+	}{
+		{name: "project root", root: root},
+		{name: ".vs root", root: vsRoot},
+		{name: "copilot-chat root", root: filepath.Join(vsRoot, "SampleApp", "copilot-chat")},
+		{name: "thread root", root: filepath.Join(vsRoot, "SampleApp", "copilot-chat", "thread")},
+		{name: "sessions root", root: filepath.Join(vsRoot, "SampleApp", "copilot-chat", "thread", "sessions")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+				Roots: []string{tc.root},
+			})
+			require.True(t, ok)
+
+			discovered, err := provider.Discover(context.Background())
+			require.NoError(t, err)
+			require.Len(t, discovered, 1)
+			assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+
+			found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+				RawSessionID: conversationID,
+			})
+			require.NoError(t, err)
+			require.True(t, ok)
+			assert.Equal(t, virtualPath, found.DisplayPath)
+
+			changed, err := provider.SourcesForChangedPath(
+				context.Background(),
+				ChangedPathRequest{
+					Path:      sessionPath,
+					EventKind: "write",
+					WatchRoot: tc.root,
+				},
+			)
+			require.NoError(t, err)
+			require.Len(t, changed, 1)
+			assert.Equal(t, virtualPath, changed[0].DisplayPath)
+
+			fingerprint, err := provider.Fingerprint(context.Background(), changed[0])
+			require.NoError(t, err)
+			assert.Equal(t, virtualPath, fingerprint.Key)
+			assert.Positive(t, fingerprint.Size)
+			assert.Positive(t, fingerprint.MTimeNS)
+			assert.NotEmpty(t, fingerprint.Hash)
+
+			parseOutcome, err := provider.Parse(context.Background(), ParseRequest{
+				Source:      changed[0],
+				Fingerprint: fingerprint,
+			})
+			require.NoError(t, err)
+			require.True(t, parseOutcome.ForceReplace)
+			require.Len(t, parseOutcome.Results, 1)
+			assert.Equal(t, "visualstudio-copilot:"+conversationID,
+				parseOutcome.Results[0].Result.Session.ID)
+			assert.Equal(t, virtualPath,
+				parseOutcome.Results[0].Result.Session.File.Path)
+			assert.Equal(t, fingerprint.Hash,
+				parseOutcome.Results[0].Result.Session.File.Hash)
+			assert.Equal(t, fingerprint.Size,
+				parseOutcome.Results[0].Result.Session.File.Size)
+			assert.Equal(t, fingerprint.MTimeNS,
+				parseOutcome.Results[0].Result.Session.File.Mtime)
+		})
+	}
+}
+
+func TestVisualStudioCopilotProviderRejectsOutsideVS2026SessionLayout(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "8e5bb2d4-ef8e-4a90-a1f2-3d3d4d6fc9e9"
+	invalidPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "transcripts",
+		conversationID,
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(invalidPath), 0o755))
+	writeSourceFile(t, invalidPath, vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	)+"\n")
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:      invalidPath,
+			EventKind: "write",
+			WatchRoot: root,
+		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, discovered)
+}
+
 func vscodeCopilotProviderJSON(sessionID, prompt string) string {
 	return `{"version":3,"sessionId":"` + sessionID + `","creationDate":1770650022790,"requests":[{"requestId":"req1","timestamp":1770650031889,"message":{"text":"` + prompt + `","parts":[]},"response":[{"value":"Hi from VS Code"}],"modelId":"copilot/gpt-4o"}]}`
 }

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -312,11 +313,56 @@ func TestVisualStudioCopilotProviderClassifiesDeletedTraceAndFansOutPhysicalTrac
 	require.NoError(t, os.Remove(tracePath))
 	deleted, err := provider.SourcesForChangedPath(
 		context.Background(),
-		ChangedPathRequest{Path: tracePath, EventKind: "remove"},
+		ChangedPathRequest{
+			Path:              tracePath,
+			EventKind:         "remove",
+			StoredSourcePaths: sourceDisplayPaths(discovered),
+		},
 	)
 	require.NoError(t, err)
 	require.Len(t, deleted, 1)
 	assert.Equal(t, tracePath, deleted[0].DisplayPath)
+}
+
+func TestVisualStudioCopilotProviderTombstonesDeletedVS2026SessionFile(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	writeSourceFile(t, sessionPath, vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	)+"\n")
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+
+	require.NoError(t, os.Remove(sessionPath))
+	deleted, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:              sessionPath,
+			EventKind:         "remove",
+			StoredSourcePaths: sourceDisplayPaths(discovered),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, deleted, 1)
+	assert.Equal(t, virtualPath, deleted[0].DisplayPath)
 }
 
 func TestVisualStudioCopilotProviderSupportsVS2026RootModes(
@@ -357,6 +403,21 @@ func TestVisualStudioCopilotProviderSupportsVS2026RootModes(
 				Roots: []string{tc.root},
 			})
 			require.True(t, ok)
+
+			plan, err := provider.WatchPlan(context.Background())
+			require.NoError(t, err)
+			switch tc.name {
+			case "project root":
+				require.Len(t, plan.Roots, 2)
+				assert.Equal(t, root, plan.Roots[0].Path)
+				assert.False(t, plan.Roots[0].Recursive)
+				assert.Equal(t, vsRoot, plan.Roots[1].Path)
+				assert.True(t, plan.Roots[1].Recursive)
+			default:
+				require.Len(t, plan.Roots, 1)
+				assert.Equal(t, tc.root, plan.Roots[0].Path)
+				assert.True(t, plan.Roots[0].Recursive)
+			}
 
 			discovered, err := provider.Discover(context.Background())
 			require.NoError(t, err)
@@ -410,6 +471,52 @@ func TestVisualStudioCopilotProviderSupportsVS2026RootModes(
 	}
 }
 
+func TestVisualStudioCopilotProviderCanonicalizesMixedLegacyAndVS2026Sources(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	legacyPath := filepath.Join(
+		root,
+		"20260612T194439_257709a3_VSGitHubCopilot_traces.jsonl",
+	)
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	traceData := vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	) + "\n"
+	writeSourceFile(t, legacyPath, traceData)
+	writeSourceFile(t, sessionPath, traceData)
+
+	older := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(legacyPath, older, older))
+	require.NoError(t, os.Chtimes(sessionPath, newer, newer))
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: conversationID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, found.DisplayPath)
+}
+
 func TestVisualStudioCopilotProviderRejectsOutsideVS2026SessionLayout(
 	t *testing.T,
 ) {
@@ -444,6 +551,45 @@ func TestVisualStudioCopilotProviderRejectsOutsideVS2026SessionLayout(
 	)
 	require.NoError(t, err)
 	assert.Empty(t, changed)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, discovered)
+}
+
+func TestVisualStudioCopilotProviderRejectsNonGUIDVS2026SessionFileNames(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	invalidName := "not-a-guid"
+	invalidPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		invalidName,
+	)
+	writeSourceFile(t, invalidPath, vsCopilotTraceLineJSON(
+		"5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20",
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	)+"\n")
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:      invalidPath,
+			EventKind: "write",
+			WatchRoot: root,
+		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, discovered)

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -365,6 +365,58 @@ func TestVisualStudioCopilotProviderTombstonesDeletedVS2026SessionFile(
 	assert.Equal(t, virtualPath, deleted[0].DisplayPath)
 }
 
+func TestVisualStudioCopilotProviderCanonicalizesVS2026SessionFileIDCase(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	upperID := strings.ToUpper(conversationID)
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		upperID,
+	)
+	traceData := vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	) + "\n"
+	legacyPath := filepath.Join(
+		root,
+		"20260612T194439_257709a3_VSGitHubCopilot_traces.jsonl",
+	)
+	writeSourceFile(t, legacyPath, traceData)
+	writeSourceFile(t, sessionPath, traceData)
+	older := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(legacyPath, older, older))
+	require.NoError(t, os.Chtimes(sessionPath, newer, newer))
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      discovered[0],
+		Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t,
+		"visualstudio-copilot:"+conversationID,
+		outcome.Results[0].Result.Session.ID,
+	)
+}
+
 func TestVisualStudioCopilotProviderSupportsVS2026RootModes(
 	t *testing.T,
 ) {

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -408,15 +408,23 @@ func TestVisualStudioCopilotProviderSupportsVS2026RootModes(
 			require.NoError(t, err)
 			switch tc.name {
 			case "project root":
-				require.Len(t, plan.Roots, 2)
+				require.Len(t, plan.Roots, 3)
 				assert.Equal(t, root, plan.Roots[0].Path)
 				assert.False(t, plan.Roots[0].Recursive)
 				assert.Equal(t, vsRoot, plan.Roots[1].Path)
 				assert.True(t, plan.Roots[1].Recursive)
-			default:
+				assert.Equal(t, filepath.Dir(sessionPath), plan.Roots[2].Path)
+				assert.False(t, plan.Roots[2].Recursive)
+			case "sessions root":
 				require.Len(t, plan.Roots, 1)
 				assert.Equal(t, tc.root, plan.Roots[0].Path)
+				assert.False(t, plan.Roots[0].Recursive)
+			default:
+				require.Len(t, plan.Roots, 2)
+				assert.Equal(t, tc.root, plan.Roots[0].Path)
 				assert.True(t, plan.Roots[0].Recursive)
+				assert.Equal(t, filepath.Dir(sessionPath), plan.Roots[1].Path)
+				assert.False(t, plan.Roots[1].Recursive)
 			}
 
 			discovered, err := provider.Discover(context.Background())
@@ -550,11 +558,13 @@ func TestVisualStudioCopilotProviderDiscoversMixedCaseVS2026Layout(
 
 	plan, err := provider.WatchPlan(context.Background())
 	require.NoError(t, err)
-	require.Len(t, plan.Roots, 2)
+	require.Len(t, plan.Roots, 3)
 	assert.Equal(t, root, plan.Roots[0].Path)
 	assert.False(t, plan.Roots[0].Recursive)
 	assert.Equal(t, vsRoot, plan.Roots[1].Path)
 	assert.True(t, plan.Roots[1].Recursive)
+	assert.Equal(t, filepath.Dir(sessionPath), plan.Roots[2].Path)
+	assert.False(t, plan.Roots[2].Recursive)
 
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
@@ -629,9 +639,11 @@ func TestVisualStudioCopilotProviderDiscoversSymlinkedVS2026Dirs(
 
 	plan, err := provider.WatchPlan(context.Background())
 	require.NoError(t, err)
-	require.Len(t, plan.Roots, 2)
+	require.Len(t, plan.Roots, 3)
 	assert.Equal(t, vsRoot, plan.Roots[1].Path)
 	assert.True(t, plan.Roots[1].Recursive)
+	assert.Equal(t, filepath.Dir(sessionPath), plan.Roots[2].Path)
+	assert.False(t, plan.Roots[2].Recursive)
 
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -523,6 +523,52 @@ func TestVisualStudioCopilotProviderClassifiesMixedCaseVS2026Layout(
 	}
 }
 
+func TestVisualStudioCopilotProviderDiscoversMixedCaseVS2026Layout(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	vsRoot := filepath.Join(root, ".VS")
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		vsRoot, "SampleApp", "Copilot-Chat", "thread", "Sessions",
+		conversationID,
+	)
+	writeSourceFile(t, sessionPath, vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	)+"\n")
+
+	provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	virtualPath := VisualStudioCopilotVirtualPath(sessionPath, conversationID)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 2)
+	assert.Equal(t, root, plan.Roots[0].Path)
+	assert.False(t, plan.Roots[0].Recursive)
+	assert.Equal(t, vsRoot, plan.Roots[1].Path)
+	assert.True(t, plan.Roots[1].Recursive)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+
+	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: conversationID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, found.DisplayPath)
+}
+
 func TestVisualStudioCopilotProviderCanonicalizesMixedLegacyAndVS2026Sources(
 	t *testing.T,
 ) {

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -575,11 +575,13 @@ func TestVisualStudioCopilotProviderDiscoversSymlinkedVS2026Dirs(
 	root := t.TempDir()
 	targetRoot := t.TempDir()
 	targetVSRoot := filepath.Join(targetRoot, "vs-data")
-	targetSolutionRoot := filepath.Join(targetVSRoot, "SampleApp")
+	targetSolutionRoot := filepath.Join(targetRoot, "solution-data")
 	targetCopilotChatRoot := filepath.Join(targetRoot, "chat-data")
-	targetThreadRoot := filepath.Join(targetCopilotChatRoot, "thread")
+	targetThreadRoot := filepath.Join(targetRoot, "thread-data")
 	targetSessionsRoot := filepath.Join(targetRoot, "sessions-data")
+	require.NoError(t, os.MkdirAll(targetVSRoot, 0o755))
 	require.NoError(t, os.MkdirAll(targetSolutionRoot, 0o755))
+	require.NoError(t, os.MkdirAll(targetCopilotChatRoot, 0o755))
 	require.NoError(t, os.MkdirAll(targetThreadRoot, 0o755))
 	require.NoError(t, os.MkdirAll(targetSessionsRoot, 0o755))
 
@@ -588,8 +590,16 @@ func TestVisualStudioCopilotProviderDiscoversSymlinkedVS2026Dirs(
 		t.Skipf("symlink not supported: %v", err)
 	}
 	require.NoError(t, os.Symlink(
+		targetSolutionRoot,
+		filepath.Join(targetVSRoot, "SampleApp"),
+	))
+	require.NoError(t, os.Symlink(
 		targetCopilotChatRoot,
 		filepath.Join(targetSolutionRoot, "Copilot-Chat"),
+	))
+	require.NoError(t, os.Symlink(
+		targetThreadRoot,
+		filepath.Join(targetCopilotChatRoot, "thread"),
 	))
 	require.NoError(t, os.Symlink(
 		targetSessionsRoot,

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 )
 
 // multi_session_container.go provides a reusable source-set, provider, and
@@ -244,11 +245,14 @@ func (s multiSessionContainerSourceSet) SourcesForChangedPath(
 		if !ok {
 			continue
 		}
-		sources := []SourceRef{s.sourceRef(root, match)}
-		sources = append(
-			sources,
-			s.changedPathTombstones(root, match, req.StoredSourcePaths)...,
-		)
+		tombstones := s.changedPathTombstones(root, match, req.StoredSourcePaths)
+		sources := make([]SourceRef, 0, 1+len(tombstones))
+		if !(req.EventKind == "remove" &&
+			len(tombstones) > 0 &&
+			!IsRegularFile(match.Container)) {
+			sources = append(sources, s.sourceRef(root, match))
+		}
+		sources = append(sources, tombstones...)
 		return sources, nil
 	}
 	return nil, nil
@@ -259,9 +263,10 @@ func (s multiSessionContainerSourceSet) SourcesForChangedPath(
 // file still exists. The whole-container source re-writes the surviving
 // members; without these, a member row deleted from a still-present container
 // is never force-replaced and a stale session lingers, diverging from the
-// db-backed providers that drop it. A vanished container yields no tombstones,
-// preserving the archive when the whole source file disappears (per the
-// persistent-archive rule).
+// db-backed providers that drop it. A vanished shared container still yields no
+// tombstones, preserving the archive when the whole source file disappears; a
+// vanished one-file-per-member container emits the stored member tombstone so
+// the deleted row is force-replaced instead of lingering forever.
 func (s multiSessionContainerSourceSet) changedPathTombstones(
 	root string,
 	changed multiSessionMatch,
@@ -270,9 +275,7 @@ func (s multiSessionContainerSourceSet) changedPathTombstones(
 	if changed.MemberID != "" || changed.Container == "" {
 		return nil
 	}
-	if !IsRegularFile(changed.Container) {
-		return nil
-	}
+	containerExists := IsRegularFile(changed.Container)
 	var tombstones []SourceRef
 	seen := make(map[string]struct{})
 	for _, stored := range storedPaths {
@@ -283,7 +286,11 @@ func (s multiSessionContainerSourceSet) changedPathTombstones(
 		if !samePath(match.Container, changed.Container) {
 			continue
 		}
-		if s.memberPresent(match.toSource(root)) {
+		if !containerExists {
+			if !multiSessionMatchOwnsContainer(match) {
+				continue
+			}
+		} else if s.memberPresent(match.toSource(root)) {
 			continue
 		}
 		if _, dup := seen[match.Path]; dup {
@@ -293,6 +300,12 @@ func (s multiSessionContainerSourceSet) changedPathTombstones(
 		tombstones = append(tombstones, s.sourceRef(root, match))
 	}
 	return tombstones
+}
+
+func multiSessionMatchOwnsContainer(
+	match multiSessionMatch,
+) bool {
+	return match.MemberID == filepath.Base(match.Container)
 }
 
 func (s multiSessionContainerSourceSet) FindSource(

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -317,13 +317,7 @@ func (s multiSessionContainerSourceSet) changedPathTombstones(
 func multiSessionMatchOwnsContainer(
 	match multiSessionMatch,
 ) bool {
-	base := filepath.Base(match.Container)
-	if match.MemberID == base {
-		return true
-	}
-	return isVisualStudioCopilotVS2026SessionID(match.MemberID) &&
-		isVisualStudioCopilotVS2026SessionID(base) &&
-		strings.EqualFold(match.MemberID, base)
+	return multiSessionMemberOwnsContainer(match.MemberID, match.Container)
 }
 
 func (s multiSessionContainerSourceSet) FindSource(
@@ -478,7 +472,20 @@ func (s multiSessionContainerSourceSet) skipOutcome(src multiSessionSource) Pars
 }
 
 func multiSessionSourceOwnsContainer(src multiSessionSource) bool {
-	return src.MemberID != "" && src.MemberID == filepath.Base(src.Container)
+	return multiSessionMemberOwnsContainer(src.MemberID, src.Container)
+}
+
+func multiSessionMemberOwnsContainer(memberID, container string) bool {
+	if memberID == "" {
+		return false
+	}
+	base := filepath.Base(container)
+	if memberID == base {
+		return true
+	}
+	return isVisualStudioCopilotVS2026SessionID(memberID) &&
+		isVisualStudioCopilotVS2026SessionID(base) &&
+		strings.EqualFold(memberID, base)
 }
 
 func (s multiSessionContainerSourceSet) memberPresent(src multiSessionSource) bool {

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // multi_session_container.go provides a reusable source-set, provider, and
@@ -316,7 +317,13 @@ func (s multiSessionContainerSourceSet) changedPathTombstones(
 func multiSessionMatchOwnsContainer(
 	match multiSessionMatch,
 ) bool {
-	return match.MemberID == filepath.Base(match.Container)
+	base := filepath.Base(match.Container)
+	if match.MemberID == base {
+		return true
+	}
+	return isVisualStudioCopilotVS2026SessionID(match.MemberID) &&
+		isVisualStudioCopilotVS2026SessionID(base) &&
+		strings.EqualFold(match.MemberID, base)
 }
 
 func (s multiSessionContainerSourceSet) FindSource(

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -2,7 +2,9 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -371,7 +373,12 @@ func (s multiSessionContainerSourceSet) Fingerprint(
 	}
 	fingerprint, err := s.cfg.fingerprint(src)
 	if err != nil {
-		return SourceFingerprint{}, err
+		if errors.Is(err, os.ErrNotExist) &&
+			multiSessionSourceOwnsContainer(src) {
+			fingerprint = SourceFingerprint{}
+		} else {
+			return SourceFingerprint{}, err
+		}
 	}
 	fingerprint.Key = firstNonEmptyJSONLString(
 		source.FingerprintKey, source.Key, src.Path,
@@ -429,13 +436,19 @@ func (s multiSessionContainerSourceSet) parse(
 }
 
 // skipOutcome builds the "no session" outcome for a container/member that
-// produced no results. When the backing container file is gone, the stored
-// sessions must be preserved (the archive survives a vanished source file), so
-// it skips without ForceReplace, which would delete them. When the container is
-// still present, the member row or contents were genuinely removed, so it
-// force-replaces to drop the now-absent stored sessions.
+// produced no results. When the backing container file is gone, whole-container
+// sources preserve the stored sessions because the archive survives a vanished
+// source file. Member tombstones for one-file-per-member layouts still
+// force-replace so a deleted session row does not linger forever.
 func (s multiSessionContainerSourceSet) skipOutcome(src multiSessionSource) ParseOutcome {
 	if src.Container != "" && !IsRegularFile(src.Container) {
+		if multiSessionSourceOwnsContainer(src) {
+			return ParseOutcome{
+				ResultSetComplete: true,
+				ForceReplace:      true,
+				SkipReason:        SkipNoSession,
+			}
+		}
 		return ParseOutcome{
 			ResultSetComplete: true,
 			SkipReason:        SkipNoSession,
@@ -446,6 +459,10 @@ func (s multiSessionContainerSourceSet) skipOutcome(src multiSessionSource) Pars
 		ForceReplace:      true,
 		SkipReason:        SkipNoSession,
 	}
+}
+
+func multiSessionSourceOwnsContainer(src multiSessionSource) bool {
+	return src.MemberID != "" && src.MemberID == filepath.Base(src.Container)
 }
 
 func (s multiSessionContainerSourceSet) memberPresent(src multiSessionSource) bool {

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -247,9 +247,9 @@ func (s multiSessionContainerSourceSet) SourcesForChangedPath(
 		}
 		tombstones := s.changedPathTombstones(root, match, req.StoredSourcePaths)
 		sources := make([]SourceRef, 0, 1+len(tombstones))
-		if !(req.EventKind == "remove" &&
-			len(tombstones) > 0 &&
-			!IsRegularFile(match.Container)) {
+		if req.EventKind != "remove" ||
+			len(tombstones) == 0 ||
+			IsRegularFile(match.Container) {
 			sources = append(sources, s.sourceRef(root, match))
 		}
 		sources = append(sources, tombstones...)

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -292,6 +292,15 @@ func (s multiSessionContainerSourceSet) changedPathTombstones(
 			if !multiSessionMatchOwnsContainer(match) {
 				continue
 			}
+			if current, ok := s.cfg.findMember(root, match.MemberID); ok &&
+				!samePath(current.Container, match.Container) {
+				if _, dup := seen[current.Path]; dup {
+					continue
+				}
+				seen[current.Path] = struct{}{}
+				tombstones = append(tombstones, s.sourceRef(root, current))
+				continue
+			}
 		} else if s.memberPresent(match.toSource(root)) {
 			continue
 		}

--- a/internal/parser/visualstudio_copilot.go
+++ b/internal/parser/visualstudio_copilot.go
@@ -60,8 +60,8 @@ func isVisualStudioCopilotVS2026SessionPath(path string) bool {
 	if len(parts) < 4 {
 		return false
 	}
-	return parts[len(parts)-1] == "sessions" &&
-		parts[len(parts)-3] == "copilot-chat"
+	return strings.EqualFold(parts[len(parts)-1], "sessions") &&
+		strings.EqualFold(parts[len(parts)-3], "copilot-chat")
 }
 
 func isVisualStudioCopilotVS2026SessionFileName(name string) bool {

--- a/internal/parser/visualstudio_copilot.go
+++ b/internal/parser/visualstudio_copilot.go
@@ -51,6 +51,12 @@ func isVisualStudioCopilotConversationPath(path string) bool {
 		isVisualStudioCopilotVS2026SessionPath(path)
 }
 
+// IsVisualStudioCopilotVS2026SessionPath reports whether path names a Visual
+// Studio 2026 Copilot one-file conversation source.
+func IsVisualStudioCopilotVS2026SessionPath(path string) bool {
+	return isVisualStudioCopilotVS2026SessionPath(path)
+}
+
 func isVisualStudioCopilotVS2026SessionPath(path string) bool {
 	if !isVisualStudioCopilotVS2026SessionFileName(filepath.Base(path)) {
 		return false

--- a/internal/parser/visualstudio_copilot.go
+++ b/internal/parser/visualstudio_copilot.go
@@ -46,6 +46,28 @@ func IsVisualStudioCopilotTraceFile(path string) bool {
 		strings.Contains(base, "_VSGitHubCopilot_traces")
 }
 
+func isVisualStudioCopilotConversationPath(path string) bool {
+	return IsVisualStudioCopilotTraceFile(path) ||
+		isVisualStudioCopilotVS2026SessionPath(path)
+}
+
+func isVisualStudioCopilotVS2026SessionPath(path string) bool {
+	if !isVisualStudioCopilotVS2026SessionFileName(filepath.Base(path)) {
+		return false
+	}
+
+	parts := strings.Split(filepath.ToSlash(filepath.Dir(path)), "/")
+	if len(parts) < 4 {
+		return false
+	}
+	return parts[len(parts)-1] == "sessions" &&
+		parts[len(parts)-3] == "copilot-chat"
+}
+
+func isVisualStudioCopilotVS2026SessionFileName(name string) bool {
+	return !strings.Contains(name, ".") && IsValidSessionID(name)
+}
+
 // ResolveSourceFilePath maps a stored session source path to a path that can
 // be opened on disk. Visual Studio Copilot stores a
 // <traceFile>#<conversationID> virtual path whose conversations share one
@@ -571,6 +593,12 @@ func visualStudioCopilotSiblingTraceFiles(path string) ([]string, error) {
 func VisualStudioCopilotTraceFingerprint(
 	tracePath string,
 ) (size, mtime int64) {
+	if isVisualStudioCopilotVS2026SessionPath(tracePath) {
+		if info, err := os.Stat(tracePath); err == nil {
+			return info.Size(), info.ModTime().UnixNano()
+		}
+		return 0, 0
+	}
 	size, mtime, err := visualStudioCopilotTraceFingerprint(tracePath, false)
 	if err != nil {
 		if info, statErr := os.Stat(tracePath); statErr == nil {
@@ -593,6 +621,13 @@ func VisualStudioCopilotTraceFingerprint(
 func VisualStudioCopilotTraceFingerprintStrict(
 	tracePath string,
 ) (size, mtime int64, err error) {
+	if isVisualStudioCopilotVS2026SessionPath(tracePath) {
+		info, err := os.Stat(tracePath)
+		if err != nil {
+			return 0, 0, err
+		}
+		return info.Size(), info.ModTime().UnixNano(), nil
+	}
 	return visualStudioCopilotTraceFingerprint(tracePath, true)
 }
 

--- a/internal/parser/visualstudio_copilot.go
+++ b/internal/parser/visualstudio_copilot.go
@@ -20,7 +20,20 @@ import (
 // A single physical trace file can hold spans for multiple conversations, so
 // each conversation is tracked as its own work item under this virtual path.
 func VisualStudioCopilotVirtualPath(tracePath, conversationID string) string {
+	conversationID = canonicalVisualStudioCopilotConversationID(conversationID)
 	return VirtualSourcePath(tracePath, conversationID)
+}
+
+func canonicalVisualStudioCopilotConversationID(id string) string {
+	if isVisualStudioCopilotVS2026SessionID(id) {
+		return strings.ToLower(id)
+	}
+	return id
+}
+
+func sameVisualStudioCopilotConversationID(a, b string) bool {
+	return canonicalVisualStudioCopilotConversationID(a) ==
+		canonicalVisualStudioCopilotConversationID(b)
 }
 
 // SplitVisualStudioCopilotVirtualPath splits a <traceFile>#<conversationID>
@@ -157,6 +170,7 @@ type vsCopilotTraceValue struct {
 func parseVisualStudioCopilotConversation(
 	tracePath, conversationID, project, machine string,
 ) (*ParsedSession, []ParsedMessage, error) {
+	conversationID = canonicalVisualStudioCopilotConversationID(conversationID)
 	if conversationID == "" {
 		return nil, nil, nil
 	}
@@ -237,7 +251,9 @@ func visualStudioCopilotConversationSpans(
 	}
 	var spans []vsCopilotSpan
 	for _, span := range own {
-		if span.attrMap["gen_ai.conversation.id"] == conversationID {
+		if sameVisualStudioCopilotConversationID(
+			span.attrMap["gen_ai.conversation.id"], conversationID,
+		) {
 			spans = append(spans, span)
 		}
 	}
@@ -263,7 +279,9 @@ func VisualStudioCopilotFileConversationIDs(path string) ([]string, error) {
 	seen := map[string]struct{}{}
 	var ids []string
 	for _, span := range spans {
-		id := span.attrMap["gen_ai.conversation.id"]
+		id := canonicalVisualStudioCopilotConversationID(
+			span.attrMap["gen_ai.conversation.id"],
+		)
 		if id == "" {
 			continue
 		}
@@ -377,6 +395,7 @@ func writeVisualStudioCopilotConversationFile(
 func visualStudioCopilotConversationLine(
 	line []byte, conversationID string,
 ) ([]byte, bool) {
+	conversationID = canonicalVisualStudioCopilotConversationID(conversationID)
 	var top map[string]json.RawMessage
 	if err := json.Unmarshal(line, &top); err != nil {
 		return nil, false
@@ -487,7 +506,9 @@ func visualStudioCopilotFilterScopeSpan(
 	kept := make([]json.RawMessage, 0, len(spans))
 	modified := false
 	for _, sp := range spans {
-		if visualStudioCopilotSpanConversationID(sp) == conversationID {
+		if sameVisualStudioCopilotConversationID(
+			visualStudioCopilotSpanConversationID(sp), conversationID,
+		) {
 			kept = append(kept, sp)
 		} else {
 			modified = true
@@ -523,7 +544,9 @@ func visualStudioCopilotSpanConversationID(span json.RawMessage) string {
 	}
 	for _, attr := range s.Attributes {
 		if attr.Key == "gen_ai.conversation.id" {
-			return attr.Value.StringValue
+			return canonicalVisualStudioCopilotConversationID(
+				attr.Value.StringValue,
+			)
 		}
 	}
 	return ""
@@ -600,7 +623,9 @@ func visualStudioCopilotSiblingTraceSpans(
 			return nil, err
 		}
 		for _, span := range candidateSpans {
-			if span.attrMap["gen_ai.conversation.id"] == conversationID {
+			if sameVisualStudioCopilotConversationID(
+				span.attrMap["gen_ai.conversation.id"], conversationID,
+			) {
 				spans = append(spans, span)
 			}
 		}

--- a/internal/parser/visualstudio_copilot.go
+++ b/internal/parser/visualstudio_copilot.go
@@ -65,7 +65,32 @@ func isVisualStudioCopilotVS2026SessionPath(path string) bool {
 }
 
 func isVisualStudioCopilotVS2026SessionFileName(name string) bool {
-	return !strings.Contains(name, ".") && IsValidSessionID(name)
+	return isVisualStudioCopilotVS2026SessionID(name)
+}
+
+func isVisualStudioCopilotVS2026SessionID(id string) bool {
+	if len(id) != 36 {
+		return false
+	}
+	for i, c := range id {
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			if !isVisualStudioCopilotVS2026Hex(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isVisualStudioCopilotVS2026Hex(c rune) bool {
+	return (c >= '0' && c <= '9') ||
+		(c >= 'a' && c <= 'f') ||
+		(c >= 'A' && c <= 'F')
 }
 
 // ResolveSourceFilePath maps a stored session source path to a path that can

--- a/internal/parser/visualstudio_copilot.go
+++ b/internal/parser/visualstudio_copilot.go
@@ -273,19 +273,36 @@ func VisualStudioCopilotFileConversationIDs(path string) ([]string, error) {
 // WriteVisualStudioCopilotConversationJSONL streams the trace data for one
 // conversation across every sibling trace file in the representative trace's
 // directory, since a conversation's spans can be split across rotated trace
-// files. From each file it emits only the spans whose gen_ai.conversation.id
-// matches the requested conversation: a line is written verbatim when all of its
-// spans already belong to that conversation, otherwise it is re-encoded with
-// only the matching spans so a batched OTLP line cannot disclose another
-// conversation's or an id-less span's prompts, tool arguments, command output,
-// or secrets. A sibling that vanished between listing and open is skipped; any
-// other read error is returned. When no trace file in the directory contains the
-// conversation (e.g. the representative trace was rotated away and no sibling
-// holds it), it returns an os.ErrNotExist-wrapped error rather than succeeding
-// with empty output, so callers can report a clear not-found error.
+// files. VS 2026 session-file paths already point at one conversation file, so
+// they are filtered and exported directly. From each file it emits only the
+// spans whose gen_ai.conversation.id matches the requested conversation: a line
+// is written verbatim when all of its spans already belong to that
+// conversation, otherwise it is re-encoded with only the matching spans so a
+// batched OTLP line cannot disclose another conversation's or an id-less span's
+// prompts, tool arguments, command output, or secrets. A sibling that vanished
+// between listing and open is skipped; any other read error is returned. When
+// no trace file in the directory contains the conversation (e.g. the
+// representative trace was rotated away and no sibling holds it), it returns an
+// os.ErrNotExist-wrapped error rather than succeeding with empty output, so
+// callers can report a clear not-found error.
 func WriteVisualStudioCopilotConversationJSONL(
 	w io.Writer, tracePath, conversationID string,
 ) error {
+	if isVisualStudioCopilotVS2026SessionPath(tracePath) {
+		written, err := writeVisualStudioCopilotConversationFile(
+			w, tracePath, conversationID,
+		)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return fmt.Errorf(
+				"conversation %s not found in %s: %w",
+				conversationID, tracePath, os.ErrNotExist,
+			)
+		}
+		return nil
+	}
 	files, err := visualStudioCopilotSiblingTraceFiles(tracePath)
 	if err != nil {
 		return err

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -189,7 +189,7 @@ func discoverVisualStudioCopilotVS2026SessionFilesInVSRoot(
 	}
 	out := []DiscoveredFile{}
 	for _, solution := range solutions {
-		if !solution.IsDir() {
+		if !isDirOrSymlink(solution, vsRoot) {
 			continue
 		}
 		copilotChatRoot, ok := visualStudioCopilotChildDir(
@@ -219,7 +219,7 @@ func discoverVisualStudioCopilotVS2026SessionFilesInCopilotChatRoot(
 	}
 	out := []DiscoveredFile{}
 	for _, thread := range threads {
-		if !thread.IsDir() {
+		if !isDirOrSymlink(thread, copilotChatRoot) {
 			continue
 		}
 		sessionsRoot, ok := visualStudioCopilotChildDir(

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -162,17 +162,21 @@ func discoverVisualStudioCopilotVS2026SessionFiles(
 	case visualStudioCopilotVS2026SessionsRoot:
 		return discoverVisualStudioCopilotVS2026SessionFilesInDirectory(root)
 	case visualStudioCopilotVS2026ThreadRoot:
-		return discoverVisualStudioCopilotVS2026SessionFilesInDirectory(
-			filepath.Join(root, "sessions"),
-		)
+		sessionsRoot, ok := visualStudioCopilotChildDir(root, "sessions")
+		if !ok {
+			return nil
+		}
+		return discoverVisualStudioCopilotVS2026SessionFilesInDirectory(sessionsRoot)
 	case visualStudioCopilotVS2026CopilotChatRoot:
 		return discoverVisualStudioCopilotVS2026SessionFilesInCopilotChatRoot(root)
 	case visualStudioCopilotVS2026VSRoot:
 		return discoverVisualStudioCopilotVS2026SessionFilesInVSRoot(root)
 	default:
-		return discoverVisualStudioCopilotVS2026SessionFilesInVSRoot(
-			filepath.Join(root, ".vs"),
-		)
+		vsRoot, ok := visualStudioCopilotChildDir(root, ".vs")
+		if !ok {
+			return nil
+		}
+		return discoverVisualStudioCopilotVS2026SessionFilesInVSRoot(vsRoot)
 	}
 }
 
@@ -188,10 +192,17 @@ func discoverVisualStudioCopilotVS2026SessionFilesInVSRoot(
 		if !solution.IsDir() {
 			continue
 		}
+		copilotChatRoot, ok := visualStudioCopilotChildDir(
+			filepath.Join(vsRoot, solution.Name()),
+			"copilot-chat",
+		)
+		if !ok {
+			continue
+		}
 		out = append(
 			out,
 			discoverVisualStudioCopilotVS2026SessionFilesInCopilotChatRoot(
-				filepath.Join(vsRoot, solution.Name(), "copilot-chat"),
+				copilotChatRoot,
 			)...,
 		)
 	}
@@ -211,10 +222,17 @@ func discoverVisualStudioCopilotVS2026SessionFilesInCopilotChatRoot(
 		if !thread.IsDir() {
 			continue
 		}
+		sessionsRoot, ok := visualStudioCopilotChildDir(
+			filepath.Join(copilotChatRoot, thread.Name()),
+			"sessions",
+		)
+		if !ok {
+			continue
+		}
 		out = append(
 			out,
 			discoverVisualStudioCopilotVS2026SessionFilesInDirectory(
-				filepath.Join(copilotChatRoot, thread.Name(), "sessions"),
+				sessionsRoot,
 			)...,
 		)
 	}
@@ -251,6 +269,24 @@ func discoverVisualStudioCopilotVS2026SessionFilesInDirectory(
 	return out
 }
 
+func visualStudioCopilotChildDir(parent, name string) (string, bool) {
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return "", false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && entry.Name() == name {
+			return filepath.Join(parent, entry.Name()), true
+		}
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && strings.EqualFold(entry.Name(), name) {
+			return filepath.Join(parent, entry.Name()), true
+		}
+	}
+	return "", false
+}
+
 func vsCopilotWatchRoots(roots []string) []WatchRoot {
 	out := make([]WatchRoot, 0, len(roots)*2)
 	for _, root := range roots {
@@ -276,8 +312,7 @@ func vsCopilotWatchRoots(roots []string) []WatchRoot {
 				IncludeGlobs: []string{"*_VSGitHubCopilot_traces.jsonl"},
 				DebounceKey:  string(AgentVSCopilot) + ":traces:" + root,
 			})
-			vsRoot := filepath.Join(root, ".vs")
-			if info, err := os.Stat(vsRoot); err == nil && info.IsDir() {
+			if vsRoot, ok := visualStudioCopilotChildDir(root, ".vs"); ok {
 				out = append(out, WatchRoot{
 					Path:         vsRoot,
 					Recursive:    true,

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -275,12 +275,12 @@ func visualStudioCopilotChildDir(parent, name string) (string, bool) {
 		return "", false
 	}
 	for _, entry := range entries {
-		if entry.IsDir() && entry.Name() == name {
+		if isDirOrSymlink(entry, parent) && entry.Name() == name {
 			return filepath.Join(parent, entry.Name()), true
 		}
 	}
 	for _, entry := range entries {
-		if entry.IsDir() && strings.EqualFold(entry.Name(), name) {
+		if isDirOrSymlink(entry, parent) && strings.EqualFold(entry.Name(), name) {
 			return filepath.Join(parent, entry.Name()), true
 		}
 	}

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -294,11 +295,14 @@ func vsCopilotWatchRoots(roots []string) []WatchRoot {
 		if root == "" || root == "." {
 			continue
 		}
+		includeSessionRoots := true
 		switch visualStudioCopilotVS2026RootKind(root) {
+		case visualStudioCopilotVS2026SessionsRoot:
+			out = append(out, vsCopilotVS2026SessionWatchRoot(root))
+			includeSessionRoots = false
 		case visualStudioCopilotVS2026VSRoot,
 			visualStudioCopilotVS2026CopilotChatRoot,
-			visualStudioCopilotVS2026ThreadRoot,
-			visualStudioCopilotVS2026SessionsRoot:
+			visualStudioCopilotVS2026ThreadRoot:
 			out = append(out, WatchRoot{
 				Path:         root,
 				Recursive:    true,
@@ -321,8 +325,100 @@ func vsCopilotWatchRoots(roots []string) []WatchRoot {
 				})
 			}
 		}
+		if includeSessionRoots {
+			for _, sessionsRoot := range visualStudioCopilotVS2026SessionRoots(root) {
+				out = append(out, vsCopilotVS2026SessionWatchRoot(sessionsRoot))
+			}
+		}
 	}
 	return out
+}
+
+func vsCopilotVS2026SessionWatchRoot(root string) WatchRoot {
+	return WatchRoot{
+		Path:         root,
+		Recursive:    false,
+		IncludeGlobs: []string{"*"},
+		DebounceKey:  string(AgentVSCopilot) + ":sessions:" + root,
+	}
+}
+
+func visualStudioCopilotVS2026SessionRoots(root string) []string {
+	root = filepath.Clean(root)
+	var roots []string
+	switch visualStudioCopilotVS2026RootKind(root) {
+	case visualStudioCopilotVS2026SessionsRoot:
+		roots = append(roots, root)
+	case visualStudioCopilotVS2026ThreadRoot:
+		if sessionsRoot, ok := visualStudioCopilotChildDir(root, "sessions"); ok {
+			roots = append(roots, sessionsRoot)
+		}
+	case visualStudioCopilotVS2026CopilotChatRoot:
+		roots = visualStudioCopilotVS2026SessionRootsInCopilotChatRoot(root)
+	case visualStudioCopilotVS2026VSRoot:
+		roots = visualStudioCopilotVS2026SessionRootsInVSRoot(root)
+	default:
+		if vsRoot, ok := visualStudioCopilotChildDir(root, ".vs"); ok {
+			roots = visualStudioCopilotVS2026SessionRootsInVSRoot(vsRoot)
+		}
+	}
+	sort.Strings(roots)
+	return slices.Compact(roots)
+}
+
+func visualStudioCopilotVS2026SessionRootsInVSRoot(
+	vsRoot string,
+) []string {
+	solutions, err := os.ReadDir(vsRoot)
+	if err != nil {
+		return nil
+	}
+	out := []string{}
+	for _, solution := range solutions {
+		if !isDirOrSymlink(solution, vsRoot) {
+			continue
+		}
+		copilotChatRoot, ok := visualStudioCopilotChildDir(
+			filepath.Join(vsRoot, solution.Name()),
+			"copilot-chat",
+		)
+		if !ok {
+			continue
+		}
+		out = append(
+			out,
+			visualStudioCopilotVS2026SessionRootsInCopilotChatRoot(
+				copilotChatRoot,
+			)...,
+		)
+	}
+	sort.Strings(out)
+	return slices.Compact(out)
+}
+
+func visualStudioCopilotVS2026SessionRootsInCopilotChatRoot(
+	copilotChatRoot string,
+) []string {
+	threads, err := os.ReadDir(copilotChatRoot)
+	if err != nil {
+		return nil
+	}
+	out := []string{}
+	for _, thread := range threads {
+		if !isDirOrSymlink(thread, copilotChatRoot) {
+			continue
+		}
+		sessionsRoot, ok := visualStudioCopilotChildDir(
+			filepath.Join(copilotChatRoot, thread.Name()),
+			"sessions",
+		)
+		if !ok {
+			continue
+		}
+		out = append(out, sessionsRoot)
+	}
+	sort.Strings(out)
+	return slices.Compact(out)
 }
 
 // vsCopilotClassifyPath maps a stored or changed path to its trace container and

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -389,18 +389,18 @@ func visualStudioCopilotVS2026SessionUnderRoot(
 	case visualStudioCopilotVS2026SessionsRoot:
 		return len(parts) == 1
 	case visualStudioCopilotVS2026ThreadRoot:
-		return len(parts) == 2 && parts[0] == "sessions"
+		return len(parts) == 2 && strings.EqualFold(parts[0], "sessions")
 	case visualStudioCopilotVS2026CopilotChatRoot:
-		return len(parts) == 3 && parts[1] == "sessions"
+		return len(parts) == 3 && strings.EqualFold(parts[1], "sessions")
 	case visualStudioCopilotVS2026VSRoot:
 		return len(parts) == 5 &&
-			parts[1] == "copilot-chat" &&
-			parts[3] == "sessions"
+			strings.EqualFold(parts[1], "copilot-chat") &&
+			strings.EqualFold(parts[3], "sessions")
 	default:
 		return len(parts) == 6 &&
 			strings.EqualFold(parts[0], ".vs") &&
-			parts[2] == "copilot-chat" &&
-			parts[4] == "sessions"
+			strings.EqualFold(parts[2], "copilot-chat") &&
+			strings.EqualFold(parts[4], "sessions")
 	}
 }
 

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -291,9 +291,10 @@ func vsCopilotWatchRoots(roots []string) []WatchRoot {
 }
 
 // vsCopilotClassifyPath maps a stored or changed path to its trace container and
-// conversation. A virtual path always requires its backing trace to exist; a
-// bare trace path relaxes the regular-file check under allowMissing so a deleted
-// trace still classifies for changed-path tombstones.
+// conversation. A virtual path normally requires its backing container to exist;
+// VS 2026 one-file member tombstones relax that under allowMissing. A bare trace
+// path also relaxes the regular-file check under allowMissing so a deleted trace
+// still classifies for changed-path tombstones.
 func vsCopilotClassifyPath(
 	root, path string, allowMissing bool,
 ) (multiSessionMatch, bool) {
@@ -302,7 +303,8 @@ func vsCopilotClassifyPath(
 	if tracePath, conversationID, ok :=
 		splitVisualStudioCopilotVirtualPath(path); ok {
 		if isVisualStudioCopilotVS2026SessionPath(tracePath) {
-			if !visualStudioCopilotVS2026SessionUnderRoot(root, tracePath) {
+			if !visualStudioCopilotVS2026SessionUnderRoot(root, tracePath) ||
+				(!allowMissing && !IsRegularFile(tracePath)) {
 				return multiSessionMatch{}, false
 			}
 			return multiSessionMatch{

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -434,12 +434,15 @@ func vsCopilotClassifyPath(
 	if tracePath, conversationID, ok :=
 		splitVisualStudioCopilotVirtualPath(path); ok {
 		if isVisualStudioCopilotVS2026SessionPath(tracePath) {
+			conversationID = canonicalVisualStudioCopilotConversationID(
+				conversationID,
+			)
 			if !visualStudioCopilotVS2026SessionUnderRoot(root, tracePath) ||
 				(!allowMissing && !IsRegularFile(tracePath)) {
 				return multiSessionMatch{}, false
 			}
 			return multiSessionMatch{
-				Path:        path,
+				Path:        VisualStudioCopilotVirtualPath(tracePath, conversationID),
 				Container:   tracePath,
 				MemberID:    conversationID,
 				ProjectHint: "visualstudio",
@@ -457,6 +460,9 @@ func vsCopilotClassifyPath(
 	}
 	if isVisualStudioCopilotVS2026SessionPath(path) &&
 		visualStudioCopilotVS2026SessionUnderRoot(root, path) {
+		conversationID := canonicalVisualStudioCopilotConversationID(
+			filepath.Base(path),
+		)
 		if allowMissing && !IsRegularFile(path) {
 			return multiSessionMatch{
 				Path:        path,
@@ -465,9 +471,9 @@ func vsCopilotClassifyPath(
 			}, true
 		}
 		return multiSessionMatch{
-			Path:        VisualStudioCopilotVirtualPath(path, filepath.Base(path)),
+			Path:        VisualStudioCopilotVirtualPath(path, conversationID),
 			Container:   path,
-			MemberID:    filepath.Base(path),
+			MemberID:    conversationID,
 			ProjectHint: "visualstudio",
 		}, true
 	}
@@ -493,12 +499,13 @@ func vsCopilotFindMember(root, rawID string) (multiSessionMatch, bool) {
 // conversation ID, deduplicating across legacy traces and VS 2026 session
 // files with the same newest-mtime, then path tie-breaker used by discovery.
 func findVisualStudioCopilotSourceFile(root, rawID string) string {
+	rawID = canonicalVisualStudioCopilotConversationID(rawID)
 	if root == "" || !IsValidSessionID(rawID) {
 		return ""
 	}
 	for _, file := range discoverVisualStudioCopilotSessionFilesUnderRoot(root) {
 		_, conversationID, ok := splitVisualStudioCopilotVirtualPath(file.Path)
-		if ok && conversationID == rawID {
+		if ok && sameVisualStudioCopilotConversationID(conversationID, rawID) {
 			return file.Path
 		}
 	}
@@ -639,6 +646,7 @@ func splitVisualStudioCopilotVirtualPath(
 		!IsValidSessionID(conversationID) {
 		return "", "", false
 	}
+	conversationID = canonicalVisualStudioCopilotConversationID(conversationID)
 	return tracePath, conversationID, true
 }
 

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // Visual Studio Copilot normally stores conversations inside shared trace
@@ -92,25 +93,65 @@ func discoverVisualStudioCopilotSessionFilesUnderRoot(
 	if vsRoot == "" {
 		return nil
 	}
+	bestByConversation := map[string]visualStudioCopilotCandidate{}
+	filesByConversation := map[string]DiscoveredFile{}
 	filesByPath := map[string]DiscoveredFile{}
 
 	entries, err := os.ReadDir(vsRoot)
 	if err == nil {
 		for _, file := range discoverVisualStudioCopilotSessionFiles(vsRoot, entries) {
-			filesByPath[file.Path] = file
+			if !vsCopilotRememberVirtualDiscoveredFile(
+				file,
+				bestByConversation,
+				filesByConversation,
+			) {
+				filesByPath[file.Path] = file
+			}
 		}
 	}
 
 	for _, file := range discoverVisualStudioCopilotVS2026SessionFiles(vsRoot) {
-		filesByPath[file.Path] = file
+		vsCopilotRememberVirtualDiscoveredFile(
+			file,
+			bestByConversation,
+			filesByConversation,
+		)
 	}
 
-	files := make([]DiscoveredFile, 0, len(filesByPath))
+	files := make([]DiscoveredFile, 0, len(filesByConversation)+len(filesByPath))
+	for _, file := range filesByConversation {
+		files = append(files, file)
+	}
 	for _, file := range filesByPath {
 		files = append(files, file)
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
 	return files
+}
+
+func vsCopilotRememberVirtualDiscoveredFile(
+	file DiscoveredFile,
+	bestByConversation map[string]visualStudioCopilotCandidate,
+	filesByConversation map[string]DiscoveredFile,
+) bool {
+	path, conversationID, ok := splitVisualStudioCopilotVirtualPath(file.Path)
+	if !ok {
+		return false
+	}
+	mtime := time.Time{}
+	if info, err := os.Stat(path); err == nil {
+		mtime = info.ModTime()
+	}
+	current := bestByConversation[conversationID]
+	if !visualStudioCopilotCandidateWins(path, mtime, current) {
+		return true
+	}
+	bestByConversation[conversationID] = visualStudioCopilotCandidate{
+		path:  path,
+		mtime: mtime,
+	}
+	filesByConversation[conversationID] = file
+	return true
 }
 
 func discoverVisualStudioCopilotVS2026SessionFiles(
@@ -211,14 +252,40 @@ func discoverVisualStudioCopilotVS2026SessionFilesInDirectory(
 }
 
 func vsCopilotWatchRoots(roots []string) []WatchRoot {
-	out := make([]WatchRoot, 0, len(roots))
+	out := make([]WatchRoot, 0, len(roots)*2)
 	for _, root := range roots {
-		out = append(out, WatchRoot{
-			Path:         root,
-			Recursive:    false,
-			IncludeGlobs: []string{"*_VSGitHubCopilot_traces.jsonl"},
-			DebounceKey:  string(AgentVSCopilot) + ":traces:" + root,
-		})
+		root = filepath.Clean(root)
+		if root == "" || root == "." {
+			continue
+		}
+		switch visualStudioCopilotVS2026RootKind(root) {
+		case visualStudioCopilotVS2026VSRoot,
+			visualStudioCopilotVS2026CopilotChatRoot,
+			visualStudioCopilotVS2026ThreadRoot,
+			visualStudioCopilotVS2026SessionsRoot:
+			out = append(out, WatchRoot{
+				Path:         root,
+				Recursive:    true,
+				IncludeGlobs: []string{"*"},
+				DebounceKey:  string(AgentVSCopilot) + ":sessions:" + root,
+			})
+		default:
+			out = append(out, WatchRoot{
+				Path:         root,
+				Recursive:    false,
+				IncludeGlobs: []string{"*_VSGitHubCopilot_traces.jsonl"},
+				DebounceKey:  string(AgentVSCopilot) + ":traces:" + root,
+			})
+			vsRoot := filepath.Join(root, ".vs")
+			if info, err := os.Stat(vsRoot); err == nil && info.IsDir() {
+				out = append(out, WatchRoot{
+					Path:         vsRoot,
+					Recursive:    true,
+					IncludeGlobs: []string{"*"},
+					DebounceKey:  string(AgentVSCopilot) + ":sessions:" + vsRoot,
+				})
+			}
+		}
 	}
 	return out
 }
@@ -257,6 +324,13 @@ func vsCopilotClassifyPath(
 	}
 	if isVisualStudioCopilotVS2026SessionPath(path) &&
 		visualStudioCopilotVS2026SessionUnderRoot(root, path) {
+		if allowMissing && !IsRegularFile(path) {
+			return multiSessionMatch{
+				Path:        path,
+				Container:   path,
+				ProjectHint: "visualstudio",
+			}, true
+		}
 		return multiSessionMatch{
 			Path:        VisualStudioCopilotVirtualPath(path, filepath.Base(path)),
 			Container:   path,
@@ -282,27 +356,18 @@ func vsCopilotFindMember(root, rawID string) (multiSessionMatch, bool) {
 	return vsCopilotClassifyPath(root, path, false)
 }
 
-// findVisualStudioCopilotSourceFile locates a trace file by conversation UUID
-// and returns a conversation-scoped <traceFile>#<conversationID> virtual path.
+// findVisualStudioCopilotSourceFile locates the canonical source for one
+// conversation ID, deduplicating across legacy traces and VS 2026 session
+// files with the same newest-mtime, then path tie-breaker used by discovery.
 func findVisualStudioCopilotSourceFile(root, rawID string) string {
 	if root == "" || !IsValidSessionID(rawID) {
 		return ""
 	}
-	if path := findVisualStudioCopilotTraceSourceFile(root, rawID); path != "" {
-		return path
-	}
-	return findVisualStudioCopilotVS2026SourceFile(root, rawID)
-}
-
-func findVisualStudioCopilotVS2026SourceFile(
-	root, rawID string,
-) string {
-	for _, file := range discoverVisualStudioCopilotVS2026SessionFiles(root) {
-		path, conversationID, ok := splitVisualStudioCopilotVirtualPath(file.Path)
-		if !ok || conversationID != rawID {
-			continue
+	for _, file := range discoverVisualStudioCopilotSessionFilesUnderRoot(root) {
+		_, conversationID, ok := splitVisualStudioCopilotVirtualPath(file.Path)
+		if ok && conversationID == rawID {
+			return file.Path
 		}
-		return VisualStudioCopilotVirtualPath(path, rawID)
 	}
 	return ""
 }

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 )
 
-// Visual Studio Copilot stores conversations inside shared trace files
-// (*_VSGitHubCopilot_traces.jsonl). It is a multi-session container provider,
-// but unlike the SQLite-backed containers it discovers one source per
-// conversation (deduplicated across trace files, newest trace wins) plus a bare
-// physical source for any trace whose conversation IDs could not be read, so
-// the read failure surfaces instead of being silently dropped. Parse of a
-// conversation virtual path yields that one session; Parse of a bare trace fans
-// out every conversation in it. All behavior is wired into the shared
-// multi-session-container base via options.
+// Visual Studio Copilot normally stores conversations inside shared trace
+// files (*_VSGitHubCopilot_traces.jsonl), and newer Visual Studio versions can
+// also write extensionless conversation files under .vs/*/copilot-chat/*/sessions.
+// It is a multi-session container provider, but unlike the SQLite-backed
+// containers it discovers one source per conversation (deduplicated across trace
+// files, newest trace wins) plus a bare physical source for any legacy trace
+// whose conversation IDs could not be read, so read failures are surfaced instead
+// of being silently dropped. Parse of a conversation virtual path yields that one
+// session; Parse of a bare trace fans out every conversation in it. All behavior
+// is wired into the shared multi-session-container base via options.
 func newVisualStudioCopilotProviderFactory(def AgentDef) ProviderFactory {
 	return NewMultiSessionProviderFactory(
 		def,
@@ -71,6 +72,9 @@ func vsCopilotDiscoveredMatch(root, path string) (multiSessionMatch, bool) {
 	if _, _, ok := splitVisualStudioCopilotVirtualPath(path); ok {
 		return multiSessionMatch{}, false
 	}
+	if visualStudioCopilotVS2026SessionUnderRoot(root, path) {
+		return multiSessionMatch{}, false
+	}
 	if !visualStudioCopilotTraceUnderRoot(root, path, false) {
 		return multiSessionMatch{}, false
 	}
@@ -84,16 +88,126 @@ func vsCopilotDiscoveredMatch(root, path string) (multiSessionMatch, bool) {
 func discoverVisualStudioCopilotSessionFilesUnderRoot(
 	vsRoot string,
 ) []DiscoveredFile {
+	vsRoot = filepath.Clean(vsRoot)
 	if vsRoot == "" {
 		return nil
 	}
+	filesByPath := map[string]DiscoveredFile{}
+
 	entries, err := os.ReadDir(vsRoot)
+	if err == nil {
+		for _, file := range discoverVisualStudioCopilotSessionFiles(vsRoot, entries) {
+			filesByPath[file.Path] = file
+		}
+	}
+
+	for _, file := range discoverVisualStudioCopilotVS2026SessionFiles(vsRoot) {
+		filesByPath[file.Path] = file
+	}
+
+	files := make([]DiscoveredFile, 0, len(filesByPath))
+	for _, file := range filesByPath {
+		files = append(files, file)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files
+}
+
+func discoverVisualStudioCopilotVS2026SessionFiles(
+	root string,
+) []DiscoveredFile {
+	root = filepath.Clean(root)
+	switch visualStudioCopilotVS2026RootKind(root) {
+	case visualStudioCopilotVS2026SessionsRoot:
+		return discoverVisualStudioCopilotVS2026SessionFilesInDirectory(root)
+	case visualStudioCopilotVS2026ThreadRoot:
+		return discoverVisualStudioCopilotVS2026SessionFilesInDirectory(
+			filepath.Join(root, "sessions"),
+		)
+	case visualStudioCopilotVS2026CopilotChatRoot:
+		return discoverVisualStudioCopilotVS2026SessionFilesInCopilotChatRoot(root)
+	case visualStudioCopilotVS2026VSRoot:
+		return discoverVisualStudioCopilotVS2026SessionFilesInVSRoot(root)
+	default:
+		return discoverVisualStudioCopilotVS2026SessionFilesInVSRoot(
+			filepath.Join(root, ".vs"),
+		)
+	}
+}
+
+func discoverVisualStudioCopilotVS2026SessionFilesInVSRoot(
+	vsRoot string,
+) []DiscoveredFile {
+	solutions, err := os.ReadDir(vsRoot)
 	if err != nil {
 		return nil
 	}
-	files := discoverVisualStudioCopilotSessionFiles(vsRoot, entries)
-	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
-	return files
+	out := []DiscoveredFile{}
+	for _, solution := range solutions {
+		if !solution.IsDir() {
+			continue
+		}
+		out = append(
+			out,
+			discoverVisualStudioCopilotVS2026SessionFilesInCopilotChatRoot(
+				filepath.Join(vsRoot, solution.Name(), "copilot-chat"),
+			)...,
+		)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+func discoverVisualStudioCopilotVS2026SessionFilesInCopilotChatRoot(
+	copilotChatRoot string,
+) []DiscoveredFile {
+	threads, err := os.ReadDir(copilotChatRoot)
+	if err != nil {
+		return nil
+	}
+	out := []DiscoveredFile{}
+	for _, thread := range threads {
+		if !thread.IsDir() {
+			continue
+		}
+		out = append(
+			out,
+			discoverVisualStudioCopilotVS2026SessionFilesInDirectory(
+				filepath.Join(copilotChatRoot, thread.Name(), "sessions"),
+			)...,
+		)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+func discoverVisualStudioCopilotVS2026SessionFilesInDirectory(
+	dir string,
+) []DiscoveredFile {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	out := make([]DiscoveredFile, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !isVisualStudioCopilotVS2026SessionFileName(name) {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if !isVisualStudioCopilotVS2026SessionPath(path) {
+			continue
+		}
+		out = append(out, DiscoveredFile{
+			Path:    VisualStudioCopilotVirtualPath(path, name),
+			Project: "visualstudio",
+			Agent:   AgentVSCopilot,
+		})
+	}
+	return out
 }
 
 func vsCopilotWatchRoots(roots []string) []WatchRoot {
@@ -120,6 +234,17 @@ func vsCopilotClassifyPath(
 	path = filepath.Clean(path)
 	if tracePath, conversationID, ok :=
 		splitVisualStudioCopilotVirtualPath(path); ok {
+		if isVisualStudioCopilotVS2026SessionPath(tracePath) {
+			if !visualStudioCopilotVS2026SessionUnderRoot(root, tracePath) {
+				return multiSessionMatch{}, false
+			}
+			return multiSessionMatch{
+				Path:        path,
+				Container:   tracePath,
+				MemberID:    conversationID,
+				ProjectHint: "visualstudio",
+			}, true
+		}
 		if !visualStudioCopilotTraceUnderRoot(root, tracePath, true) {
 			return multiSessionMatch{}, false
 		}
@@ -127,6 +252,15 @@ func vsCopilotClassifyPath(
 			Path:        path,
 			Container:   tracePath,
 			MemberID:    conversationID,
+			ProjectHint: "visualstudio",
+		}, true
+	}
+	if isVisualStudioCopilotVS2026SessionPath(path) &&
+		visualStudioCopilotVS2026SessionUnderRoot(root, path) {
+		return multiSessionMatch{
+			Path:        VisualStudioCopilotVirtualPath(path, filepath.Base(path)),
+			Container:   path,
+			MemberID:    filepath.Base(path),
 			ProjectHint: "visualstudio",
 		}, true
 	}
@@ -154,7 +288,82 @@ func findVisualStudioCopilotSourceFile(root, rawID string) string {
 	if root == "" || !IsValidSessionID(rawID) {
 		return ""
 	}
-	return findVisualStudioCopilotTraceSourceFile(root, rawID)
+	if path := findVisualStudioCopilotTraceSourceFile(root, rawID); path != "" {
+		return path
+	}
+	return findVisualStudioCopilotVS2026SourceFile(root, rawID)
+}
+
+func findVisualStudioCopilotVS2026SourceFile(
+	root, rawID string,
+) string {
+	for _, file := range discoverVisualStudioCopilotVS2026SessionFiles(root) {
+		path, conversationID, ok := splitVisualStudioCopilotVirtualPath(file.Path)
+		if !ok || conversationID != rawID {
+			continue
+		}
+		return VisualStudioCopilotVirtualPath(path, rawID)
+	}
+	return ""
+}
+
+func visualStudioCopilotVS2026SessionUnderRoot(
+	root, path string,
+) bool {
+	rel, ok := relUnder(root, path)
+	if !ok {
+		return false
+	}
+	if !isVisualStudioCopilotVS2026SessionPath(path) {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	switch visualStudioCopilotVS2026RootKind(root) {
+	case visualStudioCopilotVS2026SessionsRoot:
+		return len(parts) == 1
+	case visualStudioCopilotVS2026ThreadRoot:
+		return len(parts) == 2 && parts[0] == "sessions"
+	case visualStudioCopilotVS2026CopilotChatRoot:
+		return len(parts) == 3 && parts[1] == "sessions"
+	case visualStudioCopilotVS2026VSRoot:
+		return len(parts) == 5 &&
+			parts[1] == "copilot-chat" &&
+			parts[3] == "sessions"
+	default:
+		return len(parts) == 6 &&
+			strings.EqualFold(parts[0], ".vs") &&
+			parts[2] == "copilot-chat" &&
+			parts[4] == "sessions"
+	}
+}
+
+type visualStudioCopilotVS2026RootMode int
+
+const (
+	visualStudioCopilotVS2026ProjectRoot visualStudioCopilotVS2026RootMode = iota
+	visualStudioCopilotVS2026VSRoot
+	visualStudioCopilotVS2026CopilotChatRoot
+	visualStudioCopilotVS2026ThreadRoot
+	visualStudioCopilotVS2026SessionsRoot
+)
+
+func visualStudioCopilotVS2026RootKind(
+	root string,
+) visualStudioCopilotVS2026RootMode {
+	root = filepath.Clean(root)
+	switch {
+	case strings.EqualFold(filepath.Base(root), "sessions") &&
+		strings.EqualFold(filepath.Base(filepath.Dir(filepath.Dir(root))), "copilot-chat"):
+		return visualStudioCopilotVS2026SessionsRoot
+	case strings.EqualFold(filepath.Base(filepath.Dir(root)), "copilot-chat"):
+		return visualStudioCopilotVS2026ThreadRoot
+	case strings.EqualFold(filepath.Base(root), "copilot-chat"):
+		return visualStudioCopilotVS2026CopilotChatRoot
+	case strings.EqualFold(filepath.Base(root), ".vs"):
+		return visualStudioCopilotVS2026VSRoot
+	default:
+		return visualStudioCopilotVS2026ProjectRoot
+	}
 }
 
 func vsCopilotFingerprintSource(
@@ -218,7 +427,7 @@ func vsCopilotParseContainer(
 // splitVisualStudioCopilotVirtualPath splits a <traceFile>#<conversationID>
 // virtual source path into its physical trace file and conversation ID. It
 // builds on the provider-neutral ParseVirtualSourcePath splitter and adds the
-// Visual Studio Copilot validation: the container must name a trace file and the
+// Visual Studio Copilot validation: the container must name a trace file path and
 // source ID must be a valid conversation ID. It returns ok=false for a plain
 // trace-file path.
 func splitVisualStudioCopilotVirtualPath(
@@ -228,7 +437,7 @@ func splitVisualStudioCopilotVirtualPath(
 	if !ok {
 		return "", "", false
 	}
-	if !IsVisualStudioCopilotTraceFile(tracePath) ||
+	if !isVisualStudioCopilotConversationPath(tracePath) ||
 		!IsValidSessionID(conversationID) {
 		return "", "", false
 	}

--- a/internal/parser/visualstudio_copilot_test.go
+++ b/internal/parser/visualstudio_copilot_test.go
@@ -1836,6 +1836,44 @@ func TestWriteVisualStudioCopilotConversationJSONLTraversesSiblings(
 	assert.NotContains(t, out, other)
 }
 
+func TestWriteVisualStudioCopilotConversationJSONLReadsVS2026SessionFile(
+	t *testing.T,
+) {
+	dir := t.TempDir()
+	convA := "4a8f63f6-7626-4416-a874-fc7bd2c3f005"
+	convB := "c0aca2e3-d1f2-4d28-bd5e-5dab29e2be28"
+	path := filepath.Join(
+		dir, ".vs", "SampleApp", "copilot-chat", "thread", "sessions", convA,
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	lineA := vsCopilotTraceLineJSONWithSpanID(convA, "a1", "chat gpt-5.5",
+		"1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Conversation A prompt."}]}]`,
+		})
+	lineB := vsCopilotTraceLineJSONWithSpanID(convB, "b1", "chat gpt-5.5",
+		"1781293620000000000", "1781293630000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Other conversation secret B."}]}]`,
+		})
+	require.NoError(t, os.WriteFile(path, []byte(lineA+"\n"+lineB+"\n"), 0o644))
+
+	var buf bytes.Buffer
+	require.NoError(
+		t, WriteVisualStudioCopilotConversationJSONL(&buf, path, convA),
+	)
+
+	out := buf.String()
+	assert.Contains(t, out, "Conversation A prompt.")
+	assert.NotContains(t, out, convB)
+	assert.NotContains(t, out, "Other conversation secret B.")
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 1)
+	assert.JSONEq(t, lineA, lines[0])
+}
+
 func vsCopilotTraceLineJSON(
 	conversationID, name, start, end string,
 	attrs map[string]string,

--- a/internal/parser/visualstudio_copilot_test.go
+++ b/internal/parser/visualstudio_copilot_test.go
@@ -45,6 +45,50 @@ func TestDiscoverVisualStudioCopilotSessions(t *testing.T) {
 	assert.Equal(t, AgentVSCopilot, files[0].Agent)
 }
 
+func TestDiscoverVisualStudioCopilot2026Sessions_SupportedRootLayouts(t *testing.T) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	data := vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"What changed?"}]}]`,
+		},
+	) + "\n"
+	writeSourceFile(t, sessionPath, data)
+
+	cases := []struct {
+		name string
+		root string
+	}{
+		{name: "project root", root: root},
+		{name: ".vs root", root: filepath.Join(root, ".vs")},
+		{name: "copilot-chat root", root: filepath.Join(root, ".vs", "SampleApp", "copilot-chat")},
+		{name: "thread root", root: filepath.Join(root, ".vs", "SampleApp", "copilot-chat", "thread")},
+		{name: "sessions root", root: filepath.Join(root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			files := discoverVisualStudioCopilotTestSessions(t, tc.root)
+
+			require.Len(t, files, 1)
+			assert.Equal(
+				t,
+				VisualStudioCopilotVirtualPath(sessionPath, conversationID),
+				files[0].Path,
+			)
+			assert.Equal(t, "visualstudio", files[0].Project)
+			assert.Equal(t, AgentVSCopilot, files[0].Agent)
+		})
+	}
+}
+
 func TestDiscoverVisualStudioCopilotSessions_IgnoresParentDirs(t *testing.T) {
 	root := t.TempDir()
 	tracesDir := filepath.Join(
@@ -121,6 +165,45 @@ func TestVisualStudioCopilotLookupMatchesDiscoveryWhenMtimeAndPathDisagree(t *te
 	found := findVisualStudioCopilotTraceSourceFile(root, conversationID)
 	assert.Equal(t, files[0].Path, found,
 		"lookup must resolve to the same canonical trace as discovery")
+}
+
+func TestFindVisualStudioCopilotSourceFile_2026SupportedRootLayouts(t *testing.T) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	data := vsCopilotTraceLineJSON(
+		conversationID,
+		"chat gpt-5.5", "1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	) + "\n"
+	writeSourceFile(t, sessionPath, data)
+
+	cases := []struct {
+		name string
+		root string
+	}{
+		{name: "project root", root: root},
+		{name: ".vs root", root: filepath.Join(root, ".vs")},
+		{name: "copilot-chat root", root: filepath.Join(root, ".vs", "SampleApp", "copilot-chat")},
+		{name: "thread root", root: filepath.Join(root, ".vs", "SampleApp", "copilot-chat", "thread")},
+		{name: "sessions root", root: filepath.Join(root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				VisualStudioCopilotVirtualPath(sessionPath, conversationID),
+				findVisualStudioCopilotTestSourceFile(t, tc.root, conversationID),
+			)
+		})
+	}
 }
 
 func TestParseVisualStudioCopilotSession_MalformedTraceLineReturnsError(t *testing.T) {
@@ -397,10 +480,19 @@ func TestDiscoverVisualStudioCopilotSessions_EnqueuesUnreadableTraceFile(t *test
 func TestResolveSourceFilePath(t *testing.T) {
 	trace := "/logs/20260612T194439_257709a3_VSGitHubCopilot_traces.jsonl"
 	conversationID := "4a8f63f6-7626-4416-a874-fc7bd2c3f005"
+	sessionPath := filepath.Join(
+		"/logs", ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
 
 	assert.Equal(t, trace,
 		ResolveSourceFilePath(VisualStudioCopilotVirtualPath(trace, conversationID)),
 		"virtual path should resolve to its physical trace file")
+	assert.Equal(t, sessionPath,
+		ResolveSourceFilePath(
+			VisualStudioCopilotVirtualPath(sessionPath, conversationID),
+		),
+		"VS 2026 session virtual path should resolve to its physical session file")
 	assert.Equal(t, "/logs/session.jsonl",
 		ResolveSourceFilePath("/logs/session.jsonl"),
 		"a plain source path should be returned unchanged")

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -391,10 +392,11 @@ func isVibeReplacement(requestedID string, detail *SessionDetail) bool {
 }
 
 // resolveSessionIDByPath returns the single session id whose
-// file_path equals the given absolute path. When a JSONL file
-// produces multiple sessions (e.g. Claude forked transcripts),
-// sync returns an ambiguity error instead of picking arbitrarily,
-// so the caller can disambiguate via `session sync <id>`.
+// file_path equals the given absolute path or a virtual key backed
+// by it. When a physical file produces multiple sessions (e.g.
+// Claude forked transcripts), sync returns an ambiguity error
+// instead of picking arbitrarily, so the caller can disambiguate via
+// `session sync <id>`.
 // Only called from Sync after it has verified b.local != nil.
 func (b *directBackend) resolveSessionIDByPath(
 	ctx context.Context, path string,
@@ -405,10 +407,10 @@ func (b *directBackend) resolveSessionIDByPath(
 	queryArgs := []any{path}
 	// Visual Studio Copilot stores file_path as a virtual sync key
 	// <traceFile>#<conversationID>, so an exact match on the physical
-	// trace path never resolves. Also match every conversation synced
-	// from that trace; multiple matches fall through to the ambiguity
-	// error below, exactly like a multi-session JSONL file.
-	if parser.IsVisualStudioCopilotTraceFile(path) {
+	// container path never resolves. Also match every conversation
+	// synced from that container; multiple matches fall through to the
+	// ambiguity error below, exactly like a multi-session JSONL file.
+	if isVisualStudioCopilotVirtualContainerPath(path) {
 		q = `SELECT id FROM sessions
 			WHERE file_path = ? OR file_path LIKE ? ESCAPE '\'
 			ORDER BY created_at DESC`
@@ -451,6 +453,16 @@ func (b *directBackend) resolveSessionIDByPath(
 			len(ids), path, ids,
 		)
 	}
+}
+
+func isVisualStudioCopilotVirtualContainerPath(path string) bool {
+	if parser.IsVisualStudioCopilotTraceFile(path) {
+		return true
+	}
+	_, _, ok := parser.SplitVisualStudioCopilotVirtualPath(
+		parser.VisualStudioCopilotVirtualPath(path, filepath.Base(path)),
+	)
+	return ok
 }
 
 // Watch returns a stream of events for the given session,

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -352,6 +352,41 @@ func TestDirectBackend_Sync_VSCopilotPhysicalPathResolvesSession(t *testing.T) {
 	assert.Equal(t, sessionID, detail.ID)
 }
 
+// TestDirectBackend_Sync_VSCopilotVS2026PhysicalPathResolvesSession verifies
+// that syncing a Visual Studio 2026 Copilot session by its physical session
+// file resolves the single session whose stored file_path is the
+// <sessionFile>#<conversationID> virtual key for that file.
+func TestDirectBackend_Sync_VSCopilotVS2026PhysicalPathResolvesSession(
+	t *testing.T,
+) {
+	t.Parallel()
+	d := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(d, sync.EngineConfig{Ephemeral: true})
+	svc := service.NewDirectBackend(d, engine)
+
+	convID := "4a8f63f6-7626-4416-a874-fc7bd2c3f005"
+	sessionPath := filepath.Join(
+		"/workspace", ".vs", "SampleApp", "copilot-chat", "thread",
+		"sessions", convID,
+	)
+	virtual := parser.VisualStudioCopilotVirtualPath(sessionPath, convID)
+	sessionID := "visualstudio-copilot:" + convID
+	require.NoError(t, d.UpsertSession(db.Session{
+		ID:       sessionID,
+		Project:  "visualstudio",
+		Machine:  "local",
+		Agent:    "visualstudio-copilot",
+		FilePath: &virtual,
+	}))
+
+	detail, err := svc.Sync(context.Background(), service.SyncInput{
+		Path: sessionPath,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.Equal(t, sessionID, detail.ID)
+}
+
 // TestDirectBackend_Sync_VSCopilotPhysicalPathAmbiguous verifies that a
 // physical trace file backing several conversations still yields the
 // disambiguation error rather than picking one arbitrarily.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2034,6 +2034,15 @@ func (e *Engine) discoverProviderSources(
 			failures++
 			continue
 		}
+		currentSources := providerSourcePathSet(sources)
+		if agentType == parser.AgentVSCopilot {
+			sources = append(
+				sources,
+				e.visualStudioCopilotMissingVS2026PollSources(
+					ctx, provider, filteredRoots, currentSources,
+				)...,
+			)
+		}
 		// Forge, Piebald, and Warp are DB-backed providers: a shared SQLite
 		// DB hosts every session. Full-sync change detection and counting
 		// run through their dedicated provider-driven DB sync phase
@@ -2084,6 +2093,122 @@ func (e *Engine) discoverProviderSources(
 		}
 	}
 	return files, failures
+}
+
+func providerSourcePathSet(sources []parser.SourceRef) map[string]struct{} {
+	seen := make(map[string]struct{}, len(sources))
+	for _, source := range sources {
+		path := providerDiscoveredPath(source)
+		if path == "" {
+			continue
+		}
+		seen[filepath.Clean(path)] = struct{}{}
+	}
+	return seen
+}
+
+func (e *Engine) visualStudioCopilotMissingVS2026PollSources(
+	ctx context.Context,
+	provider parser.Provider,
+	roots []string,
+	currentSources map[string]struct{},
+) []parser.SourceRef {
+	watchRoots := providerChangedPathWatchRoots(ctx, provider, roots)
+	var out []parser.SourceRef
+	seenHints := make(map[string]struct{})
+	for _, watchRoot := range watchRoots {
+		hints, err := e.db.ListStoredSourcePathHints(
+			string(parser.AgentVSCopilot), []string{watchRoot},
+		)
+		if err != nil {
+			log.Printf(
+				"%s provider poll stored hints: %v",
+				parser.AgentVSCopilot, err,
+			)
+			continue
+		}
+		for _, hint := range hints {
+			hint = filepath.Clean(hint)
+			if _, seen := seenHints[hint]; seen {
+				continue
+			}
+			seenHints[hint] = struct{}{}
+			container, conversationID, ok :=
+				parser.SplitVisualStudioCopilotVirtualPath(hint)
+			if !ok ||
+				!parser.IsVisualStudioCopilotVS2026SessionPath(container) {
+				continue
+			}
+			if _, ok := currentSources[hint]; ok {
+				continue
+			}
+			if current, ok := e.visualStudioCopilotCurrentPollSource(
+				ctx, provider, conversationID,
+			); ok {
+				sourcePath := providerDiscoveredPath(current)
+				if sourcePath == "" {
+					continue
+				}
+				path := filepath.Clean(sourcePath)
+				if _, exists := currentSources[path]; !exists {
+					currentSources[path] = struct{}{}
+					out = append(out, current)
+				}
+				continue
+			}
+			tombstones, err := provider.SourcesForChangedPath(
+				ctx,
+				parser.ChangedPathRequest{
+					Path:              hint,
+					EventKind:         "remove",
+					WatchRoot:         watchRoot,
+					StoredSourcePaths: []string{hint},
+				},
+			)
+			if err != nil {
+				log.Printf(
+					"%s provider poll tombstone: %v",
+					parser.AgentVSCopilot, err,
+				)
+				continue
+			}
+			for _, tombstone := range tombstones {
+				sourcePath := providerDiscoveredPath(tombstone)
+				if sourcePath == "" {
+					continue
+				}
+				path := filepath.Clean(sourcePath)
+				if _, exists := currentSources[path]; exists {
+					continue
+				}
+				currentSources[path] = struct{}{}
+				out = append(out, tombstone)
+			}
+		}
+	}
+	return out
+}
+
+func (e *Engine) visualStudioCopilotCurrentPollSource(
+	ctx context.Context,
+	provider parser.Provider,
+	conversationID string,
+) (parser.SourceRef, bool) {
+	current, ok, err := provider.FindSource(
+		ctx,
+		parser.FindSourceRequest{
+			RawSessionID:       conversationID,
+			RequireFreshSource: true,
+		},
+	)
+	if err != nil {
+		log.Printf(
+			"%s provider poll source lookup: %v",
+			parser.AgentVSCopilot, err,
+		)
+		return parser.SourceRef{}, false
+	}
+	return current, ok
 }
 
 // expandCodexProviderDuplicates re-adds the on-disk duplicate paths of each

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2156,6 +2156,11 @@ func (e *Engine) visualStudioCopilotMissingVS2026PollSources(
 				}
 				continue
 			}
+			if !visualStudioCopilotVS2026PollCanTombstone(
+				roots, container,
+			) {
+				continue
+			}
 			tombstones, err := provider.SourcesForChangedPath(
 				ctx,
 				parser.ChangedPathRequest{
@@ -2187,6 +2192,31 @@ func (e *Engine) visualStudioCopilotMissingVS2026PollSources(
 		}
 	}
 	return out
+}
+
+func visualStudioCopilotVS2026PollCanTombstone(
+	roots []string,
+	container string,
+) bool {
+	if container == "" {
+		return false
+	}
+	container = filepath.Clean(container)
+	if parser.IsRegularFile(container) {
+		return false
+	}
+	if !reachableDir(filepath.Dir(container)) {
+		return false
+	}
+	return slices.ContainsFunc(roots, func(root string) bool {
+		root = filepath.Clean(root)
+		return samePathOrDescendant(container, root) && reachableDir(root)
+	})
+}
+
+func reachableDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info != nil && info.IsDir()
 }
 
 func (e *Engine) visualStudioCopilotCurrentPollSource(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2035,13 +2035,18 @@ func (e *Engine) discoverProviderSources(
 			continue
 		}
 		currentSources := providerSourcePathSet(sources)
+		forceParseSources := map[string]struct{}{}
 		if agentType == parser.AgentVSCopilot {
-			sources = append(
-				sources,
+			missingSources, forceSources :=
 				e.visualStudioCopilotMissingVS2026PollSources(
 					ctx, provider, filteredRoots, currentSources,
-				)...,
-			)
+				)
+			sources = append(sources, missingSources...)
+			maps.Copy(forceParseSources, forceSources)
+		}
+		forceParseSource := func(sourcePath string) bool {
+			_, ok := forceParseSources[filepath.Clean(sourcePath)]
+			return ok
 		}
 		// Forge, Piebald, and Warp are DB-backed providers: a shared SQLite
 		// DB hosts every session. Full-sync change detection and counting
@@ -2070,6 +2075,9 @@ func (e *Engine) discoverProviderSources(
 				Agent:           agent,
 				ProviderSource:  &sourceCopy,
 				ProviderProcess: true,
+			}
+			if forceParseSource(sourcePath) {
+				discovered.ForceParse = true
 			}
 			// S3-aware source sets carry the durable object metadata in the
 			// Opaque payload. Thread it into the DiscoveredFile so the S3 sync
@@ -2112,10 +2120,11 @@ func (e *Engine) visualStudioCopilotMissingVS2026PollSources(
 	provider parser.Provider,
 	roots []string,
 	currentSources map[string]struct{},
-) []parser.SourceRef {
+) ([]parser.SourceRef, map[string]struct{}) {
 	watchRoots := providerChangedPathWatchRoots(ctx, provider, roots)
 	var out []parser.SourceRef
 	seenHints := make(map[string]struct{})
+	forceParseSources := make(map[string]struct{})
 	for _, watchRoot := range watchRoots {
 		hints, err := e.db.ListStoredSourcePathHints(
 			string(parser.AgentVSCopilot), []string{watchRoot},
@@ -2150,6 +2159,7 @@ func (e *Engine) visualStudioCopilotMissingVS2026PollSources(
 					continue
 				}
 				path := filepath.Clean(sourcePath)
+				forceParseSources[path] = struct{}{}
 				if _, exists := currentSources[path]; !exists {
 					currentSources[path] = struct{}{}
 					out = append(out, current)
@@ -2187,11 +2197,12 @@ func (e *Engine) visualStudioCopilotMissingVS2026PollSources(
 					continue
 				}
 				currentSources[path] = struct{}{}
+				forceParseSources[path] = struct{}{}
 				out = append(out, tombstone)
 			}
 		}
 	}
-	return out
+	return out, forceParseSources
 }
 
 func visualStudioCopilotVS2026PollCanTombstone(
@@ -2360,6 +2371,10 @@ func (e *Engine) filterFilesByMtime(
 	out := files[:0]
 	codexIndexRefresh := make(map[string][]parser.DiscoveredFile)
 	for _, f := range files {
+		if f.ForceParse {
+			out = append(out, f)
+			continue
+		}
 		mtime, err := e.discoveredFileEffectiveMtime(ctx, f)
 		if err != nil {
 			out = append(out, f)

--- a/internal/sync/visualstudio_copilot_integration_test.go
+++ b/internal/sync/visualstudio_copilot_integration_test.go
@@ -286,6 +286,49 @@ func TestSyncRootsSinceVisualStudioCopilotPollTombstonesDeletedVS2026Session(
 		"unwatched polling must tombstone deleted VS 2026 session files")
 }
 
+func TestSyncRootsSinceVisualStudioCopilotPollPreservesVS2026SessionWhenRootMissing(
+	t *testing.T,
+) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "workspace")
+	conversationID := "4a8f63f6-7626-4416-a874-fc7bd2c3f005"
+	sessionID := "visualstudio-copilot:" + conversationID
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		vsCopilotTraceLine(conversationID, "d1", "chat gpt-5.5",
+			"1781293600000000000", "1781293610000000000",
+			map[string]string{
+				"gen_ai.operation.name": "chat",
+				"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Hello."}]}]`,
+			})+"\n"), 0o644))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVSCopilot: {root},
+		},
+		Machine: "local",
+	})
+	require.NotZero(t, engine.SyncAll(context.Background(), nil).Synced)
+	assertSessionMessageCount(t, database, sessionID, 1)
+
+	require.NoError(t, os.RemoveAll(root))
+	engine.SyncRootsSince(context.Background(), []string{root}, time.Time{}, nil)
+
+	preserved, err := database.GetSession(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, preserved,
+		"polling must preserve archived VS 2026 sessions when the root is unavailable")
+	assertSessionMessageCount(t, database, sessionID, 1)
+}
+
 // TestSyncSingleSessionContextVisualStudioCopilotPreservesProject verifies that
 // a single-session re-sync keeps the stored project rather than overwriting it
 // with the provider's default project.

--- a/internal/sync/visualstudio_copilot_integration_test.go
+++ b/internal/sync/visualstudio_copilot_integration_test.go
@@ -245,6 +245,47 @@ func TestFindSourceFileVisualStudioCopilotReturnsVirtualPath(t *testing.T) {
 		"mtime must resolve the virtual path to the physical trace")
 }
 
+func TestSyncRootsSinceVisualStudioCopilotPollTombstonesDeletedVS2026Session(
+	t *testing.T,
+) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	conversationID := "4a8f63f6-7626-4416-a874-fc7bd2c3f005"
+	sessionID := "visualstudio-copilot:" + conversationID
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		vsCopilotTraceLine(conversationID, "d1", "chat gpt-5.5",
+			"1781293600000000000", "1781293610000000000",
+			map[string]string{
+				"gen_ai.operation.name": "chat",
+				"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Hello."}]}]`,
+			})+"\n"), 0o644))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVSCopilot: {root},
+		},
+		Machine: "local",
+	})
+	require.NotZero(t, engine.SyncAll(context.Background(), nil).Synced)
+	assertSessionMessageCount(t, database, sessionID, 1)
+
+	require.NoError(t, os.Remove(sessionPath))
+	engine.SyncRootsSince(context.Background(), []string{root}, time.Time{}, nil)
+
+	gone, err := database.GetSession(context.Background(), sessionID)
+	require.NoError(t, err)
+	assert.Nil(t, gone,
+		"unwatched polling must tombstone deleted VS 2026 session files")
+}
+
 // TestSyncSingleSessionContextVisualStudioCopilotPreservesProject verifies that
 // a single-session re-sync keeps the stored project rather than overwriting it
 // with the provider's default project.

--- a/internal/sync/visualstudio_copilot_integration_test.go
+++ b/internal/sync/visualstudio_copilot_integration_test.go
@@ -329,6 +329,63 @@ func TestSyncRootsSinceVisualStudioCopilotPollPreservesVS2026SessionWhenRootMiss
 	assertSessionMessageCount(t, database, sessionID, 1)
 }
 
+func TestSyncRootsSinceVisualStudioCopilotRecanonicalizesDeletedVS2026SessionToOldLegacyTrace(
+	t *testing.T,
+) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	conversationID := "4a8f63f6-7626-4416-a874-fc7bd2c3f005"
+	sessionID := "visualstudio-copilot:" + conversationID
+	data := vsCopilotTraceLine(conversationID, "d1", "chat gpt-5.5",
+		"1781293600000000000", "1781293610000000000",
+		map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Hello."}]}]`,
+		}) + "\n"
+	legacyPath := filepath.Join(
+		root, "20260612T194439_257709a3_VSGitHubCopilot_traces.jsonl",
+	)
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	require.NoError(t, os.WriteFile(legacyPath, []byte(data), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(data), 0o644))
+	legacyMtime := time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC)
+	sessionMtime := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(legacyPath, legacyMtime, legacyMtime))
+	require.NoError(t, os.Chtimes(sessionPath, sessionMtime, sessionMtime))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVSCopilot: {root},
+		},
+		Machine: "local",
+	})
+	require.NotZero(t, engine.SyncAll(context.Background(), nil).Synced)
+	vsVirtualPath := parser.VisualStudioCopilotVirtualPath(
+		sessionPath, conversationID,
+	)
+	require.Equal(t, vsVirtualPath, database.GetSessionFilePath(sessionID))
+
+	require.NoError(t, os.Remove(sessionPath))
+	stats := engine.SyncRootsSince(
+		context.Background(), []string{root},
+		time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC), nil,
+	)
+	require.NotZero(t, stats.Synced)
+
+	legacyVirtualPath := parser.VisualStudioCopilotVirtualPath(
+		legacyPath, conversationID,
+	)
+	assert.Equal(t, legacyVirtualPath, database.GetSessionFilePath(sessionID))
+	assertSessionMessageCount(t, database, sessionID, 1)
+}
+
 // TestSyncSingleSessionContextVisualStudioCopilotPreservesProject verifies that
 // a single-session re-sync keeps the stored project rather than overwriting it
 // with the provider's default project.


### PR DESCRIPTION
Visual Studio Copilot sessions from Visual Studio 2026 are currently missed because the parser only discovers the older `VSGitHubCopilotLogs/traces` layout. The new Visual Studio layout stores Copilot Chat data under each project’s `.vs/<ProjectName>/copilot-chat/<thread>/sessions/<GUID>` tree, so a configured project root or `.vs` root produces no Visual Studio Copilot sources today.

This teaches the existing Visual Studio Copilot provider to recognize the project-local session layout while keeping the current shared-trace behavior intact. Discovery, changed-path classification, watch planning, and source identity stay in the provider that already owns the Visual Studio Copilot surface, and payload parsing still reuses the current normalization path where the on-disk JSONL shape matches. The update also keeps mixed legacy and VS 2026 storage on one canonical session source, so the same conversation ID does not get rewritten from two competing file identities.

The focused coverage proves that project-root and `.vs`-root discovery find Visual Studio 2026 session files, that delete and write handling classify the new layout correctly, that the watch plan covers the nested session roots Visual Studio 2026 writes under, that non-GUID extensionless files stay rejected, and that legacy `*_VSGitHubCopilot_traces.jsonl` sources still discover and resolve exactly as before.

Fixes #890
