### PR TITLE
feat(sessions): fork Claude sessions from a message point

### DIFF
--- a/cmd/agentsview/daemon_runtime_test.go
+++ b/cmd/agentsview/daemon_runtime_test.go
@@ -293,6 +293,67 @@ func startExternalDaemonStartLockHelper(t *testing.T, dataDir string) io.Closer 
 	return stdin
 }
 
+func holdExternalBackgroundLaunchLock(t *testing.T, dataDir string) func() {
+	t.Helper()
+	stdin := startExternalBackgroundLaunchLockHelper(t, dataDir)
+
+	var once sync.Once
+	unlock := func() {
+		once.Do(func() { _ = stdin.Close() })
+	}
+	t.Cleanup(unlock)
+	return unlock
+}
+
+func startExternalBackgroundLaunchLockHelper(
+	t *testing.T,
+	dataDir string,
+) io.Closer {
+	t.Helper()
+	cmd := exec.Command(
+		os.Args[0],
+		"-test.run=^TestHoldExternalBackgroundLaunchLockHelperProcess$",
+	)
+	cmd.Env = append(
+		os.Environ(),
+		"AGENTSVIEW_HOLD_EXTERNAL_BACKGROUND_LAUNCH_LOCK_HELPER=1",
+		"AGENTSVIEW_HOLD_EXTERNAL_BACKGROUND_LAUNCH_LOCK_DATA_DIR="+dataDir,
+	)
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+			<-done
+		}
+	})
+
+	line, err := bufio.NewReader(stdout).ReadString('\n')
+	if err != nil {
+		_ = cmd.Process.Kill()
+		require.NoError(t, err)
+	}
+	if strings.TrimSpace(line) != "ready" {
+		_ = cmd.Process.Kill()
+		require.Equal(t, "ready", strings.TrimSpace(line))
+	}
+	require.Eventually(t, func() bool {
+		return isBackgroundLaunchActive(dataDir)
+	}, 2*time.Second, 10*time.Millisecond,
+		"external background launch lock should be visible to parent")
+	return stdin
+}
+
 func TestHoldExternalDaemonStartLockHelperProcess(t *testing.T) {
 	if os.Getenv("AGENTSVIEW_HOLD_EXTERNAL_START_LOCK_HELPER") != "1" {
 		return
@@ -302,6 +363,26 @@ func TestHoldExternalDaemonStartLockHelperProcess(t *testing.T) {
 	lockPath, err := runtimeStore(dataDir).LockPath()
 	require.NoError(t, err)
 	lock := flock.New(lockPath)
+	locked, err := lock.TryLock()
+	require.NoError(t, err)
+	require.True(t, locked)
+	fmt.Println("ready")
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	require.NoError(t, lock.Unlock())
+}
+
+func TestHoldExternalBackgroundLaunchLockHelperProcess(t *testing.T) {
+	if os.Getenv(
+		"AGENTSVIEW_HOLD_EXTERNAL_BACKGROUND_LAUNCH_LOCK_HELPER",
+	) != "1" {
+		return
+	}
+	dataDir := os.Getenv(
+		"AGENTSVIEW_HOLD_EXTERNAL_BACKGROUND_LAUNCH_LOCK_DATA_DIR",
+	)
+	require.NotEmpty(t, dataDir)
+	require.NoError(t, os.MkdirAll(dataDir, 0o700))
+	lock := flock.New(backgroundLaunchLockPath(dataDir))
 	locked, err := lock.TryLock()
 	require.NoError(t, err)
 	require.True(t, locked)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -111,7 +111,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		}
 	}
 
-	cont, releaseForegroundReplacement, err := prepareForegroundServeDaemon(
+	cont, releaseForegroundServeLaunch, err := prepareForegroundServeDaemon(
 		&cfg,
 		serveReplacementOptions{
 			Replace:        opts.ReplaceDaemon,
@@ -124,7 +124,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 	if !cont {
 		return
 	}
-	defer releaseForegroundReplacement()
+	defer releaseForegroundServeLaunch()
 
 	// Acquire the daemon start lock immediately after config setup,
 	// before opening the DB, so token-use never sees a window
@@ -281,7 +281,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		runtimeRecordDataDir = rt.Cfg.DataDir
 		UnmarkDaemonStarting(rt.Cfg.DataDir)
 	}
-	releaseForegroundReplacement()
+	releaseForegroundServeLaunch()
 	if idleTracker != nil {
 		idleTracker.Touch()
 		go idleTracker.Run(ctx)
@@ -513,7 +513,7 @@ func rejectLiveWritableDaemonBeforeDirectWrite(cfg config.Config) error {
 		)
 	}
 	if isBackgroundLaunchActive(dataDir) &&
-		!ownsForegroundReplacementLaunchLock(dataDir) &&
+		!ownsForegroundServeLaunchLock(dataDir) &&
 		!runningAsBackgroundChild() {
 		return fmt.Errorf(
 			"local daemon launch is in progress and owns the SQLite archive; " +

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -545,6 +545,21 @@ func waitForExternalServeStartupBeforeReplacement(
 		ctx, dataDir, authToken, waitTimeout,
 	)
 	if !waited {
+		// A foreground startup can take the start lock immediately after the
+		// replacement decision is made. Recheck once before stopping the
+		// incumbent daemon so we do not cut across that handoff.
+		timer := time.NewTimer(startProbeTick())
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false, ctx.Err()
+		case <-timer.C:
+		}
+		_, waited, err = waitForExternalServeStartup(
+			ctx, dataDir, authToken, waitTimeout,
+		)
+	}
+	if !waited {
 		return false, nil
 	}
 	if err != nil && (errors.Is(err, errServeStartupInProgress) ||

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -545,21 +545,6 @@ func waitForExternalServeStartupBeforeReplacement(
 		ctx, dataDir, authToken, waitTimeout,
 	)
 	if !waited {
-		// A foreground startup can take the start lock immediately after the
-		// replacement decision is made. Recheck once before stopping the
-		// incumbent daemon so we do not cut across that handoff.
-		timer := time.NewTimer(startProbeTick())
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return false, ctx.Err()
-		case <-timer.C:
-		}
-		_, waited, err = waitForExternalServeStartup(
-			ctx, dataDir, authToken, waitTimeout,
-		)
-	}
-	if !waited {
 		return false, nil
 	}
 	if err != nil && (errors.Is(err, errServeStartupInProgress) ||

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1122,6 +1122,13 @@ func TestEnsureBackgroundServeLaunchLoserIgnoresReadOnlyRuntimeDuringReplacement
 	releaseLaunchLock := holdExternalBackgroundLaunchLock(t, dir)
 	MarkDaemonStarting(dir)
 	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+	oldStartProcess := startServeBackgroundProcessForEnsure
+	startServeBackgroundProcessForEnsure = func(
+		config.Config, []string,
+	) (*exec.Cmd, string, error) {
+		return nil, "", fmt.Errorf("start should not run")
+	}
+	t.Cleanup(func() { startServeBackgroundProcessForEnsure = oldStartProcess })
 
 	readOnlyHost, readOnlyPort := testPingServer(t)
 	_, err := WriteDaemonRuntime(
@@ -1134,8 +1141,8 @@ func TestEnsureBackgroundServeLaunchLoserIgnoresReadOnlyRuntimeDuringReplacement
 	published := make(chan error, 1)
 	go func() {
 		time.Sleep(2 * startProbeTick())
-		_, err := WriteDaemonRuntime(
-			dir, writableHost, writablePort, version, false,
+		err := publishDaemonRuntimeWhenVisible(
+			dir, writableHost, writablePort, version,
 		)
 		UnmarkDaemonStarting(dir)
 		releaseLaunchLock()

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1119,9 +1119,7 @@ func TestEnsureBackgroundServeLaunchLoserIgnoresReadOnlyRuntimeDuringReplacement
 	setStartProbeTickForTest(t, 25*time.Millisecond)
 
 	dir := runtimeTestDir(t)
-	launchLock, ok := acquireBackgroundLaunchLock(dir)
-	require.True(t, ok)
-	t.Cleanup(func() { _ = launchLock.Unlock() })
+	releaseLaunchLock := holdExternalBackgroundLaunchLock(t, dir)
 	MarkDaemonStarting(dir)
 	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
 
@@ -1140,7 +1138,7 @@ func TestEnsureBackgroundServeLaunchLoserIgnoresReadOnlyRuntimeDuringReplacement
 			dir, writableHost, writablePort, version, false,
 		)
 		UnmarkDaemonStarting(dir)
-		_ = launchLock.Unlock()
+		releaseLaunchLock()
 		published <- err
 	}()
 

--- a/cmd/agentsview/serve_replacement.go
+++ b/cmd/agentsview/serve_replacement.go
@@ -34,7 +34,7 @@ type serveReplacementDecision struct {
 	Reason           string
 }
 
-var foregroundReplacementLaunchLocks sync.Map
+var foregroundServeLaunchLocks sync.Map
 
 func prepareForegroundServeDaemon(
 	cfg *config.Config, opts serveReplacementOptions,
@@ -46,7 +46,17 @@ func prepareForegroundServeDaemon(
 	decision := decideServeDaemonReplacement(*cfg, opts)
 	switch decision.Action {
 	case serveReplacementNone:
-		return true, noRelease, nil
+		if runningAsBackgroundChild() {
+			return true, noRelease, nil
+		}
+		// A normal foreground start marks the daemon as starting after this
+		// function returns. Hold the launch lock first so background
+		// replacement cannot stop an incumbent during that handoff.
+		releaseLaunchLock, err := acquireForegroundServeLaunchLock(*cfg)
+		if err != nil {
+			return false, noRelease, err
+		}
+		return true, releaseLaunchLock, nil
 	case serveReplacementUseExisting:
 		rt := decision.Runtime
 		if rt != nil {
@@ -62,7 +72,7 @@ func prepareForegroundServeDaemon(
 		); err != nil {
 			return false, noRelease, err
 		}
-		releaseReplacementLock, err := acquireForegroundReplacementLock(*cfg)
+		releaseReplacementLock, err := acquireForegroundServeLaunchLock(*cfg)
 		if err != nil {
 			return false, noRelease, err
 		}
@@ -100,7 +110,7 @@ func prepareForegroundServeDaemon(
 	}
 }
 
-func acquireForegroundReplacementLock(cfg config.Config) (func(), error) {
+func acquireForegroundServeLaunchLock(cfg config.Config) (func(), error) {
 	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating data dir: %w", err)
 	}
@@ -112,15 +122,15 @@ func acquireForegroundReplacementLock(cfg config.Config) (func(), error) {
 		)
 	}
 	path := backgroundLaunchLockPath(cfg.DataDir)
-	foregroundReplacementLaunchLocks.Store(path, struct{}{})
+	foregroundServeLaunchLocks.Store(path, struct{}{})
 	return sync.OnceFunc(func() {
-		foregroundReplacementLaunchLocks.Delete(path)
+		foregroundServeLaunchLocks.Delete(path)
 		_ = lock.Unlock()
 	}), nil
 }
 
-func ownsForegroundReplacementLaunchLock(dataDir string) bool {
-	_, ok := foregroundReplacementLaunchLocks.Load(
+func ownsForegroundServeLaunchLock(dataDir string) bool {
+	_, ok := foregroundServeLaunchLocks.Load(
 		backgroundLaunchLockPath(dataDir),
 	)
 	return ok

--- a/cmd/agentsview/serve_replacement_test.go
+++ b/cmd/agentsview/serve_replacement_test.go
@@ -215,6 +215,68 @@ func TestPrepareForegroundServeDaemonRefusesReplacementWhenBackgroundLaunchHeld(
 	assert.NotNil(t, FindDaemonRuntime(dir))
 }
 
+func TestPrepareForegroundServeDaemonRefusesFreshStartWhenBackgroundLaunchHeld(
+	t *testing.T,
+) {
+	dir := runtimeTestDir(t)
+	launchLock, ok := acquireBackgroundLaunchLock(dir)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, launchLock.Unlock()) })
+
+	cont, release, err := prepareForegroundServeDaemon(
+		&config.Config{DataDir: dir}, serveReplacementOptions{},
+	)
+	t.Cleanup(release)
+
+	assert.False(t, cont)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "background")
+	assert.False(t, IsDaemonStarting(dir))
+}
+
+func TestPrepareForegroundServeDaemonKeepsLaunchLockForFreshStart(
+	t *testing.T,
+) {
+	dir := runtimeTestDir(t)
+
+	cont, release, err := prepareForegroundServeDaemon(
+		&config.Config{DataDir: dir}, serveReplacementOptions{},
+	)
+	t.Cleanup(release)
+
+	require.NoError(t, err)
+	assert.True(t, cont)
+	launchLock, ok := acquireBackgroundLaunchLock(dir)
+	if ok {
+		require.NoError(t, launchLock.Unlock())
+	}
+	assert.False(t, ok,
+		"foreground startup must hold launch lock until startup handoff")
+
+	release()
+	launchLock, ok = acquireBackgroundLaunchLock(dir)
+	require.True(t, ok)
+	require.NoError(t, launchLock.Unlock())
+}
+
+func TestPrepareForegroundServeDaemonBackgroundChildUsesParentLaunchLock(
+	t *testing.T,
+) {
+	dir := runtimeTestDir(t)
+	launchLock, ok := acquireBackgroundLaunchLock(dir)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, launchLock.Unlock()) })
+	t.Setenv(backgroundChildEnvVar, "1")
+
+	cont, release, err := prepareForegroundServeDaemon(
+		&config.Config{DataDir: dir}, serveReplacementOptions{},
+	)
+	t.Cleanup(release)
+
+	require.NoError(t, err)
+	assert.True(t, cont)
+}
+
 func TestPrepareForegroundServeDaemonStopsUnderBackgroundLaunchLock(
 	t *testing.T,
 ) {

--- a/frontend/src/lib/api/generated/models/ResumeRequest.ts
+++ b/frontend/src/lib/api/generated/models/ResumeRequest.ts
@@ -5,6 +5,7 @@
 export type ResumeRequest = {
   command_only?: boolean;
   fork_session?: boolean;
+  from_ordinal?: number;
   opener_id?: string;
   skip_permissions?: boolean;
 };

--- a/frontend/src/lib/components/content/MessageContent.svelte
+++ b/frontend/src/lib/components/content/MessageContent.svelte
@@ -15,6 +15,15 @@
   import { messages as messagesStore } from "../../stores/messages.svelte.js";
   import { sessionTiming } from "../../stores/sessionTiming.svelte.js";
   import { liveTick } from "../../stores/liveTick.svelte.js";
+  import {
+    configureGeneratedClient,
+    isRemoteConnection,
+  } from "../../api/runtime.js";
+  import {
+    SessionsService,
+    type ResumeRequest,
+    type ResumeResponse,
+  } from "../../api/generated/index";
   import ThinkingBlock from "./ThinkingBlock.svelte";
   import ToolBlock from "./ToolBlock.svelte";
   import ParallelGroup from "./ParallelGroup.svelte";
@@ -24,22 +33,30 @@
   import { ui } from "../../stores/ui.svelte.js";
   import { pins } from "../../stores/pins.svelte.js";
   import { sessions } from "../../stores/sessions.svelte.js";
+  import { sync } from "../../stores/sync.svelte.js";
   import { applyHighlight } from "../../utils/highlight.js";
   import { highlightCodeFences } from "../../utils/highlight-fences.js";
   import { renderMarkdown } from "../../utils/markdown.js";
   import { displayToolName } from "../../utils/toolDisplay.js";
-  import { PinIcon } from "../../icons.js";
+  import { CirclePlayIcon, PinIcon } from "../../icons.js";
   import type { Session } from "../../api/types.js";
   import { m } from "../../i18n/index.js";
 
   interface Props {
     message: Message;
+    session?: Session | null;
     isSubagentContext?: boolean;
     highlightQuery?: string;
     isCurrentHighlight?: boolean;
   }
 
-  let { message, isSubagentContext = false, highlightQuery = "", isCurrentHighlight = false }: Props = $props();
+  let {
+    message,
+    session,
+    isSubagentContext = false,
+    highlightQuery = "",
+    isCurrentHighlight = false,
+  }: Props = $props();
 
   let copied = $state(false);
 
@@ -86,10 +103,12 @@
     ),
   );
 
-  /** Resolve the session that owns this message, falling back to activeSession. */
+  /** Resolve the owning session, favoring explicit embedded-session context. */
   let owningSession = $derived(
-    sessions.sessions.find((s) => s.id === message.session_id) ??
-      sessions.activeSession,
+    session !== undefined
+      ? session
+      : sessions.sessions.find((s) => s.id === message.session_id) ??
+        sessions.activeSession,
   );
 
   /** Walk the parent chain to check if any ancestor has the teammate tag. */
@@ -171,6 +190,7 @@
 
   let pinned = $derived(pins.isPinned(message.id));
   let pinFeedback = $state("");
+  let forkFeedback = $state("");
 
   /** Index turn timings by message id for O(1) lookup. */
   let turnByMessage = $derived.by(() => {
@@ -264,6 +284,7 @@
 
   let copyTimer: ReturnType<typeof setTimeout>;
   let pinTimer: ReturnType<typeof setTimeout>;
+  let forkTimer: ReturnType<typeof setTimeout>;
 
   async function handleCopy() {
     const ok = await copyToClipboard(formatMessageForCopy(message));
@@ -290,6 +311,50 @@
     } catch {
       // silently fail
     }
+  }
+
+  let canForkFromMessage = $derived(
+    owningSession?.agent === "claude" &&
+      !(owningSession?.id ?? "").includes("~") &&
+      !(sync.readOnly && isRemoteConnection()),
+  );
+
+  async function handleForkFromHere() {
+    if (!canForkFromMessage) return;
+    clearTimeout(forkTimer);
+    try {
+      configureGeneratedClient();
+      const resp =
+        await SessionsService.postApiV1SessionsIdResume({
+          id: message.session_id,
+          requestBody: {
+            ...(sync.readOnly && !isRemoteConnection()
+              ? { command_only: true }
+              : {}),
+            from_ordinal: message.ordinal,
+            fork_session: true,
+          } satisfies ResumeRequest,
+        }) as ResumeResponse;
+      if (resp.launched) {
+        forkFeedback = m.session_breadcrumb_resumed_in({
+          target: resp.terminal ?? "terminal",
+        });
+        forkTimer = setTimeout(() => { forkFeedback = ""; }, 2000);
+        return;
+      }
+      if (resp.command) {
+        const ok = await copyToClipboard(resp.command);
+        forkFeedback = ok
+          ? m.session_breadcrumb_command_copied()
+          : m.session_breadcrumb_failed();
+        forkTimer = setTimeout(() => { forkFeedback = ""; }, 2000);
+        return;
+      }
+    } catch {
+      // silently fail
+    }
+    forkFeedback = m.session_breadcrumb_failed();
+    forkTimer = setTimeout(() => { forkFeedback = ""; }, 2000);
   }
 </script>
 
@@ -332,8 +397,22 @@
     >
       <PinIcon size="14" strokeWidth="1.8" aria-hidden="true" />
     </button>
+    {#if canForkFromMessage}
+      <button
+        type="button"
+        class="pin-btn fork-btn"
+        title={m.session_breadcrumb_resume_session()}
+        aria-label={m.session_breadcrumb_resume_session()}
+        onclick={handleForkFromHere}
+      >
+        <CirclePlayIcon size="14" strokeWidth="1.8" aria-hidden="true" />
+      </button>
+    {/if}
     {#if pinFeedback}
       <span class="pin-feedback">{pinFeedback}</span>
+    {/if}
+    {#if forkFeedback}
+      <span class="fork-feedback">{forkFeedback}</span>
     {/if}
     <div class="header-meta">
       {#if tokenSummary}
@@ -592,6 +671,12 @@
   }
 
   .pin-feedback {
+    font-size: 11px;
+    color: var(--text-muted);
+    animation: fade-in-out 1.5s ease-in-out;
+  }
+
+  .fork-feedback {
     font-size: 11px;
     color: var(--text-muted);
     animation: fade-in-out 1.5s ease-in-out;

--- a/frontend/src/lib/components/content/MessageContent.test.ts
+++ b/frontend/src/lib/components/content/MessageContent.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { mount, tick, unmount } from "svelte";
-import type { Message } from "../../api/types.js";
+import type { Message, Session } from "../../api/types.js";
 import { setLocale } from "../../i18n/index.js";
 // @ts-ignore
 import MessageContent from "./MessageContent.svelte";
@@ -9,6 +9,18 @@ import MessageContent from "./MessageContent.svelte";
 const copyToClipboardMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue(true),
 );
+
+const forkSessionMock = vi.hoisted(() => vi.fn());
+const sessionsState = vi.hoisted(() => ({
+  sessions: [] as Session[],
+  activeSession: null as Session | null,
+}));
+const syncState = vi.hoisted(() => ({
+  readOnly: false,
+}));
+const runtimeState = vi.hoisted(() => ({
+  isRemote: false,
+}));
 
 vi.mock("../../stores/messages.svelte.js", () => ({
   messages: {
@@ -31,11 +43,28 @@ vi.mock("../../stores/pins.svelte.js", () => ({
 }));
 
 vi.mock("../../stores/sessions.svelte.js", () => ({
-  sessions: {
-    sessions: [],
-    activeSession: null,
-  },
+  sessions: sessionsState,
 }));
+
+vi.mock("../../stores/sync.svelte.js", () => ({
+  sync: syncState,
+}));
+
+vi.mock("../../api/runtime.js", () => ({
+  configureGeneratedClient: vi.fn(),
+  isRemoteConnection: () => runtimeState.isRemote,
+}));
+
+vi.mock("../../api/generated/index", async (importOriginal) => {
+  const orig =
+    await importOriginal<typeof import("../../api/generated/index")>();
+  return {
+    ...orig,
+    SessionsService: {
+      postApiV1SessionsIdResume: forkSessionMock,
+    },
+  };
+});
 
 vi.mock("../../utils/highlight.js", async () => {
   const actual = await vi.importActual<
@@ -83,6 +112,14 @@ afterEach(() => {
   setLocale("en");
   document.body.innerHTML = "";
   vi.clearAllMocks();
+  sessionsState.sessions = [];
+  sessionsState.activeSession = null;
+  syncState.readOnly = false;
+  runtimeState.isRemote = false;
+});
+
+beforeEach(() => {
+  forkSessionMock.mockReset();
 });
 
 describe("MessageContent", () => {
@@ -242,6 +279,251 @@ describe("MessageContent", () => {
     );
     expect(copyButton!.querySelector("svg")).not.toBeNull();
     expect(copyButton!.textContent?.trim()).toBe("");
+
+    unmount(component);
+  });
+
+  it("forks a Claude session from the selected message ordinal", async () => {
+    sessionsState.sessions = [{
+      id: "session-1",
+      agent: "claude",
+      project: "proj-a",
+      machine: "test",
+      first_message: "hello",
+      started_at: "2026-02-20T12:30:00Z",
+      ended_at: "2026-02-20T12:31:00Z",
+      message_count: 3,
+      user_message_count: 2,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2026-02-20T12:30:00Z",
+    } as Session];
+    forkSessionMock.mockResolvedValueOnce({
+      launched: false,
+      command: "claude < '/tmp/agentsview/claude-message-points/session-1-ordinal-1.txt'",
+      cwd: "/tmp/project",
+    });
+
+    const component = mount(MessageContent, {
+      target: document.body,
+      props: {
+        message: makeMessage({
+          session_id: "session-1",
+          ordinal: 1,
+          role: "assistant",
+          content: "Branch here.",
+        }),
+      },
+    });
+
+    await tick();
+
+    const forkButton = document.querySelector<HTMLButtonElement>(
+      "button.fork-btn",
+    );
+    expect(forkButton).not.toBeNull();
+    forkButton!.click();
+    await Promise.resolve();
+    await tick();
+
+    expect(forkSessionMock).toHaveBeenCalledWith({
+      id: "session-1",
+      requestBody: {
+        from_ordinal: 1,
+        fork_session: true,
+      },
+    });
+    expect(copyToClipboardMock).toHaveBeenCalledWith(
+      "claude < '/tmp/agentsview/claude-message-points/session-1-ordinal-1.txt'",
+    );
+    await vi.waitFor(() => {
+      expect(document.querySelector(".fork-feedback")).toBeTruthy();
+    });
+    const forkFeedback = document.querySelector(".fork-feedback");
+    expect(forkFeedback).toBeTruthy();
+    expect(forkFeedback?.textContent?.trim()).not.toBe("");
+
+    unmount(component);
+  });
+
+  it("does not show the fork action for an embedded non-Claude child session", async () => {
+    sessionsState.activeSession = {
+      id: "parent-session",
+      agent: "claude",
+      project: "proj-a",
+      machine: "test",
+      first_message: "hello",
+      started_at: "2026-02-20T12:30:00Z",
+      ended_at: "2026-02-20T12:31:00Z",
+      message_count: 3,
+      user_message_count: 2,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2026-02-20T12:30:00Z",
+    } as Session;
+
+    const component = mount(MessageContent, {
+      target: document.body,
+      props: {
+        message: makeMessage({
+          session_id: "child-session",
+          ordinal: 1,
+          role: "assistant",
+          content: "Embedded child message.",
+        }),
+        session: {
+          id: "child-session",
+          agent: "codex",
+          project: "proj-b",
+          machine: "test",
+          first_message: "child",
+          started_at: "2026-02-20T12:30:00Z",
+          ended_at: "2026-02-20T12:31:00Z",
+          message_count: 2,
+          user_message_count: 1,
+          total_output_tokens: 0,
+          peak_context_tokens: 0,
+          is_automated: false,
+          created_at: "2026-02-20T12:30:00Z",
+        } as Session,
+        isSubagentContext: true,
+      },
+    });
+
+    await tick();
+
+    expect(document.querySelector("button.fork-btn")).toBeNull();
+
+    unmount(component);
+  });
+
+  it("requests command-only message forks in local read-only mode", async () => {
+    syncState.readOnly = true;
+    sessionsState.sessions = [{
+      id: "session-1",
+      agent: "claude",
+      project: "proj-a",
+      machine: "test",
+      first_message: "hello",
+      started_at: "2026-02-20T12:30:00Z",
+      ended_at: "2026-02-20T12:31:00Z",
+      message_count: 3,
+      user_message_count: 2,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2026-02-20T12:30:00Z",
+    } as Session];
+    forkSessionMock.mockResolvedValueOnce({
+      launched: false,
+      command: "claude < '/tmp/agentsview/claude-message-points/session-1-ordinal-1.txt'",
+      cwd: "/tmp/project",
+    });
+
+    const component = mount(MessageContent, {
+      target: document.body,
+      props: {
+        message: makeMessage({
+          session_id: "session-1",
+          ordinal: 1,
+          role: "assistant",
+          content: "Branch here.",
+        }),
+      },
+    });
+
+    await tick();
+
+    document.querySelector<HTMLButtonElement>("button.fork-btn")!.click();
+    await Promise.resolve();
+    await tick();
+
+    expect(forkSessionMock).toHaveBeenCalledWith({
+      id: "session-1",
+      requestBody: {
+        command_only: true,
+        from_ordinal: 1,
+        fork_session: true,
+      },
+    });
+
+    unmount(component);
+  });
+
+  it("hides the fork action in remote read-only mode", async () => {
+    syncState.readOnly = true;
+    runtimeState.isRemote = true;
+    sessionsState.sessions = [{
+      id: "session-1",
+      agent: "claude",
+      project: "proj-a",
+      machine: "test",
+      first_message: "hello",
+      started_at: "2026-02-20T12:30:00Z",
+      ended_at: "2026-02-20T12:31:00Z",
+      message_count: 3,
+      user_message_count: 2,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2026-02-20T12:30:00Z",
+    } as Session];
+
+    const component = mount(MessageContent, {
+      target: document.body,
+      props: {
+        message: makeMessage({
+          session_id: "session-1",
+          ordinal: 1,
+          role: "assistant",
+          content: "Branch here.",
+        }),
+      },
+    });
+
+    await tick();
+
+    expect(document.querySelector("button.fork-btn")).toBeNull();
+
+    unmount(component);
+  });
+
+  it("does not fall back to the active session when embedded session metadata is missing", async () => {
+    sessionsState.activeSession = {
+      id: "parent-session",
+      agent: "claude",
+      project: "proj-a",
+      machine: "test",
+      first_message: "hello",
+      started_at: "2026-02-20T12:30:00Z",
+      ended_at: "2026-02-20T12:31:00Z",
+      message_count: 3,
+      user_message_count: 2,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2026-02-20T12:30:00Z",
+    } as Session;
+
+    const component = mount(MessageContent, {
+      target: document.body,
+      props: {
+        message: makeMessage({
+          session_id: "child-session",
+          ordinal: 1,
+          role: "assistant",
+          content: "Embedded child message.",
+        }),
+        session: null,
+        isSubagentContext: true,
+      },
+    });
+
+    await tick();
+
+    expect(document.querySelector("button.fork-btn")).toBeNull();
 
     unmount(component);
   });

--- a/frontend/src/lib/components/content/SubagentInline.svelte
+++ b/frontend/src/lib/components/content/SubagentInline.svelte
@@ -147,7 +147,11 @@
         <div class="subagent-status subagent-error">{error}</div>
       {:else if messages && messages.length > 0}
         {#each messages as message}
-          <MessageContent {message} isSubagentContext={true} />
+          <MessageContent
+            {message}
+            session={tokenSourceSession}
+            isSubagentContext={true}
+          />
         {/each}
       {:else if messages}
         <div class="subagent-status">{m.subagent_inline_no_messages()}</div>

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -56,6 +56,7 @@ const openersService = OpenersService as unknown as {
 const sessionsService = SessionsService as unknown as {
   getApiV1SessionsIdDirectory: ReturnType<typeof vi.fn>;
   getApiV1SessionsIdUsage: ReturnType<typeof vi.fn>;
+  postApiV1SessionsIdResume: ReturnType<typeof vi.fn>;
 };
 
 type SessionWithTokenFlags = Session & {
@@ -163,6 +164,7 @@ beforeEach(() => {
   sessionsService.getApiV1SessionsIdUsage
     .mockReset()
     .mockResolvedValue(makeUsage());
+  sessionsService.postApiV1SessionsIdResume.mockReset();
 });
 
 afterEach(() => {
@@ -244,6 +246,47 @@ describe("SessionBreadcrumb", () => {
 
     expect(document.body.textContent).toContain("重命名");
     expect(document.body.textContent).toContain("删除");
+
+    unmount(component);
+  });
+
+  it("keeps whole-session resume request bodies unchanged", async () => {
+    sessionsService.postApiV1SessionsIdResume.mockResolvedValue({
+      launched: false,
+      command: "claude --resume run:123456789abcdef",
+      cwd: "/tmp/project",
+    });
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude", {
+          file_path: "/tmp/project/session.jsonl",
+        }),
+        onBack: () => {},
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector(".resume-btn")).toBeTruthy();
+    });
+    await tick();
+
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+
+    const resumeItem = document.querySelector<HTMLButtonElement>(
+      ".open-menu-item",
+    );
+    expect(resumeItem).toBeTruthy();
+    resumeItem!.click();
+    await Promise.resolve();
+    await tick();
+
+    expect(sessionsService.postApiV1SessionsIdResume).toHaveBeenCalledWith({
+      id: "run:123456789abcdef",
+      requestBody: {},
+    });
 
     unmount(component);
   });

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -1010,6 +1010,118 @@ func (s *Server) humaResumeSession(
 			fmt.Sprintf("agent %q does not support resume", session.Agent))
 	}
 	req := in.Body
+	if req.FromOrdinal != nil {
+		if string(session.Agent) != "claude" {
+			return nil, apiError(http.StatusBadRequest,
+				"message-point fork is only available for Claude sessions")
+		}
+		if !req.ForkSession {
+			return nil, apiError(http.StatusBadRequest,
+				"message-point fork requires fork_session")
+		}
+		if req.OpenerID != "" {
+			return nil, apiError(http.StatusBadRequest,
+				"message-point fork does not support opener_id")
+		}
+		if *req.FromOrdinal < 0 {
+			return nil, apiError(http.StatusBadRequest,
+				"from_ordinal must be non-negative")
+		}
+		msgs, err := s.db.GetAllMessages(ctx, session.ID)
+		if err != nil {
+			return nil, internalError("resume: message lookup failed", err)
+		}
+		if *req.FromOrdinal >= len(msgs) || msgs[*req.FromOrdinal].Ordinal != *req.FromOrdinal {
+			return nil, apiError(http.StatusNotFound, "message not found")
+		}
+		if !req.CommandOnly && s.db.ReadOnly() {
+			return nil, apiError(http.StatusNotImplemented,
+				"session launch not available in remote mode")
+		}
+		promptPath, err := writeClaudeMessagePointPrompt(
+			session, msgs[:*req.FromOrdinal+1], *req.FromOrdinal,
+		)
+		if err != nil {
+			return nil, internalError("resume: prompt render failed", err)
+		}
+		cmd := "claude"
+		if req.SkipPermissions {
+			cmd += " --dangerously-skip-permissions"
+		}
+		cmd += " < " + shellQuote(promptPath)
+		cleanupCmd := commandWithCleanup(cmd, promptPath)
+		launchDir, _ := resolveResumePaths(session)
+		responseCmd := commandWithCwd(cleanupCmd, launchDir)
+		if req.CommandOnly {
+			return &jsonOutput[resumeResponse]{
+				Body: resumeResponse{
+					Launched: false,
+					Command:  responseCmd,
+					Cwd:      launchDir,
+				},
+			}, nil
+		}
+		s.mu.RLock()
+		termCfg := s.cfg.Terminal
+		s.mu.RUnlock()
+		if termCfg.Mode == string(terminalModeClipboard) {
+			return &jsonOutput[resumeResponse]{
+				Body: resumeResponse{
+					Launched: false,
+					Command:  responseCmd,
+					Cwd:      launchDir,
+				},
+			}, nil
+		}
+		launchCmd := cleanupCmd
+		detectCwd := launchDir
+		if termCfg.Mode == string(terminalModeAuto) {
+			detectCwd = resumeLaunchCwd(
+				string(session.Agent), "auto", runtime.GOOS, launchDir,
+			)
+		}
+		termBin, termArgs, termName, termErr := detectTerminal(
+			launchCmd, detectCwd, termCfg,
+		)
+		if termErr != nil {
+			log.Printf("resume: terminal detection failed: %v", termErr)
+			return &jsonOutput[resumeResponse]{
+				Body: resumeResponse{
+					Launched: false,
+					Command:  responseCmd,
+					Cwd:      launchDir,
+					Error:    "no_terminal_found",
+				},
+			}, nil
+		}
+		proc := exec.Command(termBin, termArgs...)
+		proc.Stdout = nil
+		proc.Stderr = nil
+		proc.Stdin = nil
+		if detectCwd != "" {
+			proc.Dir = detectCwd
+		}
+		if err := proc.Start(); err != nil {
+			log.Printf("resume: launch failed via %s: %v", termName, err)
+			return &jsonOutput[resumeResponse]{
+				Body: resumeResponse{
+					Launched: false,
+					Command:  responseCmd,
+					Cwd:      launchDir,
+					Error:    "launch_failed",
+				},
+			}, nil
+		}
+		go func() { _ = proc.Wait() }()
+		return &jsonOutput[resumeResponse]{
+			Body: resumeResponse{
+				Launched: true,
+				Terminal: termName,
+				Command:  responseCmd,
+				Cwd:      launchDir,
+			},
+		}, nil
+	}
 	prefix := string(session.Agent) + ":"
 	rawID := strings.TrimPrefix(in.ID, prefix)
 	var cmd string

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -1051,14 +1051,13 @@ func (s *Server) humaResumeSession(
 		if err != nil {
 			return nil, internalError("resume: prompt render failed", err)
 		}
-		cmd := "claude"
-		if req.SkipPermissions {
-			cmd += " --dangerously-skip-permissions"
-		}
-		cmd += " < " + shellQuote(promptPath)
-		cleanupCmd := commandWithCleanup(cmd, promptPath)
 		launchDir, _ := resolveResumePaths(session)
-		responseCmd := commandWithCwd(cleanupCmd, launchDir)
+		launchCmd := claudeMessagePointLaunchCommand(
+			promptPath, req.SkipPermissions,
+		)
+		responseCmd := claudeMessagePointResponseCommand(
+			promptPath, req.SkipPermissions, launchDir, runtime.GOOS,
+		)
 		if req.CommandOnly {
 			return &jsonOutput[resumeResponse]{
 				Body: resumeResponse{
@@ -1080,7 +1079,6 @@ func (s *Server) humaResumeSession(
 				},
 			}, nil
 		}
-		launchCmd := cleanupCmd
 		detectCwd := launchDir
 		if termCfg.Mode == string(terminalModeAuto) {
 			detectCwd = resumeLaunchCwd(

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -1031,7 +1031,14 @@ func (s *Server) humaResumeSession(
 		if err != nil {
 			return nil, internalError("resume: message lookup failed", err)
 		}
-		if *req.FromOrdinal >= len(msgs) || msgs[*req.FromOrdinal].Ordinal != *req.FromOrdinal {
+		messageIdx := -1
+		for i := range msgs {
+			if msgs[i].Ordinal == *req.FromOrdinal {
+				messageIdx = i
+				break
+			}
+		}
+		if messageIdx < 0 {
 			return nil, apiError(http.StatusNotFound, "message not found")
 		}
 		if !req.CommandOnly && s.db.ReadOnly() {
@@ -1039,7 +1046,7 @@ func (s *Server) humaResumeSession(
 				"session launch not available in remote mode")
 		}
 		promptPath, err := writeClaudeMessagePointPrompt(
-			session, msgs[:*req.FromOrdinal+1], *req.FromOrdinal,
+			session, msgs[:messageIdx+1], *req.FromOrdinal,
 		)
 		if err != nil {
 			return nil, internalError("resume: prompt render failed", err)

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/google/shlex"
 	"github.com/tidwall/gjson"
@@ -21,6 +22,7 @@ import (
 type resumeRequest struct {
 	SkipPermissions bool   `json:"skip_permissions,omitempty"`
 	ForkSession     bool   `json:"fork_session,omitempty"`
+	FromOrdinal     *int   `json:"from_ordinal,omitempty"`
 	CommandOnly     bool   `json:"command_only,omitempty"`
 	OpenerID        string `json:"opener_id,omitempty"`
 }
@@ -91,6 +93,109 @@ func commandWithCwd(cmd, cwd string) string {
 		return cmd
 	}
 	return fmt.Sprintf("cd %s && %s", shellQuote(cwd), cmd)
+}
+
+func commandWithCleanup(cmd, cleanupPath string) string {
+	if cleanupPath == "" {
+		return cmd
+	}
+	return cmd + "; rm -f -- " + shellQuote(cleanupPath)
+}
+
+func claudeMessagePointPromptPath(sessionID string, ordinal int) (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(cacheDir, "agentsview", "claude-message-points")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	stem := sanitizeFilename(
+		fmt.Sprintf(
+			"%s-ordinal-%d-%d.txt",
+			sessionID,
+			ordinal,
+			time.Now().UnixNano(),
+		),
+	)
+	return filepath.Join(dir, stem), nil
+}
+
+func renderClaudeMessagePointPrompt(
+	session *db.Session, msgs []db.Message, ordinal int,
+) string {
+	var b strings.Builder
+	b.WriteString("You are continuing a Claude Code conversation forked from AgentsView.\n")
+	b.WriteString("Treat the transcript below as the full context through the selected message ordinal.\n")
+	b.WriteString("Continue the conversation from the next turn.\n\n")
+	b.WriteString("Session: ")
+	b.WriteString(session.ID)
+	b.WriteString("\n")
+	if session.Project != "" {
+		b.WriteString("Project: ")
+		b.WriteString(session.Project)
+		b.WriteString("\n")
+	}
+	fmt.Fprintf(&b, "Fork point ordinal: %d\n\n", ordinal)
+	b.WriteString("Transcript:\n")
+	for _, msg := range msgs {
+		fmt.Fprintf(&b, "\n## Message %d\n", msg.Ordinal)
+		b.WriteString("Role: ")
+		b.WriteString(msg.Role)
+		b.WriteString("\n")
+		if msg.Timestamp != "" {
+			b.WriteString("Timestamp: ")
+			b.WriteString(msg.Timestamp)
+			b.WriteString("\n")
+		}
+		if msg.Model != "" {
+			b.WriteString("Model: ")
+			b.WriteString(msg.Model)
+			b.WriteString("\n")
+		}
+		if body := renderClaudeMessagePointMessage(msg); body != "" {
+			b.WriteString("\n")
+			b.WriteString(body)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func renderClaudeMessagePointMessage(msg db.Message) string {
+	var parts []string
+	if msg.Content != "" {
+		parts = append(parts, msg.Content)
+	}
+	for _, tc := range msg.ToolCalls {
+		header := tc.ToolName
+		if header == "" {
+			header = "Tool"
+		}
+		parts = append(parts, "["+header+"]")
+		if tc.InputJSON != "" {
+			parts = append(parts, tc.InputJSON)
+		}
+		if tc.ResultContent != "" {
+			parts = append(parts, tc.ResultContent)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func writeClaudeMessagePointPrompt(
+	session *db.Session, msgs []db.Message, ordinal int,
+) (string, error) {
+	path, err := claudeMessagePointPromptPath(session.ID, ordinal)
+	if err != nil {
+		return "", err
+	}
+	prompt := renderClaudeMessagePointPrompt(session, msgs, ordinal)
+	if err := os.WriteFile(path, []byte(prompt), 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // resumeLaunchCwd returns the cwd a terminal launcher should apply for

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/google/shlex"
 	"github.com/tidwall/gjson"
@@ -111,15 +110,18 @@ func claudeMessagePointPromptPath(sessionID string, ordinal int) (string, error)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
-	stem := sanitizeFilename(
-		fmt.Sprintf(
-			"%s-ordinal-%d-%d.txt",
-			sessionID,
-			ordinal,
-			time.Now().UnixNano(),
-		),
+	prefix := sanitizeFilename(
+		fmt.Sprintf("%s-ordinal-%d-", sessionID, ordinal),
 	)
-	return filepath.Join(dir, stem), nil
+	f, err := os.CreateTemp(dir, prefix+"*.txt")
+	if err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 func renderClaudeMessagePointPrompt(

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"bufio"
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"net/url"
 	"os"
@@ -9,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/google/shlex"
 	"github.com/tidwall/gjson"
@@ -99,6 +102,76 @@ func commandWithCleanup(cmd, cleanupPath string) string {
 		return cmd
 	}
 	return cmd + "; rm -f -- " + shellQuote(cleanupPath)
+}
+
+func claudeMessagePointLaunchCommand(
+	promptPath string, skipPermissions bool,
+) string {
+	cmd := "claude"
+	if skipPermissions {
+		cmd += " --dangerously-skip-permissions"
+	}
+	cmd += " < " + shellQuote(promptPath)
+	return commandWithCleanup(cmd, promptPath)
+}
+
+func claudeMessagePointResponseCommand(
+	promptPath string, skipPermissions bool, cwd string, goos string,
+) string {
+	if goos == "windows" {
+		return claudeMessagePointWindowsCommand(
+			promptPath, skipPermissions, cwd,
+		)
+	}
+	return commandWithCwd(
+		claudeMessagePointLaunchCommand(promptPath, skipPermissions),
+		cwd,
+	)
+}
+
+func claudeMessagePointWindowsCommand(
+	promptPath string, skipPermissions bool, cwd string,
+) string {
+	script := claudeMessagePointWindowsScript(
+		promptPath, skipPermissions, cwd,
+	)
+	return "powershell.exe -NoProfile -EncodedCommand " +
+		powerShellEncodedCommand(script)
+}
+
+func claudeMessagePointWindowsScript(
+	promptPath string, skipPermissions bool, cwd string,
+) string {
+	var b strings.Builder
+	b.WriteString("try { ")
+	if cwd != "" {
+		b.WriteString("Set-Location -LiteralPath ")
+		b.WriteString(powerShellSingleQuote(cwd))
+		b.WriteString("; ")
+	}
+	b.WriteString("Get-Content -Raw -Encoding UTF8 -LiteralPath ")
+	b.WriteString(powerShellSingleQuote(promptPath))
+	b.WriteString(" | & 'claude'")
+	if skipPermissions {
+		b.WriteString(" --dangerously-skip-permissions")
+	}
+	b.WriteString(" } finally { Remove-Item -LiteralPath ")
+	b.WriteString(powerShellSingleQuote(promptPath))
+	b.WriteString(" -Force -ErrorAction SilentlyContinue }")
+	return b.String()
+}
+
+func powerShellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+func powerShellEncodedCommand(script string) string {
+	codeUnits := utf16.Encode([]rune(script))
+	raw := make([]byte, len(codeUnits)*2)
+	for i, unit := range codeUnits {
+		binary.LittleEndian.PutUint16(raw[i*2:], unit)
+	}
+	return base64.StdEncoding.EncodeToString(raw)
 }
 
 func claudeMessagePointPromptPath(sessionID string, ordinal int) (string, error) {

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -330,6 +330,45 @@ func TestResumeSession(t *testing.T) {
 		assert.NotContains(t, text, "Message C")
 	})
 
+	t.Run("message point command only finds sparse ordinals", func(t *testing.T) {
+		removeMessagePointPrompts(t, "sess-sparse", 3)
+
+		te.seedSession(t, "sess-sparse", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-sparse", 3, func(i int, m *db.Message) {
+			if i == 2 {
+				m.Ordinal = 3
+				m.Content = "Message D"
+			}
+		})
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-sparse/resume",
+			`{"command_only":true,"from_ordinal":3,"fork_session":true}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Launched bool   `json:"launched"`
+			Command  string `json:"command"`
+			Cwd      string `json:"cwd"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
+		assert.Contains(t, resp.Command, "claude <")
+		assertSamePath(t, "cwd", resp.Cwd, projectDir)
+
+		promptPath := findSingleMessagePointPrompt(t, "sess-sparse", 3)
+		t.Cleanup(func() { _ = os.Remove(promptPath) })
+
+		data, err := os.ReadFile(promptPath)
+		require.NoError(t, err)
+		text := string(data)
+		assert.Contains(t, text, "Message A")
+		assert.Contains(t, text, "Message B")
+		assert.Contains(t, text, "Message D")
+	})
+
 	t.Run("message point rejects unsupported agents", func(t *testing.T) {
 		removeMessagePointPrompts(t, "codex-desk", 0)
 

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -47,6 +48,52 @@ func assertSamePath(t *testing.T, label, got, want string) {
 	assert.Fail(t, "path mismatch", "%s = %q, want %q", label, got, want)
 }
 
+func messagePointPromptGlob(t *testing.T, sessionID string, ordinal int) string {
+	t.Helper()
+	cacheDir, err := os.UserCacheDir()
+	require.NoError(t, err)
+	return filepath.Join(
+		cacheDir,
+		"agentsview",
+		"claude-message-points",
+		fmt.Sprintf("%s-ordinal-%d-*.txt", sessionID, ordinal),
+	)
+}
+
+func removeMessagePointPrompts(t *testing.T, sessionID string, ordinal int) {
+	t.Helper()
+	matches, err := filepath.Glob(
+		messagePointPromptGlob(t, sessionID, ordinal),
+	)
+	require.NoError(t, err)
+	for _, match := range matches {
+		_ = os.Remove(match)
+	}
+}
+
+func findSingleMessagePointPrompt(
+	t *testing.T, sessionID string, ordinal int,
+) string {
+	t.Helper()
+	matches, err := filepath.Glob(
+		messagePointPromptGlob(t, sessionID, ordinal),
+	)
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	return matches[0]
+}
+
+func assertNoMessagePointPrompts(
+	t *testing.T, sessionID string, ordinal int,
+) {
+	t.Helper()
+	matches, err := filepath.Glob(
+		messagePointPromptGlob(t, sessionID, ordinal),
+	)
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
 func TestResumeSession(t *testing.T) {
 	te := setup(t)
 
@@ -70,6 +117,23 @@ func TestResumeSession(t *testing.T) {
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.False(t, resp.Launched, "expected launched=false for command_only")
 		assert.NotEmpty(t, resp.Command)
+		assertSamePath(t, "cwd", resp.Cwd, projectDir)
+	})
+
+	t.Run("fork session command only", func(t *testing.T) {
+		w := te.post(t,
+			"/api/v1/sessions/sess-1/resume",
+			`{"command_only":true,"fork_session":true}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Launched bool   `json:"launched"`
+			Command  string `json:"command"`
+			Cwd      string `json:"cwd"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
+		assert.Contains(t, resp.Command, "claude --resume sess-1 --fork-session")
 		assertSamePath(t, "cwd", resp.Cwd, projectDir)
 	})
 
@@ -219,6 +283,155 @@ func TestResumeSession(t *testing.T) {
 			`{"command_only":true}`,
 		)
 		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("message point command only", func(t *testing.T) {
+		removeMessagePointPrompts(t, "sess-2", 1)
+
+		te.seedSession(t, "sess-2", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-2", 3)
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-2/resume",
+			`{"command_only":true,"from_ordinal":1,"fork_session":true}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Launched bool   `json:"launched"`
+			Command  string `json:"command"`
+			Cwd      string `json:"cwd"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
+		assert.Contains(t, resp.Command, "claude <")
+		assert.Contains(t, resp.Command, "< '")
+		assert.Contains(t, resp.Command, "rm -f --")
+		assertSamePath(t, "cwd", resp.Cwd, projectDir)
+
+		idx := strings.LastIndex(resp.Command, "< ")
+		require.Greater(t, idx, 0, "command = %q", resp.Command)
+		extracted := strings.TrimSpace(resp.Command[idx+2:])
+		if semi := strings.Index(extracted, ";"); semi >= 0 {
+			extracted = strings.TrimSpace(extracted[:semi])
+		}
+		extracted = strings.TrimPrefix(extracted, "'")
+		extracted = strings.TrimSuffix(extracted, "'")
+		promptPath := findSingleMessagePointPrompt(t, "sess-2", 1)
+		assertSamePath(t, "prompt file", extracted, promptPath)
+
+		data, err := os.ReadFile(extracted)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(extracted) })
+		text := string(data)
+		assert.Contains(t, text, "Message A")
+		assert.Contains(t, text, "Message B")
+		assert.NotContains(t, text, "Message C")
+	})
+
+	t.Run("message point rejects unsupported agents", func(t *testing.T) {
+		removeMessagePointPrompts(t, "codex-desk", 0)
+
+		te.seedSession(t, "codex-desk", t.TempDir(), 3, func(s *db.Session) {
+			s.Agent = "codex"
+		})
+		w := te.post(t,
+			"/api/v1/sessions/codex-desk/resume",
+			`{"command_only":true,"from_ordinal":0,"fork_session":true}`,
+		)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertNoMessagePointPrompts(t, "codex-desk", 0)
+	})
+
+	t.Run("message point requires fork session", func(t *testing.T) {
+		removeMessagePointPrompts(t, "sess-need-fork", 0)
+
+		te.seedSession(t, "sess-need-fork", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-need-fork", 3)
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-need-fork/resume",
+			`{"command_only":true,"from_ordinal":0}`,
+		)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertNoMessagePointPrompts(t, "sess-need-fork", 0)
+	})
+
+	t.Run("message point rejects opener id", func(t *testing.T) {
+		removeMessagePointPrompts(t, "sess-opener", 0)
+
+		te.seedSession(t, "sess-opener", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-opener", 3)
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-opener/resume",
+			`{"command_only":true,"from_ordinal":0,"fork_session":true,"opener_id":"claude-desktop"}`,
+		)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertNoMessagePointPrompts(t, "sess-opener", 0)
+	})
+
+	t.Run("message point rejects missing ordinals", func(t *testing.T) {
+		removeMessagePointPrompts(t, "sess-3", 99)
+
+		te.seedSession(t, "sess-3", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-3", 3)
+		w := te.post(t,
+			"/api/v1/sessions/sess-3/resume",
+			`{"command_only":true,"from_ordinal":99,"fork_session":true}`,
+		)
+		assertStatus(t, w, http.StatusNotFound)
+		assertNoMessagePointPrompts(t, "sess-3", 99)
+	})
+
+	t.Run("message point remote launch rejects before writing prompt", func(t *testing.T) {
+		te := setupPGMode(t)
+		removeMessagePointPrompts(t, "sess-remote", 1)
+
+		te.seedSession(t, "sess-remote", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-remote", 3)
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-remote/resume",
+			`{"from_ordinal":1,"fork_session":true}`,
+		)
+		assertStatus(t, w, http.StatusNotImplemented)
+		assertNoMessagePointPrompts(t, "sess-remote", 1)
+	})
+
+	t.Run("message point command only works in read only mode", func(t *testing.T) {
+		te := setupPGMode(t)
+		removeMessagePointPrompts(t, "sess-remote-copy", 1)
+
+		te.seedSession(t, "sess-remote-copy", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-remote-copy", 3)
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-remote-copy/resume",
+			`{"command_only":true,"from_ordinal":1,"fork_session":true}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Launched bool   `json:"launched"`
+			Command  string `json:"command"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched)
+		assert.Contains(t, resp.Command, "claude <")
+		assert.Contains(t, resp.Command, "rm -f --")
+		promptPath := findSingleMessagePointPrompt(t, "sess-remote-copy", 1)
+		t.Cleanup(func() { _ = os.Remove(promptPath) })
 	})
 
 	t.Run("deleted session rejected", func(t *testing.T) {

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -94,6 +94,19 @@ func assertNoMessagePointPrompts(
 	assert.Empty(t, matches)
 }
 
+func assertMessagePointCommandForRuntime(t *testing.T, command string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, command,
+			"powershell.exe -NoProfile -EncodedCommand ")
+		assert.NotContains(t, command, " < ")
+		assert.NotContains(t, command, "rm -f --")
+		return
+	}
+	assert.Contains(t, command, "claude <")
+	assert.Contains(t, command, "rm -f --")
+}
+
 func TestResumeSession(t *testing.T) {
 	te := setup(t)
 
@@ -305,25 +318,28 @@ func TestResumeSession(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.False(t, resp.Launched, "expected launched=false for command_only")
-		assert.Contains(t, resp.Command, "claude <")
-		assert.Contains(t, resp.Command, "< '")
-		assert.Contains(t, resp.Command, "rm -f --")
+		assertMessagePointCommandForRuntime(t, resp.Command)
+		if runtime.GOOS != "windows" {
+			assert.Contains(t, resp.Command, "< '")
+		}
 		assertSamePath(t, "cwd", resp.Cwd, projectDir)
 
-		idx := strings.LastIndex(resp.Command, "< ")
-		require.Greater(t, idx, 0, "command = %q", resp.Command)
-		extracted := strings.TrimSpace(resp.Command[idx+2:])
-		if semi := strings.Index(extracted, ";"); semi >= 0 {
-			extracted = strings.TrimSpace(extracted[:semi])
-		}
-		extracted = strings.TrimPrefix(extracted, "'")
-		extracted = strings.TrimSuffix(extracted, "'")
 		promptPath := findSingleMessagePointPrompt(t, "sess-2", 1)
-		assertSamePath(t, "prompt file", extracted, promptPath)
+		if runtime.GOOS != "windows" {
+			idx := strings.LastIndex(resp.Command, "< ")
+			require.Greater(t, idx, 0, "command = %q", resp.Command)
+			extracted := strings.TrimSpace(resp.Command[idx+2:])
+			if semi := strings.Index(extracted, ";"); semi >= 0 {
+				extracted = strings.TrimSpace(extracted[:semi])
+			}
+			extracted = strings.TrimPrefix(extracted, "'")
+			extracted = strings.TrimSuffix(extracted, "'")
+			assertSamePath(t, "prompt file", extracted, promptPath)
+		}
 
-		data, err := os.ReadFile(extracted)
+		data, err := os.ReadFile(promptPath)
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = os.Remove(extracted) })
+		t.Cleanup(func() { _ = os.Remove(promptPath) })
 		text := string(data)
 		assert.Contains(t, text, "Message A")
 		assert.Contains(t, text, "Message B")
@@ -355,7 +371,7 @@ func TestResumeSession(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.False(t, resp.Launched, "expected launched=false for command_only")
-		assert.Contains(t, resp.Command, "claude <")
+		assertMessagePointCommandForRuntime(t, resp.Command)
 		assertSamePath(t, "cwd", resp.Cwd, projectDir)
 
 		promptPath := findSingleMessagePointPrompt(t, "sess-sparse", 3)
@@ -467,8 +483,7 @@ func TestResumeSession(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.False(t, resp.Launched)
-		assert.Contains(t, resp.Command, "claude <")
-		assert.Contains(t, resp.Command, "rm -f --")
+		assertMessagePointCommandForRuntime(t, resp.Command)
 		promptPath := findSingleMessagePointPrompt(t, "sess-remote-copy", 1)
 		t.Cleanup(func() { _ = os.Remove(promptPath) })
 	})

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -1,6 +1,8 @@
 package server_test
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,17 +97,48 @@ func assertNoMessagePointPrompts(
 	assert.Empty(t, matches)
 }
 
-func assertMessagePointCommandForRuntime(t *testing.T, command string) {
+func assertMessagePointCommandForRuntime(
+	t *testing.T, command string, promptPath string,
+) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
-		assert.Contains(t, command,
-			"powershell.exe -NoProfile -EncodedCommand ")
+		script := decodeMessagePointPowerShellCommandForTest(t, command)
+		quotedPromptPath := powerShellSingleQuoteForTest(promptPath)
+		assert.Contains(t, script,
+			"Get-Content -Raw -Encoding UTF8 -LiteralPath "+
+				quotedPromptPath)
+		assert.Contains(t, script,
+			"Remove-Item -LiteralPath "+quotedPromptPath+
+				" -Force -ErrorAction SilentlyContinue")
 		assert.NotContains(t, command, " < ")
 		assert.NotContains(t, command, "rm -f --")
+		assert.NotContains(t, script, " < ")
+		assert.NotContains(t, script, "rm -f --")
 		return
 	}
 	assert.Contains(t, command, "claude <")
 	assert.Contains(t, command, "rm -f --")
+}
+
+func decodeMessagePointPowerShellCommandForTest(
+	t *testing.T, command string,
+) string {
+	t.Helper()
+	const prefix = "powershell.exe -NoProfile -EncodedCommand "
+	require.True(t, strings.HasPrefix(command, prefix), "command = %q", command)
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(command, prefix))
+	require.NoError(t, err)
+	require.Zero(t, len(raw)%2, "UTF-16LE byte length must be even")
+
+	codeUnits := make([]uint16, len(raw)/2)
+	for i := range codeUnits {
+		codeUnits[i] = binary.LittleEndian.Uint16(raw[i*2:])
+	}
+	return string(utf16.Decode(codeUnits))
+}
+
+func powerShellSingleQuoteForTest(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 func TestResumeSession(t *testing.T) {
@@ -318,13 +352,13 @@ func TestResumeSession(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.False(t, resp.Launched, "expected launched=false for command_only")
-		assertMessagePointCommandForRuntime(t, resp.Command)
+		promptPath := findSingleMessagePointPrompt(t, "sess-2", 1)
+		assertMessagePointCommandForRuntime(t, resp.Command, promptPath)
 		if runtime.GOOS != "windows" {
 			assert.Contains(t, resp.Command, "< '")
 		}
 		assertSamePath(t, "cwd", resp.Cwd, projectDir)
 
-		promptPath := findSingleMessagePointPrompt(t, "sess-2", 1)
 		if runtime.GOOS != "windows" {
 			idx := strings.LastIndex(resp.Command, "< ")
 			require.Greater(t, idx, 0, "command = %q", resp.Command)
@@ -371,10 +405,9 @@ func TestResumeSession(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.False(t, resp.Launched, "expected launched=false for command_only")
-		assertMessagePointCommandForRuntime(t, resp.Command)
-		assertSamePath(t, "cwd", resp.Cwd, projectDir)
-
 		promptPath := findSingleMessagePointPrompt(t, "sess-sparse", 3)
+		assertMessagePointCommandForRuntime(t, resp.Command, promptPath)
+		assertSamePath(t, "cwd", resp.Cwd, projectDir)
 		t.Cleanup(func() { _ = os.Remove(promptPath) })
 
 		data, err := os.ReadFile(promptPath)
@@ -483,8 +516,8 @@ func TestResumeSession(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.False(t, resp.Launched)
-		assertMessagePointCommandForRuntime(t, resp.Command)
 		promptPath := findSingleMessagePointPrompt(t, "sess-remote-copy", 1)
+		assertMessagePointCommandForRuntime(t, resp.Command, promptPath)
 		t.Cleanup(func() { _ = os.Remove(promptPath) })
 	})
 

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -57,6 +57,25 @@ func TestShellQuote(t *testing.T) {
 	}
 }
 
+func TestCommandWithCleanup(t *testing.T) {
+	assert.Equal(t,
+		"claude < prompt.txt; rm -f -- prompt.txt",
+		commandWithCleanup("claude < prompt.txt", "prompt.txt"),
+	)
+	assert.Equal(t,
+		"claude < prompt.txt",
+		commandWithCleanup("claude < prompt.txt", ""),
+	)
+}
+
+func TestClaudeMessagePointPromptPathIsUniquePerLaunch(t *testing.T) {
+	first, err := claudeMessagePointPromptPath("sess-1", 2)
+	require.NoError(t, err)
+	second, err := claudeMessagePointPromptPath("sess-1", 2)
+	require.NoError(t, err)
+	assert.NotEqual(t, first, second)
+}
+
 func TestDetectTerminalLinux_NoTerminal(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Linux-only terminal detection")

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -1,12 +1,15 @@
 package server
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,6 +69,66 @@ func TestCommandWithCleanup(t *testing.T) {
 		"claude < prompt.txt",
 		commandWithCleanup("claude < prompt.txt", ""),
 	)
+}
+
+func TestClaudeMessagePointResponseCommandUsesPOSIXShellOffWindows(
+	t *testing.T,
+) {
+	cwd := t.TempDir()
+	promptPath := filepath.Join(t.TempDir(), "prompt file.txt")
+
+	got := claudeMessagePointResponseCommand(promptPath, true, cwd, "linux")
+
+	want := "cd " + shellQuote(cwd) + " && claude --dangerously-skip-permissions < " +
+		shellQuote(promptPath) + "; rm -f -- " + shellQuote(promptPath)
+	assert.Equal(t, want, got)
+}
+
+func TestClaudeMessagePointResponseCommandUsesPowerShellOnWindows(
+	t *testing.T,
+) {
+	promptPath := `C:\Users\Ada\AppData\Local\Temp\prompt's file.txt`
+	cwd := `C:\Users\Ada\source\agentsview`
+
+	got := claudeMessagePointResponseCommand(
+		promptPath, true, cwd, "windows",
+	)
+
+	const prefix = "powershell.exe -NoProfile -EncodedCommand "
+	require.True(t, strings.HasPrefix(got, prefix), "command = %q", got)
+	assert.NotContains(t, got, " < ")
+	assert.NotContains(t, got, "rm -f --")
+
+	script := decodePowerShellEncodedCommandForTest(
+		t, strings.TrimPrefix(got, prefix),
+	)
+	assert.Contains(t, script,
+		"Set-Location -LiteralPath 'C:\\Users\\Ada\\source\\agentsview'")
+	assert.Contains(t, script,
+		"Get-Content -Raw -Encoding UTF8 -LiteralPath "+
+			"'C:\\Users\\Ada\\AppData\\Local\\Temp\\prompt''s file.txt' | "+
+			"& 'claude' --dangerously-skip-permissions")
+	assert.Contains(t, script,
+		"Remove-Item -LiteralPath "+
+			"'C:\\Users\\Ada\\AppData\\Local\\Temp\\prompt''s file.txt' "+
+			"-Force -ErrorAction SilentlyContinue")
+	assert.NotContains(t, script, " < ")
+	assert.NotContains(t, script, "rm -f --")
+}
+
+func decodePowerShellEncodedCommandForTest(
+	t *testing.T, encoded string,
+) string {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	require.Zero(t, len(raw)%2, "UTF-16LE byte length must be even")
+
+	codeUnits := make([]uint16, len(raw)/2)
+	for i := range codeUnits {
+		codeUnits[i] = binary.LittleEndian.Uint16(raw[i*2:])
+	}
+	return string(utf16.Decode(codeUnits))
 }
 
 func TestClaudeMessagePointPromptPathIsUniquePerLaunch(t *testing.T) {

--- a/internal/server/resume_test.go
+++ b/internal/server/resume_test.go
@@ -59,7 +59,7 @@ func TestShellQuote(t *testing.T) {
 
 func TestCommandWithCleanup(t *testing.T) {
 	assert.Equal(t,
-		"claude < prompt.txt; rm -f -- prompt.txt",
+		"claude < prompt.txt; rm -f -- 'prompt.txt'",
 		commandWithCleanup("claude < prompt.txt", "prompt.txt"),
 	)
 	assert.Equal(t,


### PR DESCRIPTION
AgentsView can resume or fork a whole Claude session, but it cannot start from the message where the user actually wants to branch. The session detail view already exposes message ordinals, and the backend already owns resume command construction, so the missing piece is a message-point contract between the message UI and the resume handler.

This adds a Claude-only message-point fork path that accepts a session ID plus message ordinal, validates that the ordinal belongs to the local Claude session, and builds a deterministic context prefix for a new Claude run. The existing whole-session resume and fork behavior stays unchanged when no ordinal is supplied, and storage remains a data source rather than the place where fork policy lives. Embedded child-session transcripts keep their own session identity, local read-only mode falls back to a copyable command, remote read-only mode hides the action, and each generated prompt file is isolated per launch and self-cleaning when run.

The frontend adds the affordance at the message level instead of overloading the breadcrumb session menu. The focused coverage should prove whole-session preservation, unsupported-agent handling, missing-ordinal handling, and the message-level request body.

Fixes #107
