### PR TITLE
fix(desktop): validate updater signatures

### DIFF
--- a/desktop/scripts/repair-appimage-diricon.sh
+++ b/desktop/scripts/repair-appimage-diricon.sh
@@ -19,6 +19,42 @@ require_cmd mksquashfs
 require_cmd tar
 require_cmd unsquashfs
 
+normalize_signature_file() {
+  local signature="$1"
+  local tmp="${signature}.tmp"
+
+  awk '
+    /^Public signature:$/ {
+      getline
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 2
+      }
+    }
+  ' "$signature" > "$tmp" || cp "$signature" "$tmp"
+
+  tr -d '[:space:]' < "$tmp" > "$signature"
+  rm -f "$tmp"
+
+  if ! grep -Eq '^[A-Za-z0-9+/]+={0,2}$' "$signature"; then
+    echo "error: signer output for $signature is not a base64 signature payload" >&2
+    exit 1
+  fi
+
+  local len
+  len="$(wc -c < "$signature" | tr -d '[:space:]')"
+  if [ $((len % 4)) -ne 0 ]; then
+    echo "error: signer output for $signature has invalid base64 length" >&2
+    exit 1
+  fi
+
+  printf '\n' >> "$signature"
+}
+
 find_squashfs_offset() {
   local appimage="$1"
   local candidate
@@ -50,6 +86,7 @@ refresh_updater_archive() {
 
   if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ] || [ -n "${TAURI_SIGNING_PRIVATE_KEY_PATH:-}" ]; then
     npx tauri signer sign "$archive" > "$signature"
+    normalize_signature_file "$signature"
   elif [ -f "$signature" ]; then
     echo "error: refreshed $archive but cannot refresh $signature without a Tauri signing key" >&2
     exit 1

--- a/desktop/scripts/test-repair-appimage-diricon.sh
+++ b/desktop/scripts/test-repair-appimage-diricon.sh
@@ -75,13 +75,38 @@ exit 1
 EOF
 chmod +x "$fake_bin/stat"
 
+cat > "$fake_bin/npx" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$*" != "tauri signer sign $TEST_ARCHIVE" ]; then
+  echo "unsupported npx invocation: $*" >&2
+  exit 1
+fi
+
+cat <<'SIGNATURE'
+Your file was signed successfully, You can find the signature here:
+/tmp/AgentsView.AppImage.tar.gz.sig
+
+Public signature:
+YWJjCg==
+
+Make sure to include this into the signature field of your update server.
+SIGNATURE
+EOF
+chmod +x "$fake_bin/npx"
+
 appimage="$tmp_root/AgentsView.AppImage"
 archive="${appimage}.tar.gz"
+signature="${archive}.sig"
 printf 'runtime hsqs old-rootfs\n' > "$appimage"
 chmod 0755 "$appimage"
 printf 'stale archive\n' > "$archive"
 
-PATH="$fake_bin:$PATH" bash "$SCRIPT_DIR/repair-appimage-diricon.sh" "$appimage" >/dev/null
+TEST_ARCHIVE="$archive" \
+TAURI_SIGNING_PRIVATE_KEY="test-key" \
+PATH="$fake_bin:$PATH" \
+  bash "$SCRIPT_DIR/repair-appimage-diricon.sh" "$appimage" >/dev/null
 
 archive_listing="$(tar -tzf "$archive")"
 assert_eq "$archive_listing" "AgentsView.AppImage" \
@@ -96,5 +121,8 @@ assert_eq "$(cat "$extracted_dir/AgentsView.AppImage")" "$(cat "$appimage")" \
 archived_mode="$(tar -tvzf "$archive" | awk '{print $1}')"
 assert_eq "$archived_mode" "-rwxr-xr-x" \
   "updater archive preserves executable AppImage mode"
+
+assert_eq "$(cat "$signature")" "YWJjCg==" \
+  "updater signature contains only the base64 public signature"
 
 echo "repair-appimage-diricon updater archive checks passed"

--- a/scripts/check_desktop_release_health.sh
+++ b/scripts/check_desktop_release_health.sh
@@ -40,13 +40,47 @@ if [ "$manifest_version" != "$version" ]; then
     exit 1
 fi
 
-while IFS=$'\t' read -r platform signature; do
+expected_platforms=(
+    "darwin-aarch64"
+    "darwin-x86_64"
+    "windows-x86_64"
+    "linux-x86_64"
+)
+
+expected_platforms_list() {
+    local label="" platform
+    for platform in "${expected_platforms[@]}"; do
+        if [ -n "$label" ]; then
+            label+=", "
+        fi
+        label+="$platform"
+    done
+    printf "%s" "$label"
+}
+
+if ! jq -e '.platforms | type == "object"' >/dev/null <<<"$manifest"; then
+    error "updater manifest platforms must be an object with signatures for $(expected_platforms_list)"
+    exit 1
+fi
+
+for platform in "${expected_platforms[@]}"; do
+    if ! jq -e --arg platform "$platform" '.platforms[$platform] | type == "object"' >/dev/null <<<"$manifest"; then
+        error "updater manifest missing platform $platform"
+        exit 1
+    fi
+
+    if ! jq -e --arg platform "$platform" '.platforms[$platform].signature | type == "string" and length > 0' >/dev/null <<<"$manifest"; then
+        error "updater manifest missing signature for $platform"
+        exit 1
+    fi
+
+    signature="$(jq -r --arg platform "$platform" '.platforms[$platform].signature' <<<"$manifest")"
     if [ -z "$signature" ] ||
         ! [[ "$signature" =~ ^[A-Za-z0-9+/]+={0,2}$ ]] ||
         [ $(( ${#signature} % 4 )) -ne 0 ]; then
         error "updater manifest signature for $platform is not a base64 payload"
         exit 1
     fi
-done < <(jq -r '.platforms // {} | to_entries[] | [.key, (.value.signature // "")] | @tsv' <<<"$manifest")
+done
 
 echo "Desktop release health OK for $tag"

--- a/scripts/check_desktop_release_health.sh
+++ b/scripts/check_desktop_release_health.sh
@@ -29,10 +29,24 @@ else
     manifest="$(curl -fsSL "https://github.com/${repo}/releases/download/updater/latest.json")"
 fi
 
+if ! jq -e . >/dev/null 2>&1 <<<"$manifest"; then
+    error "updater manifest is not valid JSON"
+    exit 1
+fi
+
 manifest_version="$(jq -r '.version // ""' <<<"$manifest")"
 if [ "$manifest_version" != "$version" ]; then
     error "updater manifest version ${manifest_version:-<empty>} does not match expected $version"
     exit 1
 fi
+
+while IFS=$'\t' read -r platform signature; do
+    if [ -z "$signature" ] ||
+        ! [[ "$signature" =~ ^[A-Za-z0-9+/]+={0,2}$ ]] ||
+        [ $(( ${#signature} % 4 )) -ne 0 ]; then
+        error "updater manifest signature for $platform is not a base64 payload"
+        exit 1
+    fi
+done < <(jq -r '.platforms // {} | to_entries[] | [.key, (.value.signature // "")] | @tsv' <<<"$manifest")
 
 echo "Desktop release health OK for $tag"

--- a/scripts/check_desktop_release_health.sh
+++ b/scripts/check_desktop_release_health.sh
@@ -69,6 +69,11 @@ for platform in "${expected_platforms[@]}"; do
         exit 1
     fi
 
+    if ! jq -e --arg platform "$platform" '.platforms[$platform].url | select(type == "string" and length > 0)' >/dev/null <<<"$manifest"; then
+        error "updater manifest missing url for $platform"
+        exit 1
+    fi
+
     if ! jq -e --arg platform "$platform" '.platforms[$platform].signature | type == "string" and length > 0' >/dev/null <<<"$manifest"; then
         error "updater manifest missing signature for $platform"
         exit 1

--- a/scripts/check_desktop_release_health_from_event_test.sh
+++ b/scripts/check_desktop_release_health_from_event_test.sh
@@ -48,15 +48,19 @@ write_fixture() {
   "version": "${version}",
   "platforms": {
     "darwin-aarch64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_aarch64.app.tar.gz",
       "signature": "YWJjCg=="
     },
     "darwin-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz",
       "signature": "YWJjCg=="
     },
     "windows-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_x64-setup.nsis.zip",
       "signature": "YWJjCg=="
     },
     "linux-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_amd64.AppImage.tar.gz",
       "signature": "YWJjCg=="
     }
   }

--- a/scripts/check_desktop_release_health_from_event_test.sh
+++ b/scripts/check_desktop_release_health_from_event_test.sh
@@ -44,7 +44,23 @@ assert_failure_contains() {
 write_fixture() {
     local dir="$1" version="$2"
     cat >"$dir/latest.json" <<EOF
-{"version":"${version}"}
+{
+  "version": "${version}",
+  "platforms": {
+    "darwin-aarch64": {
+      "signature": "YWJjCg=="
+    },
+    "darwin-x86_64": {
+      "signature": "YWJjCg=="
+    },
+    "windows-x86_64": {
+      "signature": "YWJjCg=="
+    },
+    "linux-x86_64": {
+      "signature": "YWJjCg=="
+    }
+  }
+}
 EOF
 }
 

--- a/scripts/check_desktop_release_health_test.sh
+++ b/scripts/check_desktop_release_health_test.sh
@@ -44,7 +44,27 @@ assert_failure_contains() {
 write_fixture() {
     local dir="$1" manifest_version="$2"
     cat >"$dir/latest.json" <<EOF
-{"version":"${manifest_version}"}
+{
+  "version": "${manifest_version}",
+  "platforms": {
+    "darwin-aarch64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_aarch64.app.tar.gz",
+      "signature": "YWJjCg=="
+    },
+    "darwin-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz",
+      "signature": "YWJjCg=="
+    },
+    "windows-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_x64-setup.nsis.zip",
+      "signature": "YWJjCg=="
+    },
+    "linux-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_amd64.AppImage.tar.gz",
+      "signature": "YWJjCg=="
+    }
+  }
+}
 EOF
 }
 
@@ -77,6 +97,40 @@ write_fixture "$tmp" "0.34.4"
 assert_failure_contains \
     "stale updater manifest fails" \
     "updater manifest version 0.34.4 does not match expected 0.34.5" \
+    run_checker "$tmp" "v0.34.5"
+
+cat >"$tmp/latest.json" <<'EOF'
+{
+  "version": "0.34.5",
+  "platforms": {
+    "linux-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_amd64.AppImage.tar.gz",
+      "signature": "
+Public signature:
+YWJjCg=="
+    }
+  }
+}
+EOF
+assert_failure_contains \
+    "invalid updater manifest JSON fails" \
+    "updater manifest is not valid JSON" \
+    run_checker "$tmp" "v0.34.5"
+
+cat >"$tmp/latest.json" <<'EOF'
+{
+  "version": "0.34.5",
+  "platforms": {
+    "linux-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_amd64.AppImage.tar.gz",
+      "signature": "Public signature: YWJjCg=="
+    }
+  }
+}
+EOF
+assert_failure_contains \
+    "non-base64 updater signature fails" \
+    "updater manifest signature for linux-x86_64 is not a base64 payload" \
     run_checker "$tmp" "v0.34.5"
 
 echo

--- a/scripts/check_desktop_release_health_test.sh
+++ b/scripts/check_desktop_release_health_test.sh
@@ -127,14 +127,19 @@ cat >"$tmp/latest.json" <<'EOF'
 {
   "version": "0.34.5",
   "platforms": {
-    "darwin-aarch64": {},
+    "darwin-aarch64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_aarch64.app.tar.gz"
+    },
     "darwin-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz",
       "signature": "YWJjCg=="
     },
     "windows-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_x64-setup.nsis.zip",
       "signature": "YWJjCg=="
     },
     "linux-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_amd64.AppImage.tar.gz",
       "signature": "YWJjCg=="
     }
   }
@@ -143,6 +148,61 @@ EOF
 assert_failure_contains \
     "manifest with missing updater signature fails" \
     "updater manifest missing signature for darwin-aarch64" \
+    run_checker "$tmp" "v0.34.5"
+
+cat >"$tmp/latest.json" <<'EOF'
+{
+  "version": "0.34.5",
+  "platforms": {
+    "darwin-aarch64": {
+      "signature": "YWJjCg=="
+    },
+    "darwin-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz",
+      "signature": "YWJjCg=="
+    },
+    "windows-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_x64-setup.nsis.zip",
+      "signature": "YWJjCg=="
+    },
+    "linux-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_amd64.AppImage.tar.gz",
+      "signature": "YWJjCg=="
+    }
+  }
+}
+EOF
+assert_failure_contains \
+    "manifest with missing updater URL fails" \
+    "updater manifest missing url for darwin-aarch64" \
+    run_checker "$tmp" "v0.34.5"
+
+cat >"$tmp/latest.json" <<'EOF'
+{
+  "version": "0.34.5",
+  "platforms": {
+    "darwin-aarch64": {
+      "url": "",
+      "signature": "YWJjCg=="
+    },
+    "darwin-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz",
+      "signature": "YWJjCg=="
+    },
+    "windows-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_x64-setup.nsis.zip",
+      "signature": "YWJjCg=="
+    },
+    "linux-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_amd64.AppImage.tar.gz",
+      "signature": "YWJjCg=="
+    }
+  }
+}
+EOF
+assert_failure_contains \
+    "manifest with empty updater URL fails" \
+    "updater manifest missing url for darwin-aarch64" \
     run_checker "$tmp" "v0.34.5"
 
 cat >"$tmp/latest.json" <<'EOF'
@@ -168,12 +228,15 @@ cat >"$tmp/latest.json" <<'EOF'
   "version": "0.34.5",
   "platforms": {
     "darwin-aarch64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_aarch64.app.tar.gz",
       "signature": "YWJjCg=="
     },
     "darwin-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_x86_64.app.tar.gz",
       "signature": "YWJjCg=="
     },
     "windows-x86_64": {
+      "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_x64-setup.nsis.zip",
       "signature": "YWJjCg=="
     },
     "linux-x86_64": {

--- a/scripts/check_desktop_release_health_test.sh
+++ b/scripts/check_desktop_release_health_test.sh
@@ -100,6 +100,52 @@ assert_failure_contains \
     run_checker "$tmp" "v0.34.5"
 
 cat >"$tmp/latest.json" <<'EOF'
+{"version":"0.34.5"}
+EOF
+assert_failure_contains \
+    "manifest without updater platforms fails" \
+    "updater manifest platforms must be an object with signatures for darwin-aarch64, darwin-x86_64, windows-x86_64, linux-x86_64" \
+    run_checker "$tmp" "v0.34.5"
+
+cat >"$tmp/latest.json" <<'EOF'
+{"version":"0.34.5","platforms":{}}
+EOF
+assert_failure_contains \
+    "manifest with empty updater platforms fails" \
+    "updater manifest missing platform darwin-aarch64" \
+    run_checker "$tmp" "v0.34.5"
+
+cat >"$tmp/latest.json" <<'EOF'
+{"version":"0.34.5","platforms":[]}
+EOF
+assert_failure_contains \
+    "manifest with non-object updater platforms fails" \
+    "updater manifest platforms must be an object with signatures for darwin-aarch64, darwin-x86_64, windows-x86_64, linux-x86_64" \
+    run_checker "$tmp" "v0.34.5"
+
+cat >"$tmp/latest.json" <<'EOF'
+{
+  "version": "0.34.5",
+  "platforms": {
+    "darwin-aarch64": {},
+    "darwin-x86_64": {
+      "signature": "YWJjCg=="
+    },
+    "windows-x86_64": {
+      "signature": "YWJjCg=="
+    },
+    "linux-x86_64": {
+      "signature": "YWJjCg=="
+    }
+  }
+}
+EOF
+assert_failure_contains \
+    "manifest with missing updater signature fails" \
+    "updater manifest missing signature for darwin-aarch64" \
+    run_checker "$tmp" "v0.34.5"
+
+cat >"$tmp/latest.json" <<'EOF'
 {
   "version": "0.34.5",
   "platforms": {
@@ -121,6 +167,15 @@ cat >"$tmp/latest.json" <<'EOF'
 {
   "version": "0.34.5",
   "platforms": {
+    "darwin-aarch64": {
+      "signature": "YWJjCg=="
+    },
+    "darwin-x86_64": {
+      "signature": "YWJjCg=="
+    },
+    "windows-x86_64": {
+      "signature": "YWJjCg=="
+    },
     "linux-x86_64": {
       "url": "https://github.com/kenn-io/agentsview/releases/download/updater/AgentsView_0.34.5_amd64.AppImage.tar.gz",
       "signature": "Public signature: YWJjCg=="


### PR DESCRIPTION
A malformed desktop updater manifest can strand users when their local archive has already been upgraded by a newer CLI. In that state the desktop app depends on Tauri's updater path for recovery, but Tauri must parse the whole `latest.json` before it can offer the macOS or Windows update.

This hardens the release path that produced the bad manifest. The AppImage repair step now normalizes Tauri signer output back to the bare base64 signature payload before it can be uploaded, and the desktop release health check rejects invalid JSON or non-base64 platform signatures instead of only checking the version field.

The immediate `updater` release assets for 0.35.0 were repaired separately so existing 0.34.x desktop users can discover the update without waiting for this change to ship.