### PR TITLE
fix(desktop): surface backend startup failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,13 +198,29 @@ desktop-windows-installer:
 	cd desktop && npm ci && npm run tauri:build:windows
 	mkdir -p $(DESKTOP_DIST_DIR)/windows
 	rm -f $(DESKTOP_DIST_DIR)/windows/*.exe
-	@exe_count=$$(find desktop/src-tauri/target/release/bundle/nsis \
-		-maxdepth 1 -type f -name '*.exe' | wc -l | tr -d ' '); \
-	if [ "$$exe_count" -eq 0 ]; then \
-		echo "error: no Windows installer (.exe) found in bundle output" >&2; \
+	@bundle_dir="desktop/src-tauri/target/release/bundle/nsis"; \
+	target_triple="$${TAURI_ENV_TARGET_TRIPLE:-$${CARGO_BUILD_TARGET:-}}"; \
+	if [ -z "$$target_triple" ] && command -v rustc >/dev/null 2>&1; then \
+		host_triple=$$(rustc -vV | awk '/^host: /{print $$2}'); \
+		if [ "$$host_triple" = "aarch64-pc-windows-msvc" ]; then \
+			target_triple="$$host_triple"; \
+		fi; \
+	fi; \
+	if [ -n "$$target_triple" ] && \
+		[ -d "desktop/src-tauri/target/$$target_triple/release/bundle/nsis" ]; then \
+		bundle_dir="desktop/src-tauri/target/$$target_triple/release/bundle/nsis"; \
+	fi; \
+	if [ ! -d "$$bundle_dir" ]; then \
+		echo "error: Windows bundle output directory not found: $$bundle_dir" >&2; \
 		exit 1; \
 	fi; \
-	find desktop/src-tauri/target/release/bundle/nsis \
+	exe_count=$$(find "$$bundle_dir" \
+		-maxdepth 1 -type f -name '*.exe' | wc -l | tr -d ' '); \
+	if [ "$$exe_count" -eq 0 ]; then \
+		echo "error: no Windows installer (.exe) found in $$bundle_dir" >&2; \
+		exit 1; \
+	fi; \
+	find "$$bundle_dir" \
 		-maxdepth 1 -type f -name '*.exe' \
 		-exec cp {} $(DESKTOP_DIST_DIR)/windows/ \;; \
 	echo "Copied $$exe_count Windows installer(s) to $(DESKTOP_DIST_DIR)/windows/"

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -41,6 +41,10 @@ func runServeStatus(cfg config.Config) {
 		}
 		return
 	}
+	if IsDaemonStarting(cfg.DataDir) {
+		fmt.Println("agentsview is starting up.")
+		return
+	}
 	if readOnly != nil {
 		for _, line := range serveStatusLines(readOnly) {
 			fmt.Println(line)
@@ -53,10 +57,6 @@ func runServeStatus(cfg config.Config) {
 				"to health checks.\n",
 			recs[0].PID,
 		)
-		return
-	}
-	if IsDaemonStarting(cfg.DataDir) {
-		fmt.Println("agentsview is starting up.")
 		return
 	}
 	fmt.Println("No agentsview server is running.")

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -127,6 +127,24 @@ func TestRunServeStatusPrefersIncompatibleWritableOverReadOnly(t *testing.T) {
 	assert.NotContains(t, out, "mode:    read-only")
 }
 
+func TestRunServeStatusPrefersStartingOverReadOnly(t *testing.T) {
+	dir := runtimeTestDir(t)
+	readOnlyHost, readOnlyPort := testPingServer(t)
+	_, err := WriteDaemonRuntime(
+		dir, readOnlyHost, readOnlyPort, "1.0.0", true,
+	)
+	require.NoError(t, err)
+	MarkDaemonStarting(dir)
+	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+
+	out := captureStdout(t, func() {
+		runServeStatus(config.Config{DataDir: dir})
+	})
+
+	assert.Contains(t, out, "agentsview is starting up.")
+	assert.NotContains(t, out, "mode:    read-only")
+}
+
 func newPingDaemonWithPID(t *testing.T, pid int) testDaemonEndpoint {
 	t.Helper()
 	ts := httptest.NewServer(daemon.NewPingHandler(daemon.PingHandlerOptions{

--- a/desktop/scripts/run-tauri.sh
+++ b/desktop/scripts/run-tauri.sh
@@ -23,7 +23,7 @@ detect_host_triple() {
   echo "$host"
 }
 
-resolve_target_triple() {
+resolve_build_target_arg() {
   if [ -n "${TAURI_ENV_TARGET_TRIPLE:-}" ]; then
     echo "$TAURI_ENV_TARGET_TRIPLE"
     return 0
@@ -32,7 +32,16 @@ resolve_target_triple() {
     echo "$CARGO_BUILD_TARGET"
     return 0
   fi
-  detect_host_triple
+
+  # Tauri currently defaults to x64 on native Windows ARM64 shells in some
+  # Node/npm environments, while prepare-sidecar builds the ARM64 sidecar from
+  # rustc's host triple. Pin only that host so the app and sidecar match,
+  # leaving other native builds on Tauri's default target/release layout.
+  local host
+  host="$(detect_host_triple)"
+  if [ "$host" = "aarch64-pc-windows-msvc" ]; then
+    echo "$host"
+  fi
 }
 
 has_explicit_target() {
@@ -54,10 +63,12 @@ trap cleanup EXIT INT TERM
 
 args=("$@")
 if [ "${args[0]:-}" = "build" ] && ! has_explicit_target "$@"; then
-  target_triple="$(resolve_target_triple)"
-  export TAURI_ENV_TARGET_TRIPLE="$target_triple"
-  args=("build" "--target" "$target_triple" "${args[@]:1}")
-  echo "Building Tauri target: $target_triple"
+  target_triple="$(resolve_build_target_arg)"
+  if [ -n "$target_triple" ]; then
+    export TAURI_ENV_TARGET_TRIPLE="$target_triple"
+    args=("build" "--target" "$target_triple" "${args[@]:1}")
+    echo "Building Tauri target: $target_triple"
+  fi
 fi
 
 tauri "${args[@]}"

--- a/desktop/scripts/run-tauri.sh
+++ b/desktop/scripts/run-tauri.sh
@@ -9,6 +9,42 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONF="$SCRIPT_DIR/../src-tauri/tauri.conf.json"
 
+detect_host_triple() {
+  if ! command -v rustc >/dev/null 2>&1; then
+    echo "error: rustc is required to determine the Tauri target triple" >&2
+    return 1
+  fi
+  local host
+  host="$(rustc -vV | awk '/^host: /{print $2}')"
+  if [ -z "$host" ]; then
+    echo "error: could not determine host target triple" >&2
+    return 1
+  fi
+  echo "$host"
+}
+
+resolve_target_triple() {
+  if [ -n "${TAURI_ENV_TARGET_TRIPLE:-}" ]; then
+    echo "$TAURI_ENV_TARGET_TRIPLE"
+    return 0
+  fi
+  if [ -n "${CARGO_BUILD_TARGET:-}" ]; then
+    echo "$CARGO_BUILD_TARGET"
+    return 0
+  fi
+  detect_host_triple
+}
+
+has_explicit_target() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --target | --target=*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 cleanup() {
   if [ -f "$CONF.orig" ]; then
     mv "$CONF.orig" "$CONF"
@@ -16,4 +52,12 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-tauri "$@"
+args=("$@")
+if [ "${args[0]:-}" = "build" ] && ! has_explicit_target "$@"; then
+  target_triple="$(resolve_target_triple)"
+  export TAURI_ENV_TARGET_TRIPLE="$target_triple"
+  args=("build" "--target" "$target_triple" "${args[@]:1}")
+  echo "Building Tauri target: $target_triple"
+fi
+
+tauri "${args[@]}"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ use tauri_plugin_updater::UpdaterExt;
 const HOST: &str = "127.0.0.1";
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const DAEMON_STARTUP_LONG_NOTICE_AFTER: Duration = Duration::from_secs(300);
+const DAEMON_UNHEALTHY_GRACE: Duration = Duration::from_secs(15);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(125);
 const STATUS_POLL_MAX_INTERVAL: Duration = Duration::from_secs(1);
 const STATUS_PROBE_TIMEOUT: Duration = Duration::from_millis(1250);
@@ -94,6 +95,7 @@ struct SidecarStdoutUpdate {
 enum BackendStatusProbe {
     Ready(u16),
     Starting(String),
+    Unhealthy(String),
     NotRunning(String),
     Incompatible(String),
     Unavailable,
@@ -1439,6 +1441,7 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
         let started = Instant::now();
         let mut failed_status_probes = 0;
         let mut long_startup_notice_shown = false;
+        let mut unhealthy_since: Option<Instant> = None;
         loop {
             if !background_status_poll_is_current(&handle, generation) {
                 return;
@@ -1458,12 +1461,34 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
                 }
                 BackendStatusProbe::Starting(status) => {
                     failed_status_probes = 0;
+                    unhealthy_since = None;
                     if !long_startup_notice_shown && !status.trim().is_empty() {
                         let escaped = status.replace('\\', "\\\\").replace('\'', "\\'");
                         let _ = window.eval(
                             format!("window.__setStatus('{escaped}');").as_str(),
                         );
                     }
+                }
+                BackendStatusProbe::Unhealthy(status) => {
+                    failed_status_probes = 0;
+                    let first_seen = unhealthy_since.get_or_insert_with(Instant::now);
+                    if first_seen.elapsed() >= DAEMON_UNHEALTHY_GRACE {
+                        spawn_startup_error_render(
+                            window,
+                            "AgentsView backend is not responding",
+                            "A backend process is running, but it is not answering health checks.",
+                            startup_failure_detail(
+                                "The daemon runtime record points to a live process, but repeated health checks did not get a usable response.",
+                                status.as_str(),
+                            )
+                            .as_str(),
+                        );
+                        return;
+                    }
+                    let _ = window.eval(
+                        "window.__setStatus(\
+                         'AgentsView found a backend process, but health checks are not responding yet.');",
+                    );
                 }
                 BackendStatusProbe::NotRunning(status) => {
                     spawn_startup_error_render(
@@ -1589,10 +1614,18 @@ fn classify_backend_status_output(stdout: &str, stderr: &str) -> BackendStatusPr
     if detail.contains("incompatible running writable daemon") {
         return BackendStatusProbe::Incompatible(detail);
     }
+    if status_output_is_unhealthy(detail.as_str()) {
+        return BackendStatusProbe::Unhealthy(detail);
+    }
     if detail.trim().is_empty() {
         return BackendStatusProbe::Unavailable;
     }
     BackendStatusProbe::Starting(detail)
+}
+
+fn status_output_is_unhealthy(output: &str) -> bool {
+    output.contains("agentsview process running")
+        && output.contains("not responding to health checks")
 }
 
 fn combined_probe_output(stdout: &str, stderr: &str) -> String {
@@ -3353,12 +3386,16 @@ agentsview running at http://127.0.0.1:18082 (pid 123)
             classify_backend_status_output("agentsview is starting up.", ""),
             BackendStatusProbe::Starting("agentsview is starting up.".to_string())
         );
+    }
+
+    #[test]
+    fn classify_backend_status_output_detects_unhealthy_daemon() {
         assert_eq!(
             classify_backend_status_output(
                 "agentsview process running (pid 123) but not responding to health checks.",
                 "",
             ),
-            BackendStatusProbe::Starting(
+            BackendStatusProbe::Unhealthy(
                 "agentsview process running (pid 123) but not responding to health checks."
                     .to_string()
             )

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ use tauri_plugin_updater::UpdaterExt;
 
 const HOST: &str = "127.0.0.1";
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
-const DAEMON_STARTUP_TIMEOUT: Duration = Duration::from_secs(300);
+const DAEMON_STARTUP_LONG_NOTICE_AFTER: Duration = Duration::from_secs(300);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(125);
 const STATUS_POLL_MAX_INTERVAL: Duration = Duration::from_secs(1);
 const STATUS_PROBE_TIMEOUT: Duration = Duration::from_millis(1250);
@@ -88,6 +88,15 @@ struct SidecarStdoutUpdate {
     redacted_chunk: String,
     status: Option<String>,
     port: Option<u16>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum BackendStatusProbe {
+    Ready(u16),
+    Starting(String),
+    NotRunning(String),
+    Incompatible(String),
+    Unavailable,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -980,8 +989,10 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
     thread::spawn(move || {
         thread::sleep(READY_TIMEOUT);
         if !timeout_state.load(Ordering::SeqCst) {
-            let _ = timeout_window
-                .eval("window.__setStatus('AgentsView backend did not become ready in time.');");
+            let _ = timeout_window.eval(
+                "window.__setStatus(\
+                 'AgentsView backend is still starting. Large migrations or initial syncs can take several minutes.');",
+            );
         }
     });
 
@@ -1425,42 +1436,78 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
         .background_status_poll_generation
         .store(generation, Ordering::SeqCst);
     tauri::async_runtime::spawn(async move {
-        let deadline = Instant::now() + DAEMON_STARTUP_TIMEOUT;
+        let started = Instant::now();
         let mut failed_status_probes = 0;
-        while Instant::now() < deadline {
+        let mut long_startup_notice_shown = false;
+        loop {
             if !background_status_poll_is_current(&handle, generation) {
                 return;
             }
-            if let Some(port) = probe_backend_status(&handle).await {
-                if !background_status_poll_is_current(&handle, generation) {
+            match probe_backend_status(&handle).await {
+                BackendStatusProbe::Ready(port) => {
+                    if !background_status_poll_is_current(&handle, generation) {
+                        return;
+                    }
+                    save_sidecar_port(&handle, port);
+                    let _ = window.eval(
+                        "window.__setStage(2); \
+                         window.__setStatus('Connecting to interface...');",
+                    );
+                    redirect_when_ready(window.clone(), port);
                     return;
                 }
-                save_sidecar_port(&handle, port);
-                let _ = window.eval(
-                    "window.__setStage(2); \
-                     window.__setStatus('Connecting to interface...');",
-                );
-                redirect_when_ready(window.clone(), port);
-                return;
+                BackendStatusProbe::Starting(status) => {
+                    failed_status_probes = 0;
+                    if !long_startup_notice_shown && !status.trim().is_empty() {
+                        let escaped = status.replace('\\', "\\\\").replace('\'', "\\'");
+                        let _ = window.eval(
+                            format!("window.__setStatus('{escaped}');").as_str(),
+                        );
+                    }
+                }
+                BackendStatusProbe::NotRunning(status) => {
+                    spawn_startup_error_render(
+                        window,
+                        "AgentsView backend stopped",
+                        "The background launcher exited, and no AgentsView server is running.",
+                        startup_failure_detail(
+                            "The background backend disappeared before it became ready.",
+                            status.as_str(),
+                        )
+                        .as_str(),
+                    );
+                    return;
+                }
+                BackendStatusProbe::Incompatible(status) => {
+                    spawn_startup_error_render(
+                        window,
+                        "AgentsView backend is incompatible",
+                        "AgentsView found a running backend that this desktop app cannot use.",
+                        status.as_str(),
+                    );
+                    return;
+                }
+                BackendStatusProbe::Unavailable => {
+                    failed_status_probes += 1;
+                    if failed_status_probes == STATUS_PROBE_FAILURE_NOTICE_AFTER {
+                        let _ = window.eval(
+                            "window.__setStatus(\
+                             'Waiting for background daemon status. Check serve.log if this persists.');",
+                        );
+                    }
+                }
             }
-            failed_status_probes += 1;
-            if failed_status_probes == STATUS_PROBE_FAILURE_NOTICE_AFTER {
+            if !long_startup_notice_shown
+                && started.elapsed() >= DAEMON_STARTUP_LONG_NOTICE_AFTER
+            {
+                long_startup_notice_shown = true;
                 let _ = window.eval(
                     "window.__setStatus(\
-                     'Waiting for background daemon status. Check serve.log if this persists.');",
+                     'AgentsView is still preparing the local archive. Large migrations or full resyncs can take many minutes.');",
                 );
             }
             tokio::time::sleep(background_status_poll_interval(failed_status_probes)).await;
         }
-        if !background_status_poll_is_current(&handle, generation) {
-            return;
-        }
-        spawn_startup_error_render(
-            window,
-            "AgentsView backend did not become ready",
-            "The background launcher exited, but no writable daemon became available.",
-            "The desktop app waited several minutes for `agentsview serve status` to report a writable backend.",
-        );
     });
 }
 
@@ -1484,21 +1531,32 @@ fn background_status_poll_interval(failed_status_probes: u32) -> Duration {
         .min(STATUS_POLL_MAX_INTERVAL)
 }
 
-async fn probe_backend_status(handle: &AppHandle) -> Option<u16> {
-    let mut command = handle.shell().sidecar("agentsview").ok()?;
+async fn probe_backend_status(handle: &AppHandle) -> BackendStatusProbe {
+    let Ok(mut command) = handle.shell().sidecar("agentsview") else {
+        return BackendStatusProbe::Unavailable;
+    };
     for (key, value) in sidecar_env() {
         command = command.env(key, value);
     }
-    let (mut rx, child) = command.args(sidecar_status_args()).spawn().ok()?;
+    let Ok((mut rx, child)) = command.args(sidecar_status_args()).spawn() else {
+        return BackendStatusProbe::Unavailable;
+    };
     let mut stdout_buffer = String::new();
+    let mut stderr_buffer = String::new();
     let status = tokio::time::timeout(STATUS_PROBE_TIMEOUT, async {
         while let Some(event) = rx.recv().await {
             match event {
                 CommandEvent::Stdout(bytes) => {
                     stdout_buffer.push_str(String::from_utf8_lossy(&bytes).as_ref());
                 }
+                CommandEvent::Stderr(bytes) => {
+                    stderr_buffer.push_str(String::from_utf8_lossy(&bytes).as_ref());
+                }
                 CommandEvent::Terminated(_) => {
-                    return Ok(parse_writable_listening_port_from_status(&stdout_buffer));
+                    return Ok(classify_backend_status_output(
+                        stdout_buffer.as_str(),
+                        stderr_buffer.as_str(),
+                    ));
                 }
                 CommandEvent::Error(err) => {
                     eprintln!("[agentsview:error] {err}");
@@ -1507,15 +1565,44 @@ async fn probe_backend_status(handle: &AppHandle) -> Option<u16> {
                 _ => {}
             }
         }
-        Ok(None)
+        Ok(BackendStatusProbe::Unavailable)
     })
     .await;
     match status {
-        Ok(Ok(port)) => port,
+        Ok(Ok(status)) => status,
         Ok(Err(())) | Err(_) => {
             let _ = child.kill();
-            None
+            BackendStatusProbe::Unavailable
         }
+    }
+}
+
+fn classify_backend_status_output(stdout: &str, stderr: &str) -> BackendStatusProbe {
+    if let Some(port) = parse_writable_listening_port_from_status(stdout) {
+        return BackendStatusProbe::Ready(port);
+    }
+
+    let detail = combined_probe_output(stdout, stderr);
+    if detail.contains("No agentsview server is running.") {
+        return BackendStatusProbe::NotRunning(detail);
+    }
+    if detail.contains("incompatible running writable daemon") {
+        return BackendStatusProbe::Incompatible(detail);
+    }
+    if detail.trim().is_empty() {
+        return BackendStatusProbe::Unavailable;
+    }
+    BackendStatusProbe::Starting(detail)
+}
+
+fn combined_probe_output(stdout: &str, stderr: &str) -> String {
+    let stdout = stdout.trim();
+    let stderr = stderr.trim();
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => stdout.to_string(),
+        (true, false) => stderr.to_string(),
+        (false, false) => format!("{stdout}\n{stderr}"),
     }
 }
 
@@ -3239,11 +3326,59 @@ mode:    read-only
     fn parse_writable_listening_port_from_status_accepts_writable_daemon() {
         let output = "\
 agentsview running at http://127.0.0.1:18082 (pid 123)
-mode:    writable
+  mode:    writable
 ";
         assert_eq!(
             parse_writable_listening_port_from_status(output),
             Some(18082)
+        );
+    }
+
+    #[test]
+    fn classify_backend_status_output_detects_ready_daemon() {
+        let output = "\
+agentsview running at http://127.0.0.1:18082 (pid 123)
+  mode:    writable
+";
+
+        assert_eq!(
+            classify_backend_status_output(output, ""),
+            BackendStatusProbe::Ready(18082)
+        );
+    }
+
+    #[test]
+    fn classify_backend_status_output_keeps_starting_state_open_ended() {
+        assert_eq!(
+            classify_backend_status_output("agentsview is starting up.", ""),
+            BackendStatusProbe::Starting("agentsview is starting up.".to_string())
+        );
+        assert_eq!(
+            classify_backend_status_output(
+                "agentsview process running (pid 123) but not responding to health checks.",
+                "",
+            ),
+            BackendStatusProbe::Starting(
+                "agentsview process running (pid 123) but not responding to health checks."
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn classify_backend_status_output_reports_absent_or_incompatible_daemon() {
+        assert_eq!(
+            classify_backend_status_output("No agentsview server is running.", ""),
+            BackendStatusProbe::NotRunning("No agentsview server is running.".to_string())
+        );
+        assert_eq!(
+            classify_backend_status_output(
+                "agentsview found an incompatible running writable daemon.",
+                "",
+            ),
+            BackendStatusProbe::Incompatible(
+                "agentsview found an incompatible running writable daemon.".to_string()
+            )
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -98,6 +98,8 @@ enum BackendStatusProbe {
     Unhealthy(String),
     NotRunning(String),
     Incompatible(String),
+    ReadOnly(String),
+    Unusable(String),
     Unavailable,
 }
 
@@ -1048,11 +1050,7 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
                         String::from_utf8_lossy(&line_bytes).as_ref(),
                     );
                     emit_redacted_sidecar_stderr_chunk(redacted_stderr.as_str());
-                    push_startup_output(
-                        &startup_output,
-                        "stderr",
-                        redacted_stderr.as_str(),
-                    );
+                    push_startup_output(&startup_output, "stderr", redacted_stderr.as_str());
                 }
                 CommandEvent::Terminated(payload) => {
                     let flushed_stdout = flush_pending_sidecar_log_record(
@@ -1464,9 +1462,7 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
                     unhealthy_since = None;
                     if !long_startup_notice_shown && !status.trim().is_empty() {
                         let escaped = status.replace('\\', "\\\\").replace('\'', "\\'");
-                        let _ = window.eval(
-                            format!("window.__setStatus('{escaped}');").as_str(),
-                        );
+                        let _ = window.eval(format!("window.__setStatus('{escaped}');").as_str());
                     }
                 }
                 BackendStatusProbe::Unhealthy(status) => {
@@ -1512,6 +1508,32 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
                     );
                     return;
                 }
+                BackendStatusProbe::ReadOnly(status) => {
+                    spawn_startup_error_render(
+                        window,
+                        "AgentsView backend is read-only",
+                        "AgentsView Desktop needs a writable local backend to sync and migrate the archive.",
+                        startup_failure_detail(
+                            "A read-only backend is running for this archive, but desktop startup requires a writable daemon.",
+                            status.as_str(),
+                        )
+                        .as_str(),
+                    );
+                    return;
+                }
+                BackendStatusProbe::Unusable(status) => {
+                    spawn_startup_error_render(
+                        window,
+                        "AgentsView backend status is unusable",
+                        "The background launcher exited, but the backend did not report a usable writable server.",
+                        startup_failure_detail(
+                            "The status command returned output that is not a ready writable daemon or an active startup lock.",
+                            status.as_str(),
+                        )
+                        .as_str(),
+                    );
+                    return;
+                }
                 BackendStatusProbe::Unavailable => {
                     failed_status_probes += 1;
                     if failed_status_probes == STATUS_PROBE_FAILURE_NOTICE_AFTER {
@@ -1522,9 +1544,7 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
                     }
                 }
             }
-            if !long_startup_notice_shown
-                && started.elapsed() >= DAEMON_STARTUP_LONG_NOTICE_AFTER
-            {
+            if !long_startup_notice_shown && started.elapsed() >= DAEMON_STARTUP_LONG_NOTICE_AFTER {
                 long_startup_notice_shown = true;
                 let _ = window.eval(
                     "window.__setStatus(\
@@ -1620,12 +1640,22 @@ fn classify_backend_status_output(stdout: &str, stderr: &str) -> BackendStatusPr
     if detail.trim().is_empty() {
         return BackendStatusProbe::Unavailable;
     }
-    BackendStatusProbe::Starting(detail)
+    if status_output_is_read_only(detail.as_str()) {
+        return BackendStatusProbe::ReadOnly(detail);
+    }
+    if status_output_is_starting(detail.as_str()) {
+        return BackendStatusProbe::Starting(detail);
+    }
+    BackendStatusProbe::Unusable(detail)
 }
 
 fn status_output_is_unhealthy(output: &str) -> bool {
     output.contains("agentsview process running")
         && output.contains("not responding to health checks")
+}
+
+fn status_output_is_starting(output: &str) -> bool {
+    output.trim() == "agentsview is starting up."
 }
 
 fn combined_probe_output(stdout: &str, stderr: &str) -> String {
@@ -3399,6 +3429,29 @@ agentsview running at http://127.0.0.1:18082 (pid 123)
                 "agentsview process running (pid 123) but not responding to health checks."
                     .to_string()
             )
+        );
+    }
+
+    #[test]
+    fn classify_backend_status_output_rejects_read_only_daemon() {
+        let output = "\
+agentsview running at http://127.0.0.1:18082
+  pid:     123
+  version: v0.35.0
+  mode:    read-only
+";
+
+        assert_eq!(
+            classify_backend_status_output(output, ""),
+            BackendStatusProbe::ReadOnly(output.trim().to_string())
+        );
+    }
+
+    #[test]
+    fn classify_backend_status_output_rejects_unknown_non_startup_status() {
+        assert_eq!(
+            classify_backend_status_output("agentsview status is unexpected.", ""),
+            BackendStatusProbe::Unusable("agentsview status is unexpected.".to_string())
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1696,7 +1696,9 @@ fn status_output_is_unhealthy(output: &str) -> bool {
 }
 
 fn status_output_is_starting(output: &str) -> bool {
-    output.trim() == "agentsview is starting up."
+    output
+        .lines()
+        .any(|line| line.trim() == "agentsview is starting up.")
 }
 
 fn combined_probe_output(stdout: &str, stderr: &str) -> String {
@@ -3495,6 +3497,19 @@ agentsview running at http://127.0.0.1:18082 (pid 123)
         assert_eq!(
             classify_backend_status_output("agentsview is starting up.", ""),
             BackendStatusProbe::Starting("agentsview is starting up.".to_string())
+        );
+    }
+
+    #[test]
+    fn classify_backend_status_output_keeps_starting_with_stderr_diagnostics() {
+        assert_eq!(
+            classify_backend_status_output(
+                "agentsview is starting up.\n",
+                "warning: using default config"
+            ),
+            BackendStatusProbe::Starting(
+                "agentsview is starting up.\nwarning: using default config".to_string()
+            )
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1439,13 +1439,17 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
     tauri::async_runtime::spawn(async move {
         let started = Instant::now();
         let mut failed_status_probes = 0;
+        let mut status_poll_backoff_attempts = 0;
         let mut long_startup_notice_shown = false;
         let mut unhealthy_since: Option<Instant> = None;
         loop {
             if !background_status_poll_is_current(&handle, generation) {
                 return;
             }
-            match probe_backend_status(&handle).await {
+            let status = probe_backend_status(&handle).await;
+            status_poll_backoff_attempts =
+                next_background_status_poll_attempts(&status, status_poll_backoff_attempts);
+            match status {
                 BackendStatusProbe::Ready(port) => {
                     if !background_status_poll_is_current(&handle, generation) {
                         return;
@@ -1568,7 +1572,10 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
                      'AgentsView is still preparing the local archive. Large migrations or full resyncs can take many minutes.');",
                 );
             }
-            tokio::time::sleep(background_status_poll_interval(failed_status_probes)).await;
+            tokio::time::sleep(background_status_poll_interval(
+                status_poll_backoff_attempts,
+            ))
+            .await;
         }
     });
 }
@@ -1581,8 +1588,8 @@ fn background_status_poll_is_current(handle: &AppHandle, generation: u64) -> boo
         == generation
 }
 
-fn background_status_poll_interval(failed_status_probes: u32) -> Duration {
-    let multiplier = match failed_status_probes {
+fn background_status_poll_interval(backoff_attempts: u32) -> Duration {
+    let multiplier = match backoff_attempts {
         0..=8 => 1,
         9..=16 => 2,
         17..=24 => 4,
@@ -1591,6 +1598,19 @@ fn background_status_poll_interval(failed_status_probes: u32) -> Duration {
     READY_POLL_INTERVAL
         .saturating_mul(multiplier)
         .min(STATUS_POLL_MAX_INTERVAL)
+}
+
+fn next_background_status_poll_attempts(status: &BackendStatusProbe, current: u32) -> u32 {
+    match status {
+        BackendStatusProbe::Starting(_)
+        | BackendStatusProbe::Unhealthy(_)
+        | BackendStatusProbe::Unavailable => current.saturating_add(1),
+        BackendStatusProbe::Ready(_)
+        | BackendStatusProbe::NotRunning(_)
+        | BackendStatusProbe::Incompatible(_)
+        | BackendStatusProbe::ReadOnly(_)
+        | BackendStatusProbe::Unusable(_) => current,
+    }
 }
 
 fn status_probe_failures_should_stop(failed_status_probes: u32) -> bool {
@@ -2856,6 +2876,34 @@ mod tests {
         assert_eq!(
             background_status_poll_interval(u32::MAX),
             Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn status_poll_backoff_counts_non_ready_statuses() {
+        let mut attempts = 0;
+
+        attempts = next_background_status_poll_attempts(
+            &BackendStatusProbe::Starting("agentsview is starting up.".to_string()),
+            attempts,
+        );
+        assert_eq!(attempts, 1);
+
+        attempts = next_background_status_poll_attempts(
+            &BackendStatusProbe::Unhealthy("health checks are not responding".to_string()),
+            attempts,
+        );
+        assert_eq!(attempts, 2);
+
+        attempts = next_background_status_poll_attempts(&BackendStatusProbe::Unavailable, attempts);
+        assert_eq!(attempts, 3);
+
+        attempts = next_background_status_poll_attempts(&BackendStatusProbe::Ready(8080), attempts);
+        assert_eq!(attempts, 3);
+
+        assert_eq!(
+            next_background_status_poll_attempts(&BackendStatusProbe::Unavailable, u32::MAX),
+            u32::MAX
         );
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ const READY_POLL_INTERVAL: Duration = Duration::from_millis(125);
 const STATUS_POLL_MAX_INTERVAL: Duration = Duration::from_secs(1);
 const STATUS_PROBE_TIMEOUT: Duration = Duration::from_millis(1250);
 const STATUS_PROBE_FAILURE_NOTICE_AFTER: u32 = 10;
+const STATUS_PROBE_FAILURE_FAIL_AFTER: u32 = 30;
 const LOGIN_SHELL_ENV_TIMEOUT: Duration = Duration::from_secs(3);
 const UPDATE_SIDECAR_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const DATA_VERSION_TOO_NEW_EXIT_CODE: i32 = 3;
@@ -1536,6 +1537,22 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
                 }
                 BackendStatusProbe::Unavailable => {
                     failed_status_probes += 1;
+                    if status_probe_failures_should_stop(failed_status_probes) {
+                        spawn_startup_error_render(
+                            window,
+                            "AgentsView backend status is unavailable",
+                            "The background launcher exited, but the desktop app could not confirm backend status.",
+                            startup_failure_detail(
+                                format!(
+                                    "`agentsview serve status` failed, timed out, or returned no usable output after {failed_status_probes} attempts."
+                                )
+                                .as_str(),
+                                "",
+                            )
+                            .as_str(),
+                        );
+                        return;
+                    }
                     if failed_status_probes == STATUS_PROBE_FAILURE_NOTICE_AFTER {
                         let _ = window.eval(
                             "window.__setStatus(\
@@ -1574,6 +1591,10 @@ fn background_status_poll_interval(failed_status_probes: u32) -> Duration {
     READY_POLL_INTERVAL
         .saturating_mul(multiplier)
         .min(STATUS_POLL_MAX_INTERVAL)
+}
+
+fn status_probe_failures_should_stop(failed_status_probes: u32) -> bool {
+    failed_status_probes >= STATUS_PROBE_FAILURE_FAIL_AFTER
 }
 
 async fn probe_backend_status(handle: &AppHandle) -> BackendStatusProbe {
@@ -2836,6 +2857,17 @@ mod tests {
             background_status_poll_interval(u32::MAX),
             Duration::from_secs(1)
         );
+    }
+
+    #[test]
+    fn status_probe_failures_stop_after_bounded_threshold() {
+        assert!(!status_probe_failures_should_stop(
+            STATUS_PROBE_FAILURE_FAIL_AFTER - 1
+        ));
+        assert!(status_probe_failures_should_stop(
+            STATUS_PROBE_FAILURE_FAIL_AFTER
+        ));
+        assert!(status_probe_failures_should_stop(u32::MAX));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ const UPDATE_SIDECAR_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const DATA_VERSION_TOO_NEW_EXIT_CODE: i32 = 3;
 const DESKTOP_LOG_FILE_NAME: &str = "agentsview-desktop.log";
 const DESKTOP_LOG_QUEUE_CAPACITY: usize = 64;
+const STARTUP_OUTPUT_MAX_CHARS: usize = 12_000;
 const OPEN_LOGS_FOLDER_MENU_ID: &str = "open_logs_folder";
 // Delay after navigating to the backend before probing whether the
 // Linux WebKitGTK web content process is actually alive. Gives the
@@ -117,11 +118,23 @@ pub fn run() {
         .plugin(init_navigation_guard_plugin())
         .manage(SidecarState::default())
         .setup(|app| {
-            setup_menu(app)?;
+            if let Err(err) = setup_menu(app) {
+                eprintln!("[agentsview] failed to set up desktop menu: {err}");
+            }
             match tauri::async_runtime::block_on(run_data_version_preflight(app.handle())) {
                 Ok(()) => {
-                    launch_backend(app)?;
-                    schedule_auto_update_check(app.handle().clone());
+                    if let Err(err) = launch_backend(app) {
+                        eprintln!("[agentsview] backend launch failed: {err}");
+                        let window = main_window(app)?;
+                        spawn_startup_error_render(
+                            window,
+                            "AgentsView could not start",
+                            "The local backend failed to launch.",
+                            err.to_string().as_str(),
+                        );
+                    } else {
+                        schedule_auto_update_check(app.handle().clone());
+                    }
                 }
                 Err(DataVersionPreflightError::TooNew(message)) => {
                     eprintln!("[agentsview] data version preflight rejected archive: {message}");
@@ -139,14 +152,11 @@ pub fn run() {
                 }
                 Err(DataVersionPreflightError::Failed(message)) => {
                     let window = main_window(app)?;
-                    spawn_preflight_error_render(
+                    spawn_startup_error_render(
                         window,
                         "AgentsView could not verify the archive",
-                        format!(
-                            "Database compatibility check failed: {message}. The backend was not started."
-                        )
-                        .as_str(),
-                        "Close and reopen AgentsView after fixing the issue.",
+                        "The database compatibility check failed, so the backend was not started.",
+                        message.as_str(),
                     );
                 }
             }
@@ -963,6 +973,7 @@ fn wait_for_sidecar_termination(state: &SidecarState, generation: u64, timeout: 
 fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u64) {
     let startup_handled = Arc::new(AtomicBool::new(false));
     let first_output = Arc::new(AtomicBool::new(false));
+    let startup_output = Arc::new(Mutex::new(String::new()));
     let log_sender = spawn_sidecar_log_writer(window.app_handle().clone());
     let timeout_window = window.clone();
     let timeout_state = startup_handled.clone();
@@ -988,6 +999,11 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
                         &chunk_bytes,
                     );
                     emit_redacted_sidecar_stdout_chunk(stdout_update.redacted_chunk.as_str());
+                    push_startup_output(
+                        &startup_output,
+                        "stdout",
+                        stdout_update.redacted_chunk.as_str(),
+                    );
                     if !startup_handled.load(Ordering::SeqCst) {
                         if !first_output.swap(true, Ordering::SeqCst) {
                             let _ = window.eval(
@@ -1012,36 +1028,46 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
                     }
                 }
                 CommandEvent::Stderr(line_bytes) => {
-                    emit_redacted_sidecar_stderr_chunk(
-                        queue_redacted_sidecar_chunk(
-                            &log_sender,
-                            "stderr",
-                            &mut stderr_log_buffer,
-                            String::from_utf8_lossy(&line_bytes).as_ref(),
-                        )
-                        .as_str(),
+                    let redacted_stderr = queue_redacted_sidecar_chunk(
+                        &log_sender,
+                        "stderr",
+                        &mut stderr_log_buffer,
+                        String::from_utf8_lossy(&line_bytes).as_ref(),
+                    );
+                    emit_redacted_sidecar_stderr_chunk(redacted_stderr.as_str());
+                    push_startup_output(
+                        &startup_output,
+                        "stderr",
+                        redacted_stderr.as_str(),
                     );
                 }
                 CommandEvent::Terminated(payload) => {
-                    emit_redacted_sidecar_stdout_chunk(
-                        flush_pending_sidecar_log_record(
-                            &log_sender,
-                            "stdout",
-                            &mut stdout_log_buffer,
-                        )
-                        .as_str(),
+                    let flushed_stdout = flush_pending_sidecar_log_record(
+                        &log_sender,
+                        "stdout",
+                        &mut stdout_log_buffer,
                     );
-                    emit_redacted_sidecar_stderr_chunk(
-                        flush_pending_sidecar_log_record(
-                            &log_sender,
-                            "stderr",
-                            &mut stderr_log_buffer,
-                        )
-                        .as_str(),
+                    emit_redacted_sidecar_stdout_chunk(flushed_stdout.as_str());
+                    push_startup_output(&startup_output, "stdout", flushed_stdout.as_str());
+                    let flushed_stderr = flush_pending_sidecar_log_record(
+                        &log_sender,
+                        "stderr",
+                        &mut stderr_log_buffer,
                     );
+                    emit_redacted_sidecar_stderr_chunk(flushed_stderr.as_str());
+                    push_startup_output(&startup_output, "stderr", flushed_stderr.as_str());
                     queue_sidecar_event_log_record(
                         &log_sender,
                         &CommandEvent::Terminated(payload.clone()),
+                    );
+                    push_startup_output(
+                        &startup_output,
+                        "terminated",
+                        format!(
+                            "sidecar terminated (code: {:?}, signal: {:?})",
+                            payload.code, payload.signal
+                        )
+                        .as_str(),
                     );
                     eprintln!(
                         "[agentsview] sidecar terminated (code: {:?}, signal: {:?})",
@@ -1064,9 +1090,15 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
                         break;
                     }
                     if handle_sidecar_terminated(&state, startup_handled.as_ref(), generation) {
-                        let _ = window.eval(
-                            "window.__setStatus(\
-                             'AgentsView backend exited before startup completed.');",
+                        spawn_startup_error_render(
+                            window.clone(),
+                            "AgentsView backend failed",
+                            "The local backend exited before startup completed.",
+                            startup_failure_detail(
+                                "The sidecar process ended before it reported a ready backend.",
+                                recent_startup_output(&startup_output).as_str(),
+                            )
+                            .as_str(),
                         );
                     }
                     let restart_after_stop_timeout =
@@ -1078,19 +1110,37 @@ fn forward_sidecar_logs(mut rx: CommandRx, window: WebviewWindow, generation: u6
                 }
                 CommandEvent::Error(err) => {
                     queue_sidecar_event_log_record(&log_sender, &CommandEvent::Error(err.clone()));
+                    let redacted = redact_sidecar_log_line(err.as_str());
+                    push_startup_output(
+                        &startup_output,
+                        "error",
+                        format!("sidecar command error: {redacted}").as_str(),
+                    );
                     eprintln!("[agentsview:error] {err}");
+                    if !startup_handled.swap(true, Ordering::SeqCst) {
+                        spawn_startup_error_render(
+                            window.clone(),
+                            "AgentsView backend failed",
+                            "The desktop wrapper received an error from the backend process.",
+                            startup_failure_detail(
+                                redacted.as_str(),
+                                recent_startup_output(&startup_output).as_str(),
+                            )
+                            .as_str(),
+                        );
+                    }
                 }
                 _ => {}
             }
         }
-        emit_redacted_sidecar_stdout_chunk(
-            flush_pending_sidecar_log_record(&log_sender, "stdout", &mut stdout_log_buffer)
-                .as_str(),
-        );
-        emit_redacted_sidecar_stderr_chunk(
-            flush_pending_sidecar_log_record(&log_sender, "stderr", &mut stderr_log_buffer)
-                .as_str(),
-        );
+        let flushed_stdout =
+            flush_pending_sidecar_log_record(&log_sender, "stdout", &mut stdout_log_buffer);
+        emit_redacted_sidecar_stdout_chunk(flushed_stdout.as_str());
+        push_startup_output(&startup_output, "stdout", flushed_stdout.as_str());
+        let flushed_stderr =
+            flush_pending_sidecar_log_record(&log_sender, "stderr", &mut stderr_log_buffer);
+        emit_redacted_sidecar_stderr_chunk(flushed_stderr.as_str());
+        push_startup_output(&startup_output, "stderr", flushed_stderr.as_str());
     });
 }
 
@@ -1103,6 +1153,65 @@ fn main_window_from_handle(handle: &AppHandle) -> Result<WebviewWindow, DynError
     handle
         .get_webview_window("main")
         .ok_or_else(|| io::Error::other("missing main window").into())
+}
+
+fn spawn_startup_error_render(window: WebviewWindow, title: &str, message: &str, detail: &str) {
+    let title = title.to_string();
+    let message = message.to_string();
+    let detail = detail.to_string();
+    let footer = startup_failure_footer(window.app_handle());
+    thread::spawn(move || {
+        let script = startup_error_script(
+            title.as_str(),
+            message.as_str(),
+            detail.as_str(),
+            footer.as_str(),
+        );
+        let deadline = Instant::now() + READY_TIMEOUT;
+        while Instant::now() < deadline {
+            if window.eval(script.as_str()).is_ok() {
+                return;
+            }
+            thread::sleep(READY_POLL_INTERVAL);
+        }
+        eprintln!("[agentsview] timed out waiting to render startup error");
+    });
+}
+
+fn startup_error_script(title: &str, message: &str, detail: &str, footer: &str) -> String {
+    let title = js_string_literal(title);
+    let message = js_string_literal(message);
+    let detail = js_string_literal(detail);
+    let footer = js_string_literal(footer);
+    let retry_ms = READY_POLL_INTERVAL.as_millis();
+    format!(
+        "(function renderStartupError() {{\
+            var h = document.querySelector('h1');\
+            var status = document.getElementById('status');\
+            if (!h || !status) {{\
+                window.setTimeout(renderStartupError, {retry_ms});\
+                return;\
+            }}\
+            var shell = document.querySelector('.shell');\
+            if (shell) shell.setAttribute('role', 'alert');\
+            if (h) h.textContent = {title};\
+            if (status) status.textContent = {message};\
+            var detail = document.getElementById('startup-error-detail');\
+            if (!detail) {{\
+                detail = document.createElement('pre');\
+                detail.id = 'startup-error-detail';\
+                status.insertAdjacentElement('afterend', detail);\
+            }}\
+            detail.textContent = {detail};\
+            detail.style.cssText = 'margin:14px 0 0;padding:12px;border:1px solid #f0b8b8;border-radius:8px;background:#fff7f7;color:#5f1f1f;font:12px/1.45 Consolas,Menlo,monospace;white-space:pre-wrap;max-height:280px;overflow:auto;';\
+            var meter = document.querySelector('.meter');\
+            if (meter) meter.style.display = 'none';\
+            var stages = document.querySelector('.stage-list');\
+            if (stages) stages.style.display = 'none';\
+            var foot = document.querySelector('.foot');\
+            if (foot) foot.textContent = {footer};\
+        }})()"
+    )
 }
 
 fn spawn_preflight_error_render(window: WebviewWindow, title: &str, message: &str, footer: &str) {
@@ -1159,6 +1268,75 @@ fn too_new_archive_footer_message() -> &'static str {
 
 fn js_string_literal(value: &str) -> String {
     serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+fn startup_failure_footer(handle: &AppHandle) -> String {
+    match desktop_log_file_path(handle) {
+        Ok(path) => format!(
+            "Attach this desktop log when reporting the failure: {}. If the details mention serve.log, attach that file too.",
+            path.display()
+        ),
+        Err(_) => {
+            "Use File > Open Logs Folder and attach agentsview-desktop.log when reporting this. If the details mention serve.log, attach that file too."
+                .to_string()
+        }
+    }
+}
+
+fn startup_failure_detail(summary: &str, recent_output: &str) -> String {
+    let recent_output = recent_output.trim();
+    if recent_output.is_empty() {
+        return format!("{summary}\n\nNo backend output was captured before startup stopped.");
+    }
+    format!("{summary}\n\nRecent backend output:\n{recent_output}")
+}
+
+fn push_startup_output(buffer: &Arc<Mutex<String>>, label: &str, chunk: &str) {
+    let chunk = chunk.trim();
+    if chunk.is_empty() {
+        return;
+    }
+    let Ok(mut guard) = buffer.lock() else {
+        return;
+    };
+    if !guard.is_empty() {
+        guard.push('\n');
+    }
+    guard.push('[');
+    guard.push_str(label);
+    guard.push_str("] ");
+    guard.push_str(chunk);
+    trim_startup_output(&mut guard);
+}
+
+fn recent_startup_output(buffer: &Arc<Mutex<String>>) -> String {
+    buffer
+        .lock()
+        .map(|guard| guard.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn trim_startup_output(output: &mut String) {
+    if output.len() <= STARTUP_OUTPUT_MAX_CHARS {
+        return;
+    }
+    let target = output.len() - STARTUP_OUTPUT_MAX_CHARS;
+    let mut drain_to = output.len();
+    for (idx, ch) in output.char_indices() {
+        if ch == '\n' && idx + ch.len_utf8() >= target {
+            drain_to = idx + ch.len_utf8();
+            break;
+        }
+        if idx >= target {
+            drain_to = idx;
+            break;
+        }
+    }
+    output.drain(..drain_to);
+    let prefix = "[earlier startup output truncated]\n";
+    if !output.starts_with(prefix) {
+        output.insert_str(0, prefix);
+    }
 }
 
 fn desktop_redirect_url(port: u16) -> String {
@@ -1231,9 +1409,11 @@ fn redirect_when_ready(window: WebviewWindow, port: u16) {
             return;
         }
 
-        let _ = window.eval(
-            "document.getElementById('status').textContent = \
-             'AgentsView backend did not start within 30 seconds.';",
+        spawn_startup_error_render(
+            window,
+            "AgentsView interface did not respond",
+            "The backend reported a port, but the desktop window could not connect to it.",
+            format!("Backend URL: {target_url}").as_str(),
         );
     });
 }
@@ -1275,8 +1455,11 @@ fn poll_background_status_after_launcher_exit(window: WebviewWindow, generation:
         if !background_status_poll_is_current(&handle, generation) {
             return;
         }
-        let _ = window.eval(
-            "window.__setStatus('AgentsView backend did not become ready after several minutes.');",
+        spawn_startup_error_render(
+            window,
+            "AgentsView backend did not become ready",
+            "The background launcher exited, but no writable daemon became available.",
+            "The desktop app waited several minutes for `agentsview serve status` to report a writable backend.",
         );
     });
 }
@@ -2600,6 +2783,46 @@ mod tests {
     }
 
     #[test]
+    fn startup_error_script_renders_reportable_details() {
+        let script = startup_error_script(
+            "Backend failed",
+            "The local backend exited.",
+            "fatal: opening database",
+            "Attach logs",
+        );
+
+        assert!(script.contains("function renderStartupError"));
+        assert!(script.contains("startup-error-detail"));
+        assert!(script.contains("fatal: opening database"));
+        assert!(script.contains("role', 'alert'"));
+        assert!(script.contains("Attach logs"));
+    }
+
+    #[test]
+    fn startup_failure_detail_includes_recent_output() {
+        let detail = startup_failure_detail(
+            "The sidecar process ended before it was ready.",
+            "[stderr] fatal: opening database",
+        );
+
+        assert!(detail.contains("The sidecar process ended"));
+        assert!(detail.contains("Recent backend output"));
+        assert!(detail.contains("[stderr] fatal: opening database"));
+    }
+
+    #[test]
+    fn startup_output_buffer_labels_recent_chunks() {
+        let buffer = Arc::new(Mutex::new(String::new()));
+
+        push_startup_output(&buffer, "stdout", "Auth enabled. Token: secret-token");
+        push_startup_output(&buffer, "stderr", "fatal: bad config");
+
+        let output = recent_startup_output(&buffer);
+        assert!(output.contains("[stdout] Auth enabled. Token: secret-token"));
+        assert!(output.contains("[stderr] fatal: bad config"));
+    }
+
+    #[test]
     fn parse_listening_port_extracts_backend_port() {
         let line = "agentsview dev listening at http://127.0.0.1:18080 (started in 1.2s)";
         assert_eq!(parse_listening_port(line), Some(18080));
@@ -2973,7 +3196,7 @@ mod tests {
         assert!(stdout_arm.contains("stdout_update.port"));
         assert!(stdout_arm.contains("window.__setStage(2)"));
         assert!(source.contains(
-            "flush_pending_sidecar_stdout_log_record(&log_sender, &mut stdout_log_buffer);"
+            "flush_pending_sidecar_log_record(&log_sender, \"stdout\", &mut stdout_log_buffer)"
         ));
     }
 


### PR DESCRIPTION
Desktop startup now renders reportable failure details in the Tauri loading window when the bundled backend fails to launch, errors, or exits before readiness. It also keeps waiting through long daemon migrations and full resyncs instead of treating a five-minute startup as failed, while still reporting clearly absent or incompatible daemons.