### PR TITLE
fix(cli): require daemon transport for read commands

### DIFF
--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -73,7 +73,9 @@ func resolveArchiveQueryBackendWithConfig(
 			case policy.ReadOnlyDaemon == archiveQueryRejectReadOnlyDaemon:
 				return nil, nil, readOnlySessionUsageDaemonError(tr.URL)
 			case policy.ReadOnlyDaemon == archiveQuerySkipReadOnlyDaemon:
-				return nil, nil, readOnlySessionUsageDaemonError(tr.URL)
+				return nil, nil, readOnlyArchiveQueryDaemonError(
+					tr.URL, policy.DirectReadOnlyAction,
+				)
 			default:
 				return nil, nil, fmt.Errorf(
 					"unknown read-only daemon policy %d",
@@ -125,6 +127,16 @@ func directReadOnlyArchiveQueryError(
 		action = "query directly"
 	}
 	return fmt.Errorf("%s; refusing to %s", reason, action)
+}
+
+func readOnlyArchiveQueryDaemonError(url string, action string) error {
+	if action == "" {
+		action = "query directly"
+	}
+	return fmt.Errorf(
+		"daemon at %s is read-only; stop it to %s",
+		url, action,
+	)
 }
 
 func openArchiveQueryDB(

--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -73,7 +73,7 @@ func resolveArchiveQueryBackendWithConfig(
 			case policy.ReadOnlyDaemon == archiveQueryRejectReadOnlyDaemon:
 				return nil, nil, readOnlySessionUsageDaemonError(tr.URL)
 			case policy.ReadOnlyDaemon == archiveQuerySkipReadOnlyDaemon:
-				// Fall through to the local read-only archive below.
+				return nil, nil, readOnlySessionUsageDaemonError(tr.URL)
 			default:
 				return nil, nil, fmt.Errorf(
 					"unknown read-only daemon policy %d",
@@ -106,7 +106,10 @@ func resolveArchiveQueryTransport(
 	if policy.AutoStart && !policy.NoSync {
 		return ensureTransport(cfg, transportIntentArchiveWrite, 0)
 	}
-	return detectTransport(cfg.DataDir, cfg.AuthToken, 0)
+	if policy.NoSync {
+		cfg.NoSync = true
+	}
+	return ensureTransport(cfg, transportIntentRead, 0)
 }
 
 func directReadOnlyArchiveQueryError(

--- a/cmd/agentsview/archive_query_backend_test.go
+++ b/cmd/agentsview/archive_query_backend_test.go
@@ -51,6 +51,7 @@ func TestResolveArchiveQueryBackendRefusesReadOnlyDaemonForFreshQueries(t *testi
 	}
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read-only")
+	assert.NotContains(t, err.Error(), "--pg")
 	assert.False(t, called)
 }
 

--- a/cmd/agentsview/archive_query_backend_test.go
+++ b/cmd/agentsview/archive_query_backend_test.go
@@ -13,18 +13,25 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-func TestResolveArchiveQueryBackendNoSyncDoesNotAutostartDaemon(t *testing.T) {
+func TestResolveArchiveQueryBackendNoSyncStartsNoSyncDaemon(t *testing.T) {
 	testDataDir(t)
-	forbidStartBackgroundServeForTransport(t,
-		"--no-sync archive query must not auto-start a daemon")
+	var started bool
+	stubStartBackgroundServeForTransport(t, func(
+		_ context.Context, cfg *config.Config, _ time.Duration,
+	) (*DaemonRuntime, error) {
+		started = true
+		assert.True(t, cfg.NoSync)
+		return &DaemonRuntime{Host: "127.0.0.1", Port: 12345}, nil
+	})
 
 	backend := resolveTestArchiveQueryBackend(t, defaultArchiveQueryPolicy(
 		func(p *archiveQueryPolicy) { p.NoSync = true },
 	))
-	assert.IsType(t, localArchiveQueryBackend{}, backend)
+	assert.True(t, started)
+	assert.IsType(t, daemonArchiveQueryBackend{}, backend)
 }
 
-func TestResolveArchiveQueryBackendSkipsReadOnlyDaemonForFreshQueries(t *testing.T) {
+func TestResolveArchiveQueryBackendRefusesReadOnlyDaemonForFreshQueries(t *testing.T) {
 	dataDir := testDataDir(t)
 
 	var called bool
@@ -36,8 +43,14 @@ func TestResolveArchiveQueryBackendSkipsReadOnlyDaemonForFreshQueries(t *testing
 	})
 	registerTestRuntime(t, dataDir, ts.URL, true)
 
-	backend := resolveTestArchiveQueryBackend(t, defaultArchiveQueryPolicy(nil))
-	assert.IsType(t, localArchiveQueryBackend{}, backend)
+	_, cleanup, err := resolveArchiveQueryBackend(
+		context.Background(), defaultArchiveQueryPolicy(nil),
+	)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read-only")
 	assert.False(t, called)
 }
 

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -416,7 +416,7 @@ func newHealthCommand() *cobra.Command {
 		Args:         cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.JSON = outputFormat(cmd) == "json"
-			runHealth(args, cfg)
+			runHealth(cmd, args, cfg)
 		},
 	}
 	registerFormatFlags(cmd.Flags())

--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	daemonService          = "agentsview"
-	daemonAPIVersion       = 1
+	daemonAPIVersion       = 2
 	runtimeReadOnly        = "read_only"
 	runtimeHost            = "host"
 	runtimePort            = "port"

--- a/cmd/agentsview/daemon_runtime_test.go
+++ b/cmd/agentsview/daemon_runtime_test.go
@@ -276,6 +276,10 @@ func startExternalDaemonStartLockHelper(t *testing.T, dataDir string) io.Closer 
 		_ = cmd.Process.Kill()
 		require.Equal(t, "ready", strings.TrimSpace(line))
 	}
+	require.Eventually(t, func() bool {
+		return isExternalDaemonStarting(dataDir)
+	}, 2*time.Second, 10*time.Millisecond,
+		"external daemon start lock should be visible to parent")
 	return stdin
 }
 

--- a/cmd/agentsview/health.go
+++ b/cmd/agentsview/health.go
@@ -123,15 +123,11 @@ func resolveHealthSessionID(
 	if err != nil {
 		return "", err
 	}
-	page, err := svc.List(ctx, healthListFilter(maxHealthLimit))
+	matches, err := svc.FindSessionIDsByPartial(
+		ctx, partial, resolveLookupLimit,
+	)
 	if err != nil {
 		return "", err
-	}
-	matches := make([]string, 0, len(page.Sessions))
-	for _, sess := range page.Sessions {
-		if strings.Contains(sess.ID, partial) {
-			matches = append(matches, sess.ID)
-		}
 	}
 	if exactDetail != nil {
 		for _, m := range matches {

--- a/cmd/agentsview/health.go
+++ b/cmd/agentsview/health.go
@@ -10,8 +10,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"go.kenn.io/agentsview/internal/config"
+	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 // HealthConfig configures the `health` command.
@@ -25,28 +26,27 @@ const (
 	maxHealthLimit     = db.MaxSessionLimit
 )
 
-func runHealth(args []string, cfg HealthConfig) {
-	appCfg, err := config.LoadMinimal()
+func runHealth(cmd *cobra.Command, args []string, cfg HealthConfig) {
+	svc, cleanup, err := resolveService(cmd)
 	if err != nil {
-		fatal("loading config: %v", err)
+		fatal("resolving service: %v", err)
 	}
-	database, err := openReadOnlyDB(appCfg)
-	if err != nil {
-		fatal("opening database: %v", err)
-	}
-	defer database.Close()
+	defer cleanup()
 
-	ctx := context.Background()
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	if len(args) == 0 {
-		runHealthList(ctx, database, cfg)
+		runHealthList(ctx, svc, cfg)
 		return
 	}
-	runHealthDetail(ctx, database, args[0], cfg.JSON)
+	runHealthDetail(ctx, svc, args[0], cfg.JSON)
 }
 
 func runHealthList(
-	ctx context.Context, database *db.DB, cfg HealthConfig,
+	ctx context.Context, svc service.SessionService, cfg HealthConfig,
 ) {
 	limit := cfg.Limit
 	if limit <= 0 {
@@ -56,7 +56,7 @@ func runHealthList(
 		limit = maxHealthLimit
 	}
 
-	page, err := database.ListSessions(ctx, db.SessionFilter{
+	page, err := svc.List(ctx, service.ListFilter{
 		Limit: limit,
 	})
 	if err != nil {
@@ -76,19 +76,14 @@ func runHealthList(
 }
 
 func runHealthDetail(
-	ctx context.Context, database *db.DB,
+	ctx context.Context, svc service.SessionService,
 	sessionID string, asJSON bool,
 ) {
-	resolved, err := resolveSessionID(ctx, database, sessionID)
+	resolved, err := resolveServiceSessionID(ctx, svc, sessionID)
 	if err != nil {
 		fatal("resolving session id: %v", err)
 	}
-	if resolved == "" {
-		fmt.Fprintf(os.Stderr,
-			"session not found: %s\n", sessionID)
-		os.Exit(1)
-	}
-	sess, err := database.GetSessionFull(ctx, resolved)
+	sess, err := svc.Get(ctx, resolved)
 	if err != nil {
 		fatal("getting session: %v", err)
 	}
@@ -102,7 +97,7 @@ func runHealthDetail(
 		writeJSON(os.Stdout, sess)
 		return
 	}
-	printHealthDetail(os.Stdout, *sess)
+	printHealthDetail(os.Stdout, sess.Session)
 }
 
 // resolveLookupLimit caps the partial-match query for

--- a/cmd/agentsview/health.go
+++ b/cmd/agentsview/health.go
@@ -119,6 +119,13 @@ func resolveHealthSessionID(
 	if partial == "" {
 		return "", nil
 	}
+	detail, err := svc.Get(ctx, partial)
+	if err != nil {
+		return "", err
+	}
+	if detail != nil {
+		return partial, nil
+	}
 	page, err := svc.List(ctx, healthListFilter(maxHealthLimit))
 	if err != nil {
 		return "", err

--- a/cmd/agentsview/health.go
+++ b/cmd/agentsview/health.go
@@ -119,12 +119,9 @@ func resolveHealthSessionID(
 	if partial == "" {
 		return "", nil
 	}
-	detail, err := svc.Get(ctx, partial)
+	exactDetail, err := svc.Get(ctx, partial)
 	if err != nil {
 		return "", err
-	}
-	if detail != nil {
-		return partial, nil
 	}
 	page, err := svc.List(ctx, healthListFilter(maxHealthLimit))
 	if err != nil {
@@ -135,6 +132,14 @@ func resolveHealthSessionID(
 		if strings.Contains(sess.ID, partial) {
 			matches = append(matches, sess.ID)
 		}
+	}
+	if exactDetail != nil {
+		for _, m := range matches {
+			if m != partial && shortID(m) == partial {
+				return "", ambiguousMatchErr(partial, matches)
+			}
+		}
+		return partial, nil
 	}
 	switch len(matches) {
 	case 0:

--- a/cmd/agentsview/health.go
+++ b/cmd/agentsview/health.go
@@ -56,9 +56,7 @@ func runHealthList(
 		limit = maxHealthLimit
 	}
 
-	page, err := svc.List(ctx, service.ListFilter{
-		Limit: limit,
-	})
+	page, err := svc.List(ctx, healthListFilter(limit))
 	if err != nil {
 		fatal("listing sessions: %v", err)
 	}
@@ -79,9 +77,14 @@ func runHealthDetail(
 	ctx context.Context, svc service.SessionService,
 	sessionID string, asJSON bool,
 ) {
-	resolved, err := resolveServiceSessionID(ctx, svc, sessionID)
+	resolved, err := resolveHealthSessionID(ctx, svc, sessionID)
 	if err != nil {
 		fatal("resolving session id: %v", err)
+	}
+	if resolved == "" {
+		fmt.Fprintf(os.Stderr,
+			"session not found: %s\n", sessionID)
+		os.Exit(1)
 	}
 	sess, err := svc.Get(ctx, resolved)
 	if err != nil {
@@ -98,6 +101,57 @@ func runHealthDetail(
 		return
 	}
 	printHealthDetail(os.Stdout, sess.Session)
+}
+
+func healthListFilter(limit int) service.ListFilter {
+	return service.ListFilter{
+		Limit:            limit,
+		IncludeOneShot:   true,
+		IncludeAutomated: true,
+	}
+}
+
+func resolveHealthSessionID(
+	ctx context.Context,
+	svc service.SessionService,
+	partial string,
+) (string, error) {
+	if partial == "" {
+		return "", nil
+	}
+	page, err := svc.List(ctx, healthListFilter(maxHealthLimit))
+	if err != nil {
+		return "", err
+	}
+	matches := make([]string, 0, len(page.Sessions))
+	for _, sess := range page.Sessions {
+		if strings.Contains(sess.ID, partial) {
+			matches = append(matches, sess.ID)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", nil
+	case 1:
+		return matches[0], nil
+	}
+
+	exact := ""
+	for _, m := range matches {
+		if m == partial {
+			exact = m
+			break
+		}
+	}
+	if exact != "" {
+		for _, m := range matches {
+			if m != exact && shortID(m) == partial {
+				return "", ambiguousMatchErr(partial, matches)
+			}
+		}
+		return exact, nil
+	}
+	return "", ambiguousMatchErr(partial, matches)
 }
 
 // resolveLookupLimit caps the partial-match query for

--- a/cmd/agentsview/health_test.go
+++ b/cmd/agentsview/health_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func TestGradeCell(t *testing.T) {
@@ -238,6 +239,35 @@ func TestPrintHealthDetail(t *testing.T) {
 	} {
 		assert.Contains(t, out, want, "output missing %q", want)
 	}
+}
+
+func TestHealthListFilterIncludesAllSessions(t *testing.T) {
+	got := healthListFilter(7)
+
+	assert.Equal(t, 7, got.Limit)
+	assert.True(t, got.IncludeOneShot)
+	assert.True(t, got.IncludeAutomated)
+}
+
+func TestResolveHealthSessionIDMatchesDisplayedShortID(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err, "open db")
+	t.Cleanup(func() { database.Close() })
+
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "abcdef1234567890", Project: "p", Machine: "m",
+		Agent: "claude", MessageCount: 1,
+	}), "upsert one-shot session")
+
+	got, err := resolveHealthSessionID(
+		context.Background(),
+		service.NewDirectBackend(database, nil),
+		"abcdef12",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "abcdef1234567890", got)
 }
 
 func TestResolveSessionID(t *testing.T) {

--- a/cmd/agentsview/health_test.go
+++ b/cmd/agentsview/health_test.go
@@ -270,6 +270,33 @@ func TestResolveHealthSessionIDMatchesDisplayedShortID(t *testing.T) {
 	assert.Equal(t, "abcdef1234567890", got)
 }
 
+func TestResolveHealthSessionIDExactMatchCanBeOutsideHealthList(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err, "open db")
+	t.Cleanup(func() { database.Close() })
+
+	parentID := "parent-session"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: parentID, Project: "p", Machine: "m", Agent: "claude",
+		MessageCount: 2, UserMessageCount: 2,
+	}), "upsert parent session")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "child-session", Project: "p", Machine: "m", Agent: "codex",
+		MessageCount: 2, UserMessageCount: 2,
+		ParentSessionID: &parentID, RelationshipType: "subagent",
+	}), "upsert child session")
+
+	got, err := resolveHealthSessionID(
+		context.Background(),
+		service.NewDirectBackend(database, nil),
+		"child-session",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "child-session", got)
+}
+
 func TestResolveSessionID(t *testing.T) {
 	dir := t.TempDir()
 	database, err := db.Open(filepath.Join(dir, "test.db"))

--- a/cmd/agentsview/health_test.go
+++ b/cmd/agentsview/health_test.go
@@ -332,7 +332,7 @@ func TestResolveHealthSessionIDPartialMatchCanBeOutsideHealthList(t *testing.T) 
 func TestResolveHealthSessionIDUsesDaemonPartialLookup(t *testing.T) {
 	var gotQuery string
 	ts := daemonRouteTestServer(t, map[string]http.HandlerFunc{
-		"/api/v1/sessions/resolve-id": func(w http.ResponseWriter, r *http.Request) {
+		"/api/v1/session-ids/resolve": func(w http.ResponseWriter, r *http.Request) {
 			gotQuery = r.URL.Query().Get("partial")
 			writeJSONResponse(w, `{"ids":["old-partial-target"]}`)
 		},

--- a/cmd/agentsview/health_test.go
+++ b/cmd/agentsview/health_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"net/http"
 	"path/filepath"
 	"testing"
 
@@ -295,6 +297,56 @@ func TestResolveHealthSessionIDExactMatchCanBeOutsideHealthList(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "child-session", got)
+}
+
+func TestResolveHealthSessionIDPartialMatchCanBeOutsideHealthList(t *testing.T) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err, "open db")
+	t.Cleanup(func() { database.Close() })
+
+	for i := range maxHealthLimit {
+		started := fmt.Sprintf("2026-04-15T12:%02d:%02dZ", i/60, i%60)
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID:      fmt.Sprintf("newer-session-%03d", i),
+			Project: "p", Machine: "m", Agent: "claude",
+			MessageCount: 1, StartedAt: &started,
+		}), "upsert newer session")
+	}
+	oldStarted := "2020-01-01T00:00:00Z"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "old-partial-target", Project: "p", Machine: "m",
+		Agent: "codex", MessageCount: 1, StartedAt: &oldStarted,
+	}), "upsert old partial target")
+
+	got, err := resolveHealthSessionID(
+		context.Background(),
+		service.NewDirectBackend(database, nil),
+		"partial-target",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "old-partial-target", got)
+}
+
+func TestResolveHealthSessionIDUsesDaemonPartialLookup(t *testing.T) {
+	var gotQuery string
+	ts := daemonRouteTestServer(t, map[string]http.HandlerFunc{
+		"/api/v1/sessions/resolve-id": func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query().Get("partial")
+			writeJSONResponse(w, `{"ids":["old-partial-target"]}`)
+		},
+	})
+
+	got, err := resolveHealthSessionID(
+		context.Background(),
+		service.NewHTTPBackend(ts.URL, "", false),
+		"partial-target",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "partial-target", gotQuery)
+	assert.Equal(t, "old-partial-target", got)
 }
 
 func TestResolveHealthSessionIDExactMatchStillChecksShortIDAmbiguity(

--- a/cmd/agentsview/health_test.go
+++ b/cmd/agentsview/health_test.go
@@ -297,6 +297,35 @@ func TestResolveHealthSessionIDExactMatchCanBeOutsideHealthList(t *testing.T) {
 	assert.Equal(t, "child-session", got)
 }
 
+func TestResolveHealthSessionIDExactMatchStillChecksShortIDAmbiguity(
+	t *testing.T,
+) {
+	dir := t.TempDir()
+	database, err := db.Open(filepath.Join(dir, "test.db"))
+	require.NoError(t, err, "open db")
+	t.Cleanup(func() { database.Close() })
+
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "abcdef12", Project: "p", Machine: "m",
+		Agent: "claude", MessageCount: 1,
+	}), "upsert exact session")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "abcdef1234567890", Project: "p", Machine: "m",
+		Agent: "codex", MessageCount: 1,
+	}), "upsert short-id collision")
+
+	got, err := resolveHealthSessionID(
+		context.Background(),
+		service.NewDirectBackend(database, nil),
+		"abcdef12",
+	)
+
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "ambiguous")
+	assert.Contains(t, err.Error(), "abcdef1234567890")
+}
+
 func TestResolveSessionID(t *testing.T) {
 	dir := t.TempDir()
 	database, err := db.Open(filepath.Join(dir, "test.db"))

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -464,15 +464,19 @@ func schemaUpgradeHint(err error) error {
 	if !db.IsSchemaUpgradeRequired(err) {
 		return err
 	}
-	return fmt.Errorf(
-		"%w\n\n"+
-			"This database was written by an older agentsview version and "+
-			"must be upgraded before it can be read. The upgrade runs when a "+
-			"writable daemon starts, so restart the daemon to let it run:\n"+
-			"  - desktop app: quit and relaunch it\n"+
-			"  - CLI: run `agentsview serve --replace`",
-		err,
-	)
+	return appendDaemonRestartUpgradeHint(err)
+}
+
+func appendDaemonRestartUpgradeHint(err error) error {
+	return fmt.Errorf("%w\n\n%s", err, daemonRestartUpgradeHint())
+}
+
+func daemonRestartUpgradeHint() string {
+	return "This database was written by an older agentsview version and " +
+		"must be upgraded before it can be read. The upgrade runs when a " +
+		"writable daemon starts, so restart the daemon to let it run:\n" +
+		"  - desktop app: quit and relaunch it\n" +
+		"  - CLI: run `agentsview serve --replace`"
 }
 
 func openWriteDB(

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -443,7 +443,7 @@ func openReadOnlyDB(cfg config.Config) (*db.DB, error) {
 	applyClassifierConfig(cfg)
 	database, err := db.OpenReadOnly(cfg.DBPath)
 	if err != nil {
-		return nil, err
+		return nil, schemaUpgradeHint(err)
 	}
 	applyCustomPricing(database, cfg)
 	if err := applyCursorSecret(database, cfg); err != nil {
@@ -451,6 +451,28 @@ func openReadOnlyDB(cfg config.Config) (*db.DB, error) {
 		return nil, err
 	}
 	return database, nil
+}
+
+// schemaUpgradeHint augments a read-only open failure with actionable guidance
+// when the archive is simply older than this binary. The pending migration only
+// runs on a writable open, which read-only commands never perform, so the user
+// must let the daemon (re)start to upgrade the archive. Without this, the raw
+// "schema missing tool_calls.file_path" error leaves upgraders with no path
+// forward; it is the failure reported in issue #929 after a version bump while
+// an older daemon still owned the archive.
+func schemaUpgradeHint(err error) error {
+	if !db.IsSchemaUpgradeRequired(err) {
+		return err
+	}
+	return fmt.Errorf(
+		"%w\n\n"+
+			"This database was written by an older agentsview version and "+
+			"must be upgraded before it can be read. The upgrade runs when a "+
+			"writable daemon starts, so restart the daemon to let it run:\n"+
+			"  - desktop app: quit and relaunch it\n"+
+			"  - CLI: run `agentsview serve --replace`",
+		err,
+	)
 }
 
 func openWriteDB(

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -946,3 +946,22 @@ func TestPrintSyncSummaryAnomalySection(t *testing.T) {
 		assert.Less(t, idx, anomalyIdx)
 	})
 }
+
+func TestSchemaUpgradeHint(t *testing.T) {
+	t.Run("guides outdated-schema errors to a daemon restart", func(t *testing.T) {
+		base := &db.SchemaUpgradeRequiredError{
+			Table:  "tool_calls",
+			Column: "file_path",
+		}
+		got := schemaUpgradeHint(base)
+		// The original error stays wrappable so logs keep the detail, and the
+		// hint names the command that actually runs the pending migration.
+		assert.ErrorIs(t, got, base)
+		assert.Contains(t, got.Error(), "agentsview serve --replace")
+	})
+
+	t.Run("passes unrelated errors through unchanged", func(t *testing.T) {
+		base := errors.New("disk is on fire")
+		assert.Equal(t, base, schemaUpgradeHint(base))
+	})
+}

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -206,6 +206,16 @@ func (s *mcpDaemonService) Get(
 	return svc.Get(ctx, id)
 }
 
+func (s *mcpDaemonService) FindSessionIDsByPartial(
+	ctx context.Context, partial string, limit int,
+) ([]string, error) {
+	svc, err := s.daemonService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return svc.FindSessionIDsByPartial(ctx, partial, limit)
+}
+
 func (s *mcpDaemonService) List(
 	ctx context.Context, f service.ListFilter,
 ) (*service.SessionList, error) {

--- a/cmd/agentsview/projects.go
+++ b/cmd/agentsview/projects.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
+	"strconv"
+	"strings"
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
@@ -17,18 +22,65 @@ func runProjects(jsonOutput bool) {
 		log.Fatalf("loading config: %v", err)
 	}
 
-	database, err := openReadOnlyDB(appCfg)
-	if err != nil {
-		fatal("opening database: %v", err)
-	}
-	defer database.Close()
-
 	ctx := context.Background()
-	projects, err := database.GetProjects(ctx, false, false)
+	tr, err := ensureTransport(&appCfg, transportIntentRead, 0)
+	if err != nil {
+		fatal("resolving transport: %v", err)
+	}
+	if tr.Mode != transportHTTP {
+		fatal("resolving transport: expected daemon transport")
+	}
+	projects, err := fetchHTTPProjects(
+		ctx, tr, appCfg.AuthToken, false, false,
+	)
 	if err != nil {
 		fatal("listing projects: %v", err)
 	}
 
+	writeProjects(projects, jsonOutput)
+}
+
+func fetchHTTPProjects(
+	ctx context.Context,
+	tr transport,
+	authToken string,
+	excludeOneShot bool,
+	excludeAutomated bool,
+) ([]db.ProjectInfo, error) {
+	q := url.Values{}
+	q.Set("include_one_shot", strconv.FormatBool(!excludeOneShot))
+	q.Set("include_automated", strconv.FormatBool(!excludeAutomated))
+	endpoint := strings.TrimSuffix(tr.URL, "/") +
+		"/api/v1/projects?" + q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf(
+			"projects: HTTP %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(body)),
+		)
+	}
+	var out struct {
+		Projects []db.ProjectInfo `json:"projects"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Projects, nil
+}
+
+func writeProjects(projects []db.ProjectInfo, jsonOutput bool) {
 	if jsonOutput {
 		if projects == nil {
 			projects = []db.ProjectInfo{}

--- a/cmd/agentsview/projects.go
+++ b/cmd/agentsview/projects.go
@@ -11,10 +11,13 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 )
+
+var projectsHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 func runProjects(jsonOutput bool) {
 	appCfg, err := config.LoadMinimal()
@@ -59,7 +62,7 @@ func fetchHTTPProjects(
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := projectsHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/agentsview/projects_test.go
+++ b/cmd/agentsview/projects_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,4 +48,28 @@ func TestFetchHTTPProjects(t *testing.T) {
 		{Name: "alpha", SessionCount: 3},
 		{Name: "beta", SessionCount: 1},
 	}, projects)
+}
+
+func TestFetchHTTPProjectsTimesOutStalledDaemon(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	oldClient := projectsHTTPClient
+	projectsHTTPClient = &http.Client{Timeout: 20 * time.Millisecond}
+	t.Cleanup(func() { projectsHTTPClient = oldClient })
+
+	_, err := fetchHTTPProjects(
+		context.Background(),
+		transport{Mode: transportHTTP, URL: ts.URL},
+		"",
+		false,
+		false,
+	)
+
+	require.Error(t, err)
 }

--- a/cmd/agentsview/projects_test.go
+++ b/cmd/agentsview/projects_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestFetchHTTPProjects(t *testing.T) {
+	var gotAuth string
+	var gotQuery url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		assert.Equal(t, "/api/v1/projects", r.URL.Path)
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.Query()
+		writeJSONResponse(w, `{
+			"projects": [
+				{"name": "alpha", "session_count": 3},
+				{"name": "beta", "session_count": 1}
+			]
+		}`)
+	}))
+	defer ts.Close()
+
+	projects, err := fetchHTTPProjects(
+		context.Background(),
+		transport{Mode: transportHTTP, URL: ts.URL},
+		"secret-token",
+		true,
+		true,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer secret-token", gotAuth)
+	assert.Equal(t, "false", gotQuery.Get("include_one_shot"))
+	assert.Equal(t, "false", gotQuery.Get("include_automated"))
+	assert.Equal(t, []db.ProjectInfo{
+		{Name: "alpha", SessionCount: 3},
+		{Name: "beta", SessionCount: 1},
+	}, projects)
+}

--- a/cmd/agentsview/secrets_test.go
+++ b/cmd/agentsview/secrets_test.go
@@ -60,6 +60,7 @@ func TestSecretsScan_DirectMode_Scans(t *testing.T) {
 		Content: "my key " + secret + " here",
 	}}))
 	require.NoError(t, d.Close())
+	registerSQLiteWritableDaemonRuntime(t, dataDir)
 
 	out, err := executeCommand(newRootCommand(),
 		"secrets", "scan", "--backfill", "--format", "json")
@@ -94,6 +95,7 @@ func TestSecretsScan_DirectMode_DeniesAgentsviewFixtures(t *testing.T) {
 		Content: "fixture token " + secret,
 	}}))
 	require.NoError(t, d.Close())
+	registerSQLiteWritableDaemonRuntime(t, dataDir)
 
 	out, err := executeCommand(newRootCommand(),
 		"secrets", "scan", "--backfill", "--format", "json")
@@ -129,6 +131,7 @@ func TestSecretsScanHint_ShownOnCandidate(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatal(err)
 	}
+	registerSQLiteWritableDaemonRuntime(t, dataDir)
 	out, err := executeCommand(newRootCommand(),
 		"secrets", "scan", "--backfill")
 	if err != nil {
@@ -161,6 +164,7 @@ func TestSecretsScanHint_SuppressedWhenDefiniteOnly(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatal(err)
 	}
+	registerSQLiteWritableDaemonRuntime(t, dataDir)
 	out, err := executeCommand(newRootCommand(),
 		"secrets", "scan", "--backfill")
 	if err != nil {
@@ -189,6 +193,7 @@ func TestSecretsScanHint_SuppressedInJSON(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatal(err)
 	}
+	registerSQLiteWritableDaemonRuntime(t, dataDir)
 	out, err := executeCommand(newRootCommand(),
 		"secrets", "scan", "--backfill", "--format", "json")
 	if err != nil {

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -564,7 +564,12 @@ func refreshServeDaemonReplacementDecision(
 	original serveReplacementDecision,
 ) serveReplacementDecision {
 	if !opts.Replace {
-		return decideServeDaemonReplacement(cfg, opts)
+		decision := decideServeDaemonReplacement(cfg, opts)
+		if decision.Runtime == nil &&
+			replacementTargetStillStopConfirmed(cfg, original.Runtime) {
+			return original
+		}
+		return decision
 	}
 	decision := decideServeDaemonReplacement(
 		cfg, serveReplacementOptions{},
@@ -573,6 +578,10 @@ func refreshServeDaemonReplacementDecision(
 		!sameDaemonReplacementTarget(original.Runtime, decision.Runtime) {
 		return decision
 	}
+	if decision.Runtime == nil &&
+		replacementTargetStillStopConfirmed(cfg, original.Runtime) {
+		return original
+	}
 	return decideServeDaemonReplacement(cfg, opts)
 }
 
@@ -580,7 +589,16 @@ func serveReplacementTargetChanged(
 	cfg config.Config, original *DaemonRuntime,
 ) bool {
 	decision := decideServeDaemonReplacement(cfg, serveReplacementOptions{})
+	if decision.Runtime == nil {
+		return !replacementTargetStillStopConfirmed(cfg, original)
+	}
 	return !sameDaemonReplacementTarget(original, decision.Runtime)
+}
+
+func replacementTargetStillStopConfirmed(
+	cfg config.Config, original *DaemonRuntime,
+) bool {
+	return original != nil && stopTargetConfirmed(original.Record, cfg.AuthToken)
 }
 
 func sameDaemonReplacementTarget(a, b *DaemonRuntime) bool {

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -160,10 +160,8 @@ func runServeBackground(
 				}
 				fatal("serve background: %v", err)
 			}
-			decision = decideServeDaemonReplacementAfterExternalStartup(
-				cfg, opts, decision,
-			)
 		}
+		decision = refreshServeDaemonReplacementDecision(cfg, opts, decision)
 		switch decision.Action {
 		case serveReplacementNone:
 		case serveReplacementUseExisting:
@@ -356,6 +354,9 @@ probeDaemon:
 				}
 				goto probeDaemon
 			}
+			if serveReplacementTargetChanged(*cfg, rt) {
+				goto probeDaemon
+			}
 			adoptDaemonRuntimeLaunchOptions(cfg, rt)
 			if err := stopDaemonRuntimeForUpgrade(*cfg, rt); err != nil {
 				return nil, fmt.Errorf(
@@ -384,6 +385,9 @@ probeDaemon:
 				if err != nil {
 					return nil, err
 				}
+				goto probeDaemon
+			}
+			if serveReplacementTargetChanged(*cfg, rt) {
 				goto probeDaemon
 			}
 			adoptDaemonRuntimeLaunchOptions(cfg, rt)
@@ -426,6 +430,9 @@ probeDaemon:
 					if err != nil {
 						return nil, err
 					}
+					goto probeDaemon
+				}
+				if serveReplacementTargetChanged(*cfg, rt) {
 					goto probeDaemon
 				}
 				adoptDaemonRuntimeLaunchOptions(cfg, rt)
@@ -551,7 +558,7 @@ func waitForExternalServeStartupBeforeReplacement(
 	return true, nil
 }
 
-func decideServeDaemonReplacementAfterExternalStartup(
+func refreshServeDaemonReplacementDecision(
 	cfg config.Config,
 	opts serveReplacementOptions,
 	original serveReplacementDecision,
@@ -567,6 +574,13 @@ func decideServeDaemonReplacementAfterExternalStartup(
 		return decision
 	}
 	return decideServeDaemonReplacement(cfg, opts)
+}
+
+func serveReplacementTargetChanged(
+	cfg config.Config, original *DaemonRuntime,
+) bool {
+	decision := decideServeDaemonReplacement(cfg, serveReplacementOptions{})
+	return !sameDaemonReplacementTarget(original, decision.Runtime)
 }
 
 func sameDaemonReplacementTarget(a, b *DaemonRuntime) bool {

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"testing"
 	"time"
@@ -1399,6 +1400,43 @@ func TestRunServeBackgroundKeepsInvocationNoSyncWhenReplacingSyncingDaemon(
 	)
 
 	assert.Equal(t, []string{"serve", "--no-sync"}, gotArgs)
+}
+
+func TestRefreshServeDaemonReplacementDecisionKeepsStopConfirmedOriginal(
+	t *testing.T,
+) {
+	dir := runtimeTestDir(t)
+	ln, oldPort := freeTCPListener(t)
+	require.NoError(t, ln.Close())
+	liveCreateTime, ok := processCreateTimeMillis(os.Getpid())
+	if !ok {
+		t.Skip("process create time is unavailable on this platform")
+	}
+	rec := daemonRuntimeRecord(
+		"127.0.0.1", oldPort,
+		withRuntimeVersion("1.0.0"),
+		withRuntimeMetadata(
+			runtimeCreateTime, strconv.FormatInt(liveCreateTime, 10),
+		),
+	)
+	writeRuntimeRecordFixture(t, dir, rec)
+	require.Nil(t, FindDaemonRuntime(dir),
+		"precondition: runtime record must be live but unprobeable")
+	original := daemonRuntimeFromRecord(rec)
+	require.True(t, stopTargetConfirmed(original.Record, ""))
+
+	got := refreshServeDaemonReplacementDecision(
+		config.Config{DataDir: dir},
+		serveReplacementOptions{},
+		serveReplacementDecision{
+			Action:  serveReplacementAuto,
+			Runtime: original,
+		},
+	)
+
+	assert.Equal(t, serveReplacementAuto, got.Action)
+	require.NotNil(t, got.Runtime)
+	assert.Equal(t, oldPort, got.Runtime.Port)
 }
 
 func TestEnsureBackgroundServeConcurrentLaunchConvergesOnDaemon(t *testing.T) {

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -23,6 +23,8 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/server"
+	agentsync "go.kenn.io/agentsview/internal/sync"
 	"go.kenn.io/kit/daemon"
 )
 
@@ -263,6 +265,7 @@ func seedEmptyArchive(t *testing.T, dataDir string) {
 	d, err := db.Open(filepath.Join(dataDir, "sessions.db"))
 	require.NoError(t, err)
 	require.NoError(t, d.Close())
+	registerSQLiteDaemonRuntime(t, dataDir)
 }
 
 // seedSessionWithOpts is like seedSession but allows mutation of
@@ -294,6 +297,53 @@ func seedSessionWithOpts(
 	}
 	require.NoError(t, d.UpsertSession(s))
 	require.NoError(t, d.Close())
+	registerSQLiteDaemonRuntime(t, dataDir)
+}
+
+func registerSQLiteDaemonRuntime(t *testing.T, dataDir string) {
+	t.Helper()
+	registerSQLiteDaemonRuntimeWithEngine(t, dataDir, false)
+}
+
+func registerSQLiteWritableDaemonRuntime(t *testing.T, dataDir string) {
+	t.Helper()
+	registerSQLiteDaemonRuntimeWithEngine(t, dataDir, true)
+}
+
+func registerSQLiteDaemonRuntimeWithEngine(
+	t *testing.T, dataDir string, writable bool,
+) {
+	t.Helper()
+	cfg, err := config.LoadMinimal()
+	require.NoError(t, err)
+	if cfg.DataDir != dataDir {
+		cfg.DataDir = dataDir
+		cfg.DBPath = sessionsDBPath(dataDir)
+	}
+	database, err := openDB(cfg)
+	require.NoError(t, err)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	cfg.Host = "127.0.0.1"
+	cfg.Port = port
+	cfg.WriteTimeout = 30 * time.Second
+	var engine *agentsync.Engine
+	if writable {
+		engine = agentsync.NewEngine(database, agentsync.EngineConfig{
+			Ephemeral: true,
+		})
+	}
+	srv := server.New(cfg, database, engine)
+	ts := httptest.NewUnstartedServer(srv.Handler())
+	ts.Listener = ln
+	ts.Start()
+	t.Cleanup(func() {
+		ts.Close()
+		database.Close()
+		RemoveDaemonRuntime(dataDir)
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
 }
 
 func TestSessionGet_JSON(t *testing.T) {

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/service"
 )
@@ -138,25 +137,10 @@ func registerStatsFlags(
 		"Include GitHub PR outcome stats via gh (implies --include-git-outcomes)")
 }
 
-// openStatsService opens a read-only SessionService scoped to the local SQLite
-// archive. The stats command deliberately bypasses resolveService
-// (and the HTTP daemon transport) because the daemon does not yet
-// expose a /stats endpoint.
 func openStatsService(
 	cmd *cobra.Command,
 ) (service.SessionService, func(), error) {
-	cfg, err := config.LoadPFlags(cmd.Flags())
-	if err != nil {
-		return nil, nil, fmt.Errorf("loading config: %w", err)
-	}
-	d, err := openReadOnlyDB(cfg)
-	if err != nil {
-		return nil, nil, fmt.Errorf("opening db: %w", err)
-	}
-	cleanup := func() { d.Close() }
-	// Pass a typed *db.DB so directBackend.Stats has the local handle
-	// it needs; engine is nil because the CLI never syncs.
-	return service.NewDirectBackend(d, nil), cleanup, nil
+	return resolveService(cmd)
 }
 
 // printStatsHuman renders a human-readable summary of a SessionStats

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/service"
 )
@@ -140,7 +141,22 @@ func registerStatsFlags(
 func openStatsService(
 	cmd *cobra.Command,
 ) (service.SessionService, func(), error) {
-	return resolveService(cmd)
+	cfg, err := config.LoadPFlags(cmd.Flags())
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading config: %w", err)
+	}
+	tr, err := ensureTransport(&cfg, transportIntentRead, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	if tr.Mode == transportHTTP && tr.ReadOnly {
+		d, err := openReadOnlyDB(cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("opening db: %w", err)
+		}
+		return service.NewDirectBackend(d, nil), func() { d.Close() }, nil
+	}
+	return newService(cfg, tr)
 }
 
 // printStatsHuman renders a human-readable summary of a SessionStats

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -349,6 +349,33 @@ func TestStatsCommandUsesDiscoveredDaemon(t *testing.T) {
 	assert.Equal(t, 5, got.Totals.SessionsAll)
 }
 
+func TestStatsCommandSkipsReadOnlyDaemon(t *testing.T) {
+	dataDir := setupGoldenStatsDataDir(t)
+
+	var called bool
+	ts := daemonRouteTestServer(t, map[string]http.HandlerFunc{
+		"/api/v1/session-stats": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			http.Error(w, "pg session stats unavailable", http.StatusNotImplemented)
+		},
+	})
+	registerTestRuntime(t, dataDir, ts.URL, true)
+
+	out, err := executeCommand(newRootCommand(),
+		"stats",
+		"--format", "json",
+		"--since", "2026-04-01",
+		"--until", "2026-04-15",
+		"--timezone", "UTC",
+	)
+
+	require.NoError(t, err, "stats output:\n%s", out)
+	assert.False(t, called, "read-only daemon stats endpoint should be skipped")
+	var got db.SessionStats
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, len(goldenFixtureSessions), got.Totals.SessionsAll)
+}
+
 // updateGolden toggles regeneration of stats_golden.json.
 // Pass `go test ./cmd/agentsview -run TestStatsGolden -update`
 // after intentionally changing the fixture or the stats pipeline.

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -349,6 +349,31 @@ func TestStatsCommandUsesDiscoveredDaemon(t *testing.T) {
 	assert.Equal(t, 5, got.Totals.SessionsAll)
 }
 
+func TestStatsCommandReportsDaemonValidationError(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+
+	var called bool
+	ts := daemonRouteTestServer(t, map[string]http.HandlerFunc{
+		"/api/v1/session-stats": func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusBadRequest)
+			writeJSONResponse(w, `{"error":"invalid timezone: Fake/Zone"}`)
+		},
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	out, err := executeCommand(newRootCommand(),
+		"stats",
+		"--format", "json",
+		"--timezone", "Fake/Zone",
+	)
+
+	require.Error(t, err, "stats output:\n%s", out)
+	assert.True(t, called, "stats should use the discovered daemon")
+	assert.Contains(t, err.Error(), "HTTP 400")
+	assert.Contains(t, err.Error(), "invalid timezone: Fake/Zone")
+}
+
 func TestStatsCommandSkipsReadOnlyDaemon(t *testing.T) {
 	dataDir := setupGoldenStatsDataDir(t)
 

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,6 +62,7 @@ func setupGoldenStatsDataDir(t *testing.T) string {
 // unmarshal into whichever shape they need.
 func runDefaultStatsJSON(t *testing.T) string {
 	t.Helper()
+	registerSQLiteDaemonRuntime(t, os.Getenv("AGENTSVIEW_DATA_DIR"))
 	out, err := executeCommand(newRootCommand(),
 		"stats",
 		"--format", "json",
@@ -299,6 +302,51 @@ func TestStatsCommand_OutcomeFlagsRegistered(t *testing.T) {
 		assert.NotNil(t, cmd.Flags().Lookup(name),
 			"missing --%s flag", name)
 	}
+}
+
+func TestStatsCommandUsesDiscoveredDaemon(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+
+	var gotQuery url.Values
+	ts := daemonRouteTestServer(t, map[string]http.HandlerFunc{
+		"/api/v1/session-stats": func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query()
+			writeJSONResponse(w, `{
+				"schema_version": 1,
+				"window": {
+					"since": "2026-04-01T00:00:00Z",
+					"until": "2026-04-15T00:00:00Z",
+					"days": 14
+				},
+				"filters": {
+					"agent": "codex",
+					"projects_excluded": [],
+					"timezone": "UTC"
+				},
+				"totals": {"sessions_all": 5}
+			}`)
+		},
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	out, err := executeCommand(newRootCommand(),
+		"stats",
+		"--format", "json",
+		"--since", "2026-04-01",
+		"--until", "2026-04-15",
+		"--agent", "codex",
+		"--timezone", "UTC",
+	)
+
+	require.NoError(t, err, "stats output:\n%s", out)
+	assert.Equal(t, "2026-04-01", gotQuery.Get("since"))
+	assert.Equal(t, "2026-04-15", gotQuery.Get("until"))
+	assert.Equal(t, "codex", gotQuery.Get("agent"))
+	assert.Equal(t, "UTC", gotQuery.Get("timezone"))
+
+	var got db.SessionStats
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, 5, got.Totals.SessionsAll)
 }
 
 // updateGolden toggles regeneration of stats_golden.json.

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -44,12 +44,13 @@ var waitForDaemonStartupForTransport = WaitForDaemonStartupContext
 // transport captures how to reach the session-data layer from a
 // CLI subcommand. Either the HTTP daemon (URL set) or the local DB.
 type transport struct {
-	Mode           transportMode
-	URL            string
-	ReadOnly       bool // daemon runtime ReadOnly flag (true for mirror serve)
-	DirectReadOnly bool // writable daemon owns DB but is not reachable
-	DirectReason   string
-	Runtime        *DaemonRuntime
+	Mode               transportMode
+	URL                string
+	ReadOnly           bool // daemon runtime ReadOnly flag (true for pg serve)
+	DirectReadOnly     bool // writable daemon owns DB but is not reachable
+	DirectIncompatible bool // live daemon owns DB but cannot serve this client
+	DirectReason       string
+	Runtime            *DaemonRuntime
 }
 
 type customPricingStore interface {
@@ -131,13 +132,16 @@ func detectTransportContext(
 	}
 	if IsLocalDaemonActive(dataDir, authToken) {
 		reason := errLocalDaemonUnreachable.Error()
+		incompatible := false
 		if _, err := FindIncompatibleDaemonRuntime(dataDir, authToken); err != nil {
 			reason = err.Error()
+			incompatible = true
 		}
 		return transport{
-			Mode:           transportDirect,
-			DirectReadOnly: true,
-			DirectReason:   reason,
+			Mode:               transportDirect,
+			DirectReadOnly:     true,
+			DirectIncompatible: incompatible,
+			DirectReason:       reason,
 		}, nil
 	}
 	return transport{Mode: transportDirect}, nil
@@ -165,7 +169,8 @@ func ensureTransportContext(
 	if err := ctx.Err(); err != nil {
 		return transport{}, err
 	}
-	if intent == transportIntentArchiveWrite && waitTimeout <= 0 {
+	if (intent == transportIntentRead || intent == transportIntentArchiveWrite) &&
+		waitTimeout <= 0 {
 		waitTimeout = backgroundAutoStartReadyTimeout
 	}
 	if intent == transportIntentArchiveWrite {
@@ -205,7 +210,8 @@ func ensureTransportContext(
 		}
 		return tr, nil
 	}
-	if intent == transportIntentArchiveWrite && !daemonAutostartDisabled() {
+	if (intent == transportIntentRead || intent == transportIntentArchiveWrite) &&
+		!daemonAutostartDisabled() {
 		if rt, err := FindIncompatibleDaemonRuntime(
 			cfg.DataDir, cfg.AuthToken,
 		); err != nil && rt != nil &&
@@ -223,7 +229,36 @@ func ensureTransportContext(
 			return transportFromRuntime(rt), nil
 		}
 	}
-	if intent == transportIntentRead || daemonAutostartDisabled() {
+	if intent == transportIntentRead {
+		if daemonAutostartDisabled() {
+			return transport{}, errors.New(
+				"daemon autostart is disabled; direct SQLite reads are " +
+					"not supported for this command. Start a daemon with " +
+					"`agentsview serve --background` or unset " +
+					"AGENTSVIEW_NO_DAEMON",
+			)
+		}
+		if tr.DirectReadOnly {
+			if tr.DirectReason != "" {
+				if tr.DirectReason == errLocalDaemonUnreachable.Error() {
+					return transport{}, errLocalDaemonUnreachable
+				}
+				return transport{}, appendDaemonRestartUpgradeHint(
+					errors.New(tr.DirectReason),
+				)
+			}
+			return transport{}, errLocalDaemonUnreachable
+		}
+		if err := guardDaemonAutoStartConfig(*cfg); err != nil {
+			return transport{}, err
+		}
+		rt, err := startBackgroundServeForTransport(ctx, cfg, waitTimeout)
+		if err != nil {
+			return transport{}, err
+		}
+		return transportFromRuntime(rt), nil
+	}
+	if daemonAutostartDisabled() {
 		return tr, nil
 	}
 	if tr.DirectReadOnly {
@@ -378,6 +413,9 @@ func newService(
 		return service.NewHTTPBackend(tr.URL, cfg.AuthToken, tr.ReadOnly),
 			func() {}, nil
 	default:
+		if err := directIncompatibleDaemonError(tr); err != nil {
+			return nil, nil, err
+		}
 		d, err := openReadOnlyDB(cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf(
@@ -389,6 +427,17 @@ func newService(
 		// is handled via the HTTP daemon when one is running.
 		return service.NewDirectBackend(d, nil), cleanup, nil
 	}
+}
+
+func directIncompatibleDaemonError(tr transport) error {
+	if !tr.DirectIncompatible {
+		return nil
+	}
+	reason := strings.TrimSpace(tr.DirectReason)
+	if reason == "" {
+		reason = "local daemon is incompatible with this agentsview client"
+	}
+	return appendDaemonRestartUpgradeHint(errors.New(reason))
 }
 
 // newPGReadService builds a read-only SessionService over the

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -190,6 +190,18 @@ func ensureTransportContext(
 	if err != nil {
 		return transport{}, err
 	}
+	if intent == transportIntentRead && cfg.AuthToken == "" &&
+		tr.Mode == transportDirect && tr.DirectReadOnly {
+		adoptBackgroundLaunchConfig(cfg)
+		if cfg.AuthToken != "" {
+			tr, err = detectTransportContext(
+				ctx, cfg.DataDir, cfg.AuthToken, waitTimeout,
+			)
+			if err != nil {
+				return transport{}, err
+			}
+		}
+	}
 	if tr.Mode == transportHTTP {
 		if (intent == transportIntentRead ||
 			intent == transportIntentArchiveWrite) &&

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -191,7 +191,8 @@ func ensureTransportContext(
 		return transport{}, err
 	}
 	if tr.Mode == transportHTTP {
-		if intent == transportIntentArchiveWrite &&
+		if (intent == transportIntentRead ||
+			intent == transportIntentArchiveWrite) &&
 			shouldUpgradeDaemonRuntime(tr.Runtime, version) {
 			if daemonAutostartDisabled() {
 				return tr, nil

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -200,7 +200,7 @@ func ensureTransportContext(
 			if err := guardDaemonAutoStartConfig(*cfg); err != nil {
 				return transport{}, err
 			}
-			cfg.NoSync = tr.Runtime.NoSync
+			cfg.NoSync = cfg.NoSync || tr.Runtime.NoSync
 			rt, err := startBackgroundServeForTransport(
 				ctx, cfg, waitTimeout,
 			)
@@ -220,7 +220,7 @@ func ensureTransportContext(
 			if err := guardDaemonAutoStartConfig(*cfg); err != nil {
 				return transport{}, err
 			}
-			cfg.NoSync = rt.NoSync
+			cfg.NoSync = cfg.NoSync || rt.NoSync
 			rt, err := startBackgroundServeForTransport(
 				ctx, cfg, waitTimeout,
 			)

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -195,6 +195,11 @@ func ensureTransportContext(
 			intent == transportIntentArchiveWrite) &&
 			shouldUpgradeDaemonRuntime(tr.Runtime, version) {
 			if daemonAutostartDisabled() {
+				if intent == transportIntentRead {
+					return transport{}, appendDaemonRestartUpgradeHint(
+						errors.New("daemon restart required: running daemon is older than this client"),
+					)
+				}
 				return tr, nil
 			}
 			if err := guardDaemonAutoStartConfig(*cfg); err != nil {

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -443,6 +443,28 @@ func TestEnsureTransport_ReadIntentRestartsOlderDaemon(t *testing.T) {
 	assert.Equal(t, "http://127.0.0.1:23456", tr.URL)
 }
 
+func TestEnsureTransport_ReadIntentNoDaemonEnvRefusesOlderDaemon(
+	t *testing.T,
+) {
+	dir := daemonRuntimeDir(t)
+	host, port := testPingServer(t)
+	writeDaemonRuntimeForTest(t, dir, host, port, "1.0.0", false)
+
+	t.Setenv("AGENTSVIEW_NO_DAEMON", "1")
+	setTestVersion(t, "1.1.0")
+	forbidStartBackgroundServeForTransport(t,
+		"AGENTSVIEW_NO_DAEMON must suppress daemon replacement")
+
+	cfg := config.Config{DataDir: dir}
+	tr, err := ensureTransport(
+		&cfg, transportIntentRead, 100*time.Millisecond,
+	)
+
+	require.Error(t, err)
+	assert.Equal(t, transport{}, tr)
+	assert.Contains(t, err.Error(), "daemon restart required")
+}
+
 func TestEnsureTransport_ReadIntentPreservesExplicitNoSyncWhenRestartingOlderDaemon(
 	t *testing.T,
 ) {

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -271,7 +271,21 @@ func TestDetectTransport_IncompatibleDaemonSetsDirectReason(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, transportDirect, tr.Mode)
 	assert.True(t, tr.DirectReadOnly)
+	assert.True(t, tr.DirectIncompatible)
 	assert.Contains(t, tr.DirectReason, "API version")
+}
+
+func TestDetectTransport_LocalDaemonUnreachableDoesNotSetDirectIncompatible(t *testing.T) {
+	t.Parallel()
+	dir := daemonRuntimeDir(t)
+	writeUnreachableDaemonRuntime(t, dir, false)
+
+	tr, err := detectTransport(dir, "", 100*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, transportDirect, tr.Mode)
+	assert.True(t, tr.DirectReadOnly)
+	assert.False(t, tr.DirectIncompatible)
+	assert.Equal(t, errLocalDaemonUnreachable.Error(), tr.DirectReason)
 }
 
 // TestDetectTransport_DaemonStarting simulates a server that's
@@ -292,14 +306,50 @@ func TestDetectTransport_DaemonStarting_FallsBackToDirect(t *testing.T) {
 	assert.Equal(t, transportDirect, tr.Mode)
 }
 
-func TestEnsureTransport_ReadIntentDoesNotStartDaemon(t *testing.T) {
+func TestEnsureTransport_ReadIntentStartsDaemon(t *testing.T) {
 	dir := daemonRuntimeDir(t)
 	cfg := config.Config{DataDir: dir}
-	forbidStartBackgroundServeForTransport(t, "read intent must not start a daemon")
+	var started bool
+	stubStartBackgroundServeForTransport(t, func(
+		_ context.Context, gotCfg *config.Config, wait time.Duration,
+	) (*DaemonRuntime, error) {
+		started = true
+		assert.Equal(t, dir, gotCfg.DataDir)
+		assert.Equal(t, backgroundAutoStartReadyTimeout, wait)
+		return &DaemonRuntime{
+			Host: "127.0.0.1",
+			Port: 12345,
+		}, nil
+	})
 
-	tr, err := ensureTransport(&cfg, transportIntentRead, 100*time.Millisecond)
+	tr, err := ensureTransport(&cfg, transportIntentRead, 0)
 	require.NoError(t, err)
-	assert.Equal(t, transportDirect, tr.Mode)
+	assert.True(t, started)
+	assert.Equal(t, transportHTTP, tr.Mode)
+	assert.Equal(t, "http://127.0.0.1:12345", tr.URL)
+}
+
+func TestEnsureTransport_ReadIntentNoDaemonEnvRefusesDirectRead(t *testing.T) {
+	dir := daemonRuntimeDir(t)
+	t.Setenv("AGENTSVIEW_NO_DAEMON", "1")
+	cfg := config.Config{DataDir: dir}
+	forbidStartBackgroundServeForTransport(t,
+		"AGENTSVIEW_NO_DAEMON must suppress daemon start")
+
+	_, err := ensureTransport(&cfg, transportIntentRead, 100*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "direct SQLite reads are not supported")
+}
+
+func TestEnsureTransport_ReadIntentUnreachableDaemonRefusesDirectRead(t *testing.T) {
+	dir := daemonRuntimeDir(t)
+	writeUnreachableDaemonRuntime(t, dir, false)
+	cfg := config.Config{DataDir: dir}
+	forbidStartBackgroundServeForTransport(t,
+		"unreachable live daemon must not trigger a second start")
+
+	_, err := ensureTransport(&cfg, transportIntentRead, 100*time.Millisecond)
+	require.ErrorIs(t, err, errLocalDaemonUnreachable)
 }
 
 func TestEnsureTransport_ArchiveWriteStartsDaemon(t *testing.T) {
@@ -430,6 +480,35 @@ func TestEnsureTransport_ArchiveWriteRestartsIncompatibleOlderDaemon(t *testing.
 	cfg := config.Config{DataDir: dir}
 	tr, err := ensureTransport(
 		&cfg, transportIntentArchiveWrite, 100*time.Millisecond,
+	)
+	require.NoError(t, err)
+	assert.True(t, started)
+	assert.Equal(t, transportHTTP, tr.Mode)
+	assert.Equal(t, "http://127.0.0.1:23456", tr.URL)
+}
+
+func TestEnsureTransport_ReadIntentRestartsIncompatibleOlderDaemon(t *testing.T) {
+	dir := daemonRuntimeDir(t)
+	host, port := testPingServer(t)
+	writeIncompatibleDaemonRuntime(t, dir, host, port, "1.0.0", true)
+
+	setTestVersion(t, "1.1.0")
+
+	var started bool
+	stubStartBackgroundServeForTransport(t, func(
+		_ context.Context, gotCfg *config.Config, _ time.Duration,
+	) (*DaemonRuntime, error) {
+		started = true
+		assert.True(t, gotCfg.NoSync)
+		return &DaemonRuntime{
+			Host: "127.0.0.1",
+			Port: 23456,
+		}, nil
+	})
+
+	cfg := config.Config{DataDir: dir}
+	tr, err := ensureTransport(
+		&cfg, transportIntentRead, 100*time.Millisecond,
 	)
 	require.NoError(t, err)
 	assert.True(t, started)
@@ -845,6 +924,26 @@ func TestNewService_DirectReadOnly(t *testing.T) {
 	require.NotNil(t, svc)
 	require.NotNil(t, cleanup)
 	cleanup()
+}
+
+func TestNewService_DirectIncompatibleRefusesWithoutOpeningDB(t *testing.T) {
+	t.Parallel()
+	dbPath := filepath.Join(t.TempDir(), "missing.db")
+	cfg := config.Config{DBPath: dbPath}
+
+	svc, cleanup, err := newService(cfg, transport{
+		Mode:               transportDirect,
+		DirectReadOnly:     true,
+		DirectIncompatible: true,
+		DirectReason:       "daemon data version 52 is incompatible with client data version 57",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, svc)
+	assert.Nil(t, cleanup)
+	assert.Contains(t, err.Error(), "daemon data version 52 is incompatible")
+	assert.Contains(t, err.Error(), "agentsview serve --replace")
+	assert.NoFileExists(t, dbPath)
 }
 
 func TestNewService_DirectModeMissingDBDoesNotCreate(t *testing.T) {

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -443,6 +443,40 @@ func TestEnsureTransport_ReadIntentRestartsOlderDaemon(t *testing.T) {
 	assert.Equal(t, "http://127.0.0.1:23456", tr.URL)
 }
 
+func TestEnsureTransport_ReadIntentPreservesExplicitNoSyncWhenRestartingOlderDaemon(
+	t *testing.T,
+) {
+	dir := daemonRuntimeDir(t)
+	host, port := testPingServer(t)
+	_, err := WriteDaemonRuntimeWithAuthAndNoSync(
+		dir, host, port, "1.0.0", false, false, false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { RemoveDaemonRuntime(dir) })
+
+	setTestVersion(t, "1.1.0")
+
+	var started bool
+	stubStartBackgroundServeForTransport(t, func(
+		_ context.Context, gotCfg *config.Config, _ time.Duration,
+	) (*DaemonRuntime, error) {
+		started = true
+		assert.True(t, gotCfg.NoSync)
+		return &DaemonRuntime{
+			Host: "127.0.0.1",
+			Port: 23456,
+		}, nil
+	})
+
+	cfg := config.Config{DataDir: dir, NoSync: true}
+	tr, err := ensureTransport(
+		&cfg, transportIntentRead, 100*time.Millisecond,
+	)
+	require.NoError(t, err)
+	assert.True(t, started)
+	assert.Equal(t, transportHTTP, tr.Mode)
+}
+
 func TestEnsureTransport_ArchiveWriteNoDaemonEnvKeepsOlderDaemon(t *testing.T) {
 	dir := daemonRuntimeDir(t)
 	host, port := testPingServer(t)
@@ -518,6 +552,36 @@ func TestEnsureTransport_ArchiveWriteRestartsIncompatibleOlderDaemon(t *testing.
 	assert.True(t, started)
 	assert.Equal(t, transportHTTP, tr.Mode)
 	assert.Equal(t, "http://127.0.0.1:23456", tr.URL)
+}
+
+func TestEnsureTransport_ReadIntentPreservesExplicitNoSyncWhenRestartingIncompatibleDaemon(
+	t *testing.T,
+) {
+	dir := daemonRuntimeDir(t)
+	host, port := testPingServer(t)
+	writeIncompatibleDaemonRuntime(t, dir, host, port, "1.0.0", false)
+
+	setTestVersion(t, "1.1.0")
+
+	var started bool
+	stubStartBackgroundServeForTransport(t, func(
+		_ context.Context, gotCfg *config.Config, _ time.Duration,
+	) (*DaemonRuntime, error) {
+		started = true
+		assert.True(t, gotCfg.NoSync)
+		return &DaemonRuntime{
+			Host: "127.0.0.1",
+			Port: 23456,
+		}, nil
+	})
+
+	cfg := config.Config{DataDir: dir, NoSync: true}
+	tr, err := ensureTransport(
+		&cfg, transportIntentRead, 100*time.Millisecond,
+	)
+	require.NoError(t, err)
+	assert.True(t, started)
+	assert.Equal(t, transportHTTP, tr.Mode)
 }
 
 func TestEnsureTransport_ReadIntentRestartsIncompatibleOlderDaemon(t *testing.T) {

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -410,6 +410,39 @@ func TestEnsureTransport_ArchiveWriteRestartsOlderDaemon(t *testing.T) {
 	assert.Equal(t, "http://127.0.0.1:23456", tr.URL)
 }
 
+func TestEnsureTransport_ReadIntentRestartsOlderDaemon(t *testing.T) {
+	dir := daemonRuntimeDir(t)
+	host, port := testPingServer(t)
+	_, err := WriteDaemonRuntimeWithAuthAndNoSync(
+		dir, host, port, "1.0.0", false, false, true,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { RemoveDaemonRuntime(dir) })
+
+	setTestVersion(t, "1.1.0")
+
+	var started bool
+	stubStartBackgroundServeForTransport(t, func(
+		_ context.Context, gotCfg *config.Config, _ time.Duration,
+	) (*DaemonRuntime, error) {
+		started = true
+		assert.True(t, gotCfg.NoSync)
+		return &DaemonRuntime{
+			Host: "127.0.0.1",
+			Port: 23456,
+		}, nil
+	})
+
+	cfg := config.Config{DataDir: dir}
+	tr, err := ensureTransport(
+		&cfg, transportIntentRead, 100*time.Millisecond,
+	)
+	require.NoError(t, err)
+	assert.True(t, started)
+	assert.Equal(t, transportHTTP, tr.Mode)
+	assert.Equal(t, "http://127.0.0.1:23456", tr.URL)
+}
+
 func TestEnsureTransport_ArchiveWriteNoDaemonEnvKeepsOlderDaemon(t *testing.T) {
 	dir := daemonRuntimeDir(t)
 	host, port := testPingServer(t)

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -901,6 +901,41 @@ auth_token = "generated-token"
 	), tr.URL)
 }
 
+func TestEnsureTransportReadAdoptsAuthAfterDaemonStartupWait(t *testing.T) {
+	dir := daemonRuntimeDir(t)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dir)
+	unlockStart := holdExternalDaemonStartLock(t, dir)
+
+	const token = "generated-token"
+	newHost, newPort := testAuthenticatedPingServer(t, token)
+	published := make(chan error, 1)
+	go func() {
+		time.Sleep(2 * startProbeTick)
+		writeTestConfig(t, dir, `require_auth = true
+auth_token = "generated-token"
+`)
+		_, err := WriteDaemonRuntimeWithAuth(
+			dir, newHost, newPort, version, false, true,
+		)
+		unlockStart()
+		published <- err
+	}()
+
+	cfg := config.Config{DataDir: dir}
+	tr, err := ensureTransport(
+		&cfg, transportIntentRead, time.Second,
+	)
+
+	require.NoError(t, <-published)
+	require.NoError(t, err)
+	assert.Equal(t, token, cfg.AuthToken)
+	assert.True(t, cfg.RequireAuth)
+	assert.Equal(t, transportHTTP, tr.Mode)
+	assert.Equal(t, "http://"+net.JoinHostPort(
+		newHost, strconv.Itoa(newPort),
+	), tr.URL)
+}
+
 func TestWaitForBackgroundLaunchBeforeArchiveWriteRejectsFileDataDir(
 	t *testing.T,
 ) {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -494,10 +494,16 @@ func TestRunUsageDailyOfflineUsesReadOnlyDBWhenWriteLockHeld(t *testing.T) {
 		"offline read-only usage must preserve custom pricing")
 }
 
-func TestArchiveQueryBackendNoSyncDoesNotAutostartDaemonForDailyUsage(t *testing.T) {
+func TestArchiveQueryBackendNoSyncStartsNoSyncDaemonForDailyUsage(t *testing.T) {
 	newAgentDataDir(t)
-	forbidStartBackgroundServeForTransport(t,
-		"--no-sync usage must not auto-start a daemon")
+	var started bool
+	stubStartBackgroundServeForTransport(t, func(
+		_ context.Context, cfg *config.Config, _ time.Duration,
+	) (*DaemonRuntime, error) {
+		started = true
+		assert.True(t, cfg.NoSync)
+		return &DaemonRuntime{Host: "127.0.0.1", Port: 12345}, nil
+	})
 
 	backend := resolveTestArchiveQueryBackend(t, defaultArchiveQueryPolicy(
 		func(p *archiveQueryPolicy) {
@@ -505,10 +511,11 @@ func TestArchiveQueryBackendNoSyncDoesNotAutostartDaemonForDailyUsage(t *testing
 			p.AutoStart = true
 		},
 	))
-	assert.IsType(t, localArchiveQueryBackend{}, backend)
+	assert.True(t, started)
+	assert.IsType(t, daemonArchiveQueryBackend{}, backend)
 }
 
-func TestArchiveQueryBackendIgnoresReadOnlyDaemonForDailyUsage(t *testing.T) {
+func TestArchiveQueryBackendRefusesReadOnlyDaemonForDailyUsage(t *testing.T) {
 	dataDir := newAgentDataDir(t)
 
 	var called bool
@@ -518,10 +525,16 @@ func TestArchiveQueryBackendIgnoresReadOnlyDaemonForDailyUsage(t *testing.T) {
 	})
 	registerTestRuntime(t, dataDir, ts.URL, true)
 
-	backend := resolveTestArchiveQueryBackend(t, defaultArchiveQueryPolicy(
-		func(p *archiveQueryPolicy) { p.AutoStart = true },
-	))
-	assert.IsType(t, localArchiveQueryBackend{}, backend)
+	_, cleanup, err := resolveArchiveQueryBackend(
+		context.Background(), defaultArchiveQueryPolicy(
+			func(p *archiveQueryPolicy) { p.AutoStart = true },
+		),
+	)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read-only")
 	assert.False(t, called)
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -834,6 +834,34 @@ func tableColumns(
 	return out, nil
 }
 
+// SchemaUpgradeRequiredError reports that a read-only open failed because the
+// on-disk archive is missing a column the current binary's schema defines. The
+// file is not corrupt: it was written by an older agentsview version and has
+// not been migrated yet. Read-only opens never run migrations, so the archive
+// can only be upgraded by a writable process (the daemon). Callers can detect
+// this with IsSchemaUpgradeRequired and point the user at restarting the daemon
+// so the migration runs. The Error text preserves the historical
+// "schema missing <table>.<column>" wording so existing diagnostics still match.
+type SchemaUpgradeRequiredError struct {
+	Table  string
+	Column string
+}
+
+func (e *SchemaUpgradeRequiredError) Error() string {
+	return fmt.Sprintf(
+		"opening read-only database: schema missing %s.%s",
+		e.Table, e.Column,
+	)
+}
+
+// IsSchemaUpgradeRequired reports whether err indicates a read-only open failed
+// because the archive predates this binary's schema and needs a writable
+// migration to run.
+func IsSchemaUpgradeRequired(err error) bool {
+	var target *SchemaUpgradeRequiredError
+	return errors.As(err, &target)
+}
+
 func checkReadOnlySchemaCompatibility(conn *sql.DB) error {
 	required, err := readOnlyRequiredSchema()
 	if err != nil {
@@ -850,10 +878,10 @@ func checkReadOnlySchemaCompatibility(conn *sql.DB) error {
 		}
 		for _, column := range columns {
 			if !have[column] {
-				return fmt.Errorf(
-					"opening read-only database: schema missing %s.%s",
-					table, column,
-				)
+				return &SchemaUpgradeRequiredError{
+					Table:  table,
+					Column: column,
+				}
 			}
 		}
 	}

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -29,6 +29,13 @@ type StatsFilter struct {
 	GHToken               string
 }
 
+// StatsInputError marks invalid user-supplied stats filters so HTTP
+// transports can return 400 instead of treating validation failures as server
+// faults.
+type StatsInputError struct{ Msg string }
+
+func (e *StatsInputError) Error() string { return e.Msg }
+
 // GetSessionStats computes the v1 session-stats JSON response.
 // Sections are populated in order so each step can reuse the per-session
 // rows (and derived sessionIDs) loaded once by loadSessionsInWindow.
@@ -37,11 +44,11 @@ func (db *DB) GetSessionStats(
 ) (*SessionStats, error) {
 	tz, err := resolveTimezone(f.Timezone)
 	if err != nil {
-		return nil, fmt.Errorf("resolving timezone: %w", err)
+		return nil, &StatsInputError{Msg: "invalid timezone: " + f.Timezone}
 	}
 	from, to, days, err := windowBounds(f, time.Now())
 	if err != nil {
-		return nil, fmt.Errorf("resolving window: %w", err)
+		return nil, &StatsInputError{Msg: err.Error()}
 	}
 
 	// Root-only rows drive every consumer (distributions, velocity,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1445,8 +1445,8 @@ func (db *DB) RefreshSessionName(id string, sessionName *string) error {
 	return err
 }
 
-// FindSessionIDsByPartial returns up to limit session IDs that
-// contain the given substring. Used by CLI lookups so users can
+// FindSessionIDsByPartial returns up to limit session IDs that contain the
+// given literal, case-sensitive substring. Used by CLI lookups so users can
 // reference sessions by a short prefix shown in list output.
 // Excludes soft-deleted sessions.
 func (db *DB) FindSessionIDsByPartial(
@@ -1460,14 +1460,14 @@ func (db *DB) FindSessionIDsByPartial(
 	}
 	rows, err := db.getReader().QueryContext(ctx,
 		`SELECT id FROM sessions
-		 WHERE id LIKE ? AND deleted_at IS NULL
+		 WHERE instr(id, ?) > 0 AND deleted_at IS NULL
 		 ORDER BY COALESCE(
 		     NULLIF(ended_at, ''),
 		     NULLIF(started_at, ''),
 		     created_at
 		 ) DESC
 		 LIMIT ?`,
-		"%"+partial+"%", limit,
+		partial, limit,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -70,6 +70,29 @@ func TestFindSessionIDsByPartial(t *testing.T) {
 	assert.Nil(t, got, "empty input")
 }
 
+func TestFindSessionIDsByPartialLiteralCaseSensitive(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "abc_def", "proj")
+	insertSession(t, d, "abcXdef", "proj")
+	insertSession(t, d, "abc%def", "proj")
+	insertSession(t, d, "ABCdef", "proj")
+
+	ctx := context.Background()
+
+	got, err := d.FindSessionIDsByPartial(ctx, "c_d", 10)
+	require.NoError(t, err, "underscore lookup")
+	assert.Equal(t, []string{"abc_def"}, got)
+
+	got, err = d.FindSessionIDsByPartial(ctx, "c%d", 10)
+	require.NoError(t, err, "percent lookup")
+	assert.Equal(t, []string{"abc%def"}, got)
+
+	got, err = d.FindSessionIDsByPartial(ctx, "abc", 10)
+	require.NoError(t, err, "case-sensitive lookup")
+	assert.ElementsMatch(t, []string{"abc_def", "abcXdef", "abc%def"}, got)
+	assert.NotContains(t, got, "ABCdef")
+}
+
 func TestListSessions_OutcomeFilter(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -30,6 +30,7 @@ type Store interface {
 	GetSidebarSessionIndex(ctx context.Context, f SessionFilter) (SidebarSessionIndex, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	GetSessionFull(ctx context.Context, id string) (*Session, error)
+	FindSessionIDsByPartial(ctx context.Context, partial string, limit int) ([]string, error)
 	GetChildSessions(ctx context.Context, parentID string) ([]Session, error)
 
 	// Messages.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -30,6 +30,7 @@ type Store interface {
 	GetSidebarSessionIndex(ctx context.Context, f SessionFilter) (SidebarSessionIndex, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	GetSessionFull(ctx context.Context, id string) (*Session, error)
+	// FindSessionIDsByPartial uses literal, case-sensitive substring matching.
 	FindSessionIDsByPartial(ctx context.Context, partial string, limit int) ([]string, error)
 	GetChildSessions(ctx context.Context, parentID string) ([]Session, error)
 

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -157,10 +157,10 @@ func (s *Store) FindSessionIDsByPartial(
 	}
 	rows, err := s.duck.QueryContext(ctx,
 		`SELECT id FROM sessions
-		 WHERE id LIKE ? AND deleted_at IS NULL
+		 WHERE strpos(id, ?) > 0 AND deleted_at IS NULL
 		 ORDER BY COALESCE(ended_at, started_at, created_at) DESC
 		 LIMIT ?`,
-		"%"+partial+"%", limit,
+		partial, limit,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -146,6 +146,40 @@ func scanSessionRows(rows *sql.Rows) ([]db.Session, error) {
 	return sessions, rows.Err()
 }
 
+func (s *Store) FindSessionIDsByPartial(
+	ctx context.Context, partial string, limit int,
+) ([]string, error) {
+	if partial == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	rows, err := s.duck.QueryContext(ctx,
+		`SELECT id FROM sessions
+		 WHERE id LIKE ? AND deleted_at IS NULL
+		 ORDER BY COALESCE(ended_at, started_at, created_at) DESC
+		 LIMIT ?`,
+		"%"+partial+"%", limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"finding sessions by partial id %q: %w",
+			partial, err,
+		)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 func formatDBTime(v any) string {
 	switch t := v.(type) {
 	case nil:

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -32,6 +32,34 @@ func TestDuckDBStoreContract(t *testing.T) {
 	}
 }
 
+func TestDuckDBFindSessionIDsByPartialLiteralCaseSensitive(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	for _, id := range []string{"abc_def", "abcXdef", "abc%def", "ABCdef"} {
+		require.NoError(t, local.UpsertSession(db.Session{
+			ID: id, Project: "proj", Machine: "test",
+			Agent: "claude", MessageCount: 1,
+		}), "upsert %q", id)
+	}
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	got, err := store.FindSessionIDsByPartial(ctx, "c_d", 10)
+	require.NoError(t, err, "underscore lookup")
+	assert.Equal(t, []string{"abc_def"}, got)
+
+	got, err = store.FindSessionIDsByPartial(ctx, "c%d", 10)
+	require.NoError(t, err, "percent lookup")
+	assert.Equal(t, []string{"abc%def"}, got)
+
+	got, err = store.FindSessionIDsByPartial(ctx, "abc", 10)
+	require.NoError(t, err, "case-sensitive lookup")
+	assert.ElementsMatch(t, []string{"abc_def", "abcXdef", "abc%def"}, got)
+	assert.NotContains(t, got, "ABCdef")
+}
+
 func duckContractSessionsCursorsAndMetadata(
 	t *testing.T, store *Store, fixture syncFixture,
 ) {

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -253,10 +253,10 @@ func (s *Store) FindSessionIDsByPartial(
 	}
 	rows, err := s.pg.QueryContext(ctx,
 		`SELECT id FROM sessions
-		 WHERE id LIKE $1 AND deleted_at IS NULL
+		 WHERE strpos(id, $1) > 0 AND deleted_at IS NULL
 		 ORDER BY COALESCE(ended_at, started_at, created_at) DESC
 		 LIMIT $2`,
-		"%"+partial+"%", limit,
+		partial, limit,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -242,6 +242,40 @@ func scanPGSession(
 	return s, nil
 }
 
+func (s *Store) FindSessionIDsByPartial(
+	ctx context.Context, partial string, limit int,
+) ([]string, error) {
+	if partial == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	rows, err := s.pg.QueryContext(ctx,
+		`SELECT id FROM sessions
+		 WHERE id LIKE $1 AND deleted_at IS NULL
+		 ORDER BY COALESCE(ended_at, started_at, created_at) DESC
+		 LIMIT $2`,
+		"%"+partial+"%", limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"finding sessions by partial id %q: %w",
+			partial, err,
+		)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // scanPGSessionRows iterates rows and scans each.
 func scanPGSessionRows(
 	rows *sql.Rows,

--- a/internal/postgres/sessions_pgtest_test.go
+++ b/internal/postgres/sessions_pgtest_test.go
@@ -338,3 +338,49 @@ func TestListSessions_SortNullsLast(t *testing.T) {
 	// Ascending with NULLs last, paginated across the sentinel boundary.
 	require.Equal(t, []string{"h20", "h80", "hnull"}, walked)
 }
+
+func TestFindSessionIDsByPartialLiteralCaseSensitivePG(t *testing.T) {
+	pgURL := testPGURL(t)
+	const schema = "agentsview_partial_lookup_test"
+
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	local := testDB(t)
+	for _, id := range []string{"abc_def", "abcXdef", "abc%def", "ABCdef"} {
+		require.NoError(t, local.UpsertSession(db.Session{
+			ID: id, Project: "proj", Machine: "local",
+			Agent: "claude", MessageCount: 1,
+		}), "upsert %q", id)
+	}
+
+	syncer := &Sync{
+		pg:         pg,
+		local:      local,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "Push")
+
+	store := &Store{pg: pg}
+	got, err := store.FindSessionIDsByPartial(ctx, "c_d", 10)
+	require.NoError(t, err, "underscore lookup")
+	assert.Equal(t, []string{"abc_def"}, got)
+
+	got, err = store.FindSessionIDsByPartial(ctx, "c%d", 10)
+	require.NoError(t, err, "percent lookup")
+	assert.Equal(t, []string{"abc%def"}, got)
+
+	got, err = store.FindSessionIDsByPartial(ctx, "abc", 10)
+	require.NoError(t, err, "case-sensitive lookup")
+	assert.ElementsMatch(t, []string{"abc_def", "abcXdef", "abc%def"}, got)
+	assert.NotContains(t, got, "ABCdef")
+}

--- a/internal/server/huma_routes_metadata.go
+++ b/internal/server/huma_routes_metadata.go
@@ -62,6 +62,10 @@ func (s *Server) humaGetSessionStats(
 	ctx context.Context,
 	in *sessionStatsInput,
 ) (*jsonOutput[*service.SessionStats], error) {
+	githubToken := ""
+	if in.IncludeGitHubOutcomes {
+		githubToken = s.githubToken(ctx)
+	}
 	stats, err := s.sessions.Stats(ctx, service.StatsFilter{
 		Since:                 in.Since,
 		Until:                 in.Until,
@@ -71,6 +75,7 @@ func (s *Server) humaGetSessionStats(
 		Timezone:              in.Timezone,
 		IncludeGitOutcomes:    in.IncludeGitOutcomes,
 		IncludeGitHubOutcomes: in.IncludeGitHubOutcomes,
+		GHToken:               githubToken,
 	})
 	if err != nil {
 		if handled := handleHumaContextError(err); handled != nil {

--- a/internal/server/huma_routes_metadata.go
+++ b/internal/server/huma_routes_metadata.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/service"
@@ -83,6 +85,10 @@ func (s *Server) humaGetSessionStats(
 		}
 		if handled := handleHumaReadOnly(err); handled != nil {
 			return nil, handled
+		}
+		var inputErr *db.StatsInputError
+		if errors.As(err, &inputErr) {
+			return nil, apiError(http.StatusBadRequest, inputErr.Msg)
 		}
 		return nil, internalError("session stats error", err)
 	}

--- a/internal/server/huma_routes_metadata.go
+++ b/internal/server/huma_routes_metadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/update"
 )
 
@@ -14,12 +15,24 @@ func (s *Server) registerMetadataRoutes() {
 	get(s, group, "/machines", "List machines", s.humaListMachines)
 	get(s, group, "/agents", "List agents", s.humaListAgents)
 	get(s, group, "/stats", "Get stats", s.humaGetStats)
+	get(s, group, "/session-stats", "Get session stats", s.humaGetSessionStats)
 	get(s, group, "/version", "Get server version", s.humaGetVersion)
 	get(s, group, "/update/check", "Check for updates", s.humaCheckUpdate)
 }
 
 type statsInput struct {
 	BoolIncludeInput
+}
+
+type sessionStatsInput struct {
+	Since                 string   `query:"since" doc:"Start of window"`
+	Until                 string   `query:"until" doc:"End of window"`
+	Agent                 string   `query:"agent" doc:"Filter by agent"`
+	IncludeProjects       []string `query:"include_project" doc:"Restrict to these projects"`
+	ExcludeProjects       []string `query:"exclude_project" doc:"Exclude these projects"`
+	Timezone              string   `query:"timezone" doc:"IANA timezone name"`
+	IncludeGitOutcomes    bool     `query:"include_git_outcomes" doc:"Include git-derived outcome stats"`
+	IncludeGitHubOutcomes bool     `query:"include_github_outcomes" doc:"Include GitHub PR outcome stats"`
 }
 
 type projectsResponse struct {
@@ -43,6 +56,32 @@ func (s *Server) humaGetStats(
 		return nil, serverError(err)
 	}
 	return &jsonOutput[db.Stats]{Body: stats}, nil
+}
+
+func (s *Server) humaGetSessionStats(
+	ctx context.Context,
+	in *sessionStatsInput,
+) (*jsonOutput[*service.SessionStats], error) {
+	stats, err := s.sessions.Stats(ctx, service.StatsFilter{
+		Since:                 in.Since,
+		Until:                 in.Until,
+		Agent:                 in.Agent,
+		IncludeProjects:       in.IncludeProjects,
+		ExcludeProjects:       in.ExcludeProjects,
+		Timezone:              in.Timezone,
+		IncludeGitOutcomes:    in.IncludeGitOutcomes,
+		IncludeGitHubOutcomes: in.IncludeGitHubOutcomes,
+	})
+	if err != nil {
+		if handled := handleHumaContextError(err); handled != nil {
+			return nil, handled
+		}
+		if handled := handleHumaReadOnly(err); handled != nil {
+			return nil, handled
+		}
+		return nil, internalError("session stats error", err)
+	}
+	return &jsonOutput[*service.SessionStats]{Body: stats}, nil
 }
 
 func (s *Server) humaListProjects(

--- a/internal/server/huma_routes_metadata_internal_test.go
+++ b/internal/server/huma_routes_metadata_internal_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/service"
+)
+
+type statsSpyService struct {
+	service.SessionService
+	got service.StatsFilter
+}
+
+func (s *statsSpyService) Stats(
+	_ context.Context, f service.StatsFilter,
+) (*service.SessionStats, error) {
+	s.got = f
+	return &service.SessionStats{}, nil
+}
+
+func TestHumaGetSessionStatsUsesServerGitHubToken(t *testing.T) {
+	spy := &statsSpyService{}
+	srv := &Server{
+		cfg:      config.Config{GithubToken: "server-token"},
+		sessions: spy,
+	}
+
+	_, err := srv.humaGetSessionStats(context.Background(), &sessionStatsInput{
+		IncludeGitHubOutcomes: true,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "server-token", spy.got.GHToken)
+}

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -26,6 +26,7 @@ func (s *Server) registerSessionRoutes() {
 
 	get(s, group, "/sessions", "List sessions", s.humaListSessions)
 	get(s, group, "/sessions/sidebar-index", "List sidebar sessions", s.humaSidebarSessionIndex)
+	get(s, group, "/sessions/resolve-id", "Resolve session IDs", s.humaResolveSessionIDs)
 	get(s, group, "/sessions/{id}", "Get session", s.humaGetSession)
 	get(s, group, "/sessions/{id}/messages", "List session messages", s.humaGetMessages)
 	get(s, group, "/sessions/{id}/tool-calls", "List session tool calls", s.humaToolCalls)
@@ -93,6 +94,15 @@ type messageListInput struct {
 type searchSessionInput struct {
 	ID    string `path:"id" required:"true" doc:"Session ID"`
 	Query string `query:"q" doc:"Search query"`
+}
+
+type resolveSessionIDsInput struct {
+	Partial string `query:"partial" required:"true" doc:"Session ID substring"`
+	Limit   int    `query:"limit" minimum:"0" maximum:"1000" doc:"Maximum number of matching IDs"`
+}
+
+type resolveSessionIDsResponse struct {
+	IDs []string `json:"ids"`
 }
 
 func (in *sessionFilterInput) listFilter() (service.ListFilter, error) {
@@ -204,6 +214,25 @@ func (s *Server) humaSidebarSessionIndex(
 		return nil, serverError(err)
 	}
 	return &jsonOutput[db.SidebarSessionIndex]{Body: index}, nil
+}
+
+func (s *Server) humaResolveSessionIDs(
+	ctx context.Context,
+	in *resolveSessionIDsInput,
+) (*jsonOutput[resolveSessionIDsResponse], error) {
+	ids, err := s.sessions.FindSessionIDsByPartial(ctx, in.Partial, in.Limit)
+	if err != nil {
+		if handled := handleHumaContextError(err); handled != nil {
+			return nil, handled
+		}
+		if handled := handleHumaReadOnly(err); handled != nil {
+			return nil, handled
+		}
+		return nil, serverError(err)
+	}
+	return &jsonOutput[resolveSessionIDsResponse]{
+		Body: resolveSessionIDsResponse{IDs: ids},
+	}, nil
 }
 
 func (s *Server) humaGetSession(

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -26,7 +26,7 @@ func (s *Server) registerSessionRoutes() {
 
 	get(s, group, "/sessions", "List sessions", s.humaListSessions)
 	get(s, group, "/sessions/sidebar-index", "List sidebar sessions", s.humaSidebarSessionIndex)
-	get(s, group, "/sessions/resolve-id", "Resolve session IDs", s.humaResolveSessionIDs)
+	get(s, group, "/session-ids/resolve", "Resolve session IDs", s.humaResolveSessionIDs)
 	get(s, group, "/sessions/{id}", "Get session", s.humaGetSession)
 	get(s, group, "/sessions/{id}/messages", "List session messages", s.humaGetMessages)
 	get(s, group, "/sessions/{id}/tool-calls", "List session tool calls", s.humaToolCalls)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -100,13 +100,13 @@ func New(
 		log.Fatalf("embedded frontend not found: %v", err)
 	}
 
-	// Pick the backend that matches the concrete store. A local
-	// *db.DB plus a sync engine yields a full read/write backend;
-	// any other combination (PG reader, or local DB with nil
-	// engine when used by a read-only daemon) yields a read-only
-	// backend whose Sync returns db.ErrReadOnly.
+	// Pick the backend that matches the concrete store. A local *db.DB uses
+	// the direct backend even when the sync engine is nil; direct Sync already
+	// returns db.ErrReadOnly without an engine, while read APIs such as stats
+	// still need the local handle. Non-SQLite stores use the generic read-only
+	// backend.
 	var sessions service.SessionService
-	if local, ok := database.(*db.DB); ok && engine != nil {
+	if local, ok := database.(*db.DB); ok {
 		sessions = service.NewDirectBackend(local, engine)
 	} else {
 		sessions = service.NewReadOnlyBackend(database)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -138,7 +138,7 @@ func New(
 		opt(s)
 	}
 	if s.version.APIVersion == 0 {
-		s.version.APIVersion = 1
+		s.version.APIVersion = 2
 	}
 	if s.version.DataVersion == 0 {
 		s.version.DataVersion = db.CurrentDataVersion()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -549,6 +549,8 @@ func TestOpenAPIEndpointDocumentsExistingAPIRoutes(t *testing.T) {
 	assert.Contains(t, spec.Paths["/api/v1/sessions/{id}/messages"], "get")
 	require.Contains(t, spec.Paths, "/api/v1/settings")
 	assert.Contains(t, spec.Paths["/api/v1/settings"], "put")
+	require.Contains(t, spec.Paths, "/api/v1/session-stats")
+	assert.Contains(t, spec.Paths["/api/v1/session-stats"], "get")
 }
 
 func TestOpenAPIEndpointKeepsUsageSummaryContract(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4130,7 +4130,7 @@ func TestGetVersion(t *testing.T) {
 		)
 	}
 	assert.True(t, resp.InsightGenerationAvailable)
-	assert.Equal(t, 1, resp.APIVersion)
+	assert.Equal(t, 2, resp.APIVersion)
 	assert.Equal(t, db.CurrentDataVersion(), resp.DataVersion)
 }
 
@@ -4144,7 +4144,7 @@ func TestGetVersion_Default(t *testing.T) {
 	if resp.Version != "" {
 		t.Errorf("version = %q, want empty", resp.Version)
 	}
-	assert.Equal(t, 1, resp.APIVersion)
+	assert.Equal(t, 2, resp.APIVersion)
 	assert.Equal(t, db.CurrentDataVersion(), resp.DataVersion)
 }
 

--- a/internal/server/session_resolve_test.go
+++ b/internal/server/session_resolve_test.go
@@ -1,0 +1,22 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveSessionIDsEndpoint(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "older-partial-match", "alpha", 2)
+	te.seedSession(t, "newer-other-session", "alpha", 2)
+
+	w := te.get(t, "/api/v1/sessions/resolve-id?partial=partial&limit=10")
+
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[struct {
+		IDs []string `json:"ids"`
+	}](t, w)
+	assert.Equal(t, []string{"older-partial-match"}, resp.IDs)
+}

--- a/internal/server/session_resolve_test.go
+++ b/internal/server/session_resolve_test.go
@@ -12,7 +12,7 @@ func TestResolveSessionIDsEndpoint(t *testing.T) {
 	te.seedSession(t, "older-partial-match", "alpha", 2)
 	te.seedSession(t, "newer-other-session", "alpha", 2)
 
-	w := te.get(t, "/api/v1/sessions/resolve-id?partial=partial&limit=10")
+	w := te.get(t, "/api/v1/session-ids/resolve?partial=partial&limit=10")
 
 	assertStatus(t, w, http.StatusOK)
 	resp := decode[struct {

--- a/internal/server/session_stats_test.go
+++ b/internal/server/session_stats_test.go
@@ -1,0 +1,43 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionStatsInvalidInputsReturnBadRequest(t *testing.T) {
+	te := setup(t)
+
+	tests := []struct {
+		name     string
+		path     string
+		wantBody string
+	}{
+		{
+			name:     "timezone",
+			path:     "/api/v1/session-stats?timezone=Fake/Zone",
+			wantBody: "invalid timezone: Fake/Zone",
+		},
+		{
+			name:     "since",
+			path:     "/api/v1/session-stats?since=7x",
+			wantBody: `parsing since "7x"`,
+		},
+		{
+			name:     "until",
+			path:     "/api/v1/session-stats?until=nope",
+			wantBody: `parsing until "nope"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := te.get(t, tt.path)
+
+			assertStatus(t, w, http.StatusBadRequest)
+			resp := decode[map[string]string](t, w)
+			assert.Contains(t, resp["error"], tt.wantBody)
+		})
+	}
+}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -62,6 +62,12 @@ func (b *directBackend) Get(
 	return buildSessionDetail(s), nil
 }
 
+func (b *directBackend) FindSessionIDsByPartial(
+	ctx context.Context, partial string, limit int,
+) ([]string, error) {
+	return b.db.FindSessionIDsByPartial(ctx, partial, limit)
+}
+
 // buildSessionDetail wraps a db.Session with its computed health
 // breakdown. The same shape is returned by GET /api/v1/sessions/{id}.
 func buildSessionDetail(s *db.Session) *SessionDetail {

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -72,6 +72,23 @@ func (b *httpBackend) Get(
 	return &out, nil
 }
 
+func (b *httpBackend) FindSessionIDsByPartial(
+	ctx context.Context, partial string, limit int,
+) ([]string, error) {
+	q := url.Values{}
+	q.Set("partial", partial)
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	var out struct {
+		IDs []string `json:"ids"`
+	}
+	if err := b.getJSON(ctx, "/api/v1/sessions/resolve-id?"+q.Encode(), &out); err != nil {
+		return nil, err
+	}
+	return out.IDs, nil
+}
+
 func (b *httpBackend) List(
 	ctx context.Context, f ListFilter,
 ) (*SessionList, error) {

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -83,7 +83,7 @@ func (b *httpBackend) FindSessionIDsByPartial(
 	var out struct {
 		IDs []string `json:"ids"`
 	}
-	if err := b.getJSON(ctx, "/api/v1/sessions/resolve-id?"+q.Encode(), &out); err != nil {
+	if err := b.getJSON(ctx, "/api/v1/session-ids/resolve?"+q.Encode(), &out); err != nil {
 		return nil, err
 	}
 	return out.IDs, nil

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -278,12 +278,39 @@ func (b *httpBackend) Watch(
 	return out, nil
 }
 
-// Stats is not yet implemented over HTTP; the daemon currently has
-// no /stats endpoint. Subsequent tasks may add one.
 func (b *httpBackend) Stats(
-	_ context.Context, _ StatsFilter,
+	ctx context.Context, f StatsFilter,
 ) (*SessionStats, error) {
-	return nil, errors.New("stats over HTTP backend: not yet implemented")
+	q := url.Values{}
+	setIfNotEmpty := func(k, v string) {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+	setIfNotEmpty("since", f.Since)
+	setIfNotEmpty("until", f.Until)
+	setIfNotEmpty("agent", f.Agent)
+	setIfNotEmpty("timezone", f.Timezone)
+	for _, p := range f.IncludeProjects {
+		q.Add("include_project", p)
+	}
+	for _, p := range f.ExcludeProjects {
+		q.Add("exclude_project", p)
+	}
+	q.Set("include_git_outcomes", strconv.FormatBool(f.IncludeGitOutcomes))
+	q.Set("include_github_outcomes", strconv.FormatBool(f.IncludeGitHubOutcomes))
+
+	var out SessionStats
+	err := b.getJSON(ctx, "/api/v1/session-stats?"+q.Encode(), &out)
+	if errors.Is(err, errHTTPNotImplemented) {
+		return nil, fmt.Errorf(
+			"stats: daemon at %s: %w", b.baseURL, db.ErrReadOnly,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
 }
 
 func (b *httpBackend) Search(

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -23,6 +23,9 @@ var ErrSearchUnavailable = errors.New("search not available")
 // (proxies to a running daemon).
 type SessionService interface {
 	Get(ctx context.Context, id string) (*SessionDetail, error)
+	// FindSessionIDsByPartial returns IDs containing partial as a literal,
+	// case-sensitive substring, ordered by most recent activity and capped by
+	// limit.
 	FindSessionIDsByPartial(ctx context.Context, partial string, limit int) ([]string, error)
 	List(ctx context.Context, f ListFilter) (*SessionList, error)
 	Messages(ctx context.Context, id string, f MessageFilter) (*MessageList, error)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -23,6 +23,7 @@ var ErrSearchUnavailable = errors.New("search not available")
 // (proxies to a running daemon).
 type SessionService interface {
 	Get(ctx context.Context, id string) (*SessionDetail, error)
+	FindSessionIDsByPartial(ctx context.Context, partial string, limit int) ([]string, error)
 	List(ctx context.Context, f ListFilter) (*SessionList, error)
 	Messages(ctx context.Context, id string, f MessageFilter) (*MessageList, error)
 	ToolCalls(ctx context.Context, id string) (*ToolCallList, error)

--- a/internal/service/stats_test.go
+++ b/internal/service/stats_test.go
@@ -1,0 +1,58 @@
+package service_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/service"
+)
+
+func TestHTTPBackendStats(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"schema_version": 1,
+				"window": {"since": "2026-04-01T00:00:00Z", "until": "2026-04-15T00:00:00Z", "days": 14},
+				"filters": {"agent": "codex", "projects_included": ["alpha"], "projects_excluded": ["beta"], "timezone": "UTC"},
+				"totals": {"sessions_all": 7}
+			}`))
+		}))
+	t.Cleanup(srv.Close)
+	svc := service.NewHTTPBackend(srv.URL, "", false)
+
+	stats, err := svc.Stats(context.Background(), service.StatsFilter{
+		Since:                 "2026-04-01",
+		Until:                 "2026-04-15",
+		Agent:                 "codex",
+		IncludeProjects:       []string{"alpha"},
+		ExcludeProjects:       []string{"beta"},
+		Timezone:              "UTC",
+		IncludeGitOutcomes:    true,
+		IncludeGitHubOutcomes: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, "/api/v1/session-stats", gotPath)
+	assert.Equal(t, "2026-04-01", gotQuery.Get("since"))
+	assert.Equal(t, "2026-04-15", gotQuery.Get("until"))
+	assert.Equal(t, "codex", gotQuery.Get("agent"))
+	assert.Equal(t, "alpha", gotQuery.Get("include_project"))
+	assert.Equal(t, "beta", gotQuery.Get("exclude_project"))
+	assert.Equal(t, "UTC", gotQuery.Get("timezone"))
+	assert.Equal(t, "true", gotQuery.Get("include_git_outcomes"))
+	assert.Equal(t, "true", gotQuery.Get("include_github_outcomes"))
+	assert.Equal(t, 7, stats.Totals.SessionsAll)
+}


### PR DESCRIPTION
Read commands still had compatibility paths that could open SQLite directly when daemon discovery did not yield HTTP. That undermined the daemon-first migration and left upgraded users exposed to old schema/read-only failures instead of letting the writable daemon own migrations.

This makes daemon-capable reads resolve through daemon transport: they use reachable daemons, start or replace the local daemon where appropriate, and fail with restart guidance when the daemon is unreachable or incompatible instead of falling back. The remaining direct DB access is limited to commands whose contract is explicitly local, offline, or writer-owned, such as raw source export and offline archive queries.

<sup>generated by a clanker</sup>