### PR TITLE
feat(cli): hint that Copilot usage records no per-message tokens (#349)

### DIFF
--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -186,6 +186,24 @@ func runUsageDaily(cfg UsageDailyConfig) {
 	}
 
 	printDailyTable(result, cfg.Breakdown)
+	if note := noTokenDataNote(cfg.Agent, result.Totals); note != "" {
+		fmt.Fprintln(os.Stderr, note)
+	}
+}
+
+// noTokenDataNote returns a one-line stderr note for a zero usage result when
+// the user has filtered to a Copilot agent, which bills via a monthly request
+// quota rather than per-token and records no per-message token usage. It
+// returns "" when the filter is not a Copilot agent or real token/cost data
+// exists. This is an agent-property statement (issue #349) shown in response to
+// an explicit --agent the user typed, so it needs no session-presence check;
+// it is appropriate even for an empty window.
+func noTokenDataNote(agent string, totals db.UsageTotals) string {
+	if !db.IsCopilotAgentFilter(agent) || !db.NoTokenData(totals) {
+		return ""
+	}
+	return "note: GitHub Copilot bills via a monthly request quota and " +
+		"does not record per-message token usage."
 }
 
 type UsageStatuslineConfig struct {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -1164,3 +1164,81 @@ func (f *pricingFetchRecorder) fetch() ([]pricing.ModelPricing, error) {
 	f.calls++
 	return f.rows, f.err
 }
+
+// zeroTotalsCopilotUsageJSON is a daily-usage summary with sessions present
+// but zero token/cost totals — the "no token data" case.
+const zeroTotalsCopilotUsageJSON = `{
+  "daily": [],
+  "totals": {"inputTokens":0,"outputTokens":0,"cacheCreationTokens":0,"cacheReadTokens":0,"totalCost":0},
+  "sessionCounts": {"total":2,"byProject":{},"byAgent":{"copilot":2}}
+}`
+
+func TestRunUsageDailyHintsNoTokenDataForCopilot(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+	ts := sessionUsageRuntimeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSONResponse(w, zeroTotalsCopilotUsageJSON)
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	stderr := captureStderr(t, func() {
+		runUsageDaily(UsageDailyConfig{Agent: "copilot", Timezone: "UTC"})
+	})
+
+	assert.Contains(t, stderr, "Copilot")
+	assert.Contains(t, stderr, "monthly")
+}
+
+func TestRunUsageDailyNoHintWithoutAgentFilter(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+	ts := sessionUsageRuntimeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSONResponse(w, zeroTotalsCopilotUsageJSON)
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	stderr := captureStderr(t, func() {
+		runUsageDaily(UsageDailyConfig{Timezone: "UTC"})
+	})
+
+	assert.NotContains(t, stderr, "token")
+}
+
+func TestRunUsageDailyNoHintWhenDataPresent(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+	ts := sessionUsageRuntimeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSONResponse(w, sampleDailyUsageJSON)
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	stderr := captureStderr(t, func() {
+		runUsageDaily(UsageDailyConfig{Agent: "codex", Timezone: "UTC"})
+	})
+
+	assert.NotContains(t, stderr, "token-usage")
+}
+
+func TestNoTokenDataNote(t *testing.T) {
+	zero := db.UsageTotals{}
+	withData := db.UsageTotals{OutputTokens: 5}
+	copilotNote := "note: GitHub Copilot bills via a monthly request quota " +
+		"and does not record per-message token usage."
+	cases := []struct {
+		name   string
+		agent  string
+		totals db.UsageTotals
+		want   string
+	}{
+		{"no agent filter", "", zero, ""},
+		{"non-copilot agent with zero totals", "codex", zero, ""},
+		{"copilot with token data", "copilot", withData, ""},
+		{"copilot with zero totals", "copilot", zero, copilotNote},
+		{"vscode-copilot with zero totals", "vscode-copilot", zero, copilotNote},
+		{"all-copilot CSV filter", "copilot,vscode-copilot", zero, copilotNote},
+		{"mixed CSV filter", "copilot,claude", zero, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want,
+				noTokenDataNote(tc.agent, tc.totals))
+		})
+	}
+}

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -18,6 +18,40 @@ func IsCopilotAgent(agent string) bool {
 	return agent == "copilot" || agent == "vscode-copilot" || agent == "visualstudio-copilot"
 }
 
+// IsCopilotAgentFilter reports whether a (possibly comma-separated) agent
+// filter selects only Copilot agents — every non-empty entry is a Copilot
+// agent and there is at least one. The Usage agent filter supports
+// comma-separated lists (e.g. "copilot,vscode-copilot"), so the no-token-data
+// hint must treat such a list as Copilot rather than exact-matching the raw
+// string.
+func IsCopilotAgentFilter(agentFilter string) bool {
+	matched := false
+	for part := range strings.SplitSeq(agentFilter, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if !IsCopilotAgent(part) {
+			return false
+		}
+		matched = true
+	}
+	return matched
+}
+
+// NoTokenData reports whether a daily-usage total carries neither token
+// data nor cost: every token counter, the cost total, and any Copilot AI
+// credits are zero. It distinguishes a window whose sessions simply do not
+// record token usage from one that genuinely has no sessions.
+func NoTokenData(t UsageTotals) bool {
+	return t.InputTokens == 0 &&
+		t.OutputTokens == 0 &&
+		t.CacheCreationTokens == 0 &&
+		t.CacheReadTokens == 0 &&
+		t.TotalCost == 0 &&
+		t.CopilotAICredits == 0
+}
+
 func lookupModelRates(
 	pricing map[string]modelRates, model string,
 ) (modelRates, bool) {

--- a/internal/db/usage_no_token_data_test.go
+++ b/internal/db/usage_no_token_data_test.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoTokenData(t *testing.T) {
+	cases := []struct {
+		name   string
+		totals UsageTotals
+		want   bool
+	}{
+		{"all zero", UsageTotals{}, true},
+		{"input tokens", UsageTotals{InputTokens: 1}, false},
+		{"output tokens", UsageTotals{OutputTokens: 1}, false},
+		{"cache creation", UsageTotals{CacheCreationTokens: 1}, false},
+		{"cache read", UsageTotals{CacheReadTokens: 1}, false},
+		{"cost", UsageTotals{TotalCost: 0.01}, false},
+		{"copilot credits", UsageTotals{CopilotAICredits: 1}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, NoTokenData(tc.totals))
+		})
+	}
+}
+
+func TestIsCopilotAgentFilter(t *testing.T) {
+	cases := []struct {
+		name   string
+		filter string
+		want   bool
+	}{
+		{"empty", "", false},
+		{"single copilot", "copilot", true},
+		{"vscode copilot", "vscode-copilot", true},
+		{"all-copilot CSV", "copilot,vscode-copilot,visualstudio-copilot", true},
+		{"CSV with spaces", " copilot , vscode-copilot ", true},
+		{"mixed CSV", "copilot,claude", false},
+		{"single non-copilot", "claude", false},
+		{"trailing comma", "copilot,", true},
+		{"only commas", ",", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsCopilotAgentFilter(tc.filter))
+		})
+	}
+}


### PR DESCRIPTION
GitHub Copilot bills via a monthly premium-request quota rather than per-token, so its session files frequently record no per-message token usage. `usage daily --agent copilot` then shows all-zeros / $0.00 with no explanation, which reads as "spent nothing" (#349).

This adds a one-line stderr note from `usage daily` when the agent filter is an all-Copilot filter and the totals are zero. The agent filter accepts comma-separated lists, so `IsCopilotAgentFilter` treats an all-Copilot list (e.g. `copilot,vscode-copilot`) as Copilot. The note is an agent-property statement shown in response to an explicit `--agent` the user typed, so it needs no session-presence check.

Scope: this is the CLI half of #349. The dashboard hint is the harder half — to avoid showing it for an empty view it needs a timezone-correct, filter-faithful matching-session count from the sessions table (to distinguish "Copilot sessions with no usage" from "no matching sessions"), which is a cross-backend change worth its own PR. Tracked separately; this PR is intentionally scoped to the CLI.

## Where to look

- `cmd/agentsview/usage.go` (`noTokenDataNote`).
- `internal/db/usage.go` (`NoTokenData`, `IsCopilotAgentFilter`).
