### PR TITLE
feat(stats): add Cursor attribution parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,11 @@ thread JSON files.
 | Zencoder              | `~/.zencoder/sessions/`                                                                                                                                                 |
 
 Each directory can be overridden with an environment variable. See the
-[configuration docs](https://agentsview.io/configuration/) for details.
-Cursor attribution stats read `~/.cursor/ai-tracking/ai-code-tracking.db` by default and can be redirected with `AGENTSVIEW_CURSOR_ATTRIBUTION_DB`.
+[configuration docs](https://agentsview.io/configuration/) for details. Cursor
+attribution stats are a live, machine-local read from
+`~/.cursor/ai-tracking/ai-code-tracking.db` by default and can be redirected
+with `AGENTSVIEW_CURSOR_ATTRIBUTION_DB`; they are not synced or aggregated
+through PostgreSQL.
 
 ### Aider: per-repo Markdown logs
 
@@ -363,7 +366,11 @@ its `# aider chat started at ...` header (written in local time, assumed UTC).
 
 ### JetBrains Copilot via exporter
 
-JetBrains IDEs store Copilot chat in a Nitrite database that agentsview does not read directly. The supported path today is to export those sessions to Copilot JSONL with [copilot-jetbrains-exporter](https://github.com/MCBoarder289/copilot-jetbrains-exporter), then point agentsview at that output directory.
+JetBrains IDEs store Copilot chat in a Nitrite database that agentsview does not
+read directly. The supported path today is to export those sessions to Copilot
+JSONL with
+[copilot-jetbrains-exporter](https://github.com/MCBoarder289/copilot-jetbrains-exporter),
+then point agentsview at that output directory.
 
 ```bash
 # Export JetBrains Copilot sessions to JSONL
@@ -379,7 +386,8 @@ Or in `~/.agentsview/config.toml`:
 copilot_dirs = ["~/.copilot/jetbrains-sessions"]
 ```
 
-Re-run the exporter after new JetBrains Copilot sessions if you want agentsview to pick up fresh conversations from that source.
+Re-run the exporter after new JetBrains Copilot sessions if you want agentsview
+to pick up fresh conversations from that source.
 
 ### Antigravity CLI: high-resolution transcripts
 
@@ -391,8 +399,8 @@ structured tool calls, results, reasoning, and diffs -- comes from a
 back to **summary mode**: a heuristic decode of the raw `.db` steps (prompts and
 tool-call names only), or for `.pb` sessions your prompts from `history.jsonl`
 plus any plain-text artifacts under `brain/` (plans, walkthroughs, checkpoints).
-Summary-mode sessions show a "Summary mode" badge in the detail header that links
-here.
+Summary-mode sessions show a "Summary mode" badge in the detail header that
+links here.
 
 To unlock full transcripts for `.db` and `.pb` sessions alike, run
 [agy-reader](https://github.com/mjacobs/agy-reader) alongside agentsview.

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ thread JSON files.
 
 Each directory can be overridden with an environment variable. See the
 [configuration docs](https://agentsview.io/configuration/) for details.
+Cursor attribution stats read `~/.cursor/ai-tracking/ai-code-tracking.db` by default and can be redirected with `AGENTSVIEW_CURSOR_ATTRIBUTION_DB`.
 
 ### Aider: per-repo Markdown logs
 

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -778,6 +781,70 @@ func TestEnsureBackgroundServeReplacementWaitsForExternalStartLock(
 			assert.Equal(t, newPort, rt.Port)
 		})
 	}
+}
+
+func TestEnsureBackgroundServeReprobesWhenExternalStartupFinishesBeforeWait(
+	t *testing.T,
+) {
+	dir := runtimeTestDir(t)
+	setTestVersion(t, "1.1.0")
+	unlockStart := holdExternalDaemonStartLock(t, dir)
+
+	newDaemon := newPingDaemon(t)
+	published := make(chan error, 1)
+	ping := daemon.NewPingHandler(daemon.PingHandlerOptions{
+		Service: daemonService,
+		Version: "test",
+	})
+	var publishOnce sync.Once
+	oldServer := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, r *http.Request,
+	) {
+		publishOnce.Do(func() {
+			RemoveDaemonRuntime(dir)
+			_, err := WriteDaemonRuntime(
+				dir, newDaemon.Host, newDaemon.Port, "1.1.0", false,
+			)
+			unlockStart()
+			published <- err
+		})
+		ping.ServeHTTP(w, r)
+	}))
+	t.Cleanup(oldServer.Close)
+	oldDaemon := serverEndpoint(t, oldServer)
+	_, err := WriteDaemonRuntime(
+		dir, oldDaemon.Host, oldDaemon.Port, "1.0.0", false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { RemoveDaemonRuntime(dir) })
+
+	forbidStopDaemonRuntimeForUpgrade(t,
+		"auto-start replacement must re-probe after foreground startup wins")
+	oldStart := startServeBackgroundProcessForEnsure
+	startServeBackgroundProcessForEnsure = func(
+		config.Config, []string,
+	) (*exec.Cmd, string, error) {
+		t.Fatal("auto-start must not spawn after foreground startup wins")
+		return nil, "", nil
+	}
+	t.Cleanup(func() {
+		startServeBackgroundProcessForEnsure = oldStart
+	})
+
+	cfg := config.Config{DataDir: dir}
+	rt, err := ensureBackgroundServe(
+		context.Background(), &cfg, time.Second,
+	)
+
+	select {
+	case publishErr := <-published:
+		require.NoError(t, publishErr)
+	case <-time.After(time.Second):
+		t.Fatal("old daemon probe did not publish replacement runtime")
+	}
+	require.NoError(t, err)
+	require.NotNil(t, rt)
+	assert.Equal(t, newDaemon.Port, rt.Port)
 }
 
 func TestEnsureBackgroundServeLaunchLoserReplacesStaleDaemonAfterStartup(

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -173,6 +173,9 @@ func printStatsHuman(w io.Writer, stats *service.SessionStats) error {
 	if stats.Totals.SessionsAll == 0 {
 		fmt.Fprintln(ew, "Totals")
 		fmt.Fprintln(ew, "  (no sessions in window)")
+		if stats.CursorAttribution != nil {
+			printCursorAttribution(ew, stats.CursorAttribution)
+		}
 		return ew.err
 	}
 	printTotals(ew, stats)
@@ -194,6 +197,9 @@ func printStatsHuman(w io.Writer, stats *service.SessionStats) error {
 	}
 	if stats.Outcomes != nil {
 		printOutcomes(ew, stats.Outcomes)
+	}
+	if stats.CursorAttribution != nil {
+		printCursorAttribution(ew, stats.CursorAttribution)
 	}
 	return ew.err
 }
@@ -448,6 +454,42 @@ func printOutcomes(w io.Writer, o *db.StatsOutcomes) {
 		fmtFloat(o.CompactionsPerSession))
 	fmt.Fprintf(w, "  Avg edit churn:      %s\n",
 		fmtFloat(o.AvgEditChurn))
+	fmt.Fprintln(w)
+}
+
+func printCursorAttribution(w io.Writer, c *db.CursorAttribution) {
+	fmt.Fprintln(w, "Cursor attribution")
+	fmt.Fprintf(w, "  Scored commits:      %s\n",
+		fmtInt64(c.ScoredCommits))
+	fmt.Fprintf(w, "  Lines added/deleted: %s / %s\n",
+		fmtInt64(c.LinesAdded), fmtInt64(c.LinesDeleted))
+	fmt.Fprintf(w, "  Tab lines:           +%s / -%s\n",
+		fmtInt64(c.TabLinesAdded), fmtInt64(c.TabLinesDeleted))
+	fmt.Fprintf(w, "  Composer lines:      +%s / -%s\n",
+		fmtInt64(c.ComposerLinesAdded), fmtInt64(c.ComposerLinesDeleted))
+	fmt.Fprintf(w, "  Human lines:         +%s / -%s\n",
+		fmtInt64(c.HumanLinesAdded), fmtInt64(c.HumanLinesDeleted))
+	fmt.Fprintf(w, "  Blank lines:         +%s / -%s\n",
+		fmtInt64(c.BlankLinesAdded), fmtInt64(c.BlankLinesDeleted))
+	fmt.Fprintf(w, "  AI-authored pct:     %.1f%%\n",
+		c.AIAuthoredPct*100)
+	if len(c.ConversationCounts) > 0 {
+		fmt.Fprintln(w, "  Conversation counts")
+		tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+		for _, entry := range c.ConversationCounts {
+			model := entry.Model
+			if model == "" {
+				model = "(empty)"
+			}
+			mode := entry.Mode
+			if mode == "" {
+				mode = "(empty)"
+			}
+			fmt.Fprintf(tw, "    %s / %s\t%s\n",
+				model, mode, fmtInt64(entry.Count))
+		}
+		tw.Flush()
+	}
 	fmt.Fprintln(w)
 }
 

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -459,6 +459,24 @@ func printOutcomes(w io.Writer, o *db.StatsOutcomes) {
 
 func printCursorAttribution(w io.Writer, c *db.CursorAttribution) {
 	fmt.Fprintln(w, "Cursor attribution")
+	if c.Status != "" {
+		fmt.Fprintf(w, "  Status:             %s\n", c.Status)
+	}
+	if c.Scope != "" {
+		fmt.Fprintf(w, "  Scope:              %s\n", c.Scope)
+	}
+	for _, warning := range c.Warnings {
+		fmt.Fprintf(w, "  Warning:            %s\n", warning)
+	}
+	switch c.Status {
+	case "unavailable", "error", "unsupported_filter":
+		fmt.Fprintln(w)
+		return
+	case "empty":
+		fmt.Fprintln(w, "  Records:            none in window")
+		fmt.Fprintln(w)
+		return
+	}
 	fmt.Fprintf(w, "  Scored commits:      %s\n",
 		fmtInt64(c.ScoredCommits))
 	fmt.Fprintf(w, "  Lines added/deleted: %s / %s\n",

--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -173,8 +173,8 @@ func printStatsHuman(w io.Writer, stats *service.SessionStats) error {
 	if stats.Totals.SessionsAll == 0 {
 		fmt.Fprintln(ew, "Totals")
 		fmt.Fprintln(ew, "  (no sessions in window)")
-		if stats.CursorAttribution != nil {
-			printCursorAttribution(ew, stats.CursorAttribution)
+		if stats.CodeAttribution != nil {
+			printCodeAttribution(ew, stats.CodeAttribution)
 		}
 		return ew.err
 	}
@@ -198,8 +198,8 @@ func printStatsHuman(w io.Writer, stats *service.SessionStats) error {
 	if stats.Outcomes != nil {
 		printOutcomes(ew, stats.Outcomes)
 	}
-	if stats.CursorAttribution != nil {
-		printCursorAttribution(ew, stats.CursorAttribution)
+	if stats.CodeAttribution != nil {
+		printCodeAttribution(ew, stats.CodeAttribution)
 	}
 	return ew.err
 }
@@ -457,26 +457,38 @@ func printOutcomes(w io.Writer, o *db.StatsOutcomes) {
 	fmt.Fprintln(w)
 }
 
-func printCursorAttribution(w io.Writer, c *db.CursorAttribution) {
-	fmt.Fprintln(w, "Cursor attribution")
-	if c.Status != "" {
-		fmt.Fprintf(w, "  Status:             %s\n", c.Status)
+func printCodeAttribution(w io.Writer, c *db.CodeAttribution) {
+	fmt.Fprintln(w, "Code attribution")
+	for _, source := range c.Sources {
+		printCodeAttributionSource(w, source)
 	}
-	if c.Scope != "" {
-		fmt.Fprintf(w, "  Scope:              %s\n", c.Scope)
+	fmt.Fprintln(w)
+}
+
+func printCodeAttributionSource(w io.Writer, s db.CodeAttributionSource) {
+	fmt.Fprintf(w, "  Source:             %s\n", s.Provider)
+	if s.Status != "" {
+		fmt.Fprintf(w, "  Status:             %s\n", s.Status)
 	}
-	for _, warning := range c.Warnings {
+	if s.Scope != "" {
+		fmt.Fprintf(w, "  Scope:              %s\n", s.Scope)
+	}
+	for _, warning := range s.Warnings {
 		fmt.Fprintf(w, "  Warning:            %s\n", warning)
 	}
-	switch c.Status {
+	switch s.Status {
 	case "unavailable", "error", "unsupported_filter":
-		fmt.Fprintln(w)
 		return
 	case "empty":
 		fmt.Fprintln(w, "  Records:            none in window")
-		fmt.Fprintln(w)
 		return
 	}
+	if s.Provider == "cursor" && s.Metrics != nil {
+		printCursorAttributionMetrics(w, s.Metrics)
+	}
+}
+
+func printCursorAttributionMetrics(w io.Writer, c *db.CursorAttributionMetrics) {
 	fmt.Fprintf(w, "  Scored commits:      %s\n",
 		fmtInt64(c.ScoredCommits))
 	fmt.Fprintf(w, "  Lines added/deleted: %s / %s\n",
@@ -508,7 +520,6 @@ func printCursorAttribution(w io.Writer, c *db.CursorAttribution) {
 		}
 		tw.Flush()
 	}
-	fmt.Fprintln(w)
 }
 
 // formatGrades renders a grade histogram in canonical A..F order so

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -218,6 +218,24 @@ func TestPrintStatsHuman_Populated(t *testing.T) {
 			CompactionsPerSession: 0.1,
 			AvgEditChurn:          1.2,
 		},
+		CursorAttribution: &db.CursorAttribution{
+			ScoredCommits:        2,
+			LinesAdded:           30,
+			LinesDeleted:         12,
+			TabLinesAdded:        8,
+			TabLinesDeleted:      2,
+			ComposerLinesAdded:   3,
+			ComposerLinesDeleted: 1,
+			HumanLinesAdded:      19,
+			HumanLinesDeleted:    9,
+			BlankLinesAdded:      4,
+			BlankLinesDeleted:    0,
+			AIAuthoredPct:        11.0 / 30.0,
+			ConversationCounts: []db.CursorConversationCount{
+				{Model: "claude-3.5-sonnet", Mode: "composer", Count: 2},
+				{Model: "claude-3.5-sonnet", Mode: "tab", Count: 1},
+			},
+		},
 		GeneratedAt: "2026-04-18T00:00:00Z",
 	}
 
@@ -240,11 +258,14 @@ func TestPrintStatsHuman_Populated(t *testing.T) {
 		"Temporal",
 		"Outcome stats",
 		"Outcomes",
+		"Cursor attribution",
 	)
 
 	// Thousands separators must be applied to large counts.
 	assert.Contains(t, out, "11,905",
 		"expected thousands separator for 11,905")
+	assert.Contains(t, out, "claude-3.5-sonnet / composer",
+		"expected cursor conversation row")
 }
 
 // TestPrintStatsHuman_Empty guards the zero-session short
@@ -269,7 +290,8 @@ func TestPrintStatsHuman_Empty(t *testing.T) {
 		"expected zero-session placeholder in output")
 	// No optional section headers should appear.
 	assertContainsNone(t, out,
-		"Archetypes", "Velocity", "Cache economics", "Outcomes")
+		"Archetypes", "Velocity", "Cache economics", "Outcomes",
+		"Cursor attribution")
 }
 
 // TestFmtInt64 covers the thousands-separator helper.

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -50,6 +50,8 @@ func assertContainsNone(t *testing.T, out string, banned ...string) {
 func setupGoldenStatsDataDir(t *testing.T) string {
 	t.Helper()
 	dataDir := newAgentDataDir(t)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB",
+		filepath.Join(dataDir, "missing-cursor-attribution.db"))
 	// TZ is normally pinned by --timezone=UTC, but the environment can
 	// still leak into date parsing on some platforms; pin it too.
 	t.Setenv("TZ", "UTC")

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -220,22 +220,29 @@ func TestPrintStatsHuman_Populated(t *testing.T) {
 			CompactionsPerSession: 0.1,
 			AvgEditChurn:          1.2,
 		},
-		CursorAttribution: &db.CursorAttribution{
-			ScoredCommits:        2,
-			LinesAdded:           30,
-			LinesDeleted:         12,
-			TabLinesAdded:        8,
-			TabLinesDeleted:      2,
-			ComposerLinesAdded:   3,
-			ComposerLinesDeleted: 1,
-			HumanLinesAdded:      19,
-			HumanLinesDeleted:    9,
-			BlankLinesAdded:      4,
-			BlankLinesDeleted:    0,
-			AIAuthoredPct:        11.0 / 30.0,
-			ConversationCounts: []db.CursorConversationCount{
-				{Model: "claude-3.5-sonnet", Mode: "composer", Count: 2},
-				{Model: "claude-3.5-sonnet", Mode: "tab", Count: 1},
+		CodeAttribution: &db.CodeAttribution{
+			Sources: []db.CodeAttributionSource{{
+				Provider: "cursor",
+				Scope:    "machine_local",
+				Status:   "available",
+				Metrics: &db.CursorAttributionMetrics{
+					ScoredCommits:        2,
+					LinesAdded:           30,
+					LinesDeleted:         12,
+					TabLinesAdded:        8,
+					TabLinesDeleted:      2,
+					ComposerLinesAdded:   3,
+					ComposerLinesDeleted: 1,
+					HumanLinesAdded:      19,
+					HumanLinesDeleted:    9,
+					BlankLinesAdded:      4,
+					BlankLinesDeleted:    0,
+					AIAuthoredPct:        11.0 / 30.0,
+					ConversationCounts: []db.CursorConversationCount{
+						{Model: "claude-3.5-sonnet", Mode: "composer", Count: 2},
+						{Model: "claude-3.5-sonnet", Mode: "tab", Count: 1},
+					},
+				}},
 			},
 		},
 		GeneratedAt: "2026-04-18T00:00:00Z",
@@ -260,7 +267,7 @@ func TestPrintStatsHuman_Populated(t *testing.T) {
 		"Temporal",
 		"Outcome stats",
 		"Outcomes",
-		"Cursor attribution",
+		"Code attribution",
 	)
 
 	// Thousands separators must be applied to large counts.
@@ -293,7 +300,7 @@ func TestPrintStatsHuman_Empty(t *testing.T) {
 	// No optional section headers should appear.
 	assertContainsNone(t, out,
 		"Archetypes", "Velocity", "Cache economics", "Outcomes",
-		"Cursor attribution")
+		"Code attribution")
 }
 
 // TestFmtInt64 covers the thousands-separator helper.

--- a/cmd/agentsview/testdata/stats_golden.json
+++ b/cmd/agentsview/testdata/stats_golden.json
@@ -89,23 +89,16 @@
     "dollars_saved_vs_uncached": 2.373315,
     "dollars_spent": 6.751545
   },
-  "cursor_attribution": {
-    "ai_authored_pct": 0,
-    "blank_lines_added": 0,
-    "blank_lines_deleted": 0,
-    "composer_lines_added": 0,
-    "composer_lines_deleted": 0,
-    "human_lines_added": 0,
-    "human_lines_deleted": 0,
-    "lines_added": 0,
-    "lines_deleted": 0,
-    "scope": "machine_local",
-    "scored_commits": 0,
-    "status": "unavailable",
-    "tab_lines_added": 0,
-    "tab_lines_deleted": 0,
-    "warnings": [
-      "Cursor attribution database is unavailable on this machine"
+  "code_attribution": {
+    "sources": [
+      {
+        "provider": "cursor",
+        "scope": "machine_local",
+        "status": "unavailable",
+        "warnings": [
+          "Cursor attribution database is unavailable on this machine"
+        ]
+      }
     ]
   },
   "distributions": {

--- a/cmd/agentsview/testdata/stats_golden.json
+++ b/cmd/agentsview/testdata/stats_golden.json
@@ -89,6 +89,25 @@
     "dollars_saved_vs_uncached": 2.373315,
     "dollars_spent": 6.751545
   },
+  "cursor_attribution": {
+    "ai_authored_pct": 0,
+    "blank_lines_added": 0,
+    "blank_lines_deleted": 0,
+    "composer_lines_added": 0,
+    "composer_lines_deleted": 0,
+    "human_lines_added": 0,
+    "human_lines_deleted": 0,
+    "lines_added": 0,
+    "lines_deleted": 0,
+    "scope": "machine_local",
+    "scored_commits": 0,
+    "status": "unavailable",
+    "tab_lines_added": 0,
+    "tab_lines_deleted": 0,
+    "warnings": [
+      "Cursor attribution database is unavailable on this machine"
+    ]
+  },
   "distributions": {
     "duration_minutes": {
       "scope_all": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,8 +31,8 @@ self-exits after an idle period. Read-only CLI commands can still open
 `AGENTSVIEW_NO_DAEMON=1` for scripts or CI jobs that must never auto-start a
 daemon.
 
-Cursor attribution stats are a live, machine-local read from
-`~/.cursor/ai-tracking/ai-code-tracking.db` by default. Set
+The Cursor source in code attribution stats is a live, machine-local read
+from `~/.cursor/ai-tracking/ai-code-tracking.db` by default. Set
 `AGENTSVIEW_CURSOR_ATTRIBUTION_DB` when Cursor stores that database
 somewhere else on the host answering the stats request. The attribution
 database is not synced into AgentsView's archive and is not pushed to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,8 @@ self-exits after an idle period. Read-only CLI commands can still open
 `AGENTSVIEW_NO_DAEMON=1` for scripts or CI jobs that must never auto-start a
 daemon.
 
+Cursor attribution stats read `~/.cursor/ai-tracking/ai-code-tracking.db` by default. Set `AGENTSVIEW_CURSOR_ATTRIBUTION_DB` when Cursor stores that database somewhere else on the host you are inspecting.
+
 ## Config File
 
 The config file at `~/.agentsview/config.toml` is auto-created on first run. It

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,12 @@ self-exits after an idle period. Read-only CLI commands can still open
 `AGENTSVIEW_NO_DAEMON=1` for scripts or CI jobs that must never auto-start a
 daemon.
 
-Cursor attribution stats read `~/.cursor/ai-tracking/ai-code-tracking.db` by default. Set `AGENTSVIEW_CURSOR_ATTRIBUTION_DB` when Cursor stores that database somewhere else on the host you are inspecting.
+Cursor attribution stats are a live, machine-local read from
+`~/.cursor/ai-tracking/ai-code-tracking.db` by default. Set
+`AGENTSVIEW_CURSOR_ATTRIBUTION_DB` when Cursor stores that database
+somewhere else on the host answering the stats request. The attribution
+database is not synced into AgentsView's archive and is not pushed to
+PostgreSQL.
 
 ## Config File
 

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -42,8 +42,8 @@ The command pulls together several categories of information:
   (= `abandoned` or `errored`), and `unknown` (= `unknown` plus
   any unrecognized value). The rollup applies to both the human
   summary and the JSON `outcomes` block.
-- **Cursor attribution** — optional Cursor AI code-attribution
-  totals from the host-local Cursor attribution database.
+- **Code attribution** — optional AI-authored code attribution from
+  host-local attribution sources such as Cursor.
 
 ## Automation Scope
 
@@ -94,17 +94,18 @@ AgentsView archive. When the command talks to a local SQLite daemon, the
 daemon answers from that same archive. If it falls back to a direct
 read-only SQLite open, it reads the archive file directly.
 
-Cursor attribution is different: it is not synced session data. When
-present, the `cursor_attribution` block is read live from the Cursor
-attribution database on the host answering the stats request:
+Code attribution is different: it is not synced session data. When
+present, the Cursor source in the `code_attribution.sources` array is
+read live from the Cursor attribution database on the host answering
+the stats request:
 `~/.cursor/ai-tracking/ai-code-tracking.db` by default, or the path in
 `AGENTSVIEW_CURSOR_ATTRIBUTION_DB`.
 
-That means Cursor attribution is machine-local. It is not aggregated
+That means the Cursor source is machine-local. It is not aggregated
 across synced machines, is not pushed to PostgreSQL, and is not available
 from PostgreSQL read-only serving. Project filters cannot be represented
-against Cursor's attribution database, so project-filtered stats report
-`cursor_attribution.status: "unsupported_filter"` instead of silently
+against Cursor's attribution database, so project-filtered stats include
+a Cursor source with `status: "unsupported_filter"` instead of silently
 reporting zero attribution.
 
 ## Human Output
@@ -124,6 +125,7 @@ on the data available in the selected window, you may see:
 - `Temporal`
 - `Outcome stats`
 - `Outcomes`
+- `Code attribution`
 
 Some sections are optional. For example, git-based outcome stats are
 omitted when AgentsView cannot derive any repos from the sessions in
@@ -153,13 +155,18 @@ Optional blocks may also appear:
 - `adoption`
 - `outcome_stats`
 - `outcomes`
-- `cursor_attribution`
+- `code_attribution`
 
-`cursor_attribution.status` reports whether the machine-local Cursor
-database produced records for the requested window. Current statuses are
-`available`, `empty`, `unavailable`, `error`, and `unsupported_filter`.
-Check `cursor_attribution.warnings` before interpreting zero counters as
-zero Cursor activity.
+`code_attribution.sources` lists attribution sources that contributed to
+the selected stats request. Each source carries `provider`, `scope`,
+`status`, optional `warnings`, and provider-specific `metrics`. The
+Cursor source currently uses `scope: "machine_local"`.
+
+Current source statuses are `available`, `empty`, `unavailable`, `error`,
+and `unsupported_filter`. Check a source's `warnings` before interpreting
+missing metrics or zero counters as zero AI code activity. If an agent
+filter excludes Cursor, the Cursor source is omitted. If no source
+contributes, the whole `code_attribution` block is omitted.
 
 Even though the JSON currently includes a version number, it is still
 best to treat it as experimental and additive: expect new fields,

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -42,6 +42,8 @@ The command pulls together several categories of information:
   (= `abandoned` or `errored`), and `unknown` (= `unknown` plus
   any unrecognized value). The rollup applies to both the human
   summary and the JSON `outcomes` block.
+- **Cursor attribution** — optional Cursor AI code-attribution
+  totals from the host-local Cursor attribution database.
 
 ## Automation Scope
 
@@ -85,19 +87,25 @@ agentsview stats --agent claude --include-project my-app
 | `--exclude-project` | | Repeatable project blocklist |
 | `--timezone` | local | Timezone used for temporal reporting |
 
-## Local-Only Behavior
+## Data Scope
 
-Unlike `agentsview session`, this command currently reads the local
-SQLite archive directly. It does **not** proxy through a running
-AgentsView daemon.
+Session-derived stats summarize the selected window in the local
+AgentsView archive. When the command talks to a local SQLite daemon, the
+daemon answers from that same archive. If it falls back to a direct
+read-only SQLite open, it reads the archive file directly.
 
-That means:
+Cursor attribution is different: it is not synced session data. When
+present, the `cursor_attribution` block is read live from the Cursor
+attribution database on the host answering the stats request:
+`~/.cursor/ai-tracking/ai-code-tracking.db` by default, or the path in
+`AGENTSVIEW_CURSOR_ATTRIBUTION_DB`.
 
-- a running `agentsview serve` process is not required
-- the command reflects whatever is already present in the local
-  archive
-- if you want the newest session data first, run
-  `agentsview sync` or `agentsview serve` before using it
+That means Cursor attribution is machine-local. It is not aggregated
+across synced machines, is not pushed to PostgreSQL, and is not available
+from PostgreSQL read-only serving. Project filters cannot be represented
+against Cursor's attribution database, so project-filtered stats report
+`cursor_attribution.status: "unsupported_filter"` instead of silently
+reporting zero attribution.
 
 ## Human Output
 
@@ -145,6 +153,13 @@ Optional blocks may also appear:
 - `adoption`
 - `outcome_stats`
 - `outcomes`
+- `cursor_attribution`
+
+`cursor_attribution.status` reports whether the machine-local Cursor
+database produced records for the requested window. Current statuses are
+`available`, `empty`, `unavailable`, `error`, and `unsupported_filter`.
+Check `cursor_attribution.warnings` before interpreting zero counters as
+zero Cursor activity.
 
 Even though the JSON currently includes a version number, it is still
 best to treat it as experimental and additive: expect new fields,

--- a/internal/db/session_stats_types.go
+++ b/internal/db/session_stats_types.go
@@ -13,22 +13,23 @@ package db
 // reporter's agentsview_version, not schema_version, for non-bump
 // changes.
 type SessionStats struct {
-	SchemaVersion  int                  `json:"schema_version"`
-	Window         StatsWindow          `json:"window"`
-	Filters        StatsFilters         `json:"filters"`
-	Totals         StatsTotals          `json:"totals"`
-	Distributions  StatsDistributions   `json:"distributions"`
-	Archetypes     StatsArchetypes      `json:"archetypes"`
-	Velocity       StatsVelocity        `json:"velocity"`
-	ToolMix        StatsToolMix         `json:"tool_mix"`
-	ModelMix       StatsModelMix        `json:"model_mix"`
-	Adoption       *StatsAdoption       `json:"adoption,omitempty"`
-	AgentPortfolio StatsAgentPortfolio  `json:"agent_portfolio"`
-	CacheEconomics *StatsCacheEconomics `json:"cache_economics,omitempty"`
-	Temporal       StatsTemporal        `json:"temporal"`
-	OutcomeStats   *StatsOutcomeStats   `json:"outcome_stats,omitempty"`
-	Outcomes       *StatsOutcomes       `json:"outcomes,omitempty"`
-	GeneratedAt    string               `json:"generated_at"`
+	SchemaVersion     int                  `json:"schema_version"`
+	Window            StatsWindow          `json:"window"`
+	Filters           StatsFilters         `json:"filters"`
+	Totals            StatsTotals          `json:"totals"`
+	Distributions     StatsDistributions   `json:"distributions"`
+	Archetypes        StatsArchetypes      `json:"archetypes"`
+	Velocity          StatsVelocity        `json:"velocity"`
+	ToolMix           StatsToolMix         `json:"tool_mix"`
+	ModelMix          StatsModelMix        `json:"model_mix"`
+	Adoption          *StatsAdoption       `json:"adoption,omitempty"`
+	AgentPortfolio    StatsAgentPortfolio  `json:"agent_portfolio"`
+	CacheEconomics    *StatsCacheEconomics `json:"cache_economics,omitempty"`
+	Temporal          StatsTemporal        `json:"temporal"`
+	OutcomeStats      *StatsOutcomeStats   `json:"outcome_stats,omitempty"`
+	Outcomes          *StatsOutcomes       `json:"outcomes,omitempty"`
+	CursorAttribution *CursorAttribution   `json:"cursor_attribution,omitempty"`
+	GeneratedAt       string               `json:"generated_at"`
 }
 
 type StatsWindow struct {
@@ -189,4 +190,26 @@ type StatsOutcomes struct {
 	ToolRetryRate         float64        `json:"tool_retry_rate"`
 	CompactionsPerSession float64        `json:"compactions_per_session"`
 	AvgEditChurn          float64        `json:"avg_edit_churn"`
+}
+
+type CursorAttribution struct {
+	ScoredCommits        int64                     `json:"scored_commits"`
+	LinesAdded           int64                     `json:"lines_added"`
+	LinesDeleted         int64                     `json:"lines_deleted"`
+	TabLinesAdded        int64                     `json:"tab_lines_added"`
+	TabLinesDeleted      int64                     `json:"tab_lines_deleted"`
+	ComposerLinesAdded   int64                     `json:"composer_lines_added"`
+	ComposerLinesDeleted int64                     `json:"composer_lines_deleted"`
+	HumanLinesAdded      int64                     `json:"human_lines_added"`
+	HumanLinesDeleted    int64                     `json:"human_lines_deleted"`
+	BlankLinesAdded      int64                     `json:"blank_lines_added"`
+	BlankLinesDeleted    int64                     `json:"blank_lines_deleted"`
+	AIAuthoredPct        float64                   `json:"ai_authored_pct"`
+	ConversationCounts   []CursorConversationCount `json:"conversation_counts,omitempty"`
+}
+
+type CursorConversationCount struct {
+	Model string `json:"model"`
+	Mode  string `json:"mode"`
+	Count int64  `json:"count"`
 }

--- a/internal/db/session_stats_types.go
+++ b/internal/db/session_stats_types.go
@@ -13,23 +13,23 @@ package db
 // reporter's agentsview_version, not schema_version, for non-bump
 // changes.
 type SessionStats struct {
-	SchemaVersion     int                  `json:"schema_version"`
-	Window            StatsWindow          `json:"window"`
-	Filters           StatsFilters         `json:"filters"`
-	Totals            StatsTotals          `json:"totals"`
-	Distributions     StatsDistributions   `json:"distributions"`
-	Archetypes        StatsArchetypes      `json:"archetypes"`
-	Velocity          StatsVelocity        `json:"velocity"`
-	ToolMix           StatsToolMix         `json:"tool_mix"`
-	ModelMix          StatsModelMix        `json:"model_mix"`
-	Adoption          *StatsAdoption       `json:"adoption,omitempty"`
-	AgentPortfolio    StatsAgentPortfolio  `json:"agent_portfolio"`
-	CacheEconomics    *StatsCacheEconomics `json:"cache_economics,omitempty"`
-	Temporal          StatsTemporal        `json:"temporal"`
-	OutcomeStats      *StatsOutcomeStats   `json:"outcome_stats,omitempty"`
-	Outcomes          *StatsOutcomes       `json:"outcomes,omitempty"`
-	CursorAttribution *CursorAttribution   `json:"cursor_attribution,omitempty"`
-	GeneratedAt       string               `json:"generated_at"`
+	SchemaVersion   int                  `json:"schema_version"`
+	Window          StatsWindow          `json:"window"`
+	Filters         StatsFilters         `json:"filters"`
+	Totals          StatsTotals          `json:"totals"`
+	Distributions   StatsDistributions   `json:"distributions"`
+	Archetypes      StatsArchetypes      `json:"archetypes"`
+	Velocity        StatsVelocity        `json:"velocity"`
+	ToolMix         StatsToolMix         `json:"tool_mix"`
+	ModelMix        StatsModelMix        `json:"model_mix"`
+	Adoption        *StatsAdoption       `json:"adoption,omitempty"`
+	AgentPortfolio  StatsAgentPortfolio  `json:"agent_portfolio"`
+	CacheEconomics  *StatsCacheEconomics `json:"cache_economics,omitempty"`
+	Temporal        StatsTemporal        `json:"temporal"`
+	OutcomeStats    *StatsOutcomeStats   `json:"outcome_stats,omitempty"`
+	Outcomes        *StatsOutcomes       `json:"outcomes,omitempty"`
+	CodeAttribution *CodeAttribution     `json:"code_attribution,omitempty"`
+	GeneratedAt     string               `json:"generated_at"`
 }
 
 type StatsWindow struct {
@@ -192,10 +192,19 @@ type StatsOutcomes struct {
 	AvgEditChurn          float64        `json:"avg_edit_churn"`
 }
 
-type CursorAttribution struct {
-	Status               string                    `json:"status"`
-	Scope                string                    `json:"scope"`
-	Warnings             []string                  `json:"warnings,omitempty"`
+type CodeAttribution struct {
+	Sources []CodeAttributionSource `json:"sources,omitempty"`
+}
+
+type CodeAttributionSource struct {
+	Provider string                    `json:"provider"`
+	Scope    string                    `json:"scope"`
+	Status   string                    `json:"status"`
+	Warnings []string                  `json:"warnings,omitempty"`
+	Metrics  *CursorAttributionMetrics `json:"metrics,omitempty"`
+}
+
+type CursorAttributionMetrics struct {
 	ScoredCommits        int64                     `json:"scored_commits"`
 	LinesAdded           int64                     `json:"lines_added"`
 	LinesDeleted         int64                     `json:"lines_deleted"`

--- a/internal/db/session_stats_types.go
+++ b/internal/db/session_stats_types.go
@@ -193,6 +193,9 @@ type StatsOutcomes struct {
 }
 
 type CursorAttribution struct {
+	Status               string                    `json:"status"`
+	Scope                string                    `json:"scope"`
+	Warnings             []string                  `json:"warnings,omitempty"`
 	ScoredCommits        int64                     `json:"scored_commits"`
 	LinesAdded           int64                     `json:"lines_added"`
 	LinesDeleted         int64                     `json:"lines_deleted"`

--- a/internal/parser/cursor_attribution.go
+++ b/internal/parser/cursor_attribution.go
@@ -160,9 +160,12 @@ func cursorAttributionDBPath() string {
 }
 
 func openCursorAttributionDB(path string) (*sql.DB, error) {
+	// The file: prefix is required for go-sqlite3 to honor mode=ro;
+	// without it the query string is dropped and the live Cursor db
+	// would be opened read-write.
 	conn, err := sql.Open(
 		"sqlite3",
-		path+"?mode=ro&_busy_timeout=3000",
+		"file:"+path+"?mode=ro&_busy_timeout=3000",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("opening cursor attribution db: %w", err)

--- a/internal/parser/cursor_attribution.go
+++ b/internal/parser/cursor_attribution.go
@@ -93,8 +93,8 @@ func LoadCursorAttribution(
 			COUNT(*)
 		FROM conversation_summaries
 		WHERE updatedAt >= ? AND updatedAt < ?
-		GROUP BY model, mode
-		ORDER BY COUNT(*) DESC, model, mode`,
+		GROUP BY COALESCE(model, ''), COALESCE(mode, '')
+		ORDER BY COUNT(*) DESC, COALESCE(model, ''), COALESCE(mode, '')`,
 		timeToMillis(from), timeToMillis(to),
 	)
 	if err != nil {

--- a/internal/parser/cursor_attribution.go
+++ b/internal/parser/cursor_attribution.go
@@ -1,0 +1,186 @@
+package parser
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type CursorAttribution struct {
+	ScoredCommits        int64                     `json:"scored_commits"`
+	LinesAdded           int64                     `json:"lines_added"`
+	LinesDeleted         int64                     `json:"lines_deleted"`
+	TabLinesAdded        int64                     `json:"tab_lines_added"`
+	TabLinesDeleted      int64                     `json:"tab_lines_deleted"`
+	ComposerLinesAdded   int64                     `json:"composer_lines_added"`
+	ComposerLinesDeleted int64                     `json:"composer_lines_deleted"`
+	HumanLinesAdded      int64                     `json:"human_lines_added"`
+	HumanLinesDeleted    int64                     `json:"human_lines_deleted"`
+	BlankLinesAdded      int64                     `json:"blank_lines_added"`
+	BlankLinesDeleted    int64                     `json:"blank_lines_deleted"`
+	AIAuthoredPct        float64                   `json:"ai_authored_pct"`
+	ConversationCounts   []CursorConversationCount `json:"conversation_counts,omitempty"`
+}
+
+type CursorConversationCount struct {
+	Model string `json:"model"`
+	Mode  string `json:"mode"`
+	Count int64  `json:"count"`
+}
+
+func LoadCursorAttribution(
+	from, to time.Time,
+) (*CursorAttribution, error) {
+	dbPath := cursorAttributionDBPath()
+	if dbPath == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat cursor attribution db: %w", err)
+	}
+
+	conn, err := openCursorAttributionDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	attr := &CursorAttribution{}
+	if err := conn.QueryRow(
+		`SELECT
+			COUNT(*),
+			COALESCE(SUM(linesAdded), 0),
+			COALESCE(SUM(linesDeleted), 0),
+			COALESCE(SUM(tabLinesAdded), 0),
+			COALESCE(SUM(tabLinesDeleted), 0),
+			COALESCE(SUM(composerLinesAdded), 0),
+			COALESCE(SUM(composerLinesDeleted), 0),
+			COALESCE(SUM(humanLinesAdded), 0),
+			COALESCE(SUM(humanLinesDeleted), 0),
+			COALESCE(SUM(blankLinesAdded), 0),
+			COALESCE(SUM(blankLinesDeleted), 0)
+		FROM scored_commits
+		WHERE scoredAt >= ? AND scoredAt < ?`,
+		timeToMillis(from), timeToMillis(to),
+	).Scan(
+		&attr.ScoredCommits,
+		&attr.LinesAdded,
+		&attr.LinesDeleted,
+		&attr.TabLinesAdded,
+		&attr.TabLinesDeleted,
+		&attr.ComposerLinesAdded,
+		&attr.ComposerLinesDeleted,
+		&attr.HumanLinesAdded,
+		&attr.HumanLinesDeleted,
+		&attr.BlankLinesAdded,
+		&attr.BlankLinesDeleted,
+	); err != nil {
+		return nil, fmt.Errorf("querying scored_commits: %w", err)
+	}
+
+	rows, err := conn.Query(
+		`SELECT
+			COALESCE(model, ''),
+			COALESCE(mode, ''),
+			COUNT(*)
+		FROM conversation_summaries
+		WHERE updatedAt >= ? AND updatedAt < ?
+		GROUP BY model, mode
+		ORDER BY COUNT(*) DESC, model, mode`,
+		timeToMillis(from), timeToMillis(to),
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"querying conversation_summaries: %w", err,
+		)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var entry CursorConversationCount
+		if err := rows.Scan(
+			&entry.Model, &entry.Mode, &entry.Count,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"scanning conversation_summaries: %w", err,
+			)
+		}
+		attr.ConversationCounts = append(
+			attr.ConversationCounts, entry,
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"iterating conversation_summaries: %w", err,
+		)
+	}
+	sortCursorConversationCounts(attr.ConversationCounts)
+
+	if attr.ScoredCommits == 0 &&
+		attr.LinesAdded == 0 &&
+		attr.LinesDeleted == 0 &&
+		len(attr.ConversationCounts) == 0 {
+		return nil, nil
+	}
+
+	aiLines := attr.TabLinesAdded + attr.ComposerLinesAdded
+	denom := aiLines + attr.HumanLinesAdded
+	if denom > 0 {
+		attr.AIAuthoredPct = float64(aiLines) / float64(denom)
+	}
+
+	return attr, nil
+}
+
+func cursorAttributionDBPath() string {
+	if path := os.Getenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB"); path != "" {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".cursor", "ai-tracking", "ai-code-tracking.db")
+}
+
+func openCursorAttributionDB(path string) (*sql.DB, error) {
+	conn, err := sql.Open(
+		"sqlite3",
+		path+"?mode=ro&_busy_timeout=3000",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("opening cursor attribution db: %w", err)
+	}
+	conn.SetMaxOpenConns(1)
+	if err := conn.Ping(); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("opening cursor attribution db: %w", err)
+	}
+	return conn, nil
+}
+
+func timeToMillis(t time.Time) int64 {
+	return t.UTC().UnixNano() / int64(time.Millisecond)
+}
+
+func sortCursorConversationCounts(
+	counts []CursorConversationCount,
+) {
+	sort.Slice(counts, func(i, j int) bool {
+		if counts[i].Count != counts[j].Count {
+			return counts[i].Count > counts[j].Count
+		}
+		if counts[i].Model != counts[j].Model {
+			return counts[i].Model < counts[j].Model
+		}
+		return counts[i].Mode < counts[j].Mode
+	})
+}

--- a/internal/parser/cursor_attribution.go
+++ b/internal/parser/cursor_attribution.go
@@ -68,7 +68,7 @@ func LoadCursorAttribution(
 			COALESCE(SUM(blankLinesAdded), 0),
 			COALESCE(SUM(blankLinesDeleted), 0)
 		FROM scored_commits
-		WHERE scoredAt >= ? AND scoredAt < ?`,
+		WHERE commitDate >= ? AND commitDate < ?`,
 		timeToMillis(from), timeToMillis(to),
 	).Scan(
 		&attr.ScoredCommits,
@@ -132,7 +132,7 @@ func LoadCursorAttribution(
 	}
 
 	aiLines := attr.TabLinesAdded + attr.ComposerLinesAdded
-	denom := aiLines + attr.HumanLinesAdded
+	denom := attr.LinesAdded
 	if denom > 0 {
 		attr.AIAuthoredPct = float64(aiLines) / float64(denom)
 	}

--- a/internal/parser/cursor_attribution.go
+++ b/internal/parser/cursor_attribution.go
@@ -68,7 +68,7 @@ func LoadCursorAttribution(
 			COALESCE(SUM(blankLinesAdded), 0),
 			COALESCE(SUM(blankLinesDeleted), 0)
 		FROM scored_commits
-		WHERE commitDate >= ? AND commitDate < ?`,
+		WHERE scoredAt >= ? AND scoredAt < ?`,
 		timeToMillis(from), timeToMillis(to),
 	).Scan(
 		&attr.ScoredCommits,

--- a/internal/parser/cursor_attribution.go
+++ b/internal/parser/cursor_attribution.go
@@ -27,6 +27,14 @@ type CursorAttribution struct {
 	ConversationCounts   []CursorConversationCount `json:"conversation_counts,omitempty"`
 }
 
+type CursorAttributionStatus string
+
+const (
+	CursorAttributionAvailable   CursorAttributionStatus = "available"
+	CursorAttributionEmpty       CursorAttributionStatus = "empty"
+	CursorAttributionUnavailable CursorAttributionStatus = "unavailable"
+)
+
 type CursorConversationCount struct {
 	Model string `json:"model"`
 	Mode  string `json:"mode"`
@@ -35,21 +43,21 @@ type CursorConversationCount struct {
 
 func LoadCursorAttribution(
 	from, to time.Time,
-) (*CursorAttribution, error) {
+) (*CursorAttribution, CursorAttributionStatus, error) {
 	dbPath := cursorAttributionDBPath()
 	if dbPath == "" {
-		return nil, nil
+		return nil, CursorAttributionUnavailable, nil
 	}
 	if _, err := os.Stat(dbPath); err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, CursorAttributionUnavailable, nil
 		}
-		return nil, fmt.Errorf("stat cursor attribution db: %w", err)
+		return nil, "", fmt.Errorf("stat cursor attribution db: %w", err)
 	}
 
 	conn, err := openCursorAttributionDB(dbPath)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer conn.Close()
 
@@ -83,7 +91,7 @@ func LoadCursorAttribution(
 		&attr.BlankLinesAdded,
 		&attr.BlankLinesDeleted,
 	); err != nil {
-		return nil, fmt.Errorf("querying scored_commits: %w", err)
+		return nil, "", fmt.Errorf("querying scored_commits: %w", err)
 	}
 
 	rows, err := conn.Query(
@@ -98,7 +106,7 @@ func LoadCursorAttribution(
 		timeToMillis(from), timeToMillis(to),
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, "", fmt.Errorf(
 			"querying conversation_summaries: %w", err,
 		)
 	}
@@ -109,7 +117,7 @@ func LoadCursorAttribution(
 		if err := rows.Scan(
 			&entry.Model, &entry.Mode, &entry.Count,
 		); err != nil {
-			return nil, fmt.Errorf(
+			return nil, "", fmt.Errorf(
 				"scanning conversation_summaries: %w", err,
 			)
 		}
@@ -118,7 +126,7 @@ func LoadCursorAttribution(
 		)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf(
+		return nil, "", fmt.Errorf(
 			"iterating conversation_summaries: %w", err,
 		)
 	}
@@ -128,7 +136,7 @@ func LoadCursorAttribution(
 		attr.LinesAdded == 0 &&
 		attr.LinesDeleted == 0 &&
 		len(attr.ConversationCounts) == 0 {
-		return nil, nil
+		return nil, CursorAttributionEmpty, nil
 	}
 
 	aiLines := attr.TabLinesAdded + attr.ComposerLinesAdded
@@ -137,7 +145,7 @@ func LoadCursorAttribution(
 		attr.AIAuthoredPct = float64(aiLines) / float64(denom)
 	}
 
-	return attr, nil
+	return attr, CursorAttributionAvailable, nil
 }
 
 func cursorAttributionDBPath() string {

--- a/internal/parser/cursor_attribution_test.go
+++ b/internal/parser/cursor_attribution_test.go
@@ -33,7 +33,7 @@ func TestLoadCursorAttribution_Happy(t *testing.T) {
 	require.Len(t, got.ConversationCounts, 2)
 	assert.Equal(t, "model-a", got.ConversationCounts[0].Model)
 	assert.Equal(t, "composer", got.ConversationCounts[0].Mode)
-	assert.Equal(t, int64(2), got.ConversationCounts[0].Count)
+	assert.Equal(t, int64(3), got.ConversationCounts[0].Count)
 }
 
 func TestLoadCursorAttribution_MissingDB(t *testing.T) {
@@ -46,6 +46,39 @@ func TestLoadCursorAttribution_MissingDB(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Nil(t, got)
+}
+
+func TestLoadCursorAttribution_NormalizesEmptyConversationKeys(t *testing.T) {
+	path := seedCursorAttributionDBTest(t)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", path)
+
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ts := time.Date(2026, 6, 1, 14, 0, 0, 0, time.UTC).UnixMilli()
+	_, err = conn.Exec(`
+		INSERT INTO conversation_summaries (model, mode, updatedAt) VALUES
+			(NULL, NULL, ?),
+			('', '', ?)
+	`, ts, ts)
+	require.NoError(t, err)
+
+	got, err := LoadCursorAttribution(
+		time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	emptyRows := 0
+	for _, entry := range got.ConversationCounts {
+		if entry.Model == "" && entry.Mode == "" {
+			emptyRows++
+			assert.Equal(t, int64(2), entry.Count)
+		}
+	}
+	assert.Equal(t, 1, emptyRows)
 }
 
 func seedCursorAttributionDBTest(t *testing.T) string {
@@ -76,8 +109,8 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 	require.NoError(t, err)
 	_, err = conn.Exec(`
 		CREATE TABLE conversation_summaries (
-			model TEXT NOT NULL,
-			mode TEXT NOT NULL,
+			model TEXT,
+			mode TEXT,
 			updatedAt INTEGER NOT NULL
 		)
 	`)
@@ -111,8 +144,9 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 		INSERT INTO conversation_summaries (model, mode, updatedAt) VALUES
 			('model-a', 'composer', ?),
 			('model-a', 'composer', ?),
+			('model-a', 'composer', ?),
 			('model-a', 'tab', ?)
-	`, first, second, second)
+	`, first, second, second, second)
 	require.NoError(t, err)
 	return path
 }

--- a/internal/parser/cursor_attribution_test.go
+++ b/internal/parser/cursor_attribution_test.go
@@ -1,0 +1,108 @@
+package parser
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCursorAttribution_Happy(t *testing.T) {
+	path := seedCursorAttributionDBTest(t)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", path)
+
+	from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+
+	got, err := LoadCursorAttribution(from, to)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, int64(2), got.ScoredCommits)
+	assert.Equal(t, int64(15), got.LinesAdded)
+	assert.Equal(t, int64(6), got.LinesDeleted)
+	assert.Equal(t, int64(6), got.TabLinesAdded)
+	assert.Equal(t, int64(4), got.ComposerLinesAdded)
+	assert.Equal(t, int64(5), got.HumanLinesAdded)
+	assert.InDelta(t, 10.0/15.0, got.AIAuthoredPct, 1e-9)
+	require.Len(t, got.ConversationCounts, 2)
+	assert.Equal(t, "model-a", got.ConversationCounts[0].Model)
+	assert.Equal(t, "composer", got.ConversationCounts[0].Mode)
+	assert.Equal(t, int64(2), got.ConversationCounts[0].Count)
+}
+
+func TestLoadCursorAttribution_MissingDB(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.db")
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", missing)
+
+	got, err := LoadCursorAttribution(
+		time.Unix(0, 0).UTC(),
+		time.Unix(0, 1).UTC(),
+	)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func seedCursorAttributionDBTest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ai-code-tracking.db")
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = conn.Exec(`
+		CREATE TABLE scored_commits (
+			commitHash TEXT PRIMARY KEY,
+			scoredAt INTEGER NOT NULL,
+			linesAdded INTEGER NOT NULL DEFAULT 0,
+			linesDeleted INTEGER NOT NULL DEFAULT 0,
+			tabLinesAdded INTEGER NOT NULL DEFAULT 0,
+			tabLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			composerLinesAdded INTEGER NOT NULL DEFAULT 0,
+			composerLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			humanLinesAdded INTEGER NOT NULL DEFAULT 0,
+			humanLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			blankLinesAdded INTEGER NOT NULL DEFAULT 0,
+			blankLinesDeleted INTEGER NOT NULL DEFAULT 0
+		)
+	`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`
+		CREATE TABLE conversation_summaries (
+			model TEXT NOT NULL,
+			mode TEXT NOT NULL,
+			updatedAt INTEGER NOT NULL
+		)
+	`)
+	require.NoError(t, err)
+
+	first := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC).UnixMilli()
+	second := time.Date(2026, 6, 1, 13, 0, 0, 0, time.UTC).UnixMilli()
+
+	_, err = conn.Exec(`
+		INSERT INTO scored_commits (
+			commitHash, scoredAt,
+			linesAdded, linesDeleted,
+			tabLinesAdded, tabLinesDeleted,
+			composerLinesAdded, composerLinesDeleted,
+			humanLinesAdded, humanLinesDeleted,
+			blankLinesAdded, blankLinesDeleted
+		) VALUES
+			('c1', ?, 10, 4, 6, 1, 3, 1, 1, 2, 0, 0),
+			('c2', ?, 5, 2, 0, 0, 1, 0, 4, 1, 0, 0)
+	`, first, second)
+	require.NoError(t, err)
+	_, err = conn.Exec(`
+		INSERT INTO conversation_summaries (model, mode, updatedAt) VALUES
+			('model-a', 'composer', ?),
+			('model-a', 'composer', ?),
+			('model-a', 'tab', ?)
+	`, first, second, second)
+	require.NoError(t, err)
+	return path
+}

--- a/internal/parser/cursor_attribution_test.go
+++ b/internal/parser/cursor_attribution_test.go
@@ -93,7 +93,7 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 		CREATE TABLE scored_commits (
 			commitHash TEXT PRIMARY KEY,
 			scoredAt INTEGER NOT NULL,
-			commitDate INTEGER NOT NULL,
+			commitDate TEXT NOT NULL,
 			linesAdded INTEGER NOT NULL DEFAULT 0,
 			linesDeleted INTEGER NOT NULL DEFAULT 0,
 			tabLinesAdded INTEGER NOT NULL DEFAULT 0,
@@ -118,6 +118,12 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 
 	first := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC).UnixMilli()
 	second := time.Date(2026, 6, 1, 13, 0, 0, 0, time.UTC).UnixMilli()
+	insideA := time.Date(2026, 6, 1, 8, 0, 0, 0,
+		time.FixedZone("EDT", -4*60*60))
+	insideB := time.Date(2026, 6, 3, 10, 0, 0, 0,
+		time.FixedZone("EDT", -4*60*60))
+	outside := time.Date(2026, 6, 1, 15, 0, 0, 0,
+		time.FixedZone("EDT", -4*60*60))
 
 	_, err = conn.Exec(`
 		INSERT INTO scored_commits (
@@ -132,12 +138,12 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 			('c2', ?, ?, 6, 2, 0, 0, 1, 0, 4, 1, 1, 0),
 			('c3', ?, ?, 99, 1, 50, 0, 40, 0, 9, 0, 0, 0)
 	`,
-		time.Date(2026, 5, 31, 23, 0, 0, 0, time.UTC).UnixMilli(),
 		first,
-		time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		formatCursorCommitDate(insideA),
 		second,
-		first,
+		formatCursorCommitDate(insideB),
 		time.Date(2026, 6, 3, 10, 0, 0, 0, time.UTC).UnixMilli(),
+		formatCursorCommitDate(outside),
 	)
 	require.NoError(t, err)
 	_, err = conn.Exec(`
@@ -149,4 +155,8 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 	`, first, second, second, second)
 	require.NoError(t, err)
 	return path
+}
+
+func formatCursorCommitDate(t time.Time) string {
+	return t.Format("Mon Jan 2 15:04:05 2006 -0700")
 }

--- a/internal/parser/cursor_attribution_test.go
+++ b/internal/parser/cursor_attribution_test.go
@@ -23,12 +23,13 @@ func TestLoadCursorAttribution_Happy(t *testing.T) {
 	require.NotNil(t, got)
 
 	assert.Equal(t, int64(2), got.ScoredCommits)
-	assert.Equal(t, int64(15), got.LinesAdded)
+	assert.Equal(t, int64(18), got.LinesAdded)
 	assert.Equal(t, int64(6), got.LinesDeleted)
 	assert.Equal(t, int64(6), got.TabLinesAdded)
 	assert.Equal(t, int64(4), got.ComposerLinesAdded)
 	assert.Equal(t, int64(5), got.HumanLinesAdded)
-	assert.InDelta(t, 10.0/15.0, got.AIAuthoredPct, 1e-9)
+	assert.Equal(t, int64(3), got.BlankLinesAdded)
+	assert.InDelta(t, 10.0/18.0, got.AIAuthoredPct, 1e-9)
 	require.Len(t, got.ConversationCounts, 2)
 	assert.Equal(t, "model-a", got.ConversationCounts[0].Model)
 	assert.Equal(t, "composer", got.ConversationCounts[0].Mode)
@@ -59,6 +60,7 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 		CREATE TABLE scored_commits (
 			commitHash TEXT PRIMARY KEY,
 			scoredAt INTEGER NOT NULL,
+			commitDate INTEGER NOT NULL,
 			linesAdded INTEGER NOT NULL DEFAULT 0,
 			linesDeleted INTEGER NOT NULL DEFAULT 0,
 			tabLinesAdded INTEGER NOT NULL DEFAULT 0,
@@ -86,16 +88,24 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 
 	_, err = conn.Exec(`
 		INSERT INTO scored_commits (
-			commitHash, scoredAt,
+			commitHash, scoredAt, commitDate,
 			linesAdded, linesDeleted,
 			tabLinesAdded, tabLinesDeleted,
 			composerLinesAdded, composerLinesDeleted,
 			humanLinesAdded, humanLinesDeleted,
 			blankLinesAdded, blankLinesDeleted
 		) VALUES
-			('c1', ?, 10, 4, 6, 1, 3, 1, 1, 2, 0, 0),
-			('c2', ?, 5, 2, 0, 0, 1, 0, 4, 1, 0, 0)
-	`, first, second)
+			('c1', ?, ?, 12, 4, 6, 1, 3, 1, 1, 2, 2, 0),
+			('c2', ?, ?, 6, 2, 0, 0, 1, 0, 4, 1, 1, 0),
+			('c3', ?, ?, 99, 1, 50, 0, 40, 0, 9, 0, 0, 0)
+	`,
+		time.Date(2026, 5, 31, 23, 0, 0, 0, time.UTC).UnixMilli(),
+		first,
+		time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		second,
+		first,
+		time.Date(2026, 6, 3, 10, 0, 0, 0, time.UTC).UnixMilli(),
+	)
 	require.NoError(t, err)
 	_, err = conn.Exec(`
 		INSERT INTO conversation_summaries (model, mode, updatedAt) VALUES

--- a/internal/parser/cursor_attribution_test.go
+++ b/internal/parser/cursor_attribution_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -10,6 +11,37 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Cursor owns and actively writes ai-code-tracking.db; agentsview must
+// never hold a writable handle on it.
+func TestOpenCursorAttributionDB_ReadOnly(t *testing.T) {
+	path := seedCursorAttributionDBTest(t)
+
+	conn, err := openCursorAttributionDB(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = conn.Exec(
+		`INSERT INTO conversation_summaries (model, mode, updatedAt)
+		 VALUES ('m', 'tab', 0)`,
+	)
+	require.ErrorContains(t, err, "readonly database",
+		"attribution db handle must reject writes")
+}
+
+func TestOpenCursorAttributionDB_DoesNotCreateMissingDB(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.db")
+
+	conn, err := openCursorAttributionDB(missing)
+	if err == nil {
+		_ = conn.Close()
+	}
+	require.Error(t, err,
+		"read-only open of a missing db must fail, not create it")
+	_, statErr := os.Stat(missing)
+	assert.True(t, os.IsNotExist(statErr),
+		"open must not create the attribution db file")
+}
 
 func TestLoadCursorAttribution_Happy(t *testing.T) {
 	path := seedCursorAttributionDBTest(t)

--- a/internal/parser/cursor_attribution_test.go
+++ b/internal/parser/cursor_attribution_test.go
@@ -18,9 +18,10 @@ func TestLoadCursorAttribution_Happy(t *testing.T) {
 	from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
 
-	got, err := LoadCursorAttribution(from, to)
+	got, status, err := LoadCursorAttribution(from, to)
 	require.NoError(t, err)
 	require.NotNil(t, got)
+	assert.Equal(t, CursorAttributionAvailable, status)
 
 	assert.Equal(t, int64(2), got.ScoredCommits)
 	assert.Equal(t, int64(18), got.LinesAdded)
@@ -40,12 +41,26 @@ func TestLoadCursorAttribution_MissingDB(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing.db")
 	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", missing)
 
-	got, err := LoadCursorAttribution(
+	got, status, err := LoadCursorAttribution(
 		time.Unix(0, 0).UTC(),
 		time.Unix(0, 1).UTC(),
 	)
 	require.NoError(t, err)
 	assert.Nil(t, got)
+	assert.Equal(t, CursorAttributionUnavailable, status)
+}
+
+func TestLoadCursorAttribution_EmptyDB(t *testing.T) {
+	path := seedEmptyCursorAttributionDBTest(t)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", path)
+
+	got, status, err := LoadCursorAttribution(
+		time.Unix(0, 0).UTC(),
+		time.Unix(0, 1).UTC(),
+	)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+	assert.Equal(t, CursorAttributionEmpty, status)
 }
 
 func TestLoadCursorAttribution_NormalizesEmptyConversationKeys(t *testing.T) {
@@ -64,12 +79,13 @@ func TestLoadCursorAttribution_NormalizesEmptyConversationKeys(t *testing.T) {
 	`, ts, ts)
 	require.NoError(t, err)
 
-	got, err := LoadCursorAttribution(
+	got, status, err := LoadCursorAttribution(
 		time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
 		time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, got)
+	assert.Equal(t, CursorAttributionAvailable, status)
 
 	emptyRows := 0
 	for _, entry := range got.ConversationCounts {
@@ -153,6 +169,43 @@ func seedCursorAttributionDBTest(t *testing.T) string {
 			('model-a', 'composer', ?),
 			('model-a', 'tab', ?)
 	`, first, second, second, second)
+	require.NoError(t, err)
+	return path
+}
+
+func seedEmptyCursorAttributionDBTest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ai-code-tracking.db")
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = conn.Exec(`
+		CREATE TABLE scored_commits (
+			commitHash TEXT PRIMARY KEY,
+			scoredAt INTEGER NOT NULL,
+			commitDate TEXT NOT NULL,
+			linesAdded INTEGER NOT NULL DEFAULT 0,
+			linesDeleted INTEGER NOT NULL DEFAULT 0,
+			tabLinesAdded INTEGER NOT NULL DEFAULT 0,
+			tabLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			composerLinesAdded INTEGER NOT NULL DEFAULT 0,
+			composerLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			humanLinesAdded INTEGER NOT NULL DEFAULT 0,
+			humanLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			blankLinesAdded INTEGER NOT NULL DEFAULT 0,
+			blankLinesDeleted INTEGER NOT NULL DEFAULT 0
+		)
+	`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`
+		CREATE TABLE conversation_summaries (
+			model TEXT,
+			mode TEXT,
+			updatedAt INTEGER NOT NULL
+		)
+	`)
 	require.NoError(t, err)
 	return path
 }

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -703,7 +703,7 @@ func (b *directBackend) Stats(
 	if b.local == nil {
 		return nil, db.ErrReadOnly
 	}
-	return b.local.GetSessionStats(ctx, db.StatsFilter{
+	stats, err := b.local.GetSessionStats(ctx, db.StatsFilter{
 		Since:                 f.Since,
 		Until:                 f.Until,
 		Agent:                 f.Agent,
@@ -714,4 +714,85 @@ func (b *directBackend) Stats(
 		IncludeGitHubOutcomes: f.IncludeGitHubOutcomes,
 		GHToken:               f.GHToken,
 	})
+	if err != nil {
+		return nil, err
+	}
+	attachCursorAttribution(stats, f)
+	return stats, nil
+}
+
+func attachCursorAttribution(stats *SessionStats, f StatsFilter) {
+	if stats == nil || !shouldLoadCursorAttribution(f) {
+		return
+	}
+	from, err := time.Parse(time.RFC3339, stats.Window.Since)
+	if err != nil {
+		return
+	}
+	to, err := time.Parse(time.RFC3339, stats.Window.Until)
+	if err != nil {
+		return
+	}
+	attr, err := parser.LoadCursorAttribution(from, to)
+	if err != nil || attr == nil {
+		return
+	}
+	stats.CursorAttribution = mapCursorAttribution(attr)
+}
+
+func shouldLoadCursorAttribution(f StatsFilter) bool {
+	agents := strings.Split(f.Agent, ",")
+	seen := 0
+	for _, agent := range agents {
+		agent = strings.TrimSpace(agent)
+		if agent == "" {
+			continue
+		}
+		seen++
+		if agent == "cursor" || agent == "all" {
+			return true
+		}
+	}
+	return seen == 0
+}
+
+func mapCursorAttribution(
+	attr *parser.CursorAttribution,
+) *db.CursorAttribution {
+	if attr == nil {
+		return nil
+	}
+	out := &db.CursorAttribution{
+		ScoredCommits:        attr.ScoredCommits,
+		LinesAdded:           attr.LinesAdded,
+		LinesDeleted:         attr.LinesDeleted,
+		TabLinesAdded:        attr.TabLinesAdded,
+		TabLinesDeleted:      attr.TabLinesDeleted,
+		ComposerLinesAdded:   attr.ComposerLinesAdded,
+		ComposerLinesDeleted: attr.ComposerLinesDeleted,
+		HumanLinesAdded:      attr.HumanLinesAdded,
+		HumanLinesDeleted:    attr.HumanLinesDeleted,
+		BlankLinesAdded:      attr.BlankLinesAdded,
+		BlankLinesDeleted:    attr.BlankLinesDeleted,
+		AIAuthoredPct:        attr.AIAuthoredPct,
+	}
+	if len(attr.ConversationCounts) == 0 {
+		return out
+	}
+	out.ConversationCounts = make(
+		[]db.CursorConversationCount,
+		0,
+		len(attr.ConversationCounts),
+	)
+	for _, entry := range attr.ConversationCounts {
+		out.ConversationCounts = append(
+			out.ConversationCounts,
+			db.CursorConversationCount{
+				Model: entry.Model,
+				Mode:  entry.Mode,
+				Count: entry.Count,
+			},
+		)
+	}
+	return out
 }

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -741,6 +741,9 @@ func attachCursorAttribution(stats *SessionStats, f StatsFilter) {
 }
 
 func shouldLoadCursorAttribution(f StatsFilter) bool {
+	if len(f.IncludeProjects) > 0 || len(f.ExcludeProjects) > 0 {
+		return false
+	}
 	agents := strings.Split(f.Agent, ",")
 	seen := 0
 	for _, agent := range agents {

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -723,22 +723,44 @@ func (b *directBackend) Stats(
 }
 
 func attachCursorAttribution(stats *SessionStats, f StatsFilter) {
-	if stats == nil || !shouldLoadCursorAttribution(f) {
+	if stats == nil {
+		return
+	}
+	switch cursorAttributionDecision(f) {
+	case cursorAttributionSkip:
+		return
+	case cursorAttributionUnsupportedProjectFilter:
+		stats.CursorAttribution = cursorAttributionStatus(
+			"unsupported_filter",
+			"Cursor attribution is machine-local and cannot be scoped by project filters",
+		)
 		return
 	}
 	from, err := time.Parse(time.RFC3339, stats.Window.Since)
 	if err != nil {
+		stats.CursorAttribution = cursorAttributionStatus(
+			"error",
+			"failed to parse stats window for Cursor attribution",
+		)
 		return
 	}
 	to, err := time.Parse(time.RFC3339, stats.Window.Until)
 	if err != nil {
+		stats.CursorAttribution = cursorAttributionStatus(
+			"error",
+			"failed to parse stats window for Cursor attribution",
+		)
 		return
 	}
-	attr, err := parser.LoadCursorAttribution(from, to)
-	if err != nil || attr == nil {
+	attr, status, err := parser.LoadCursorAttribution(from, to)
+	if err != nil {
+		stats.CursorAttribution = cursorAttributionStatus(
+			"error",
+			"failed to load Cursor attribution: "+err.Error(),
+		)
 		return
 	}
-	stats.CursorAttribution = mapCursorAttribution(attr)
+	stats.CursorAttribution = mapCursorAttribution(attr, status)
 }
 
 func normalizeStatsAgentFilter(raw string) string {
@@ -754,12 +776,19 @@ func normalizeStatsAgentFilter(raw string) string {
 	return strings.Join(filtered, ",")
 }
 
-func shouldLoadCursorAttribution(f StatsFilter) bool {
-	if len(f.IncludeProjects) > 0 || len(f.ExcludeProjects) > 0 {
-		return false
-	}
+type cursorAttributionLoadDecision int
+
+const (
+	cursorAttributionLoad cursorAttributionLoadDecision = iota
+	cursorAttributionSkip
+	cursorAttributionUnsupportedProjectFilter
+	cursorAttributionScopeMachineLocal = "machine_local"
+)
+
+func cursorAttributionDecision(f StatsFilter) cursorAttributionLoadDecision {
 	agents := strings.Split(normalizeStatsAgentFilter(f.Agent), ",")
 	seen := 0
+	hasCursor := false
 	for _, agent := range agents {
 		agent = strings.TrimSpace(agent)
 		if agent == "" {
@@ -767,19 +796,34 @@ func shouldLoadCursorAttribution(f StatsFilter) bool {
 		}
 		seen++
 		if agent == "cursor" {
-			return true
+			hasCursor = true
 		}
 	}
-	return seen == 0
+	if seen > 0 && !hasCursor {
+		return cursorAttributionSkip
+	}
+	if len(f.IncludeProjects) > 0 || len(f.ExcludeProjects) > 0 {
+		return cursorAttributionUnsupportedProjectFilter
+	}
+	return cursorAttributionLoad
 }
 
 func mapCursorAttribution(
 	attr *parser.CursorAttribution,
+	status parser.CursorAttributionStatus,
 ) *db.CursorAttribution {
 	if attr == nil {
-		return nil
+		out := cursorAttributionStatus(string(status), "")
+		if status == parser.CursorAttributionUnavailable {
+			out.Warnings = []string{
+				"Cursor attribution database is unavailable on this machine",
+			}
+		}
+		return out
 	}
 	out := &db.CursorAttribution{
+		Status:               string(status),
+		Scope:                cursorAttributionScopeMachineLocal,
 		ScoredCommits:        attr.ScoredCommits,
 		LinesAdded:           attr.LinesAdded,
 		LinesDeleted:         attr.LinesDeleted,
@@ -810,6 +854,17 @@ func mapCursorAttribution(
 				Count: entry.Count,
 			},
 		)
+	}
+	return out
+}
+
+func cursorAttributionStatus(status, warning string) *db.CursorAttribution {
+	out := &db.CursorAttribution{
+		Status: status,
+		Scope:  cursorAttributionScopeMachineLocal,
+	}
+	if warning != "" {
+		out.Warnings = []string{warning}
 	}
 	return out
 }

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -718,49 +718,71 @@ func (b *directBackend) Stats(
 	if err != nil {
 		return nil, err
 	}
-	attachCursorAttribution(stats, f)
+	stats.CodeAttribution = collectCodeAttribution(f, stats)
 	return stats, nil
 }
 
-func attachCursorAttribution(stats *SessionStats, f StatsFilter) {
+func collectCodeAttribution(
+	f StatsFilter,
+	stats *SessionStats,
+) *db.CodeAttribution {
 	if stats == nil {
-		return
+		return nil
 	}
+	sources := []db.CodeAttributionSource{}
+	if source, ok := collectCursorAttribution(f, stats); ok {
+		sources = append(sources, source)
+	}
+	if len(sources) == 0 {
+		return nil
+	}
+	slices.SortFunc(sources, func(a, b db.CodeAttributionSource) int {
+		if n := strings.Compare(a.Provider, b.Provider); n != 0 {
+			return n
+		}
+		if n := strings.Compare(a.Scope, b.Scope); n != 0 {
+			return n
+		}
+		return strings.Compare(a.Status, b.Status)
+	})
+	return &db.CodeAttribution{Sources: sources}
+}
+
+func collectCursorAttribution(
+	f StatsFilter,
+	stats *SessionStats,
+) (db.CodeAttributionSource, bool) {
 	switch cursorAttributionDecision(f) {
 	case cursorAttributionSkip:
-		return
+		return db.CodeAttributionSource{}, false
 	case cursorAttributionUnsupportedProjectFilter:
-		stats.CursorAttribution = cursorAttributionStatus(
+		return cursorAttributionSource(
 			"unsupported_filter",
 			"Cursor attribution is machine-local and cannot be scoped by project filters",
-		)
-		return
+		), true
 	}
 	from, err := time.Parse(time.RFC3339, stats.Window.Since)
 	if err != nil {
-		stats.CursorAttribution = cursorAttributionStatus(
+		return cursorAttributionSource(
 			"error",
 			"failed to parse stats window for Cursor attribution",
-		)
-		return
+		), true
 	}
 	to, err := time.Parse(time.RFC3339, stats.Window.Until)
 	if err != nil {
-		stats.CursorAttribution = cursorAttributionStatus(
+		return cursorAttributionSource(
 			"error",
 			"failed to parse stats window for Cursor attribution",
-		)
-		return
+		), true
 	}
 	attr, status, err := parser.LoadCursorAttribution(from, to)
 	if err != nil {
-		stats.CursorAttribution = cursorAttributionStatus(
+		return cursorAttributionSource(
 			"error",
 			"failed to load Cursor attribution: "+err.Error(),
-		)
-		return
+		), true
 	}
-	stats.CursorAttribution = mapCursorAttribution(attr, status)
+	return mapCursorAttributionSource(attr, status), true
 }
 
 func normalizeStatsAgentFilter(raw string) string {
@@ -808,12 +830,12 @@ func cursorAttributionDecision(f StatsFilter) cursorAttributionLoadDecision {
 	return cursorAttributionLoad
 }
 
-func mapCursorAttribution(
+func mapCursorAttributionSource(
 	attr *parser.CursorAttribution,
 	status parser.CursorAttributionStatus,
-) *db.CursorAttribution {
+) db.CodeAttributionSource {
 	if attr == nil {
-		out := cursorAttributionStatus(string(status), "")
+		out := cursorAttributionSource(string(status), "")
 		if status == parser.CursorAttributionUnavailable {
 			out.Warnings = []string{
 				"Cursor attribution database is unavailable on this machine",
@@ -821,9 +843,8 @@ func mapCursorAttribution(
 		}
 		return out
 	}
-	out := &db.CursorAttribution{
-		Status:               string(status),
-		Scope:                cursorAttributionScopeMachineLocal,
+	out := cursorAttributionSource(string(status), "")
+	out.Metrics = &db.CursorAttributionMetrics{
 		ScoredCommits:        attr.ScoredCommits,
 		LinesAdded:           attr.LinesAdded,
 		LinesDeleted:         attr.LinesDeleted,
@@ -840,14 +861,14 @@ func mapCursorAttribution(
 	if len(attr.ConversationCounts) == 0 {
 		return out
 	}
-	out.ConversationCounts = make(
+	out.Metrics.ConversationCounts = make(
 		[]db.CursorConversationCount,
 		0,
 		len(attr.ConversationCounts),
 	)
 	for _, entry := range attr.ConversationCounts {
-		out.ConversationCounts = append(
-			out.ConversationCounts,
+		out.Metrics.ConversationCounts = append(
+			out.Metrics.ConversationCounts,
 			db.CursorConversationCount{
 				Model: entry.Model,
 				Mode:  entry.Mode,
@@ -858,10 +879,11 @@ func mapCursorAttribution(
 	return out
 }
 
-func cursorAttributionStatus(status, warning string) *db.CursorAttribution {
-	out := &db.CursorAttribution{
-		Status: status,
-		Scope:  cursorAttributionScopeMachineLocal,
+func cursorAttributionSource(status, warning string) db.CodeAttributionSource {
+	out := db.CodeAttributionSource{
+		Provider: "cursor",
+		Status:   status,
+		Scope:    cursorAttributionScopeMachineLocal,
 	}
 	if warning != "" {
 		out.Warnings = []string{warning}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -703,6 +703,7 @@ func (b *directBackend) Stats(
 	if b.local == nil {
 		return nil, db.ErrReadOnly
 	}
+	f.Agent = normalizeStatsAgentFilter(f.Agent)
 	stats, err := b.local.GetSessionStats(ctx, db.StatsFilter{
 		Since:                 f.Since,
 		Until:                 f.Until,
@@ -740,11 +741,24 @@ func attachCursorAttribution(stats *SessionStats, f StatsFilter) {
 	stats.CursorAttribution = mapCursorAttribution(attr)
 }
 
+func normalizeStatsAgentFilter(raw string) string {
+	parts := strings.Split(raw, ",")
+	filtered := parts[:0]
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" || part == "all" {
+			continue
+		}
+		filtered = append(filtered, part)
+	}
+	return strings.Join(filtered, ",")
+}
+
 func shouldLoadCursorAttribution(f StatsFilter) bool {
 	if len(f.IncludeProjects) > 0 || len(f.ExcludeProjects) > 0 {
 		return false
 	}
-	agents := strings.Split(f.Agent, ",")
+	agents := strings.Split(normalizeStatsAgentFilter(f.Agent), ",")
 	seen := 0
 	for _, agent := range agents {
 		agent = strings.TrimSpace(agent)
@@ -752,7 +766,7 @@ func shouldLoadCursorAttribution(f StatsFilter) bool {
 			continue
 		}
 		seen++
-		if agent == "cursor" || agent == "all" {
+		if agent == "cursor" {
 			return true
 		}
 	}

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -220,17 +220,18 @@ func TestDirectBackend_Stats_CursorAttribution(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, stats)
-	require.NotNil(t, stats.CursorAttribution)
-	assert.Equal(t, "available", stats.CursorAttribution.Status)
-	assert.Equal(t, "machine_local", stats.CursorAttribution.Scope)
-	assert.Equal(t, int64(2), stats.CursorAttribution.ScoredCommits)
-	assert.Equal(t, int64(18), stats.CursorAttribution.LinesAdded)
-	assert.InDelta(t, 10.0/18.0, stats.CursorAttribution.AIAuthoredPct, 1e-9)
-	require.Len(t, stats.CursorAttribution.ConversationCounts, 1)
+	source := requireCursorAttributionSource(t, stats)
+	assert.Equal(t, "available", source.Status)
+	assert.Equal(t, "machine_local", source.Scope)
+	require.NotNil(t, source.Metrics)
+	assert.Equal(t, int64(2), source.Metrics.ScoredCommits)
+	assert.Equal(t, int64(18), source.Metrics.LinesAdded)
+	assert.InDelta(t, 10.0/18.0, source.Metrics.AIAuthoredPct, 1e-9)
+	require.Len(t, source.Metrics.ConversationCounts, 1)
 	assert.Equal(
 		t,
 		"claude-3.5-sonnet",
-		stats.CursorAttribution.ConversationCounts[0].Model,
+		source.Metrics.ConversationCounts[0].Model,
 	)
 }
 
@@ -248,7 +249,7 @@ func TestDirectBackend_Stats_CursorAttributionIgnoredForNonCursorFilter(
 	})
 	require.NoError(t, err)
 	require.NotNil(t, stats)
-	assert.Nil(t, stats.CursorAttribution)
+	assert.Nil(t, stats.CodeAttribution)
 }
 
 func TestDirectBackend_Stats_CursorAttributionReportsMissingDB(t *testing.T) {
@@ -262,11 +263,12 @@ func TestDirectBackend_Stats_CursorAttributionReportsMissingDB(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, stats)
-	require.NotNil(t, stats.CursorAttribution)
-	assert.Equal(t, "unavailable", stats.CursorAttribution.Status)
-	assert.Equal(t, "machine_local", stats.CursorAttribution.Scope)
-	require.NotEmpty(t, stats.CursorAttribution.Warnings)
-	assert.Contains(t, stats.CursorAttribution.Warnings[0],
+	source := requireCursorAttributionSource(t, stats)
+	assert.Equal(t, "unavailable", source.Status)
+	assert.Equal(t, "machine_local", source.Scope)
+	assert.Nil(t, source.Metrics)
+	require.NotEmpty(t, source.Warnings)
+	assert.Contains(t, source.Warnings[0],
 		"Cursor attribution database is unavailable")
 }
 
@@ -282,11 +284,12 @@ func TestDirectBackend_Stats_CursorAttributionReportsLoadError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, stats)
-	require.NotNil(t, stats.CursorAttribution)
-	assert.Equal(t, "error", stats.CursorAttribution.Status)
-	assert.Equal(t, "machine_local", stats.CursorAttribution.Scope)
-	require.NotEmpty(t, stats.CursorAttribution.Warnings)
-	assert.Contains(t, stats.CursorAttribution.Warnings[0],
+	source := requireCursorAttributionSource(t, stats)
+	assert.Equal(t, "error", source.Status)
+	assert.Equal(t, "machine_local", source.Scope)
+	assert.Nil(t, source.Metrics)
+	require.NotEmpty(t, source.Warnings)
+	assert.Contains(t, source.Warnings[0],
 		"failed to load Cursor attribution")
 }
 
@@ -316,12 +319,12 @@ func TestDirectBackend_Stats_CursorAttributionReportsUnsupportedProjectFilters(
 		stats, err := svc.Stats(context.Background(), filter)
 		require.NoError(t, err)
 		require.NotNil(t, stats)
-		require.NotNil(t, stats.CursorAttribution)
-		assert.Equal(t, "unsupported_filter",
-			stats.CursorAttribution.Status)
-		assert.Equal(t, "machine_local", stats.CursorAttribution.Scope)
-		require.NotEmpty(t, stats.CursorAttribution.Warnings)
-		assert.Contains(t, stats.CursorAttribution.Warnings[0],
+		source := requireCursorAttributionSource(t, stats)
+		assert.Equal(t, "unsupported_filter", source.Status)
+		assert.Equal(t, "machine_local", source.Scope)
+		assert.Nil(t, source.Metrics)
+		require.NotEmpty(t, source.Warnings)
+		assert.Contains(t, source.Warnings[0],
 			"cannot be scoped by project filters")
 	}
 }
@@ -370,8 +373,9 @@ func TestDirectBackend_Stats_CursorAttributionLoadedForAllAgentFilter(
 	require.NoError(t, err)
 	require.NotNil(t, stats)
 	assert.Equal(t, 2, stats.Totals.SessionsAll)
-	require.NotNil(t, stats.CursorAttribution)
-	assert.Equal(t, int64(1), stats.CursorAttribution.ScoredCommits)
+	source := requireCursorAttributionSource(t, stats)
+	require.NotNil(t, source.Metrics)
+	assert.Equal(t, int64(1), source.Metrics.ScoredCommits)
 }
 
 func TestDirectBackend_Stats_CursorAttributionIgnoredWhenAllMixedWithNonCursorFilter(
@@ -419,7 +423,19 @@ func TestDirectBackend_Stats_CursorAttributionIgnoredWhenAllMixedWithNonCursorFi
 	require.NotNil(t, stats)
 	assert.Equal(t, 1, stats.Totals.SessionsAll)
 	assert.Equal(t, "codex", stats.Filters.Agent)
-	assert.Nil(t, stats.CursorAttribution)
+	assert.Nil(t, stats.CodeAttribution)
+}
+
+func requireCursorAttributionSource(
+	t *testing.T,
+	stats *service.SessionStats,
+) db.CodeAttributionSource {
+	t.Helper()
+	require.NotNil(t, stats.CodeAttribution)
+	require.Len(t, stats.CodeAttribution.Sources, 1)
+	source := stats.CodeAttribution.Sources[0]
+	assert.Equal(t, "cursor", source.Provider)
+	return source
 }
 
 func TestDirectBackend_Get_HealthBreakdownIncludesHeuristics(

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -51,6 +53,98 @@ func newDirectTestSvc(t *testing.T) (service.SessionService, *directTestEnv) {
 	return service.NewDirectBackend(d, nil), &directTestEnv{db: d}
 }
 
+type cursorCommitFixture struct {
+	commitHash           string
+	scoredAt             int64
+	linesAdded           int64
+	linesDeleted         int64
+	tabLinesAdded        int64
+	tabLinesDeleted      int64
+	composerLinesAdded   int64
+	composerLinesDeleted int64
+	humanLinesAdded      int64
+	humanLinesDeleted    int64
+	blankLinesAdded      int64
+	blankLinesDeleted    int64
+}
+
+type cursorConversationFixture struct {
+	model     string
+	mode      string
+	updatedAt int64
+}
+
+func seedCursorAttributionDB(
+	t *testing.T,
+	commits []cursorCommitFixture,
+	conversations []cursorConversationFixture,
+) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ai-code-tracking.db")
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open cursor attribution db")
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = conn.Exec(`
+		CREATE TABLE scored_commits (
+			commitHash TEXT PRIMARY KEY,
+			scoredAt INTEGER NOT NULL,
+			linesAdded INTEGER NOT NULL DEFAULT 0,
+			linesDeleted INTEGER NOT NULL DEFAULT 0,
+			tabLinesAdded INTEGER NOT NULL DEFAULT 0,
+			tabLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			composerLinesAdded INTEGER NOT NULL DEFAULT 0,
+			composerLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			humanLinesAdded INTEGER NOT NULL DEFAULT 0,
+			humanLinesDeleted INTEGER NOT NULL DEFAULT 0,
+			blankLinesAdded INTEGER NOT NULL DEFAULT 0,
+			blankLinesDeleted INTEGER NOT NULL DEFAULT 0
+		)
+	`)
+	require.NoError(t, err, "create scored_commits table")
+	_, err = conn.Exec(`
+		CREATE TABLE conversation_summaries (
+			model TEXT NOT NULL,
+			mode TEXT NOT NULL,
+			updatedAt INTEGER NOT NULL
+		)
+	`)
+	require.NoError(t, err, "create conversation_summaries table")
+
+	for _, commit := range commits {
+		_, err := conn.Exec(`
+			INSERT INTO scored_commits (
+				commitHash, scoredAt,
+				linesAdded, linesDeleted,
+				tabLinesAdded, tabLinesDeleted,
+				composerLinesAdded, composerLinesDeleted,
+				humanLinesAdded, humanLinesDeleted,
+				blankLinesAdded, blankLinesDeleted
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			commit.commitHash, commit.scoredAt,
+			commit.linesAdded, commit.linesDeleted,
+			commit.tabLinesAdded, commit.tabLinesDeleted,
+			commit.composerLinesAdded, commit.composerLinesDeleted,
+			commit.humanLinesAdded, commit.humanLinesDeleted,
+			commit.blankLinesAdded, commit.blankLinesDeleted,
+		)
+		require.NoError(t, err, "insert scored_commit %s", commit.commitHash)
+	}
+
+	for i, convo := range conversations {
+		_, err := conn.Exec(`
+			INSERT INTO conversation_summaries (
+				model, mode, updatedAt
+			) VALUES (?, ?, ?)`,
+			convo.model, convo.mode, convo.updatedAt,
+		)
+		require.NoError(t, err, "insert conversation_summary %d", i)
+	}
+
+	return path
+}
+
 func TestDirectBackend_Get_Roundtrip(t *testing.T) {
 	t.Parallel()
 	svc, env := newDirectTestSvc(t)
@@ -60,6 +154,89 @@ func TestDirectBackend_Get_Roundtrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, detail)
 	assert.Equal(t, sessionID, detail.ID)
+}
+
+func TestDirectBackend_Stats_CursorAttribution(t *testing.T) {
+	svc, env := newDirectTestSvc(t)
+	now := time.Now().UTC()
+	startedAt := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	dbtest.SeedSession(t, env.db, "cursor-1", "proj",
+		func(s *db.Session) {
+			s.Agent = "cursor"
+			s.MessageCount = 2
+			s.UserMessageCount = 1
+			s.StartedAt = &startedAt
+		},
+	)
+
+	path := seedCursorAttributionDB(t,
+		[]cursorCommitFixture{
+			{
+				commitHash:         "c1",
+				scoredAt:           now.Add(-110 * time.Minute).UnixMilli(),
+				linesAdded:         10,
+				linesDeleted:       4,
+				tabLinesAdded:      6,
+				composerLinesAdded: 2,
+				humanLinesAdded:    4,
+			},
+			{
+				commitHash:         "c2",
+				scoredAt:           now.Add(-90 * time.Minute).UnixMilli(),
+				linesAdded:         5,
+				linesDeleted:       2,
+				composerLinesAdded: 2,
+				humanLinesAdded:    1,
+			},
+		},
+		[]cursorConversationFixture{
+			{
+				model:     "claude-3.5-sonnet",
+				mode:      "composer",
+				updatedAt: now.Add(-110 * time.Minute).UnixMilli(),
+			},
+			{
+				model:     "claude-3.5-sonnet",
+				mode:      "composer",
+				updatedAt: now.Add(-90 * time.Minute).UnixMilli(),
+			},
+		},
+	)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", path)
+
+	stats, err := svc.Stats(context.Background(), service.StatsFilter{
+		Since: "28d",
+		Agent: "cursor",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.NotNil(t, stats.CursorAttribution)
+	assert.Equal(t, int64(2), stats.CursorAttribution.ScoredCommits)
+	assert.Equal(t, int64(15), stats.CursorAttribution.LinesAdded)
+	assert.InDelta(t, 10.0/15.0, stats.CursorAttribution.AIAuthoredPct, 1e-9)
+	require.Len(t, stats.CursorAttribution.ConversationCounts, 1)
+	assert.Equal(
+		t,
+		"claude-3.5-sonnet",
+		stats.CursorAttribution.ConversationCounts[0].Model,
+	)
+}
+
+func TestDirectBackend_Stats_CursorAttributionIgnoredForNonCursorFilter(
+	t *testing.T,
+) {
+	svc, _ := newDirectTestSvc(t)
+	badPath := filepath.Join(t.TempDir(), "ai-code-tracking.db")
+	require.NoError(t, os.WriteFile(badPath, []byte("not sqlite"), 0o600))
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", badPath)
+
+	stats, err := svc.Stats(context.Background(), service.StatsFilter{
+		Since: "28d",
+		Agent: "codex",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Nil(t, stats.CursorAttribution)
 }
 
 func TestDirectBackend_Get_HealthBreakdownIncludesHeuristics(

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -221,6 +221,8 @@ func TestDirectBackend_Stats_CursorAttribution(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, stats)
 	require.NotNil(t, stats.CursorAttribution)
+	assert.Equal(t, "available", stats.CursorAttribution.Status)
+	assert.Equal(t, "machine_local", stats.CursorAttribution.Scope)
 	assert.Equal(t, int64(2), stats.CursorAttribution.ScoredCommits)
 	assert.Equal(t, int64(18), stats.CursorAttribution.LinesAdded)
 	assert.InDelta(t, 10.0/18.0, stats.CursorAttribution.AIAuthoredPct, 1e-9)
@@ -249,7 +251,46 @@ func TestDirectBackend_Stats_CursorAttributionIgnoredForNonCursorFilter(
 	assert.Nil(t, stats.CursorAttribution)
 }
 
-func TestDirectBackend_Stats_CursorAttributionIgnoredForProjectFilters(
+func TestDirectBackend_Stats_CursorAttributionReportsMissingDB(t *testing.T) {
+	svc, _ := newDirectTestSvc(t)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB",
+		filepath.Join(t.TempDir(), "missing.db"))
+
+	stats, err := svc.Stats(context.Background(), service.StatsFilter{
+		Since: "28d",
+		Agent: "cursor",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.NotNil(t, stats.CursorAttribution)
+	assert.Equal(t, "unavailable", stats.CursorAttribution.Status)
+	assert.Equal(t, "machine_local", stats.CursorAttribution.Scope)
+	require.NotEmpty(t, stats.CursorAttribution.Warnings)
+	assert.Contains(t, stats.CursorAttribution.Warnings[0],
+		"Cursor attribution database is unavailable")
+}
+
+func TestDirectBackend_Stats_CursorAttributionReportsLoadError(t *testing.T) {
+	svc, _ := newDirectTestSvc(t)
+	badPath := filepath.Join(t.TempDir(), "ai-code-tracking.db")
+	require.NoError(t, os.WriteFile(badPath, []byte("not sqlite"), 0o600))
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", badPath)
+
+	stats, err := svc.Stats(context.Background(), service.StatsFilter{
+		Since: "28d",
+		Agent: "cursor",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.NotNil(t, stats.CursorAttribution)
+	assert.Equal(t, "error", stats.CursorAttribution.Status)
+	assert.Equal(t, "machine_local", stats.CursorAttribution.Scope)
+	require.NotEmpty(t, stats.CursorAttribution.Warnings)
+	assert.Contains(t, stats.CursorAttribution.Warnings[0],
+		"failed to load Cursor attribution")
+}
+
+func TestDirectBackend_Stats_CursorAttributionReportsUnsupportedProjectFilters(
 	t *testing.T,
 ) {
 	svc, _ := newDirectTestSvc(t)
@@ -275,7 +316,13 @@ func TestDirectBackend_Stats_CursorAttributionIgnoredForProjectFilters(
 		stats, err := svc.Stats(context.Background(), filter)
 		require.NoError(t, err)
 		require.NotNil(t, stats)
-		assert.Nil(t, stats.CursorAttribution)
+		require.NotNil(t, stats.CursorAttribution)
+		assert.Equal(t, "unsupported_filter",
+			stats.CursorAttribution.Status)
+		assert.Equal(t, "machine_local", stats.CursorAttribution.Scope)
+		require.NotEmpty(t, stats.CursorAttribution.Warnings)
+		assert.Contains(t, stats.CursorAttribution.Warnings[0],
+			"cannot be scoped by project filters")
 	}
 }
 

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -56,7 +56,7 @@ func newDirectTestSvc(t *testing.T) (service.SessionService, *directTestEnv) {
 type cursorCommitFixture struct {
 	commitHash           string
 	scoredAt             int64
-	commitDate           int64
+	commitDate           string
 	linesAdded           int64
 	linesDeleted         int64
 	tabLinesAdded        int64
@@ -75,6 +75,10 @@ type cursorConversationFixture struct {
 	updatedAt int64
 }
 
+func formatCursorCommitDate(t time.Time) string {
+	return t.Format("Mon Jan 2 15:04:05 2006 -0700")
+}
+
 func seedCursorAttributionDB(
 	t *testing.T,
 	commits []cursorCommitFixture,
@@ -91,7 +95,7 @@ func seedCursorAttributionDB(
 		CREATE TABLE scored_commits (
 			commitHash TEXT PRIMARY KEY,
 			scoredAt INTEGER NOT NULL,
-			commitDate INTEGER NOT NULL,
+			commitDate TEXT NOT NULL,
 			linesAdded INTEGER NOT NULL DEFAULT 0,
 			linesDeleted INTEGER NOT NULL DEFAULT 0,
 			tabLinesAdded INTEGER NOT NULL DEFAULT 0,
@@ -175,8 +179,8 @@ func TestDirectBackend_Stats_CursorAttribution(t *testing.T) {
 		[]cursorCommitFixture{
 			{
 				commitHash:         "c1",
-				scoredAt:           now.Add(48 * time.Hour).UnixMilli(),
-				commitDate:         now.Add(-110 * time.Minute).UnixMilli(),
+				scoredAt:           now.Add(-110 * time.Minute).UnixMilli(),
+				commitDate:         formatCursorCommitDate(now.Add(48 * time.Hour)),
 				linesAdded:         12,
 				linesDeleted:       4,
 				tabLinesAdded:      6,
@@ -187,7 +191,7 @@ func TestDirectBackend_Stats_CursorAttribution(t *testing.T) {
 			{
 				commitHash:         "c2",
 				scoredAt:           now.Add(-90 * time.Minute).UnixMilli(),
-				commitDate:         now.Add(-90 * time.Minute).UnixMilli(),
+				commitDate:         formatCursorCommitDate(now.Add(-90 * time.Minute)),
 				linesAdded:         6,
 				linesDeleted:       2,
 				composerLinesAdded: 2,
@@ -254,7 +258,7 @@ func TestDirectBackend_Stats_CursorAttributionIgnoredForProjectFilters(
 		[]cursorCommitFixture{{
 			commitHash:         "c1",
 			scoredAt:           now.Add(-30 * time.Minute).UnixMilli(),
-			commitDate:         now.Add(-30 * time.Minute).UnixMilli(),
+			commitDate:         formatCursorCommitDate(now.Add(-30 * time.Minute)),
 			linesAdded:         9,
 			tabLinesAdded:      4,
 			composerLinesAdded: 2,

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -56,6 +56,7 @@ func newDirectTestSvc(t *testing.T) (service.SessionService, *directTestEnv) {
 type cursorCommitFixture struct {
 	commitHash           string
 	scoredAt             int64
+	commitDate           int64
 	linesAdded           int64
 	linesDeleted         int64
 	tabLinesAdded        int64
@@ -90,6 +91,7 @@ func seedCursorAttributionDB(
 		CREATE TABLE scored_commits (
 			commitHash TEXT PRIMARY KEY,
 			scoredAt INTEGER NOT NULL,
+			commitDate INTEGER NOT NULL,
 			linesAdded INTEGER NOT NULL DEFAULT 0,
 			linesDeleted INTEGER NOT NULL DEFAULT 0,
 			tabLinesAdded INTEGER NOT NULL DEFAULT 0,
@@ -115,14 +117,14 @@ func seedCursorAttributionDB(
 	for _, commit := range commits {
 		_, err := conn.Exec(`
 			INSERT INTO scored_commits (
-				commitHash, scoredAt,
+				commitHash, scoredAt, commitDate,
 				linesAdded, linesDeleted,
 				tabLinesAdded, tabLinesDeleted,
 				composerLinesAdded, composerLinesDeleted,
 				humanLinesAdded, humanLinesDeleted,
 				blankLinesAdded, blankLinesDeleted
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			commit.commitHash, commit.scoredAt,
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			commit.commitHash, commit.scoredAt, commit.commitDate,
 			commit.linesAdded, commit.linesDeleted,
 			commit.tabLinesAdded, commit.tabLinesDeleted,
 			commit.composerLinesAdded, commit.composerLinesDeleted,
@@ -173,20 +175,24 @@ func TestDirectBackend_Stats_CursorAttribution(t *testing.T) {
 		[]cursorCommitFixture{
 			{
 				commitHash:         "c1",
-				scoredAt:           now.Add(-110 * time.Minute).UnixMilli(),
-				linesAdded:         10,
+				scoredAt:           now.Add(48 * time.Hour).UnixMilli(),
+				commitDate:         now.Add(-110 * time.Minute).UnixMilli(),
+				linesAdded:         12,
 				linesDeleted:       4,
 				tabLinesAdded:      6,
 				composerLinesAdded: 2,
 				humanLinesAdded:    4,
+				blankLinesAdded:    2,
 			},
 			{
 				commitHash:         "c2",
 				scoredAt:           now.Add(-90 * time.Minute).UnixMilli(),
-				linesAdded:         5,
+				commitDate:         now.Add(-90 * time.Minute).UnixMilli(),
+				linesAdded:         6,
 				linesDeleted:       2,
 				composerLinesAdded: 2,
 				humanLinesAdded:    1,
+				blankLinesAdded:    1,
 			},
 		},
 		[]cursorConversationFixture{
@@ -212,8 +218,8 @@ func TestDirectBackend_Stats_CursorAttribution(t *testing.T) {
 	require.NotNil(t, stats)
 	require.NotNil(t, stats.CursorAttribution)
 	assert.Equal(t, int64(2), stats.CursorAttribution.ScoredCommits)
-	assert.Equal(t, int64(15), stats.CursorAttribution.LinesAdded)
-	assert.InDelta(t, 10.0/15.0, stats.CursorAttribution.AIAuthoredPct, 1e-9)
+	assert.Equal(t, int64(18), stats.CursorAttribution.LinesAdded)
+	assert.InDelta(t, 10.0/18.0, stats.CursorAttribution.AIAuthoredPct, 1e-9)
 	require.Len(t, stats.CursorAttribution.ConversationCounts, 1)
 	assert.Equal(
 		t,
@@ -237,6 +243,36 @@ func TestDirectBackend_Stats_CursorAttributionIgnoredForNonCursorFilter(
 	require.NoError(t, err)
 	require.NotNil(t, stats)
 	assert.Nil(t, stats.CursorAttribution)
+}
+
+func TestDirectBackend_Stats_CursorAttributionIgnoredForProjectFilters(
+	t *testing.T,
+) {
+	svc, _ := newDirectTestSvc(t)
+	now := time.Now().UTC()
+	path := seedCursorAttributionDB(t,
+		[]cursorCommitFixture{{
+			commitHash:         "c1",
+			scoredAt:           now.Add(-30 * time.Minute).UnixMilli(),
+			commitDate:         now.Add(-30 * time.Minute).UnixMilli(),
+			linesAdded:         9,
+			tabLinesAdded:      4,
+			composerLinesAdded: 2,
+			humanLinesAdded:    3,
+		}},
+		nil,
+	)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", path)
+
+	for _, filter := range []service.StatsFilter{
+		{Since: "28d", Agent: "cursor", IncludeProjects: []string{"proj"}},
+		{Since: "28d", Agent: "cursor", ExcludeProjects: []string{"proj"}},
+	} {
+		stats, err := svc.Stats(context.Background(), filter)
+		require.NoError(t, err)
+		require.NotNil(t, stats)
+		assert.Nil(t, stats.CursorAttribution)
+	}
 }
 
 func TestDirectBackend_Get_HealthBreakdownIncludesHeuristics(

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -279,6 +279,102 @@ func TestDirectBackend_Stats_CursorAttributionIgnoredForProjectFilters(
 	}
 }
 
+func TestDirectBackend_Stats_CursorAttributionLoadedForAllAgentFilter(
+	t *testing.T,
+) {
+	svc, env := newDirectTestSvc(t)
+	now := time.Now().UTC()
+	startedAt := now.Add(-45 * time.Minute).Format(time.RFC3339)
+	dbtest.SeedSession(t, env.db, "cursor-1", "proj",
+		func(s *db.Session) {
+			s.Agent = "cursor"
+			s.MessageCount = 2
+			s.UserMessageCount = 1
+			s.StartedAt = &startedAt
+		},
+	)
+	dbtest.SeedSession(t, env.db, "codex-1", "proj",
+		func(s *db.Session) {
+			s.Agent = "codex"
+			s.MessageCount = 2
+			s.UserMessageCount = 1
+			s.StartedAt = &startedAt
+		},
+	)
+
+	path := seedCursorAttributionDB(t,
+		[]cursorCommitFixture{{
+			commitHash:         "c1",
+			scoredAt:           now.Add(-30 * time.Minute).UnixMilli(),
+			commitDate:         formatCursorCommitDate(now.Add(-30 * time.Minute)),
+			linesAdded:         9,
+			tabLinesAdded:      4,
+			composerLinesAdded: 2,
+			humanLinesAdded:    3,
+		}},
+		nil,
+	)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", path)
+
+	stats, err := svc.Stats(context.Background(), service.StatsFilter{
+		Since: "28d",
+		Agent: "all",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, 2, stats.Totals.SessionsAll)
+	require.NotNil(t, stats.CursorAttribution)
+	assert.Equal(t, int64(1), stats.CursorAttribution.ScoredCommits)
+}
+
+func TestDirectBackend_Stats_CursorAttributionIgnoredWhenAllMixedWithNonCursorFilter(
+	t *testing.T,
+) {
+	svc, env := newDirectTestSvc(t)
+	now := time.Now().UTC()
+	startedAt := now.Add(-45 * time.Minute).Format(time.RFC3339)
+	dbtest.SeedSession(t, env.db, "cursor-1", "proj",
+		func(s *db.Session) {
+			s.Agent = "cursor"
+			s.MessageCount = 2
+			s.UserMessageCount = 1
+			s.StartedAt = &startedAt
+		},
+	)
+	dbtest.SeedSession(t, env.db, "codex-1", "proj",
+		func(s *db.Session) {
+			s.Agent = "codex"
+			s.MessageCount = 2
+			s.UserMessageCount = 1
+			s.StartedAt = &startedAt
+		},
+	)
+
+	path := seedCursorAttributionDB(t,
+		[]cursorCommitFixture{{
+			commitHash:         "c1",
+			scoredAt:           now.Add(-30 * time.Minute).UnixMilli(),
+			commitDate:         formatCursorCommitDate(now.Add(-30 * time.Minute)),
+			linesAdded:         9,
+			tabLinesAdded:      4,
+			composerLinesAdded: 2,
+			humanLinesAdded:    3,
+		}},
+		nil,
+	)
+	t.Setenv("AGENTSVIEW_CURSOR_ATTRIBUTION_DB", path)
+
+	stats, err := svc.Stats(context.Background(), service.StatsFilter{
+		Since: "28d",
+		Agent: "all, codex",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, 1, stats.Totals.SessionsAll)
+	assert.Equal(t, "codex", stats.Filters.Agent)
+	assert.Nil(t, stats.CursorAttribution)
+}
+
 func TestDirectBackend_Get_HealthBreakdownIncludesHeuristics(
 	t *testing.T,
 ) {


### PR DESCRIPTION
tkmx-client still needs Cursor attribution parity before it can retire the last legacy Cursor collector. AgentsView already ingests Cursor transcripts, but it still ignores `~/.cursor/ai-tracking/ai-code-tracking.db`, so the stats payload has no commit-level tab, composer, human, or conversation-count attribution from Cursor itself.

This keeps the scope to the surviving Cursor attribution slice from #358. The new reader lives beside the existing Cursor parser, can be redirected with `AGENTSVIEW_CURSOR_ATTRIBUTION_DB`, follows Cursor's live schema by windowing scored commits on `scoredAt` while leaving the text `commitDate` column as metadata, and leaves transcript discovery untouched. Aggregation stays owned by service stats code, and the result lands in a dedicated top-level `cursor_attribution` block rather than being mixed into git-derived `outcome_stats` or folded into the session-derived `agent_portfolio` maps. That preserves the meaning of the existing stats owners while giving downstream consumers one explicit Cursor attribution surface to read.

Project include and exclude filters still suppress the block because Cursor's local attribution DB has no project key, and non-Cursor agent filters keep it nil for the same reason. The human-readable stats output only renders the section when the service-owned block is present.

PR #413 stays separate. It covers Cursor `state.vscdb` session ingestion, which is a different Cursor data source from `ai-code-tracking.db` and does not provide the line-attribution totals required here.

Closes #358
