### PR TITLE
docs: update 0.35.1 release notes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,47 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
+## 0.35.1
+<small>2026-06-30</small>
+
+**New features**
+
+- Add **OpenClaude session support** so AgentsView can discover, import, and
+  display OpenClaude JSONL sessions alongside Claude Code and other local
+  agents.
+- Add **Copilot CLI usage guidance** for records that include aggregate usage
+  metadata but do not include per-message token counts.
+
+**Improvements**
+
+- Reuse the configured **DuckDB mirror path** for Quack sync so `duckdb push`,
+  `duckdb status`, `duckdb serve`, and `duckdb quack serve` stay pointed at the
+  same mirror by default.
+- Improve **DuckDB and Quack sync behavior and coverage**.
+
+**Bug fixes**
+
+- Require **daemon transport** for CLI read commands that depend on
+  daemon-backed data.
+- Surface **desktop backend startup failures** clearly instead of hiding the
+  underlying error.
+- Validate **desktop updater signatures** before applying updates.
+
+**Acknowledgements**
+
+- Thanks to [Rod Boev](https://github.com/rodboev) for OpenClaude session
+  support.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for Copilot CLI usage
+  guidance when usage records do not include per-message token counts.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for reusing the
+  configured DuckDB path for Quack sync and improving DuckDB/Quack coverage.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the
+  daemon-transport requirement on CLI read commands.
+- Thanks to [Wes McKinney](https://github.com/wesm) for desktop backend error
+  surfacing, desktop updater signature validation, and release documentation.
+
+---
+
 ## 0.35.0
 <small>2026-06-29</small>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -553,7 +553,9 @@ agentsview duckdb quack serve   # expose the mirror over Quack
 `--all-projects` / `--watch` / `--debounce` / `--interval` flags as `pg push`.
 With `[duckdb].url` or `AGENTSVIEW_DUCKDB_URL`, `duckdb push`, `duckdb status`,
 and `duckdb serve` target the remote Quack endpoint; otherwise they use the
-local mirror file. `duckdb serve` accepts the same serve flags as `pg serve`.
+local mirror file. When `[duckdb].path` or `AGENTSVIEW_DUCKDB_PATH` is set,
+`duckdb quack serve` exposes that same mirror by default unless `--path`
+overrides it. `duckdb serve` accepts the same serve flags as `pg serve`.
 The DuckDB backend is unavailable on Windows ARM64 (the upstream bindings ship
 no prebuilt library for that platform); all other commands work normally there.
 

--- a/docs/duckdb.md
+++ b/docs/duckdb.md
@@ -51,6 +51,12 @@ With `--watch`, AgentsView performs one initial sync and DuckDB push, then keeps
 running until interrupted. Shutdown via `Ctrl+C` or `SIGTERM` cancels the
 watcher cleanly.
 
+When `[duckdb].path` or `AGENTSVIEW_DUCKDB_PATH` is configured, all local
+DuckDB commands use that same mirror file by default, including
+`duckdb quack serve`. Use `duckdb quack serve --path ...` only when you want to
+expose a different mirror than the one used by `duckdb push`, `duckdb status`,
+and `duckdb serve`.
+
 `duckdb serve` accepts the same serve flags as
 [`pg serve`](/pg-sync/#agentsview-pg-serve) (`--host`, `--port`, `--base-path`,
 proxy and TLS flags) and is read-only in the same way — no uploads, file

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ A local-first desktop and web app for browsing, searching, and analyzing your pa
 
 <div class="agent-grid">
   <a class="agent-chip" data-agent="claude-code" href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener"><span class="agent-chip__glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-claude"/></svg></span><span class="agent-chip__name">Claude Code</span></a>
+  <a class="agent-chip" data-agent="openclaude" href="/configuration/#session-discovery"><span class="agent-chip__glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-claude"/></svg></span><span class="agent-chip__name">OpenClaude</span></a>
   <a class="agent-chip" data-agent="codex" href="https://openai.com/codex/" target="_blank" rel="noopener"><span class="agent-chip__glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-openai"/></svg></span><span class="agent-chip__name">Codex</span></a>
   <a class="agent-chip" data-agent="gemini" href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener"><span class="agent-chip__glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-gemini"/></svg></span><span class="agent-chip__name">Gemini</span></a>
   <a class="agent-chip" data-agent="copilot" href="https://github.com/features/copilot" target="_blank" rel="noopener"><span class="agent-chip__glyph"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#i-copilot"/></svg></span><span class="agent-chip__name">Copilot</span></a>
@@ -242,8 +243,8 @@ to a shared database for team or multi-machine setups.
 -   **Multi-Agent Support**
 
     Works with [dozens of AI coding session sources](/configuration/#session-discovery)
-    including Claude Code, Codex, Copilot, Cursor, Gemini,
-    OpenHands, Aider, Claude Cowork, DeepSeek TUI, gptme,
+    including Claude Code, OpenClaude, Codex, Copilot, Cursor,
+    Gemini, OpenHands, Aider, Claude Cowork, DeepSeek TUI, gptme,
     Kilo, MiMoCode, Mistral Vibe, OhMyPi, QwenPaw, Reasonix,
     Shelley, and Visual Studio Copilot. Auto-discovers session
     directories so there's nothing to configure.

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -350,6 +350,14 @@ dotted version numbers, so the parser normalizes names such as
 Upgrading to 0.32.0 bumps the parser data version so existing
 Copilot CLI sessions are re-indexed with the new usage rows.
 
+Some Copilot CLI records include `session.shutdown.modelMetrics`
+totals but omit per-message `assistant.message.outputTokens`.
+AgentsView can still use the aggregate model totals where they are
+complete, but it cannot reconstruct per-message output-token rows
+from those records. As of 0.35.1, the CLI reports that limitation
+directly instead of implying that the session has no usage data at
+all.
+
 ### VS Code Copilot Token Metrics
 
 As of 0.34.0, VS Code Copilot chat sessions also contribute when


### PR DESCRIPTION
The 0.35.1 tag is cut, so the public docs need to describe the shipped behavior rather than leaving the site at 0.35.0. This adds the release notes and acknowledgements for the OpenClaude, Copilot usage, DuckDB/Quack, CLI daemon, and desktop updater changes.

The visible docs now also point users at OpenClaude support, explain why some Copilot usage records cannot produce per-message token rows, and clarify that Quack serving reuses the configured DuckDB mirror path by default.