### PR TITLE
fix(postgres): don't let skipped ownership conflicts block the session-alias backfill marker

### DIFF
--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -943,7 +943,14 @@ func markSessionAliasBackfillDone(local syncStateStore) error {
 func completeSessionAliasBackfill(
 	local syncStateStore, needed bool, result PushResult,
 ) error {
-	if !needed || result.Errors > 0 || result.SkippedConflicts > 0 {
+	// Skipped ownership conflicts are sessions owned by another machine on
+	// the hub; this host neither can nor should re-push them, so they do not
+	// indicate an incomplete backfill of this host's own sessions. Only real
+	// push errors (this host's own sessions that failed to push) should defer
+	// the marker and re-force a full push. Gating on skipped conflicts made
+	// the one-time alias backfill impossible to complete on any shared hub —
+	// every push saw the marker missing and fell back to a full sweep.
+	if !needed || result.Errors > 0 {
 		return nil
 	}
 	return markSessionAliasBackfillDone(local)

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -163,7 +163,7 @@ func TestSessionAliasBackfillForcesOneFullPush(t *testing.T) {
 	assert.False(t, needed)
 }
 
-func TestCompleteSessionAliasBackfillRequiresCleanPush(t *testing.T) {
+func TestCompleteSessionAliasBackfillMarksDoneUnlessErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		res  PushResult
@@ -171,7 +171,14 @@ func TestCompleteSessionAliasBackfillRequiresCleanPush(t *testing.T) {
 	}{
 		{name: "clean", want: "1"},
 		{name: "errors", res: PushResult{Errors: 1}},
-		{name: "skipped conflicts", res: PushResult{SkippedConflicts: 1}},
+		// Skipped ownership conflicts are other machines' sessions this host
+		// can never push; they must not block the one-time backfill marker,
+		// or a shared hub can never leave the forced-full-push state.
+		{name: "skipped conflicts", res: PushResult{SkippedConflicts: 1}, want: "1"},
+		{
+			name: "errors with skipped conflicts",
+			res:  PushResult{Errors: 1, SkippedConflicts: 2},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := &syncStateStoreStub{}


### PR DESCRIPTION
## Problem

On a shared PG hub, `pg push` repeatedly re-runs the one-time session-alias backfill (#898) as a full ~30-min sweep and never records it as done, so `pg status` shows `Last push: never` and every push is a cold full sweep.

`completeSessionAliasBackfill` only writes `pg_session_alias_backfill_v1` when `Errors == 0 && SkippedConflicts == 0`. But `SkippedConflicts` counts sessions owned by **another** machine (`errSessionOwnershipConflict`) — a permanent, expected condition on any shared hub. A host that doesn't own 100% of the matching sessions can therefore never complete the backfill, and `applySessionAliasBackfillRequirement` forces a full push on every run.

## Change

Gate the marker on real push `Errors` only. Skipped ownership conflicts are other machines' sessions this host neither can nor should re-push, so they don't indicate an incomplete backfill of *this host's own* sessions. The `Errors > 0` guard is kept, so a push that actually failed to write this host's sessions still re-forces full next time.

`TestCompleteSessionAliasBackfill*` now covers: clean → marked; errors → deferred; skipped-conflicts → **marked**; errors+skipped → deferred.

## Scope

This fixes one of the two causes in #939. The other — the backfill marker also being **per-project-filter scoped**, so any change to the filter set re-triggers a full sweep — is left for discussion in #939 because keying it by PG target instead touches transition-window semantics that are a maintainer call.

Refs #939. Follow-up to #891.
