### PR TITLE
Fix DuckDB push schema setup through Quack

### DIFF
--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -200,6 +200,9 @@ func (b daemonArchiveWriteBackend) duckDBPush(
 	excludeProjects []string,
 	syncStateTarget string,
 ) (duckdbsync.PushResult, error) {
+	if err := duckdbsync.ValidatePushTarget(duckCfg); err != nil {
+		return duckdbsync.PushResult{}, err
+	}
 	duckCfg, err := absolutizeDuckDBPath(duckCfg)
 	if err != nil {
 		return duckdbsync.PushResult{}, err
@@ -377,6 +380,9 @@ func (b *localArchiveWriteBackend) duckDBPush(
 	excludeProjects []string,
 	syncStateTarget string,
 ) (duckdbsync.PushResult, error) {
+	if err := duckdbsync.ValidatePushTarget(duckCfg); err != nil {
+		return duckdbsync.PushResult{}, err
+	}
 	didResync := runLocalSync(ctx, b.appCfg, b.database, cfg.Full)
 	if err := ctx.Err(); err != nil {
 		return duckdbsync.PushResult{}, err
@@ -493,6 +499,18 @@ func (b *localArchiveWriteBackend) DuckDBPushWatch(
 }
 
 func logDuckDBWatchPushResult(res duckdbsync.PushResult, reason pushReason) {
+	if res.Diagnostics.Cutoff != "" {
+		log.Printf(
+			"duckdb watch: source local %s; candidates %s; skipped unchanged %s; stale deleted %d; wrote sessions %s, messages %d (%s)",
+			formatDuckDBPushSessionCounts(res.Diagnostics.LocalSessions),
+			formatDuckDBPushSessionCounts(res.Diagnostics.CandidateSessions),
+			formatDuckDBPushSessionCounts(res.Diagnostics.SkippedUnchangedSessions),
+			res.Diagnostics.DeletedStaleSessions,
+			formatDuckDBPushSessionCounts(res.Diagnostics.PushedSessions),
+			res.MessagesPushed,
+			reason,
+		)
+	}
 	if res.Errors > 0 {
 		log.Printf(
 			"duckdb watch: pushed %d sessions, %d messages, %d errors (%s)",

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -53,6 +53,29 @@ func TestLocalArchiveWriteBackendDuckDBPushUsesConfiguredRemoteURL(t *testing.T)
 	})
 }
 
+func TestLocalArchiveWriteBackendDuckDBPushValidatesRemoteBeforeLocalSync(t *testing.T) {
+	backend := testLocalArchiveWriteBackend(t)
+
+	var err error
+	out := captureStdout(t, func() {
+		_, err = backend.DuckDBPush(
+			context.Background(),
+			config.DuckDBConfig{
+				URL:         "quack:https://duck.example.test",
+				MachineName: "workstation",
+			},
+			DuckDBPushConfig{Full: true},
+			nil,
+			nil,
+		)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duckdb quack token is required")
+	assert.NotContains(t, out, "Database:")
+	assert.NotContains(t, out, "Opening DuckDB mirror")
+}
+
 func TestRunPGWatchStartupSyncFallsBackAfterAbortedResync(t *testing.T) {
 	database := dbtest.OpenTestDB(t)
 	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")

--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -10,6 +10,8 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -54,6 +56,13 @@ func runDuckDBPush(cfg DuckDBPushConfig) {
 	if err != nil {
 		fatal("duckdb push: %v", err)
 	}
+	if err := duckdbsync.ValidatePushTarget(duckCfg); err != nil {
+		fatal("duckdb push: %v", err)
+	}
+	syncStateTarget := duckdbsync.SyncStateTargetForConfig(duckCfg)
+	writeDuckDBPushPlan(
+		os.Stdout, duckCfg, cfg, projects, excludeProjects, syncStateTarget,
+	)
 
 	ctx, stop := signal.NotifyContext(
 		context.Background(), duckDBLongRunningSignals()...,
@@ -87,6 +96,7 @@ func runDuckDBPush(cfg DuckDBPushConfig) {
 	if err != nil {
 		fatal("duckdb push: %v", err)
 	}
+	writeDuckDBPushDiagnostics(os.Stdout, result)
 	fmt.Printf(
 		"Pushed %d sessions, %d messages to DuckDB in %s\n",
 		result.SessionsPushed,
@@ -96,6 +106,84 @@ func runDuckDBPush(cfg DuckDBPushConfig) {
 	if result.Errors > 0 {
 		fatal("duckdb push: %d session(s) failed", result.Errors)
 	}
+}
+
+func writeDuckDBPushPlan(
+	w io.Writer,
+	duckCfg config.DuckDBConfig,
+	cfg DuckDBPushConfig,
+	projects []string,
+	excludeProjects []string,
+	syncStateTarget string,
+) {
+	target := "local file " + duckCfg.Path
+	if duckCfg.URL != "" {
+		target = "remote Quack endpoint"
+	}
+	mode := "incremental"
+	if cfg.Full {
+		mode = "full"
+	}
+	scope := "default"
+	if syncStateTarget != "" {
+		scope = syncStateTarget
+	}
+	fmt.Fprintf(
+		w,
+		"DuckDB push target: %s; machine %q; mode %s; sync scope %s\n",
+		target, duckCfg.MachineName, mode, scope,
+	)
+	fmt.Fprintf(
+		w, "DuckDB push filters: %s\n",
+		formatDuckDBPushFilters(projects, excludeProjects),
+	)
+}
+
+func writeDuckDBPushDiagnostics(w io.Writer, result duckdbsync.PushResult) {
+	if result.Diagnostics.Cutoff == "" {
+		return
+	}
+	fmt.Fprintf(
+		w,
+		"DuckDB push source: local %s; candidates %s; skipped unchanged %s; stale deleted %d\n",
+		formatDuckDBPushSessionCounts(result.Diagnostics.LocalSessions),
+		formatDuckDBPushSessionCounts(result.Diagnostics.CandidateSessions),
+		formatDuckDBPushSessionCounts(result.Diagnostics.SkippedUnchangedSessions),
+		result.Diagnostics.DeletedStaleSessions,
+	)
+	fmt.Fprintf(
+		w,
+		"DuckDB push wrote: sessions %s, messages %d\n",
+		formatDuckDBPushSessionCounts(result.Diagnostics.PushedSessions),
+		result.MessagesPushed,
+	)
+}
+
+func formatDuckDBPushFilters(projects []string, excludeProjects []string) string {
+	switch {
+	case len(projects) > 0:
+		return "include projects " + strings.Join(projects, ", ")
+	case len(excludeProjects) > 0:
+		return "exclude projects " + strings.Join(excludeProjects, ", ")
+	default:
+		return "all projects"
+	}
+}
+
+func formatDuckDBPushSessionCounts(counts duckdbsync.PushSessionCounts) string {
+	if len(counts.ByAgent) == 0 {
+		return fmt.Sprintf("%d", counts.Total)
+	}
+	agents := make([]string, 0, len(counts.ByAgent))
+	for agent := range counts.ByAgent {
+		agents = append(agents, agent)
+	}
+	sort.Strings(agents)
+	parts := make([]string, 0, len(agents))
+	for _, agent := range agents {
+		parts = append(parts, fmt.Sprintf("%s=%d", agent, counts.ByAgent[agent]))
+	}
+	return fmt.Sprintf("%d (%s)", counts.Total, strings.Join(parts, ", "))
 }
 
 func duckDBLongRunningSignals() []os.Signal {
@@ -210,9 +298,15 @@ func runDuckDBServe(appCfg config.Config, basePath string) {
 			fatal("duckdb serve: schema migration failed: %v", err)
 		}
 	}
-	if err := duckdbsync.CheckSchemaCompat(ctx, store.DB()); err != nil {
+	var schemaErr error
+	if duckCfg.URL == "" {
+		schemaErr = duckdbsync.CheckSchemaCompat(ctx, store.DB())
+	} else {
+		schemaErr = duckdbsync.CheckSchemaCompatViaQuack(ctx, store.DB())
+	}
+	if schemaErr != nil {
 		fatal("duckdb serve: schema incompatible: %v\n"+
-			"Run 'agentsview duckdb push --full' to repopulate the mirror.", err)
+			"Run 'agentsview duckdb push --full' to repopulate the mirror.", schemaErr)
 	}
 
 	rtOpts := serveRuntimeOptions{

--- a/cmd/agentsview/duckdb_test.go
+++ b/cmd/agentsview/duckdb_test.go
@@ -214,6 +214,66 @@ func TestArchiveWriteBackendDuckDBPushWatchReResolvesDaemon(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(dataDir, "sessions.db"))
 }
 
+func TestWriteDuckDBPushPlanOmitsRemoteSecrets(t *testing.T) {
+	var out bytes.Buffer
+	duckCfg := config.DuckDBConfig{
+		URL:         "quack:https://user:duck-secret@duck.example.test/path?token=duck-secret",
+		Token:       "duck-token",
+		MachineName: "workstation",
+	}
+
+	writeDuckDBPushPlan(
+		&out,
+		duckCfg,
+		DuckDBPushConfig{Full: true},
+		[]string{"alpha", "beta"},
+		nil,
+		"url-abc123",
+	)
+
+	got := out.String()
+	assert.Contains(t, got, "DuckDB push target: remote Quack endpoint")
+	assert.Contains(t, got, `machine "workstation"`)
+	assert.Contains(t, got, "mode full")
+	assert.Contains(t, got, "sync scope url-abc123")
+	assert.Contains(t, got, "DuckDB push filters: include projects alpha, beta")
+	assert.NotContains(t, got, duckCfg.URL)
+	assert.NotContains(t, got, duckCfg.Token)
+	assert.NotContains(t, got, "duck-secret")
+}
+
+func TestWriteDuckDBPushDiagnosticsIncludesAgentBreakdown(t *testing.T) {
+	var out bytes.Buffer
+
+	writeDuckDBPushDiagnostics(&out, duckdbsync.PushResult{
+		SessionsPushed: 3,
+		MessagesPushed: 7,
+		Diagnostics: duckdbsync.PushDiagnostics{
+			Cutoff: "2026-07-01T12:00:00.000Z",
+			LocalSessions: duckdbsync.PushSessionCounts{
+				Total:   3,
+				ByAgent: map[string]int{"codex": 1, "claude": 2},
+			},
+			CandidateSessions: duckdbsync.PushSessionCounts{
+				Total:   3,
+				ByAgent: map[string]int{"codex": 1, "claude": 2},
+			},
+			SkippedUnchangedSessions: duckdbsync.PushSessionCounts{
+				Total: 0,
+			},
+			PushedSessions: duckdbsync.PushSessionCounts{
+				Total:   3,
+				ByAgent: map[string]int{"codex": 1, "claude": 2},
+			},
+			DeletedStaleSessions: 1,
+		},
+	})
+
+	got := out.String()
+	assert.Contains(t, got, "DuckDB push source: local 3 (claude=2, codex=1); candidates 3 (claude=2, codex=1); skipped unchanged 0; stale deleted 1")
+	assert.Contains(t, got, "DuckDB push wrote: sessions 3 (claude=2, codex=1), messages 7")
+}
+
 func TestWriteDuckDBQuackServeStartupDoesNotPrintToken(t *testing.T) {
 	var out bytes.Buffer
 	const token = "plain-quack-secret-token"

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -241,6 +241,11 @@ import (
 // classification, so historical skill usage is backfilled on
 // re-parse.)
 //
+// (58: Persisted message/result content sanitization now covers
+// tool_calls.result_content and tool_result_events.content. Existing rows
+// need re-parsing so NUL/control bytes accepted by SQLite are stripped before
+// they can poison DuckDB mirrors.)
+//
 // (57: Antigravity-CLI transcript fidelity classification. Re-parsing
 // populates transcript_fidelity ("full"/"summary") on existing
 // Antigravity CLI rows so sessions built from summary transcripts are
@@ -265,7 +270,7 @@ import (
 // (51: Gemini cumulative-to-delta token reparse.)
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 57
+const dataVersion = 58
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -842,9 +842,9 @@ func TestCurrentDataVersionGoalContextFiltering(t *testing.T) {
 		"Codex goal-context filtering requires a data version bump")
 }
 
-func TestCurrentDataVersionTranscriptFidelity(t *testing.T) {
-	assert.Equal(t, 57, CurrentDataVersion(),
-		"antigravity-cli transcript fidelity requires a data version bump")
+func TestCurrentDataVersionResultContentNULSanitization(t *testing.T) {
+	assert.Equal(t, 58, CurrentDataVersion(),
+		"message/result content NUL sanitization requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
@@ -5488,6 +5488,41 @@ func TestGetSessionForIncremental(t *testing.T) {
 		assert.True(t, got.HasTotalOutputTokens, "stored HasTotalOutputTokens = false, want true")
 		assert.True(t, got.HasPeakContextTokens, "stored HasPeakContextTokens = false, want true")
 	})
+}
+
+func TestFileIdentityChanged(t *testing.T) {
+	d := testDB(t)
+	path := "/tmp/sessions/forked.jsonl"
+
+	requireNoError(t, d.UpsertSession(Session{
+		ID:         "fork-main",
+		Agent:      "claude",
+		FilePath:   new(path),
+		FileInode:  new(int64(10)),
+		FileDevice: new(int64(20)),
+	}), "upsert fork-main")
+	requireNoError(t, d.UpsertSession(Session{
+		ID:         "fork-side",
+		Agent:      "claude",
+		FilePath:   new(path),
+		FileInode:  new(int64(10)),
+		FileDevice: new(int64(20)),
+	}), "upsert fork-side")
+
+	assert.False(t, d.FileIdentityChanged(path, 10, 20), "same identity changed")
+	assert.True(t, d.FileIdentityChanged(path, 11, 20), "different inode unchanged")
+	assert.True(t, d.FileIdentityChanged(path, 10, 21), "different device unchanged")
+	assert.False(t, d.FileIdentityChanged(path, 0, 20), "zero inode changed")
+	assert.False(t, d.FileIdentityChanged(path, 10, 0), "zero device changed")
+	assert.False(t, d.FileIdentityChanged("/tmp/sessions/missing.jsonl", 11, 20), "missing path changed")
+
+	legacyPath := "/tmp/sessions/legacy.jsonl"
+	requireNoError(t, d.UpsertSession(Session{
+		ID:       "legacy",
+		Agent:    "claude",
+		FilePath: new(legacyPath),
+	}), "upsert legacy")
+	assert.False(t, d.FileIdentityChanged(legacyPath, 1, 1), "missing stored identity changed")
 }
 
 func TestUpdateSessionIncremental(t *testing.T) {

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -205,6 +205,9 @@ func (d *DB) CopyOrphanedDataFromExcluding(
 	if err := copySessionDataForIDs(ctx, tx, "_orphaned_ids"); err != nil {
 		return 0, fmt.Errorf("copying orphaned data: %w", err)
 	}
+	if err := sanitizeCopiedSessionContent(ctx, tx, "_orphaned_ids"); err != nil {
+		return 0, fmt.Errorf("sanitizing orphaned data: %w", err)
+	}
 
 	if err := tx.Commit(); err != nil {
 		return 0, fmt.Errorf(
@@ -291,6 +294,9 @@ func (d *DB) CopyTrashedDataFrom(sourcePath string) (int, error) {
 
 	if err := copySessionDataForIDs(ctx, tx, "_trashed_ids"); err != nil {
 		return 0, fmt.Errorf("copying trashed data: %w", err)
+	}
+	if err := sanitizeCopiedSessionContent(ctx, tx, "_trashed_ids"); err != nil {
+		return 0, fmt.Errorf("sanitizing trashed data: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -786,6 +792,271 @@ func copySessionDataForIDs(
 		return err
 	}
 	return nil
+}
+
+func sanitizeCopiedSessionContent(
+	ctx context.Context,
+	tx *sql.Tx,
+	tempIDsTable string,
+) error {
+	if err := sanitizeCopiedMessageContent(ctx, tx, tempIDsTable); err != nil {
+		return err
+	}
+	if err := sanitizeCopiedToolCallInputs(ctx, tx, tempIDsTable); err != nil {
+		return err
+	}
+	if err := sanitizeCopiedToolCallResults(ctx, tx, tempIDsTable); err != nil {
+		return err
+	}
+	return sanitizeCopiedToolResultEvents(ctx, tx, tempIDsTable)
+}
+
+type copiedTextUpdate struct {
+	id      int64
+	content string
+	length  int
+}
+
+func sanitizeCopiedMessageContent(
+	ctx context.Context,
+	tx *sql.Tx,
+	tempIDsTable string,
+) error {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT id, content, content_length
+		 FROM main.messages
+		 WHERE session_id IN (SELECT id FROM `+tempIDsTable+`)`,
+	)
+	if err != nil {
+		return fmt.Errorf("querying copied messages: %w", err)
+	}
+	defer rows.Close()
+
+	var updates []copiedTextUpdate
+	for rows.Next() {
+		var row copiedTextUpdate
+		var storedLength int
+		if err := rows.Scan(&row.id, &row.content, &storedLength); err != nil {
+			return fmt.Errorf("scanning copied message: %w", err)
+		}
+		sanitized := SanitizeUTF8(row.content)
+		if sanitized == row.content {
+			continue
+		}
+		row.length = sanitizedCopiedTextLength(
+			row.content, sanitized, storedLength,
+		)
+		row.content = sanitized
+		updates = append(updates, row)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating copied messages: %w", err)
+	}
+	for _, row := range updates {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE main.messages
+			 SET content = ?, content_length = ?
+			 WHERE id = ?`,
+			row.content, row.length, row.id,
+		); err != nil {
+			return fmt.Errorf("updating copied message %d: %w", row.id, err)
+		}
+	}
+	return nil
+}
+
+type copiedNullableTextUpdate struct {
+	id      int64
+	content any
+	length  any
+}
+
+func sanitizeCopiedToolCallInputs(
+	ctx context.Context,
+	tx *sql.Tx,
+	tempIDsTable string,
+) error {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT id, input_json
+		 FROM main.tool_calls
+		 WHERE session_id IN (SELECT id FROM `+tempIDsTable+`)
+		   AND input_json IS NOT NULL`,
+	)
+	if err != nil {
+		return fmt.Errorf("querying copied tool call inputs: %w", err)
+	}
+	defer rows.Close()
+
+	var updates []copiedNullableTextUpdate
+	for rows.Next() {
+		var row copiedNullableTextUpdate
+		var content sql.NullString
+		if err := rows.Scan(&row.id, &content); err != nil {
+			return fmt.Errorf("scanning copied tool call input: %w", err)
+		}
+		if !content.Valid {
+			continue
+		}
+		sanitized := SanitizeUTF8(content.String)
+		if sanitized == content.String {
+			continue
+		}
+		if sanitized == "" {
+			row.content = nil
+		} else {
+			row.content = sanitized
+		}
+		updates = append(updates, row)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating copied tool call inputs: %w", err)
+	}
+	for _, row := range updates {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE main.tool_calls
+			 SET input_json = ?
+			 WHERE id = ?`,
+			row.content, row.id,
+		); err != nil {
+			return fmt.Errorf("updating copied tool call input %d: %w", row.id, err)
+		}
+	}
+	return nil
+}
+
+func sanitizeCopiedToolCallResults(
+	ctx context.Context,
+	tx *sql.Tx,
+	tempIDsTable string,
+) error {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT id, result_content, result_content_length
+		 FROM main.tool_calls
+		 WHERE session_id IN (SELECT id FROM `+tempIDsTable+`)
+		   AND result_content IS NOT NULL`,
+	)
+	if err != nil {
+		return fmt.Errorf("querying copied tool calls: %w", err)
+	}
+	defer rows.Close()
+
+	var updates []copiedNullableTextUpdate
+	for rows.Next() {
+		var id int64
+		var content sql.NullString
+		var storedLength sql.NullInt64
+		if err := rows.Scan(&id, &content, &storedLength); err != nil {
+			return fmt.Errorf("scanning copied tool call: %w", err)
+		}
+		if !content.Valid {
+			continue
+		}
+		sanitized := SanitizeUTF8(content.String)
+		if sanitized == content.String {
+			continue
+		}
+		update := copiedNullableTextUpdate{id: id}
+		if sanitized == "" {
+			update.content = nil
+		} else {
+			update.content = sanitized
+		}
+		update.length = sanitizedCopiedNullableTextLength(
+			content.String, sanitized, storedLength,
+		)
+		updates = append(updates, update)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating copied tool calls: %w", err)
+	}
+	for _, row := range updates {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE main.tool_calls
+			 SET result_content = ?, result_content_length = ?
+			 WHERE id = ?`,
+			row.content, row.length, row.id,
+		); err != nil {
+			return fmt.Errorf("updating copied tool call %d: %w", row.id, err)
+		}
+	}
+	return nil
+}
+
+func sanitizeCopiedToolResultEvents(
+	ctx context.Context,
+	tx *sql.Tx,
+	tempIDsTable string,
+) error {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT id, content, content_length
+		 FROM main.tool_result_events
+		 WHERE session_id IN (SELECT id FROM `+tempIDsTable+`)`,
+	)
+	if err != nil {
+		return fmt.Errorf("querying copied tool result events: %w", err)
+	}
+	defer rows.Close()
+
+	var updates []copiedTextUpdate
+	for rows.Next() {
+		var row copiedTextUpdate
+		var storedLength int
+		if err := rows.Scan(&row.id, &row.content, &storedLength); err != nil {
+			return fmt.Errorf("scanning copied tool result event: %w", err)
+		}
+		sanitized := SanitizeUTF8(row.content)
+		if sanitized == row.content {
+			continue
+		}
+		row.length = sanitizedCopiedTextLength(
+			row.content, sanitized, storedLength,
+		)
+		row.content = sanitized
+		updates = append(updates, row)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating copied tool result events: %w", err)
+	}
+	for _, row := range updates {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE main.tool_result_events
+			 SET content = ?, content_length = ?
+			 WHERE id = ?`,
+			row.content, row.length, row.id,
+		); err != nil {
+			return fmt.Errorf(
+				"updating copied tool result event %d: %w",
+				row.id, err,
+			)
+		}
+	}
+	return nil
+}
+
+func sanitizedCopiedTextLength(
+	original, sanitized string,
+	storedLength int,
+) int {
+	removed := len(original) - len(sanitized)
+	if removed > 0 {
+		subtractRemovedBytes(&storedLength, removed)
+	}
+	return storedLength
+}
+
+func sanitizedCopiedNullableTextLength(
+	original, sanitized string,
+	storedLength sql.NullInt64,
+) any {
+	if !storedLength.Valid {
+		return nil
+	}
+	length := int(storedLength.Int64)
+	removed := len(original) - len(sanitized)
+	if removed > 0 {
+		subtractRemovedBytes(&length, removed)
+	}
+	return int64(length)
 }
 
 func copyPinnedMessagesForIDs(

--- a/internal/db/orphaned_test.go
+++ b/internal/db/orphaned_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,4 +39,158 @@ func TestExecWithoutCancelDropsTempTableWithCanceledContext(t *testing.T) {
 			id TEXT PRIMARY KEY
 		)`)
 	require.NoError(t, err, "recreate temp table after cleanup")
+}
+
+func TestCopyOrphanedDataSanitizesCopiedContent(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "old.db")
+	srcDB := testDBAtPath(t, srcPath, "src")
+	insertSession(t, srcDB, "poison-orphan", "proj")
+	insertMessages(t, srcDB, userMsg("poison-orphan", 0, "clean"))
+	var messageID int64
+	require.NoError(t, srcDB.getWriter().QueryRowContext(ctx,
+		`SELECT id FROM messages WHERE session_id = ? AND ordinal = 0`,
+		"poison-orphan",
+	).Scan(&messageID), "query source message id")
+
+	messageContent := "message\x00body\x01\nkept"
+	toolInput := "{\"cmd\":\"tool\x00input\x04\"}"
+	emptyToolInput := "\x00\x04"
+	toolResult := "tool\x00result\x02"
+	emptyToolResult := "\x00\x04"
+	eventContent := "event\x00content\x03"
+	const (
+		messageLengthExcess = 7
+		toolLengthExcess    = 11
+		eventLengthExcess   = 5
+		emptyResultLength   = 7
+	)
+	_, err := srcDB.getWriter().ExecContext(ctx,
+		`UPDATE messages
+		 SET content = ?, content_length = ?
+		 WHERE id = ?`,
+		messageContent, len(messageContent)+messageLengthExcess, messageID,
+	)
+	require.NoError(t, err, "plant poisoned message")
+	_, err = srcDB.getWriter().ExecContext(ctx,
+		`INSERT INTO tool_calls (
+			message_id, session_id, tool_name, category,
+			tool_use_id, input_json, result_content_length,
+			result_content, call_index
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		messageID, "poison-orphan", "Read", "file", "tool-1",
+		toolInput, len(toolResult)+toolLengthExcess, toolResult, 0,
+	)
+	require.NoError(t, err, "plant poisoned tool call")
+	_, err = srcDB.getWriter().ExecContext(ctx,
+		`INSERT INTO tool_calls (
+			message_id, session_id, tool_name, category,
+			tool_use_id, input_json, call_index
+		) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		messageID, "poison-orphan", "Read", "file", "tool-empty",
+		emptyToolInput, 1,
+	)
+	require.NoError(t, err, "plant empty-sanitized tool input")
+	_, err = srcDB.getWriter().ExecContext(ctx,
+		`INSERT INTO tool_calls (
+			message_id, session_id, tool_name, category,
+			tool_use_id, result_content_length, result_content,
+			call_index
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		messageID, "poison-orphan", "Read", "file", "tool-empty-result",
+		emptyResultLength, emptyToolResult, 2,
+	)
+	require.NoError(t, err, "plant empty-sanitized tool result")
+	_, err = srcDB.getWriter().ExecContext(ctx,
+		`INSERT INTO tool_result_events (
+			session_id, tool_call_message_ordinal, call_index,
+			tool_use_id, source, status, content, content_length,
+			event_index
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"poison-orphan", 0, 0, "tool-1", "tool_result", "ok",
+		eventContent, len(eventContent)+eventLengthExcess, 0,
+	)
+	require.NoError(t, err, "plant poisoned tool result event")
+	require.NoError(t, srcDB.Close(), "close source")
+
+	dstPath := filepath.Join(dir, "new.db")
+	dstDB := testDBAtPath(t, dstPath, "dst")
+	defer dstDB.Close()
+
+	count, err := dstDB.CopyOrphanedDataFrom(srcPath)
+	require.NoError(t, err, "CopyOrphanedDataFrom")
+	require.Equal(t, 1, count, "expected one orphan")
+
+	var gotMessage string
+	var gotMessageLength int
+	require.NoError(t, dstDB.getReader().QueryRowContext(ctx,
+		`SELECT content, content_length
+		 FROM messages
+		 WHERE session_id = ? AND ordinal = 0`,
+		"poison-orphan",
+	).Scan(&gotMessage, &gotMessageLength), "query copied message")
+	wantMessage := SanitizeUTF8(messageContent)
+	assert.Equal(t, wantMessage, gotMessage)
+	assert.Equal(t, len(wantMessage)+messageLengthExcess, gotMessageLength)
+
+	var gotToolInput string
+	require.NoError(t, dstDB.getReader().QueryRowContext(ctx,
+		`SELECT input_json
+		 FROM tool_calls
+		 WHERE session_id = ? AND call_index = 0`,
+		"poison-orphan",
+	).Scan(&gotToolInput), "query copied tool input")
+	assert.Equal(t, SanitizeUTF8(toolInput), gotToolInput)
+
+	var gotEmptyToolInput sql.NullString
+	require.NoError(t, dstDB.getReader().QueryRowContext(ctx,
+		`SELECT input_json
+		 FROM tool_calls
+		 WHERE session_id = ? AND call_index = 1`,
+		"poison-orphan",
+	).Scan(&gotEmptyToolInput), "query empty copied tool input")
+	assert.False(t, gotEmptyToolInput.Valid)
+
+	var gotToolResult string
+	var gotToolResultLength int
+	require.NoError(t, dstDB.getReader().QueryRowContext(ctx,
+		`SELECT result_content, result_content_length
+		 FROM tool_calls
+		 WHERE session_id = ? AND call_index = 0`,
+		"poison-orphan",
+	).Scan(&gotToolResult, &gotToolResultLength), "query copied tool call")
+	wantToolResult := SanitizeUTF8(toolResult)
+	assert.Equal(t, wantToolResult, gotToolResult)
+	assert.Equal(t, len(wantToolResult)+toolLengthExcess, gotToolResultLength)
+
+	var gotEmptyToolResult sql.NullString
+	var gotEmptyToolResultLength sql.NullInt64
+	require.NoError(t, dstDB.getReader().QueryRowContext(ctx,
+		`SELECT result_content, result_content_length
+		 FROM tool_calls
+		 WHERE session_id = ? AND call_index = 2`,
+		"poison-orphan",
+	).Scan(
+		&gotEmptyToolResult,
+		&gotEmptyToolResultLength,
+	), "query empty copied tool call result")
+	assert.False(t, gotEmptyToolResult.Valid)
+	require.True(t, gotEmptyToolResultLength.Valid)
+	assert.Equal(t,
+		int64(emptyResultLength-len(emptyToolResult)),
+		gotEmptyToolResultLength.Int64,
+	)
+
+	var gotEventContent string
+	var gotEventLength int
+	require.NoError(t, dstDB.getReader().QueryRowContext(ctx,
+		`SELECT content, content_length
+		 FROM tool_result_events
+		 WHERE session_id = ? AND event_index = 0`,
+		"poison-orphan",
+	).Scan(&gotEventContent, &gotEventLength), "query copied tool result event")
+	wantEventContent := SanitizeUTF8(eventContent)
+	assert.Equal(t, wantEventContent, gotEventContent)
+	assert.Equal(t, len(wantEventContent)+eventLengthExcess, gotEventLength)
 }

--- a/internal/db/read_only_test.go
+++ b/internal/db/read_only_test.go
@@ -302,7 +302,7 @@ func requireReadOnlySchemaCompatibilityFails(
 
 func TestOpenReadOnlyAllowsMissingFTSTable(t *testing.T) {
 	path := createClosedTestDB(t, tempDBPath(t, "sessions.db"), nil)
-	execRawSQLite(t, path, "DROP TABLE messages_fts")
+	execRawSQLite(t, path, "DROP TABLE IF EXISTS messages_fts")
 
 	readonly, err := OpenReadOnly(path)
 	require.NoError(t, err)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1746,6 +1746,29 @@ func (db *DB) GetSessionForIncremental(
 	return &info, true
 }
 
+// FileIdentityChanged reports whether any active session row for path has a
+// known file identity that differs from the current file identity.
+func (db *DB) FileIdentityChanged(path string, inode, device int64) bool {
+	if path == "" || inode == 0 || device == 0 {
+		return false
+	}
+
+	var count int
+	err := db.getReader().QueryRow(
+		`SELECT COUNT(*)
+		 FROM sessions
+		 WHERE file_path = ?
+		   AND deleted_at IS NULL
+		   AND file_inode IS NOT NULL
+		   AND file_device IS NOT NULL
+		   AND file_inode != 0
+		   AND file_device != 0
+		   AND (file_inode != ? OR file_device != ?)`,
+		path, inode, device,
+	).Scan(&count)
+	return err == nil && count > 0
+}
+
 // UpdateSessionIncremental updates only the fields that change
 // during an incremental append: ended_at, message_count,
 // user_message_count, file_size, file_mtime, optional file_hash, and token

--- a/internal/db/validate.go
+++ b/internal/db/validate.go
@@ -36,17 +36,13 @@ import (
 //     blanked. Empty-string handling is preserved as-is so downstream
 //     localTime treats a blanked timestamp as invalid.
 //
-// DELIBERATE EXCLUSION: Message.TokenUsage (json.RawMessage) and the
-// nested ToolCalls/ToolResults string fields are intentionally NOT run
-// through the central sanitizer here. They are sanitized symmetrically by
-// the local fingerprint builders and the pg-push path, so idempotency and
-// backend parity still hold. Usage aggregation separately clamps numeric
-// TokenUsage fields as it reads them, so a retained corrupt raw value cannot
-// inflate dashboards or estimated cost; leaving these nested values out only
-// means local SQLite columns may retain control bytes in those nested values.
-// Expanding sanitization into nested structures is deferred to a
-// follow-up to avoid changing the bytes fingerprints are computed over in
-// this commit.
+// Message.TokenUsage (json.RawMessage), tool-call input JSON, and transient
+// ToolResults.ContentRaw are intentionally not run through this pass. They are
+// raw provider payloads, not persisted display text. Persisted result content
+// (tool_calls.result_content and tool_result_events.content) follows the same
+// text contract as Message.Content, with length fields reduced by the
+// stripped-byte delta so re-ingest rewrites historical poison rows into the
+// stable stored shape.
 //
 // CRITICAL idempotency invariant: SanitizeUTF8 is the shared
 // sanitization seam used here, by the local fingerprint builders, and
@@ -159,14 +155,9 @@ func SanitizeMessage(m *Message) ValidationStats {
 	// which would false-fire forever when stored content was stripped but
 	// its length stayed raw; the reconcile path sanitizes re-parsed
 	// content before comparing, so the lengths stay aligned.
-	origLen := len(m.Content)
-	sanitizeStringField(&m.Content, &stats)
-	if removed := origLen - len(m.Content); removed > 0 {
-		m.ContentLength -= removed
-		if m.ContentLength < 0 {
-			m.ContentLength = 0
-		}
-	}
+	sanitizeLengthTrackedString(
+		&m.Content, &m.ContentLength, &stats,
+	)
 	origThinkingLen := len(m.ThinkingText)
 	sanitizeStringField(&m.ThinkingText, &stats)
 	if removed := origThinkingLen - len(m.ThinkingText); removed > 0 {
@@ -189,6 +180,10 @@ func SanitizeMessage(m *Message) ValidationStats {
 	sanitizeStringField(&m.SourceUUID, &stats)
 	sanitizeStringField(&m.SourceParentUUID, &stats)
 
+	for i := range m.ToolCalls {
+		sanitizeToolCallResultContent(&m.ToolCalls[i], &stats)
+	}
+
 	sanitizeStringField(&m.Model, &stats)
 	if ClampModel(&m.Model) {
 		stats.ModelClamped++
@@ -206,6 +201,21 @@ func SanitizeMessage(m *Message) ValidationStats {
 	}
 
 	return stats
+}
+
+func sanitizeToolCallResultContent(
+	tc *ToolCall, stats *ValidationStats,
+) {
+	sanitizeLengthTrackedString(
+		&tc.ResultContent, &tc.ResultContentLength, stats,
+	)
+	for i := range tc.ResultEvents {
+		sanitizeLengthTrackedString(
+			&tc.ResultEvents[i].Content,
+			&tc.ResultEvents[i].ContentLength,
+			stats,
+		)
+	}
 }
 
 // SanitizeUsageEvent applies the contract to a single usage event row.
@@ -319,6 +329,23 @@ func sanitizeStringPtrField(p *string, stats *ValidationStats) {
 		return
 	}
 	sanitizeStringField(p, stats)
+}
+
+func sanitizeLengthTrackedString(
+	p *string, length *int, stats *ValidationStats,
+) {
+	origLen := len(*p)
+	sanitizeStringField(p, stats)
+	if removed := origLen - len(*p); removed > 0 {
+		subtractRemovedBytes(length, removed)
+	}
+}
+
+func subtractRemovedBytes(length *int, removed int) {
+	*length -= removed
+	if *length < 0 {
+		*length = 0
+	}
 }
 
 // ClampModel truncates an over-long model id in place and reports

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -108,7 +108,7 @@ func (s *Store) activityReportSessions(
 			s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)
 		AND COALESCE(s.started_at, s.created_at) < CAST(? AS TIMESTAMP)`
 
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"querying duckdb activity report sessions: %w", err)
@@ -157,7 +157,7 @@ func (s *Store) activityReportActivity(
 			AND timestamp IS NOT NULL
 		ORDER BY session_id, ordinal`
 
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"querying duckdb activity report activity: %w", err)
@@ -236,7 +236,7 @@ func (s *Store) activityReportUsage(
 	args = append(args, idArgs...) // event-source IN
 	args = append(args, lowerBound, upperBound)
 
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying duckdb activity report usage: %w", err)
 	}

--- a/internal/duckdb/analytics_scope.go
+++ b/internal/duckdb/analytics_scope.go
@@ -69,7 +69,7 @@ func (s *Store) resolveAnalyticsMessageScope(
 	if err := duckQueryChunked(unique, func(chunk []string) error {
 		reducer := db.NewScopeReducer(flt, emit)
 		ph, args := duckInPlaceholders(chunk)
-		rows, err := s.duck.QueryContext(ctx, `
+		rows, err := s.queryContext(ctx, `
 			SELECT session_id, ordinal, role, is_system, COALESCE(model, ''),
 				has_thinking, has_tool_use, timestamp,
 				output_tokens, has_output_tokens, content_length, `+contentExpr+`

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -79,7 +79,7 @@ func (s *Store) analyticsSessionsFiltered(
 	where, args := duckBuildAnalyticsWhere(
 		f, "COALESCE(s.started_at, s.created_at)", "s.",
 		includeDate, includeTime)
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT id, project, machine, agent, first_message,
 			COALESCE(display_name, session_name) AS display_name,
 			started_at, ended_at, created_at, message_count,
@@ -523,7 +523,7 @@ func (s *Store) getAnalyticsModelsForSessionIDs(
 	models := map[string]bool{}
 	err := duckQueryChunked(sessionIDs, func(chunk []string) error {
 		ph, args := duckInPlaceholders(chunk)
-		rows, err := s.duck.QueryContext(ctx, `
+		rows, err := s.queryContext(ctx, `
 			SELECT DISTINCT model
 			FROM messages
 			WHERE session_id IN `+ph+`
@@ -575,7 +575,7 @@ func (s *Store) getAnalyticsModelsForSessionIDsFiltered(
 	models := map[string]bool{}
 	err := duckQueryChunked(unique, func(chunk []string) error {
 		ph, args := duckInPlaceholders(chunk)
-		rows, err := s.duck.QueryContext(ctx, `
+		rows, err := s.queryContext(ctx, `
 			SELECT model, timestamp
 			FROM messages
 			WHERE session_id IN `+ph+`
@@ -814,7 +814,7 @@ func (s *Store) GetAnalyticsSummary(
 				) top_projects
 			)::DOUBLE / NULLIF(SUM(message_count), 0), 3), 0) AS concentration
 		FROM filtered`
-	rows, err := s.duck.QueryContext(ctx, query, queryArgs...)
+	rows, err := s.queryContext(ctx, query, queryArgs...)
 	if err != nil {
 		return db.AnalyticsSummary{}, fmt.Errorf("querying duckdb analytics summary: %w", err)
 	}
@@ -847,7 +847,7 @@ func (s *Store) GetAnalyticsSummary(
 		return db.AnalyticsSummary{}, fmt.Errorf("closing duckdb analytics summary rows: %w", err)
 	}
 
-	agentRows, err := s.duck.QueryContext(ctx, `
+	agentRows, err := s.queryContext(ctx, `
 		WITH filtered AS (
 			SELECT s.agent, s.message_count
 			FROM sessions s
@@ -915,7 +915,7 @@ func (s *Store) getAnalyticsFilteredToolCallCounts(
 	loc := analyticsLocation(f.Timezone)
 	err := duckQueryChunked(sessionIDs, func(chunk []string) error {
 		ph, args := duckInPlaceholders(chunk)
-		rows, err := s.duck.QueryContext(ctx, `
+		rows, err := s.queryContext(ctx, `
 			SELECT tc.session_id, m.model, m.timestamp, COUNT(*)
 			FROM tool_calls tc
 			JOIN messages m
@@ -1064,7 +1064,7 @@ func (s *Store) queryActivityBuckets(
 		queryArgs = append(queryArgs, modelArgs...)
 		queryArgs = append(queryArgs, modelArgs...)
 	}
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		WITH filtered_sessions AS (
 			SELECT s.id, s.message_count, `+localDate+` AS local_date
 			FROM sessions s
@@ -1149,7 +1149,7 @@ func (s *Store) addActivityAgentCounts(
 	if _, modelArgs := duckAnalyticsCSVPredicate("m.model", f.Model); len(modelArgs) > 0 {
 		queryArgs = append(queryArgs, modelArgs...)
 	}
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		WITH filtered_sessions AS (
 			SELECT s.id, s.agent, `+localDate+` AS local_date
 			FROM sessions s
@@ -1312,7 +1312,7 @@ func (s *Store) GetAnalyticsHeatmap(
 	}
 	queryArgs := append([]any{}, localDateArgs...)
 	queryArgs = append(queryArgs, args...)
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT `+localDate+` AS local_date, `+valueExpr+` AS value
 		FROM sessions s
 		WHERE `+where+`
@@ -1504,7 +1504,7 @@ func (s *Store) GetAnalyticsHourOfWeek(
 	localTime, localTimeArgs := duckAnalyticsLocalTimeExpr("m.timestamp", f)
 	queryArgs := append([]any{}, args...)
 	queryArgs = append(queryArgs, localTimeArgs...)
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		WITH filtered_sessions AS (
 			SELECT s.id
 			FROM sessions s
@@ -1730,7 +1730,7 @@ func (s *Store) analyticsAutonomyBuckets(
 		args[i] = id
 		placeholders[i] = "?"
 	}
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT session_id,
 			SUM(CASE WHEN role = 'user' AND is_system = FALSE THEN 1 ELSE 0 END) AS user_count,
 			SUM(CASE WHEN role = 'assistant' AND has_tool_use = TRUE THEN 1 ELSE 0 END) AS tool_count
@@ -1826,7 +1826,7 @@ func (s *Store) GetAnalyticsTools(
 		}
 		query += `
 				GROUP BY tc.session_id, tc.category, m.timestamp`
-		rows, qErr := s.duck.QueryContext(ctx, query, args...)
+		rows, qErr := s.queryContext(ctx, query, args...)
 		if qErr != nil {
 			return qErr
 		}
@@ -1928,7 +1928,7 @@ func (s *Store) GetAnalyticsSkills(
 		ph, args := duckInPlaceholders(chunk)
 		modelPred, modelArgs := duckAnalyticsCSVPredicate("m.model", f.Model)
 		args = append(args, modelArgs...)
-		rows, qErr := s.duck.QueryContext(ctx,
+		rows, qErr := s.queryContext(ctx,
 			`SELECT tc.session_id, TRIM(COALESCE(tc.skill_name, '')),
 				COUNT(*), m.timestamp
 				FROM tool_calls tc
@@ -2133,7 +2133,7 @@ func (s *Store) velocityMessages(
 		return out, nil
 	}
 	args, placeholders := stringInArgs(sessionIDs)
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT session_id, ordinal, role, timestamp, content_length
 		FROM messages
 		WHERE session_id IN (`+strings.Join(placeholders, ",")+`)
@@ -2202,7 +2202,7 @@ func (s *Store) velocityToolCounts(
 		return out, nil
 	}
 	args, placeholders := stringInArgs(sessionIDs)
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT session_id, COUNT(*)
 		FROM tool_calls
 		WHERE session_id IN (`+strings.Join(placeholders, ",")+`)
@@ -2495,7 +2495,7 @@ func (s *Store) GetAnalyticsTopSessions(
 		FROM sessions s
 		WHERE ` + where + `
 		ORDER BY ` + orderExpr + limitClause
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return db.TopSessionsResponse{}, fmt.Errorf("querying duckdb analytics top sessions: %w", err)
 	}
@@ -2647,7 +2647,7 @@ func (s *Store) duckPopulateFrustrationMarkers(
 		FROM messages
 		WHERE role = 'user' AND session_id IN (` +
 		strings.Join(placeholders, ",") + `)`
-	msgRows, err := s.duck.QueryContext(ctx, q, args...)
+	msgRows, err := s.queryContext(ctx, q, args...)
 	if err != nil {
 		return fmt.Errorf("querying duckdb frustration markers: %w", err)
 	}
@@ -2733,7 +2733,7 @@ func (s *Store) duckSignalMessages(
 	}
 	q += `
 		ORDER BY session_id, ordinal`
-	msgRows, err := s.duck.QueryContext(ctx, q, args...)
+	msgRows, err := s.queryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying duckdb signal messages: %w", err)
 	}
@@ -2804,7 +2804,7 @@ func (s *Store) GetTrendsTerms(
 		}
 		return t.In(loc), true
 	}
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT m.session_id, m.ordinal, m.role, m.is_system,
 			COALESCE(m.model, ''), m.content, m.timestamp,
 			s.started_at, s.created_at
@@ -2899,7 +2899,7 @@ type duckRates struct {
 }
 
 func (s *Store) loadPricing(ctx context.Context) (map[string]duckRates, error) {
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT model_pattern, input_per_mtok, output_per_mtok,
 			cache_creation_per_mtok, cache_read_per_mtok
 		FROM model_pricing`)
@@ -3477,7 +3477,7 @@ func (s *Store) dailyUsageAggregateRows(
 		FROM usage_localized
 		GROUP BY local_date, project, agent, model
 		ORDER BY local_date ASC, project ASC, agent ASC, model ASC`
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying duckdb daily usage aggregates: %w", err)
 	}
@@ -3704,7 +3704,7 @@ func (s *Store) sessionUsageAggregateRows(
 		FROM usage_localized
 		GROUP BY session_id, project, agent, model
 		ORDER BY session_id ASC, model ASC`
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying duckdb session usage aggregates: %w", err)
 	}

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -385,6 +385,17 @@ func redactQuackErrorValue(message, value, replacement string) string {
 	return strings.ReplaceAll(message, duckLiteral(value), duckLiteral(replacement))
 }
 
+func redactQuackCredentialValue(message, value string) string {
+	message = redactQuackErrorValue(message, value, "<redacted>")
+	if escaped := neturl.QueryEscape(value); escaped != value {
+		message = redactQuackErrorValue(message, escaped, "<redacted>")
+	}
+	if escaped := neturl.PathEscape(value); escaped != value {
+		message = redactQuackErrorValue(message, escaped, "<redacted>")
+	}
+	return message
+}
+
 func redactQuackURLCredentialValues(message, rawURL string) string {
 	transport := strings.TrimPrefix(rawURL, "quack:")
 	if strings.HasPrefix(transport, "http://") ||
@@ -400,17 +411,17 @@ func redactHTTPQuackURLCredentialValues(message, transport string) string {
 		return message
 	}
 	if username := u.User.Username(); username != "" {
-		message = redactQuackErrorValue(message, username, "<redacted>")
+		message = redactQuackCredentialValue(message, username)
 	}
 	if password, ok := u.User.Password(); ok {
-		message = redactQuackErrorValue(message, password, "<redacted>")
+		message = redactQuackCredentialValue(message, password)
 	}
 	for key, values := range u.Query() {
 		if !isSecretURLQueryKey(key) {
 			continue
 		}
 		for _, value := range values {
-			message = redactQuackErrorValue(message, value, "<redacted>")
+			message = redactQuackCredentialValue(message, value)
 		}
 	}
 	return message
@@ -419,9 +430,14 @@ func redactHTTPQuackURLCredentialValues(message, transport string) string {
 func redactNativeQuackCredentialValues(message, transport string) string {
 	transport = strings.SplitN(transport, "#", 2)[0]
 	base, rawQuery, hasQuery := strings.Cut(transport, "?")
-	if userinfo, _, ok := strings.Cut(base, "@"); ok {
+	base = strings.TrimPrefix(base, "//")
+	if scheme, rest, ok := strings.Cut(base, "://"); ok && scheme != "" {
+		base = rest
+	}
+	if at := strings.LastIndex(base, "@"); at >= 0 {
+		userinfo := base[:at]
 		for value := range strings.SplitSeq(userinfo, ":") {
-			message = redactQuackErrorValue(message, value, "<redacted>")
+			message = redactQuackCredentialValue(message, value)
 		}
 	}
 	if !hasQuery {
@@ -436,7 +452,7 @@ func redactNativeQuackCredentialValues(message, transport string) string {
 			continue
 		}
 		for _, value := range values {
-			message = redactQuackErrorValue(message, value, "<redacted>")
+			message = redactQuackCredentialValue(message, value)
 		}
 	}
 	return message

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -462,14 +462,51 @@ func nativeQuackUserinfo(base string) string {
 	if at := strings.LastIndex(authority, "@"); at >= 0 {
 		return authority[:at]
 	}
-	if !hasPath || !strings.Contains(authority, ":") {
+	if !hasPath {
 		return ""
 	}
 	at := strings.LastIndex(base, "@")
 	if at < 0 {
 		return ""
 	}
+	userinfo := base[:at]
+	userinfoHead, _, _ := strings.Cut(userinfo, "/")
+	if !strings.Contains(userinfoHead, ":") {
+		return ""
+	}
+	reattachedAuthority, _, _ := strings.Cut(base[at+1:], "/")
+	if !nativeQuackLooksLikeAuthority(reattachedAuthority) {
+		return ""
+	}
 	return base[:at]
+}
+
+func nativeQuackLooksLikeAuthority(authority string) bool {
+	if authority == "" {
+		return false
+	}
+	host := authority
+	if maybeHost, maybePort, ok := strings.Cut(authority, ":"); ok {
+		if maybeHost != "" && allDigits(maybePort) {
+			return true
+		}
+		host = maybeHost
+	}
+	return strings.Contains(host, ".") ||
+		strings.EqualFold(host, "localhost") ||
+		net.ParseIP(host) != nil
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func (q *quackClient) queryRemote(

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -434,9 +434,7 @@ func redactNativeQuackCredentialValues(message, transport string) string {
 	if scheme, rest, ok := strings.Cut(base, "://"); ok && scheme != "" {
 		base = rest
 	}
-	authority, _, _ := strings.Cut(base, "/")
-	if at := strings.LastIndex(authority, "@"); at >= 0 {
-		userinfo := authority[:at]
+	if userinfo := nativeQuackUserinfo(base); userinfo != "" {
 		for value := range strings.SplitSeq(userinfo, ":") {
 			message = redactQuackCredentialValue(message, value)
 		}
@@ -457,6 +455,21 @@ func redactNativeQuackCredentialValues(message, transport string) string {
 		}
 	}
 	return message
+}
+
+func nativeQuackUserinfo(base string) string {
+	authority, _, hasPath := strings.Cut(base, "/")
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		return authority[:at]
+	}
+	if !hasPath || !strings.Contains(authority, ":") {
+		return ""
+	}
+	at := strings.LastIndex(base, "@")
+	if at < 0 {
+		return ""
+	}
+	return base[:at]
 }
 
 func (q *quackClient) queryRemote(

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -434,8 +434,9 @@ func redactNativeQuackCredentialValues(message, transport string) string {
 	if scheme, rest, ok := strings.Cut(base, "://"); ok && scheme != "" {
 		base = rest
 	}
-	if at := strings.LastIndex(base, "@"); at >= 0 {
-		userinfo := base[:at]
+	authority, _, _ := strings.Cut(base, "/")
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		userinfo := authority[:at]
 		for value := range strings.SplitSeq(userinfo, ":") {
 			message = redactQuackCredentialValue(message, value)
 		}

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -5,15 +5,19 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	neturl "net/url"
 	"runtime"
 	"strings"
+	"sync"
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 )
+
+const quackAttachmentName = "agentsview_remote"
 
 // Open opens a local DuckDB file for the agentsview mirror backend.
 func Open(path string) (*sql.DB, error) {
@@ -128,17 +132,22 @@ func ReadStatusFromConfig(
 		return SyncStatus{}, err
 	}
 	defer store.Close()
-	return readMachineStatus(ctx, store.DB(), cfg.MachineName, lastPush)
+	return readMachineStatus(
+		ctx, store.DB(), store.connectionKind, store.quack,
+		cfg.MachineName, lastPush,
+	)
 }
 
 func readMachineStatus(
 	ctx context.Context,
 	duck *sql.DB,
+	connectionKind duckDBConnectionKind,
+	quack *quackClient,
 	machine string,
 	lastPush string,
 ) (SyncStatus, error) {
 	status := SyncStatus{Machine: machine, LastPushAt: lastPush}
-	if err := duck.QueryRowContext(ctx,
+	if err := queryDuckDBRowContext(ctx, duck, connectionKind, quack,
 		`SELECT COUNT(*) FROM sessions WHERE machine = ?`,
 		machine,
 	).Scan(&status.DuckDBSessions); err != nil {
@@ -147,7 +156,7 @@ func readMachineStatus(
 		}
 		return SyncStatus{}, fmt.Errorf("counting duckdb sessions: %w", err)
 	}
-	if err := duck.QueryRowContext(ctx,
+	if err := queryDuckDBRowContext(ctx, duck, connectionKind, quack,
 		`SELECT COUNT(*)
 		 FROM messages
 		 WHERE session_id IN (
@@ -182,23 +191,35 @@ func NewStoreFromConfig(cfg config.DuckDBConfig) (*Store, error) {
 	return NewStore(cfg.Path)
 }
 
+// ValidatePushTarget validates remote DuckDB push targets without opening a
+// DuckDB connection. Local file targets are validated when opened.
+func ValidatePushTarget(cfg config.DuckDBConfig) error {
+	if cfg.URL == "" {
+		return nil
+	}
+	return ValidateQuackClientURL(cfg.URL, cfg.Token, cfg.AllowInsecure)
+}
+
 // NewFromConfig opens either a local DuckDB mirror file or a remote Quack
 // endpoint for push sync.
 func NewFromConfig(
 	cfg config.DuckDBConfig, local *db.DB, opts SyncOptions,
 ) (*Sync, error) {
-	if local == nil {
-		return nil, fmt.Errorf("local db is required")
-	}
-	if cfg.MachineName == "" {
-		return nil, fmt.Errorf("machine name must not be empty")
+	if err := validateSyncInputs(local, cfg.MachineName); err != nil {
+		return nil, err
 	}
 	var (
-		duck *sql.DB
-		err  error
+		duck           *sql.DB
+		quack          *quackClient
+		err            error
+		connectionKind = duckDBBaseConnection
 	)
 	if cfg.URL != "" {
-		duck, err = OpenQuack(cfg.URL, cfg.Token, cfg.AllowInsecure)
+		quack, err = openQuackClient(cfg.URL, cfg.Token, cfg.AllowInsecure)
+		if err == nil {
+			duck = quack.DB()
+		}
+		connectionKind = duckDBQuackClientConnection
 	} else {
 		duck, err = Open(cfg.Path)
 	}
@@ -212,21 +233,44 @@ func NewFromConfig(
 		syncStateScope:  opts.SyncStateTarget,
 		projects:        opts.Projects,
 		excludeProjects: opts.ExcludeProjects,
+		connectionKind:  connectionKind,
+		quack:           quack,
 	}, nil
 }
 
 // NewQuackStore attaches a remote DuckDB exposed over Quack.
 func NewQuackStore(rawURL, token string, allowInsecure bool) (*Store, error) {
-	conn, err := OpenQuack(rawURL, token, allowInsecure)
+	client, err := openQuackClient(rawURL, token, allowInsecure)
 	if err != nil {
 		return nil, err
 	}
-	return NewStoreFromDB(conn), nil
+	return &Store{
+		duck:           client.DB(),
+		quack:          client,
+		connectionKind: duckDBQuackClientConnection,
+	}, nil
 }
 
 // OpenQuack opens an in-memory DuckDB client and attaches a remote DuckDB
 // exposed over Quack as the default catalog.
 func OpenQuack(rawURL, token string, allowInsecure bool) (*sql.DB, error) {
+	client, err := openQuackClient(rawURL, token, allowInsecure)
+	if err != nil {
+		return nil, err
+	}
+	return client.DB(), nil
+}
+
+type quackClient struct {
+	duck       *sql.DB
+	rawURL     string
+	token      string
+	reattachMu sync.Mutex
+}
+
+func openQuackClient(
+	rawURL, token string, allowInsecure bool,
+) (*quackClient, error) {
 	if err := ValidateQuackClientURL(rawURL, token, allowInsecure); err != nil {
 		return nil, err
 	}
@@ -249,22 +293,218 @@ func OpenQuack(rawURL, token string, allowInsecure bool) (*sql.DB, error) {
 		conn.Close()
 		return nil, fmt.Errorf("loading quack extension: %w", err)
 	}
-	attach := "ATTACH " + duckLiteral(rawURL) + " AS agentsview_remote"
+	client := &quackClient{
+		duck:   conn,
+		rawURL: rawURL,
+		token:  token,
+	}
+	if err := client.attach(context.Background()); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return client, nil
+}
+
+func (q *quackClient) DB() *sql.DB { return q.duck }
+
+func (q *quackClient) attach(ctx context.Context) error {
+	conn, err := q.duck.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("opening duckdb client connection: %w", err)
+	}
+	defer conn.Close()
+	return q.attachConn(ctx, conn)
+}
+
+func (q *quackClient) attachConn(ctx context.Context, conn *sql.Conn) error {
+	if _, err := conn.ExecContext(ctx, quackAttachSQL(q.rawURL, q.token)); err != nil {
+		return fmt.Errorf(
+			"attaching quack endpoint %s: %w", RedactQuackURL(q.rawURL),
+			redactQuackClientError(err, q.rawURL, q.token),
+		)
+	}
+	if _, err := conn.ExecContext(ctx, "USE "+quackAttachmentName); err != nil {
+		return fmt.Errorf("selecting quack catalog: %w", err)
+	}
+	return nil
+}
+
+func quackAttachSQL(rawURL, token string) string {
+	attach := "ATTACH " + duckLiteral(rawURL) + " AS " + quackAttachmentName
 	if token != "" {
 		attach += " (TOKEN " + duckLiteral(token) + ")"
 	}
-	if _, err := conn.Exec(attach); err != nil {
-		conn.Close()
+	return attach
+}
+
+func (q *quackClient) reattachLocked(ctx context.Context) error {
+	conn, err := q.duck.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("opening duckdb client connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "USE memory"); err != nil {
+		return fmt.Errorf("selecting local duckdb catalog: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "DETACH "+quackAttachmentName); err != nil {
+		if !isMissingQuackAttachmentError(err) {
+			return fmt.Errorf(
+				"detaching quack endpoint %s: %w",
+				RedactQuackURL(q.rawURL), err,
+			)
+		}
+	}
+	return q.attachConn(ctx, conn)
+}
+
+func redactQuackClientError(err error, rawURL, token string) error {
+	if err == nil {
+		return nil
+	}
+	msg := redactQuackClientErrorMessage(err.Error(), rawURL, token)
+	return errors.New(msg)
+}
+
+func redactQuackClientErrorMessage(message, rawURL, token string) string {
+	redactedURL := RedactQuackURL(rawURL)
+	message = redactQuackErrorValue(message, rawURL, redactedURL)
+	if transport, ok := strings.CutPrefix(rawURL, "quack:"); ok {
+		redactedTransport := strings.TrimPrefix(redactedURL, "quack:")
+		message = redactQuackErrorValue(message, transport, redactedTransport)
+	}
+	message = redactQuackURLCredentialValues(message, rawURL)
+	message = redactQuackErrorValue(message, token, "<redacted>")
+	return message
+}
+
+func redactQuackErrorValue(message, value, replacement string) string {
+	if value == "" {
+		return message
+	}
+	message = strings.ReplaceAll(message, value, replacement)
+	return strings.ReplaceAll(message, duckLiteral(value), duckLiteral(replacement))
+}
+
+func redactQuackURLCredentialValues(message, rawURL string) string {
+	transport := strings.TrimPrefix(rawURL, "quack:")
+	if strings.HasPrefix(transport, "http://") ||
+		strings.HasPrefix(transport, "https://") {
+		return redactHTTPQuackURLCredentialValues(message, transport)
+	}
+	return redactNativeQuackCredentialValues(message, transport)
+}
+
+func redactHTTPQuackURLCredentialValues(message, transport string) string {
+	u, err := neturl.Parse(transport)
+	if err != nil {
+		return message
+	}
+	if username := u.User.Username(); username != "" {
+		message = redactQuackErrorValue(message, username, "<redacted>")
+	}
+	if password, ok := u.User.Password(); ok {
+		message = redactQuackErrorValue(message, password, "<redacted>")
+	}
+	for key, values := range u.Query() {
+		if !isSecretURLQueryKey(key) {
+			continue
+		}
+		for _, value := range values {
+			message = redactQuackErrorValue(message, value, "<redacted>")
+		}
+	}
+	return message
+}
+
+func redactNativeQuackCredentialValues(message, transport string) string {
+	transport = strings.SplitN(transport, "#", 2)[0]
+	base, rawQuery, hasQuery := strings.Cut(transport, "?")
+	if userinfo, _, ok := strings.Cut(base, "@"); ok {
+		for value := range strings.SplitSeq(userinfo, ":") {
+			message = redactQuackErrorValue(message, value, "<redacted>")
+		}
+	}
+	if !hasQuery {
+		return message
+	}
+	q, err := neturl.ParseQuery(rawQuery)
+	if err != nil {
+		return message
+	}
+	for key, values := range q {
+		if !isSecretURLQueryKey(key) {
+			continue
+		}
+		for _, value := range values {
+			message = redactQuackErrorValue(message, value, "<redacted>")
+		}
+	}
+	return message
+}
+
+func (q *quackClient) queryRemote(
+	ctx context.Context, sqlText string, retryStale bool,
+) (*sql.Rows, error) {
+	query := "SELECT * FROM " + quackAttachmentName + ".query(?)"
+	rows, err := q.duck.QueryContext(ctx, query, sqlText)
+	if err == nil || !retryStale || !isStaleQuackConnectionError(err) ||
+		ctx.Err() != nil {
+		return rows, err
+	}
+	q.reattachMu.Lock()
+	defer q.reattachMu.Unlock()
+	if reattachErr := q.reattachLocked(ctx); reattachErr != nil {
 		return nil, fmt.Errorf(
-			"attaching quack endpoint %s: %w",
-			RedactQuackURL(rawURL), err,
+			"%w; reattaching quack endpoint %s: %v",
+			err, RedactQuackURL(q.rawURL), reattachErr,
 		)
 	}
-	if _, err := conn.Exec("USE agentsview_remote"); err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("selecting quack catalog: %w", err)
+	return q.duck.QueryContext(ctx, query, sqlText)
+}
+
+func (q *quackClient) execRemote(
+	ctx context.Context, sqlText string, retryStale bool,
+) error {
+	query := "FROM " + quackAttachmentName + ".query(?)"
+	_, err := q.duck.ExecContext(ctx, query, sqlText)
+	if err == nil || !retryStale || !isStaleQuackConnectionError(err) ||
+		ctx.Err() != nil {
+		return err
 	}
-	return conn, nil
+	q.reattachMu.Lock()
+	defer q.reattachMu.Unlock()
+	if reattachErr := q.reattachLocked(ctx); reattachErr != nil {
+		return fmt.Errorf(
+			"%w; reattaching quack endpoint %s: %v",
+			err, RedactQuackURL(q.rawURL), reattachErr,
+		)
+	}
+	_, err = q.duck.ExecContext(ctx, query, sqlText)
+	return err
+}
+
+func isStaleQuackConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "invalid connection id") ||
+		isMissingQuackAttachmentError(err) ||
+		(strings.Contains(msg, "failed to send message") &&
+			strings.Contains(msg, "bad gateway"))
+}
+
+func isMissingQuackAttachmentError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "does not exist") &&
+		!strings.Contains(msg, "database not found") {
+		return false
+	}
+	return strings.Contains(msg, strings.ToLower(quackAttachmentName)) ||
+		strings.Contains(msg, "table function with name query")
 }
 
 func configureDuckDBThreads(db *sql.DB) error {
@@ -293,7 +533,9 @@ func ValidateQuackClientURL(rawURL, token string, allowInsecure bool) error {
 		return fmt.Errorf("duckdb url must start with quack")
 	}
 	if token == "" {
-		return fmt.Errorf("duckdb quack token is required")
+		return fmt.Errorf(
+			"duckdb quack token is required; set AGENTSVIEW_DUCKDB_TOKEN or [duckdb].token",
+		)
 	}
 	transport := strings.TrimPrefix(rawURL, "quack:")
 	if !strings.HasPrefix(transport, "http://") &&

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -474,11 +474,13 @@ func nativeQuackUserinfo(base string) string {
 	if !strings.Contains(userinfoHead, ":") {
 		return ""
 	}
-	reattachedAuthority, _, _ := strings.Cut(base[at+1:], "/")
-	if !nativeQuackLooksLikeAuthority(reattachedAuthority) {
-		return ""
+	reattachedAuthority, _, hasReattachedPath := strings.Cut(base[at+1:], "/")
+	if nativeQuackLooksLikeAuthority(reattachedAuthority) ||
+		(hasReattachedPath && reattachedAuthority != "" &&
+			!nativeQuackLooksLikeAuthority(userinfoHead)) {
+		return userinfo
 	}
-	return base[:at]
+	return ""
 }
 
 func nativeQuackLooksLikeAuthority(authority string) bool {

--- a/internal/duckdb/connect_test.go
+++ b/internal/duckdb/connect_test.go
@@ -169,6 +169,59 @@ func TestRedactQuackClientErrorScrubsNativeDoubleSlashUserinfo(t *testing.T) {
 	assert.Contains(t, msg, "duck.example.com")
 }
 
+func TestRedactQuackClientErrorScrubsNativeRawAtPassword(t *testing.T) {
+	rawURL := "quack://account:pa@ss@duck.example.com:9494/db?token=credential1&x=1"
+	err := redactQuackClientError(
+		errors.New(
+			"IO Error connecting to account:pa@ss@duck.example.com:9494/db?x=1&token=credential1",
+		),
+		rawURL,
+		"credential2",
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "account")
+	assert.NotContains(t, msg, "pa@ss")
+	assert.NotContains(t, msg, "ss@duck")
+	assert.NotContains(t, msg, "credential1")
+	assert.Contains(t, msg, "duck.example.com")
+}
+
+func TestRedactQuackClientErrorScrubsNativeSchemeUserinfo(t *testing.T) {
+	rawURL := "quack:tcp://account:credential0@duck.example.com:9494/db?token=credential1&x=1"
+	err := redactQuackClientError(
+		errors.New(
+			"IO Error connecting to account:credential0@duck.example.com:9494/db?x=1&token=credential1",
+		),
+		rawURL,
+		"credential2",
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "account")
+	assert.NotContains(t, msg, "credential0")
+	assert.NotContains(t, msg, "credential1")
+	assert.Contains(t, msg, "duck.example.com")
+}
+
+func TestRedactQuackClientErrorPreservesNativeHostWithAtInPath(t *testing.T) {
+	rawURL := "quack://account:credential0@duck.example.com:9494/db@v2?token=credential1&x=1"
+	err := redactQuackClientError(
+		errors.New(
+			"IO Error connecting to account:credential0@duck.example.com:9494/db@v2?x=1&token=credential1",
+		),
+		rawURL,
+		"credential2",
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "account")
+	assert.NotContains(t, msg, "credential0")
+	assert.NotContains(t, msg, "credential1")
+	assert.Contains(t, msg, "duck.example.com")
+	assert.Contains(t, msg, "db@v2")
+}
+
 func TestRedactQuackClientErrorScrubsEncodedCredentialValues(t *testing.T) {
 	rawURL := "quack:https://account:p%40ss@duck.example.com/db?token=s%2Bcret&x=1"
 	err := redactQuackClientError(

--- a/internal/duckdb/connect_test.go
+++ b/internal/duckdb/connect_test.go
@@ -204,6 +204,23 @@ func TestRedactQuackClientErrorScrubsNativeRawSlashPassword(t *testing.T) {
 	assert.Contains(t, msg, "duck.example.com")
 }
 
+func TestRedactQuackClientErrorScrubsNativeRawSlashPasswordDotlessHost(t *testing.T) {
+	rawURL := "quack://account:pa/ss@myhost/db?token=credential1&x=1"
+	err := redactQuackClientError(
+		errors.New(
+			"IO Error connecting to account:pa/ss@myhost/db?x=1&token=credential1",
+		),
+		rawURL,
+		"credential2",
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "account")
+	assert.NotContains(t, msg, "pa/ss")
+	assert.NotContains(t, msg, "credential1")
+	assert.Contains(t, msg, "myhost")
+}
+
 func TestRedactQuackClientErrorScrubsNativeSchemeUserinfo(t *testing.T) {
 	rawURL := "quack:tcp://account:credential0@duck.example.com:9494/db?token=credential1&x=1"
 	err := redactQuackClientError(

--- a/internal/duckdb/connect_test.go
+++ b/internal/duckdb/connect_test.go
@@ -1,6 +1,7 @@
 package duckdb
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,6 +86,21 @@ func TestValidateQuackClientURL(t *testing.T) {
 	}
 }
 
+func TestIsStaleQuackConnectionError(t *testing.T) {
+	assert.True(t, isStaleQuackConnectionError(
+		errors.New("Invalid Input Error: Invalid connection id"),
+	))
+	assert.True(t, isStaleQuackConnectionError(
+		errors.New("IO Error: Failed to send message: Bad Gateway"),
+	))
+	assert.True(t, isStaleQuackConnectionError(
+		errors.New("Catalog Error: Table Function with name query does not exist!"),
+	))
+	assert.False(t, isStaleQuackConnectionError(
+		errors.New("Catalog Error: Table with name sessions does not exist"),
+	))
+}
+
 func TestRedactQuackURL(t *testing.T) {
 	got := RedactQuackURL(
 		"quack:https://account:credential0@duck.example.com/db?token=credential1&password=credential2&api_key=credential3&x=1",
@@ -112,6 +128,28 @@ func TestRedactQuackURLNativeTransport(t *testing.T) {
 	assert.Contains(t, got, "token=%3Credacted%3E")
 	assert.Contains(t, got, "x=1")
 	assert.NotContains(t, got, "#")
+}
+
+func TestRedactQuackClientErrorScrubsAttachSecrets(t *testing.T) {
+	rawURL := "quack:https://account:credential0@duck.example.com/db?token=credential1&x=1"
+	token := "credential2'quoted"
+	err := redactQuackClientError(
+		errors.New(
+			"Parser Error near "+quackAttachSQL(rawURL, token)+
+				"; IO Error connecting to https://account:credential0@DUCK.EXAMPLE.COM:443/db?x=1&token=credential1",
+		),
+		rawURL,
+		token,
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "account")
+	assert.NotContains(t, msg, "credential0")
+	assert.NotContains(t, msg, "credential1")
+	assert.NotContains(t, msg, "credential2")
+	assert.NotContains(t, msg, "credential2''quoted")
+	assert.Contains(t, msg, "<redacted>")
+	assert.Contains(t, msg, "duck.example.com")
 }
 
 func TestSyncStateTargetForConfigScopesRemoteURLWithoutSecrets(t *testing.T) {

--- a/internal/duckdb/connect_test.go
+++ b/internal/duckdb/connect_test.go
@@ -239,6 +239,23 @@ func TestRedactQuackClientErrorPreservesNativeHostWithAtInPath(t *testing.T) {
 	assert.Contains(t, msg, "db@v2")
 }
 
+func TestRedactQuackClientErrorPreservesNativeHostPortWithAtInPath(t *testing.T) {
+	rawURL := "quack://duck.example.com:9494/db@v2?token=credential1&x=1"
+	err := redactQuackClientError(
+		errors.New(
+			"IO Error connecting to duck.example.com:9494/db@v2?x=1&token=credential1",
+		),
+		rawURL,
+		"credential2",
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "credential1")
+	assert.Contains(t, msg, "duck.example.com")
+	assert.Contains(t, msg, "9494")
+	assert.Contains(t, msg, "db@v2")
+}
+
 func TestRedactQuackClientErrorScrubsEncodedCredentialValues(t *testing.T) {
 	rawURL := "quack:https://account:p%40ss@duck.example.com/db?token=s%2Bcret&x=1"
 	err := redactQuackClientError(

--- a/internal/duckdb/connect_test.go
+++ b/internal/duckdb/connect_test.go
@@ -152,6 +152,42 @@ func TestRedactQuackClientErrorScrubsAttachSecrets(t *testing.T) {
 	assert.Contains(t, msg, "duck.example.com")
 }
 
+func TestRedactQuackClientErrorScrubsNativeDoubleSlashUserinfo(t *testing.T) {
+	rawURL := "quack://account:credential0@duck.example.com:9494/db?token=credential1&x=1"
+	err := redactQuackClientError(
+		errors.New(
+			"IO Error connecting to account:credential0@duck.example.com:9494/db?x=1&token=credential1",
+		),
+		rawURL,
+		"credential2",
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "account")
+	assert.NotContains(t, msg, "credential0")
+	assert.NotContains(t, msg, "credential1")
+	assert.Contains(t, msg, "duck.example.com")
+}
+
+func TestRedactQuackClientErrorScrubsEncodedCredentialValues(t *testing.T) {
+	rawURL := "quack:https://account:p%40ss@duck.example.com/db?token=s%2Bcret&x=1"
+	err := redactQuackClientError(
+		errors.New(
+			"IO Error connecting to https://account:p%40ss@duck.example.com/db?x=1&token=s%2Bcret",
+		),
+		rawURL,
+		"attach-token",
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "account")
+	assert.NotContains(t, msg, "p%40ss")
+	assert.NotContains(t, msg, "p@ss")
+	assert.NotContains(t, msg, "s%2Bcret")
+	assert.NotContains(t, msg, "s+cret")
+	assert.Contains(t, msg, "duck.example.com")
+}
+
 func TestSyncStateTargetForConfigScopesRemoteURLWithoutSecrets(t *testing.T) {
 	base := config.DuckDBConfig{
 		URL:   "quack:https://user:secret@duck.example.com/db?token=secret&x=1#frag",

--- a/internal/duckdb/connect_test.go
+++ b/internal/duckdb/connect_test.go
@@ -187,6 +187,23 @@ func TestRedactQuackClientErrorScrubsNativeRawAtPassword(t *testing.T) {
 	assert.Contains(t, msg, "duck.example.com")
 }
 
+func TestRedactQuackClientErrorScrubsNativeRawSlashPassword(t *testing.T) {
+	rawURL := "quack://account:pa/ss@duck.example.com:9494/db?token=credential1&x=1"
+	err := redactQuackClientError(
+		errors.New(
+			"IO Error connecting to account:pa/ss@duck.example.com:9494/db?x=1&token=credential1",
+		),
+		rawURL,
+		"credential2",
+	)
+	msg := err.Error()
+
+	assert.NotContains(t, msg, "account")
+	assert.NotContains(t, msg, "pa/ss")
+	assert.NotContains(t, msg, "credential1")
+	assert.Contains(t, msg, "duck.example.com")
+}
+
 func TestRedactQuackClientErrorScrubsNativeSchemeUserinfo(t *testing.T) {
 	rawURL := "quack:tcp://account:credential0@duck.example.com:9494/db?token=credential1&x=1"
 	err := redactQuackClientError(

--- a/internal/duckdb/curation.go
+++ b/internal/duckdb/curation.go
@@ -17,7 +17,7 @@ func (s *Store) UnstarSession(sessionID string) error {
 }
 
 func (s *Store) ListStarredSessionIDs(ctx context.Context) ([]string, error) {
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT session_id FROM starred_sessions
 		ORDER BY created_at DESC, session_id DESC`)
 	if err != nil {
@@ -53,7 +53,7 @@ func (s *Store) ListPinnedMessages(
 	var rows *sql.Rows
 	var err error
 	if sessionID != "" {
-		rows, err = s.duck.QueryContext(ctx, `
+		rows, err = s.queryContext(ctx, `
 			SELECT id, session_id, message_id, ordinal, note, created_at
 			FROM pinned_messages
 			WHERE session_id = ?
@@ -75,7 +75,7 @@ func (s *Store) ListPinnedMessages(
 			args = append(args, project)
 		}
 		query += " ORDER BY p.created_at DESC, p.id DESC LIMIT 500"
-		rows, err = s.duck.QueryContext(ctx, query, args...)
+		rows, err = s.queryContext(ctx, query, args...)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("listing duckdb pinned messages: %w", err)

--- a/internal/duckdb/messages.go
+++ b/internal/duckdb/messages.go
@@ -21,7 +21,7 @@ func (s *Store) GetMessages(
 		dir = "DESC"
 		op = "<="
 	}
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT id, session_id, ordinal, role, content, thinking_text,
 			timestamp, has_thinking, has_tool_use, content_length,
 			is_system, model, token_usage, context_tokens, output_tokens,
@@ -49,7 +49,7 @@ func (s *Store) GetMessages(
 }
 
 func (s *Store) GetAllMessages(ctx context.Context, sessionID string) ([]db.Message, error) {
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT id, session_id, ordinal, role, content, thinking_text,
 			timestamp, has_thinking, has_tool_use, content_length,
 			is_system, model, token_usage, context_tokens, output_tokens,
@@ -109,7 +109,7 @@ func (s *Store) attachToolCalls(ctx context.Context, msgs []db.Message) error {
 	for i, msg := range msgs {
 		index[msg.Ordinal] = i
 	}
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT m.ordinal, tc.call_index, tc.tool_name, tc.category,
 			COALESCE(tc.tool_use_id, ''), COALESCE(tc.input_json, ''),
 			COALESCE(tc.skill_name, ''), COALESCE(tc.result_content_length, 0),
@@ -156,7 +156,7 @@ func (s *Store) attachToolCalls(ctx context.Context, msgs []db.Message) error {
 func (s *Store) attachToolResultEvents(
 	ctx context.Context, msgs []db.Message, index map[int]int, sessionID string,
 ) error {
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT tool_call_message_ordinal, call_index,
 			COALESCE(tool_use_id, ''), COALESCE(agent_id, ''),
 			COALESCE(subagent_session_id, ''), source, status,
@@ -284,7 +284,7 @@ func (s *Store) GetSessionTiming(ctx context.Context, sessionID string) (*db.Ses
 func (s *Store) queryTurnRows(
 	ctx context.Context, sess *db.Session,
 ) ([]db.TurnRow, error) {
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT id, ordinal, timestamp, has_tool_use
 		FROM messages
 		WHERE session_id = ?
@@ -329,7 +329,7 @@ func (s *Store) queryTurnRows(
 func (s *Store) queryCallRows(
 	ctx context.Context, sessionID string,
 ) ([]db.CallRow, error) {
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT tc.message_id, COALESCE(tc.tool_use_id, ''),
 			tc.tool_name, tc.category, tc.skill_name,
 			tc.subagent_session_id, COALESCE(tc.input_json, ''),

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -458,18 +458,17 @@ func appendDuckRemoteMutationBatch(
 	if maxBytes <= 0 {
 		maxBytes = duckRemoteMutationCoalesceMaxBytes
 	}
-	if next.transactionBytes() > maxBytes {
+	nextBytes := next.transactionBytes()
+	if nextBytes > maxBytes {
 		if err := execDuckRemoteMutationBatch(
 			ctx, execCoalesced, label, current, true,
 		); err != nil {
 			return current, err
 		}
-		if err := execDuckRemoteMutationBatchChunks(
-			ctx, execCoalesced, label, next, maxBytes,
-		); err != nil {
-			return &duckRemoteMutationBatch{}, err
-		}
-		return &duckRemoteMutationBatch{}, nil
+		return &duckRemoteMutationBatch{}, fmt.Errorf(
+			"duckdb remote mutation batch exceeds remote mutation coalesce budget: %d > %d",
+			nextBytes, maxBytes,
+		)
 	}
 	if current.Len() > 0 && current.combinedTransactionBytes(next) > maxBytes {
 		if err := execDuckRemoteMutationBatch(ctx, execCoalesced, label, current, true); err != nil {
@@ -549,22 +548,7 @@ func execDuckRemoteMutationBatchWithStatementFallback(
 	return nil
 }
 
-func execDuckRemoteMutationBatchChunks(
-	ctx context.Context,
-	exec func(context.Context, string) error,
-	label string,
-	batch *duckRemoteMutationBatch,
-	maxBytes int,
-) error {
-	for _, chunk := range batch.chunks(maxBytes) {
-		if err := execDuckRemoteMutationBatch(ctx, exec, label, chunk, true); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func execDuckRemoteMutationBatchChunksWithStatementFallback(
+func execDuckRemoteMutationBatchOversizeWithStatementFallback(
 	ctx context.Context,
 	execCoalesced func(context.Context, string) error,
 	execStatement func(context.Context, string) error,
@@ -572,14 +556,15 @@ func execDuckRemoteMutationBatchChunksWithStatementFallback(
 	batch *duckRemoteMutationBatch,
 	maxBytes int,
 ) error {
-	for _, chunk := range batch.chunks(maxBytes) {
-		if err := execDuckRemoteMutationBatchWithStatementFallback(
-			ctx, execCoalesced, execStatement, label, chunk,
-		); err != nil {
-			return err
-		}
+	if maxBytes <= 0 {
+		maxBytes = duckRemoteMutationCoalesceMaxBytes
 	}
-	return nil
+	if batch.transactionBytes() > maxBytes {
+		return execDuckRemoteMutationBatch(ctx, execStatement, label, batch, false)
+	}
+	return execDuckRemoteMutationBatchWithStatementFallback(
+		ctx, execCoalesced, execStatement, label, batch,
+	)
 }
 
 func (b *duckRemoteMutationBatch) transactionSQL() string {
@@ -629,72 +614,6 @@ func (b *duckRemoteMutationBatch) combinedTransactionBytes(
 		b.renderedStatementBytes+other.renderedStatementBytes,
 		len(left)+len(right),
 	)
-}
-
-func (b *duckRemoteMutationBatch) chunks(maxBytes int) []*duckRemoteMutationBatch {
-	if b == nil || b.Len() == 0 {
-		return nil
-	}
-	if maxBytes <= 0 {
-		maxBytes = duckRemoteMutationCoalesceMaxBytes
-	}
-	var chunks []*duckRemoteMutationBatch
-	currentStart := -1
-	currentEnd := 0
-	currentStatementBytes := 0
-	currentStatementCount := 0
-	rendered := b.renderedForMaxTransactionBytes(maxBytes)
-	flush := func() {
-		if currentStatementCount == 0 {
-			return
-		}
-		statements := append([]string(nil), b.statements[currentStart:currentEnd]...)
-		chunks = append(chunks, &duckRemoteMutationBatch{statements: statements})
-		currentStart = -1
-		currentEnd = 0
-		currentStatementBytes = 0
-		currentStatementCount = 0
-	}
-	for _, stmt := range rendered {
-		nextStatementBytes := currentStatementBytes + len(stmt.sql)
-		nextStatementCount := currentStatementCount + 1
-		if currentStatementCount > 0 &&
-			duckRemoteTransactionBytesFor(
-				nextStatementBytes, nextStatementCount,
-			) > maxBytes {
-			flush()
-		}
-		if currentStart < 0 {
-			currentStart = stmt.start
-		}
-		currentEnd = stmt.end
-		currentStatementBytes += len(stmt.sql)
-		currentStatementCount++
-	}
-	flush()
-	return chunks
-}
-
-func (b *duckRemoteMutationBatch) renderedForMaxTransactionBytes(
-	maxBytes int,
-) []duckRemoteRenderedStatement {
-	insertMaxBytes := duckRemoteInsertMaxBytesForTransaction(maxBytes)
-	if insertMaxBytes >= duckRemoteInsertCoalesceMaxBytes {
-		return b.rendered()
-	}
-	return renderDuckRemoteMutationStatements(
-		b.statements,
-		duckRemoteInsertCoalesceMaxRows,
-		insertMaxBytes,
-	)
-}
-
-func duckRemoteInsertMaxBytesForTransaction(maxBytes int) int {
-	statementOverhead := len("BEGIN TRANSACTION;\n") + len(";\n") + len("COMMIT")
-	if maxBytes <= statementOverhead {
-		return 1
-	}
-	return min(maxBytes-statementOverhead, duckRemoteInsertCoalesceMaxBytes)
 }
 
 func (b *duckRemoteMutationBatch) rendered() []duckRemoteRenderedStatement {

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -502,6 +502,35 @@ func execDuckRemoteMutationBatch(
 		}
 		return nil
 	}
+	return execDuckRemoteMutationStatements(ctx, exec, label, batch.statements)
+}
+
+func execDuckRemoteMutationRenderedStatements(
+	ctx context.Context,
+	exec func(context.Context, string) error,
+	label string,
+	batch *duckRemoteMutationBatch,
+) error {
+	if batch.Len() == 0 {
+		return nil
+	}
+	rendered := batch.rendered()
+	statements := make([]string, 0, len(rendered))
+	for _, stmt := range rendered {
+		statements = append(statements, stmt.sql)
+	}
+	return execDuckRemoteMutationStatements(ctx, exec, label, statements)
+}
+
+func execDuckRemoteMutationStatements(
+	ctx context.Context,
+	exec func(context.Context, string) error,
+	label string,
+	statements []string,
+) (err error) {
+	if len(statements) == 0 {
+		return nil
+	}
 	if err := exec(ctx, "BEGIN TRANSACTION"); err != nil {
 		return fmt.Errorf("begin %s: %w", label, err)
 	}
@@ -515,11 +544,11 @@ func execDuckRemoteMutationBatch(
 			err = fmt.Errorf("%w; rollback %s: %v", err, label, rollbackErr)
 		}
 	}()
-	for i, stmt := range batch.statements {
+	for i, stmt := range statements {
 		if err := exec(ctx, stmt); err != nil {
 			return fmt.Errorf(
 				"execute %s statement %d/%d: %w",
-				label, i+1, batch.Len(), err,
+				label, i+1, len(statements), err,
 			)
 		}
 	}
@@ -560,7 +589,9 @@ func execDuckRemoteMutationBatchOversizeWithStatementFallback(
 		maxBytes = duckRemoteMutationCoalesceMaxBytes
 	}
 	if batch.transactionBytes() > maxBytes {
-		return execDuckRemoteMutationBatch(ctx, execStatement, label, batch, false)
+		return execDuckRemoteMutationRenderedStatements(
+			ctx, execStatement, label, batch,
+		)
 	}
 	return execDuckRemoteMutationBatchWithStatementFallback(
 		ctx, execCoalesced, execStatement, label, batch,

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -402,8 +402,24 @@ func (b *duckRemoteMutationBatch) appendBatch(other *duckRemoteMutationBatch) {
 	if other == nil || other.Len() == 0 {
 		return
 	}
+	oldLen := len(b.statements)
+	preserveRendered := b.renderedValid
+	rendered := b.renderedStatementsCache
+	renderedBytes := b.renderedStatementBytes
 	b.statements = append(b.statements, other.statements...)
-	b.invalidateRendered()
+	if !preserveRendered {
+		b.invalidateRendered()
+		return
+	}
+	for _, stmt := range other.rendered() {
+		stmt.start += oldLen
+		stmt.end += oldLen
+		rendered = append(rendered, stmt)
+		renderedBytes += len(stmt.sql)
+	}
+	b.renderedStatementsCache = rendered
+	b.renderedStatementBytes = renderedBytes
+	b.renderedValid = true
 }
 
 func (b *duckRemoteMutationBatch) invalidateRendered() {

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -364,11 +364,14 @@ type duckMutationExecutor interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
-const duckRemoteMutationCoalesceMaxBytes = 2 << 20
+const (
+	duckRemoteMutationCoalesceMaxBytes = 2 << 20
+	duckRemoteInsertCoalesceMaxRows    = 256
+	duckRemoteInsertCoalesceMaxBytes   = 1 << 20
+)
 
 type duckRemoteMutationBatch struct {
-	statements     []string
-	statementBytes int
+	statements []string
 }
 
 func (b *duckRemoteMutationBatch) ExecContext(
@@ -379,7 +382,6 @@ func (b *duckRemoteMutationBatch) ExecContext(
 		return nil, err
 	}
 	b.statements = append(b.statements, sqlText)
-	b.statementBytes += len(sqlText)
 	return duckNoopResult{}, nil
 }
 
@@ -392,7 +394,6 @@ func (b *duckRemoteMutationBatch) appendBatch(other *duckRemoteMutationBatch) {
 		return
 	}
 	b.statements = append(b.statements, other.statements...)
-	b.statementBytes += other.statementBytes
 }
 
 type duckNoopResult struct{}
@@ -551,8 +552,9 @@ func execDuckRemoteMutationBatchChunksWithStatementFallback(
 
 func (b *duckRemoteMutationBatch) transactionSQL() string {
 	var sqlText strings.Builder
+	statements := b.renderedStatements()
 	sqlText.WriteString("BEGIN TRANSACTION;\n")
-	for _, stmt := range b.statements {
+	for _, stmt := range statements {
 		sqlText.WriteString(stmt)
 		sqlText.WriteString(";\n")
 	}
@@ -564,9 +566,20 @@ func (b *duckRemoteMutationBatch) transactionBytes() int {
 	if b == nil || b.Len() == 0 {
 		return 0
 	}
+	return duckRemoteTransactionBytes(b.renderedStatements())
+}
+
+func duckRemoteTransactionBytes(statements []string) int {
+	if len(statements) == 0 {
+		return 0
+	}
+	statementBytes := 0
+	for _, stmt := range statements {
+		statementBytes += len(stmt)
+	}
 	return len("BEGIN TRANSACTION;\n") +
-		b.statementBytes +
-		len(";\n")*b.Len() +
+		statementBytes +
+		len(";\n")*len(statements) +
 		len("COMMIT")
 }
 
@@ -579,10 +592,14 @@ func (b *duckRemoteMutationBatch) combinedTransactionBytes(
 	if other == nil || other.Len() == 0 {
 		return b.transactionBytes()
 	}
-	return len("BEGIN TRANSACTION;\n") +
-		b.statementBytes + other.statementBytes +
-		len(";\n")*(b.Len()+other.Len()) +
-		len("COMMIT")
+	statements := make([]string, 0, b.Len()+other.Len())
+	statements = append(statements, b.statements...)
+	statements = append(statements, other.statements...)
+	return duckRemoteTransactionBytes(coalesceDuckRemoteInsertStatements(
+		statements,
+		duckRemoteInsertCoalesceMaxRows,
+		duckRemoteInsertCoalesceMaxBytes,
+	))
 }
 
 func (b *duckRemoteMutationBatch) chunks(maxBytes int) []*duckRemoteMutationBatch {
@@ -596,8 +613,7 @@ func (b *duckRemoteMutationBatch) chunks(maxBytes int) []*duckRemoteMutationBatc
 	current := &duckRemoteMutationBatch{}
 	for _, stmt := range b.statements {
 		next := &duckRemoteMutationBatch{
-			statements:     []string{stmt},
-			statementBytes: len(stmt),
+			statements: []string{stmt},
 		}
 		if current.Len() > 0 && current.combinedTransactionBytes(next) > maxBytes {
 			chunks = append(chunks, current)
@@ -609,6 +625,182 @@ func (b *duckRemoteMutationBatch) chunks(maxBytes int) []*duckRemoteMutationBatc
 		chunks = append(chunks, current)
 	}
 	return chunks
+}
+
+func (b *duckRemoteMutationBatch) renderedStatements() []string {
+	if b == nil || b.Len() == 0 {
+		return nil
+	}
+	return coalesceDuckRemoteInsertStatements(
+		b.statements,
+		duckRemoteInsertCoalesceMaxRows,
+		duckRemoteInsertCoalesceMaxBytes,
+	)
+}
+
+func coalesceDuckRemoteInsertStatements(
+	statements []string, maxRows int, maxBytes int,
+) []string {
+	if len(statements) == 0 {
+		return nil
+	}
+	if maxRows <= 0 {
+		maxRows = duckRemoteInsertCoalesceMaxRows
+	}
+	if maxBytes <= 0 {
+		maxBytes = duckRemoteInsertCoalesceMaxBytes
+	}
+	out := make([]string, 0, len(statements))
+	var pending duckRemoteInsertGroup
+	hasPending := false
+	flush := func() {
+		if !hasPending {
+			return
+		}
+		out = append(out, pending.SQL())
+		pending = duckRemoteInsertGroup{}
+		hasPending = false
+	}
+	for _, stmt := range statements {
+		prefix, tuple, ok := splitDuckRemoteSimpleInsert(stmt)
+		if !ok {
+			flush()
+			out = append(out, stmt)
+			continue
+		}
+		if !hasPending || pending.prefix != prefix {
+			flush()
+			pending = duckRemoteInsertGroup{prefix: prefix}
+			hasPending = true
+		}
+		if pending.rows > 0 && (pending.rows+1 > maxRows ||
+			pending.bytes+len(", ")+len(tuple) > maxBytes) {
+			flush()
+			pending = duckRemoteInsertGroup{prefix: prefix}
+			hasPending = true
+		}
+		pending.Append(tuple)
+	}
+	flush()
+	return out
+}
+
+type duckRemoteInsertGroup struct {
+	prefix string
+	tuples []string
+	rows   int
+	bytes  int
+}
+
+func (g *duckRemoteInsertGroup) Append(tuple string) {
+	if g.rows == 0 {
+		g.bytes = len(g.prefix)
+	} else {
+		g.bytes += len(", ")
+	}
+	g.tuples = append(g.tuples, tuple)
+	g.rows++
+	g.bytes += len(tuple)
+}
+
+func (g duckRemoteInsertGroup) SQL() string {
+	return g.prefix + strings.Join(g.tuples, ", ")
+}
+
+func splitDuckRemoteSimpleInsert(stmt string) (string, string, bool) {
+	trimmed := strings.TrimSpace(stmt)
+	upper := strings.ToUpper(trimmed)
+	if !strings.HasPrefix(upper, "INSERT INTO ") {
+		return "", "", false
+	}
+	valuesIndex := strings.Index(upper, " VALUES ")
+	if valuesIndex < 0 {
+		return "", "", false
+	}
+	prefix := strings.TrimSpace(trimmed[:valuesIndex]) + " VALUES "
+	rest := strings.TrimSpace(trimmed[valuesIndex+len(" VALUES "):])
+	tuple, suffix, ok := duckSQLLeadingParenthesizedExpression(rest)
+	if !ok || strings.TrimSpace(suffix) != "" {
+		return "", "", false
+	}
+	return prefix, tuple, true
+}
+
+func duckSQLLeadingParenthesizedExpression(sqlText string) (
+	string, string, bool,
+) {
+	if !strings.HasPrefix(sqlText, "(") {
+		return "", "", false
+	}
+	depth := 0
+	for i := 0; i < len(sqlText); {
+		switch sqlText[i] {
+		case '$':
+			delimiter, ok := duckDollarQuoteDelimiterAt(sqlText, i)
+			if ok {
+				next := strings.Index(sqlText[i+len(delimiter):], delimiter)
+				if next < 0 {
+					return "", "", false
+				}
+				i += len(delimiter) + next + len(delimiter)
+				continue
+			}
+		case '\'':
+			next, ok := duckSingleQuotedLiteralEnd(sqlText, i)
+			if !ok {
+				return "", "", false
+			}
+			i = next
+			continue
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return sqlText[:i+1], sqlText[i+1:], true
+			}
+			if depth < 0 {
+				return "", "", false
+			}
+		}
+		i++
+	}
+	return "", "", false
+}
+
+func duckDollarQuoteDelimiterAt(sqlText string, start int) (string, bool) {
+	if start >= len(sqlText) || sqlText[start] != '$' {
+		return "", false
+	}
+	i := start + 1
+	for i < len(sqlText) && duckDollarQuoteTagByte(sqlText[i]) {
+		i++
+	}
+	if i >= len(sqlText) || sqlText[i] != '$' {
+		return "", false
+	}
+	return sqlText[start : i+1], true
+}
+
+func duckDollarQuoteTagByte(b byte) bool {
+	return b == '_' ||
+		('0' <= b && b <= '9') ||
+		('A' <= b && b <= 'Z') ||
+		('a' <= b && b <= 'z')
+}
+
+func duckSingleQuotedLiteralEnd(sqlText string, start int) (int, bool) {
+	for i := start + 1; i < len(sqlText); i++ {
+		if sqlText[i] != '\'' {
+			continue
+		}
+		if i+1 < len(sqlText) && sqlText[i+1] == '\'' {
+			i++
+			continue
+		}
+		return i + 1, true
+	}
+	return 0, false
 }
 
 func isDuckRemoteMutationTimeoutError(err error) bool {

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -371,7 +371,15 @@ const (
 )
 
 type duckRemoteMutationBatch struct {
-	statements []string
+	statements              []string
+	renderedValid           bool
+	renderedStatementsCache []duckRemoteRenderedStatement
+	renderedStatementBytes  int
+}
+
+type duckRemoteRenderedStatement struct {
+	sql        string
+	start, end int
 }
 
 func (b *duckRemoteMutationBatch) ExecContext(
@@ -382,6 +390,7 @@ func (b *duckRemoteMutationBatch) ExecContext(
 		return nil, err
 	}
 	b.statements = append(b.statements, sqlText)
+	b.invalidateRendered()
 	return duckNoopResult{}, nil
 }
 
@@ -394,6 +403,13 @@ func (b *duckRemoteMutationBatch) appendBatch(other *duckRemoteMutationBatch) {
 		return
 	}
 	b.statements = append(b.statements, other.statements...)
+	b.invalidateRendered()
+}
+
+func (b *duckRemoteMutationBatch) invalidateRendered() {
+	b.renderedValid = false
+	b.renderedStatementsCache = nil
+	b.renderedStatementBytes = 0
 }
 
 type duckNoopResult struct{}
@@ -552,10 +568,10 @@ func execDuckRemoteMutationBatchChunksWithStatementFallback(
 
 func (b *duckRemoteMutationBatch) transactionSQL() string {
 	var sqlText strings.Builder
-	statements := b.renderedStatements()
+	statements := b.rendered()
 	sqlText.WriteString("BEGIN TRANSACTION;\n")
 	for _, stmt := range statements {
-		sqlText.WriteString(stmt)
+		sqlText.WriteString(stmt.sql)
 		sqlText.WriteString(";\n")
 	}
 	sqlText.WriteString("COMMIT")
@@ -566,7 +582,10 @@ func (b *duckRemoteMutationBatch) transactionBytes() int {
 	if b == nil || b.Len() == 0 {
 		return 0
 	}
-	return duckRemoteTransactionBytes(b.renderedStatements())
+	statements := b.rendered()
+	return duckRemoteTransactionBytesFor(
+		b.renderedStatementBytes, len(statements),
+	)
 }
 
 func duckRemoteTransactionBytes(statements []string) int {
@@ -577,9 +596,16 @@ func duckRemoteTransactionBytes(statements []string) int {
 	for _, stmt := range statements {
 		statementBytes += len(stmt)
 	}
+	return duckRemoteTransactionBytesFor(statementBytes, len(statements))
+}
+
+func duckRemoteTransactionBytesFor(statementBytes, statementCount int) int {
+	if statementCount == 0 {
+		return 0
+	}
 	return len("BEGIN TRANSACTION;\n") +
 		statementBytes +
-		len(";\n")*len(statements) +
+		len(";\n")*statementCount +
 		len("COMMIT")
 }
 
@@ -592,14 +618,12 @@ func (b *duckRemoteMutationBatch) combinedTransactionBytes(
 	if other == nil || other.Len() == 0 {
 		return b.transactionBytes()
 	}
-	statements := make([]string, 0, b.Len()+other.Len())
-	statements = append(statements, b.statements...)
-	statements = append(statements, other.statements...)
-	return duckRemoteTransactionBytes(coalesceDuckRemoteInsertStatements(
-		statements,
-		duckRemoteInsertCoalesceMaxRows,
-		duckRemoteInsertCoalesceMaxBytes,
-	))
+	left := b.rendered()
+	right := other.rendered()
+	return duckRemoteTransactionBytesFor(
+		b.renderedStatementBytes+other.renderedStatementBytes,
+		len(left)+len(right),
+	)
 }
 
 func (b *duckRemoteMutationBatch) chunks(maxBytes int) []*duckRemoteMutationBatch {
@@ -610,37 +634,107 @@ func (b *duckRemoteMutationBatch) chunks(maxBytes int) []*duckRemoteMutationBatc
 		maxBytes = duckRemoteMutationCoalesceMaxBytes
 	}
 	var chunks []*duckRemoteMutationBatch
-	current := &duckRemoteMutationBatch{}
-	for _, stmt := range b.statements {
-		next := &duckRemoteMutationBatch{
-			statements: []string{stmt},
+	currentStart := -1
+	currentEnd := 0
+	currentStatementBytes := 0
+	currentStatementCount := 0
+	rendered := b.renderedForMaxTransactionBytes(maxBytes)
+	flush := func() {
+		if currentStatementCount == 0 {
+			return
 		}
-		if current.Len() > 0 && current.combinedTransactionBytes(next) > maxBytes {
-			chunks = append(chunks, current)
-			current = &duckRemoteMutationBatch{}
+		statements := append([]string(nil), b.statements[currentStart:currentEnd]...)
+		chunks = append(chunks, &duckRemoteMutationBatch{statements: statements})
+		currentStart = -1
+		currentEnd = 0
+		currentStatementBytes = 0
+		currentStatementCount = 0
+	}
+	for _, stmt := range rendered {
+		nextStatementBytes := currentStatementBytes + len(stmt.sql)
+		nextStatementCount := currentStatementCount + 1
+		if currentStatementCount > 0 &&
+			duckRemoteTransactionBytesFor(
+				nextStatementBytes, nextStatementCount,
+			) > maxBytes {
+			flush()
 		}
-		current.appendBatch(next)
+		if currentStart < 0 {
+			currentStart = stmt.start
+		}
+		currentEnd = stmt.end
+		currentStatementBytes += len(stmt.sql)
+		currentStatementCount++
 	}
-	if current.Len() > 0 {
-		chunks = append(chunks, current)
-	}
+	flush()
 	return chunks
 }
 
+func (b *duckRemoteMutationBatch) renderedForMaxTransactionBytes(
+	maxBytes int,
+) []duckRemoteRenderedStatement {
+	insertMaxBytes := duckRemoteInsertMaxBytesForTransaction(maxBytes)
+	if insertMaxBytes >= duckRemoteInsertCoalesceMaxBytes {
+		return b.rendered()
+	}
+	return renderDuckRemoteMutationStatements(
+		b.statements,
+		duckRemoteInsertCoalesceMaxRows,
+		insertMaxBytes,
+	)
+}
+
+func duckRemoteInsertMaxBytesForTransaction(maxBytes int) int {
+	statementOverhead := len("BEGIN TRANSACTION;\n") + len(";\n") + len("COMMIT")
+	if maxBytes <= statementOverhead {
+		return 1
+	}
+	return min(maxBytes-statementOverhead, duckRemoteInsertCoalesceMaxBytes)
+}
+
 func (b *duckRemoteMutationBatch) renderedStatements() []string {
+	rendered := b.rendered()
+	out := make([]string, 0, len(rendered))
+	for _, stmt := range rendered {
+		out = append(out, stmt.sql)
+	}
+	return out
+}
+
+func (b *duckRemoteMutationBatch) rendered() []duckRemoteRenderedStatement {
 	if b == nil || b.Len() == 0 {
 		return nil
 	}
-	return coalesceDuckRemoteInsertStatements(
+	if b.renderedValid {
+		return b.renderedStatementsCache
+	}
+	b.renderedStatementsCache = renderDuckRemoteMutationStatements(
 		b.statements,
 		duckRemoteInsertCoalesceMaxRows,
 		duckRemoteInsertCoalesceMaxBytes,
 	)
+	b.renderedStatementBytes = 0
+	for _, stmt := range b.renderedStatementsCache {
+		b.renderedStatementBytes += len(stmt.sql)
+	}
+	b.renderedValid = true
+	return b.renderedStatementsCache
 }
 
 func coalesceDuckRemoteInsertStatements(
 	statements []string, maxRows int, maxBytes int,
 ) []string {
+	rendered := renderDuckRemoteMutationStatements(statements, maxRows, maxBytes)
+	out := make([]string, 0, len(rendered))
+	for _, stmt := range rendered {
+		out = append(out, stmt.sql)
+	}
+	return out
+}
+
+func renderDuckRemoteMutationStatements(
+	statements []string, maxRows int, maxBytes int,
+) []duckRemoteRenderedStatement {
 	if len(statements) == 0 {
 		return nil
 	}
@@ -650,36 +744,40 @@ func coalesceDuckRemoteInsertStatements(
 	if maxBytes <= 0 {
 		maxBytes = duckRemoteInsertCoalesceMaxBytes
 	}
-	out := make([]string, 0, len(statements))
+	out := make([]duckRemoteRenderedStatement, 0, len(statements))
 	var pending duckRemoteInsertGroup
 	hasPending := false
 	flush := func() {
 		if !hasPending {
 			return
 		}
-		out = append(out, pending.SQL())
+		out = append(out, pending.RenderedStatement())
 		pending = duckRemoteInsertGroup{}
 		hasPending = false
 	}
-	for _, stmt := range statements {
+	for i, stmt := range statements {
 		prefix, tuple, ok := splitDuckRemoteSimpleInsert(stmt)
 		if !ok {
 			flush()
-			out = append(out, stmt)
+			out = append(out, duckRemoteRenderedStatement{
+				sql:   stmt,
+				start: i,
+				end:   i + 1,
+			})
 			continue
 		}
 		if !hasPending || pending.prefix != prefix {
 			flush()
-			pending = duckRemoteInsertGroup{prefix: prefix}
+			pending = duckRemoteInsertGroup{prefix: prefix, start: i}
 			hasPending = true
 		}
 		if pending.rows > 0 && (pending.rows+1 > maxRows ||
 			pending.bytes+len(", ")+len(tuple) > maxBytes) {
 			flush()
-			pending = duckRemoteInsertGroup{prefix: prefix}
+			pending = duckRemoteInsertGroup{prefix: prefix, start: i}
 			hasPending = true
 		}
-		pending.Append(tuple)
+		pending.Append(tuple, i+1)
 	}
 	flush()
 	return out
@@ -690,9 +788,11 @@ type duckRemoteInsertGroup struct {
 	tuples []string
 	rows   int
 	bytes  int
+	start  int
+	end    int
 }
 
-func (g *duckRemoteInsertGroup) Append(tuple string) {
+func (g *duckRemoteInsertGroup) Append(tuple string, end int) {
 	if g.rows == 0 {
 		g.bytes = len(g.prefix)
 	} else {
@@ -701,19 +801,23 @@ func (g *duckRemoteInsertGroup) Append(tuple string) {
 	g.tuples = append(g.tuples, tuple)
 	g.rows++
 	g.bytes += len(tuple)
+	g.end = end
 }
 
-func (g duckRemoteInsertGroup) SQL() string {
-	return g.prefix + strings.Join(g.tuples, ", ")
+func (g duckRemoteInsertGroup) RenderedStatement() duckRemoteRenderedStatement {
+	return duckRemoteRenderedStatement{
+		sql:   g.prefix + strings.Join(g.tuples, ", "),
+		start: g.start,
+		end:   g.end,
+	}
 }
 
 func splitDuckRemoteSimpleInsert(stmt string) (string, string, bool) {
 	trimmed := strings.TrimSpace(stmt)
-	upper := strings.ToUpper(trimmed)
-	if !strings.HasPrefix(upper, "INSERT INTO ") {
+	if !duckASCIIHasPrefixFold(trimmed, "INSERT INTO ") {
 		return "", "", false
 	}
-	valuesIndex := strings.Index(upper, " VALUES ")
+	valuesIndex := duckSQLValuesKeywordIndex(trimmed)
 	if valuesIndex < 0 {
 		return "", "", false
 	}
@@ -724,6 +828,42 @@ func splitDuckRemoteSimpleInsert(stmt string) (string, string, bool) {
 		return "", "", false
 	}
 	return prefix, tuple, true
+}
+
+func duckSQLValuesKeywordIndex(sqlText string) int {
+	const valuesKeyword = " VALUES "
+	for i := len("INSERT INTO "); i+len(valuesKeyword) <= len(sqlText); i++ {
+		if duckASCIIEqualFoldAt(sqlText, i, valuesKeyword) {
+			return i
+		}
+	}
+	return -1
+}
+
+func duckASCIIHasPrefixFold(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	return duckASCIIEqualFoldAt(s, 0, prefix)
+}
+
+func duckASCIIEqualFoldAt(s string, start int, pattern string) bool {
+	if start < 0 || start+len(pattern) > len(s) {
+		return false
+	}
+	for i := range len(pattern) {
+		if duckASCIIFold(s[start+i]) != duckASCIIFold(pattern[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func duckASCIIFold(b byte) byte {
+	if b >= 'a' && b <= 'z' {
+		return b - 'a' + 'A'
+	}
+	return b
 }
 
 func duckSQLLeadingParenthesizedExpression(sqlText string) (

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -588,17 +588,6 @@ func (b *duckRemoteMutationBatch) transactionBytes() int {
 	)
 }
 
-func duckRemoteTransactionBytes(statements []string) int {
-	if len(statements) == 0 {
-		return 0
-	}
-	statementBytes := 0
-	for _, stmt := range statements {
-		statementBytes += len(stmt)
-	}
-	return duckRemoteTransactionBytesFor(statementBytes, len(statements))
-}
-
 func duckRemoteTransactionBytesFor(statementBytes, statementCount int) int {
 	if statementCount == 0 {
 		return 0
@@ -692,15 +681,6 @@ func duckRemoteInsertMaxBytesForTransaction(maxBytes int) int {
 	return min(maxBytes-statementOverhead, duckRemoteInsertCoalesceMaxBytes)
 }
 
-func (b *duckRemoteMutationBatch) renderedStatements() []string {
-	rendered := b.rendered()
-	out := make([]string, 0, len(rendered))
-	for _, stmt := range rendered {
-		out = append(out, stmt.sql)
-	}
-	return out
-}
-
 func (b *duckRemoteMutationBatch) rendered() []duckRemoteRenderedStatement {
 	if b == nil || b.Len() == 0 {
 		return nil
@@ -719,17 +699,6 @@ func (b *duckRemoteMutationBatch) rendered() []duckRemoteRenderedStatement {
 	}
 	b.renderedValid = true
 	return b.renderedStatementsCache
-}
-
-func coalesceDuckRemoteInsertStatements(
-	statements []string, maxRows int, maxBytes int,
-) []string {
-	rendered := renderDuckRemoteMutationStatements(statements, maxRows, maxBytes)
-	out := make([]string, 0, len(rendered))
-	for _, stmt := range rendered {
-		out = append(out, stmt.sql)
-	}
-	return out
 }
 
 func renderDuckRemoteMutationStatements(

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -2,7 +2,9 @@ package duckdb
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"slices"
 	"sort"
@@ -25,7 +27,7 @@ func (s *Sync) syncModelPricing(ctx context.Context) error {
 		return nil
 	}
 
-	existing, err := listDuckModelPricing(ctx, s.duck)
+	existing, err := s.listDuckModelPricing(ctx)
 	if err != nil {
 		return err
 	}
@@ -44,8 +46,9 @@ func (s *Sync) syncModelPricing(ctx context.Context) error {
 
 	for i := 0; i < len(prices); i += duckPricingUpsertBatch {
 		end := min(i+duckPricingUpsertBatch, len(prices))
-		query, args := duckPricingUpsertStatement(prices[i:end])
-		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		batch := prices[i:end]
+		query, args := duckPricingUpsertStatement(batch)
+		if err := s.execMutation(ctx, tx, query, args...); err != nil {
 			return fmt.Errorf(
 				"syncing duckdb pricing batch starting at %d: %w",
 				i, err,
@@ -91,8 +94,9 @@ func duckPricingUpsertStatement(prices []db.ModelPricing) (string, []any) {
 	return b.String(), args
 }
 
-func listDuckModelPricing(ctx context.Context, duck *sql.DB) ([]db.ModelPricing, error) {
-	rows, err := duck.QueryContext(ctx,
+func (s *Sync) listDuckModelPricing(ctx context.Context) ([]db.ModelPricing, error) {
+	rows, err := queryDuckDBContext(
+		ctx, s.duck, s.connectionKind, s.quack,
 		`SELECT model_pattern, input_per_mtok,
 			output_per_mtok, cache_creation_per_mtok,
 			cache_read_per_mtok, updated_at
@@ -147,7 +151,7 @@ func (s *Sync) syncCursorUsageEvents(ctx context.Context) error {
 		_ = tx.Rollback()
 	}()
 
-	if err := bulkInsertCursorUsageEvents(ctx, tx, events); err != nil {
+	if err := s.bulkInsertCursorUsageEvents(ctx, tx, events); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
@@ -186,14 +190,14 @@ func (s *Sync) replaceStarredSessions(
 	}
 	if s.isFiltered() {
 		for _, sess := range sessions {
-			if _, err := tx.ExecContext(ctx,
+			if err := s.execMutation(ctx, tx,
 				`DELETE FROM starred_sessions WHERE session_id = ?`, sess.ID,
 			); err != nil {
 				return fmt.Errorf("clearing duckdb starred session %s: %w", sess.ID, err)
 			}
 		}
 	} else {
-		if _, err := tx.ExecContext(ctx, `
+		if err := s.execMutation(ctx, tx, `
 			DELETE FROM starred_sessions
 			WHERE session_id IN (
 				SELECT id FROM sessions WHERE machine = ?
@@ -217,49 +221,38 @@ func (s *Sync) replaceStarredSessions(
 }
 
 func (s *Sync) pushSession(
-	ctx context.Context, tx *sql.Tx, sess db.Session,
+	ctx context.Context, exec duckMutationExecutor, sess db.Session,
 ) (int, error) {
-	if err := upsertSession(ctx, tx, sess, s.machine); err != nil {
+	if err := s.upsertSession(ctx, exec, sess); err != nil {
 		return 0, err
 	}
-	if err := replaceSessionDependents(ctx, tx, sess.ID); err != nil {
+	if err := s.replaceSessionDependents(ctx, exec, sess.ID); err != nil {
 		return 0, err
 	}
-	if err := s.replaceUsageEvents(ctx, tx, sess.ID); err != nil {
+	if err := s.replaceUsageEvents(ctx, exec, sess.ID); err != nil {
 		return 0, err
 	}
 	msgs, err := s.local.GetAllMessages(ctx, sess.ID)
 	if err != nil {
 		return 0, fmt.Errorf("reading local messages for %s: %w", sess.ID, err)
 	}
-	if err := insertMessages(ctx, tx, msgs); err != nil {
+	if err := insertMessages(ctx, exec, msgs); err != nil {
 		return 0, err
 	}
-	toolCallKeys, err := upsertToolCalls(ctx, tx, msgs)
-	if err != nil {
+	if err := s.replaceToolRows(ctx, exec, sess.ID, msgs); err != nil {
 		return 0, err
 	}
-	eventKeys, err := upsertToolResultEvents(ctx, tx, msgs)
-	if err != nil {
+	if err := s.replaceSecretFindings(ctx, exec, sess.ID); err != nil {
 		return 0, err
 	}
-	if err := deleteStaleToolCalls(ctx, tx, sess.ID, toolCallKeys); err != nil {
-		return 0, err
-	}
-	if err := deleteStaleToolResultEvents(ctx, tx, sess.ID, eventKeys); err != nil {
-		return 0, err
-	}
-	if err := s.replaceSecretFindings(ctx, tx, sess.ID); err != nil {
-		return 0, err
-	}
-	if err := s.replacePinnedMessages(ctx, tx, sess.ID); err != nil {
+	if err := s.replacePinnedMessages(ctx, exec, sess.ID); err != nil {
 		return 0, err
 	}
 	return len(msgs), nil
 }
 
-func replaceSessionDependents(
-	ctx context.Context, tx *sql.Tx, sessionID string,
+func (s *Sync) replaceSessionDependents(
+	ctx context.Context, exec duckMutationExecutor, sessionID string,
 ) error {
 	for _, stmt := range []string{
 		`DELETE FROM pinned_messages WHERE session_id = ?`,
@@ -267,14 +260,14 @@ func replaceSessionDependents(
 		`DELETE FROM usage_events WHERE session_id = ?`,
 		`DELETE FROM messages WHERE session_id = ?`,
 	} {
-		if _, err := tx.ExecContext(ctx, stmt, sessionID); err != nil {
+		if err := s.execMutation(ctx, exec, stmt, sessionID); err != nil {
 			return fmt.Errorf("clearing duckdb session dependents: %w", err)
 		}
 	}
 	return nil
 }
 
-func deleteHardDeletedMirrorSessions(
+func (s *Sync) deleteHardDeletedMirrorSessions(
 	ctx context.Context, tx *sql.Tx, localSessions []db.Session,
 	machine string, projects, excludeProjects []string,
 ) ([]string, error) {
@@ -308,14 +301,16 @@ func deleteHardDeletedMirrorSessions(
 	}
 	sort.Strings(stale)
 	for _, id := range stale {
-		if err := deleteMirrorSession(ctx, tx, id); err != nil {
+		if err := s.deleteMirrorSession(ctx, tx, id); err != nil {
 			return nil, err
 		}
 	}
 	return stale, nil
 }
 
-func deleteMirrorSession(ctx context.Context, tx *sql.Tx, sessionID string) error {
+func (s *Sync) deleteMirrorSession(
+	ctx context.Context, tx *sql.Tx, sessionID string,
+) error {
 	for _, stmt := range []string{
 		`DELETE FROM pinned_messages WHERE session_id = ?`,
 		`DELETE FROM starred_sessions WHERE session_id = ?`,
@@ -326,7 +321,7 @@ func deleteMirrorSession(ctx context.Context, tx *sql.Tx, sessionID string) erro
 		`DELETE FROM messages WHERE session_id = ?`,
 		`DELETE FROM sessions WHERE id = ?`,
 	} {
-		if _, err := tx.ExecContext(ctx, stmt, sessionID); err != nil {
+		if err := s.execMutation(ctx, tx, stmt, sessionID); err != nil {
 			return fmt.Errorf("deleting hard-deleted duckdb session %s: %w", sessionID, err)
 		}
 	}
@@ -343,10 +338,317 @@ func projectInSyncScope(project string, projects, excludeProjects []string) bool
 	return !slices.Contains(excludeProjects, project)
 }
 
-func upsertSession(
-	ctx context.Context, tx *sql.Tx, sess db.Session, machine string,
+func (s *Sync) execMutation(
+	ctx context.Context, exec duckMutationExecutor, stmt string, args ...any,
 ) error {
-	_, err := tx.ExecContext(ctx, `
+	if s.connectionKind != duckDBQuackClientConnection {
+		_, err := exec.ExecContext(ctx, stmt, args...)
+		return err
+	}
+	if _, ok := exec.(*duckRemoteMutationBatch); ok {
+		_, err := exec.ExecContext(ctx, stmt, args...)
+		return err
+	}
+	// Quack attachments can accept plain inserts, but DELETE, UPDATE, and
+	// ON CONFLICT are planned against proxy storage and currently fail with
+	// GetStorageInfo errors. Run those mutations on the server-side base DB.
+	sqlText, err := duckSQLWithArgs(stmt, args...)
+	if err != nil {
+		return err
+	}
+	_, err = exec.ExecContext(ctx, "FROM "+quackAttachmentName+".query(?)", sqlText)
+	return err
+}
+
+type duckMutationExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+const duckRemoteMutationCoalesceMaxBytes = 16 << 20
+
+type duckRemoteMutationBatch struct {
+	statements     []string
+	statementBytes int
+}
+
+func (b *duckRemoteMutationBatch) ExecContext(
+	_ context.Context, stmt string, args ...any,
+) (sql.Result, error) {
+	sqlText, err := duckSQLWithArgs(stmt, args...)
+	if err != nil {
+		return nil, err
+	}
+	b.statements = append(b.statements, sqlText)
+	b.statementBytes += len(sqlText)
+	return duckNoopResult{}, nil
+}
+
+func (b *duckRemoteMutationBatch) Len() int {
+	return len(b.statements)
+}
+
+func (b *duckRemoteMutationBatch) appendBatch(other *duckRemoteMutationBatch) {
+	if other == nil || other.Len() == 0 {
+		return
+	}
+	b.statements = append(b.statements, other.statements...)
+	b.statementBytes += other.statementBytes
+}
+
+type duckNoopResult struct{}
+
+func (duckNoopResult) LastInsertId() (int64, error) { return 0, nil }
+func (duckNoopResult) RowsAffected() (int64, error) { return 0, nil }
+
+func (s *Sync) execRemoteMutationBatch(
+	ctx context.Context, label string, batch *duckRemoteMutationBatch, coalesce bool,
+) error {
+	exec := s.execRemoteSQLNoRetry
+	if coalesce {
+		exec = s.execRemoteSQLRetry
+	}
+	return execDuckRemoteMutationBatch(ctx, exec, label, batch, coalesce)
+}
+
+func appendDuckRemoteMutationBatch(
+	ctx context.Context,
+	execCoalesced func(context.Context, string) error,
+	execStatement func(context.Context, string) error,
+	label string,
+	current *duckRemoteMutationBatch,
+	next *duckRemoteMutationBatch,
+	maxBytes int,
+) (*duckRemoteMutationBatch, error) {
+	if current == nil {
+		current = &duckRemoteMutationBatch{}
+	}
+	if next == nil || next.Len() == 0 {
+		return current, nil
+	}
+	if maxBytes <= 0 {
+		maxBytes = duckRemoteMutationCoalesceMaxBytes
+	}
+	if next.transactionBytes() > maxBytes {
+		if err := execDuckRemoteMutationBatch(ctx, execCoalesced, label, current, true); err != nil {
+			return current, err
+		}
+		if err := execDuckRemoteMutationBatch(ctx, execStatement, label, next, false); err != nil {
+			return &duckRemoteMutationBatch{}, err
+		}
+		return &duckRemoteMutationBatch{}, nil
+	}
+	if current.Len() > 0 && current.combinedTransactionBytes(next) > maxBytes {
+		if err := execDuckRemoteMutationBatch(ctx, execCoalesced, label, current, true); err != nil {
+			return current, err
+		}
+		current = &duckRemoteMutationBatch{}
+	}
+	current.appendBatch(next)
+	return current, nil
+}
+
+func execDuckRemoteMutationBatch(
+	ctx context.Context,
+	exec func(context.Context, string) error,
+	label string,
+	batch *duckRemoteMutationBatch,
+	coalesce bool,
+) (err error) {
+	if batch.Len() == 0 {
+		return nil
+	}
+	if coalesce {
+		if err := exec(ctx, batch.transactionSQL()); err != nil {
+			if rollbackErr := exec(ctx, "ROLLBACK"); rollbackErr != nil {
+				return fmt.Errorf("%w; rollback %s: %v", err, label, rollbackErr)
+			}
+			return err
+		}
+		return nil
+	}
+	if err := exec(ctx, "BEGIN TRANSACTION"); err != nil {
+		return fmt.Errorf("begin %s: %w", label, err)
+	}
+	needsRollback := true
+	defer func() {
+		if !needsRollback {
+			return
+		}
+		rollbackErr := exec(ctx, "ROLLBACK")
+		if err != nil && rollbackErr != nil {
+			err = fmt.Errorf("%w; rollback %s: %v", err, label, rollbackErr)
+		}
+	}()
+	for i, stmt := range batch.statements {
+		if err := exec(ctx, stmt); err != nil {
+			return fmt.Errorf(
+				"execute %s statement %d/%d: %w",
+				label, i+1, batch.Len(), err,
+			)
+		}
+	}
+	if err := exec(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("commit %s: %w", label, err)
+	}
+	needsRollback = false
+	return nil
+}
+
+func execDuckRemoteMutationBatchWithStatementFallback(
+	ctx context.Context,
+	execCoalesced func(context.Context, string) error,
+	execStatement func(context.Context, string) error,
+	label string,
+	batch *duckRemoteMutationBatch,
+) error {
+	if err := execDuckRemoteMutationBatch(ctx, execCoalesced, label, batch, true); err != nil {
+		if ctx.Err() != nil || isStaleQuackConnectionError(err) {
+			return err
+		}
+		return execDuckRemoteMutationBatch(ctx, execStatement, label, batch, false)
+	}
+	return nil
+}
+
+func (b *duckRemoteMutationBatch) transactionSQL() string {
+	var sqlText strings.Builder
+	sqlText.WriteString("BEGIN TRANSACTION;\n")
+	for _, stmt := range b.statements {
+		sqlText.WriteString(stmt)
+		sqlText.WriteString(";\n")
+	}
+	sqlText.WriteString("COMMIT")
+	return sqlText.String()
+}
+
+func (b *duckRemoteMutationBatch) transactionBytes() int {
+	if b == nil || b.Len() == 0 {
+		return 0
+	}
+	return len("BEGIN TRANSACTION;\n") +
+		b.statementBytes +
+		len(";\n")*b.Len() +
+		len("COMMIT")
+}
+
+func (b *duckRemoteMutationBatch) combinedTransactionBytes(
+	other *duckRemoteMutationBatch,
+) int {
+	if b == nil || b.Len() == 0 {
+		return other.transactionBytes()
+	}
+	if other == nil || other.Len() == 0 {
+		return b.transactionBytes()
+	}
+	return len("BEGIN TRANSACTION;\n") +
+		b.statementBytes + other.statementBytes +
+		len(";\n")*(b.Len()+other.Len()) +
+		len("COMMIT")
+}
+
+func (s *Sync) execRemoteSQLRetry(ctx context.Context, sqlText string) error {
+	if s.quack != nil {
+		return s.quack.execRemote(ctx, sqlText, true)
+	}
+	return s.execRemoteSQLNoRetry(ctx, sqlText)
+}
+
+func (s *Sync) execRemoteSQLNoRetry(ctx context.Context, sqlText string) error {
+	if s.quack != nil {
+		return s.quack.execRemote(ctx, sqlText, false)
+	}
+	_, err := s.duck.ExecContext(ctx, "FROM "+quackAttachmentName+".query(?)", sqlText)
+	return err
+}
+
+func duckSQLWithArgs(stmt string, args ...any) (string, error) {
+	var b strings.Builder
+	argIndex := 0
+	for _, r := range stmt {
+		if r != '?' {
+			b.WriteRune(r)
+			continue
+		}
+		if argIndex >= len(args) {
+			return "", fmt.Errorf("duckdb remote statement missing argument")
+		}
+		lit, err := duckValueLiteral(args[argIndex])
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(lit)
+		argIndex++
+	}
+	if argIndex != len(args) {
+		return "", fmt.Errorf("duckdb remote statement has unused argument")
+	}
+	return b.String(), nil
+}
+
+func duckValueLiteral(v any) (string, error) {
+	switch value := v.(type) {
+	case nil:
+		return "NULL", nil
+	case string:
+		return duckRemoteStringLiteral(value)
+	case *string:
+		if value == nil {
+			return "NULL", nil
+		}
+		return duckRemoteStringLiteral(*value)
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return fmt.Sprint(value), nil
+	case *int:
+		if value == nil {
+			return "NULL", nil
+		}
+		return fmt.Sprint(*value), nil
+	case *int64:
+		if value == nil {
+			return "NULL", nil
+		}
+		return fmt.Sprint(*value), nil
+	case *float64:
+		if value == nil {
+			return "NULL", nil
+		}
+		return fmt.Sprint(*value), nil
+	case bool:
+		if value {
+			return "TRUE", nil
+		}
+		return "FALSE", nil
+	case time.Time:
+		return "TIMESTAMP " + duckLiteral(
+			value.UTC().Format("2006-01-02 15:04:05.999999"),
+		), nil
+	default:
+		return "", fmt.Errorf("unsupported duckdb remote argument type %T", v)
+	}
+}
+
+func duckRemoteStringLiteral(s string) (string, error) {
+	s = strings.ReplaceAll(s, "\x00", "")
+	for {
+		var tagBytes [16]byte
+		if _, err := rand.Read(tagBytes[:]); err != nil {
+			return "", fmt.Errorf("generating duckdb string literal tag: %w", err)
+		}
+		tag := "agentsview_" + hex.EncodeToString(tagBytes[:])
+		delimiter := "$" + tag + "$"
+		if strings.Contains(s, delimiter) {
+			continue
+		}
+		return delimiter + s + delimiter, nil
+	}
+}
+
+func (s *Sync) upsertSession(
+	ctx context.Context, exec duckMutationExecutor, sess db.Session,
+) error {
+	query := `
 		INSERT INTO sessions (
 			id, project, machine, agent,
 			first_message, display_name, session_name, started_at, ended_at,
@@ -373,7 +675,8 @@ func upsertSession(
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?
-		)
+		)`
+	query += `
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project,
 			machine = excluded.machine,
@@ -435,7 +738,16 @@ func upsertSession(
 			created_at = excluded.created_at,
 			termination_status = excluded.termination_status,
 			secret_leak_count = excluded.secret_leak_count,
-			secrets_rules_version = excluded.secrets_rules_version`,
+			secrets_rules_version = excluded.secrets_rules_version`
+
+	if err := s.execMutation(ctx, exec, query, sessionInsertArgs(sess, s.machine)...); err != nil {
+		return fmt.Errorf("writing duckdb session %s: %w", sess.ID, err)
+	}
+	return nil
+}
+
+func sessionInsertArgs(sess db.Session, machine string) []any {
+	return []any{
 		sess.ID, sess.Project, machine, sess.Agent,
 		nilString(sess.FirstMessage), nilString(sess.DisplayName),
 		nilString(sess.SessionName),
@@ -466,16 +778,14 @@ func upsertSession(
 		sess.IsTruncated, nilTime(sess.DeletedAt),
 		timeValue(sess.CreatedAt), nilString(sess.TerminationStatus),
 		sess.SecretLeakCount, sess.SecretsRulesVersion,
-	)
-	if err != nil {
-		return fmt.Errorf("upserting duckdb session %s: %w", sess.ID, err)
 	}
-	return nil
 }
 
-func insertMessages(ctx context.Context, tx *sql.Tx, msgs []db.Message) error {
+func insertMessages(
+	ctx context.Context, exec duckMutationExecutor, msgs []db.Message,
+) error {
 	for _, m := range msgs {
-		if _, err := tx.ExecContext(ctx, `
+		if _, err := exec.ExecContext(ctx, `
 			INSERT INTO messages (
 				id, session_id, ordinal, role, content, thinking_text,
 				timestamp, has_thinking, has_tool_use, content_length,
@@ -500,45 +810,36 @@ func insertMessages(ctx context.Context, tx *sql.Tx, msgs []db.Message) error {
 	return nil
 }
 
-type duckToolCallKey struct {
-	messageID int64
-	callIndex int
+func (s *Sync) replaceToolRows(
+	ctx context.Context, exec duckMutationExecutor, sessionID string, msgs []db.Message,
+) error {
+	if err := s.execMutation(ctx, exec,
+		`DELETE FROM tool_result_events WHERE session_id = ?`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("clearing duckdb tool_result_events for %s: %w", sessionID, err)
+	}
+	if err := s.execMutation(ctx, exec,
+		`DELETE FROM tool_calls WHERE session_id = ?`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("clearing duckdb tool_calls for %s: %w", sessionID, err)
+	}
+	if err := insertToolCalls(ctx, exec, msgs); err != nil {
+		return err
+	}
+	if err := insertToolResultEvents(ctx, exec, msgs); err != nil {
+		return err
+	}
+	return nil
 }
 
-type duckToolResultEventKey struct {
-	ordinal    int
-	callIndex  int
-	eventIndex int
-}
-
-func upsertToolCalls(ctx context.Context, tx *sql.Tx, msgs []db.Message) ([]duckToolCallKey, error) {
-	keys := []duckToolCallKey{}
+func insertToolCalls(
+	ctx context.Context, exec duckMutationExecutor, msgs []db.Message,
+) error {
 	for _, m := range msgs {
 		for i, tc := range m.ToolCalls {
-			key := duckToolCallKey{messageID: m.ID, callIndex: i}
-			keys = append(keys, key)
-			res, err := tx.ExecContext(ctx, `
-				UPDATE tool_calls SET
-					tool_name = ?, category = ?, tool_use_id = ?,
-					input_json = ?, skill_name = ?,
-					result_content_length = ?, result_content = ?,
-					subagent_session_id = ?, file_path = ?
-				WHERE session_id = ? AND message_id = ? AND call_index = ?`,
-				tc.ToolName, tc.Category, tc.ToolUseID,
-				nilEmpty(tc.InputJSON), nilEmpty(tc.SkillName),
-				nilZero(tc.ResultContentLength), nilEmpty(tc.ResultContent),
-				nilEmpty(tc.SubagentSessionID), nilEmpty(tc.FilePath),
-				m.SessionID, m.ID, i,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("updating duckdb tool_call %s/%d/%d: %w",
-					m.SessionID, m.Ordinal, i, err)
-			}
-			affected, _ := res.RowsAffected()
-			if affected > 0 {
-				continue
-			}
-			if _, err := tx.ExecContext(ctx, `
+			if _, err := exec.ExecContext(ctx, `
 				INSERT INTO tool_calls (
 					message_id, session_id, tool_name, category,
 					call_index, tool_use_id, input_json, skill_name,
@@ -551,50 +852,21 @@ func upsertToolCalls(ctx context.Context, tx *sql.Tx, msgs []db.Message) ([]duck
 				nilEmpty(tc.ResultContent), nilEmpty(tc.SubagentSessionID),
 				nilEmpty(tc.FilePath),
 			); err != nil {
-				return nil, fmt.Errorf("inserting duckdb tool_call %s/%d/%d: %w",
+				return fmt.Errorf("inserting duckdb tool_call %s/%d/%d: %w",
 					m.SessionID, m.Ordinal, i, err)
 			}
 		}
 	}
-	return keys, nil
+	return nil
 }
 
-func upsertToolResultEvents(
-	ctx context.Context, tx *sql.Tx, msgs []db.Message,
-) ([]duckToolResultEventKey, error) {
-	keys := []duckToolResultEventKey{}
+func insertToolResultEvents(
+	ctx context.Context, exec duckMutationExecutor, msgs []db.Message,
+) error {
 	for _, m := range msgs {
 		for i, tc := range m.ToolCalls {
 			for _, ev := range tc.ResultEvents {
-				key := duckToolResultEventKey{
-					ordinal:    m.Ordinal,
-					callIndex:  i,
-					eventIndex: ev.EventIndex,
-				}
-				keys = append(keys, key)
-				res, err := tx.ExecContext(ctx, `
-					UPDATE tool_result_events SET
-						tool_use_id = ?, agent_id = ?, subagent_session_id = ?,
-						source = ?, status = ?, content = ?,
-						content_length = ?, timestamp = ?
-					WHERE session_id = ?
-						AND tool_call_message_ordinal = ?
-						AND call_index = ?
-						AND event_index = ?`,
-					nilEmpty(ev.ToolUseID), nilEmpty(ev.AgentID),
-					nilEmpty(ev.SubagentSessionID), ev.Source, ev.Status,
-					ev.Content, ev.ContentLength, timeValue(ev.Timestamp),
-					m.SessionID, m.Ordinal, i, ev.EventIndex,
-				)
-				if err != nil {
-					return nil, fmt.Errorf("updating duckdb tool_result_event %s/%d/%d: %w",
-						m.SessionID, m.Ordinal, i, err)
-				}
-				affected, _ := res.RowsAffected()
-				if affected > 0 {
-					continue
-				}
-				if _, err := tx.ExecContext(ctx, `
+				if _, err := exec.ExecContext(ctx, `
 					INSERT INTO tool_result_events (
 						session_id, tool_call_message_ordinal, call_index,
 						tool_use_id, agent_id, subagent_session_id,
@@ -607,111 +879,41 @@ func upsertToolResultEvents(
 					ev.Content, ev.ContentLength, timeValue(ev.Timestamp),
 					ev.EventIndex,
 				); err != nil {
-					return nil, fmt.Errorf("inserting duckdb tool_result_event %s/%d/%d: %w",
+					return fmt.Errorf("inserting duckdb tool_result_event %s/%d/%d: %w",
 						m.SessionID, m.Ordinal, i, err)
 				}
 			}
 		}
 	}
-	return keys, nil
-}
-
-func deleteStaleToolCalls(
-	ctx context.Context, tx *sql.Tx, sessionID string, keep []duckToolCallKey,
-) error {
-	keepSet := make(map[duckToolCallKey]bool, len(keep))
-	for _, key := range keep {
-		keepSet[key] = true
-	}
-	rows, err := tx.QueryContext(ctx,
-		`SELECT message_id, call_index FROM tool_calls WHERE session_id = ?`,
-		sessionID,
-	)
-	if err != nil {
-		return fmt.Errorf("listing duckdb tool_calls for stale delete %s: %w", sessionID, err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var key duckToolCallKey
-		if err := rows.Scan(&key.messageID, &key.callIndex); err != nil {
-			return err
-		}
-		if keepSet[key] {
-			continue
-		}
-		if _, err := tx.ExecContext(ctx,
-			`DELETE FROM tool_calls WHERE session_id = ? AND message_id = ? AND call_index = ?`,
-			sessionID, key.messageID, key.callIndex,
-		); err != nil {
-			return fmt.Errorf("deleting stale duckdb tool_call %s: %w", sessionID, err)
-		}
-	}
-	return rows.Err()
-}
-
-func deleteStaleToolResultEvents(
-	ctx context.Context, tx *sql.Tx, sessionID string, keep []duckToolResultEventKey,
-) error {
-	keepSet := make(map[duckToolResultEventKey]bool, len(keep))
-	for _, key := range keep {
-		keepSet[key] = true
-	}
-	rows, err := tx.QueryContext(ctx, `
-		SELECT tool_call_message_ordinal, call_index, event_index
-		FROM tool_result_events
-		WHERE session_id = ?`,
-		sessionID,
-	)
-	if err != nil {
-		return fmt.Errorf("listing duckdb tool_result_events for stale delete %s: %w", sessionID, err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var key duckToolResultEventKey
-		if err := rows.Scan(&key.ordinal, &key.callIndex, &key.eventIndex); err != nil {
-			return err
-		}
-		if keepSet[key] {
-			continue
-		}
-		if _, err := tx.ExecContext(ctx, `
-			DELETE FROM tool_result_events
-			WHERE session_id = ?
-				AND tool_call_message_ordinal = ?
-				AND call_index = ?
-				AND event_index = ?`,
-			sessionID, key.ordinal, key.callIndex, key.eventIndex,
-		); err != nil {
-			return fmt.Errorf("deleting stale duckdb tool_result_event %s: %w", sessionID, err)
-		}
-	}
-	return rows.Err()
+	return nil
 }
 
 func (s *Sync) replaceUsageEvents(
-	ctx context.Context, tx *sql.Tx, sessionID string,
+	ctx context.Context, exec duckMutationExecutor, sessionID string,
 ) error {
 	events, err := s.local.GetUsageEvents(ctx, sessionID)
 	if err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx,
+	if err := s.execMutation(ctx, exec,
 		`DELETE FROM usage_events WHERE session_id = ?`,
 		sessionID,
 	); err != nil {
 		return fmt.Errorf("clearing duckdb usage_events for %s: %w", sessionID, err)
 	}
 	for _, ev := range events {
-		if err := insertUsageEvent(ctx, tx, ev); err != nil {
+		if err := insertUsageEvent(ctx, exec, ev); err != nil {
 			return fmt.Errorf("inserting duckdb usage_event %s: %w", sessionID, err)
 		}
 	}
 	return nil
 }
 
-func insertUsageEvent(ctx context.Context, tx *sql.Tx, ev db.UsageEvent) error {
+func insertUsageEvent(
+	ctx context.Context, exec duckMutationExecutor, ev db.UsageEvent,
+) error {
 	ordinal, cost, occurredAt := usageEventNullableValues(ev)
-	if _, err := tx.ExecContext(ctx, `
+	if _, err := exec.ExecContext(ctx, `
 		INSERT INTO usage_events (
 			id, session_id, message_ordinal, source, model,
 			input_tokens, output_tokens,
@@ -730,7 +932,7 @@ func insertUsageEvent(ctx context.Context, tx *sql.Tx, ev db.UsageEvent) error {
 	return nil
 }
 
-func bulkInsertCursorUsageEvents(
+func (s *Sync) bulkInsertCursorUsageEvents(
 	ctx context.Context, tx *sql.Tx, events []db.CursorUsageEvent,
 ) error {
 	if len(events) == 0 {
@@ -776,7 +978,7 @@ func bulkInsertCursorUsageEvents(
 			)
 		}
 		b.WriteString(` ON CONFLICT DO NOTHING`)
-		if _, err := tx.ExecContext(ctx, b.String(), args...); err != nil {
+		if err := s.execMutation(ctx, tx, b.String(), args...); err != nil {
 			return fmt.Errorf("bulk inserting duckdb cursor_usage_events: %w", err)
 		}
 	}
@@ -800,14 +1002,14 @@ func usageEventNullableValues(ev db.UsageEvent) (any, any, any) {
 }
 
 func (s *Sync) replaceSecretFindings(
-	ctx context.Context, tx *sql.Tx, sessionID string,
+	ctx context.Context, exec duckMutationExecutor, sessionID string,
 ) error {
 	findings, err := s.local.SessionSecretFindings(ctx, sessionID)
 	if err != nil {
 		return err
 	}
 	for _, f := range findings {
-		if _, err := tx.ExecContext(ctx, `
+		if _, err := exec.ExecContext(ctx, `
 			INSERT INTO secret_findings (
 				session_id, rule_name, confidence, location_kind,
 				message_ordinal, call_index, event_index,
@@ -826,14 +1028,14 @@ func (s *Sync) replaceSecretFindings(
 }
 
 func (s *Sync) replacePinnedMessages(
-	ctx context.Context, tx *sql.Tx, sessionID string,
+	ctx context.Context, exec duckMutationExecutor, sessionID string,
 ) error {
 	pins, err := s.local.ListPinnedMessages(ctx, sessionID, "")
 	if err != nil {
 		return err
 	}
 	for _, p := range pins {
-		if _, err := tx.ExecContext(ctx, `
+		if _, err := exec.ExecContext(ctx, `
 			INSERT INTO pinned_messages (
 				id, session_id, message_id, ordinal, note, created_at
 			) VALUES (?, ?, ?, ?, ?, ?)`,
@@ -850,7 +1052,7 @@ func (s *Sync) replacePinnedMessages(
 func (s *Sync) replaceAllPinnedMessages(
 	ctx context.Context, tx *sql.Tx, sessions []db.Session,
 ) error {
-	if _, err := tx.ExecContext(ctx, `
+	if err := s.execMutation(ctx, tx, `
 		DELETE FROM pinned_messages
 		WHERE session_id IN (
 			SELECT id FROM sessions WHERE machine = ?
@@ -869,7 +1071,7 @@ func (s *Sync) replaceScopedPinnedMessages(
 	ctx context.Context, tx *sql.Tx, sessions []db.Session,
 ) error {
 	for _, sess := range sessions {
-		if _, err := tx.ExecContext(ctx,
+		if err := s.execMutation(ctx, tx,
 			`DELETE FROM pinned_messages WHERE session_id = ?`, sess.ID,
 		); err != nil {
 			return fmt.Errorf("clearing duckdb pinned_messages for %s: %w", sess.ID, err)

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -401,13 +401,11 @@ func (duckNoopResult) LastInsertId() (int64, error) { return 0, nil }
 func (duckNoopResult) RowsAffected() (int64, error) { return 0, nil }
 
 func (s *Sync) execRemoteMutationBatch(
-	ctx context.Context, label string, batch *duckRemoteMutationBatch, coalesce bool,
+	ctx context.Context, label string, batch *duckRemoteMutationBatch,
 ) error {
-	exec := s.execRemoteSQLNoRetry
-	if coalesce {
-		exec = s.execRemoteSQLRetry
-	}
-	return execDuckRemoteMutationBatch(ctx, exec, label, batch, coalesce)
+	return execDuckRemoteMutationBatch(
+		ctx, s.execRemoteSQLRetry, label, batch, true,
+	)
 }
 
 func appendDuckRemoteMutationBatch(

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -364,7 +364,7 @@ type duckMutationExecutor interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
-const duckRemoteMutationCoalesceMaxBytes = 16 << 20
+const duckRemoteMutationCoalesceMaxBytes = 2 << 20
 
 type duckRemoteMutationBatch struct {
 	statements     []string
@@ -413,7 +413,6 @@ func (s *Sync) execRemoteMutationBatch(
 func appendDuckRemoteMutationBatch(
 	ctx context.Context,
 	execCoalesced func(context.Context, string) error,
-	execStatement func(context.Context, string) error,
 	label string,
 	current *duckRemoteMutationBatch,
 	next *duckRemoteMutationBatch,
@@ -429,10 +428,14 @@ func appendDuckRemoteMutationBatch(
 		maxBytes = duckRemoteMutationCoalesceMaxBytes
 	}
 	if next.transactionBytes() > maxBytes {
-		if err := execDuckRemoteMutationBatch(ctx, execCoalesced, label, current, true); err != nil {
+		if err := execDuckRemoteMutationBatch(
+			ctx, execCoalesced, label, current, true,
+		); err != nil {
 			return current, err
 		}
-		if err := execDuckRemoteMutationBatch(ctx, execStatement, label, next, false); err != nil {
+		if err := execDuckRemoteMutationBatchChunks(
+			ctx, execCoalesced, label, next, maxBytes,
+		); err != nil {
 			return &duckRemoteMutationBatch{}, err
 		}
 		return &duckRemoteMutationBatch{}, nil
@@ -459,6 +462,9 @@ func execDuckRemoteMutationBatch(
 	}
 	if coalesce {
 		if err := exec(ctx, batch.transactionSQL()); err != nil {
+			if isDuckRemoteMutationTimeoutError(err) {
+				return err
+			}
 			if rollbackErr := exec(ctx, "ROLLBACK"); rollbackErr != nil {
 				return fmt.Errorf("%w; rollback %s: %v", err, label, rollbackErr)
 			}
@@ -502,10 +508,45 @@ func execDuckRemoteMutationBatchWithStatementFallback(
 	batch *duckRemoteMutationBatch,
 ) error {
 	if err := execDuckRemoteMutationBatch(ctx, execCoalesced, label, batch, true); err != nil {
-		if ctx.Err() != nil || isStaleQuackConnectionError(err) {
+		if ctx.Err() != nil ||
+			isStaleQuackConnectionError(err) ||
+			isDuckRemoteMutationTimeoutError(err) {
 			return err
 		}
 		return execDuckRemoteMutationBatch(ctx, execStatement, label, batch, false)
+	}
+	return nil
+}
+
+func execDuckRemoteMutationBatchChunks(
+	ctx context.Context,
+	exec func(context.Context, string) error,
+	label string,
+	batch *duckRemoteMutationBatch,
+	maxBytes int,
+) error {
+	for _, chunk := range batch.chunks(maxBytes) {
+		if err := execDuckRemoteMutationBatch(ctx, exec, label, chunk, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func execDuckRemoteMutationBatchChunksWithStatementFallback(
+	ctx context.Context,
+	execCoalesced func(context.Context, string) error,
+	execStatement func(context.Context, string) error,
+	label string,
+	batch *duckRemoteMutationBatch,
+	maxBytes int,
+) error {
+	for _, chunk := range batch.chunks(maxBytes) {
+		if err := execDuckRemoteMutationBatchWithStatementFallback(
+			ctx, execCoalesced, execStatement, label, chunk,
+		); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -544,6 +585,39 @@ func (b *duckRemoteMutationBatch) combinedTransactionBytes(
 		b.statementBytes + other.statementBytes +
 		len(";\n")*(b.Len()+other.Len()) +
 		len("COMMIT")
+}
+
+func (b *duckRemoteMutationBatch) chunks(maxBytes int) []*duckRemoteMutationBatch {
+	if b == nil || b.Len() == 0 {
+		return nil
+	}
+	if maxBytes <= 0 {
+		maxBytes = duckRemoteMutationCoalesceMaxBytes
+	}
+	var chunks []*duckRemoteMutationBatch
+	current := &duckRemoteMutationBatch{}
+	for _, stmt := range b.statements {
+		next := &duckRemoteMutationBatch{
+			statements:     []string{stmt},
+			statementBytes: len(stmt),
+		}
+		if current.Len() > 0 && current.combinedTransactionBytes(next) > maxBytes {
+			chunks = append(chunks, current)
+			current = &duckRemoteMutationBatch{}
+		}
+		current.appendBatch(next)
+	}
+	if current.Len() > 0 {
+		chunks = append(chunks, current)
+	}
+	return chunks
+}
+
+func isDuckRemoteMutationTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "timeout was reached")
 }
 
 func (s *Sync) execRemoteSQLRetry(ctx context.Context, sqlText string) error {

--- a/internal/duckdb/quack_smoke_duckdbtest_test.go
+++ b/internal/duckdb/quack_smoke_duckdbtest_test.go
@@ -862,6 +862,94 @@ func TestQuackRemoteMutationBatchCoalescesAgainstServer(t *testing.T) {
 	assertDuckDBCount(t, server, "remote_batch_test", 2)
 }
 
+func TestQuackRemoteMutationBatchChunksRepairInterruptedSession(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-chunks.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0009"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	_, err := server.ExecContext(ctx,
+		`CREATE TABLE remote_chunk_repair_test (
+			session_id VARCHAR,
+			ordinal INTEGER,
+			content VARCHAR,
+			PRIMARY KEY(session_id, ordinal)
+		)`,
+	)
+	require.NoError(t, err, "create remote chunk repair test table")
+	client := openQuackClientAttachment(t, ctx, uri, token)
+	execRemote := func(ctx context.Context, sqlText string) error {
+		_, err := client.ExecContext(
+			ctx, "FROM "+quackAttachmentName+".query(?)", sqlText,
+		)
+		return err
+	}
+
+	const sessionID = "chunk-repair-session"
+	_, err = server.ExecContext(ctx,
+		`INSERT INTO remote_chunk_repair_test VALUES (?, ?, ?)`,
+		sessionID, 99, "stale",
+	)
+	require.NoError(t, err, "seed stale remote row")
+
+	batch := &duckRemoteMutationBatch{}
+	_, err = batch.ExecContext(ctx,
+		`DELETE FROM remote_chunk_repair_test WHERE session_id = ?`, sessionID,
+	)
+	require.NoError(t, err)
+	deleteOnly := &duckRemoteMutationBatch{statements: batch.statements[:1]}
+	deleteOnly.statementBytes = len(batch.statements[0])
+	for i, content := range []string{"one", "two", "three"} {
+		_, err = batch.ExecContext(ctx,
+			`INSERT INTO remote_chunk_repair_test VALUES (?, ?, ?)`,
+			sessionID, i, content,
+		)
+		require.NoError(t, err)
+	}
+	chunks := batch.chunks(deleteOnly.transactionBytes())
+	require.Greater(t, len(chunks), 1)
+	require.Contains(t, chunks[0].transactionSQL(), "DELETE FROM")
+	require.NotContains(t, chunks[0].transactionSQL(), "INSERT INTO")
+
+	require.NoError(t, execDuckRemoteMutationBatch(
+		ctx, execRemote, "quack interrupted chunk", chunks[0], true,
+	))
+	assertDuckDBCountWhere(
+		t, server, "remote_chunk_repair_test", "session_id = ?", sessionID, 0,
+	)
+
+	require.NoError(t, execDuckRemoteMutationBatchChunks(
+		ctx, execRemote, "quack repaired chunks", batch,
+		deleteOnly.transactionBytes(),
+	))
+	rows, err := server.QueryContext(ctx,
+		`SELECT ordinal, content
+		 FROM remote_chunk_repair_test
+		 WHERE session_id = ?
+		 ORDER BY ordinal`,
+		sessionID,
+	)
+	require.NoError(t, err, "read repaired chunk rows")
+	defer rows.Close()
+	type row struct {
+		ordinal int
+		content string
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		require.NoError(t, rows.Scan(&r.ordinal, &r.content))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []row{
+		{ordinal: 0, content: "one"},
+		{ordinal: 1, content: "two"},
+		{ordinal: 2, content: "three"},
+	}, got)
+}
+
 type duckMirrorSessionState struct {
 	FirstMessage         string
 	MessageCount         int

--- a/internal/duckdb/quack_smoke_duckdbtest_test.go
+++ b/internal/duckdb/quack_smoke_duckdbtest_test.go
@@ -9,10 +9,13 @@ import (
 	"net"
 	"path/filepath"
 	"testing"
+	"time"
 
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 func TestQuackLoopbackAttachRoundTrip(t *testing.T) {
@@ -103,6 +106,21 @@ func TestQuackLoopbackAttachRoundTrip(t *testing.T) {
 	)
 	assert.Equal(t, 41, got)
 
+	_, err = client.ExecContext(ctx, `FROM remote_db.query(?)`,
+		`INSERT INTO local_seed VALUES ('seed', 43)
+		 ON CONFLICT(id) DO UPDATE SET value = excluded.value`,
+	)
+	require.NoError(t, err, "upsert seed row through quack query")
+
+	require.NoError(t,
+		server.QueryRowContext(ctx,
+			`SELECT value FROM local_seed WHERE id = ?`,
+			"seed",
+		).Scan(&got),
+		"query upserted seed row on server",
+	)
+	assert.Equal(t, 43, got)
+
 	_, err = client.ExecContext(ctx,
 		`CREATE TABLE remote_db.remote_write
 		 AS SELECT 'client'::TEXT AS id, 42::INTEGER AS value`,
@@ -118,6 +136,835 @@ func TestQuackLoopbackAttachRoundTrip(t *testing.T) {
 		"query row written through quack attachment",
 	)
 	assert.Equal(t, 42, remoteValue)
+}
+
+func TestQuackStoreReattachesAfterServerRestart(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-reattach.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0009"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	_, err := server.ExecContext(ctx,
+		`CREATE TABLE stale_connection_test (
+			id TEXT PRIMARY KEY,
+			value INTEGER
+		)`,
+	)
+	require.NoError(t, err, "create stale connection table")
+	_, err = server.ExecContext(ctx,
+		`INSERT INTO stale_connection_test VALUES (?, ?)`,
+		"seed", 41,
+	)
+	require.NoError(t, err, "insert seed row")
+
+	store, err := NewQuackStore(uri, token, false)
+	require.NoError(t, err, "open quack store")
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(), "close quack store")
+	})
+	var got int
+	require.NoError(t,
+		store.queryRowContext(ctx,
+			`SELECT value FROM stale_connection_test WHERE id = ?`,
+			"seed",
+		).Scan(&got),
+		"query before server restart",
+	)
+	assert.Equal(t, 41, got)
+
+	_, err = server.ExecContext(ctx, `CALL quack_stop(?)`, uri)
+	require.NoError(t, err, "stop quack server")
+	_, err = server.ExecContext(ctx, `CALL quack_serve(?, token => ?)`, uri, token)
+	require.NoError(t, err, "restart quack server")
+
+	require.NoError(t,
+		store.queryRowContext(ctx,
+			`SELECT value FROM stale_connection_test WHERE id = ?`,
+			"seed",
+		).Scan(&got),
+		"query after server restart",
+	)
+	assert.Equal(t, 41, got)
+}
+
+func TestQuackStoreReattachesAfterFailedReattach(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-reattach-failure.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0011"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	_, err := server.ExecContext(ctx,
+		`CREATE TABLE failed_reattach_test (
+			id TEXT PRIMARY KEY,
+			value INTEGER
+		)`,
+	)
+	require.NoError(t, err, "create failed reattach table")
+	_, err = server.ExecContext(ctx,
+		`INSERT INTO failed_reattach_test VALUES (?, ?)`,
+		"seed", 41,
+	)
+	require.NoError(t, err, "insert seed row")
+
+	store, err := NewQuackStore(uri, token, false)
+	require.NoError(t, err, "open quack store")
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(), "close quack store")
+	})
+	_, err = server.ExecContext(ctx, `CALL quack_stop(?)`, uri)
+	require.NoError(t, err, "stop quack server")
+
+	var got int
+	err = store.queryRowContext(ctx,
+		`SELECT value FROM failed_reattach_test WHERE id = ?`,
+		"seed",
+	).Scan(&got)
+	require.Error(t, err, "query while server is stopped should fail")
+
+	_, err = server.ExecContext(ctx, `CALL quack_serve(?, token => ?)`, uri, token)
+	require.NoError(t, err, "restart quack server")
+	_, err = store.quack.DB().ExecContext(ctx, "USE memory")
+	require.NoError(t, err, "select local catalog before forced detach")
+	_, err = store.quack.DB().ExecContext(ctx, "DETACH "+quackAttachmentName)
+	require.NoError(t, err, "force stranded detached Quack attachment")
+	require.NoError(t,
+		store.queryRowContext(ctx,
+			`SELECT value FROM failed_reattach_test WHERE id = ?`,
+			"seed",
+		).Scan(&got),
+		"query after failed reattach and server restart",
+	)
+	assert.Equal(t, 41, got)
+}
+
+func TestQuackClientSyncEnsureSchemaSkipsRemoteIndexes(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-schema.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0002"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	require.NoError(t, EnsureSchema(ctx, server), "prepare server schema")
+
+	local := newLocalDB(t)
+	syncer, err := NewFromConfig(
+		config.DuckDBConfig{
+			URL:         uri,
+			Token:       token,
+			MachineName: "quack-client",
+		},
+		local,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "open Quack-backed sync")
+	t.Cleanup(func() {
+		require.NoError(t, syncer.Close(), "close Quack-backed sync")
+	})
+
+	require.NoError(t, syncer.EnsureSchema(ctx), "ensure schema through Quack")
+	require.NoError(t,
+		CheckSchemaCompatViaQuack(ctx, syncer.DB()),
+		"check schema compatibility through Quack",
+	)
+	assertDuckDBIndexExists(t, server, "tool_calls", "idx_tool_calls_file_path")
+}
+
+func TestQuackClientSyncEnsureSchemaRequiresPreparedServerMetadata(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-metadata.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0004"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	require.NoError(t, EnsureSchema(ctx, server), "prepare server schema")
+	_, err := server.ExecContext(ctx,
+		`DELETE FROM sync_metadata WHERE key = ?`,
+		schemaVersionMetadataKey,
+	)
+	require.NoError(t, err, "remove server schema metadata")
+
+	local := newLocalDB(t)
+	syncer, err := NewFromConfig(
+		config.DuckDBConfig{
+			URL:         uri,
+			Token:       token,
+			MachineName: "quack-client",
+		},
+		local,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "open Quack-backed sync")
+	t.Cleanup(func() {
+		require.NoError(t, syncer.Close(), "close Quack-backed sync")
+	})
+
+	err = syncer.EnsureSchema(ctx)
+	require.Error(t, err, "schema metadata should be required through Quack")
+	assert.Contains(t, err.Error(), "missing "+schemaVersionMetadataKey)
+	assert.NotContains(t, err.Error(), "GetStorageInfo")
+}
+
+func TestQuackClientSyncEnsureSchemaRejectsUnmigratedServerSchema(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-unmigrated.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0005"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	require.NoError(t, EnsureSchema(ctx, server), "prepare server schema")
+	recreateMessagesWithIDPrimaryKey(t, ctx, server)
+
+	local := newLocalDB(t)
+	syncer, err := NewFromConfig(
+		config.DuckDBConfig{
+			URL:         uri,
+			Token:       token,
+			MachineName: "quack-client",
+		},
+		local,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "open Quack-backed sync")
+	t.Cleanup(func() {
+		require.NoError(t, syncer.Close(), "close Quack-backed sync")
+	})
+
+	err = syncer.EnsureSchema(ctx)
+	require.Error(t, err, "unmigrated server schema should be rejected through Quack")
+	assert.Contains(t, err.Error(), "messages.id primary key")
+	assert.NotContains(t, err.Error(), "base table")
+	assert.NotContains(t, err.Error(), "GetStorageInfo")
+}
+
+func TestQuackStoreAnalyticsDashboardReads(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-analytics.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0006"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	require.NoError(t, EnsureSchema(ctx, server), "prepare server schema")
+
+	local := newLocalDB(t)
+	seedDuckDBSyncFixture(t, local)
+	seedDuckEdit(
+		t, local, "alpha", "duck-sync-edit",
+		0, 0, "src/main.go", "2026-01-10T02:00:00Z",
+	)
+	syncer, err := NewFromConfig(
+		config.DuckDBConfig{
+			URL:         uri,
+			Token:       token,
+			MachineName: "quack-client",
+		},
+		local,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "open Quack-backed sync")
+	t.Cleanup(func() {
+		require.NoError(t, syncer.Close(), "close Quack-backed sync")
+	})
+
+	result, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "push analytics fixture through Quack")
+	assert.Equal(t, 3, result.SessionsPushed)
+	assert.Equal(t, 4, result.MessagesPushed)
+
+	store, err := NewQuackStore(uri, token, false)
+	require.NoError(t, err, "open Quack-backed store")
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(), "close Quack-backed store")
+	})
+
+	filter := db.AnalyticsFilter{
+		From:     "2026-01-10",
+		To:       "2026-01-11",
+		Timezone: "UTC",
+	}
+	page, err := store.ListSessions(ctx, db.SessionFilter{Limit: 10})
+	require.NoError(t, err, "list sessions through Quack")
+	assert.Len(t, page.Sessions, 3)
+
+	sidebar, err := store.GetSidebarSessionIndex(ctx, db.SessionFilter{})
+	require.NoError(t, err, "read sidebar session index through Quack")
+	assert.Equal(t, 3, sidebar.Total)
+
+	search, err := store.Search(ctx, db.SearchFilter{Query: "alpha", Limit: 10})
+	require.NoError(t, err, "search sessions through Quack")
+	assert.NotEmpty(t, search.Results)
+
+	ordinals, err := store.SearchSession(ctx, "duck-sync-alpha", "duck result")
+	require.NoError(t, err, "search session through Quack")
+	assert.NotEmpty(t, ordinals)
+
+	msgs, err := store.GetMessages(ctx, "duck-sync-alpha", 0, 10, true)
+	require.NoError(t, err, "read messages through Quack")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	require.Len(t, msgs[1].ToolCalls[0].ResultEvents, 1)
+	assert.Equal(t, "duck result", msgs[1].ToolCalls[0].ResultEvents[0].Content)
+
+	timing, err := store.GetSessionTiming(ctx, "duck-sync-alpha")
+	require.NoError(t, err, "read session timing through Quack")
+	require.NotNil(t, timing)
+	assert.NotEmpty(t, timing.Turns)
+
+	stars, err := store.ListStarredSessionIDs(ctx)
+	require.NoError(t, err, "read starred sessions through Quack")
+	assert.Equal(t, []string{"duck-sync-alpha"}, stars)
+
+	pins, err := store.ListPinnedMessages(ctx, "duck-sync-alpha", "")
+	require.NoError(t, err, "read pinned messages through Quack")
+	require.Len(t, pins, 1)
+	require.NotNil(t, pins[0].Note)
+	assert.Equal(t, "pin alpha", *pins[0].Note)
+
+	findings, err := store.ListSecretFindings(ctx, db.SecretFindingFilter{
+		Project: "alpha",
+		Limit:   10,
+	})
+	require.NoError(t, err, "read secret findings through Quack")
+	require.Len(t, findings.Findings, 1)
+	assert.Equal(t, "test_secret", findings.Findings[0].RuleName)
+
+	activity, err := store.GetAnalyticsActivity(ctx, filter, "day")
+	require.NoError(t, err, "read activity analytics through Quack")
+	assert.NotEmpty(t, activity.Series)
+
+	hours, err := store.GetAnalyticsHourOfWeek(ctx, filter)
+	require.NoError(t, err, "read hour-of-week analytics through Quack")
+	assert.NotEmpty(t, hours.Cells)
+
+	top, err := store.GetAnalyticsTopSessions(ctx, filter, "messages")
+	require.NoError(t, err, "read top sessions through Quack")
+	require.NotEmpty(t, top.Sessions)
+	assert.Equal(t, "duck-sync-alpha", top.Sessions[0].ID)
+
+	tools, err := store.GetAnalyticsTools(ctx, filter)
+	require.NoError(t, err, "read tool analytics through Quack")
+	assert.Equal(t, 2, tools.TotalCalls)
+
+	edits, err := store.RecentEdits(ctx, db.RecentEditsParams{})
+	require.NoError(t, err, "read recent edits through Quack")
+	require.NotEmpty(t, edits.Files)
+	assert.Equal(t, "src/main.go", edits.Files[0].FilePath)
+
+	report, err := store.GetActivityReport(
+		ctx,
+		db.AnalyticsFilter{Timezone: "UTC"},
+		duckDayQuery(t, "2026-01-10", "UTC"),
+	)
+	require.NoError(t, err, "read activity report through Quack")
+	assert.GreaterOrEqual(t, report.Totals.Sessions, 1)
+}
+
+func TestQuackClientSyncPushWritesThroughAttachment(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-push.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0003"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	require.NoError(t, EnsureSchema(ctx, server), "prepare server schema")
+
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	require.NoError(t, local.InsertCursorUsageEvents([]db.CursorUsageEvent{
+		{
+			OccurredAt:       "2026-01-10T00:03:00Z",
+			Model:            "cursor-model-a",
+			Kind:             "usage",
+			InputTokens:      11,
+			OutputTokens:     7,
+			CacheWriteTokens: 5,
+			CacheReadTokens:  3,
+			ChargedCents:     1.25,
+			CursorTokenFee:   0.75,
+			UserID:           "cursor-user-a",
+			UserEmail:        "cursor-a@example.invalid",
+			DedupKey:         "cursor-quack-a",
+		},
+		{
+			OccurredAt:     "2026-01-10T00:04:00Z",
+			Model:          "cursor-model-b",
+			Kind:           "usage",
+			InputTokens:    13,
+			OutputTokens:   9,
+			ChargedCents:   1.50,
+			CursorTokenFee: 0.50,
+			UserID:         "cursor-user-b",
+			UserEmail:      "cursor-b@example.invalid",
+			IsHeadless:     true,
+			DedupKey:       "cursor-quack-b",
+		},
+	}), "InsertCursorUsageEvents")
+	syncer, err := NewFromConfig(
+		config.DuckDBConfig{
+			URL:         uri,
+			Token:       token,
+			MachineName: "quack-client",
+		},
+		local,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "open Quack-backed sync")
+	t.Cleanup(func() {
+		require.NoError(t, syncer.Close(), "close Quack-backed sync")
+	})
+
+	result, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "push through Quack")
+	assert.Equal(t, 2, result.SessionsPushed)
+	assert.Equal(t, 3, result.MessagesPushed)
+
+	status, err := syncer.Status(ctx)
+	require.NoError(t, err, "read Quack-backed sync status")
+	assert.Equal(t, "quack-client", status.Machine)
+	assert.Equal(t, 2, status.DuckDBSessions)
+	assert.Equal(t, 3, status.DuckDBMessages)
+
+	configStatus, err := ReadStatusFromConfig(ctx, config.DuckDBConfig{
+		URL:         uri,
+		Token:       token,
+		MachineName: "quack-client",
+	}, "2026-06-30T12:00:00.000Z")
+	require.NoError(t, err, "read Quack-backed status from config")
+	assert.Equal(t, "quack-client", configStatus.Machine)
+	assert.Equal(t, "2026-06-30T12:00:00.000Z", configStatus.LastPushAt)
+	assert.Equal(t, 2, configStatus.DuckDBSessions)
+	assert.Equal(t, 3, configStatus.DuckDBMessages)
+
+	var machine string
+	require.NoError(t,
+		server.QueryRowContext(ctx,
+			`SELECT machine FROM sessions WHERE id = ?`,
+			fixture.alphaID,
+		).Scan(&machine),
+		"query pushed session on server",
+	)
+	assert.Equal(t, "quack-client", machine)
+	assertDuckDBCount(t, server, "messages", 3)
+	assertDuckDBCount(t, server, "cursor_usage_events", 2)
+	assertDuckDBIndexExists(t, server, "tool_calls", "idx_tool_calls_file_path")
+
+	alphaState := readDuckMirrorSessionState(t, ctx, server, fixture.alphaID)
+	betaState := readDuckMirrorSessionState(t, ctx, server, fixture.betaID)
+	result, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "idempotent repeat push through Quack")
+	assert.Equal(t, alphaState, readDuckMirrorSessionState(t, ctx, server, fixture.alphaID))
+	assert.Equal(t, betaState, readDuckMirrorSessionState(t, ctx, server, fixture.betaID))
+
+	mutatedAt := "2026-01-10T03:04:05.123456Z"
+	mutatedResult := "duck result changed\nquoted ' output\ncontains $$ delimiter"
+	mutatedFilePath := "src/quoted ' file\ncontains $$ delimiter"
+	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: syncSession(
+			fixture.alphaID, "alpha", "alpha changed", mutatedAt, 2,
+		),
+		Messages: []db.Message{
+			syncMessage(
+				fixture.alphaID, 0, "user", "alpha changed", mutatedAt,
+			),
+			syncMessage(
+				fixture.alphaID, 1, "assistant",
+				"alpha changed assistant",
+				"2026-01-10T03:04:06.000Z",
+				db.ToolCall{
+					ToolName:  "grep",
+					Category:  "search",
+					SkillName: "duck-grep",
+					ToolUseID: "tool-alpha",
+					InputJSON: `{"query":"changed"}`,
+					FilePath:  mutatedFilePath,
+					ResultEvents: []db.ToolResultEvent{{
+						Source:        "tool",
+						Status:        "complete",
+						Content:       mutatedResult,
+						Timestamp:     "2026-01-10T03:04:07.000Z",
+						EventIndex:    0,
+						ContentLength: len(mutatedResult),
+					}},
+				},
+			),
+		},
+		DataVersion:     2,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err, "mutate local alpha session")
+
+	mutatedMessages, err := local.GetAllMessages(ctx, fixture.alphaID)
+	require.NoError(t, err, "read mutated local messages")
+	require.Len(t, mutatedMessages, 2)
+	assistantMessage := mutatedMessages[1]
+	_, err = server.ExecContext(ctx, `
+		INSERT INTO tool_calls (
+			message_id, session_id, tool_name, category, call_index,
+			tool_use_id, input_json, skill_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		assistantMessage.ID, fixture.alphaID, "stale-tool", "stale",
+		0, "stale-tool-use", `{"query":"stale"}`, "stale-skill",
+	)
+	require.NoError(t, err, "seed stale matching remote tool_call")
+
+	result, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "mutated repeat push through Quack")
+	assert.Equal(t, 2, result.SessionsPushed)
+	assert.Equal(t, 3, result.MessagesPushed)
+	assertDuckDBCount(t, server, "sessions", 2)
+	assertDuckDBCount(t, server, "messages", 3)
+	assertDuckDBCount(t, server, "tool_calls", 1)
+	assertDuckDBCount(t, server, "tool_result_events", 1)
+	assertDuckDBCount(t, server, "cursor_usage_events", 2)
+
+	var firstMessage string
+	var startedAt time.Time
+	require.NoError(t,
+		server.QueryRowContext(ctx,
+			`SELECT first_message, started_at FROM sessions WHERE id = ?`,
+			fixture.alphaID,
+		).Scan(&firstMessage, &startedAt),
+		"query mutated session",
+	)
+	assert.Equal(t, "alpha changed", firstMessage)
+	assert.Equal(t,
+		time.Date(2026, time.January, 10, 3, 4, 5, 123456000, time.UTC),
+		startedAt.UTC(),
+	)
+
+	var toolName, category, skillName, inputJSON, filePath string
+	require.NoError(t,
+		server.QueryRowContext(ctx, `
+			SELECT tool_name, category, skill_name, input_json, file_path
+			FROM tool_calls
+			WHERE session_id = ? AND message_id = ? AND call_index = ?`,
+			fixture.alphaID, assistantMessage.ID, 0,
+		).Scan(&toolName, &category, &skillName, &inputJSON, &filePath),
+		"query updated tool_call",
+	)
+	assert.Equal(t, "grep", toolName)
+	assert.Equal(t, "search", category)
+	assert.Equal(t, "duck-grep", skillName)
+	assert.Equal(t, `{"query":"changed"}`, inputJSON)
+	assert.Equal(t, mutatedFilePath, filePath)
+
+	var resultStatus, resultContent string
+	require.NoError(t,
+		server.QueryRowContext(ctx, `
+			SELECT status, content
+			FROM tool_result_events
+			WHERE session_id = ?
+			  AND tool_call_message_ordinal = ?
+			  AND call_index = ?
+			  AND event_index = ?`,
+			fixture.alphaID, 1, 0, 0,
+		).Scan(&resultStatus, &resultContent),
+		"query updated tool_result_event",
+	)
+	assert.Equal(t, "complete", resultStatus)
+	assert.Equal(t, mutatedResult, resultContent)
+
+	shrunkenAt := "2026-01-10T04:00:00.000Z"
+	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: syncSession(
+			fixture.alphaID, "alpha", "alpha without tool", shrunkenAt, 2,
+		),
+		Messages: []db.Message{
+			syncMessage(
+				fixture.alphaID, 0, "user", "alpha without tool", shrunkenAt,
+			),
+			syncMessage(
+				fixture.alphaID, 1, "assistant",
+				"alpha assistant without tool",
+				"2026-01-10T04:00:01.000Z",
+			),
+		},
+		DataVersion:     3,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err, "shrink local alpha tool set")
+
+	result, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "shrunken repeat push through Quack")
+	assert.Equal(t, 2, result.SessionsPushed)
+	assert.Equal(t, 3, result.MessagesPushed)
+	assertDuckDBCount(t, server, "sessions", 2)
+	assertDuckDBCount(t, server, "messages", 3)
+	assertDuckDBCount(t, server, "tool_calls", 0)
+	assertDuckDBCount(t, server, "tool_result_events", 0)
+	assertDuckDBCount(t, server, "cursor_usage_events", 2)
+
+	store, err := NewQuackStore(uri, token, false)
+	require.NoError(t, err, "open Quack-backed store")
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(), "close Quack-backed store")
+	})
+
+	stats, err := store.GetStats(ctx, false, false)
+	require.NoError(t, err, "read stats through Quack")
+	assert.Equal(t, 2, stats.SessionCount)
+	assert.Equal(t, 3, stats.MessageCount)
+	assert.Equal(t, 2, stats.ProjectCount)
+	assert.Equal(t, 1, stats.MachineCount)
+	assert.NotNil(t, stats.EarliestSession)
+}
+
+func TestQuackClientSyncPushReattachesAfterServerRestart(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-push-reattach.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0010"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	require.NoError(t, EnsureSchema(ctx, server), "prepare server schema")
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer, err := NewFromConfig(
+		config.DuckDBConfig{
+			URL:         uri,
+			Token:       token,
+			MachineName: "quack-client",
+		},
+		local,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "open Quack-backed sync")
+	t.Cleanup(func() {
+		require.NoError(t, syncer.Close(), "close Quack-backed sync")
+	})
+	require.NoError(t, syncer.EnsureSchema(ctx), "warm client schema")
+
+	_, err = server.ExecContext(ctx, `CALL quack_stop(?)`, uri)
+	require.NoError(t, err, "stop quack server")
+	_, err = server.ExecContext(ctx, `CALL quack_serve(?, token => ?)`, uri, token)
+	require.NoError(t, err, "restart quack server")
+
+	result, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "push through reattached Quack client")
+	assert.Equal(t, 2, result.SessionsPushed)
+	assert.Equal(t, 3, result.MessagesPushed)
+	var machine string
+	require.NoError(t,
+		server.QueryRowContext(ctx,
+			`SELECT machine FROM sessions WHERE id = ?`,
+			fixture.alphaID,
+		).Scan(&machine),
+		"query pushed session on server",
+	)
+	assert.Equal(t, "quack-client", machine)
+}
+
+func TestQuackClientSyncPushFailedSessionLeavesRemoteRowsUnchanged(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-push-failure.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0007"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	require.NoError(t, EnsureSchema(ctx, server), "prepare server schema")
+
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer, err := NewFromConfig(
+		config.DuckDBConfig{
+			URL:         uri,
+			Token:       token,
+			MachineName: "quack-client",
+		},
+		local,
+		SyncOptions{},
+	)
+	require.NoError(t, err, "open Quack-backed sync")
+	t.Cleanup(func() {
+		require.NoError(t, syncer.Close(), "close Quack-backed sync")
+	})
+
+	result, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "initial push through Quack")
+	require.Equal(t, 0, result.Errors)
+	before := readDuckMirrorSessionState(t, ctx, server, fixture.alphaID)
+
+	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: syncSession(
+			fixture.alphaID, "alpha", "alpha poisoned",
+			"2026-01-10T05:00:00.000Z", 1,
+		),
+		Messages: []db.Message{
+			syncMessage(
+				fixture.alphaID, 0, "user", "alpha poisoned",
+				"not-a-timestamp",
+			),
+		},
+		DataVersion:     2,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err, "write local session with invalid message timestamp")
+
+	result, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "failed session should be counted, not fatal")
+	assert.Equal(t, 1, result.Errors)
+
+	after := readDuckMirrorSessionState(t, ctx, server, fixture.alphaID)
+	assert.Equal(t, before, after)
+}
+
+func TestQuackRemoteMutationBatchCoalescesAgainstServer(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "agentsview-quack-batch.duckdb")
+	uri := "quack:127.0.0.1:" + freeTCPPort(t)
+	const token = "agentsview-duckdbtest-token-0008"
+
+	server := openQuackMirrorServer(t, ctx, path, uri, token)
+	_, err := server.ExecContext(ctx,
+		`CREATE TABLE remote_batch_test (
+			id INTEGER PRIMARY KEY,
+			value INTEGER
+		)`,
+	)
+	require.NoError(t, err, "create remote batch test table")
+	client := openQuackClientAttachment(t, ctx, uri, token)
+	execRemote := func(ctx context.Context, sqlText string) error {
+		_, err := client.ExecContext(
+			ctx, "FROM "+quackAttachmentName+".query(?)", sqlText,
+		)
+		return err
+	}
+
+	success := &duckRemoteMutationBatch{}
+	_, err = success.ExecContext(ctx,
+		`INSERT INTO remote_batch_test VALUES (?, ?)`, 1, 11,
+	)
+	require.NoError(t, err)
+	_, err = success.ExecContext(ctx,
+		`INSERT INTO remote_batch_test VALUES (?, ?)`, 2, 22,
+	)
+	require.NoError(t, err)
+	require.NoError(t, execDuckRemoteMutationBatch(
+		ctx, execRemote, "quack smoke success", success, true,
+	))
+	assertDuckDBCount(t, server, "remote_batch_test", 2)
+
+	failing := &duckRemoteMutationBatch{}
+	_, err = failing.ExecContext(ctx,
+		`INSERT INTO remote_batch_test VALUES (?, ?)`, 3, 33,
+	)
+	require.NoError(t, err)
+	_, err = failing.ExecContext(ctx,
+		`INSERT INTO remote_batch_test VALUES (?, ?)`, 4, "not-an-int",
+	)
+	require.NoError(t, err)
+	err = execDuckRemoteMutationBatch(
+		ctx, execRemote, "quack smoke failure", failing, true,
+	)
+	require.Error(t, err, "coalesced batch should surface server error")
+	assert.Contains(t, err.Error(), "not-an-int")
+	assertDuckDBCount(t, server, "remote_batch_test", 2)
+}
+
+type duckMirrorSessionState struct {
+	FirstMessage         string
+	MessageCount         int
+	ToolCallCount        int
+	ToolResultEventCount int
+	UsageEventCount      int
+	SecretFindingCount   int
+}
+
+func readDuckMirrorSessionState(
+	t *testing.T, ctx context.Context, conn *sql.DB, sessionID string,
+) duckMirrorSessionState {
+	t.Helper()
+	state := duckMirrorSessionState{
+		MessageCount: duckDBCountWhere(t, ctx, conn, "messages", "session_id = ?", sessionID),
+		ToolCallCount: duckDBCountWhere(
+			t, ctx, conn, "tool_calls", "session_id = ?", sessionID,
+		),
+		ToolResultEventCount: duckDBCountWhere(
+			t, ctx, conn, "tool_result_events", "session_id = ?", sessionID,
+		),
+		UsageEventCount: duckDBCountWhere(
+			t, ctx, conn, "usage_events", "session_id = ?", sessionID,
+		),
+		SecretFindingCount: duckDBCountWhere(
+			t, ctx, conn, "secret_findings", "session_id = ?", sessionID,
+		),
+	}
+	require.NoError(t,
+		conn.QueryRowContext(ctx,
+			`SELECT first_message FROM sessions WHERE id = ?`,
+			sessionID,
+		).Scan(&state.FirstMessage),
+		"read mirrored session state",
+	)
+	return state
+}
+
+func duckDBCountWhere(
+	t *testing.T, ctx context.Context, conn *sql.DB, table, where string, arg any,
+) int {
+	t.Helper()
+	var got int
+	require.NoError(t, conn.QueryRowContext(
+		ctx, `SELECT COUNT(*) FROM `+table+` WHERE `+where, arg,
+	).Scan(&got))
+	return got
+}
+
+func openQuackMirrorServer(
+	t *testing.T, ctx context.Context, path, uri, token string,
+) *sql.DB {
+	t.Helper()
+	server, err := Open(path)
+	require.NoError(t, err, "open server DuckDB file")
+	t.Cleanup(func() {
+		require.NoError(t, server.Close(), "close server DuckDB file")
+	})
+	_, err = server.ExecContext(ctx, "INSTALL quack")
+	require.NoError(t, err, "install quack extension")
+	_, err = server.ExecContext(ctx, "LOAD quack")
+	require.NoError(t, err, "load quack extension")
+	_, err = server.ExecContext(ctx, `CALL quack_serve(?, token => ?)`, uri, token)
+	require.NoError(t, err, "start quack server")
+	t.Cleanup(func() {
+		_, stopErr := server.ExecContext(context.Background(), `CALL quack_stop(?)`, uri)
+		require.NoError(t, stopErr, "stop quack server")
+	})
+	return server
+}
+
+func openQuackClientAttachment(
+	t *testing.T, ctx context.Context, uri, token string,
+) *sql.DB {
+	t.Helper()
+	client, err := sql.Open("duckdb", "")
+	require.NoError(t, err, "open Quack client DuckDB")
+	client.SetMaxOpenConns(1)
+	client.SetMaxIdleConns(1)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close(), "close Quack client DuckDB")
+	})
+	_, err = client.ExecContext(ctx, "LOAD quack")
+	require.NoError(t, err, "load quack extension in client")
+	_, err = client.ExecContext(ctx, fmt.Sprintf(
+		`ATTACH '%s' AS %s (TOKEN '%s')`,
+		uri, quackAttachmentName, token,
+	))
+	require.NoError(t, err, "attach quack endpoint")
+	return client
+}
+
+func assertDuckDBIndexExists(
+	t *testing.T, conn *sql.DB, tableName, indexName string,
+) {
+	t.Helper()
+	var count int
+	require.NoError(t, conn.QueryRow(`
+		SELECT count(*) FROM duckdb_indexes()
+		WHERE table_name = ?
+		  AND index_name = ?`, tableName, indexName).Scan(&count),
+		"query duckdb_indexes")
+	assert.Equal(t, 1, count, "%s must exist on %s", indexName, tableName)
 }
 
 func freeTCPPort(t *testing.T) string {

--- a/internal/duckdb/quack_smoke_duckdbtest_test.go
+++ b/internal/duckdb/quack_smoke_duckdbtest_test.go
@@ -899,7 +899,6 @@ func TestQuackRemoteMutationBatchChunksRepairInterruptedSession(t *testing.T) {
 	)
 	require.NoError(t, err)
 	deleteOnly := &duckRemoteMutationBatch{statements: batch.statements[:1]}
-	deleteOnly.statementBytes = len(batch.statements[0])
 	for i, content := range []string{"one", "two", "three"} {
 		_, err = batch.ExecContext(ctx,
 			`INSERT INTO remote_chunk_repair_test VALUES (?, ?, ?)`,

--- a/internal/duckdb/quack_smoke_duckdbtest_test.go
+++ b/internal/duckdb/quack_smoke_duckdbtest_test.go
@@ -862,22 +862,24 @@ func TestQuackRemoteMutationBatchCoalescesAgainstServer(t *testing.T) {
 	assertDuckDBCount(t, server, "remote_batch_test", 2)
 }
 
-func TestQuackRemoteMutationBatchChunksRepairInterruptedSession(t *testing.T) {
+func TestQuackRemoteMutationOversizeStatementFallbackRollsBackSession(
+	t *testing.T,
+) {
 	ctx := context.Background()
-	path := filepath.Join(t.TempDir(), "agentsview-quack-chunks.duckdb")
+	path := filepath.Join(t.TempDir(), "agentsview-quack-oversize.duckdb")
 	uri := "quack:127.0.0.1:" + freeTCPPort(t)
 	const token = "agentsview-duckdbtest-token-0009"
 
 	server := openQuackMirrorServer(t, ctx, path, uri, token)
 	_, err := server.ExecContext(ctx,
-		`CREATE TABLE remote_chunk_repair_test (
+		`CREATE TABLE remote_oversize_atomic_test (
 			session_id VARCHAR,
 			ordinal INTEGER,
 			content VARCHAR,
 			PRIMARY KEY(session_id, ordinal)
 		)`,
 	)
-	require.NoError(t, err, "create remote chunk repair test table")
+	require.NoError(t, err, "create remote oversize atomic test table")
 	client := openQuackClientAttachment(t, ctx, uri, token)
 	execRemote := func(ctx context.Context, sqlText string) error {
 		_, err := client.ExecContext(
@@ -886,67 +888,58 @@ func TestQuackRemoteMutationBatchChunksRepairInterruptedSession(t *testing.T) {
 		return err
 	}
 
-	const sessionID = "chunk-repair-session"
+	const sessionID = "oversize-atomic-session"
 	_, err = server.ExecContext(ctx,
-		`INSERT INTO remote_chunk_repair_test VALUES (?, ?, ?)`,
+		`INSERT INTO remote_oversize_atomic_test VALUES (?, ?, ?)`,
 		sessionID, 99, "stale",
 	)
 	require.NoError(t, err, "seed stale remote row")
 
 	batch := &duckRemoteMutationBatch{}
 	_, err = batch.ExecContext(ctx,
-		`DELETE FROM remote_chunk_repair_test WHERE session_id = ?`, sessionID,
+		`DELETE FROM remote_oversize_atomic_test WHERE session_id = ?`,
+		sessionID,
 	)
 	require.NoError(t, err)
 	deleteOnly := &duckRemoteMutationBatch{statements: batch.statements[:1]}
-	for i, content := range []string{"one", "two", "three"} {
-		_, err = batch.ExecContext(ctx,
-			`INSERT INTO remote_chunk_repair_test VALUES (?, ?, ?)`,
-			sessionID, i, content,
-		)
-		require.NoError(t, err)
-	}
-	chunks := batch.chunks(deleteOnly.transactionBytes())
-	require.Greater(t, len(chunks), 1)
-	require.Contains(t, chunks[0].transactionSQL(), "DELETE FROM")
-	require.NotContains(t, chunks[0].transactionSQL(), "INSERT INTO")
-
-	require.NoError(t, execDuckRemoteMutationBatch(
-		ctx, execRemote, "quack interrupted chunk", chunks[0], true,
-	))
-	assertDuckDBCountWhere(
-		t, server, "remote_chunk_repair_test", "session_id = ?", sessionID, 0,
+	_, err = batch.ExecContext(ctx,
+		`INSERT INTO remote_oversize_atomic_test VALUES (?, ?, ?)`,
+		sessionID, 0, "replacement",
 	)
+	require.NoError(t, err)
+	_, err = batch.ExecContext(ctx,
+		`INSERT INTO remote_oversize_atomic_test VALUES (?, ?, ?)`,
+		sessionID, "not-an-int", "poison",
+	)
+	require.NoError(t, err)
 
-	require.NoError(t, execDuckRemoteMutationBatchChunks(
-		ctx, execRemote, "quack repaired chunks", batch,
+	var coalescedCalls int
+	err = execDuckRemoteMutationBatchOversizeWithStatementFallback(
+		ctx,
+		func(ctx context.Context, sqlText string) error {
+			coalescedCalls++
+			return execRemote(ctx, sqlText)
+		},
+		execRemote,
+		"quack oversize atomic",
+		batch,
 		deleteOnly.transactionBytes(),
-	))
-	rows, err := server.QueryContext(ctx,
-		`SELECT ordinal, content
-		 FROM remote_chunk_repair_test
-		 WHERE session_id = ?
-		 ORDER BY ordinal`,
-		sessionID,
 	)
-	require.NoError(t, err, "read repaired chunk rows")
-	defer rows.Close()
-	type row struct {
-		ordinal int
-		content string
-	}
-	var got []row
-	for rows.Next() {
-		var r row
-		require.NoError(t, rows.Scan(&r.ordinal, &r.content))
-		got = append(got, r)
-	}
-	require.NoError(t, rows.Err())
-	assert.Equal(t, []row{
-		{ordinal: 0, content: "one"},
-		{ordinal: 1, content: "two"},
-		{ordinal: 2, content: "three"},
-	}, got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not-an-int")
+	assert.Equal(t, 0, coalescedCalls)
+
+	var ordinal int
+	var content string
+	err = server.QueryRowContext(ctx,
+		`SELECT ordinal, content
+		 FROM remote_oversize_atomic_test
+		 WHERE session_id = ?`,
+		sessionID,
+	).Scan(&ordinal, &content)
+	require.NoError(t, err, "read rolled back session row")
+	assert.Equal(t, 99, ordinal)
+	assert.Equal(t, "stale", content)
 }
 
 type duckMirrorSessionState struct {

--- a/internal/duckdb/recentedits.go
+++ b/internal/duckdb/recentedits.go
@@ -73,7 +73,7 @@ ORDER BY fp.last_edited_at DESC NULLS LAST, fp.last_session_id DESC,
 		qArgs = append(qArgs, "%"+db.EscapeLikePattern(p.Search)+"%")
 	}
 	qArgs = append(qArgs, p.Limit+1, p.Offset, p.MaxEditsPerFile)
-	rows, err := s.duck.QueryContext(ctx, query, qArgs...)
+	rows, err := s.queryContext(ctx, query, qArgs...)
 	if err != nil {
 		return db.RecentEditsResult{}, fmt.Errorf("querying duckdb recent edits: %w", err)
 	}

--- a/internal/duckdb/schema.go
+++ b/internal/duckdb/schema.go
@@ -531,12 +531,26 @@ var mirrorTables = []tableSpec{
 	},
 }
 
+type schemaOptions struct {
+	createIndexes bool
+}
+
 // EnsureSchema creates and additively migrates the DuckDB mirror schema.
 func EnsureSchema(ctx context.Context, db *sql.DB) error {
+	return ensureSchema(ctx, db, schemaOptions{createIndexes: true})
+}
+
+func ensureSchema(ctx context.Context, db *sql.DB, opts schemaOptions) error {
 	for _, table := range mirrorTables {
 		if _, err := db.ExecContext(ctx, table.create); err != nil {
 			return fmt.Errorf("creating duckdb table %s: %w", table.name, err)
 		}
+	}
+	if !opts.createIndexes {
+		if err := checkSchemaShapeCompat(ctx, db); err != nil {
+			return err
+		}
+		return checkSchemaRepairsViaQuack(ctx, db)
 	}
 
 	existing, err := loadColumns(ctx, db)
@@ -584,6 +598,7 @@ func EnsureSchema(ctx context.Context, db *sql.DB) error {
 	if err := dropQuackIncompatibleTimestampDefaults(ctx, db); err != nil {
 		return err
 	}
+
 	recordUsageDedupIndexMigration, err := migrateUsageEventsDedupIndex(ctx, db)
 	if err != nil {
 		return err
@@ -713,6 +728,17 @@ func metadataKeyExists(ctx context.Context, db *sql.DB, key string) (bool, error
 func recordMetadataKey(
 	ctx context.Context, db *sql.DB, key string, value string,
 ) error {
+	var existing string
+	err := db.QueryRowContext(ctx,
+		`SELECT value FROM sync_metadata WHERE key = ?`,
+		key,
+	).Scan(&existing)
+	if err == nil && existing == value {
+		return nil
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("checking duckdb metadata key %s: %w", key, err)
+	}
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO sync_metadata (key, value)
 		VALUES (?, ?)
@@ -823,6 +849,24 @@ func columnDefaultLiteral(def string) (string, bool) {
 // CheckSchemaCompat verifies that the DuckDB mirror has the required
 // read/push tables and columns. It does not mutate the database.
 func CheckSchemaCompat(ctx context.Context, db *sql.DB) error {
+	if err := checkSchemaShapeCompat(ctx, db); err != nil {
+		return err
+	}
+	pendingRepairs, err := pendingSchemaRepairs(ctx, db)
+	if err != nil {
+		return err
+	}
+	return schemaRepairError(pendingRepairs)
+}
+
+func CheckSchemaCompatViaQuack(ctx context.Context, db *sql.DB) error {
+	if err := checkSchemaShapeCompat(ctx, db); err != nil {
+		return err
+	}
+	return checkSchemaRepairsViaQuack(ctx, db)
+}
+
+func checkSchemaShapeCompat(ctx context.Context, db *sql.DB) error {
 	existing, err := loadColumns(ctx, db)
 	if err != nil {
 		return err
@@ -875,7 +919,102 @@ func CheckSchemaCompat(ctx context.Context, db *sql.DB) error {
 			got, SchemaVersion,
 		)
 	}
+
 	return nil
+}
+
+func checkSchemaRepairsViaQuack(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx,
+		"SELECT issue FROM "+quackAttachmentName+".query(?)",
+		pendingSchemaRepairsQuery(),
+	)
+	if err != nil {
+		return fmt.Errorf("checking duckdb schema repairs through quack: %w", err)
+	}
+	pendingRepairs, err := collectSchemaRepairIssues(rows)
+	if err != nil {
+		return err
+	}
+	return schemaRepairError(pendingRepairs)
+}
+
+func pendingSchemaRepairs(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, pendingSchemaRepairsQuery())
+	if err != nil {
+		return nil, fmt.Errorf("checking duckdb schema repairs: %w", err)
+	}
+	return collectSchemaRepairIssues(rows)
+}
+
+func collectSchemaRepairIssues(rows *sql.Rows) ([]string, error) {
+	defer func() {
+		_ = rows.Close()
+	}()
+	var pendingRepairs []string
+	for rows.Next() {
+		var issue string
+		if err := rows.Scan(&issue); err != nil {
+			return nil, fmt.Errorf("scanning duckdb schema repair check: %w", err)
+		}
+		pendingRepairs = append(pendingRepairs, issue)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating duckdb schema repair check: %w", err)
+	}
+	return pendingRepairs, nil
+}
+
+func schemaRepairError(pendingRepairs []string) error {
+	if len(pendingRepairs) == 0 {
+		return nil
+	}
+	sort.Strings(pendingRepairs)
+	return fmt.Errorf(
+		"duckdb schema incompatible; run full DuckDB schema migration on the base database; pending repairs: %s",
+		strings.Join(pendingRepairs, ", "),
+	)
+}
+
+func pendingSchemaRepairsQuery() string {
+	metadataValues := []string{
+		"(" + duckLiteral(defaultRepairMetadataKey) + ")",
+		"(" + duckLiteral(usageDedupIndexMetadataKey) + ")",
+	}
+	defaultValues := make([]string, len(quackIncompatibleTimestampDefaults))
+	for i, spec := range quackIncompatibleTimestampDefaults {
+		defaultValues[i] = "(" + duckLiteral(spec.table) + ", " +
+			duckLiteral(spec.column) + ")"
+	}
+	return `
+		WITH required_metadata(key) AS (
+			VALUES ` + strings.Join(metadataValues, ", ") + `
+		),
+		checked_defaults(table_name, column_name) AS (
+			VALUES ` + strings.Join(defaultValues, ", ") + `
+		)
+		SELECT 'missing ' || key AS issue
+		FROM required_metadata m
+		WHERE NOT EXISTS (
+			SELECT 1 FROM sync_metadata sm WHERE sm.key = m.key
+		)
+		UNION ALL
+		SELECT 'messages.id primary key' AS issue
+		WHERE EXISTS (
+			SELECT 1
+			FROM information_schema.table_constraints
+			WHERE table_schema = current_schema()
+			  AND lower(table_name) = 'messages'
+			  AND constraint_type = 'PRIMARY KEY'
+		)
+		UNION ALL
+		SELECT lower(c.table_name) || '.' || lower(c.column_name) ||
+			' current_timestamp default' AS issue
+		FROM information_schema.columns c
+		JOIN checked_defaults d
+		  ON lower(c.table_name) = d.table_name
+		 AND lower(c.column_name) = d.column_name
+		WHERE c.table_schema = current_schema()
+		  AND lower(coalesce(c.column_default, '')) LIKE '%current_timestamp%'`
 }
 
 func loadColumns(ctx context.Context, db *sql.DB) (map[string]map[string]bool, error) {

--- a/internal/duckdb/schema_test.go
+++ b/internal/duckdb/schema_test.go
@@ -180,6 +180,61 @@ func TestEnsureSchemaMigratesMessagesIDPrimaryKey(t *testing.T) {
 	assertDuckDBCountWhere(t, db, "messages", "id = ?", int64(1), 2)
 }
 
+func TestCheckSchemaCompatRejectsPendingNonIndexRepairs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("messages id primary key", func(t *testing.T) {
+		db := openTestDuckDB(t)
+		require.NoError(t, EnsureSchema(ctx, db), "EnsureSchema")
+		recreateMessagesWithIDPrimaryKey(t, ctx, db)
+
+		err := CheckSchemaCompat(ctx, db)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "messages.id primary key")
+	})
+
+	t.Run("missing default repair metadata", func(t *testing.T) {
+		db := openTestDuckDB(t)
+		require.NoError(t, EnsureSchema(ctx, db), "EnsureSchema")
+		_, err := db.ExecContext(ctx,
+			`DELETE FROM sync_metadata WHERE key = ?`,
+			defaultRepairMetadataKey,
+		)
+		require.NoError(t, err)
+
+		err = CheckSchemaCompat(ctx, db)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), defaultRepairMetadataKey)
+	})
+
+	t.Run("missing usage repair metadata", func(t *testing.T) {
+		db := openTestDuckDB(t)
+		require.NoError(t, EnsureSchema(ctx, db), "EnsureSchema")
+		_, err := db.ExecContext(ctx,
+			`DELETE FROM sync_metadata WHERE key = ?`,
+			usageDedupIndexMetadataKey,
+		)
+		require.NoError(t, err)
+
+		err = CheckSchemaCompat(ctx, db)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), usageDedupIndexMetadataKey)
+	})
+
+	t.Run("quack incompatible timestamp default", func(t *testing.T) {
+		db := openTestDuckDB(t)
+		require.NoError(t, EnsureSchema(ctx, db), "EnsureSchema")
+		_, err := db.ExecContext(ctx,
+			`ALTER TABLE starred_sessions ALTER COLUMN created_at SET DEFAULT current_timestamp`,
+		)
+		require.NoError(t, err)
+
+		err = CheckSchemaCompat(ctx, db)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "starred_sessions.created_at")
+	})
+}
+
 func TestEnsureSchemaDropsQuackIncompatibleTimestampDefaults(t *testing.T) {
 	ctx := context.Background()
 	db := openTestDuckDB(t)
@@ -267,6 +322,25 @@ func openTestDuckDB(t *testing.T) *sql.DB {
 		require.NoError(t, db.Close(), "close DuckDB")
 	})
 	return db
+}
+
+func recreateMessagesWithIDPrimaryKey(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, `DROP TABLE messages`)
+	require.NoError(t, err)
+	create := strings.Replace(
+		mirrorTableCreate("messages"),
+		"id BIGINT,",
+		"id BIGINT PRIMARY KEY,",
+		1,
+	)
+	require.NotEqual(t, mirrorTableCreate("messages"), create)
+	_, err = db.ExecContext(ctx, create)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO messages (id, session_id, ordinal, role, content)
+		VALUES (1, 'from-other-machine', 0, 'user', 'kept')`)
+	require.NoError(t, err)
 }
 
 func tableExists(t *testing.T, db *sql.DB, table string) bool {

--- a/internal/duckdb/secrets.go
+++ b/internal/duckdb/secrets.go
@@ -58,7 +58,7 @@ func (s *Store) ListSecretFindings(
 		where += " AND " + strings.Join(preds, " AND ")
 	}
 	args = append(args, f.Limit+1, f.Cursor)
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT sf.session_id, sf.rule_name, sf.confidence,
 			sf.location_kind, sf.message_ordinal, sf.call_index,
 			sf.event_index, sf.match_start, sf.match_end,

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -26,10 +26,12 @@ var _ db.Store = (*Store)(nil)
 
 // Store wraps a DuckDB connection for read-mostly serve mode.
 type Store struct {
-	duck          *sql.DB
-	cursorMu      sync.RWMutex
-	cursorSecret  []byte
-	customPricing map[string]config.CustomModelRate
+	duck           *sql.DB
+	quack          *quackClient
+	connectionKind duckDBConnectionKind
+	cursorMu       sync.RWMutex
+	cursorSecret   []byte
+	customPricing  map[string]config.CustomModelRate
 }
 
 // NewStore opens a local DuckDB mirror file as a db.Store.
@@ -47,6 +49,82 @@ func NewStoreFromDB(conn *sql.DB) *Store { return &Store{duck: conn} }
 func (s *Store) DB() *sql.DB { return s.duck }
 
 func (s *Store) Close() error { return s.duck.Close() }
+
+func (s *Store) queryContext(
+	ctx context.Context, query string, args ...any,
+) (*sql.Rows, error) {
+	return queryDuckDBContext(ctx, s.duck, s.connectionKind, s.quack, query, args...)
+}
+
+func (s *Store) queryRowContext(
+	ctx context.Context, query string, args ...any,
+) interface{ Scan(...any) error } {
+	return queryDuckDBRowContext(
+		ctx, s.duck, s.connectionKind, s.quack, query, args...,
+	)
+}
+
+func queryDuckDBContext(
+	ctx context.Context,
+	duck *sql.DB,
+	connectionKind duckDBConnectionKind,
+	quack *quackClient,
+	query string,
+	args ...any,
+) (*sql.Rows, error) {
+	if connectionKind != duckDBQuackClientConnection {
+		return duck.QueryContext(ctx, query, args...)
+	}
+	sqlText, err := duckSQLWithArgs(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	if quack != nil {
+		return quack.queryRemote(ctx, sqlText, true)
+	}
+	return duck.QueryContext(
+		ctx,
+		"SELECT * FROM "+quackAttachmentName+".query(?)",
+		sqlText,
+	)
+}
+
+func queryDuckDBRowContext(
+	ctx context.Context,
+	duck *sql.DB,
+	connectionKind duckDBConnectionKind,
+	quack *quackClient,
+	query string,
+	args ...any,
+) interface{ Scan(...any) error } {
+	if connectionKind != duckDBQuackClientConnection {
+		return duck.QueryRowContext(ctx, query, args...)
+	}
+	rows, err := queryDuckDBContext(ctx, duck, connectionKind, quack, query, args...)
+	return duckSingleRow{rows: rows, err: err}
+}
+
+type duckSingleRow struct {
+	rows *sql.Rows
+	err  error
+}
+
+func (r duckSingleRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	defer r.rows.Close()
+	if !r.rows.Next() {
+		if err := r.rows.Err(); err != nil {
+			return err
+		}
+		return sql.ErrNoRows
+	}
+	if err := r.rows.Scan(dest...); err != nil {
+		return err
+	}
+	return r.rows.Err()
+}
 
 func (s *Store) SetCustomPricing(p map[string]config.CustomModelRate) {
 	s.customPricing = p
@@ -155,7 +233,7 @@ func (s *Store) FindSessionIDsByPartial(
 	if limit <= 0 {
 		limit = 5
 	}
-	rows, err := s.duck.QueryContext(ctx,
+	rows, err := s.queryContext(ctx,
 		`SELECT id FROM sessions
 		 WHERE strpos(id, ?) > 0 AND deleted_at IS NULL
 		 ORDER BY COALESCE(ended_at, started_at, created_at) DESC
@@ -264,7 +342,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		total = cur.Total
 	}
 	if total <= 0 {
-		if err := s.duck.QueryRowContext(ctx,
+		if err := s.queryRowContext(ctx,
 			"SELECT COUNT(*) FROM sessions WHERE "+where,
 			args...,
 		).Scan(&total); err != nil {
@@ -286,7 +364,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
 	cursorArgs = append(cursorArgs, pageBuilder.Args()...)
-	rows, err := s.duck.QueryContext(ctx, query, cursorArgs...)
+	rows, err := s.queryContext(ctx, query, cursorArgs...)
 	if err != nil {
 		return db.SessionPage{}, fmt.Errorf("querying duckdb sessions: %w", err)
 	}
@@ -334,7 +412,7 @@ func (s *Store) GetSidebarSessionIndex(ctx context.Context, f db.SessionFilter) 
 			ended_at, started_at, created_at
 		) DESC, id DESC`
 
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return db.SidebarSessionIndex{},
 			fmt.Errorf("querying duckdb sidebar session index: %w", err)
@@ -389,7 +467,7 @@ func (s *Store) GetSidebarSessionIndex(ctx context.Context, f db.SessionFilter) 
 }
 
 func (s *Store) GetSession(ctx context.Context, id string) (*db.Session, error) {
-	row := s.duck.QueryRowContext(ctx,
+	row := s.queryRowContext(ctx,
 		"SELECT "+duckSessionCols+" FROM sessions WHERE id = ? AND deleted_at IS NULL",
 		id,
 	)
@@ -404,7 +482,7 @@ func (s *Store) GetSession(ctx context.Context, id string) (*db.Session, error) 
 }
 
 func (s *Store) GetSessionFull(ctx context.Context, id string) (*db.Session, error) {
-	row := s.duck.QueryRowContext(ctx,
+	row := s.queryRowContext(ctx,
 		"SELECT "+duckSessionCols+" FROM sessions WHERE id = ?",
 		id,
 	)
@@ -419,7 +497,7 @@ func (s *Store) GetSessionFull(ctx context.Context, id string) (*db.Session, err
 }
 
 func (s *Store) GetChildSessions(ctx context.Context, parentID string) ([]db.Session, error) {
-	rows, err := s.duck.QueryContext(ctx,
+	rows, err := s.queryContext(ctx,
 		"SELECT "+duckSessionCols+` FROM sessions
 		 WHERE parent_session_id = ? AND deleted_at IS NULL
 		 ORDER BY COALESCE(started_at, created_at) ASC`,
@@ -437,7 +515,7 @@ func (s *Store) GetSessionVersion(id string) (int, int64, bool) {
 	var fileMtime sql.NullInt64
 	var fileHash sql.NullString
 	var updated any
-	err := s.duck.QueryRow(
+	err := s.queryRowContext(context.Background(),
 		`SELECT message_count, file_mtime, file_hash,
 		        COALESCE(local_modified_at, ended_at, started_at, created_at)
 		 FROM sessions WHERE id = ?`,
@@ -465,15 +543,17 @@ func (s *Store) GetStats(ctx context.Context, excludeOneShot, excludeAutomated b
 	filter := rootSessionWhere(excludeOneShot, excludeAutomated)
 	query := fmt.Sprintf(`
 		SELECT
-			(SELECT COUNT(*) FROM sessions WHERE %s),
-			(SELECT COALESCE(SUM(message_count), 0) FROM sessions WHERE %s),
-			(SELECT COUNT(DISTINCT project) FROM sessions WHERE %s),
-			(SELECT COUNT(DISTINCT machine) FROM sessions WHERE %s),
-			(SELECT MIN(COALESCE(started_at, created_at)) FROM sessions WHERE %s)`,
-		filter, filter, filter, filter, filter)
+			COUNT(*),
+			COALESCE(SUM(message_count), 0),
+			COUNT(DISTINCT project),
+			COUNT(DISTINCT machine),
+			MIN(COALESCE(started_at, created_at))
+		FROM sessions
+		WHERE %s`,
+		filter)
 	var stats db.Stats
 	var earliest any
-	if err := s.duck.QueryRowContext(ctx, query).Scan(
+	if err := s.queryRowContext(ctx, query).Scan(
 		&stats.SessionCount, &stats.MessageCount,
 		&stats.ProjectCount, &stats.MachineCount, &earliest,
 	); err != nil {
@@ -486,7 +566,7 @@ func (s *Store) GetStats(ctx context.Context, excludeOneShot, excludeAutomated b
 }
 
 func (s *Store) GetProjects(ctx context.Context, excludeOneShot, excludeAutomated bool) ([]db.ProjectInfo, error) {
-	rows, err := s.duck.QueryContext(ctx,
+	rows, err := s.queryContext(ctx,
 		`SELECT project, COUNT(*) FROM sessions WHERE `+
 			rootSessionWhere(excludeOneShot, excludeAutomated)+
 			` GROUP BY project ORDER BY project`,
@@ -507,7 +587,7 @@ func (s *Store) GetProjects(ctx context.Context, excludeOneShot, excludeAutomate
 }
 
 func (s *Store) GetAgents(ctx context.Context, excludeOneShot, excludeAutomated bool) ([]db.AgentInfo, error) {
-	rows, err := s.duck.QueryContext(ctx,
+	rows, err := s.queryContext(ctx,
 		`SELECT agent, COUNT(*) FROM sessions WHERE agent <> '' AND `+
 			rootSessionWhere(excludeOneShot, excludeAutomated)+
 			` GROUP BY agent ORDER BY agent`,
@@ -528,7 +608,7 @@ func (s *Store) GetAgents(ctx context.Context, excludeOneShot, excludeAutomated 
 }
 
 func (s *Store) GetMachines(ctx context.Context, excludeOneShot, excludeAutomated bool) ([]string, error) {
-	rows, err := s.duck.QueryContext(ctx,
+	rows, err := s.queryContext(ctx,
 		`SELECT DISTINCT machine FROM sessions WHERE `+
 			rootSessionWhere(excludeOneShot, excludeAutomated)+
 			` ORDER BY machine`,
@@ -640,7 +720,7 @@ func (s *Store) Search(ctx context.Context, f db.SearchFilter) (db.SearchPage, e
 		orderBy = "session_ended_at DESC, session_id ASC"
 	}
 	args = append(args, f.Limit+1, f.Cursor)
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		WITH msg_ranked AS (
 			SELECT m.session_id, s.project, s.agent,
 				COALESCE(s.display_name, s.session_name, s.first_message, '') AS name,
@@ -734,7 +814,7 @@ func (s *Store) SearchSession(ctx context.Context, sessionID, query string) ([]i
 	if query == "" {
 		return nil, nil
 	}
-	rows, err := s.duck.QueryContext(ctx, `
+	rows, err := s.queryContext(ctx, `
 		SELECT DISTINCT m.ordinal
 		FROM messages m
 		LEFT JOIN tool_calls tc
@@ -1180,7 +1260,7 @@ func (s *Store) collectContentSource(
 		return nil, &db.SearchInputError{Msg: fmt.Sprintf("search: unknown source %q", source)}
 	}
 	query += ` ORDER BY ` + orderBy
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("duckdb content search: %w", err)
 	}
@@ -1190,7 +1270,7 @@ func (s *Store) collectContentSource(
 func (s *Store) scanContentMatches(
 	ctx context.Context, query string, args []any, makeSnippet func(string) string,
 ) ([]db.ContentMatch, error) {
-	rows, err := s.duck.QueryContext(ctx, query, args...)
+	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("duckdb content search: %w", err)
 	}

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -4,11 +4,15 @@ package duckdb
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +23,88 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type sessionVersionProbeDriver struct{}
+
+type sessionVersionProbeConn struct{}
+
+type sessionVersionProbeRows struct {
+	columns []string
+	values  [][]driver.Value
+	next    int
+}
+
+var sessionVersionProbeRegisterOnce sync.Once
+
+func newSessionVersionProbeStore(t *testing.T) *Store {
+	t.Helper()
+	sessionVersionProbeRegisterOnce.Do(func() {
+		sql.Register("agentsview_session_version_probe", sessionVersionProbeDriver{})
+	})
+	duck, err := sql.Open("agentsview_session_version_probe", t.Name())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, duck.Close()) })
+	return &Store{
+		duck:           duck,
+		connectionKind: duckDBQuackClientConnection,
+	}
+}
+
+func (sessionVersionProbeDriver) Open(string) (driver.Conn, error) {
+	return sessionVersionProbeConn{}, nil
+}
+
+func (sessionVersionProbeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (sessionVersionProbeConn) Close() error { return nil }
+
+func (sessionVersionProbeConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("begin not implemented")
+}
+
+func (sessionVersionProbeConn) QueryContext(
+	_ context.Context, query string, args []driver.NamedValue,
+) (driver.Rows, error) {
+	if !strings.Contains(query, quackAttachmentName+".query(?)") {
+		return nil, errors.New("direct session version query should not be used")
+	}
+	if len(args) != 1 {
+		return nil, fmt.Errorf("remote query got %d args, want 1", len(args))
+	}
+	sqlText, ok := args[0].Value.(string)
+	if !ok {
+		return nil, fmt.Errorf("remote query arg has type %T", args[0].Value)
+	}
+	if !strings.Contains(sqlText, "FROM sessions WHERE id") {
+		return nil, fmt.Errorf("unexpected remote query: %s", sqlText)
+	}
+	return &sessionVersionProbeRows{
+		columns: []string{
+			"message_count", "file_mtime", "file_hash", "updated_at",
+		},
+		values: [][]driver.Value{{
+			int64(7), int64(123), "hash",
+			"2026-01-10T00:00:00Z",
+		}},
+	}, nil
+}
+
+func (r *sessionVersionProbeRows) Columns() []string {
+	return r.columns
+}
+
+func (r *sessionVersionProbeRows) Close() error { return nil }
+
+func (r *sessionVersionProbeRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.next])
+	r.next++
+	return nil
+}
 
 func TestDecodeCursorClearsLegacyTotal(t *testing.T) {
 	store := &Store{}
@@ -35,6 +121,21 @@ func TestDecodeCursorClearsLegacyTotal(t *testing.T) {
 
 	assert.Equal(t, "legacy-cursor", got.ID)
 	assert.Equal(t, 0, got.Total)
+}
+
+func TestQuackStoreGetSessionVersionUsesRemoteQuery(t *testing.T) {
+	store := newSessionVersionProbeStore(t)
+
+	count, marker, ok := store.GetSessionVersion("quoted ' session")
+
+	require.True(t, ok)
+	assert.Equal(t, 7, count)
+	assert.Equal(t,
+		db.SessionVersionMarker(
+			"123", "hash", "2026-01-10T00:00:00Z",
+		),
+		marker,
+	)
 }
 
 func TestStoreReadsSessionsMessagesAndMetadata(t *testing.T) {
@@ -85,6 +186,104 @@ func TestStoreReadsSessionsMessagesAndMetadata(t *testing.T) {
 	machines, err := store.GetMachines(ctx, false, false)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"test-machine"}, machines)
+}
+
+func TestStoreGetStatsPreservesRootAndScopeFilters(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, syncer.EnsureSchema(ctx))
+	duck := syncer.DB()
+	store := NewStoreFromDB(duck)
+
+	insertSession := func(
+		id, project, relationship, ts string,
+		messageCount, userMessageCount int,
+		automated bool,
+	) {
+		t.Helper()
+		_, err := duck.ExecContext(ctx, `
+			INSERT INTO sessions (
+				id, project, machine, agent, message_count,
+				user_message_count, relationship_type, is_automated,
+				started_at, created_at
+			) VALUES (
+				?, ?, 'stats-machine', 'claude', ?, ?, ?, ?,
+				CAST(? AS TIMESTAMP), CAST(? AS TIMESTAMP)
+			)`,
+			id, project, messageCount, userMessageCount, relationship,
+			automated, ts, ts,
+		)
+		require.NoError(t, err)
+	}
+
+	insertSession(
+		"stats-fork", "fork", "fork", "2025-12-26 00:00:00",
+		1, 2, false,
+	)
+	insertSession(
+		"stats-subagent", "child", "subagent", "2025-12-27 00:00:00",
+		1, 2, false,
+	)
+	insertSession(
+		"stats-empty", "empty", "root", "2025-12-28 00:00:00",
+		0, 2, false,
+	)
+	insertSession(
+		"stats-deleted", "deleted", "root", "2025-12-29 00:00:00",
+		1, 2, false,
+	)
+	insertSession(
+		"stats-one-shot", "beta", "root", "2025-12-30 00:00:00",
+		1, 1, false,
+	)
+	insertSession(
+		"stats-automated", "bot", "root", "2025-12-31 00:00:00",
+		1, 1, true,
+	)
+	insertSession(
+		"stats-human", "alpha", "root", "2026-01-01 00:00:00",
+		2, 2, false,
+	)
+	_, err := duck.ExecContext(ctx,
+		`UPDATE sessions SET deleted_at = CAST(? AS TIMESTAMP) WHERE id = ?`,
+		"2026-01-02 00:00:00", "stats-deleted",
+	)
+	require.NoError(t, err)
+
+	assertStats := func(
+		name string,
+		excludeOneShot, excludeAutomated bool,
+		wantSessions, wantMessages, wantProjects int,
+		wantEarliest string,
+	) {
+		t.Helper()
+		stats, err := store.GetStats(ctx, excludeOneShot, excludeAutomated)
+		require.NoError(t, err, name)
+		assert.Equal(t, wantSessions, stats.SessionCount, name)
+		assert.Equal(t, wantMessages, stats.MessageCount, name)
+		assert.Equal(t, wantProjects, stats.ProjectCount, name)
+		assert.Equal(t, 1, stats.MachineCount, name)
+		require.NotNil(t, stats.EarliestSession, name)
+		assert.Equal(t, wantEarliest, *stats.EarliestSession, name)
+	}
+
+	assertStats(
+		"include all root sessions", false, false, 3, 4, 3,
+		"2025-12-30T00:00:00Z",
+	)
+	assertStats(
+		"exclude one-shot keeps automated", true, false, 2, 3, 2,
+		"2025-12-31T00:00:00Z",
+	)
+	assertStats(
+		"exclude automated keeps human one-shot", false, true, 2, 3, 2,
+		"2025-12-30T00:00:00Z",
+	)
+	assertStats(
+		"exclude one-shot and automated", true, true, 1, 2, 1,
+		"2026-01-01T00:00:00Z",
+	)
 }
 
 func TestStoreMessageIDJoinsAreSessionScoped(t *testing.T) {

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -6,9 +6,11 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -34,12 +36,21 @@ type Sync struct {
 	syncStateScope  string
 	projects        []string
 	excludeProjects []string
+	connectionKind  duckDBConnectionKind
+	quack           *quackClient
 
 	closeOnce sync.Once
 	closeErr  error
 	schemaMu  sync.Mutex
 	schemaOK  bool
 }
+
+type duckDBConnectionKind int
+
+const (
+	duckDBBaseConnection duckDBConnectionKind = iota
+	duckDBQuackClientConnection
+)
 
 // SyncOptions holds optional DuckDB push-scope filters.
 type SyncOptions struct {
@@ -54,9 +65,28 @@ type PushResult struct {
 	MessagesPushed int
 	Errors         int
 	Duration       time.Duration
+	Diagnostics    PushDiagnostics
 }
 
-// PushProgress is reported after each pushed session.
+// PushDiagnostics summarizes how a DuckDB push selected sessions.
+type PushDiagnostics struct {
+	Full                     bool
+	LastPushAt               string
+	Cutoff                   string
+	LocalSessions            PushSessionCounts
+	CandidateSessions        PushSessionCounts
+	SkippedUnchangedSessions PushSessionCounts
+	PushedSessions           PushSessionCounts
+	DeletedStaleSessions     int
+}
+
+// PushSessionCounts summarizes a set of sessions without exposing content.
+type PushSessionCounts struct {
+	Total   int
+	ByAgent map[string]int
+}
+
+// PushProgress is reported after each attempted session.
 type PushProgress struct {
 	SessionsDone  int
 	SessionsTotal int
@@ -76,11 +106,8 @@ type SyncStatus struct {
 func New(
 	path string, local *db.DB, machine string, opts SyncOptions,
 ) (*Sync, error) {
-	if local == nil {
-		return nil, fmt.Errorf("local db is required")
-	}
-	if machine == "" {
-		return nil, fmt.Errorf("machine name must not be empty")
+	if err := validateSyncInputs(local, machine); err != nil {
+		return nil, err
 	}
 	duck, err := Open(path)
 	if err != nil {
@@ -94,6 +121,16 @@ func New(
 		projects:        opts.Projects,
 		excludeProjects: opts.ExcludeProjects,
 	}, nil
+}
+
+func validateSyncInputs(local *db.DB, machine string) error {
+	if local == nil {
+		return fmt.Errorf("local db is required")
+	}
+	if machine == "" {
+		return fmt.Errorf("machine name must not be empty")
+	}
+	return nil
 }
 
 // DB returns the underlying DuckDB connection.
@@ -125,7 +162,10 @@ func (s *Sync) EnsureSchema(ctx context.Context) error {
 	if s.schemaOK {
 		return nil
 	}
-	if err := EnsureSchema(ctx, s.duck); err != nil {
+	opts := schemaOptions{
+		createIndexes: s.connectionKind != duckDBQuackClientConnection,
+	}
+	if err := ensureSchema(ctx, s.duck, opts); err != nil {
 		return err
 	}
 	s.schemaOK = true
@@ -143,7 +183,9 @@ func (s *Sync) Status(ctx context.Context) (SyncStatus, error) {
 	if err := s.EnsureSchema(ctx); err != nil {
 		return SyncStatus{}, err
 	}
-	return readMachineStatus(ctx, s.duck, s.machine, status.LastPushAt)
+	return readMachineStatus(
+		ctx, s.duck, s.connectionKind, s.quack, s.machine, status.LastPushAt,
+	)
 }
 
 // Push syncs local sessions and dependent rows to DuckDB.
@@ -186,6 +228,9 @@ func (s *Sync) Push(
 	}
 
 	cutoff := time.Now().UTC().Format(localSyncTimestampLayout)
+	result.Diagnostics.Full = full
+	result.Diagnostics.LastPushAt = lastPush
+	result.Diagnostics.Cutoff = cutoff
 	sessions, err := s.local.ListSessionsModifiedBetween(
 		ctx, lastPush, cutoff, s.projects, s.excludeProjects,
 	)
@@ -223,10 +268,13 @@ func (s *Sync) Push(
 	if err != nil {
 		return result, fmt.Errorf("listing local sessions: %w", err)
 	}
+	result.Diagnostics.LocalSessions = countPushSessions(allLocalSessions)
 	sessionFingerprints, err := s.sessionFingerprints(ctx, sessions)
 	if err != nil {
 		return result, err
 	}
+	candidateSessions := append([]db.Session(nil), sessions...)
+	result.Diagnostics.CandidateSessions = countPushSessions(candidateSessions)
 	priorFingerprints := map[string]string{}
 	if !full {
 		priorFingerprints, err = readSyncFingerprintsWithKey(
@@ -237,60 +285,62 @@ func (s *Sync) Push(
 			return result, err
 		}
 		sessions = filterUnchangedSessions(sessions, priorFingerprints, sessionFingerprints)
+		result.Diagnostics.SkippedUnchangedSessions = skippedPushSessions(
+			candidateSessions, sessions,
+		)
 	}
 	sort.Slice(sessions, func(i, j int) bool {
 		return sessions[i].ID < sessions[j].ID
 	})
 
-	tx, err := s.duck.BeginTx(ctx, nil)
-	if err != nil {
-		return result, fmt.Errorf("begin duckdb tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
 	var staleIDs []string
-	staleIDs, err = deleteHardDeletedMirrorSessions(
-		ctx, tx, allLocalSessions, s.machine, s.projects, s.excludeProjects,
-	)
+	err = s.withDuckTx(ctx, "delete hard-deleted sessions", func(tx *sql.Tx) error {
+		var txErr error
+		staleIDs, txErr = s.deleteHardDeletedMirrorSessions(
+			ctx, tx, allLocalSessions, s.machine, s.projects, s.excludeProjects,
+		)
+		return txErr
+	})
 	if err != nil {
 		return result, err
 	}
 	for _, id := range staleIDs {
 		delete(priorFingerprints, id)
 	}
+	result.Diagnostics.DeletedStaleSessions = len(staleIDs)
 
 	pushed := make([]db.Session, 0, len(sessions))
-	for i, sess := range sessions {
-		messages, err := s.pushSession(ctx, tx, sess)
+	for start := 0; start < len(sessions); start += duckSessionPushBatchSize {
+		end := min(start+duckSessionPushBatchSize, len(sessions))
+		if err := s.pushSessionBatch(
+			ctx, sessions[start:end], start, len(sessions),
+			&result, &pushed, onProgress,
+		); err != nil {
+			return result, err
+		}
+	}
+	result.Diagnostics.PushedSessions = countPushSessions(pushed)
+	if result.Errors == 0 {
+		err = s.withDuckTx(ctx, "replace curation rows", func(tx *sql.Tx) error {
+			if !s.isFiltered() {
+				if err := s.replaceAllPinnedMessages(ctx, tx, allLocalSessions); err != nil {
+					return err
+				}
+			} else {
+				if err := s.replaceScopedPinnedMessages(ctx, tx, allLocalSessions); err != nil {
+					return err
+				}
+			}
+			return s.replaceStarredSessions(ctx, tx, allLocalSessions)
+		})
 		if err != nil {
 			return result, err
 		}
-		result.SessionsPushed++
-		result.MessagesPushed += messages
-		pushed = append(pushed, sess)
-		if onProgress != nil {
-			onProgress(PushProgress{
-				SessionsDone:  i + 1,
-				SessionsTotal: len(sessions),
-				MessagesDone:  result.MessagesPushed,
-				Errors:        result.Errors,
-			})
-		}
-	}
-	if !s.isFiltered() {
-		if err := s.replaceAllPinnedMessages(ctx, tx, allLocalSessions); err != nil {
-			return result, err
-		}
 	} else {
-		if err := s.replaceScopedPinnedMessages(ctx, tx, allLocalSessions); err != nil {
-			return result, err
-		}
-	}
-	if err := s.replaceStarredSessions(ctx, tx, allLocalSessions); err != nil {
-		return result, err
-	}
-	if err := tx.Commit(); err != nil {
-		return result, fmt.Errorf("commit duckdb tx: %w", err)
+		log.Printf(
+			"duckdbsync: skipping curation refresh after %d session push errors",
+			result.Errors,
+		)
 	}
 	if full && s.isFiltered() {
 		// Clear the global watermark so the next unfiltered push
@@ -300,16 +350,280 @@ func (s *Sync) Push(
 			return result, err
 		}
 	}
-	if err := s.finalizeState(lastPush, cutoff, pushed, priorFingerprints, sessionFingerprints); err != nil {
+	advanceWatermark := result.Errors == 0
+	if err := s.finalizeState(
+		lastPush, cutoff, pushed, priorFingerprints,
+		sessionFingerprints, advanceWatermark,
+	); err != nil {
 		return result, err
 	}
 	result.Duration = time.Since(start)
 	return result, nil
 }
 
+func (s *Sync) withDuckTx(
+	ctx context.Context, label string, fn func(*sql.Tx) error,
+) error {
+	tx, err := s.duck.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin duckdb tx for %s: %w", label, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit duckdb tx for %s: %w", label, err)
+	}
+	return nil
+}
+
+const duckSessionPushBatchSize = 100
+
+func (s *Sync) pushSessionBatch(
+	ctx context.Context,
+	sessions []db.Session,
+	offset int,
+	total int,
+	result *PushResult,
+	pushed *[]db.Session,
+	onProgress func(PushProgress),
+) error {
+	messagesBySession, err := s.tryPushSessionBatch(ctx, sessions)
+	if err == nil {
+		for i, sess := range sessions {
+			result.SessionsPushed++
+			result.MessagesPushed += messagesBySession[i]
+			*pushed = append(*pushed, sess)
+			reportDuckPushProgress(
+				offset+i+1, total, result, onProgress,
+			)
+		}
+		return nil
+	}
+	if err := fatalDuckPushError(ctx, err); err != nil {
+		return err
+	}
+	log.Printf(
+		"duckdbsync: session batch starting at %d failed; retrying sessions individually: %v",
+		offset, err,
+	)
+	for i, sess := range sessions {
+		if err := ctx.Err(); err != nil {
+			return abandonDuckPushFallback(
+				err, len(sessions)-i, offset+len(sessions),
+				total, result, onProgress,
+			)
+		}
+		messages, err := s.pushSingleSession(ctx, sess)
+		if err != nil {
+			if err := fatalDuckPushError(ctx, err); err != nil {
+				return abandonDuckPushFallback(
+					err, len(sessions)-i, offset+len(sessions),
+					total, result, onProgress,
+				)
+			}
+			result.Errors++
+			log.Printf("duckdbsync: skipping session %s after push error: %v", sess.ID, err)
+		} else {
+			result.SessionsPushed++
+			result.MessagesPushed += messages
+			*pushed = append(*pushed, sess)
+		}
+		reportDuckPushProgress(offset+i+1, total, result, onProgress)
+	}
+	return nil
+}
+
+func abandonDuckPushFallback(
+	err error,
+	abandoned int,
+	done int,
+	total int,
+	result *PushResult,
+	onProgress func(PushProgress),
+) error {
+	if abandoned > 0 {
+		result.Errors += abandoned
+		log.Printf(
+			"duckdbsync: abandoning %d sessions after context cancellation during individual retry: %v",
+			abandoned, err,
+		)
+		reportDuckPushProgress(done, total, result, onProgress)
+	}
+	return err
+}
+
+func fatalDuckPushError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return nil
+}
+
+func reportDuckPushProgress(
+	done int,
+	total int,
+	result *PushResult,
+	onProgress func(PushProgress),
+) {
+	if onProgress == nil {
+		return
+	}
+	onProgress(PushProgress{
+		SessionsDone:  done,
+		SessionsTotal: total,
+		MessagesDone:  result.MessagesPushed,
+		Errors:        result.Errors,
+	})
+}
+
+func (s *Sync) tryPushSessionBatch(
+	ctx context.Context, sessions []db.Session,
+) ([]int, error) {
+	if s.connectionKind == duckDBQuackClientConnection {
+		return s.tryPushRemoteSessionBatch(ctx, sessions)
+	}
+	tx, err := s.duck.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin duckdb session batch tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	messagesBySession := make([]int, len(sessions))
+
+	for i, sess := range sessions {
+		messages, err := s.pushSession(ctx, tx, sess)
+		if err != nil {
+			return nil, fmt.Errorf("pushing duckdb session %s: %w", sess.ID, err)
+		}
+		messagesBySession[i] = messages
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit duckdb session batch: %w", err)
+	}
+	return messagesBySession, nil
+}
+
+func (s *Sync) tryPushRemoteSessionBatch(
+	ctx context.Context, sessions []db.Session,
+) ([]int, error) {
+	batch := &duckRemoteMutationBatch{}
+	messagesBySession := make([]int, len(sessions))
+
+	for i, sess := range sessions {
+		sessionBatch := &duckRemoteMutationBatch{}
+		messages, err := s.pushSession(ctx, sessionBatch, sess)
+		if err != nil {
+			return nil, fmt.Errorf("pushing duckdb remote session %s: %w", sess.ID, err)
+		}
+		batch, err = appendDuckRemoteMutationBatch(
+			ctx,
+			s.execRemoteSQLRetry,
+			s.execRemoteSQLNoRetry,
+			"duckdb remote session batch",
+			batch,
+			sessionBatch,
+			duckRemoteMutationCoalesceMaxBytes,
+		)
+		if err != nil {
+			return nil, err
+		}
+		messagesBySession[i] = messages
+	}
+	if err := s.execRemoteMutationBatch(ctx, "duckdb remote session batch", batch, true); err != nil {
+		return nil, err
+	}
+	return messagesBySession, nil
+}
+
+func (s *Sync) pushSingleSession(ctx context.Context, sess db.Session) (int, error) {
+	if s.connectionKind == duckDBQuackClientConnection {
+		return s.pushSingleRemoteSession(ctx, sess)
+	}
+	tx, err := s.duck.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin duckdb session tx %s: %w", sess.ID, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	messages, err := s.pushSession(ctx, tx, sess)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit duckdb session %s: %w", sess.ID, err)
+	}
+	return messages, nil
+}
+
+func (s *Sync) pushSingleRemoteSession(ctx context.Context, sess db.Session) (int, error) {
+	batch := &duckRemoteMutationBatch{}
+	messages, err := s.pushSession(ctx, batch, sess)
+	if err != nil {
+		return 0, err
+	}
+	if err := s.execSingleRemoteMutationBatch(
+		ctx, "duckdb remote session "+sess.ID, batch,
+	); err != nil {
+		return 0, err
+	}
+	return messages, nil
+}
+
+func (s *Sync) execSingleRemoteMutationBatch(
+	ctx context.Context, label string, batch *duckRemoteMutationBatch,
+) error {
+	if batch.transactionBytes() > duckRemoteMutationCoalesceMaxBytes {
+		return s.execRemoteMutationBatch(ctx, label, batch, false)
+	}
+	return execDuckRemoteMutationBatchWithStatementFallback(
+		ctx, s.execRemoteSQLRetry, s.execRemoteSQLNoRetry, label, batch,
+	)
+}
+
+func countPushSessions(sessions []db.Session) PushSessionCounts {
+	counts := PushSessionCounts{Total: len(sessions)}
+	if len(sessions) == 0 {
+		return counts
+	}
+	counts.ByAgent = make(map[string]int)
+	for _, sess := range sessions {
+		agent := strings.TrimSpace(sess.Agent)
+		if agent == "" {
+			agent = "unknown"
+		}
+		counts.ByAgent[agent]++
+	}
+	return counts
+}
+
+func skippedPushSessions(
+	candidates []db.Session,
+	pushed []db.Session,
+) PushSessionCounts {
+	pushedIDs := make(map[string]struct{}, len(pushed))
+	for _, sess := range pushed {
+		pushedIDs[sess.ID] = struct{}{}
+	}
+	skipped := make([]db.Session, 0, len(candidates)-len(pushed))
+	for _, sess := range candidates {
+		if _, ok := pushedIDs[sess.ID]; ok {
+			continue
+		}
+		skipped = append(skipped, sess)
+	}
+	return countPushSessions(skipped)
+}
+
 func (s *Sync) sessionCount(ctx context.Context) (int, error) {
 	var count int
-	if err := s.duck.QueryRowContext(ctx,
+	if err := queryDuckDBRowContext(ctx, s.duck, s.connectionKind, s.quack,
 		`SELECT COUNT(*) FROM sessions WHERE machine = ?`,
 		s.machine,
 	).Scan(&count); err != nil {
@@ -323,6 +637,7 @@ func (s *Sync) finalizeState(
 	pushed []db.Session,
 	priorFingerprints map[string]string,
 	sessionFingerprints map[string]string,
+	advanceWatermark bool,
 ) error {
 	if s.isFiltered() {
 		// Filtered pushes must not advance the global watermark
@@ -341,8 +656,10 @@ func (s *Sync) finalizeState(
 		)
 	}
 	lastPushKey := s.syncStateKey(lastPushStateKey)
-	if err := s.local.SetSyncState(lastPushKey, cutoff); err != nil {
-		return fmt.Errorf("updating %s: %w", lastPushKey, err)
+	if advanceWatermark {
+		if err := s.local.SetSyncState(lastPushKey, cutoff); err != nil {
+			return fmt.Errorf("updating %s: %w", lastPushKey, err)
+		}
 	}
 	return writeSyncFingerprints(
 		s.local, s.syncStateKey(lastPushBoundaryStateKey),

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -380,6 +380,8 @@ func (s *Sync) withDuckTx(
 
 const duckSessionPushBatchSize = 100
 
+const duckRemoteMutationTimeoutBackoff = 30 * time.Second
+
 func (s *Sync) pushSessionBatch(
 	ctx context.Context,
 	sessions []db.Session,
@@ -389,7 +391,42 @@ func (s *Sync) pushSessionBatch(
 	pushed *[]db.Session,
 	onProgress func(PushProgress),
 ) error {
-	messagesBySession, err := s.tryPushSessionBatch(ctx, sessions)
+	return pushSessionBatchWith(
+		ctx, sessions, offset, total, result, pushed, onProgress,
+		s.tryPushSessionBatch, s.pushSingleSession, waitAfterRemoteMutationTimeout,
+	)
+}
+
+func pushSessionBatchWith(
+	ctx context.Context,
+	sessions []db.Session,
+	offset int,
+	total int,
+	result *PushResult,
+	pushed *[]db.Session,
+	onProgress func(PushProgress),
+	tryBatch func(context.Context, []db.Session) ([]int, error),
+	pushSingle func(context.Context, db.Session) (int, error),
+	waitAfterTimeout func(context.Context) error,
+) error {
+	messagesBySession, err := tryBatch(ctx, sessions)
+	if err != nil {
+		if fatalErr := fatalDuckPushError(ctx, err); fatalErr != nil {
+			return fatalErr
+		}
+		if isDuckRemoteMutationTimeoutError(err) {
+			log.Printf(
+				"duckdbsync: session batch starting at %d timed out; waiting before retrying batch: %v",
+				offset, err,
+			)
+			if waitAfterTimeout != nil {
+				if waitErr := waitAfterTimeout(ctx); waitErr != nil {
+					return waitErr
+				}
+			}
+			messagesBySession, err = tryBatch(ctx, sessions)
+		}
+	}
 	if err == nil {
 		for i, sess := range sessions {
 			result.SessionsPushed++
@@ -404,6 +441,9 @@ func (s *Sync) pushSessionBatch(
 	if err := fatalDuckPushError(ctx, err); err != nil {
 		return err
 	}
+	if isDuckRemoteMutationTimeoutError(err) {
+		return err
+	}
 	log.Printf(
 		"duckdbsync: session batch starting at %d failed; retrying sessions individually: %v",
 		offset, err,
@@ -415,7 +455,7 @@ func (s *Sync) pushSessionBatch(
 				total, result, onProgress,
 			)
 		}
-		messages, err := s.pushSingleSession(ctx, sess)
+		messages, err := pushSingle(ctx, sess)
 		if err != nil {
 			if err := fatalDuckPushError(ctx, err); err != nil {
 				return abandonDuckPushFallback(
@@ -433,6 +473,21 @@ func (s *Sync) pushSessionBatch(
 		reportDuckPushProgress(offset+i+1, total, result, onProgress)
 	}
 	return nil
+}
+
+func waitAfterRemoteMutationTimeout(ctx context.Context) error {
+	return sleepContext(ctx, duckRemoteMutationTimeoutBackoff)
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func abandonDuckPushFallback(
@@ -526,7 +581,6 @@ func (s *Sync) tryPushRemoteSessionBatch(
 		batch, err = appendDuckRemoteMutationBatch(
 			ctx,
 			s.execRemoteSQLRetry,
-			s.execRemoteSQLNoRetry,
 			"duckdb remote session batch",
 			batch,
 			sessionBatch,
@@ -580,7 +634,14 @@ func (s *Sync) execSingleRemoteMutationBatch(
 	ctx context.Context, label string, batch *duckRemoteMutationBatch,
 ) error {
 	if batch.transactionBytes() > duckRemoteMutationCoalesceMaxBytes {
-		return s.execRemoteMutationBatch(ctx, label, batch, false)
+		return execDuckRemoteMutationBatchChunksWithStatementFallback(
+			ctx,
+			s.execRemoteSQLRetry,
+			s.execRemoteSQLNoRetry,
+			label,
+			batch,
+			duckRemoteMutationCoalesceMaxBytes,
+		)
 	}
 	return execDuckRemoteMutationBatchWithStatementFallback(
 		ctx, s.execRemoteSQLRetry, s.execRemoteSQLNoRetry, label, batch,

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -569,6 +569,8 @@ func (s *Sync) tryPushSessionBatch(
 func (s *Sync) tryPushRemoteSessionBatch(
 	ctx context.Context, sessions []db.Session,
 ) ([]int, error) {
+	const batchLabel = "duckdb remote session batch"
+
 	batch := &duckRemoteMutationBatch{}
 	messagesBySession := make([]int, len(sessions))
 
@@ -578,10 +580,23 @@ func (s *Sync) tryPushRemoteSessionBatch(
 		if err != nil {
 			return nil, fmt.Errorf("pushing duckdb remote session %s: %w", sess.ID, err)
 		}
+		if sessionBatch.transactionBytes() > duckRemoteMutationCoalesceMaxBytes {
+			if err := s.execRemoteMutationBatch(ctx, batchLabel, batch); err != nil {
+				return nil, err
+			}
+			batch = &duckRemoteMutationBatch{}
+			if err := s.execSingleRemoteMutationBatch(
+				ctx, "duckdb remote session "+sess.ID, sessionBatch,
+			); err != nil {
+				return nil, err
+			}
+			messagesBySession[i] = messages
+			continue
+		}
 		batch, err = appendDuckRemoteMutationBatch(
 			ctx,
 			s.execRemoteSQLRetry,
-			"duckdb remote session batch",
+			batchLabel,
 			batch,
 			sessionBatch,
 			duckRemoteMutationCoalesceMaxBytes,
@@ -591,7 +606,7 @@ func (s *Sync) tryPushRemoteSessionBatch(
 		}
 		messagesBySession[i] = messages
 	}
-	if err := s.execRemoteMutationBatch(ctx, "duckdb remote session batch", batch); err != nil {
+	if err := s.execRemoteMutationBatch(ctx, batchLabel, batch); err != nil {
 		return nil, err
 	}
 	return messagesBySession, nil
@@ -633,18 +648,13 @@ func (s *Sync) pushSingleRemoteSession(ctx context.Context, sess db.Session) (in
 func (s *Sync) execSingleRemoteMutationBatch(
 	ctx context.Context, label string, batch *duckRemoteMutationBatch,
 ) error {
-	if batch.transactionBytes() > duckRemoteMutationCoalesceMaxBytes {
-		return execDuckRemoteMutationBatchChunksWithStatementFallback(
-			ctx,
-			s.execRemoteSQLRetry,
-			s.execRemoteSQLNoRetry,
-			label,
-			batch,
-			duckRemoteMutationCoalesceMaxBytes,
-		)
-	}
-	return execDuckRemoteMutationBatchWithStatementFallback(
-		ctx, s.execRemoteSQLRetry, s.execRemoteSQLNoRetry, label, batch,
+	return execDuckRemoteMutationBatchOversizeWithStatementFallback(
+		ctx,
+		s.execRemoteSQLRetry,
+		s.execRemoteSQLNoRetry,
+		label,
+		batch,
+		duckRemoteMutationCoalesceMaxBytes,
 	)
 }
 

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -591,7 +591,7 @@ func (s *Sync) tryPushRemoteSessionBatch(
 		}
 		messagesBySession[i] = messages
 	}
-	if err := s.execRemoteMutationBatch(ctx, "duckdb remote session batch", batch, true); err != nil {
+	if err := s.execRemoteMutationBatch(ctx, "duckdb remote session batch", batch); err != nil {
 		return nil, err
 	}
 	return messagesBySession, nil

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -778,6 +778,50 @@ func TestDuckRemoteMutationBatchFallbackKeepsPerRowInsertAttribution(
 	}, statementCalls)
 }
 
+func TestDuckRemoteMutationBatchCombinedTransactionBytesUsesCachedRendering(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	for i := range 50 {
+		_, err := batch.ExecContext(ctx,
+			`INSERT INTO remote_test VALUES (?, ?)`, i, strings.Repeat("x", 32),
+		)
+		require.NoError(t, err)
+	}
+	next := &duckRemoteMutationBatch{}
+	_, err := next.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 51, strings.Repeat("y", 32),
+	)
+	require.NoError(t, err)
+
+	require.Positive(t, batch.transactionBytes())
+	require.Positive(t, next.transactionBytes())
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = batch.combinedTransactionBytes(next)
+	})
+
+	assert.Zero(t, allocs)
+}
+
+func TestSplitDuckRemoteSimpleInsertAllocatesOnlyReturnedPrefix(
+	t *testing.T,
+) {
+	literal, err := duckRemoteStringLiteral(strings.Repeat("x", 4096))
+	require.NoError(t, err)
+	stmt := "INSERT INTO remote_test VALUES (" + literal + ")"
+	prefix, tuple, ok := splitDuckRemoteSimpleInsert(stmt)
+	require.True(t, ok)
+	assert.Equal(t, "INSERT INTO remote_test VALUES ", prefix)
+	assert.Contains(t, tuple, strings.Repeat("x", 128))
+
+	allocs := testing.AllocsPerRun(100, func() {
+		_, _, _ = splitDuckRemoteSimpleInsert(stmt)
+	})
+
+	assert.LessOrEqual(t, allocs, 1.0)
+}
+
 func TestAppendDuckRemoteMutationBatchFlushesBeforeByteBudget(t *testing.T) {
 	ctx := context.Background()
 	first := &duckRemoteMutationBatch{}

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -915,7 +915,7 @@ func TestAppendDuckRemoteMutationBatchFlushesBeforeByteBudget(t *testing.T) {
 	assert.Contains(t, calls[1], "second")
 }
 
-func TestAppendDuckRemoteMutationBatchSplitsOversizeSessionCoalesced(
+func TestExecDuckRemoteMutationBatchOversizeUsesStatementModeTransaction(
 	t *testing.T,
 ) {
 	ctx := context.Background()
@@ -934,34 +934,35 @@ func TestAppendDuckRemoteMutationBatchSplitsOversizeSessionCoalesced(
 	require.NoError(t, err)
 	oneStatement := &duckRemoteMutationBatch{statements: oversize.statements[:1]}
 	maxBytes := oneStatement.transactionBytes()
-	var calls []string
+	var coalescedCalls []string
+	var statementCalls []string
 
-	current, err := appendDuckRemoteMutationBatch(
+	err = execDuckRemoteMutationBatchOversizeWithStatementFallback(
 		ctx,
 		func(_ context.Context, sqlText string) error {
-			calls = append(calls, sqlText)
+			coalescedCalls = append(coalescedCalls, sqlText)
+			return nil
+		},
+		func(_ context.Context, sqlText string) error {
+			statementCalls = append(statementCalls, sqlText)
 			return nil
 		},
 		"oversize session",
-		&duckRemoteMutationBatch{},
 		oversize,
 		maxBytes,
 	)
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, current.Len())
-	require.Len(t, calls, 3)
-	assert.Contains(t, calls[0], "VALUES (1, ")
-	assert.Contains(t, calls[1], "VALUES (2, ")
-	assert.Contains(t, calls[2], "VALUES (3, ")
-	for _, call := range calls {
-		assert.Contains(t, call, "BEGIN TRANSACTION")
-		assert.Contains(t, call, "COMMIT")
-		assert.LessOrEqual(t, len(call), maxBytes)
-	}
+	assert.Empty(t, coalescedCalls)
+	require.Len(t, statementCalls, 5)
+	assert.Equal(t, "BEGIN TRANSACTION", statementCalls[0])
+	assert.Contains(t, statementCalls[1], "INSERT INTO remote_test VALUES (1, $")
+	assert.Contains(t, statementCalls[2], "INSERT INTO remote_test VALUES (2, $")
+	assert.Contains(t, statementCalls[3], "INSERT INTO remote_test VALUES (3, $")
+	assert.Equal(t, "COMMIT", statementCalls[4])
 }
 
-func TestAppendDuckRemoteMutationBatchFlushesCurrentBeforeOversizeSession(
+func TestAppendDuckRemoteMutationBatchRejectsOversizeSessionAfterFlush(
 	t *testing.T,
 ) {
 	ctx := context.Background()
@@ -994,18 +995,11 @@ func TestAppendDuckRemoteMutationBatchFlushesCurrentBeforeOversizeSession(
 		oversize,
 		maxBytes,
 	)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "exceeds remote mutation coalesce budget")
 
 	assert.Equal(t, 0, next.Len())
-	require.Len(t, calls, 3)
+	require.Len(t, calls, 1)
 	assert.Equal(t, current.transactionSQL(), calls[0])
-	assert.Contains(t, calls[1], "VALUES (2, ")
-	assert.Contains(t, calls[2], "VALUES (3, ")
-	for _, call := range calls[1:] {
-		assert.Contains(t, call, "BEGIN TRANSACTION")
-		assert.Contains(t, call, "COMMIT")
-		assert.LessOrEqual(t, len(call), maxBytes)
-	}
 }
 
 func TestExecDuckRemoteMutationBatchStatementModePinpointsFailure(t *testing.T) {

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -804,6 +804,59 @@ func TestDuckRemoteMutationBatchCombinedTransactionBytesUsesCachedRendering(
 	assert.Zero(t, allocs)
 }
 
+func TestDuckRemoteMutationBatchAppendBatchPreservesRenderedCache(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	current := &duckRemoteMutationBatch{}
+	first := &duckRemoteMutationBatch{}
+	_, err := first.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 1, strings.Repeat("a", 32),
+	)
+	require.NoError(t, err)
+	second := &duckRemoteMutationBatch{}
+	_, err = second.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 2, strings.Repeat("b", 32),
+	)
+	require.NoError(t, err)
+	third := &duckRemoteMutationBatch{}
+	_, err = third.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 3, strings.Repeat("c", 32),
+	)
+	require.NoError(t, err)
+
+	current.appendBatch(first)
+	require.Positive(t, current.combinedTransactionBytes(second))
+	current.appendBatch(second)
+	require.Positive(t, third.transactionBytes())
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = current.combinedTransactionBytes(third)
+	})
+
+	assert.Zero(t, allocs)
+}
+
+func TestDuckRemoteMutationBatchAppendPreservesRenderedCache(t *testing.T) {
+	ctx := context.Background()
+	current := &duckRemoteMutationBatch{}
+	_, err := current.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 1, strings.Repeat("x", 32),
+	)
+	require.NoError(t, err)
+	next := &duckRemoteMutationBatch{}
+	_, err = next.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 2, strings.Repeat("y", 32),
+	)
+	require.NoError(t, err)
+
+	require.Positive(t, current.combinedTransactionBytes(next))
+	require.True(t, current.renderedValid)
+	current.appendBatch(next)
+
+	assert.True(t, current.renderedValid)
+	assert.Len(t, current.rendered(), 2)
+}
+
 func TestSplitDuckRemoteSimpleInsertAllocatesOnlyReturnedPrefix(
 	t *testing.T,
 ) {

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -598,6 +598,186 @@ func TestDuckRemoteMutationBatchByteAccountingMatchesRenderedTransaction(
 	assert.Equal(t, len(batch.transactionSQL()), batch.transactionBytes())
 }
 
+func TestDuckRemoteMutationBatchCoalescesAdjacentInsertStatements(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx,
+		`DELETE FROM remote_test WHERE session_id = ?`, "session-1",
+	)
+	require.NoError(t, err)
+	for i := range 3 {
+		_, err = batch.ExecContext(ctx,
+			`INSERT INTO remote_test (session_id, ordinal) VALUES (?, ?)`,
+			"session-1", i,
+		)
+		require.NoError(t, err)
+	}
+
+	sqlText := batch.transactionSQL()
+
+	assert.Equal(t, 1, strings.Count(sqlText, "INSERT INTO remote_test"))
+	assert.Contains(t, sqlText,
+		"INSERT INTO remote_test (session_id, ordinal) VALUES ("+
+			"$agentsview_")
+	assert.Contains(t, sqlText, ", 0), (")
+	assert.Contains(t, sqlText, ", 1), (")
+	assert.Contains(t, sqlText, ", 2);")
+	assert.Less(t, batch.transactionBytes(), len(strings.Join(batch.statements, ";\n")))
+}
+
+func TestDuckRemoteMutationBatchInsertCoalescingSplitsByRowLimit(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	for i := range 257 {
+		_, err := batch.ExecContext(ctx,
+			`INSERT INTO remote_test (session_id, ordinal) VALUES (?, ?)`,
+			"session-1", i,
+		)
+		require.NoError(t, err)
+	}
+
+	sqlText := batch.transactionSQL()
+
+	assert.Equal(t, 2, strings.Count(sqlText, "INSERT INTO remote_test"))
+}
+
+func TestDuckRemoteMutationBatchCoalescedInsertMatchesPerRowExecution(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	coalescedDB := openTestDuckDB(t)
+	perRowDB := openTestDuckDB(t)
+	for _, conn := range []*sql.DB{coalescedDB, perRowDB} {
+		_, err := conn.ExecContext(ctx,
+			`CREATE TABLE remote_test (
+				session_id VARCHAR,
+				ordinal INTEGER,
+				content VARCHAR
+			)`,
+		)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx,
+			`INSERT INTO remote_test VALUES ('session-1', 99, 'stale')`,
+		)
+		require.NoError(t, err)
+	}
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx,
+		`DELETE FROM remote_test WHERE session_id = ?`, "session-1",
+	)
+	require.NoError(t, err)
+	for _, row := range []struct {
+		ordinal int
+		content string
+	}{
+		{ordinal: 0, content: "first"},
+		{ordinal: 1, content: "second"},
+		{ordinal: 2, content: "third"},
+	} {
+		_, err = batch.ExecContext(ctx,
+			`INSERT INTO remote_test (session_id, ordinal, content) VALUES (?, ?, ?)`,
+			"session-1", row.ordinal, row.content,
+		)
+		require.NoError(t, err)
+	}
+
+	_, err = coalescedDB.ExecContext(ctx, batch.transactionSQL())
+	require.NoError(t, err)
+	require.NoError(t, execDuckRemoteMutationBatch(
+		ctx,
+		func(ctx context.Context, sqlText string) error {
+			_, err := perRowDB.ExecContext(ctx, sqlText)
+			return err
+		},
+		"per-row equivalence",
+		batch,
+		false,
+	))
+
+	assert.Equal(
+		t,
+		readRemoteTestRows(t, ctx, perRowDB),
+		readRemoteTestRows(t, ctx, coalescedDB),
+	)
+}
+
+type remoteTestRow struct {
+	SessionID string
+	Ordinal   int
+	Content   string
+}
+
+func readRemoteTestRows(
+	t *testing.T, ctx context.Context, conn *sql.DB,
+) []remoteTestRow {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx,
+		`SELECT session_id, ordinal, content
+		 FROM remote_test
+		 ORDER BY session_id, ordinal, content`,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []remoteTestRow
+	for rows.Next() {
+		var row remoteTestRow
+		require.NoError(t, rows.Scan(
+			&row.SessionID, &row.Ordinal, &row.Content,
+		))
+		out = append(out, row)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func TestDuckRemoteMutationBatchFallbackKeepsPerRowInsertAttribution(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+	_, err = batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 2)
+	require.NoError(t, err)
+	var coalescedCalls []string
+	var statementCalls []string
+
+	err = execDuckRemoteMutationBatchWithStatementFallback(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			coalescedCalls = append(coalescedCalls, sqlText)
+			if sqlText == "ROLLBACK" {
+				return nil
+			}
+			return fmt.Errorf("coalesced failure")
+		},
+		func(_ context.Context, sqlText string) error {
+			statementCalls = append(statementCalls, sqlText)
+			if sqlText == "INSERT INTO remote_test VALUES (2)" {
+				return fmt.Errorf("poison row")
+			}
+			return nil
+		},
+		"test session",
+		batch,
+	)
+	require.Error(t, err)
+
+	require.NotEmpty(t, coalescedCalls)
+	assert.Equal(t, 1, strings.Count(coalescedCalls[0], "INSERT INTO remote_test"))
+	assert.Contains(t, err.Error(), "execute test session statement 2/2")
+	assert.Equal(t, []string{
+		"BEGIN TRANSACTION",
+		"INSERT INTO remote_test VALUES (1)",
+		"INSERT INTO remote_test VALUES (2)",
+		"ROLLBACK",
+	}, statementCalls)
+}
+
 func TestAppendDuckRemoteMutationBatchFlushesBeforeByteBudget(t *testing.T) {
 	ctx := context.Background()
 	first := &duckRemoteMutationBatch{}
@@ -656,7 +836,6 @@ func TestAppendDuckRemoteMutationBatchSplitsOversizeSessionCoalesced(
 	)
 	require.NoError(t, err)
 	oneStatement := &duckRemoteMutationBatch{statements: oversize.statements[:1]}
-	oneStatement.statementBytes = len(oversize.statements[0])
 	maxBytes := oneStatement.transactionBytes()
 	var calls []string
 
@@ -704,7 +883,6 @@ func TestAppendDuckRemoteMutationBatchFlushesCurrentBeforeOversizeSession(
 	)
 	require.NoError(t, err)
 	oneStatement := &duckRemoteMutationBatch{statements: oversize.statements[:1]}
-	oneStatement.statementBytes = len(oversize.statements[0])
 	maxBytes := oneStatement.transactionBytes()
 	var calls []string
 

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -251,6 +251,94 @@ func TestPushSessionBatchLogsAbandonedSessionsAfterContextCancel(
 	assert.Contains(t, gotLogs, "abandoning 2 sessions")
 }
 
+func TestPushSessionBatchBacksOffAndRetriesBatchAfterTimeout(t *testing.T) {
+	ctx := context.Background()
+	sessions := []db.Session{
+		syncSession(
+			"duck-timeout-batch-1", "alpha", "timeout one",
+			"2026-01-10T00:00:00.000Z", 1,
+		),
+		syncSession(
+			"duck-timeout-batch-2", "alpha", "timeout two",
+			"2026-01-10T00:01:00.000Z", 2,
+		),
+	}
+	var result PushResult
+	var pushed []db.Session
+	timeoutErr := fmt.Errorf(
+		"IO Error: Failed to send message: IO Error: Timeout was reached error for HTTP POST to '<url>'",
+	)
+	tryCalls := 0
+	waitCalls := 0
+	pushSingleCalls := 0
+
+	err := pushSessionBatchWith(
+		ctx, sessions, 0, len(sessions), &result, &pushed, nil,
+		func(_ context.Context, got []db.Session) ([]int, error) {
+			tryCalls++
+			assert.Equal(t, sessions, got)
+			if tryCalls == 1 {
+				return nil, timeoutErr
+			}
+			return []int{1, 2}, nil
+		},
+		func(context.Context, db.Session) (int, error) {
+			pushSingleCalls++
+			return 0, fmt.Errorf("individual retry should not run")
+		},
+		func(context.Context) error {
+			waitCalls++
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, tryCalls)
+	assert.Equal(t, 1, waitCalls)
+	assert.Equal(t, 0, pushSingleCalls)
+	assert.Equal(t, 2, result.SessionsPushed)
+	assert.Equal(t, 3, result.MessagesPushed)
+	assert.Equal(t, 0, result.Errors)
+	assert.Equal(t, sessions, pushed)
+}
+
+func TestPushSessionBatchReturnsRepeatedTimeoutWithoutIndividualRetry(t *testing.T) {
+	ctx := context.Background()
+	sessions := []db.Session{
+		syncSession(
+			"duck-timeout-batch-repeat", "alpha", "timeout",
+			"2026-01-10T00:00:00.000Z", 1,
+		),
+	}
+	var result PushResult
+	var pushed []db.Session
+	timeoutErr := fmt.Errorf(
+		"IO Error: Failed to send message: IO Error: Timeout was reached error for HTTP POST to '<url>'",
+	)
+	tryCalls := 0
+	pushSingleCalls := 0
+
+	err := pushSessionBatchWith(
+		ctx, sessions, 0, len(sessions), &result, &pushed, nil,
+		func(context.Context, []db.Session) ([]int, error) {
+			tryCalls++
+			return nil, timeoutErr
+		},
+		func(context.Context, db.Session) (int, error) {
+			pushSingleCalls++
+			return 0, fmt.Errorf("individual retry should not run")
+		},
+		func(context.Context) error { return nil },
+	)
+	require.Error(t, err)
+
+	assert.True(t, isDuckRemoteMutationTimeoutError(err))
+	assert.Equal(t, 2, tryCalls)
+	assert.Equal(t, 0, pushSingleCalls)
+	assert.Equal(t, 0, result.Errors)
+	assert.Empty(t, pushed)
+}
+
 func TestSyncPushReportsSessionDiagnosticsByAgent(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)
@@ -435,6 +523,33 @@ func TestExecDuckRemoteMutationBatchCoalescedFailureRollsBack(t *testing.T) {
 	assert.Equal(t, "ROLLBACK", calls[1])
 }
 
+func TestExecDuckRemoteMutationBatchCoalescedTimeoutSkipsRollback(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+	var calls []string
+
+	err = execDuckRemoteMutationBatch(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			calls = append(calls, sqlText)
+			return fmt.Errorf(
+				"IO Error: Failed to send message: IO Error: Timeout was reached error for HTTP POST to '<url>'",
+			)
+		},
+		"test batch",
+		batch,
+		true,
+	)
+
+	require.Error(t, err)
+	assert.True(t, isDuckRemoteMutationTimeoutError(err))
+	assert.Equal(t, []string{batch.transactionSQL()}, calls)
+}
+
 func TestExecDuckRemoteMutationBatchCoalescedRollbackFailureIsWrapped(
 	t *testing.T,
 ) {
@@ -461,6 +576,28 @@ func TestExecDuckRemoteMutationBatchCoalescedRollbackFailureIsWrapped(
 	assert.ErrorContains(t, err, "rollback failed")
 }
 
+func TestDuckRemoteMutationDefaultBudgetFitsQuackTimeout(t *testing.T) {
+	assert.GreaterOrEqual(t, duckRemoteMutationCoalesceMaxBytes, 2<<20)
+	assert.LessOrEqual(t, duckRemoteMutationCoalesceMaxBytes, 4<<20)
+}
+
+func TestDuckRemoteMutationBatchByteAccountingMatchesRenderedTransaction(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 1, "first",
+	)
+	require.NoError(t, err)
+	_, err = batch.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 2, "second",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, len(batch.transactionSQL()), batch.transactionBytes())
+}
+
 func TestAppendDuckRemoteMutationBatchFlushesBeforeByteBudget(t *testing.T) {
 	ctx := context.Background()
 	first := &duckRemoteMutationBatch{}
@@ -482,11 +619,11 @@ func TestAppendDuckRemoteMutationBatchFlushesBeforeByteBudget(t *testing.T) {
 	}
 
 	current, err = appendDuckRemoteMutationBatch(
-		ctx, exec, exec, "test batch", current, first, maxBytes,
+		ctx, exec, "test batch", current, first, maxBytes,
 	)
 	require.NoError(t, err)
 	current, err = appendDuckRemoteMutationBatch(
-		ctx, exec, exec, "test batch", current, second, maxBytes,
+		ctx, exec, "test batch", current, second, maxBytes,
 	)
 	require.NoError(t, err)
 	require.Len(t, calls, 1)
@@ -501,24 +638,30 @@ func TestAppendDuckRemoteMutationBatchFlushesBeforeByteBudget(t *testing.T) {
 	assert.Contains(t, calls[1], "second")
 }
 
-func TestAppendDuckRemoteMutationBatchUsesStatementModeForOversizeSession(
+func TestAppendDuckRemoteMutationBatchSplitsOversizeSessionCoalesced(
 	t *testing.T,
 ) {
 	ctx := context.Background()
 	oversize := &duckRemoteMutationBatch{}
 	_, err := oversize.ExecContext(ctx,
-		`INSERT INTO remote_test VALUES (?, ?)`, 1, strings.Repeat("x", 64),
+		`INSERT INTO remote_test VALUES (?, ?)`, 1, "aaaaa",
 	)
 	require.NoError(t, err)
-	maxBytes := oversize.transactionBytes() - 1
+	_, err = oversize.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 2, "bbbbb",
+	)
+	require.NoError(t, err)
+	_, err = oversize.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 3, "ccccc",
+	)
+	require.NoError(t, err)
+	oneStatement := &duckRemoteMutationBatch{statements: oversize.statements[:1]}
+	oneStatement.statementBytes = len(oversize.statements[0])
+	maxBytes := oneStatement.transactionBytes()
 	var calls []string
 
 	current, err := appendDuckRemoteMutationBatch(
 		ctx,
-		func(_ context.Context, sqlText string) error {
-			calls = append(calls, sqlText)
-			return nil
-		},
 		func(_ context.Context, sqlText string) error {
 			calls = append(calls, sqlText)
 			return nil
@@ -531,9 +674,15 @@ func TestAppendDuckRemoteMutationBatchUsesStatementModeForOversizeSession(
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, current.Len())
-	assert.Equal(t, "BEGIN TRANSACTION", calls[0])
-	assert.Contains(t, calls[1], "INSERT INTO remote_test")
-	assert.Equal(t, "COMMIT", calls[2])
+	require.Len(t, calls, 3)
+	assert.Contains(t, calls[0], "VALUES (1, ")
+	assert.Contains(t, calls[1], "VALUES (2, ")
+	assert.Contains(t, calls[2], "VALUES (3, ")
+	for _, call := range calls {
+		assert.Contains(t, call, "BEGIN TRANSACTION")
+		assert.Contains(t, call, "COMMIT")
+		assert.LessOrEqual(t, len(call), maxBytes)
+	}
 }
 
 func TestAppendDuckRemoteMutationBatchFlushesCurrentBeforeOversizeSession(
@@ -547,18 +696,20 @@ func TestAppendDuckRemoteMutationBatchFlushesCurrentBeforeOversizeSession(
 	require.NoError(t, err)
 	oversize := &duckRemoteMutationBatch{}
 	_, err = oversize.ExecContext(ctx,
-		`INSERT INTO remote_test VALUES (?, ?)`, 2, strings.Repeat("x", 64),
+		`INSERT INTO remote_test VALUES (?, ?)`, 2, "bbbbb",
 	)
 	require.NoError(t, err)
-	maxBytes := oversize.transactionBytes() - 1
+	_, err = oversize.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 3, "ccccc",
+	)
+	require.NoError(t, err)
+	oneStatement := &duckRemoteMutationBatch{statements: oversize.statements[:1]}
+	oneStatement.statementBytes = len(oversize.statements[0])
+	maxBytes := oneStatement.transactionBytes()
 	var calls []string
 
 	next, err := appendDuckRemoteMutationBatch(
 		ctx,
-		func(_ context.Context, sqlText string) error {
-			calls = append(calls, sqlText)
-			return nil
-		},
 		func(_ context.Context, sqlText string) error {
 			calls = append(calls, sqlText)
 			return nil
@@ -571,12 +722,15 @@ func TestAppendDuckRemoteMutationBatchFlushesCurrentBeforeOversizeSession(
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, next.Len())
-	require.Len(t, calls, 4)
+	require.Len(t, calls, 3)
 	assert.Equal(t, current.transactionSQL(), calls[0])
-	assert.Equal(t, "BEGIN TRANSACTION", calls[1])
-	assert.Contains(t, calls[2], "INSERT INTO remote_test")
-	assert.Contains(t, calls[2], strings.Repeat("x", 64))
-	assert.Equal(t, "COMMIT", calls[3])
+	assert.Contains(t, calls[1], "VALUES (2, ")
+	assert.Contains(t, calls[2], "VALUES (3, ")
+	for _, call := range calls[1:] {
+		assert.Contains(t, call, "BEGIN TRANSACTION")
+		assert.Contains(t, call, "COMMIT")
+		assert.LessOrEqual(t, len(call), maxBytes)
+	}
 }
 
 func TestExecDuckRemoteMutationBatchStatementModePinpointsFailure(t *testing.T) {
@@ -676,6 +830,38 @@ func TestExecDuckRemoteMutationBatchFallbackDoesNotRetryStaleFailure(t *testing.
 		batch,
 	)
 	require.ErrorContains(t, err, "Invalid connection id")
+	assert.Empty(t, statementCalls)
+}
+
+func TestExecDuckRemoteMutationBatchFallbackDoesNotRetryTimeout(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+	var coalescedCalls []string
+	var statementCalls []string
+
+	err = execDuckRemoteMutationBatchWithStatementFallback(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			coalescedCalls = append(coalescedCalls, sqlText)
+			return fmt.Errorf(
+				"IO Error: Failed to send message: IO Error: Timeout was reached error for HTTP POST to '<url>'",
+			)
+		},
+		func(_ context.Context, sqlText string) error {
+			statementCalls = append(statementCalls, sqlText)
+			return nil
+		},
+		"test session",
+		batch,
+	)
+	require.Error(t, err)
+
+	assert.True(t, isDuckRemoteMutationTimeoutError(err))
+	assert.Equal(t, []string{batch.transactionSQL()}, coalescedCalls)
 	assert.Empty(t, statementCalls)
 }
 

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -3,10 +3,12 @@
 package duckdb
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -48,6 +50,660 @@ func TestSyncFullPushCreatesExpectedRows(t *testing.T) {
 		fixture.alphaID,
 	).Scan(&firstMessage))
 	assert.Equal(t, "alpha first", firstMessage)
+}
+
+func TestSyncPushContinuesAfterSessionError(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{
+			Session: syncSession(
+				"duck-bad", "alpha", "bad first",
+				"2026-01-10T00:00:00.000Z", 1,
+			),
+			Messages: []db.Message{
+				syncMessage(
+					"duck-bad", 0, "user", "bad first",
+					"not-a-timestamp",
+				),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session: syncSession(
+				"duck-good", "alpha", "good first",
+				"2026-01-11T00:00:00.000Z", 1,
+			),
+			Messages: []db.Message{
+				syncMessage(
+					"duck-good", 0, "user", "good first",
+					"2026-01-11T00:00:00.000Z",
+				),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	})
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	var progress []PushProgress
+
+	result, err := syncer.Push(ctx, true, func(p PushProgress) {
+		progress = append(progress, p)
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.SessionsPushed)
+	assert.Equal(t, 1, result.MessagesPushed)
+	assert.Equal(t, 1, result.Errors)
+	assertDuckDBCountWhere(t, syncer.DB(), "sessions", "id = ?", "duck-good", 1)
+	assertDuckDBCountWhere(t, syncer.DB(), "sessions", "id = ?", "duck-bad", 0)
+	assertDuckDBCountWhere(t, syncer.DB(), "messages", "session_id = ?", "duck-good", 1)
+	require.NotEmpty(t, progress)
+	last := progress[len(progress)-1]
+	assert.Equal(t, 2, last.SessionsDone)
+	assert.Equal(t, 2, last.SessionsTotal)
+	assert.Equal(t, 1, last.MessagesDone)
+	assert.Equal(t, 1, last.Errors)
+
+	watermark, err := local.GetSyncState(lastPushStateKey)
+	require.NoError(t, err)
+	assert.Empty(t, watermark)
+
+	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: syncSession(
+			"duck-bad", "alpha", "bad repaired",
+			"2026-01-10T00:00:00.000Z", 1,
+		),
+		Messages: []db.Message{
+			syncMessage(
+				"duck-bad", 0, "user", "bad repaired",
+				"2026-01-10T00:00:00.000Z",
+			),
+		},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, second.Errors)
+	assertDuckDBCountWhere(t, syncer.DB(), "sessions", "id = ?", "duck-bad", 1)
+	assertDuckDBCountWhere(t, syncer.DB(), "messages", "session_id = ?", "duck-bad", 1)
+	watermark, err = local.GetSyncState(lastPushStateKey)
+	require.NoError(t, err)
+	assert.NotEmpty(t, watermark)
+}
+
+func TestSyncPushSkipsCurationRefreshAfterSessionError(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	sessionID := "duck-bad-curation"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: syncSession(
+			sessionID, "alpha", "bad curation",
+			"2026-01-10T00:00:00.000Z", 1,
+		),
+		Messages: []db.Message{
+			syncMessage(
+				sessionID, 0, "user", "bad curation",
+				"not-a-timestamp",
+			),
+		},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+	ok, err := local.StarSession(sessionID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	msgs, err := local.GetAllMessages(ctx, sessionID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	note := "bad pin"
+	_, err = local.PinMessage(sessionID, msgs[0].ID, &note)
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	result, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Errors)
+	assertDuckDBCountWhere(t, syncer.DB(), "sessions", "id = ?", sessionID, 0)
+	assertDuckDBCountWhere(t, syncer.DB(), "pinned_messages", "session_id = ?", sessionID, 0)
+	assertDuckDBCountWhere(t, syncer.DB(), "starred_sessions", "session_id = ?", sessionID, 0)
+}
+
+func TestPushSessionBatchReturnsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	local := newLocalDB(t)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	var result PushResult
+	var pushed []db.Session
+
+	err := syncer.pushSessionBatch(
+		ctx,
+		[]db.Session{syncSession(
+			"duck-canceled", "alpha", "canceled",
+			"2026-01-10T00:00:00.000Z", 1,
+		)},
+		0, 1, &result, &pushed, nil,
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, result.Errors)
+	assert.Empty(t, pushed)
+}
+
+func TestPushSessionBatchLogsAbandonedSessionsAfterContextCancel(
+	t *testing.T,
+) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	local := newLocalDB(t)
+	sessions := make([]db.Session, 0, 3)
+	writes := make([]db.SessionBatchWrite, 0, 3)
+	for i := range 3 {
+		sessionID := fmt.Sprintf("duck-cancel-fallback-%d", i)
+		sess := syncSession(
+			sessionID, "alpha", "cancel fallback",
+			"2026-01-10T00:00:00.000Z", 1,
+		)
+		sessions = append(sessions, sess)
+		writes = append(writes, db.SessionBatchWrite{
+			Session: sess,
+			Messages: []db.Message{
+				syncMessage(
+					sessionID, 0, "user", "cancel fallback",
+					"not-a-timestamp",
+				),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		})
+	}
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	var result PushResult
+	var pushed []db.Session
+	var logs bytes.Buffer
+	oldLog := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(oldLog) })
+
+	err = syncer.pushSessionBatch(
+		ctx, sessions, 0, len(sessions), &result, &pushed,
+		func(p PushProgress) {
+			if p.SessionsDone == 1 {
+				cancel()
+			}
+		},
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 3, result.Errors)
+	assert.Empty(t, pushed)
+	gotLogs := logs.String()
+	assert.Equal(t, 1, strings.Count(gotLogs, "skipping session"))
+	assert.Contains(t, gotLogs, "abandoning 2 sessions")
+}
+
+func TestSyncPushReportsSessionDiagnosticsByAgent(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	seedDuckDBSyncFixture(t, local)
+	codexID := "duck-sync-codex"
+	codexSession := syncSession(
+		codexID, "gamma", "codex first",
+		"2026-01-12T00:00:00.000Z", 1,
+	)
+	codexSession.Agent = "codex"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: codexSession,
+		Messages: []db.Message{
+			syncMessage(
+				codexID, 0, "user", "codex first",
+				"2026-01-12T00:00:00.000Z",
+			),
+		},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	result, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+
+	wantByAgent := map[string]int{"claude": 2, "codex": 1}
+	assert.True(t, result.Diagnostics.Full)
+	assert.Empty(t, result.Diagnostics.LastPushAt)
+	assert.Equal(t, 3, result.Diagnostics.LocalSessions.Total)
+	assert.Equal(t, wantByAgent, result.Diagnostics.LocalSessions.ByAgent)
+	assert.Equal(t, 3, result.Diagnostics.CandidateSessions.Total)
+	assert.Equal(t, wantByAgent, result.Diagnostics.CandidateSessions.ByAgent)
+	assert.Equal(t, 0, result.Diagnostics.SkippedUnchangedSessions.Total)
+	assert.Empty(t, result.Diagnostics.SkippedUnchangedSessions.ByAgent)
+	assert.Equal(t, 3, result.Diagnostics.PushedSessions.Total)
+	assert.Equal(t, wantByAgent, result.Diagnostics.PushedSessions.ByAgent)
+	assert.NotEmpty(t, result.Diagnostics.Cutoff)
+}
+
+func TestSyncPushReportsProgressAcrossBatchBoundaries(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	count := duckSessionPushBatchSize + 1
+	writes := make([]db.SessionBatchWrite, 0, count)
+	for i := range count {
+		sessionID := fmt.Sprintf("duck-batch-%03d", i)
+		ts := fmt.Sprintf("2026-01-12T00:%02d:00.000Z", i%60)
+		writes = append(writes, db.SessionBatchWrite{
+			Session: syncSession(
+				sessionID, "alpha", "batch first", ts, 1,
+			),
+			Messages: []db.Message{
+				syncMessage(
+					sessionID, 0, "user", "batch first", ts,
+				),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		})
+	}
+	_, err := local.WriteSessionBatchAtomic(writes)
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	var progress []PushProgress
+
+	result, err := syncer.Push(ctx, true, func(p PushProgress) {
+		progress = append(progress, p)
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, count, result.SessionsPushed)
+	assert.Equal(t, count, result.MessagesPushed)
+	assert.Equal(t, 0, result.Errors)
+	require.Len(t, progress, count)
+	assert.Equal(t, duckSessionPushBatchSize, progress[duckSessionPushBatchSize-1].SessionsDone)
+	assert.Equal(t, count, progress[duckSessionPushBatchSize].SessionsDone)
+	assert.Equal(t, count, progress[duckSessionPushBatchSize].SessionsTotal)
+	assert.Equal(t, count, progress[duckSessionPushBatchSize].MessagesDone)
+}
+
+func TestDuckValueLiteralFormatsTimestampWithoutZone(t *testing.T) {
+	got, err := duckValueLiteral(time.Date(
+		2026, time.January, 10, 3, 4, 5, 123456789, time.UTC,
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, "TIMESTAMP '2026-01-10 03:04:05.123456'", got)
+}
+
+func TestDuckSQLWithArgsExecutesQuotedMultilineString(t *testing.T) {
+	ctx := context.Background()
+	duck := openTestDuckDB(t)
+	want := "first line\nquoted ' value\ncontains $$ delimiter text"
+
+	stmt, err := duckSQLWithArgs(`SELECT ?`, want)
+	require.NoError(t, err)
+
+	var got string
+	require.NoError(t, duck.QueryRowContext(ctx, stmt).Scan(&got))
+	assert.Equal(t, want, got)
+}
+
+func TestDuckSQLWithArgsStripsNULFromStringLiteral(t *testing.T) {
+	ctx := context.Background()
+	duck := openTestDuckDB(t)
+
+	stmt, err := duckSQLWithArgs(`SELECT ?`, "before\x00after")
+	require.NoError(t, err)
+
+	var got string
+	require.NoError(t, duck.QueryRowContext(ctx, stmt).Scan(&got))
+	assert.Equal(t, "beforeafter", got)
+}
+
+func TestDuckSQLWithArgsExecutesStringPointer(t *testing.T) {
+	ctx := context.Background()
+	duck := openTestDuckDB(t)
+	want := "pinned note\nquoted ' value"
+
+	stmt, err := duckSQLWithArgs(`SELECT ?`, &want)
+	require.NoError(t, err)
+
+	var got string
+	require.NoError(t, duck.QueryRowContext(ctx, stmt).Scan(&got))
+	assert.Equal(t, want, got)
+}
+
+func TestExecDuckRemoteMutationBatchCoalescesSuccessfulBatch(t *testing.T) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+	_, err = batch.ExecContext(ctx, `DELETE FROM remote_test WHERE id = ?`, 2)
+	require.NoError(t, err)
+	var calls []string
+
+	err = execDuckRemoteMutationBatch(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			calls = append(calls, sqlText)
+			return nil
+		},
+		"test batch",
+		batch,
+		true,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, `BEGIN TRANSACTION;
+INSERT INTO remote_test VALUES (1);
+DELETE FROM remote_test WHERE id = 2;
+COMMIT`, calls[0])
+}
+
+func TestExecDuckRemoteMutationBatchCoalescedFailureRollsBack(t *testing.T) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+	var calls []string
+
+	err = execDuckRemoteMutationBatch(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			calls = append(calls, sqlText)
+			if sqlText == "ROLLBACK" {
+				return nil
+			}
+			return fmt.Errorf("batch failed")
+		},
+		"test batch",
+		batch,
+		true,
+	)
+
+	require.ErrorContains(t, err, "batch failed")
+	require.Len(t, calls, 2)
+	assert.Contains(t, calls[0], "BEGIN TRANSACTION")
+	assert.Equal(t, "ROLLBACK", calls[1])
+}
+
+func TestExecDuckRemoteMutationBatchCoalescedRollbackFailureIsWrapped(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+
+	err = execDuckRemoteMutationBatch(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			if sqlText == "ROLLBACK" {
+				return fmt.Errorf("rollback failed")
+			}
+			return fmt.Errorf("batch failed")
+		},
+		"test batch",
+		batch,
+		true,
+	)
+
+	require.ErrorContains(t, err, "batch failed")
+	assert.ErrorContains(t, err, "rollback test batch")
+	assert.ErrorContains(t, err, "rollback failed")
+}
+
+func TestAppendDuckRemoteMutationBatchFlushesBeforeByteBudget(t *testing.T) {
+	ctx := context.Background()
+	first := &duckRemoteMutationBatch{}
+	_, err := first.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 1, "first",
+	)
+	require.NoError(t, err)
+	second := &duckRemoteMutationBatch{}
+	_, err = second.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 2, "second",
+	)
+	require.NoError(t, err)
+	maxBytes := first.combinedTransactionBytes(second) - 1
+	current := &duckRemoteMutationBatch{}
+	var calls []string
+	exec := func(_ context.Context, sqlText string) error {
+		calls = append(calls, sqlText)
+		return nil
+	}
+
+	current, err = appendDuckRemoteMutationBatch(
+		ctx, exec, exec, "test batch", current, first, maxBytes,
+	)
+	require.NoError(t, err)
+	current, err = appendDuckRemoteMutationBatch(
+		ctx, exec, exec, "test batch", current, second, maxBytes,
+	)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Contains(t, calls[0], "$")
+	assert.Contains(t, calls[0], "first")
+	assert.NotContains(t, calls[0], "second")
+
+	require.NoError(t, execDuckRemoteMutationBatch(
+		ctx, exec, "test batch", current, true,
+	))
+	require.Len(t, calls, 2)
+	assert.Contains(t, calls[1], "second")
+}
+
+func TestAppendDuckRemoteMutationBatchUsesStatementModeForOversizeSession(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	oversize := &duckRemoteMutationBatch{}
+	_, err := oversize.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 1, strings.Repeat("x", 64),
+	)
+	require.NoError(t, err)
+	maxBytes := oversize.transactionBytes() - 1
+	var calls []string
+
+	current, err := appendDuckRemoteMutationBatch(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			calls = append(calls, sqlText)
+			return nil
+		},
+		func(_ context.Context, sqlText string) error {
+			calls = append(calls, sqlText)
+			return nil
+		},
+		"oversize session",
+		&duckRemoteMutationBatch{},
+		oversize,
+		maxBytes,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, current.Len())
+	assert.Equal(t, "BEGIN TRANSACTION", calls[0])
+	assert.Contains(t, calls[1], "INSERT INTO remote_test")
+	assert.Equal(t, "COMMIT", calls[2])
+}
+
+func TestAppendDuckRemoteMutationBatchFlushesCurrentBeforeOversizeSession(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	current := &duckRemoteMutationBatch{}
+	_, err := current.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 1, "current",
+	)
+	require.NoError(t, err)
+	oversize := &duckRemoteMutationBatch{}
+	_, err = oversize.ExecContext(ctx,
+		`INSERT INTO remote_test VALUES (?, ?)`, 2, strings.Repeat("x", 64),
+	)
+	require.NoError(t, err)
+	maxBytes := oversize.transactionBytes() - 1
+	var calls []string
+
+	next, err := appendDuckRemoteMutationBatch(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			calls = append(calls, sqlText)
+			return nil
+		},
+		func(_ context.Context, sqlText string) error {
+			calls = append(calls, sqlText)
+			return nil
+		},
+		"oversize session",
+		current,
+		oversize,
+		maxBytes,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, next.Len())
+	require.Len(t, calls, 4)
+	assert.Equal(t, current.transactionSQL(), calls[0])
+	assert.Equal(t, "BEGIN TRANSACTION", calls[1])
+	assert.Contains(t, calls[2], "INSERT INTO remote_test")
+	assert.Contains(t, calls[2], strings.Repeat("x", 64))
+	assert.Equal(t, "COMMIT", calls[3])
+}
+
+func TestExecDuckRemoteMutationBatchStatementModePinpointsFailure(t *testing.T) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+	_, err = batch.ExecContext(ctx, `DELETE FROM remote_test WHERE id = ?`, 2)
+	require.NoError(t, err)
+	var calls []string
+
+	err = execDuckRemoteMutationBatch(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			calls = append(calls, sqlText)
+			if strings.HasPrefix(sqlText, "DELETE") {
+				return fmt.Errorf("delete failed")
+			}
+			return nil
+		},
+		"test session",
+		batch,
+		false,
+	)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "execute test session statement 2/2")
+	assert.Equal(t, []string{
+		"BEGIN TRANSACTION",
+		"INSERT INTO remote_test VALUES (1)",
+		"DELETE FROM remote_test WHERE id = 2",
+		"ROLLBACK",
+	}, calls)
+}
+
+func TestExecDuckRemoteMutationBatchFallbackLocalizesNonStaleFailure(t *testing.T) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+	_, err = batch.ExecContext(ctx, `DELETE FROM remote_test WHERE id = ?`, 2)
+	require.NoError(t, err)
+	var coalescedCalls []string
+	var statementCalls []string
+
+	err = execDuckRemoteMutationBatchWithStatementFallback(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			coalescedCalls = append(coalescedCalls, sqlText)
+			if sqlText == "ROLLBACK" {
+				return nil
+			}
+			return fmt.Errorf("coalesced failure")
+		},
+		func(_ context.Context, sqlText string) error {
+			statementCalls = append(statementCalls, sqlText)
+			if strings.HasPrefix(sqlText, "DELETE") {
+				return fmt.Errorf("delete failed")
+			}
+			return nil
+		},
+		"test session",
+		batch,
+	)
+	require.Error(t, err)
+
+	assert.Equal(t, []string{batch.transactionSQL(), "ROLLBACK"}, coalescedCalls)
+	assert.Contains(t, err.Error(), "execute test session statement 2/2")
+	assert.Equal(t, []string{
+		"BEGIN TRANSACTION",
+		"INSERT INTO remote_test VALUES (1)",
+		"DELETE FROM remote_test WHERE id = 2",
+		"ROLLBACK",
+	}, statementCalls)
+}
+
+func TestExecDuckRemoteMutationBatchFallbackDoesNotRetryStaleFailure(t *testing.T) {
+	ctx := context.Background()
+	batch := &duckRemoteMutationBatch{}
+	_, err := batch.ExecContext(ctx, `INSERT INTO remote_test VALUES (?)`, 1)
+	require.NoError(t, err)
+	var statementCalls []string
+
+	err = execDuckRemoteMutationBatchWithStatementFallback(
+		ctx,
+		func(_ context.Context, sqlText string) error {
+			if sqlText == "ROLLBACK" {
+				return nil
+			}
+			return fmt.Errorf("Invalid Input Error: Invalid connection id")
+		},
+		func(_ context.Context, sqlText string) error {
+			statementCalls = append(statementCalls, sqlText)
+			return nil
+		},
+		"test session",
+		batch,
+	)
+	require.ErrorContains(t, err, "Invalid connection id")
+	assert.Empty(t, statementCalls)
+}
+
+func TestDuckValueLiteralFormatsNullableNumericPointers(t *testing.T) {
+	score := 88
+	fileSize := int64(4096)
+	contextPressure := 0.875
+
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{name: "int pointer", in: &score, want: "88"},
+		{name: "int64 pointer", in: &fileSize, want: "4096"},
+		{name: "float64 pointer", in: &contextPressure, want: "0.875"},
+		{name: "nil int pointer", in: (*int)(nil), want: "NULL"},
+		{name: "nil int64 pointer", in: (*int64)(nil), want: "NULL"},
+		{name: "nil float64 pointer", in: (*float64)(nil), want: "NULL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := duckValueLiteral(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestSessionFingerprintsStoreDigestOnly(t *testing.T) {

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -954,12 +954,12 @@ func TestExecDuckRemoteMutationBatchOversizeUsesStatementModeTransaction(
 	require.NoError(t, err)
 
 	assert.Empty(t, coalescedCalls)
-	require.Len(t, statementCalls, 5)
+	require.Len(t, statementCalls, 3)
 	assert.Equal(t, "BEGIN TRANSACTION", statementCalls[0])
 	assert.Contains(t, statementCalls[1], "INSERT INTO remote_test VALUES (1, $")
-	assert.Contains(t, statementCalls[2], "INSERT INTO remote_test VALUES (2, $")
-	assert.Contains(t, statementCalls[3], "INSERT INTO remote_test VALUES (3, $")
-	assert.Equal(t, "COMMIT", statementCalls[4])
+	assert.Contains(t, statementCalls[1], "), (2, $")
+	assert.Contains(t, statementCalls[1], "), (3, $")
+	assert.Equal(t, "COMMIT", statementCalls[2])
 }
 
 func TestAppendDuckRemoteMutationBatchRejectsOversizeSessionAfterFlush(

--- a/internal/server/huma_routes_push.go
+++ b/internal/server/huma_routes_push.go
@@ -157,6 +157,9 @@ func (s *Server) humaDuckDBPush(
 	if err != nil {
 		return nil, apiError(http.StatusBadRequest, err.Error())
 	}
+	if err := duckdbsync.ValidatePushTarget(duckCfg); err != nil {
+		return nil, apiError(http.StatusBadRequest, err.Error())
+	}
 
 	engine := s.syncEngineForLocal(local)
 	opts := duckDBPushSyncOptions(in.Body, duckCfg)

--- a/internal/server/huma_routes_push_internal_test.go
+++ b/internal/server/huma_routes_push_internal_test.go
@@ -133,6 +133,25 @@ func TestDuckDBPushRejectsIncludeAndExcludeProjects(t *testing.T) {
 		"projects and exclude_projects are mutually exclusive")
 }
 
+func TestDuckDBPushRejectsMissingQuackTokenAsBadRequest(t *testing.T) {
+	s := testServer(t, 30)
+
+	_, err := s.humaDuckDBPush(context.Background(), &daemonPushInput{
+		Body: daemonPushRequest{
+			DuckDB: &config.DuckDBConfig{
+				URL:         "quack:https://duck.example.test",
+				MachineName: "workstation",
+			},
+		},
+	})
+	require.Error(t, err)
+
+	var statusErr interface{ GetStatus() int }
+	require.ErrorAs(t, err, &statusErr)
+	assert.Equal(t, http.StatusBadRequest, statusErr.GetStatus())
+	assert.Contains(t, err.Error(), "duckdb quack token is required")
+}
+
 func TestDuckDBPushConfigRequestOverrideSkipsDaemonEnvResolution(t *testing.T) {
 	const envName = "AGENTSVIEW_TEST_MISSING_DUCKDB_PATH_25053"
 	s := testServerWithConfig(config.Config{

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3428,9 +3428,10 @@ type processResult struct {
 	// forceReplace requests full message replacement on write,
 	// even when the existing rows would otherwise be left in
 	// place. Set when a fall-through to full parse is recovering
-	// from a cross-sync streaming split: the new merged messages
-	// reuse the existing ordinals, so the default append-only
-	// writeMessages would silently drop the rewrite.
+	// from stale stored rows, such as an atomic file replacement
+	// or cross-sync streaming split. In those cases the parsed
+	// messages can reuse existing ordinals, so the default
+	// append-only writeMessages would silently drop the rewrite.
 	forceReplace bool
 	cacheKey     string
 	// retrySessionIDs carries provider per-result data-version state.
@@ -3647,11 +3648,16 @@ func (e *Engine) processProviderFile(
 	// parse entirely. This reproduces the legacy process arm's
 	// shouldSkipFile gate so an unchanged session is not re-parsed on
 	// every full sync.
-	if mtime, fresh := e.providerSingleSessionFresh(ctx, provider, source, file); fresh {
+	sourceForceReplace := false
+	if mtime, fresh, forceReplace := e.providerSingleSessionFresh(
+		ctx, provider, source, file,
+	); fresh {
 		return processResult{
 			skip:  true,
 			mtime: mtime,
 		}, true
+	} else if forceReplace {
+		sourceForceReplace = true
 	}
 	if freshMtime, fresh := e.providerSourceFreshBeforeFingerprint(source, file); fresh {
 		return processResult{
@@ -3720,7 +3726,7 @@ func (e *Engine) processProviderFile(
 		incRes.cacheKey = cacheKey
 		return incRes, true
 	}
-	incForceReplace := incRes.forceReplace
+	incForceReplace := sourceForceReplace || incRes.forceReplace
 
 	// DB-stored fingerprint skip. The provider has no database handle, so the
 	// engine reproduces the legacy DB-aware skip that single-session JSONL
@@ -3730,7 +3736,7 @@ func (e *Engine) processProviderFile(
 	// engine). For Codex this also folds in the session_index.jsonl sidecar:
 	// a shared index mtime bump that did not change this session's title must
 	// not trigger a reparse.
-	if !e.forceParse && !file.ForceParse &&
+	if !incForceReplace && !e.forceParse && !file.ForceParse &&
 		e.shouldSkipProviderSourceByDB(file, fingerprint) {
 		return processResult{
 			skip:        true,
@@ -3751,7 +3757,7 @@ func (e *Engine) processProviderFile(
 	// a provider whose fingerprint mtime differs from the stored value simply
 	// reparses, matching the prior behavior. Claude and Cowork have their own
 	// earlier freshness checks; this is the generic fallback for the rest.
-	if !e.forceParse && !file.ForceParse &&
+	if !incForceReplace && !e.forceParse && !file.ForceParse &&
 		e.providerSourceUnchangedInDB(source, fingerprint) {
 		return processResult{
 			skip:      true,
@@ -4446,7 +4452,7 @@ func (e *Engine) providerSingleSessionFresh(
 	provider parser.Provider,
 	source parser.SourceRef,
 	file parser.DiscoveredFile,
-) (int64, bool) {
+) (int64, bool, bool) {
 	// Match the legacy shouldSkipFile gate, which keyed off the
 	// engine-wide forceParse (parse-diff) flag only. A per-file
 	// ForceParse (set by SyncSingleSession to bypass the error skip
@@ -4454,7 +4460,7 @@ func (e *Engine) providerSingleSessionFresh(
 	// is still skipped so a single-session resync does not, for example,
 	// reapply a worktree project mapping to a file that has not changed.
 	if e.forceParse {
-		return 0, false
+		return 0, false, false
 	}
 	// Claude is the single-physical-file provider that takes the
 	// append-only incremental path. Its source stem is the session ID,
@@ -4462,15 +4468,15 @@ func (e *Engine) providerSingleSessionFresh(
 	// can later split the file into several sessions.
 	if provider.Capabilities().Source.IncrementalAppend !=
 		parser.CapabilitySupported {
-		return 0, false
+		return 0, false, false
 	}
 	path := providerDiscoveredPath(source)
 	if path == "" {
-		return 0, false
+		return 0, false, false
 	}
 	sessionID := claudeSessionIDFromPath(path)
 	if sessionID == "" {
-		return 0, false
+		return 0, false, false
 	}
 	lookupPath := path
 	if e.pathRewriter != nil {
@@ -4480,16 +4486,32 @@ func (e *Engine) providerSingleSessionFresh(
 	if err != nil {
 		info, err = os.Stat(path)
 		if err != nil {
-			return 0, false
+			return 0, false, false
 		}
 	}
 	if !e.shouldSkipFile(sessionID, info) {
-		return 0, false
+		return 0, false, false
+	}
+	if e.providerIncrementalIdentityChanged(lookupPath, info) {
+		return 0, false, true
 	}
 	sess, _ := e.db.GetSession(ctx, e.idPrefix+sessionID)
 	return info.ModTime().UnixNano(), sess != nil &&
 		sess.Project != "" &&
-		!parser.NeedsProjectReparse(sess.Project)
+		!parser.NeedsProjectReparse(sess.Project), false
+}
+
+func (e *Engine) providerIncrementalIdentityChanged(
+	lookupPath string,
+	info os.FileInfo,
+) bool {
+	if e.pathRewriter != nil {
+		// Remote imports rewrite per-run temp paths to stable source paths;
+		// the temp inode is expected to change between identical downloads.
+		return false
+	}
+	curInode, curDevice := getFileIdentity(info)
+	return e.db.FileIdentityChanged(lookupPath, curInode, curDevice)
 }
 
 func (e *Engine) providerSourceFreshBeforeFingerprint(
@@ -4722,7 +4744,7 @@ func (e *Engine) tryIncrementalJSONL(
 	// state. Only check when both sides have a known identity
 	// (non-zero); zeros mean the data is missing or the
 	// platform doesn't expose inode/device (Windows).
-	if inc.FileInode != 0 && inc.FileDevice != 0 {
+	if e.pathRewriter == nil && inc.FileInode != 0 && inc.FileDevice != 0 {
 		curInode, curDevice := getFileIdentity(info)
 		if curInode != 0 && curDevice != 0 &&
 			(curInode != inc.FileInode ||

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -7864,6 +7864,194 @@ func TestIncrementalSync_ClaudeSameSizeFileReplaceUsesFullParse(t *testing.T) {
 	assert.Equal(t, "bravo", msgs[1].Content)
 }
 
+func TestIncrementalSync_ClaudeSameSizeSameMtimeFileReplaceUsesFullParse(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("identity tracking is a no-op on Windows")
+	}
+	env := setupTestEnv(t)
+
+	original := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsZero),
+		testjsonl.ClaudeAssistantJSON("alpha", tsZeroS5),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "same-size-same-mtime-replace.jsonl", original,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	full, err := env.db.GetSessionFull(
+		context.Background(), "same-size-same-mtime-replace",
+	)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, full.FileInode, "file_inode not populated after initial sync")
+	origInode := *full.FileInode
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat original")
+	originalMtime := info.ModTime()
+
+	replacement := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("third", tsZero),
+		testjsonl.ClaudeAssistantJSON("bravo", tsZeroS5),
+	)
+	require.Len(t, replacement, len(original), "replacement fixture must keep same byte size")
+	tmp := path + ".tmp"
+	require.NoError(t, os.WriteFile(tmp, []byte(replacement), 0o644), "write replacement")
+	require.NoError(t, os.Rename(tmp, path), "rename replacement")
+	require.NoError(t, os.Chtimes(path, originalMtime, originalMtime), "restore replacement mtime")
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "same-size-same-mtime-replace")
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "third", msgs[0].Content)
+	assert.Equal(t, "bravo", msgs[1].Content)
+	full, err = env.db.GetSessionFull(
+		context.Background(), "same-size-same-mtime-replace",
+	)
+	require.NoError(t, err, "GetSessionFull after replace")
+	require.NotNil(t, full.FileInode, "file_inode cleared after replace")
+	assert.NotEqual(t, origInode, *full.FileInode)
+}
+
+func TestIncrementalSync_ClaudeForkSameSizeSameMtimeFileReplaceUsesFullParse(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("identity tracking is a no-op on Windows")
+	}
+	env := setupTestEnv(t)
+
+	original := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithUUID("2024-01-01T10:00:00Z", "start", "a", "").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:01Z", "ok", "b", "a").
+		AddClaudeUserWithUUID("2024-01-01T10:00:02Z", "step2", "c", "b").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:03Z", "ok2", "d", "c").
+		AddClaudeUserWithUUID("2024-01-01T10:00:04Z", "step3", "e", "d").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:05Z", "ok3", "f", "e").
+		AddClaudeUserWithUUID("2024-01-01T10:00:06Z", "step4", "g", "f").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:07Z", "ok4", "h", "g").
+		AddClaudeUserWithUUID("2024-01-01T10:00:08Z", "step5", "k", "h").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:09Z", "ok5", "l", "k").
+		AddClaudeUserWithUUID("2024-01-01T10:01:00Z", "fork-start", "i", "b").
+		AddClaudeAssistantWithUUID("2024-01-01T10:01:01Z", "fork-ok", "j", "i").
+		String()
+	path := env.writeClaudeSession(
+		t, "proj", "same-size-same-mtime-fork-replace.jsonl", original,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	assertSessionMessageCount(t, env.db, "same-size-same-mtime-fork-replace", 10)
+	assertSessionMessageCount(t, env.db, "same-size-same-mtime-fork-replace-i", 2)
+	full, err := env.db.GetSessionFull(
+		context.Background(), "same-size-same-mtime-fork-replace",
+	)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, full.FileInode, "file_inode not populated after initial sync")
+	origInode := *full.FileInode
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat original")
+	originalMtime := info.ModTime()
+
+	replacement := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithUUID("2024-01-01T10:00:00Z", "START", "a", "").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:01Z", "no", "b", "a").
+		AddClaudeUserWithUUID("2024-01-01T10:00:02Z", "STEP2", "c", "b").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:03Z", "NO2", "d", "c").
+		AddClaudeUserWithUUID("2024-01-01T10:00:04Z", "STEP3", "e", "d").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:05Z", "NO3", "f", "e").
+		AddClaudeUserWithUUID("2024-01-01T10:00:06Z", "STEP4", "g", "f").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:07Z", "NO4", "h", "g").
+		AddClaudeUserWithUUID("2024-01-01T10:00:08Z", "STEP5", "k", "h").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:09Z", "NO5", "l", "k").
+		AddClaudeUserWithUUID("2024-01-01T10:01:00Z", "fork-other", "i", "b").
+		AddClaudeAssistantWithUUID("2024-01-01T10:01:01Z", "FORK-NO", "j", "i").
+		String()
+	require.Len(t, replacement, len(original), "replacement fixture must keep same byte size")
+	tmp := path + ".tmp"
+	require.NoError(t, os.WriteFile(tmp, []byte(replacement), 0o644), "write replacement")
+	require.NoError(t, os.Rename(tmp, path), "rename replacement")
+	require.NoError(t, os.Chtimes(path, originalMtime, originalMtime), "restore replacement mtime")
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "same-size-same-mtime-fork-replace")
+	require.Len(t, msgs, 10)
+	assert.Equal(t, "START", msgs[0].Content)
+	assert.Equal(t, "NO5", msgs[9].Content)
+	forkMsgs := fetchMessages(t, env.db, "same-size-same-mtime-fork-replace-i")
+	require.Len(t, forkMsgs, 2)
+	assert.Equal(t, "fork-other", forkMsgs[0].Content)
+	assert.Equal(t, "FORK-NO", forkMsgs[1].Content)
+	full, err = env.db.GetSessionFull(
+		context.Background(), "same-size-same-mtime-fork-replace",
+	)
+	require.NoError(t, err, "GetSessionFull after replace")
+	require.NotNil(t, full.FileInode, "file_inode cleared after replace")
+	assert.NotEqual(t, origInode, *full.FileInode)
+}
+
+func TestIncrementalSync_ClaudePathRewriterIgnoresTempInodeChange(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("identity tracking is a no-op on Windows")
+	}
+	db := dbtest.OpenTestDB(t)
+	firstRoot := t.TempDir()
+	secondRoot := t.TempDir()
+	const remoteRoot = "/home/test/.claude/projects"
+	rewriter := func(p string) string {
+		for _, root := range []string{firstRoot, secondRoot} {
+			rel, err := filepath.Rel(root, p)
+			if err == nil && !strings.HasPrefix(rel, "..") {
+				return "host:" + filepath.ToSlash(
+					filepath.Join(remoteRoot, rel),
+				)
+			}
+		}
+		return "host:" + filepath.ToSlash(p)
+	}
+	content := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsZero),
+		testjsonl.ClaudeAssistantJSON("alpha", tsZeroS5),
+	)
+	firstPath := filepath.Join(firstRoot, "proj", "remote-same.jsonl")
+	dbtest.WriteTestFile(t, firstPath, []byte(content))
+	firstInfo, err := os.Stat(firstPath)
+	require.NoError(t, err, "stat first temp copy")
+	firstEngine := sync.NewEngine(db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {firstRoot},
+		},
+		Machine:      "host",
+		IDPrefix:     "host~",
+		PathRewriter: rewriter,
+		Ephemeral:    true,
+	})
+	runSyncAndAssert(t, firstEngine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	secondPath := filepath.Join(secondRoot, "proj", "remote-same.jsonl")
+	dbtest.WriteTestFile(t, secondPath, []byte(content))
+	require.NoError(t,
+		os.Chtimes(secondPath, firstInfo.ModTime(), firstInfo.ModTime()),
+		"preserve remote mtime on second temp copy",
+	)
+	secondEngine := sync.NewEngine(db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {secondRoot},
+		},
+		Machine:      "host",
+		IDPrefix:     "host~",
+		PathRewriter: rewriter,
+		Ephemeral:    true,
+	})
+	runSyncAndAssert(t, secondEngine, sync.SyncStats{
+		TotalSessions: 1, Synced: 0, Skipped: 1,
+	})
+}
+
 func TestIncrementalSync_ClaudeSameSizeInPlaceRewriteClearsStaleRows(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
 

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1351,10 +1351,14 @@ func TestProcessAntigravityBrainOnlyUpdateNotSkipped(t *testing.T) {
 	// Brain-only update: the conversation DB files are untouched.
 	brainDir := filepath.Join(root, "brain", id)
 	require.NoError(t, os.MkdirAll(brainDir, 0o755))
+	brainPath := filepath.Join(brainDir, "task.md")
 	require.NoError(t, os.WriteFile(
-		filepath.Join(brainDir, "task.md"),
-		[]byte("brain artifact body"), 0o644,
+		brainPath, []byte("brain artifact body"), 0o644,
 	))
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err)
+	brainTime := info.ModTime().Add(5 * time.Second)
+	require.NoError(t, os.Chtimes(brainPath, brainTime, brainTime))
 
 	res = e.processFile(ctx, file)
 	require.False(t, res.skip,

--- a/internal/sync/validate_test.go
+++ b/internal/sync/validate_test.go
@@ -303,6 +303,43 @@ func TestSanitizeMessageContentLengthDelta(t *testing.T) {
 	})
 }
 
+func TestSanitizeMessageStripsNULFromResultContent(t *testing.T) {
+	resultRaw := "tool\x00result"
+	resultClean := "toolresult"
+	eventRaw := "event\x00content"
+	eventClean := "eventcontent"
+	m := db.Message{
+		Role: "assistant",
+		ToolCalls: []db.ToolCall{{
+			ToolUseID:           "tu1",
+			ToolName:            "Bash",
+			Category:            "Bash",
+			ResultContent:       resultRaw,
+			ResultContentLength: len(resultRaw),
+			ResultEvents: []db.ToolResultEvent{{
+				Source:        "wait_output",
+				Status:        "completed",
+				Content:       eventRaw,
+				ContentLength: len(eventRaw),
+			}},
+		}},
+	}
+
+	stats := sanitizeMessage(&m)
+
+	require.Len(t, m.ToolCalls, 1)
+	tc := m.ToolCalls[0]
+	assert.Equal(t, resultClean, tc.ResultContent)
+	assert.Equal(t, len(resultClean), tc.ResultContentLength)
+	require.Len(t, tc.ResultEvents, 1)
+	assert.Equal(t, eventClean, tc.ResultEvents[0].Content)
+	assert.Equal(t, len(eventClean), tc.ResultEvents[0].ContentLength)
+	assert.Equal(t, 2, stats.ControlCharsStripped)
+
+	second := sanitizeMessage(&m)
+	assert.Equal(t, validationStats{}, second, "second pass must be a no-op")
+}
+
 func TestSanitizeUsageEvent(t *testing.T) {
 	ev := db.UsageEvent{
 		Source:                   "api\x1bcall",
@@ -426,6 +463,19 @@ func TestValidateAndSanitizeIdempotent(t *testing.T) {
 			OutputTokens:  -10,
 			Timestamp:     "2999-01-01T00:00:00Z",
 			SourceUUID:    "uuid\x00val",
+			ToolCalls: []db.ToolCall{{
+				ToolUseID:           "tu1",
+				ToolName:            "Bash",
+				Category:            "Bash",
+				ResultContent:       "tool\x00result",
+				ResultContentLength: len("tool\x00result"),
+				ResultEvents: []db.ToolResultEvent{{
+					Source:        "wait_output",
+					Status:        "completed",
+					Content:       "event\x00content",
+					ContentLength: len("event\x00content"),
+				}},
+			}},
 		},
 		{
 			Role:      "assistant",


### PR DESCRIPTION
Pushing to a Quack-backed DuckDB was broken in layers: schema setup issued `CREATE INDEX` against proxy tables and failed instantly; one poisoned row (a NUL byte in stored tool output) aborted the entire single-transaction push, forever; every statement paid its own HTTPS round trip (a measured 15,000x below line rate); and any server restart permanently stranded every connected client. This PR makes Quack push and serve correct first, then fast.

**Correctness**

- Schema setup, status/store reads, and mutations now use call shapes Quack attachments can actually execute; index and migration work runs only on the real server database.
- NUL bytes are stripped from persisted tool result content at ingest, with a data-version bump so existing rows are re-ingested. DuckDB VARCHARs cannot hold them, and one such row poisoned every push.
- Session batches commit in explicit server-side transactions. A failed batch retries per session; a persistently failing session is skipped and counted instead of aborting the run. Context cancellation stays fatal, and the sync watermark only advances on clean runs.
- Clients recover from server restarts: stale or detached attachments are detected and re-attached on one pinned connection, with a single retry for self-contained calls. Previously every client failed with `Invalid connection id` until process restart. Attach errors scrub credentials.

**Performance**

- Batches coalesce into one multi-statement `BEGIN`/`COMMIT` `query()` call instead of one round trip per statement.
- Batches are bounded by rendered bytes (2 MiB) so each POST executes within the Quack client's fixed 120 s deadline on small servers. Oversized single sessions leave the coalesced path and execute rendered mutation groups inside one remote transaction, preserving session atomicity without returning to per-row round trips.
- Adjacent single-row INSERTs render as bounded multi-row `VALUES` statements (~10x less server-side parse/dispatch), and tool rows push as read-free delete+insert instead of per-row existence checks that previously cost hundreds of thousands of serial reads per catch-up.
- A timed-out coalesced batch may still be executing server-side, so timeouts back off and retry once instead of immediately grinding per-session retries against the abandoned writer.

**Tradeoffs**

- The 120 s HTTP deadline is hard-coded in the Quack extension (its ATTACH `TIMEOUT` option is ignored), so this PR sizes normal coalesced work under the deadline rather than raising it.
- Oversized sessions can still be slower than normal coalesced batches, but they keep delete-and-replace work atomic while using rendered INSERT groups to avoid per-row round trips.
- The per-session retry path deliberately keeps statement-by-statement execution so a failing session still reports the exact statement that rejected it.

Core changes in `internal/duckdb/{sync,push,connect}.go`; real-server coverage, including restart recovery and rollback behavior, in `internal/duckdb/quack_smoke_duckdbtest_test.go`.
