### PR TITLE
fix(db): backfill worktree mappings for empty cwd rows

### DIFF
--- a/internal/db/worktree_mappings.go
+++ b/internal/db/worktree_mappings.go
@@ -433,10 +433,12 @@ func bestWorktreeProjectMapping(
 }
 
 type worktreeMappingSessionRow struct {
-	id      string
-	machine string
-	project string
-	cwd     string
+	id       string
+	machine  string
+	project  string
+	cwd      string
+	filePath string
+	matchCwd string
 }
 
 type worktreeMappingSessionUpdate struct {
@@ -517,7 +519,11 @@ func applyMappingToSessionRow(
 	mappings []WorktreeProjectMapping,
 	row worktreeMappingSessionRow,
 ) (worktreeMappingSessionUpdate, bool, bool) {
-	mapping, ok := bestWorktreeProjectMapping(mappings, row.cwd)
+	matchCwd := row.matchCwd
+	if matchCwd == "" {
+		matchCwd = row.cwd
+	}
+	mapping, ok := bestWorktreeProjectMapping(mappings, matchCwd)
 	if !ok {
 		return worktreeMappingSessionUpdate{}, false, false
 	}
@@ -531,6 +537,31 @@ func applyMappingToSessionRow(
 		currentProject: row.project,
 		nextProject:    mapping.Project,
 	}, true, true
+}
+
+func applyWorktreeMappingMatchCwdFromSiblings(
+	rows []worktreeMappingSessionRow,
+	siblingKey func(worktreeMappingSessionRow) string,
+) {
+	fallbackBySibling := map[string]string{}
+	for _, row := range rows {
+		key := siblingKey(row)
+		if key == "" || row.cwd == "" {
+			continue
+		}
+		if _, ok := fallbackBySibling[key]; !ok {
+			fallbackBySibling[key] = row.cwd
+		}
+	}
+
+	for i, row := range rows {
+		row.matchCwd = row.cwd
+		key := siblingKey(row)
+		if row.cwd == "" && key != "" {
+			row.matchCwd = fallbackBySibling[key]
+		}
+		rows[i] = row
+	}
 }
 
 func updateSessionProjectTx(
@@ -616,9 +647,9 @@ func (db *DB) applyWorktreeProjectMappings(
 	}
 
 	rows, err := tx.QueryContext(ctx, `
-		SELECT id, project, cwd
+		SELECT id, project, cwd, file_path
 		FROM sessions
-		WHERE machine = ? AND cwd != '' AND deleted_at IS NULL`,
+		WHERE machine = ? AND deleted_at IS NULL`,
 		machine,
 	)
 	if err != nil {
@@ -627,14 +658,35 @@ func (db *DB) applyWorktreeProjectMappings(
 		)
 	}
 
+	rowsForMachine := []worktreeMappingSessionRow{}
 	var updates []worktreeMappingSessionUpdate
 	var result ApplyWorktreeProjectMappingsResult
 	for rows.Next() {
-		row := worktreeMappingSessionRow{machine: machine}
-		if err := rows.Scan(&row.id, &row.project, &row.cwd); err != nil {
+		var row worktreeMappingSessionRow
+		var filePath sql.NullString
+		row.machine = machine
+		if err := rows.Scan(&row.id, &row.project, &row.cwd, &filePath); err != nil {
 			rows.Close()
 			return result, fmt.Errorf("scanning session for worktree mapping apply: %w", err)
 		}
+		if filePath.Valid {
+			row.filePath = filePath.String
+		}
+		rowsForMachine = append(rowsForMachine, row)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return result, fmt.Errorf("iterating sessions for worktree mapping apply: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return result, fmt.Errorf("closing worktree mapping apply rows: %w", err)
+	}
+
+	applyWorktreeMappingMatchCwdFromSiblings(rowsForMachine, func(row worktreeMappingSessionRow) string {
+		return strings.TrimSpace(row.filePath)
+	})
+
+	for _, row := range rowsForMachine {
 		update, matched, shouldUpdate := applyMappingToSessionRow(mappings, row)
 		if !matched {
 			continue
@@ -643,13 +695,6 @@ func (db *DB) applyWorktreeProjectMappings(
 		if shouldUpdate {
 			updates = append(updates, update)
 		}
-	}
-	if err := rows.Err(); err != nil {
-		rows.Close()
-		return result, fmt.Errorf("iterating sessions for worktree mapping apply: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return result, fmt.Errorf("closing worktree mapping apply rows: %w", err)
 	}
 
 	for _, update := range updates {
@@ -807,9 +852,9 @@ func (db *DB) applyWorktreeProjectMappingsToSessionsByPath(
 	defer func() { _ = tx.Rollback() }()
 
 	rows, err := tx.QueryContext(ctx, `
-		SELECT id, machine, project, cwd
+		SELECT id, machine, project, cwd, file_path
 		FROM sessions
-		WHERE file_path = ? AND cwd != '' AND deleted_at IS NULL`,
+		WHERE file_path = ? AND deleted_at IS NULL`,
 		filePath,
 	)
 	if err != nil {
@@ -822,14 +867,18 @@ func (db *DB) applyWorktreeProjectMappingsToSessionsByPath(
 	machines := map[string]bool{}
 	for rows.Next() {
 		var row worktreeMappingSessionRow
+		var rowFilePath sql.NullString
 		if err := rows.Scan(
-			&row.id, &row.machine, &row.project, &row.cwd,
+			&row.id, &row.machine, &row.project, &row.cwd, &rowFilePath,
 		); err != nil {
 			rows.Close()
 			return ApplyWorktreeProjectMappingsResult{}, fmt.Errorf(
 				"scanning session for worktree mapping path apply: %w",
 				err,
 			)
+		}
+		if rowFilePath.Valid {
+			row.filePath = rowFilePath.String
 		}
 		sessions = append(sessions, row)
 		machines[row.machine] = true
@@ -849,6 +898,10 @@ func (db *DB) applyWorktreeProjectMappingsToSessionsByPath(
 	if len(sessions) == 0 {
 		return ApplyWorktreeProjectMappingsResult{}, nil
 	}
+
+	applyWorktreeMappingMatchCwdFromSiblings(sessions, func(row worktreeMappingSessionRow) string {
+		return row.machine + "|" + strings.TrimSpace(row.filePath)
+	})
 
 	mappingsByMachine, err := loadActiveWorktreeMappingsByMachineTx(
 		ctx, tx, machines,

--- a/internal/db/worktree_mappings.go
+++ b/internal/db/worktree_mappings.go
@@ -549,6 +549,7 @@ func applyWorktreeMappingMatchCwdFromSiblings(
 		project string
 	}
 	candidatesBySibling := map[string][]siblingCandidate{}
+	unresolvedBySibling := map[string]bool{}
 	for _, row := range rows {
 		key := siblingKey(row)
 		if key == "" || row.cwd == "" {
@@ -556,6 +557,7 @@ func applyWorktreeMappingMatchCwdFromSiblings(
 		}
 		project, ok := resolveProject(row, row.cwd)
 		if !ok {
+			unresolvedBySibling[key] = true
 			continue
 		}
 		candidates := candidatesBySibling[key]
@@ -573,11 +575,12 @@ func applyWorktreeMappingMatchCwdFromSiblings(
 		}
 	}
 
-	// Only fall back when every non-empty sibling resolves to the same
-	// project; conflicting siblings mean the fallback would be a guess.
+	// Only fall back when every non-empty sibling resolves to a mapping and
+	// all of them agree on the same project; an unmapped sibling or
+	// conflicting projects mean the fallback would be a guess.
 	fallbackBySibling := map[string]string{}
 	for key, candidates := range candidatesBySibling {
-		if len(candidates) == 1 {
+		if len(candidates) == 1 && !unresolvedBySibling[key] {
 			fallbackBySibling[key] = candidates[0].cwd
 		}
 	}

--- a/internal/db/worktree_mappings.go
+++ b/internal/db/worktree_mappings.go
@@ -542,15 +542,43 @@ func applyMappingToSessionRow(
 func applyWorktreeMappingMatchCwdFromSiblings(
 	rows []worktreeMappingSessionRow,
 	siblingKey func(worktreeMappingSessionRow) string,
+	resolveProject func(row worktreeMappingSessionRow, cwd string) (string, bool),
 ) {
-	fallbackBySibling := map[string]string{}
+	type siblingCandidate struct {
+		cwd     string
+		project string
+	}
+	candidatesBySibling := map[string][]siblingCandidate{}
 	for _, row := range rows {
 		key := siblingKey(row)
 		if key == "" || row.cwd == "" {
 			continue
 		}
-		if _, ok := fallbackBySibling[key]; !ok {
-			fallbackBySibling[key] = row.cwd
+		project, ok := resolveProject(row, row.cwd)
+		if !ok {
+			continue
+		}
+		candidates := candidatesBySibling[key]
+		alreadySeen := false
+		for _, candidate := range candidates {
+			if candidate.project == project {
+				alreadySeen = true
+				break
+			}
+		}
+		if !alreadySeen {
+			candidatesBySibling[key] = append(
+				candidates, siblingCandidate{cwd: row.cwd, project: project},
+			)
+		}
+	}
+
+	// Only fall back when every non-empty sibling resolves to the same
+	// project; conflicting siblings mean the fallback would be a guess.
+	fallbackBySibling := map[string]string{}
+	for key, candidates := range candidatesBySibling {
+		if len(candidates) == 1 {
+			fallbackBySibling[key] = candidates[0].cwd
 		}
 	}
 
@@ -684,6 +712,12 @@ func (db *DB) applyWorktreeProjectMappings(
 
 	applyWorktreeMappingMatchCwdFromSiblings(rowsForMachine, func(row worktreeMappingSessionRow) string {
 		return strings.TrimSpace(row.filePath)
+	}, func(row worktreeMappingSessionRow, cwd string) (string, bool) {
+		mapping, ok := bestWorktreeProjectMapping(mappings, cwd)
+		if !ok {
+			return "", false
+		}
+		return mapping.Project, true
 	})
 
 	for _, row := range rowsForMachine {
@@ -899,10 +933,6 @@ func (db *DB) applyWorktreeProjectMappingsToSessionsByPath(
 		return ApplyWorktreeProjectMappingsResult{}, nil
 	}
 
-	applyWorktreeMappingMatchCwdFromSiblings(sessions, func(row worktreeMappingSessionRow) string {
-		return row.machine + "|" + strings.TrimSpace(row.filePath)
-	})
-
 	mappingsByMachine, err := loadActiveWorktreeMappingsByMachineTx(
 		ctx, tx, machines,
 	)
@@ -911,6 +941,16 @@ func (db *DB) applyWorktreeProjectMappingsToSessionsByPath(
 			"loading active worktree mappings: %w", err,
 		)
 	}
+
+	applyWorktreeMappingMatchCwdFromSiblings(sessions, func(row worktreeMappingSessionRow) string {
+		return row.machine + "|" + strings.TrimSpace(row.filePath)
+	}, func(row worktreeMappingSessionRow, cwd string) (string, bool) {
+		mapping, ok := bestWorktreeProjectMapping(mappingsByMachine[row.machine], cwd)
+		if !ok {
+			return "", false
+		}
+		return mapping.Project, true
+	})
 
 	var result ApplyWorktreeProjectMappingsResult
 	for _, session := range sessions {

--- a/internal/db/worktree_mappings_test.go
+++ b/internal/db/worktree_mappings_test.go
@@ -285,6 +285,53 @@ func TestApplyWorktreeProjectMappings_EmptyCwdConflictingSiblingsNoFallback(t *t
 	assertSessionProject(t, d, "reference-b", "repo_b")
 }
 
+func TestApplyWorktreeProjectMappings_EmptyCwdUnmappedSiblingNoFallback(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	filePath := filepath.Join(root, "session.jsonl")
+	prefixA := filepath.Join(root, "repo-a.worktrees")
+	unmappedCwd := filepath.Join(root, "unrelated", "dir")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefixA, Project: "repo-a", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping A")
+
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd row")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-mapped",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefixA, "feat"),
+		FilePath: &filePath,
+	}), "insert reference row resolving to mapping A")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-unmapped",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      unmappedCwd,
+		FilePath: &filePath,
+	}), "insert reference row with no matching mapping")
+
+	result, err := d.ApplyWorktreeProjectMappings(ctx, "laptop")
+	require.NoError(t, err, "apply mappings")
+	assert.Equal(t, 1, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 1, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd", "stale")
+	assertSessionProject(t, d, "reference-mapped", "repo_a")
+	assertSessionProject(t, d, "reference-unmapped", "stale")
+}
+
 func TestApplyWorktreeProjectMappings_EmptyCwdNoSiblingNoUpdate(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
@@ -452,6 +499,55 @@ func TestApplyWorktreeProjectMappingsToSessionsByPath_EmptyCwdConflictingSibling
 	assertSessionProject(t, d, "empty-cwd", "stale")
 	assertSessionProject(t, d, "reference-a", "repo_a")
 	assertSessionProject(t, d, "reference-b", "repo_b")
+}
+
+func TestApplyWorktreeProjectMappingsToSessionsByPath_EmptyCwdUnmappedSiblingNoFallback(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	filePath := filepath.Join(root, "session.jsonl")
+	prefixA := filepath.Join(root, "repo-a.worktrees")
+	unmappedCwd := filepath.Join(root, "unrelated", "dir")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefixA, Project: "repo-a", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping A")
+
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd row")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-mapped",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefixA, "feat"),
+		FilePath: &filePath,
+	}), "insert reference row resolving to mapping A")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-unmapped",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      unmappedCwd,
+		FilePath: &filePath,
+	}), "insert reference row with no matching mapping")
+
+	result, err := d.ApplyWorktreeProjectMappingsToSessionsByPath(ctx, filePath)
+	require.NoError(t, err, "apply mappings by path")
+	assert.Equal(t, 1, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 1, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd", "stale")
+	assertSessionProject(t, d, "reference-mapped", "repo_a")
+	assertSessionProject(t, d, "reference-unmapped", "stale")
 }
 
 func TestApplyWorktreeProjectMappingsToSessionsByPath_EmptyCwdOnlyEmptySiblingsNoMatch(

--- a/internal/db/worktree_mappings_test.go
+++ b/internal/db/worktree_mappings_test.go
@@ -193,6 +193,201 @@ func TestApplyWorktreeProjectMappingsBumpsLocalModifiedAt(t *testing.T) {
 	assert.NotEmpty(t, *after.LocalModifiedAt, "local_modified_at after")
 }
 
+func TestApplyWorktreeProjectMappings_EmptyCwdSiblingFallback(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	filePath := filepath.Join(root, "session.jsonl")
+	prefix := filepath.Join(root, "repo.worktrees")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd row")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefix, "feat", "task"),
+		FilePath: &filePath,
+	}), "insert fallback reference row")
+
+	result, err := d.ApplyWorktreeProjectMappings(ctx, "laptop")
+	require.NoError(t, err, "apply mappings")
+	assert.Equal(t, 2, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 2, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd", "repo")
+	assertSessionProject(t, d, "reference", "repo")
+
+	emptyRow, err := d.GetSession(ctx, "empty-cwd")
+	require.NoError(t, err, "GetSession empty-cwd")
+	require.NotNil(t, emptyRow, "empty-cwd session")
+	assert.Equal(t, "", emptyRow.Cwd, "stored cwd unchanged")
+}
+
+func TestApplyWorktreeProjectMappings_EmptyCwdNoSiblingNoUpdate(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	prefix := filepath.Join(root, "repo.worktrees")
+	filePath := filepath.Join(root, "session.jsonl")
+	otherFilePath := filepath.Join(root, "other-session.jsonl")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd-no-sibling",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd row")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-unrelated",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefix, "feat"),
+		FilePath: &otherFilePath,
+	}), "insert unrelated non-empty row")
+
+	result, err := d.ApplyWorktreeProjectMappings(ctx, "laptop")
+	require.NoError(t, err, "apply mappings")
+	assert.Equal(t, 1, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 1, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd-no-sibling", "stale")
+	assertSessionProject(t, d, "reference-unrelated", "repo")
+
+	emptyRow, err := d.GetSession(ctx, "empty-cwd-no-sibling")
+	require.NoError(t, err, "GetSession empty-cwd-no-sibling")
+	require.NotNil(t, emptyRow, "empty-cwd-no-sibling session")
+	assert.Equal(t, "", emptyRow.Cwd, "stored cwd unchanged")
+}
+
+func TestApplyWorktreeProjectMappings_EmptyCwdSameProjectNoUpdate(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	filePath := filepath.Join(root, "session.jsonl")
+	prefix := filepath.Join(root, "repo.worktrees")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd-already-matched",
+		Project:  "repo",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd same project row")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefix, "feat"),
+		FilePath: &filePath,
+	}), "insert reference row")
+
+	result, err := d.ApplyWorktreeProjectMappings(ctx, "laptop")
+	require.NoError(t, err, "apply mappings")
+	assert.Equal(t, 2, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 1, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd-already-matched", "repo")
+	assertSessionProject(t, d, "reference", "repo")
+}
+
+func TestApplyWorktreeProjectMappingsToSessionsByPath_EmptyCwdSiblingFallback(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	filePath := filepath.Join(root, "session.jsonl")
+	prefix := filepath.Join(root, "repo.worktrees")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd row")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefix, "feat"),
+		FilePath: &filePath,
+	}), "insert reference row")
+
+	result, err := d.ApplyWorktreeProjectMappingsToSessionsByPath(ctx, filePath)
+	require.NoError(t, err, "apply mappings by path")
+	assert.Equal(t, 2, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 2, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd", "repo")
+	assertSessionProject(t, d, "reference", "repo")
+}
+
+func TestApplyWorktreeProjectMappingsToSessionsByPath_EmptyCwdOnlyEmptySiblingsNoMatch(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	filePath := filepath.Join(root, "session.jsonl")
+	prefix := filepath.Join(root, "repo.worktrees")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefix, Project: "repo", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd-a",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd sibling A")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd-b",
+		Project:  "other",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd sibling B")
+
+	result, err := d.ApplyWorktreeProjectMappingsToSessionsByPath(ctx, filePath)
+	require.NoError(t, err, "apply mappings by path")
+	assert.Equal(t, 0, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 0, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd-a", "stale")
+	assertSessionProject(t, d, "empty-cwd-b", "other")
+}
+
 func TestApplyWorktreeProjectMappingsToSessionUsesCurrentSessionState(
 	t *testing.T,
 ) {

--- a/internal/db/worktree_mappings_test.go
+++ b/internal/db/worktree_mappings_test.go
@@ -234,6 +234,57 @@ func TestApplyWorktreeProjectMappings_EmptyCwdSiblingFallback(t *testing.T) {
 	assert.Equal(t, "", emptyRow.Cwd, "stored cwd unchanged")
 }
 
+func TestApplyWorktreeProjectMappings_EmptyCwdConflictingSiblingsNoFallback(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	filePath := filepath.Join(root, "session.jsonl")
+	prefixA := filepath.Join(root, "repo-a.worktrees")
+	prefixB := filepath.Join(root, "repo-b.worktrees")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefixA, Project: "repo-a", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping A")
+	_, err = d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefixB, Project: "repo-b", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping B")
+
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd row")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-a",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefixA, "feat"),
+		FilePath: &filePath,
+	}), "insert reference row resolving to mapping A")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-b",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefixB, "feat"),
+		FilePath: &filePath,
+	}), "insert reference row resolving to mapping B")
+
+	result, err := d.ApplyWorktreeProjectMappings(ctx, "laptop")
+	require.NoError(t, err, "apply mappings")
+	assert.Equal(t, 2, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 2, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd", "stale")
+	assertSessionProject(t, d, "reference-a", "repo_a")
+	assertSessionProject(t, d, "reference-b", "repo_b")
+}
+
 func TestApplyWorktreeProjectMappings_EmptyCwdNoSiblingNoUpdate(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
@@ -348,6 +399,59 @@ func TestApplyWorktreeProjectMappingsToSessionsByPath_EmptyCwdSiblingFallback(
 	assert.Equal(t, 2, result.UpdatedSessions, "updated sessions")
 	assertSessionProject(t, d, "empty-cwd", "repo")
 	assertSessionProject(t, d, "reference", "repo")
+}
+
+func TestApplyWorktreeProjectMappingsToSessionsByPath_EmptyCwdConflictingSiblingsNoFallback(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+	root := t.TempDir()
+	filePath := filepath.Join(root, "session.jsonl")
+	prefixA := filepath.Join(root, "repo-a.worktrees")
+	prefixB := filepath.Join(root, "repo-b.worktrees")
+
+	_, err := d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefixA, Project: "repo-a", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping A")
+	_, err = d.CreateWorktreeProjectMapping(ctx, WorktreeProjectMapping{
+		Machine: "laptop", PathPrefix: prefixB, Project: "repo-b", Enabled: true,
+	})
+	require.NoError(t, err, "create mapping B")
+
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "empty-cwd",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      "",
+		FilePath: &filePath,
+	}), "insert empty cwd row")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-a",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefixA, "feat"),
+		FilePath: &filePath,
+	}), "insert reference row resolving to mapping A")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:       "reference-b",
+		Project:  "stale",
+		Machine:  "laptop",
+		Agent:    "claude",
+		Cwd:      filepath.Join(prefixB, "feat"),
+		FilePath: &filePath,
+	}), "insert reference row resolving to mapping B")
+
+	result, err := d.ApplyWorktreeProjectMappingsToSessionsByPath(ctx, filePath)
+	require.NoError(t, err, "apply mappings by path")
+	assert.Equal(t, 2, result.MatchedSessions, "matched sessions")
+	assert.Equal(t, 2, result.UpdatedSessions, "updated sessions")
+	assertSessionProject(t, d, "empty-cwd", "stale")
+	assertSessionProject(t, d, "reference-a", "repo_a")
+	assertSessionProject(t, d, "reference-b", "repo_b")
 }
 
 func TestApplyWorktreeProjectMappingsToSessionsByPath_EmptyCwdOnlyEmptySiblingsNoMatch(


### PR DESCRIPTION
Worktree project mappings currently skip any historical session row whose stored `cwd` is empty, even when another row for the same transcript file proves the real working directory. That leaves older sessions stuck on stale project names after a user adds or reapplies a worktree mapping, which is especially visible after a worktree disappears and the user tries to recover those sessions under the correct project.

The path matcher itself is not the bug. It is correct to reject an empty `cwd`. The gap is that both scan-based apply paths discard empty-`cwd` rows before matching, even though those rows still carry `file_path` and can have a same-file sibling with a real `cwd`. This change keeps the fix in `internal/db`, adds a match-only fallback `cwd` for scanned rows, and uses a same-`file_path`, non-deleted sibling row only to decide which mapping applies. The row's own stored `cwd` stays untouched, and the existing optimistic-concurrency update guard keeps comparing against that stored value.

Scope stays narrow on purpose. The live single-session sync path already receives a caller-supplied `cwd`, so this PR leaves it alone and fixes only the historical backfill surfaces that scan stored rows. Rows with no usable sibling remain unmatched exactly as they do today, and rows that already have non-empty `cwd` keep their current behavior.

Fixes #942
