### PR TITLE
fix(usage): surface unsupported Copilot usage filters

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -686,6 +686,7 @@
   "usage_refresh": "Refresh usage data",
   "usage_summary_total_cost": "Total Cost",
   "usage_summary_copilot_ai_credits": "Copilot AI Credits",
+  "usage_summary_unsupported_copilot_no_token_data": "Copilot sessions matched this range, but Copilot does not record per-message token usage.",
   "usage_summary_input_tokens": "Input Tokens",
   "usage_summary_daily_burn": "Daily Burn",
   "usage_summary_peak_day": "Peak Day",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1551,6 +1551,7 @@
   "usage_refresh_data": "刷新用量数据",
   "usage_vs_prior": "{pct}% 较上期",
   "usage_total_cost": "总成本",
+  "usage_summary_unsupported_copilot_no_token_data": "此范围内匹配到了 Copilot 会话，但 Copilot 不会记录每条消息的 token 用量。",
   "usage_copilot_credits": "Copilot AI 积分",
   "usage_input_tokens": "输入 Token",
   "usage_cached_suffix": "+{tokens} 已缓存",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -1551,6 +1551,7 @@
   "usage_refresh_data": "刷新用量數據",
   "usage_vs_prior": "{pct}% 較上期",
   "usage_total_cost": "總成本",
+  "usage_summary_unsupported_copilot_no_token_data": "此範圍內匹配到了 Copilot 會話，但 Copilot 不會記錄每條訊息的 token 用量。",
   "usage_copilot_credits": "Copilot AI 積分",
   "usage_input_tokens": "輸入 Token",
   "usage_cached_suffix": "+{tokens} 已緩存",

--- a/frontend/src/lib/api/generated/index.ts
+++ b/frontend/src/lib/api/generated/index.ts
@@ -148,6 +148,7 @@ export type { SyncSyncStats } from './models/SyncSyncStats';
 export { TerminalConfigBody } from './models/TerminalConfigBody';
 export type { TerminalResponse } from './models/TerminalResponse';
 export type { TrashResponse } from './models/TrashResponse';
+export type { UnsupportedUsage } from './models/UnsupportedUsage';
 export type { UpdateCheckResponse } from './models/UpdateCheckResponse';
 export type { UploadSessionResponse } from './models/UploadSessionResponse';
 export type { UsageSummaryResponse } from './models/UsageSummaryResponse';

--- a/frontend/src/lib/api/generated/models/UnsupportedUsage.ts
+++ b/frontend/src/lib/api/generated/models/UnsupportedUsage.ts
@@ -1,0 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UnsupportedUsage = {
+  kind: string;
+};

--- a/frontend/src/lib/api/generated/models/UsageSummaryResponse.ts
+++ b/frontend/src/lib/api/generated/models/UsageSummaryResponse.ts
@@ -6,6 +6,7 @@ import type { CacheStats } from './CacheStats';
 import type { Comparison } from './Comparison';
 import type { DbUsageSessionCounts } from './DbUsageSessionCounts';
 import type { DbUsageTotals } from './DbUsageTotals';
+import type { UnsupportedUsage } from './UnsupportedUsage';
 export type UsageSummaryResponse = {
   agentTotals: any[] | null;
   cacheStats: CacheStats;
@@ -17,5 +18,5 @@ export type UsageSummaryResponse = {
   sessionCounts: DbUsageSessionCounts;
   to: string;
   totals: DbUsageTotals;
+  unsupportedUsage?: UnsupportedUsage;
 };
-

--- a/frontend/src/lib/api/types/usage.ts
+++ b/frontend/src/lib/api/types/usage.ts
@@ -99,6 +99,10 @@ export interface UsageComparison {
   deltaPct: number;
 }
 
+export interface UnsupportedUsage {
+  kind: string;
+}
+
 export interface UsageSummaryResponse {
   from: string;
   to: string;
@@ -109,6 +113,7 @@ export interface UsageSummaryResponse {
   agentTotals: AgentTotal[];
   sessionCounts: UsageSessionCounts;
   cacheStats: CacheStats;
+  unsupportedUsage?: UnsupportedUsage;
   comparison?: UsageComparison;
 }
 

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -121,6 +121,13 @@
       ? usage.selectedModels.split(",").filter(Boolean)
       : [],
   );
+  const unsupportedUsageMessage = $derived.by(() => {
+    const kind = usage.summary?.unsupportedUsage?.kind;
+    if (kind === "copilot-no-token-data") {
+      return m.usage_summary_unsupported_copilot_no_token_data();
+    }
+    return "";
+  });
   const sessionUrlParams = $derived(
     filtersToParams(sessions.filters),
   );
@@ -428,6 +435,12 @@
       <div class="query-progress" aria-hidden="true"></div>
     {/if}
 
+    {#if unsupportedUsageMessage}
+      <div class="usage-note" role="status">
+        {unsupportedUsageMessage}
+      </div>
+    {/if}
+
     <UsageSummaryCards />
 
     <div class="chart-panel wide">
@@ -490,6 +503,15 @@
     gap: 16px;
     position: relative;
     transition: opacity 0.12s;
+  }
+
+  .usage-note {
+    padding: 12px 14px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-muted);
+    border-left: 4px solid var(--accent-blue);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
   }
 
   .usage-content.querying {

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -10,7 +10,6 @@ import { router } from "../../stores/router.svelte.js";
 import { sessions } from "../../stores/sessions.svelte.js";
 import { usage } from "../../stores/usage.svelte.js";
 import source from "./UsagePage.svelte?raw";
-// @ts-ignore
 import UsagePage from "./UsagePage.svelte";
 
 async function flushEffects() {

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -1,7 +1,120 @@
-import { describe, expect, it } from "vite-plus/test";
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { mount, tick, unmount } from "svelte";
+import { router } from "../../stores/router.svelte.js";
+import { sessions } from "../../stores/sessions.svelte.js";
+import { usage } from "../../stores/usage.svelte.js";
 import source from "./UsagePage.svelte?raw";
+// @ts-ignore
+import UsagePage from "./UsagePage.svelte";
+
+async function flushEffects() {
+  await tick();
+  await Promise.resolve();
+  await tick();
+}
+
+let component: ReturnType<typeof mount> | undefined;
+
+function usageSummaryWithUnsupported(kind?: string) {
+  return {
+    from: "2024-06-01",
+    to: "2024-06-01",
+    totals: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      totalCost: 0,
+    },
+    daily: [],
+    projectTotals: [],
+    modelTotals: [],
+    agentTotals: [],
+    sessionCounts: {
+      total: 0,
+      byProject: {},
+      byAgent: {},
+    },
+    cacheStats: {
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      uncachedInputTokens: 0,
+      outputTokens: 0,
+      hitRate: 0,
+      savingsVsUncached: 0,
+    },
+    ...(kind ? { unsupportedUsage: { kind } } : {}),
+  };
+}
+
+afterEach(() => {
+  if (component) {
+    unmount(component);
+    component = undefined;
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+  router.route = "sessions";
+  router.params = {};
+  router.sessionId = null;
+  usage.summary = null;
+  usage.topSessions = null;
+  usage.errors.summary = null;
+  sessions.projects = [];
+});
 
 describe("UsagePage refresh behavior", () => {
+  it("renders the unsupported Copilot note from the summary contract", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+
+    router.route = "usage";
+    router.params = {};
+    usage.summary = usageSummaryWithUnsupported("copilot-no-token-data");
+
+    component = mount(UsagePage, { target: document.body });
+    await flushEffects();
+
+    expect(document.body.textContent).toContain(
+      "Copilot sessions matched this range",
+    );
+  });
+
+  it("keeps the note hidden without an unsupported usage signal", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+
+    router.route = "usage";
+    router.params = {};
+    usage.summary = usageSummaryWithUnsupported();
+
+    component = mount(UsagePage, { target: document.body });
+    await flushEffects();
+
+    expect(document.body.textContent).not.toContain(
+      "Copilot sessions matched this range",
+    );
+  });
+
   it("does not auto-refresh usage scans from SSE updates", () => {
     expect(source).not.toContain("subscribeDebounced");
     expect(source).not.toContain("REFRESH_MS");

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -178,6 +178,22 @@ describe("UsageStore filter persistence", () => {
     expect(usage.excludedAgents).toBe("");
   });
 
+  it("preserves unsupported usage metadata when comparison data is merged", async () => {
+    usageServiceMocks.getApiV1UsageSummary.mockResolvedValueOnce({
+      ...usageSummary(0),
+      unsupportedUsage: { kind: "copilot-no-token-data" },
+    });
+
+    const { usage } = await loadStore();
+    await usage.fetchSummary();
+    await Promise.resolve();
+
+    expect(usage.summary?.unsupportedUsage).toEqual({
+      kind: "copilot-no-token-data",
+    });
+    expect(usage.summary?.comparison).toEqual(usageComparison());
+  });
+
   it("falls back to defaults on corrupted localStorage", async () => {
     localStorage.setItem("usage-filters", "not json");
     const { usage } = await loadStore();

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -80,6 +80,7 @@ type Store interface {
 	GetDailyUsage(ctx context.Context, f UsageFilter) (DailyUsageResult, error)
 	GetTopSessionsByCost(ctx context.Context, f UsageFilter, limit int) ([]TopSessionEntry, error)
 	GetUsageSessionCounts(ctx context.Context, f UsageFilter) (UsageSessionCounts, error)
+	GetUsageMatchingSessionCount(ctx context.Context, f UsageFilter) (int, error)
 	GetSessionUsage(ctx context.Context, sessionID string) (*SessionUsage, error)
 
 	// Stars.

--- a/internal/db/store_contract_test.go
+++ b/internal/db/store_contract_test.go
@@ -676,6 +676,53 @@ func TestStoreContractGetUsageMatchingSessionCountCountsCopilotSessionsWithoutUs
 	require.Equal(t, 1, count)
 }
 
+func TestStoreContractGetUsageMatchingSessionCountCountsCopilotSessionByMessageTimestampOutsideSessionWindow(
+	t *testing.T,
+) {
+	store, ok := openStoreContractSQLiteFixtureDB(t).(*DB)
+	require.True(t, ok, "sqlite fixture should expose *DB")
+	ctx := context.Background()
+
+	insertSession(t, store, "contract-copilot-late-message", "alpha", func(s *Session) {
+		ts := "2026-02-08T10:00:00Z"
+		s.Agent = "copilot"
+		s.StartedAt = &ts
+		s.EndedAt = &ts
+	})
+	insertMessages(t, store, Message{
+		SessionID:  "contract-copilot-late-message",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2026-02-10T12:00:00Z",
+		Model:      "gpt-5.3-codex",
+		TokenUsage: nil,
+	})
+
+	insertSession(t, store, "contract-copilot-out-of-range", "alpha", func(s *Session) {
+		ts := "2026-02-08T10:00:00Z"
+		s.Agent = "copilot"
+		s.StartedAt = &ts
+		s.EndedAt = &ts
+	})
+	insertMessages(t, store, Message{
+		SessionID:  "contract-copilot-out-of-range",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2026-02-08T10:00:00Z",
+		Model:      "gpt-5.3-codex",
+		TokenUsage: nil,
+	})
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, UsageFilter{
+		From:     "2026-02-10",
+		To:       "2026-02-10",
+		Timezone: "UTC",
+		Agent:    "copilot",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
 func seedStoreContractSQLite(
 	t *testing.T,
 	store Store,

--- a/internal/db/store_contract_test.go
+++ b/internal/db/store_contract_test.go
@@ -644,6 +644,38 @@ func contractLocalOnlyMethods(
 	require.NoError(t, store.DeleteInsight(insightID))
 }
 
+func TestStoreContractGetUsageMatchingSessionCountCountsCopilotSessionsWithoutUsageRows(
+	t *testing.T,
+) {
+	store, ok := openStoreContractSQLiteFixtureDB(t).(*DB)
+	require.True(t, ok, "sqlite fixture should expose *DB")
+	ctx := context.Background()
+
+	insertSession(t, store, "contract-copilot-empty", "alpha", func(s *Session) {
+		ts := "2026-01-12T16:00:00Z"
+		s.Agent = "copilot"
+		s.StartedAt = &ts
+		s.EndedAt = &ts
+	})
+	insertMessages(t, store, Message{
+		SessionID:  "contract-copilot-empty",
+		Ordinal:    0,
+		Role:       "assistant",
+		Timestamp:  "2026-01-12T16:00:00Z",
+		Model:      "gpt-5.3-codex",
+		TokenUsage: nil,
+	})
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, UsageFilter{
+		From:     "2026-01-12",
+		To:       "2026-01-12",
+		Timezone: "UTC",
+		Agent:    "copilot",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
 func seedStoreContractSQLite(
 	t *testing.T,
 	store Store,

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -224,20 +224,25 @@ func (f UsageFilter) appendUsageSessionFilterClauses(
 	return where, args
 }
 
-func (f UsageFilter) appendUsageSessionModelMatchClauses(
+// appendUsageMatchingActivityClauses requires the session to have at
+// least one row that GetUsageMatchingSessionCount's bounded branch would
+// count: an assistant, non-synthetic message (model optional — some
+// Copilot assistant messages parse before a model name is known) or a
+// usage_events row with a model. Model/ExcludeModel narrow those same
+// rows. Seeding the EXISTS subqueries with the matching eligibility
+// predicates keeps the unbounded branch's semantics aligned with the
+// bounded branch's per-row predicates, so the same filter matches the
+// same sessions whether or not a date range is set.
+func (f UsageFilter) appendUsageMatchingActivityClauses(
 	where string, args []any,
 ) (string, []any) {
-	if strings.TrimSpace(f.Model) == "" && strings.TrimSpace(f.ExcludeModel) == "" {
-		return where, args
-	}
-
 	var messageArgs []any
 	messageWhere, messageArgs := f.appendUsageSourceFilterClauses(
-		"m.model != ''", messageArgs, "m.model",
+		usageMatchingMessageSourceEligibility, messageArgs, "m.model",
 	)
 	var eventArgs []any
 	eventWhere, eventArgs := f.appendUsageSourceFilterClauses(
-		"ue.model != ''", eventArgs, "ue.model",
+		usageEventSourceEligibility, eventArgs, "ue.model",
 	)
 
 	where += `
@@ -765,10 +770,6 @@ func usageBoundsForFilter(f UsageFilter) usageBounds {
 	return b
 }
 
-func usageSessionActivityExprSQLite() string {
-	return "COALESCE(NULLIF(s.ended_at, ''), NULLIF(s.started_at, ''), s.created_at)"
-}
-
 func appendUsageColumnBounds(
 	where, col string, b usageBounds, args []any,
 ) (string, []any) {
@@ -800,7 +801,19 @@ func usageRowsSQLForBounds(
 		return rowsSQL, args
 	}
 
-	messageTimestampSourceWhere := usageMessageSourceEligibility +
+	return usageBoundedRowsSQL(
+		f, b, usageMessageSourceEligibility, usageMessageEligibility)
+}
+
+// usageBoundedRowsSQL builds the bounded-branch CTE row source shared by
+// usageRowsSQLForBounds (token-eligible rows) and
+// usageMatchingSessionRowsSQLForBounds (relaxed matching rows). The two
+// callers differ only in the message eligibility predicates.
+func usageBoundedRowsSQL(
+	f UsageFilter, b usageBounds,
+	messageSourceEligibility, messageEligibility string,
+) (string, []any) {
+	messageTimestampSourceWhere := messageSourceEligibility +
 		"\n\tAND m.timestamp IS NOT NULL" +
 		"\n\tAND m.timestamp != ''"
 	var messageTimestampArgs []any
@@ -827,7 +840,7 @@ func usageRowsSQLForBounds(
 		f.appendUsageSessionFilterClauses(
 			usageSessionEligibility, eventTimestampJoinArgs)
 
-	messageFallbackWhere := usageMessageEligibility +
+	messageFallbackWhere := messageEligibility +
 		"\n\tAND NULLIF(m.timestamp, '') IS NULL"
 	var messageFallbackArgs []any
 	messageFallbackWhere, messageFallbackArgs =
@@ -868,78 +881,17 @@ func usageRowsSQLForBounds(
 	return rowsSQL, args
 }
 
-// usageMatchingSessionRowsSQLForBounds mirrors usageRowsSQLForBounds's
-// bounded-branch CTE shape, but is built from the relaxed
-// usageMatchingMessageEligibility predicate, so GetUsageMatchingSessionCount
-// only relaxes the token-usage requirement and keeps the same per-row
-// Model/ExcludeModel filtering as the normal bounded path. Only used by
-// GetUsageMatchingSessionCount's bounded branch.
+// usageMatchingSessionRowsSQLForBounds is usageRowsSQLForBounds's bounded
+// branch built from the relaxed usageMatchingMessageEligibility predicates,
+// so GetUsageMatchingSessionCount only relaxes the token-usage and
+// model-presence requirements and keeps the same per-row
+// Model/ExcludeModel filtering as the normal bounded path.
 func usageMatchingSessionRowsSQLForBounds(
 	f UsageFilter, b usageBounds,
 ) (string, []any) {
-	messageTimestampSourceWhere := usageMatchingMessageSourceEligibility +
-		"\n\tAND m.timestamp IS NOT NULL" +
-		"\n\tAND m.timestamp != ''"
-	var messageTimestampArgs []any
-	messageTimestampSourceWhere, messageTimestampArgs =
-		f.appendUsageSourceFilterClauses(
-			messageTimestampSourceWhere, messageTimestampArgs, "m.model")
-	messageTimestampSourceWhere, messageTimestampArgs = appendUsageColumnBounds(
-		messageTimestampSourceWhere, "m.timestamp", b, messageTimestampArgs)
-
-	eventTimestampSourceWhere := usageEventSourceEligibility +
-		"\n\tAND ue.occurred_at IS NOT NULL"
-	var eventTimestampArgs []any
-	eventTimestampSourceWhere, eventTimestampArgs =
-		f.appendUsageSourceFilterClauses(
-			eventTimestampSourceWhere, eventTimestampArgs, "ue.model")
-	eventTimestampSourceWhere, eventTimestampArgs = appendUsageColumnBounds(
-		eventTimestampSourceWhere, "ue.occurred_at", b, eventTimestampArgs)
-
-	var messageTimestampJoinArgs []any
-	messageTimestampJoinWhere, messageTimestampJoinArgs :=
-		f.appendUsageSessionFilterClauses(usageSessionEligibility, messageTimestampJoinArgs)
-
-	var eventTimestampJoinArgs []any
-	eventTimestampJoinWhere, eventTimestampJoinArgs :=
-		f.appendUsageSessionFilterClauses(usageSessionEligibility, eventTimestampJoinArgs)
-
-	messageFallbackWhere := usageMatchingMessageEligibility +
-		"\n\tAND NULLIF(m.timestamp, '') IS NULL"
-	var messageFallbackArgs []any
-	messageFallbackWhere, messageFallbackArgs =
-		f.appendUsageBranchFilterClauses(
-			messageFallbackWhere, messageFallbackArgs, "m.model")
-	messageFallbackWhere, messageFallbackArgs = appendUsageColumnBounds(
-		messageFallbackWhere, "s.started_at", b, messageFallbackArgs)
-
-	eventFallbackWhere := usageEventEligibility +
-		"\n\tAND ue.occurred_at IS NULL"
-	var eventFallbackArgs []any
-	eventFallbackWhere, eventFallbackArgs =
-		f.appendUsageBranchFilterClauses(
-			eventFallbackWhere, eventFallbackArgs, "ue.model")
-	eventFallbackWhere, eventFallbackArgs = appendUsageColumnBounds(
-		eventFallbackWhere, "s.started_at", b, eventFallbackArgs)
-
-	rowsSQL := dailyUsageRowsSQLWithTimestampCTEs(
-		messageTimestampSourceWhere, eventTimestampSourceWhere,
-		messageTimestampJoinWhere, eventTimestampJoinWhere,
-		messageFallbackWhere, eventFallbackWhere,
-	)
-	args := make(
-		[]any, 0,
-		len(messageTimestampArgs)+len(eventTimestampArgs)+
-			len(messageTimestampJoinArgs)+len(eventTimestampJoinArgs)+
-			len(messageFallbackArgs)+len(eventFallbackArgs),
-	)
-	args = append(args, messageTimestampArgs...)
-	args = append(args, eventTimestampArgs...)
-	args = append(args, messageTimestampJoinArgs...)
-	args = append(args, eventTimestampJoinArgs...)
-	args = append(args, messageFallbackArgs...)
-	args = append(args, eventFallbackArgs...)
-	return rowsSQL, args
+	return usageBoundedRowsSQL(
+		f, b,
+		usageMatchingMessageSourceEligibility, usageMatchingMessageEligibility)
 }
 
 func usageRowQuery(f UsageFilter) (string, []any) {
@@ -2542,25 +2494,14 @@ func (db *DB) GetUsageMatchingSessionCount(
 
 	if !bounds.bounded() {
 		where, args := f.appendUsageSessionFilterClauses(usageSessionEligibility, nil)
-		where, args = f.appendUsageSessionModelMatchClauses(where, args)
+		where, args = f.appendUsageMatchingActivityClauses(where, args)
 
-		// Keep selecting session_activity_at even though it's unused here:
-		// this is the original query's WHERE/SELECT shape, unchanged, so
-		// nothing downstream (tests, tooling) that matches on this SQL
-		// text needs to change for the unbounded path.
-		rows, err := db.getReader().QueryContext(ctx, `
-			SELECT s.id, `+usageSessionActivityExprSQLite()+`
-			FROM sessions s WHERE `+where, args...)
+		var count int
+		err := db.getReader().QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM sessions s WHERE `+where, args...).Scan(&count)
 		if err != nil {
 			return 0, fmt.Errorf("querying matching usage sessions: %w", err)
-		}
-		defer rows.Close()
-		count := 0
-		for rows.Next() {
-			count++
-		}
-		if err := rows.Err(); err != nil {
-			return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
 		}
 		return count, nil
 	}

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -339,19 +339,22 @@ const usageMessageSourceEligibility = `
     AND m.model != '<synthetic>'`
 
 // usageMatchingMessageEligibility is usageMessageEligibility with the
-// token-presence requirement removed. GetUsageMatchingSessionCount counts
-// sessions that have usage-shaped activity even when the agent (e.g.
-// Copilot) never records per-message tokens, so it must not gate on
-// m.token_usage the way every token/cost query does. Do not reuse this
-// for usageRowQuery or its callers — see the usageMessageEligibility
-// doc comment above.
+// token-presence requirement removed and the model-presence requirement
+// relaxed to a role check. GetUsageMatchingSessionCount counts sessions
+// that have usage-shaped activity even when the agent (e.g. Copilot)
+// never records per-message tokens or, for some assistant messages, a
+// model name, so it must not gate on m.token_usage or m.model != ” the
+// way every token/cost query does; Model/ExcludeModel filters are applied
+// separately and still narrow the match when set. Do not reuse this for
+// usageRowQuery or its callers — see the usageMessageEligibility doc
+// comment above.
 const usageMatchingMessageEligibility = `
-    m.model != ''
+    m.role = 'assistant'
     AND m.model != '<synthetic>'
     AND s.deleted_at IS NULL`
 
 const usageMatchingMessageSourceEligibility = `
-    m.model != ''
+    m.role = 'assistant'
     AND m.model != '<synthetic>'`
 
 const usageEventEligibility = `

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -224,6 +224,42 @@ func (f UsageFilter) appendUsageSessionFilterClauses(
 	return where, args
 }
 
+func (f UsageFilter) appendUsageSessionModelMatchClauses(
+	where string, args []any,
+) (string, []any) {
+	if strings.TrimSpace(f.Model) == "" && strings.TrimSpace(f.ExcludeModel) == "" {
+		return where, args
+	}
+
+	var messageArgs []any
+	messageWhere, messageArgs := f.appendUsageSourceFilterClauses(
+		"m.model != ''", messageArgs, "m.model",
+	)
+	var eventArgs []any
+	eventWhere, eventArgs := f.appendUsageSourceFilterClauses(
+		"ue.model != ''", eventArgs, "ue.model",
+	)
+
+	where += `
+	AND (
+		EXISTS (
+			SELECT 1
+			FROM messages m
+			WHERE m.session_id = s.id
+				AND ` + messageWhere + `
+		)
+		OR EXISTS (
+			SELECT 1
+			FROM usage_events ue
+			WHERE ue.session_id = s.id
+				AND ` + eventWhere + `
+		)
+	)`
+	args = append(args, messageArgs...)
+	args = append(args, eventArgs...)
+	return where, args
+}
+
 func buildUsageTerminationPredSQLite(status string) (string, []any) {
 	if status == "" || status == "all" {
 		return "", nil
@@ -708,6 +744,10 @@ func usageBoundsForFilter(f UsageFilter) usageBounds {
 		b.to = paddedUTCBound(f.To+"T23:59:59Z", 14)
 	}
 	return b
+}
+
+func usageSessionActivityExprSQLite() string {
+	return "COALESCE(NULLIF(s.ended_at, ''), NULLIF(s.started_at, ''), s.created_at)"
 }
 
 func appendUsageColumnBounds(
@@ -2393,4 +2433,59 @@ func (db *DB) GetUsageSessionCounts(
 	}
 
 	return out, nil
+}
+
+// GetUsageMatchingSessionCount counts sessions that match the usage filter
+// even when they have no token-bearing usage rows.
+func (db *DB) GetUsageMatchingSessionCount(
+	ctx context.Context, f UsageFilter,
+) (int, error) {
+	loc := f.location()
+
+	where, args := f.appendUsageSessionFilterClauses(
+		usageSessionEligibility, nil,
+	)
+	where, args = f.appendUsageSessionModelMatchClauses(where, args)
+	where, args = appendUsageColumnBounds(
+		where,
+		usageSessionActivityExprSQLite(),
+		usageBoundsForFilter(f),
+		args,
+	)
+
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT s.id, `+usageSessionActivityExprSQLite()+`
+		FROM sessions s
+		WHERE `+where, args...)
+	if err != nil {
+		return 0, fmt.Errorf("querying matching usage sessions: %w", err)
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var (
+			id string
+			ts string
+		)
+		if err := rows.Scan(&id, &ts); err != nil {
+			return 0, fmt.Errorf("scanning matching usage session: %w", err)
+		}
+		date := localDate(ts, loc)
+		if date == "" {
+			continue
+		}
+		if f.From != "" && date < f.From {
+			continue
+		}
+		if f.To != "" && date > f.To {
+			continue
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
+	}
+
+	return count, nil
 }

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -867,10 +867,9 @@ func usageRowsSQLForBounds(
 
 // usageMatchingSessionRowsSQLForBounds mirrors usageRowsSQLForBounds's
 // bounded-branch CTE shape, but is built from the relaxed
-// usageMatchingMessageEligibility predicate and folds the session-wide
-// model-match clause into each branch instead of filtering per row, so
-// GetUsageMatchingSessionCount's Model/ExcludeModel semantics stay
-// bit-for-bit identical to the unbounded path. Only used by
+// usageMatchingMessageEligibility predicate, so GetUsageMatchingSessionCount
+// only relaxes the token-usage requirement and keeps the same per-row
+// Model/ExcludeModel filtering as the normal bounded path. Only used by
 // GetUsageMatchingSessionCount's bounded branch.
 func usageMatchingSessionRowsSQLForBounds(
 	f UsageFilter, b usageBounds,
@@ -879,34 +878,35 @@ func usageMatchingSessionRowsSQLForBounds(
 		"\n\tAND m.timestamp IS NOT NULL" +
 		"\n\tAND m.timestamp != ''"
 	var messageTimestampArgs []any
+	messageTimestampSourceWhere, messageTimestampArgs =
+		f.appendUsageSourceFilterClauses(
+			messageTimestampSourceWhere, messageTimestampArgs, "m.model")
 	messageTimestampSourceWhere, messageTimestampArgs = appendUsageColumnBounds(
 		messageTimestampSourceWhere, "m.timestamp", b, messageTimestampArgs)
 
 	eventTimestampSourceWhere := usageEventSourceEligibility +
 		"\n\tAND ue.occurred_at IS NOT NULL"
 	var eventTimestampArgs []any
+	eventTimestampSourceWhere, eventTimestampArgs =
+		f.appendUsageSourceFilterClauses(
+			eventTimestampSourceWhere, eventTimestampArgs, "ue.model")
 	eventTimestampSourceWhere, eventTimestampArgs = appendUsageColumnBounds(
 		eventTimestampSourceWhere, "ue.occurred_at", b, eventTimestampArgs)
 
 	var messageTimestampJoinArgs []any
 	messageTimestampJoinWhere, messageTimestampJoinArgs :=
 		f.appendUsageSessionFilterClauses(usageSessionEligibility, messageTimestampJoinArgs)
-	messageTimestampJoinWhere, messageTimestampJoinArgs =
-		f.appendUsageSessionModelMatchClauses(messageTimestampJoinWhere, messageTimestampJoinArgs)
 
 	var eventTimestampJoinArgs []any
 	eventTimestampJoinWhere, eventTimestampJoinArgs :=
 		f.appendUsageSessionFilterClauses(usageSessionEligibility, eventTimestampJoinArgs)
-	eventTimestampJoinWhere, eventTimestampJoinArgs =
-		f.appendUsageSessionModelMatchClauses(eventTimestampJoinWhere, eventTimestampJoinArgs)
 
 	messageFallbackWhere := usageMatchingMessageEligibility +
 		"\n\tAND NULLIF(m.timestamp, '') IS NULL"
 	var messageFallbackArgs []any
 	messageFallbackWhere, messageFallbackArgs =
-		f.appendUsageSessionFilterClauses(messageFallbackWhere, messageFallbackArgs)
-	messageFallbackWhere, messageFallbackArgs =
-		f.appendUsageSessionModelMatchClauses(messageFallbackWhere, messageFallbackArgs)
+		f.appendUsageBranchFilterClauses(
+			messageFallbackWhere, messageFallbackArgs, "m.model")
 	messageFallbackWhere, messageFallbackArgs = appendUsageColumnBounds(
 		messageFallbackWhere, "s.started_at", b, messageFallbackArgs)
 
@@ -914,9 +914,8 @@ func usageMatchingSessionRowsSQLForBounds(
 		"\n\tAND ue.occurred_at IS NULL"
 	var eventFallbackArgs []any
 	eventFallbackWhere, eventFallbackArgs =
-		f.appendUsageSessionFilterClauses(eventFallbackWhere, eventFallbackArgs)
-	eventFallbackWhere, eventFallbackArgs =
-		f.appendUsageSessionModelMatchClauses(eventFallbackWhere, eventFallbackArgs)
+		f.appendUsageBranchFilterClauses(
+			eventFallbackWhere, eventFallbackArgs, "ue.model")
 	eventFallbackWhere, eventFallbackArgs = appendUsageColumnBounds(
 		eventFallbackWhere, "s.started_at", b, eventFallbackArgs)
 

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -338,6 +338,22 @@ const usageMessageSourceEligibility = `
     AND m.model != ''
     AND m.model != '<synthetic>'`
 
+// usageMatchingMessageEligibility is usageMessageEligibility with the
+// token-presence requirement removed. GetUsageMatchingSessionCount counts
+// sessions that have usage-shaped activity even when the agent (e.g.
+// Copilot) never records per-message tokens, so it must not gate on
+// m.token_usage the way every token/cost query does. Do not reuse this
+// for usageRowQuery or its callers — see the usageMessageEligibility
+// doc comment above.
+const usageMatchingMessageEligibility = `
+    m.model != ''
+    AND m.model != '<synthetic>'
+    AND s.deleted_at IS NULL`
+
+const usageMatchingMessageSourceEligibility = `
+    m.model != ''
+    AND m.model != '<synthetic>'`
+
 const usageEventEligibility = `
     ue.model != ''
     AND s.deleted_at IS NULL`
@@ -833,6 +849,81 @@ func usageRowsSQLForBounds(
 		eventTimestampJoinWhere,
 		messageFallbackWhere,
 		eventFallbackWhere,
+	)
+	args := make(
+		[]any, 0,
+		len(messageTimestampArgs)+len(eventTimestampArgs)+
+			len(messageTimestampJoinArgs)+len(eventTimestampJoinArgs)+
+			len(messageFallbackArgs)+len(eventFallbackArgs),
+	)
+	args = append(args, messageTimestampArgs...)
+	args = append(args, eventTimestampArgs...)
+	args = append(args, messageTimestampJoinArgs...)
+	args = append(args, eventTimestampJoinArgs...)
+	args = append(args, messageFallbackArgs...)
+	args = append(args, eventFallbackArgs...)
+	return rowsSQL, args
+}
+
+// usageMatchingSessionRowsSQLForBounds mirrors usageRowsSQLForBounds's
+// bounded-branch CTE shape, but is built from the relaxed
+// usageMatchingMessageEligibility predicate and folds the session-wide
+// model-match clause into each branch instead of filtering per row, so
+// GetUsageMatchingSessionCount's Model/ExcludeModel semantics stay
+// bit-for-bit identical to the unbounded path. Only used by
+// GetUsageMatchingSessionCount's bounded branch.
+func usageMatchingSessionRowsSQLForBounds(
+	f UsageFilter, b usageBounds,
+) (string, []any) {
+	messageTimestampSourceWhere := usageMatchingMessageSourceEligibility +
+		"\n\tAND m.timestamp IS NOT NULL" +
+		"\n\tAND m.timestamp != ''"
+	var messageTimestampArgs []any
+	messageTimestampSourceWhere, messageTimestampArgs = appendUsageColumnBounds(
+		messageTimestampSourceWhere, "m.timestamp", b, messageTimestampArgs)
+
+	eventTimestampSourceWhere := usageEventSourceEligibility +
+		"\n\tAND ue.occurred_at IS NOT NULL"
+	var eventTimestampArgs []any
+	eventTimestampSourceWhere, eventTimestampArgs = appendUsageColumnBounds(
+		eventTimestampSourceWhere, "ue.occurred_at", b, eventTimestampArgs)
+
+	var messageTimestampJoinArgs []any
+	messageTimestampJoinWhere, messageTimestampJoinArgs :=
+		f.appendUsageSessionFilterClauses(usageSessionEligibility, messageTimestampJoinArgs)
+	messageTimestampJoinWhere, messageTimestampJoinArgs =
+		f.appendUsageSessionModelMatchClauses(messageTimestampJoinWhere, messageTimestampJoinArgs)
+
+	var eventTimestampJoinArgs []any
+	eventTimestampJoinWhere, eventTimestampJoinArgs :=
+		f.appendUsageSessionFilterClauses(usageSessionEligibility, eventTimestampJoinArgs)
+	eventTimestampJoinWhere, eventTimestampJoinArgs =
+		f.appendUsageSessionModelMatchClauses(eventTimestampJoinWhere, eventTimestampJoinArgs)
+
+	messageFallbackWhere := usageMatchingMessageEligibility +
+		"\n\tAND NULLIF(m.timestamp, '') IS NULL"
+	var messageFallbackArgs []any
+	messageFallbackWhere, messageFallbackArgs =
+		f.appendUsageSessionFilterClauses(messageFallbackWhere, messageFallbackArgs)
+	messageFallbackWhere, messageFallbackArgs =
+		f.appendUsageSessionModelMatchClauses(messageFallbackWhere, messageFallbackArgs)
+	messageFallbackWhere, messageFallbackArgs = appendUsageColumnBounds(
+		messageFallbackWhere, "s.started_at", b, messageFallbackArgs)
+
+	eventFallbackWhere := usageEventEligibility +
+		"\n\tAND ue.occurred_at IS NULL"
+	var eventFallbackArgs []any
+	eventFallbackWhere, eventFallbackArgs =
+		f.appendUsageSessionFilterClauses(eventFallbackWhere, eventFallbackArgs)
+	eventFallbackWhere, eventFallbackArgs =
+		f.appendUsageSessionModelMatchClauses(eventFallbackWhere, eventFallbackArgs)
+	eventFallbackWhere, eventFallbackArgs = appendUsageColumnBounds(
+		eventFallbackWhere, "s.started_at", b, eventFallbackArgs)
+
+	rowsSQL := dailyUsageRowsSQLWithTimestampCTEs(
+		messageTimestampSourceWhere, eventTimestampSourceWhere,
+		messageTimestampJoinWhere, eventTimestampJoinWhere,
+		messageFallbackWhere, eventFallbackWhere,
 	)
 	args := make(
 		[]any, 0,
@@ -2436,42 +2527,58 @@ func (db *DB) GetUsageSessionCounts(
 }
 
 // GetUsageMatchingSessionCount counts sessions that match the usage filter
-// even when they have no token-bearing usage rows.
+// even when they have no token-bearing usage rows. Bounded ranges are
+// resolved against the timestamps of the sessions' messages/usage_events
+// rows (falling back to s.started_at for rows with no timestamp of their
+// own), the same shape usageRowsSQLForBounds uses, so a session whose
+// started_at/ended_at fall outside the window but whose message activity
+// falls inside it is still counted.
 func (db *DB) GetUsageMatchingSessionCount(
 	ctx context.Context, f UsageFilter,
 ) (int, error) {
-	loc := f.location()
+	bounds := usageBoundsForFilter(f)
 
-	where, args := f.appendUsageSessionFilterClauses(
-		usageSessionEligibility, nil,
-	)
-	where, args = f.appendUsageSessionModelMatchClauses(where, args)
-	where, args = appendUsageColumnBounds(
-		where,
-		usageSessionActivityExprSQLite(),
-		usageBoundsForFilter(f),
-		args,
-	)
+	if !bounds.bounded() {
+		where, args := f.appendUsageSessionFilterClauses(usageSessionEligibility, nil)
+		where, args = f.appendUsageSessionModelMatchClauses(where, args)
 
-	rows, err := db.getReader().QueryContext(ctx, `
-		SELECT s.id, `+usageSessionActivityExprSQLite()+`
-		FROM sessions s
-		WHERE `+where, args...)
+		// Keep selecting session_activity_at even though it's unused here:
+		// this is the original query's WHERE/SELECT shape, unchanged, so
+		// nothing downstream (tests, tooling) that matches on this SQL
+		// text needs to change for the unbounded path.
+		rows, err := db.getReader().QueryContext(ctx, `
+			SELECT s.id, `+usageSessionActivityExprSQLite()+`
+			FROM sessions s WHERE `+where, args...)
+		if err != nil {
+			return 0, fmt.Errorf("querying matching usage sessions: %w", err)
+		}
+		defer rows.Close()
+		count := 0
+		for rows.Next() {
+			count++
+		}
+		if err := rows.Err(); err != nil {
+			return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
+		}
+		return count, nil
+	}
+
+	rowsSQL, args := usageMatchingSessionRowsSQLForBounds(f, bounds)
+	rows, err := db.getReader().QueryContext(
+		ctx, dailyUsageRowSelectFromRows(rowsSQL), args...)
 	if err != nil {
 		return 0, fmt.Errorf("querying matching usage sessions: %w", err)
 	}
 	defer rows.Close()
 
-	count := 0
+	loc := f.location()
+	seen := make(map[string]struct{})
 	for rows.Next() {
-		var (
-			id string
-			ts string
-		)
-		if err := rows.Scan(&id, &ts); err != nil {
+		r, err := scanDailyUsageRow(rows)
+		if err != nil {
 			return 0, fmt.Errorf("scanning matching usage session: %w", err)
 		}
-		date := localDate(ts, loc)
+		date := localDate(r.ts, loc)
 		if date == "" {
 			continue
 		}
@@ -2481,11 +2588,10 @@ func (db *DB) GetUsageMatchingSessionCount(
 		if f.To != "" && date > f.To {
 			continue
 		}
-		count++
+		seen[r.sessionID] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
 		return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
 	}
-
-	return count, nil
+	return len(seen), nil
 }

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -2078,6 +2078,63 @@ func TestGetUsageMatchingSessionCount_UsesMessageTimestampNotSessionActivity(
 	assert.Equal(t, 1, got)
 }
 
+// TestGetUsageMatchingSessionCount_ModelFilterAppliesToBoundedRow guards
+// against the model/exclude-model predicate being applied session-wide
+// instead of to the in-range message/event row: a session with an
+// out-of-range message on the filtered model but an in-range message on a
+// different model must not match a Model filter for the out-of-range
+// model, and must not be excluded by an ExcludeModel filter for the
+// out-of-range model either.
+func TestGetUsageMatchingSessionCount_ModelFilterAppliesToBoundedRow(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "copilot-mixed-model", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2026-02-08T10:00:00Z")
+		s.EndedAt = new("2026-02-10T12:00:00Z")
+	})
+	insertMessages(t, d,
+		Message{
+			SessionID: "copilot-mixed-model", Ordinal: 0,
+			Role: "assistant", Timestamp: "2026-02-08T10:00:00Z",
+			Model:      "gpt-5.3-codex",
+			TokenUsage: nil,
+		},
+		Message{
+			SessionID: "copilot-mixed-model", Ordinal: 1,
+			Role: "assistant", Timestamp: "2026-02-10T12:00:00Z",
+			Model:      "claude-sonnet",
+			TokenUsage: nil,
+		},
+	)
+
+	inRangeFilter := UsageFilter{
+		From: "2026-02-10", To: "2026-02-10",
+		Timezone: "UTC", Agent: "copilot",
+	}
+
+	got, err := d.GetUsageMatchingSessionCount(ctx, UsageFilter{
+		From: inRangeFilter.From, To: inRangeFilter.To,
+		Timezone: inRangeFilter.Timezone, Agent: inRangeFilter.Agent,
+		Model: "gpt-5.3-codex",
+	})
+	requireNoError(t, err, "GetUsageMatchingSessionCount with Model")
+	assert.Equal(t, 0, got,
+		"out-of-range message's model must not match the bounded window")
+
+	got, err = d.GetUsageMatchingSessionCount(ctx, UsageFilter{
+		From: inRangeFilter.From, To: inRangeFilter.To,
+		Timezone: inRangeFilter.Timezone, Agent: inRangeFilter.Agent,
+		ExcludeModel: "gpt-5.3-codex",
+	})
+	requireNoError(t, err, "GetUsageMatchingSessionCount with ExcludeModel")
+	assert.Equal(t, 1, got,
+		"in-range message's model is not excluded, so the session must still count")
+}
+
 func TestNewUsageSessionCounts(t *testing.T) {
 	counts := NewUsageSessionCounts(map[string]UsageSessionInfo{
 		"s1": {Project: "proj-a", Agent: "claude"},

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -2032,6 +2032,52 @@ func TestGetUsageMatchingSessionCount(t *testing.T) {
 	}
 }
 
+// TestGetUsageMatchingSessionCount_UsesMessageTimestampNotSessionActivity
+// guards against regressing to session-activity bounding: a Copilot
+// session whose started_at/ended_at fall outside the requested window but
+// whose message is timestamped inside it must still be counted, because
+// GetDailyUsage and GetUsageSessionCounts already bound on message/event
+// timestamps, not session activity.
+func TestGetUsageMatchingSessionCount_UsesMessageTimestampNotSessionActivity(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "copilot-late-message", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2026-02-08T10:00:00Z")
+		s.EndedAt = new("2026-02-08T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "copilot-late-message", Ordinal: 0,
+		Role: "assistant", Timestamp: "2026-02-10T12:00:00Z",
+		Model:      "gpt-5.3-codex",
+		TokenUsage: nil,
+	})
+
+	insertSession(t, d, "copilot-out-of-range", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2026-02-08T10:00:00Z")
+		s.EndedAt = new("2026-02-08T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "copilot-out-of-range", Ordinal: 0,
+		Role: "assistant", Timestamp: "2026-02-08T10:00:00Z",
+		Model:      "gpt-5.3-codex",
+		TokenUsage: nil,
+	})
+
+	filter := UsageFilter{
+		From: "2026-02-10", To: "2026-02-10",
+		Timezone: "UTC", Agent: "copilot",
+	}
+
+	got, err := d.GetUsageMatchingSessionCount(ctx, filter)
+	requireNoError(t, err, "GetUsageMatchingSessionCount")
+	assert.Equal(t, 1, got)
+}
+
 func TestNewUsageSessionCounts(t *testing.T) {
 	counts := NewUsageSessionCounts(map[string]UsageSessionInfo{
 		"s1": {Project: "proj-a", Agent: "claude"},

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -2135,6 +2135,38 @@ func TestGetUsageMatchingSessionCount_ModelFilterAppliesToBoundedRow(
 		"in-range message's model is not excluded, so the session must still count")
 }
 
+// TestGetUsageMatchingSessionCount_CountsAssistantMessageWithNoModel
+// guards against gating matching-session eligibility on m.model != ”:
+// some Copilot assistant messages parse before a model name is known, so
+// an assistant message with an empty Model must still count toward the
+// matching-session total when no Model/ExcludeModel filter narrows it.
+func TestGetUsageMatchingSessionCount_CountsAssistantMessageWithNoModel(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "copilot-no-model", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2026-02-10T10:00:00Z")
+		s.EndedAt = new("2026-02-10T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "copilot-no-model", Ordinal: 0,
+		Role: "assistant", Timestamp: "2026-02-10T10:00:00Z",
+		Model:      "",
+		TokenUsage: nil,
+	})
+
+	got, err := d.GetUsageMatchingSessionCount(ctx, UsageFilter{
+		From: "2026-02-10", To: "2026-02-10",
+		Timezone: "UTC", Agent: "copilot",
+	})
+	requireNoError(t, err, "GetUsageMatchingSessionCount")
+	assert.Equal(t, 1, got,
+		"assistant message with no model must still count without a model filter")
+}
+
 func TestNewUsageSessionCounts(t *testing.T) {
 	counts := NewUsageSessionCounts(map[string]UsageSessionInfo{
 		"s1": {Project: "proj-a", Agent: "claude"},

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -1956,6 +1956,82 @@ func TestGetUsageSessionCounts(t *testing.T) {
 	assert.Nil(t, dailyNoCounts.SessionCounts.ByAgent)
 }
 
+func TestGetUsageMatchingSessionCount(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "copilot-empty", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2024-06-15T10:00:00Z")
+		s.EndedAt = new("2024-06-15T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "copilot-empty", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T10:00:00Z",
+		Model: "gpt-5.3-codex",
+	})
+
+	insertSession(t, d, "claude-usage", "proj-a", func(s *Session) {
+		s.Agent = "claude"
+		s.StartedAt = new("2024-06-15T11:00:00Z")
+		s.EndedAt = new("2024-06-15T11:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "claude-usage", Ordinal: 0,
+		Role: "assistant", Timestamp: "2024-06-15T11:00:00Z",
+		Model: "claude-sonnet",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":100,"output_tokens":50}`),
+	})
+
+	tests := []struct {
+		name   string
+		filter UsageFilter
+		want   int
+	}{
+		{
+			name: "counts copilot sessions without usage rows",
+			filter: UsageFilter{
+				From: "2024-06-15", To: "2024-06-15",
+				Timezone: "UTC", Agent: "copilot",
+			},
+			want: 1,
+		},
+		{
+			name: "respects model filters from session messages",
+			filter: UsageFilter{
+				From: "2024-06-15", To: "2024-06-15",
+				Timezone: "UTC", Agent: "copilot", Model: "gpt-5.3-codex",
+			},
+			want: 1,
+		},
+		{
+			name: "excludes sessions when model is excluded",
+			filter: UsageFilter{
+				From: "2024-06-15", To: "2024-06-15",
+				Timezone: "UTC", Agent: "copilot", ExcludeModel: "gpt-5.3-codex",
+			},
+			want: 0,
+		},
+		{
+			name: "respects date range",
+			filter: UsageFilter{
+				From: "2024-06-16", To: "2024-06-16",
+				Timezone: "UTC", Agent: "copilot",
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := d.GetUsageMatchingSessionCount(ctx, tt.filter)
+			requireNoError(t, err, "GetUsageMatchingSessionCount")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestNewUsageSessionCounts(t *testing.T) {
 	counts := NewUsageSessionCounts(map[string]UsageSessionInfo{
 		"s1": {Project: "proj-a", Agent: "claude"},

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -2167,6 +2167,102 @@ func TestGetUsageMatchingSessionCount_CountsAssistantMessageWithNoModel(
 		"assistant message with no model must still count without a model filter")
 }
 
+// TestGetUsageMatchingSessionCount_UnboundedMatchesBoundedSemantics guards
+// against the unbounded (no From/To) branch drifting from the bounded
+// branch: both must require an assistant, non-synthetic message (or a
+// usage_events row with a model), both must admit empty-model assistant
+// messages, and Model/ExcludeModel must narrow the same rows.
+func TestGetUsageMatchingSessionCount_UnboundedMatchesBoundedSemantics(
+	t *testing.T,
+) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "copilot-user-only", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2026-03-01T10:00:00Z")
+		s.EndedAt = new("2026-03-01T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "copilot-user-only", Ordinal: 0,
+		Role: "user", Timestamp: "2026-03-01T10:00:00Z",
+	})
+
+	insertSession(t, d, "copilot-synthetic-only", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2026-03-01T11:00:00Z")
+		s.EndedAt = new("2026-03-01T11:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "copilot-synthetic-only", Ordinal: 0,
+		Role: "assistant", Timestamp: "2026-03-01T11:00:00Z",
+		Model: "<synthetic>",
+	})
+
+	insertSession(t, d, "copilot-no-model-msg", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2026-03-01T12:00:00Z")
+		s.EndedAt = new("2026-03-01T12:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "copilot-no-model-msg", Ordinal: 0,
+		Role: "assistant", Timestamp: "2026-03-01T12:00:00Z",
+		Model: "",
+	})
+
+	insertSession(t, d, "copilot-no-messages", "proj-a", func(s *Session) {
+		s.Agent = "copilot"
+		s.StartedAt = new("2026-03-01T13:00:00Z")
+		s.EndedAt = new("2026-03-01T13:00:00Z")
+	})
+
+	tests := []struct {
+		name   string
+		filter UsageFilter
+		want   int
+	}{
+		{
+			name:   "unbounded requires assistant or event activity",
+			filter: UsageFilter{Timezone: "UTC", Agent: "copilot"},
+			// Only copilot-no-model-msg has a qualifying assistant
+			// message; user-only, synthetic-only, and message-less
+			// sessions must not count.
+			want: 1,
+		},
+		{
+			name: "unbounded exclude-model keeps empty-model assistant messages",
+			filter: UsageFilter{
+				Timezone: "UTC", Agent: "copilot",
+				ExcludeModel: "gpt-5.3-codex",
+			},
+			want: 1,
+		},
+		{
+			name: "unbounded model filter narrows to matching rows",
+			filter: UsageFilter{
+				Timezone: "UTC", Agent: "copilot", Model: "gpt-5.3-codex",
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := d.GetUsageMatchingSessionCount(ctx, tt.filter)
+			requireNoError(t, err, "GetUsageMatchingSessionCount")
+			assert.Equal(t, tt.want, got)
+
+			bounded := tt.filter
+			bounded.From = "2026-03-01"
+			bounded.To = "2026-03-01"
+			boundedGot, err := d.GetUsageMatchingSessionCount(ctx, bounded)
+			requireNoError(t, err, "GetUsageMatchingSessionCount bounded")
+			assert.Equal(t, got, boundedGot,
+				"bounded and unbounded requests must match the same sessions")
+		})
+	}
+}
+
 func TestNewUsageSessionCounts(t *testing.T) {
 	counts := NewUsageSessionCounts(map[string]UsageSessionInfo{
 		"s1": {Project: "proj-a", Agent: "claude"},

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3101,31 +3101,60 @@ SELECT
 FROM cursor_usage_events cu
 WHERE %s`
 
-func duckUsageRawSQL(f db.UsageFilter, sessionID string) (string, []any) {
-	bounds := duckUsageBoundsForFilter(f)
-	messageWhere := `
+const duckUsageMessageEligibility = `
 			m.token_usage != ''
 			AND m.model != ''
 			AND m.model != '<synthetic>'
 			AND s.deleted_at IS NULL`
+
+// duckUsageMatchingMessageSourceEligibility is the message-only half of
+// duckUsageMessageEligibility with the token-presence requirement removed
+// and the model-presence requirement relaxed to a role check, for
+// GetUsageMatchingSessionCount. See the usageMatchingMessageEligibility
+// doc comment in internal/db.
+const duckUsageMatchingMessageSourceEligibility = `
+			m.role = 'assistant'
+			AND m.model != '<synthetic>'`
+
+const duckUsageMatchingMessageEligibility = duckUsageMatchingMessageSourceEligibility + `
+			AND s.deleted_at IS NULL`
+
+const duckUsageEventSourceEligibility = `
+			ue.model != ''`
+
+const duckUsageEventEligibility = duckUsageEventSourceEligibility + `
+			AND s.deleted_at IS NULL`
+
+// duckUsageSourceWheres builds the message/event WHERE clauses shared by
+// duckUsageRawSQL and duckMatchingUsageRawSQL; the two callers differ only
+// in the message eligibility predicate.
+func duckUsageSourceWheres(
+	f db.UsageFilter, sessionID, messageEligibility string, b duckUsageBounds,
+) (string, []any, string, []any) {
+	messageWhere := messageEligibility
 	var messageArgs []any
 	messageWhere, messageArgs = appendDuckUsageSourceFilterClauses(
 		messageWhere, messageArgs, "m.model", f)
 	messageWhere, messageArgs = appendDuckUsageSessionFilterClauses(
 		messageWhere, messageArgs, f, sessionID)
 	messageWhere, messageArgs = appendDuckUsageColumnBounds(
-		messageWhere, "COALESCE(m.timestamp, s.started_at)", bounds, messageArgs)
+		messageWhere, "COALESCE(m.timestamp, s.started_at)", b, messageArgs)
 
-	eventWhere := `
-			ue.model != ''
-			AND s.deleted_at IS NULL`
+	eventWhere := duckUsageEventEligibility
 	var eventArgs []any
 	eventWhere, eventArgs = appendDuckUsageSourceFilterClauses(
 		eventWhere, eventArgs, "ue.model", f)
 	eventWhere, eventArgs = appendDuckUsageSessionFilterClauses(
 		eventWhere, eventArgs, f, sessionID)
 	eventWhere, eventArgs = appendDuckUsageColumnBounds(
-		eventWhere, "COALESCE(ue.occurred_at, s.started_at)", bounds, eventArgs)
+		eventWhere, "COALESCE(ue.occurred_at, s.started_at)", b, eventArgs)
+
+	return messageWhere, messageArgs, eventWhere, eventArgs
+}
+
+func duckUsageRawSQL(f db.UsageFilter, sessionID string) (string, []any) {
+	messageWhere, messageArgs, eventWhere, eventArgs := duckUsageSourceWheres(
+		f, sessionID, duckUsageMessageEligibility, duckUsageBoundsForFilter(f))
 
 	query := fmt.Sprintf(`
 		SELECT m.session_id AS session_id, m.ordinal AS message_ordinal,
@@ -3175,42 +3204,16 @@ func duckUsageRawSQL(f db.UsageFilter, sessionID string) (string, []any) {
 }
 
 // duckMatchingUsageRawSQL builds the bounded-range row source for
-// GetUsageMatchingSessionCount. DuckDB's normal usage query
-// (duckUsageRawSQL) already bounds each row source on
-// COALESCE(m.timestamp, s.started_at) / COALESCE(ue.occurred_at,
-// s.started_at) directly, so this mirrors that shape but relaxes the
-// message predicate: no token_usage requirement (Copilot messages never
-// populate it) and no model-presence requirement (some Copilot assistant
-// messages parse before a model name is known), scoping to assistant rows
-// via m.role instead. Model/ExcludeModel filters are still applied
-// per-row via appendDuckUsageSourceFilterClauses, same as duckUsageRawSQL,
-// so GetUsageMatchingSessionCount's semantics only relax the token-usage
-// and model-presence requirements.
+// GetUsageMatchingSessionCount. It shares duckUsageRawSQL's WHERE
+// assembly (via duckUsageSourceWheres) but relaxes the message predicate:
+// no token_usage requirement (Copilot messages never populate it) and no
+// model-presence requirement (some Copilot assistant messages parse
+// before a model name is known), scoping to assistant rows via m.role
+// instead. Model/ExcludeModel filters are still applied per-row, same as
+// duckUsageRawSQL.
 func duckMatchingUsageRawSQL(f db.UsageFilter) (string, []any) {
-	bounds := duckUsageBoundsForFilter(f)
-
-	messageWhere := `
-			m.role = 'assistant'
-			AND m.model != '<synthetic>'
-			AND s.deleted_at IS NULL`
-	var messageArgs []any
-	messageWhere, messageArgs = appendDuckUsageSourceFilterClauses(
-		messageWhere, messageArgs, "m.model", f)
-	messageWhere, messageArgs = appendDuckUsageSessionFilterClauses(
-		messageWhere, messageArgs, f, "")
-	messageWhere, messageArgs = appendDuckUsageColumnBounds(
-		messageWhere, "COALESCE(m.timestamp, s.started_at)", bounds, messageArgs)
-
-	eventWhere := `
-			ue.model != ''
-			AND s.deleted_at IS NULL`
-	var eventArgs []any
-	eventWhere, eventArgs = appendDuckUsageSourceFilterClauses(
-		eventWhere, eventArgs, "ue.model", f)
-	eventWhere, eventArgs = appendDuckUsageSessionFilterClauses(
-		eventWhere, eventArgs, f, "")
-	eventWhere, eventArgs = appendDuckUsageColumnBounds(
-		eventWhere, "COALESCE(ue.occurred_at, s.started_at)", bounds, eventArgs)
+	messageWhere, messageArgs, eventWhere, eventArgs := duckUsageSourceWheres(
+		f, "", duckUsageMatchingMessageEligibility, duckUsageBoundsForFilter(f))
 
 	query := fmt.Sprintf(`
 		SELECT m.session_id AS session_id,
@@ -3798,20 +3801,20 @@ func (s *Store) GetUsageSessionCounts(
 	return out, nil
 }
 
-func appendDuckUsageSessionModelMatchClauses(
+// appendDuckUsageMatchingActivityClauses requires the session to have at
+// least one row that GetUsageMatchingSessionCount's bounded branch would
+// count, mirroring appendUsageMatchingActivityClauses in internal/db so
+// bounded and unbounded requests agree on which sessions match.
+func appendDuckUsageMatchingActivityClauses(
 	where string, args []any, f db.UsageFilter,
 ) (string, []any) {
-	if strings.TrimSpace(f.Model) == "" && strings.TrimSpace(f.ExcludeModel) == "" {
-		return where, args
-	}
-
 	var messageArgs []any
 	messageWhere, messageArgs := appendDuckUsageSourceFilterClauses(
-		"m.model != ''", messageArgs, "m.model", f,
+		duckUsageMatchingMessageSourceEligibility, messageArgs, "m.model", f,
 	)
 	var eventArgs []any
 	eventWhere, eventArgs := appendDuckUsageSourceFilterClauses(
-		"ue.model != ''", eventArgs, "ue.model", f,
+		duckUsageEventSourceEligibility, eventArgs, "ue.model", f,
 	)
 
 	where += `
@@ -3844,24 +3847,16 @@ func (s *Store) GetUsageMatchingSessionCount(
 	ctx context.Context, f db.UsageFilter,
 ) (int, error) {
 	if f.From == "" && f.To == "" {
-		where, args := appendDuckUsageSessionFilterClauses("1=1", nil, f, "")
-		where, args = appendDuckUsageSessionModelMatchClauses(where, args, f)
+		where, args := appendDuckUsageSessionFilterClauses(
+			"s.deleted_at IS NULL", nil, f, "")
+		where, args = appendDuckUsageMatchingActivityClauses(where, args, f)
 
-		// Keep selecting the activity column even though it's unused
-		// here: the original query's WHERE/SELECT shape, unchanged.
-		rows, err := s.duck.QueryContext(ctx, `
-			SELECT s.id, COALESCE(s.ended_at, s.started_at, s.created_at)
-			FROM sessions s WHERE `+where, args...)
+		var count int
+		err := s.duck.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM sessions s WHERE `+where, args...).Scan(&count)
 		if err != nil {
 			return 0, fmt.Errorf("querying matching usage sessions: %w", err)
-		}
-		defer rows.Close()
-		count := 0
-		for rows.Next() {
-			count++
-		}
-		if err := rows.Err(); err != nil {
-			return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
 		}
 		return count, nil
 	}

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3741,6 +3741,95 @@ func (s *Store) GetUsageSessionCounts(
 	return out, nil
 }
 
+func appendDuckUsageSessionModelMatchClauses(
+	where string, args []any, f db.UsageFilter,
+) (string, []any) {
+	if strings.TrimSpace(f.Model) == "" && strings.TrimSpace(f.ExcludeModel) == "" {
+		return where, args
+	}
+
+	var messageArgs []any
+	messageWhere, messageArgs := appendDuckUsageSourceFilterClauses(
+		"m.model != ''", messageArgs, "m.model", f,
+	)
+	var eventArgs []any
+	eventWhere, eventArgs := appendDuckUsageSourceFilterClauses(
+		"ue.model != ''", eventArgs, "ue.model", f,
+	)
+
+	where += `
+		AND (
+			EXISTS (
+				SELECT 1
+				FROM messages m
+				WHERE m.session_id = s.id
+					AND ` + messageWhere + `
+			)
+			OR EXISTS (
+				SELECT 1
+				FROM usage_events ue
+				WHERE ue.session_id = s.id
+					AND ` + eventWhere + `
+			)
+		)`
+	args = append(args, messageArgs...)
+	args = append(args, eventArgs...)
+	return where, args
+}
+
+func (s *Store) GetUsageMatchingSessionCount(
+	ctx context.Context, f db.UsageFilter,
+) (int, error) {
+	where, args := appendDuckUsageSessionFilterClauses(
+		"1=1", nil, f, "",
+	)
+	where, args = appendDuckUsageSessionModelMatchClauses(where, args, f)
+	if f.From != "" {
+		where += "\n\t\t\tAND COALESCE(s.ended_at, s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)"
+		args = append(args, duckUsagePaddedUTCBound(f.From+"T00:00:00Z", -14))
+	}
+	if f.To != "" {
+		where += "\n\t\t\tAND COALESCE(s.ended_at, s.started_at, s.created_at) <= CAST(? AS TIMESTAMP)"
+		args = append(args, duckUsagePaddedUTCBound(f.To+"T23:59:59Z", 14))
+	}
+
+	rows, err := s.duck.QueryContext(ctx, `
+		SELECT s.id, COALESCE(s.ended_at, s.started_at, s.created_at)
+		FROM sessions s
+		WHERE `+where, args...)
+	if err != nil {
+		return 0, fmt.Errorf("querying matching usage sessions: %w", err)
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var (
+			id string
+			ts any
+		)
+		if err := rows.Scan(&id, &ts); err != nil {
+			return 0, fmt.Errorf("scanning matching usage session: %w", err)
+		}
+		date := analyticsLocalDate(formatDBTime(ts), f.Timezone)
+		if date == "" {
+			continue
+		}
+		if f.From != "" && date < f.From {
+			continue
+		}
+		if f.To != "" && date > f.To {
+			continue
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
+	}
+
+	return count, nil
+}
+
 func (s *Store) GetSessionUsage(
 	ctx context.Context, sessionID string,
 ) (*db.SessionUsage, error) {

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3179,15 +3179,18 @@ func duckUsageRawSQL(f db.UsageFilter, sessionID string) (string, []any) {
 // (duckUsageRawSQL) already bounds each row source on
 // COALESCE(m.timestamp, s.started_at) / COALESCE(ue.occurred_at,
 // s.started_at) directly, so this mirrors that shape but relaxes the
-// message predicate (no token_usage requirement — Copilot messages never
-// populate it), keeping the same per-row Model/ExcludeModel filtering as
-// duckUsageRawSQL so GetUsageMatchingSessionCount's semantics only relax
-// the token-usage requirement.
+// message predicate: no token_usage requirement (Copilot messages never
+// populate it) and no model-presence requirement (some Copilot assistant
+// messages parse before a model name is known), scoping to assistant rows
+// via m.role instead. Model/ExcludeModel filters are still applied
+// per-row via appendDuckUsageSourceFilterClauses, same as duckUsageRawSQL,
+// so GetUsageMatchingSessionCount's semantics only relax the token-usage
+// and model-presence requirements.
 func duckMatchingUsageRawSQL(f db.UsageFilter) (string, []any) {
 	bounds := duckUsageBoundsForFilter(f)
 
 	messageWhere := `
-			m.model != ''
+			m.role = 'assistant'
 			AND m.model != '<synthetic>'
 			AND s.deleted_at IS NULL`
 	var messageArgs []any

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3174,6 +3174,60 @@ func duckUsageRawSQL(f db.UsageFilter, sessionID string) (string, []any) {
 	return query, args
 }
 
+// duckMatchingUsageRawSQL builds the bounded-range row source for
+// GetUsageMatchingSessionCount. DuckDB's normal usage query
+// (duckUsageRawSQL) already bounds each row source on
+// COALESCE(m.timestamp, s.started_at) / COALESCE(ue.occurred_at,
+// s.started_at) directly, so this mirrors that shape but relaxes the
+// message predicate (no token_usage requirement — Copilot messages never
+// populate it) and folds the session-wide model-match clause into each
+// branch instead of filtering per row, preserving
+// GetUsageMatchingSessionCount's existing Model/ExcludeModel semantics.
+func duckMatchingUsageRawSQL(f db.UsageFilter) (string, []any) {
+	bounds := duckUsageBoundsForFilter(f)
+
+	messageWhere := `
+			m.model != ''
+			AND m.model != '<synthetic>'
+			AND s.deleted_at IS NULL`
+	var messageArgs []any
+	messageWhere, messageArgs = appendDuckUsageSessionFilterClauses(
+		messageWhere, messageArgs, f, "")
+	messageWhere, messageArgs = appendDuckUsageSessionModelMatchClauses(
+		messageWhere, messageArgs, f)
+	messageWhere, messageArgs = appendDuckUsageColumnBounds(
+		messageWhere, "COALESCE(m.timestamp, s.started_at)", bounds, messageArgs)
+
+	eventWhere := `
+			ue.model != ''
+			AND s.deleted_at IS NULL`
+	var eventArgs []any
+	eventWhere, eventArgs = appendDuckUsageSessionFilterClauses(
+		eventWhere, eventArgs, f, "")
+	eventWhere, eventArgs = appendDuckUsageSessionModelMatchClauses(
+		eventWhere, eventArgs, f)
+	eventWhere, eventArgs = appendDuckUsageColumnBounds(
+		eventWhere, "COALESCE(ue.occurred_at, s.started_at)", bounds, eventArgs)
+
+	query := fmt.Sprintf(`
+		SELECT m.session_id AS session_id,
+			COALESCE(m.timestamp, s.started_at) AS ts
+		FROM messages m
+		JOIN sessions s ON s.id = m.session_id
+		WHERE %s
+		UNION ALL
+		SELECT ue.session_id AS session_id,
+			COALESCE(ue.occurred_at, s.started_at) AS ts
+		FROM usage_events ue
+		JOIN sessions s ON s.id = ue.session_id
+		WHERE %s`,
+		messageWhere, eventWhere)
+	args := make([]any, 0, len(messageArgs)+len(eventArgs))
+	args = append(args, messageArgs...)
+	args = append(args, eventArgs...)
+	return query, args
+}
+
 func duckCursorUsageRowsSQLForBounds(
 	f db.UsageFilter, b duckUsageBounds,
 ) (string, []any, bool) {
@@ -3777,32 +3831,46 @@ func appendDuckUsageSessionModelMatchClauses(
 	return where, args
 }
 
+// GetUsageMatchingSessionCount counts sessions that match the usage filter
+// even when they have no token-bearing usage rows. Bounded ranges are
+// resolved against message/usage_events timestamps (falling back to
+// s.started_at), the same shape duckUsageRawSQL already uses for the
+// normal usage query, so a session whose activity falls outside the
+// window but whose message timestamp falls inside it is still counted.
 func (s *Store) GetUsageMatchingSessionCount(
 	ctx context.Context, f db.UsageFilter,
 ) (int, error) {
-	where, args := appendDuckUsageSessionFilterClauses(
-		"1=1", nil, f, "",
-	)
-	where, args = appendDuckUsageSessionModelMatchClauses(where, args, f)
-	if f.From != "" {
-		where += "\n\t\t\tAND COALESCE(s.ended_at, s.started_at, s.created_at) >= CAST(? AS TIMESTAMP)"
-		args = append(args, duckUsagePaddedUTCBound(f.From+"T00:00:00Z", -14))
-	}
-	if f.To != "" {
-		where += "\n\t\t\tAND COALESCE(s.ended_at, s.started_at, s.created_at) <= CAST(? AS TIMESTAMP)"
-		args = append(args, duckUsagePaddedUTCBound(f.To+"T23:59:59Z", 14))
+	if f.From == "" && f.To == "" {
+		where, args := appendDuckUsageSessionFilterClauses("1=1", nil, f, "")
+		where, args = appendDuckUsageSessionModelMatchClauses(where, args, f)
+
+		// Keep selecting the activity column even though it's unused
+		// here: the original query's WHERE/SELECT shape, unchanged.
+		rows, err := s.duck.QueryContext(ctx, `
+			SELECT s.id, COALESCE(s.ended_at, s.started_at, s.created_at)
+			FROM sessions s WHERE `+where, args...)
+		if err != nil {
+			return 0, fmt.Errorf("querying matching usage sessions: %w", err)
+		}
+		defer rows.Close()
+		count := 0
+		for rows.Next() {
+			count++
+		}
+		if err := rows.Err(); err != nil {
+			return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
+		}
+		return count, nil
 	}
 
-	rows, err := s.duck.QueryContext(ctx, `
-		SELECT s.id, COALESCE(s.ended_at, s.started_at, s.created_at)
-		FROM sessions s
-		WHERE `+where, args...)
+	query, args := duckMatchingUsageRawSQL(f)
+	rows, err := s.duck.QueryContext(ctx, query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("querying matching usage sessions: %w", err)
 	}
 	defer rows.Close()
 
-	count := 0
+	seen := make(map[string]struct{})
 	for rows.Next() {
 		var (
 			id string
@@ -3821,13 +3889,12 @@ func (s *Store) GetUsageMatchingSessionCount(
 		if f.To != "" && date > f.To {
 			continue
 		}
-		count++
+		seen[id] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
 		return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
 	}
-
-	return count, nil
+	return len(seen), nil
 }
 
 func (s *Store) GetSessionUsage(

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3180,9 +3180,9 @@ func duckUsageRawSQL(f db.UsageFilter, sessionID string) (string, []any) {
 // COALESCE(m.timestamp, s.started_at) / COALESCE(ue.occurred_at,
 // s.started_at) directly, so this mirrors that shape but relaxes the
 // message predicate (no token_usage requirement — Copilot messages never
-// populate it) and folds the session-wide model-match clause into each
-// branch instead of filtering per row, preserving
-// GetUsageMatchingSessionCount's existing Model/ExcludeModel semantics.
+// populate it), keeping the same per-row Model/ExcludeModel filtering as
+// duckUsageRawSQL so GetUsageMatchingSessionCount's semantics only relax
+// the token-usage requirement.
 func duckMatchingUsageRawSQL(f db.UsageFilter) (string, []any) {
 	bounds := duckUsageBoundsForFilter(f)
 
@@ -3191,10 +3191,10 @@ func duckMatchingUsageRawSQL(f db.UsageFilter) (string, []any) {
 			AND m.model != '<synthetic>'
 			AND s.deleted_at IS NULL`
 	var messageArgs []any
+	messageWhere, messageArgs = appendDuckUsageSourceFilterClauses(
+		messageWhere, messageArgs, "m.model", f)
 	messageWhere, messageArgs = appendDuckUsageSessionFilterClauses(
 		messageWhere, messageArgs, f, "")
-	messageWhere, messageArgs = appendDuckUsageSessionModelMatchClauses(
-		messageWhere, messageArgs, f)
 	messageWhere, messageArgs = appendDuckUsageColumnBounds(
 		messageWhere, "COALESCE(m.timestamp, s.started_at)", bounds, messageArgs)
 
@@ -3202,10 +3202,10 @@ func duckMatchingUsageRawSQL(f db.UsageFilter) (string, []any) {
 			ue.model != ''
 			AND s.deleted_at IS NULL`
 	var eventArgs []any
+	eventWhere, eventArgs = appendDuckUsageSourceFilterClauses(
+		eventWhere, eventArgs, "ue.model", f)
 	eventWhere, eventArgs = appendDuckUsageSessionFilterClauses(
 		eventWhere, eventArgs, f, "")
-	eventWhere, eventArgs = appendDuckUsageSessionModelMatchClauses(
-		eventWhere, eventArgs, f)
 	eventWhere, eventArgs = appendDuckUsageColumnBounds(
 		eventWhere, "COALESCE(ue.occurred_at, s.started_at)", bounds, eventArgs)
 

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -525,6 +525,111 @@ func TestDuckDBGetUsageMatchingSessionCountCountsAssistantMessageWithNoModel(
 		"assistant message with no model must still count without a model filter")
 }
 
+// TestDuckDBGetUsageMatchingSessionCountUnboundedMatchesBoundedSemantics
+// guards against the unbounded (no From/To) branch drifting from the
+// bounded branch: soft-deleted sessions must be excluded (backend parity
+// with SQLite/PG, which seed their unbounded WHERE with the deleted_at
+// eligibility), sessions without assistant/event activity must not count,
+// and empty-model assistant messages must survive an ExcludeModel filter.
+func TestDuckDBGetUsageMatchingSessionCountUnboundedMatchesBoundedSemantics(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	ts := "2026-03-01T10:00:00Z"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{
+			Session: db.Session{
+				ID:               "duck-copilot-live",
+				Project:          "alpha",
+				Machine:          "test-machine",
+				Agent:            "copilot",
+				StartedAt:        &ts,
+				EndedAt:          &ts,
+				MessageCount:     1,
+				UserMessageCount: 1,
+			},
+			Messages: []db.Message{{
+				SessionID:  "duck-copilot-live",
+				Ordinal:    0,
+				Role:       "assistant",
+				Timestamp:  ts,
+				Model:      "",
+				TokenUsage: nil,
+			}},
+			ReplaceMessages: true,
+		},
+		{
+			Session: db.Session{
+				ID:               "duck-copilot-trashed",
+				Project:          "alpha",
+				Machine:          "test-machine",
+				Agent:            "copilot",
+				StartedAt:        &ts,
+				EndedAt:          &ts,
+				MessageCount:     1,
+				UserMessageCount: 1,
+			},
+			Messages: []db.Message{{
+				SessionID:  "duck-copilot-trashed",
+				Ordinal:    0,
+				Role:       "assistant",
+				Timestamp:  ts,
+				Model:      "gpt-5.3-codex",
+				TokenUsage: nil,
+			}},
+			ReplaceMessages: true,
+		},
+		{
+			Session: db.Session{
+				ID:               "duck-copilot-user-only",
+				Project:          "alpha",
+				Machine:          "test-machine",
+				Agent:            "copilot",
+				StartedAt:        &ts,
+				EndedAt:          &ts,
+				MessageCount:     1,
+				UserMessageCount: 1,
+			},
+			Messages: []db.Message{{
+				SessionID: "duck-copilot-user-only",
+				Ordinal:   0,
+				Role:      "user",
+				Timestamp: ts,
+			}},
+			ReplaceMessages: true,
+		},
+	})
+	require.NoError(t, err, "seed copilot sessions")
+	require.NoError(t, local.SoftDeleteSession("duck-copilot-trashed"))
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	unbounded := db.UsageFilter{Timezone: "UTC", Agent: "copilot"}
+	count, err := store.GetUsageMatchingSessionCount(ctx, unbounded)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count,
+		"soft-deleted and assistant-less sessions must not count unbounded")
+
+	bounded := unbounded
+	bounded.From = "2026-03-01"
+	bounded.To = "2026-03-01"
+	boundedCount, err := store.GetUsageMatchingSessionCount(ctx, bounded)
+	require.NoError(t, err)
+	assert.Equal(t, count, boundedCount,
+		"bounded and unbounded requests must match the same sessions")
+
+	excluded := unbounded
+	excluded.ExcludeModel = "gpt-5.3-codex"
+	excludedCount, err := store.GetUsageMatchingSessionCount(ctx, excluded)
+	require.NoError(t, err)
+	assert.Equal(t, 1, excludedCount,
+		"empty-model assistant message must survive an ExcludeModel filter")
+}
+
 func duckSessionIDs(sessions []db.Session) []string {
 	ids := make([]string, len(sessions))
 	for i, session := range sessions {

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -477,6 +477,54 @@ func TestDuckDBGetUsageMatchingSessionCountModelFilterAppliesToBoundedRow(
 		"out-of-range message's model must not match the bounded window")
 }
 
+// TestDuckDBGetUsageMatchingSessionCountCountsAssistantMessageWithNoModel
+// guards against gating matching-session eligibility on m.model != ”:
+// some Copilot assistant messages parse before a model name is known, so
+// an assistant message with an empty Model must still count toward the
+// matching-session total when no Model/ExcludeModel filter narrows it.
+func TestDuckDBGetUsageMatchingSessionCountCountsAssistantMessageWithNoModel(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	ts := "2026-02-10T10:00:00Z"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: db.Session{
+			ID:               "duck-copilot-no-model",
+			Project:          "alpha",
+			Machine:          "test-machine",
+			Agent:            "copilot",
+			StartedAt:        &ts,
+			EndedAt:          &ts,
+			MessageCount:     1,
+			UserMessageCount: 1,
+		},
+		Messages: []db.Message{{
+			SessionID:  "duck-copilot-no-model",
+			Ordinal:    0,
+			Role:       "assistant",
+			Timestamp:  ts,
+			Model:      "",
+			TokenUsage: nil,
+		}},
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err, "seed no-model copilot session")
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, db.UsageFilter{
+		From: "2026-02-10", To: "2026-02-10",
+		Timezone: "UTC", Agent: "copilot",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count,
+		"assistant message with no model must still count without a model filter")
+}
+
 func duckSessionIDs(sessions []db.Session) []string {
 	ids := make([]string, len(sessions))
 	for i, session := range sessions {

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -306,6 +306,50 @@ func requireReadOnlyDuck(t *testing.T, err error) {
 	assert.True(t, errors.Is(err, db.ErrReadOnly), "expected ErrReadOnly, got %v", err)
 }
 
+func TestDuckDBGetUsageMatchingSessionCountCountsCopilotSessionsWithoutUsageRows(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	ts := "2024-06-15T10:00:00Z"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: db.Session{
+			ID:               "duck-copilot-empty",
+			Project:          "alpha",
+			Machine:          "test-machine",
+			Agent:            "copilot",
+			StartedAt:        &ts,
+			EndedAt:          &ts,
+			MessageCount:     1,
+			UserMessageCount: 1,
+		},
+		Messages: []db.Message{{
+			SessionID:  "duck-copilot-empty",
+			Ordinal:    0,
+			Role:       "assistant",
+			Timestamp:  ts,
+			Model:      "gpt-5.3-codex",
+			TokenUsage: nil,
+		}},
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err, "seed copilot session")
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, db.UsageFilter{
+		From:     "2024-06-15",
+		To:       "2024-06-15",
+		Timezone: "UTC",
+		Agent:    "copilot",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
 func duckSessionIDs(sessions []db.Session) []string {
 	ids := make([]string, len(sessions))
 	for i, session := range sessions {

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -350,6 +350,73 @@ func TestDuckDBGetUsageMatchingSessionCountCountsCopilotSessionsWithoutUsageRows
 	require.Equal(t, 1, count)
 }
 
+func TestDuckDBGetUsageMatchingSessionCountCountsCopilotSessionByMessageTimestampOutsideSessionWindow(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	activityTS := "2026-02-08T10:00:00Z"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{
+			Session: db.Session{
+				ID:               "duck-copilot-late-message",
+				Project:          "alpha",
+				Machine:          "test-machine",
+				Agent:            "copilot",
+				StartedAt:        &activityTS,
+				EndedAt:          &activityTS,
+				MessageCount:     1,
+				UserMessageCount: 1,
+			},
+			Messages: []db.Message{{
+				SessionID:  "duck-copilot-late-message",
+				Ordinal:    0,
+				Role:       "assistant",
+				Timestamp:  "2026-02-10T12:00:00Z",
+				Model:      "gpt-5.3-codex",
+				TokenUsage: nil,
+			}},
+			ReplaceMessages: true,
+		},
+		{
+			Session: db.Session{
+				ID:               "duck-copilot-out-of-range",
+				Project:          "alpha",
+				Machine:          "test-machine",
+				Agent:            "copilot",
+				StartedAt:        &activityTS,
+				EndedAt:          &activityTS,
+				MessageCount:     1,
+				UserMessageCount: 1,
+			},
+			Messages: []db.Message{{
+				SessionID:  "duck-copilot-out-of-range",
+				Ordinal:    0,
+				Role:       "assistant",
+				Timestamp:  activityTS,
+				Model:      "gpt-5.3-codex",
+				TokenUsage: nil,
+			}},
+			ReplaceMessages: true,
+		},
+	})
+	require.NoError(t, err, "seed copilot sessions")
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, db.UsageFilter{
+		From:     "2026-02-10",
+		To:       "2026-02-10",
+		Timezone: "UTC",
+		Agent:    "copilot",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
 func duckSessionIDs(sessions []db.Session) []string {
 	ids := make([]string, len(sessions))
 	for i, session := range sessions {

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -417,6 +417,66 @@ func TestDuckDBGetUsageMatchingSessionCountCountsCopilotSessionByMessageTimestam
 	require.Equal(t, 1, count)
 }
 
+// TestDuckDBGetUsageMatchingSessionCountModelFilterAppliesToBoundedRow
+// guards against the model/exclude-model predicate matching session-wide
+// instead of on the in-range message row: a session with an out-of-range
+// message on the filtered model but an in-range message on a different
+// model must not match a Model filter for the out-of-range model.
+func TestDuckDBGetUsageMatchingSessionCountModelFilterAppliesToBoundedRow(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	startedAt := "2026-02-08T10:00:00Z"
+	endedAt := "2026-02-10T12:00:00Z"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: db.Session{
+			ID:               "duck-copilot-mixed-model",
+			Project:          "alpha",
+			Machine:          "test-machine",
+			Agent:            "copilot",
+			StartedAt:        &startedAt,
+			EndedAt:          &endedAt,
+			MessageCount:     2,
+			UserMessageCount: 1,
+		},
+		Messages: []db.Message{
+			{
+				SessionID:  "duck-copilot-mixed-model",
+				Ordinal:    0,
+				Role:       "assistant",
+				Timestamp:  "2026-02-08T10:00:00Z",
+				Model:      "gpt-5.3-codex",
+				TokenUsage: nil,
+			},
+			{
+				SessionID:  "duck-copilot-mixed-model",
+				Ordinal:    1,
+				Role:       "assistant",
+				Timestamp:  "2026-02-10T12:00:00Z",
+				Model:      "claude-sonnet",
+				TokenUsage: nil,
+			},
+		},
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err, "seed mixed-model copilot session")
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, db.UsageFilter{
+		From: "2026-02-10", To: "2026-02-10",
+		Timezone: "UTC", Agent: "copilot",
+		Model: "gpt-5.3-codex",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, count,
+		"out-of-range message's model must not match the bounded window")
+}
+
 func duckSessionIDs(sessions []db.Session) []string {
 	ids := make([]string, len(sessions))
 	for i, session := range sessions {

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -626,7 +626,19 @@ func pgDailyUsageRowsSQLForBounds(
 		return pgDailyUsageRowsSQLWithWhere(messageWhere, eventWhere)
 	}
 
-	messageTimestampSourceWhere := pgUsageMessageSourceEligibility +
+	return pgBoundedDailyUsageRowsSQL(
+		pb, f, b, pgUsageMessageSourceEligibility, pgUsageMessageEligibility)
+}
+
+// pgBoundedDailyUsageRowsSQL builds the bounded-branch CTE row source
+// shared by pgDailyUsageRowsSQLForBounds (token-eligible rows) and
+// pgMatchingUsageRowsSQLForBounds (relaxed matching rows). The two
+// callers differ only in the message eligibility predicates.
+func pgBoundedDailyUsageRowsSQL(
+	pb *paramBuilder, f db.UsageFilter, b pgUsageBounds,
+	messageSourceEligibility, messageEligibility string,
+) string {
+	messageTimestampSourceWhere := messageSourceEligibility +
 		"\n\tAND m.timestamp IS NOT NULL"
 	messageTimestampSourceWhere = appendPGUsageSourceFilterClauses(
 		messageTimestampSourceWhere, pb, f, "m.model")
@@ -645,7 +657,7 @@ func pgDailyUsageRowsSQLForBounds(
 	eventTimestampJoinWhere := appendPGUsageSessionFilterClauses(
 		pgUsageSessionEligibility, pb, f)
 
-	messageFallbackWhere := pgUsageMessageEligibility +
+	messageFallbackWhere := messageEligibility +
 		"\n\tAND m.timestamp IS NULL"
 	messageFallbackWhere = appendPGUsageBranchFilterClauses(
 		messageFallbackWhere, pb, f, "m.model")
@@ -668,53 +680,17 @@ func pgDailyUsageRowsSQLForBounds(
 	)
 }
 
-// pgMatchingUsageRowsSQLForBounds mirrors pgDailyUsageRowsSQLForBounds's
-// bounded-branch CTE shape, but is built from the relaxed
-// pgUsageMatchingMessageEligibility predicate, so GetUsageMatchingSessionCount
-// only relaxes the token-usage requirement and keeps the same per-row
-// Model/ExcludeModel filtering as the normal bounded path. Only used by
-// GetUsageMatchingSessionCount's bounded branch.
+// pgMatchingUsageRowsSQLForBounds is pgDailyUsageRowsSQLForBounds's
+// bounded branch built from the relaxed pgUsageMatchingMessageEligibility
+// predicates, so GetUsageMatchingSessionCount only relaxes the token-usage
+// and model-presence requirements and keeps the same per-row
+// Model/ExcludeModel filtering as the normal bounded path.
 func pgMatchingUsageRowsSQLForBounds(
 	pb *paramBuilder, f db.UsageFilter, b pgUsageBounds,
 ) string {
-	messageTimestampSourceWhere := pgUsageMatchingMessageSourceEligibility +
-		"\n\tAND m.timestamp IS NOT NULL"
-	messageTimestampSourceWhere = appendPGUsageSourceFilterClauses(
-		messageTimestampSourceWhere, pb, f, "m.model")
-	messageTimestampSourceWhere = appendPGUsageColumnBounds(
-		messageTimestampSourceWhere, "m.timestamp", b)
-
-	eventTimestampSourceWhere := pgUsageEventSourceEligibility +
-		"\n\tAND ue.occurred_at IS NOT NULL"
-	eventTimestampSourceWhere = appendPGUsageSourceFilterClauses(
-		eventTimestampSourceWhere, pb, f, "ue.model")
-	eventTimestampSourceWhere = appendPGUsageColumnBounds(
-		eventTimestampSourceWhere, "ue.occurred_at", b)
-
-	messageTimestampJoinWhere := appendPGUsageSessionFilterClauses(
-		pgUsageSessionEligibility, pb, f)
-	eventTimestampJoinWhere := appendPGUsageSessionFilterClauses(
-		pgUsageSessionEligibility, pb, f)
-
-	messageFallbackWhere := pgUsageMatchingMessageEligibility +
-		"\n\tAND m.timestamp IS NULL"
-	messageFallbackWhere = appendPGUsageBranchFilterClauses(
-		messageFallbackWhere, pb, f, "m.model")
-	messageFallbackWhere = appendPGUsageColumnBounds(
-		messageFallbackWhere, "s.started_at", b)
-
-	eventFallbackWhere := pgUsageEventEligibility +
-		"\n\tAND ue.occurred_at IS NULL"
-	eventFallbackWhere = appendPGUsageBranchFilterClauses(
-		eventFallbackWhere, pb, f, "ue.model")
-	eventFallbackWhere = appendPGUsageColumnBounds(
-		eventFallbackWhere, "s.started_at", b)
-
-	return pgDailyUsageRowsSQLWithTimestampCTEs(
-		messageTimestampSourceWhere, eventTimestampSourceWhere,
-		messageTimestampJoinWhere, eventTimestampJoinWhere,
-		messageFallbackWhere, eventFallbackWhere,
-	)
+	return pgBoundedDailyUsageRowsSQL(
+		pb, f, b,
+		pgUsageMatchingMessageSourceEligibility, pgUsageMatchingMessageEligibility)
 }
 
 func pgUsageRowQuery(pb *paramBuilder, f db.UsageFilter) string {
@@ -1749,18 +1725,18 @@ func (s *Store) GetUsageSessionCounts(
 	return out, nil
 }
 
-func appendPGUsageSessionModelMatchClauses(
+// appendPGUsageMatchingActivityClauses requires the session to have at
+// least one row that GetUsageMatchingSessionCount's bounded branch would
+// count, mirroring appendUsageMatchingActivityClauses in internal/db so
+// bounded and unbounded requests agree on which sessions match.
+func appendPGUsageMatchingActivityClauses(
 	where string, pb *paramBuilder, f db.UsageFilter,
 ) string {
-	if strings.TrimSpace(f.Model) == "" && strings.TrimSpace(f.ExcludeModel) == "" {
-		return where
-	}
-
 	messageWhere := appendPGUsageSourceFilterClauses(
-		"m.model != ''", pb, f, "m.model",
+		pgUsageMatchingMessageSourceEligibility, pb, f, "m.model",
 	)
 	eventWhere := appendPGUsageSourceFilterClauses(
-		"ue.model != ''", pb, f, "ue.model",
+		pgUsageEventSourceEligibility, pb, f, "ue.model",
 	)
 
 	return where + `
@@ -1794,29 +1770,15 @@ func (s *Store) GetUsageMatchingSessionCount(
 
 	if f.From == "" && f.To == "" {
 		where := appendPGUsageSessionFilterClauses(pgUsageSessionEligibility, pb, f)
-		where = appendPGUsageSessionModelMatchClauses(where, pb, f)
+		where = appendPGUsageMatchingActivityClauses(where, pb, f)
 
-		// Keep selecting session_activity_at even though it's unused
-		// here: this is the original query's WHERE/SELECT shape,
-		// unchanged, so internal/postgres/usage_unit_test.go's probe-mock
-		// string match (which keys off this literal SQL text) still
-		// finds this branch for the unbounded case.
-		rows, err := s.pg.QueryContext(ctx, `
-SELECT
-	s.id,
-	COALESCE(s.ended_at, s.started_at, s.created_at) AS session_activity_at
+		var count int
+		err := s.pg.QueryRowContext(ctx, `
+SELECT COUNT(*)
 FROM sessions s
-WHERE `+where, pb.args...)
+WHERE `+where, pb.args...).Scan(&count)
 		if err != nil {
 			return 0, fmt.Errorf("querying matching usage sessions: %w", err)
-		}
-		defer rows.Close()
-		count := 0
-		for rows.Next() {
-			count++
-		}
-		if err := rows.Err(); err != nil {
-			return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
 		}
 		return count, nil
 	}

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -25,12 +25,12 @@ const pgUsageMessageSourceEligibility = `
 	AND m.model != '<synthetic>'`
 
 const pgUsageMatchingMessageEligibility = `
-	m.model != ''
+	m.role = 'assistant'
 	AND m.model != '<synthetic>'
 	AND s.deleted_at IS NULL`
 
 const pgUsageMatchingMessageSourceEligibility = `
-	m.model != ''
+	m.role = 'assistant'
 	AND m.model != '<synthetic>'`
 
 const pgUsageEventEligibility = `

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -24,6 +24,15 @@ const pgUsageMessageSourceEligibility = `
 	AND m.model != ''
 	AND m.model != '<synthetic>'`
 
+const pgUsageMatchingMessageEligibility = `
+	m.model != ''
+	AND m.model != '<synthetic>'
+	AND s.deleted_at IS NULL`
+
+const pgUsageMatchingMessageSourceEligibility = `
+	m.model != ''
+	AND m.model != '<synthetic>'`
+
 const pgUsageEventEligibility = `
 	ue.model != ''
 	AND s.deleted_at IS NULL`
@@ -656,6 +665,60 @@ func pgDailyUsageRowsSQLForBounds(
 		eventTimestampJoinWhere,
 		messageFallbackWhere,
 		eventFallbackWhere,
+	)
+}
+
+// pgMatchingUsageRowsSQLForBounds mirrors pgDailyUsageRowsSQLForBounds's
+// bounded-branch CTE shape, but is built from the relaxed
+// pgUsageMatchingMessageEligibility predicate and folds the session-wide
+// model-match clause into each branch instead of filtering per row, so
+// GetUsageMatchingSessionCount's Model/ExcludeModel semantics stay
+// bit-for-bit identical to the unbounded path. Only used by
+// GetUsageMatchingSessionCount's bounded branch.
+func pgMatchingUsageRowsSQLForBounds(
+	pb *paramBuilder, f db.UsageFilter, b pgUsageBounds,
+) string {
+	messageTimestampSourceWhere := pgUsageMatchingMessageSourceEligibility +
+		"\n\tAND m.timestamp IS NOT NULL"
+	messageTimestampSourceWhere = appendPGUsageColumnBounds(
+		messageTimestampSourceWhere, "m.timestamp", b)
+
+	eventTimestampSourceWhere := pgUsageEventSourceEligibility +
+		"\n\tAND ue.occurred_at IS NOT NULL"
+	eventTimestampSourceWhere = appendPGUsageColumnBounds(
+		eventTimestampSourceWhere, "ue.occurred_at", b)
+
+	messageTimestampJoinWhere := appendPGUsageSessionFilterClauses(
+		pgUsageSessionEligibility, pb, f)
+	messageTimestampJoinWhere = appendPGUsageSessionModelMatchClauses(
+		messageTimestampJoinWhere, pb, f)
+	eventTimestampJoinWhere := appendPGUsageSessionFilterClauses(
+		pgUsageSessionEligibility, pb, f)
+	eventTimestampJoinWhere = appendPGUsageSessionModelMatchClauses(
+		eventTimestampJoinWhere, pb, f)
+
+	messageFallbackWhere := pgUsageMatchingMessageEligibility +
+		"\n\tAND m.timestamp IS NULL"
+	messageFallbackWhere = appendPGUsageSessionFilterClauses(
+		messageFallbackWhere, pb, f)
+	messageFallbackWhere = appendPGUsageSessionModelMatchClauses(
+		messageFallbackWhere, pb, f)
+	messageFallbackWhere = appendPGUsageColumnBounds(
+		messageFallbackWhere, "s.started_at", b)
+
+	eventFallbackWhere := pgUsageEventEligibility +
+		"\n\tAND ue.occurred_at IS NULL"
+	eventFallbackWhere = appendPGUsageSessionFilterClauses(
+		eventFallbackWhere, pb, f)
+	eventFallbackWhere = appendPGUsageSessionModelMatchClauses(
+		eventFallbackWhere, pb, f)
+	eventFallbackWhere = appendPGUsageColumnBounds(
+		eventFallbackWhere, "s.started_at", b)
+
+	return pgDailyUsageRowsSQLWithTimestampCTEs(
+		messageTimestampSourceWhere, eventTimestampSourceWhere,
+		messageTimestampJoinWhere, eventTimestampJoinWhere,
+		messageFallbackWhere, eventFallbackWhere,
 	)
 }
 
@@ -1722,45 +1785,65 @@ func appendPGUsageSessionModelMatchClauses(
 	)`
 }
 
+// GetUsageMatchingSessionCount counts sessions that match the usage filter
+// even when they have no token-bearing usage rows. Bounded ranges are
+// resolved against the timestamps of the sessions' messages/usage_events
+// rows (falling back to s.started_at for rows with no timestamp of their
+// own), the same shape pgDailyUsageRowsSQLForBounds uses, so a session
+// whose started_at/ended_at fall outside the window but whose message
+// activity falls inside it is still counted.
 func (s *Store) GetUsageMatchingSessionCount(
 	ctx context.Context, f db.UsageFilter,
 ) (int, error) {
 	pb := &paramBuilder{}
-	where := appendPGUsageSessionFilterClauses(
-		pgUsageSessionEligibility, pb, f,
-	)
-	where = appendPGUsageSessionModelMatchClauses(where, pb, f)
-	if f.From != "" {
-		where += "\n\tAND COALESCE(s.ended_at, s.started_at, s.created_at) >= " +
-			pb.add(paddedUTCBound(f.From+"T00:00:00Z", -14)) + "::timestamptz"
-	}
-	if f.To != "" {
-		where += "\n\tAND COALESCE(s.ended_at, s.started_at, s.created_at) <= " +
-			pb.add(paddedUTCBound(f.To+"T23:59:59Z", 14)) + "::timestamptz"
-	}
 
-	rows, err := s.pg.QueryContext(ctx, `
+	if f.From == "" && f.To == "" {
+		where := appendPGUsageSessionFilterClauses(pgUsageSessionEligibility, pb, f)
+		where = appendPGUsageSessionModelMatchClauses(where, pb, f)
+
+		// Keep selecting session_activity_at even though it's unused
+		// here: this is the original query's WHERE/SELECT shape,
+		// unchanged, so internal/postgres/usage_unit_test.go's probe-mock
+		// string match (which keys off this literal SQL text) still
+		// finds this branch for the unbounded case.
+		rows, err := s.pg.QueryContext(ctx, `
 SELECT
 	s.id,
 	COALESCE(s.ended_at, s.started_at, s.created_at) AS session_activity_at
 FROM sessions s
 WHERE `+where, pb.args...)
+		if err != nil {
+			return 0, fmt.Errorf("querying matching usage sessions: %w", err)
+		}
+		defer rows.Close()
+		count := 0
+		for rows.Next() {
+			count++
+		}
+		if err := rows.Err(); err != nil {
+			return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
+		}
+		return count, nil
+	}
+
+	bounds := pgUsageBoundsForFilter(pb, f)
+	rowsSQL := pgMatchingUsageRowsSQLForBounds(pb, f, bounds)
+
+	rows, err := s.pg.QueryContext(
+		ctx, pgDailyUsageRowSelectFromRows(rowsSQL), pb.args...)
 	if err != nil {
 		return 0, fmt.Errorf("querying matching usage sessions: %w", err)
 	}
 	defer rows.Close()
 
 	loc := usageLocation(f)
-	count := 0
+	seen := make(map[string]struct{})
 	for rows.Next() {
-		var (
-			id string
-			ts sql.NullTime
-		)
-		if err := rows.Scan(&id, &ts); err != nil {
+		r, err := scanPGDailyUsageRow(rows)
+		if err != nil {
 			return 0, fmt.Errorf("scanning matching usage session: %w", err)
 		}
-		date := usageDate(ts, loc)
+		date := usageDate(r.ts, loc)
 		if date == "" {
 			continue
 		}
@@ -1770,11 +1853,10 @@ WHERE `+where, pb.args...)
 		if f.To != "" && date > f.To {
 			continue
 		}
-		count++
+		seen[r.sessionID] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
 		return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
 	}
-
-	return count, nil
+	return len(seen), nil
 }

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -670,48 +670,43 @@ func pgDailyUsageRowsSQLForBounds(
 
 // pgMatchingUsageRowsSQLForBounds mirrors pgDailyUsageRowsSQLForBounds's
 // bounded-branch CTE shape, but is built from the relaxed
-// pgUsageMatchingMessageEligibility predicate and folds the session-wide
-// model-match clause into each branch instead of filtering per row, so
-// GetUsageMatchingSessionCount's Model/ExcludeModel semantics stay
-// bit-for-bit identical to the unbounded path. Only used by
+// pgUsageMatchingMessageEligibility predicate, so GetUsageMatchingSessionCount
+// only relaxes the token-usage requirement and keeps the same per-row
+// Model/ExcludeModel filtering as the normal bounded path. Only used by
 // GetUsageMatchingSessionCount's bounded branch.
 func pgMatchingUsageRowsSQLForBounds(
 	pb *paramBuilder, f db.UsageFilter, b pgUsageBounds,
 ) string {
 	messageTimestampSourceWhere := pgUsageMatchingMessageSourceEligibility +
 		"\n\tAND m.timestamp IS NOT NULL"
+	messageTimestampSourceWhere = appendPGUsageSourceFilterClauses(
+		messageTimestampSourceWhere, pb, f, "m.model")
 	messageTimestampSourceWhere = appendPGUsageColumnBounds(
 		messageTimestampSourceWhere, "m.timestamp", b)
 
 	eventTimestampSourceWhere := pgUsageEventSourceEligibility +
 		"\n\tAND ue.occurred_at IS NOT NULL"
+	eventTimestampSourceWhere = appendPGUsageSourceFilterClauses(
+		eventTimestampSourceWhere, pb, f, "ue.model")
 	eventTimestampSourceWhere = appendPGUsageColumnBounds(
 		eventTimestampSourceWhere, "ue.occurred_at", b)
 
 	messageTimestampJoinWhere := appendPGUsageSessionFilterClauses(
 		pgUsageSessionEligibility, pb, f)
-	messageTimestampJoinWhere = appendPGUsageSessionModelMatchClauses(
-		messageTimestampJoinWhere, pb, f)
 	eventTimestampJoinWhere := appendPGUsageSessionFilterClauses(
 		pgUsageSessionEligibility, pb, f)
-	eventTimestampJoinWhere = appendPGUsageSessionModelMatchClauses(
-		eventTimestampJoinWhere, pb, f)
 
 	messageFallbackWhere := pgUsageMatchingMessageEligibility +
 		"\n\tAND m.timestamp IS NULL"
-	messageFallbackWhere = appendPGUsageSessionFilterClauses(
-		messageFallbackWhere, pb, f)
-	messageFallbackWhere = appendPGUsageSessionModelMatchClauses(
-		messageFallbackWhere, pb, f)
+	messageFallbackWhere = appendPGUsageBranchFilterClauses(
+		messageFallbackWhere, pb, f, "m.model")
 	messageFallbackWhere = appendPGUsageColumnBounds(
 		messageFallbackWhere, "s.started_at", b)
 
 	eventFallbackWhere := pgUsageEventEligibility +
 		"\n\tAND ue.occurred_at IS NULL"
-	eventFallbackWhere = appendPGUsageSessionFilterClauses(
-		eventFallbackWhere, pb, f)
-	eventFallbackWhere = appendPGUsageSessionModelMatchClauses(
-		eventFallbackWhere, pb, f)
+	eventFallbackWhere = appendPGUsageBranchFilterClauses(
+		eventFallbackWhere, pb, f, "ue.model")
 	eventFallbackWhere = appendPGUsageColumnBounds(
 		eventFallbackWhere, "s.started_at", b)
 

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -1690,3 +1690,91 @@ func (s *Store) GetUsageSessionCounts(
 	}
 	return out, nil
 }
+
+func appendPGUsageSessionModelMatchClauses(
+	where string, pb *paramBuilder, f db.UsageFilter,
+) string {
+	if strings.TrimSpace(f.Model) == "" && strings.TrimSpace(f.ExcludeModel) == "" {
+		return where
+	}
+
+	messageWhere := appendPGUsageSourceFilterClauses(
+		"m.model != ''", pb, f, "m.model",
+	)
+	eventWhere := appendPGUsageSourceFilterClauses(
+		"ue.model != ''", pb, f, "ue.model",
+	)
+
+	return where + `
+	AND (
+		EXISTS (
+			SELECT 1
+			FROM messages m
+			WHERE m.session_id = s.id
+				AND ` + messageWhere + `
+		)
+		OR EXISTS (
+			SELECT 1
+			FROM usage_events ue
+			WHERE ue.session_id = s.id
+				AND ` + eventWhere + `
+		)
+	)`
+}
+
+func (s *Store) GetUsageMatchingSessionCount(
+	ctx context.Context, f db.UsageFilter,
+) (int, error) {
+	pb := &paramBuilder{}
+	where := appendPGUsageSessionFilterClauses(
+		pgUsageSessionEligibility, pb, f,
+	)
+	where = appendPGUsageSessionModelMatchClauses(where, pb, f)
+	if f.From != "" {
+		where += "\n\tAND COALESCE(s.ended_at, s.started_at, s.created_at) >= " +
+			pb.add(paddedUTCBound(f.From+"T00:00:00Z", -14)) + "::timestamptz"
+	}
+	if f.To != "" {
+		where += "\n\tAND COALESCE(s.ended_at, s.started_at, s.created_at) <= " +
+			pb.add(paddedUTCBound(f.To+"T23:59:59Z", 14)) + "::timestamptz"
+	}
+
+	rows, err := s.pg.QueryContext(ctx, `
+SELECT
+	s.id,
+	COALESCE(s.ended_at, s.started_at, s.created_at) AS session_activity_at
+FROM sessions s
+WHERE `+where, pb.args...)
+	if err != nil {
+		return 0, fmt.Errorf("querying matching usage sessions: %w", err)
+	}
+	defer rows.Close()
+
+	loc := usageLocation(f)
+	count := 0
+	for rows.Next() {
+		var (
+			id string
+			ts sql.NullTime
+		)
+		if err := rows.Scan(&id, &ts); err != nil {
+			return 0, fmt.Errorf("scanning matching usage session: %w", err)
+		}
+		date := usageDate(ts, loc)
+		if date == "" {
+			continue
+		}
+		if f.From != "" && date < f.From {
+			continue
+		}
+		if f.To != "" && date > f.To {
+			continue
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterating matching usage sessions: %w", err)
+	}
+
+	return count, nil
+}

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -562,6 +562,47 @@ func TestStoreGetUsageMatchingSessionCountModelFilterAppliesToBoundedRow(
 		"out-of-range message's model must not match the bounded window")
 }
 
+// TestStoreGetUsageMatchingSessionCountCountsAssistantMessageWithNoModel
+// guards against gating matching-session eligibility on m.model != ”:
+// some Copilot assistant messages parse before a model name is known, so
+// an assistant message with an empty model must still count toward the
+// matching-session total when no Model/ExcludeModel filter narrows it.
+func TestStoreGetUsageMatchingSessionCountCountsAssistantMessageWithNoModel(
+	t *testing.T,
+) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_matching_sessions_no_model_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES
+			('copilot-no-model', 'test-machine', 'proj-a', 'copilot',
+			 '2026-02-10T10:00:00Z'::timestamptz,
+			 '2026-02-10T10:00:00Z'::timestamptz, 1, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES
+			('copilot-no-model', 0, 'assistant', 'copilot',
+			 '2026-02-10T10:00:00Z'::timestamptz, 7,
+			 '', '')`)
+	require.NoError(t, err, "insert messages")
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, db.UsageFilter{
+		From:     "2026-02-10",
+		To:       "2026-02-10",
+		Timezone: "UTC",
+		Agent:    "copilot",
+	})
+	require.NoError(t, err, "GetUsageMatchingSessionCount")
+	assert.Equal(t, 1, count,
+		"assistant message with no model must still count without a model filter")
+}
+
 func TestStoreGetUsageSessionCountsDedupesSourceUUIDFallback(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_usage_counts_source_uuid_test")
 

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -603,6 +603,72 @@ func TestStoreGetUsageMatchingSessionCountCountsAssistantMessageWithNoModel(
 		"assistant message with no model must still count without a model filter")
 }
 
+// TestStoreGetUsageMatchingSessionCountUnboundedMatchesBoundedSemantics
+// guards against the unbounded (no From/To) branch drifting from the
+// bounded branch: soft-deleted sessions and sessions without
+// assistant/event activity must not count, and empty-model assistant
+// messages must survive an ExcludeModel filter, exactly as on the
+// bounded path.
+func TestStoreGetUsageMatchingSessionCountUnboundedMatchesBoundedSemantics(
+	t *testing.T,
+) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_matching_sessions_unbounded_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count, deleted_at
+		) VALUES
+			('copilot-live', 'test-machine', 'proj-a', 'copilot',
+			 '2026-03-01T10:00:00Z'::timestamptz,
+			 '2026-03-01T10:00:00Z'::timestamptz, 1, 1, NULL),
+			('copilot-trashed', 'test-machine', 'proj-a', 'copilot',
+			 '2026-03-01T10:00:00Z'::timestamptz,
+			 '2026-03-01T10:00:00Z'::timestamptz, 1, 1,
+			 '2026-03-02T00:00:00Z'::timestamptz),
+			('copilot-user-only', 'test-machine', 'proj-a', 'copilot',
+			 '2026-03-01T10:00:00Z'::timestamptz,
+			 '2026-03-01T10:00:00Z'::timestamptz, 1, 1, NULL)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES
+			('copilot-live', 0, 'assistant', 'copilot',
+			 '2026-03-01T10:00:00Z'::timestamptz, 7,
+			 '', ''),
+			('copilot-trashed', 0, 'assistant', 'copilot',
+			 '2026-03-01T10:00:00Z'::timestamptz, 7,
+			 'gpt-5.3-codex', ''),
+			('copilot-user-only', 0, 'user', 'hello',
+			 '2026-03-01T10:00:00Z'::timestamptz, 5,
+			 '', '')`)
+	require.NoError(t, err, "insert messages")
+
+	unbounded := db.UsageFilter{Timezone: "UTC", Agent: "copilot"}
+	count, err := store.GetUsageMatchingSessionCount(ctx, unbounded)
+	require.NoError(t, err, "GetUsageMatchingSessionCount unbounded")
+	assert.Equal(t, 1, count,
+		"soft-deleted and assistant-less sessions must not count unbounded")
+
+	bounded := unbounded
+	bounded.From = "2026-03-01"
+	bounded.To = "2026-03-01"
+	boundedCount, err := store.GetUsageMatchingSessionCount(ctx, bounded)
+	require.NoError(t, err, "GetUsageMatchingSessionCount bounded")
+	assert.Equal(t, count, boundedCount,
+		"bounded and unbounded requests must match the same sessions")
+
+	excluded := unbounded
+	excluded.ExcludeModel = "gpt-5.3-codex"
+	excludedCount, err := store.GetUsageMatchingSessionCount(ctx, excluded)
+	require.NoError(t, err, "GetUsageMatchingSessionCount exclude-model")
+	assert.Equal(t, 1, excludedCount,
+		"empty-model assistant message must survive an ExcludeModel filter")
+}
+
 func TestStoreGetUsageSessionCountsDedupesSourceUUIDFallback(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_usage_counts_source_uuid_test")
 

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -517,6 +517,51 @@ func TestStoreGetUsageMatchingSessionCountCountsCopilotSessionByMessageTimestamp
 	assert.Equal(t, 1, count)
 }
 
+// TestStoreGetUsageMatchingSessionCountModelFilterAppliesToBoundedRow
+// guards against the model/exclude-model predicate matching session-wide
+// instead of on the in-range message row: a session with an out-of-range
+// message on the filtered model but an in-range message on a different
+// model must not match a Model filter for the out-of-range model.
+func TestStoreGetUsageMatchingSessionCountModelFilterAppliesToBoundedRow(
+	t *testing.T,
+) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_matching_sessions_model_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES
+			('copilot-mixed-model', 'test-machine', 'proj-a', 'copilot',
+			 '2026-02-08T10:00:00Z'::timestamptz,
+			 '2026-02-10T12:00:00Z'::timestamptz, 2, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES
+			('copilot-mixed-model', 0, 'assistant', 'copilot',
+			 '2026-02-08T10:00:00Z'::timestamptz, 7,
+			 'gpt-5.3-codex', ''),
+			('copilot-mixed-model', 1, 'assistant', 'claude',
+			 '2026-02-10T12:00:00Z'::timestamptz, 6,
+			 'claude-sonnet', '')`)
+	require.NoError(t, err, "insert messages")
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, db.UsageFilter{
+		From:     "2026-02-10",
+		To:       "2026-02-10",
+		Timezone: "UTC",
+		Agent:    "copilot",
+		Model:    "gpt-5.3-codex",
+	})
+	require.NoError(t, err, "GetUsageMatchingSessionCount")
+	assert.Equal(t, 0, count,
+		"out-of-range message's model must not match the bounded window")
+}
+
 func TestStoreGetUsageSessionCountsDedupesSourceUUIDFallback(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_usage_counts_source_uuid_test")
 

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -476,6 +476,47 @@ func TestStoreGetUsageMatchingSessionCountCountsCopilotSessionsWithoutUsageRows(
 	assert.Equal(t, 1, count)
 }
 
+func TestStoreGetUsageMatchingSessionCountCountsCopilotSessionByMessageTimestampOutsideSessionWindow(
+	t *testing.T,
+) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_matching_sessions_late_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES
+			('copilot-late-message', 'test-machine', 'proj-a', 'copilot',
+			 '2026-02-08T10:00:00Z'::timestamptz,
+			 '2026-02-08T10:00:00Z'::timestamptz, 1, 1),
+			('copilot-out-of-range', 'test-machine', 'proj-a', 'copilot',
+			 '2026-02-08T10:00:00Z'::timestamptz,
+			 '2026-02-08T10:00:00Z'::timestamptz, 1, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES
+			('copilot-late-message', 0, 'assistant', 'copilot',
+			 '2026-02-10T12:00:00Z'::timestamptz, 7,
+			 'gpt-5.3-codex', ''),
+			('copilot-out-of-range', 0, 'assistant', 'copilot',
+			 '2026-02-08T10:00:00Z'::timestamptz, 7,
+			 'gpt-5.3-codex', '')`)
+	require.NoError(t, err, "insert messages")
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, db.UsageFilter{
+		From:     "2026-02-10",
+		To:       "2026-02-10",
+		Timezone: "UTC",
+		Agent:    "copilot",
+	})
+	require.NoError(t, err, "GetUsageMatchingSessionCount")
+	assert.Equal(t, 1, count)
+}
+
 func TestStoreGetUsageSessionCountsDedupesSourceUUIDFallback(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_usage_counts_source_uuid_test")
 

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -434,6 +434,48 @@ func TestStoreGetUsageSessionCountsDedupesClaudeKeys(t *testing.T) {
 	assert.False(t, ok, "proj-b should have been deduped out: %#v", counts.ByProject)
 }
 
+func TestStoreGetUsageMatchingSessionCountCountsCopilotSessionsWithoutUsageRows(
+	t *testing.T,
+) {
+	_, store := prepareUsageSchema(t, "agentsview_usage_matching_sessions_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, ended_at,
+			message_count, user_message_count
+		) VALUES
+			('copilot-empty', 'test-machine', 'proj-a', 'copilot',
+			 '2026-03-12T10:00:00Z'::timestamptz,
+			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
+			('claude-usage', 'test-machine', 'proj-a', 'claude',
+			 '2026-03-12T11:00:00Z'::timestamptz,
+			 '2026-03-12T11:00:00Z'::timestamptz, 1, 1)`)
+	require.NoError(t, err, "insert sessions")
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES
+			('copilot-empty', 0, 'assistant', 'copilot',
+			 '2026-03-12T10:00:00Z'::timestamptz, 7,
+			 'gpt-5.3-codex', ''),
+			('claude-usage', 0, 'assistant', 'claude',
+			 '2026-03-12T11:00:00Z'::timestamptz, 6,
+			 'claude-sonnet-4-20250514', '{"input_tokens":1}')`)
+	require.NoError(t, err, "insert messages")
+
+	count, err := store.GetUsageMatchingSessionCount(ctx, db.UsageFilter{
+		From:     "2026-03-12",
+		To:       "2026-03-12",
+		Timezone: "UTC",
+		Agent:    "copilot",
+		Model:    "gpt-5.3-codex",
+	})
+	require.NoError(t, err, "GetUsageMatchingSessionCount")
+	assert.Equal(t, 1, count)
+}
+
 func TestStoreGetUsageSessionCountsDedupesSourceUUIDFallback(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_usage_counts_source_uuid_test")
 

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -296,6 +296,13 @@ func TestPGUsageRowQueryPushesDateBoundsIntoUnion(t *testing.T) {
 	assert.Equal(t, "2024-07-01T13:59:59Z", pb.args[1])
 }
 
+// TestPGGetUsageMatchingSessionCountUsesSessionQuery exercises the
+// unbounded (no From/To) code path, which still queries `sessions`
+// directly and relies on the probe mock's
+// "coalesce(s.ended_at, s.started_at, s.created_at) as
+// session_activity_at" branch. Bounded filters now take the
+// timestamped-CTE path (see TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility
+// for that SQL shape) and are not exercised by this probe-mock test.
 func TestPGGetUsageMatchingSessionCountUsesSessionQuery(t *testing.T) {
 	state := &usageProbeState{}
 	store := &Store{
@@ -303,11 +310,8 @@ func TestPGGetUsageMatchingSessionCountUsesSessionQuery(t *testing.T) {
 	}
 
 	count, err := store.GetUsageMatchingSessionCount(context.Background(), db.UsageFilter{
-		From:     "2024-06-15",
-		To:       "2024-06-15",
-		Timezone: "UTC",
-		Agent:    "copilot",
-		Model:    "gpt-5.3-codex",
+		Agent: "copilot",
+		Model: "gpt-5.3-codex",
 	})
 	require.NoError(t, err, "GetUsageMatchingSessionCount")
 	assert.Equal(t, 1, count)
@@ -324,6 +328,34 @@ func TestPGGetUsageMatchingSessionCountUsesSessionQuery(t *testing.T) {
 	assert.Contains(t, last, "from usage_events ue")
 	assert.Contains(t, last, "s.agent = ")
 	assert.Contains(t, last, "m.model = ")
+}
+
+// TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility asserts the
+// bounded matching-session query relaxes token eligibility (no
+// m.token_usage check) while still folding in the session-wide
+// model-match EXISTS clause, mirroring
+// TestPGUsageRowQueryPushesDateBoundsIntoUnion's direct-call style with
+// no live DB and no probe mock.
+func TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility(t *testing.T) {
+	pb := &paramBuilder{}
+	f := db.UsageFilter{
+		From:  "2024-06-01",
+		To:    "2024-06-30",
+		Model: "gpt-5.3-codex",
+	}
+	bounds := pgUsageBoundsForFilter(pb, f)
+	query := pgMatchingUsageRowsSQLForBounds(pb, f, bounds)
+
+	normalized := strings.ToLower(query)
+	assert.Contains(t, normalized, "message_timestamp_rows as materialized")
+	assert.Contains(t, normalized, "usage_event_timestamp_rows as materialized")
+	assert.Contains(t, normalized, "m.model != ''")
+	assert.NotContains(t, normalized, "m.token_usage != ''")
+	// Each of the four branches (message-timestamp join, event-timestamp
+	// join, message fallback, event fallback) folds in the session-wide
+	// model-match clause, which itself emits one EXISTS for messages and
+	// one for usage_events - 4 branches * 2 EXISTS each.
+	assert.Equal(t, 8, strings.Count(normalized, "exists ("))
 }
 
 func TestPGTopSessionsUsageRowQueryUsesNarrowScan(t *testing.T) {

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -332,8 +332,9 @@ func TestPGGetUsageMatchingSessionCountUsesSessionQuery(t *testing.T) {
 
 // TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility asserts the
 // bounded matching-session query relaxes token eligibility (no
-// m.token_usage check) while still folding in the session-wide
-// model-match EXISTS clause, mirroring
+// m.token_usage check) while filtering Model/ExcludeModel directly on the
+// bounded message/event row, matching the normal bounded path instead of
+// folding in a session-wide model-match EXISTS clause. Mirrors
 // TestPGUsageRowQueryPushesDateBoundsIntoUnion's direct-call style with
 // no live DB and no probe mock.
 func TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility(t *testing.T) {
@@ -351,11 +352,13 @@ func TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility(t *testing.T) {
 	assert.Contains(t, normalized, "usage_event_timestamp_rows as materialized")
 	assert.Contains(t, normalized, "m.model != ''")
 	assert.NotContains(t, normalized, "m.token_usage != ''")
-	// Each of the four branches (message-timestamp join, event-timestamp
-	// join, message fallback, event fallback) folds in the session-wide
-	// model-match clause, which itself emits one EXISTS for messages and
-	// one for usage_events - 4 branches * 2 EXISTS each.
-	assert.Equal(t, 8, strings.Count(normalized, "exists ("))
+	// Model is filtered on the bounded row directly, not via a
+	// session-wide EXISTS: each of the four branches (message-timestamp
+	// source, event-timestamp source, message fallback, event fallback)
+	// applies its own m.model/ue.model comparison, no EXISTS subqueries.
+	assert.Equal(t, 0, strings.Count(normalized, "exists ("))
+	assert.Equal(t, 2, strings.Count(normalized, "m.model = "))
+	assert.Equal(t, 2, strings.Count(normalized, "ue.model = "))
 }
 
 func TestPGTopSessionsUsageRowQueryUsesNarrowScan(t *testing.T) {

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -332,11 +332,13 @@ func TestPGGetUsageMatchingSessionCountUsesSessionQuery(t *testing.T) {
 
 // TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility asserts the
 // bounded matching-session query relaxes token eligibility (no
-// m.token_usage check) while filtering Model/ExcludeModel directly on the
-// bounded message/event row, matching the normal bounded path instead of
-// folding in a session-wide model-match EXISTS clause. Mirrors
-// TestPGUsageRowQueryPushesDateBoundsIntoUnion's direct-call style with
-// no live DB and no probe mock.
+// m.token_usage check) and model-presence eligibility (m.role = 'assistant'
+// instead of m.model != ”, since some Copilot assistant messages parse
+// before a model name is known) while filtering Model/ExcludeModel
+// directly on the bounded message/event row, matching the normal bounded
+// path instead of folding in a session-wide model-match EXISTS clause.
+// Mirrors TestPGUsageRowQueryPushesDateBoundsIntoUnion's direct-call style
+// with no live DB and no probe mock.
 func TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility(t *testing.T) {
 	pb := &paramBuilder{}
 	f := db.UsageFilter{
@@ -350,7 +352,8 @@ func TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility(t *testing.T) {
 	normalized := strings.ToLower(query)
 	assert.Contains(t, normalized, "message_timestamp_rows as materialized")
 	assert.Contains(t, normalized, "usage_event_timestamp_rows as materialized")
-	assert.Contains(t, normalized, "m.model != ''")
+	assert.Contains(t, normalized, "m.role = 'assistant'")
+	assert.NotContains(t, normalized, "m.model != ''")
 	assert.NotContains(t, normalized, "m.token_usage != ''")
 	// Model is filtered on the bounded row directly, not via a
 	// session-wide EXISTS: each of the four branches (message-timestamp

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -112,12 +112,12 @@ func (c *usageProbeConn) QueryContext(
 			},
 		}, nil
 	}
-	if strings.Contains(normalized, "coalesce(s.ended_at, s.started_at, s.created_at) as session_activity_at") {
-		ts := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)
+	if strings.Contains(normalized, "select count(*)") &&
+		strings.Contains(normalized, "from sessions s") {
 		return &usageProbeRows{
-			columns: []string{"id", "session_activity_at"},
+			columns: []string{"count"},
 			values: [][]driver.Value{
-				{"copilot-empty", ts},
+				{int64(1)},
 			},
 		}, nil
 	}
@@ -297,10 +297,9 @@ func TestPGUsageRowQueryPushesDateBoundsIntoUnion(t *testing.T) {
 }
 
 // TestPGGetUsageMatchingSessionCountUsesSessionQuery exercises the
-// unbounded (no From/To) code path, which still queries `sessions`
-// directly and relies on the probe mock's
-// "coalesce(s.ended_at, s.started_at, s.created_at) as
-// session_activity_at" branch. Bounded filters now take the
+// unbounded (no From/To) code path, which counts sessions directly with
+// EXISTS subqueries built from the same relaxed matching eligibility
+// predicates as the bounded branch. Bounded filters take the
 // timestamped-CTE path (see TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility
 // for that SQL shape) and are not exercised by this probe-mock test.
 func TestPGGetUsageMatchingSessionCountUsesSessionQuery(t *testing.T) {
@@ -322,12 +321,18 @@ func TestPGGetUsageMatchingSessionCountUsesSessionQuery(t *testing.T) {
 	require.NotEmpty(t, queries)
 
 	last := strings.ToLower(queries[len(queries)-1])
+	assert.Contains(t, last, "select count(*)")
 	assert.Contains(t, last, "from sessions s")
 	assert.Contains(t, last, "exists (")
 	assert.Contains(t, last, "from messages m")
 	assert.Contains(t, last, "from usage_events ue")
 	assert.Contains(t, last, "s.agent = ")
 	assert.Contains(t, last, "m.model = ")
+	// The message EXISTS uses the relaxed matching eligibility: assistant
+	// rows without requiring a model name, so empty-model Copilot
+	// assistant messages match the same way they do on the bounded path.
+	assert.Contains(t, last, "m.role = 'assistant'")
+	assert.NotContains(t, last, "m.model != ''")
 }
 
 // TestPGMatchingUsageRowsSQLForBoundsRelaxesTokenEligibility asserts the

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -112,6 +112,15 @@ func (c *usageProbeConn) QueryContext(
 			},
 		}, nil
 	}
+	if strings.Contains(normalized, "coalesce(s.ended_at, s.started_at, s.created_at) as session_activity_at") {
+		ts := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)
+		return &usageProbeRows{
+			columns: []string{"id", "session_activity_at"},
+			values: [][]driver.Value{
+				{"copilot-empty", ts},
+			},
+		}, nil
+	}
 	if strings.Contains(normalized, "from (") &&
 		strings.Contains(normalized, "from messages") {
 		ts := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)
@@ -285,6 +294,36 @@ func TestPGUsageRowQueryPushesDateBoundsIntoUnion(t *testing.T) {
 	require.Len(t, pb.args, 2)
 	assert.Equal(t, "2024-05-31T10:00:00Z", pb.args[0])
 	assert.Equal(t, "2024-07-01T13:59:59Z", pb.args[1])
+}
+
+func TestPGGetUsageMatchingSessionCountUsesSessionQuery(t *testing.T) {
+	state := &usageProbeState{}
+	store := &Store{
+		pg: newUsageProbeDB(t, state),
+	}
+
+	count, err := store.GetUsageMatchingSessionCount(context.Background(), db.UsageFilter{
+		From:     "2024-06-15",
+		To:       "2024-06-15",
+		Timezone: "UTC",
+		Agent:    "copilot",
+		Model:    "gpt-5.3-codex",
+	})
+	require.NoError(t, err, "GetUsageMatchingSessionCount")
+	assert.Equal(t, 1, count)
+
+	state.mu.Lock()
+	queries := append([]string(nil), state.queries...)
+	state.mu.Unlock()
+	require.NotEmpty(t, queries)
+
+	last := strings.ToLower(queries[len(queries)-1])
+	assert.Contains(t, last, "from sessions s")
+	assert.Contains(t, last, "exists (")
+	assert.Contains(t, last, "from messages m")
+	assert.Contains(t, last, "from usage_events ue")
+	assert.Contains(t, last, "s.agent = ")
+	assert.Contains(t, last, "m.model = ")
 }
 
 func TestPGTopSessionsUsageRowQueryUsesNarrowScan(t *testing.T) {

--- a/internal/server/usage.go
+++ b/internal/server/usage.go
@@ -54,36 +54,51 @@ type CacheStats struct {
 	SavingsVsUncached   float64 `json:"savingsVsUncached"`
 }
 
+type UnsupportedUsage struct {
+	Kind string `json:"kind"`
+}
+
 // UsageSummaryResponse preserves the public OpenAPI schema for
 // GET /api/v1/usage/summary while the handler delegates assembly to
 // the transport-neutral service layer.
 type UsageSummaryResponse struct {
-	From          string                `json:"from"`
-	To            string                `json:"to"`
-	Totals        db.UsageTotals        `json:"totals"`
-	Daily         []db.DailyUsageEntry  `json:"daily"`
-	ProjectTotals []ProjectTotal        `json:"projectTotals"`
-	ModelTotals   []ModelTotal          `json:"modelTotals"`
-	AgentTotals   []AgentTotal          `json:"agentTotals"`
-	SessionCounts db.UsageSessionCounts `json:"sessionCounts"`
-	CacheStats    CacheStats            `json:"cacheStats"`
-	Comparison    *Comparison           `json:"comparison,omitempty"`
+	From             string                `json:"from"`
+	To               string                `json:"to"`
+	Totals           db.UsageTotals        `json:"totals"`
+	Daily            []db.DailyUsageEntry  `json:"daily"`
+	ProjectTotals    []ProjectTotal        `json:"projectTotals"`
+	ModelTotals      []ModelTotal          `json:"modelTotals"`
+	AgentTotals      []AgentTotal          `json:"agentTotals"`
+	SessionCounts    db.UsageSessionCounts `json:"sessionCounts"`
+	CacheStats       CacheStats            `json:"cacheStats"`
+	UnsupportedUsage *UnsupportedUsage     `json:"unsupportedUsage,omitempty"`
+	Comparison       *Comparison           `json:"comparison,omitempty"`
 }
 
 func usageSummaryResponseFromService(
 	res *service.UsageSummaryResult,
 ) UsageSummaryResponse {
 	return UsageSummaryResponse{
-		From:          res.From,
-		To:            res.To,
-		Totals:        res.Totals,
-		Daily:         res.Daily,
-		ProjectTotals: projectTotalsFromService(res.ProjectTotals),
-		ModelTotals:   modelTotalsFromService(res.ModelTotals),
-		AgentTotals:   agentTotalsFromService(res.AgentTotals),
-		SessionCounts: res.SessionCounts,
-		CacheStats:    cacheStatsFromService(res.CacheStats),
+		From:             res.From,
+		To:               res.To,
+		Totals:           res.Totals,
+		Daily:            res.Daily,
+		ProjectTotals:    projectTotalsFromService(res.ProjectTotals),
+		ModelTotals:      modelTotalsFromService(res.ModelTotals),
+		AgentTotals:      agentTotalsFromService(res.AgentTotals),
+		SessionCounts:    res.SessionCounts,
+		CacheStats:       cacheStatsFromService(res.CacheStats),
+		UnsupportedUsage: unsupportedUsageFromService(res.UnsupportedUsage),
 	}
+}
+
+func unsupportedUsageFromService(
+	in *service.UnsupportedUsage,
+) *UnsupportedUsage {
+	if in == nil {
+		return nil
+	}
+	return &UnsupportedUsage{Kind: in.Kind}
 }
 
 func projectTotalsFromService(in []service.ProjectTotal) []ProjectTotal {

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 // oneDayUsageRange is the from/to query for a single-day usage
@@ -18,20 +19,24 @@ const oneDayUsageRange = "from=2024-06-01&to=2024-06-01"
 
 type usageSummaryCountsSpy struct {
 	db.Store
-	dailyCalls  int
-	countsCalls int
-	filters     []db.UsageFilter
+	dailyCalls           int
+	countsCalls          int
+	matchingSessionCalls int
+	matchingSessionCount int
+	filters              []db.UsageFilter
+	result               db.DailyUsageResult
 }
 
 // assertUsageQueryCalls verifies how many times the usage handler
 // queried the daily-usage and session-count store methods.
 func assertUsageQueryCalls(
 	t *testing.T, spy *usageSummaryCountsSpy,
-	wantDaily, wantCounts int,
+	wantDaily, wantCounts, wantMatching int,
 ) {
 	t.Helper()
 	assert.Equal(t, wantDaily, spy.dailyCalls, "daily usage calls")
 	assert.Equal(t, wantCounts, spy.countsCalls, "session count calls")
+	assert.Equal(t, wantMatching, spy.matchingSessionCalls, "matching session calls")
 }
 
 func (s *usageSummaryCountsSpy) GetDailyUsage(
@@ -39,18 +44,23 @@ func (s *usageSummaryCountsSpy) GetDailyUsage(
 ) (db.DailyUsageResult, error) {
 	s.dailyCalls++
 	s.filters = append(s.filters, f)
-	return db.DailyUsageResult{
-		Daily: []db.DailyUsageEntry{{
-			Date:      "2024-06-01",
-			TotalCost: 1,
-		}},
-		Totals: db.UsageTotals{TotalCost: 1},
-		SessionCounts: db.UsageSessionCounts{
-			Total:     1,
-			ByProject: map[string]int{"proj": 1},
-			ByAgent:   map[string]int{"claude": 1},
-		},
-	}, nil
+	if len(s.result.Daily) == 0 && s.result.Totals == (db.UsageTotals{}) &&
+		s.result.SessionCounts.Total == 0 && s.result.SessionCounts.ByProject == nil &&
+		s.result.SessionCounts.ByAgent == nil {
+		return db.DailyUsageResult{
+			Daily: []db.DailyUsageEntry{{
+				Date:      "2024-06-01",
+				TotalCost: 1,
+			}},
+			Totals: db.UsageTotals{TotalCost: 1},
+			SessionCounts: db.UsageSessionCounts{
+				Total:     1,
+				ByProject: map[string]int{"proj": 1},
+				ByAgent:   map[string]int{"claude": 1},
+			},
+		}, nil
+	}
+	return s.result, nil
 }
 
 func (s *usageSummaryCountsSpy) GetUsageSessionCounts(
@@ -60,6 +70,13 @@ func (s *usageSummaryCountsSpy) GetUsageSessionCounts(
 	return db.UsageSessionCounts{}, nil
 }
 
+func (s *usageSummaryCountsSpy) GetUsageMatchingSessionCount(
+	_ context.Context, _ db.UsageFilter,
+) (int, error) {
+	s.matchingSessionCalls++
+	return s.matchingSessionCount, nil
+}
+
 func TestUsageSummaryScansCurrentPeriodOnly(t *testing.T) {
 	spy := &usageSummaryCountsSpy{}
 	s := newRoutedTestServerWithStore(t, spy)
@@ -67,7 +84,7 @@ func TestUsageSummaryScansCurrentPeriodOnly(t *testing.T) {
 	w := serveGet(t, s, "/api/v1/usage/summary?"+oneDayUsageRange)
 	assertRecorderStatus(t, w, http.StatusOK)
 
-	assertUsageQueryCalls(t, spy, 1, 0)
+	assertUsageQueryCalls(t, spy, 1, 0, 0)
 }
 
 func TestUsageSummaryDefaultsToBreakdowns(t *testing.T) {
@@ -124,7 +141,7 @@ func TestUsageComparisonScansPriorPeriodOnly(t *testing.T) {
 		"/api/v1/usage/comparison?"+oneDayUsageRange+"&current_cost=3")
 	assertRecorderStatus(t, w, http.StatusOK)
 
-	assertUsageQueryCalls(t, spy, 1, 0)
+	assertUsageQueryCalls(t, spy, 1, 0, 0)
 
 	var out Comparison
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -141,7 +158,7 @@ func TestUsageComparisonRequiresCurrentCost(t *testing.T) {
 	w := serveGet(t, s, "/api/v1/usage/comparison?"+oneDayUsageRange)
 	assertRecorderStatus(t, w, http.StatusBadRequest)
 
-	assertUsageQueryCalls(t, spy, 0, 0)
+	assertUsageQueryCalls(t, spy, 0, 0, 0)
 }
 
 func TestUsageComparisonNoDefaultRangeRequiresConcreteRange(t *testing.T) {
@@ -153,7 +170,7 @@ func TestUsageComparisonNoDefaultRangeRequiresConcreteRange(t *testing.T) {
 	assertRecorderStatus(t, w, http.StatusBadRequest)
 	assert.Contains(t, w.Body.String(), "requires from and to")
 
-	assertUsageQueryCalls(t, spy, 0, 0)
+	assertUsageQueryCalls(t, spy, 0, 0, 0)
 }
 
 func TestUsageComparisonAllowsZeroCurrentCost(t *testing.T) {
@@ -164,5 +181,59 @@ func TestUsageComparisonAllowsZeroCurrentCost(t *testing.T) {
 		"/api/v1/usage/comparison?"+oneDayUsageRange+"&current_cost=0")
 	assertRecorderStatus(t, w, http.StatusOK)
 
-	assertUsageQueryCalls(t, spy, 1, 0)
+	assertUsageQueryCalls(t, spy, 1, 0, 0)
+}
+
+func TestUsageSummarySetsUnsupportedUsageForCopilotNoTokenData(t *testing.T) {
+	spy := &usageSummaryCountsSpy{
+		matchingSessionCount: 2,
+		result: db.DailyUsageResult{
+			Daily:  []db.DailyUsageEntry{{Date: "2024-06-01"}},
+			Totals: db.UsageTotals{},
+			SessionCounts: db.UsageSessionCounts{
+				Total:     0,
+				ByProject: map[string]int{},
+				ByAgent:   map[string]int{},
+			},
+		},
+	}
+	s := newRoutedTestServerWithStore(t, spy)
+
+	w := serveGet(t, s,
+		"/api/v1/usage/summary?"+oneDayUsageRange+"&agent=copilot")
+	assertRecorderStatus(t, w, http.StatusOK)
+
+	var resp UsageSummaryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.UnsupportedUsage)
+	assert.Equal(t,
+		service.UnsupportedUsageKindCopilotNoTokenData,
+		resp.UnsupportedUsage.Kind,
+	)
+	assertUsageQueryCalls(t, spy, 1, 0, 1)
+}
+
+func TestUsageSummarySkipsUnsupportedUsageForMixedAgentFilters(t *testing.T) {
+	spy := &usageSummaryCountsSpy{
+		matchingSessionCount: 2,
+		result: db.DailyUsageResult{
+			Daily:  []db.DailyUsageEntry{{Date: "2024-06-01"}},
+			Totals: db.UsageTotals{},
+			SessionCounts: db.UsageSessionCounts{
+				Total:     0,
+				ByProject: map[string]int{},
+				ByAgent:   map[string]int{},
+			},
+		},
+	}
+	s := newRoutedTestServerWithStore(t, spy)
+
+	w := serveGet(t, s,
+		"/api/v1/usage/summary?"+oneDayUsageRange+"&agent=copilot,claude")
+	assertRecorderStatus(t, w, http.StatusOK)
+
+	var resp UsageSummaryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Nil(t, resp.UnsupportedUsage)
+	assertUsageQueryCalls(t, spy, 1, 0, 0)
 }

--- a/internal/server/usage_readonly_internal_test.go
+++ b/internal/server/usage_readonly_internal_test.go
@@ -34,6 +34,12 @@ func (readOnlyUsageSpy) GetUsageSessionCounts(
 	return db.UsageSessionCounts{}, db.ErrReadOnly
 }
 
+func (readOnlyUsageSpy) GetUsageMatchingSessionCount(
+	_ context.Context, _ db.UsageFilter,
+) (int, error) {
+	return 0, db.ErrReadOnly
+}
+
 // TestUsageHandlers_ReturnNotImplementedOnReadOnlyStore locks
 // in the Postgres-backend contract: when the underlying Store
 // reports a usage query as unavailable (db.ErrReadOnly), both

--- a/internal/server/usage_test.go
+++ b/internal/server/usage_test.go
@@ -131,6 +131,23 @@ func seedUsageEnv(t *testing.T, te *testEnv) {
 	}
 }
 
+func seedCopilotNoTokenSession(t *testing.T, te *testEnv, id string) {
+	t.Helper()
+	te.seedSession(t, id, "alpha", 1, func(sess *db.Session) {
+		ts := "2024-06-01T09:00:00Z"
+		sess.Agent = "copilot"
+		sess.StartedAt = &ts
+		sess.EndedAt = &ts
+		sess.UserMessageCount = 1
+	})
+	te.seedMessages(t, id, 1, func(_ int, m *db.Message) {
+		m.Role = "assistant"
+		m.Timestamp = "2024-06-01T09:00:00Z"
+		m.Model = "gpt-5.3-codex"
+		m.TokenUsage = nil
+	})
+}
+
 func TestHandleUsageSummaryJSONShape(t *testing.T) {
 	te := setup(t)
 	seedUsageEnv(t, te)
@@ -161,6 +178,44 @@ func TestHandleUsageSummaryJSONShape(t *testing.T) {
 	assert.NotEmpty(t, resp.ProjectTotals)
 	assert.NotEmpty(t, resp.ModelTotals)
 	assert.NotEmpty(t, resp.AgentTotals)
+}
+
+func TestHandleUsageSummaryIncludesUnsupportedCopilotSignal(t *testing.T) {
+	te := setup(t)
+	seedCopilotNoTokenSession(t, te, "copilot-unsupported")
+
+	w := te.get(t, buildPathURL("/api/v1/usage/summary",
+		map[string]string{
+			"from":     "2024-06-01",
+			"to":       "2024-06-01",
+			"timezone": "UTC",
+			"agent":    "copilot",
+		}))
+	assertStatus(t, w, http.StatusOK)
+
+	resp := decode[server.UsageSummaryResponse](t, w)
+	require.NotNil(t, resp.UnsupportedUsage)
+	assert.Equal(t, service.UnsupportedUsageKindCopilotNoTokenData, resp.UnsupportedUsage.Kind)
+	assert.Equal(t, 0, resp.SessionCounts.Total)
+	assert.Equal(t, 0.0, resp.Totals.TotalCost)
+}
+
+func TestHandleUsageSummarySkipsUnsupportedCopilotSignalForMixedFilters(t *testing.T) {
+	te := setup(t)
+	seedCopilotNoTokenSession(t, te, "copilot-unsupported")
+	seedUsageEnv(t, te)
+
+	w := te.get(t, buildPathURL("/api/v1/usage/summary",
+		map[string]string{
+			"from":     "2024-06-01",
+			"to":       "2024-06-02",
+			"timezone": "UTC",
+			"agent":    "copilot,claude",
+		}))
+	assertStatus(t, w, http.StatusOK)
+
+	resp := decode[server.UsageSummaryResponse](t, w)
+	assert.Nil(t, resp.UnsupportedUsage)
 }
 
 func TestHandleUsageSummaryIncludesCursorUsageEvents(t *testing.T) {

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -566,7 +566,19 @@ func (b *directBackend) UsageSummary(
 	if err != nil {
 		return nil, err
 	}
-	return buildUsageSummary(f, result), nil
+	summary := buildUsageSummary(f, result)
+	if db.IsCopilotAgentFilter(f.Agent) && db.NoTokenData(result.Totals) {
+		matchingSessions, err := b.db.GetUsageMatchingSessionCount(ctx, f)
+		if err != nil {
+			return nil, err
+		}
+		if matchingSessions > 0 {
+			summary.UnsupportedUsage = &UnsupportedUsage{
+				Kind: UnsupportedUsageKindCopilotNoTokenData,
+			}
+		}
+	}
+	return summary, nil
 }
 
 // SearchContent maps the transport-neutral request to a

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -160,19 +160,26 @@ type CacheStats struct {
 	SavingsVsUncached   float64 `json:"savingsVsUncached"`
 }
 
+const UnsupportedUsageKindCopilotNoTokenData = "copilot-no-token-data"
+
+type UnsupportedUsage struct {
+	Kind string `json:"kind"`
+}
+
 // UsageSummaryResult is the transport-neutral usage-summary response, the
 // JSON shape served by GET /api/v1/usage/summary. The prior-period
 // comparison is a separate endpoint, so it is intentionally absent here.
 type UsageSummaryResult struct {
-	From          string                `json:"from"`
-	To            string                `json:"to"`
-	Totals        db.UsageTotals        `json:"totals"`
-	Daily         []db.DailyUsageEntry  `json:"daily"`
-	ProjectTotals []ProjectTotal        `json:"projectTotals"`
-	ModelTotals   []ModelTotal          `json:"modelTotals"`
-	AgentTotals   []AgentTotal          `json:"agentTotals"`
-	SessionCounts db.UsageSessionCounts `json:"sessionCounts"`
-	CacheStats    CacheStats            `json:"cacheStats"`
+	From             string                `json:"from"`
+	To               string                `json:"to"`
+	Totals           db.UsageTotals        `json:"totals"`
+	Daily            []db.DailyUsageEntry  `json:"daily"`
+	ProjectTotals    []ProjectTotal        `json:"projectTotals"`
+	ModelTotals      []ModelTotal          `json:"modelTotals"`
+	AgentTotals      []AgentTotal          `json:"agentTotals"`
+	SessionCounts    db.UsageSessionCounts `json:"sessionCounts"`
+	CacheStats       CacheStats            `json:"cacheStats"`
+	UnsupportedUsage *UnsupportedUsage     `json:"unsupportedUsage,omitempty"`
 }
 
 // buildUsageSummary assembles a UsageSummaryResult from a daily-usage


### PR DESCRIPTION
GitHub Copilot sessions really do arrive without per-message token counters or per-message cost, so the Usage dashboard's current zero-state is misleading rather than accurate when a user filters down to Copilot-only agents. The page shows zero-value cards and generic empty panels even when matching Copilot sessions exist in the selected range, which reads as "nothing was spent" instead of "this agent family does not expose token usage."

PR #934 already fixed the CLI half of this issue and explicitly scoped the dashboard half out because it needs a filter-faithful matching-session count from the sessions table, not a usage-row count. Current summary assembly still has that exact gap: the dashboard only receives totals plus usage-row-gated session counts, so it cannot tell the difference between unsupported Copilot usage and a truly empty filter result. This change adds that missing cross-backend session-presence helper behind the shared store interface, then exposes one narrow machine-readable summary signal only when the filter is Copilot-only, the totals still have no token data, and matching sessions do exist. The frontend uses that signal to render a short note above the summary cards and leaves the existing charts, tables, and generic empty states unchanged.

Scope stays tight. There are no CLI changes here, because #934 already shipped them, and the separate model-picker complaint in the issue remains out of scope because it is a catalog-population problem, not a usage-visibility problem. Reviewers should look first at the new matching-session helper and its backend parity tests, then at the small summary-contract addition that the dashboard consumes.

Fixes #349
