### PR TITLE
feat(frontend): show parser malformed-lines badge on session detail

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -172,6 +172,36 @@
   "session_breadcrumb_failed_to_open": "Failed to open",
   "session_breadcrumb_summary_mode": "Summary mode",
   "session_breadcrumb_summary_mode_tooltip": "Tool results, thinking, and diffs are missing from this transcript. Full fidelity needs the agy-reader sidecar — install it, or if installed, let it catch up. Click to learn how.",
+  "session_breadcrumb_malformed_lines": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} malformed line",
+        "countPlural=other": "{count} malformed lines"
+      }
+    }
+  ],
+  "session_breadcrumb_malformed_lines_tooltip": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} line in the source file could not be parsed",
+        "countPlural=other": "{count} lines in the source file could not be parsed"
+      }
+    }
+  ],
   "session_find_find_in_session": "Find in session",
   "session_find_placeholder": "Find in session...",
   "session_find_search_query": "Search query",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -169,6 +169,34 @@
   "session_breadcrumb_failed_to_open": "打开失败",
   "session_breadcrumb_summary_mode": "摘要模式",
   "session_breadcrumb_summary_mode_tooltip": "此 transcript 缺少工具结果、思考内容和代码差异。需要 agy-reader sidecar 才能获得完整保真度 — 请安装它，若已安装，请等待其同步完成。点击了解如何操作。",
+  "session_breadcrumb_malformed_lines": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{count} 行格式错误"
+      }
+    }
+  ],
+  "session_breadcrumb_malformed_lines_tooltip": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "源文件中有 {count} 行无法解析"
+      }
+    }
+  ],
   "session_find_find_in_session": "在会话中查找",
   "session_find_placeholder": "在会话中查找...",
   "session_find_search_query": "搜索关键词",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -169,6 +169,34 @@
   "session_breadcrumb_failed_to_open": "打開失敗",
   "session_breadcrumb_summary_mode": "摘要模式",
   "session_breadcrumb_summary_mode_tooltip": "此 transcript 缺少工具結果、思考內容和代碼差異。需要 agy-reader sidecar 才能獲得完整保真度 — 請安裝它，若已安裝，請等待其同步完成。點擊了解如何操作。",
+  "session_breadcrumb_malformed_lines": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "{count} 行格式錯誤"
+      }
+    }
+  ],
+  "session_breadcrumb_malformed_lines_tooltip": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=other": "源文件中有 {count} 行無法解析"
+      }
+    }
+  ],
   "session_find_find_in_session": "在會話中查找",
   "session_find_placeholder": "在會話中查找...",
   "session_find_search_query": "搜索關鍵詞",

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -64,6 +64,7 @@ export interface Session {
   health_score_basis?: string[] | null;
   health_penalties?: Record<string, number> | null;
   transcript_fidelity?: string;
+  parser_malformed_lines?: number;
   created_at: string;
 }
 

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -564,6 +564,16 @@
           title={m.session_breadcrumb_summary_mode_tooltip()}
         >{m.session_breadcrumb_summary_mode()}</a>
       {/if}
+      {#if session.parser_malformed_lines}
+        <span
+          class="malformed-badge"
+          title={m.session_breadcrumb_malformed_lines_tooltip({
+            count: session.parser_malformed_lines,
+          })}
+        >{m.session_breadcrumb_malformed_lines({
+          count: session.parser_malformed_lines,
+        })}</span>
+      {/if}
       {#if session.started_at}
         <span class="session-time">
           {new Date(session.started_at).toLocaleDateString(
@@ -878,6 +888,22 @@
 
   .summary-badge:hover {
     text-decoration: underline;
+  }
+
+  .malformed-badge {
+    display: inline-flex;
+    align-items: center;
+    font-size: 9px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 8px;
+    letter-spacing: 0.02em;
+    flex-shrink: 0;
+    color: var(--accent-amber, #e0a458);
+    background: color-mix(in srgb, var(--accent-amber, #e0a458) 18%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent-amber, #e0a458) 40%, transparent);
+    white-space: nowrap;
+    cursor: default;
   }
 
   .session-time {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -516,6 +516,75 @@ describe("SessionBreadcrumb", () => {
     });
   });
 
+  describe("malformed-lines badge", () => {
+    it("shows the badge with the line count when parser_malformed_lines is positive", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude", {
+            parser_malformed_lines: 3,
+          }),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      const badge = document.querySelector(".malformed-badge");
+      expect(badge).toBeTruthy();
+      expect(badge?.textContent?.trim()).toBe("3 malformed lines");
+      expect(badge?.getAttribute("title")).toBe(
+        "3 lines in the source file could not be parsed",
+      );
+      unmount(component);
+    });
+
+    it("uses singular wording for exactly one malformed line", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude", {
+            parser_malformed_lines: 1,
+          }),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      const badge = document.querySelector(".malformed-badge");
+      expect(badge?.textContent?.trim()).toBe("1 malformed line");
+      expect(badge?.getAttribute("title")).toBe(
+        "1 line in the source file could not be parsed",
+      );
+      unmount(component);
+    });
+
+    it("hides the badge when parser_malformed_lines is zero", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude", {
+            parser_malformed_lines: 0,
+          }),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      expect(document.querySelector(".malformed-badge")).toBeNull();
+      unmount(component);
+    });
+
+    it("hides the badge when parser_malformed_lines is absent", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      expect(document.querySelector(".malformed-badge")).toBeNull();
+      unmount(component);
+    });
+  });
+
   it("hides local-only actions for remote sessions", async () => {
     const component = mount(SessionBreadcrumb, {
       target: document.body,


### PR DESCRIPTION
#866 started surfacing parser anomaly signals in the CLI sync summary; the per-session `parser_malformed_lines` count has been serialized in the session API since then, but nothing in the UI rendered it. This adds the missing read side: a warning badge in the session-detail breadcrumb, shown only when the count is non-zero, with a tooltip explaining that N lines in the source file could not be parsed.

The badge reuses the local badge vocabulary already in `SessionBreadcrumb.svelte` — it sits next to the summary-mode badge from #914 and follows the same conditional-pill pattern — rather than introducing a new shared component. The hand-maintained `Session` type gains the already-serialized field, and plural-aware message keys are added for en, zh-CN, and zh-TW.

Frontend-only; no backend or schema changes. Scope is deliberately the session-detail surface — the session list is untouched.

Where to look: `SessionBreadcrumb.svelte` for the badge and its gating, `core.ts` for the type addition.
