### PR TITLE
feat(parse-diff): cover DB-backed Warp, Forge, and Piebald providers

### DIFF
--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -83,7 +83,7 @@ func newParseDiffCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringArrayVar(&cfg.Agents, "agent", nil,
-		"Restrict to these agents (repeatable; default: all file-based agents)")
+		"Restrict to these agents (repeatable; default: all re-parseable agents)")
 	cmd.Flags().IntVar(&cfg.Limit, "limit", 0,
 		"Re-parse only the N most recently modified source files (0 = all)")
 	cmd.Flags().BoolVar(&cfg.FailOnChange, "fail-on-change", false,
@@ -265,9 +265,12 @@ func parseDiffSupportedAgents() []string {
 }
 
 func parseDiffAgentSupported(def parser.AgentDef) bool {
-	if !def.FileBased {
-		return false
-	}
+	// A provider-authoritative agent with a registered factory has a
+	// Discover()/Parse() parse-diff can re-parse, whether it reads literal
+	// per-session files or a shared SQLite store it fans out per session
+	// (Kiro, OpenCode, Forge, Piebald, Warp). FileBased is not consulted:
+	// import-only agents are already excluded because they are not
+	// provider-authoritative.
 	switch parser.ProviderMigrationModes()[def.Type] {
 	case parser.ProviderMigrationProviderAuthoritative:
 		_, ok := parser.ProviderFactoryByType(def.Type)

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -58,20 +58,27 @@ func TestParseDiff_UnknownAgentListsSupported(t *testing.T) {
 		assert.Contains(t, err.Error(), want,
 			"error should list supported agent %q", want)
 	}
-	for _, unwanted := range []string{"forge", "piebald", "warp"} {
+	// The DB-backed provider-authoritative agents are re-parseable through
+	// their providers, so they appear in the supported list too.
+	for _, want := range []string{"forge", "piebald", "warp"} {
+		assert.Contains(t, err.Error(), want,
+			"error should list supported DB-backed agent %q", want)
+	}
+	// Import-only agents remain unsupported and must not be listed.
+	for _, unwanted := range []string{"claude-ai", "chatgpt"} {
 		assert.NotContains(t, err.Error(), unwanted,
-			"error should not list unsupported agent %q", unwanted)
+			"error should not list import-only agent %q", unwanted)
 	}
 }
 
 func TestParseDiff_RejectsAgentsWithoutOnDiskSource(t *testing.T) {
+	// Only import-only agents have no source to re-parse. The DB-backed
+	// provider-authoritative agents (Forge/Piebald/Warp) are re-parseable
+	// through their providers and are covered as supported elsewhere.
 	tests := []struct {
 		name  string
 		agent string
 	}{
-		{"database-backed forge", "forge"},
-		{"database-backed piebald", "piebald"},
-		{"database-backed warp", "warp"},
 		{"import-only claude-ai", "claude-ai"},
 		{"import-only chatgpt", "chatgpt"},
 	}
@@ -122,6 +129,11 @@ func TestParseDiffAgentTypes(t *testing.T) {
 			want: []string{"omp"},
 		},
 		{
+			name: "db-backed provider-authoritative agents",
+			in:   []string{"forge", "piebald", "warp"},
+			want: []string{"forge", "piebald", "warp"},
+		},
+		{
 			name: "trims and lowercases",
 			in:   []string{" Claude "},
 			want: []string{"claude"},
@@ -137,8 +149,8 @@ func TestParseDiffAgentTypes(t *testing.T) {
 			wantErr: `unknown agent "nope"`,
 		},
 		{
-			name:    "db-backed agent",
-			in:      []string{"forge"},
+			name:    "import-only agent",
+			in:      []string{"claude-ai"},
 			wantErr: "no on-disk source to re-parse",
 		},
 	}
@@ -168,12 +180,13 @@ func TestParseDiffSupportedAgentsIncludesProviderAuthoritativeAgents(t *testing.
 	supported := parseDiffSupportedAgents()
 	modes := parser.ProviderMigrationModes()
 	// Build the expected set from the registry so the contract covers every
-	// current file-based, provider-authoritative agent and stays correct as
-	// the migration manifest changes, rather than a hand-maintained subset.
+	// current provider-authoritative agent and stays correct as the migration
+	// manifest changes, rather than a hand-maintained subset. FileBased is not
+	// part of the gate: DB-backed provider-authoritative agents
+	// (Forge/Piebald/Warp) are re-parseable through their providers too.
 	checked := 0
 	for _, def := range parser.Registry {
-		if !def.FileBased ||
-			modes[def.Type] != parser.ProviderMigrationProviderAuthoritative {
+		if modes[def.Type] != parser.ProviderMigrationProviderAuthoritative {
 			continue
 		}
 		checked++
@@ -183,7 +196,23 @@ func TestParseDiffSupportedAgentsIncludesProviderAuthoritativeAgents(t *testing.
 			"parse-diff supported list must include %s", def.Type)
 	}
 	require.Positive(t, checked,
-		"expected at least one file-based provider-authoritative agent")
+		"expected at least one provider-authoritative agent")
+
+	// Explicitly pin the DB-backed provider-authoritative agents so a
+	// regression that re-adds a FileBased gate to the parse-diff support
+	// check is caught by name, not just by the registry-wide sweep above.
+	for _, agent := range []parser.AgentType{
+		parser.AgentForge, parser.AgentPiebald, parser.AgentWarp,
+	} {
+		def, ok := parser.AgentByType(agent)
+		require.True(t, ok, "agent %s", agent)
+		assert.False(t, def.FileBased,
+			"%s is expected to be DB-backed (FileBased=false)", agent)
+		assert.True(t, parseDiffAgentSupported(def),
+			"DB-backed %s must be supported by parse-diff", agent)
+		assert.Contains(t, supported, string(agent),
+			"parse-diff supported list must include DB-backed %s", agent)
+	}
 }
 
 func TestParseDiff_EmptyArchiveRunsClean(t *testing.T) {

--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -190,11 +190,14 @@ func (s dbBackedSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 			return nil, err
 		}
 		for _, meta := range metas {
-			addJSONLSource(
-				s.newSourceRef(root, dbPath, meta.SessionID, meta.VirtualPath),
-				&sources,
-				seen,
-			)
+			ref := s.newSourceRef(root, dbPath, meta.SessionID, meta.VirtualPath)
+			// Carry the per-session mtime captured here so parse-diff's --limit
+			// sampler can order these virtual "<db>#<sessionID>" sources by each
+			// session's real mtime rather than stat'ing a path that has no
+			// on-disk existence. Ordering metadata only: skip-cache and
+			// data-version freshness still resolve through Fingerprint.
+			ref.DiscoveryMTimeNS = meta.FileMtime
+			addJSONLSource(ref, &sources, seen)
 		}
 	}
 	sortJSONLSources(sources)

--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -468,7 +468,7 @@ func newForgeProviderFactory(def AgentDef) ProviderFactory {
 func forgeProviderSpec() dbBackedProviderSpec {
 	return dbBackedProviderSpec{
 		agent:  AgentForge,
-		dbName: forgeDBFilename,
+		dbName: ForgeDBFilename,
 		findDB: forgeDBPath,
 		listMeta: func(dbPath string) ([]dbBackedSessionMeta, error) {
 			metas, err := ListForgeSessionMeta(dbPath)
@@ -499,7 +499,7 @@ func newPiebaldProviderFactory(def AgentDef) ProviderFactory {
 func piebaldProviderSpec() dbBackedProviderSpec {
 	return dbBackedProviderSpec{
 		agent:  AgentPiebald,
-		dbName: piebaldDBFilename,
+		dbName: PiebaldDBFilename,
 		findDB: piebaldDBPath,
 		listMeta: func(dbPath string) ([]dbBackedSessionMeta, error) {
 			metas, err := ListPiebaldSessionMeta(dbPath)
@@ -530,7 +530,7 @@ func newWarpProviderFactory(def AgentDef) ProviderFactory {
 func warpProviderSpec() dbBackedProviderSpec {
 	return dbBackedProviderSpec{
 		agent:  AgentWarp,
-		dbName: warpDBFilename,
+		dbName: WarpDBFilename,
 		findDB: warpDBPath,
 		listMeta: func(dbPath string) ([]dbBackedSessionMeta, error) {
 			metas, err := ListWarpSessionMeta(dbPath)

--- a/internal/parser/db_backed_provider_test.go
+++ b/internal/parser/db_backed_provider_test.go
@@ -74,7 +74,7 @@ func TestForgeProviderSourceMethodsAndParse(t *testing.T) {
 	})
 	require.True(t, ok)
 
-	assertDBBackedWatchPlan(t, provider, root, forgeDBFilename)
+	assertDBBackedWatchPlan(t, provider, root, ForgeDBFilename)
 	assertDBBackedDiscoverFindFingerprint(
 		t, provider, root, dbPath, "conv-001",
 	)
@@ -109,7 +109,7 @@ func TestPiebaldProviderSourceMethodsAndParse(t *testing.T) {
 	})
 	require.True(t, ok)
 
-	assertDBBackedWatchPlan(t, provider, root, piebaldDBFilename)
+	assertDBBackedWatchPlan(t, provider, root, PiebaldDBFilename)
 	assertDBBackedDiscoverFindFingerprint(
 		t, provider, root, dbPath, "42",
 	)
@@ -152,7 +152,7 @@ func TestWarpProviderSourceMethodsAndParse(t *testing.T) {
 	})
 	require.True(t, ok)
 
-	assertDBBackedWatchPlan(t, provider, root, warpDBFilename)
+	assertDBBackedWatchPlan(t, provider, root, WarpDBFilename)
 	assertDBBackedDiscoverFindFingerprint(
 		t, provider, root, dbPath, "conv-001",
 	)
@@ -328,7 +328,7 @@ func TestDBBackedProviderRejectsInvalidStoredVirtualPaths(t *testing.T) {
 	for _, path := range []string{
 		dbPath + "#",
 		filepath.Join(root, "forge-copy.db") + "#conv-001",
-		filepath.Join(root, "nested", forgeDBFilename) + "#conv-001",
+		filepath.Join(root, "nested", ForgeDBFilename) + "#conv-001",
 	} {
 		_, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
 			StoredFilePath:     path,

--- a/internal/parser/forge.go
+++ b/internal/parser/forge.go
@@ -12,7 +12,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const forgeDBFilename = ".forge.db"
+// ForgeDBFilename is the Forge session store filename inside its data dir.
+const ForgeDBFilename = ".forge.db"
 
 // ForgeSessionMeta is lightweight metadata for a session,
 // used to detect changes without parsing messages.
@@ -27,7 +28,7 @@ func forgeDBPath(dir string) string {
 	if dir == "" {
 		return ""
 	}
-	path := filepath.Join(dir, forgeDBFilename)
+	path := filepath.Join(dir, ForgeDBFilename)
 	info, err := os.Stat(path)
 	if err != nil || info.IsDir() {
 		return ""

--- a/internal/parser/piebald.go
+++ b/internal/parser/piebald.go
@@ -11,7 +11,8 @@ import (
 	"time"
 )
 
-const piebaldDBFilename = "app.db"
+// PiebaldDBFilename is the Piebald session store filename inside its data dir.
+const PiebaldDBFilename = "app.db"
 
 // PiebaldSessionMeta is lightweight metadata for a Piebald chat.
 type PiebaldSessionMeta struct {
@@ -25,7 +26,7 @@ func piebaldDBPath(dir string) string {
 	if dir == "" {
 		return ""
 	}
-	path := filepath.Join(dir, piebaldDBFilename)
+	path := filepath.Join(dir, PiebaldDBFilename)
 	info, err := os.Stat(path)
 	if err != nil || info.IsDir() {
 		return ""

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -176,6 +176,16 @@ type SourceRef struct {
 	FingerprintKey string
 	// ProjectHint is advisory metadata for UI grouping and may be empty.
 	ProjectHint string
+	// DiscoveryMTimeNS is an optional per-source modification time in Unix
+	// nanoseconds captured at discovery. Providers whose sources are virtual --
+	// a shared store fanned out to one source per session, where DisplayPath is
+	// "<db>#<sessionID>" and os.Stat cannot resolve a real mtime -- set it so
+	// ordering consumers (parse-diff's --limit sampler) can rank sources by each
+	// session's real mtime instead of a failed stat that collapses to 0. Zero
+	// means unset. It is advisory ordering metadata only: it is never persisted
+	// and must not be used for skip-cache or data-version freshness, which go
+	// through Fingerprint.
+	DiscoveryMTimeNS int64
 	// Opaque is in-memory-only source state: never persisted and never required
 	// for lookup from persisted rows, so any source that must survive a restart
 	// has to be recoverable from Key, DisplayPath, FingerprintKey,

--- a/internal/parser/warp.go
+++ b/internal/parser/warp.go
@@ -10,7 +10,8 @@ import (
 	"time"
 )
 
-const warpDBFilename = "warp.sqlite"
+// WarpDBFilename is the Warp session store filename inside its data dir.
+const WarpDBFilename = "warp.sqlite"
 
 // WarpSessionMeta is lightweight metadata for a session,
 // used to detect changes without parsing messages.
@@ -486,7 +487,7 @@ func parseWarpTimestamp(s string) time.Time {
 // warpDBPath returns the path to warp.sqlite inside the
 // given directory, or "" if it doesn't exist.
 func warpDBPath(dir string) string {
-	candidate := filepath.Join(dir, warpDBFilename)
+	candidate := filepath.Join(dir, WarpDBFilename)
 	if _, err := os.Stat(candidate); err == nil {
 		return candidate
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -34,6 +34,7 @@ type testEnv struct {
 	mimocodeDir       string
 	forgeDir          string
 	piebaldDir        string
+	warpDir           string
 	iflowDir          string
 	ampDir            string
 	piDir             string
@@ -115,6 +116,7 @@ func setupTestEnv(t *testing.T, opts ...TestEnvOption) *testEnv {
 		mimocodeDir:       t.TempDir(),
 		forgeDir:          t.TempDir(),
 		piebaldDir:        t.TempDir(),
+		warpDir:           t.TempDir(),
 		iflowDir:          t.TempDir(),
 		ampDir:            t.TempDir(),
 		piDir:             t.TempDir(),
@@ -183,6 +185,7 @@ func setupTestEnv(t *testing.T, opts ...TestEnvOption) *testEnv {
 			parser.AgentMiMoCode:       {env.mimocodeDir},
 			parser.AgentForge:          {env.forgeDir},
 			parser.AgentPiebald:        {env.piebaldDir},
+			parser.AgentWarp:           {env.warpDir},
 			parser.AgentIflow:          {env.iflowDir},
 			parser.AgentAmp:            {env.ampDir},
 			parser.AgentPi:             {env.piDir},
@@ -262,6 +265,10 @@ func assignFocusedAgentDir(
 		env.mimocodeDir = dir
 	case parser.AgentPiebald:
 		env.piebaldDir = dir
+	case parser.AgentForge:
+		env.forgeDir = dir
+	case parser.AgentWarp:
+		env.warpDir = dir
 	case parser.AgentPi:
 		env.piDir = dir
 	case parser.AgentOMP:

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -483,17 +483,18 @@ func (e *Engine) parseDiffSourceReliableForRaced(
 	if stripVirtualSourceSuffix(sourcePath) != sourcePath {
 		return false
 	}
-	// Only agents with a literal on-disk source -- the same discoverability
-	// condition resolveParseDiffAgents uses -- read a file whose mtime
-	// populated file_mtime. An unknown or non-authoritative agent has no such
-	// basis; a DB-backed agent's source is virtual and was already gated out
-	// above, so what remains here is a literal-file provider-authoritative
-	// source.
+	// Only a literal-file agent reads a source whose os.Stat mtime is a
+	// per-session race signal that populated file_mtime. FileBased is exactly
+	// that predicate, so it is required here even though the discoverability
+	// gate no longer consults it: a DB-backed agent (FileBased == false) is
+	// never reliable for the raced guard. Its real sources are virtual and were
+	// gated out above; requiring FileBased also fails closed on the impossible
+	// non-virtual DB path rather than trusting a shared store's composite mtime.
 	def, ok := parser.AgentByType(agent)
 	if !ok {
 		return false
 	}
-	return e.parseDiffAgentDiscoverable(def)
+	return def.FileBased && e.parseDiffAgentDiscoverable(def)
 }
 
 // parseDiffLiveMtime resolves a session's live source mtime for the raced

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -405,18 +405,8 @@ func parseDiffSourceKey(path string) string {
 // database as one source; those key by the stripped database path.
 var perSessionDBVirtualSourceBases = []string{
 	"opencode.db", "kilo.db", "mimocode.db",
-	warpDBFile, forgeDBFile, piebaldDBFile,
+	parser.WarpDBFilename, parser.ForgeDBFilename, parser.PiebaldDBFilename,
 }
-
-// warpDBFile, forgeDBFile, and piebaldDBFile mirror the unexported DB
-// filenames the parser package assigns each DB-backed provider. They are
-// duplicated here (like the opencode-family literals above) because the parser
-// constants are unexported.
-const (
-	warpDBFile    = "warp.sqlite"
-	forgeDBFile   = ".forge.db"
-	piebaldDBFile = "app.db"
-)
 
 func isPerSessionDBVirtualSource(path string) bool {
 	for _, base := range perSessionDBVirtualSourceBases {

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -14,10 +14,12 @@ import (
 
 // ParseDiffOptions configures a report-only re-parse comparison.
 type ParseDiffOptions struct {
-	// Agents restricts the run; empty means every file-based agent with
-	// a provider-discoverable on-disk source. Agents without an on-disk
-	// source to re-parse (database-backed or import-only) are rejected
-	// with an error.
+	// Agents restricts the run; empty means every provider-authoritative
+	// agent whose registered factory can Discover() and re-parse a source.
+	// That includes shared-SQLite DB-backed providers that fan a database
+	// out to one virtual source per session (Kiro, OpenCode, Forge,
+	// Piebald, Warp). Only import-only agents, which have no source to
+	// re-parse, are rejected with an error.
 	Agents []parser.AgentType
 	// Limit caps the number of source files parsed, newest mtime first
 	// across all agents. 0 means no limit.
@@ -174,7 +176,7 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 	e.parseDiffPresenceSweep(report, presencePaths, storedByPath, visited)
 
 	// Final sweep: stored sessions never visited by any file.
-	parseDiffSweepStored(
+	e.parseDiffSweepStored(
 		report, storedSessions, resolvedSet,
 		len(opts.Agents) == 0, cutPaths, visited,
 	)
@@ -266,9 +268,15 @@ func (e *Engine) parseDiffProviderSources(
 }
 
 func (e *Engine) parseDiffAgentDiscoverable(def parser.AgentDef) bool {
-	if !def.FileBased {
-		return false
-	}
+	// A provider-authoritative agent with a registered factory exposes a
+	// working Discover()/Parse() the report-only run can re-parse, whether it
+	// reads literal per-session files (Claude, Codex) or a shared SQLite store
+	// its provider fans out to one virtual source per session (Kiro, OpenCode,
+	// and the DB-backed Forge/Piebald/Warp providers). FileBased is not
+	// consulted here: it distinguishes literal-file agents from DB-backed ones
+	// for the watcher and sync paths, but both kinds satisfy the same provider
+	// Discover() contract parse-diff needs. Import-only agents are not
+	// provider-authoritative, so the switch still rejects them.
 	switch e.providerMigrationModes[def.Type] {
 	case parser.ProviderMigrationProviderAuthoritative:
 		factory, ok := e.providerFactories[def.Type]
@@ -360,14 +368,36 @@ func sortAndLimitParseDiffFiles(
 }
 
 func parseDiffSourceKey(path string) string {
-	if isOpenCodeFamilyProviderVirtualSource(path) {
+	if isPerSessionDBVirtualSource(path) {
 		return path
 	}
 	return stripVirtualSourceSuffix(path)
 }
 
-func isOpenCodeFamilyProviderVirtualSource(path string) bool {
-	for _, base := range []string{"opencode.db", "kilo.db", "mimocode.db"} {
+// perSessionDBVirtualSourceBases lists the shared-SQLite database filenames
+// whose providers discover one virtual source per session (opencode.db#id,
+// warp.sqlite#id, ...). parse-diff keys these by their full virtual path, so a
+// --limit sample or a per-session parse failure stays scoped to the single
+// session it names instead of fanning out across every sibling row in the same
+// physical database. Contrast Kiro/Zed/Shelley, whose providers discover the
+// database as one source; those key by the stripped database path.
+var perSessionDBVirtualSourceBases = []string{
+	"opencode.db", "kilo.db", "mimocode.db",
+	warpDBFile, forgeDBFile, piebaldDBFile,
+}
+
+// warpDBFile, forgeDBFile, and piebaldDBFile mirror the unexported DB
+// filenames the parser package assigns each DB-backed provider. They are
+// duplicated here (like the opencode-family literals above) because the parser
+// constants are unexported.
+const (
+	warpDBFile    = "warp.sqlite"
+	forgeDBFile   = ".forge.db"
+	piebaldDBFile = "app.db"
+)
+
+func isPerSessionDBVirtualSource(path string) bool {
+	for _, base := range perSessionDBVirtualSourceBases {
 		if _, _, ok := parser.ParseVirtualSourcePathForBase(path, base); ok {
 			return true
 		}
@@ -375,12 +405,12 @@ func isOpenCodeFamilyProviderVirtualSource(path string) bool {
 	return false
 }
 
-// stripVirtualSourceSuffix maps a stored file_path to its on-disk base
-// file by removing the "#rawID" suffix that Kiro, Zed, OpenCode, Kilo,
-// MiMoCode, and Shelley SQLite-backed sessions append to their shared database
-// path, the "#conversationID" suffix Visual Studio Copilot appends to its
-// shared trace file, and the "#runIdx" suffix aider appends to its shared
-// history file.
+// stripVirtualSourceSuffix maps a stored file_path to its on-disk base file by
+// removing the "#rawID" suffix that Kiro, Zed, OpenCode, Kilo, MiMoCode,
+// IcodeMate, Shelley, Forge, Piebald, and Warp SQLite-backed sessions append to
+// their shared database path, the "#conversationID" suffix Visual Studio
+// Copilot appends to its shared trace file, and the "#runIdx" suffix aider
+// appends to its shared history file.
 func stripVirtualSourceSuffix(path string) string {
 	if tracePath, _, ok := parser.SplitVisualStudioCopilotVirtualPath(path); ok {
 		return tracePath
@@ -394,14 +424,10 @@ func stripVirtualSourceSuffix(path string) string {
 	if dbPath, _, ok := parser.ParseVirtualSourcePathForBase(path, "threads.db"); ok {
 		return dbPath
 	}
-	if dbPath, _, ok := parser.ParseVirtualSourcePathForBase(path, "opencode.db"); ok {
-		return dbPath
-	}
-	if dbPath, _, ok := parser.ParseVirtualSourcePathForBase(path, "kilo.db"); ok {
-		return dbPath
-	}
-	if dbPath, _, ok := parser.ParseVirtualSourcePathForBase(path, "mimocode.db"); ok {
-		return dbPath
+	for _, base := range perSessionDBVirtualSourceBases {
+		if dbPath, _, ok := parser.ParseVirtualSourcePathForBase(path, base); ok {
+			return dbPath
+		}
 	}
 	if dbPath, _, ok := parser.ParseVirtualSourcePathForBase(path, "icodemate.db"); ok {
 		return dbPath
@@ -429,14 +455,15 @@ func stripVirtualSourceSuffix(path string) string {
 // it fails CLOSED rather than risk masking genuine parser drift:
 //
 //   - Virtual-path sources (Aider "#runIdx", Kiro/Zed/OpenCode/Kilo/MiMoCode
-//     "#rawID", Shelley, Visual Studio Copilot "#conversationID"). Many
-//     sessions fan out of ONE physical source, so the source mtime is NOT a
-//     per-session signal. A shared DB's rows can carry advanced updated_at
-//     values, and Aider's File.Mtime is the whole .aider.chat.history.md
-//     file's mtime shared by every run in it -- appending a new run bumps it
-//     for all runs -- so a newer mtime does not mean THIS session's parsed
-//     content was torn. Including them would mask genuine drift on untouched
-//     siblings; instead they keep their real changed/unchanged verdict (see
+//     "#rawID", Shelley, Forge/Piebald/Warp "#sessionID", Visual Studio Copilot
+//     "#conversationID"). Many sessions fan out of ONE physical source, so the
+//     source mtime is NOT a per-session signal. A shared DB's rows can carry
+//     advanced updated_at values, and Aider's File.Mtime is the whole
+//     .aider.chat.history.md file's mtime shared by every run in it --
+//     appending a new run bumps it for all runs -- so a newer mtime does not
+//     mean THIS session's parsed content was torn. Including them would mask
+//     genuine drift on untouched siblings; instead they keep their real
+//     changed/unchanged verdict (see
 //     TestParseDiffDBBackedSourceNotMaskedAsRaced).
 //   - Agents that are not plain file-based (no on-disk literal file at all).
 //
@@ -448,15 +475,20 @@ func (e *Engine) parseDiffSourceReliableForRaced(
 ) bool {
 	// A virtual path carries a recognized "#..." suffix; stripping changes
 	// the string only for such paths. The stored file_mtime for these is a
-	// per-row/composite value, not trusted as a mid-run race signal.
+	// per-row/composite value, not trusted as a mid-run race signal. This is
+	// the gate that holds the DB-backed providers (Forge/Piebald/Warp and the
+	// shared-SQLite families) out of the raced guard now that
+	// parseDiffAgentDiscoverable admits them: their virtual paths strip, so
+	// they fail closed here and keep their real changed/unchanged verdict.
 	if stripVirtualSourceSuffix(sourcePath) != sourcePath {
 		return false
 	}
 	// Only agents with a literal on-disk source -- the same discoverability
 	// condition resolveParseDiffAgents uses -- read a file whose mtime
-	// populated file_mtime. parseDiffAgentDiscoverable gates out DB-backed
-	// (FileBased == false, e.g. Forge) and non-authoritative agents, so an
-	// unknown or DB-backed agent has no such basis.
+	// populated file_mtime. An unknown or non-authoritative agent has no such
+	// basis; a DB-backed agent's source is virtual and was already gated out
+	// above, so what remains here is a literal-file provider-authoritative
+	// source.
 	def, ok := parser.AgentByType(agent)
 	if !ok {
 		return false
@@ -874,7 +906,7 @@ func (e *Engine) parseDiffPresenceSweep(
 // sweep is restricted to those agents; an unrestricted run accounts
 // for every stored session, including import-only and
 // database-backed agents.
-func parseDiffSweepStored(
+func (e *Engine) parseDiffSweepStored(
 	report *ParseDiffReport,
 	storedSessions []db.Session,
 	resolvedSet map[parser.AgentType]bool,
@@ -902,7 +934,12 @@ func parseDiffSweepStored(
 		case defOK && !def.FileBased &&
 			def.EnvVar == "" && def.ConfigKey == "":
 			reason = "import-only agent"
-		case defOK && !def.FileBased:
+		case defOK && !def.FileBased && !e.parseDiffAgentDiscoverable(def):
+			// A DB-backed agent parse-diff cannot re-parse (no provider
+			// factory). Provider-authoritative DB-backed agents
+			// (Forge/Piebald/Warp) are discoverable, so they fall through
+			// to the source-based reasons below (not sampled / source
+			// missing / not discovered) just like literal-file agents.
 			reason = "database-backed agent"
 		case s.FilePath == nil || *s.FilePath == "":
 			reason = "source missing"

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -341,6 +341,10 @@ func sortAndLimitParseDiffFiles(
 ) ([]parser.DiscoveredFile, map[string]bool, bool) {
 	mtimes := make(map[string]int64, len(files))
 	for _, f := range files {
+		if m, ok := parseDiffDiscoveryMtime(f); ok {
+			mtimes[f.Path] = m
+			continue
+		}
 		m, err := discoveredFileMtime(f)
 		if err != nil {
 			m = 0
@@ -365,6 +369,24 @@ func sortAndLimitParseDiffFiles(
 		files = files[:limit]
 	}
 	return files, cutPaths, limited
+}
+
+// parseDiffDiscoveryMtime returns a per-source mtime captured at provider
+// discovery when the source carries one. The DB-backed providers (Forge,
+// Piebald, Warp) fan a shared SQLite store out to one virtual
+// "<db>#<sessionID>" source per session; those paths have no on-disk existence,
+// so discoveredFileMtime's os.Stat fallback fails and yields 0. With every
+// virtual source pinned to 0, the --limit sampler would order them
+// lexicographically by path and could cut the newest sessions. The provider
+// stamps SourceRef.DiscoveryMTimeNS with each session's real mtime during
+// Discover, so use it directly for ordering here. Ordering only: raced-guard
+// reliability (parseDiffSourceReliableForRaced) and skip-cache/data-version
+// freshness are unaffected.
+func parseDiffDiscoveryMtime(f parser.DiscoveredFile) (int64, bool) {
+	if f.ProviderSource == nil || f.ProviderSource.DiscoveryMTimeNS == 0 {
+		return 0, false
+	}
+	return f.ProviderSource.DiscoveryMTimeNS, true
 }
 
 func parseDiffSourceKey(path string) string {

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -2073,6 +2073,37 @@ func TestParseDiffProviderVirtualSQLiteLimitUsesExactSource(t *testing.T) {
 	}
 }
 
+// TestParseDiffDBBackedLimitOrdersByDiscoveryMtime pins the ordering fix at the
+// sorter boundary: two DB-backed virtual sources whose paths sort in the
+// opposite order to their per-session mtimes. Before the fix both stat to 0 and
+// --limit keeps the lexicographically-earlier (older) path, cutting the newer
+// session; the sorter must instead honor SourceRef.DiscoveryMTimeNS and keep the
+// newer one.
+func TestParseDiffDBBackedLimitOrdersByDiscoveryMtime(t *testing.T) {
+	dbPath := "/tmp/.forge.db"
+	// "a-older" sorts before "z-newer" as a path but carries the older mtime.
+	olderPath := dbPath + "#a-older"
+	newerPath := dbPath + "#z-newer"
+	older := parser.SourceRef{Provider: parser.AgentForge, DiscoveryMTimeNS: 100}
+	newer := parser.SourceRef{Provider: parser.AgentForge, DiscoveryMTimeNS: 200}
+
+	kept, cutPaths, limited := sortAndLimitParseDiffFiles(
+		[]parser.DiscoveredFile{
+			{Path: olderPath, Agent: parser.AgentForge, ProviderSource: &older},
+			{Path: newerPath, Agent: parser.AgentForge, ProviderSource: &newer},
+		},
+		1,
+	)
+
+	require.True(t, limited)
+	require.Len(t, kept, 1)
+	assert.Equal(t, newerPath, kept[0].Path,
+		"newer per-session mtime must be sampled even though its path sorts later")
+	assert.Len(t, cutPaths, 1)
+	assert.True(t, cutPaths[olderPath],
+		"the older session must be the one cut by --limit")
+}
+
 func TestParseDiffReportHasFailures(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/sync/parsediff_dbbacked_test.go
+++ b/internal/sync/parsediff_dbbacked_test.go
@@ -1,0 +1,245 @@
+package sync_test
+
+// Integration coverage for parse-diff over the DB-backed
+// provider-authoritative agents (Forge, Piebald, Warp). Each provider
+// discovers a shared SQLite store as one virtual source per session and
+// re-parses it through the provider facade, so these tests prove the
+// report-only run actually re-parses and compares those sessions rather than
+// bucketing them as skipped/"database-backed agent". Assertions go through the
+// exported DiffClass/ParseDiffTotals contract, never rendered strings.
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// warpTestDB is a minimal Warp SQLite store for the sync test package,
+// mirroring the schema the parser reads (agent_conversations + ai_queries).
+type warpTestDB struct {
+	path string
+	db   *sql.DB
+}
+
+func createWarpDB(t *testing.T, dir string) *warpTestDB {
+	t.Helper()
+	path := filepath.Join(dir, "warp.sqlite")
+	d, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "opening warp test db")
+	t.Cleanup(func() { _ = d.Close() })
+	_, err = d.Exec(`
+		CREATE TABLE agent_conversations (
+			id INTEGER PRIMARY KEY NOT NULL,
+			conversation_id TEXT NOT NULL,
+			conversation_data TEXT NOT NULL,
+			last_modified_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE UNIQUE INDEX ux_agent_conversations_conversation_id
+			ON agent_conversations (conversation_id);
+		CREATE TABLE ai_queries (
+			id INTEGER PRIMARY KEY NOT NULL,
+			exchange_id TEXT NOT NULL,
+			conversation_id TEXT NOT NULL,
+			start_ts DATETIME NOT NULL,
+			input TEXT NOT NULL,
+			working_directory TEXT,
+			output_status TEXT NOT NULL,
+			model_id TEXT NOT NULL DEFAULT ''
+		);
+		CREATE UNIQUE INDEX ux_ai_queries_exchange_id
+			ON ai_queries(exchange_id);
+	`)
+	require.NoError(t, err, "creating warp schema")
+	return &warpTestDB{path: path, db: d}
+}
+
+// addConversation seeds one Warp conversation with one user-query exchange per
+// prompt. conversation_data stays "{}" so no aggregate tool messages are
+// synthesized and the message count equals the number of prompts.
+func (w *warpTestDB) addConversation(
+	t *testing.T, convID, lastModified string, prompts ...string,
+) {
+	t.Helper()
+	_, err := w.db.Exec(
+		`INSERT INTO agent_conversations
+			(conversation_id, conversation_data, last_modified_at)
+		 VALUES (?, '{}', ?)`,
+		convID, lastModified,
+	)
+	require.NoError(t, err, "insert warp conversation")
+	for i, p := range prompts {
+		input := fmt.Sprintf(`[{"Query":{"text":%q,"context":[]}}]`, p)
+		_, err := w.db.Exec(
+			`INSERT INTO ai_queries
+				(exchange_id, conversation_id, start_ts, input,
+				 working_directory, output_status, model_id)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			fmt.Sprintf("%s-ex-%d", convID, i), convID,
+			fmt.Sprintf("2026-04-07 09:5%d:00.000000", i), input,
+			"/Users/alice/code/myproject", `"Completed"`, "auto-genius",
+		)
+		require.NoError(t, err, "insert warp exchange")
+	}
+}
+
+// TestParseDiffCoversForge proves Forge's shared .forge.db, discovered as one
+// virtual source per conversation, is re-parsed and compared by parse-diff.
+// Examined:1/Identical:1 means the stored conversation was matched and vetted,
+// not bucketed as skipped/"database-backed agent".
+func TestParseDiffCoversForge(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentForge)
+	forge := createForgeDB(t, env.forgeDir)
+	forge.addConversation(
+		t, "forge-clean-1", "Forge Clean",
+		forgeTestContext("Add Forge coverage.", "Added Forge coverage."),
+		"2026-05-02 09:58:15.741021507",
+		"2026-05-02 10:00:16.848497543",
+		`{"input_tokens":360,"output_tokens":55,"cached_input_tokens":85}`,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1, Synced: 1})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentForge},
+	})
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Identical: 1},
+		report.Totals, "forge conversation must be examined, not skipped")
+	assert.Equal(t, 1, report.FilesExamined, ".forge.db examined")
+	assert.False(t, report.HasFailures(), "clean forge run")
+}
+
+// TestParseDiffCoversPiebald proves Piebald's shared app.db is re-parsed and
+// compared per chat.
+func TestParseDiffCoversPiebald(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentPiebald)
+	piebald := createPiebaldDB(t, env.piebaldDir)
+	piebald.addChat(t, 7, "Piebald Clean",
+		"Add Piebald coverage.", "Added Piebald coverage.",
+		"2026-05-01T10:05:00Z")
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1, Synced: 1})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentPiebald},
+	})
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Identical: 1},
+		report.Totals, "piebald chat must be examined, not skipped")
+	assert.Equal(t, 1, report.FilesExamined, "app.db examined")
+	assert.False(t, report.HasFailures(), "clean piebald run")
+}
+
+// TestParseDiffCoversWarp proves Warp's shared warp.sqlite is re-parsed and
+// compared per conversation.
+func TestParseDiffCoversWarp(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentWarp)
+	warp := createWarpDB(t, env.warpDir)
+	warp.addConversation(t, "warp-clean-1", "2026-04-07 10:00:00",
+		"Fix the JSON parsing bug.")
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1, Synced: 1})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentWarp},
+	})
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Identical: 1},
+		report.Totals, "warp conversation must be examined, not skipped")
+	assert.Equal(t, 1, report.FilesExamined, "warp.sqlite examined")
+	assert.False(t, report.HasFailures(), "clean warp run")
+}
+
+// TestParseDiffForgeDetectsStoredDrift mutates a stored Forge row after a sync
+// and verifies the re-parse from the unchanged .forge.db surfaces the drift as
+// DiffChanged. This proves the DB-backed re-parse+compare path is real, not a
+// no-op that always reports identical, and that the raced guard does not mask
+// the change (the virtual DB source is held out of the guard, so it keeps its
+// real changed verdict).
+func TestParseDiffForgeDetectsStoredDrift(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentForge)
+	forge := createForgeDB(t, env.forgeDir)
+	forge.addConversation(
+		t, "forge-drift-1", "Forge Drift",
+		forgeTestContext("Original prompt.", "Original answer."),
+		"2026-05-02 09:58:15.741021507",
+		"2026-05-02 10:00:16.848497543",
+		`{"input_tokens":360,"output_tokens":55,"cached_input_tokens":85}`,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 1, Synced: 1})
+
+	// Stored-row drift against the unchanged source.
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "forge:forge-drift-1")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentForge},
+	})
+	assert.Equal(t, sync.ParseDiffTotals{Examined: 1, Changed: 1},
+		report.Totals, "forge drift must be detected as changed")
+
+	sd := findSessionDiff(report, "forge:forge-drift-1")
+	require.NotNil(t, sd, "drifted forge session must be listed")
+	assert.Equal(t, sync.DiffChanged, sd.Class, "class")
+	assert.ElementsMatch(t, []string{sync.FieldFirstMessage},
+		sessionDiffFieldNames(sd, false), "non-informational fields")
+	assert.Equal(t, 1, report.FieldCounts[sync.FieldFirstMessage],
+		"FieldCounts[first_message]")
+	assert.True(t, report.HasFailures(), "drift must trip --fail-on-change")
+}
+
+// TestParseDiffDBBackedLimitScopesPerSession is the per-session-keying acid
+// test. A shared .forge.db holds two conversations; --limit 1 samples one and
+// cuts the other. Because these providers discover one virtual source per
+// session, the cut conversation must be reported as an ordinary
+// not-sampled skip -- NOT fanned into a presence "changed" false positive
+// (which a shared-DB base key would produce) and NOT bucketed as
+// "database-backed agent" (which the pre-relaxation sweep would produce for a
+// FileBased=false agent). Totals.Changed must stay 0.
+func TestParseDiffDBBackedLimitScopesPerSession(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentForge)
+	forge := createForgeDB(t, env.forgeDir)
+	forge.addConversation(
+		t, "forge-a", "Conversation A",
+		forgeTestContext("Prompt A.", "Answer A."),
+		"2026-05-02 09:00:00", "2026-05-02 09:01:00",
+		`{"input_tokens":100,"output_tokens":20}`,
+	)
+	forge.addConversation(
+		t, "forge-b", "Conversation B",
+		forgeTestContext("Prompt B.", "Answer B."),
+		"2026-05-02 09:00:00", "2026-05-02 09:02:00",
+		`{"input_tokens":120,"output_tokens":25}`,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 2, Synced: 2})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentForge},
+		Limit:  1,
+	})
+
+	assert.True(t, report.FilesLimited, "files limited")
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Identical: 1, Skipped: 1,
+	}, report.Totals, "one conversation sampled, one cut")
+	// The cut conversation must never be counted as parser drift.
+	assert.Zero(t, report.Totals.Changed,
+		"cut sibling conversation must not become a presence change")
+	assert.Empty(t, report.FieldCounts,
+		"no field drift from an unsampled sibling")
+
+	// Exactly one session is listed: the cut one, as a not-sampled skip.
+	var skipped []sync.SessionDiff
+	for _, s := range report.Sessions {
+		if s.Class == sync.DiffSkipped {
+			skipped = append(skipped, s)
+		}
+	}
+	require.Len(t, skipped, 1, "exactly one skipped session listed")
+	assert.Contains(t, skipped[0].Reason, "limit",
+		"cut DB-backed session must read as not-sampled, "+
+			"not 'database-backed agent'")
+}

--- a/internal/sync/parsediff_dbbacked_test.go
+++ b/internal/sync/parsediff_dbbacked_test.go
@@ -243,3 +243,57 @@ func TestParseDiffDBBackedLimitScopesPerSession(t *testing.T) {
 		"cut DB-backed session must read as not-sampled, "+
 			"not 'database-backed agent'")
 }
+
+// TestParseDiffDBBackedLimitOrdersByPerSessionMtime is the ordering acid test.
+// A shared .forge.db holds two conversations whose virtual-path order (by
+// conversation ID) is the opposite of their updated_at order: forge-a sorts
+// lexicographically first but is older, forge-b sorts later but is newer. Under
+// --limit 1 the newest session must be the one sampled, so forge-a is cut.
+// Before the ordering fix both virtual sources stat to mtime 0, --limit
+// tie-breaks on the lexicographically-earlier path, forge-a is sampled instead,
+// and the newer forge-b is dropped -- so this asserted skip would be
+// "forge:forge-b" and the test would fail.
+func TestParseDiffDBBackedLimitOrdersByPerSessionMtime(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentForge)
+	forge := createForgeDB(t, env.forgeDir)
+	// forge-a: sorts first by path, older updated_at.
+	forge.addConversation(
+		t, "forge-a", "Older A",
+		forgeTestContext("Prompt A.", "Answer A."),
+		"2026-05-01 09:00:00", "2026-05-01 09:00:00",
+		`{"input_tokens":100,"output_tokens":20}`,
+	)
+	// forge-b: sorts later by path, newer updated_at.
+	forge.addConversation(
+		t, "forge-b", "Newer B",
+		forgeTestContext("Prompt B.", "Answer B."),
+		"2026-06-01 09:00:00", "2026-06-01 09:00:00",
+		`{"input_tokens":120,"output_tokens":25}`,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 2, Synced: 2})
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentForge},
+		Limit:  1,
+	})
+
+	assert.True(t, report.FilesLimited, "files limited")
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Identical: 1, Skipped: 1,
+	}, report.Totals, "the newer conversation is sampled, the older cut")
+
+	// A clean identical sample is not listed, so the sole listed session is the
+	// cut (older) one -- and it must be forge-a, proving the newer forge-b won
+	// the --limit slot by mtime rather than by lexicographic path.
+	var skipped []sync.SessionDiff
+	for _, s := range report.Sessions {
+		if s.Class == sync.DiffSkipped {
+			skipped = append(skipped, s)
+		}
+	}
+	require.Len(t, skipped, 1, "exactly one skipped session listed")
+	assert.Equal(t, "forge:forge-a", skipped[0].SessionID,
+		"the older conversation must be the one cut by --limit")
+	assert.Contains(t, skipped[0].Reason, "limit",
+		"cut session reads as not-sampled")
+}

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -49,6 +49,7 @@ func parseDiffAgentDirs(env *testEnv) map[parser.AgentType][]string {
 	add(parser.AgentOpenCode, env.opencodeDir)
 	add(parser.AgentForge, env.forgeDir)
 	add(parser.AgentPiebald, env.piebaldDir)
+	add(parser.AgentWarp, env.warpDir)
 	add(parser.AgentIflow, env.iflowDir)
 	add(parser.AgentAmp, env.ampDir)
 	add(parser.AgentPi, env.piDir)

--- a/internal/sync/parsediff_provider_test.go
+++ b/internal/sync/parsediff_provider_test.go
@@ -70,11 +70,48 @@ func TestParseDiffProviderAuthoritativeAgentsAreDiscoverable(t *testing.T) {
 		parser.AgentClaude,
 		parser.AgentCowork,
 		parser.AgentHermes,
+		// DB-backed provider-authoritative agents: discoverable through
+		// their providers even though FileBased is false.
+		parser.AgentForge,
+		parser.AgentPiebald,
+		parser.AgentWarp,
 	} {
 		def, ok := parser.AgentByType(agent)
 		require.True(t, ok, "agent %s", agent)
 		assert.True(t, engine.parseDiffAgentDiscoverable(def),
 			"parse-diff engine must include provider-authoritative %s", agent)
+	}
+}
+
+// TestParseDiffDBBackedAgentsAreDiscoverable pins the specific contract this
+// change adds: the DB-backed provider-authoritative agents are FileBased=false
+// yet still admitted by the parse-diff discoverability gate, because the gate
+// keys on the provider factory, not FileBased.
+func TestParseDiffDBBackedAgentsAreDiscoverable(t *testing.T) {
+	engine := NewDiffEngine(dbtest.OpenTestDB(t), EngineConfig{})
+	for _, agent := range []parser.AgentType{
+		parser.AgentForge,
+		parser.AgentPiebald,
+		parser.AgentWarp,
+	} {
+		def, ok := parser.AgentByType(agent)
+		require.True(t, ok, "agent %s", agent)
+		assert.False(t, def.FileBased,
+			"%s is expected to be DB-backed (FileBased=false)", agent)
+		assert.True(t, engine.parseDiffAgentDiscoverable(def),
+			"DB-backed %s must be discoverable by parse-diff", agent)
+	}
+
+	// Import-only agents are still rejected: they are not
+	// provider-authoritative and have no source to re-parse.
+	for _, agent := range []parser.AgentType{
+		parser.AgentClaudeAI,
+		parser.AgentChatGPT,
+	} {
+		def, ok := parser.AgentByType(agent)
+		require.True(t, ok, "agent %s", agent)
+		assert.False(t, engine.parseDiffAgentDiscoverable(def),
+			"import-only %s must not be discoverable by parse-diff", agent)
 	}
 }
 


### PR DESCRIPTION
parse-diff v1 (#662) rejected Warp, Forge, and Piebald because their sync phases had woven-in change detectors and no `DiscoverFunc`. The provider facade (#876–#885, #924) made that reason obsolete — all three now have a unified `Discover()` via `dbBackedProviderFactory` — but both parse-diff gates still keyed on `FileBased`, which is false for these shared-SQLite stores.

This relaxes the two gates (`parseDiffAgentDiscoverable`, `parseDiffAgentSupported`) to admit provider-authoritative agents with registered factories, instead of flipping `FileBased`: that flag is read at nine-plus other sites (watcher, sync engine, token accounting, remote sync, SSH resolve, settings) and genuinely means "reads a literal per-session file", so flipping it would change unrelated behavior.

Two hazards the wider gate exposed are handled in the same change:

- Virtual `<db>#<sessionID>` sources cannot be stat'd, so the raced-skew reclassification from #805 would have masked every real drift on these agents as "raced". `stripVirtualSourceSuffix` now knows their DB filenames and `parseDiffSourceReliableForRaced` re-requires `FileBased`, so DB-backed agents fail closed toward reporting a change rather than masking one.
- These providers discover one source per session (like OpenCode, unlike per-DB Kiro), so `--limit` presence-keying moved to a shared per-session base list; sessions cut by `--limit` now report "not sampled" instead of false-positive presence findings.

Quack (#930) is out of scope: it is the DuckDB remote-sync transport, not a registry agent with session sources to re-parse.

`--limit` ordering: the provider stamps each session's real mtime onto an additive, advisory `SourceRef.DiscoveryMTimeNS` while `Discover()` already has the store's session metas in hand, and the parse-diff sampler prefers it over the failed-stat fallback — so limited runs sample these virtual sources newest-first like file-based agents. The field is ordering-only metadata; skip-cache and data-version freshness still resolve through `Fingerprint`, and the raced-guard is unchanged.

Where to look: `internal/sync/parsediff.go` (gate, raced predicate, per-session base keying) and `internal/sync/parsediff_dbbacked_test.go` for the end-to-end coverage.

