### PR TITLE
docs(mcp): define message_count and filtered semantics in tool schemas

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -91,7 +91,10 @@ func newServer(opts ServeOptions) *mcp.Server {
 		Name: ToolGetMessages,
 		Description: "Read a slice of one session's transcript, paginated by message ordinal. Defaults " +
 			"return only user and assistant messages, each truncated to 2000 characters; truncated " +
-			"messages are flagged so you can re-fetch with a higher max_chars_per_message.",
+			"messages are flagged so you can re-fetch with a higher max_chars_per_message. Each page " +
+			"reports how many scanned messages the role/system filter dropped as filtered, so across a " +
+			"full pagination sweep, returned plus filtered messages add up to the session's " +
+			"message_count (which counts all stored messages, system included).",
 		Annotations: readOnly,
 	}, t.getMessages)
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -176,8 +176,8 @@ type sessionRow struct {
 	Name             string `json:"name"`
 	StartedAt        string `json:"started_at"`
 	EndedAt          string `json:"ended_at"`
-	MessageCount     int    `json:"message_count"`
-	UserMessageCount int    `json:"user_message_count"`
+	MessageCount     int    `json:"message_count" jsonschema:"Total stored messages for the session across all roles, including system messages. get_messages always drops system messages, so no roles filter makes its returned count match this; reconcile instead via message_count = returned + filtered summed over a full get_messages pagination sweep."`
+	UserMessageCount int    `json:"user_message_count" jsonschema:"Stored user-role messages, excluding those flagged as system-injected."`
 	OutputTokens     int64  `json:"output_tokens,omitempty"`
 	Outcome          string `json:"outcome,omitempty"`
 	HealthGrade      string `json:"health_grade,omitempty"`
@@ -332,12 +332,11 @@ type messageOut struct {
 
 type getMessagesOut struct {
 	Messages []messageOut `json:"messages"`
-	Filtered int          `json:"filtered,omitempty"`
-	// NextFrom is the from anchor for the next page when more messages may
-	// remain. It is set off the last scanned ordinal (not the last visible
+	Filtered int          `json:"filtered,omitempty" jsonschema:"How many of this page's scanned messages were excluded by the role/system filter (omitted when zero). Summed across a full pagination sweep, filtered plus the returned messages adds up to the session's message_count."`
+	// NextFrom is set off the last scanned ordinal (not the last visible
 	// one), so paging stays reliable even though filtering can make a page
-	// return fewer than the limit. An empty follow-up result means the end.
-	NextFrom *int `json:"next_from,omitempty"`
+	// return fewer than the limit.
+	NextFrom *int `json:"next_from,omitempty" jsonschema:"Anchor for the next page's from parameter when more messages may remain; absent means the end. Filtering can make a page return fewer than limit messages, so keep paging until next_from is absent, not until a page comes back short."`
 }
 
 func (t *toolset) getMessages(

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -627,6 +627,77 @@ func TestGetMessages_NextFromUsesScannedNotVisible(t *testing.T) {
 		"next_from advances past scanned ordinal 1, not visible ordinal 0")
 }
 
+// The schemas promise that message_count counts every stored message across
+// all roles (system included), and that a full get_messages pagination sweep
+// reconciles against it: returned messages plus filtered add up to
+// message_count for any roles filter. This pins that contract so a refactor
+// of either code path cannot silently break it (issue #944).
+func TestGetMessages_FilteredReconcilesWithMessageCount(t *testing.T) {
+	ts, d := newTestToolset(t)
+	// A realistic mix: user/assistant turns, an is_system-flagged row, a
+	// tool dump, and a legacy system-prefixed user row (parsed before
+	// is_system was backfilled, so the flag is unset). message_count is
+	// the row total, mirroring the sync engine's write-time derivation.
+	msgs := []db.Message{
+		dbtest.UserMsg("s1", 0, "hello"),
+		dbtest.AsstMsg("s1", 1, "hi"),
+		{
+			SessionID: "s1", Ordinal: 2, Role: "system",
+			Content: "sys", IsSystem: true, ContentLength: 3,
+		},
+		{
+			SessionID: "s1", Ordinal: 3, Role: "tool",
+			Content: "tool output", ContentLength: 11,
+		},
+		dbtest.UserMsg("s1", 4,
+			"This session is being continued from a previous conversation"),
+		dbtest.AsstMsg("s1", 5, "more"),
+		{
+			SessionID: "s1", Ordinal: 6, Role: "tool",
+			Content: "tool output 2", ContentLength: 13,
+		},
+		dbtest.UserMsg("s1", 7, "bye"),
+	}
+	dbtest.SeedSessionWithMessages(t, d, "s1", "proj", msgs,
+		dbtest.WithMessageCounts(len(msgs), 3))
+
+	_, ov, err := ts.sessionOverview(context.Background(), nil,
+		sessionOverviewIn{SessionID: "s1"})
+	require.NoError(t, err)
+	require.Equal(t, len(msgs), ov.Session.MessageCount)
+
+	tests := []struct {
+		name  string
+		roles []string
+	}{
+		{"default roles", nil},
+		{"user assistant tool", []string{"user", "assistant", "tool"}},
+		{"tool only", []string{"tool"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			returned, filtered := 0, 0
+			var from *int
+			for range len(msgs) + 1 { // bounded: a sweep never needs more pages
+				_, out, err := ts.getMessages(context.Background(), nil,
+					getMessagesIn{
+						SessionID: "s1", Direction: "asc",
+						Limit: 3, From: from, Roles: tt.roles,
+					})
+				require.NoError(t, err)
+				returned += len(out.Messages)
+				filtered += out.Filtered
+				if out.NextFrom == nil {
+					break
+				}
+				from = out.NextFrom
+			}
+			assert.Equal(t, ov.Session.MessageCount, returned+filtered,
+				"returned + filtered must reconcile to message_count")
+		})
+	}
+}
+
 // search_sessions must exclude a session active now even when its search
 // result carries no ended_at/started_at (empty SessionEndedAt), by falling
 // back to created_at like search_content -- mirroring the canonical


### PR DESCRIPTION
Fixes #944.

Callers building against `agentsview mcp` had to read the Go source to learn why `message_count` never matches any `get_messages` total, or whether `sum(filtered) + sum(returned) == message_count` is safe to rely on: the output schemas exposed `message_count`, `user_message_count`, `filtered`, and `next_from` with no descriptions.

## What changed

The semantics are now documented where MCP clients actually see them -- the generated output schemas -- using the same `jsonschema` tag mechanism that already documents the input parameters:

- `message_count` counts every stored message across all roles, including system messages. No `roles` filter can make a `get_messages` total match it, because `get_messages` unconditionally drops system rows.
- `filtered` is the count of scanned messages a page excluded via the role/system filter; across a full pagination sweep, returned plus filtered adds up to `message_count`.
- `user_message_count` and `next_from` gained descriptions in passing: they sit on the same structs, and `next_from`'s "page until absent, not until a short page" behavior is easy to misuse from outside.

The `get_messages` tool description states the reconciliation as well, and a new regression test sweeps a mixed-role session (user/assistant turns, an `is_system` row, tool dumps, and a legacy system-prefixed user row) to exhaustion under three `roles` filters, asserting `returned + filtered == message_count`. That takes the issue's open question -- documented invariant or coincidence of shared filtering logic -- and resolves it as a deliberate, pinned contract.

## Limitations

The reconciliation is documented unqualified, but it strictly holds against the stored message rows, which equal `message_count` for a session at rest. A session mid-sync can drift briefly (the session row and its message rows are written in separate steps), and a sweep racing new appends can land on either side. If you'd rather the schema wording carry an "at rest" qualifier, happy to adjust.

Reviewers should look at the field tags in `internal/mcp/tools.go`, the tool description in `internal/mcp/server.go`, and `TestGetMessages_FilteredReconcilesWithMessageCount` in `internal/mcp/tools_test.go`.
