### PR TITLE
fix(cli): avoid legacy Copilot billing wording

### DIFF
--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -192,18 +192,18 @@ func runUsageDaily(cfg UsageDailyConfig) {
 }
 
 // noTokenDataNote returns a one-line stderr note for a zero usage result when
-// the user has filtered to a Copilot agent, which bills via a monthly request
-// quota rather than per-token and records no per-message token usage. It
-// returns "" when the filter is not a Copilot agent or real token/cost data
-// exists. This is an agent-property statement (issue #349) shown in response to
-// an explicit --agent the user typed, so it needs no session-presence check;
-// it is appropriate even for an empty window.
+// the user has filtered to a Copilot agent whose records do not include token
+// or cost data that agentsview can total. It returns "" when the filter is not
+// a Copilot agent or real token/cost data exists. This is an agent-property
+// statement (issue #349) shown in response to an explicit --agent the user
+// typed, so it needs no session-presence check; it is appropriate even for an
+// empty window.
 func noTokenDataNote(agent string, totals db.UsageTotals) string {
 	if !db.IsCopilotAgentFilter(agent) || !db.NoTokenData(totals) {
 		return ""
 	}
-	return "note: GitHub Copilot bills via a monthly request quota and " +
-		"does not record per-message token usage."
+	return "note: these GitHub Copilot records do not include token " +
+		"or cost data that agentsview can total."
 }
 
 type UsageStatuslineConfig struct {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -1197,7 +1197,7 @@ func TestRunUsageDailyHintsNoTokenDataForCopilot(t *testing.T) {
 	})
 
 	assert.Contains(t, stderr, "Copilot")
-	assert.Contains(t, stderr, "monthly")
+	assert.Contains(t, stderr, "do not include token or cost data")
 }
 
 func TestRunUsageDailyNoHintWithoutAgentFilter(t *testing.T) {
@@ -1231,8 +1231,8 @@ func TestRunUsageDailyNoHintWhenDataPresent(t *testing.T) {
 func TestNoTokenDataNote(t *testing.T) {
 	zero := db.UsageTotals{}
 	withData := db.UsageTotals{OutputTokens: 5}
-	copilotNote := "note: GitHub Copilot bills via a monthly request quota " +
-		"and does not record per-message token usage."
+	copilotNote := "note: these GitHub Copilot records do not include token " +
+		"or cost data that agentsview can total."
 	cases := []struct {
 		name   string
 		agent  string


### PR DESCRIPTION
After rebasing on the upstream dashboard fix in #947, the remaining change here is the CLI wording from #934. That note still described GitHub Copilot as billing via a monthly request quota, but Copilot billing has moved on and that claim is now too specific for what agentsview can infer from local records.

The CLI still warns when an all-Copilot `usage daily --agent ...` filter returns zero token and cost totals, but the message now describes only the data limitation agentsview observes: these Copilot records do not include token or cost data that can be totaled. That keeps the user-facing explanation accurate without trying to summarize GitHub's current billing model.

Scope is intentionally small. The dashboard behavior is already handled by #947 through the `unsupportedUsage` summary signal, so this PR no longer changes frontend copy, storage interfaces, or cross-backend session counting. Reviewers should look at `cmd/agentsview/usage.go` and the matching assertions in `cmd/agentsview/usage_test.go`.

Follow-up to #934 and #947.