### PR TITLE
feat(antigravity): flag sessions decoded from unrecognized schemas

### DIFF
--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -557,6 +557,13 @@ type heldStartLock struct {
 
 var startLocks sync.Map
 
+// startLockMu makes "this process holds the start flock" and "the lock is
+// registered in startLocks" a single atomic state for same-process observers.
+// Without it, a probe running between markDaemonStarting's flock acquire and
+// its startLocks registration sees the lock held with no registration and
+// misreports a same-process startup as an external daemon.
+var startLockMu sync.Mutex
+
 // markDaemonStarting acquires the kit daemon start lock for this data dir while
 // the server is starting. owned reports whether this process now owns the
 // marker; acquired reports whether this call acquired it.
@@ -565,6 +572,8 @@ func markDaemonStarting(dataDir string) (owned bool, acquired bool) {
 	if err != nil {
 		return false, false
 	}
+	startLockMu.Lock()
+	defer startLockMu.Unlock()
 	if _, ok := startLocks.Load(path); ok {
 		return true, false
 	}
@@ -573,11 +582,7 @@ func markDaemonStarting(dataDir string) (owned bool, acquired bool) {
 	if err != nil || !locked {
 		return false, false
 	}
-	held := heldStartLock{path: path, lock: lock}
-	if _, loaded := startLocks.LoadOrStore(path, held); loaded {
-		_ = lock.Unlock()
-		return true, false
-	}
+	startLocks.Store(path, heldStartLock{path: path, lock: lock})
 	return true, true
 }
 
@@ -594,6 +599,8 @@ func UnmarkDaemonStarting(dataDir string) {
 	if err != nil {
 		return
 	}
+	startLockMu.Lock()
+	defer startLockMu.Unlock()
 	value, ok := startLocks.LoadAndDelete(path)
 	if !ok {
 		return
@@ -607,6 +614,8 @@ func isDaemonStarting(dataDir string) bool {
 	if err != nil {
 		return false
 	}
+	startLockMu.Lock()
+	defer startLockMu.Unlock()
 	if _, ok := startLocks.Load(path); ok {
 		return true
 	}
@@ -627,6 +636,8 @@ func isExternalDaemonStarting(dataDir string) bool {
 	if err != nil {
 		return false
 	}
+	startLockMu.Lock()
+	defer startLockMu.Unlock()
 	if _, ok := startLocks.Load(path); ok {
 		return false
 	}

--- a/cmd/agentsview/daemon_runtime_test.go
+++ b/cmd/agentsview/daemon_runtime_test.go
@@ -239,6 +239,44 @@ func runtimeTestDir(t *testing.T) string {
 	return dir
 }
 
+// TestSameProcessStartMarkerNeverReportsExternal hammers the race between
+// markDaemonStarting's flock-acquire-then-register sequence and the
+// isExternalDaemonStarting probe: a start marker owned by this process must
+// never be classified as an external daemon startup, even mid-acquisition.
+// Misclassification makes waitForExternalServeStartup return before the
+// same-process owner publishes its runtime record, which surfaced as a flaky
+// "serve --background is already in progress" error in
+// TestEnsureBackgroundServeConcurrentLaunchConvergesOnDaemon.
+func TestSameProcessStartMarkerNeverReportsExternal(t *testing.T) {
+	dir := runtimeTestDir(t)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			MarkDaemonStarting(dir)
+			UnmarkDaemonStarting(dir)
+		}
+	})
+	t.Cleanup(func() {
+		close(stop)
+		wg.Wait()
+		UnmarkDaemonStarting(dir)
+	})
+
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		require.False(t, isExternalDaemonStarting(dir),
+			"same-process start marker reported as external")
+	}
+}
+
 func holdExternalDaemonStartLock(t *testing.T, dataDir string) func() {
 	t.Helper()
 	stdin := startExternalDaemonStartLockHelper(t, dataDir)

--- a/cmd/agentsview/doctor.go
+++ b/cmd/agentsview/doctor.go
@@ -32,22 +32,27 @@ type doctorAgentRoot struct {
 	Err            error
 }
 
+type doctorDBInspection struct {
+	DBExists                 bool
+	DBReadable               bool
+	DBError                  error
+	UserVersion              *int
+	SessionCounts            []doctorDataVersionCount
+	SessionCountsErr         error
+	AntigravityCLITotal      int
+	AntigravityCLISummary    int
+	AntigravityUnknownSchema int
+	AntigravityCountsErr     error
+}
+
 type doctorSyncReport struct {
-	Config                config.Config
-	DBExists              bool
-	DBReadable            bool
-	DBError               error
-	UserVersion           *int
-	SessionCounts         []doctorDataVersionCount
-	SessionCountsErr      error
-	AntigravityCLITotal   int
-	AntigravityCLISummary int
-	SummaryModeErr        error
-	TempFiles             []string
-	AgentRoots            []doctorAgentRoot
-	DebugLines            []string
-	DebugLogErr           error
-	HasResyncFailureLog   bool
+	Config config.Config
+	doctorDBInspection
+	TempFiles           []string
+	AgentRoots          []doctorAgentRoot
+	DebugLines          []string
+	DebugLogErr         error
+	HasResyncFailureLog bool
 }
 
 func newDoctorCommand() *cobra.Command {
@@ -90,11 +95,7 @@ func runDoctorSync(w io.Writer, cfg config.Config) error {
 func collectDoctorSyncReport(cfg config.Config) doctorSyncReport {
 	report := doctorSyncReport{Config: cfg}
 
-	report.DBExists, report.DBReadable, report.DBError,
-		report.UserVersion, report.SessionCounts,
-		report.SessionCountsErr,
-		report.AntigravityCLITotal, report.AntigravityCLISummary,
-		report.SummaryModeErr = inspectDoctorDB(cfg.DBPath)
+	report.doctorDBInspection = inspectDoctorDB(cfg.DBPath)
 	report.TempFiles = listDoctorResyncTempFiles(cfg.DBPath)
 	report.AgentRoots = collectDoctorAgentRoots(cfg)
 	report.DebugLines, report.DebugLogErr = readDoctorDebugLines(
@@ -106,74 +107,80 @@ func collectDoctorSyncReport(cfg config.Config) doctorSyncReport {
 	return report
 }
 
-func inspectDoctorDB(
-	path string,
-) (
-	exists bool,
-	readable bool,
-	dbErr error,
-	userVersion *int,
-	counts []doctorDataVersionCount,
-	countsErr error,
-	antigravityCLITotal int,
-	antigravityCLISummary int,
-	summaryModeErr error,
-) {
+func inspectDoctorDB(path string) doctorDBInspection {
+	var insp doctorDBInspection
 	info, err := os.Stat(path)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, false, nil, nil, nil, nil, 0, 0, nil
+		if !errors.Is(err, os.ErrNotExist) {
+			insp.DBError = err
 		}
-		return false, false, err, nil, nil, nil, 0, 0, nil
+		return insp
 	}
+	insp.DBExists = true
 	if info.IsDir() {
-		return true, false, fmt.Errorf("database path is a directory"),
-			nil, nil, nil, 0, 0, nil
+		insp.DBError = fmt.Errorf("database path is a directory")
+		return insp
 	}
 
 	conn, err := sql.Open("sqlite3", doctorReadOnlyDSN(path))
 	if err != nil {
-		return true, false, err, nil, nil, nil, 0, 0, nil
+		insp.DBError = err
+		return insp
 	}
 	defer conn.Close()
 
 	var version int
 	if err := conn.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
-		return true, false, err, nil, nil, nil, 0, 0, nil
+		insp.DBError = err
+		return insp
 	}
-	readable = true
-	userVersion = &version
+	insp.DBReadable = true
+	insp.UserVersion = &version
 
 	rows, err := conn.Query(
 		"SELECT data_version, COUNT(*) FROM sessions " +
 			"GROUP BY data_version ORDER BY data_version",
 	)
 	if err != nil {
-		return true, readable, nil, userVersion, nil, err, 0, 0, nil
+		insp.SessionCountsErr = err
+		return insp
 	}
 	defer rows.Close()
 
 	for rows.Next() {
 		var row doctorDataVersionCount
 		if err := rows.Scan(&row.Version, &row.Count); err != nil {
-			return true, readable, nil, userVersion, counts, err, 0, 0, nil
+			insp.SessionCountsErr = err
+			return insp
 		}
-		counts = append(counts, row)
+		insp.SessionCounts = append(insp.SessionCounts, row)
 	}
 	if err := rows.Err(); err != nil {
-		return true, readable, nil, userVersion, counts, err, 0, 0, nil
+		insp.SessionCountsErr = err
+		return insp
 	}
 
-	var total, summary int
+	// One scan collects both Antigravity operator counts: antigravity-cli
+	// summary-mode sessions (transcript fidelity) and sessions on an
+	// unrecognized schema across both Antigravity agents (decode confidence).
 	row := conn.QueryRow(
-		"SELECT COUNT(*), " +
-			"COUNT(*) FILTER (WHERE transcript_fidelity = 'summary') " +
-			"FROM sessions WHERE agent = 'antigravity-cli'",
+		"SELECT " +
+			"COUNT(*) FILTER (WHERE agent = 'antigravity-cli'), " +
+			"COUNT(*) FILTER (WHERE agent = 'antigravity-cli' " +
+			"AND transcript_fidelity = 'summary'), " +
+			"COUNT(*) FILTER (WHERE agent IN ('antigravity', 'antigravity-cli') " +
+			"AND source_version LIKE 'agy-schema:%') " +
+			"FROM sessions",
 	)
-	if err := row.Scan(&total, &summary); err != nil {
-		return true, readable, nil, userVersion, counts, nil, 0, 0, err
+	var total, summary, unknownSchema int
+	if err := row.Scan(&total, &summary, &unknownSchema); err != nil {
+		insp.AntigravityCountsErr = err
+		return insp
 	}
-	return true, readable, nil, userVersion, counts, nil, total, summary, nil
+	insp.AntigravityCLITotal = total
+	insp.AntigravityCLISummary = summary
+	insp.AntigravityUnknownSchema = unknownSchema
+	return insp
 }
 
 func doctorReadOnlyDSN(path string) string {
@@ -299,6 +306,7 @@ func writeDoctorSyncReport(w io.Writer, report doctorSyncReport) {
 
 	writeDoctorSessionCounts(w, report)
 	writeDoctorSummaryMode(w, report)
+	writeDoctorUnknownSchema(w, report)
 	writeDoctorTempFiles(w, report.TempFiles)
 	writeDoctorAgentRoots(w, report.AgentRoots)
 	writeDoctorDebugEvidence(w, report)
@@ -347,7 +355,7 @@ func writeDoctorSessionCounts(w io.Writer, report doctorSyncReport) {
 }
 
 func writeDoctorSummaryMode(w io.Writer, report doctorSyncReport) {
-	if report.SummaryModeErr != nil || report.AntigravityCLISummary == 0 {
+	if report.AntigravityCountsErr != nil || report.AntigravityCLISummary == 0 {
 		return
 	}
 	fmt.Fprintf(w,
@@ -355,6 +363,22 @@ func writeDoctorSummaryMode(w io.Writer, report doctorSyncReport) {
 			"  -> install agy-reader for full transcripts: "+
 			"https://github.com/mjacobs/agy-reader\n",
 		report.AntigravityCLITotal, report.AntigravityCLISummary)
+}
+
+// writeDoctorUnknownSchema surfaces Antigravity sessions decoded from an
+// unrecognized (newer) schema fingerprint (source_version "agy-schema:..."),
+// where the heuristic decode may be incomplete or wrong. It stays silent on a
+// clean archive or when the antigravity-counts query failed.
+func writeDoctorUnknownSchema(w io.Writer, report doctorSyncReport) {
+	if report.AntigravityCountsErr != nil ||
+		report.AntigravityUnknownSchema == 0 {
+		return
+	}
+	fmt.Fprintf(w,
+		"%d session(s) on unrecognized Antigravity schema (agy-schema:...)\n"+
+			"  -> a newer Antigravity build changed the schema; "+
+			"the decode is heuristic and may be incomplete\n",
+		report.AntigravityUnknownSchema)
 }
 
 func writeDoctorTempFiles(w io.Writer, files []string) {

--- a/cmd/agentsview/doctor_test.go
+++ b/cmd/agentsview/doctor_test.go
@@ -118,8 +118,10 @@ func TestDoctorSyncNewerDatabaseReportsRefusedStartup(t *testing.T) {
 func TestWriteDoctorSummaryMode(t *testing.T) {
 	var buf bytes.Buffer
 	writeDoctorSummaryMode(&buf, doctorSyncReport{
-		AntigravityCLITotal:   12,
-		AntigravityCLISummary: 5,
+		doctorDBInspection: doctorDBInspection{
+			AntigravityCLITotal:   12,
+			AntigravityCLISummary: 5,
+		},
 	})
 	out := buf.String()
 	assert.Contains(t, out, "antigravity-cli")
@@ -131,7 +133,9 @@ func TestWriteDoctorSummaryMode(t *testing.T) {
 func TestWriteDoctorSummaryModeSilentWhenNone(t *testing.T) {
 	var buf bytes.Buffer
 	writeDoctorSummaryMode(&buf, doctorSyncReport{
-		AntigravityCLITotal: 12, AntigravityCLISummary: 0,
+		doctorDBInspection: doctorDBInspection{
+			AntigravityCLITotal: 12, AntigravityCLISummary: 0,
+		},
 	})
 	assert.NotContains(t, buf.String(), "summary mode")
 }
@@ -139,9 +143,44 @@ func TestWriteDoctorSummaryModeSilentWhenNone(t *testing.T) {
 func TestWriteDoctorSummaryModeSilentOnErr(t *testing.T) {
 	var buf bytes.Buffer
 	writeDoctorSummaryMode(&buf, doctorSyncReport{
-		AntigravityCLITotal:   12,
-		AntigravityCLISummary: 5,
-		SummaryModeErr:        errors.New("query failed"),
+		doctorDBInspection: doctorDBInspection{
+			AntigravityCLITotal:   12,
+			AntigravityCLISummary: 5,
+			AntigravityCountsErr:  errors.New("query failed"),
+		},
+	})
+	assert.Empty(t, buf.String())
+}
+
+func TestWriteDoctorUnknownSchema(t *testing.T) {
+	var buf bytes.Buffer
+	writeDoctorUnknownSchema(&buf, doctorSyncReport{
+		doctorDBInspection: doctorDBInspection{
+			AntigravityUnknownSchema: 3,
+		},
+	})
+	out := buf.String()
+	assert.Contains(t, out, "3 session(s) on unrecognized Antigravity schema")
+	assert.Contains(t, out, "agy-schema:")
+}
+
+func TestWriteDoctorUnknownSchemaSilentWhenNone(t *testing.T) {
+	var buf bytes.Buffer
+	writeDoctorUnknownSchema(&buf, doctorSyncReport{
+		doctorDBInspection: doctorDBInspection{
+			AntigravityUnknownSchema: 0,
+		},
+	})
+	assert.Empty(t, buf.String())
+}
+
+func TestWriteDoctorUnknownSchemaSilentOnErr(t *testing.T) {
+	var buf bytes.Buffer
+	writeDoctorUnknownSchema(&buf, doctorSyncReport{
+		doctorDBInspection: doctorDBInspection{
+			AntigravityUnknownSchema: 3,
+			AntigravityCountsErr:     errors.New("query failed"),
+		},
 	})
 	assert.Empty(t, buf.String())
 }
@@ -173,10 +212,53 @@ func TestInspectDoctorDBCountsAntigravityCLISummaryMode(t *testing.T) {
 	}), "upsert other-agent session")
 	require.NoError(t, database.Close(), "close db")
 
-	_, _, _, _, _, _, total, summary, summaryErr := inspectDoctorDB(dbPath)
-	require.NoError(t, summaryErr, "summary mode query")
-	assert.Equal(t, 2, total, "AntigravityCLITotal")
-	assert.Equal(t, 1, summary, "AntigravityCLISummary")
+	insp := inspectDoctorDB(dbPath)
+	require.NoError(t, insp.AntigravityCountsErr, "antigravity counts query")
+	assert.Equal(t, 2, insp.AntigravityCLITotal, "AntigravityCLITotal")
+	assert.Equal(t, 1, insp.AntigravityCLISummary, "AntigravityCLISummary")
+}
+
+// TestInspectDoctorDBCountsUnknownSchema verifies the unrecognized-schema
+// count spans both Antigravity agents and excludes known-range labels and
+// other agents that carry a generic source_version.
+func TestInspectDoctorDBCountsUnknownSchema(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "sessions.db")
+
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:            "agy-ide-unknown",
+		Agent:         "antigravity",
+		Machine:       "local",
+		Project:       "proj",
+		SourceVersion: "agy-schema:abc123def456",
+	}), "upsert IDE unknown-schema session")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:            "agy-cli-unknown",
+		Agent:         "antigravity-cli",
+		Machine:       "local",
+		Project:       "proj",
+		SourceVersion: "agy-schema:abc123def456",
+	}), "upsert CLI unknown-schema session")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:            "agy-known",
+		Agent:         "antigravity-cli",
+		Machine:       "local",
+		Project:       "proj",
+		SourceVersion: "1.0.7-1.0.10",
+	}), "upsert known-range session")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:            "piebald-generic",
+		Agent:         "piebald",
+		Machine:       "local",
+		Project:       "proj",
+		SourceVersion: "piebald-appdb-v1",
+	}), "upsert non-antigravity session")
+	require.NoError(t, database.Close(), "close db")
+
+	insp := inspectDoctorDB(dbPath)
+	require.NoError(t, insp.AntigravityCountsErr, "antigravity counts query")
+	assert.Equal(t, 2, insp.AntigravityUnknownSchema, "AntigravityUnknownSchema")
 }
 
 func TestDoctorSyncReportStatErrorDoesNotRenderAsMissingDatabase(t *testing.T) {
@@ -185,8 +267,10 @@ func TestDoctorSyncReportStatErrorDoesNotRenderAsMissingDatabase(t *testing.T) {
 			DataDir: "/data",
 			DBPath:  "/data/sessions.db",
 		},
-		DBExists: false,
-		DBError:  errors.New("stat /data/sessions.db: permission denied"),
+		doctorDBInspection: doctorDBInspection{
+			DBExists: false,
+			DBError:  errors.New("stat /data/sessions.db: permission denied"),
+		},
 	}
 
 	var out bytes.Buffer

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -836,6 +836,19 @@ func formatAnomalySummary(a sync.AnomalyStats) string {
 			)
 		}
 	}
+	if a.UnknownSchemaSessionsTotal > 0 {
+		fmt.Fprintf(&b,
+			"  unrecognized schema sessions: %d total\n",
+			a.UnknownSchemaSessionsTotal,
+		)
+		for _, agent := range slices.Sorted(
+			maps.Keys(a.UnknownSchemaSessionsByAgent),
+		) {
+			fmt.Fprintf(&b,
+				"    %s: %d\n", agent, a.UnknownSchemaSessionsByAgent[agent],
+			)
+		}
+	}
 	if !a.Sanitize.IsZero() {
 		fmt.Fprintf(&b,
 			"  sanitized fields: %d total\n", a.Sanitize.Total(),

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -920,6 +920,22 @@ func TestFormatAnomalySummary(t *testing.T) {
 				"timestamps blanked: 1",
 			},
 		},
+		{
+			name: "unknown schema sessions only",
+			anomalies: agentsync.AnomalyStats{
+				UnknownSchemaSessionsByAgent: map[string]int{
+					"antigravity": 2, "antigravity-cli": 1,
+				},
+				UnknownSchemaSessionsTotal: 3,
+			},
+			wantContain: []string{
+				"Parser anomalies (this run):",
+				"unrecognized schema sessions: 3 total",
+				"antigravity: 2",
+				"antigravity-cli: 1",
+			},
+			wantOmit: []string{"malformed lines", "sanitized fields"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -202,6 +202,8 @@
       }
     }
   ],
+  "session_breadcrumb_antigravity_decode_confidence_low": "Unverified schema",
+  "session_breadcrumb_antigravity_decode_confidence_low_tooltip": "This session came from an unrecognized (newer) Antigravity build. The decode is heuristic and may be incomplete or wrong.",
   "session_find_find_in_session": "Find in session",
   "session_find_placeholder": "Find in session...",
   "session_find_search_query": "Search query",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -197,6 +197,8 @@
       }
     }
   ],
+  "session_breadcrumb_antigravity_decode_confidence_low": "未识别架构",
+  "session_breadcrumb_antigravity_decode_confidence_low_tooltip": "此会话来自无法识别的（更新版本）Antigravity 构建。解码为启发式推断，可能不完整或有误。",
   "session_find_find_in_session": "在会话中查找",
   "session_find_placeholder": "在会话中查找...",
   "session_find_search_query": "搜索关键词",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -197,6 +197,8 @@
       }
     }
   ],
+  "session_breadcrumb_antigravity_decode_confidence_low": "未識別架構",
+  "session_breadcrumb_antigravity_decode_confidence_low_tooltip": "此會話來自無法識別的（較新版本）Antigravity 建置。解碼為啟發式推斷，可能不完整或有誤。",
   "session_find_find_in_session": "在會話中查找",
   "session_find_placeholder": "在會話中查找...",
   "session_find_search_query": "搜索關鍵詞",

--- a/frontend/src/lib/api/generated/models/ServiceSessionDetail.ts
+++ b/frontend/src/lib/api/generated/models/ServiceSessionDetail.ts
@@ -10,6 +10,7 @@ export type ServiceSessionDetail = {
   context_pressure_max?: number;
   created_at: string;
   cwd?: string;
+  decode_confidence?: string;
   deleted_at?: string;
   display_name?: string;
   edit_churn_count: number;

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -65,6 +65,13 @@ export interface Session {
   health_penalties?: Record<string, number> | null;
   transcript_fidelity?: string;
   parser_malformed_lines?: number;
+  /**
+   * Antigravity decode confidence, derived on read from agent +
+   * source_version (see internal/service SessionDetail.MarshalJSON).
+   * "low" means an unrecognized (newer) schema; "high" a known range;
+   * absent for other agents. Only present on the detail response.
+   */
+  decode_confidence?: string;
   created_at: string;
 }
 

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -574,6 +574,12 @@
           count: session.parser_malformed_lines,
         })}</span>
       {/if}
+      {#if (session.agent === "antigravity" || session.agent === "antigravity-cli") && session.decode_confidence === "low"}
+        <span
+          class="decode-badge"
+          title={m.session_breadcrumb_antigravity_decode_confidence_low_tooltip()}
+        >{m.session_breadcrumb_antigravity_decode_confidence_low()}</span>
+      {/if}
       {#if session.started_at}
         <span class="session-time">
           {new Date(session.started_at).toLocaleDateString(
@@ -904,6 +910,21 @@
     border: 1px solid color-mix(in srgb, var(--accent-amber, #e0a458) 40%, transparent);
     white-space: nowrap;
     cursor: default;
+  }
+
+  .decode-badge {
+    font-size: 9px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    flex-shrink: 0;
+    color: var(--accent-red, #e55);
+    background: color-mix(in srgb, var(--accent-red, #e55) 16%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent-red, #e55) 45%, transparent);
+    white-space: nowrap;
+    cursor: help;
   }
 
   .session-time {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -585,6 +585,85 @@ describe("SessionBreadcrumb", () => {
     });
   });
 
+  describe("decode-confidence badge", () => {
+    it("shows the badge for low-confidence antigravity", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("antigravity", {
+            decode_confidence: "low",
+          }),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      const badge = document.querySelector(".decode-badge");
+      expect(badge).toBeTruthy();
+      expect(badge?.textContent?.trim().toLowerCase()).toContain(
+        "unverified schema",
+      );
+      unmount(component);
+    });
+
+    it("shows the badge for low-confidence antigravity-cli", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("antigravity-cli", {
+            decode_confidence: "low",
+          }),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      expect(document.querySelector(".decode-badge")).toBeTruthy();
+      unmount(component);
+    });
+
+    it("hides the badge for high confidence", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("antigravity", {
+            decode_confidence: "high",
+          }),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      expect(document.querySelector(".decode-badge")).toBeNull();
+      unmount(component);
+    });
+
+    it("hides the badge when confidence is absent", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("antigravity"),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      expect(document.querySelector(".decode-badge")).toBeNull();
+      unmount(component);
+    });
+
+    it("hides the badge for non-antigravity agents", async () => {
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude", {
+            decode_confidence: "low",
+          }),
+          onBack: () => {},
+        },
+      });
+      await tick();
+      expect(document.querySelector(".decode-badge")).toBeNull();
+      unmount(component);
+    });
+  });
+
   it("hides local-only actions for remote sessions", async () => {
     const component = mount(SessionBreadcrumb, {
       target: document.body,

--- a/internal/parser/antigravity_version.go
+++ b/internal/parser/antigravity_version.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"strconv"
+	"strings"
 )
 
 // Antigravity session databases carry no literal product version: PRAGMA
@@ -113,4 +114,44 @@ func antigravitySourceVersion(db *sql.DB) string {
 		return ""
 	}
 	return antigravitySchemaLabel(fp)
+}
+
+// DecodeConfidence values classify how much trust the schema-fingerprint
+// decode of an Antigravity session warrants. They are consumed by the
+// session-detail badge (as string literals) and the operator surfaces.
+const (
+	DecodeConfidenceHigh = "high"
+	DecodeConfidenceLow  = "low"
+)
+
+// DecodeConfidence reports how much to trust the heuristic decode of an
+// Antigravity session, derived purely from its already-computed source_version
+// label (see antigravitySchemaLabel). It is the single source of truth for the
+// rule, shared by the service layer (session-detail badge), the doctor
+// diagnostics, and the sync anomaly counter, so the "agy-schema:" prefix
+// knowledge stays in one place next to the label logic.
+//
+// The agent gate is mandatory: SourceVersion is a generic field that other
+// parsers also populate (piebald.go sets "piebald-appdb-v1", commandcode.go
+// sets "2"), so a non-empty label alone must never imply confidence. Both the
+// IDE agent ("antigravity") and the CLI agent ("antigravity-cli") classify
+// identically because both .db parse paths compute the same fingerprint.
+//
+//   - antigravity / antigravity-cli with an "agy-schema:" label (an
+//     unrecognized, newer schema) -> "low": the decode is heuristic and may be
+//     incomplete or wrong.
+//   - antigravity / antigravity-cli with any other non-empty label (a known
+//     release range) -> "high".
+//   - empty label, or any other agent -> "" (no value, no badge).
+func DecodeConfidence(agent, sourceVersion string) string {
+	if agent != string(AgentAntigravity) && agent != string(AgentAntigravityCLI) {
+		return ""
+	}
+	if sourceVersion == "" {
+		return ""
+	}
+	if strings.HasPrefix(sourceVersion, antigravitySchemaUnknownPrefix) {
+		return DecodeConfidenceLow
+	}
+	return DecodeConfidenceHigh
 }

--- a/internal/parser/antigravity_version_test.go
+++ b/internal/parser/antigravity_version_test.go
@@ -129,6 +129,79 @@ func TestAntigravitySchemaLabel(t *testing.T) {
 	}
 }
 
+// TestDecodeConfidence exercises the single-source-of-truth confidence rule
+// derived from an agent name and its source_version label. It covers the
+// agent gate against SourceVersion being a generic field set by other parsers.
+func TestDecodeConfidence(t *testing.T) {
+	tests := []struct {
+		name          string
+		agent         string
+		sourceVersion string
+		want          string
+	}{
+		{
+			name:          "antigravity known range is high",
+			agent:         string(AgentAntigravity),
+			sourceVersion: "1.0.7-1.0.10",
+			want:          DecodeConfidenceHigh,
+		},
+		{
+			name:          "antigravity-cli known range is high",
+			agent:         string(AgentAntigravityCLI),
+			sourceVersion: "1.0.7-1.0.10",
+			want:          DecodeConfidenceHigh,
+		},
+		{
+			name:          "antigravity unknown schema is low",
+			agent:         string(AgentAntigravity),
+			sourceVersion: antigravitySchemaUnknownPrefix + "abc123def456",
+			want:          DecodeConfidenceLow,
+		},
+		{
+			name:          "antigravity-cli unknown schema is low",
+			agent:         string(AgentAntigravityCLI),
+			sourceVersion: antigravitySchemaUnknownPrefix + "abc123def456",
+			want:          DecodeConfidenceLow,
+		},
+		{
+			name:          "antigravity empty source_version yields no value",
+			agent:         string(AgentAntigravity),
+			sourceVersion: "",
+			want:          "",
+		},
+		{
+			name:          "antigravity-cli empty source_version yields no value",
+			agent:         string(AgentAntigravityCLI),
+			sourceVersion: "",
+			want:          "",
+		},
+		{
+			name:          "piebald generic label yields no value",
+			agent:         string(AgentPiebald),
+			sourceVersion: "piebald-appdb-v1",
+			want:          "",
+		},
+		{
+			name:          "commandcode generic label yields no value",
+			agent:         string(AgentCommandCode),
+			sourceVersion: "2",
+			want:          "",
+		},
+		{
+			name:          "other agent with agy-schema-shaped label yields no value",
+			agent:         string(AgentClaude),
+			sourceVersion: antigravitySchemaUnknownPrefix + "abc123def456",
+			want:          "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want,
+				DecodeConfidence(tt.agent, tt.sourceVersion))
+		})
+	}
+}
+
 // TestAntigravitySchemaFingerprintBaseline verifies the Go fingerprint of the
 // real baseline schema matches agy-reader's recorded sha256, so the
 // known-label mapping actually fires on real databases.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -864,6 +864,43 @@ func TestOpenAPIEndpointDocumentsQualitySignalResponses(t *testing.T) {
 		"sessions item schema")
 }
 
+// TestOpenAPIEndpointDocumentsDecodeConfidence guards that the derived
+// decode_confidence marker is a reflected field on the session-detail response
+// schema, so Huma/OpenAPI and the generated TypeScript client document and type
+// it. It is a detail-only derive-on-read field with no persisted column, so it
+// must appear on ServiceSessionDetail but not on the plain DbSession schema.
+func TestOpenAPIEndpointDocumentsDecodeConfidence(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, "/api/openapi.json")
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	type openAPISchema struct {
+		Type       any                      `json:"type"`
+		Properties map[string]openAPISchema `json:"properties"`
+	}
+	var spec struct {
+		Components struct {
+			Schemas map[string]openAPISchema `json:"schemas"`
+		} `json:"components"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &spec))
+
+	detail, ok := spec.Components.Schemas["ServiceSessionDetail"]
+	require.True(t, ok, "schema ServiceSessionDetail missing")
+	prop, ok := detail.Properties["decode_confidence"]
+	require.True(t, ok,
+		"ServiceSessionDetail should document the derived decode_confidence field")
+	assert.Equal(t, "string", prop.Type,
+		"decode_confidence should be typed as a string")
+
+	dbSession, ok := spec.Components.Schemas["DbSession"]
+	require.True(t, ok, "schema DbSession missing")
+	_, present := dbSession.Properties["decode_confidence"]
+	assert.False(t, present,
+		"decode_confidence is detail-only and must not leak into DbSession")
+}
+
 func TestOpenAPIEndpointDocumentsImportResponseContentTypes(t *testing.T) {
 	te := setup(t)
 

--- a/internal/service/decode_confidence_test.go
+++ b/internal/service/decode_confidence_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// TestSessionDetailDecodeConfidence verifies the derive-on-read
+// decode_confidence field the detail endpoint emits. buildSessionDetail derives
+// it once from the session's agent and source_version, MarshalJSON passes the
+// stored field through, and UnmarshalJSON restores it so the HTTP backend
+// round-trips it. It is "low" for an Antigravity session on an unrecognized
+// schema, "high" for a known range, and omitted for empty labels and other
+// agents that carry a generic source_version.
+func TestSessionDetailDecodeConfidence(t *testing.T) {
+	tests := []struct {
+		name          string
+		agent         string
+		sourceVersion string
+		wantPresent   bool
+		wantValue     string
+	}{
+		{
+			name:          "antigravity unknown schema emits low",
+			agent:         "antigravity",
+			sourceVersion: "agy-schema:abc123def456",
+			wantPresent:   true,
+			wantValue:     "low",
+		},
+		{
+			name:          "antigravity-cli unknown schema emits low",
+			agent:         "antigravity-cli",
+			sourceVersion: "agy-schema:abc123def456",
+			wantPresent:   true,
+			wantValue:     "low",
+		},
+		{
+			name:          "antigravity known range emits high",
+			agent:         "antigravity",
+			sourceVersion: "1.0.7-1.0.10",
+			wantPresent:   true,
+			wantValue:     "high",
+		},
+		{
+			name:          "antigravity empty source_version omits field",
+			agent:         "antigravity",
+			sourceVersion: "",
+			wantPresent:   false,
+		},
+		{
+			name:          "piebald generic label omits field",
+			agent:         "piebald",
+			sourceVersion: "piebald-appdb-v1",
+			wantPresent:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detail := buildSessionDetail(&db.Session{
+				ID:            "s1",
+				Agent:         tt.agent,
+				SourceVersion: tt.sourceVersion,
+			})
+			if tt.wantPresent {
+				assert.Equal(t, tt.wantValue, detail.DecodeConfidence,
+					"buildSessionDetail should derive DecodeConfidence")
+			} else {
+				assert.Empty(t, detail.DecodeConfidence,
+					"DecodeConfidence should be empty")
+			}
+
+			raw, err := json.Marshal(detail)
+			require.NoError(t, err)
+
+			var decoded map[string]any
+			require.NoError(t, json.Unmarshal(raw, &decoded))
+
+			got, present := decoded["decode_confidence"]
+			assert.Equal(t, tt.wantPresent, present,
+				"decode_confidence presence")
+			if tt.wantPresent {
+				assert.Equal(t, tt.wantValue, got)
+			}
+
+			// The HTTP backend decodes the response into a SessionDetail, so the
+			// field must round-trip rather than being dropped.
+			var roundTripped SessionDetail
+			require.NoError(t, json.Unmarshal(raw, &roundTripped))
+			assert.Equal(t, detail.DecodeConfidence,
+				roundTripped.DecodeConfidence,
+				"decode_confidence should round-trip through UnmarshalJSON")
+		})
+	}
+}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -72,7 +72,13 @@ func (b *directBackend) FindSessionIDsByPartial(
 // buildSessionDetail wraps a db.Session with its computed health
 // breakdown. The same shape is returned by GET /api/v1/sessions/{id}.
 func buildSessionDetail(s *db.Session) *SessionDetail {
-	detail := &SessionDetail{Session: *s}
+	detail := &SessionDetail{
+		Session: *s,
+		// Derive-on-read: no persisted column. Computed once here from the
+		// session's agent and source_version so MarshalJSON just passes the
+		// field through and the HTTP backend round-trips it.
+		DecodeConfidence: parser.DecodeConfidence(s.Agent, s.SourceVersion),
+	}
 	if s.HealthScore != nil {
 		result := signals.ComputeHealthScore(signals.ScoreInput{
 			Outcome:                s.Outcome,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -139,10 +139,22 @@ type SessionDetail struct {
 	db.Session
 	HealthScoreBasis []string       `json:"health_score_basis,omitempty"`
 	HealthPenalties  map[string]int `json:"health_penalties,omitempty"`
+	// DecodeConfidence is a derive-on-read Antigravity marker: it has no
+	// persisted column. The serving side (buildSessionDetail) computes it
+	// once from the session's agent and source_version via
+	// parser.DecodeConfidence, so the "agy-schema:" prefix knowledge stays
+	// Go-only. It is a real reflected field so Huma/OpenAPI and the generated
+	// TypeScript client document and type the response property; MarshalJSON
+	// passes the field through and UnmarshalJSON restores it so the HTTP
+	// backend round-trips it rather than dropping it.
+	DecodeConfidence string `json:"decode_confidence,omitempty"`
 }
 
 // MarshalJSON preserves the grouped db.Session quality_signals field
-// while also exposing detail-only health explanation fields.
+// while also exposing the detail-only health explanation fields and the
+// derived Antigravity decode-confidence marker. DecodeConfidence is passed
+// through from the field populated at construction (see buildSessionDetail),
+// not recomputed here.
 func (d SessionDetail) MarshalJSON() ([]byte, error) {
 	type sessionAlias db.Session
 	return json.Marshal(struct {
@@ -150,16 +162,19 @@ func (d SessionDetail) MarshalJSON() ([]byte, error) {
 		QualitySignals   *db.QualitySignals `json:"quality_signals,omitempty"`
 		HealthScoreBasis []string           `json:"health_score_basis,omitempty"`
 		HealthPenalties  map[string]int     `json:"health_penalties,omitempty"`
+		DecodeConfidence string             `json:"decode_confidence,omitempty"`
 	}{
 		sessionAlias:     sessionAlias(d.Session),
 		QualitySignals:   d.StoredQualitySignals(),
 		HealthScoreBasis: d.HealthScoreBasis,
 		HealthPenalties:  d.HealthPenalties,
+		DecodeConfidence: d.DecodeConfidence,
 	})
 }
 
-// UnmarshalJSON preserves the grouped quality_signals object when
-// SessionDetail is decoded by the HTTP-backed service.
+// UnmarshalJSON preserves the grouped quality_signals object and the
+// derived decode_confidence marker when SessionDetail is decoded by the
+// HTTP-backed service.
 func (d *SessionDetail) UnmarshalJSON(data []byte) error {
 	type sessionAlias db.Session
 	var v struct {
@@ -167,6 +182,7 @@ func (d *SessionDetail) UnmarshalJSON(data []byte) error {
 		QualitySignals   *db.QualitySignals `json:"quality_signals"`
 		HealthScoreBasis []string           `json:"health_score_basis"`
 		HealthPenalties  map[string]int     `json:"health_penalties"`
+		DecodeConfidence string             `json:"decode_confidence"`
 	}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
@@ -175,6 +191,7 @@ func (d *SessionDetail) UnmarshalJSON(data []byte) error {
 	d.ApplyQualitySignals(v.QualitySignals)
 	d.HealthScoreBasis = v.HealthScoreBasis
 	d.HealthPenalties = v.HealthPenalties
+	d.DecodeConfidence = v.DecodeConfidence
 	return nil
 }
 

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -24,6 +24,17 @@ const antigravityCLITestSchema = `
 		PRIMARY KEY (idx))
 `
 
+// agyCLIUnknownSchemaAnomaly is the anomaly a run produces when it writes n
+// antigravity-cli sessions from the minimal test schema above. That schema is
+// not the recognized agy baseline, so its fingerprint maps to an "agy-schema:"
+// source_version and the decode-confidence rule flags it as low confidence.
+func agyCLIUnknownSchemaAnomaly(n int) sync.AnomalyStats {
+	return sync.AnomalyStats{
+		UnknownSchemaSessionsByAgent: map[string]int{"antigravity-cli": n},
+		UnknownSchemaSessionsTotal:   n,
+	}
+}
+
 func TestSyncEngineAntigravityCLI_HappyPath(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentAntigravityCLI)
 	uuid := "33333333-4444-5555-6666-777777777777"
@@ -214,6 +225,7 @@ func TestSyncEngineAntigravityCLI_SyncAllSinceReSyncsDBWalUpdate(t *testing.T) {
 		TotalSessions: 1,
 		Synced:        1,
 		Skipped:       0,
+		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 
 	baseInfo, err := os.Stat(dbPath)
@@ -305,6 +317,7 @@ func TestSyncEngineAntigravityCLI_DBFallbackRetries(t *testing.T) {
 		TotalSessions: 2,
 		Synced:        2,
 		Skipped:       0,
+		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 
 	assertSessionMessageCount(t, env.db, malformedSessionID, 1)
@@ -327,6 +340,7 @@ func TestSyncEngineAntigravityCLI_DBFallbackRetries(t *testing.T) {
 		TotalSessions: 2,
 		Synced:        2,
 		Skipped:       0,
+		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 	assert.Less(t, env.db.GetSessionDataVersion(malformedSessionID), db.CurrentDataVersion(),
 		"DB decode fallback should demote previously current rows")
@@ -337,6 +351,7 @@ func TestSyncEngineAntigravityCLI_DBFallbackRetries(t *testing.T) {
 		TotalSessions: 2,
 		Synced:        2,
 		Skipped:       0,
+		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 	assert.Less(t, env.db.GetSessionDataVersion(malformedSessionID), db.CurrentDataVersion(),
 		"unchanged DB decode fallback should keep retrying")
@@ -365,6 +380,7 @@ func TestSyncEngineAntigravityCLI_NeedsRetryReplacesCurrentMessages(t *testing.T
 		TotalSessions: 1,
 		Synced:        1,
 		Skipped:       0,
+		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 	assertSessionMessageCount(t, env.db, sessionID, 2)
 	assert.Equal(t, db.CurrentDataVersion(), env.db.GetSessionDataVersion(sessionID))
@@ -487,6 +503,7 @@ func TestSyncEngineAntigravityCLI_InferredProjectWithoutConversationID(t *testin
 				TotalSessions: 1,
 				Synced:        1,
 				Skipped:       0,
+				Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 			})
 
 			assertSessionProject(t, env.db, sessionID, tt.wantProject)
@@ -534,6 +551,7 @@ func TestSyncPathsAntigravityCLIHistoryOnlyUpdateRefreshesProject(t *testing.T) 
 		TotalSessions: 1,
 		Synced:        1,
 		Skipped:       0,
+		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 	assertSessionProject(t, env.db, sessionID, "")
 
@@ -584,6 +602,7 @@ func TestSyncPathsAntigravityCLIHistoryRetagClearsRemovedProject(t *testing.T) {
 		TotalSessions: 2,
 		Synced:        2,
 		Skipped:       0,
+		Anomalies:     agyCLIUnknownSchemaAnomaly(2),
 	})
 	assertSessionProject(t, env.db, removedSessionID, "/home/user/removed")
 	assertSessionProject(t, env.db, retaggedSessionID, "/home/user/retagged")

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5643,6 +5643,13 @@ func (e *Engine) prepareSessionWrite(
 	e.anomalies.recordMalformedLines(
 		s.Agent, pw.sess.File.Path, s.ParserMalformedLines,
 	)
+	// An Antigravity session decoded from an unrecognized (newer) schema
+	// carries an "agy-schema:" source_version; count it as an early warning
+	// that a new agy build may have broken the heuristic decode. Reuse the
+	// single-source-of-truth rule so the agent gate stays in one place.
+	if parser.DecodeConfidence(s.Agent, s.SourceVersion) == parser.DecodeConfidenceLow {
+		e.anomalies.recordUnknownSchemaSession(s.Agent)
+	}
 
 	// A per-row token clamp must not leave an inflated value stranded in a
 	// row-derived session total while the row that produced it was clamped.

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -92,6 +92,16 @@ type AnomalyStats struct {
 	// MalformedLinesTotal is the grand total across all agents.
 	MalformedLinesTotal int `json:"malformed_lines_total,omitempty"`
 
+	// UnknownSchemaSessionsByAgent maps an agent type to the number of
+	// sessions written this run that were decoded from an unrecognized
+	// (newer) Antigravity schema -- source_version carries an "agy-schema:"
+	// marker, so the heuristic decode may be incomplete or wrong. Unlike the
+	// malformed-line counter this counts whole SESSIONS, not lines. Only
+	// non-zero agents are present.
+	UnknownSchemaSessionsByAgent map[string]int `json:"unknown_schema_sessions_by_agent,omitempty"`
+	// UnknownSchemaSessionsTotal is the grand total across all agents.
+	UnknownSchemaSessionsTotal int `json:"unknown_schema_sessions_total,omitempty"`
+
 	// Sanitize aggregates the central validation/sanitization fix counts
 	// across every session, message, and usage event written this run.
 	Sanitize SanitizeStats `json:"sanitize,omitzero"`
@@ -123,7 +133,9 @@ func (s SanitizeStats) IsZero() bool {
 // IsZero reports whether the run observed no anomalies at all, so the CLI
 // summary can omit the anomaly section entirely on clean runs.
 func (a AnomalyStats) IsZero() bool {
-	return a.MalformedLinesTotal == 0 && a.Sanitize.IsZero()
+	return a.MalformedLinesTotal == 0 &&
+		a.UnknownSchemaSessionsTotal == 0 &&
+		a.Sanitize.IsZero()
 }
 
 // RecordMalformedLines attributes n parser malformed lines to the given
@@ -140,6 +152,20 @@ func (a *AnomalyStats) RecordMalformedLines(agent string, n int) {
 	a.MalformedLinesTotal += n
 }
 
+// RecordUnknownSchemaSessions attributes n unrecognized-schema sessions to the
+// given agent and updates the grand total. A non-positive count is ignored so
+// clean agents do not appear in the per-agent breakdown.
+func (a *AnomalyStats) RecordUnknownSchemaSessions(agent string, n int) {
+	if n <= 0 {
+		return
+	}
+	if a.UnknownSchemaSessionsByAgent == nil {
+		a.UnknownSchemaSessionsByAgent = make(map[string]int)
+	}
+	a.UnknownSchemaSessionsByAgent[agent] += n
+	a.UnknownSchemaSessionsTotal += n
+}
+
 // addSanitize accumulates the per-category counts from one
 // validateAndSanitize pass into the aggregate.
 func (a *AnomalyStats) addSanitize(v validationStats) {
@@ -154,6 +180,9 @@ func (a *AnomalyStats) addSanitize(v validationStats) {
 func (a *AnomalyStats) merge(o AnomalyStats) {
 	for agent, n := range o.MalformedLinesByAgent {
 		a.RecordMalformedLines(agent, n)
+	}
+	for agent, n := range o.UnknownSchemaSessionsByAgent {
+		a.RecordUnknownSchemaSessions(agent, n)
 	}
 	a.Sanitize.ControlCharsStripped += o.Sanitize.ControlCharsStripped
 	a.Sanitize.ModelClamped += o.Sanitize.ModelClamped
@@ -210,6 +239,16 @@ func (a *anomalyAccumulator) recordMalformedLines(
 		a.malformedFiles[sourcePath] = true
 	}
 	a.stats.RecordMalformedLines(agent, n)
+}
+
+// recordUnknownSchemaSession attributes one unrecognized-schema session to the
+// given agent. Unlike malformed lines this counts whole sessions, so it is not
+// deduplicated per source path: a source that forks into several sessions
+// records each fork.
+func (a *anomalyAccumulator) recordUnknownSchemaSession(agent string) {
+	a.mu.Lock()
+	a.stats.RecordUnknownSchemaSessions(agent, 1)
+	a.mu.Unlock()
 }
 
 // recordSanitize accumulates one validateAndSanitize pass's fix counts.

--- a/internal/sync/progress_test.go
+++ b/internal/sync/progress_test.go
@@ -103,6 +103,85 @@ func TestAnomalyStats_RecordMalformedLines(t *testing.T) {
 	}
 }
 
+func TestAnomalyStats_RecordUnknownSchemaSessions(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []struct {
+			agent string
+			n     int
+		}
+		wantByAgent map[string]int
+		wantTotal   int
+	}{
+		{
+			name:        "clean run records nothing",
+			wantByAgent: nil,
+			wantTotal:   0,
+		},
+		{
+			name: "zero and negative counts are ignored",
+			records: []struct {
+				agent string
+				n     int
+			}{
+				{"antigravity", 0},
+				{"antigravity-cli", -2},
+			},
+			wantByAgent: nil,
+			wantTotal:   0,
+		},
+		{
+			name: "per-agent breakdown plus grand total",
+			records: []struct {
+				agent string
+				n     int
+			}{
+				{"antigravity", 1},
+				{"antigravity-cli", 2},
+				{"antigravity", 1},
+			},
+			wantByAgent: map[string]int{"antigravity": 2, "antigravity-cli": 2},
+			wantTotal:   4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a AnomalyStats
+			for _, r := range tt.records {
+				a.RecordUnknownSchemaSessions(r.agent, r.n)
+			}
+			assert.Equal(t, tt.wantByAgent, a.UnknownSchemaSessionsByAgent)
+			assert.Equal(t, tt.wantTotal, a.UnknownSchemaSessionsTotal)
+		})
+	}
+}
+
+// TestAnomalyAccumulator_RecordUnknownSchemaSession verifies whole-session
+// accumulation per agent (no per-source dedup) and that a reset clears it.
+func TestAnomalyAccumulator_RecordUnknownSchemaSession(t *testing.T) {
+	var acc anomalyAccumulator
+	acc.reset()
+
+	acc.recordUnknownSchemaSession("antigravity")
+	acc.recordUnknownSchemaSession("antigravity")
+	acc.recordUnknownSchemaSession("antigravity-cli")
+
+	var stats SyncStats
+	acc.applyTo(&stats)
+	assert.Equal(t, 3, stats.Anomalies.UnknownSchemaSessionsTotal)
+	assert.Equal(t, map[string]int{"antigravity": 2, "antigravity-cli": 1},
+		stats.Anomalies.UnknownSchemaSessionsByAgent)
+	assert.False(t, stats.Anomalies.IsZero())
+
+	// A fresh run starts from zero.
+	acc.reset()
+	var next SyncStats
+	acc.applyTo(&next)
+	assert.True(t, next.Anomalies.IsZero())
+	assert.Zero(t, next.Anomalies.UnknownSchemaSessionsTotal)
+	assert.Nil(t, next.Anomalies.UnknownSchemaSessionsByAgent)
+}
+
 func TestAnomalyAccumulator_Aggregate(t *testing.T) {
 	var acc anomalyAccumulator
 	acc.reset()
@@ -183,6 +262,11 @@ func TestAnomalyStats_IsZero(t *testing.T) {
 		{
 			name: "malformed only",
 			a:    AnomalyStats{MalformedLinesTotal: 1},
+			want: false,
+		},
+		{
+			name: "unknown schema only",
+			a:    AnomalyStats{UnknownSchemaSessionsTotal: 1},
 			want: false,
 		},
 		{


### PR DESCRIPTION
Antigravity is decoded by reverse-engineered heuristics, and #862 started recording which schema produced each session: `sessions.source_version` carries either a known release-range label ("1.0.7-1.0.10") or an `agy-schema:<12hex>` marker for fingerprints the parser has never seen. An unrecognized marker means a newer Antigravity build changed the schema and the heuristics may be silently wrong — but nothing surfaced it. This PR turns that stored signal into a visible one.

A single classifier, `parser.DecodeConfidence(agent, sourceVersion)`, derives a confidence for the two Antigravity agents: `low` for the unknown-schema marker, `high` for a recognized label, nothing otherwise. It is deliberately agent-gated because `source_version` is a generic field — Piebald and CommandCode write their own values there — so non-empty alone proves nothing. This is a separate axis from `transcript_fidelity` (#914): fidelity measures sidecar coverage, confidence measures schema recognition; a session can be full-fidelity yet low-confidence and vice versa.

The value is computed at read time in `SessionDetail.MarshalJSON` rather than persisted. Confidence is a pure function of an already-stored column, so a persisted copy would refresh on exactly the same re-parse events while costing a dataVersion bump, a three-backend migration, and duplicate parse-diff drift whenever the schema map learns a new fingerprint. Derive-on-read gets identical freshness for none of that, and works unchanged across SQLite, PostgreSQL, and DuckDB read paths.

Three surfaces consume it: a warning badge in the session-detail breadcrumb (only for `low`; localized en/zh-CN/zh-TW), an `agentsview doctor` count of sessions on unrecognized schemas (folded into the existing Antigravity session scan, one extra aggregate rather than a second query), and a per-run `UnknownSchemaSessionsByAgent` counter in the sync anomaly summary so a new Antigravity release becomes visible on the first sync after it appears.

One test-visible consequence: the sync integration fixtures build minimal synthetic Antigravity databases, which are legitimately unrecognized schemas, so their expected `SyncStats` now include the anomaly count.

Where to look: `DecodeConfidence` in `internal/parser/antigravity_version.go`, the `MarshalJSON` hook in `internal/service/service.go`, and the recording seam in `internal/sync/engine.go`.
