### PR TITLE
perf: reduce daemon sync CPU on streaming sessions

### DIFF
--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -258,6 +258,9 @@ func (b localArchiveQueryBackend) SessionUsage(
 			fmt.Fprintf(os.Stderr,
 				"warning: sync failed: %v\n", syncErr)
 		}
+		// Flush pending debounced signal recomputes before the
+		// usage query reads the session.
+		engine.Close()
 	}
 
 	u, err := b.database.GetSessionUsage(ctx, resolvedID)

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -534,6 +534,7 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 		Machine:                 "local",
 		BlockedResultCategories: b.appCfg.ResultContentBlockedCategories,
 	})
+	defer engine.Close()
 
 	didResync, err := runPGWatchStartupSync(ctx, engine, cfg.Full)
 	if err != nil {

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -547,6 +547,10 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 	pusher := &pgPusher{
 		localSync: func(c context.Context) error {
 			engine.SyncAll(c, nil)
+			// The push scans SQLite rows right after this returns;
+			// flush deferred signal recomputes so pushed sessions
+			// carry current signal/secret fields.
+			engine.FlushSignals()
 			return nil
 		},
 		connect: func() (pgTarget, error) {

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -124,6 +124,7 @@ func newServeCommand() *cobra.Command {
 	var background bool
 	var checkDataVersion bool
 	var replace bool
+	var pprofEnabled bool
 	cmd := &cobra.Command{
 		Use:          "serve",
 		Short:        "Start server",
@@ -150,6 +151,7 @@ func newServeCommand() *cobra.Command {
 			runServe(mustLoadConfig(cmd), serveOptions{
 				ReplaceDaemon:  replace,
 				NoSyncExplicit: cmd.Flags().Changed("no-sync"),
+				Pprof:          pprofEnabled,
 			})
 			return nil
 		},
@@ -173,6 +175,13 @@ func newServeCommand() *cobra.Command {
 		"Check whether the configured database is compatible with this binary",
 	)
 	_ = cmd.Flags().MarkHidden("check-data-version")
+	cmd.Flags().BoolVar(
+		&pprofEnabled,
+		"pprof",
+		false,
+		"Serve net/http/pprof under /debug/pprof (developer use)",
+	)
+	_ = cmd.Flags().MarkHidden("pprof")
 	config.RegisterServePFlags(cmd.Flags())
 	cmd.AddCommand(newServeStatusCommand())
 	cmd.AddCommand(newServeStopCommand())

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -87,6 +87,7 @@ func warnMissingDirs(dirs []string, label string) {
 type serveOptions struct {
 	ReplaceDaemon  bool
 	NoSyncExplicit bool
+	Pprof          bool
 }
 
 func runServe(cfg config.Config, opts serveOptions) {
@@ -252,6 +253,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		server.WithBaseContext(ctx),
 		server.WithBroadcaster(broadcaster),
 		server.WithIdleTracker(idleTracker),
+		server.WithPprof(opts.Pprof),
 	)
 
 	rt, err := startServerWithOptionalCaddy(ctx, cfg, srv, rtOpts)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -305,6 +305,10 @@ func runServe(cfg config.Config, opts serveOptions) {
 	startTelemetryPings(ctx, telemetryReporter)
 
 	if engine != nil {
+		// Registered before stopWatcher so LIFO defer order stops
+		// the watcher first, then Close flushes any pending
+		// debounced signal recomputes.
+		defer engine.Close()
 		stopWatcher, unwatchedDirs := startFileWatcher(
 			cfg, engine, func(paths []string) {
 				idleTracker.Do(func() {

--- a/cmd/agentsview/session_sync.go
+++ b/cmd/agentsview/session_sync.go
@@ -76,7 +76,12 @@ func syncService(
 		AgentDirs: cfg.AgentDirs,
 		Machine:   "local",
 	})
-	cleanup := func() { closeWriteDB(d, lock) }
+	// Close the engine before the DB so pending debounced signal
+	// recomputes flush while the DB is still open.
+	cleanup := func() {
+		engine.Close()
+		closeWriteDB(d, lock)
+	}
 	return service.NewDirectBackend(d, engine), cleanup, nil
 }
 

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -534,7 +534,7 @@ func buildGoldenFixtureTemplateFiles(t *testing.T) (map[string][]byte, error) {
 	}()
 
 	seedGoldenFixtureDB(t, d)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := d.CheckpointWALTruncate(ctx); err != nil {
 		return nil, fmt.Errorf("checkpoint golden fixture template: %w", err)

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -453,6 +453,7 @@ func runLocalSync(
 		Machine:                 "local",
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
 	})
+	defer engine.Close()
 
 	didResync := full || database.NeedsResync()
 	if didResync {

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -302,6 +302,7 @@ func ensureFreshData(
 			AgentDirs: appCfg.AgentDirs,
 			Machine:   "local",
 		})
+		defer engine.Close()
 		fmt.Fprintln(os.Stderr,
 			"Data version changed, running full resync...")
 		t := time.Now()
@@ -324,6 +325,7 @@ func ensureFreshData(
 		AgentDirs: appCfg.AgentDirs,
 		Machine:   "local",
 	})
+	defer engine.Close()
 
 	since := engine.LastSyncStartedAt()
 	if !since.IsZero() {

--- a/internal/db/chunk_fixture_test.go
+++ b/internal/db/chunk_fixture_test.go
@@ -54,7 +54,7 @@ func buildChunkedAnalyticsFixtureTemplate(t *testing.T) (string, string) {
 	d, err := OpenPreparedTestDB(path)
 	require.NoError(t, err, "open chunked analytics template")
 	seedChunkedAnalyticsFixture(t, d)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	require.NoError(t, d.CheckpointWALTruncate(ctx),
 		"checkpoint chunked analytics template")

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -221,19 +221,8 @@ func insertMessagesTx(
 		for i, m := range batch {
 			id := nextID + int64(start+i)
 			ids[start+i] = id
-			args = append(args,
-				id,
-				m.SessionID, m.Ordinal, m.Role, m.Content,
-				m.ThinkingText,
-				m.Timestamp, m.HasThinking, m.HasToolUse,
-				m.ContentLength, m.IsSystem,
-				m.Model, string(m.TokenUsage),
-				m.ContextTokens, m.OutputTokens,
-				m.HasContextTokens, m.HasOutputTokens,
-				m.ClaudeMessageID, m.ClaudeRequestID,
-				m.SourceType, m.SourceSubtype, m.SourceUUID,
-				m.SourceParentUUID, m.IsSidechain, m.IsCompactBoundary,
-			)
+			args = append(args, id)
+			args = append(args, messageInsertArgs(m)...)
 		}
 		query := fmt.Sprintf(
 			"INSERT INTO messages (id, %s) VALUES %s",
@@ -587,13 +576,23 @@ func (db *DB) ReplaceSessionMessages(
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
+	// Prefer an in-place diff (append/merge shapes from streaming
+	// syncs) so unchanged rows keep their rowids, pins, and FTS
+	// entries; fall back to the full delete+reinsert for
+	// truncations, reorders, and wholesale rewrites.
+	plan, useDiff := db.planStoredMessageDiff(sessionID, msgs)
+
 	tx, err := db.getWriter().Begin()
 	if err != nil {
 		return fmt.Errorf("beginning tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if err := replaceSessionMessagesTx(tx, sessionID, msgs); err != nil {
+	if useDiff {
+		if err := applySessionMessageDiffTx(tx, sessionID, plan); err != nil {
+			return err
+		}
+	} else if err := replaceSessionMessagesTx(tx, sessionID, msgs); err != nil {
 		return err
 	}
 	if err := updateSessionAutomationFromMessagesTx(tx, sessionID); err != nil {
@@ -721,13 +720,21 @@ func (db *DB) ReplaceSessionContent(
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
+	// Same diff-vs-full decision as ReplaceSessionMessages: this is
+	// the hot path for streaming chunk-merge full-parse fallbacks.
+	plan, useDiff := db.planStoredMessageDiff(sessionID, msgs)
+
 	tx, err := db.getWriter().Begin()
 	if err != nil {
 		return fmt.Errorf("beginning tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if err := replaceSessionMessagesTx(tx, sessionID, msgs); err != nil {
+	if useDiff {
+		if err := applySessionMessageDiffTx(tx, sessionID, plan); err != nil {
+			return err
+		}
+	} else if err := replaceSessionMessagesTx(tx, sessionID, msgs); err != nil {
 		return err
 	}
 	if err := updateSessionAutomationFromMessagesTx(tx, sessionID); err != nil {

--- a/internal/db/messages_diff.go
+++ b/internal/db/messages_diff.go
@@ -1,0 +1,286 @@
+// ABOUTME: Diff-based session message replacement: updates only the
+// ABOUTME: rows that changed instead of delete+reinserting the session.
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// diffDeleteChunkSize bounds IN(...) parameter lists when clearing
+// tool rows for updated messages, mirroring the insert chunk limits.
+const diffDeleteChunkSize = 500
+
+// messageInsertArgs returns the values for insertMessageCols in
+// declaration order. insertMessagesTx and the diff UPDATE share it
+// so the persisted tuple has exactly one definition.
+func messageInsertArgs(m Message) []any {
+	return []any{
+		m.SessionID, m.Ordinal, m.Role, m.Content,
+		m.ThinkingText,
+		m.Timestamp, m.HasThinking, m.HasToolUse,
+		m.ContentLength, m.IsSystem,
+		m.Model, string(m.TokenUsage),
+		m.ContextTokens, m.OutputTokens,
+		m.HasContextTokens, m.HasOutputTokens,
+		m.ClaudeMessageID, m.ClaudeRequestID,
+		m.SourceType, m.SourceSubtype, m.SourceUUID,
+		m.SourceParentUUID, m.IsSidechain, m.IsCompactBoundary,
+	}
+}
+
+// messageUpdateSetClause is the UPDATE assignment list derived from
+// insertMessageCols, so the two can never drift apart.
+var messageUpdateSetClause = func() string {
+	cols := strings.Split(insertMessageCols, ",")
+	parts := make([]string, 0, len(cols))
+	for _, c := range cols {
+		parts = append(parts, strings.TrimSpace(c)+" = ?")
+	}
+	return strings.Join(parts, ", ")
+}()
+
+// messageRowEqual reports whether two messages would persist the
+// same message row, tool_calls rows, and tool_result_events rows.
+// Both sides go through the same resolve helpers the insert path
+// uses, so equality is defined on exactly the persisted tuples.
+func messageRowEqual(a, b Message) bool {
+	aArgs, bArgs := messageInsertArgs(a), messageInsertArgs(b)
+	for i := range aArgs {
+		if aArgs[i] != bArgs[i] {
+			return false
+		}
+	}
+
+	aCalls := resolveToolCalls([]Message{a}, []int64{0})
+	bCalls := resolveToolCalls([]Message{b}, []int64{0})
+	if len(aCalls) != len(bCalls) {
+		return false
+	}
+	for i := range aCalls {
+		if !toolCallRowEqual(aCalls[i], bCalls[i]) {
+			return false
+		}
+	}
+
+	aEvents := resolveToolResultEvents([]Message{a})
+	bEvents := resolveToolResultEvents([]Message{b})
+	if len(aEvents) != len(bEvents) {
+		return false
+	}
+	for i := range aEvents {
+		if aEvents[i] != bEvents[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// toolCallRowEqual compares the persisted tool_calls columns except
+// message_id (rowid-derived on both sides of a diff).
+func toolCallRowEqual(a, b ToolCall) bool {
+	return a.SessionID == b.SessionID &&
+		a.ToolName == b.ToolName &&
+		a.Category == b.Category &&
+		a.ToolUseID == b.ToolUseID &&
+		a.InputJSON == b.InputJSON &&
+		a.SkillName == b.SkillName &&
+		a.ResultContentLength == b.ResultContentLength &&
+		a.ResultContent == b.ResultContent &&
+		a.SubagentSessionID == b.SubagentSessionID &&
+		a.FilePath == b.FilePath &&
+		a.CallIndex == b.CallIndex
+}
+
+type messageDiffUpdate struct {
+	id  int64
+	msg Message
+}
+
+type messageDiffPlan struct {
+	updates []messageDiffUpdate
+	inserts []Message
+}
+
+// planStoredMessageDiff loads the session's stored messages and
+// plans an in-place diff against msgs. ok=false means the caller
+// must use the full replace path; a load failure also degrades to
+// full replace rather than failing the write.
+func (db *DB) planStoredMessageDiff(
+	sessionID string, msgs []Message,
+) (messageDiffPlan, bool) {
+	stored, err := db.GetAllMessages(
+		context.Background(), sessionID,
+	)
+	if err != nil {
+		return messageDiffPlan{}, false
+	}
+	return planSessionMessageDiff(stored, msgs)
+}
+
+// planSessionMessageDiff classifies incoming messages against stored
+// rows by ordinal. It refuses (ok=false) when the diff cannot be
+// applied safely or profitably:
+//   - a stored ordinal is absent from the incoming set (truncation
+//     or reordering needs delete handling and pin re-matching);
+//   - duplicate ordinals on either side;
+//   - a changed row's source_uuid differs from the stored row's
+//     (the ordinal now holds a different message, so pins must be
+//     re-matched by source_uuid — full replace's job);
+//   - more than half the stored rows changed (an ordinal-shifting
+//     rewrite, where full replace's source_uuid pin re-matching and
+//     bulk FTS handling are the right tool).
+func planSessionMessageDiff(
+	stored, incoming []Message,
+) (messageDiffPlan, bool) {
+	if len(stored) == 0 {
+		return messageDiffPlan{}, false
+	}
+	byOrdinal := make(map[int]Message, len(stored))
+	for _, m := range stored {
+		if _, dup := byOrdinal[m.Ordinal]; dup {
+			return messageDiffPlan{}, false
+		}
+		byOrdinal[m.Ordinal] = m
+	}
+
+	var plan messageDiffPlan
+	seen := make(map[int]bool, len(incoming))
+	for _, m := range incoming {
+		if seen[m.Ordinal] {
+			return messageDiffPlan{}, false
+		}
+		seen[m.Ordinal] = true
+		old, exists := byOrdinal[m.Ordinal]
+		switch {
+		case !exists:
+			plan.inserts = append(plan.inserts, m)
+		case !messageRowEqual(old, m):
+			if old.SourceUUID != m.SourceUUID {
+				return messageDiffPlan{}, false
+			}
+			plan.updates = append(plan.updates, messageDiffUpdate{
+				id:  old.ID,
+				msg: m,
+			})
+		}
+	}
+	for ord := range byOrdinal {
+		if !seen[ord] {
+			return messageDiffPlan{}, false
+		}
+	}
+	if 2*len(plan.updates) > len(stored) {
+		return messageDiffPlan{}, false
+	}
+	return plan, true
+}
+
+// applySessionMessageDiffTx persists a planned diff: changed rows
+// are updated in place (keeping rowids, so pins survive and the FTS
+// triggers reindex only those rows), their tool rows are rebuilt,
+// and new ordinals are inserted through the normal insert path.
+func applySessionMessageDiffTx(
+	tx *sql.Tx, sessionID string, plan messageDiffPlan,
+) error {
+	if len(plan.updates) > 0 {
+		updateSQL := "UPDATE messages SET " +
+			messageUpdateSetClause + " WHERE id = ?"
+		ids := make([]int64, 0, len(plan.updates))
+		ordinals := make([]int, 0, len(plan.updates))
+		msgs := make([]Message, 0, len(plan.updates))
+		for _, u := range plan.updates {
+			args := append(messageInsertArgs(u.msg), u.id)
+			if _, err := tx.Exec(updateSQL, args...); err != nil {
+				return fmt.Errorf(
+					"updating message ord=%d: %w",
+					u.msg.Ordinal, err,
+				)
+			}
+			ids = append(ids, u.id)
+			ordinals = append(ordinals, u.msg.Ordinal)
+			msgs = append(msgs, u.msg)
+		}
+		if err := deleteToolRowsForMessagesTx(
+			tx, sessionID, ids, ordinals,
+		); err != nil {
+			return err
+		}
+		if err := insertToolCallsTx(
+			tx, resolveToolCalls(msgs, ids),
+		); err != nil {
+			return err
+		}
+		if err := insertToolResultEventsTx(
+			tx, resolveToolResultEvents(msgs),
+		); err != nil {
+			return err
+		}
+	}
+
+	if len(plan.inserts) > 0 {
+		ids, err := insertMessagesTx(tx, plan.inserts)
+		if err != nil {
+			return err
+		}
+		if err := insertToolCallsTx(
+			tx, resolveToolCalls(plan.inserts, ids),
+		); err != nil {
+			return err
+		}
+		if err := insertToolResultEventsTx(
+			tx, resolveToolResultEvents(plan.inserts),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteToolRowsForMessagesTx clears tool_calls and
+// tool_result_events for the updated messages so their rebuilt rows
+// cannot duplicate the stale ones.
+func deleteToolRowsForMessagesTx(
+	tx *sql.Tx, sessionID string, ids []int64, ordinals []int,
+) error {
+	for start := 0; start < len(ids); start += diffDeleteChunkSize {
+		end := min(start+diffDeleteChunkSize, len(ids))
+
+		idArgs := make([]any, 0, end-start)
+		for _, id := range ids[start:end] {
+			idArgs = append(idArgs, id)
+		}
+		if _, err := tx.Exec(
+			"DELETE FROM tool_calls WHERE message_id IN ("+
+				placeholderList(len(idArgs))+")",
+			idArgs...,
+		); err != nil {
+			return fmt.Errorf("deleting stale tool_calls: %w", err)
+		}
+
+		ordArgs := make([]any, 0, 1+end-start)
+		ordArgs = append(ordArgs, sessionID)
+		for _, ord := range ordinals[start:end] {
+			ordArgs = append(ordArgs, ord)
+		}
+		if _, err := tx.Exec(
+			"DELETE FROM tool_result_events WHERE session_id = ?"+
+				" AND tool_call_message_ordinal IN ("+
+				placeholderList(len(ordArgs)-1)+")",
+			ordArgs...,
+		); err != nil {
+			return fmt.Errorf(
+				"deleting stale tool_result_events: %w", err,
+			)
+		}
+	}
+	return nil
+}
+
+func placeholderList(n int) string {
+	return strings.TrimSuffix(
+		strings.Repeat("?,", n), ",",
+	)
+}

--- a/internal/db/messages_diff_test.go
+++ b/internal/db/messages_diff_test.go
@@ -1,0 +1,282 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func diffTestMsg(
+	sessionID string, ord int, role, content string,
+	mut ...func(*Message),
+) Message {
+	m := Message{
+		SessionID:     sessionID,
+		Ordinal:       ord,
+		Role:          role,
+		Content:       content,
+		Timestamp:     "2026-06-20T10:00:00Z",
+		ContentLength: len(content),
+	}
+	for _, f := range mut {
+		f(&m)
+	}
+	return m
+}
+
+func seedDiffSession(
+	t *testing.T, d *DB, sessionID string, msgs []Message,
+) {
+	t.Helper()
+	require.NoError(t, d.UpsertSession(Session{
+		ID:      sessionID,
+		Project: "proj",
+		Machine: defaultMachine,
+		Agent:   defaultAgent,
+	}), "seed session %s", sessionID)
+	require.NoError(t, d.InsertMessages(msgs),
+		"seed messages for %s", sessionID)
+}
+
+func messageIDsByOrdinal(
+	t *testing.T, d *DB, sessionID string,
+) map[int]int64 {
+	t.Helper()
+	rows, err := d.getReader().Query(
+		"SELECT ordinal, id FROM messages WHERE session_id = ?",
+		sessionID,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	out := make(map[int]int64)
+	for rows.Next() {
+		var ord int
+		var id int64
+		require.NoError(t, rows.Scan(&ord, &id))
+		out[ord] = id
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// TestReplaceSessionMessagesUpdatesChangedRowsInPlace verifies the
+// streaming chunk-merge shape: a replace whose new message set only
+// extends the stored tail and appends must keep the rowids of every
+// stored message — unchanged rows untouched, the merged tail updated
+// in place — instead of delete+reinserting the whole session.
+func TestReplaceSessionMessagesUpdatesChangedRowsInPlace(t *testing.T) {
+	d := testDB(t)
+
+	v1 := []Message{
+		diffTestMsg("diff-a", 0, "user", "hello there"),
+		diffTestMsg("diff-a", 1, "assistant", "partial chunk",
+			func(m *Message) {
+				m.ClaudeMessageID = "m1"
+				m.ToolCalls = []ToolCall{{
+					ToolName: "Bash",
+					Category: "execution",
+					ResultEvents: []ToolResultEvent{{
+						Source: "result", Status: "ok",
+						Content: "one",
+					}},
+				}}
+			}),
+	}
+	seedDiffSession(t, d, "diff-a", v1)
+	// A second session claims MAX(id), so a delete+reinsert of
+	// diff-a would visibly reassign its rowids.
+	seedDiffSession(t, d, "diff-b", []Message{
+		diffTestMsg("diff-b", 0, "user", "other session"),
+	})
+	before := messageIDsByOrdinal(t, d, "diff-a")
+	require.Len(t, before, 2)
+
+	v2 := []Message{
+		v1[0],
+		diffTestMsg("diff-a", 1, "assistant",
+			"partial chunk plus merged tail zqmergetoken",
+			func(m *Message) {
+				m.ClaudeMessageID = "m1"
+				m.ToolCalls = v1[1].ToolCalls
+			}),
+		diffTestMsg("diff-a", 2, "assistant", "follow-up"),
+	}
+	require.NoError(t, d.ReplaceSessionMessages("diff-a", v2))
+
+	after := messageIDsByOrdinal(t, d, "diff-a")
+	require.Len(t, after, 3)
+	assert.Equal(t, before[0], after[0],
+		"unchanged row must keep its rowid")
+	assert.Equal(t, before[1], after[1],
+		"merged tail row must be updated in place, not reinserted")
+
+	msgs, err := d.GetAllMessages(context.Background(), "diff-a")
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	assert.Contains(t, msgs[1].Content, "zqmergetoken",
+		"merged content must be persisted")
+
+	if d.HasFTS() {
+		var n int
+		require.NoError(t, d.getReader().QueryRow(
+			`SELECT count(*) FROM messages_fts
+			 WHERE messages_fts MATCH 'zqmergetoken'`,
+		).Scan(&n))
+		assert.Equal(t, 1, n,
+			"FTS index must cover the updated row content")
+	}
+}
+
+// TestReplaceSessionMessagesDiffMatchesFullReplace checks that the
+// stored state after replacing v1 with v2 is identical (modulo
+// rowids) to inserting v2 from scratch, across shapes that exercise
+// the in-place diff, the append path, and the full-replace
+// fallbacks (truncation, wholesale rewrites).
+func TestReplaceSessionMessagesDiffMatchesFullReplace(t *testing.T) {
+	base := func(sid string) []Message {
+		return []Message{
+			diffTestMsg(sid, 0, "user", "question",
+				func(m *Message) {
+					m.ToolCalls = []ToolCall{{
+						ToolName:  "Read",
+						Category:  "file",
+						InputJSON: `{"path":"a.go"}`,
+					}}
+				}),
+			diffTestMsg(sid, 1, "assistant", "partial answer",
+				func(m *Message) {
+					m.ClaudeMessageID = "m1"
+					m.ContextTokens = 100
+					m.HasContextTokens = true
+					m.ToolCalls = []ToolCall{{
+						ToolName:  "Task",
+						Category:  "agent",
+						ToolUseID: "tu1",
+						ResultEvents: []ToolResultEvent{{
+							Source: "progress", Status: "running",
+							Content: "spawning",
+						}},
+					}}
+				}),
+		}
+	}
+
+	cases := []struct {
+		name string
+		v2   func(sid string) []Message
+	}{
+		{"identical no-op", func(sid string) []Message {
+			return base(sid)
+		}},
+		{"chunk merge tail plus append", func(sid string) []Message {
+			msgs := base(sid)
+			msgs[1].Content = "partial answer now completed"
+			msgs[1].ContentLength = len(msgs[1].Content)
+			return append(msgs, diffTestMsg(sid, 2, "user", "thanks"))
+		}},
+		{"subagent linkage event appended", func(sid string) []Message {
+			msgs := base(sid)
+			tc := &msgs[1].ToolCalls[0]
+			tc.SubagentSessionID = "sub-1"
+			tc.ResultEvents = append(tc.ResultEvents, ToolResultEvent{
+				Source: "result", Status: "ok",
+				Content: "done", AgentID: "agent-9",
+			})
+			return msgs
+		}},
+		{"token fields updated", func(sid string) []Message {
+			msgs := base(sid)
+			msgs[1].OutputTokens = 42
+			msgs[1].HasOutputTokens = true
+			return msgs
+		}},
+		{"tool input changed", func(sid string) []Message {
+			msgs := base(sid)
+			msgs[0].ToolCalls[0].InputJSON = `{"path":"b.go"}`
+			return msgs
+		}},
+		{"truncated", func(sid string) []Message {
+			return base(sid)[:1]
+		}},
+		{"wholesale rewrite", func(sid string) []Message {
+			msgs := base(sid)
+			for i := range msgs {
+				msgs[i].Content = "rewritten " + msgs[i].Content
+				msgs[i].ContentLength = len(msgs[i].Content)
+			}
+			return msgs
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := testDB(t)
+			seedDiffSession(t, got, "par", base("par"))
+			require.NoError(t,
+				got.ReplaceSessionMessages("par", tc.v2("par")))
+
+			want := testDB(t)
+			seedDiffSession(t, want, "par", tc.v2("par"))
+
+			gotMsgs, err := got.GetAllMessages(
+				context.Background(), "par",
+			)
+			require.NoError(t, err)
+			wantMsgs, err := want.GetAllMessages(
+				context.Background(), "par",
+			)
+			require.NoError(t, err)
+			assert.Equal(t,
+				stripRowIdentity(wantMsgs), stripRowIdentity(gotMsgs),
+				"replaced state must match a from-scratch insert")
+		})
+	}
+}
+
+// stripRowIdentity zeroes rowid-derived fields so state comparisons
+// ignore legitimately different id allocations.
+func stripRowIdentity(msgs []Message) []Message {
+	out := append([]Message(nil), msgs...)
+	for i := range out {
+		out[i].ID = 0
+		out[i].ToolCalls = append([]ToolCall(nil), out[i].ToolCalls...)
+		for j := range out[i].ToolCalls {
+			out[i].ToolCalls[j].MessageID = 0
+		}
+	}
+	return out
+}
+
+// TestReplaceSessionMessagesKeepsPinOnMergedRow guards pin survival
+// through a chunk-merge replace: the pinned tail row is updated, not
+// deleted, so its pin must remain.
+func TestReplaceSessionMessagesKeepsPinOnMergedRow(t *testing.T) {
+	d := testDB(t)
+	v1 := []Message{
+		diffTestMsg("pin-s", 0, "user", "hello"),
+		diffTestMsg("pin-s", 1, "assistant", "partial"),
+	}
+	seedDiffSession(t, d, "pin-s", v1)
+	ids := messageIDsByOrdinal(t, d, "pin-s")
+	note := "keep me"
+	pinID, err := d.PinMessage("pin-s", ids[1], &note)
+	require.NoError(t, err)
+	require.NotZero(t, pinID)
+
+	v2 := []Message{
+		v1[0],
+		diffTestMsg("pin-s", 1, "assistant", "partial now complete"),
+		diffTestMsg("pin-s", 2, "user", "more"),
+	}
+	require.NoError(t, d.ReplaceSessionMessages("pin-s", v2))
+
+	var n int
+	require.NoError(t, d.getReader().QueryRow(
+		`SELECT count(*) FROM pinned_messages
+		 WHERE session_id = 'pin-s' AND ordinal = 1 AND note = ?`,
+		note,
+	).Scan(&n))
+	assert.Equal(t, 1, n, "pin on the merged row must survive")
+}

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -58,7 +58,7 @@ func buildDailyUsageFixtureTemplate(t *testing.T) (string, string) {
 	d, err := OpenPreparedTestDB(path)
 	require.NoError(t, err, "open daily usage template")
 	seedDailyUsageFixture(t, d)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	require.NoError(t, d.CheckpointWALTruncate(ctx),
 		"checkpoint daily usage template")

--- a/internal/dbtest/dbtest.go
+++ b/internal/dbtest/dbtest.go
@@ -147,7 +147,10 @@ func buildTestDBTemplate() (map[string][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening db template: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// The deadline only guards against a hung checkpoint: flushing
+	// the schema-creation WAL can take well over a second on slow
+	// Windows CI disks under parallel package load.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	checkpointErr := template.CheckpointWALTruncate(ctx)
 	closeErr := template.Close()

--- a/internal/remotesync/import.go
+++ b/internal/remotesync/import.go
@@ -53,6 +53,7 @@ func (im Importer) ImportExtracted(
 		Ephemeral:               true,
 		BlockedResultCategories: im.BlockedResultCategories,
 	})
+	defer engine.Close()
 
 	if !im.Full {
 		remoteCache, err := im.DB.LoadRemoteSkippedFiles(im.Host)

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -60,13 +60,23 @@ func hasForwardingHeader(r *http.Request) bool {
 		r.Header.Get("Forwarded") != ""
 }
 
-// authMiddleware enforces Bearer token authentication for /api/ routes,
-// including /api/ping, when require_auth is enabled. Non-API routes
-// such as static assets are never gated.
+// protectedPath reports whether a path is subject to bearer auth and
+// Host validation: every /api/ route, plus /debug/pprof/ when the
+// profiling handlers are mounted. With pprof disabled the path is
+// SPA fallback and stays ungated like other static assets.
+func (s *Server) protectedPath(path string) bool {
+	return strings.HasPrefix(path, "/api/") ||
+		(s.pprofEnabled && strings.HasPrefix(path, "/debug/pprof/"))
+}
+
+// authMiddleware enforces Bearer token authentication for protected
+// routes (/api/ including /api/ping, and /debug/pprof/ when enabled)
+// when require_auth is on. Non-protected routes such as static
+// assets are never gated.
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Only gate /api/ routes — static assets are always served.
-		if !strings.HasPrefix(r.URL.Path, "/api/") {
+		// Static assets are always served.
+		if !s.protectedPath(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/pprof_test.go
+++ b/internal/server/pprof_test.go
@@ -2,11 +2,13 @@ package server_test
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/server"
 )
 
@@ -36,4 +38,55 @@ func TestPprofEnabledServesProfiles(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "heap profile:",
 		"named profiles should be served via the pprof index")
+}
+
+func TestPprofRequiresBearerAuthWhenAuthEnabled(t *testing.T) {
+	te := setupWithServerOpts(t,
+		[]server.Option{server.WithPprof(true)},
+		func(cfg *config.Config) {
+			cfg.RequireAuth = true
+			cfg.AuthToken = "pprof-secret"
+		},
+	)
+
+	w := te.get(t, "/debug/pprof/cmdline")
+	assert.Equal(t, http.StatusUnauthorized, w.Code,
+		"pprof must be gated like /api/ when require_auth is on")
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/debug/pprof/cmdline", nil,
+	)
+	req.Header.Set("Authorization", "Bearer pprof-secret")
+	rec := httptest.NewRecorder()
+	te.handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "text/plain; charset=utf-8",
+		rec.Header().Get("Content-Type"),
+		"a valid bearer token must reach the pprof handler")
+}
+
+func TestPprofRejectsUnexpectedHost(t *testing.T) {
+	te := setupWithServerOpts(
+		t, []server.Option{server.WithPprof(true)},
+	)
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/debug/pprof/cmdline", nil,
+	)
+	req.Host = "attacker.example.net"
+	rec := httptest.NewRecorder()
+	te.handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"pprof must enforce the same Host allowlist as API routes")
+}
+
+func TestPprofPathStaysUngatedWhenDisabled(t *testing.T) {
+	te := setup(t, func(cfg *config.Config) {
+		cfg.RequireAuth = true
+		cfg.AuthToken = "pprof-secret"
+	})
+
+	w := te.get(t, "/debug/pprof/cmdline")
+	assert.Equal(t, http.StatusOK, w.Code,
+		"with pprof disabled the path is SPA fallback and must not be auth-gated")
 }

--- a/internal/server/pprof_test.go
+++ b/internal/server/pprof_test.go
@@ -1,0 +1,39 @@
+package server_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/server"
+)
+
+func TestPprofDisabledByDefault(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, "/debug/pprof/cmdline")
+
+	// Without the option the path falls through to the SPA
+	// handler, which never serves the pprof text/plain payload.
+	assert.NotEqual(t, "text/plain; charset=utf-8",
+		w.Header().Get("Content-Type"),
+		"pprof must not be reachable unless enabled")
+}
+
+func TestPprofEnabledServesProfiles(t *testing.T) {
+	te := setupWithServerOpts(
+		t, []server.Option{server.WithPprof(true)},
+	)
+
+	w := te.get(t, "/debug/pprof/cmdline")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "text/plain; charset=utf-8",
+		w.Header().Get("Content-Type"))
+
+	w = te.get(t, "/debug/pprof/heap?debug=1")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "heap profile:",
+		"named profiles should be served via the pprof index")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	httppprof "net/http/pprof"
 	"net/url"
 	"sort"
 	"strconv"
@@ -88,6 +89,11 @@ type Server struct {
 	// into the SPA's index.html.
 	basePath string
 	idle     *IdleTracker
+
+	// pprofEnabled registers net/http/pprof handlers under
+	// /debug/pprof/ so a running daemon can be profiled. Off by
+	// default; enabled by the hidden serve --pprof flag.
+	pprofEnabled bool
 }
 
 // New creates a new Server.
@@ -253,6 +259,12 @@ func WithIdleTracker(t *IdleTracker) Option {
 	return func(s *Server) { s.idle = t }
 }
 
+// WithPprof enables the net/http/pprof handlers under
+// /debug/pprof/ for live profiling of a running daemon.
+func WithPprof(enabled bool) Option {
+	return func(s *Server) { s.pprofEnabled = enabled }
+}
+
 func (s *Server) humaConfig() huma.Config {
 	version := s.version.Version
 	if version == "" {
@@ -281,6 +293,14 @@ func (s *Server) routes() {
 	configureHumaErrors()
 	s.api = humago.New(s.mux, s.humaConfig())
 	s.registerTypedAPIRoutes()
+
+	if s.pprofEnabled {
+		s.mux.HandleFunc("/debug/pprof/", httppprof.Index)
+		s.mux.HandleFunc("/debug/pprof/cmdline", httppprof.Cmdline)
+		s.mux.HandleFunc("/debug/pprof/profile", httppprof.Profile)
+		s.mux.HandleFunc("/debug/pprof/symbol", httppprof.Symbol)
+		s.mux.HandleFunc("/debug/pprof/trace", httppprof.Trace)
+	}
 
 	// SPA fallback: serve embedded frontend
 	// Do not use timeout handler for static assets to avoid buffering.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -888,15 +888,26 @@ func (s *Server) Serve(ln net.Listener) error {
 	return srv.Serve(ln)
 }
 
-// Shutdown gracefully shuts down the HTTP server.
+// Shutdown gracefully shuts down the HTTP server, then closes the
+// server-owned on-demand sync engine (if one was lazily created) so
+// its pending debounced signal recomputes flush while the DB is
+// still open. Injected engines are closed by their owner.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.mu.RLock()
 	srv := s.httpSrv
 	s.mu.RUnlock()
-	if srv == nil {
-		return nil
+	var err error
+	if srv != nil {
+		err = srv.Shutdown(ctx)
 	}
-	return srv.Shutdown(ctx)
+	s.mu.Lock()
+	engine := s.onDemandEngine
+	s.onDemandEngine = nil
+	s.mu.Unlock()
+	if engine != nil {
+		engine.Close()
+	}
+	return err
 }
 
 // FindAvailablePort finds an available port starting from the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -418,6 +418,7 @@ func (s *Server) Handler() http.Handler {
 		s.authMiddleware(
 			hostCheckMiddleware(
 				allowedHosts, bindAll, s.cfg.Port, bindAllIPs,
+				s.protectedPath,
 				corsMiddleware(
 					allowedOrigins, bindAll, s.cfg.Port, bindAllIPs,
 					gzipMiddleware(logMiddleware(s.mux)),
@@ -619,13 +620,15 @@ func buildAllowedHosts(
 }
 
 // hostCheckMiddleware validates the Host header against expected
-// values to prevent DNS rebinding attacks. Only applied to /api/
-// routes — the SPA fallback is left accessible for flexibility.
+// values to prevent DNS rebinding attacks. Only applied to paths the
+// protected predicate matches (API routes, and pprof when enabled) —
+// the SPA fallback is left accessible for flexibility.
 func hostCheckMiddleware(
-	allowedHosts map[string]bool, bindAll bool, port int, allowedIPs map[string]bool, next http.Handler,
+	allowedHosts map[string]bool, bindAll bool, port int, allowedIPs map[string]bool,
+	protected func(path string) bool, next http.Handler,
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/") {
+		if protected(r.URL.Path) {
 			// Authenticated remote requests bypass host checks.
 			if isRemoteAuth(r) {
 				next.ServeHTTP(w, r)

--- a/internal/server/shutdown_test.go
+++ b/internal/server/shutdown_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/dbtest"
+)
+
+// TestShutdownClosesOnDemandEngine guards the lifecycle of the
+// server-owned lazily-created sync engine: Shutdown must close it so
+// pending debounced signal recomputes flush before the owner closes
+// the DB. Injected engines are closed by their owner, not here.
+func TestShutdownClosesOnDemandEngine(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	srv := New(config.Config{
+		Host:         "127.0.0.1",
+		Port:         0,
+		WriteTimeout: 30 * time.Second,
+	}, database, nil)
+
+	require.NotNil(t, srv.syncEngineForLocal(database),
+		"on-demand engine should be created lazily")
+
+	require.NoError(t, srv.Shutdown(context.Background()))
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	assert.Nil(t, srv.onDemandEngine,
+		"shutdown must close and release the on-demand engine")
+}

--- a/internal/sync/classify_changed_path.go
+++ b/internal/sync/classify_changed_path.go
@@ -1,0 +1,39 @@
+// ABOUTME: Root-containment checks used to skip provider changed-path
+// ABOUTME: classification for agents whose roots cannot contain the path.
+package sync
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// changedPathWithinAnyRoot reports whether path lies within at least
+// one of roots (see changedPathWithinRoot).
+func changedPathWithinAnyRoot(path string, roots []string) bool {
+	for _, root := range roots {
+		if changedPathWithinRoot(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+// changedPathWithinRoot reports whether path is root itself or lies
+// under it, including the "root#member" virtual form used for
+// sessions stored inside container files. It mirrors the containment
+// clauses of storedSourcePathHintQuery.
+func changedPathWithinRoot(path, root string) bool {
+	root = filepath.Clean(root)
+	if root == "" || root == "." {
+		return false
+	}
+	path = filepath.Clean(path)
+	if path == root {
+		return true
+	}
+	if root == string(filepath.Separator) {
+		return strings.HasPrefix(path, root)
+	}
+	return strings.HasPrefix(path, root+string(filepath.Separator)) ||
+		strings.HasPrefix(path, root+"#")
+}

--- a/internal/sync/classify_changed_path_test.go
+++ b/internal/sync/classify_changed_path_test.go
@@ -1,0 +1,56 @@
+package sync
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChangedPathWithinRoot(t *testing.T) {
+	sep := string(filepath.Separator)
+	cases := []struct {
+		name string
+		path string
+		root string
+		want bool
+	}{
+		{"exact root", "/home/u/.claude/projects", "/home/u/.claude/projects", true},
+		{"nested file", "/home/u/.claude/projects/p/s.jsonl", "/home/u/.claude/projects", true},
+		{"deeply nested", "/home/u/.claude/projects/p/sub/agents/a.jsonl", "/home/u/.claude/projects", true},
+		{"sibling sharing prefix", "/home/u/.claude-backup/s.jsonl", "/home/u/.claude", false},
+		{"outside root", "/home/u/.cortex/sessions/s.jsonl", "/home/u/.claude/projects", false},
+		{"root with trailing separator", "/home/u/.gemini/tmp/s.json", "/home/u/.gemini/tmp" + sep, true},
+		{"dot segments resolving inside", "/home/u/.claude/x/../projects/s.jsonl", "/home/u/.claude/projects", true},
+		{"dot segments resolving outside", "/home/u/.claude/projects/../../other/s.jsonl", "/home/u/.claude/projects", false},
+		{"archive member form", "/home/u/ws/state.vscdb#session-1", "/home/u/ws", true},
+		{"root itself archive-suffixed", "/home/u/ws#member", "/home/u/ws", true},
+		{"empty root", "/home/u/x", "", false},
+		{"dot root", "/home/u/x", ".", false},
+		{"filesystem root", "/home/u/x", sep, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.FromSlash(strings.ReplaceAll(tc.path, "/", sep))
+			root := tc.root
+			if root != "" && root != "." && root != sep {
+				root = filepath.FromSlash(strings.ReplaceAll(root, "/", sep))
+			}
+			assert.Equal(t, tc.want, changedPathWithinRoot(path, root))
+		})
+	}
+}
+
+func TestChangedPathWithinAnyRoot(t *testing.T) {
+	roots := []string{
+		filepath.FromSlash("/home/u/.claude/projects"),
+		filepath.FromSlash("/home/u/.config/opencode"),
+	}
+	assert.True(t, changedPathWithinAnyRoot(
+		filepath.FromSlash("/home/u/.config/opencode/storage/s.json"), roots))
+	assert.False(t, changedPathWithinAnyRoot(
+		filepath.FromSlash("/home/u/.cortex/s.jsonl"), roots))
+	assert.False(t, changedPathWithinAnyRoot(
+		filepath.FromSlash("/home/u/.cortex/s.jsonl"), nil))
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -629,6 +629,17 @@ func (e *Engine) classifyProviderChangedPath(
 		})
 		def := provider.Definition()
 		watchRoots := providerChangedPathWatchRoots(ctx, provider, roots)
+		// Every SourcesForChangedPath implementation resolves the
+		// changed path within the provider's configured roots or plan
+		// watch roots (stored-path hints are already scoped to the
+		// watch root by the query), so an agent whose roots cannot
+		// contain the path never claims it. Skip it before the
+		// per-root stored-hint DB queries, which otherwise run for
+		// every registered agent on every watcher event.
+		if !changedPathWithinAnyRoot(path, roots) &&
+			!changedPathWithinAnyRoot(path, watchRoots) {
+			continue
+		}
 		for _, watchRoot := range watchRoots {
 			storedSourcePaths, err := e.db.ListStoredSourcePathHints(
 				string(def.Type),

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -130,6 +130,12 @@ type Engine struct {
 	// toDBUsageEvents). Reset at the start of each sync run and folded
 	// into the returned SyncStats before the run completes.
 	anomalies anomalyAccumulator
+
+	// signalSched debounces the O(session history) signal/secret
+	// recompute triggered by incremental writes, so streaming
+	// sessions don't rescan their whole history on every appended
+	// line. Close flushes and stops it.
+	signalSched *signalScheduler
 }
 
 // PhaseStats returns the engine's phase counter. The values reflect only
@@ -206,7 +212,7 @@ func NewEngine(
 		maps.Copy(providerModes, cfg.ProviderMigrationModes)
 	}
 
-	return &Engine{
+	e := &Engine{
 		db:                      database,
 		agentDirs:               dirs,
 		machine:                 cfg.Machine,
@@ -221,6 +227,24 @@ func NewEngine(
 		providerFactories:       providerFactoryMap(providerFactories),
 		providerMigrationModes:  providerModes,
 	}
+	e.signalSched = newSignalScheduler(
+		signalRecomputeInterval, signalRecomputeQuiet,
+		func(sessionID string) {
+			// Errors are logged inside recomputeSignalsFromDB and
+			// are non-fatal: the next write or flush retries.
+			_ = e.recomputeSignalsFromDB(
+				context.Background(), sessionID,
+			)
+		},
+	)
+	return e
+}
+
+// Close flushes any pending debounced signal recomputes and stops
+// the scheduler. Call once when the engine's owner shuts down;
+// safe to call repeatedly.
+func (e *Engine) Close() {
+	e.signalSched.stop()
 }
 
 func providerFactoryMap(
@@ -6280,12 +6304,14 @@ func (e *Engine) writeIncremental(
 		return err
 	}
 
-	// Errors here are already logged by recomputeSignalsFromDB
-	// and are non-fatal for incremental sync; the next
-	// incremental write will retry.
-	_ = e.recomputeSignalsFromDB(
-		context.Background(), inc.sessionID,
-	)
+	// Signal/secret recompute costs O(session history), so it is
+	// debounced per session instead of running on every appended
+	// line: the first write after a quiet period recomputes
+	// inline, writes during a streaming burst coalesce into one
+	// recompute per interval plus a trailing flush. Recompute
+	// errors are logged inside recomputeSignalsFromDB and are
+	// non-fatal; a later write or flush retries.
+	e.signalSched.markDirty(inc.sessionID)
 
 	return nil
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -239,14 +239,16 @@ func NewEngine(
 		// Inline runs happen from markDirty inside writeIncremental,
 		// whose callers already hold syncMu.
 		recompute,
-		// Timer and flush runs happen outside any sync operation, so
-		// they take syncMu themselves: otherwise a delayed recompute
-		// could read an older message snapshot and overwrite signals
-		// just written by a concurrent incremental or full sync.
-		func(sessionID string) {
+		// Timer and flush passes happen outside any sync operation,
+		// so they take syncMu around the whole claim-and-recompute
+		// pass: otherwise a delayed recompute could read an older
+		// message snapshot and overwrite signals just written by a
+		// concurrent sync, or claim a session and block while a
+		// locked pre-push flush finds nothing left to recompute.
+		func(flush func()) {
 			e.syncMu.Lock()
 			defer e.syncMu.Unlock()
-			recompute(sessionID)
+			flush()
 		},
 	)
 	return e

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -259,6 +259,16 @@ func (e *Engine) Close() {
 	e.signalSched.stop()
 }
 
+// FlushSignals immediately recomputes signals for sessions with a
+// pending debounced recompute, leaving the scheduler running. Push
+// paths that read SQLite rows outside a sync operation call it
+// first so pushed sessions carry current signal fields. Callers
+// must not hold syncMu; work running inside SyncThenRun is flushed
+// by the engine instead.
+func (e *Engine) FlushSignals() {
+	e.signalSched.flushAll()
+}
+
 func providerFactoryMap(
 	factories []parser.ProviderFactory,
 ) map[parser.AgentType]parser.ProviderFactory {
@@ -1611,6 +1621,10 @@ func (e *Engine) SyncThenRun(
 	if ctx.Err() != nil {
 		return stats, ctx.Err()
 	}
+	// work typically scans and pushes SQLite rows, so flush any
+	// deferred signal recomputes first (inline: syncMu is held) or
+	// pushed sessions could carry stale signal/secret fields.
+	e.signalSched.flushAllInline()
 	if err := work(full || didResync); err != nil {
 		return stats, err
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -227,14 +227,26 @@ func NewEngine(
 		providerFactories:       providerFactoryMap(providerFactories),
 		providerMigrationModes:  providerModes,
 	}
+	// Errors are logged inside recomputeSignalsFromDB and are
+	// non-fatal: the next write or flush retries.
+	recompute := func(sessionID string) {
+		_ = e.recomputeSignalsFromDB(
+			context.Background(), sessionID,
+		)
+	}
 	e.signalSched = newSignalScheduler(
 		signalRecomputeInterval, signalRecomputeQuiet,
+		// Inline runs happen from markDirty inside writeIncremental,
+		// whose callers already hold syncMu.
+		recompute,
+		// Timer and flush runs happen outside any sync operation, so
+		// they take syncMu themselves: otherwise a delayed recompute
+		// could read an older message snapshot and overwrite signals
+		// just written by a concurrent incremental or full sync.
 		func(sessionID string) {
-			// Errors are logged inside recomputeSignalsFromDB and
-			// are non-fatal: the next write or flush retries.
-			_ = e.recomputeSignalsFromDB(
-				context.Background(), sessionID,
-			)
+			e.syncMu.Lock()
+			defer e.syncMu.Unlock()
+			recompute(sessionID)
 		},
 	)
 	return e

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -4314,7 +4314,9 @@ func TestWriteIncrementalBlanksImplausibleEndedAt(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			database := openTestDB(t)
-			e := &Engine{db: database}
+			// writeIncremental needs the signal scheduler, so build
+			// via NewEngine rather than a bare struct literal.
+			e := NewEngine(database, EngineConfig{})
 
 			plausibleEnd := time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC)
 			start := plausibleEnd.Add(-time.Hour)
@@ -4384,7 +4386,9 @@ func TestWriteIncrementalBlanksImplausibleEndedAt(t *testing.T) {
 // ended_at must still update the column.
 func TestWriteIncrementalKeepsPlausibleEndedAt(t *testing.T) {
 	database := openTestDB(t)
-	e := &Engine{db: database}
+	// writeIncremental needs the signal scheduler, so build via
+	// NewEngine rather than a bare struct literal.
+	e := NewEngine(database, EngineConfig{})
 
 	start := time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC)
 	firstEnd := start.Add(time.Hour)

--- a/internal/sync/signal_schedule.go
+++ b/internal/sync/signal_schedule.go
@@ -28,7 +28,12 @@ const (
 type signalScheduler struct {
 	interval time.Duration
 	quiet    time.Duration
-	run      func(sessionID string)
+	// run recomputes inline from markDirty, whose callers already
+	// hold the engine's sync lock. deferredRun recomputes from the
+	// flush timer and explicit flushes, which run outside any sync
+	// operation and must serialize with sync writes themselves.
+	run         func(sessionID string)
+	deferredRun func(sessionID string)
 
 	// now and afterFunc are injectable for deterministic tests.
 	now       func() time.Time
@@ -42,16 +47,18 @@ type signalScheduler struct {
 }
 
 func newSignalScheduler(
-	interval, quiet time.Duration, run func(sessionID string),
+	interval, quiet time.Duration,
+	run, deferredRun func(sessionID string),
 ) *signalScheduler {
 	return &signalScheduler{
-		interval:  interval,
-		quiet:     quiet,
-		run:       run,
-		now:       time.Now,
-		afterFunc: func(d time.Duration, f func()) { time.AfterFunc(d, f) },
-		last:      make(map[string]time.Time),
-		dirty:     make(map[string]time.Time),
+		interval:    interval,
+		quiet:       quiet,
+		run:         run,
+		deferredRun: deferredRun,
+		now:         time.Now,
+		afterFunc:   func(d time.Duration, f func()) { time.AfterFunc(d, f) },
+		last:        make(map[string]time.Time),
+		dirty:       make(map[string]time.Time),
 	}
 }
 
@@ -97,7 +104,7 @@ func (s *signalScheduler) stop() {
 
 func (s *signalScheduler) runAll(sessionIDs []string) {
 	for _, id := range sessionIDs {
-		s.run(id)
+		s.deferredRun(id)
 	}
 }
 

--- a/internal/sync/signal_schedule.go
+++ b/internal/sync/signal_schedule.go
@@ -29,11 +29,14 @@ type signalScheduler struct {
 	interval time.Duration
 	quiet    time.Duration
 	// run recomputes inline from markDirty, whose callers already
-	// hold the engine's sync lock. deferredRun recomputes from the
-	// flush timer and explicit flushes, which run outside any sync
-	// operation and must serialize with sync writes themselves.
-	run         func(sessionID string)
-	deferredRun func(sessionID string)
+	// hold the engine's sync lock. exclusive wraps deferred flushes
+	// (timer ticks, flushAll), which run outside any sync operation:
+	// it acquires that lock around the whole claim-and-recompute
+	// pass, so sessions are never claimed out of the dirty map by a
+	// goroutine that then blocks — a concurrent locked flush would
+	// see an empty map and push stale rows.
+	run       func(sessionID string)
+	exclusive func(flush func())
 
 	// now and afterFunc are injectable for deterministic tests.
 	// afterFunc returns a cancel function reporting whether the
@@ -56,14 +59,15 @@ type signalScheduler struct {
 
 func newSignalScheduler(
 	interval, quiet time.Duration,
-	run, deferredRun func(sessionID string),
+	run func(sessionID string),
+	exclusive func(flush func()),
 ) *signalScheduler {
 	return &signalScheduler{
-		interval:    interval,
-		quiet:       quiet,
-		run:         run,
-		deferredRun: deferredRun,
-		now:         time.Now,
+		interval:  interval,
+		quiet:     quiet,
+		run:       run,
+		exclusive: exclusive,
+		now:       time.Now,
 		afterFunc: func(d time.Duration, f func()) func() bool {
 			return time.AfterFunc(d, f).Stop
 		},
@@ -92,24 +96,29 @@ func (s *signalScheduler) markDirty(sessionID string) {
 }
 
 // tick flushes deferred sessions whose interval has elapsed or
-// that have been quiet long enough.
+// that have been quiet long enough. Callers must not hold the
+// engine's sync lock: the pass runs inside exclusive, which takes
+// it before claiming anything.
 func (s *signalScheduler) tick() {
-	s.runAll(s.takeDue(false))
+	s.exclusive(func() { s.flushDue(false) })
 }
 
 // flushAll immediately recomputes every deferred session. Callers
-// must not hold the engine's sync lock: recomputes go through the
-// deferred callback, which takes it.
+// must not hold the engine's sync lock (see tick).
 func (s *signalScheduler) flushAll() {
-	s.runAll(s.takeDue(true))
+	s.exclusive(func() { s.flushDue(true) })
 }
 
-// flushAllInline immediately recomputes every deferred session via
-// the inline callback. For callers already holding the engine's
-// sync lock (the context markDirty's inline runs execute under),
-// where the deferred callback would deadlock.
+// flushAllInline immediately recomputes every deferred session
+// without entering exclusive. For callers already holding the
+// engine's sync lock (the context markDirty's inline runs execute
+// under), where exclusive would deadlock.
 func (s *signalScheduler) flushAllInline() {
-	for _, id := range s.takeDue(true) {
+	s.flushDue(true)
+}
+
+func (s *signalScheduler) flushDue(all bool) {
+	for _, id := range s.takeDue(all) {
 		s.run(id)
 	}
 }
@@ -136,12 +145,6 @@ func (s *signalScheduler) stop() {
 	}
 	s.inflight.Wait()
 	s.flushAll()
-}
-
-func (s *signalScheduler) runAll(sessionIDs []string) {
-	for _, id := range sessionIDs {
-		s.deferredRun(id)
-	}
 }
 
 // takeDue removes and returns the sessions ready to recompute,

--- a/internal/sync/signal_schedule.go
+++ b/internal/sync/signal_schedule.go
@@ -97,9 +97,21 @@ func (s *signalScheduler) tick() {
 	s.runAll(s.takeDue(false))
 }
 
-// flushAll immediately recomputes every deferred session.
+// flushAll immediately recomputes every deferred session. Callers
+// must not hold the engine's sync lock: recomputes go through the
+// deferred callback, which takes it.
 func (s *signalScheduler) flushAll() {
 	s.runAll(s.takeDue(true))
+}
+
+// flushAllInline immediately recomputes every deferred session via
+// the inline callback. For callers already holding the engine's
+// sync lock (the context markDirty's inline runs execute under),
+// where the deferred callback would deadlock.
+func (s *signalScheduler) flushAllInline() {
+	for _, id := range s.takeDue(true) {
+		s.run(id)
+	}
 }
 
 // stop cancels the pending flush timer, waits for any timer

--- a/internal/sync/signal_schedule.go
+++ b/internal/sync/signal_schedule.go
@@ -1,0 +1,157 @@
+// ABOUTME: Per-session debouncer for signal/secret recomputation on
+// ABOUTME: the incremental write path (leading-edge run + quiet flush).
+package sync
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+// Debounce parameters for signal recomputation triggered by
+// incremental writes. Recomputing signals costs O(session history)
+// (full message reload plus regex secret scan), so during streaming
+// bursts a session recomputes at most once per
+// signalRecomputeInterval, with a trailing flush once the session
+// has been quiet for signalRecomputeQuiet.
+const (
+	signalRecomputeInterval = 10 * time.Second
+	signalRecomputeQuiet    = 2 * time.Second
+)
+
+// signalScheduler coalesces per-session recompute requests. The
+// first request for a quiet session runs inline immediately
+// (leading edge), further requests within the interval are
+// deferred, and a one-shot timer flushes deferred sessions once
+// they go quiet or their interval elapses. No timer is armed while
+// nothing is dirty, so an idle scheduler costs nothing.
+type signalScheduler struct {
+	interval time.Duration
+	quiet    time.Duration
+	run      func(sessionID string)
+
+	// now and afterFunc are injectable for deterministic tests.
+	now       func() time.Time
+	afterFunc func(d time.Duration, f func())
+
+	mu         sync.Mutex
+	last       map[string]time.Time // sessionID -> last recompute
+	dirty      map[string]time.Time // sessionID -> last deferred mark
+	timerArmed bool
+	stopped    bool
+}
+
+func newSignalScheduler(
+	interval, quiet time.Duration, run func(sessionID string),
+) *signalScheduler {
+	return &signalScheduler{
+		interval:  interval,
+		quiet:     quiet,
+		run:       run,
+		now:       time.Now,
+		afterFunc: func(d time.Duration, f func()) { time.AfterFunc(d, f) },
+		last:      make(map[string]time.Time),
+		dirty:     make(map[string]time.Time),
+	}
+}
+
+// markDirty requests a signal recompute for the session. It runs
+// inline when the session hasn't recomputed within the interval
+// (or the scheduler is stopped); otherwise it defers the recompute
+// and arms the flush timer.
+func (s *signalScheduler) markDirty(sessionID string) {
+	s.mu.Lock()
+	now := s.now()
+	if s.stopped || now.Sub(s.last[sessionID]) >= s.interval {
+		s.last[sessionID] = now
+		delete(s.dirty, sessionID)
+		s.mu.Unlock()
+		s.run(sessionID)
+		return
+	}
+	s.dirty[sessionID] = now
+	s.armLocked()
+	s.mu.Unlock()
+}
+
+// tick flushes deferred sessions whose interval has elapsed or
+// that have been quiet long enough.
+func (s *signalScheduler) tick() {
+	s.runAll(s.takeDue(false))
+}
+
+// flushAll immediately recomputes every deferred session.
+func (s *signalScheduler) flushAll() {
+	s.runAll(s.takeDue(true))
+}
+
+// stop flushes pending recomputes and puts the scheduler in
+// pass-through mode: later marks recompute inline and no timers
+// are armed. Used at engine shutdown; safe to call repeatedly.
+func (s *signalScheduler) stop() {
+	s.mu.Lock()
+	s.stopped = true
+	s.mu.Unlock()
+	s.flushAll()
+}
+
+func (s *signalScheduler) runAll(sessionIDs []string) {
+	for _, id := range sessionIDs {
+		s.run(id)
+	}
+}
+
+// takeDue removes and returns the sessions ready to recompute,
+// stamping their recompute time. With all set, every dirty session
+// is due.
+func (s *signalScheduler) takeDue(all bool) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	var due []string
+	for id, markedAt := range s.dirty {
+		if all ||
+			now.Sub(s.last[id]) >= s.interval ||
+			now.Sub(markedAt) >= s.quiet {
+			due = append(due, id)
+			s.last[id] = now
+			delete(s.dirty, id)
+		}
+	}
+	// Drop stale recompute stamps so the map doesn't accumulate an
+	// entry for every session ever synced.
+	for id, at := range s.last {
+		if _, pending := s.dirty[id]; !pending &&
+			now.Sub(at) >= 10*s.interval {
+			delete(s.last, id)
+		}
+	}
+	slices.Sort(due)
+	return due
+}
+
+// armLocked schedules the one-shot flush timer if it isn't already
+// pending. Caller must hold s.mu.
+func (s *signalScheduler) armLocked() {
+	if s.timerArmed || s.stopped {
+		return
+	}
+	s.timerArmed = true
+	s.afterFunc(s.quiet, s.onTimer)
+}
+
+// onTimer is the flush-timer callback: flush what is due, then
+// re-arm while sessions remain dirty.
+func (s *signalScheduler) onTimer() {
+	s.mu.Lock()
+	s.timerArmed = false
+	s.mu.Unlock()
+
+	s.tick()
+
+	s.mu.Lock()
+	if len(s.dirty) > 0 {
+		s.armLocked()
+	}
+	s.mu.Unlock()
+}

--- a/internal/sync/signal_schedule.go
+++ b/internal/sync/signal_schedule.go
@@ -36,14 +36,22 @@ type signalScheduler struct {
 	deferredRun func(sessionID string)
 
 	// now and afterFunc are injectable for deterministic tests.
+	// afterFunc returns a cancel function reporting whether the
+	// callback was stopped before it started running.
 	now       func() time.Time
-	afterFunc func(d time.Duration, f func())
+	afterFunc func(d time.Duration, f func()) (cancel func() bool)
 
-	mu         sync.Mutex
-	last       map[string]time.Time // sessionID -> last recompute
-	dirty      map[string]time.Time // sessionID -> last deferred mark
-	timerArmed bool
-	stopped    bool
+	// inflight counts armed flush timers whose callbacks have not
+	// finished, so stop can wait for a recompute already running
+	// on the timer goroutine before its owner closes the DB.
+	inflight sync.WaitGroup
+
+	mu          sync.Mutex
+	last        map[string]time.Time // sessionID -> last recompute
+	dirty       map[string]time.Time // sessionID -> last deferred mark
+	timerArmed  bool
+	timerCancel func() bool
+	stopped     bool
 }
 
 func newSignalScheduler(
@@ -56,9 +64,11 @@ func newSignalScheduler(
 		run:         run,
 		deferredRun: deferredRun,
 		now:         time.Now,
-		afterFunc:   func(d time.Duration, f func()) { time.AfterFunc(d, f) },
-		last:        make(map[string]time.Time),
-		dirty:       make(map[string]time.Time),
+		afterFunc: func(d time.Duration, f func()) func() bool {
+			return time.AfterFunc(d, f).Stop
+		},
+		last:  make(map[string]time.Time),
+		dirty: make(map[string]time.Time),
 	}
 }
 
@@ -92,13 +102,27 @@ func (s *signalScheduler) flushAll() {
 	s.runAll(s.takeDue(true))
 }
 
-// stop flushes pending recomputes and puts the scheduler in
-// pass-through mode: later marks recompute inline and no timers
-// are armed. Used at engine shutdown; safe to call repeatedly.
+// stop cancels the pending flush timer, waits for any timer
+// callback already running (so no recompute is still using the DB
+// when stop returns), flushes remaining deferred recomputes, and
+// puts the scheduler in pass-through mode: later marks recompute
+// inline and no timers are armed. Used at engine shutdown; safe to
+// call repeatedly.
 func (s *signalScheduler) stop() {
 	s.mu.Lock()
 	s.stopped = true
+	cancel := s.timerCancel
+	armed := s.timerArmed
+	s.timerArmed = false
+	s.timerCancel = nil
 	s.mu.Unlock()
+	// A successful cancel means the callback will never run, so its
+	// inflight slot is released here; otherwise the callback is
+	// already running (or about to) and releases it itself.
+	if armed && cancel != nil && cancel() {
+		s.inflight.Done()
+	}
+	s.inflight.Wait()
 	s.flushAll()
 }
 
@@ -144,14 +168,19 @@ func (s *signalScheduler) armLocked() {
 		return
 	}
 	s.timerArmed = true
-	s.afterFunc(s.quiet, s.onTimer)
+	s.inflight.Add(1)
+	s.timerCancel = s.afterFunc(s.quiet, s.onTimer)
 }
 
 // onTimer is the flush-timer callback: flush what is due, then
-// re-arm while sessions remain dirty.
+// re-arm while sessions remain dirty. The deferred Done runs after
+// any re-arm's Add, so the inflight count never dips to zero while
+// a follow-up timer is pending.
 func (s *signalScheduler) onTimer() {
+	defer s.inflight.Done()
 	s.mu.Lock()
 	s.timerArmed = false
+	s.timerCancel = nil
 	s.mu.Unlock()
 
 	s.tick()

--- a/internal/sync/signal_schedule_test.go
+++ b/internal/sync/signal_schedule_test.go
@@ -10,13 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type harnessTimer struct {
+	f        func()
+	fired    bool
+	canceled bool
+}
+
 type schedulerHarness struct {
 	mu       sync.Mutex
 	sched    *signalScheduler
 	clock    time.Time
 	runs     []string
 	deferred []string
-	armed    []func()
+	armed    []*harnessTimer
 }
 
 func newSchedulerHarness(interval, quiet time.Duration) *schedulerHarness {
@@ -38,10 +44,20 @@ func newSchedulerHarness(interval, quiet time.Duration) *schedulerHarness {
 		defer h.mu.Unlock()
 		return h.clock
 	}
-	h.sched.afterFunc = func(_ time.Duration, f func()) {
+	h.sched.afterFunc = func(_ time.Duration, f func()) func() bool {
 		h.mu.Lock()
-		h.armed = append(h.armed, f)
+		ht := &harnessTimer{f: f}
+		h.armed = append(h.armed, ht)
 		h.mu.Unlock()
+		return func() bool {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			if ht.fired || ht.canceled {
+				return false
+			}
+			ht.canceled = true
+			return true
+		}
 	}
 	return h
 }
@@ -64,22 +80,36 @@ func (h *schedulerHarness) deferredSnapshot() []string {
 	return append([]string(nil), h.deferred...)
 }
 
+// armedCount returns the number of pending (not fired, not
+// canceled) timers.
 func (h *schedulerHarness) armedCount() int {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return len(h.armed)
+	n := 0
+	for _, ht := range h.armed {
+		if !ht.fired && !ht.canceled {
+			n++
+		}
+	}
+	return n
 }
 
-// fireTimer invokes the oldest armed timer callback, simulating
+// fireTimer invokes the oldest pending timer callback, simulating
 // its expiry regardless of the fake clock.
 func (h *schedulerHarness) fireTimer(t *testing.T) {
 	t.Helper()
 	h.mu.Lock()
-	require.NotEmpty(t, h.armed, "no timer armed")
-	f := h.armed[0]
-	h.armed = h.armed[1:]
+	var pending *harnessTimer
+	for _, ht := range h.armed {
+		if !ht.fired && !ht.canceled {
+			pending = ht
+			break
+		}
+	}
+	require.NotNil(t, pending, "no timer armed")
+	pending.fired = true
 	h.mu.Unlock()
-	f()
+	pending.f()
 }
 
 func TestSignalSchedulerFirstMarkRunsInline(t *testing.T) {
@@ -210,25 +240,80 @@ func TestSignalSchedulerStopFlushesAndRunsInlineAfter(t *testing.T) {
 	h.sched.markDirty("s1")
 	require.Len(t, h.runsSnapshot(), 1)
 
-	armedBefore := h.armedCount()
+	require.Equal(t, 1, h.armedCount(),
+		"deferral should have armed the flush timer")
 	h.sched.stop()
 	assert.Len(t, h.runsSnapshot(), 2,
 		"stop should flush pending recomputes")
+	assert.Zero(t, h.armedCount(),
+		"stop should cancel the pending flush timer")
 
 	h.sched.markDirty("s1")
 	assert.Len(t, h.runsSnapshot(), 3,
 		"marks after stop should recompute inline")
-	assert.Equal(t, armedBefore, h.armedCount(),
+	assert.Zero(t, h.armedCount(),
 		"stopped scheduler must not arm new timers")
 
-	// A timer armed before stop must fire as a no-op.
-	h.fireTimer(t)
-	assert.Len(t, h.runsSnapshot(), 3,
-		"stale timer firing after stop should do nothing")
-	assert.Zero(t, h.armedCount(),
-		"stale timer must not re-arm after stop")
-
 	h.sched.stop() // double-stop must not panic
+}
+
+// TestSignalSchedulerStopWaitsForInflightTimerRun guards the
+// shutdown ordering Engine.Close relies on: a recompute already
+// running on the timer goroutine must finish before stop returns,
+// or the owner could close the DB underneath it.
+func TestSignalSchedulerStopWaitsForInflightTimerRun(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var mu sync.Mutex
+	clock := time.Unix(1_700_000_000, 0)
+	sched := newSignalScheduler(10*time.Second, 2*time.Second,
+		func(string) {},
+		func(string) {
+			close(started)
+			<-release
+		},
+	)
+	sched.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return clock
+	}
+	var timerCB func()
+	sched.afterFunc = func(_ time.Duration, f func()) func() bool {
+		timerCB = f
+		return func() bool { return false }
+	}
+
+	sched.markDirty("s1") // leading edge, inline
+	sched.markDirty("s1") // defers and arms the timer
+	require.NotNil(t, timerCB, "deferral should arm the flush timer")
+
+	// The timer fires after the quiet delay and the deferred run
+	// blocks, simulating a recompute in the middle of DB work.
+	mu.Lock()
+	clock = clock.Add(3 * time.Second)
+	mu.Unlock()
+	go timerCB()
+	<-started
+
+	stopDone := make(chan struct{})
+	go func() {
+		sched.stop()
+		close(stopDone)
+	}()
+	stopped := func() bool {
+		select {
+		case <-stopDone:
+			return true
+		default:
+			return false
+		}
+	}
+	assert.Never(t, stopped, 100*time.Millisecond, 10*time.Millisecond,
+		"stop must wait for the in-flight timer recompute")
+	close(release)
+	require.Eventually(t, stopped, 2*time.Second, 5*time.Millisecond,
+		"stop must return once the in-flight recompute finishes")
 }
 
 // TestSignalSchedulerRoutesDeferredRunsSeparately pins which runs go

--- a/internal/sync/signal_schedule_test.go
+++ b/internal/sync/signal_schedule_test.go
@@ -1,0 +1,277 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type schedulerHarness struct {
+	mu    sync.Mutex
+	sched *signalScheduler
+	clock time.Time
+	runs  []string
+	armed []func()
+}
+
+func newSchedulerHarness(interval, quiet time.Duration) *schedulerHarness {
+	h := &schedulerHarness{clock: time.Unix(1_700_000_000, 0)}
+	h.sched = newSignalScheduler(interval, quiet, func(id string) {
+		h.mu.Lock()
+		h.runs = append(h.runs, id)
+		h.mu.Unlock()
+	})
+	h.sched.now = func() time.Time {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		return h.clock
+	}
+	h.sched.afterFunc = func(_ time.Duration, f func()) {
+		h.mu.Lock()
+		h.armed = append(h.armed, f)
+		h.mu.Unlock()
+	}
+	return h
+}
+
+func (h *schedulerHarness) advance(d time.Duration) {
+	h.mu.Lock()
+	h.clock = h.clock.Add(d)
+	h.mu.Unlock()
+}
+
+func (h *schedulerHarness) runsSnapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.runs...)
+}
+
+func (h *schedulerHarness) armedCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.armed)
+}
+
+// fireTimer invokes the oldest armed timer callback, simulating
+// its expiry regardless of the fake clock.
+func (h *schedulerHarness) fireTimer(t *testing.T) {
+	t.Helper()
+	h.mu.Lock()
+	require.NotEmpty(t, h.armed, "no timer armed")
+	f := h.armed[0]
+	h.armed = h.armed[1:]
+	h.mu.Unlock()
+	f()
+}
+
+func TestSignalSchedulerFirstMarkRunsInline(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	h.sched.markDirty("s1")
+
+	assert.Equal(t, []string{"s1"}, h.runsSnapshot(),
+		"first mark after quiet should recompute immediately")
+	assert.Zero(t, h.armedCount(),
+		"inline run should not arm a flush timer")
+}
+
+func TestSignalSchedulerDefersWithinIntervalThenQuietFlush(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	h.sched.markDirty("s1")
+	require.Len(t, h.runsSnapshot(), 1)
+
+	h.advance(1 * time.Second)
+	h.sched.markDirty("s1")
+	h.sched.tick()
+	assert.Len(t, h.runsSnapshot(), 1,
+		"mark within interval should defer, not recompute")
+
+	h.advance(1 * time.Second)
+	h.sched.tick()
+	assert.Len(t, h.runsSnapshot(), 1,
+		"tick before quiet delay elapses should not flush")
+
+	h.advance(1 * time.Second)
+	h.sched.tick()
+	assert.Equal(t, []string{"s1", "s1"}, h.runsSnapshot(),
+		"tick after quiet delay should flush the deferred recompute")
+
+	h.sched.tick()
+	assert.Len(t, h.runsSnapshot(), 2,
+		"flushed session should not run again")
+}
+
+func TestSignalSchedulerContinuousMarksHonorInterval(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	// Simulate a streaming session touching the scheduler every
+	// 500ms for 12 seconds, ticking once per second.
+	h.sched.markDirty("s1")
+	for i := range 24 {
+		h.advance(500 * time.Millisecond)
+		h.sched.markDirty("s1")
+		if i%2 == 1 {
+			h.sched.tick()
+		}
+	}
+	assert.Len(t, h.runsSnapshot(), 2,
+		"continuous writes should recompute once per interval")
+
+	h.advance(2 * time.Second)
+	h.sched.tick()
+	assert.Len(t, h.runsSnapshot(), 3,
+		"trailing flush should run after writes go quiet")
+}
+
+func TestSignalSchedulerSessionsIndependent(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	h.sched.markDirty("a")
+	h.sched.markDirty("b")
+
+	assert.Equal(t, []string{"a", "b"}, h.runsSnapshot(),
+		"distinct sessions should not throttle each other")
+}
+
+func TestSignalSchedulerFlushAllRunsEverythingPending(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	h.sched.markDirty("a")
+	h.sched.markDirty("b")
+	h.advance(1 * time.Second)
+	h.sched.markDirty("a")
+	h.sched.markDirty("b")
+	require.Len(t, h.runsSnapshot(), 2, "second marks should defer")
+
+	h.sched.flushAll()
+	assert.ElementsMatch(t, []string{"a", "b", "a", "b"}, h.runsSnapshot(),
+		"flushAll should recompute every pending session")
+
+	h.advance(10 * time.Second)
+	h.sched.tick()
+	assert.Len(t, h.runsSnapshot(), 4,
+		"nothing should remain pending after flushAll")
+}
+
+func TestSignalSchedulerTimerArmsOncePerBurstAndRearms(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	h.sched.markDirty("s1")
+	require.Zero(t, h.armedCount())
+
+	h.advance(1 * time.Second)
+	h.sched.markDirty("s1")
+	require.Equal(t, 1, h.armedCount(),
+		"first deferral should arm the flush timer")
+	h.sched.markDirty("s1")
+	require.Equal(t, 1, h.armedCount(),
+		"further deferrals must not stack timers")
+
+	// Timer fires before the quiet delay has elapsed: nothing
+	// flushes, but the timer must re-arm to cover the still-dirty
+	// session.
+	h.fireTimer(t)
+	assert.Len(t, h.runsSnapshot(), 1)
+	require.Equal(t, 1, h.armedCount(),
+		"early fire with dirty sessions should re-arm")
+
+	h.advance(2 * time.Second)
+	h.fireTimer(t)
+	assert.Len(t, h.runsSnapshot(), 2,
+		"fire after quiet delay should flush")
+	assert.Zero(t, h.armedCount(),
+		"no dirty sessions left, timer should stay disarmed")
+}
+
+func TestSignalSchedulerStopFlushesAndRunsInlineAfter(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	h.sched.markDirty("s1")
+	h.advance(1 * time.Second)
+	h.sched.markDirty("s1")
+	require.Len(t, h.runsSnapshot(), 1)
+
+	armedBefore := h.armedCount()
+	h.sched.stop()
+	assert.Len(t, h.runsSnapshot(), 2,
+		"stop should flush pending recomputes")
+
+	h.sched.markDirty("s1")
+	assert.Len(t, h.runsSnapshot(), 3,
+		"marks after stop should recompute inline")
+	assert.Equal(t, armedBefore, h.armedCount(),
+		"stopped scheduler must not arm new timers")
+
+	// A timer armed before stop must fire as a no-op.
+	h.fireTimer(t)
+	assert.Len(t, h.runsSnapshot(), 3,
+		"stale timer firing after stop should do nothing")
+	assert.Zero(t, h.armedCount(),
+		"stale timer must not re-arm after stop")
+
+	h.sched.stop() // double-stop must not panic
+}
+
+// secretLeakCount reads the session's persisted secret_leak_count
+// signal, the observable for whether a recompute has run.
+func secretLeakCount(t *testing.T, fx *engineFixture, sessionID string) int {
+	t.Helper()
+	sess, err := fx.db.GetSessionFull(context.Background(), sessionID)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, sess, "session %s not found", sessionID)
+	return sess.SecretLeakCount
+}
+
+func TestWriteIncrementalDebouncesSignalRecompute(t *testing.T) {
+	fx := newEngineFixture(t)
+	path := fx.writeClaudeSession(t, "proj", "sig-debounce.jsonl", "hello")
+	fx.engine.SyncAll(context.Background(), nil)
+	sid := fx.sessionIDFor(t, path)
+	require.Zero(t, secretLeakCount(t, fx, sid))
+
+	// First incremental append is the session's first mark, so the
+	// leading edge recomputes inline and the new secret is counted
+	// immediately.
+	fx.appendClaudeMessage(t, path, "key AKIA7QHWN2DKR4FYPLJM leaked")
+	fx.engine.SyncPaths([]string{path})
+	require.Equal(t, 1, secretLeakCount(t, fx, sid),
+		"first incremental write should recompute signals inline")
+
+	// A second append inside the debounce interval must defer the
+	// recompute: the stored signal stays stale until a flush.
+	fx.appendClaudeMessage(t, path, "key AKIA9XKQV3ZTN8WMB2RC leaked")
+	fx.engine.SyncPaths([]string{path})
+	assert.Equal(t, 1, secretLeakCount(t, fx, sid),
+		"second write within interval should defer the recompute")
+
+	fx.engine.signalSched.flushAll()
+	assert.Equal(t, 2, secretLeakCount(t, fx, sid),
+		"flush should persist the deferred recompute")
+}
+
+func TestSignalSchedulerRealTimerFlushes(t *testing.T) {
+	var mu sync.Mutex
+	var runs int
+	sched := newSignalScheduler(
+		50*time.Millisecond, 10*time.Millisecond,
+		func(string) {
+			mu.Lock()
+			runs++
+			mu.Unlock()
+		},
+	)
+
+	sched.markDirty("s1")
+	sched.markDirty("s1")
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return runs == 2
+	}, 2*time.Second, 5*time.Millisecond,
+		"deferred recompute should flush via the real timer")
+}

--- a/internal/sync/signal_schedule_test.go
+++ b/internal/sync/signal_schedule_test.go
@@ -316,6 +316,30 @@ func TestSignalSchedulerStopWaitsForInflightTimerRun(t *testing.T) {
 		"stop must return once the in-flight recompute finishes")
 }
 
+// TestSignalSchedulerFlushAllInlineUsesInlinePath covers the flush
+// variant for callers already holding the engine's sync lock: it
+// must recompute pending sessions via the inline callback, never
+// the deferred (lock-taking) one, and leave the scheduler running.
+func TestSignalSchedulerFlushAllInlineUsesInlinePath(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	h.sched.markDirty("s1")
+	h.advance(1 * time.Second)
+	h.sched.markDirty("s1")
+	require.Len(t, h.runsSnapshot(), 1, "second mark should defer")
+
+	h.sched.flushAllInline()
+	assert.Equal(t, []string{"s1", "s1"}, h.runsSnapshot(),
+		"inline flush should recompute every pending session")
+	assert.Empty(t, h.deferredSnapshot(),
+		"inline flush must not use the deferred path")
+
+	h.advance(1 * time.Second)
+	h.sched.markDirty("s1")
+	assert.Len(t, h.runsSnapshot(), 2,
+		"scheduler must keep debouncing after an inline flush")
+}
+
 // TestSignalSchedulerRoutesDeferredRunsSeparately pins which runs go
 // through the deferred path (timer ticks, flushes) versus the inline
 // path (leading edge, stopped pass-through). The engine wraps only
@@ -416,9 +440,48 @@ func TestWriteIncrementalDebouncesSignalRecompute(t *testing.T) {
 	assert.Equal(t, 1, secretLeakCount(t, fx, sid),
 		"second write within interval should defer the recompute")
 
-	fx.engine.signalSched.flushAll()
+	fx.engine.FlushSignals()
 	assert.Equal(t, 2, secretLeakCount(t, fx, sid),
 		"flush should persist the deferred recompute")
+
+	// FlushSignals must leave the scheduler running: another write
+	// inside the interval defers again instead of running inline.
+	fx.appendClaudeMessage(t, path, "key AKIA2PLVWX6QR8ZKN4TJ leaked")
+	fx.engine.SyncPaths([]string{path})
+	assert.Equal(t, 2, secretLeakCount(t, fx, sid),
+		"scheduler must keep debouncing after FlushSignals")
+	fx.engine.FlushSignals()
+	assert.Equal(t, 3, secretLeakCount(t, fx, sid),
+		"third secret must flush, proving the deferral was real")
+}
+
+// TestSyncThenRunFlushesSignalsBeforeWork mirrors the PG/DuckDB push
+// endpoints: work scans SQLite rows while syncMu is held, so any
+// deferred signal recompute must be flushed before work runs or the
+// push carries stale fields such as secret_leak_count.
+func TestSyncThenRunFlushesSignalsBeforeWork(t *testing.T) {
+	fx := newEngineFixture(t)
+	path := fx.writeClaudeSession(t, "proj", "sig-flush.jsonl", "hello")
+	fx.engine.SyncAll(context.Background(), nil)
+	sid := fx.sessionIDFor(t, path)
+
+	fx.appendClaudeMessage(t, path, "key AKIA7QHWN2DKR4FYPLJM leaked")
+	fx.engine.SyncPaths([]string{path})
+	require.Equal(t, 1, secretLeakCount(t, fx, sid))
+	fx.appendClaudeMessage(t, path, "key AKIA9XKQV3ZTN8WMB2RC leaked")
+	fx.engine.SyncPaths([]string{path})
+	require.Equal(t, 1, secretLeakCount(t, fx, sid),
+		"second write within interval should defer the recompute")
+
+	var seen int
+	_, err := fx.engine.SyncThenRun(context.Background(), false, nil,
+		func(bool) error {
+			seen = secretLeakCount(t, fx, sid)
+			return nil
+		})
+	require.NoError(t, err)
+	assert.Equal(t, 2, seen,
+		"work must observe flushed signal fields before pushing")
 }
 
 func TestSignalSchedulerRealTimerFlushes(t *testing.T) {

--- a/internal/sync/signal_schedule_test.go
+++ b/internal/sync/signal_schedule_test.go
@@ -11,20 +11,28 @@ import (
 )
 
 type schedulerHarness struct {
-	mu    sync.Mutex
-	sched *signalScheduler
-	clock time.Time
-	runs  []string
-	armed []func()
+	mu       sync.Mutex
+	sched    *signalScheduler
+	clock    time.Time
+	runs     []string
+	deferred []string
+	armed    []func()
 }
 
 func newSchedulerHarness(interval, quiet time.Duration) *schedulerHarness {
 	h := &schedulerHarness{clock: time.Unix(1_700_000_000, 0)}
-	h.sched = newSignalScheduler(interval, quiet, func(id string) {
+	record := func(id string) {
 		h.mu.Lock()
 		h.runs = append(h.runs, id)
 		h.mu.Unlock()
-	})
+	}
+	h.sched = newSignalScheduler(interval, quiet, record,
+		func(id string) {
+			h.mu.Lock()
+			h.deferred = append(h.deferred, id)
+			h.mu.Unlock()
+			record(id)
+		})
 	h.sched.now = func() time.Time {
 		h.mu.Lock()
 		defer h.mu.Unlock()
@@ -48,6 +56,12 @@ func (h *schedulerHarness) runsSnapshot() []string {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return append([]string(nil), h.runs...)
+}
+
+func (h *schedulerHarness) deferredSnapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.deferred...)
 }
 
 func (h *schedulerHarness) armedCount() int {
@@ -217,6 +231,74 @@ func TestSignalSchedulerStopFlushesAndRunsInlineAfter(t *testing.T) {
 	h.sched.stop() // double-stop must not panic
 }
 
+// TestSignalSchedulerRoutesDeferredRunsSeparately pins which runs go
+// through the deferred path (timer ticks, flushes) versus the inline
+// path (leading edge, stopped pass-through). The engine wraps only
+// deferred runs in the sync lock, so misrouting either way would
+// mean recomputes racing sync writes or a self-deadlock.
+func TestSignalSchedulerRoutesDeferredRunsSeparately(t *testing.T) {
+	h := newSchedulerHarness(10*time.Second, 2*time.Second)
+
+	h.sched.markDirty("s1")
+	assert.Empty(t, h.deferredSnapshot(),
+		"leading-edge run must use the inline path")
+
+	h.advance(1 * time.Second)
+	h.sched.markDirty("s1")
+	h.advance(2 * time.Second)
+	h.sched.tick()
+	assert.Equal(t, []string{"s1"}, h.deferredSnapshot(),
+		"tick flushes must use the deferred path")
+
+	h.advance(1 * time.Second)
+	h.sched.markDirty("s1")
+	h.sched.flushAll()
+	assert.Equal(t, []string{"s1", "s1"}, h.deferredSnapshot(),
+		"flushAll must use the deferred path")
+
+	h.sched.stop()
+	h.sched.markDirty("s1")
+	assert.Equal(t, []string{"s1", "s1"}, h.deferredSnapshot(),
+		"stopped pass-through marks must stay inline")
+	assert.Len(t, h.runsSnapshot(), 4,
+		"every mark and flush must still recompute exactly once")
+}
+
+// TestDeferredSignalRecomputeSerializesWithSync verifies the engine
+// wires deferred recomputes through syncMu: a flush racing an
+// in-flight sync must wait for it, so a delayed recompute can never
+// read an older message snapshot and then overwrite signals written
+// by that sync.
+func TestDeferredSignalRecomputeSerializesWithSync(t *testing.T) {
+	fx := newEngineFixture(t)
+	e := fx.engine
+
+	// First mark runs inline; the second defers so the flush below
+	// has pending work.
+	e.signalSched.markDirty("sess-lock")
+	e.signalSched.markDirty("sess-lock")
+
+	e.syncMu.Lock()
+	done := make(chan struct{})
+	go func() {
+		e.signalSched.flushAll()
+		close(done)
+	}()
+	flushed := func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}
+	assert.Never(t, flushed, 100*time.Millisecond, 10*time.Millisecond,
+		"deferred recompute must wait for the in-flight sync operation")
+	e.syncMu.Unlock()
+	require.Eventually(t, flushed, 2*time.Second, 5*time.Millisecond,
+		"deferred recompute must run once the sync lock is released")
+}
+
 // secretLeakCount reads the session's persisted secret_leak_count
 // signal, the observable for whether a recompute has run.
 func secretLeakCount(t *testing.T, fx *engineFixture, sessionID string) int {
@@ -257,13 +339,13 @@ func TestWriteIncrementalDebouncesSignalRecompute(t *testing.T) {
 func TestSignalSchedulerRealTimerFlushes(t *testing.T) {
 	var mu sync.Mutex
 	var runs int
+	run := func(string) {
+		mu.Lock()
+		runs++
+		mu.Unlock()
+	}
 	sched := newSignalScheduler(
-		50*time.Millisecond, 10*time.Millisecond,
-		func(string) {
-			mu.Lock()
-			runs++
-			mu.Unlock()
-		},
+		50*time.Millisecond, 10*time.Millisecond, run, run,
 	)
 
 	sched.markDirty("s1")

--- a/internal/sync/signal_schedule_test.go
+++ b/internal/sync/signal_schedule_test.go
@@ -17,12 +17,13 @@ type harnessTimer struct {
 }
 
 type schedulerHarness struct {
-	mu       sync.Mutex
-	sched    *signalScheduler
-	clock    time.Time
-	runs     []string
-	deferred []string
-	armed    []*harnessTimer
+	mu          sync.Mutex
+	sched       *signalScheduler
+	clock       time.Time
+	runs        []string
+	deferred    []string // runs that happened inside exclusive
+	inExclusive bool
+	armed       []*harnessTimer
 }
 
 func newSchedulerHarness(interval, quiet time.Duration) *schedulerHarness {
@@ -30,14 +31,20 @@ func newSchedulerHarness(interval, quiet time.Duration) *schedulerHarness {
 	record := func(id string) {
 		h.mu.Lock()
 		h.runs = append(h.runs, id)
+		if h.inExclusive {
+			h.deferred = append(h.deferred, id)
+		}
 		h.mu.Unlock()
 	}
 	h.sched = newSignalScheduler(interval, quiet, record,
-		func(id string) {
+		func(flush func()) {
 			h.mu.Lock()
-			h.deferred = append(h.deferred, id)
+			h.inExclusive = true
 			h.mu.Unlock()
-			record(id)
+			flush()
+			h.mu.Lock()
+			h.inExclusive = false
+			h.mu.Unlock()
 		})
 	h.sched.now = func() time.Time {
 		h.mu.Lock()
@@ -264,13 +271,15 @@ func TestSignalSchedulerStopFlushesAndRunsInlineAfter(t *testing.T) {
 func TestSignalSchedulerStopWaitsForInflightTimerRun(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
+	var startedOnce sync.Once
 	var mu sync.Mutex
 	clock := time.Unix(1_700_000_000, 0)
 	sched := newSignalScheduler(10*time.Second, 2*time.Second,
 		func(string) {},
-		func(string) {
-			close(started)
+		func(flush func()) {
+			startedOnce.Do(func() { close(started) })
 			<-release
+			flush()
 		},
 	)
 	sched.now = func() time.Time {
@@ -340,10 +349,10 @@ func TestSignalSchedulerFlushAllInlineUsesInlinePath(t *testing.T) {
 		"scheduler must keep debouncing after an inline flush")
 }
 
-// TestSignalSchedulerRoutesDeferredRunsSeparately pins which runs go
-// through the deferred path (timer ticks, flushes) versus the inline
-// path (leading edge, stopped pass-through). The engine wraps only
-// deferred runs in the sync lock, so misrouting either way would
+// TestSignalSchedulerRoutesDeferredRunsSeparately pins which runs
+// happen inside the exclusive section (timer ticks, flushes) versus
+// directly (leading edge, stopped pass-through). The engine takes
+// the sync lock only in exclusive, so misrouting either way would
 // mean recomputes racing sync writes or a self-deadlock.
 func TestSignalSchedulerRoutesDeferredRunsSeparately(t *testing.T) {
 	h := newSchedulerHarness(10*time.Second, 2*time.Second)
@@ -406,6 +415,70 @@ func TestDeferredSignalRecomputeSerializesWithSync(t *testing.T) {
 	e.syncMu.Unlock()
 	require.Eventually(t, flushed, 2*time.Second, 5*time.Millisecond,
 		"deferred recompute must run once the sync lock is released")
+}
+
+// TestLockedFlushSeesSessionClaimedByBlockedTimer reproduces the
+// claim-then-block race: the flush timer fires while a sync holds
+// syncMu. The timer must not claim sessions out of the dirty map
+// before it can recompute under the lock — otherwise the sync's own
+// pre-push flush (flushAllInline in SyncThenRun) sees no pending
+// work and pushes stale signal fields.
+func TestLockedFlushSeesSessionClaimedByBlockedTimer(t *testing.T) {
+	fx := newEngineFixture(t)
+	e := fx.engine
+
+	// Capture the flush timer instead of arming a real one.
+	var timerCB func()
+	e.signalSched.afterFunc = func(_ time.Duration, f func()) func() bool {
+		timerCB = f
+		return func() bool { return false }
+	}
+
+	path := fx.writeClaudeSession(t, "proj", "sig-race.jsonl", "hello")
+	e.SyncAll(context.Background(), nil)
+	sid := fx.sessionIDFor(t, path)
+
+	fx.appendClaudeMessage(t, path, "key AKIA7QHWN2DKR4FYPLJM leaked")
+	e.SyncPaths([]string{path})
+	require.Equal(t, 1, secretLeakCount(t, fx, sid))
+	fx.appendClaudeMessage(t, path, "key AKIA9XKQV3ZTN8WMB2RC leaked")
+	e.SyncPaths([]string{path})
+	require.Equal(t, 1, secretLeakCount(t, fx, sid),
+		"second write within interval should defer the recompute")
+	require.NotNil(t, timerCB, "deferral should arm the flush timer")
+
+	// The quiet delay has elapsed by the time the timer fires, so
+	// its takeDue pass considers the session due.
+	e.signalSched.now = func() time.Time {
+		return time.Now().Add(3 * time.Second)
+	}
+
+	// A sync is in progress when the timer fires.
+	e.syncMu.Lock()
+	timerDone := make(chan struct{})
+	go func() {
+		timerCB()
+		close(timerDone)
+	}()
+	// Give the timer goroutine time to reach the lock (and, in the
+	// buggy ordering, to claim the session before blocking).
+	time.Sleep(50 * time.Millisecond)
+
+	// The sync now flushes before its push work, as SyncThenRun does.
+	e.signalSched.flushAllInline()
+	seen := secretLeakCount(t, fx, sid)
+	e.syncMu.Unlock()
+
+	assert.Equal(t, 2, seen,
+		"locked flush must recompute sessions the blocked timer would handle")
+	require.Eventually(t, func() bool {
+		select {
+		case <-timerDone:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 5*time.Millisecond, "timer callback must finish")
 }
 
 // secretLeakCount reads the session's persisted secret_leak_count
@@ -493,7 +566,8 @@ func TestSignalSchedulerRealTimerFlushes(t *testing.T) {
 		mu.Unlock()
 	}
 	sched := newSignalScheduler(
-		50*time.Millisecond, 10*time.Millisecond, run, run,
+		50*time.Millisecond, 10*time.Millisecond, run,
+		func(flush func()) { flush() },
 	)
 
 	sched.markDirty("s1")


### PR DESCRIPTION
The serve daemon paid O(session history) on nearly every watcher-triggered
write: ~4,700 session updates per day on an active machine, each rescanning or
rewriting a whole session to absorb a few appended lines. This PR removes the
hot paths; the daemon's steady-state work now scales with new data instead of
archive depth.

**Debounced signal recompute (internal/sync/signal_schedule.go).** The
incremental append path ran recomputeSignalsFromDB synchronously per write: a
full reload of the session's stored messages, the definite-rule secret regex
scan over all of them, and a delete+reinsert of the session's secret findings.
writeIncremental now marks the session on a per-session scheduler instead. The
first write after a quiet period recomputes inline, writes during a streaming
burst coalesce into at most one recompute per 10s, and a one-shot timer
flushes 2s after writes go quiet. No timer is armed while nothing is dirty.
Engine.Close cancels the pending timer, waits for any in-flight timer
recompute, and flushes the rest, so no recompute is still using the DB when
it returns; every engine owner (serve, sync, session sync, usage, remote
import, pg watch, and the server's on-demand engine via Server.Shutdown)
closes the engine before the DB. Push paths flush pending recomputes before
scanning rows — pg watch via Engine.FlushSignals in its sync step, and
SyncThenRun (server PG/DuckDB pushes) via an inline flush under syncMu — so
PostgreSQL never receives stale signal fields. Timer- and
flush-driven recomputes take the engine's sync lock (inline runs already hold
it via writeIncremental), so a delayed recompute can never read an older
message snapshot and then overwrite signals written by a concurrent sync.
Tradeoff:
health/secret signals for an actively-streaming session can lag by up to ~12s;
message content itself still indexes immediately.

**Diff-based message replace (internal/db/messages_diff.go).** Claude
streaming sessions frequently hit the chunk-merge/agent-linkage full-parse
fallbacks, and each one ran ReplaceSessionMessages/ReplaceSessionContent as a
full delete+reinsert — every message row and FTS entry rewritten to merge one
tail chunk, which also kept the WAL hundreds of MB large. Both entry points
now diff incoming messages against stored rows by ordinal and write only
changes: unchanged rows are untouched (keeping rowids, pins, and FTS entries),
the merged tail is updated in place, and new rows are appended. Equality is
defined on the exact persisted tuples by sharing the insert argument builder
and resolve helpers between the insert and diff paths. The diff falls back to
the existing full replace when it cannot preserve row identity: truncations,
duplicate or vanished ordinals, changed rows whose source_uuid differs (pins
are re-matched by uuid on the full path), or rewrites touching more than half
the stored rows. The bulk initial-sync write path is unchanged.

**Root-gated changed-path classification (internal/sync/classify_changed_path.go).**
A live CPU profile of the patched daemon showed the next hot spot:
classifyProviderChangedPath ran ListStoredSourcePathHints for every
provider-authoritative agent's watch roots on every watcher event, and the
LIKE ... ESCAPE hint query cannot use an index, so each event cost ~30 agents'
worth of sessions-table scans. Every SourcesForChangedPath implementation
resolves the changed path within the provider's configured roots or plan watch
roots, and the hint query already scopes stored paths to the watch root, so an
agent whose roots cannot contain the path never claims it. Classification now
skips such agents before their per-root hint queries, cutting the per-event DB
work to the one or two agents whose roots overlap the changed path.

**Hidden serve --pprof flag.** The deployed binary is stripped, so a hot
daemon could not be profiled. serve --pprof registers net/http/pprof under
/debug/pprof; off by default and hidden, mirroring the sync command's
profiling flags. When mounted, the pprof routes are gated by the same bearer
auth and Host-header (DNS-rebinding) checks as /api/ routes; with pprof
disabled the path remains ordinary SPA fallback.

Reviewers should start with planSessionMessageDiff's fallback conditions
(internal/db/messages_diff.go) — they encode every case where in-place updates
would change observable behavior — the scheduler's leading-edge/trailing-
flush semantics in internal/sync/signal_schedule.go, and the root-containment
invariant asserted in the classifyProviderChangedPath gate comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
